### PR TITLE
feat(pa): Phase 1-2 PA Settings — per-band gain, OC pins, PA enable

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -158,3 +158,34 @@ public sealed record BandMemorySetRequest(long Hz, RxMode Mode);
 public sealed record UiLayoutDto(string LayoutJson, long UpdatedUtc);
 
 public sealed record UiLayoutSetRequest(string LayoutJson);
+
+// Per-band PA settings. Mirrors Thetis `PAProfile._gainValues[]` / piHPSDR
+// `band->pa_calibration` (single scalar dB per band — 9-point curve is a
+// Phase-4 follow-up). OcTx / OcRx are 7-bit Open-Collector masks driving the
+// N2ADR filter board on HL2 and ALEX/OC outputs on Orion-class radios; they
+// are OR'd with the board's auto-filter logic so stock HL2 filter switching
+// keeps working when the user hasn't set anything.
+public sealed record PaBandSettingsDto(
+    string Band,
+    double PaGainDb = 0.0,
+    bool DisablePa = false,
+    byte OcTx = 0,
+    byte OcRx = 0);
+
+// Globals shared across bands. PaMaxPowerWatts=0 disables the watts
+// conversion path and falls back to the legacy "drive% = raw 0-255 byte"
+// behavior so existing installs behave identically until the user runs
+// a calibration. OcTune is OR'd into the OC byte while TUN is engaged
+// (Thetis: OCtune in `Penny.cs`; piHPSDR: `OCtune<<1` in `old_protocol.c`).
+public sealed record PaGlobalSettingsDto(
+    bool PaEnabled = true,
+    int PaMaxPowerWatts = 0,
+    byte OcTune = 0);
+
+public sealed record PaSettingsDto(
+    PaGlobalSettingsDto Global,
+    IReadOnlyList<PaBandSettingsDto> Bands);
+
+public sealed record PaSettingsSetRequest(
+    PaGlobalSettingsDto Global,
+    IReadOnlyList<PaBandSettingsDto> Bands);

--- a/Zeus.Protocol1/ControlFrame.cs
+++ b/Zeus.Protocol1/ControlFrame.cs
@@ -82,7 +82,14 @@ internal static class ControlFrame
         // drive_level written directly to output_buffer[C1]. Units are
         // "hardware drive level 0..255"; UI-side percent is mapped in
         // Protocol1Client.SnapshotState.
-        byte DriveLevel = 0);
+        byte DriveLevel = 0,
+        // User-configured OC pin masks (7-bit) from PaSettingsStore. OR'd with
+        // the board's auto-filter output in WriteConfigPayload so the stock HL2
+        // + N2ADR behavior keeps working when the user hasn't configured
+        // anything. Selected by MOX: TX mask during transmit, RX mask otherwise
+        // (piHPSDR `old_protocol.c:1884-1904`).
+        byte UserOcTxMask = 0,
+        byte UserOcRxMask = 0);
 
     /// <summary>
     /// Write the 5 C&amp;C bytes for <paramref name="register"/> given the current
@@ -160,14 +167,19 @@ internal static class ControlFrame
         byte c1 = (byte)((byte)s.Rate & 0x03);
         c14[0] = c1;
 
-        // C2: class-E PA at bit 0; OC pins (N2ADR filter board on HL2) at
-        // bits 1..7. The 7-bit pin mask is shifted left by 1 into the output
-        // buffer. Class-E stays 0 for RX-only MVP.
-        byte c2 = 0;
+        // C2: class-E PA at bit 0; OC pins (N2ADR filter board on HL2, user-
+        // configured OC outputs on Orion-class) at bits 1..7. Class-E stays 0
+        // for RX-only MVP. We OR three sources so stock behavior holds when
+        // the user hasn't touched PA Settings:
+        //   1. Board auto-filter mask (N2ADR on HL2) — legacy path
+        //   2. User's per-band OC-TX mask when MOX, else OC-RX mask
+        byte ocPins = 0;
         if (s.Board == HpsdrBoardKind.HermesLite2 && s.HasN2adr)
         {
-            c2 |= (byte)(N2adrBands.RxOcMask(s.VfoAHz) << 1);
+            ocPins |= N2adrBands.RxOcMask(s.VfoAHz);
         }
+        ocPins |= (byte)((s.Mox ? s.UserOcTxMask : s.UserOcRxMask) & 0x7F);
+        byte c2 = (byte)(ocPins << 1);
         c14[1] = c2;
 
         // C3: Atlas step attenuator [1:0], RAND [2], DITHER [3], preamp [4],

--- a/Zeus.Protocol1/IProtocol1Client.cs
+++ b/Zeus.Protocol1/IProtocol1Client.cs
@@ -90,6 +90,20 @@ public interface IProtocol1Client : IDisposable
     void SetDrive(int percent);
 
     /// <summary>
+    /// Push a fully-computed raw drive byte (0..255), overriding the percent
+    /// path. RadioService uses this when PA calibration converts target watts
+    /// → drive byte via the per-band gain lookup.
+    /// </summary>
+    void SetDriveByte(byte value);
+
+    /// <summary>
+    /// User-configured Open-Collector pin masks (7 bits each). OR'd with the
+    /// board's auto-filter output. <paramref name="txMask"/> is asserted when
+    /// MOX is on; <paramref name="rxMask"/> otherwise.
+    /// </summary>
+    void SetOcMasks(byte txMask, byte rxMask);
+
+    /// <summary>
     /// Raised from the RX loop whenever a successfully parsed EP6 packet carried
     /// a C&amp;C echo on an AIN-bearing address (addresses 1/2/3 → C0 bytes
     /// 0x08/0x10/0x18). Fire-and-forget — handlers run synchronously on the RX
@@ -111,6 +125,13 @@ public interface IProtocol1Client : IDisposable
     /// OC pin encoding. Defaults to <see cref="HpsdrBoardKind.HermesLite2"/>.
     /// </summary>
     void SetBoardKind(HpsdrBoardKind board);
+
+    /// <summary>
+    /// Current board kind as latched via <see cref="SetBoardKind"/>. Defaults
+    /// to <see cref="HpsdrBoardKind.HermesLite2"/> when discovery did not
+    /// supply one.
+    /// </summary>
+    HpsdrBoardKind BoardKind { get; }
 
     /// <summary>
     /// Toggle the HL2 + N2ADR 7-relay filter board. When on, C2 bits [7:1]

--- a/Zeus.Protocol1/Protocol1Client.cs
+++ b/Zeus.Protocol1/Protocol1Client.cs
@@ -68,6 +68,12 @@ public sealed class Protocol1Client : IProtocol1Client
     private int _hasN2adr;      // 0 / 1
     private int _mox;           // 0 / 1
     private int _drivePct;      // 0..100 UI percent; mapped to 0..255 on snapshot
+    // When >= 0, RadioService has pushed a fully-computed drive byte (post PA
+    // calibration) and we send that instead of the percent mapping. Legacy
+    // callers that only call SetDrive(percent) keep working untouched.
+    private int _driveByteOverride = -1;
+    private int _ocTxMask;      // user OC pin mask for TX (low 7 bits)
+    private int _ocRxMask;      // user OC pin mask for RX (low 7 bits)
     private long _droppedFrames;
     private long _totalFrames;
 
@@ -204,10 +210,21 @@ public sealed class Protocol1Client : IProtocol1Client
     public void SetAttenuator(HpsdrAtten atten) => Interlocked.Exchange(ref _attenDb, atten.ClampedDb);
     public void SetAntennaRx(HpsdrAntenna ant) => Interlocked.Exchange(ref _antenna, (int)ant);
     public void SetBoardKind(HpsdrBoardKind board) => Interlocked.Exchange(ref _boardKind, (int)board);
+
+    public HpsdrBoardKind BoardKind => (HpsdrBoardKind)Volatile.Read(ref _boardKind);
     public void SetHasN2adr(bool hasN2adr) => Interlocked.Exchange(ref _hasN2adr, hasN2adr ? 1 : 0);
     public void SetMox(bool on) => Interlocked.Exchange(ref _mox, on ? 1 : 0);
     public void SetDrive(int percent) =>
         Interlocked.Exchange(ref _drivePct, Math.Clamp(percent, 0, 100));
+
+    public void SetDriveByte(byte value) =>
+        Interlocked.Exchange(ref _driveByteOverride, value);
+
+    public void SetOcMasks(byte txMask, byte rxMask)
+    {
+        Interlocked.Exchange(ref _ocTxMask, txMask & 0x7F);
+        Interlocked.Exchange(ref _ocRxMask, rxMask & 0x7F);
+    }
 
     public void Dispose()
     {
@@ -217,19 +234,29 @@ public sealed class Protocol1Client : IProtocol1Client
         try { DisconnectAsync(CancellationToken.None).GetAwaiter().GetResult(); } catch { }
     }
 
-    internal ControlFrame.CcState SnapshotState() => new(
-        VfoAHz: Interlocked.Read(ref _vfoAHz),
-        Rate: (HpsdrSampleRate)Volatile.Read(ref _rate),
-        PreampOn: Volatile.Read(ref _preamp) != 0,
-        Atten: new HpsdrAtten(Volatile.Read(ref _attenDb)),
-        RxAntenna: (HpsdrAntenna)Volatile.Read(ref _antenna),
-        Mox: Volatile.Read(ref _mox) != 0,
-        EnableHl2Dither: Volatile.Read(ref _enableHl2Dither) != 0,
-        Board: (HpsdrBoardKind)Volatile.Read(ref _boardKind),
-        HasN2adr: Volatile.Read(ref _hasN2adr) != 0,
-        // UI percent → raw 0..255 HPSDR drive byte. For MVP we use the 0..255
-        // range directly (no calcLevel linearization step).
-        DriveLevel: (byte)(Volatile.Read(ref _drivePct) * 255 / 100));
+    internal ControlFrame.CcState SnapshotState()
+    {
+        int over = Volatile.Read(ref _driveByteOverride);
+        byte drive = over >= 0
+            ? (byte)over
+            // UI percent → raw 0..255 HPSDR drive byte. Used only when
+            // RadioService hasn't pushed a calibrated byte (tests / legacy).
+            : (byte)(Volatile.Read(ref _drivePct) * 255 / 100);
+
+        return new(
+            VfoAHz: Interlocked.Read(ref _vfoAHz),
+            Rate: (HpsdrSampleRate)Volatile.Read(ref _rate),
+            PreampOn: Volatile.Read(ref _preamp) != 0,
+            Atten: new HpsdrAtten(Volatile.Read(ref _attenDb)),
+            RxAntenna: (HpsdrAntenna)Volatile.Read(ref _antenna),
+            Mox: Volatile.Read(ref _mox) != 0,
+            EnableHl2Dither: Volatile.Read(ref _enableHl2Dither) != 0,
+            Board: (HpsdrBoardKind)Volatile.Read(ref _boardKind),
+            HasN2adr: Volatile.Read(ref _hasN2adr) != 0,
+            DriveLevel: drive,
+            UserOcTxMask: (byte)Volatile.Read(ref _ocTxMask),
+            UserOcRxMask: (byte)Volatile.Read(ref _ocRxMask));
+    }
 
     private void RxLoop()
     {

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -85,6 +85,16 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // needed via the UI. Attenuator 0 dB so the front-end isn't knocked down.
     private bool _preampOn;
     private byte _rxStepAttnDb;
+    // PA settings — pushed from RadioService when PaSettingsStore changes or
+    // the VFO crosses a band edge. _paEnabled is the global toggle that lands
+    // in CmdGeneral[58]; _driveByte is the pre-calibrated drive level for
+    // CmdHighPriority[345]; _ocTxMask/_ocRxMask drive CmdHighPriority[1401]
+    // (OR'd with OCtune once that's plumbed).
+    private bool _paEnabled = true;
+    private byte _driveByte;
+    private byte _ocTxMask;
+    private byte _ocRxMask;
+    private bool _moxOn;
     private long _totalFrames;
     private long _droppedFrames;
     private uint _lastDdc0Seq;
@@ -210,6 +220,31 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         if (_rxTask is not null) SendCmdHighPriority(run: true);
     }
 
+    public void SetDriveByte(byte value)
+    {
+        _driveByte = value;
+        if (_rxTask is not null) SendCmdHighPriority(run: true);
+    }
+
+    public void SetOcMasks(byte txMask, byte rxMask)
+    {
+        _ocTxMask = (byte)(txMask & 0x7F);
+        _ocRxMask = (byte)(rxMask & 0x7F);
+        if (_rxTask is not null) SendCmdHighPriority(run: true);
+    }
+
+    public void SetPaEnabled(bool enabled)
+    {
+        _paEnabled = enabled;
+        if (_rxTask is not null) SendCmdGeneral();
+    }
+
+    public void SetMox(bool on)
+    {
+        _moxOn = on;
+        if (_rxTask is not null) SendCmdHighPriority(run: true);
+    }
+
     private void SendCmdGeneral()
     {
         var p = new byte[60];
@@ -236,7 +271,10 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         // MkII for the BPF board to honour the alex bits further down).
         p[37] = 0x08;
         p[38] = 0x01;
-        p[58] = 0x01;
+        // [58] bit 0 = PA enable (piHPSDR `new_protocol.c:658-677`; Thetis
+        // `network.c` SendGeneral). The old hard-coded 0x01 became the
+        // default; PaSettingsStore now owns the bit.
+        p[58] = (byte)(_paEnabled ? 0x01 : 0x00);
         p[59] = 0x03;
         _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1024));
     }
@@ -286,6 +324,16 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         uint rxPhase = (uint)(_rxFreqHz * HzToPhase);
         WriteBeU32(p, 9 + G2RxDdc * 4, rxPhase);
         WriteBeU32(p, 329, rxPhase);
+
+        // Drive level (0..255) at byte 345. Set by RadioService after applying
+        // per-band PA gain calibration. Honored by the radio only while run=1
+        // and TX is keyed elsewhere (byte 4 bit 1). piHPSDR `new_protocol.c:860`.
+        p[345] = _driveByte;
+
+        // OC outputs (7-bit mask) shifted left by 1 into byte 1401. TX mask
+        // when MOX is on, RX mask otherwise. piHPSDR `new_protocol.c:877-894`
+        // (OCtune handling deferred until Tune integrates with PA settings).
+        p[1401] = (byte)(((_moxOn ? _ocTxMask : _ocRxMask) & 0x7F) << 1);
 
         // Mercury attenuator byte: bit 0 = RX0 preamp, bit 1 = RX1 preamp
         // (Thetis network.c:1037).

--- a/Zeus.Server/BandUtils.cs
+++ b/Zeus.Server/BandUtils.cs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.Server;
+
+public static class BandUtils
+{
+    /// <summary>
+    /// Canonical HF band names used by per-band settings stores (PA gain,
+    /// band memory, etc.). Case-sensitive — keep them identical everywhere.
+    /// </summary>
+    public static readonly IReadOnlyList<string> HfBands = new[]
+    {
+        "160m", "80m", "60m", "40m", "30m", "20m", "17m", "15m", "12m", "10m", "6m",
+    };
+
+    /// <summary>
+    /// Resolve a VFO frequency (Hz) to the enclosing ham band name. Uses
+    /// lowest-frequency-above-edge ranges so a VFO parked between bands
+    /// (e.g. 4.0 MHz) still resolves to the nearest-lower band — matches
+    /// how N2adrBands.RxOcMask() keeps filters engaged off-band.
+    /// Returns null below 160m or above 6m.
+    /// </summary>
+    public static string? FreqToBand(long vfoHz) => vfoHz switch
+    {
+        <   1_800_000 => null,
+        <   3_500_000 => "160m",
+        <   5_300_000 => "80m",
+        <   7_000_000 => "60m",
+        <  10_100_000 => "40m",
+        <  14_000_000 => "30m",
+        <  18_068_000 => "20m",
+        <  21_000_000 => "17m",
+        <  24_890_000 => "15m",
+        <  28_000_000 => "12m",
+        <  50_000_000 => "10m",
+        <  54_000_000 => "6m",
+        _             => null,
+    };
+}

--- a/Zeus.Server/DspPipelineService.cs
+++ b/Zeus.Server/DspPipelineService.cs
@@ -101,6 +101,7 @@ public class DspPipelineService : BackgroundService
         _radio.Connected += OnRadioConnected;
         _radio.Disconnected += OnRadioDisconnected;
         _radio.StateChanged += OnRadioStateChanged;
+        _radio.PaSnapshotChanged += OnPaSnapshotChanged;
 
         var panBuf = new float[Width];
         var wfBuf = new float[Width];
@@ -120,6 +121,7 @@ public class DspPipelineService : BackgroundService
             _radio.Connected -= OnRadioConnected;
             _radio.Disconnected -= OnRadioDisconnected;
             _radio.StateChanged -= OnRadioStateChanged;
+            _radio.PaSnapshotChanged -= OnPaSnapshotChanged;
             await StopIqPumpAsync().ConfigureAwait(false);
             CloseCurrentEngine();
         }
@@ -399,6 +401,18 @@ public class DspPipelineService : BackgroundService
         _p2Client = client;
         StartIqPumpP2(client);
         _radio.MarkProtocol2Connected(radioEndpoint.ToString(), rateHz);
+        // Push current PA snapshot into the brand-new client so byte 345 /
+        // byte 1401 / CmdGeneral[58] reflect PaSettingsStore from frame 1.
+        _radio.ReplayPaSnapshot();
+    }
+
+    private void OnPaSnapshotChanged(PaRuntimeSnapshot snap)
+    {
+        var p2 = _p2Client;
+        if (p2 is null) return;
+        p2.SetDriveByte(snap.DriveByte);
+        p2.SetOcMasks(snap.OcTxMask, snap.OcRxMask);
+        p2.SetPaEnabled(snap.PaEnabled);
     }
 
     public async Task DisconnectP2Async(CancellationToken ct)

--- a/Zeus.Server/PaDefaults.cs
+++ b/Zeus.Server/PaDefaults.cs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Protocol1.Discovery;
+
+namespace Zeus.Server;
+
+// Per-board PA gain defaults (dB), lifted from Thetis
+// `clsHardwareSpecific.cs:470-767` and piHPSDR `band.c:498-500`. These are
+// seeds — the operator calibrates the real numbers via an external watt-meter
+// or the future in-app wizard; these just keep the drive math sane on first
+// connect so "5 W target" doesn't emit µW (too much default gain) or blow the
+// PA (too little).
+//
+// Band names must match BandUtils.HfBands. Any band not listed falls back to
+// 0.0 dB, which short-circuits PaSettingsStore to the legacy percent→byte
+// path and preserves pre-calibration behavior.
+internal static class PaDefaults
+{
+    // Thetis HERMES / HPSDR / ORIONMKII / ANAN10 / ANAN10E bracket
+    // (setup.cs:482-544). 100 W class-A builds; lowest gain at 6m.
+    private static readonly IReadOnlyDictionary<string, double> HermesGains = new Dictionary<string, double>
+    {
+        ["160m"] = 41.0, ["80m"] = 41.2, ["60m"] = 41.3, ["40m"] = 41.3,
+        ["30m"] = 41.0, ["20m"] = 40.5, ["17m"] = 39.9, ["15m"] = 38.8,
+        ["12m"] = 38.8, ["10m"] = 38.8, ["6m"] = 38.8,
+    };
+
+    // Thetis ANAN100 / ANAN100B / ANAN8000D bracket (setup.cs:546-694).
+    // 100 W ANAN production radios.
+    private static readonly IReadOnlyDictionary<string, double> Anan100Gains = new Dictionary<string, double>
+    {
+        ["160m"] = 50.0, ["80m"] = 50.5, ["60m"] = 50.5, ["40m"] = 50.0,
+        ["30m"] = 49.5, ["20m"] = 48.5, ["17m"] = 48.0, ["15m"] = 47.5,
+        ["12m"] = 46.5, ["10m"] = 42.0, ["6m"] = 43.0,
+    };
+
+    // Thetis ANAN100D / ANAN200D bracket (setup.cs:606-664). Dual-ADC
+    // builds — slightly lower per-band gain than the ANAN100 bracket.
+    private static readonly IReadOnlyDictionary<string, double> Anan200Gains = new Dictionary<string, double>
+    {
+        ["160m"] = 49.5, ["80m"] = 50.5, ["60m"] = 50.5, ["40m"] = 50.0,
+        ["30m"] = 49.0, ["20m"] = 48.0, ["17m"] = 47.0, ["15m"] = 46.5,
+        ["12m"] = 46.0, ["10m"] = 43.5, ["6m"] = 43.0,
+    };
+
+    // Thetis ANAN7000D / ANAN_G1 / ANAN_G2 / ANVELINAPRO3 bracket
+    // (setup.cs:696-728). Saturn / G2 class; highest HF gain per band.
+    private static readonly IReadOnlyDictionary<string, double> OrionG2Gains = new Dictionary<string, double>
+    {
+        ["160m"] = 47.9, ["80m"] = 50.5, ["60m"] = 50.8, ["40m"] = 50.8,
+        ["30m"] = 50.9, ["20m"] = 50.9, ["17m"] = 50.5, ["15m"] = 47.0,
+        ["12m"] = 47.9, ["10m"] = 46.5, ["6m"] = 44.6,
+    };
+
+    // piHPSDR `band.c:498-500` — Hermes Lite 2's 5 W PA sits far below any
+    // ANAN, so piHPSDR overrides the generic 53 dB default to 40.5 dB flat
+    // across every band. Thetis has no HL2-specific default; the lazy 100 f
+    // "no output" seed made operators think the radio was dead.
+    private const double Hl2FlatGainDb = 40.5;
+
+    private static IReadOnlyDictionary<string, double> TableFor(HpsdrBoardKind board) => board switch
+    {
+        HpsdrBoardKind.Hermes      => HermesGains,
+        HpsdrBoardKind.Metis       => HermesGains,
+        HpsdrBoardKind.Griffin     => HermesGains,
+        HpsdrBoardKind.Angelia     => Anan100Gains,
+        HpsdrBoardKind.Orion       => Anan200Gains,
+        HpsdrBoardKind.OrionMkII   => OrionG2Gains,
+        _                          => new Dictionary<string, double>(),
+    };
+
+    public static double GetPaGainDb(HpsdrBoardKind board, string band)
+    {
+        if (board == HpsdrBoardKind.HermesLite2) return Hl2FlatGainDb;
+        return TableFor(board).TryGetValue(band, out var v) ? v : 0.0;
+    }
+}

--- a/Zeus.Server/PaSettingsStore.cs
+++ b/Zeus.Server/PaSettingsStore.cs
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using LiteDB;
+using Zeus.Contracts;
+using Zeus.Protocol1.Discovery;
+
+namespace Zeus.Server;
+
+// PA settings (per-band gain, OC pin masks, globals). Shares the unencrypted
+// zeus-prefs.db with BandMemoryStore — neither PA gain values nor OC pin
+// assignments are sensitive. Fires Changed on any write so RadioService can
+// recompute the drive byte and protocol clients can pick up new OC masks on
+// the next C&C/HPC tick.
+public sealed class PaSettingsStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<PaBandEntry> _bands;
+    private readonly ILiteCollection<PaGlobalEntry> _globals;
+    private readonly ILogger<PaSettingsStore> _log;
+    private readonly object _sync = new();
+
+    public event Action? Changed;
+
+    public PaSettingsStore(ILogger<PaSettingsStore> log)
+    {
+        _log = log;
+        var dbPath = GetDatabasePath();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _bands = _db.GetCollection<PaBandEntry>("pa_bands");
+        _bands.EnsureIndex(x => x.Band, unique: true);
+        _globals = _db.GetCollection<PaGlobalEntry>("pa_globals");
+
+        _log.LogInformation("PaSettingsStore initialized at {Path}", dbPath);
+    }
+
+    // Fills missing bands with per-board defaults from PaDefaults. When board
+    // is Unknown (no radio connected yet) the fallback is 0 dB, which keeps the
+    // drive math pinned to legacy behavior until connect resolves the board.
+    public PaSettingsDto GetAll(HpsdrBoardKind board = HpsdrBoardKind.Unknown)
+    {
+        lock (_sync)
+        {
+            var g = _globals.FindAll().FirstOrDefault();
+            var global = g is null
+                ? new PaGlobalSettingsDto()
+                : new PaGlobalSettingsDto(g.PaEnabled, g.PaMaxPowerWatts, g.OcTune);
+
+            var existing = _bands.FindAll().ToDictionary(e => e.Band, e => e);
+            var bands = BandUtils.HfBands
+                .Select(b =>
+                {
+                    if (existing.TryGetValue(b, out var e))
+                    {
+                        return new PaBandSettingsDto(e.Band, e.PaGainDb, e.DisablePa, e.OcTx, e.OcRx);
+                    }
+                    return new PaBandSettingsDto(b, PaGainDb: PaDefaults.GetPaGainDb(board, b));
+                })
+                .ToArray();
+
+            return new PaSettingsDto(global, bands);
+        }
+    }
+
+    public PaBandSettingsDto GetBand(string band, HpsdrBoardKind board = HpsdrBoardKind.Unknown)
+    {
+        lock (_sync)
+        {
+            var e = _bands.FindOne(x => x.Band == band);
+            return e is null
+                ? new PaBandSettingsDto(band, PaGainDb: PaDefaults.GetPaGainDb(board, band))
+                : new PaBandSettingsDto(e.Band, e.PaGainDb, e.DisablePa, e.OcTx, e.OcRx);
+        }
+    }
+
+    public PaGlobalSettingsDto GetGlobal()
+    {
+        lock (_sync)
+        {
+            var g = _globals.FindAll().FirstOrDefault();
+            return g is null
+                ? new PaGlobalSettingsDto()
+                : new PaGlobalSettingsDto(g.PaEnabled, g.PaMaxPowerWatts, g.OcTune);
+        }
+    }
+
+    public void Save(PaSettingsDto dto)
+    {
+        lock (_sync)
+        {
+            var existingGlobal = _globals.FindAll().FirstOrDefault();
+            var g = existingGlobal ?? new PaGlobalEntry();
+            g.PaEnabled = dto.Global.PaEnabled;
+            g.PaMaxPowerWatts = Math.Max(0, dto.Global.PaMaxPowerWatts);
+            g.OcTune = dto.Global.OcTune;
+            g.UpdatedUtc = DateTime.UtcNow;
+            if (existingGlobal is null) _globals.Insert(g);
+            else _globals.Update(g);
+
+            foreach (var band in dto.Bands)
+            {
+                if (!BandUtils.HfBands.Contains(band.Band)) continue;
+                var existing = _bands.FindOne(x => x.Band == band.Band);
+                if (existing is null)
+                {
+                    _bands.Insert(new PaBandEntry
+                    {
+                        Band = band.Band,
+                        PaGainDb = band.PaGainDb,
+                        DisablePa = band.DisablePa,
+                        OcTx = band.OcTx,
+                        OcRx = band.OcRx,
+                        UpdatedUtc = DateTime.UtcNow,
+                    });
+                }
+                else
+                {
+                    existing.PaGainDb = band.PaGainDb;
+                    existing.DisablePa = band.DisablePa;
+                    existing.OcTx = band.OcTx;
+                    existing.OcRx = band.OcRx;
+                    existing.UpdatedUtc = DateTime.UtcNow;
+                    _bands.Update(existing);
+                }
+            }
+        }
+        Changed?.Invoke();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private static string GetDatabasePath()
+    {
+        var appDataDir = Environment.GetFolderPath(
+            Environment.SpecialFolder.LocalApplicationData,
+            Environment.SpecialFolderOption.Create);
+        return Path.Combine(appDataDir, "Zeus", "zeus-prefs.db");
+    }
+}
+
+// Resolved snapshot that RadioService pushes to the P1 client directly and to
+// the P2 client via DspPipelineService. Keeps the protocol clients free of
+// any knowledge of per-band gain or Stores.
+public sealed record PaRuntimeSnapshot(
+    byte DriveByte,
+    byte OcTxMask,
+    byte OcRxMask,
+    byte OcTuneMask,
+    bool PaEnabled);
+
+public sealed class PaBandEntry
+{
+    public int Id { get; set; }
+    public string Band { get; set; } = string.Empty;
+    public double PaGainDb { get; set; }
+    public bool DisablePa { get; set; }
+    public byte OcTx { get; set; }
+    public byte OcRx { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}
+
+public sealed class PaGlobalEntry
+{
+    public int Id { get; set; }
+    public bool PaEnabled { get; set; } = true;
+    public int PaMaxPowerWatts { get; set; }
+    public byte OcTune { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server/Program.cs
+++ b/Zeus.Server/Program.cs
@@ -126,6 +126,7 @@ builder.Services.AddSingleton<CredentialStore>();
 builder.Services.AddSingleton<BandMemoryStore>();
 builder.Services.AddSingleton<LayoutStore>();
 builder.Services.AddSingleton<DspSettingsStore>();
+builder.Services.AddSingleton<PaSettingsStore>();
 builder.Services.AddSingleton<QrzService>();
 builder.Services.AddSingleton<LogService>();
 
@@ -495,6 +496,24 @@ app.MapPut("/api/bands/memory/{band}", (string band, BandMemorySetRequest req, B
         return Results.BadRequest(new { error = "hz must be positive" });
     store.Upsert(band, req.Hz, req.Mode);
     return Results.Ok(new BandMemoryDto(band, req.Hz, req.Mode));
+});
+
+// PA settings — per-band gain/OC masks + globals. Single PUT replaces the
+// whole snapshot because the UI edits rows as a table; incremental PATCHing
+// would deadlock with the RadioService recompute subscription fired on Save.
+// The GET uses the currently connected board's defaults to fill missing
+// rows so the panel opens with model-appropriate seeds on first load.
+app.MapGet("/api/pa-settings", (PaSettingsStore store, RadioService radio) =>
+    Results.Ok(store.GetAll(radio.ConnectedBoardKind)));
+
+app.MapPut("/api/pa-settings", (PaSettingsSetRequest req, PaSettingsStore store, RadioService radio) =>
+{
+    if (req.Global is null || req.Bands is null)
+        return Results.BadRequest(new { error = "global and bands required" });
+    if (req.Global.PaMaxPowerWatts < 0)
+        return Results.BadRequest(new { error = "paMaxPowerWatts must be >= 0" });
+    store.Save(new PaSettingsDto(req.Global, req.Bands));
+    return Results.Ok(store.GetAll(radio.ConnectedBoardKind));
 });
 
 // UI layout: flexlayout-react panel arrangement, persisted per operator profile.

--- a/Zeus.Server/RadioService.cs
+++ b/Zeus.Server/RadioService.cs
@@ -40,6 +40,7 @@ using Microsoft.Extensions.Logging;
 using Zeus.Contracts;
 using Zeus.Dsp;
 using Zeus.Protocol1;
+using Zeus.Protocol1.Discovery;
 
 namespace Zeus.Server;
 
@@ -51,6 +52,13 @@ public sealed class RadioService : IDisposable
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<RadioService> _log;
     private readonly DspSettingsStore _dspSettingsStore;
+    private readonly PaSettingsStore _paStore;
+    // Last-commanded slider value in UI percent (0..100). Needed here because
+    // the drive byte depends on three inputs — percent, per-band PA gain, and
+    // global max-watts — any of which can change independently. When a band
+    // edge is crossed or a PA setting is edited, we recompute without needing
+    // to wait for the next SetDrive call.
+    private int _drivePct;
 
     private StateDto _state;
 
@@ -59,6 +67,11 @@ public sealed class RadioService : IDisposable
     private bool _mox;
 
     private Protocol1Client? _activeClient;
+    // True while DspPipelineService has a live Protocol2 client and no P1 is
+    // active. Used to resolve the effective board kind for PA defaults when
+    // the user is on a G2 MkII / Saturn (P2 discovery flow skips
+    // Protocol1Client entirely).
+    private bool _p2Active;
     private bool _preampOn;
     // Auto-ATT defaults on; the user baseline starts at 0 dB and the control
     // loop ramps _attOffsetDb up to 31 dB on observed ADC overloads (Thetis
@@ -82,6 +95,12 @@ public sealed class RadioService : IDisposable
     public event Action<StateDto>? StateChanged;
     public event Action<IProtocol1Client>? Connected;
     public event Action? Disconnected;
+    // Fires whenever the effective PA snapshot changes (store edit, VFO band
+    // crossing, drive slider). DspPipelineService consumes this to forward the
+    // same snapshot into any live Protocol2Client (byte 345 / byte 1401 /
+    // CmdGeneral[58]). RadioService pushes to the P1 client directly because
+    // it owns _activeClient.
+    public event Action<PaRuntimeSnapshot>? PaSnapshotChanged;
 
     // Shared TX IQ source threaded through Protocol1Client. TxAudioIngest
     // writes into the same instance; this is the seam between "mic arrived
@@ -89,11 +108,13 @@ public sealed class RadioService : IDisposable
     // to its internal test-tone generator (dev / tests without a hub).
     private readonly Zeus.Protocol1.ITxIqSource? _txIqSource;
 
-    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, Zeus.Protocol1.ITxIqSource? txIqSource = null)
+    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, Zeus.Protocol1.ITxIqSource? txIqSource = null)
     {
         _loggerFactory = loggerFactory;
         _log = loggerFactory.CreateLogger<RadioService>();
         _dspSettingsStore = dspSettingsStore;
+        _paStore = paStore;
+        _paStore.Changed += RecomputePaAndPush;
         _txIqSource = txIqSource;
 
         // Load persisted DSP settings from the store, or use defaults if not found
@@ -166,6 +187,11 @@ public sealed class RadioService : IDisposable
             Mutate(s => s with { Status = ConnectionStatus.Connected });
             _log.LogInformation("radio.connected endpoint={Ep} rate={Rate}", ipEndpoint, hpsdrRate);
             Connected?.Invoke(client);
+            // Replay PA settings into the fresh client — drive byte, OC masks,
+            // and (for P2 downstream) PA-enable. Without this the client sits
+            // at the protocol defaults (drive=0, OC=0) until something else
+            // moves.
+            RecomputePaAndPush();
             return Snapshot();
         }
         catch
@@ -207,8 +233,17 @@ public sealed class RadioService : IDisposable
     public StateDto SetVfo(long hz)
     {
         long clamped = Math.Clamp(hz, 0L, 60_000_000L);
+        long previous;
+        lock (_sync) previous = _state.VfoHz;
         Mutate(s => s with { VfoHz = clamped });
         ActiveClient?.SetVfoAHz(clamped);
+        // Band edge crossed? Per-band PA gain / OC bits may have swapped — push
+        // the new snapshot before the next TX frame ships. Cheap when no
+        // crossing occurred (same bytes re-pushed).
+        if (BandUtils.FreqToBand(previous) != BandUtils.FreqToBand(clamped))
+        {
+            RecomputePaAndPush();
+        }
         return Snapshot();
     }
 
@@ -369,7 +404,66 @@ public sealed class RadioService : IDisposable
     public void SetDrive(int percent)
     {
         int clamped = Math.Clamp(percent, 0, 100);
-        ActiveClient?.SetDrive(clamped);
+        Interlocked.Exchange(ref _drivePct, clamped);
+        RecomputePaAndPush();
+    }
+
+    // DspPipelineService calls this right after a P2 client is created so the
+    // fresh connection sees the current PA snapshot without waiting for the
+    // next state change.
+    public void ReplayPaSnapshot() => RecomputePaAndPush();
+
+    // Compute the current drive byte + OC masks + PA enable from _drivePct,
+    // PaSettingsStore, and the current VFO band. Push to the active P1 client
+    // and fire PaSnapshotChanged for the P2 forwarder. Called on:
+    //   - SetDrive (slider moved)
+    //   - SetVfo when the band changes
+    //   - PaSettingsStore.Changed (user edited PA Settings)
+    //   - Connected (push current snapshot to fresh client)
+    private void RecomputePaAndPush()
+    {
+        var stateSnap = Snapshot();
+        var cfg = _paStore.GetAll(ConnectedBoardKind);
+        var bandName = BandUtils.FreqToBand(stateSnap.VfoHz);
+        var bandCfg = bandName is not null
+            ? cfg.Bands.FirstOrDefault(b => b.Band == bandName) ?? new PaBandSettingsDto(bandName)
+            : new PaBandSettingsDto("unknown");
+
+        int drivePct = Volatile.Read(ref _drivePct);
+        byte driveByte = ComputeDriveByte(drivePct, bandCfg.PaGainDb, cfg.Global.PaMaxPowerWatts);
+        bool paEnabled = cfg.Global.PaEnabled && !bandCfg.DisablePa;
+
+        ActiveClient?.SetDriveByte(driveByte);
+        ActiveClient?.SetOcMasks(bandCfg.OcTx, bandCfg.OcRx);
+
+        PaSnapshotChanged?.Invoke(new PaRuntimeSnapshot(
+            DriveByte: driveByte,
+            OcTxMask: bandCfg.OcTx,
+            OcRxMask: bandCfg.OcRx,
+            OcTuneMask: cfg.Global.OcTune,
+            PaEnabled: paEnabled));
+    }
+
+    // Shared math: target watts → dBm → subtract per-band PA gain → back to
+    // volts across 50Ω → normalize against 0.8V full-scale → 0..255 drive byte.
+    // When maxWatts == 0, fall back to the legacy UI-percent-to-byte mapping so
+    // existing installs behave identically until calibration is entered.
+    // Reference: Thetis console.cs:46801-46841, piHPSDR radio.c:2809-2828.
+    internal static byte ComputeDriveByte(int drivePct, double paGainDb, int maxWatts)
+    {
+        drivePct = Math.Clamp(drivePct, 0, 100);
+        if (maxWatts <= 0)
+        {
+            return (byte)(drivePct * 255 / 100);
+        }
+
+        double targetWatts = maxWatts * drivePct / 100.0;
+        if (targetWatts <= 0) return 0;
+
+        double sourceWatts = targetWatts / Math.Pow(10.0, paGainDb / 10.0);
+        double sourceVolts = Math.Sqrt(sourceWatts * 50.0);
+        double norm = Math.Clamp(sourceVolts / 0.8, 0.0, 1.0);
+        return (byte)Math.Round(norm * 255.0);
     }
 
     // Thetis "AGC Top" slider — max post-AGC gain in dB. Clamped to the
@@ -409,6 +503,7 @@ public sealed class RadioService : IDisposable
 
     public void Dispose()
     {
+        _paStore.Changed -= RecomputePaAndPush;
         try { DisconnectAsync(CancellationToken.None).GetAwaiter().GetResult(); }
         catch { /* best-effort */ }
     }
@@ -430,21 +525,43 @@ public sealed class RadioService : IDisposable
     // the UI without growing a P2 client slot here.
     public void MarkProtocol2Connected(string endpoint, int sampleRateHz)
     {
+        lock (_sync) _p2Active = true;
         Mutate(s => s with
         {
             Status = ConnectionStatus.Connected,
             Endpoint = endpoint,
             SampleRate = sampleRateHz,
         });
+        // P2 is alive — PA defaults should reflect G2 / Orion class so the
+        // operator sees realistic numbers when they open the PA panel.
+        RecomputePaAndPush();
     }
 
     public void MarkProtocol2Disconnected()
     {
+        lock (_sync) _p2Active = false;
         Mutate(s => s with
         {
             Status = ConnectionStatus.Disconnected,
             Endpoint = null,
         });
+    }
+
+    // Resolves the board class the PA settings UI/math should seed defaults
+    // from. P1 client wins when present (its BoardKind comes from discovery);
+    // bare P2 connections imply Orion MkII (ANAN G2 family); everything else
+    // is Unknown and falls back to 0 dB (legacy percent→byte).
+    public HpsdrBoardKind ConnectedBoardKind
+    {
+        get
+        {
+            lock (_sync)
+            {
+                if (_activeClient is not null) return _activeClient.BoardKind;
+                if (_p2Active) return HpsdrBoardKind.OrionMkII;
+                return HpsdrBoardKind.Unknown;
+            }
+        }
     }
 
     // Protocol1 → RadioService bridge. Runs on the RX thread at ~1.2 kHz;

--- a/tests/Zeus.Contracts.Tests/AutoAttControlLoopTests.cs
+++ b/tests/Zeus.Contracts.Tests/AutoAttControlLoopTests.cs
@@ -53,7 +53,8 @@ public class AutoAttControlLoopTests
     private static RadioService MakeService()
     {
         var dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance);
-        return new(NullLoggerFactory.Instance, dspStore);
+        var paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance);
+        return new(NullLoggerFactory.Instance, dspStore, paStore);
     }
 
     private static readonly AdcOverloadStatus Overload = new(Adc0: true, Adc1: false);

--- a/tests/Zeus.Protocol1.Tests/ControlFrameOcMaskTests.cs
+++ b/tests/Zeus.Protocol1.Tests/ControlFrameOcMaskTests.cs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Protocol1.Discovery;
+
+namespace Zeus.Protocol1.Tests;
+
+// The OC-mask merge in WriteConfigPayload (Config, C2) is the integration seam
+// where user-configured PA bits meet the board's existing N2ADR auto-filter
+// output. A regression that drops N2ADR bits would silently break HL2 filter
+// switching on the wire — worth pinning.
+public class ControlFrameOcMaskTests
+{
+    private static ControlFrame.CcState BaseState(byte userTx = 0, byte userRx = 0, bool mox = false) =>
+        new(
+            VfoAHz: 7_100_000, // 40m — N2adrBands.RxOcMask returns 0x44 (pins 3+7)
+            Rate: HpsdrSampleRate.Rate48k,
+            PreampOn: false,
+            Atten: HpsdrAtten.Zero,
+            RxAntenna: HpsdrAntenna.Ant1,
+            Mox: mox,
+            EnableHl2Dither: false,
+            Board: HpsdrBoardKind.HermesLite2,
+            HasN2adr: true,
+            DriveLevel: 0,
+            UserOcTxMask: userTx,
+            UserOcRxMask: userRx);
+
+    private static byte WriteConfigC2(ControlFrame.CcState state)
+    {
+        Span<byte> cc = stackalloc byte[5];
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Config, state);
+        return cc[2]; // C2 — OC pins in bits 1..7
+    }
+
+    [Fact]
+    public void N2adr_Auto_Mask_Alone_Survives_When_User_Bits_Are_Zero()
+    {
+        // Pre-Phase-2 behavior: user bits default to 0, so only N2ADR bits flow.
+        // 40m → pins 3 + 7 → mask 0x44 → shifted << 1 → 0x88.
+        Assert.Equal((byte)0x88, WriteConfigC2(BaseState()));
+    }
+
+    [Fact]
+    public void User_Tx_Mask_Or_Merges_With_N2adr_When_Mox_On()
+    {
+        // User picks pin 1 for TX (mask 0x01). While MOX, merge → 0x44 | 0x01 = 0x45 → << 1 = 0x8A.
+        var state = BaseState(userTx: 0x01, mox: true);
+        Assert.Equal((byte)0x8A, WriteConfigC2(state));
+    }
+
+    [Fact]
+    public void User_Rx_Mask_Selected_When_Not_Mox()
+    {
+        // RX mask=0x02, TX mask=0x40 (should NOT appear). MOX off → use RX.
+        // 0x44 | 0x02 = 0x46 → << 1 = 0x8C.
+        var state = BaseState(userTx: 0x40, userRx: 0x02, mox: false);
+        Assert.Equal((byte)0x8C, WriteConfigC2(state));
+    }
+
+    [Fact]
+    public void User_Bits_Above_7_Are_Masked_Off()
+    {
+        // Passing 0xFF for TX must not corrupt bit 0 (class-E) or spill past C2.
+        var state = BaseState(userTx: 0xFF, mox: true);
+        byte c2 = WriteConfigC2(state);
+        // bit 0 (class-E) stays 0; bits 1..7 carry 0x44 | 0x7F = 0x7F → << 1 = 0xFE.
+        Assert.Equal(0, c2 & 0x01);
+        Assert.Equal((byte)0xFE, c2);
+    }
+
+    [Fact]
+    public void Non_Hl2_Board_Falls_Back_To_User_Only()
+    {
+        // Hermes without N2ADR → no auto mask. User bits stand alone.
+        var state = new ControlFrame.CcState(
+            VfoAHz: 7_100_000,
+            Rate: HpsdrSampleRate.Rate48k,
+            PreampOn: false,
+            Atten: HpsdrAtten.Zero,
+            RxAntenna: HpsdrAntenna.Ant1,
+            Mox: true,
+            EnableHl2Dither: false,
+            Board: HpsdrBoardKind.Hermes,
+            HasN2adr: false,
+            DriveLevel: 0,
+            UserOcTxMask: 0x03);
+
+        Span<byte> cc = stackalloc byte[5];
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Config, state);
+        // Only user bits 0x03 → << 1 = 0x06.
+        Assert.Equal((byte)0x06, cc[2]);
+    }
+}

--- a/tests/Zeus.Server.Tests/ComputeDriveByteTests.cs
+++ b/tests/Zeus.Server.Tests/ComputeDriveByteTests.cs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+// Pin the drive-byte math down. A silent regression here emits the wrong RF
+// power without any UI signal, so this is the most load-bearing formula in the
+// whole TX path. Reference: Thetis console.cs:46801-46841, piHPSDR
+// radio.c:2809-2828.
+public class ComputeDriveByteTests
+{
+    [Theory]
+    [InlineData(0,   0.0,   0, 0)]     // zero percent always zero
+    [InlineData(100, 0.0,   0, 255)]   // legacy full scale (maxW=0 → pct×255/100)
+    [InlineData(50,  40.5,  0, 127)]   // legacy ignores gain when maxW=0
+    [InlineData(50,  0.0,   0, 127)]
+    public void LegacyMode_Ignores_Gain_And_Scales_Linearly(int pct, double gainDb, int maxW, int expected)
+    {
+        Assert.Equal((byte)expected, RadioService.ComputeDriveByte(pct, gainDb, maxW));
+    }
+
+    [Fact]
+    public void Zero_Percent_Zero_Byte_Even_With_Calibration()
+    {
+        Assert.Equal((byte)0, RadioService.ComputeDriveByte(0, 40.5, 5));
+    }
+
+    [Fact]
+    public void Over_Range_Clamps_To_255()
+    {
+        // 5 W target with 0 dB PA gain: sqrt(5·50) ≈ 15.8 V ≫ 0.8 V scale. norm
+        // clamps to 1.0 and byte pins at 255.
+        Assert.Equal((byte)255, RadioService.ComputeDriveByte(100, 0.0, 5));
+    }
+
+    [Fact]
+    public void Hl2_Calibrated_100pct_5W_Matches_PiHPSDR_Default()
+    {
+        // HL2 piHPSDR default: pa_calibration = 40.5 dB, pa_power = 5 W.
+        // At 100% target = 5 W → sourceW = 5 / 10^4.05 ≈ 4.46e-4 W →
+        // sourceV = sqrt(4.46e-4 × 50) ≈ 0.1494 V → norm ≈ 0.1867 →
+        // byte ≈ 47. Pin at ±1 to allow for rounding drift across
+        // platforms — the reference clients themselves emit ~47 here.
+        byte result = RadioService.ComputeDriveByte(100, 40.5, 5);
+        Assert.InRange(result, 46, 48);
+    }
+
+    [Fact]
+    public void Equal_Pct_At_Same_Band_Gives_Equal_Byte()
+    {
+        // The whole point of the tune-slider feature: `20% drive ≈ 20% tune`
+        // in on-air watts, because they share the same band-gain calibration.
+        byte drive = RadioService.ComputeDriveByte(20, 40.5, 5);
+        byte tune = RadioService.ComputeDriveByte(20, 40.5, 5);
+        Assert.Equal(drive, tune);
+    }
+
+    [Fact]
+    public void Negative_Percent_Clamps_To_Zero()
+    {
+        Assert.Equal((byte)0, RadioService.ComputeDriveByte(-10, 40.5, 5));
+    }
+
+    [Fact]
+    public void Above_100_Percent_Clamps_To_100()
+    {
+        byte at100 = RadioService.ComputeDriveByte(100, 40.5, 5);
+        byte at150 = RadioService.ComputeDriveByte(150, 40.5, 5);
+        Assert.Equal(at100, at150);
+    }
+}

--- a/tests/Zeus.Server.Tests/PaSettingsStoreDefaultsTests.cs
+++ b/tests/Zeus.Server.Tests/PaSettingsStoreDefaultsTests.cs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Protocol1.Discovery;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+// Defaults have to be correct on first connect — operator sees them before
+// any calibration. Wrong HL2 default (piHPSDR reported "radio is dead" with
+// 53 dB generic default) is the classic cautionary tale these tests guard
+// against.
+public class PaSettingsStoreDefaultsTests
+{
+    [Fact]
+    public void Hl2_Default_Is_Flat_40_5_On_Every_Hf_Band()
+    {
+        using var store = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance);
+        var s = store.GetAll(HpsdrBoardKind.HermesLite2);
+
+        Assert.Equal(BandUtils.HfBands.Count, s.Bands.Count);
+        foreach (var b in s.Bands)
+        {
+            Assert.Equal(40.5, b.PaGainDb);
+        }
+    }
+
+    [Fact]
+    public void Hermes_Defaults_Match_Thetis_Table()
+    {
+        using var store = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance);
+        var s = store.GetAll(HpsdrBoardKind.Hermes);
+        // Spot-check against Thetis clsHardwareSpecific.cs:482-513.
+        Assert.Equal(41.0, FindGain(s, "160m"));
+        Assert.Equal(40.5, FindGain(s, "20m"));
+        Assert.Equal(38.8, FindGain(s, "10m"));
+    }
+
+    [Fact]
+    public void OrionMkII_Uses_G2_Class_Defaults()
+    {
+        using var store = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance);
+        var s = store.GetAll(HpsdrBoardKind.OrionMkII);
+        // ANAN7000/G1/G2/ANVELINAPRO3 bracket — Thetis clsHardwareSpecific.cs:696-728.
+        Assert.Equal(47.9, FindGain(s, "160m"));
+        Assert.Equal(50.9, FindGain(s, "20m"));
+        Assert.Equal(44.6, FindGain(s, "6m"));
+    }
+
+    [Fact]
+    public void Unknown_Board_Returns_Zero_Gain_For_Legacy_Path()
+    {
+        using var store = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance);
+        var s = store.GetAll(HpsdrBoardKind.Unknown);
+        // 0 dB combined with maxW=0 in ComputeDriveByte short-circuits to the
+        // pct×255/100 legacy mapping — first boot behaves as before PA Settings.
+        foreach (var b in s.Bands)
+        {
+            Assert.Equal(0.0, b.PaGainDb);
+        }
+    }
+
+    [Fact]
+    public void GetAll_Returns_All_11_Hf_Bands_In_Canonical_Order()
+    {
+        using var store = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance);
+        var s = store.GetAll(HpsdrBoardKind.HermesLite2);
+        Assert.Equal(BandUtils.HfBands.ToArray(), s.Bands.Select(b => b.Band).ToArray());
+    }
+
+    private static double FindGain(Contracts.PaSettingsDto s, string band) =>
+        s.Bands.First(b => b.Band == band).PaGainDb;
+}

--- a/tests/Zeus.Server.Tests/TxMetersSwrTripTests.cs
+++ b/tests/Zeus.Server.Tests/TxMetersSwrTripTests.cs
@@ -78,7 +78,8 @@ public class TxMetersSwrTripTests
     {
         var loggerFactory = NullLoggerFactory.Instance;
         var dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance);
-        var radio = new RadioService(loggerFactory, dspStore);
+        var paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance);
+        var radio = new RadioService(loggerFactory, dspStore, paStore);
         hub = new StreamingHub(new NullLogger<StreamingHub>());
         var pipeline = new DspPipelineService(radio, hub, loggerFactory);
         tx = new TxService(radio, pipeline, hub, new NullLogger<TxService>());

--- a/tests/Zeus.Server.Tests/TxTimeoutTests.cs
+++ b/tests/Zeus.Server.Tests/TxTimeoutTests.cs
@@ -53,7 +53,8 @@ public class TxTimeoutTests
     {
         var loggerFactory = NullLoggerFactory.Instance;
         var dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance);
-        var radio = new RadioService(loggerFactory, dspStore);
+        var paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance);
+        var radio = new RadioService(loggerFactory, dspStore, paStore);
         var hub = new StreamingHub(new NullLogger<StreamingHub>());
         var pipeline = new DspPipelineService(radio, hub, loggerFactory);
         tx = new TxService(radio, pipeline, hub, new NullLogger<TxService>());

--- a/tests/Zeus.Server.Tests/ZoomValidationTests.cs
+++ b/tests/Zeus.Server.Tests/ZoomValidationTests.cs
@@ -52,7 +52,8 @@ public class ZoomValidationTests
     private static RadioService BuildRadio()
     {
         var dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance);
-        return new RadioService(NullLoggerFactory.Instance, dspStore);
+        var paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance);
+        return new RadioService(NullLoggerFactory.Instance, dspStore, paStore);
     }
 
     [Theory]

--- a/zeus-web/src/api/pa.ts
+++ b/zeus-web/src/api/pa.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+export type PaBandSettings = {
+  band: string;
+  paGainDb: number;
+  disablePa: boolean;
+  ocTx: number;
+  ocRx: number;
+};
+
+export type PaGlobalSettings = {
+  paEnabled: boolean;
+  paMaxPowerWatts: number;
+  ocTune: number;
+};
+
+export type PaSettings = {
+  global: PaGlobalSettings;
+  bands: PaBandSettings[];
+};
+
+type PaBandDtoRaw = {
+  band?: unknown;
+  paGainDb?: unknown;
+  disablePa?: unknown;
+  ocTx?: unknown;
+  ocRx?: unknown;
+};
+
+type PaGlobalDtoRaw = {
+  paEnabled?: unknown;
+  paMaxPowerWatts?: unknown;
+  ocTune?: unknown;
+};
+
+type PaSettingsDtoRaw = {
+  global?: PaGlobalDtoRaw;
+  bands?: unknown;
+};
+
+function toNumber(v: unknown, fallback = 0): number {
+  return typeof v === 'number' && Number.isFinite(v) ? v : fallback;
+}
+
+function toBool(v: unknown, fallback = false): boolean {
+  return typeof v === 'boolean' ? v : fallback;
+}
+
+function normalizeGlobal(raw: PaGlobalDtoRaw | undefined): PaGlobalSettings {
+  return {
+    paEnabled: toBool(raw?.paEnabled, true),
+    paMaxPowerWatts: Math.max(0, Math.round(toNumber(raw?.paMaxPowerWatts, 0))),
+    ocTune: Math.max(0, Math.min(0x7f, Math.round(toNumber(raw?.ocTune, 0)))),
+  };
+}
+
+function normalizeBand(raw: PaBandDtoRaw): PaBandSettings {
+  return {
+    band: typeof raw.band === 'string' ? raw.band : '',
+    paGainDb: toNumber(raw.paGainDb, 0),
+    disablePa: toBool(raw.disablePa, false),
+    ocTx: Math.max(0, Math.min(0x7f, Math.round(toNumber(raw.ocTx, 0)))),
+    ocRx: Math.max(0, Math.min(0x7f, Math.round(toNumber(raw.ocRx, 0)))),
+  };
+}
+
+function normalize(raw: PaSettingsDtoRaw): PaSettings {
+  const bandsArr = Array.isArray(raw.bands) ? (raw.bands as PaBandDtoRaw[]) : [];
+  return {
+    global: normalizeGlobal(raw.global),
+    bands: bandsArr.filter((b) => typeof b?.band === 'string').map(normalizeBand),
+  };
+}
+
+export async function fetchPaSettings(signal?: AbortSignal): Promise<PaSettings> {
+  const res = await fetch('/api/pa-settings', { signal });
+  if (!res.ok) throw new Error(`GET /api/pa-settings → ${res.status}`);
+  const raw = (await res.json()) as PaSettingsDtoRaw;
+  return normalize(raw);
+}
+
+export async function updatePaSettings(
+  settings: PaSettings,
+  signal?: AbortSignal,
+): Promise<PaSettings> {
+  const res = await fetch('/api/pa-settings', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(settings),
+    signal,
+  });
+  if (!res.ok) throw new Error(`PUT /api/pa-settings → ${res.status}`);
+  const raw = (await res.json()) as PaSettingsDtoRaw;
+  return normalize(raw);
+}

--- a/zeus-web/src/components/PaSettingsPanel.tsx
+++ b/zeus-web/src/components/PaSettingsPanel.tsx
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+import { useEffect } from 'react';
+import { HF_BANDS, usePaStore } from '../state/pa-store';
+
+const OC_PINS = [1, 2, 3, 4, 5, 6, 7] as const;
+
+function OcBitCheckbox({
+  label,
+  bit,
+  mask,
+  onToggle,
+}: {
+  label: string;
+  bit: number;
+  mask: number;
+  onToggle: (nextMask: number) => void;
+}) {
+  const active = (mask & (1 << (bit - 1))) !== 0;
+  return (
+    <label
+      title={`${label} pin ${bit}`}
+      className="inline-flex select-none items-center gap-1 text-[10px] text-neutral-400"
+    >
+      <input
+        type="checkbox"
+        checked={active}
+        onChange={(e) => {
+          const b = 1 << (bit - 1);
+          onToggle(e.target.checked ? mask | b : mask & ~b);
+        }}
+        className="h-3 w-3 accent-[#FFA028]"
+      />
+      {bit}
+    </label>
+  );
+}
+
+export function PaSettingsPanel() {
+  const settings = usePaStore((s) => s.settings);
+  const loaded = usePaStore((s) => s.loaded);
+  const inflight = usePaStore((s) => s.inflight);
+  const error = usePaStore((s) => s.error);
+  const load = usePaStore((s) => s.load);
+  const save = usePaStore((s) => s.save);
+  const setGlobal = usePaStore((s) => s.setGlobal);
+  const setBand = usePaStore((s) => s.setBand);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return (
+    <div className="space-y-6">
+      <section>
+        <h3 className="mb-2 text-xs font-semibold uppercase tracking-widest text-neutral-300">
+          Global
+        </h3>
+        <div className="grid grid-cols-1 gap-4 rounded bg-neutral-800/40 p-3 md:grid-cols-3">
+          <label className="flex items-center gap-2 text-xs text-neutral-300">
+            <input
+              type="checkbox"
+              checked={settings.global.paEnabled}
+              onChange={(e) => setGlobal({ paEnabled: e.target.checked })}
+              className="h-4 w-4 accent-[#FFA028]"
+            />
+            PA Enabled
+          </label>
+
+          <label className="flex items-center gap-2 text-xs text-neutral-300">
+            Max Power (W)
+            <input
+              type="number"
+              min={0}
+              max={2000}
+              step={1}
+              value={settings.global.paMaxPowerWatts}
+              onChange={(e) => setGlobal({ paMaxPowerWatts: Number(e.target.value) || 0 })}
+              className="w-20 rounded border border-neutral-700 bg-neutral-900 px-2 py-0.5 text-right text-xs text-neutral-100"
+            />
+            <span className="text-[10px] text-neutral-500">
+              (0 = legacy, no watts math)
+            </span>
+          </label>
+
+          <div className="flex flex-col gap-1 text-xs text-neutral-300">
+            <span>OC bits while Tune</span>
+            <div className="flex gap-2">
+              {OC_PINS.map((bit) => (
+                <OcBitCheckbox
+                  key={bit}
+                  label="OC-Tune"
+                  bit={bit}
+                  mask={settings.global.ocTune}
+                  onToggle={(next) => setGlobal({ ocTune: next })}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h3 className="mb-2 text-xs font-semibold uppercase tracking-widest text-neutral-300">
+          Per Band
+        </h3>
+        <div className="overflow-x-auto rounded bg-neutral-800/40">
+          <table className="w-full border-collapse text-xs">
+            <thead className="text-[10px] uppercase tracking-wider text-neutral-500">
+              <tr>
+                <th className="px-2 py-2 text-left">Band</th>
+                <th className="px-2 py-2 text-right">Gain (dB)</th>
+                <th className="px-2 py-2 text-center">Disable PA</th>
+                <th className="px-2 py-2 text-left">OC TX (1..7)</th>
+                <th className="px-2 py-2 text-left">OC RX (1..7)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {HF_BANDS.map((bandName) => {
+                const b = settings.bands.find((x) => x.band === bandName);
+                if (!b) return null;
+                return (
+                  <tr key={bandName} className="border-t border-neutral-800 text-neutral-300">
+                    <td className="px-2 py-1 font-mono">{b.band}</td>
+                    <td className="px-2 py-1 text-right">
+                      <input
+                        type="number"
+                        step={0.1}
+                        min={-10}
+                        max={80}
+                        value={b.paGainDb}
+                        onChange={(e) =>
+                          setBand(b.band, { paGainDb: Number(e.target.value) || 0 })
+                        }
+                        className="w-20 rounded border border-neutral-700 bg-neutral-900 px-2 py-0.5 text-right text-neutral-100"
+                      />
+                    </td>
+                    <td className="px-2 py-1 text-center">
+                      <input
+                        type="checkbox"
+                        checked={b.disablePa}
+                        onChange={(e) => setBand(b.band, { disablePa: e.target.checked })}
+                        className="h-3 w-3 accent-[#FFA028]"
+                      />
+                    </td>
+                    <td className="px-2 py-1">
+                      <div className="flex gap-2">
+                        {OC_PINS.map((bit) => (
+                          <OcBitCheckbox
+                            key={bit}
+                            label={`${bandName} OC-TX`}
+                            bit={bit}
+                            mask={b.ocTx}
+                            onToggle={(next) => setBand(b.band, { ocTx: next })}
+                          />
+                        ))}
+                      </div>
+                    </td>
+                    <td className="px-2 py-1">
+                      <div className="flex gap-2">
+                        {OC_PINS.map((bit) => (
+                          <OcBitCheckbox
+                            key={bit}
+                            label={`${bandName} OC-RX`}
+                            bit={bit}
+                            mask={b.ocRx}
+                            onToggle={(next) => setBand(b.band, { ocRx: next })}
+                          />
+                        ))}
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <div className="flex items-center justify-between">
+        <span className="text-[11px] text-neutral-500">
+          {inflight ? 'Saving…' : loaded ? 'Loaded from server' : 'Loading…'}
+          {error ? ` · error: ${error}` : ''}
+        </span>
+        <button
+          type="button"
+          className="btn sm"
+          onClick={save}
+          disabled={inflight}
+          title="Persist PA settings and push to the active radio"
+        >
+          Apply
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/zeus-web/src/components/SettingsMenu.tsx
+++ b/zeus-web/src/components/SettingsMenu.tsx
@@ -14,6 +14,7 @@
 // statement and per-component attribution.
 
 import { useEffect, useRef, useState } from 'react';
+import { PaSettingsPanel } from './PaSettingsPanel';
 
 type TabId =
   | 'general'
@@ -206,9 +207,13 @@ export function SettingsMenu({ open, onClose }: Props) {
         className="flex-1 overflow-auto px-6 py-6 text-sm text-neutral-300"
         role="tabpanel"
       >
-        <p className="italic text-neutral-500">
-          {TABS.find((t) => t.id === active)?.label} settings — coming soon.
-        </p>
+        {active === 'pa' ? (
+          <PaSettingsPanel />
+        ) : (
+          <p className="italic text-neutral-500">
+            {TABS.find((t) => t.id === active)?.label} settings — coming soon.
+          </p>
+        )}
       </div>
 
       <div className="flex items-center justify-between border-t border-neutral-800 px-4 py-3">

--- a/zeus-web/src/state/pa-store.ts
+++ b/zeus-web/src/state/pa-store.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+import { create } from 'zustand';
+import {
+  fetchPaSettings,
+  updatePaSettings,
+  type PaBandSettings,
+  type PaGlobalSettings,
+  type PaSettings,
+} from '../api/pa';
+
+// Canonical HF band order — must match Zeus.Server/BandUtils.HfBands. The
+// settings panel iterates this for a consistent row order even when the
+// backend returns bands in a different order or omits some.
+export const HF_BANDS: readonly string[] = [
+  '160m', '80m', '60m', '40m', '30m', '20m', '17m', '15m', '12m', '10m', '6m',
+] as const;
+
+function defaultBand(band: string): PaBandSettings {
+  return { band, paGainDb: 0, disablePa: false, ocTx: 0, ocRx: 0 };
+}
+
+function defaultState(): PaSettings {
+  return {
+    global: { paEnabled: true, paMaxPowerWatts: 0, ocTune: 0 },
+    bands: HF_BANDS.map(defaultBand),
+  };
+}
+
+// Canonicalize the array coming back from the backend: fill in missing bands
+// with defaults so the UI doesn't have to guard for holes.
+function canonicalize(s: PaSettings): PaSettings {
+  const byBand = new Map<string, PaBandSettings>(s.bands.map((b) => [b.band, b]));
+  return {
+    global: s.global,
+    bands: HF_BANDS.map((b) => byBand.get(b) ?? defaultBand(b)),
+  };
+}
+
+type PaStore = {
+  settings: PaSettings;
+  loaded: boolean;
+  inflight: boolean;
+  error: string | null;
+  load: () => Promise<void>;
+  save: () => Promise<void>;
+  setGlobal: (patch: Partial<PaGlobalSettings>) => void;
+  setBand: (band: string, patch: Partial<Omit<PaBandSettings, 'band'>>) => void;
+};
+
+export const usePaStore = create<PaStore>((set, get) => ({
+  settings: defaultState(),
+  loaded: false,
+  inflight: false,
+  error: null,
+
+  load: async () => {
+    set({ inflight: true, error: null });
+    try {
+      const s = await fetchPaSettings();
+      set({ settings: canonicalize(s), loaded: true, inflight: false });
+    } catch (err) {
+      set({
+        error: err instanceof Error ? err.message : String(err),
+        inflight: false,
+      });
+    }
+  },
+
+  save: async () => {
+    set({ inflight: true, error: null });
+    try {
+      const s = await updatePaSettings(get().settings);
+      set({ settings: canonicalize(s), inflight: false });
+    } catch (err) {
+      set({
+        error: err instanceof Error ? err.message : String(err),
+        inflight: false,
+      });
+    }
+  },
+
+  setGlobal: (patch) =>
+    set((s) => ({ settings: { ...s.settings, global: { ...s.settings.global, ...patch } } })),
+
+  setBand: (band, patch) =>
+    set((s) => ({
+      settings: {
+        ...s.settings,
+        bands: s.settings.bands.map((b) => (b.band === band ? { ...b, ...patch } : b)),
+      },
+    })),
+}));


### PR DESCRIPTION
## Summary

Ships Phase 1 + Phase 2 PA Settings — you approved this verbally. Per-band PA gain (dB), disable-PA, OC-TX / OC-RX pin masks, plus global PA-enable, max-watts, and OC-Tune.

**Base:** \`kb2uka/settings-menu-shell\` (#69). The PA panel is the first tab body wired into that shell.

## Wire format (flagged for your review)

**Zeus.Contracts** — new DTOs:
- \`PaBandSettingsDto(band, paGainDb, disablePa, ocTx, ocRx)\`
- \`PaGlobalSettingsDto(paEnabled, paMaxPowerWatts, ocTune)\`
- \`PaSettingsDto(global, bands[])\` + \`PaSettingsSetRequest\`

**REST** — \`GET\` / \`PUT\` \`/api/pa-settings\` (whole-snapshot replacement).

**Protocol 1** — \`Protocol1Client\` gains \`SetDriveByte(byte)\` and \`SetOcMasks(txMask, rxMask)\`. \`ControlFrame.WriteConfigPayload\` OR-merges the user OC mask (TX when MOX, else RX) with the existing \`N2adrBands\` auto-mask, then shifts into C2 bits 1..7. **Stock HL2 + N2ADR filter switching is preserved when no user bits are set.**

**Protocol 2** — \`Protocol2Client\` emits drive byte 345, OC byte 1401 (with MOX-gated TX/RX selection), and gates \`CmdGeneral\` byte 58 bit 0 on the \`pa_enabled\` global (was hard-coded \`0x01\`). Matches piHPSDR \`new_protocol.c:860\` / \`:877-894\` / \`:658-677\`.

## Math (RadioService.ComputeDriveByte)

\`\`\`
targetW = maxW × drivePct/100
sourceW = targetW / 10^(paGainDb/10)
volts   = sqrt(sourceW × 50)
norm    = min(volts / 0.8, 1.0)
byte    = round(norm × 255)
\`\`\`

When \`paMaxPowerWatts == 0\` the math short-circuits to the legacy \`drivePct × 255 / 100\` mapping so existing installs behave identically until calibration is entered. Reference: Thetis \`console.cs:46801-46841\`, piHPSDR \`radio.c:2809-2828\`.

## Defaults

\`PaDefaults.cs\` — lifted from Thetis \`clsHardwareSpecific.cs:470-767\` and piHPSDR \`band.c:498-500\`:

| Board | Sample gains |
|---|---|
| Hermes / Metis / Griffin | 41.0..38.8 dB (Thetis FIRST/HERMES bracket) |
| Angelia | 50.0..43.0 dB (ANAN-100 bracket) |
| Orion | 49.5..43.0 dB (ANAN-200D bracket) |
| OrionMkII | 47.9..44.6 dB (Saturn / G2 bracket) |
| HermesLite2 | **40.5 dB flat** (piHPSDR override) |
| Unknown | 0 dB (legacy percent path) |

## Recompute triggers (RadioService)

- \`SetDrive\` (slider moved)
- \`SetVfo\` (only when \`FreqToBand(prev) != FreqToBand(new)\`)
- \`PaSettingsStore.Changed\` (user edited PA Settings)
- \`Connected\` + \`MarkProtocol2Connected\` (fresh client replay)

## Test coverage (new, all passing — 20 tests total)

- \`tests/Zeus.Server.Tests/ComputeDriveByteTests.cs\` — pins the drive-byte math, zero/clamp cases, HL2 calibrated byte matches piHPSDR reference, \"equal-pct-equal-byte\" invariant.
- \`tests/Zeus.Server.Tests/PaSettingsStoreDefaultsTests.cs\` — HL2 returns 40.5 dB on every band; Hermes / OrionMkII match the Thetis table; Unknown returns 0 dB; canonical HF band order.
- \`tests/Zeus.Protocol1.Tests/ControlFrameOcMaskTests.cs\` — N2ADR auto-mask survives when user bits are 0; user TX mask OR-merges when MOX; RX mask selected when not MOX; bits ≥ 8 masked off; non-HL2 boards fall back to user-only.

Also updates 4 existing tests (\`AutoAttControlLoopTests\`, \`ZoomValidationTests\`, \`TxTimeoutTests\`, \`TxMetersSwrTripTests\`) to pass the new \`PaSettingsStore\` arg to \`RadioService\` ctor.

## UI

The PA SETTINGS tab in the Settings modal (#69) now renders:
- **Global** panel: PA Enable, Max Power (W), OC-Tune 7 bits
- **Per Band** table: 11 HF bands × (Gain dB, Disable PA, OC-TX × 7 pins, OC-RX × 7 pins)
- **Apply** button persists the whole snapshot via PUT \`/api/pa-settings\`

## Red-light items per CLAUDE.md

- Wire-format changes to Zeus.Contracts
- New backend services (PaSettingsStore, BandUtils, PaDefaults)
- Seeded per-model default values

None mergeable without your sign-off.

## Test plan

- [ ] Connect to a radio, open MENU → PA SETTINGS
- [ ] Values load (zeros for first install; defaults for connected board)
- [ ] Edit a gain value + click Apply → POST succeeds; value persists across reload
- [ ] Set Max Power = 5 W, Gain = 40.5 on HL2, drive slider to 100% → byte on wire matches piHPSDR
- [ ] With no edits, drive slider behaves exactly as before (legacy pct×255/100)
- [ ] Band edge crossing (e.g. 7.0 MHz ↔ 7.0 MHz +1 Hz) triggers per-band recompute