### PR TITLE
fix(vfo): stop wheel-over-digit from scrolling parent pane (#127)

### DIFF
--- a/zeus-web/src/components/VfoDisplay.tsx
+++ b/zeus-web/src/components/VfoDisplay.tsx
@@ -108,6 +108,7 @@ export function VfoDisplay() {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState('');
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const digitsContainerRef = useRef<HTMLButtonElement | null>(null);
 
   const wheelTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const wheelPending = useRef<number | null>(null);
@@ -186,9 +187,25 @@ export function VfoDisplay() {
   // digit's decade. Wheel up = freq up. Updates local store immediately so
   // the display tracks the wheel, POSTs the final resting value after the
   // user stops scrolling.
-  const onDigitWheel = useCallback(
-    (e: React.WheelEvent<HTMLSpanElement>) => {
-      const decadeAttr = e.currentTarget.dataset.decade;
+  //
+  // Attached as a NATIVE listener via addEventListener with { passive: false }
+  // rather than a React `onWheel` JSX prop. React 17+ delegates wheel events
+  // through a root-level passive listener, which means `e.preventDefault()`
+  // inside a synthetic onWheel handler is silently ignored — letting the
+  // ancestor `.freq-panel` (overflow:auto, see layout/panels/VfoPanel.tsx) and
+  // any other scrollable parent perform their default scroll. Compare the
+  // canonical pattern at `util/use-pan-tune-gesture.ts:307` (panadapter zoom).
+  // Event-delegated on the digits container: wheel over a `[data-decade]`
+  // span is consumed; wheel over a separator or padding is left alone so the
+  // outer page can still scroll naturally.
+  useEffect(() => {
+    const el = digitsContainerRef.current;
+    if (!el || editing) return;
+    const handler = (e: WheelEvent) => {
+      const target = e.target as Element | null;
+      const digit = target?.closest<HTMLElement>('[data-decade]');
+      if (!digit || !el.contains(digit)) return;
+      const decadeAttr = digit.dataset.decade;
       if (!decadeAttr) return;
       const decade = Number.parseInt(decadeAttr, 10);
       if (!Number.isFinite(decade) || decade <= 0) return;
@@ -204,13 +221,13 @@ export function VfoDisplay() {
       if (wheelTimer.current != null) clearTimeout(wheelTimer.current);
       wheelTimer.current = setTimeout(() => {
         wheelTimer.current = null;
-        const target = wheelPending.current;
+        const pending = wheelPending.current;
         wheelPending.current = null;
-        if (target == null) return;
+        if (pending == null) return;
         wheelInflight.current?.abort();
         const ac = new AbortController();
         wheelInflight.current = ac;
-        setVfo(target, ac.signal)
+        setVfo(pending, ac.signal)
           .then((reply) => {
             if (ac.signal.aborted) return;
             applyState(reply);
@@ -221,9 +238,11 @@ export function VfoDisplay() {
             /* next state poll will reconcile */
           });
       }, WHEEL_DEBOUNCE_MS);
-    },
-    [applyState],
-  );
+    };
+    // passive:false so preventDefault() actually stops the ancestor scroll.
+    el.addEventListener('wheel', handler, { passive: false });
+    return () => el.removeEventListener('wheel', handler);
+  }, [applyState, editing]);
 
   const digits = useMemo(() => DIGIT_PLACES, []);
 
@@ -259,6 +278,7 @@ export function VfoDisplay() {
         </div>
       ) : (
         <button
+          ref={digitsContainerRef}
           type="button"
           onClick={beginEdit}
           aria-label="Edit frequency"
@@ -274,7 +294,6 @@ export function VfoDisplay() {
                 <span
                   className={`digit ${isLeading ? 'leading' : ''}`}
                   data-decade={place.decade}
-                  onWheel={onDigitWheel}
                   style={{ cursor: 'ns-resize' }}
                 >
                   {d}


### PR DESCRIPTION
## Summary

Fixes #127 — when the operator hovers over a VFO digit and rolls the wheel, the digit now changes **and only the digit changes**. Previously the entire right-hand pane scrolled along with the digit, because `e.preventDefault()` on a React `onWheel` synthetic handler was a no-op.

Rack-tested on `kb2uka/local` (integrated with PR #122 + PR #128) — VFO wheel behavior is fixed; PS Monitor + CFC UI both unaffected.

## Root cause

`zeus-web/src/components/VfoDisplay.tsx` attached its wheel handler as a React JSX `onWheel` prop. React 17+ delegates wheel events through a **root-level passive listener** — meaning `e.preventDefault()` inside the synthetic handler is silently ignored. The digit incremented (because the handler still ran) but the ancestor `.freq-panel` (overflow:auto, in `layout/panels/VfoPanel.tsx`) ALSO performed its default scroll. Two effects, same wheel event, exactly the symptom @Dfinitski reported.

## Fix

Replaced the React `onWheel` JSX prop with a native `addEventListener('wheel', handler, { passive: false })` registered via `useEffect` on the digits-container ref. Three deliberate design choices:

1. **`{ passive: false }`** — restores `preventDefault()`'s power to actually cancel the parent scroll.
2. **Event delegation via `closest('[data-decade]')`** — wheel that originates from a digit is consumed; wheel over a separator or padding falls through, so the outer page still scrolls naturally where the operator expects it to.
3. **`e.preventDefault()` placed AFTER the early-return guards** — only the digit case prevents default, never the surrounding region.

The pattern mirrors the canonical non-passive wheel handler at `zeus-web/src/util/use-pan-tune-gesture.ts:307` (panadapter zoom). The listener is also skipped while editing (the input field replaces the button), so wheel-while-editing behavior is unchanged.

## Why this is the right fix (not a guess)

- **`stopPropagation` would NOT have worked** — the parent scroll is the browser's default action, not a React-event-bubble layer. The synthetic event would still be passive; `preventDefault` would still no-op; the parent would still scroll.
- **CSS `overflow: hidden` on the parent would break legitimate scrolling** when the user's mouse is OUTSIDE the VFO digits.
- **Document-level wheel suppressors would break panadapter zoom** and any other deliberate wheel UI.

The passive-listener fix addresses the root cause and is scoped to exactly the digit container.

## Files changed

- `zeus-web/src/components/VfoDisplay.tsx` — +29 / −10. Replaced JSX `onWheel` with native listener via `useEffect`+`useRef`+`{ passive: false }`. Added `digitsContainerRef`. Skipped when `editing`.

## Test plan

- [x] Wheel over a VFO digit increments/decrements only that digit. Right pane does NOT scroll.
- [x] Wheel over a non-digit area inside the VFO panel (e.g. a separator) falls through to default scroll behavior — outer page still scrolls.
- [x] Wheel-while-editing (input mode) unchanged.
- [x] Panadapter zoom (separate `useEffect`-attached wheel handler) still works — confirmed by inspection that this fix is scoped to `VfoDisplay`.
- [x] Frontend build clean (`npm --prefix zeus-web run build`).
- [x] Verified in browser on integrated `kb2uka/local` build (develop + PR #122 + PR #128 + this fix).

## Risks

- Scoped change to one component. No other wheel handlers in the app are affected.
- Dependency array `[applyState, editing]` is correct: closures rebind when those change. Store reads use `getState()` so stale-closure on `vfoHz` is impossible.

Closes #127