### PR TITLE
feat(mobile): forward-port responsive layout + hold-to-talk PTT

### DIFF
--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -7,6 +7,7 @@ import { ConnectPanel } from './components/ConnectPanel';
 import { DriveSlider } from './components/DriveSlider';
 import { MicGainSlider } from './components/MicGainSlider';
 import { MicMeter } from './components/MicMeter';
+import { MobilePttButton } from './components/MobilePttButton';
 import { ModeBandwidth } from './components/ModeBandwidth';
 import { MoxButton } from './components/MoxButton';
 import { Panadapter } from './components/Panadapter';
@@ -340,22 +341,22 @@ export default function App() {
           </div>
           <div className="brand-text">
             <div className="brand-name mono">ZEUS</div>
-            <div className="brand-sub label-xs">HERMES LITE 2 · 0.1–54 MHz</div>
+            <div className="brand-sub label-xs hide-mobile">HERMES LITE 2 · 0.1–54 MHz</div>
           </div>
         </div>
 
-        <div className="topbar-divider" />
+        <div className="topbar-divider hide-mobile" />
 
-        <div className="vfo-group">
+        <div className="vfo-group hide-mobile">
           <div className="vfo-tab active">
             <div className="vfo-label label-xs">VFO A</div>
             <div className="vfo-freq mono">{(vfoHz / 1e6).toFixed(3)}</div>
           </div>
         </div>
 
-        <div className="topbar-divider" />
+        <div className="topbar-divider hide-mobile" />
 
-        <div className="status-chips">
+        <div className="status-chips hide-mobile">
           <div className="chip">
             <span className="k">MODE</span>
             <span className="v">{mode}</span>
@@ -389,12 +390,14 @@ export default function App() {
             polls. */}
         {connected && <ConnectPanel />}
 
-        <RotatorStatusPill />
-        <QrzStatusPill />
+        <div className="hide-mobile" style={{ display: 'contents' }}>
+          <RotatorStatusPill />
+          <QrzStatusPill />
+        </div>
 
         <button
           type="button"
-          className={`btn qrz-btn ${terminatorActive ? 'active' : ''}`}
+          className={`btn qrz-btn hide-mobile ${terminatorActive ? 'active' : ''}`}
           onClick={() => (terminatorActive ? disengageTerminator() : engageTerminator())}
         >
           <span className="led on" style={{ marginRight: 6 }} />
@@ -404,23 +407,27 @@ export default function App() {
 
       {/* Control strip — real wired controls rebuilt into the design's chassis */}
       <div className="control-strip">
-        <ModeBandwidth />
-        <div className="ctrl-group" style={{ minWidth: 220 }}>
+        <div className="hide-mobile" style={{ display: 'contents' }}>
+          <ModeBandwidth />
+        </div>
+        <div className="ctrl-group hide-mobile" style={{ minWidth: 220 }}>
           <div className="label-xs ctrl-lbl">FRONT-END</div>
           <div className="btn-row" style={{ gap: 6, alignItems: 'center' }}>
             <PreampButton />
             <AttenuatorSlider />
           </div>
         </div>
-        <div className="ctrl-group" style={{ minWidth: 180 }}>
+        <div className="ctrl-group hide-mobile" style={{ minWidth: 180 }}>
           <div className="label-xs ctrl-lbl">AGC</div>
           <AgcSlider />
         </div>
-        <div className="spacer" style={{ flex: 1 }} />
+        <div className="spacer hide-mobile" style={{ flex: 1 }} />
         <div className="ctrl-group" style={{ minWidth: 360 }}>
           <div className="label-xs ctrl-lbl">ZOOM · DRIVE · MIC</div>
           <div className="btn-row" style={{ gap: 10 }}>
-            <ZoomControl />
+            <div className="hide-mobile" style={{ display: 'contents' }}>
+              <ZoomControl />
+            </div>
             <DriveSlider />
             <MicGainSlider />
           </div>
@@ -559,7 +566,7 @@ export default function App() {
           </div>
 
           {terminatorActive ? (
-            <div className="side-slot grow">
+            <div className="side-slot grow hide-mobile">
               <Dockable
                 title="QRZ.com Lookup"
                 ledOn={!!contact}
@@ -585,37 +592,40 @@ export default function App() {
               </Dockable>
             </div>
           ) : (
-            <div className="side-slot">
+            <div className="side-slot hide-mobile">
               <Dockable title="Great-Circle Map" ledOn={!!contact}>
                 <AzimuthMap target={contact} myGrid="EM48" />
               </Dockable>
             </div>
           )}
 
-          <div className="side-slot">
+          <div className="side-slot hide-mobile">
             <Dockable title="DSP" ledOn={dspActive}>
               <DspPanel />
             </Dockable>
           </div>
 
-          <div className="side-slot">
+          <div className="side-slot hide-mobile">
             <Dockable title={`CW Keyer · ${wpm} WPM`} ledOn={mode === 'CWU' || mode === 'CWL'}>
               <CwKeyer wpm={wpm} setWpm={setWpm} />
             </Dockable>
           </div>
         </div>
 
-        {/* Bottom row — Logbook + Memory (mock, read-only) */}
+        {/* Bottom row — Logbook + TX Stage Meters on desktop; big PTT on mobile. */}
         <div className="bottom-row">
-          <div className="bottom-slot">
+          <div className="bottom-slot hide-mobile">
             <Dockable title="Logbook" ledOn>
               <Logbook onPick={onLogPick} />
             </Dockable>
           </div>
-          <div className="bottom-slot">
+          <div className="bottom-slot hide-mobile">
             <Dockable title="TX Stage Meters" ledOn={moxOn || tunOn}>
               <TxStageMeters />
             </Dockable>
+          </div>
+          <div className="bottom-slot show-mobile mobile-ptt-slot">
+            <MobilePttButton />
           </div>
         </div>
 
@@ -629,16 +639,16 @@ export default function App() {
         <div className="transport-sep" />
         <AudioToggle />
         <MicMeter />
-        <div className="transport-sep" />
-        <button type="button" className="btn ghost">SPLIT</button>
-        <button type="button" className="btn ghost">RIT</button>
-        <button type="button" className="btn ghost">SAVE MEM</button>
+        <div className="transport-sep hide-mobile" />
+        <button type="button" className="btn ghost hide-mobile">SPLIT</button>
+        <button type="button" className="btn ghost hide-mobile">RIT</button>
+        <button type="button" className="btn ghost hide-mobile">SAVE MEM</button>
         <div className="spacer" style={{ flex: 1 }} />
-        <div className="chip">
+        <div className="chip hide-mobile">
           <span className="k">LINK</span>
           <span className="v mono">{connected ? 'UP' : 'DOWN'}</span>
         </div>
-        <div className="chip">
+        <div className="chip hide-mobile">
           <span className="k">PRE</span>
           <span className="v">{preampOn ? 'ON' : 'OFF'}</span>
         </div>

--- a/zeus-web/src/components/MobilePttButton.tsx
+++ b/zeus-web/src/components/MobilePttButton.tsx
@@ -1,0 +1,65 @@
+import { useCallback, useRef } from 'react';
+import { setMox } from '../api/client';
+import { useConnectionStore } from '../state/connection-store';
+import { useTxStore } from '../state/tx-store';
+
+// Press-and-hold PTT for mobile. Pointer events mirror the spacebar-PTT
+// pattern in use-keyboard-shortcuts — driveMox(true) on pointerdown,
+// driveMox(false) on pointerup/cancel/leave so a drag off the button still
+// releases the key. setPointerCapture keeps the up event owned by this
+// element even if the finger strays outside the hit area.
+export function MobilePttButton() {
+  const connected = useConnectionStore((s) => s.status === 'Connected');
+  const moxOn = useTxStore((s) => s.moxOn);
+  const setMoxOn = useTxStore((s) => s.setMoxOn);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const drive = useCallback(
+    (on: boolean) => {
+      if (useTxStore.getState().moxOn === on) return;
+      setMoxOn(on);
+      abortRef.current?.abort();
+      const ctrl = new AbortController();
+      abortRef.current = ctrl;
+      setMox(on, ctrl.signal).catch(() => {
+        if (!ctrl.signal.aborted) setMoxOn(!on);
+      });
+    },
+    [setMoxOn],
+  );
+
+  const onDown = useCallback(
+    (e: React.PointerEvent<HTMLButtonElement>) => {
+      if (!connected) return;
+      e.currentTarget.setPointerCapture(e.pointerId);
+      drive(true);
+    },
+    [connected, drive],
+  );
+
+  const onUp = useCallback(
+    (e: React.PointerEvent<HTMLButtonElement>) => {
+      if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      }
+      drive(false);
+    },
+    [drive],
+  );
+
+  return (
+    <button
+      type="button"
+      disabled={!connected}
+      className={`mobile-ptt-btn ${moxOn ? 'tx' : ''}`}
+      onPointerDown={onDown}
+      onPointerUp={onUp}
+      onPointerCancel={onUp}
+      onContextMenu={(e) => e.preventDefault()}
+    >
+      <span className={`led ${moxOn ? 'tx' : 'on'}`} />
+      <span className="mobile-ptt-label">{moxOn ? 'TX' : 'PTT'}</span>
+      <span className="mobile-ptt-hint">{moxOn ? 'release to stop' : 'hold to transmit'}</span>
+    </button>
+  );
+}

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -1053,3 +1053,151 @@
   bottom: 54px;
   z-index: 999;
 }
+
+/* .show-mobile — hidden on desktop, flexed in on mobile. Used for the PTT
+   slot that takes the bottom-row space normally occupied by the logbook. */
+.show-mobile { display: none; }
+
+/* ===== Mobile PTT button — desktop styles are unused (slot is hidden) but
+   kept here for consistency with the rest of the design system. ===== */
+.mobile-ptt-slot { flex: 1; }
+.mobile-ptt-btn {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 10px 14px;
+  font-size: 22px;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  color: var(--fg-0);
+  background: linear-gradient(180deg, var(--btn-top), var(--btn-bot));
+  border: 1px solid var(--btn-edge);
+  border-radius: var(--r-md);
+  box-shadow:
+    inset 0 1px 0 var(--btn-hl),
+    inset 0 -2px 0 rgba(0,0,0,0.4),
+    0 2px 4px rgba(0,0,0,0.5);
+  text-shadow: 0 1px 0 rgba(0,0,0,0.6);
+  user-select: none;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+  cursor: pointer;
+  transition: background 80ms ease, transform 80ms ease;
+}
+.mobile-ptt-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.mobile-ptt-btn.tx {
+  background: linear-gradient(180deg, #ff7a7a, #c41515);
+  color: #fff;
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,0.3),
+    0 0 18px rgba(255,56,56,0.8);
+  transform: translateY(1px);
+}
+.mobile-ptt-label {
+  font-size: 28px;
+  letter-spacing: 0.24em;
+}
+.mobile-ptt-hint {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fg-2);
+  opacity: 0.85;
+}
+.mobile-ptt-btn.tx .mobile-ptt-hint { color: rgba(255,255,255,0.85); }
+
+/* ===== Mobile responsive layout (≤640 px) =====
+   Shows only frequency (VFO), signal (S-meter), mic level, power level (drive),
+   the panadapter/waterfall stack, and a big hold-to-talk PTT button where the
+   logbook sits on desktop. Everything else — QRZ, azimuth map, DSP, CW keyer,
+   logbook, TX stage meters, mode/bandwidth, front-end, AGC, zoom, status chips,
+   tweaks panel — is hidden via the .hide-mobile utility. */
+@media (max-width: 900px) {
+  .hide-mobile { display: none !important; }
+  .show-mobile { display: flex; }
+
+  html, body { overflow-x: hidden; }
+
+  .app {
+    grid-template-rows: 44px 52px auto 1fr 44px;
+    width: 100%;
+    padding: 4px;
+    gap: 4px;
+    overflow-x: hidden;
+  }
+
+  .topbar {
+    height: 44px;
+    padding: 0 8px;
+    gap: 6px;
+    min-width: 0;
+  }
+  .brand { padding: 0 4px; gap: 6px; }
+  .brand-mark { width: 22px; height: 22px; }
+  .brand-name { font-size: 13px; }
+  /* Compact the connected "RADIO x.x.x.x:pppp" chip — the mono IP overflows
+     a 390 px viewport when the Disconnect button sits next to it. */
+  .topbar .chip.accent .v { max-width: 100px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: inline-block; }
+
+  .control-strip {
+    height: 52px;
+    padding: 2px 6px;
+    gap: 8px;
+    overflow-x: hidden;
+    min-width: 0;
+  }
+  /* Override inline min-width: 360 on the visible ZOOM·DRIVE·MIC ctrl-group so
+     the two remaining sliders shrink to fit narrow viewports. */
+  .control-strip .ctrl-group { min-width: 0 !important; }
+  .control-strip .btn-row { min-width: 0; flex: 1; }
+  .control-strip .knob-group { min-width: 0; flex: 1; }
+
+  .workspace {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(0, 1.4fr) minmax(0, 0.85fr) auto;
+    gap: 4px;
+  }
+  .workspace .hero { grid-column: 1; grid-row: 1; }
+  .workspace .side-stack {
+    grid-column: 1;
+    grid-row: 2;
+    flex-direction: column;
+    overflow-y: auto;
+    overflow-x: hidden;
+    gap: 4px;
+  }
+  .workspace .side-stack .side-slot {
+    flex: 0 0 auto;
+    min-width: 0;
+  }
+  .workspace .side-stack .side-slot.grow {
+    flex: 0 0 auto;
+    min-height: 0;
+  }
+  .workspace .bottom-row {
+    grid-column: 1;
+    grid-row: 3;
+    grid-template-columns: 1fr;
+    min-height: 72px;
+  }
+
+  .freq-digits { font-size: 26px; margin: 2px 0; }
+  .freq-panel { padding: 6px; gap: 4px; }
+  .smeter { padding: 6px 8px; gap: 4px; }
+  .smeter-scale { height: 40px; padding: 4px; }
+
+  .transport {
+    height: 44px;
+    padding: 0 6px;
+    gap: 4px;
+    min-width: 0;
+    overflow-x: hidden;
+  }
+  .transport .knob-group { min-width: 0; flex: 1; }
+
+  .tweaks-fab,
+  .tweaks-panel { display: none !important; }
+}


### PR DESCRIPTION
## Summary
- Forward-ports the mobile support work that was stranded on `feature/mobile_support` after the `nereus-web/` → `zeus-web/` rename — the branch never merged because a plain merge would have landed in a non-existent directory.
- At viewports ≤900 px (catches every common phone in either orientation plus iPad portrait), the UI drops to frequency, S-meter, mic, drive, and the panadapter/waterfall stack; logbook/TX-stage-meters are replaced by a press-and-hold PTT button with pointer capture that mirrors the spacebar-PTT flow.
- Clamps horizontal overflow (`overflow-x: hidden` on html/body/.app, `min-width: 0` on the surviving control-strip children) so narrow phones don't get a stray horizontal scrollbar.

Squashes four original commits: `0cacbef` responsive layout, `f32b018` PTT button, `4024a4e` breakpoint 640→900, `478dfc0` overflow clamp. App.tsx diverged from the original patch (ZEUS brand, Tweaks removed, QRZ replaced with QrzStatusPill/RotatorStatusPill) — `hide-mobile` classes were applied to the equivalent elements on master.

The 5th commit on the original branch (`ed26743` feat(pwa)) is **not** included — it conflicts with the Zeus-statue icon replacement on master and needs separate treatment. (Note: the build log shows `vite-plugin-pwa` is already active on master, so only the manifest/icon wiring is outstanding.)

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean, 721 ms
- [x] `npm test -- --run` — 63/63 passing
- [x] Live smoke in Chrome at 500×705: `scrollWidth === innerWidth` (no overflow), `(max-width: 900px)` media query active, 23 `.hide-mobile` elements, MobilePttButton renders in `.mobile-ptt-slot` (display: flex)
- [x] Live smoke in Chrome at 1440×900: all `.hide-mobile` elements visible, `.mobile-ptt-slot` hidden (display: none), full desktop layout intact
- [ ] Hardware PTT round-trip on a phone with a live HL2 connection — the pointerdown/up path wasn't exercised against a real radio in this session

## Notes for review
Per CLAUDE.md this is a red-light area (mobile UX defaults). Choices carried over from the original branch without second-guessing: 900 px breakpoint, which panels survive on mobile, PTT replacing logbook. Happy to revisit any of these if you'd rather call them differently on master.