### PR TITLE
chore(deps): bump flexlayout-react to ^0.8.19 for React 19 peers

### DIFF
--- a/zeus-web/package-lock.json
+++ b/zeus-web/package-lock.json
@@ -8,7 +8,7 @@
       "name": "zeus-web",
       "version": "0.0.1",
       "dependencies": {
-        "flexlayout-react": "^0.7.15",
+        "flexlayout-react": "^0.8.19",
         "leaflet": "^1.9.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -3334,7 +3334,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4315,7 +4315,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -5105,13 +5105,13 @@
       "license": "ISC"
     },
     "node_modules/flexlayout-react": {
-      "version": "0.7.15",
-      "resolved": "https://registry.npmjs.org/flexlayout-react/-/flexlayout-react-0.7.15.tgz",
-      "integrity": "sha512-ydTMdEoQO5BniylxVkSxa59rEY0+96lqqRII+QK+yq6028eHywPuxZawt4g45y5pMb9ptP4N9HPAQXAFsxwowQ==",
+      "version": "0.8.19",
+      "resolved": "https://registry.npmjs.org/flexlayout-react/-/flexlayout-react-0.8.19.tgz",
+      "integrity": "sha512-OC8PvAZ7ElYutiSQhLbuycpzxXdIQuyREozWGu8Wx3+6G4r3ctBMUiSYEVKICgiW1wLOPwvZOSpOFqddG3eoVg==",
       "license": "ISC",
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/for-each": {

--- a/zeus-web/package.json
+++ b/zeus-web/package.json
@@ -14,7 +14,7 @@
     "smoke": "node scripts/smoke.mjs"
   },
   "dependencies": {
-    "flexlayout-react": "^0.7.15",
+    "flexlayout-react": "^0.8.19",
     "leaflet": "^1.9.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",


### PR DESCRIPTION
## Summary
- Bumps `flexlayout-react` from `^0.7.15` to `^0.8.19`.
- 0.7.x declared `peerDependencies.react: ^18.0.0`, which npm's strict peer resolver rejected against this project's `react@^19.0.0` (hence `npm install` failed with `ERESOLVE`; `pnpm install` succeeded only because pnpm defaults to `strict-peer-dependencies=false`).
- 0.8.x widens the peer range to `^18.0.0 || ^19.0.0` — no source changes needed; existing imports (`Layout`, `Model`, `IJsonModel`, `TabNode`, `flexlayout-react/style/dark.css`) remain exported.

## Test plan
- [x] `npm install` (no `--legacy-peer-deps`) resolves cleanly
- [x] `npm run build` succeeds (Vite + tsc)
- [x] `npm test` — 66/66 vitest cases pass
- [ ] Manual smoke of `?layout=flex` flag (FlexWorkspace) — maintainer to verify if desired