### PR TITLE
docs(readme): note ANAN G2 / Protocol-2 RX support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,14 @@ A browser-based SDR console for the **Hermes Lite 2**. .NET 10 backend talks
 OpenHPSDR Protocol-1 to the radio and streams IQ / audio / meter data to a
 React + WebGL frontend over WebSocket.
 
-> Status: early but working. HL2 only. RX is solid; TX is operator-verified on
-> FM and TUNE (v0.1, April 2026). Other Protocol-1 radios (ANAN etc.) are not
-> yet supported.
+> Status: early but working.
+>
+> - **Hermes Lite 2 (Protocol-1):** RX is solid; TX is operator-verified on FM
+>   and TUNE (v0.1, April 2026).
+> - **ANAN G2 (Protocol-2):** RX verified on OrionMkII / fw 2.7b41 across
+>   80m–10m. TX and 160m are not yet wired — experimental.
+> - Other Protocol-1 radios (older ANAN, Hermes, Angelia, etc.) are not yet
+>   supported.
 
 ## About the name
 
@@ -27,7 +32,7 @@ long-running project a lot of the DSP heritage traces back to.
 - **Leaflet satellite map** with terminator and QRZ grid-square / beam heading
   — to interact with the map (pan / zoom), **press and hold the `M` key**.
   The experience isn't ideal yet and will improve over time.
-- **Radio discovery** on the LAN (Protocol-1 broadcast)
+- **Radio discovery** on the LAN (Protocol-1 + Protocol-2 broadcast, in parallel)
 
 ## Layout
 
@@ -35,6 +40,7 @@ long-running project a lot of the DSP heritage traces back to.
 | ------------------------ | --------------------------------------------------- |
 | `Zeus.Server/`           | ASP.NET Core host, SignalR hub, radio service       |
 | `Zeus.Protocol1/`        | OpenHPSDR Protocol-1 client, framing, discovery     |
+| `Zeus.Protocol2/`        | OpenHPSDR Protocol-2 client (ANAN G2)               |
 | `Zeus.Dsp/`              | DSP engine — WDSP via P/Invoke + synthetic fallback |
 | `Zeus.Contracts/`        | Wire-format DTOs shared backend ↔ web               |
 | `zeus-web/`              | Vite + React + TypeScript + WebGL frontend         |


### PR DESCRIPTION
## Summary

README update to reflect current hardware support after PR #37 (P2 discovery + connect + multi-band RX on ANAN G2). No code changes — docs only.

## Changes

- **Status block** split into per-radio bullets so HL2 (P1) and ANAN G2 (P2) each have their own verification notes. The prior line ("Other Protocol-1 radios (ANAN etc.) are not yet supported") now reads "older ANAN, Hermes, Angelia" to avoid implying G2 isn't working.
- **Discovery bullet** updated to mention P1 + P2 parallel broadcast (matches current `/api/radios` behavior).
- **Layout table** gains a `Zeus.Protocol2/` row next to `Zeus.Protocol1/`.

## Review asks

- This is user-visible top-of-repo copy — happy to reword the "experimental" framing, the OrionMkII-specific caveat, or the hardware list ordering however you'd prefer, Brian.
- Depends on / is meaningful only after PR #37 merges. Merge order: #37 first, then this.

## Test plan

- [x] `docs`-only change; no build / tests affected
- [x] Verified README renders correctly on GitHub (bullet nesting, table formatting intact)