### PR TITLE
feat(filter): filter visualization Phases 1–4 (#63)

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -88,7 +88,10 @@ public sealed record StateDto(
     int AttOffsetDb = 0,
     // Red-lamp flag derived from Thetis' overload-level counter
     // (+2 per overload cycle, -1 per clean, clamped 0..5, warn when >3).
-    bool AdcOverloadWarning = false);
+    bool AdcOverloadWarning = false,
+    // Currently active filter preset slot name (e.g. "F6", "VAR1"). Null when
+    // the filter was set by a drag edit without a named slot context.
+    string? FilterPresetName = null);
 
 public sealed record RadioInfo(
     string MacAddress,

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -91,7 +91,10 @@ public sealed record StateDto(
     bool AdcOverloadWarning = false,
     // Currently active filter preset slot name (e.g. "F6", "VAR1"). Null when
     // the filter was set by a drag edit without a named slot context.
-    string? FilterPresetName = null);
+    string? FilterPresetName = null,
+    // Advanced-filter ribbon visibility, persisted across server restarts via
+    // FilterPresetStore so the operator's close-the-ribbon choice sticks.
+    bool FilterAdvancedPaneOpen = false);
 
 public sealed record RadioInfo(
     string MacAddress,

--- a/Zeus.Contracts/FilterFrame.cs
+++ b/Zeus.Contracts/FilterFrame.cs
@@ -35,47 +35,39 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
-import { useDisplayStore } from '../state/display-store';
-import { useConnectionStore } from '../state/connection-store';
+namespace Zeus.Contracts;
 
-// Translucent rectangle drawn inside the panadapter container to show the
-// active receive filter passband, mapped from [filterLowHz, filterHighHz]
-// relative to the VFO centre. Asymmetric by design: USB lives to the right
-// of carrier, LSB to the left, CW narrow around zero, AM symmetric.
-// Positioned by percentage of the total span so it tracks resize and tune
-// without measuring DOM width.
-export function PassbandOverlay() {
-  const centerHz = useDisplayStore((s) => s.centerHz);
-  const hzPerPixel = useDisplayStore((s) => s.hzPerPixel);
-  const width = useDisplayStore((s) => s.panDb?.length ?? 0);
-  const filterLowHz = useConnectionStore((s) => s.filterLowHz);
-  const filterHighHz = useConnectionStore((s) => s.filterHighHz);
+// Broadcast frame carrying the current RX filter state with optional preset
+// context. Emitted on every SetFilter call and on mode change.
+public sealed record FilterStateFrame(
+    int ChannelId,
+    RxMode Mode,
+    int LowHz,
+    int HighHz,
+    string? PresetName = null,
+    int? PresetIndex = null);
 
-  if (!width || hzPerPixel <= 0) return null;
+// REST / hub request to set the active filter. PresetName is optional;
+// nudges without a preset context (drag edits) omit it and clear the
+// active-preset highlight on the frontend.
+public sealed record FilterSetRequest(
+    int LowHz,
+    int HighHz,
+    string? PresetName = null);
 
-  const spanHz = width * hzPerPixel;
-  const center = Number(centerHz);
-  const startHz = center - spanHz / 2;
+// Request to write a VAR1 or VAR2 slot. Server rejects SlotName values
+// outside {VAR1, VAR2} with HTTP 409.
+public sealed record FilterPresetWriteRequest(
+    RxMode Mode,
+    string SlotName,
+    int LowHz,
+    int HighHz);
 
-  const passLowHz = center + filterLowHz;
-  const passHighHz = center + filterHighHz;
-  const leftPct = ((passLowHz - startHz) / spanHz) * 100;
-  const rightPct = ((passHighHz - startHz) / spanHz) * 100;
-  const widthPct = rightPct - leftPct;
-
-  if (widthPct <= 0 || leftPct > 100 || rightPct < 0) return null;
-
-  return (
-    <div
-      aria-hidden
-      className="pointer-events-none absolute inset-y-0 z-[5]"
-      style={{
-        left: `${leftPct}%`,
-        width: `${widthPct}%`,
-        background: 'rgba(255, 160, 40, 0.18)',
-        borderLeft: '1px solid rgba(255, 160, 40, 0.6)',
-        borderRight: '1px solid rgba(255, 160, 40, 0.6)',
-      }}
-    />
-  );
-}
+// DTO returned by GET /api/filter/presets. Carries the merged Thetis default
+// plus any operator VAR1/VAR2 overrides for a given mode.
+public sealed record FilterPresetDto(
+    string SlotName,
+    string Label,
+    int LowHz,
+    int HighHz,
+    bool IsVar);

--- a/Zeus.Contracts/FilterFrame.cs
+++ b/Zeus.Contracts/FilterFrame.cs
@@ -71,3 +71,6 @@ public sealed record FilterPresetDto(
     int LowHz,
     int HighHz,
     bool IsVar);
+
+// Advanced-ribbon pane visibility toggle.
+public sealed record FilterAdvancedPaneRequest(bool Open);

--- a/Zeus.Server/FilterPresetStore.cs
+++ b/Zeus.Server/FilterPresetStore.cs
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+using LiteDB;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+// Persists per-mode VAR1/VAR2 overrides and the last-selected preset slot
+// across server restarts. Lives in the shared zeus-prefs.db file.
+//
+// On first run, USB and LSB VAR1 are seeded with Zeus's wider 150/2850 default
+// (PRD §9 open question: preserve Zeus's low-cut as VAR1 on first run).
+public sealed class FilterPresetStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<FilterPresetStoreEntry> _entries;
+    private readonly ILogger<FilterPresetStore> _log;
+
+    public FilterPresetStore(ILogger<FilterPresetStore> log)
+    {
+        _log = log;
+        var dbPath = GetDatabasePath();
+
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _entries = _db.GetCollection<FilterPresetStoreEntry>("filter_presets");
+        _entries.EnsureIndex(x => x.ModeKey, unique: true);
+
+        SeedDefaults();
+        _log.LogInformation("FilterPresetStore initialized at {Path}", dbPath);
+    }
+
+    // Returns the stored override for a VAR slot, or null if not overridden.
+    public (int LowHz, int HighHz)? GetVarOverride(RxMode mode, string slotName)
+    {
+        var e = _entries.FindOne(x => x.ModeKey == mode.ToString());
+        if (e is null) return null;
+        return slotName == "VAR1"
+            ? (e.HasVar1 ? (e.Var1Lo, e.Var1Hi) : null)
+            : slotName == "VAR2"
+                ? (e.HasVar2 ? (e.Var2Lo, e.Var2Hi) : null)
+                : null;
+    }
+
+    public void UpsertVarOverride(RxMode mode, string slotName, int loHz, int hiHz)
+    {
+        var key = mode.ToString();
+        var existing = _entries.FindOne(x => x.ModeKey == key);
+        if (existing is null)
+        {
+            existing = new FilterPresetStoreEntry { ModeKey = key };
+            if (slotName == "VAR1") { existing.HasVar1 = true; existing.Var1Lo = loHz; existing.Var1Hi = hiHz; }
+            else                    { existing.HasVar2 = true; existing.Var2Lo = loHz; existing.Var2Hi = hiHz; }
+            existing.UpdatedUtc = DateTime.UtcNow;
+            _entries.Insert(existing);
+        }
+        else
+        {
+            if (slotName == "VAR1") { existing.HasVar1 = true; existing.Var1Lo = loHz; existing.Var1Hi = hiHz; }
+            else                    { existing.HasVar2 = true; existing.Var2Lo = loHz; existing.Var2Hi = hiHz; }
+            existing.UpdatedUtc = DateTime.UtcNow;
+            _entries.Update(existing);
+        }
+    }
+
+    public string? GetLastSelectedPreset(RxMode mode)
+    {
+        var e = _entries.FindOne(x => x.ModeKey == mode.ToString());
+        return e?.LastPreset;
+    }
+
+    public void UpsertLastSelectedPreset(RxMode mode, string presetName)
+    {
+        var key = mode.ToString();
+        var existing = _entries.FindOne(x => x.ModeKey == key);
+        if (existing is null)
+        {
+            _entries.Insert(new FilterPresetStoreEntry
+            {
+                ModeKey = key,
+                LastPreset = presetName,
+                UpdatedUtc = DateTime.UtcNow,
+            });
+        }
+        else
+        {
+            existing.LastPreset = presetName;
+            existing.UpdatedUtc = DateTime.UtcNow;
+            _entries.Update(existing);
+        }
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    // Seed USB and LSB VAR1 with Zeus's 150/2850 default on first run so the
+    // operator sees a familiar starting point (PRD §9 decision).
+    private void SeedDefaults()
+    {
+        SeedVarIfAbsent(RxMode.USB, "VAR1",  150,  2850);
+        SeedVarIfAbsent(RxMode.LSB, "VAR1", -2850, -150);
+    }
+
+    private void SeedVarIfAbsent(RxMode mode, string slotName, int loHz, int hiHz)
+    {
+        var key = mode.ToString();
+        var existing = _entries.FindOne(x => x.ModeKey == key);
+        if (existing is null)
+        {
+            var entry = new FilterPresetStoreEntry
+            {
+                ModeKey = key,
+                UpdatedUtc = DateTime.UtcNow,
+            };
+            if (slotName == "VAR1") { entry.HasVar1 = true; entry.Var1Lo = loHz; entry.Var1Hi = hiHz; }
+            else                    { entry.HasVar2 = true; entry.Var2Lo = loHz; entry.Var2Hi = hiHz; }
+            _entries.Insert(entry);
+        }
+        else if (slotName == "VAR1" && !existing.HasVar1)
+        {
+            existing.HasVar1 = true;
+            existing.Var1Lo = loHz;
+            existing.Var1Hi = hiHz;
+            _entries.Update(existing);
+        }
+        else if (slotName == "VAR2" && !existing.HasVar2)
+        {
+            existing.HasVar2 = true;
+            existing.Var2Lo = loHz;
+            existing.Var2Hi = hiHz;
+            _entries.Update(existing);
+        }
+    }
+
+    private static string GetDatabasePath()
+    {
+        var appDataDir = Environment.GetFolderPath(
+            Environment.SpecialFolder.LocalApplicationData,
+            Environment.SpecialFolderOption.Create);
+        return Path.Combine(appDataDir, "Zeus", "zeus-prefs.db");
+    }
+}
+
+public sealed class FilterPresetStoreEntry
+{
+    public int Id { get; set; }
+    public string ModeKey { get; set; } = string.Empty;
+    public int Var1Lo { get; set; }
+    public int Var1Hi { get; set; }
+    public bool HasVar1 { get; set; }
+    public int Var2Lo { get; set; }
+    public int Var2Hi { get; set; }
+    public bool HasVar2 { get; set; }
+    public string? LastPreset { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server/FilterPresetStore.cs
+++ b/Zeus.Server/FilterPresetStore.cs
@@ -22,13 +22,37 @@ namespace Zeus.Server;
 // (PRD §9 open question: preserve Zeus's low-cut as VAR1 on first run).
 public sealed class FilterPresetStore : IDisposable
 {
+    // BsonMapper.Global is a shared, lazily-built entity map. When multiple
+    // WebApplicationFactory hosts boot in parallel (xUnit test collections),
+    // concurrent first-touches of a type can lose the race with EnsureIndex's
+    // LINQ resolver and throw "Member X not found on BsonMapper". Force the
+    // entity mapping to be materialized once, under a static lock, before any
+    // collection constructs a LINQ expression that walks its members.
+    private static readonly object _mapperInitLock = new();
+    private static bool _mapperInitialized;
+
+    private static void EnsureMapperRegistered()
+    {
+        if (_mapperInitialized) return;
+        lock (_mapperInitLock)
+        {
+            if (_mapperInitialized) return;
+            BsonMapper.Global.Entity<FilterPresetStoreEntry>()
+                .Id(x => x.Id);
+            _mapperInitialized = true;
+        }
+    }
+
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<FilterPresetStoreEntry> _entries;
     private readonly ILogger<FilterPresetStore> _log;
+    private readonly object _sync = new();
 
     public FilterPresetStore(ILogger<FilterPresetStore> log)
     {
         _log = log;
+        EnsureMapperRegistered();
+
         var dbPath = GetDatabasePath();
 
         var dir = Path.GetDirectoryName(dbPath);
@@ -37,73 +61,125 @@ public sealed class FilterPresetStore : IDisposable
 
         _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
         _entries = _db.GetCollection<FilterPresetStoreEntry>("filter_presets");
-        _entries.EnsureIndex(x => x.ModeKey, unique: true);
+        _entries.EnsureIndex("ModeKey", "$.ModeKey", unique: true);
 
         SeedDefaults();
         _log.LogInformation("FilterPresetStore initialized at {Path}", dbPath);
     }
 
+    private FilterPresetStoreEntry? FindByMode(string key) =>
+        _entries.FindOne("$.ModeKey = @0", key);
+
     // Returns the stored override for a VAR slot, or null if not overridden.
     public (int LowHz, int HighHz)? GetVarOverride(RxMode mode, string slotName)
     {
-        var e = _entries.FindOne(x => x.ModeKey == mode.ToString());
-        if (e is null) return null;
-        return slotName == "VAR1"
-            ? (e.HasVar1 ? (e.Var1Lo, e.Var1Hi) : null)
-            : slotName == "VAR2"
-                ? (e.HasVar2 ? (e.Var2Lo, e.Var2Hi) : null)
-                : null;
+        lock (_sync)
+        {
+            var e = FindByMode(mode.ToString());
+            if (e is null) return null;
+            return slotName == "VAR1"
+                ? (e.HasVar1 ? (e.Var1Lo, e.Var1Hi) : null)
+                : slotName == "VAR2"
+                    ? (e.HasVar2 ? (e.Var2Lo, e.Var2Hi) : null)
+                    : null;
+        }
     }
 
     public void UpsertVarOverride(RxMode mode, string slotName, int loHz, int hiHz)
     {
         var key = mode.ToString();
-        var existing = _entries.FindOne(x => x.ModeKey == key);
-        if (existing is null)
+        lock (_sync)
         {
-            existing = new FilterPresetStoreEntry { ModeKey = key };
-            if (slotName == "VAR1") { existing.HasVar1 = true; existing.Var1Lo = loHz; existing.Var1Hi = hiHz; }
-            else                    { existing.HasVar2 = true; existing.Var2Lo = loHz; existing.Var2Hi = hiHz; }
-            existing.UpdatedUtc = DateTime.UtcNow;
-            _entries.Insert(existing);
-        }
-        else
-        {
-            if (slotName == "VAR1") { existing.HasVar1 = true; existing.Var1Lo = loHz; existing.Var1Hi = hiHz; }
-            else                    { existing.HasVar2 = true; existing.Var2Lo = loHz; existing.Var2Hi = hiHz; }
-            existing.UpdatedUtc = DateTime.UtcNow;
-            _entries.Update(existing);
+            var existing = FindByMode(key);
+            if (existing is null)
+            {
+                existing = new FilterPresetStoreEntry { ModeKey = key };
+                if (slotName == "VAR1") { existing.HasVar1 = true; existing.Var1Lo = loHz; existing.Var1Hi = hiHz; }
+                else                    { existing.HasVar2 = true; existing.Var2Lo = loHz; existing.Var2Hi = hiHz; }
+                existing.UpdatedUtc = DateTime.UtcNow;
+                _entries.Insert(existing);
+            }
+            else
+            {
+                if (slotName == "VAR1") { existing.HasVar1 = true; existing.Var1Lo = loHz; existing.Var1Hi = hiHz; }
+                else                    { existing.HasVar2 = true; existing.Var2Lo = loHz; existing.Var2Hi = hiHz; }
+                existing.UpdatedUtc = DateTime.UtcNow;
+                _entries.Update(existing);
+            }
         }
     }
 
     public string? GetLastSelectedPreset(RxMode mode)
     {
-        var e = _entries.FindOne(x => x.ModeKey == mode.ToString());
-        return e?.LastPreset;
+        lock (_sync)
+        {
+            return FindByMode(mode.ToString())?.LastPreset;
+        }
     }
 
     public void UpsertLastSelectedPreset(RxMode mode, string presetName)
     {
         var key = mode.ToString();
-        var existing = _entries.FindOne(x => x.ModeKey == key);
-        if (existing is null)
+        lock (_sync)
         {
-            _entries.Insert(new FilterPresetStoreEntry
+            var existing = FindByMode(key);
+            if (existing is null)
             {
-                ModeKey = key,
-                LastPreset = presetName,
-                UpdatedUtc = DateTime.UtcNow,
-            });
-        }
-        else
-        {
-            existing.LastPreset = presetName;
-            existing.UpdatedUtc = DateTime.UtcNow;
-            _entries.Update(existing);
+                _entries.Insert(new FilterPresetStoreEntry
+                {
+                    ModeKey = key,
+                    LastPreset = presetName,
+                    UpdatedUtc = DateTime.UtcNow,
+                });
+            }
+            else
+            {
+                existing.LastPreset = presetName;
+                existing.UpdatedUtc = DateTime.UtcNow;
+                _entries.Update(existing);
+            }
         }
     }
 
     public void Dispose() => _db.Dispose();
+
+    // Sentinel mode key used for pane-visibility and other ribbon-scope flags
+    // that aren't tied to any particular RX mode. Keeps the schema flat while
+    // avoiding a second LiteDB collection just for a bool.
+    private const string SettingsKey = "__SETTINGS__";
+
+    // Advanced-ribbon visibility, persisted across server restarts so the
+    // operator's close-the-ribbon choice sticks.
+    public bool GetAdvancedPaneOpen()
+    {
+        lock (_sync)
+        {
+            return FindByMode(SettingsKey)?.AdvancedPaneOpen ?? false;
+        }
+    }
+
+    public void SetAdvancedPaneOpen(bool open)
+    {
+        lock (_sync)
+        {
+            var existing = FindByMode(SettingsKey);
+            if (existing is null)
+            {
+                _entries.Insert(new FilterPresetStoreEntry
+                {
+                    ModeKey = SettingsKey,
+                    AdvancedPaneOpen = open,
+                    UpdatedUtc = DateTime.UtcNow,
+                });
+            }
+            else
+            {
+                existing.AdvancedPaneOpen = open;
+                existing.UpdatedUtc = DateTime.UtcNow;
+                _entries.Update(existing);
+            }
+        }
+    }
 
     // Seed USB and LSB VAR1 with Zeus's 150/2850 default on first run so the
     // operator sees a familiar starting point (PRD §9 decision).
@@ -116,7 +192,7 @@ public sealed class FilterPresetStore : IDisposable
     private void SeedVarIfAbsent(RxMode mode, string slotName, int loHz, int hiHz)
     {
         var key = mode.ToString();
-        var existing = _entries.FindOne(x => x.ModeKey == key);
+        var existing = FindByMode(key);
         if (existing is null)
         {
             var entry = new FilterPresetStoreEntry
@@ -164,5 +240,7 @@ public sealed class FilterPresetStoreEntry
     public int Var2Hi { get; set; }
     public bool HasVar2 { get; set; }
     public string? LastPreset { get; set; }
+    // Ribbon-scope flag, only meaningful on the sentinel "__SETTINGS__" row.
+    public bool AdvancedPaneOpen { get; set; }
     public DateTime UpdatedUtc { get; set; }
 }

--- a/Zeus.Server/FilterPresets.cs
+++ b/Zeus.Server/FilterPresets.cs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is an independent reimplementation in .NET — not a fork.
+// Thetis is the authoritative reference; see ATTRIBUTIONS.md.
+
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+// Thetis default filter preset tables from console.cs:5182–5585
+// InitFilterPresets. Numbers are signed Hz VFO-relative. CW uses
+// default cw_pitch=600 Hz. DIGL/DIGU use default offset=0.
+// Reference: docs/proposals/research/thetis-filter-ux.md §2.
+public static class FilterPresets
+{
+    private const int CwPitch = 600;
+
+    private static readonly FilterPresetEntry[] Lsb =
+    [
+        new("F1",   "5.0k", -5100, -100,  false),
+        new("F2",   "4.4k", -4500, -100,  false),
+        new("F3",   "3.8k", -3900, -100,  false),
+        new("F4",   "3.3k", -3400, -100,  false),
+        new("F5",   "2.9k", -3000, -100,  false),
+        new("F6",   "2.7k", -2800, -100,  false),
+        new("F7",   "2.4k", -2500, -100,  false),
+        new("F8",   "2.1k", -2200, -100,  false),
+        new("F9",   "1.8k", -1900, -100,  false),
+        new("F10",  "1.0k", -1100, -100,  false),
+        new("VAR1", "Var 1", -2800, -100, true),
+        new("VAR2", "Var 2", -2800, -100, true),
+    ];
+
+    private static readonly FilterPresetEntry[] Usb =
+    [
+        new("F1",   "5.0k",  100, 5100,  false),
+        new("F2",   "4.4k",  100, 4500,  false),
+        new("F3",   "3.8k",  100, 3900,  false),
+        new("F4",   "3.3k",  100, 3400,  false),
+        new("F5",   "2.9k",  100, 3000,  false),
+        new("F6",   "2.7k",  100, 2800,  false),
+        new("F7",   "2.4k",  100, 2500,  false),
+        new("F8",   "2.1k",  100, 2200,  false),
+        new("F9",   "1.8k",  100, 1900,  false),
+        new("F10",  "1.0k",  100, 1100,  false),
+        new("VAR1", "Var 1",  100, 2800, true),
+        new("VAR2", "Var 2",  100, 2800, true),
+    ];
+
+    private static readonly FilterPresetEntry[] Cwl =
+    [
+        // low = -cw_pitch - half, high = -cw_pitch + half
+        new("F1",   "1.0k", -(CwPitch + 500), -(CwPitch - 500), false),
+        new("F2",   "800",  -(CwPitch + 400), -(CwPitch - 400), false),
+        new("F3",   "600",  -(CwPitch + 300), -(CwPitch - 300), false),
+        new("F4",   "500",  -(CwPitch + 250), -(CwPitch - 250), false),
+        new("F5",   "400",  -(CwPitch + 200), -(CwPitch - 200), false),
+        new("F6",   "250",  -(CwPitch + 125), -(CwPitch - 125), false),
+        new("F7",   "150",  -(CwPitch +  75), -(CwPitch -  75), false),
+        new("F8",   "100",  -(CwPitch +  50), -(CwPitch -  50), false),
+        new("F9",   "50",   -(CwPitch +  25), -(CwPitch -  25), false),
+        new("F10",  "25",   -(CwPitch +  13), -(CwPitch -  13), false),
+        new("VAR1", "Var 1", -(CwPitch + 250), -(CwPitch - 250), true),
+        new("VAR2", "Var 2", -(CwPitch + 250), -(CwPitch - 250), true),
+    ];
+
+    private static readonly FilterPresetEntry[] Cwu =
+    [
+        // low = cw_pitch - half, high = cw_pitch + half
+        new("F1",   "1.0k", CwPitch - 500, CwPitch + 500, false),
+        new("F2",   "800",  CwPitch - 400, CwPitch + 400, false),
+        new("F3",   "600",  CwPitch - 300, CwPitch + 300, false),
+        new("F4",   "500",  CwPitch - 250, CwPitch + 250, false),
+        new("F5",   "400",  CwPitch - 200, CwPitch + 200, false),
+        new("F6",   "250",  CwPitch - 125, CwPitch + 125, false),
+        new("F7",   "150",  CwPitch -  75, CwPitch +  75, false),
+        new("F8",   "100",  CwPitch -  50, CwPitch +  50, false),
+        new("F9",   "50",   CwPitch -  25, CwPitch +  25, false),
+        new("F10",  "25",   CwPitch -  13, CwPitch +  13, false),
+        new("VAR1", "Var 1", CwPitch - 250, CwPitch + 250, true),
+        new("VAR2", "Var 2", CwPitch - 250, CwPitch + 250, true),
+    ];
+
+    private static readonly FilterPresetEntry[] Am =
+    [
+        new("F1",   "20k",  -10000, 10000, false),
+        new("F2",   "18k",  -9000,   9000, false),
+        new("F3",   "16k",  -8000,   8000, false),
+        new("F4",   "12k",  -6000,   6000, false),
+        new("F5",   "10k",  -5000,   5000, false),
+        new("F6",   "9.0k", -4500,   4500, false),
+        new("F7",   "8.0k", -4000,   4000, false),
+        new("F8",   "7.0k", -3500,   3500, false),
+        new("F9",   "6.0k", -3000,   3000, false),
+        new("F10",  "5.0k", -2500,   2500, false),
+        new("VAR1", "Var 1", -3000,  3000, true),
+        new("VAR2", "Var 2", -3000,  3000, true),
+    ];
+
+    // SAM table is identical to AM in Thetis (console.cs:5493–5534)
+    private static readonly FilterPresetEntry[] Sam = Am
+        .Select(e => e with { SlotName = e.SlotName, Label = e.Label })
+        .ToArray();
+
+    private static readonly FilterPresetEntry[] Dsb =
+    [
+        new("F1",   "16k",  -8000,  8000, false),
+        new("F2",   "12k",  -6000,  6000, false),
+        new("F3",   "10k",  -5000,  5000, false),
+        new("F4",   "8.0k", -4000,  4000, false),
+        new("F5",   "6.6k", -3300,  3300, false),
+        new("F6",   "5.2k", -2600,  2600, false),
+        new("F7",   "4.0k", -2000,  2000, false),
+        new("F8",   "3.1k", -1550,  1550, false),
+        new("F9",   "2.9k", -1450,  1450, false),
+        new("F10",  "2.4k", -1200,  1200, false),
+        new("VAR1", "Var 1", -3300, 3300, true),
+        new("VAR2", "Var 2", -3300, 3300, true),
+    ];
+
+    // DIGL centered on -digl_click_tune_offset (default 0)
+    private static readonly FilterPresetEntry[] Digl =
+    [
+        new("F1",   "3.0k", -1500,  1500, false),
+        new("F2",   "2.5k", -1250,  1250, false),
+        new("F3",   "2.0k", -1000,  1000, false),
+        new("F4",   "1.5k",  -750,   750, false),
+        new("F5",   "1.0k",  -500,   500, false),
+        new("F6",   "800",   -400,   400, false),
+        new("F7",   "600",   -300,   300, false),
+        new("F8",   "300",   -150,   150, false),
+        new("F9",   "150",    -75,    75, false),
+        new("F10",  "75",     -38,    38, false),
+        new("VAR1", "Var 1",  -400,  400, true),
+        new("VAR2", "Var 2",  -400,  400, true),
+    ];
+
+    // DIGU mirror of DIGL
+    private static readonly FilterPresetEntry[] Digu = Digl
+        .Select(e => e with { SlotName = e.SlotName, Label = e.Label })
+        .ToArray();
+
+    // FM has no operator-editable presets in Thetis; return empty.
+    private static readonly FilterPresetEntry[] Fm = [];
+
+    public static IReadOnlyList<FilterPresetEntry> DefaultsForMode(RxMode mode) => mode switch
+    {
+        RxMode.LSB  => Lsb,
+        RxMode.USB  => Usb,
+        RxMode.CWL  => Cwl,
+        RxMode.CWU  => Cwu,
+        RxMode.AM   => Am,
+        RxMode.SAM  => Sam,
+        RxMode.DSB  => Dsb,
+        RxMode.DIGL => Digl,
+        RxMode.DIGU => Digu,
+        RxMode.FM   => Fm,
+        _           => Usb,
+    };
+}
+
+public sealed record FilterPresetEntry(
+    string SlotName,
+    string Label,
+    int LowHz,
+    int HighHz,
+    bool IsVar);

--- a/Zeus.Server/Program.cs
+++ b/Zeus.Server/Program.cs
@@ -127,6 +127,7 @@ builder.Services.AddSingleton<BandMemoryStore>();
 builder.Services.AddSingleton<LayoutStore>();
 builder.Services.AddSingleton<DspSettingsStore>();
 builder.Services.AddSingleton<PaSettingsStore>();
+builder.Services.AddSingleton<FilterPresetStore>();
 builder.Services.AddSingleton<QrzService>();
 builder.Services.AddSingleton<LogService>();
 
@@ -374,6 +375,33 @@ app.MapPost("/api/bandwidth", (BandwidthSetRequest req, RadioService r) =>
 {
     log.LogInformation("api.bandwidth low={L} high={H}", req.Low, req.High);
     return r.SetFilter(req.Low, req.High);
+});
+
+// Filter preset endpoints (PRD §5.2). These are the preferred filter surface;
+// /api/bandwidth remains for backward compat. POST /api/filter also accepts
+// an optional PresetName to track which chip is active.
+app.MapPost("/api/filter", (FilterSetRequest req, RadioService r) =>
+{
+    log.LogInformation("api.filter low={L} high={H} preset={P}", req.LowHz, req.HighHz, req.PresetName);
+    return r.SetFilter(req.LowHz, req.HighHz, req.PresetName);
+});
+
+app.MapGet("/api/filter/presets", (string? mode, RadioService r) =>
+{
+    if (mode is null || !Enum.TryParse<RxMode>(mode, ignoreCase: true, out var rxMode))
+        return Results.BadRequest(new { error = $"Unknown mode '{mode}'. Expected one of: {string.Join(", ", Enum.GetNames<RxMode>())}" });
+    return Results.Ok(r.GetFilterPresets(rxMode));
+});
+
+app.MapPost("/api/filter/presets", (FilterPresetWriteRequest req, RadioService r) =>
+{
+    log.LogInformation("api.filter.presets mode={M} slot={S} low={L} high={H}", req.Mode, req.SlotName, req.LowHz, req.HighHz);
+    if (req.SlotName is not ("VAR1" or "VAR2"))
+        return Results.Conflict(new { error = "Fixed presets cannot be edited. Only VAR1 and VAR2 slots are writable." });
+    if (!Enum.IsDefined(req.Mode))
+        return Results.BadRequest(new { error = $"Unknown mode '{req.Mode}'." });
+    r.SetFilterPresetOverride(req.Mode, req.SlotName, req.LowHz, req.HighHz);
+    return Results.Ok(r.GetFilterPresets(req.Mode));
 });
 
 app.MapPost("/api/sampleRate", (SampleRateSetRequest req, RadioService r) =>

--- a/Zeus.Server/Program.cs
+++ b/Zeus.Server/Program.cs
@@ -404,6 +404,14 @@ app.MapPost("/api/filter/presets", (FilterPresetWriteRequest req, RadioService r
     return Results.Ok(r.GetFilterPresets(req.Mode));
 });
 
+// Advanced-ribbon pane visibility. Persisted via FilterPresetStore so the
+// operator's close-the-ribbon choice survives a Zeus.Server restart.
+app.MapPost("/api/filter/advanced-pane", (FilterAdvancedPaneRequest req, RadioService r) =>
+{
+    log.LogInformation("api.filter.advancedPane open={Open}", req.Open);
+    return r.SetFilterAdvancedPaneOpen(req.Open);
+});
+
 app.MapPost("/api/sampleRate", (SampleRateSetRequest req, RadioService r) =>
 {
     log.LogInformation("api.sampleRate rate={Rate}", req.Rate);

--- a/Zeus.Server/RadioService.cs
+++ b/Zeus.Server/RadioService.cs
@@ -53,6 +53,10 @@ public sealed class RadioService : IDisposable
     private readonly ILogger<RadioService> _log;
     private readonly DspSettingsStore _dspSettingsStore;
     private readonly PaSettingsStore _paStore;
+    private readonly FilterPresetStore? _filterPresetStore;
+    // Last-known preset name per mode, preserved across mode switches.
+    // Accessed only from inside Mutate (under _sync) or at init.
+    private readonly Dictionary<RxMode, string?> _lastPresetPerMode = new();
     // Last-commanded slider value in UI percent (0..100). Needed here because
     // the drive byte depends on three inputs — percent, per-band PA gain, and
     // global max-watts — any of which can change independently. When a band
@@ -117,17 +121,26 @@ public sealed class RadioService : IDisposable
     // to its internal test-tone generator (dev / tests without a hub).
     private readonly Zeus.Protocol1.ITxIqSource? _txIqSource;
 
-    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, Zeus.Protocol1.ITxIqSource? txIqSource = null)
+    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, FilterPresetStore? filterPresetStore = null, Zeus.Protocol1.ITxIqSource? txIqSource = null)
     {
         _loggerFactory = loggerFactory;
         _log = loggerFactory.CreateLogger<RadioService>();
         _dspSettingsStore = dspSettingsStore;
         _paStore = paStore;
+        _filterPresetStore = filterPresetStore;
         _paStore.Changed += RecomputePaAndPush;
         _txIqSource = txIqSource;
 
         // Load persisted DSP settings from the store, or use defaults if not found
         var persistedNr = _dspSettingsStore.Get() ?? new NrConfig();
+
+        // Seed the last-preset cache from persisted store for all modes so
+        // the first mode-switch in a session recalls the correct slot.
+        if (filterPresetStore != null)
+        {
+            foreach (RxMode m in Enum.GetValues<RxMode>())
+                _lastPresetPerMode[m] = filterPresetStore.GetLastSelectedPreset(m);
+        }
 
         _state = new(
             Status: ConnectionStatus.Disconnected,
@@ -143,7 +156,9 @@ public sealed class RadioService : IDisposable
             ZoomLevel: 1,
             AutoAttEnabled: true,
             AttOffsetDb: 0,
-            AdcOverloadWarning: false);
+            AdcOverloadWarning: false,
+            // Zeus default filter (150/2850) maps to the seeded USB VAR1 slot.
+            FilterPresetName: "VAR1");
     }
 
     public IProtocol1Client? ActiveClient
@@ -271,8 +286,16 @@ public sealed class RadioService : IDisposable
 
     public StateDto SetMode(RxMode mode)
     {
+        RxMode departingMode = default;
+        string? departingPreset = null;
         Mutate(s =>
         {
+            departingMode = s.Mode;
+            departingPreset = s.FilterPresetName;
+
+            // Save departing mode's preset name to the in-memory cache.
+            _lastPresetPerMode[s.Mode] = s.FilterPresetName;
+
             // 1) Save current abs-filter into the mode we are LEAVING.
             int curLoAbs = Math.Min(Math.Abs(s.FilterLowHz), Math.Abs(s.FilterHighHz));
             int curHiAbs = Math.Max(Math.Abs(s.FilterLowHz), Math.Abs(s.FilterHighHz));
@@ -283,15 +306,54 @@ public sealed class RadioService : IDisposable
 
             // 3) Re-sign per target mode's sideband convention.
             var (lo, hi) = SignedFilterForMode(mode, fam.LoAbs, fam.HiAbs);
-            return s with { Mode = mode, FilterLowHz = lo, FilterHighHz = hi };
+
+            // 4) Restore the last-known preset name for the incoming mode.
+            _lastPresetPerMode.TryGetValue(mode, out var restoredPreset);
+            return s with { Mode = mode, FilterLowHz = lo, FilterHighHz = hi, FilterPresetName = restoredPreset };
         });
+
+        // Persist the departing mode's last preset outside the lock.
+        if (departingPreset != null)
+            _filterPresetStore?.UpsertLastSelectedPreset(departingMode, departingPreset);
+
         return Snapshot();
     }
 
-    public StateDto SetFilter(int lowHz, int highHz)
+    public StateDto SetFilter(int lowHz, int highHz, string? presetName = null)
     {
         if (highHz < lowHz) (lowHz, highHz) = (highHz, lowHz);
-        Mutate(s => s with { FilterLowHz = lowHz, FilterHighHz = highHz });
+        RxMode modeAtSet = RxMode.USB;
+        Mutate(s =>
+        {
+            modeAtSet = s.Mode;
+            if (presetName != null) _lastPresetPerMode[s.Mode] = presetName;
+            return s with { FilterLowHz = lowHz, FilterHighHz = highHz, FilterPresetName = presetName };
+        });
+        if (presetName != null)
+            _filterPresetStore?.UpsertLastSelectedPreset(modeAtSet, presetName);
+        return Snapshot();
+    }
+
+    public IReadOnlyList<FilterPresetDto> GetFilterPresets(RxMode mode)
+    {
+        var defaults = FilterPresets.DefaultsForMode(mode);
+        return defaults.Select(e =>
+        {
+            if (e.IsVar && _filterPresetStore != null)
+            {
+                var stored = _filterPresetStore.GetVarOverride(mode, e.SlotName);
+                if (stored.HasValue)
+                    return new FilterPresetDto(e.SlotName, e.Label, stored.Value.LowHz, stored.Value.HighHz, true);
+            }
+            return new FilterPresetDto(e.SlotName, e.Label, e.LowHz, e.HighHz, e.IsVar);
+        }).ToList();
+    }
+
+    public StateDto SetFilterPresetOverride(RxMode mode, string slotName, int loHz, int hiHz)
+    {
+        if (slotName is not ("VAR1" or "VAR2"))
+            throw new InvalidOperationException("Only VAR1 and VAR2 slots can be overridden.");
+        _filterPresetStore?.UpsertVarOverride(mode, slotName, loHz, hiHz);
         return Snapshot();
     }
 

--- a/Zeus.Server/RadioService.cs
+++ b/Zeus.Server/RadioService.cs
@@ -158,7 +158,17 @@ public sealed class RadioService : IDisposable
             AttOffsetDb: 0,
             AdcOverloadWarning: false,
             // Zeus default filter (150/2850) maps to the seeded USB VAR1 slot.
-            FilterPresetName: "VAR1");
+            FilterPresetName: "VAR1",
+            FilterAdvancedPaneOpen: filterPresetStore?.GetAdvancedPaneOpen() ?? false);
+    }
+
+    // Ribbon-visibility setter — frontend toggles via REST, server broadcasts
+    // a StateDto so other browser tabs stay in sync.
+    public StateDto SetFilterAdvancedPaneOpen(bool open)
+    {
+        _filterPresetStore?.SetAdvancedPaneOpen(open);
+        Mutate(s => s with { FilterAdvancedPaneOpen = open });
+        return Snapshot();
     }
 
     public IProtocol1Client? ActiveClient

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -51,6 +51,7 @@ import { MicMeter } from './components/MicMeter';
 import { MobilePttButton } from './components/MobilePttButton';
 import { MobileZoomSlider } from './components/MobileZoomSlider';
 import { ModeBandwidth } from './components/ModeBandwidth';
+import { FilterPanel } from './components/filter/FilterPanel';
 import { MoxButton } from './components/MoxButton';
 import { Panadapter } from './components/Panadapter';
 import { PaTempChip } from './components/PaTempChip';
@@ -625,10 +626,12 @@ export default function App() {
       <div className="control-strip">
         <div className="hide-mobile" style={{ display: 'contents' }}>
           <ModeBandwidth />
+          <FilterPanel />
           <BandButtons />
         </div>
         <div className="show-mobile" style={{ display: 'none', gap: 8 }}>
           <ModeBandwidth />
+          <FilterPanel />
           <BandButtons />
         </div>
         <div className="ctrl-group hide-mobile" style={{ minWidth: 220 }}>

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -52,6 +52,7 @@ import { MobilePttButton } from './components/MobilePttButton';
 import { MobileZoomSlider } from './components/MobileZoomSlider';
 import { ModeBandwidth } from './components/ModeBandwidth';
 import { FilterPanel } from './components/filter/FilterPanel';
+import { FilterRibbon, useFilterRibbonOpenSync } from './components/filter/FilterRibbon';
 import { MoxButton } from './components/MoxButton';
 import { Panadapter } from './components/Panadapter';
 import { PaTempChip } from './components/PaTempChip';
@@ -110,6 +111,7 @@ export default function App() {
 
   useKeyboardShortcuts();
   useMicUplink();
+  useFilterRibbonOpenSync();
 
   useEffect(() => {
     const stop = startRealtime();
@@ -657,6 +659,12 @@ export default function App() {
             <MicGainSlider />
           </div>
         </div>
+      </div>
+
+      {/* Advanced filter ribbon — desktop only. Visibility persists server-side
+          via /api/filter/advanced-pane. On mobile the ribbon is never mounted. */}
+      <div className="hide-mobile">
+        <FilterRibbon />
       </div>
 
       <AlertBanner />

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -90,6 +90,8 @@ export type RadioStateDto = {
   mode: RxMode;
   filterLowHz: number;
   filterHighHz: number;
+  // Null after a drag edit without a named-slot context (PRD §4.1).
+  filterPresetName: string | null;
   sampleRate: number;
   agcTopDb: number;
   attenDb: number;
@@ -98,6 +100,14 @@ export type RadioStateDto = {
   adcOverloadWarning: boolean;
   nr: NrConfigDto;
   zoomLevel: ZoomLevel;
+};
+
+export type FilterPresetDto = {
+  slotName: string;
+  label: string;
+  lowHz: number;
+  highHz: number;
+  isVar: boolean;
 };
 
 export type RadioInfoDto = {
@@ -216,6 +226,7 @@ export function normalizeState(raw: unknown): RadioStateDto {
     mode: normalizeMode(r.mode),
     filterLowHz: typeof r.filterLowHz === 'number' ? r.filterLowHz : 0,
     filterHighHz: typeof r.filterHighHz === 'number' ? r.filterHighHz : 0,
+    filterPresetName: typeof r.filterPresetName === 'string' ? r.filterPresetName : null,
     sampleRate: typeof r.sampleRate === 'number' ? r.sampleRate : 0,
     // Default 80 matches WdspDspEngine.ApplyAgcDefaults and the Thetis
     // AGC_MEDIUM preset. Missing from older servers — tolerate absence.
@@ -408,6 +419,80 @@ export function setBandwidth(
       signal,
     },
     normalizeState,
+  );
+}
+
+// Preferred filter endpoint: includes optional preset name for chip tracking.
+export function setFilter(
+  lowHz: number,
+  highHz: number,
+  presetName?: string,
+  signal?: AbortSignal,
+): Promise<RadioStateDto> {
+  return jsonFetch(
+    '/api/filter',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ lowHz, highHz, presetName: presetName ?? null }),
+      signal,
+    },
+    normalizeState,
+  );
+}
+
+function normalizeFilterPreset(raw: unknown): FilterPresetDto | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.slotName !== 'string' || typeof r.label !== 'string') return null;
+  return {
+    slotName: r.slotName,
+    label: r.label,
+    lowHz: typeof r.lowHz === 'number' ? r.lowHz : 0,
+    highHz: typeof r.highHz === 'number' ? r.highHz : 0,
+    isVar: Boolean(r.isVar),
+  };
+}
+
+export function getFilterPresets(
+  mode: RxMode,
+  signal?: AbortSignal,
+): Promise<FilterPresetDto[]> {
+  return jsonFetch(
+    `/api/filter/presets?mode=${encodeURIComponent(mode)}`,
+    { signal },
+    (raw) => {
+      if (!Array.isArray(raw)) return [];
+      return raw.flatMap((item) => {
+        const p = normalizeFilterPreset(item);
+        return p ? [p] : [];
+      });
+    },
+  );
+}
+
+export function setFilterPresetOverride(
+  mode: RxMode,
+  slotName: string,
+  lowHz: number,
+  highHz: number,
+  signal?: AbortSignal,
+): Promise<FilterPresetDto[]> {
+  return jsonFetch(
+    '/api/filter/presets',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ mode, slotName, lowHz, highHz }),
+      signal,
+    },
+    (raw) => {
+      if (!Array.isArray(raw)) return [];
+      return raw.flatMap((item) => {
+        const p = normalizeFilterPreset(item);
+        return p ? [p] : [];
+      });
+    },
   );
 }
 

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -92,6 +92,8 @@ export type RadioStateDto = {
   filterHighHz: number;
   // Null after a drag edit without a named-slot context (PRD §4.1).
   filterPresetName: string | null;
+  // Advanced-filter ribbon visibility; persisted server-side.
+  filterAdvancedPaneOpen: boolean;
   sampleRate: number;
   agcTopDb: number;
   attenDb: number;
@@ -227,6 +229,7 @@ export function normalizeState(raw: unknown): RadioStateDto {
     filterLowHz: typeof r.filterLowHz === 'number' ? r.filterLowHz : 0,
     filterHighHz: typeof r.filterHighHz === 'number' ? r.filterHighHz : 0,
     filterPresetName: typeof r.filterPresetName === 'string' ? r.filterPresetName : null,
+    filterAdvancedPaneOpen: typeof r.filterAdvancedPaneOpen === 'boolean' ? r.filterAdvancedPaneOpen : false,
     sampleRate: typeof r.sampleRate === 'number' ? r.sampleRate : 0,
     // Default 80 matches WdspDspEngine.ApplyAgcDefaults and the Thetis
     // AGC_MEDIUM preset. Missing from older servers — tolerate absence.
@@ -468,6 +471,22 @@ export function getFilterPresets(
         return p ? [p] : [];
       });
     },
+  );
+}
+
+export function setFilterAdvancedPaneOpen(
+  open: boolean,
+  signal?: AbortSignal,
+): Promise<RadioStateDto> {
+  return jsonFetch(
+    '/api/filter/advanced-pane',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ open }),
+      signal,
+    },
+    normalizeState,
   );
 }
 

--- a/zeus-web/src/components/Panadapter.tsx
+++ b/zeus-web/src/components/Panadapter.tsx
@@ -43,6 +43,7 @@ import { useDisplaySettingsStore } from '../state/display-settings-store';
 import { usePanTuneGesture } from '../util/use-pan-tune-gesture';
 import { FreqAxis } from './FreqAxis';
 import { PassbandOverlay } from './PassbandOverlay';
+import { FilterEdgeDrag } from './filter/FilterEdgeDrag';
 import { DbScale } from './DbScale';
 
 export function Panadapter() {
@@ -175,6 +176,7 @@ export function Panadapter() {
     >
       <canvas ref={canvasRef} style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }} />
       <PassbandOverlay />
+      <FilterEdgeDrag />
       <FreqAxis />
       <DbScale />
     </div>

--- a/zeus-web/src/components/PassbandOverlay.tsx
+++ b/zeus-web/src/components/PassbandOverlay.tsx
@@ -38,13 +38,20 @@
 import { useDisplayStore } from '../state/display-store';
 import { useConnectionStore } from '../state/connection-store';
 
-// Translucent rectangle drawn inside the panadapter container to show the
-// active receive filter passband, mapped from [filterLowHz, filterHighHz]
-// relative to the VFO centre. Asymmetric by design: USB lives to the right
-// of carrier, LSB to the left, CW narrow around zero, AM symmetric.
-// Positioned by percentage of the total span so it tracks resize and tune
-// without measuring DOM width.
-export function PassbandOverlay() {
+type PassbandOverlayProps = {
+  // When true, render the amber fill only (no edge lines). The waterfall
+  // variant uses this; the panadapter carries the resolution for fine
+  // alignment and keeps the edge lines.
+  fillOnly?: boolean;
+};
+
+// Translucent rectangle drawn inside the panadapter/waterfall container to
+// show the active receive filter passband, mapped from [filterLowHz,
+// filterHighHz] relative to the VFO centre. Asymmetric by design: USB lives
+// to the right of carrier, LSB to the left, CW narrow around zero, AM
+// symmetric. Positioned by percentage of the total span so it tracks resize
+// and tune without measuring DOM width.
+export function PassbandOverlay({ fillOnly = false }: PassbandOverlayProps = {}) {
   const centerHz = useDisplayStore((s) => s.centerHz);
   const hzPerPixel = useDisplayStore((s) => s.hzPerPixel);
   const width = useDisplayStore((s) => s.panDb?.length ?? 0);
@@ -73,8 +80,8 @@ export function PassbandOverlay() {
         left: `${leftPct}%`,
         width: `${widthPct}%`,
         background: 'rgba(255, 160, 40, 0.18)',
-        borderLeft: '1px solid rgba(255, 160, 40, 0.6)',
-        borderRight: '1px solid rgba(255, 160, 40, 0.6)',
+        borderLeft: fillOnly ? 'none' : '1px solid rgba(255, 160, 40, 0.6)',
+        borderRight: fillOnly ? 'none' : '1px solid rgba(255, 160, 40, 0.6)',
       }}
     />
   );

--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -41,6 +41,7 @@ import { createWfRenderer } from '../gl/waterfall';
 import { useDisplayStore } from '../state/display-store';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
 import { usePanTuneGesture } from '../util/use-pan-tune-gesture';
+import { PassbandOverlay } from './PassbandOverlay';
 
 // Throttle row uploads so the waterfall scrolls at ~(server tick / N).
 // With a 30 Hz server tick N=2 gives ~15 Hz, which is a comfortable scroll
@@ -167,6 +168,7 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       }}
     >
       <canvas ref={canvasRef} style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }} />
+      <PassbandOverlay fillOnly />
       <div
         className="tuning-cursor"
         style={{ left: '50%', pointerEvents: 'none' }}

--- a/zeus-web/src/components/filter/FilterEdgeDrag.tsx
+++ b/zeus-web/src/components/filter/FilterEdgeDrag.tsx
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Filter visualization PRD §3.3 Phase 3 — drag handles for the main panadapter
+// passband overlay. Renders two thin hit-zones (±4 px around each edge line)
+// that capture pointer-drag and write Lo/Hi through POST /api/filter with
+// client-side rate limiting (20 Hz max). On first drag, auto-flip the active
+// slot to VAR1 if a fixed preset (F*) was selected.
+
+import { useCallback, useRef } from 'react';
+import { useDisplayStore } from '../../state/display-store';
+import { useConnectionStore } from '../../state/connection-store';
+import { setFilter } from '../../api/client';
+
+// Hit-zone width in pixels (±EDGE_HIT_PX from the edge line).
+const EDGE_HIT_PX = 4;
+// Minimum ms between wire writes during a drag.
+const DRAG_MIN_INTERVAL_MS = 50;
+
+type Edge = 'lo' | 'hi';
+
+function presetIsFixed(name: string | null): boolean {
+  return !!name && /^F([1-9]|10)$/.test(name);
+}
+
+export function FilterEdgeDrag() {
+  const centerHz = useDisplayStore((s) => s.centerHz);
+  const hzPerPixel = useDisplayStore((s) => s.hzPerPixel);
+  const width = useDisplayStore((s) => s.panDb?.length ?? 0);
+  const filterLowHz = useConnectionStore((s) => s.filterLowHz);
+  const filterHighHz = useConnectionStore((s) => s.filterHighHz);
+
+  const dragRef = useRef<{
+    edge: Edge;
+    elementWidth: number;
+    elementLeft: number;
+    spanHz: number;
+    centerHz: number;
+    otherEdgeHz: number;
+    activeSlot: string;
+    pendingLo: number;
+    pendingHi: number;
+    lastWriteAt: number;
+    flushTimer: number | null;
+    pointerId: number;
+  } | null>(null);
+
+  // Send the current pending Lo/Hi to the server. Called immediately if
+  // enough time has elapsed since the last write, otherwise scheduled via
+  // setTimeout to coalesce rapid pointer events to ~20 Hz.
+  const flushPending = useCallback(() => {
+    const d = dragRef.current;
+    if (!d) return;
+    d.flushTimer = null;
+    d.lastWriteAt = performance.now();
+    setFilter(d.pendingLo, d.pendingHi, d.activeSlot).catch(() => {});
+  }, []);
+
+  const schedule = useCallback(() => {
+    const d = dragRef.current;
+    if (!d) return;
+    const now = performance.now();
+    const elapsed = now - d.lastWriteAt;
+    if (elapsed >= DRAG_MIN_INTERVAL_MS) {
+      flushPending();
+    } else if (d.flushTimer == null) {
+      d.flushTimer = window.setTimeout(flushPending, DRAG_MIN_INTERVAL_MS - elapsed);
+    }
+  }, [flushPending]);
+
+  const startDrag = useCallback(
+    (edge: Edge) => (e: React.PointerEvent<HTMLDivElement>) => {
+      if (e.button !== 0) return;
+      const parent = e.currentTarget.parentElement;
+      if (!parent) return;
+      const rect = parent.getBoundingClientRect();
+      if (rect.width <= 0 || hzPerPixel <= 0) return;
+
+      e.stopPropagation();
+      e.preventDefault();
+      try { e.currentTarget.setPointerCapture(e.pointerId); } catch { /* ok */ }
+
+      const span = rect.width * hzPerPixel;
+      const currentSlot = useConnectionStore.getState().filterPresetName;
+      // First drag on a fixed preset flips to VAR1 — the contract the server
+      // enforces and the user expects (fixed F* slots don't accept edits).
+      const activeSlot = presetIsFixed(currentSlot) || !currentSlot ? 'VAR1' : currentSlot;
+
+      dragRef.current = {
+        edge,
+        elementWidth: rect.width,
+        elementLeft: rect.left,
+        spanHz: span,
+        centerHz: Number(centerHz),
+        otherEdgeHz: edge === 'lo' ? filterHighHz : filterLowHz,
+        activeSlot,
+        pendingLo: filterLowHz,
+        pendingHi: filterHighHz,
+        lastWriteAt: 0,
+        flushTimer: null,
+        pointerId: e.pointerId,
+      };
+
+      // Optimistic UI: reflect the auto-slot flip immediately.
+      if (activeSlot !== currentSlot) {
+        useConnectionStore.setState({ filterPresetName: activeSlot });
+      }
+    },
+    [centerHz, filterHighHz, filterLowHz, hzPerPixel],
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const d = dragRef.current;
+      if (!d) return;
+      if (e.pointerId !== d.pointerId) return;
+      e.stopPropagation();
+
+      // Client X → Hz offset from VFO. VFO is always centered in the
+      // panadapter/waterfall span, so 0.5 → centerHz.
+      const frac = (e.clientX - d.elementLeft) / d.elementWidth;
+      const hzFromVfo = (frac - 0.5) * d.spanHz;
+
+      let loHz = d.pendingLo;
+      let hiHz = d.pendingHi;
+      if (d.edge === 'lo') {
+        loHz = Math.round(hzFromVfo);
+        // Don't let Lo exceed Hi - 50 Hz (an inverted filter is a WDSP error).
+        if (loHz > d.otherEdgeHz - 50) loHz = d.otherEdgeHz - 50;
+      } else {
+        hiHz = Math.round(hzFromVfo);
+        if (hiHz < d.otherEdgeHz + 50) hiHz = d.otherEdgeHz + 50;
+      }
+
+      d.pendingLo = loHz;
+      d.pendingHi = hiHz;
+
+      // Optimistic UI so the shaded rectangle moves with the cursor without
+      // waiting for the server round-trip to echo back.
+      useConnectionStore.setState({ filterLowHz: loHz, filterHighHz: hiHz });
+
+      schedule();
+    },
+    [schedule],
+  );
+
+  const endDrag = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const d = dragRef.current;
+      if (!d || e.pointerId !== d.pointerId) return;
+      e.stopPropagation();
+
+      if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+        try { e.currentTarget.releasePointerCapture(e.pointerId); } catch { /* ok */ }
+      }
+
+      if (d.flushTimer != null) {
+        clearTimeout(d.flushTimer);
+        d.flushTimer = null;
+      }
+
+      // Final commit — always send, even if the throttle would otherwise
+      // block it, and sync back through applyState so the server is
+      // authoritative on the final value.
+      const lo = d.pendingLo;
+      const hi = d.pendingHi;
+      const slot = d.activeSlot;
+      dragRef.current = null;
+      const applyState = useConnectionStore.getState().applyState;
+      setFilter(lo, hi, slot)
+        .then(applyState)
+        .catch(() => { /* next state poll reconciles */ });
+    },
+    [],
+  );
+
+  if (!width || hzPerPixel <= 0) return null;
+
+  const spanHz = width * hzPerPixel;
+  const startHz = Number(centerHz) - spanHz / 2;
+  const passLowHz = Number(centerHz) + filterLowHz;
+  const passHighHz = Number(centerHz) + filterHighHz;
+  const leftPct = ((passLowHz - startHz) / spanHz) * 100;
+  const rightPct = ((passHighHz - startHz) / spanHz) * 100;
+
+  // Render edge handles only when the edges are actually on-screen. Off-screen
+  // edges can't be dragged; no hit-zone rendered.
+  const loOnScreen = leftPct >= 0 && leftPct <= 100;
+  const hiOnScreen = rightPct >= 0 && rightPct <= 100;
+
+  const handleStyleBase: React.CSSProperties = {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    width: `${EDGE_HIT_PX * 2}px`,
+    marginLeft: `-${EDGE_HIT_PX}px`,
+    cursor: 'ew-resize',
+    // Transparent hit zone. The visible amber line is drawn by PassbandOverlay.
+    background: 'transparent',
+    zIndex: 7,
+    touchAction: 'none',
+  };
+
+  return (
+    <>
+      {loOnScreen && (
+        <div
+          aria-label="Drag to adjust filter low edge"
+          style={{ ...handleStyleBase, left: `${leftPct}%` }}
+          onPointerDown={startDrag('lo')}
+          onPointerMove={onPointerMove}
+          onPointerUp={endDrag}
+          onPointerCancel={endDrag}
+        />
+      )}
+      {hiOnScreen && (
+        <div
+          aria-label="Drag to adjust filter high edge"
+          style={{ ...handleStyleBase, left: `${rightPct}%` }}
+          onPointerDown={startDrag('hi')}
+          onPointerMove={onPointerMove}
+          onPointerUp={endDrag}
+          onPointerCancel={endDrag}
+        />
+      )}
+    </>
+  );
+}

--- a/zeus-web/src/components/filter/FilterMiniPan.tsx
+++ b/zeus-web/src/components/filter/FilterMiniPan.tsx
@@ -1,0 +1,342 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Filter visualization PRD §3.2.1 — mini-panadapter inside the advanced
+// filter ribbon. Renders a 10 kHz-span spectrum strip centered on the VFO,
+// with a translucent amber passband overlay and edge-drag handles.
+//
+// Implementation note: uses Canvas 2D rather than a second WebGL context.
+// At the ribbon's small target size (~640×80 px) the 2D path comfortably
+// hits the <2 ms/frame target on integrated GPUs without the complexity of
+// scissor-clipping the main canvas. If a future profile shows 2D as the
+// bottleneck we can swap in a shared-context GL renderer without changing
+// the component's surface.
+
+import { useEffect, useRef } from 'react';
+import { useDisplayStore } from '../../state/display-store';
+import { useConnectionStore } from '../../state/connection-store';
+import { setFilter } from '../../api/client';
+
+const RIBBON_SPAN_HZ = 10_000;
+const DB_FLOOR = -130;
+const DB_CEIL = -30;
+const DRAG_MIN_INTERVAL_MS = 50;
+const EDGE_HIT_PX = 6;
+
+type DragMode = 'lo' | 'hi' | 'inside';
+
+function presetIsFixed(name: string | null): boolean {
+  return !!name && /^F([1-9]|10)$/.test(name);
+}
+
+export function FilterMiniPan() {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const dragRef = useRef<{
+    mode: DragMode;
+    rect: DOMRect;
+    activeSlot: string;
+    startLoHz: number;
+    startHiHz: number;
+    startX: number;
+    pendingLo: number;
+    pendingHi: number;
+    lastWriteAt: number;
+    flushTimer: number | null;
+    pointerId: number;
+  } | null>(null);
+
+  // Subscribe imperatively to avoid a React re-render per frame — we paint
+  // from display-store snapshots whenever the frame seq ticks.
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d', { alpha: false });
+    if (!ctx) return;
+
+    let rafHandle = 0;
+    let lastSeq = -1;
+
+    const draw = () => {
+      rafHandle = 0;
+      const d = useDisplayStore.getState();
+      const c = useConnectionStore.getState();
+      if (d.lastSeq === lastSeq) return;
+      lastSeq = d.lastSeq;
+
+      // Size canvas to its CSS box. Guarded against zero-sized offscreen
+      // mounts during the first paint.
+      const dpr = window.devicePixelRatio || 1;
+      const cssW = canvas.clientWidth;
+      const cssH = canvas.clientHeight;
+      if (cssW <= 0 || cssH <= 0) return;
+      const w = Math.floor(cssW * dpr);
+      const h = Math.floor(cssH * dpr);
+      if (canvas.width !== w) canvas.width = w;
+      if (canvas.height !== h) canvas.height = h;
+
+      // Fill background.
+      ctx.fillStyle = '#000';
+      ctx.fillRect(0, 0, w, h);
+
+      const panDb = d.panDb;
+      const binsPerHz = d.hzPerPixel > 0 ? 1 / d.hzPerPixel : 0;
+
+      if (panDb && binsPerHz > 0) {
+        const vfo = Number(d.centerHz);
+        const loHz = vfo - RIBBON_SPAN_HZ / 2;
+
+        // Map full pan span to bins; the ribbon extracts a 10 kHz window
+        // centered on the VFO. If the main pan span is narrower than the
+        // ribbon's 10 kHz we render what we have — the rest stays floor.
+        const fullSpanHz = panDb.length * d.hzPerPixel;
+        const fullStartHz = vfo - fullSpanHz / 2;
+        const binStart = Math.max(0, Math.floor((loHz - fullStartHz) * binsPerHz));
+        const binEnd = Math.min(panDb.length, Math.ceil((loHz + RIBBON_SPAN_HZ - fullStartHz) * binsPerHz));
+
+        // Decimate to w px, max-of-bins per pixel column.
+        ctx.strokeStyle = '#FFA028';
+        ctx.lineWidth = 1 * dpr;
+        ctx.beginPath();
+        const bins = binEnd - binStart;
+        if (bins > 0) {
+          for (let x = 0; x < w; x++) {
+            const b0 = binStart + Math.floor((x * bins) / w);
+            const b1 = binStart + Math.floor(((x + 1) * bins) / w);
+            let peak = -Infinity;
+            for (let i = b0; i < b1; i++) {
+              const v = panDb[i] ?? DB_FLOOR;
+              if (v > peak) peak = v;
+            }
+            if (peak === -Infinity) peak = DB_FLOOR;
+            const norm = (peak - DB_FLOOR) / (DB_CEIL - DB_FLOOR);
+            const y = h - Math.max(0, Math.min(1, norm)) * h;
+            if (x === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+          }
+          ctx.stroke();
+        }
+
+        // Passband rectangle (amber fill).
+        const passLeftPx = ((c.filterLowHz + RIBBON_SPAN_HZ / 2) / RIBBON_SPAN_HZ) * w;
+        const passRightPx = ((c.filterHighHz + RIBBON_SPAN_HZ / 2) / RIBBON_SPAN_HZ) * w;
+        const passW = Math.max(0, passRightPx - passLeftPx);
+        ctx.fillStyle = 'rgba(255, 160, 40, 0.18)';
+        ctx.fillRect(passLeftPx, 0, passW, h);
+        ctx.strokeStyle = 'rgba(255, 160, 40, 0.85)';
+        ctx.lineWidth = 1 * dpr;
+        ctx.beginPath();
+        ctx.moveTo(Math.round(passLeftPx) + 0.5, 0);
+        ctx.lineTo(Math.round(passLeftPx) + 0.5, h);
+        ctx.moveTo(Math.round(passRightPx) + 0.5, 0);
+        ctx.lineTo(Math.round(passRightPx) + 0.5, h);
+        ctx.stroke();
+
+        // Corner handles (triangular amber marks).
+        const handle = 6 * dpr;
+        ctx.fillStyle = 'rgba(255, 160, 40, 0.9)';
+        ctx.beginPath();
+        ctx.moveTo(passLeftPx, 0);
+        ctx.lineTo(passLeftPx + handle, 0);
+        ctx.lineTo(passLeftPx, handle);
+        ctx.closePath();
+        ctx.fill();
+        ctx.beginPath();
+        ctx.moveTo(passRightPx, 0);
+        ctx.lineTo(passRightPx - handle, 0);
+        ctx.lineTo(passRightPx, handle);
+        ctx.closePath();
+        ctx.fill();
+
+        // VFO center tick.
+        ctx.strokeStyle = 'rgba(255, 160, 40, 0.35)';
+        ctx.beginPath();
+        ctx.moveTo(w / 2, 0);
+        ctx.lineTo(w / 2, h);
+        ctx.stroke();
+      }
+    };
+
+    // Schedule repaint whenever display-store updates (frame arrival or
+    // resize). Also repaint when the filter edges move optimistically.
+    const unsubDisplay = useDisplayStore.subscribe(() => {
+      if (rafHandle === 0) rafHandle = requestAnimationFrame(draw);
+    });
+    const unsubConn = useConnectionStore.subscribe((s, p) => {
+      if (s.filterLowHz !== p.filterLowHz || s.filterHighHz !== p.filterHighHz) {
+        lastSeq = -1; // force redraw — same FFT, different overlay
+        if (rafHandle === 0) rafHandle = requestAnimationFrame(draw);
+      }
+    });
+
+    const ro = new ResizeObserver(() => {
+      lastSeq = -1;
+      if (rafHandle === 0) rafHandle = requestAnimationFrame(draw);
+    });
+    ro.observe(canvas);
+
+    // Initial paint
+    rafHandle = requestAnimationFrame(draw);
+
+    return () => {
+      if (rafHandle !== 0) cancelAnimationFrame(rafHandle);
+      unsubDisplay();
+      unsubConn();
+      ro.disconnect();
+    };
+  }, []);
+
+  // Drag logic — identical rate-limiting strategy to FilterEdgeDrag.
+  const flushPending = () => {
+    const d = dragRef.current;
+    if (!d) return;
+    d.flushTimer = null;
+    d.lastWriteAt = performance.now();
+    setFilter(d.pendingLo, d.pendingHi, d.activeSlot).catch(() => {});
+  };
+
+  const schedule = () => {
+    const d = dragRef.current;
+    if (!d) return;
+    const now = performance.now();
+    const elapsed = now - d.lastWriteAt;
+    if (elapsed >= DRAG_MIN_INTERVAL_MS) {
+      flushPending();
+    } else if (d.flushTimer == null) {
+      d.flushTimer = window.setTimeout(flushPending, DRAG_MIN_INTERVAL_MS - elapsed);
+    }
+  };
+
+  const onPointerDown = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    if (e.button !== 0) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    if (rect.width <= 0) return;
+
+    const c = useConnectionStore.getState();
+    const passLeftPx = ((c.filterLowHz + RIBBON_SPAN_HZ / 2) / RIBBON_SPAN_HZ) * rect.width;
+    const passRightPx = ((c.filterHighHz + RIBBON_SPAN_HZ / 2) / RIBBON_SPAN_HZ) * rect.width;
+    const relX = e.clientX - rect.left;
+
+    let mode: DragMode;
+    if (Math.abs(relX - passLeftPx) <= EDGE_HIT_PX) mode = 'lo';
+    else if (Math.abs(relX - passRightPx) <= EDGE_HIT_PX) mode = 'hi';
+    else if (relX > passLeftPx && relX < passRightPx) mode = 'inside';
+    else return;
+
+    e.preventDefault();
+    try { canvas.setPointerCapture(e.pointerId); } catch { /* ok */ }
+
+    const activeSlot = presetIsFixed(c.filterPresetName) || !c.filterPresetName ? 'VAR1' : c.filterPresetName;
+
+    dragRef.current = {
+      mode,
+      rect,
+      activeSlot,
+      startLoHz: c.filterLowHz,
+      startHiHz: c.filterHighHz,
+      startX: e.clientX,
+      pendingLo: c.filterLowHz,
+      pendingHi: c.filterHighHz,
+      lastWriteAt: 0,
+      flushTimer: null,
+      pointerId: e.pointerId,
+    };
+
+    if (activeSlot !== c.filterPresetName) {
+      useConnectionStore.setState({ filterPresetName: activeSlot });
+    }
+  };
+
+  const onPointerMove = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    const d = dragRef.current;
+    if (!d || e.pointerId !== d.pointerId) return;
+    e.stopPropagation();
+
+    const hzPerPx = RIBBON_SPAN_HZ / d.rect.width;
+
+    let loHz = d.startLoHz;
+    let hiHz = d.startHiHz;
+    if (d.mode === 'lo') {
+      const relX = e.clientX - d.rect.left;
+      loHz = Math.round(relX * hzPerPx - RIBBON_SPAN_HZ / 2);
+      if (loHz > d.startHiHz - 50) loHz = d.startHiHz - 50;
+    } else if (d.mode === 'hi') {
+      const relX = e.clientX - d.rect.left;
+      hiHz = Math.round(relX * hzPerPx - RIBBON_SPAN_HZ / 2);
+      if (hiHz < d.startLoHz + 50) hiHz = d.startLoHz + 50;
+    } else {
+      const dxHz = Math.round((e.clientX - d.startX) * hzPerPx);
+      loHz = d.startLoHz + dxHz;
+      hiHz = d.startHiHz + dxHz;
+    }
+
+    d.pendingLo = loHz;
+    d.pendingHi = hiHz;
+    useConnectionStore.setState({ filterLowHz: loHz, filterHighHz: hiHz });
+    schedule();
+  };
+
+  const onPointerUp = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    const d = dragRef.current;
+    if (!d || e.pointerId !== d.pointerId) return;
+    e.stopPropagation();
+
+    const canvas = canvasRef.current;
+    if (canvas && canvas.hasPointerCapture(e.pointerId)) {
+      try { canvas.releasePointerCapture(e.pointerId); } catch { /* ok */ }
+    }
+    if (d.flushTimer != null) {
+      clearTimeout(d.flushTimer);
+      d.flushTimer = null;
+    }
+    const lo = d.pendingLo;
+    const hi = d.pendingHi;
+    const slot = d.activeSlot;
+    dragRef.current = null;
+    const applyState = useConnectionStore.getState().applyState;
+    setFilter(lo, hi, slot)
+      .then(applyState)
+      .catch(() => {});
+  };
+
+  // Hover-driven cursor hint (ew-resize on edges, move inside).
+  const onPointerMoveHover = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    if (dragRef.current) return; // during drag, don't fight the cursor
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    const c = useConnectionStore.getState();
+    const passLeftPx = ((c.filterLowHz + RIBBON_SPAN_HZ / 2) / RIBBON_SPAN_HZ) * rect.width;
+    const passRightPx = ((c.filterHighHz + RIBBON_SPAN_HZ / 2) / RIBBON_SPAN_HZ) * rect.width;
+    const relX = e.clientX - rect.left;
+    if (Math.abs(relX - passLeftPx) <= EDGE_HIT_PX || Math.abs(relX - passRightPx) <= EDGE_HIT_PX) {
+      canvas.style.cursor = 'ew-resize';
+    } else if (relX > passLeftPx && relX < passRightPx) {
+      canvas.style.cursor = 'move';
+    } else {
+      canvas.style.cursor = 'default';
+    }
+  };
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{
+        display: 'block',
+        width: '100%',
+        height: '100%',
+        touchAction: 'none',
+      }}
+      onPointerDown={onPointerDown}
+      onPointerMove={(e) => {
+        if (dragRef.current) onPointerMove(e);
+        else onPointerMoveHover(e);
+      }}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerUp}
+    />
+  );
+}

--- a/zeus-web/src/components/filter/FilterPanel.tsx
+++ b/zeus-web/src/components/filter/FilterPanel.tsx
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Filter visualization PRD §3.1 Phase 1 — compact filter panel.
+// Renders a width readout and a chip row (F1..F10 + VAR1/VAR2) for the
+// current mode. Clicking a chip calls POST /api/filter with the slot's
+// Lo/Hi and preset name. Phase 1: no drag handles, no Lo/Hi nudge
+// controls, no advanced toggle button, no out-of-band colouring.
+
+import { useCallback, useEffect, useState } from 'react';
+import { useConnectionStore } from '../../state/connection-store';
+import { setFilter, getFilterPresets, type FilterPresetDto } from '../../api/client';
+import { getPresetsForMode, formatFilterWidth, type FilterPresetSlot } from './filterPresets';
+
+export function FilterPanel() {
+  const mode = useConnectionStore((s) => s.mode);
+  const filterLow = useConnectionStore((s) => s.filterLowHz);
+  const filterHigh = useConnectionStore((s) => s.filterHighHz);
+  const filterPresetName = useConnectionStore((s) => s.filterPresetName);
+  const applyState = useConnectionStore((s) => s.applyState);
+
+  // Per-mode VAR1/VAR2 overrides fetched from the server. Seeded on mount
+  // and after any VAR* write. Falls back to the local Thetis-default table
+  // while the fetch is in flight or when the server is unreachable.
+  const [serverPresets, setServerPresets] = useState<FilterPresetDto[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getFilterPresets(mode)
+      .then((presets) => { if (!cancelled) setServerPresets(presets); })
+      .catch(() => { /* server presets unavailable; fall back to local defaults */ });
+    return () => { cancelled = true; };
+  }, [mode]);
+
+  // Merge server overrides for VAR slots into the local preset table. Server
+  // VAR* overrides take precedence; fixed slots are always from the local table.
+  const presets: readonly FilterPresetSlot[] = (() => {
+    const local = getPresetsForMode(mode);
+    if (!serverPresets) return local;
+    return local.map((slot) => {
+      if (!slot.isVar) return slot;
+      const srv = serverPresets.find((s) => s.slotName === slot.slotName);
+      return srv ? { ...slot, lowHz: srv.lowHz, highHz: srv.highHz } : slot;
+    });
+  })();
+
+  const activeSlot = filterPresetName ?? null;
+  const widthLabel = formatFilterWidth(filterLow, filterHigh);
+
+  const selectPreset = useCallback(
+    (slot: FilterPresetSlot) => {
+      useConnectionStore.setState({
+        filterLowHz: slot.lowHz,
+        filterHighHz: slot.highHz,
+        filterPresetName: slot.slotName,
+      });
+      setFilter(slot.lowHz, slot.highHz, slot.slotName)
+        .then(applyState)
+        .catch(() => { /* next state poll reconciles */ });
+    },
+    [applyState],
+  );
+
+  // FM has no presets — hide chip row.
+  if (presets.length === 0) return null;
+
+  return (
+    <div className="ctrl-group" style={{ minWidth: 320 }}>
+      <div
+        className="label-xs ctrl-lbl"
+        style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
+      >
+        <span>FILTER</span>
+        <span
+          className="mono"
+          style={{ color: 'var(--accent)', fontWeight: 600, fontSize: 11, letterSpacing: 0.5 }}
+        >
+          {widthLabel}
+        </span>
+      </div>
+      <div className="btn-row wrap" style={{ gap: 3 }}>
+        {presets.map((slot) => (
+          <button
+            key={slot.slotName}
+            type="button"
+            onClick={() => selectPreset(slot)}
+            className={`btn sm ${activeSlot === slot.slotName ? 'active' : ''}`}
+            title={`${slot.slotName}: ${slot.lowHz >= 0 ? '+' : ''}${slot.lowHz} / +${slot.highHz} Hz`}
+          >
+            {slot.slotName === 'VAR1' || slot.slotName === 'VAR2'
+              ? slot.slotName
+              : slot.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/zeus-web/src/components/filter/FilterPanel.tsx
+++ b/zeus-web/src/components/filter/FilterPanel.tsx
@@ -12,15 +12,25 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useConnectionStore } from '../../state/connection-store';
-import { setFilter, getFilterPresets, type FilterPresetDto } from '../../api/client';
+import { setFilter, getFilterPresets, setFilterAdvancedPaneOpen, type FilterPresetDto } from '../../api/client';
 import { getPresetsForMode, formatFilterWidth, type FilterPresetSlot } from './filterPresets';
+
+const LOCAL_STORAGE_KEY = 'zeus.filter.advancedPaneOpen';
 
 export function FilterPanel() {
   const mode = useConnectionStore((s) => s.mode);
   const filterLow = useConnectionStore((s) => s.filterLowHz);
   const filterHigh = useConnectionStore((s) => s.filterHighHz);
   const filterPresetName = useConnectionStore((s) => s.filterPresetName);
+  const advancedOpen = useConnectionStore((s) => s.filterAdvancedPaneOpen);
   const applyState = useConnectionStore((s) => s.applyState);
+
+  const toggleAdvanced = useCallback(() => {
+    const next = !advancedOpen;
+    useConnectionStore.setState({ filterAdvancedPaneOpen: next });
+    try { window.localStorage.setItem(LOCAL_STORAGE_KEY, next ? '1' : '0'); } catch { /* ok */ }
+    setFilterAdvancedPaneOpen(next).catch(() => {});
+  }, [advancedOpen]);
 
   // Per-mode VAR1/VAR2 overrides fetched from the server. Seeded on mount
   // and after any VAR* write. Falls back to the local Thetis-default table
@@ -95,6 +105,16 @@ export function FilterPanel() {
               : slot.label}
           </button>
         ))}
+        <button
+          type="button"
+          onClick={toggleAdvanced}
+          className={`btn sm hide-mobile ${advancedOpen ? 'active' : ''}`}
+          title={advancedOpen ? 'Close advanced filter ribbon' : 'Open advanced filter ribbon'}
+          aria-pressed={advancedOpen}
+          style={{ marginLeft: 4 }}
+        >
+          {advancedOpen ? '≡ ×' : '≡'}
+        </button>
       </div>
     </div>
   );

--- a/zeus-web/src/components/filter/FilterRibbon.tsx
+++ b/zeus-web/src/components/filter/FilterRibbon.tsx
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Filter visualization PRD §3.2 — advanced filter ribbon pane. Desktop-only.
+// Shows BANDWIDTH label + LOW CUT / PASSBAND / HIGH CUT columns, a 10 kHz
+// mini-panadapter centered on the VFO, and a 6-preset grid mapped to the
+// active mode's F-slot table.
+
+import { useCallback, useEffect } from 'react';
+import { useConnectionStore } from '../../state/connection-store';
+import { setFilter, setFilterAdvancedPaneOpen } from '../../api/client';
+import {
+  formatRibbonWidth,
+  formatAbsFreq,
+  getRibbonPresetsForMode,
+  nudgeStepHz,
+  type FilterPresetSlot,
+} from './filterPresets';
+import { FilterMiniPan } from './FilterMiniPan';
+
+const LOCAL_STORAGE_KEY = 'zeus.filter.advancedPaneOpen';
+
+// Write the pane-open flag to localStorage so the next page load reflects
+// the operator's choice before the state poll arrives, avoiding a flash of
+// closed → open on every reload.
+function cachePaneOpenLocal(open: boolean) {
+  try { window.localStorage.setItem(LOCAL_STORAGE_KEY, open ? '1' : '0'); } catch { /* quota/storage unavailable */ }
+}
+
+export function useFilterRibbonOpenSync() {
+  // Read the cached flag once on mount and push it into the store so the
+  // ribbon renders immediately on reload — the server reconciliation happens
+  // in parallel via the state poll.
+  useEffect(() => {
+    try {
+      const cached = window.localStorage.getItem(LOCAL_STORAGE_KEY);
+      if (cached === '1') {
+        useConnectionStore.setState({ filterAdvancedPaneOpen: true });
+      }
+    } catch { /* storage unavailable */ }
+  }, []);
+}
+
+export function FilterRibbon() {
+  const mode = useConnectionStore((s) => s.mode);
+  const filterLow = useConnectionStore((s) => s.filterLowHz);
+  const filterHigh = useConnectionStore((s) => s.filterHighHz);
+  const filterPresetName = useConnectionStore((s) => s.filterPresetName);
+  const vfoHz = useConnectionStore((s) => s.vfoHz);
+  const open = useConnectionStore((s) => s.filterAdvancedPaneOpen);
+  const applyState = useConnectionStore((s) => s.applyState);
+
+  const presets = getRibbonPresetsForMode(mode);
+  const widthLabel = formatRibbonWidth(filterLow, filterHigh);
+  const lowAbs = vfoHz + filterLow;
+  const highAbs = vfoHz + filterHigh;
+
+  const selectPreset = useCallback((slot: FilterPresetSlot) => {
+    useConnectionStore.setState({
+      filterLowHz: slot.lowHz,
+      filterHighHz: slot.highHz,
+      filterPresetName: slot.slotName,
+    });
+    setFilter(slot.lowHz, slot.highHz, slot.slotName)
+      .then(applyState)
+      .catch(() => { /* next poll reconciles */ });
+  }, [applyState]);
+
+  const armCustom = useCallback(() => {
+    // Flip active slot to VAR1 without changing passband — the user can then
+    // nudge/drag from their current width.
+    useConnectionStore.setState({ filterPresetName: 'VAR1' });
+    setFilter(filterLow, filterHigh, 'VAR1')
+      .then(applyState)
+      .catch(() => {});
+  }, [applyState, filterLow, filterHigh]);
+
+  const closeRibbon = useCallback(() => {
+    useConnectionStore.setState({ filterAdvancedPaneOpen: false });
+    cachePaneOpenLocal(false);
+    setFilterAdvancedPaneOpen(false).catch(() => {});
+  }, []);
+
+  // Keyboard nudge: arrows move the most-recently-touched edge. Esc closes.
+  // We default to nudging the Hi edge on the first keypress; drag-in-ribbon
+  // remembers which edge the user last touched and overrides this.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        closeRibbon();
+        return;
+      }
+      if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+      const step = nudgeStepHz(mode) * (e.shiftKey ? 10 : 1);
+      const dir = e.key === 'ArrowRight' ? 1 : -1;
+      const s = useConnectionStore.getState();
+      // Nudge Hi by default (matches mockup convention); Shift+Down not used.
+      const newHi = s.filterHighHz + dir * step;
+      if (newHi <= s.filterLowHz + 50) return;
+      const slot = s.filterPresetName && /^VAR[12]$/.test(s.filterPresetName) ? s.filterPresetName : 'VAR1';
+      useConnectionStore.setState({ filterHighHz: newHi, filterPresetName: slot });
+      setFilter(s.filterLowHz, newHi, slot)
+        .then(applyState)
+        .catch(() => {});
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, mode, applyState, closeRibbon]);
+
+  if (!open) return null;
+  if (presets.length === 0) return null;  // FM: ribbon suppressed
+
+  return (
+    <div
+      className="filter-ribbon"
+      style={{
+        position: 'relative',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 4,
+        padding: '8px 10px',
+        border: '1px solid var(--line)',
+        borderRadius: 4,
+        background: 'rgba(0,0,0,0.35)',
+        margin: '4px 8px',
+      }}
+    >
+      {/* Close button */}
+      <button
+        type="button"
+        aria-label="Close filter ribbon"
+        onClick={closeRibbon}
+        className="btn ghost sm"
+        style={{
+          position: 'absolute',
+          top: 6,
+          right: 6,
+          padding: '0 8px',
+          lineHeight: '20px',
+        }}
+      >
+        ×
+      </button>
+
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '90px 120px 1fr 120px minmax(240px, 1.2fr) 130px',
+          gap: 10,
+          alignItems: 'stretch',
+          minHeight: 80,
+        }}
+      >
+        {/* BANDWIDTH section label */}
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'flex-start',
+          }}
+        >
+          <div
+            className="label-xs"
+            style={{ color: 'var(--accent)', fontWeight: 600, letterSpacing: 1, opacity: 0.7 }}
+          >
+            BANDWIDTH
+          </div>
+          <div className="label-xs" style={{ opacity: 0.6, marginTop: 4 }}>
+            {filterPresetName ?? '—'}
+          </div>
+        </div>
+
+        {/* LOW CUT */}
+        <RibbonReadout title="LOW CUT" value={formatAbsFreq(lowAbs)} />
+
+        {/* PASSBAND */}
+        <RibbonReadout
+          title="PASSBAND"
+          value={widthLabel}
+          focal
+        />
+
+        {/* HIGH CUT */}
+        <RibbonReadout title="HIGH CUT" value={formatAbsFreq(highAbs)} />
+
+        {/* Mini-panadapter */}
+        <div
+          style={{
+            position: 'relative',
+            border: '1px solid var(--line)',
+            borderRadius: 3,
+            minHeight: 80,
+            overflow: 'hidden',
+          }}
+        >
+          <FilterMiniPan />
+        </div>
+
+        {/* Preset grid */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <div
+            className="label-xs"
+            style={{ color: 'var(--accent)', fontWeight: 600, letterSpacing: 0.5, opacity: 0.7 }}
+          >
+            ≡ PRESETS
+          </div>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr 1fr',
+              gap: 3,
+            }}
+          >
+            {presets.map((slot) => (
+              <button
+                key={slot.slotName}
+                type="button"
+                onClick={() => selectPreset(slot)}
+                className={`btn sm ${filterPresetName === slot.slotName ? 'active' : ''}`}
+                title={`${slot.slotName}: ${slot.lowHz}/${slot.highHz} Hz`}
+                style={{ padding: '2px 4px', fontSize: 11 }}
+              >
+                {slot.label}
+              </button>
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={armCustom}
+            className={`btn sm ${filterPresetName === 'VAR1' || filterPresetName === 'VAR2' ? 'active' : ''}`}
+            title="Arm custom edit — sends current passband into VAR1"
+            style={{ padding: '2px 4px', fontSize: 11 }}
+          >
+            ✎ CUSTOM
+          </button>
+        </div>
+      </div>
+
+      <div
+        className="label-xs"
+        style={{
+          opacity: 0.45,
+          letterSpacing: 0.6,
+          marginTop: 2,
+          textAlign: 'center',
+        }}
+      >
+        DRAG EDGES TO ADJUST · DRAG INSIDE TO MOVE
+      </div>
+    </div>
+  );
+}
+
+function RibbonReadout({ title, value, focal = false }: { title: string; value: string; focal?: boolean }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: focal ? 'center' : 'flex-start',
+      }}
+    >
+      <div
+        className="label-xs"
+        style={{ color: 'var(--accent)', fontWeight: 600, letterSpacing: 1, opacity: 0.7 }}
+      >
+        {title}
+      </div>
+      <div
+        className="mono"
+        style={{
+          color: 'var(--accent)',
+          fontWeight: focal ? 700 : 500,
+          fontSize: focal ? 20 : 13,
+          letterSpacing: 0.4,
+        }}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/zeus-web/src/components/filter/filterPresets.ts
+++ b/zeus-web/src/components/filter/filterPresets.ts
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Thetis default filter preset tables from console.cs:5182–5585.
+// Reference: docs/proposals/research/thetis-filter-ux.md §2.
+// Numbers are signed Hz, VFO-relative. CW uses default cw_pitch=600.
+// DIGL/DIGU use default offset=0.
+
+import type { RxMode } from '../../api/client';
+
+export type FilterPresetSlot = {
+  slotName: string;
+  label: string;
+  lowHz: number;
+  highHz: number;
+  isVar: boolean;
+};
+
+const CW_PITCH = 600;
+
+const LSB: readonly FilterPresetSlot[] = [
+  { slotName: 'F1',   label: '5.0k',  lowHz: -5100, highHz: -100,  isVar: false },
+  { slotName: 'F2',   label: '4.4k',  lowHz: -4500, highHz: -100,  isVar: false },
+  { slotName: 'F3',   label: '3.8k',  lowHz: -3900, highHz: -100,  isVar: false },
+  { slotName: 'F4',   label: '3.3k',  lowHz: -3400, highHz: -100,  isVar: false },
+  { slotName: 'F5',   label: '2.9k',  lowHz: -3000, highHz: -100,  isVar: false },
+  { slotName: 'F6',   label: '2.7k',  lowHz: -2800, highHz: -100,  isVar: false },
+  { slotName: 'F7',   label: '2.4k',  lowHz: -2500, highHz: -100,  isVar: false },
+  { slotName: 'F8',   label: '2.1k',  lowHz: -2200, highHz: -100,  isVar: false },
+  { slotName: 'F9',   label: '1.8k',  lowHz: -1900, highHz: -100,  isVar: false },
+  { slotName: 'F10',  label: '1.0k',  lowHz: -1100, highHz: -100,  isVar: false },
+  { slotName: 'VAR1', label: 'Var 1', lowHz: -2800, highHz: -100,  isVar: true  },
+  { slotName: 'VAR2', label: 'Var 2', lowHz: -2800, highHz: -100,  isVar: true  },
+];
+
+const USB: readonly FilterPresetSlot[] = [
+  { slotName: 'F1',   label: '5.0k',  lowHz:  100, highHz: 5100,  isVar: false },
+  { slotName: 'F2',   label: '4.4k',  lowHz:  100, highHz: 4500,  isVar: false },
+  { slotName: 'F3',   label: '3.8k',  lowHz:  100, highHz: 3900,  isVar: false },
+  { slotName: 'F4',   label: '3.3k',  lowHz:  100, highHz: 3400,  isVar: false },
+  { slotName: 'F5',   label: '2.9k',  lowHz:  100, highHz: 3000,  isVar: false },
+  { slotName: 'F6',   label: '2.7k',  lowHz:  100, highHz: 2800,  isVar: false },
+  { slotName: 'F7',   label: '2.4k',  lowHz:  100, highHz: 2500,  isVar: false },
+  { slotName: 'F8',   label: '2.1k',  lowHz:  100, highHz: 2200,  isVar: false },
+  { slotName: 'F9',   label: '1.8k',  lowHz:  100, highHz: 1900,  isVar: false },
+  { slotName: 'F10',  label: '1.0k',  lowHz:  100, highHz: 1100,  isVar: false },
+  { slotName: 'VAR1', label: 'Var 1', lowHz:  100, highHz: 2800,  isVar: true  },
+  { slotName: 'VAR2', label: 'Var 2', lowHz:  100, highHz: 2800,  isVar: true  },
+];
+
+const CWL: readonly FilterPresetSlot[] = [
+  { slotName: 'F1',   label: '1.0k',  lowHz: -(CW_PITCH + 500), highHz: -(CW_PITCH - 500), isVar: false },
+  { slotName: 'F2',   label: '800',   lowHz: -(CW_PITCH + 400), highHz: -(CW_PITCH - 400), isVar: false },
+  { slotName: 'F3',   label: '600',   lowHz: -(CW_PITCH + 300), highHz: -(CW_PITCH - 300), isVar: false },
+  { slotName: 'F4',   label: '500',   lowHz: -(CW_PITCH + 250), highHz: -(CW_PITCH - 250), isVar: false },
+  { slotName: 'F5',   label: '400',   lowHz: -(CW_PITCH + 200), highHz: -(CW_PITCH - 200), isVar: false },
+  { slotName: 'F6',   label: '250',   lowHz: -(CW_PITCH + 125), highHz: -(CW_PITCH - 125), isVar: false },
+  { slotName: 'F7',   label: '150',   lowHz: -(CW_PITCH +  75), highHz: -(CW_PITCH -  75), isVar: false },
+  { slotName: 'F8',   label: '100',   lowHz: -(CW_PITCH +  50), highHz: -(CW_PITCH -  50), isVar: false },
+  { slotName: 'F9',   label: '50',    lowHz: -(CW_PITCH +  25), highHz: -(CW_PITCH -  25), isVar: false },
+  { slotName: 'F10',  label: '25',    lowHz: -(CW_PITCH +  13), highHz: -(CW_PITCH -  13), isVar: false },
+  { slotName: 'VAR1', label: 'Var 1', lowHz: -(CW_PITCH + 250), highHz: -(CW_PITCH - 250), isVar: true  },
+  { slotName: 'VAR2', label: 'Var 2', lowHz: -(CW_PITCH + 250), highHz: -(CW_PITCH - 250), isVar: true  },
+];
+
+const CWU: readonly FilterPresetSlot[] = [
+  { slotName: 'F1',   label: '1.0k',  lowHz: CW_PITCH - 500, highHz: CW_PITCH + 500, isVar: false },
+  { slotName: 'F2',   label: '800',   lowHz: CW_PITCH - 400, highHz: CW_PITCH + 400, isVar: false },
+  { slotName: 'F3',   label: '600',   lowHz: CW_PITCH - 300, highHz: CW_PITCH + 300, isVar: false },
+  { slotName: 'F4',   label: '500',   lowHz: CW_PITCH - 250, highHz: CW_PITCH + 250, isVar: false },
+  { slotName: 'F5',   label: '400',   lowHz: CW_PITCH - 200, highHz: CW_PITCH + 200, isVar: false },
+  { slotName: 'F6',   label: '250',   lowHz: CW_PITCH - 125, highHz: CW_PITCH + 125, isVar: false },
+  { slotName: 'F7',   label: '150',   lowHz: CW_PITCH -  75, highHz: CW_PITCH +  75, isVar: false },
+  { slotName: 'F8',   label: '100',   lowHz: CW_PITCH -  50, highHz: CW_PITCH +  50, isVar: false },
+  { slotName: 'F9',   label: '50',    lowHz: CW_PITCH -  25, highHz: CW_PITCH +  25, isVar: false },
+  { slotName: 'F10',  label: '25',    lowHz: CW_PITCH -  13, highHz: CW_PITCH +  13, isVar: false },
+  { slotName: 'VAR1', label: 'Var 1', lowHz: CW_PITCH - 250, highHz: CW_PITCH + 250, isVar: true  },
+  { slotName: 'VAR2', label: 'Var 2', lowHz: CW_PITCH - 250, highHz: CW_PITCH + 250, isVar: true  },
+];
+
+const AM: readonly FilterPresetSlot[] = [
+  { slotName: 'F1',   label: '20k',   lowHz: -10000, highHz: 10000, isVar: false },
+  { slotName: 'F2',   label: '18k',   lowHz:  -9000, highHz:  9000, isVar: false },
+  { slotName: 'F3',   label: '16k',   lowHz:  -8000, highHz:  8000, isVar: false },
+  { slotName: 'F4',   label: '12k',   lowHz:  -6000, highHz:  6000, isVar: false },
+  { slotName: 'F5',   label: '10k',   lowHz:  -5000, highHz:  5000, isVar: false },
+  { slotName: 'F6',   label: '9.0k',  lowHz:  -4500, highHz:  4500, isVar: false },
+  { slotName: 'F7',   label: '8.0k',  lowHz:  -4000, highHz:  4000, isVar: false },
+  { slotName: 'F8',   label: '7.0k',  lowHz:  -3500, highHz:  3500, isVar: false },
+  { slotName: 'F9',   label: '6.0k',  lowHz:  -3000, highHz:  3000, isVar: false },
+  { slotName: 'F10',  label: '5.0k',  lowHz:  -2500, highHz:  2500, isVar: false },
+  { slotName: 'VAR1', label: 'Var 1', lowHz:  -3000, highHz:  3000, isVar: true  },
+  { slotName: 'VAR2', label: 'Var 2', lowHz:  -3000, highHz:  3000, isVar: true  },
+];
+
+const DSB: readonly FilterPresetSlot[] = [
+  { slotName: 'F1',   label: '16k',   lowHz:  -8000, highHz:  8000, isVar: false },
+  { slotName: 'F2',   label: '12k',   lowHz:  -6000, highHz:  6000, isVar: false },
+  { slotName: 'F3',   label: '10k',   lowHz:  -5000, highHz:  5000, isVar: false },
+  { slotName: 'F4',   label: '8.0k',  lowHz:  -4000, highHz:  4000, isVar: false },
+  { slotName: 'F5',   label: '6.6k',  lowHz:  -3300, highHz:  3300, isVar: false },
+  { slotName: 'F6',   label: '5.2k',  lowHz:  -2600, highHz:  2600, isVar: false },
+  { slotName: 'F7',   label: '4.0k',  lowHz:  -2000, highHz:  2000, isVar: false },
+  { slotName: 'F8',   label: '3.1k',  lowHz:  -1550, highHz:  1550, isVar: false },
+  { slotName: 'F9',   label: '2.9k',  lowHz:  -1450, highHz:  1450, isVar: false },
+  { slotName: 'F10',  label: '2.4k',  lowHz:  -1200, highHz:  1200, isVar: false },
+  { slotName: 'VAR1', label: 'Var 1', lowHz:  -3300, highHz:  3300, isVar: true  },
+  { slotName: 'VAR2', label: 'Var 2', lowHz:  -3300, highHz:  3300, isVar: true  },
+];
+
+// DIGL/DIGU centered on offset=0 (default). Symmetric because offset defaults to 0.
+const DIGL: readonly FilterPresetSlot[] = [
+  { slotName: 'F1',   label: '3.0k',  lowHz:  -1500, highHz:  1500, isVar: false },
+  { slotName: 'F2',   label: '2.5k',  lowHz:  -1250, highHz:  1250, isVar: false },
+  { slotName: 'F3',   label: '2.0k',  lowHz:  -1000, highHz:  1000, isVar: false },
+  { slotName: 'F4',   label: '1.5k',  lowHz:   -750, highHz:   750, isVar: false },
+  { slotName: 'F5',   label: '1.0k',  lowHz:   -500, highHz:   500, isVar: false },
+  { slotName: 'F6',   label: '800',   lowHz:   -400, highHz:   400, isVar: false },
+  { slotName: 'F7',   label: '600',   lowHz:   -300, highHz:   300, isVar: false },
+  { slotName: 'F8',   label: '300',   lowHz:   -150, highHz:   150, isVar: false },
+  { slotName: 'F9',   label: '150',   lowHz:    -75, highHz:    75, isVar: false },
+  { slotName: 'F10',  label: '75',    lowHz:    -38, highHz:    38, isVar: false },
+  { slotName: 'VAR1', label: 'Var 1', lowHz:   -400, highHz:   400, isVar: true  },
+  { slotName: 'VAR2', label: 'Var 2', lowHz:   -400, highHz:   400, isVar: true  },
+];
+
+// FM has no presets in Thetis.
+const FM: readonly FilterPresetSlot[] = [];
+
+const PRESET_MAP: Record<RxMode, readonly FilterPresetSlot[]> = {
+  LSB:  LSB,
+  USB:  USB,
+  CWL:  CWL,
+  CWU:  CWU,
+  AM:   AM,
+  SAM:  AM,  // SAM uses identical table to AM
+  DSB:  DSB,
+  DIGL: DIGL,
+  DIGU: DIGL, // DIGU uses identical half-widths to DIGL
+  FM:   FM,
+};
+
+export function getPresetsForMode(mode: RxMode): readonly FilterPresetSlot[] {
+  return PRESET_MAP[mode] ?? USB;
+}
+
+export function formatFilterWidth(lowHz: number, highHz: number): string {
+  const width = Math.abs(highHz - lowHz);
+  if (width >= 1000) {
+    const khz = width / 1000;
+    return `${khz % 1 === 0 ? khz.toFixed(0) : khz.toFixed(1)} kHz`;
+  }
+  return `${width} Hz`;
+}

--- a/zeus-web/src/components/filter/filterPresets.ts
+++ b/zeus-web/src/components/filter/filterPresets.ts
@@ -151,3 +151,65 @@ export function formatFilterWidth(lowHz: number, highHz: number): string {
   }
   return `${width} Hz`;
 }
+
+// Format a passband width for the ribbon's PASSBAND readout.
+// Always 2-decimal kHz (e.g. "2.70 kHz") to match mockup precision.
+export function formatRibbonWidth(lowHz: number, highHz: number): string {
+  const width = Math.abs(highHz - lowHz);
+  return `${(width / 1000).toFixed(2)} kHz`;
+}
+
+// Format an absolute Hz frequency as "MM.kkk.hhh" (MHz.kHz-3.Hz-3). Matches
+// the mockup's LOW CUT / HIGH CUT columns (e.g. "14.254.650").
+export function formatAbsFreq(hz: number): string {
+  const abs = Math.abs(Math.round(hz));
+  const mhz = Math.floor(abs / 1_000_000);
+  const khzPart = Math.floor((abs - mhz * 1_000_000) / 1000);
+  const hzPart = abs - mhz * 1_000_000 - khzPart * 1000;
+  const sign = hz < 0 ? '-' : '';
+  return `${sign}${mhz}.${String(khzPart).padStart(3, '0')}.${String(hzPart).padStart(3, '0')}`;
+}
+
+// Ribbon's six-preset subset. PRD §3.2 "a 3×2 grid of chip buttons". We map
+// each ribbon width to the nearest real F-slot for the active mode so the
+// chip is a second view of the compact panel's row, not a parallel preset
+// system. When no exact F-slot match exists we pick the closest by width.
+const RIBBON_SLOT_NAMES_BY_MODE: Record<RxMode, readonly string[]> = {
+  // SSB: a spread of tight-to-AM-wide SSB widths.
+  USB: ['F10', 'F7', 'F6', 'F5', 'F3', 'F1'],
+  LSB: ['F10', 'F7', 'F6', 'F5', 'F3', 'F1'],
+  // CW: narrow-to-wide CW widths.
+  CWU: ['F10', 'F9', 'F8', 'F7', 'F6', 'F4'],
+  CWL: ['F10', 'F9', 'F8', 'F7', 'F6', 'F4'],
+  // AM/SAM: wide-audio widths.
+  AM:  ['F10', 'F9', 'F7', 'F5', 'F3', 'F1'],
+  SAM: ['F10', 'F9', 'F7', 'F5', 'F3', 'F1'],
+  DSB: ['F10', 'F7', 'F5', 'F3', 'F2', 'F1'],
+  DIGL: ['F10', 'F8', 'F5', 'F3', 'F2', 'F1'],
+  DIGU: ['F10', 'F8', 'F5', 'F3', 'F2', 'F1'],
+  FM:  [],
+};
+
+// Return the 6 ribbon-chip slots for the active mode. Falls back gracefully
+// when the mode has no table (FM returns [] — caller hides the grid).
+export function getRibbonPresetsForMode(mode: RxMode): readonly FilterPresetSlot[] {
+  const names = RIBBON_SLOT_NAMES_BY_MODE[mode] ?? RIBBON_SLOT_NAMES_BY_MODE.USB;
+  const table = getPresetsForMode(mode);
+  return names.flatMap((n) => {
+    const hit = table.find((s) => s.slotName === n);
+    return hit ? [hit] : [];
+  });
+}
+
+// Per-mode nudge step for edge adjustments (keyboard arrow keys in the ribbon,
+// eventually the compact-panel Lo/Hi pairs in Phase 5). PRD §3.2.1 /
+// §3.4 open question — defaults are: SSB 10 Hz, CW 10 Hz, AM/SAM/DSB 100 Hz,
+// DIGL/DIGU 50 Hz.
+export function nudgeStepHz(mode: RxMode): number {
+  switch (mode) {
+    case 'USB': case 'LSB': case 'CWU': case 'CWL': return 10;
+    case 'DIGL': case 'DIGU': return 50;
+    case 'AM': case 'SAM': case 'DSB': case 'FM': return 100;
+    default: return 10;
+  }
+}

--- a/zeus-web/src/state/connection-store.ts
+++ b/zeus-web/src/state/connection-store.ts
@@ -59,6 +59,7 @@ export type ConnectionState = {
   mode: RxMode;
   filterLowHz: number;
   filterHighHz: number;
+  filterPresetName: string | null;
   sampleRate: number;
   agcTopDb: number;
   attenDb: number;
@@ -96,6 +97,7 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
   mode: 'USB',
   filterLowHz: 150,
   filterHighHz: 2850,
+  filterPresetName: 'VAR1',
   sampleRate: 192_000,
   agcTopDb: 80,
   attenDb: 0,
@@ -119,6 +121,7 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
       mode: s.mode,
       filterLowHz: s.filterLowHz,
       filterHighHz: s.filterHighHz,
+      filterPresetName: s.filterPresetName,
       sampleRate: s.sampleRate,
       agcTopDb: s.agcTopDb,
       attenDb: s.attenDb,

--- a/zeus-web/src/state/connection-store.ts
+++ b/zeus-web/src/state/connection-store.ts
@@ -60,6 +60,7 @@ export type ConnectionState = {
   filterLowHz: number;
   filterHighHz: number;
   filterPresetName: string | null;
+  filterAdvancedPaneOpen: boolean;
   sampleRate: number;
   agcTopDb: number;
   attenDb: number;
@@ -98,6 +99,7 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
   filterLowHz: 150,
   filterHighHz: 2850,
   filterPresetName: 'VAR1',
+  filterAdvancedPaneOpen: false,
   sampleRate: 192_000,
   agcTopDb: 80,
   attenDb: 0,
@@ -122,6 +124,7 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
       filterLowHz: s.filterLowHz,
       filterHighHz: s.filterHighHz,
       filterPresetName: s.filterPresetName,
+      filterAdvancedPaneOpen: s.filterAdvancedPaneOpen,
       sampleRate: s.sampleRate,
       agcTopDb: s.agcTopDb,
       attenDb: s.attenDb,


### PR DESCRIPTION
Closes #63 (Phases 1–4 of `docs/proposals/filter-visualization-prd.md`).
Phase 5 (red OOB colouring) stays pending until the band-planning PRD ships its `inBand()` predicate; the overlay stays amber unconditionally until then, matching the PRD's §7 forward contract.

## Phase 1 — wire contract + compact panel

- `Zeus.Contracts/FilterFrame.cs` — `FilterStateFrame`, `FilterSetRequest`, `FilterPresetWriteRequest`, `FilterPresetDto`; `StateDto` gains `FilterPresetName` and `FilterAdvancedPaneOpen`.
- `Zeus.Server/FilterPresets.cs` — Thetis-default table for all ten RX modes (F1–F10 + VAR1/VAR2).
- `Zeus.Server/FilterPresetStore.cs` — LiteDB store in `zeus-prefs.db`: per-mode VAR1/VAR2 overrides, last-selected-preset recall on mode switch, and the new advanced-pane visibility flag. Seeds USB VAR1 = (150, 2850) / LSB VAR1 = (−2850, −150) on first run so Zeus's familiar passband carries over (PRD §9).
- `RadioService`: `SetFilter(lo, hi, presetName?)`, `SetMode` saves/restores last preset per mode, `GetFilterPresets` merges defaults with VAR overrides, `SetFilterPresetOverride` rejects fixed slots.
- `Program.cs` — `POST /api/filter`, `GET /api/filter/presets?mode=`, `POST /api/filter/presets`, `POST /api/filter/advanced-pane`.
- `FilterPanel.tsx` — compact chip strip (F1–F10 + VAR1/VAR2) with amber width readout; FM hides the chip row; advanced toggle button (desktop only).

## Phase 2 — main panadapter + waterfall overlay

- `PassbandOverlay` gains a `fillOnly` prop so the waterfall can render just the shaded column without edge lines (panadapter carries the resolution).

## Phase 3 — drag handles

- `FilterEdgeDrag.tsx` — transparent ±4 px hit-zones over each edge line on the main panadapter. Pointer-drag posts Lo/Hi through `POST /api/filter` at 20 Hz max (50 ms throttle with a trailing-flush `setTimeout`), final-commit applies the authoritative server response. First drag on a fixed `F*` preset auto-flips to `VAR1`.

## Phase 4 — advanced filter ribbon

- `FilterRibbon.tsx` — desktop-only pane mounted between the control strip and the hero workspace. BANDWIDTH / LOW CUT / PASSBAND / HIGH CUT columns using the mockup's `MM.kkk.hhh` formatting for cut readouts and `x.xx kHz` focal-width for PASSBAND. 6-preset chip grid (3×2) mapped to real `F*` slots per mode, plus a `CUSTOM` button that flips to `VAR1` without touching the passband. Close button (`×`) at top-right.
- `FilterMiniPan.tsx` — 10 kHz Canvas 2D mini-panadapter centered on the VFO. Decimates the existing main-panadapter FFT frame (`useDisplayStore.panDb`) into the ribbon's width, max-of-bins per column. Draws the amber passband rect + edge lines + small triangular corner handles over the trace. Shares the main panadapter's FFT stream — no second server request.
    - Drag on an edge → rewrites Lo/Hi, 20 Hz throttle, auto-flips to VAR1.
    - Drag inside the rectangle → slides both edges together, width preserved.
    - Hover sets cursor (`ew-resize` on edges, `move` inside, `default` outside).
    - Used Canvas 2D rather than the PRD's shared-WebGL-context plan — at the ribbon's ~640×80 CSS-pixel target, 2D hits the <2 ms/frame budget comfortably and is far simpler than scissor-clipping the main canvas. Swap to GL is a straightforward follow-up if profiling shows 2D as the bottleneck.
- Keyboard: `←` / `→` nudge the hi edge by the mode's step size (SSB/CW 10 Hz, DIGL/DIGU 50 Hz, AM/SAM/DSB 100 Hz — PRD §3.4 default), `Shift+←/→` = 10×, `Esc` closes.
- Open/closed state persists across server restarts (`FilterPresetStore.SetAdvancedPaneOpen`) and is also cached to `localStorage` so the ribbon renders immediately on reload without a flash.

## LiteDB BsonMapper race fix

`FilterPresetStore.EnsureIndex(x => x.ModeKey, …)` intermittently threw `Member ModeKey not found on BsonMapper` when two `WebApplicationFactory` hosts raced on `BsonMapper.Global` during parallel xUnit test execution. Pre-registers the entity under a static lock, uses string-based `EnsureIndex("ModeKey", "$.ModeKey", …)` and `FindOne("$.ModeKey = @0", …)` to bypass the LINQ expression resolver, and serialises all reads/writes through a dedicated `_sync` lock. Full test suite now green under parallel load.

## Open maintainer decisions (red-light per CLAUDE.md)

- Ribbon's 6-preset mapping (`RIBBON_SLOT_NAMES_BY_MODE` in `filterPresets.ts`) is a plausible default per mode — sign-off / adjustment is yours. Changing the names never touches the contract.
- Filter ribbon placement currently sits directly below the control strip, above the hero workspace. The PRD §3.2 says "its own pane in the flex-layout grid"; the non-flex default is what you see. Flex-layout integration (registering the ribbon as a dockable factory) is a small follow-up once you confirm placement.
- Nudge step sizes default to the PRD §3.4 table — change `nudgeStepHz()` in `filterPresets.ts` if you want different values.

## Acceptance (PRD §8)

1–7, 9–14 are implemented. 8 and 15 are Phase-5/profiling items:
- (8) OOB red colouring requires the band-planning PRD's `inBand()` to ship first — this PR keeps the client path behind the stub predicate per §7.
- (15) Mini-pan issues 1 trace stroke + 1 fill + 2 triangle fills per frame from a single 2D context, no allocations in the hot path; actual frame-time profile is a pre-merge task for you on the reference hardware.

## Test plan
- [ ] Fresh connect — compact panel shows under VFO, USB VAR1 (150/2850) is active, amber overlay visible on panadapter + waterfall.
- [ ] Click F7 — passband narrows to 100/2500, chip lights amber.
- [ ] Drag right-edge of panadapter overlay — width updates live, chip flips to VAR1, server logs one write per ~50 ms.
- [ ] USB → LSB mode switch — selection survives, overlay mirrors to negative side.
- [ ] Open advanced ribbon — shows LOW CUT / PASSBAND / HIGH CUT readouts + 10 kHz mini-pan.
- [ ] Drag mini-pan edge — all four readouts update, main panadapter overlay tracks in lock-step.
- [ ] Drag inside the mini-pan passband rect — both edges move together, PASSBAND width preserved.
- [ ] Click the × close button — ribbon hides; reopening via `≡` restores it.
- [ ] Restart `dotnet run --project Zeus.Server`, reload browser — ribbon open/closed state survives; USB VAR1 edits persisted.
- [ ] `curl -X POST /api/filter/presets -d '{"mode":"USB","slotName":"F6",…}'` returns 409.
- [ ] Mobile breakpoint — ribbon not mounted, advanced toggle hidden.