### PR TITLE
fix(dsp): WDSPwisdom needs a trailing path separator or wisdom lands in the wrong directory

### DIFF
--- a/Zeus.Dsp/Wdsp/WdspWisdomInitializer.cs
+++ b/Zeus.Dsp/Wdsp/WdspWisdomInitializer.cs
@@ -51,8 +51,17 @@ public sealed class WdspWisdomInitializer
                 Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                 "Zeus");
             Directory.CreateDirectory(dir);
-            _log.LogInformation("wdsp.wisdom initialising dir={Dir}", dir);
-            int result = NativeMethods.WDSPwisdom(dir);
+
+            // WDSP's wisdom.c does a plain strcat of "wdspWisdom00" onto the
+            // directory without inserting a path separator (see native/wdsp/
+            // wisdom.c:49-50). Pass the directory with a trailing separator so
+            // the native side produces a valid "<dir>/wdspWisdom00" path
+            // instead of "<dir>wdspWisdom00" which lands the wisdom file one
+            // level up.
+            var dirForNative = dir + Path.DirectorySeparatorChar;
+
+            _log.LogInformation("wdsp.wisdom initialising dir={Dir}", dirForNative);
+            int result = NativeMethods.WDSPwisdom(dirForNative);
             var status = Marshal.PtrToStringUTF8(NativeMethods.wisdom_get_status()) ?? string.Empty;
             _log.LogInformation(
                 "wdsp.wisdom ready result={Result} ({Source}) status={Status}",


### PR DESCRIPTION
## Summary

`Zeus.Dsp/Wdsp/WdspWisdomInitializer.cs` now appends `Path.DirectorySeparatorChar` to the directory it hands to the native `WDSPwisdom(directory)` call. Without it, the native code's `strcat` concatenates the directory and the filename directly — the resulting wisdom file lands one level above the intended `Zeus` folder.

## Root cause

In `native/wdsp/wisdom.c:49-50`:

\`\`\`c
strcpy (wisdom_file, directory);
strncat (wisdom_file, \"wdspWisdom00\", 16);
\`\`\`

No path separator is ever inserted. So when C# passes:

- **Linux:** \`/home/<user>/.local/share/Zeus\` → native writes to \`/home/<user>/.local/share/ZeuswdspWisdom00\` (note the missing slash).
- **Windows:** same bug in principle; the backslash semantics may have masked the issue depending on how users were interacting with it.

That file **does write successfully** — the parent directory (\`~/.local/share\`) exists and is writable — which is why nothing explodes at startup. But:

1. On the next launch, Zeus looks for wisdom in \`~/.local/share/Zeus/\` (the right place), doesn't find one, and re-runs the full multi-minute FFTW plan.
2. The stray file pollutes \`~/.local/share\` alongside other apps' data.

## Operator symptom

FFTW re-plans every single startup. Every time Zeus starts cold, the backend prints:

\`\`\`
Optimizing FFT sizes through 262145
Planning COMPLEX FORWARD  FFT size 64
Planning COMPLEX BACKWARD FFT size 64
... (many lines) ...
\`\`\`

and a \"Preparing DSP\" pulse shows in the UI for 1–3 minutes depending on CPU. With this fix, the wisdom file lands in the correct location, subsequent starts find it and log \`wdsp.wisdom ready result=0 (loaded)\` instantly.

## Operator note (important!)

**This bootstrap runs inside \`Zeus.Server\`. Don't open the web UI or click Connect until the log prints \`wdsp.wisdom ready\`.** Connecting to a radio mid-planning caused \`Protocol2Client.StartAsync\` to open a DSP channel while FFTW was still planning, which native-crashed the server with a \`double free or corruption (out)\` abort on my box tonight. That crash is a separate bug (filing a follow-up issue) but the short-term guidance is: let the server reach \"wisdom ready\" before clicking anything.

## Verified live

Ubuntu x86_64, kb2uka's box:

- **Pre-fix:** 33 KB \`~/.local/share/ZeuswdspWisdom00\` (wrong directory).
- **Post-fix:** 33 KB \`~/.local/share/Zeus/wdspWisdom00\` (correct directory). Cold build took ~90 seconds; second start reported \`wdsp.wisdom ready result=0 (loaded)\` and started instantly.

## Test plan

- [x] \`dotnet build Zeus.slnx\` — clean
- [x] Delete existing wisdom, restart backend, watch wisdom generate and wisdom file land at the correct path
- [x] Restart again, confirm \`result=0 (loaded)\`
- [x] Confirm no stray \`ZeuswdspWisdom00\` appears in \`~/.local/share/\`
- [ ] Windows verification — I can't test; worth a sanity check on Brian's Windows box to confirm no regression

## Follow-up worth considering

- Patch the native \`wisdom.c\` to also insert a path separator, so any future caller (pihpsdr, Thetis, Zeus) is resilient to the missing-slash bug.
- Ship a pre-built \`wdspWisdom00\` in the repo (like Thetis's installer does) so first-run users don't have to wait for FFTW plans.