### PR TITLE
feat(map): SP/LP click auto-rotates beam

### DIFF
--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -399,6 +399,16 @@ export default function App() {
   const lp = (sp + 180) % 360;
   const dist = contact && effectiveHome ? distanceKm(effectiveHome.lat, effectiveHome.lon, contact.lat, contact.lon) : 0;
 
+  function rotateToBearing(brg: number) {
+    const normalized = ((brg % 360) + 360) % 360;
+    setBeamOverrideDeg(normalized);
+    setBeamInputStr(normalized.toFixed(0));
+    const rot = useRotatorStore.getState();
+    if (rot.config.enabled && rot.status?.connected) {
+      void rot.setAzimuth(normalized);
+    }
+  }
+
   function submitBeam(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     const trimmed = beamInputStr.trim();
@@ -408,14 +418,7 @@ export default function App() {
     }
     const parsed = Number(trimmed);
     if (!Number.isFinite(parsed)) return;
-    const normalized = ((parsed % 360) + 360) % 360;
-    setBeamOverrideDeg(normalized);
-    // Also command the rotator if it's enabled — visual override + physical
-    // rotation in one click, same UX as Log4YM's map beam control.
-    const rot = useRotatorStore.getState();
-    if (rot.config.enabled && rot.status?.connected) {
-      void rot.setAzimuth(normalized);
-    }
+    rotateToBearing(parsed);
   }
 
   // --- Hero title
@@ -694,7 +697,8 @@ export default function App() {
                 <button
                   type="button"
                   className="chip mono"
-                  onClick={() => setBeamInputStr((((sp % 360) + 360) % 360).toFixed(0))}
+                  onClick={() => rotateToBearing(sp)}
+                  title="Short path — click to rotate"
                 >
                   <span className="k">SP</span>
                   <span className="v">{sp.toFixed(0)}°</span>
@@ -702,7 +706,8 @@ export default function App() {
                 <button
                   type="button"
                   className="chip mono"
-                  onClick={() => setBeamInputStr((((lp % 360) + 360) % 360).toFixed(0))}
+                  onClick={() => rotateToBearing(lp)}
+                  title="Long path — click to rotate"
                 >
                   <span className="k">LP</span>
                   <span className="v">{lp.toFixed(0)}°</span>

--- a/zeus-web/src/layout/panels/HeroPanel.tsx
+++ b/zeus-web/src/layout/panels/HeroPanel.tsx
@@ -101,7 +101,8 @@ export function HeroPanel() {
             <button
               type="button"
               className="chip mono"
-              onClick={() => setBeamInputStr((((sp % 360) + 360) % 360).toFixed(0))}
+              onClick={() => handleRotateToBearing(sp)}
+              title="Short path — click to rotate"
             >
               <span className="k">SP</span>
               <span className="v">{sp.toFixed(0)}°</span>
@@ -109,7 +110,8 @@ export function HeroPanel() {
             <button
               type="button"
               className="chip mono"
-              onClick={() => setBeamInputStr((((lp % 360) + 360) % 360).toFixed(0))}
+              onClick={() => handleRotateToBearing(lp)}
+              title="Long path — click to rotate"
             >
               <span className="k">LP</span>
               <span className="v">{lp.toFixed(0)}°</span>


### PR DESCRIPTION
## Summary
- Clicking the **SP** or **LP** chip in the hero map controls now rotates the beam in a single click — no more populating the BEAM field and hitting Go.
- The click still updates the BEAM input (as before) and commands the rotator when it's enabled + connected, so visual override and physical rotation land together.
- The BEAM text field + Go button are unchanged for manual headings.

Applied in both renderers that host the hero controls: `src/App.tsx` and `src/layout/panels/HeroPanel.tsx` (HeroPanel reuses its existing `handleRotateToBearing`; App gets a small `rotateToBearing` helper that `submitBeam` also delegates to).

Added `title` tooltips ("Short path — click to rotate" / "Long path — click to rotate") so the new behaviour is discoverable on hover.

## Test plan
- [ ] With a QRZ contact loaded and the map visible, click **SP** — BEAM field updates and rotator (if enabled) moves to the short-path bearing without a second click.
- [ ] Same with **LP** — rotator commands the long-path bearing (sp + 180 mod 360).
- [ ] Type a heading into BEAM and click **Go** — still works.
- [ ] Hover SP/LP — tooltips appear.
- [ ] `npx tsc --noEmit` clean, `npx vitest run` 66/66 passing.