### PR TITLE
fix(tci): idempotent TciServer shutdown, no more SIGABRT on exit

### DIFF
--- a/Zeus.Server/Tci/TciServer.cs
+++ b/Zeus.Server/Tci/TciServer.cs
@@ -99,7 +99,7 @@ public sealed class TciServer : IHostedService, IDisposable
         _radio.Connected -= OnRadioConnected;
         _radio.Disconnected -= OnRadioDisconnected;
 
-        _cts?.Cancel();
+        try { _cts?.Cancel(); } catch (ObjectDisposedException) { }
         _listener.Stop();
 
         if (_acceptTask is not null)
@@ -115,7 +115,9 @@ public sealed class TciServer : IHostedService, IDisposable
         _clients.Clear();
 
         _cts?.Dispose();
+        _cts = null;
         _listener.Close();
+        _listener = null;
     }
 
     private async Task AcceptLoopAsync(CancellationToken ct)
@@ -128,6 +130,10 @@ public sealed class TciServer : IHostedService, IDisposable
                 _ = Task.Run(() => HandleClientAsync(context, ct), ct);
             }
             catch (HttpListenerException) when (ct.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (ObjectDisposedException) when (ct.IsCancellationRequested)
             {
                 break;
             }
@@ -239,10 +245,13 @@ public sealed class TciServer : IHostedService, IDisposable
 
     public void Dispose()
     {
-        _cts?.Cancel();
+        try { _cts?.Cancel(); } catch (ObjectDisposedException) { }
+        _cts?.Dispose();
+        _cts = null;
+
         _listener?.Stop();
         _listener?.Close();
-        _cts?.Dispose();
+        _listener = null;
 
         foreach (var session in _clients.Values)
         {


### PR DESCRIPTION
## Summary

- `TciServer` is an `IHostedService`, so the .NET host calls **`StopAsync` then `Dispose`** on shutdown. `StopAsync` already disposes `_cts` and closes the listener, but `Dispose` then invoked `Cancel`/`Stop`/`Close` on the same objects. `CancellationTokenSource.Cancel()` on a disposed instance throws `ObjectDisposedException`, which propagated out of `Dispose` and turned a clean exit into **exit code 134 (SIGABRT)**.
- Guard both paths so double-teardown is safe, null the fields after disposal, and also swallow `ObjectDisposedException` in the accept loop so the cosmetic `tci accept loop error` warning no longer fires during normal shutdown.

## Root cause (reproducible)

On Ctrl-C / host shutdown:

```
info: Zeus.Server.Tci.TciServer[0]
      tci.stopping
warn: Zeus.Server.Tci.TciServer[0]
      tci accept loop error
      System.ObjectDisposedException: Cannot access a disposed object.
      Object name: 'listener'.
Unhandled exception. System.ObjectDisposedException: The CancellationTokenSource has been disposed.
   at System.Threading.CancellationTokenSource.Cancel()
   at Zeus.Server.Tci.TciServer.Dispose() in Zeus.Server/Tci/TciServer.cs:line 242
```

The `?.` checks only guard against `null`, not against disposed state.

## Test plan

- [x] `dotnet build Zeus.slnx` — 0 warnings, 0 errors
- [x] `dotnet test Zeus.slnx` — 451 passed, 6 skipped, 0 failed
- [ ] Manual: start backend, Ctrl-C, confirm process exits 0 (not 134) and no `ObjectDisposedException` stack trace in the log