### PR TITLE
feat(web): fluid button sizing with 4K-specific bump

### DIFF
--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -146,8 +146,10 @@
   align-items: center;
   justify-content: center;
   gap: 4px;
-  padding: 6px 10px;
-  font-size: 12px;
+  /* Fluid sizing: stays ~current on MBA/QHD/ultrawide, bumps on 4K+ below.
+     em-padding so the box tracks font-size automatically. */
+  padding: 0.5em 0.85em;
+  font-size: clamp(11px, 0.15vw + 10px, 13.5px);
   font-weight: 700;
   letter-spacing: 0.03em;
   color: var(--btn-text);
@@ -181,8 +183,8 @@
   color: var(--btn-active-text);
   text-shadow: 0 1px 0 rgba(0,0,0,0.6), 0 0 8px rgba(74,158,255,0.4);
 }
-.btn.sm { padding: 3px 8px; font-size: 11px; }
-.btn.lg { padding: 8px 14px; font-size: 13px; }
+.btn.sm { padding: 0.3em 0.7em;  font-size: clamp(10px, 0.1vw + 9.5px, 12px); }
+.btn.lg { padding: 0.55em 1em;   font-size: clamp(13px, 0.2vw + 10px, 15px); }
 .btn.ghost {
   background: linear-gradient(180deg, #2e2f33, #1c1d20);
   color: var(--fg-1);
@@ -203,6 +205,15 @@
   --btn-bot-c: #b45410;
   color: #fff;
   text-shadow: 0 1px 0 rgba(0,0,0,0.4);
+}
+
+/* 4K-and-above bump. 34" ultrawide (3440 CSS px) stays under this threshold
+   on purpose — buttons are already sized right there. Native-scaled 4K
+   (3840 CSS px) and 5K trigger this and get larger, ergonomic buttons. */
+@media (min-width: 3600px) {
+  .btn    { font-size: clamp(14px, 0.3vw + 4px,  18px); }
+  .btn.sm { font-size: clamp(12px, 0.2vw + 5px,  15px); }
+  .btn.lg { font-size: clamp(16px, 0.35vw + 5px, 21px); }
 }
 
 /* LED indicator dot */
@@ -1200,4 +1211,13 @@
 
   .tweaks-fab,
   .tweaks-panel { display: none !important; }
+}
+
+/* Touch-target floor for coarse pointers (phones, tablets). Keyed off pointer
+   type rather than width so a narrow desktop window doesn't inherit the
+   bigger tap zones. Apple HIG: 44 px minimum for primary targets. */
+@media (pointer: coarse) and (max-width: 900px) {
+  .btn     { min-height: 36px; }
+  .btn.lg  { min-height: 44px; }
+  .btn-row { gap: 6px; }
 }


### PR DESCRIPTION
## Summary
- Fixed-px button sizing looked fine on MBA, QHD, and 34" ultrawide (≤ 3440 CSS px) but appeared undersized on native-scaled 4K where each CSS pixel is physically smaller.
- `.btn` / `.btn.sm` / `.btn.lg` now use `clamp()` for font-size and em-relative padding. Baseline clamp tops out at ~13.5 px so the ultrawide feel is unchanged.
- New `@media (min-width: 3600px)` block bumps font-size for 4K+ only.
- New `@media (pointer: coarse) and (max-width: 900px)` block enforces 36 px min-height on `.btn` (44 px on `.btn.lg`) for touch devices — Apple HIG floor.

Colors, gradients, fonts, and layout grid are untouched — staying inside the green-light lane per `CLAUDE.md`. Maintainer should still eyeball the 4K feel before merge.

## Test plan
- [ ] Verify on MacBook Air (default and More-Space scalings) — buttons should look identical to pre-change.
- [ ] Verify on 34" 3440×1440 ultrawide — should feel identical to today.
- [ ] Verify on 4K (3840×2160) at native scaling — buttons should be noticeably larger and more legible.
- [ ] Verify on a phone / tablet — no visual regression; tap targets should feel larger, not smaller.
- [ ] Verify on a narrow-window desktop (<900 px wide, mouse pointer) — should NOT inherit touch-target min-heights.