### PR TITLE
fix(web/connect): make first-run wisdom-build wait unmistakable (#177)

### DIFF
--- a/zeus-web/src/components/ConnectPanel.tsx
+++ b/zeus-web/src/components/ConnectPanel.tsx
@@ -570,21 +570,21 @@ export function ConnectPanel() {
                       <button
                         type="button"
                         onClick={() => handleConnect(r)}
-                        disabled={r.busy || inflight || (dspPreparing && !isP2)}
+                        disabled={r.busy || inflight || dspPreparing}
                         title={
                           r.busy
                             ? 'Radio is busy (in use by another client)'
-                            : dspPreparing && !isP2
-                              ? 'DSP is preparing FFTW plans (first-run only, up to ~2 min)'
+                            : dspPreparing
+                              ? 'DSP is preparing FFTW plans — first-run only. Please leave the app open and wait.'
                               : isP2
                                 ? 'Protocol 2 path — experimental, RX only'
                                 : undefined
                         }
-                        className={`btn sm ${r.busy ? '' : 'active'} ${dspPreparing && !isP2 ? 'pulsing' : ''}`}
+                        className={`btn sm ${r.busy ? '' : 'active'} ${dspPreparing ? 'pulsing' : ''}`}
                       >
                         {r.busy
                           ? 'Busy'
-                          : dspPreparing && !isP2
+                          : dspPreparing
                             ? 'Preparing DSP…'
                             : inflight
                               ? 'Connecting…'
@@ -627,6 +627,72 @@ export function ConnectPanel() {
         )}
       </div>
       </div>
+      {dspPreparing && (
+        <div
+          role="status"
+          aria-live="polite"
+          aria-label="First-run DSP setup in progress"
+          style={{
+            position: 'absolute',
+            inset: 0,
+            zIndex: 3,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 14,
+            padding: '24px 28px',
+            textAlign: 'center',
+            background: 'var(--bg-1)',
+            boxShadow: 'inset 0 0 0 1px var(--panel-border)',
+          }}
+        >
+          <span
+            className="label-xs"
+            style={{
+              color: 'var(--accent)',
+              fontSize: 11,
+              letterSpacing: '0.18em',
+            }}
+          >
+            First-run setup
+          </span>
+          <span
+            className="mono"
+            style={{
+              color: 'var(--fg-0)',
+              fontSize: 20,
+              fontWeight: 700,
+              letterSpacing: '0.04em',
+            }}
+          >
+            Preparing DSP…
+          </span>
+          <span
+            style={{
+              color: 'var(--fg-1)',
+              fontSize: 12,
+              lineHeight: 1.5,
+              maxWidth: 380,
+            }}
+          >
+            Zeus is building FFTW plans for WDSP. This is a one-time step
+            the first time Zeus runs on this machine and may take several
+            minutes — please leave the app open and wait. Subsequent
+            startups are fast.
+          </span>
+          <span
+            className="label-xs"
+            style={{
+              color: 'var(--fg-3)',
+              fontSize: 10,
+              letterSpacing: '0.14em',
+            }}
+          >
+            Connect will become available automatically when DSP is ready
+          </span>
+        </div>
+      )}
     </div>
   );
 }
@@ -666,7 +732,7 @@ const fieldLabelStyle: React.CSSProperties = {
 };
 
 function ManualMode(p: ManualModeProps) {
-  const canConnect = !p.inflight && !(p.dspPreparing && p.protocol === 'P1');
+  const canConnect = !p.inflight && !p.dspPreparing;
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
       <div
@@ -775,12 +841,17 @@ function ManualMode(p: ManualModeProps) {
         type="button"
         onClick={p.onConnect}
         disabled={!canConnect}
-        className={`btn lg ${canConnect ? 'active' : ''} ${p.dspPreparing && p.protocol === 'P1' ? 'pulsing' : ''}`}
+        title={
+          p.dspPreparing
+            ? 'DSP is preparing FFTW plans — first-run only. Please leave the app open and wait.'
+            : undefined
+        }
+        className={`btn lg ${canConnect ? 'active' : ''} ${p.dspPreparing ? 'pulsing' : ''}`}
         style={{ alignSelf: 'stretch' }}
       >
         {p.inflight
           ? 'Connecting…'
-          : p.dspPreparing && p.protocol === 'P1'
+          : p.dspPreparing
             ? 'Preparing DSP…'
             : 'Connect'}
       </button>


### PR DESCRIPTION
## Summary
Closes #177 — surfaces the FFTW wisdom-build wait as a full-panel overlay on the splash ConnectPanel so the first-run "Preparing DSP…" period reads as a real, in-progress one-time setup step rather than a hung UI.

- Adds an absolute overlay covering panel chrome + body that explicitly tells the user this is a first-run, one-time step, asks them to leave the app open, and tells them Connect will re-enable automatically. Uses only existing tokens (`--bg-1`, `--panel-border`, `--accent`, `--fg-0/1/3`) and Archivo Narrow.
- Un-gates the disable + "Preparing DSP…" button label and pulsing cue from P1-only to **all** paths (Discover Connect, Manual Connect, P1, P2). Wisdom is built once at server startup and gates every connect path, so the prior P1-only treatment was a bug — P2 users could click Connect mid-build and silently fall back to synthetic DSP.
- Drops the stale "~2 min" tooltip estimate; slower first boots overrun it and it reads as a stalled UI rather than guidance.

No wire-format / `Zeus.Contracts` / backend changes. No new packages or tokens.

Visual prominence (full-panel overlay vs. inline notice) was directed by maintainer triage on the issue; final visual sign-off remains with EI6LF.

## Test plan
- [x] `dotnet build Zeus.slnx` — green
- [x] `npm --prefix zeus-web run typecheck` — green
- [x] `npm --prefix zeus-web test` — 66/66 pass
- [x] Rack-tested locally with wisdom file deleted: full-panel overlay appears immediately on splash, Connect button shows "Preparing DSP…" pulse, overlay clears and Connect re-enables once `wdsp.wisdom ready` fires.
- [ ] Maintainer (EI6LF) visual sign-off on overlay copy/styling.

Refs: #177