### PR TITLE
fix(filter): stop control-strip clipping FILTER header and ≡ toggle

### DIFF
--- a/zeus-web/src/components/filter/FilterPanel.tsx
+++ b/zeus-web/src/components/filter/FilterPanel.tsx
@@ -78,7 +78,7 @@ export function FilterPanel() {
   if (presets.length === 0) return null;
 
   return (
-    <div className="ctrl-group" style={{ minWidth: 320 }}>
+    <div className="ctrl-group" style={{ minWidth: 400 }}>
       <div
         className="label-xs ctrl-lbl"
         style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
@@ -91,7 +91,7 @@ export function FilterPanel() {
           {widthLabel}
         </span>
       </div>
-      <div className="btn-row wrap" style={{ gap: 3 }}>
+      <div className="btn-row wrap" style={{ gap: 3, width: 400 }}>
         {presets.map((slot) => (
           <button
             key={slot.slotName}


### PR DESCRIPTION
## Summary
- `FilterPanel` renders FILTER label + 12 preset chips + the `≡` advanced-ribbon toggle inside `.btn-row.wrap` (default `width: 290px`). The control strip is a fixed `68px` / `overflow: hidden` row, so the chip grid wrapped to 3 rows and both the FILTER header above and the `≡` toggle below got clipped — the button that opens the advanced filter ribbon was invisible in USB/LSB modes.
- Widen FilterPanel's `ctrl-group` to `minWidth: 400` and override the nested `btn-row.wrap` to `width: 400` so all 13 items fit in two rows inside the existing 68px strip.
- Global `.btn-row.wrap { width: 290px }` is untouched, so `ModeBandwidth`'s BANDWIDTH row layout is unchanged. Minimal surface area while the design agent is mid-rework of this area.

## Test plan
- [ ] Load the app in USB mode — FILTER label and width readout are visible above the chips.
- [ ] Confirm the `≡` toggle is visible at the end of the second chip row (after VAR2) on desktop.
- [ ] Click `≡` → advanced filter ribbon opens (legacy grid layout, no `?layout=flex`).
- [ ] Switch to LSB / CWL / CWU / AM / SAM / DSB / DIGL / DIGU — FILTER group still fits in two rows, no clipping.
- [ ] Switch to FM — FilterPanel returns null as before (no presets).
- [ ] Confirm BANDWIDTH / BAND / FRONT-END / AGC / ZOOM·DRIVE·MIC layout is unchanged.