### PR TITLE
feat(tci): Phase 3 — RX IQ binary streaming + priority queues

### DIFF
--- a/Zeus.Server/DspPipelineService.cs
+++ b/Zeus.Server/DspPipelineService.cs
@@ -70,6 +70,14 @@ public class DspPipelineService : BackgroundService
     /// </summary>
     public event Action<int, double>? RxMeterUpdated;
 
+    /// <summary>
+    /// Raised on every decoded RX IQ frame, after it has been fed to WDSP.
+    /// Arguments: (receiver, sampleRateHz, interleavedIQ).
+    /// The memory references a pooled buffer and is only valid for the
+    /// duration of the synchronous handler — copy if retention is needed.
+    /// </summary>
+    public event Action<int, int, ReadOnlyMemory<double>>? RxIqAvailable;
+
     private readonly object _engineLock = new();
     private IDspEngine? _engine;
     private int _channelId;
@@ -498,6 +506,7 @@ public class DspPipelineService : BackgroundService
                     int channel;
                     lock (_engineLock) { engine = _engine; channel = _channelId; }
                     engine?.FeedIq(channel, frame.InterleavedSamples.Span);
+                    RxIqAvailable?.Invoke(0, frame.SampleRateHz, frame.InterleavedSamples);
                 }
             }
             catch (OperationCanceledException) { }
@@ -523,6 +532,7 @@ public class DspPipelineService : BackgroundService
                     int channel;
                     lock (_engineLock) { engine = _engine; channel = _channelId; }
                     engine?.FeedIq(channel, frame.InterleavedSamples.Span);
+                    RxIqAvailable?.Invoke(0, frame.SampleRateHz, frame.InterleavedSamples);
                 }
             }
             catch (OperationCanceledException) { }

--- a/Zeus.Server/Tci/TciServer.cs
+++ b/Zeus.Server/Tci/TciServer.cs
@@ -106,6 +106,7 @@ public sealed class TciServer : IHostedService, IDisposable
         _radio.Connected += OnRadioConnected;
         _radio.Disconnected += OnRadioDisconnected;
         _pipeline.RxMeterUpdated += OnRxMeterUpdated;
+        _pipeline.RxIqAvailable += OnRxIqAvailable;
         _txMeters.TxMetersUpdated += OnTxMetersUpdated;
         _subscribed = true;
 
@@ -121,6 +122,7 @@ public sealed class TciServer : IHostedService, IDisposable
             _radio.Connected -= OnRadioConnected;
             _radio.Disconnected -= OnRadioDisconnected;
             _pipeline.RxMeterUpdated -= OnRxMeterUpdated;
+            _pipeline.RxIqAvailable -= OnRxIqAvailable;
             _txMeters.TxMetersUpdated -= OnTxMetersUpdated;
             _subscribed = false;
         }
@@ -218,6 +220,29 @@ public sealed class TciServer : IHostedService, IDisposable
         // TCI rx_smeter event: rx_smeter:<rx>,<chan>,<dbm>
         // Rate-limited to avoid flooding during rapid meter updates
         BroadcastRateLimited($"rx_smeter:0,{channelId}", TciProtocol.Command("rx_smeter", 0, channelId, (int)Math.Round(dbm)));
+    }
+
+    private void OnRxIqAvailable(int receiver, int sampleRateHz, ReadOnlyMemory<double> interleavedIQ)
+    {
+        // The pooled IQ buffer is only valid for the duration of this call.
+        // Build the binary frame synchronously (which copies samples into a
+        // freshly allocated byte[]) so the enqueued payload outlives the buffer.
+        if (_clients.IsEmpty) return;
+
+        // Cheap pre-flight: skip the allocate+copy if no client wants this RX.
+        bool anyWants = false;
+        foreach (var session in _clients.Values)
+        {
+            if (session.WantsIqStream(receiver)) { anyWants = true; break; }
+        }
+        if (!anyWants) return;
+
+        var payload = TciStreamPayload.BuildIqFromDoubles(receiver, sampleRateHz, interleavedIQ.Span);
+        foreach (var session in _clients.Values)
+        {
+            if (session.WantsIqStream(receiver))
+                session.SendBinary(payload);
+        }
     }
 
     private void OnTxMetersUpdated(float fwdWatts, float refWatts, float swr, float alcPk, float alcGr)

--- a/Zeus.Server/Tci/TciSession.cs
+++ b/Zeus.Server/Tci/TciSession.cs
@@ -42,21 +42,25 @@
 // License for details.
 
 using System.Buffers;
+using System.Collections.Concurrent;
 using System.Net.WebSockets;
 using System.Text;
-using System.Threading.Channels;
 using Zeus.Contracts;
 
 namespace Zeus.Server.Tci;
 
 /// <summary>
 /// Per-client TCI session. Manages WebSocket send/receive loops, command
-/// parsing, event broadcasting, and rate limiting. Mirrors the StreamingHub
-/// pattern: parallel send + receive tasks, bounded channel with drop-oldest.
+/// parsing, event broadcasting, and rate limiting.
+///
+/// Outbound architecture mirrors Thetis TCIServer: three priority queues
+/// (Urgent / Binary / Control) drained by a single send loop in priority
+/// order. Queues are unbounded — backpressure is provided implicitly by
+/// the underlying socket send window; on a write exception, the session
+/// is torn down.
 /// </summary>
 public sealed class TciSession : IDisposable
 {
-    private const int MaxBacklogPerClient = 16;
     private const int MaxInboundTextBytes = 8 * 1024;
     private const int MaxInboundBinaryBytes = 2 * 1024 * 1024; // 2 MB for future binary frames
 
@@ -70,13 +74,10 @@ public sealed class TciSession : IDisposable
     private readonly TciOptions _options;
     private readonly TciRateLimiter _rateLimiter;
 
-    private readonly Channel<string> _sendQueue = Channel.CreateBounded<string>(
-        new BoundedChannelOptions(MaxBacklogPerClient)
-        {
-            FullMode = BoundedChannelFullMode.DropOldest,
-            SingleReader = true,
-            SingleWriter = false,
-        });
+    private readonly ConcurrentQueue<TciOutboundFrame> _urgentQueue = new();
+    private readonly ConcurrentQueue<TciOutboundFrame> _binaryQueue = new();
+    private readonly ConcurrentQueue<TciOutboundFrame> _controlQueue = new();
+    private readonly SemaphoreSlim _outboundSignal = new(0);
 
     // Track current drive level so we can echo it back on query
     private int _lastDrivePercent = 50;
@@ -109,15 +110,16 @@ public sealed class TciSession : IDisposable
     /// </summary>
     public async Task RunAsync(CancellationToken ct)
     {
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         try
         {
             // Send handshake immediately after WS upgrade
-            await SendHandshakeAsync(ct);
+            await SendHandshakeAsync(linkedCts.Token);
 
-            var sendTask = SendLoopAsync(ct);
-            var recvTask = ReceiveLoopAsync(ct);
+            var sendTask = SendLoopAsync(linkedCts.Token);
+            var recvTask = ReceiveLoopAsync(linkedCts.Token);
             await Task.WhenAny(sendTask, recvTask);
-            _sendQueue.Writer.TryComplete();
+            linkedCts.Cancel();
             try { await Task.WhenAll(sendTask, recvTask); } catch { /* drained */ }
         }
         finally
@@ -127,11 +129,30 @@ public sealed class TciSession : IDisposable
     }
 
     /// <summary>
-    /// Enqueue a TCI command for immediate send (bypass rate limiter).
+    /// Enqueue a TCI text command at Control priority (commands, query echoes,
+    /// state-change events). Bypasses the rate limiter.
     /// </summary>
     public void Send(string commandLine)
     {
-        _sendQueue.Writer.TryWrite(commandLine);
+        Enqueue(new TciOutboundFrame(commandLine), TciOutboundPriority.Control);
+    }
+
+    /// <summary>
+    /// Enqueue a TCI text command at Urgent priority (ping/pong, close, errors).
+    /// </summary>
+    public void SendUrgent(string commandLine)
+    {
+        Enqueue(new TciOutboundFrame(commandLine), TciOutboundPriority.Urgent);
+    }
+
+    /// <summary>
+    /// Enqueue a binary frame (IQ / RX-audio / TX-chrono stream payload) at
+    /// Binary priority. Frame bytes are sent verbatim as a WebSocket binary
+    /// message — the caller is responsible for the TCI 64-byte stream header.
+    /// </summary>
+    public void SendBinary(byte[] payload)
+    {
+        Enqueue(new TciOutboundFrame(payload), TciOutboundPriority.Binary);
     }
 
     /// <summary>
@@ -140,6 +161,23 @@ public sealed class TciSession : IDisposable
     public void SendRateLimited(string key, string commandLine)
     {
         _rateLimiter.Enqueue(key, commandLine);
+    }
+
+    private void Enqueue(TciOutboundFrame frame, TciOutboundPriority priority)
+    {
+        switch (priority)
+        {
+            case TciOutboundPriority.Urgent:
+                _urgentQueue.Enqueue(frame);
+                break;
+            case TciOutboundPriority.Binary:
+                _binaryQueue.Enqueue(frame);
+                break;
+            default:
+                _controlQueue.Enqueue(frame);
+                break;
+        }
+        _outboundSignal.Release();
     }
 
     private async Task SendHandshakeAsync(CancellationToken ct)
@@ -157,21 +195,55 @@ public sealed class TciSession : IDisposable
         _log.LogInformation("tci.handshake sent client={Id}", _id);
     }
 
+    /// <summary>
+    /// Single send loop draining Urgent → Binary → Control queues in priority
+    /// order. On any send failure the loop exits, the linked CTS cancels the
+    /// receive loop, and the session tears down (matches Thetis abortSocketTransport).
+    /// </summary>
     private async Task SendLoopAsync(CancellationToken ct)
     {
         try
         {
-            await foreach (var line in _sendQueue.Reader.ReadAllAsync(ct))
+            while (!ct.IsCancellationRequested && _ws.State == WebSocketState.Open)
             {
-                if (_ws.State != WebSocketState.Open) break;
-                var bytes = Encoding.ASCII.GetBytes(line);
-                await _ws.SendAsync(bytes, WebSocketMessageType.Text, true, ct);
+                await _outboundSignal.WaitAsync(ct);
+                if (TryDequeueNext(out var frame))
+                {
+                    await SendFrameAsync(frame, ct);
+                }
             }
         }
         catch (OperationCanceledException) { }
         catch (WebSocketException ex)
         {
             _log.LogDebug(ex, "tci send loop ended client={Id}", _id);
+        }
+        catch (Exception ex)
+        {
+            _log.LogDebug(ex, "tci send loop write failed client={Id}", _id);
+        }
+    }
+
+    private bool TryDequeueNext(out TciOutboundFrame frame)
+    {
+        if (_urgentQueue.TryDequeue(out frame)) return true;
+        if (_binaryQueue.TryDequeue(out frame)) return true;
+        if (_controlQueue.TryDequeue(out frame)) return true;
+        frame = default;
+        return false;
+    }
+
+    private async Task SendFrameAsync(TciOutboundFrame frame, CancellationToken ct)
+    {
+        if (_ws.State != WebSocketState.Open) return;
+        if (frame.IsBinary)
+        {
+            await _ws.SendAsync(frame.Bytes!, WebSocketMessageType.Binary, true, ct);
+        }
+        else
+        {
+            var bytes = Encoding.ASCII.GetBytes(frame.Text!);
+            await _ws.SendAsync(bytes, WebSocketMessageType.Text, true, ct);
         }
     }
 
@@ -760,5 +832,33 @@ public sealed class TciSession : IDisposable
     public void Dispose()
     {
         _rateLimiter.Dispose();
+        _outboundSignal.Dispose();
+    }
+}
+
+internal enum TciOutboundPriority
+{
+    Urgent,
+    Binary,
+    Control,
+}
+
+internal readonly struct TciOutboundFrame
+{
+    public readonly string? Text;
+    public readonly byte[]? Bytes;
+
+    public bool IsBinary => Bytes is not null;
+
+    public TciOutboundFrame(string text)
+    {
+        Text = text;
+        Bytes = null;
+    }
+
+    public TciOutboundFrame(byte[] bytes)
+    {
+        Text = null;
+        Bytes = bytes;
     }
 }

--- a/Zeus.Server/Tci/TciSession.cs
+++ b/Zeus.Server/Tci/TciSession.cs
@@ -82,7 +82,31 @@ public sealed class TciSession : IDisposable
     // Track current drive level so we can echo it back on query
     private int _lastDrivePercent = 50;
 
+    // Per-session binary stream subscriptions. Producers (TciServer publish
+    // path) check WantsIqStream(rx) before building/dispatching frames.
+    private readonly object _streamLock = new();
+    private readonly HashSet<int> _iqStreamEnabled = new();
+    private int _iqSampleRate = 48000;
+
     public Guid Id => _id;
+
+    /// <summary>True if this session has subscribed to IQ for the given receiver.</summary>
+    public bool WantsIqStream(int receiver)
+    {
+        lock (_streamLock) return _iqStreamEnabled.Contains(receiver);
+    }
+
+    /// <summary>True if this session has subscribed to IQ for any receiver.</summary>
+    public bool WantsAnyIqStream()
+    {
+        lock (_streamLock) return _iqStreamEnabled.Count > 0;
+    }
+
+    /// <summary>Last client-requested IQ sample rate, clamped to [48000, 384000].</summary>
+    public int IqSampleRate
+    {
+        get { lock (_streamLock) return _iqSampleRate; }
+    }
 
     public TciSession(
         Guid id,
@@ -460,11 +484,19 @@ public sealed class TciSession : IDisposable
                     HandleSpotClear(args);
                     break;
 
-                // --- Binary streams (future) ---
+                // --- Binary streams ---
                 case "iq_start":
+                    HandleIqStart(args);
+                    break;
                 case "iq_stop":
+                    HandleIqStop(args);
+                    break;
+                case "iq_samplerate":
+                    HandleIqSampleRate(args);
+                    break;
                 case "audio_start":
                 case "audio_stop":
+                case "audio_samplerate":
                     _log.LogDebug("tci command not implemented: {Cmd}", command);
                     break;
 
@@ -827,6 +859,54 @@ public sealed class TciSession : IDisposable
     {
         // spot_clear
         _spots.ClearAll();
+    }
+
+    private void HandleIqStart(string[] args)
+    {
+        // iq_start:<rx>,<bool>  — start (true) or stop (false) per-receiver IQ stream
+        if (args.Length < 1) return;
+        if (!TciProtocol.TryParseInt(args[0], out int rx)) return;
+        bool enable = true;
+        if (args.Length >= 2 && TciProtocol.TryParseBool(args[1], out bool parsed))
+            enable = parsed;
+        SetIqStream(rx, enable);
+    }
+
+    private void HandleIqStop(string[] args)
+    {
+        // iq_stop:<rx>  — alias of iq_start:<rx>,false
+        if (args.Length < 1) return;
+        if (!TciProtocol.TryParseInt(args[0], out int rx)) return;
+        SetIqStream(rx, false);
+    }
+
+    private void HandleIqSampleRate(string[] args)
+    {
+        // iq_samplerate:<rate>  or  iq_samplerate (query)
+        // Range matches Thetis: [48000, 384000]. Stored on the session; the
+        // actual rate of published frames is the radio's native rate, echoed
+        // back to the client when streaming starts.
+        if (args.Length == 0)
+        {
+            Send(TciProtocol.Command("iq_samplerate", IqSampleRate));
+            return;
+        }
+        if (TciProtocol.TryParseInt(args[0], out int rate))
+        {
+            rate = Math.Clamp(rate, 48000, 384000);
+            lock (_streamLock) _iqSampleRate = rate;
+            Send(TciProtocol.Command("iq_samplerate", rate));
+        }
+    }
+
+    private void SetIqStream(int rx, bool enable)
+    {
+        lock (_streamLock)
+        {
+            if (enable) _iqStreamEnabled.Add(rx);
+            else _iqStreamEnabled.Remove(rx);
+        }
+        Send(TciProtocol.Command("iq_start", rx, enable));
     }
 
     public void Dispose()

--- a/Zeus.Server/Tci/TciStreamPayload.cs
+++ b/Zeus.Server/Tci/TciStreamPayload.cs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Distributed under the GNU General Public License v2 or later. See the
+// LICENSE file at the root of this repository for full text.
+
+using System.Buffers.Binary;
+using System.Runtime.InteropServices;
+
+namespace Zeus.Server.Tci;
+
+/// <summary>
+/// TCI binary stream type tag — matches Thetis TCIServer.TCIStreamType
+/// (Project Files/Source/Console/TCIServer.cs:341) so on-the-wire bytes
+/// are identical for ExpertSDR3-compatible clients.
+/// </summary>
+internal enum TciStreamType : uint
+{
+    IqStream = 0,
+    RxAudioStream = 1,
+    TxAudioStream = 2,
+    TxChrono = 3,
+    LineOutStream = 4,
+}
+
+/// <summary>
+/// TCI sample-encoding tag — matches Thetis TCIServer.TCISampleType.
+/// </summary>
+internal enum TciSampleType : uint
+{
+    Int16 = 0,
+    Int24 = 1,
+    Int32 = 2,
+    Float32 = 3,
+}
+
+/// <summary>
+/// Builds the 64-byte fixed TCI binary stream header used for IQ, RX audio,
+/// TX audio, and TX_CHRONO frames. Layout is byte-for-byte identical to
+/// Thetis TCIServer.buildStreamPayload (TCIServer.cs:5645).
+///
+/// Layout (all little-endian uint32):
+///   [ 0]: receiver index
+///   [ 4]: sample rate (Hz)
+///   [ 8]: sample type   — see <see cref="TciSampleType"/>
+///   [12]: reserved 0
+///   [16]: reserved 0
+///   [20]: length        — count of float values for FLOAT32 IQ
+///                         (= complex_samples * 2 for I+Q interleaved)
+///   [24]: stream type   — see <see cref="TciStreamType"/>
+///   [28]: channels      — 2 for IQ (I,Q interleaved)
+///   [32..63]: 8 reserved zero uint32
+///   [64..]: sample payload bytes
+/// </summary>
+internal static class TciStreamPayload
+{
+    public const int HeaderSize = 64;
+
+    public static byte[] Build(
+        int receiver,
+        int sampleRate,
+        TciSampleType sampleType,
+        int length,
+        TciStreamType streamType,
+        int channels,
+        ReadOnlySpan<byte> samplePayload)
+    {
+        var payload = new byte[HeaderSize + samplePayload.Length];
+        BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(0), (uint)receiver);
+        BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(4), (uint)sampleRate);
+        BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(8), (uint)sampleType);
+        // [12], [16] reserved zero (cleared by `new byte[]`)
+        BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(20), (uint)length);
+        BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(24), (uint)streamType);
+        BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(28), (uint)channels);
+        // [32..60] reserved zero
+        if (samplePayload.Length > 0)
+            samplePayload.CopyTo(payload.AsSpan(HeaderSize));
+        return payload;
+    }
+
+    /// <summary>
+    /// Builds an IQ frame from interleaved doubles (Zeus's internal format).
+    /// Samples are downcast to FLOAT32 because that's the TCI canonical IQ
+    /// encoding — clients negotiate FLOAT32 and Thetis publishes FLOAT32.
+    /// </summary>
+    public static byte[] BuildIqFromDoubles(int receiver, int sampleRate, ReadOnlySpan<double> interleavedIQ)
+    {
+        // Convert double → float into a temporary buffer, then build the frame.
+        // Allocating a fresh float[] here is fine; the frame allocation already
+        // dominates and we'd have to copy anyway to land on FLOAT32 LE bytes.
+        var floats = new float[interleavedIQ.Length];
+        for (int i = 0; i < interleavedIQ.Length; i++)
+            floats[i] = (float)interleavedIQ[i];
+        return Build(
+            receiver,
+            sampleRate,
+            TciSampleType.Float32,
+            length: floats.Length,
+            streamType: TciStreamType.IqStream,
+            channels: 2,
+            samplePayload: MemoryMarshal.AsBytes(floats.AsSpan()));
+    }
+}

--- a/docs/tci.md
+++ b/docs/tci.md
@@ -105,6 +105,30 @@ The following commands are accepted by the dispatcher but currently no-op (logge
 
 **Note:** Spots are stored but not rendered on the panadapter in this release.
 
+### Binary Streams (Phase 3)
+
+- `iq_start:<rx>,<bool>` — Subscribe (true) / unsubscribe (false) to RX IQ binary stream for the given receiver
+- `iq_stop:<rx>` — Alias for `iq_start:<rx>,false`
+- `iq_samplerate:<hz>` — Set/query requested IQ sample rate (clamped to 48000–384000)
+
+The actual rate of published frames is the radio's native IQ sample rate (set via the protocol layer); the server echoes the clamped requested rate so the client knows what it will receive. Streams emit WebSocket binary frames with the 64-byte TCI header described below.
+
+#### Binary frame layout (64-byte header + samples)
+
+All header fields are little-endian uint32. Layout matches Thetis `buildStreamPayload`:
+
+| Offset | Field | IQ value |
+|---|---|---|
+| 0..3 | receiver index | `0` |
+| 4..7 | sample rate (Hz) | radio native (48k/96k/192k/384k) |
+| 8..11 | sample type | `3` = FLOAT32 |
+| 12..19 | reserved | 0 |
+| 20..23 | length | float-value count = `complex_samples * 2` |
+| 24..27 | stream type | `0` = IQ_STREAM |
+| 28..31 | channels | `2` (I, Q interleaved) |
+| 32..63 | reserved | 0 |
+| 64.. | payload | FLOAT32 little-endian, interleaved I, Q, I, Q, … |
+
 ## Events (Server → Client)
 
 The server broadcasts these events to all connected clients when radio state changes:
@@ -176,10 +200,12 @@ tx_enable:0,true;
 - ✅ TX-meter event broadcasts (power, SWR, ALC)
 - 🟡 CW message / keyer commands (ack-only stubs; functional impl deferred pending CW engine)
 
-**Phase 3 — Binary Streams**
-- IQ streaming (`iq_start`, `iq_stop`, `iq_samplerate`)
-- Audio streaming (`audio_start`, `audio_stop`, `audio_samplerate`)
-- Backpressure handling
+**Phase 3 — Binary Streams** 🟡 (Partially Complete)
+- ✅ IQ streaming (`iq_start`, `iq_stop`, `iq_samplerate`) — single receiver, FLOAT32, native radio rate
+- ✅ Outbound priority queues (Urgent / Binary / Control) mirroring Thetis architecture
+- ⏸️ Audio streaming (`audio_start`, `audio_stop`, `audio_samplerate`)
+- ⏸️ Multi-receiver IQ when Zeus gains Diversity / dual-RX support
+- ⏸️ Conformance test against a real third-party client (Log4OM / SMP)
 
 **Phase 4 — Polish**
 - Noise reduction commands (NB, NR, ANF, ANC)

--- a/tests/Zeus.Server.Tests/Tci/TciStreamPayloadTests.cs
+++ b/tests/Zeus.Server.Tests/Tci/TciStreamPayloadTests.cs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Distributed under the GNU General Public License v2 or later. See the
+// LICENSE file at the root of this repository for full text.
+
+using System.Buffers.Binary;
+using Zeus.Server.Tci;
+
+namespace Zeus.Server.Tests.Tci;
+
+/// <summary>
+/// Wire-compatibility tests for the 64-byte TCI binary stream header.
+/// Layout must match Thetis TCIServer.buildStreamPayload byte-for-byte —
+/// any drift here breaks ExpertSDR3 clients.
+/// </summary>
+public class TciStreamPayloadTests
+{
+    [Fact]
+    public void Build_HeaderSize_IsSixtyFourBytes()
+    {
+        var frame = TciStreamPayload.Build(
+            receiver: 0, sampleRate: 48000, sampleType: TciSampleType.Float32,
+            length: 0, streamType: TciStreamType.IqStream, channels: 2,
+            samplePayload: ReadOnlySpan<byte>.Empty);
+
+        Assert.Equal(TciStreamPayload.HeaderSize, frame.Length);
+        Assert.Equal(64, frame.Length);
+    }
+
+    [Fact]
+    public void Build_HeaderFields_LittleEndianAtCorrectOffsets()
+    {
+        var frame = TciStreamPayload.Build(
+            receiver: 1, sampleRate: 192_000, sampleType: TciSampleType.Float32,
+            length: 1024, streamType: TciStreamType.IqStream, channels: 2,
+            samplePayload: ReadOnlySpan<byte>.Empty);
+
+        Assert.Equal(1u, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(0)));
+        Assert.Equal(192_000u, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(4)));
+        Assert.Equal((uint)TciSampleType.Float32, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(8)));
+        Assert.Equal(1024u, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(20)));
+        Assert.Equal((uint)TciStreamType.IqStream, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(24)));
+        Assert.Equal(2u, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(28)));
+    }
+
+    [Fact]
+    public void Build_ReservedFields_AreZero()
+    {
+        var frame = TciStreamPayload.Build(
+            receiver: 0, sampleRate: 48000, sampleType: TciSampleType.Float32,
+            length: 0, streamType: TciStreamType.IqStream, channels: 2,
+            samplePayload: ReadOnlySpan<byte>.Empty);
+
+        // Two reserved uint32 between sampleType and length (offsets 12, 16)
+        Assert.Equal(0u, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(12)));
+        Assert.Equal(0u, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(16)));
+        // Eight reserved uint32 from offset 32..63
+        for (int offset = 32; offset < 64; offset += 4)
+            Assert.Equal(0u, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(offset)));
+    }
+
+    [Fact]
+    public void Build_AppendsPayloadAfterHeader()
+    {
+        ReadOnlySpan<byte> payload = stackalloc byte[] { 0xDE, 0xAD, 0xBE, 0xEF };
+        var frame = TciStreamPayload.Build(
+            receiver: 0, sampleRate: 48000, sampleType: TciSampleType.Float32,
+            length: 4, streamType: TciStreamType.IqStream, channels: 2,
+            samplePayload: payload);
+
+        Assert.Equal(64 + 4, frame.Length);
+        Assert.Equal(0xDE, frame[64]);
+        Assert.Equal(0xAD, frame[65]);
+        Assert.Equal(0xBE, frame[66]);
+        Assert.Equal(0xEF, frame[67]);
+    }
+
+    [Fact]
+    public void BuildIqFromDoubles_HeaderTypedAsFloat32IqWithTwoChannels()
+    {
+        ReadOnlySpan<double> samples = stackalloc double[] { 1.0, -1.0, 0.5, -0.5 };
+        var frame = TciStreamPayload.BuildIqFromDoubles(0, 48000, samples);
+
+        Assert.Equal((uint)TciSampleType.Float32, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(8)));
+        Assert.Equal((uint)TciStreamType.IqStream, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(24)));
+        Assert.Equal(2u, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(28)));
+        // length is the count of float values, equal to samples.Length for IQ
+        Assert.Equal((uint)samples.Length, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(20)));
+    }
+
+    [Fact]
+    public void BuildIqFromDoubles_DowncastsSamplesToFloat32LittleEndian()
+    {
+        ReadOnlySpan<double> samples = stackalloc double[] { 1.0, -1.0, 0.5, -0.5 };
+        var frame = TciStreamPayload.BuildIqFromDoubles(0, 48000, samples);
+
+        // Each input double becomes one little-endian FLOAT32 (4 bytes) starting at offset 64.
+        Assert.Equal(64 + samples.Length * 4, frame.Length);
+        for (int i = 0; i < samples.Length; i++)
+        {
+            float expected = (float)samples[i];
+            float actual = BitConverter.ToSingle(frame, 64 + i * 4);
+            Assert.Equal(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Two commits implementing the IQ portion of TCI Phase 3 (issue #109):

**1. `refactor(tci): replace bounded channel with three priority queues`**
Mirrors Thetis `TCIServer` outbound architecture: per-session Urgent / Binary / Control queues drained by a single send loop in priority order. Replaces the previous `Channel<string>` + `MaxBacklogPerClient=16` + `DropOldest` policy that would silently corrupt continuous binary streams. Backpressure is implicit (socket send window); on a write exception the linked CTS cancels the receive loop and the session tears down — same effect as Thetis `abortSocketTransport`.

**2. `feat(tci): publish RX IQ as binary stream (Phase 3)`**
- `iq_start:<rx>,<bool>` / `iq_stop:<rx>` / `iq_samplerate:<hz>` handlers
- New `TciStreamPayload` builds the 64-byte header byte-for-byte against Thetis `buildStreamPayload` (TCIServer.cs:5645). FLOAT32 LE I/Q interleaved.
- `DspPipelineService.RxIqAvailable` event raised from both P1 and P2 IQ pumps after `FeedIq`. Receiver hardcoded to `0` (single-RX).
- `TciServer.OnRxIqAvailable` pre-flights for any subscriber, builds the byte[] once, dispatches via `SendBinary` on each interested session.

## Known gaps left for follow-up (issue #109 stays open)
- Hardcoded `receiver=0` (multi-RX needs Diversity / dual-RX support upstream first).
- `iq_samplerate` is stored but published frames use the radio's native rate — server echoes the clamped value back so clients know what they'll actually receive. A real resampler is a separate task.
- Audio streams (`audio_start` / `audio_stop` / `audio_samplerate`) still stubbed — priority-queue plumbing is in place, the RX-audio publish path is not.
- End-to-end conformance test against a real TCI client (Log4OM panadapter / SMP) needs bench time.

> Earlier commit messages on this branch reference `#108` in error — the umbrella TCI issue is `#109`. Code itself is unaffected.

## Test plan
- [ ] `dotnet build Zeus.slnx` — confirmed 0 warnings, 0 errors
- [ ] `dotnet test --filter Tci` — 99/99 pass (5 pre-existing skips); +6 new `TciStreamPayloadTests` covering 64-byte header layout, reserved zeros, payload append, and double→FLOAT32 downcast
- [ ] **Bench** — connect a TCI-capable client (Log4OM panadapter or SMP) to `ws://127.0.0.1:40001`, send `iq_start:0,true;`, verify it renders Zeus's spectrum without disconnect or audible artifacts. **Maintainer.**

## Out of scope
- Spot rendering on the panadapter (Phase 4, visual-design red-light per CLAUDE.md)
- NB / NR / ANF / ANC commands (Phase 4)
- REST status endpoint (Phase 4)

Refs #109 (does **not** close — see remaining bullets above).