### PR TITLE
fix(release/linux): bundle libfftw3 in tarball so it runs without system fftw

### DIFF
--- a/.github/workflows/build-native-libs.yml
+++ b/.github/workflows/build-native-libs.yml
@@ -195,11 +195,32 @@ jobs:
           mkdir -p "$destDir"
           cp native/build/libwdsp.so "$destDir/libwdsp.so"
 
+      - name: Bundle FFTW3 alongside libwdsp.so (x64)
+        if: matrix.arch == 'x64'
+        run: |
+          # Ship the FFTW3 dynamic libs in the tarball so the launcher's
+          # LD_LIBRARY_PATH (set in installers/create-linux-package.sh to
+          # runtimes/linux-x64/native/) finds them and the user does NOT need
+          # libfftw3 installed system-wide. readlink -f resolves the SONAME
+          # symlink so we copy the real .so file, then rename it back to the
+          # SONAME filename libwdsp.so was linked against.
+          set -eux
+          destDir="Zeus.Dsp/runtimes/linux-x64/native"
+          for soname in libfftw3.so.3 libfftw3f.so.3; do
+            src=$(readlink -f "/usr/lib/x86_64-linux-gnu/$soname")
+            test -f "$src"
+            cp "$src" "$destDir/$soname"
+          done
+          ls -la "$destDir/"
+          ldd "$destDir/libwdsp.so"
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: wdsp-linux-${{ matrix.arch }}
-          path: Zeus.Dsp/runtimes/linux-${{ matrix.arch }}/native/libwdsp.so
+          # Directory upload (not a single file) so the bundled FFTW .so.3
+          # files in the x64 build land in the artifact alongside libwdsp.so.
+          path: Zeus.Dsp/runtimes/linux-${{ matrix.arch }}/native/
 
   commit-libraries:
     name: Commit Native Libraries
@@ -218,35 +239,25 @@ jobs:
 
       - name: Stage all libraries
         run: |
-          # actions/upload-artifact@v4 strips the directory prefix when the
-          # `path:` is a single file, so each artifact arrives as a flat
-          # `<filename>` at the artifact root. Place each one explicitly
-          # under Zeus.Dsp/runtimes/<rid>/native/ — the previous
-          # `cp -r "$artifact"/* .` left them at the repo root, where the
-          # commit step's `git add Zeus.Dsp/runtimes/` could never see them.
+          # Each artifact's root contains the runtime files staged by its
+          # build job — a single .dll/.so for windows / linux-arm64, plus the
+          # bundled libfftw3.so.3 / libfftw3f.so.3 for linux-x64. Copy whole
+          # contents into the matching runtimes/<rid>/native/ destination
+          # rather than picking out a single file by name.
           set -eux
           for artifact_dir in artifacts/wdsp-*; do
             artifact_name=$(basename "$artifact_dir")  # e.g. wdsp-windows-x64
             case "$artifact_name" in
-              wdsp-windows-x64)
-                dest=Zeus.Dsp/runtimes/win-x64/native/wdsp.dll
-                src=$artifact_dir/wdsp.dll
-                ;;
-              wdsp-linux-x64)
-                dest=Zeus.Dsp/runtimes/linux-x64/native/libwdsp.so
-                src=$artifact_dir/libwdsp.so
-                ;;
-              wdsp-linux-arm64)
-                dest=Zeus.Dsp/runtimes/linux-arm64/native/libwdsp.so
-                src=$artifact_dir/libwdsp.so
-                ;;
+              wdsp-windows-x64) destDir=Zeus.Dsp/runtimes/win-x64/native ;;
+              wdsp-linux-x64)   destDir=Zeus.Dsp/runtimes/linux-x64/native ;;
+              wdsp-linux-arm64) destDir=Zeus.Dsp/runtimes/linux-arm64/native ;;
               *)
                 echo "Unrecognised artifact $artifact_name — refusing to guess destination" >&2
                 exit 1
                 ;;
             esac
-            mkdir -p "$(dirname "$dest")"
-            cp "$src" "$dest"
+            mkdir -p "$destDir"
+            cp -p "$artifact_dir"/* "$destDir/"
           done
 
       - name: Commit and push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,8 @@ jobs:
           ### Linux (x64)
           - **zeus-${{ steps.version.outputs.version }}-linux-x64.tar.gz** - Linux x64 tarball
             - Extract and run `./zeus` from the extracted directory
-            - Requires libfftw3 (usually pre-installed)
+            - Self-contained: bundles the .NET runtime and statically embeds
+              FFTW3 into libwdsp.so, so no system packages are required
 
           ## Changes
 

--- a/Zeus.Dsp/Zeus.Dsp.csproj
+++ b/Zeus.Dsp/Zeus.Dsp.csproj
@@ -21,7 +21,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>runtimes/%(RecursiveDir)%(Filename)%(Extension)</Link>
     </None>
-    <None Include="runtimes/**/*.so" Pack="true" PackagePath="runtimes/">
+    <!-- *.so* (not *.so) so SONAME-versioned bundled deps like
+         libfftw3.so.3 / libfftw3f.so.3 are picked up alongside libwdsp.so. -->
+    <None Include="runtimes/**/*.so*" Pack="true" PackagePath="runtimes/">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>runtimes/%(RecursiveDir)%(Filename)%(Extension)</Link>
     </None>

--- a/installers/create-linux-package.sh
+++ b/installers/create-linux-package.sh
@@ -88,8 +88,8 @@ Command line usage:
   ./Zeus.Server    # Start Zeus server only (manual browser access)
 
 Requirements:
-- Linux x64 system
-- libfftw3 (usually installed by default on most distributions)
+- Linux x64 system (glibc-based; no system packages required — FFTW3 is
+  statically linked into libwdsp.so and the .NET runtime is bundled)
 
 For more information:
 https://github.com/brianbruff/openhpsdr-zeus


### PR DESCRIPTION
## Summary

The shipped Linux x64 tarball (`zeus-*-linux-x64.tar.gz`) fails at startup on systems that don't already have `libfftw3` installed (Ubuntu Server, minimal/cloud images, headless Fedora, etc.):

```
fail: Zeus.Dsp.Wdsp.WdspWisdomInitializer[0]
      wdsp.wisdom failed — subsequent FFT planning will take the slow path
      System.DllNotFoundException: Unable to load shared library 'wdsp' or one of its dependencies.
      ...
      libfftw3f.so.3: cannot open shared object file: No such file or directory
```

`libwdsp.so` dynamically links against `libfftw3.so.3` / `libfftw3f.so.3`. When the dynamic linker can't find them, WDSP never initialises and the DSP pipeline silently falls back to the synthetic engine. The release notes claimed "Requires libfftw3 (usually pre-installed)" — that's not true on Ubuntu Server / minimal images.

## Approach — bundle, not static-link

Bundle the FFTW3 SONAME files (`libfftw3.so.3`, `libfftw3f.so.3`) inside `runtimes/linux-x64/native/` alongside `libwdsp.so`. The Linux launcher's existing `LD_LIBRARY_PATH` already points at that directory, so `dlopen` resolves the bundled copies before anything system-wide.

Considered static-linking FFTW into `libwdsp.so` (mirrors the Windows vcpkg static-md path); rejected as more invasive — touches CMake detection logic, depends on Ubuntu's `libfftw3.a` being PIC. Bundling is two extra files in the tarball and zero changes to the native build.

## Changes

- **`build-native-libs.yml`** — new `Bundle FFTW3 alongside libwdsp.so (x64)` step that copies the runner's `libfftw3.so.3` / `libfftw3f.so.3` into the staged native dir. Switch the linux-x64 artifact upload from a single-file path to the directory so all three `.so` files travel together. Simplify `commit-libraries` to copy whole artifact contents instead of one file per case (windows/arm64 behaviour unchanged — their artifacts still contain just one file each).
- **`Zeus.Dsp/Zeus.Dsp.csproj`** — broaden the `<None>` glob from `runtimes/**/*.so` to `runtimes/**/*.so*` so SONAME-versioned files like `libfftw3.so.3` are picked up by `dotnet publish`.
- **`release.yml`** + **`installers/create-linux-package.sh`** — fix the now-incorrect "Requires libfftw3" notes.

linux-arm64 is **not** changed — it isn't in the release matrix today. Same treatment when it ships.

## Test plan

CI must verify before merge:

- [ ] `build-native-libs` workflow runs on this branch and the new `Bundle FFTW3` step succeeds
- [ ] `commit-libraries` job pushes `libfftw3.so.3` and `libfftw3f.so.3` into `Zeus.Dsp/runtimes/linux-x64/native/` on `main` after merge
- [ ] After the next release tag, the `linux-x64.tar.gz` contains all three files at `runtimes/linux-x64/native/`: `tar tzf zeus-*-linux-x64.tar.gz | grep -E '(wdsp|fftw)'`
- [ ] On a Linux box **without** `libfftw3` installed, `./zeus` starts and the log shows `wdsp.wisdom` running (no `DllNotFoundException`)
- [ ] Existing tests still pass — verified locally: 575 passed, 102 skipped, 0 failed