### PR TITLE
fix(ci): revert zeus-agent triage to claude-code-base-action@v0.0.63

### DIFF
--- a/.github/workflows/zeus-agent.yml
+++ b/.github/workflows/zeus-agent.yml
@@ -22,9 +22,10 @@ jobs:
           private-key: ${{ secrets.ZEUS_AGENT_PRIVATE_KEY }}
 
       - name: Run Zeus-Agent
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-base-action@v0.0.63
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
-          github_token: ${{ steps.app-token.outputs.token }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--max-turns 15 --model claude-sonnet-4-6 --allowedTools 'Bash(gh label list),Bash(gh label list:*),Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh issue comment:*),Bash(gh search:*),Read,Glob,Grep'"
           prompt: |


### PR DESCRIPTION
## Summary
- Reverts the Zeus-Agent triage action from `claude-code-action@v1` back to `claude-code-base-action@v0.0.63`
- The v1 wrapper aborts with *"Actor does not have write permissions to the repository"* whenever an outside contributor opens an issue — the one scenario triage needs to cover
- The base action has no such check; `v0.0.63` is the exact version that successfully triaged #14 and #18 earlier today

## Why the v1 switch broke things
Run [`24742113504`](https://github.com/brianbruff/openhpsdr-zeus/actions/runs/24742113504) (issue #19, opened by outside contributor `Kb2uka`):

```
Checking permissions for actor: Kb2uka
Permission level retrieved: read
##[warning]Actor has insufficient permissions: read
##[error]Action failed with error: Actor does not have write permissions to the repository
```

The wrapper reads `github.event.sender.login` and checks that user's repo permission *before* it even looks at the `github_token` we pass in — so the Zeus-Agent App token never gets used.

## Test plan
- [ ] Open a test issue as `brianbruff` → Zeus-Agent comments and labels
- [ ] Ask an outside contributor (or use a second account) to open an issue → Zeus-Agent comments and labels
- [ ] Confirm the comment is posted as the Zeus-Agent App, not as `brianbruff` or `github-actions[bot]`