### PR TITLE
feat(vfo): wheel-scroll tuning per digit — closes #42

### DIFF
--- a/zeus-web/src/components/VfoDisplay.tsx
+++ b/zeus-web/src/components/VfoDisplay.tsx
@@ -53,6 +53,11 @@ function formatKhz(hz: number): string {
   return (hz / 1000).toFixed(3);
 }
 
+// Per-digit wheel tuning debounce. Wheel events fire at ~60 Hz during a spin;
+// we update the store (and therefore the display) on every tick for instant
+// feedback, but only POST the last resting value to avoid flooding /api/vfo.
+const WHEEL_DEBOUNCE_MS = 80;
+
 export function VfoDisplay() {
   const vfoHz = useConnectionStore((s) => s.vfoHz);
   const applyState = useConnectionStore((s) => s.applyState);
@@ -60,6 +65,15 @@ export function VfoDisplay() {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState('');
   const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const wheelTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const wheelPending = useRef<number | null>(null);
+  const wheelInflight = useRef<AbortController | null>(null);
+
+  useEffect(() => () => {
+    wheelInflight.current?.abort();
+    if (wheelTimer.current != null) clearTimeout(wheelTimer.current);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -125,6 +139,49 @@ export function VfoDisplay() {
     [commitEdit, cancelEdit],
   );
 
+  // Per-digit wheel tuning: hover over a digit, scroll wheel to step that
+  // digit's decade. Wheel up = freq up. Updates local store immediately so
+  // the display tracks the wheel, POSTs the final resting value after the
+  // user stops scrolling.
+  const onDigitWheel = useCallback(
+    (e: React.WheelEvent<HTMLSpanElement>) => {
+      const decadeAttr = e.currentTarget.dataset.decade;
+      if (!decadeAttr) return;
+      const decade = Number.parseInt(decadeAttr, 10);
+      if (!Number.isFinite(decade) || decade <= 0) return;
+      e.preventDefault();
+
+      const direction = e.deltaY < 0 ? 1 : -1;
+      const current = useConnectionStore.getState().vfoHz;
+      const next = clampHz(current + direction * decade);
+      if (next === current) return;
+      useConnectionStore.setState({ vfoHz: next });
+      wheelPending.current = next;
+
+      if (wheelTimer.current != null) clearTimeout(wheelTimer.current);
+      wheelTimer.current = setTimeout(() => {
+        wheelTimer.current = null;
+        const target = wheelPending.current;
+        wheelPending.current = null;
+        if (target == null) return;
+        wheelInflight.current?.abort();
+        const ac = new AbortController();
+        wheelInflight.current = ac;
+        setVfo(target, ac.signal)
+          .then((reply) => {
+            if (ac.signal.aborted) return;
+            applyState(reply);
+          })
+          .catch((err) => {
+            if (ac.signal.aborted) return;
+            if (err instanceof DOMException && err.name === 'AbortError') return;
+            /* next state poll will reconcile */
+          });
+      }, WHEEL_DEBOUNCE_MS);
+    },
+    [applyState],
+  );
+
   const digits = useMemo(() => DIGIT_PLACES, []);
 
   return (
@@ -162,7 +219,7 @@ export function VfoDisplay() {
           type="button"
           onClick={beginEdit}
           aria-label="Edit frequency"
-          title="Click to enter frequency in kHz"
+          title="Click to enter frequency in kHz — scroll the wheel over a digit to tune it"
           className="freq-digits mono"
           style={{ background: 'none', border: 'none', cursor: 'text', width: '100%' }}
         >
@@ -171,7 +228,14 @@ export function VfoDisplay() {
             const isLeading = vfoHz < place.decade;
             return (
               <Fragment key={place.decade}>
-                <span className={`digit ${isLeading ? 'leading' : ''}`}>{d}</span>
+                <span
+                  className={`digit ${isLeading ? 'leading' : ''}`}
+                  data-decade={place.decade}
+                  onWheel={onDigitWheel}
+                  style={{ cursor: 'ns-resize' }}
+                >
+                  {d}
+                </span>
                 {place.separatorAfter && (
                   <span aria-hidden className="sep">
                     {place.separatorAfter}
@@ -183,7 +247,7 @@ export function VfoDisplay() {
         </button>
       )}
       <div className="freq-bot" style={{ justifyContent: 'flex-end', gap: 6, marginTop: 4 }}>
-        <span className="label-xs">MHz · click to enter kHz</span>
+        <span className="label-xs">MHz · click to type · wheel on a digit to step</span>
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #42.

## Summary

Per-digit mouse-wheel tuning on the VFO display. Hover over any digit, scroll the wheel, and that digit's decade is added to or subtracted from the VFO frequency. No more forced click-to-type for small adjustments — matches how Thetis and most traditional SDR clients handle tuning.

## Behavior

| Action | Result |
|---|---|
| Wheel up on the `100 Hz` digit | +100 Hz |
| Wheel down on the `10 kHz` digit | -10 kHz |
| Wheel on any digit | Clamped to `0..MAX_HZ` |
| Click on the display | Still opens the kHz text input (unchanged) |
| Hover over a digit | Cursor becomes `ns-resize` as a hint |
| Page scroll | Blocked while wheeling over a digit (`preventDefault`) |

## Implementation notes

- One `onWheel` handler on all eight digit spans. Each span carries its decade via `data-decade={place.decade}`; the handler reads it from `e.currentTarget.dataset`, so we don't allocate a per-digit callback.
- Local state (zustand store) updates on every wheel tick for instant display feedback.
- `POST /api/vfo` is trailing-edge debounced at 80 ms: a fast spin produces one settled network round-trip after the user stops.
- In-flight requests use `AbortController` — a new spin cancels the old POST, so the display doesn't get snapped back to a stale value mid-tune.

## Scope

- **One file changed**: `zeus-web/src/components/VfoDisplay.tsx`
- **Zero backend changes**. `POST /api/vfo` already accepts arbitrary Hz.
- **Zero `Zeus.Contracts` changes**.

## Radios

Frequency changes are DSP-side and radio-agnostic. Works on HL2 (P1) and ANAN G2 (P2) identically.

## Test plan

- [x] `npm --prefix zeus-web run build` — clean, 0 errors
- [x] Live on my G2 MkII: wheeled through 1 Hz / 10 Hz / 100 Hz / 1 kHz / 10 kHz / 100 kHz / 1 MHz / 10 MHz digits, all step correctly. Panadapter and waterfall track live. Fast spins coalesce into a single settled POST.
- [x] Click-to-type flow still works.
- [ ] Verified on HL2 over P1 — please confirm when convenient.

## Possible follow-ups (not in this PR)

- `Shift+wheel` for 10× step size.
- Up/Down arrow keys when the display has focus.