### PR TITLE
feat(background): selectable panadapter background — Basic / Beam Map / Image

### DIFF
--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -99,6 +99,7 @@ import { useRotatorStore } from './state/rotator-store';
 import { useLoggerStore } from './state/logger-store';
 import { useTxStore } from './state/tx-store';
 import { useLayoutPreferenceStore } from './state/layout-preference-store';
+import { useDisplaySettingsStore } from './state/display-settings-store';
 import { useKeyboardShortcuts } from './util/use-keyboard-shortcuts';
 import { SpectrumWheelActionsContext, type SpectrumWheelActions } from './util/use-pan-tune-gesture';
 import { registerServiceWorker } from './service-worker/registerSW';
@@ -228,8 +229,17 @@ export default function App() {
 
   // --- Design-mock state (QRZ, DSP grid toggles, CW WPM, memories) ---
   const [callsign, setCallsign] = useState('');
-  const [terminatorActive, setTerminatorActive] = useState(true);
-  // While 'M' is held and QRZ is engaged, the spectrum canvas stack goes
+  // Panadapter background is now driven by the Display settings panel
+  // (display-settings-store): 'basic' | 'beam-map' | 'image'. terminatorActive
+  // (= map + terminator chrome visible) is derived from 'beam-map'; imageMode
+  // is derived from 'image' + a loaded image.
+  const panBackground = useDisplaySettingsStore((s) => s.panBackground);
+  const backgroundImage = useDisplaySettingsStore((s) => s.backgroundImage);
+  const backgroundImageFit = useDisplaySettingsStore((s) => s.backgroundImageFit);
+  const terminatorActive = panBackground === 'beam-map';
+  const imageMode = panBackground === 'image' && !!backgroundImage;
+  const bgActive = terminatorActive || imageMode;
+  // While 'M' is held and the map is showing, the spectrum canvas stack goes
   // pointer-events:none and the Leaflet map underneath takes drag/zoom input.
   // Click-to-tune is suspended for the duration of the modifier.
   const [mapModifier, setMapModifier] = useState(false);
@@ -360,18 +370,19 @@ export default function App() {
     },
   }), []);
 
-  const engageTerminator = useCallback((cs?: string) => {
+  // QRZ is now passively engaged whenever the user has it configured (see
+  // qrzActive below) — there is no separate engage/disengage step. Submitting
+  // a callsign just runs a lookup; the contact card / chips render off the
+  // resulting `contact` regardless of what's drawn behind the panadapter.
+  const runQrzLookup = useCallback((cs?: string) => {
     const target = (cs ?? callsign).toUpperCase();
     setCallsign(target);
-    setTerminatorActive(true);
     setEnriching(true);
     setLookupKey((k) => k + 1);
     setBeamOverrideDeg(null);
     setBeamInputStr('');
     const qrz = useQrzStore.getState();
     if (qrz.connected && qrz.hasXmlSubscription) {
-      // Real QRZ lookup. The store updates lastLookup on success; the enriching
-      // scan animation keeps playing until the promise settles.
       qrz.lookup(target).finally(() => setEnriching(false));
     } else {
       // Design-mock fallback: CONTACTS lookup is synchronous; just run the scan
@@ -379,11 +390,6 @@ export default function App() {
       setTimeout(() => setEnriching(false), 700);
     }
   }, [callsign]);
-
-  const disengageTerminator = useCallback(() => {
-    setTerminatorActive(false);
-    setEnriching(false);
-  }, []);
 
   // `/` focuses the callsign input so the operator can type a call and hit Enter.
   useEffect(() => {
@@ -436,7 +442,7 @@ export default function App() {
 
   const onCallsignSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    engageTerminator();
+    runQrzLookup();
   };
 
   const bandLabel = bandOf(vfoHz);
@@ -549,6 +555,11 @@ export default function App() {
     callsign,
     setCallsign,
     terminatorActive,
+    imageMode,
+    bgActive,
+    panBackground,
+    backgroundImage,
+    backgroundImageFit,
     enriching,
     lookupKey,
     contact,
@@ -568,8 +579,7 @@ export default function App() {
     dist,
     heroTitle,
     csInputRef,
-    engageTerminator,
-    disengageTerminator,
+    runQrzLookup,
     onCallsignSubmit,
     submitBeam,
     handleLogQso,
@@ -580,13 +590,15 @@ export default function App() {
     logbookActions,
   }), [
     connected, moxOn, tunOn, mode, vfoHz,
-    callsign, terminatorActive, enriching, lookupKey, contact,
+    callsign, terminatorActive, imageMode, bgActive, panBackground,
+    backgroundImage, backgroundImageFit,
+    enriching, lookupKey, contact,
     qrzLookupError, qrzActive, mapAvailable, mapInteractive, effectiveHome,
     beamOverrideDeg, beamInputStr, rotLiveAz, sp, lp, dist,
     // heroTitle and logbookActions are ReactNodes (new objects each render);
     // their underlying primitive deps are already above, so omit them here.
     dspActive, wpm, logbookTitle,
-    handleLogQso, engageTerminator, disengageTerminator,
+    handleLogQso, runQrzLookup,
   ]);
 
   // Mobile viewport short-circuit. All initialization hooks above (realtime,
@@ -691,15 +703,6 @@ export default function App() {
 
         <button
           type="button"
-          className={`btn qrz-btn hide-mobile ${terminatorActive ? 'active' : ''}`}
-          onClick={() => (terminatorActive ? disengageTerminator() : engageTerminator())}
-        >
-          <span className="led on" style={{ marginRight: 6 }} />
-          {terminatorActive ? 'QRZ ENGAGED' : 'Engage QRZ'}
-        </button>
-
-        <button
-          type="button"
           className="btn"
           onClick={() => setSettingsOpen(true)}
           title="Open settings menu"
@@ -755,8 +758,9 @@ export default function App() {
             and the `has-filter-ribbon` class is absent, so the workspace
             collapses to its original two-row layout. */}
         <FilterRibbon />
-        {/* Hero — spectrum + waterfall with QRZ world-map layer */}
-        <div className={`panel hero ${terminatorActive ? 'qrz-mode' : ''} ${mapInteractive ? 'map-mode' : ''}`}>
+        {/* Hero — spectrum + waterfall over an optional background overlay
+            (Beam Map or user image), driven by display-settings-store. */}
+        <div className={`panel hero ${bgActive ? 'bg-active' : ''} ${mapInteractive ? 'map-mode' : ''}`}>
           <div className="panel-head">
             <span className={`dot ${moxOn || tunOn ? 'tx' : 'on'}`} />
             <span className="title">{heroTitle}</span>
@@ -818,6 +822,12 @@ export default function App() {
             <HzPerPixelChip />
           </div>
           <div className="panel-body hero-body">
+            {imageMode && (
+              <div
+                className={`image-layer ${backgroundImageFit}`}
+                style={{ backgroundImage: `url(${backgroundImage})` }}
+              />
+            )}
             <div className={`map-layer ${terminatorActive ? 'visible' : ''}`}>
               <LeafletMapErrorBoundary
                 onError={(error) => {
@@ -880,7 +890,7 @@ export default function App() {
               }}
             >
               {connected && <Panadapter />}
-              {connected && <Waterfall transparent={terminatorActive} />}
+              {connected && <Waterfall transparent={bgActive} />}
             </div>
             {/* Mobile vertical zoom slider — hidden on desktop via CSS */}
             <div className="show-mobile" style={{ display: 'none' }}>
@@ -904,11 +914,10 @@ export default function App() {
             </Dockable>
           </div>
 
-          {/* QRZ.com Lookup sits under the S-Meter when the operator has
-              the QRZ button engaged. Only renders while terminator is
-              active — when QRZ is off the slot collapses and DSP moves
-              up, matching the operator's "QRZ on demand" workflow. */}
-          {terminatorActive && (
+          {/* QRZ.com Lookup is visible whenever QRZ is configured (XML
+              subscription + station home loaded). When QRZ is not
+              configured the slot collapses and DSP moves up. */}
+          {qrzActive && (
             <div className="side-slot grow hide-mobile">
               <Dockable
                 title="QRZ.com Lookup"

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -55,6 +55,7 @@ import { ConnectPanel } from './components/ConnectPanel';
 import { MicMeter } from './components/MicMeter';
 import { MobilePttButton } from './components/MobilePttButton';
 import { MobileZoomSlider } from './components/MobileZoomSlider';
+import { ZoomControl } from './components/ZoomControl';
 import { ModeBandwidth } from './components/ModeBandwidth';
 import { ModeFavorites } from './components/toolbar/ModeFavorites';
 import { BandFavorites } from './components/toolbar/BandFavorites';
@@ -75,7 +76,6 @@ import { OverdriveIndicator, TxStageMeters } from './components/TxStageMeters';
 import { TunButton } from './components/TunButton';
 import { VfoDisplay } from './components/VfoDisplay';
 import { Waterfall } from './components/Waterfall';
-import { ZoomControl } from './components/ZoomControl';
 import { useSwUpdatePrompt } from './pwa/useSwUpdatePrompt';
 import { AzimuthMap } from './components/design/AzimuthMap';
 import { CONTACTS, bandOf } from './components/design/data';
@@ -712,8 +712,11 @@ export default function App() {
       <div className="control-strip">
         <div className="hide-mobile" style={{ display: 'contents' }}>
           <ModeFavorites />
+          <span className="strip-divider" aria-hidden="true" />
           <FilterPanel />
+          <span className="strip-divider" aria-hidden="true" />
           <BandFavorites />
+          <span className="strip-divider" aria-hidden="true" />
           <StepFavorites />
         </div>
         <div className="show-mobile" style={{ display: 'none', gap: 8 }}>
@@ -737,12 +740,6 @@ export default function App() {
           <AfGainSlider />
         </div>
         <div className="spacer hide-mobile" style={{ flex: 1 }} />
-        <div className="ctrl-group hide-mobile" style={{ minWidth: 160 }}>
-          <div className="label-xs ctrl-lbl">ZOOM</div>
-          <div className="btn-row" style={{ gap: 10 }}>
-            <ZoomControl />
-          </div>
-        </div>
       </div>
 
       <AlertBanner />
@@ -817,6 +814,7 @@ export default function App() {
                 <span className="v">+ −</span>
               </span>
             )}
+            <ZoomControl />
             <HzPerPixelChip />
           </div>
           <div className="panel-body hero-body">

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -56,6 +56,9 @@ import { MicMeter } from './components/MicMeter';
 import { MobilePttButton } from './components/MobilePttButton';
 import { MobileZoomSlider } from './components/MobileZoomSlider';
 import { ModeBandwidth } from './components/ModeBandwidth';
+import { ModeFavorites } from './components/toolbar/ModeFavorites';
+import { BandFavorites } from './components/toolbar/BandFavorites';
+import { StepFavorites } from './components/toolbar/StepFavorites';
 import { FilterPanel } from './components/filter/FilterPanel';
 import { FilterRibbon, useFilterRibbonOpenSync } from './components/filter/FilterRibbon';
 import { MoxButton } from './components/MoxButton';
@@ -708,9 +711,10 @@ export default function App() {
       {/* Control strip — real wired controls rebuilt into the design's chassis */}
       <div className="control-strip">
         <div className="hide-mobile" style={{ display: 'contents' }}>
-          <ModeBandwidth />
+          <ModeFavorites />
           <FilterPanel />
-          <BandButtons />
+          <BandFavorites />
+          <StepFavorites />
         </div>
         <div className="show-mobile" style={{ display: 'none', gap: 8 }}>
           <ModeBandwidth />

--- a/zeus-web/src/components/BackgroundSettingsPanel.tsx
+++ b/zeus-web/src/components/BackgroundSettingsPanel.tsx
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+import { useRef, useState } from 'react';
+import {
+  useDisplaySettingsStore,
+  type BackgroundImageFit,
+  type PanBackgroundMode,
+} from '../state/display-settings-store';
+
+const MODE_OPTIONS: ReadonlyArray<{ id: PanBackgroundMode; label: string; help: string }> = [
+  { id: 'basic', label: 'Basic', help: 'Plain panadapter and waterfall — no overlay.' },
+  { id: 'beam-map', label: 'Beam Map', help: 'World map behind the panadapter, with QRZ contact and rotator overlays when configured.' },
+  { id: 'image', label: 'Image', help: 'Show a custom image behind the panadapter.' },
+];
+
+const FIT_OPTIONS: ReadonlyArray<{ id: BackgroundImageFit; label: string }> = [
+  { id: 'fit', label: 'Fit' },
+  { id: 'fill', label: 'Fill' },
+  { id: 'stretch', label: 'Stretch' },
+];
+
+// Downscale large images on the way into localStorage so a phone-camera
+// JPEG doesn't blow the ~5 MB browser quota. We never upscale; if the
+// source is already <= MAX_DIM on its longest edge it passes through
+// unchanged. JPEG quality 0.85 is a sweet spot for photographs; PNGs are
+// re-encoded as JPEG since the panadapter background never benefits from
+// alpha or lossless edges.
+const MAX_DIM = 1920;
+const JPEG_QUALITY = 0.85;
+
+async function fileToCompressedDataUrl(file: File): Promise<string> {
+  const url = URL.createObjectURL(file);
+  try {
+    const img = await loadImage(url);
+    const longest = Math.max(img.naturalWidth, img.naturalHeight);
+    const scale = longest > MAX_DIM ? MAX_DIM / longest : 1;
+    const w = Math.max(1, Math.round(img.naturalWidth * scale));
+    const h = Math.max(1, Math.round(img.naturalHeight * scale));
+    const canvas = document.createElement('canvas');
+    canvas.width = w;
+    canvas.height = h;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error('Canvas 2D unavailable');
+    ctx.drawImage(img, 0, 0, w, h);
+    return canvas.toDataURL('image/jpeg', JPEG_QUALITY);
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('Image decode failed'));
+    img.src = src;
+  });
+}
+
+export function BackgroundSettingsPanel() {
+  const panBackground = useDisplaySettingsStore((s) => s.panBackground);
+  const setPanBackground = useDisplaySettingsStore((s) => s.setPanBackground);
+  const backgroundImage = useDisplaySettingsStore((s) => s.backgroundImage);
+  const setBackgroundImage = useDisplaySettingsStore((s) => s.setBackgroundImage);
+  const backgroundImageFit = useDisplaySettingsStore((s) => s.backgroundImageFit);
+  const setBackgroundImageFit = useDisplaySettingsStore((s) => s.setBackgroundImageFit);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [dropActive, setDropActive] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleFile = async (file: File | null | undefined) => {
+    if (!file) return;
+    if (!file.type.startsWith('image/')) {
+      setError('Not an image file.');
+      return;
+    }
+    setError(null);
+    setBusy(true);
+    try {
+      const dataUrl = await fileToCompressedDataUrl(file);
+      const ok = setBackgroundImage(dataUrl);
+      if (!ok) {
+        setError('Browser refused to store the image (quota exceeded). Try a smaller picture.');
+      } else if (panBackground !== 'image') {
+        setPanBackground('image');
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onDragEnter = (e: React.DragEvent) => {
+    e.preventDefault();
+    if (e.dataTransfer?.types.includes('Files')) setDropActive(true);
+  };
+  const onDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'copy';
+  };
+  const onDragLeave = (e: React.DragEvent) => {
+    if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
+    setDropActive(false);
+  };
+  const onDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setDropActive(false);
+    const file = e.dataTransfer.files?.[0];
+    void handleFile(file);
+  };
+
+  return (
+    <section>
+      <h3 style={sectionH3}>Panadapter Background</h3>
+      <p style={sectionP}>
+        Choose what's drawn behind the panadapter and waterfall. Beam Map needs
+        QRZ configured under the QRZ tab to populate contact lookups.
+      </p>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {MODE_OPTIONS.map((opt) => {
+          const active = panBackground === opt.id;
+          return (
+            <label key={opt.id} style={modeRowStyle(active)}>
+              <input
+                type="radio"
+                name="pan-background"
+                value={opt.id}
+                checked={active}
+                onChange={() => setPanBackground(opt.id)}
+                style={{ cursor: 'pointer' }}
+              />
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--fg-0)' }}>{opt.label}</div>
+                <div style={{ fontSize: 11, color: 'var(--fg-2)', marginTop: 2 }}>{opt.help}</div>
+              </div>
+            </label>
+          );
+        })}
+      </div>
+
+      {panBackground === 'image' && (
+        <div style={{ marginTop: 16, display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <div
+            onDragEnter={onDragEnter}
+            onDragOver={onDragOver}
+            onDragLeave={onDragLeave}
+            onDrop={onDrop}
+            onClick={() => fileInputRef.current?.click()}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') fileInputRef.current?.click(); }}
+            style={dropZoneStyle(dropActive)}
+          >
+            {backgroundImage ? (
+              <img
+                src={backgroundImage}
+                alt="Background preview"
+                style={{
+                  maxWidth: '100%',
+                  maxHeight: 140,
+                  borderRadius: 'var(--r-xs)',
+                  display: 'block',
+                  margin: '0 auto',
+                }}
+              />
+            ) : (
+              <div style={{ textAlign: 'center', color: 'var(--fg-2)', fontSize: 12 }}>
+                {dropActive ? 'Release to load image' : 'Drop an image here, or click to choose a file'}
+              </div>
+            )}
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              style={{ display: 'none' }}
+              onChange={(e) => {
+                void handleFile(e.target.files?.[0]);
+                e.currentTarget.value = '';
+              }}
+            />
+          </div>
+
+          {busy && <div style={{ fontSize: 11, color: 'var(--fg-2)' }}>Processing…</div>}
+          {error && <div style={{ fontSize: 11, color: 'var(--tx)' }}>{error}</div>}
+
+          <div>
+            <div style={{ fontSize: 11, fontWeight: 600, color: 'var(--fg-1)', marginBottom: 6 }}>
+              Sizing
+            </div>
+            <div style={{ display: 'flex', gap: 6 }}>
+              {FIT_OPTIONS.map((opt) => {
+                const active = backgroundImageFit === opt.id;
+                return (
+                  <button
+                    key={opt.id}
+                    type="button"
+                    className={`btn sm ${active ? 'active' : ''}`}
+                    onClick={() => setBackgroundImageFit(opt.id)}
+                  >
+                    {opt.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {backgroundImage && (
+            <button
+              type="button"
+              className="btn sm"
+              style={{ alignSelf: 'flex-start' }}
+              onClick={() => setBackgroundImage(null)}
+            >
+              CLEAR IMAGE
+            </button>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+const sectionH3: React.CSSProperties = {
+  margin: '0 0 10px 0',
+  fontSize: 11,
+  fontWeight: 700,
+  letterSpacing: '0.12em',
+  textTransform: 'uppercase',
+  color: 'var(--fg-0)',
+};
+const sectionP: React.CSSProperties = {
+  margin: '0 0 12px 0',
+  fontSize: 12,
+  lineHeight: 1.5,
+  color: 'var(--fg-2)',
+};
+function modeRowStyle(active: boolean): React.CSSProperties {
+  return {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    padding: '8px 12px',
+    borderRadius: 'var(--r-sm)',
+    background: active ? 'var(--bg-2)' : 'transparent',
+    border: '1px solid',
+    borderColor: active ? 'var(--accent)' : 'var(--line)',
+    cursor: 'pointer',
+    transition: 'all var(--dur-fast)',
+  };
+}
+function dropZoneStyle(active: boolean): React.CSSProperties {
+  return {
+    border: '2px dashed',
+    borderColor: active ? 'var(--accent)' : 'var(--line)',
+    borderRadius: 'var(--r-sm)',
+    padding: 14,
+    cursor: 'pointer',
+    background: active ? 'rgba(74, 158, 255, 0.06)' : 'rgba(255,255,255,0.02)',
+    transition: 'all var(--dur-fast)',
+  };
+}

--- a/zeus-web/src/components/BandButtons.tsx
+++ b/zeus-web/src/components/BandButtons.tsx
@@ -53,6 +53,7 @@ import {
 } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
 import { BANDS, bandOf } from './design/data';
+import { toolbarFavDragMime } from './toolbar/ToolbarFavorites';
 
 type BandEntry = {
   name: string;
@@ -161,8 +162,14 @@ export function BandButtons() {
             <button
               key={band.name}
               type="button"
+              draggable
+              onDragStart={(e) => {
+                e.dataTransfer.setData(toolbarFavDragMime('band'), band.name);
+                e.dataTransfer.effectAllowed = 'move';
+              }}
               onClick={() => selectBand(band)}
               className={`btn sm ${currentBand === band.name ? 'active' : ''}`}
+              title={`${band.name} — drag onto a toolbar favorite slot to pin`}
             >
               {band.name}
             </button>

--- a/zeus-web/src/components/DisplayPanel.tsx
+++ b/zeus-web/src/components/DisplayPanel.tsx
@@ -21,6 +21,7 @@
 
 import { useLayoutPreferenceStore, type LayoutMode } from '../state/layout-preference-store';
 import { useLayoutStore } from '../state/layout-store';
+import { BackgroundSettingsPanel } from './BackgroundSettingsPanel';
 
 export function DisplayPanel() {
   const layoutMode = useLayoutPreferenceStore((s) => s.layoutMode);
@@ -42,6 +43,8 @@ export function DisplayPanel() {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+      <BackgroundSettingsPanel />
+
       <section>
         <h3 style={{
           margin: '0 0 10px 0',

--- a/zeus-web/src/components/ModeBandwidth.tsx
+++ b/zeus-web/src/components/ModeBandwidth.tsx
@@ -45,6 +45,7 @@
 import { useCallback } from 'react';
 import { setMode, type RxMode } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import { toolbarFavDragMime } from './toolbar/ToolbarFavorites';
 
 type ModeEntry = { value: RxMode; label: string };
 
@@ -88,8 +89,14 @@ export function ModeBandwidth() {
             <button
               key={m.value}
               type="button"
+              draggable
+              onDragStart={(e) => {
+                e.dataTransfer.setData(toolbarFavDragMime('mode'), m.value);
+                e.dataTransfer.effectAllowed = 'move';
+              }}
               onClick={() => selectMode(m.value)}
               className={`btn sm ${mode === m.value ? 'active' : ''}`}
+              title={`${m.label} — drag onto a toolbar favorite slot to pin`}
             >
               {m.label}
             </button>

--- a/zeus-web/src/components/TuningStepWidget.tsx
+++ b/zeus-web/src/components/TuningStepWidget.tsx
@@ -42,7 +42,8 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
-import { useState } from 'react';
+import { useToolbarFavoritesStore } from '../state/toolbar-favorites-store';
+import { toolbarFavDragMime } from './toolbar/ToolbarFavorites';
 
 type TuningStep = {
   hz: number;
@@ -66,10 +67,9 @@ const TUNING_STEPS: readonly TuningStep[] = [
   { hz: 1_000_000, label: '1 MHz' },
 ];
 
-const DEFAULT_STEP_HZ = 500;
-
 export function TuningStepWidget() {
-  const [stepHz, setStepHz] = useState<number>(DEFAULT_STEP_HZ);
+  const stepHz = useToolbarFavoritesStore((s) => s.stepHz);
+  const setStepHz = useToolbarFavoritesStore((s) => s.setStepHz);
 
   return (
     <>
@@ -82,9 +82,14 @@ export function TuningStepWidget() {
             <button
               key={step.hz}
               type="button"
+              draggable
+              onDragStart={(e) => {
+                e.dataTransfer.setData(toolbarFavDragMime('step'), String(step.hz));
+                e.dataTransfer.effectAllowed = 'move';
+              }}
               onClick={() => setStepHz(step.hz)}
               className={`btn sm ${stepHz === step.hz ? 'active' : ''}`}
-              title={`Wheel-on-digit step: ${step.label}`}
+              title={`${step.label} — drag onto a toolbar favorite slot to pin`}
             >
               {step.label}
             </button>

--- a/zeus-web/src/components/ZoomControl.tsx
+++ b/zeus-web/src/components/ZoomControl.tsx
@@ -46,6 +46,10 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { setZoom, ZOOM_MAX, ZOOM_MIN, type ZoomLevel } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
 
+// Compact zoom slider styled as a panel-head chip. Lives in the hero
+// panel header (above the panadapter) so the operator always sees the
+// current zoom level alongside HZ/PX. Uses the same abort-inflight
+// pattern as use-keyboard-shortcuts so rapid drags don't queue POSTs.
 export function ZoomControl() {
   const serverZoom = useConnectionStore((s) => s.zoomLevel);
   const setLocalZoom = useConnectionStore((s) => s.setZoomLevel);
@@ -85,8 +89,8 @@ export function ZoomControl() {
   };
 
   return (
-    <label className="knob-group">
-      <span className="label-xs">ZOOM</span>
+    <label className="chip mono" style={{ gap: 6, alignItems: 'center' }}>
+      <span className="k">ZOOM</span>
       <input
         type="range"
         min={ZOOM_MIN}
@@ -98,9 +102,15 @@ export function ZoomControl() {
         onMouseUp={commit}
         onTouchEnd={commit}
         onKeyUp={commit}
-        style={{ flex: 1, cursor: 'pointer', accentColor: 'var(--accent)' }}
+        aria-label="Zoom level"
+        style={{
+          width: 90,
+          cursor: 'pointer',
+          accentColor: 'var(--accent)',
+          margin: 0,
+        }}
       />
-      <span className="mono" style={{ width: 40, textAlign: 'right', color: 'var(--fg-1)', fontSize: 11 }}>
+      <span className="v" style={{ minWidth: 18, textAlign: 'right' }}>
         {value}×
       </span>
     </label>

--- a/zeus-web/src/components/filter/FilterPanel.tsx
+++ b/zeus-web/src/components/filter/FilterPanel.tsx
@@ -4,9 +4,10 @@
 // Copyright (C) 2025-2026 Brian Keating (EI6LF),
 //                         Douglas J. Cerrato (KB2UKA), and contributors.
 //
-// Unified filter panel with favorites. Shows 3 favorite filter presets plus
-// a "..." button that drops down the existing FilterRibbon (full presets +
-// mini-pan + readouts) for the operator to pick from or edit favorites.
+// Unified filter control-strip widget. Three favorite filter-preset buttons
+// + a "⋯" toggle that opens the FilterRibbon (mini-pan + presets + custom).
+// Operators drag any preset chip out of the ribbon onto one of the three
+// buttons here to pin it — same UX as the Mode/Band/Step toolbar groups.
 
 import { useCallback, useEffect, useState } from 'react';
 import { useConnectionStore } from '../../state/connection-store';
@@ -17,6 +18,7 @@ import {
   type FilterPresetDto,
 } from '../../api/client';
 import { useFilterFavoritesStore, useFavoritesForMode } from '../../state/filter-favorites-store';
+import { FILTER_DRAG_MIME } from './FilterRibbon';
 
 const RIBBON_OPEN_KEY = 'zeus.filter.advancedPaneOpen';
 
@@ -26,9 +28,11 @@ export function FilterPanel() {
   const ribbonOpen = useConnectionStore((s) => s.filterAdvancedPaneOpen);
   const applyState = useConnectionStore((s) => s.applyState);
   const loadFavorites = useFilterFavoritesStore((s) => s.load);
+  const updateFavorites = useFilterFavoritesStore((s) => s.update);
   const favoriteSlotNames = useFavoritesForMode(mode);
 
   const [presets, setPresets] = useState<FilterPresetDto[]>([]);
+  const [dragOverIdx, setDragOverIdx] = useState<number | null>(null);
 
   useEffect(() => { void loadFavorites(mode); }, [mode, loadFavorites]);
 
@@ -39,10 +43,6 @@ export function FilterPanel() {
       .catch(() => { if (!cancelled) setPresets([]); });
     return () => { cancelled = true; };
   }, [mode]);
-
-  const favoritePresets: FilterPresetDto[] = favoriteSlotNames
-    .map((name) => presets.find((p) => p.slotName === name))
-    .filter((p): p is FilterPresetDto => Boolean(p));
 
   const activeSlot = filterPresetName ?? null;
 
@@ -67,23 +67,67 @@ export function FilterPanel() {
     setFilterAdvancedPaneOpen(next).catch(() => { /* next state poll reconciles */ });
   }, [ribbonOpen]);
 
+  // Drop a preset chip from the ribbon onto favorite-index `idx`. Swaps if
+  // the dropped slot is already a favorite; otherwise displaces idx.
+  const onDrop = useCallback(
+    (idx: number, slotName: string) => {
+      const next = [...favoriteSlotNames];
+      const existing = next.indexOf(slotName);
+      if (existing === idx) return;
+      const displaced = next[idx];
+      if (existing >= 0 && displaced !== undefined) {
+        next[existing] = displaced;
+      }
+      next[idx] = slotName;
+      void updateFavorites(mode, next);
+    },
+    [favoriteSlotNames, mode, updateFavorites],
+  );
+
+  const onDragOver = (idx: number) => (e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes(FILTER_DRAG_MIME)) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    if (dragOverIdx !== idx) setDragOverIdx(idx);
+  };
+  const onDragLeave = () => setDragOverIdx(null);
+  const onDropEvt = (idx: number) => (e: React.DragEvent) => {
+    const slotName = e.dataTransfer.getData(FILTER_DRAG_MIME);
+    if (!slotName) return;
+    e.preventDefault();
+    onDrop(idx, slotName);
+    setDragOverIdx(null);
+  };
+
   if (mode === 'FM') return null;
 
   return (
     <div className="ctrl-group filter-bar" style={{ minWidth: 220 }}>
       <div className="label-xs ctrl-lbl">FILTER</div>
-      <div className="btn-row wrap" style={{ gap: 3 }}>
-        {favoritePresets.map((slot) => (
-          <button
-            key={slot.slotName}
-            type="button"
-            onClick={() => selectPreset(slot)}
-            className={`btn sm ${activeSlot === slot.slotName ? 'active' : ''}`}
-            title={`${slot.slotName}: ${slot.lowHz >= 0 ? '+' : ''}${slot.lowHz} / ${slot.highHz >= 0 ? '+' : ''}${slot.highHz} Hz`}
-          >
-            {slot.label}
-          </button>
-        ))}
+      <div className="btn-row" style={{ gap: 3 }}>
+        {favoriteSlotNames.map((slotName, idx) => {
+          const slot = presets.find((p) => p.slotName === slotName);
+          const isActive = !!slot && activeSlot === slot.slotName;
+          return (
+            <button
+              key={`fav-${idx}`}
+              type="button"
+              onClick={() => slot && selectPreset(slot)}
+              onDragOver={onDragOver(idx)}
+              onDragLeave={onDragLeave}
+              onDrop={onDropEvt(idx)}
+              className={`btn sm ${isActive ? 'active' : ''} ${dragOverIdx === idx ? 'is-drop-target' : ''}`}
+              title={
+                slot
+                  ? `${slot.slotName}: ${slot.lowHz >= 0 ? '+' : ''}${slot.lowHz} / ${slot.highHz >= 0 ? '+' : ''}${slot.highHz} Hz — drag a preset here to replace`
+                  : `Empty slot — drop a preset here`
+              }
+              aria-label={`Filter favorite ${idx + 1}: ${slot ? slot.label : slotName}`}
+            >
+              {slot ? slot.label : slotName}
+            </button>
+          );
+        })}
         <button
           type="button"
           onClick={toggleRibbon}

--- a/zeus-web/src/components/filter/FilterRibbon.tsx
+++ b/zeus-web/src/components/filter/FilterRibbon.tsx
@@ -121,6 +121,18 @@ export function FilterRibbon({ embedded = false }: { embedded?: boolean } = {}) 
 
   const presets = useMemo(() => mergePresets(mode, serverPresets), [mode, serverPresets]);
 
+  // PRESETS grid order: F-slots ascending by passband width, then VAR1, VAR2.
+  // The local table is descending (5.0k → 1.0k); operators read narrow-to-wide
+  // more naturally, and pinning VAR slots to the end keeps drag targets stable
+  // even when their stored widths change.
+  const sortedPresets = useMemo(() => {
+    const fSlots = presets.filter((p) => !p.isVar).slice().sort((a, b) => {
+      return Math.abs(a.highHz - a.lowHz) - Math.abs(b.highHz - b.lowHz);
+    });
+    const varSlots = presets.filter((p) => p.isVar);
+    return [...fSlots, ...varSlots];
+  }, [presets]);
+
   const selectPreset = useCallback((slot: FilterPresetSlot) => {
     useConnectionStore.setState({
       filterLowHz: slot.lowHz,
@@ -138,22 +150,25 @@ export function FilterRibbon({ embedded = false }: { embedded?: boolean } = {}) 
     setFilterAdvancedPaneOpen(false).catch(() => {});
   }, []);
 
-  // CUSTOM Lo/Hi inputs — armed against VAR1.
-  const var1 = presets.find((p) => p.slotName === 'VAR1');
-  const var1Active = filterPresetName === 'VAR1';
-  const seedLow = var1Active ? filterLow : (var1?.lowHz ?? filterLow);
-  const seedHigh = var1Active ? filterHigh : (var1?.highHz ?? filterHigh);
-  const seedAbs = signedToAbs(mode, seedLow, seedHigh);
+  // CUSTOM Lo/Hi inputs always mirror the live filter, so clicking any
+  // preset (F1..F10 or VAR1/VAR2) immediately repaints the entry fields
+  // with that slot's actual lo/hi. Where edits LAND is a separate question:
+  //   - VAR1 active → write to VAR1
+  //   - VAR2 active → write to VAR2
+  //   - F1..F10 active → fall back to VAR1 (F-slots are Thetis defaults
+  //     and must never be overwritten; freeform edits land in VAR1).
+  const activeVarSlot: 'VAR1' | 'VAR2' = filterPresetName === 'VAR2' ? 'VAR2' : 'VAR1';
+  const seedAbs = signedToAbs(mode, filterLow, filterHigh);
   const [loDraft, setLoDraft] = useState<string>(String(seedAbs.lo));
   const [hiDraft, setHiDraft] = useState<string>(String(seedAbs.hi));
 
-  // Reseed the drafts when the source values change (mode flip, VAR1 override
-  // edit elsewhere, server reconciliation).
+  // Reseed the drafts when the live filter changes (preset click, mode flip,
+  // server reconciliation). The CUSTOM inputs always reflect what's playing.
   useEffect(() => {
-    const abs = signedToAbs(mode, seedLow, seedHigh);
+    const abs = signedToAbs(mode, filterLow, filterHigh);
     setLoDraft(String(abs.lo));
     setHiDraft(String(abs.hi));
-  }, [mode, seedLow, seedHigh]);
+  }, [mode, filterLow, filterHigh]);
 
   const commitCustom = useCallback(async () => {
     const loAbs = Number.parseInt(loDraft, 10);
@@ -161,19 +176,23 @@ export function FilterRibbon({ embedded = false }: { embedded?: boolean } = {}) 
     if (!Number.isFinite(loAbs) || !Number.isFinite(hiAbs)) return;
     const { low, high } = absToSigned(mode, loAbs, hiAbs);
     if (high <= low + 50) return;
+    // Writes land on the currently-active VAR slot. F1..F10 are Thetis
+    // defaults and never get overwritten — when one is active the edit falls
+    // back to VAR1 (set by activeVarSlot above).
+    const target = activeVarSlot;
     useConnectionStore.setState({
       filterLowHz: low,
       filterHighHz: high,
-      filterPresetName: 'VAR1',
+      filterPresetName: target,
     });
     try {
-      await setFilter(low, high, 'VAR1').then(applyState);
-      await setFilterPresetOverride(mode, 'VAR1', low, high);
-      // Refresh preset list so VAR1 chip shows the new values.
+      await setFilter(low, high, target).then(applyState);
+      await setFilterPresetOverride(mode, target, low, high);
+      // Refresh preset list so the VAR chip shows the new values.
       const fresh = await getFilterPresets(mode);
       setServerPresets(fresh);
     } catch { /* next state poll reconciles */ }
-  }, [loDraft, hiDraft, mode, applyState]);
+  }, [loDraft, hiDraft, mode, applyState, activeVarSlot]);
 
   const onCustomKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') e.currentTarget.blur();
@@ -250,7 +269,7 @@ export function FilterRibbon({ embedded = false }: { embedded?: boolean } = {}) 
         <div className="filter-ribbon__presets">
           <div className="filter-ribbon__section-label">PRESETS</div>
           <div className="filter-ribbon__preset-grid">
-            {presets.map((slot) => {
+            {sortedPresets.map((slot) => {
               const slotWidth = Math.abs(slot.highHz - slot.lowHz);
               const isActive = filterPresetName === slot.slotName
                 || (Math.abs(slotWidth - currentWidth) <= 20 && !slot.isVar);
@@ -273,7 +292,7 @@ export function FilterRibbon({ embedded = false }: { embedded?: boolean } = {}) 
             })}
           </div>
 
-          <div className="filter-ribbon__section-label">CUSTOM</div>
+          <div className="filter-ribbon__section-label">CUSTOM · {activeVarSlot}</div>
           <div className="filter-ribbon__custom-row">
             <input
               type="number"

--- a/zeus-web/src/components/filter/FilterRibbon.tsx
+++ b/zeus-web/src/components/filter/FilterRibbon.tsx
@@ -33,16 +33,15 @@ import {
   type RxMode,
 } from '../../api/client';
 import {
-  formatAbsFreq,
   getPresetsForMode,
   nudgeStepHz,
   type FilterPresetSlot,
 } from './filterPresets';
 import { FilterMiniPan } from './FilterMiniPan';
-import { useFilterFavoritesStore, useFavoritesForMode } from '../../state/filter-favorites-store';
+import { useFavoritesForMode } from '../../state/filter-favorites-store';
 
 const LOCAL_STORAGE_KEY = 'zeus.filter.advancedPaneOpen';
-const DRAG_MIME = 'application/x-zeus-filter-slot';
+export const FILTER_DRAG_MIME = 'application/x-zeus-filter-slot';
 
 const CUSTOM_MIN = 0;
 const CUSTOM_MAX = 10000;
@@ -106,18 +105,11 @@ export function FilterRibbon({ embedded = false }: { embedded?: boolean } = {}) 
   const filterLow = useConnectionStore((s) => s.filterLowHz);
   const filterHigh = useConnectionStore((s) => s.filterHighHz);
   const filterPresetName = useConnectionStore((s) => s.filterPresetName);
-  const vfoHz = useConnectionStore((s) => s.vfoHz);
   const open = useConnectionStore((s) => s.filterAdvancedPaneOpen);
   const applyState = useConnectionStore((s) => s.applyState);
-  const loadFavorites = useFilterFavoritesStore((s) => s.load);
-  const updateFavorites = useFilterFavoritesStore((s) => s.update);
   const favoriteSlotNames = useFavoritesForMode(mode);
-
   const [serverPresets, setServerPresets] = useState<FilterPresetDto[] | null>(null);
   const [dragSlot, setDragSlot] = useState<string | null>(null);
-  const [dragOverFav, setDragOverFav] = useState<number | null>(null);
-
-  useEffect(() => { void loadFavorites(mode); }, [mode, loadFavorites]);
 
   useEffect(() => {
     let cancelled = false;
@@ -128,13 +120,6 @@ export function FilterRibbon({ embedded = false }: { embedded?: boolean } = {}) 
   }, [mode]);
 
   const presets = useMemo(() => mergePresets(mode, serverPresets), [mode, serverPresets]);
-  const lowAbs = vfoHz + filterLow;
-  const highAbs = vfoHz + filterHigh;
-  const widthKHz = Math.abs(filterHigh - filterLow) / 1000;
-
-  const favoritePresets: (FilterPresetSlot | undefined)[] = favoriteSlotNames.map((name) =>
-    presets.find((p) => p.slotName === name),
-  );
 
   const selectPreset = useCallback((slot: FilterPresetSlot) => {
     useConnectionStore.setState({
@@ -152,20 +137,6 @@ export function FilterRibbon({ embedded = false }: { embedded?: boolean } = {}) 
     cachePaneOpenLocal(false);
     setFilterAdvancedPaneOpen(false).catch(() => {});
   }, []);
-
-  // Drop a slot onto favorite-index `idx`. Swaps if dropped slot already
-  // exists in favorites; otherwise displaces the slot at idx.
-  const onDropFavorite = useCallback((idx: number, slotName: string) => {
-    const next = [...favoriteSlotNames];
-    const existingIdx = next.indexOf(slotName);
-    if (existingIdx === idx) return;
-    const displaced = next[idx];
-    if (existingIdx >= 0 && displaced !== undefined) {
-      next[existingIdx] = displaced;
-    }
-    next[idx] = slotName;
-    void updateFavorites(mode, next);
-  }, [favoriteSlotNames, mode, updateFavorites]);
 
   // CUSTOM Lo/Hi inputs — armed against VAR1.
   const var1 = presets.find((p) => p.slotName === 'VAR1');
@@ -236,27 +207,11 @@ export function FilterRibbon({ embedded = false }: { embedded?: boolean } = {}) 
   const isLowDisabled = isSymmetricMode(mode);
 
   const startDrag = (e: React.DragEvent, slotName: string) => {
-    e.dataTransfer.setData(DRAG_MIME, slotName);
+    e.dataTransfer.setData(FILTER_DRAG_MIME, slotName);
     e.dataTransfer.effectAllowed = 'move';
     setDragSlot(slotName);
   };
-  const endDrag = () => { setDragSlot(null); setDragOverFav(null); };
-
-  const onFavDragOver = (idx: number) => (e: React.DragEvent) => {
-    if (!e.dataTransfer.types.includes(DRAG_MIME)) return;
-    e.preventDefault();
-    e.dataTransfer.dropEffect = 'move';
-    if (dragOverFav !== idx) setDragOverFav(idx);
-  };
-  const onFavDragLeave = () => setDragOverFav(null);
-  const onFavDrop = (idx: number) => (e: React.DragEvent) => {
-    const slotName = e.dataTransfer.getData(DRAG_MIME);
-    if (!slotName) return;
-    e.preventDefault();
-    onDropFavorite(idx, slotName);
-    setDragOverFav(null);
-    setDragSlot(null);
-  };
+  const endDrag = () => { setDragSlot(null); };
 
   return (
     <div
@@ -276,29 +231,10 @@ export function FilterRibbon({ embedded = false }: { embedded?: boolean } = {}) 
       )}
 
       <div className="filter-ribbon__body">
-        {/* Left column: top readout row, full-width mini-pan, footer hint */}
+        {/* Left column: full-width mini-pan, footer hint. The top BW/LO/PB/HI
+            readout row was removed — its data is already shown in the topbar
+            chips and the mini-pan visualises the same passband. */}
         <div className="filter-ribbon__main">
-          <div className="filter-ribbon__topRow">
-            <div className="filter-ribbon__topCol filter-ribbon__topCol--bw">
-              <div className="filter-ribbon__label">BANDWIDTH</div>
-            </div>
-            <div className="filter-ribbon__topCol filter-ribbon__topCol--lo">
-              <div className="filter-ribbon__label">LOW CUT</div>
-              <div className="filter-ribbon__freq">{formatAbsFreq(lowAbs)}</div>
-            </div>
-            <div className="filter-ribbon__topCol filter-ribbon__topCol--pb">
-              <div className="filter-ribbon__label">PASSBAND</div>
-              <div className="filter-ribbon__passband">
-                <span className="filter-ribbon__passband-value">{widthKHz.toFixed(2)}</span>
-                <span className="filter-ribbon__passband-unit">kHz</span>
-              </div>
-            </div>
-            <div className="filter-ribbon__topCol filter-ribbon__topCol--hi">
-              <div className="filter-ribbon__label">HIGH CUT</div>
-              <div className="filter-ribbon__freq">{formatAbsFreq(highAbs)}</div>
-            </div>
-          </div>
-
           <div className="filter-ribbon__minipan">
             <FilterMiniPan />
           </div>
@@ -308,39 +244,17 @@ export function FilterRibbon({ embedded = false }: { embedded?: boolean } = {}) 
           </div>
         </div>
 
-        {/* Right column: favorites + presets + custom */}
+        {/* Right column: presets + custom. The in-ribbon FAVORITES row was
+            removed — drag any preset chip below onto one of the three filter
+            buttons in the control strip to pin it (same UX as Mode/Band/Step). */}
         <div className="filter-ribbon__presets">
-          <div className="filter-ribbon__section-label">FAVORITES</div>
-          <div className="filter-ribbon__favorites">
-            {favoritePresets.map((slot, idx) => {
-              const slotName = favoriteSlotNames[idx];
-              const isActive = slot && filterPresetName === slot.slotName;
-              const slotWidth = slot ? Math.abs(slot.highHz - slot.lowHz) : -1;
-              const widthMatches = slot && Math.abs(slotWidth - currentWidth) <= 20;
-              return (
-                <button
-                  key={`fav-${idx}`}
-                  type="button"
-                  onClick={() => slot && selectPreset(slot)}
-                  onDragOver={onFavDragOver(idx)}
-                  onDragLeave={onFavDragLeave}
-                  onDrop={onFavDrop(idx)}
-                  className={`filter-ribbon__chip filter-ribbon__chip--fav ${isActive || widthMatches ? 'is-active' : ''} ${dragOverFav === idx ? 'is-drop-target' : ''}`}
-                  title={slot ? `${slot.slotName}: drag a preset here to replace` : `Empty slot — drop a preset here`}
-                  aria-label={`Favorite slot ${idx + 1}: ${slot ? slot.label : slotName}`}
-                >
-                  {slot ? slot.label : slotName}
-                </button>
-              );
-            })}
-          </div>
-
           <div className="filter-ribbon__section-label">PRESETS</div>
           <div className="filter-ribbon__preset-grid">
             {presets.map((slot) => {
               const slotWidth = Math.abs(slot.highHz - slot.lowHz);
               const isActive = filterPresetName === slot.slotName
                 || (Math.abs(slotWidth - currentWidth) <= 20 && !slot.isVar);
+              const isPinned = favoriteSlotNames.includes(slot.slotName);
               const label = slot.isVar ? slot.slotName : slot.label;
               return (
                 <button
@@ -351,7 +265,7 @@ export function FilterRibbon({ embedded = false }: { embedded?: boolean } = {}) 
                   onDragEnd={endDrag}
                   onClick={() => selectPreset(slot)}
                   title={`${slot.slotName}: ${slot.lowHz >= 0 ? '+' : ''}${slot.lowHz} / ${slot.highHz >= 0 ? '+' : ''}${slot.highHz} Hz · drag onto a favorite to pin`}
-                  className={`filter-ribbon__chip ${isActive ? 'is-active' : ''} ${dragSlot === slot.slotName ? 'is-dragging' : ''}`}
+                  className={`filter-ribbon__chip ${isActive ? 'is-active' : ''} ${isPinned ? 'is-pinned' : ''} ${dragSlot === slot.slotName ? 'is-dragging' : ''}`}
                 >
                   {label}
                 </button>

--- a/zeus-web/src/components/toolbar/BandFavorites.tsx
+++ b/zeus-web/src/components/toolbar/BandFavorites.tsx
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Band picker for the control strip — three favorite band buttons + a "⋯"
+// dropdown listing every HF band. Drag any band chip in the dropdown onto
+// a favorite slot to pin it. Selecting a band restores the saved (hz, mode)
+// from server-side band memory, matching BandButtons behaviour.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  fetchBandMemory,
+  saveBandMemory,
+  setMode,
+  setVfo,
+  type BandMemoryEntry,
+  type RxMode,
+} from '../../api/client';
+import { useConnectionStore } from '../../state/connection-store';
+import { BANDS, bandOf } from '../design/data';
+import { ToolbarFavorites, type ToolbarOption } from './ToolbarFavorites';
+
+type BandEntry = {
+  name: string;
+  centerHz: number;
+};
+
+const HF_BANDS: readonly BandEntry[] = BANDS.slice(0, 10).map((b) => ({
+  name: b.n + 'm',
+  centerHz: b.center,
+}));
+
+const BAND_OPTIONS: readonly ToolbarOption[] = HF_BANDS.map((b) => ({
+  key: b.name,
+  label: b.name,
+}));
+
+const SAVE_DEBOUNCE_MS = 500;
+
+export function BandFavorites() {
+  const vfoHz = useConnectionStore((s) => s.vfoHz);
+  const mode = useConnectionStore((s) => s.mode);
+  const applyState = useConnectionStore((s) => s.applyState);
+
+  const [currentBand, setCurrentBand] = useState<string>(() => bandOf(vfoHz));
+  const memoryRef = useRef<Map<string, BandMemoryEntry>>(new Map());
+  const saveTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const ac = new AbortController();
+    fetchBandMemory(ac.signal)
+      .then((entries) => {
+        const m = new Map<string, BandMemoryEntry>();
+        for (const e of entries) m.set(e.band, e);
+        memoryRef.current = m;
+      })
+      .catch(() => {
+        /* offline / older server — band click will fall back to centre defaults */
+      });
+    return () => ac.abort();
+  }, []);
+
+  useEffect(() => {
+    const band = bandOf(vfoHz);
+    setCurrentBand(band);
+    if (band === '—') return;
+    if (saveTimerRef.current !== null) window.clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = window.setTimeout(() => {
+      saveTimerRef.current = null;
+      memoryRef.current.set(band, { band, hz: vfoHz, mode });
+      saveBandMemory(band, vfoHz, mode).catch(() => { /* next tune retries */ });
+    }, SAVE_DEBOUNCE_MS);
+    return () => {
+      if (saveTimerRef.current !== null) {
+        window.clearTimeout(saveTimerRef.current);
+        saveTimerRef.current = null;
+      }
+    };
+  }, [vfoHz, mode]);
+
+  const onSelect = useCallback(
+    (key: string) => {
+      const band = HF_BANDS.find((b) => b.name === key);
+      if (!band) return;
+      const stored = memoryRef.current.get(band.name);
+      const targetHz = stored?.hz ?? band.centerHz;
+      const targetMode: RxMode | null = stored?.mode ?? null;
+
+      useConnectionStore.setState({ vfoHz: targetHz });
+      setVfo(targetHz).then(applyState).catch(() => { /* next state poll reconciles */ });
+
+      if (targetMode && targetMode !== mode) {
+        useConnectionStore.setState({ mode: targetMode });
+        setMode(targetMode).then(applyState).catch(() => { /* next state poll reconciles */ });
+      }
+    },
+    [applyState, mode],
+  );
+
+  return (
+    <ToolbarFavorites
+      kind="band"
+      label="BAND"
+      options={BAND_OPTIONS}
+      currentKey={currentBand}
+      onSelect={onSelect}
+      minWidth={170}
+    />
+  );
+}

--- a/zeus-web/src/components/toolbar/ModeFavorites.tsx
+++ b/zeus-web/src/components/toolbar/ModeFavorites.tsx
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Mode picker for the control strip — three favorite mode buttons + a "⋯"
+// dropdown listing every mode. Drag any mode chip in the dropdown onto a
+// favorite slot to pin it.
+
+import { useCallback } from 'react';
+import { setMode, type RxMode } from '../../api/client';
+import { useConnectionStore } from '../../state/connection-store';
+import { ToolbarFavorites, type ToolbarOption } from './ToolbarFavorites';
+
+const MODE_OPTIONS: readonly ToolbarOption[] = [
+  { key: 'LSB', label: 'LSB' },
+  { key: 'USB', label: 'USB' },
+  { key: 'CWL', label: 'CWL' },
+  { key: 'CWU', label: 'CWU' },
+  { key: 'AM', label: 'AM' },
+  { key: 'SAM', label: 'SAM' },
+  { key: 'DSB', label: 'DSB' },
+  { key: 'FM', label: 'FM' },
+  { key: 'DIGL', label: 'DIGL' },
+  { key: 'DIGU', label: 'DIGU' },
+];
+
+export function ModeFavorites() {
+  const mode = useConnectionStore((s) => s.mode);
+  const applyState = useConnectionStore((s) => s.applyState);
+
+  const onSelect = useCallback(
+    (key: string) => {
+      const m = key as RxMode;
+      if (m === mode) return;
+      useConnectionStore.setState({ mode: m });
+      setMode(m).then(applyState).catch(() => {
+        /* next state poll reconciles */
+      });
+    },
+    [mode, applyState],
+  );
+
+  return (
+    <ToolbarFavorites
+      kind="mode"
+      label="MODE"
+      options={MODE_OPTIONS}
+      currentKey={mode}
+      onSelect={onSelect}
+      minWidth={170}
+    />
+  );
+}

--- a/zeus-web/src/components/toolbar/StepFavorites.tsx
+++ b/zeus-web/src/components/toolbar/StepFavorites.tsx
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Tuning-step picker for the control strip — three favorite step buttons +
+// a "⋯" dropdown listing every step. Drag any chip in the dropdown onto a
+// favorite slot to pin it. Step state is shared with the side-stack
+// TuningStepWidget via the toolbar-favorites store.
+
+import { useCallback } from 'react';
+import { useToolbarFavoritesStore } from '../../state/toolbar-favorites-store';
+import { ToolbarFavorites, type ToolbarOption } from './ToolbarFavorites';
+
+const STEP_OPTIONS: readonly ToolbarOption[] = [
+  { key: '1', label: '1 Hz' },
+  { key: '10', label: '10 Hz' },
+  { key: '50', label: '50 Hz' },
+  { key: '100', label: '100 Hz' },
+  { key: '250', label: '250 Hz' },
+  { key: '500', label: '500 Hz' },
+  { key: '1000', label: '1 kHz' },
+  { key: '5000', label: '5 kHz' },
+  { key: '9000', label: '9 kHz' },
+  { key: '10000', label: '10 kHz' },
+  { key: '100000', label: '100 kHz' },
+  { key: '250000', label: '250 kHz' },
+  { key: '1000000', label: '1 MHz' },
+];
+
+export function StepFavorites() {
+  const stepHz = useToolbarFavoritesStore((s) => s.stepHz);
+  const setStepHz = useToolbarFavoritesStore((s) => s.setStepHz);
+
+  const onSelect = useCallback(
+    (key: string) => {
+      const hz = Number(key);
+      if (Number.isFinite(hz) && hz > 0) setStepHz(hz);
+    },
+    [setStepHz],
+  );
+
+  return (
+    <ToolbarFavorites
+      kind="step"
+      label="STEP"
+      options={STEP_OPTIONS}
+      currentKey={String(stepHz)}
+      onSelect={onSelect}
+      minWidth={180}
+    />
+  );
+}

--- a/zeus-web/src/components/toolbar/ToolbarFavorites.tsx
+++ b/zeus-web/src/components/toolbar/ToolbarFavorites.tsx
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Generic three-favorite + dropdown picker used by Mode, Band, and Step in
+// the control strip. Mirrors the FilterPanel/FilterRibbon favorites pattern:
+// three pinned buttons, a "⋯" toggle that opens a popover containing every
+// option, and drag-to-pin gesture from any popover chip into one of the
+// three favorite slots. Click a favorite (or any option in the popover) to
+// apply it.
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useToolbarFavoritesStore, type ToolbarFavKind } from '../../state/toolbar-favorites-store';
+
+export type ToolbarOption = {
+  key: string;
+  label: string;
+  title?: string;
+};
+
+export type ToolbarFavoritesProps = {
+  kind: ToolbarFavKind;
+  label: string;
+  options: readonly ToolbarOption[];
+  currentKey: string | null;
+  onSelect: (key: string) => void;
+  minWidth?: number;
+};
+
+const DRAG_MIME_PREFIX = 'application/x-zeus-toolbar-fav-';
+
+// MIME used by toolbar favorite drop targets. External components (e.g. the
+// flex-mode Mode/Band/Step panels) set this on their own buttons' dragstart
+// so the operator can drag any option onto a toolbar slot to pin it.
+export function toolbarFavDragMime(kind: ToolbarFavKind): string {
+  return DRAG_MIME_PREFIX + kind;
+}
+
+export function ToolbarFavorites({
+  kind,
+  label,
+  options,
+  currentKey,
+  onSelect,
+  minWidth = 180,
+}: ToolbarFavoritesProps) {
+  const slots = useToolbarFavoritesStore((s) => s[kind]);
+  const setFavorites = useToolbarFavoritesStore((s) => s.setFavorites);
+
+  const [open, setOpen] = useState(false);
+  const [dragKey, setDragKey] = useState<string | null>(null);
+  const [dragOverFav, setDragOverFav] = useState<number | null>(null);
+  const [popoverPos, setPopoverPos] = useState<{ top: number; left: number } | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const toggleRef = useRef<HTMLButtonElement | null>(null);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+  const dragMime = DRAG_MIME_PREFIX + kind;
+
+  // Repair a stale slot list (legacy / corrupted persistence) by replacing
+  // unknown keys with the first non-favorite option so the operator never
+  // sees an empty button.
+  const validKeys = new Set(options.map((o) => o.key));
+  const safeSlots: string[] =
+    slots.length === 3 && slots.every((k) => validKeys.has(k))
+      ? slots
+      : (() => {
+          const fallback: string[] = [];
+          for (const o of options) {
+            if (fallback.length === 3) break;
+            fallback.push(o.key);
+          }
+          const filler = options[0]?.key;
+          while (fallback.length < 3 && filler !== undefined) {
+            fallback.push(filler);
+          }
+          return fallback;
+        })();
+
+  // Close popover on outside click or Escape. Treats clicks inside either
+  // the trigger row or the portaled popover as "inside" so the menu doesn't
+  // self-dismiss when the operator clicks one of its own chips.
+  useEffect(() => {
+    if (!open) return;
+    const onDocDown = (e: MouseEvent) => {
+      const t = e.target as Node | null;
+      if (!t) return;
+      if (containerRef.current?.contains(t)) return;
+      if (popoverRef.current?.contains(t)) return;
+      setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onDocDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDocDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  // Anchor the portaled popover to the "⋯" toggle. Re-measure on open and on
+  // window resize / scroll so the menu tracks if the layout shifts. The
+  // popover is rendered into document.body to escape `.control-strip`'s
+  // `overflow: hidden` clip.
+  useLayoutEffect(() => {
+    if (!open) {
+      setPopoverPos(null);
+      return;
+    }
+    const measure = () => {
+      const t = toggleRef.current;
+      if (!t) return;
+      const r = t.getBoundingClientRect();
+      setPopoverPos({ top: r.bottom + 6, left: r.left });
+    };
+    measure();
+    window.addEventListener('resize', measure);
+    window.addEventListener('scroll', measure, true);
+    return () => {
+      window.removeEventListener('resize', measure);
+      window.removeEventListener('scroll', measure, true);
+    };
+  }, [open]);
+
+  const dropOnFav = useCallback(
+    (idx: number, key: string) => {
+      const next = [...safeSlots];
+      const existing = next.indexOf(key);
+      if (existing === idx) return;
+      const displaced = next[idx];
+      if (existing >= 0 && displaced !== undefined) {
+        next[existing] = displaced;
+      }
+      next[idx] = key;
+      setFavorites(kind, next);
+    },
+    [safeSlots, kind, setFavorites],
+  );
+
+  const startDrag = (e: React.DragEvent, key: string) => {
+    e.dataTransfer.setData(dragMime, key);
+    e.dataTransfer.effectAllowed = 'move';
+    setDragKey(key);
+  };
+  const endDrag = () => {
+    setDragKey(null);
+    setDragOverFav(null);
+  };
+  const onFavDragOver = (idx: number) => (e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes(dragMime)) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    if (dragOverFav !== idx) setDragOverFav(idx);
+  };
+  const onFavDrop = (idx: number) => (e: React.DragEvent) => {
+    const key = e.dataTransfer.getData(dragMime);
+    if (!key) return;
+    e.preventDefault();
+    dropOnFav(idx, key);
+    setDragOverFav(null);
+    setDragKey(null);
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className="ctrl-group toolbar-fav"
+      style={{ minWidth, position: 'relative' }}
+    >
+      <div className="label-xs ctrl-lbl">{label}</div>
+      <div className="btn-row" style={{ gap: 3 }}>
+        {safeSlots.map((slotKey, idx) => {
+          const opt = options.find((o) => o.key === slotKey);
+          const active = opt && currentKey === opt.key;
+          return (
+            <button
+              key={`fav-${idx}`}
+              type="button"
+              onClick={() => opt && onSelect(opt.key)}
+              onDragOver={onFavDragOver(idx)}
+              onDragLeave={() => setDragOverFav(null)}
+              onDrop={onFavDrop(idx)}
+              className={`btn sm toolbar-fav__slot ${active ? 'active' : ''} ${dragOverFav === idx ? 'is-drop-target' : ''}`}
+              title={opt ? (opt.title ?? `${opt.label} — drag a different option here to replace`) : 'Empty slot — drop an option here'}
+              aria-label={`Favorite ${idx + 1}: ${opt ? opt.label : slotKey}`}
+            >
+              {opt ? opt.label : slotKey}
+            </button>
+          );
+        })}
+        <button
+          ref={toggleRef}
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className={`btn sm ${open ? 'active' : ''}`}
+          title={`All ${label.toLowerCase()} options — drag onto a favorite to pin`}
+          aria-expanded={open}
+          style={{ marginLeft: 4 }}
+        >
+          ⋯
+        </button>
+      </div>
+
+      {open && popoverPos && createPortal(
+        <div
+          ref={popoverRef}
+          className="toolbar-fav__popover"
+          role="dialog"
+          aria-label={`${label} options`}
+          style={{ top: popoverPos.top, left: popoverPos.left }}
+        >
+          <div className="toolbar-fav__hint">DRAG ONTO A FAVORITE TO PIN</div>
+          <div className="toolbar-fav__grid">
+            {options.map((opt) => {
+              const isFav = safeSlots.includes(opt.key);
+              const isActive = currentKey === opt.key;
+              return (
+                <button
+                  key={opt.key}
+                  type="button"
+                  draggable
+                  onDragStart={(e) => startDrag(e, opt.key)}
+                  onDragEnd={endDrag}
+                  onClick={() => {
+                    onSelect(opt.key);
+                    setOpen(false);
+                  }}
+                  title={opt.title ?? `${opt.label} — drag onto a favorite slot to pin`}
+                  className={`toolbar-fav__chip ${isActive ? 'is-active' : ''} ${isFav ? 'is-pinned' : ''} ${dragKey === opt.key ? 'is-dragging' : ''}`}
+                >
+                  {opt.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>,
+        document.body,
+      )}
+    </div>
+  );
+}

--- a/zeus-web/src/layout/WorkspaceContext.tsx
+++ b/zeus-web/src/layout/WorkspaceContext.tsx
@@ -44,6 +44,7 @@
 
 import { createContext, useContext, type FormEvent, type ReactNode, type RefObject } from 'react';
 import type { Contact } from '../components/design/data';
+import type { BackgroundImageFit, PanBackgroundMode } from '../state/display-settings-store';
 
 export interface EffectiveHome {
   call: string;
@@ -68,7 +69,15 @@ export interface WorkspaceCtx {
   // QRZ / Terminator
   callsign: string;
   setCallsign: (v: string) => void;
+  // terminatorActive is derived: panBackground === 'beam-map'.
   terminatorActive: boolean;
+  // imageMode: panBackground === 'image' AND a backgroundImage is loaded.
+  imageMode: boolean;
+  // bgActive: any non-basic background overlay is active (map or image).
+  bgActive: boolean;
+  panBackground: PanBackgroundMode;
+  backgroundImage: string | null;
+  backgroundImageFit: BackgroundImageFit;
   enriching: boolean;
   lookupKey: number;
   contact: Contact | null;
@@ -88,8 +97,7 @@ export interface WorkspaceCtx {
   dist: number;
   heroTitle: ReactNode;
   csInputRef: RefObject<HTMLInputElement | null>;
-  engageTerminator: (cs?: string) => void;
-  disengageTerminator: () => void;
+  runQrzLookup: (cs?: string) => void;
   onCallsignSubmit: (e: FormEvent<HTMLFormElement>) => void;
   submitBeam: (e: FormEvent<HTMLFormElement>) => void;
   handleLogQso: () => void;

--- a/zeus-web/src/layout/panels/HeroPanel.tsx
+++ b/zeus-web/src/layout/panels/HeroPanel.tsx
@@ -64,6 +64,10 @@ function useDisplayHzPerPixel(): string {
 export function HeroPanel() {
   const {
     terminatorActive,
+    imageMode,
+    bgActive,
+    backgroundImage,
+    backgroundImageFit,
     moxOn,
     tunOn,
     contact,
@@ -96,7 +100,7 @@ export function HeroPanel() {
 
   return (
     <div
-      className={`panel hero ${terminatorActive ? 'qrz-mode' : ''} ${mapInteractive ? 'map-mode' : ''}`}
+      className={`panel hero ${bgActive ? 'bg-active' : ''} ${mapInteractive ? 'map-mode' : ''}`}
       style={{ display: 'flex', flexDirection: 'column', height: '100%' }}
     >
       <div className="panel-head">
@@ -162,6 +166,12 @@ export function HeroPanel() {
         </span>
       </div>
       <div className="panel-body hero-body" style={{ flex: 1, position: 'relative' }}>
+        {imageMode && (
+          <div
+            className={`image-layer ${backgroundImageFit}`}
+            style={{ backgroundImage: `url(${backgroundImage})` }}
+          />
+        )}
         <div className={`map-layer ${terminatorActive ? 'visible' : ''}`}>
           <LeafletMapErrorBoundary
             onError={(error) => {
@@ -209,7 +219,7 @@ export function HeroPanel() {
           }}
         >
           {connected && <Panadapter />}
-          {connected && <Waterfall transparent={terminatorActive} />}
+          {connected && <Waterfall transparent={bgActive} />}
         </div>
       </div>
     </div>

--- a/zeus-web/src/main.tsx
+++ b/zeus-web/src/main.tsx
@@ -48,6 +48,7 @@ import './index.css';
 import './styles/tokens.css';
 import './styles/layout.css';
 import './styles/filter-ribbon.css';
+import './styles/toolbar-favorites.css';
 import './styles/nr-settings.css';
 import App from './App.tsx';
 

--- a/zeus-web/src/state/display-settings-store.ts
+++ b/zeus-web/src/state/display-settings-store.ts
@@ -64,6 +64,76 @@ export const TX_FIXED_DB_MAX = 20;
 const STORAGE_KEY = 'zeus.display.dbRange';
 const TX_STORAGE_KEY = 'zeus.display.txDbRange';
 const WF_STORAGE_KEY = 'zeus.display.wfDbRange';
+const PAN_BG_KEY = 'zeus.display.panBackground';
+const BG_IMAGE_KEY = 'zeus.display.backgroundImage';
+const BG_FIT_KEY = 'zeus.display.backgroundImageFit';
+
+// Panadapter background mode. 'basic' = no overlay (current QRZ-off
+// look). 'beam-map' = world-map overlay with terminator lines and beam
+// chrome (current QRZ-on look). 'image' = user-supplied still image
+// behind a transparent panadapter / waterfall.
+export type PanBackgroundMode = 'basic' | 'beam-map' | 'image';
+
+// CSS background-size mapping for the image background.
+// 'fit' → contain (entire image visible, may letterbox)
+// 'fill' → cover (fills the panel, may crop)
+// 'stretch' → 100% 100% (distorts to fit exactly)
+export type BackgroundImageFit = 'fit' | 'fill' | 'stretch';
+
+function readPanBackground(): PanBackgroundMode {
+  try {
+    if (typeof localStorage === 'undefined') return 'basic';
+    const raw = localStorage.getItem(PAN_BG_KEY);
+    if (raw === 'basic' || raw === 'beam-map' || raw === 'image') return raw;
+    return 'basic';
+  } catch {
+    return 'basic';
+  }
+}
+function writePanBackground(v: PanBackgroundMode): void {
+  try { if (typeof localStorage !== 'undefined') localStorage.setItem(PAN_BG_KEY, v); } catch { /* quota */ }
+}
+
+function readBackgroundImage(): string | null {
+  try {
+    if (typeof localStorage === 'undefined') return null;
+    const raw = localStorage.getItem(BG_IMAGE_KEY);
+    return raw && raw.startsWith('data:image/') ? raw : null;
+  } catch {
+    return null;
+  }
+}
+function writeBackgroundImage(dataUrl: string | null): boolean {
+  try {
+    if (typeof localStorage === 'undefined') return false;
+    if (dataUrl == null) {
+      localStorage.removeItem(BG_IMAGE_KEY);
+    } else {
+      localStorage.setItem(BG_IMAGE_KEY, dataUrl);
+    }
+    return true;
+  } catch {
+    // Image too big for localStorage quota — caller should warn the user.
+    return false;
+  }
+}
+
+// Default to 'fill' (cover): matches the Beam Map's full-bleed look so
+// portrait / square images fill the wide panadapter without letterboxing.
+// Users who want the whole image visible can pick 'fit' explicitly.
+function readBackgroundImageFit(): BackgroundImageFit {
+  try {
+    if (typeof localStorage === 'undefined') return 'fill';
+    const raw = localStorage.getItem(BG_FIT_KEY);
+    if (raw === 'fit' || raw === 'fill' || raw === 'stretch') return raw;
+    return 'fill';
+  } catch {
+    return 'fill';
+  }
+}
+function writeBackgroundImageFit(v: BackgroundImageFit): void {
+  try { if (typeof localStorage !== 'undefined') localStorage.setItem(BG_FIT_KEY, v); } catch { /* quota */ }
+}
 
 function readSavedRange(): { dbMin: number; dbMax: number } {
   try {
@@ -174,6 +244,16 @@ export type DisplaySettingsState = {
   txDbMin: number;
   txDbMax: number;
   colormap: ColormapId;
+  // Panadapter background overlay mode + (optional) user image. See the
+  // PanBackgroundMode and BackgroundImageFit types above. The image is
+  // stored as a data:URL inside localStorage; setBackgroundImage returns
+  // false if the browser refused the write (quota exceeded).
+  panBackground: PanBackgroundMode;
+  backgroundImage: string | null;
+  backgroundImageFit: BackgroundImageFit;
+  setPanBackground: (v: PanBackgroundMode) => void;
+  setBackgroundImage: (dataUrl: string | null) => boolean;
+  setBackgroundImageFit: (v: BackgroundImageFit) => void;
   setAutoRange: (v: boolean) => void;
   setColormap: (id: ColormapId) => void;
   updateAutoRange: (wfDb: Float32Array) => void;
@@ -203,6 +283,22 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
   txDbMin: initialTxRange.txDbMin,
   txDbMax: initialTxRange.txDbMax,
   colormap: 'blue',
+  panBackground: readPanBackground(),
+  backgroundImage: readBackgroundImage(),
+  backgroundImageFit: readBackgroundImageFit(),
+  setPanBackground: (panBackground) => {
+    writePanBackground(panBackground);
+    set({ panBackground });
+  },
+  setBackgroundImage: (dataUrl) => {
+    const ok = writeBackgroundImage(dataUrl);
+    set({ backgroundImage: ok ? dataUrl : get().backgroundImage });
+    return ok;
+  },
+  setBackgroundImageFit: (backgroundImageFit) => {
+    writeBackgroundImageFit(backgroundImageFit);
+    set({ backgroundImageFit });
+  },
   setAutoRange: (autoRange) => {
     if (autoRange) {
       set({ autoRange: true });

--- a/zeus-web/src/state/toolbar-favorites-store.ts
+++ b/zeus-web/src/state/toolbar-favorites-store.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Per-toolbar favorite-slot store for the Mode/Band/Step pickers in the
+// control strip. Each kind keeps an ordered list of three slot keys; the
+// dropdown lets the operator drag any option onto a slot to pin it. Step
+// also stores the currently-selected step value so the toolbar widget and
+// the side-stack widget agree on a single tuning step.
+
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type ToolbarFavKind = 'mode' | 'band' | 'step';
+
+const DEFAULT_MODE: readonly string[] = ['USB', 'LSB', 'CWU'];
+const DEFAULT_BAND: readonly string[] = ['40m', '20m', '15m'];
+const DEFAULT_STEP: readonly string[] = ['100', '500', '1000'];
+const DEFAULT_STEP_HZ = 500;
+
+type ToolbarFavoritesState = {
+  mode: string[];
+  band: string[];
+  step: string[];
+  stepHz: number;
+  setFavorites: (kind: ToolbarFavKind, slots: string[]) => void;
+  setStepHz: (hz: number) => void;
+};
+
+export const useToolbarFavoritesStore = create<ToolbarFavoritesState>()(
+  persist(
+    (set) => ({
+      mode: [...DEFAULT_MODE],
+      band: [...DEFAULT_BAND],
+      step: [...DEFAULT_STEP],
+      stepHz: DEFAULT_STEP_HZ,
+      setFavorites: (kind, slots) => {
+        if (slots.length !== 3) return;
+        if (kind === 'mode') set({ mode: slots });
+        else if (kind === 'band') set({ band: slots });
+        else if (kind === 'step') set({ step: slots });
+      },
+      setStepHz: (hz) => set({ stepHz: hz }),
+    }),
+    { name: 'zeus.toolbar.favorites' },
+  ),
+);

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -435,13 +435,32 @@
 .spectrum-canvas { display: block; width: 100%; background: #081228; transition: opacity 400ms ease, background 400ms ease; }
 .waterfall-canvas { display: block; width: 100%; background: var(--wf-0); transition: opacity 400ms ease, background 400ms ease; }
 
-/* When QRZ engaged, canvases render with genuine alpha (panadapter clears to
-   0,0,0,0; waterfall shader fades noise floor to transparent via uBgAlpha),
-   so the Leaflet map beneath is untouched except where actual signal energy
-   is drawn. No opacity/blend-mode hacks needed. */
-.hero.qrz-mode .spectrum-wrap { background: transparent; }
-.hero.qrz-mode .spectrum-canvas { background: transparent !important; }
-.hero.qrz-mode .waterfall-canvas { background: transparent !important; }
+/* Background-overlay mode (panBackground !== 'basic'): canvases render
+   with genuine alpha (panadapter clears to 0,0,0,0; waterfall shader
+   fades noise floor to transparent via uBgAlpha), so the map / image
+   beneath is untouched except where actual signal energy is drawn. No
+   opacity/blend-mode hacks needed. */
+.hero.bg-active .spectrum-wrap { background: transparent; }
+.hero.bg-active .spectrum-canvas { background: transparent !important; }
+.hero.bg-active .waterfall-canvas { background: transparent !important; }
+
+/* User-supplied still image rendered behind the panadapter when
+   panBackground === 'image'. Sized via the variant class set by
+   backgroundImageFit. */
+.image-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-repeat: no-repeat;
+  background-position: center center;
+  /* Letterbox area in 'fit' mode reads as a deliberate cinematic frame
+     rather than the blue-gray app surface peeking through. */
+  background-color: #000;
+}
+.image-layer.fit { background-size: contain; }
+.image-layer.fill { background-size: cover; }
+.image-layer.stretch { background-size: 100% 100%; }
 
 /* ===== World-map layer (behind spectrum in QRZ mode) ===== */
 .map-layer {

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -138,6 +138,23 @@
 .btn-row { display: flex; gap: 3px; align-items: center; }
 .btn-row.wrap { flex-wrap: wrap; width: 290px; }
 
+/* Thin vertical separator between control-strip groups
+   (Mode | Filter | Band | Step). Faded at top/bottom so it
+   blends with the panel chrome instead of clipping hard. */
+.strip-divider {
+  align-self: stretch;
+  width: 1px;
+  margin: 6px 4px;
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    var(--panel-edge) 20%,
+    var(--panel-edge) 80%,
+    transparent 100%
+  );
+  flex: 0 0 auto;
+}
+
 /* TuningStepWidget — auto-fit grid of equal-width step buttons. Each
    button stays at least 56px wide; when the panel is too narrow to fit
    all 13 buttons in a single row at that floor, the row wraps. Wide

--- a/zeus-web/src/styles/toolbar-favorites.css
+++ b/zeus-web/src/styles/toolbar-favorites.css
@@ -1,0 +1,126 @@
+/* ============================================================
+   Toolbar favorites — Mode / Band / Step pickers in the control
+   strip. Mirrors the FilterPanel + FilterRibbon pattern: three
+   pinned slots beside a "⋯" toggle that opens a popover containing
+   every option. Drag any chip in the popover onto a favorite slot
+   to pin it.
+
+   Visual language matches `.filter-ribbon__chip` so the toolbar
+   reads as a coherent system. Palette: neutral warm gray, accent
+   blue (#4a9eff) for drop-target highlight only.
+   ============================================================ */
+
+.toolbar-fav { /* container shares ctrl-group spacing — no overrides needed */ }
+
+/* Drop-target highlight on a favorite slot button (uses .btn.sm). The same
+   rule is shared by the FilterPanel's three favorite buttons via the bare
+   `.is-drop-target` class so all four toolbar groups (Mode/Band/Step/Filter)
+   light up identically when a draggable chip hovers over them. */
+.toolbar-fav__slot.is-drop-target,
+.btn.sm.is-drop-target {
+  border-color: #4a9eff;
+  border-top-color: #6cb0ff;
+  box-shadow:
+    inset 0 0 0 1px rgba(108, 176, 255, 0.40),
+    inset 0 1px 0 rgba(255, 255, 255, 0.10),
+    0 0 12px rgba(74, 158, 255, 0.20),
+    0 1px 0 rgba(0, 0, 0, 0.35);
+}
+
+/* ----- Popover (portaled into <body>, anchored to the "⋯" button via
+   inline top/left set by the component on open/resize/scroll). Using
+   `position: fixed` so it escapes `.control-strip`'s `overflow: hidden`
+   clip — that's the whole reason for portaling. ----- */
+.toolbar-fav__popover {
+  position: fixed;
+  z-index: 400;
+  min-width: 240px;
+  max-width: 360px;
+  padding: 8px 10px 10px 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: linear-gradient(180deg, #26292f 0%, #1e2025 100%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.04),
+    0 30px 80px rgba(0, 0, 0, 0.55),
+    0 6px 18px rgba(0, 0, 0, 0.35);
+  color: #edeef1;
+}
+
+.toolbar-fav__hint {
+  font-size: 9px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #7c8088;
+  margin-bottom: 6px;
+  user-select: none;
+}
+
+.toolbar-fav__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(56px, 1fr));
+  gap: 4px;
+}
+
+/* ----- Chip in popover (mirrors .filter-ribbon__chip) ----- */
+.toolbar-fav__chip {
+  appearance: none;
+  font-family: inherit;
+  padding: 4px 6px;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  color: #e0e2e6;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.10) 0%, rgba(255, 255, 255, 0) 45%, rgba(0, 0, 0, 0.12) 100%),
+    linear-gradient(180deg, #3a3e45 0%, #2a2d33 100%);
+  border: 1px solid #4a4e55;
+  border-top-color: #585c63;
+  border-bottom-color: #32353b;
+  border-radius: 4px;
+  cursor: grab;
+  font-variant-numeric: tabular-nums;
+  transition: border-color 120ms ease, filter 120ms ease, color 120ms ease;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.10),
+    0 1px 0 rgba(0, 0, 0, 0.35);
+  text-align: center;
+}
+.toolbar-fav__chip:hover {
+  filter: brightness(1.12);
+  border-color: #626670;
+}
+.toolbar-fav__chip:active { cursor: grabbing; }
+
+.toolbar-fav__chip.is-active {
+  color: #ffffff;
+  border-color: #8a8e97;
+  border-top-color: #a4a8b0;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0.02) 45%, rgba(0, 0, 0, 0.10) 100%),
+    linear-gradient(180deg, #52565e 0%, #3a3e45 100%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.22),
+    inset 0 0 0 1px rgba(220, 225, 232, 0.15),
+    0 0 10px rgba(200, 205, 212, 0.10),
+    0 1px 0 rgba(0, 0, 0, 0.40);
+}
+
+/* Pinned chip — subtle accent dot indicating the chip is one of the three
+   currently-pinned favorites in the toolbar slot row. Same indicator is
+   reused on the filter ribbon's PRESETS grid so the operator can see at a
+   glance which presets are already pinned in the FILTER toolbar buttons. */
+.toolbar-fav__chip.is-pinned::after,
+.filter-ribbon__chip.is-pinned::after {
+  content: '';
+  display: inline-block;
+  width: 4px;
+  height: 4px;
+  margin-left: 4px;
+  border-radius: 50%;
+  background: var(--accent, #4a9eff);
+  vertical-align: middle;
+  opacity: 0.75;
+}
+
+.toolbar-fav__chip.is-dragging { opacity: 0.45; }


### PR DESCRIPTION
## Summary
- **Decouples QRZ from the panadapter background.** The "Engage QRZ" button is gone. The QRZ Lookup widget now appears whenever QRZ credentials are configured (`qrzActive`), and submitting a callsign runs a lookup directly.
- **New Display → Panadapter Background setting** with three modes:
  - **Basic** — plain panadapter, no overlay (default).
  - **Beam Map** — world map + terminator lines + beam chrome (the previous QRZ-on look). Lookups gated on QRZ config; beam line gated on rotator config.
  - **Image** — user-supplied image with **Fit / Fill / Stretch** sizing. Drag-and-drop or file-picker in Display tab. Auto-downscaled to 1920 px / JPEG q 0.85 and persisted to `localStorage`. Default sizing is **Fill** so portrait images don't letterbox.
- `terminatorActive` becomes a derived flag (`panBackground === 'beam-map'`) so the existing map / chips / terminator-lines plumbing keeps working unchanged.
- `.qrz-mode` → `.bg-active` since the canvas-transparency rules now serve both map and image overlays.

## Maintainer-review notes
Per `CLAUDE.md`, this touches UX behaviour and visual surfaces (red-light territory):
- The QRZ Engage button is removed; visibility of the QRZ Lookup widget is now driven purely by QRZ being configured.
- New default for the panadapter background is **Basic**, so users who currently boot into the QRZ map will land on the plain panadapter on first reload after this lands. They can pick **Beam Map** in Display to restore the old look.
- New `.bg-active` class supersedes `.qrz-mode`. No external CSS depends on the old name within this repo.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run` — 66/66 passing
- [x] `dotnet build Zeus.slnx` — 0 warnings, 0 errors
- [ ] **Manual:** Display → Panadapter Background → cycle Basic / Beam Map / Image
- [ ] **Manual:** Drag-drop a JPEG into the Image picker; confirm it lands behind a transparent panadapter / waterfall
- [ ] **Manual:** Switch Fit / Fill / Stretch; confirm sizing changes
- [ ] **Manual:** With QRZ configured, confirm the QRZ Lookup widget appears in the side-stack and a callsign lookup populates the contact card
- [ ] **Manual:** With QRZ unconfigured, confirm Beam Map still renders the world map (no contact chips, no lookups)
- [ ] **Manual:** Confirm Clear Image button removes the image and falls back to whatever mode is selected

## Notes
- `develop` on origin is currently 3 commits behind local `develop`; once those land on origin, this PR's diff narrows to just the feature commit.