### PR TITLE
docs(readme): explain the first-run WDSP wisdom wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,36 @@ dotnet run --project Zeus.Server
 
 Open **http://localhost:6060**, hit **Discover**, and connect to your HL2.
 
+### First run — wait for WDSP wisdom before connecting
+
+The first time you start `Zeus.Server` on a machine, WDSP/FFTW runs a
+one-shot "wisdom" pass to plan the FFT sizes Zeus uses. It takes **1–3
+minutes** on a modern CPU, and during that time you'll see output like:
+
+```
+info: Zeus.Dsp.Wdsp.WdspWisdomInitializer[0]
+      wdsp.wisdom initialising dir=/home/<user>/.local/share/Zeus/
+Optimizing FFT sizes through 262145
+
+Please do not close this window until wisdom plans are completed.
+
+Planning COMPLEX FORWARD  FFT size 64
+Planning COMPLEX BACKWARD FFT size 64
+... (many lines) ...
+```
+
+**Don't click Discover or Connect in the web UI until you see:**
+
+```
+info: Zeus.Dsp.Wdsp.WdspWisdomInitializer[0]
+      wdsp.wisdom ready result=1 (built) status=...
+```
+
+Connecting to a radio while wisdom is still building will crash the backend
+with a native double-free abort. Once wisdom is cached
+(`~/.local/share/Zeus/wdspWisdom00` on Linux, `%LOCALAPPDATA%\Zeus\wdspWisdom00`
+on Windows), subsequent starts log `result=0 (loaded)` and come up instantly.
+
 ## Getting started (developers)
 
 The backend and frontend run as two independent processes during development.
@@ -103,8 +133,12 @@ npm --prefix zeus-web run dev
 ```
 
 Then open **http://localhost:5173**. Edits under `zeus-web/src/` hot-reload;
-changes under `Zeus.Server/`, `Zeus.Protocol1/`, `Zeus.Dsp/`, or
-`Zeus.Contracts/` require restarting the backend.
+changes under `Zeus.Server/`, `Zeus.Protocol1/`, `Zeus.Protocol2/`, `Zeus.Dsp/`,
+or `Zeus.Contracts/` require restarting the backend.
+
+> On the very first backend start, wait for `wdsp.wisdom ready` before clicking
+> Discover — see [First run](#first-run--wait-for-wdsp-wisdom-before-connecting)
+> above.
 
 If you'd rather run the production-style single-port build, use the `Running`
 instructions above — the bundled UI is served directly from the .NET host on


### PR DESCRIPTION
Small README-only change to save first-run users from confusion (and, worse, a native crash).

## Why

Fresh clones on any platform hit a 1–3 minute FFTW wisdom build the first time the backend starts. The log scrolls \`Planning COMPLEX ... FFT size N\` lines for a while and it's easy to assume the server is hung or broken. I did tonight, and it cost me a full rebuild when I clicked Connect before wisdom finished — the backend crashed with \`double free or corruption (out)\` because the wisdom/channel-open paths race inside FFTW.

## What this PR adds

- A **\"First run\"** subsection under \`## Running\` explaining what to expect, the exact log lines to watch for, and the rule: *don't click Discover/Connect until you see \`wdsp.wisdom ready\`*. Includes the wisdom-file path per OS.
- A one-line pointer at the end of \`### Dev loop (two terminals)\` so developers on the \`:5173\` dev path see the same info.
- Bonus fix: that paragraph also mentions \"changes under Zeus.Server/Zeus.Protocol1/...require restart\" — added \`Zeus.Protocol2\` so it isn't left out.

## Related bugs

The wisdom path-separator bug is fixed by #43 (merging that makes the directory path in this README's example accurate).

The **\"connecting before wisdom crashes the server\"** issue is tracked as #49. The README entry is the short-term mitigation until #49 is fixed in code (gate \`/api/connect/*\` on \`wisdomPhase == Ready\`).

## Not in scope

- Ship a pre-built \`wdspWisdom00\` in the repo the way Thetis's installer does, which would make first-run painless for every user. Worth doing later.

## Test plan

- [x] \`git diff\` shows README-only changes.
- [x] Visually inspected the rendered markdown for correct heading levels and the anchor link in the dev-loop pointer works.