### PR TITLE
docs(prd): regional band planning

### DIFF
--- a/docs/proposals/band-planning-prd.md
+++ b/docs/proposals/band-planning-prd.md
@@ -1,0 +1,339 @@
+# PRD — Regional band planning
+
+**Status:** Draft (2026-04-23) — Brian Keating (EI6LF), via team-lead.
+**Related:** `docs/proposals/filter-visualization-prd.md` (consumes the `inBand(freqHz, mode)`
+predicate this PRD exposes).
+**Research:** `docs/proposals/research/thetis-bandplan.md`.
+
+---
+
+## 1. Problem statement
+
+Zeus has no concept of a band plan. The VFO tunes freely; there is no visual indication when
+the operator strays into a non-ham allocation, there is no sub-band label ("40M Extra CW"),
+and there is no hook for the filter-visualization PRD to light up an out-of-band warning.
+Operators need:
+
+- A **default regional plan** (IARU Region 1 / 2 / 3 + UK, EI, US FCC general/extra, etc.)
+  so a fresh install "just works" for their location. A UK/EI operator shouldn't see US sub-
+  band labels on the panadapter (Thetis's long-standing gotcha — see
+  `research/thetis-bandplan.md` §6).
+- The ability to **edit the plan** when the default is wrong for them: locally-varying
+  allocations (e.g. UK 60m spot channels differ from US channels; notch-permits differ by
+  country) and to correct our defaults when the operator finds a mistake.
+- A **consumable API** for the filter-visualization PRD to color filter passbands by in/out
+  of band, and for a future TX-guard PRD to inhibit transmit.
+
+## 2. Non-goals
+
+- **TX inhibit / guard.** Thetis re-uses its band plan to gate MOX via `CheckValidTXFreq`
+  (`console.cs:6778`). Zeus will follow — but that belongs in a separate "TX band guard" PRD
+  once the plan model lands. This PRD only **surfaces** the data.
+- **Full regulator parity.** We are not re-implementing every IARU member country's plan
+  down to the last channelized segment. v1 ships a viable baseline for the regions Zeus
+  operators actually use (based on current operator base: EI, G, US + generic IARU R1/R2/R3)
+  and leaves the door open for community additions.
+- **Power caps.** Thetis has none; Zeus v1 won't add them either. Reserved as a column-name
+  slot in the data model so future versions can without a migration. Not surfaced in UI v1.
+- **Mode-auto-switch** ("tune into the CW sub-band, mode auto-flips to CWU"). Explicit
+  non-goal — operators find this annoying (per Thetis community feedback).
+
+## 3. Data model
+
+### 3.1 Region catalog
+
+```csharp
+namespace Zeus.Contracts;
+
+public sealed record BandRegion(
+    string Id,          // "IARU_R1", "IARU_R2", "IARU_R3", "EI", "G", "US_FCC_GENERAL", ...
+    string DisplayName, // "IARU Region 1", "Ireland (EI)", "United Kingdom (G)", ...
+    string ShortCode,   // "R1" | "R2" | "R3" | "EI" | "G" | "K-Gen"
+    string? ParentId);  // null for pure IARU regions; set for country overrides that layer on top
+```
+
+A country region can declare a parent (e.g. `EI.ParentId = "IARU_R1"`); the effective plan is
+parent segments overridden by country segments where they overlap. This is the **single
+biggest departure from Thetis**, which has no parent/override relationship — Thetis collapses
+everything into one flat `FRSRegion` enum. Layered regions lets us ship a minimal country
+file that only overrides what's actually different.
+
+### 3.2 Band segment
+
+```csharp
+public sealed record BandSegment(
+    string RegionId,        // which region owns this segment
+    long LowHz,             // inclusive
+    long HighHz,            // inclusive
+    string Label,           // "40M Extra CW", "60M Ch 1", "Out of Band"
+    BandAllocation Allocation,   // Amateur | SWL | Broadcast | Reserved
+    ModeRestriction ModeRestriction, // Any | CwOnly | PhoneOnly | DigitalOnly | CustomMask
+    int? MaxPowerW,         // null = unlimited / unspecified. Reserved; unused in v1 UI.
+    string? Notes);         // free-text, shown in tooltip
+
+public enum BandAllocation : byte { Amateur, SWL, Broadcast, Reserved, Unknown }
+public enum ModeRestriction : byte { Any, CwOnly, PhoneOnly, DigitalOnly }
+```
+
+- Frequencies in Hz (not MHz — wire consistency with the rest of Zeus).
+- `Amateur` + `Any` is the common case.
+- `ModeRestriction` is a coarse enum, not a bitmask — 95% of sub-bands are CW-only, phone-
+  only, or unrestricted. If a segment needs finer control (e.g. "digital + CW, no phone"),
+  the PRD adds a `CustomMask` variant with a flags field later. Not in v1.
+- `MaxPowerW` is a reserved nullable field so the shape doesn't change when a TX-power PRD
+  lands. UI ignores it in v1.
+
+### 3.3 Effective plan resolution
+
+Pseudocode for the server-side resolver that both `inBand(f, mode)` and the UI consume:
+
+```
+resolvePlan(regionId):
+  acc = []
+  for r in [regionId's ancestors, oldest-first] + [regionId]:
+    for seg in r.segments:
+      remove any overlapping segment in acc
+      add seg to acc
+  return acc sorted by LowHz
+```
+
+Country-level segments override parent segments by clearing the overlap first. Segments
+returned by `resolvePlan` do NOT overlap each other — overlap is resolved at resolution
+time, not at query time.
+
+### 3.4 Frequency → segment lookup
+
+```
+getSegment(f):
+  binary search resolvePlan(currentRegion) for the segment containing f.
+  returns null if outside any Amateur segment.
+
+inBand(f, mode):
+  seg = getSegment(f)
+  if seg == null -> false
+  if seg.Allocation != Amateur -> false
+  return seg.ModeRestriction matches mode or ModeRestriction == Any
+```
+
+Mode-matching rules:
+
+- `CwOnly`: matches `RxMode.CWU` and `RxMode.CWL` only.
+- `PhoneOnly`: matches `USB`, `LSB`, `AM`, `SAM`, `DSB`, `FM`.
+- `DigitalOnly`: matches `DIGL`, `DIGU`.
+- `Any`: matches everything.
+
+## 4. Default regional data (shipped with Zeus.Server)
+
+Ships as JSON under `Zeus.Server/BandPlans/` (one file per region). Loaded into a new
+`BandPlanStore` on startup. Layout:
+
+```
+Zeus.Server/BandPlans/
+  regions.json                 # region catalog (id, display, shortCode, parentId)
+  IARU_R1.segments.json        # generic Region 1 baseline
+  IARU_R2.segments.json        # generic Region 2 baseline
+  IARU_R3.segments.json        # generic Region 3 baseline
+  EI.segments.json             # Ireland overrides (parent: IARU_R1)
+  G.segments.json              # UK overrides (parent: IARU_R1)
+  US_FCC_GENERAL.segments.json # US FCC General class (parent: IARU_R2)
+  US_FCC_EXTRA.segments.json   # US FCC Extra class (parent: IARU_R2)
+```
+
+**Scope for v1**: the seven files above. This is the "minimum viable set" matching the
+expected initial operator base (EI maintainer + UK + US + generic IARU fallback). Additional
+country files (DE, F, JA, VK, etc.) can be added as PRs without schema changes — the loader
+auto-discovers any `*.segments.json` in the directory at startup.
+
+Example `EI.segments.json` (abbreviated — just the 40m/60m slice):
+
+```json
+{
+  "regionId": "EI",
+  "segments": [
+    { "lowHz": 7000000,  "highHz": 7039999,  "label": "40M CW",         "allocation": "Amateur", "modeRestriction": "CwOnly",   "notes": null },
+    { "lowHz": 7040000,  "highHz": 7199999,  "label": "40M Mixed",      "allocation": "Amateur", "modeRestriction": "Any",      "notes": null },
+    { "lowHz": 5351500,  "highHz": 5366500,  "label": "60M (secondary)","allocation": "Amateur", "modeRestriction": "Any",      "notes": "15 W EIRP cap — see ComReg" }
+  ]
+}
+```
+
+All default segment data is under version control in this repo; corrections land as PRs.
+
+## 5. User edit surface
+
+Thetis operators cannot edit the band plan without a code change (research §4). Zeus will
+fix this — regulatory details vary and operators catch our mistakes before we do.
+
+### 5.1 Setup panel (new `BandPlanEditor` component)
+
+Placement: Settings drawer > "Band Plan" tab, alongside the existing AGC / NR / Layout tabs.
+
+- **Region dropdown** — lists all known regions (baseline + country). Current selection is
+  persisted in `DspSettingsStore` (new field `CurrentRegionId`, default `"IARU_R1"` — Ireland
+  default, matches maintainer's location).
+- **Segment table** — shows the effective plan for the chosen region (parent merged with
+  country overrides). Columns: Low (MHz), High (MHz), Label, Allocation, Mode, Notes, Source.
+  The **Source** column shows which region file owns the segment (`EI` override vs.
+  `IARU_R1` inherited) so edits target the right level.
+- **Row actions**: edit, delete, clone-as-override. "Edit" on an inherited row prompts
+  "Override at EI level?" — an edit saves as a new country-level segment, leaving the parent
+  file untouched.
+- **Add row** button to insert new segments.
+- **Reset to defaults** — restores the country file from the shipped JSON; inherited rows
+  are untouched.
+
+### 5.2 Persistence
+
+User edits go into a separate LiteDB collection `BandPlanOverrides` in
+`Zeus.Server`'s data file. Structure:
+
+```csharp
+public sealed record BandPlanOverrideRecord(
+    string RegionId,
+    IReadOnlyList<BandSegment> Segments,
+    DateTime UpdatedUtc);
+```
+
+Override records SUPERSEDE the shipped JSON when present. "Reset to defaults" deletes the
+record for that region. Overrides are per-region, not per-segment — simpler than trying to
+diff individual segments, and the whole-region payload is small (~50 rows max).
+
+## 6. API
+
+### 6.1 REST
+
+- `GET /api/bands/regions` → `BandRegion[]` (full catalog).
+- `GET /api/bands/plan?region=EI` → `{ regionId, segments: BandSegment[] }` — resolved
+  (parent merged with overrides).
+- `PUT /api/bands/plan` — body `{ regionId, segments: BandSegment[] }` — replaces the
+  override record wholesale. Server validates: no overlaps within the submitted set, sorted
+  low→high, all Hz non-negative, Low ≤ High, labels non-empty. 400 on any failure.
+- `DELETE /api/bands/plan/:regionId` — resets to shipped defaults.
+- `GET /api/bands/current` → current region id + resolved plan (convenience for
+  frontend mount).
+- `POST /api/bands/current` — body `{ regionId }` — set the active region; persists via
+  `DspSettingsStore`.
+
+### 6.2 Hub (for the filter-overlay consumer)
+
+- `BandPlanChangedEvent` broadcast on region change or plan edit. Frontend refetches
+  `/api/bands/plan?region=X` on receipt.
+
+### 6.3 Contract exposed to the filter PRD
+
+```csharp
+namespace Zeus.Server;
+
+public interface IBandPlanService
+{
+    BandRegion CurrentRegion { get; }
+    IReadOnlyList<BandSegment> CurrentPlan { get; }
+    BandSegment? GetSegment(long freqHz);
+    bool InBand(long freqHz, RxMode mode);
+    event Action PlanChanged;
+}
+```
+
+The filter PRD's frontend BandPlan context is populated from `GET /api/bands/plan` on mount
+and on `BandPlanChangedEvent`. Same shape on both sides.
+
+## 7. Frontend changes (`zeus-web/`)
+
+### 7.1 New files
+
+- `src/components/bandplan/BandPlanEditor.tsx` — the Settings > Band Plan panel (§5.1).
+- `src/state/bandPlan.ts` — store: current region id, resolved segment array, edit-dirty
+  flag.
+- `src/context/BandPlanContext.tsx` — provides `inBand`, `getSegment`, `currentRegion` to
+  consumers (filter overlay, future TX guard, future VFO label strip).
+
+### 7.2 Modified files
+
+- `src/api/*` — new REST client for the `/api/bands/*` endpoints.
+- `src/realtime/hubClient.ts` — handle `BandPlanChangedEvent`.
+- `src/layout/*` — register the Band Plan tab in the Settings drawer.
+
+## 8. Filter PRD integration
+
+This PRD **produces** the contract the filter PRD consumes:
+
+```ts
+// filter-visualization-prd.md §7 references this
+export interface BandPlan {
+  inBand(freqHz: number, mode: RxMode): boolean;
+  getSegment(freqHz: number): BandSegment | null;
+}
+```
+
+Both methods land in `src/context/BandPlanContext.tsx`. Before this PRD merges, the filter
+PRD ships a local stub that always returns `true` for `inBand`. Once this PRD merges, the
+stub is replaced by the real context provider. No changes to the filter PRD's code beyond
+that wiring — the contract is stable.
+
+The filter PRD's "Phase 4" (OOB coloring) is gated on this PRD reaching Phase 2 (editable
+plan) — see §10.
+
+## 9. Acceptance criteria
+
+1. Fresh Zeus install with no operator config defaults to `IARU_R1` (single-operator v1
+   bias; UI can be re-defaulted by shipping a `defaultRegionId` in `appsettings.json`).
+2. `GET /api/bands/regions` returns the 7 baseline regions shipped in v1.
+3. `GET /api/bands/plan?region=EI` returns a resolved plan with `IARU_R1` segments merged
+   with the EI-specific 60m row from §4's example — no overlaps in the output.
+4. The Band Plan editor lists segments with the right "Source" column; an `IARU_R1`
+   inherited row shows source=`IARU_R1`, an EI override row shows source=`EI`.
+5. Editing an inherited row and saving creates a new override record for EI; the `IARU_R1`
+   file on disk is unchanged.
+6. `InBand(7025000, RxMode.CWU)` returns `true`; `InBand(7025000, RxMode.USB)` returns
+   `false` (CW-only sub-band per default EI plan).
+7. `InBand(8000000, RxMode.USB)` returns `false` (outside any Amateur segment).
+8. Clicking "Reset to defaults" on the editor wipes the override record and the UI
+   refreshes to the inherited-only view.
+9. Changing region fires `BandPlanChangedEvent`; filter-overlay consumers re-render.
+10. Server refuses `PUT /api/bands/plan` with overlapping segments (HTTP 400, meaningful
+    error).
+
+## 10. Implementation phasing
+
+- **Phase 1** — data model + shipped JSON (7 regions) + `BandPlanStore` + REST GETs +
+  `IBandPlanService` + frontend context with read-only surface. No editor UI. Filter PRD
+  can wire `inBand` against this.
+- **Phase 2** — Band Plan editor (add/edit/delete/reset), override persistence, PUT +
+  DELETE endpoints.
+- **Phase 3** — (follow-up PRD) TX-guard consumer gating MOX on `InBand`.
+
+Each phase is a separately-mergeable PR.
+
+## 11. Open questions
+
+- **Default region**: IARU_R1 is the safe default (maintainer's region). Should the
+  installer prompt for region on first run? Default: no — operator sets it in Settings.
+  Lightweight enough that the prompt would add friction.
+- **Ireland vs. UK vs. generic R1**: both EI and G are R1 countries. Do operators who
+  don't set their country explicitly get shown "IARU_R1" generic labels? Default: yes.
+  Upgrade path: operator picks their country from the region dropdown.
+- **Where does the shipped JSON live for testing?** Default: copy-on-publish from the
+  source tree into `bin/Debug/net8.0/BandPlans/` via `<Content CopyToOutputDirectory>`.
+- **Schema versioning**: if a future PRD needs `CustomMask`, do we bump the JSON schema?
+  Default: add `$schema` at the top of each file; migration tooling deferred until we
+  actually need it.
+- **Multiple RX**: if RX2 is tuned outside the band, do we light it red too? Defer — when
+  RX2 lands, the band-plan context is already per-frequency, so the overlay naturally picks
+  up both.
+- **Beacon sub-bands, calling frequencies**: Thetis's `BandText` has several one-Hz-wide
+  "AM Calling Frequency" entries. We skip those in v1 (visual clutter). Label-only entries
+  with no mode restriction can be added later under `Allocation = Amateur` +
+  `ModeRestriction = Any` + a descriptive `Label`.
+
+## 12. Risks
+
+- **Regulatory accuracy**: shipping wrong default segments is worse than shipping none at
+  all from a liability standpoint. Every shipped JSON file names the source regulator + the
+  last-verified date in a top-of-file comment. Operators are reminded in the editor UI that
+  "defaults are best-effort; you are responsible for operating within your license".
+- **Schema churn**: the `BandSegment` shape is load-bearing for the filter PRD's `BandPlan`
+  context. Any future additions should be backwards-compatible (new nullable fields), not
+  renames/removals.
+- **Plan resolution cost**: for a 50-row plan the resolver runs once per region change (not
+  per-query). `getSegment` uses a pre-sorted binary search on the resolved array. No hot
+  path concern.

--- a/docs/proposals/research/thetis-bandplan.md
+++ b/docs/proposals/research/thetis-bandplan.md
@@ -1,0 +1,200 @@
+# Thetis band plan & region model
+
+Research reference for the Zeus "Regional band planning" PRD. Source: `ramdor/Thetis` @ `master`
+(public mirror of the main Apache Labs working fork). Paths below are relative to
+`Project Files/Source/Console/` in that repo.
+
+---
+
+## 1. Region model
+
+Thetis has **one region enum** (`FRSRegion`) and a global, singleton selection. All band-plan
+behavior is derived from that single value — there is no country-of-operator override that layers
+on top of a "base" IARU region.
+
+**`FRSRegion`** — `enums.cs:205`
+
+```csharp
+public enum FRSRegion {
+    FIRST = -1,
+    US = 0, Spain = 1, Europe = 2, UK = 3, Italy_Plus = 4, Japan = 5, Australia = 6,
+    Norway = 7, Denmark = 8, Latvia = 9, Slovakia = 10, Bulgaria = 11, Greece = 12,
+    Hungary = 13, Netherlands = 14, France = 15, Russia = 16, Israel = 17,
+    Extended = 18, India = 19, Sweden = 20,
+    Region1 = 21, Region2 = 22, Region3 = 23, Germany = 24,
+    LAST,
+}
+```
+
+Notes:
+- `Extended` is a **pseudo-region** that unlocks TX across the full tunable range (SWL + out-of-band).
+  When `Extended` is set, `BandStackManager.Extended = true` is also passed in to every lookup and
+  overrides the user's regional selection (`clsBandStackManager.cs:1276`).
+- `Region1` / `Region2` / `Region3` are "pure IARU" fallbacks. Most European countries (Denmark,
+  France, Netherlands, …) resolve to `Region1` for their default band stack but get slightly
+  different `BandFrequencyData` edges (e.g. Italy's 160M is 1.83–1.85 vs Europe's 1.81–2.0) —
+  see `clsBandStackManager.cs:1274` switch.
+- Holder: `console.cs:15369` `private FRSRegion current_region`. Set via the `CurrentRegion`
+  property (`console.cs:15370`) which forwards to `BandStackManager.Region`.
+
+---
+
+## 2. BandSegment model
+
+Thetis splits "band plan data" across **two independent tables** — a distinction the Zeus
+contract needs to preserve.
+
+### 2a. `BandFrequencyData` — coarse band range (TX-guard + band-button routing)
+
+`clsBandStackManager.cs:80`
+
+```csharp
+public struct BandFrequencyData {
+    public double   low;       // MHz
+    public double   high;      // MHz (0 when lowOnly=true, i.e. point-frequency entry like WWV)
+    public Band     band;      // enum Band: B160M, B80M, …, B2M, WWV, BLMF, GEN, VHF0..13
+    public bool     lowOnly;
+    public FRSRegion region;
+    public BandType bandType;  // GEN, HF, VHF, UHF, SHF — drives IsOKToTX()
+}
+```
+
+No power cap, no mode/submode restriction, no explicit TX-allowed flag. TX permission is
+implicit: `bandType == HF` AND `band not in {WWV, BLMF}` ⇒ TX allowed
+(`clsBandStackManager.cs:1063 IsOKToTX`). SWL entries are `BandType.GEN` so they read-only by
+construction.
+
+### 2b. `BandText` — fine-grained sub-band label + TX flag (display + regulatory carve-outs)
+
+`database.cs:747` (DataSet table "BandText")
+
+| Column | Type   | Purpose |
+|--------|--------|---------|
+| Low    | double | MHz, inclusive |
+| High   | double | MHz, inclusive |
+| Name   | string | Human label shown on panadapter / VFO (e.g. `"20M Extra CW"`, `"60M Channel 1"`) |
+| TX     | bool   | Sub-band TX-allowed flag — **this** is where CW-vs-phone, 60m channelization, "Out of Band" carve-outs live |
+
+`DB.BandText(freq, out name)` (`database.cs:9566`) returns `(Name, TX)` for the sub-segment
+containing `freq`; if nothing matches, returns `"Out of Band"` with TX=false.
+
+So: **TX-inhibit actually blends both tables.** `BandStackManager.IsOKToTX` does the
+coarse "is this in an HF ham band for the current region" check; `DB.BandText(...).TX` does the
+sub-band "is this the 60m general segment vs a 60m channel" check.
+
+---
+
+## 3. Default data shape — sample rows
+
+### `BandFrequencyData` defaults for Region 1 (Europe-style) — `clsBandStackManager.cs:1405`
+
+```csharp
+new BandFrequencyData(1.81,   2.0,    Band.B160M, BandType.HF, false, region);
+new BandFrequencyData(3.5,    3.8,    Band.B80M,  BandType.HF, false, region);
+new BandFrequencyData(5.1,    5.5,    Band.B60M,  BandType.HF, false, region);  // covers UK 5MHz spread
+new BandFrequencyData(7.0,    7.2,    Band.B40M,  BandType.HF, false, region);
+new BandFrequencyData(14.0,  14.35,   Band.B20M,  BandType.HF, false, region);
+new BandFrequencyData(50.0,  52.0,    Band.B6M,   BandType.HF, false, region);  // note: bandType HF even on 6m
+new BandFrequencyData(144.0, 148.0,   Band.B2M,   BandType.VHF, false, region);
+```
+
+### `BandFrequencyData` defaults for US — `clsBandStackManager.cs:1334`
+
+```csharp
+new BandFrequencyData(7.0,  7.3,  Band.B40M, BandType.HF, false, region);  // wider vs EU 7.0-7.2
+new BandFrequencyData(3.5,  4.0,  Band.B80M, BandType.HF, false, region);  // wider
+new BandFrequencyData(5.1,  5.5,  Band.B60M, BandType.HF, false, region);  // 60m actual allowed subset is in BandText
+```
+
+### `BandText` US sample — `database.cs:792` (40m block)
+
+```
+7.000000, 7.024999, "40M Extra CW",          TX=true
+7.025000, 7.039999, "40M CW",                TX=true
+7.040000, 7.040000, "40M RTTY DX",           TX=true
+7.100000, 7.124999, "40M CW",                TX=true
+7.125000, 7.170999, "40M Ext/Adv SSB",       TX=true
+7.290000, 7.290000, "40M AM Calling Frequency", TX=true
+```
+
+### `BandText` US 60m — channelized, only 5 narrow TX-allowed spots:
+
+```
+5.100000, 5.331999, "60M General",  TX=false
+5.332000, 5.332000, "60M Channel 1", TX=true   // single-Hz-wide TX window
+5.332001, 5.347999, "60M General",  TX=false
+5.348000, 5.348000, "60M Channel 2", TX=true
+…
+```
+
+---
+
+## 4. User edit surface
+
+- **Region selection**: Setup form → "General" page → "Region" group box (`grpFRSRegion`,
+  combo `comboFRSRegion`). `setup.cs:14193` handles the selected-index-changed event, maps the
+  display string to an `FRSRegion` value, sets `console.CurrentRegion`, then calls
+  `BandStackManager.RegionReset()` which wipes + reseeds the default band-stack entries.
+- **Band-stack entries** (frequency/mode/filter memory per band): editable via the
+  `frmBandStack2` dialog. Users can add/delete/rename entries. These are stored in the
+  `BandStack2Entries` table.
+- **`BandFrequencyData` ranges (the actual per-region band edges)**: **not user-editable in the
+  GUI** — they are hard-coded in the `frequencyData()` switch. Changing an operator's local edges
+  requires a code change + rebuild.
+- **`BandText` sub-band labels + TX flag**: **not user-editable in the GUI** — also hard-coded,
+  seeded by `DB.AddRegion2BandText()` etc. (`database.cs:1070`).
+- Region change fires `DB.UpdateRegion(...)` (`database.cs:11327`), which calls
+  `ClearBandText()` then re-seeds the BandText for the selected region family. Note: only
+  `US/Australia` and `Japan` have distinct BandText seeders; all other regions (UK, EU, …) inherit
+  whatever BandText was last loaded — **known Thetis gotcha**, worth flagging in the Zeus PRD.
+
+Persistence: all of the above lives in a single `DataSet` serialized to XML via
+`DB.WriteDB()` → `ds.WriteXml(_file_name, WriteSchema)` (`database.cs:9530`, `9546`). The file
+lives under `%AppData%\OpenHPSDR\Thetis\database.xml` (path built by caller).
+The region choice itself is persisted as an option row via
+`DB.SaveVarsDictionary("Options", …)` (`setup.cs:1627`).
+
+---
+
+## 5. Downstream consumers
+
+1. **TX inhibit** (`console.cs:6778 CheckValidTXFreq`): called from MOX engage, tune, CAT-set-freq,
+   and TX mode changes. For SSB/AM/FM/DIGU/DIGL/SPEC it re-checks with the *filter edges* added
+   (`f + filterLow`, `f + filterHigh`) — so a wide filter hanging over a band edge inhibits TX
+   even if the carrier frequency is in-band. For CW it checks the carrier only. For DRM it offsets
+   by −12 kHz. `extended` mode short-circuits to `true`.
+2. **`BandByFreq`** (`console.cs:6451`): frequency → `Band` enum, used for band-button highlight
+   and BandStack filter selection.
+3. **BandStack memory**: each `Band` has its own filtered list of `BandStackEntry` (freq + mode
+   + filter + zoom + CTUN state + description + GUID), navigated via `GetFilter(Band)`.
+4. **Display label**: `DB.BandText(freq, ...)` → shown in `txtVFOABand` / `txtVFOBBand`. Returns
+   `"Out of Band"` string for unmatched frequencies and drives the amber/green
+   `band_text_light_color` / `band_text_dark_color` indicator.
+5. **Mode coercion**: no automatic mode flip on band change — mode is recalled per
+   `BandStackEntry`. Region change does NOT rewrite existing BandStack entries, so an EU operator
+   loading a US-seeded DB can have CWL memories in a region where only CWU is conventional.
+
+---
+
+## 6. Gotchas / edge cases
+
+- **Boundary inclusivity**: `BandText` lookup uses SQL-style `freq >= Low AND freq <= High`
+  (`database.cs:9575`). Seed rows are authored as `x.xxx000 … x.xxx999` deliberately to avoid
+  double-matches at adjacent-row boundaries, but a frequency sitting on an exact row edge
+  (e.g. 7.025000) matches only the row that claims it as `Low` — author-dependent, easy to get
+  wrong when adding a new segment.
+- **Filter-aware TX check can deny TX at an otherwise in-band carrier** (see §5.1). Thetis exposes
+  a "tune" bypass (`chkTUN.Checked` passed in as `bIgnoreFilter`).
+- **`Extended` region is sticky**: setting `Extended = true` rewrites `m_oldRegion` and
+  subsequent reads short-circuit; must also reset Extended when switching away.
+- **`FRSRegion.FIRST = -1` is used as "uninitialized"** — don't treat it as a valid selection.
+- **Region switch rebuilds BandStack defaults** only when the entries list is empty. If the user
+  has any entries at all (from previous session), `addStandardFrequencies()` is skipped
+  (`clsBandStackManager.cs:805`) — so changing region mid-session does NOT replace band-stack
+  memories; only `RegionReset()` (triggered explicitly by the region combo) wipes and reseeds.
+- **BandText is not fully region-partitioned** — UK/EU default to US-seeded sub-band labels
+  unless the user has manually set region=Japan. Likely-wrong labels on panadapter for EU
+  operators is a long-standing Thetis issue; Zeus should fix this in the contract.
+- **No power cap field anywhere**. TX power is a separate per-mode / per-TXProfile setting and is
+  NOT coupled to the region or the band segment. If Zeus wants region-aware TX power caps (e.g.
+  UK 60m 15 W), that is a **new** concept not in Thetis.


### PR DESCRIPTION
## Summary

Adds the PRD for a region-catalog + BandSegment model with editable regional defaults, plus Thetis research that motivates the parent/override design.

- `docs/proposals/band-planning-prd.md` — full PRD (data model, default regions, editor surface, API, phasing)
- `docs/proposals/research/thetis-bandplan.md` — Thetis's `BandFrequencyData` + `BandText` duality, `FRSRegion` flat enum, known UK/EU labelling gap

## Linked

Tracking issue: #59
Co-designed PRD: `feature/filter-visualization-prd` (consumes `IBandPlanService.InBand` for out-of-band filter-edge colouring)

## Test plan

- [ ] Docs-only change, nothing to run.
- [ ] Maintainer review of red-light items listed in issue #59 (default region, shipped-region set, installer prompt).