### PR TITLE
feat(#81): TX panadapter + PureSignal (P2) + AutoAttenuate convergence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Backend + frontend run independently during dev:
 dotnet run --project Zeus.Server
 
 # frontend (Vite dev server on :5173, proxies /api and /hub to :6060)
-npm --prefix Zeus.Web run dev
+npm --prefix zeus-web run dev
 ```
 
 Full details, dependency list, and native WDSP build in `README.md` and `native/`. Do not duplicate them here.
@@ -79,8 +79,9 @@ Full details, dependency list, and native WDSP build in `README.md` and `native/
 
 - **`Zeus.Contracts`** — wire format shared between server and web (frames, DTOs, enums). Changes here are red-light.
 - **`Zeus.Protocol1`** — HPSDR original-protocol UDP client, discovery, packet parsing, TX IQ ring.
+- **`Zeus.Protocol2`** — HPSDR Protocol 2 (ANAN-class / Orion) UDP client: discovery, DDC RX streaming, TX IQ/mic path.
 - **`Zeus.Dsp`** — DSP engine abstraction (`IDspEngine`), synthetic and WDSP implementations, TX-stage meters.
 - **`Zeus.Server`** — ASP.NET host, SignalR `StreamingHub`, radio / DSP / TX pipeline services, discovery.
-- **`Zeus.Web`** (frontend) — Vite + React, connects to the hub, renders panadapter/waterfall/VFO/meters.
+- **`zeus-web`** (frontend) — Vite + React, connects to the hub, renders panadapter/waterfall/VFO/meters.
 
 When in doubt about where code belongs, match the existing project's single responsibility rather than introducing a new one.

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -42,6 +42,13 @@ public enum RxMode : byte
     LSB, USB, CWL, CWU, AM, FM, SAM, DSB, DIGL, DIGU,
 }
 
+// PureSignal feedback antenna source. On G2/MkII the wire-format diff
+// between Internal coupler and External (Bypass) is exactly one bit
+// (ALEX_RX_ANTENNA_BYPASS = 0x00000800) in alex0 when xmit && PS armed.
+// pihpsdr's three-way Internal/Ext1/Bypass collapses to two on the wire
+// for this hardware, so Zeus exposes a two-way selector.
+public enum PsFeedbackSource : byte { Internal = 0, External = 1 }
+
 public enum ConnectionStatus { Disconnected, Connecting, Connected, Error }
 
 // Thetis NR-button state: Off = no spectral NR, Anr = NR1 (time-domain LMS),
@@ -129,6 +136,7 @@ public sealed record StateDto(
     // RadioService HW-peak switch overrides on the first ConnectAsync /
     // ConnectP2Async. See PLAN section 7 / hermes.md §7.1.
     double PsHwPeak = 0.4072,
+    PsFeedbackSource PsFeedbackSource = PsFeedbackSource.Internal,
     string PsIntsSpiPreset = "16/256",
     double PsFeedbackLevel = 0.0,   // info[4] read-back, 0..256
     byte PsCalState = 0,            // info[15] enum
@@ -286,6 +294,11 @@ public sealed record PsResetRequest();
 public sealed record PsSaveRequest(string Filename);
 
 public sealed record PsRestoreRequest(string Filename);
+
+// Feedback antenna selector — Internal coupler vs External (Bypass).
+// Sent from the PS settings panel. Affects only the radio-side ALEX bit;
+// the WDSP cal/iqc stages operate on whatever IQ arrives at DDC0/DDC1.
+public sealed record PsFeedbackSourceSetRequest(PsFeedbackSource Source);
 
 // Two-tone test generator (used as PS calibration excitation but works
 // standalone too). Protocol-agnostic.

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -108,7 +108,38 @@ public sealed record StateDto(
     // is −50..+20 dB (see RadioService.SetRxAfGain). Per-RX not supported
     // yet; when multi-RX lands this becomes the master and the per-RX
     // values layer on top.
-    double RxAfGainDb = 0.0);
+    double RxAfGainDb = 0.0,
+
+    // ---- PureSignal predistortion (TXA-side; WDSP calcc/iqc stages) ----
+    // PsEnabled is the master arm bit. Deliberately NOT persisted server-side
+    // — operator must re-arm each session (parity with MOX). The other PS
+    // fields ARE persisted via PsSettingsStore so the operator's calibration
+    // tuning survives restarts.
+    bool PsEnabled = false,
+    bool PsAuto = true,             // continuous adapt by default once armed
+    bool PsSingle = false,          // one-shot SetPSControl(1,1,0,0)
+    bool PsPtol = false,            // false = strict 0.4; true = relax 0.8
+    bool PsAutoAttenuate = true,
+    double PsMoxDelaySec = 0.2,
+    double PsLoopDelaySec = 0.0,
+    double PsAmpDelayNs = 150.0,
+    // PS hardware peak — set per protocol/hardware by RadioService at connect
+    // time. P1 = 0.4072 (Hermes/ANAN-10/100); P2 OrionMkII/Saturn = 0.6121;
+    // P2 ANAN-7000/8000 = 0.2899. Default here (P1) is a safe neutral; the
+    // RadioService HW-peak switch overrides on the first ConnectAsync /
+    // ConnectP2Async. See PLAN section 7 / hermes.md §7.1.
+    double PsHwPeak = 0.4072,
+    string PsIntsSpiPreset = "16/256",
+    double PsFeedbackLevel = 0.0,   // info[4] read-back, 0..256
+    byte PsCalState = 0,            // info[15] enum
+    bool PsCorrecting = false,      // info[14]
+    // ---- TwoTone test generator (TXA PostGen mode=1; protocol-agnostic) ----
+    // Standard PureSignal calibration excitation. Defaults match pihpsdr's
+    // TwoTone defaults — 700/1900 Hz, 0.49 linear amplitude per tone.
+    bool TwoToneEnabled = false,
+    double TwoToneFreq1 = 700.0,
+    double TwoToneFreq2 = 1900.0,
+    double TwoToneMag = 0.49);
 
 public sealed record RadioInfo(
     string MacAddress,
@@ -234,3 +265,32 @@ public sealed record RadioSelectionDto(
     string Effective);
 
 public sealed record RadioSelectionSetRequest(string Preferred);
+
+// ---- PureSignal request records ----
+// PsControlSetRequest = master arm (Enabled) + mode (Auto vs Single).
+// PsAdvancedSetRequest = nullable so partial updates from the settings
+// panel don't reset other fields.
+public sealed record PsControlSetRequest(bool Enabled, bool Auto, bool Single);
+
+public sealed record PsAdvancedSetRequest(
+    bool? Ptol = null,
+    bool? AutoAttenuate = null,
+    double? MoxDelaySec = null,
+    double? LoopDelaySec = null,
+    double? AmpDelayNs = null,
+    double? HwPeak = null,
+    string? IntsSpiPreset = null);
+
+public sealed record PsResetRequest();
+
+public sealed record PsSaveRequest(string Filename);
+
+public sealed record PsRestoreRequest(string Filename);
+
+// Two-tone test generator (used as PS calibration excitation but works
+// standalone too). Protocol-agnostic.
+public sealed record TwoToneSetRequest(
+    bool Enabled,
+    double? Freq1 = null,
+    double? Freq2 = null,
+    double? Mag = null);

--- a/Zeus.Contracts/MsgType.cs
+++ b/Zeus.Contracts/MsgType.cs
@@ -79,4 +79,12 @@ public enum MsgType : byte
     // seconds timescale, so bolting it onto the 10 Hz TX meter cadence
     // would be overkill. Broadcast at 2 Hz always.
     PaTemp = 0x17,
+
+    // PureSignal stage telemetry. Broadcast at 10 Hz only while PsEnabled is
+    // armed — keeps the wire quiet during normal operation. Carries WDSP
+    // GetPSInfo readouts (info[4] = feedback level, info[14] = correcting
+    // bit, info[15] = cal-state enum) plus a derived correction-depth dB
+    // and the GetPSMaxTX envelope peak. Bare-payload like TxMetersV2 (no
+    // 16-byte header) — same 10 Hz rate logic.
+    PsMeters = 0x18,
 }

--- a/Zeus.Contracts/PsMetersFrame.cs
+++ b/Zeus.Contracts/PsMetersFrame.cs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Buffers;
+using System.Buffers.Binary;
+
+namespace Zeus.Contracts;
+
+// PureSignal stage meters. 19 bytes total:
+//
+//   [0x18] [feedbackLevel:f32] [correctionDb:f32]
+//          [calState:u8] [correcting:u8]
+//          [maxTxEnvelope:f32]
+//
+// FeedbackLevel — WDSP GetPSInfo info[4], 0..256 raw (UI normalises to 0..1).
+// CorrectionDb — derived correction-depth in dB (RMS of the recent calcc
+//                output curve). Zero when not correcting.
+// CalState — info[15] enum: 0 RESET, 1 WAIT, 2 MOXDELAY, 3 SETUP, 4 COLLECT,
+//            5 MOXCHECK, 6 CALC, 7 DELAY, 8 STAYON, 9 TURNON.
+// Correcting — info[14] != 0; non-zero means the iqc stage has a curve loaded
+//              and is actively predistorting.
+// MaxTxEnvelope — GetPSMaxTX(out double maxtx); the highest TX envelope
+//                 magnitude seen since last PS reset. Used by the auto-attenuate
+//                 control loop.
+//
+// Bare-payload like TxMetersV2Frame (0x16) — no 16-byte WireFormat header.
+// Server only emits this when PsEnabled is true so idle wire stays quiet.
+public readonly record struct PsMetersFrame(
+    float FeedbackLevel,
+    float CorrectionDb,
+    byte CalState,
+    bool Correcting,
+    float MaxTxEnvelope)
+{
+    public const int ByteLength = 1 + 4 + 4 + 1 + 1 + 4;
+
+    public void Serialize(IBufferWriter<byte> writer)
+    {
+        var span = writer.GetSpan(ByteLength);
+        span[0] = (byte)MsgType.PsMeters;
+        BinaryPrimitives.WriteSingleLittleEndian(span.Slice(1, 4), FeedbackLevel);
+        BinaryPrimitives.WriteSingleLittleEndian(span.Slice(5, 4), CorrectionDb);
+        span[9] = CalState;
+        span[10] = Correcting ? (byte)1 : (byte)0;
+        BinaryPrimitives.WriteSingleLittleEndian(span.Slice(11, 4), MaxTxEnvelope);
+        writer.Advance(ByteLength);
+    }
+
+    public static PsMetersFrame Deserialize(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length < ByteLength)
+            throw new InvalidDataException($"PsMetersFrame requires {ByteLength} bytes, got {bytes.Length}");
+        if (bytes[0] != (byte)MsgType.PsMeters)
+            throw new InvalidDataException($"expected PsMeters (0x{(byte)MsgType.PsMeters:X2}), got 0x{bytes[0]:X2}");
+        return new PsMetersFrame(
+            FeedbackLevel: BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(1, 4)),
+            CorrectionDb: BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(5, 4)),
+            CalState: bytes[9],
+            Correcting: bytes[10] != 0,
+            MaxTxEnvelope: BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(11, 4)));
+    }
+}

--- a/Zeus.Dsp/IDspEngine.cs
+++ b/Zeus.Dsp/IDspEngine.cs
@@ -69,6 +69,14 @@ public interface IDspEngine : IDisposable
 
     bool TryGetDisplayPixels(int channelId, DisplayPixout which, Span<float> dbOut);
 
+    /// <summary>TX panadapter / waterfall pixels in dBm, sourced from a
+    /// dedicated WDSP analyzer fed with the post-CFIR TX IQ. Returns false
+    /// when TXA is not open or no fresh FFT is ready. The TX analyzer is
+    /// configured to display the same frequency span as the RXA analyzer
+    /// (via bin clipping) so the panadapter axis does not move on MOX —
+    /// see issue #81. No-op on Synthetic.</summary>
+    bool TryGetTxDisplayPixels(DisplayPixout which, Span<float> dbOut);
+
     /// <summary>Open the TXA channel. Idempotent — calling twice returns the existing id.
     /// Must be called after at least one OpenChannel(RXA). For Synthetic, returns -1 and is a no-op.
     /// <paramref name="outputRateHz"/> picks the TXA profile: 48000 for P1 (48k in/out, CFIR off),

--- a/Zeus.Dsp/IDspEngine.cs
+++ b/Zeus.Dsp/IDspEngine.cs
@@ -149,4 +149,70 @@ public interface IDspEngine : IDisposable
     /// concurrently with ProcessTxBlock — the engine publishes via an
     /// atomic snapshot so the reader sees a consistent set.</summary>
     TxStageMeters GetTxStageMeters();
+
+    /// <summary>Two-tone test generator. Replaces mic input with summed tones
+    /// at <paramref name="freq1"/>/<paramref name="freq2"/> while armed.
+    /// Standard PureSignal calibration excitation but useful standalone.
+    /// Mutually exclusive with TUN (both share the WDSP PostGen stage).
+    /// Protocol-agnostic. No-op on Synthetic.</summary>
+    void SetTwoTone(bool on, double freq1, double freq2, double mag);
+
+    // ----------------- PureSignal predistortion (TXA-side) -----------------
+    // PS lives inside the TXA channel (txa[ch].calcc.p, txa[ch].iqc.p0/p1
+    // allocated by create_txa). The setters here drive the WDSP state
+    // machine; FeedPsFeedbackBlock pumps paired TX-modulator + RX-coupler
+    // IQ into pscc. Synthetic implements all of these as no-ops; meters
+    // return PsStageMeters.Silent.
+
+    /// <summary>Master arm. true → SetPSRunCal(1) and SetPSControl mode-on
+    /// (auto vs single is set via <see cref="SetPsControl"/>). false →
+    /// pihpsdr's "7× zero-pscc → SetPSRunCal(0) → SetPSControl reset"
+    /// shutdown sequence so the iqc stage doesn't latch a stale curve.
+    /// </summary>
+    void SetPsEnabled(bool enabled);
+
+    /// <summary>Cal-mode select. <paramref name="autoCal"/> = continuous
+    /// adaptation; <paramref name="singleCal"/> = one-shot collect-then-stay.
+    /// At most one of the two should be true; if both, single takes
+    /// precedence (one-shot then auto). Calls <c>SetPSControl</c> directly.
+    /// </summary>
+    void SetPsControl(bool autoCal, bool singleCal);
+
+    /// <summary>Apply timing + hardware-peak + ints/spi settings as a batch
+    /// (each call internally guards against the heavy
+    /// <c>SetPSIntsAndSpi</c> path firing when the values haven't changed).
+    /// </summary>
+    void SetPsAdvanced(bool ptol, double moxDelaySec, double loopDelaySec,
+                      double ampDelayNs, double hwPeak, int ints, int spi);
+
+    /// <summary>Set just the hardware-peak. Called from RadioService at
+    /// connect time once the protocol/board is known so the right value
+    /// (P1=0.4072, P2 G2=0.6121, P2 ANAN-7000=0.2899) lands before the
+    /// operator arms PS.</summary>
+    void SetPsHwPeak(double hwPeak);
+
+    /// <summary>Push one paired TX-mod-IQ + RX-feedback-IQ block into the
+    /// WDSP <c>psccF</c> entry. Block size must match the value pihpsdr
+    /// uses (1024 complex samples at 192 kHz). Caller owns the buffers; the
+    /// engine copies internally before handing to the native side.</summary>
+    void FeedPsFeedbackBlock(ReadOnlySpan<float> txI, ReadOnlySpan<float> txQ,
+                             ReadOnlySpan<float> rxI, ReadOnlySpan<float> rxQ);
+
+    /// <summary>Latest PureSignal stage readings (GetPSInfo + GetPSMaxTX).
+    /// Returns <see cref="PsStageMeters.Silent"/> when PS isn't armed or
+    /// the engine has no TXA. Safe to poll concurrently.</summary>
+    PsStageMeters GetPsStageMeters();
+
+    /// <summary>Reset PS state — calls <c>SetPSControl(1,0,0,0)</c>. Useful
+    /// after an aborted calibration or when changing radios.</summary>
+    void ResetPs();
+
+    /// <summary>Save the current PS correction curve to disk (ints/spi must
+    /// be 16/256 — WDSP refuses other shapes per Thetis PSForm.cs:865).
+    /// </summary>
+    void SavePsCorrection(string path);
+
+    /// <summary>Restore a previously-saved correction curve. Equivalent to
+    /// PSForm's "Restore-and-go" with <c>SetPSControl(0,0,0,1)</c>.</summary>
+    void RestorePsCorrection(string path);
 }

--- a/Zeus.Dsp/PsStageMeters.cs
+++ b/Zeus.Dsp/PsStageMeters.cs
@@ -32,17 +32,27 @@ namespace Zeus.Dsp;
 /// <param name="MaxTxEnvelope"><c>GetPSMaxTX</c> — peak TX envelope
 /// magnitude since the last reset. Used by auto-attenuate to know when to
 /// step the attenuator down.</param>
+/// <param name="CalibrationAttempts">info[5] — cumulative count of completed
+/// calibration fits (calc() invocations that produced a result, regardless
+/// of whether scheck accepted them). Thetis <c>PSForm.cs:1097-1099</c>
+/// gates AutoAttenuate's <c>timer2code</c> on this counter incrementing
+/// (<c>CalibrationAttemptsChanged</c>) — only step the attenuator after
+/// calcc has finished a fit, otherwise the loop changes the envelope mid-
+/// calc and cm jumps trigger info[6]=0x40 (cm changed too much) every
+/// iteration, forcing perpetual LRESET.</param>
 public readonly record struct PsStageMeters(
     float FeedbackLevel,
     byte CalState,
     bool Correcting,
     float CorrectionDb,
-    float MaxTxEnvelope)
+    float MaxTxEnvelope,
+    int CalibrationAttempts)
 {
     public static readonly PsStageMeters Silent = new(
         FeedbackLevel: 0f,
         CalState: 0,
         Correcting: false,
         CorrectionDb: 0f,
-        MaxTxEnvelope: 0f);
+        MaxTxEnvelope: 0f,
+        CalibrationAttempts: 0);
 }

--- a/Zeus.Dsp/PsStageMeters.cs
+++ b/Zeus.Dsp/PsStageMeters.cs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.Dsp;
+
+/// <summary>
+/// PureSignal calcc-stage readings sampled from <c>GetPSInfo</c> and
+/// <c>GetPSMaxTX</c>. Captured at the same 10 Hz cadence as the TX stage
+/// meters but only emitted to the wire when PsEnabled is true.
+/// </summary>
+/// <param name="FeedbackLevel">info[4] — feedback envelope level, 0..256
+/// raw. UI normalises to 0..1 via /256 for the bar.</param>
+/// <param name="CalState">info[15] — cal-state enum: 0 RESET, 1 WAIT,
+/// 2 MOXDELAY, 3 SETUP, 4 COLLECT, 5 MOXCHECK, 6 CALC, 7 DELAY, 8 STAYON,
+/// 9 TURNON. Drives the cal-state badge in the UI.</param>
+/// <param name="Correcting">info[14] != 0 — the iqc stage is actively
+/// applying a correction curve.</param>
+/// <param name="CorrectionDb">Derived metric: RMS of the calcc output curve
+/// in dB. Zero when not correcting; useful as a "depth" indicator.</param>
+/// <param name="MaxTxEnvelope"><c>GetPSMaxTX</c> — peak TX envelope
+/// magnitude since the last reset. Used by auto-attenuate to know when to
+/// step the attenuator down.</param>
+public readonly record struct PsStageMeters(
+    float FeedbackLevel,
+    byte CalState,
+    bool Correcting,
+    float CorrectionDb,
+    float MaxTxEnvelope)
+{
+    public static readonly PsStageMeters Silent = new(
+        FeedbackLevel: 0f,
+        CalState: 0,
+        Correcting: false,
+        CorrectionDb: 0f,
+        MaxTxEnvelope: 0f);
+}

--- a/Zeus.Dsp/SyntheticDspEngine.cs
+++ b/Zeus.Dsp/SyntheticDspEngine.cs
@@ -155,6 +155,11 @@ public sealed class SyntheticDspEngine : IDspEngine
     public void SetTxTune(bool on) { }
     public TxStageMeters GetTxStageMeters() => TxStageMeters.Silent;
 
+    // Synthetic has no TX analyzer; the TX panadapter stays on the RX trace.
+    // Returning false tells DspPipelineService.Tick to leave the display alone
+    // while MOX is on, matching the existing "no new data" semantics.
+    public bool TryGetTxDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
+
     private const float NoiseFloorDb = -90f;
     private const float SweepPeakDb = -25f;
     private const float StaticPeakDb = -35f;

--- a/Zeus.Dsp/SyntheticDspEngine.cs
+++ b/Zeus.Dsp/SyntheticDspEngine.cs
@@ -155,6 +155,23 @@ public sealed class SyntheticDspEngine : IDspEngine
     public void SetTxTune(bool on) { }
     public TxStageMeters GetTxStageMeters() => TxStageMeters.Silent;
 
+    // TwoTone — no PostGen, so no-op on synthetic.
+    public void SetTwoTone(bool on, double freq1, double freq2, double mag) { }
+
+    // PureSignal — synthetic has no TXA / calcc / iqc. All setters and the
+    // feedback pump are no-ops; GetPsStageMeters returns the silent record.
+    public void SetPsEnabled(bool enabled) { }
+    public void SetPsControl(bool autoCal, bool singleCal) { }
+    public void SetPsAdvanced(bool ptol, double moxDelaySec, double loopDelaySec,
+                              double ampDelayNs, double hwPeak, int ints, int spi) { }
+    public void SetPsHwPeak(double hwPeak) { }
+    public void FeedPsFeedbackBlock(ReadOnlySpan<float> txI, ReadOnlySpan<float> txQ,
+                                    ReadOnlySpan<float> rxI, ReadOnlySpan<float> rxQ) { }
+    public PsStageMeters GetPsStageMeters() => PsStageMeters.Silent;
+    public void ResetPs() { }
+    public void SavePsCorrection(string path) { }
+    public void RestorePsCorrection(string path) { }
+
     // Synthetic has no TX analyzer; the TX panadapter stays on the RX trace.
     // Returning false tells DspPipelineService.Tick to leave the display alone
     // while MOX is on, matching the existing "no new data" semantics.

--- a/Zeus.Dsp/Wdsp/NativeMethods.cs
+++ b/Zeus.Dsp/Wdsp/NativeMethods.cs
@@ -582,6 +582,17 @@ internal static partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial void SetTXAPostGenToneFreq(int channel, double freq);
 
+    // Two-tone test generator (wdsp.h:590-591). PostGen mode=1 sums two
+    // tones at the modulator input. Standard PS calibration excitation —
+    // see Thetis PSForm.cs:935-940. Independent of TUN (mode=0).
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetTXAPostGenTTMag(int channel, double mag1, double mag2);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetTXAPostGenTTFreq(int channel, double freq1, double freq2);
+
     // Pre-DSP generator (injected before the TX chain). pihpsdr transmitter.c
     // :1293-1296 explicitly disables PreGen on TXA open — WDSP's create_channel
     // doesn't guarantee mag=0/run=0, and a residual PreGen tone would appear
@@ -638,4 +649,91 @@ internal static partial class NativeMethods
     [LibraryImport(LibraryName)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial IntPtr wisdom_get_status();
+
+    // -- PureSignal (predistortion). Lives inside the TXA channel via
+    //    create_calcc / create_iqc (TXA.c:405,424). Symbol set verified
+    //    against native/wdsp/wdsp.h. The mox/solidmox args to psccF are
+    //    documented as ignored — drive MOX state through SetPSMox instead
+    //    (calcc.c:846).
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetPSControl(int channel, int reset, int mancal, int automode, int turnon);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetPSRunCal(int channel, int run);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetPSMox(int channel, int mox);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetPSFeedbackRate(int channel, int rate);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetPSHWPeak(int channel, double peak);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetPSPtol(int channel, double ptol);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetPSPinMode(int channel, int pin);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetPSMapMode(int channel, int map);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetPSStabilize(int channel, int stbl);
+
+    // SetPSIntsAndSpi is a heavy restart, not a setter (calcc.c:1132-1151).
+    // Only safe to call when not actively calibrating.
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetPSIntsAndSpi(int channel, int ints, int spi);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetPSMoxDelay(int channel, double delay);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetPSLoopDelay(int channel, double delay);
+
+    // Returns the actual delay applied (clamped). pihpsdr stores the return.
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial double SetPSTXDelay(int channel, double delay);
+
+    // info[16]: state-machine snapshot. Caller passes a pinned int[16].
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void GetPSInfo(int channel, IntPtr info);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void GetPSMaxTX(int channel, out double maxtx);
+
+    // pscc float variant (calcc.c:840). Feed paired TX-modulator IQ + RX
+    // feedback IQ. Block size is 1024 complex samples per pihpsdr's
+    // receiver.c:636. mox/solidmox are dead args — pass 0/0.
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void psccF(int channel, int size,
+                                       float[] Itxbuff, float[] Qtxbuff,
+                                       float[] Irxbuff, float[] Qrxbuff,
+                                       int mox, int solidmox);
+
+    [LibraryImport(LibraryName, StringMarshalling = StringMarshalling.Utf8)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void PSSaveCorr(int channel, string filename);
+
+    [LibraryImport(LibraryName, StringMarshalling = StringMarshalling.Utf8)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void PSRestoreCorr(int channel, string filename);
 }

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -1438,6 +1438,7 @@ public sealed class WdspDspEngine : IDspEngine
         byte calState;
         bool correcting;
         double maxTx;
+        int calibrationAttempts;
         lock (_psLock)
         {
             unsafe
@@ -1450,6 +1451,7 @@ public sealed class WdspDspEngine : IDspEngine
             feedbackRaw = _psInfoBuf[4];
             correcting = _psInfoBuf[14] != 0;
             calState = (byte)Math.Clamp(_psInfoBuf[15], 0, 255);
+            calibrationAttempts = _psInfoBuf[5];
             NativeMethods.GetPSMaxTX(id, out maxTx);
             _psMaxTxEnvelope = maxTx;
         }
@@ -1497,7 +1499,8 @@ public sealed class WdspDspEngine : IDspEngine
             CalState: calState,
             Correcting: correcting,
             CorrectionDb: depthDb,
-            MaxTxEnvelope: (float)maxTx);
+            MaxTxEnvelope: (float)maxTx,
+            CalibrationAttempts: calibrationAttempts);
     }
 
     public void ResetPs()
@@ -1508,9 +1511,21 @@ public sealed class WdspDspEngine : IDspEngine
         if (txa is not int id) return;
         lock (_psLock)
         {
+            // Two-phase reset+restore — matches Thetis PSForm.cs:760-783
+            // (timer2code Monitor → SetNewValues → RestoreOperation) and
+            // pihpsdr's tx_ps_reset → tx_ps_resume pattern (transmitter.c
+            // :2478-2502). Phase 1 clears calcc to LRESET with mancal/
+            // automode zeroed (drops any in-flight fit). Phase 2 restores
+            // the saved Auto/Single mode so calcc autorestarts. Without
+            // phase 2, automode stays 0 and calcc parks at LRESET forever
+            // — which on a Patch-A-gated AutoAttenuate loop means info[5]
+            // never increments past 1 and the loop stalls after one step.
             NativeMethods.SetPSControl(id, 1, 0, 0, 0);
+            int mancal = _psSingle ? 1 : 0;
+            int automode = (_psAuto && !_psSingle) ? 1 : 0;
+            NativeMethods.SetPSControl(id, 0, mancal, automode, 0);
         }
-        _log.LogInformation("wdsp.resetPs");
+        _log.LogInformation("wdsp.resetPs auto={Auto} single={Single}", _psAuto, _psSingle);
     }
 
     public void SavePsCorrection(string path)

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -178,6 +178,22 @@ public sealed class WdspDspEngine : IDspEngine
     private TxStageMeters? _latestTxStageMeters;
     private readonly object _txMeterPublishLock = new();
 
+    // TX panadapter analyzer. Separate WDSP `disp` slot from RXA's, fed with
+    // the post-CFIR IQ from ProcessTxBlock so the operator can see the on-air
+    // signal during MOX / TUN. The analyzer runs at the TXA output rate
+    // (48 kHz on P1, 192 kHz on P2 post-CFIR) and uses fscLin/fscHin bin
+    // clipping to display the same frequency span as the RXA analyzer —
+    // matches pihpsdr transmitter.c:2323-2324. See issue #81.
+    //
+    // `_txDispLock` serializes Spectrum0 feed (from ProcessTxBlock), GetPixels
+    // (from TryGetTxDisplayPixels), and SetAnalyzer reconfig (from SetZoom) —
+    // same pattern as ChannelState.AnalyzerLock on the RX side.
+    private readonly object _txDispLock = new();
+    private int _txDispPixelWidth;
+    private int _txDispZoomLevel = 1;
+    private int _txDispRxSampleRateHz;
+    private bool _txDispAlive;
+
     public WdspDspEngine(ILogger<WdspDspEngine>? logger = null)
     {
         _log = logger ?? NullLogger<WdspDspEngine>.Instance;
@@ -412,7 +428,23 @@ public sealed class WdspDspEngine : IDspEngine
             state.ZoomLevel = level;
             ConfigureAnalyzer(channelId, state.SampleRateHz, state.PixelWidth, level);
         }
-        _log.LogInformation("wdsp.setZoom channel={Id} level={Level}", channelId, level);
+
+        // Mirror zoom onto the TX analyzer so the TX panadapter span stays
+        // lock-step with RX — otherwise keying mid-zoom would show a different
+        // frequency window on MOX. No-op when TX analyzer is off.
+        int? txaIdToReconfig = null;
+        lock (_txDispLock)
+        {
+            if (_txDispAlive && _txaChannelId is int txa)
+            {
+                _txDispZoomLevel = level;
+                txaIdToReconfig = txa;
+                TryConfigureTxAnalyzer(txa, _txaOutputRateHz, _txDispRxSampleRateHz, _txDispPixelWidth, level);
+            }
+        }
+
+        _log.LogInformation("wdsp.setZoom channel={Id} level={Level} txDisp={TxDisp}",
+            channelId, level, txaIdToReconfig?.ToString() ?? "off");
     }
 
     public void SetNoiseReduction(int channelId, NrConfig cfg)
@@ -652,6 +684,24 @@ public sealed class WdspDspEngine : IDspEngine
         }
     }
 
+    public bool TryGetTxDisplayPixels(DisplayPixout which, Span<float> dbOut)
+    {
+        if (_disposed != 0) return false;
+        int disp;
+        int expectedWidth;
+        lock (_txDispLock)
+        {
+            if (!_txDispAlive) return false;
+            if (_txaChannelId is not int txa) return false;
+            disp = txa;
+            expectedWidth = _txDispPixelWidth;
+            if (dbOut.Length != expectedWidth)
+                throw new ArgumentException($"expected span of {expectedWidth}", nameof(dbOut));
+            NativeMethods.GetPixels(disp, (int)which, ref MemoryMarshal.GetReference(dbOut), out int flag);
+            return flag == 1;
+        }
+    }
+
     public int OpenTxChannel(int outputRateHz = 48_000)
     {
         ObjectDisposedException.ThrowIf(_disposed != 0, this);
@@ -805,10 +855,70 @@ public sealed class WdspDspEngine : IDspEngine
             }
 
             _txaChannelId = id;
+
+            // TX panadapter analyzer — issue #81. Match the first RXA's pixel
+            // width and zoom so the TX trace renders into the same widget
+            // without a span change on MOX. If no RXA exists yet (shouldn't
+            // happen in practice — RadioService opens RX before TX), skip
+            // analyzer creation and leave _txDispAlive false so the server
+            // falls back to the RX pixels during MOX.
+            int rxPixelWidth = 0;
+            int rxSampleRateHz = 0;
+            int rxZoom = 1;
+            foreach (var st in _channels.Values)
+            {
+                rxPixelWidth = st.PixelWidth;
+                rxSampleRateHz = st.SampleRateHz;
+                rxZoom = Math.Max(1, st.ZoomLevel);
+                break;
+            }
+            if (rxPixelWidth > 0)
+            {
+                // Analyzer disp index reuses the TXA channel id — WDSP keeps
+                // channels and analyzers in separate arrays so the collision
+                // between RXA's channel=0 / disp=0 and TXA's channel=id /
+                // disp=id is purely in our bookkeeping, not in the library.
+                NativeMethods.XCreateAnalyzer(id, out int txRc, MaxFftSize, 1, 1, null);
+                if (txRc == 0)
+                {
+                    bool configured;
+                    lock (_txDispLock)
+                    {
+                        _txDispPixelWidth = rxPixelWidth;
+                        _txDispZoomLevel = rxZoom;
+                        _txDispRxSampleRateHz = rxSampleRateHz;
+                        configured = TryConfigureTxAnalyzer(id, _txaOutputRateHz, rxSampleRateHz, rxPixelWidth, rxZoom);
+                        if (configured)
+                        {
+                            ConfigureDisplayAveraging(id);
+                            _txDispAlive = true;
+                        }
+                    }
+                    if (!configured)
+                    {
+                        // Rate relationship doesn't support bin-clip (e.g. TX narrower
+                        // than RX, or non-integer ratio). Destroy the unused analyzer
+                        // slot and leave _txDispAlive false so the panadapter falls
+                        // back to the RX analyzer on MOX.
+                        NativeMethods.DestroyAnalyzer(id);
+                        _log.LogWarning(
+                            "wdsp.openTxChannel tx-analyzer skipped — rx={RxRate} tx={TxRate} not an integer multiple; panadapter will fall back to RX trace",
+                            rxSampleRateHz, _txaOutputRateHz);
+                    }
+                }
+                else
+                {
+                    _log.LogWarning(
+                        "wdsp.openTxChannel tx-analyzer XCreateAnalyzer rc={Rc} — TX panadapter will fall back to RX trace",
+                        txRc);
+                }
+            }
+
             _log.LogInformation(
-                "wdsp.openTxChannel id={Id} rates={InRate}/{DspRate}/{OutRate} sizes={InSz}/{OutSz} cfir={Cfir} chain=[alc=1 lvlr=1 lvlrMax={LvlrMax:F1}dB cpdr=0 cfc=0 phrot=0 osctrl=0 eq=0 amsq=0] bp=150..2850 panelGain=1.0",
+                "wdsp.openTxChannel id={Id} rates={InRate}/{DspRate}/{OutRate} sizes={InSz}/{OutSz} cfir={Cfir} chain=[alc=1 lvlr=1 lvlrMax={LvlrMax:F1}dB cpdr=0 cfc=0 phrot=0 osctrl=0 eq=0 amsq=0] bp=150..2850 panelGain=1.0 txDisp={TxDisp}(pix={Pix} rxRate={RxRate} txRate={TxRate} zoom={Zoom})",
                 id, _txaInputRateHz, _txaDspRateHz, _txaOutputRateHz,
-                _txaInSize, _txaOutSize, _txaCfirRun ? 1 : 0, DefaultLevelerMaxGainDb);
+                _txaInSize, _txaOutSize, _txaCfirRun ? 1 : 0, DefaultLevelerMaxGainDb,
+                _txDispAlive ? "on" : "off", _txDispPixelWidth, _txDispRxSampleRateHz, _txaOutputRateHz, _txDispZoomLevel);
             return id;
         }
     }
@@ -1012,6 +1122,28 @@ public sealed class WdspDspEngine : IDspEngine
             iqInterleaved[2 * i + 1] = qout[i];
         }
 
+        // Feed the TX analyzer with the post-CFIR IQ so TryGetTxDisplayPixels
+        // can serve the panadapter during MOX (issue #81). pihpsdr's
+        // transmitter.c:1639 feeds iq_output_buffer — same tap point. We feed
+        // unconditionally here: ProcessTxBlock only runs while TXA is keyed,
+        // and when it isn't called the analyzer's log-recursive average just
+        // coasts. No Q-negation — the sideband mirror fix is HL2-specific to
+        // the RX ADC path (see RunWorker:1223-1227); TXA modulator already
+        // places energy on the right side of the carrier.
+        if (_txDispAlive)
+        {
+            Span<double> txSpectrumIq = stackalloc double[2 * outSize];
+            for (int i = 0; i < outSize; i++)
+            {
+                txSpectrumIq[2 * i] = iout[i];
+                txSpectrumIq[2 * i + 1] = qout[i];
+            }
+            lock (_txDispLock)
+            {
+                NativeMethods.Spectrum0(1, txa, 0, 0, ref txSpectrumIq[0]);
+            }
+        }
+
         // Per-stage TXA peak + average meters. Peak surfaces clipping-induced
         // crackle that averages smooth away; the average is what the operator
         // reads to judge level. Both are published so the frontend can show
@@ -1106,6 +1238,14 @@ public sealed class WdspDspEngine : IDspEngine
         {
             if (_txaChannelId is int txa)
             {
+                lock (_txDispLock)
+                {
+                    if (_txDispAlive)
+                    {
+                        NativeMethods.DestroyAnalyzer(txa);
+                        _txDispAlive = false;
+                    }
+                }
                 NativeMethods.CloseChannel(txa);
                 _txaChannelId = null;
             }
@@ -1130,6 +1270,27 @@ public sealed class WdspDspEngine : IDspEngine
             NativeMethods.SetDisplayAvBackmult(disp, pixout, backmult);
             NativeMethods.SetDisplayNumAverage(disp, pixout, 2);
         }
+    }
+
+    // TX analyzer wrapper: reuses ConfigureAnalyzer's bin-clip math after
+    // folding the TX/RX rate ratio into an "effective zoom" so the TX trace
+    // displays the same frequency span as RX. Example: P2 TX at 192 kHz vs
+    // RX at 48 kHz is a 4× rate ratio; at RX zoom=1 the effective TX zoom is
+    // 4, which clips 3/8 × fft_size bins off each side — i.e. keeps the
+    // centre 25% of the full-span FFT, which is exactly pihpsdr's fixed
+    // 24 kHz-wide TX panadapter (transmitter.c:2323-2324). On P1 the ratio
+    // is 1 and this degenerates back to RX-zoom behaviour.
+    // Returns true when the TX/RX rate relationship supports the bin-clip span
+    // match (txRate is a positive integer multiple of rxRate). Callers that get
+    // false skip TX analyzer creation and fall back to the RX analyzer during
+    // MOX — matches the pre-issue-#81 behaviour for that codepath.
+    private static bool TryConfigureTxAnalyzer(int disp, int txSampleRateHz, int rxSampleRateHz, int pixelWidth, int rxZoomLevel)
+    {
+        if (rxSampleRateHz <= 0 || txSampleRateHz < rxSampleRateHz || txSampleRateHz % rxSampleRateHz != 0)
+            return false;
+        int effectiveZoom = rxZoomLevel * (txSampleRateHz / rxSampleRateHz);
+        ConfigureAnalyzer(disp, txSampleRateHz, pixelWidth, effectiveZoom);
+        return true;
     }
 
     private static void ConfigureAnalyzer(int disp, int sampleRateHz, int pixelWidth, int zoomLevel)

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -170,6 +170,16 @@ public sealed class WdspDspEngine : IDspEngine
     // Tracked so SetTxMode can re-sign bandpass bounds (LSB family wants negative,
     // USB family positive) the same way RXA does through ApplyBandpassForMode.
     private RxaMode _txCurrentMode = RxaMode.USB;
+    // TwoTone arm-state cache. SetTwoTone records the operator-supplied freqs
+    // (positive Hz) here when arming; SetTxMode reads them back so a mid-test
+    // mode change re-asserts the sideband-correct signed freqs onto PostGen.
+    // gen.c xgen mode-1 emits e^(-jωt) — positive freq always lands LSB-side
+    // of carrier, so USB-family modes need a sign flip to put the tones inside
+    // the displayed bandpass. See gen.c:241-242 and Thetis setup.cs:11097-11101
+    // (chkInvertTones, gated behind a checkbox there; we auto-sign per mode).
+    private double _twoToneF1Hz;
+    private double _twoToneF2Hz;
+    private bool _twoToneArmed;
     // Latest per-stage TX peak meters, published atomically at the end of each
     // ProcessTxBlock. The reader (TxMetersService, 10 Hz during MOX) sees a
     // consistent snapshot without blocking the DSP thread. null until first TX
@@ -1132,6 +1142,24 @@ public sealed class WdspDspEngine : IDspEngine
             // TXA bandpass is now operator-controlled — DspPipelineService
             // asserts SetTxFilter after SetTxMode using the per-mode-family
             // memory in RadioService. No auto-apply here.
+            //
+            // TwoTone is sideband-sensitive (gen.c xgen mode-1 emits e^(-jωt)
+            // which always lands LSB-side of carrier). If a TwoTone test is
+            // mid-flight when the operator changes mode, re-assert PostGen
+            // freqs with the new sign so the tones stay inside the displayed
+            // bandpass. Mag and run flag stay as last set.
+            if (_twoToneArmed)
+            {
+                bool usbFamily = mapped == RxaMode.USB
+                              || mapped == RxaMode.CWU
+                              || mapped == RxaMode.DIGU;
+                double signedF1 = usbFamily ? -_twoToneF1Hz : _twoToneF1Hz;
+                double signedF2 = usbFamily ? -_twoToneF2Hz : _twoToneF2Hz;
+                NativeMethods.SetTXAPostGenTTFreq(txa, signedF1, signedF2);
+                _log.LogInformation(
+                    "wdsp.setTxMode twoTone re-signed f1={F1} f2={F2} signedF1={SF1} signedF2={SF2} mode={Mode}",
+                    _twoToneF1Hz, _twoToneF2Hz, signedF1, signedF2, mapped);
+            }
         }
         _log.LogInformation("wdsp.setTxMode mode={Mode}", mapped);
     }
@@ -1162,25 +1190,43 @@ public sealed class WdspDspEngine : IDspEngine
             if (_txaChannelId is not int txa) return;
             if (on)
             {
+                // gen.c xgen mode-1 emits e^(-jωt): positive freq lands on
+                // the LSB-side of carrier in any TX mode. USB-family modes
+                // need a sign flip so the tones appear above carrier inside
+                // the displayed bandpass. Cache the operator-supplied
+                // (unsigned) freqs so SetTxMode can re-assert with the
+                // correct sign on a mid-test mode change.
+                bool usbFamily = _txCurrentMode == RxaMode.USB
+                              || _txCurrentMode == RxaMode.CWU
+                              || _txCurrentMode == RxaMode.DIGU;
+                double signedF1 = usbFamily ? -freq1 : freq1;
+                double signedF2 = usbFamily ? -freq2 : freq2;
+                _twoToneF1Hz = freq1;
+                _twoToneF2Hz = freq2;
+                _twoToneArmed = true;
                 // PostGen mode=1 = two-tone summed (gen.c:221-241).
                 NativeMethods.SetTXAPostGenMode(txa, 1);
-                NativeMethods.SetTXAPostGenTTFreq(txa, freq1, freq2);
+                NativeMethods.SetTXAPostGenTTFreq(txa, signedF1, signedF2);
                 NativeMethods.SetTXAPostGenTTMag(txa, mag, mag);
                 NativeMethods.SetTXAPostGenRun(txa, 1);
                 // Same Leveler-off pattern SetTxTune uses; the test signal
                 // doesn't need voice-energy AGC and Leveler can pump on the
                 // discrete tones.
                 NativeMethods.SetTXALevelerSt(txa, 0);
+                _log.LogInformation(
+                    "wdsp.setTwoTone on=true f1={F1} f2={F2} signedF1={SF1} signedF2={SF2} mag={Mag:F3} mode={Mode}",
+                    freq1, freq2, signedF1, signedF2, mag, _txCurrentMode);
             }
             else
             {
+                _twoToneArmed = false;
                 NativeMethods.SetTXAPostGenRun(txa, 0);
                 NativeMethods.SetTXALevelerSt(txa, 1);
+                _log.LogInformation(
+                    "wdsp.setTwoTone on=false f1={F1} f2={F2} mag={Mag:F3}",
+                    freq1, freq2, mag);
             }
         }
-        _log.LogInformation(
-            "wdsp.setTwoTone on={On} f1={F1} f2={F2} mag={Mag:F3}",
-            on, freq1, freq2, mag);
     }
 
     public void SetPsHwPeak(double hwPeak)

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -1127,16 +1127,19 @@ public sealed class WdspDspEngine : IDspEngine
         // transmitter.c:1639 feeds iq_output_buffer — same tap point. We feed
         // unconditionally here: ProcessTxBlock only runs while TXA is keyed,
         // and when it isn't called the analyzer's log-recursive average just
-        // coasts. No Q-negation — the sideband mirror fix is HL2-specific to
-        // the RX ADC path (see RunWorker:1223-1227); TXA modulator already
-        // places energy on the right side of the carrier.
+        // coasts. Q is negated (complex conjugate) to match the RX analyzer's
+        // treatment in RunWorker: WDSP's analyzer pipeline renders both
+        // sidebands flipped about the carrier for our IQ convention, so the
+        // same empirical fix is needed on TX. Observed on a G2 MkII: without
+        // the negation, an LSB carrier/modulation rendered on the USB side
+        // and vice-versa even though on-air RF and audio were correct.
         if (_txDispAlive)
         {
             Span<double> txSpectrumIq = stackalloc double[2 * outSize];
             for (int i = 0; i < outSize; i++)
             {
                 txSpectrumIq[2 * i] = iout[i];
-                txSpectrumIq[2 * i + 1] = qout[i];
+                txSpectrumIq[2 * i + 1] = -qout[i];
             }
             lock (_txDispLock)
             {

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -211,6 +211,10 @@ public sealed class WdspDspEngine : IDspEngine
     private const int PsFeedbackBlockSize = 1024;
     private readonly int[] _psInfoBuf = new int[16];
     private double _psMaxTxEnvelope;
+    // Bring-up diagnostic — emit info[] every Nth GetPsStageMeters tick so the
+    // calcc state machine is visible in the server log without flooding.
+    // Drop alongside the wdsp.psSeed log once PS is confirmed stable.
+    private int _psInfoLogCounter;
 
     public WdspDspEngine(ILogger<WdspDspEngine>? logger = null)
     {
@@ -906,6 +910,10 @@ public sealed class WdspDspEngine : IDspEngine
             NativeMethods.SetPSHWPeak(id, _psHwPeak);
             NativeMethods.SetPSControl(id, 1, 0, 0, 0);   // RESET state
             // SetPSRunCal stays 0 until the operator arms PS.
+            // Bring-up diagnostic — drop once PS is confirmed stable on rack.
+            _log.LogInformation(
+                "wdsp.psSeed pinMode=1 mapMode=1 ptol={Ptol} hwPeak={Peak:F4} feedbackRate=192000",
+                _psPtol ? 0.4 : 0.8, _psHwPeak);
 
             // TX panadapter analyzer — issue #81. Match the first RXA's pixel
             // width and zoom so the TX trace renders into the same widget
@@ -1386,6 +1394,20 @@ public sealed class WdspDspEngine : IDspEngine
         float depthDb = correcting
             ? (float)(20.0 * Math.Log10(Math.Max(feedback, 1e-3) / 256.0))
             : 0f;
+
+        // Bring-up diagnostic — log info[0..7] + correcting/state every Nth
+        // call so the calcc state machine progression is visible during a
+        // rack run. With TxMetersService running at ~10 Hz, N=50 ≈ 5 s.
+        // Drop once PS is confirmed working.
+        if (++_psInfoLogCounter % 50 == 0)
+        {
+            _log.LogDebug(
+                "wdsp.psInfo binfo=[{B0},{B1},{B2},{B3},{B4},{B5},{B6},{B7}] correcting={C} state={S}",
+                _psInfoBuf[0], _psInfoBuf[1], _psInfoBuf[2], _psInfoBuf[3],
+                _psInfoBuf[4], _psInfoBuf[5], _psInfoBuf[6], _psInfoBuf[7],
+                _psInfoBuf[14], _psInfoBuf[15]);
+        }
+
         return new PsStageMeters(
             FeedbackLevel: feedback,
             CalState: calState,

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -279,7 +279,7 @@ public sealed class WdspDspEngine : IDspEngine
         NativeMethods.XCreateAnalyzer(id, out int rc, MaxFftSize, 1, 1, null);
         if (rc != 0) throw new InvalidOperationException($"XCreateAnalyzer failed rc={rc}");
 
-        ConfigureAnalyzer(id, sampleRateHz, pixelWidth, zoomLevel: 1);
+        ConfigureAnalyzer(id, sampleRateHz, InSize, pixelWidth, zoomLevel: 1);
         ConfigureDisplayAveraging(id);
 
         var state = new ChannelState
@@ -426,7 +426,7 @@ public sealed class WdspDspEngine : IDspEngine
         {
             if (state.ZoomLevel == level) return;
             state.ZoomLevel = level;
-            ConfigureAnalyzer(channelId, state.SampleRateHz, state.PixelWidth, level);
+            ConfigureAnalyzer(channelId, state.SampleRateHz, InSize, state.PixelWidth, level);
         }
 
         // Mirror zoom onto the TX analyzer so the TX panadapter span stays
@@ -439,7 +439,7 @@ public sealed class WdspDspEngine : IDspEngine
             {
                 _txDispZoomLevel = level;
                 txaIdToReconfig = txa;
-                TryConfigureTxAnalyzer(txa, _txaOutputRateHz, _txDispRxSampleRateHz, _txDispPixelWidth, level);
+                TryConfigureTxAnalyzer(txa, _txaOutputRateHz, _txaOutSize, _txDispRxSampleRateHz, _txDispPixelWidth, level);
             }
         }
 
@@ -887,7 +887,7 @@ public sealed class WdspDspEngine : IDspEngine
                         _txDispPixelWidth = rxPixelWidth;
                         _txDispZoomLevel = rxZoom;
                         _txDispRxSampleRateHz = rxSampleRateHz;
-                        configured = TryConfigureTxAnalyzer(id, _txaOutputRateHz, rxSampleRateHz, rxPixelWidth, rxZoom);
+                        configured = TryConfigureTxAnalyzer(id, _txaOutputRateHz, _txaOutSize, rxSampleRateHz, rxPixelWidth, rxZoom);
                         if (configured)
                         {
                             ConfigureDisplayAveraging(id);
@@ -1284,16 +1284,20 @@ public sealed class WdspDspEngine : IDspEngine
     // match (txRate is a positive integer multiple of rxRate). Callers that get
     // false skip TX analyzer creation and fall back to the RX analyzer during
     // MOX — matches the pre-issue-#81 behaviour for that codepath.
-    private static bool TryConfigureTxAnalyzer(int disp, int txSampleRateHz, int rxSampleRateHz, int pixelWidth, int rxZoomLevel)
+    private static bool TryConfigureTxAnalyzer(int disp, int txSampleRateHz, int txBlockSize, int rxSampleRateHz, int pixelWidth, int rxZoomLevel)
     {
         if (rxSampleRateHz <= 0 || txSampleRateHz < rxSampleRateHz || txSampleRateHz % rxSampleRateHz != 0)
             return false;
         int effectiveZoom = rxZoomLevel * (txSampleRateHz / rxSampleRateHz);
-        ConfigureAnalyzer(disp, txSampleRateHz, pixelWidth, effectiveZoom);
+        // bf_sz must match the per-Spectrum0 block size fed from ProcessTxBlock
+        // (_txaOutSize: 1024 on P1, 2048 on P2). Hardcoding InSize left WDSP
+        // reading only the first 1024 of each 2048-sample P2 block, aliasing at
+        // (192000/1024) ≈ 188 Hz and producing a spur comb on the TUN carrier.
+        ConfigureAnalyzer(disp, txSampleRateHz, txBlockSize, pixelWidth, effectiveZoom);
         return true;
     }
 
-    private static void ConfigureAnalyzer(int disp, int sampleRateHz, int pixelWidth, int zoomLevel)
+    private static void ConfigureAnalyzer(int disp, int sampleRateHz, int bfSize, int pixelWidth, int zoomLevel)
     {
         int overlap = (int)Math.Max(0, Math.Ceiling(AnalyzerFftSize - (double)sampleRateHz / AnalyzerFps));
         int maxW = AnalyzerFftSize + (int)Math.Min(
@@ -1321,7 +1325,7 @@ public sealed class WdspDspEngine : IDspEngine
             typ: 1,
             flp: ref flp,
             sz: AnalyzerFftSize,
-            bf_sz: InSize,
+            bf_sz: bfSize,
             win_type: AnalyzerWindow,
             pi_alpha: AnalyzerKaiserPi,
             ovrlp: overlap,

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -194,6 +194,24 @@ public sealed class WdspDspEngine : IDspEngine
     private int _txDispRxSampleRateHz;
     private bool _txDispAlive;
 
+    // PureSignal state. _psLock serializes the WDSP PS setters (which mutate
+    // shared state inside calcc.c) and FeedPsFeedbackBlock. _psInfoBuf is
+    // pinned once and reused on every GetPSInfo call.
+    private readonly object _psLock = new();
+    private bool _psEnabled;
+    private bool _psAuto = true;
+    private bool _psSingle;
+    private double _psHwPeak = 0.4072;   // P1 default; RadioService overrides at connect
+    private int _psInts = 16;
+    private int _psSpi = 256;
+    private double _psMoxDelaySec = 0.2;
+    private double _psLoopDelaySec = 0.0;
+    private double _psAmpDelayNs = 150.0;
+    private bool _psPtol;                // false = strict 0.4 ; true = relax 0.8
+    private const int PsFeedbackBlockSize = 1024;
+    private readonly int[] _psInfoBuf = new int[16];
+    private double _psMaxTxEnvelope;
+
     public WdspDspEngine(ILogger<WdspDspEngine>? logger = null)
     {
         _log = logger ?? NullLogger<WdspDspEngine>.Instance;
@@ -856,6 +874,33 @@ public sealed class WdspDspEngine : IDspEngine
 
             _txaChannelId = id;
 
+            // PureSignal seed. The TXA channel already owns `calcc.p` and
+            // `iqc.p0/p1` as a side effect of create_txa() (TXA.c:405,424);
+            // these setters tune the WDSP state machine to safe defaults so
+            // arming PS later just needs SetPSRunCal(1) + SetPSControl mode-on.
+            //
+            // HW-peak is *not* set here — RadioService.SetPsHwPeak runs after
+            // discovery so the right value (P1=0.4072 / G2=0.6121 / ANAN-7000
+            // =0.2899) is applied per actual connected radio. The 0.4072 in
+            // `_psHwPeak` is just a neutral default.
+            //
+            // See `docs/lessons/wdsp-init-gotchas.md`: setters before state-
+            // flip is the load-bearing pattern. PS setters are independent of
+            // `SetChannelState`, so they're safe to run unconditionally at
+            // TXA open time.
+            NativeMethods.SetPSFeedbackRate(id, 192_000);
+            NativeMethods.SetPSPtol(id, _psPtol ? 0.8 : 0.4);
+            NativeMethods.SetPSPinMode(id, 0);
+            NativeMethods.SetPSMapMode(id, 0);
+            NativeMethods.SetPSStabilize(id, 0);
+            NativeMethods.SetPSIntsAndSpi(id, _psInts, _psSpi);
+            NativeMethods.SetPSMoxDelay(id, _psMoxDelaySec);
+            NativeMethods.SetPSLoopDelay(id, _psLoopDelaySec);
+            _ = NativeMethods.SetPSTXDelay(id, _psAmpDelayNs * 1e-9);
+            NativeMethods.SetPSHWPeak(id, _psHwPeak);
+            NativeMethods.SetPSControl(id, 1, 0, 0, 0);   // RESET state
+            // SetPSRunCal stays 0 until the operator arms PS.
+
             // TX panadapter analyzer — issue #81. Match the first RXA's pixel
             // width and zoom so the TX trace renders into the same widget
             // without a span change on MOX. If no RXA exists yet (shouldn't
@@ -954,9 +999,17 @@ public sealed class WdspDspEngine : IDspEngine
             txaPrior = NativeMethods.SetChannelState(txaId, 1, 0);
             // No priming: Thetis (console.cs:31375) does not prime — bfo=1
             // semantics already make the first fexchange wait for real output.
+            // Tell PureSignal calcc that MOX is now true so the LCOLLECT phase
+            // can advance once feedback IQ starts flowing. Safe to call even
+            // when PS isn't armed — it just toggles a flag inside calcc.
+            NativeMethods.SetPSMox(txaId, 1);
         }
         else
         {
+            // Drop the PS MOX flag *before* the TXA state-flip so the iqc
+            // stage sees "no longer transmitting" while the chain is still
+            // alive — same ordering pihpsdr uses (transmitter.c:2422-2444).
+            NativeMethods.SetPSMox(txaId, 0);
             txaPrior = NativeMethods.SetChannelState(txaId, 0, 1);
             rxaPrior = NativeMethods.SetChannelState(rxaId, 1, 0);
             // Unkeying: clear the stage-meter snapshot so UI doesn't latch the
@@ -1078,6 +1131,299 @@ public sealed class WdspDspEngine : IDspEngine
             NativeMethods.SetTXABandpassFreqs(txa, lowHz, highHz);
         }
         _log.LogInformation("wdsp.setTxFilter low={Low} high={High}", lowHz, highHz);
+    }
+
+    public void SetTwoTone(bool on, double freq1, double freq2, double mag)
+    {
+        if (_disposed != 0) return;
+        // Clamp to safe ranges. Audio passband 50..5000; mag 0..1 linear.
+        if (freq1 < 50.0) freq1 = 50.0;
+        if (freq1 > 5000.0) freq1 = 5000.0;
+        if (freq2 < 50.0) freq2 = 50.0;
+        if (freq2 > 5000.0) freq2 = 5000.0;
+        if (mag < 0.0) mag = 0.0;
+        if (mag > 1.0) mag = 1.0;
+        lock (_txaLock)
+        {
+            if (_txaChannelId is not int txa) return;
+            if (on)
+            {
+                // PostGen mode=1 = two-tone summed (gen.c:221-241).
+                NativeMethods.SetTXAPostGenMode(txa, 1);
+                NativeMethods.SetTXAPostGenTTFreq(txa, freq1, freq2);
+                NativeMethods.SetTXAPostGenTTMag(txa, mag, mag);
+                NativeMethods.SetTXAPostGenRun(txa, 1);
+                // Same Leveler-off pattern SetTxTune uses; the test signal
+                // doesn't need voice-energy AGC and Leveler can pump on the
+                // discrete tones.
+                NativeMethods.SetTXALevelerSt(txa, 0);
+            }
+            else
+            {
+                NativeMethods.SetTXAPostGenRun(txa, 0);
+                NativeMethods.SetTXALevelerSt(txa, 1);
+            }
+        }
+        _log.LogInformation(
+            "wdsp.setTwoTone on={On} f1={F1} f2={F2} mag={Mag:F3}",
+            on, freq1, freq2, mag);
+    }
+
+    public void SetPsHwPeak(double hwPeak)
+    {
+        if (_disposed != 0) return;
+        if (hwPeak <= 0.0 || hwPeak > 2.0) return;   // bogus value, ignore
+        lock (_psLock)
+        {
+            _psHwPeak = hwPeak;
+            int? txa;
+            lock (_txaLock) txa = _txaChannelId;
+            if (txa is int id)
+            {
+                NativeMethods.SetPSHWPeak(id, hwPeak);
+            }
+        }
+        _log.LogInformation("wdsp.setPsHwPeak peak={Peak:F4}", hwPeak);
+    }
+
+    public void SetPsControl(bool autoCal, bool singleCal)
+    {
+        if (_disposed != 0) return;
+        lock (_psLock)
+        {
+            _psAuto = autoCal;
+            _psSingle = singleCal;
+            int? txa;
+            lock (_txaLock) txa = _txaChannelId;
+            if (txa is not int id) return;
+            // (reset, mancal, automode, turnon) — see Thetis PSForm.cs.
+            // Single takes precedence over auto when both true.
+            int reset = 0;
+            int mancal = singleCal ? 1 : 0;
+            int automode = (autoCal && !singleCal) ? 1 : 0;
+            int turnon = 0;
+            if (!autoCal && !singleCal)
+            {
+                // Both off → reset / idle.
+                reset = 1;
+            }
+            NativeMethods.SetPSControl(id, reset, mancal, automode, turnon);
+        }
+        _log.LogInformation("wdsp.setPsControl auto={Auto} single={Single}", autoCal, singleCal);
+    }
+
+    public void SetPsAdvanced(bool ptol, double moxDelaySec, double loopDelaySec,
+                              double ampDelayNs, double hwPeak, int ints, int spi)
+    {
+        if (_disposed != 0) return;
+        lock (_psLock)
+        {
+            int? txa;
+            lock (_txaLock) txa = _txaChannelId;
+            int id = txa ?? -1;
+
+            if (ptol != _psPtol)
+            {
+                _psPtol = ptol;
+                if (id >= 0) NativeMethods.SetPSPtol(id, ptol ? 0.8 : 0.4);
+            }
+            if (moxDelaySec != _psMoxDelaySec)
+            {
+                _psMoxDelaySec = moxDelaySec;
+                if (id >= 0) NativeMethods.SetPSMoxDelay(id, moxDelaySec);
+            }
+            if (loopDelaySec != _psLoopDelaySec)
+            {
+                _psLoopDelaySec = loopDelaySec;
+                if (id >= 0) NativeMethods.SetPSLoopDelay(id, loopDelaySec);
+            }
+            if (ampDelayNs != _psAmpDelayNs)
+            {
+                _psAmpDelayNs = ampDelayNs;
+                if (id >= 0) _ = NativeMethods.SetPSTXDelay(id, ampDelayNs * 1e-9);
+            }
+            if (hwPeak > 0.0 && hwPeak <= 2.0 && hwPeak != _psHwPeak)
+            {
+                _psHwPeak = hwPeak;
+                if (id >= 0) NativeMethods.SetPSHWPeak(id, hwPeak);
+            }
+            // Only call SetPSIntsAndSpi when the values actually changed —
+            // it's a heavy restart inside calcc.c (allocates new buffers).
+            if (ints > 0 && spi > 0 && (ints != _psInts || spi != _psSpi))
+            {
+                _psInts = ints;
+                _psSpi = spi;
+                if (id >= 0) NativeMethods.SetPSIntsAndSpi(id, ints, spi);
+            }
+        }
+        _log.LogInformation(
+            "wdsp.setPsAdvanced ptol={Ptol} mox={Mox:F3}s loop={Loop:F3}s amp={Amp:F1}ns peak={Peak:F4} ints={Ints} spi={Spi}",
+            ptol, moxDelaySec, loopDelaySec, ampDelayNs, hwPeak, ints, spi);
+    }
+
+    public void SetPsEnabled(bool enabled)
+    {
+        if (_disposed != 0) return;
+        lock (_psLock)
+        {
+            int? txa;
+            lock (_txaLock) txa = _txaChannelId;
+            if (txa is not int id)
+            {
+                _psEnabled = false;
+                return;
+            }
+
+            if (enabled)
+            {
+                _psEnabled = true;
+                NativeMethods.SetPSRunCal(id, 1);
+                int mancal = _psSingle ? 1 : 0;
+                int automode = (_psAuto && !_psSingle) ? 1 : 0;
+                NativeMethods.SetPSControl(id, 0, mancal, automode, 0);
+            }
+            else
+            {
+                _psEnabled = false;
+                // pihpsdr shutdown gotcha (transmitter.c:2422-2444): when
+                // disabling PS while NOT keyed, push 7 zero-IQ blocks through
+                // psccF so the calcc state machine advances to LRESET cleanly
+                // and doesn't latch a stale curve in iqc on re-arm.
+                var zeros = new float[PsFeedbackBlockSize];
+                for (int i = 0; i < 7; i++)
+                {
+                    NativeMethods.psccF(id, PsFeedbackBlockSize, zeros, zeros, zeros, zeros, 0, 0);
+                }
+                NativeMethods.SetPSRunCal(id, 0);
+                NativeMethods.SetPSControl(id, 1, 0, 0, 0);
+            }
+        }
+        _log.LogInformation("wdsp.setPsEnabled enabled={Enabled}", enabled);
+    }
+
+    public void FeedPsFeedbackBlock(ReadOnlySpan<float> txI, ReadOnlySpan<float> txQ,
+                                    ReadOnlySpan<float> rxI, ReadOnlySpan<float> rxQ)
+    {
+        if (_disposed != 0) return;
+        if (txI.Length != PsFeedbackBlockSize ||
+            txQ.Length != PsFeedbackBlockSize ||
+            rxI.Length != PsFeedbackBlockSize ||
+            rxQ.Length != PsFeedbackBlockSize)
+        {
+            // Don't throw — log once and drop, so a transient sizing mismatch
+            // upstream (DDC re-config edge) doesn't crash the pipeline.
+            _log.LogWarning("wdsp.feedPsFeedback block sizes mismatch; expected {Expected}", PsFeedbackBlockSize);
+            return;
+        }
+        int? txa;
+        lock (_txaLock) txa = _txaChannelId;
+        if (txa is not int id) return;
+
+        // psccF takes float[] (not Span). Allocate fresh — caller may reuse
+        // its buffers immediately after this returns.
+        var bufTxI = txI.ToArray();
+        var bufTxQ = txQ.ToArray();
+        var bufRxI = rxI.ToArray();
+        var bufRxQ = rxQ.ToArray();
+
+        lock (_psLock)
+        {
+            // mox/solidmox args are ignored by psccF (calcc.c:846); SetPSMox
+            // is the source of truth and is driven from SetMox above.
+            NativeMethods.psccF(id, PsFeedbackBlockSize, bufTxI, bufTxQ, bufRxI, bufRxQ, 0, 0);
+        }
+    }
+
+    public PsStageMeters GetPsStageMeters()
+    {
+        if (_disposed != 0) return PsStageMeters.Silent;
+        int? txa;
+        lock (_txaLock) txa = _txaChannelId;
+        if (txa is not int id) return PsStageMeters.Silent;
+        // Skip the GetPSInfo P/Invoke when PS isn't armed — saves a per-tick
+        // jaunt into the native side and matches the wire-quiet contract for
+        // the PsMeters frame.
+        if (!_psEnabled) return PsStageMeters.Silent;
+
+        // Pin the int[16] buffer for the duration of the GetPSInfo call so
+        // WDSP can write into it. Re-using the same buffer between calls is
+        // fine because GetPSInfo writes synchronously.
+        int feedbackRaw;
+        byte calState;
+        bool correcting;
+        double maxTx;
+        lock (_psLock)
+        {
+            unsafe
+            {
+                fixed (int* p = _psInfoBuf)
+                {
+                    NativeMethods.GetPSInfo(id, (IntPtr)p);
+                }
+            }
+            feedbackRaw = _psInfoBuf[4];
+            correcting = _psInfoBuf[14] != 0;
+            calState = (byte)Math.Clamp(_psInfoBuf[15], 0, 255);
+            NativeMethods.GetPSMaxTX(id, out maxTx);
+            _psMaxTxEnvelope = maxTx;
+        }
+
+        // CorrectionDb: until we tap GetPSDisp's curve, derive a coarse
+        // proxy as 20*log10(feedbackLevel/256+eps). Replace with a real RMS
+        // when we wire GetPSDisp. Safe: callers treat <=−200 as "bypassed".
+        float feedback = feedbackRaw;
+        float depthDb = correcting
+            ? (float)(20.0 * Math.Log10(Math.Max(feedback, 1e-3) / 256.0))
+            : 0f;
+        return new PsStageMeters(
+            FeedbackLevel: feedback,
+            CalState: calState,
+            Correcting: correcting,
+            CorrectionDb: depthDb,
+            MaxTxEnvelope: (float)maxTx);
+    }
+
+    public void ResetPs()
+    {
+        if (_disposed != 0) return;
+        int? txa;
+        lock (_txaLock) txa = _txaChannelId;
+        if (txa is not int id) return;
+        lock (_psLock)
+        {
+            NativeMethods.SetPSControl(id, 1, 0, 0, 0);
+        }
+        _log.LogInformation("wdsp.resetPs");
+    }
+
+    public void SavePsCorrection(string path)
+    {
+        if (_disposed != 0) return;
+        if (string.IsNullOrWhiteSpace(path)) return;
+        int? txa;
+        lock (_txaLock) txa = _txaChannelId;
+        if (txa is not int id) return;
+        lock (_psLock)
+        {
+            NativeMethods.PSSaveCorr(id, path);
+        }
+        _log.LogInformation("wdsp.savePsCorrection path={Path}", path);
+    }
+
+    public void RestorePsCorrection(string path)
+    {
+        if (_disposed != 0) return;
+        if (string.IsNullOrWhiteSpace(path)) return;
+        int? txa;
+        lock (_txaLock) txa = _txaChannelId;
+        if (txa is not int id) return;
+        lock (_psLock)
+        {
+            NativeMethods.PSRestoreCorr(id, path);
+            // Restore-and-go pattern from Thetis PSForm.cs:982-1162: turnon=1
+            NativeMethods.SetPSControl(id, 0, 0, 0, 1);
+        }
+        _log.LogInformation("wdsp.restorePsCorrection path={Path}", path);
     }
 
     private DateTime _lastTxMeterLogUtc;

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -220,6 +220,15 @@ public sealed class WdspDspEngine : IDspEngine
     private bool _psPtol;                // false = strict 0.8 ; true = relax 0.4 (matches pihpsdr/Thetis: ptol ? 0.4 : 0.8)
     private const int PsFeedbackBlockSize = 1024;
     private readonly int[] _psInfoBuf = new int[16];
+    // Edge-triggered state-transition log target. 255 is an out-of-range
+    // sentinel so the first observed state always logs (LRESET..LTURNON
+    // = 0..9 per calcc.c:543-552). Updated under _psLock.
+    private byte _lastLoggedPsState = 255;
+    // Pscc-call counter — incremented in FeedPsFeedbackBlock after psccF.
+    // At 192 kHz / 1024-sample blocks we expect ~187 calls/sec while keyed.
+    // Periodic log at every 100th call lets the operator confirm feedback is
+    // arriving from the radio without flooding when PS is idle.
+    private long _psFeedCount;
     private double _psMaxTxEnvelope;
     // Bring-up diagnostic — emit info[] every Nth GetPsStageMeters tick so the
     // calcc state machine is visible in the server log without flooding.
@@ -1339,6 +1348,10 @@ public sealed class WdspDspEngine : IDspEngine
             if (enabled)
             {
                 _psEnabled = true;
+                // Reset diagnostic counters so the first state transition
+                // and the first 100 pscc blocks log on every fresh arm.
+                _lastLoggedPsState = 255;
+                Interlocked.Exchange(ref _psFeedCount, 0);
                 NativeMethods.SetPSRunCal(id, 1);
                 int mancal = _psSingle ? 1 : 0;
                 int automode = (_psAuto && !_psSingle) ? 1 : 0;
@@ -1396,6 +1409,14 @@ public sealed class WdspDspEngine : IDspEngine
             // mox/solidmox args are ignored by psccF (calcc.c:846); SetPSMox
             // is the source of truth and is driven from SetMox above.
             NativeMethods.psccF(id, PsFeedbackBlockSize, bufTxI, bufTxQ, bufRxI, bufRxQ, 0, 0);
+            long n = Interlocked.Increment(ref _psFeedCount);
+            if (n % 100 == 1)
+            {
+                // Confirms paired packets are reaching the engine. If this
+                // line never appears while keyed + PS armed, the wire path
+                // (Protocol2Client paired-packet decode) isn't running.
+                _log.LogInformation("wdsp.pscc fed {N} blocks", n);
+            }
         }
     }
 
@@ -1440,6 +1461,23 @@ public sealed class WdspDspEngine : IDspEngine
         float depthDb = correcting
             ? (float)(20.0 * Math.Log10(Math.Max(feedback, 1e-3) / 256.0))
             : 0f;
+
+        // Edge-triggered state-transition log. calcc.c:543-552 LRESET=0,
+        // LWAIT=1, LMOXDELAY=2, LSETUP=3, LCOLLECT=4, MOXCHECK=5, LCALC=6,
+        // LDELAY=7, LSTAYON=8, LTURNON=9. info[14]=1 means corrections live;
+        // info[6] bitmask flags scheck rejections (see r3-correct.md §B1).
+        // The 5-sec periodic log below is too sparse to catch the
+        // LCOLLECT↔LRESET bounce that happens every ~50 ms when scheck fails;
+        // edge-triggered surfaces every transition without flooding when
+        // PS is parked (e.g. stuck at LRESET while idle).
+        if (_lastLoggedPsState != calState)
+        {
+            _log.LogInformation(
+                "wdsp.psState {Prev}->{Cur} info4={Fb} info6=0x{Sc:X4} info13={Dog} info14={Cor}",
+                _lastLoggedPsState, calState,
+                _psInfoBuf[4], _psInfoBuf[6], _psInfoBuf[13], _psInfoBuf[14]);
+            _lastLoggedPsState = calState;
+        }
 
         // Bring-up diagnostic — log info[0..7] + correcting/state every Nth
         // call so the calcc state machine progression is visible during a

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -207,7 +207,7 @@ public sealed class WdspDspEngine : IDspEngine
     private double _psMoxDelaySec = 0.2;
     private double _psLoopDelaySec = 0.0;
     private double _psAmpDelayNs = 150.0;
-    private bool _psPtol;                // false = strict 0.4 ; true = relax 0.8
+    private bool _psPtol;                // false = strict 0.8 ; true = relax 0.4 (matches pihpsdr/Thetis: ptol ? 0.4 : 0.8)
     private const int PsFeedbackBlockSize = 1024;
     private readonly int[] _psInfoBuf = new int[16];
     private double _psMaxTxEnvelope;
@@ -889,9 +889,15 @@ public sealed class WdspDspEngine : IDspEngine
             // `SetChannelState`, so they're safe to run unconditionally at
             // TXA open time.
             NativeMethods.SetPSFeedbackRate(id, 192_000);
-            NativeMethods.SetPSPtol(id, _psPtol ? 0.8 : 0.4);
-            NativeMethods.SetPSPinMode(id, 0);
-            NativeMethods.SetPSMapMode(id, 0);
+            // pihpsdr semantic (transmitter.c:2517): ps_ptol=0 (default) → 0.8
+            // strict; ps_ptol=1 → 0.4 relaxed. Same convention in Thetis
+            // PSForm.designer.cs.
+            NativeMethods.SetPSPtol(id, _psPtol ? 0.4 : 0.8);
+            // pihpsdr/Thetis defaults: PinMode=1, MapMode=1 (transmitter.c:
+            // 1041-1042 ps_map=1 / ps_pin=1; PSForm.designer.cs chkPSPin /
+            // chkPSMap = Checked = true).
+            NativeMethods.SetPSPinMode(id, 1);
+            NativeMethods.SetPSMapMode(id, 1);
             NativeMethods.SetPSStabilize(id, 0);
             NativeMethods.SetPSIntsAndSpi(id, _psInts, _psSpi);
             NativeMethods.SetPSMoxDelay(id, _psMoxDelaySec);
@@ -1225,7 +1231,9 @@ public sealed class WdspDspEngine : IDspEngine
             if (ptol != _psPtol)
             {
                 _psPtol = ptol;
-                if (id >= 0) NativeMethods.SetPSPtol(id, ptol ? 0.8 : 0.4);
+                // ptol=true → relax 0.4; ptol=false → strict 0.8
+                // (pihpsdr transmitter.c:2517 / Thetis PSForm.cs).
+                if (id >= 0) NativeMethods.SetPSPtol(id, ptol ? 0.4 : 0.8);
             }
             if (moxDelaySec != _psMoxDelaySec)
             {
@@ -1280,7 +1288,10 @@ public sealed class WdspDspEngine : IDspEngine
                 NativeMethods.SetPSRunCal(id, 1);
                 int mancal = _psSingle ? 1 : 0;
                 int automode = (_psAuto && !_psSingle) ? 1 : 0;
-                NativeMethods.SetPSControl(id, 0, mancal, automode, 0);
+                // reset=1 forces a clean LRESET transit so a re-arm after a
+                // single-cal cycle (which can leave the SM in LSTAYON) starts
+                // a fresh fit (Thetis PSForm.cs:645,661).
+                NativeMethods.SetPSControl(id, 1, mancal, automode, 0);
             }
             else
             {

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -593,34 +593,59 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
 
     private void SendCmdTx()
     {
-        var p = ComposeCmdTxBuffer(_seqCmdTx++, (ushort)_sampleRateKhz, _txStepAttnDb);
+        var p = ComposeCmdTxBuffer(_seqCmdTx++, (ushort)_sampleRateKhz, _txStepAttnDb, _paEnabled, _psFeedbackEnabled);
         _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1026));
     }
 
     // Test-seamed Compose for the CmdTx (TxSpecific) packet. Layout per
-    // Thetis network.c (function specific_buffer / fillTxSpecificBuffer
-    // around line 1235) and pihpsdr new_protocol.c new_protocol_tx_specific:
+    // pihpsdr new_protocol.c new_protocol_tx_specific (1502-1594) and
+    // saturnmain.c::saturn_handle_duc_specific:
     //   bytes 0..3   : sequence (BE)
     //   byte  4      : num_dac (1 on G2)
-    //   bytes 14..15 : DAC sample rate kHz (BE)
-    //   byte  57     : ADC2 TX step attenuator (0..31 dB)
-    //   byte  58     : ADC1 TX step attenuator
-    //   byte  59     : ADC0 TX step attenuator
-    // Other bytes are zero on G2 — pihpsdr fills mic-source flags but the
-    // G2 ignores them.
-    internal static byte[] ComposeCmdTxBuffer(uint seq, ushort sampleRateKhz, byte txStepAttnDb)
+    //   bytes 14..15 : DAC sample rate kHz (BE) — Zeus-only; Saturn ignores
+    //   byte  57     : reserved on Saturn (FPGA does not read)
+    //   byte  58     : ADC1 TX step attenuator (TX-DAC reference loopback)
+    //   byte  59     : ADC0 TX step attenuator (PA-coupler feedback)
+    //
+    // pihpsdr's PA-protection / PS asymmetry (new_protocol.c:1540-1547):
+    //   if (xmit && pa_enabled) { p[58]=31; p[59]=31; }   // protect both ADCs
+    //   if (puresignal)         { p[59]=tx->attenuation; } // ONLY byte 59
+    //
+    // Byte 58 is NEVER overridden by PS — the TX-DAC reference ADC needs
+    // its own protection independent of where AutoAttenuate parks the
+    // PA-feedback ADC. If we let PS write to byte 58 too, the first
+    // attenuator step drops the loopback reference in lockstep with the
+    // feedback, leaving the gain ratio uncorrected and starving calcc.
+    //
+    // When PS is OFF we keep the historical Zeus shape (value across
+    // 57/58/59) — operator's normal voice TX has been validated working
+    // with that wire form on G2 MkII, so we don't ship a wire change
+    // beyond the PS-armed window in this patch.
+    internal static byte[] ComposeCmdTxBuffer(uint seq, ushort sampleRateKhz, byte txStepAttnDb, bool paEnabled, bool psEnabled)
     {
         var p = new byte[60];
         WriteBeU32(p, 0, seq);
         p[4] = 1;                 // num_dac
         WriteBeU16(p, 14, sampleRateKhz);
-        // TX step attenuator — Thetis network.c:1238-1242 writes the same
-        // value into bytes 57 (ADC2), 58 (ADC1), 59 (ADC0). 0..31 dB.
-        // Drives the PS auto-attenuate loop's recovery path when feedback
-        // level lands outside the 128..181 ideal window.
-        p[57] = txStepAttnDb;
-        p[58] = txStepAttnDb;
-        p[59] = txStepAttnDb;
+
+        if (psEnabled)
+        {
+            // PS-armed canonical pihpsdr shape: byte 58 holds PA-protection
+            // for the TX-DAC reference; byte 59 takes the dynamic step-att
+            // so calcc can read the post-PA envelope.
+            p[57] = 0;
+            p[58] = paEnabled ? (byte)31 : (byte)0;
+            p[59] = txStepAttnDb;
+        }
+        else
+        {
+            // Historical Zeus shape — preserved so normal voice TX wire
+            // form is unchanged. Revisit when bringing the full pihpsdr
+            // PA-protection invariant to non-PS TX.
+            p[57] = txStepAttnDb;
+            p[58] = txStepAttnDb;
+            p[59] = txStepAttnDb;
+        }
         return p;
     }
 

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -517,43 +517,49 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1024));
     }
 
-    private void SendCmdRx()
+    // Static byte composer — pure function over (seq, numAdc, sampleRateKhz,
+    // psEnabled). Exposed internal so wire-format tests don't need a live
+    // socket. SendCmdRx constructs the same bytes and pushes to UDP.
+    internal static byte[] ComposeCmdRxBuffer(uint seq, byte numAdc, ushort sampleRateKhz, bool psEnabled)
     {
         var p = new byte[BufLen];
-        WriteBeU32(p, 0, _seqCmdRx++);
-        // Mirrors pihpsdr new_protocol_receive_specific for the MkII:
-        //   n_adc = 2 (G2 has two physical ADCs), DDC2 enabled by bit 2 in
-        //   the enable mask, and the DDC config block sits at 17 + 2*6 = 29.
-        //   DDC0/1 stay disabled by default — those slots are reserved by
-        //   the radio for the PureSignal / Diversity hardware pair.
-        p[4] = _numAdc;
+        WriteBeU32(p, 0, seq);
+        p[4] = numAdc;
         p[5] = 0;
         p[6] = 0;
         byte ddcEnable = (byte)(1 << G2RxDdc);
 
-        if (_psFeedbackEnabled)
+        if (psEnabled)
         {
-            // pihpsdr new_protocol.c:1611-1630 — when PS is armed, also turn
-            // on DDC0 and lock DDC1 to DDC0 (byte 1363 = 0x02). Both DDCs run
-            // at 192 kHz / 24-bit; DDC0 = TX-mod-IQ tap, DDC1 = feedback IQ.
             ddcEnable |= 0x01;
-            // DDC0 config: <- ADC0, 192 kHz, 24-bit
             p[17] = 0x00;
             WriteBeU16(p, 18, 192);
             p[22] = 24;
-            // DDC1 config: <- ADC <n_adc> (mirrors the PS pair), 192k, 24-bit
-            p[23] = _numAdc;
+            p[23] = numAdc;
             WriteBeU16(p, 24, 192);
             p[28] = 24;
-            // Sync DDC1→DDC0 (paired packet shape on UDP 1035).
             p[1363] = 0x02;
         }
 
         p[7] = ddcEnable;
         int off = 17 + G2RxDdc * 6;
-        p[off + 0] = 0x00;            // DDC2 <- ADC0
-        WriteBeU16(p, off + 1, _sampleRateKhz);
-        p[off + 5] = 24;              // bit depth
+        p[off + 0] = 0x00;
+        WriteBeU16(p, off + 1, sampleRateKhz);
+        p[off + 5] = 24;
+        return p;
+    }
+
+    private void SendCmdRx()
+    {
+        // Mirrors pihpsdr new_protocol_receive_specific for the MkII:
+        //   n_adc = G2 has two physical ADCs; DDC2 enabled by bit 2 in the
+        //   enable mask; the DDC config block sits at 17 + 2*6 = 29. DDC0/1
+        //   stay disabled by default — those slots are reserved by the radio
+        //   for the PureSignal / Diversity hardware pair. When PS is armed,
+        //   ComposeCmdRxBuffer also enables DDC0, configures DDC0/1 at
+        //   192 kHz / 24-bit, and sets byte 1363 = 0x02 to sync DDC1→DDC0
+        //   (pihpsdr new_protocol.c:1611-1630).
+        var p = ComposeCmdRxBuffer(_seqCmdRx++, _numAdc, (ushort)_sampleRateKhz, _psFeedbackEnabled);
         _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1025));
     }
 
@@ -683,7 +689,7 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     private const uint ALEX_TX_RELAY       = 0x08000000;
     // PureSignal feedback-coupler enable. OR'd into alex1 always when PS is
     // armed and into alex0 during xmit (pihpsdr new_protocol.c:994-998).
-    private const uint AlexPsBit           = 0x00040000;
+    internal const uint AlexPsBit          = 0x00040000;
     // Alex1-only: grounds the RX input while keyed so the hot TX field doesn't
     // back-feed into the Mercury ADC (pihpsdr alex.h ANAN7000_RX_GNDonTX).
     private const uint ALEX1_ANAN7000_RX_GNDonTX = 0x00000100;

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -593,18 +593,35 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
 
     private void SendCmdTx()
     {
+        var p = ComposeCmdTxBuffer(_seqCmdTx++, (ushort)_sampleRateKhz, _txStepAttnDb);
+        _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1026));
+    }
+
+    // Test-seamed Compose for the CmdTx (TxSpecific) packet. Layout per
+    // Thetis network.c (function specific_buffer / fillTxSpecificBuffer
+    // around line 1235) and pihpsdr new_protocol.c new_protocol_tx_specific:
+    //   bytes 0..3   : sequence (BE)
+    //   byte  4      : num_dac (1 on G2)
+    //   bytes 14..15 : DAC sample rate kHz (BE)
+    //   byte  57     : ADC2 TX step attenuator (0..31 dB)
+    //   byte  58     : ADC1 TX step attenuator
+    //   byte  59     : ADC0 TX step attenuator
+    // Other bytes are zero on G2 — pihpsdr fills mic-source flags but the
+    // G2 ignores them.
+    internal static byte[] ComposeCmdTxBuffer(uint seq, ushort sampleRateKhz, byte txStepAttnDb)
+    {
         var p = new byte[60];
-        WriteBeU32(p, 0, _seqCmdTx++);
+        WriteBeU32(p, 0, seq);
         p[4] = 1;                 // num_dac
-        WriteBeU16(p, 14, _sampleRateKhz);
+        WriteBeU16(p, 14, sampleRateKhz);
         // TX step attenuator — Thetis network.c:1238-1242 writes the same
         // value into bytes 57 (ADC2), 58 (ADC1), 59 (ADC0). 0..31 dB.
         // Drives the PS auto-attenuate loop's recovery path when feedback
         // level lands outside the 128..181 ideal window.
-        p[57] = _txStepAttnDb;
-        p[58] = _txStepAttnDb;
-        p[59] = _txStepAttnDb;
-        _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1026));
+        p[57] = txStepAttnDb;
+        p[58] = txStepAttnDb;
+        p[59] = txStepAttnDb;
+        return p;
     }
 
     /// <summary>

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -143,6 +143,12 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // to single-DDC packets and the standard RX demuxer takes over.
     // Volatile because RxLoop reads it across threads.
     private volatile bool _psFeedbackEnabled;
+    // PS feedback source — false=Internal coupler (default), true=External
+    // (Bypass). When externally bypassing, alex0 gains ALEX_RX_ANTENNA_BYPASS
+    // (bit 11) during xmit + PS armed. RxSpecific/TxSpecific are byte-
+    // identical between sources — only this one alex0 bit differs.
+    // Reference: pihpsdr new_protocol.c:1284-1296 alex0 bypass selection.
+    private volatile bool _psFeedbackExternal;
     private const int PsFeedbackBlockSize = 1024;
     private readonly Channel<PsFeedbackFrame> _psFeedbackFrames = Channel.CreateUnbounded<PsFeedbackFrame>(
         new UnboundedChannelOptions { SingleReader = true, SingleWriter = true });
@@ -339,6 +345,19 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
             SendCmdRx();
             SendCmdHighPriority(run: true);
         }
+    }
+
+    /// <summary>
+    /// Choose between Internal feedback coupler and External (Bypass)
+    /// feedback antenna. Drives <c>ALEX_RX_ANTENNA_BYPASS</c> in alex0
+    /// during xmit + PS armed (pihpsdr new_protocol.c:1284-1296). No
+    /// effect on RxSpecific / TxSpecific buffers.
+    /// </summary>
+    public void SetPsFeedbackSource(bool external)
+    {
+        if (_psFeedbackExternal == external) return;
+        _psFeedbackExternal = external;
+        if (_rxTask is not null) SendCmdHighPriority(run: true);
     }
 
     public ChannelReader<PsFeedbackFrame> PsFeedbackFrames => _psFeedbackFrames.Reader;
@@ -651,6 +670,14 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
             alex1 |= AlexPsBit;
             if (xmit) alex0 |= AlexPsBit;
         }
+        // External (Bypass) feedback antenna — pihpsdr new_protocol.c:1284-
+        // 1296 ORs ALEX_RX_ANTENNA_BYPASS into alex0 only during xmit when
+        // PS is armed and the operator selected the external path. Internal
+        // coupler leaves this bit clear.
+        if (_psFeedbackEnabled && _psFeedbackExternal && xmit)
+        {
+            alex0 |= AlexRxAntennaBypass;
+        }
         WriteBeU32(p, 1428, alex1);
         WriteBeU32(p, 1432, alex0);
         _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1027));
@@ -692,6 +719,11 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // PureSignal feedback-coupler enable. OR'd into alex1 always when PS is
     // armed and into alex0 during xmit (pihpsdr new_protocol.c:994-998).
     internal const uint AlexPsBit          = 0x00040000;
+    // PS External (Bypass) antenna select — pihpsdr new_protocol.c:1284-1296
+    // ORs ALEX_RX_ANTENNA_BYPASS into alex0 during xmit + PS armed when the
+    // operator picks the external feedback path. Internal coupler leaves
+    // this bit clear.
+    internal const uint AlexRxAntennaBypass = 0x00000800;
     // Alex1-only: grounds the RX input while keyed so the hot TX field doesn't
     // back-feed into the Mercury ADC (pihpsdr alex.h ANAN7000_RX_GNDonTX).
     private const uint ALEX1_ANAN7000_RX_GNDonTX = 0x00000100;

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -728,6 +728,25 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // back-feed into the Mercury ADC (pihpsdr alex.h ANAN7000_RX_GNDonTX).
     private const uint ALEX1_ANAN7000_RX_GNDonTX = 0x00000100;
 
+    /// <summary>
+    /// Compose the alex0 word the way <see cref="SendCmdHighPriority"/>
+    /// does, exposed internal so wire-format tests can assert the
+    /// PureSignal-related bits without standing up a socket. Mirrors the
+    /// in-line logic at SendCmdHighPriority &gt; alex0 calculation.
+    /// </summary>
+    internal static uint ComposeAlex0ForTest(
+        uint rxFreqHz,
+        bool moxOn,
+        bool psEnabled,
+        bool psExternal)
+    {
+        uint alexCommon = ComputeAlexWord(rxFreqHz, rxFreqHz, txAnt: 1);
+        uint alex0 = alexCommon | (moxOn ? ALEX_TX_RELAY : 0u);
+        if (psEnabled && moxOn) alex0 |= AlexPsBit;
+        if (psEnabled && psExternal && moxOn) alex0 |= AlexRxAntennaBypass;
+        return alex0;
+    }
+
     internal static uint ComputeAlexWord(uint rxFreqHz, uint txFreqHz, int txAnt)
     {
         uint word = 0;
@@ -916,22 +935,19 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     {
         var seq = BinaryPrimitives.ReadUInt32BigEndian(buf);
         const int samplesPerPacket = 119;
-        const float scale = 1f / 8388608f;
 
         for (int i = 0; i < samplesPerPacket; i++)
         {
             int off = 16 + i * 12;
-            int d0i = SignExtend24((buf[off + 0] << 16) | (buf[off + 1] << 8) | buf[off + 2]);
-            int d0q = SignExtend24((buf[off + 3] << 16) | (buf[off + 4] << 8) | buf[off + 5]);
-            int d1i = SignExtend24((buf[off + 6] << 16) | (buf[off + 7] << 8) | buf[off + 8]);
-            int d1q = SignExtend24((buf[off + 9] << 16) | (buf[off + 10] << 8) | buf[off + 11]);
-
-            // DDC0 (off+0..5) is PS_RX_FEEDBACK -> pscc's "rx" pair.
-            // DDC1 (off+6..11) is PS_TX_FEEDBACK -> pscc's "tx" pair.
-            _psRxI[_psBlockFill] = d0i * scale;
-            _psRxQ[_psBlockFill] = d0q * scale;
-            _psTxI[_psBlockFill] = d1i * scale;
-            _psTxQ[_psBlockFill] = d1q * scale;
+            // DecodePsPairForTest is the canonical mapping (DDC0=rx, DDC1=tx).
+            // Reusing it here keeps the test-asserted contract identical to
+            // the live decode path so the regression guard is real.
+            var (sampleRxI, sampleRxQ, sampleTxI, sampleTxQ) =
+                DecodePsPairForTest(new ReadOnlySpan<byte>(buf, off, 12));
+            _psRxI[_psBlockFill] = sampleRxI;
+            _psRxQ[_psBlockFill] = sampleRxQ;
+            _psTxI[_psBlockFill] = sampleTxI;
+            _psTxQ[_psBlockFill] = sampleTxQ;
 
             if (_psBlockFill == 0) _psBlockStartSeq = seq;
             _psBlockFill++;
@@ -958,6 +974,25 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     {
         if ((raw & 0x800000) != 0) raw |= unchecked((int)0xFF000000);
         return raw;
+    }
+
+    /// <summary>
+    /// Test seam — decode a single sample-pair from a PS paired packet and
+    /// return the (rxI, rxQ, txI, txQ) destination assignments per the
+    /// pihpsdr DDC0=RX_FEEDBACK / DDC1=TX_FEEDBACK contract. Used by tests
+    /// to guard against re-introducing the round-1 swap bug.
+    /// </summary>
+    internal static (float rxI, float rxQ, float txI, float txQ)
+        DecodePsPairForTest(ReadOnlySpan<byte> pair)
+    {
+        if (pair.Length < 12) throw new ArgumentException("pair must be 12 bytes", nameof(pair));
+        const float scale = 1f / 8388608f;
+        int d0i = SignExtend24((pair[0]  << 16) | (pair[1]  << 8) | pair[2]);
+        int d0q = SignExtend24((pair[3]  << 16) | (pair[4]  << 8) | pair[5]);
+        int d1i = SignExtend24((pair[6]  << 16) | (pair[7]  << 8) | pair[8]);
+        int d1q = SignExtend24((pair[9]  << 16) | (pair[10] << 8) | pair[11]);
+        // DDC0 -> rx, DDC1 -> tx.
+        return (d0i * scale, d0q * scale, d1i * scale, d1q * scale);
     }
 
     public void Dispose()

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -85,6 +85,13 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // needed via the UI. Attenuator 0 dB so the front-end isn't knocked down.
     private bool _preampOn;
     private byte _rxStepAttnDb;
+    // TX step attenuator (0..31 dB) — Thetis network.c:1238-1242 writes the
+    // same value to bytes 57/58/59 of CmdTx (one per ADC tap). The PS
+    // auto-attenuate loop adjusts this when info[4] feedback level lands
+    // outside the 128..181 ideal window so calcc has a chance to converge.
+    // Default 0 matches the radio's power-on state and pihpsdr's untouched
+    // baseline.
+    private byte _txStepAttnDb;
     // PA settings — pushed from RadioService when PaSettingsStore changes or
     // the VFO crosses a band edge. _paEnabled is the global toggle that lands
     // in CmdGeneral[58]; _driveByte is the pre-calibrated drive level for
@@ -590,7 +597,30 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         WriteBeU32(p, 0, _seqCmdTx++);
         p[4] = 1;                 // num_dac
         WriteBeU16(p, 14, _sampleRateKhz);
+        // TX step attenuator — Thetis network.c:1238-1242 writes the same
+        // value into bytes 57 (ADC2), 58 (ADC1), 59 (ADC0). 0..31 dB.
+        // Drives the PS auto-attenuate loop's recovery path when feedback
+        // level lands outside the 128..181 ideal window.
+        p[57] = _txStepAttnDb;
+        p[58] = _txStepAttnDb;
+        p[59] = _txStepAttnDb;
         _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1026));
+    }
+
+    /// <summary>
+    /// Set the TX step attenuator (0..31 dB) and re-emit the CmdTx packet
+    /// so the radio honours the new value on the next transmit cycle. Bytes
+    /// 57/58/59 — Thetis network.c:1238-1242. Used by the PS auto-attenuate
+    /// loop to ramp feedback level into the 128..181 window when calcc
+    /// rejects fits because the loopback is too hot or too quiet.
+    /// </summary>
+    public void SetTxAttenuationDb(byte db)
+    {
+        if (db > 31) db = 31;
+        if (_txStepAttnDb == db) return;
+        _txStepAttnDb = db;
+        if (_rxTask is not null) SendCmdTx();
+        _log.LogInformation("p2.txAttn db={Db}", db);
     }
 
     private void SendCmdHighPriority(bool run)

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -133,6 +133,24 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         new UnboundedChannelOptions { SingleReader = true });
     private Task? _txIqSenderTask;
 
+    // ---- PureSignal feedback (DDC0 + DDC1 paired on UDP 1035) ----
+    // PS feedback decoder: when armed, packets on port 1035 carry interleaved
+    // (DDC0=TX-mod-IQ, DDC1=feedback-coupler-IQ) sample pairs (pihpsdr
+    // process_ps_iq_data, new_protocol.c:2463-2510). The accumulator collects
+    // 1024 complex pairs across packets before emitting a frame. When PS is
+    // disarmed the radio reverts to single-DDC packets and the standard RX
+    // demuxer takes over. Volatile because RxLoop reads it across threads.
+    private volatile bool _psFeedbackEnabled;
+    private const int PsFeedbackBlockSize = 1024;
+    private readonly Channel<PsFeedbackFrame> _psFeedbackFrames = Channel.CreateUnbounded<PsFeedbackFrame>(
+        new UnboundedChannelOptions { SingleReader = true, SingleWriter = true });
+    private readonly float[] _psTxI = new float[PsFeedbackBlockSize];
+    private readonly float[] _psTxQ = new float[PsFeedbackBlockSize];
+    private readonly float[] _psRxI = new float[PsFeedbackBlockSize];
+    private readonly float[] _psRxQ = new float[PsFeedbackBlockSize];
+    private int _psBlockFill;
+    private ulong _psBlockStartSeq;
+
     public Protocol2Client(ILogger<Protocol2Client> log)
     {
         _log = log;
@@ -291,6 +309,37 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         if (!on) ResetTxIq();
         if (_rxTask is not null) SendCmdHighPriority(run: true);
     }
+
+    /// <summary>
+    /// Arm or disarm PureSignal feedback streaming. When on:
+    ///   - <c>SendCmdRx</c> enables DDC0 alongside the user-visible DDC2 and
+    ///     synchronises DDC1→DDC0 (byte 1363 = 0x02) so the radio sends
+    ///     paired DDC0/DDC1 IQ on port 1035.
+    ///   - <c>SendCmdHighPriority</c> sets <c>ALEX_PS_BIT (0x00040000)</c>
+    ///     in alex0/alex1 and, during xmit, mirrors DDC0+DDC1 phase words
+    ///     to the TX DUC frequency.
+    ///   - The packet decoder switches to the paired format (6B DDC0 + 6B
+    ///     DDC1 per sample, repeating).
+    /// When off the radio reverts to the standard non-PS RX layout and any
+    /// in-flight paired packets are discarded by the decoder.
+    /// </summary>
+    public void SetPsFeedbackEnabled(bool on)
+    {
+        if (_psFeedbackEnabled == on) return;
+        _psFeedbackEnabled = on;
+        // Reset accumulator so we don't mix old samples with new on a re-arm.
+        _psBlockFill = 0;
+        if (_rxTask is not null)
+        {
+            // Re-emit RX-spec (DDC enables / sync bit) and HighPriority (PS
+            // bit / DDC0/1 phase) so the radio honours the new state on the
+            // very next sample window.
+            SendCmdRx();
+            SendCmdHighPriority(run: true);
+        }
+    }
+
+    public ChannelReader<PsFeedbackFrame> PsFeedbackFrames => _psFeedbackFrames.Reader;
 
     /// <summary>
     /// Push a block of interleaved float IQ (−1..+1) into the TX-DUC stream.
@@ -475,12 +524,32 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         // Mirrors pihpsdr new_protocol_receive_specific for the MkII:
         //   n_adc = 2 (G2 has two physical ADCs), DDC2 enabled by bit 2 in
         //   the enable mask, and the DDC config block sits at 17 + 2*6 = 29.
-        //   DDC0/1 stay disabled — those slots are reserved by the radio for
-        //   the PureSignal/Diversity hardware pair.
-        p[4] = 2;
+        //   DDC0/1 stay disabled by default — those slots are reserved by
+        //   the radio for the PureSignal / Diversity hardware pair.
+        p[4] = _numAdc;
         p[5] = 0;
         p[6] = 0;
-        p[7] = (byte)(1 << G2RxDdc);  // = 0x04
+        byte ddcEnable = (byte)(1 << G2RxDdc);
+
+        if (_psFeedbackEnabled)
+        {
+            // pihpsdr new_protocol.c:1611-1630 — when PS is armed, also turn
+            // on DDC0 and lock DDC1 to DDC0 (byte 1363 = 0x02). Both DDCs run
+            // at 192 kHz / 24-bit; DDC0 = TX-mod-IQ tap, DDC1 = feedback IQ.
+            ddcEnable |= 0x01;
+            // DDC0 config: <- ADC0, 192 kHz, 24-bit
+            p[17] = 0x00;
+            WriteBeU16(p, 18, 192);
+            p[22] = 24;
+            // DDC1 config: <- ADC <n_adc> (mirrors the PS pair), 192k, 24-bit
+            p[23] = _numAdc;
+            WriteBeU16(p, 24, 192);
+            p[28] = 24;
+            // Sync DDC1→DDC0 (paired packet shape on UDP 1035).
+            p[1363] = 0x02;
+        }
+
+        p[7] = ddcEnable;
         int off = 17 + G2RxDdc * 6;
         p[off + 0] = 0x00;            // DDC2 <- ADC0
         WriteBeU16(p, off + 1, _sampleRateKhz);
@@ -511,12 +580,24 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         // reads a 32-bit phase increment, not Hz. pihpsdr computes this as
         //   phase = freq_hz * 2^32 / 122_880_000
         // The G2 MkII puts the user-visible RX0 at DDC slot 2, so the phase
-        // goes to bytes 9 + 2*4 = 17..20. Bytes 9..16 (DDC0/1) are left as
-        // zero per pihpsdr's non-PS non-diversity code path. TX DUC phase is
-        // written to 329..332 as the same value for out-of-band gating.
+        // goes to bytes 9 + 2*4 = 17..20. Bytes 9..16 (DDC0/1) are normally
+        // left as zero (non-PS path). TX DUC phase is written to 329..332.
         uint rxPhase = (uint)(_rxFreqHz * HzToPhase);
         WriteBeU32(p, 9 + G2RxDdc * 4, rxPhase);
         WriteBeU32(p, 329, rxPhase);
+
+        // PureSignal — when armed, DDC0 + DDC1 phase words also need to
+        // track the TX frequency during xmit so the feedback DDC samples
+        // the actual TX coupler signal. pihpsdr new_protocol.c:827-839.
+        if (_psFeedbackEnabled && _moxOn)
+        {
+            // For now mirror the RX freq onto the TX side — the radio's
+            // single-VFO assumption today means TX = RX. Multi-VFO support
+            // is a follow-up.
+            uint txPhase = rxPhase;
+            WriteBeU32(p, 9, txPhase);     // DDC0 = TX freq
+            WriteBeU32(p, 13, txPhase);    // DDC1 = TX freq
+        }
 
         // Drive level (0..255) at byte 345. Set by RadioService after applying
         // per-band PA gain calibration. Honored by the radio only while run=1
@@ -553,6 +634,15 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         uint alexCommon = ComputeAlexWord(_rxFreqHz, _rxFreqHz, txAnt: 1);
         uint alex0 = alexCommon | (xmit ? ALEX_TX_RELAY : 0u);
         uint alex1 = alexCommon | (xmit ? ALEX_TX_RELAY | ALEX1_ANAN7000_RX_GNDonTX : 0u);
+        // ALEX_PS_BIT (0x00040000): pihpsdr new_protocol.c:994-998 ORs this
+        // into alex0 (during xmit) and alex1 (always-on while PS armed). The
+        // BPF board uses it to swap to the feedback-coupler tap on the TX
+        // path so DDC0/DDC1 see the post-PA signal.
+        if (_psFeedbackEnabled)
+        {
+            alex1 |= AlexPsBit;
+            if (xmit) alex0 |= AlexPsBit;
+        }
         WriteBeU32(p, 1428, alex1);
         WriteBeU32(p, 1432, alex0);
         _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1027));
@@ -591,6 +681,9 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // through the selected TX LPF instead of through the RX BPF path. OR'd
     // into both alex0 and alex1 during TX (pihpsdr new_protocol.c:989-992).
     private const uint ALEX_TX_RELAY       = 0x08000000;
+    // PureSignal feedback-coupler enable. OR'd into alex1 always when PS is
+    // armed and into alex0 during xmit (pihpsdr new_protocol.c:994-998).
+    private const uint AlexPsBit           = 0x00040000;
     // Alex1-only: grounds the RX input while keyed so the hot TX field doesn't
     // back-feed into the Mercury ADC (pihpsdr alex.h ANAN7000_RX_GNDonTX).
     private const uint ALEX1_ANAN7000_RX_GNDonTX = 0x00000100;
@@ -704,7 +797,18 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
                 var srcPort = ((IPEndPoint)from).Port;
                 if (srcPort >= 1035 && srcPort <= 1041 && n == BufLen)
                 {
-                    HandleDdcPacket(buf, srcPort - 1035);
+                    int ddcIndex = srcPort - 1035;
+                    if (_psFeedbackEnabled && ddcIndex == 0)
+                    {
+                        // PS-armed paired-DDC packet: 6B DDC0 (TX-mod-IQ) + 6B
+                        // DDC1 (feedback) interleaved per sample. pihpsdr
+                        // process_ps_iq_data, new_protocol.c:2463-2510.
+                        HandlePsPairedPacket(buf);
+                    }
+                    else
+                    {
+                        HandleDdcPacket(buf, ddcIndex);
+                    }
                 }
                 // other ports (hi-pri status, mic, wideband) intentionally ignored for now
             }
@@ -755,6 +859,62 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
 
         Interlocked.Increment(ref _totalFrames);
         _iqFrames.Writer.TryWrite(frame);
+    }
+
+    // PS-armed packet shape on UDP 1035: 16-byte header (4 seq, 8 timestamp,
+    // 4 reserved) followed by 119 sample pairs at 12 bytes each (6B DDC0 +
+    // 6B DDC1). 16 + 119*12 = 1444 = BufLen. We accumulate into the 1024-
+    // sample paired buffers and emit a PsFeedbackFrame per full block.
+    //
+    // Sample layout per pair (big-endian, signed 24-bit):
+    //   off+0..2 : DDC0 I
+    //   off+3..5 : DDC0 Q
+    //   off+6..8 : DDC1 I
+    //   off+9..11: DDC1 Q
+    private void HandlePsPairedPacket(byte[] buf)
+    {
+        var seq = BinaryPrimitives.ReadUInt32BigEndian(buf);
+        const int samplesPerPacket = 119;
+        const float scale = 1f / 8388608f;
+
+        for (int i = 0; i < samplesPerPacket; i++)
+        {
+            int off = 16 + i * 12;
+            int d0i = SignExtend24((buf[off + 0] << 16) | (buf[off + 1] << 8) | buf[off + 2]);
+            int d0q = SignExtend24((buf[off + 3] << 16) | (buf[off + 4] << 8) | buf[off + 5]);
+            int d1i = SignExtend24((buf[off + 6] << 16) | (buf[off + 7] << 8) | buf[off + 8]);
+            int d1q = SignExtend24((buf[off + 9] << 16) | (buf[off + 10] << 8) | buf[off + 11]);
+
+            _psTxI[_psBlockFill] = d0i * scale;
+            _psTxQ[_psBlockFill] = d0q * scale;
+            _psRxI[_psBlockFill] = d1i * scale;
+            _psRxQ[_psBlockFill] = d1q * scale;
+
+            if (_psBlockFill == 0) _psBlockStartSeq = seq;
+            _psBlockFill++;
+
+            if (_psBlockFill >= PsFeedbackBlockSize)
+            {
+                // Copy out — caller may reuse the buffers immediately.
+                var txI = new float[PsFeedbackBlockSize];
+                var txQ = new float[PsFeedbackBlockSize];
+                var rxI = new float[PsFeedbackBlockSize];
+                var rxQ = new float[PsFeedbackBlockSize];
+                Array.Copy(_psTxI, txI, PsFeedbackBlockSize);
+                Array.Copy(_psTxQ, txQ, PsFeedbackBlockSize);
+                Array.Copy(_psRxI, rxI, PsFeedbackBlockSize);
+                Array.Copy(_psRxQ, rxQ, PsFeedbackBlockSize);
+                _psFeedbackFrames.Writer.TryWrite(new PsFeedbackFrame(
+                    txI, txQ, rxI, rxQ, _psBlockStartSeq));
+                _psBlockFill = 0;
+            }
+        }
+    }
+
+    private static int SignExtend24(int raw)
+    {
+        if ((raw & 0x800000) != 0) raw |= unchecked((int)0xFF000000);
+        return raw;
     }
 
     public void Dispose()

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -135,11 +135,13 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
 
     // ---- PureSignal feedback (DDC0 + DDC1 paired on UDP 1035) ----
     // PS feedback decoder: when armed, packets on port 1035 carry interleaved
-    // (DDC0=TX-mod-IQ, DDC1=feedback-coupler-IQ) sample pairs (pihpsdr
-    // process_ps_iq_data, new_protocol.c:2463-2510). The accumulator collects
-    // 1024 complex pairs across packets before emitting a frame. When PS is
-    // disarmed the radio reverts to single-DDC packets and the standard RX
-    // demuxer takes over. Volatile because RxLoop reads it across threads.
+    // (DDC0=PS_RX_FEEDBACK=post-PA coupler IQ, DDC1=PS_TX_FEEDBACK=TX-DAC
+    // loopback IQ) sample pairs (pihpsdr new_protocol.c:1615-1616, 2463-2510;
+    // transmitter.c:2015-2030, 2066). DDC0 feeds pscc's "rx" arg; DDC1 feeds
+    // pscc's "tx" arg. The accumulator collects 1024 complex pairs across
+    // packets before emitting a frame. When PS is disarmed the radio reverts
+    // to single-DDC packets and the standard RX demuxer takes over.
+    // Volatile because RxLoop reads it across threads.
     private volatile bool _psFeedbackEnabled;
     private const int PsFeedbackBlockSize = 1024;
     private readonly Channel<PsFeedbackFrame> _psFeedbackFrames = Channel.CreateUnbounded<PsFeedbackFrame>(
@@ -872,10 +874,11 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // 6B DDC1). 16 + 119*12 = 1444 = BufLen. We accumulate into the 1024-
     // sample paired buffers and emit a PsFeedbackFrame per full block.
     //
-    // Sample layout per pair (big-endian, signed 24-bit):
-    //   off+0..2 : DDC0 I
+    // Sample layout per pair (big-endian, signed 24-bit), per pihpsdr
+    // new_protocol.c:1615-1616:
+    //   off+0..2 : DDC0 I  (PS_RX_FEEDBACK — post-PA coupler — pscc's "rx")
     //   off+3..5 : DDC0 Q
-    //   off+6..8 : DDC1 I
+    //   off+6..8 : DDC1 I  (PS_TX_FEEDBACK — TX-DAC loopback — pscc's "tx")
     //   off+9..11: DDC1 Q
     private void HandlePsPairedPacket(byte[] buf)
     {
@@ -891,10 +894,12 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
             int d1i = SignExtend24((buf[off + 6] << 16) | (buf[off + 7] << 8) | buf[off + 8]);
             int d1q = SignExtend24((buf[off + 9] << 16) | (buf[off + 10] << 8) | buf[off + 11]);
 
-            _psTxI[_psBlockFill] = d0i * scale;
-            _psTxQ[_psBlockFill] = d0q * scale;
-            _psRxI[_psBlockFill] = d1i * scale;
-            _psRxQ[_psBlockFill] = d1q * scale;
+            // DDC0 (off+0..5) is PS_RX_FEEDBACK -> pscc's "rx" pair.
+            // DDC1 (off+6..11) is PS_TX_FEEDBACK -> pscc's "tx" pair.
+            _psRxI[_psBlockFill] = d0i * scale;
+            _psRxQ[_psBlockFill] = d0q * scale;
+            _psTxI[_psBlockFill] = d1i * scale;
+            _psTxQ[_psBlockFill] = d1q * scale;
 
             if (_psBlockFill == 0) _psBlockStartSeq = seq;
             _psBlockFill++;

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -934,7 +934,21 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     private void HandlePsPairedPacket(byte[] buf)
     {
         var seq = BinaryPrimitives.ReadUInt32BigEndian(buf);
-        const int samplesPerPacket = 119;
+        // Read samplesperframe from the packet header (pihpsdr
+        // new_protocol.c:2475). G2 at 192 kHz emits 238 samples/frame
+        // = 119 pairs/packet — the prior hardcoded literal happened to
+        // match. Defensive bounds check + fallback to 119 on any garbage
+        // value keeps the decoder working if the radio reports something
+        // unexpected (older firmware, future variants).
+        int samplesPerFrame = (buf[14] << 8) | buf[15];
+        int samplesPerPacket = samplesPerFrame / 2;
+        if (samplesPerPacket <= 0 || samplesPerPacket > 200)
+        {
+            _log.LogWarning(
+                "p2.psPaired bad samplesPerFrame={N}, falling back to 119",
+                samplesPerFrame);
+            samplesPerPacket = 119;
+        }
 
         for (int i = 0; i < samplesPerPacket; i++)
         {

--- a/Zeus.Protocol2/PsFeedbackFrame.cs
+++ b/Zeus.Protocol2/PsFeedbackFrame.cs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.Protocol2;
+
+/// <summary>
+/// One 1024-sample paired feedback block destined for WDSP <c>psccF</c>.
+/// TX side comes from the post-fexchange2 IQ tap inside Zeus's TXA pipeline
+/// (forwarded over the network via DDC0 phase = TX freq) and the RX side is
+/// the radio's feedback-coupler IQ on DDC1. Both arrive interleaved within
+/// a single UDP packet on port 1035 when PS is armed (pihpsdr
+/// <c>process_ps_iq_data</c>, <c>new_protocol.c:2463-2510</c>).
+///
+/// Block size is 1024 complex samples per pihpsdr <c>receiver.c:636</c> —
+/// independent of Zeus's TX analyzer 2048-sample block. Do NOT share the
+/// buffers across pumps; the calcc state machine demands its own sample
+/// alignment.
+///
+/// SeqHint is the radio's UDP sequence at the start of the block, useful
+/// for diagnostic logging when the cal converges slowly. Not used by WDSP.
+/// </summary>
+public readonly record struct PsFeedbackFrame(
+    float[] TxI,
+    float[] TxQ,
+    float[] RxI,
+    float[] RxQ,
+    ulong SeqHint);

--- a/Zeus.Server/DspPipelineService.cs
+++ b/Zeus.Server/DspPipelineService.cs
@@ -193,6 +193,13 @@ public class DspPipelineService : BackgroundService
         get { lock (_engineLock) return _engine; }
     }
 
+    /// <summary>Snapshot of the active Protocol2 client, or null on P1 / no
+    /// connection. Exposed for the PS auto-attenuate service which needs to
+    /// call <c>SetTxAttenuationDb</c> on the same client this pipeline is
+    /// driving. Non-virtual — auto-attenuate is hard-gated on a P2 connection
+    /// and tests don't exercise it.</summary>
+    public Zeus.Protocol2.Protocol2Client? CurrentP2Client => _p2Client;
+
     private void OpenSynthetic()
     {
         var engine = new SyntheticDspEngine();

--- a/Zeus.Server/DspPipelineService.cs
+++ b/Zeus.Server/DspPipelineService.cs
@@ -84,6 +84,12 @@ public class DspPipelineService : BackgroundService
 
     private uint _seq;
     private uint _audioSeq;
+    // Latched from MoxChanged so Tick can route the panadapter to the TX
+    // analyzer during keying without snapshotting RadioService. TUN also flips
+    // MOX on (TxService.cs:153-155), so this single flag covers both paths —
+    // see issue #81. volatile because MoxChanged fires on the caller's thread
+    // and Tick reads from the pipeline thread.
+    private volatile bool _keyed;
     // RX S-meter broadcast throttle. Pipeline ticks at 30 Hz; broadcasting
     // every 6 ticks = 5 Hz gives a smoother meter than Thetis's 4 Hz baseline
     // without spamming the WS (30 Hz dBm readouts add nothing a UI can use).
@@ -447,6 +453,7 @@ public class DspPipelineService : BackgroundService
 
     private void OnRadioMoxChanged(bool on)
     {
+        _keyed = on;
         _p2Client?.SetMox(on);
     }
 
@@ -561,8 +568,22 @@ public class DspPipelineService : BackgroundService
 
         engine.SetVfoHz(channel, state.VfoHz);
 
-        bool pan = engine.TryGetDisplayPixels(channel, DisplayPixout.Panadapter, panBuf);
-        bool wf = engine.TryGetDisplayPixels(channel, DisplayPixout.Waterfall, wfBuf);
+        // While keyed (MOX or TUN — see _keyed comment) pull from the TX
+        // analyzer so the panadapter shows the transmitted signal instead of
+        // the RX front end's TX bleed (issue #81). If the TX analyzer isn't
+        // ready (not yet produced an FFT, or engine doesn't have a TX
+        // analyzer — e.g. Synthetic), TryGetTxDisplayPixels returns false and
+        // we fall through to the RX analyzer, matching the pre-issue-#81
+        // behaviour. This fallback also covers the first ~1 tick after
+        // keying before the analyzer averaging has settled.
+        bool pan = false, wf = false;
+        if (_keyed)
+        {
+            pan = engine.TryGetTxDisplayPixels(DisplayPixout.Panadapter, panBuf);
+            wf = engine.TryGetTxDisplayPixels(DisplayPixout.Waterfall, wfBuf);
+        }
+        if (!pan) pan = engine.TryGetDisplayPixels(channel, DisplayPixout.Panadapter, panBuf);
+        if (!wf) wf = engine.TryGetDisplayPixels(channel, DisplayPixout.Waterfall, wfBuf);
 
         // Flip to display order (low freq left, high freq right). WDSP emits
         // pixel 0 = highest positive frequency — see doc 03 §10 and

--- a/Zeus.Server/DspPipelineService.cs
+++ b/Zeus.Server/DspPipelineService.cs
@@ -102,6 +102,7 @@ public class DspPipelineService : BackgroundService
     private double _appliedPsAmpDelayNs = 150.0;
     private double _appliedPsHwPeak = 0.4072;
     private string _appliedPsIntsSpiPreset = "16/256";
+    private PsFeedbackSource _appliedPsFeedbackSource = PsFeedbackSource.Internal;
     // TwoTone latched fields (protocol-agnostic, drives PostGen mode=1).
     private bool _appliedTwoToneEnabled;
     private double _appliedTwoToneFreq1 = 700.0;
@@ -380,6 +381,13 @@ public class DspPipelineService : BackgroundService
             // would arrive at the engine after PS shut down.
             if (!s.PsEnabled) DrainPsFeedback();
             _appliedPsEnabled = s.PsEnabled;
+        }
+        if (s.PsFeedbackSource != _appliedPsFeedbackSource)
+        {
+            // Wire-only change — flips ALEX_RX_ANTENNA_BYPASS in alex0 on
+            // the next CmdHighPriority emission. WDSP is unaffected.
+            _p2Client?.SetPsFeedbackSource(s.PsFeedbackSource == PsFeedbackSource.External);
+            _appliedPsFeedbackSource = s.PsFeedbackSource;
         }
     }
 

--- a/Zeus.Server/DspPipelineService.cs
+++ b/Zeus.Server/DspPipelineService.cs
@@ -66,6 +66,15 @@ public class DspPipelineService : BackgroundService
     private Task? _iqPumpTask;
     private CancellationTokenSource? _iqPumpCts;
 
+    // PureSignal feedback pump. Reads paired DDC0+DDC1 IQ from the active
+    // protocol client and feeds the WDSP psccF entry once per 1024-sample
+    // block. Lifecycle is tied to the connection (started on connect,
+    // stopped on disconnect) — not to PsEnabled, because the radio sends
+    // paired frames whenever the PS wire bit is set even before the WDSP
+    // calcc state machine is armed.
+    private Task? _psFeedbackPumpTask;
+    private CancellationTokenSource? _psFeedbackPumpCts;
+
     // Protocol 2 path (parallel to the RadioService-owned P1 path). Held
     // directly here because RadioService is Protocol1Client-shaped and
     // growing a P2 variant there would require a larger refactor; for now
@@ -81,6 +90,23 @@ public class DspPipelineService : BackgroundService
     private double _appliedRxAfGainDb;
     private NrConfig _appliedNr = new();
     private int _appliedZoomLevel = 1;
+    // PureSignal latched values — same change-detect pattern as the others
+    // so OnRadioStateChanged only fires the (possibly heavy)
+    // SetPsIntsAndSpi / SetPsRunCal calls when the value actually moves.
+    private bool _appliedPsEnabled;
+    private bool _appliedPsAuto = true;
+    private bool _appliedPsSingle;
+    private bool _appliedPsPtol;
+    private double _appliedPsMoxDelaySec = 0.2;
+    private double _appliedPsLoopDelaySec;
+    private double _appliedPsAmpDelayNs = 150.0;
+    private double _appliedPsHwPeak = 0.4072;
+    private string _appliedPsIntsSpiPreset = "16/256";
+    // TwoTone latched fields (protocol-agnostic, drives PostGen mode=1).
+    private bool _appliedTwoToneEnabled;
+    private double _appliedTwoToneFreq1 = 700.0;
+    private double _appliedTwoToneFreq2 = 1900.0;
+    private double _appliedTwoToneMag = 0.49;
 
     private uint _seq;
     private uint _audioSeq;
@@ -288,6 +314,87 @@ public class DspPipelineService : BackgroundService
             engine.SetZoom(channel, s.ZoomLevel);
             _appliedZoomLevel = s.ZoomLevel;
         }
+
+        // ---- TwoTone (protocol-agnostic; PostGen mode=1 inside TXA) ----
+        // TwoTone is safe on P1 even though PS itself is P2-only in v1
+        // because it touches only the TXA stage, not the wire format.
+        if (s.TwoToneEnabled != _appliedTwoToneEnabled
+            || s.TwoToneFreq1 != _appliedTwoToneFreq1
+            || s.TwoToneFreq2 != _appliedTwoToneFreq2
+            || s.TwoToneMag != _appliedTwoToneMag)
+        {
+            engine.SetTwoTone(s.TwoToneEnabled, s.TwoToneFreq1, s.TwoToneFreq2, s.TwoToneMag);
+            _appliedTwoToneEnabled = s.TwoToneEnabled;
+            _appliedTwoToneFreq1 = s.TwoToneFreq1;
+            _appliedTwoToneFreq2 = s.TwoToneFreq2;
+            _appliedTwoToneMag = s.TwoToneMag;
+        }
+
+        // ---- PureSignal ----
+        // Apply HW-peak first because SetPsAdvanced may also touch it; then
+        // advanced timing/preset; then control mode; then master arm last so
+        // the engine is fully configured before the cal state machine starts.
+        if (s.PsHwPeak != _appliedPsHwPeak)
+        {
+            engine.SetPsHwPeak(s.PsHwPeak);
+            _appliedPsHwPeak = s.PsHwPeak;
+        }
+        if (s.PsPtol != _appliedPsPtol
+            || s.PsMoxDelaySec != _appliedPsMoxDelaySec
+            || s.PsLoopDelaySec != _appliedPsLoopDelaySec
+            || s.PsAmpDelayNs != _appliedPsAmpDelayNs
+            || s.PsIntsSpiPreset != _appliedPsIntsSpiPreset)
+        {
+            (int ints, int spi) = ParseIntsSpi(s.PsIntsSpiPreset);
+            engine.SetPsAdvanced(
+                s.PsPtol,
+                s.PsMoxDelaySec,
+                s.PsLoopDelaySec,
+                s.PsAmpDelayNs,
+                s.PsHwPeak,
+                ints,
+                spi);
+            _appliedPsPtol = s.PsPtol;
+            _appliedPsMoxDelaySec = s.PsMoxDelaySec;
+            _appliedPsLoopDelaySec = s.PsLoopDelaySec;
+            _appliedPsAmpDelayNs = s.PsAmpDelayNs;
+            _appliedPsIntsSpiPreset = s.PsIntsSpiPreset;
+        }
+        if (s.PsAuto != _appliedPsAuto || s.PsSingle != _appliedPsSingle)
+        {
+            engine.SetPsControl(s.PsAuto, s.PsSingle);
+            _appliedPsAuto = s.PsAuto;
+            _appliedPsSingle = s.PsSingle;
+        }
+        if (s.PsEnabled != _appliedPsEnabled)
+        {
+            engine.SetPsEnabled(s.PsEnabled);
+            // TODO(ps-p1): when P1 PS lands, dispatch to _radio.ActiveClient
+            // here too (the P1 client gains a SetPuresignal(bool) sibling
+            // — see hermes.md item 4b). Today the P1 ActiveClient receives
+            // no PS bit and the frontend gates the PS toggle off on P1.
+            _p2Client?.SetPsFeedbackEnabled(s.PsEnabled);
+            // Drain stale frames if we just disarmed: the radio will keep
+            // sending paired packets in flight for a few ms after we drop
+            // the bit on the wire, and stalled frames in the pump channel
+            // would arrive at the engine after PS shut down.
+            if (!s.PsEnabled) DrainPsFeedback();
+            _appliedPsEnabled = s.PsEnabled;
+        }
+    }
+
+    // "16/256" → (16, 256). Falls back to (16, 256) on any parse failure
+    // because that's the only ints/spi pair WDSP allows save/restore on
+    // (Thetis PSForm.cs:865) — a safe default.
+    private static (int Ints, int Spi) ParseIntsSpi(string preset)
+    {
+        if (string.IsNullOrWhiteSpace(preset)) return (16, 256);
+        var slash = preset.IndexOf('/');
+        if (slash <= 0) return (16, 256);
+        if (!int.TryParse(preset.AsSpan(0, slash), out int ints)) return (16, 256);
+        if (!int.TryParse(preset.AsSpan(slash + 1), out int spi)) return (16, 256);
+        if (ints <= 0 || spi <= 0) return (16, 256);
+        return (ints, spi);
     }
 
     private void ApplyStateToNewChannel(IDspEngine engine, int channelId)
@@ -367,6 +474,62 @@ public class DspPipelineService : BackgroundService
         }, cts.Token);
     }
 
+    // PureSignal feedback pump (P2). Reads 1024-sample paired blocks from the
+    // Protocol2Client and hands them to the WDSP `psccF` entry. Runs whether
+    // or not PS is armed — the engine drops blocks internally when SetPsRunCal
+    // is 0, so steady-state cost is one P/Invoke per 5.3 ms (1024 / 192 kHz).
+    private void StartPsFeedbackPumpP2(Zeus.Protocol2.Protocol2Client client)
+    {
+        var cts = new CancellationTokenSource();
+        _psFeedbackPumpCts = cts;
+        _psFeedbackPumpTask = Task.Run(async () =>
+        {
+            try
+            {
+                await foreach (var frame in client.PsFeedbackFrames.ReadAllAsync(cts.Token).ConfigureAwait(false))
+                {
+                    IDspEngine? engine;
+                    lock (_engineLock) { engine = _engine; }
+                    engine?.FeedPsFeedbackBlock(frame.TxI, frame.TxQ, frame.RxI, frame.RxQ);
+                }
+            }
+            catch (OperationCanceledException) { }
+            catch (ChannelClosedException) { }
+            catch (Exception ex)
+            {
+                _log.LogWarning(ex, "dsp.pipeline p2 ps-feedback-pump exited with error");
+            }
+        }, cts.Token);
+    }
+
+    private async Task StopPsFeedbackPumpAsync()
+    {
+        var cts = _psFeedbackPumpCts;
+        var task = _psFeedbackPumpTask;
+        _psFeedbackPumpCts = null;
+        _psFeedbackPumpTask = null;
+        if (cts is null) return;
+        try { cts.Cancel(); } catch { }
+        if (task is not null)
+        {
+            try { await task.ConfigureAwait(false); }
+            catch (OperationCanceledException) { }
+        }
+        cts.Dispose();
+    }
+
+    // Best-effort drain of in-flight paired frames after PS disarm. Called
+    // synchronously from OnRadioStateChanged so by the time the next state
+    // change tries to re-arm, the channel is empty. The pump task itself is
+    // not stopped — only the buffered backlog is drained.
+    private void DrainPsFeedback()
+    {
+        var client = _p2Client;
+        if (client is null) return;
+        var reader = client.PsFeedbackFrames;
+        while (reader.TryRead(out _)) { }
+    }
+
     /// <summary>
     /// Connect to a Protocol 2 radio and start streaming RX IQ into the DSP
     /// engine. Parallel path to RadioService.ConnectAsync (which is Protocol 1
@@ -435,7 +598,13 @@ public class DspPipelineService : BackgroundService
 
         _p2Client = client;
         StartIqPumpP2(client);
+        StartPsFeedbackPumpP2(client);
         _radio.MarkProtocol2Connected(radioEndpoint.ToString(), rateHz);
+        // P2 G2/MkII default HW peak = 0.6121; ANAN-7000/8000 = 0.2899. The
+        // RadioService switch covers both so we don't bake a value in here.
+        // ConnectedBoardKind returns OrionMkII when _p2Active is true; future
+        // P2 discovery work can refine it.
+        _radio.ApplyPsHwPeakForConnection(isProtocol2: true, _radio.ConnectedBoardKind);
         // Push current PA snapshot into the brand-new client so byte 345 /
         // byte 1401 / CmdGeneral[58] reflect PaSettingsStore from frame 1.
         _radio.ReplayPaSnapshot();
@@ -479,6 +648,7 @@ public class DspPipelineService : BackgroundService
         if (client is null) return;
 
         await StopIqPumpAsync().ConfigureAwait(false);
+        await StopPsFeedbackPumpAsync().ConfigureAwait(false);
         try { await client.StopAsync(ct).ConfigureAwait(false); } catch { }
         await client.DisposeAsync().ConfigureAwait(false);
 

--- a/Zeus.Server/DspPipelineService.cs
+++ b/Zeus.Server/DspPipelineService.cs
@@ -369,17 +369,36 @@ public class DspPipelineService : BackgroundService
         }
         if (s.PsEnabled != _appliedPsEnabled)
         {
-            engine.SetPsEnabled(s.PsEnabled);
+            // pihpsdr transmitter.c:2467-2473 inverts the order: write the
+            // wire (RxSpec / HighPriority with PS bits set) FIRST, then sleep
+            // 100 ms to let the radio firmware spin up DDC0/DDC1 sync, then
+            // arm the engine. Without the settle window, the first 5-20
+            // pscc calls receive partial / glitched samples, scheck flags
+            // binfo[6], bs_count climbs to 2, calcc resets to LRESET — and
+            // the loop sometimes thrashes instead of converging.
+            //
+            // Disarm path stays engine-first: drop the engine run flag, then
+            // close the wire, then drain any in-flight paired frames so they
+            // don't arrive after PS has shut down.
+            //
+            // Task.Delay(100).Wait() is acceptable here — OnRadioStateChanged
+            // runs on a state-change handler thread, not the request path.
             // TODO(ps-p1): when P1 PS lands, dispatch to _radio.ActiveClient
             // here too (the P1 client gains a SetPuresignal(bool) sibling
             // — see hermes.md item 4b). Today the P1 ActiveClient receives
             // no PS bit and the frontend gates the PS toggle off on P1.
-            _p2Client?.SetPsFeedbackEnabled(s.PsEnabled);
-            // Drain stale frames if we just disarmed: the radio will keep
-            // sending paired packets in flight for a few ms after we drop
-            // the bit on the wire, and stalled frames in the pump channel
-            // would arrive at the engine after PS shut down.
-            if (!s.PsEnabled) DrainPsFeedback();
+            if (s.PsEnabled)
+            {
+                _p2Client?.SetPsFeedbackEnabled(true);
+                try { Task.Delay(100).Wait(); } catch { /* ignore */ }
+                engine.SetPsEnabled(true);
+            }
+            else
+            {
+                engine.SetPsEnabled(false);
+                _p2Client?.SetPsFeedbackEnabled(false);
+                DrainPsFeedback();
+            }
             _appliedPsEnabled = s.PsEnabled;
         }
         if (s.PsFeedbackSource != _appliedPsFeedbackSource)

--- a/Zeus.Server/Program.cs
+++ b/Zeus.Server/Program.cs
@@ -539,7 +539,7 @@ app.MapPost("/api/tx/tune-drive", (TuneDriveSetRequest req, RadioService r) =>
 
 // Two-tone test generator (TXA PostGen mode=1). Protocol-agnostic — works
 // on both P1 and P2 because it only touches WDSP TXA, not the wire format.
-app.MapPost("/api/tx/twotone", (TwoToneSetRequest req, RadioService r) =>
+app.MapPost("/api/tx/twotone", (TwoToneSetRequest req, RadioService r, TxService tx) =>
 {
     log.LogInformation(
         "api.tx.twotone enabled={On} f1={F1} f2={F2} mag={Mag}",
@@ -550,7 +550,13 @@ app.MapPost("/api/tx/twotone", (TwoToneSetRequest req, RadioService r) =>
         return Results.BadRequest(new { error = "freq1 must be 50..5000 Hz" });
     if (req.Freq2 is double f2 && (f2 < 50.0 || f2 > 5000.0 || double.IsNaN(f2)))
         return Results.BadRequest(new { error = "freq2 must be 50..5000 Hz" });
-    return Results.Ok(r.SetTwoTone(req));
+    var snap = r.SetTwoTone(req);
+    // Latch into TxService so TxTuneDriver pumps WDSP fexchange2 while
+    // TwoTone is armed even when the mic ingest pump is idle (no MOX/no
+    // mic uplink). Without this latch, PostGen mode=1 has nothing to
+    // shove its excitation into and the radio sees zero IQ.
+    tx.SetTwoToneOn(req.Enabled);
+    return Results.Ok(snap);
 });
 
 // PureSignal master arm + cal-mode. P1 is gated off in the frontend in v1

--- a/Zeus.Server/Program.cs
+++ b/Zeus.Server/Program.cs
@@ -118,6 +118,11 @@ builder.Services.AddHostedService(sp => sp.GetRequiredService<TxMetersService>()
 // TxTuneDriver pumps silent mic blocks through WDSP TXA while TUN is on so
 // the post-gen tone actually reaches the ring (no mic uplink during TUN).
 builder.Services.AddHostedService<TxTuneDriver>();
+// PS auto-attenuate timer2code-equivalent: ramps the radio's TX step
+// attenuator (Protocol2 only today) when calcc feedback level lands outside
+// the 128..181 ideal window, so PS has a recovery path on first arm. Idle
+// when PS is off or AutoAttenuate is off — no wire, no engine pokes.
+builder.Services.AddHostedService<PsAutoAttenuateService>();
 
 // QRZ.com XML client. HttpClient default timeout is 100 s — cap at 10 s so a
 // hung login surfaces quickly in the UI.

--- a/Zeus.Server/Program.cs
+++ b/Zeus.Server/Program.cs
@@ -586,6 +586,17 @@ app.MapPost("/api/tx/ps/advanced", (PsAdvancedSetRequest req, RadioService r) =>
     return Results.Ok(r.SetPsAdvanced(req));
 });
 
+// PS feedback antenna selector. Internal coupler vs External (Bypass).
+// On G2/MkII this flips ALEX_RX_ANTENNA_BYPASS in alex0 during xmit + PS
+// armed. WDSP cal/iqc are unaffected — same DDC0/DDC1 paired feed either
+// way; only the radio routes a different physical signal into DDC0.
+app.MapPost("/api/tx/ps/feedback-source",
+    (PsFeedbackSourceSetRequest req, RadioService r) =>
+{
+    log.LogInformation("api.tx.ps.feedbackSource source={Source}", req.Source);
+    return Results.Ok(r.SetPsFeedbackSource(req));
+});
+
 app.MapPost("/api/tx/ps/reset", (DspPipelineService pipe) =>
 {
     log.LogInformation("api.tx.ps.reset");

--- a/Zeus.Server/Program.cs
+++ b/Zeus.Server/Program.cs
@@ -550,13 +550,13 @@ app.MapPost("/api/tx/twotone", (TwoToneSetRequest req, RadioService r, TxService
         return Results.BadRequest(new { error = "freq1 must be 50..5000 Hz" });
     if (req.Freq2 is double f2 && (f2 < 50.0 || f2 > 5000.0 || double.IsNaN(f2)))
         return Results.BadRequest(new { error = "freq2 must be 50..5000 Hz" });
-    var snap = r.SetTwoTone(req);
-    // Latch into TxService so TxTuneDriver pumps WDSP fexchange2 while
-    // TwoTone is armed even when the mic ingest pump is idle (no MOX/no
-    // mic uplink). Without this latch, PostGen mode=1 has nothing to
-    // shove its excitation into and the radio sees zero IQ.
-    tx.SetTwoToneOn(req.Enabled);
-    return Results.Ok(snap);
+    // TrySetTwoTone owns both the engine state (RadioService.SetTwoTone) and
+    // the MOX side-effect — Thetis parity, setup.cs:11162-11165. Returns the
+    // post-mutate snapshot via Snapshot(); on a connect-interlock failure
+    // the request is rejected with 400.
+    if (!tx.TrySetTwoTone(req, out var err))
+        return Results.BadRequest(new { error = err });
+    return Results.Ok(r.Snapshot());
 });
 
 // PureSignal master arm + cal-mode. P1 is gated off in the frontend in v1

--- a/Zeus.Server/Program.cs
+++ b/Zeus.Server/Program.cs
@@ -128,6 +128,7 @@ builder.Services.AddSingleton<LayoutStore>();
 builder.Services.AddSingleton<DspSettingsStore>();
 builder.Services.AddSingleton<PaSettingsStore>();
 builder.Services.AddSingleton<PreferredRadioStore>();
+builder.Services.AddSingleton<PsSettingsStore>();
 builder.Services.AddSingleton<FilterPresetStore>();
 builder.Services.AddSingleton<QrzService>();
 builder.Services.AddSingleton<LogService>();
@@ -534,6 +535,74 @@ app.MapPost("/api/tx/tune-drive", (TuneDriveSetRequest req, RadioService r) =>
         return Results.BadRequest(new { error = "percent must be 0..100" });
     r.SetTuneDrive(req.Percent);
     return Results.Ok(new { tunePercent = req.Percent });
+});
+
+// Two-tone test generator (TXA PostGen mode=1). Protocol-agnostic — works
+// on both P1 and P2 because it only touches WDSP TXA, not the wire format.
+app.MapPost("/api/tx/twotone", (TwoToneSetRequest req, RadioService r) =>
+{
+    log.LogInformation(
+        "api.tx.twotone enabled={On} f1={F1} f2={F2} mag={Mag}",
+        req.Enabled, req.Freq1, req.Freq2, req.Mag);
+    if (req.Mag is double m && (m < 0.0 || m > 1.0 || double.IsNaN(m)))
+        return Results.BadRequest(new { error = "mag must be 0..1" });
+    if (req.Freq1 is double f1 && (f1 < 50.0 || f1 > 5000.0 || double.IsNaN(f1)))
+        return Results.BadRequest(new { error = "freq1 must be 50..5000 Hz" });
+    if (req.Freq2 is double f2 && (f2 < 50.0 || f2 > 5000.0 || double.IsNaN(f2)))
+        return Results.BadRequest(new { error = "freq2 must be 50..5000 Hz" });
+    return Results.Ok(r.SetTwoTone(req));
+});
+
+// PureSignal master arm + cal-mode. P1 is gated off in the frontend in v1
+// because the Protocol1Client wire-format work for PS isn't done yet, but
+// the server endpoint stays open — RadioService.SetPs sets the StateDto bit
+// and the engine receives SetPsEnabled either way; only the radio-side
+// feedback path is P2-only. See hermes.md / TODO(ps-p1).
+app.MapPost("/api/tx/ps", (PsControlSetRequest req, RadioService r) =>
+{
+    log.LogInformation(
+        "api.tx.ps enabled={On} auto={Auto} single={Single}",
+        req.Enabled, req.Auto, req.Single);
+    return Results.Ok(r.SetPs(req));
+});
+
+app.MapPost("/api/tx/ps/advanced", (PsAdvancedSetRequest req, RadioService r) =>
+{
+    if (req.HwPeak is double p && (p <= 0.0 || p > 2.0 || double.IsNaN(p)))
+        return Results.BadRequest(new { error = "hwPeak must be in (0, 2]" });
+    if (req.MoxDelaySec is double mox && (mox < 0.0 || mox > 10.0 || double.IsNaN(mox)))
+        return Results.BadRequest(new { error = "moxDelaySec must be 0..10" });
+    if (req.LoopDelaySec is double loop && (loop < 0.0 || loop > 100.0 || double.IsNaN(loop)))
+        return Results.BadRequest(new { error = "loopDelaySec must be 0..100" });
+    if (req.AmpDelayNs is double amp && (amp < 0.0 || amp > 25e6 || double.IsNaN(amp)))
+        return Results.BadRequest(new { error = "ampDelayNs must be 0..25e6" });
+    log.LogInformation("api.tx.ps.advanced");
+    return Results.Ok(r.SetPsAdvanced(req));
+});
+
+app.MapPost("/api/tx/ps/reset", (DspPipelineService pipe) =>
+{
+    log.LogInformation("api.tx.ps.reset");
+    pipe.CurrentEngine?.ResetPs();
+    return Results.Ok(new { reset = true });
+});
+
+app.MapPost("/api/tx/ps/save", (PsSaveRequest req, DspPipelineService pipe) =>
+{
+    if (string.IsNullOrWhiteSpace(req.Filename))
+        return Results.BadRequest(new { error = "filename required" });
+    log.LogInformation("api.tx.ps.save filename={Filename}", req.Filename);
+    pipe.CurrentEngine?.SavePsCorrection(req.Filename);
+    return Results.Ok(new { saved = req.Filename });
+});
+
+app.MapPost("/api/tx/ps/restore", (PsRestoreRequest req, DspPipelineService pipe) =>
+{
+    if (string.IsNullOrWhiteSpace(req.Filename))
+        return Results.BadRequest(new { error = "filename required" });
+    log.LogInformation("api.tx.ps.restore filename={Filename}", req.Filename);
+    pipe.CurrentEngine?.RestorePsCorrection(req.Filename);
+    return Results.Ok(new { restored = req.Filename });
 });
 
 app.MapPost("/api/rx/nr", (NrSetRequest req, RadioService r) =>

--- a/Zeus.Server/PsAutoAttenuateService.cs
+++ b/Zeus.Server/PsAutoAttenuateService.cs
@@ -69,6 +69,22 @@ public sealed class PsAutoAttenuateService : BackgroundService
     private int _currentAttnDb;
     private bool _psWasEnabled;
 
+    // Last-observed info[5] (calcc CalibrationAttempts counter). We only
+    // step the attenuator after calcc finishes a NEW fit — matches Thetis
+    // PSForm.cs:1097-1099 timer2code which gates on
+    // `CalibrationAttemptsChanged`. Stepping on every 100 ms tick instead
+    // makes cm jump mid-fit, scheck flags 0x40, scOK=0, bs_count==2 forces
+    // LRESET, and calcc never converges. Initialize to -1 so the first
+    // observed counter (0 or any value) registers as "new".
+    private int _lastCalibrationAttempts = -1;
+
+    // Rate-limit bucket for diagnostic gate-skip logging. Tick1 runs at 10 Hz;
+    // without rate-limiting a stuck gate would emit 10 lines/sec. 1 s bucket
+    // gives one line per gate-state per second — enough to localise the
+    // failing gate during a 5 s rack key without flooding the log.
+    private long _lastGateLogTickMs;
+    private const long GateLogIntervalMs = 1000;
+
     public PsAutoAttenuateService(
         RadioService radio,
         TxService tx,
@@ -107,6 +123,19 @@ public sealed class PsAutoAttenuateService : BackgroundService
         }
     }
 
+    // Diagnostic — emits one line per second tagging which gate short-
+    // circuited Tick1. Without this the loop is invisible when it returns
+    // early (the only visible signals were `psAutoAttn.armed` and
+    // `psAutoAttn.step`, neither of which fire when a gate fails). Used to
+    // localise the silent-gate symptom on the G2 MkII rack test.
+    private void LogGate(string outcome)
+    {
+        long now = Environment.TickCount64;
+        if (now - _lastGateLogTickMs < GateLogIntervalMs) return;
+        _lastGateLogTickMs = now;
+        _log.LogInformation("psAutoAttn.gate {Outcome}", outcome);
+    }
+
     private void Tick1()
     {
         var s = _radio.Snapshot();
@@ -118,32 +147,48 @@ public sealed class PsAutoAttenuateService : BackgroundService
         if (s.PsEnabled && !_psWasEnabled)
         {
             _currentAttnDb = 0;
+            _lastCalibrationAttempts = -1;
             _log.LogInformation("psAutoAttn.armed reset attn={Db}", _currentAttnDb);
         }
         _psWasEnabled = s.PsEnabled;
 
         // Idle conditions — no telemetry to act on.
-        if (!s.PsEnabled) return;
-        if (!s.PsAutoAttenuate) return;
-        if (!_tx.IsMoxOn && !_tx.IsTwoToneOn) return;
+        if (!s.PsEnabled) { LogGate("skip=PsEnabled-off"); return; }
+        if (!s.PsAutoAttenuate) { LogGate("skip=AutoAttenuate-off"); return; }
+        if (!_tx.IsMoxOn && !_tx.IsTwoToneOn) { LogGate("skip=not-keyed"); return; }
 
         var p2 = _pipe.CurrentP2Client;
-        if (p2 is null) return;     // P1 not yet wired
+        if (p2 is null) { LogGate("skip=p2-null"); return; }
 
         var engine = _pipe.CurrentEngine;
-        if (engine is null) return;
+        if (engine is null) { LogGate("skip=engine-null"); return; }
 
         var psm = engine.GetPsStageMeters();
         int feedback = (int)Math.Round(psm.FeedbackLevel);
 
+        // Thetis-canonical CalibrationAttemptsChanged gate (PSForm.cs:
+        // 1097-1099). info[5] increments on every completed calc(). We
+        // only step the attenuator after a NEW fit, otherwise the loop
+        // changes the envelope mid-fit, cm coefficients jump, scheck
+        // flags 0x40 (cm changed too much), scOK=0, bs_count==2 forces
+        // LRESET, and the state machine spins without ever converging.
+        // First-tick guard: only skip when we have an old value to
+        // compare against AND the counter hasn't moved.
+        if (_lastCalibrationAttempts >= 0 && psm.CalibrationAttempts == _lastCalibrationAttempts)
+        {
+            LogGate($"skip=no-new-calc info5={psm.CalibrationAttempts} fb={feedback}");
+            return;
+        }
+        _lastCalibrationAttempts = psm.CalibrationAttempts;
+
         // info[4] = 0 means calcc hasn't completed a fit yet (state machine
         // is still pre-LCALC). No reading to act on.
-        if (feedback <= 0) return;
+        if (feedback <= 0) { LogGate($"skip=fb-zero psm.fb={psm.FeedbackLevel:F2}"); return; }
         // Already in window — nothing to do.
-        if (feedback >= FeedbackLowThreshold && feedback <= FeedbackHighThreshold) return;
+        if (feedback >= FeedbackLowThreshold && feedback <= FeedbackHighThreshold) { LogGate($"skip=in-window fb={feedback}"); return; }
         // Too quiet AND we're already at zero attenuation — operator must
         // raise drive (Thetis behaviour: timer2code falls through silently).
-        if (feedback < FeedbackLowThreshold && _currentAttnDb <= TxAttnMinDb) return;
+        if (feedback < FeedbackLowThreshold && _currentAttnDb <= TxAttnMinDb) { LogGate($"skip=too-quiet-at-zero fb={feedback}"); return; }
 
         // Compute target step. Thetis PSForm.cs:745:
         //     ddB = 20 * log10(feedback / 152.293)
@@ -157,8 +202,8 @@ public sealed class PsAutoAttenuateService : BackgroundService
         if (newAttn == _currentAttnDb) return;
 
         _log.LogInformation(
-            "psAutoAttn.step feedback={Fb} ddB={DDb:F1} attn {Old}->{New} dB",
-            feedback, ddB, _currentAttnDb, newAttn);
+            "psAutoAttn.step feedback={Fb} info5={Cal} ddB={DDb:F1} attn {Old}->{New} dB",
+            feedback, psm.CalibrationAttempts, ddB, _currentAttnDb, newAttn);
 
         _currentAttnDb = newAttn;
         p2.SetTxAttenuationDb((byte)newAttn);

--- a/Zeus.Server/PsAutoAttenuateService.cs
+++ b/Zeus.Server/PsAutoAttenuateService.cs
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.Server;
+
+/// <summary>
+/// PureSignal AutoAttenuate loop. Polls the calcc feedback level (info[4]) at
+/// 10 Hz while PS is armed and the operator has AutoAttenuate on; if the level
+/// lands outside the [128, 181] ideal window calcc rejects every fit
+/// (binfo[6] != 0 → scOK=0 → bs_count==2 → LRESET → loop), so PS never
+/// converges. The loop adjusts the radio's TX step attenuator to bring
+/// feedback into the window.
+///
+/// Mirrors Thetis <c>PSForm.cs:728-784</c> timer2code and the
+/// <c>PSForm.cs:1109-1112</c> NeedToRecalibrate threshold:
+///   • feedback &gt; 181  → too hot → attenuate more (delta &gt; 0).
+///   • feedback ≤ 128 AND current att &gt; 0 → too quiet → attenuate less.
+/// Step size is <c>20 * log10(feedback / 152.293)</c> dB clamped to ±1 per
+/// tick (1 dB/100 ms — matches Thetis feel; converges within a couple of
+/// seconds without overshooting). After every attenuator change we issue a
+/// SetPSControl(reset=1) so calcc retries with the new feedback level.
+///
+/// Hard-gated on a P2 connection (TX step attenuator wire support landed in
+/// <see cref="Zeus.Protocol2.Protocol2Client.SetTxAttenuationDb"/>; the P1
+/// path hasn't been wired yet). Idle when PS is off, AutoAttenuate is off, or
+/// the radio isn't keyed — no broadcast, no engine pokes.
+/// </summary>
+public sealed class PsAutoAttenuateService : BackgroundService
+{
+    // Thetis ideal feedback target: 152.293 (PSForm.cs:745). Window 128..181
+    // matches the lblPSInfoFB green-LED thresholds (PSForm.cs:1123-1138).
+    private const double IdealFeedback = 152.293;
+    private const int FeedbackLowThreshold = 128;
+    private const int FeedbackHighThreshold = 181;
+
+    // 10 Hz tick. Same cadence Thetis runs timer2code at when PS is armed and
+    // the form has focus (PSForm.cs:204-209, m_bQuckAttenuate=false default).
+    private static readonly TimeSpan Tick = TimeSpan.FromMilliseconds(100);
+
+    // Hardware bounds for the TX step attenuator (Thetis network.c:1238-1242
+    // writes a single byte 0..31 dB per ADC tap).
+    private const int TxAttnMinDb = 0;
+    private const int TxAttnMaxDb = 31;
+
+    // Settle time after a step change: give the radio one wire-cycle to pick
+    // up the new attenuator, then issue the reset so calcc starts fresh.
+    private static readonly TimeSpan PostStepSettle = TimeSpan.FromMilliseconds(100);
+
+    private readonly RadioService _radio;
+    private readonly TxService _tx;
+    private readonly DspPipelineService _pipe;
+    private readonly ILogger<PsAutoAttenuateService> _log;
+
+    // Mirrored attenuator value — server-of-truth for what we last asked the
+    // radio to apply. Reset to 0 on every fresh PS arm (PsEnabled false→true)
+    // so a new operator session starts from the radio's untouched baseline.
+    private int _currentAttnDb;
+    private bool _psWasEnabled;
+
+    public PsAutoAttenuateService(
+        RadioService radio,
+        TxService tx,
+        DspPipelineService pipe,
+        ILogger<PsAutoAttenuateService> log)
+    {
+        _radio = radio;
+        _tx = tx;
+        _pipe = pipe;
+        _log = log;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _log.LogInformation("psAutoAttn.start");
+        try
+        {
+            using var timer = new PeriodicTimer(Tick);
+            while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false))
+            {
+                try
+                {
+                    Tick1();
+                }
+                catch (Exception ex)
+                {
+                    // Swallow — the loop must keep running so a transient
+                    // engine race doesn't permanently disable auto-attn.
+                    _log.LogWarning(ex, "psAutoAttn.tick failed");
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal shutdown.
+        }
+    }
+
+    private void Tick1()
+    {
+        var s = _radio.Snapshot();
+
+        // PS-arm edge: re-baseline _currentAttnDb on every false→true so a
+        // fresh arm starts at the radio's untouched 0 dB. The actual radio
+        // state may differ if the operator manually changed step-att between
+        // sessions; assume the radio holds 0 between arms (matches pihpsdr).
+        if (s.PsEnabled && !_psWasEnabled)
+        {
+            _currentAttnDb = 0;
+            _log.LogInformation("psAutoAttn.armed reset attn={Db}", _currentAttnDb);
+        }
+        _psWasEnabled = s.PsEnabled;
+
+        // Idle conditions — no telemetry to act on.
+        if (!s.PsEnabled) return;
+        if (!s.PsAutoAttenuate) return;
+        if (!_tx.IsMoxOn && !_tx.IsTwoToneOn) return;
+
+        var p2 = _pipe.CurrentP2Client;
+        if (p2 is null) return;     // P1 not yet wired
+
+        var engine = _pipe.CurrentEngine;
+        if (engine is null) return;
+
+        var psm = engine.GetPsStageMeters();
+        int feedback = (int)Math.Round(psm.FeedbackLevel);
+
+        // info[4] = 0 means calcc hasn't completed a fit yet (state machine
+        // is still pre-LCALC). No reading to act on.
+        if (feedback <= 0) return;
+        // Already in window — nothing to do.
+        if (feedback >= FeedbackLowThreshold && feedback <= FeedbackHighThreshold) return;
+        // Too quiet AND we're already at zero attenuation — operator must
+        // raise drive (Thetis behaviour: timer2code falls through silently).
+        if (feedback < FeedbackLowThreshold && _currentAttnDb <= TxAttnMinDb) return;
+
+        // Compute target step. Thetis PSForm.cs:745:
+        //     ddB = 20 * log10(feedback / 152.293)
+        // Sign convention matches: feedback > 152 → ddB > 0 → attenuate more.
+        double ddB = 20.0 * Math.Log10(feedback / IdealFeedback);
+        // Clamp to ±1 dB per tick — matches Thetis timer2code feel and
+        // prevents overshoot when feedback briefly spikes (e.g. SSB envelope
+        // transient at a syllable).
+        int step = ddB > 0 ? 1 : -1;
+        int newAttn = Math.Clamp(_currentAttnDb + step, TxAttnMinDb, TxAttnMaxDb);
+        if (newAttn == _currentAttnDb) return;
+
+        _log.LogInformation(
+            "psAutoAttn.step feedback={Fb} ddB={DDb:F1} attn {Old}->{New} dB",
+            feedback, ddB, _currentAttnDb, newAttn);
+
+        _currentAttnDb = newAttn;
+        p2.SetTxAttenuationDb((byte)newAttn);
+
+        // Brief settle so the radio applies the new step-att before calcc
+        // rebuilds. Then reset state machine so the next pscc starts fresh
+        // with the new feedback envelope (Thetis PSForm.cs:760-764 pattern:
+        // SetPSControl(reset=1) then re-arm).
+        try { Task.Delay(PostStepSettle).Wait(); } catch { /* ignore */ }
+        engine.ResetPs();
+    }
+}

--- a/Zeus.Server/PsSettingsStore.cs
+++ b/Zeus.Server/PsSettingsStore.cs
@@ -33,10 +33,10 @@ public sealed class PsSettingsStore : IDisposable
     private readonly ILiteCollection<PsSettingsEntry> _entries;
     private readonly ILogger<PsSettingsStore> _log;
 
-    public PsSettingsStore(ILogger<PsSettingsStore> log)
+    public PsSettingsStore(ILogger<PsSettingsStore> log, string? dbPathOverride = null)
     {
         _log = log;
-        var dbPath = GetDatabasePath();
+        var dbPath = dbPathOverride ?? GetDatabasePath();
 
         var dir = Path.GetDirectoryName(dbPath);
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))

--- a/Zeus.Server/PsSettingsStore.cs
+++ b/Zeus.Server/PsSettingsStore.cs
@@ -14,6 +14,7 @@
 // statement and per-component attribution.
 
 using LiteDB;
+using Zeus.Contracts;
 
 namespace Zeus.Server;
 
@@ -92,5 +93,9 @@ public sealed class PsSettingsEntry
     public double LoopDelaySec { get; set; } = 0.0;
     public double AmpDelayNs { get; set; } = 150.0;
     public string IntsSpiPreset { get; set; } = "16/256";
+    // Feedback antenna source — Internal coupler (default) or External
+    // (Bypass). Persisted so an operator who runs an external sniffer
+    // doesn't have to re-pick it every session.
+    public PsFeedbackSource Source { get; set; } = PsFeedbackSource.Internal;
     public DateTime UpdatedUtc { get; set; }
 }

--- a/Zeus.Server/PsSettingsStore.cs
+++ b/Zeus.Server/PsSettingsStore.cs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using LiteDB;
+
+namespace Zeus.Server;
+
+// PureSignal settings persistence. Stores the operator's calibration tuning
+// (timing delays, ints/spi preset, ptol mode, auto-attenuate) so it survives
+// server restarts. Shares zeus-prefs.db with DspSettingsStore.
+//
+// Deliberately does NOT persist `PsEnabled` (the master arm) or `PsAuto` /
+// `PsSingle` (cal mode) — these reset to safe defaults each session. Same
+// pattern as MOX / TUN: arming PS is an operator action, never an automatic
+// "resume what we did last time" behaviour. PsHwPeak isn't persisted either
+// because RadioService re-derives it per-radio at connect time.
+public sealed class PsSettingsStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<PsSettingsEntry> _entries;
+    private readonly ILogger<PsSettingsStore> _log;
+
+    public PsSettingsStore(ILogger<PsSettingsStore> log)
+    {
+        _log = log;
+        var dbPath = GetDatabasePath();
+
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _entries = _db.GetCollection<PsSettingsEntry>("ps_settings");
+        _entries.EnsureIndex(x => x.ProfileId, unique: true);
+
+        _log.LogInformation("PsSettingsStore initialized at {Path}", dbPath);
+    }
+
+    public PsSettingsEntry? Get(string profileId = "default")
+        => _entries.FindOne(x => x.ProfileId == profileId);
+
+    public void Upsert(PsSettingsEntry entry, string profileId = "default")
+    {
+        entry.ProfileId = profileId;
+        entry.UpdatedUtc = DateTime.UtcNow;
+        var existing = _entries.FindOne(x => x.ProfileId == profileId);
+        if (existing is null)
+        {
+            _entries.Insert(entry);
+        }
+        else
+        {
+            entry.Id = existing.Id;
+            _entries.Update(entry);
+        }
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private static string GetDatabasePath()
+    {
+        var appDataDir = Environment.GetFolderPath(
+            Environment.SpecialFolder.LocalApplicationData,
+            Environment.SpecialFolderOption.Create);
+        return Path.Combine(appDataDir, "Zeus", "zeus-prefs.db");
+    }
+}
+
+public sealed class PsSettingsEntry
+{
+    public int Id { get; set; }
+    public string ProfileId { get; set; } = string.Empty;
+    // Cal-mode default — Auto = continuous adapt. Persisted because operators
+    // who prefer single-shot calibration (and run TwoTone manually) want that
+    // selection to stick across sessions.
+    public bool Auto { get; set; } = true;
+    public bool Ptol { get; set; }
+    public bool AutoAttenuate { get; set; } = true;
+    public double MoxDelaySec { get; set; } = 0.2;
+    public double LoopDelaySec { get; set; } = 0.0;
+    public double AmpDelayNs { get; set; } = 150.0;
+    public string IntsSpiPreset { get; set; } = "16/256";
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server/PsSettingsStore.cs
+++ b/Zeus.Server/PsSettingsStore.cs
@@ -97,5 +97,14 @@ public sealed class PsSettingsEntry
     // (Bypass). Persisted so an operator who runs an external sniffer
     // doesn't have to re-pick it every session.
     public PsFeedbackSource Source { get; set; } = PsFeedbackSource.Internal;
+    // Two-tone test generator settings. Persisted so an operator who has
+    // dialled in custom IMD test tones (e.g. for a specific filter response
+    // or PA test) doesn't have to re-enter them every session. PsEnabled and
+    // TwoToneEnabled are intentionally NOT persisted — same operator-action
+    // discipline as MOX/TUN — but the dialled-in freqs/mag are.
+    // Defaults match tx-store.ts (700/1900/0.49) and pihpsdr.
+    public double TwoToneFreq1 { get; set; } = 700.0;
+    public double TwoToneFreq2 { get; set; } = 1900.0;
+    public double TwoToneMag { get; set; } = 0.49;
     public DateTime UpdatedUtc { get; set; }
 }

--- a/Zeus.Server/RadioService.cs
+++ b/Zeus.Server/RadioService.cs
@@ -186,6 +186,7 @@ public sealed class RadioService : IDisposable
             PsMoxDelaySec: ps?.MoxDelaySec ?? 0.2,
             PsLoopDelaySec: ps?.LoopDelaySec ?? 0.0,
             PsAmpDelayNs: ps?.AmpDelayNs ?? 150.0,
+            PsFeedbackSource: ps?.Source ?? PsFeedbackSource.Internal,
             PsIntsSpiPreset: ps?.IntsSpiPreset ?? "16/256");
     }
 
@@ -738,6 +739,34 @@ public sealed class RadioService : IDisposable
             LoopDelaySec = snap.PsLoopDelaySec,
             AmpDelayNs = snap.PsAmpDelayNs,
             IntsSpiPreset = snap.PsIntsSpiPreset,
+            Source = snap.PsFeedbackSource,
+        });
+        return snap;
+    }
+
+    /// <summary>
+    /// Choose Internal vs External feedback antenna for PureSignal.
+    /// Mutates StateDto; DspPipelineService.OnRadioStateChanged forwards
+    /// the bool into the active Protocol2Client where it flips one alex0
+    /// bit on the next CmdHighPriority. WDSP cal/iqc are unaffected — the
+    /// HW-Peak slider stays shared across sources (matches pihpsdr/Thetis).
+    /// </summary>
+    public StateDto SetPsFeedbackSource(PsFeedbackSourceSetRequest req)
+    {
+        ArgumentNullException.ThrowIfNull(req);
+        Mutate(s => s with { PsFeedbackSource = req.Source });
+        var snap = Snapshot();
+        // Persist alongside the other PS tuning so it survives a restart.
+        _psStore?.Upsert(new PsSettingsEntry
+        {
+            Auto = snap.PsAuto,
+            Ptol = snap.PsPtol,
+            AutoAttenuate = snap.PsAutoAttenuate,
+            MoxDelaySec = snap.PsMoxDelaySec,
+            LoopDelaySec = snap.PsLoopDelaySec,
+            AmpDelayNs = snap.PsAmpDelayNs,
+            IntsSpiPreset = snap.PsIntsSpiPreset,
+            Source = snap.PsFeedbackSource,
         });
         return snap;
     }

--- a/Zeus.Server/RadioService.cs
+++ b/Zeus.Server/RadioService.cs
@@ -54,6 +54,7 @@ public sealed class RadioService : IDisposable
     private readonly DspSettingsStore _dspSettingsStore;
     private readonly PaSettingsStore _paStore;
     private readonly PreferredRadioStore? _preferredRadioStore;
+    private readonly PsSettingsStore? _psStore;
     private readonly FilterPresetStore? _filterPresetStore;
     // Last-known preset name per mode, preserved across mode switches.
     // Accessed only from inside Mutate (under _sync) or at init.
@@ -128,13 +129,14 @@ public sealed class RadioService : IDisposable
     // to its internal test-tone generator (dev / tests without a hub).
     private readonly Zeus.Protocol1.ITxIqSource? _txIqSource;
 
-    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, FilterPresetStore? filterPresetStore = null, Zeus.Protocol1.ITxIqSource? txIqSource = null, PreferredRadioStore? preferredRadioStore = null)
+    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, FilterPresetStore? filterPresetStore = null, Zeus.Protocol1.ITxIqSource? txIqSource = null, PreferredRadioStore? preferredRadioStore = null, PsSettingsStore? psStore = null)
     {
         _loggerFactory = loggerFactory;
         _log = loggerFactory.CreateLogger<RadioService>();
         _dspSettingsStore = dspSettingsStore;
         _paStore = paStore;
         _preferredRadioStore = preferredRadioStore;
+        _psStore = psStore;
         _filterPresetStore = filterPresetStore;
         _paStore.Changed += RecomputePaAndPush;
         if (_preferredRadioStore is not null)
@@ -151,6 +153,12 @@ public sealed class RadioService : IDisposable
             foreach (RxMode m in Enum.GetValues<RxMode>())
                 _lastPresetPerMode[m] = filterPresetStore.GetLastSelectedPreset(m);
         }
+
+        // Load persisted PS settings — operator's calibration tuning. Master
+        // arm and cal-mode are deliberately NOT persisted (parity with MOX);
+        // only the timing/preset/auto-att tuning is. PsHwPeak is left at the
+        // P1 default; ConnectAsync / ConnectP2Async overrides per-radio.
+        var ps = _psStore?.Get();
 
         _state = new(
             Status: ConnectionStatus.Disconnected,
@@ -169,7 +177,16 @@ public sealed class RadioService : IDisposable
             AdcOverloadWarning: false,
             // Zeus default filter (150/2850) maps to the seeded USB VAR1 slot.
             FilterPresetName: "VAR1",
-            FilterAdvancedPaneOpen: filterPresetStore?.GetAdvancedPaneOpen() ?? false);
+            FilterAdvancedPaneOpen: filterPresetStore?.GetAdvancedPaneOpen() ?? false,
+            // PS persisted fields (or DTO defaults when not persisted yet).
+            // PsEnabled NOT persisted — always starts off each session.
+            PsAuto: ps?.Auto ?? true,
+            PsPtol: ps?.Ptol ?? false,
+            PsAutoAttenuate: ps?.AutoAttenuate ?? true,
+            PsMoxDelaySec: ps?.MoxDelaySec ?? 0.2,
+            PsLoopDelaySec: ps?.LoopDelaySec ?? 0.0,
+            PsAmpDelayNs: ps?.AmpDelayNs ?? 150.0,
+            PsIntsSpiPreset: ps?.IntsSpiPreset ?? "16/256");
     }
 
     // Ribbon-visibility setter — frontend toggles via REST, server broadcasts
@@ -679,6 +696,117 @@ public sealed class RadioService : IDisposable
         _dspSettingsStore.Upsert(cfg);
 
         return Snapshot();
+    }
+
+    // ---------------- PureSignal ----------------
+    // SetPs flips master arm and cal-mode in a single mutate so the engine
+    // sees a consistent state when DspPipelineService.OnRadioStateChanged
+    // fires.
+    public StateDto SetPs(PsControlSetRequest req)
+    {
+        ArgumentNullException.ThrowIfNull(req);
+        Mutate(s => s with
+        {
+            PsEnabled = req.Enabled,
+            PsAuto = req.Auto,
+            PsSingle = req.Single,
+        });
+        return Snapshot();
+    }
+
+    public StateDto SetPsAdvanced(PsAdvancedSetRequest req)
+    {
+        ArgumentNullException.ThrowIfNull(req);
+        Mutate(s => s with
+        {
+            PsPtol = req.Ptol ?? s.PsPtol,
+            PsAutoAttenuate = req.AutoAttenuate ?? s.PsAutoAttenuate,
+            PsMoxDelaySec = req.MoxDelaySec ?? s.PsMoxDelaySec,
+            PsLoopDelaySec = req.LoopDelaySec ?? s.PsLoopDelaySec,
+            PsAmpDelayNs = req.AmpDelayNs ?? s.PsAmpDelayNs,
+            PsHwPeak = req.HwPeak ?? s.PsHwPeak,
+            PsIntsSpiPreset = req.IntsSpiPreset ?? s.PsIntsSpiPreset,
+        });
+        // Persist the new tuning.
+        var snap = Snapshot();
+        _psStore?.Upsert(new PsSettingsEntry
+        {
+            Auto = snap.PsAuto,
+            Ptol = snap.PsPtol,
+            AutoAttenuate = snap.PsAutoAttenuate,
+            MoxDelaySec = snap.PsMoxDelaySec,
+            LoopDelaySec = snap.PsLoopDelaySec,
+            AmpDelayNs = snap.PsAmpDelayNs,
+            IntsSpiPreset = snap.PsIntsSpiPreset,
+        });
+        return snap;
+    }
+
+    public StateDto SetTwoTone(TwoToneSetRequest req)
+    {
+        ArgumentNullException.ThrowIfNull(req);
+        Mutate(s => s with
+        {
+            TwoToneEnabled = req.Enabled,
+            TwoToneFreq1 = req.Freq1 ?? s.TwoToneFreq1,
+            TwoToneFreq2 = req.Freq2 ?? s.TwoToneFreq2,
+            TwoToneMag = req.Mag ?? s.TwoToneMag,
+        });
+        return Snapshot();
+    }
+
+    // Update the live state to track PS read-back from the engine. Called by
+    // TxMetersService at 10 Hz while PS is armed.
+    public void UpdatePsLiveReadout(double feedbackLevel, byte calState, bool correcting)
+    {
+        Mutate(s => s with
+        {
+            PsFeedbackLevel = feedbackLevel,
+            PsCalState = calState,
+            PsCorrecting = correcting,
+        });
+    }
+
+    /// <summary>
+    /// Resolves the operator-correct PS hardware-peak default for the given
+    /// protocol + board kind. Sources:
+    ///   - P1 Hermes / ANAN-10/100/100D/200D / Hermes-II / 10E / 100B → 0.4072
+    ///   - P2 OrionMkII (G2 / Saturn) → 0.6121
+    ///   - P2 ANAN-7000 / 8000 (default P2) → 0.2899
+    ///   - HermesLite2 (either protocol) → 0.233 (MI0BOT special, but only if
+    ///     someone connects an HL2 — Brian's Hermes is original, not HL2)
+    /// Source authority: Thetis clsHardwareSpecific.cs:295-318 +
+    /// pihpsdr transmitter.c:1166-1179 NEW_DEVICE_SATURN.
+    /// </summary>
+    public static double ResolvePsHwPeak(bool isProtocol2, HpsdrBoardKind board) =>
+        // Per-protocol switch shaped so the P1 follow-up (TODO(ps-p1)) can
+        // wire HW-peak per-board too. P1 today is gated off in the frontend
+        // but the engine still receives the right number on connect — keeps
+        // Synthetic + tests deterministic.
+        (isProtocol2, board) switch
+        {
+            // TODO(ps-p1): P1 path is deferred — only P2 is wired through to
+            // Protocol2Client.SetPsFeedbackEnabled and the feedback pump.
+            (false, HpsdrBoardKind.HermesLite2)              => 0.233,
+            (false, _)                                        => 0.4072,
+            (true,  HpsdrBoardKind.OrionMkII)                 => 0.6121,
+            (true,  HpsdrBoardKind.HermesLite2)               => 0.233,
+            (true,  _)                                        => 0.2899,
+        };
+
+    /// <summary>
+    /// Apply a per-radio PS hardware-peak default to the StateDto. Called by
+    /// DspPipelineService after a successful connect (P1 or P2) so the
+    /// engine sees the correct curve scale before the operator arms PS.
+    /// Doesn't fire StateChanged unless the value actually moves.
+    /// </summary>
+    public void ApplyPsHwPeakForConnection(bool isProtocol2, HpsdrBoardKind board)
+    {
+        double peak = ResolvePsHwPeak(isProtocol2, board);
+        Mutate(s => s.PsHwPeak == peak ? s : s with { PsHwPeak = peak });
+        _log.LogInformation(
+            "radio.applyPsHwPeak proto={Proto} board={Board} peak={Peak:F4}",
+            isProtocol2 ? "P2" : "P1", board, peak);
     }
 
     public StateDto SetZoom(int level)

--- a/Zeus.Server/RadioService.cs
+++ b/Zeus.Server/RadioService.cs
@@ -187,7 +187,42 @@ public sealed class RadioService : IDisposable
             PsLoopDelaySec: ps?.LoopDelaySec ?? 0.0,
             PsAmpDelayNs: ps?.AmpDelayNs ?? 150.0,
             PsFeedbackSource: ps?.Source ?? PsFeedbackSource.Internal,
-            PsIntsSpiPreset: ps?.IntsSpiPreset ?? "16/256");
+            PsIntsSpiPreset: ps?.IntsSpiPreset ?? "16/256",
+            // Two-tone test generator dial-in. Defaults match pihpsdr / Thetis
+            // (700/1900 Hz, 0.49 each — peak ~0.98 just under WDSP IQ clip).
+            TwoToneFreq1: ps?.TwoToneFreq1 ?? 700.0,
+            TwoToneFreq2: ps?.TwoToneFreq2 ?? 1900.0,
+            TwoToneMag: ps?.TwoToneMag ?? 0.49);
+    }
+
+    /// <summary>
+    /// Single-source-of-truth Upsert helper for the PS settings store. Reads
+    /// the current StateDto snapshot and writes the full PsSettingsEntry so
+    /// callers don't drop fields by writing only what they touched. Called
+    /// from SetPs, SetPsAdvanced, SetPsFeedbackSource, and SetTwoTone.
+    ///
+    /// PsEnabled / TwoToneEnabled (master arm flags) and PsHwPeak (per-radio
+    /// derived) are intentionally NOT in the entry — same operator-action
+    /// discipline as MOX/TUN.
+    /// </summary>
+    private void PersistPsState()
+    {
+        if (_psStore is null) return;
+        var snap = Snapshot();
+        _psStore.Upsert(new PsSettingsEntry
+        {
+            Auto = snap.PsAuto,
+            Ptol = snap.PsPtol,
+            AutoAttenuate = snap.PsAutoAttenuate,
+            MoxDelaySec = snap.PsMoxDelaySec,
+            LoopDelaySec = snap.PsLoopDelaySec,
+            AmpDelayNs = snap.PsAmpDelayNs,
+            IntsSpiPreset = snap.PsIntsSpiPreset,
+            Source = snap.PsFeedbackSource,
+            TwoToneFreq1 = snap.TwoToneFreq1,
+            TwoToneFreq2 = snap.TwoToneFreq2,
+            TwoToneMag = snap.TwoToneMag,
+        });
     }
 
     // Ribbon-visibility setter — frontend toggles via REST, server broadcasts
@@ -712,6 +747,10 @@ public sealed class RadioService : IDisposable
             PsAuto = req.Auto,
             PsSingle = req.Single,
         });
+        // Persist Auto/Single change so the operator's cal-mode preference
+        // sticks across restarts. (PsEnabled is the master arm — not
+        // persisted; same discipline as MOX/TUN.)
+        PersistPsState();
         return Snapshot();
     }
 
@@ -728,20 +767,8 @@ public sealed class RadioService : IDisposable
             PsHwPeak = req.HwPeak ?? s.PsHwPeak,
             PsIntsSpiPreset = req.IntsSpiPreset ?? s.PsIntsSpiPreset,
         });
-        // Persist the new tuning.
-        var snap = Snapshot();
-        _psStore?.Upsert(new PsSettingsEntry
-        {
-            Auto = snap.PsAuto,
-            Ptol = snap.PsPtol,
-            AutoAttenuate = snap.PsAutoAttenuate,
-            MoxDelaySec = snap.PsMoxDelaySec,
-            LoopDelaySec = snap.PsLoopDelaySec,
-            AmpDelayNs = snap.PsAmpDelayNs,
-            IntsSpiPreset = snap.PsIntsSpiPreset,
-            Source = snap.PsFeedbackSource,
-        });
-        return snap;
+        PersistPsState();
+        return Snapshot();
     }
 
     /// <summary>
@@ -755,20 +782,8 @@ public sealed class RadioService : IDisposable
     {
         ArgumentNullException.ThrowIfNull(req);
         Mutate(s => s with { PsFeedbackSource = req.Source });
-        var snap = Snapshot();
-        // Persist alongside the other PS tuning so it survives a restart.
-        _psStore?.Upsert(new PsSettingsEntry
-        {
-            Auto = snap.PsAuto,
-            Ptol = snap.PsPtol,
-            AutoAttenuate = snap.PsAutoAttenuate,
-            MoxDelaySec = snap.PsMoxDelaySec,
-            LoopDelaySec = snap.PsLoopDelaySec,
-            AmpDelayNs = snap.PsAmpDelayNs,
-            IntsSpiPreset = snap.PsIntsSpiPreset,
-            Source = snap.PsFeedbackSource,
-        });
-        return snap;
+        PersistPsState();
+        return Snapshot();
     }
 
     public StateDto SetTwoTone(TwoToneSetRequest req)
@@ -781,6 +796,10 @@ public sealed class RadioService : IDisposable
             TwoToneFreq2 = req.Freq2 ?? s.TwoToneFreq2,
             TwoToneMag = req.Mag ?? s.TwoToneMag,
         });
+        // Persist freq1/freq2/mag — operator tunings survive restart.
+        // TwoToneEnabled (master arm) is NOT persisted; same operator-action
+        // discipline as MOX/TUN.
+        PersistPsState();
         return Snapshot();
     }
 

--- a/Zeus.Server/StreamingHub.cs
+++ b/Zeus.Server/StreamingHub.cs
@@ -203,6 +203,25 @@ public sealed class StreamingHub
         }
     }
 
+    public void Broadcast(in PsMetersFrame frame)
+    {
+        if (_clients.IsEmpty) return;
+
+        int total = PsMetersFrame.ByteLength;
+        var rented = ArrayPool<byte>.Shared.Rent(total);
+        try
+        {
+            var writer = new FixedBufferWriter(rented, total);
+            frame.Serialize(writer);
+            var payload = new ReadOnlyMemory<byte>(rented, 0, total).ToArray();
+            foreach (var client in _clients.Values) client.TryEnqueue(payload);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rented);
+        }
+    }
+
     public void Broadcast(in RxMeterFrame frame)
     {
         if (_clients.IsEmpty) return;

--- a/Zeus.Server/TxMetersService.cs
+++ b/Zeus.Server/TxMetersService.cs
@@ -107,6 +107,7 @@ public sealed class TxMetersService : BackgroundService
     private const float PaTempMaxC = 125f;
 
     private readonly StreamingHub _hub;
+    private readonly RadioService _radio;
     private readonly TxService _tx;
     private readonly DspPipelineService _pipe;
     private readonly ILogger<TxMetersService> _log;
@@ -131,6 +132,7 @@ public sealed class TxMetersService : BackgroundService
     public TxMetersService(StreamingHub hub, RadioService radio, TxService tx, DspPipelineService pipe, ILogger<TxMetersService> log)
     {
         _hub = hub;
+        _radio = radio;
         _tx = tx;
         _pipe = pipe;
         _log = log;
@@ -302,6 +304,28 @@ public sealed class TxMetersService : BackgroundService
                 }
 
                 _hub.Broadcast(frame);
+
+                // PureSignal stage meters — broadcast only while PsEnabled is
+                // armed so idle wire stays quiet. The engine returns
+                // `PsStageMeters.Silent` when PS is off, so we double-gate on
+                // both the StateDto bit and the engine view to avoid emitting
+                // a frame between the operator arming PS and the engine
+                // applying it.
+                var snap = _radio.Snapshot();
+                if (snap.PsEnabled && _pipe.CurrentEngine is IDspEngine ps)
+                {
+                    var psm = ps.GetPsStageMeters();
+                    var psFrame = new PsMetersFrame(
+                        FeedbackLevel: psm.FeedbackLevel,
+                        CorrectionDb: psm.CorrectionDb,
+                        CalState: psm.CalState,
+                        Correcting: psm.Correcting,
+                        MaxTxEnvelope: psm.MaxTxEnvelope);
+                    _hub.Broadcast(psFrame);
+                    // Mirror the live read-out into the StateDto so REST/state
+                    // pollers see it too — same pattern PA/Mic meters use.
+                    _radio.UpdatePsLiveReadout(psm.FeedbackLevel, psm.CalState, psm.Correcting);
+                }
 
                 // PA temperature broadcast — 2 Hz always, throttled against
                 // wall-clock so the 10 Hz MOX loop emits it every 5th tick

--- a/Zeus.Server/TxService.cs
+++ b/Zeus.Server/TxService.cs
@@ -148,12 +148,20 @@ public sealed class TxService
             wasTunOn = _tunOn;
             if (req.Enabled)
             {
-                // TwoTone-on preempts MOX and TUN (PRD FR-7 mutual-exclusion);
-                // the test signal owns the TX path while armed.
-                _moxOn = false;
+                // TwoTone-on preempts TUN and OWNS MOX while armed (PRD FR-7
+                // mutual-exclusion + Thetis setup.cs:11162-11165). _moxOn
+                // tracks "TX is keyed", whether by mic-MOX or TwoTone — the
+                // operator's MOX button reflects the same flag, so a TwoTone
+                // arm reads as "transmitting" in the UI.
                 _tunOn = false;
-                _moxStartedAt = null;
                 _tunStartedAt = null;
+                _moxOn = true;
+                _moxStartedAt = DateTime.UtcNow;
+            }
+            else
+            {
+                _moxOn = false;
+                _moxStartedAt = null;
             }
         }
 

--- a/Zeus.Server/TxService.cs
+++ b/Zeus.Server/TxService.cs
@@ -62,6 +62,13 @@ public sealed class TxService
     public bool IsMoxOn { get { lock (_sync) return _moxOn; } }
     public bool IsTunOn { get { lock (_sync) return _tunOn; } }
 
+    // TwoTone latch — independent of MOX/TUN. Set by RadioService.SetTwoTone
+    // on every state mutation. TxTuneDriver polls it so the WDSP TXA pump
+    // runs even when no mic uplink is feeding fexchange2 (PostGen mode=1
+    // injects the two-tone excitation regardless of mic input).
+    public bool IsTwoToneOn { get; private set; }
+    internal void SetTwoToneOn(bool on) { IsTwoToneOn = on; }
+
     public DateTime? MoxStartedAt { get { lock (_sync) return _moxStartedAt; } }
     public DateTime? TunStartedAt { get { lock (_sync) return _tunStartedAt; } }
 

--- a/Zeus.Server/TxService.cs
+++ b/Zeus.Server/TxService.cs
@@ -121,6 +121,74 @@ public sealed class TxService
         return true;
     }
 
+    /// <summary>
+    /// Arm or disarm the TwoTone test generator AND key MOX. Mirrors the Thetis
+    /// chkTestIMD_CheckedChanged path (setup.cs:11162-11165, 11189-11216):
+    /// TwoTone owns the MOX state while armed and unconditionally drops it on
+    /// disarm. This matches the operator expectation "press 2-Tone → radio is
+    /// transmitting two tones" without a separate MOX press.
+    ///
+    /// Order on arm: configure PostGen via RadioService.SetTwoTone (which arms
+    /// xgen mode=1 with the sideband-correct signed freqs from Group A), THEN
+    /// flip MOX on so TXA is alive when the generator starts running. On disarm
+    /// the order is reversed — MOX off first so the radio stops emitting RF
+    /// before the engine drops the generator run flag.
+    /// </summary>
+    public bool TrySetTwoTone(TwoToneSetRequest req, out string? error)
+    {
+        ArgumentNullException.ThrowIfNull(req);
+        // Connect interlock — same as TrySetMox / TrySetTun. No TX of any kind
+        // before the radio is up.
+        if (req.Enabled && !_radio.IsConnected) { error = "not connected"; return false; }
+
+        bool wasMoxOn, wasTunOn;
+        lock (_sync)
+        {
+            wasMoxOn = _moxOn;
+            wasTunOn = _tunOn;
+            if (req.Enabled)
+            {
+                // TwoTone-on preempts MOX and TUN (PRD FR-7 mutual-exclusion);
+                // the test signal owns the TX path while armed.
+                _moxOn = false;
+                _tunOn = false;
+                _moxStartedAt = null;
+                _tunStartedAt = null;
+            }
+        }
+
+        if (req.Enabled)
+        {
+            if (wasTunOn) _pipeline.SetTxTune(false);
+            // Arm PostGen + cache state (signed freqs for USB family, mag,
+            // run=1) BEFORE flipping MOX so TXA pump sees a configured
+            // generator on the very first sample window.
+            _radio.SetTwoTone(req);
+            IsTwoToneOn = true;
+            _pipeline.SetMox(true);
+            _radio.SetMox(true);
+            // Drive recompute for the next half-key — TwoTone is mic-path-free
+            // so any TUN drive % left over should be reset.
+            _radio.NotifyTunActive(false);
+            _log.LogInformation(
+                "tx.twoTone on=true f1={F1} f2={F2} mag={Mag}",
+                req.Freq1, req.Freq2, req.Mag);
+        }
+        else
+        {
+            // Disarm: flip MOX off first so RF stops, then drop the generator
+            // run flag in the engine. Order matches Thetis (setup.cs:11189-11216
+            // — MOX off, then TXPostGenRun=0).
+            IsTwoToneOn = false;
+            _pipeline.SetMox(false);
+            _radio.SetMox(false);
+            _radio.SetTwoTone(req);
+            _log.LogInformation("tx.twoTone on=false");
+        }
+        error = null;
+        return true;
+    }
+
     public bool TrySetTun(bool on, out string? error)
     {
         // Same connect-interlock as MOX: no TX of any kind without a connected

--- a/Zeus.Server/TxTuneDriver.cs
+++ b/Zeus.Server/TxTuneDriver.cs
@@ -43,16 +43,21 @@ using Zeus.Protocol1;
 namespace Zeus.Server;
 
 /// <summary>
-/// Keeps WDSP TXA's sample pump running when TUN is on but the mic uplink
-/// isn't. TUN's post-generator tone lives inside the TXA chain
-/// (<see cref="Zeus.Dsp.Wdsp.WdspDspEngine.SetTxTune"/>), so it only emits
-/// IQ when <c>fexchange2</c> is called at the block rate. During MOX that
-/// call is driven by <see cref="TxAudioIngest"/> as mic frames arrive; during
-/// TUN we have no mic, so this service synthesises silent mic input at the
-/// WDSP block cadence (1024 samples @ 48 kHz ≈ 21 ms).
+/// Keeps WDSP TXA's sample pump running when TUN or TwoTone is armed but
+/// the mic uplink isn't. Both PostGen modes (mode=0 TUN carrier, mode=1
+/// TwoTone) live inside the TXA chain
+/// (<see cref="Zeus.Dsp.Wdsp.WdspDspEngine.SetTxTune"/> /
+/// <see cref="Zeus.Dsp.Wdsp.WdspDspEngine.SetTwoTone"/>), so they only
+/// emit IQ when <c>fexchange2</c> is called at the block rate. During MOX
+/// that call is driven by <see cref="TxAudioIngest"/> as mic frames arrive;
+/// during TUN/TwoTone there's no mic, so this service synthesises silent
+/// mic input at the WDSP block cadence (1024 samples @ 48 kHz ≈ 21 ms).
+/// PostGen overwrites the silent midbuff regardless of mic content, so the
+/// same pump path works for both modes — we just gate on either flag.
 ///
-/// Starts and stops via <see cref="TxService.IsTunOn"/> polling; not worth
-/// building a subscription pattern for a feature that toggles at click rate.
+/// Starts and stops via <see cref="TxService.IsTunOn"/> /
+/// <see cref="TxService.IsTwoToneOn"/> polling; not worth building a
+/// subscription pattern for a feature that toggles at click rate.
 /// </summary>
 internal sealed class TxTuneDriver : BackgroundService
 {
@@ -84,7 +89,7 @@ internal sealed class TxTuneDriver : BackgroundService
         {
             try
             {
-                if (!_tx.IsTunOn)
+                if (!_tx.IsTunOn && !_tx.IsTwoToneOn)
                 {
                     await Task.Delay(PollIdle, ct).ConfigureAwait(false);
                     continue;

--- a/tests/Zeus.Contracts.Tests/PsMetersFrameTests.cs
+++ b/tests/Zeus.Contracts.Tests/PsMetersFrameTests.cs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Buffers;
+using Zeus.Contracts;
+using Xunit;
+
+namespace Zeus.Contracts.Tests;
+
+public class PsMetersFrameTests
+{
+    [Fact]
+    public void RoundTrip_PreservesAllFields()
+    {
+        var frame = new PsMetersFrame(
+            FeedbackLevel: 128.5f,
+            CorrectionDb: -42.3f,
+            CalState: 7,
+            Correcting: true,
+            MaxTxEnvelope: 0.7321f);
+
+        var writer = new ArrayBufferWriter<byte>();
+        frame.Serialize(writer);
+
+        Assert.Equal(PsMetersFrame.ByteLength, writer.WrittenCount);
+        Assert.Equal(15, writer.WrittenCount);
+
+        var decoded = PsMetersFrame.Deserialize(writer.WrittenSpan);
+        Assert.Equal(frame.FeedbackLevel, decoded.FeedbackLevel);
+        Assert.Equal(frame.CorrectionDb, decoded.CorrectionDb);
+        Assert.Equal(frame.CalState, decoded.CalState);
+        Assert.Equal(frame.Correcting, decoded.Correcting);
+        Assert.Equal(frame.MaxTxEnvelope, decoded.MaxTxEnvelope);
+    }
+
+    [Fact]
+    public void Serialize_WritesMsgTypeFirst()
+    {
+        var frame = new PsMetersFrame(0f, 0f, 0, false, 0f);
+        var writer = new ArrayBufferWriter<byte>();
+        frame.Serialize(writer);
+        Assert.Equal((byte)MsgType.PsMeters, writer.WrittenSpan[0]);
+        Assert.Equal(0x18, writer.WrittenSpan[0]);
+    }
+
+    [Fact]
+    public void Deserialize_RejectsWrongMsgType()
+    {
+        var bogus = new byte[PsMetersFrame.ByteLength];
+        bogus[0] = (byte)MsgType.TxMetersV2;
+        Assert.Throws<InvalidDataException>(() => PsMetersFrame.Deserialize(bogus));
+    }
+
+    [Fact]
+    public void Deserialize_RejectsTruncated()
+    {
+        var buf = new byte[PsMetersFrame.ByteLength - 1];
+        buf[0] = (byte)MsgType.PsMeters;
+        Assert.Throws<InvalidDataException>(() => PsMetersFrame.Deserialize(buf));
+    }
+
+    [Fact]
+    public void Correcting_RoundTripsAsBool()
+    {
+        var on = new PsMetersFrame(1f, 1f, 1, true, 1f);
+        var off = new PsMetersFrame(1f, 1f, 1, false, 1f);
+
+        var w1 = new ArrayBufferWriter<byte>();
+        on.Serialize(w1);
+        var w2 = new ArrayBufferWriter<byte>();
+        off.Serialize(w2);
+
+        Assert.True(PsMetersFrame.Deserialize(w1.WrittenSpan).Correcting);
+        Assert.False(PsMetersFrame.Deserialize(w2.WrittenSpan).Correcting);
+    }
+}

--- a/tests/Zeus.Protocol2.Tests/PsWireFormatTests.cs
+++ b/tests/Zeus.Protocol2.Tests/PsWireFormatTests.cs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Xunit;
+
+namespace Zeus.Protocol2.Tests;
+
+/// <summary>
+/// Wire-format tests for PureSignal-armed CmdRx packets. Sourced from
+/// pihpsdr new_protocol.c:1611-1630 + Thetis network.c. The bytes that
+/// must change when PS is armed:
+///   - p[7] |= 0x01           DDC0 enable (alongside existing DDC2)
+///   - p[1363] = 0x02         sync DDC1→DDC0
+///   - p[17]   = 0x00         DDC0 ADC = 0
+///   - p[18..19] = 0x00 0xC0  DDC0 sample rate = 192 kHz BE
+///   - p[22]   = 24           DDC0 bit depth
+///   - p[23]   = numAdc       DDC1 ADC selection
+///   - p[24..25] = 0x00 0xC0  DDC1 sample rate = 192 kHz BE
+///   - p[28]   = 24           DDC1 bit depth
+/// </summary>
+public class PsWireFormatTests
+{
+    [Fact]
+    public void CmdRx_NotArmed_LeavesDdc0AndSyncBitClear()
+    {
+        var p = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 7, numAdc: 2, sampleRateKhz: 192, psEnabled: false);
+
+        Assert.Equal((byte)0x04, p[7]);          // only DDC2 enable bit
+        Assert.Equal((byte)0x00, p[1363]);       // no DDC1→DDC0 sync
+        // DDC0 cfg block stays zeroed.
+        Assert.Equal((byte)0x00, p[17]);
+        Assert.Equal((byte)0x00, p[18]);
+        Assert.Equal((byte)0x00, p[19]);
+        Assert.Equal((byte)0x00, p[22]);
+    }
+
+    [Fact]
+    public void CmdRx_PsArmed_EnablesDdc0AndSyncBit()
+    {
+        var p = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 9, numAdc: 2, sampleRateKhz: 192, psEnabled: true);
+
+        Assert.Equal((byte)0x05, p[7]);          // DDC0 (0x01) | DDC2 (0x04)
+        Assert.Equal((byte)0x02, p[1363]);       // DDC1→DDC0 sync
+    }
+
+    [Fact]
+    public void CmdRx_PsArmed_ConfiguresDdc0_192kHz_24Bit_FromAdc0()
+    {
+        var p = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 1, numAdc: 2, sampleRateKhz: 192, psEnabled: true);
+
+        // DDC0 cfg at offset 17.
+        Assert.Equal((byte)0x00, p[17]);         // ADC0
+        // 192 kHz big-endian = 0x00 0xC0.
+        Assert.Equal((byte)0x00, p[18]);
+        Assert.Equal((byte)0xC0, p[19]);
+        Assert.Equal((byte)24, p[22]);           // 24-bit depth
+    }
+
+    [Fact]
+    public void CmdRx_PsArmed_ConfiguresDdc1_192kHz_24Bit_FromNAdc()
+    {
+        var p = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 1, numAdc: 2, sampleRateKhz: 192, psEnabled: true);
+
+        // DDC1 cfg at offset 23 = 17 + 6.
+        Assert.Equal((byte)2, p[23]);            // ADC = numAdc
+        Assert.Equal((byte)0x00, p[24]);
+        Assert.Equal((byte)0xC0, p[25]);
+        Assert.Equal((byte)24, p[28]);
+    }
+
+    [Fact]
+    public void CmdRx_PreservesDdc2AndSequence()
+    {
+        var p = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 0xDEADBEEF, numAdc: 2, sampleRateKhz: 96, psEnabled: true);
+
+        // Sequence at byte 0 BE.
+        Assert.Equal((byte)0xDE, p[0]);
+        Assert.Equal((byte)0xAD, p[1]);
+        Assert.Equal((byte)0xBE, p[2]);
+        Assert.Equal((byte)0xEF, p[3]);
+        // DDC2 cfg at 17 + 12 = 29.
+        Assert.Equal((byte)0x00, p[29]);
+        Assert.Equal((byte)0x00, p[30]);
+        Assert.Equal((byte)96, p[31]);
+        Assert.Equal((byte)24, p[34]);
+    }
+
+    [Fact]
+    public void AlexPsBit_Is_0x00040000()
+    {
+        // Defensive constant test — pihpsdr new_protocol.c:994-998 says
+        // ALEX_PS_BIT = 0x00040000. If we change it Brian's G2 stops
+        // engaging the feedback-coupler tap.
+        Assert.Equal(0x00040000u, Protocol2Client.AlexPsBit);
+    }
+}

--- a/tests/Zeus.Protocol2.Tests/PsWireFormatTests.cs
+++ b/tests/Zeus.Protocol2.Tests/PsWireFormatTests.cs
@@ -110,4 +110,118 @@ public class PsWireFormatTests
         // engaging the feedback-coupler tap.
         Assert.Equal(0x00040000u, Protocol2Client.AlexPsBit);
     }
+
+    [Fact]
+    public void AlexRxAntennaBypass_Is_0x00000800()
+    {
+        // pihpsdr new_protocol.c:1284-1296. Wrong value silently breaks
+        // the External feedback path.
+        Assert.Equal(0x00000800u, Protocol2Client.AlexRxAntennaBypass);
+    }
+
+    // ---- DDC0/DDC1 destination assignment (round-1 swap regression) ----
+
+    [Fact]
+    public void DecodePsPair_Ddc0BytesLandInRx_Ddc1BytesLandInTx()
+    {
+        // Synthesize a sample-pair with distinct, identifiable patterns
+        // for DDC0 vs DDC1 so a swap bug shows up immediately.
+        // DDC0 = +1.0 in I, +0.5 in Q (max-positive pattern)
+        // DDC1 = -1.0 in I, -0.5 in Q (max-negative pattern)
+        // 24-bit signed: 0x7FFFFF =  8388607, 0x800000 = -8388608.
+        // We use 0x400000 (≈+0.5) and 0xC00000 (≈-0.5) for the Q values.
+        var pair = new byte[12]
+        {
+            // DDC0 I = 0x7FFFFF
+            0x7F, 0xFF, 0xFF,
+            // DDC0 Q = 0x400000
+            0x40, 0x00, 0x00,
+            // DDC1 I = 0x800000
+            0x80, 0x00, 0x00,
+            // DDC1 Q = 0xC00000
+            0xC0, 0x00, 0x00,
+        };
+
+        var (rxI, rxQ, txI, txQ) = Protocol2Client.DecodePsPairForTest(pair);
+
+        // DDC0 → rx side, DDC1 → tx side. If this assertion ever flips,
+        // PS will arm but never correct (round-1 bug).
+        Assert.True(rxI > 0.99f, $"rxI from DDC0 should be ~+1.0, got {rxI}");
+        Assert.True(rxQ > 0.49f && rxQ < 0.51f, $"rxQ from DDC0 should be ~+0.5, got {rxQ}");
+        Assert.True(txI < -0.99f, $"txI from DDC1 should be ~-1.0, got {txI}");
+        Assert.True(txQ < -0.49f && txQ > -0.51f, $"txQ from DDC1 should be ~-0.5, got {txQ}");
+    }
+
+    // ---- ALEX bypass bit (External feedback antenna) ----
+
+    [Fact]
+    public void Alex0_BypassBit_SetWhenExternal_PsArmed_AndMox()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: 14_200_000,
+            moxOn: true,
+            psEnabled: true,
+            psExternal: true);
+
+        Assert.True((alex0 & Protocol2Client.AlexRxAntennaBypass) != 0,
+            "Bypass bit must be set when PS armed && External && MOX.");
+    }
+
+    [Fact]
+    public void Alex0_BypassBit_ClearWhenInternal()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: 14_200_000,
+            moxOn: true,
+            psEnabled: true,
+            psExternal: false);
+
+        Assert.True((alex0 & Protocol2Client.AlexRxAntennaBypass) == 0,
+            "Bypass bit must stay clear in Internal-coupler mode.");
+        // Sanity: PS bit is still set during MOX.
+        Assert.True((alex0 & Protocol2Client.AlexPsBit) != 0,
+            "PS bit should still be set on alex0 during xmit + PS armed.");
+    }
+
+    [Fact]
+    public void Alex0_BypassBit_ClearWhenMoxOff()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: 14_200_000,
+            moxOn: false,
+            psEnabled: true,
+            psExternal: true);
+
+        Assert.True((alex0 & Protocol2Client.AlexRxAntennaBypass) == 0,
+            "Bypass bit must not flip on alex0 outside xmit (matches pihpsdr).");
+    }
+
+    [Fact]
+    public void Alex0_BypassBit_ClearWhenPsDisarmed()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: 14_200_000,
+            moxOn: true,
+            psEnabled: false,
+            psExternal: true);
+
+        Assert.True((alex0 & Protocol2Client.AlexRxAntennaBypass) == 0,
+            "Bypass bit must not flip when PS isn't armed even if External is selected.");
+    }
+
+    // ---- RxSpecific buffer parity between Internal and External ----
+
+    [Fact]
+    public void CmdRx_BytesAreIdentical_BetweenInternalAndExternal()
+    {
+        // The RxSpecific buffer doesn't take a 'feedback source' input
+        // (only psEnabled) — verify it stays that way so a future change
+        // doesn't accidentally start emitting different bytes per source.
+        var p1 = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 1, numAdc: 2, sampleRateKhz: 192, psEnabled: true);
+        var p2 = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 1, numAdc: 2, sampleRateKhz: 192, psEnabled: true);
+
+        Assert.Equal(p1, p2);
+    }
 }

--- a/tests/Zeus.Protocol2.Tests/PsWireFormatTests.cs
+++ b/tests/Zeus.Protocol2.Tests/PsWireFormatTests.cs
@@ -224,4 +224,49 @@ public class PsWireFormatTests
 
         Assert.Equal(p1, p2);
     }
+
+    // ---- CmdTx (TxSpecific) — TX step attenuator wire support for PS
+    // AutoAttenuate. Thetis network.c:1238-1242 writes the same value into
+    // bytes 57/58/59 (ADC2/ADC1/ADC0). Without these PsAutoAttenuate has
+    // nowhere to land its dB ramp.
+
+    [Fact]
+    public void CmdTx_TxStepAttn_LandsInBytes57Through59()
+    {
+        var p = Protocol2Client.ComposeCmdTxBuffer(
+            seq: 1, sampleRateKhz: 48, txStepAttnDb: 17);
+
+        Assert.Equal((byte)17, p[57]);
+        Assert.Equal((byte)17, p[58]);
+        Assert.Equal((byte)17, p[59]);
+    }
+
+    [Fact]
+    public void CmdTx_DefaultZeroAttn_LeavesBytes57Through59Clear()
+    {
+        var p = Protocol2Client.ComposeCmdTxBuffer(
+            seq: 0, sampleRateKhz: 48, txStepAttnDb: 0);
+
+        Assert.Equal((byte)0, p[57]);
+        Assert.Equal((byte)0, p[58]);
+        Assert.Equal((byte)0, p[59]);
+    }
+
+    [Fact]
+    public void CmdTx_PreservesSequenceAndNumDac()
+    {
+        var p = Protocol2Client.ComposeCmdTxBuffer(
+            seq: 0xCAFEBABE, sampleRateKhz: 192, txStepAttnDb: 5);
+
+        // Sequence at byte 0 BE
+        Assert.Equal((byte)0xCA, p[0]);
+        Assert.Equal((byte)0xFE, p[1]);
+        Assert.Equal((byte)0xBA, p[2]);
+        Assert.Equal((byte)0xBE, p[3]);
+        // num_dac always 1 on G2
+        Assert.Equal((byte)1, p[4]);
+        // Sample rate at bytes 14..15 BE — 192 = 0x00C0
+        Assert.Equal((byte)0x00, p[14]);
+        Assert.Equal((byte)0xC0, p[15]);
+    }
 }

--- a/tests/Zeus.Protocol2.Tests/PsWireFormatTests.cs
+++ b/tests/Zeus.Protocol2.Tests/PsWireFormatTests.cs
@@ -226,26 +226,58 @@ public class PsWireFormatTests
     }
 
     // ---- CmdTx (TxSpecific) — TX step attenuator wire support for PS
-    // AutoAttenuate. Thetis network.c:1238-1242 writes the same value into
-    // bytes 57/58/59 (ADC2/ADC1/ADC0). Without these PsAutoAttenuate has
-    // nowhere to land its dB ramp.
+    // AutoAttenuate. pihpsdr new_protocol.c:1540-1547 enforces an asymmetric
+    // PA-protection invariant: byte 58 (ADC1 / TX-DAC reference) MUST stay
+    // at 31 dB whenever PA is on, while byte 59 (ADC0 / PA-feedback) is the
+    // ONE byte PS overrides with the operator/auto-attenuator value. When
+    // PS is off Zeus preserves the historical wire shape that voice TX has
+    // been validated against.
 
     [Fact]
-    public void CmdTx_TxStepAttn_LandsInBytes57Through59()
+    public void CmdTx_PsOff_HistoricalShape_TxStepAttnLandsInAllThreeBytes()
     {
         var p = Protocol2Client.ComposeCmdTxBuffer(
-            seq: 1, sampleRateKhz: 48, txStepAttnDb: 17);
+            seq: 1, sampleRateKhz: 48, txStepAttnDb: 17, paEnabled: true, psEnabled: false);
 
+        // PS off: historical Zeus shape — value lands in 57/58/59 verbatim
+        // so normal voice TX wire form is unchanged from the prior release.
         Assert.Equal((byte)17, p[57]);
         Assert.Equal((byte)17, p[58]);
         Assert.Equal((byte)17, p[59]);
     }
 
     [Fact]
-    public void CmdTx_DefaultZeroAttn_LeavesBytes57Through59Clear()
+    public void CmdTx_PsOn_PaOn_PihpsdrAsymmetry_Byte58Stays31_Byte59TakesAttn()
     {
         var p = Protocol2Client.ComposeCmdTxBuffer(
-            seq: 0, sampleRateKhz: 48, txStepAttnDb: 0);
+            seq: 1, sampleRateKhz: 48, txStepAttnDb: 17, paEnabled: true, psEnabled: true);
+
+        // pihpsdr new_protocol.c:1540-1547: byte 58 = 31 (TX-DAC ref
+        // protection, never overridden by PS), byte 59 = operator step-att
+        // (PA-feedback ADC, the only byte PS owns). Byte 57 reserved → 0.
+        Assert.Equal((byte)0, p[57]);
+        Assert.Equal((byte)31, p[58]);
+        Assert.Equal((byte)17, p[59]);
+    }
+
+    [Fact]
+    public void CmdTx_PsOn_PaOff_Byte58Zero_Byte59TakesAttn()
+    {
+        var p = Protocol2Client.ComposeCmdTxBuffer(
+            seq: 1, sampleRateKhz: 48, txStepAttnDb: 17, paEnabled: false, psEnabled: true);
+
+        // PA off: nothing to protect, so byte 58 stays at 0. Byte 59 still
+        // carries the dynamic PS step-att.
+        Assert.Equal((byte)0, p[57]);
+        Assert.Equal((byte)0, p[58]);
+        Assert.Equal((byte)17, p[59]);
+    }
+
+    [Fact]
+    public void CmdTx_DefaultZeroAttn_PsOff_LeavesBytes57Through59Clear()
+    {
+        var p = Protocol2Client.ComposeCmdTxBuffer(
+            seq: 0, sampleRateKhz: 48, txStepAttnDb: 0, paEnabled: true, psEnabled: false);
 
         Assert.Equal((byte)0, p[57]);
         Assert.Equal((byte)0, p[58]);
@@ -256,7 +288,7 @@ public class PsWireFormatTests
     public void CmdTx_PreservesSequenceAndNumDac()
     {
         var p = Protocol2Client.ComposeCmdTxBuffer(
-            seq: 0xCAFEBABE, sampleRateKhz: 192, txStepAttnDb: 5);
+            seq: 0xCAFEBABE, sampleRateKhz: 192, txStepAttnDb: 5, paEnabled: false, psEnabled: false);
 
         // Sequence at byte 0 BE
         Assert.Equal((byte)0xCA, p[0]);

--- a/tests/Zeus.Server.Tests/AssemblyAttributes.cs
+++ b/tests/Zeus.Server.Tests/AssemblyAttributes.cs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+// LiteDB v5's BsonMapper.Global is a process-wide static cache that is not
+// thread-safe during the first GetEntityMapper(T) call for a given T. Two
+// xUnit test classes constructing PaSettingsStore / DspSettingsStore /
+// PsSettingsStore in parallel can race on populating PaBandEntry's field
+// map and intermittently throw "Member Band not found on BsonMapper for
+// type Zeus.Server.PaBandEntry" inside LiteCollection.EnsureIndex.
+//
+// Per-fixture temp DB paths (4a33523) only narrow the timing window — they
+// don't remove the race because the mapper cache is global, not per-file.
+// Production never hits this because the real radio runtime constructs the
+// stores exactly once. Disabling class-level test parallelism for THIS
+// assembly serializes those constructions and removes the race outright,
+// at a measured cost of ~1s on a 200-test suite.
+[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
@@ -162,6 +162,7 @@ public class MicGainEndpointTests : IClassFixture<MicGainEndpointTests.Factory>
         public void SetZoom(int channelId, int level) { }
         public int ReadAudio(int channelId, Span<float> output) => 0;
         public bool TryGetDisplayPixels(int channelId, DisplayPixout which, Span<float> dbOut) => false;
+        public bool TryGetTxDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
         public int OpenTxChannel(int outputRateHz = 48_000) => 0;
         public void SetMox(bool moxOn) { }
         public double GetRxaSignalDbm(int channelId) => -140.0;

--- a/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
@@ -171,6 +171,18 @@ public class MicGainEndpointTests : IClassFixture<MicGainEndpointTests.Factory>
         public int ProcessTxBlock(ReadOnlySpan<float> micMono, Span<float> iqInterleaved) => 0;
         public void SetTxTune(bool on) { }
         public TxStageMeters GetTxStageMeters() => TxStageMeters.Silent;
+        public void SetTwoTone(bool on, double freq1, double freq2, double mag) { }
+        public void SetPsEnabled(bool enabled) { }
+        public void SetPsControl(bool autoCal, bool singleCal) { }
+        public void SetPsAdvanced(bool ptol, double moxDelaySec, double loopDelaySec,
+                                  double ampDelayNs, double hwPeak, int ints, int spi) { }
+        public void SetPsHwPeak(double hwPeak) { }
+        public void FeedPsFeedbackBlock(ReadOnlySpan<float> txI, ReadOnlySpan<float> txQ,
+                                        ReadOnlySpan<float> rxI, ReadOnlySpan<float> rxQ) { }
+        public PsStageMeters GetPsStageMeters() => PsStageMeters.Silent;
+        public void ResetPs() { }
+        public void SavePsCorrection(string path) { }
+        public void RestorePsCorrection(string path) { }
         public void Dispose() { }
     }
 

--- a/tests/Zeus.Server.Tests/PsHwPeakResolutionTests.cs
+++ b/tests/Zeus.Server.Tests/PsHwPeakResolutionTests.cs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Protocol1.Discovery;
+using Zeus.Server;
+using Xunit;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Per-protocol / per-board PureSignal HW-peak resolution. Sourced from
+/// Thetis clsHardwareSpecific.cs:295-318 + pihpsdr transmitter.c:1166-1179.
+/// These values land via SetPSHWPeak to the WDSP calcc stage; getting them
+/// wrong by even a few percent makes the correction curve fight the radio.
+/// </summary>
+public class PsHwPeakResolutionTests
+{
+    [Fact]
+    public void Protocol1_Hermes_Defaults_To_0_4072()
+    {
+        Assert.Equal(0.4072, RadioService.ResolvePsHwPeak(false, HpsdrBoardKind.Hermes));
+        Assert.Equal(0.4072, RadioService.ResolvePsHwPeak(false, HpsdrBoardKind.Angelia));
+        Assert.Equal(0.4072, RadioService.ResolvePsHwPeak(false, HpsdrBoardKind.Orion));
+    }
+
+    [Fact]
+    public void Protocol2_OrionMkII_Defaults_To_0_6121()
+    {
+        Assert.Equal(0.6121, RadioService.ResolvePsHwPeak(true, HpsdrBoardKind.OrionMkII));
+    }
+
+    [Fact]
+    public void Protocol2_Default_Is_0_2899()
+    {
+        Assert.Equal(0.2899, RadioService.ResolvePsHwPeak(true, HpsdrBoardKind.Hermes));
+        Assert.Equal(0.2899, RadioService.ResolvePsHwPeak(true, HpsdrBoardKind.Angelia));
+        Assert.Equal(0.2899, RadioService.ResolvePsHwPeak(true, HpsdrBoardKind.Unknown));
+    }
+
+    [Fact]
+    public void HermesLite2_Both_Protocols_Use_0_233()
+    {
+        // MI0BOT special-case (HL2 only). Same value either protocol —
+        // the HL2 hardware peak is determined by the mod, not the protocol.
+        Assert.Equal(0.233, RadioService.ResolvePsHwPeak(false, HpsdrBoardKind.HermesLite2));
+        Assert.Equal(0.233, RadioService.ResolvePsHwPeak(true, HpsdrBoardKind.HermesLite2));
+    }
+}

--- a/tests/Zeus.Server.Tests/PsPersistenceTests.cs
+++ b/tests/Zeus.Server.Tests/PsPersistenceTests.cs
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server;
+using Xunit;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// PureSignal settings persistence — guards the round-3 fix where SetPs and
+/// SetTwoTone silently failed to call _psStore.Upsert. After the fix, every
+/// Set* path that mutates a persisted PS field must drop a doc into the
+/// LiteDB-backed store. Master-arm flags (PsEnabled, TwoToneEnabled) are
+/// intentionally NOT persisted — same operator-action discipline as MOX/TUN.
+/// </summary>
+public class PsPersistenceTests : IDisposable
+{
+    private readonly string _dbPath;
+
+    public PsPersistenceTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"zeus-prefs-pstest-{Guid.NewGuid():N}.db");
+    }
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+    }
+
+    private (RadioService radio, PsSettingsStore store) BuildRadioWithStore()
+    {
+        var loggerFactory = NullLoggerFactory.Instance;
+        var dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance);
+        var paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, _dbPath);
+        var psStore = new PsSettingsStore(NullLogger<PsSettingsStore>.Instance, _dbPath);
+        var radio = new RadioService(
+            loggerFactory, dspStore, paStore,
+            filterPresetStore: null, txIqSource: null,
+            preferredRadioStore: null, psStore: psStore);
+        return (radio, psStore);
+    }
+
+    [Fact]
+    public void SetPs_PersistsAutoFlag()
+    {
+        var (radio, store) = BuildRadioWithStore();
+
+        // Operator picks Single mode — persisted Auto field flips false.
+        radio.SetPs(new PsControlSetRequest(Enabled: false, Auto: false, Single: true));
+
+        var entry = store.Get();
+        Assert.NotNull(entry);
+        Assert.False(entry!.Auto);
+    }
+
+    [Fact]
+    public void SetTwoTone_PersistsFreq1Freq2Mag()
+    {
+        var (radio, store) = BuildRadioWithStore();
+
+        radio.SetTwoTone(new TwoToneSetRequest(
+            Enabled: false, Freq1: 750.0, Freq2: 2000.0, Mag: 0.4));
+
+        var entry = store.Get();
+        Assert.NotNull(entry);
+        Assert.Equal(750.0, entry!.TwoToneFreq1);
+        Assert.Equal(2000.0, entry.TwoToneFreq2);
+        Assert.Equal(0.4, entry.TwoToneMag);
+    }
+
+    [Fact]
+    public void SetTwoTone_PartialFields_PreservesUnsetTunings()
+    {
+        // Operator changes only freq1 — freq2 and mag should keep their
+        // existing StateDto / persisted values, not flip to defaults.
+        var (radio, store) = BuildRadioWithStore();
+
+        // First seed: full set.
+        radio.SetTwoTone(new TwoToneSetRequest(
+            Enabled: false, Freq1: 800.0, Freq2: 2100.0, Mag: 0.45));
+        // Second call: only freq1 supplied.
+        radio.SetTwoTone(new TwoToneSetRequest(
+            Enabled: false, Freq1: 850.0));
+
+        var entry = store.Get();
+        Assert.NotNull(entry);
+        Assert.Equal(850.0, entry!.TwoToneFreq1);
+        Assert.Equal(2100.0, entry.TwoToneFreq2);
+        Assert.Equal(0.45, entry.TwoToneMag);
+    }
+
+    [Fact]
+    public void SetPsAdvanced_PersistsTunings()
+    {
+        var (radio, store) = BuildRadioWithStore();
+
+        radio.SetPsAdvanced(new PsAdvancedSetRequest(
+            Ptol: true,
+            AutoAttenuate: false,
+            MoxDelaySec: 0.5,
+            LoopDelaySec: 0.1,
+            AmpDelayNs: 200.0,
+            HwPeak: null,
+            IntsSpiPreset: "8/512"));
+
+        var entry = store.Get();
+        Assert.NotNull(entry);
+        Assert.True(entry!.Ptol);
+        Assert.False(entry.AutoAttenuate);
+        Assert.Equal(0.5, entry.MoxDelaySec);
+        Assert.Equal(0.1, entry.LoopDelaySec);
+        Assert.Equal(200.0, entry.AmpDelayNs);
+        Assert.Equal("8/512", entry.IntsSpiPreset);
+    }
+
+    [Fact]
+    public void SetPsFeedbackSource_PersistsSource()
+    {
+        var (radio, store) = BuildRadioWithStore();
+
+        radio.SetPsFeedbackSource(new PsFeedbackSourceSetRequest(PsFeedbackSource.External));
+
+        var entry = store.Get();
+        Assert.NotNull(entry);
+        Assert.Equal(PsFeedbackSource.External, entry!.Source);
+    }
+
+    [Fact]
+    public void NewRadioService_RehydratesPersistedFields()
+    {
+        // Round-trip: write via one RadioService, restart, read via second.
+        var (radio1, _) = BuildRadioWithStore();
+        radio1.SetTwoTone(new TwoToneSetRequest(
+            Enabled: false, Freq1: 900.0, Freq2: 2200.0, Mag: 0.42));
+        radio1.SetPsAdvanced(new PsAdvancedSetRequest(
+            MoxDelaySec: 0.35,
+            IntsSpiPreset: "16/512"));
+        radio1.SetPsFeedbackSource(new PsFeedbackSourceSetRequest(PsFeedbackSource.External));
+
+        // Build a fresh RadioService against the same on-disk DB (same _dbPath).
+        var (radio2, _) = BuildRadioWithStore();
+        var snap = radio2.Snapshot();
+
+        Assert.Equal(900.0, snap.TwoToneFreq1);
+        Assert.Equal(2200.0, snap.TwoToneFreq2);
+        Assert.Equal(0.42, snap.TwoToneMag);
+        Assert.Equal(0.35, snap.PsMoxDelaySec);
+        Assert.Equal("16/512", snap.PsIntsSpiPreset);
+        Assert.Equal(PsFeedbackSource.External, snap.PsFeedbackSource);
+        // Master-arm flag should NOT survive — TwoToneEnabled stays false on
+        // every fresh session even if Enabled=true had been set previously.
+        Assert.False(snap.TwoToneEnabled);
+    }
+}

--- a/tests/Zeus.Server.Tests/TwoToneLatchTests.cs
+++ b/tests/Zeus.Server.Tests/TwoToneLatchTests.cs
@@ -26,13 +26,26 @@ namespace Zeus.Server.Tests;
 /// when the mic ingest pump is idle. Without the latch, PostGen mode=1
 /// has nothing to shove its excitation into and the radio sees zero IQ.
 /// </summary>
-public class TwoToneLatchTests
+public class TwoToneLatchTests : IDisposable
 {
-    private static TxService BuildTxService()
+    // Per-fixture temp DBs so xUnit class-level parallelism can't collide on
+    // the shared zeus-prefs.db. Without this, parallel construction of LiteDB
+    // instances against the same file races the BsonMapper and intermittently
+    // fails with "Member Band not found on BsonMapper for type PaBandEntry".
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-twotone-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+        try { if (File.Exists(_dbPath + ".pa")) File.Delete(_dbPath + ".pa"); } catch { }
+    }
+
+    private TxService BuildTxService()
     {
         var loggerFactory = NullLoggerFactory.Instance;
-        var dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance);
-        var paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance);
+        var dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance, _dbPath);
+        var paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, _dbPath + ".pa");
         var radio = new RadioService(loggerFactory, dspStore, paStore);
         var hub = new StreamingHub(new NullLogger<StreamingHub>());
         var pipeline = new DspPipelineService(radio, hub, loggerFactory);
@@ -82,11 +95,11 @@ public class TwoToneLatchTests
     // MOX press. TrySetTwoTone owns the MOX state while armed and drops it
     // unconditionally on disarm (mirrors setup.cs:11162-11165, 11189-11216).
 
-    private static (RadioService radio, TxService tx) BuildConnectedRadioAndTx()
+    private (RadioService radio, TxService tx) BuildConnectedRadioAndTx()
     {
         var loggerFactory = NullLoggerFactory.Instance;
-        var dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance);
-        var paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance);
+        var dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance, _dbPath);
+        var paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, _dbPath + ".pa");
         var radio = new RadioService(loggerFactory, dspStore, paStore);
         // Mark the radio P2-connected so the connect-interlock in
         // TrySetTwoTone passes — production calls this from

--- a/tests/Zeus.Server.Tests/TwoToneLatchTests.cs
+++ b/tests/Zeus.Server.Tests/TwoToneLatchTests.cs
@@ -76,4 +76,88 @@ public class TwoToneLatchTests
         Assert.False(tx.IsMoxOn);
         Assert.False(tx.IsTunOn);
     }
+
+    // ---- TrySetTwoTone — round-3 auto-MOX path (Thetis parity).
+    // Brian's expectation: pressing 2-Tone produces RF without a separate
+    // MOX press. TrySetTwoTone owns the MOX state while armed and drops it
+    // unconditionally on disarm (mirrors setup.cs:11162-11165, 11189-11216).
+
+    private static (RadioService radio, TxService tx) BuildConnectedRadioAndTx()
+    {
+        var loggerFactory = NullLoggerFactory.Instance;
+        var dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance);
+        var paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance);
+        var radio = new RadioService(loggerFactory, dspStore, paStore);
+        // Mark the radio P2-connected so the connect-interlock in
+        // TrySetTwoTone passes — production calls this from
+        // ConnectP2Async; here we shortcut.
+        radio.MarkProtocol2Connected("127.0.0.1:1024", 48_000);
+        var hub = new StreamingHub(new NullLogger<StreamingHub>());
+        var pipeline = new DspPipelineService(radio, hub, loggerFactory);
+        return (radio, new TxService(radio, pipeline, hub, new NullLogger<TxService>()));
+    }
+
+    [Fact]
+    public void TrySetTwoTone_NotConnected_ReturnsFalse_AndDoesNotKeyMox()
+    {
+        // Connect interlock — same shape as TrySetMox / TrySetTun.
+        var tx = BuildTxService();    // RadioService not connected
+
+        var ok = tx.TrySetTwoTone(
+            new Zeus.Contracts.TwoToneSetRequest(Enabled: true), out var err);
+
+        Assert.False(ok);
+        Assert.Equal("not connected", err);
+        Assert.False(tx.IsMoxOn);
+        Assert.False(tx.IsTwoToneOn);
+    }
+
+    [Fact]
+    public void TrySetTwoTone_Arm_KeysMox_AndLatchesTwoToneOn()
+    {
+        var (_, tx) = BuildConnectedRadioAndTx();
+
+        var ok = tx.TrySetTwoTone(
+            new Zeus.Contracts.TwoToneSetRequest(
+                Enabled: true, Freq1: 700, Freq2: 1900, Mag: 0.49),
+            out var err);
+
+        Assert.True(ok);
+        Assert.Null(err);
+        Assert.True(tx.IsTwoToneOn);
+        Assert.True(tx.IsMoxOn);
+    }
+
+    [Fact]
+    public void TrySetTwoTone_Disarm_DropsMox_AndClearsTwoToneOn()
+    {
+        var (_, tx) = BuildConnectedRadioAndTx();
+        // Arm first.
+        tx.TrySetTwoTone(
+            new Zeus.Contracts.TwoToneSetRequest(Enabled: true), out _);
+        Assert.True(tx.IsMoxOn);
+
+        // Disarm.
+        var ok = tx.TrySetTwoTone(
+            new Zeus.Contracts.TwoToneSetRequest(Enabled: false), out var err);
+
+        Assert.True(ok);
+        Assert.Null(err);
+        Assert.False(tx.IsTwoToneOn);
+        Assert.False(tx.IsMoxOn);
+    }
+
+    [Fact]
+    public void TrySetTwoTone_Disarm_AllowedEvenWhenNotConnected()
+    {
+        // The connect interlock only gates arm — disarm always passes so an
+        // operator can clear the latch after a disconnect.
+        var tx = BuildTxService();    // RadioService not connected
+
+        var ok = tx.TrySetTwoTone(
+            new Zeus.Contracts.TwoToneSetRequest(Enabled: false), out var err);
+
+        Assert.True(ok);
+        Assert.Null(err);
+    }
 }

--- a/tests/Zeus.Server.Tests/TwoToneLatchTests.cs
+++ b/tests/Zeus.Server.Tests/TwoToneLatchTests.cs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server;
+using Xunit;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// TwoTone latch on TxService — flipped by SetTwoToneOn from the
+/// /api/tx/twotone handler so TxTuneDriver pumps WDSP's TXA chain even
+/// when the mic ingest pump is idle. Without the latch, PostGen mode=1
+/// has nothing to shove its excitation into and the radio sees zero IQ.
+/// </summary>
+public class TwoToneLatchTests
+{
+    private static TxService BuildTxService()
+    {
+        var loggerFactory = NullLoggerFactory.Instance;
+        var dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance);
+        var paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance);
+        var radio = new RadioService(loggerFactory, dspStore, paStore);
+        var hub = new StreamingHub(new NullLogger<StreamingHub>());
+        var pipeline = new DspPipelineService(radio, hub, loggerFactory);
+        return new TxService(radio, pipeline, hub, new NullLogger<TxService>());
+    }
+
+    [Fact]
+    public void IsTwoToneOn_DefaultsFalse()
+    {
+        var tx = BuildTxService();
+        Assert.False(tx.IsTwoToneOn);
+    }
+
+    [Fact]
+    public void SetTwoToneOn_True_FlipsLatch()
+    {
+        var tx = BuildTxService();
+        tx.SetTwoToneOn(true);
+        Assert.True(tx.IsTwoToneOn);
+    }
+
+    [Fact]
+    public void SetTwoToneOn_FalseAfterTrue_ClearsLatch()
+    {
+        var tx = BuildTxService();
+        tx.SetTwoToneOn(true);
+        tx.SetTwoToneOn(false);
+        Assert.False(tx.IsTwoToneOn);
+    }
+
+    [Fact]
+    public void SetTwoToneOn_DoesNotAffectMoxOrTun()
+    {
+        // The latch is independent of MOX/TUN — TxTuneDriver gates on
+        // (IsTunOn || IsTwoToneOn), so a TwoTone arm without MOX/TUN
+        // should still leave those bits clear.
+        var tx = BuildTxService();
+        tx.SetTwoToneOn(true);
+
+        Assert.True(tx.IsTwoToneOn);
+        Assert.False(tx.IsMoxOn);
+        Assert.False(tx.IsTunOn);
+    }
+}

--- a/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
+++ b/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
@@ -85,6 +85,7 @@ public class TxAudioIngestTests
         public void SetZoom(int channelId, int level) { }
         public int ReadAudio(int channelId, Span<float> output) => 0;
         public bool TryGetDisplayPixels(int channelId, DisplayPixout which, Span<float> dbOut) => false;
+        public bool TryGetTxDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
         public int OpenTxChannel(int outputRateHz = 48_000) => 0;
         public void SetMox(bool moxOn) { }
         public double GetRxaSignalDbm(int channelId) => -140.0;

--- a/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
+++ b/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
@@ -95,6 +95,18 @@ public class TxAudioIngestTests
         public void SetTxLevelerMaxGain(double maxGainDb) { }
         public void SetTxTune(bool on) { }
         public TxStageMeters GetTxStageMeters() => TxStageMeters.Silent;
+        public void SetTwoTone(bool on, double freq1, double freq2, double mag) { }
+        public void SetPsEnabled(bool enabled) { }
+        public void SetPsControl(bool autoCal, bool singleCal) { }
+        public void SetPsAdvanced(bool ptol, double moxDelaySec, double loopDelaySec,
+                                  double ampDelayNs, double hwPeak, int ints, int spi) { }
+        public void SetPsHwPeak(double hwPeak) { }
+        public void FeedPsFeedbackBlock(ReadOnlySpan<float> txI, ReadOnlySpan<float> txQ,
+                                        ReadOnlySpan<float> rxI, ReadOnlySpan<float> rxQ) { }
+        public PsStageMeters GetPsStageMeters() => PsStageMeters.Silent;
+        public void ResetPs() { }
+        public void SavePsCorrection(string path) { }
+        public void RestorePsCorrection(string path) { }
         public void Dispose() { }
     }
 

--- a/zeus-web/package-lock.json
+++ b/zeus-web/package-lock.json
@@ -2640,9 +2640,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2657,9 +2654,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2674,9 +2668,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2691,9 +2682,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2708,9 +2696,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2725,9 +2710,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2742,9 +2724,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2759,9 +2738,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2776,9 +2752,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2793,9 +2766,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2810,9 +2780,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2827,9 +2794,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2844,9 +2808,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3093,9 +3054,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3113,9 +3071,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3133,9 +3088,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3153,9 +3105,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6455,9 +6404,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6479,9 +6425,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6503,9 +6446,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6527,9 +6467,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -55,6 +55,8 @@ import { ModeBandwidth } from './components/ModeBandwidth';
 import { FilterPanel } from './components/filter/FilterPanel';
 import { FilterRibbon, useFilterRibbonOpenSync } from './components/filter/FilterRibbon';
 import { MoxButton } from './components/MoxButton';
+import { PsToggleButton } from './components/PsToggleButton';
+import { TwoToneButton } from './components/TwoToneButton';
 import { Panadapter } from './components/Panadapter';
 import { PaTempChip } from './components/PaTempChip';
 import { PreampButton } from './components/PreampButton';
@@ -924,6 +926,8 @@ export default function App() {
       <div className="transport">
         <MoxButton />
         <TunButton />
+        <PsToggleButton />
+        <TwoToneButton />
         <div className="transport-sep" />
         <AudioToggle />
         <MicMeter />

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -134,7 +134,14 @@ export default function App() {
       ctrl = new AbortController();
       try {
         const next = await fetchState(ctrl.signal);
-        if (!cancelled) useConnectionStore.getState().applyState(next);
+        if (!cancelled) {
+          useConnectionStore.getState().applyState(next);
+          // Hydrate persistable PS / TwoTone fields from the server's StateDto
+          // so server-persisted edits (e.g. operator changed MOX delay on
+          // another tab) reach this tab even after the initial connect-time
+          // hydrate. Master-arm fields are session-only and skipped.
+          useTxStore.getState().hydrateFromState(next);
+        }
       } catch {
         /* transient errors reconcile on the next tick */
       }

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -905,6 +905,28 @@ export async function setPsAdvanced(
   );
 }
 
+// PureSignal feedback antenna source. Internal coupler vs External
+// (Bypass). Server enum is 0 (Internal) / 1 (External); the wire DTO
+// uses 'Internal' / 'External' string serialization through System.Text.Json
+// default StringEnumConverter setup.
+export async function setPsFeedbackSource(
+  source: 'internal' | 'external',
+  signal?: AbortSignal,
+): Promise<RadioStateDto> {
+  return jsonFetch(
+    '/api/tx/ps/feedback-source',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        source: source === 'external' ? 'External' : 'Internal',
+      }),
+      signal,
+    },
+    (raw) => raw as RadioStateDto,
+  );
+}
+
 export async function resetPs(signal?: AbortSignal): Promise<void> {
   await jsonFetch('/api/tx/ps/reset', { method: 'POST', signal }, () => null);
 }

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -860,6 +860,98 @@ export async function setLevelerMaxGain(
   }
 }
 
+// PureSignal master arm + cal-mode. POST /api/tx/ps. Backend swaps the engine
+// state machine (SetPSRunCal, SetPSControl) and toggles the radio-side
+// feedback wire bits. Returns the updated StateDto.
+export async function setPs(
+  req: { enabled: boolean; auto: boolean; single: boolean },
+  signal?: AbortSignal,
+): Promise<RadioStateDto> {
+  return jsonFetch(
+    '/api/tx/ps',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(req),
+      signal,
+    },
+    (raw) => raw as RadioStateDto,
+  );
+}
+
+// PureSignal advanced settings. Nullable fields = partial update so the
+// settings panel doesn't have to round-trip every value.
+export async function setPsAdvanced(
+  req: {
+    ptol?: boolean;
+    autoAttenuate?: boolean;
+    moxDelaySec?: number;
+    loopDelaySec?: number;
+    ampDelayNs?: number;
+    hwPeak?: number;
+    intsSpiPreset?: string;
+  },
+  signal?: AbortSignal,
+): Promise<RadioStateDto> {
+  return jsonFetch(
+    '/api/tx/ps/advanced',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(req),
+      signal,
+    },
+    (raw) => raw as RadioStateDto,
+  );
+}
+
+export async function resetPs(signal?: AbortSignal): Promise<void> {
+  await jsonFetch('/api/tx/ps/reset', { method: 'POST', signal }, () => null);
+}
+
+export async function savePs(filename: string, signal?: AbortSignal): Promise<void> {
+  await jsonFetch(
+    '/api/tx/ps/save',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ filename }),
+      signal,
+    },
+    () => null,
+  );
+}
+
+export async function restorePs(filename: string, signal?: AbortSignal): Promise<void> {
+  await jsonFetch(
+    '/api/tx/ps/restore',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ filename }),
+      signal,
+    },
+    () => null,
+  );
+}
+
+// Two-tone test generator. Protocol-agnostic — works on both P1 and P2.
+export async function setTwoTone(
+  req: { enabled: boolean; freq1?: number; freq2?: number; mag?: number },
+  signal?: AbortSignal,
+): Promise<RadioStateDto> {
+  return jsonFetch(
+    '/api/tx/twotone',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(req),
+      signal,
+    },
+    (raw) => raw as RadioStateDto,
+  );
+}
+
 // Mic-gain endpoint: POST /api/mic-gain { db }. Returns { micGainDb }.
 // Backend may not have landed the handler yet — a 404 is downgraded to a
 // silent warnOnce so the console doesn't fill with noise during the

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -107,6 +107,21 @@ export type RadioStateDto = {
   zoomLevel: ZoomLevel;
   // Master RX AF gain in dB — 0 = unity (WDSP SetRXAPanelGain1(1.0) default).
   rxAfGainDb: number;
+  // PureSignal persisted tunings — server is the source of truth, hydrated
+  // into tx-store on connect so a fresh browser (no localStorage) sees the
+  // operator's last dial-in. PsEnabled, PsSingle, TwoToneEnabled (master-arm
+  // flags) are intentionally session-only and left out.
+  psAuto: boolean;
+  psPtol: boolean;
+  psAutoAttenuate: boolean;
+  psMoxDelaySec: number;
+  psLoopDelaySec: number;
+  psAmpDelayNs: number;
+  psIntsSpiPreset: string;
+  psFeedbackSource: 'internal' | 'external';
+  twoToneFreq1: number;
+  twoToneFreq2: number;
+  twoToneMag: number;
 };
 
 export type FilterPresetDto = {
@@ -258,6 +273,20 @@ export function normalizeState(raw: unknown): RadioStateDto {
     // 0 dB matches the pre-#77 unity-gain default — older servers without
     // the field behave identically to a fresh-install slider at centre.
     rxAfGainDb: typeof r.rxAfGainDb === 'number' ? r.rxAfGainDb : 0,
+    // PureSignal persisted tunings. Defaults match RadioService.cs init and
+    // PsSettingsEntry — older servers without the fields fall back cleanly.
+    psAuto: typeof r.psAuto === 'boolean' ? r.psAuto : true,
+    psPtol: typeof r.psPtol === 'boolean' ? r.psPtol : false,
+    psAutoAttenuate: typeof r.psAutoAttenuate === 'boolean' ? r.psAutoAttenuate : true,
+    psMoxDelaySec: typeof r.psMoxDelaySec === 'number' ? r.psMoxDelaySec : 0.2,
+    psLoopDelaySec: typeof r.psLoopDelaySec === 'number' ? r.psLoopDelaySec : 0,
+    psAmpDelayNs: typeof r.psAmpDelayNs === 'number' ? r.psAmpDelayNs : 150,
+    psIntsSpiPreset: typeof r.psIntsSpiPreset === 'string' ? r.psIntsSpiPreset : '16/256',
+    psFeedbackSource:
+      r.psFeedbackSource === 'External' || r.psFeedbackSource === 'external' ? 'external' : 'internal',
+    twoToneFreq1: typeof r.twoToneFreq1 === 'number' ? r.twoToneFreq1 : 700,
+    twoToneFreq2: typeof r.twoToneFreq2 === 'number' ? r.twoToneFreq2 : 1900,
+    twoToneMag: typeof r.twoToneMag === 'number' ? r.twoToneMag : 0.49,
   };
 }
 

--- a/zeus-web/src/components/ConnectPanel.tsx
+++ b/zeus-web/src/components/ConnectPanel.tsx
@@ -97,6 +97,7 @@ export function ConnectPanel() {
   const inflight = useConnectionStore((s) => s.inflight);
   const setInflight = useConnectionStore((s) => s.setInflight);
   const setBoardId = useConnectionStore((s) => s.setBoardId);
+  const setConnectedProtocol = useConnectionStore((s) => s.setConnectedProtocol);
   const lastConnectedEndpoint = useConnectionStore(
     (s) => s.lastConnectedEndpoint,
   );
@@ -202,6 +203,7 @@ export function ConnectPanel() {
           applyState(next);
         }
         setBoardId(r.boardId || null);
+        setConnectedProtocol(isP2 ? 'P2' : 'P1');
         setLastConnectedEndpoint(ep || null);
         applyPostConnectEffects();
       } catch (err) {
@@ -210,7 +212,7 @@ export function ConnectPanel() {
         setInflight(false);
       }
     },
-    [applyState, setBoardId, setInflight, setLastConnectedEndpoint],
+    [applyState, setBoardId, setConnectedProtocol, setInflight, setLastConnectedEndpoint],
   );
 
   const handleManualConnect = useCallback(
@@ -245,6 +247,7 @@ export function ConnectPanel() {
           applyState(next);
         }
         setBoardId(null);
+        setConnectedProtocol(protocol);
         setLastConnectedEndpoint(ep);
         applyPostConnectEffects();
         if (manualSave || override) {
@@ -259,8 +262,8 @@ export function ConnectPanel() {
     },
     [
       manualIp, manualPort, manualProtocol, manualSampleRate,
-      manualSave, applyState, setBoardId, setInflight, setLastConnectedEndpoint,
-      saveEndpoint, setManualFormDefaults,
+      manualSave, applyState, setBoardId, setConnectedProtocol, setInflight,
+      setLastConnectedEndpoint, saveEndpoint, setManualFormDefaults,
     ],
   );
 
@@ -274,13 +277,14 @@ export function ConnectPanel() {
       const fresh = await fetchState();
       applyState(fresh);
       setBoardId(null);
+      setConnectedProtocol(null);
       setRadios(null);
     } catch (err) {
       setError(errorMessage(err));
     } finally {
       setInflight(false);
     }
-  }, [applyState, setBoardId, setInflight]);
+  }, [applyState, setBoardId, setConnectedProtocol, setInflight]);
 
   const handleRetry = useCallback(() => {
     setError(null);

--- a/zeus-web/src/components/ConnectPanel.tsx
+++ b/zeus-web/src/components/ConnectPanel.tsx
@@ -94,6 +94,10 @@ export function ConnectPanel() {
   const status = useConnectionStore((s) => s.status);
   const endpoint = useConnectionStore((s) => s.endpoint);
   const applyState = useConnectionStore((s) => s.applyState);
+  // tx-store hydration runs alongside applyState on every fresh
+  // RadioStateDto so PS / TwoTone tunings persisted server-side reach the
+  // UI even when localStorage is empty (cleared cache, new browser, etc.).
+  const hydrateTxFromState = useTxStore((s) => s.hydrateFromState);
   const inflight = useConnectionStore((s) => s.inflight);
   const setInflight = useConnectionStore((s) => s.setInflight);
   const setBoardId = useConnectionStore((s) => s.setBoardId);
@@ -138,14 +142,17 @@ export function ConnectPanel() {
   useEffect(() => {
     const ctrl = new AbortController();
     fetchState(ctrl.signal)
-      .then(applyState)
+      .then((s) => {
+        applyState(s);
+        hydrateTxFromState(s);
+      })
       .catch((err) => {
         if (ctrl.signal.aborted) return;
         setError(errorMessage(err));
         setFailureCount((n) => n + 1);
       });
     return () => ctrl.abort();
-  }, [applyState]);
+  }, [applyState, hydrateTxFromState]);
 
   // Discovery polling keeps running while Manual mode is active (PRD §6.2
   // proposal): toggling back to Discover shows fresh results immediately.
@@ -195,12 +202,14 @@ export function ConnectPanel() {
           await apiConnectP2({ endpoint: ep, sampleRate: 48_000 });
           const fresh = await fetchState();
           applyState(fresh);
+          hydrateTxFromState(fresh);
         } else {
           const next = await apiConnect({
             endpoint: ep,
             sampleRate: DEFAULT_SAMPLE_RATE,
           });
           applyState(next);
+          hydrateTxFromState(next);
         }
         setBoardId(r.boardId || null);
         setConnectedProtocol(isP2 ? 'P2' : 'P1');
@@ -212,7 +221,7 @@ export function ConnectPanel() {
         setInflight(false);
       }
     },
-    [applyState, setBoardId, setConnectedProtocol, setInflight, setLastConnectedEndpoint],
+    [applyState, hydrateTxFromState, setBoardId, setConnectedProtocol, setInflight, setLastConnectedEndpoint],
   );
 
   const handleManualConnect = useCallback(
@@ -242,9 +251,11 @@ export function ConnectPanel() {
           await apiConnectP2({ endpoint: ep, sampleRate: 48_000 });
           const fresh = await fetchState();
           applyState(fresh);
+          hydrateTxFromState(fresh);
         } else {
           const next = await apiConnect({ endpoint: ep, sampleRate });
           applyState(next);
+          hydrateTxFromState(next);
         }
         setBoardId(null);
         setConnectedProtocol(protocol);
@@ -262,7 +273,7 @@ export function ConnectPanel() {
     },
     [
       manualIp, manualPort, manualProtocol, manualSampleRate,
-      manualSave, applyState, setBoardId, setConnectedProtocol, setInflight,
+      manualSave, applyState, hydrateTxFromState, setBoardId, setConnectedProtocol, setInflight,
       setLastConnectedEndpoint, saveEndpoint, setManualFormDefaults,
     ],
   );
@@ -276,6 +287,7 @@ export function ConnectPanel() {
       try { await apiDisconnectP2(); } catch { /* may have been P1 */ }
       const fresh = await fetchState();
       applyState(fresh);
+      hydrateTxFromState(fresh);
       setBoardId(null);
       setConnectedProtocol(null);
       setRadios(null);
@@ -284,7 +296,7 @@ export function ConnectPanel() {
     } finally {
       setInflight(false);
     }
-  }, [applyState, setBoardId, setConnectedProtocol, setInflight]);
+  }, [applyState, hydrateTxFromState, setBoardId, setConnectedProtocol, setInflight]);
 
   const handleRetry = useCallback(() => {
     setError(null);

--- a/zeus-web/src/components/DbScale.tsx
+++ b/zeus-web/src/components/DbScale.tsx
@@ -37,6 +37,7 @@
 
 import { useCallback, useRef } from 'react';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
+import { useTxStore } from '../state/tx-store';
 
 // Tick stride in dB. Thetis defaults to 5 dB; our smaller canvas reads
 // cleaner at 10 dB. Tick label rendered at every stride, minor line between.
@@ -47,9 +48,23 @@ const TICK_STRIDE_DB = 10;
 // PanDisplay.cs:3684-3700. No independent min/max scaling; just an offset.
 // Sits inside the Panadapter container as an absolutely-positioned column.
 export function DbScale() {
-  const dbMin = useDisplaySettingsStore((s) => s.dbMin);
-  const dbMax = useDisplaySettingsStore((s) => s.dbMax);
+  const rxDbMin = useDisplaySettingsStore((s) => s.dbMin);
+  const rxDbMax = useDisplaySettingsStore((s) => s.dbMax);
+  const txDbMin = useDisplaySettingsStore((s) => s.txDbMin);
+  const txDbMax = useDisplaySettingsStore((s) => s.txDbMax);
   const shiftDbRange = useDisplaySettingsStore((s) => s.shiftDbRange);
+  const shiftTxDbRange = useDisplaySettingsStore((s) => s.shiftTxDbRange);
+  const moxOn = useTxStore((s) => s.moxOn);
+  const tunOn = useTxStore((s) => s.tunOn);
+  const keyed = moxOn || tunOn;
+
+  // Pick the active range + shifter based on whether we're looking at TX or
+  // RX pixels. Thetis-parity: each side has its own Grid Min/Max so the
+  // operator can hide the silence-time TX floor without moving the RX
+  // noise-floor view.
+  const dbMin = keyed ? txDbMin : rxDbMin;
+  const dbMax = keyed ? txDbMax : rxDbMax;
+  const shift = keyed ? shiftTxDbRange : shiftDbRange;
 
   const dragState = useRef<{
     startY: number;
@@ -86,9 +101,9 @@ export function DbScale() {
       const deltaDb = dySig * dbPerPixel;
       const nextMin = d.startDbMin + deltaDb;
       const targetShift = nextMin - dbMin;
-      if (Math.abs(targetShift) > 0.5) shiftDbRange(targetShift);
+      if (Math.abs(targetShift) > 0.5) shift(targetShift);
     },
-    [dbMin, shiftDbRange],
+    [dbMin, shift],
   );
 
   const onPointerUp = useCallback(

--- a/zeus-web/src/components/Panadapter.tsx
+++ b/zeus-web/src/components/Panadapter.tsx
@@ -40,6 +40,7 @@ import { createPanRenderer } from '../gl/panadapter';
 import { planWaterfallUpdate } from '../gl/wf-shift';
 import { useDisplayStore } from '../state/display-store';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
+import { useTxStore } from '../state/tx-store';
 import { usePanTuneGesture } from '../util/use-pan-tune-gesture';
 import { FreqAxis } from './FreqAxis';
 import { PassbandOverlay } from './PassbandOverlay';
@@ -77,7 +78,15 @@ export function Panadapter() {
     const redraw = () => {
       rafHandle = 0;
       if (!drawPan) return;
-      const { dbMin, dbMax } = useDisplaySettingsStore.getState();
+      const s = useDisplaySettingsStore.getState();
+      // While keyed (MOX or TUN — server already feeds TX pixels via
+      // DspPipelineService.Tick) use the TX-specific dB range so the
+      // operator's RX noise-floor view is untouched. Thetis parity, see
+      // TX_FIXED_DB_MIN/MAX in display-settings-store.
+      const { moxOn, tunOn } = useTxStore.getState();
+      const keyed = moxOn || tunOn;
+      const dbMin = keyed ? s.txDbMin : s.dbMin;
+      const dbMax = keyed ? s.txDbMax : s.dbMax;
       renderer.draw(drawPan, dbMin, dbMax, drawOffsetPx);
     };
     const requestRedraw = () => {
@@ -150,9 +159,16 @@ export function Panadapter() {
       requestRedraw();
     });
 
+    // Repaint when MOX / TUN flips so the RX-vs-TX dB range swap is
+    // reflected immediately, even if no fresh pan frame arrived yet.
+    const unsubTx = useTxStore.subscribe(() => {
+      requestRedraw();
+    });
+
     return () => {
       unsub();
       unsubSettings();
+      unsubTx();
       ro.disconnect();
       if (rafHandle !== 0) cancelAnimationFrame(rafHandle);
       renderer.dispose();

--- a/zeus-web/src/components/PsSettingsPanel.tsx
+++ b/zeus-web/src/components/PsSettingsPanel.tsx
@@ -17,6 +17,7 @@ import { useCallback } from 'react';
 import {
   setPs,
   setPsAdvanced,
+  setPsFeedbackSource,
   resetPs,
   setTwoTone,
 } from '../api/client';
@@ -59,6 +60,7 @@ export function PsSettingsPanel() {
   const psAmpDelayNs = useTxStore((s) => s.psAmpDelayNs);
   const psHwPeak = useTxStore((s) => s.psHwPeak);
   const psIntsSpiPreset = useTxStore((s) => s.psIntsSpiPreset);
+  const psFeedbackSourceState = useTxStore((s) => s.psFeedbackSource);
   const psFeedbackLevel = useTxStore((s) => s.psFeedbackLevel);
   const psCalState = useTxStore((s) => s.psCalState);
   const psCorrecting = useTxStore((s) => s.psCorrecting);
@@ -72,6 +74,7 @@ export function PsSettingsPanel() {
   const setPsAmpDelayNs = useTxStore((s) => s.setPsAmpDelayNs);
   const setPsHwPeak = useTxStore((s) => s.setPsHwPeak);
   const setPsIntsSpiPreset = useTxStore((s) => s.setPsIntsSpiPreset);
+  const setPsFeedbackSourceLocal = useTxStore((s) => s.setPsFeedbackSource);
 
   const twoToneOn = useTxStore((s) => s.twoToneOn);
   const twoToneFreq1 = useTxStore((s) => s.twoToneFreq1);
@@ -110,6 +113,18 @@ export function PsSettingsPanel() {
   const onReset = useCallback(() => {
     resetPs().catch(() => {});
   }, []);
+
+  // Feedback antenna source — Internal coupler vs External (Bypass).
+  // Optimistic local set + POST. Rolls back on POST failure so the radio's
+  // alex bit and the UI stay in sync.
+  const onFeedbackSourceChange = useCallback(
+    (next: 'internal' | 'external') => {
+      const prev = psFeedbackSourceState;
+      setPsFeedbackSourceLocal(next);
+      setPsFeedbackSource(next).catch(() => setPsFeedbackSourceLocal(prev));
+    },
+    [psFeedbackSourceState, setPsFeedbackSourceLocal],
+  );
 
   const onTwoToneToggle = useCallback(() => {
     const next = !twoToneOn;
@@ -264,6 +279,40 @@ export function PsSettingsPanel() {
 
       {/* Hardware */}
       <Section title="Hardware">
+        <Row label="Feedback source">
+          {/* Two-way selector: Internal coupler (default) or External
+              (Bypass). On G2/MkII this flips ALEX_RX_ANTENNA_BYPASS in
+              alex0 during xmit + PS armed. WDSP cal/iqc are unaffected;
+              the HW-peak slider below stays shared across sources to
+              match pihpsdr/Thetis. Disabled on P1 because P1 PS isn't
+              wired through yet. */}
+          <label
+            style={{ display: 'inline-flex', alignItems: 'center', marginRight: 12 }}
+          >
+            <input
+              type="radio"
+              name="psFeedbackSource"
+              value="internal"
+              checked={psFeedbackSourceState === 'internal'}
+              onChange={() => onFeedbackSourceChange('internal')}
+              disabled={p1Disabled}
+              style={{ marginRight: 4 }}
+            />
+            <span style={{ fontSize: 11, color: '#FFA028' }}>Internal coupler</span>
+          </label>
+          <label style={{ display: 'inline-flex', alignItems: 'center' }}>
+            <input
+              type="radio"
+              name="psFeedbackSource"
+              value="external"
+              checked={psFeedbackSourceState === 'external'}
+              onChange={() => onFeedbackSourceChange('external')}
+              disabled={p1Disabled}
+              style={{ marginRight: 4 }}
+            />
+            <span style={{ fontSize: 11, color: '#FFA028' }}>External (Bypass)</span>
+          </label>
+        </Row>
         <Row label="HW peak">
           <NumberInput
             value={psHwPeak}

--- a/zeus-web/src/components/PsSettingsPanel.tsx
+++ b/zeus-web/src/components/PsSettingsPanel.tsx
@@ -1,0 +1,490 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+import { useCallback } from 'react';
+import {
+  setPs,
+  setPsAdvanced,
+  resetPs,
+  setTwoTone,
+} from '../api/client';
+import { useConnectionStore } from '../state/connection-store';
+import { useTxStore } from '../state/tx-store';
+
+const CAL_STATE_NAMES = [
+  'RESET',
+  'WAIT',
+  'MOXDELAY',
+  'SETUP',
+  'COLLECT',
+  'MOXCHECK',
+  'CALC',
+  'DELAY',
+  'STAYON',
+  'TURNON',
+];
+
+/**
+ * PureSignal + Two-tone control surface. Lives inside the Settings modal
+ * (SettingsMenu) and as a standalone dockable panel (PsFlexPanel).
+ *
+ * Visual style note: amber #FFA028 with alpha for state per project
+ * convention (CLAUDE.md). Sliders + form controls are unstyled here so
+ * the global CSS variables drive them — keeps the panel coherent with
+ * other settings tabs.
+ */
+export function PsSettingsPanel() {
+  const protocol = useConnectionStore((s) => s.connectedProtocol);
+  const p1Disabled = protocol === 'P1';
+
+  const psEnabled = useTxStore((s) => s.psEnabled);
+  const psAuto = useTxStore((s) => s.psAuto);
+  const psSingle = useTxStore((s) => s.psSingle);
+  const psPtol = useTxStore((s) => s.psPtol);
+  const psAutoAttenuate = useTxStore((s) => s.psAutoAttenuate);
+  const psMoxDelaySec = useTxStore((s) => s.psMoxDelaySec);
+  const psLoopDelaySec = useTxStore((s) => s.psLoopDelaySec);
+  const psAmpDelayNs = useTxStore((s) => s.psAmpDelayNs);
+  const psHwPeak = useTxStore((s) => s.psHwPeak);
+  const psIntsSpiPreset = useTxStore((s) => s.psIntsSpiPreset);
+  const psFeedbackLevel = useTxStore((s) => s.psFeedbackLevel);
+  const psCalState = useTxStore((s) => s.psCalState);
+  const psCorrecting = useTxStore((s) => s.psCorrecting);
+  const psCorrectionDb = useTxStore((s) => s.psCorrectionDb);
+  const setPsAuto = useTxStore((s) => s.setPsAuto);
+  const setPsSingle = useTxStore((s) => s.setPsSingle);
+  const setPsPtol = useTxStore((s) => s.setPsPtol);
+  const setPsAutoAttenuate = useTxStore((s) => s.setPsAutoAttenuate);
+  const setPsMoxDelaySec = useTxStore((s) => s.setPsMoxDelaySec);
+  const setPsLoopDelaySec = useTxStore((s) => s.setPsLoopDelaySec);
+  const setPsAmpDelayNs = useTxStore((s) => s.setPsAmpDelayNs);
+  const setPsHwPeak = useTxStore((s) => s.setPsHwPeak);
+  const setPsIntsSpiPreset = useTxStore((s) => s.setPsIntsSpiPreset);
+
+  const twoToneOn = useTxStore((s) => s.twoToneOn);
+  const twoToneFreq1 = useTxStore((s) => s.twoToneFreq1);
+  const twoToneFreq2 = useTxStore((s) => s.twoToneFreq2);
+  const twoToneMag = useTxStore((s) => s.twoToneMag);
+  const setTwoToneOn = useTxStore((s) => s.setTwoToneOn);
+  const setTwoToneFreq1 = useTxStore((s) => s.setTwoToneFreq1);
+  const setTwoToneFreq2 = useTxStore((s) => s.setTwoToneFreq2);
+  const setTwoToneMag = useTxStore((s) => s.setTwoToneMag);
+
+  // Cal-mode radio buttons send the new combination on every change.
+  const setMode = useCallback(
+    (auto: boolean, single: boolean) => {
+      setPsAuto(auto);
+      setPsSingle(single);
+      setPs({ enabled: psEnabled, auto, single }).catch(() => {});
+    },
+    [psEnabled, setPsAuto, setPsSingle],
+  );
+
+  const pushAdvanced = useCallback(
+    (overrides: Partial<{
+      ptol: boolean;
+      autoAttenuate: boolean;
+      moxDelaySec: number;
+      loopDelaySec: number;
+      ampDelayNs: number;
+      hwPeak: number;
+      intsSpiPreset: string;
+    }>) => {
+      setPsAdvanced(overrides).catch(() => {});
+    },
+    [],
+  );
+
+  const onReset = useCallback(() => {
+    resetPs().catch(() => {});
+  }, []);
+
+  const onTwoToneToggle = useCallback(() => {
+    const next = !twoToneOn;
+    setTwoToneOn(next);
+    setTwoTone({
+      enabled: next,
+      freq1: twoToneFreq1,
+      freq2: twoToneFreq2,
+      mag: twoToneMag,
+    }).catch(() => setTwoToneOn(!next));
+  }, [twoToneOn, twoToneFreq1, twoToneFreq2, twoToneMag, setTwoToneOn]);
+
+  const onTwoToneFreq1Change = useCallback(
+    (hz: number) => {
+      const v = Math.max(50, Math.min(5000, Math.round(hz)));
+      setTwoToneFreq1(v);
+      if (twoToneOn) setTwoTone({ enabled: true, freq1: v }).catch(() => {});
+    },
+    [twoToneOn, setTwoToneFreq1],
+  );
+
+  const onTwoToneFreq2Change = useCallback(
+    (hz: number) => {
+      const v = Math.max(50, Math.min(5000, Math.round(hz)));
+      setTwoToneFreq2(v);
+      if (twoToneOn) setTwoTone({ enabled: true, freq2: v }).catch(() => {});
+    },
+    [twoToneOn, setTwoToneFreq2],
+  );
+
+  const onTwoToneMagChange = useCallback(
+    (mag: number) => {
+      const v = Math.max(0, Math.min(1, mag));
+      setTwoToneMag(v);
+      if (twoToneOn) setTwoTone({ enabled: true, mag: v }).catch(() => {});
+    },
+    [twoToneOn, setTwoToneMag],
+  );
+
+  const calStateLabel = CAL_STATE_NAMES[psCalState] ?? `state ${psCalState}`;
+  // Feedback level is 0..256 raw; UI shows 0..1.
+  const feedbackBar = Math.max(0, Math.min(1, psFeedbackLevel / 256));
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+      {p1Disabled ? (
+        <div
+          style={{
+            padding: 10,
+            border: '1px solid rgba(255, 160, 40, 0.4)',
+            borderRadius: 6,
+            background: 'rgba(255, 160, 40, 0.06)',
+            color: '#FFA028',
+            fontSize: 11,
+          }}
+        >
+          PureSignal predistortion for Hermes / Protocol 1 is coming in a
+          follow-up. Two-tone test generator below works on both protocols.
+        </div>
+      ) : null}
+
+      {/* Calibration */}
+      <Section title="Calibration">
+        <Row label="Mode">
+          <label style={{ marginRight: 12 }}>
+            <input
+              type="radio"
+              name="ps-mode"
+              checked={psAuto && !psSingle}
+              onChange={() => setMode(true, false)}
+              disabled={p1Disabled}
+            />{' '}
+            Auto
+          </label>
+          <label>
+            <input
+              type="radio"
+              name="ps-mode"
+              checked={psSingle}
+              onChange={() => setMode(false, true)}
+              disabled={p1Disabled}
+            />{' '}
+            Single
+          </label>
+        </Row>
+        <Row label="">
+          <button
+            type="button"
+            onClick={onReset}
+            disabled={p1Disabled}
+            className="btn sm"
+          >
+            Reset
+          </button>
+        </Row>
+        <Row label="Auto-Attenuate">
+          <input
+            type="checkbox"
+            checked={psAutoAttenuate}
+            onChange={(e) => {
+              const v = e.target.checked;
+              setPsAutoAttenuate(v);
+              pushAdvanced({ autoAttenuate: v });
+            }}
+            disabled={p1Disabled}
+          />
+        </Row>
+      </Section>
+
+      {/* Timing */}
+      <Section title="Timing">
+        <Row label="MOX delay (s)">
+          <NumberInput
+            value={psMoxDelaySec}
+            min={0.0}
+            max={10.0}
+            step={0.1}
+            onChange={(v) => {
+              setPsMoxDelaySec(v);
+              pushAdvanced({ moxDelaySec: v });
+            }}
+            disabled={p1Disabled}
+          />
+        </Row>
+        <Row label="Cal delay (s)">
+          <NumberInput
+            value={psLoopDelaySec}
+            min={0.0}
+            max={100.0}
+            step={0.5}
+            onChange={(v) => {
+              setPsLoopDelaySec(v);
+              pushAdvanced({ loopDelaySec: v });
+            }}
+            disabled={p1Disabled}
+          />
+        </Row>
+        <Row label="Amp delay (ns)">
+          <NumberInput
+            value={psAmpDelayNs}
+            min={0}
+            max={25_000_000}
+            step={50}
+            onChange={(v) => {
+              setPsAmpDelayNs(v);
+              pushAdvanced({ ampDelayNs: v });
+            }}
+            disabled={p1Disabled}
+          />
+        </Row>
+      </Section>
+
+      {/* Hardware */}
+      <Section title="Hardware">
+        <Row label="HW peak">
+          <NumberInput
+            value={psHwPeak}
+            min={0.01}
+            max={2.0}
+            step={0.001}
+            onChange={(v) => {
+              setPsHwPeak(v);
+              pushAdvanced({ hwPeak: v });
+            }}
+            disabled={p1Disabled}
+          />
+        </Row>
+        <Row label="Ints / Spi">
+          <select
+            value={psIntsSpiPreset}
+            onChange={(e) => {
+              const v = e.target.value;
+              setPsIntsSpiPreset(v);
+              pushAdvanced({ intsSpiPreset: v });
+            }}
+            disabled={p1Disabled}
+          >
+            <option value="16/256">16 / 256</option>
+            <option value="8/512">8 / 512</option>
+            <option value="4/1024">4 / 1024</option>
+          </select>
+        </Row>
+        <Row label="Relax phase tol">
+          <input
+            type="checkbox"
+            checked={psPtol}
+            onChange={(e) => {
+              const v = e.target.checked;
+              setPsPtol(v);
+              pushAdvanced({ ptol: v });
+            }}
+            disabled={p1Disabled}
+          />
+        </Row>
+      </Section>
+
+      {/* Read-out */}
+      <Section title="Read-out">
+        <Row label="Feedback">
+          <Bar value={feedbackBar} />
+          <span style={{ fontSize: 11, color: '#FFA028', marginLeft: 8 }}>
+            {psFeedbackLevel.toFixed(0)} / 256
+          </span>
+        </Row>
+        <Row label="Cal state">
+          <span style={{ fontSize: 11, color: '#FFA028' }}>
+            {calStateLabel}
+            {psCorrecting ? ' · correcting' : ''}
+          </span>
+        </Row>
+        <Row label="Correction">
+          <span style={{ fontSize: 11, color: '#FFA028' }}>
+            {psCorrecting ? `${psCorrectionDb.toFixed(1)} dB` : '—'}
+          </span>
+        </Row>
+      </Section>
+
+      {/* Two-tone */}
+      <Section title="Two-tone test signal">
+        <Row label="">
+          <button
+            type="button"
+            onClick={onTwoToneToggle}
+            className={`btn sm ${twoToneOn ? 'active' : ''}`}
+            title="Standard PureSignal calibration excitation"
+          >
+            {twoToneOn ? '2-Tone ON' : '2-Tone OFF'}
+          </button>
+        </Row>
+        <Row label="Freq 1 (Hz)">
+          <NumberInput
+            value={twoToneFreq1}
+            min={50}
+            max={5000}
+            step={10}
+            onChange={onTwoToneFreq1Change}
+          />
+        </Row>
+        <Row label="Freq 2 (Hz)">
+          <NumberInput
+            value={twoToneFreq2}
+            min={50}
+            max={5000}
+            step={10}
+            onChange={onTwoToneFreq2Change}
+          />
+        </Row>
+        <Row label="Magnitude">
+          <NumberInput
+            value={twoToneMag}
+            min={0}
+            max={1}
+            step={0.01}
+            onChange={onTwoToneMagChange}
+          />
+        </Row>
+      </Section>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section
+      style={{
+        border: '1px solid var(--panel-border)',
+        borderRadius: 6,
+        padding: '10px 12px',
+        background: 'var(--bg-1)',
+      }}
+    >
+      <h3
+        style={{
+          margin: 0,
+          marginBottom: 8,
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: '0.12em',
+          textTransform: 'uppercase',
+          color: '#FFA028',
+        }}
+      >
+        {title}
+      </h3>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        {children}
+      </div>
+    </section>
+  );
+}
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        fontSize: 12,
+      }}
+    >
+      <span style={{ minWidth: 110, color: 'var(--fg-2)' }}>{label}</span>
+      <span style={{ display: 'flex', alignItems: 'center', flex: 1, gap: 6 }}>
+        {children}
+      </span>
+    </div>
+  );
+}
+
+function NumberInput({
+  value,
+  min,
+  max,
+  step,
+  onChange,
+  disabled,
+}: {
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (v: number) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <input
+      type="number"
+      value={value}
+      min={min}
+      max={max}
+      step={step}
+      disabled={disabled}
+      onChange={(e) => {
+        const v = Number(e.target.value);
+        if (Number.isFinite(v)) onChange(v);
+      }}
+      style={{
+        width: 100,
+        padding: '3px 6px',
+        background: 'var(--bg-0)',
+        color: 'var(--fg-1)',
+        border: '1px solid var(--panel-border)',
+        borderRadius: 3,
+        fontSize: 12,
+      }}
+    />
+  );
+}
+
+function Bar({ value }: { value: number }) {
+  const pct = Math.max(0, Math.min(1, value)) * 100;
+  return (
+    <div
+      style={{
+        width: 140,
+        height: 8,
+        background: 'rgba(255, 160, 40, 0.12)',
+        borderRadius: 2,
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          width: `${pct}%`,
+          height: '100%',
+          background: '#FFA028',
+          transition: 'width 80ms linear',
+        }}
+      />
+    </div>
+  );
+}

--- a/zeus-web/src/components/PsSettingsPanel.tsx
+++ b/zeus-web/src/components/PsSettingsPanel.tsx
@@ -137,11 +137,17 @@ export function PsSettingsPanel() {
     }).catch(() => setTwoToneOn(!next));
   }, [twoToneOn, twoToneFreq1, twoToneFreq2, twoToneMag, setTwoToneOn]);
 
+  // Two-tone freq/mag POSTs always go to the server, even when twoToneOn is
+  // false. The server persists freq1/freq2/mag via PsSettingsStore so an
+  // operator who dials in tones first ("set up the test, then arm") sees the
+  // values stick across restarts. Server SetTwoTone accepts partial fields
+  // and only flips the master arm if `enabled` changes — passing the current
+  // twoToneOn state keeps the radio's TwoTone arm state untouched.
   const onTwoToneFreq1Change = useCallback(
     (hz: number) => {
       const v = Math.max(50, Math.min(5000, Math.round(hz)));
       setTwoToneFreq1(v);
-      if (twoToneOn) setTwoTone({ enabled: true, freq1: v }).catch(() => {});
+      setTwoTone({ enabled: twoToneOn, freq1: v }).catch(() => {});
     },
     [twoToneOn, setTwoToneFreq1],
   );
@@ -150,7 +156,7 @@ export function PsSettingsPanel() {
     (hz: number) => {
       const v = Math.max(50, Math.min(5000, Math.round(hz)));
       setTwoToneFreq2(v);
-      if (twoToneOn) setTwoTone({ enabled: true, freq2: v }).catch(() => {});
+      setTwoTone({ enabled: twoToneOn, freq2: v }).catch(() => {});
     },
     [twoToneOn, setTwoToneFreq2],
   );
@@ -159,7 +165,7 @@ export function PsSettingsPanel() {
     (mag: number) => {
       const v = Math.max(0, Math.min(1, mag));
       setTwoToneMag(v);
-      if (twoToneOn) setTwoTone({ enabled: true, mag: v }).catch(() => {});
+      setTwoTone({ enabled: twoToneOn, mag: v }).catch(() => {});
     },
     [twoToneOn, setTwoToneMag],
   );

--- a/zeus-web/src/components/PsToggleButton.tsx
+++ b/zeus-web/src/components/PsToggleButton.tsx
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+import { useCallback } from 'react';
+import { setPs } from '../api/client';
+import { useConnectionStore } from '../state/connection-store';
+import { useTxStore } from '../state/tx-store';
+
+/**
+ * PureSignal master arm. Optimistic update with rollback on server refusal —
+ * same pattern as MoxButton. Disabled until a P2 radio is connected:
+ * Protocol1 PureSignal is deferred to a follow-up because we can only
+ * rack-test against a G2 / OrionMkII today. TODO(ps-p1): drop the gate
+ * once Protocol1Client gains the SetPuresignal hooks.
+ */
+export function PsToggleButton() {
+  const connected = useConnectionStore((s) => s.status === 'Connected');
+  const protocol = useConnectionStore((s) => s.connectedProtocol);
+  const psEnabled = useTxStore((s) => s.psEnabled);
+  const psAuto = useTxStore((s) => s.psAuto);
+  const psSingle = useTxStore((s) => s.psSingle);
+  const setPsEnabled = useTxStore((s) => s.setPsEnabled);
+
+  // P1 gate — backend forwards SetPsEnabled to the engine on either protocol
+  // but the wire-side feedback path is P2-only in v1.
+  const p1Disabled = protocol === 'P1';
+  const disabled = !connected || p1Disabled;
+  const tooltip = p1Disabled
+    ? 'PureSignal for Hermes coming in a follow-up'
+    : psEnabled
+      ? 'PureSignal armed — predistortion active'
+      : 'Arm PureSignal predistortion';
+
+  const click = useCallback(() => {
+    if (disabled) return;
+    const next = !psEnabled;
+    setPsEnabled(next);
+    setPs({ enabled: next, auto: psAuto, single: psSingle }).catch(() => {
+      setPsEnabled(!next);
+    });
+  }, [disabled, psEnabled, psAuto, psSingle, setPsEnabled]);
+
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={click}
+      className={`btn lg tx-btn ${psEnabled ? 'tx' : ''}`}
+      title={tooltip}
+    >
+      <span className={`led ${psEnabled ? 'tx' : ''}`} style={{ marginRight: 8 }} />
+      PS
+    </button>
+  );
+}

--- a/zeus-web/src/components/SettingsMenu.tsx
+++ b/zeus-web/src/components/SettingsMenu.tsx
@@ -18,11 +18,13 @@ import { PaSettingsPanel } from './PaSettingsPanel';
 import { AboutPanel } from './AboutPanel';
 import { RadioSelector } from './RadioSelector';
 import { usePaStore } from '../state/pa-store';
+import { PsSettingsPanel } from './PsSettingsPanel';
 
-type TabId = 'pa' | 'about';
+type TabId = 'pa' | 'ps' | 'about';
 
 const TABS: ReadonlyArray<{ id: TabId; label: string }> = [
   { id: 'pa', label: 'PA SETTINGS' },
+  { id: 'ps', label: 'PURESIGNAL' },
   { id: 'about', label: 'ABOUT' },
 ];
 
@@ -277,6 +279,7 @@ export function SettingsMenu({ open, onClose }: Props) {
           }}
         >
           {active === 'pa' && <PaSettingsPanel />}
+          {active === 'ps' && <PsSettingsPanel />}
           {active === 'about' && <AboutPanel />}
         </div>
       </div>

--- a/zeus-web/src/components/TwoToneButton.tsx
+++ b/zeus-web/src/components/TwoToneButton.tsx
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+import { useCallback } from 'react';
+import { setTwoTone } from '../api/client';
+import { useConnectionStore } from '../state/connection-store';
+import { useTxStore } from '../state/tx-store';
+
+/**
+ * Two-tone test signal arm. Standard PureSignal calibration excitation,
+ * but useful standalone for IMD measurements / linearity checks. Always
+ * available when connected — TwoTone is protocol-agnostic; safe on P1
+ * even though PS itself is P2-only in v1.
+ */
+export function TwoToneButton() {
+  const connected = useConnectionStore((s) => s.status === 'Connected');
+  const twoToneOn = useTxStore((s) => s.twoToneOn);
+  const setTwoToneOn = useTxStore((s) => s.setTwoToneOn);
+  const f1 = useTxStore((s) => s.twoToneFreq1);
+  const f2 = useTxStore((s) => s.twoToneFreq2);
+  const mag = useTxStore((s) => s.twoToneMag);
+
+  const click = useCallback(() => {
+    const next = !twoToneOn;
+    setTwoToneOn(next);
+    setTwoTone({ enabled: next, freq1: f1, freq2: f2, mag }).catch(() => {
+      setTwoToneOn(!next);
+    });
+  }, [twoToneOn, f1, f2, mag, setTwoToneOn]);
+
+  return (
+    <button
+      type="button"
+      disabled={!connected}
+      onClick={click}
+      className={`btn lg tx-btn ${twoToneOn ? 'tx' : ''}`}
+      title={
+        twoToneOn
+          ? 'Two-tone test signal armed'
+          : 'Arm two-tone test signal (PS calibration / IMD)'
+      }
+    >
+      <span className={`led ${twoToneOn ? 'tx' : ''}`} style={{ marginRight: 8 }} />
+      2-TONE
+    </button>
+  );
+}

--- a/zeus-web/src/layout/panels.ts
+++ b/zeus-web/src/layout/panels.ts
@@ -46,6 +46,7 @@ import { CwPanel } from './panels/CwPanel';
 import { LogbookPanel } from './panels/LogbookPanel';
 import { TxMetersPanel } from './panels/TxMetersPanel';
 import { FilterRibbonPanel } from './panels/FilterRibbonPanel';
+import { PsFlexPanel } from './panels/PsFlexPanel';
 
 export type PanelCategory = 'spectrum' | 'vfo' | 'meters' | 'dsp' | 'log' | 'tools';
 
@@ -130,5 +131,12 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'dsp',
     tags: ['filter', 'bandwidth', 'passband', 'ribbon'],
     component: FilterRibbonPanel,
+  },
+  ps: {
+    id: 'ps',
+    name: 'PureSignal',
+    category: 'tools',
+    tags: ['puresignal', 'ps', 'tx', 'predistortion', 'linearization', 'twotone'],
+    component: PsFlexPanel,
   },
 };

--- a/zeus-web/src/layout/panels/PsFlexPanel.tsx
+++ b/zeus-web/src/layout/panels/PsFlexPanel.tsx
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+import { PsSettingsPanel } from '../../components/PsSettingsPanel';
+
+export function PsFlexPanel() {
+  return (
+    <div style={{ flex: 1, overflow: 'auto', padding: 12 }}>
+      <PsSettingsPanel />
+    </div>
+  );
+}

--- a/zeus-web/src/realtime/ws-client.ts
+++ b/zeus-web/src/realtime/ws-client.ts
@@ -75,6 +75,13 @@ export const MSG_TYPE_ALERT = 0x13;
 export const MSG_TYPE_PA_TEMP = 0x17;
 const PA_TEMP_BYTES = 1 + 4;
 
+// PureSignal stage telemetry. 1 type byte + 4 (feedback) + 4 (correctionDb)
+// + 1 (calState) + 1 (correcting bool) + 4 (maxTxEnvelope) = 15 bytes.
+// Broadcast at 10 Hz only while PsEnabled is armed — keeps the wire quiet
+// when PS is off. Server-side bare-payload like TxMetersV2 (no header).
+export const MSG_TYPE_PS_METERS = 0x18;
+const PS_METERS_BYTES = 1 + 4 + 4 + 1 + 1 + 4;
+
 // WDSP wisdom status: 1 type byte + 1 phase byte (0=idle, 1=building, 2=ready).
 // Pushed once on WS attach and again on every transition. The UI disables the
 // Connect button and pulses while phase=building so the user doesn't try to
@@ -225,6 +232,24 @@ export function startRealtime(path = '/ws'): () => void {
           }
           const tempC = new DataView(ev.data).getFloat32(1, true);
           useTxStore.getState().setPaTempC(tempC);
+          return;
+        }
+        if (peekType === MSG_TYPE_PS_METERS) {
+          if (ev.data.byteLength < PS_METERS_BYTES) {
+            warnOnce(
+              'ws-ps-meters-short',
+              `PS meters frame too short: ${ev.data.byteLength}`,
+            );
+            return;
+          }
+          const dv = new DataView(ev.data);
+          useTxStore.getState().setPsMeters({
+            feedbackLevel: dv.getFloat32(1, true),
+            correctionDb: dv.getFloat32(5, true),
+            calState: dv.getUint8(9),
+            correcting: dv.getUint8(10) !== 0,
+            maxTxEnvelope: dv.getFloat32(11, true),
+          });
           return;
         }
         if (peekType === MSG_TYPE_RX_METER) {

--- a/zeus-web/src/state/connection-store.ts
+++ b/zeus-web/src/state/connection-store.ts
@@ -75,6 +75,13 @@ export type ConnectionState = {
   // preamp guard treats null as "show", which is the safe default (an HL2
   // preamp toggle does nothing harmful, just nothing useful).
   boardId: string | null;
+  // Connected protocol — 'P1' or 'P2', or null when disconnected. Set by
+  // ConnectPanel on a successful /api/connect or /api/connect/p2 call so
+  // protocol-gated features (e.g. PureSignal v1 — P2 only) can disable
+  // their controls cleanly without round-tripping the discovery list.
+  // TODO(ps-p1): once Protocol1 PureSignal lands, this gate can drop the
+  // PS-toggle disabled branch.
+  connectedProtocol: 'P1' | 'P2' | null;
   preampOn: boolean;
   nr: NrConfigDto;
   zoomLevel: ZoomLevel;
@@ -87,6 +94,7 @@ export type ConnectionState = {
   applyState: (s: RadioStateDto) => void;
   setInflight: (v: boolean) => void;
   setBoardId: (id: string | null) => void;
+  setConnectedProtocol: (p: 'P1' | 'P2' | null) => void;
   setPreampOn: (on: boolean) => void;
   setNr: (nr: NrConfigDto) => void;
   setZoomLevel: (level: ZoomLevel) => void;
@@ -113,6 +121,7 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
   attOffsetDb: 0,
   adcOverloadWarning: false,
   boardId: null,
+  connectedProtocol: null,
   preampOn: false,
   nr: { ...NR_CONFIG_DEFAULT },
   zoomLevel: 1,
@@ -145,6 +154,7 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
     }),
   setInflight: (inflight) => set({ inflight }),
   setBoardId: (boardId) => set({ boardId }),
+  setConnectedProtocol: (connectedProtocol) => set({ connectedProtocol }),
   setPreampOn: (preampOn) => set({ preampOn }),
   setNr: (nr) => set({ nr }),
   setZoomLevel: (zoomLevel) => set({ zoomLevel }),

--- a/zeus-web/src/state/display-settings-store.ts
+++ b/zeus-web/src/state/display-settings-store.ts
@@ -46,7 +46,16 @@ import type { ColormapId } from '../gl/colormap';
 export const FIXED_DB_MIN = -140;
 export const FIXED_DB_MAX = -50;
 
+// TX panadapter defaults — kept separate from RX so the user can drag the
+// scale while keyed without disturbing their RX noise-floor view. Matches
+// Thetis's `TXSpectrumGridMin = -80` / `TXSpectrumGridMax = 20` (Display.cs:
+// 1881-1897). Speech peaks land inside this window; a user who wants to
+// hide silence-time floor pumping raises TX_DB_MIN via the drag gesture.
+export const TX_FIXED_DB_MIN = -80;
+export const TX_FIXED_DB_MAX = 20;
+
 const STORAGE_KEY = 'zeus.display.dbRange';
+const TX_STORAGE_KEY = 'zeus.display.txDbRange';
 const CONTRAST_STORAGE_KEY = 'zeus.display.contrast';
 
 // Allowed range for the waterfall gamma. Outside this band the display
@@ -105,6 +114,32 @@ function writeSavedRange(dbMin: number, dbMax: number): void {
   }
 }
 
+function readSavedTxRange(): { txDbMin: number; txDbMax: number } {
+  try {
+    if (typeof localStorage === 'undefined') return { txDbMin: TX_FIXED_DB_MIN, txDbMax: TX_FIXED_DB_MAX };
+    const raw = localStorage.getItem(TX_STORAGE_KEY);
+    if (!raw) return { txDbMin: TX_FIXED_DB_MIN, txDbMax: TX_FIXED_DB_MAX };
+    const parsed = JSON.parse(raw);
+    const txDbMin = typeof parsed?.txDbMin === 'number' ? parsed.txDbMin : TX_FIXED_DB_MIN;
+    const txDbMax = typeof parsed?.txDbMax === 'number' ? parsed.txDbMax : TX_FIXED_DB_MAX;
+    if (!(txDbMin < txDbMax) || !Number.isFinite(txDbMin) || !Number.isFinite(txDbMax)) {
+      return { txDbMin: TX_FIXED_DB_MIN, txDbMax: TX_FIXED_DB_MAX };
+    }
+    return { txDbMin, txDbMax };
+  } catch {
+    return { txDbMin: TX_FIXED_DB_MIN, txDbMax: TX_FIXED_DB_MAX };
+  }
+}
+
+function writeSavedTxRange(txDbMin: number, txDbMax: number): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(TX_STORAGE_KEY, JSON.stringify({ txDbMin, txDbMax }));
+  } catch {
+    // quota exceeded / private mode — accept silently.
+  }
+}
+
 // Exponential smoothing constant for the auto-range tracker. 0.1 trades
 // flicker resistance for responsiveness — band-change artifacts fade over
 // ~30 frames at 30 Hz (~1 s).
@@ -132,6 +167,10 @@ export type DisplaySettingsState = {
   // operator's only direct knob on the waterfall is the contrast (γ) slider.
   wfDbMin: number;
   wfDbMax: number;
+  // Separate dB range for TX panadapter (rendered during MOX/TUN). Thetis
+  // parity — see TX_FIXED_DB_MIN/MAX constants.
+  txDbMin: number;
+  txDbMax: number;
   colormap: ColormapId;
   contrast: number;
   setAutoRange: (v: boolean) => void;
@@ -145,11 +184,14 @@ export type DisplaySettingsState = {
   // drag DOWN raises both limits so the trace slides DOWN on the canvas.
   // Clamps absolute values to Thetis's ±200 dB window.
   shiftDbRange: (deltaDb: number) => void;
+  // Same as shiftDbRange but for the TX-specific range.
+  shiftTxDbRange: (deltaDb: number) => void;
 };
 
 const DB_ABS_LIMIT = 200;
 
 const initialRange = readSavedRange();
+const initialTxRange = readSavedTxRange();
 
 export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) => ({
   autoRange: false,
@@ -157,6 +199,8 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
   dbMax: initialRange.dbMax,
   wfDbMin: FIXED_DB_MIN,
   wfDbMax: FIXED_DB_MAX,
+  txDbMin: initialTxRange.txDbMin,
+  txDbMax: initialTxRange.txDbMax,
   colormap: 'blue',
   contrast: readSavedContrast(),
   setAutoRange: (autoRange) => {
@@ -189,6 +233,13 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
     const nextMax = Math.max(-DB_ABS_LIMIT, Math.min(DB_ABS_LIMIT, baseMax + deltaDb));
     set({ autoRange: false, dbMin: nextMin, dbMax: nextMax });
     writeSavedRange(nextMin, nextMax);
+  },
+  shiftTxDbRange: (deltaDb) => {
+    const { txDbMin, txDbMax } = get();
+    const nextMin = Math.max(-DB_ABS_LIMIT, Math.min(DB_ABS_LIMIT, txDbMin + deltaDb));
+    const nextMax = Math.max(-DB_ABS_LIMIT, Math.min(DB_ABS_LIMIT, txDbMax + deltaDb));
+    set({ txDbMin: nextMin, txDbMax: nextMax });
+    writeSavedTxRange(nextMin, nextMax);
   },
   updateAutoRange: (wfDb) => {
     if (!get().autoRange || wfDb.length === 0) return;

--- a/zeus-web/src/state/tx-store.ts
+++ b/zeus-web/src/state/tx-store.ts
@@ -156,6 +156,55 @@ export type TxState = {
   // haven't connected). Transient per-session — not persisted.
   paTempC: number | null;
   setPaTempC: (c: number) => void;
+
+  // ---- PureSignal (predistortion) — MsgType 0x18 at 10 Hz when armed.
+  // psEnabled is the master arm; not persisted (parity with MOX).
+  // psAuto / psSingle are the cal-mode select. The advanced fields are
+  // persisted because they're per-rack tuning the operator dials in once
+  // and rarely revisits.
+  psEnabled: boolean;
+  setPsEnabled: (on: boolean) => void;
+  psAuto: boolean;
+  setPsAuto: (on: boolean) => void;
+  psSingle: boolean;
+  setPsSingle: (on: boolean) => void;
+  psPtol: boolean;
+  setPsPtol: (on: boolean) => void;
+  psAutoAttenuate: boolean;
+  setPsAutoAttenuate: (on: boolean) => void;
+  psMoxDelaySec: number;
+  setPsMoxDelaySec: (s: number) => void;
+  psLoopDelaySec: number;
+  setPsLoopDelaySec: (s: number) => void;
+  psAmpDelayNs: number;
+  setPsAmpDelayNs: (ns: number) => void;
+  psHwPeak: number;
+  setPsHwPeak: (p: number) => void;
+  psIntsSpiPreset: string;
+  setPsIntsSpiPreset: (p: string) => void;
+  // Live readout pushed via MsgType.PsMeters (0x18) at 10 Hz when armed.
+  psFeedbackLevel: number;
+  psCorrectionDb: number;
+  psCalState: number;
+  psCorrecting: boolean;
+  psMaxTxEnvelope: number;
+  setPsMeters: (m: {
+    feedbackLevel: number;
+    correctionDb: number;
+    calState: number;
+    correcting: boolean;
+    maxTxEnvelope: number;
+  }) => void;
+
+  // ---- Two-tone test generator (TXA PostGen mode=1; protocol-agnostic).
+  twoToneOn: boolean;
+  setTwoToneOn: (on: boolean) => void;
+  twoToneFreq1: number;
+  setTwoToneFreq1: (hz: number) => void;
+  twoToneFreq2: number;
+  setTwoToneFreq2: (hz: number) => void;
+  twoToneMag: number;
+  setTwoToneMag: (m: number) => void;
 };
 
 export const useTxStore = create<TxState>()(
@@ -226,16 +275,74 @@ export const useTxStore = create<TxState>()(
       setAlert: (a) => set({ alert: a }),
       paTempC: null,
       setPaTempC: (c) => set({ paTempC: c }),
+
+      // PureSignal — psEnabled / psSingle / live read-out are NOT persisted;
+      // operator must re-arm each session.
+      psEnabled: false,
+      setPsEnabled: (on) => set({ psEnabled: on }),
+      psAuto: true,
+      setPsAuto: (on) => set({ psAuto: on }),
+      psSingle: false,
+      setPsSingle: (on) => set({ psSingle: on }),
+      psPtol: false,
+      setPsPtol: (on) => set({ psPtol: on }),
+      psAutoAttenuate: true,
+      setPsAutoAttenuate: (on) => set({ psAutoAttenuate: on }),
+      psMoxDelaySec: 0.2,
+      setPsMoxDelaySec: (s) => set({ psMoxDelaySec: s }),
+      psLoopDelaySec: 0,
+      setPsLoopDelaySec: (s) => set({ psLoopDelaySec: s }),
+      psAmpDelayNs: 150,
+      setPsAmpDelayNs: (ns) => set({ psAmpDelayNs: ns }),
+      psHwPeak: 0.4072,
+      setPsHwPeak: (p) => set({ psHwPeak: p }),
+      psIntsSpiPreset: '16/256',
+      setPsIntsSpiPreset: (p) => set({ psIntsSpiPreset: p }),
+      psFeedbackLevel: 0,
+      psCorrectionDb: 0,
+      psCalState: 0,
+      psCorrecting: false,
+      psMaxTxEnvelope: 0,
+      setPsMeters: (m) => set({
+        psFeedbackLevel: m.feedbackLevel,
+        psCorrectionDb: m.correctionDb,
+        psCalState: m.calState,
+        psCorrecting: m.correcting,
+        psMaxTxEnvelope: m.maxTxEnvelope,
+      }),
+
+      // Two-tone — defaults match pihpsdr.
+      twoToneOn: false,
+      setTwoToneOn: (on) => set({ twoToneOn: on }),
+      twoToneFreq1: 700,
+      setTwoToneFreq1: (hz) => set({ twoToneFreq1: hz }),
+      twoToneFreq2: 1900,
+      setTwoToneFreq2: (hz) => set({ twoToneFreq2: hz }),
+      twoToneMag: 0.49,
+      setTwoToneMag: (m) => set({ twoToneMag: m }),
     }),
     {
       name: 'zeus-tx',
-      // Only persist the two fields the operator repeatedly sets. Everything
-      // else (mox/tun/meters/alert) is transient per-session.
+      // Persist only operator-tuning fields. Master arm bits (psEnabled,
+      // twoToneOn, mox/tun) are transient per-session.
       partialize: (s) => ({
         drivePercent: s.drivePercent,
         tunePercent: s.tunePercent,
         micGainDb: s.micGainDb,
         levelerMaxGainDb: s.levelerMaxGainDb,
+        // PS tuning is persisted server-side too, but we mirror it here so
+        // the slider seeks don't flicker on first paint after a reload.
+        psAuto: s.psAuto,
+        psPtol: s.psPtol,
+        psAutoAttenuate: s.psAutoAttenuate,
+        psMoxDelaySec: s.psMoxDelaySec,
+        psLoopDelaySec: s.psLoopDelaySec,
+        psAmpDelayNs: s.psAmpDelayNs,
+        psHwPeak: s.psHwPeak,
+        psIntsSpiPreset: s.psIntsSpiPreset,
+        twoToneFreq1: s.twoToneFreq1,
+        twoToneFreq2: s.twoToneFreq2,
+        twoToneMag: s.twoToneMag,
       }),
     },
   ),

--- a/zeus-web/src/state/tx-store.ts
+++ b/zeus-web/src/state/tx-store.ts
@@ -182,6 +182,12 @@ export type TxState = {
   setPsHwPeak: (p: number) => void;
   psIntsSpiPreset: string;
   setPsIntsSpiPreset: (p: string) => void;
+  // Feedback antenna source — Internal coupler (default) or External
+  // (Bypass). On G2/MkII this flips one ALEX bit; WDSP cal/iqc are
+  // unaffected. The HW-Peak slider stays shared across sources to match
+  // pihpsdr/Thetis behaviour.
+  psFeedbackSource: 'internal' | 'external';
+  setPsFeedbackSource: (s: 'internal' | 'external') => void;
   // Live readout pushed via MsgType.PsMeters (0x18) at 10 Hz when armed.
   psFeedbackLevel: number;
   psCorrectionDb: number;
@@ -298,6 +304,8 @@ export const useTxStore = create<TxState>()(
       setPsHwPeak: (p) => set({ psHwPeak: p }),
       psIntsSpiPreset: '16/256',
       setPsIntsSpiPreset: (p) => set({ psIntsSpiPreset: p }),
+      psFeedbackSource: 'internal',
+      setPsFeedbackSource: (s) => set({ psFeedbackSource: s }),
       psFeedbackLevel: 0,
       psCorrectionDb: 0,
       psCalState: 0,
@@ -340,6 +348,7 @@ export const useTxStore = create<TxState>()(
         psAmpDelayNs: s.psAmpDelayNs,
         psHwPeak: s.psHwPeak,
         psIntsSpiPreset: s.psIntsSpiPreset,
+        psFeedbackSource: s.psFeedbackSource,
         twoToneFreq1: s.twoToneFreq1,
         twoToneFreq2: s.twoToneFreq2,
         twoToneMag: s.twoToneMag,

--- a/zeus-web/src/state/tx-store.ts
+++ b/zeus-web/src/state/tx-store.ts
@@ -38,6 +38,8 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
+import type { RadioStateDto } from '../api/client';
+
 // TX-side state. Intentionally separate from connection-store so the TX panel
 // can mount/unmount cleanly and so TX-specific fields (drivePercent, micGainDb,
 // meter values, SWR alert) can accumulate here as subsequent slices land.
@@ -211,6 +213,13 @@ export type TxState = {
   setTwoToneFreq2: (hz: number) => void;
   twoToneMag: number;
   setTwoToneMag: (m: number) => void;
+
+  // Hydrate the persistable PS / TwoTone fields from the server's StateDto.
+  // Called from ConnectPanel and App.tsx alongside connection-store.applyState
+  // so a fresh browser (no localStorage) sees the operator's last persisted
+  // dial-in instead of the hard-coded defaults. Master-arm fields are
+  // intentionally NOT hydrated — the operator must re-arm each session.
+  hydrateFromState: (s: RadioStateDto) => void;
 };
 
 export const useTxStore = create<TxState>()(
@@ -328,6 +337,21 @@ export const useTxStore = create<TxState>()(
       setTwoToneFreq2: (hz) => set({ twoToneFreq2: hz }),
       twoToneMag: 0.49,
       setTwoToneMag: (m) => set({ twoToneMag: m }),
+
+      hydrateFromState: (s) =>
+        set({
+          psAuto: s.psAuto,
+          psPtol: s.psPtol,
+          psAutoAttenuate: s.psAutoAttenuate,
+          psMoxDelaySec: s.psMoxDelaySec,
+          psLoopDelaySec: s.psLoopDelaySec,
+          psAmpDelayNs: s.psAmpDelayNs,
+          psIntsSpiPreset: s.psIntsSpiPreset,
+          psFeedbackSource: s.psFeedbackSource,
+          twoToneFreq1: s.twoToneFreq1,
+          twoToneFreq2: s.twoToneFreq2,
+          twoToneMag: s.twoToneMag,
+        }),
     }),
     {
       name: 'zeus-tx',


### PR DESCRIPTION
Closes #81 (TX panadapter) and lands the PureSignal foundation + working AutoAttenuate convergence on Protocol 2 (Saturn / G2 MkII).

This is a big PR because the work was done in tightly-coupled layers (wire → DSP → server → web), and rack debugging on the G2 MkII surfaced several fixes that had to land alongside each other to actually make PS converge. I've split commits logically so the PR can be read top-to-bottom, but the easiest review path is probably: read this description first, then look at the final two commits (`983f0a8`, `55f36c1`) which are today's convergence fixes.

> **For George:** the deep-dive section below is structured so you can pull a focused understanding of Zeus's PS architecture without re-reading the full WDSP / pihpsdr / Thetis source trees. The "Wiring Notes for Protocol 1 (Hermes)" section is the action item.

---

## What this PR ships

| Area | Status | Commits |
|------|--------|---------|
| TX panadapter (issue #81) | Working | `8c63cc9`, `c549d32`, `43239cd`, `5bf39d2` |
| Protocol 2 PureSignal foundation | Working — rack-verified | `4cbd981`, `e356098`, `3bef94b`, `8060a5a`, `1a51827`, `c83a39b`, `dc8daca` |
| Web UI: PS Settings panel + TwoTone button | Working | `ca75d1a` |
| PS arm sequence (wire-first → 100 ms → engine-arm) | Working | `1da34e3` |
| PS Auto/Single/TwoTone/AutoAttenuate persistence | Working | `62e2dee` |
| AutoAttenuate timer2 + step-att wire support | Working — rack-verified today | `1a96963`, `983f0a8`, `55f36c1` |
| TwoTone (basic gen.c PostGen, mode-1) | **Partially broken — RF lands wrong sideband in LSB** | `794b743`, `b100d41`, `ae82733` (deferred to follow-up PR) |

**Test coverage** added across the layers: `56f9027` (frame round-trip / HW peak / wire format), `d46ce64` (DDC pairing / Bypass bit / TwoTone latch), `4ec4d67` (attenuator / auto-MOX / persistence). Today's convergence patch updates `PsWireFormatTests` for the new asymmetric byte 58/59 contract.

**Rack verification** (today, 2026-04-25, G2 MkII firmware 2.7b41, 80m, 1300 W external amp, mic-MOX, PS Auto + AutoAttenuate ON + Feedback Source External):
- AutoAttenuate ramped 0 → 21 dB
- WDSP `info[4]` (feedback peak) dropped 440 → 162 (target window 128..181)
- WDSP `info[14] = 1` (calcc actively correcting)
- External KiwiSDR confirmed cleaner signal envelope (spurs reduced)

---

## Architecture map

The PS path crosses every layer in the stack. The end-to-end flow during a PS-armed MOX:

```
[radio] → UDP/1035 paired DDC0+DDC1 packets (192 kHz, 24-bit)
  ↓
Zeus.Protocol2/Protocol2Client.HandlePsPairedPacket()
  - DDC0 → rx buffer (PA-coupler feedback)
  - DDC1 → tx buffer (TX-DAC reference loopback)
  - 1024-sample blocks accumulated, fed to engine
  ↓
Zeus.Server/DspPipelineService.StartPsFeedbackPumpP2()
  - Pumps blocks into engine.FeedPsFeedbackBlock()
  ↓
Zeus.Dsp/Wdsp/WdspDspEngine.FeedPsFeedbackBlock()
  - NativeMethods.psccF(id, 1024, txI, txQ, rxI, rxQ, 0, 0)
  - Note pscc arg order: TX-DAC ref FIRST, RX feedback SECOND (matches pihpsdr transmitter.c:2066)
  ↓
[WDSP calcc state machine]
  - LRESET → LWAIT → LMOXDELAY → LSETUP → LCOLLECT → LMOXCHECK → LCALC → LDELAY → LSTAYON → LTURNON
  - Reads info[4]=feedback peak, info[5]=cal attempts, info[6]=status flags, info[14]=correcting, info[15]=state
  ↓
Zeus.Server/PsAutoAttenuateService.Tick1() (10 Hz polling, info[5]-gated stepping)
  - Reads psm.FeedbackLevel via engine.GetPsStageMeters()
  - If feedback > 181: step attenuator UP via p2.SetTxAttenuationDb()
  - If feedback < 128 with attn > 0: step DOWN
  ↓
Zeus.Protocol2/Protocol2Client.SetTxAttenuationDb()
  - Updates _txStepAttnDb, re-emits SendCmdTx() on UDP/1026
  - Byte 58 always 31 when PA on (TX-DAC ref protection)
  - Byte 59 takes the dynamic step-att (PA-feedback ADC)
  ↓
[radio applies new attenuator on next TX cycle, calcc sees new envelope]
```

---

## Deep dive: what we built and why

### 1. Wire path — paired DDC packets on Saturn

Saturn (G2 MkII / Saturn-XDMA) emits PS feedback as **interleaved DDC0+DDC1 sample pairs** on UDP/1035. The radio's hardware pairs them: DDC0 reads the PA-coupler ADC (feedback / "rx" in pscc parlance), DDC1 reads the TX-DAC loopback ADC (reference / "tx" in pscc parlance). They share a sample clock and arrive in the same packet, so application-level timestamping is unnecessary.

Activation requires three things:
1. `ALEX_PS_BIT (0x00040000)` set in the high-priority alex0/alex1 words (`Protocol2Client.cs:740-744`)
2. DDC0 enabled + DDC1 enabled at 192 kHz / 24-bit + sync byte `1363 = 0x02` in CmdRxSpecific (`Protocol2Client.cs:558-570`)
3. `ALEX_RX_ANTENNA_BYPASS (0x00000800)` set in alex0 during xmit when the operator selected "External" feedback source (the amp coupler tap goes to the radio's Bypass / Ext1 port)

This is bit-for-bit identical to pihpsdr's Saturn `case 107` (External Bypass + PS armed) — verified during today's deep-dive.

### 2. The HW peak per-board (Thetis vs pihpsdr disagreement)

`SetPSHWPeak(channel, peak)` tells calcc the peak normalised amplitude the radio can produce. It's used to compute `info[4] = 256 × hw_scale ÷ rx_scale` where `hw_scale = 1/peak`. Choosing the wrong value pushes info[4] permanently outside the convergence window.

Thetis and pihpsdr disagree on the value for G2 MkII:
- **Thetis** (`clsHardwareSpecific.PSDefaultPeak:295-318`): only `Saturn` (PCIe Orion-MkII) → 0.6121; `ANAN_G2 / OrionMkII / etc.` → 0.2899
- **pihpsdr** (`transmitter.c:1166-1179`): `NEW_DEVICE_SATURN` → 0.6121; `NEW_DEVICE_SATURN` is labelled "Saturn/G2" in `new_discovery.c:341`

Per project convention (the user's memory rule: pihpsdr wins for MkII-specific quirks), Zeus uses **0.6121 for G2 MkII** (`RadioService.cs:840`). Today's rack run confirmed this is correct — info[4] settled at 162, smack in the middle of the 128..181 window, with hw_peak=0.6121.

### 3. The PS arm sequence

Order matters here. pihpsdr does **wire-first → 100 ms settle → engine-arm-second** (`transmitter.c:2387-2476`). Thetis does it without an explicit sleep, relying on the 10 ms PS-thread tick spacing. Zeus chose pihpsdr's pattern (commit `1da34e3`) — empirically the radio firmware needs the wire-side reconfiguration to land before the WDSP `SetPSControl(autorestart=1)` arms calcc, otherwise the first calc cycle can race and produce unstable cm.

Inside `DspPipelineService.OnRadioStateChanged` (lines 341-410):
1. Apply `SetPsHwPeak`, `SetPsAdvanced` (Pin/Map/Ptol/Stbl/Ints/Spi/MoxDelay/LoopDelay/AmpDelay)
2. Apply `SetPsControl` for current Auto/Single mode
3. On PS-enable transition: `_p2Client.SetPsFeedbackEnabled(true)` → `Task.Delay(100).Wait()` → `engine.SetPsEnabled(true)`

### 4. AutoAttenuate — Thetis-style continuous, pihpsdr-style settle

Two reference implementations took different design paths:
- **Thetis** runs `timer2code` continuously while PS is armed — gated on `CalibrationAttemptsChanged` so it only steps after a fresh calc completes (PSForm.cs:1097-1099). Step computation: `ddB = 20·log10(feedback / 152.293)` with ±1 dB clamp (PSForm.cs:745-754). Operator can mic-key during cal.
- **pihpsdr** runs `ps_calibration_timer` ONLY during TwoTone (`tx_set_twotone → g_timeout_add(100, …)`). Outside two-tone, operator manually adjusts via the att spinbox.

Zeus follows Thetis's more aggressive continuous behaviour but matches pihpsdr's per-step settle. This is encoded in `PsAutoAttenuateService.Tick1`:
1. **Gate suite** (lines 126-148, with diagnostic logs added today):
   - `s.PsEnabled` — PS armed
   - `s.PsAutoAttenuate` — checkbox ticked (default true, persisted in LiteDB)
   - `_tx.IsMoxOn || _tx.IsTwoToneOn` — actively keying
   - `_pipe.CurrentP2Client != null` — P1 not yet wired (gated to P2 only — see Hermes notes below)
   - `_pipe.CurrentEngine != null` — DSP up
   - `psm.CalibrationAttempts != _lastCalibrationAttempts` — Thetis-canonical info[5] gate (today's Patch A)
   - `feedback > 0` — calcc has produced a real reading
   - `feedback NOT in [128..181]` — outside target window
2. **Step computation** (lines 151-156): `ddB = 20·log10(feedback / 152.293)`, `step = ±1 dB`, clamp to [0, 31]
3. **Wire write** (line 164): `p2.SetTxAttenuationDb((byte)newAttn)` — emits CmdTx to UDP/1026
4. **Settle + reset** (lines 170-171): 100 ms delay → `engine.ResetPs()` (today's Patch D — two-phase reset+restore so calcc autorestarts)

### 5. The PA-protection asymmetry (today's Patch B)

`pihpsdr new_protocol.c:1540-1547` enforces a strict invariant:

```c
if (xmit && local_pa_enable) {
    transmit_specific_buffer[58] = 31;   // ADC1 (TX-DAC reference)
    transmit_specific_buffer[59] = 31;   // ADC0 (PA-feedback)
}
if (transmitter->puresignal) {
    transmit_specific_buffer[59] = transmitter->attenuation;   // ONLY byte 59
}
```

When PA is on and PS is on:
- **Byte 58 stays at 31** — the TX-DAC reference loopback ADC needs its own protection independent of where the operator parks the PA-feedback ADC
- **Byte 59 takes the operator's step-att** — the PA-feedback ADC is the one PS reads, and AutoAttenuate's job is to keep its envelope in the calcc target window

Pre-Patch-B Zeus wrote the same value across bytes 57/58/59. That meant the first AutoAttenuate step dropped both ADCs in lockstep, the rx/tx envelope ratio inside calcc never shifted, and `info[4]` stayed glued at the over-range reading regardless of how high AutoAttenuate ramped. **This was a silent killer** — the wire change reached the radio (verified via tcpdump) but didn't actually redistribute the feedback gain.

### 6. The convergence loop (today's Patch A + Patch D)

Patch A and Patch D had to land together. Symptoms of either alone:

| State | Symptom |
|-------|---------|
| Pre-A, Pre-D | Loop steps every 100 ms regardless of calc state. cm jumps every fit, info[6]=0x40 set continuously, calcc thrashes between LCOLLECT and LRESET, info[14] stays 0. |
| Patch A only (without D) | Loop correctly waits for info[5] to increment. After the first step, ResetPs sets `automode=0`, calcc parks at LRESET forever, info[5] never increments past 1, loop gates forever. **One step then dead.** |
| Patch D only (without A) | Calcc autorestarts after each reset. But loop still steps every 100 ms, so cm jumps every fit, info[6]=0x40 every iteration, never converges. |
| **Both A + D** | Loop steps once per completed calc. Each step's ResetPs cleans calcc to LRESET then re-arms with `automode=1` so calcc autorestarts. info[5] increments. info[4] drops monotonically. info[14] flips to 1 when cm coefficients stabilise. **Converges.** |

Patch A also extends `PsStageMeters` with `CalibrationAttempts` (the info[5] surface) so the service can read it from the engine cleanly without exposing the raw `_psInfoBuf`.

### 7. The diagnostic gate logging (today's Patch C)

Pre-Patch-C, every early-return in `Tick1` was indistinguishable from "loop is firing fine, gates are passing, just no work to do." During the rack work that produced fixes A/B/D, this was the single biggest blocker — we couldn't tell whether:
- `s.PsAutoAttenuate` was false (silent UI POST failure)
- `_tx.IsMoxOn` was racing
- `engine.GetPsStageMeters()` was returning Silent
- some exception was being swallowed

The patch adds a rate-limited (1 line/sec) `psAutoAttn.gate skip=<reason>` log that tags exactly which gate fired. Examples:
```
psAutoAttn.gate skip=PsEnabled-off
psAutoAttn.gate skip=AutoAttenuate-off
psAutoAttn.gate skip=not-keyed
psAutoAttn.gate skip=p2-null
psAutoAttn.gate skip=fb-zero psm.fb=0.00
psAutoAttn.gate skip=in-window fb=162
psAutoAttn.gate skip=too-quiet-at-zero fb=80
psAutoAttn.gate skip=no-new-calc info5=21 fb=182
```

Left in the code for future regressions — the cost is one log line per second when the loop is gated, zero when it's stepping.

---

## What didn't work — false starts and theories disproved

For history (and so George doesn't waste time on the same dead ends):

1. **"Silent UI POST failure → server has PsAutoAttenuate=false"** — disproved by `curl /api/state` showing `psAutoAttenuate: true` while the symptom persisted. The frontend `.catch(() => {})` swallows is real but wasn't the cause of this particular bug.
2. **"HW peak 0.6121 is wrong, should be 0.2899 for ANAN_G2 per Thetis"** — partially right (Thetis does use 0.2899 for ANAN_G2) but irrelevant for G2 MkII per pihpsdr's "Saturn/G2 = 0.6121" labelling. Also the math: lowering hw_peak makes info[4] *bigger*, not smaller, so this couldn't have been the convergence fix anyway.
3. **"pscc arg order reversed (tx/rx swap at the P/Invoke)"** — would have been a single-deviation fix for everything, but verified in code: Zeus calls `psccF(id, 1024, txI, txQ, rxI, rxQ, …)` matching pihpsdr's `pscc(id, n, tx_dac_iq, rx_feedback_iq)` exactly. False alarm.
4. **"DDC0/DDC1 antenna routing wrong"** — investigated end-to-end against pihpsdr's `case 107` (External Bypass + PS armed). Bit-for-bit identical. The radio was sampling the right physical port the whole time.
5. **"AutoAttenuate's ddB computation ramps the wrong direction"** — looked at the math repeatedly. Direction is correct (feedback > 152 → ddB > 0 → attenuate more → feedback drops). Confirmed by today's monotonic ramp.

---

## Wiring notes for Protocol 1 (Hermes-class)

Brian — this is the key handoff. The PS work above is **P2-gated** by `_pipe.CurrentP2Client is null` at `PsAutoAttenuateService.cs:131`. To bring PS up on Hermes / Hermes-Lite-2 / Atlas / other P1 boards, here's what George will need to wire:

### What changes on the wire

1. **PS feedback path** — P1 doesn't use paired DDC packets. Feedback arrives in the C&C structure of the regular P1 RX stream. The bit that enables PS routing is a C&C control bit, not a high-priority ALEX bit. See Thetis `cmaster.cs:538-540` (`SetPSRxIdx(0,0)` / `SetPSTxIdx(0,1)`) — the Stream0/Stream1 routing is C&C-side on P1.
2. **PS sample rate** — P1 matches the RX sample rate (typically 48 kHz). Not pinned at 192 kHz like P2. The `SetPSFeedbackRate` call in `WdspDspEngine.OpenTxChannel` already uses 48 kHz on P1 (`Wdsp/WdspDspEngine.cs:914`).
3. **TX step attenuator wire path** — P1 uses a single byte (the C0/C1/C2 step-att structure in the standard P1 frame), not the asymmetric 58/59 of P2. The `Protocol1Client` will need a `SetTxAttenuationDb` equivalent that writes to the right C&C byte.

### What changes for the engine setup

4. **HW peak per P1 board** — per pihpsdr `transmitter.c:1166-1179`:
   - Hermes-Lite 2: `0.2400`
   - StemLab: `0.4160`
   - Other P1 (Hermes, Atlas): `0.4067`
   - Thetis (`clsHardwareSpecific.PSDefaultPeak`) uses `0.4072` for ALL P1 models — close enough that either should work; pihpsdr's per-board variants are more precise.
5. **The per-board seam already exists** — `RadioService.ResolvePsHwPeak` at `RadioService.cs:829-843`. Add P1 board cases there alongside the existing OrionMkII handling.

### What changes in the service layer

6. **`PsAutoAttenuateService.Tick1` line 131** — `if (p2 is null) return;` is the P1-block. Replace with a unified path:
   ```csharp
   var radioClient = _pipe.CurrentP2Client ?? (object)_pipe.CurrentP1Client;
   if (radioClient is null) return;
   ```
   ...or split the service into a P1 and P2 variant if the wire-write surface differs enough.
7. **`SetTxAttenuationDb` for P1** — implement in `Protocol1Client` writing to whichever C&C byte the P1 wire format uses. Match the dynamic-update pattern (re-emit on change).
8. **PA-protection invariant** — P1 has its own equivalent. pihpsdr's `new_protocol.c` writes 31 to ADC1 step-att during xmit when PA enabled. P1's analog: confirm by reading `Thetis cmaster.cs` PS section.

### What stays the same

- The state machine semantics (LRESET..LTURNON), info[] indices, and target window (128..181) are WDSP-internal — they're identical regardless of protocol.
- The 100 ms wire-first arm settle (commit `1da34e3`) — pihpsdr does this for all protocols, keep it for P1.
- The Auto/Single/AutoAttenuate UI knobs and the persistence — already protocol-agnostic.
- The `engine.ResetPs()` two-phase reset+restore (today's Patch D) — engine-internal, doesn't touch the wire.

### What to test on P1 first

- Discovery + connect to a Hermes (or HL2 — the user has one available)
- Confirm DDC0+DDC1 sample routing through C&C
- Verify `info[4]` reads stable values (anything > 0) before worrying about AutoAttenuate convergence
- Then bring up `PsAutoAttenuateService` for P1 — use the same diagnostic gate logging from Patch C to verify each guard

### A note on protocol-1 difficulties

P1's framing is bit-packed C&C control, which is harder to inspect in tcpdump than the byte-aligned P2 packets. The diagnostic patterns we used here (tcpdump byte 59, gate-skip logs, `psState` edge logs) translate but the C&C decoding is more involved. Worth investing 30 minutes in a small `PrintC&CFrame(span)` helper before debugging anything live on Hermes.

---

## What's NOT in this PR (deferred)

### TwoTone sideband direction (will be a separate PR)

TwoTone tones currently emit on the upper sideband (USB-side of carrier) regardless of mode. In USB this happens to be correct; in LSB this is wrong. The fix is a one-line predicate flip at `WdspDspEngine.cs:1208-1212` and `:1162-1166` (currently flips for USB-family; should flip for LSB-family per Thetis `setup.cs:11097-11101`), but it needs an external-RX confirmation in USB before landing — we have ground truth for LSB (verified wrong) but not yet for USB (only the panadapter — which can mirror). The user has chosen to defer this so the PS work can ship cleanly.

### TwoTone panadapter rendering

The TX analyzer feed at `WdspDspEngine.cs:1604-1605` complex-conjugates Q before pushing into `Spectrum0`. This was added in commit `43239cd` as an empirical voice-display fix (without it, voice in LSB renders on the USB side of the trace and vice-versa even though on-air RF is correct). For TwoTone, gen.c bypasses the SSB bandpass and emits a pre-conjugated baseband, so the analyzer's second conjugation un-mirrors it back across the screen. Currently displays across the whole frequency range. The fix is to skip the conjugation when `_twoToneArmed`, but it needs to land alongside the predicate fix above. Same follow-up PR.

### `s.PsAutoAttenuate` UI silent-catch hardening

`zeus-web/src/components/PsSettingsPanel.tsx` has multiple `.catch(() => {})` swallowing setPsAdvanced POST errors. This isn't the proximate cause of any PS bug today, but it's a hidden divergence trap (UI shows checkbox ON, server has the field at its previous value). Worth a small cleanup PR to surface errors and revert local state on POST failure.

---

## Critical file pointers (for George)

- **`Zeus.Server/PsAutoAttenuateService.cs`** — the AutoAttenuate gate + step + reset cycle. Today's Patches A and C live here.
- **`Zeus.Dsp/Wdsp/WdspDspEngine.cs`** — `OpenTxChannel` (PS seed setup), `SetPsEnabled` (arm), `SetPsHwPeak`, `GetPsStageMeters` (info[] read), `ResetPs` (today's Patch D), `SetTwoTone` (TwoTone arm — the deferred-PR area).
- **`Zeus.Protocol2/Protocol2Client.cs`** — `HandlePsPairedPacket` (DDC pair decode), `ComposeCmdTxBuffer` (today's Patch B asymmetric byte 58/59), `SetTxAttenuationDb` (wire write), `SendCmdHighPriority` (ALEX_PS_BIT + Bypass routing), `SendCmdRxSpecific` (DDC0+DDC1 enable, sync byte 1363).
- **`Zeus.Server/DspPipelineService.cs`** — `OnRadioStateChanged` (PS arm orchestration), `StartPsFeedbackPumpP2`.
- **`Zeus.Server/RadioService.cs`** — PS state DTO, `SetPs`, `SetPsAdvanced`, `SetPsFeedbackSource`, `ResolvePsHwPeak` (per-board hw_peak seam).
- **`Zeus.Server/PsSettingsStore.cs`** — LiteDB persistence (`Auto`, `AutoAttenuate`, `Ptol`, MoxDelay, LoopDelay, AmpDelay, IntsSpi, FeedbackSource, TwoTone freq/mag).
- **`Zeus.Contracts/PsMetersFrame.cs`** — wire DTO for the PS feedback meter broadcast (FeedbackLevel, CorrectionDb, CalState, Correcting, MaxTxEnvelope).
- **`Zeus.Dsp/PsStageMeters.cs`** — engine-internal PS stage record (today's Patch A added `CalibrationAttempts` here).
- **`zeus-web/src/components/PsSettingsPanel.tsx`** — Auto/Single, AutoAttenuate checkbox, Feedback Source selector, TwoTone button, advanced settings (Ptol/MoxDelay/etc.), feedback bar.

## Reference implementations consulted

- **Thetis** (`/Users/bek/zeus-projects/Thetis-source` for kb2uka or similar for Brian) — `Source/Console/PSForm.cs` (timer2code, info[] read), `Source/Console/cmaster.cs` (wire-side PS), `Source/Console/clsHardwareSpecific.cs` (`PSDefaultPeak`), `Source/Console/setup.cs` (Linearity menu defaults — chkPSPin/chkPSMap/chkPSStbl/chkPSRelaxPtol/etc.)
- **pihpsdr** (`/path/to/pihpsdr/src/`) — `transmitter.c` (PS engine arm, `ps_setpk` per board, `tx_ps_resume`/`tx_ps_reset`), `new_protocol.c` (wire format, ALEX bits, byte 58/59 PA-protection), `ps_menu.c` (UI, `ps_calibration_timer` AutoAttenuate)
- **WDSP** (`native/wdsp/calcc.c`) — the canonical state machine (LRESET..LTURNON enum at lines 542-553, the calc() function, scheck/scOK predicates, the info[] writes)
- **Warren Pratt's PureSignal_Public.pdf** (2014 Friedrichshafen deck) — operator workflow ("adjust attenuators for GREEN Feedback Level"), time-alignment requirement (`SetPSTXDelay`), conceptual coverage. Predates Saturn so doesn't list per-radio HW peak values.

## Test plan

1. Connect to G2 MkII (or any P2 Saturn-class)
2. PS Settings panel:
   - Auto mode (not Single)
   - AutoAttenuate checkbox ticked
   - Feedback Source = External (or Internal if no external coupler)
3. Tune to a band with sufficient drive (80m / 1.3 kW recommended; lower power should also converge but with smaller info[4] starting envelope)
4. Key MOX with mic for ~10 seconds
5. Watch backend log for:
   - `psAutoAttn.armed reset attn=0` (PS arm edge)
   - `psAutoAttn.step feedback=N info5=K ddB=… attn 0->1 dB` (steps)
   - `wdsp.psState … info4=N info14=1` (correcting)
6. UI:
   - Feedback bar shows roughly half-full when settled
   - PS Settings cal-state badge transitions through SETUP → COLLECT → CALC → STAYON

## Maintainer review checklist

- [ ] Audio chain unchanged (no edits to TX bandpass, AGC, leveler, EER, mic gain, equalizer, compander, ALC)
- [ ] DUC frequency / phase word path unchanged (CmdHighPriority bytes 329-332, CmdGeneral byte 37 untouched)
- [ ] HL2 not touched — Patch B's wire change is gated to the P2 path (`Protocol2Client`), HL2 (P1) untouched
- [ ] Defaults unchanged — no operator-feel changes to TX power, filter widths, AGC, meter scaling, etc.
- [ ] No new threads / no new NuGet packages
- [ ] Test suite green (`dotnet test Zeus.slnx` — 451 passed, 5 skipped, 0 failed locally)