### PR TITLE
fix(band-memory): self-heal duplicate rows; race-tolerate Upsert

### DIFF
--- a/Zeus.Server/BandMemoryStore.cs
+++ b/Zeus.Server/BandMemoryStore.cs
@@ -70,9 +70,38 @@ public sealed class BandMemoryStore : IDisposable
 
         _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
         _entries = _db.GetCollection<BandMemoryEntry>("band_memory");
+        // Pre-existing rows can violate the unique-Band invariant if they were
+        // written by a build before EnsureIndex(unique:true) was added, or by a
+        // race in Upsert before the index existed. Build will fail with
+        // "duplicate key" and every subsequent request 500s on construction —
+        // self-heal by collapsing duplicates (newest UpdatedUtc wins) before
+        // asking LiteDB to enforce uniqueness.
+        DedupeByBand();
         _entries.EnsureIndex(x => x.Band, unique: true);
 
         _log.LogInformation("BandMemoryStore initialized at {Path}", dbPath);
+    }
+
+    private void DedupeByBand()
+    {
+        var dupGroups = _entries.FindAll()
+            .GroupBy(e => e.Band, StringComparer.Ordinal)
+            .Where(g => g.Count() > 1)
+            .ToList();
+        foreach (var g in dupGroups)
+        {
+            var keeper = g.OrderByDescending(e => e.UpdatedUtc).First();
+            var removed = 0;
+            foreach (var dup in g)
+            {
+                if (dup.Id == keeper.Id) continue;
+                _entries.Delete(dup.Id);
+                removed++;
+            }
+            _log.LogWarning(
+                "BandMemoryStore: collapsed {Removed} duplicate row(s) for band {Band}; kept Id={KeptId} (UpdatedUtc={Updated:o})",
+                removed, g.Key, keeper.Id, keeper.UpdatedUtc);
+        }
     }
 
     public IReadOnlyList<BandMemoryDto> GetAll()
@@ -94,21 +123,32 @@ public sealed class BandMemoryStore : IDisposable
         var existing = _entries.FindOne(x => x.Band == band);
         if (existing is null)
         {
-            _entries.Insert(new BandMemoryEntry
+            // Concurrent PUTs for the same band (debounced batches, StrictMode
+            // double-effects) can both observe FindOne == null and race into
+            // Insert; the unique-Band index then trips one of them. Catch the
+            // collision and fall through to the update path with a re-fetch.
+            try
             {
-                Band = band,
-                Hz = hz,
-                Mode = mode,
-                UpdatedUtc = DateTime.UtcNow,
-            });
+                _entries.Insert(new BandMemoryEntry
+                {
+                    Band = band,
+                    Hz = hz,
+                    Mode = mode,
+                    UpdatedUtc = DateTime.UtcNow,
+                });
+                return;
+            }
+            catch (LiteException ex) when (ex.ErrorCode == LiteException.INDEX_DUPLICATE_KEY)
+            {
+                existing = _entries.FindOne(x => x.Band == band);
+                if (existing is null) throw;
+            }
         }
-        else
-        {
-            existing.Hz = hz;
-            existing.Mode = mode;
-            existing.UpdatedUtc = DateTime.UtcNow;
-            _entries.Update(existing);
-        }
+
+        existing.Hz = hz;
+        existing.Mode = mode;
+        existing.UpdatedUtc = DateTime.UtcNow;
+        _entries.Update(existing);
     }
 
     public void Dispose() => _db.Dispose();


### PR DESCRIPTION
## Summary
- `BandMemoryStore` constructor was crashing on `EnsureIndex(x => x.Band, unique: true)` when the LiteDB `band_memory` collection contained duplicate-`Band` rows left over from a pre-unique-index build. Because the store is registered as a singleton, every `/api/bands/memory` request retried construction and 500'd — band buttons were unusable in the UI.
- A second, latent race in `Upsert` (concurrent PUTs both observing `FindOne == null` and racing into `Insert`) was the most likely way those duplicates appeared in the first place, and it kept producing fresh `INDEX_DUPLICATE_KEY` errors after a restart whenever the frontend reconnect storm fired multiple PUTs for the same band.

## Fix
- Added `DedupeByBand()` that runs before `EnsureIndex` and collapses any duplicate-`Band` rows, keeping the row with the newest `UpdatedUtc`. Logs a warning so a recurrence is visible. A dirty `zeus-prefs.db` now self-heals on next startup instead of bricking band-memory endpoints.
- `Upsert` now catches `LiteException.INDEX_DUPLICATE_KEY` on `Insert`, re-fetches, and falls through to the update path. This is the same pattern already used in `FilterPresetStore.cs:265`.

## Reproduction (before)
```
PUT /api/bands/memory/20m
HTTP/1.1 500 Internal Server Error
LiteDB.LiteException: Cannot insert duplicate key in unique index 'Band'. The duplicate value is '"15m"'.
   at LiteDB.LiteCollection.EnsureIndex[K](Expression keySelector, Boolean unique)
   at Zeus.Server.BandMemoryStore..ctor(...) BandMemoryStore.cs:73
```

After the fix, the same DB starts cleanly with one warning:
```
warn: Zeus.Server.BandMemoryStore[0]
      BandMemoryStore: collapsed 1 duplicate row(s) for band 15m; kept Id=1 (...)
```

## Test plan
- [x] `dotnet test Zeus.slnx` — 637 passed, 30 skipped, 0 failed
- [x] Locally reproduced the 500 against the existing dirty `zeus-prefs.db`, applied the fix, restarted, and got 200 OK on `PUT /api/bands/memory/20m`
- [x] Race-tested `Upsert` with 8 concurrent PUTs for an unwritten band (`40m`): all returned 200, single row in `GET /api/bands/memory`
- [ ] Click through the band buttons in the UI and confirm no `/api/bands/memory/*` 500s in the browser console