### PR TITLE
docs: add pihpsdr (DL1YCF/DH1KLM) and DeskHPSDR (DL1BZ) attributions

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -16,11 +16,13 @@ text is in [`LICENSE`](LICENSE). Every first-party source file in this
 repository carries the `SPDX-License-Identifier: GPL-2.0-or-later` tag
 plus a short-form copyright and attribution block.
 
-This licence was chosen deliberately to align Zeus with its two direct
-upstreams:
+This licence was chosen deliberately to align Zeus with its primary
+upstreams and reference projects:
 
 - **Thetis** — GPL v2 or later
 - **WDSP** — GPL v2 or later
+- **pihpsdr** — GPL v2 or later
+- **DeskHPSDR** — GPL v2 or later
 
 Zeus's "or later" clause preserves forward-compatibility with downstream
 GPL v3 works.
@@ -128,6 +130,37 @@ GPL-2.0-or-later under the Zeus copyright:
 - `native/wdsp/stubs/sbnr_stub.c`
 - `native/wdsp/stubs/specbleach_adenoiser.h`
 
+## Relationship to pihpsdr
+
+Zeus is independent of pihpsdr but **routinely consulted pihpsdr source as
+the authoritative reference for Saturn-class (ANAN G2, G2 MkII, Saturn /
+Saturn-XDMA) Protocol-2 behaviour**, particularly for:
+
+- Hardware-peak values per board class (`transmitter.c`)
+- Wire-format byte semantics on `CmdHighPriority` and `CmdTx` (`new_protocol.c`)
+- PureSignal arm sequence and `tx_ps_reset` / `tx_ps_resume` patterns
+- ALEX antenna routing for the PS feedback DDC pair
+- DDC0 / DDC1 sample-pair convention into `pscc()`
+
+pihpsdr is maintained by **Christoph Wüllen, DL1YCF** at
+[github.com/dl1ycf/pihpsdr](https://github.com/dl1ycf/pihpsdr) and is
+licensed GPL-2.0-or-later, compatible with Zeus.
+
+Zeus acknowledges the following pihpsdr contributors whose work informed
+Zeus's Protocol-2 / PureSignal implementation:
+
+| Callsign |
+| --- |
+| DL1YCF (Christoph Wüllen) |
+| DH1KLM |
+
+## Relationship to DeskHPSDR
+
+Zeus is independent of DeskHPSDR but consulted DeskHPSDR as a
+cross-reference for HPSDR client behaviour. DeskHPSDR is maintained by
+**Heiko, DL1BZ** at [github.com/dl1bz/deskhpsdr](https://github.com/dl1bz/deskhpsdr)
+and is licensed GPL-2.0-or-later, compatible with Zeus.
+
 ## Third-party assets and imagery
 
 Images under `docs/pics/` are original screenshots of the Zeus user
@@ -138,10 +171,10 @@ imagery is reproduced in this repository.
 ## Per-file header format
 
 Every first-party Zeus source file begins with an SPDX identifier,
-the Zeus copyright line, the short GPL notice, and a Thetis /
-WDSP acknowledgement block that names all twelve Thetis
-contributors and points back at this file. See any source file
-for the canonical form.
+the Zeus copyright line, the short GPL notice, and an acknowledgement
+block that names all twelve Thetis contributors, references pihpsdr
+(DL1YCF / DH1KLM) and DeskHPSDR (DL1BZ), and points back at this file.
+See any source file for the canonical form.
 
 ## Reporting attribution concerns
 

--- a/Zeus.Contracts/AlertFrame.cs
+++ b/Zeus.Contracts/AlertFrame.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Contracts/AudioFrame.cs
+++ b/Zeus.Contracts/AudioFrame.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Contracts/DisplayFrame.cs
+++ b/Zeus.Contracts/DisplayFrame.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Contracts/FilterFrame.cs
+++ b/Zeus.Contracts/FilterFrame.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Contracts/LogDtos.cs
+++ b/Zeus.Contracts/LogDtos.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Contracts/MsgType.cs
+++ b/Zeus.Contracts/MsgType.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Contracts/PaTempFrame.cs
+++ b/Zeus.Contracts/PaTempFrame.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Contracts/PsMetersFrame.cs
+++ b/Zeus.Contracts/PsMetersFrame.cs
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 using System.Buffers;
 using System.Buffers.Binary;

--- a/Zeus.Contracts/QrzDtos.cs
+++ b/Zeus.Contracts/QrzDtos.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Contracts/RadioCalibration.cs
+++ b/Zeus.Contracts/RadioCalibration.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Contracts/RotctldDtos.cs
+++ b/Zeus.Contracts/RotctldDtos.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Contracts/RxMeterFrame.cs
+++ b/Zeus.Contracts/RxMeterFrame.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Contracts/TxMetersFrame.cs
+++ b/Zeus.Contracts/TxMetersFrame.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Contracts/TxMetersV2Frame.cs
+++ b/Zeus.Contracts/TxMetersV2Frame.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Contracts/WireFormat.cs
+++ b/Zeus.Contracts/WireFormat.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Contracts/WisdomStatusFrame.cs
+++ b/Zeus.Contracts/WisdomStatusFrame.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Dsp/DspEngineFactory.cs
+++ b/Zeus.Dsp/DspEngineFactory.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Dsp/IDspEngine.cs
+++ b/Zeus.Dsp/IDspEngine.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Dsp/PsStageMeters.cs
+++ b/Zeus.Dsp/PsStageMeters.cs
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 namespace Zeus.Dsp;
 

--- a/Zeus.Dsp/SyntheticDspEngine.cs
+++ b/Zeus.Dsp/SyntheticDspEngine.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Dsp/TxStageMeters.cs
+++ b/Zeus.Dsp/TxStageMeters.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Dsp/Wdsp/NativeMethods.cs
+++ b/Zeus.Dsp/Wdsp/NativeMethods.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Dsp/Wdsp/WdspNativeLoader.cs
+++ b/Zeus.Dsp/Wdsp/WdspNativeLoader.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Dsp/Wdsp/WdspWisdomInitializer.cs
+++ b/Zeus.Dsp/Wdsp/WdspWisdomInitializer.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Protocol1/AssemblyInfo.cs
+++ b/Zeus.Protocol1/AssemblyInfo.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Protocol1/ControlFrame.cs
+++ b/Zeus.Protocol1/ControlFrame.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Protocol1/Discovery/DiscoveredRadio.cs
+++ b/Zeus.Protocol1/Discovery/DiscoveredRadio.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Protocol1/Discovery/HpsdrBoardKind.cs
+++ b/Zeus.Protocol1/Discovery/HpsdrBoardKind.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Protocol1/Discovery/IRadioDiscovery.cs
+++ b/Zeus.Protocol1/Discovery/IRadioDiscovery.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Protocol1/Discovery/RadioDiscoveryService.cs
+++ b/Zeus.Protocol1/Discovery/RadioDiscoveryService.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Protocol1/Discovery/ReplyParser.cs
+++ b/Zeus.Protocol1/Discovery/ReplyParser.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Protocol1/HpsdrEnums.cs
+++ b/Zeus.Protocol1/HpsdrEnums.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Protocol1/IProtocol1Client.cs
+++ b/Zeus.Protocol1/IProtocol1Client.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Protocol1/IRadioTransport.cs
+++ b/Zeus.Protocol1/IRadioTransport.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Protocol1/ITxIqSource.cs
+++ b/Zeus.Protocol1/ITxIqSource.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Protocol1/IqFrame.cs
+++ b/Zeus.Protocol1/IqFrame.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Protocol1/N2adrBands.cs
+++ b/Zeus.Protocol1/N2adrBands.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Protocol1/PacketParser.cs
+++ b/Zeus.Protocol1/PacketParser.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Protocol1/Protocol1Client.cs
+++ b/Zeus.Protocol1/Protocol1Client.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Protocol1/TestToneGenerator.cs
+++ b/Zeus.Protocol1/TestToneGenerator.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Protocol1/TxIqRing.cs
+++ b/Zeus.Protocol1/TxIqRing.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Protocol2/AssemblyInfo.cs
+++ b/Zeus.Protocol2/AssemblyInfo.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Protocol2/Discovery/DiscoveredRadio.cs
+++ b/Zeus.Protocol2/Discovery/DiscoveredRadio.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Protocol2/Discovery/HpsdrBoardKind.cs
+++ b/Zeus.Protocol2/Discovery/HpsdrBoardKind.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Protocol2/Discovery/IRadioDiscovery.cs
+++ b/Zeus.Protocol2/Discovery/IRadioDiscovery.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Protocol2/Discovery/RadioDiscoveryService.cs
+++ b/Zeus.Protocol2/Discovery/RadioDiscoveryService.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Protocol2/Discovery/ReplyParser.cs
+++ b/Zeus.Protocol2/Discovery/ReplyParser.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Protocol2/IqFrame.cs
+++ b/Zeus.Protocol2/IqFrame.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Protocol2/PsFeedbackFrame.cs
+++ b/Zeus.Protocol2/PsFeedbackFrame.cs
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 namespace Zeus.Protocol2;
 

--- a/Zeus.Server/BandMemoryStore.cs
+++ b/Zeus.Server/BandMemoryStore.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Server/BandUtils.cs
+++ b/Zeus.Server/BandUtils.cs
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 namespace Zeus.Server;
 

--- a/Zeus.Server/CredentialStore.cs
+++ b/Zeus.Server/CredentialStore.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Server/DspPipelineService.cs
+++ b/Zeus.Server/DspPipelineService.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Server/LayoutStore.cs
+++ b/Zeus.Server/LayoutStore.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Server/LogService.cs
+++ b/Zeus.Server/LogService.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Server/PaDefaults.cs
+++ b/Zeus.Server/PaDefaults.cs
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 using Zeus.Protocol1.Discovery;
 

--- a/Zeus.Server/PaSettingsStore.cs
+++ b/Zeus.Server/PaSettingsStore.cs
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 using LiteDB;
 using Zeus.Contracts;

--- a/Zeus.Server/Program.cs
+++ b/Zeus.Server/Program.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Server/PsAutoAttenuateService.cs
+++ b/Zeus.Server/PsAutoAttenuateService.cs
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 namespace Zeus.Server;
 

--- a/Zeus.Server/PsSettingsStore.cs
+++ b/Zeus.Server/PsSettingsStore.cs
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 using LiteDB;
 using Zeus.Contracts;

--- a/Zeus.Server/QrzService.cs
+++ b/Zeus.Server/QrzService.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Server/RadioService.cs
+++ b/Zeus.Server/RadioService.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Server/RotctldService.cs
+++ b/Zeus.Server/RotctldService.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Server/StreamingHub.cs
+++ b/Zeus.Server/StreamingHub.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Server/Tci/SpotManager.cs
+++ b/Zeus.Server/Tci/SpotManager.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Server/Tci/TciHandshake.cs
+++ b/Zeus.Server/Tci/TciHandshake.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Server/Tci/TciOptions.cs
+++ b/Zeus.Server/Tci/TciOptions.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Server/Tci/TciProtocol.cs
+++ b/Zeus.Server/Tci/TciProtocol.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Server/Tci/TciRateLimiter.cs
+++ b/Zeus.Server/Tci/TciRateLimiter.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Server/Tci/TciServer.cs
+++ b/Zeus.Server/Tci/TciServer.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Server/Tci/TciSession.cs
+++ b/Zeus.Server/Tci/TciSession.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Server/TxAudioIngest.cs
+++ b/Zeus.Server/TxAudioIngest.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Server/TxAudioIngestStartup.cs
+++ b/Zeus.Server/TxAudioIngestStartup.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Server/TxMetersService.cs
+++ b/Zeus.Server/TxMetersService.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Server/TxService.cs
+++ b/Zeus.Server/TxService.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Server/TxTuneDriver.cs
+++ b/Zeus.Server/TxTuneDriver.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/Zeus.Server/WisdomBootstrapService.cs
+++ b/Zeus.Server/WisdomBootstrapService.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Contracts.Tests/AlertFrameTests.cs
+++ b/tests/Zeus.Contracts.Tests/AlertFrameTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Contracts.Tests/AudioFrameTests.cs
+++ b/tests/Zeus.Contracts.Tests/AudioFrameTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Contracts.Tests/AutoAttControlLoopTests.cs
+++ b/tests/Zeus.Contracts.Tests/AutoAttControlLoopTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Contracts.Tests/DisplayFrameTests.cs
+++ b/tests/Zeus.Contracts.Tests/DisplayFrameTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Contracts.Tests/PaTempFrameTests.cs
+++ b/tests/Zeus.Contracts.Tests/PaTempFrameTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Contracts.Tests/PsMetersFrameTests.cs
+++ b/tests/Zeus.Contracts.Tests/PsMetersFrameTests.cs
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 using System.Buffers;
 using Zeus.Contracts;

--- a/tests/Zeus.Contracts.Tests/TxMetersFrameTests.cs
+++ b/tests/Zeus.Contracts.Tests/TxMetersFrameTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Contracts.Tests/TxMetersMathTests.cs
+++ b/tests/Zeus.Contracts.Tests/TxMetersMathTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Contracts.Tests/TxMetersV2FrameTests.cs
+++ b/tests/Zeus.Contracts.Tests/TxMetersV2FrameTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Dsp.Tests/NoiseReductionTests.cs
+++ b/tests/Zeus.Dsp.Tests/NoiseReductionTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Dsp.Tests/SyntheticDspEngineTests.cs
+++ b/tests/Zeus.Dsp.Tests/SyntheticDspEngineTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Dsp.Tests/WdspDspEngineTests.cs
+++ b/tests/Zeus.Dsp.Tests/WdspDspEngineTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Dsp.Tests/ZoomTests.cs
+++ b/tests/Zeus.Dsp.Tests/ZoomTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Protocol1.Tests/ControlFrameOcMaskTests.cs
+++ b/tests/Zeus.Protocol1.Tests/ControlFrameOcMaskTests.cs
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 using Zeus.Protocol1.Discovery;
 

--- a/tests/Zeus.Protocol1.Tests/ControlFrameTests.cs
+++ b/tests/Zeus.Protocol1.Tests/ControlFrameTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Protocol1.Tests/DiscoveryTests.cs
+++ b/tests/Zeus.Protocol1.Tests/DiscoveryTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Protocol1.Tests/FramingTests.cs
+++ b/tests/Zeus.Protocol1.Tests/FramingTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Protocol1.Tests/N2adrBandsTests.cs
+++ b/tests/Zeus.Protocol1.Tests/N2adrBandsTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Protocol1.Tests/PacketParserTests.cs
+++ b/tests/Zeus.Protocol1.Tests/PacketParserTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Protocol1.Tests/Protocol1Client_AdcOverloadEventTests.cs
+++ b/tests/Zeus.Protocol1.Tests/Protocol1Client_AdcOverloadEventTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Protocol1.Tests/Protocol1Client_LiveRx_IntegrationTest.cs
+++ b/tests/Zeus.Protocol1.Tests/Protocol1Client_LiveRx_IntegrationTest.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Protocol1.Tests/TestToneGeneratorTests.cs
+++ b/tests/Zeus.Protocol1.Tests/TestToneGeneratorTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Protocol1.Tests/TxIqRingTests.cs
+++ b/tests/Zeus.Protocol1.Tests/TxIqRingTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Protocol2.Tests/DiscoveryTests.cs
+++ b/tests/Zeus.Protocol2.Tests/DiscoveryTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Protocol2.Tests/PsWireFormatTests.cs
+++ b/tests/Zeus.Protocol2.Tests/PsWireFormatTests.cs
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 using Xunit;
 

--- a/tests/Zeus.Server.Tests/AssemblyAttributes.cs
+++ b/tests/Zeus.Server.Tests/AssemblyAttributes.cs
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 // LiteDB v5's BsonMapper.Global is a process-wide static cache that is not
 // thread-safe during the first GetEntityMapper(T) call for a given T. Two

--- a/tests/Zeus.Server.Tests/ComputeDriveByteTests.cs
+++ b/tests/Zeus.Server.Tests/ComputeDriveByteTests.cs
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 using Zeus.Server;
 

--- a/tests/Zeus.Server.Tests/CredentialStoreTests.cs
+++ b/tests/Zeus.Server.Tests/CredentialStoreTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Server.Tests/LevelerMaxGainEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/LevelerMaxGainEndpointTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Server.Tests/PaTempConversionTests.cs
+++ b/tests/Zeus.Server.Tests/PaTempConversionTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Server.Tests/PsHwPeakResolutionTests.cs
+++ b/tests/Zeus.Server.Tests/PsHwPeakResolutionTests.cs
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 using Zeus.Protocol1.Discovery;
 using Zeus.Server;

--- a/tests/Zeus.Server.Tests/PsPersistenceTests.cs
+++ b/tests/Zeus.Server.Tests/PsPersistenceTests.cs
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 using Microsoft.Extensions.Logging.Abstractions;
 using Zeus.Contracts;

--- a/tests/Zeus.Server.Tests/Tci/SpotManagerTests.cs
+++ b/tests/Zeus.Server.Tests/Tci/SpotManagerTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Server.Tests/Tci/TciHandshakeTests.cs
+++ b/tests/Zeus.Server.Tests/Tci/TciHandshakeTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Server.Tests/Tci/TciProtocolTests.cs
+++ b/tests/Zeus.Server.Tests/Tci/TciProtocolTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Server.Tests/Tci/TciRateLimiterTests.cs
+++ b/tests/Zeus.Server.Tests/Tci/TciRateLimiterTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Server.Tests/TwoToneLatchTests.cs
+++ b/tests/Zeus.Server.Tests/TwoToneLatchTests.cs
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 using Microsoft.Extensions.Logging.Abstractions;
 using Zeus.Contracts;

--- a/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
+++ b/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Server.Tests/TxMetersSwrTripTests.cs
+++ b/tests/Zeus.Server.Tests/TxMetersSwrTripTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Server.Tests/TxTimeoutTests.cs
+++ b/tests/Zeus.Server.Tests/TxTimeoutTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tests/Zeus.Server.Tests/ZoomValidationTests.cs
+++ b/tests/Zeus.Server.Tests/ZoomValidationTests.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tools/discovery-probe/Program.cs
+++ b/tools/discovery-probe/Program.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/tools/zeus-dump/Program.cs
+++ b/tools/zeus-dump/Program.cs
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/api/client.test.ts
+++ b/zeus-web/src/api/client.test.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/api/log.ts
+++ b/zeus-web/src/api/log.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/api/pa.ts
+++ b/zeus-web/src/api/pa.ts
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 export type PaBandSettings = {
   band: string;

--- a/zeus-web/src/api/qrz.ts
+++ b/zeus-web/src/api/qrz.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/api/rotator.ts
+++ b/zeus-web/src/api/rotator.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/audio/audio-client.ts
+++ b/zeus-web/src/audio/audio-client.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/audio/frame.test.ts
+++ b/zeus-web/src/audio/frame.test.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/audio/frame.ts
+++ b/zeus-web/src/audio/frame.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/audio/mic-uplink.ts
+++ b/zeus-web/src/audio/mic-uplink.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/audio/use-mic-uplink.ts
+++ b/zeus-web/src/audio/use-mic-uplink.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/AboutPanel.tsx
+++ b/zeus-web/src/components/AboutPanel.tsx
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 import { useEffect, useState } from 'react';
 

--- a/zeus-web/src/components/AfGainSlider.tsx
+++ b/zeus-web/src/components/AfGainSlider.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/AgcSlider.tsx
+++ b/zeus-web/src/components/AgcSlider.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/AlertBanner.tsx
+++ b/zeus-web/src/components/AlertBanner.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/AttenuatorSlider.tsx
+++ b/zeus-web/src/components/AttenuatorSlider.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/AudioToggle.tsx
+++ b/zeus-web/src/components/AudioToggle.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/BandButtons.tsx
+++ b/zeus-web/src/components/BandButtons.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/ConnectPanel.tsx
+++ b/zeus-web/src/components/ConnectPanel.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/DbScale.tsx
+++ b/zeus-web/src/components/DbScale.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/DisplayPanel.tsx
+++ b/zeus-web/src/components/DisplayPanel.tsx
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 import { useLayoutPreferenceStore, type LayoutMode } from '../state/layout-preference-store';
 import { useLayoutStore } from '../state/layout-store';

--- a/zeus-web/src/components/DriveSlider.tsx
+++ b/zeus-web/src/components/DriveSlider.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/DspPanel.tsx
+++ b/zeus-web/src/components/DspPanel.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/FreqAxis.tsx
+++ b/zeus-web/src/components/FreqAxis.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/MicGainSlider.tsx
+++ b/zeus-web/src/components/MicGainSlider.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/MicMeter.tsx
+++ b/zeus-web/src/components/MicMeter.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/MobilePttButton.tsx
+++ b/zeus-web/src/components/MobilePttButton.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/MobileZoomSlider.tsx
+++ b/zeus-web/src/components/MobileZoomSlider.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/ModeBandwidth.tsx
+++ b/zeus-web/src/components/ModeBandwidth.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/MoxButton.tsx
+++ b/zeus-web/src/components/MoxButton.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/NrControls.tsx
+++ b/zeus-web/src/components/NrControls.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/PaSettingsPanel.tsx
+++ b/zeus-web/src/components/PaSettingsPanel.tsx
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 import { useEffect } from 'react';
 import { HF_BANDS, usePaStore } from '../state/pa-store';

--- a/zeus-web/src/components/PaTempChip.tsx
+++ b/zeus-web/src/components/PaTempChip.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/Panadapter.tsx
+++ b/zeus-web/src/components/Panadapter.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/PassbandOverlay.tsx
+++ b/zeus-web/src/components/PassbandOverlay.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/PreampButton.tsx
+++ b/zeus-web/src/components/PreampButton.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/PsSettingsPanel.tsx
+++ b/zeus-web/src/components/PsSettingsPanel.tsx
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 import { useCallback } from 'react';
 import {

--- a/zeus-web/src/components/PsToggleButton.tsx
+++ b/zeus-web/src/components/PsToggleButton.tsx
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 import { useCallback } from 'react';
 import { setPs } from '../api/client';

--- a/zeus-web/src/components/QrzSettingsPanel.tsx
+++ b/zeus-web/src/components/QrzSettingsPanel.tsx
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 import { useEffect, useState } from 'react';
 import { useQrzStore } from '../state/qrz-store';

--- a/zeus-web/src/components/QrzStatusPill.tsx
+++ b/zeus-web/src/components/QrzStatusPill.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/RotatorSettingsPanel.tsx
+++ b/zeus-web/src/components/RotatorSettingsPanel.tsx
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 import { useEffect, useState } from 'react';
 import { useRotatorStore } from '../state/rotator-store';

--- a/zeus-web/src/components/RotatorStatusPill.tsx
+++ b/zeus-web/src/components/RotatorStatusPill.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/SMeter.tsx
+++ b/zeus-web/src/components/SMeter.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/SMeterDemo.tsx
+++ b/zeus-web/src/components/SMeterDemo.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/SMeterLive.tsx
+++ b/zeus-web/src/components/SMeterLive.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/SettingsMenu.tsx
+++ b/zeus-web/src/components/SettingsMenu.tsx
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 import { useEffect, useRef, useState } from 'react';
 import { PaSettingsPanel } from './PaSettingsPanel';

--- a/zeus-web/src/components/TopBar.tsx
+++ b/zeus-web/src/components/TopBar.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/TunButton.tsx
+++ b/zeus-web/src/components/TunButton.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/TunePowerSlider.tsx
+++ b/zeus-web/src/components/TunePowerSlider.tsx
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 import { useCallback, useEffect, useRef } from 'react';
 import { setTuneDrive } from '../api/client';

--- a/zeus-web/src/components/TwoToneButton.tsx
+++ b/zeus-web/src/components/TwoToneButton.tsx
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 import { useCallback } from 'react';
 import { setTwoTone } from '../api/client';

--- a/zeus-web/src/components/TxFilterPanel.tsx
+++ b/zeus-web/src/components/TxFilterPanel.tsx
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 import { useCallback, useEffect, useState } from 'react';
 import { setTxFilter, type RxMode } from '../api/client';

--- a/zeus-web/src/components/TxStageMeters.tsx
+++ b/zeus-web/src/components/TxStageMeters.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/VfoDisplay.tsx
+++ b/zeus-web/src/components/VfoDisplay.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/ZoomControl.tsx
+++ b/zeus-web/src/components/ZoomControl.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/design/AzimuthMap.tsx
+++ b/zeus-web/src/components/design/AzimuthMap.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/design/CwKeyer.tsx
+++ b/zeus-web/src/components/design/CwKeyer.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/design/Dockable.tsx
+++ b/zeus-web/src/components/design/Dockable.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/design/LeafletMapErrorBoundary.tsx
+++ b/zeus-web/src/components/design/LeafletMapErrorBoundary.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/design/LeafletWorldMap.tsx
+++ b/zeus-web/src/components/design/LeafletWorldMap.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/design/Logbook.tsx
+++ b/zeus-web/src/components/design/Logbook.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/design/LogbookLive.tsx
+++ b/zeus-web/src/components/design/LogbookLive.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/design/Memory.tsx
+++ b/zeus-web/src/components/design/Memory.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/design/Meter.tsx
+++ b/zeus-web/src/components/design/Meter.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/design/QrzCard.tsx
+++ b/zeus-web/src/components/design/QrzCard.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/design/SMeterBars.tsx
+++ b/zeus-web/src/components/design/SMeterBars.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/design/Select.tsx
+++ b/zeus-web/src/components/design/Select.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/design/Slider.tsx
+++ b/zeus-web/src/components/design/Slider.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/design/TerminatorLines.tsx
+++ b/zeus-web/src/components/design/TerminatorLines.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/design/TweaksPanel.tsx
+++ b/zeus-web/src/components/design/TweaksPanel.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/design/WorldMap.tsx
+++ b/zeus-web/src/components/design/WorldMap.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/design/data.ts
+++ b/zeus-web/src/components/design/data.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/components/design/geo.ts
+++ b/zeus-web/src/components/design/geo.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/gl/colormap.ts
+++ b/zeus-web/src/gl/colormap.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/gl/panadapter.ts
+++ b/zeus-web/src/gl/panadapter.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/gl/shaders.ts
+++ b/zeus-web/src/gl/shaders.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/gl/util.ts
+++ b/zeus-web/src/gl/util.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/gl/waterfall.ts
+++ b/zeus-web/src/gl/waterfall.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/gl/wf-shift.test.ts
+++ b/zeus-web/src/gl/wf-shift.test.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/gl/wf-shift.ts
+++ b/zeus-web/src/gl/wf-shift.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/layout/WorkspaceContext.tsx
+++ b/zeus-web/src/layout/WorkspaceContext.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/layout/defaultLayout.ts
+++ b/zeus-web/src/layout/defaultLayout.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/layout/panels.ts
+++ b/zeus-web/src/layout/panels.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/layout/panels/AzimuthPanel.tsx
+++ b/zeus-web/src/layout/panels/AzimuthPanel.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/layout/panels/CwPanel.tsx
+++ b/zeus-web/src/layout/panels/CwPanel.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/layout/panels/DspFlexPanel.tsx
+++ b/zeus-web/src/layout/panels/DspFlexPanel.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/layout/panels/HeroPanel.tsx
+++ b/zeus-web/src/layout/panels/HeroPanel.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/layout/panels/LogbookPanel.tsx
+++ b/zeus-web/src/layout/panels/LogbookPanel.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/layout/panels/PsFlexPanel.tsx
+++ b/zeus-web/src/layout/panels/PsFlexPanel.tsx
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 import { PsSettingsPanel } from '../../components/PsSettingsPanel';
 

--- a/zeus-web/src/layout/panels/QrzPanel.tsx
+++ b/zeus-web/src/layout/panels/QrzPanel.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/layout/panels/SMeterPanel.tsx
+++ b/zeus-web/src/layout/panels/SMeterPanel.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/layout/panels/TxMetersPanel.tsx
+++ b/zeus-web/src/layout/panels/TxMetersPanel.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/layout/panels/VfoPanel.tsx
+++ b/zeus-web/src/layout/panels/VfoPanel.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/main.tsx
+++ b/zeus-web/src/main.tsx
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/realtime/frame.test.ts
+++ b/zeus-web/src/realtime/frame.test.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/realtime/frame.ts
+++ b/zeus-web/src/realtime/frame.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/realtime/mic-pcm.test.ts
+++ b/zeus-web/src/realtime/mic-pcm.test.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/realtime/ws-client.ts
+++ b/zeus-web/src/realtime/ws-client.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/state/connection-store.ts
+++ b/zeus-web/src/state/connection-store.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/state/display-settings-store.test.ts
+++ b/zeus-web/src/state/display-settings-store.test.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/state/display-settings-store.ts
+++ b/zeus-web/src/state/display-settings-store.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/state/display-store.ts
+++ b/zeus-web/src/state/display-store.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/state/layout-preference-store.ts
+++ b/zeus-web/src/state/layout-preference-store.ts
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 import { create } from 'zustand';
 

--- a/zeus-web/src/state/layout-store.ts
+++ b/zeus-web/src/state/layout-store.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/state/logger-store.ts
+++ b/zeus-web/src/state/logger-store.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/state/pa-store.ts
+++ b/zeus-web/src/state/pa-store.ts
@@ -12,6 +12,12 @@
 //
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
 
 import { create } from 'zustand';
 import {

--- a/zeus-web/src/state/qrz-store.ts
+++ b/zeus-web/src/state/qrz-store.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/state/rotator-store.ts
+++ b/zeus-web/src/state/rotator-store.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/state/tx-store.ts
+++ b/zeus-web/src/state/tx-store.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/util/logger.ts
+++ b/zeus-web/src/util/logger.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/util/use-keyboard-shortcuts.ts
+++ b/zeus-web/src/util/use-keyboard-shortcuts.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/src/util/use-pan-tune-gesture.ts
+++ b/zeus-web/src/util/use-pan-tune-gesture.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/vite.config.ts
+++ b/zeus-web/vite.config.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //

--- a/zeus-web/vitest.config.ts
+++ b/zeus-web/vitest.config.ts
@@ -29,6 +29,12 @@
 // here. See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF), with contributions from (DH1KLM); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
 // WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
 // (NR0V), distributed under GPL v2 or later.
 //


### PR DESCRIPTION
Update ATTRIBUTIONS.md to formally credit:
- pihpsdr (Christoph Wüllen, DL1YCF; contributor DH1KLM) as the authoritative reference for Saturn-class / ANAN G2 MkII Protocol-2 behaviour, PureSignal arm sequence, ALEX antenna routing, and DDC sample-pair conventions
- DeskHPSDR (Heiko, DL1BZ) as a cross-reference for HPSDR client behaviour

Update the per-file attribution header in all 240 first-party .cs / .ts / .tsx source files to include the pihpsdr and DeskHPSDR acknowledgement block, consistent with the existing Thetis / WDSP attribution lines.

Closes #105