### PR TITLE
chore: add issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,93 @@
+name: Bug report
+description: Something Zeus does wrong on a real radio (RX, TX, panadapter, meters, hub, etc.)
+labels: ["bug", "needs-repro"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Zeus runs against several different HPSDR
+        boards and a lot of issues turn out to be board-specific, so the questions below
+        exist to save a round-trip.
+
+        If you want the in-repo agent (`@claude`) to look at this issue, you can mention it
+        in the body or in a follow-up comment.
+
+  - type: dropdown
+    id: board
+    attributes:
+      label: Radio / board
+      description: Which HPSDR board are you running Zeus against?
+      options:
+        - Hermes Lite 2 (HL2)
+        - Hermes
+        - ANAN-10
+        - ANAN-100
+        - ANAN-100D
+        - ANAN-200D
+        - Orion
+        - ANAN G2 / G2 MkII
+        - Other (please describe in "What happened")
+        - Not connected to a radio (synthetic / web-only)
+    validations:
+      required: true
+
+  - type: input
+    id: zeus-version
+    attributes:
+      label: Zeus version / commit
+      description: Output of "About" in the UI, the installer filename, or a git SHA if you built from source.
+      placeholder: e.g. v0.4.2  or  commit 7329284
+    validations:
+      required: true
+
+  - type: input
+    id: env
+    attributes:
+      label: OS and browser
+      description: Operating system + browser (Zeus uses your browser as the frontend).
+      placeholder: e.g. macOS 14.5, Chrome 124  /  Windows 11, Edge 125
+    validations:
+      required: true
+
+  - type: dropdown
+    id: connection
+    attributes:
+      label: How is Zeus reaching the radio?
+      options:
+        - Auto-discovery (UDP broadcast)
+        - Static IP / manual address
+        - N/A (no radio)
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did you do, what did you expect, and what did Zeus actually do?
+      placeholder: |
+        Steps:
+        1. ...
+        2. ...
+
+        Expected: ...
+        Actual: ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: backend-log
+    attributes:
+      label: Zeus.Server log excerpt (if relevant)
+      description: |
+        For TX / power / drive issues, the `p1.tx.rate pkts=... drv=... peak=...` lines from
+        Zeus.Server during MOX/TUN are usually the whole answer — please include a few seconds
+        of them if you can. For RX / panadapter / meter issues, anything around the time of
+        the bug helps.
+      render: text
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else
+      description: Screenshots, browser-console errors, related issues, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Zeus wiki
+    url: https://github.com/brianbruff/openhpsdr-zeus/wiki
+    about: Setup, supported radios, and usage notes live on the wiki — please skim before filing.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: Feature request
+description: Suggest a new capability or an improvement to existing behaviour
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing: Zeus aims for parity with Thetis behaviour first, and visual / UX /
+        default-value changes are decided by the maintainer (Brian, EI6LF). Suggestions in
+        those areas are welcome, but they may be discussed before any code is written.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: What can't you do today, or what's awkward about how Zeus does it now?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: What should Zeus do instead? Rough sketches and screenshots are fine.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about, including "leave it alone".
+
+  - type: input
+    id: board
+    attributes:
+      label: Affected radio(s)
+      description: If the request is board-specific (HL2, ANAN, Orion, G2…), say which.
+      placeholder: e.g. Hermes Lite 2 only / all boards / N/A


### PR DESCRIPTION
## Summary
- Adds `.github/ISSUE_TEMPLATE/bug_report.yml` — radio board dropdown (HL2, Hermes, ANAN-*, Orion, G2, …), Zeus version, OS/browser, connection mode, what-happened, optional Zeus.Server log excerpt.
- Adds `.github/ISSUE_TEMPLATE/feature_request.yml` — problem / proposal / alternatives / affected boards.
- Adds `.github/ISSUE_TEMPLATE/config.yml` — links the wiki and leaves blank issues enabled.

## Why
A lot of Zeus bugs turn out to be board-specific (HL2 drive model, ANAN PA gain, etc.). Forcing reporters to state the board + version + connection mode upfront should save round-trips, and gives the triage agent more structured text to work from.

## Compatibility with existing automations
Verified before adding:
- **`claude.yml`** (`@claude` responder) — matches `@claude` as a substring of `issue.body` / `issue.title` / comment bodies. Issue forms render to a plain-markdown body, so the match still works. Comments are untouched.
- **`zeus-agent.yml`** (triage on `issues.opened`) — reads `github.event.issue.body` and uses `gh issue view`; both still return the rendered form as markdown, giving the agent *more* structure, not less. Pre-applied labels (`bug`, `needs-repro`, `enhancement`) all already exist on the repo, so the "NEVER invent new labels" rule is preserved.
- Blank issues remain enabled, so a quick `@claude`-mention issue with no scaffolding is still possible.

## Test plan
- [ ] Open a draft issue from each template via the GitHub UI and confirm fields render as expected.
- [ ] File a throwaway test issue to confirm `zeus-agent` triage still runs on `issues.opened` and applies labels.
- [ ] Comment `@claude` on an existing issue to confirm the responder workflow still fires.