### PR TITLE
feat(layout): swap CW Keyer for Tuning Step in default side stack

### DIFF
--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -76,7 +76,7 @@ import { ZoomControl } from './components/ZoomControl';
 import { useSwUpdatePrompt } from './pwa/useSwUpdatePrompt';
 import { AzimuthMap } from './components/design/AzimuthMap';
 import { CONTACTS, bandOf } from './components/design/data';
-import { CwKeyer } from './components/design/CwKeyer';
+import { TuningStepWidget } from './components/TuningStepWidget';
 import { Dockable } from './components/design/Dockable';
 import { DspPanel } from './components/DspPanel';
 import { TxFilterPanel } from './components/TxFilterPanel';
@@ -887,7 +887,7 @@ export default function App() {
           </div>
         </div>
 
-        {/* Side stack — Freq, S-Meter, QRZ, DSP, CW (and Map when QRZ off) */}
+        {/* Side stack — Freq, S-Meter, QRZ, DSP, Step (and Map when QRZ off) */}
         <div className="side-stack">
           <div className="side-slot">
             <Dockable title="Frequency · VFO" ledOn>
@@ -955,8 +955,8 @@ export default function App() {
           </div>
 
           <div className="side-slot hide-mobile">
-            <Dockable title={`CW Keyer · ${wpm} WPM`} ledOn={mode === 'CWU' || mode === 'CWL'}>
-              <CwKeyer wpm={wpm} setWpm={setWpm} />
+            <Dockable title="Tuning Step" ledOn>
+              <TuningStepWidget />
             </Dockable>
           </div>
         </div>

--- a/zeus-web/src/layout/defaultLayout.ts
+++ b/zeus-web/src/layout/defaultLayout.ts
@@ -44,7 +44,7 @@
 
 // Default flexlayout-react model that replicates the current CSS grid:
 //   left column (75%): hero spectrum (70%) + bottom row [logbook + tx meters] (30%)
-//   right column (25%): VFO + SMeter + QRZ/Azimuth + DSP + CW (stacked)
+//   right column (25%): VFO + SMeter + QRZ/Azimuth + DSP + Step (stacked)
 //
 // Phase 1 — operators who never drag panels see the same screen as today.
 // Weights are approximate; flexlayout distributes remaining space proportionally.
@@ -139,7 +139,7 @@ export const DEFAULT_LAYOUT = {
             type: 'tabset',
             weight: 15,
             children: [
-              { type: 'tab', name: 'CW Keyer', component: 'cw' },
+              { type: 'tab', name: 'Tuning Step', component: 'step' },
             ],
           },
         ],


### PR DESCRIPTION
## Summary
- Default mode side stack now hosts **Tuning Step** in the slot previously occupied by CW Keyer.
- CW Keyer stays registered in the panel registry, so flex-mode users can still add it via each tabset's `+` picker — it's now opt-in only.
- Flex-mode initial layout (`DEFAULT_LAYOUT`) updated to match: a fresh flex workspace seeds Step instead of CW.

## Files changed
- `zeus-web/src/App.tsx` — swap `CwKeyer` → `TuningStepWidget` in the default side stack; drop the now-dead `CwKeyer` import; `wpm`/`setWpm` stay in `WorkspaceContext` because flex's `CwPanel` still consumes them.
- `zeus-web/src/layout/defaultLayout.ts` — bottom-right tabset seeds `step` (`Tuning Step`) instead of `cw` (`CW Keyer`); comment updated.

## Test plan
- [ ] Default layout shows Tuning Step in the bottom-right side slot, no CW Keyer in the side stack.
- [ ] Switch to flex layout (Settings → Display) — fresh workspace seeds Tuning Step in the bottom-right tabset.
- [ ] In flex mode, click the `+` on any tabset → Add Panel modal lists "CW Keyer" and adds it correctly.
- [ ] `npx tsc --noEmit` clean (verified).