### PR TITLE
fix(linux/macos): pin bundled libwdsp + guard EMNR post2 against stale libs

### DIFF
--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -577,13 +577,13 @@ public sealed class WdspDspEngine : IDspEngine
                 // pre-dates Phase 1 (no SBNR exports) leaves the channel in
                 // NR-off rather than crashing the worker.
                 NativeMethods.SetRXAANRRun(channelId, 0);
-                NativeMethods.SetRXAEMNRpost2Run(channelId, 0);
+                TrySetEmnrPost2Run(channelId, 0);
                 NativeMethods.SetRXAEMNRRun(channelId, 0);
                 ApplyNr4Sbnr(channelId, cfg);
                 break;
             default:
                 NativeMethods.SetRXAANRRun(channelId, 0);
-                NativeMethods.SetRXAEMNRpost2Run(channelId, 0);
+                TrySetEmnrPost2Run(channelId, 0);
                 NativeMethods.SetRXAEMNRRun(channelId, 0);
                 TrySetSbnrRun(channelId, 0);
                 break;
@@ -665,15 +665,27 @@ public sealed class WdspDspEngine : IDspEngine
     // before flipping post2Run so the post-processing stage starts coherent.
     // Null fields fall back to NrDefaults so the operator's "leave it default"
     // choice (cleared field) is honoured at write time without baking the
-    // current default into the persisted config.
-    private static void ApplyNr2Post2(int channelId, NrConfig cfg)
+    // current default into the persisted config. Wrapped in try/catch so a
+    // libwdsp.so built before the post2 exports landed (or a stale system
+    // copy shadowing the bundled one) leaves NR2 running without comfort-noise
+    // instead of crashing the worker.
+    private void ApplyNr2Post2(int channelId, NrConfig cfg)
     {
-        NativeMethods.SetRXAEMNRpost2Factor(channelId, cfg.EmnrPost2Factor ?? NrDefaults.EmnrPost2Factor);
-        NativeMethods.SetRXAEMNRpost2Nlevel(channelId, cfg.EmnrPost2Nlevel ?? NrDefaults.EmnrPost2Nlevel);
-        NativeMethods.SetRXAEMNRpost2Rate(channelId, cfg.EmnrPost2Rate ?? NrDefaults.EmnrPost2Rate);
-        NativeMethods.SetRXAEMNRpost2Taper(channelId, cfg.EmnrPost2Taper ?? NrDefaults.EmnrPost2Taper);
-        bool runOn = cfg.EmnrPost2Run ?? (NrDefaults.EmnrPost2Run != 0);
-        NativeMethods.SetRXAEMNRpost2Run(channelId, runOn ? 1 : 0);
+        try
+        {
+            NativeMethods.SetRXAEMNRpost2Factor(channelId, cfg.EmnrPost2Factor ?? NrDefaults.EmnrPost2Factor);
+            NativeMethods.SetRXAEMNRpost2Nlevel(channelId, cfg.EmnrPost2Nlevel ?? NrDefaults.EmnrPost2Nlevel);
+            NativeMethods.SetRXAEMNRpost2Rate(channelId, cfg.EmnrPost2Rate ?? NrDefaults.EmnrPost2Rate);
+            NativeMethods.SetRXAEMNRpost2Taper(channelId, cfg.EmnrPost2Taper ?? NrDefaults.EmnrPost2Taper);
+            bool runOn = cfg.EmnrPost2Run ?? (NrDefaults.EmnrPost2Run != 0);
+            NativeMethods.SetRXAEMNRpost2Run(channelId, runOn ? 1 : 0);
+        }
+        catch (EntryPointNotFoundException ex)
+        {
+            _log.LogWarning(
+                "wdsp.emnr.post2.unavailable channel={Id} reason=\"libwdsp does not export SetRXAEMNRpost2* — bundled .so is being shadowed by an older system copy, or the build pre-dates post2 support\" detail={Msg}",
+                channelId, ex.Message);
+        }
     }
 
     // NR4 (SBNR / libspecbleach) parameter push + Run=1. Native setters take
@@ -708,6 +720,16 @@ public sealed class WdspDspEngine : IDspEngine
     {
         try { NativeMethods.SetRXASBNRRun(channelId, run); }
         catch (EntryPointNotFoundException) { /* libwdsp pre-Phase-1; SBNR is a no-op */ }
+    }
+
+    // Same shape as TrySetSbnrRun for the post2 Run=0 calls we issue when
+    // switching away from NR2. A stale libwdsp.so on the operator's machine
+    // (e.g. an older copy in /usr/local/lib shadowing the bundled .so) would
+    // otherwise throw EntryPointNotFoundException straight up the worker.
+    private void TrySetEmnrPost2Run(int channelId, int run)
+    {
+        try { NativeMethods.SetRXAEMNRpost2Run(channelId, run); }
+        catch (EntryPointNotFoundException) { /* libwdsp lacks post2; nothing to turn off */ }
     }
 
     // Post-RXA NR defaults — sourced from Thetis setup.designer.cs + radio.cs.

--- a/installers/create-linux-package.sh
+++ b/installers/create-linux-package.sh
@@ -36,6 +36,14 @@ cat > "${PACKAGE_DIR}/zeus" << 'EOF'
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "${SCRIPT_DIR}"
 
+# Pin the bundled libwdsp.so so an older system copy in /usr/lib or
+# /usr/local/lib (e.g. left by a piHPSDR build) cannot shadow it. Linux
+# does NOT search the executable's directory by default; without this
+# line, dlopen("libwdsp.so") goes straight to LD_LIBRARY_PATH +
+# /etc/ld.so.cache and may bind P/Invoke calls against a stale lib that
+# pre-dates symbols Zeus relies on (e.g. SetRXAEMNRpost2*).
+export LD_LIBRARY_PATH="${SCRIPT_DIR}/runtimes/linux-x64/native:${SCRIPT_DIR}/runtimes/linux-arm64/native:${LD_LIBRARY_PATH}"
+
 # Check if running in a display environment
 if [ -n "$DISPLAY" ] || [ -n "$WAYLAND_DISPLAY" ]; then
     echo "Starting Zeus server on http://localhost:6060"

--- a/installers/create-macos-app.sh
+++ b/installers/create-macos-app.sh
@@ -107,6 +107,15 @@ cat > "${APP_BUNDLE}/Contents/MacOS/launch.sh" << 'EOF'
 #!/bin/bash
 cd "$(dirname "$0")"
 
+# Pin the bundled libwdsp.dylib so an older copy in /usr/local/lib or
+# /opt/homebrew/lib (e.g. from a piHPSDR / DeskHPSDR install) cannot
+# shadow it. macOS dlopen does not search the executable's directory by
+# default, so without this line P/Invoke can bind against a stale dylib
+# that pre-dates symbols Zeus relies on (e.g. SetRXAEMNRpost2*). Both
+# arches are listed so the same launcher works on arm64 and x64 builds;
+# the loader silently skips a path that does not exist.
+export DYLD_LIBRARY_PATH="$(pwd)/runtimes/osx-arm64/native:$(pwd)/runtimes/osx-x64/native:${DYLD_LIBRARY_PATH}"
+
 ./Zeus.Server &
 SERVER_PID=$!
 


### PR DESCRIPTION
## Summary

A v0.3.1 Linux user hit `EntryPointNotFoundException` for `SetRXAEMNRpost2Run` on radio connect. Investigation: the bundled `libwdsp.so` (verified by extracting the v0.3.1 release tarball — md5 matches the git tag, all 5 `SetRXAEMNRpost2*` and 8 `SetRXASBNR*` exports present) was being **shadowed at runtime** by an older copy elsewhere on the user's machine.

Root cause: Linux/macOS `dlopen` does not search the executable's directory by default. When .NET asks for `libwdsp.so` with no path, the OS goes to `LD_LIBRARY_PATH` → `/etc/ld.so.cache` → `/usr/lib` etc., and a stale `libwdsp.so` from an older piHPSDR / DeskHPSDR install in `/usr/local/lib` (or the macOS equivalent) gets bound to the P/Invoke instead of our bundle.

This PR fixes it two ways — primary fix + belt-and-braces:

### 1. Primary: pin the bundled lib in the launcher (`installers/create-linux-package.sh`, `create-macos-app.sh`)

Both launchers now prepend the bundled native dir to `LD_LIBRARY_PATH` (Linux) / `DYLD_LIBRARY_PATH` (macOS) before invoking `Zeus.Server`. The bundled `.so` / `.dylib` always wins; system shadows can never get loaded again. Both arches are listed (`linux-x64` + `linux-arm64`, `osx-arm64` + `osx-x64`); the loader silently skips a path that does not exist, so the same launcher works for either build.

### 2. Defensive: wrap `SetRXAEMNRpost2*` in `WdspDspEngine.cs`

Mirrors the existing `TrySetSbnrRun` / `ApplyNr4Sbnr` pattern. If `libwdsp` ever lacks the post2 exports for any reason (older bundle, exotic loader edge case, future build skew), Zeus logs a warning and NR2 runs without comfort-noise instead of taking the worker down. Should never fire after the primary fix lands, but we already had this shape for SBNR and it cost us nothing to add for post2.

Targets `develop` so it ships in the next tagged release.

## Test plan

- [x] `dotnet build Zeus.Dsp/Zeus.Dsp.csproj -c Release` — clean
- [x] `dotnet test tests/Zeus.Dsp.Tests --filter NoiseReduction` — 107 passed, 96 gated-skipped, 0 failed
- [x] Verified shipped v0.3.1 Linux tarball already contains correct `libwdsp.so` (md5 `ffd5384b…` = git tag), so the bug is loader-order, not packaging
- [ ] CI green
- [ ] Manual Linux: extract the new tarball next to a deliberately stale `/usr/local/lib/libwdsp.so`; confirm Zeus loads the bundled one (`LD_DEBUG=libs ./zeus 2>&1 | grep wdsp` shows the tarball path)
- [ ] Manual macOS: same with a stale `/usr/local/lib/libwdsp.dylib`