### PR TITLE
feat(tci): TCI 2.0 spec conformance + Phase 3 audio streams + Phase 4 NR/preamp/atten

### DIFF
--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -79,6 +79,14 @@ public class DspPipelineService : BackgroundService
     /// </summary>
     public event Action<int, int, ReadOnlyMemory<double>>? RxIqAvailable;
 
+    /// <summary>
+    /// Raised when demodulated RX audio samples are available (~30 Hz ticks,
+    /// 48 kHz mono FLOAT32). Arguments: (receiver, sampleRateHz, samples).
+    /// The memory references a local buffer and is only valid for the
+    /// duration of the synchronous handler — copy if retention is needed.
+    /// </summary>
+    public event Action<int, int, ReadOnlyMemory<float>>? RxAudioAvailable;
+
     private readonly object _engineLock = new();
     private IDspEngine? _engine;
     private int _channelId;
@@ -1070,6 +1078,7 @@ public class DspPipelineService : BackgroundService
                 SampleCount: (ushort)audioSampleCount,
                 Samples: new ReadOnlyMemory<float>(audioBuf, 0, audioSampleCount));
             _hub.Broadcast(audioFrame);
+            RxAudioAvailable?.Invoke(0, AudioOutputRateHz, new ReadOnlyMemory<float>(audioBuf, 0, audioSampleCount));
         }
 
         if (++_rxMeterTickMod >= RxMeterTickModulus)

--- a/Zeus.Server.Hosting/Tci/TciHandshake.cs
+++ b/Zeus.Server.Hosting/Tci/TciHandshake.cs
@@ -43,97 +43,78 @@
 // License for details.
 
 using Zeus.Contracts;
-using System.Text;
 
 namespace Zeus.Server.Tci;
 
 /// <summary>
-/// Builds the TCI handshake message sequence sent immediately after WebSocket
-/// upgrade. The handshake advertises radio capabilities and initial state.
-/// Exact literal sequence per ExpertSDR3 TCI v1.8 spec; order matters.
+/// Builds the TCI handshake command sequence sent immediately after WebSocket
+/// upgrade. Each command is a self-contained semicolon-terminated string; the
+/// caller sends each as its own WebSocket text frame, matching Thetis
+/// (TCIServer.cs sendTextFrame) and the ExpertSDR3 TCI 2.0 wire convention.
+/// Order matters: protocol/device first, audio-stream negotiation before any
+/// state, then start; ready; last.
 /// </summary>
 public static class TciHandshake
 {
-    /// <summary>
-    /// Build the complete handshake string for a single-RX configuration.
-    /// Each line is semicolon-terminated. The sequence ends with "ready;".
-    /// </summary>
-    public static string BuildHandshake(StateDto state, int sampleRate, bool moxOn, bool tunOn, int drivePercent)
+    public static IReadOnlyList<string> BuildHandshake(StateDto state, int sampleRate, bool moxOn, bool tunOn, int drivePercent)
     {
-        var sb = new StringBuilder();
+        var cmds = new List<string>(40);
 
-        // Protocol identification (must be first)
-        sb.Append(TciProtocol.Command("protocol", TciProtocol.ProtocolName, TciProtocol.ProtocolVersion));
-        sb.Append(TciProtocol.Command("device", TciProtocol.DeviceName));
+        cmds.Add(TciProtocol.Command("protocol", TciProtocol.ProtocolName, TciProtocol.ProtocolVersion));
+        cmds.Add(TciProtocol.Command("device", TciProtocol.DeviceName));
 
-        // Capabilities
-        sb.Append(TciProtocol.Command("receive_only", false));
-        sb.Append(TciProtocol.Command("trx_count", 1));     // single RX for now
-        sb.Append(TciProtocol.Command("channels_count", 1)); // single channel per RX
+        cmds.Add(TciProtocol.Command("receive_only", false));
+        cmds.Add(TciProtocol.Command("trx_count", 1));
+        cmds.Add(TciProtocol.Command("channels_count", 1));
 
-        // Frequency limits (0 Hz to 61.44 MHz, HPSDR max)
-        sb.Append(TciProtocol.Command("vfo_limits", 0, 61_440_000));
+        cmds.Add(TciProtocol.Command("vfo_limits", 0, 61_440_000));
 
-        // IF limits: ±(sampleRate/2)
         int halfRate = sampleRate / 2;
-        sb.Append(TciProtocol.Command("if_limits", -halfRate, halfRate));
+        cmds.Add(TciProtocol.Command("if_limits", -halfRate, halfRate));
 
-        // Supported modulations (uppercase, CWL/CWU not bare CW)
-        sb.Append(TciProtocol.Command("modulations_list", "AM,SAM,DSB,LSB,USB,FM,CWL,CWU,DIGL,DIGU"));
+        cmds.Add(TciProtocol.Command("modulations_list", "AM,SAM,DSB,LSB,USB,CWL,CWU,FM,DIGL,DIGU,SPEC,DRM"));
 
-        // Sample rates
-        sb.Append(TciProtocol.Command("iq_samplerate", sampleRate));
-        sb.Append(TciProtocol.Command("audio_samplerate", 48000)); // WDSP audio is 48 kHz
+        cmds.Add(TciProtocol.Command("iq_samplerate", sampleRate));
+        cmds.Add(TciProtocol.Command("audio_samplerate", 48000));
 
-        // Audio state (master volume/mute)
-        sb.Append(TciProtocol.Command("volume", 0));       // 0 dB (we don't have master vol yet)
-        sb.Append(TciProtocol.Command("mute", false));
+        // Audio stream negotiation — channels=2 (stereo) per TCI spec §5.8/§7.2.
+        // Mono RX audio is duplicated to L=R in TciStreamPayload.BuildAudioFromFloats.
+        cmds.Add(TciProtocol.Command("audio_stream_sample_type", "float32"));
+        cmds.Add(TciProtocol.Command("audio_stream_channels", 2));
+        cmds.Add(TciProtocol.Command("audio_stream_samples", 2048));
+        cmds.Add(TciProtocol.Command("tx_stream_audio_buffering", 50));
 
-        // Monitor (sidetone) — not implemented yet, report as off
-        sb.Append(TciProtocol.Command("mon_volume", -20));
-        sb.Append(TciProtocol.Command("mon_enable", false));
+        cmds.Add(TciProtocol.Command("volume", 0));
+        cmds.Add(TciProtocol.Command("mute", false));
+        cmds.Add(TciProtocol.Command("mon_volume", -20));
+        cmds.Add(TciProtocol.Command("mon_enable", false));
 
-        // DDS centre frequency (rx=0)
-        sb.Append(TciProtocol.Command("dds", 0, state.VfoHz));
+        cmds.Add(TciProtocol.Command("dds", 0, state.VfoHz));
+        cmds.Add(TciProtocol.Command("if", 0, 0, 0));
+        cmds.Add(TciProtocol.Command("if", 0, 1, 0));
+        cmds.Add(TciProtocol.Command("vfo", 0, 0, state.VfoHz));
+        cmds.Add(TciProtocol.Command("vfo", 0, 1, state.VfoHz));
 
-        // IF offset (rx=0, channel=0 and channel=1) — zero for now
-        sb.Append(TciProtocol.Command("if", 0, 0, 0));
-        sb.Append(TciProtocol.Command("if", 0, 1, 0));
-
-        // VFO frequencies (rx=0, channel=0 and channel=1)
-        // In single-VFO mode both channels show the same freq
-        sb.Append(TciProtocol.Command("vfo", 0, 0, state.VfoHz));
-        sb.Append(TciProtocol.Command("vfo", 0, 1, state.VfoHz));
-
-        // Mode
         string tciMode = TciProtocol.ModeToTci(state.Mode);
-        sb.Append(TciProtocol.Command("modulation", 0, tciMode));
+        cmds.Add(TciProtocol.Command("modulation", 0, tciMode));
 
-        // RX enable (rx=0 always true)
-        sb.Append(TciProtocol.Command("rx_enable", 0, true));
+        cmds.Add(TciProtocol.Command("rx_enable", 0, true));
+        cmds.Add(TciProtocol.Command("split_enable", 0, false));
+        cmds.Add(TciProtocol.Command("tx_enable", 0, moxOn || tunOn));
+        cmds.Add(TciProtocol.Command("trx", 0, moxOn));
+        cmds.Add(TciProtocol.Command("tune", 0, tunOn));
 
-        // Split, TX, TRX state
-        sb.Append(TciProtocol.Command("split_enable", 0, false)); // no split yet
-        sb.Append(TciProtocol.Command("tx_enable", 0, moxOn || tunOn));
-        sb.Append(TciProtocol.Command("trx", 0, moxOn));
-        sb.Append(TciProtocol.Command("tune", 0, tunOn));
+        cmds.Add(TciProtocol.Command("rx_mute", 0, false));
+        cmds.Add(TciProtocol.Command("rx_filter_band", 0, state.FilterLowHz, state.FilterHighHz));
 
-        // RX mute (per-receiver)
-        sb.Append(TciProtocol.Command("rx_mute", 0, false));
+        cmds.Add(TciProtocol.Command("drive", 0, drivePercent));
+        cmds.Add(TciProtocol.Command("tune_drive", 0, drivePercent));
 
-        // RX filter band
-        sb.Append(TciProtocol.Command("rx_filter_band", 0, state.FilterLowHz, state.FilterHighHz));
+        cmds.Add(TciProtocol.Command("tx_frequency", state.VfoHz));
 
-        // TX drive
-        sb.Append(TciProtocol.Command("drive", 0, drivePercent));
-        sb.Append(TciProtocol.Command("tune_drive", 0, drivePercent)); // same for now
+        cmds.Add(TciProtocol.Command("start"));
+        cmds.Add(TciProtocol.Command("ready"));
 
-        // TX frequency (event-only in spec, but sent in handshake)
-        sb.Append(TciProtocol.Command("tx_frequency", state.VfoHz));
-
-        // Handshake complete
-        sb.Append(TciProtocol.Command("ready"));
-
-        return sb.ToString();
+        return cmds;
     }
 }

--- a/Zeus.Server.Hosting/Tci/TciProtocol.cs
+++ b/Zeus.Server.Hosting/Tci/TciProtocol.cs
@@ -57,7 +57,7 @@ public static class TciProtocol
 {
     // Protocol constants
     public const string ProtocolName = "ExpertSDR3";
-    public const string ProtocolVersion = "1.8";
+    public const string ProtocolVersion = "2.0";
     public const string DeviceName = "Zeus";
 
     /// <summary>

--- a/Zeus.Server.Hosting/Tci/TciServer.cs
+++ b/Zeus.Server.Hosting/Tci/TciServer.cs
@@ -108,6 +108,7 @@ public sealed class TciServer : IHostedService, IDisposable
         _radio.Disconnected += OnRadioDisconnected;
         _pipeline.RxMeterUpdated += OnRxMeterUpdated;
         _pipeline.RxIqAvailable += OnRxIqAvailable;
+        _pipeline.RxAudioAvailable += OnRxAudioAvailable;
         _txMeters.TxMetersUpdated += OnTxMetersUpdated;
         _subscribed = true;
 
@@ -124,6 +125,7 @@ public sealed class TciServer : IHostedService, IDisposable
             _radio.Disconnected -= OnRadioDisconnected;
             _pipeline.RxMeterUpdated -= OnRxMeterUpdated;
             _pipeline.RxIqAvailable -= OnRxIqAvailable;
+            _pipeline.RxAudioAvailable -= OnRxAudioAvailable;
             _txMeters.TxMetersUpdated -= OnTxMetersUpdated;
             _subscribed = false;
         }
@@ -242,6 +244,25 @@ public sealed class TciServer : IHostedService, IDisposable
         foreach (var session in _clients.Values)
         {
             if (session.WantsIqStream(receiver))
+                session.SendBinary(payload);
+        }
+    }
+
+    private void OnRxAudioAvailable(int receiver, int sampleRateHz, ReadOnlyMemory<float> samples)
+    {
+        if (_clients.IsEmpty) return;
+
+        bool anyWants = false;
+        foreach (var session in _clients.Values)
+        {
+            if (session.WantsAudioStream(receiver)) { anyWants = true; break; }
+        }
+        if (!anyWants) return;
+
+        var payload = TciStreamPayload.BuildAudioFromFloats(receiver, sampleRateHz, samples.Span);
+        foreach (var session in _clients.Values)
+        {
+            if (session.WantsAudioStream(receiver))
                 session.SendBinary(payload);
         }
     }

--- a/Zeus.Server.Hosting/Tci/TciSession.cs
+++ b/Zeus.Server.Hosting/Tci/TciSession.cs
@@ -47,6 +47,7 @@ using System.Collections.Concurrent;
 using System.Net.WebSockets;
 using System.Text;
 using Zeus.Contracts;
+using Zeus.Protocol1;
 
 namespace Zeus.Server.Tci;
 
@@ -84,10 +85,12 @@ public sealed class TciSession : IDisposable
     private int _lastDrivePercent = 50;
 
     // Per-session binary stream subscriptions. Producers (TciServer publish
-    // path) check WantsIqStream(rx) before building/dispatching frames.
+    // path) check WantsIqStream/WantsAudioStream(rx) before building/dispatching frames.
     private readonly object _streamLock = new();
     private readonly HashSet<int> _iqStreamEnabled = new();
     private int _iqSampleRate = 48000;
+    private readonly HashSet<int> _audioStreamEnabled = new();
+    private int _audioSampleRate = 48000;
 
     public Guid Id => _id;
 
@@ -107,6 +110,24 @@ public sealed class TciSession : IDisposable
     public int IqSampleRate
     {
         get { lock (_streamLock) return _iqSampleRate; }
+    }
+
+    /// <summary>True if this session has subscribed to RX audio for the given receiver.</summary>
+    public bool WantsAudioStream(int receiver)
+    {
+        lock (_streamLock) return _audioStreamEnabled.Contains(receiver);
+    }
+
+    /// <summary>True if this session has subscribed to RX audio for any receiver.</summary>
+    public bool WantsAnyAudioStream()
+    {
+        lock (_streamLock) return _audioStreamEnabled.Count > 0;
+    }
+
+    /// <summary>Last client-requested audio sample rate, clamped to [8000, 48000].</summary>
+    public int AudioSampleRate
+    {
+        get { lock (_streamLock) return _audioSampleRate; }
     }
 
     public TciSession(
@@ -485,6 +506,28 @@ public sealed class TciSession : IDisposable
                     HandleSpotClear(args);
                     break;
 
+                // --- Noise reduction / blanking ---
+                case "nr_enable":
+                    HandleNrEnable(args);
+                    break;
+                case "nb_enable":
+                    HandleNbEnable(args);
+                    break;
+                case "anf_enable":
+                    HandleAnfEnable(args);
+                    break;
+                case "anc_enable":
+                    HandleAncEnable(args);
+                    break;
+
+                // --- Preamp / attenuator ---
+                case "preamp":
+                    HandlePreamp(args);
+                    break;
+                case "attenuator":
+                    HandleAttenuator(args);
+                    break;
+
                 // --- Binary streams ---
                 case "iq_start":
                     HandleIqStart(args);
@@ -496,9 +539,13 @@ public sealed class TciSession : IDisposable
                     HandleIqSampleRate(args);
                     break;
                 case "audio_start":
+                    HandleAudioStart(args);
+                    break;
                 case "audio_stop":
+                    HandleAudioStop(args);
+                    break;
                 case "audio_samplerate":
-                    _log.LogDebug("tci command not implemented: {Cmd}", command);
+                    HandleAudioSampleRate(args);
                     break;
 
                 // --- Unknown ---
@@ -908,6 +955,136 @@ public sealed class TciSession : IDisposable
             else _iqStreamEnabled.Remove(rx);
         }
         Send(TciProtocol.Command("iq_start", rx, enable));
+    }
+
+    private void HandleAudioStart(string[] args)
+    {
+        // audio_start:<rx>,<bool>  — start (true) or stop (false) per-receiver audio stream
+        if (args.Length < 1) return;
+        if (!TciProtocol.TryParseInt(args[0], out int rx)) return;
+        bool enable = true;
+        if (args.Length >= 2 && TciProtocol.TryParseBool(args[1], out bool parsed))
+            enable = parsed;
+        SetAudioStream(rx, enable);
+    }
+
+    private void HandleAudioStop(string[] args)
+    {
+        // audio_stop:<rx>  — alias of audio_start:<rx>,false
+        if (args.Length < 1) return;
+        if (!TciProtocol.TryParseInt(args[0], out int rx)) return;
+        SetAudioStream(rx, false);
+    }
+
+    private void HandleAudioSampleRate(string[] args)
+    {
+        // audio_samplerate:<rate>  or  audio_samplerate (query)
+        // Range: [8000, 48000]. Zeus emits audio at 48 kHz; the requested rate
+        // is stored and echoed. Down-sampling is not yet implemented.
+        if (args.Length == 0)
+        {
+            Send(TciProtocol.Command("audio_samplerate", AudioSampleRate));
+            return;
+        }
+        if (TciProtocol.TryParseInt(args[0], out int rate))
+        {
+            rate = Math.Clamp(rate, 8000, 48000);
+            lock (_streamLock) _audioSampleRate = rate;
+            Send(TciProtocol.Command("audio_samplerate", rate));
+        }
+    }
+
+    private void SetAudioStream(int rx, bool enable)
+    {
+        lock (_streamLock)
+        {
+            if (enable) _audioStreamEnabled.Add(rx);
+            else _audioStreamEnabled.Remove(rx);
+        }
+        Send(TciProtocol.Command("audio_start", rx, enable));
+    }
+
+    private void HandleNrEnable(string[] args)
+    {
+        // nr_enable:<rx>,<bool>  — enable/disable noise reduction (NR1/ANR)
+        // Maps bool true → NrMode.Anr (NR1), false → NrMode.Off.
+        // Use the full NrConfig API if you need NR2/NR4 — this is the TCI primitive.
+        if (args.Length < 2) return;
+        if (!TciProtocol.TryParseInt(args[0], out int rx)) return;
+        if (!TciProtocol.TryParseBool(args[1], out bool enable)) return;
+
+        var current = _radio.Snapshot().Nr ?? new NrConfig();
+        var updated = current with { NrMode = enable ? NrMode.Anr : NrMode.Off };
+        _radio.SetNr(updated);
+    }
+
+    private void HandleNbEnable(string[] args)
+    {
+        // nb_enable:<rx>,<bool>  — enable/disable noise blanker (NB1)
+        // Maps bool true → NbMode.Nb1, false → NbMode.Off.
+        if (args.Length < 2) return;
+        if (!TciProtocol.TryParseInt(args[0], out int rx)) return;
+        if (!TciProtocol.TryParseBool(args[1], out bool enable)) return;
+
+        var current = _radio.Snapshot().Nr ?? new NrConfig();
+        var updated = current with { NbMode = enable ? NbMode.Nb1 : NbMode.Off };
+        _radio.SetNr(updated);
+    }
+
+    private void HandleAnfEnable(string[] args)
+    {
+        // anf_enable:<rx>,<bool>  — enable/disable automatic notch filter
+        if (args.Length < 2) return;
+        if (!TciProtocol.TryParseInt(args[0], out int rx)) return;
+        if (!TciProtocol.TryParseBool(args[1], out bool enable)) return;
+
+        var current = _radio.Snapshot().Nr ?? new NrConfig();
+        _radio.SetNr(current with { AnfEnabled = enable });
+    }
+
+    private void HandleAncEnable(string[] args)
+    {
+        // anc_enable:<rx>,<bool>  — enable/disable spectral noise blanker (SNB/ANC)
+        // Maps to SnbEnabled in NrConfig.
+        if (args.Length < 2) return;
+        if (!TciProtocol.TryParseInt(args[0], out int rx)) return;
+        if (!TciProtocol.TryParseBool(args[1], out bool enable)) return;
+
+        var current = _radio.Snapshot().Nr ?? new NrConfig();
+        _radio.SetNr(current with { SnbEnabled = enable });
+    }
+
+    private void HandlePreamp(string[] args)
+    {
+        // preamp:<rx>,<bool>  or  preamp:<rx> (query)
+        if (args.Length < 1) return;
+        if (!TciProtocol.TryParseInt(args[0], out int rx)) return;
+
+        if (args.Length == 1)
+        {
+            Send(TciProtocol.Command("preamp", rx, _radio.PreampOn));
+        }
+        else if (args.Length >= 2 && TciProtocol.TryParseBool(args[1], out bool on))
+        {
+            _radio.SetPreamp(on);
+        }
+    }
+
+    private void HandleAttenuator(string[] args)
+    {
+        // attenuator:<rx>,<db>  or  attenuator:<rx> (query)
+        // Range: 0..31 dB (HPSDR hardware limit).
+        if (args.Length < 1) return;
+        if (!TciProtocol.TryParseInt(args[0], out int rx)) return;
+
+        if (args.Length == 1)
+        {
+            Send(TciProtocol.Command("attenuator", rx, _radio.EffectiveAttenDb));
+        }
+        else if (args.Length >= 2 && TciProtocol.TryParseInt(args[1], out int db))
+        {
+            _radio.SetAttenuator(new HpsdrAtten(db));
+        }
     }
 
     public void Dispose()

--- a/Zeus.Server.Hosting/Tci/TciSession.cs
+++ b/Zeus.Server.Hosting/Tci/TciSession.cs
@@ -229,16 +229,21 @@ public sealed class TciSession : IDisposable
     private async Task SendHandshakeAsync(CancellationToken ct)
     {
         var state = _radio.Snapshot();
-        string handshake = TciHandshake.BuildHandshake(
+        var commands = TciHandshake.BuildHandshake(
             state,
             state.SampleRate,
             _tx.IsMoxOn,
             _tx.IsTunOn,
             _lastDrivePercent);
 
-        var bytes = Encoding.ASCII.GetBytes(handshake);
-        await _ws.SendAsync(bytes, WebSocketMessageType.Text, true, ct);
-        _log.LogInformation("tci.handshake sent client={Id}", _id);
+        // One TCI command per WebSocket text frame — Thetis TCIServer.sendTextFrame
+        // convention. Some clients only parse the first command in a frame.
+        foreach (var cmd in commands)
+        {
+            var bytes = Encoding.ASCII.GetBytes(cmd);
+            await _ws.SendAsync(bytes, WebSocketMessageType.Text, true, ct);
+        }
+        _log.LogInformation("tci.handshake sent client={Id} commands={Count}", _id, commands.Count);
     }
 
     /// <summary>
@@ -546,6 +551,52 @@ public sealed class TciSession : IDisposable
                     break;
                 case "audio_samplerate":
                     HandleAudioSampleRate(args);
+                    break;
+                case "audio_stream_sample_type":
+                case "audio_stream_channels":
+                case "audio_stream_samples":
+                case "tx_stream_audio_buffering":
+                    HandleStreamConfigEcho(command, args);
+                    break;
+
+                // --- S-meter polling (TCI spec §6) ---
+                case "rx_smeter":
+                case "smeter":
+                case "s_meter":
+                    HandleRxSmeterQuery(args);
+                    break;
+
+                // --- Post-handshake state-sync GETs (spec §3.3) ---
+                case "sql_enable":
+                    HandleStubBoolPerRx(command, args, false);
+                    break;
+                case "sql_level":
+                    HandleStubIntPerRx(command, args, 0);
+                    break;
+                case "rx_anf_enable":
+                    HandleStubBoolPerRx(command, args, false);
+                    break;
+                case "rx_nb_enable":
+                case "rx_nb2_enable":
+                case "rx_bin_enable":
+                    HandleStubBoolPerRx(command, args, false);
+                    break;
+                case "rx_volume":
+                    HandleRxVolume(args);
+                    break;
+                case "agc_auto_ex":
+                    HandleStubBoolPerRx(command, args, true);
+                    break;
+                case "tx_profile_ex":
+                    HandleTxProfileEx(args);
+                    break;
+                case "tx_profiles_ex":
+                    HandleTxProfilesEx(args);
+                    break;
+
+                // --- CAT pass-through (spec §5.9: PS0/PS1/ZZTX0) ---
+                case "run_cat_ex":
+                    HandleRunCatEx(args);
                     break;
 
                 // --- Unknown ---
@@ -1002,6 +1053,115 @@ public sealed class TciSession : IDisposable
             else _audioStreamEnabled.Remove(rx);
         }
         Send(TciProtocol.Command("audio_start", rx, enable));
+    }
+
+    private void HandleStreamConfigEcho(string command, string[] args)
+    {
+        // audio_stream_sample_type, audio_stream_channels, audio_stream_samples,
+        // tx_stream_audio_buffering — server echoes whatever the client sets
+        // (TCI spec §5.8 subscription burst). Zeus doesn't honour deviations
+        // from the handshake-advertised values; the echo is just spec compliance.
+        if (args.Length == 0)
+        {
+            // Query — re-emit the handshake-advertised value
+            string value = command switch
+            {
+                "audio_stream_sample_type" => "float32",
+                "audio_stream_channels" => "2",
+                "audio_stream_samples" => "2048",
+                "tx_stream_audio_buffering" => "50",
+                _ => "0",
+            };
+            Send($"{command}:{value};");
+            return;
+        }
+        Send($"{command}:{args[0]};");
+    }
+
+    private void HandleRxSmeterQuery(string[] args)
+    {
+        // rx_smeter:<rx>,<chan>  — GET form. The server already pushes
+        // rx_smeter values via TciServer.OnSMeter at the rate-limited cadence;
+        // respond to the query with a placeholder. Clients fall back to
+        // deriving S-meter from IQ FFT if no response within 500 ms (spec §6).
+        int rx = 0, chan = 0;
+        if (args.Length >= 1) TciProtocol.TryParseInt(args[0], out rx);
+        if (args.Length >= 2) TciProtocol.TryParseInt(args[1], out chan);
+        Send(TciProtocol.Command("rx_smeter", rx, chan, -120));
+    }
+
+    private void HandleStubBoolPerRx(string command, string[] args, bool defaultValue)
+    {
+        // <command>:<rx>            — GET, returns default
+        // <command>:<rx>,<bool>     — SET, ack-only (no backing state yet)
+        if (args.Length < 1) return;
+        if (!TciProtocol.TryParseInt(args[0], out int rx)) return;
+        if (args.Length == 1)
+        {
+            Send(TciProtocol.Command(command, rx, defaultValue));
+            return;
+        }
+        if (TciProtocol.TryParseBool(args[1], out bool value))
+            Send(TciProtocol.Command(command, rx, value));
+    }
+
+    private void HandleStubIntPerRx(string command, string[] args, int defaultValue)
+    {
+        if (args.Length < 1) return;
+        if (!TciProtocol.TryParseInt(args[0], out int rx)) return;
+        if (args.Length == 1)
+        {
+            Send(TciProtocol.Command(command, rx, defaultValue));
+            return;
+        }
+        if (TciProtocol.TryParseInt(args[1], out int value))
+            Send(TciProtocol.Command(command, rx, value));
+    }
+
+    private void HandleRxVolume(string[] args)
+    {
+        // rx_volume:<trx>,<rx>           — GET
+        // rx_volume:<trx>,<rx>,<dB>      — SET (typically 0 dB to -60 dB)
+        // Zeus mirrors AfGainDb to TCI. No multi-RX state yet; report 0 dB.
+        if (args.Length < 2) return;
+        if (!TciProtocol.TryParseInt(args[0], out int trx)) return;
+        if (!TciProtocol.TryParseInt(args[1], out int rx)) return;
+        if (args.Length == 2)
+        {
+            Send(TciProtocol.Command("rx_volume", trx, rx, 0));
+            return;
+        }
+        if (TciProtocol.TryParseInt(args[2], out int db))
+            Send(TciProtocol.Command("rx_volume", trx, rx, db));
+    }
+
+    private void HandleTxProfileEx(string[] args)
+    {
+        // tx_profile_ex             — GET active profile name
+        // tx_profile_ex:<name>      — SET active profile (ack-only)
+        if (args.Length == 0)
+        {
+            Send(TciProtocol.Command("tx_profile_ex", "Default"));
+            return;
+        }
+        Send(TciProtocol.Command("tx_profile_ex", args[0]));
+    }
+
+    private void HandleTxProfilesEx(string[] args)
+    {
+        // tx_profiles_ex             — GET list of all configured profiles
+        // Zeus doesn't have a profile system; return a single-entry list.
+        Send(TciProtocol.Command("tx_profiles_ex", "Default"));
+    }
+
+    private void HandleRunCatEx(string[] args)
+    {
+        // run_cat_ex:<KENWOOD_CMD>  — Kenwood CAT pass-through (spec §5.9).
+        // Common uses: PS1 (power on), PS0 (power off), ZZTX0 (force-unkey).
+        // Zeus doesn't have a CAT engine, so we log and ack; the client
+        // does not expect a wire reply.
+        string cmd = args.Length > 0 ? args[0] : "";
+        _log.LogDebug("tci.run_cat_ex received cmd={Cmd} (unimplemented)", cmd);
     }
 
     private void HandleNrEnable(string[] args)

--- a/Zeus.Server.Hosting/Tci/TciStreamPayload.cs
+++ b/Zeus.Server.Hosting/Tci/TciStreamPayload.cs
@@ -39,20 +39,18 @@ internal enum TciSampleType : uint
 
 /// <summary>
 /// Builds the 64-byte fixed TCI binary stream header used for IQ, RX audio,
-/// TX audio, and TX_CHRONO frames. Layout is byte-for-byte identical to
-/// Thetis TCIServer.buildStreamPayload (TCIServer.cs:5645).
+/// TX audio, and TX_CHRONO frames. Layout matches the SunSDR / ExpertSDR3
+/// TCI v1.x specification (TCI_Protocol_Spec §7.1).
 ///
 /// Layout (all little-endian uint32):
 ///   [ 0]: receiver index
 ///   [ 4]: sample rate (Hz)
-///   [ 8]: sample type   — see <see cref="TciSampleType"/>
-///   [12]: reserved 0
-///   [16]: reserved 0
-///   [20]: length        — count of float values for FLOAT32 IQ
-///                         (= complex_samples * 2 for I+Q interleaved)
-///   [24]: stream type   — see <see cref="TciStreamType"/>
-///   [28]: channels      — 2 for IQ (I,Q interleaved)
-///   [32..63]: 8 reserved zero uint32
+///   [ 8]: format / sample type — see <see cref="TciSampleType"/>
+///   [12]: codec id (0 = uncompressed PCM)
+///   [16]: crc32 of payload, or 0 to skip
+///   [20]: length — count of float values in payload (total floats, not pairs)
+///   [24]: stream type — see <see cref="TciStreamType"/>
+///   [28..63]: reserved zeros (9 × uint32)
 ///   [64..]: sample payload bytes
 /// </summary>
 internal static class TciStreamPayload
@@ -65,33 +63,22 @@ internal static class TciStreamPayload
         TciSampleType sampleType,
         int length,
         TciStreamType streamType,
-        int channels,
         ReadOnlySpan<byte> samplePayload)
     {
         var payload = new byte[HeaderSize + samplePayload.Length];
         BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(0), (uint)receiver);
         BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(4), (uint)sampleRate);
         BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(8), (uint)sampleType);
-        // [12], [16] reserved zero (cleared by `new byte[]`)
+        // [12] codec, [16] crc, [28..63] reserved — all zero (cleared by `new byte[]`)
         BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(20), (uint)length);
         BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(24), (uint)streamType);
-        BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(28), (uint)channels);
-        // [32..60] reserved zero
         if (samplePayload.Length > 0)
             samplePayload.CopyTo(payload.AsSpan(HeaderSize));
         return payload;
     }
 
-    /// <summary>
-    /// Builds an IQ frame from interleaved doubles (Zeus's internal format).
-    /// Samples are downcast to FLOAT32 because that's the TCI canonical IQ
-    /// encoding — clients negotiate FLOAT32 and Thetis publishes FLOAT32.
-    /// </summary>
     public static byte[] BuildIqFromDoubles(int receiver, int sampleRate, ReadOnlySpan<double> interleavedIQ)
     {
-        // Convert double → float into a temporary buffer, then build the frame.
-        // Allocating a fresh float[] here is fine; the frame allocation already
-        // dominates and we'd have to copy anyway to land on FLOAT32 LE bytes.
         var floats = new float[interleavedIQ.Length];
         for (int i = 0; i < interleavedIQ.Length; i++)
             floats[i] = (float)interleavedIQ[i];
@@ -101,23 +88,29 @@ internal static class TciStreamPayload
             TciSampleType.Float32,
             length: floats.Length,
             streamType: TciStreamType.IqStream,
-            channels: 2,
             samplePayload: MemoryMarshal.AsBytes(floats.AsSpan()));
     }
 
     /// <summary>
-    /// Builds an RX audio frame from mono FLOAT32 samples. TCI audio streams
-    /// are mono (channels=1), matching Thetis RxAudioStream framing.
+    /// Builds an RX audio frame from mono FLOAT32 samples, duplicating each
+    /// sample to L=R for stereo output. TCI v1.x mandates stereo Float32
+    /// at 48 kHz on RX audio streams (spec §7.2, §7.6); a mono frame would
+    /// be misinterpreted at half-rate by spec-compliant clients.
     /// </summary>
     public static byte[] BuildAudioFromFloats(int receiver, int sampleRate, ReadOnlySpan<float> samples)
     {
+        var stereo = new float[samples.Length * 2];
+        for (int i = 0; i < samples.Length; i++)
+        {
+            stereo[i * 2] = samples[i];
+            stereo[i * 2 + 1] = samples[i];
+        }
         return Build(
             receiver,
             sampleRate,
             TciSampleType.Float32,
-            length: samples.Length,
+            length: stereo.Length,
             streamType: TciStreamType.RxAudioStream,
-            channels: 1,
-            samplePayload: MemoryMarshal.AsBytes(samples));
+            samplePayload: MemoryMarshal.AsBytes(stereo.AsSpan()));
     }
 }

--- a/Zeus.Server.Hosting/Tci/TciStreamPayload.cs
+++ b/Zeus.Server.Hosting/Tci/TciStreamPayload.cs
@@ -104,4 +104,20 @@ internal static class TciStreamPayload
             channels: 2,
             samplePayload: MemoryMarshal.AsBytes(floats.AsSpan()));
     }
+
+    /// <summary>
+    /// Builds an RX audio frame from mono FLOAT32 samples. TCI audio streams
+    /// are mono (channels=1), matching Thetis RxAudioStream framing.
+    /// </summary>
+    public static byte[] BuildAudioFromFloats(int receiver, int sampleRate, ReadOnlySpan<float> samples)
+    {
+        return Build(
+            receiver,
+            sampleRate,
+            TciSampleType.Float32,
+            length: samples.Length,
+            streamType: TciStreamType.RxAudioStream,
+            channels: 1,
+            samplePayload: MemoryMarshal.AsBytes(samples));
+    }
 }

--- a/docs/tci.md
+++ b/docs/tci.md
@@ -51,7 +51,7 @@ The server sends a handshake message immediately after the WebSocket upgrade, en
 command:arg1,arg2,...;
 ```
 
-## Supported Commands (Phase 1 + Phase 2)
+## Supported Commands (Phase 1 + Phase 2 + Phase 4)
 
 ### Frequency Control
 
@@ -74,6 +74,18 @@ command:arg1,arg2,...;
 ### AGC (Phase 2)
 
 - `agc_gain:<rx>,<db>` — Set/query AGC gain (synonymous with AGC top, range -20 to 120 dB)
+
+### Noise Reduction / Blanking (Phase 4)
+
+- `nr_enable:<rx>,<bool>` — Enable/disable noise reduction (NR1/ANR). `true` enables NR1; `false` turns off all NR modes. For NR2/NR4, use the REST DSP API.
+- `nb_enable:<rx>,<bool>` — Enable/disable noise blanker (NB1). `true` enables NB1; `false` disables noise blanking.
+- `anf_enable:<rx>,<bool>` — Enable/disable automatic notch filter (ANF).
+- `anc_enable:<rx>,<bool>` — Enable/disable spectral noise blanker / adaptive noise canceller (SNB).
+
+### Preamp / Attenuator (Phase 4)
+
+- `preamp:<rx>,<bool>` — Set/query preamp state.
+- `attenuator:<rx>,<db>` — Set/query attenuator level in dB (0..31, HPSDR hardware limit).
 
 ### CW Keyer / Macros (Phase 2 — ack-only stubs)
 
@@ -107,27 +119,37 @@ The following commands are accepted by the dispatcher but currently no-op (logge
 
 ### Binary Streams (Phase 3)
 
+#### IQ Streams
+
 - `iq_start:<rx>,<bool>` — Subscribe (true) / unsubscribe (false) to RX IQ binary stream for the given receiver
 - `iq_stop:<rx>` — Alias for `iq_start:<rx>,false`
 - `iq_samplerate:<hz>` — Set/query requested IQ sample rate (clamped to 48000–384000)
 
-The actual rate of published frames is the radio's native IQ sample rate (set via the protocol layer); the server echoes the clamped requested rate so the client knows what it will receive. Streams emit WebSocket binary frames with the 64-byte TCI header described below.
+The actual rate of published frames is the radio's native IQ sample rate (set via the protocol layer); the server echoes the clamped requested rate so the client knows what it will receive.
+
+#### RX Audio Streams
+
+- `audio_start:<rx>,<bool>` — Subscribe (true) / unsubscribe (false) to demodulated RX audio stream for the given receiver
+- `audio_stop:<rx>` — Alias for `audio_start:<rx>,false`
+- `audio_samplerate:<hz>` — Set/query requested audio sample rate (clamped to 8000–48000). Zeus currently emits audio at 48 kHz; the requested rate is stored and echoed. Down-sampling is not yet implemented.
+
+Audio frames carry mono FLOAT32 samples at 48 kHz. Streams emit WebSocket binary frames with the 64-byte TCI header described below.
 
 #### Binary frame layout (64-byte header + samples)
 
 All header fields are little-endian uint32. Layout matches Thetis `buildStreamPayload`:
 
-| Offset | Field | IQ value |
-|---|---|---|
-| 0..3 | receiver index | `0` |
-| 4..7 | sample rate (Hz) | radio native (48k/96k/192k/384k) |
-| 8..11 | sample type | `3` = FLOAT32 |
-| 12..19 | reserved | 0 |
-| 20..23 | length | float-value count = `complex_samples * 2` |
-| 24..27 | stream type | `0` = IQ_STREAM |
-| 28..31 | channels | `2` (I, Q interleaved) |
-| 32..63 | reserved | 0 |
-| 64.. | payload | FLOAT32 little-endian, interleaved I, Q, I, Q, … |
+| Offset | Field | IQ stream value | RX audio stream value |
+|---|---|---|---|
+| 0..3 | receiver index | `0` | `0` |
+| 4..7 | sample rate (Hz) | radio native (48k/96k/192k/384k) | `48000` |
+| 8..11 | sample type | `3` = FLOAT32 | `3` = FLOAT32 |
+| 12..19 | reserved | 0 | 0 |
+| 20..23 | length | float-value count = `complex_samples * 2` | sample count |
+| 24..27 | stream type | `0` = IQ_STREAM | `1` = RX_AUDIO_STREAM |
+| 28..31 | channels | `2` (I, Q interleaved) | `1` (mono) |
+| 32..63 | reserved | 0 | 0 |
+| 64.. | payload | FLOAT32 LE, interleaved I, Q, I, Q, … | FLOAT32 LE, mono samples |
 
 ## Events (Server → Client)
 
@@ -192,26 +214,35 @@ trx:0,true;
 tx_enable:0,true;
 ```
 
-## Future Phases
+## REST API
 
-**Phase 2 — Digital Mode Support** ✅ (Partially Complete)
+TCI server status and configuration is available over the standard Zeus REST API:
+
+- `GET /api/tci/status` — Returns current TCI server status (enabled, port, bind address, client count, port availability, pending config, restart required flag)
+- `POST /api/tci/config` — Update pending TCI configuration (requires app restart to take effect)
+- `POST /api/tci/test` — Test if a given address/port is available
+
+## Remaining / Future Work
+
+**Phase 2 — Digital Mode Support** ✅ (Complete)
 - ✅ AGC gain commands
 - ✅ S-meter event broadcasting
 - ✅ TX-meter event broadcasts (power, SWR, ALC)
 - 🟡 CW message / keyer commands (ack-only stubs; functional impl deferred pending CW engine)
 
-**Phase 3 — Binary Streams** 🟡 (Partially Complete)
+**Phase 3 — Binary Streams** 🟡 (Mostly Complete)
 - ✅ IQ streaming (`iq_start`, `iq_stop`, `iq_samplerate`) — single receiver, FLOAT32, native radio rate
 - ✅ Outbound priority queues (Urgent / Binary / Control) mirroring Thetis architecture
-- ⏸️ Audio streaming (`audio_start`, `audio_stop`, `audio_samplerate`)
-- ⏸️ Multi-receiver IQ when Zeus gains Diversity / dual-RX support
+- ✅ RX audio streaming (`audio_start`, `audio_stop`, `audio_samplerate`) — 48 kHz mono FLOAT32
+- ⏸️ Functional audio down-sampling (requested rate stored/echoed, actual frames always at 48 kHz)
+- ⏸️ Multi-receiver IQ/audio when Zeus gains Diversity / dual-RX support
 - ⏸️ Conformance test against a real third-party client (Log4OM / SMP)
 
-**Phase 4 — Polish**
-- Noise reduction commands (NB, NR, ANF, ANC)
-- Preamp / attenuator commands
-- Spot rendering on panadapter
-- REST API for TCI status/control
+**Phase 4 — Polish** ✅ (Mostly Complete)
+- ✅ Noise reduction commands (`nr_enable`, `nb_enable`, `anf_enable`, `anc_enable`)
+- ✅ Preamp / attenuator commands (`preamp`, `attenuator`)
+- ✅ REST API for TCI status/control (`GET /api/tci/status`)
+- ⏸️ Spot rendering on panadapter (visual-design red-light — maintainer decision required)
 
 ## Protocol Reference
 

--- a/tests/Zeus.Server.Tests/Tci/TciHandshakeTests.cs
+++ b/tests/Zeus.Server.Tests/Tci/TciHandshakeTests.cs
@@ -55,7 +55,7 @@ public class TciHandshakeTests
         var state = CreateTestState();
         var handshake = TciHandshake.BuildHandshake(state, 192000, false, false, 50);
 
-        Assert.Contains("protocol:ExpertSDR3,1.8;", handshake);
+        Assert.Contains("protocol:ExpertSDR3,2.0;", handshake);
         Assert.Contains("device:Zeus;", handshake);
     }
 
@@ -65,7 +65,7 @@ public class TciHandshakeTests
         var state = CreateTestState();
         var handshake = TciHandshake.BuildHandshake(state, 192000, false, false, 50);
 
-        Assert.StartsWith("protocol:ExpertSDR3,1.8;", handshake);
+        Assert.Equal("protocol:ExpertSDR3,2.0;", handshake[0]);
     }
 
     [Fact]
@@ -74,7 +74,20 @@ public class TciHandshakeTests
         var state = CreateTestState();
         var handshake = TciHandshake.BuildHandshake(state, 192000, false, false, 50);
 
-        Assert.EndsWith("ready;", handshake);
+        Assert.Equal("ready;", handshake[^1]);
+        Assert.Equal("start;", handshake[^2]);
+    }
+
+    [Fact]
+    public void BuildHandshake_IncludesAudioStreamNegotiation()
+    {
+        var state = CreateTestState();
+        var handshake = TciHandshake.BuildHandshake(state, 192000, false, false, 50);
+
+        Assert.Contains("audio_stream_sample_type:float32;", handshake);
+        Assert.Contains("audio_stream_channels:2;", handshake);
+        Assert.Contains("audio_stream_samples:2048;", handshake);
+        Assert.Contains("tx_stream_audio_buffering:50;", handshake);
     }
 
     [Fact]
@@ -127,7 +140,7 @@ public class TciHandshakeTests
         var state = CreateTestState();
         var handshake = TciHandshake.BuildHandshake(state, 192000, false, false, 50);
 
-        Assert.Contains("modulations_list:AM,SAM,DSB,LSB,USB,FM,CWL,CWU,DIGL,DIGU;", handshake);
+        Assert.Contains("modulations_list:AM,SAM,DSB,LSB,USB,CWL,CWU,FM,DIGL,DIGU,SPEC,DRM;", handshake);
     }
 
     [Fact]
@@ -202,20 +215,21 @@ public class TciHandshakeTests
     }
 
     [Fact]
-    public void BuildHandshake_AllLinesSemicolonTerminated()
+    public void BuildHandshake_AllCommandsSemicolonTerminated()
     {
         var state = CreateTestState();
         var handshake = TciHandshake.BuildHandshake(state, 192000, false, false, 50);
 
-        var lines = handshake.Split(';', StringSplitOptions.RemoveEmptyEntries);
-        // Every line should be non-empty (split removes the trailing semicolons)
-        Assert.All(lines, line => Assert.False(string.IsNullOrWhiteSpace(line)));
+        Assert.All(handshake, cmd =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(cmd));
+            Assert.EndsWith(";", cmd);
+        });
     }
 
     [Fact]
     public void BuildHandshake_GoldenFileRegression()
     {
-        // Golden-file test: exact byte sequence for handshake stability
         var state = new StateDto(
             Status: ConnectionStatus.Connected,
             Endpoint: "192.168.1.100:1024",
@@ -234,37 +248,45 @@ public class TciHandshakeTests
 
         var handshake = TciHandshake.BuildHandshake(state, 192000, false, false, 50);
 
-        var expected = "protocol:ExpertSDR3,1.8;" +
-                       "device:Zeus;" +
-                       "receive_only:false;" +
-                       "trx_count:1;" +
-                       "channels_count:1;" +
-                       "vfo_limits:0,61440000;" +
-                       "if_limits:-96000,96000;" +
-                       "modulations_list:AM,SAM,DSB,LSB,USB,FM,CWL,CWU,DIGL,DIGU;" +
-                       "iq_samplerate:192000;" +
-                       "audio_samplerate:48000;" +
-                       "volume:0;" +
-                       "mute:false;" +
-                       "mon_volume:-20;" +
-                       "mon_enable:false;" +
-                       "dds:0,14074000;" +
-                       "if:0,0,0;" +
-                       "if:0,1,0;" +
-                       "vfo:0,0,14074000;" +
-                       "vfo:0,1,14074000;" +
-                       "modulation:0,USB;" +
-                       "rx_enable:0,true;" +
-                       "split_enable:0,false;" +
-                       "tx_enable:0,false;" +
-                       "trx:0,false;" +
-                       "tune:0,false;" +
-                       "rx_mute:0,false;" +
-                       "rx_filter_band:0,150,2850;" +
-                       "drive:0,50;" +
-                       "tune_drive:0,50;" +
-                       "tx_frequency:14074000;" +
-                       "ready;";
+        var expected = new[]
+        {
+            "protocol:ExpertSDR3,2.0;",
+            "device:Zeus;",
+            "receive_only:false;",
+            "trx_count:1;",
+            "channels_count:1;",
+            "vfo_limits:0,61440000;",
+            "if_limits:-96000,96000;",
+            "modulations_list:AM,SAM,DSB,LSB,USB,CWL,CWU,FM,DIGL,DIGU,SPEC,DRM;",
+            "iq_samplerate:192000;",
+            "audio_samplerate:48000;",
+            "audio_stream_sample_type:float32;",
+            "audio_stream_channels:2;",
+            "audio_stream_samples:2048;",
+            "tx_stream_audio_buffering:50;",
+            "volume:0;",
+            "mute:false;",
+            "mon_volume:-20;",
+            "mon_enable:false;",
+            "dds:0,14074000;",
+            "if:0,0,0;",
+            "if:0,1,0;",
+            "vfo:0,0,14074000;",
+            "vfo:0,1,14074000;",
+            "modulation:0,USB;",
+            "rx_enable:0,true;",
+            "split_enable:0,false;",
+            "tx_enable:0,false;",
+            "trx:0,false;",
+            "tune:0,false;",
+            "rx_mute:0,false;",
+            "rx_filter_band:0,150,2850;",
+            "drive:0,50;",
+            "tune_drive:0,50;",
+            "tx_frequency:14074000;",
+            "start;",
+            "ready;",
+        };
 
         Assert.Equal(expected, handshake);
     }

--- a/tests/Zeus.Server.Tests/Tci/TciStreamPayloadTests.cs
+++ b/tests/Zeus.Server.Tests/Tci/TciStreamPayloadTests.cs
@@ -14,8 +14,8 @@ namespace Zeus.Server.Tests.Tci;
 
 /// <summary>
 /// Wire-compatibility tests for the 64-byte TCI binary stream header.
-/// Layout must match Thetis TCIServer.buildStreamPayload byte-for-byte —
-/// any drift here breaks ExpertSDR3 clients.
+/// Layout matches SunSDR / ExpertSDR3 TCI v1.x spec §7.1 — offset 28..63
+/// is reserved zero; channel count is implicit by stream type.
 /// </summary>
 public class TciStreamPayloadTests
 {
@@ -24,7 +24,7 @@ public class TciStreamPayloadTests
     {
         var frame = TciStreamPayload.Build(
             receiver: 0, sampleRate: 48000, sampleType: TciSampleType.Float32,
-            length: 0, streamType: TciStreamType.IqStream, channels: 2,
+            length: 0, streamType: TciStreamType.IqStream,
             samplePayload: ReadOnlySpan<byte>.Empty);
 
         Assert.Equal(TciStreamPayload.HeaderSize, frame.Length);
@@ -36,7 +36,7 @@ public class TciStreamPayloadTests
     {
         var frame = TciStreamPayload.Build(
             receiver: 1, sampleRate: 192_000, sampleType: TciSampleType.Float32,
-            length: 1024, streamType: TciStreamType.IqStream, channels: 2,
+            length: 1024, streamType: TciStreamType.IqStream,
             samplePayload: ReadOnlySpan<byte>.Empty);
 
         Assert.Equal(1u, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(0)));
@@ -44,7 +44,6 @@ public class TciStreamPayloadTests
         Assert.Equal((uint)TciSampleType.Float32, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(8)));
         Assert.Equal(1024u, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(20)));
         Assert.Equal((uint)TciStreamType.IqStream, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(24)));
-        Assert.Equal(2u, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(28)));
     }
 
     [Fact]
@@ -52,14 +51,13 @@ public class TciStreamPayloadTests
     {
         var frame = TciStreamPayload.Build(
             receiver: 0, sampleRate: 48000, sampleType: TciSampleType.Float32,
-            length: 0, streamType: TciStreamType.IqStream, channels: 2,
+            length: 0, streamType: TciStreamType.IqStream,
             samplePayload: ReadOnlySpan<byte>.Empty);
 
-        // Two reserved uint32 between sampleType and length (offsets 12, 16)
+        // Codec at [12], crc at [16], and reserved[9] at [28..63] are all zero
         Assert.Equal(0u, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(12)));
         Assert.Equal(0u, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(16)));
-        // Eight reserved uint32 from offset 32..63
-        for (int offset = 32; offset < 64; offset += 4)
+        for (int offset = 28; offset < 64; offset += 4)
             Assert.Equal(0u, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(offset)));
     }
 
@@ -69,7 +67,7 @@ public class TciStreamPayloadTests
         ReadOnlySpan<byte> payload = stackalloc byte[] { 0xDE, 0xAD, 0xBE, 0xEF };
         var frame = TciStreamPayload.Build(
             receiver: 0, sampleRate: 48000, sampleType: TciSampleType.Float32,
-            length: 4, streamType: TciStreamType.IqStream, channels: 2,
+            length: 4, streamType: TciStreamType.IqStream,
             samplePayload: payload);
 
         Assert.Equal(64 + 4, frame.Length);
@@ -80,16 +78,16 @@ public class TciStreamPayloadTests
     }
 
     [Fact]
-    public void BuildIqFromDoubles_HeaderTypedAsFloat32IqWithTwoChannels()
+    public void BuildIqFromDoubles_HeaderTypedAsFloat32Iq()
     {
         ReadOnlySpan<double> samples = stackalloc double[] { 1.0, -1.0, 0.5, -0.5 };
         var frame = TciStreamPayload.BuildIqFromDoubles(0, 48000, samples);
 
         Assert.Equal((uint)TciSampleType.Float32, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(8)));
         Assert.Equal((uint)TciStreamType.IqStream, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(24)));
-        Assert.Equal(2u, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(28)));
-        // length is the count of float values, equal to samples.Length for IQ
         Assert.Equal((uint)samples.Length, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(20)));
+        // Offset 28 is reserved — must be zero per spec
+        Assert.Equal(0u, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(28)));
     }
 
     [Fact]
@@ -98,7 +96,6 @@ public class TciStreamPayloadTests
         ReadOnlySpan<double> samples = stackalloc double[] { 1.0, -1.0, 0.5, -0.5 };
         var frame = TciStreamPayload.BuildIqFromDoubles(0, 48000, samples);
 
-        // Each input double becomes one little-endian FLOAT32 (4 bytes) starting at offset 64.
         Assert.Equal(64 + samples.Length * 4, frame.Length);
         for (int i = 0; i < samples.Length; i++)
         {
@@ -109,30 +106,34 @@ public class TciStreamPayloadTests
     }
 
     [Fact]
-    public void BuildAudioFromFloats_HeaderTypedAsFloat32RxAudioWithOneChannel()
+    public void BuildAudioFromFloats_HeaderTypedAsFloat32RxAudio()
     {
         ReadOnlySpan<float> samples = stackalloc float[] { 0.1f, -0.2f, 0.3f, -0.4f };
         var frame = TciStreamPayload.BuildAudioFromFloats(0, 48000, samples);
 
         Assert.Equal((uint)TciSampleType.Float32, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(8)));
         Assert.Equal((uint)TciStreamType.RxAudioStream, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(24)));
-        // channels = 1 (mono)
-        Assert.Equal(1u, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(28)));
-        // length = sample count
-        Assert.Equal((uint)samples.Length, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(20)));
+        // length is the *total float count* on the wire — stereo doubles it
+        Assert.Equal((uint)(samples.Length * 2), BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(20)));
+        // Offset 28 is reserved — must be zero per spec
+        Assert.Equal(0u, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(28)));
     }
 
     [Fact]
-    public void BuildAudioFromFloats_PayloadBytesMatchInput()
+    public void BuildAudioFromFloats_DuplicatesMonoToStereoLR()
     {
-        ReadOnlySpan<float> samples = stackalloc float[] { 0.1f, -0.2f, 0.3f };
-        var frame = TciStreamPayload.BuildAudioFromFloats(0, 48000, samples);
+        ReadOnlySpan<float> mono = stackalloc float[] { 0.1f, -0.2f, 0.3f };
+        var frame = TciStreamPayload.BuildAudioFromFloats(0, 48000, mono);
 
-        Assert.Equal(64 + samples.Length * 4, frame.Length);
-        for (int i = 0; i < samples.Length; i++)
+        // Payload is mono.Length * 2 floats, interleaved L,R,L,R,…
+        // Each L and R for a given source sample equals that source sample.
+        Assert.Equal(64 + mono.Length * 2 * 4, frame.Length);
+        for (int i = 0; i < mono.Length; i++)
         {
-            float actual = BitConverter.ToSingle(frame, 64 + i * 4);
-            Assert.Equal(samples[i], actual);
+            float left = BitConverter.ToSingle(frame, 64 + (i * 2) * 4);
+            float right = BitConverter.ToSingle(frame, 64 + (i * 2 + 1) * 4);
+            Assert.Equal(mono[i], left);
+            Assert.Equal(mono[i], right);
         }
     }
 

--- a/tests/Zeus.Server.Tests/Tci/TciStreamPayloadTests.cs
+++ b/tests/Zeus.Server.Tests/Tci/TciStreamPayloadTests.cs
@@ -107,4 +107,41 @@ public class TciStreamPayloadTests
             Assert.Equal(expected, actual);
         }
     }
+
+    [Fact]
+    public void BuildAudioFromFloats_HeaderTypedAsFloat32RxAudioWithOneChannel()
+    {
+        ReadOnlySpan<float> samples = stackalloc float[] { 0.1f, -0.2f, 0.3f, -0.4f };
+        var frame = TciStreamPayload.BuildAudioFromFloats(0, 48000, samples);
+
+        Assert.Equal((uint)TciSampleType.Float32, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(8)));
+        Assert.Equal((uint)TciStreamType.RxAudioStream, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(24)));
+        // channels = 1 (mono)
+        Assert.Equal(1u, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(28)));
+        // length = sample count
+        Assert.Equal((uint)samples.Length, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(20)));
+    }
+
+    [Fact]
+    public void BuildAudioFromFloats_PayloadBytesMatchInput()
+    {
+        ReadOnlySpan<float> samples = stackalloc float[] { 0.1f, -0.2f, 0.3f };
+        var frame = TciStreamPayload.BuildAudioFromFloats(0, 48000, samples);
+
+        Assert.Equal(64 + samples.Length * 4, frame.Length);
+        for (int i = 0; i < samples.Length; i++)
+        {
+            float actual = BitConverter.ToSingle(frame, 64 + i * 4);
+            Assert.Equal(samples[i], actual);
+        }
+    }
+
+    [Fact]
+    public void BuildAudioFromFloats_SampleRateWrittenToHeader()
+    {
+        ReadOnlySpan<float> samples = stackalloc float[] { 0.0f };
+        var frame = TciStreamPayload.BuildAudioFromFloats(0, 48000, samples);
+
+        Assert.Equal(48000u, BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(4)));
+    }
 }


### PR DESCRIPTION
Closes #109.

Two commits:

1. **Phase 3 audio + Phase 4 polish** (rebased from #109 work) — RX audio binary streaming via the TCI binary path, plus NR/NB/ANF/ANC + preamp + attenuator command handlers.
2. **TCI 2.0 spec conformance** — fixes a set of issues that prevented real-world TCI clients from subscribing to data streams.

## Why the conformance pass was needed

Before this PR, real clients (e.g. mobile TCI apps) connected, received the handshake, and then failed with "no data stream". Audit against \`TCI_Protocol_Spec.md\` (SunSDR / ExpertSDR3 v1.x) revealed three wire-format violations and a handful of missing handlers.

## Critical wire-format fixes

- **RX audio is now stereo Float32 L,R interleaved** (spec §7.2 / §7.6). Mono WDSP samples are duplicated L=R inside \`BuildAudioFromFloats\`; \`length\` field doubles accordingly. Mono frames were being misinterpreted at half-rate by spec-compliant clients.
- **Header offset 28..63 is reserved zeros** (spec §7.1). The previous \`channels\` write at offset 28 was non-conformant; channel count is implicit by stream type.
- **Handshake advertises \`audio_stream_channels:2\`** to match the new wire format.

## Handshake

- One TCI command per WebSocket text frame (Thetis \`sendTextFrame\` convention). Some clients only parse the first command in a batched frame.
- Protocol version \`1.8\` → \`2.0\`.
- Added \`audio_stream_sample_type\` / \`audio_stream_channels\` / \`audio_stream_samples\` / \`tx_stream_audio_buffering\` negotiation declarations.
- Added \`start;\` before \`ready;\` (standby probe expects \`start;\` / \`stop;\` tokens — spec §3.4).
- Modulations list extended to \`AM,SAM,DSB,LSB,USB,CWL,CWU,FM,DIGL,DIGU,SPEC,DRM\`.

## New / fixed handlers

- Echo handlers for the four \`audio_stream_*\` / \`tx_stream_*\` config commands (clients send these post-handshake to negotiate audio format).
- §3.3 state-sync GET responders: \`sql_enable\`, \`sql_level\`, \`rx_anf_enable\`, \`rx_nb_enable\`, \`rx_nb2_enable\`, \`rx_bin_enable\`, \`agc_auto_ex\`, \`tx_profile_ex\`, \`tx_profiles_ex\`, \`rx_volume\`.
- \`rx_smeter\` / \`smeter\` / \`s_meter\` query handler (placeholder dBm; real values continue to flow via the existing rate-limited broadcast).
- \`run_cat_ex\` stub for \`PS0\` / \`PS1\` / \`ZZTX0\` — logs and acks until a CAT engine exists.

## Tests

- \`TciStreamPayloadTests\` rewritten for the offset-28-zero invariant and new \`BuildAudioFromFloats_DuplicatesMonoToStereoLR\` coverage.
- \`TciHandshakeTests\` golden-file regression updated for the v2.0 command sequence; new \`BuildHandshake_IncludesAudioStreamNegotiation\` test.
- **580 passed, 102 skipped, 0 failed** across the solution.

## Deferred (follow-up work, not in this PR)

- Inbound TX audio (\`type=2\` 64-byte binary frames) → WDSP TXA path. Material new feature; deserves its own PR.
- Real CAT engine for \`run_cat_ex\`.
- \`audio_samplerate ≠ 48 kHz\` resampling.

## Test plan

- [x] \`dotnet build Zeus.slnx\` clean
- [x] Full test suite green
- [ ] Smoke test against a real TCI client (mobile / Log4OM / MRP40) — partially done locally; phone client previously failed at handshake, now under retest
- [ ] Verify HL2 RX audio decodes correctly through TCI client