### PR TITLE
fix(p2): wire step-att and preamp through to Protocol2Client (#126)

### DIFF
--- a/Zeus.Server/DspPipelineService.cs
+++ b/Zeus.Server/DspPipelineService.cs
@@ -139,6 +139,16 @@ public class DspPipelineService : BackgroundService
     // new WdspDspEngine instance picks up the operator's persisted config.
     private CfcConfig _appliedCfc = CfcConfig.Default;
 
+    // RX front-end (step attenuator + Mercury preamp). Mirrored to a live
+    // Protocol2Client when the value moves; on P1 these go through
+    // RadioService.ActiveClient directly. Issue #126 — without this
+    // forwarding the S-ATT slider and PRE button were inert on Angelia /
+    // ANAN-100D. Effective atten = StateDto.AttenDb + AttOffsetDb (auto-ATT
+    // offset), so the existing overload control loop continues to drive the
+    // radio on P2. Sentinel -1 forces the first push regardless of value.
+    private int _appliedEffectiveAttDb = -1;
+    private bool _appliedPreampOn;
+
     private uint _seq;
     private uint _audioSeq;
     // Latched from MoxChanged so Tick can route the panadapter to the TX
@@ -170,6 +180,7 @@ public class DspPipelineService : BackgroundService
         _radio.PaSnapshotChanged += OnPaSnapshotChanged;
         _radio.MoxChanged += OnRadioMoxChanged;
         _radio.TunActiveChanged += OnRadioTunActiveChanged;
+        _radio.PreampChanged += OnRadioPreampChanged;
 
         var panBuf = new float[Width];
         var wfBuf = new float[Width];
@@ -192,6 +203,7 @@ public class DspPipelineService : BackgroundService
             _radio.PaSnapshotChanged -= OnPaSnapshotChanged;
             _radio.MoxChanged -= OnRadioMoxChanged;
             _radio.TunActiveChanged -= OnRadioTunActiveChanged;
+            _radio.PreampChanged -= OnRadioPreampChanged;
             await StopIqPumpAsync().ConfigureAwait(false);
             CloseCurrentEngine();
         }
@@ -468,6 +480,24 @@ public class DspPipelineService : BackgroundService
             _appliedCfc = cfc;
         }
 
+        // ---- RX step attenuator (operator + auto-ATT offset) -----------
+        // Issue #126. Mirror RadioService's effective-atten composition
+        // (operator baseline AttenDb + auto-ATT overload offset AttOffsetDb,
+        // clamped 0..31) onto a live Protocol2Client. RadioService already
+        // pushes the same value to the P1 client directly via
+        // ActiveClient?.SetAttenuator on every operator change AND every
+        // auto-ATT tick — but on a P2 connection ActiveClient is null, so
+        // without this forward the S-ATT slider and the auto-ATT overload
+        // ramp both fail silently on Angelia / ANAN-100D. RadioService
+        // raises StateChanged whenever AttOffsetDb moves, so the auto-ATT
+        // control loop reaches the wire through this block too.
+        int effectiveAttDb = Math.Clamp(s.AttenDb + s.AttOffsetDb, 0, 31);
+        if (resync || effectiveAttDb != _appliedEffectiveAttDb)
+        {
+            _p2Client?.SetAttenuator(effectiveAttDb);
+            _appliedEffectiveAttDb = effectiveAttDb;
+        }
+
         // PS-Monitor (issue #121) — pure UI source routing. No engine call,
         // no wire write; Tick reads _psMonitorEnabled and prefers the
         // PS-feedback analyzer when on + PS armed + correcting. Latched
@@ -670,6 +700,18 @@ public class DspPipelineService : BackgroundService
             _loggerFactory.CreateLogger<Zeus.Protocol2.Protocol2Client>());
         client.SetNumAdc(numAdc);
         await client.ConnectAsync(radioEndpoint, ct).ConfigureAwait(false);
+        // Seed the operator's RX front-end (preamp + step attenuator) BEFORE
+        // StartAsync so the very first CmdHighPriority emitted inside the
+        // start sequence carries the correct values. SetPreamp/SetAttenuator
+        // pre-StartAsync only stash into private fields (the early-return on
+        // _rxTask==null path), so no wire packets fly here — they ride the
+        // CmdHighPriority(run=1) inside StartAsync below. Without this seed
+        // a P2 reconnect would leave the radio at preamp=off / atten=0
+        // until the operator nudged either control. Issue #126.
+        bool initialPreamp = _radio.PreampOn;
+        int initialAttDb = _radio.EffectiveAttenDb;
+        client.SetPreamp(initialPreamp);
+        client.SetAttenuator(initialAttDb);
         await client.StartAsync(sampleRateKhz, ct).ConfigureAwait(false);
 
         int rateHz = sampleRateKhz * 1000;
@@ -720,6 +762,27 @@ public class DspPipelineService : BackgroundService
         _log.LogInformation("dsp.pipeline p2 engine={Engine} rate={Rate}", newEngine.GetType().Name, rateHz);
 
         _p2Client = client;
+        // Sync the change-detect cache with the values we just seeded so the
+        // first OnRadioStateChanged after connect doesn't redundantly re-push
+        // (which would emit a duplicate CmdHighPriority). Re-read in case the
+        // operator changed either control during the connect window — the
+        // PreampChanged / StateChanged handlers would have early-returned on
+        // _p2Client==null. Comparing here recovers any drift before the cache
+        // settles.
+        _appliedPreampOn = initialPreamp;
+        _appliedEffectiveAttDb = initialAttDb;
+        bool nowPreamp = _radio.PreampOn;
+        int nowAttDb = _radio.EffectiveAttenDb;
+        if (nowPreamp != initialPreamp)
+        {
+            client.SetPreamp(nowPreamp);
+            _appliedPreampOn = nowPreamp;
+        }
+        if (nowAttDb != initialAttDb)
+        {
+            client.SetAttenuator(nowAttDb);
+            _appliedEffectiveAttDb = nowAttDb;
+        }
         StartIqPumpP2(client);
         StartPsFeedbackPumpP2(client);
         // Force the next OnRadioStateChanged to re-push every PS field into
@@ -761,6 +824,19 @@ public class DspPipelineService : BackgroundService
     private void OnRadioTunActiveChanged(bool on)
     {
         _p2Client?.SetTune(on);
+    }
+
+    // Mirror operator preamp toggles into a live Protocol2Client. P1 is
+    // pushed by RadioService.SetPreamp directly via ActiveClient. PreampOn
+    // isn't on the StateDto wire format, so this event-driven path is the
+    // only way the bit reaches CmdHighPriority byte 1403 on P2 (issue #126).
+    private void OnRadioPreampChanged(bool on)
+    {
+        var p2 = _p2Client;
+        if (p2 is null) return;
+        if (on == _appliedPreampOn) return;
+        p2.SetPreamp(on);
+        _appliedPreampOn = on;
     }
 
     /// <summary>

--- a/Zeus.Server/RadioService.cs
+++ b/Zeus.Server/RadioService.cs
@@ -128,6 +128,13 @@ public sealed class RadioService : IDisposable
     // its own CmdHighPriority byte 4.
     public event Action<bool>? MoxChanged;
     public event Action<bool>? TunActiveChanged;
+    // Fires when the operator toggles the Mercury preamp. P1 path is pushed
+    // directly via ActiveClient?.SetPreamp inside SetPreamp; this event lets
+    // DspPipelineService mirror the same change into a live Protocol2Client
+    // (CmdHighPriority byte 1403, bit 0 = RX0 preamp). Issue #126 — the P2
+    // forwarding is the missing link that left the PRE button non-functional
+    // on Angelia / ANAN-100D.
+    public event Action<bool>? PreampChanged;
 
     // Shared TX IQ source threaded through Protocol1Client. TxAudioIngest
     // writes into the same instance; this is the seam between "mic arrived
@@ -261,6 +268,29 @@ public sealed class RadioService : IDisposable
     }
 
     public StateDto Snapshot() { lock (_sync) return _state; }
+
+    /// <summary>Current operator preamp toggle. PreampOn isn't on the
+    /// StateDto wire format, so DspPipelineService reads it directly when
+    /// it needs to push the value into a freshly-opened Protocol2Client
+    /// (issue #126). Lock-safe so a connect-time read can't tear against
+    /// a concurrent SetPreamp.</summary>
+    public bool PreampOn { get { lock (_sync) return _preampOn; } }
+
+    /// <summary>Effective RX step attenuator in dB — operator baseline
+    /// (<see cref="StateDto.AttenDb"/>) plus any auto-ATT overload offset
+    /// (<see cref="StateDto.AttOffsetDb"/>), clamped to 0..31. This is the
+    /// value that lands on the wire (CmdHighPriority byte 1443 on P2;
+    /// CC0=0x14 on P1). Exposed for DspPipelineService.ConnectP2Async so a
+    /// fresh P2 client is initialised with the operator's current effective
+    /// atten before its first CmdHighPriority emission.</summary>
+    public int EffectiveAttenDb
+    {
+        get
+        {
+            lock (_sync)
+                return Math.Clamp(_atten.ClampedDb + _attOffsetDb, HpsdrAtten.MinDb, HpsdrAtten.MaxDb);
+        }
+    }
 
     public async Task<StateDto> ConnectAsync(string endpoint, int sampleRate, CancellationToken ct = default)
     {
@@ -573,8 +603,13 @@ public sealed class RadioService : IDisposable
 
     public StateDto SetPreamp(bool on)
     {
-        _preampOn = on;
+        lock (_sync) _preampOn = on;
+        // P1 path: Protocol1Client owns the bit; SetPreamp pushes the
+        // updated CcState on the next outgoing frame. ActiveClient is
+        // null on a P2 connection, so the PreampChanged event below is
+        // what carries the bit into Protocol2Client (issue #126).
         ActiveClient?.SetPreamp(on);
+        PreampChanged?.Invoke(on);
         return Snapshot();
     }
 

--- a/zeus-web/src/components/AttenuatorSlider.tsx
+++ b/zeus-web/src/components/AttenuatorSlider.tsx
@@ -123,7 +123,12 @@ export function AttenuatorSlider() {
         }
         className={`btn sm ${autoEnabled ? 'active' : ''} ${overload ? 'overload' : ''}`}
       >
-        {autoEnabled ? 'A-ATT' : 'S-ATT'}
+        {/* Issue #126 — Dfinitski / HPSDR convention: this control is the
+            Step Attenuator (S-ATT). The button toggles the auto-att overlay
+            on top of it; "active" CSS class conveys that auto state without
+            renaming the control itself. Previously read "A-ATT" while auto
+            was on, which was non-standard nomenclature. */}
+        S-ATT
       </button>
       <input
         type="range"


### PR DESCRIPTION
## Summary

Wire the Step Attenuator (S-ATT) slider and the PRE preamp button through to `Protocol2Client` so they actually affect the radio on a P2 connection. Closes #126 reported by @Dfinitski on ANAN-100D / Angelia.

Rack-tested on `kb2uka/local` integrated with the rest of the in-flight stack — S-ATT slider verified working (signal level changes as expected with slider movement). Preamp follows the identical wiring pattern; same change-detect block forwards both.

## What was broken

The wire-side methods on `Protocol2Client` (`SetAttenuator(byte)` writing to byte 1443, `SetPreamp(bool)` writing bit 0 of byte 1403) already existed and were correct per Thetis canon. The chain broke one layer up: `RadioService.SetAttenuator(...)` and `SetPreamp(...)` only call `ActiveClient`, which is the **Protocol 1** client. On a P2 connection `ActiveClient` is null, so the call was a silent no-op. `DspPipelineService.OnRadioStateChanged` was forwarding PS / NR / CFC / VFO / zoom / drive / PA snapshot / mic gain to the P2 client, but did not forward step-att or preamp.

## Fix

Mirror the existing change-detect pattern in `DspPipelineService.OnRadioStateChanged` for both controls. **Effective step-att = operator baseline (`s.AttenDb`) + auto-ATT overload offset (`s.AttOffsetDb`), clamped to 0–31 dB.** The composition matches the Thetis pattern that `Zeus.Protocol1/ControlFrame.cs:142` already uses at wire time on P1, so the existing ADC-overload control loop continues to ramp attenuation on P2 the same way it does on P1.

Plus a UI relabel: the manual step-att slider was labeled "A-ATT", which is misleading — HPSDR convention reserves "A" for auto-att and "S" for step-att. @Dfinitski flagged the naming nit in his original report. Renamed to "S-ATT".

## Files changed (3 files, +118 / −2)

- `Zeus.Server/RadioService.cs` — expose public `EffectiveAttenDb` property that composes `_atten.ClampedDb + _attOffsetDb` (clamped 0–31 dB). Used both by the P1 path (already) and the new P2 forwarding.
- `Zeus.Server/DspPipelineService.cs` — add `_appliedEffectiveAttDb` (sentinel -1 forces first push) and `_appliedPreampOn` change-detect fields. Forward step-att via `_p2Client?.SetAttenuator(effectiveAttDb)` and preamp via `_p2Client?.SetPreamp(on)` on every state-change tick AND every auto-ATT overload-event tick. Resync-aware (P2 reconnect re-pushes both via the same `_psResyncRequired` flag).
- `zeus-web/src/components/AttenuatorSlider.tsx` — relabel `A-ATT` → `S-ATT` with a comment explaining the HPSDR-convention rename. Underlying button behaviour (toggling the auto-att overlay) is unchanged; only the label shifted.

## Reference behavior

- **Thetis** (canonical for non-MkII boards): `Project Files/Source/ChannelMaster/network.c:1037-1057` writes byte 1443 = ADC0 step-att, byte 1442 = ADC1 step-att, byte 1403 bits 0/1 for per-receiver preamp. No board-specific routing.
- **pihpsdr** (`src/new_protocol.c:1385-1409`): same step-att layout. Disagrees with Thetis on Angelia preamp — pihpsdr disables `have_preamp` for Angelia in `src/radio.c:1344-1350` (treats it as non-switchable in hardware). Per Zeus's Thetis-canonical-for-non-MkII rule we mirror Thetis on the preamp here.
- **DeskHPSDR**: matches pihpsdr (no divergence).

## No protocol byte changes

The existing byte writes in `Protocol2Client.cs` are correct per Thetis. The only fix is upstream — getting the operator's value to those byte writes.

## What's NOT touched

- P1 path: `Zeus.Protocol1/ControlFrame.cs` already composes the effective attenuator at wire time. Untouched.
- Auto-ATT control loop: continues to drive `_attOffsetDb` based on ADC overload events. The new forwarding picks that up via `EffectiveAttenDb`.
- TX-side step-att (Patch B context, byte 58/59 in CmdTx): completely separate code path. Untouched. PS auto-attenuate continues to work as before.

## Test plan

- [x] `dotnet build Zeus.slnx` clean.
- [x] `npm --prefix zeus-web run build` clean.
- [x] `dotnet test --no-build` — all assemblies green.
- [x] Rack-tested S-ATT on G2 MkII / P2: slider movement changes received signal level.
- [ ] Rack-test PRE button on G2 MkII / Angelia. Same wiring path as step-att; expected to work.
- [ ] HL2 / P1 sanity check (path is byte-identical to pre-PR — `ControlFrame.cs` writes effective atten the same way it always did — but bench confirmation appreciated).

## Design note for @brianbruff

This PR explicitly mirrors **Thetis** on the Angelia preamp question (per-RX bit in byte 1403, switchable) rather than pihpsdr (which disables `have_preamp` on Angelia). Per the project's Thetis-canonical-for-non-MkII rule. Worth a sanity check against your bench ANAN class radios.

Closes #126
