### PR TITLE
fix(server): accept full 1..16 zoom range in RadioService.SetZoom

### DIFF
--- a/Zeus.Server/RadioService.cs
+++ b/Zeus.Server/RadioService.cs
@@ -38,6 +38,7 @@
 using System.Net;
 using Microsoft.Extensions.Logging;
 using Zeus.Contracts;
+using Zeus.Dsp;
 using Zeus.Protocol1;
 
 namespace Zeus.Server;
@@ -394,8 +395,14 @@ public sealed class RadioService : IDisposable
 
     public StateDto SetZoom(int level)
     {
-        if (level is not (1 or 2 or 4 or 8))
-            throw new ArgumentException($"zoom level must be 1, 2, 4, or 8; got {level}", nameof(level));
+        // Accepts the full DSP range (1..16); Program.cs already range-checks
+        // the HTTP payload against these same bounds. A prior powers-of-two
+        // guard here silently rejected 3/5/6/7 with a 500, causing the
+        // frontend slider (step=1, 1..8) to appear stuck after valid steps.
+        if (level < SyntheticDspEngine.MinZoomLevel || level > SyntheticDspEngine.MaxZoomLevel)
+            throw new ArgumentException(
+                $"zoom level must be in [{SyntheticDspEngine.MinZoomLevel},{SyntheticDspEngine.MaxZoomLevel}]; got {level}",
+                nameof(level));
         Mutate(s => s with { ZoomLevel = level });
         return Snapshot();
     }

--- a/tests/Zeus.Server.Tests/ZoomValidationTests.cs
+++ b/tests/Zeus.Server.Tests/ZoomValidationTests.cs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is an independent reimplementation in .NET — not a fork. Its
+// Protocol-1 / Protocol-2 framing, WDSP integration, meter pipelines, and
+// TX behaviour were informed by studying the Thetis project
+// (https://github.com/ramdor/Thetis), the authoritative reference
+// implementation in the OpenHPSDR ecosystem. Zeus gratefully acknowledges
+// the Thetis contributors whose work made this possible:
+//
+//   Richard Samphire (MW0LGE), Warren Pratt (NR0V),
+//   Laurence Barker (G8NJJ),   Rick Koch (N1GP),
+//   Bryan Rambo (W4WMT),       Chris Codella (W2PA),
+//   Doug Wigley (W5WC),        FlexRadio Systems,
+//   Richard Allen (W5SD),      Joe Torrey (WD5Y),
+//   Andrew Mansfield (M0YGG),  Reid Campbell (MI0BOT).
+//
+// Thetis itself continues the GPL-governed lineage of FlexRadio PowerSDR
+// and the OpenHPSDR (TAPR/OpenHPSDR) ecosystem; that lineage is preserved
+// here. See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
+// (NR0V), distributed under GPL v2 or later.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Regression coverage for RadioService.SetZoom. An earlier guard rejected
+/// anything that wasn't a power of two (1/2/4/8), which silently 500'd the
+/// frontend's step=1 slider for levels 3/5/6/7 and left the UI "stuck"
+/// bouncing against the next state-poll. Service must accept the full
+/// DSP-engine range (1..16) and reject anything outside it.
+/// </summary>
+public class ZoomValidationTests
+{
+    private static RadioService BuildRadio()
+    {
+        var dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance);
+        return new RadioService(NullLoggerFactory.Instance, dspStore);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(5)]
+    [InlineData(6)]
+    [InlineData(7)]
+    [InlineData(8)]
+    [InlineData(16)]
+    public void SetZoom_AcceptsInRangeLevels(int level)
+    {
+        using var radio = BuildRadio();
+        var snap = radio.SetZoom(level);
+        Assert.Equal(level, snap.ZoomLevel);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(17)]
+    [InlineData(100)]
+    public void SetZoom_RejectsOutOfRangeLevels(int level)
+    {
+        using var radio = BuildRadio();
+        Assert.Throws<ArgumentException>(() => radio.SetZoom(level));
+    }
+}


### PR DESCRIPTION
## Summary

- `RadioService.SetZoom` previously rejected anything that wasn't `1|2|4|8` with an `ArgumentException` → 500, silently breaking the frontend slider for levels 3/5/6/7.
- Relaxed the guard to the DSP engine's published `1..16` range (same bounds `Program.cs` already enforces on the HTTP payload).
- Added `tests/Zeus.Server.Tests/ZoomValidationTests.cs` covering in-range and out-of-range boundaries.

## Root cause (re: #34)

The web slider is `<input type="range" min=1 max=8 step=1>`, so tapping ↑ produces levels 1 → 2 → 3 → 4 → … The `3/5/6/7` values were 500'd at the service layer while `Program.cs` happily accepted them (it only range-checks against `SyntheticDspEngine.MinZoomLevel`/`MaxZoomLevel`, which are `1..16`). The client's `.catch` swallowed the error, then the 333 ms state poll pulled the previous (valid) value back and the slider snapped back. Dragging worked because only the final released value is POSTed and the right edge (8) is valid.

`SyntheticDspEngine.SetZoom` and its tests in `tests/Zeus.Dsp.Tests/ZoomTests.cs` (e.g. `Synthetic_SetZoom_AcceptsAllowedLevels` with 3, 5, 7, 11) already treat the full `1..16` range as the contract, so `RadioService` was the outlier.

## Test plan

- [x] `dotnet build Zeus.slnx` clean
- [x] `dotnet test Zeus.slnx` — all existing suites pass (Zeus.Server.Tests 129 passed / 5 skipped, Zeus.Dsp.Tests 196 passed, Zeus.Protocol1/2 and Contracts unchanged)
- [x] New `ZoomValidationTests`: 9 in-range levels accepted, 4 out-of-range levels throw
- [ ] Manual: tap ↑ repeatedly on the ZoomControl with a live connection — slider should step cleanly through 1→8 without snapping back; dragging still works