### PR TITLE
feat(filter): surface Low/High Cut on mini-pan and compact filter bar

### DIFF
--- a/zeus-web/src/components/filter/FilterMiniPan.tsx
+++ b/zeus-web/src/components/filter/FilterMiniPan.tsx
@@ -17,6 +17,7 @@ import { useEffect, useRef } from 'react';
 import { useDisplayStore } from '../../state/display-store';
 import { useConnectionStore } from '../../state/connection-store';
 import { setFilter } from '../../api/client';
+import { formatCutOffset } from './filterPresets';
 
 const RIBBON_SPAN_HZ = 12_000;        // 12 kHz span centered on VFO (matches mockup: 14.249..14.261)
 const TICK_STEP_HZ = 2_000;           // label a tick every 2 kHz
@@ -34,6 +35,9 @@ const COL_VFO_CENTER = 'rgba(200, 205, 215, 0.08)'; // very subtle neutral VFO l
 const COL_PB_WASH = 'rgba(220, 232, 245, 0.035)';   // almost-invisible interior wash
 const COL_WALL_HALO = 'rgba(220, 225, 232, 0.45)';  // soft neutral halo behind walls
 const COL_DOT = 'rgba(245, 247, 250, 0.95)';        // bright white corner dots
+const COL_CUT_KEY = '#7c8088';                       // "LOW CUT" / "HIGH CUT" key text
+const COL_CUT_VAL = '#edeef1';                       // value text
+const COL_CUT_TICK = 'rgba(220, 225, 232, 0.35)';    // hairline callout connecting label to wall
 
 type DragMode = 'lo' | 'hi' | 'inside';
 
@@ -90,10 +94,12 @@ export function FilterMiniPan() {
 
       ctx.clearRect(0, 0, w, h);
 
-      // Reserve the bottom ~16 px (dpr-adjusted) for the x-axis labels so the
-      // trace never overlaps them.
+      // Reserve the top ~22 px for LOW CUT / HIGH CUT wall callouts and the
+      // bottom ~14 px for the x-axis labels so neither overlap the trace.
+      const labelH = Math.round(22 * dpr);
       const axisH = Math.round(14 * dpr);
-      const plotH = h - axisH;
+      const plotTop = labelH;
+      const plotH = h - axisH - labelH;
 
       const vfo = Number(c.vfoHz);
       const panDb = d.panDb;
@@ -123,7 +129,7 @@ export function FilterMiniPan() {
             }
             if (peak === -Infinity) peak = DB_FLOOR;
             const norm = (peak - DB_FLOOR) / (DB_CEIL - DB_FLOOR);
-            const y = plotH - Math.max(0, Math.min(1, norm)) * plotH;
+            const y = plotTop + plotH - Math.max(0, Math.min(1, norm)) * plotH;
             if (x === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
           }
           ctx.stroke();
@@ -134,8 +140,8 @@ export function FilterMiniPan() {
       ctx.strokeStyle = COL_VFO_CENTER;
       ctx.lineWidth = 1 * dpr;
       ctx.beginPath();
-      ctx.moveTo(w / 2, 0);
-      ctx.lineTo(w / 2, plotH);
+      ctx.moveTo(w / 2, plotTop);
+      ctx.lineTo(w / 2, plotTop + plotH);
       ctx.stroke();
 
       // Passband — bright silver walls + soft neutral halo + corner dots.
@@ -148,8 +154,8 @@ export function FilterMiniPan() {
       if (onScreen) {
         const clampedL = Math.max(0, passLeftPx);
         const clampedR = Math.min(w, passRightPx);
-        const pbTop = Math.round(4 * dpr);
-        const pbBottom = plotH - Math.round(4 * dpr);
+        const pbTop = plotTop + Math.round(4 * dpr);
+        const pbBottom = plotTop + plotH - Math.round(4 * dpr);
         const wallW = Math.max(2, Math.round(2 * dpr));
         const dotSize = Math.round(6 * dpr);
         const halo = Math.round(6 * dpr);
@@ -191,6 +197,59 @@ export function FilterMiniPan() {
         ctx.fillRect(dotL, pbBottom - Math.ceil(dotSize / 2), dotSize, dotSize);
         ctx.fillRect(dotR, pbBottom - Math.ceil(dotSize / 2), dotSize, dotSize);
         ctx.restore();
+
+        // LOW CUT / HIGH CUT callouts. Key (letter-spaced, muted) stacked
+        // above value (bold, brighter) in the reserved top band. A hairline
+        // connector ties each label to its wall top. Labels center on the
+        // wall X and clamp to canvas edges so they never clip.
+        const keyFontPx = Math.round(8 * dpr);
+        const valFontPx = Math.round(10.5 * dpr);
+        const keyFont = `600 ${keyFontPx}px "SFMono-Regular", ui-monospace, monospace`;
+        const valFont = `600 ${valFontPx}px "SFMono-Regular", ui-monospace, monospace`;
+        const padX = Math.round(4 * dpr);
+        const keyY = Math.round(1 * dpr);
+        const valY = keyY + keyFontPx + Math.round(1 * dpr);
+
+        const drawCallout = (wallX: number, side: 'lo' | 'hi', value: string) => {
+          if (wallX < 0 || wallX > w) return;
+          const key = side === 'lo' ? 'LOW CUT' : 'HIGH CUT';
+
+          // Hairline from label bottom down to wall top (lands on the dot).
+          ctx.strokeStyle = COL_CUT_TICK;
+          ctx.lineWidth = 1 * dpr;
+          ctx.beginPath();
+          ctx.moveTo(Math.round(wallX) + 0.5, valY + valFontPx + Math.round(1 * dpr));
+          ctx.lineTo(Math.round(wallX) + 0.5, pbTop - Math.floor(dotSize / 2));
+          ctx.stroke();
+
+          // Measure both lines to find clamp bounds.
+          ctx.font = valFont;
+          const valW = ctx.measureText(value).width;
+          ctx.letterSpacing = '0.15em';
+          ctx.font = keyFont;
+          const keyW = ctx.measureText(key).width;
+          const halfMax = Math.max(valW, keyW) / 2;
+          const cx = Math.max(halfMax + padX, Math.min(w - halfMax - padX, wallX));
+
+          // Key (top, muted, letter-spaced).
+          ctx.textBaseline = 'top';
+          ctx.textAlign = 'center';
+          ctx.fillStyle = COL_CUT_KEY;
+          ctx.fillText(key, cx, keyY);
+
+          // Value (bold, brighter, no letter-spacing).
+          ctx.letterSpacing = '0px';
+          ctx.font = valFont;
+          ctx.fillStyle = COL_CUT_VAL;
+          ctx.fillText(value, cx, valY);
+        };
+
+        drawCallout(passLeftPx, 'lo', formatCutOffset(c.filterLowHz));
+        drawCallout(passRightPx, 'hi', formatCutOffset(c.filterHighHz));
+
+        // Reset text state for subsequent draws (x-axis labels assume start).
+        ctx.textAlign = 'start';
+        ctx.letterSpacing = '0px';
       }
 
       // X-axis tick labels. One label every TICK_STEP_HZ (2 kHz), centered
@@ -198,7 +257,7 @@ export function FilterMiniPan() {
       ctx.fillStyle = COL_TICK_LABEL;
       ctx.font = `${Math.round(9.5 * dpr)}px "SFMono-Regular", ui-monospace, monospace`;
       ctx.textBaseline = 'middle';
-      const labelY = plotH + Math.round(axisH / 2);
+      const labelY = plotTop + plotH + Math.round(axisH / 2);
       const nTicks = Math.floor(RIBBON_SPAN_HZ / TICK_STEP_HZ) + 1; // inclusive both ends
       const tickOffsets: number[] = [];
       // Center-out so VFO tick is guaranteed; symmetric ticks either side.

--- a/zeus-web/src/components/filter/FilterPanel.tsx
+++ b/zeus-web/src/components/filter/FilterPanel.tsx
@@ -13,7 +13,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useConnectionStore } from '../../state/connection-store';
 import { setFilter, getFilterPresets, setFilterAdvancedPaneOpen, type FilterPresetDto } from '../../api/client';
-import { getPresetsForMode, formatFilterWidth, type FilterPresetSlot } from './filterPresets';
+import { getPresetsForMode, formatFilterWidth, formatCutOffset, type FilterPresetSlot } from './filterPresets';
 
 const LOCAL_STORAGE_KEY = 'zeus.filter.advancedPaneOpen';
 
@@ -78,18 +78,21 @@ export function FilterPanel() {
   if (presets.length === 0) return null;
 
   return (
-    <div className="ctrl-group" style={{ minWidth: 320 }}>
-      <div
-        className="label-xs ctrl-lbl"
-        style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
-      >
-        <span>FILTER</span>
-        <span
-          className="mono"
-          style={{ color: 'var(--accent)', fontWeight: 600, fontSize: 11, letterSpacing: 0.5 }}
-        >
-          {widthLabel}
-        </span>
+    <div className="ctrl-group filter-bar" style={{ minWidth: 320 }}>
+      <div className="label-xs ctrl-lbl">FILTER</div>
+      <div className="filter-bar__readout" role="group" aria-label="Filter edges and width">
+        <div className="filter-bar__cell filter-bar__cell--lo">
+          <div className="filter-bar__key">LOW CUT</div>
+          <div className="filter-bar__val mono">{formatCutOffset(filterLow)}</div>
+        </div>
+        <div className="filter-bar__cell filter-bar__cell--width">
+          <div className="filter-bar__key">WIDTH</div>
+          <div className="filter-bar__val filter-bar__val--accent mono">{widthLabel}</div>
+        </div>
+        <div className="filter-bar__cell filter-bar__cell--hi">
+          <div className="filter-bar__key">HIGH CUT</div>
+          <div className="filter-bar__val mono">{formatCutOffset(filterHigh)}</div>
+        </div>
       </div>
       <div className="btn-row wrap" style={{ gap: 3 }}>
         {presets.map((slot) => (

--- a/zeus-web/src/components/filter/filterPresets.ts
+++ b/zeus-web/src/components/filter/filterPresets.ts
@@ -159,6 +159,20 @@ export function formatRibbonWidth(lowHz: number, highHz: number): string {
   return `${(width / 1000).toFixed(2)} kHz`;
 }
 
+// Format a VFO-relative filter edge as a signed offset. Uses a typographic
+// minus sign, collapses ≥1 kHz to two-decimal kHz ("+2.70 kHz"), and keeps
+// sub-kHz values in whole Hz ("−200 Hz"). Used by both the compact filter
+// bar readout and the mini-pan wall callouts.
+export function formatCutOffset(hz: number): string {
+  const rounded = Math.round(hz);
+  const sign = rounded < 0 ? '−' : '+';
+  const abs = Math.abs(rounded);
+  if (abs >= 1000) {
+    return `${sign}${(abs / 1000).toFixed(2)} kHz`;
+  }
+  return `${sign}${abs} Hz`;
+}
+
 // Format an absolute Hz frequency as "MM.kkk.hhh" (MHz.kHz-3.Hz-3). Matches
 // the mockup's LOW CUT / HIGH CUT columns (e.g. "14.254.650").
 export function formatAbsFreq(hz: number): string {

--- a/zeus-web/src/styles/filter-ribbon.css
+++ b/zeus-web/src/styles/filter-ribbon.css
@@ -131,12 +131,14 @@
 .filter-ribbon__passband-value { font-size: 22px; font-weight: 600; letter-spacing: 0.02em; }
 .filter-ribbon__passband-unit  { font-size: 12px; color: #b4b7bd; font-weight: 500; }
 
-/* Mini-pan — fills the remaining vertical space in the main column */
+/* Mini-pan — fills the remaining vertical space in the main column.
+   Height accommodates the top LOW/HIGH CUT callout band (~22px) on top
+   of the spectrum/passband/axis stack. */
 .filter-ribbon__minipan {
   position: relative;
   flex: 1 1 auto;
-  min-height: 80px;
-  height: 100px;
+  min-height: 102px;
+  height: 122px;
   border-radius: 4px;
   overflow: hidden;
 }
@@ -252,3 +254,73 @@
     0 1px 0 rgba(0, 0, 0, 0.40);
 }
 .filter-ribbon__custom-icon { opacity: 0.75; margin-left: 8px; font-size: 12px; }
+
+/* ===========================================================
+   Compact filter bar — triplet readout above the preset chips.
+   Mirrors the ribbon's top-row hierarchy (LOW CUT / PASSBAND /
+   HIGH CUT) at miniature scale so the edges are legible without
+   opening the ribbon.
+   =========================================================== */
+.filter-bar__readout {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: baseline;
+  column-gap: 10px;
+  margin: 2px 0 5px;
+  padding: 3px 4px 4px;
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+.filter-bar__cell {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  position: relative;
+}
+.filter-bar__cell--lo     { align-items: flex-start; text-align: left; }
+.filter-bar__cell--width  { align-items: center;    text-align: center; }
+.filter-bar__cell--hi     { align-items: flex-end;  text-align: right; }
+
+/* Hairline vertical dividers between cells — pure atmosphere, no strong line. */
+.filter-bar__cell--width::before,
+.filter-bar__cell--width::after {
+  content: '';
+  position: absolute;
+  top: 8%;
+  bottom: 8%;
+  width: 1px;
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0) 0%,
+    rgba(255, 255, 255, 0.08) 50%,
+    rgba(255, 255, 255, 0) 100%
+  );
+  pointer-events: none;
+}
+.filter-bar__cell--width::before { left: -5px; }
+.filter-bar__cell--width::after  { right: -5px; }
+
+.filter-bar__key {
+  font-size: 8.5px;
+  font-weight: 600;
+  letter-spacing: 0.22em;
+  color: var(--fg-3);
+  text-transform: uppercase;
+  line-height: 1;
+  white-space: nowrap;
+}
+.filter-bar__val {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--fg-0);
+  line-height: 1.2;
+  letter-spacing: 0.01em;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.filter-bar__val--accent {
+  font-size: 13.5px;
+  color: var(--accent);
+  letter-spacing: 0.02em;
+}


### PR DESCRIPTION
## Summary
- **Compact filter bar** (`FilterPanel`): replaces the single width badge with a three-cell `LOW CUT · WIDTH · HIGH CUT` readout above the preset chips, mirroring the advanced ribbon's hierarchy at compact scale.
- **Filter visualization** (`FilterMiniPan`): reserves a top label band and draws `LOW CUT` / `HIGH CUT` callouts pinned to each passband wall, with a hairline dropping to the corner dot. Labels clamp to canvas edges and update live while dragging.
- Lifts `formatCutOffset` into `filterPresets` so both views share one signed-offset formatter (`−200 Hz`, `+2.70 kHz`).

Palette stays in the existing neutral/pearl family — no amber, no cyan, no new accents. Plot-area bump on `.filter-ribbon__minipan` (100 → 122 px) preserves trace density after carving out the label band.

## Test plan
- [ ] `npm --prefix zeus-web run typecheck` clean
- [ ] `npm --prefix zeus-web test` green (66 tests)
- [ ] Open the compact filter group and confirm the three-cell readout renders and updates when switching modes / presets
- [ ] Open the advanced ribbon (`≡`) and confirm the mini-pan shows `LOW CUT` / `HIGH CUT` callouts anchored to the walls; drag the walls and confirm labels update live without flicker
- [ ] Narrow the passband to near-minimum and confirm the two callouts don't collide or clip the canvas edges
- [ ] Verify FM (no presets) still hides the compact filter bar as before