### PR TITLE
feat(rx): master AF Gain slider driving WDSP SetRXAPanelGain1 (#77)

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -101,7 +101,14 @@ public sealed record StateDto(
     // LSB flips the sign and USB → AM swaps to AM's remembered width.
     // Default 150/2850 matches Thetis's stock SSB TX bandpass.
     int TxFilterLowHz = 150,
-    int TxFilterHighHz = 2850);
+    int TxFilterHighHz = 2850,
+    // Master RX AF gain in dB. 0 dB ≡ WDSP SetRXAPanelGain1(1.0), the
+    // engine's open-time default — a fresh session that never touches this
+    // field is audibly identical to pre-#77 builds. Operator slider range
+    // is −50..+20 dB (see RadioService.SetRxAfGain). Per-RX not supported
+    // yet; when multi-RX lands this becomes the master and the per-RX
+    // values layer on top.
+    double RxAfGainDb = 0.0);
 
 public sealed record RadioInfo(
     string MacAddress,
@@ -133,6 +140,8 @@ public sealed record SampleRateSetRequest(int Rate);
 public sealed record PreampSetRequest(bool On);
 
 public sealed record AgcGainSetRequest(double TopDb);
+
+public sealed record RxAfGainSetRequest(double Db);
 
 public sealed record AttenuatorSetRequest(int Db);
 

--- a/Zeus.Dsp/IDspEngine.cs
+++ b/Zeus.Dsp/IDspEngine.cs
@@ -56,6 +56,13 @@ public interface IDspEngine : IDisposable
     void SetFilter(int channelId, int lowHz, int highHz);
     void SetVfoHz(int channelId, long vfoHz);
     void SetAgcTop(int channelId, double topDb);
+
+    /// <summary>Set the RX master AF gain in dB. Drives WDSP's
+    /// <c>SetRXAPanelGain1</c> (linear) after a dB→linear conversion. 0 dB
+    /// equals the engine's open-time default (linear 1.0). No-op on
+    /// Synthetic.</summary>
+    void SetRxAfGainDb(int channelId, double db);
+
     void SetNoiseReduction(int channelId, NrConfig cfg);
     void SetZoom(int channelId, int level);
     int ReadAudio(int channelId, Span<float> output);

--- a/Zeus.Dsp/SyntheticDspEngine.cs
+++ b/Zeus.Dsp/SyntheticDspEngine.cs
@@ -93,6 +93,8 @@ public sealed class SyntheticDspEngine : IDspEngine
 
     public void SetAgcTop(int channelId, double topDb) { /* synthetic has no AGC */ }
 
+    public void SetRxAfGainDb(int channelId, double db) { /* synthetic has no audio path */ }
+
     public void SetNoiseReduction(int channelId, NrConfig cfg)
     {
         ArgumentNullException.ThrowIfNull(cfg);

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -383,6 +383,20 @@ public sealed class WdspDspEngine : IDspEngine
         _log.LogInformation("wdsp.setAgcTop channel={Id} topDb={TopDb:F1}", channelId, topDb);
     }
 
+    public void SetRxAfGainDb(int channelId, double db)
+    {
+        if (!_channels.TryGetValue(channelId, out _)) return;
+        // WDSP's SetRXAPanelGain1 takes a linear multiplier on the post-demod
+        // audio panel (panel.c:66). 0 dB ≡ 1.0 linear, which is the value
+        // OpenChannel installs at line 237 — so a fresh channel that never
+        // sees this call behaves exactly as before. Thetis wires its master
+        // AF slider the same way (audio.cs:218-224, `SetRXAPanelGain1(rxa,
+        // Math.Pow(10.0, db/20.0))`).
+        double linear = Math.Pow(10.0, db / 20.0);
+        NativeMethods.SetRXAPanelGain1(channelId, linear);
+        _log.LogInformation("wdsp.setRxAfGain channel={Id} db={Db:F1} linear={Linear:F4}", channelId, db, linear);
+    }
+
     public void SetZoom(int channelId, int level)
     {
         SyntheticDspEngine.ValidateZoomLevel(level);

--- a/Zeus.Server/DspPipelineService.cs
+++ b/Zeus.Server/DspPipelineService.cs
@@ -78,6 +78,7 @@ public class DspPipelineService : BackgroundService
     private int _appliedTxLowHz;
     private int _appliedTxHighHz;
     private double _appliedAgcTopDb;
+    private double _appliedRxAfGainDb;
     private NrConfig _appliedNr = new();
     private int _appliedZoomLevel = 1;
 
@@ -265,6 +266,11 @@ public class DspPipelineService : BackgroundService
             engine.SetAgcTop(channel, s.AgcTopDb);
             _appliedAgcTopDb = s.AgcTopDb;
         }
+        if (s.RxAfGainDb != _appliedRxAfGainDb)
+        {
+            engine.SetRxAfGainDb(channel, s.RxAfGainDb);
+            _appliedRxAfGainDb = s.RxAfGainDb;
+        }
         var nr = s.Nr ?? new NrConfig();
         if (!nr.Equals(_appliedNr))
         {
@@ -291,6 +297,7 @@ public class DspPipelineService : BackgroundService
         engine.SetTxFilter(s.TxFilterLowHz, s.TxFilterHighHz);
         engine.SetVfoHz(channelId, s.VfoHz);
         engine.SetAgcTop(channelId, s.AgcTopDb);
+        engine.SetRxAfGainDb(channelId, s.RxAfGainDb);
         engine.SetNoiseReduction(channelId, nr);
         engine.SetZoom(channelId, s.ZoomLevel);
         _appliedMode = s.Mode;
@@ -299,6 +306,7 @@ public class DspPipelineService : BackgroundService
         _appliedTxLowHz = s.TxFilterLowHz;
         _appliedTxHighHz = s.TxFilterHighHz;
         _appliedAgcTopDb = s.AgcTopDb;
+        _appliedRxAfGainDb = s.RxAfGainDb;
         _appliedNr = nr;
         _appliedZoomLevel = s.ZoomLevel;
     }

--- a/Zeus.Server/Program.cs
+++ b/Zeus.Server/Program.cs
@@ -441,6 +441,12 @@ app.MapPost("/api/agcGain", (AgcGainSetRequest req, RadioService r) =>
     return r.SetAgcTop(req.TopDb);
 });
 
+app.MapPost("/api/rx/afGain", (RxAfGainSetRequest req, RadioService r) =>
+{
+    log.LogInformation("api.rx.afGain db={Db:F1}", req.Db);
+    return r.SetRxAfGain(req.Db);
+});
+
 app.MapPost("/api/attenuator", (AttenuatorSetRequest req, RadioService r) =>
 {
     log.LogInformation("api.attenuator db={Db}", req.Db);

--- a/Zeus.Server/RadioService.cs
+++ b/Zeus.Server/RadioService.cs
@@ -656,6 +656,17 @@ public sealed class RadioService : IDisposable
         return Snapshot();
     }
 
+    // Master RX AF gain in dB. −50 dB is effectively silent (0.003 linear),
+    // 0 dB matches the fresh-open default, +20 dB is a 10× linear boost for
+    // quiet signals. Range mirrors Thetis's ptbAF (console.cs:4312-4313:
+    // tbAF.Minimum = -50, Maximum = 20).
+    public StateDto SetRxAfGain(double db)
+    {
+        double clamped = Math.Clamp(db, -50.0, 20.0);
+        Mutate(s => s with { RxAfGainDb = clamped });
+        return Snapshot();
+    }
+
     public StateDto SetNr(NrConfig cfg)
     {
         ArgumentNullException.ThrowIfNull(cfg);

--- a/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
@@ -157,6 +157,7 @@ public class MicGainEndpointTests : IClassFixture<MicGainEndpointTests.Factory>
         public void SetFilter(int channelId, int lowHz, int highHz) { }
         public void SetVfoHz(int channelId, long vfoHz) { }
         public void SetAgcTop(int channelId, double topDb) { }
+        public void SetRxAfGainDb(int channelId, double db) { }
         public void SetNoiseReduction(int channelId, NrConfig cfg) { }
         public void SetZoom(int channelId, int level) { }
         public int ReadAudio(int channelId, Span<float> output) => 0;

--- a/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
+++ b/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
@@ -80,6 +80,7 @@ public class TxAudioIngestTests
         public void SetFilter(int channelId, int lowHz, int highHz) { }
         public void SetVfoHz(int channelId, long vfoHz) { }
         public void SetAgcTop(int channelId, double topDb) { }
+        public void SetRxAfGainDb(int channelId, double db) { }
         public void SetNoiseReduction(int channelId, NrConfig cfg) { }
         public void SetZoom(int channelId, int level) { }
         public int ReadAudio(int channelId, Span<float> output) => 0;

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -39,6 +39,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } fro
 import { WorkspaceContext } from './layout/WorkspaceContext';
 import { FlexWorkspace } from './layout/FlexWorkspace';
 import { AgcSlider } from './components/AgcSlider';
+import { AfGainSlider } from './components/AfGainSlider';
 import { AlertBanner } from './components/AlertBanner';
 import { AttenuatorSlider } from './components/AttenuatorSlider';
 import { AudioToggle } from './components/AudioToggle';
@@ -648,6 +649,10 @@ export default function App() {
         <div className="ctrl-group hide-mobile" style={{ minWidth: 180 }}>
           <div className="label-xs ctrl-lbl">AGC</div>
           <AgcSlider />
+        </div>
+        <div className="ctrl-group hide-mobile" style={{ minWidth: 180 }}>
+          <div className="label-xs ctrl-lbl">AF</div>
+          <AfGainSlider />
         </div>
         <div className="spacer hide-mobile" style={{ flex: 1 }} />
         <div className="ctrl-group" style={{ minWidth: 360 }}>

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -105,6 +105,8 @@ export type RadioStateDto = {
   adcOverloadWarning: boolean;
   nr: NrConfigDto;
   zoomLevel: ZoomLevel;
+  // Master RX AF gain in dB — 0 = unity (WDSP SetRXAPanelGain1(1.0) default).
+  rxAfGainDb: number;
 };
 
 export type FilterPresetDto = {
@@ -253,6 +255,9 @@ export function normalizeState(raw: unknown): RadioStateDto {
     // the engine's declared defaults so the UI has something to render.
     nr: normalizeNr(r.nr),
     zoomLevel: normalizeZoomLevel(r.zoomLevel),
+    // 0 dB matches the pre-#77 unity-gain default — older servers without
+    // the field behave identically to a fresh-install slider at centre.
+    rxAfGainDb: typeof r.rxAfGainDb === 'number' ? r.rxAfGainDb : 0,
   };
 }
 
@@ -584,6 +589,22 @@ export function setAgcTop(
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ topDb }),
+      signal,
+    },
+    normalizeState,
+  );
+}
+
+export function setRxAfGain(
+  db: number,
+  signal?: AbortSignal,
+): Promise<RadioStateDto> {
+  return jsonFetch(
+    '/api/rx/afGain',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ db }),
       signal,
     },
     normalizeState,

--- a/zeus-web/src/components/AfGainSlider.tsx
+++ b/zeus-web/src/components/AfGainSlider.tsx
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is an independent reimplementation in .NET — not a fork. Its
+// Protocol-1 / Protocol-2 framing, WDSP integration, meter pipelines, and
+// TX behaviour were informed by studying the Thetis project
+// (https://github.com/ramdor/Thetis), the authoritative reference
+// implementation in the OpenHPSDR ecosystem. Zeus gratefully acknowledges
+// the Thetis contributors whose work made this possible:
+//
+//   Richard Samphire (MW0LGE), Warren Pratt (NR0V),
+//   Laurence Barker (G8NJJ),   Rick Koch (N1GP),
+//   Bryan Rambo (W4WMT),       Chris Codella (W2PA),
+//   Doug Wigley (W5WC),        FlexRadio Systems,
+//   Richard Allen (W5SD),      Joe Torrey (WD5Y),
+//   Andrew Mansfield (M0YGG),  Reid Campbell (MI0BOT).
+//
+// Thetis itself continues the GPL-governed lineage of FlexRadio PowerSDR
+// and the OpenHPSDR (TAPR/OpenHPSDR) ecosystem; that lineage is preserved
+// here. See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
+// (NR0V), distributed under GPL v2 or later.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { setRxAfGain } from '../api/client';
+import { useConnectionStore } from '../state/connection-store';
+
+// Master RX AF gain in dB. Drives WDSP's SetRXAPanelGain1(linear) server-side
+// after a dB→linear conversion; the browser audio GainNode stays at 1.0 so
+// the full operator range is realised in the DSP chain, not the soundcard.
+// -50..+20 mirrors Thetis's ptbAF range (console.cs:4312-4313). 0 dB is the
+// engine's fresh-open default — slider at centre on first connect is
+// audibly identical to pre-issue-#77 builds.
+const MIN = -50;
+const MAX = 20;
+
+export function AfGainSlider() {
+  const serverAf = useConnectionStore((s) => s.rxAfGainDb);
+  const connected = useConnectionStore((s) => s.status === 'Connected');
+  const applyState = useConnectionStore((s) => s.applyState);
+
+  const [dragValue, setDragValue] = useState<number | null>(null);
+  const value = dragValue ?? serverAf;
+
+  const inflightAbort = useRef<AbortController | null>(null);
+  const latestSent = useRef<number>(serverAf);
+
+  const sendValue = useCallback(
+    (v: number) => {
+      if (v === latestSent.current) return;
+      latestSent.current = v;
+      inflightAbort.current?.abort();
+      const ac = new AbortController();
+      inflightAbort.current = ac;
+      setRxAfGain(v, ac.signal)
+        .then((next) => {
+          if (!ac.signal.aborted) applyState(next);
+        })
+        .catch(() => {
+          /* next poll will reconcile; don't noisily log on abort */
+        });
+    },
+    [applyState],
+  );
+
+  useEffect(() => () => inflightAbort.current?.abort(), []);
+
+  return (
+    <label className="knob-group" style={{ minWidth: 170 }}>
+      <span className="label-xs" style={{ whiteSpace: 'nowrap' }}>AF</span>
+      <input
+        type="range"
+        min={MIN}
+        max={MAX}
+        step={1}
+        value={value}
+        disabled={!connected}
+        onChange={(e) => setDragValue(Number(e.currentTarget.value))}
+        onMouseUp={() => {
+          if (dragValue !== null) sendValue(dragValue);
+          setDragValue(null);
+        }}
+        onTouchEnd={() => {
+          if (dragValue !== null) sendValue(dragValue);
+          setDragValue(null);
+        }}
+        onKeyUp={() => {
+          if (dragValue !== null) sendValue(dragValue);
+          setDragValue(null);
+        }}
+        style={{ flex: 1, cursor: 'pointer', accentColor: 'var(--accent)' }}
+      />
+      <span className="mono" style={{ width: 48, textAlign: 'right', color: 'var(--fg-1)', fontSize: 11 }}>
+        {value} dB
+      </span>
+    </label>
+  );
+}

--- a/zeus-web/src/components/TopBar.tsx
+++ b/zeus-web/src/components/TopBar.tsx
@@ -37,6 +37,7 @@
 
 import { useDisplayStore } from '../state/display-store';
 import { AgcSlider } from './AgcSlider';
+import { AfGainSlider } from './AfGainSlider';
 import { AttenuatorSlider } from './AttenuatorSlider';
 import { AudioToggle } from './AudioToggle';
 import { DriveSlider } from './DriveSlider';
@@ -74,6 +75,7 @@ export function TopBar() {
         <PreampButton />
         <AttenuatorSlider />
         <AgcSlider />
+        <AfGainSlider />
         <NrControls />
         <AudioToggle />
         <MoxButton />

--- a/zeus-web/src/state/connection-store.ts
+++ b/zeus-web/src/state/connection-store.ts
@@ -65,6 +65,7 @@ export type ConnectionState = {
   txFilterHighHz: number;
   sampleRate: number;
   agcTopDb: number;
+  rxAfGainDb: number;
   attenDb: number;
   autoAttEnabled: boolean;
   attOffsetDb: number;
@@ -106,6 +107,7 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
   txFilterHighHz: 2850,
   sampleRate: 192_000,
   agcTopDb: 80,
+  rxAfGainDb: 0,
   attenDb: 0,
   autoAttEnabled: true,
   attOffsetDb: 0,
@@ -133,6 +135,7 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
       txFilterHighHz: s.txFilterHighHz,
       sampleRate: s.sampleRate,
       agcTopDb: s.agcTopDb,
+      rxAfGainDb: s.rxAfGainDb,
       attenDb: s.attenDb,
       autoAttEnabled: s.autoAttEnabled,
       attOffsetDb: s.attOffsetDb,


### PR DESCRIPTION
## Summary

Adds an operator-facing master RX AF gain slider. Closes #77.

- Scale: **dB**, range −50…+20, step 1, default **0 dB**.
- Default 0 dB maps to `SetRXAPanelGain1(1.0)` — exactly the value `OpenChannel` installs today, so a freshly-connected session that never touches the slider is audibly identical to pre-#77 builds.
- Backing: server-side WDSP via the existing `SetRXAPanelGain1` P/Invoke (dB → linear `pow(10, db/20)`). Browser `GainNode` stays at 1.0 so the full operator range is realised in the DSP chain, not the soundcard.
- Per-RX is deferred — this is a master AF only since Zeus currently runs one RX; when multi-RX lands it can layer per-channel on top.

## Maintainer review points

- **UI placement and styling are your call.** I put the slider in a new \"AF\" \`ctrl-group\` adjacent to AGC in \`App.tsx\`'s control strip, and after \`AgcSlider\` in the flat \`TopBar.tsx\` layout — chosen to match Thetis's \`lblMasterAF\` sitting next to AGC-T. **Move it, regroup it, or restyle the label/width** (\`AfGainSlider.tsx\` mirrors \`AgcSlider.tsx\` one-for-one) as you see fit.
- **The control strip is getting crowded.** With AF added, the header now runs PRE / S-ATT / A-ATT / AGC-T / AF / NR / MUTE / MOX / TUN / DRIVE / MIC — and the FlexLayout panels route is going to add more. Worth a pass from you on how you want the RX-audio-chain controls grouped (one \"RX audio\" pane with AGC-T + AF + NR + MUTE? Drawer behind a single icon? Keep flat but wrap?). I held back from restructuring beyond inserting the one new slider since that's a UX-design decision — happy to do the regroup once you've called the direction.
- Default range (−50…+20 dB) mirrors Thetis's \`ptbAF\` and is the only operator-felt default on first connect. Tune if it's not the right feel for your typical setup.
- **Not done in this PR** — #77 items 6 and 7, filed as separate follow-ups so this PR can close #77 cleanly:
  - #85 — wire the TCI \`volume\` / \`mon_volume\` stubs (\`TciHandshake.cs:82\`, \`TciSession.cs:570-595\`) to \`StateDto.RxAfGainDb\`.
  - #86 — persist \`RxAfGainDb\` to LiteDB across server restarts.

## State flow (AGC-T template, one-for-one)

1. \`StateDto.RxAfGainDb = 0.0\` (Zeus.Contracts/Dtos.cs).
2. \`RadioService.SetRxAfGain(db)\` clamps to [−50, 20] and mutates state.
3. \`POST /api/rx/afGain { db }\` endpoint in Program.cs.
4. \`DspPipelineService\` applies at \`ApplyStateToNewChannel\` and re-applies on state change via \`_appliedRxAfGainDb\` latch.
5. \`IDspEngine.SetRxAfGainDb(channel, db)\` → \`WdspDspEngine\` calls \`SetRXAPanelGain1(channel, pow(10, db/20))\`; \`SyntheticDspEngine\` no-ops.

## Test plan

- [x] \`dotnet build Zeus.slnx\` clean.
- [x] Full test suite: 196/196 Dsp pass; server-suite pre-existing WebApplicationFactory flake (unrelated) survives in-isolation runs.
- [x] \`npx tsc --noEmit\` in \`zeus-web/\` clean.
- [ ] Operator-bench test on G2 MkII: slider drag, default-0 audibly unchanged, −20 dB attenuates noticeably, +10 dB boosts weak signal cleanly, no clipping at +20 dB on a strong signal.