### PR TITLE
ci(mobile): iOS Simulator sanity build + local-sign README path

### DIFF
--- a/.github/workflows/build-mobile-android.yml
+++ b/.github/workflows/build-mobile-android.yml
@@ -1,0 +1,97 @@
+name: Build Android APK
+
+# Builds an unsigned debug APK of the Zeus Capacitor wrapper. The APK is
+# uploaded as a workflow artifact you can sideload onto a phone for testing.
+#
+# Triggers:
+#   - Pushes to develop / main that touch zeus-mobile/, zeus-web/, or this
+#     workflow itself.
+#   - PRs into develop / main with the same path filter.
+#   - Manual dispatch from the Actions tab.
+#
+# iOS is intentionally out of scope here — that needs a macOS runner plus
+# signing certs / provisioning profiles, which are a separate concern.
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'zeus-web/**'
+      - 'zeus-mobile/**'
+      - '.github/workflows/build-mobile-android.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'zeus-web/**'
+      - 'zeus-mobile/**'
+      - '.github/workflows/build-mobile-android.yml'
+  workflow_dispatch:
+
+jobs:
+  android-debug-apk:
+    name: Build debug APK
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: |
+            zeus-web/package-lock.json
+            zeus-mobile/package-lock.json
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Build zeus-web bundle
+        run: |
+          npm ci
+          npm run build
+        working-directory: zeus-web
+
+      - name: Install zeus-mobile dependencies
+        run: npm ci
+        working-directory: zeus-mobile
+
+      - name: Add Android platform
+        run: npx cap add android
+        working-directory: zeus-mobile
+
+      - name: Apply Zeus Android patches
+        run: bash scripts/apply-android-patches.sh
+        working-directory: zeus-mobile
+
+      - name: Sync web bundle into Android project
+        run: npx cap sync android
+        working-directory: zeus-mobile
+
+      - name: Build debug APK
+        run: ./gradlew --no-daemon assembleDebug
+        working-directory: zeus-mobile/android
+
+      - name: Locate APK
+        id: locate
+        run: |
+          APK=$(find zeus-mobile/android/app/build/outputs/apk/debug -name "*.apk" -print -quit)
+          if [[ -z "$APK" ]]; then
+            echo "✗ no APK produced" >&2
+            ls -la zeus-mobile/android/app/build/outputs/apk/ || true
+            exit 1
+          fi
+          echo "apk=$APK" >> "$GITHUB_OUTPUT"
+          echo "Built: $APK"
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zeus-android-debug
+          path: ${{ steps.locate.outputs.apk }}
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/build-mobile-ios.yml
+++ b/.github/workflows/build-mobile-ios.yml
@@ -1,0 +1,77 @@
+name: Build iOS (Simulator)
+
+# Sanity-check that the iOS Capacitor project still compiles. Builds against
+# the iOS Simulator only — no signing, no real-device install. The output is
+# not uploaded as an artifact: a simulator build can't be sideloaded onto an
+# iPhone, so its only purpose is to fail the CI check if the project breaks.
+#
+# To actually run Zeus on your iPhone, build locally with `npm run open:ios`
+# in zeus-mobile/ and sign with your personal Apple ID — see
+# zeus-mobile/README.md.
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'zeus-web/**'
+      - 'zeus-mobile/**'
+      - '.github/workflows/build-mobile-ios.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'zeus-web/**'
+      - 'zeus-mobile/**'
+      - '.github/workflows/build-mobile-ios.yml'
+  workflow_dispatch:
+
+jobs:
+  ios-simulator-build:
+    name: Build for iOS Simulator
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: |
+            zeus-web/package-lock.json
+            zeus-mobile/package-lock.json
+
+      - name: Build zeus-web bundle
+        run: |
+          npm ci
+          npm run build
+        working-directory: zeus-web
+
+      - name: Install zeus-mobile dependencies
+        run: npm ci
+        working-directory: zeus-mobile
+
+      - name: Add iOS platform
+        run: npx cap add ios
+        working-directory: zeus-mobile
+
+      - name: Apply Zeus iOS patches
+        run: bash scripts/apply-ios-patches.sh
+        working-directory: zeus-mobile
+
+      - name: Sync web bundle into iOS project
+        run: npx cap sync ios
+        working-directory: zeus-mobile
+
+      - name: Build for iOS Simulator
+        # CODE_SIGNING_ALLOWED=NO skips the device-signing step — we only
+        # care that the project compiles. A simulator binary can't be
+        # sideloaded onto a real iPhone anyway.
+        run: |
+          xcodebuild \
+            -workspace zeus-mobile/ios/App/App.xcworkspace \
+            -scheme App \
+            -configuration Debug \
+            -destination 'generic/platform=iOS Simulator' \
+            CODE_SIGNING_ALLOWED=NO \
+            build

--- a/zeus-mobile/.gitignore
+++ b/zeus-mobile/.gitignore
@@ -1,0 +1,12 @@
+# Capacitor scaffolds the Android Gradle and iOS Xcode projects on first
+# `cap add`; they're regeneratable from this dir's package.json + config so
+# we keep them out of git until they need real customisation. Anchor the
+# rules at the zeus-mobile root so templates/android/ is NOT excluded.
+/node_modules/
+/android/
+/ios/
+
+# Build artefacts
+/dist/
+.DS_Store
+*.log

--- a/zeus-mobile/README.md
+++ b/zeus-mobile/README.md
@@ -1,0 +1,109 @@
+# zeus-mobile — Capacitor wrapper
+
+Native Android and iOS shells for the Zeus web frontend. The web bundle
+that `zeus-web` already produces (vite outputs to
+`../Zeus.Server.Hosting/wwwroot/` so the .NET server can serve it directly)
+is loaded from a Capacitor WebView; everything else runs unchanged. The
+user picks a LAN-side `Zeus.Server` host at first launch via
+**Settings → Server**.
+
+This directory is JS-side only. Platform projects (`android/`, `ios/`) are
+gitignored; they're scaffolded by `npm run setup` on first checkout.
+
+## Skip the local toolchain — grab a CI-built APK
+
+If you just want to install Zeus on an Android device, you don't need a
+local Android SDK. The
+[**Build Android APK**](../../../actions/workflows/build-mobile-android.yml)
+workflow on GitHub Actions builds an unsigned debug APK on every push to
+`develop` / `main` (and on demand). Open the latest run, download the
+`zeus-android-debug` artefact, and sideload the APK with
+`adb install zeus-android-debug.apk` (or transfer it to the phone and tap
+to install — you'll need to enable "Install unknown apps" for your file
+manager).
+
+iOS builds are not yet on CI — they need a macOS runner and signing certs.
+Build locally with `npm run open:ios` for now.
+
+## Prerequisites for local builds
+
+- Node 18+ (same as `zeus-web`)
+- For Android: Android Studio + Android SDK (Java 17 in PATH)
+- For iOS: Xcode + CocoaPods (macOS only)
+
+## First-run setup
+
+```sh
+npm run setup
+```
+
+The script will:
+1. `npm install` Capacitor's CLI + platform packages
+2. Build `zeus-web` (`../zeus-web/dist`)
+3. Run `npx cap add android` and apply Zeus patches
+4. On macOS: run `npx cap add ios` and apply Zeus patches
+5. Run `npx cap sync` to copy the web bundle into both platforms
+
+## Day-to-day workflows
+
+| Task                            | Command                  |
+|---------------------------------|--------------------------|
+| Rebuild web + sync into apps    | `npm run sync`           |
+| Open Android Studio             | `npm run open:android`   |
+| Open Xcode                      | `npm run open:ios`       |
+| Build + launch on Android       | `npm run run:android`    |
+| Build + launch on iOS           | `npm run run:ios`        |
+
+## How the server URL works
+
+The Capacitor WebView serves the bundled web app from `http://localhost`
+(Android) or `capacitor://localhost` (iOS). It can't reach the radio that
+way. On first launch the app detects the Capacitor runtime
+(`window.Capacitor.isNativePlatform()`) and pops Settings → **Server** so
+the operator can paste an address like `http://192.168.1.23:6060`.
+
+The address is persisted to `localStorage["zeus.serverUrl"]`. A small
+fetch-interceptor + WebSocket builder in `zeus-web/src/serverUrl.ts`
+prepends the configured base to every `/api/*`, `/ws`, and `/hub/*`
+request. Web (browser) users leave the field blank — relative paths still
+work because Zeus.Server is the same origin.
+
+## Permissions
+
+| Permission             | Why                                                           |
+|------------------------|---------------------------------------------------------------|
+| `INTERNET`             | Talk to the LAN-side Zeus.Server (HTTP + WS)                  |
+| `ACCESS_NETWORK_STATE` | Detect when the device drops off the LAN                      |
+| `RECORD_AUDIO`         | PTT / TX mic uplink (the same path the browser uses)          |
+| iOS Local Network      | iOS 14+ system prompt for `192.168.*` reachability            |
+
+## Cleartext to RFC1918
+
+A LAN HPSDR radio doesn't have a public hostname or a TLS cert, so the
+WebView has to talk plain HTTP to addresses like `192.168.1.23`. Both
+platforms scope cleartext narrowly:
+
+- **Android** — `network_security_config.xml` (in
+  `templates/android/network_security_config.xml`) whitelists the RFC1918
+  ranges, link-local IPv4, mDNS `.local`, and the Android emulator
+  loopback. Public hosts still require HTTPS.
+- **iOS** — `NSAppTransportSecurity → NSAllowsLocalNetworking = YES` in
+  `Info.plist`. iOS handles the public-host restriction itself.
+
+## Re-applying patches after `cap add`
+
+If you ever delete and re-add a platform, run the apply scripts manually:
+
+```sh
+bash scripts/apply-android-patches.sh
+bash scripts/apply-ios-patches.sh
+```
+
+They're idempotent — safe to run repeatedly.
+
+## Out of scope (separate tickets)
+
+- Store signing / distribution
+- Push notifications
+- Native radio drivers (this is a network-only client)
+- Custom splash screens / app icons (using Capacitor defaults until art is approved)

--- a/zeus-mobile/README.md
+++ b/zeus-mobile/README.md
@@ -10,7 +10,7 @@ user picks a LAN-side `Zeus.Server` host at first launch via
 This directory is JS-side only. Platform projects (`android/`, `ios/`) are
 gitignored; they're scaffolded by `npm run setup` on first checkout.
 
-## Skip the local toolchain — grab a CI-built APK
+## Skip the local toolchain — grab a CI-built APK (Android)
 
 If you just want to install Zeus on an Android device, you don't need a
 local Android SDK. The
@@ -22,8 +22,40 @@ workflow on GitHub Actions builds an unsigned debug APK on every push to
 to install — you'll need to enable "Install unknown apps" for your file
 manager).
 
-iOS builds are not yet on CI — they need a macOS runner and signing certs.
-Build locally with `npm run open:ios` for now.
+## iPhone — build locally and sign with your Apple ID
+
+CI does run a
+[**Build iOS (Simulator)**](../../../actions/workflows/build-mobile-ios.yml)
+sanity check on every push, but a simulator build can't be sideloaded onto
+a real iPhone. To actually install Zeus on your phone you need Xcode on a
+Mac plus an Apple ID — the *free* tier is enough for personal use, no
+$99/yr Developer Program required.
+
+One-time setup:
+
+1. `cd zeus-mobile && npm run setup` (does the bootstrap from this README).
+2. `npm run open:ios` — opens the project in Xcode.
+3. In Xcode, select the **App** target → **Signing & Capabilities** → tick
+   **Automatically manage signing** → set **Team** to your personal Apple
+   ID. (Xcode will offer to add it the first time.)
+4. Plug in your iPhone, pick it as the run destination in the toolbar, and
+   click ▶ Run.
+5. The first launch on the phone will fail to start — go to **Settings →
+   General → VPN & Device Management** on the phone, trust the developer
+   profile, then tap the Zeus icon again.
+
+Caveats of the free Apple ID path:
+- The signed build expires after **7 days**. To refresh, plug back in and
+  hit Run again — Xcode re-signs automatically.
+- Up to **3 apps** at once on one device.
+- A signed Developer Program build (paid, with proper provisioning) is a
+  separate ticket — out of scope here.
+
+After any UI change, rebuild the web bundle and re-sync before re-running:
+
+```sh
+npm run sync
+```
 
 ## Prerequisites for local builds
 

--- a/zeus-mobile/capacitor.config.ts
+++ b/zeus-mobile/capacitor.config.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+// See LICENSE / ATTRIBUTIONS.md at the repository root.
+
+import type { CapacitorConfig } from '@capacitor/cli';
+
+const config: CapacitorConfig = {
+  appId: 'org.openhpsdr.zeus',
+  appName: 'OpenHPSDR Zeus',
+  // The Capacitor shell ships zeus-web's compiled output. zeus-web's vite
+  // config points its build at Zeus.Server.Hosting/wwwroot/ (so the .NET
+  // server can serve it directly); we re-use that same artefact here. The
+  // user picks the LAN-side Zeus.Server at runtime via Settings → Server.
+  // See ../zeus-web/src/serverUrl.ts.
+  webDir: '../Zeus.Server.Hosting/wwwroot',
+  bundledWebRuntime: false,
+  android: {
+    // Required for plain-HTTP requests to RFC1918 / link-local Zeus.Server
+    // hosts. Combined with res/xml/network_security_config.xml so we don't
+    // unconditionally allow cleartext to public hosts.
+    allowMixedContent: true,
+    backgroundColor: '#0a1220',
+  },
+  ios: {
+    // The native shell loads the bundle from capacitor:// (default). Mic
+    // permissions and ATS exceptions live in Info.plist via the apply-ios
+    // patches script.
+    contentInset: 'always',
+    backgroundColor: '#0a1220',
+  },
+  server: {
+    // Don't override URL here — that would force a fixed server at build time.
+    // Operators configure the Zeus.Server endpoint at runtime instead.
+    androidScheme: 'http',
+    cleartext: true,
+  },
+};
+
+export default config;

--- a/zeus-mobile/package-lock.json
+++ b/zeus-mobile/package-lock.json
@@ -1,0 +1,1284 @@
+{
+  "name": "zeus-mobile",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "zeus-mobile",
+      "version": "0.0.1",
+      "dependencies": {
+        "@capacitor/android": "^6.2.0",
+        "@capacitor/core": "^6.2.0",
+        "@capacitor/ios": "^6.2.0"
+      },
+      "devDependencies": {
+        "@capacitor/cli": "^6.2.0",
+        "typescript": "^5.7.0"
+      }
+    },
+    "node_modules/@capacitor/android": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-6.2.1.tgz",
+      "integrity": "sha512-8gd4CIiQO5LAIlPIfd5mCuodBRxMMdZZEdj8qG8m+dQ1sQ2xyemVpzHmRK8qSCHorsBUCg3D62j2cp6bEBAkdw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": "^6.2.0"
+      }
+    },
+    "node_modules/@capacitor/cli": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-6.2.1.tgz",
+      "integrity": "sha512-JKl0FpFge8PgQNInw12kcKieQ4BmOyazQ4JGJOfEpVXlgrX1yPhSZTPjngupzTCiK3I7q7iGG5kjun0fDqgSCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/cli-framework-output": "^2.2.5",
+        "@ionic/utils-fs": "^3.1.6",
+        "@ionic/utils-subprocess": "2.1.11",
+        "@ionic/utils-terminal": "^2.3.3",
+        "commander": "^9.3.0",
+        "debug": "^4.3.4",
+        "env-paths": "^2.2.0",
+        "kleur": "^4.1.4",
+        "native-run": "^2.0.0",
+        "open": "^8.4.0",
+        "plist": "^3.0.5",
+        "prompts": "^2.4.2",
+        "rimraf": "^4.4.1",
+        "semver": "^7.3.7",
+        "tar": "^6.1.11",
+        "tslib": "^2.4.0",
+        "xml2js": "^0.5.0"
+      },
+      "bin": {
+        "cap": "bin/capacitor",
+        "capacitor": "bin/capacitor"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@capacitor/core": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-6.2.1.tgz",
+      "integrity": "sha512-urZwxa7hVE/BnA18oCFAdizXPse6fCKanQyEqpmz6cBJ2vObwMpyJDG5jBeoSsgocS9+Ax+9vb4ducWJn0y2qQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@capacitor/ios": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-6.2.1.tgz",
+      "integrity": "sha512-tbMlQdQjxe1wyaBvYVU1yTojKJjgluZQsJkALuJxv/6F8QTw5b6vd7X785O/O7cMpIAZfUWo/vtAHzFkRV+kXw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": "^6.2.0"
+      }
+    },
+    "node_modules/@ionic/cli-framework-output": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ionic/cli-framework-output/-/cli-framework-output-2.2.8.tgz",
+      "integrity": "sha512-TshtaFQsovB4NWRBydbNFawql6yul7d5bMiW1WYYf17hd99V6xdDdk3vtF51bw6sLkxON3bDQpWsnUc9/hVo3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/utils-terminal": "2.3.5",
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-array": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-array/-/utils-array-2.1.5.tgz",
+      "integrity": "sha512-HD72a71IQVBmQckDwmA8RxNVMTbxnaLbgFOl+dO5tbvW9CkkSFCv41h6fUuNsSEVgngfkn0i98HDuZC8mk+lTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10.3.0"
+      }
+    },
+    "node_modules/@ionic/utils-fs": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-fs/-/utils-fs-3.1.7.tgz",
+      "integrity": "sha512-2EknRvMVfhnyhL1VhFkSLa5gOcycK91VnjfrTB0kbqkTFCOXyXgVLI5whzq7SLrgD9t1aqos3lMMQyVzaQ5gVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/fs-extra": "^8.0.0",
+        "debug": "^4.0.0",
+        "fs-extra": "^9.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-object": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-object/-/utils-object-2.1.5.tgz",
+      "integrity": "sha512-XnYNSwfewUqxq+yjER1hxTKggftpNjFLJH0s37jcrNDwbzmbpFTQTVAp4ikNK4rd9DOebX/jbeZb8jfD86IYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10.3.0"
+      }
+    },
+    "node_modules/@ionic/utils-process": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-process/-/utils-process-2.1.10.tgz",
+      "integrity": "sha512-mZ7JEowcuGQK+SKsJXi0liYTcXd2bNMR3nE0CyTROpMECUpJeAvvaBaPGZf5ERQUPeWBVuwqAqjUmIdxhz5bxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/utils-object": "2.1.5",
+        "@ionic/utils-terminal": "2.3.3",
+        "debug": "^4.0.0",
+        "signal-exit": "^3.0.3",
+        "tree-kill": "^1.2.2",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10.3.0"
+      }
+    },
+    "node_modules/@ionic/utils-process/node_modules/@ionic/utils-terminal": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-terminal/-/utils-terminal-2.3.3.tgz",
+      "integrity": "sha512-RnuSfNZ5fLEyX3R5mtcMY97cGD1A0NVBbarsSQ6yMMfRJ5YHU7hHVyUfvZeClbqkBC/pAqI/rYJuXKCT9YeMCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/slice-ansi": "^4.0.0",
+        "debug": "^4.0.0",
+        "signal-exit": "^3.0.3",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "tslib": "^2.0.1",
+        "untildify": "^4.0.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10.3.0"
+      }
+    },
+    "node_modules/@ionic/utils-stream": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-stream/-/utils-stream-3.1.5.tgz",
+      "integrity": "sha512-hkm46uHvEC05X/8PHgdJi4l4zv9VQDELZTM+Kz69odtO9zZYfnt8DkfXHJqJ+PxmtiE5mk/ehJWLnn/XAczTUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10.3.0"
+      }
+    },
+    "node_modules/@ionic/utils-subprocess": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-subprocess/-/utils-subprocess-2.1.11.tgz",
+      "integrity": "sha512-6zCDixNmZCbMCy5np8klSxOZF85kuDyzZSTTQKQP90ZtYNCcPYmuFSzaqDwApJT4r5L3MY3JrqK1gLkc6xiUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/utils-array": "2.1.5",
+        "@ionic/utils-fs": "3.1.6",
+        "@ionic/utils-process": "2.1.10",
+        "@ionic/utils-stream": "3.1.5",
+        "@ionic/utils-terminal": "2.3.3",
+        "cross-spawn": "^7.0.3",
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10.3.0"
+      }
+    },
+    "node_modules/@ionic/utils-subprocess/node_modules/@ionic/utils-fs": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-fs/-/utils-fs-3.1.6.tgz",
+      "integrity": "sha512-eikrNkK89CfGPmexjTfSWl4EYqsPSBh0Ka7by4F0PLc1hJZYtJxUZV3X4r5ecA8ikjicUmcbU7zJmAjmqutG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/fs-extra": "^8.0.0",
+        "debug": "^4.0.0",
+        "fs-extra": "^9.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10.3.0"
+      }
+    },
+    "node_modules/@ionic/utils-subprocess/node_modules/@ionic/utils-terminal": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-terminal/-/utils-terminal-2.3.3.tgz",
+      "integrity": "sha512-RnuSfNZ5fLEyX3R5mtcMY97cGD1A0NVBbarsSQ6yMMfRJ5YHU7hHVyUfvZeClbqkBC/pAqI/rYJuXKCT9YeMCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/slice-ansi": "^4.0.0",
+        "debug": "^4.0.0",
+        "signal-exit": "^3.0.3",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "tslib": "^2.0.1",
+        "untildify": "^4.0.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10.3.0"
+      }
+    },
+    "node_modules/@ionic/utils-terminal": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-terminal/-/utils-terminal-2.3.5.tgz",
+      "integrity": "sha512-3cKScz9Jx2/Pr9ijj1OzGlBDfcmx7OMVBt4+P1uRR0SSW4cm1/y3Mo4OY3lfkuaYifMNBW8Wz6lQHbs1bihr7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/slice-ansi": "^4.0.0",
+        "debug": "^4.0.0",
+        "signal-exit": "^3.0.3",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "tslib": "^2.0.1",
+        "untildify": "^4.0.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@types/fs-extra": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.5.tgz",
+      "integrity": "sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-+OpjSaq85gvlZAYINyzKpLeiFkSC4EsC6IIiT6v6TLSU5k5U83fHGj9Lel8oKEXM0HqgrMVCjXPDPVICtxF7EQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "dev": true,
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/bplist-parser": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.2.tgz",
+      "integrity": "sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "1.6.x"
+      },
+      "engines": {
+        "node": ">= 5.10.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/elementtree": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/elementtree/-/elementtree-0.1.7.tgz",
+      "integrity": "sha512-wkgGT6kugeQk/P6VZ/f4T+4HB41BVgNBq5CDIZVbQ02nvTVqAiVTbskxxu3eA/X96lMlfYOwnLQpN2v5E1zDEg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "sax": "1.1.4"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/glob": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/minimatch": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.7.tgz",
+      "integrity": "sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/native-run": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/native-run/-/native-run-2.0.3.tgz",
+      "integrity": "sha512-U1PllBuzW5d1gfan+88L+Hky2eZx+9gv3Pf6rNBxKbORxi7boHzqiA6QFGSnqMem4j0A9tZ08NMIs5+0m/VS1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/utils-fs": "^3.1.7",
+        "@ionic/utils-terminal": "^2.3.4",
+        "bplist-parser": "^0.3.2",
+        "debug": "^4.3.4",
+        "elementtree": "^0.1.7",
+        "ini": "^4.1.1",
+        "plist": "^3.1.0",
+        "split2": "^4.2.0",
+        "through2": "^4.0.2",
+        "tslib": "^2.6.2",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "native-run": "bin/native-run"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/plist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.1.tgz",
+      "integrity": "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.9.10",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=10.4.0"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/prompts/node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
+      "integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^9.2.0"
+      },
+      "bin": {
+        "rimraf": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
+      "integrity": "sha512-5f3k2PbGGp+YtKJjOItpg3P99IMD84E4HOvcfleTb5joCHNXYLsR9yWFPOYGgaeMPDubQILTCMdsFb2OMeOjtg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "3"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xml2js/node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    }
+  }
+}

--- a/zeus-mobile/package.json
+++ b/zeus-mobile/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "zeus-mobile",
+  "private": true,
+  "version": "0.0.1",
+  "description": "Capacitor wrapper for the Zeus web frontend (Android + iOS)",
+  "scripts": {
+    "build:web": "npm --prefix ../zeus-web run build",
+    "sync": "npm run build:web && cap sync",
+    "open:android": "cap open android",
+    "open:ios": "cap open ios",
+    "run:android": "npm run sync && cap run android",
+    "run:ios": "npm run sync && cap run ios",
+    "add:android": "cap add android && bash scripts/apply-android-patches.sh",
+    "add:ios": "cap add ios && bash scripts/apply-ios-patches.sh",
+    "setup": "bash scripts/setup.sh"
+  },
+  "dependencies": {
+    "@capacitor/android": "^6.2.0",
+    "@capacitor/core": "^6.2.0",
+    "@capacitor/ios": "^6.2.0"
+  },
+  "devDependencies": {
+    "@capacitor/cli": "^6.2.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/zeus-mobile/scripts/apply-android-patches.sh
+++ b/zeus-mobile/scripts/apply-android-patches.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Apply Zeus mobile patches to the freshly-scaffolded Android project. Run
+# after `npx cap add android`. Idempotent — safe to re-run.
+#
+# What it does:
+#   1) Drops a network_security_config.xml that whitelists RFC1918 + .local
+#      for cleartext HTTP (the WebView talks plain HTTP to LAN Zeus.Servers).
+#   2) Patches AndroidManifest.xml to:
+#        - reference networkSecurityConfig
+#        - request INTERNET, ACCESS_NETWORK_STATE
+#        - request RECORD_AUDIO (PTT mic uplink)
+#        - keep the Capacitor default usesCleartextTraffic="true" intact.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+
+ANDROID_DIR="$ROOT/android"
+APP_DIR="$ANDROID_DIR/app"
+RES_XML_DIR="$APP_DIR/src/main/res/xml"
+MANIFEST="$APP_DIR/src/main/AndroidManifest.xml"
+
+if [[ ! -d "$ANDROID_DIR" ]]; then
+    echo "✗ android/ not found — run \`npx cap add android\` first" >&2
+    exit 1
+fi
+
+mkdir -p "$RES_XML_DIR"
+cp "$ROOT/templates/android/network_security_config.xml" \
+   "$RES_XML_DIR/network_security_config.xml"
+echo "✓ network_security_config.xml installed"
+
+if [[ ! -f "$MANIFEST" ]]; then
+    echo "✗ AndroidManifest.xml not found at $MANIFEST" >&2
+    exit 1
+fi
+
+# Patches are idempotent — they grep first and skip if already present.
+
+# 1) Reference the network security config from <application>.
+if ! grep -q 'networkSecurityConfig' "$MANIFEST"; then
+    # Insert into the <application ...> open tag.
+    perl -0777 -i -pe 's/(<application\b)/$1 android:networkSecurityConfig="\@xml\/network_security_config"/' "$MANIFEST"
+    echo "✓ networkSecurityConfig wired into <application>"
+else
+    echo "✓ networkSecurityConfig already present"
+fi
+
+# 2) Add RECORD_AUDIO if missing. Capacitor 6 already adds INTERNET +
+#    ACCESS_NETWORK_STATE; we only top up what's needed for PTT mic.
+add_permission() {
+    local perm="$1"
+    if ! grep -q "android.permission.${perm}" "$MANIFEST"; then
+        perl -0777 -i -pe "s/(<manifest\b[^>]*>)/\$1\n    <uses-permission android:name=\"android.permission.${perm}\"\\/>/" "$MANIFEST"
+        echo "✓ added <uses-permission ${perm}>"
+    else
+        echo "✓ ${perm} already present"
+    fi
+}
+
+add_permission RECORD_AUDIO
+add_permission INTERNET
+add_permission ACCESS_NETWORK_STATE
+
+echo
+echo "Android patches applied. Open the project with:"
+echo "    npm run open:android"

--- a/zeus-mobile/scripts/apply-ios-patches.sh
+++ b/zeus-mobile/scripts/apply-ios-patches.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Patch the freshly-scaffolded iOS project's Info.plist. Run after
+# `npx cap add ios`. Uses /usr/libexec/PlistBuddy so it's idempotent.
+#
+# What it does:
+#   - NSAppTransportSecurity → NSAllowsLocalNetworking = YES (iOS 14+ ATS
+#     exception for plain-HTTP RFC1918 / .local Zeus.Servers).
+#   - NSLocalNetworkUsageDescription (iOS 14+ system prompt copy).
+#   - NSMicrophoneUsageDescription (PTT mic uplink).
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+
+PLIST="$ROOT/ios/App/App/Info.plist"
+PB=/usr/libexec/PlistBuddy
+
+if [[ ! -f "$PLIST" ]]; then
+    echo "✗ Info.plist not found at $PLIST — run \`npx cap add ios\` first" >&2
+    exit 1
+fi
+
+if ! command -v "$PB" >/dev/null 2>&1; then
+    echo "✗ PlistBuddy not found (this script only runs on macOS)" >&2
+    exit 1
+fi
+
+# 1) ATS exception for local networking (HTTP to RFC1918 / .local).
+"$PB" -c "Delete :NSAppTransportSecurity" "$PLIST" 2>/dev/null || true
+"$PB" -c "Add :NSAppTransportSecurity dict" "$PLIST"
+"$PB" -c "Add :NSAppTransportSecurity:NSAllowsLocalNetworking bool YES" "$PLIST"
+echo "✓ NSAppTransportSecurity → NSAllowsLocalNetworking=YES"
+
+# 2) iOS 14+ local-network discovery prompt.
+"$PB" -c "Delete :NSLocalNetworkUsageDescription" "$PLIST" 2>/dev/null || true
+"$PB" -c "Add :NSLocalNetworkUsageDescription string Zeus needs to find your radio's Zeus.Server on the local network." "$PLIST"
+echo "✓ NSLocalNetworkUsageDescription set"
+
+# 3) Microphone permission for PTT mic uplink.
+"$PB" -c "Delete :NSMicrophoneUsageDescription" "$PLIST" 2>/dev/null || true
+"$PB" -c "Add :NSMicrophoneUsageDescription string Zeus uses the microphone to send your PTT audio to the radio." "$PLIST"
+echo "✓ NSMicrophoneUsageDescription set"
+
+echo
+echo "iOS patches applied. Open the project with:"
+echo "    npm run open:ios"

--- a/zeus-mobile/scripts/setup.sh
+++ b/zeus-mobile/scripts/setup.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# One-shot bootstrap for the Zeus Capacitor wrapper. Run this once after
+# cloning. Adds android/ and ios/ platform projects and applies the
+# Zeus-specific manifest / Info.plist patches.
+#
+# Prerequisites (you'll need these locally):
+#   - Node 18+ (already required for zeus-web)
+#   - Android Studio + Android SDK (for android target)
+#   - Xcode + CocoaPods (for ios target, macOS only)
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+cd "$ROOT"
+
+echo "→ installing zeus-mobile dependencies"
+npm install
+
+echo "→ building zeus-web bundle"
+npm --prefix ../zeus-web ci
+npm --prefix ../zeus-web run build
+
+if [[ ! -d ./android ]]; then
+    echo "→ adding android platform"
+    npx cap add android
+    bash scripts/apply-android-patches.sh
+else
+    echo "✓ android/ already exists; skipping cap add android"
+fi
+
+if [[ "$(uname)" == "Darwin" ]]; then
+    if [[ ! -d ./ios ]]; then
+        echo "→ adding ios platform"
+        npx cap add ios
+        bash scripts/apply-ios-patches.sh
+    else
+        echo "✓ ios/ already exists; skipping cap add ios"
+    fi
+else
+    echo "↷ skipping ios platform (only supported on macOS)"
+fi
+
+echo "→ syncing web bundle into native projects"
+npx cap sync
+
+echo
+echo "Done. Next steps:"
+echo "  npm run open:android   # opens Android Studio"
+[[ "$(uname)" == "Darwin" ]] && echo "  npm run open:ios       # opens Xcode"

--- a/zeus-mobile/templates/android/network_security_config.xml
+++ b/zeus-mobile/templates/android/network_security_config.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Allow cleartext HTTP to RFC1918 / link-local addresses so the WebView can
+  reach a LAN-side Zeus.Server. Public hosts still require HTTPS.
+  Capacitor itself loads from http://localhost via androidScheme=http; it's
+  whitelisted explicitly.
+-->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+
+    <domain-config cleartextTrafficPermitted="true">
+        <!-- Capacitor's webview origin -->
+        <domain includeSubdomains="false">localhost</domain>
+        <domain includeSubdomains="false">10.0.2.2</domain> <!-- Android emulator host loopback -->
+
+        <!-- RFC1918 private ranges -->
+        <domain includeSubdomains="true">10.0.0.0/8</domain>
+        <domain includeSubdomains="true">172.16.0.0/12</domain>
+        <domain includeSubdomains="true">192.168.0.0/16</domain>
+
+        <!-- Link-local IPv4 -->
+        <domain includeSubdomains="true">169.254.0.0/16</domain>
+
+        <!-- mDNS .local -->
+        <domain includeSubdomains="true">local</domain>
+    </domain-config>
+</network-security-config>

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -90,6 +90,7 @@ import { bearingDeg, distanceKm } from './components/design/geo';
 import { LeafletWorldMap } from './components/design/LeafletWorldMap';
 import { LeafletMapErrorBoundary } from './components/design/LeafletMapErrorBoundary';
 import { startRealtime } from './realtime/ws-client';
+import { getServerBaseUrl, isCapacitorRuntime } from './serverUrl';
 import { getAudioClient } from './audio/audio-client';
 import { useMicUplink } from './audio/use-mic-uplink';
 import { fetchState } from './api/client';
@@ -116,7 +117,7 @@ const STATE_POLL_MS = 333;
 export default function App() {
   useSwUpdatePrompt();
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const [settingsInitialTab, setSettingsInitialTab] = useState<'pa' | 'qrz' | 'rotator' | 'about' | undefined>();
+  const [settingsInitialTab, setSettingsInitialTab] = useState<'pa' | 'qrz' | 'rotator' | 'server' | 'about' | undefined>();
   const [updateAvailable, setUpdateAvailable] = useState(false);
   const [installUpdate, setInstallUpdate] = useState<(() => Promise<void>) | null>(null);
   const status = useConnectionStore((s) => s.status);
@@ -206,12 +207,18 @@ export default function App() {
     document.documentElement.setAttribute('data-fonts', fonts);
   }, []);
 
-  // Handle deeplink via URL hash (#qrz, #rotator, #pa, #about).
+  // Handle deeplink via URL hash (#qrz, #rotator, #pa, #server, #about).
   // Opens settings menu and navigates to the specified tab.
   useEffect(() => {
     const handleHash = () => {
       const hash = window.location.hash.slice(1); // Remove '#'
-      if (hash === 'qrz' || hash === 'rotator' || hash === 'pa' || hash === 'about') {
+      if (
+        hash === 'qrz' ||
+        hash === 'rotator' ||
+        hash === 'pa' ||
+        hash === 'server' ||
+        hash === 'about'
+      ) {
         setSettingsInitialTab(hash);
         setSettingsOpen(true);
         // Clear the hash after handling it
@@ -225,6 +232,17 @@ export default function App() {
     // Listen for hash changes
     window.addEventListener('hashchange', handleHash);
     return () => window.removeEventListener('hashchange', handleHash);
+  }, []);
+
+  // First-run UX for native shells (Capacitor): if there is no server URL
+  // configured, the app would spin trying to reach the WebView's own host.
+  // Pop the Settings → Server tab open so the operator can paste their LAN
+  // address.
+  useEffect(() => {
+    if (!isCapacitorRuntime()) return;
+    if (getServerBaseUrl()) return;
+    setSettingsInitialTab('server');
+    setSettingsOpen(true);
   }, []);
 
   // --- Design-mock state (QRZ, DSP grid toggles, CW WPM, memories) ---

--- a/zeus-web/src/components/ServerUrlPanel.tsx
+++ b/zeus-web/src/components/ServerUrlPanel.tsx
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+// See LICENSE / ATTRIBUTIONS.md at the repository root.
+
+import { useEffect, useState } from 'react';
+import {
+  getServerBaseUrl,
+  isCapacitorRuntime,
+  setServerBaseUrl,
+} from '../serverUrl';
+
+// Settings tab: lets the operator point a Capacitor / standalone build at a
+// specific Zeus.Server on their LAN (e.g. http://192.168.1.23:6060). Browser
+// users on the bundled deploy normally leave this blank — relative paths
+// already reach the same-origin server.
+
+export function ServerUrlPanel() {
+  const [value, setValue] = useState(() => getServerBaseUrl());
+  const [touched, setTouched] = useState(false);
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+  const isCapacitor = isCapacitorRuntime();
+
+  useEffect(() => {
+    if (!savedAt) return;
+    const t = setTimeout(() => setSavedAt(null), 2000);
+    return () => clearTimeout(t);
+  }, [savedAt]);
+
+  const trimmed = value.trim();
+  const error = trimmed === '' ? null : validateUrl(trimmed);
+  const dirty = trimmed !== getServerBaseUrl();
+
+  const handleSave = () => {
+    if (error) return;
+    setServerBaseUrl(trimmed);
+    setSavedAt(Date.now());
+    setTouched(false);
+    // Reload so all in-flight subscribers (WS, polling timers, store hydration)
+    // pick up the new base URL cleanly. This matches the connect-panel
+    // expectations and avoids half-routed traffic.
+    if (trimmed !== '' || isCapacitor) {
+      setTimeout(() => window.location.reload(), 250);
+    }
+  };
+
+  const handleClear = () => {
+    setServerBaseUrl('');
+    setValue('');
+    setSavedAt(Date.now());
+    setTouched(false);
+    setTimeout(() => window.location.reload(), 250);
+  };
+
+  return (
+    <div style={{ maxWidth: 600 }}>
+      <h3
+        style={{
+          margin: '0 0 14px',
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: '0.12em',
+          textTransform: 'uppercase',
+          color: 'var(--fg-2)',
+        }}
+      >
+        SERVER URL
+      </h3>
+
+      <p style={{ fontSize: 12, color: 'var(--fg-2)', lineHeight: 1.5, marginTop: 0 }}>
+        Address of the Zeus.Server you want to control. Leave blank when the
+        web UI is being served by Zeus.Server itself (the typical browser
+        deploy). On native mobile / desktop wrappers, point this at the LAN
+        host running Zeus.Server, e.g.{' '}
+        <code style={{ fontFamily: 'monospace', color: 'var(--fg-1)' }}>
+          http://192.168.1.23:6060
+        </code>
+        .
+      </p>
+
+      <label style={{ display: 'flex', flexDirection: 'column', gap: 6, marginTop: 16 }}>
+        <span
+          style={{
+            fontSize: 11,
+            fontWeight: 600,
+            letterSpacing: '0.1em',
+            textTransform: 'uppercase',
+            color: 'var(--fg-2)',
+          }}
+        >
+          Base URL
+        </span>
+        <input
+          type="url"
+          autoCapitalize="off"
+          autoCorrect="off"
+          spellCheck={false}
+          inputMode="url"
+          placeholder="http://192.168.1.23:6060"
+          value={value}
+          onChange={(e) => {
+            setValue(e.target.value);
+            setTouched(true);
+          }}
+          style={{
+            padding: '8px 10px',
+            fontFamily: 'monospace',
+            fontSize: 13,
+            color: 'var(--fg-0)',
+            background: 'var(--bg-2)',
+            border: '1px solid var(--panel-border)',
+            borderRadius: 'var(--r-sm)',
+            outline: 'none',
+          }}
+        />
+        {touched && error && (
+          <span style={{ fontSize: 11, color: 'var(--tx)' }}>{error}</span>
+        )}
+      </label>
+
+      <div style={{ display: 'flex', gap: 8, marginTop: 18, alignItems: 'center' }}>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={!dirty || !!error}
+          style={{
+            padding: '8px 16px',
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: '0.1em',
+            textTransform: 'uppercase',
+            color: dirty && !error ? 'var(--fg-0)' : 'var(--fg-2)',
+            background: dirty && !error ? 'var(--accent)' : 'var(--bg-2)',
+            border: '1px solid var(--panel-border)',
+            borderRadius: 'var(--r-sm)',
+            cursor: dirty && !error ? 'pointer' : 'not-allowed',
+            opacity: dirty && !error ? 1 : 0.6,
+          }}
+        >
+          Save & reload
+        </button>
+        <button
+          type="button"
+          onClick={handleClear}
+          disabled={getServerBaseUrl() === ''}
+          style={{
+            padding: '8px 16px',
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: '0.1em',
+            textTransform: 'uppercase',
+            color: 'var(--fg-2)',
+            background: 'var(--bg-2)',
+            border: '1px solid var(--panel-border)',
+            borderRadius: 'var(--r-sm)',
+            cursor: getServerBaseUrl() === '' ? 'not-allowed' : 'pointer',
+            opacity: getServerBaseUrl() === '' ? 0.5 : 1,
+          }}
+        >
+          Clear
+        </button>
+        {savedAt && (
+          <span style={{ fontSize: 11, color: 'var(--accent)' }}>Saved.</span>
+        )}
+      </div>
+
+      {isCapacitor && (
+        <div
+          style={{
+            marginTop: 22,
+            padding: 10,
+            fontSize: 11,
+            lineHeight: 1.5,
+            color: 'var(--fg-2)',
+            background: 'var(--bg-2)',
+            border: '1px solid var(--panel-border)',
+            borderRadius: 'var(--r-sm)',
+          }}
+        >
+          <strong style={{ color: 'var(--fg-1)' }}>Native shell detected.</strong>{' '}
+          Cleartext HTTP to RFC1918 / link-local addresses is permitted; iOS
+          may show a "Find devices on local network" prompt the first time
+          the app reaches a 192.168.* / 10.* host.
+        </div>
+      )}
+    </div>
+  );
+}
+
+function validateUrl(raw: string): string | null {
+  try {
+    const u = new URL(raw);
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') {
+      return 'Use http:// or https://';
+    }
+    if (!u.host) return 'Missing host';
+    return null;
+  } catch {
+    return 'Invalid URL';
+  }
+}

--- a/zeus-web/src/components/SettingsMenu.tsx
+++ b/zeus-web/src/components/SettingsMenu.tsx
@@ -25,13 +25,23 @@ import { AboutPanel } from './AboutPanel';
 import { DisplayPanel } from './DisplayPanel';
 import { QrzSettingsPanel } from './QrzSettingsPanel';
 import { RotatorSettingsPanel } from './RotatorSettingsPanel';
+import { ServerUrlPanel } from './ServerUrlPanel';
 import { TciSettingsPanel } from './TciSettingsPanel';
 import { RadioSelector } from './RadioSelector';
 import { usePaStore } from '../state/pa-store';
 import { PsSettingsPanel } from './PsSettingsPanel';
 import { TxAudioToolsPanel } from './TxAudioToolsPanel';
 
-type TabId = 'pa' | 'ps' | 'tx-audio' | 'qrz' | 'rotator' | 'tci' | 'display' | 'about';
+type TabId =
+  | 'pa'
+  | 'ps'
+  | 'tx-audio'
+  | 'qrz'
+  | 'rotator'
+  | 'tci'
+  | 'display'
+  | 'server'
+  | 'about';
 
 const TABS: ReadonlyArray<{ id: TabId; label: string }> = [
   { id: 'pa', label: 'PA SETTINGS' },
@@ -41,6 +51,7 @@ const TABS: ReadonlyArray<{ id: TabId; label: string }> = [
   { id: 'rotator', label: 'ROTATOR' },
   { id: 'tci', label: 'TCI' },
   { id: 'display', label: 'DISPLAY' },
+  { id: 'server', label: 'SERVER' },
   { id: 'about', label: 'ABOUT' },
 ];
 
@@ -307,6 +318,7 @@ export function SettingsMenu({ open, onClose, initialTab }: Props) {
           {active === 'rotator' && <RotatorSettingsPanel />}
           {active === 'tci' && <TciSettingsPanel />}
           {active === 'display' && <DisplayPanel />}
+          {active === 'server' && <ServerUrlPanel />}
           {active === 'about' && <AboutPanel />}
         </div>
       </div>

--- a/zeus-web/src/main.tsx
+++ b/zeus-web/src/main.tsx
@@ -51,6 +51,11 @@ import './styles/filter-ribbon.css';
 import './styles/toolbar-favorites.css';
 import './styles/nr-settings.css';
 import App from './App.tsx';
+import { installFetchInterceptor } from './serverUrl';
+
+// Capacitor / standalone-host builds set localStorage["zeus.serverUrl"]
+// to a LAN address; on plain web this is a no-op (relative paths).
+installFetchInterceptor();
 
 const rootEl = document.getElementById('root');
 if (!rootEl) throw new Error('root element missing');

--- a/zeus-web/src/realtime/ws-client.ts
+++ b/zeus-web/src/realtime/ws-client.ts
@@ -49,6 +49,7 @@ import { useConnectionStore, type WisdomPhase } from '../state/connection-store'
 import { useDisplayStore } from '../state/display-store';
 import { useTxStore } from '../state/tx-store';
 import { warnOnce } from '../util/logger';
+import { wsUrl as buildWsUrl } from '../serverUrl';
 
 const INITIAL_BACKOFF_MS = 1000;
 const MAX_BACKOFF_MS = 8000;
@@ -109,9 +110,7 @@ const MIC_PCM_BYTES = 1 + MIC_PCM_SAMPLES * 4;
 let activeWs: WebSocket | null = null;
 
 function wsUrl(path: string): string {
-  if (typeof window === 'undefined') return path;
-  const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-  return `${proto}//${window.location.host}${path}`;
+  return buildWsUrl(path);
 }
 
 /**

--- a/zeus-web/src/serverUrl.test.ts
+++ b/zeus-web/src/serverUrl.test.ts
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+// See LICENSE / ATTRIBUTIONS.md at the repository root.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Node 25 ships a stub `localStorage` global that lacks the Storage API
+// methods, shadowing jsdom's implementation. Install a minimal in-memory
+// stand-in BEFORE importing the module under test so its first read sees
+// a working API.
+function installLocalStorageShim() {
+  const store = new Map<string, string>();
+  const shim: Storage = {
+    getItem: (k) => (store.has(k) ? (store.get(k) as string) : null),
+    setItem: (k, v) => void store.set(k, String(v)),
+    removeItem: (k) => void store.delete(k),
+    clear: () => store.clear(),
+    key: (i) => Array.from(store.keys())[i] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: shim,
+  });
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: shim,
+  });
+}
+installLocalStorageShim();
+
+const {
+  apiUrl,
+  getServerBaseUrl,
+  installFetchInterceptor,
+  setServerBaseUrl,
+  wsUrl,
+} = await import('./serverUrl');
+
+const STORAGE_KEY = 'zeus.serverUrl';
+
+beforeEach(() => {
+  localStorage.removeItem(STORAGE_KEY);
+});
+
+afterEach(() => {
+  localStorage.removeItem(STORAGE_KEY);
+});
+
+describe('getServerBaseUrl / setServerBaseUrl', () => {
+  it('defaults to empty string when nothing is stored', () => {
+    expect(getServerBaseUrl()).toBe('');
+  });
+
+  it('round-trips a configured URL', () => {
+    setServerBaseUrl('http://192.168.1.23:6060');
+    expect(getServerBaseUrl()).toBe('http://192.168.1.23:6060');
+  });
+
+  it('strips trailing slashes', () => {
+    setServerBaseUrl('http://192.168.1.23:6060/');
+    expect(getServerBaseUrl()).toBe('http://192.168.1.23:6060');
+    setServerBaseUrl('http://example.invalid///');
+    expect(getServerBaseUrl()).toBe('http://example.invalid');
+  });
+
+  it('trims whitespace', () => {
+    setServerBaseUrl('   http://10.0.0.5:6060   ');
+    expect(getServerBaseUrl()).toBe('http://10.0.0.5:6060');
+  });
+
+  it('clears when given empty input', () => {
+    setServerBaseUrl('http://10.0.0.5:6060');
+    setServerBaseUrl('');
+    expect(getServerBaseUrl()).toBe('');
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe('apiUrl', () => {
+  it('returns the path unchanged when no base is configured', () => {
+    expect(apiUrl('/api/state')).toBe('/api/state');
+  });
+
+  it('prepends the configured base for relative paths', () => {
+    setServerBaseUrl('http://192.168.1.23:6060');
+    expect(apiUrl('/api/state')).toBe('http://192.168.1.23:6060/api/state');
+  });
+
+  it('passes absolute URLs through untouched', () => {
+    setServerBaseUrl('http://192.168.1.23:6060');
+    expect(apiUrl('http://other.example/foo')).toBe('http://other.example/foo');
+    expect(apiUrl('https://example.com/x')).toBe('https://example.com/x');
+  });
+
+  it('inserts a leading slash if the caller forgot one', () => {
+    setServerBaseUrl('http://10.0.0.1:6060');
+    expect(apiUrl('api/state')).toBe('http://10.0.0.1:6060/api/state');
+  });
+});
+
+describe('wsUrl', () => {
+  it('uses window.location when no base is configured', () => {
+    // jsdom default origin is http://localhost
+    expect(wsUrl('/ws')).toMatch(/^ws:\/\/localhost(:\d+)?\/ws$/);
+  });
+
+  it('uses ws:// with http base', () => {
+    setServerBaseUrl('http://192.168.1.23:6060');
+    expect(wsUrl('/ws')).toBe('ws://192.168.1.23:6060/ws');
+  });
+
+  it('uses wss:// with https base', () => {
+    setServerBaseUrl('https://radio.example:443');
+    expect(wsUrl('/ws')).toBe('wss://radio.example/ws');
+  });
+});
+
+describe('installFetchInterceptor', () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = window.fetch;
+  });
+
+  afterEach(() => {
+    window.fetch = originalFetch;
+    // clear the patch marker so each test reinstalls cleanly
+    delete (window as unknown as Record<string, unknown>).__zeusServerUrlPatched;
+  });
+
+  it('is a no-op when no base is configured', async () => {
+    const spy = vi.fn(async () => new Response('ok'));
+    window.fetch = spy as unknown as typeof fetch;
+    installFetchInterceptor();
+    await window.fetch('/api/state');
+    expect(spy).toHaveBeenCalledWith('/api/state', undefined);
+  });
+
+  it('rewrites /api/* paths when a base is configured', async () => {
+    const spy = vi.fn(async () => new Response('ok'));
+    window.fetch = spy as unknown as typeof fetch;
+    installFetchInterceptor();
+    setServerBaseUrl('http://192.168.1.23:6060');
+    await window.fetch('/api/state');
+    expect(spy).toHaveBeenCalledWith(
+      'http://192.168.1.23:6060/api/state',
+      undefined,
+    );
+  });
+
+  it('leaves non-matching relative paths alone', async () => {
+    const spy = vi.fn(async () => new Response('ok'));
+    window.fetch = spy as unknown as typeof fetch;
+    installFetchInterceptor();
+    setServerBaseUrl('http://192.168.1.23:6060');
+    await window.fetch('/static/icon.png');
+    expect(spy).toHaveBeenCalledWith('/static/icon.png', undefined);
+  });
+
+  it('leaves absolute URLs untouched', async () => {
+    const spy = vi.fn(async () => new Response('ok'));
+    window.fetch = spy as unknown as typeof fetch;
+    installFetchInterceptor();
+    setServerBaseUrl('http://192.168.1.23:6060');
+    await window.fetch('https://other.example/api/state');
+    expect(spy).toHaveBeenCalledWith(
+      'https://other.example/api/state',
+      undefined,
+    );
+  });
+
+  it('is idempotent — re-installing does not double-wrap', async () => {
+    const spy = vi.fn(async () => new Response('ok'));
+    window.fetch = spy as unknown as typeof fetch;
+    installFetchInterceptor();
+    installFetchInterceptor();
+    installFetchInterceptor();
+    setServerBaseUrl('http://10.0.0.5:6060');
+    await window.fetch('/api/x');
+    // If we'd double-wrapped, the URL would be doubly-prefixed garbage.
+    expect(spy).toHaveBeenCalledWith('http://10.0.0.5:6060/api/x', undefined);
+  });
+});

--- a/zeus-web/src/serverUrl.ts
+++ b/zeus-web/src/serverUrl.ts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+// See LICENSE / ATTRIBUTIONS.md at the repository root.
+
+// Configurable server base URL. The web build defaults to relative paths
+// (same-origin, served by Zeus.Server itself) so this module is invisible
+// to browser users. Capacitor builds can't assume same-origin — the WebView
+// runs on capacitor:// or http://localhost — so the user picks a LAN host
+// like "http://192.168.1.23:6060" and we route every /api/* call and the
+// /ws WebSocket to it.
+
+const STORAGE_KEY = 'zeus.serverUrl';
+const CHANGED_EVENT = 'zeus:server-url-changed';
+const FETCH_PATCH_MARKER = '__zeusServerUrlPatched';
+
+// Paths the interceptor rewrites onto the configured base. Anything else
+// (absolute URLs, third-party hosts, blob: / data: / file: schemes) passes
+// through untouched.
+const REWRITE_PREFIXES = ['/api/', '/ws', '/hub/'] as const;
+
+export type ServerUrlChangedEvent = CustomEvent<{ url: string }>;
+
+function readRaw(): string {
+  if (typeof localStorage === 'undefined') return '';
+  try {
+    return localStorage.getItem(STORAGE_KEY) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Returns the configured server base URL with no trailing slash, e.g.
+ * "http://192.168.1.23:6060". Empty string means "use relative paths"
+ * (the standard browser flow). Never throws.
+ */
+export function getServerBaseUrl(): string {
+  return normalize(readRaw());
+}
+
+/** Persist a new base URL. Pass empty string to clear. */
+export function setServerBaseUrl(url: string): void {
+  const cleaned = normalize(url);
+  try {
+    if (cleaned === '') {
+      localStorage.removeItem(STORAGE_KEY);
+    } else {
+      localStorage.setItem(STORAGE_KEY, cleaned);
+    }
+  } catch {
+    // Storage may be unavailable (private mode, etc.); the caller already
+    // sees the rejection via the next read.
+  }
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent(CHANGED_EVENT, { detail: { url: cleaned } }) as ServerUrlChangedEvent,
+    );
+  }
+}
+
+/** Strip whitespace and any trailing slashes. Empty in → empty out. */
+function normalize(raw: string): string {
+  const trimmed = (raw ?? '').trim();
+  if (trimmed === '') return '';
+  return trimmed.replace(/\/+$/, '');
+}
+
+/** Subscribe to base-URL changes (returns an unsubscribe). */
+export function onServerBaseUrlChanged(cb: (url: string) => void): () => void {
+  if (typeof window === 'undefined') return () => undefined;
+  const handler = (ev: Event) => {
+    const detail = (ev as ServerUrlChangedEvent).detail;
+    cb(detail?.url ?? '');
+  };
+  window.addEventListener(CHANGED_EVENT, handler);
+  return () => window.removeEventListener(CHANGED_EVENT, handler);
+}
+
+/**
+ * True when the page is hosted by Capacitor (Android/iOS native shell).
+ * Capacitor exposes a global, but it lands after the bridge initialises —
+ * we also accept the capacitor:// protocol or the runtime-injected meta tag
+ * so an isCapacitor() check at module-init time still works.
+ */
+export function isCapacitorRuntime(): boolean {
+  if (typeof window === 'undefined') return false;
+  const w = window as unknown as { Capacitor?: { isNativePlatform?: () => boolean } };
+  if (w.Capacitor?.isNativePlatform?.()) return true;
+  try {
+    if (window.location.protocol === 'capacitor:') return true;
+  } catch {
+    // ignore
+  }
+  return false;
+}
+
+/** Apply the configured base to a request path. Passes absolute URLs through. */
+export function apiUrl(path: string): string {
+  if (/^[a-z][a-z0-9+.-]*:/i.test(path)) return path; // already absolute
+  const base = getServerBaseUrl();
+  if (!base) return path;
+  return base + (path.startsWith('/') ? path : '/' + path);
+}
+
+/**
+ * Build a ws://host/path or wss://host/path URL using the configured
+ * server, falling back to window.location when no base is set.
+ */
+export function wsUrl(path: string): string {
+  if (typeof window === 'undefined') return path;
+  const base = getServerBaseUrl();
+  if (base) {
+    try {
+      const u = new URL(base);
+      const proto = u.protocol === 'https:' ? 'wss:' : 'ws:';
+      return `${proto}//${u.host}${path.startsWith('/') ? path : '/' + path}`;
+    } catch {
+      // fall through to same-origin fallback
+    }
+  }
+  const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  return `${proto}//${window.location.host}${path.startsWith('/') ? path : '/' + path}`;
+}
+
+function shouldRewrite(input: string): boolean {
+  if (/^[a-z][a-z0-9+.-]*:/i.test(input)) return false; // absolute URL
+  return REWRITE_PREFIXES.some((p) => input === p || input.startsWith(p));
+}
+
+function rewriteRequestInfo(input: RequestInfo | URL, base: string): RequestInfo | URL {
+  if (typeof input === 'string') {
+    return shouldRewrite(input) ? base + input : input;
+  }
+  if (input instanceof URL) return input;
+  // Request object — only rewrite if it's a same-origin relative path. The
+  // simplest reliable signal is comparing against window.location.origin.
+  try {
+    const reqUrl = new URL(input.url);
+    const here = new URL(window.location.href);
+    if (reqUrl.origin !== here.origin) return input;
+    const path = reqUrl.pathname + reqUrl.search + reqUrl.hash;
+    if (!shouldRewrite(path)) return input;
+    return new Request(base + path, input);
+  } catch {
+    return input;
+  }
+}
+
+/**
+ * Patch window.fetch so that any /api/*, /ws*, or /hub/* request is sent
+ * to the configured server base instead of same-origin. Idempotent — safe
+ * to call from main.tsx and again from tests. The patch is a no-op when no
+ * base is configured (web users on the bundled deploy).
+ */
+export function installFetchInterceptor(): void {
+  if (typeof window === 'undefined') return;
+  const w = window as unknown as Record<string, unknown>;
+  if (w[FETCH_PATCH_MARKER]) return;
+  const original = window.fetch.bind(window);
+  const patched: typeof fetch = (input, init) => {
+    const base = getServerBaseUrl();
+    if (!base) return original(input, init);
+    return original(rewriteRequestInfo(input, base), init);
+  };
+  window.fetch = patched;
+  w[FETCH_PATCH_MARKER] = true;
+}

--- a/zeus-web/src/service-worker/registerSW.ts
+++ b/zeus-web/src/service-worker/registerSW.ts
@@ -14,6 +14,7 @@
 // statement and per-component attribution.
 
 import { Workbox } from 'workbox-window';
+import { isCapacitorRuntime } from '../serverUrl';
 
 /**
  * Register the service worker and handle updates.
@@ -24,6 +25,13 @@ export function registerServiceWorker(
 ): (() => Promise<void>) | null {
   // Service worker only works in production builds
   if (import.meta.env.DEV) {
+    return null;
+  }
+
+  // Capacitor's WebView already ships the bundled assets — running the PWA
+  // service worker on top of capacitor:// scope causes redundant caching
+  // and update prompts that don't make sense for a native shell.
+  if (isCapacitorRuntime()) {
     return null;
   }
 


### PR DESCRIPTION
Follow-up to #191 (now merged). Adds the iOS half of the mobile CI story.

## Summary

- New workflow `.github/workflows/build-mobile-ios.yml` runs on `macos-latest` and compiles the Capacitor iOS project against the iOS Simulator on every push/PR that touches `zeus-web`, `zeus-mobile`, or the workflow itself, plus on `workflow_dispatch`.
- The build uses `CODE_SIGNING_ALLOWED=NO` — we only care that the project compiles. A simulator binary can't be sideloaded onto a real iPhone, so no artifact is uploaded; the workflow's only job is to fail the check if the project breaks.
- `zeus-mobile/README.md` gains a section documenting the local on-device install path: free-tier Apple ID, automatic Xcode signing, the 7-day re-sign caveat, and the trust-developer-profile step. A signed Apple Developer Program build is left as a separate ticket.

## Why simulator-only?

A real-device IPA needs an Apple Developer Program account ($99/yr) plus a distribution cert and provisioning profile loaded into GitHub secrets. That's the right move once there's a TestFlight / App Store distribution story, but it's overkill for a "does it still compile" gate. The simulator build gives the same regression coverage at zero cost and zero secrets.

## Test plan

- [ ] On merge to `develop`, confirm the **Build iOS (Simulator)** workflow runs green.
- [ ] Local: follow the new README section, sign with personal Apple ID, install on a real iPhone, paste a LAN Zeus.Server URL into Settings → Server, confirm the radio connects. (Manual; needs a Mac + iPhone.)