### PR TITLE
ci(native-libs): open auto-PR instead of pushing direct to protected main

### DIFF
--- a/.github/workflows/build-native-libs.yml
+++ b/.github/workflows/build-native-libs.yml
@@ -229,6 +229,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
@@ -260,14 +261,39 @@ jobs:
             cp -p "$artifact_dir"/* "$destDir/"
           done
 
-      - name: Commit and push
+      - name: Open or update auto-PR with rebuilt libraries
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Branch protection on main blocks direct pushes by github-actions[bot]
+          # (GH006 "Changes must be made through a pull request"). Push to a
+          # stable bot branch and open / refresh a PR there instead — re-runs
+          # force-push and update the existing PR rather than spawning new ones.
+          set -eux
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Zeus.Dsp/runtimes/
           if git diff --staged --quiet; then
             echo "No changes to commit"
+            exit 0
+          fi
+
+          branch="auto/native-libs-update"
+          git checkout -b "$branch"
+          git commit -m "build: update native WDSP libraries for Windows and Linux"
+          # Force-push so re-runs replace the bot branch in place.
+          git push --force origin "$branch"
+
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if [ -n "$(gh pr list --head "$branch" --state open --json number --jq '.[0].number')" ]; then
+            echo "PR already open for $branch — branch updated by force-push"
           else
-            git commit -m "build: update native WDSP libraries for Windows and Linux"
-            git push
+            body=$(printf '%s\n\n%s\n\n%s\n' \
+              "Automated rebuild of native WDSP libraries from [build-native-libs run]($run_url)." \
+              "Merge after sanity-checking the staged binaries (size, ldd, dumpbin /EXPORTS, etc)." \
+              "The bot will force-push this branch on every native-libs rebuild — re-runs reuse this PR rather than opening a new one.")
+            gh pr create \
+              --base main --head "$branch" \
+              --title "build: update native WDSP libraries (auto)" \
+              --body "$body"
           fi


### PR DESCRIPTION
## Summary

The `commit-libraries` job in `build-native-libs.yml` has been silently failing on every native-libs rebuild since main-branch protection was enabled:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
```

That's how the v0.4.0 and v0.4.1 tarballs shipped without the bundled `libfftw3.so.3` — the build job produced the right binaries (incl. fftw bundling per #186), but `commit-libraries` couldn't get them into the repo.

## Fix

- Push the rebuilt libraries to a stable `auto/native-libs-update` branch
- Open a PR there if none is open; re-runs force-push to update the existing PR in place
- Add `pull-requests: write` permission to the job

## Why not auto-merge

Intentionally **not** auto-merging the bot's PR. Native libs are binary blobs that benefit from a sanity check (size / `ldd` / `dumpbin /EXPORTS`) before they land — auto-merge would just route around the protection rule.

## Test plan

- [ ] Workflow still parses (validated locally with `ruby -ryaml`)
- [ ] After merge, the next push to `main` that touches `native/**` opens a PR titled `build: update native WDSP libraries (auto)` instead of failing with GH006
- [ ] A second rebuild on the same content does not open a duplicate PR — it force-pushes the existing branch
- [ ] When the auto-PR is merged, the next rebuild with new content opens a fresh PR (no leftover branch state)