### PR TITLE
feat(display): operator-selectable RX trace color

### DIFF
--- a/zeus-web/src/components/DisplayPanel.tsx
+++ b/zeus-web/src/components/DisplayPanel.tsx
@@ -22,6 +22,7 @@
 import { useLayoutPreferenceStore, type LayoutMode } from '../state/layout-preference-store';
 import { useLayoutStore } from '../state/layout-store';
 import { BackgroundSettingsPanel } from './BackgroundSettingsPanel';
+import { TraceColorPanel } from './TraceColorPanel';
 
 export function DisplayPanel() {
   const layoutMode = useLayoutPreferenceStore((s) => s.layoutMode);
@@ -44,6 +45,8 @@ export function DisplayPanel() {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
       <BackgroundSettingsPanel />
+
+      <TraceColorPanel />
 
       <section>
         <h3 style={{

--- a/zeus-web/src/components/Panadapter.tsx
+++ b/zeus-web/src/components/Panadapter.tsx
@@ -43,7 +43,7 @@
 // License for details.
 
 import { useEffect, useRef } from 'react';
-import { createPanRenderer } from '../gl/panadapter';
+import { createPanRenderer, hexToRgbFloats } from '../gl/panadapter';
 import { planWaterfallUpdate } from '../gl/wf-shift';
 import { useDisplayStore } from '../state/display-store';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
@@ -94,6 +94,8 @@ export function Panadapter() {
       const keyed = moxOn || tunOn;
       const dbMin = keyed ? s.txDbMin : s.dbMin;
       const dbMax = keyed ? s.txDbMax : s.dbMax;
+      const { r, g, b } = hexToRgbFloats(s.rxTraceColor);
+      renderer.setTraceColor(r, g, b);
       renderer.draw(drawPan, dbMin, dbMax, drawOffsetPx);
     };
     const requestRedraw = () => {

--- a/zeus-web/src/components/TraceColorPanel.tsx
+++ b/zeus-web/src/components/TraceColorPanel.tsx
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+import { useDisplaySettingsStore } from '../state/display-settings-store';
+
+const SWATCHES: ReadonlyArray<{ id: string; label: string; color: string }> = [
+  { id: 'amber',   label: 'Amber',   color: '#FFA028' },
+  { id: 'orange',  label: 'Orange',  color: '#FF7A2E' },
+  { id: 'yellow',  label: 'Yellow',  color: '#FFD93A' },
+  { id: 'red',     label: 'Red',     color: '#FF4A5B' },
+  { id: 'lime',    label: 'Lime',    color: '#A8E63A' },
+  { id: 'green',   label: 'Green',   color: '#33D17A' },
+  { id: 'mint',    label: 'Mint',    color: '#3AE6C5' },
+  { id: 'cyan',    label: 'Cyan',    color: '#5BE5FF' },
+  { id: 'sky',     label: 'Sky',     color: '#4A9EFF' },
+  { id: 'purple',  label: 'Purple',  color: '#A66BFF' },
+  { id: 'magenta', label: 'Magenta', color: '#FF5BC8' },
+  { id: 'white',   label: 'White',   color: '#E8ECF4' },
+];
+
+export function TraceColorPanel() {
+  const rxTraceColor = useDisplaySettingsStore((s) => s.rxTraceColor);
+  const setRxTraceColor = useDisplaySettingsStore((s) => s.setRxTraceColor);
+  const norm = rxTraceColor.toUpperCase();
+
+  return (
+    <section>
+      <h3 style={sectionH3}>RX Trace Color</h3>
+      <p style={sectionP}>
+        Color of the RX panadapter trace and its fill. Affects only the
+        spectrum graph — meters, S-meter, and passband overlays keep their
+        own colors.
+      </p>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)', gap: 8 }}>
+        {SWATCHES.map((s) => {
+          const active = s.color.toUpperCase() === norm;
+          return (
+            <button
+              key={s.id}
+              type="button"
+              title={s.label}
+              aria-label={s.label}
+              aria-pressed={active}
+              onClick={() => setRxTraceColor(s.color)}
+              style={swatchStyle(s.color, active)}
+            />
+          );
+        })}
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginTop: 14 }}>
+        <label
+          htmlFor="rx-trace-color-custom"
+          style={{
+            fontSize: 11,
+            fontWeight: 600,
+            color: 'var(--fg-1)',
+            textTransform: 'uppercase',
+            letterSpacing: '0.08em',
+          }}
+        >
+          Custom
+        </label>
+        <input
+          id="rx-trace-color-custom"
+          type="color"
+          value={norm}
+          onChange={(e) => setRxTraceColor(e.target.value.toUpperCase())}
+          style={{
+            width: 44,
+            height: 28,
+            padding: 0,
+            border: '1px solid var(--line)',
+            borderRadius: 'var(--r-xs)',
+            background: 'transparent',
+            cursor: 'pointer',
+          }}
+        />
+        <span
+          style={{
+            fontSize: 11,
+            color: 'var(--fg-2)',
+            fontFamily: 'var(--font-mono, ui-monospace, monospace)',
+            letterSpacing: '0.04em',
+          }}
+        >
+          {norm}
+        </span>
+      </div>
+    </section>
+  );
+}
+
+const sectionH3: React.CSSProperties = {
+  margin: '0 0 10px 0',
+  fontSize: 11,
+  fontWeight: 700,
+  letterSpacing: '0.12em',
+  textTransform: 'uppercase',
+  color: 'var(--fg-0)',
+};
+const sectionP: React.CSSProperties = {
+  margin: '0 0 12px 0',
+  fontSize: 12,
+  lineHeight: 1.5,
+  color: 'var(--fg-2)',
+};
+function swatchStyle(color: string, active: boolean): React.CSSProperties {
+  return {
+    width: '100%',
+    aspectRatio: '1.6 / 1',
+    padding: 0,
+    borderRadius: 'var(--r-sm)',
+    background: color,
+    border: '2px solid',
+    borderColor: active ? 'var(--accent)' : 'var(--line)',
+    cursor: 'pointer',
+    transition: 'border-color var(--dur-fast)',
+  };
+}

--- a/zeus-web/src/gl/panadapter.ts
+++ b/zeus-web/src/gl/panadapter.ts
@@ -60,17 +60,38 @@ export type PanRenderer = {
     dbMax: number,
     offsetPx: number,
   ) => void;
+  // Update the trace + fill colour. Components 0..1, premultiplied alpha is
+  // applied inside draw via the FILL_ALPHA_TOP uniform; callers pass plain
+  // RGB. No GL re-init — the next draw picks up the new uniform values.
+  setTraceColor: (r: number, g: number, b: number) => void;
   dispose: () => void;
 };
 
-// Premultiplied-alpha trace colour (0xFFA028 roughly — warm amber).
-const TRACE_R = 1.0;
-const TRACE_G = 0.627;
-const TRACE_B = 0.157;
+// Convert a #RRGGBB string into the 0..1 RGB triplet the renderer wants.
+// Malformed input falls back to amber so a typo can never crash GL.
+export function hexToRgbFloats(hex: string): { r: number; g: number; b: number } {
+  const m = /^#([0-9A-Fa-f]{2})([0-9A-Fa-f]{2})([0-9A-Fa-f]{2})$/.exec(hex);
+  if (!m || m[1] === undefined || m[2] === undefined || m[3] === undefined) {
+    return { r: 1.0, g: 0.627, b: 0.157 };
+  }
+  return {
+    r: parseInt(m[1], 16) / 255,
+    g: parseInt(m[2], 16) / 255,
+    b: parseInt(m[3], 16) / 255,
+  };
+}
+
 // Fade at the trace edge; fragment alpha drops to 0 at the floor.
 const FILL_ALPHA_TOP = 0.55;
 
 export function createPanRenderer(gl: WebGL2RenderingContext): PanRenderer {
+  // Mutable trace colour, default amber. setTraceColor swaps these in place;
+  // every draw reads the current values into the fill + line uniforms so the
+  // operator's choice from the Display tab takes effect on the next frame.
+  let traceR = 1.0;
+  let traceG = 0.627;
+  let traceB = 0.157;
+
   const traceProg = buildProgram(gl, PAN_VS, PAN_FS);
   const uTraceWidth = gl.getUniformLocation(traceProg, 'uWidth');
   const uTraceDbMin = gl.getUniformLocation(traceProg, 'uDbMin');
@@ -176,7 +197,7 @@ export function createPanRenderer(gl: WebGL2RenderingContext): PanRenderer {
       gl.uniform1f(uFillDbMin, dbMin);
       gl.uniform1f(uFillDbMax, dbMax);
       gl.uniform1f(uFillOffsetPx, offsetPx);
-      gl.uniform3f(uFillColor, TRACE_R, TRACE_G, TRACE_B);
+      gl.uniform3f(uFillColor, traceR, traceG, traceB);
       gl.uniform1f(uFillAlphaTop, FILL_ALPHA_TOP);
       gl.drawArrays(gl.TRIANGLE_STRIP, 0, panDb.length * 2);
 
@@ -195,7 +216,7 @@ export function createPanRenderer(gl: WebGL2RenderingContext): PanRenderer {
       gl.uniform1f(uTraceDbMin, dbMin);
       gl.uniform1f(uTraceDbMax, dbMax);
       gl.uniform1f(uTraceOffsetPx, offsetPx);
-      gl.uniform3f(uTraceColor, TRACE_R, TRACE_G, TRACE_B);
+      gl.uniform3f(uTraceColor, traceR, traceG, traceB);
       gl.drawArrays(gl.LINE_STRIP, 0, panDb.length);
 
       gl.useProgram(cursorProg);
@@ -204,6 +225,11 @@ export function createPanRenderer(gl: WebGL2RenderingContext): PanRenderer {
       gl.drawArrays(gl.LINES, 0, 2);
 
       gl.bindVertexArray(null);
+    },
+    setTraceColor(r, g, b) {
+      traceR = r;
+      traceG = g;
+      traceB = b;
     },
     dispose() {
       gl.deleteBuffer(traceVbo);

--- a/zeus-web/src/state/display-settings-store.ts
+++ b/zeus-web/src/state/display-settings-store.ts
@@ -67,6 +67,16 @@ const WF_STORAGE_KEY = 'zeus.display.wfDbRange';
 const PAN_BG_KEY = 'zeus.display.panBackground';
 const BG_IMAGE_KEY = 'zeus.display.backgroundImage';
 const BG_FIT_KEY = 'zeus.display.backgroundImageFit';
+const RX_TRACE_COLOR_KEY = 'zeus.display.rxTraceColor';
+
+// Default RX panadapter trace colour — warm amber, matching the original
+// hardcoded constant in gl/panadapter.ts. Operators can pick another colour
+// from the Display tab; the choice is persisted to localStorage.
+export const DEFAULT_RX_TRACE_COLOR = '#FFA028';
+
+function isHexColor(v: unknown): v is string {
+  return typeof v === 'string' && /^#[0-9A-Fa-f]{6}$/.test(v);
+}
 
 // Panadapter background mode. 'basic' = no overlay (current QRZ-off
 // look). 'beam-map' = world-map overlay with terminator lines and beam
@@ -133,6 +143,19 @@ function readBackgroundImageFit(): BackgroundImageFit {
 }
 function writeBackgroundImageFit(v: BackgroundImageFit): void {
   try { if (typeof localStorage !== 'undefined') localStorage.setItem(BG_FIT_KEY, v); } catch { /* quota */ }
+}
+
+function readRxTraceColor(): string {
+  try {
+    if (typeof localStorage === 'undefined') return DEFAULT_RX_TRACE_COLOR;
+    const raw = localStorage.getItem(RX_TRACE_COLOR_KEY);
+    return isHexColor(raw) ? raw.toUpperCase() : DEFAULT_RX_TRACE_COLOR;
+  } catch {
+    return DEFAULT_RX_TRACE_COLOR;
+  }
+}
+function writeRxTraceColor(v: string): void {
+  try { if (typeof localStorage !== 'undefined') localStorage.setItem(RX_TRACE_COLOR_KEY, v); } catch { /* quota */ }
 }
 
 function readSavedRange(): { dbMin: number; dbMax: number } {
@@ -251,9 +274,13 @@ export type DisplaySettingsState = {
   panBackground: PanBackgroundMode;
   backgroundImage: string | null;
   backgroundImageFit: BackgroundImageFit;
+  // RX panadapter trace colour as #RRGGBB. Drives both the sharp trace line
+  // and the fill underneath in gl/panadapter.ts (kept in lockstep).
+  rxTraceColor: string;
   setPanBackground: (v: PanBackgroundMode) => void;
   setBackgroundImage: (dataUrl: string | null) => boolean;
   setBackgroundImageFit: (v: BackgroundImageFit) => void;
+  setRxTraceColor: (v: string) => void;
   setAutoRange: (v: boolean) => void;
   setColormap: (id: ColormapId) => void;
   updateAutoRange: (wfDb: Float32Array) => void;
@@ -286,6 +313,7 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
   panBackground: readPanBackground(),
   backgroundImage: readBackgroundImage(),
   backgroundImageFit: readBackgroundImageFit(),
+  rxTraceColor: readRxTraceColor(),
   setPanBackground: (panBackground) => {
     writePanBackground(panBackground);
     set({ panBackground });
@@ -298,6 +326,12 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
   setBackgroundImageFit: (backgroundImageFit) => {
     writeBackgroundImageFit(backgroundImageFit);
     set({ backgroundImageFit });
+  },
+  setRxTraceColor: (v) => {
+    if (!isHexColor(v)) return;
+    const norm = v.toUpperCase();
+    writeRxTraceColor(norm);
+    set({ rxTraceColor: norm });
   },
   setAutoRange: (autoRange) => {
     if (autoRange) {


### PR DESCRIPTION
## Summary

Adds an **RX Trace Color** section to **Settings → Display**, sibling to Brian's new Panadapter Background panel from #181. Operator picks from a 12-swatch palette (Amber default, plus Orange/Yellow/Red/Lime/Green/Mint/Cyan/Sky/Purple/Magenta/White) or a custom hex via the native color picker. Choice persists in `localStorage` at `zeus.display.rxTraceColor`.

Trace line and fill always match — changing one changes both, in lockstep, no GL re-init.

## Scope

Intentionally narrow — only the WebGL trace + fill in `zeus-web/src/gl/panadapter.ts`. **Meters, S-meter, passband overlay, alert banner, About panel, and any other amber chrome are untouched.** Brian's amber accents stay exactly where they are.

Default is `#FFA028` (current amber), so first-connect aesthetic and existing installs are visually unchanged.

## Implementation notes

- New `rxTraceColor` slice in `display-settings-store.ts`, `localStorage`-only, no backend round-trip (mirrors how `panBackground` from #181 is wired)
- `gl/panadapter.ts` gets a `setTraceColor(r, g, b)` method on `PanRenderer`. The compile-time `TRACE_R/G/B` constants are now mutable closure state initialized to amber
- `Panadapter.tsx` calls `renderer.setTraceColor(...)` in its existing `redraw()` path; the existing `useDisplaySettingsStore.subscribe` already triggers redraws on store changes, so swatch clicks update the GL view immediately
- New `TraceColorPanel.tsx` component, dropped into `DisplayPanel.tsx` between `BackgroundSettingsPanel` and `Layout Mode`

## Test plan

- [ ] Build clean (`npm --prefix zeus-web run build`) — verified locally
- [ ] Default install shows amber trace, identical to before
- [ ] Clicking each swatch changes trace + fill instantly, no reload
- [ ] Selection persists across reload
- [ ] Custom picker writes a valid hex; malformed values silently no-op
- [ ] Meters / S-meter / passband edges remain amber regardless of trace selection
- [ ] Trace color survives MOX/TUN (TX panadapter uses the same renderer)

Tested locally on G2 MkII with all 12 swatches plus a few custom values; trace and fill stay in lockstep on RX and during TUN.