### PR TITLE
fix(transport): normalize transport bar button sizes

### DIFF
--- a/zeus-web/src/components/AudioToggle.tsx
+++ b/zeus-web/src/components/AudioToggle.tsx
@@ -72,7 +72,7 @@ export function AudioToggle() {
         type="button"
         onPointerUp={onClick}
         disabled={loading}
-        className={`btn sm ${playing ? 'active' : ''}`}
+        className={`btn ${playing ? 'active' : ''}`}
         title={title}
       >
         <span className={`led ${playing ? 'on' : ''}`} style={{ marginRight: 6 }} />

--- a/zeus-web/src/components/MoxButton.tsx
+++ b/zeus-web/src/components/MoxButton.tsx
@@ -63,7 +63,7 @@ export function MoxButton() {
       type="button"
       disabled={!connected}
       onClick={click}
-      className={`btn lg tx-btn ${moxOn ? 'tx' : ''}`}
+      className={`btn tx-btn ${moxOn ? 'tx' : ''}`}
       title={moxOn ? 'MOX on — transmitting' : 'MOX off (hold Space to key)'}
     >
       <span className={`led ${moxOn ? 'tx' : ''}`} style={{ marginRight: 8 }} />

--- a/zeus-web/src/components/TunButton.tsx
+++ b/zeus-web/src/components/TunButton.tsx
@@ -64,7 +64,7 @@ export function TunButton() {
       type="button"
       disabled={!connected}
       onClick={click}
-      className={`btn lg ${tunOn ? 'active' : ''}`}
+      className={`btn ${tunOn ? 'active' : ''}`}
       title={tunOn ? 'TUN on — single-tone carrier' : 'TUN off (single-tone carrier for tuning)'}
     >
       TUNE


### PR DESCRIPTION
## Summary
- Drop `.lg` from MOX and TUNE so they render at the default `.btn` size.
- Drop `.sm` from the Mute audio toggle for the same reason.
- All transport-bar buttons (MOX, TUNE, Mute, SPLIT, RIT, SAVE MEM) now share one consistent size.

MOX retains `.tx-btn` so it keeps its 80px min-width and the TX-keyed red pulse animation.

## Test plan
- [ ] Transport bar renders MOX / TUNE / Mute at the same height as SPLIT / RIT / SAVE MEM.
- [ ] MOX still pulses red when keyed.
- [ ] Mute still shows the blue LED when audio is playing.
- [ ] Mobile layout (`.transport` responsive block) still looks reasonable.

## Notes
Visual-design change — per project CLAUDE.md this is maintainer-review territory; opening for review rather than merging blind.