### PR TITLE
feat(dsp): WDSPwisdom at startup + UI pulse while building

### DIFF
--- a/Zeus.Contracts/MsgType.cs
+++ b/Zeus.Contracts/MsgType.cs
@@ -20,4 +20,9 @@ public enum MsgType : byte
 
     // Server → client (RX signal strength, dBm)
     RxMeter = 0x14,
+
+    // Server → client (DSP bootstrap state). Broadcast when the WDSPwisdom
+    // FFTW plan cache transitions between idle/building/ready; also pushed
+    // once per client at WS attach so late joiners get the current state.
+    WisdomStatus = 0x15,
 }

--- a/Zeus.Contracts/WisdomStatusFrame.cs
+++ b/Zeus.Contracts/WisdomStatusFrame.cs
@@ -1,0 +1,33 @@
+using System.Buffers;
+
+namespace Zeus.Contracts;
+
+public enum WisdomPhase : byte
+{
+    Idle = 0,
+    Building = 1,
+    Ready = 2,
+}
+
+// [0x15][phase:u8] = 2 bytes. Latest value wins; no seq/timestamp needed.
+public readonly record struct WisdomStatusFrame(WisdomPhase Phase)
+{
+    public const int ByteLength = 1 + 1;
+
+    public void Serialize(IBufferWriter<byte> writer)
+    {
+        var span = writer.GetSpan(ByteLength);
+        span[0] = (byte)MsgType.WisdomStatus;
+        span[1] = (byte)Phase;
+        writer.Advance(ByteLength);
+    }
+
+    public static WisdomStatusFrame Deserialize(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length < ByteLength)
+            throw new InvalidDataException($"WisdomStatusFrame requires {ByteLength} bytes, got {bytes.Length}");
+        if (bytes[0] != (byte)MsgType.WisdomStatus)
+            throw new InvalidDataException($"expected WisdomStatus (0x{(byte)MsgType.WisdomStatus:X2}), got 0x{bytes[0]:X2}");
+        return new WisdomStatusFrame((WisdomPhase)bytes[1]);
+    }
+}

--- a/Zeus.Dsp/Wdsp/NativeMethods.cs
+++ b/Zeus.Dsp/Wdsp/NativeMethods.cs
@@ -544,4 +544,19 @@ internal static partial class NativeMethods
     [LibraryImport(LibraryName)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial double GetTXAMeter(int channel, int mt);
+
+    // FFTW wisdom: builds or loads cached plans from `directory/wdspWisdom00`.
+    // Returns 0 if plans were loaded from file (fast), 1 if newly built and
+    // saved (slow — FFTW_PATIENT runs sizes 64..262144). Must be called once
+    // before the first OpenChannel so FFTW reuses the cached plans instead of
+    // re-planning cold on every launch.
+    [LibraryImport(LibraryName, StringMarshalling = StringMarshalling.Utf8)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial int WDSPwisdom(string directory);
+
+    // Returns a pointer into a static 128-byte buffer written by the last
+    // WDSPwisdom call (e.g. "Wisdom already existed" / "Wisdom created").
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial IntPtr wisdom_get_status();
 }

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -111,6 +111,20 @@ public sealed class WdspDspEngine : IDspEngine
     {
         _log = logger ?? NullLogger<WdspDspEngine>.Instance;
         WdspNativeLoader.EnsureResolverRegistered();
+        InitWisdom();
+    }
+
+    private void InitWisdom()
+    {
+        var dir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "Zeus");
+        Directory.CreateDirectory(dir);
+        _log.LogInformation("wdsp.wisdom initialising dir={Dir}", dir);
+        int result = NativeMethods.WDSPwisdom(dir);
+        var status = Marshal.PtrToStringUTF8(NativeMethods.wisdom_get_status()) ?? string.Empty;
+        _log.LogInformation("wdsp.wisdom ready result={Result} ({Source}) status={Status}",
+            result, result == 0 ? "loaded" : "built", status);
     }
 
     public int OpenChannel(int sampleRateHz, int pixelWidth)

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -111,20 +111,11 @@ public sealed class WdspDspEngine : IDspEngine
     {
         _log = logger ?? NullLogger<WdspDspEngine>.Instance;
         WdspNativeLoader.EnsureResolverRegistered();
-        InitWisdom();
-    }
-
-    private void InitWisdom()
-    {
-        var dir = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "Zeus");
-        Directory.CreateDirectory(dir);
-        _log.LogInformation("wdsp.wisdom initialising dir={Dir}", dir);
-        int result = NativeMethods.WDSPwisdom(dir);
-        var status = Marshal.PtrToStringUTF8(NativeMethods.wisdom_get_status()) ?? string.Empty;
-        _log.LogInformation("wdsp.wisdom ready result={Result} ({Source}) status={Status}",
-            result, result == 0 ? "loaded" : "built", status);
+        // WDSPwisdom is run by WdspWisdomInitializer at app startup before any
+        // connect is allowed, so we trust it has completed by the time the
+        // first OpenChannel lands here. Tests that construct the engine in
+        // isolation can call WdspWisdomInitializer.EnsureInitializedAsync()
+        // themselves, or accept slow first-open planning.
     }
 
     public int OpenChannel(int sampleRateHz, int pixelWidth)

--- a/Zeus.Dsp/Wdsp/WdspWisdomInitializer.cs
+++ b/Zeus.Dsp/Wdsp/WdspWisdomInitializer.cs
@@ -1,0 +1,76 @@
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+
+namespace Zeus.Dsp.Wdsp;
+
+/// <summary>
+/// Owns the one-shot WDSPwisdom FFTW plan-cache initialisation. Singleton —
+/// the WDSP wisdom file at $LOCALAPPDATA/Zeus/wdspWisdom00 is process-global
+/// state, so there's nothing to parallelise.
+/// </summary>
+public sealed class WdspWisdomInitializer
+{
+    private readonly ILogger _log;
+    private readonly object _gate = new();
+    private Task? _task;
+    private int _phase = (int)WisdomPhase.Idle;
+
+    public WdspWisdomInitializer(ILogger<WdspWisdomInitializer>? logger = null)
+    {
+        _log = logger ?? NullLogger<WdspWisdomInitializer>.Instance;
+    }
+
+    public WisdomPhase Phase => (WisdomPhase)Volatile.Read(ref _phase);
+
+    public event Action<WisdomPhase>? PhaseChanged;
+
+    /// <summary>
+    /// Idempotent. First call kicks off the WDSPwisdom P/Invoke on a worker
+    /// thread and returns a Task tracking it. Subsequent calls (including
+    /// re-entrance from WdspDspEngine) return the same Task.
+    /// </summary>
+    public Task EnsureInitializedAsync()
+    {
+        lock (_gate)
+        {
+            if (_task is not null) return _task;
+            SetPhase(WisdomPhase.Building);
+            WdspNativeLoader.EnsureResolverRegistered();
+            _task = Task.Run(RunWisdom);
+            return _task;
+        }
+    }
+
+    private void RunWisdom()
+    {
+        try
+        {
+            var dir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "Zeus");
+            Directory.CreateDirectory(dir);
+            _log.LogInformation("wdsp.wisdom initialising dir={Dir}", dir);
+            int result = NativeMethods.WDSPwisdom(dir);
+            var status = Marshal.PtrToStringUTF8(NativeMethods.wisdom_get_status()) ?? string.Empty;
+            _log.LogInformation(
+                "wdsp.wisdom ready result={Result} ({Source}) status={Status}",
+                result, result == 0 ? "loaded" : "built", status);
+        }
+        catch (Exception ex)
+        {
+            _log.LogError(ex, "wdsp.wisdom failed — subsequent FFT planning will take the slow path");
+        }
+        finally
+        {
+            SetPhase(WisdomPhase.Ready);
+        }
+    }
+
+    private void SetPhase(WisdomPhase next)
+    {
+        var prev = (WisdomPhase)Interlocked.Exchange(ref _phase, (int)next);
+        if (prev != next) PhaseChanged?.Invoke(next);
+    }
+}

--- a/Zeus.Server/Program.cs
+++ b/Zeus.Server/Program.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http.Json;
 using Zeus.Contracts;
 using Zeus.Dsp;
+using Zeus.Dsp.Wdsp;
 using Zeus.Protocol1;
 using Zeus.Protocol1.Discovery;
 using Zeus.Server;
@@ -34,6 +35,11 @@ builder.Services.AddSingleton<Zeus.Protocol1.ITxIqSource>(sp =>
     sp.GetRequiredService<Zeus.Protocol1.TxIqRing>());
 builder.Services.AddSingleton<RadioService>();
 builder.Services.AddSingleton<StreamingHub>();
+// WDSPwisdom bootstrap: run FFTW plan caching on a worker at app start so the
+// first /api/connect isn't blocked for ~2 min while WDSP plans FFTs 64..262144.
+// Clients are told to keep Connect disabled until phase=Ready.
+builder.Services.AddSingleton<WdspWisdomInitializer>();
+builder.Services.AddHostedService<WisdomBootstrapService>();
 builder.Services.AddSingleton<DspPipelineService>();
 builder.Services.AddHostedService(sp => sp.GetRequiredService<DspPipelineService>());
 builder.Services.AddSingleton<TxService>();
@@ -73,6 +79,17 @@ app.UseDefaultFiles();
 app.UseStaticFiles();
 
 var log = app.Services.GetRequiredService<ILogger<Program>>();
+
+// Wire wisdom initializer → hub so every phase change is broadcast to all
+// connected clients. Seed the hub's cached phase with whatever the
+// initializer currently reports (Idle at first boot, Ready on restart once
+// the file is cached).
+{
+    var wisdom = app.Services.GetRequiredService<WdspWisdomInitializer>();
+    var hub = app.Services.GetRequiredService<StreamingHub>();
+    hub.SetWisdomPhase(wisdom.Phase);
+    wisdom.PhaseChanged += phase => hub.Broadcast(new WisdomStatusFrame(phase));
+}
 
 app.MapGet("/api/state", (RadioService r) => r.Snapshot());
 
@@ -121,11 +138,20 @@ app.MapGet("/api/radios", async (IRadioDiscovery discovery, HttpContext ctx) =>
     }
 });
 
-app.MapPost("/api/connect", async (ConnectRequest req, RadioService r, HttpContext ctx) =>
+app.MapPost("/api/connect", async (ConnectRequest req, RadioService r, WdspWisdomInitializer wisdom, HttpContext ctx) =>
 {
     log.LogInformation(
         "api.connect endpoint={Ep} rate={Rate} preamp={Pre} atten={Atten}",
         req.Endpoint, req.SampleRate, req.PreampOn, req.Atten);
+
+    // WDSPwisdom must finish before OpenChannel, otherwise FFTW runs its slow
+    // per-size planner on the pipeline thread and RX packets pile up until
+    // the radio drops. The UI keeps Connect disabled during build; this is
+    // the server-side guard for non-UI callers (curl, older clients).
+    if (wisdom.Phase != WisdomPhase.Ready)
+        return Results.Json(
+            new { error = "DSP is preparing FFTW plans — try again in a moment." },
+            statusCode: StatusCodes.Status503ServiceUnavailable);
 
     if (!TryValidateSampleRate(req.SampleRate, out var rateErr))
         return Results.BadRequest(new { error = rateErr });

--- a/Zeus.Server/StreamingHub.cs
+++ b/Zeus.Server/StreamingHub.cs
@@ -21,10 +21,22 @@ public sealed class StreamingHub
 
     private readonly ILogger<StreamingHub> _log;
     private readonly ConcurrentDictionary<Guid, ClientSession> _clients = new();
+    // Latest WDSP wisdom phase. Set by StreamingHubWisdomBridge on phase-changed
+    // events; read on every AttachClientAsync so late joiners see the current
+    // state without waiting for the next transition. Volatile because the
+    // writer is on a worker thread and readers can be on any hub caller.
+    private volatile byte _wisdomPhase;
 
     public StreamingHub(ILogger<StreamingHub> log) { _log = log; }
 
     public int ClientCount => _clients.Count;
+
+    /// <summary>Updates the hub's cached wisdom phase so clients attaching
+    /// after the one-shot broadcast still receive the current state.</summary>
+    public void SetWisdomPhase(Zeus.Contracts.WisdomPhase phase)
+    {
+        _wisdomPhase = (byte)phase;
+    }
 
     /// <summary>
     /// Raised when a client sends a <c>MicPcm</c> binary frame. The handler
@@ -40,6 +52,11 @@ public sealed class StreamingHub
         var session = new ClientSession(id, ws, _log, this);
         _clients[id] = session;
         _log.LogInformation("ws.client.connected id={Id} total={Count}", id, _clients.Count);
+
+        // Prime the new client with the current wisdom phase. Without this a
+        // client that joins after the ready event would sit at default (Idle)
+        // and render the pulsing Connect button indefinitely.
+        session.TryEnqueue(BuildWisdomPayload((Zeus.Contracts.WisdomPhase)_wisdomPhase));
 
         try
         {
@@ -147,6 +164,22 @@ public sealed class StreamingHub
         {
             ArrayPool<byte>.Shared.Return(rented);
         }
+    }
+
+    public void Broadcast(in WisdomStatusFrame frame)
+    {
+        SetWisdomPhase(frame.Phase);
+        if (_clients.IsEmpty) return;
+        var payload = BuildWisdomPayload(frame.Phase);
+        foreach (var client in _clients.Values) client.TryEnqueue(payload);
+    }
+
+    private static byte[] BuildWisdomPayload(Zeus.Contracts.WisdomPhase phase)
+    {
+        var buf = new byte[WisdomStatusFrame.ByteLength];
+        var writer = new FixedBufferWriter(buf, buf.Length);
+        new WisdomStatusFrame(phase).Serialize(writer);
+        return buf;
     }
 
     public void Broadcast(in AlertFrame frame)

--- a/Zeus.Server/WisdomBootstrapService.cs
+++ b/Zeus.Server/WisdomBootstrapService.cs
@@ -1,0 +1,27 @@
+using Zeus.Dsp.Wdsp;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Kicks off WDSPwisdom on a worker thread at app start so first-connect
+/// isn't blocked for ~2 minutes while FFTW runs FFTW_PATIENT across sizes
+/// 64..262144. Returns from StartAsync immediately — Kestrel must not wait
+/// on wisdom generation.
+/// </summary>
+public sealed class WisdomBootstrapService : IHostedService
+{
+    private readonly WdspWisdomInitializer _initializer;
+
+    public WisdomBootstrapService(WdspWisdomInitializer initializer)
+    {
+        _initializer = initializer;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _ = _initializer.EnsureInitializedAsync();
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/zeus-web/src/components/ConnectPanel.tsx
+++ b/zeus-web/src/components/ConnectPanel.tsx
@@ -45,6 +45,8 @@ export function ConnectPanel() {
   const setLastConnectedEndpoint = useConnectionStore(
     (s) => s.setLastConnectedEndpoint,
   );
+  const wisdomPhase = useConnectionStore((s) => s.wisdomPhase);
+  const dspPreparing = wisdomPhase === 'building';
 
   const [radios, setRadios] = useState<RadioInfoDto[] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -205,8 +207,9 @@ export function ConnectPanel() {
     );
   }
 
-  const statusRight =
-    status === 'Connecting'
+  const statusRight = dspPreparing
+    ? 'Preparing DSP…'
+    : status === 'Connecting'
       ? 'Connecting…'
       : inflight
         ? 'Working…'
@@ -300,11 +303,23 @@ export function ConnectPanel() {
                 <button
                   type="button"
                   onClick={() => handleConnect(r)}
-                  disabled={r.busy || inflight}
-                  title={r.busy ? 'Radio is busy (in use by another client)' : undefined}
-                  className={`btn sm ${r.busy ? '' : 'active'}`}
+                  disabled={r.busy || inflight || dspPreparing}
+                  title={
+                    r.busy
+                      ? 'Radio is busy (in use by another client)'
+                      : dspPreparing
+                        ? 'DSP is preparing FFTW plans (first-run only, up to ~2 min)'
+                        : undefined
+                  }
+                  className={`btn sm ${r.busy ? '' : 'active'} ${dspPreparing ? 'pulsing' : ''}`}
                 >
-                  {r.busy ? 'Busy' : inflight ? 'Connecting…' : 'Connect'}
+                  {r.busy
+                    ? 'Busy'
+                    : dspPreparing
+                      ? 'Preparing DSP…'
+                      : inflight
+                        ? 'Connecting…'
+                        : 'Connect'}
                 </button>
               </li>
             );

--- a/zeus-web/src/realtime/ws-client.ts
+++ b/zeus-web/src/realtime/ws-client.ts
@@ -1,6 +1,7 @@
 import { decodeDisplayFrame, FrameDecodeError, MSG_TYPE_DISPLAY_FRAME } from './frame';
 import { AudioFrameDecodeError, MSG_TYPE_AUDIO_PCM, decodeAudioFrame } from '../audio/frame';
 import { getAudioClient } from '../audio/audio-client';
+import { useConnectionStore, type WisdomPhase } from '../state/connection-store';
 import { useDisplayStore } from '../state/display-store';
 import { useTxStore } from '../state/tx-store';
 import { warnOnce } from '../util/logger';
@@ -24,6 +25,13 @@ const RX_METER_BYTES = 1 + 4;
 // Alert frame: 1 type byte + 1 kind byte + UTF-8 message (variable length).
 // Server emits when SWR > 2.5 sustained ≥500 ms (PRD FR-6). Kind 0 = SWR trip.
 export const MSG_TYPE_ALERT = 0x13;
+
+// WDSP wisdom status: 1 type byte + 1 phase byte (0=idle, 1=building, 2=ready).
+// Pushed once on WS attach and again on every transition. The UI disables the
+// Connect button and pulses while phase=building so the user doesn't try to
+// talk to the radio while FFTW is still planning.
+export const MSG_TYPE_WISDOM_STATUS = 0x15;
+const WISDOM_STATUS_BYTES = 1 + 1;
 
 // Mic uplink (client → server). Payload: 960 × f32le = 3840 bytes preceded by
 // the 1-byte type, total 3841 bytes. 960 samples = 20 ms @ 48 kHz mono.
@@ -157,6 +165,20 @@ export function startRealtime(path = '/ws'): () => void {
           }
           const dbm = new DataView(ev.data).getFloat32(1, true);
           useTxStore.getState().setRxDbm(dbm);
+          return;
+        }
+        if (peekType === MSG_TYPE_WISDOM_STATUS) {
+          if (ev.data.byteLength < WISDOM_STATUS_BYTES) {
+            warnOnce(
+              'ws-wisdom-short',
+              `wisdom frame too short: ${ev.data.byteLength}`,
+            );
+            return;
+          }
+          const raw = new DataView(ev.data).getUint8(1);
+          const phase: WisdomPhase =
+            raw === 1 ? 'building' : raw === 2 ? 'ready' : 'idle';
+          useConnectionStore.getState().setWisdomPhase(phase);
           return;
         }
         if (peekType === MSG_TYPE_ALERT) {

--- a/zeus-web/src/state/connection-store.ts
+++ b/zeus-web/src/state/connection-store.ts
@@ -8,6 +8,13 @@ import {
   type ZoomLevel,
 } from '../api/client';
 
+// WDSP wisdom bootstrap phase, mirroring the server's WisdomPhase enum.
+// 'idle' = initializer hasn't started yet (first ms after boot),
+// 'building' = WDSPwisdom is running (up to ~2 min on a fresh machine),
+// 'ready' = FFTW plans are cached and /api/connect is accepting. The
+// ConnectPanel disables + pulses Connect while !== 'ready'.
+export type WisdomPhase = 'idle' | 'building' | 'ready';
+
 export type ConnectionState = {
   status: ConnectionStatus;
   endpoint: string | null;
@@ -34,6 +41,7 @@ export type ConnectionState = {
   // disconnect so ConnectPanel can float it to the top of the next scan.
   // Intentionally in-memory only — no localStorage yet.
   lastConnectedEndpoint: string | null;
+  wisdomPhase: WisdomPhase;
   applyState: (s: RadioStateDto) => void;
   setInflight: (v: boolean) => void;
   setBoardId: (id: string | null) => void;
@@ -41,6 +49,7 @@ export type ConnectionState = {
   setNr: (nr: NrConfigDto) => void;
   setZoomLevel: (level: ZoomLevel) => void;
   setLastConnectedEndpoint: (ep: string | null) => void;
+  setWisdomPhase: (phase: WisdomPhase) => void;
 };
 
 export const useConnectionStore = create<ConnectionState>((set) => ({
@@ -62,6 +71,9 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
   zoomLevel: 1,
   inflight: false,
   lastConnectedEndpoint: null,
+  // Default to 'ready' so a page-load before the WS attach doesn't show the
+  // pulse spuriously. The server overrides on attach with the real phase.
+  wisdomPhase: 'ready',
   applyState: (s) =>
     set({
       status: s.status,
@@ -86,4 +98,5 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
   setZoomLevel: (zoomLevel) => set({ zoomLevel }),
   setLastConnectedEndpoint: (lastConnectedEndpoint) =>
     set({ lastConnectedEndpoint }),
+  setWisdomPhase: (wisdomPhase) => set({ wisdomPhase }),
 }));

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -99,6 +99,11 @@
   letter-spacing: 0.04em;
 }
 .qrz-btn.active { animation: pulse 1.8s ease-in-out infinite; }
+/* .btn.pulsing — disabled-state attention cue. Used by ConnectPanel while the
+ * backend is running WDSPwisdom so the user sees why the Connect button is
+ * unclickable instead of assuming the UI is stuck. */
+.btn.pulsing { animation: pulse 1.8s ease-in-out infinite; }
+.btn.pulsing:disabled { opacity: 1; cursor: wait; }
 @keyframes pulse {
   0%, 100% { box-shadow: inset 0 1px 0 var(--btn-hl), 0 0 0 0 rgba(255,120,20,0.6); }
   50% { box-shadow: inset 0 1px 0 var(--btn-hl), 0 0 0 6px rgba(255,120,20,0); }


### PR DESCRIPTION
Closes #6.

## Summary

- Builds on 4cd99b1 (which first added the `WDSPwisdom` P/Invoke) by moving the call out of `WdspDspEngine`'s ctor and into an `IHostedService` that fires at server start. The first-ever connect no longer blocks for ~2 min, and the radio no longer drops from RX timeouts while the pipeline thread is busy FFTW-planning.
- A new `WisdomStatusFrame` (`MsgType 0x15`) broadcasts phase transitions (`Idle → Building → Ready`) over the existing WS hub; new clients are primed with the current phase on attach.
- `ConnectPanel` disables the Connect button and applies a reused amber pulse (`.btn.pulsing`) with label **"Preparing DSP…"** while the backend is mid-rebuild. `/api/connect` returns `503` during that window as a safety net for non-UI callers.

## Why the red-flag discussion was waved off

The `docs/lessons/wdsp-init-gotchas.md` lesson is specifically about **channel state** ordering (`OpenChannel(state=0)` → flip to `state=1` after the xmeter worker is live). `WDSPwisdom` is a one-shot FFTW-plan-cache call with no relationship to channel state, audio ring, or the worker thread — running it earlier (startup) vs later (engine ctor) is the same operation at a different clock time. No channel-init code was touched.

## Test plan

- [x] `dotnet test Zeus.slnx` — 446 passed, 6 skipped, 0 failed.
- [x] `npm --prefix zeus-web run test` — 63 passed.
- [x] `npm --prefix zeus-web run typecheck` — clean.
- [x] **First-run rebuild:** deleted `~/Library/Application Support/ZeuswdspWisdom00`, started backend. Log shows `wdsp.wisdom initialising` → WDSP plans sizes 64..262145 (~2 min) → `wdsp.wisdom ready result=1 (built)`. UI pulses throughout, then Connect button becomes available.
- [x] **Cached-run:** subsequent startup logs `result=0 (loaded)` in sub-second; UI skips straight to enabled Connect.
- [x] **Live radio connect + disconnect/reconnect cycle** on HermesLite2 (192.168.100.21): radio stays up, DSP engaged, no more in-and-out drops.

## Notes

- Pre-existing unrelated bug spotted during testing: WDSP's `strncat(wisdom_file, "wdspWisdom00", 16)` has no path separator, so the wisdom file lands at `…/Support/ZeuswdspWisdom00` instead of `…/Support/Zeus/wdspWisdom00`. Functionally harmless (read/write are symmetric) but worth a follow-up to fix the native concat.