### PR TITLE
feat(dsp): add 10-band Continuous Frequency Compressor + TX Audio Tools menu

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -182,7 +182,13 @@ public sealed record StateDto(
     bool TwoToneEnabled = false,
     double TwoToneFreq1 = 700.0,
     double TwoToneFreq2 = 1900.0,
-    double TwoToneMag = 0.49);
+    double TwoToneMag = 0.49,
+
+    // ---- CFC (Continuous Frequency Compressor) — issue #123 ----
+    // Nullable so legacy state frames (no Cfc field) deserialize unchanged;
+    // null at the engine seam means "use CfcConfig.Default" — same pattern
+    // as the Nr field above. Persisted globally via DspSettingsStore.
+    CfcConfig? Cfc = null);
 
 public sealed record RadioInfo(
     string MacAddress,
@@ -361,3 +367,58 @@ public sealed record TwoToneSetRequest(
     double? Freq1 = null,
     double? Freq2 = null,
     double? Mag = null);
+
+// ---- CFC (Continuous Frequency Compressor) — issue #123 ------------------
+// Multi-band frequency-domain compressor exposed by WDSP's xcfcomp stage
+// (already wired in xtxa between xeqp and xbandpass). Mirrors pihpsdr's
+// classic 10-band non-parametric design — see cfc_menu.c. The architecture
+// proposal on issue #123 enumerates every WDSP CFCOMP setter we surface.
+//
+// Persisted GLOBALLY (not per-band/mode) per kb2uka's spec — operator
+// profiles are a future feature. CFC defaults to OFF so existing operators
+// (including the project owner's external analog rack workflow) see no
+// behavior change unless they enable. PostEqEnabled is a separate toggle
+// from the master Enabled to mirror pihpsdr — operators may want CFC
+// compression without the EQ branch.
+
+/// <summary>One CFC band: centre frequency in Hz (operator-typed),
+/// compression-level threshold in dB, and post-comp makeup gain in dB.
+/// WDSP sorts the band array internally (cfcomp.c:147), so the on-the-wire
+/// order is informational only — the engine relies on WDSP to canonicalise.
+/// </summary>
+public sealed record CfcBand(double FreqHz, double CompLevelDb, double PostGainDb);
+
+/// <summary>Operator-tunable CFC configuration. <c>Bands</c> length is
+/// fixed at 10 to match pihpsdr's classic-mode default and keep the panel
+/// layout stable. Engine validates length at the seam.</summary>
+public sealed record CfcConfig(
+    bool Enabled,
+    bool PostEqEnabled,
+    double PreCompDb,
+    double PrePeqDb,
+    CfcBand[] Bands)
+{
+    /// <summary>Pihpsdr's vfo.c:284-314 baseline — 10 bands at the voice-band
+    /// frequencies operators recognise from PowerSDR. All compression and
+    /// gains zeroed so enabling neutral CFC is audibly transparent.</summary>
+    public static CfcConfig Default => new(
+        Enabled: false,
+        PostEqEnabled: false,
+        PreCompDb: 0.0,
+        PrePeqDb: 0.0,
+        Bands: new[]
+        {
+            new CfcBand(50,    0, 0),
+            new CfcBand(100,   0, 0),
+            new CfcBand(200,   0, 0),
+            new CfcBand(500,   0, 0),
+            new CfcBand(1000,  0, 0),
+            new CfcBand(1500,  0, 0),
+            new CfcBand(2000,  0, 0),
+            new CfcBand(2500,  0, 0),
+            new CfcBand(3000,  0, 0),
+            new CfcBand(5000,  0, 0),
+        });
+}
+
+public sealed record CfcSetRequest(CfcConfig Config);

--- a/Zeus.Dsp/IDspEngine.cs
+++ b/Zeus.Dsp/IDspEngine.cs
@@ -221,4 +221,19 @@ public interface IDspEngine : IDisposable
     /// <summary>Restore a previously-saved correction curve. Equivalent to
     /// PSForm's "Restore-and-go" with <c>SetPSControl(0,0,0,1)</c>.</summary>
     void RestorePsCorrection(string path);
+
+    // ----------------- CFC (Continuous Frequency Compressor) ---------------
+    // Multi-band frequency-domain compressor (xcfcomp) — issue #123. The
+    // stage already lives in xtxa between xeqp and xbandpass; this seam just
+    // pushes parameters and toggles run flags. Synthetic engine validates
+    // and no-ops; the WDSP engine pushes the profile arrays + scalar
+    // parameters under the TXA lock and flips Run last so a partial config
+    // never lands in the live audio path.
+
+    /// <summary>Apply a CFC profile: per-band frequencies/compression/post-gains
+    /// plus scalar pre-comp/pre-EQ/post-EQ-run/master-run toggles. The
+    /// <c>cfg.Bands</c> array must have exactly 10 entries (matches pihpsdr
+    /// classic-mode shape; the panel layout depends on it). No-op when no TXA
+    /// is open or on Synthetic.</summary>
+    void SetCfcConfig(CfcConfig cfg);
 }

--- a/Zeus.Dsp/SyntheticDspEngine.cs
+++ b/Zeus.Dsp/SyntheticDspEngine.cs
@@ -178,6 +178,16 @@ public sealed class SyntheticDspEngine : IDspEngine
     public void SavePsCorrection(string path) { }
     public void RestorePsCorrection(string path) { }
 
+    // CFC — synthetic has no TXA so SetCfcConfig only validates the payload
+    // shape so bad client requests fail fast in dev/CI without touching audio.
+    public void SetCfcConfig(CfcConfig cfg)
+    {
+        ArgumentNullException.ThrowIfNull(cfg);
+        if (cfg.Bands is null) throw new ArgumentException("Bands must not be null", nameof(cfg));
+        if (cfg.Bands.Length != 10)
+            throw new ArgumentException($"Bands must have exactly 10 entries; got {cfg.Bands.Length}", nameof(cfg));
+    }
+
     // Synthetic has no TX analyzer; the TX panadapter stays on the RX trace.
     // Returning false tells DspPipelineService.Tick to leave the display alone
     // while MOX is on, matching the existing "no new data" semantics.

--- a/Zeus.Dsp/Wdsp/NativeMethods.cs
+++ b/Zeus.Dsp/Wdsp/NativeMethods.cs
@@ -595,6 +595,53 @@ internal static partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial void SetTXACFCOMPRun(int channel, int run);
 
+    // CFC (Continuous Frequency Compressor — multi-band frequency-domain
+    // compressor sitting in xtxa between xeqp and xbandpass). Issue #123.
+    // Entry points are case-sensitive — note `prof_i_le` is lowercase per
+    // cfcomp.c. Verified via `nm -D libwdsp.so | grep -i CFC`.
+    //
+    // SetTXACFCOMPprofile takes parallel arrays F[], G[], E[] (frequency Hz,
+    // compression dB, post-EQ gain dB) plus optional Q-derivative arrays for
+    // the *parametric* mode. Pass IntPtr.Zero for Qg/Qe to select the classic
+    // (pihpsdr / PowerSDR) non-parametric mode — cfcomp.c:122-123 falls back
+    // to linear interpolation when the Q pointers are NULL. The caller pins
+    // F/G/E with `fixed` blocks and passes them via `ref *pF`.
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetTXACFCOMPprofile(
+        int channel,
+        int nfreqs,
+        ref double F,
+        ref double G,
+        ref double E,
+        IntPtr Qg,
+        IntPtr Qe);
+
+    // Frequency-independent pre-compressor gain (dB).
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetTXACFCOMPPrecomp(int channel, double precomp);
+
+    // Frequency-independent pre-EQ gain (dB).
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetTXACFCOMPPrePeq(int channel, double prepeq);
+
+    // Post-comp EQ branch enable (separate toggle from the master CFCOMPRun).
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetTXACFCOMPPeqRun(int channel, int run);
+
+    // Per-bin compression-meter readback. `comp_values` must be a pinned
+    // double[] sized to the FFT bins; `ready` is set to 1 when a fresh frame
+    // is available. Read-only diagnostic — not on the hot path.
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void GetTXACFCOMPDisplayCompression(
+        int channel,
+        ref double comp_values,
+        out int ready);
+
     [LibraryImport(LibraryName)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial void SetTXAPHROTRun(int channel, int run);

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -1636,6 +1636,75 @@ public sealed class WdspDspEngine : IDspEngine
         _log.LogInformation("wdsp.restorePsCorrection path={Path}", path);
     }
 
+    // CFC (Continuous Frequency Compressor) — issue #123. xcfcomp already
+    // sits in xtxa between xeqp and xbandpass; this method just pushes the
+    // operator-tuned profile + scalar params and toggles the run flag.
+    //
+    // Param push order matters: profile + scalars + post-EQ-run all happen
+    // BEFORE the master CFCOMPRun flip. That way when the master toggles on,
+    // the audio pipeline starts processing with a fully-configured stage —
+    // mirrors the same "configure, then enable" Thetis pattern we use for
+    // every other WDSP stage (see SetNoiseReduction NR2/NR4 ordering).
+    //
+    // Pass IntPtr.Zero for Qg/Qe — selects classic non-parametric mode
+    // (cfcomp.c:122-123 falls back to linear interpolation). Matches
+    // pihpsdr's cfc_menu.c, which is the canonical reference per issue #123.
+    public unsafe void SetCfcConfig(CfcConfig cfg)
+    {
+        ArgumentNullException.ThrowIfNull(cfg);
+        if (cfg.Bands is null) throw new ArgumentException("Bands must not be null", nameof(cfg));
+        if (cfg.Bands.Length != 10)
+            throw new ArgumentException($"Bands must have exactly 10 entries; got {cfg.Bands.Length}", nameof(cfg));
+
+        if (_disposed != 0) return;
+
+        int txa;
+        lock (_txaLock)
+        {
+            if (_txaChannelId is not int id) return;
+            txa = id;
+        }
+
+        // Build parallel arrays for SetTXACFCOMPprofile. WDSP sorts internally
+        // (cfcomp.c:147) and clamps to [0, Nyquist], so we don't pre-validate
+        // monotonicity — operators are free to type frequencies in any order.
+        const int nfreqs = 10;
+        double[] f = new double[nfreqs];
+        double[] g = new double[nfreqs];
+        double[] e = new double[nfreqs];
+        for (int i = 0; i < nfreqs; i++)
+        {
+            var band = cfg.Bands[i];
+            f[i] = band.FreqHz;
+            g[i] = band.CompLevelDb;
+            e[i] = band.PostGainDb;
+        }
+
+        lock (_txaLock)
+        {
+            // Re-check inside the lock — TXA could have closed between the
+            // outer lookup and here on a teardown race. Same pattern other
+            // _txaLock callers use.
+            if (_txaChannelId is not int id) return;
+
+            fixed (double* pF = f, pG = g, pE = e)
+            {
+                NativeMethods.SetTXACFCOMPprofile(
+                    id, nfreqs,
+                    ref *pF, ref *pG, ref *pE,
+                    IntPtr.Zero, IntPtr.Zero);
+            }
+            NativeMethods.SetTXACFCOMPPrecomp(id, cfg.PreCompDb);
+            NativeMethods.SetTXACFCOMPPrePeq(id, cfg.PrePeqDb);
+            NativeMethods.SetTXACFCOMPPeqRun(id, cfg.PostEqEnabled ? 1 : 0);
+            NativeMethods.SetTXACFCOMPRun(id, cfg.Enabled ? 1 : 0);
+        }
+
+        _log.LogInformation(
+            "wdsp.setCfc enabled={Enabled} peq={Peq} precomp={Pre:F1}dB prepeq={PrePeq:F1}dB",
+            cfg.Enabled, cfg.PostEqEnabled, cfg.PreCompDb, cfg.PrePeqDb);
+    }
+
     private DateTime _lastTxMeterLogUtc;
 
     public int ProcessTxBlock(ReadOnlySpan<float> micMono, Span<float> iqInterleaved)
@@ -1775,10 +1844,11 @@ public sealed class WdspDspEngine : IDspEngine
                 double ma = Math.Max(oi, oq); if (ma > ioutPeak) ioutPeak = ma;
             }
             _log.LogInformation(
-                "wdsp.tx.stage micBlockPeak={MP:F3} iqBlockPeak={IP:F4} | mic pk={MicPk:F1} av={MicAv:F1} | eq pk={EqPk:F1} av={EqAv:F1} | lvlr pk={LvlrPk:F1} av={LvlrAv:F1} gr={LvlrGr:F1} | alc pk={AlcPk:F1} av={AlcAv:F1} gr={AlcGr:F1} | out pk={OutPk:F1} av={OutAv:F1}",
+                "wdsp.tx.stage micBlockPeak={MP:F3} iqBlockPeak={IP:F4} | mic pk={MicPk:F1} av={MicAv:F1} | eq pk={EqPk:F1} av={EqAv:F1} | lvlr pk={LvlrPk:F1} av={LvlrAv:F1} gr={LvlrGr:F1} | cfc pk={CfcPk:F1} av={CfcAv:F1} gr={CfcGr:F1} | alc pk={AlcPk:F1} av={AlcAv:F1} gr={AlcGr:F1} | out pk={OutPk:F1} av={OutAv:F1}",
                 micBlockPeak, ioutPeak,
                 micPk, micAv, eqPk, eqAv,
                 lvlrPk, lvlrAv, -lvlrGain,
+                cfcPk, cfcAv, -cfcGain,
                 alcPk, alcAv, -alcGain,
                 outPk, outAv);
         }

--- a/Zeus.Server/DspPipelineService.cs
+++ b/Zeus.Server/DspPipelineService.cs
@@ -119,6 +119,12 @@ public class DspPipelineService : BackgroundService
     private double _appliedTwoToneFreq1 = 700.0;
     private double _appliedTwoToneFreq2 = 1900.0;
     private double _appliedTwoToneMag = 0.49;
+    // CFC (Continuous Frequency Compressor) — issue #123. Default-OFF so a
+    // fresh state-change push (no Cfc field on the wire) doesn't flip the
+    // engine into a partial config. _psResyncRequired piggybacks: when a P2
+    // reconnect tears down the engine, we re-push the CFC profile too so the
+    // new WdspDspEngine instance picks up the operator's persisted config.
+    private CfcConfig _appliedCfc = CfcConfig.Default;
 
     private uint _seq;
     private uint _audioSeq;
@@ -432,9 +438,49 @@ public class DspPipelineService : BackgroundService
             _p2Client?.SetPsFeedbackSource(s.PsFeedbackSource == PsFeedbackSource.External);
             _appliedPsFeedbackSource = s.PsFeedbackSource;
         }
+
+        // ---- CFC (Continuous Frequency Compressor) ---------------------
+        // issue #123. Same resync rule as PS: a P2 disconnect tears down the
+        // engine, so the next state-change push has to re-assert the operator
+        // CFC config even when the StateDto value hasn't changed. Equality
+        // check uses CfcConfig record value semantics (the Bands array length
+        // is fixed at 10, contents compared element-wise via the auto-record
+        // Equals — but `record` only does reference equality on arrays, so
+        // value-compare manually). null on the wire (legacy state frame)
+        // falls back to CfcConfig.Default → engine sees a clean OFF profile.
+        var cfc = s.Cfc ?? CfcConfig.Default;
+        if (resync || !CfcConfigsEqual(cfc, _appliedCfc))
+        {
+            engine.SetCfcConfig(cfc);
+            _appliedCfc = cfc;
+        }
+
         // Resync done — clear the flag so subsequent state changes use
         // normal change-detect (no spurious wire writes on each tick).
         _psResyncRequired = false;
+    }
+
+    // CfcConfig auto-generated record Equals does reference equality on the
+    // Bands array, which would always trigger a re-push on every tick where
+    // the panel rebuilt the array. Explicit element-wise compare so a no-op
+    // POST round-trip stays cheap.
+    private static bool CfcConfigsEqual(CfcConfig a, CfcConfig b)
+    {
+        if (ReferenceEquals(a, b)) return true;
+        if (a is null || b is null) return false;
+        if (a.Enabled != b.Enabled) return false;
+        if (a.PostEqEnabled != b.PostEqEnabled) return false;
+        if (a.PreCompDb != b.PreCompDb) return false;
+        if (a.PrePeqDb != b.PrePeqDb) return false;
+        if (a.Bands is null || b.Bands is null) return ReferenceEquals(a.Bands, b.Bands);
+        if (a.Bands.Length != b.Bands.Length) return false;
+        for (int i = 0; i < a.Bands.Length; i++)
+        {
+            if (a.Bands[i].FreqHz != b.Bands[i].FreqHz) return false;
+            if (a.Bands[i].CompLevelDb != b.Bands[i].CompLevelDb) return false;
+            if (a.Bands[i].PostGainDb != b.Bands[i].PostGainDb) return false;
+        }
+        return true;
     }
 
     // "16/256" → (16, 256). Falls back to (16, 256) on any parse failure

--- a/Zeus.Server/DspSettingsStore.cs
+++ b/Zeus.Server/DspSettingsStore.cs
@@ -61,6 +61,43 @@ public sealed class DspSettingsStore : IDisposable
             Nr4Position: e.Nr4Position);
     }
 
+    // CFC (Continuous Frequency Compressor) — issue #123. Persisted globally
+    // (one row per profileId, sharing the same DspSettingsEntry). Returns null
+    // when the entry is missing OR when CFC has never been written, so the
+    // caller can fall back to <see cref="CfcConfig.Default"/>. Old DB rows
+    // (pre-CFC) load with all CfcEnabled/CfcBandN* fields at their nullable
+    // / zero defaults, which means CfcEnabled is null on a legacy upsert; we
+    // return null in that case to preserve the default-OFF promise.
+    public CfcConfig? GetCfc(string profileId = "default")
+    {
+        var e = _entries.FindOne(x => x.ProfileId == profileId);
+        if (e is null) return null;
+        if (e.CfcEnabled is null) return null;  // never written → caller uses Default
+
+        // Reconstruct the 10-band array from the per-band scalars. Order of
+        // the rows on disk is stable (band index 0..9), so the operator's
+        // typed order survives the round-trip exactly.
+        var bands = new CfcBand[10]
+        {
+            new(e.CfcBand1Freq, e.CfcBand1Comp, e.CfcBand1Post),
+            new(e.CfcBand2Freq, e.CfcBand2Comp, e.CfcBand2Post),
+            new(e.CfcBand3Freq, e.CfcBand3Comp, e.CfcBand3Post),
+            new(e.CfcBand4Freq, e.CfcBand4Comp, e.CfcBand4Post),
+            new(e.CfcBand5Freq, e.CfcBand5Comp, e.CfcBand5Post),
+            new(e.CfcBand6Freq, e.CfcBand6Comp, e.CfcBand6Post),
+            new(e.CfcBand7Freq, e.CfcBand7Comp, e.CfcBand7Post),
+            new(e.CfcBand8Freq, e.CfcBand8Comp, e.CfcBand8Post),
+            new(e.CfcBand9Freq, e.CfcBand9Comp, e.CfcBand9Post),
+            new(e.CfcBand10Freq, e.CfcBand10Comp, e.CfcBand10Post),
+        };
+        return new CfcConfig(
+            Enabled: e.CfcEnabled.Value,
+            PostEqEnabled: e.CfcPostEqEnabled ?? false,
+            PreCompDb: e.CfcPreCompDb ?? 0.0,
+            PrePeqDb: e.CfcPrePeqDb ?? 0.0,
+            Bands: bands);
+    }
+
     public void Upsert(NrConfig config, string profileId = "default")
     {
         var existing = _entries.FindOne(x => x.ProfileId == profileId);
@@ -115,6 +152,61 @@ public sealed class DspSettingsStore : IDisposable
         }
     }
 
+    // CFC upsert — extends the same row used for NR. Insert path needs all the
+    // NR fields too because the row may not exist yet (a fresh install where
+    // the operator opens TX Audio Tools before touching NR). NR fields are
+    // seeded from a default NrConfig in that case so the legacy NR path
+    // continues to round-trip on subsequent NR-only Upserts.
+    public void Upsert(CfcConfig config, string profileId = "default")
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        if (config.Bands is null || config.Bands.Length != 10)
+            throw new ArgumentException($"Bands must have exactly 10 entries; got {config.Bands?.Length ?? 0}", nameof(config));
+
+        var existing = _entries.FindOne(x => x.ProfileId == profileId);
+        if (existing is null)
+        {
+            var nrSeed = new NrConfig();
+            existing = new DspSettingsEntry
+            {
+                ProfileId = profileId,
+                NrMode = nrSeed.NrMode,
+                AnfEnabled = nrSeed.AnfEnabled,
+                SnbEnabled = nrSeed.SnbEnabled,
+                NbpNotchesEnabled = nrSeed.NbpNotchesEnabled,
+                NbMode = nrSeed.NbMode,
+                NbThreshold = nrSeed.NbThreshold,
+            };
+            ApplyCfcToEntry(existing, config);
+            existing.UpdatedUtc = DateTime.UtcNow;
+            _entries.Insert(existing);
+        }
+        else
+        {
+            ApplyCfcToEntry(existing, config);
+            existing.UpdatedUtc = DateTime.UtcNow;
+            _entries.Update(existing);
+        }
+    }
+
+    private static void ApplyCfcToEntry(DspSettingsEntry e, CfcConfig c)
+    {
+        e.CfcEnabled = c.Enabled;
+        e.CfcPostEqEnabled = c.PostEqEnabled;
+        e.CfcPreCompDb = c.PreCompDb;
+        e.CfcPrePeqDb = c.PrePeqDb;
+        e.CfcBand1Freq = c.Bands[0].FreqHz;  e.CfcBand1Comp = c.Bands[0].CompLevelDb;  e.CfcBand1Post = c.Bands[0].PostGainDb;
+        e.CfcBand2Freq = c.Bands[1].FreqHz;  e.CfcBand2Comp = c.Bands[1].CompLevelDb;  e.CfcBand2Post = c.Bands[1].PostGainDb;
+        e.CfcBand3Freq = c.Bands[2].FreqHz;  e.CfcBand3Comp = c.Bands[2].CompLevelDb;  e.CfcBand3Post = c.Bands[2].PostGainDb;
+        e.CfcBand4Freq = c.Bands[3].FreqHz;  e.CfcBand4Comp = c.Bands[3].CompLevelDb;  e.CfcBand4Post = c.Bands[3].PostGainDb;
+        e.CfcBand5Freq = c.Bands[4].FreqHz;  e.CfcBand5Comp = c.Bands[4].CompLevelDb;  e.CfcBand5Post = c.Bands[4].PostGainDb;
+        e.CfcBand6Freq = c.Bands[5].FreqHz;  e.CfcBand6Comp = c.Bands[5].CompLevelDb;  e.CfcBand6Post = c.Bands[5].PostGainDb;
+        e.CfcBand7Freq = c.Bands[6].FreqHz;  e.CfcBand7Comp = c.Bands[6].CompLevelDb;  e.CfcBand7Post = c.Bands[6].PostGainDb;
+        e.CfcBand8Freq = c.Bands[7].FreqHz;  e.CfcBand8Comp = c.Bands[7].CompLevelDb;  e.CfcBand8Post = c.Bands[7].PostGainDb;
+        e.CfcBand9Freq = c.Bands[8].FreqHz;  e.CfcBand9Comp = c.Bands[8].CompLevelDb;  e.CfcBand9Post = c.Bands[8].PostGainDb;
+        e.CfcBand10Freq = c.Bands[9].FreqHz; e.CfcBand10Comp = c.Bands[9].CompLevelDb; e.CfcBand10Post = c.Bands[9].PostGainDb;
+    }
+
     public void Dispose() => _db.Dispose();
 
     private static string GetDatabasePath()
@@ -150,5 +242,25 @@ public sealed class DspSettingsEntry
     public double? Nr4PostFilterThreshold { get; set; }
     public int? Nr4NoiseScalingType { get; set; }
     public int? Nr4Position { get; set; }
+    // CFC (Continuous Frequency Compressor) — issue #123. Master flags are
+    // nullable so legacy rows (pre-CFC) load with CfcEnabled=null and
+    // GetCfc() returns null → operator gets CfcConfig.Default. Per-band
+    // scalars are non-nullable doubles and default to 0 on legacy rows; the
+    // null Enabled flag prevents those zeros from being interpreted as a
+    // valid CFC config.
+    public bool? CfcEnabled { get; set; }
+    public bool? CfcPostEqEnabled { get; set; }
+    public double? CfcPreCompDb { get; set; }
+    public double? CfcPrePeqDb { get; set; }
+    public double CfcBand1Freq { get; set; }  public double CfcBand1Comp { get; set; }  public double CfcBand1Post { get; set; }
+    public double CfcBand2Freq { get; set; }  public double CfcBand2Comp { get; set; }  public double CfcBand2Post { get; set; }
+    public double CfcBand3Freq { get; set; }  public double CfcBand3Comp { get; set; }  public double CfcBand3Post { get; set; }
+    public double CfcBand4Freq { get; set; }  public double CfcBand4Comp { get; set; }  public double CfcBand4Post { get; set; }
+    public double CfcBand5Freq { get; set; }  public double CfcBand5Comp { get; set; }  public double CfcBand5Post { get; set; }
+    public double CfcBand6Freq { get; set; }  public double CfcBand6Comp { get; set; }  public double CfcBand6Post { get; set; }
+    public double CfcBand7Freq { get; set; }  public double CfcBand7Comp { get; set; }  public double CfcBand7Post { get; set; }
+    public double CfcBand8Freq { get; set; }  public double CfcBand8Comp { get; set; }  public double CfcBand8Post { get; set; }
+    public double CfcBand9Freq { get; set; }  public double CfcBand9Comp { get; set; }  public double CfcBand9Post { get; set; }
+    public double CfcBand10Freq { get; set; } public double CfcBand10Comp { get; set; } public double CfcBand10Post { get; set; }
     public DateTime UpdatedUtc { get; set; }
 }

--- a/Zeus.Server/Program.cs
+++ b/Zeus.Server/Program.cs
@@ -687,6 +687,22 @@ app.MapPost("/api/rx/nr4", (Nr4ConfigSetRequest req, RadioService r) =>
     return Results.Ok(r.SetNr4(req));
 });
 
+// CFC (Continuous Frequency Compressor) — issue #123. POSTs the full 10-band
+// CFC profile + master flags. Defaults to OFF so existing operators see no
+// behavior change. Validation is done by RadioService.SetCfc — bad shapes
+// throw ArgumentException which the framework returns as 400.
+app.MapPost("/api/tx/cfc", (CfcSetRequest req, RadioService r) =>
+{
+    if (req?.Config is null)
+        return Results.BadRequest(new { error = "Config required" });
+    if (req.Config.Bands is null || req.Config.Bands.Length != 10)
+        return Results.BadRequest(new { error = $"Bands must have exactly 10 entries; got {req.Config.Bands?.Length ?? 0}" });
+    log.LogInformation(
+        "api.tx.cfc enabled={Enabled} peq={Peq} preComp={Pre:F1}dB prePeq={PrePeq:F1}dB",
+        req.Config.Enabled, req.Config.PostEqEnabled, req.Config.PreCompDb, req.Config.PrePeqDb);
+    return Results.Ok(r.SetCfc(req));
+});
+
 app.MapPost("/api/rx/zoom", (ZoomSetRequest req, RadioService r) =>
 {
     log.LogInformation("api.rx.zoom level={Level}", req.Level);

--- a/Zeus.Server/RadioService.cs
+++ b/Zeus.Server/RadioService.cs
@@ -151,6 +151,10 @@ public sealed class RadioService : IDisposable
 
         // Load persisted DSP settings from the store, or use defaults if not found
         var persistedNr = _dspSettingsStore.Get() ?? new NrConfig();
+        // CFC — issue #123. Persisted globally; null on a fresh install or
+        // legacy DB row falls back to the default-OFF baseline so the operator
+        // sees no behaviour change unless they enable.
+        var persistedCfc = _dspSettingsStore.GetCfc() ?? CfcConfig.Default;
 
         // Seed the last-preset cache from persisted store for all modes so
         // the first mode-switch in a session recalls the correct slot.
@@ -198,7 +202,8 @@ public sealed class RadioService : IDisposable
             // (700/1900 Hz, 0.49 each — peak ~0.98 just under WDSP IQ clip).
             TwoToneFreq1: ps?.TwoToneFreq1 ?? 700.0,
             TwoToneFreq2: ps?.TwoToneFreq2 ?? 1900.0,
-            TwoToneMag: ps?.TwoToneMag ?? 0.49);
+            TwoToneMag: ps?.TwoToneMag ?? 0.49,
+            Cfc: persistedCfc);
     }
 
     /// <summary>
@@ -789,6 +794,27 @@ public sealed class RadioService : IDisposable
             Nr4Position = req.Position ?? current.Nr4Position,
         };
         return SetNr(merged);
+    }
+
+    // CFC (Continuous Frequency Compressor) — issue #123. The whole 10-band
+    // config travels in one POST because the operator edits the panel as a
+    // single table; the engine then re-pushes the whole profile to WDSP.
+    // Mirrors the SetNr shape: validate, mutate state, persist, return
+    // snapshot. DspPipelineService picks up the change-detect on the next
+    // OnRadioStateChanged tick and pushes through to the engine.
+    public StateDto SetCfc(CfcSetRequest req)
+    {
+        ArgumentNullException.ThrowIfNull(req);
+        var cfg = req.Config ?? throw new ArgumentException("Config required", nameof(req));
+        if (cfg.Bands is null || cfg.Bands.Length != 10)
+            throw new ArgumentException($"Bands must have exactly 10 entries; got {cfg.Bands?.Length ?? 0}", nameof(req));
+
+        Mutate(s => s with { Cfc = cfg });
+        _dspSettingsStore.Upsert(cfg);
+        _log.LogInformation(
+            "radio.setCfc enabled={Enabled} peq={Peq} preComp={Pre:F1}dB prePeq={PrePeq:F1}dB",
+            cfg.Enabled, cfg.PostEqEnabled, cfg.PreCompDb, cfg.PrePeqDb);
+        return Snapshot();
     }
 
     // ---------------- PureSignal ----------------

--- a/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
@@ -189,6 +189,7 @@ public class MicGainEndpointTests : IClassFixture<MicGainEndpointTests.Factory>
         public void ResetPs() { }
         public void SavePsCorrection(string path) { }
         public void RestorePsCorrection(string path) { }
+        public void SetCfcConfig(CfcConfig cfg) { }
         public void Dispose() { }
     }
 

--- a/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
+++ b/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
@@ -113,6 +113,7 @@ public class TxAudioIngestTests
         public void ResetPs() { }
         public void SavePsCorrection(string path) { }
         public void RestorePsCorrection(string path) { }
+        public void SetCfcConfig(CfcConfig cfg) { }
         public void Dispose() { }
     }
 

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -163,6 +163,47 @@ export type RadioStateDto = {
   twoToneFreq1: number;
   twoToneFreq2: number;
   twoToneMag: number;
+  // CFC (Continuous Frequency Compressor) — issue #123. Always present
+  // after normalisation; falls back to CFC_CONFIG_DEFAULT when the server
+  // omits it (legacy state frames).
+  cfc: CfcConfigDto;
+};
+
+// CFC mirrors Zeus.Contracts.CfcConfig. Bands array is fixed at 10 entries
+// — the panel layout depends on it; the server validates the same.
+export type CfcBandDto = {
+  freqHz: number;
+  compLevelDb: number;
+  postGainDb: number;
+};
+export type CfcConfigDto = {
+  enabled: boolean;
+  postEqEnabled: boolean;
+  preCompDb: number;
+  prePeqDb: number;
+  bands: CfcBandDto[];
+};
+
+// Pihpsdr classic-mode default — voice-band split the operator recognises
+// from PowerSDR. Master OFF + zeroed comp/post means a fresh enable is
+// audibly transparent. Mirrors CfcConfig.Default on the server.
+export const CFC_CONFIG_DEFAULT: CfcConfigDto = {
+  enabled: false,
+  postEqEnabled: false,
+  preCompDb: 0,
+  prePeqDb: 0,
+  bands: [
+    { freqHz: 50,   compLevelDb: 0, postGainDb: 0 },
+    { freqHz: 100,  compLevelDb: 0, postGainDb: 0 },
+    { freqHz: 200,  compLevelDb: 0, postGainDb: 0 },
+    { freqHz: 500,  compLevelDb: 0, postGainDb: 0 },
+    { freqHz: 1000, compLevelDb: 0, postGainDb: 0 },
+    { freqHz: 1500, compLevelDb: 0, postGainDb: 0 },
+    { freqHz: 2000, compLevelDb: 0, postGainDb: 0 },
+    { freqHz: 2500, compLevelDb: 0, postGainDb: 0 },
+    { freqHz: 3000, compLevelDb: 0, postGainDb: 0 },
+    { freqHz: 5000, compLevelDb: 0, postGainDb: 0 },
+  ],
 };
 
 export type FilterPresetDto = {
@@ -354,6 +395,50 @@ export function normalizeState(raw: unknown): RadioStateDto {
     twoToneFreq1: typeof r.twoToneFreq1 === 'number' ? r.twoToneFreq1 : 700,
     twoToneFreq2: typeof r.twoToneFreq2 === 'number' ? r.twoToneFreq2 : 1900,
     twoToneMag: typeof r.twoToneMag === 'number' ? r.twoToneMag : 0.49,
+    cfc: normalizeCfc(r.cfc),
+  };
+}
+
+// Normalise the wire CFC config. Missing or malformed payload falls back to
+// CFC_CONFIG_DEFAULT so a legacy server (no `cfc` field) still gives the
+// settings panel something to render. Bands are clamped to length 10 by
+// padding with the matching default-band slot if the server somehow returns
+// fewer; extras are truncated. The server validates length on POST.
+export function normalizeCfc(raw: unknown): CfcConfigDto {
+  if (!raw || typeof raw !== 'object') return cloneCfc(CFC_CONFIG_DEFAULT);
+  const r = raw as Record<string, unknown>;
+  const rawBands = Array.isArray(r.bands) ? (r.bands as unknown[]) : [];
+  const bands: CfcBandDto[] = [];
+  for (let i = 0; i < 10; i++) {
+    const b = (rawBands[i] ?? {}) as Record<string, unknown>;
+    // CFC_CONFIG_DEFAULT.bands has exactly 10 entries (frozen at module
+    // init), so the indexed lookup is always defined — but tsc's
+    // noUncheckedIndexedAccess can't see that, so fall through with a
+    // zeroed band as a belt-and-braces guard.
+    const fallback =
+      CFC_CONFIG_DEFAULT.bands[i] ?? { freqHz: 0, compLevelDb: 0, postGainDb: 0 };
+    bands.push({
+      freqHz: typeof b.freqHz === 'number' ? b.freqHz : fallback.freqHz,
+      compLevelDb: typeof b.compLevelDb === 'number' ? b.compLevelDb : fallback.compLevelDb,
+      postGainDb: typeof b.postGainDb === 'number' ? b.postGainDb : fallback.postGainDb,
+    });
+  }
+  return {
+    enabled: typeof r.enabled === 'boolean' ? r.enabled : false,
+    postEqEnabled: typeof r.postEqEnabled === 'boolean' ? r.postEqEnabled : false,
+    preCompDb: typeof r.preCompDb === 'number' ? r.preCompDb : 0,
+    prePeqDb: typeof r.prePeqDb === 'number' ? r.prePeqDb : 0,
+    bands,
+  };
+}
+
+function cloneCfc(c: CfcConfigDto): CfcConfigDto {
+  return {
+    enabled: c.enabled,
+    postEqEnabled: c.postEqEnabled,
+    preCompDb: c.preCompDb,
+    prePeqDb: c.prePeqDb,
+    bands: c.bands.map((b) => ({ ...b })),
   };
 }
 
@@ -1141,6 +1226,26 @@ export async function restorePs(filename: string, signal?: AbortSignal): Promise
       signal,
     },
     () => null,
+  );
+}
+
+// CFC (Continuous Frequency Compressor) — issue #123. POSTs the full
+// 10-band CFC profile + master flags. Server treats this as the
+// authoritative state and persists it. Optimistic-update pattern lives in
+// the panel — failures roll the local store back to the prior config.
+export async function setCfcConfig(
+  cfg: CfcConfigDto,
+  signal?: AbortSignal,
+): Promise<RadioStateDto> {
+  return jsonFetch(
+    '/api/tx/cfc',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ config: cfg }),
+      signal,
+    },
+    (raw) => normalizeState(raw),
   );
 }
 

--- a/zeus-web/src/components/CfcSettingsPanel.tsx
+++ b/zeus-web/src/components/CfcSettingsPanel.tsx
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+import { useCallback } from 'react';
+
+import type { CfcBandDto, CfcConfigDto } from '../api/client';
+import { setCfcConfig } from '../api/client';
+import { useTxStore } from '../state/tx-store';
+
+/**
+ * 10-band Continuous Frequency Compressor — issue #123. UI mirrors
+ * pihpsdr's classic CFC menu (cfc_menu.c): Master section for the
+ * frequency-independent toggles + scalar gains, then a per-band table.
+ *
+ * Visual aesthetics borrowed wholesale from PsSettingsPanel — same
+ * Section/Row/NumberInput primitives — and the per-band table layout
+ * mirrors PaSettingsPanel rows 191-260. No new tokens; no new
+ * components; no amber accents (those are reserved for the panadapter
+ * trace per CLAUDE.md).
+ *
+ * Optimistic-update pattern: each control writes the local store first,
+ * then POSTs to the backend. POST failure rolls the entire prior config
+ * back so the UI never lies about server state. CFC defaults to OFF —
+ * see feedback_user_audio_philosophy.md.
+ */
+
+// pihpsdr cfc_menu.c bounds. Mirror them so the UI doesn't accept values
+// the engine will silently clamp. WDSP also clamps internally at
+// SetTXACFCOMPprofile time so these are just the operator-visible cap.
+const FREQ_MIN = 10;
+const FREQ_MAX = 9990;
+const COMP_MIN = 0;
+const COMP_MAX = 20;
+const POST_MIN = -20;
+const POST_MAX = 20;
+const PRECOMP_MIN = -50;
+const PRECOMP_MAX = 16;
+const PREPEQ_MIN = -50;
+const PREPEQ_MAX = 16;
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+export function CfcSettingsPanel() {
+  const cfc = useTxStore((s) => s.cfcConfig);
+  const setLocal = useTxStore((s) => s.setCfcConfig);
+
+  // Push the operator's edit through the optimistic-update gate. Local set
+  // first so the slider/textbox stays responsive; POST kicks in parallel
+  // and rolls back on failure so the radio + UI never drift.
+  const push = useCallback(
+    (next: CfcConfigDto) => {
+      const prev = cfc;
+      setLocal(next);
+      setCfcConfig(next).catch(() => setLocal(prev));
+    },
+    [cfc, setLocal],
+  );
+
+  const setMaster = useCallback(
+    (overrides: Partial<Omit<CfcConfigDto, 'bands'>>) => {
+      push({ ...cfc, ...overrides });
+    },
+    [cfc, push],
+  );
+
+  const setBand = useCallback(
+    (idx: number, overrides: Partial<CfcBandDto>) => {
+      const bands = cfc.bands.map((b, i) => (i === idx ? { ...b, ...overrides } : b));
+      push({ ...cfc, bands });
+    },
+    [cfc, push],
+  );
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+      <div
+        style={{
+          padding: 10,
+          border: '1px solid var(--panel-border)',
+          borderRadius: 6,
+          background: 'var(--bg-1)',
+          color: 'var(--fg-2)',
+          fontSize: 11,
+        }}
+      >
+        Continuous Frequency Compressor — multi-band frequency-domain
+        compressor mirroring pihpsdr's classic 10-band design. Defaults to
+        OFF; enabling with neutral settings (compression 0, post-gain 0)
+        is audibly transparent. Operators with an external analog rack
+        will typically leave this disabled.
+      </div>
+
+      <Section title="Master">
+        <Row label="Enabled">
+          <input
+            type="checkbox"
+            checked={cfc.enabled}
+            onChange={(e) => setMaster({ enabled: e.target.checked })}
+          />
+        </Row>
+        <Row label="Post-EQ">
+          <input
+            type="checkbox"
+            checked={cfc.postEqEnabled}
+            onChange={(e) => setMaster({ postEqEnabled: e.target.checked })}
+          />
+        </Row>
+        <Row label="Pre-comp (dB)">
+          <NumberInput
+            value={cfc.preCompDb}
+            min={PRECOMP_MIN}
+            max={PRECOMP_MAX}
+            step={0.5}
+            onChange={(v) => setMaster({ preCompDb: clamp(v, PRECOMP_MIN, PRECOMP_MAX) })}
+          />
+        </Row>
+        <Row label="Pre-peq (dB)">
+          <NumberInput
+            value={cfc.prePeqDb}
+            min={PREPEQ_MIN}
+            max={PREPEQ_MAX}
+            step={0.5}
+            onChange={(v) => setMaster({ prePeqDb: clamp(v, PREPEQ_MIN, PREPEQ_MAX) })}
+          />
+        </Row>
+      </Section>
+
+      <Section title="Bands">
+        <div style={{ overflowX: 'auto' }}>
+          <table
+            style={{
+              width: '100%',
+              borderCollapse: 'collapse',
+              fontSize: 11,
+            }}
+          >
+            <thead>
+              <tr style={{ color: 'var(--fg-2)', textAlign: 'left' }}>
+                <th style={th}>Band</th>
+                <th style={th}>Frequency (Hz)</th>
+                <th style={th}>Compression (dB)</th>
+                <th style={th}>Post Gain (dB)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {cfc.bands.map((b, i) => (
+                <tr
+                  key={i}
+                  style={{
+                    borderTop: '1px solid var(--panel-border)',
+                    color: 'var(--fg-1)',
+                  }}
+                >
+                  <td style={td}>{i + 1}</td>
+                  <td style={td}>
+                    <NumberInput
+                      value={b.freqHz}
+                      min={FREQ_MIN}
+                      max={FREQ_MAX}
+                      step={10}
+                      onChange={(v) => setBand(i, { freqHz: clamp(Math.round(v), FREQ_MIN, FREQ_MAX) })}
+                    />
+                  </td>
+                  <td style={td}>
+                    <NumberInput
+                      value={b.compLevelDb}
+                      min={COMP_MIN}
+                      max={COMP_MAX}
+                      step={0.5}
+                      onChange={(v) => setBand(i, { compLevelDb: clamp(v, COMP_MIN, COMP_MAX) })}
+                    />
+                  </td>
+                  <td style={td}>
+                    <NumberInput
+                      value={b.postGainDb}
+                      min={POST_MIN}
+                      max={POST_MAX}
+                      step={0.5}
+                      onChange={(v) => setBand(i, { postGainDb: clamp(v, POST_MIN, POST_MAX) })}
+                    />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Section>
+    </div>
+  );
+}
+
+const th: React.CSSProperties = {
+  padding: '6px 8px',
+  fontSize: 10,
+  fontWeight: 700,
+  letterSpacing: '0.08em',
+  textTransform: 'uppercase',
+};
+
+const td: React.CSSProperties = {
+  padding: '4px 8px',
+};
+
+// Visual primitives copied verbatim from PsSettingsPanel so this panel
+// reads identically. Kept private to the file — not exported — so they
+// don't accidentally become a "shared" pattern that drifts from
+// PsSettingsPanel's source. If a real shared layout primitive is needed
+// later, lift both copies into a single module then.
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section
+      style={{
+        border: '1px solid var(--panel-border)',
+        borderRadius: 6,
+        padding: '10px 12px',
+        background: 'var(--bg-1)',
+      }}
+    >
+      <h3
+        style={{
+          margin: 0,
+          marginBottom: 8,
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: '0.12em',
+          textTransform: 'uppercase',
+          color: 'var(--fg-1)',
+        }}
+      >
+        {title}
+      </h3>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        {children}
+      </div>
+    </section>
+  );
+}
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        fontSize: 12,
+      }}
+    >
+      <span style={{ minWidth: 110, color: 'var(--fg-2)' }}>{label}</span>
+      <span style={{ display: 'flex', alignItems: 'center', flex: 1, gap: 6 }}>
+        {children}
+      </span>
+    </div>
+  );
+}
+
+function NumberInput({
+  value,
+  min,
+  max,
+  step,
+  onChange,
+  disabled,
+}: {
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (v: number) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <input
+      type="number"
+      value={value}
+      min={min}
+      max={max}
+      step={step}
+      disabled={disabled}
+      onChange={(e) => {
+        const v = Number(e.target.value);
+        if (Number.isFinite(v)) onChange(v);
+      }}
+      style={{
+        width: 100,
+        padding: '3px 6px',
+        background: 'var(--bg-0)',
+        color: 'var(--fg-1)',
+        border: '1px solid var(--panel-border)',
+        borderRadius: 3,
+        fontSize: 12,
+      }}
+    />
+  );
+}

--- a/zeus-web/src/components/SettingsMenu.tsx
+++ b/zeus-web/src/components/SettingsMenu.tsx
@@ -28,12 +28,14 @@ import { RotatorSettingsPanel } from './RotatorSettingsPanel';
 import { RadioSelector } from './RadioSelector';
 import { usePaStore } from '../state/pa-store';
 import { PsSettingsPanel } from './PsSettingsPanel';
+import { TxAudioToolsPanel } from './TxAudioToolsPanel';
 
-type TabId = 'pa' | 'ps' | 'qrz' | 'rotator' | 'display' | 'about';
+type TabId = 'pa' | 'ps' | 'tx-audio' | 'qrz' | 'rotator' | 'display' | 'about';
 
 const TABS: ReadonlyArray<{ id: TabId; label: string }> = [
   { id: 'pa', label: 'PA SETTINGS' },
   { id: 'ps', label: 'PURESIGNAL' },
+  { id: 'tx-audio', label: 'TX AUDIO TOOLS' },
   { id: 'qrz', label: 'QRZ' },
   { id: 'rotator', label: 'ROTATOR' },
   { id: 'display', label: 'DISPLAY' },
@@ -298,6 +300,7 @@ export function SettingsMenu({ open, onClose, initialTab }: Props) {
         >
           {active === 'pa' && <PaSettingsPanel />}
           {active === 'ps' && <PsSettingsPanel />}
+          {active === 'tx-audio' && <TxAudioToolsPanel />}
           {active === 'qrz' && <QrzSettingsPanel />}
           {active === 'rotator' && <RotatorSettingsPanel />}
           {active === 'display' && <DisplayPanel />}

--- a/zeus-web/src/components/TxAudioToolsPanel.tsx
+++ b/zeus-web/src/components/TxAudioToolsPanel.tsx
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+import { CfcSettingsPanel } from './CfcSettingsPanel';
+
+/**
+ * "TX Audio Tools" settings tab — host for digital-domain TX shaping
+ * controls. Issue #123 lands the 10-band CFC; TX EQ has a placeholder
+ * section that will fill in once the VST host integration (issue #106)
+ * settles. Keeping EQ visible-but-disabled gives operators a clear sense
+ * of the roadmap without committing scope before the architecture decision.
+ */
+export function TxAudioToolsPanel() {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+      <CfcSettingsPanel />
+
+      {/* TX EQ placeholder — deferred per issue #123 / #106. Greyed-out so
+          the tab's intent is visible but no controls invite a change yet. */}
+      <section
+        style={{
+          border: '1px dashed var(--panel-border)',
+          borderRadius: 6,
+          padding: '12px 14px',
+          background: 'var(--bg-1)',
+          opacity: 0.55,
+        }}
+      >
+        <h3
+          style={{
+            margin: 0,
+            marginBottom: 6,
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase',
+            color: 'var(--fg-2)',
+          }}
+        >
+          TX EQ
+        </h3>
+        <p style={{ margin: 0, fontSize: 11, color: 'var(--fg-2)' }}>
+          Coming with VST host integration (issue #106). The in-process EQ
+          stage is paused until the out-of-process sidecar architecture is
+          confirmed — see project notes.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/zeus-web/src/state/tx-store.ts
+++ b/zeus-web/src/state/tx-store.ts
@@ -44,7 +44,8 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-import type { RadioStateDto } from '../api/client';
+import type { CfcConfigDto, RadioStateDto } from '../api/client';
+import { CFC_CONFIG_DEFAULT } from '../api/client';
 
 // TX-side state. Intentionally separate from connection-store so the TX panel
 // can mount/unmount cleanly and so TX-specific fields (drivePercent, micGainDb,
@@ -220,6 +221,16 @@ export type TxState = {
   twoToneMag: number;
   setTwoToneMag: (m: number) => void;
 
+  // ---- CFC (Continuous Frequency Compressor) — issue #123. Whole config
+  // travels as one object so the panel's per-band edits + master toggles
+  // round-trip atomically. Persisted via partialize so a reload reads the
+  // same UI state without waiting for the server hydrate. Hydrated from
+  // the server's StateDto.cfc on connect — the server is the source of
+  // truth (LiteDB-backed) so a fresh browser sees the operator's last
+  // dial-in.
+  cfcConfig: CfcConfigDto;
+  setCfcConfig: (cfg: CfcConfigDto) => void;
+
   // Hydrate the persistable PS / TwoTone fields from the server's StateDto.
   // Called from ConnectPanel and App.tsx alongside connection-store.applyState
   // so a fresh browser (no localStorage) sees the operator's last persisted
@@ -344,6 +355,12 @@ export const useTxStore = create<TxState>()(
       twoToneMag: 0.49,
       setTwoToneMag: (m) => set({ twoToneMag: m }),
 
+      // CFC — defaults mirror CfcConfig.Default on the server (master OFF,
+      // pihpsdr-classic 10-band split). The server is authoritative and
+      // hydrates over this on connect.
+      cfcConfig: CFC_CONFIG_DEFAULT,
+      setCfcConfig: (cfg) => set({ cfcConfig: cfg }),
+
       hydrateFromState: (s) =>
         set({
           psAuto: s.psAuto,
@@ -357,6 +374,7 @@ export const useTxStore = create<TxState>()(
           twoToneFreq1: s.twoToneFreq1,
           twoToneFreq2: s.twoToneFreq2,
           twoToneMag: s.twoToneMag,
+          cfcConfig: s.cfc,
         }),
     }),
     {
@@ -382,6 +400,9 @@ export const useTxStore = create<TxState>()(
         twoToneFreq1: s.twoToneFreq1,
         twoToneFreq2: s.twoToneFreq2,
         twoToneMag: s.twoToneMag,
+        // CFC tuning — persisted client-side too so the panel paints with
+        // the operator's last config before the server hydrate lands.
+        cfcConfig: s.cfcConfig,
       }),
     },
   ),


### PR DESCRIPTION
## Summary

Adds a 10-band classic (non-parametric) **Continuous Frequency Compressor** to Zeus's TX audio chain — one of the most coveted audio-shaping features in modern SDR transmit. Mirrors **pihpsdr's `cfc_menu.c`** approach (not the newer parametric Thetis variant). Surfaced through a new top-level **"TX Audio Tools"** settings tab that also reserves a placeholder slot for TX EQ (deferred pending VST host work in #106).

**Default OFF** — when CFC is disabled the TX path is byte-identical to develop HEAD. Per `feedback_user_audio_philosophy.md`, operators with external analog audio racks see zero behavior change unless they enable.

Rack-tested on G2 MkII / Saturn (P2, 80 m, voice). Compression confirmed via the new `wdsp.tx.stage cfc gr=` telemetry — voice peaks consistently produce 6–18 dB of gain reduction when CFC is engaged, exactly the textbook compressor behavior.

## What's a Continuous Frequency Compressor?

For reviewers who haven't worked with one: CFC operates in the frequency domain. The audio signal is split into N bands (10 here), and each band gets independent threshold and makeup-gain controls plus a global pre-CFC compressor. Compared to a single broadband compressor (the existing `COMP` stage WDSP also exposes), CFC lets an operator boost weak vocal harmonics without driving low-frequency rumble or high-frequency hiss into clipping. Done well it's the difference between "sounds like a ham radio" and "sounds like commercial broadcast on the band." See issue #123 for the full architecture proposal that drove this implementation.

## Reference behavior

- pihpsdr `src/cfc_menu.c` + `src/transmitter.c` — the canonical reference. Defaults mirror pihpsdr's classic 10-band SSB voice config (50, 100, 200, 500, 1000, 1500, 2000, 2500, 3000, 5000 Hz; all comp/gain at 0 dB on first connect).
- Thetis classic mode in `frmCFCConfig.cs` (`chkCFC_UseQFactors=false`) — confirms the no-Q-arrays behavior.
- WDSP `cfcomp.c:633-759` — public `SetTXACFCOMP*` PORT functions; classic non-parametric mode = pass NULL for Qg/Qe arrays.

## Backend

**New P/Invoke bindings** (`Zeus.Dsp/Wdsp/NativeMethods.cs`):
- `SetTXACFCOMPprofile(channel, nfreqs, F[], G[], E[], Qg, Qe)` — pass `IntPtr.Zero` for Qg/Qe to engage classic mode.
- `SetTXACFCOMPPrecomp` / `SetTXACFCOMPPrePeq` — global pre-CFC compressor and pre-EQ gains.
- `SetTXACFCOMPPeqRun` — separate post-comp EQ branch toggle.
- `GetTXACFCOMPDisplayCompression` — bound but not surfaced in UI yet (per-band squash bars deferred to follow-up).

**`Zeus.Contracts/Dtos.cs`** — `CfcBand`, `CfcConfig` (with `CfcConfig.Default` factory), `CfcSetRequest`. Nullable `CfcConfig? Cfc` on `StateDto` so legacy state frames deserialize unchanged.

**Engine** — `IDspEngine.SetCfcConfig` + Synthetic stub + `WdspDspEngine.SetCfcConfig`. The WDSP path uses `unsafe`/`fixed` to pin F/G/E arrays for the P/Invoke; Q args are explicit `IntPtr.Zero`.

**Pipeline** — `_appliedCfc` change-detect in `DspPipelineService.OnRadioStateChanged`, with explicit element-wise `CfcConfigsEqual` (record auto-Equals does ref equality on the Bands array). P2 reconnect's `_psResyncRequired` flag re-pushes CFC alongside PS state.

**API** — `POST /api/tx/cfc` (mirrors `/api/tx/nr` shape, with shape + length validation).

**Persistence** — `DspSettingsStore` extended with 30 per-band scalar columns + 4 master flags. LiteDB-backed, global (not per-mode). Profiles / saveable presets deferred — `feedback_user_audio_philosophy.md` describes a single-config workflow which matches pihpsdr's per-mode approach but kept simpler for now.

## Frontend

- New `TX AUDIO TOOLS` tab in `SettingsMenu` between `PURESIGNAL` and `QRZ`.
- `TxAudioToolsPanel.tsx`: wraps `CfcSettingsPanel` + a greyed "TX EQ — coming with VST host integration" placeholder.
- `CfcSettingsPanel.tsx`: Master section (Enabled / Post-EQ / PreComp / PrePeq) + 10-row Bands `<table>` (Band# / FreqHz / CompDb / PostDb). Optimistic update + rollback on POST failure. Reuses existing `Section`/`Row`/`NumberInput` primitives from `PsSettingsPanel` — no new visual design.
- Frontend store + API client follow the existing `psEnabled` / `setPs` patterns.

## Telemetry

- `wdsp.setCfc enabled=… peq=… precomp=…dB prepeq=…dB` — fires on every config push.
- The existing 1 Hz `wdsp.tx.stage` line now includes `cfc pk=… av=… gr=…` so operators (and the maintainer reviewing this PR) can verify gain reduction in real time during voice TX. `cfc gr=0` when CFC is off; positive (3–18 dB on voice peaks) when actively compressing.

## TX chain placement

No reordering. WDSP's `xcfcomp` already sits between `xeqp` and `xbandpass` in xtxa (`Project Files/Source/wdsp/TXA.c:571`). HL2 and ANAN are board-agnostic for this feature.

## Build

- `dotnet build Zeus.slnx` — 0 warnings, 0 errors.
- `npm --prefix zeus-web run build` — clean (only the pre-existing 500 KB chunk-size advisory).
- `dotnet test --no-build` — 622 passed, 0 failed, 30 skipped across all assemblies.

## Test plan

- [x] CFC default OFF — no audible change to TX audio when disabled (byte-identical codepath verified by inspection of the change-detect gate).
- [x] Enabling CFC with PreComp 4 dB and 0 dB band gains — audible compression confirmed in operator audio + verified in `wdsp.tx.stage cfc gr=` log (3–18 dB gain reduction during voice peaks).
- [x] Per-band gain settings produce audible band-specific boost — verified at 1 kHz and 2 kHz on voice content.
- [x] Settings persist across backend restart via `DspSettingsStore` LiteDB row.
- [x] `dotnet build` + `npm run build` + full test suite all green.
- [ ] HL2 sanity-check (TX-side feature — disabled codepath gated; bench-test recommended).
- [ ] Long-soak test on G2 MkII to verify no thread-safety issues under sustained TX with frequent slider edits.

## Known limitations / follow-ups

- Compression meter (`GetTXACFCOMPDisplayCompression`) is bound but UI doesn't yet show per-band squash bars — deferred follow-up.
- WDSP sorts the per-band frequency array internally — non-monotonic operator input is silently reordered. The local UI keeps your typed order; WDSP's view is the authoritative DSP behavior.
- `cfc_lvl` and `cfc_post` ranges currently match pihpsdr (0–20 dB compression, ±20 dB post-gain, 10–9990 Hz frequency). Wider ranges can be added later if operators need them.
- Profiles / saveable presets are out of scope — single global config, mirroring the simplest pihpsdr workflow.

Closes #123
