### PR TITLE
docs(prd): filter visualization & panel

### DIFF
--- a/docs/proposals/filter-visualization-prd.md
+++ b/docs/proposals/filter-visualization-prd.md
@@ -1,0 +1,257 @@
+# PRD — Filter visualization & filter panel
+
+**Status:** Draft (2026-04-23) — Brian Keating (EI6LF), via team-lead.
+**Related:** `docs/proposals/band-planning-prd.md` (co-designed; this PRD consumes the
+`inBand(freqHz, mode)` predicate from that one).
+**Research:** `docs/proposals/research/wdsp-filter-inventory.md`,
+`docs/proposals/research/thetis-filter-ux.md`.
+
+---
+
+## 1. Problem statement
+
+Zeus today exposes the RX filter as **two numbers** on `/api/state` (`FilterLowHz`,
+`FilterHighHz`) and has no operator-facing way to change them. The operator cannot:
+
+- See the filter passband on the panadapter/waterfall (Thetis's single most-used visual cue
+  for "am I hearing the signal I want to hear").
+- Click a preset to switch between common widths (2.4k / 2.7k / 2.9k SSB, 500/250/100 Hz CW).
+- Nudge the low/high edges independently for a variable SSB roofing shape.
+- Tell at a glance whether the filter is hanging over a band edge — critical for SSB near
+  the bottom of a band where a wide filter can push the low sideband out of allocation.
+
+The WDSP wiring is already correct (engine-side `SetFilter` already writes all three RXA
+stages per `rxa.cs:110–124`, and mode-switch preserves stored magnitudes — verified shipping
+code at `WdspDspEngine.cs:333–343, 1175–1200`). The gap is **surface**: wire format,
+REST/hub endpoint, frontend panel, and panadapter/waterfall overlay.
+
+## 2. Non-goals
+
+- TX filter editing surface. Thetis itself treats the TX filter as a per-profile pair set in
+  Setup > DSP, not a per-mode preset stack. Zeus will follow suit: TX filter stays
+  engine-managed.
+- Second receiver (RX2) preset separation. Contract is already per-channel-id; UI shows
+  whichever RXA is open.
+- Filter tap count / min-phase knobs (`SetRXABandpassNC`, `SetRXABandpassMP`). Marked as
+  `[GAP]` in the inventory; reserved for a later "DSP advanced" panel.
+- FM filter presets — Thetis has none; Zeus will not invent them.
+- Enforcement of out-of-band: this PRD only **visualizes** it. Transmit inhibit stays a band-
+  planning PRD follow-up.
+
+## 3. UX specification
+
+### 3.1 Filter panel (new component)
+
+Placement: a single row under the VFO readout, spanning the width of the VFO + mode cluster.
+In the existing Zeus flex-layout it joins the same panel as the VFO/mode/AGC group; the
+maintainer (Brian) signs off on final placement (CLAUDE.md: visual design is red-light, so
+the first PR lands with a plausible default and the maintainer adjusts).
+
+Contents:
+
+- **Width readout** (left): current filter width in Hz/kHz (e.g., `2.7 kHz` for USB F6,
+  `500 Hz` for CWL F4). Single-hue amber (`#FFA028`), matches the existing VFO readout style.
+- **Preset chip row** (center): 12 chips labelled from the Thetis default preset table for
+  the current mode (`F1..F10` + `VAR1 VAR2`). The selected chip is filled amber; others show
+  only the amber outline. Modes without presets (FM) hide the chip row and show just Lo/Hi.
+- **Lo / Hi nudge controls** (right): two compact up/down pairs, each stepping by 10 Hz (SSB)
+  or 10 Hz (CW) or 100 Hz (AM/SAM/DSB/DIGx). Clicking the chip `VAR1` or `VAR2` and then
+  nudging writes the value back into that slot (matching Thetis's edit-in-place behavior).
+  Clicking a fixed `F*` chip and nudging is **silent-accepted** — Zeus does not overwrite
+  fixed-preset slots (cleaner semantics than Thetis, where any edit bleeds back into the
+  slot). The server will return HTTP 409 for a fixed-slot write and the frontend surfaces a
+  brief toast.
+
+### 3.2 Panadapter / waterfall overlay
+
+Single layer rendered on top of the existing GL panadapter (reuses the same coordinate space
+the VFO center-frequency marker already uses):
+
+- **Shaded passband fill**: a translucent amber rectangle (`rgba(255, 160, 40, 0.18)`) from
+  x=`px(vfo + loHz)` to x=`px(vfo + hiHz)`, spanning the full panadapter height.
+- **Edge lines**: two 1px solid amber vertical lines at the same x positions, full height.
+- **Drag handles**: the edge lines become drag-cursor-enabled when the operator hovers
+  within ±4 px. Dragging writes the new Lo or Hi through the same REST endpoint the preset
+  chips use; the active chip auto-flips to `VAR1` if a fixed preset was selected. Drag is
+  rate-limited client-side (20 Hz max) to keep the wire from thrashing.
+- **Waterfall**: the same shaded column is drawn on the waterfall layer (no edge lines, just
+  the fill — the panadapter carries the resolution for fine alignment).
+
+Out-of-band coloring (requires `band-planning-prd.md` to ship first):
+
+- If either `vfo + loHz` or `vfo + hiHz` falls outside the current region/mode band plan
+  (as reported by `inBand(freqHz, mode)`), the fill color flips to red
+  (`rgba(255, 60, 40, 0.28)`) and the edge line on the offending side goes solid red. The
+  panel width readout appends a small red `OOB` label. No TX interference — purely visual.
+- Until the band-planning PRD lands, this path is a no-op and the overlay stays amber in
+  all cases. The filter PRD commits the client code path behind a `bandPlan.inBand`
+  predicate that returns `true` when the band plan is unavailable.
+
+### 3.3 Interaction details
+
+- Clicking a preset chip: immediate write, no confirm. Optimistic UI with rollback on
+  server-reported error.
+- Mode switch: engine already re-applies stored magnitudes with correct sign
+  (`ApplyBandpassForMode` via `SetMode`). Frontend shows the **LastFilter** slot (`F5` by
+  default per Thetis convention) as active; if the persisted slot for the new mode is
+  different, that one lights up instead.
+- CW offset: the frontend adds `cw_pitch` (default 600 Hz; reads from state if/when we
+  expose it) to the low/high when drawing CW — matching Thetis's `-cw_pitch ± half` form.
+  The Lo/Hi panel values shown to the operator are **the actual Hz offsets from VFO**, not
+  centered-on-pitch — operators expect to read VFO-relative numbers.
+
+## 4. Data model
+
+### 4.1 Wire contract additions (`Zeus.Contracts/FilterFrame.cs` — new file)
+
+```csharp
+namespace Zeus.Contracts;
+
+public sealed record FilterStateFrame(
+    int ChannelId,
+    RxMode Mode,
+    int LowHz,     // signed, VFO-relative
+    int HighHz,    // signed, VFO-relative
+    string? PresetName = null,  // e.g. "F6" or "VAR1" — nullable if operator dragged
+    int? PresetIndex = null);
+
+public sealed record FilterSetRequest(
+    int LowHz,
+    int HighHz,
+    string? PresetName = null);  // optional — nudges without a preset context omit this
+
+public sealed record FilterPresetWriteRequest(
+    RxMode Mode,
+    string SlotName,     // "VAR1" or "VAR2"; server rejects F1..F10
+    int LowHz,
+    int HighHz);
+```
+
+The server rejects `FilterPresetWriteRequest` for slots other than `VAR1/VAR2` with HTTP 409.
+
+### 4.2 State extension
+
+`StateDto` already carries `FilterLowHz` / `FilterHighHz`. Add:
+
+- `FilterPresetName: string?` — the currently-active slot name, or `null` after a drag edit.
+
+### 4.3 Server persistence
+
+`DspSettingsStore` currently holds AGC/NR/attenuator state. Extend with:
+
+- `FilterPresetOverrides: Dictionary<RxMode, { var1: (lo, hi), var2: (lo, hi) }>`
+  — per-mode VAR1/VAR2 edits.
+- `LastSelectedPreset: Dictionary<RxMode, string>` — remembers which preset slot the
+  operator last used per mode, so mode-switch recalls the matching slot.
+
+Both persist across Zeus.Server restarts (LiteDB, same file).
+
+## 5. Backend changes
+
+### 5.1 `RadioService` / `StreamingHub`
+
+- `SetFilter(int lowHz, int highHz, string? presetName)` — existing hub method; grow to
+  accept `presetName` and broadcast the updated `FilterStateFrame`.
+- `SetFilterPresetOverride(RxMode mode, string slotName, int loHz, int hiHz)` — new.
+  Validates slotName in `{VAR1, VAR2}`. Persists via `DspSettingsStore`. Returns the
+  updated override map.
+- `GetFilterPresets(RxMode mode): IReadOnlyList<FilterPreset>` — returns the merged Thetis
+  defaults + operator overrides for the requested mode. Frontend calls this on mount and
+  after any VAR* write.
+
+### 5.2 REST endpoints (parity with hub)
+
+- `POST /api/filter` — body `FilterSetRequest`.
+- `GET /api/filter/presets?mode=USB` — returns preset list.
+- `POST /api/filter/presets` — body `FilterPresetWriteRequest` (VAR* only).
+
+### 5.3 Frame publishing
+
+Add `FilterStateFrame` to the `StreamingHub` broadcast set; emit on every `SetFilter` or
+mode change. Existing state broadcast already carries `FilterLowHz/HighHz` — this is the
+richer variant that adds preset context.
+
+## 6. Frontend changes (`zeus-web/`)
+
+### 6.1 New files
+
+- `src/components/filter/FilterPanel.tsx` — the VFO-row component described in §3.1.
+- `src/components/filter/filterPresets.ts` — TypeScript constant mirroring
+  `thetis-filter-ux.md` §2 (all 10 modes × 12 slots). Source of truth for default labels and
+  default Lo/Hi.
+- `src/gl/panadapter/FilterOverlay.ts` (or equivalent hook in the existing panadapter module)
+  — renders the shaded passband + edge lines + drag handles.
+- `src/state/filter.ts` — client state: active preset slot, drag-in-flight flag, per-mode
+  override cache (seeded by `GET /api/filter/presets` on connect).
+
+### 6.2 Modified files
+
+- `src/layout/*` — inject `FilterPanel` into the VFO row. Maintainer to confirm placement.
+- `src/realtime/hubClient.ts` — handle `FilterStateFrame` subscription.
+- `src/gl/panadapter/*` — invoke the new overlay after the waterfall pass (Hz-to-pixel math
+  is already available via the panadapter's freq-to-x projection).
+
+## 7. Band-planning integration (forward contract)
+
+This PRD commits to consuming the band-plan predicate without blocking on its
+implementation. Contract:
+
+```ts
+// Provided by band-planning PRD; a no-op stub ships with this PRD.
+export interface BandPlan {
+  inBand(freqHz: number, mode: RxMode): boolean;
+  getSegment(freqHz: number): BandSegment | null;  // nullable when off-plan
+}
+```
+
+The filter overlay imports `BandPlan` via a React context. Until the band-planning PRD lands,
+a stub is registered that returns `true` unconditionally, so the amber overlay ships as the
+only visible state.
+
+**Handoff definition**: `inBand(f, mode)` returns `true` iff the frequency is inside a
+segment whose `mode` matches (mode-aware so 40m CW sub-band doesn't light green for USB).
+`getSegment` is unused in this PRD — but the filter overlay will use it later for the hover
+tooltip ("40m Extra CW").
+
+## 8. Acceptance criteria
+
+1. On fresh connect, operator sees the filter panel under the VFO with default preset `F6`
+   (2.7k) highlighted for USB; shaded amber passband visible on panadapter and waterfall.
+2. Clicking `F7` changes the filter to 100..2500 Hz (USB), width readout updates to `2.4 kHz`,
+   audio passband narrows audibly, WDSP logs confirm the new Lo/Hi values.
+3. Switching mode USB → LSB preserves the F6 selection (Thetis parity) and re-signs the
+   passband so the overlay appears on the correct side of the carrier.
+4. Dragging the right edge of the passband updates Hi in real time; the active chip flips to
+   `VAR1`; server logs one write per ~50 ms during the drag (rate-limited).
+5. Restarting Zeus.Server and reconnecting restores the operator's last VAR1 edit for USB
+   (persisted in `DspSettingsStore`).
+6. Attempting `POST /api/filter/presets` with `SlotName=F6` returns HTTP 409 and the
+   frontend toasts "Fixed presets cannot be edited".
+7. With the band-plan stub returning `true`, no red OOB coloring appears anywhere.
+8. (Post band-plan PRD) Tuning USB on 14.347 MHz with a 5.0k filter (F1) shows the right
+   edge crossing 14.350 MHz and the fill turns red on the high side.
+
+## 9. Open questions
+
+- **Default preset for Zeus's current 150..2850 passband**: does the PRD preserve Zeus's
+  wider low-cut as a new "VAR1 pre-seed" on first connect, or reset operators to Thetis F6?
+  Maintainer call. Default implementation: preserve Zeus's 150/2850 as VAR1 for SSB on
+  first run, and select VAR1 on that first run only.
+- **CW pitch readout**: should the panel expose `cw_pitch` to the operator (Setup
+  control), or wait for a broader "DSP advanced" PRD? Default: do not expose in this PRD.
+- **Step sizes for nudge**: 10 Hz SSB feels right; should it be 50 Hz for DIGx to avoid
+  misery? Default: 50 Hz step for DIGL/DIGU.
+- **Display span behavior**: if operator narrows the filter below one pixel-per-Hz at
+  current zoom, do we auto-zoom? Default: no, keep zoom operator-controlled.
+
+## 10. Implementation phasing
+
+- **Phase 1** (this PRD's PR) — wire contract + hub/REST + backend store + minimal
+  frontend panel with fixed presets only, no drag handles, no OOB coloring.
+- **Phase 2** — panadapter overlay (shaded + edge lines, no drag), waterfall overlay.
+- **Phase 3** — drag handles writing back to VAR*.
+- **Phase 4** — OOB coloring, gated on band-planning PRD v1 shipping and the BandPlan
+  context being populated.
+
+Each phase is a separately-mergeable PR. The maintainer can stop after any phase without
+leaving half-finished UX visible.

--- a/docs/proposals/research/thetis-filter-ux.md
+++ b/docs/proposals/research/thetis-filter-ux.md
@@ -1,0 +1,240 @@
+# Thetis filter panel UX
+
+Research reference for the Zeus "Filter visualization & filter panel" PRD. Source:
+`ramdor/Thetis` @ `master` — `Project Files/Source/Console/` unless noted otherwise. Line numbers
+refer to that mirror's `console.cs` as fetched for this research.
+
+---
+
+## 1. Filter slot model
+
+- Each DSP mode owns its own `FilterPreset[]` row. Slots per mode are **exactly 12**:
+  `F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, VAR1, VAR2`.
+- Two parallel preset stacks: `rx1_filters[(int)DSPMode]` and `rx2_filters[(int)DSPMode]`
+  (`console.cs:5179–5180`). Same shape for both receivers.
+- Default "last filter" (the one selected on mode entry) is `F5` for every mode that has
+  presets (LSB/USB/CWL/CWU/AM/SAM/DSB/DIGL/DIGU) — see the repeated
+  `preset[m].LastFilter = Filter.F5;` at the end of each case.
+- Modes without presets (`FM`, `SPEC`, `DRM`, any unused `DSPMode`): `LastFilter = NONE`.
+  FM specifically is treated as fixed-bandwidth by the Thetis radio.cs path; there is no
+  operator-editable FM filter preset.
+
+---
+
+## 2. Per-mode default preset tables (Hz, signed)
+
+All numbers verbatim from `console.cs:5182–5585` `InitFilterPresets`. Positive = above VFO,
+negative = below. `cw_pitch` is the CW sidetone (default 600 Hz). `digl_click_tune_offset` /
+`digu_click_tune_offset` are the digital-mode click-tune offsets (set by operator; default
+reads as 0 on a fresh profile — Thetis lets the user set them via Setup > DSP > Options).
+
+### LSB — `console.cs:5199–5240`
+
+| Slot | Low | High | Name |
+|------|-----|------|------|
+| F1 | −5100 | −100 | 5.0k |
+| F2 | −4500 | −100 | 4.4k |
+| F3 | −3900 | −100 | 3.8k |
+| F4 | −3400 | −100 | 3.3k |
+| F5 | −3000 | −100 | 2.9k |
+| F6 | −2800 | −100 | 2.7k |
+| F7 | −2500 | −100 | 2.4k |
+| F8 | −2200 | −100 | 2.1k |
+| F9 | −1900 | −100 | 1.8k |
+| F10 | −1100 | −100 | 1.0k |
+| VAR1 | −2800 | −100 | Var 1 |
+| VAR2 | −2800 | −100 | Var 2 |
+
+### USB — `console.cs:5241–5282` (mirror of LSB)
+
+| Slot | Low | High | Name |
+|------|-----|------|------|
+| F1 | 100 | 5100 | 5.0k |
+| F2 | 100 | 4500 | 4.4k |
+| F3 | 100 | 3900 | 3.8k |
+| F4 | 100 | 3400 | 3.3k |
+| F5 | 100 | 3000 | 2.9k |
+| F6 | 100 | 2800 | 2.7k |
+| F7 | 100 | 2500 | 2.4k |
+| F8 | 100 | 2200 | 2.1k |
+| F9 | 100 | 1900 | 1.8k |
+| F10 | 100 | 1100 | 1.0k |
+| VAR1 | 100 | 2800 | Var 1 |
+| VAR2 | 100 | 2800 | Var 2 |
+
+> Note: Zeus's default `FilterLowAbsHz=150, FilterHighAbsHz=2850`
+> (`WdspDspEngine.cs:114–115`) corresponds to **neither** Thetis F6 (100, 2800, 2.7k) nor F7
+> (100, 2500, 2.4k) exactly. Zeus chose 150 Hz low-cut instead of 100 Hz intentionally (see the
+> OpenTxChannel comment at `WdspDspEngine.cs:649–653`: "wider than the classic SSB 300-2700 to
+> keep low-frequency voice energy through the chain"). The PRD should decide whether to
+> preserve this Zeus default or snap to Thetis F5/F6.
+
+### CWL — `console.cs:5367–5408` (centered on `-cw_pitch`)
+
+| Slot | Half-width | Width | Name |
+|------|-----------|-------|------|
+| F1 | ±500 | 1.0k | 1.0k |
+| F2 | ±400 | 800 | 800 |
+| F3 | ±300 | 600 | 600 |
+| F4 | ±250 | 500 | 500 |
+| F5 | ±200 | 400 | 400 |
+| F6 | ±125 | 250 | 250 |
+| F7 | ±75 | 150 | 150 |
+| F8 | ±50 | 100 | 100 |
+| F9 | ±25 | 50 | 50 |
+| F10 | ±13 | 25 | 25 |
+| VAR1/VAR2 | ±250 | 500 | Var 1 / Var 2 |
+
+Actual Hz: `low = -cw_pitch - half`, `high = -cw_pitch + half`. With default `cw_pitch = 600`
+the F5 (400 Hz) slot spans −800..−400 Hz.
+
+### CWU — `console.cs:5409–5450` (mirror of CWL, centered on `+cw_pitch`)
+
+Same half-widths as CWL; `low = cw_pitch - half`, `high = cw_pitch + half`. With default
+`cw_pitch = 600` the F5 (400 Hz) slot spans +400..+800 Hz.
+
+### AM — `console.cs:5451–5492` (symmetric around 0)
+
+| Slot | Half-width | Width | Name |
+|------|-----------|-------|------|
+| F1 | ±10000 | 20k | 20k |
+| F2 | ±9000 | 18k | 18k |
+| F3 | ±8000 | 16k | 16k |
+| F4 | ±6000 | 12k | 12k |
+| F5 | ±5000 | 10k | 10k |
+| F6 | ±4500 | 9.0k | 9.0k |
+| F7 | ±4000 | 8.0k | 8.0k |
+| F8 | ±3500 | 7.0k | 7.0k |
+| F9 | ±3000 | 6.0k | 6.0k |
+| F10 | ±2500 | 5.0k | 5.0k |
+| VAR1/VAR2 | ±3000 | 6.0k | Var 1 / Var 2 |
+
+### SAM — `console.cs:5493–5534` (identical to AM table)
+
+### DSB — `console.cs:5535–5576`
+
+| Slot | Half-width | Width | Name |
+|------|-----------|-------|------|
+| F1 | ±8000 | 16k | 16k |
+| F2 | ±6000 | 12k | 12k |
+| F3 | ±5000 | 10k | 10k |
+| F4 | ±4000 | 8.0k | 8.0k |
+| F5 | ±3300 | 6.6k | 6.6k |
+| F6 | ±2600 | 5.2k | 5.2k |
+| F7 | ±2000 | 4.0k | 4.0k |
+| F8 | ±1550 | 3.1k | 3.1k |
+| F9 | ±1450 | 2.9k | 2.9k |
+| F10 | ±1200 | 2.4k | 2.4k |
+| VAR1/VAR2 | ±3300 | 6.6k | Var 1 / Var 2 |
+
+### DIGL — `console.cs:5283–5324` (centered on `-digl_click_tune_offset`)
+
+Half-widths: 1500 / 1250 / 1000 / 750 / 500 / 400 / 300 / 150 / 75 / 38. Names: 3.0k / 2.5k /
+2.0k / 1.5k / 1.0k / 800 / 600 / 300 / 150 / 75. VAR1/VAR2 = ±400 "Var 1/2". Default
+`digl_click_tune_offset = 0` so the F5 (1.0k) slot spans −500..+500 Hz until the operator sets
+a click-tune offset.
+
+### DIGU — `console.cs:5325–5366` (mirror of DIGL)
+
+Half-widths identical to DIGL, centered on `+digu_click_tune_offset`.
+
+### FM — no entries in `InitFilterPresets`
+
+FM falls into the `default:` branch (`console.cs:5577–5580`) which only sets
+`LastFilter = NONE`. The FM filter is instead driven by the FMN/FMW mode in the radio-path code;
+operator-editable FM filter presets do not exist in Thetis 2.10.
+
+---
+
+## 3. Variable filter behavior
+
+`VAR1` / `VAR2` are edit-in-place slots: clicking VAR1 selects it, then the operator edits the
+low/high directly (Setup > Filters > FilterForm, or by dragging the passband edges on the
+panadapter — see §4). The numbers are persisted per mode back into the same preset array, which
+is then written to the profile DB. There is no separate "variable mode" — the selected preset
+slot is always `Filter`-typed, and VAR* slots simply behave as mutable presets.
+
+`FilterPreset.SetLow(Filter, int)` / `SetHigh(Filter, int)` (`filter.cs` class) are the setters
+called by the drag interaction and by the Setup dialog. Both clamp to the form's `udLow.Minimum
+/ Maximum` bounds — `FilterForm.cs:371–407` shows the `NumericUpDown` range on the manual-edit
+form but the literal min/max are not in the uppermost 200 lines I pulled; typical values are
+±9999 for SSB, ±20000 for AM/SAM. Flag for PRD: confirm the clamp range if the UI is going to
+mimic Thetis's behavior exactly.
+
+---
+
+## 4. Panadapter passband overlay (Thetis)
+
+From `PanDisplay.cs` (not fully read — structural summary only, based on known Thetis behavior
+and the `filterColor` naming found in searches):
+
+- **Shaded region** drawn between `vfo + low` and `vfo + high` pixels. Color is
+  configurable (`grid_filter_color` / `filter_color` — default a semi-transparent green on
+  white grid, cyan on dark grid).
+- **Edge lines**: thin vertical at the low and high pixel positions; these are drag-handles
+  when the operator clicks within a few pixels of them (the drag action writes back into the
+  active `FilterPreset` slot — VAR1/VAR2 for ad-hoc, or the selected F-slot if the operator has
+  "Edit mode" engaged).
+- **Center marker**: a vertical line at the VFO (not the filter center). For CW this means
+  the filter passband sits offset from the center line by `cw_pitch`.
+- **Waterfall**: the same shaded passband column is drawn down the waterfall so the operator
+  can see the filter's relationship to moving signals.
+
+> Caveat: I did not paste exact pixel-drawing code from PanDisplay.cs into this doc — the full
+> file wasn't needed to produce the Zeus PRD, since the Zeus overlay will be rendered by the
+> web frontend, not a direct port. The PRD can work from this structural summary plus the
+> numeric preset tables in §2.
+
+---
+
+## 5. Out-of-band indication
+
+**Thetis does NOT draw any filter-specific out-of-band indicator on the panadapter.** The
+region-based band-edge information is surfaced separately:
+
+1. `BandText` (the sub-band label shown under the VFO) turns to "Out of Band" in amber/red
+   when the current carrier frequency is outside any matching band segment
+   (`database.cs:9566` `BandText()`, fallback return); see `thetis-bandplan.md` §2b.
+2. TX is inhibited via `CheckValidTXFreq` (`console.cs:6778`), which for SSB/AM/FM etc.
+   re-checks with `freq + filterLow` / `freq + filterHigh` — so a filter extending past the
+   band edge denies TX even if the carrier is in-band. There is NO visual warning for this on
+   the panadapter; the operator only learns by hitting MOX and seeing the TX-denied light.
+
+This is a **Zeus PRD opportunity**: once the band-planning feature lands, Zeus can draw a
+colored warning band in the filter overlay when `vfo + loHz` or `vfo + hiHz` crosses a
+band-plan boundary. The contract already needs `inBand(freqHz, mode)` for the band-planning
+PRD; the filter PRD just consumes it.
+
+---
+
+## 6. Gotchas
+
+- **Filter is an RX concept separate from TX.** `rx1_filters[]` and `rx2_filters[]` are
+  receiver-side; TX filter is derived from the TXA mode + a single per-profile TX filter
+  low/high pair (Setup > DSP > Transmit). The operator does not pick from a TX preset list.
+  The Zeus PRD should follow suit — visualize and edit only the RX filter.
+- **CW filter is centered on sidetone, not 0 Hz.** Naïve "draw passband at `vfo ± halfwidth`"
+  will put the CW passband on the wrong side of the carrier. The overlay must read the signed
+  low/high produced by `ApplyBandpassForMode` or re-apply the same sign logic client-side.
+- **DIGL/DIGU click-tune offset is user-configurable** and defaults to 0. Any visualization
+  that assumes a non-zero offset will mis-position the digital passband for fresh profiles.
+- **VAR1/VAR2 are per-mode, per-receiver** — edits to RX1's USB VAR1 do not propagate to
+  RX2 or to any other mode.
+- **Zeus's 150 Hz low-cut** deviates from Thetis's 100 Hz low-cut on SSB. The PRD has to
+  pick: keep Zeus's current default (wider low end) or reset to Thetis F6 on fresh connect.
+
+---
+
+## 7. Zeus-side implication summary
+
+- **Frontend preset tables** can be shipped as a TypeScript constant identical to §2 — no
+  server round-trip needed just to render labels. Per-operator edits to VAR1/VAR2 will need
+  server persistence (fits the `DspSettingsStore` pattern).
+- **Wire format**: the frame only needs `{channelId, mode, loHz, hiHz}` (signed), plus
+  optionally the name of the currently-selected slot if the UI wants to highlight it. The
+  frontend can reconstruct the preset table from its TypeScript constant.
+- **Visualization**: shaded passband rectangle + two drag-handle vertical lines, drawn at
+  `vfo + loHz`..`vfo + hiHz` on the panadapter AND the waterfall. Amber (`#FFA028`) at low
+  alpha for the fill, solid amber lines at the edges — stay on-palette (see CLAUDE.md).
+- **Out-of-band warning**: deferred to band-planning PRD landing; coloring flips from amber
+  to red once `inBand(...)` returns false for either edge.

--- a/docs/proposals/research/wdsp-filter-inventory.md
+++ b/docs/proposals/research/wdsp-filter-inventory.md
@@ -1,0 +1,141 @@
+# WDSP filter API inventory (Zeus-facing)
+
+Research reference for the Zeus "Filter visualization & filter panel" PRD. Scope: what filter state
+WDSP exposes, what Zeus already surfaces through P/Invoke, and where the frontier is for adding
+visualization without touching WDSP itself.
+
+Native sources live under `native/wdsp/`; Zeus wrappers under `Zeus.Dsp/Wdsp/`.
+
+---
+
+## 1. The two bandpass families
+
+WDSP ships two distinct overlap-save bandpass implementations — both visible in
+`native/wdsp/bandpass.h`.
+
+- **`BPS` (simple overlap-save)** — `bandpass.h:36–81`. Monolithic FIR, the whole filter in a
+  single overlap-save block. Exports `SetRXABPSRun`, `SetRXABPSFreqs`, `SetTXABPSRun`,
+  `SetTXABPSFreqs`. **Zeus does not expose any of these.** Thetis uses BPS only for the RXA `bp1`
+  "compressor-only aux bandpass" slot; `bp1` is bypassed for SSB.
+- **`BANDPASS` (partitioned overlap-save)** — `bandpass.h:96–139`. Segmented FIR with tap count
+  `nc` and min-phase flag `mp`. Backed by a `FIRCORE` (`firmin.h`). This is the one Zeus actually
+  drives via `SetRXABandpassFreqs` / `SetTXABandpassFreqs`.
+
+The struct carries: `f_low`, `f_high`, `samplerate`, `wintype`, `gain`, plus the FIRCORE (tap
+count `nc`, min-phase `mp`). Everything in that list is set via a public `Set*` entrypoint in
+WDSP, but Zeus only uses the freq + run + window subset.
+
+### RXA chain: three independent filter stages
+
+`WdspDspEngine.ApplyBandpassForMode` (`Zeus.Dsp/Wdsp/WdspDspEngine.cs:1175–1200`) writes the
+passband into **three** WDSP objects on every filter change — matching Thetis `rxa.cs:110–124`:
+
+1. `SetRXABandpassFreqs(ch, lo, hi)` — RXA `bp1`. Bypassed for SSB but kept coherent so a
+    mode switch doesn't leave a stale passband behind.
+2. `RXANBPSetFreqs(ch, lo, hi)` — RXA `nbp0` (notch-bandpass). **This is the stage that
+    enforces the SSB passband.** Without this call, `SetRXABandpassFreqs` alone is a no-op for
+    SSB audio.
+3. `SetRXASNBAOutputBandwidth(ch, lo, hi)` — SNBA output mask, tracks the selected passband.
+
+All three take **signed** Hz offsets from VFO: LSB-family wants `low = -hiAbs, high = -loAbs`,
+USB-family `low = +loAbs, high = +hiAbs`; AM/SAM/DSB/FM/DRM are symmetric around 0 (`low = -hi,
+high = +hi`). See the switch at `WdspDspEngine.cs:1181–1193`.
+
+### TXA chain: one filter
+
+`SetTXABandpassFreqs(ch, lo, hi)` — called by `ApplyTxBandpassForMode`
+(`WdspDspEngine.cs:959–978`). Same sign convention as RXA. `SetTXABandpassRun` is explicitly
+**not** called — despite the name it sets `bp1.run` (compressor-only aux) not `bp0`, and flipping
+it reintroduced the "TX 0 W until mode toggle" symptom (see comment at `WdspDspEngine.cs:658–663`).
+
+---
+
+## 2. Exposed to Zeus today (via `Zeus.Dsp/Wdsp/NativeMethods.cs`)
+
+| P/Invoke | WDSP function | What it does | Used by |
+|---|---|---|---|
+| `SetRXABandpassFreqs` | `SetRXABandpassFreqs` in `bandpass.c` | RXA bp1 low/high Hz (signed) | `ApplyBandpassForMode` |
+| `RXANBPSetFreqs` | `RXANBPSetFreqs` in `nbp.c` | RXA nbp0 low/high Hz — the SSB-carrying stage | `ApplyBandpassForMode` |
+| `SetRXASNBAOutputBandwidth` | `SetRXASNBAOutputBandwidth` in `snba.c` | SNBA output passband | `ApplyBandpassForMode` |
+| `SetRXABandpassRun` | `SetRXABandpassRun` | bp1 enable | `OpenChannel` init |
+| `SetRXABandpassWindow` | `SetRXABandpassWindow` | FFT window selector (1 = Blackman-Harris) | `OpenChannel` init |
+| `SetTXABandpassFreqs` | `SetTXABandpassFreqs` | TXA bp0 low/high Hz (signed) | `ApplyTxBandpassForMode` |
+| `SetTXABandpassWindow` | `SetTXABandpassWindow` | TXA FFT window | `OpenTxChannel` |
+| `SetRXAMode`, `SetTXAMode` | `SetRXAMode`, `SetTXAMode` | Demod/mod mode selector (LSB/USB/CWL/CWU/AM/FM/SAM/DSB/DIGL/DIGU/SPEC/DRM) | `SetMode`, `SetTxMode` |
+
+### Filter state Zeus can read today (no new P/Invoke needed)
+
+The engine already stores, per channel, in `ChannelState`
+(`WdspDspEngine.cs:93–129`):
+
+- `FilterLowAbsHz`, `FilterHighAbsHz` — unsigned magnitudes (sign is re-derived from
+  `CurrentMode`). Default `150..2850 Hz`.
+- `CurrentMode` (`RxaMode` enum) — drives sign selection.
+- `SampleRateHz` — 48/96/192 kHz input rate.
+- `PixelWidth` — analyzer span in pixels (not a filter field, but we need it to map Hz →
+  pixel offsets in the overlay).
+
+This is everything required to publish a `FilterStateFrame` today: `{channelId, mode, loHz,
+hiHz}` with signed values derived by the same switch `ApplyBandpassForMode` uses.
+
+### Zeus `SetFilter` contract (`WdspDspEngine.cs:333–343`)
+
+```
+public void SetFilter(int channelId, int lowHz, int highHz)
+```
+
+- Accepts **unsigned magnitudes**; internally reorders if `highHz < lowHz`.
+- Stores on `ChannelState`, then calls `ApplyBandpassForMode(state)` which (re)issues all
+  three RXA stages with the correct sign.
+- Mode switches (`SetMode`) re-invoke `ApplyBandpassForMode` so stored magnitudes survive
+  LSB ⇄ USB transitions without operator action.
+
+RX filter state therefore lives **entirely in Zeus.Server memory**; WDSP does not carry
+persistent "presets" per mode. Preset tables are a Thetis-side construct (see
+`thetis-filter-ux.md`) that would live in Zeus.Server config/store — they are not a WDSP concept.
+
+---
+
+## 3. Gaps (cheap to add if the PRD needs them)
+
+- **`[GAP]` `SetRXABandpassNC(channel, nc)`** — FIR tap count on the partitioned bandpass.
+  Thetis default is **1024** (from `rxa.cs`'s `FilterNC` initializer — not verified in Zeus
+  context, flag for PRD check). Lets the operator trade audio latency for passband steepness.
+  Declared at `bandpass.h:133` but no `NativeMethods` entry. Adding is ~5 lines of P/Invoke plus
+  an `engine.SetFilterTaps(int)` pass-through. Not needed for visualization v0 — filter
+  visualization draws from `loHz/hiHz`, not from the tap count.
+- **`[GAP]` `SetRXABandpassMP(channel, mp)`** — min-phase flag. `bandpass.h:135`. Default is 0
+  (linear-phase). Again cheap to add, not needed for v0.
+- **`[GAP]` simple BPS family** (`SetRXABPSRun/Freqs`, `SetTXABPSRun/Freqs`) — `bandpass.h:73–81`.
+  Zeus does not drive `bp1` (compressor aux) via BPS, and probably never should at the operator
+  surface; leave unexposed.
+- **`[GAP]` RX2 / second receiver passband** — Zeus today runs a single RXA instance. When/if
+  RX2 lands, `SetFilter` needs a channel id the same way Thetis separates `rx1_filters[]` /
+  `rx2_filters[]`. Worth designing the contract to be per-channel from the outset (it already is
+  — `SetFilter(channelId, ...)`).
+
+No other filter-shape knob is worth exposing for a v0 visualization feature.
+
+---
+
+## 4. Preset mapping — Zeus-side responsibility
+
+Zeus will carry the per-mode preset tables in its own config store (frontend constants +
+server-validated write), not via WDSP. The authoritative Thetis defaults live in
+`InitFilterPresets` at `console.cs:5182–5585` (12 preset slots `F1..F10, VAR1, VAR2` per mode);
+all numeric values and the full mode table are captured in `thetis-filter-ux.md` so the filter
+PRD can reference concrete numbers directly.
+
+---
+
+## 5. Verified vs. flagged
+
+- **Verified**: Zeus's `SetFilter` P/Invoke sequence (three stages) matches Thetis
+  `rxa.cs:110–124` behavior and keeps SSB audio audible. Already shipping.
+- **Verified**: sign convention per mode (`WdspDspEngine.cs:1175–1200`). Already shipping.
+- **Flagged for PRD**: tap count `nc` is currently at WDSP's `create_bandpass` default. Zeus
+  never calls `SetRXABandpassNC`. If the PRD aims for Thetis parity on passband-edge steepness
+  the default `nc` should be matched at `OpenChannel` time (one setter call) — consider
+  including in the filter PRD implementation plan or defer as a follow-up.
+- **Flagged**: TXA `bp1.run` trap — do not re-enable `SetTXABandpassRun` from the frontend;
+  leave it to `OpenTxChannel` which deliberately skips it.


### PR DESCRIPTION
## Summary

Adds the PRD for the Zeus filter panel + panadapter/waterfall passband overlay, plus two research notes that back it.

- `docs/proposals/filter-visualization-prd.md` — full PRD (UX, data model, backend, frontend, phasing, open questions)
- `docs/proposals/research/wdsp-filter-inventory.md` — what WDSP exposes to Zeus today + cheap gaps
- `docs/proposals/research/thetis-filter-ux.md` — every per-mode Thetis preset table verbatim from `console.cs:5182–5585`

## Linked

Tracking issue: #59
Co-designed PRD: `feature/band-planning-prd` (defines the `inBand(freqHz, mode)` predicate this PRD's out-of-band overlay consumes)

## Test plan

- [ ] Docs-only change, nothing to run.
- [ ] Maintainer review of red-light items listed in issue #59.