### PR TITLE
fix(connect): default P2 to 192 kHz, respect dropdown selection (#145)

### DIFF
--- a/zeus-web/src/components/ConnectPanel.tsx
+++ b/zeus-web/src/components/ConnectPanel.tsx
@@ -206,7 +206,10 @@ export function ConnectPanel() {
       setError(null);
       try {
         if (isP2) {
-          await apiConnectP2({ endpoint: ep, sampleRate: 48_000 });
+          // P2 auto-discover defaults to 192 kHz (parity with P1) so the panadapter
+          // at zoom=1 shows ~192 kHz of spectrum — wide enough for any HF band.
+          // Operator can still pick another rate via the manual-connect dropdown.
+          await apiConnectP2({ endpoint: ep, sampleRate: DEFAULT_SAMPLE_RATE });
           const fresh = await fetchState();
           applyState(fresh);
           hydrateTxFromState(fresh);
@@ -238,7 +241,7 @@ export function ConnectPanel() {
       const port = override?.port ?? manualPort;
       const protocol: ProtocolChoice = override?.protocol ?? manualProtocol;
       const sampleRate: SampleRate = (override?.sampleRate as SampleRate | undefined)
-        ?? (protocol === 'P2' ? 48_000 : manualSampleRate);
+        ?? manualSampleRate;
       const label = override?.label;
 
       if (!IPV4_RE.test(ip)) {
@@ -255,7 +258,7 @@ export function ConnectPanel() {
       setManualError(null);
       try {
         if (protocol === 'P2') {
-          await apiConnectP2({ endpoint: ep, sampleRate: 48_000 });
+          await apiConnectP2({ endpoint: ep, sampleRate });
           const fresh = await fetchState();
           applyState(fresh);
           hydrateTxFromState(fresh);


### PR DESCRIPTION
## Summary

Phase 1 of the P2 sample-rate work tracked in #145. Stops hardcoding 48 kHz at every P2 connect site in `ConnectPanel.tsx`. Default is now 192 kHz (parity with P1) and the existing combo box on the manual-connect form actually does something.

Rack-tested on `kb2uka/local` (integrated stack): auto-discover P2 → 192 kHz, panadapter at zoom=1 shows ~192 kHz of span — comfortably fits an HF band. Reporter's complaint about not being able to zoom out wide enough is resolved.

## What was broken

`zeus-web/src/components/ConnectPanel.tsx` had three hardcoded `sampleRate: 48_000` literals:
- Line 209 — auto-discover P2 click handler.
- Line 241 — manual-connect sampleRate computation, with a `protocol === 'P2' ? 48_000 : manualSampleRate` ternary that forced 48 kHz on P2 and respected the dropdown only on P1.
- Line 258 — manual-connect P2 `apiConnectP2` call also hardcoded the literal.

Asymmetry vs P1 in the same file: P1 auto-discover already used `DEFAULT_SAMPLE_RATE = 192_000` (line 71) and P1 manual respected `manualSampleRate`.

## Fix (3 lines + a comment)

1. **Auto-discover P2** → `sampleRate: DEFAULT_SAMPLE_RATE` (192 kHz). Comment added explaining why.
2. **Manual-connect rate calc** → drop the protocol ternary; use `manualSampleRate` for both P1 and P2.
3. **Manual-connect P2 call** → use the computed `sampleRate` variable instead of the literal.

After this:
- Auto-discover P2 → 192 kHz
- Manual P2 with default form → 192 kHz (the connect-store default at `connect-store.ts:45`)
- Manual P2 with operator picking 96 / 192 / 384 → that rate
- Saved endpoints → the remembered rate

## What's NOT touched

- **Backend.** `Program.cs /api/connect/p2` already threads the request body's `SampleRate` through to `DspPipelineService.ConnectP2Async` → `Protocol2Client.SetSampleRateKhz` → `WdspDspEngine.OpenChannel`. No backend change needed.
- **`SAMPLE_RATES` array** stays at `[48_000, 96_000, 192_000, 384_000]`. Adding 768 / 1536 kHz is in scope for Phase 2 (#145 / future), not this PR.
- **Runtime rate change** (without disconnect) is also Phase 2 — would need a new endpoint, off-DDC / swap / on-DDC dance on `Protocol2Client`, and engine `SetInputSamplerate` plumbing. Deferred.
- **P1 path** is untouched — already correct.

## Test plan

- [x] `npm --prefix zeus-web run build` clean.
- [x] Connected to G2 MkII (P2) via auto-discover. Panadapter at zoom=1 now shows ~192 kHz of span; HF band fits comfortably.
- [x] Manual connect with default form → 192 kHz, confirmed via panadapter span.
- [x] Existing P1 path (auto-discover and manual) unaffected — same 192 kHz default and dropdown respect as before.
- [ ] HL2 / P1 sanity check on bench (path is byte-identical to pre-PR — manual confirmation appreciated).

Closes #145
