### PR TITLE
feat(tx): separate tune-power slider with shared PA calibration

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -122,6 +122,12 @@ public sealed record MoxSetRequest(bool On);
 
 public sealed record DriveSetRequest(int Percent);
 
+// TUN has its own drive % so the operator can pre-set a lower tune level
+// without touching the MOX drive. Same per-band PA gain compensates both,
+// so equal slider positions yield equal watts on air (Thetis parity —
+// `console.cs:46756-46788`).
+public sealed record TuneDriveSetRequest(int Percent);
+
 public sealed record NrSetRequest(NrConfig Nr);
 
 // Panadapter/waterfall zoom levels. Level=1 means the analyzer covers the full

--- a/Zeus.Server/Program.cs
+++ b/Zeus.Server/Program.cs
@@ -462,6 +462,19 @@ app.MapPost("/api/tx/drive", (DriveSetRequest req, RadioService r) =>
     return Results.Ok(new { drivePercent = req.Percent });
 });
 
+// TUN drive %. Symmetric with /api/tx/drive; the same PA-gain math applies,
+// so equal slider positions emit equal watts. Backend selects between the
+// two sources based on whether TUN is keyed (TxService.TrySetTun →
+// RadioService.NotifyTunActive).
+app.MapPost("/api/tx/tune-drive", (TuneDriveSetRequest req, RadioService r) =>
+{
+    log.LogInformation("api.tx.tune-drive percent={Pct}", req.Percent);
+    if (req.Percent < 0 || req.Percent > 100)
+        return Results.BadRequest(new { error = "percent must be 0..100" });
+    r.SetTuneDrive(req.Percent);
+    return Results.Ok(new { tunePercent = req.Percent });
+});
+
 app.MapPost("/api/rx/nr", (NrSetRequest req, RadioService r) =>
 {
     log.LogInformation(

--- a/Zeus.Server/RadioService.cs
+++ b/Zeus.Server/RadioService.cs
@@ -59,6 +59,15 @@ public sealed class RadioService : IDisposable
     // edge is crossed or a PA setting is edited, we recompute without needing
     // to wait for the next SetDrive call.
     private int _drivePct;
+    // Independent TUN drive %. When TUN is keyed, the recompute uses this in
+    // place of _drivePct so the operator can pre-set a lower tune level (and
+    // the same per-band PA gain gives equal watts at equal percentages). piHPSDR
+    // default is 10 — a 0 default would be "press TUN, nothing happens".
+    private int _tunePct = 10;
+    // Which drive % the next frame uses. Latched via NotifyTunActive from
+    // TxService whenever the MOX/TUN keying state changes so a drag on either
+    // slider during a live TX picks the right source without polling.
+    private bool _tunActive;
 
     private StateDto _state;
 
@@ -408,6 +417,24 @@ public sealed class RadioService : IDisposable
         RecomputePaAndPush();
     }
 
+    // Independent TUN drive %. Applies on the very next frame if TUN is already
+    // keyed; otherwise it sits until TxService flips _tunActive.
+    public void SetTuneDrive(int percent)
+    {
+        int clamped = Math.Clamp(percent, 0, 100);
+        Interlocked.Exchange(ref _tunePct, clamped);
+        RecomputePaAndPush();
+    }
+
+    // TxService calls this on every MOX/TUN edge. Runs the same recompute the
+    // drive-slider path uses so the drive byte on the wire always reflects the
+    // just-applied keying state (Thetis PreviousPWR swap, `console.cs:30094`).
+    public void NotifyTunActive(bool on)
+    {
+        lock (_sync) _tunActive = on;
+        RecomputePaAndPush();
+    }
+
     // DspPipelineService calls this right after a P2 client is created so the
     // fresh connection sees the current PA snapshot without waiting for the
     // next state change.
@@ -429,8 +456,12 @@ public sealed class RadioService : IDisposable
             ? cfg.Bands.FirstOrDefault(b => b.Band == bandName) ?? new PaBandSettingsDto(bandName)
             : new PaBandSettingsDto("unknown");
 
-        int drivePct = Volatile.Read(ref _drivePct);
-        byte driveByte = ComputeDriveByte(drivePct, bandCfg.PaGainDb, cfg.Global.PaMaxPowerWatts);
+        bool tunActive;
+        lock (_sync) tunActive = _tunActive;
+        int activePct = tunActive
+            ? Volatile.Read(ref _tunePct)
+            : Volatile.Read(ref _drivePct);
+        byte driveByte = ComputeDriveByte(activePct, bandCfg.PaGainDb, cfg.Global.PaMaxPowerWatts);
         bool paEnabled = cfg.Global.PaEnabled && !bandCfg.DisablePa;
 
         ActiveClient?.SetDriveByte(driveByte);

--- a/Zeus.Server/TxService.cs
+++ b/Zeus.Server/TxService.cs
@@ -105,6 +105,10 @@ public sealed class TxService
         // Engine handles the RXA/TXA pair atomically under its own lock.
         _pipeline.SetMox(on);
         _radio.SetMox(on);
+        // MOX-edge unconditionally deactivates TUN on the drive-source side —
+        // MOX-on preempts TUN above, MOX-off should also leave the recompute
+        // pointing at _drivePct for the next half-key.
+        _radio.NotifyTunActive(false);
         _log.LogInformation("tx.mox on={On}", on);
         error = null;
         return true;
@@ -148,6 +152,9 @@ public sealed class TxService
         _pipeline.SetMox(on);
         _radio.SetMox(on);
         _pipeline.SetTxTune(on);
+        // Swap the drive source AFTER the engine flip so the DriveFilter byte
+        // on the first TUN frame carries the tune % (not the stale drive %).
+        _radio.NotifyTunActive(on);
         _log.LogInformation("tx.tun on={On}", on);
         error = null;
         return true;
@@ -178,6 +185,7 @@ public sealed class TxService
             _pipeline.SetMox(false);
             _radio.SetMox(false);
             if (wasTunOn) _pipeline.SetTxTune(false);
+            _radio.NotifyTunActive(false);
             _log.LogWarning("tx.trip kind={Kind} reason={Reason}", kind, reason);
             _hub.Broadcast(new AlertFrame(kind, reason));
         }

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -45,6 +45,7 @@ import { AudioToggle } from './components/AudioToggle';
 import { BandButtons } from './components/BandButtons';
 import { ConnectPanel } from './components/ConnectPanel';
 import { DriveSlider } from './components/DriveSlider';
+import { TunePowerSlider } from './components/TunePowerSlider';
 import { MicGainSlider } from './components/MicGainSlider';
 import { MicMeter } from './components/MicMeter';
 import { MobilePttButton } from './components/MobilePttButton';
@@ -649,6 +650,7 @@ export default function App() {
               <ZoomControl />
             </div>
             <DriveSlider />
+            <TunePowerSlider />
             <MicGainSlider />
           </div>
         </div>

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -568,6 +568,28 @@ export function setDrive(
   );
 }
 
+// Tune-drive endpoint: POST /api/tx/tune-drive { percent }. Returns
+// { tunePercent }. Backend picks this in place of drivePercent while TUN is
+// keyed; same PA-gain calibration applies.
+export function setTuneDrive(
+  percent: number,
+  signal?: AbortSignal,
+): Promise<{ tunePercent: number }> {
+  return jsonFetch(
+    '/api/tx/tune-drive',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ percent: Math.round(percent) }),
+      signal,
+    },
+    (raw) => {
+      const v = (raw as { tunePercent?: unknown }).tunePercent;
+      return { tunePercent: typeof v === 'number' ? v : 0 };
+    },
+  );
+}
+
 // TUN endpoint: POST /api/tx/tun { on }. Returns { tunOn }. Keys a single-tone
 // carrier via WDSP SetTXAPostGen* and is mutually exclusive with MOX on the
 // server. Same 404-tolerant pattern as setMicGain because the backend handler

--- a/zeus-web/src/components/ConnectPanel.tsx
+++ b/zeus-web/src/components/ConnectPanel.tsx
@@ -44,6 +44,7 @@ import {
   fetchRadios,
   fetchState,
   setDrive,
+  setTuneDrive,
   setLevelerMaxGain,
   setMicGain,
   type RadioInfoDto,
@@ -84,6 +85,7 @@ function applyPostConnectEffects() {
   void getAudioClient().start();
   const tx = useTxStore.getState();
   void setDrive(tx.drivePercent).catch(() => {});
+  void setTuneDrive(tx.tunePercent).catch(() => {});
   void setMicGain(tx.micGainDb).catch(() => {});
   void setLevelerMaxGain(tx.levelerMaxGainDb).catch(() => {});
 }

--- a/zeus-web/src/components/TunePowerSlider.tsx
+++ b/zeus-web/src/components/TunePowerSlider.tsx
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+import { useCallback, useEffect, useRef } from 'react';
+import { setTuneDrive } from '../api/client';
+import { useConnectionStore } from '../state/connection-store';
+import { useTxStore } from '../state/tx-store';
+
+// Same 0..100 range and debounce shape as DriveSlider; the backend picks
+// between the two sources based on TUN keying state so the UX/wire are
+// symmetric.
+const MIN = 0;
+const MAX = 100;
+const DEBOUNCE_MS = 100;
+
+export function TunePowerSlider() {
+  const connected = useConnectionStore((s) => s.status === 'Connected');
+  const tunePercent = useTxStore((s) => s.tunePercent);
+  const setTunePercent = useTxStore((s) => s.setTunePercent);
+
+  const inflightAbort = useRef<AbortController | null>(null);
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastSent = useRef<number>(tunePercent);
+  const previousOnError = useRef<number>(tunePercent);
+
+  const sendDebounced = useCallback((v: number) => {
+    if (debounceTimer.current != null) clearTimeout(debounceTimer.current);
+    debounceTimer.current = setTimeout(() => {
+      if (v === lastSent.current) return;
+      inflightAbort.current?.abort();
+      const ac = new AbortController();
+      inflightAbort.current = ac;
+      const prevValue = lastSent.current;
+      lastSent.current = v;
+      previousOnError.current = prevValue;
+      setTuneDrive(v, ac.signal)
+        .then((r) => {
+          if (ac.signal.aborted) return;
+          if (r.tunePercent !== v) setTunePercent(r.tunePercent);
+        })
+        .catch((err) => {
+          if (ac.signal.aborted) return;
+          if (err instanceof DOMException && err.name === 'AbortError') return;
+          setTunePercent(previousOnError.current);
+          lastSent.current = previousOnError.current;
+        });
+    }, DEBOUNCE_MS);
+  }, [setTunePercent]);
+
+  useEffect(() => () => {
+    inflightAbort.current?.abort();
+    if (debounceTimer.current != null) clearTimeout(debounceTimer.current);
+  }, []);
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const v = Number(e.currentTarget.value);
+    setTunePercent(v);
+    sendDebounced(v);
+  };
+
+  return (
+    <label className="knob-group">
+      <span className="label-xs">TUN</span>
+      <input
+        type="range"
+        min={MIN}
+        max={MAX}
+        step={1}
+        value={tunePercent}
+        disabled={!connected}
+        onChange={onChange}
+        style={{ flex: 1, cursor: 'pointer', accentColor: 'var(--accent)' }}
+      />
+      <span
+        className="mono"
+        style={{
+          width: 40,
+          textAlign: 'right',
+          color: 'var(--power)',
+          fontSize: 11,
+          fontWeight: 700,
+        }}
+      >
+        {tunePercent}%
+      </span>
+    </label>
+  );
+}

--- a/zeus-web/src/state/tx-store.ts
+++ b/zeus-web/src/state/tx-store.ts
@@ -90,6 +90,11 @@ export type TxState = {
   // can't flash full power into the PA.
   drivePercent: number;
   setDrivePercent: (p: number) => void;
+  // TUN has its own drive %. Same PA-gain calibration as drive, so equal
+  // percentages produce equal watts. Default 10 matches piHPSDR — zero would
+  // make a first TUN press appear broken ("nothing happens").
+  tunePercent: number;
+  setTunePercent: (p: number) => void;
   // PRD FR-3: mic-gain slider 0..+20 dB (default 0). Server applies via
   // WDSP SetTXAPanelGain1(TXA, 10^(db/20)). Kept as int dB on the wire.
   micGainDb: number;
@@ -162,6 +167,8 @@ export const useTxStore = create<TxState>()(
       setTunOn: (on) => set(on ? { tunOn: true, moxOn: false } : { tunOn: false }),
       drivePercent: 10,
       setDrivePercent: (p) => set({ drivePercent: p }),
+      tunePercent: 10,
+      setTunePercent: (p) => set({ tunePercent: p }),
       micGainDb: 0,
       setMicGainDb: (db) => set({ micGainDb: db }),
       levelerMaxGainDb: 5,
@@ -226,6 +233,7 @@ export const useTxStore = create<TxState>()(
       // else (mox/tun/meters/alert) is transient per-session.
       partialize: (s) => ({
         drivePercent: s.drivePercent,
+        tunePercent: s.tunePercent,
         micGainDb: s.micGainDb,
         levelerMaxGainDb: s.levelerMaxGainDb,
       }),


### PR DESCRIPTION
## Summary

Adds a dedicated **TUN drive %** slider separate from the MOX drive. Both sliders feed the **same** per-band PA-gain math (#70), so **equal slider positions produce equal on-air watts** — the Thetis / piHPSDR convention.

**Base:** \`kb2uka/pa-settings\` (#70). Depends on \`ComputeDriveByte\` / the recompute pipeline from that PR.

Not previously discussed with you. Opening for your explicit call on whether to merge, rework, or drop in favor of a different approach.

## ⚠️ TUN TX does NOT actually work end-to-end yet

**Read this before merging:**

- **Protocol 2:** Zeus P2 is pure RX today. Byte 345 goes out with the right drive value, but **no TX IQ is being generated** — the HPC packet is the only TX wiring P2 has. So TUN on a G2 MkII currently emits nothing regardless of what this slider says.
- **Protocol 1:** TUN on HL2 may emit a carrier (existing WDSP TXA post-gen tone + DriveFilter byte scaffold from earlier work). **I have NOT verified this end-to-end on hardware in this session.** It might work; it might not.

Next session I plan to start wiring real TUN TX (WDSP tone → P2 IQ path), starting with the TUN button on P2. This slider is the UI prerequisite so the operator has a power control to drag when TUN actually keys.

## Wire

\`\`\`
POST /api/tx/tune-drive { percent }  → 200 { tunePercent }
\`\`\`

**RadioService** gets:
- \`_tunePct\` (default 10, piHPSDR parity)
- \`_tunActive\` (latched by TxService on every MOX/TUN edge)
- \`SetTuneDrive(int)\` → updates pct, triggers recompute
- \`NotifyTunActive(bool)\` → latches active source, triggers recompute

**TxService**: \`TrySetTun\`, \`TrySetMox\`, \`TryTripForAlert\` now call \`_radio.NotifyTunActive(...)\` after the engine flip so the drive byte on the wire always reflects the just-applied keying state.

**Recompute picks the source**:
\`\`\`csharp
int activePct = _tunActive ? _tunePct : _drivePct;
byte driveByte = ComputeDriveByte(activePct, bandCfg.PaGainDb, cfg.Global.PaMaxPowerWatts);
\`\`\`

## Frontend

- \`api/client.ts\`: \`setTuneDrive()\` mirrors \`setDrive()\`
- \`state/tx-store.ts\`: \`tunePercent\` (persisted, default 10)
- \`components/TunePowerSlider.tsx\`: mirrors \`DriveSlider\` with label \`TUN\`
- \`App.tsx\`: slider mounted next to DRV/MIC in the top-bar control row
- \`ConnectPanel.tsx\`: \`applyPostConnectEffects()\` re-POSTs \`tunePercent\` on connect

## No new tests

The math under the slider is the same \`ComputeDriveByte\` that #70 already covers (equal-pct-equal-byte invariant is asserted there). A separate TUN-TX integration test should land with the actual TX wiring, not this UI-only slider.

## No DSP work

The HL2 DriveFilter byte / P2 HPC byte 345 are the sole amplitude controls for both MOX and TUN paths — which is exactly what makes the equal-pct-equal-watts invariant work.

## Test plan

- [ ] Slider appears next to DRV in the top bar
- [ ] Drag → debounced POST to \`/api/tx/tune-drive\`
- [ ] Value persists across reload
- [ ] With Max Power calibrated, 20% TUN should match 20% DRV in byte on wire (verify with packet capture or backend log)
- [ ] ⚠️ TUN keying does NOT yet transmit on P2 — do not bench-test that path