### PR TITLE
feat(rx): custom RX filter bandwidth (3k/4k/6k presets + user low/high) — closes #39

### DIFF
--- a/zeus-web/src/components/ModeBandwidth.tsx
+++ b/zeus-web/src/components/ModeBandwidth.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { setBandwidth, setMode, type RxMode } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
 
@@ -19,11 +19,14 @@ const MODES: readonly ModeEntry[] = [
 
 type Preset = { label: string; low: number; high: number };
 
+const CUSTOM_MIN = 0;
+const CUSTOM_MAX = 10000;
+
 // Per docs/prd/08-display-sync-and-sideband.md §4: sideband-aware presets.
 // Upper-sideband modes are strictly positive; lower-sideband are negative;
 // double-sideband/AM/FM are symmetric around zero; CW is a narrow symmetric
 // pair around the tone pitch (tone handling is server-side).
-function presetsFor(mode: RxMode): readonly Preset[] {
+function basePresetsFor(mode: RxMode): readonly Preset[] {
   switch (mode) {
     case 'USB':
     case 'DIGU':
@@ -54,6 +57,74 @@ function presetsFor(mode: RxMode): readonly Preset[] {
   }
 }
 
+// Issue #39: 3k / 4k / 6k audio-domain presets. Pass-through from 0 Hz to N Hz
+// on SSB; symmetric ±N Hz on DSB. Hidden for CW (250/500 Hz is canonical there).
+function standardPresetsFor(mode: RxMode): readonly Preset[] {
+  const widths = [3000, 4000, 6000] as const;
+  switch (mode) {
+    case 'USB':
+    case 'DIGU':
+      return widths.map((w) => ({ label: `${w / 1000}k`, low: 0, high: w }));
+    case 'LSB':
+    case 'DIGL':
+      return widths.map((w) => ({ label: `${w / 1000}k`, low: -w, high: 0 }));
+    case 'AM':
+    case 'SAM':
+    case 'DSB':
+    case 'FM':
+      return widths.map((w) => ({ label: `${w / 1000}k`, low: -w, high: w }));
+    case 'CWL':
+    case 'CWU':
+      return [];
+  }
+}
+
+function presetsFor(mode: RxMode): readonly Preset[] {
+  return [...basePresetsFor(mode), ...standardPresetsFor(mode)];
+}
+
+// Double-sideband modes use a symmetric bandpass. The "Low" input is not
+// meaningful there in v1 — the filter is always ±high around the carrier.
+function isSymmetricMode(mode: RxMode): boolean {
+  return mode === 'AM' || mode === 'SAM' || mode === 'DSB' || mode === 'FM';
+}
+
+// Convert a signed (low,high) stored pair into positive audio-domain values
+// the user sees in the custom inputs.
+function signedToAbs(mode: RxMode, low: number, high: number): { lowAbs: number; highAbs: number } {
+  if (isSymmetricMode(mode)) {
+    return { lowAbs: 0, highAbs: Math.max(Math.abs(low), Math.abs(high)) };
+  }
+  // SSB / CW: positive sideband → (low, high) already positive;
+  // negative sideband → (low=-hi, high=-lo) so abs is (-high, -low).
+  const lo = Math.min(Math.abs(low), Math.abs(high));
+  const hi = Math.max(Math.abs(low), Math.abs(high));
+  return { lowAbs: lo, highAbs: hi };
+}
+
+// Convert user-entered positive audio-domain values into the signed pair the
+// backend expects for the current mode.
+function absToSigned(mode: RxMode, lowAbs: number, highAbs: number): { low: number; high: number } {
+  const lo = Math.max(CUSTOM_MIN, Math.min(CUSTOM_MAX, Math.round(lowAbs)));
+  const hi = Math.max(CUSTOM_MIN, Math.min(CUSTOM_MAX, Math.round(highAbs)));
+  const [lCap, hCap] = lo <= hi ? [lo, hi] : [hi, lo];
+  switch (mode) {
+    case 'USB':
+    case 'DIGU':
+    case 'CWU':
+      return { low: lCap, high: hCap };
+    case 'LSB':
+    case 'DIGL':
+    case 'CWL':
+      return { low: -hCap, high: -lCap };
+    case 'AM':
+    case 'SAM':
+    case 'DSB':
+    case 'FM':
+      return { low: -hCap, high: hCap };
+  }
+}
+
 function isActive(p: Preset, low: number, high: number): boolean {
   return p.low === low && p.high === high;
 }
@@ -63,6 +134,21 @@ export function ModeBandwidth() {
   const low = useConnectionStore((s) => s.filterLowHz);
   const high = useConnectionStore((s) => s.filterHighHz);
   const applyState = useConnectionStore((s) => s.applyState);
+
+  // Draft state for the custom inputs so the user can type "3000" a character
+  // at a time without us firing setBandwidth on every keystroke.
+  const currentAbs = signedToAbs(mode, low, high);
+  const [lowDraft, setLowDraft] = useState<string>(String(currentAbs.lowAbs));
+  const [highDraft, setHighDraft] = useState<string>(String(currentAbs.highAbs));
+
+  // Sync the drafts when the store-side filter changes (preset click, mode flip,
+  // reconciliation from /api/state). We key the reset on the canonical pair so
+  // local keystrokes don't fight the sync.
+  useEffect(() => {
+    const abs = signedToAbs(mode, low, high);
+    setLowDraft(String(abs.lowAbs));
+    setHighDraft(String(abs.highAbs));
+  }, [mode, low, high]);
 
   const selectMode = useCallback(
     (m: RxMode) => {
@@ -77,11 +163,11 @@ export function ModeBandwidth() {
     [mode, applyState],
   );
 
-  const selectPreset = useCallback(
-    (p: Preset) => {
-      if (p.low === low && p.high === high) return;
-      useConnectionStore.setState({ filterLowHz: p.low, filterHighHz: p.high });
-      setBandwidth(p.low, p.high)
+  const applyFilter = useCallback(
+    (nextLow: number, nextHigh: number) => {
+      if (nextLow === low && nextHigh === high) return;
+      useConnectionStore.setState({ filterLowHz: nextLow, filterHighHz: nextHigh });
+      setBandwidth(nextLow, nextHigh)
         .then(applyState)
         .catch(() => {
           /* next state poll will reconcile */
@@ -90,7 +176,29 @@ export function ModeBandwidth() {
     [low, high, applyState],
   );
 
+  const selectPreset = useCallback(
+    (p: Preset) => {
+      applyFilter(p.low, p.high);
+    },
+    [applyFilter],
+  );
+
+  const commitCustom = useCallback(() => {
+    const loAbs = Number.parseInt(lowDraft, 10);
+    const hiAbs = Number.parseInt(highDraft, 10);
+    if (!Number.isFinite(loAbs) || !Number.isFinite(hiAbs)) return;
+    const { low: nextLow, high: nextHigh } = absToSigned(mode, loAbs, hiAbs);
+    applyFilter(nextLow, nextHigh);
+  }, [lowDraft, highDraft, mode, applyFilter]);
+
+  const onCustomKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.currentTarget.blur();
+    }
+  };
+
   const presets = presetsFor(mode);
+  const lowDisabled = isSymmetricMode(mode);
 
   return (
     <>
@@ -137,9 +245,9 @@ export function ModeBandwidth() {
         </select>
       </div>
 
-      <div className="ctrl-group" style={{ minWidth: 220 }}>
+      <div className="ctrl-group" style={{ minWidth: 260 }}>
         <div className="label-xs ctrl-lbl">BANDWIDTH</div>
-        <div className="btn-row" style={{ alignItems: 'center' }}>
+        <div className="btn-row wrap" style={{ alignItems: 'center' }}>
           {presets.map((p) => (
             <button
               key={p.label}
@@ -150,8 +258,56 @@ export function ModeBandwidth() {
               {p.label}
             </button>
           ))}
+        </div>
+        <div className="btn-row" style={{ alignItems: 'center', marginTop: 4, gap: 4 }}>
+          <span className="label-xs" style={{ color: 'var(--fg-3)' }}>CUSTOM</span>
+          <input
+            type="number"
+            min={CUSTOM_MIN}
+            max={CUSTOM_MAX}
+            step={50}
+            value={lowDraft}
+            onChange={(e) => setLowDraft(e.currentTarget.value)}
+            onBlur={commitCustom}
+            onKeyDown={onCustomKeyDown}
+            disabled={lowDisabled}
+            aria-label="Custom filter low edge in Hz"
+            className="mono"
+            style={{
+              width: 60,
+              fontSize: 11,
+              padding: '2px 4px',
+              background: 'var(--btn-top)',
+              color: lowDisabled ? 'var(--fg-3)' : 'var(--fg-0)',
+              border: '1px solid var(--line)',
+              borderRadius: 'var(--r-sm)',
+            }}
+          />
+          <span className="label-xs" style={{ color: 'var(--fg-3)' }}>–</span>
+          <input
+            type="number"
+            min={CUSTOM_MIN}
+            max={CUSTOM_MAX}
+            step={50}
+            value={highDraft}
+            onChange={(e) => setHighDraft(e.currentTarget.value)}
+            onBlur={commitCustom}
+            onKeyDown={onCustomKeyDown}
+            aria-label="Custom filter high edge in Hz"
+            className="mono"
+            style={{
+              width: 60,
+              fontSize: 11,
+              padding: '2px 4px',
+              background: 'var(--btn-top)',
+              color: 'var(--fg-0)',
+              border: '1px solid var(--line)',
+              borderRadius: 'var(--r-sm)',
+            }}
+          />
+          <span className="label-xs mono" style={{ color: 'var(--fg-3)' }}>Hz</span>
           <span className="label-xs mono" style={{ marginLeft: 6, color: 'var(--fg-3)', whiteSpace: 'nowrap' }}>
-            [{Math.min(Math.abs(low), Math.abs(high))}…{Math.max(Math.abs(low), Math.abs(high))} Hz]
+            [{Math.min(Math.abs(low), Math.abs(high))}…{Math.max(Math.abs(low), Math.abs(high))}]
           </span>
         </div>
       </div>


### PR DESCRIPTION
Closes #39.

## Summary

- Adds three new audio-domain bandwidth presets — **3k / 4k / 6k** — alongside the existing Narrow / Wide per-mode buttons. Applied through the existing backend signing path, so USB gets `0 → +N kHz`, LSB gets `-N → 0 kHz`, AM/SAM/DSB/FM get `±N kHz`. Hidden on CW where the existing 250/500 Hz presets remain canonical.
- Adds a **custom-filter row** with two number inputs (Low / High, range 0–10000 Hz). User types positive audio-domain values; the component converts to the signed pair the backend expects for the active mode. Applied on blur or Enter. On AM/SAM/DSB/FM the Low input is disabled since those modes use a symmetric bandpass in v1.

## Scope

- **One file changed: `zeus-web/src/components/ModeBandwidth.tsx`.** ~160 LoC added.
- **Zero backend changes.** `POST /api/bandwidth` already accepts signed `(low, high)`; `RadioService.SetFilter` normalises per-mode family; `WdspDspEngine.ApplyBandpassForMode` re-signs on mode change. The existing plumbing already handles everything — we just expose more of it.
- **Zero `Zeus.Contracts` changes.** Wire format untouched.
- **Works on any supported radio** (HL2 over P1, ANAN G2 over P2 via #37), since the filter plumbing is DSP-side and radio-agnostic.

## UX notes

- Draft input state is seeded from the server-reconciled filter via a `signedToAbs()` helper keyed on `(mode, low, high)`, so preset clicks, mode flips, and `/api/state` reconciliation push the current passband back into the input boxes without fighting in-flight typing.
- Both inputs step in 50 Hz increments (arrow keys).
- Layout matches the existing single-hue amber convention; no new colors introduced.

## Open questions for you

- **CW:** currently hiding the 3k/4k/6k presets on CW since they make no sense there. Let me know if you'd rather keep them.
- **Second custom slot (Thetis-style Var1/Var2):** started with a single custom pair. Can add Var2 in a follow-up if you want feature parity with Thetis's filter picker.
- **Persistence:** custom values are not remembered across restarts yet. `BandMemoryDto` in LiteDB is the natural home if you want it — happy to follow up.

## Test plan

- [x] `dotnet build Zeus.slnx` — clean (no backend code touched)
- [x] `npm --prefix zeus-web run build` — 0 warnings, 0 errors
- [x] Live on my G2 MkII (requires #37): 3k/4k/6k buttons switch panadapter filter overlay on USB / LSB / AM / SAM. Custom inputs accept 200/2800 and 0/4000 and apply correctly. LSB ↔ USB flip preserves user bandwidth and swaps passband side.
- [ ] Verified on HL2 over P1 — please confirm since I don't have one handy.