### PR TITLE
refactor(map): drop W0NER placeholder HOME fallback

### DIFF
--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -63,7 +63,7 @@ import { VfoDisplay } from './components/VfoDisplay';
 import { Waterfall } from './components/Waterfall';
 import { ZoomControl } from './components/ZoomControl';
 import { AzimuthMap } from './components/design/AzimuthMap';
-import { CONTACTS, HOME, bandOf } from './components/design/data';
+import { CONTACTS, bandOf } from './components/design/data';
 import { CwKeyer } from './components/design/CwKeyer';
 import { Dockable } from './components/design/Dockable';
 import { DspPanel } from './components/DspPanel';
@@ -359,9 +359,8 @@ export default function App() {
   // --- Tx status chip
   const txChip = moxOn || tunOn ? 'TX' : 'RX';
 
-  // --- Effective home station for the map + bearing math. Real QRZ profile
-  // takes precedence; otherwise the design-mock HOME constant keeps the
-  // disconnected demo looking populated.
+  // Effective home for the map + bearing math. Null until QRZ supplies a real
+  // station — the map just omits the home marker and great-circle until then.
   const effectiveHome = qrzHome && qrzHome.lat != null && qrzHome.lon != null
     ? {
         call: qrzHome.callsign,
@@ -370,11 +369,11 @@ export default function App() {
         grid: qrzHome.grid ?? '',
         imageUrl: qrzHome.imageUrl ?? null,
       }
-    : { call: HOME.call, lat: HOME.lat, lon: HOME.lon, grid: HOME.grid, imageUrl: null as string | null };
+    : null;
 
-  const sp = contact ? bearingDeg(effectiveHome.lat, effectiveHome.lon, contact.lat, contact.lon) : 0;
+  const sp = contact && effectiveHome ? bearingDeg(effectiveHome.lat, effectiveHome.lon, contact.lat, contact.lon) : 0;
   const lp = (sp + 180) % 360;
-  const dist = contact ? distanceKm(effectiveHome.lat, effectiveHome.lon, contact.lat, contact.lon) : 0;
+  const dist = contact && effectiveHome ? distanceKm(effectiveHome.lat, effectiveHome.lon, contact.lat, contact.lon) : 0;
 
   function submitBeam(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -707,6 +706,7 @@ export default function App() {
                 }}
                 fallback={null}
               >
+                {effectiveHome && (
                 <LeafletWorldMap
                   home={{
                     call: effectiveHome.call,
@@ -745,6 +745,7 @@ export default function App() {
                     void rot.setAzimuth(normalized);
                   }}
                 />
+                )}
               </LeafletMapErrorBoundary>
             </div>
             <div

--- a/zeus-web/src/components/design/data.ts
+++ b/zeus-web/src/components/design/data.ts
@@ -109,17 +109,6 @@ export type Contact = {
   qrzUrl?: string;
 };
 
-// Central-US home station — placeholder so the default great-circle runs
-// Ireland ↔ North America. Swap in the operator's real call/grid once the
-// backend surfaces it.
-export const HOME = {
-  call: 'W0NER',
-  lat: 38.63,
-  lon: -90.2,
-  grid: 'EM48',
-  name: 'Home',
-};
-
 export const CONTACTS: Record<string, Contact> = {
   EI6LF: {
     callsign: 'EI6LF',

--- a/zeus-web/src/layout/WorkspaceContext.tsx
+++ b/zeus-web/src/layout/WorkspaceContext.tsx
@@ -70,7 +70,7 @@ export interface WorkspaceCtx {
   mapAvailable: boolean;
   setMapAvailable: (v: boolean) => void;
   mapInteractive: boolean;
-  effectiveHome: EffectiveHome;
+  effectiveHome: EffectiveHome | null;
   beamOverrideDeg: number | null;
   setBeamOverrideDeg: (v: number | null) => void;
   beamInputStr: string;

--- a/zeus-web/src/layout/panels/HeroPanel.tsx
+++ b/zeus-web/src/layout/panels/HeroPanel.tsx
@@ -161,6 +161,7 @@ export function HeroPanel() {
             }}
             fallback={null}
           >
+            {effectiveHome && (
             <LeafletWorldMap
               home={{
                 call: effectiveHome.call,
@@ -185,6 +186,7 @@ export function HeroPanel() {
               interactive={mapInteractive}
               onRotateToBearing={handleRotateToBearing}
             />
+            )}
           </LeafletMapErrorBoundary>
         </div>
         <div


### PR DESCRIPTION
## Summary
- Removes the hard-coded `HOME = { call: 'W0NER', lat: 38.63, lon: -90.2, grid: 'EM48' }` placeholder from `zeus-web/src/components/design/data.ts`.
- `effectiveHome` becomes `EffectiveHome | null`; the LeafletWorldMap home marker, great-circle arc, and bearing/distance calcs only render when QRZ supplies a real station.

## Why
The placeholder was a dev-time crutch from the original Nereus design port so the disconnected demo looked populated. In live use (e.g. when the QRZ lookup succeeds but doesn't return a home lat/lon), the fallback branch fires and a fake W0NER/EM48 marker shows up on the map. No one asked for W0NER.

## Test plan
- [ ] `npm run typecheck` passes (verified locally).
- [ ] Disconnected / no-QRZ state: map area is empty (fallback renders nothing) — no W0NER marker, no Ireland↔Missouri arc.
- [ ] Connected + QRZ home loaded: home marker, home→target arc, and bearing/distance display normally.
- [ ] Target-only lookup with no home: map stays empty, QRZ card still populates, no runtime errors.