### PR TITLE
fix(p2): remove global OcTune mask — OC during TUNE = OC during TX (#124)

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -318,12 +318,14 @@ public sealed record PaBandSettingsDto(
 // Globals shared across bands. PaMaxPowerWatts=0 disables the watts
 // conversion path and falls back to the legacy "drive% = raw 0-255 byte"
 // behavior so existing installs behave identically until the user runs
-// a calibration. OcTune is OR'd into the OC byte while TUN is engaged
-// (Thetis: OCtune in `Penny.cs`; piHPSDR: `OCtune<<1` in `old_protocol.c`).
+// a calibration. OC bits during TUN follow the per-band OcTx mask (same
+// as TX) — Thetis behaves this way and the inherited piHPSDR-style
+// "OcTune" override was removed in #124 for hardware-safety reasons (a
+// global override can hand an external amp a confused band-select state
+// during a steady tune carrier and damage finals).
 public sealed record PaGlobalSettingsDto(
     bool PaEnabled = true,
-    int PaMaxPowerWatts = 0,
-    byte OcTune = 0);
+    int PaMaxPowerWatts = 0);
 
 public sealed record PaSettingsDto(
     PaGlobalSettingsDto Global,

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -101,13 +101,13 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // PA settings — pushed from RadioService when PaSettingsStore changes or
     // the VFO crosses a band edge. _paEnabled is the global toggle that lands
     // in CmdGeneral[58]; _driveByte is the pre-calibrated drive level for
-    // CmdHighPriority[345]; _ocTxMask/_ocRxMask drive CmdHighPriority[1401]
-    // (OR'd with OCtune once that's plumbed).
+    // CmdHighPriority[345]; _ocTxMask/_ocRxMask drive CmdHighPriority[1401].
+    // The piHPSDR-style global "OCtune" override was removed in #124 for
+    // hardware-safety: OC during TUN follows OcTx, identical to TX.
     private bool _paEnabled = true;
     private byte _driveByte;
     private byte _ocTxMask;
     private byte _ocRxMask;
-    private byte _ocTuneMask;
     private bool _moxOn;
     private bool _tuneActive;
     private long _totalFrames;
@@ -303,12 +303,6 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         _ocTxMask = (byte)(txMask & 0x7F);
         _ocRxMask = (byte)(rxMask & 0x7F);
         if (_rxTask is not null) SendCmdHighPriority(run: true);
-    }
-
-    public void SetOcTuneMask(byte mask)
-    {
-        _ocTuneMask = (byte)(mask & 0x7F);
-        if (_rxTask is not null && _tuneActive) SendCmdHighPriority(run: true);
     }
 
     public void SetPaEnabled(bool enabled)
@@ -709,14 +703,14 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         // and TX is keyed elsewhere (byte 4 bit 1). piHPSDR `new_protocol.c:860`.
         p[345] = _driveByte;
 
-        // OC outputs (7-bit mask) shifted left by 1 into byte 1401. During
-        // TX the TX mask applies; during TUN we OR in the OCtune mask so
-        // anything wired to the tune pin (e.g. an external linear's tune-
-        // mode relay) closes. RX mask when keyed down. pihpsdr
-        // new_protocol.c:877-894.
-        byte ocBits = _moxOn
-            ? (byte)(_ocTxMask | (_tuneActive ? _ocTuneMask : (byte)0))
-            : _ocRxMask;
+        // OC outputs (7-bit mask) shifted left by 1 into byte 1401. The TX
+        // mask applies whenever MOX is on (whether keyed by the operator or
+        // by TUN) and the RX mask applies otherwise. The piHPSDR-style global
+        // "OCtune" override was removed in #124 for hardware-safety reasons:
+        // a global override layered on top of the per-band OC TX mask could
+        // hand an external amp a confused band-select state during a steady
+        // tune carrier and damage the finals. Thetis behaves this way too.
+        byte ocBits = _moxOn ? _ocTxMask : _ocRxMask;
         p[1401] = (byte)((ocBits & 0x7F) << 1);
 
         // Mercury attenuator byte: bit 0 = RX0 preamp, bit 1 = RX1 preamp

--- a/Zeus.Server/DspPipelineService.cs
+++ b/Zeus.Server/DspPipelineService.cs
@@ -748,7 +748,6 @@ public class DspPipelineService : BackgroundService
         if (p2 is null) return;
         p2.SetDriveByte(snap.DriveByte);
         p2.SetOcMasks(snap.OcTxMask, snap.OcRxMask);
-        p2.SetOcTuneMask(snap.OcTuneMask);
         p2.SetPaEnabled(snap.PaEnabled);
     }
 

--- a/Zeus.Server/PaSettingsStore.cs
+++ b/Zeus.Server/PaSettingsStore.cs
@@ -72,9 +72,8 @@ public sealed class PaSettingsStore : IDisposable
             var global = g is null
                 ? new PaGlobalSettingsDto(
                     PaEnabled: true,
-                    PaMaxPowerWatts: PaDefaults.GetMaxPowerWatts(board),
-                    OcTune: 0)
-                : new PaGlobalSettingsDto(g.PaEnabled, g.PaMaxPowerWatts, g.OcTune);
+                    PaMaxPowerWatts: PaDefaults.GetMaxPowerWatts(board))
+                : new PaGlobalSettingsDto(g.PaEnabled, g.PaMaxPowerWatts);
 
             var existing = _bands.FindAll().ToDictionary(e => e.Band, e => e);
             var bands = BandUtils.HfBands
@@ -101,8 +100,7 @@ public sealed class PaSettingsStore : IDisposable
     {
         var global = new PaGlobalSettingsDto(
             PaEnabled: true,
-            PaMaxPowerWatts: PaDefaults.GetMaxPowerWatts(board),
-            OcTune: 0);
+            PaMaxPowerWatts: PaDefaults.GetMaxPowerWatts(board));
         var bands = BandUtils.HfBands
             .Select(b => new PaBandSettingsDto(b, PaGainDb: PaDefaults.GetPaGainDb(board, b)))
             .ToArray();
@@ -128,9 +126,8 @@ public sealed class PaSettingsStore : IDisposable
             return g is null
                 ? new PaGlobalSettingsDto(
                     PaEnabled: true,
-                    PaMaxPowerWatts: PaDefaults.GetMaxPowerWatts(board),
-                    OcTune: 0)
-                : new PaGlobalSettingsDto(g.PaEnabled, g.PaMaxPowerWatts, g.OcTune);
+                    PaMaxPowerWatts: PaDefaults.GetMaxPowerWatts(board))
+                : new PaGlobalSettingsDto(g.PaEnabled, g.PaMaxPowerWatts);
         }
     }
 
@@ -142,7 +139,6 @@ public sealed class PaSettingsStore : IDisposable
             var g = existingGlobal ?? new PaGlobalEntry();
             g.PaEnabled = dto.Global.PaEnabled;
             g.PaMaxPowerWatts = Math.Max(0, dto.Global.PaMaxPowerWatts);
-            g.OcTune = dto.Global.OcTune;
             g.UpdatedUtc = DateTime.UtcNow;
             if (existingGlobal is null) _globals.Insert(g);
             else _globals.Update(g);
@@ -195,7 +191,6 @@ public sealed record PaRuntimeSnapshot(
     byte DriveByte,
     byte OcTxMask,
     byte OcRxMask,
-    byte OcTuneMask,
     bool PaEnabled);
 
 public sealed class PaBandEntry
@@ -214,6 +209,12 @@ public sealed class PaGlobalEntry
     public int Id { get; set; }
     public bool PaEnabled { get; set; } = true;
     public int PaMaxPowerWatts { get; set; }
-    public byte OcTune { get; set; }
+    // NOTE: legacy rows persisted before #124 may carry an `OcTune` column.
+    // LiteDB's BsonMapper silently ignores unknown fields when deserializing,
+    // so existing PaSettings rows survive a load → save roundtrip with the
+    // column dropped on the next write. The global "OC bits while Tune"
+    // override was removed for hardware-safety (issue #124): it could hand
+    // an external amp a confused band-select state during a steady tune
+    // carrier and damage the finals. OC during TUN now follows OcTx.
     public DateTime UpdatedUtc { get; set; }
 }

--- a/Zeus.Server/RadioService.cs
+++ b/Zeus.Server/RadioService.cs
@@ -714,7 +714,6 @@ public sealed class RadioService : IDisposable
             DriveByte: driveByte,
             OcTxMask: bandCfg.OcTx,
             OcRxMask: bandCfg.OcRx,
-            OcTuneMask: cfg.Global.OcTune,
             PaEnabled: paEnabled));
     }
 

--- a/docs/references/supported-settings.md
+++ b/docs/references/supported-settings.md
@@ -77,11 +77,11 @@ Zeus mapping: `Zeus.Protocol1/HpsdrEnums.cs` lines 65–73.
 |---|:---:|:---:|:---:|
 | Filter board style | N2ADR filter via 7 OC bits (`0x00[23:17]`) | Onboard ALEX filters + OC | Onboard ALEX filters + OC |
 | OC outputs per band | ✅ (`OcTx` / `OcRx` per band) | ✅ | ✅ |
-| OC on tune (`OcTune`) | ✅ | ✅ | ✅ |
+| OC on tune | identical to `OcTx` (no separate override) | identical to `OcTx` | identical to `OcTx` |
 | RX antenna select | ✅ (`0x00[13]`) | ✅ (ALEX RX ants 1–3) | ✅ |
 | Alex manual filter mode | ⚠️ not yet implemented (`0x09[22]`) | ✅ | ✅ |
 
-Zeus contracts: `Zeus.Contracts/Dtos.cs` lines ~192–197 (`OcTx`, `OcRx`, `OcTune`).
+Zeus contracts: `Zeus.Contracts/Dtos.cs` (`OcTx`, `OcRx`). The piHPSDR-style global `OcTune` override was removed in #124 for hardware-safety: OC during TUN follows the per-band `OcTx`, identical to TX.
 
 ---
 

--- a/zeus-web/src/api/pa.ts
+++ b/zeus-web/src/api/pa.ts
@@ -30,7 +30,6 @@ export type PaBandSettings = {
 export type PaGlobalSettings = {
   paEnabled: boolean;
   paMaxPowerWatts: number;
-  ocTune: number;
 };
 
 export type PaSettings = {
@@ -49,7 +48,6 @@ type PaBandDtoRaw = {
 type PaGlobalDtoRaw = {
   paEnabled?: unknown;
   paMaxPowerWatts?: unknown;
-  ocTune?: unknown;
 };
 
 type PaSettingsDtoRaw = {
@@ -69,7 +67,6 @@ function normalizeGlobal(raw: PaGlobalDtoRaw | undefined): PaGlobalSettings {
   return {
     paEnabled: toBool(raw?.paEnabled, true),
     paMaxPowerWatts: Math.max(0, Math.round(toNumber(raw?.paMaxPowerWatts, 0))),
-    ocTune: Math.max(0, Math.min(0x7f, Math.round(toNumber(raw?.ocTune, 0)))),
   };
 }
 

--- a/zeus-web/src/components/PaSettingsPanel.tsx
+++ b/zeus-web/src/components/PaSettingsPanel.tsx
@@ -139,7 +139,7 @@ export function PaSettingsPanel() {
             Reset to {resetTargetLabel}
           </button>
         </div>
-        <div className="grid grid-cols-1 gap-4 rounded bg-neutral-800/40 p-3 md:grid-cols-3">
+        <div className="grid grid-cols-1 gap-4 rounded bg-neutral-800/40 p-3 md:grid-cols-2">
           <label className="flex items-center gap-2 text-xs text-neutral-300">
             <input
               type="checkbox"
@@ -174,21 +174,6 @@ export function PaSettingsPanel() {
               </span>
             )}
           </label>
-
-          <div className="flex flex-col gap-1 text-xs text-neutral-300">
-            <span>OC bits while Tune</span>
-            <div className="flex gap-2">
-              {OC_PINS.map((bit) => (
-                <OcBitCheckbox
-                  key={bit}
-                  label="OC-Tune"
-                  bit={bit}
-                  mask={settings.global.ocTune}
-                  onToggle={(next) => setGlobal({ ocTune: next })}
-                />
-              ))}
-            </div>
-          </div>
         </div>
       </section>
 

--- a/zeus-web/src/state/pa-store.ts
+++ b/zeus-web/src/state/pa-store.ts
@@ -42,7 +42,7 @@ function defaultBand(band: string): PaBandSettings {
 
 function defaultState(): PaSettings {
   return {
-    global: { paEnabled: true, paMaxPowerWatts: 0, ocTune: 0 },
+    global: { paEnabled: true, paMaxPowerWatts: 0 },
     bands: HF_BANDS.map(defaultBand),
   };
 }
@@ -71,8 +71,8 @@ type PaStore = {
   setBand: (band: string, patch: Partial<Omit<PaBandSettings, 'band'>>) => void;
   // Overwrite per-band PaGainDb + global PaMaxPowerWatts with the requested
   // board's pure defaults. Does NOT persist — the operator still has to
-  // press APPLY. OC masks / Disable-PA / PaEnabled / OcTune are preserved
-  // because those are wiring preferences, not per-board data.
+  // press APPLY. OC masks / Disable-PA / PaEnabled are preserved because
+  // those are wiring preferences, not per-board data.
   resetToBoardDefaults: (boardOverride?: string) => Promise<void>;
 };
 


### PR DESCRIPTION
## Summary

Removes the global "OC bits while Tune" mask from PA Settings so the wire OC byte during TUNE is always equal to the per-band OC TX byte — closing a hardware-safety hole flagged by @Dfinitski in #124. Default OFF / unconfigured installations are unaffected; the only operators who notice a change are those who had set the global OcTune mask to non-zero (in which case the mask is dropped on next save and any OC pins that were firing only during TUNE stop firing).

## What was broken

`Zeus.Protocol2/Protocol2Client.cs` composed the OC byte during MOX as `_ocTxMask | (_tuneActive ? _ocTuneMask : 0)`. The `_ocTuneMask` came from a single global "OC bits while Tune" toggle in the PA Settings panel — a feature inherited from pihpsdr's `OCtune`, not present in Thetis. The hazard: an operator who set the global OcTune mask to a bit overlapping their per-band band-select wiring would see EXTRA OC pins fire during TUNE that did not fire during TX, driving a confused band-select state at an external amp while a steady tune carrier hit it. Damaged finals are a real risk.

## Fix

OC during TUNE now equals OC during TX, period:
```csharp
byte ocBits = _moxOn ? _ocTxMask : _ocRxMask;
```

Per-band OC TX / OC RX masks are untouched — those are legitimate features and the operator's right to configure. Only the global "OC bits while Tune" override is removed.

## Files changed (9 files, +35 / −58)

**Backend:**
- `Zeus.Contracts/Dtos.cs` — drop `OcTune` from `PaGlobalSettingsDto`. Comment notes the safety rationale.
- `Zeus.Server/PaSettingsStore.cs` — drop `OcTune` from DTO construction sites and `PaGlobalEntry` LiteDB row class. NOTE comment explains the silent-migration: LiteDB ignores unknown columns on deserialize, so legacy rows with an OcTune value load fine and lose the field on next Save.
- `Zeus.Server/RadioService.cs` — drop `OcTuneMask` from `PaRuntimeSnapshot`.
- `Zeus.Server/DspPipelineService.cs` — drop `p2.SetOcTuneMask(snap.OcTuneMask)` call.
- `Zeus.Protocol2/Protocol2Client.cs` — drop `_ocTuneMask` field and `SetOcTuneMask()` method. Simplify OC byte composition.
- `Zeus.Protocol1` — already correct (no OcTune handling). Untouched.

**Frontend:**
- `zeus-web/src/api/pa.ts` — drop `ocTune` from `PaGlobalSettings` + raw DTO + `normalizeGlobal`.
- `zeus-web/src/state/pa-store.ts` — drop `ocTune: 0` from default state.
- `zeus-web/src/components/PaSettingsPanel.tsx` — remove the "OC bits while Tune" `<div>`, switch the global panel grid from `md:grid-cols-3` → `md:grid-cols-2` so PA Enabled + Rated PA Output sit cleanly. Per-band OC TX / OC RX columns untouched.

**Docs:**
- `docs/references/supported-settings.md` — replace OC-on-tune ✅/✅/✅ row with one noting the removal.

## Migration

LiteDB silently ignores unknown columns on deserialize — that's the documented and observed behaviour. Legacy `zeus-prefs.db` rows with an `OcTune` column load fine, the field drops on next `Save`, and `PaEnabled` / `PaMaxPowerWatts` / per-band `PaGainDb` / `OcTx` / `OcRx` / `DisablePa` are preserved. Rack-tested locally on `kb2uka/local` with the full integrated stack (PR #122 + PR #128 + this fix); panel renders cleanly, per-band gains and OC masks survive.

## Test plan

- [x] `dotnet build Zeus.slnx` clean.
- [x] `npm --prefix zeus-web run build` clean.
- [x] `dotnet test --no-build` — 622 passed, 0 failed, 30 skipped across all 5 test projects.
- [x] Rack-tested on G2 MkII (P2): PA Settings panel renders without the OC-on-tune section, per-band OC TX bits assert correctly during MOX, same bits assert during TUNE on the same band — no extra OC pins firing during tune.
- [ ] Manual rack test recommended on a `zeus-prefs.db` populated by an earlier Zeus version that had a non-zero `OcTune` row (operator who had used the option). Confirm panel comes up clean, per-band PA gains and OC TX/OC RX masks intact, APPLY round-trips without error.
- [ ] HL2 sanity-check (P1 path is byte-identical to pre-PR — `ControlFrame.cs:187` already does the right thing — but bench confirmation appreciated).

## Design note for @brianbruff

This is a deliberate divergence from pihpsdr (which keeps OCtune as a feature) toward the Thetis baseline (which never exposed it). Operator-error-leads-to-PA-damage is the kind of footgun that's worth dropping by default. If a future operator demands OcTune-style behaviour back, it can return as a per-band field rather than a global override that silently overlays.

Closes #124
