### PR TITLE
feat(map): narrow beam span 30% and shade wedge between edges

### DIFF
--- a/zeus-web/src/components/design/LeafletWorldMap.tsx
+++ b/zeus-web/src/components/design/LeafletWorldMap.tsx
@@ -38,7 +38,13 @@
 import { useEffect, useRef, type MutableRefObject } from 'react';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
-import { bearingDeg, destinationPoint, distanceKm, greatCircleSegments } from './geo';
+import {
+  bearingDeg,
+  destinationPoint,
+  distanceKm,
+  greatCirclePath,
+  greatCircleSegments,
+} from './geo';
 
 type MapStation = {
   call: string;
@@ -58,8 +64,9 @@ type LeafletWorldMapProps = {
   /** Beam range in km — Log4YM uses 5000 km to reach across oceans. */
   beamRangeKm?: number;
   /** Half-angle of the beam span rendered as side-lobe lines either side of
-   *  the centre bearing, in degrees. Default 15° (≈ 30° total span) matches
-   *  a medium-gain yagi; set to 0 to draw just the single centre beam. */
+   *  the centre bearing, in degrees. Default 10.5° (≈ 21° total span) —
+   *  a narrower hint than a textbook 3 dB yagi lobe so the wedge doesn't
+   *  overpower the map; set to 0 to draw just the single centre beam. */
   beamHalfWidthDeg?: number;
   /** When true, arcs and markers are drawn; otherwise the map renders empty-ish. */
   active: boolean;
@@ -220,7 +227,7 @@ export function LeafletWorldMap({
   target,
   beamBearing,
   beamRangeKm = 10000,
-  beamHalfWidthDeg = 15,
+  beamHalfWidthDeg = 10.5,
   active,
   interactive = false,
   onRotateToBearing,
@@ -397,6 +404,30 @@ export function LeafletWorldMap({
       : null;
     const beam = beamBearing ?? implicitBeam;
     if (beam != null) {
+      // Shaded wedge between the two edge beams — unwrapped continuous paths
+      // keep the ring closed across the antimeridian. Rendered first so the
+      // centre/edge polylines draw on top.
+      if (beamHalfWidthDeg > 0) {
+        const edgeLeft = destinationPoint(home.lat, home.lon, beam - beamHalfWidthDeg, beamRangeKm);
+        const edgeRight = destinationPoint(home.lat, home.lon, beam + beamHalfWidthDeg, beamRangeKm);
+        const pathLeft = greatCirclePath(
+          { lat: home.lat, lon: home.lon },
+          { lat: edgeLeft[0], lon: edgeLeft[1] },
+        );
+        const pathRight = greatCirclePath(
+          { lat: home.lat, lon: home.lon },
+          { lat: edgeRight[0], lon: edgeRight[1] },
+        );
+        const ring: [number, number][] = [...pathLeft, ...pathRight.slice().reverse()];
+        L.polygon(ring, {
+          stroke: false,
+          fill: true,
+          fillColor: COLOR_RED,
+          fillOpacity: 0.22,
+          interactive: false,
+        }).addTo(layer);
+      }
+
       const offsets = beamHalfWidthDeg > 0
         ? [-beamHalfWidthDeg, 0, beamHalfWidthDeg]
         : [0];

--- a/zeus-web/src/components/design/geo.ts
+++ b/zeus-web/src/components/design/geo.ts
@@ -149,3 +149,46 @@ export function greatCircleSegments(
   }
   return segments.filter((s) => s.length > 1);
 }
+
+/**
+ * Continuous great-circle path a→b as a single [lat, lon] list — longitudes
+ * are unwrapped (may exceed ±180°) so consecutive points stay within 180° of
+ * each other. Use for closed polygon fills where `greatCircleSegments`' split
+ * would break the ring; Leaflet handles unwrapped longitudes when rendering.
+ */
+export function greatCirclePath(
+  a: { lat: number; lon: number },
+  b: { lat: number; lon: number },
+  steps = 64,
+): [number, number][] {
+  const φ1 = toRad(a.lat);
+  const λ1 = toRad(a.lon);
+  const φ2 = toRad(b.lat);
+  const λ2 = toRad(b.lon);
+  const Δφ = φ2 - φ1;
+  const Δλ = λ2 - λ1;
+  const aa =
+    Math.sin(Δφ / 2) ** 2 + Math.cos(φ1) * Math.cos(φ2) * Math.sin(Δλ / 2) ** 2;
+  const d = 2 * Math.atan2(Math.sqrt(aa), Math.sqrt(1 - aa));
+  if (d === 0) return [[a.lat, a.lon]];
+
+  const pts: [number, number][] = [];
+  let prevLon: number | null = null;
+  for (let i = 0; i <= steps; i++) {
+    const f = i / steps;
+    const A = Math.sin((1 - f) * d) / Math.sin(d);
+    const B = Math.sin(f * d) / Math.sin(d);
+    const x = A * Math.cos(φ1) * Math.cos(λ1) + B * Math.cos(φ2) * Math.cos(λ2);
+    const y = A * Math.cos(φ1) * Math.sin(λ1) + B * Math.cos(φ2) * Math.sin(λ2);
+    const z = A * Math.sin(φ1) + B * Math.sin(φ2);
+    const φ = Math.atan2(z, Math.sqrt(x * x + y * y));
+    let lon = toDeg(Math.atan2(y, x));
+    if (prevLon != null) {
+      while (lon - prevLon > 180) lon -= 360;
+      while (lon - prevLon < -180) lon += 360;
+    }
+    pts.push([toDeg(φ), lon]);
+    prevLon = lon;
+  }
+  return pts;
+}


### PR DESCRIPTION
## Summary
- Default beam half-width drops **15° → 10.5°** (total span 30° → 21°) so the directional hint stops looking like a half-sky sweep.
- Added a soft cyan filled wedge (12% opacity) between the two edge rays on `LeafletWorldMap` — the centre + edge dashed lines still render on top.
- New `greatCirclePath()` helper in `geo.ts` returns a continuous (unwrapped-longitude) [lat, lon] list so the polygon ring closes cleanly across the antimeridian; `greatCircleSegments` would have split the ring.

## Test plan
- [ ] Verify the beam wedge renders cleanly with a target set (centre + edges + fill visible, centre dashed line on top of fill)
- [ ] Verify the wedge looks correct when the beam path crosses the antimeridian (e.g. a North-Pacific target from Europe)
- [ ] Verify `beamHalfWidthDeg={0}` still draws just the single centre beam with no fill
- [ ] Eyeball the 12% cyan fill against Esri imagery — tune down to ~0.08 or swap to amber if it overpowers the tiles

Design note: fill colour/opacity are flagged as tweakable — maintainer review welcome since this touches visual design.