### PR TITLE
fix(tci): host TCI on Kestrel to fix Windows clone-and-run (#30)

### DIFF
--- a/Zeus.Server/Program.cs
+++ b/Zeus.Server/Program.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http.Json;
 using Zeus.Contracts;
@@ -24,7 +25,30 @@ builder.Services.Configure<JsonOptions>(o =>
 // on the LAN (doc 01 §Deployment: local single-user, same LAN as radio).
 // ZEUS_PORT overrides the default (used by the /run skill's portOffset).
 var zeusPort = int.TryParse(Environment.GetEnvironmentVariable("ZEUS_PORT"), out var zp) ? zp : 6060;
-builder.WebHost.ConfigureKestrel(k => k.ListenAnyIP(zeusPort));
+
+// Resolve TCI bind settings from configuration before DI builds, because Kestrel's
+// listeners have to be declared now. TCI shares Kestrel (rather than a separate
+// HttpListener) so clone-and-run on Windows doesn't need an http.sys URL ACL — see #30.
+var tciSection = builder.Configuration.GetSection("Tci");
+var tciEnabled = tciSection.GetValue<bool>("Enabled");
+var tciBindAddress = tciSection.GetValue<string?>("BindAddress") ?? "0.0.0.0";
+var tciPort = tciSection.GetValue<int?>("Port") ?? 40001;
+
+builder.WebHost.ConfigureKestrel(k =>
+{
+    k.ListenAnyIP(zeusPort);
+    if (tciEnabled)
+    {
+        if (tciBindAddress is "0.0.0.0" or "*" or "")
+            k.ListenAnyIP(tciPort);
+        else if (string.Equals(tciBindAddress, "localhost", StringComparison.OrdinalIgnoreCase))
+            k.ListenLocalhost(tciPort);
+        else if (IPAddress.TryParse(tciBindAddress, out var tciIp))
+            k.Listen(tciIp, tciPort);
+        else
+            k.ListenAnyIP(tciPort);
+    }
+});
 
 // DspPipelineService owns engine selection directly: Synthetic while idle,
 // WDSP while a Protocol1Client is attached. No IDspEngine DI registration —
@@ -84,6 +108,19 @@ var qrzService = app.Services.GetRequiredService<QrzService>();
 await qrzService.InitializeAsync(CancellationToken.None);
 
 app.UseWebSockets(new WebSocketOptions { KeepAliveInterval = TimeSpan.FromSeconds(20) });
+
+// Port-branch: any request arriving on the TCI listener (default :40001) is
+// routed straight to TciServer.AcceptAsync. Keeps TCI clients connecting to
+// ws://host:40001/ (root path, per ExpertSDR3 spec) from colliding with the
+// API/SPA on the main port.
+if (tciEnabled)
+{
+    app.UseWhen(
+        ctx => ctx.Connection.LocalPort == tciPort,
+        tciBranch => tciBranch.Run(ctx =>
+            ctx.RequestServices.GetRequiredService<TciServer>().AcceptAsync(ctx)));
+}
+
 app.UseDefaultFiles();
 app.UseStaticFiles();
 

--- a/Zeus.Server/Tci/TciServer.cs
+++ b/Zeus.Server/Tci/TciServer.cs
@@ -1,6 +1,4 @@
 using System.Collections.Concurrent;
-using System.Net;
-using System.Net.Sockets;
 using System.Net.WebSockets;
 using Microsoft.Extensions.Options;
 using Zeus.Contracts;
@@ -8,11 +6,16 @@ using Zeus.Contracts;
 namespace Zeus.Server.Tci;
 
 /// <summary>
-/// TCI (Transceiver Control Interface) server. Hosts a WebSocket listener on
-/// a dedicated port (default 40001) for ExpertSDR3-compatible remote control.
-/// Spoken by loggers (Log4OM, N1MM+), digital-mode apps (JTDX, WSJT-X), and
-/// SDR display tools. Implements TCI v1.8 protocol per the ExpertSDR3 spec.
+/// TCI (Transceiver Control Interface) server. Accepts ExpertSDR3-compatible
+/// WebSocket clients on a dedicated Kestrel listener (default :40001) wired
+/// in Program.cs via a port-branched middleware. Spoken by loggers (Log4OM,
+/// N1MM+), digital-mode apps (JTDX, WSJT-X), and SDR display tools. Implements
+/// TCI v1.8 per the ExpertSDR3 spec.
 /// </summary>
+// Hosted lifetime here only wires/unwires radio-event subscriptions and closes
+// live sessions on shutdown — the HTTP accept loop lives in Kestrel, not here.
+// (HttpListener on Windows needs a per-user urlacl for wildcard binds; Kestrel
+// binds sockets directly, so clone-and-run works without elevation. See #30.)
 public sealed class TciServer : IHostedService, IDisposable
 {
     private readonly ILogger<TciServer> _log;
@@ -24,9 +27,7 @@ public sealed class TciServer : IHostedService, IDisposable
     private readonly ILoggerFactory _loggerFactory;
 
     private readonly ConcurrentDictionary<Guid, TciSession> _clients = new();
-    private HttpListener? _listener;
-    private Task? _acceptTask;
-    private CancellationTokenSource? _cts;
+    private bool _subscribed;
 
     public TciServer(
         IOptions<TciOptions> options,
@@ -55,118 +56,61 @@ public sealed class TciServer : IHostedService, IDisposable
             return Task.CompletedTask;
         }
 
-        try
-        {
-            _cts = new CancellationTokenSource();
-            _listener = new HttpListener();
-            // HttpListener prefix syntax: "+" is the all-interfaces wildcard.
-            // Translate common user values ("0.0.0.0", "*", empty) so the
-            // config stays intuitive. Explicit IPs (e.g. "127.0.0.1") pass through.
-            string host = _options.BindAddress switch
-            {
-                "0.0.0.0" or "*" or "" or null => "+",
-                _ => _options.BindAddress,
-            };
-            string prefix = $"http://{host}:{_options.Port}/";
-            _listener.Prefixes.Add(prefix);
-            _listener.Start();
+        _radio.StateChanged += OnRadioStateChanged;
+        _radio.Connected += OnRadioConnected;
+        _radio.Disconnected += OnRadioDisconnected;
+        _subscribed = true;
 
-            _log.LogInformation("tci.listening bind={Bind} port={Port}", _options.BindAddress, _options.Port);
-
-            // Subscribe to radio events for broadcasting state changes
-            _radio.StateChanged += OnRadioStateChanged;
-            _radio.Connected += OnRadioConnected;
-            _radio.Disconnected += OnRadioDisconnected;
-
-            _acceptTask = AcceptLoopAsync(_cts.Token);
-        }
-        catch (Exception ex)
-        {
-            _log.LogError(ex, "tci.start failed");
-            throw;
-        }
-
+        _log.LogInformation("tci.listening bind={Bind} port={Port}", _options.BindAddress, _options.Port);
         return Task.CompletedTask;
     }
 
     public async Task StopAsync(CancellationToken ct)
     {
-        if (_listener is null) return;
-
-        _log.LogInformation("tci.stopping");
-
-        _radio.StateChanged -= OnRadioStateChanged;
-        _radio.Connected -= OnRadioConnected;
-        _radio.Disconnected -= OnRadioDisconnected;
-
-        try { _cts?.Cancel(); } catch (ObjectDisposedException) { }
-        _listener.Stop();
-
-        if (_acceptTask is not null)
+        if (_subscribed)
         {
-            try { await _acceptTask; } catch { /* shutdown */ }
+            _radio.StateChanged -= OnRadioStateChanged;
+            _radio.Connected -= OnRadioConnected;
+            _radio.Disconnected -= OnRadioDisconnected;
+            _subscribed = false;
         }
 
-        // Close all client sessions
+        _log.LogInformation("tci.stopping active={Count}", _clients.Count);
+
         foreach (var session in _clients.Values)
         {
             session.Dispose();
         }
         _clients.Clear();
 
-        _cts?.Dispose();
-        _cts = null;
-        _listener.Close();
-        _listener = null;
+        await Task.CompletedTask;
     }
 
-    private async Task AcceptLoopAsync(CancellationToken ct)
+    /// <summary>
+    /// Handle an incoming HTTP request on the TCI listener port. Upgrades to a
+    /// WebSocket, registers a session, and runs it to completion. Invoked from
+    /// the port-branch middleware in Program.cs.
+    /// </summary>
+    public async Task AcceptAsync(HttpContext context)
     {
-        while (!ct.IsCancellationRequested)
+        if (!context.WebSockets.IsWebSocketRequest)
         {
-            try
-            {
-                var context = await _listener!.GetContextAsync();
-                _ = Task.Run(() => HandleClientAsync(context, ct), ct);
-            }
-            catch (HttpListenerException) when (ct.IsCancellationRequested)
-            {
-                break;
-            }
-            catch (ObjectDisposedException) when (ct.IsCancellationRequested)
-            {
-                break;
-            }
-            catch (Exception ex)
-            {
-                _log.LogWarning(ex, "tci accept loop error");
-            }
-        }
-    }
-
-    private async Task HandleClientAsync(HttpListenerContext context, CancellationToken ct)
-    {
-        if (!context.Request.IsWebSocketRequest)
-        {
-            context.Response.StatusCode = 400;
-            context.Response.Close();
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
             return;
         }
 
-        HttpListenerWebSocketContext wsContext;
+        WebSocket ws;
         try
         {
-            wsContext = await context.AcceptWebSocketAsync(subProtocol: null);
+            ws = await context.WebSockets.AcceptWebSocketAsync();
         }
         catch (Exception ex)
         {
             _log.LogWarning(ex, "tci websocket upgrade failed");
-            context.Response.StatusCode = 500;
-            context.Response.Close();
+            context.Response.StatusCode = StatusCodes.Status500InternalServerError;
             return;
         }
 
-        var ws = wsContext.WebSocket;
         var id = Guid.NewGuid();
         var sessionLog = _loggerFactory.CreateLogger<TciSession>();
         var session = new TciSession(id, ws, sessionLog, _radio, _tx, _pipeline, _spots, _options);
@@ -176,7 +120,7 @@ public sealed class TciServer : IHostedService, IDisposable
 
         try
         {
-            await session.RunAsync(ct);
+            await session.RunAsync(context.RequestAborted);
         }
         finally
         {
@@ -245,14 +189,6 @@ public sealed class TciServer : IHostedService, IDisposable
 
     public void Dispose()
     {
-        try { _cts?.Cancel(); } catch (ObjectDisposedException) { }
-        _cts?.Dispose();
-        _cts = null;
-
-        _listener?.Stop();
-        _listener?.Close();
-        _listener = null;
-
         foreach (var session in _clients.Values)
         {
             session.Dispose();


### PR DESCRIPTION
## Summary

Closes #30.

- Move the TCI WebSocket listener from a separate `HttpListener` onto the Kestrel that already serves `/api` + the SignalR hub on :6060. On Windows, `HttpListener` routes wildcard prefixes through `http.sys`, which requires either admin rights or a per-user `netsh http add urlacl` registration — a fresh clone following the README crashed on startup with `HttpListenerException "Access is denied"` and `ObjectDisposedException` took the whole host down.
- Add a second `ListenAnyIP` (or `Listen` for an explicit IP) for `Tci:Port`, and route requests arriving on that port to `TciServer.AcceptAsync` via a `UseWhen` port-branch so the TCI root path `/` doesn't collide with the SPA on :6060.
- Drops `HttpListener`, the accept loop, and the dedicated `CancellationTokenSource` from `TciServer`. `StartAsync` reduces to radio-event wiring; `StopAsync` reduces to closing live sessions. `TciSession`, `TciProtocol`, `SpotManager`, broadcast, and rate-limiting are untouched.

Per the CLAUDE.md red-light list this is architecture-level, but the original issue explicitly listed it as option C and the maintainer nodded to go this route. No wire-format or default-value changes.

## Test plan

- [ ] `dotnet build Zeus.slnx` — clean (0 warn, 0 err).
- [ ] `dotnet test Zeus.slnx` — 354 passed locally.
- [ ] Fresh Windows clone + `dotnet run --project Zeus.Server`, unprivileged, no pre-existing urlacl: backend + TCI come up, `Now listening on: http://[::]:40001` appears.
- [ ] `curl http://localhost:40001/` → `400` (non-WS rejected).
- [ ] `curl http://localhost:6060/api/state` → `200` (main API unaffected).
- [ ] `ClientWebSocket` → `ws://localhost:40001/` → handshake succeeds, session emits `protocol:ExpertSDR3,1.8;...ready;` banner.
- [ ] Smoke test with a real TCI client (Log4OM / JTDX / WSJT-X) on the LAN.
- [ ] macOS / Linux unchanged — same code path, same port.

## Depends on

#31 — companion PR bundling `wdsp.dll` for win-x64. Merge that first if you want Connect to work end-to-end on a fresh Windows clone; not required for TCI-only review.