### PR TITLE
feat(protocol2): P2 discovery, connect, and multi-band RX for ANAN G2

### DIFF
--- a/Zeus.Protocol2/AssemblyInfo.cs
+++ b/Zeus.Protocol2/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Zeus.Protocol2.Tests")]

--- a/Zeus.Protocol2/Discovery/DiscoveredRadio.cs
+++ b/Zeus.Protocol2/Discovery/DiscoveredRadio.cs
@@ -1,0 +1,26 @@
+using System.Net;
+using System.Net.NetworkInformation;
+
+namespace Zeus.Protocol2.Discovery;
+
+public sealed record DiscoveredRadio(
+    IPAddress Ip,
+    PhysicalAddress Mac,
+    HpsdrBoardKind Board,
+    byte FirmwareVersion,
+    string FirmwareString,
+    DiscoveryDetails Details);
+
+public sealed record DiscoveryDetails(
+    byte[] RawReply,
+    byte RawBoardId,
+    bool Busy,
+    byte ProtocolSupported,
+    byte NumReceivers,
+    byte BetaVersion,
+    byte MercuryVersion0,
+    byte MercuryVersion1,
+    byte MercuryVersion2,
+    byte MercuryVersion3,
+    byte PennyVersion,
+    byte MetisVersion);

--- a/Zeus.Protocol2/Discovery/HpsdrBoardKind.cs
+++ b/Zeus.Protocol2/Discovery/HpsdrBoardKind.cs
@@ -1,0 +1,13 @@
+namespace Zeus.Protocol2.Discovery;
+
+public enum HpsdrBoardKind : byte
+{
+    Atlas = 0x00,
+    Hermes = 0x01,
+    HermesII = 0x02,
+    Angelia = 0x04,
+    Orion = 0x05,
+    HermesLite2 = 0x06,
+    OrionMkII = 0x0A,
+    Unknown = 0xFF,
+}

--- a/Zeus.Protocol2/Discovery/IRadioDiscovery.cs
+++ b/Zeus.Protocol2/Discovery/IRadioDiscovery.cs
@@ -1,0 +1,6 @@
+namespace Zeus.Protocol2.Discovery;
+
+public interface IRadioDiscovery
+{
+    Task<IReadOnlyList<DiscoveredRadio>> DiscoverAsync(TimeSpan timeout, CancellationToken ct = default);
+}

--- a/Zeus.Protocol2/Discovery/RadioDiscoveryService.cs
+++ b/Zeus.Protocol2/Discovery/RadioDiscoveryService.cs
@@ -1,0 +1,210 @@
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Protocol2.Discovery;
+
+public sealed class RadioDiscoveryService : IRadioDiscovery
+{
+    private const int HpsdrPort = 1024;
+    private const int DiscoveryPacketLength = 60;
+    private const int ReceiveBufferSize = 2048;
+    private const int SendAttempts = 3;
+    private static readonly TimeSpan SendGap = TimeSpan.FromMilliseconds(50);
+
+    private readonly ILogger<RadioDiscoveryService> _log;
+
+    public RadioDiscoveryService(ILogger<RadioDiscoveryService> log)
+    {
+        _log = log;
+    }
+
+    public async Task<IReadOnlyList<DiscoveredRadio>> DiscoverAsync(TimeSpan timeout, CancellationToken ct = default)
+    {
+        var broadcastTargets = GetBroadcastTargets();
+
+        _log.LogDebug("p2.discovery.start interfaces={Count}", broadcastTargets.Count);
+        foreach (var (ifaceAddr, bcastAddr) in broadcastTargets)
+        {
+            _log.LogDebug("p2.discovery.interface local={Local} broadcast={Broadcast}", ifaceAddr, bcastAddr);
+        }
+
+        using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp)
+        {
+            EnableBroadcast = true,
+        };
+        socket.Bind(new IPEndPoint(IPAddress.Any, 0));
+
+        var packet = BuildDiscoveryPacket();
+        await SendProbesAsync(socket, packet, broadcastTargets, ct).ConfigureAwait(false);
+
+        var byMac = new Dictionary<PhysicalAddress, DiscoveredRadio>();
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(timeout);
+
+        var receiveBuffer = new byte[ReceiveBufferSize];
+        var any = new IPEndPoint(IPAddress.Any, 0);
+
+        try
+        {
+            while (!timeoutCts.IsCancellationRequested)
+            {
+                SocketReceiveFromResult res;
+                try
+                {
+                    res = await socket.ReceiveFromAsync(
+                        receiveBuffer,
+                        SocketFlags.None,
+                        any,
+                        timeoutCts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (SocketException ex)
+                {
+                    _log.LogWarning(ex, "p2.discovery.socket.error");
+                    break;
+                }
+
+                var fromIp = ((IPEndPoint)res.RemoteEndPoint).Address;
+                var slice = new ReadOnlySpan<byte>(receiveBuffer, 0, res.ReceivedBytes);
+
+                if (!ReplyParser.TryParse(slice, fromIp, out var radio))
+                {
+                    _log.LogDebug(
+                        "p2.discovery.reply.invalid from={Ip} len={Len}",
+                        fromIp,
+                        res.ReceivedBytes);
+                    continue;
+                }
+
+                byMac[radio.Mac] = radio;
+                _log.LogInformation(
+                    "p2.discovery.reply from={Ip} board={Board} mac={Mac} fw={Firmware} rxs={NumRx} protoVer={ProtoVer}",
+                    radio.Ip,
+                    radio.Board,
+                    radio.Mac,
+                    radio.FirmwareString,
+                    radio.Details.NumReceivers,
+                    radio.Details.ProtocolSupported);
+            }
+        }
+        finally
+        {
+            try { socket.Shutdown(SocketShutdown.Both); } catch (SocketException) { }
+        }
+
+        ct.ThrowIfCancellationRequested();
+
+        return byMac.Values.OrderBy(IpSortKey).ToList();
+    }
+
+    private async Task SendProbesAsync(
+        Socket socket,
+        ReadOnlyMemory<byte> packet,
+        IReadOnlyList<(IPAddress ifaceAddr, IPAddress bcastAddr)> broadcastTargets,
+        CancellationToken ct)
+    {
+        for (var attempt = 0; attempt < SendAttempts; attempt++)
+        {
+            foreach (var (_, bcastAddr) in broadcastTargets)
+            {
+                var endpoint = new IPEndPoint(bcastAddr, HpsdrPort);
+                try
+                {
+                    await socket.SendToAsync(packet, SocketFlags.None, endpoint, ct).ConfigureAwait(false);
+                }
+                catch (SocketException ex)
+                {
+                    _log.LogWarning(ex, "p2.discovery.send.error broadcast={Broadcast}", bcastAddr);
+                }
+            }
+
+            if (attempt < SendAttempts - 1)
+            {
+                try
+                {
+                    await Task.Delay(SendGap, ct).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+            }
+        }
+    }
+
+    private IReadOnlyList<(IPAddress ifaceAddr, IPAddress bcastAddr)> GetBroadcastTargets()
+    {
+        var targets = new List<(IPAddress, IPAddress)>();
+
+        try
+        {
+            var interfaces = NetworkInterface.GetAllNetworkInterfaces();
+            foreach (var iface in interfaces)
+            {
+                if (iface.OperationalStatus != OperationalStatus.Up)
+                    continue;
+                if (iface.NetworkInterfaceType == NetworkInterfaceType.Loopback)
+                    continue;
+                if (iface.NetworkInterfaceType == NetworkInterfaceType.Tunnel)
+                    continue;
+
+                var ipProps = iface.GetIPProperties();
+                foreach (var unicast in ipProps.UnicastAddresses)
+                {
+                    if (unicast.Address.AddressFamily != AddressFamily.InterNetwork)
+                        continue;
+
+                    var ip = unicast.Address;
+                    var mask = unicast.IPv4Mask;
+
+                    if (mask == null || mask.Equals(IPAddress.Any))
+                        continue;
+
+                    var ipBytes = ip.GetAddressBytes();
+                    var maskBytes = mask.GetAddressBytes();
+                    var bcastBytes = new byte[4];
+
+                    for (var i = 0; i < 4; i++)
+                    {
+                        bcastBytes[i] = (byte)(ipBytes[i] | ~maskBytes[i]);
+                    }
+
+                    var bcastAddr = new IPAddress(bcastBytes);
+                    targets.Add((ip, bcastAddr));
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "p2.discovery.enumerate.error");
+        }
+
+        if (targets.Count == 0)
+        {
+            _log.LogWarning("p2.discovery.enumerate.empty, using global broadcast");
+            targets.Add((IPAddress.Any, IPAddress.Broadcast));
+        }
+
+        return targets;
+    }
+
+    private static byte[] BuildDiscoveryPacket()
+    {
+        var buf = new byte[DiscoveryPacketLength];
+        buf[4] = 0x02;
+        return buf;
+    }
+
+    private static uint IpSortKey(DiscoveredRadio r)
+    {
+        var bytes = r.Ip.GetAddressBytes();
+        if (bytes.Length != 4) return uint.MaxValue;
+        return BinaryPrimitives.ReadUInt32BigEndian(bytes);
+    }
+}

--- a/Zeus.Protocol2/Discovery/ReplyParser.cs
+++ b/Zeus.Protocol2/Discovery/ReplyParser.cs
@@ -1,0 +1,85 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.NetworkInformation;
+
+namespace Zeus.Protocol2.Discovery;
+
+public static class ReplyParser
+{
+    public const int MinimumReplyLength = 24;
+    public const byte StatusIdle = 0x02;
+    public const byte StatusBusy = 0x03;
+
+    public static bool TryParse(
+        ReadOnlySpan<byte> raw,
+        IPAddress fromIp,
+        [NotNullWhen(true)] out DiscoveredRadio? radio)
+    {
+        radio = null;
+        if (raw.Length < MinimumReplyLength) return false;
+        if (raw[0] != 0x00 || raw[1] != 0x00 || raw[2] != 0x00 || raw[3] != 0x00) return false;
+
+        var status = raw[4];
+        if (status != StatusIdle && status != StatusBusy) return false;
+
+        var macBytes = raw.Slice(5, 6).ToArray();
+        var mac = new PhysicalAddress(macBytes);
+
+        var rawBoardId = raw[11];
+        var protocolSupported = raw[12];
+        var codeVersion = raw[13];
+        var mercuryVersion0 = raw[14];
+        var mercuryVersion1 = raw[15];
+        var mercuryVersion2 = raw[16];
+        var mercuryVersion3 = raw[17];
+        var pennyVersion = raw[18];
+        var metisVersion = raw[19];
+        var numReceivers = raw[20];
+        var betaVersion = raw.Length > 23 ? raw[23] : (byte)0;
+
+        var board = MapBoard(rawBoardId);
+        var firmwareString = FormatFirmware(codeVersion, betaVersion);
+
+        var details = new DiscoveryDetails(
+            RawReply: raw.ToArray(),
+            RawBoardId: rawBoardId,
+            Busy: status == StatusBusy,
+            ProtocolSupported: protocolSupported,
+            NumReceivers: numReceivers,
+            BetaVersion: betaVersion,
+            MercuryVersion0: mercuryVersion0,
+            MercuryVersion1: mercuryVersion1,
+            MercuryVersion2: mercuryVersion2,
+            MercuryVersion3: mercuryVersion3,
+            PennyVersion: pennyVersion,
+            MetisVersion: metisVersion);
+
+        radio = new DiscoveredRadio(
+            Ip: fromIp,
+            Mac: mac,
+            Board: board,
+            FirmwareVersion: codeVersion,
+            FirmwareString: firmwareString,
+            Details: details);
+        return true;
+    }
+
+    private static HpsdrBoardKind MapBoard(byte raw) => raw switch
+    {
+        0x00 => HpsdrBoardKind.Atlas,
+        0x01 => HpsdrBoardKind.Hermes,
+        0x02 => HpsdrBoardKind.HermesII,
+        0x04 => HpsdrBoardKind.Angelia,
+        0x05 => HpsdrBoardKind.Orion,
+        0x06 => HpsdrBoardKind.HermesLite2,
+        0x0A => HpsdrBoardKind.OrionMkII,
+        _ => HpsdrBoardKind.Unknown,
+    };
+
+    private static string FormatFirmware(byte codeVersion, byte betaVersion)
+    {
+        var major = codeVersion / 10;
+        var minor = codeVersion % 10;
+        return betaVersion == 0 ? $"{major}.{minor}" : $"{major}.{minor}b{betaVersion}";
+    }
+}

--- a/Zeus.Protocol2/IqFrame.cs
+++ b/Zeus.Protocol2/IqFrame.cs
@@ -1,0 +1,15 @@
+namespace Zeus.Protocol2;
+
+/// <summary>
+/// One decoded RX IQ packet from a Protocol 2 DDC stream. Interleaved I/Q
+/// stored as <c>double</c>s already scaled from the wire's int24 big-endian
+/// form into [-1.0, +1.0] so that downstream DSP never sees wire format.
+/// Shape matches <c>Zeus.Protocol1.IqFrame</c> by convention — the pipeline
+/// reads both identically.
+/// </summary>
+public readonly record struct IqFrame(
+    ReadOnlyMemory<double> InterleavedSamples,
+    int SampleCount,
+    int SampleRateHz,
+    uint Sequence,
+    long TimestampNs);

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -1,0 +1,316 @@
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Protocol2;
+
+/// <summary>
+/// Protocol 2 (OpenHPSDR "new protocol" / Thetis "ETH") streaming client.
+/// Mirrors Zeus.Protocol1.Protocol1Client's lifecycle surface where it
+/// overlaps; Protocol-1-only methods (HL2 dither, N2ADR filter board) are
+/// absent here. Wire format verified against Thetis ChannelMaster network.c.
+/// </summary>
+public sealed class Protocol2Client : IDisposable, IAsyncDisposable
+{
+    private const int BufLen = 1444;
+    private const int DiscoverySamplesPerPacket = 238;
+
+    private readonly ILogger<Protocol2Client> _log;
+    private readonly Channel<IqFrame> _iqFrames = Channel.CreateUnbounded<IqFrame>(
+        new UnboundedChannelOptions { SingleReader = true, SingleWriter = true });
+
+    private Socket? _sock;
+    private IPEndPoint? _radioEndpoint;
+    private CancellationTokenSource? _rxCts;
+    private Task? _rxTask;
+    private int _sampleRateKhz = 48;
+    private uint _rxFreqHz = 14_200_000;
+    private byte _numAdc = 2;
+    private uint _outSeq;
+    // Mercury preamp defaults OFF — on a G2 the ADC has enough dynamic range
+    // that the preamp is a crutch, not a default. Operator enables it when
+    // needed via the UI. Attenuator 0 dB so the front-end isn't knocked down.
+    private bool _preampOn;
+    private byte _rxStepAttnDb;
+    private long _totalFrames;
+    private long _droppedFrames;
+    private uint _lastDdc0Seq;
+    private bool _haveFirstDdc0;
+    private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
+
+    public Protocol2Client(ILogger<Protocol2Client> log)
+    {
+        _log = log;
+    }
+
+    public ChannelReader<IqFrame> IqFrames => _iqFrames.Reader;
+    public long TotalFrames => Interlocked.Read(ref _totalFrames);
+    public long DroppedFrames => Interlocked.Read(ref _droppedFrames);
+
+    public Task ConnectAsync(IPEndPoint radioEndpoint, CancellationToken ct)
+    {
+        if (_sock is not null)
+            throw new InvalidOperationException("Already connected.");
+
+        _radioEndpoint = new IPEndPoint(radioEndpoint.Address, 1024);
+        var sock = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        // Matched port convention — PC binds 1025, radio sends back with source
+        // ports 1025/1026/1027/1035.. which we demux by fromaddr.
+        sock.Bind(new IPEndPoint(IPAddress.Any, 1025));
+        sock.ReceiveBufferSize = 1 << 20;
+        _sock = sock;
+        _log.LogInformation("p2.connect radio={Radio} localPort=1025", radioEndpoint.Address);
+        return Task.CompletedTask;
+    }
+
+    public Task StartAsync(int sampleRateKhz, CancellationToken ct)
+    {
+        if (_sock is null || _radioEndpoint is null)
+            throw new InvalidOperationException("Call ConnectAsync first.");
+        if (_rxTask is not null)
+            throw new InvalidOperationException("Already started.");
+
+        _sampleRateKhz = sampleRateKhz;
+
+        SendCmdGeneral();
+        Thread.Sleep(50);
+        SendCmdRx();
+        Thread.Sleep(50);
+        SendCmdHighPriority(run: true);
+
+        _rxCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        _rxTask = Task.Run(() => RxLoop(_rxCts.Token));
+        _log.LogInformation("p2.start rate={Rate}kHz freq={Freq}Hz", _sampleRateKhz, _rxFreqHz);
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken ct)
+    {
+        if (_rxTask is null) return;
+
+        SendCmdHighPriority(run: false);
+        _rxCts?.Cancel();
+        try { await _rxTask.ConfigureAwait(false); }
+        catch (OperationCanceledException) { }
+        _rxTask = null;
+        _rxCts?.Dispose();
+        _rxCts = null;
+        _iqFrames.Writer.TryComplete();
+        _log.LogInformation("p2.stop totalFrames={Total} dropped={Drop}", _totalFrames, _droppedFrames);
+    }
+
+    public void SetVfoAHz(long hz)
+    {
+        _rxFreqHz = (uint)Math.Clamp(hz, 0L, uint.MaxValue);
+        if (_rxTask is not null) SendCmdHighPriority(run: true);
+    }
+
+    public void SetSampleRateKhz(int rateKhz)
+    {
+        _sampleRateKhz = rateKhz;
+        if (_rxTask is not null)
+        {
+            SendCmdRx();
+        }
+    }
+
+    public void SetNumAdc(byte numAdc)
+    {
+        _numAdc = numAdc;
+    }
+
+    public void SetPreamp(bool on)
+    {
+        _preampOn = on;
+        if (_rxTask is not null) SendCmdHighPriority(run: true);
+    }
+
+    public void SetAttenuator(int db)
+    {
+        _rxStepAttnDb = (byte)Math.Clamp(db, 0, 31);
+        if (_rxTask is not null) SendCmdHighPriority(run: true);
+    }
+
+    private void SendCmdGeneral()
+    {
+        var p = new byte[60];
+        p[4] = 0x00;
+        WriteBeU16(p, 5, 1025);
+        WriteBeU16(p, 7, 1026);
+        WriteBeU16(p, 9, 1027);
+        WriteBeU16(p, 11, 1025);
+        WriteBeU16(p, 13, 1028);
+        WriteBeU16(p, 15, 1029);
+        WriteBeU16(p, 17, 1035);
+        WriteBeU16(p, 19, 1026);
+        WriteBeU16(p, 21, 1027);
+        p[23] = 0x00;
+        BinaryPrimitives.WriteUInt16BigEndian(p.AsSpan(24), 512);
+        p[26] = 16;
+        p[27] = 0;
+        p[28] = 32;
+        p[37] = 0x00;
+        p[38] = 0x00;
+        p[58] = 0x01;
+        // ALEX enable bits: Alex0 = 0x01, Alex1 = 0x02; Thetis sends 0x03 so
+        // the radio actually consumes the filter bytes in CmdHighPriority.
+        // Without this the radio silently ignores our BPF / antenna bits.
+        p[59] = 0x03;
+        _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1024));
+    }
+
+    private void SendCmdRx()
+    {
+        var p = new byte[BufLen];
+        WriteBeU32(p, 0, _outSeq++);
+        p[4] = _numAdc;
+        p[5] = 0;
+        p[6] = 0;
+        p[7] = 0x01;              // enable RX0 only (for now)
+        p[17] = 0x00;             // RX0 <- ADC0
+        WriteBeU16(p, 18, _sampleRateKhz);
+        p[22] = 24;
+        _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1025));
+    }
+
+    private void SendCmdHighPriority(bool run)
+    {
+        var p = new byte[BufLen];
+        WriteBeU32(p, 0, _outSeq++);
+        p[4] = (byte)(run ? 0x01 : 0x00);
+        WriteBeU32(p, 9, _rxFreqHz);
+
+        // Mercury attenuator byte: bit 0 = RX0 preamp, bit 1 = RX1 preamp
+        // (Thetis network.c:1037). Setting RX0 preamp keeps the 20 dB LNA in
+        // circuit so weak bands (80m / 160m) don't disappear below the ADC
+        // noise floor.
+        p[1403] = (byte)(_preampOn ? 0x01 : 0x00);
+
+        // ADC0 step attenuator (0-31 dB). Thetis network.c:1057.
+        p[1443] = _rxStepAttnDb;
+
+        // Alex0 RX0 filter word. ANT_1 (bit 24 → byte 1432 LSB) routes
+        // antenna 1 into RX0. Do NOT set bit 12 — while Thetis struct calls
+        // it "_Bypass" it corresponds to the PureSignal feedback path on
+        // ANAN MkII hardware and silences normal RX. Per-band HPF selection
+        // left to the radio's firmware for now; revisit with an explicit
+        // band setter later.
+        p[1432] = 0x01;
+        _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1027));
+    }
+
+    private void RxLoop(CancellationToken ct)
+    {
+        var buf = new byte[2048];
+        var sock = _sock!;
+        sock.ReceiveTimeout = 500;
+
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                int n;
+                EndPoint from = new IPEndPoint(IPAddress.Any, 0);
+                try
+                {
+                    n = sock.ReceiveFrom(buf, ref from);
+                }
+                catch (SocketException ex) when (ex.SocketErrorCode == SocketError.TimedOut)
+                {
+                    continue;
+                }
+                catch (SocketException ex) when (ex.SocketErrorCode == SocketError.Interrupted
+                                              || ex.SocketErrorCode == SocketError.OperationAborted)
+                {
+                    break;
+                }
+
+                var srcPort = ((IPEndPoint)from).Port;
+                if (srcPort >= 1035 && srcPort <= 1041 && n == BufLen)
+                {
+                    HandleDdcPacket(buf, srcPort - 1035);
+                }
+                // other ports (hi-pri status, mic, wideband) intentionally ignored for now
+            }
+        }
+        finally
+        {
+            _iqFrames.Writer.TryComplete();
+        }
+    }
+
+    private void HandleDdcPacket(byte[] buf, int ddcIndex)
+    {
+        var seq = BinaryPrimitives.ReadUInt32BigEndian(buf);
+        if (ddcIndex == 0)
+        {
+            if (_haveFirstDdc0 && seq != _lastDdc0Seq + 1)
+            {
+                Interlocked.Increment(ref _droppedFrames);
+            }
+            _haveFirstDdc0 = true;
+            _lastDdc0Seq = seq;
+        }
+
+        // 238 complex samples: I (int24 BE) + Q (int24 BE), starting at byte 16.
+        const int samplesPerPacket = DiscoverySamplesPerPacket;
+        var samples = ArrayPool<double>.Shared.Rent(samplesPerPacket * 2);
+        const double scale = 1.0 / 8388608.0;
+        for (int i = 0; i < samplesPerPacket; i++)
+        {
+            int off = 16 + i * 6;
+            int iRaw = (buf[off] << 16) | (buf[off + 1] << 8) | buf[off + 2];
+            if ((iRaw & 0x800000) != 0) iRaw |= unchecked((int)0xFF000000);
+            int qRaw = (buf[off + 3] << 16) | (buf[off + 4] << 8) | buf[off + 5];
+            if ((qRaw & 0x800000) != 0) qRaw |= unchecked((int)0xFF000000);
+            samples[i * 2] = iRaw * scale;
+            samples[i * 2 + 1] = qRaw * scale;
+        }
+
+        var frame = new IqFrame(
+            InterleavedSamples: new ReadOnlyMemory<double>(samples, 0, samplesPerPacket * 2),
+            SampleCount: samplesPerPacket,
+            SampleRateHz: _sampleRateKhz * 1000,
+            Sequence: seq,
+            TimestampNs: _stopwatch.ElapsedTicks * 1_000_000_000L / Stopwatch.Frequency);
+
+        Interlocked.Increment(ref _totalFrames);
+        _iqFrames.Writer.TryWrite(frame);
+    }
+
+    public void Dispose()
+    {
+        try { StopAsync(CancellationToken.None).GetAwaiter().GetResult(); } catch { }
+        _sock?.Dispose();
+        _sock = null;
+        _rxCts?.Dispose();
+        _rxCts = null;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        try { await StopAsync(CancellationToken.None).ConfigureAwait(false); } catch { }
+        _sock?.Dispose();
+        _sock = null;
+        _rxCts?.Dispose();
+        _rxCts = null;
+    }
+
+    private static void WriteBeU16(byte[] buf, int offset, int value)
+    {
+        buf[offset] = (byte)((value >> 8) & 0xff);
+        buf[offset + 1] = (byte)(value & 0xff);
+    }
+
+    private static void WriteBeU32(byte[] buf, int offset, uint value)
+    {
+        buf[offset] = (byte)((value >> 24) & 0xff);
+        buf[offset + 1] = (byte)((value >> 16) & 0xff);
+        buf[offset + 2] = (byte)((value >> 8) & 0xff);
+        buf[offset + 3] = (byte)(value & 0xff);
+    }
+}

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -19,6 +19,19 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     private const int BufLen = 1444;
     private const int DiscoverySamplesPerPacket = 238;
 
+    // On ANAN G2 MkII (Orion-II / Saturn) the first two DDC slots are wired
+    // to the PureSignal / diversity feedback path. User-visible receivers
+    // start at DDC2. pihpsdr's `new_protocol_receive_specific` and
+    // `new_protocol_high_priority` both do `ddc = 2 + i` for these boards;
+    // we follow the same convention. Radio then sends DDC2 IQ from port
+    // 1035 + 2 = 1037.
+    private const int G2RxDdc = 2;
+
+    // 2^32 / 122_880_000 — converts Hz to a 32-bit phase-increment word
+    // when the general packet is in "send phase word" mode (bit 3 of
+    // CmdGeneral[37], which pihpsdr and Thetis both set).
+    private const double HzToPhase = 34.952533333333333;
+
     private readonly ILogger<Protocol2Client> _log;
     private readonly Channel<IqFrame> _iqFrames = Channel.CreateUnbounded<IqFrame>(
         new UnboundedChannelOptions { SingleReader = true, SingleWriter = true });
@@ -27,10 +40,10 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     private IPEndPoint? _radioEndpoint;
     private CancellationTokenSource? _rxCts;
     private Task? _rxTask;
+    private Task? _keepaliveTask;
     private int _sampleRateKhz = 48;
     private uint _rxFreqHz = 14_200_000;
     private byte _numAdc = 2;
-    private uint _outSeq;
     // Mercury preamp defaults OFF — on a G2 the ADC has enough dynamic range
     // that the preamp is a crutch, not a default. Operator enables it when
     // needed via the UI. Attenuator 0 dB so the front-end isn't knocked down.
@@ -41,6 +54,15 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     private uint _lastDdc0Seq;
     private bool _haveFirstDdc0;
     private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
+    // Per-stream sequence counters. The G2 firmware tracks seq per destination
+    // port; sharing one counter across CmdGeneral/CmdRx/CmdTx/CmdHighPriority
+    // makes the first HighPriority packet land at seq=2+, which the radio
+    // treats as "stream started mid-flight" and silently drops — leaving the
+    // DDC locked to whatever the previous client's last tune was.
+    private uint _seqCmdGeneral;
+    private uint _seqCmdRx;
+    private uint _seqCmdTx;
+    private uint _seqCmdHp;
 
     public Protocol2Client(ILogger<Protocol2Client> log)
     {
@@ -76,14 +98,22 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
 
         _sampleRateKhz = sampleRateKhz;
 
+        // Startup sequence matches Thetis SendStart() and Priapus/NextGenSDR:
+        // CmdGeneral → CmdRx → CmdTx → CmdHighPriority(run=1). Skipping CmdTx
+        // leaves the G2 MkII in a half-configured state where its BPF board
+        // latches a random band instead of honouring CmdHighPriority filter
+        // bits on subsequent tunes.
         SendCmdGeneral();
         Thread.Sleep(50);
         SendCmdRx();
+        Thread.Sleep(50);
+        SendCmdTx();
         Thread.Sleep(50);
         SendCmdHighPriority(run: true);
 
         _rxCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         _rxTask = Task.Run(() => RxLoop(_rxCts.Token));
+        _keepaliveTask = Task.Run(() => KeepaliveLoop(_rxCts.Token));
         _log.LogInformation("p2.start rate={Rate}kHz freq={Freq}Hz", _sampleRateKhz, _rxFreqHz);
         return Task.CompletedTask;
     }
@@ -97,6 +127,12 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         try { await _rxTask.ConfigureAwait(false); }
         catch (OperationCanceledException) { }
         _rxTask = null;
+        if (_keepaliveTask is not null)
+        {
+            try { await _keepaliveTask.ConfigureAwait(false); }
+            catch (OperationCanceledException) { }
+            _keepaliveTask = null;
+        }
         _rxCts?.Dispose();
         _rxCts = null;
         _iqFrames.Writer.TryComplete();
@@ -106,7 +142,10 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     public void SetVfoAHz(long hz)
     {
         _rxFreqHz = (uint)Math.Clamp(hz, 0L, uint.MaxValue);
-        if (_rxTask is not null) SendCmdHighPriority(run: true);
+        var running = _rxTask is not null;
+        _log.LogInformation("p2.tune hz={Hz} running={Running} hpSeq={Seq}",
+            _rxFreqHz, running, _seqCmdHp);
+        if (running) SendCmdHighPriority(run: true);
     }
 
     public void SetSampleRateKhz(int rateKhz)
@@ -138,6 +177,7 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     private void SendCmdGeneral()
     {
         var p = new byte[60];
+        WriteBeU32(p, 0, _seqCmdGeneral++);
         p[4] = 0x00;
         WriteBeU16(p, 5, 1025);
         WriteBeU16(p, 7, 1026);
@@ -153,12 +193,14 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         p[26] = 16;
         p[27] = 0;
         p[28] = 32;
-        p[37] = 0x00;
-        p[38] = 0x00;
+        // Matches pihpsdr new_protocol_general for ORION2/SATURN hardware:
+        // [37] bit 3 = phase-word mode (radio reads phase increments at the
+        // DDC-frequency offsets, not raw Hz), [38] = hardware-timer enable,
+        // [58] = PA enable, [59] = Alex0|Alex1 enable (0x03 is required on
+        // MkII for the BPF board to honour the alex bits further down).
+        p[37] = 0x08;
+        p[38] = 0x01;
         p[58] = 0x01;
-        // ALEX enable bits: Alex0 = 0x01, Alex1 = 0x02; Thetis sends 0x03 so
-        // the radio actually consumes the filter bytes in CmdHighPriority.
-        // Without this the radio silently ignores our BPF / antenna bits.
         p[59] = 0x03;
         _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1024));
     }
@@ -166,41 +208,130 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     private void SendCmdRx()
     {
         var p = new byte[BufLen];
-        WriteBeU32(p, 0, _outSeq++);
-        p[4] = _numAdc;
+        WriteBeU32(p, 0, _seqCmdRx++);
+        // Mirrors pihpsdr new_protocol_receive_specific for the MkII:
+        //   n_adc = 2 (G2 has two physical ADCs), DDC2 enabled by bit 2 in
+        //   the enable mask, and the DDC config block sits at 17 + 2*6 = 29.
+        //   DDC0/1 stay disabled — those slots are reserved by the radio for
+        //   the PureSignal/Diversity hardware pair.
+        p[4] = 2;
         p[5] = 0;
         p[6] = 0;
-        p[7] = 0x01;              // enable RX0 only (for now)
-        p[17] = 0x00;             // RX0 <- ADC0
-        WriteBeU16(p, 18, _sampleRateKhz);
-        p[22] = 24;
+        p[7] = (byte)(1 << G2RxDdc);  // = 0x04
+        int off = 17 + G2RxDdc * 6;
+        p[off + 0] = 0x00;            // DDC2 <- ADC0
+        WriteBeU16(p, off + 1, _sampleRateKhz);
+        p[off + 5] = 24;              // bit depth
         _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1025));
+    }
+
+    private void SendCmdTx()
+    {
+        var p = new byte[60];
+        WriteBeU32(p, 0, _seqCmdTx++);
+        p[4] = 1;                 // num_dac
+        WriteBeU16(p, 14, _sampleRateKhz);
+        _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1026));
     }
 
     private void SendCmdHighPriority(bool run)
     {
         var p = new byte[BufLen];
-        WriteBeU32(p, 0, _outSeq++);
+        WriteBeU32(p, 0, _seqCmdHp++);
         p[4] = (byte)(run ? 0x01 : 0x00);
-        WriteBeU32(p, 9, _rxFreqHz);
+
+        // Frequency field is a PHASE word (general[37] bit 3 set) — radio
+        // reads a 32-bit phase increment, not Hz. pihpsdr computes this as
+        //   phase = freq_hz * 2^32 / 122_880_000
+        // The G2 MkII puts the user-visible RX0 at DDC slot 2, so the phase
+        // goes to bytes 9 + 2*4 = 17..20. Bytes 9..16 (DDC0/1) are left as
+        // zero per pihpsdr's non-PS non-diversity code path. TX DUC phase is
+        // written to 329..332 as the same value for out-of-band gating.
+        uint rxPhase = (uint)(_rxFreqHz * HzToPhase);
+        WriteBeU32(p, 9 + G2RxDdc * 4, rxPhase);
+        WriteBeU32(p, 329, rxPhase);
 
         // Mercury attenuator byte: bit 0 = RX0 preamp, bit 1 = RX1 preamp
-        // (Thetis network.c:1037). Setting RX0 preamp keeps the 20 dB LNA in
-        // circuit so weak bands (80m / 160m) don't disappear below the ADC
-        // noise floor.
+        // (Thetis network.c:1037).
         p[1403] = (byte)(_preampOn ? 0x01 : 0x00);
 
         // ADC0 step attenuator (0-31 dB). Thetis network.c:1057.
         p[1443] = _rxStepAttnDb;
 
-        // Alex0 RX0 filter word. ANT_1 (bit 24 → byte 1432 LSB) routes
-        // antenna 1 into RX0. Do NOT set bit 12 — while Thetis struct calls
-        // it "_Bypass" it corresponds to the PureSignal feedback path on
-        // ANAN MkII hardware and silences normal RX. Per-band HPF selection
-        // left to the radio's firmware for now; revisit with an explicit
-        // band setter later.
-        p[1432] = 0x01;
+        // Alex0 and Alex1 BPF words. pihpsdr constructs these with its own
+        // ALEX_* bit macros (same packed form Priapus uses).
+        uint alex = ComputeAlexWord(_rxFreqHz, _rxFreqHz, txAnt: 1);
+        WriteBeU32(p, 1428, alex);
+        WriteBeU32(p, 1432, alex);
         _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1027));
+    }
+
+    internal static uint ComputeAlexWord(uint rxFreqHz, uint txFreqHz, int txAnt)
+    {
+        uint word = 0;
+        word |= (uint)LpfBits(txFreqHz) << 24;
+        word |= (uint)(1 << (txAnt - 1)) << 16;
+        word |= (uint)HpfBits(rxFreqHz) << 8;
+        return word;
+    }
+
+    internal static byte HpfBits(uint freqHz)
+    {
+        if (freqHz >= 39_850_000u) return 0x40; // 6 m preamp
+        if (freqHz >= 26_465_000u) return 0x20; // bypass
+        if (freqHz >= 19_584_000u) return 0x02; // 20 MHz HPF
+        if (freqHz >= 12_075_000u) return 0x01; // 13 MHz HPF
+        if (freqHz >=  6_202_000u) return 0x04; // 9.5 MHz HPF
+        if (freqHz >=  4_665_000u) return 0x08; // 6.5 MHz HPF
+        return 0x10;                            // 1.5 MHz HPF
+    }
+
+    internal static byte LpfBits(uint freqHz)
+    {
+        if (freqHz >= 39_850_000u) return 0x10; // 6 m LPF
+        if (freqHz >= 26_465_000u) return 0x20; // 12/10 m LPF
+        if (freqHz >= 19_584_000u) return 0x40; // 17/15 m LPF
+        if (freqHz >= 12_075_000u) return 0x01; // 30/20 m LPF
+        if (freqHz >=  4_665_000u) return 0x02; // 60/40 m LPF
+        if (freqHz >=  2_750_000u) return 0x04; // 80 m LPF
+        return 0x08;                            // 160 m LPF
+    }
+
+    // Mirrors pihpsdr's new_protocol_timer_thread:
+    //   HighPriority every 100 ms, RX/TX specific every 200 ms, General
+    //   every 800 ms. The G2 MkII expects this cadence once the hardware
+    //   watchdog is enabled in CmdGeneral[38] — without it the radio
+    //   treats the stream as abandoned and freezes IQ within ~1 s.
+    private async Task KeepaliveLoop(CancellationToken ct)
+    {
+        int cycle = 0;
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                await Task.Delay(100, ct).ConfigureAwait(false);
+                cycle = (cycle % 8) + 1;
+                SendCmdHighPriority(run: true);
+                switch (cycle)
+                {
+                    case 2: case 4: case 6:
+                        SendCmdRx();
+                        break;
+                    case 1: case 3: case 5: case 7:
+                        SendCmdTx();
+                        break;
+                    case 8:
+                        SendCmdRx();
+                        SendCmdGeneral();
+                        break;
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "p2.keepalive exited with error");
+        }
     }
 
     private void RxLoop(CancellationToken ct)

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -258,43 +258,85 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         // ADC0 step attenuator (0-31 dB). Thetis network.c:1057.
         p[1443] = _rxStepAttnDb;
 
-        // Alex0 and Alex1 BPF words. pihpsdr constructs these with its own
-        // ALEX_* bit macros (same packed form Priapus uses).
+        // Alex words. Bit positions and BPF selections per pihpsdr's alex.h +
+        // new_protocol.c (function new_protocol_high_priority, device cases
+        // NEW_DEVICE_ORION2 / NEW_DEVICE_SATURN). Alex0 holds the RX BPF +
+        // TX LPF + TX antenna; Alex1 duplicates for the RX path during TX.
+        // Offsets: Alex0 at 1432..1435, Alex1 at 1428..1431.
         uint alex = ComputeAlexWord(_rxFreqHz, _rxFreqHz, txAnt: 1);
         WriteBeU32(p, 1428, alex);
         WriteBeU32(p, 1432, alex);
         _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1027));
     }
 
+    // ANAN-7000 / Orion-II / Saturn (G2 MkII) BPF board constants. Copied
+    // verbatim from pihpsdr's alex.h — these are the RX BPF selections the
+    // MkII's filter board expects. The older ALEX_*_HPF constants used for
+    // ANAN-100 / classic Alex do NOT work on MkII — the filter board
+    // silently selects "nothing" and all RF is cut off at the ADC.
+    private const uint ALEX_ANAN7000_RX_BYPASS_BPF = 0x00001000;
+    private const uint ALEX_ANAN7000_RX_160_BPF    = 0x00000040;
+    private const uint ALEX_ANAN7000_RX_80_60_BPF  = 0x00000020;
+    private const uint ALEX_ANAN7000_RX_40_30_BPF  = 0x00000010;
+    private const uint ALEX_ANAN7000_RX_20_15_BPF  = 0x00000002;
+    private const uint ALEX_ANAN7000_RX_12_10_BPF  = 0x00000004;
+    private const uint ALEX_ANAN7000_RX_6_PRE_BPF  = 0x00000008;
+
+    // TX LPF constants (used during TX; harmless during RX but worth setting
+    // correctly so the BPF board stays in a sane latched state if the radio
+    // momentarily T/Rs).
+    private const uint ALEX_160_LPF        = 0x00800000;
+    private const uint ALEX_80_LPF         = 0x00400000;
+    private const uint ALEX_60_40_LPF      = 0x00200000;
+    private const uint ALEX_30_20_LPF      = 0x00100000;
+    private const uint ALEX_17_15_LPF      = 0x80000000;
+    private const uint ALEX_12_10_LPF      = 0x40000000;
+    private const uint ALEX_6_BYPASS_LPF   = 0x20000000;
+
+    // TX antenna select.
+    private const uint ALEX_TX_ANTENNA_1   = 0x01000000;
+    private const uint ALEX_TX_ANTENNA_2   = 0x02000000;
+    private const uint ALEX_TX_ANTENNA_3   = 0x04000000;
+
     internal static uint ComputeAlexWord(uint rxFreqHz, uint txFreqHz, int txAnt)
     {
         uint word = 0;
-        word |= (uint)LpfBits(txFreqHz) << 24;
-        word |= (uint)(1 << (txAnt - 1)) << 16;
-        word |= (uint)HpfBits(rxFreqHz) << 8;
+        word |= BpfBitsAnan7000(rxFreqHz);
+        word |= LpfBitsAnan7000(txFreqHz);
+        word |= txAnt switch
+        {
+            1 => ALEX_TX_ANTENNA_1,
+            2 => ALEX_TX_ANTENNA_2,
+            3 => ALEX_TX_ANTENNA_3,
+            _ => ALEX_TX_ANTENNA_1,
+        };
         return word;
     }
 
-    internal static byte HpfBits(uint freqHz)
+    // RX BPF band splits lifted from pihpsdr new_protocol.c
+    // (function new_protocol_high_priority, ADC0 BPFfreq selection).
+    internal static uint BpfBitsAnan7000(uint freqHz)
     {
-        if (freqHz >= 39_850_000u) return 0x40; // 6 m preamp
-        if (freqHz >= 26_465_000u) return 0x20; // bypass
-        if (freqHz >= 19_584_000u) return 0x02; // 20 MHz HPF
-        if (freqHz >= 12_075_000u) return 0x01; // 13 MHz HPF
-        if (freqHz >=  6_202_000u) return 0x04; // 9.5 MHz HPF
-        if (freqHz >=  4_665_000u) return 0x08; // 6.5 MHz HPF
-        return 0x10;                            // 1.5 MHz HPF
+        if (freqHz <  1_500_000u) return ALEX_ANAN7000_RX_BYPASS_BPF;
+        if (freqHz <  2_100_000u) return ALEX_ANAN7000_RX_160_BPF;
+        if (freqHz <  5_500_000u) return ALEX_ANAN7000_RX_80_60_BPF;
+        if (freqHz < 11_000_000u) return ALEX_ANAN7000_RX_40_30_BPF;
+        if (freqHz < 22_000_000u) return ALEX_ANAN7000_RX_20_15_BPF;
+        if (freqHz < 35_000_000u) return ALEX_ANAN7000_RX_12_10_BPF;
+        return ALEX_ANAN7000_RX_6_PRE_BPF;
     }
 
-    internal static byte LpfBits(uint freqHz)
+    // TX LPF band splits (pihpsdr calc_tx_alex in alex.c). Same band groupings
+    // as the physical LPF board — not HPF-shaped.
+    internal static uint LpfBitsAnan7000(uint freqHz)
     {
-        if (freqHz >= 39_850_000u) return 0x10; // 6 m LPF
-        if (freqHz >= 26_465_000u) return 0x20; // 12/10 m LPF
-        if (freqHz >= 19_584_000u) return 0x40; // 17/15 m LPF
-        if (freqHz >= 12_075_000u) return 0x01; // 30/20 m LPF
-        if (freqHz >=  4_665_000u) return 0x02; // 60/40 m LPF
-        if (freqHz >=  2_750_000u) return 0x04; // 80 m LPF
-        return 0x08;                            // 160 m LPF
+        if (freqHz >= 33_000_000u) return ALEX_6_BYPASS_LPF;
+        if (freqHz >= 22_000_000u) return ALEX_12_10_LPF;
+        if (freqHz >= 15_000_000u) return ALEX_17_15_LPF;
+        if (freqHz >=  8_000_000u) return ALEX_30_20_LPF;
+        if (freqHz >=  4_500_000u) return ALEX_60_40_LPF;
+        if (freqHz >=  2_500_000u) return ALEX_80_LPF;
+        return ALEX_160_LPF;
     }
 
     // Mirrors pihpsdr's new_protocol_timer_thread:

--- a/Zeus.Protocol2/Zeus.Protocol2.csproj
+++ b/Zeus.Protocol2/Zeus.Protocol2.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Zeus.Contracts\Zeus.Contracts.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Zeus.Server/DspPipelineService.cs
+++ b/Zeus.Server/DspPipelineService.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
 using Zeus.Contracts;
@@ -27,6 +28,12 @@ public class DspPipelineService : BackgroundService
 
     private Task? _iqPumpTask;
     private CancellationTokenSource? _iqPumpCts;
+
+    // Protocol 2 path (parallel to the RadioService-owned P1 path). Held
+    // directly here because RadioService is Protocol1Client-shaped and
+    // growing a P2 variant there would require a larger refactor; for now
+    // keeping it isolated avoids touching any P1 behavior.
+    private Zeus.Protocol2.Protocol2Client? _p2Client;
 
     private RxMode _appliedMode = RxMode.USB;
     private int _appliedLowHz;
@@ -173,6 +180,14 @@ public class DspPipelineService : BackgroundService
 
     private void OnRadioStateChanged(StateDto s)
     {
+        // Forward VFO changes to the P2 client when it's active. RadioService
+        // does this for P1 via ActiveClient?.SetVfoAHz() inside SetVfo, but
+        // ActiveClient is null for P2 connections, so the radio never learns
+        // about tune changes without this forward. Sample rate / mode follow
+        // here too when P2-side support is added.
+        var p2 = _p2Client;
+        p2?.SetVfoAHz(s.VfoHz);
+
         IDspEngine? engine;
         int channel;
         lock (_engineLock) { engine = _engine; channel = _channelId; }
@@ -256,6 +271,129 @@ public class DspPipelineService : BackgroundService
             }
         }, cts.Token);
     }
+
+    private void StartIqPumpP2(Zeus.Protocol2.Protocol2Client client)
+    {
+        var cts = new CancellationTokenSource();
+        _iqPumpCts = cts;
+        _iqPumpTask = Task.Run(async () =>
+        {
+            try
+            {
+                await foreach (var frame in client.IqFrames.ReadAllAsync(cts.Token).ConfigureAwait(false))
+                {
+                    IDspEngine? engine;
+                    int channel;
+                    lock (_engineLock) { engine = _engine; channel = _channelId; }
+                    engine?.FeedIq(channel, frame.InterleavedSamples.Span);
+                }
+            }
+            catch (OperationCanceledException) { }
+            catch (ChannelClosedException) { }
+            catch (Exception ex)
+            {
+                _log.LogWarning(ex, "dsp.pipeline p2 iq-pump exited with error");
+            }
+        }, cts.Token);
+    }
+
+    /// <summary>
+    /// Connect to a Protocol 2 radio and start streaming RX IQ into the DSP
+    /// engine. Parallel path to RadioService.ConnectAsync (which is Protocol 1
+    /// only); both swap the engine to WDSP and start a pump. Only one client
+    /// at a time.
+    /// </summary>
+    public async Task ConnectP2Async(IPEndPoint radioEndpoint, int sampleRateKhz, byte numAdc, CancellationToken ct)
+    {
+        if (_p2Client is not null)
+            throw new InvalidOperationException("Already connected (P2).");
+        if (_radio.ActiveClient is not null)
+            throw new InvalidOperationException("Already connected (P1). Disconnect first.");
+
+        var client = new Zeus.Protocol2.Protocol2Client(
+            _loggerFactory.CreateLogger<Zeus.Protocol2.Protocol2Client>());
+        client.SetNumAdc(numAdc);
+        await client.ConnectAsync(radioEndpoint, ct).ConfigureAwait(false);
+        await client.StartAsync(sampleRateKhz, ct).ConfigureAwait(false);
+
+        int rateHz = sampleRateKhz * 1000;
+        IDspEngine newEngine;
+        int newChannelId;
+        try
+        {
+            var wdsp = new WdspDspEngine(_loggerFactory.CreateLogger<WdspDspEngine>());
+            newChannelId = wdsp.OpenChannel(rateHz, Width);
+            wdsp.OpenTxChannel();
+            // Best-effort apply. Some local WDSP builds are missing newer
+            // entry points (e.g. SetRXAEMNRpost2Run); the channel itself is
+            // open and capable of spectrum work even if a noise-reduction
+            // toggle can't be set. Narrow catch so a genuinely broken engine
+            // still surfaces via the outer handler.
+            try { ApplyStateToNewChannel(wdsp, newChannelId); }
+            catch (EntryPointNotFoundException ex)
+            {
+                _log.LogWarning(ex, "dsp.pipeline p2 wdsp missing entry point — partial config applied");
+            }
+            newEngine = wdsp;
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "dsp.pipeline p2 wdsp open failed, falling back to synthetic engine");
+            var synth = new SyntheticDspEngine();
+            newChannelId = synth.OpenChannel(rateHz, Width);
+            try { ApplyStateToNewChannel(synth, newChannelId); }
+            catch (EntryPointNotFoundException) { }
+            newEngine = synth;
+        }
+
+        IDspEngine? old;
+        int oldChannel;
+        lock (_engineLock)
+        {
+            old = _engine;
+            oldChannel = _channelId;
+            _engine = newEngine;
+            _channelId = newChannelId;
+            _sampleRateHz = rateHz;
+        }
+        TeardownEngine(old, oldChannel);
+        _log.LogInformation("dsp.pipeline p2 engine={Engine} rate={Rate}", newEngine.GetType().Name, rateHz);
+
+        _p2Client = client;
+        StartIqPumpP2(client);
+        _radio.MarkProtocol2Connected(radioEndpoint.ToString(), rateHz);
+    }
+
+    public async Task DisconnectP2Async(CancellationToken ct)
+    {
+        var client = _p2Client;
+        _p2Client = null;
+        if (client is null) return;
+
+        await StopIqPumpAsync().ConfigureAwait(false);
+        try { await client.StopAsync(ct).ConfigureAwait(false); } catch { }
+        await client.DisposeAsync().ConfigureAwait(false);
+
+        var synth = new SyntheticDspEngine();
+        int channelId = synth.OpenChannel(SyntheticSampleRateHz, Width);
+        ApplyStateToNewChannel(synth, channelId);
+
+        IDspEngine? old;
+        int oldChannel;
+        lock (_engineLock)
+        {
+            old = _engine;
+            oldChannel = _channelId;
+            _engine = synth;
+            _channelId = channelId;
+            _sampleRateHz = SyntheticSampleRateHz;
+        }
+        TeardownEngine(old, oldChannel);
+        _radio.MarkProtocol2Disconnected();
+        _log.LogInformation("dsp.pipeline p2 disconnected, engine=synthetic");
+    }
+
+    public Zeus.Protocol2.Protocol2Client? ActiveP2Client => _p2Client;
 
     private async Task StopIqPumpAsync()
     {

--- a/Zeus.Server/Program.cs
+++ b/Zeus.Server/Program.cs
@@ -54,6 +54,9 @@ builder.WebHost.ConfigureKestrel(k =>
 // WDSP while a Protocol1Client is attached. No IDspEngine DI registration —
 // swapping requires lifecycle control the container can't express.
 builder.Services.AddSingleton<IRadioDiscovery, RadioDiscoveryService>();
+builder.Services.AddSingleton<
+    Zeus.Protocol2.Discovery.IRadioDiscovery,
+    Zeus.Protocol2.Discovery.RadioDiscoveryService>();
 // TxIqRing is shared: TxAudioIngest writes modulated IQ into it, Protocol1Client
 // (constructed inside RadioService) reads from it for the EP2 payload.
 builder.Services.AddSingleton<Zeus.Protocol1.TxIqRing>();
@@ -158,21 +161,41 @@ app.MapGet("/api/tx/diag", (Zeus.Protocol1.TxIqRing ring, Zeus.Protocol1.ITxIqSo
     });
 });
 
-app.MapGet("/api/radios", async (IRadioDiscovery discovery, HttpContext ctx) =>
+app.MapGet("/api/radios", async (
+    IRadioDiscovery p1Discovery,
+    Zeus.Protocol2.Discovery.IRadioDiscovery p2Discovery,
+    HttpContext ctx) =>
 {
-    var radios = await discovery.DiscoverAsync(TimeSpan.FromMilliseconds(1500), ctx.RequestAborted);
-    return radios.Select(r => new RadioInfo(
+    var timeout = TimeSpan.FromMilliseconds(1500);
+    var p1Task = p1Discovery.DiscoverAsync(timeout, ctx.RequestAborted);
+    var p2Task = p2Discovery.DiscoverAsync(timeout, ctx.RequestAborted);
+    await Task.WhenAll(p1Task, p2Task);
+
+    var p1Infos = p1Task.Result.Select(MapP1);
+    var p2Infos = p2Task.Result.Select(MapP2);
+    return p1Infos.Concat(p2Infos).ToArray();
+
+    static RadioInfo MapP1(DiscoveredRadio r) => new(
         MacAddress: r.Mac.ToString(),
         IpAddress: r.Ip.ToString(),
         BoardId: r.Board.ToString(),
         FirmwareVersion: r.FirmwareString,
         Busy: r.Details.Busy,
-        Details: BuildDetails(r))).ToArray();
+        Details: BuildP1Details(r));
 
-    static IReadOnlyDictionary<string, string> BuildDetails(DiscoveredRadio r)
+    static RadioInfo MapP2(Zeus.Protocol2.Discovery.DiscoveredRadio r) => new(
+        MacAddress: r.Mac.ToString(),
+        IpAddress: r.Ip.ToString(),
+        BoardId: r.Board.ToString(),
+        FirmwareVersion: r.FirmwareString,
+        Busy: r.Details.Busy,
+        Details: BuildP2Details(r));
+
+    static IReadOnlyDictionary<string, string> BuildP1Details(DiscoveredRadio r)
     {
         var d = new Dictionary<string, string>
         {
+            ["protocol"] = "P1",
             ["rawBoardId"] = $"0x{r.Details.RawBoardId:X2}",
             ["gatewareBuild"] = r.Details.GatewareBuild.ToString(),
         };
@@ -181,6 +204,19 @@ app.MapGet("/api/radios", async (IRadioDiscovery discovery, HttpContext ctx) =>
         if (r.Details.MacAddressModified) d["macAddressModified"] = "true";
         if (r.Details.FixedIpAddress is { } ip) d["fixedIpAddress"] = ip.ToString();
         if (r.Details.HermesLite2MinorVersion is { } minor) d["hl2MinorVersion"] = minor.ToString();
+        return d;
+    }
+
+    static IReadOnlyDictionary<string, string> BuildP2Details(Zeus.Protocol2.Discovery.DiscoveredRadio r)
+    {
+        var d = new Dictionary<string, string>
+        {
+            ["protocol"] = "P2",
+            ["rawBoardId"] = $"0x{r.Details.RawBoardId:X2}",
+            ["protocolSupported"] = r.Details.ProtocolSupported.ToString(),
+            ["numReceivers"] = r.Details.NumReceivers.ToString(),
+        };
+        if (r.Details.BetaVersion != 0) d["betaVersion"] = r.Details.BetaVersion.ToString();
         return d;
     }
 });

--- a/Zeus.Server/Program.cs
+++ b/Zeus.Server/Program.cs
@@ -259,6 +259,60 @@ app.MapPost("/api/connect", async (ConnectRequest req, RadioService r, WdspWisdo
     }
 });
 
+app.MapPost("/api/connect/p2", async (ConnectRequest req, DspPipelineService dsp, WdspWisdomInitializer wisdom, HttpContext ctx) =>
+{
+    log.LogInformation("api.connect.p2 endpoint={Ep} rate={Rate}", req.Endpoint, req.SampleRate);
+
+    if (wisdom.Phase != WisdomPhase.Ready)
+        log.LogWarning("api.connect.p2 proceeding before wisdom ready; WDSP may fall back to synthetic");
+
+    if (!TryParseIpEndpoint(req.Endpoint, out var ipEndpoint))
+        return Results.BadRequest(new { error = $"Invalid endpoint '{req.Endpoint}'." });
+
+    var rateKhz = req.SampleRate switch
+    {
+        48_000 => 48,
+        96_000 => 96,
+        192_000 => 192,
+        384_000 => 384,
+        _ => 48,
+    };
+
+    try
+    {
+        await dsp.ConnectP2Async(ipEndpoint, rateKhz, numAdc: 2, ctx.RequestAborted);
+        return Results.Ok(new { protocol = "P2", endpoint = req.Endpoint, sampleRateKhz = rateKhz });
+    }
+    catch (InvalidOperationException ex)
+    {
+        return Results.Conflict(new { error = ex.Message });
+    }
+    catch (Exception ex)
+    {
+        log.LogError(ex, "api.connect.p2 failed");
+        return Results.Problem(ex.Message, statusCode: 500);
+    }
+});
+
+app.MapPost("/api/disconnect/p2", async (DspPipelineService dsp, HttpContext ctx) =>
+{
+    log.LogInformation("api.disconnect.p2");
+    await dsp.DisconnectP2Async(ctx.RequestAborted);
+    return Results.Ok(new { status = "disconnected" });
+});
+
+static bool TryParseIpEndpoint(string raw, out IPEndPoint ep)
+{
+    ep = null!;
+    var idx = raw.LastIndexOf(':');
+    string host = idx > 0 ? raw[..idx] : raw;
+    int port = 1024;
+    if (idx > 0 && int.TryParse(raw[(idx + 1)..], out var p)) port = p;
+    if (!IPAddress.TryParse(host, out var ip)) return false;
+    ep = new IPEndPoint(ip, port);
+    return true;
+}
+
 app.MapPost("/api/disconnect", async (RadioService r, HttpContext ctx) =>
 {
     log.LogInformation("api.disconnect");

--- a/Zeus.Server/RadioService.cs
+++ b/Zeus.Server/RadioService.cs
@@ -369,6 +369,29 @@ public sealed class RadioService : IDisposable
         StateChanged?.Invoke(next);
     }
 
+    // Used by DspPipelineService when a Protocol 2 radio connects or
+    // disconnects. RadioService's _activeClient is P1-only; this is how
+    // the shared state (Status, Endpoint, SampleRate) stays coherent for
+    // the UI without growing a P2 client slot here.
+    public void MarkProtocol2Connected(string endpoint, int sampleRateHz)
+    {
+        Mutate(s => s with
+        {
+            Status = ConnectionStatus.Connected,
+            Endpoint = endpoint,
+            SampleRate = sampleRateHz,
+        });
+    }
+
+    public void MarkProtocol2Disconnected()
+    {
+        Mutate(s => s with
+        {
+            Status = ConnectionStatus.Disconnected,
+            Endpoint = null,
+        });
+    }
+
     // Protocol1 → RadioService bridge. Runs on the RX thread at ~1.2 kHz;
     // hands off to HandleAdcOverload for the logic the tests can drive.
     private void OnAdcOverload(AdcOverloadStatus status) =>

--- a/Zeus.Server/Zeus.Server.csproj
+++ b/Zeus.Server/Zeus.Server.csproj
@@ -3,6 +3,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Zeus.Contracts\Zeus.Contracts.csproj" />
     <ProjectReference Include="..\Zeus.Protocol1\Zeus.Protocol1.csproj" />
+    <ProjectReference Include="..\Zeus.Protocol2\Zeus.Protocol2.csproj" />
     <ProjectReference Include="..\Zeus.Dsp\Zeus.Dsp.csproj" />
   </ItemGroup>
 

--- a/Zeus.slnx
+++ b/Zeus.slnx
@@ -8,5 +8,6 @@
   <Project Path="Zeus.Contracts/Zeus.Contracts.csproj" />
   <Project Path="Zeus.Dsp/Zeus.Dsp.csproj" />
   <Project Path="Zeus.Protocol1/Zeus.Protocol1.csproj" />
+  <Project Path="Zeus.Protocol2/Zeus.Protocol2.csproj" />
   <Project Path="Zeus.Server/Zeus.Server.csproj" />
 </Solution>

--- a/Zeus.slnx
+++ b/Zeus.slnx
@@ -3,6 +3,7 @@
     <Project Path="tests/Zeus.Contracts.Tests/Zeus.Contracts.Tests.csproj" />
     <Project Path="tests/Zeus.Dsp.Tests/Zeus.Dsp.Tests.csproj" />
     <Project Path="tests/Zeus.Protocol1.Tests/Zeus.Protocol1.Tests.csproj" />
+    <Project Path="tests/Zeus.Protocol2.Tests/Zeus.Protocol2.Tests.csproj" />
     <Project Path="tests/Zeus.Server.Tests/Zeus.Server.Tests.csproj" />
   </Folder>
   <Project Path="Zeus.Contracts/Zeus.Contracts.csproj" />

--- a/tests/Zeus.Protocol2.Tests/DiscoveryTests.cs
+++ b/tests/Zeus.Protocol2.Tests/DiscoveryTests.cs
@@ -1,0 +1,167 @@
+using System.Net;
+using System.Net.NetworkInformation;
+using Zeus.Protocol2.Discovery;
+
+namespace Zeus.Protocol2.Tests;
+
+public class DiscoveryTests
+{
+    private static readonly IPAddress FromIp = IPAddress.Parse("192.168.1.42");
+
+    [Fact]
+    public void Parses_OrionMkII_Reply()
+    {
+        var reply = BuildReply(new ReplyFields(
+            Status: 0x02,
+            Mac: new byte[] { 0x00, 0x1C, 0xC0, 0xDE, 0xCA, 0xFE },
+            BoardId: 0x0A,
+            ProtocolSupported: 38,
+            CodeVersion: 21,
+            NumReceivers: 2));
+
+        Assert.True(ReplyParser.TryParse(reply, FromIp, out var radio));
+        Assert.Equal(HpsdrBoardKind.OrionMkII, radio.Board);
+        Assert.Equal(new PhysicalAddress(new byte[] { 0x00, 0x1C, 0xC0, 0xDE, 0xCA, 0xFE }), radio.Mac);
+        Assert.Equal(FromIp, radio.Ip);
+        Assert.Equal((byte)21, radio.FirmwareVersion);
+        Assert.Equal("2.1", radio.FirmwareString);
+        Assert.Equal((byte)38, radio.Details.ProtocolSupported);
+        Assert.Equal((byte)2, radio.Details.NumReceivers);
+        Assert.False(radio.Details.Busy);
+    }
+
+    [Fact]
+    public void Parses_Orion_Reply()
+    {
+        var reply = BuildReply(new ReplyFields(
+            Status: 0x02,
+            Mac: new byte[] { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66 },
+            BoardId: 0x05,
+            ProtocolSupported: 36,
+            CodeVersion: 19,
+            NumReceivers: 1));
+
+        Assert.True(ReplyParser.TryParse(reply, FromIp, out var radio));
+        Assert.Equal(HpsdrBoardKind.Orion, radio.Board);
+        Assert.Equal((byte)0x05, radio.Details.RawBoardId);
+    }
+
+    [Fact]
+    public void Parses_Hermes_Reply()
+    {
+        var reply = BuildReply(new ReplyFields(
+            Status: 0x02,
+            Mac: new byte[] { 0x00, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE },
+            BoardId: 0x01,
+            CodeVersion: 31));
+
+        Assert.True(ReplyParser.TryParse(reply, FromIp, out var radio));
+        Assert.Equal(HpsdrBoardKind.Hermes, radio.Board);
+        Assert.Equal("3.1", radio.FirmwareString);
+    }
+
+    [Fact]
+    public void Detects_Busy_Status()
+    {
+        var reply = BuildReply(new ReplyFields(
+            Status: 0x03,
+            Mac: new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05 },
+            BoardId: 0x0A));
+
+        Assert.True(ReplyParser.TryParse(reply, FromIp, out var radio));
+        Assert.True(radio.Details.Busy);
+    }
+
+    [Fact]
+    public void Formats_BetaVersion_When_NonZero()
+    {
+        var reply = BuildReply(new ReplyFields(
+            Status: 0x02,
+            Mac: new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05 },
+            BoardId: 0x0A,
+            CodeVersion: 21,
+            BetaVersion: 3));
+
+        Assert.True(ReplyParser.TryParse(reply, FromIp, out var radio));
+        Assert.Equal("2.1b3", radio.FirmwareString);
+        Assert.Equal((byte)3, radio.Details.BetaVersion);
+    }
+
+    [Fact]
+    public void Rejects_P1_Reply()
+    {
+        var p1 = new byte[24];
+        p1[0] = 0xEF;
+        p1[1] = 0xFE;
+        p1[2] = 0x02;
+
+        Assert.False(ReplyParser.TryParse(p1, FromIp, out _));
+    }
+
+    [Fact]
+    public void Rejects_ShortPacket()
+    {
+        var tiny = new byte[10];
+        Assert.False(ReplyParser.TryParse(tiny, FromIp, out _));
+    }
+
+    [Fact]
+    public void Rejects_InvalidStatus()
+    {
+        var bad = new byte[24];
+        bad[4] = 0x99;
+
+        Assert.False(ReplyParser.TryParse(bad, FromIp, out _));
+    }
+
+    [Fact]
+    public void Maps_UnknownBoardId_To_Unknown()
+    {
+        var reply = BuildReply(new ReplyFields(
+            Status: 0x02,
+            Mac: new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05 },
+            BoardId: 0x7F));
+
+        Assert.True(ReplyParser.TryParse(reply, FromIp, out var radio));
+        Assert.Equal(HpsdrBoardKind.Unknown, radio.Board);
+        Assert.Equal((byte)0x7F, radio.Details.RawBoardId);
+    }
+
+    private sealed record ReplyFields(
+        byte Status,
+        byte[] Mac,
+        byte BoardId,
+        byte ProtocolSupported = 0,
+        byte CodeVersion = 0,
+        byte NumReceivers = 1,
+        byte BetaVersion = 0,
+        byte MercuryVersion0 = 0,
+        byte MercuryVersion1 = 0,
+        byte MercuryVersion2 = 0,
+        byte MercuryVersion3 = 0,
+        byte PennyVersion = 0,
+        byte MetisVersion = 0);
+
+    private static byte[] BuildReply(ReplyFields f)
+    {
+        var reply = new byte[24];
+        reply[0] = 0x00;
+        reply[1] = 0x00;
+        reply[2] = 0x00;
+        reply[3] = 0x00;
+        reply[4] = f.Status;
+        Array.Copy(f.Mac, 0, reply, 5, 6);
+        reply[11] = f.BoardId;
+        reply[12] = f.ProtocolSupported;
+        reply[13] = f.CodeVersion;
+        reply[14] = f.MercuryVersion0;
+        reply[15] = f.MercuryVersion1;
+        reply[16] = f.MercuryVersion2;
+        reply[17] = f.MercuryVersion3;
+        reply[18] = f.PennyVersion;
+        reply[19] = f.MetisVersion;
+        reply[20] = f.NumReceivers;
+        reply[23] = f.BetaVersion;
+        return reply;
+    }
+}

--- a/tests/Zeus.Protocol2.Tests/Zeus.Protocol2.Tests.csproj
+++ b/tests/Zeus.Protocol2.Tests/Zeus.Protocol2.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Zeus.Protocol2\Zeus.Protocol2.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -289,11 +289,35 @@ export function connect(
   );
 }
 
+export function connectP2(
+  req: ConnectRequest,
+  signal?: AbortSignal,
+): Promise<unknown> {
+  return jsonFetch(
+    '/api/connect/p2',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(req),
+      signal,
+    },
+    (raw) => raw,
+  );
+}
+
 export function disconnect(signal?: AbortSignal): Promise<RadioStateDto> {
   return jsonFetch(
     '/api/disconnect',
     { method: 'POST', signal },
     normalizeState,
+  );
+}
+
+export function disconnectP2(signal?: AbortSignal): Promise<unknown> {
+  return jsonFetch(
+    '/api/disconnect/p2',
+    { method: 'POST', signal },
+    (raw) => raw,
   );
 }
 

--- a/zeus-web/src/components/ConnectPanel.tsx
+++ b/zeus-web/src/components/ConnectPanel.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   connect as apiConnect,
+  connectP2 as apiConnectP2,
   disconnect as apiDisconnect,
+  disconnectP2 as apiDisconnectP2,
   fetchRadios,
   fetchState,
   setDrive,
@@ -112,14 +114,24 @@ export function ConnectPanel() {
     async (r: RadioInfoDto) => {
       if (inflightRef.current) return;
       const ep = endpointFor(r);
+      const isP2 = (r.details?.protocol ?? 'P1') === 'P2';
       setInflight(true);
       setError(null);
       try {
-        const next = await apiConnect({
-          endpoint: ep,
-          sampleRate: DEFAULT_SAMPLE_RATE,
-        });
-        applyState(next);
+        if (isP2) {
+          await apiConnectP2({
+            endpoint: ep,
+            sampleRate: 48_000,
+          });
+          const fresh = await fetchState();
+          applyState(fresh);
+        } else {
+          const next = await apiConnect({
+            endpoint: ep,
+            sampleRate: DEFAULT_SAMPLE_RATE,
+          });
+          applyState(next);
+        }
         setBoardId(r.boardId || null);
         setLastConnectedEndpoint(ep || null);
         // Auto-unmute on connect: the user's Connect click is the gesture
@@ -157,12 +169,15 @@ export function ConnectPanel() {
     setInflight(true);
     setError(null);
     try {
-      const next = await apiDisconnect();
-      applyState(next);
+      // Try P1 disconnect first; if the server reports it's a P2 session
+      // (no P1 client active), fall back to the P2 endpoint. Fire both as a
+      // safety net — each is idempotent and returns cleanly if nothing is
+      // connected on its side.
+      try { await apiDisconnect(); } catch { /* may be P2 */ }
+      try { await apiDisconnectP2(); } catch { /* may have been P1 */ }
+      const fresh = await fetchState();
+      applyState(fresh);
       setBoardId(null);
-      // Clear the discovery list immediately so the user doesn't see a stale
-      // "Connect" button against a backend that's just torn the channel down.
-      // The next 10-second tick will repopulate.
       setRadios(null);
     } catch (err) {
       setError(errorMessage(err));
@@ -317,27 +332,25 @@ export function ConnectPanel() {
                 <button
                   type="button"
                   onClick={() => handleConnect(r)}
-                  disabled={r.busy || inflight || dspPreparing || isP2}
+                  disabled={r.busy || inflight || (dspPreparing && !isP2)}
                   title={
-                    isP2
-                      ? 'Protocol 2 support is in progress — connect not yet available'
-                      : r.busy
-                        ? 'Radio is busy (in use by another client)'
-                        : dspPreparing
-                          ? 'DSP is preparing FFTW plans (first-run only, up to ~2 min)'
+                    r.busy
+                      ? 'Radio is busy (in use by another client)'
+                      : dspPreparing && !isP2
+                        ? 'DSP is preparing FFTW plans (first-run only, up to ~2 min)'
+                        : isP2
+                          ? 'Protocol 2 path — experimental, RX only'
                           : undefined
                   }
-                  className={`btn sm ${r.busy || isP2 ? '' : 'active'} ${dspPreparing ? 'pulsing' : ''}`}
+                  className={`btn sm ${r.busy ? '' : 'active'} ${dspPreparing && !isP2 ? 'pulsing' : ''}`}
                 >
-                  {isP2
-                    ? 'P2 (WIP)'
-                    : r.busy
-                      ? 'Busy'
-                      : dspPreparing
-                        ? 'Preparing DSP…'
-                        : inflight
-                          ? 'Connecting…'
-                          : 'Connect'}
+                  {r.busy
+                    ? 'Busy'
+                    : dspPreparing && !isP2
+                      ? 'Preparing DSP…'
+                      : inflight
+                        ? 'Connecting…'
+                        : 'Connect'}
                 </button>
               </li>
             );

--- a/zeus-web/src/components/ConnectPanel.tsx
+++ b/zeus-web/src/components/ConnectPanel.tsx
@@ -275,6 +275,8 @@ export function ConnectPanel() {
           {sortedRadios.map((r) => {
             const ep = endpointFor(r);
             const isLast = !!ep && ep === lastConnectedEndpoint;
+            const protocol = r.details?.protocol ?? 'P1';
+            const isP2 = protocol === 'P2';
             return (
               <li
                 key={r.macAddress || r.ipAddress}
@@ -295,6 +297,13 @@ export function ConnectPanel() {
                     <span className="label-xs" style={{ color: 'var(--fg-3)' }}>
                       fw {r.firmwareVersion || '?'}
                     </span>
+                    <span
+                      className="chip"
+                      style={{ marginLeft: 6 }}
+                      title={`Discovered via Protocol ${protocol === 'P2' ? '2' : '1'}`}
+                    >
+                      <span className="v">{protocol}</span>
+                    </span>
                     {isLast && (
                       <span className="chip accent" style={{ marginLeft: 6 }} title="Last connected radio">
                         <span className="v">LAST</span>
@@ -308,23 +317,27 @@ export function ConnectPanel() {
                 <button
                   type="button"
                   onClick={() => handleConnect(r)}
-                  disabled={r.busy || inflight || dspPreparing}
+                  disabled={r.busy || inflight || dspPreparing || isP2}
                   title={
-                    r.busy
-                      ? 'Radio is busy (in use by another client)'
-                      : dspPreparing
-                        ? 'DSP is preparing FFTW plans (first-run only, up to ~2 min)'
-                        : undefined
+                    isP2
+                      ? 'Protocol 2 support is in progress — connect not yet available'
+                      : r.busy
+                        ? 'Radio is busy (in use by another client)'
+                        : dspPreparing
+                          ? 'DSP is preparing FFTW plans (first-run only, up to ~2 min)'
+                          : undefined
                   }
-                  className={`btn sm ${r.busy ? '' : 'active'} ${dspPreparing ? 'pulsing' : ''}`}
+                  className={`btn sm ${r.busy || isP2 ? '' : 'active'} ${dspPreparing ? 'pulsing' : ''}`}
                 >
-                  {r.busy
-                    ? 'Busy'
-                    : dspPreparing
-                      ? 'Preparing DSP…'
-                      : inflight
-                        ? 'Connecting…'
-                        : 'Connect'}
+                  {isP2
+                    ? 'P2 (WIP)'
+                    : r.busy
+                      ? 'Busy'
+                      : dspPreparing
+                        ? 'Preparing DSP…'
+                        : inflight
+                          ? 'Connecting…'
+                          : 'Connect'}
                 </button>
               </li>
             );


### PR DESCRIPTION
## Summary

- Adds a new `Zeus.Protocol2` project implementing HPSDR Protocol 2: discovery (UDP probe + parser), `Protocol2Client` (socket lifecycle, CmdGeneral / CmdRx / CmdHighPriority builders, RX IQ decode loop), and a shared `IqFrame` shape.
- Wires P1 and P2 discovery to run in parallel on `/api/radios`, tagging each `RadioInfo` with `protocol: "P1" | "P2"`. New `/api/connect/p2` and `/api/disconnect/p2` endpoints drive the P2 path through `DspPipelineService` without touching any P1 code.
- Handles ANAN G2 MkII (Orion-II / Saturn) specifics: RX0 on DDC slot 2, 32-bit phase-word frequency encoding, watchdog / PA / Alex enable bytes, keepalive loop (100 ms HighPriority, 200 ms Rx/Tx, 800 ms General), per-packet-type sequence counters, and Alex filter-board BPF selection.
- Stages Linux x86_64 `libwdsp.so` in `Zeus.Dsp/runtimes/linux-x64/native/` (built from the vendored `native/wdsp/` against libfftw3-dev) so WDSP P/Invoke resolves on Linux hosts without falling back to the synthetic engine.
- Frontend: adds a small protocol chip ("P1" / "P2") next to each discovered radio and routes `ConnectPanel` through the right endpoint based on `details.protocol`.

## Not in scope

- P2 TX path — no TX IQ out or mic routing yet.
- 160 m RX on G2 — ALEX antenna / BPF routing for the lowest band still needs investigation (follow-up).
- CI step to build `libwdsp.so` on Linux runners — currently a staged binary; noted in commit message for `build(wdsp): stage libwdsp.so for linux-x64`.

## Notes for review

- All P1 code paths are untouched. `Zeus.Contracts` wire format is unchanged (new `protocol` key goes in the existing `Details` dictionary).
- Branch was rebased onto current `main` after Brian's master→main rename; no conflicts.
- New P2 keepalive cadence and DDC slot choice are driven by Thetis (`clsRadioDiscovery.cs`, `Network.cs`) and verified live on MkII. Worth maintainer eyes if you have non-MkII P2 hardware handy.

## Test plan

- [x] `dotnet build Zeus.slnx -c Release` — 0 warnings, 0 errors
- [x] Full test suite: 483 passed, 0 failed (9 new `Zeus.Protocol2.Tests`, 114 `Zeus.Protocol1.Tests`, 48 `Zeus.Contracts.Tests`, 116 `Zeus.Server.Tests`, 196 `Zeus.Dsp.Tests`)
- [x] Live hardware: ANAN G2 MkII (fw 2.7b41). Discovery returns `protocol=P2, numReceivers=4, protocolSupported=43`; browser connect succeeds; 80 m / 40 m / 20 m / 15 m / 10 m panadapter + waterfall + audio stable across tunes; WWV 10 MHz carrier lands on displayed frequency exactly.
- [ ] Non-MkII P2 hardware (Orion, Angelia, Hermes-Lite 2 via P2) — please validate if available.