### PR TITLE
TX audio meters: Thetis parity + operator-facing diagnostics (Phases 1-3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ AI agents opening PRs against this repo may autonomously fix:
 - **Default values** — anything an operator will notice on first connect: TX power, filter widths, AGC, meter calibration, default band/mode, color palette. One bug report is not evidence that the default is wrong for everyone.
 - **Feature scope creep** — if the issue says "fix meter," fix the meter. Don't add a new meter, refactor the meter pipeline, or rename the meter types.
 
-When uncertain, implement the minimal fix and note in the PR description that design decisions need maintainer review. The maintainer (Brian, EI4HQ) is the sole authority on visual design, UX, and defaults.
+When uncertain, implement the minimal fix and note in the PR description that design decisions need maintainer review. The maintainer (Brian, EI6LF) is the sole authority on visual design, UX, and defaults.
 
 ## Load-Bearing Invariants
 

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -99,6 +99,12 @@ public sealed record TunSetRequest(bool On);
 
 public sealed record MicGainSetRequest(int Db);
 
+// Leveler max-gain ceiling in dB. Server clamps to [0, 15]; outside that is
+// 400. Frontend POSTs this whenever the slider moves and on WS reconnect so
+// the operator's preferred ceiling is re-applied after a server restart
+// (backend holds no persistent state for this setting).
+public sealed record LevelerMaxGainSetRequest(double Gain);
+
 // Per-band memory: last-used frequency and mode for a given ham band
 // (e.g. "20m"). The server keeps these in an unencrypted LiteDB file so they
 // survive restarts and follow the backend (not the browser). Band buttons

--- a/Zeus.Contracts/MsgType.cs
+++ b/Zeus.Contracts/MsgType.cs
@@ -34,4 +34,12 @@ public enum MsgType : byte
     // left in the enum for decoder interop / historical clients but the
     // server only broadcasts v2 after the feat/tx-audio-meters branch.
     TxMetersV2 = 0x16,
+
+    // Server → client (HL2 PA temperature in °C, MCP9700 sensor). Separate
+    // from the TX meter frame because temperature is a protection signal
+    // the operator wants to see during RX-only operation too — the HL2
+    // gateware auto-disables TX at 55 °C (Q6 sensor) — and it moves on a
+    // seconds timescale, so bolting it onto the 10 Hz TX meter cadence
+    // would be overkill. Broadcast at 2 Hz always.
+    PaTemp = 0x17,
 }

--- a/Zeus.Contracts/MsgType.cs
+++ b/Zeus.Contracts/MsgType.cs
@@ -25,4 +25,13 @@ public enum MsgType : byte
     // FFTW plan cache transitions between idle/building/ready; also pushed
     // once per client at WS attach so late joiners get the current state.
     WisdomStatus = 0x15,
+
+    // Server → client (TX telemetry v2). Compatible additive extension of
+    // TxMeters (0x11): carries average readings alongside peak for every
+    // stage, plus CFC/COMP stages that v1 omitted. Operators need the
+    // average to judge level and the peak to catch clipping; v1's peak-only
+    // payload hid transient overshoots inside the smoothing window. v1 is
+    // left in the enum for decoder interop / historical clients but the
+    // server only broadcasts v2 after the feat/tx-audio-meters branch.
+    TxMetersV2 = 0x16,
 }

--- a/Zeus.Contracts/PaTempFrame.cs
+++ b/Zeus.Contracts/PaTempFrame.cs
@@ -1,0 +1,46 @@
+using System.Buffers;
+using System.Buffers.Binary;
+
+namespace Zeus.Contracts;
+
+// Compact PA-temperature frame. 5 bytes total:
+//
+//   [0x17] [tempC:f32]
+//
+// Broadcast at 2 Hz regardless of MOX state — temperature is a protection
+// signal that matters during RX-only operation as well (the HL2 gateware
+// auto-disables TX at 55 °C on the Q6 sensor, so the operator wants to see
+// the climb even when not keyed). Moves on a seconds timescale, so the
+// 10 Hz TX-meter cadence is overkill.
+//
+// Value is the smoothed-and-clamped Celsius reading from the HL2 Q6
+// sensor, arriving as <c>reading.Ain0</c> on the C0=0x08 echo slot (same
+// slot that carries Alex FWD power in <c>Ain1</c>). Clamped into the
+// plausible sensor range at the server so a floating ADC input can't
+// trip the UI's 55 °C red zone on boot.
+//
+// Deliberately does NOT use the 16-byte WireFormat header — matches
+// RxMeterFrame / TxMetersFrame conventions: a per-frame header would more
+// than quadruple the wire cost for a value that updates twice a second.
+public readonly record struct PaTempFrame(float TempC)
+{
+    public const int ByteLength = 1 + 4;
+
+    public void Serialize(IBufferWriter<byte> writer)
+    {
+        var span = writer.GetSpan(ByteLength);
+        span[0] = (byte)MsgType.PaTemp;
+        BinaryPrimitives.WriteSingleLittleEndian(span.Slice(1, 4), TempC);
+        writer.Advance(ByteLength);
+    }
+
+    public static PaTempFrame Deserialize(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length < ByteLength)
+            throw new InvalidDataException($"PaTempFrame requires {ByteLength} bytes, got {bytes.Length}");
+        if (bytes[0] != (byte)MsgType.PaTemp)
+            throw new InvalidDataException($"expected PaTemp (0x{(byte)MsgType.PaTemp:X2}), got 0x{bytes[0]:X2}");
+        return new PaTempFrame(
+            TempC: BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(1, 4)));
+    }
+}

--- a/Zeus.Contracts/TxMetersV2Frame.cs
+++ b/Zeus.Contracts/TxMetersV2Frame.cs
@@ -1,0 +1,109 @@
+using System.Buffers;
+using System.Buffers.Binary;
+
+namespace Zeus.Contracts;
+
+// Extended TX-telemetry frame (v2). 81 bytes total:
+//
+//   [0x16] [fwdW:f32] [refW:f32] [swr:f32]
+//          [micPk:f32] [micAv:f32]
+//          [eqPk:f32]  [eqAv:f32]
+//          [lvlrPk:f32][lvlrAv:f32][lvlrGr:f32]
+//          [cfcPk:f32] [cfcAv:f32] [cfcGr:f32]
+//          [compPk:f32][compAv:f32]
+//          [alcPk:f32] [alcAv:f32] [alcGr:f32]
+//          [outPk:f32] [outAv:f32]
+//
+// Compatible additive extension of TxMetersFrame (0x11): carries average
+// readings alongside peak for every stage, plus CFC / COMP stages that v1
+// omitted. The operator needs the average to judge level and the peak to
+// catch clipping that hides inside the ~100 ms meter window.
+//
+// Deliberately does NOT use the 16-byte WireFormat header: TX meters fire
+// at 10 Hz during key-down and a per-frame header would more than double
+// the wire cost without adding anything the client needs.
+//
+// Level meters are dBFS (typically −60..0). The *Gr fields are dB of gain
+// reduction (≥0, with 0 meaning "no reduction"); CFC and COMP stages sit
+// at the WDSP silence sentinel (≈ −400 dBFS) until those stages are
+// engaged, which the frontend treats as "bypassed" (P1.4).
+public readonly record struct TxMetersV2Frame(
+    float FwdWatts,
+    float RefWatts,
+    float Swr,
+    float MicPk,
+    float MicAv,
+    float EqPk,
+    float EqAv,
+    float LvlrPk,
+    float LvlrAv,
+    float LvlrGr,
+    float CfcPk,
+    float CfcAv,
+    float CfcGr,
+    float CompPk,
+    float CompAv,
+    float AlcPk,
+    float AlcAv,
+    float AlcGr,
+    float OutPk,
+    float OutAv)
+{
+    public const int ByteLength = 1 + 4 * 20;
+
+    public void Serialize(IBufferWriter<byte> writer)
+    {
+        var span = writer.GetSpan(ByteLength);
+        span[0] = (byte)MsgType.TxMetersV2;
+        BinaryPrimitives.WriteSingleLittleEndian(span.Slice(1, 4), FwdWatts);
+        BinaryPrimitives.WriteSingleLittleEndian(span.Slice(5, 4), RefWatts);
+        BinaryPrimitives.WriteSingleLittleEndian(span.Slice(9, 4), Swr);
+        BinaryPrimitives.WriteSingleLittleEndian(span.Slice(13, 4), MicPk);
+        BinaryPrimitives.WriteSingleLittleEndian(span.Slice(17, 4), MicAv);
+        BinaryPrimitives.WriteSingleLittleEndian(span.Slice(21, 4), EqPk);
+        BinaryPrimitives.WriteSingleLittleEndian(span.Slice(25, 4), EqAv);
+        BinaryPrimitives.WriteSingleLittleEndian(span.Slice(29, 4), LvlrPk);
+        BinaryPrimitives.WriteSingleLittleEndian(span.Slice(33, 4), LvlrAv);
+        BinaryPrimitives.WriteSingleLittleEndian(span.Slice(37, 4), LvlrGr);
+        BinaryPrimitives.WriteSingleLittleEndian(span.Slice(41, 4), CfcPk);
+        BinaryPrimitives.WriteSingleLittleEndian(span.Slice(45, 4), CfcAv);
+        BinaryPrimitives.WriteSingleLittleEndian(span.Slice(49, 4), CfcGr);
+        BinaryPrimitives.WriteSingleLittleEndian(span.Slice(53, 4), CompPk);
+        BinaryPrimitives.WriteSingleLittleEndian(span.Slice(57, 4), CompAv);
+        BinaryPrimitives.WriteSingleLittleEndian(span.Slice(61, 4), AlcPk);
+        BinaryPrimitives.WriteSingleLittleEndian(span.Slice(65, 4), AlcAv);
+        BinaryPrimitives.WriteSingleLittleEndian(span.Slice(69, 4), AlcGr);
+        BinaryPrimitives.WriteSingleLittleEndian(span.Slice(73, 4), OutPk);
+        BinaryPrimitives.WriteSingleLittleEndian(span.Slice(77, 4), OutAv);
+        writer.Advance(ByteLength);
+    }
+
+    public static TxMetersV2Frame Deserialize(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length < ByteLength)
+            throw new InvalidDataException($"TxMetersV2Frame requires {ByteLength} bytes, got {bytes.Length}");
+        if (bytes[0] != (byte)MsgType.TxMetersV2)
+            throw new InvalidDataException($"expected TxMetersV2 (0x{(byte)MsgType.TxMetersV2:X2}), got 0x{bytes[0]:X2}");
+        return new TxMetersV2Frame(
+            FwdWatts: BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(1, 4)),
+            RefWatts: BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(5, 4)),
+            Swr: BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(9, 4)),
+            MicPk: BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(13, 4)),
+            MicAv: BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(17, 4)),
+            EqPk: BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(21, 4)),
+            EqAv: BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(25, 4)),
+            LvlrPk: BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(29, 4)),
+            LvlrAv: BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(33, 4)),
+            LvlrGr: BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(37, 4)),
+            CfcPk: BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(41, 4)),
+            CfcAv: BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(45, 4)),
+            CfcGr: BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(49, 4)),
+            CompPk: BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(53, 4)),
+            CompAv: BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(57, 4)),
+            AlcPk: BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(61, 4)),
+            AlcAv: BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(65, 4)),
+            AlcGr: BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(69, 4)),
+            OutPk: BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(73, 4)),
+            OutAv: BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(77, 4)));
+    }
+}

--- a/Zeus.Dsp/IDspEngine.cs
+++ b/Zeus.Dsp/IDspEngine.cs
@@ -62,6 +62,13 @@ public interface IDspEngine : IDisposable
     /// and when TXA is not open.</summary>
     void SetTxPanelGain(double linearGain);
 
+    /// <summary>Set the TXA Leveler maximum-gain ceiling in dB. Calls
+    /// <c>SetTXALevelerTop</c> (wcpAGC.c:648), which WDSP converts internally
+    /// to a linear cap via <c>pow(10, maxgainDb/20)</c>. Caller is
+    /// responsible for range-clamping; this method passes the value through.
+    /// No-op on Synthetic and when TXA is not open.</summary>
+    void SetTxLevelerMaxGain(double maxGainDb);
+
     /// <summary>Start or stop the TXA internal-tune post-generator tone
     /// (Thetis console.cs:18648 `chkTUN_CheckedChanged`). When on, TXA emits
     /// a steady unmodulated carrier regardless of mic input. When off, the

--- a/Zeus.Dsp/SyntheticDspEngine.cs
+++ b/Zeus.Dsp/SyntheticDspEngine.cs
@@ -110,6 +110,7 @@ public sealed class SyntheticDspEngine : IDspEngine
     public int ProcessTxBlock(ReadOnlySpan<float> micMono, Span<float> iqInterleaved) => 0;
     public int TxBlockSamples => 1024;
     public void SetTxPanelGain(double linearGain) { }
+    public void SetTxLevelerMaxGain(double maxGainDb) { }
     public void SetTxTune(bool on) { }
     public TxStageMeters GetTxStageMeters() => TxStageMeters.Silent;
 

--- a/Zeus.Dsp/TxStageMeters.cs
+++ b/Zeus.Dsp/TxStageMeters.cs
@@ -1,33 +1,62 @@
 namespace Zeus.Dsp;
 
 /// <summary>
-/// Per-block peak readings from the WDSP TXA metering ring. Values are in
-/// dBFS for the level meters and dB for the gain-reduction meters. When TXA
-/// is not processing (MOX off, or engine lacks TXA), all fields are
-/// <see cref="float.NegativeInfinity"/> except the gain fields which are 0.
+/// Per-block TXA stage readings sampled from the WDSP metering ring. Level
+/// fields (*Pk/*Av) are dBFS; gain-reduction fields (*Gr) are positive dB
+/// of reduction (0 = no reduction, 6 = 6 dB cut). When TXA is not processing
+/// (MOX off, or engine lacks TXA), all level fields are
+/// <see cref="float.NegativeInfinity"/> and all gain-reduction fields are 0.
 ///
-/// Chosen as peak (not average) readings — the diagnostic we care about is
-/// clipping-induced distortion, which hides inside the average window's
-/// ~100 ms smoothing. Indices tracked per <c>native/wdsp/TXA.h</c> txaMeterType.
+/// Both peak and average are captured for each active stage. The operator
+/// uses average to judge level and peak to spot clipping-induced distortion
+/// that hides inside the average window's ~100 ms smoothing. Indices tracked
+/// per <c>native/wdsp/TXA.h:49-66</c> txaMeterType.
 ///
-/// Sign convention: <see cref="AlcGr"/> is stored as positive dB of gain
-/// reduction (0 = no reduction, 6 = 6 dB cut). WDSP returns <c>TXA_ALC_GAIN</c>
-/// as <c>20*log10(linear_gain)</c> which is ≤ 0 when reducing — callers must
-/// negate before storing here.
+/// Sign convention for *Gr fields: WDSP returns <c>TXA_*_GAIN</c> as
+/// <c>20*log10(linear_gain)</c>, which is ≤ 0 when the stage is reducing.
+/// Callers must negate before storing here so downstream consumers see a
+/// monotonic "how much are we cutting?" scale.
+///
+/// CFC / COMP readings will sit at the WDSP silence sentinel (≈ −400 dBFS)
+/// until their stages are engaged; the frontend treats the sentinel as
+/// "bypassed" (P1.4 sentinel handling). Leaving the fields in the record
+/// keeps the DSP→wire pipeline uniform regardless of which stages are on.
 /// </summary>
 public readonly record struct TxStageMeters(
     float MicPk,
+    float MicAv,
     float EqPk,
+    float EqAv,
     float LvlrPk,
+    float LvlrAv,
+    float LvlrGr,
+    float CfcPk,
+    float CfcAv,
+    float CfcGr,
+    float CompPk,
+    float CompAv,
     float AlcPk,
+    float AlcAv,
     float AlcGr,
-    float OutPk)
+    float OutPk,
+    float OutAv)
 {
     public static readonly TxStageMeters Silent = new(
         MicPk: float.NegativeInfinity,
+        MicAv: float.NegativeInfinity,
         EqPk: float.NegativeInfinity,
+        EqAv: float.NegativeInfinity,
         LvlrPk: float.NegativeInfinity,
+        LvlrAv: float.NegativeInfinity,
+        LvlrGr: 0f,
+        CfcPk: float.NegativeInfinity,
+        CfcAv: float.NegativeInfinity,
+        CfcGr: 0f,
+        CompPk: float.NegativeInfinity,
+        CompAv: float.NegativeInfinity,
         AlcPk: float.NegativeInfinity,
+        AlcAv: float.NegativeInfinity,
         AlcGr: 0f,
-        OutPk: float.NegativeInfinity);
+        OutPk: float.NegativeInfinity,
+        OutAv: float.NegativeInfinity);
 }

--- a/Zeus.Dsp/TxStageMeters.cs
+++ b/Zeus.Dsp/TxStageMeters.cs
@@ -9,8 +9,14 @@ namespace Zeus.Dsp;
 /// Chosen as peak (not average) readings — the diagnostic we care about is
 /// clipping-induced distortion, which hides inside the average window's
 /// ~100 ms smoothing. Indices tracked per <c>native/wdsp/TXA.h</c> txaMeterType.
+///
+/// Sign convention: <see cref="AlcGr"/> is stored as positive dB of gain
+/// reduction (0 = no reduction, 6 = 6 dB cut). WDSP returns <c>TXA_ALC_GAIN</c>
+/// as <c>20*log10(linear_gain)</c> which is ≤ 0 when reducing — callers must
+/// negate before storing here.
 /// </summary>
 public readonly record struct TxStageMeters(
+    float MicPk,
     float EqPk,
     float LvlrPk,
     float AlcPk,
@@ -18,6 +24,7 @@ public readonly record struct TxStageMeters(
     float OutPk)
 {
     public static readonly TxStageMeters Silent = new(
+        MicPk: float.NegativeInfinity,
         EqPk: float.NegativeInfinity,
         LvlrPk: float.NegativeInfinity,
         AlcPk: float.NegativeInfinity,

--- a/Zeus.Dsp/Wdsp/NativeMethods.cs
+++ b/Zeus.Dsp/Wdsp/NativeMethods.cs
@@ -489,6 +489,15 @@ internal static partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial void SetTXALevelerSt(int channel, int state);
 
+    // Leveler maximum-gain ceiling. WDSP's SetTXALevelerTop takes the value
+    // in dB (wcpAGC.c:648 — converts internally via pow(10, maxgain/20)
+    // to the linear `max_gain` field on the wcpagc struct). create_wcpagc
+    // (TXA.c:169) ships with max_gain = 1.778 linear ≈ +5 dB; this setter
+    // lets the operator widen/narrow the peak-leveling headroom at runtime.
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetTXALevelerTop(int channel, double maxgain);
+
     [LibraryImport(LibraryName)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial void SetTXACompressorRun(int channel, int run);

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -812,32 +812,61 @@ public sealed class WdspDspEngine : IDspEngine
             iqInterleaved[2 * i + 1] = qout[i];
         }
 
-        // Per-stage TXA peak meters. Peak (not average) is what surfaces
-        // clipping-induced crackle — averages smooth a transient peak over
-        // the ~100 ms meter window and hide the very thing we're chasing.
-        // Indices per native/wdsp/TXA.h:49-66 txaMeterType.
-        //   MIC_PK=0   EQ_PK=2   LVLR_PK=4  LVLR_GAIN=6
-        //   CFC_PK=7   CFC_GAIN=9 COMP_PK=10 ALC_PK=12  ALC_GAIN=14  OUT_PK=15
+        // Per-stage TXA peak + average meters. Peak surfaces clipping-induced
+        // crackle that averages smooth away; the average is what the operator
+        // reads to judge level. Both are published so the frontend can show
+        // a Thetis-style dual-needle per row. Indices per native/wdsp/TXA.h:49-66
+        // txaMeterType:
+        //   0  MIC_PK    1  MIC_AV
+        //   2  EQ_PK     3  EQ_AV
+        //   4  LVLR_PK   5  LVLR_AV   6  LVLR_GAIN
+        //   7  CFC_PK    8  CFC_AV    9  CFC_GAIN
+        //  10  COMP_PK  11  COMP_AV
+        //  12  ALC_PK   13  ALC_AV   14  ALC_GAIN
+        //  15  OUT_PK   16  OUT_AV
         double micPk = NativeMethods.GetTXAMeter(txa, 0);
+        double micAv = NativeMethods.GetTXAMeter(txa, 1);
         double eqPk = NativeMethods.GetTXAMeter(txa, 2);
+        double eqAv = NativeMethods.GetTXAMeter(txa, 3);
         double lvlrPk = NativeMethods.GetTXAMeter(txa, 4);
+        double lvlrAv = NativeMethods.GetTXAMeter(txa, 5);
+        double lvlrGain = NativeMethods.GetTXAMeter(txa, 6);
+        double cfcPk = NativeMethods.GetTXAMeter(txa, 7);
+        double cfcAv = NativeMethods.GetTXAMeter(txa, 8);
+        double cfcGain = NativeMethods.GetTXAMeter(txa, 9);
+        double compPk = NativeMethods.GetTXAMeter(txa, 10);
+        double compAv = NativeMethods.GetTXAMeter(txa, 11);
         double alcPk = NativeMethods.GetTXAMeter(txa, 12);
+        double alcAv = NativeMethods.GetTXAMeter(txa, 13);
         double alcGain = NativeMethods.GetTXAMeter(txa, 14);
         double outPk = NativeMethods.GetTXAMeter(txa, 15);
+        double outAv = NativeMethods.GetTXAMeter(txa, 16);
 
         // Publish the snapshot before returning so pollers don't see a
         // partially-written set. Lock is uncontended in steady state —
         // ProcessTxBlock runs from the TX ingest thread and GetTxStageMeters
         // only from TxMetersService (10 Hz).
-        // alcGain from WDSP is 20*log10(linear_gain) ≤ 0 when reducing.
-        // Store as positive "gain reduction" dB per TxStageMeters convention.
+        // *Gain readings from WDSP are 20*log10(linear_gain) ≤ 0 when
+        // reducing. Store as positive "gain reduction" dB per TxStageMeters
+        // convention.
         var snap = new TxStageMeters(
             MicPk: (float)micPk,
+            MicAv: (float)micAv,
             EqPk: (float)eqPk,
+            EqAv: (float)eqAv,
             LvlrPk: (float)lvlrPk,
+            LvlrAv: (float)lvlrAv,
+            LvlrGr: (float)-lvlrGain,
+            CfcPk: (float)cfcPk,
+            CfcAv: (float)cfcAv,
+            CfcGr: (float)-cfcGain,
+            CompPk: (float)compPk,
+            CompAv: (float)compAv,
             AlcPk: (float)alcPk,
+            AlcAv: (float)alcAv,
             AlcGr: (float)-alcGain,
-            OutPk: (float)outPk);
+            OutPk: (float)outPk,
+            OutAv: (float)outAv);
         lock (_txMeterPublishLock) { _latestTxStageMeters = snap; }
 
         var now = DateTime.UtcNow;
@@ -852,8 +881,12 @@ public sealed class WdspDspEngine : IDspEngine
                 double ma = Math.Max(oi, oq); if (ma > ioutPeak) ioutPeak = ma;
             }
             _log.LogInformation(
-                "wdsp.tx.stage micBlockPeak={MP:F3} iqBlockPeak={IP:F4} | mic={Mic:F1} eq={Eq:F1} lvlr={Lvlr:F1} alc={Alc:F1} alcGr={AlcG:F1} out={Out:F1}",
-                micBlockPeak, ioutPeak, micPk, eqPk, lvlrPk, alcPk, alcGain, outPk);
+                "wdsp.tx.stage micBlockPeak={MP:F3} iqBlockPeak={IP:F4} | mic pk={MicPk:F1} av={MicAv:F1} | eq pk={EqPk:F1} av={EqAv:F1} | lvlr pk={LvlrPk:F1} av={LvlrAv:F1} gr={LvlrGr:F1} | alc pk={AlcPk:F1} av={AlcAv:F1} gr={AlcGr:F1} | out pk={OutPk:F1} av={OutAv:F1}",
+                micBlockPeak, ioutPeak,
+                micPk, micAv, eqPk, eqAv,
+                lvlrPk, lvlrAv, -lvlrGain,
+                alcPk, alcAv, -alcGain,
+                outPk, outAv);
         }
         return TxaInSize;
     }

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -826,11 +826,14 @@ public sealed class WdspDspEngine : IDspEngine
         // partially-written set. Lock is uncontended in steady state —
         // ProcessTxBlock runs from the TX ingest thread and GetTxStageMeters
         // only from TxMetersService (10 Hz).
+        // alcGain from WDSP is 20*log10(linear_gain) ≤ 0 when reducing.
+        // Store as positive "gain reduction" dB per TxStageMeters convention.
         var snap = new TxStageMeters(
+            MicPk: (float)micPk,
             EqPk: (float)eqPk,
             LvlrPk: (float)lvlrPk,
             AlcPk: (float)alcPk,
-            AlcGr: (float)alcGain,
+            AlcGr: (float)-alcGain,
             OutPk: (float)outPk);
         lock (_txMeterPublishLock) { _latestTxStageMeters = snap; }
 

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -21,6 +21,13 @@ public sealed class WdspDspEngine : IDspEngine
     private const int TxaInSize = 1024;
     private const int TxaDspSize = 1024;
 
+    // Leveler max-gain ceiling in dB applied at TXA init. Matches the
+    // W1AEX / softerhardware community default ("CFC Audio Tools" guide,
+    // ~+5 dB) — milder than Thetis's stock +15 dB, erring toward cleaner
+    // transmit audio on the first connect. Operator overrides via
+    // POST /api/tx/leveler-max-gain.
+    internal const double DefaultLevelerMaxGainDb = 5.0;
+
     // Legacy aliases — RXA-side code still references these. Kept = RxaInSize
     // / RxaDspSize so existing callsites (audio outSamples math, channel
     // structs, etc.) don't have to change.
@@ -633,6 +640,14 @@ public sealed class WdspDspEngine : IDspEngine
             // ALC stays on (see SetTXAALCSt below; never 0). AMSQ is the mic
             // noise gate and shouldn't shape SSB audio.
             NativeMethods.SetTXALevelerSt(id, 1);
+            // Leveler max-gain default. WDSP's create_wcpagc ships with
+            // max_gain = 1.778 linear (≈ +5 dB) at TXA.c:169; we assert the
+            // value explicitly so the baseline stays deterministic and the
+            // init log confirms what the Leveler's headroom is set to.
+            // +5 dB matches the W1AEX / softerhardware community default
+            // (milder than Thetis's +15 dB stock — see task #13 notes).
+            // Operator-settable at runtime via POST /api/tx/leveler-max-gain.
+            NativeMethods.SetTXALevelerTop(id, DefaultLevelerMaxGainDb);
             NativeMethods.SetTXACompressorRun(id, 0);
             NativeMethods.SetTXACFCOMPRun(id, 0);
             NativeMethods.SetTXAPHROTRun(id, 0);
@@ -643,8 +658,8 @@ public sealed class WdspDspEngine : IDspEngine
 
             _txaChannelId = id;
             _log.LogInformation(
-                "wdsp.openTxChannel id={Id} chain=[alc=1 lvlr=1 cpdr=0 cfc=0 phrot=0 osctrl=0 eq=0 amsq=0] bp=150..2850 panelGain=1.0 (Leveler enabled to match Thetis default)",
-                id);
+                "wdsp.openTxChannel id={Id} chain=[alc=1 lvlr=1 lvlrMax={LvlrMax:F1}dB cpdr=0 cfc=0 phrot=0 osctrl=0 eq=0 amsq=0] bp=150..2850 panelGain=1.0 (Leveler enabled to match Thetis default)",
+                id, DefaultLevelerMaxGainDb);
             return id;
         }
     }
@@ -718,6 +733,17 @@ public sealed class WdspDspEngine : IDspEngine
             NativeMethods.SetTXAPanelGain1(txa, linearGain);
         }
         _log.LogInformation("wdsp.setTxPanelGain linear={Gain:F3}", linearGain);
+    }
+
+    public void SetTxLevelerMaxGain(double maxGainDb)
+    {
+        if (_disposed != 0) return;
+        lock (_txaLock)
+        {
+            if (_txaChannelId is not int txa) return;
+            NativeMethods.SetTXALevelerTop(txa, maxGainDb);
+        }
+        _log.LogInformation("wdsp.setTxLevelerMaxGain dB={Db:F1}", maxGainDb);
     }
 
     public void SetTxTune(bool on)

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -622,14 +622,17 @@ public sealed class WdspDspEngine : IDspEngine
 
             // Explicit clean-slate TX chain state. WDSP initializes these
             // "off" at channel-create, but asserting them makes the baseline
-            // deterministic and independent of the library build. Leveler
-            // and Compressor are Thetis-factory-ON per its database profile,
-            // but we keep them OFF here until they're wired to operator UI
-            // and tuned — enabling them with library-default parameters can
-            // mask or create new distortion on its own. ALC stays on (see
-            // SetTXAALCSt below; never 0). AMSQ is the mic noise gate and
-            // shouldn't shape SSB audio.
-            NativeMethods.SetTXALevelerSt(id, 0);
+            // deterministic and independent of the library build. Leveler is
+            // Thetis-factory-ON (radio.cs:3018 tx_leveler_on = true) and is
+            // enabled here to match that default — a disabled Leveler stage
+            // also leaves GetTXAMeter(LVLR_PK) stuck at WDSP's -400 silence
+            // sentinel, which made the frontend LVLR bar look broken. Other
+            // stages (Compressor, CFC, PHROT, osctrl, EQ, AMSQ) remain OFF
+            // until they're wired to operator UI and tuned — enabling them
+            // with library-default parameters can mask or create distortion.
+            // ALC stays on (see SetTXAALCSt below; never 0). AMSQ is the mic
+            // noise gate and shouldn't shape SSB audio.
+            NativeMethods.SetTXALevelerSt(id, 1);
             NativeMethods.SetTXACompressorRun(id, 0);
             NativeMethods.SetTXACFCOMPRun(id, 0);
             NativeMethods.SetTXAPHROTRun(id, 0);
@@ -640,7 +643,7 @@ public sealed class WdspDspEngine : IDspEngine
 
             _txaChannelId = id;
             _log.LogInformation(
-                "wdsp.openTxChannel id={Id} chain=[alc=1 lvlr=0 cpdr=0 cfc=0 phrot=0 osctrl=0 eq=0 amsq=0] bp=150..2850 panelGain=1.0",
+                "wdsp.openTxChannel id={Id} chain=[alc=1 lvlr=1 cpdr=0 cfc=0 phrot=0 osctrl=0 eq=0 amsq=0] bp=150..2850 panelGain=1.0 (Leveler enabled to match Thetis default)",
                 id);
             return id;
         }

--- a/Zeus.Server/Program.cs
+++ b/Zeus.Server/Program.cs
@@ -261,6 +261,21 @@ app.MapPost("/api/mic-gain", (MicGainSetRequest req, DspPipelineService pipe) =>
     return Results.Ok(new { micGainDb = db });
 });
 
+// Leveler max-gain ceiling in dB. Operator-safe band is 0..15 dB: 0 disables
+// the headroom entirely (unity-cap Leveler) and 15 matches Thetis's stock
+// ceiling (radio.cs:2979 tx_leveler_max_gain = 15.0). Anything outside is a
+// 400 so a misbehaving client can't hand WDSP a value that'd saturate on
+// the first voiced sample. The server is stateless for this setting —
+// frontend re-POSTs on WS reconnect to re-sync after a server restart.
+app.MapPost("/api/tx/leveler-max-gain", (LevelerMaxGainSetRequest req, DspPipelineService pipe) =>
+{
+    if (req.Gain < 0.0 || req.Gain > 15.0 || double.IsNaN(req.Gain))
+        return Results.BadRequest(new { error = "gain must be 0..15 dB" });
+    log.LogInformation("api.tx.levelerMaxGain dB={Db:F1}", req.Gain);
+    pipe.CurrentEngine?.SetTxLevelerMaxGain(req.Gain);
+    return Results.Ok(new { levelerMaxGainDb = req.Gain });
+});
+
 // TUN: internal-tune carrier. Flips SetTXAPostGenRun on WDSP; server-side is
 // where the PRD's drive clamp to min(drive, 25) lives, and where we gate
 // mutual exclusion with MOX so the HL2 sees exactly one of them active.

--- a/Zeus.Server/StreamingHub.cs
+++ b/Zeus.Server/StreamingHub.cs
@@ -185,6 +185,25 @@ public sealed class StreamingHub
         }
     }
 
+    public void Broadcast(in PaTempFrame frame)
+    {
+        if (_clients.IsEmpty) return;
+
+        int total = PaTempFrame.ByteLength;
+        var rented = ArrayPool<byte>.Shared.Rent(total);
+        try
+        {
+            var writer = new FixedBufferWriter(rented, total);
+            frame.Serialize(writer);
+            var payload = new ReadOnlyMemory<byte>(rented, 0, total).ToArray();
+            foreach (var client in _clients.Values) client.TryEnqueue(payload);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rented);
+        }
+    }
+
     public void Broadcast(in WisdomStatusFrame frame)
     {
         SetWisdomPhase(frame.Phase);

--- a/Zeus.Server/StreamingHub.cs
+++ b/Zeus.Server/StreamingHub.cs
@@ -147,6 +147,25 @@ public sealed class StreamingHub
         }
     }
 
+    public void Broadcast(in TxMetersV2Frame frame)
+    {
+        if (_clients.IsEmpty) return;
+
+        int total = TxMetersV2Frame.ByteLength;
+        var rented = ArrayPool<byte>.Shared.Rent(total);
+        try
+        {
+            var writer = new FixedBufferWriter(rented, total);
+            frame.Serialize(writer);
+            var payload = new ReadOnlyMemory<byte>(rented, 0, total).ToArray();
+            foreach (var client in _clients.Values) client.TryEnqueue(payload);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rented);
+        }
+    }
+
     public void Broadcast(in RxMeterFrame frame)
     {
         if (_clients.IsEmpty) return;

--- a/Zeus.Server/TxMetersService.cs
+++ b/Zeus.Server/TxMetersService.cs
@@ -8,7 +8,7 @@ namespace Zeus.Server;
 /// <summary>
 /// Consumes raw FWD/REF ADC readings from Protocol1, smooths them with an
 /// exponential low-pass, converts to watts + SWR per the HermesLite2
-/// calibration, and broadcasts a <see cref="TxMetersFrame"/> over the
+/// calibration, and broadcasts a <see cref="TxMetersV2Frame"/> over the
 /// StreamingHub at 10 Hz while MOX is on / 2 Hz when idle.
 ///
 /// PRD FR-6: If SWR > 2.5 sustained for ≥500 ms while MOX or TUN is on,
@@ -154,7 +154,7 @@ public sealed class TxMetersService : BackgroundService
                 // Meter during MOX *or* TUN — both drive the PA, both need live
                 // FWD/SWR readouts. Idle frame is only for fully-unkeyed RX.
                 bool mox = _tx.IsMoxOn || _tx.IsTunOn;
-                TxMetersFrame frame;
+                TxMetersV2Frame frame;
                 double swr = 1.0;
                 if (mox)
                 {
@@ -166,16 +166,7 @@ public sealed class TxMetersService : BackgroundService
                     // may lag the first TX block by a few ticks at MOX-on, which
                     // reads as "Silent" (−∞ level / 0 GR) — UI treats as empty.
                     var stage = _pipe.CurrentEngine?.GetTxStageMeters() ?? TxStageMeters.Silent;
-                    frame = new TxMetersFrame(
-                        FwdWatts: (float)fwdW,
-                        RefWatts: (float)refW,
-                        Swr: (float)swr,
-                        MicDbfs: stage.MicPk,
-                        EqPk: stage.EqPk,
-                        LvlrPk: stage.LvlrPk,
-                        AlcPk: stage.AlcPk,
-                        AlcGr: stage.AlcGr,
-                        OutPk: stage.OutPk);
+                    frame = BuildFrame((float)fwdW, (float)refW, (float)swr, stage);
 
                     if (EvaluateSwrTrip(swr, DateTime.UtcNow) is { } tripReason)
                     {
@@ -191,17 +182,7 @@ public sealed class TxMetersService : BackgroundService
                     // stale pre-unkey reading. Stage meters go to Silent (−∞)
                     // so the diagnostic strip renders empty instead of latching
                     // last-during-TX values.
-                    var silent = TxStageMeters.Silent;
-                    frame = new TxMetersFrame(
-                        FwdWatts: 0f,
-                        RefWatts: 0f,
-                        Swr: 1.0f,
-                        MicDbfs: silent.MicPk,
-                        EqPk: silent.EqPk,
-                        LvlrPk: silent.LvlrPk,
-                        AlcPk: silent.AlcPk,
-                        AlcGr: silent.AlcGr,
-                        OutPk: silent.OutPk);
+                    frame = BuildFrame(0f, 0f, 1.0f, TxStageMeters.Silent);
                     // Clear the trip timer when not keyed so a brief spike doesn't
                     // carry over into the next TX.
                     lock (_sync) { _swrAboveThresholdSince = null; }
@@ -267,6 +248,36 @@ public sealed class TxMetersService : BackgroundService
             return $"TX timeout: TUN keyed >{(int)TxTimeout.TotalSeconds} s — dropped to protect PA";
         return null;
     }
+
+    /// <summary>
+    /// Compose a <see cref="TxMetersV2Frame"/> from the protection readings
+    /// (FWD/REF/SWR) and the latest stage-meter snapshot. Kept as a small
+    /// helper so the MOX and idle branches in <see cref="ExecuteAsync"/>
+    /// stay symmetric and a future v3 frame is a one-line change. Pure
+    /// function — no instance state.
+    /// </summary>
+    internal static TxMetersV2Frame BuildFrame(float fwdW, float refW, float swr, TxStageMeters stage)
+        => new(
+            FwdWatts: fwdW,
+            RefWatts: refW,
+            Swr: swr,
+            MicPk: stage.MicPk,
+            MicAv: stage.MicAv,
+            EqPk: stage.EqPk,
+            EqAv: stage.EqAv,
+            LvlrPk: stage.LvlrPk,
+            LvlrAv: stage.LvlrAv,
+            LvlrGr: stage.LvlrGr,
+            CfcPk: stage.CfcPk,
+            CfcAv: stage.CfcAv,
+            CfcGr: stage.CfcGr,
+            CompPk: stage.CompPk,
+            CompAv: stage.CompAv,
+            AlcPk: stage.AlcPk,
+            AlcAv: stage.AlcAv,
+            AlcGr: stage.AlcGr,
+            OutPk: stage.OutPk,
+            OutAv: stage.OutAv);
 
     /// <summary>
     /// Port of Thetis <c>console.cs:25008-25072</c> watts math plus the

--- a/Zeus.Server/TxMetersService.cs
+++ b/Zeus.Server/TxMetersService.cs
@@ -44,6 +44,31 @@ public sealed class TxMetersService : BackgroundService
     private static readonly TimeSpan MoxTick = TimeSpan.FromMilliseconds(100); // 10 Hz
     private static readonly TimeSpan IdleTick = TimeSpan.FromMilliseconds(500); // 2 Hz
 
+    // PA temperature broadcast cadence: 2 Hz regardless of MOX. Temperature
+    // is a protection signal (HL2 auto-disables TX at 55 °C) and moves on
+    // a seconds timescale, so piggybacking on the 10 Hz MOX tick would be
+    // wasted wire. When MOX is off the outer loop already ticks at 500 ms;
+    // when MOX is on the outer loop ticks at 100 ms and we throttle the
+    // PA broadcast with a last-sent timestamp.
+    private static readonly TimeSpan PaTempTick = TimeSpan.FromMilliseconds(500);
+
+    // MCP9700 / TMP36-style sensor on the HL2 Q6 position. Datasheet:
+    // V_out = 500 mV + 10 mV/°C * T; ADC is 12-bit against a 3.26 V ref.
+    // Derived: tempC = (3.26 * raw / 4096 - 0.5) * 100. See Steve Haynal's
+    // hermes-lite wiki for the board-level mapping and reference voltage.
+    private const double PaTempAdcRefVolts = 3.26;
+    private const int PaTempAdcFullScale = 4096;
+    private const double PaTempSensorOffsetVolts = 0.5;
+    private const double PaTempSensorVoltsPerDegC = 0.01;
+
+    // Clamp range for the conversion output. Below this the sensor is
+    // either unplugged or reading noise floor; above this the reading is
+    // well beyond the HL2 gateware's 55 °C shutdown. Broadcasting a
+    // clamped value keeps the UI from flashing red during boot while a
+    // floating ADC settles.
+    private const float PaTempMinC = -40f;
+    private const float PaTempMaxC = 125f;
+
     private readonly StreamingHub _hub;
     private readonly TxService _tx;
     private readonly DspPipelineService _pipe;
@@ -53,10 +78,18 @@ public sealed class TxMetersService : BackgroundService
     private readonly object _sync = new();
     private double _fwdAdc;
     private double _refAdc;
+    // PA temperature smoothed ADC and first-sample flag — separate from
+    // _seenSample because temperature arrives on a different slot and may
+    // show up before / after the FWD-REF pair on any given packet.
+    private double _paTempAdc;
+    private bool _seenPaTempSample;
     private bool _seenSample;
     // SWR trip state: timestamp when SWR first exceeded threshold, or null if
     // SWR is currently below threshold. Checked on every meter tick (100 ms).
     private DateTime? _swrAboveThresholdSince;
+    // Last time a PaTempFrame was broadcast, so the 10 Hz MOX loop can
+    // throttle itself down to the 2 Hz PA cadence without a separate timer.
+    private DateTime _lastPaTempBroadcastAtUtc = DateTime.MinValue;
 
     public TxMetersService(StreamingHub hub, RadioService radio, TxService tx, DspPipelineService pipe, ILogger<TxMetersService> log)
     {
@@ -75,10 +108,10 @@ public sealed class TxMetersService : BackgroundService
     // TelemetryReceived handler once the Protocol1 surface lands.
     private Zeus.Protocol1.IProtocol1Client? _subscribedClient;
 
-    // HL2 C&C-echo addresses that carry the alex FWD/REF ADCs
-    // (see TelemetryReading docs).
-    // addr=1 (C0=0x08): Ain1 = alex_forward_power
-    // addr=2 (C0=0x10): Ain0 = alex_reverse_power
+    // HL2 C&C-echo addresses that carry the alex FWD/REF ADCs and the PA
+    // temperature (see TelemetryReading docs in Zeus.Protocol1).
+    // addr=1 (C0=0x08): Ain0 = HL2 PA temperature;   Ain1 = alex_forward_power
+    // addr=2 (C0=0x10): Ain0 = alex_reverse_power;   Ain1 = ADC0 bias
     // Match on bits 4:1 only — C0[0] is the PTT/MOX echo (so a live TX packet
     // arrives as 0x09/0x11), and C0[7] is the HL2 IOB ACK
     // marker which PacketParser already filters out via the addr==1|2|3 gate.
@@ -87,9 +120,11 @@ public sealed class TxMetersService : BackgroundService
     private const byte C0AddrAlexRef = 0x10;
 
     /// <summary>
-    /// Entry point for telemetry consumers. FWD and REF live on different
-    /// C&amp;C echo slots (0x08 and 0x10), so one <see cref="Zeus.Protocol1.TelemetryReading"/>
-    /// updates at most one axis per call.
+    /// Entry point for telemetry consumers. FWD+temperature share the 0x08
+    /// slot (Ain1 / Ain0 respectively); REF arrives on 0x10 (Ain0). One
+    /// <see cref="Zeus.Protocol1.TelemetryReading"/> may update multiple axes
+    /// on the 0x08 slot (FWD + temperature) but never more than one slot's
+    /// worth per call — packets carry the echo-slot map, not a combined blob.
     /// </summary>
     public void OnTelemetry(Zeus.Protocol1.TelemetryReading reading)
     {
@@ -97,6 +132,10 @@ public sealed class TxMetersService : BackgroundService
         {
             case C0AddrAlexFwd:
                 ApplySmoothed(ref _fwdAdc, reading.Ain1);
+                // Ain0 on this slot is the HL2 Q6 temperature ADC. Smooth
+                // with the same α as FWD/REF so the UI sees a stable reading
+                // instead of ADC jitter.
+                ApplyPaTempSmoothed(reading.Ain0);
                 break;
             case C0AddrAlexRef:
                 ApplySmoothed(ref _refAdc, reading.Ain0);
@@ -134,6 +173,43 @@ public sealed class TxMetersService : BackgroundService
             }
             state = SmoothAlpha * state + (1.0 - SmoothAlpha) * raw;
         }
+    }
+
+    // Same α as FWD/REF (0.90 / 0.10) so the temperature reading settles at
+    // the same timescale the operator is already used to for protection
+    // signals. Tracked separately from _seenSample because the temperature
+    // arrives on the same slot as FWD but via a different AIN pair; seeding
+    // it on the first sample avoids a ~2 s ramp from zero.
+    internal void ApplyPaTempSmoothed(ushort raw)
+    {
+        lock (_sync)
+        {
+            if (!_seenPaTempSample)
+            {
+                _paTempAdc = raw;
+                _seenPaTempSample = true;
+                return;
+            }
+            _paTempAdc = SmoothAlpha * _paTempAdc + (1.0 - SmoothAlpha) * raw;
+        }
+    }
+
+    /// <summary>
+    /// Convert a raw HL2 Q6-sensor ADC reading to °C, clamped into the
+    /// plausible physical range so a floating ADC or disconnected sensor
+    /// can't trip the UI's 55 °C red zone at boot. Pure function — exposed
+    /// <c>internal</c> for unit tests. Formula derivation:
+    /// MCP9700-class sensor, V_out = 500 mV + 10 mV/°C · T, 12-bit ADC
+    /// against a 3.26 V reference; see the hermes-lite wiki / Steve
+    /// Haynal's HL2 docs for the board-level mapping.
+    /// </summary>
+    internal static float ConvertPaTempAdcToCelsius(double rawAdc)
+    {
+        double volts = rawAdc * PaTempAdcRefVolts / PaTempAdcFullScale;
+        double tempC = (volts - PaTempSensorOffsetVolts) / PaTempSensorVoltsPerDegC;
+        if (tempC < PaTempMinC) tempC = PaTempMinC;
+        if (tempC > PaTempMaxC) tempC = PaTempMaxC;
+        return (float)tempC;
     }
 
     protected override async Task ExecuteAsync(CancellationToken ct)
@@ -189,6 +265,22 @@ public sealed class TxMetersService : BackgroundService
                 }
 
                 _hub.Broadcast(frame);
+
+                // PA temperature broadcast — 2 Hz always, throttled against
+                // wall-clock so the 10 Hz MOX loop emits it every 5th tick
+                // and the 2 Hz idle loop emits it every tick. Suppressed
+                // until at least one telemetry sample has landed; a fresh
+                // client would otherwise see a garbage ADC of 0 mapped to
+                // the -40 °C clamp floor.
+                var nowUtc = DateTime.UtcNow;
+                bool paSeen;
+                double paAdc;
+                lock (_sync) { paSeen = _seenPaTempSample; paAdc = _paTempAdc; }
+                if (paSeen && nowUtc - _lastPaTempBroadcastAtUtc >= PaTempTick)
+                {
+                    _lastPaTempBroadcastAtUtc = nowUtc;
+                    _hub.Broadcast(new PaTempFrame(ConvertPaTempAdcToCelsius(paAdc)));
+                }
 
                 try { await Task.Delay(mox ? MoxTick : IdleTick, ct).ConfigureAwait(false); }
                 catch (OperationCanceledException) { return; }
@@ -334,8 +426,14 @@ public sealed class TxMetersService : BackgroundService
         {
             _fwdAdc = 0;
             _refAdc = 0;
+            _paTempAdc = 0;
+            _seenPaTempSample = false;
             _seenSample = false;
             _swrAboveThresholdSince = null;
         }
+        // Reset the broadcast throttle so the next connection's first
+        // sample fires a PaTempFrame immediately instead of waiting out
+        // the previous session's 500 ms window.
+        _lastPaTempBroadcastAtUtc = DateTime.MinValue;
     }
 }

--- a/Zeus.Server/TxMetersService.cs
+++ b/Zeus.Server/TxMetersService.cs
@@ -28,7 +28,6 @@ public sealed class TxMetersService : BackgroundService
     // and the ratio is meaningless (Thetis does the same in console.cs:25974).
     private const double SwrMinFwdWatts = 2.0;
     private const double SwrMax = 9.0;
-    private const float MicDbfsPlaceholder = -100f;
 
     // PRD FR-6: SWR > 2.5 sustained 500 ms → trip MOX/TUN. Tighter than the
     // original 3.0 threshold; chosen to protect HL2 PA aggressively.
@@ -171,7 +170,7 @@ public sealed class TxMetersService : BackgroundService
                         FwdWatts: (float)fwdW,
                         RefWatts: (float)refW,
                         Swr: (float)swr,
-                        MicDbfs: MicDbfsPlaceholder,
+                        MicDbfs: stage.MicPk,
                         EqPk: stage.EqPk,
                         LvlrPk: stage.LvlrPk,
                         AlcPk: stage.AlcPk,
@@ -197,7 +196,7 @@ public sealed class TxMetersService : BackgroundService
                         FwdWatts: 0f,
                         RefWatts: 0f,
                         Swr: 1.0f,
-                        MicDbfs: MicDbfsPlaceholder,
+                        MicDbfs: silent.MicPk,
                         EqPk: silent.EqPk,
                         LvlrPk: silent.LvlrPk,
                         AlcPk: silent.AlcPk,

--- a/docs/rca/2026-04-21-tx-stage-meters-alc-gr-sign-mic-pk.md
+++ b/docs/rca/2026-04-21-tx-stage-meters-alc-gr-sign-mic-pk.md
@@ -1,0 +1,80 @@
+# RCA: TX Stage Meters — ALC GR sign inversion + MIC_PK not wired
+
+**Date:** 2026-04-21  
+**Branch:** `claude/issue-2-20260421-1826`  
+**Issue:** #2
+
+## Symptoms
+
+1. **ALC GR bar never filled** — the gain-reduction bar in the TX Stage Meters panel
+   showed 0 dB regardless of input level, even when the ALC was visibly compressing
+   the signal.
+
+2. **MIC row missing** — the signal-chain view started at EQ, hiding the post-panel-gain
+   mic level that enters WDSP. Thetis shows `MIC → EQ → LVLR → ALC → ALC-GR → OUT`.
+
+## Root causes
+
+### ALC GR sign inversion
+
+`GetTXAMeter(ch, 14)` returns `TXA_ALC_GAIN`. Per `native/wdsp/meter.c:103`:
+
+```c
+a->result[a->enum_gain] = 20.0 * mlog10(*a->pgain + 1.0e-40);
+```
+
+`pgain` is the linear gain multiplier that the ALC applies. When the ALC is reducing
+the signal, `gain < 1.0`, so `20*log10(gain)` is **negative** (e.g., −6 dB for 6 dB of
+reduction). The raw WDSP value is therefore ≤ 0 dB when active.
+
+`WdspDspEngine.ProcessTxBlock` stored this raw negative value directly:
+```csharp
+AlcGr: (float)alcGain,   // bug: -6.0 stored as "gain reduction"
+```
+
+The frontend `GrRow` component expects a **positive** gain-reduction dB on a 0..20 dB
+scale and clamps with `Math.max(0, ...)`, so a −6 value became 0 — the bar never moved.
+
+**Fix:** negate before storing:
+```csharp
+AlcGr: (float)-alcGain,  // +6.0 = "6 dB of gain reduction"
+```
+
+### MIC_PK not wired
+
+`WdspDspEngine.ProcessTxBlock` already read `TXA_MIC_PK` (index 0) for diagnostic
+logging, but did not include it in the `TxStageMeters` snapshot. `TxMetersService`
+therefore sent a hard-coded `−100f` placeholder in `TxMetersFrame.MicDbfs`, and
+`setMeters` in the frontend intentionally skipped `micDbfs` to avoid clobbering the
+browser-worklet mic level.
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `Zeus.Dsp/TxStageMeters.cs` | Added `MicPk` field; documented `AlcGr` sign convention |
+| `Zeus.Dsp/Wdsp/WdspDspEngine.cs` | Store `MicPk` in snapshot; negate `alcGain` → `AlcGr` |
+| `Zeus.Server/TxMetersService.cs` | Use `stage.MicPk` for `TxMetersFrame.MicDbfs`; removed dead `MicDbfsPlaceholder` |
+| `zeus-web/src/state/tx-store.ts` | Added `wdspMicPk` field; `setMeters` maps `m.micDbfs → wdspMicPk` |
+| `zeus-web/src/components/TxStageMeters.tsx` | Added MIC row at top of chain |
+
+## Meter chain (post-fix)
+
+| Row    | Store field | Source (WDSP index) | Unit  | Notes |
+|--------|-------------|---------------------|-------|-------|
+| MIC    | wdspMicPk   | TXA_MIC_PK (0)      | dBFS  | Post-panel-gain, pre-EQ |
+| EQ     | eqPk        | TXA_EQ_PK (2)       | dBFS  | |
+| LVLR   | lvlrPk      | TXA_LVLR_PK (4)     | dBFS  | Equals EQ when Leveler is off |
+| ALC    | alcPk       | TXA_ALC_PK (12)     | dBFS  | Key SSB clipping indicator |
+| ALC GR | alcGr       | −TXA_ALC_GAIN (14)  | dB    | Positive; >12 dB = over-driving |
+| OUT    | outPk       | TXA_OUT_PK (15)     | dBFS  | Final TX peak before EP2 packer |
+
+Note: `micDbfs` in `TxState` remains worklet-driven (pre-WDSP, animates during RX).
+`wdspMicPk` is server-driven (post-panel-gain, −∞ when MOX off).
+
+## What was NOT changed
+
+- `Zeus.Contracts/TxMetersFrame.cs` — wire format unchanged (red-light per CLAUDE.md).
+  `MicDbfs` field now carries real WDSP data instead of the placeholder.
+- `Zeus.Protocol1` and `Zeus.Dsp` initialization order — no changes.
+- No new NuGet or npm dependencies.

--- a/tests/Zeus.Contracts.Tests/PaTempFrameTests.cs
+++ b/tests/Zeus.Contracts.Tests/PaTempFrameTests.cs
@@ -1,0 +1,62 @@
+using System.Buffers;
+using Zeus.Contracts;
+using Xunit;
+
+namespace Zeus.Contracts.Tests;
+
+public class PaTempFrameTests
+{
+    [Fact]
+    public void RoundTrip_PreservesTempC()
+    {
+        var frame = new PaTempFrame(47.25f);
+
+        var writer = new ArrayBufferWriter<byte>();
+        frame.Serialize(writer);
+
+        Assert.Equal(PaTempFrame.ByteLength, writer.WrittenCount);
+        Assert.Equal(5, writer.WrittenCount);
+
+        var bytes = writer.WrittenSpan;
+        Assert.Equal((byte)MsgType.PaTemp, bytes[0]);
+
+        var decoded = PaTempFrame.Deserialize(bytes);
+        Assert.Equal(frame.TempC, decoded.TempC);
+    }
+
+    [Fact]
+    public void Deserialize_RejectsWrongMsgType()
+    {
+        var bogus = new byte[PaTempFrame.ByteLength];
+        bogus[0] = (byte)MsgType.TxMetersV2; // 0x16, not 0x17
+        Assert.Throws<InvalidDataException>(() => PaTempFrame.Deserialize(bogus));
+    }
+
+    [Fact]
+    public void Deserialize_RejectsTruncated()
+    {
+        var buf = new byte[PaTempFrame.ByteLength - 1];
+        buf[0] = (byte)MsgType.PaTemp;
+        Assert.Throws<InvalidDataException>(() => PaTempFrame.Deserialize(buf));
+    }
+
+    [Fact]
+    public void Serialize_WritesLittleEndian()
+    {
+        // 1.0 f32 LE = 0x00 0x00 0x80 0x3F
+        var frame = new PaTempFrame(1.0f);
+        var writer = new ArrayBufferWriter<byte>();
+        frame.Serialize(writer);
+        var bytes = writer.WrittenSpan;
+        Assert.Equal(0x00, bytes[1]);
+        Assert.Equal(0x00, bytes[2]);
+        Assert.Equal(0x80, bytes[3]);
+        Assert.Equal(0x3F, bytes[4]);
+    }
+
+    [Fact]
+    public void ByteLength_Is5()
+    {
+        Assert.Equal(5, PaTempFrame.ByteLength);
+    }
+}

--- a/tests/Zeus.Contracts.Tests/TxMetersV2FrameTests.cs
+++ b/tests/Zeus.Contracts.Tests/TxMetersV2FrameTests.cs
@@ -1,0 +1,112 @@
+using System.Buffers;
+using Zeus.Contracts;
+using Xunit;
+
+namespace Zeus.Contracts.Tests;
+
+public class TxMetersV2FrameTests
+{
+    [Fact]
+    public void RoundTrip_PreservesAllFields()
+    {
+        var frame = new TxMetersV2Frame(
+            FwdWatts: 4.75f,
+            RefWatts: 0.08f,
+            Swr: 1.32f,
+            MicPk: -20.1f,
+            MicAv: -23.5f,
+            EqPk: -18.2f,
+            EqAv: -21.4f,
+            LvlrPk: -12.1f,
+            LvlrAv: -14.8f,
+            LvlrGr: 2.1f,
+            CfcPk: -9.0f,
+            CfcAv: -11.0f,
+            CfcGr: 1.5f,
+            CompPk: -7.5f,
+            CompAv: -10.2f,
+            AlcPk: -6.0f,
+            AlcAv: -8.1f,
+            AlcGr: 3.5f,
+            OutPk: -2.0f,
+            OutAv: -4.3f);
+
+        var writer = new ArrayBufferWriter<byte>();
+        frame.Serialize(writer);
+
+        Assert.Equal(TxMetersV2Frame.ByteLength, writer.WrittenCount);
+        Assert.Equal(81, writer.WrittenCount);
+
+        var bytes = writer.WrittenSpan;
+        Assert.Equal((byte)MsgType.TxMetersV2, bytes[0]);
+
+        var decoded = TxMetersV2Frame.Deserialize(bytes);
+        Assert.Equal(frame.FwdWatts, decoded.FwdWatts);
+        Assert.Equal(frame.RefWatts, decoded.RefWatts);
+        Assert.Equal(frame.Swr, decoded.Swr);
+        Assert.Equal(frame.MicPk, decoded.MicPk);
+        Assert.Equal(frame.MicAv, decoded.MicAv);
+        Assert.Equal(frame.EqPk, decoded.EqPk);
+        Assert.Equal(frame.EqAv, decoded.EqAv);
+        Assert.Equal(frame.LvlrPk, decoded.LvlrPk);
+        Assert.Equal(frame.LvlrAv, decoded.LvlrAv);
+        Assert.Equal(frame.LvlrGr, decoded.LvlrGr);
+        Assert.Equal(frame.CfcPk, decoded.CfcPk);
+        Assert.Equal(frame.CfcAv, decoded.CfcAv);
+        Assert.Equal(frame.CfcGr, decoded.CfcGr);
+        Assert.Equal(frame.CompPk, decoded.CompPk);
+        Assert.Equal(frame.CompAv, decoded.CompAv);
+        Assert.Equal(frame.AlcPk, decoded.AlcPk);
+        Assert.Equal(frame.AlcAv, decoded.AlcAv);
+        Assert.Equal(frame.AlcGr, decoded.AlcGr);
+        Assert.Equal(frame.OutPk, decoded.OutPk);
+        Assert.Equal(frame.OutAv, decoded.OutAv);
+    }
+
+    [Fact]
+    public void Deserialize_RejectsWrongMsgType()
+    {
+        var bogus = new byte[TxMetersV2Frame.ByteLength];
+        bogus[0] = (byte)MsgType.TxMeters; // 0x11, not 0x16 — should be rejected
+        Assert.Throws<InvalidDataException>(() => TxMetersV2Frame.Deserialize(bogus));
+    }
+
+    [Fact]
+    public void Deserialize_RejectsTruncated()
+    {
+        var buf = new byte[TxMetersV2Frame.ByteLength - 1];
+        buf[0] = (byte)MsgType.TxMetersV2;
+        Assert.Throws<InvalidDataException>(() => TxMetersV2Frame.Deserialize(buf));
+    }
+
+    [Fact]
+    public void Serialize_WritesLittleEndian()
+    {
+        // 1.0 f32 LE = 0x00 0x00 0x80 0x3F — first float slot (FwdWatts)
+        // lives at bytes 1..4.
+        var frame = new TxMetersV2Frame(
+            FwdWatts: 1.0f, RefWatts: 0f, Swr: 0f,
+            MicPk: 0f, MicAv: 0f, EqPk: 0f, EqAv: 0f,
+            LvlrPk: 0f, LvlrAv: 0f, LvlrGr: 0f,
+            CfcPk: 0f, CfcAv: 0f, CfcGr: 0f,
+            CompPk: 0f, CompAv: 0f,
+            AlcPk: 0f, AlcAv: 0f, AlcGr: 0f,
+            OutPk: 0f, OutAv: 0f);
+        var writer = new ArrayBufferWriter<byte>();
+        frame.Serialize(writer);
+        var bytes = writer.WrittenSpan;
+        Assert.Equal(0x00, bytes[1]);
+        Assert.Equal(0x00, bytes[2]);
+        Assert.Equal(0x80, bytes[3]);
+        Assert.Equal(0x3F, bytes[4]);
+    }
+
+    [Fact]
+    public void ByteLength_Is81()
+    {
+        // Sanity check so a future field insertion without updating
+        // ByteLength fails the test suite immediately: 1 type byte +
+        // 20 × f32 = 81 bytes.
+        Assert.Equal(81, TxMetersV2Frame.ByteLength);
+    }
+}

--- a/tests/Zeus.Dsp.Tests/WdspDspEngineTests.cs
+++ b/tests/Zeus.Dsp.Tests/WdspDspEngineTests.cs
@@ -656,8 +656,18 @@ public class WdspDspEngineTests
             var mic = new float[block];
             var iq = new float[2 * block];
 
-            // Build a synthetic mic block: 1 kHz tone at amplitude 0.1
-            const double Amplitude = 0.1;
+            // Build a synthetic mic block: 1 kHz tone at amplitude 0.01.
+            //
+            // Input amplitude is kept ≤ 0.05 so both the 1x and 10x cases
+            // stay below the Leveler's compression knee (WDSP defaults:
+            // out_targ = 1.05, max_gain = 1.778 — see TXA.c:169,173).
+            // Testing panel-gain linearity above that point would be
+            // testing the Leveler, not the gain. The Leveler is on by
+            // default to match Thetis (radio.cs:3018 tx_leveler_on = true),
+            // so this amplitude choice is tied to that default — if the
+            // Leveler default ever flips off, the amplitude can be raised
+            // back to 0.1 without loss of meaning.
+            const double Amplitude = 0.01;
             const double ToneHz = 1000.0;
             const int SampleRate = 48_000;
             for (int n = 0; n < block; n++)
@@ -674,7 +684,11 @@ public class WdspDspEngineTests
             // Measure RMS of IQ output at gain=1.0
             double rms1 = ComputeRms(iq);
 
-            // Now set gain to 10.0 (20 dB) and process again
+            // Now set gain to 10.0 (20 dB) and process again. With
+            // Amplitude = 0.01, the 10x intermediate signal peaks near 0.1,
+            // well under the Leveler's out_targ of 1.05, so the Leveler
+            // stays in unity-gain pass-through and the ratio reflects
+            // panel-gain alone.
             engine.SetTxPanelGain(10.0);
             for (int k = 0; k < 16; k++)
                 engine.ProcessTxBlock(mic, iq);

--- a/tests/Zeus.Server.Tests/LevelerMaxGainEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/LevelerMaxGainEndpointTests.cs
@@ -1,0 +1,118 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Zeus.Contracts;
+using Zeus.Dsp;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// End-to-end endpoint test for <c>POST /api/tx/leveler-max-gain</c>: drives
+/// the real handler via <see cref="WebApplicationFactory{TEntryPoint}"/>,
+/// asserting a JSON <c>{gain}</c> body reaches
+/// <see cref="IDspEngine.SetTxLevelerMaxGain"/> on the current engine, and
+/// that out-of-range values are rejected with a 400.
+///
+/// Frontend re-POSTs this on every slider move and on WS reconnect (task
+/// #19), so the handler's range check is the only thing between a rogue
+/// client and WDSP's Leveler ceiling.
+/// </summary>
+public class LevelerMaxGainEndpointTests : IClassFixture<LevelerMaxGainEndpointTests.Factory>
+{
+    private readonly Factory _factory;
+    public LevelerMaxGainEndpointTests(Factory factory) => _factory = factory;
+
+    [Theory]
+    [InlineData(0.0)]   // band floor
+    [InlineData(5.0)]   // W1AEX / softerhardware default
+    [InlineData(15.0)]  // band ceiling (Thetis stock)
+    public async Task PostInRange_CallsEngineWithSameValue(double gain)
+    {
+        _factory.TestEngine.LevelerMaxGainCalls.Clear();
+        using var client = _factory.CreateClient();
+
+        var resp = await client.PostAsJsonAsync("/api/tx/leveler-max-gain", new { gain });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var call = Assert.Single(_factory.TestEngine.LevelerMaxGainCalls);
+        Assert.Equal(gain, call, precision: 6);
+    }
+
+    [Theory]
+    [InlineData(-0.1)]
+    [InlineData(15.1)]
+    public async Task PostOutOfRange_Returns400_AndDoesNotCallEngine(double gain)
+    {
+        _factory.TestEngine.LevelerMaxGainCalls.Clear();
+        using var client = _factory.CreateClient();
+
+        var resp = await client.PostAsJsonAsync("/api/tx/leveler-max-gain", new { gain });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        Assert.Empty(_factory.TestEngine.LevelerMaxGainCalls);
+    }
+
+    [Fact]
+    public async Task PostNaN_Returns400_AndDoesNotCallEngine()
+    {
+        // System.Text.Json refuses to serialize NaN via PostAsJsonAsync, so
+        // simulate a rogue client sending the JavaScript literal `NaN` by
+        // posting raw string content. The server's guard
+        // (double.IsNaN(req.Gain)) is defensive belt-and-braces against a
+        // deserializer that later enables AllowNamedFloatingPointLiterals —
+        // the test pins the rejection shape in place now.
+        _factory.TestEngine.LevelerMaxGainCalls.Clear();
+        using var client = _factory.CreateClient();
+        using var content = new StringContent(
+            "{\"gain\":NaN}", Encoding.UTF8, "application/json");
+
+        var resp = await client.PostAsync("/api/tx/leveler-max-gain", content);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        Assert.Empty(_factory.TestEngine.LevelerMaxGainCalls);
+    }
+
+    public sealed class Factory : WebApplicationFactory<Program>
+    {
+        public MicGainEndpointTests.StubEngine TestEngine { get; } = new();
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Test");
+            builder.ConfigureServices(services =>
+            {
+                // Strip every IHostedService so the real DspPipelineService /
+                // TxMetersService / TxAudioIngestStartup / TxTuneDriver never
+                // spin up — we're only testing the HTTP handler.
+                services.RemoveAll<IHostedService>();
+
+                // Swap the DspPipelineService singleton for a stubbed
+                // subclass whose CurrentEngine is our recording stub.
+                services.RemoveAll<DspPipelineService>();
+                services.AddSingleton<DspPipelineService>(sp =>
+                    new TestPipeline(
+                        sp.GetRequiredService<RadioService>(),
+                        sp.GetRequiredService<StreamingHub>(),
+                        sp.GetRequiredService<ILoggerFactory>(),
+                        TestEngine));
+            });
+        }
+
+        // Non-hosted subclass used only in tests. Mirrors
+        // MicGainEndpointTests.TestPipeline so the stub drives CurrentEngine
+        // while the base class's ExecuteAsync stays dormant.
+        private sealed class TestPipeline(
+            RadioService radio,
+            StreamingHub hub,
+            ILoggerFactory logs,
+            MicGainEndpointTests.StubEngine engine) : DspPipelineService(radio, hub, logs)
+        {
+            public override IDspEngine CurrentEngine => engine;
+        }
+    }
+}

--- a/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
@@ -100,13 +100,16 @@ public class MicGainEndpointTests : IClassFixture<MicGainEndpointTests.Factory>
         }
     }
 
-    // Minimal IDspEngine that records SetTxPanelGain calls for assertion.
-    // All other members are safe no-ops because the endpoint never calls them.
+    // Minimal IDspEngine that records SetTxPanelGain and SetTxLevelerMaxGain
+    // calls for assertion. All other members are safe no-ops because the
+    // endpoints under test never call them.
     public sealed class StubEngine : IDspEngine
     {
         public List<double> GainCalls { get; } = new();
+        public List<double> LevelerMaxGainCalls { get; } = new();
 
         public void SetTxPanelGain(double linearGain) => GainCalls.Add(linearGain);
+        public void SetTxLevelerMaxGain(double maxGainDb) => LevelerMaxGainCalls.Add(maxGainDb);
 
         public int TxBlockSamples => 1024;
         public int OpenChannel(int sampleRateHz, int pixelWidth) => 0;

--- a/tests/Zeus.Server.Tests/PaTempConversionTests.cs
+++ b/tests/Zeus.Server.Tests/PaTempConversionTests.cs
@@ -1,0 +1,73 @@
+using Zeus.Server;
+using Xunit;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Sanity-check the HL2 PA-temperature ADC → °C conversion (MCP9700-class
+/// sensor) and the protective clamp around it. The numeric reference points
+/// come from HL2 community operator data cited in task P2.4:
+///   idle 30 °C, 1 W ~44 °C, 5 W ~47-51 °C, gateware trip at 55 °C.
+/// Formula: tempC = (3.26 * raw / 4096 - 0.5) * 100 — see
+/// <c>TxMetersService.ConvertPaTempAdcToCelsius</c> for provenance.
+/// </summary>
+public class PaTempConversionTests
+{
+    // Invert the formula to build raw ADC values that should decode to a
+    // known °C: raw = (tempC / 100 + 0.5) * 4096 / 3.26
+    private static int RawForTempC(double tempC)
+        => (int)Math.Round((tempC / 100.0 + 0.5) * 4096.0 / 3.26);
+
+    [Theory]
+    [InlineData(30.0)]  // idle
+    [InlineData(44.0)]  // 1 W
+    [InlineData(51.0)]  // 5 W
+    [InlineData(55.0)]  // HL2 gateware trip threshold
+    public void Convert_CommunityReferencePoints_RoundTripWithinTolerance(double expectedC)
+    {
+        int raw = RawForTempC(expectedC);
+        float actualC = TxMetersService.ConvertPaTempAdcToCelsius(raw);
+
+        // Half-degree tolerance — the ADC quantization is ~0.08 °C per LSB
+        // at 3.26 V ref, so round-trip drift stays well within ±0.1 °C.
+        Assert.InRange(actualC, expectedC - 0.5, expectedC + 0.5);
+    }
+
+    [Fact]
+    public void Convert_ZeroAdc_ClampsToFloor()
+    {
+        // A raw reading of 0 decodes mathematically to -50 °C; clamp pins
+        // it to -40 so the UI never shows a physically-impossible value
+        // on a floating-ADC boot.
+        Assert.Equal(-40f, TxMetersService.ConvertPaTempAdcToCelsius(0));
+    }
+
+    [Fact]
+    public void Convert_MaxAdc_ClampsToCeiling()
+    {
+        // Full-scale ADC (4095) decodes to ~275 °C; clamp pins it to
+        // 125 °C so a disconnected sensor can't light the 55 °C red
+        // zone with a wild value.
+        Assert.Equal(125f, TxMetersService.ConvertPaTempAdcToCelsius(4095));
+    }
+
+    [Fact]
+    public void Convert_Monotonic_Between_ClampedReference_Points()
+    {
+        // Across the operating band (idle → trip) the conversion must be
+        // strictly monotonic: a hotter ADC reading must yield a hotter °C.
+        int rawIdle = RawForTempC(30);
+        int raw1w = RawForTempC(44);
+        int raw5w = RawForTempC(51);
+        int rawTrip = RawForTempC(55);
+
+        float cIdle = TxMetersService.ConvertPaTempAdcToCelsius(rawIdle);
+        float c1w = TxMetersService.ConvertPaTempAdcToCelsius(raw1w);
+        float c5w = TxMetersService.ConvertPaTempAdcToCelsius(raw5w);
+        float cTrip = TxMetersService.ConvertPaTempAdcToCelsius(rawTrip);
+
+        Assert.True(cIdle < c1w);
+        Assert.True(c1w < c5w);
+        Assert.True(c5w < cTrip);
+    }
+}

--- a/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
+++ b/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
@@ -51,6 +51,7 @@ public class TxAudioIngestTests
         public double GetRxaSignalDbm(int channelId) => -140.0;
         public void SetTxMode(RxMode mode) { }
         public void SetTxPanelGain(double linearGain) { }
+        public void SetTxLevelerMaxGain(double maxGainDb) { }
         public void SetTxTune(bool on) { }
         public TxStageMeters GetTxStageMeters() => TxStageMeters.Silent;
         public void Dispose() { }

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -12,6 +12,7 @@ import { MobilePttButton } from './components/MobilePttButton';
 import { ModeBandwidth } from './components/ModeBandwidth';
 import { MoxButton } from './components/MoxButton';
 import { Panadapter } from './components/Panadapter';
+import { PaTempChip } from './components/PaTempChip';
 import { PreampButton } from './components/PreampButton';
 import { QrzStatusPill } from './components/QrzStatusPill';
 import { RotatorStatusPill } from './components/RotatorStatusPill';
@@ -760,6 +761,7 @@ export default function App() {
         <button type="button" className="btn ghost hide-mobile">RIT</button>
         <button type="button" className="btn ghost hide-mobile">SAVE MEM</button>
         <div className="spacer" style={{ flex: 1 }} />
+        <PaTempChip />
         <div className="chip hide-mobile">
           <span className="k">LINK</span>
           <span className="v mono">{connected ? 'UP' : 'DOWN'}</span>

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -16,7 +16,7 @@ import { PreampButton } from './components/PreampButton';
 import { QrzStatusPill } from './components/QrzStatusPill';
 import { RotatorStatusPill } from './components/RotatorStatusPill';
 import { SMeterLive } from './components/SMeterLive';
-import { TxStageMeters } from './components/TxStageMeters';
+import { OverdriveIndicator, TxStageMeters } from './components/TxStageMeters';
 import { TunButton } from './components/TunButton';
 import { VfoDisplay } from './components/VfoDisplay';
 import { Waterfall } from './components/Waterfall';
@@ -732,7 +732,11 @@ export default function App() {
             </Dockable>
           </div>
           <div className="bottom-slot hide-mobile">
-            <Dockable title="TX Stage Meters" ledOn={moxOn || tunOn}>
+            <Dockable
+              title="TX Stage Meters"
+              ledOn={moxOn || tunOn}
+              actions={<OverdriveIndicator />}
+            >
               <TxStageMeters />
             </Dockable>
           </div>

--- a/zeus-web/src/api/client.test.ts
+++ b/zeus-web/src/api/client.test.ts
@@ -12,6 +12,7 @@ import {
   setAgcTop,
   setAttenuator,
   setAutoAtt,
+  setLevelerMaxGain,
   setMicGain,
   setMode,
   setNr,
@@ -395,6 +396,46 @@ describe('POST helpers', () => {
       ),
     );
     await expect(setMicGain(99)).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 400,
+    });
+  });
+
+  it('setLevelerMaxGain posts { gain } to /api/tx/leveler-max-gain and returns echoed value', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonResponse({ levelerMaxGainDb: 7.5 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(setLevelerMaxGain(7.5)).resolves.toEqual({
+      levelerMaxGainDb: 7.5,
+    });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('/api/tx/leveler-max-gain');
+    expect(init?.method).toBe('POST');
+    expect(JSON.parse((init?.body ?? '') as string)).toEqual({ gain: 7.5 });
+  });
+
+  it('setLevelerMaxGain treats 404 as accepted (backend not landed yet)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn<typeof fetch>().mockResolvedValue(
+        new Response('Not Found', { status: 404, statusText: 'Not Found' }),
+      ),
+    );
+    await expect(setLevelerMaxGain(5)).resolves.toEqual({
+      levelerMaxGainDb: 5,
+    });
+  });
+
+  it('setLevelerMaxGain rethrows non-404 errors so the slider can roll back', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn<typeof fetch>().mockResolvedValue(
+        jsonResponse({ error: 'gain out of range' }, 400),
+      ),
+    );
+    await expect(setLevelerMaxGain(99)).rejects.toMatchObject({
       name: 'ApiError',
       status: 400,
     });

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -592,6 +592,41 @@ export function saveBandMemory(
   );
 }
 
+// Leveler max-gain endpoint: POST /api/tx/leveler-max-gain { gain }. Returns
+// { levelerMaxGainDb }. Backend clamps to [0, 15] and echoes the applied
+// value; stateless across backend restart, so ConnectPanel re-POSTs the
+// persisted value when the connection comes up. Same 404-tolerant pattern as
+// setMicGain for the frontend-ahead-of-backend window.
+export async function setLevelerMaxGain(
+  gain: number,
+  signal?: AbortSignal,
+): Promise<{ levelerMaxGainDb: number }> {
+  try {
+    return await jsonFetch(
+      '/api/tx/leveler-max-gain',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ gain }),
+        signal,
+      },
+      (raw) => {
+        const v = (raw as { levelerMaxGainDb?: unknown }).levelerMaxGainDb;
+        return { levelerMaxGainDb: typeof v === 'number' ? v : gain };
+      },
+    );
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) {
+      warnOnce(
+        'tx-leveler-max-gain-404',
+        'POST /api/tx/leveler-max-gain not implemented yet — treating as accepted',
+      );
+      return { levelerMaxGainDb: gain };
+    }
+    throw err;
+  }
+}
+
 // Mic-gain endpoint: POST /api/mic-gain { db }. Returns { micGainDb }.
 // Backend may not have landed the handler yet — a 404 is downgraded to a
 // silent warnOnce so the console doesn't fill with noise during the

--- a/zeus-web/src/components/ConnectPanel.tsx
+++ b/zeus-web/src/components/ConnectPanel.tsx
@@ -5,6 +5,7 @@ import {
   fetchRadios,
   fetchState,
   setDrive,
+  setLevelerMaxGain,
   setMicGain,
   type RadioInfoDto,
 } from '../api/client';
@@ -138,6 +139,10 @@ export function ConnectPanel() {
         const tx = useTxStore.getState();
         void setDrive(tx.drivePercent).catch(() => {});
         void setMicGain(tx.micGainDb).catch(() => {});
+        // Leveler max-gain is stateless across backend restart; re-POST the
+        // persisted value so the radio uses our preference instead of the
+        // server default (+5 dB).
+        void setLevelerMaxGain(tx.levelerMaxGainDb).catch(() => {});
       } catch (err) {
         setError(errorMessage(err));
       } finally {

--- a/zeus-web/src/components/DspPanel.tsx
+++ b/zeus-web/src/components/DspPanel.tsx
@@ -1,12 +1,28 @@
 import { useCallback, useEffect, useRef } from 'react';
 import {
+  setLevelerMaxGain,
   setNr,
   type NbMode,
   type NrConfigDto,
   type NrMode,
 } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import { useTxStore } from '../state/tx-store';
 import { Slider } from './design/Slider';
+
+// Leveler max-gain slider bounds — matches backend clamp and the HL2
+// community-recommended range. 0.5 dB steps give a useful resolution
+// without flooding the POST endpoint.
+const LVLR_MIN_DB = 0;
+const LVLR_MAX_DB = 15;
+const LVLR_STEP_DB = 0.5;
+const LVLR_DEBOUNCE_MS = 100;
+
+function quantizeLvlr(v: number): number {
+  const snapped = Math.round(v / LVLR_STEP_DB) * LVLR_STEP_DB;
+  // JS float artefacts: round to 1 decimal so "5.0" stays "5.0".
+  return Math.round(snapped * 10) / 10;
+}
 
 // Mirrors NrControls.tsx — cycle order matches Thetis WDSP semantics. ANR
 // and EMNR are mutually exclusive in WDSP so both ride the single nrMode.
@@ -30,8 +46,59 @@ export function DspPanel() {
   const applyState = useConnectionStore((s) => s.applyState);
   const connected = useConnectionStore((s) => s.status === 'Connected');
 
+  const levelerMaxGainDb = useTxStore((s) => s.levelerMaxGainDb);
+  const setLevelerMaxGainDb = useTxStore((s) => s.setLevelerMaxGainDb);
+
   const inflightAbort = useRef<AbortController | null>(null);
-  useEffect(() => () => inflightAbort.current?.abort(), []);
+  const lvlrInflight = useRef<AbortController | null>(null);
+  const lvlrDebounce = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lvlrLastSent = useRef<number>(levelerMaxGainDb);
+  const lvlrPrevOnError = useRef<number>(levelerMaxGainDb);
+  useEffect(
+    () => () => {
+      inflightAbort.current?.abort();
+      lvlrInflight.current?.abort();
+      if (lvlrDebounce.current != null) clearTimeout(lvlrDebounce.current);
+    },
+    [],
+  );
+
+  const sendLvlrDebounced = useCallback(
+    (v: number) => {
+      if (lvlrDebounce.current != null) clearTimeout(lvlrDebounce.current);
+      lvlrDebounce.current = setTimeout(() => {
+        if (v === lvlrLastSent.current) return;
+        lvlrInflight.current?.abort();
+        const ac = new AbortController();
+        lvlrInflight.current = ac;
+        const prevValue = lvlrLastSent.current;
+        lvlrLastSent.current = v;
+        lvlrPrevOnError.current = prevValue;
+        setLevelerMaxGain(v, ac.signal)
+          .then((r) => {
+            if (ac.signal.aborted) return;
+            if (r.levelerMaxGainDb !== v) setLevelerMaxGainDb(r.levelerMaxGainDb);
+          })
+          .catch((err) => {
+            if (ac.signal.aborted) return;
+            if (err instanceof DOMException && err.name === 'AbortError') return;
+            // Roll back the optimistic store update on non-abort failures.
+            setLevelerMaxGainDb(lvlrPrevOnError.current);
+            lvlrLastSent.current = lvlrPrevOnError.current;
+          });
+      }, LVLR_DEBOUNCE_MS);
+    },
+    [setLevelerMaxGainDb],
+  );
+
+  const onLvlrChange = useCallback(
+    (v: number) => {
+      const q = quantizeLvlr(v);
+      setLevelerMaxGainDb(q);
+      sendLvlrDebounced(q);
+    },
+    [setLevelerMaxGainDb, sendLvlrDebounced],
+  );
 
   const send = useCallback(
     (next: NrConfigDto) => {
@@ -151,6 +218,20 @@ export function DspPanel() {
         >
           NBP
         </button>
+      </div>
+      <div
+        className="dsp-row"
+        title="How much the Leveler can boost quiet speech. +5 dB is the community-recommended starting point. Higher = more aggressive voice leveling, but can push ALC into limiting."
+      >
+        <Slider
+          label="Leveler Max Gain"
+          value={levelerMaxGainDb}
+          onChange={onLvlrChange}
+          min={LVLR_MIN_DB}
+          max={LVLR_MAX_DB}
+          formatValue={(v) => `+${v.toFixed(1)} dB`}
+          disabled={!connected}
+        />
       </div>
     </div>
   );

--- a/zeus-web/src/components/PaTempChip.tsx
+++ b/zeus-web/src/components/PaTempChip.tsx
@@ -1,0 +1,55 @@
+import { useTxStore } from '../state/tx-store';
+
+// HL2 PA temperature chip for the transport bar.
+//
+// Source: MsgType 0x17 (PaTempFrame) at 2 Hz, already clamped server-side to
+// [-40, 125] °C. The HL2 Q6 sensor drives the gateware auto-shutdown at 55 °C,
+// so the operator needs a quick at-a-glance read with headroom warning:
+//   < 50 °C         — normal      (default chip color)
+//   50 ≤ t < 55 °C  — warning     (amber — var(--orange))
+//   ≥ 55 °C         — danger      (red   — var(--tx))
+//
+// Format matches the task spec: one decimal below 50 °C (precision matters
+// at low temps), integer at/above 50 °C (visual clarity in the warning band).
+// Null reading (no sample yet / disconnected) renders em-dash.
+
+const WARN_C = 50;
+const DANGER_C = 55;
+
+function formatTempC(c: number): string {
+  return c >= WARN_C ? `${Math.round(c)}` : c.toFixed(1);
+}
+
+export function PaTempChip() {
+  const paTempC = useTxStore((s) => s.paTempC);
+  const hasReading = paTempC !== null && Number.isFinite(paTempC);
+  const danger = hasReading && paTempC >= DANGER_C;
+  const warn = hasReading && !danger && paTempC >= WARN_C;
+  const valueColor = danger
+    ? 'var(--tx)'
+    : warn
+      ? 'var(--orange)'
+      : 'var(--fg-0)';
+  const display = hasReading ? `${formatTempC(paTempC)} °C` : '— °C';
+  return (
+    <div
+      className="chip hide-mobile"
+      title="HL2 PA temperature (Q6 sensor). 55 °C auto-shutdown threshold."
+      aria-label={hasReading ? `PA temperature ${display}` : 'PA temperature no reading'}
+      style={
+        danger
+          ? {
+              // Subtle red glow on shutdown-imminent; no new hue introduced,
+              // just the existing --tx-soft token used elsewhere for TX chrome.
+              boxShadow: '0 0 6px var(--tx-soft)',
+            }
+          : undefined
+      }
+    >
+      <span className="k">PA TEMP</span>
+      <span className="v mono" style={{ color: valueColor }}>
+        {display}
+      </span>
+    </div>
+  );
+}

--- a/zeus-web/src/components/TxStageMeters.tsx
+++ b/zeus-web/src/components/TxStageMeters.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { useTxStore } from '../state/tx-store';
 
 // Per-stage TX meter panel. Replaces the Memory-channels placeholder in the
@@ -31,6 +32,31 @@ function isBypassed(dbfs: number): boolean {
   return dbfs <= BYPASSED_DBFS_THRESHOLD;
 }
 
+// Thetis convention (MeterManager.cs: attack 0.8, decay 0.1, ~2 s visible
+// history): the held peak decays 30 dB/sec, i.e. a peak at 0 dB drops off
+// the −60 dBFS axis over ~2 seconds. The hook tracks the running max in a
+// ref so the decay stays continuous across renders, using wall-clock time
+// for dt rather than frame count (the component re-renders at the 10 Hz WS
+// tick, giving ~3 dB steps — visually smooth enough for a 60 dB range).
+// Returns −Infinity while current is non-finite or ≤ the bypass sentinel.
+const PEAK_DECAY_DB_PER_SEC = 30;
+
+function usePeakHold(current: number, decayDbPerSec = PEAK_DECAY_DB_PER_SEC): number {
+  const state = useRef<{ db: number; ts: number }>({ db: -Infinity, ts: 0 });
+  if (!isFinite(current) || isBypassed(current)) {
+    state.current = { db: -Infinity, ts: 0 };
+    return -Infinity;
+  }
+  const now =
+    typeof performance !== 'undefined' ? performance.now() : Date.now();
+  const prev = state.current;
+  const dt = prev.ts === 0 ? 0 : Math.max(0, (now - prev.ts) / 1000);
+  const decayed = isFinite(prev.db) ? prev.db - decayDbPerSec * dt : -Infinity;
+  const held = Math.max(current, decayed);
+  state.current = { db: held, ts: now };
+  return held;
+}
+
 // Convert a dBFS reading (≤ 0) to the 0..max axis the Meter primitive wants.
 // -60 dBFS → 0, 0 dBFS → 60.
 function dbfsToAxis(dbfs: number): number {
@@ -48,6 +74,9 @@ type LevelRowProps = {
 function LevelRow({ label, dbfs, hint }: LevelRowProps) {
   const bypassed = isBypassed(dbfs);
   const axis = dbfsToAxis(dbfs);
+  const held = usePeakHold(dbfs);
+  const heldAxis = dbfsToAxis(held);
+  const heldVisible = isFinite(held) && !isBypassed(held) && heldAxis > axis;
   const display = !isFinite(dbfs) || bypassed ? '—' : dbfs.toFixed(0);
   const rowTitle = bypassed ? `${hint} (stage bypassed)` : hint;
   return (
@@ -70,6 +99,23 @@ function LevelRow({ label, dbfs, hint }: LevelRowProps) {
                 : undefined,
           }}
         />
+        {heldVisible && (
+          // 2 px tick at the held peak — amber (#FFA028) @ 0.4 alpha, no new
+          // hue introduced. Decays 30 dB/sec per Thetis convention.
+          <div
+            className="meter-peak-hold"
+            aria-hidden="true"
+            style={{
+              position: 'absolute',
+              left: `calc(${(heldAxis / LEVEL_RANGE_DB) * 100}% - 1px)`,
+              top: 0,
+              bottom: 0,
+              width: 2,
+              background: 'rgba(255, 160, 40, 0.4)',
+              pointerEvents: 'none',
+            }}
+          />
+        )}
         <div className="meter-ticks">
           {[0.25, 0.5, 0.75].map((t) => (
             <div key={t} className="meter-tick" style={{ left: `${t * 100}%` }} />
@@ -90,6 +136,11 @@ function GrRow({ db, hint }: { db: number; hint: string }) {
   // a meaningless readout.
   const bypassed = isBypassed(db);
   const clamped = bypassed ? 0 : Math.max(0, Math.min(GR_MAX_DB, db));
+  // GR axis is 20 dB wide; scale decay so full-range takes ~2 s.
+  const held = usePeakHold(db, GR_MAX_DB / 2);
+  const heldClamped = Math.max(0, Math.min(GR_MAX_DB, held));
+  const heldVisible =
+    isFinite(held) && !isBypassed(held) && heldClamped > clamped;
   const display =
     !isFinite(db) || bypassed ? '—' : db === 0 ? '0' : db.toFixed(1);
   const rowTitle = bypassed ? `${hint} (stage bypassed)` : hint;
@@ -113,6 +164,21 @@ function GrRow({ db, hint }: { db: number; hint: string }) {
                 : undefined,
           }}
         />
+        {heldVisible && (
+          <div
+            className="meter-peak-hold"
+            aria-hidden="true"
+            style={{
+              position: 'absolute',
+              left: `calc(${(heldClamped / GR_MAX_DB) * 100}% - 1px)`,
+              top: 0,
+              bottom: 0,
+              width: 2,
+              background: 'rgba(255, 160, 40, 0.4)',
+              pointerEvents: 'none',
+            }}
+          />
+        )}
         <div className="meter-ticks">
           {[0.25, 0.5, 0.75].map((t) => (
             <div key={t} className="meter-tick" style={{ left: `${t * 100}%` }} />

--- a/zeus-web/src/components/TxStageMeters.tsx
+++ b/zeus-web/src/components/TxStageMeters.tsx
@@ -161,7 +161,11 @@ function LevelRow({ label, dbfs, hint }: LevelRowProps) {
   const display = !isFinite(dbfs) || bypassed ? '—' : dbfs.toFixed(0);
   const rowTitle = bypassed ? `${hint} (stage bypassed)` : hint;
   return (
-    <div className="meter" title={rowTitle}>
+    <div
+      className="meter"
+      title={rowTitle}
+      style={bypassed ? { opacity: 0.55 } : undefined}
+    >
       <div className="meter-head">
         <span className="label-xs">{label}</span>
         <span className="meter-val mono">
@@ -441,7 +445,11 @@ function GrRow({ db, hint }: { db: number; hint: string }) {
         : normalized.toFixed(1);
   const rowTitle = bypassed ? `${hint} (stage bypassed)` : hint;
   return (
-    <div className="meter" title={rowTitle}>
+    <div
+      className="meter"
+      title={rowTitle}
+      style={bypassed ? { opacity: 0.55 } : undefined}
+    >
       <div className="meter-head">
         <span className="label-xs">ALC GR</span>
         <span className="meter-val mono">
@@ -489,10 +497,142 @@ function GrRow({ db, hint }: { db: number; hint: string }) {
   );
 }
 
+// Compact CFC row: PK level bar on the left, GR bar on the right — same
+// visual language as AlcPairRow but in a single LevelRow-sized vertical
+// slot. CFC is bypassed by default (WDSP SetTXACFCRun is not called), so
+// both readings land on the −400 sentinel and the row dims to 55% via
+// the `bypassed` style on the outer meter chassis.
+function CfcPairRow({ pk, gr, hint }: { pk: number; gr: number; hint: string }) {
+  const pkBypassed = isBypassed(pk);
+  const grBypassed = isBypassed(gr);
+  // Row-level "bypassed" = both streams silent (CFC off in WDSP).
+  const bypassed = pkBypassed && grBypassed;
+
+  const pkAxis = dbfsToAxis(pk);
+  const pkHeld = usePeakHold(pk);
+  const pkHeldAxis = dbfsToAxis(pkHeld);
+  const pkHeldVisible =
+    isFinite(pkHeld) && !isBypassed(pkHeld) && pkHeldAxis > pkAxis;
+  const pkDisplay = !isFinite(pk) || pkBypassed ? '—' : pk.toFixed(0);
+
+  const grNormalized = grBypassed ? gr : Math.max(0, gr);
+  const grClamped = grBypassed ? 0 : Math.min(GR_MAX_DB, grNormalized);
+  const grOverdrive = grClamped >= ALC_ZONE_HEALTHY_END_DB;
+  const grHeld = usePeakHold(grNormalized, GR_MAX_DB / 2);
+  const grHeldClamped = Math.max(0, Math.min(GR_MAX_DB, grHeld));
+  const grHeldVisible =
+    isFinite(grHeld) && !isBypassed(grHeld) && grHeldClamped > grClamped;
+  const grDisplay =
+    !isFinite(grNormalized) || grBypassed
+      ? '—'
+      : grNormalized === 0
+        ? '0'
+        : grNormalized.toFixed(1);
+
+  const rowTitle = bypassed ? `${hint} (stage bypassed)` : hint;
+  return (
+    <div
+      className="meter"
+      title={rowTitle}
+      style={bypassed ? { opacity: 0.55 } : undefined}
+    >
+      <div className="meter-head">
+        <span className="label-xs">CFC</span>
+        <span className="meter-val mono" style={{ fontSize: 12 }}>
+          PK {pkDisplay}
+          <span className="unit"> dBFS</span>
+          <span style={{ color: 'var(--fg-3)', margin: '0 6px' }}>·</span>
+          GR {grDisplay}
+          <span className="unit"> dB</span>
+        </span>
+      </div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr',
+          gap: 6,
+          alignItems: 'stretch',
+        }}
+      >
+        {/* PK bar */}
+        <div className="meter-bar">
+          <div
+            className="meter-fill"
+            style={{
+              width: `${(pkAxis / LEVEL_RANGE_DB) * 100}%`,
+              filter:
+                pkAxis / LEVEL_RANGE_DB > LEVEL_DANGER_POS
+                  ? 'hue-rotate(-20deg) saturate(1.4)'
+                  : undefined,
+            }}
+          />
+          {pkHeldVisible && (
+            <div
+              aria-hidden="true"
+              style={{
+                position: 'absolute',
+                left: `calc(${(pkHeldAxis / LEVEL_RANGE_DB) * 100}% - 1px)`,
+                top: 0,
+                bottom: 0,
+                width: 2,
+                background: 'rgba(255, 160, 40, 0.4)',
+                pointerEvents: 'none',
+              }}
+            />
+          )}
+          <div className="meter-ticks">
+            <div
+              className="meter-tick danger"
+              style={{ left: `${LEVEL_DANGER_POS * 100}%` }}
+            />
+          </div>
+        </div>
+        {/* GR bar */}
+        <div className="meter-bar">
+          <div
+            className="meter-fill"
+            style={{
+              width: `${(grClamped / GR_MAX_DB) * 100}%`,
+              filter: grOverdrive
+                ? 'hue-rotate(-20deg) saturate(1.4)'
+                : undefined,
+            }}
+          />
+          {grHeldVisible && (
+            <div
+              aria-hidden="true"
+              style={{
+                position: 'absolute',
+                left: `calc(${(grHeldClamped / GR_MAX_DB) * 100}% - 1px)`,
+                top: 0,
+                bottom: 0,
+                width: 2,
+                background: 'rgba(255, 160, 40, 0.4)',
+                pointerEvents: 'none',
+              }}
+            />
+          )}
+          <div className="meter-ticks">
+            <div
+              className="meter-tick danger"
+              style={{
+                left: `${(ALC_ZONE_HEALTHY_END_DB / GR_MAX_DB) * 100}%`,
+              }}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function TxStageMeters() {
   const wdspMicPk = useTxStore((s) => s.wdspMicPk);
   const eqPk = useTxStore((s) => s.eqPk);
   const lvlrPk = useTxStore((s) => s.lvlrPk);
+  const cfcPk = useTxStore((s) => s.cfcPk);
+  const cfcGr = useTxStore((s) => s.cfcGr);
+  const compPk = useTxStore((s) => s.compPk);
   const alcPk = useTxStore((s) => s.alcPk);
   const alcGr = useTxStore((s) => s.alcGr);
   const outPk = useTxStore((s) => s.outPk);
@@ -537,6 +677,16 @@ export function TxStageMeters() {
         label="LVLR"
         dbfs={lvlrPk}
         hint="Post-Leveler peak — same as EQ while Leveler is disabled"
+      />
+      <CfcPairRow
+        pk={cfcPk}
+        gr={cfcGr}
+        hint="CFC (continuous-frequency compressor) peak + gain reduction"
+      />
+      <LevelRow
+        label="COMP"
+        dbfs={compPk}
+        hint="Post-compressor peak — bypassed by default"
       />
       <LevelRow
         label="ALC"

--- a/zeus-web/src/components/TxStageMeters.tsx
+++ b/zeus-web/src/components/TxStageMeters.tsx
@@ -232,6 +232,14 @@ export function TxStageMeters() {
         padding: '4px 0',
         opacity: transmitting ? 1 : 0.55,
         transition: 'opacity 120ms',
+        // The bottom-row slot is fixed at 200 px (see layout.css .workspace
+        // grid-template-rows) and .panel-body hides overflow, so without an
+        // inner scroller rows 4-6 (ALC / ALC GR / OUT) are clipped off the
+        // bottom of the Dockable. Use a thin scrollbar per the .side-stack
+        // convention rather than changing row density (deferred to Phase 2).
+        height: '100%',
+        overflowY: 'auto',
+        scrollbarWidth: 'thin',
       }}
       aria-label="TX stage meters"
     >

--- a/zeus-web/src/components/TxStageMeters.tsx
+++ b/zeus-web/src/components/TxStageMeters.tsx
@@ -1,6 +1,84 @@
 import { useRef } from 'react';
 import { useTxStore } from '../state/tx-store';
 
+// Overdrive detector — "you are distorting" signature per HL2 community
+// guidance: mic clipping (micPk >= -1 dBFS) AND ALC limiting hard
+// (alcGr > 10 dB), sustained >= 200 ms. At the 10 Hz WS frame rate that's
+// effectively "both conditions true for 2+ consecutive samples".
+const OVERDRIVE_MIC_PK_DBFS = -1;
+const OVERDRIVE_ALC_GR_DB = 10;
+const OVERDRIVE_SUSTAIN_MS = 200;
+
+function useOverdrive(): boolean {
+  const micPk = useTxStore((s) => s.wdspMicPk);
+  const alcGr = useTxStore((s) => s.alcGr);
+  const moxOn = useTxStore((s) => s.moxOn);
+  const tunOn = useTxStore((s) => s.tunOn);
+  // Track the most recent timestamp at which the sustained condition was
+  // NOT met. While it IS met, `now - lastNotMet` measures sustain time.
+  const lastNotMetRef = useRef<number>(
+    typeof performance !== 'undefined' ? performance.now() : 0,
+  );
+  const transmitting = moxOn || tunOn;
+  const conditionsMet =
+    transmitting &&
+    isFinite(micPk) &&
+    !isBypassed(micPk) &&
+    micPk >= OVERDRIVE_MIC_PK_DBFS &&
+    isFinite(alcGr) &&
+    alcGr > OVERDRIVE_ALC_GR_DB;
+  const now =
+    typeof performance !== 'undefined' ? performance.now() : Date.now();
+  if (!conditionsMet) {
+    lastNotMetRef.current = now;
+    return false;
+  }
+  return now - lastNotMetRef.current >= OVERDRIVE_SUSTAIN_MS;
+}
+
+export function OverdriveIndicator() {
+  const tripped = useOverdrive();
+  return (
+    <span
+      aria-live="polite"
+      aria-label={tripped ? 'Overdrive detected' : 'Overdrive clear'}
+      title={
+        tripped
+          ? 'Mic clipping + ALC limiting hard — reduce mic gain or drive.'
+          : 'Overdrive detector (mic peak ≥ -1 dBFS AND ALC GR > 10 dB sustained 200 ms)'
+      }
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 4,
+        padding: '2px 6px',
+        borderRadius: 3,
+        fontSize: 9,
+        fontWeight: 700,
+        letterSpacing: '0.08em',
+        textTransform: 'uppercase',
+        background: tripped ? 'var(--tx)' : 'transparent',
+        color: tripped ? '#fff' : 'var(--fg-3)',
+        border: `1px solid ${tripped ? 'var(--tx)' : 'var(--panel-border)'}`,
+        opacity: tripped ? 1 : 0.35,
+        transition: 'background 120ms, opacity 120ms, color 120ms',
+        boxShadow: tripped ? '0 0 6px var(--tx-soft)' : undefined,
+      }}
+    >
+      <span
+        aria-hidden="true"
+        style={{
+          width: 6,
+          height: 6,
+          borderRadius: '50%',
+          background: tripped ? '#fff' : 'var(--fg-3)',
+        }}
+      />
+      Overdrive
+    </span>
+  );
+}
+
 // Per-stage TX meter panel. Replaces the Memory-channels placeholder in the
 // bottom row for now — TX diagnostics are higher-priority while we chase
 // the SSB audio-quality issue. Reads peak-dBFS readings published by

--- a/zeus-web/src/components/TxStageMeters.tsx
+++ b/zeus-web/src/components/TxStageMeters.tsx
@@ -1,52 +1,99 @@
 import { useRef } from 'react';
 import { useTxStore } from '../state/tx-store';
 
-// Overdrive detector — "you are distorting" signature per HL2 community
-// guidance: mic clipping (micPk >= -1 dBFS) AND ALC limiting hard
-// (alcGr > 10 dB), sustained >= 200 ms. At the 10 Hz WS frame rate that's
-// effectively "both conditions true for 2+ consecutive samples".
+// Overdrive detector — fires on ANY of three independent HL2 community
+// signatures (W1AEX, softerhardware wiki), each sustained >= 200 ms:
+//   1. mic clipping         micPk  >= -1 dBFS  (bad regardless of downstream)
+//   2. ALC limiting hard    alcGr  > 10 dB
+//   3. CFC limiting hard    cfcGr  > 10 dB     (silent until CFC is enabled)
+// Earlier AND-of-mic+ALC spec never fired in live test because the Leveler
+// (enabled by default in P1.1) absorbs mic dynamics before ALC — so mic
+// could peg at 0 dBFS while alcGr stayed near 0. OR of independent
+// signatures captures each failure mode on its own. Each signature gets
+// its own sustain timer so a short transient on one doesn't reset the others.
 const OVERDRIVE_MIC_PK_DBFS = -1;
 const OVERDRIVE_ALC_GR_DB = 10;
+const OVERDRIVE_CFC_GR_DB = 10;
 const OVERDRIVE_SUSTAIN_MS = 200;
 
-function useOverdrive(): boolean {
+type OverdriveState = {
+  tripped: boolean;
+  mic: boolean;
+  alc: boolean;
+  cfc: boolean;
+};
+
+function useOverdrive(): OverdriveState {
   const micPk = useTxStore((s) => s.wdspMicPk);
   const alcGr = useTxStore((s) => s.alcGr);
+  const cfcGr = useTxStore((s) => s.cfcGr);
   const moxOn = useTxStore((s) => s.moxOn);
   const tunOn = useTxStore((s) => s.tunOn);
-  // Track the most recent timestamp at which the sustained condition was
-  // NOT met. While it IS met, `now - lastNotMet` measures sustain time.
-  const lastNotMetRef = useRef<number>(
-    typeof performance !== 'undefined' ? performance.now() : 0,
-  );
+  // Per-signature last-NOT-met timestamps; sustain = now - lastNotMet.
+  const now0 =
+    typeof performance !== 'undefined' ? performance.now() : 0;
+  const micNotMetRef = useRef<number>(now0);
+  const alcNotMetRef = useRef<number>(now0);
+  const cfcNotMetRef = useRef<number>(now0);
+
   const transmitting = moxOn || tunOn;
-  const conditionsMet =
+  const now =
+    typeof performance !== 'undefined' ? performance.now() : Date.now();
+
+  const micRaw =
     transmitting &&
     isFinite(micPk) &&
     !isBypassed(micPk) &&
-    micPk >= OVERDRIVE_MIC_PK_DBFS &&
+    micPk >= OVERDRIVE_MIC_PK_DBFS;
+  const alcRaw =
+    transmitting &&
     isFinite(alcGr) &&
+    !isBypassed(alcGr) &&
     alcGr > OVERDRIVE_ALC_GR_DB;
-  const now =
-    typeof performance !== 'undefined' ? performance.now() : Date.now();
-  if (!conditionsMet) {
-    lastNotMetRef.current = now;
-    return false;
+  // CFC stays bypassed by default; isBypassed check keeps the −400 sentinel
+  // from ever tripping this signature until the operator enables CFC.
+  const cfcRaw =
+    transmitting &&
+    isFinite(cfcGr) &&
+    !isBypassed(cfcGr) &&
+    cfcGr > OVERDRIVE_CFC_GR_DB;
+
+  if (!micRaw) micNotMetRef.current = now;
+  if (!alcRaw) alcNotMetRef.current = now;
+  if (!cfcRaw) cfcNotMetRef.current = now;
+
+  const mic = micRaw && now - micNotMetRef.current >= OVERDRIVE_SUSTAIN_MS;
+  const alc = alcRaw && now - alcNotMetRef.current >= OVERDRIVE_SUSTAIN_MS;
+  const cfc = cfcRaw && now - cfcNotMetRef.current >= OVERDRIVE_SUSTAIN_MS;
+
+  return { tripped: mic || alc || cfc, mic, alc, cfc };
+}
+
+function overdriveTooltip(s: OverdriveState): string {
+  const triggers: string[] = [];
+  if (s.mic) triggers.push('mic clipping (≥ -1 dBFS)');
+  if (s.alc) triggers.push('ALC limiting hard (> 10 dB GR)');
+  if (s.cfc) triggers.push('CFC limiting hard (> 10 dB GR)');
+  if (s.tripped) {
+    return (
+      `Overdrive: ${triggers.join(' + ')}. ` +
+      'Reduce mic gain or drive.'
+    );
   }
-  return now - lastNotMetRef.current >= OVERDRIVE_SUSTAIN_MS;
+  return (
+    'Overdrive detector — fires on any of: mic peak ≥ -1 dBFS, ALC GR > 10 dB, ' +
+    'or CFC GR > 10 dB, sustained 200 ms.'
+  );
 }
 
 export function OverdriveIndicator() {
-  const tripped = useOverdrive();
+  const state = useOverdrive();
+  const tripped = state.tripped;
   return (
     <span
       aria-live="polite"
       aria-label={tripped ? 'Overdrive detected' : 'Overdrive clear'}
-      title={
-        tripped
-          ? 'Mic clipping + ALC limiting hard — reduce mic gain or drive.'
-          : 'Overdrive detector (mic peak ≥ -1 dBFS AND ALC GR > 10 dB sustained 200 ms)'
-      }
+      title={overdriveTooltip(state)}
       style={{
         display: 'inline-flex',
         alignItems: 'center',

--- a/zeus-web/src/components/TxStageMeters.tsx
+++ b/zeus-web/src/components/TxStageMeters.tsx
@@ -21,11 +21,20 @@ const LEVEL_RANGE_DB = 60; // -60..0 dBFS displayed
 const LEVEL_DANGER_POS = (LEVEL_RANGE_DB - 3) / LEVEL_RANGE_DB; // -3 dBFS
 const GR_MAX_DB = 20;
 const GR_DANGER_POS = 12 / GR_MAX_DB;
+// WDSP returns −400 dBFS when a stage is bypassed. Anything ≤ −200 is far
+// below any real audio level, so we treat it as a bypassed sentinel rather
+// than clamping to the axis floor (which would paint a misleading tiny bar
+// and a confusing "-400 dBFS" readout).
+const BYPASSED_DBFS_THRESHOLD = -200;
+
+function isBypassed(dbfs: number): boolean {
+  return dbfs <= BYPASSED_DBFS_THRESHOLD;
+}
 
 // Convert a dBFS reading (≤ 0) to the 0..max axis the Meter primitive wants.
 // -60 dBFS → 0, 0 dBFS → 60.
 function dbfsToAxis(dbfs: number): number {
-  if (!isFinite(dbfs)) return 0;
+  if (!isFinite(dbfs) || isBypassed(dbfs)) return 0;
   const clamped = Math.max(-LEVEL_RANGE_DB, Math.min(0, dbfs));
   return LEVEL_RANGE_DB + clamped;
 }
@@ -37,10 +46,12 @@ type LevelRowProps = {
 };
 
 function LevelRow({ label, dbfs, hint }: LevelRowProps) {
+  const bypassed = isBypassed(dbfs);
   const axis = dbfsToAxis(dbfs);
-  const display = isFinite(dbfs) ? dbfs.toFixed(0) : '—';
+  const display = !isFinite(dbfs) || bypassed ? '—' : dbfs.toFixed(0);
+  const rowTitle = bypassed ? `${hint} (stage bypassed)` : hint;
   return (
-    <div className="meter" title={hint}>
+    <div className="meter" title={rowTitle}>
       <div className="meter-head">
         <span className="label-xs">{label}</span>
         <span className="meter-val mono">
@@ -74,10 +85,16 @@ function LevelRow({ label, dbfs, hint }: LevelRowProps) {
 }
 
 function GrRow({ db, hint }: { db: number; hint: string }) {
-  const clamped = Math.max(0, Math.min(GR_MAX_DB, db));
-  const display = isFinite(db) ? (db === 0 ? '0' : db.toFixed(1)) : '—';
+  // GR readings are always ≥ 0 dB; a large negative value is WDSP's bypass
+  // sentinel (−400). Show em-dash rather than pinning the bar to 0 dB with
+  // a meaningless readout.
+  const bypassed = isBypassed(db);
+  const clamped = bypassed ? 0 : Math.max(0, Math.min(GR_MAX_DB, db));
+  const display =
+    !isFinite(db) || bypassed ? '—' : db === 0 ? '0' : db.toFixed(1);
+  const rowTitle = bypassed ? `${hint} (stage bypassed)` : hint;
   return (
-    <div className="meter" title={hint}>
+    <div className="meter" title={rowTitle}>
       <div className="meter-head">
         <span className="label-xs">ALC GR</span>
         <span className="meter-val mono">

--- a/zeus-web/src/components/TxStageMeters.tsx
+++ b/zeus-web/src/components/TxStageMeters.tsx
@@ -142,18 +142,27 @@ function LevelRow({ label, dbfs, hint }: LevelRowProps) {
 }
 
 function GrRow({ db, hint }: { db: number; hint: string }) {
-  // GR readings are always ≥ 0 dB; a large negative value is WDSP's bypass
-  // sentinel (−400). Show em-dash rather than pinning the bar to 0 dB with
-  // a meaningless readout.
+  // GR is "dB of gain reduction" by convention: 0 = no reduction, +N = N dB
+  // cut. WDSP's ALC_GAIN meter drifts slightly above unity when ALC isn't
+  // limiting, which lands as small negative values after the backend's
+  // negation — meaningless for the operator. Clamp the raw reading to ≥ 0
+  // *before* anything else so text, bar, and peak-hold all agree.
+  // Bypass (−400 dBFS sentinel) wins over the clamp so bypassed stages
+  // still render as em-dash rather than "0 dB".
   const bypassed = isBypassed(db);
-  const clamped = bypassed ? 0 : Math.max(0, Math.min(GR_MAX_DB, db));
-  // GR axis is 20 dB wide; scale decay so full-range takes ~2 s.
-  const held = usePeakHold(db, GR_MAX_DB / 2);
+  const normalized = bypassed ? db : Math.max(0, db);
+  const clamped = bypassed ? 0 : Math.min(GR_MAX_DB, normalized);
+  // GR axis is GR_MAX_DB wide; scale decay so full-range takes ~2 s.
+  const held = usePeakHold(normalized, GR_MAX_DB / 2);
   const heldClamped = Math.max(0, Math.min(GR_MAX_DB, held));
   const heldVisible =
     isFinite(held) && !isBypassed(held) && heldClamped > clamped;
   const display =
-    !isFinite(db) || bypassed ? '—' : db === 0 ? '0' : db.toFixed(1);
+    !isFinite(normalized) || bypassed
+      ? '—'
+      : normalized === 0
+        ? '0'
+        : normalized.toFixed(1);
   const rowTitle = bypassed ? `${hint} (stage bypassed)` : hint;
   return (
     <div className="meter" title={rowTitle}>

--- a/zeus-web/src/components/TxStageMeters.tsx
+++ b/zeus-web/src/components/TxStageMeters.tsx
@@ -111,6 +111,7 @@ function GrRow({ db, hint }: { db: number; hint: string }) {
 }
 
 export function TxStageMeters() {
+  const wdspMicPk = useTxStore((s) => s.wdspMicPk);
   const eqPk = useTxStore((s) => s.eqPk);
   const lvlrPk = useTxStore((s) => s.lvlrPk);
   const alcPk = useTxStore((s) => s.alcPk);
@@ -131,6 +132,11 @@ export function TxStageMeters() {
       }}
       aria-label="TX stage meters"
     >
+      <LevelRow
+        label="MIC"
+        dbfs={wdspMicPk}
+        hint="Post-panel-gain mic level entering WDSP TXA (TXA_MIC_PK)"
+      />
       <LevelRow label="EQ" dbfs={eqPk} hint="Post-EQ peak" />
       <LevelRow
         label="LVLR"

--- a/zeus-web/src/components/TxStageMeters.tsx
+++ b/zeus-web/src/components/TxStageMeters.tsx
@@ -7,21 +7,24 @@ import { useTxStore } from '../state/tx-store';
 // WdspDspEngine.ProcessTxBlock (via TxMetersFrame) and renders them in
 // the design's .meter chassis.
 //
-// Conventions:
-//   - Levels shown on a -60..0 dBFS scale with the danger tick at -3 dBFS
-//     (3 dB headroom, Thetis-equivalent). We negate the stored dBFS for
-//     the Meter primitive's 0..max positive axis — i.e. a −20 dBFS peak
-//     fills 40/60 of the bar.
-//   - ALC gain reduction uses a 0..20 dB scale with the danger tick at
-//     ~12 dB; sustained >12 dB on SSB means the input is consistently
+// Conventions (Thetis MeterManager.cs):
+//   - Levels shown on a -30..+12 dB scale (42 dB span) with the danger tick
+//     at 0 dBFS (clip point) and a secondary "target peak" tick at -6 dBFS.
+//     The asymmetric scale concentrates resolution around the useful range
+//     for SSB voice, where healthy peaks sit around -6..-3 dBFS.
+//   - ALC gain reduction uses a 0..25 dB scale with the danger tick at
+//     10 dB; sustained > 10 dB GR means the input is consistently
 //     over-driving the limiter.
 //   - While MOX/TUN is off, TxMetersFrame carries −Infinity level / 0 GR;
 //     we detect that with isFinite() and render em-dashes.
 
-const LEVEL_RANGE_DB = 60; // -60..0 dBFS displayed
-const LEVEL_DANGER_POS = (LEVEL_RANGE_DB - 3) / LEVEL_RANGE_DB; // -3 dBFS
-const GR_MAX_DB = 20;
-const GR_DANGER_POS = 12 / GR_MAX_DB;
+const LEVEL_MIN_DB = -30;
+const LEVEL_MAX_DB = 12;
+const LEVEL_RANGE_DB = LEVEL_MAX_DB - LEVEL_MIN_DB; // 42 dB span
+const LEVEL_DANGER_POS = (0 - LEVEL_MIN_DB) / LEVEL_RANGE_DB; // 0 dBFS = clip
+const LEVEL_TARGET_POS = (-6 - LEVEL_MIN_DB) / LEVEL_RANGE_DB; // -6 dBFS target
+const GR_MAX_DB = 25;
+const GR_DANGER_POS = 10 / GR_MAX_DB; // >10 dB GR = over-driving the limiter
 // WDSP returns −400 dBFS when a stage is bypassed. Anything ≤ −200 is far
 // below any real audio level, so we treat it as a bypassed sentinel rather
 // than clamping to the axis floor (which would paint a misleading tiny bar
@@ -33,13 +36,13 @@ function isBypassed(dbfs: number): boolean {
 }
 
 // Thetis convention (MeterManager.cs: attack 0.8, decay 0.1, ~2 s visible
-// history): the held peak decays 30 dB/sec, i.e. a peak at 0 dB drops off
-// the −60 dBFS axis over ~2 seconds. The hook tracks the running max in a
-// ref so the decay stays continuous across renders, using wall-clock time
-// for dt rather than frame count (the component re-renders at the 10 Hz WS
-// tick, giving ~3 dB steps — visually smooth enough for a 60 dB range).
-// Returns −Infinity while current is non-finite or ≤ the bypass sentinel.
-const PEAK_DECAY_DB_PER_SEC = 30;
+// history): the held peak decays at a rate that takes ~2 s to traverse the
+// full axis. For the 42 dB level axis that's 21 dB/s; the GR axis uses
+// GR_MAX_DB/2 via the decayDbPerSec override. The hook tracks the running
+// max in a ref so decay stays continuous across renders, using wall-clock
+// time for dt rather than frame count. Returns −Infinity while current is
+// non-finite or ≤ the bypass sentinel.
+const PEAK_DECAY_DB_PER_SEC = LEVEL_RANGE_DB / 2;
 
 function usePeakHold(current: number, decayDbPerSec = PEAK_DECAY_DB_PER_SEC): number {
   const state = useRef<{ db: number; ts: number }>({ db: -Infinity, ts: 0 });
@@ -57,12 +60,12 @@ function usePeakHold(current: number, decayDbPerSec = PEAK_DECAY_DB_PER_SEC): nu
   return held;
 }
 
-// Convert a dBFS reading (≤ 0) to the 0..max axis the Meter primitive wants.
-// -60 dBFS → 0, 0 dBFS → 60.
+// Convert a dBFS reading to the 0..LEVEL_RANGE_DB axis (0..42).
+// -30 dBFS → 0, 0 dBFS → 30, +12 dBFS → 42.
 function dbfsToAxis(dbfs: number): number {
   if (!isFinite(dbfs) || isBypassed(dbfs)) return 0;
-  const clamped = Math.max(-LEVEL_RANGE_DB, Math.min(0, dbfs));
-  return LEVEL_RANGE_DB + clamped;
+  const clamped = Math.max(LEVEL_MIN_DB, Math.min(LEVEL_MAX_DB, dbfs));
+  return clamped - LEVEL_MIN_DB;
 }
 
 type LevelRowProps = {
@@ -120,6 +123,14 @@ function LevelRow({ label, dbfs, hint }: LevelRowProps) {
           {[0.25, 0.5, 0.75].map((t) => (
             <div key={t} className="meter-tick" style={{ left: `${t * 100}%` }} />
           ))}
+          {/* Target-peak marker at -6 dBFS (amber, #FFA028 @ 0.55 alpha). */}
+          <div
+            className="meter-tick"
+            style={{
+              left: `${LEVEL_TARGET_POS * 100}%`,
+              background: 'rgba(255, 160, 40, 0.55)',
+            }}
+          />
           <div
             className="meter-tick danger"
             style={{ left: `${LEVEL_DANGER_POS * 100}%` }}
@@ -233,7 +244,7 @@ export function TxStageMeters() {
       />
       <GrRow
         db={alcGr}
-        hint="ALC gain reduction; sustained >12 dB means the input is over-driving the limiter"
+        hint="ALC gain reduction; sustained >10 dB means the input is over-driving the limiter"
       />
       <LevelRow label="OUT" dbfs={outPk} hint="Final TX peak" />
     </div>

--- a/zeus-web/src/components/TxStageMeters.tsx
+++ b/zeus-web/src/components/TxStageMeters.tsx
@@ -141,6 +141,204 @@ function LevelRow({ label, dbfs, hint }: LevelRowProps) {
   );
 }
 
+// W1AEX / softerhardware-wiki community guidance: operators must read ALC
+// peak and ALC gain-reduction side-by-side to know how much the limiter is
+// acting. Zones on the GR bar follow the task spec:
+//   0..3  dB — "quiet"    (Leveler barely engaging)
+//   3..10 dB — "healthy"  (SSB compression sweet spot)
+//   10+   dB — "overdrive" (input is consistently over-driving the limiter)
+// Zone colors track the existing .meter-fill green→amber→red gradient so
+// the surrounding Zeus amber chrome stays intact; zones are rendered as
+// low-alpha background stripes so the bar itself still reads as amber.
+const ALC_ZONE_QUIET_END_DB = 3;
+const ALC_ZONE_HEALTHY_END_DB = 10;
+
+const ALC_TOOLTIP =
+  'ALC peak (left) + gain reduction (right). You must read both to know ' +
+  'how much ALC is acting — the ALC meter tops out at 0 dB and the Comp ' +
+  'meter bottoms at 0 dB (W1AEX). Healthy SSB compression sits in the ' +
+  '3–10 dB GR band; sustained >10 dB means the input is over-driving.';
+
+// Faint background stripes behind the GR fill that cue the zones without
+// overwhelming the amber palette. Alpha is kept low (0.10–0.14) so the
+// primary readout is still the filled bar.
+function grZoneBackground(): string {
+  const q = (ALC_ZONE_QUIET_END_DB / GR_MAX_DB) * 100;
+  const h = (ALC_ZONE_HEALTHY_END_DB / GR_MAX_DB) * 100;
+  return (
+    `linear-gradient(90deg,` +
+    ` rgba(242, 133, 36, 0.10) 0%,` + //   amber (quiet)
+    ` rgba(242, 133, 36, 0.10) ${q}%,` +
+    ` rgba(0, 200, 83, 0.14) ${q}%,` + //  green (healthy)
+    ` rgba(0, 200, 83, 0.14) ${h}%,` +
+    ` rgba(230, 58, 43, 0.14) ${h}%,` + // red (overdrive)
+    ` rgba(230, 58, 43, 0.14) 100%)`
+  );
+}
+
+function AlcPairRow({ alcPk, alcGr }: { alcPk: number; alcGr: number }) {
+  // PK side re-uses the same -30..+12 dB axis as the per-stage strip so the
+  // prominent summary agrees with the strip below.
+  const pkBypassed = isBypassed(alcPk);
+  const pkAxis = dbfsToAxis(alcPk);
+  const pkHeld = usePeakHold(alcPk);
+  const pkHeldAxis = dbfsToAxis(pkHeld);
+  const pkHeldVisible =
+    isFinite(pkHeld) && !isBypassed(pkHeld) && pkHeldAxis > pkAxis;
+  const pkDisplay =
+    !isFinite(alcPk) || pkBypassed ? '—' : alcPk.toFixed(0);
+
+  // GR side clamps negative noise to 0 (see P1.8); bypass sentinel still wins.
+  const grBypassed = isBypassed(alcGr);
+  const grNormalized = grBypassed ? alcGr : Math.max(0, alcGr);
+  const grClamped = grBypassed ? 0 : Math.min(GR_MAX_DB, grNormalized);
+  const grOverdrive = grClamped >= ALC_ZONE_HEALTHY_END_DB;
+  const grHeld = usePeakHold(grNormalized, GR_MAX_DB / 2);
+  const grHeldClamped = Math.max(0, Math.min(GR_MAX_DB, grHeld));
+  const grHeldVisible =
+    isFinite(grHeld) && !isBypassed(grHeld) && grHeldClamped > grClamped;
+  const grDisplay =
+    !isFinite(grNormalized) || grBypassed
+      ? '—'
+      : grNormalized === 0
+        ? '0'
+        : grNormalized.toFixed(1);
+
+  return (
+    <div
+      className="meter"
+      title={ALC_TOOLTIP}
+      aria-label="ALC peak and gain reduction pair"
+      style={{
+        borderTop: '1px solid var(--panel-border)',
+        borderBottom: '1px solid var(--panel-border)',
+        background: 'rgba(255, 160, 40, 0.04)',
+      }}
+    >
+      <div className="meter-head">
+        <span className="label-xs" style={{ fontWeight: 700 }}>
+          ALC
+        </span>
+        <span className="meter-val mono" style={{ fontSize: 12 }}>
+          PK {pkDisplay}
+          <span className="unit"> dBFS</span>
+          <span style={{ color: 'var(--fg-3)', margin: '0 6px' }}>·</span>
+          GR {grDisplay}
+          <span className="unit"> dB</span>
+        </span>
+      </div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr',
+          gap: 8,
+          alignItems: 'stretch',
+        }}
+      >
+        {/* PK bar (-30..+12) */}
+        <div className="meter-bar">
+          <div
+            className="meter-fill"
+            style={{
+              width: `${(pkAxis / LEVEL_RANGE_DB) * 100}%`,
+              filter:
+                pkAxis / LEVEL_RANGE_DB > LEVEL_DANGER_POS
+                  ? 'hue-rotate(-20deg) saturate(1.4)'
+                  : undefined,
+            }}
+          />
+          {pkHeldVisible && (
+            <div
+              aria-hidden="true"
+              style={{
+                position: 'absolute',
+                left: `calc(${(pkHeldAxis / LEVEL_RANGE_DB) * 100}% - 1px)`,
+                top: 0,
+                bottom: 0,
+                width: 2,
+                background: 'rgba(255, 160, 40, 0.4)',
+                pointerEvents: 'none',
+              }}
+            />
+          )}
+          <div className="meter-ticks">
+            {[0.25, 0.5, 0.75].map((t) => (
+              <div
+                key={t}
+                className="meter-tick"
+                style={{ left: `${t * 100}%` }}
+              />
+            ))}
+            <div
+              className="meter-tick"
+              style={{
+                left: `${LEVEL_TARGET_POS * 100}%`,
+                background: 'rgba(255, 160, 40, 0.55)',
+              }}
+            />
+            <div
+              className="meter-tick danger"
+              style={{ left: `${LEVEL_DANGER_POS * 100}%` }}
+            />
+          </div>
+        </div>
+
+        {/* GR bar (0..25) with zone bands */}
+        <div className="meter-bar">
+          {/* Zone background stripes sit behind the fill. */}
+          <div
+            aria-hidden="true"
+            style={{
+              position: 'absolute',
+              inset: 0,
+              background: grZoneBackground(),
+              pointerEvents: 'none',
+            }}
+          />
+          <div
+            className="meter-fill"
+            style={{
+              width: `${(grClamped / GR_MAX_DB) * 100}%`,
+              filter: grOverdrive
+                ? 'hue-rotate(-20deg) saturate(1.4)'
+                : undefined,
+            }}
+          />
+          {grHeldVisible && (
+            <div
+              aria-hidden="true"
+              style={{
+                position: 'absolute',
+                left: `calc(${(grHeldClamped / GR_MAX_DB) * 100}% - 1px)`,
+                top: 0,
+                bottom: 0,
+                width: 2,
+                background: 'rgba(255, 160, 40, 0.4)',
+                pointerEvents: 'none',
+              }}
+            />
+          )}
+          <div className="meter-ticks">
+            {/* Zone dividers at the boundaries and the overdrive danger tick. */}
+            <div
+              className="meter-tick"
+              style={{
+                left: `${(ALC_ZONE_QUIET_END_DB / GR_MAX_DB) * 100}%`,
+              }}
+            />
+            <div
+              className="meter-tick danger"
+              style={{
+                left: `${(ALC_ZONE_HEALTHY_END_DB / GR_MAX_DB) * 100}%`,
+              }}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function GrRow({ db, hint }: { db: number; hint: string }) {
   // GR is "dB of gain reduction" by convention: 0 = no reduction, +N = N dB
   // cut. WDSP's ALC_GAIN meter drifts slightly above unity when ALC isn't
@@ -243,6 +441,14 @@ export function TxStageMeters() {
       }}
       aria-label="TX stage meters"
     >
+      {/*
+        ALC prominent summary — peak + gain-reduction side-by-side. The
+        community-critical operator diagnostic (W1AEX, softerhardware wiki).
+        Rendered above the per-stage strip so it's always in view even
+        before the user scrolls.
+      */}
+      <AlcPairRow alcPk={alcPk} alcGr={alcGr} />
+
       <LevelRow
         label="MIC"
         dbfs={wdspMicPk}

--- a/zeus-web/src/realtime/ws-client.ts
+++ b/zeus-web/src/realtime/ws-client.ts
@@ -32,6 +32,12 @@ const RX_METER_BYTES = 1 + 4;
 // Server emits when SWR > 2.5 sustained ≥500 ms (PRD FR-6). Kind 0 = SWR trip.
 export const MSG_TYPE_ALERT = 0x13;
 
+// HL2 PA temperature: 1 type byte + 1 × f32 LE (°C). Broadcast at 2 Hz
+// regardless of MOX state; server clamps to [-40, 125] °C before send.
+// Operator-visible in the transport bar chip with 50/55 °C warning zones.
+export const MSG_TYPE_PA_TEMP = 0x17;
+const PA_TEMP_BYTES = 1 + 4;
+
 // WDSP wisdom status: 1 type byte + 1 phase byte (0=idle, 1=building, 2=ready).
 // Pushed once on WS attach and again on every transition. The UI disables the
 // Connect button and pulses while phase=building so the user doesn't try to
@@ -170,6 +176,18 @@ export function startRealtime(path = '/ws'): () => void {
             outPk: dv.getFloat32(73, true),
             outAv: dv.getFloat32(77, true),
           });
+          return;
+        }
+        if (peekType === MSG_TYPE_PA_TEMP) {
+          if (ev.data.byteLength < PA_TEMP_BYTES) {
+            warnOnce(
+              'ws-pa-temp-short',
+              `PA temp frame too short: ${ev.data.byteLength}`,
+            );
+            return;
+          }
+          const tempC = new DataView(ev.data).getFloat32(1, true);
+          useTxStore.getState().setPaTempC(tempC);
           return;
         }
         if (peekType === MSG_TYPE_RX_METER) {

--- a/zeus-web/src/realtime/ws-client.ts
+++ b/zeus-web/src/realtime/ws-client.ts
@@ -9,13 +9,19 @@ import { warnOnce } from '../util/logger';
 const INITIAL_BACKOFF_MS = 1000;
 const MAX_BACKOFF_MS = 8000;
 
-// Binary WS frame type for TX meters: 1 type byte + 9 × f32 LE
-// (fwdWatts, refWatts, swr, micDbfs, eqPk, lvlrPk, alcPk, alcGr, outPk).
-// Contract locked with the server team in Zeus.Contracts/TxMetersFrame.cs —
-// the last 5 floats are TXA per-stage peak readings added for the TX-quality
-// diagnostic strip; they read −∞ / 0 while idle.
-export const MSG_TYPE_TX_METERS = 0x11;
-const TX_METERS_BYTES = 1 + 4 * 9;
+// Binary WS frame type for TX meters v2: 1 type byte + 20 × f32 LE.
+// Payload order (must match Zeus.Contracts/TxMetersFrame.cs v2):
+//   fwdWatts, refWatts, swr,
+//   micPk, micAv, eqPk, eqAv,
+//   lvlrPk, lvlrAv, lvlrGr,
+//   cfcPk, cfcAv, cfcGr,
+//   compPk, compAv,
+//   alcPk, alcAv, alcGr,
+//   outPk, outAv.
+// Bypassed WDSP stages emit ≤ −200 dBFS (near the WDSP −400 sentinel) and
+// `*Gr` fields stay at 0 when the stage is idle.
+export const MSG_TYPE_TX_METERS_V2 = 0x16;
+const TX_METERS_V2_BYTES = 1 + 4 * 20;
 
 // RX S-meter: 1 type byte + 1 × f32 LE (dBm). Broadcast at ~5 Hz from
 // DspPipelineService; server clamps floor to −160 dBm before send.
@@ -133,11 +139,11 @@ export function startRealtime(path = '/ws'): () => void {
           getAudioClient().push(audio);
           return;
         }
-        if (peekType === MSG_TYPE_TX_METERS) {
-          if (ev.data.byteLength < TX_METERS_BYTES) {
+        if (peekType === MSG_TYPE_TX_METERS_V2) {
+          if (ev.data.byteLength < TX_METERS_V2_BYTES) {
             warnOnce(
-              'ws-tx-meters-short',
-              `tx meters frame too short: ${ev.data.byteLength}`,
+              'ws-tx-meters-v2-short',
+              `tx meters v2 frame too short: ${ev.data.byteLength}`,
             );
             return;
           }
@@ -146,12 +152,23 @@ export function startRealtime(path = '/ws'): () => void {
             fwdWatts: dv.getFloat32(1, true),
             refWatts: dv.getFloat32(5, true),
             swr: dv.getFloat32(9, true),
-            micDbfs: dv.getFloat32(13, true),
-            eqPk: dv.getFloat32(17, true),
-            lvlrPk: dv.getFloat32(21, true),
-            alcPk: dv.getFloat32(25, true),
-            alcGr: dv.getFloat32(29, true),
-            outPk: dv.getFloat32(33, true),
+            micPk: dv.getFloat32(13, true),
+            micAv: dv.getFloat32(17, true),
+            eqPk: dv.getFloat32(21, true),
+            eqAv: dv.getFloat32(25, true),
+            lvlrPk: dv.getFloat32(29, true),
+            lvlrAv: dv.getFloat32(33, true),
+            lvlrGr: dv.getFloat32(37, true),
+            cfcPk: dv.getFloat32(41, true),
+            cfcAv: dv.getFloat32(45, true),
+            cfcGr: dv.getFloat32(49, true),
+            compPk: dv.getFloat32(53, true),
+            compAv: dv.getFloat32(57, true),
+            alcPk: dv.getFloat32(61, true),
+            alcAv: dv.getFloat32(65, true),
+            alcGr: dv.getFloat32(69, true),
+            outPk: dv.getFloat32(73, true),
+            outAv: dv.getFloat32(77, true),
           });
           return;
         }

--- a/zeus-web/src/state/tx-store.ts
+++ b/zeus-web/src/state/tx-store.ts
@@ -57,6 +57,13 @@ export type TxState = {
   // WDSP SetTXAPanelGain1(TXA, 10^(db/20)). Kept as int dB on the wire.
   micGainDb: number;
   setMicGainDb: (db: number) => void;
+  // Leveler max-gain slider 0..+15 dB (default +5 — matches backend default
+  // and HL2 community starting point). Higher = more aggressive voice
+  // leveling; can push ALC into hard limiting. Persisted — a user preference
+  // that should survive reload. Server clamps [0, 15]; we clamp here too so
+  // persisted / race-condition writes can't poison the store.
+  levelerMaxGainDb: number;
+  setLevelerMaxGainDb: (db: number) => void;
   // Meter telemetry pushed from the server's TxMetersService over WS (0x16 v2).
   // Defaults look "quiet": 0 W forward/reflected, 1.0 SWR (matched), -100 dBfs
   // mic (near silence) so the SMeter/dBfs readouts don't spike on first paint.
@@ -120,6 +127,9 @@ export const useTxStore = create<TxState>()(
       setDrivePercent: (p) => set({ drivePercent: p }),
       micGainDb: 0,
       setMicGainDb: (db) => set({ micGainDb: db }),
+      levelerMaxGainDb: 5,
+      setLevelerMaxGainDb: (db) =>
+        set({ levelerMaxGainDb: Math.max(0, Math.min(15, db)) }),
       fwdWatts: 0,
       refWatts: 0,
       swr: 1.0,
@@ -180,6 +190,7 @@ export const useTxStore = create<TxState>()(
       partialize: (s) => ({
         drivePercent: s.drivePercent,
         micGainDb: s.micGainDb,
+        levelerMaxGainDb: s.levelerMaxGainDb,
       }),
     },
   ),

--- a/zeus-web/src/state/tx-store.ts
+++ b/zeus-web/src/state/tx-store.ts
@@ -102,6 +102,11 @@ export type TxState = {
   // sustained ≥500 ms. Dismissable amber banner in UI; sticks until dismissed.
   alert: Alert | null;
   setAlert: (a: Alert | null) => void;
+  // HL2 PA temperature (°C), from MsgType 0x17 at 2 Hz. Server clamps to
+  // [-40, 125]. null means "no reading yet" (server hasn't sampled or we
+  // haven't connected). Transient per-session — not persisted.
+  paTempC: number | null;
+  setPaTempC: (c: number) => void;
 };
 
 export const useTxStore = create<TxState>()(
@@ -165,6 +170,8 @@ export const useTxStore = create<TxState>()(
       setRxDbm: (dbm) => set({ rxDbm: dbm }),
       alert: null,
       setAlert: (a) => set({ alert: a }),
+      paTempC: null,
+      setPaTempC: (c) => set({ paTempC: c }),
     }),
     {
       name: 'zeus-tx',

--- a/zeus-web/src/state/tx-store.ts
+++ b/zeus-web/src/state/tx-store.ts
@@ -49,13 +49,14 @@ export type TxState = {
   // mic (near silence) so the SMeter/dBfs readouts don't spike on first paint.
   //
   // micDbfs is client-driven: set by the mic-uplink worklet's per-block peak
-  // so the MicMeter animates even during RX. The server's TxMetersFrame no
-  // longer writes this field — its placeholder -100f would clobber the live
-  // capture. setMeters intentionally skips micDbfs.
+  // so the MicMeter animates even during RX. setMeters does not overwrite it.
+  // wdspMicPk is server-driven: WDSP TXA_MIC_PK (post-panel-gain) carried in
+  // TxMetersFrame.MicDbfs at 10 Hz during MOX; −Infinity when idle.
   fwdWatts: number;
   refWatts: number;
   swr: number;
   micDbfs: number;
+  wdspMicPk: number;
   eqPk: number;
   lvlrPk: number;
   alcPk: number;
@@ -94,6 +95,7 @@ export const useTxStore = create<TxState>()(
       refWatts: 0,
       swr: 1.0,
       micDbfs: -100,
+      wdspMicPk: -Infinity,
       eqPk: -Infinity,
       lvlrPk: -Infinity,
       alcPk: -Infinity,
@@ -103,6 +105,7 @@ export const useTxStore = create<TxState>()(
         fwdWatts: m.fwdWatts,
         refWatts: m.refWatts,
         swr: m.swr,
+        wdspMicPk: m.micDbfs,
         eqPk: m.eqPk,
         lvlrPk: m.lvlrPk,
         alcPk: m.alcPk,

--- a/zeus-web/src/state/tx-store.ts
+++ b/zeus-web/src/state/tx-store.ts
@@ -4,19 +4,32 @@ import { persist } from 'zustand/middleware';
 // TX-side state. Intentionally separate from connection-store so the TX panel
 // can mount/unmount cleanly and so TX-specific fields (drivePercent, micGainDb,
 // meter values, SWR alert) can accumulate here as subsequent slices land.
+// TxMetersV2 wire payload (MsgType 0x16, 20 f32 LE). TXA per-stage peak/average
+// readings from WdspDspEngine.ProcessTxBlock. Valid during MOX/TUN only — idle
+// or bypassed WDSP stages emit ≤ −200 dBFS (near the −400 sentinel) and `*Gr`
+// fields stay at 0 when the stage is idle. Consumers should treat ≤ −200 as
+// "bypassed" rather than a real level (see P1.4).
 export type TxMeters = {
   fwdWatts: number;
   refWatts: number;
   swr: number;
-  micDbfs: number;
-  // TXA per-stage peak readings from WdspDspEngine.ProcessTxBlock. Valid
-  // during MOX/TUN only — idle frames carry −Infinity levels and 0 GR, so
-  // consumers can detect "no live data" by checking isFinite().
+  micPk: number;
+  micAv: number;
   eqPk: number;
+  eqAv: number;
   lvlrPk: number;
+  lvlrAv: number;
+  lvlrGr: number;
+  cfcPk: number;
+  cfcAv: number;
+  cfcGr: number;
+  compPk: number;
+  compAv: number;
   alcPk: number;
+  alcAv: number;
   alcGr: number;
   outPk: number;
+  outAv: number;
 };
 
 export enum AlertKind {
@@ -44,24 +57,35 @@ export type TxState = {
   // WDSP SetTXAPanelGain1(TXA, 10^(db/20)). Kept as int dB on the wire.
   micGainDb: number;
   setMicGainDb: (db: number) => void;
-  // Meter telemetry pushed from the server's TxMetersService over WS (0x11).
+  // Meter telemetry pushed from the server's TxMetersService over WS (0x16 v2).
   // Defaults look "quiet": 0 W forward/reflected, 1.0 SWR (matched), -100 dBfs
   // mic (near silence) so the SMeter/dBfs readouts don't spike on first paint.
   //
   // micDbfs is client-driven: set by the mic-uplink worklet's per-block peak
   // so the MicMeter animates even during RX. setMeters does not overwrite it.
   // wdspMicPk is server-driven: WDSP TXA_MIC_PK (post-panel-gain) carried in
-  // TxMetersFrame.MicDbfs at 10 Hz during MOX; −Infinity when idle.
+  // TxMetersFrame.MicPk at 10 Hz during MOX; −Infinity when idle.
   fwdWatts: number;
   refWatts: number;
   swr: number;
   micDbfs: number;
   wdspMicPk: number;
+  micAv: number;
   eqPk: number;
+  eqAv: number;
   lvlrPk: number;
+  lvlrAv: number;
+  lvlrGr: number;
+  cfcPk: number;
+  cfcAv: number;
+  cfcGr: number;
+  compPk: number;
+  compAv: number;
   alcPk: number;
+  alcAv: number;
   alcGr: number;
   outPk: number;
+  outAv: number;
   setMeters: (m: TxMeters) => void;
   setMicDbfs: (dbfs: number) => void;
   // Surfaced when getUserMedia / AudioWorklet init fails so MicMeter can
@@ -96,21 +120,43 @@ export const useTxStore = create<TxState>()(
       swr: 1.0,
       micDbfs: -100,
       wdspMicPk: -Infinity,
+      micAv: -Infinity,
       eqPk: -Infinity,
+      eqAv: -Infinity,
       lvlrPk: -Infinity,
+      lvlrAv: -Infinity,
+      lvlrGr: 0,
+      cfcPk: -Infinity,
+      cfcAv: -Infinity,
+      cfcGr: 0,
+      compPk: -Infinity,
+      compAv: -Infinity,
       alcPk: -Infinity,
+      alcAv: -Infinity,
       alcGr: 0,
       outPk: -Infinity,
+      outAv: -Infinity,
       setMeters: (m) => set({
         fwdWatts: m.fwdWatts,
         refWatts: m.refWatts,
         swr: m.swr,
-        wdspMicPk: m.micDbfs,
+        wdspMicPk: m.micPk,
+        micAv: m.micAv,
         eqPk: m.eqPk,
+        eqAv: m.eqAv,
         lvlrPk: m.lvlrPk,
+        lvlrAv: m.lvlrAv,
+        lvlrGr: m.lvlrGr,
+        cfcPk: m.cfcPk,
+        cfcAv: m.cfcAv,
+        cfcGr: m.cfcGr,
+        compPk: m.compPk,
+        compAv: m.compAv,
         alcPk: m.alcPk,
+        alcAv: m.alcAv,
         alcGr: m.alcGr,
         outPk: m.outPk,
+        outAv: m.outAv,
       }),
       setMicDbfs: (dbfs) => set({ micDbfs: dbfs }),
       micError: null,


### PR DESCRIPTION
Closes #2.

## Summary

Rebuilds the TX-audio metering stack end-to-end so operators can actually diagnose and tune audio — detect over-drive, judge compression, monitor PA temperature. Three phases, each independently verified in-browser on a live HL2.

### Phase 1 — Thetis parity
- Enable WDSP Leveler by default (matches Thetis `radio.cs:2965 tx_leveler_on = true`). Previously Zeus left it bypassed, which is why the LVLR meter read `-400`.
- Extend wire format to `TxMetersV2 = 0x16` (81 bytes, 20 floats): per-stage average readings alongside peak, plus CFC / COMP slots.
- Frontend: `-400 dBFS` silence sentinel renders em-dash with a "stage bypassed" tooltip; 2 s peak-hold ticks on every bar (Thetis convention); level scale rescaled to `-30 .. +12 dB` with danger tick at clip and secondary tick at `-6 dBFS` target.
- Small safety: GR display clamped to `>= 0` to absorb WDSP `ALC_GAIN` meter noise below threshold (negative "GR" is meaningless to the operator).
- Panel scroll so all 6 rows reach in the existing 200 px slot.

### Phase 2 — Operator-facing diagnostics
- **Prominent ALC PK + GR paired row** above the per-stage strip, with color-banded zones on GR (0-3 amber / 3-10 green / >10 red). Community-sourced per W1AEX CFC Audio Tools: *"the ALC meter only reads to 0 dB max, the ALC Comp meter only reads to 0 dB min — you must look at both to know how much ALC is being invoked."*
- **Sustained-overdrive detector pill** in the panel header. **OR** of three independent signatures — any one trips the pill:
  - mic clipping (`micPk >= -1 dBFS` sustained >= 200 ms)
  - ALC pinned (`alcGr > 10 dB` sustained >= 200 ms)
  - CFC pinned (`cfcGr > 10 dB` sustained >= 200 ms; bypass-sentinel-gated so it won't fire until operator enables CFC)
- **CFC + COMP rows** added between LVLR and ALC, dimmed at 55 % opacity while bypassed.
- **PA temperature chip** in the transport bar, reading HL2 Q6 sensor (MCP9700 conversion) via new `PaTempFrame = 0x17` at 2 Hz always. Zones: normal / amber at 50 °C / red at 55 °C (Q6 auto-shutdown threshold). Server clamps °C output to `[-40, 125]` so a floating ADC on boot doesn't spuriously trip red.

### Phase 3 — Operator control
- **Leveler Max Gain slider** in DspPanel (range 0..15 dB, default +5 dB per W1AEX community recommendation; Thetis ships +15 dB).
- POST `/api/tx/leveler-max-gain` with clamp, re-POST on WS reconnect so the slider state survives backend restart.
- Zustand `persist` partialize: slider position survives reload alongside existing `drivePercent` / `micGainDb`.

## Maintainer-review items (red-light per CLAUDE.md)

These are operator-visible default-value choices that need EI6LF sign-off:

| Setting | Phase | Chosen default | Alternative | Source |
|---|---|---|---|---|
| Leveler **enabled** at init | 1 | **on** | off (Zeus previous behavior) | Thetis `radio.cs:2965` — direct parity |
| Leveler **Max Gain** | 3 | **+5 dB** | Thetis stock +15 dB | W1AEX CFC Audio Tools (community SSB starting point) |
| Level meter scale | 1 | -30 .. +12 dB | previous -60 .. 0 | Thetis `MeterManager.cs` |
| GR meter danger tick | 1 | 10 dB | previous 12 dB | community "overdriving" threshold |
| GR healthy zone (visual) | 2 | 3-10 dB green | amber-alpha-only | task desc specified green; frontend-dev flagged in commit |
| PA temp thresholds | 2 | amber 50 / red 55 °C | — | HL2 softerhardware wiki, Q6 trip |
| Overdrive detector | 2 | OR of mic / alc / cfc | AND (original spec, unreachable with Leveler on) | live test fix — AND was unreachable |

Wire-format additions (additive, v1 frames left in place for interop):
- `MsgType.TxMetersV2 = 0x16` (81 bytes)
- `MsgType.PaTemp = 0x17` (5 bytes)

## Research provenance

- Thetis C# source audit: TX meter modes, defaults, scale conventions, peak-hold timings. Primary files: `radio.cs` (DSP defaults), `dsp.cs` / `MeterManager.cs` (meter indices + scales), `console.cs` (TX meter mode enum + default selection).
- WDSP: `native/wdsp/TXA.h:49-66` `txaMeterType` enum for the 17 meter slots. `wcpAGC.c` for Leveler API surface.
- HL2 community:
  - [W1AEX CFC Audio Tools](http://www.w1aex.com/anan/CFC_Audio_Tools/CFC_Audio_Tools.html) — authoritative audio-setup walkthrough.
  - [softerhardware/Hermes-Lite2 Thetis-Setup wiki](https://github.com/softerhardware/Hermes-Lite2/wiki/Thetis-Setup)
  - [hermes-lite groups](https://groups.google.com/g/hermes-lite) — PA temperature data, duty cycle limits, 55 °C auto-shutdown.

## Tests

- Backend: 474 tests pass (was 456 on main, +18 from this branch — frame round-trips, conversion sanity, endpoint clamp behavior).
- Frontend: 66 tests pass (+3 from this branch — API client for Leveler endpoint).

## Test plan

- [x] Build: `dotnet build Zeus.slnx` clean, zero warnings.
- [x] Build: `npm --prefix zeus-web run build` clean.
- [x] Unit tests: backend 474 pass / frontend 66 pass.
- [x] Phase 1 live MOX: LVLR bar moves, em-dash on bypassed stages, no `-400` leaks.
- [x] Phase 2 live MOX: paired ALC row with zones renders, CFC/COMP dimmed, PA temp chip updates, overdrive pill trips on deliberate mic-clipping.
- [ ] Phase 3 live test pending maintainer: slider moves, backend accepts, reload persists.