### PR TITLE
feat: configurable dev ports via ZEUS_PORT / BACKEND_PORT

### DIFF
--- a/.claude/skills/run/SKILL.md
+++ b/.claude/skills/run/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: run
+description: Build the Zeus frontend into wwwroot, start the Vite dev server, and start the Zeus.Server backend. Kills any process already bound to the target ports first. Optional portOffset argument (e.g. `/run 10`) shifts both ports by that amount.
+---
+
+# /run — start Zeus full stack
+
+Bring up Zeus for local development:
+
+1. Free the target ports (kill any existing listeners).
+2. Build the frontend into `Zeus.Server/wwwroot`.
+3. Start the Vite dev server (live-reload frontend).
+4. Start the .NET backend.
+5. Report the bound ports back to the user.
+
+## Argument
+
+- `$1` (optional): integer **portOffset**, default `0`. Shifts both ports.
+  - `/run` → Vite **5173**, backend **6060**
+  - `/run 10` → Vite **5183**, backend **6070**
+  - `/run 100` → Vite **5273**, backend **6160**
+- Reject negative values — tell the user, don't proceed.
+
+## Port configuration (how offset works)
+
+Both services already read their ports from env vars — no code patching needed:
+
+- Backend (`Zeus.Server/Program.cs`): reads `ZEUS_PORT` env var, defaults to 6060. Still uses `ListenAnyIP` so LAN access is preserved.
+- Frontend (`zeus-web/vite.config.ts`): `/api` and `/ws` proxy target reads `BACKEND_PORT` env var, defaults to 6060. Vite's own listen port is set via `--port` on the CLI.
+
+## Steps
+
+### 1. Parse offset
+
+```bash
+OFFSET="${1:-0}"
+# reject non-integer / negative
+case "$OFFSET" in
+  ''|*[!0-9]*) echo "portOffset must be a non-negative integer"; exit 1 ;;
+esac
+FRONTEND_PORT=$((5173 + OFFSET))
+BACKEND_PORT=$((6060 + OFFSET))
+```
+
+### 2. Kill existing listeners on both target ports
+
+```bash
+lsof -ti :"$FRONTEND_PORT" | xargs kill -9 2>/dev/null; \
+lsof -ti :"$BACKEND_PORT"  | xargs kill -9 2>/dev/null; \
+sleep 1
+```
+
+Do NOT use `fuser` (not default on macOS).
+
+### 3. Build the frontend into wwwroot
+
+```bash
+npm --prefix zeus-web run build
+```
+
+This runs `tsc -b && vite build` and writes to `Zeus.Server/wwwroot/` (`emptyOutDir: true`). Must complete before the backend starts so served assets aren't stale. If this fails, stop — do not start the servers.
+
+### 4. Start the Vite dev server (background)
+
+```bash
+BACKEND_PORT=$BACKEND_PORT npm --prefix zeus-web run dev -- --port $FRONTEND_PORT --strictPort
+```
+
+- Run with `run_in_background: true` on the Bash tool.
+- `BACKEND_PORT` tells the Vite proxy where to forward `/api` and `/ws`.
+- `--strictPort` makes Vite fail loudly rather than silently picking another port.
+
+### 5. Start the .NET backend (background)
+
+```bash
+ZEUS_PORT=$BACKEND_PORT dotnet run --project Zeus.Server
+```
+
+- Run with `run_in_background: true`.
+- `ZEUS_PORT` is read in `Zeus.Server/Program.cs` to drive `ListenAnyIP`. No source edits required.
+
+### 6. Verify both ports are listening, then report
+
+Give each server a moment, then probe:
+
+```bash
+lsof -iTCP:"$FRONTEND_PORT" -sTCP:LISTEN -P | tail -n +2
+lsof -iTCP:"$BACKEND_PORT"  -sTCP:LISTEN -P | tail -n +2
+```
+
+If either port has no listener after ~10 seconds, read the background task output and report the failure honestly — don't claim success.
+
+Final message must name the ports explicitly, e.g.:
+
+```
+Zeus is running:
+  Vite dev:  http://localhost:<FRONTEND_PORT>   (proxies /api,/ws → :<BACKEND_PORT>)
+  Backend:   http://localhost:<BACKEND_PORT>
+  wwwroot:   built from zeus-web into Zeus.Server/wwwroot
+```
+
+## Do NOT
+
+- Do **not** edit `Program.cs`, `vite.config.ts`, or any other source file — the env-var plumbing is already in place.
+- Do **not** run tests or a separate `dotnet build` — `dotnet run` compiles and step 3 already builds the frontend.
+- Do **not** foreground either server — both must be backgrounded so control returns to the user.
+- Do **not** start the backend before the frontend build completes, or `wwwroot` may be stale/empty.

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,9 @@ Thumbs.db
 *.log
 tools/demo-server/bin/
 tools/demo-server/obj/
-.claude/
+# Claude Code: share skills/commands/agents, keep per-machine state local
+.claude/settings.local.json
+.claude/*.lock
 
 # Local credential store (LiteDB) — stored in user's app-data dir, never in repo
 zeus.db*

--- a/Zeus.Server/Program.cs
+++ b/Zeus.Server/Program.cs
@@ -22,7 +22,9 @@ builder.Services.Configure<JsonOptions>(o =>
 // conflicting with the user's Log4YM project (which also binds :5050).
 // Bind on all interfaces so the SPA + API are reachable from other hosts
 // on the LAN (doc 01 §Deployment: local single-user, same LAN as radio).
-builder.WebHost.ConfigureKestrel(k => k.ListenAnyIP(6060));
+// ZEUS_PORT overrides the default (used by the /run skill's portOffset).
+var zeusPort = int.TryParse(Environment.GetEnvironmentVariable("ZEUS_PORT"), out var zp) ? zp : 6060;
+builder.WebHost.ConfigureKestrel(k => k.ListenAnyIP(zeusPort));
 
 // DspPipelineService owns engine selection directly: Synthetic while idle,
 // WDSP while a Protocol1Client is attached. No IDspEngine DI registration —

--- a/zeus-web/vite.config.ts
+++ b/zeus-web/vite.config.ts
@@ -3,6 +3,8 @@ import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import { VitePWA } from 'vite-plugin-pwa';
 
+const backendPort = process.env.BACKEND_PORT || '6060';
+
 export default defineConfig({
   plugins: [
     react(),
@@ -53,8 +55,8 @@ export default defineConfig({
     port: 5173,
     allowedHosts: ['.ngrok-free.app', '.ngrok.app', '.ngrok.io'],
     proxy: {
-      '/api': 'http://localhost:6060',
-      '/ws': { target: 'ws://localhost:6060', ws: true },
+      '/api': `http://localhost:${backendPort}`,
+      '/ws': { target: `ws://localhost:${backendPort}`, ws: true },
     },
   },
   build: {


### PR DESCRIPTION
## Summary
- Backend reads `ZEUS_PORT` (default `6060`) and continues to bind via `ListenAnyIP`, preserving LAN reachability.
- Vite proxy `/api` and `/ws` targets now read `BACKEND_PORT` (default `6060`), so the dev server forwards to the right backend when the ports are shifted.
- Matches the Log4YM env-var pattern. Lets a launcher script (`/run N`-style) move both servers by an offset without patching source.

Default behavior is unchanged when the env vars are unset.

## Test plan
- [x] `dotnet build Zeus.slnx` — clean
- [x] `dotnet test Zeus.slnx` — 451 passed, 6 skipped, 0 failed
- [x] `npm --prefix zeus-web run typecheck` — clean
- [x] `npm --prefix zeus-web run test` — 63 passed
- [ ] Smoke: `dotnet run --project Zeus.Server` with no env vars binds :6060 as before
- [ ] Smoke: `ZEUS_PORT=6070 dotnet run --project Zeus.Server` binds :6070
- [ ] Smoke: `BACKEND_PORT=6070 npm --prefix zeus-web run dev -- --port 5183` proxies `/api` to :6070