### PR TITLE
fix(zeus-web): show full QRZ name and collapse logbook entries to one row

### DIFF
--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -946,9 +946,10 @@ function qrzStationToContact(s: QrzStation | null, home: QrzStation | null): Con
   const last = (s.name || '').trim().split(/\s+/).pop()?.charAt(0).toUpperCase() ?? '';
   const initials = (first + last) || s.callsign.slice(0, 2);
   const location = [s.city, s.state, s.country].filter(Boolean).join(', ') || (s.country ?? '—');
+  const fullName = [s.firstName, s.name].filter(Boolean).join(' ') || '—';
   return {
     callsign: s.callsign,
-    name: s.name ?? '—',
+    name: fullName,
     location,
     grid: s.grid ?? '—',
     cq: s.cqZone != null ? String(s.cqZone).padStart(2, '0') : '—',

--- a/zeus-web/src/components/design/LogbookLive.tsx
+++ b/zeus-web/src/components/design/LogbookLive.tsx
@@ -108,7 +108,7 @@ export function LogbookLive() {
             className={`log-row mono ${selectedIds.has(entry.id) ? 'selected' : ''}`}
             onClick={() => toggleSelected(entry.id)}
           >
-            <span style={{ width: '2rem' }}>
+            <span>
               <input
                 type="checkbox"
                 checked={selectedIds.has(entry.id)}
@@ -123,12 +123,16 @@ export function LogbookLive() {
             <span>{entry.frequencyMhz.toFixed(3)}</span>
             <span className="t-mode">{entry.mode}</span>
             <span>{entry.rstSent}/{entry.rstRcvd}</span>
-            <span className="t-name">{entry.name ?? '—'}</span>
-            {entry.qrzLogId && (
-              <span style={{ marginLeft: '0.5rem', color: 'var(--accent)', fontSize: '0.7em' }}>
-                ✓ QRZ
+            <span className="t-name" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', minWidth: 0 }}>
+              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {entry.name ?? '—'}
               </span>
-            )}
+              {entry.qrzLogId && (
+                <span style={{ color: 'var(--accent)', fontSize: '0.7em', flexShrink: 0 }}>
+                  ✓ QRZ
+                </span>
+              )}
+            </span>
           </button>
         ))}
       </div>

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -782,7 +782,7 @@
 .logbook { display: flex; flex-direction: column; height: 100%; min-height: 0; background: var(--bg-1); }
 .log-head {
   display: grid;
-  grid-template-columns: 50px 80px 70px 50px 40px 1fr;
+  grid-template-columns: 2rem 60px 55px 85px 70px 50px 70px 1fr;
   gap: 8px;
   padding: 5px 10px;
   font-size: 10px;
@@ -797,7 +797,7 @@
 .log-rows { flex: 1; overflow-y: auto; min-height: 0; }
 .log-row {
   display: grid;
-  grid-template-columns: 50px 80px 70px 50px 40px 1fr;
+  grid-template-columns: 2rem 60px 55px 85px 70px 50px 70px 1fr;
   gap: 8px;
   padding: 5px 10px;
   font-size: 12px;


### PR DESCRIPTION
## Summary
- QRZ panel now renders both first and last name (`Brian Keating` instead of just `Keating`) by joining `firstName` + `name` in `qrzStationToContact`.
- Logbook grid now shows each entry on a single row. The CSS `grid-template-columns` only had 6 columns while each header/row renders 8 spans (plus an optional QRZ badge), so the overflow wrapped onto a second row per entry.
- The optional `✓ QRZ` badge is now nested inside the name cell so it doesn't create a 9th grid child that would trigger a new row.

## Test plan
- [ ] Look up a callsign in the QRZ panel — verify the displayed name includes both first and last name (e.g. `EI6LF` → `Brian Keating`).
- [ ] Load the logbook panel — verify each entry occupies a single row, columns align with the header.
- [ ] Log a QSO that's been published to QRZ — verify the `✓ QRZ` badge renders next to the name without pushing the row to two lines.