### PR TITLE
feat(mobile): single-column shell with QRZ map + pinch-to-zoom

### DIFF
--- a/Zeus.Server/LanCertificate.cs
+++ b/Zeus.Server/LanCertificate.cs
@@ -1,0 +1,148 @@
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Zeus.Server;
+
+// Self-signed certificate for serving Zeus over HTTPS on the LAN. Browsers
+// require a secure context (HTTPS or localhost) before they hand over
+// getUserMedia — without that, the Zeus mobile shell on a phone can never
+// open the mic. Localhost is exempt for the dev box itself; everywhere else
+// the certificate signed here is what gets the operator past the secure-
+// context gate.
+//
+// Trust is on the operator: every device that visits will see a "Not secure"
+// warning the first time and has to tap through it. That's expected for a
+// self-signed LAN cert. Once accepted, getUserMedia works and the rest of
+// the Zeus stack treats the origin like any other HTTPS one.
+//
+// The cert is regenerated when the machine's LAN IPs change so the SAN list
+// stays in sync with reality (laptop moved between networks, router
+// reassigned a new prefix, etc.). Anything else is cached at
+// {LocalAppData}/Zeus/certs/zeus-lan.pfx so a restart isn't a fresh Trust-
+// On-First-Use moment.
+public static class LanCertificate
+{
+    private const string CertFileName = "zeus-lan.pfx";
+    private const string SanExtensionOid = "2.5.29.17";
+    private const string ServerAuthOid = "1.3.6.1.5.5.7.3.1";
+    private static readonly TimeSpan Validity = TimeSpan.FromDays(1825); // 5 years
+
+    public static X509Certificate2 GetOrCreate(ILogger? log = null)
+    {
+        var path = ResolveCertPath();
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+        var ips = GetLanIps().ToHashSet();
+
+        if (File.Exists(path))
+        {
+            try
+            {
+                var existing = X509CertificateLoader.LoadPkcs12FromFile(
+                    path,
+                    string.Empty,
+                    X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+                if (CoversAllIps(existing, ips) && existing.NotAfter > DateTime.UtcNow.AddDays(30))
+                {
+                    log?.LogInformation("LAN certificate loaded from {Path} ({Subject}, expires {Expires:yyyy-MM-dd})",
+                        path, existing.Subject, existing.NotAfter);
+                    return existing;
+                }
+                log?.LogInformation("LAN certificate regenerating: SAN list out of date or near expiry");
+                existing.Dispose();
+            }
+            catch (Exception ex)
+            {
+                log?.LogWarning(ex, "Existing LAN certificate at {Path} failed to load — regenerating", path);
+            }
+        }
+
+        var fresh = Generate(ips);
+        File.WriteAllBytes(path, fresh.Export(X509ContentType.Pfx, string.Empty));
+        log?.LogInformation("LAN certificate generated at {Path} for {IpCount} IP(s): {Ips}",
+            path, ips.Count, string.Join(", ", ips));
+        return fresh;
+    }
+
+    public static int GetHttpsPort()
+        => int.TryParse(Environment.GetEnvironmentVariable("ZEUS_HTTPS_PORT"), out var p) ? p : 6443;
+
+    public static IReadOnlyList<IPAddress> GetLanIps()
+    {
+        return NetworkInterface.GetAllNetworkInterfaces()
+            .Where(i => i.OperationalStatus == OperationalStatus.Up &&
+                        i.NetworkInterfaceType != NetworkInterfaceType.Loopback)
+            .SelectMany(i => i.GetIPProperties().UnicastAddresses)
+            .Where(a => a.Address.AddressFamily == AddressFamily.InterNetwork &&
+                        !IPAddress.IsLoopback(a.Address))
+            .Select(a => a.Address)
+            .Distinct()
+            .ToArray();
+    }
+
+    private static X509Certificate2 Generate(HashSet<IPAddress> ips)
+    {
+        using var rsa = RSA.Create(2048);
+        var req = new CertificateRequest(
+            $"CN=Zeus on {Environment.MachineName}",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+
+        var san = new SubjectAlternativeNameBuilder();
+        san.AddDnsName("localhost");
+        if (!string.IsNullOrEmpty(Environment.MachineName))
+            san.AddDnsName(Environment.MachineName);
+        san.AddDnsName("zeus.local");
+        san.AddIpAddress(IPAddress.Loopback);
+        foreach (var ip in ips) san.AddIpAddress(ip);
+        req.CertificateExtensions.Add(san.Build());
+
+        req.CertificateExtensions.Add(new X509BasicConstraintsExtension(false, false, 0, false));
+        req.CertificateExtensions.Add(new X509KeyUsageExtension(
+            X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment, false));
+        req.CertificateExtensions.Add(new X509EnhancedKeyUsageExtension(
+            new OidCollection { new Oid(ServerAuthOid) }, false));
+
+        var cert = req.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddMinutes(-5),
+            DateTimeOffset.UtcNow.Add(Validity));
+        // Round-trip via PFX so the returned cert owns an exportable private
+        // key — needed when we serialise it to disk for the next run.
+        var pfx = cert.Export(X509ContentType.Pfx, string.Empty);
+        return X509CertificateLoader.LoadPkcs12(
+            pfx,
+            string.Empty,
+            X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+    }
+
+    private static bool CoversAllIps(X509Certificate2 cert, HashSet<IPAddress> required)
+    {
+        var sanExt = cert.Extensions.FirstOrDefault(e => e.Oid?.Value == SanExtensionOid);
+        if (sanExt is null) return false;
+        // Format(false) returns one entry per line, e.g.
+        //   "IP Address=192.168.1.5"
+        //   "DNS Name=localhost"
+        // Substring match against the IP literal is good enough — false
+        // positives would need an IP literal to appear inside an unrelated
+        // SAN entry, which the SAN format doesn't allow.
+        var rendered = sanExt.Format(false);
+        foreach (var ip in required)
+        {
+            if (!rendered.Contains(ip.ToString(), StringComparison.Ordinal))
+                return false;
+        }
+        return true;
+    }
+
+    private static string ResolveCertPath()
+    {
+        var dir = Environment.GetFolderPath(
+            Environment.SpecialFolder.LocalApplicationData,
+            Environment.SpecialFolderOption.Create);
+        return Path.Combine(dir, "Zeus", "certs", CertFileName);
+    }
+}

--- a/Zeus.Server/Program.cs
+++ b/Zeus.Server/Program.cs
@@ -69,6 +69,12 @@ builder.Services.Configure<JsonOptions>(o =>
 // on the LAN (doc 01 §Deployment: local single-user, same LAN as radio).
 // ZEUS_PORT overrides the default (used by the /run skill's portOffset).
 var zeusPort = int.TryParse(Environment.GetEnvironmentVariable("ZEUS_PORT"), out var zp) ? zp : 6060;
+var zeusHttpsPort = LanCertificate.GetHttpsPort();
+// HTTPS bind for mobile-browser parity. Browsers refuse getUserMedia on a
+// non-secure context, which kills mic-uplink TX from any phone reaching
+// the server by LAN IP. The cert is auto-managed; first visit on each
+// device shows the standard "Not secure" warning.
+var lanCert = LanCertificate.GetOrCreate();
 
 // Resolve TCI bind settings from configuration before DI builds, because Kestrel's
 // listeners have to be declared now. TCI shares Kestrel (rather than a separate
@@ -81,6 +87,7 @@ var tciPort = tciSection.GetValue<int?>("Port") ?? 40001;
 builder.WebHost.ConfigureKestrel(k =>
 {
     k.ListenAnyIP(zeusPort);
+    k.ListenAnyIP(zeusHttpsPort, l => l.UseHttps(lanCert));
     if (tciEnabled)
     {
         if (tciBindAddress is "0.0.0.0" or "*" or "")
@@ -161,6 +168,20 @@ builder.Services.AddHostedService(sp => sp.GetRequiredService<TciServer>());
 builder.Services.AddSingleton<TciManagementService>();
 
 var app = builder.Build();
+
+// Surface the HTTPS endpoints up front so the operator can pick one for
+// their phone. iOS Safari + Chrome on Android both refuse getUserMedia on
+// non-secure origins, so the mobile shell hard-requires this URL.
+{
+    var lanIps = LanCertificate.GetLanIps();
+    var startupLog = app.Services.GetRequiredService<ILogger<Program>>();
+    startupLog.LogInformation(
+        "Zeus listening:  http://localhost:{HttpPort}   https://localhost:{HttpsPort}{LanLines}",
+        zeusPort, zeusHttpsPort,
+        lanIps.Count == 0
+            ? string.Empty
+            : "   (LAN: " + string.Join(", ", lanIps.Select(ip => $"https://{ip}:{zeusHttpsPort}")) + ")");
+}
 
 // Initialize QrzService to restore stored credentials (silent login)
 var qrzService = app.Services.GetRequiredService<QrzService>();

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -100,6 +100,7 @@ import { useKeyboardShortcuts } from './util/use-keyboard-shortcuts';
 import { SpectrumWheelActionsContext, type SpectrumWheelActions } from './util/use-pan-tune-gesture';
 import { registerServiceWorker } from './service-worker/registerSW';
 import { UpdatePrompt } from './service-worker/UpdatePrompt';
+import { MobileApp, useIsMobileViewport } from './mobile/MobileApp';
 import type L from 'leaflet';
 import type { QrzStation } from './api/qrz';
 import type { Contact } from './components/design/data';
@@ -519,16 +520,19 @@ export default function App() {
     );
   }, [connected]);
 
+  // Mobile viewport (≤900px) reactively tracked. Also honours `?mobile=1` so
+  // the mobile shell can be previewed on a desktop browser without resizing.
+  // The matchMedia listener is mounted in a layout effect so we don't paint
+  // a stale variant after a window resize / device-rotate.
+  const isMobile = useIsMobileViewport();
+
   // Feature flag: layout preference store determines whether to use the
-  // flexlayout-react dockable panel layout. Mobile viewports (≤900px) always
-  // use the fixed grid regardless of the preference — the mobile layout does
-  // not support flexlayout-react.
+  // flexlayout-react dockable panel layout. Mobile shell does not use
+  // flexlayout-react and short-circuits before the desktop tree renders.
   const layoutMode = useLayoutPreferenceStore((s) => s.layoutMode);
   const useFlexLayout = useMemo(() => {
-    if (typeof window === 'undefined') return false;
-    const isMobile = window.matchMedia('(max-width: 900px)').matches;
     return layoutMode === 'flex' && !isMobile;
-  }, [layoutMode]);
+  }, [layoutMode, isMobile]);
 
   // Bundle workspace state into a context so panel components can consume it
   // without prop-drilling through the FlexWorkspace factory.
@@ -581,6 +585,19 @@ export default function App() {
     dspActive, wpm, logbookTitle,
     handleLogQso, engageTerminator, disengageTerminator,
   ]);
+
+  // Mobile viewport short-circuit. All initialization hooks above (realtime,
+  // state poll, keyboard, mic uplink, service worker) have already run, so
+  // the mobile shell inherits the same live data feeds and the same store
+  // state — it just renders a different UI tree. SpectrumWheelActions is
+  // still required because Panadapter depends on the gesture context.
+  if (isMobile) {
+    return (
+      <SpectrumWheelActionsContext.Provider value={spectrumWheelActions}>
+        <MobileApp />
+      </SpectrumWheelActionsContext.Provider>
+    );
+  }
 
   return (
     <WorkspaceContext.Provider value={workspaceCtx}>

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -631,7 +631,7 @@ export default function App() {
             </svg>
           </div>
           <div className="brand-text">
-            <div className="brand-name mono">ZEUS</div>
+            <div className="brand-name mono">OpenHpsdr Zeus</div>
             <div className="brand-sub label-xs hide-mobile">HERMES LITE 2 · 0.1–54 MHz</div>
           </div>
         </div>

--- a/zeus-web/src/components/SMeterLive.tsx
+++ b/zeus-web/src/components/SMeterLive.tsx
@@ -52,8 +52,13 @@ import { useTxStore } from '../state/tx-store';
 //
 // SWR and mic dBfs are surfaced alongside the meter only while MOX is on —
 // they're TX-only telemetry and would be misleading under RX.
+//
+// `hideChips` lets a host (mobile shell) suppress the in-body chip row and
+// surface the same telemetry in its own chrome (e.g. the S-Meter section
+// header). Without that escape, the chips appear/disappear with TX state and
+// shift everything below the meter down on key — see MobileApp.tsx.
 
-export function SMeterLive() {
+export function SMeterLive({ hideChips = false }: { hideChips?: boolean } = {}) {
   const moxOn = useTxStore((s) => s.moxOn);
   const tunOn = useTxStore((s) => s.tunOn);
   const fwdWatts = useTxStore((s) => s.fwdWatts);
@@ -73,7 +78,7 @@ export function SMeterLive() {
           <SMeter mode="rx" dbm={rxDbm} />
         )}
       </div>
-      {transmitting && (
+      {transmitting && !hideChips && (
         <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end' }}>
           <span className="chip mono">
             <span className="k">SWR</span>

--- a/zeus-web/src/mobile/MobileApp.tsx
+++ b/zeus-web/src/mobile/MobileApp.tsx
@@ -284,7 +284,7 @@ function MicGate() {
       <div className="m-mic-gate__msg">
         <strong>Microphone unavailable.</strong>{' '}
         {insecure
-          ? 'iOS Safari requires HTTPS for mic access on a LAN IP — open this app via a secure URL.'
+          ? 'Mobile browsers require HTTPS for microphone access. The Zeus server prints an https:// LAN URL at startup — open that one on your phone instead. The first visit will warn that the certificate is self-signed; tap through to proceed.'
           : micError}
       </div>
       {!insecure && (

--- a/zeus-web/src/mobile/MobileApp.tsx
+++ b/zeus-web/src/mobile/MobileApp.tsx
@@ -13,6 +13,7 @@ import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 import { setMode, type RxMode } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
 import { useQrzStore } from '../state/qrz-store';
+import { useTxStore } from '../state/tx-store';
 import { VfoDisplay } from '../components/VfoDisplay';
 import { SMeterLive } from '../components/SMeterLive';
 import { Panadapter } from '../components/Panadapter';
@@ -212,6 +213,7 @@ export function MobileApp() {
         </Section>
 
         <div className="m-mox-block">
+          <MicGate />
           <MobilePttButton />
           <div className="m-mox-row">
             <TunButton />
@@ -234,6 +236,67 @@ export function MobileApp() {
           </div>
         </Section>
       </main>
+    </div>
+  );
+}
+
+// Mic permission gate. useMicUplink() in App.tsx kicks getUserMedia at mount
+// — that call falls outside any user gesture, and on iOS Safari over plain
+// HTTP-on-LAN-IP the origin isn't a secure context either, so the call is
+// silently rejected. Surfaces the error and offers an "Allow microphone"
+// button that re-requests permission FROM the user gesture, where Safari
+// will actually present the prompt. Reloads on success so the existing
+// uplink hook picks up the granted permission cleanly.
+function MicGate() {
+  const micError = useTxStore((s) => s.micError);
+  const [granting, setGranting] = useState(false);
+
+  if (!micError) return null;
+
+  // Non-secure-context detection. Localhost is treated as secure even over
+  // HTTP, but a LAN IP like 192.168.x.y over plain HTTP fails this and is
+  // unrecoverable without an HTTPS scheme.
+  const insecure =
+    typeof window !== 'undefined' && window.isSecureContext === false;
+
+  const onAllow = async () => {
+    setGranting(true);
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      // Tear the temp stream down — useMicUplink will open its own once we
+      // reload. Holding it would tie up the mic.
+      for (const t of stream.getTracks()) t.stop();
+      useTxStore.getState().setMicError(null);
+      // Reload so useMicUplink's mount-effect re-runs with permission
+      // already granted; in-place retry would need plumbing the hook to
+      // accept a reset token.
+      window.location.reload();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      useTxStore.getState().setMicError(msg);
+    } finally {
+      setGranting(false);
+    }
+  };
+
+  return (
+    <div className="m-mic-gate" role="alert">
+      <div className="m-mic-gate__msg">
+        <strong>Microphone unavailable.</strong>{' '}
+        {insecure
+          ? 'iOS Safari requires HTTPS for mic access on a LAN IP — open this app via a secure URL.'
+          : micError}
+      </div>
+      {!insecure && (
+        <button
+          type="button"
+          className="m-mic-gate__btn"
+          onClick={onAllow}
+          disabled={granting}
+        >
+          {granting ? 'Requesting…' : 'Allow microphone'}
+        </button>
+      )}
     </div>
   );
 }

--- a/zeus-web/src/mobile/MobileApp.tsx
+++ b/zeus-web/src/mobile/MobileApp.tsx
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// Mobile single-column shell. Renders the same widgets and stores the
+// desktop layout uses, in a vertical stack tuned for a touch viewport.
+// The layout shape comes from the Zeus Mobile design hand-off; colours,
+// type, and controls are the existing Zeus surface (tokens.css + the
+// component library) per the maintainer's brief.
+
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
+import { setMode, type RxMode } from '../api/client';
+import { useConnectionStore } from '../state/connection-store';
+import { useQrzStore } from '../state/qrz-store';
+import { VfoDisplay } from '../components/VfoDisplay';
+import { SMeterLive } from '../components/SMeterLive';
+import { Panadapter } from '../components/Panadapter';
+import { Waterfall } from '../components/Waterfall';
+import { MobilePttButton } from '../components/MobilePttButton';
+import { TunButton } from '../components/TunButton';
+import { PsToggleButton } from '../components/PsToggleButton';
+import { AudioToggle } from '../components/AudioToggle';
+import { BandButtons } from '../components/BandButtons';
+import { LeafletWorldMap } from '../components/design/LeafletWorldMap';
+import { LeafletMapErrorBoundary } from '../components/design/LeafletMapErrorBoundary';
+import { bandOf } from '../components/design/data';
+import './mobile.css';
+
+const MODES: readonly RxMode[] = ['LSB', 'USB', 'CWL', 'CWU', 'AM', 'FM', 'DIGU'];
+
+const MOBILE_QUERY = '(max-width: 900px)';
+
+// Reactive viewport check. `?mobile=1` forces the mobile shell on for desktop
+// previews; everything else honours the matchMedia breakpoint and updates
+// when the window is resized or the device rotates.
+export function useIsMobileViewport(): boolean {
+  const [mobile, setMobile] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('mobile') === '1') return true;
+    return window.matchMedia(MOBILE_QUERY).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('mobile') === '1') return; // forced — no listener needed
+    const mq = window.matchMedia(MOBILE_QUERY);
+    const onChange = (e: MediaQueryListEvent) => setMobile(e.matches);
+    mq.addEventListener('change', onChange);
+    return () => mq.removeEventListener('change', onChange);
+  }, []);
+
+  return mobile;
+}
+
+export function MobileApp() {
+  const status = useConnectionStore((s) => s.status);
+  const endpoint = useConnectionStore((s) => s.endpoint);
+  const lastEndpoint = useConnectionStore((s) => s.lastConnectedEndpoint);
+  const vfoHz = useConnectionStore((s) => s.vfoHz);
+  const mode = useConnectionStore((s) => s.mode);
+  const qrzHome = useQrzStore((s) => s.home);
+  const qrzHasXml = useQrzStore((s) => s.hasXmlSubscription);
+  const connected = status === 'Connected';
+
+  const radioLabel = endpoint || lastEndpoint || '—';
+  const bandLabel = bandOf(vfoHz);
+  const freqMHz = (vfoHz / 1_000_000).toFixed(3);
+
+  // QRZ map background — mirrors desktop's behaviour. The map renders behind
+  // the spectrum stack when the operator has a QTH home pinned and an XML
+  // subscription (same gate as App.tsx's qrzActive). LeafletWorldMap takes a
+  // MapStation shape (call, not callsign), so we adapt the QrzStation here
+  // the same way App.tsx:446-454 does.
+  const effectiveHome =
+    qrzHome && qrzHome.lat != null && qrzHome.lon != null && qrzHasXml
+      ? {
+          call: qrzHome.callsign,
+          lat: qrzHome.lat,
+          lon: qrzHome.lon,
+          grid: qrzHome.grid ?? '',
+          imageUrl: qrzHome.imageUrl ?? null,
+        }
+      : null;
+
+  return (
+    <div className="m-app">
+      <header className="m-topbar">
+        <div className="m-brand">
+          <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden>
+            <circle cx="12" cy="12" r="3" fill="var(--accent)" />
+            <circle cx="12" cy="12" r="7" fill="none" stroke="var(--accent)" strokeWidth="1" opacity="0.5" />
+            <circle cx="12" cy="12" r="11" fill="none" stroke="var(--accent)" strokeWidth="1" opacity="0.25" />
+          </svg>
+          <span className="m-brand-text">ZEUS</span>
+        </div>
+        <div className="m-conn-chip" data-connected={connected}>
+          <span className="m-conn-k">RADIO</span>
+          <span className="m-conn-v">{radioLabel}</span>
+        </div>
+      </header>
+
+      <main className="m-stack">
+        <Section label="Frequency" meta="VFO A">
+          <div className="m-vfo-wrap">
+            <VfoDisplay />
+          </div>
+        </Section>
+
+        <Section label="S-Meter" meta="RX">
+          <SMeterLive />
+        </Section>
+
+        <Section label="Panadapter" meta={`${freqMHz} MHz · ${bandLabel}`}>
+          <div className="m-pan-stack">
+            {effectiveHome && (
+              // The "map-layer visible" pair pulls in the desktop sizing
+              // chain in layout.css:451-470 — without it the inner Leaflet
+              // .leaflet-container collapses to 0×0 and tiles never paint.
+              // .m-map-layer still applies for any mobile-only tweaks.
+              <div className="m-map-layer map-layer visible">
+                <LeafletMapErrorBoundary fallback={null} onError={() => undefined}>
+                  <LeafletWorldMap
+                    home={effectiveHome}
+                    target={null}
+                    active
+                    interactive={false}
+                  />
+                </LeafletMapErrorBoundary>
+              </div>
+            )}
+            <div className="m-pan-spectrum">
+              <div className="m-pan">
+                <Panadapter />
+              </div>
+              <div className="m-wf">
+                {/* Opaque on mobile even when QRZ is on. With a transparent
+                    waterfall + dark Esri tiles + the colormap's near-black
+                    noise floor, signal traces blended into the map and the
+                    waterfall read as solid black. The map remains visible
+                    behind the spectrum (top half), where it's primarily
+                    contextual decoration. */}
+                <Waterfall transparent={false} />
+              </div>
+            </div>
+          </div>
+        </Section>
+
+        <div className="m-mox-block">
+          <MobilePttButton />
+          <div className="m-mox-row">
+            <TunButton />
+            <PsToggleButton />
+            <AudioToggle />
+          </div>
+        </div>
+
+        <Section label="Mode · Band">
+          <div className="m-modeband">
+            <Segmented
+              options={MODES}
+              value={mode}
+              disabled={!connected}
+              onChange={(m) => setMode(m).catch(() => undefined)}
+            />
+            <div className="m-band-row">
+              <BandButtons />
+            </div>
+          </div>
+        </Section>
+      </main>
+    </div>
+  );
+}
+
+function Section({
+  label,
+  meta,
+  children,
+}: {
+  label: string;
+  meta?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="m-section">
+      <header className="m-section-head">
+        <span className="m-section-led" />
+        <span className="m-section-label">{label}</span>
+        {meta && <span className="m-section-meta">· {meta}</span>}
+      </header>
+      <div className="m-section-body">{children}</div>
+    </section>
+  );
+}
+
+function Segmented<T extends string>({
+  options,
+  value,
+  disabled,
+  onChange,
+}: {
+  options: readonly T[];
+  value: T;
+  disabled?: boolean;
+  onChange: (v: T) => void;
+}) {
+  // Optimistic local highlight so the segment lights immediately even before
+  // the StateDto echo lands; the prop value reasserts itself once the server
+  // confirms (or contradicts) the choice.
+  const [pending, setPending] = useState<T | null>(null);
+  const active = pending ?? value;
+
+  const handle = useCallback(
+    (v: T) => {
+      if (disabled) return;
+      setPending(v);
+      Promise.resolve(onChange(v)).finally(() => setPending(null));
+    },
+    [disabled, onChange],
+  );
+
+  return (
+    <div className="m-segmented" role="radiogroup">
+      {options.map((o) => {
+        const on = o === active;
+        return (
+          <button
+            key={o}
+            type="button"
+            role="radio"
+            aria-checked={on}
+            disabled={disabled}
+            onClick={() => handle(o)}
+            className={`m-seg-btn ${on ? 'on' : ''}`}
+          >
+            {o}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/zeus-web/src/mobile/MobileApp.tsx
+++ b/zeus-web/src/mobile/MobileApp.tsx
@@ -173,9 +173,8 @@ export function MobileApp() {
           </div>
         </Section>
 
-        <Section label="S-Meter" meta="RX" tight>
-          <SMeterLive />
-        </Section>
+        <SMeterSection />
+
 
         <Section label="Panadapter" meta={`${freqMHz} MHz · ${bandLabel}`}>
           <div className="m-pan-stack">
@@ -301,14 +300,52 @@ function MicGate() {
   );
 }
 
+// S-Meter card. Wrapped in its own component so subscribing to TX state
+// for the in-header SWR + MIC chips doesn't re-render the whole MobileApp
+// at the meter's update rate. During TX, the chips render in the section
+// header (right-aligned) instead of below the meter — keeping the body
+// height fixed so keying MOX doesn't push the PTT button down.
+function SMeterSection() {
+  const moxOn = useTxStore((s) => s.moxOn);
+  const tunOn = useTxStore((s) => s.tunOn);
+  const swr = useTxStore((s) => s.swr);
+  const micDbfs = useTxStore((s) => s.micDbfs);
+  const transmitting = moxOn || tunOn;
+  const swrColor = swr >= 3 ? 'var(--tx)' : swr >= 2 ? 'var(--power)' : 'var(--fg-0)';
+
+  const chips = transmitting ? (
+    <>
+      <span className="chip mono">
+        <span className="k">SWR</span>
+        <span className="v" style={{ color: swrColor }}>{swr.toFixed(2)}</span>
+      </span>
+      <span className="chip mono">
+        <span className="k">MIC</span>
+        <span className="v">{micDbfs.toFixed(0)} dBfs</span>
+      </span>
+    </>
+  ) : null;
+
+  return (
+    <Section label="S-Meter" meta={transmitting ? 'TX' : 'RX'} extra={chips} tight>
+      <SMeterLive hideChips />
+    </Section>
+  );
+}
+
 function Section({
   label,
   meta,
+  extra,
   tight,
   children,
 }: {
   label: string;
   meta?: string;
+  /** Right-aligned slot in the section header. Used by the S-Meter card to
+   *  surface SWR + MIC dBfs chips during TX without growing the body and
+   *  shifting the PTT button below it. */
+  extra?: ReactNode;
   /** Strip the body padding — used by the SMeter section so the meter
    *  fills the chrome edge to edge. */
   tight?: boolean;
@@ -320,6 +357,7 @@ function Section({
         <span className="m-section-led" />
         <span className="m-section-label">{label}</span>
         {meta && <span className="m-section-meta">· {meta}</span>}
+        {extra && <span className="m-section-extra">{extra}</span>}
       </header>
       <div className="m-section-body">{children}</div>
     </section>

--- a/zeus-web/src/mobile/MobileApp.tsx
+++ b/zeus-web/src/mobile/MobileApp.tsx
@@ -9,7 +9,7 @@
 // type, and controls are the existing Zeus surface (tokens.css + the
 // component library) per the maintainer's brief.
 
-import { useCallback, useEffect, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import { setMode, type RxMode } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
 import { useQrzStore } from '../state/qrz-store';
@@ -22,6 +22,7 @@ import { TunButton } from '../components/TunButton';
 import { PsToggleButton } from '../components/PsToggleButton';
 import { AudioToggle } from '../components/AudioToggle';
 import { BandButtons } from '../components/BandButtons';
+import { ConnectPanel } from '../components/ConnectPanel';
 import { LeafletWorldMap } from '../components/design/LeafletWorldMap';
 import { LeafletMapErrorBoundary } from '../components/design/LeafletMapErrorBoundary';
 import { bandOf } from '../components/design/data';
@@ -69,6 +70,21 @@ export function MobileApp() {
   const bandLabel = bandOf(vfoHz);
   const freqMHz = (vfoHz / 1_000_000).toFixed(3);
 
+  // Radio selector overlay. Open from the topbar; auto-close once a connect
+  // *transition* completes (status flips Disconnected → Connected) so the
+  // operator lands back on the radio screen without an extra dismiss tap.
+  // Watching the edge — not the steady state — lets the operator open the
+  // selector while already connected (to disconnect or switch radios)
+  // without it slamming shut on first render.
+  const [selectorOpen, setSelectorOpen] = useState(false);
+  const prevConnectedRef = useRef(connected);
+  useEffect(() => {
+    if (selectorOpen && !prevConnectedRef.current && connected) {
+      setSelectorOpen(false);
+    }
+    prevConnectedRef.current = connected;
+  }, [selectorOpen, connected]);
+
   // QRZ map background — mirrors desktop's behaviour. The map renders behind
   // the spectrum stack when the operator has a QTH home pinned and an XML
   // subscription (same gate as App.tsx's qrzActive). LeafletWorldMap takes a
@@ -96,11 +112,58 @@ export function MobileApp() {
           </svg>
           <span className="m-brand-text">ZEUS</span>
         </div>
-        <div className="m-conn-chip" data-connected={connected}>
-          <span className="m-conn-k">RADIO</span>
-          <span className="m-conn-v">{radioLabel}</span>
-        </div>
+        <button
+          type="button"
+          className="m-conn-btn"
+          data-connected={connected}
+          onClick={() => setSelectorOpen(true)}
+          title={connected ? `Connected to ${radioLabel} — tap to manage` : 'Tap to discover radios'}
+        >
+          {connected ? (
+            <>
+              <span className="m-conn-led" aria-hidden />
+              <span className="m-conn-v">{radioLabel}</span>
+              <span className="m-conn-action">Disconnect</span>
+            </>
+          ) : (
+            <>
+              <span className="m-conn-led m-conn-led--off" aria-hidden />
+              <span className="m-conn-action m-conn-action--primary">Connect</span>
+            </>
+          )}
+        </button>
       </header>
+
+      {selectorOpen && (
+        <div
+          className="m-selector-backdrop"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Radio selector"
+          onClick={(e) => {
+            // Backdrop click dismisses; clicks inside the sheet bubble through
+            // to here too, so guard on currentTarget.
+            if (e.target === e.currentTarget) setSelectorOpen(false);
+          }}
+        >
+          <div className="m-selector-sheet">
+            <header className="m-selector-head">
+              <span className="m-selector-title">Radio</span>
+              <button
+                type="button"
+                className="m-selector-close"
+                onClick={() => setSelectorOpen(false)}
+                aria-label="Close radio selector"
+              >
+                ✕
+              </button>
+            </header>
+            <div className="m-selector-body">
+              <ConnectPanel />
+            </div>
+          </div>
+        </div>
+      )}
 
       <main className="m-stack">
         <Section label="Frequency" meta="VFO A">
@@ -109,7 +172,7 @@ export function MobileApp() {
           </div>
         </Section>
 
-        <Section label="S-Meter" meta="RX">
+        <Section label="S-Meter" meta="RX" tight>
           <SMeterLive />
         </Section>
 
@@ -178,14 +241,18 @@ export function MobileApp() {
 function Section({
   label,
   meta,
+  tight,
   children,
 }: {
   label: string;
   meta?: string;
+  /** Strip the body padding — used by the SMeter section so the meter
+   *  fills the chrome edge to edge. */
+  tight?: boolean;
   children: ReactNode;
 }) {
   return (
-    <section className="m-section">
+    <section className={`m-section${tight ? ' m-section--tight' : ''}`}>
       <header className="m-section-head">
         <span className="m-section-led" />
         <span className="m-section-label">{label}</span>

--- a/zeus-web/src/mobile/MobileApp.tsx
+++ b/zeus-web/src/mobile/MobileApp.tsx
@@ -110,7 +110,7 @@ export function MobileApp() {
             <circle cx="12" cy="12" r="7" fill="none" stroke="var(--accent)" strokeWidth="1" opacity="0.5" />
             <circle cx="12" cy="12" r="11" fill="none" stroke="var(--accent)" strokeWidth="1" opacity="0.25" />
           </svg>
-          <span className="m-brand-text">ZEUS</span>
+          <span className="m-brand-text">OpenHpsdr Zeus</span>
         </div>
         <button
           type="button"

--- a/zeus-web/src/mobile/mobile.css
+++ b/zeus-web/src/mobile/mobile.css
@@ -281,14 +281,49 @@
   flex-direction: column;
   gap: 8px;
 }
+
+/* Mic permission gate. Shown only when useMicUplink reports an error —
+   typically iOS Safari blocking getUserMedia over HTTP-on-LAN-IP, or a
+   prior denial that needs an explicit user-gesture re-request. */
+.m-mic-gate {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  background: var(--tx-soft);
+  border: 1px solid var(--tx);
+  border-radius: var(--r-md);
+  color: var(--fg-1);
+  font-size: 12px;
+  line-height: 1.4;
+}
+.m-mic-gate__msg strong { color: var(--tx); margin-right: 4px; }
+.m-mic-gate__btn {
+  align-self: flex-start;
+  padding: 8px 14px;
+  border-radius: var(--r-md);
+  background: var(--accent);
+  color: #06121f;
+  font-weight: 700;
+  font-size: 12px;
+  letter-spacing: 0.4px;
+  cursor: pointer;
+  border: none;
+  min-height: 36px;
+}
+.m-mic-gate__btn:disabled { opacity: 0.5; cursor: not-allowed; }
 .m-mox-row {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   gap: 6px;
 }
 /* The mobile-ptt-btn already exists in src/styles/layout.css with mobile
-   sizing; we just want it full-width inside the block. */
+   sizing; we just want it full-width inside the block. The desktop CSS
+   adds `transform: translateY(1px)` on the .tx state for a press-down
+   feel — disorienting on a phone where the surrounding row stays put,
+   so we pin it. */
 .m-mox-block .mobile-ptt-btn { width: 100%; }
+.m-mox-block .mobile-ptt-btn.tx { transform: none; }
 /* Compact the secondary buttons so three fit comfortably across. */
 .m-mox-row .btn,
 .m-mox-row .tx-btn { width: 100%; padding: 10px 6px; font-size: 13px; }

--- a/zeus-web/src/mobile/mobile.css
+++ b/zeus-web/src/mobile/mobile.css
@@ -1,0 +1,263 @@
+/* Mobile single-column shell. Layout shape from the Zeus Mobile design;
+   colour and type from src/styles/tokens.css. The desktop "body { overflow:
+   hidden }" rule keeps the desktop shell pinned to the viewport — mobile
+   needs a scrolling document, so .m-app sets its own scroll context. */
+
+.m-app {
+  position: fixed;
+  inset: 0;
+  background: var(--bg-app);
+  color: var(--fg-0);
+  font-family: var(--font-sans);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  /* Status-bar / dynamic-island clearance + bottom home-indicator clearance */
+  padding-top: env(safe-area-inset-top, 0);
+  padding-bottom: env(safe-area-inset-bottom, 0);
+}
+
+/* ── Topbar ────────────────────────────────────────────── */
+.m-topbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  background: linear-gradient(180deg, var(--panel-head-top) 0%, var(--panel-head-bot) 100%);
+  border-bottom: 1px solid var(--panel-border);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+.m-brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.m-brand-text {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 14px;
+  letter-spacing: 3px;
+  color: var(--fg-0);
+}
+.m-conn-chip {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 9px;
+  background: var(--bg-0);
+  border: 1px solid var(--btn-edge);
+  border-radius: var(--r-md);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+.m-conn-k { color: var(--fg-3); letter-spacing: 0.5px; }
+.m-conn-v { color: var(--fg-2); }
+.m-conn-chip[data-connected='true'] .m-conn-v { color: var(--accent); }
+
+/* ── Vertical stack ────────────────────────────────────── */
+.m-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px;
+}
+
+/* ── Section panel ─────────────────────────────────────── */
+.m-section {
+  background: var(--bg-0);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--r-lg);
+  overflow: hidden;
+  box-shadow: var(--panel-shadow);
+}
+.m-section-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  background: linear-gradient(180deg, var(--panel-head-top) 0%, var(--panel-head-bot) 100%);
+  border-bottom: 1px solid var(--panel-border);
+  font-family: var(--font-sans);
+  font-size: 10px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+.m-section-led {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 6px var(--accent);
+  flex-shrink: 0;
+}
+.m-section-label {
+  color: var(--fg-0);
+  font-weight: 600;
+}
+.m-section-meta {
+  color: var(--fg-3);
+  font-family: var(--font-mono);
+}
+.m-section-body {
+  padding: 10px;
+}
+
+/* The VFO is the hero — give it room to breathe and centre the digits.
+   The shared `.freq-display` panel sizes its digits with `clamp(38px, 26cqh, 140px)`
+   (layout.css:607). When dropped into a 34px-tall flex slot the 38 px floor
+   overflows the panel chrome — pin a comfortable mobile height so the digits
+   sit inside the dark blue inset chrome. */
+.m-vfo-wrap {
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+}
+.m-app .freq-display {
+  min-height: 110px;
+  width: 100%;
+}
+
+/* ── Panadapter + waterfall ────────────────────────────── */
+/* The map-layer + spectrum stack share a single positioned ancestor so the
+   QRZ Leaflet world map can sit behind a transparent waterfall the same way
+   the desktop "hero" panel does (see App.tsx:818-882). */
+.m-pan-stack {
+  position: relative;
+  height: 310px;
+  background: var(--spec-bg);
+}
+.m-map-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  overflow: hidden;
+}
+.m-pan-spectrum {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  display: grid;
+  grid-template-rows: 1fr 1fr;
+  pointer-events: auto;
+}
+.m-pan,
+.m-wf {
+  position: relative;
+  background: transparent;
+}
+.m-pan { border-bottom: 1px solid var(--panel-border); }
+/* Both child components fill their container via absolute children */
+.m-pan > *,
+.m-wf > * { position: absolute; inset: 0; }
+
+/* When the QRZ map is rendering behind, the panadapter + waterfall
+   containers must paint transparent so the map tiles bleed through. The
+   Panadapter widget's <div class="spectrum-canvas"> sets var(--spec-bg)
+   inline (Panadapter.tsx:196); override for the mobile shell. The Waterfall
+   widget's noise floor is faded inside its WebGL fragment shader by the
+   `transparent` prop we already pass. */
+.m-app .spectrum-canvas { background: transparent !important; }
+
+/* The Panadapter widget brings its own dB scale axis pinned to the left
+   which we keep visible. The Waterfall widget brings two pieces of chrome
+   that don't belong on mobile:
+     • γ contrast slider — hidden, takes the same left rail as the dB scale.
+     • Colormap radios + dB:FIXED chip — hidden per maintainer brief, mobile
+       has no room for palette selection in this iteration. */
+.m-app [aria-label="Waterfall contrast (γ)"] { display: none !important; }
+.m-app [role="radiogroup"][aria-label="Colormap"],
+.m-app [role="radiogroup"][aria-label="Colormap"] + button { display: none !important; }
+/* Pinch-to-zoom: tell the browser we own all touch on the spectrum surface
+   so it doesn't double-tap-zoom or pinch-zoom the document instead of the
+   canvas. usePanTuneGesture handles the multi-pointer math for both pan
+   (Panadapter) and waterfall canvases. */
+.m-app .m-pan canvas,
+.m-app .m-wf canvas { touch-action: none; }
+
+/* The Panadapter section overrides the default 10px body padding so the
+   spectrum + waterfall reach the panel edges. */
+.m-section:has(.m-pan) > .m-section-body { padding: 0; }
+
+/* ── MOX block ─────────────────────────────────────────── */
+.m-mox-block {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.m-mox-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 6px;
+}
+/* The mobile-ptt-btn already exists in src/styles/layout.css with mobile
+   sizing; we just want it full-width inside the block. */
+.m-mox-block .mobile-ptt-btn { width: 100%; }
+/* Compact the secondary buttons so three fit comfortably across. */
+.m-mox-row .btn,
+.m-mox-row .tx-btn { width: 100%; padding: 10px 6px; font-size: 13px; }
+
+/* ── Mode + Band ───────────────────────────────────────── */
+.m-modeband {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.m-segmented {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 1fr;
+  gap: 4px;
+  padding: 3px;
+  background: var(--bg-1);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--r-lg);
+}
+.m-seg-btn {
+  padding: 9px 0;
+  border-radius: var(--r-md);
+  background: transparent;
+  color: var(--fg-2);
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.4px;
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out),
+              color var(--dur-fast) var(--ease-out);
+  min-height: 36px;             /* Apple-recommended touch target */
+}
+.m-seg-btn:hover:not([disabled]) { color: var(--fg-0); }
+.m-seg-btn.on {
+  background: var(--accent);
+  color: #06121f;
+  font-weight: 700;
+}
+.m-seg-btn[disabled] { opacity: 0.4; cursor: not-allowed; }
+
+/* Wrap the existing BandButtons row so it stays inside the panel and the
+   chunky desktop buttons get a slightly tighter mobile sizing. The exact
+   internal markup of BandButtons is owned by that component; we just give
+   it a flex container that allows wrapping if 10 buttons don't fit one line. */
+.m-band-row { display: flex; flex-wrap: wrap; gap: 4px; }
+.m-band-row > * { flex: 1 1 auto; }
+.m-band-row button { min-width: 38px; padding: 8px 6px; font-size: 12px; }
+
+/* The legacy `.hide-mobile` / `.show-mobile` classes were added for the
+   chrome-only mobile fallback (most widgets hidden, a couple of mobile
+   variants surfaced). Inside the new mobile shell we want each component's
+   *desktop* variant — full band-button row, full mode row, etc. — so we
+   neutralise both legacy classes within .m-app. show-mobile widgets that
+   set `display: none` inline (e.g. the BandButtons dropdown) stay hidden
+   because the inline style still wins. */
+.m-app .hide-mobile { display: revert !important; }
+.m-app .show-mobile { display: none !important; }
+
+/* The hide-mobile band row inside BandButtons brings its own .ctrl-group +
+   .ctrl-lbl chrome that doesn't read well in the mobile section. Hide the
+   redundant "BAND" label and let the .btn-row sit flush. */
+.m-band-row .ctrl-lbl { display: none; }
+.m-band-row .ctrl-group { padding: 0; }

--- a/zeus-web/src/mobile/mobile.css
+++ b/zeus-web/src/mobile/mobile.css
@@ -187,6 +187,20 @@
   color: var(--fg-3);
   font-family: var(--font-mono);
 }
+/* Right-aligned slot in the section head — used by the S-Meter card to
+   carry SWR + MIC dBfs chips during TX. `margin-left: auto` pushes the
+   slot to the right edge regardless of the label/meta width on its left.
+   The header inherits `text-transform: uppercase`, but `.chip .k` is
+   already uppercase and `.chip .v` is just digits so the cascade is a
+   no-op in practice. */
+.m-section-extra {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  text-transform: none;
+  letter-spacing: normal;
+}
 .m-section-body {
   padding: 10px;
 }

--- a/zeus-web/src/mobile/mobile.css
+++ b/zeus-web/src/mobile/mobile.css
@@ -38,9 +38,10 @@
 .m-brand-text {
   font-family: var(--font-display);
   font-weight: 700;
-  font-size: 14px;
-  letter-spacing: 3px;
+  font-size: 13px;
+  letter-spacing: 0.4px;
   color: var(--fg-0);
+  white-space: nowrap;
 }
 /* Topbar Connect/Disconnect button. The chip-style container doubles as the
    tap target that opens the radio selector overlay. Tinted accent when

--- a/zeus-web/src/mobile/mobile.css
+++ b/zeus-web/src/mobile/mobile.css
@@ -42,21 +42,105 @@
   letter-spacing: 3px;
   color: var(--fg-0);
 }
-.m-conn-chip {
+/* Topbar Connect/Disconnect button. The chip-style container doubles as the
+   tap target that opens the radio selector overlay. Tinted accent when
+   connected, accent-blue when prompting to connect. */
+.m-conn-btn {
   margin-left: auto;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 5px 9px;
+  gap: 8px;
+  padding: 6px 10px;
   background: var(--bg-0);
   border: 1px solid var(--btn-edge);
   border-radius: var(--r-md);
-  font-family: var(--font-mono);
+  color: var(--fg-1);
+  font-family: var(--font-sans);
   font-size: 11px;
+  cursor: pointer;
+  min-height: 32px;
 }
-.m-conn-k { color: var(--fg-3); letter-spacing: 0.5px; }
-.m-conn-v { color: var(--fg-2); }
-.m-conn-chip[data-connected='true'] .m-conn-v { color: var(--accent); }
+.m-conn-btn:hover { background: var(--bg-1); }
+.m-conn-led {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 6px var(--accent);
+  flex-shrink: 0;
+}
+.m-conn-led--off {
+  background: var(--fg-3);
+  box-shadow: none;
+}
+.m-conn-v {
+  font-family: var(--font-mono);
+  color: var(--accent);
+}
+.m-conn-action {
+  color: var(--fg-2);
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  font-size: 10px;
+}
+.m-conn-action--primary { color: var(--accent); font-weight: 700; }
+.m-conn-btn[data-connected='false'] { border-color: var(--accent-soft); }
+
+/* ── Radio selector overlay ─────────────────────────────── */
+.m-selector-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(2px);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: env(safe-area-inset-top, 16px) 12px 12px;
+  z-index: 50;
+  overflow-y: auto;
+}
+.m-selector-sheet {
+  width: 100%;
+  max-width: 460px;
+  margin-top: 48px;
+  background: var(--bg-0);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--r-lg);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.m-selector-head {
+  display: flex;
+  align-items: center;
+  padding: 10px 12px;
+  background: linear-gradient(180deg, var(--panel-head-top) 0%, var(--panel-head-bot) 100%);
+  border-bottom: 1px solid var(--panel-border);
+}
+.m-selector-title {
+  font-weight: 700;
+  font-size: 12px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--fg-0);
+}
+.m-selector-close {
+  margin-left: auto;
+  background: transparent;
+  border: none;
+  color: var(--fg-2);
+  font-size: 16px;
+  cursor: pointer;
+  padding: 4px 10px;
+  border-radius: var(--r-sm);
+}
+.m-selector-close:hover { background: var(--bg-1); color: var(--fg-0); }
+.m-selector-body {
+  padding: 8px;
+  overflow-y: auto;
+}
+/* ConnectPanel sets minWidth: 460px inline (ConnectPanel.tsx:363); on a
+   402 px viewport that overflows. Force it to fill the sheet width. */
+.m-selector-body .panel { min-width: 0 !important; max-width: 100% !important; }
 
 /* ── Vertical stack ────────────────────────────────────── */
 .m-stack {
@@ -105,21 +189,29 @@
 .m-section-body {
   padding: 10px;
 }
+/* Tight modifier — used by S-Meter so the LED strip + dBm readout fill the
+   panel chrome edge to edge. SMeterLive paints its own padding:10 inline,
+   override that too. */
+.m-section--tight > .m-section-body { padding: 0; }
+.m-section--tight > .m-section-body > div { padding: 0 !important; }
 
-/* The VFO is the hero — give it room to breathe and centre the digits.
-   The shared `.freq-display` panel sizes its digits with `clamp(38px, 26cqh, 140px)`
-   (layout.css:607). When dropped into a 34px-tall flex slot the 38 px floor
-   overflows the panel chrome — pin a comfortable mobile height so the digits
-   sit inside the dark blue inset chrome. */
+/* The VFO. The shared `.freq-display` panel sizes digits with
+   `clamp(38px, 26cqh, 140px)` (layout.css:607); pin a tight mobile height
+   so the digits sit inside the dark blue inset chrome and the panel doesn't
+   dominate the screen. The bottom hint label (.freq-bot) is hidden — it's
+   discoverable on first interaction; not worth the extra rows on mobile. */
 .m-vfo-wrap {
   display: flex;
   justify-content: center;
   align-items: stretch;
 }
 .m-app .freq-display {
-  min-height: 110px;
+  min-height: 56px;
+  padding: 6px 12px;
   width: 100%;
 }
+.m-app .freq-display .freq-bot { display: none; }
+.m-app .freq-display .freq-digits { margin: 0; }
 
 /* ── Panadapter + waterfall ────────────────────────────── */
 /* The map-layer + spectrum stack share a single positioned ancestor so the

--- a/zeus-web/src/util/use-pan-tune-gesture.ts
+++ b/zeus-web/src/util/use-pan-tune-gesture.ts
@@ -112,14 +112,41 @@ export function usePanTuneGesture(
 
     type Drag = { startX: number; startHz: number; spanHz: number; moved: boolean };
     type MapDrag = { lastX: number; lastY: number };
+    type Pinch = {
+      baseDist: number;     // pointer separation when the pinch began (px)
+      baseZoom: number;     // zoom level when the pinch began
+      pendingZoom: number | null;
+      raf: number;
+    };
     let drag: Drag | null = null;
     // alt-held pointer drag — delegates to the background map via the
     // SpectrumWheelActionsContext so it feels like M-hold drag without
     // swapping pointer-events on the spectrum stack.
     let mapDrag: MapDrag | null = null;
+    // Live pointer roster for multi-touch (pinch-to-zoom on mobile). Single
+    // pointer flows through the existing drag-to-tune path; ≥2 pointers
+    // triggers pinch and suppresses any in-flight drag.
+    const pointers = new Map<number, { x: number; y: number }>();
+    let pinch: Pinch | null = null;
     let pendingHz: number | null = null;
     let pendingAbort: AbortController | null = null;
     let pendingRaf = 0;
+
+    const pinchDistance = (): number => {
+      const arr = Array.from(pointers.values());
+      if (arr.length < 2) return 0;
+      const a = arr[0];
+      const b = arr[1];
+      if (!a || !b) return 0;
+      return Math.hypot(a.x - b.x, a.y - b.y);
+    };
+
+    const cancelPinchRaf = () => {
+      if (pinch && pinch.raf !== 0) {
+        cancelAnimationFrame(pinch.raf);
+        pinch.raf = 0;
+      }
+    };
 
     // Wheel bookkeeping: accumulate deltas so trackpad micro-deltas feel
     // consistent, but emit at most one step per physical wheel event — one
@@ -184,6 +211,26 @@ export function usePanTuneGesture(
 
     const onPointerDown = (e: PointerEvent) => {
       if (e.button !== 0) return;
+      pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+      // Two-finger pinch on mobile → zoom. Pinch always wins over an in-flight
+      // single-pointer drag; we drop the drag state so the lifted finger
+      // doesn't snap-tune on release.
+      if (pointers.size >= 2) {
+        if (drag) drag = null;
+        if (mapDrag) mapDrag = null;
+        canvas.style.cursor = '';
+        if (!pinch) {
+          pinch = {
+            baseDist: pinchDistance(),
+            baseZoom: useConnectionStore.getState().zoomLevel,
+            pendingZoom: null,
+            raf: 0,
+          };
+        }
+        try { canvas.setPointerCapture(e.pointerId); } catch { /* ok */ }
+        e.preventDefault();
+        return;
+      }
       // alt held → drag the background map instead of panning the spectrum.
       // Mirrors M-hold drag behavior without the pointer-events:none swap.
       if (e.altKey) {
@@ -211,6 +258,36 @@ export function usePanTuneGesture(
     };
 
     const onPointerMove = (e: PointerEvent) => {
+      const p = pointers.get(e.pointerId);
+      if (p) {
+        p.x = e.clientX;
+        p.y = e.clientY;
+      }
+      if (pinch) {
+        const d = pinchDistance();
+        if (d > 0 && pinch.baseDist > 0) {
+          const ratio = d / pinch.baseDist;
+          // Linear ratio → integer zoom level. Round so a small wobble doesn't
+          // chatter; the optimistic store update + setZoom still flush via
+          // nudgeZoom's existing debounce.
+          const target = clampZoom(pinch.baseZoom * ratio);
+          if (pinch.pendingZoom !== target) {
+            pinch.pendingZoom = target;
+            if (pinch.raf === 0) {
+              pinch.raf = requestAnimationFrame(() => {
+                if (!pinch) return;
+                pinch.raf = 0;
+                const next = pinch.pendingZoom;
+                if (next == null) return;
+                const cur = useConnectionStore.getState().zoomLevel;
+                if (next !== cur) nudgeZoom(next - cur);
+              });
+            }
+          }
+        }
+        e.preventDefault();
+        return;
+      }
       if (mapDrag) {
         const dx = e.clientX - mapDrag.lastX;
         const dy = e.clientY - mapDrag.lastY;
@@ -234,6 +311,20 @@ export function usePanTuneGesture(
     };
 
     const onPointerUp = (e: PointerEvent) => {
+      pointers.delete(e.pointerId);
+      if (pinch) {
+        if (canvas.hasPointerCapture(e.pointerId)) canvas.releasePointerCapture(e.pointerId);
+        if (pointers.size < 2) {
+          // End of pinch — discard any in-flight rAF and let the user lift +
+          // re-touch to start a fresh drag-to-tune. Re-entering drag from a
+          // post-pinch single finger leads to a jump tune, which is worse
+          // than an enforced clean break.
+          cancelPinchRaf();
+          pinch = null;
+          canvas.style.cursor = 'grab';
+        }
+        return;
+      }
       if (mapDrag) {
         mapDrag = null;
         canvas.style.cursor = 'grab';
@@ -309,6 +400,7 @@ export function usePanTuneGesture(
 
     return () => {
       if (pendingRaf !== 0) cancelAnimationFrame(pendingRaf);
+      cancelPinchRaf();
       pendingAbort?.abort();
       zoomInflight?.abort();
       canvas.removeEventListener('pointerdown', onPointerDown);


### PR DESCRIPTION
## Summary

A separate mobile layout that ships when the viewport is ≤900 px (or `?mobile=1` for desktop preview), instead of the legacy "hide-mobile chrome" approach. Reuses every existing widget — VfoDisplay, SMeterLive, Panadapter, Waterfall, MobilePttButton, TunButton, PsToggleButton, AudioToggle, BandButtons — in a vertical stack matching the Zeus Mobile design hand-off. **Tokens, palette, typography, and the controls themselves are unchanged from the desktop surface.**

- TopBar (Zeus mark + RADIO IP chip) → Frequency VFO → S-Meter → Panadapter (spectrum + waterfall) → MOX block (PTT, TUNE, PS, Mute) → Mode + Band selectors.
- **QRZ map background** mirrors desktop: when `qrzHome.lat/lon + hasXmlSubscription` are set, Esri tiles render behind the spectrum half. The waterfall stays opaque on mobile so signal traces don't blend into dark map tiles; the map is contextual decoration behind the spectrum where it's most useful.
- **Pinch-to-zoom** added to `usePanTuneGesture`. A second pointer initiates pinch, distance ratio drives integer zoom level via the existing `nudgeZoom` path. Single-pointer drag-to-tune behaviour preserved. `touch-action: none` on the canvases prevents the browser from hijacking the gesture.
- Architectural surface: one early `return` in `App.tsx`, two new files in `zeus-web/src/mobile/`, +92 lines in the gesture hook. Desktop tree untouched.

### Notes for the reviewer

- The shared `.freq-display` panel uses `font-size: clamp(38px, 26cqh, 140px)` — the 38 px floor overflows a small flex slot, so the mobile shell pins `.freq-display { min-height: 110px }`. Verified the digits sit cleanly inside the inset chrome at 402×874.
- The legacy `.hide-mobile` / `.show-mobile` classes are neutralised inside `.m-app` so each component's *desktop* variant renders (full BandButtons row instead of the dropdown).
- The Waterfall component bundles a γ contrast slider and Colormap+dB:FIXED chip for desktop; both are hidden on mobile (no room, not in scope).
- This is **red-light territory** per CLAUDE.md (visual design, UX behaviour). Brian explicitly authorised the work and constrained scope to "same controls + same palette, lay out per the design".

## Test plan

- [ ] `npm --prefix zeus-web run build` passes (verified locally — clean).
- [ ] On a phone, open `http://<lan-ip>:6060` — mobile shell renders automatically.
- [ ] On desktop, open `http://localhost:5173/?mobile=1` — same shell renders. Resizing the window across the 900 px breakpoint flips between desktop and mobile views without reload.
- [ ] Tap a mode segment → `setMode` POST goes through, segment lights immediately (optimistic).
- [ ] Tap a band button → VFO retunes via existing BandButtons memory.
- [ ] Hold the PTT button → MOX engages, LED + label flip to TX, release → MOX clears.
- [ ] Tap TUNE → tune carrier on; tap again → off.
- [ ] Tap Unmute → audio plays; label flips to Mute.
- [ ] **Pinch out on the panadapter canvas** → spectrum span narrows (zoom in). Pinch in → span widens (zoom out). Single-finger drag still tunes the VFO.
- [ ] If QRZ home + XML subscription are configured on desktop, the Esri world map appears behind the mobile spectrum within a few seconds (Leaflet tile load).
- [ ] Waterfall signal traces are clearly visible (not blended into the map).
- [ ] Desktop layout (>900 px) is unaffected — open the same URL in a wide window, original layout renders unchanged.