### PR TITLE
refactor(tci): persist runtime config in LiteDB

### DIFF
--- a/Zeus.Server/Program.cs
+++ b/Zeus.Server/Program.cs
@@ -45,6 +45,7 @@
 using System.Net;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http.Json;
+using Microsoft.Extensions.Logging.Abstractions;
 using Zeus.Contracts;
 using Zeus.Dsp;
 using Zeus.Dsp.Wdsp;
@@ -83,6 +84,27 @@ var tciSection = builder.Configuration.GetSection("Tci");
 var tciEnabled = tciSection.GetValue<bool>("Enabled");
 var tciBindAddress = tciSection.GetValue<string?>("BindAddress") ?? "0.0.0.0";
 var tciPort = tciSection.GetValue<int?>("Port") ?? 40001;
+
+// Persisted runtime override (LiteDB). The TCI management API queues changes
+// here because Kestrel's listener can only be wired before host build; we
+// pick those changes up on the next start. Falls back to appsettings when
+// nothing has ever been persisted.
+TciRuntimeConfig? persistedTci = null;
+try
+{
+    using var bootstrapTciStore = new TciConfigStore(NullLogger<TciConfigStore>.Instance);
+    persistedTci = bootstrapTciStore.Get();
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine($"tci.config.bootstrap-load failed: {ex.Message}");
+}
+if (persistedTci is not null)
+{
+    tciEnabled = persistedTci.Enabled;
+    tciBindAddress = persistedTci.BindAddress;
+    tciPort = persistedTci.Port;
+}
 
 builder.WebHost.ConfigureKestrel(k =>
 {
@@ -162,6 +184,20 @@ builder.Services.AddHostedService(sp => sp.GetRequiredService<RotctldService>())
 // for remote control by loggers (Log4OM, N1MM+), digital-mode apps (JTDX, WSJT-X),
 // and SDR display tools. Disabled by default; enable via appsettings.json Tci:Enabled=true.
 builder.Services.Configure<TciOptions>(builder.Configuration.GetSection("Tci"));
+// PostConfigure applies the persisted runtime override (set via /api/tci/config
+// in a previous session) on top of appsettings, so in-process services see the
+// same Enabled/Bind/Port values that Kestrel just bound to.
+if (persistedTci is not null)
+{
+    var pendingTci = persistedTci;
+    builder.Services.PostConfigure<TciOptions>(o =>
+    {
+        o.Enabled = pendingTci.Enabled;
+        o.BindAddress = pendingTci.BindAddress;
+        o.Port = pendingTci.Port;
+    });
+}
+builder.Services.AddSingleton<TciConfigStore>();
 builder.Services.AddSingleton<SpotManager>();
 builder.Services.AddSingleton<TciServer>();
 builder.Services.AddHostedService(sp => sp.GetRequiredService<TciServer>());

--- a/Zeus.Server/TciConfigStore.cs
+++ b/Zeus.Server/TciConfigStore.cs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using LiteDB;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+// TCI runtime config persistence. Holds the operator's pending Enabled/Bind/Port
+// selection so it survives restarts — TCI shares Kestrel's listener, which
+// can only be configured at host build, so changes are queued here and
+// re-read at next startup. Lives in zeus-prefs.db alongside the other
+// non-sensitive preference stores.
+//
+// Single-row collection: there is one TCI server per Zeus instance, so a
+// profile key would just be ceremony. Everything else (PaSettings, PsSettings)
+// uses Upsert keyed by ProfileId; here the row identity is implicit.
+public sealed class TciConfigStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<TciConfigEntry> _entries;
+    private readonly ILogger<TciConfigStore> _log;
+    private readonly object _sync = new();
+
+    public TciConfigStore(ILogger<TciConfigStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? GetDatabasePath();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _entries = _db.GetCollection<TciConfigEntry>("tci_config");
+
+        _log.LogInformation("TciConfigStore initialized at {Path}", dbPath);
+    }
+
+    // null = nothing persisted yet — caller should fall back to appsettings.
+    public TciRuntimeConfig? Get()
+    {
+        lock (_sync)
+        {
+            var e = _entries.FindAll().FirstOrDefault();
+            if (e is null) return null;
+            return new TciRuntimeConfig(
+                Enabled: e.Enabled,
+                BindAddress: e.BindAddress,
+                Port: e.Port);
+        }
+    }
+
+    public void Set(TciRuntimeConfig config)
+    {
+        lock (_sync)
+        {
+            var existing = _entries.FindAll().FirstOrDefault();
+            if (existing is null)
+            {
+                _entries.Insert(new TciConfigEntry
+                {
+                    Enabled = config.Enabled,
+                    BindAddress = config.BindAddress,
+                    Port = config.Port,
+                    UpdatedUtc = DateTime.UtcNow,
+                });
+            }
+            else
+            {
+                existing.Enabled = config.Enabled;
+                existing.BindAddress = config.BindAddress;
+                existing.Port = config.Port;
+                existing.UpdatedUtc = DateTime.UtcNow;
+                _entries.Update(existing);
+            }
+        }
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private static string GetDatabasePath()
+    {
+        var appDataDir = Environment.GetFolderPath(
+            Environment.SpecialFolder.LocalApplicationData,
+            Environment.SpecialFolderOption.Create);
+        return Path.Combine(appDataDir, "Zeus", "zeus-prefs.db");
+    }
+}
+
+public sealed class TciConfigEntry
+{
+    public int Id { get; set; }
+    public bool Enabled { get; set; }
+    public string BindAddress { get; set; } = "127.0.0.1";
+    public int Port { get; set; } = 40001;
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server/TciManagementService.cs
+++ b/Zeus.Server/TciManagementService.cs
@@ -46,15 +46,16 @@ namespace Zeus.Server;
 /// <summary>
 /// Management service for TCI server configuration and status reporting.
 /// Since TCI uses Kestrel port binding (configured at startup), runtime
-/// changes require app restart. This service persists config changes to
-/// a local JSON file and reports current status including port availability.
+/// changes require app restart. This service persists config changes via
+/// TciConfigStore (LiteDB) and reports current status including port
+/// availability.
 /// </summary>
 public sealed class TciManagementService
 {
     private readonly ILogger<TciManagementService> _log;
     private readonly TciServer _tciServer;
     private readonly TciOptions _startupOptions;
-    private readonly string _configPath;
+    private readonly TciConfigStore _store;
 
     // In-memory pending config (what the user wants for next restart)
     private TciRuntimeConfig _pendingConfig;
@@ -63,24 +64,20 @@ public sealed class TciManagementService
         ILogger<TciManagementService> log,
         TciServer tciServer,
         IOptions<TciOptions> options,
-        IHostEnvironment env)
+        TciConfigStore store)
     {
         _log = log;
         _tciServer = tciServer;
         _startupOptions = options.Value;
+        _store = store;
 
-        // Persist config in app data directory
-        var dataPath = Path.Combine(env.ContentRootPath, "App_Data");
-        Directory.CreateDirectory(dataPath);
-        _configPath = Path.Combine(dataPath, "tci-config.json");
-
-        // Load or initialize pending config
-        _pendingConfig = LoadPersistedConfig() ?? new TciRuntimeConfig
-        {
-            Enabled = _startupOptions.Enabled,
-            BindAddress = _startupOptions.BindAddress,
-            Port = _startupOptions.Port,
-        };
+        // Load or initialize pending config from the persisted store. When
+        // nothing is persisted yet, mirror the startup options so a "no
+        // change" GetStatus() reports RequiresRestart=false.
+        _pendingConfig = _store.Get() ?? new TciRuntimeConfig(
+            Enabled: _startupOptions.Enabled,
+            BindAddress: _startupOptions.BindAddress,
+            Port: _startupOptions.Port);
     }
 
     public TciStatus GetStatus()
@@ -124,17 +121,22 @@ public sealed class TciManagementService
     public TciStatus SetConfig(TciRuntimeConfig config)
     {
         // Validate and normalize
-        var normalized = new TciRuntimeConfig
-        {
-            Enabled = config.Enabled,
-            BindAddress = string.IsNullOrWhiteSpace(config.BindAddress)
+        var normalized = new TciRuntimeConfig(
+            Enabled: config.Enabled,
+            BindAddress: string.IsNullOrWhiteSpace(config.BindAddress)
                 ? "127.0.0.1"
                 : config.BindAddress.Trim(),
-            Port = config.Port is > 0 and < 65536 ? config.Port : 40001,
-        };
+            Port: config.Port is > 0 and < 65536 ? config.Port : 40001);
 
         _pendingConfig = normalized;
-        PersistConfig(normalized);
+        try
+        {
+            _store.Set(normalized);
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "tci.config.persist failed");
+        }
 
         _log.LogInformation(
             "tci.config.updated enabled={Enabled} bind={Bind} port={Port} (restart required)",
@@ -194,34 +196,4 @@ public sealed class TciManagementService
         }
     }
 
-    private TciRuntimeConfig? LoadPersistedConfig()
-    {
-        try
-        {
-            if (!File.Exists(_configPath)) return null;
-            var json = File.ReadAllText(_configPath);
-            return System.Text.Json.JsonSerializer.Deserialize<TciRuntimeConfig>(json);
-        }
-        catch (Exception ex)
-        {
-            _log.LogWarning(ex, "tci.config.load failed, using defaults");
-            return null;
-        }
-    }
-
-    private void PersistConfig(TciRuntimeConfig config)
-    {
-        try
-        {
-            var json = System.Text.Json.JsonSerializer.Serialize(config, new System.Text.Json.JsonSerializerOptions
-            {
-                WriteIndented = true
-            });
-            File.WriteAllText(_configPath, json);
-        }
-        catch (Exception ex)
-        {
-            _log.LogWarning(ex, "tci.config.persist failed");
-        }
-    }
 }


### PR DESCRIPTION
## Summary

- TCI management was the only settings store using file IO under the repo's ContentRoot — `Zeus.Server/App_Data/tci-config.json`. Every other settings store (`PreferredRadioStore`, `LayoutStore`, `PsSettingsStore`, `PaSettingsStore`, `FilterPresetStore`, etc.) persists to `zeus-prefs.db` in `LocalApplicationData`. This PR closes that gap and stops `App_Data/` from materialising in the dev tree on every run.
- New `Zeus.Server/TciConfigStore.cs` — single-row LiteDB collection (`tci_config` in `zeus-prefs.db`), Get/Set, mirrors the `PreferredRadioStore` / `PsSettingsStore` pattern.
- `TciManagementService` now injects `TciConfigStore` and drops the `System.Text.Json` file IO path.
- `Program.cs` reads any persisted override before Kestrel binds (so restart picks up the operator's queued Enabled/Bind/Port) and `PostConfigure<TciOptions>` propagates the same values to in-process services (`TciServer`, `TciSession`).

## Test plan

- [x] `dotnet build Zeus.slnx` — clean, 0 warnings
- [x] `dotnet test Zeus.slnx` — all suites pass (Protocol1, Protocol2, Contracts, Server, Dsp). No tests reference `App_Data` / the JSON path so nothing needed updating.
- [ ] Live smoke: start server, hit `POST /api/tci/config` with a different bind/port, restart, confirm next start binds to the persisted values (Kestrel listener and DI-bound `TciOptions`).
- [ ] Confirm `Zeus.Server/App_Data/` is no longer recreated under the repo on dev runs.

## Notes

- No migration of any existing `App_Data/tci-config.json` — feature is recent and the file was a developer-only artefact (lived in the repo dir). On first start with no LiteDB record, the store falls through to `appsettings.json` defaults, which matches the prior fallback behaviour.