### PR TITLE
feat(dsp): clean TX panadapter via WDSP siphon + PS Monitor toggle

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -123,6 +123,17 @@ public sealed record StateDto(
     // fields ARE persisted via PsSettingsStore so the operator's calibration
     // tuning survives restarts.
     bool PsEnabled = false,
+    // PsMonitorEnabled — operator-facing "Monitor PA output" toggle
+    // (issue #121). When true AND PsEnabled AND PS has converged
+    // (info[14]==1), DspPipelineService.Tick switches the TX panadapter /
+    // waterfall source from the post-CFIR predistorted-IQ analyzer to the
+    // PS-feedback analyzer fed from the radio's loopback ADC, so the
+    // operator sees the actual on-air signal. Default off — preserves the
+    // Thetis-style predistorted view. Hidden / disabled in the UI on
+    // boards that have no PS feedback path (e.g. HermesLite2). NOT
+    // persisted server-side: this is an operator viewing preference,
+    // resets to off each session same as PsEnabled.
+    bool PsMonitorEnabled = false,
     bool PsAuto = true,             // continuous adapt by default once armed
     bool PsSingle = false,          // one-shot SetPSControl(1,1,0,0)
     bool PsPtol = false,            // false = strict 0.4; true = relax 0.8
@@ -299,6 +310,12 @@ public sealed record PsRestoreRequest(string Filename);
 // Sent from the PS settings panel. Affects only the radio-side ALEX bit;
 // the WDSP cal/iqc stages operate on whatever IQ arrives at DDC0/DDC1.
 public sealed record PsFeedbackSourceSetRequest(PsFeedbackSource Source);
+
+// "Monitor PA output" toggle (issue #121). Pure UI/source-routing flag —
+// no WDSP setter, no wire-format change. RadioService just stamps the
+// StateDto, DspPipelineService reads it on Tick to pick which analyzer
+// to drain. Default off; operator opt-in.
+public sealed record PsMonitorSetRequest(bool Enabled);
 
 // Two-tone test generator (used as PS calibration excitation but works
 // standalone too). Protocol-agnostic.

--- a/Zeus.Dsp/IDspEngine.cs
+++ b/Zeus.Dsp/IDspEngine.cs
@@ -77,6 +77,16 @@ public interface IDspEngine : IDisposable
     /// see issue #81. No-op on Synthetic.</summary>
     bool TryGetTxDisplayPixels(DisplayPixout which, Span<float> dbOut);
 
+    /// <summary>PureSignal-feedback panadapter / waterfall pixels in dBm,
+    /// sourced from a separate WDSP analyzer fed with the post-PA loopback
+    /// IQ pumped through <see cref="FeedPsFeedbackBlock"/>. Returns false
+    /// when PS isn't armed (analyzer slot closed), TXA isn't open, or no
+    /// fresh FFT is ready. Caller is expected to also check that PS has
+    /// converged (info[14]==1) before showing this trace — pre-correction
+    /// the loopback shows the real PA splatter. See issue #121.
+    /// No-op on Synthetic.</summary>
+    bool TryGetPsFeedbackDisplayPixels(DisplayPixout which, Span<float> dbOut);
+
     /// <summary>Open the TXA channel. Idempotent — calling twice returns the existing id.
     /// Must be called after at least one OpenChannel(RXA). For Synthetic, returns -1 and is a no-op.
     /// <paramref name="outputRateHz"/> picks the TXA profile: 48000 for P1 (48k in/out, CFIR off),

--- a/Zeus.Dsp/SyntheticDspEngine.cs
+++ b/Zeus.Dsp/SyntheticDspEngine.cs
@@ -177,6 +177,10 @@ public sealed class SyntheticDspEngine : IDspEngine
     // while MOX is on, matching the existing "no new data" semantics.
     public bool TryGetTxDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
 
+    // Synthetic has no PS feedback path either — the PS-Monitor toggle is a
+    // no-op here, same shape as TryGetTxDisplayPixels.
+    public bool TryGetPsFeedbackDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
+
     private const float NoiseFloorDb = -90f;
     private const float SweepPeakDb = -25f;
     private const float StaticPeakDb = -35f;

--- a/Zeus.Dsp/Wdsp/NativeMethods.cs
+++ b/Zeus.Dsp/Wdsp/NativeMethods.cs
@@ -199,6 +199,17 @@ internal static partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial void Spectrum0(int run, int disp, int ss, int LO, ref double pbuff);
 
+    // Pull complex IQ samples from TXA's siphon ring. The siphon sits at
+    // xsiphon's position in xtxa, which is BEFORE iqc (PureSignal correction)
+    // and BEFORE cfir/rsmpout. Default run=1, mode=0, sipsize=16384 (set
+    // inside libwdsp's create_txa). Output buffer is 2*size floats interleaved
+    // I,Q,I,Q. This lets the panadapter render the operator's pre-distortion
+    // voice spectrum so the trace looks "clean" while PS is converging — the
+    // same approach Thetis uses (cmaster.cs:544-545 + siphon.c:268).
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void TXAGetaSipF1(int channel, ref float pout, int size);
+
     // Averaging trio. Mode 3 = log-recursive (EMA in dB space) — the Thetis
     // default. Backmult is the per-frame retention factor (0 = no smoothing,
     // 1 = frozen). NumAverage matters for modes 2/4; we're on mode 3 so it

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -204,6 +204,30 @@ public sealed class WdspDspEngine : IDspEngine
     private int _txDispRxSampleRateHz;
     private bool _txDispAlive;
 
+    // PureSignal feedback display analyzer (issue #121). Optional second WDSP
+    // disp slot fed from FeedPsFeedbackBlock's rxI/rxQ — i.e. the post-PA
+    // signal observed via the radio's loopback ADC. When the operator turns on
+    // the "Monitor PA output" toggle (StateDto.PsMonitorEnabled) AND PS is
+    // armed AND calcc reports correcting=true, DspPipelineService.Tick reads
+    // pixels from this analyzer instead of the post-CFIR TX analyzer so the
+    // panadapter shows the actual on-air RF rather than the predistorted
+    // baseband. Lifecycle is paired with SetPsEnabled(true/false): we open
+    // the disp slot when PS arms and tear it down when PS disarms so the
+    // WDSP analyzer table doesn't leak.
+    //
+    // Pixel width / zoom / matched RX sample rate are inherited from the TX
+    // analyzer at arm time so display frames slot in with no resize when the
+    // toggle flips. If the TX analyzer isn't alive (no RXA, or rate mismatch)
+    // the PS-FB analyzer is also skipped — Tick will fall through to the TX
+    // analyzer (or RX analyzer) the same as today.
+    private readonly object _psFbDispLock = new();
+    private int? _psFbDispId;
+    private int _psFbDispPixelWidth;
+    private int _psFbDispZoomLevel = 1;
+    private int _psFbDispRxSampleRateHz;
+    private bool _psFbDispAlive;
+    private long _psFbFeedCount;
+
     // PureSignal state. _psLock serializes the WDSP PS setters (which mutate
     // shared state inside calcc.c) and FeedPsFeedbackBlock. _psInfoBuf is
     // pinned once and reused on every GetPSInfo call.
@@ -219,6 +243,11 @@ public sealed class WdspDspEngine : IDspEngine
     private double _psAmpDelayNs = 150.0;
     private bool _psPtol;                // false = strict 0.8 ; true = relax 0.4 (matches pihpsdr/Thetis: ptol ? 0.4 : 0.8)
     private const int PsFeedbackBlockSize = 1024;
+    // PS feedback IQ runs at 192 kHz on G2 / Saturn / ANAN-7000 (P2 paired
+    // DDC0/DDC1 — see SetPSFeedbackRate(id, 192_000) in OpenTxChannel).
+    // Used when configuring the PS-feedback display analyzer so its bin-clip
+    // math matches the data rate it's receiving.
+    private const int PsFeedbackSampleRateHz = 192_000;
     private readonly int[] _psInfoBuf = new int[16];
     // Edge-triggered state-transition log target. 255 is an out-of-range
     // sentinel so the first observed state always logs (LRESET..LTURNON
@@ -480,7 +509,19 @@ public sealed class WdspDspEngine : IDspEngine
             {
                 _txDispZoomLevel = level;
                 txaIdToReconfig = txa;
-                TryConfigureTxAnalyzer(txa, _txaOutputRateHz, _txaOutSize, _txDispRxSampleRateHz, _txDispPixelWidth, level);
+                TryConfigureTxAnalyzer(txa, _txaDspRateHz, _txaDspSize, _txDispRxSampleRateHz, _txDispPixelWidth, level);
+            }
+        }
+
+        // Mirror zoom onto the PS-FB analyzer when it's open, same reasoning
+        // as the TX analyzer: keep the PA-output trace span lock-step with the
+        // RX panadapter so toggling the PS-Monitor view doesn't shift the axis.
+        lock (_psFbDispLock)
+        {
+            if (_psFbDispAlive && _psFbDispId is int psFb)
+            {
+                _psFbDispZoomLevel = level;
+                TryConfigureTxAnalyzer(psFb, PsFeedbackSampleRateHz, PsFeedbackBlockSize, _psFbDispRxSampleRateHz, _psFbDispPixelWidth, level);
             }
         }
 
@@ -743,6 +784,31 @@ public sealed class WdspDspEngine : IDspEngine
         }
     }
 
+    /// <summary>PureSignal feedback panadapter pixels — sourced from the
+    /// post-PA loopback IQ pumped through FeedPsFeedbackBlock. Returns false
+    /// when the PS-FB analyzer is not open (PS disarmed, TX analyzer inactive,
+    /// or engine disposed). Caller is expected to gate this on
+    /// <c>PsEnabled &amp;&amp; PsMonitorEnabled &amp;&amp; PsCorrecting</c> so a
+    /// pre-correction transient doesn't briefly show splatter on the
+    /// panadapter.</summary>
+    public bool TryGetPsFeedbackDisplayPixels(DisplayPixout which, Span<float> dbOut)
+    {
+        if (_disposed != 0) return false;
+        int disp;
+        int expectedWidth;
+        lock (_psFbDispLock)
+        {
+            if (!_psFbDispAlive) return false;
+            if (_psFbDispId is not int id) return false;
+            disp = id;
+            expectedWidth = _psFbDispPixelWidth;
+            if (dbOut.Length != expectedWidth)
+                throw new ArgumentException($"expected span of {expectedWidth}", nameof(dbOut));
+            NativeMethods.GetPixels(disp, (int)which, ref MemoryMarshal.GetReference(dbOut), out int flag);
+            return flag == 1;
+        }
+    }
+
     public int OpenTxChannel(int outputRateHz = 48_000)
     {
         ObjectDisposedException.ThrowIf(_disposed != 0, this);
@@ -965,10 +1031,18 @@ public sealed class WdspDspEngine : IDspEngine
                         _txDispPixelWidth = rxPixelWidth;
                         _txDispZoomLevel = rxZoom;
                         _txDispRxSampleRateHz = rxSampleRateHz;
-                        configured = TryConfigureTxAnalyzer(id, _txaOutputRateHz, _txaOutSize, rxSampleRateHz, rxPixelWidth, rxZoom);
+                        // Configure for the SIPHON tap point (xsiphon position
+                        // in xtxa — BEFORE iqc/cfir/rsmpout). dsp_rate / dsp_size
+                        // describe the IQ at that stage. Pulling pre-iqc samples
+                        // gives the operator's clean voice spectrum on the
+                        // panadapter, matching Thetis (cmaster.cs:544-545,
+                        // TXA.c:586). Pre-fix the analyzer was configured at
+                        // the OUTPUT (post-cfir/rsmpout) rate and got fed the
+                        // predistorted IQ — cosmetically dirty by design.
+                        configured = TryConfigureTxAnalyzer(id, _txaDspRateHz, _txaDspSize, rxSampleRateHz, rxPixelWidth, rxZoom);
                         if (configured)
                         {
-                            ConfigureDisplayAveraging(id);
+                            ConfigureDisplayAveragingTau(id, TxAvgTauSec);
                             _txDispAlive = true;
                         }
                     }
@@ -1359,10 +1433,21 @@ public sealed class WdspDspEngine : IDspEngine
                 // single-cal cycle (which can leave the SM in LSTAYON) starts
                 // a fresh fit (Thetis PSForm.cs:645,661).
                 NativeMethods.SetPSControl(id, 1, mancal, automode, 0);
+                // Open the PS-feedback display analyzer (issue #121). Inherits
+                // pixel width / zoom / matched RX rate from the TX analyzer so
+                // the PS-Monitor pan/wf frames slot into the same widget the
+                // TX analyzer is rendering into. Skipped when TX analyzer is
+                // off (no RXA, or P1 P2 rate-ratio mismatch) — the toggle
+                // becomes a no-op in that case and Tick keeps falling through
+                // to the existing TX/RX trace.
+                OpenPsFeedbackAnalyzer(id);
             }
             else
             {
                 _psEnabled = false;
+                // Tear down the PS-FB analyzer first so a stale GetPixels
+                // call from Tick doesn't race with WDSP cleaning up the slot.
+                ClosePsFeedbackAnalyzer();
                 // pihpsdr shutdown gotcha (transmitter.c:2422-2444): when
                 // disabling PS while NOT keyed, push 7 zero-IQ blocks through
                 // psccF so the calcc state machine advances to LRESET cleanly
@@ -1377,6 +1462,93 @@ public sealed class WdspDspEngine : IDspEngine
             }
         }
         _log.LogInformation("wdsp.setPsEnabled enabled={Enabled}", enabled);
+    }
+
+    // Open / configure the PS-feedback display analyzer. Caller holds
+    // _psLock. Mirrors the TX analyzer's pixel width / zoom / matched RX
+    // sample rate so DspPipelineService.Tick can pick between TX-pixels and
+    // PS-FB-pixels per tick without a buffer resize.
+    private void OpenPsFeedbackAnalyzer(int txaId)
+    {
+        // Snapshot TX-display geometry under its own lock — we need it whether
+        // or not _txDispAlive is true, but the values are only meaningful when
+        // it is.
+        bool txAlive;
+        int pixelWidth;
+        int rxRate;
+        int zoom;
+        lock (_txDispLock)
+        {
+            txAlive = _txDispAlive;
+            pixelWidth = _txDispPixelWidth;
+            rxRate = _txDispRxSampleRateHz;
+            zoom = _txDispZoomLevel;
+        }
+        if (!txAlive || pixelWidth <= 0)
+        {
+            _log.LogInformation("wdsp.psFb.open skip — txDisp not alive (toggle will fall through to TX pixels)");
+            return;
+        }
+
+        lock (_psFbDispLock)
+        {
+            if (_psFbDispAlive) return;
+
+            // Pick a disp slot that doesn't collide with any RX channel id or
+            // the TXA channel id. WDSP's analyzer table is indexed
+            // independently of channel ids (see comment at OpenTxChannel
+            // analyzer creation), but our own bookkeeping needs the int to be
+            // unique so SetZoom / Spectrum0 / GetPixels reach the right slot.
+            int psFbId = 0;
+            while (_channels.ContainsKey(psFbId) || psFbId == txaId) psFbId++;
+
+            NativeMethods.XCreateAnalyzer(psFbId, out int rc, MaxFftSize, 1, 1, null);
+            if (rc != 0)
+            {
+                _log.LogWarning("wdsp.psFb.open XCreateAnalyzer rc={Rc} — PS-Monitor will fall back to TX trace", rc);
+                return;
+            }
+            bool configured = TryConfigureTxAnalyzer(psFbId, PsFeedbackSampleRateHz, PsFeedbackBlockSize, rxRate, pixelWidth, zoom);
+            if (!configured)
+            {
+                NativeMethods.DestroyAnalyzer(psFbId);
+                _log.LogWarning(
+                    "wdsp.psFb.open skipped — rx={RxRate} psFb={PsFbRate} not an integer multiple; PS-Monitor will fall back to TX trace",
+                    rxRate, PsFeedbackSampleRateHz);
+                return;
+            }
+            ConfigureDisplayAveragingTau(psFbId, TxAvgTauSec);
+            _psFbDispId = psFbId;
+            _psFbDispPixelWidth = pixelWidth;
+            _psFbDispRxSampleRateHz = rxRate;
+            _psFbDispZoomLevel = zoom;
+            _psFbDispAlive = true;
+            _log.LogInformation(
+                "wdsp.psFb.open id={Id} pix={Pix} rxRate={RxRate} psFbRate={PsFbRate} zoom={Zoom}",
+                psFbId, pixelWidth, rxRate, PsFeedbackSampleRateHz, zoom);
+        }
+    }
+
+    // Tear down the PS-feedback display analyzer. Caller holds _psLock so
+    // FeedPsFeedbackBlock can't race in mid-Spectrum0; combined with
+    // _psFbDispLock around GetPixels / Spectrum0 this keeps the analyzer slot
+    // safe to destroy.
+    private void ClosePsFeedbackAnalyzer()
+    {
+        lock (_psFbDispLock)
+        {
+            if (!_psFbDispAlive) return;
+            if (_psFbDispId is int id)
+            {
+                NativeMethods.DestroyAnalyzer(id);
+                _log.LogInformation("wdsp.psFb.close id={Id}", id);
+            }
+            _psFbDispId = null;
+            _psFbDispAlive = false;
+            _psFbDispPixelWidth = 0;
+            _psFbDispRxSampleRateHz = 0;
+            _psFbDispZoomLevel = 1;
+        }
     }
 
     public void FeedPsFeedbackBlock(ReadOnlySpan<float> txI, ReadOnlySpan<float> txQ,
@@ -1416,6 +1588,44 @@ public sealed class WdspDspEngine : IDspEngine
                 // line never appears while keyed + PS armed, the wire path
                 // (Protocol2Client paired-packet decode) isn't running.
                 _log.LogInformation("wdsp.pscc fed {N} blocks", n);
+            }
+        }
+
+        // Feed the PS-feedback display analyzer with the same rxI/rxQ block
+        // (post-PA loopback IQ). DspPipelineService.Tick reads from this
+        // analyzer when PsMonitorEnabled is on, surfacing the actual on-air
+        // signal instead of the predistorted TX-modulator IQ. Q is negated
+        // for the same WDSP analyzer convention used on the RX and TX paths
+        // (see ProcessTxBlock: `txSpectrumIq[2*i + 1] = -qout[i]`); without
+        // it the PS-Monitor view would render with sidebands flipped about
+        // the carrier.
+        if (_psFbDispAlive)
+        {
+            int? psFbId = null;
+            lock (_psFbDispLock)
+            {
+                if (_psFbDispAlive) psFbId = _psFbDispId;
+            }
+            if (psFbId is int fbDisp)
+            {
+                Span<double> psSpectrumIq = stackalloc double[2 * PsFeedbackBlockSize];
+                for (int i = 0; i < PsFeedbackBlockSize; i++)
+                {
+                    psSpectrumIq[2 * i] = bufRxI[i];
+                    psSpectrumIq[2 * i + 1] = -bufRxQ[i];
+                }
+                lock (_psFbDispLock)
+                {
+                    if (_psFbDispAlive && _psFbDispId == fbDisp)
+                    {
+                        NativeMethods.Spectrum0(1, fbDisp, 0, 0, ref psSpectrumIq[0]);
+                        long n = ++_psFbFeedCount;
+                        if (n == 1 || n % 200 == 0)
+                        {
+                            _log.LogInformation("wdsp.psFb.fed n={N} blocks", n);
+                        }
+                    }
+                }
             }
         }
     }
@@ -1601,23 +1811,28 @@ public sealed class WdspDspEngine : IDspEngine
         }
 
         // Feed the TX analyzer with the post-CFIR IQ so TryGetTxDisplayPixels
-        // can serve the panadapter during MOX (issue #81). pihpsdr's
-        // transmitter.c:1639 feeds iq_output_buffer — same tap point. We feed
-        // unconditionally here: ProcessTxBlock only runs while TXA is keyed,
-        // and when it isn't called the analyzer's log-recursive average just
-        // coasts. Q is negated (complex conjugate) to match the RX analyzer's
-        // treatment in RunWorker: WDSP's analyzer pipeline renders both
-        // sidebands flipped about the carrier for our IQ convention, so the
-        // same empirical fix is needed on TX. Observed on a G2 MkII: without
-        // the negation, an LSB carrier/modulation rendered on the USB side
-        // and vice-versa even though on-air RF and audio were correct.
+        // Feed the TX analyzer from the WDSP TXA SIPHON (xsiphon position in
+        // xtxa, BEFORE iqc/cfir/rsmpout — see siphon.c, TXA.c:586) so the
+        // panadapter trace shows the operator's pre-distortion voice spectrum.
+        // Pre-fix this used the post-cfir iout/qout output buffer, which is
+        // intentionally shaped with anti-IMD content while PS is correcting
+        // and renders as visible "splatter" even when the antenna is clean
+        // (issue #121). Thetis takes the same tap (cmaster.cs:544-545,
+        // TXASetSipMode + TXASetSipDisplay). Sample rate / size match the
+        // analyzer config: dsp_rate / dsp_size. Q is still negated to match
+        // the WDSP analyzer's sideband convention (same fix as before — the
+        // siphon hands back complex IQ in the same orientation as the post-
+        // CFIR buffer did).
         if (_txDispAlive)
         {
-            Span<double> txSpectrumIq = stackalloc double[2 * outSize];
-            for (int i = 0; i < outSize; i++)
+            int sipSize = _txaDspSize;
+            Span<float> sipBuf = stackalloc float[2 * sipSize];
+            NativeMethods.TXAGetaSipF1(txa, ref sipBuf[0], sipSize);
+            Span<double> txSpectrumIq = stackalloc double[2 * sipSize];
+            for (int i = 0; i < sipSize; i++)
             {
-                txSpectrumIq[2 * i] = iout[i];
-                txSpectrumIq[2 * i + 1] = -qout[i];
+                txSpectrumIq[2 * i] = sipBuf[2 * i];
+                txSpectrumIq[2 * i + 1] = -sipBuf[2 * i + 1];
             }
             lock (_txDispLock)
             {
@@ -1715,6 +1930,10 @@ public sealed class WdspDspEngine : IDspEngine
             if (_channels.TryRemove(key, out var state))
                 StopChannel(state);
         }
+        lock (_psLock)
+        {
+            ClosePsFeedbackAnalyzer();
+        }
         lock (_txaLock)
         {
             if (_txaChannelId is int txa)
@@ -1740,11 +1959,20 @@ public sealed class WdspDspEngine : IDspEngine
     // user called out, light enough that signals still pop.
     private const int PipelineFps = 30;
     private const double DefaultAvgTauSec = 0.100;
+    // Heavier smoothing on TX-side traces. Voice modulation through the
+    // operator's leveler/compressor/ALC has natural envelope dynamics that
+    // a 100 ms tau renders as visible "splatter spreading"; 0.5 s gives the
+    // Thetis-style smoothed envelope so the operator sees signal shape, not
+    // every voiced/unvoiced transition.
+    private const double TxAvgTauSec = 0.175;
     private const int LogRecursiveMode = 3;
 
     private static void ConfigureDisplayAveraging(int disp)
+        => ConfigureDisplayAveragingTau(disp, DefaultAvgTauSec);
+
+    private static void ConfigureDisplayAveragingTau(int disp, double tauSec)
     {
-        double backmult = Math.Exp(-1.0 / (PipelineFps * DefaultAvgTauSec));
+        double backmult = Math.Exp(-1.0 / (PipelineFps * tauSec));
         for (int pixout = 0; pixout < 2; pixout++)
         {
             NativeMethods.SetDisplayAverageMode(disp, pixout, LogRecursiveMode);

--- a/Zeus.Server/DspPipelineService.cs
+++ b/Zeus.Server/DspPipelineService.cs
@@ -103,6 +103,13 @@ public class DspPipelineService : BackgroundService
     private double _appliedPsHwPeak = 0.4072;
     private string _appliedPsIntsSpiPreset = "16/256";
     private PsFeedbackSource _appliedPsFeedbackSource = PsFeedbackSource.Internal;
+    // PS-Monitor toggle (issue #121). Pure source-routing flag — Tick reads
+    // it on each tick to choose between the TX analyzer (predistorted IQ)
+    // and the PS-feedback analyzer (post-PA loopback IQ). volatile because
+    // OnRadioStateChanged writes from the state-handler thread and Tick
+    // reads from the pipeline thread — no compound mutation, just a bool.
+    private volatile bool _psMonitorEnabled;
+    private long _psMonitorTickCount;
     // Set by DisconnectP2Async so the next OnRadioStateChanged after a
     // fresh ConnectP2Async re-pushes every PS field regardless of equality
     // — necessary because the new WdspDspEngine instance starts with field
@@ -425,6 +432,15 @@ public class DspPipelineService : BackgroundService
             // the next CmdHighPriority emission. WDSP is unaffected.
             _p2Client?.SetPsFeedbackSource(s.PsFeedbackSource == PsFeedbackSource.External);
             _appliedPsFeedbackSource = s.PsFeedbackSource;
+        }
+        // PS-Monitor (issue #121) — pure UI source routing. No engine call,
+        // no wire write; Tick reads _psMonitorEnabled and prefers the
+        // PS-feedback analyzer when on + PS armed + correcting. Latched
+        // here so the volatile read in Tick stays cheap.
+        if (_psMonitorEnabled != s.PsMonitorEnabled)
+        {
+            _log.LogInformation("psMonitor.latch enabled={Enabled}", s.PsMonitorEnabled);
+            _psMonitorEnabled = s.PsMonitorEnabled;
         }
         // Resync done — clear the flag so subsequent state changes use
         // normal change-detect (no spurious wire writes on each tick).
@@ -813,11 +829,44 @@ public class DspPipelineService : BackgroundService
         // we fall through to the RX analyzer, matching the pre-issue-#81
         // behaviour. This fallback also covers the first ~1 tick after
         // keying before the analyzer averaging has settled.
+        //
+        // Issue #121 layered on top: if the operator has the "Monitor PA
+        // output" toggle on AND PS is armed AND PS has converged
+        // (info[14]==1, surfaced via GetPsStageMeters().Correcting), prefer
+        // the PS-feedback analyzer (post-PA loopback IQ). Falls back to the
+        // TX analyzer if the PS-FB analyzer hasn't produced a fresh FFT yet
+        // — same shape as the existing TX → RX fallback. Default-off
+        // toggle: when off the codepath is identical to pre-#121, byte for
+        // byte, on every board.
         bool pan = false, wf = false;
+        bool psFbPanUsed = false, psFbWfUsed = false;
         if (_keyed)
         {
-            pan = engine.TryGetTxDisplayPixels(DisplayPixout.Panadapter, panBuf);
-            wf = engine.TryGetTxDisplayPixels(DisplayPixout.Waterfall, wfBuf);
+            if (_appliedPsEnabled && _psMonitorEnabled
+                && engine.GetPsStageMeters().Correcting)
+            {
+                pan = engine.TryGetPsFeedbackDisplayPixels(DisplayPixout.Panadapter, panBuf);
+                wf = engine.TryGetPsFeedbackDisplayPixels(DisplayPixout.Waterfall, wfBuf);
+                psFbPanUsed = pan;
+                psFbWfUsed = wf;
+            }
+            if (!pan) pan = engine.TryGetTxDisplayPixels(DisplayPixout.Panadapter, panBuf);
+            if (!wf) wf = engine.TryGetTxDisplayPixels(DisplayPixout.Waterfall, wfBuf);
+        }
+        if (_keyed && _psMonitorEnabled)
+        {
+            _psMonitorTickCount++;
+            if (_psMonitorTickCount % 30 == 0)
+            {
+                var m = engine.GetPsStageMeters();
+                _log.LogInformation(
+                    "psMonitor.gate keyed=1 psEn={PsEn} mon=1 corr={Corr} psFbPan={Pan} psFbWf={Wf}",
+                    _appliedPsEnabled, m.Correcting, psFbPanUsed, psFbWfUsed);
+            }
+        }
+        else
+        {
+            _psMonitorTickCount = 0;
         }
         if (!pan) pan = engine.TryGetDisplayPixels(channel, DisplayPixout.Panadapter, panBuf);
         if (!wf) wf = engine.TryGetDisplayPixels(channel, DisplayPixout.Waterfall, wfBuf);

--- a/Zeus.Server/Program.cs
+++ b/Zeus.Server/Program.cs
@@ -622,6 +622,17 @@ app.MapPost("/api/tx/ps/feedback-source",
     return Results.Ok(r.SetPsFeedbackSource(req));
 });
 
+// PS-Monitor — operator-facing toggle that swaps the TX panadapter source
+// from the predistorted-IQ analyzer to the PS-feedback (post-PA) analyzer.
+// Pure UI/source-routing flag; no WDSP setter, no wire-format change.
+// Default off; resets each session same as the PS master arm. See issue #121.
+app.MapPost("/api/tx/ps/monitor",
+    (PsMonitorSetRequest req, RadioService r) =>
+{
+    log.LogInformation("api.tx.ps.monitor enabled={Enabled}", req.Enabled);
+    return Results.Ok(r.SetPsMonitor(req));
+});
+
 app.MapPost("/api/tx/ps/reset", (DspPipelineService pipe) =>
 {
     log.LogInformation("api.tx.ps.reset");

--- a/Zeus.Server/RadioService.cs
+++ b/Zeus.Server/RadioService.cs
@@ -799,6 +799,22 @@ public sealed class RadioService : IDisposable
         return Snapshot();
     }
 
+    /// <summary>
+    /// Toggle the "Monitor PA output" view (issue #121). When on, AND PS is
+    /// armed, AND PS has converged, DspPipelineService.Tick reads pixels
+    /// from the PS-feedback analyzer instead of the post-CFIR TX analyzer
+    /// so the operator sees the actual on-air RF rather than the
+    /// predistorted baseband. Operator viewing preference — NOT persisted
+    /// across sessions (same discipline as PsEnabled / MOX).
+    /// </summary>
+    public StateDto SetPsMonitor(PsMonitorSetRequest req)
+    {
+        ArgumentNullException.ThrowIfNull(req);
+        _log.LogInformation("setPsMonitor enabled={Enabled}", req.Enabled);
+        Mutate(s => s with { PsMonitorEnabled = req.Enabled });
+        return Snapshot();
+    }
+
     public StateDto SetTwoTone(TwoToneSetRequest req)
     {
         ArgumentNullException.ThrowIfNull(req);

--- a/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
@@ -163,6 +163,7 @@ public class MicGainEndpointTests : IClassFixture<MicGainEndpointTests.Factory>
         public int ReadAudio(int channelId, Span<float> output) => 0;
         public bool TryGetDisplayPixels(int channelId, DisplayPixout which, Span<float> dbOut) => false;
         public bool TryGetTxDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
+        public bool TryGetPsFeedbackDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
         public int OpenTxChannel(int outputRateHz = 48_000) => 0;
         public void SetMox(bool moxOn) { }
         public double GetRxaSignalDbm(int channelId) => -140.0;

--- a/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
+++ b/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
@@ -86,6 +86,7 @@ public class TxAudioIngestTests
         public int ReadAudio(int channelId, Span<float> output) => 0;
         public bool TryGetDisplayPixels(int channelId, DisplayPixout which, Span<float> dbOut) => false;
         public bool TryGetTxDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
+        public bool TryGetPsFeedbackDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
         public int OpenTxChannel(int outputRateHz = 48_000) => 0;
         public void SetMox(bool moxOn) { }
         public double GetRxaSignalDbm(int channelId) => -140.0;

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -992,6 +992,29 @@ export async function setPsFeedbackSource(
   );
 }
 
+// PS-Monitor toggle (issue #121). When on AND PS is armed AND PS has
+// converged, the TX panadapter switches its source from the post-CFIR
+// predistorted-IQ analyzer to the PS-feedback (post-PA loopback) analyzer
+// so the operator sees the actual on-air RF instead of the predistorted
+// baseband. Default off — preserves the Thetis-style predistorted view.
+// Server-side this is a pure UI source-routing flag; no WDSP setter, no
+// wire-format change, default-off is byte-identical to pre-#121.
+export async function setPsMonitor(
+  enabled: boolean,
+  signal?: AbortSignal,
+): Promise<RadioStateDto> {
+  return jsonFetch(
+    '/api/tx/ps/monitor',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ enabled }),
+      signal,
+    },
+    (raw) => raw as RadioStateDto,
+  );
+}
+
 export async function resetPs(signal?: AbortSignal): Promise<void> {
   await jsonFetch('/api/tx/ps/reset', { method: 'POST', signal }, () => null);
 }

--- a/zeus-web/src/components/PsSettingsPanel.tsx
+++ b/zeus-web/src/components/PsSettingsPanel.tsx
@@ -18,11 +18,20 @@ import {
   setPs,
   setPsAdvanced,
   setPsFeedbackSource,
+  setPsMonitor,
   resetPs,
   setTwoTone,
 } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import { useRadioStore } from '../state/radio-store';
 import { useTxStore } from '../state/tx-store';
+
+// HermesLite2 has no PS feedback receiver — the entire PS-Monitor view
+// hinges on a paired DDC0/DDC1 loopback that doesn't exist on HL2. Hide
+// the toggle on HL2 so the operator doesn't get a switch that does
+// nothing. ANAN-class boards (and anything else that shows up here)
+// retain the toggle. See issue #121.
+const HL2_BOARD_ID = 'HermesLite2';
 
 const CAL_STATE_NAMES = [
   'RESET',
@@ -47,8 +56,17 @@ const CAL_STATE_NAMES = [
 export function PsSettingsPanel() {
   const protocol = useConnectionStore((s) => s.connectedProtocol);
   const p1Disabled = protocol === 'P1';
+  // The PS-Monitor source switch only makes sense when there's a real PS
+  // feedback receiver. On HL2 we hide the toggle entirely. We key on the
+  // CONNECTED board (not preferred) so a user who explicitly selects G2
+  // while no radio is attached still sees the control as a preview, but
+  // a live HL2 connection cleanly drops it.
+  const connectedBoard = useRadioStore((s) => s.selection.connected);
+  const psMonitorSupported = connectedBoard !== HL2_BOARD_ID;
 
   const psEnabled = useTxStore((s) => s.psEnabled);
+  const psMonitorEnabled = useTxStore((s) => s.psMonitorEnabled);
+  const setPsMonitorLocal = useTxStore((s) => s.setPsMonitorEnabled);
   const psAuto = useTxStore((s) => s.psAuto);
   const psSingle = useTxStore((s) => s.psSingle);
   const psPtol = useTxStore((s) => s.psPtol);
@@ -122,6 +140,18 @@ export function PsSettingsPanel() {
       setPsFeedbackSource(next).catch(() => setPsFeedbackSourceLocal(prev));
     },
     [psFeedbackSourceState, setPsFeedbackSourceLocal],
+  );
+
+  // PS-Monitor — operator-facing display source switch (issue #121).
+  // Optimistic local set + POST, rolls back on failure so the analyzer
+  // routing the backend uses and the UI checkbox stay in sync.
+  const onPsMonitorToggle = useCallback(
+    (next: boolean) => {
+      const prev = psMonitorEnabled;
+      setPsMonitorLocal(next);
+      setPsMonitor(next).catch(() => setPsMonitorLocal(prev));
+    },
+    [psMonitorEnabled, setPsMonitorLocal],
   );
 
   const onTwoToneToggle = useCallback(() => {
@@ -358,6 +388,28 @@ export function PsSettingsPanel() {
           />
         </Row>
       </Section>
+
+      {/* Display — issue #121. Hidden on HL2 (no PS feedback Rx). The
+          control is operator opt-in; default off preserves the Thetis-
+          style predistorted-IQ panadapter view. The backend gates the
+          actual analyzer swap on PsEnabled && PsCorrecting in addition
+          to this flag, so flipping it on while PS is off is harmless. */}
+      {psMonitorSupported ? (
+        <Section title="Display">
+          <Row label="Monitor PA output">
+            <input
+              type="checkbox"
+              checked={psMonitorEnabled}
+              onChange={(e) => onPsMonitorToggle(e.target.checked)}
+              disabled={p1Disabled}
+              title="Show post-correction signal in TX panadapter"
+            />
+            <span style={{ fontSize: 11, color: 'var(--fg-2)', marginLeft: 8 }}>
+              Show post-correction signal in TX panadapter
+            </span>
+          </Row>
+        </Section>
+      ) : null}
 
       {/* Read-out */}
       <Section title="Read-out">

--- a/zeus-web/src/state/tx-store.ts
+++ b/zeus-web/src/state/tx-store.ts
@@ -190,6 +190,14 @@ export type TxState = {
   // pihpsdr/Thetis behaviour.
   psFeedbackSource: 'internal' | 'external';
   setPsFeedbackSource: (s: 'internal' | 'external') => void;
+  // PS-Monitor (issue #121) — operator-facing "Monitor PA output" toggle.
+  // When on AND PS armed AND PS converged, the TX panadapter source flips
+  // from the predistorted TX-IQ analyzer to the PS-feedback analyzer
+  // (post-PA loopback). Default off; not persisted (parity with psEnabled
+  // — viewing preference, resets each session). Hidden / disabled in the
+  // UI on boards with no PS feedback path (e.g. HermesLite2).
+  psMonitorEnabled: boolean;
+  setPsMonitorEnabled: (on: boolean) => void;
   // Live readout pushed via MsgType.PsMeters (0x18) at 10 Hz when armed.
   psFeedbackLevel: number;
   psCorrectionDb: number;
@@ -315,6 +323,8 @@ export const useTxStore = create<TxState>()(
       setPsIntsSpiPreset: (p) => set({ psIntsSpiPreset: p }),
       psFeedbackSource: 'internal',
       setPsFeedbackSource: (s) => set({ psFeedbackSource: s }),
+      psMonitorEnabled: false,
+      setPsMonitorEnabled: (on) => set({ psMonitorEnabled: on }),
       psFeedbackLevel: 0,
       psCorrectionDb: 0,
       psCalState: 0,


### PR DESCRIPTION
## Summary

Fix Zeus's TX panadapter / waterfall showing pre-correction splatter during voice TX with PureSignal engaged. Two changes ride together — a default-view fix and an opt-in toggle — both rack-tested on G2 MkII / Saturn (P2, 80 m, voice).

## Changes

1. **Default TX panadapter now feeds from the WDSP TXA siphon.** Previously it was fed via `Spectrum0` from the post-CFIR `iout`/`qout` buffer — i.e. the predistorted IQ being sent to the radio, which is intentionally anti-IMD-shaped while PS is correcting and renders as visible splatter even when the antenna is clean. The new feed uses `TXAGetaSipF1` (already exported by our libwdsp build) to pull from the siphon's circular buffer at the same tap point Thetis uses (`Project Files/Source/wdsp/TXA.c:586` — between `xmeter(alc)` and `xiqc`). The TX analyzer is reconfigured at `_txaDspRateHz` / `_txaDspSize` to match the siphon's sample stream; `SetZoom` mirrors.

2. **New opt-in "Monitor PA output" toggle on the PureSignal settings panel.** When PS is engaged and correcting (`info[14]==1`), this routes the TX panadapter / waterfall to a second WDSP analyzer fed from the PS feedback Rx samples (post-PA loopback ADC). Default off. Hidden on Hermes Lite 2 (no PS-FB path). Pipeline-level only — no engine state changes, no wire writes.

3. **Display averaging tau bumped to 0.175 s** on TX-side analyzers (from the default 0.100 s) so voice envelope dynamics smooth into a Thetis-style trace rather than per-syllable spreading. Tuned empirically on the rack.

## Wire format

- `StateDto.PsMonitorEnabled` (bool, default false). Not persisted across sessions — same discipline as `PsEnabled` / MOX, viewing-preference only.
- `POST /api/tx/ps/monitor` → `RadioService.SetPsMonitor`.
- Frontend: `zeus-web` tx-store gains `psMonitorEnabled`, `setPsMonitor` API helper, and a new "Display" section on `PsSettingsPanel` with a "Monitor PA output" checkbox + tooltip.

## Diagnostic logging

Added with rate-limiting so future debug doesn't need a new instrumentation pass:
- `setPsMonitor enabled=…` (on toggle)
- `psMonitor.latch enabled=…` (on pipeline pickup)
- `psMonitor.gate keyed=1 psEn=… mon=1 corr=… psFbPan=… psFbWf=…` (1 Hz while keyed + monitor on)
- `wdsp.psFb.open` / `psFb.close` / `wdsp.psFb.fed n=N blocks` (lifecycle + cadence proof)

## Known limitations

- **The PA-Monitor button must be ENGAGED for the cleanest view.** With it off, the panadapter now shows the operator's pre-iqc baseband trace (siphon view — cleaner than pre-fix but still reflects compressor/leveler/ALC envelope shape). With it on, the panadapter shows the post-PA feedback Rx (closest visible match to what the antenna actually emits).
- **Still not perfect.** The post-PA loopback view on G2 MkII shows slightly more residual content than a "true" external Rx view of the antenna would. Will be made better in a future release — likely via a libwdsp rebuild that exposes `TXASetSipPosition` / `TXASetSipMode` for finer tap-point control, or analyzer-config tuning.
- HL2 sanity-check still owed (HL2 has no PS feedback Rx; toggle is hidden client-side, default-off codepath is byte-identical to pre-PR for HL2).

## Build

- `dotnet build Zeus.slnx` — 0 warnings, 0 errors.
- All existing tests still build / pass.

## Test plan

- [x] Voice TX with PS engaged + PA Monitor ON: panadapter and waterfall noticeably cleaner, matches operator's expectation.
- [x] Voice TX with PS engaged + PA Monitor OFF: panadapter shows pre-iqc baseband trace (cleaner than pre-fix predistorted view).
- [x] PS still converges normally (`info[14]=1`, four-patch chain unchanged).
- [x] Toggle hidden on HL2.
- [ ] Bench-test on HL2 to confirm zero regression in default-off codepath.

Closes #121