### PR TITLE
feat(protocol2): G2 MkII TX pipeline — TUN/MOX + TX filter + PA defaults + gain staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ React + WebGL frontend over WebSocket.
 > - **Hermes Lite 2 (Protocol-1):** RX is solid; TX is operator-verified on FM
 >   and TUNE (v0.1, April 2026).
 > - **ANAN G2 (Protocol-2):** RX verified on OrionMkII / fw 2.7b41 across
->   80m–10m. TX and 160m are not yet wired — experimental.
+>   80m–10m. TX wired for TUNE and MOX — on-air carrier verified clean via an
+>   external KiwiSDR. 160m not yet wired.
 > - Other Protocol-1 radios (older ANAN, Hermes, Angelia, etc.) are not yet
 >   supported.
 
@@ -93,6 +94,57 @@ Connecting to a radio while wisdom is still building will crash the backend
 with a native double-free abort. Once wisdom is cached
 (`~/.local/share/Zeus/wdspWisdom00` on Linux, `%LOCALAPPDATA%\Zeus\wdspWisdom00`
 on Windows), subsequent starts log `result=0 (loaded)` and come up instantly.
+
+## PA settings (power calibration)
+
+Zeus maps the drive / tune slider to an on-air wattage using a two-input
+formula lifted from Thetis and pihpsdr:
+
+1. **Rated PA Output (W)** — the amplifier's rated max power at full drive.
+2. **PA Gain (dB)**, per band — the amplifier's forward gain from DUC output
+   to the antenna (not a trim; the amplifier's physical gain).
+
+Slider 100 % targets the rated wattage; slider 50 % targets half that wattage.
+The per-band gain corrects for the fact that different HF bands need different
+drive bytes to produce the same on-air watts.
+
+### Defaults
+
+Fresh installs now seed the Rated PA Output per board class:
+
+| Radio class                        | Rated PA Output (default) |
+| ---------------------------------- | ------------------------- |
+| Hermes Lite 2                      |    5 W                    |
+| Hermes / Metis / Griffin / ANAN-10 |   10 W                    |
+| ANAN-100 / 100B / 8000D (Angelia)  |  100 W                    |
+| ANAN-100D / 200D (Orion)           |  100 W                    |
+| ANAN-7000D / G1 / G2 (OrionMkII)   |  100 W                    |
+
+Per-band PA Gain defaults are seeded from Thetis's per-board calibration
+tables (see `Zeus.Server/PaDefaults.cs`).
+
+> **Upgrading from an older Zeus install?** The per-board default only
+> applies on first run — if you've used Zeus before the `pa_globals` record
+> is already stored with `PaMaxPowerWatts = 0`, which silently forces the
+> legacy linear mode (PA Gain is ignored). **Open the Settings menu → PA
+> tab, set `Rated PA Output (W)` to 100 for a G2 / ANAN or 10 for a Hermes,
+> and click Apply.** Or delete `~/.local/share/Zeus/zeus-prefs.db` to start
+> fresh and pick up the new defaults automatically.
+
+### Applying changes
+
+**PA settings require an explicit Apply click to persist.** After editing
+any value in the Settings menu's PA tab, click the **Apply** button at the
+bottom of the tab — changes only take effect on the radio at that moment.
+Closing the Settings modal without clicking Apply discards pending edits.
+
+## Known quirks
+
+- **TUN carrier looks momentarily wide / pulses for ~1 s on the Zeus
+  panadapter when you first key it.** This is a Zeus display artifact —
+  the actual RF transmitted is a clean zero-beat single-tone carrier,
+  verified via an external receiver (KiwiSDR). To be cleaned up at a
+  later date.
 
 ## Getting started (developers)
 

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -94,7 +94,14 @@ public sealed record StateDto(
     string? FilterPresetName = null,
     // Advanced-filter ribbon visibility, persisted across server restarts via
     // FilterPresetStore so the operator's close-the-ribbon choice sticks.
-    bool FilterAdvancedPaneOpen = false);
+    bool FilterAdvancedPaneOpen = false,
+    // TX bandpass filter (WDSP TXA SetTXABandpassFreqs). Signed per sideband
+    // like RX FilterLowHz/HighHz: USB positive, LSB negative, AM/FM symmetric
+    // around 0. RadioService keeps per-mode-family memory so switching USB →
+    // LSB flips the sign and USB → AM swaps to AM's remembered width.
+    // Default 150/2850 matches Thetis's stock SSB TX bandpass.
+    int TxFilterLowHz = 150,
+    int TxFilterHighHz = 2850);
 
 public sealed record RadioInfo(
     string MacAddress,
@@ -115,6 +122,11 @@ public sealed record VfoSetRequest(long Hz);
 public sealed record ModeSetRequest(RxMode Mode);
 
 public sealed record BandwidthSetRequest(int Low, int High);
+
+/// <summary>TX bandpass set request — signed Hz pair matching StateDto's
+/// TxFilterLowHz/TxFilterHighHz convention (LSB-style passbands are negative,
+/// DSB/AM/FM symmetric around 0).</summary>
+public sealed record TxFilterSetRequest(int LowHz, int HighHz);
 
 public sealed record SampleRateSetRequest(int Rate);
 

--- a/Zeus.Dsp/IDspEngine.cs
+++ b/Zeus.Dsp/IDspEngine.cs
@@ -63,8 +63,11 @@ public interface IDspEngine : IDisposable
     bool TryGetDisplayPixels(int channelId, DisplayPixout which, Span<float> dbOut);
 
     /// <summary>Open the TXA channel. Idempotent — calling twice returns the existing id.
-    /// Must be called after at least one OpenChannel(RXA). For Synthetic, returns -1 and is a no-op.</summary>
-    int OpenTxChannel();
+    /// Must be called after at least one OpenChannel(RXA). For Synthetic, returns -1 and is a no-op.
+    /// <paramref name="outputRateHz"/> picks the TXA profile: 48000 for P1 (48k in/out, CFIR off),
+    /// 192000 for P2 (48k mic / 96k dsp / 192k out, CFIR on). Defaults to P1 for tests and
+    /// bring-up code that doesn't care.</summary>
+    int OpenTxChannel(int outputRateHz = 48_000);
 
     /// <summary>Flip MOX. When on: SetChannelState(RXA,0,1) then SetChannelState(TXA,1,0).
     /// When off: SetChannelState(TXA,0,1) then SetChannelState(RXA,1,0). For Synthetic, no-op.
@@ -84,14 +87,21 @@ public interface IDspEngine : IDisposable
     /// <summary>Process one WDSP-sized block of mic audio through TXA and return
     /// the modulated IQ. <paramref name="micMono"/> must contain exactly
     /// <see cref="TxBlockSamples"/> float samples (48 kHz mono). <paramref name="iqInterleaved"/>
-    /// receives 2 × TxBlockSamples floats ([I0, Q0, I1, Q1, …]).
+    /// receives 2 × <see cref="TxOutputSamples"/> floats ([I0, Q0, I1, Q1, …]).
+    /// For P1 the TXA output rate equals 48 kHz so input count == output count;
+    /// for P2 the TXA upsamples to 192 kHz so output count == 4 × input count.
     /// Returns the number of IQ complex samples produced (0 if TXA not open, MOX
     /// off, or the engine does not implement TX processing like Synthetic).</summary>
     int ProcessTxBlock(ReadOnlySpan<float> micMono, Span<float> iqInterleaved);
 
-    /// <summary>WDSP TXA block size in mono samples. Mic ingest buffers accumulate
-    /// this many samples before calling ProcessTxBlock.</summary>
+    /// <summary>WDSP TXA mic-input block size in mono samples. Mic ingest buffers
+    /// accumulate this many samples before calling ProcessTxBlock.</summary>
     int TxBlockSamples { get; }
+
+    /// <summary>WDSP TXA IQ-output block size in complex samples. Equals
+    /// <see cref="TxBlockSamples"/> for P1 (48 kHz out); for P2 the TXA upsamples
+    /// 48k → 192k so this is 4 × <see cref="TxBlockSamples"/>.</summary>
+    int TxOutputSamples { get; }
 
     /// <summary>Set TXA mic-side linear gain (Thetis audio.cs:218-224 wires the
     /// mic-gain dB slider via <c>SetTXAPanelGain1(TXA, 10^(db/20))</c>).

--- a/Zeus.Dsp/IDspEngine.cs
+++ b/Zeus.Dsp/IDspEngine.cs
@@ -84,6 +84,12 @@ public interface IDspEngine : IDisposable
     /// TXA is open.</summary>
     void SetTxMode(RxMode mode);
 
+    /// <summary>Set TXA bandpass (SetTXABandpassFreqs). <paramref name="lowHz"/>
+    /// / <paramref name="highHz"/> are signed Hz around baseband — LSB-style
+    /// passbands are negative, DSB/AM/FM symmetric. No-op for Synthetic and
+    /// when TXA is not open.</summary>
+    void SetTxFilter(int lowHz, int highHz);
+
     /// <summary>Process one WDSP-sized block of mic audio through TXA and return
     /// the modulated IQ. <paramref name="micMono"/> must contain exactly
     /// <see cref="TxBlockSamples"/> float samples (48 kHz mono). <paramref name="iqInterleaved"/>

--- a/Zeus.Dsp/SyntheticDspEngine.cs
+++ b/Zeus.Dsp/SyntheticDspEngine.cs
@@ -131,7 +131,7 @@ public sealed class SyntheticDspEngine : IDspEngine
     // TX interface — synthetic engine has no TXA and no outbound path. Returning
     // -1 lets callers distinguish "no TXA open" from any real id. SetMox is a
     // no-op so TxService calls while disconnected don't throw.
-    public int OpenTxChannel() => -1;
+    public int OpenTxChannel(int outputRateHz = 48_000) => -1;
 
     public void SetMox(bool moxOn) { }
 
@@ -146,6 +146,7 @@ public sealed class SyntheticDspEngine : IDspEngine
     public void SetTxMode(RxMode mode) { }
     public int ProcessTxBlock(ReadOnlySpan<float> micMono, Span<float> iqInterleaved) => 0;
     public int TxBlockSamples => 1024;
+    public int TxOutputSamples => 1024;
     public void SetTxPanelGain(double linearGain) { }
     public void SetTxLevelerMaxGain(double maxGainDb) { }
     public void SetTxTune(bool on) { }

--- a/Zeus.Dsp/SyntheticDspEngine.cs
+++ b/Zeus.Dsp/SyntheticDspEngine.cs
@@ -144,6 +144,7 @@ public sealed class SyntheticDspEngine : IDspEngine
     // mirrors WDSP so tests that round-trip through the interface can assume
     // the same buffering shape.
     public void SetTxMode(RxMode mode) { }
+    public void SetTxFilter(int lowHz, int highHz) { }
     public int ProcessTxBlock(ReadOnlySpan<float> micMono, Span<float> iqInterleaved) => 0;
     public int TxBlockSamples => 1024;
     public int TxOutputSamples => 1024;

--- a/Zeus.Dsp/Wdsp/NativeMethods.cs
+++ b/Zeus.Dsp/Wdsp/NativeMethods.cs
@@ -484,6 +484,13 @@ internal static partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial void SetTXABandpassWindow(int channel, int wintype);
 
+    // Correcting FIR — compensates the sinc droop introduced by TXA's
+    // 48k → 192k upsample on P2. P2 firmware requires this on; P1 leaves it
+    // off. Thetis audio.cs:1803-1808, pihpsdr transmitter.c:1288.
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetTXACFIRRun(int channel, int run);
+
     [LibraryImport(LibraryName)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial void SetTXAPanelRun(int channel, int run);
@@ -574,6 +581,32 @@ internal static partial class NativeMethods
     [LibraryImport(LibraryName)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial void SetTXAPostGenToneFreq(int channel, double freq);
+
+    // Pre-DSP generator (injected before the TX chain). pihpsdr transmitter.c
+    // :1293-1296 explicitly disables PreGen on TXA open — WDSP's create_channel
+    // doesn't guarantee mag=0/run=0, and a residual PreGen tone would appear
+    // alongside the PostGen tune tone as a second carrier.
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetTXAPreGenRun(int channel, int run);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetTXAPreGenMode(int channel, int mode);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetTXAPreGenToneMag(int channel, double mag);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetTXAPreGenToneFreq(int channel, double freq);
+
+    // TXA Panel input-select. pihpsdr sets this to 2 = "Mic I sample" on open
+    // (transmitter.c:1298). Default varies by WDSP build — being explicit.
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetTXAPanelSelect(int channel, int select);
 
     // meter.h:67 — returns a dBm value from RXA's internal meter ring. `mt` is
     // the rxaMeterType ordinal: 0 = RXA_S_PK, 1 = RXA_S_AV (what the S-meter

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -51,12 +51,32 @@ public sealed class WdspDspEngine : IDspEngine
     private const int RxaInSize = 1024;
     private const int RxaDspSize = 1024;
 
-    // TXA: match RXA's 1024@48k window. The Thetis 64@96k profile was tried
-    // on 2026-04-18 and produced ~0.6 W on TUN at 100% drive (target ~6 W),
-    // so this branch (feature/tx_pwr2) restores the dcd3766 settings that
-    // the operator confirmed produced rated power.
-    private const int TxaInSize = 1024;
-    private const int TxaDspSize = 1024;
+    // TXA profile varies by protocol — OpenTxChannel picks the right one:
+    //   P1 (48 kHz DAC) : in=1024@48k, dsp=1024@48k, out=1024@48k, CFIR off
+    //   P2 (192 kHz DAC): in=512@48k,  dsp=1024@96k, out=2048@192k, CFIR on
+    // pihpsdr transmitter.c:954-997 (protocol switch → buffer_size / dsp_rate /
+    // ratio) and Thetis audio.cs:1800-1809 (SampleRateTX + SetTXACFIRRun)
+    // define these exactly. Zeus was previously hard-coded to the P1 profile
+    // regardless of protocol, which on P2 left the G2 DUC starved (it runs
+    // at 192 kHz but we fed 48 kHz) and generated 8-10 kHz close-in spurs
+    // on TUN and MOX.
+    private const int TxaInSizeP1 = 1024;
+    private const int TxaDspSizeP1 = 1024;
+    private const int TxaOutSizeP1 = 1024;
+    private const int TxaInSizeP2 = 512;
+    private const int TxaDspSizeP2 = 1024;
+    private const int TxaOutSizeP2 = 2048;
+
+    // Latched values chosen at OpenTxChannel time; ProcessTxBlock uses them
+    // to size the mic / iq spans. Default to the P1 profile so tests and
+    // bring-up code that open TXA without specifying a protocol still work.
+    private int _txaInSize = TxaInSizeP1;
+    private int _txaDspSize = TxaDspSizeP1;
+    private int _txaOutSize = TxaOutSizeP1;
+    private int _txaInputRateHz = 48_000;
+    private int _txaDspRateHz = 48_000;
+    private int _txaOutputRateHz = 48_000;
+    private bool _txaCfirRun;
 
     // Leveler max-gain ceiling in dB applied at TXA init. Matches the
     // W1AEX / softerhardware community default ("CFC Audio Tools" guide,
@@ -611,7 +631,7 @@ public sealed class WdspDspEngine : IDspEngine
         }
     }
 
-    public int OpenTxChannel()
+    public int OpenTxChannel(int outputRateHz = 48_000)
     {
         ObjectDisposedException.ThrowIf(_disposed != 0, this);
 
@@ -619,25 +639,50 @@ public sealed class WdspDspEngine : IDspEngine
         {
             if (_txaChannelId is int existing) return existing;
 
+            // Pick the TXA profile from the requested output rate. P1's DAC
+            // runs at 48 kHz; the G2 on P2 expects 192 kHz. Any other value
+            // falls back to the P1 profile (treated as "not a supported P2
+            // rate" and keeps us off the air until the connect path specifies
+            // one we know about).
+            if (outputRateHz == 192_000)
+            {
+                _txaInSize = TxaInSizeP2;
+                _txaDspSize = TxaDspSizeP2;
+                _txaOutSize = TxaOutSizeP2;
+                _txaInputRateHz = 48_000;
+                _txaDspRateHz = 96_000;
+                _txaOutputRateHz = 192_000;
+                _txaCfirRun = true;
+            }
+            else
+            {
+                _txaInSize = TxaInSizeP1;
+                _txaDspSize = TxaDspSizeP1;
+                _txaOutSize = TxaOutSizeP1;
+                _txaInputRateHz = 48_000;
+                _txaDspRateHz = 48_000;
+                _txaOutputRateHz = 48_000;
+                _txaCfirRun = false;
+            }
+
             // TXA id must not collide with any RXA id — pick the first free slot
             // past the current RXA allocation. WDSP doesn't care about id
             // ordering, it just uses the int as an index into its channel table.
             int id = 0;
             while (_channels.ContainsKey(id) || id == _txaChannelId) id++;
 
-            // TXA matches the RXA OpenChannel shape — tdelay defaults identical
-            // — differing only in `type: 1` (TX) and `state: 0` (stays quiescent
-            // until SetMox(true)). Sample rates all 48 kHz: P1 EP2 uplink is
-            // 48 kHz, TXA runs at 48 kHz internally, output returns to 48 kHz
-            // for the EP2 packer. This is the dcd3766 configuration that the
-            // operator confirmed produced rated TX power.
+            // type: 1 (TX), state: 0 (stays quiescent until SetMox). Rates
+            // chosen above so P1 keeps its 48/48/48 shape (rated power
+            // confirmed on Hermes) and P2 matches pihpsdr transmitter.c's
+            // 48/96/192 profile with ratio=4 so the G2 DUC sees samples at
+            // its expected 192 kHz clock.
             NativeMethods.OpenChannel(
                 channel: id,
-                in_size: TxaInSize,
-                dsp_size: TxaDspSize,
-                input_samplerate: 48_000,
-                dsp_rate: 48_000,
-                output_samplerate: 48_000,
+                in_size: _txaInSize,
+                dsp_size: _txaDspSize,
+                input_samplerate: _txaInputRateHz,
+                dsp_rate: _txaDspRateHz,
+                output_samplerate: _txaOutputRateHz,
                 type: 1,
                 state: 0,
                 tdelayup: 0.010,
@@ -663,6 +708,27 @@ public sealed class WdspDspEngine : IDspEngine
             // bp0 is always on from create_bandpass; nothing to enable here.
             NativeMethods.SetTXAPanelRun(id, 1);
             NativeMethods.SetTXAPanelGain1(id, 1.0);
+            // pihpsdr transmitter.c:1298 routes mic to both I and Q via
+            // PanelSelect=2 ("Mic I sample"). Without this, WDSP's default
+            // may leave Q unassigned, allowing a secondary signal path to
+            // leak into the TXA output.
+            NativeMethods.SetTXAPanelSelect(id, 2);
+
+            // Explicitly disable the PreGen stage and zero its state — pihpsdr
+            // transmitter.c:1293-1296 does this on every TXA open. WDSP's
+            // create_channel does not guarantee these defaults, and a residual
+            // non-zero PreGen tone shows up alongside the PostGen tune carrier
+            // as a second discrete frequency on the air (reported as
+            // "2-tone-like output" during TUN on the G2 MkII).
+            NativeMethods.SetTXAPreGenMode(id, 0);
+            NativeMethods.SetTXAPreGenToneMag(id, 0.0);
+            NativeMethods.SetTXAPreGenToneFreq(id, 0.0);
+            NativeMethods.SetTXAPreGenRun(id, 0);
+
+            // Clamp PostGen off at open time too — TUN will re-enable it via
+            // SetTxTune. Same rationale: WDSP state from a previous channel
+            // open can leak through if we don't zero it.
+            NativeMethods.SetTXAPostGenRun(id, 0);
 
             // Explicit clean-slate TX chain state. WDSP initializes these
             // "off" at channel-create, but asserting them makes the baseline
@@ -693,10 +759,21 @@ public sealed class WdspDspEngine : IDspEngine
             NativeMethods.SetTXAAMSQRun(id, 0);
             NativeMethods.SetTXAALCSt(id, 1);
 
+            // CFIR compensates the sinc droop introduced by the TXA upsample
+            // to the output rate. Thetis (audio.cs:1808) turns it ON for P2,
+            // OFF for P1; pihpsdr (transmitter.c:1288) does the same. Wiring
+            // this on P1 would over-correct the flat 48k chain and tilt the
+            // passband, so it's conditional on the P2 profile.
+            if (_txaCfirRun)
+            {
+                NativeMethods.SetTXACFIRRun(id, 1);
+            }
+
             _txaChannelId = id;
             _log.LogInformation(
-                "wdsp.openTxChannel id={Id} chain=[alc=1 lvlr=1 lvlrMax={LvlrMax:F1}dB cpdr=0 cfc=0 phrot=0 osctrl=0 eq=0 amsq=0] bp=150..2850 panelGain=1.0 (Leveler enabled to match Thetis default)",
-                id, DefaultLevelerMaxGainDb);
+                "wdsp.openTxChannel id={Id} rates={InRate}/{DspRate}/{OutRate} sizes={InSz}/{OutSz} cfir={Cfir} chain=[alc=1 lvlr=1 lvlrMax={LvlrMax:F1}dB cpdr=0 cfc=0 phrot=0 osctrl=0 eq=0 amsq=0] bp=150..2850 panelGain=1.0",
+                id, _txaInputRateHz, _txaDspRateHz, _txaOutputRateHz,
+                _txaInSize, _txaOutSize, _txaCfirRun ? 1 : 0, DefaultLevelerMaxGainDb);
             return id;
         }
     }
@@ -759,7 +836,8 @@ public sealed class WdspDspEngine : IDspEngine
         }
     }
 
-    public int TxBlockSamples => TxaInSize;
+    public int TxBlockSamples => _txaInSize;
+    public int TxOutputSamples => _txaOutSize;
 
     public void SetTxPanelGain(double linearGain)
     {
@@ -800,23 +878,36 @@ public sealed class WdspDspEngine : IDspEngine
             // null for SSB). Sign mirrors Thetis's sideband rule.
             if (on)
             {
-                const double cwPitch = 600.0;
+                // pihpsdr radio.c:2716/2743 tunes at freq=0.0 — a true
+                // zero-beat carrier right on the VFO, which is the correct
+                // signal for tuning an external antenna tuner. Thetis uses
+                // ±cw_pitch so the tone survives the SSB bandpass, but for
+                // an ATU we want the carrier on-frequency, not 600 Hz off.
+                // Mode 0 = single tone (pihpsdr transmitter.c:2808, Thetis
+                // console.cs:30089 — both use mode 0).
+                const double toneFreq = 0.0;
                 const double toneMag = 0.99999;
-                double freq = _txCurrentMode switch
-                {
-                    RxaMode.LSB or RxaMode.CWL or RxaMode.DIGL => -cwPitch,
-                    _ => +cwPitch,
-                };
                 NativeMethods.SetTXAPostGenMode(txa, 0);
-                NativeMethods.SetTXAPostGenToneFreq(txa, freq);
+                NativeMethods.SetTXAPostGenToneFreq(txa, toneFreq);
                 NativeMethods.SetTXAPostGenToneMag(txa, toneMag);
                 NativeMethods.SetTXAPostGenRun(txa, 1);
-                _log.LogInformation("wdsp.setTxTune on=true mode={Mode} freq={Freq:F0} mag={Mag:F5}", _txCurrentMode, freq, toneMag);
+                // Disable Leveler while TUN is keyed. The 0 Hz tone lives
+                // below the SSB bandpass (150-2850 Hz), so the bandpass
+                // attenuates it ~30-40 dB. With the default Leveler on at
+                // +5 dB max gain, WDSP's AGC loop pumps trying to boost the
+                // weak signal — showing up as slow AM envelope on the
+                // panadapter. pihpsdr sidesteps this by keeping Leveler off
+                // by default (transmitter.c:2612 — state = compressor||cfc,
+                // both off on tune). We restore Leveler on TUN-off so mic
+                // MOX keeps its current Thetis-matching behavior.
+                NativeMethods.SetTXALevelerSt(txa, 0);
+                _log.LogInformation("wdsp.setTxTune on=true mode=singletone freq={Freq:F0} mag={Mag:F5} leveler=off", toneFreq, toneMag);
             }
             else
             {
                 NativeMethods.SetTXAPostGenRun(txa, 0);
-                _log.LogInformation("wdsp.setTxTune on=false");
+                NativeMethods.SetTXALevelerSt(txa, 1);
+                _log.LogInformation("wdsp.setTxTune on=false leveler=on");
             }
         }
     }
@@ -840,10 +931,12 @@ public sealed class WdspDspEngine : IDspEngine
     public int ProcessTxBlock(ReadOnlySpan<float> micMono, Span<float> iqInterleaved)
     {
         if (_disposed != 0) return 0;
-        if (micMono.Length != TxaInSize)
-            throw new ArgumentException($"expected mic span of {TxaInSize}", nameof(micMono));
-        if (iqInterleaved.Length != 2 * TxaInSize)
-            throw new ArgumentException($"expected iq span of {2 * TxaInSize}", nameof(iqInterleaved));
+        int inSize = _txaInSize;
+        int outSize = _txaOutSize;
+        if (micMono.Length != inSize)
+            throw new ArgumentException($"expected mic span of {inSize}", nameof(micMono));
+        if (iqInterleaved.Length != 2 * outSize)
+            throw new ArgumentException($"expected iq span of {2 * outSize}", nameof(iqInterleaved));
 
         int txa;
         lock (_txaLock)
@@ -852,16 +945,16 @@ public sealed class WdspDspEngine : IDspEngine
             txa = id;
         }
 
-        // fexchange2 wants mutable refs to the first float of each buffer. Copy
-        // the mic ReadOnlySpan into a scratch array so we can pass a ref, and
-        // stack-allocate Qin as silence and the output I/Q buffers. 1024 floats
-        // × 4 buffers = 16 KiB, well inside the default stack budget.
-        Span<float> iin = stackalloc float[TxaInSize];
+        // fexchange2 wants mutable refs to the first float of each buffer.
+        // For P2, in != out (inSize=512 mic, outSize=2048 IQ). Stack-allocate
+        // both — max combined footprint is 512 + 512 + 2048 + 2048 = 5120 floats
+        // ≈ 20 KiB, well inside the default stack budget.
+        Span<float> iin = stackalloc float[inSize];
         micMono.CopyTo(iin);
-        Span<float> qin = stackalloc float[TxaInSize];
+        Span<float> qin = stackalloc float[inSize];
         qin.Clear();
-        Span<float> iout = stackalloc float[TxaInSize];
-        Span<float> qout = stackalloc float[TxaInSize];
+        Span<float> iout = stackalloc float[outSize];
+        Span<float> qout = stackalloc float[outSize];
 
         NativeMethods.fexchange2(txa, ref iin[0], ref qin[0], ref iout[0], ref qout[0], out int err);
         if (err != 0 && ++_txFexchangeErrLogged <= 8)
@@ -869,7 +962,7 @@ public sealed class WdspDspEngine : IDspEngine
             _log.LogWarning("wdsp.fexchange2 tx err={Err} (suppressed after 8 occurrences)", err);
         }
 
-        for (int i = 0; i < TxaInSize; i++)
+        for (int i = 0; i < outSize; i++)
         {
             iqInterleaved[2 * i] = iout[i];
             iqInterleaved[2 * i + 1] = qout[i];
@@ -937,9 +1030,12 @@ public sealed class WdspDspEngine : IDspEngine
         {
             _lastTxMeterLogUtc = now;
             double micBlockPeak = 0, ioutPeak = 0;
-            for (int i = 0; i < TxaInSize; i++)
+            for (int i = 0; i < inSize; i++)
             {
                 double m = Math.Abs(iin[i]); if (m > micBlockPeak) micBlockPeak = m;
+            }
+            for (int i = 0; i < outSize; i++)
+            {
                 double oi = Math.Abs(iout[i]); double oq = Math.Abs(qout[i]);
                 double ma = Math.Max(oi, oq); if (ma > ioutPeak) ioutPeak = ma;
             }
@@ -951,7 +1047,7 @@ public sealed class WdspDspEngine : IDspEngine
                 alcPk, alcAv, -alcGain,
                 outPk, outAv);
         }
-        return TxaInSize;
+        return outSize;
     }
 
     // Mirror of ApplyBandpassForMode for the TX side. TXA has one bandpass

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -78,12 +78,19 @@ public sealed class WdspDspEngine : IDspEngine
     private int _txaOutputRateHz = 48_000;
     private bool _txaCfirRun;
 
-    // Leveler max-gain ceiling in dB applied at TXA init. Matches the
-    // W1AEX / softerhardware community default ("CFC Audio Tools" guide,
-    // ~+5 dB) — milder than Thetis's stock +15 dB, erring toward cleaner
-    // transmit audio on the first connect. Operator overrides via
+    // Leveler max-gain ceiling in dB applied at TXA init. Thetis ships
+    // 15 dB (radio.cs:2981 tx_leveler_max_gain = 15.0). Zeus used to ship
+    // 5 dB — which turned out to be the WDSP C-init default (TXA.c:169
+    // 1.778 linear), not a considered choice. With Compressor off the
+    // Leveler is the only makeup stage, so 5 dB left operators 10+ dB
+    // below Thetis-equivalent modulation on the air.
+    //
+    // Operator (kb2uka) requested 8 dB: his external analog rack already
+    // provides significant preamp and pre-DSP conditioning, so a smaller
+    // Leveler ceiling sounds cleaner than the Thetis stock 15 dB on his
+    // setup. Operators without an external rack can push it up to 15 via
     // POST /api/tx/leveler-max-gain.
-    internal const double DefaultLevelerMaxGainDb = 5.0;
+    internal const double DefaultLevelerMaxGainDb = 8.0;
 
     // Legacy aliases — RXA-side code still references these. Kept = RxaInSize
     // / RxaDspSize so existing callsites (audio outSamples math, channel
@@ -698,6 +705,10 @@ public sealed class WdspDspEngine : IDspEngine
             // at state=0 and consumes nothing.
             NativeMethods.SetTXAMode(id, (int)RxaMode.USB);
             _txCurrentMode = RxaMode.USB;
+            // Default passband matches the stock SSB TX width. DspPipelineService
+            // re-asserts this from the live StateDto (TxFilterLowHz/HighHz)
+            // immediately after OpenTxChannel so operator-edited widths survive
+            // a protocol switch / engine reopen.
             NativeMethods.SetTXABandpassFreqs(id, 150.0, 2850.0);
             NativeMethods.SetTXABandpassWindow(id, 1);
             // Intentionally NOT calling SetTXABandpassRun(id, 1): despite the
@@ -758,6 +769,16 @@ public sealed class WdspDspEngine : IDspEngine
             NativeMethods.SetTXAEQRun(id, 0);
             NativeMethods.SetTXAAMSQRun(id, 0);
             NativeMethods.SetTXAALCSt(id, 1);
+            // ALC tuning — Zeus previously left these at WDSP library defaults
+            // (MaxGain=0 dB linear/1.0). Thetis ships +3 dB max gain
+            // (database.cs:4596). Attack 1 ms / Decay 10 ms matches both
+            // pihpsdr (transmitter.c:1290-1291) and the WDSP factory that
+            // Thetis inherits (TXA.c:319, tau_attack = 0.001). A slower 2 ms
+            // attack missed plosive onset and the follow-up ALC chop sounded
+            // crunchy — operator described it as "brittle."
+            NativeMethods.SetTXAALCMaxGain(id, 3.0);
+            NativeMethods.SetTXAALCAttack(id, 1);
+            NativeMethods.SetTXAALCDecay(id, 10);
 
             // CFIR compensates the sinc droop introduced by the TXA upsample
             // to the output rate. Thetis (audio.cs:1808) turns it ON for P2,
@@ -921,9 +942,22 @@ public sealed class WdspDspEngine : IDspEngine
             if (_txaChannelId is not int txa) return;
             NativeMethods.SetTXAMode(txa, (int)mapped);
             _txCurrentMode = mapped;
-            ApplyTxBandpassForMode(txa, mapped);
+            // TXA bandpass is now operator-controlled — DspPipelineService
+            // asserts SetTxFilter after SetTxMode using the per-mode-family
+            // memory in RadioService. No auto-apply here.
         }
         _log.LogInformation("wdsp.setTxMode mode={Mode}", mapped);
+    }
+
+    public void SetTxFilter(int lowHz, int highHz)
+    {
+        if (_disposed != 0) return;
+        lock (_txaLock)
+        {
+            if (_txaChannelId is not int txa) return;
+            NativeMethods.SetTXABandpassFreqs(txa, lowHz, highHz);
+        }
+        _log.LogInformation("wdsp.setTxFilter low={Low} high={High}", lowHz, highHz);
     }
 
     private DateTime _lastTxMeterLogUtc;
@@ -1048,29 +1082,6 @@ public sealed class WdspDspEngine : IDspEngine
                 outPk, outAv);
         }
         return outSize;
-    }
-
-    // Mirror of ApplyBandpassForMode for the TX side. TXA has one bandpass
-    // (SetTXABandpassFreqs), not the three-stage RXA chain, so this is short.
-    private void ApplyTxBandpassForMode(int txa, RxaMode mode)
-    {
-        const double lo = 150.0;
-        const double hi = 2850.0;
-        double low, high;
-        switch (mode)
-        {
-            case RxaMode.LSB:
-            case RxaMode.CWL:
-            case RxaMode.DIGL:
-                low = -hi; high = -lo; break;
-            case RxaMode.USB:
-            case RxaMode.CWU:
-            case RxaMode.DIGU:
-                low = lo; high = hi; break;
-            default:
-                low = -hi; high = hi; break;
-        }
-        NativeMethods.SetTXABandpassFreqs(txa, low, high);
     }
 
     public void Dispose()

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -94,7 +94,9 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     private byte _driveByte;
     private byte _ocTxMask;
     private byte _ocRxMask;
+    private byte _ocTuneMask;
     private bool _moxOn;
+    private bool _tuneActive;
     private long _totalFrames;
     private long _droppedFrames;
     private uint _lastDdc0Seq;
@@ -109,6 +111,27 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     private uint _seqCmdRx;
     private uint _seqCmdTx;
     private uint _seqCmdHp;
+    private uint _seqCmdTxIq;
+
+    // TX-DUC IQ accumulator. WDSP TXA emits 1024/2048-sample blocks; the P2
+    // wire format wants 240 complex samples per 1444-byte packet on port 1029.
+    // We buffer into this 240-pair scratch and enqueue whenever it fills.
+    private const int TxIqSamplesPerPacket = 240;
+    // DAC rate = 192 kHz. 240 samples = 1.25 ms of audio per packet. A steady
+    // 1 packet / 1.25 ms stream keeps the radio's TX FIFO level instead of
+    // bursting (which shows up on the air as a pulsed / AM-modulated carrier
+    // with multi-tone-looking sidebands).
+    private const double TxDacSampleRate = 192_000.0;
+    // Mirrors pihpsdr new_protocol.c:1972 — target FIFO fill of ~1250 samples
+    // (6.5 ms of audio buffered in the radio). Past that we pace; below it
+    // we send as fast as packets are ready so the radio never underruns.
+    private const double TxFifoTargetSamples = 1250.0;
+    private readonly float[] _txIqScratch = new float[TxIqSamplesPerPacket * 2];
+    private int _txIqScratchCount;
+    private readonly object _txIqGate = new();
+    private readonly Channel<byte[]> _txIqQueue = Channel.CreateUnbounded<byte[]>(
+        new UnboundedChannelOptions { SingleReader = true });
+    private Task? _txIqSenderTask;
 
     public Protocol2Client(ILogger<Protocol2Client> log)
     {
@@ -160,6 +183,9 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         _rxCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         _rxTask = Task.Run(() => RxLoop(_rxCts.Token));
         _keepaliveTask = Task.Run(() => KeepaliveLoop(_rxCts.Token));
+        // Paced TX IQ sender — drains the queue FlushTxIqLocked fills and
+        // holds the radio's DUC FIFO at a steady level.
+        _txIqSenderTask = Task.Run(() => TxIqSenderLoop(_rxCts.Token));
         _log.LogInformation("p2.start rate={Rate}kHz freq={Freq}Hz", _sampleRateKhz, _rxFreqHz);
         return Task.CompletedTask;
     }
@@ -178,6 +204,13 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
             try { await _keepaliveTask.ConfigureAwait(false); }
             catch (OperationCanceledException) { }
             _keepaliveTask = null;
+        }
+        _txIqQueue.Writer.TryComplete();
+        if (_txIqSenderTask is not null)
+        {
+            try { await _txIqSenderTask.ConfigureAwait(false); }
+            catch (OperationCanceledException) { }
+            _txIqSenderTask = null;
         }
         _rxCts?.Dispose();
         _rxCts = null;
@@ -233,6 +266,12 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         if (_rxTask is not null) SendCmdHighPriority(run: true);
     }
 
+    public void SetOcTuneMask(byte mask)
+    {
+        _ocTuneMask = (byte)(mask & 0x7F);
+        if (_rxTask is not null && _tuneActive) SendCmdHighPriority(run: true);
+    }
+
     public void SetPaEnabled(bool enabled)
     {
         _paEnabled = enabled;
@@ -242,7 +281,157 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     public void SetMox(bool on)
     {
         _moxOn = on;
+        if (!on) ResetTxIq();
         if (_rxTask is not null) SendCmdHighPriority(run: true);
+    }
+
+    public void SetTune(bool on)
+    {
+        _tuneActive = on;
+        if (!on) ResetTxIq();
+        if (_rxTask is not null) SendCmdHighPriority(run: true);
+    }
+
+    /// <summary>
+    /// Push a block of interleaved float IQ (−1..+1) into the TX-DUC stream.
+    /// The block is buffered; when the accumulator reaches 240 complex
+    /// samples a 1444-byte P2 packet is sent to port 1029 (pihpsdr
+    /// new_protocol.c:1909-1942 — new_protocol_txiq_thread). Caller owns the
+    /// input buffer; we copy. Samples are scaled by pihpsdr's ggain=0.896
+    /// (transmitter.c:1761) to compensate for the end-of-chain FIR gain and
+    /// then quantized to signed 24-bit BE.
+    /// </summary>
+    public void SendTxIq(ReadOnlySpan<float> iqInterleaved)
+    {
+        if (_sock is null || _rxTask is null) return;
+        if ((iqInterleaved.Length & 1) != 0)
+            throw new ArgumentException("interleaved length must be even (I,Q pairs)", nameof(iqInterleaved));
+
+        lock (_txIqGate)
+        {
+            int idx = 0;
+            while (idx < iqInterleaved.Length)
+            {
+                int capacity = _txIqScratch.Length - _txIqScratchCount;
+                int copyLen = Math.Min(capacity, iqInterleaved.Length - idx);
+                iqInterleaved.Slice(idx, copyLen).CopyTo(_txIqScratch.AsSpan(_txIqScratchCount));
+                _txIqScratchCount += copyLen;
+                idx += copyLen;
+                if (_txIqScratchCount >= _txIqScratch.Length)
+                {
+                    FlushTxIqLocked();
+                }
+            }
+        }
+    }
+
+    private void ResetTxIq()
+    {
+        lock (_txIqGate) _txIqScratchCount = 0;
+        // Drain any queued-but-unsent packets so a fresh key-down starts
+        // from an empty FIFO model and the radio isn't playing 10 ms of
+        // the previous transmission's IQ when PTT re-engages.
+        while (_txIqQueue.Reader.TryRead(out _)) { }
+    }
+
+    private void FlushTxIqLocked()
+    {
+        // The 0.896 trim pihpsdr applies in transmitter.c:1707-1712 is
+        // CW-path-only — it compensates for the CW shaped pulse skipping
+        // WDSP TXA's end-of-chain FIR. The regular TXA path (which is what
+        // Zeus feeds — mic and TUN both go through TXA) takes the samples
+        // unscaled (transmitter.c:1739-1754), so no pre-quantize trim here.
+        var p = new byte[BufLen];
+        WriteBeU32(p, 0, _seqCmdTxIq++);
+        for (int i = 0; i < TxIqSamplesPerPacket; i++)
+        {
+            float fi = _txIqScratch[i * 2];
+            float fq = _txIqScratch[i * 2 + 1];
+            int vi = Int24Clamp(fi);
+            int vq = Int24Clamp(fq);
+            int off = 4 + i * 6;
+            p[off + 0] = (byte)((vi >> 16) & 0xff);
+            p[off + 1] = (byte)((vi >> 8) & 0xff);
+            p[off + 2] = (byte)(vi & 0xff);
+            p[off + 3] = (byte)((vq >> 16) & 0xff);
+            p[off + 4] = (byte)((vq >> 8) & 0xff);
+            p[off + 5] = (byte)(vq & 0xff);
+        }
+        // Enqueue instead of sending inline. The sender task drains this at
+        // the DAC rate so the radio's TX FIFO stays level — sending the full
+        // 8-packet burst from one WDSP cycle straight to the wire overfills
+        // then starves the FIFO, showing up as a pulsed carrier.
+        _txIqQueue.Writer.TryWrite(p);
+        _txIqScratchCount = 0;
+    }
+
+    private async Task TxIqSenderLoop(CancellationToken ct)
+    {
+        // Port of pihpsdr's new_protocol_txiq_thread (new_protocol.c:1909-1997).
+        // Maintains a software model of the radio's TX FIFO fill level: each
+        // packet adds 240 samples, wall-clock elapses drain at 192 kHz. When
+        // the modeled level exceeds the target (1250 samples ≈ 6.5 ms) we hold
+        // for 1 ms before sending the next packet. Below the target we send
+        // as fast as the queue delivers — that's the startup ramp that fills
+        // the radio's FIFO to its steady-state depth.
+        var reader = _txIqQueue.Reader;
+        var ep = new IPEndPoint(_radioEndpoint!.Address, 1029);
+        double fifoSamples = 0.0;
+        long lastTicks = Stopwatch.GetTimestamp();
+        double ticksPerSecond = Stopwatch.Frequency;
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                byte[] packet;
+                try { packet = await reader.ReadAsync(ct).ConfigureAwait(false); }
+                catch (OperationCanceledException) { break; }
+                catch (ChannelClosedException) { break; }
+
+                // Drain by wall-clock since the previous send.
+                long now = Stopwatch.GetTimestamp();
+                double elapsedSec = (now - lastTicks) / ticksPerSecond;
+                fifoSamples -= elapsedSec * TxDacSampleRate;
+                if (fifoSamples < 0.0) fifoSamples = 0.0;
+                lastTicks = now;
+
+                // If the radio's FIFO would overflow, wait a tick before the
+                // next send. The 1 ms delay is coarse but well within the
+                // FIFO's 6.5 ms target headroom, so no underrun risk.
+                if (fifoSamples > TxFifoTargetSamples)
+                {
+                    try { await Task.Delay(1, ct).ConfigureAwait(false); }
+                    catch (OperationCanceledException) { break; }
+                    now = Stopwatch.GetTimestamp();
+                    elapsedSec = (now - lastTicks) / ticksPerSecond;
+                    fifoSamples -= elapsedSec * TxDacSampleRate;
+                    if (fifoSamples < 0.0) fifoSamples = 0.0;
+                    lastTicks = now;
+                }
+
+                fifoSamples += TxIqSamplesPerPacket;
+                try { _sock!.SendTo(packet, ep); }
+                catch (ObjectDisposedException) { break; }
+                catch (SocketException ex)
+                {
+                    _log.LogWarning(ex, "p2.txiq send failed");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "p2.txiq sender exited with error");
+        }
+    }
+
+    private static int Int24Clamp(float v)
+    {
+        if (v >  1.0f) v =  1.0f;
+        if (v < -1.0f) v = -1.0f;
+        // 8_388_607 = 2^23 - 1. Using the ceiling (8_388_608) would map +1.0
+        // to a value that, when sign-extended on the far side, wraps to
+        // −8_388_608 — a full-scale negative spike on the loudest sample.
+        return (int)MathF.Round(v * 8_388_607.0f);
     }
 
     private void SendCmdGeneral()
@@ -312,7 +501,11 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     {
         var p = new byte[BufLen];
         WriteBeU32(p, 0, _seqCmdHp++);
-        p[4] = (byte)(run ? 0x01 : 0x00);
+        // Byte 4 bit 0 = run, bit 1 = PTT. Thetis network.c:924-925 and
+        // pihpsdr new_protocol.c:746-757 both set bit 1 whenever the radio
+        // should key — covers both mic-MOX and TUN. Without this bit the
+        // radio stays in RX regardless of drive / tune state.
+        p[4] = (byte)((_moxOn ? 0x02 : 0x00) | (run ? 0x01 : 0x00));
 
         // Frequency field is a PHASE word (general[37] bit 3 set) — radio
         // reads a 32-bit phase increment, not Hz. pihpsdr computes this as
@@ -330,10 +523,15 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         // and TX is keyed elsewhere (byte 4 bit 1). piHPSDR `new_protocol.c:860`.
         p[345] = _driveByte;
 
-        // OC outputs (7-bit mask) shifted left by 1 into byte 1401. TX mask
-        // when MOX is on, RX mask otherwise. piHPSDR `new_protocol.c:877-894`
-        // (OCtune handling deferred until Tune integrates with PA settings).
-        p[1401] = (byte)(((_moxOn ? _ocTxMask : _ocRxMask) & 0x7F) << 1);
+        // OC outputs (7-bit mask) shifted left by 1 into byte 1401. During
+        // TX the TX mask applies; during TUN we OR in the OCtune mask so
+        // anything wired to the tune pin (e.g. an external linear's tune-
+        // mode relay) closes. RX mask when keyed down. pihpsdr
+        // new_protocol.c:877-894.
+        byte ocBits = _moxOn
+            ? (byte)(_ocTxMask | (_tuneActive ? _ocTuneMask : (byte)0))
+            : _ocRxMask;
+        p[1401] = (byte)((ocBits & 0x7F) << 1);
 
         // Mercury attenuator byte: bit 0 = RX0 preamp, bit 1 = RX1 preamp
         // (Thetis network.c:1037).
@@ -344,12 +542,19 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
 
         // Alex words. Bit positions and BPF selections per pihpsdr's alex.h +
         // new_protocol.c (function new_protocol_high_priority, device cases
-        // NEW_DEVICE_ORION2 / NEW_DEVICE_SATURN). Alex0 holds the RX BPF +
-        // TX LPF + TX antenna; Alex1 duplicates for the RX path during TX.
-        // Offsets: Alex0 at 1432..1435, Alex1 at 1428..1431.
-        uint alex = ComputeAlexWord(_rxFreqHz, _rxFreqHz, txAnt: 1);
-        WriteBeU32(p, 1428, alex);
-        WriteBeU32(p, 1432, alex);
+        // NEW_DEVICE_ORION2 / NEW_DEVICE_SATURN). Offsets: Alex0 at 1432..1435,
+        // Alex1 at 1428..1431. During TX both words need ALEX_TX_RELAY
+        // (pihpsdr new_protocol.c:989-992) so the T/R relay on the LPF board
+        // flips to the TX path; without it the TX signal reaches the antenna
+        // through the RX filters and DAC images radiate as out-of-band
+        // harmonics. Alex1 additionally gets RX_GNDonTX to short the RX input
+        // while keyed, protecting the ADC.
+        bool xmit = _moxOn;
+        uint alexCommon = ComputeAlexWord(_rxFreqHz, _rxFreqHz, txAnt: 1);
+        uint alex0 = alexCommon | (xmit ? ALEX_TX_RELAY : 0u);
+        uint alex1 = alexCommon | (xmit ? ALEX_TX_RELAY | ALEX1_ANAN7000_RX_GNDonTX : 0u);
+        WriteBeU32(p, 1428, alex1);
+        WriteBeU32(p, 1432, alex0);
         _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1027));
     }
 
@@ -382,6 +587,14 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     private const uint ALEX_TX_ANTENNA_2   = 0x02000000;
     private const uint ALEX_TX_ANTENNA_3   = 0x04000000;
 
+    // Flips the T/R relay on the LPF board so the TX path reaches the antenna
+    // through the selected TX LPF instead of through the RX BPF path. OR'd
+    // into both alex0 and alex1 during TX (pihpsdr new_protocol.c:989-992).
+    private const uint ALEX_TX_RELAY       = 0x08000000;
+    // Alex1-only: grounds the RX input while keyed so the hot TX field doesn't
+    // back-feed into the Mercury ADC (pihpsdr alex.h ANAN7000_RX_GNDonTX).
+    private const uint ALEX1_ANAN7000_RX_GNDonTX = 0x00000100;
+
     internal static uint ComputeAlexWord(uint rxFreqHz, uint txFreqHz, int txAnt)
     {
         uint word = 0;
@@ -410,16 +623,18 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         return ALEX_ANAN7000_RX_6_PRE_BPF;
     }
 
-    // TX LPF band splits (pihpsdr calc_tx_alex in alex.c). Same band groupings
-    // as the physical LPF board — not HPF-shaped.
+    // TX LPF band splits. Thresholds match pihpsdr new_protocol.c:1204-1218
+    // exactly (strict > rather than >= so the band edges route the way the
+    // LPF board expects; off-by-one on a threshold lets the wrong filter
+    // pass harmonics at e.g. 24.9 MHz or 16.4 MHz).
     internal static uint LpfBitsAnan7000(uint freqHz)
     {
-        if (freqHz >= 33_000_000u) return ALEX_6_BYPASS_LPF;
-        if (freqHz >= 22_000_000u) return ALEX_12_10_LPF;
-        if (freqHz >= 15_000_000u) return ALEX_17_15_LPF;
-        if (freqHz >=  8_000_000u) return ALEX_30_20_LPF;
-        if (freqHz >=  4_500_000u) return ALEX_60_40_LPF;
-        if (freqHz >=  2_500_000u) return ALEX_80_LPF;
+        if (freqHz > 35_600_000u) return ALEX_6_BYPASS_LPF;
+        if (freqHz > 24_000_000u) return ALEX_12_10_LPF;
+        if (freqHz > 16_500_000u) return ALEX_17_15_LPF;
+        if (freqHz >  8_000_000u) return ALEX_30_20_LPF;
+        if (freqHz >  5_000_000u) return ALEX_60_40_LPF;
+        if (freqHz >  2_500_000u) return ALEX_80_LPF;
         return ALEX_160_LPF;
     }
 

--- a/Zeus.Server/DspPipelineService.cs
+++ b/Zeus.Server/DspPipelineService.cs
@@ -75,6 +75,8 @@ public class DspPipelineService : BackgroundService
     private RxMode _appliedMode = RxMode.USB;
     private int _appliedLowHz;
     private int _appliedHighHz;
+    private int _appliedTxLowHz;
+    private int _appliedTxHighHz;
     private double _appliedAgcTopDb;
     private NrConfig _appliedNr = new();
     private int _appliedZoomLevel = 1;
@@ -252,6 +254,12 @@ public class DspPipelineService : BackgroundService
             _appliedLowHz = s.FilterLowHz;
             _appliedHighHz = s.FilterHighHz;
         }
+        if (s.TxFilterLowHz != _appliedTxLowHz || s.TxFilterHighHz != _appliedTxHighHz)
+        {
+            engine.SetTxFilter(s.TxFilterLowHz, s.TxFilterHighHz);
+            _appliedTxLowHz = s.TxFilterLowHz;
+            _appliedTxHighHz = s.TxFilterHighHz;
+        }
         if (s.AgcTopDb != _appliedAgcTopDb)
         {
             engine.SetAgcTop(channel, s.AgcTopDb);
@@ -280,6 +288,7 @@ public class DspPipelineService : BackgroundService
         // OpenTxChannel).
         engine.SetTxMode(s.Mode);
         engine.SetFilter(channelId, s.FilterLowHz, s.FilterHighHz);
+        engine.SetTxFilter(s.TxFilterLowHz, s.TxFilterHighHz);
         engine.SetVfoHz(channelId, s.VfoHz);
         engine.SetAgcTop(channelId, s.AgcTopDb);
         engine.SetNoiseReduction(channelId, nr);
@@ -287,6 +296,8 @@ public class DspPipelineService : BackgroundService
         _appliedMode = s.Mode;
         _appliedLowHz = s.FilterLowHz;
         _appliedHighHz = s.FilterHighHz;
+        _appliedTxLowHz = s.TxFilterLowHz;
+        _appliedTxHighHz = s.TxFilterHighHz;
         _appliedAgcTopDb = s.AgcTopDb;
         _appliedNr = nr;
         _appliedZoomLevel = s.ZoomLevel;

--- a/Zeus.Server/DspPipelineService.cs
+++ b/Zeus.Server/DspPipelineService.cs
@@ -102,6 +102,8 @@ public class DspPipelineService : BackgroundService
         _radio.Disconnected += OnRadioDisconnected;
         _radio.StateChanged += OnRadioStateChanged;
         _radio.PaSnapshotChanged += OnPaSnapshotChanged;
+        _radio.MoxChanged += OnRadioMoxChanged;
+        _radio.TunActiveChanged += OnRadioTunActiveChanged;
 
         var panBuf = new float[Width];
         var wfBuf = new float[Width];
@@ -122,6 +124,8 @@ public class DspPipelineService : BackgroundService
             _radio.Disconnected -= OnRadioDisconnected;
             _radio.StateChanged -= OnRadioStateChanged;
             _radio.PaSnapshotChanged -= OnPaSnapshotChanged;
+            _radio.MoxChanged -= OnRadioMoxChanged;
+            _radio.TunActiveChanged -= OnRadioTunActiveChanged;
             await StopIqPumpAsync().ConfigureAwait(false);
             CloseCurrentEngine();
         }
@@ -174,7 +178,9 @@ public class DspPipelineService : BackgroundService
 
         var wdsp = new WdspDspEngine(_loggerFactory.CreateLogger<WdspDspEngine>());
         int channelId = wdsp.OpenChannel(rate, Width);
-        wdsp.OpenTxChannel();
+        // P1 DAC runs at 48 kHz; keep TXA at the 48/48/48 profile Hermes is
+        // calibrated against.
+        wdsp.OpenTxChannel(outputRateHz: 48_000);
         ApplyStateToNewChannel(wdsp, channelId);
 
         IDspEngine? old;
@@ -362,7 +368,11 @@ public class DspPipelineService : BackgroundService
         {
             var wdsp = new WdspDspEngine(_loggerFactory.CreateLogger<WdspDspEngine>());
             newChannelId = wdsp.OpenChannel(rateHz, Width);
-            wdsp.OpenTxChannel();
+            // G2 MkII DUC on P2 expects 192 kHz TX IQ. WDSP upsamples internally
+            // (48k mic → 96k DSP → 192k out) and CFIR compensates the sinc
+            // droop. Feeding 48 kHz IQ to a 192 kHz DUC as we did before
+            // produced 8-10 kHz close-in spurs around the carrier.
+            wdsp.OpenTxChannel(outputRateHz: 192_000);
             // Best-effort apply. Some local WDSP builds are missing newer
             // entry points (e.g. SetRXAEMNRpost2Run); the channel itself is
             // open and capable of spectrum work even if a noise-reduction
@@ -412,7 +422,28 @@ public class DspPipelineService : BackgroundService
         if (p2 is null) return;
         p2.SetDriveByte(snap.DriveByte);
         p2.SetOcMasks(snap.OcTxMask, snap.OcRxMask);
+        p2.SetOcTuneMask(snap.OcTuneMask);
         p2.SetPaEnabled(snap.PaEnabled);
+    }
+
+    private void OnRadioMoxChanged(bool on)
+    {
+        _p2Client?.SetMox(on);
+    }
+
+    private void OnRadioTunActiveChanged(bool on)
+    {
+        _p2Client?.SetTune(on);
+    }
+
+    /// <summary>
+    /// Forward a WDSP TXA block of interleaved float IQ to the live P2 client.
+    /// No-op when P2 isn't connected; safe to call from TxTuneDriver / future
+    /// mic-MOX feeders without branching on protocol.
+    /// </summary>
+    public void ForwardTxIqToP2(ReadOnlySpan<float> iqInterleaved)
+    {
+        _p2Client?.SendTxIq(iqInterleaved);
     }
 
     public async Task DisconnectP2Async(CancellationToken ct)

--- a/Zeus.Server/PaDefaults.cs
+++ b/Zeus.Server/PaDefaults.cs
@@ -87,4 +87,25 @@ internal static class PaDefaults
         if (board == HpsdrBoardKind.HermesLite2) return Hl2FlatGainDb;
         return TableFor(board).TryGetValue(band, out var v) ? v : 0.0;
     }
+
+    // Rated PA output in watts per board class. Used as the default for
+    // PaGlobalSettingsDto.PaMaxPowerWatts when no operator-entered value is
+    // stored. Without this, new installs fall into the
+    // `maxWatts == 0` → `byte = pct * 255 / 100` legacy path, which silently
+    // ignores PaGainDb and makes the per-band settings feel broken.
+    //
+    // Values match the Thetis factory labels per board class. Operators can
+    // override at any time via the PA Settings panel and the stored value
+    // wins over this default on subsequent reads.
+    public static int GetMaxPowerWatts(HpsdrBoardKind board) => board switch
+    {
+        HpsdrBoardKind.HermesLite2 => 5,      // HL2: class-A 5 W stock
+        HpsdrBoardKind.Hermes      => 10,     // Hermes / ANAN-10 / ANAN-10E: 10 W
+        HpsdrBoardKind.Metis       => 10,     // Metis boards paired with 10 W PA
+        HpsdrBoardKind.Griffin     => 10,
+        HpsdrBoardKind.Angelia     => 100,    // ANAN-100 / ANAN-100B / ANAN-8000D: 100 W
+        HpsdrBoardKind.Orion       => 100,    // ANAN-100D / ANAN-200D: 100 W
+        HpsdrBoardKind.OrionMkII   => 100,    // ANAN-7000D / G1 / G2 / G2-1K driven: 100 W
+        _                          => 0,      // Unknown board — keep legacy mode, no surprises
+    };
 }

--- a/Zeus.Server/PaSettingsStore.cs
+++ b/Zeus.Server/PaSettingsStore.cs
@@ -60,8 +60,14 @@ public sealed class PaSettingsStore : IDisposable
         lock (_sync)
         {
             var g = _globals.FindAll().FirstOrDefault();
+            // When nothing is persisted yet, seed the global with board-specific
+            // defaults so new operators don't land in the "PaMaxPowerWatts=0 →
+            // PaGainDb ignored" legacy mode on first connect.
             var global = g is null
-                ? new PaGlobalSettingsDto()
+                ? new PaGlobalSettingsDto(
+                    PaEnabled: true,
+                    PaMaxPowerWatts: PaDefaults.GetMaxPowerWatts(board),
+                    OcTune: 0)
                 : new PaGlobalSettingsDto(g.PaEnabled, g.PaMaxPowerWatts, g.OcTune);
 
             var existing = _bands.FindAll().ToDictionary(e => e.Band, e => e);
@@ -91,13 +97,16 @@ public sealed class PaSettingsStore : IDisposable
         }
     }
 
-    public PaGlobalSettingsDto GetGlobal()
+    public PaGlobalSettingsDto GetGlobal(HpsdrBoardKind board = HpsdrBoardKind.Unknown)
     {
         lock (_sync)
         {
             var g = _globals.FindAll().FirstOrDefault();
             return g is null
-                ? new PaGlobalSettingsDto()
+                ? new PaGlobalSettingsDto(
+                    PaEnabled: true,
+                    PaMaxPowerWatts: PaDefaults.GetMaxPowerWatts(board),
+                    OcTune: 0)
                 : new PaGlobalSettingsDto(g.PaEnabled, g.PaMaxPowerWatts, g.OcTune);
         }
     }

--- a/Zeus.Server/Program.cs
+++ b/Zeus.Server/Program.cs
@@ -377,6 +377,15 @@ app.MapPost("/api/bandwidth", (BandwidthSetRequest req, RadioService r) =>
     return r.SetFilter(req.Low, req.High);
 });
 
+// TX bandpass filter — signed Hz pair (LSB negative, DSB symmetric). Per-mode
+// family memory is managed in RadioService, identical shape to the RX filter.
+// Operator-editable via Settings → TX Filter panel.
+app.MapPost("/api/tx-filter", (TxFilterSetRequest req, RadioService r) =>
+{
+    log.LogInformation("api.tx-filter low={L} high={H}", req.LowHz, req.HighHz);
+    return r.SetTxFilter(req.LowHz, req.HighHz);
+});
+
 // Filter preset endpoints (PRD §5.2). These are the preferred filter surface;
 // /api/bandwidth remains for backward compat. POST /api/filter also accepts
 // an optional PresetName to track which chip is active.

--- a/Zeus.Server/RadioService.cs
+++ b/Zeus.Server/RadioService.cs
@@ -114,6 +114,12 @@ public sealed class RadioService : IDisposable
     // CmdGeneral[58]). RadioService pushes to the P1 client directly because
     // it owns _activeClient.
     public event Action<PaRuntimeSnapshot>? PaSnapshotChanged;
+    // Fires on every MOX / TUN edge. P1 side is pushed directly via
+    // ActiveClient?.SetMox; these events give DspPipelineService the hook it
+    // needs to forward the same bit into a live Protocol2Client, which owns
+    // its own CmdHighPriority byte 4.
+    public event Action<bool>? MoxChanged;
+    public event Action<bool>? TunActiveChanged;
 
     // Shared TX IQ source threaded through Protocol1Client. TxAudioIngest
     // writes into the same instance; this is the seam between "mic arrived
@@ -174,6 +180,16 @@ public sealed class RadioService : IDisposable
     public IProtocol1Client? ActiveClient
     {
         get { lock (_sync) return _activeClient; }
+    }
+
+    /// <summary>
+    /// True when any backend (P1 or P2) has a live connection. Needed by
+    /// TxService's MOX / TUN interlock — a G2 on P2 has no ActiveClient
+    /// (Protocol1Client is null) but still wants to accept TX requests.
+    /// </summary>
+    public bool IsConnected
+    {
+        get { lock (_sync) return _activeClient is not null || _p2Active; }
     }
 
     public StateDto Snapshot() { lock (_sync) return _state; }
@@ -476,6 +492,7 @@ public sealed class RadioService : IDisposable
     {
         lock (_sync) _mox = on;
         ActiveClient?.SetMox(on);
+        MoxChanged?.Invoke(on);
     }
 
     // Drive is transient like MOX — latched on the Protocol1Client so the
@@ -505,6 +522,7 @@ public sealed class RadioService : IDisposable
     {
         lock (_sync) _tunActive = on;
         RecomputePaAndPush();
+        TunActiveChanged?.Invoke(on);
     }
 
     // DspPipelineService calls this right after a P2 client is created so the

--- a/Zeus.Server/RadioService.cs
+++ b/Zeus.Server/RadioService.cs
@@ -310,6 +310,18 @@ public sealed class RadioService : IDisposable
     private FamilyFilter _fmFilter = new(0, 5500);
     private FamilyFilter _cwFilter = new(0, 125);
 
+    // TX-side per-family filter memory. Thetis stores a single TX filter Lo/Hi
+    // (setup.cs:5029-5066); pihpsdr uses hardcoded per-mode shapes
+    // (transmitter.c:2108-2211). Zeus mirrors the RX per-family model so the
+    // operator's USB TX width survives an AM round-trip, and LSB/USB share
+    // absolute values with sign flipped at apply time. Defaults track Thetis
+    // stock: SSB 150-2850, AM/DSB 0-4000, FM 0-3000 (Thetis narrowest FM TX
+    // is 3 kHz half-width), CW 0-150 (150 Hz around cw_pitch is plenty).
+    private FamilyFilter _ssbTxFilter = new(150, 2850);
+    private FamilyFilter _amTxFilter = new(0, 4000);
+    private FamilyFilter _fmTxFilter = new(0, 3000);
+    private FamilyFilter _cwTxFilter = new(0, 150);
+
     public StateDto SetMode(RxMode mode)
     {
         RxMode departingMode = default;
@@ -322,20 +334,31 @@ public sealed class RadioService : IDisposable
             // Save departing mode's preset name to the in-memory cache.
             _lastPresetPerMode[s.Mode] = s.FilterPresetName;
 
-            // 1) Save current abs-filter into the mode we are LEAVING.
+            // 1) Save current abs-filter into the mode we are LEAVING (RX + TX).
             int curLoAbs = Math.Min(Math.Abs(s.FilterLowHz), Math.Abs(s.FilterHighHz));
             int curHiAbs = Math.Max(Math.Abs(s.FilterLowHz), Math.Abs(s.FilterHighHz));
             StoreFamilyFilter(s.Mode, curLoAbs, curHiAbs);
+            int curTxLoAbs = Math.Min(Math.Abs(s.TxFilterLowHz), Math.Abs(s.TxFilterHighHz));
+            int curTxHiAbs = Math.Max(Math.Abs(s.TxFilterLowHz), Math.Abs(s.TxFilterHighHz));
+            StoreTxFamilyFilter(s.Mode, curTxLoAbs, curTxHiAbs);
 
-            // 2) Look up the target family's remembered filter.
+            // 2) Look up the target family's remembered filter (RX + TX).
             var fam = FamilyFilterFor(mode);
+            var txFam = TxFamilyFilterFor(mode);
 
             // 3) Re-sign per target mode's sideband convention.
             var (lo, hi) = SignedFilterForMode(mode, fam.LoAbs, fam.HiAbs);
+            var (txLo, txHi) = SignedFilterForMode(mode, txFam.LoAbs, txFam.HiAbs);
 
             // 4) Restore the last-known preset name for the incoming mode.
             _lastPresetPerMode.TryGetValue(mode, out var restoredPreset);
-            return s with { Mode = mode, FilterLowHz = lo, FilterHighHz = hi, FilterPresetName = restoredPreset };
+            return s with
+            {
+                Mode = mode,
+                FilterLowHz = lo, FilterHighHz = hi,
+                TxFilterLowHz = txLo, TxFilterHighHz = txHi,
+                FilterPresetName = restoredPreset,
+            };
         });
 
         // Persist the departing mode's last preset outside the lock.
@@ -357,6 +380,17 @@ public sealed class RadioService : IDisposable
         });
         if (presetName != null)
             _filterPresetStore?.UpsertLastSelectedPreset(modeAtSet, presetName);
+        return Snapshot();
+    }
+
+    // TX bandpass filter setter. Signed pair like SetFilter — caller is
+    // expected to have already re-signed positive (abs) values per the current
+    // mode's sideband convention. DspPipelineService picks up the state-change
+    // and forwards to the engine via IDspEngine.SetTxFilter.
+    public StateDto SetTxFilter(int lowHz, int highHz)
+    {
+        if (highHz < lowHz) (lowHz, highHz) = (highHz, lowHz);
+        Mutate(s => s with { TxFilterLowHz = lowHz, TxFilterHighHz = highHz });
         return Snapshot();
     }
 
@@ -398,6 +432,31 @@ public sealed class RadioService : IDisposable
                 _cwFilter = slot; break;
         }
     }
+
+    private void StoreTxFamilyFilter(RxMode mode, int loAbs, int hiAbs)
+    {
+        var slot = new FamilyFilter(loAbs, hiAbs);
+        switch (mode)
+        {
+            case RxMode.USB: case RxMode.LSB: case RxMode.DIGU: case RxMode.DIGL:
+                _ssbTxFilter = slot; break;
+            case RxMode.AM: case RxMode.SAM: case RxMode.DSB:
+                _amTxFilter = slot; break;
+            case RxMode.FM:
+                _fmTxFilter = slot; break;
+            case RxMode.CWL: case RxMode.CWU:
+                _cwTxFilter = slot; break;
+        }
+    }
+
+    private FamilyFilter TxFamilyFilterFor(RxMode mode) => mode switch
+    {
+        RxMode.USB or RxMode.LSB or RxMode.DIGU or RxMode.DIGL => _ssbTxFilter,
+        RxMode.AM or RxMode.SAM or RxMode.DSB => _amTxFilter,
+        RxMode.FM => _fmTxFilter,
+        RxMode.CWL or RxMode.CWU => _cwTxFilter,
+        _ => _ssbTxFilter,
+    };
 
     private FamilyFilter FamilyFilterFor(RxMode mode) => mode switch
     {

--- a/Zeus.Server/TxAudioIngest.cs
+++ b/Zeus.Server/TxAudioIngest.cs
@@ -78,8 +78,10 @@ public sealed class TxAudioIngest : IDisposable
     // draining. The excess gets shifted back after each flush.
     private readonly float[] _accumulator = new float[2048];
     private int _accumulatorFill;
+    // Sized for the larger of the P1 (1024 in / 2048 iq) and P2
+    // (512 in / 4096 iq) profiles so we don't reallocate at protocol switch.
     private readonly float[] _scratchMic = new float[1024];
-    private readonly float[] _scratchIq = new float[2048];
+    private readonly float[] _scratchIq = new float[4096];
 
     private long _totalMicSamples;
     private long _totalTxBlocks;
@@ -173,9 +175,12 @@ public sealed class TxAudioIngest : IDisposable
 
         var engine = _engineProvider();
         int blockSize = engine?.TxBlockSamples ?? 0;
-        if (engine is null || blockSize <= 0 || blockSize > _scratchMic.Length)
+        int iqOut = engine?.TxOutputSamples ?? 0;
+        if (engine is null || blockSize <= 0 || iqOut <= 0
+            || blockSize > _scratchMic.Length || 2 * iqOut > _scratchIq.Length)
         {
-            // Synthetic engine or no TXA open. Swallow samples quietly.
+            // Synthetic engine, no TXA open, or a protocol whose block size
+            // exceeds our scratch buffers. Swallow samples quietly.
             return;
         }
 
@@ -206,7 +211,7 @@ public sealed class TxAudioIngest : IDisposable
                 Array.Copy(_accumulator, 0, _scratchMic, 0, blockSize);
                 int produced = engine.ProcessTxBlock(
                     new ReadOnlySpan<float>(_scratchMic, 0, blockSize),
-                    new Span<float>(_scratchIq, 0, 2 * blockSize));
+                    new Span<float>(_scratchIq, 0, 2 * iqOut));
                 if (produced > 0)
                 {
                     _ring.Write(new ReadOnlySpan<float>(_scratchIq, 0, 2 * produced));

--- a/Zeus.Server/TxAudioIngest.cs
+++ b/Zeus.Server/TxAudioIngest.cs
@@ -107,27 +107,35 @@ public sealed class TxAudioIngest : IDisposable
         TxService tx,
         StreamingHub hub,
         ILogger<TxAudioIngest> log)
-        : this(ring, () => pipeline.CurrentEngine, () => tx.IsMoxOn, hub, log)
+        : this(ring, () => pipeline.CurrentEngine, () => tx.IsMoxOn, hub, log,
+               forwardP2: iq => pipeline.ForwardTxIqToP2(iq.Span))
     {
     }
 
     /// <summary>Test-only constructor that wires the engine + MOX lookups
-    /// through plain delegates so unit tests don't need a live pipeline.</summary>
+    /// through plain delegates so unit tests don't need a live pipeline.
+    /// <paramref name="forwardP2"/> is called with the same IQ block that's
+    /// handed to the P1 ring so mic MOX on a Protocol 2 radio (G2 MkII) has
+    /// a TX path. Null in tests that don't exercise the P2 forward.</summary>
     internal TxAudioIngest(
         TxIqRing ring,
         Func<IDspEngine?> engineProvider,
         Func<bool> isMoxOn,
         StreamingHub hub,
-        ILogger<TxAudioIngest> log)
+        ILogger<TxAudioIngest> log,
+        Action<ReadOnlyMemory<float>>? forwardP2 = null)
     {
         _ring = ring;
         _engineProvider = engineProvider;
         _isMoxOn = isMoxOn;
+        _forwardP2 = forwardP2;
         _hub = hub;
         _log = log;
         _handler = OnMicPcmBytes;
         _hub.MicPcmReceived += _handler;
     }
+
+    private readonly Action<ReadOnlyMemory<float>>? _forwardP2;
 
     public long TotalMicSamples { get { lock (_sync) return _totalMicSamples; } }
     public long TotalTxBlocks { get { lock (_sync) return _totalTxBlocks; } }
@@ -214,7 +222,13 @@ public sealed class TxAudioIngest : IDisposable
                     new Span<float>(_scratchIq, 0, 2 * iqOut));
                 if (produced > 0)
                 {
-                    _ring.Write(new ReadOnlySpan<float>(_scratchIq, 0, 2 * produced));
+                    var iqSpan = new ReadOnlySpan<float>(_scratchIq, 0, 2 * produced);
+                    // P1 path — EP2 packer in Protocol1Client drains the ring.
+                    _ring.Write(iqSpan);
+                    // P2 path — Protocol2Client's 1029-port DUC sender. No-op
+                    // when P2 isn't the active backend so both protocols share
+                    // this seam cleanly. Mirrors TxTuneDriver's dual-write.
+                    _forwardP2?.Invoke(new ReadOnlyMemory<float>(_scratchIq, 0, 2 * produced));
                     _totalTxBlocks++;
 
                     // Accumulate peaks for the 1 Hz diagnostic log.

--- a/Zeus.Server/TxService.cs
+++ b/Zeus.Server/TxService.cs
@@ -74,7 +74,7 @@ public sealed class TxService
     public bool TrySetMox(bool on, out string? error)
     {
         // FR-1 interlock: no TX unless connected. Band-legality check deferred to a follow-up.
-        if (on && _radio.ActiveClient is null) { error = "not connected"; return false; }
+        if (on && !_radio.IsConnected) { error = "not connected"; return false; }
 
         bool wasTunOn;
         lock (_sync)
@@ -116,10 +116,11 @@ public sealed class TxService
 
     public bool TrySetTun(bool on, out string? error)
     {
-        // Same connect-interlock as MOX: no TX of any kind without an active
-        // client (the HL2 PA-enable bit is gated on MOX, but TUN flips MOX on
-        // via the engine, so we reject the precondition here for symmetry).
-        if (on && _radio.ActiveClient is null) { error = "not connected"; return false; }
+        // Same connect-interlock as MOX: no TX of any kind without a connected
+        // backend. IsConnected covers both P1 (Protocol1Client) and P2
+        // (Protocol2Client owned by DspPipelineService); ActiveClient alone
+        // would reject TUN on any G2 MkII.
+        if (on && !_radio.IsConnected) { error = "not connected"; return false; }
 
         bool wasMoxOn;
         lock (_sync)

--- a/Zeus.Server/TxTuneDriver.cs
+++ b/Zeus.Server/TxTuneDriver.cs
@@ -57,10 +57,11 @@ namespace Zeus.Server;
 internal sealed class TxTuneDriver : BackgroundService
 {
     private static readonly TimeSpan PollIdle = TimeSpan.FromMilliseconds(100);
-    // 1024 mono samples / 48 kHz ≈ 21.33 ms. Round to 20 ms so we run a little
-    // faster than WDSP's block clock and avoid starving the ring — drop-oldest
-    // in TxIqRing handles the ~6 % overrun.
-    private static readonly TimeSpan TuneTick = TimeSpan.FromMilliseconds(20);
+    // Tick is derived from the engine's mic block size per loop iteration
+    // (block_samples / 48 kHz, shaved slightly so we run a little faster
+    // than WDSP's block clock). Fixed 20 ms fell behind on P2's 512-sample
+    // block (10.67 ms) and starved the G2 DUC, producing close-in spurs.
+    private const int MicRateHz = 48_000;
 
     private readonly TxService _tx;
     private readonly DspPipelineService _pipeline;
@@ -90,32 +91,45 @@ internal sealed class TxTuneDriver : BackgroundService
                 }
 
                 var engine = _pipeline.CurrentEngine;
-                int blockSize = engine?.TxBlockSamples ?? 0;
-                if (engine is null || blockSize <= 0)
+                int micBlock = engine?.TxBlockSamples ?? 0;
+                int iqOut = engine?.TxOutputSamples ?? 0;
+                if (engine is null || micBlock <= 0 || iqOut <= 0)
                 {
                     // No TXA yet — retry on the slow cadence.
                     await Task.Delay(PollIdle, ct).ConfigureAwait(false);
                     continue;
                 }
 
-                if (micScratch is null || micScratch.Length < blockSize)
-                    micScratch = new float[blockSize];
-                if (iqScratch is null || iqScratch.Length < 2 * blockSize)
-                    iqScratch = new float[2 * blockSize];
+                if (micScratch is null || micScratch.Length < micBlock)
+                    micScratch = new float[micBlock];
+                if (iqScratch is null || iqScratch.Length < 2 * iqOut)
+                    iqScratch = new float[2 * iqOut];
 
                 // Silent mic — the post-gen tone gets inserted after the mic
                 // processing stage by WDSP, so fexchange2 still produces the
                 // carrier even with zero mic input.
-                Array.Clear(micScratch, 0, blockSize);
+                Array.Clear(micScratch, 0, micBlock);
                 int produced = engine.ProcessTxBlock(
-                    new ReadOnlySpan<float>(micScratch, 0, blockSize),
-                    new Span<float>(iqScratch, 0, 2 * blockSize));
+                    new ReadOnlySpan<float>(micScratch, 0, micBlock),
+                    new Span<float>(iqScratch, 0, 2 * iqOut));
                 if (produced > 0)
                 {
-                    _ring.Write(new ReadOnlySpan<float>(iqScratch, 0, 2 * produced));
+                    var iqSpan = new ReadOnlySpan<float>(iqScratch, 0, 2 * produced);
+                    // P1 path: ring feeds the EP2 packer in Protocol1Client.
+                    _ring.Write(iqSpan);
+                    // P2 path: forward the same block directly to the active
+                    // Protocol2Client's 1029-port DUC sender. No-op when P2
+                    // isn't the active backend, so both protocols coexist
+                    // without a conditional at this seam.
+                    _pipeline.ForwardTxIqToP2(iqSpan);
                 }
 
-                await Task.Delay(TuneTick, ct).ConfigureAwait(false);
+                // Tick at ~95 % of the mic-block duration so WDSP is nearly
+                // always ready for the next fexchange2 call (the 5 % margin
+                // keeps us ahead of the block clock without blowing a CPU
+                // spin on early wakeups).
+                int tickMs = Math.Max(1, (micBlock * 950) / (MicRateHz));
+                await Task.Delay(TimeSpan.FromMilliseconds(tickMs), ct).ConfigureAwait(false);
             }
             catch (OperationCanceledException) { return; }
             catch (Exception ex)

--- a/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
@@ -149,6 +149,7 @@ public class MicGainEndpointTests : IClassFixture<MicGainEndpointTests.Factory>
         public void SetTxLevelerMaxGain(double maxGainDb) => LevelerMaxGainCalls.Add(maxGainDb);
 
         public int TxBlockSamples => 1024;
+        public int TxOutputSamples => 1024;
         public int OpenChannel(int sampleRateHz, int pixelWidth) => 0;
         public void CloseChannel(int channelId) { }
         public void FeedIq(int channelId, ReadOnlySpan<double> interleavedIqSamples) { }
@@ -160,7 +161,7 @@ public class MicGainEndpointTests : IClassFixture<MicGainEndpointTests.Factory>
         public void SetZoom(int channelId, int level) { }
         public int ReadAudio(int channelId, Span<float> output) => 0;
         public bool TryGetDisplayPixels(int channelId, DisplayPixout which, Span<float> dbOut) => false;
-        public int OpenTxChannel() => 0;
+        public int OpenTxChannel(int outputRateHz = 48_000) => 0;
         public void SetMox(bool moxOn) { }
         public double GetRxaSignalDbm(int channelId) => -140.0;
         public void SetTxMode(RxMode mode) { }

--- a/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
@@ -165,6 +165,7 @@ public class MicGainEndpointTests : IClassFixture<MicGainEndpointTests.Factory>
         public void SetMox(bool moxOn) { }
         public double GetRxaSignalDbm(int channelId) => -140.0;
         public void SetTxMode(RxMode mode) { }
+        public void SetTxFilter(int lowHz, int highHz) { }
         public int ProcessTxBlock(ReadOnlySpan<float> micMono, Span<float> iqInterleaved) => 0;
         public void SetTxTune(bool on) { }
         public TxStageMeters GetTxStageMeters() => TxStageMeters.Silent;

--- a/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
+++ b/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
@@ -55,6 +55,7 @@ public class TxAudioIngestTests
     {
         public int BlockSize { get; set; } = 1024;
         public int TxBlockSamples => BlockSize;
+        public int TxOutputSamples => BlockSize;
         public int ProcessedBlocks { get; private set; }
 
         public int ProcessTxBlock(ReadOnlySpan<float> micMono, Span<float> iqInterleaved)
@@ -83,7 +84,7 @@ public class TxAudioIngestTests
         public void SetZoom(int channelId, int level) { }
         public int ReadAudio(int channelId, Span<float> output) => 0;
         public bool TryGetDisplayPixels(int channelId, DisplayPixout which, Span<float> dbOut) => false;
-        public int OpenTxChannel() => 0;
+        public int OpenTxChannel(int outputRateHz = 48_000) => 0;
         public void SetMox(bool moxOn) { }
         public double GetRxaSignalDbm(int channelId) => -140.0;
         public void SetTxMode(RxMode mode) { }

--- a/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
+++ b/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
@@ -88,6 +88,7 @@ public class TxAudioIngestTests
         public void SetMox(bool moxOn) { }
         public double GetRxaSignalDbm(int channelId) => -140.0;
         public void SetTxMode(RxMode mode) { }
+        public void SetTxFilter(int lowHz, int highHz) { }
         public void SetTxPanelGain(double linearGain) { }
         public void SetTxLevelerMaxGain(double maxGainDb) { }
         public void SetTxTune(bool on) { }

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -71,6 +71,7 @@ import { CONTACTS, bandOf } from './components/design/data';
 import { CwKeyer } from './components/design/CwKeyer';
 import { Dockable } from './components/design/Dockable';
 import { DspPanel } from './components/DspPanel';
+import { TxFilterPanel } from './components/TxFilterPanel';
 import { LogbookLive } from './components/design/LogbookLive';
 import { QrzCard } from './components/design/QrzCard';
 import { TerminatorLines } from './components/design/TerminatorLines';
@@ -871,6 +872,12 @@ export default function App() {
           <div className="side-slot hide-mobile">
             <Dockable title="DSP" ledOn={dspActive}>
               <DspPanel />
+            </Dockable>
+          </div>
+
+          <div className="side-slot hide-mobile">
+            <Dockable title="TX Filter" ledOn={false}>
+              <TxFilterPanel />
             </Dockable>
           </div>
 

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -94,6 +94,9 @@ export type RadioStateDto = {
   filterPresetName: string | null;
   // Advanced-filter ribbon visibility; persisted server-side.
   filterAdvancedPaneOpen: boolean;
+  // TX bandpass (signed, per-sideband). Per-mode family memory on the server.
+  txFilterLowHz: number;
+  txFilterHighHz: number;
   sampleRate: number;
   agcTopDb: number;
   attenDb: number;
@@ -230,6 +233,8 @@ export function normalizeState(raw: unknown): RadioStateDto {
     filterHighHz: typeof r.filterHighHz === 'number' ? r.filterHighHz : 0,
     filterPresetName: typeof r.filterPresetName === 'string' ? r.filterPresetName : null,
     filterAdvancedPaneOpen: typeof r.filterAdvancedPaneOpen === 'boolean' ? r.filterAdvancedPaneOpen : false,
+    txFilterLowHz: typeof r.txFilterLowHz === 'number' ? r.txFilterLowHz : 150,
+    txFilterHighHz: typeof r.txFilterHighHz === 'number' ? r.txFilterHighHz : 2850,
     sampleRate: typeof r.sampleRate === 'number' ? r.sampleRate : 0,
     // Default 80 matches WdspDspEngine.ApplyAgcDefaults and the Thetis
     // AGC_MEDIUM preset. Missing from older servers — tolerate absence.
@@ -438,6 +443,26 @@ export function setFilter(
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ lowHz, highHz, presetName: presetName ?? null }),
+      signal,
+    },
+    normalizeState,
+  );
+}
+
+// TX bandpass filter — signed Hz pair, LSB negative, DSB symmetric. Per-mode
+// memory is server-side; caller passes already-signed values for the active
+// mode.
+export function setTxFilter(
+  lowHz: number,
+  highHz: number,
+  signal?: AbortSignal,
+): Promise<RadioStateDto> {
+  return jsonFetch(
+    '/api/tx-filter',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ lowHz, highHz }),
       signal,
     },
     normalizeState,

--- a/zeus-web/src/components/DriveSlider.tsx
+++ b/zeus-web/src/components/DriveSlider.tsx
@@ -39,6 +39,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import { setDrive } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
 import { useTxStore } from '../state/tx-store';
+import { usePaStore } from '../state/pa-store';
 
 // PRD FR-4 drive range: 0..100 percent. Per-pixel POSTs would flood the
 // server during a drag — trailing-edge debounce keeps the wire quiet while
@@ -51,6 +52,12 @@ export function DriveSlider() {
   const connected = useConnectionStore((s) => s.status === 'Connected');
   const drivePercent = useTxStore((s) => s.drivePercent);
   const setDrivePercent = useTxStore((s) => s.setDrivePercent);
+  // Live "target watts" preview so the operator can read "35% of 100 W = 35 W"
+  // at a glance — the slider itself is target-watts-%, not drive-byte-%, and
+  // this field makes the muscle-memory bridge from Thetis explicit. Hidden
+  // when Rated PA Output is 0 (raw drive-byte mode — watts have no meaning).
+  const paMaxWatts = usePaStore((s) => s.settings.global.paMaxPowerWatts);
+  const targetWatts = paMaxWatts > 0 ? Math.round((paMaxWatts * drivePercent) / 100) : null;
 
   const inflightAbort = useRef<AbortController | null>(null);
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -109,6 +116,15 @@ export function DriveSlider() {
       <span className="mono" style={{ width: 40, textAlign: 'right', color: 'var(--power)', fontSize: 11, fontWeight: 700 }}>
         {drivePercent}%
       </span>
+      {targetWatts !== null && (
+        <span
+          className="mono"
+          style={{ width: 44, textAlign: 'right', color: 'var(--neutral-400, #888)', fontSize: 10 }}
+          title="Target output watts = Rated PA Output × Drive %"
+        >
+          ~{targetWatts} W
+        </span>
+      )}
     </label>
   );
 }

--- a/zeus-web/src/components/PaSettingsPanel.tsx
+++ b/zeus-web/src/components/PaSettingsPanel.tsx
@@ -80,8 +80,11 @@ export function PaSettingsPanel() {
             PA Enabled
           </label>
 
-          <label className="flex items-center gap-2 text-xs text-neutral-300">
-            Max Power (W)
+          <label
+            className="flex items-center gap-2 text-xs text-neutral-300"
+            title="Rated PA output in watts. Slider 100% targets this wattage. Seeded from the connected board kind — HL2 = 5 W, Hermes-class = 10 W, ANAN/Orion/G2 = 100 W. Set to 0 to fall back to the raw drive-byte mode (PA Gain field is ignored)."
+          >
+            Rated PA Output (W)
             <input
               type="number"
               min={0}
@@ -91,9 +94,11 @@ export function PaSettingsPanel() {
               onChange={(e) => setGlobal({ paMaxPowerWatts: Number(e.target.value) || 0 })}
               className="w-20 rounded border border-neutral-700 bg-neutral-900 px-2 py-0.5 text-right text-xs text-neutral-100"
             />
-            <span className="text-[10px] text-neutral-500">
-              (0 = legacy, no watts math)
-            </span>
+            {settings.global.paMaxPowerWatts === 0 && (
+              <span className="text-[10px] text-amber-400">
+                (0 = raw drive-byte mode — PA Gain ignored)
+              </span>
+            )}
           </label>
 
           <div className="flex flex-col gap-1 text-xs text-neutral-300">
@@ -122,7 +127,12 @@ export function PaSettingsPanel() {
             <thead className="text-[10px] uppercase tracking-wider text-neutral-500">
               <tr>
                 <th className="px-2 py-2 text-left">Band</th>
-                <th className="px-2 py-2 text-right">Gain (dB)</th>
+                <th
+                  className="px-2 py-2 text-right"
+                  title="PA forward gain in dB per band — the amplifier's own gain from DUC output to antenna. NOT a trim. Seeded from the board kind (e.g. G2 MkII ≈ 48-51 dB on HF). Used together with Rated PA Output (W) to compute the drive byte: lower gain here → more drive byte → more output at a given slider %."
+                >
+                  PA Gain (dB)
+                </th>
                 <th className="px-2 py-2 text-center">Disable PA</th>
                 <th className="px-2 py-2 text-left">OC TX (1..7)</th>
                 <th className="px-2 py-2 text-left">OC RX (1..7)</th>
@@ -190,7 +200,10 @@ export function PaSettingsPanel() {
         </div>
       </section>
 
-      <div className="flex items-center justify-between">
+      <div
+        className="sticky bottom-0 -mx-[22px] -mb-[18px] flex items-center justify-between border-t border-neutral-800 px-[22px] py-2"
+        style={{ background: 'var(--bg-1)' }}
+      >
         <span className="text-[11px] text-neutral-500">
           {inflight ? 'Saving…' : loaded ? 'Loaded from server' : 'Loading…'}
           {error ? ` · error: ${error}` : ''}

--- a/zeus-web/src/components/TunePowerSlider.tsx
+++ b/zeus-web/src/components/TunePowerSlider.tsx
@@ -17,6 +17,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import { setTuneDrive } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
 import { useTxStore } from '../state/tx-store';
+import { usePaStore } from '../state/pa-store';
 
 // Same 0..100 range and debounce shape as DriveSlider; the backend picks
 // between the two sources based on TUN keying state so the UX/wire are
@@ -29,6 +30,9 @@ export function TunePowerSlider() {
   const connected = useConnectionStore((s) => s.status === 'Connected');
   const tunePercent = useTxStore((s) => s.tunePercent);
   const setTunePercent = useTxStore((s) => s.setTunePercent);
+  // Live target-watts readout (see DriveSlider for rationale).
+  const paMaxWatts = usePaStore((s) => s.settings.global.paMaxPowerWatts);
+  const targetWatts = paMaxWatts > 0 ? Math.round((paMaxWatts * tunePercent) / 100) : null;
 
   const inflightAbort = useRef<AbortController | null>(null);
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -95,6 +99,15 @@ export function TunePowerSlider() {
       >
         {tunePercent}%
       </span>
+      {targetWatts !== null && (
+        <span
+          className="mono"
+          style={{ width: 44, textAlign: 'right', color: 'var(--neutral-400, #888)', fontSize: 10 }}
+          title="Target tune watts = Rated PA Output × Tune %"
+        >
+          ~{targetWatts} W
+        </span>
+      )}
     </label>
   );
 }

--- a/zeus-web/src/components/TxFilterPanel.tsx
+++ b/zeus-web/src/components/TxFilterPanel.tsx
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+import { useCallback, useEffect, useState } from 'react';
+import { setTxFilter, type RxMode } from '../api/client';
+import { useConnectionStore } from '../state/connection-store';
+
+const CUSTOM_MIN = 0;
+const CUSTOM_MAX = 10000;
+
+// Mirror of ModeBandwidth's symmetry rule — AM/FM/DSB/SAM bandpasses are
+// symmetric around 0 Hz; SSB / CW sidebands are one-sided with a sign
+// determined by USB vs LSB.
+function isSymmetricMode(mode: RxMode): boolean {
+  return mode === 'AM' || mode === 'SAM' || mode === 'DSB' || mode === 'FM';
+}
+
+// Convert a signed (low, high) pair into absolute Hz the operator types into
+// the custom inputs. LSB mode stores negative values; we show the positive
+// magnitudes.
+function signedToAbs(mode: RxMode, low: number, high: number): { lowAbs: number; highAbs: number } {
+  if (isSymmetricMode(mode)) {
+    return { lowAbs: 0, highAbs: Math.max(Math.abs(low), Math.abs(high)) };
+  }
+  const lo = Math.min(Math.abs(low), Math.abs(high));
+  const hi = Math.max(Math.abs(low), Math.abs(high));
+  return { lowAbs: lo, highAbs: hi };
+}
+
+// Re-sign the user's positive Hz inputs for the current mode's sideband
+// convention. Matches RadioService.SignedFilterForMode on the server so the
+// round-trip doesn't shift values under mode changes.
+function absToSigned(mode: RxMode, lowAbs: number, highAbs: number): { low: number; high: number } {
+  const lo = Math.max(CUSTOM_MIN, Math.min(CUSTOM_MAX, Math.round(lowAbs)));
+  const hi = Math.max(CUSTOM_MIN, Math.min(CUSTOM_MAX, Math.round(highAbs)));
+  const [lCap, hCap] = lo <= hi ? [lo, hi] : [hi, lo];
+  switch (mode) {
+    case 'USB':
+    case 'DIGU':
+    case 'CWU':
+      return { low: lCap, high: hCap };
+    case 'LSB':
+    case 'DIGL':
+    case 'CWL':
+      return { low: -hCap, high: -lCap };
+    case 'AM':
+    case 'SAM':
+    case 'DSB':
+    case 'FM':
+      return { low: -hCap, high: hCap };
+  }
+}
+
+// Operator-facing TX bandpass control. The presets row is deliberately empty
+// for now — the frame and layout match the RX ModeBandwidth custom block so
+// future preset chips (2.4k / 2.7k / 3.0k / 4k / 6k / 8k) can drop in beside
+// the current CUSTOM pair without re-flowing the surrounding rail.
+export function TxFilterPanel() {
+  const mode = useConnectionStore((s) => s.mode);
+  const low = useConnectionStore((s) => s.txFilterLowHz);
+  const high = useConnectionStore((s) => s.txFilterHighHz);
+  const applyState = useConnectionStore((s) => s.applyState);
+
+  // Draft values so typing doesn't fire setTxFilter on every keystroke; we
+  // commit on blur / Enter and reset the draft whenever the store-side pair
+  // changes (mode flip, server reconciliation).
+  const currentAbs = signedToAbs(mode, low, high);
+  const [lowDraft, setLowDraft] = useState<string>(String(currentAbs.lowAbs));
+  const [highDraft, setHighDraft] = useState<string>(String(currentAbs.highAbs));
+
+  useEffect(() => {
+    const abs = signedToAbs(mode, low, high);
+    setLowDraft(String(abs.lowAbs));
+    setHighDraft(String(abs.highAbs));
+  }, [mode, low, high]);
+
+  const commitCustom = useCallback(() => {
+    const loAbs = Number.parseInt(lowDraft, 10);
+    const hiAbs = Number.parseInt(highDraft, 10);
+    if (!Number.isFinite(loAbs) || !Number.isFinite(hiAbs)) return;
+    const { low: nextLow, high: nextHigh } = absToSigned(mode, loAbs, hiAbs);
+    if (nextLow === low && nextHigh === high) return;
+    useConnectionStore.setState({ txFilterLowHz: nextLow, txFilterHighHz: nextHigh });
+    setTxFilter(nextLow, nextHigh)
+      .then(applyState)
+      .catch(() => {
+        /* next state broadcast will reconcile */
+      });
+  }, [lowDraft, highDraft, mode, low, high, applyState]);
+
+  const onCustomKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') e.currentTarget.blur();
+  };
+
+  const lowDisabled = isSymmetricMode(mode);
+
+  return (
+    <div className="ctrl-group" style={{ padding: '6px 8px' }}>
+      {/* Reserved for future preset chips — keeps vertical rhythm matching the
+          RX ModeBandwidth custom block even while presets are unset. */}
+      <div className="btn-row wrap" style={{ minHeight: 4, marginBottom: 2 }} />
+      <div className="btn-row" style={{ alignItems: 'center', gap: 4 }}>
+        <span className="label-xs" style={{ color: 'var(--fg-3)' }}>CUSTOM</span>
+        <input
+          type="number"
+          min={CUSTOM_MIN}
+          max={CUSTOM_MAX}
+          step={50}
+          value={lowDraft}
+          onChange={(e) => setLowDraft(e.currentTarget.value)}
+          onBlur={commitCustom}
+          onKeyDown={onCustomKeyDown}
+          disabled={lowDisabled}
+          aria-label="Custom TX filter low edge in Hz"
+          className="mono"
+          style={{
+            width: 60,
+            fontSize: 11,
+            padding: '2px 4px',
+            background: 'var(--btn-top)',
+            color: lowDisabled ? 'var(--fg-3)' : 'var(--fg-0)',
+            border: '1px solid var(--line)',
+            borderRadius: 'var(--r-sm)',
+          }}
+        />
+        <span className="label-xs" style={{ color: 'var(--fg-3)' }}>–</span>
+        <input
+          type="number"
+          min={CUSTOM_MIN}
+          max={CUSTOM_MAX}
+          step={50}
+          value={highDraft}
+          onChange={(e) => setHighDraft(e.currentTarget.value)}
+          onBlur={commitCustom}
+          onKeyDown={onCustomKeyDown}
+          aria-label="Custom TX filter high edge in Hz"
+          className="mono"
+          style={{
+            width: 60,
+            fontSize: 11,
+            padding: '2px 4px',
+            background: 'var(--btn-top)',
+            color: 'var(--fg-0)',
+            border: '1px solid var(--line)',
+            borderRadius: 'var(--r-sm)',
+          }}
+        />
+        <span className="label-xs mono" style={{ color: 'var(--fg-3)' }}>Hz</span>
+        <span className="label-xs mono" style={{ marginLeft: 6, color: 'var(--fg-3)', whiteSpace: 'nowrap' }}>
+          [{Math.min(Math.abs(low), Math.abs(high))}…{Math.max(Math.abs(low), Math.abs(high))}]
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/zeus-web/src/state/connection-store.ts
+++ b/zeus-web/src/state/connection-store.ts
@@ -61,6 +61,8 @@ export type ConnectionState = {
   filterHighHz: number;
   filterPresetName: string | null;
   filterAdvancedPaneOpen: boolean;
+  txFilterLowHz: number;
+  txFilterHighHz: number;
   sampleRate: number;
   agcTopDb: number;
   attenDb: number;
@@ -100,6 +102,8 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
   filterHighHz: 2850,
   filterPresetName: 'VAR1',
   filterAdvancedPaneOpen: false,
+  txFilterLowHz: 150,
+  txFilterHighHz: 2850,
   sampleRate: 192_000,
   agcTopDb: 80,
   attenDb: 0,
@@ -125,6 +129,8 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
       filterHighHz: s.filterHighHz,
       filterPresetName: s.filterPresetName,
       filterAdvancedPaneOpen: s.filterAdvancedPaneOpen,
+      txFilterLowHz: s.txFilterLowHz,
+      txFilterHighHz: s.txFilterHighHz,
       sampleRate: s.sampleRate,
       agcTopDb: s.agcTopDb,
       attenDb: s.attenDb,


### PR DESCRIPTION
## Summary

Wires Protocol 2 TX end-to-end so **TUN keys a clean zero-beat carrier on a G2 MkII**, fixes the PA drive-math path that was silently ignoring `PaGainDb` on fresh installs, and polishes the PA Settings UX so the knobs read correctly.

On-air verification: live OrionMkII (fw 2.7b41), TUN keys a clean single-tone carrier on the selected VFO frequency. Confirmed clean off-radio via an external KiwiSDR. Slider % → on-air watts tracks linearly once Rated PA Output is set.

P1 (Hermes Lite 2) path is preserved: explicit `outputRateHz: 48_000` at TXA open keeps the 48/48/48 profile that HL2 is calibrated against.

## What's in here

### Protocol 2 wire layer (`Zeus.Protocol2/Protocol2Client.cs`)
- **HighPriority byte 4 bit 1 (PTT)** now set while MOX is engaged. Was only writing the run bit, so the radio stayed in RX regardless of drive / tune state. Matches pihpsdr `new_protocol.c:746-757`, Thetis `network.c:924-925`.
- **Alex words** (bytes 1428-1435) now split `alex0` / `alex1` and OR in `ALEX_TX_RELAY (0x08000000)` on both during TX, plus `ALEX1_ANAN7000_RX_GNDonTX (0x00000100)` on `alex1`. Without TX_RELAY the TX signal reached the antenna through the RX BPF path with no TX-band LPF — DAC images radiated as out-of-band harmonics. pihpsdr `new_protocol.c:989-992`.
- **TX LPF thresholds** corrected to pihpsdr exact boundaries (strict `>` not `>=`, with 35.6 / 24 / 16.5 / 8 / 5 / 2.5 MHz edges).
- **OCtune mask** wired — during TUN, `PaGlobalSettings.OcTune` bits are OR'd into byte 1401 alongside `OcTx`, so external linear tune-pin relays close.
- **TX-DUC IQ sender added on port 1029** — the entire 1444-byte packet layout (240 complex samples of signed 24-bit BE, 4-byte sequence prefix) was missing. No pihpsdr CW-only `0.896` gain trim (the `0.896` constant is CW-path-only per `transmitter.c:1707-1712`; non-CW TXA feeds unscaled).
- **Paced TX IQ sender task** drains an internal queue at the 192 kHz DAC rate, modelling the radio's DUC FIFO (target ~1250 samples / 6.5 ms buffered, per pihpsdr `new_protocol.c:1909-1997`). Previously we bursted all 8 packets of a WDSP block straight to the wire then sat idle for ~10 ms — FIFO oscillated into an AM-style pulsed carrier.

### MOX / TUN routing (`Zeus.Server/`)
- `RadioService` now exposes `MoxChanged` + `TunActiveChanged` events plus an `IsConnected` property covering both P1 and P2. `DspPipelineService` subscribes and forwards to the `_p2Client`. `TxService`'s connect interlock now honours `IsConnected` — previously `ActiveClient`-only, so TUN/MOX were silently rejected on any G2.

### WDSP TXA configuration (`Zeus.Dsp/Wdsp/WdspDspEngine.cs`)
- **`OpenTxChannel(int outputRateHz)`** — P1 keeps the existing 48/48/48 profile; P2 opens at 48 kHz mic / 96 kHz DSP / 192 kHz out and calls `SetTXACFIRRun(id, 1)`. "P2 firmware requires this" per pihpsdr `transmitter.c:1288`, Thetis `audio.cs:1808`. Feeding 48 kHz IQ to a 192 kHz DUC was generating ±48 / ±96 kHz spectral images on the air.
- **Explicit PreGen disable at open time** (`SetTXAPreGenMode=0`, `ToneMag=0`, `ToneFreq=0`, `Run=0`) — WDSP's `create_channel` doesn't guarantee safe defaults, and a residual PreGen tone rode alongside the PostGen tune carrier as a second discrete frequency ("2-tone-like output"). pihpsdr `transmitter.c:1293-1296`.
- **`SetTXAPanelSelect(id, 2)`** (Mic I sample, pihpsdr `transmitter.c:1298`).
- **`SetTxTune` now drives `freq=0.0`** — true zero-beat carrier on the VFO (pihpsdr `radio.c:2716/2743`). Correct for tuning an external ATU.
- **Leveler gates off during TUN, on after** — the 0 Hz tone lives below the SSB bandpass (150-2850 Hz), so with Leveler at +5 dB max gain the AGC loop pumped trying to boost the heavily-attenuated signal, producing an AM envelope on the Zeus panadapter. pihpsdr keeps Leveler off by default (`transmitter.c:2612`: `state = compressor || cfc`).
- **`ProcessTxBlock` / `TxBlockSamples` / new `TxOutputSamples`** — input mic count and output IQ count are now separate (P2 upsamples 4×). `TxTuneDriver` + `TxAudioIngest` size scratch buffers and cadence accordingly. `TxTuneDriver` tick is data-driven from `engine.TxBlockSamples` (fixed 20 ms fell behind on P2's 10.67 ms cadence and starved the DUC).

### PA drive math (`Zeus.Server/PaSettingsStore.cs`, `PaDefaults.cs`)
- `PaDefaults.GetMaxPowerWatts(board)` seeds per-board Rated PA Output defaults: HL2 → 5, Hermes/Metis/Griffin → 10, Angelia/Orion/OrionMkII → 100. `PaSettingsStore.GetAll(board)` and `GetGlobal(board)` use it when no global is persisted.
- Previously `PaMaxPowerWatts` defaulted to `0`, which short-circuits `ComputeDriveByte` to a linear `(pct*255/100)` that **silently ignores `PaGainDb`** — making the per-band gain field feel broken.
- Drive math itself (`RadioService.ComputeDriveByte`) is unchanged — matches pihpsdr `radio.c:2809-2828` line-for-line.

### PA Settings UX (`zeus-web/src/components/PaSettingsPanel.tsx`)
- "Max Power (W)" → **"Rated PA Output (W)"** with tooltip "Slider 100% targets this wattage."
- Per-band "Gain (dB)" → **"PA Gain (dB)"** with tooltip clarifying it's the amplifier's physical forward gain per band, not a trim.
- **Apply button + status row now sticks** to the bottom of the PA tab's scroll viewport — was below the band table and invisible until the user scrolled down.
- **DriveSlider + TunePowerSlider** now show a live **"~NN W"** target-watts readout next to the % display (`35% of 100 W = ~35 W`). Hidden when Rated PA Output is 0.

### README
- Status line reflects that P2 / G2 TX is wired for TUN/MOX.
- New **PA settings** section: formula explanation, per-board default table, upgrade-path guidance.
- New **Known quirks** section: TUN carrier visual artifact.

## Known limitations (not blockers, documented in README)

- **TUN carrier looks momentarily wide and pulses for ~1 s on the Zeus panadapter when first keyed.** Display artifact only — the RF transmitted is clean (verified via KiwiSDR). To be cleaned up at a later date; probably a race between the RXA-to-TXA state flip and when the panadapter resumes valid data.

## Upgrade notes for existing Zeus installs

If you've used Zeus before this PR lands, your `pa_globals` record is already stored with `PaMaxPowerWatts = 0`, which keeps the legacy linear path active and ignores `PaGainDb`. To pick up the new math:

- Open **Settings → PA tab**, set **Rated PA Output (W)** to `100` for a G2 / ANAN or `10` for a Hermes, and **click Apply** at the bottom of the PA tab.
- **PA changes require an explicit Apply click** to persist to LiteDB and push to the radio. Closing the Settings modal without clicking Apply discards pending edits.
- Alternative: delete `~/.local/share/Zeus/zeus-prefs.db` to start fresh and pick up the per-board defaults automatically on first connect.

## Red-light items flagged for maintainer review (per `CLAUDE.md`)

- **Per-board `PaMaxPowerWatts` defaults** — new operator-felt default on first connect. HL2 → 5 W, Hermes/Metis/Griffin → 10 W, ANAN/Orion/OrionMkII → 100 W. Values match Thetis's per-board labels but Brian should weigh in if a different shipping default is preferred.
- **Tune tone at 0 Hz instead of ±cw_pitch** — changes operator-felt default from Thetis's ±600 Hz behavior to pihpsdr's zero-beat. Right call for antenna-tuner use; flagging for awareness.
- **Leveler off during TUN** — runtime toggle, not a config default, but it changes Zeus's prior "Leveler always on" stance. Restored to ON immediately after TUN-off.

## Test plan

- [ ] TUN on a G2 MkII keys a clean single carrier on VFO frequency (Zeus panadapter + external receiver)
- [ ] TUN power tracks the tune slider as a percentage of Rated PA Output (whatever the operator configured: 50% at 20 W rated → ~10 W; 10% at 100 W rated → ~10 W)
- [ ] MOX on G2 passes mic audio at the expected drive level
- [ ] Hermes Lite 2 TX / TUN still works (regression check — P1 path unchanged)
- [ ] PA Settings → Rated PA Output default seeds from the connected board kind on a fresh `zeus-prefs.db`
- [ ] PA Settings → Apply button is visible at the bottom of the PA tab regardless of scroll position
- [ ] Drive / Tune sliders show `~NN W` next to the %



---

## Follow-up commits added after initial review (2026-04-23)

### `fix(tx)`: forward mic-path IQ to Protocol 2 client (`969a38a`)
The initial commit wired `TxTuneDriver` to forward TX IQ to both the P1 ring and the P2 client, but `TxAudioIngest` (the mic path) was only updated for buffer sizing. Mic MOX on a G2 engaged PTT but transmitted silence. Adds an optional `forwardP2` delegate that mirrors `TxTuneDriver`'s dual-write.

### `feat(tx)`: operator-editable TX bandpass filter + gain staging (`028caea`)

**TX filter (operator-editable bandpass):**
- New `StateDto.TxFilterLowHz` / `TxFilterHighHz` (signed, mirrors RX).
- `RadioService` per-mode-family TX memory — SSB 150/2850, AM/DSB 0/4000, FM 0/3000, CW 0/150. Mode flip saves departing mode's TX filter and restores target mode-family's slot re-signed for the new sideband.
- `IDspEngine.SetTxFilter` + WDSP `SetTXABandpassFreqs` wiring. Deleted `ApplyTxBandpassForMode` (mode flip now drives through state).
- `POST /api/tx-filter { lowHz, highHz }` + `TxFilterSetRequest` contract.
- New `TxFilterPanel.tsx` in the right rail between DSP and CW Keyer — custom LOW/HIGH integer inputs, preset row reserved for future chips. Visual grammar matches `ModeBandwidth`'s custom block.
- `zeus-web` `connection-store`, `RadioStateDto`, `setTxFilter()` API.

**Gain staging:**
- `DefaultLevelerMaxGainDb` 5 → 8 dB. The 5 dB was actually WDSP's C-init factory (TXA.c:169 1.778 linear), not a deliberate Zeus choice — comment was misleading. 8 dB tuned for operator's external analog rack setup.
- `SetTXAALCMaxGain(id, 3.0)` now called explicitly — matches Thetis `database.cs:4596`. Recovers ~3 dB of average modulation that WDSP's 0 dB factory default was eating.
- `SetTXAALCAttack(id, 1)` + `SetTXAALCDecay(id, 10)` explicit. Matches pihpsdr `transmitter.c:1290-1291` and the WDSP factory Thetis inherits. A previously-set 2 ms attack sounded "crunchy" on plosives.

## Additional known limitation

- **TX audio still has a subtle "brittle / digital" quality on-air** (operator feedback after the 1 ms attack fix). The obvious Thetis/pihpsdr deviations (Leveler default-on vs. gated, MicGain 1.0 vs 0.5) are not the cause — operator runs the same Leveler configuration in Thetis and pihpsdr with the same audio rack. Root cause not identified; filed as a separate follow-up so it doesn't block this change. Voice MOX transmits clean-enough for on-air use; this is a polish item.

## Updated test plan

- [ ] TX Filter panel appears in right rail between DSP and CW Keyer
- [ ] Custom LOW/HIGH inputs on the TX Filter panel apply live to WDSP `SetTXABandpassFreqs`
- [ ] Mode switch (USB → LSB → AM → CW → USB) round-trips the TX filter values per family with correct sideband signing
- [ ] Mic MOX on G2 transmits clean audio at expected drive level (no silent carrier)
