### PR TITLE
fix(protocol2): drop ArrayPool leak in HandleDdcPacket

### DIFF
--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -1,4 +1,3 @@
-using System.Buffers;
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Net;
@@ -430,8 +429,11 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         }
 
         // 238 complex samples: I (int24 BE) + Q (int24 BE), starting at byte 16.
+        // We own the array for the lifetime of the IqFrame the downstream
+        // pump consumes; there's no back-channel to Return it to a pool, so
+        // plain GC allocation is both simpler and correct.
         const int samplesPerPacket = DiscoverySamplesPerPacket;
-        var samples = ArrayPool<double>.Shared.Rent(samplesPerPacket * 2);
+        var samples = new double[samplesPerPacket * 2];
         const double scale = 1.0 / 8388608.0;
         for (int i = 0; i < samplesPerPacket; i++)
         {


### PR DESCRIPTION
Addresses the ArrayPool item Brian flagged on PR #37.

## The leak

`Protocol2Client.HandleDdcPacket` rents a `double[]` from `ArrayPool<double>.Shared` every time a DDC IQ packet arrives (~200 packets per second at 48 kHz) and never returns it. The pool degrades to plain GC allocation under that kind of rental pressure, so we were paying the allocation cost *plus* the pool's lease bookkeeping.

## Why not add a `Return` call?

There's no back-channel from the IQ frame consumer (`DspPipelineService.StartIqPumpP2` → downstream WDSP feeder) back to the `Protocol2Client`. The `IqFrame` hands a `ReadOnlyMemory<double>` to the consumer, which holds the array alive for the lifetime of its processing. Building a lease-tracking return channel for a ~200 pkt/s stream whose GC cost is trivial adds complexity without meaningful gain.

## The fix

Swap `ArrayPool<double>.Shared.Rent(...)` → `new double[...]`. Removes the now-unused `using System.Buffers;` as a tidy-up.

Diff is 4 lines net.

## Test plan

- [x] `dotnet build Zeus.slnx` — clean
- [x] `dotnet test` on `Zeus.Protocol2.Tests` — 9/9 pass
- [x] No behavioural change expected; allocator swap only.