### PR TITLE
fix(tci): wire volume / rx_volume to RxAfGainDb (re-applies #85)

### DIFF
--- a/Zeus.Server.Hosting/Tci/TciHandshake.cs
+++ b/Zeus.Server.Hosting/Tci/TciHandshake.cs
@@ -84,7 +84,11 @@ public static class TciHandshake
         cmds.Add(TciProtocol.Command("audio_stream_samples", 2048));
         cmds.Add(TciProtocol.Command("tx_stream_audio_buffering", 50));
 
-        cmds.Add(TciProtocol.Command("volume", 0));
+        // Master volume tracks RxAfGainDb so TCI clients see the live value
+        // immediately on connect. mon_volume is the TX sidetone bus (TCI spec
+        // §5.5) — independent of RX audio gain — so it stays a placeholder
+        // until Zeus has a real monitor path.
+        cmds.Add(TciProtocol.Command("volume", (int)Math.Round(state.RxAfGainDb)));
         cmds.Add(TciProtocol.Command("mute", false));
         cmds.Add(TciProtocol.Command("mon_volume", -20));
         cmds.Add(TciProtocol.Command("mon_enable", false));

--- a/Zeus.Server.Hosting/Tci/TciSession.cs
+++ b/Zeus.Server.Hosting/Tci/TciSession.cs
@@ -791,12 +791,19 @@ public sealed class TciSession : IDisposable
 
     private void HandleVolume(string[] args)
     {
-        // volume:<db> or volume (query)
+        // volume:<db>  (SET)  or  volume  (GET)
+        // Legacy / Thetis-flavoured master volume — not in the SunSDR TCI
+        // catalog, but real clients emit it. Wire to RxAfGainDb so this and
+        // rx_volume share a single source of truth (RadioService clamps to
+        // [-50, +20] dB to mirror Thetis ptbAF).
         if (args.Length == 0)
         {
-            Send(TciProtocol.Command("volume", 0)); // no master volume yet
+            var state = _radio.Snapshot();
+            Send(TciProtocol.Command("volume", (int)Math.Round(state.RxAfGainDb)));
+            return;
         }
-        // Ignore set — not implemented
+        if (TciProtocol.TryParseDouble(args[0], out double db))
+            _radio.SetRxAfGain(db);
     }
 
     private void HandleMonEnable(string[] args)
@@ -1120,19 +1127,22 @@ public sealed class TciSession : IDisposable
 
     private void HandleRxVolume(string[] args)
     {
-        // rx_volume:<trx>,<rx>           — GET
-        // rx_volume:<trx>,<rx>,<dB>      — SET (typically 0 dB to -60 dB)
-        // Zeus mirrors AfGainDb to TCI. No multi-RX state yet; report 0 dB.
+        // SunSDR TCI spec §5.4 — per-RX volume in dB.
+        //   rx_volume:<trx>,<rx>          GET → echo current dB
+        //   rx_volume:<trx>,<rx>,<dB>     SET → route through SetRxAfGain
+        // Zeus has a single shared AF bus today, so all (trx,rx) combos
+        // mirror RxAfGainDb. RadioService clamps to [-50, +20] dB.
         if (args.Length < 2) return;
         if (!TciProtocol.TryParseInt(args[0], out int trx)) return;
         if (!TciProtocol.TryParseInt(args[1], out int rx)) return;
         if (args.Length == 2)
         {
-            Send(TciProtocol.Command("rx_volume", trx, rx, 0));
+            var state = _radio.Snapshot();
+            Send(TciProtocol.Command("rx_volume", trx, rx, (int)Math.Round(state.RxAfGainDb)));
             return;
         }
-        if (TciProtocol.TryParseInt(args[2], out int db))
-            Send(TciProtocol.Command("rx_volume", trx, rx, db));
+        if (TciProtocol.TryParseDouble(args[2], out double db))
+            _radio.SetRxAfGain(db);
     }
 
     private void HandleTxProfileEx(string[] args)

--- a/tests/Zeus.Server.Tests/Tci/TciHandshakeTests.cs
+++ b/tests/Zeus.Server.Tests/Tci/TciHandshakeTests.cs
@@ -78,6 +78,20 @@ public class TciHandshakeTests
         Assert.Equal("start;", handshake[^2]);
     }
 
+    [Theory]
+    [InlineData(0.0, 0)]
+    [InlineData(-12.4, -12)]
+    [InlineData(-37.6, -38)]
+    [InlineData(20.0, 20)]
+    [InlineData(-50.0, -50)]
+    public void BuildHandshake_VolumeFieldReflectsRxAfGainDb(double rxAfGainDb, int expectedVolume)
+    {
+        var state = CreateTestState(rxAfGainDb: rxAfGainDb);
+        var handshake = TciHandshake.BuildHandshake(state, 192000, false, false, 50);
+
+        Assert.Contains($"volume:{expectedVolume};", handshake);
+    }
+
     [Fact]
     public void BuildHandshake_IncludesAudioStreamNegotiation()
     {
@@ -295,7 +309,8 @@ public class TciHandshakeTests
         long vfoHz = 14200000,
         RxMode mode = RxMode.USB,
         int filterLow = 150,
-        int filterHigh = 2850)
+        int filterHigh = 2850,
+        double rxAfGainDb = 0.0)
     {
         return new StateDto(
             Status: ConnectionStatus.Connected,
@@ -311,6 +326,7 @@ public class TciHandshakeTests
             ZoomLevel: 1,
             AutoAttEnabled: true,
             AttOffsetDb: 0,
-            AdcOverloadWarning: false);
+            AdcOverloadWarning: false,
+            RxAfGainDb: rxAfGainDb);
     }
 }


### PR DESCRIPTION
Closes #85.

## Background

#85 was nominally fixed by commit \`843a034\` (April 24) — \"feat(tci): wire volume/mon_volume stubs to RxAfGainDb state\" — but the subsequent \`Zeus.Server.Hosting\` extraction refactor (\`106cba4\`) silently regressed it. The TCI handlers and handshake fields went back to hardcoded stubs even though the underlying \`RadioService.SetRxAfGain\` / \`StateDto.RxAfGainDb\` plumbing survived intact. Discovered while triaging open TCI issues after #194 landed.

## What changed

- \`rx_volume:trx,rx,db\` (SunSDR TCI spec §5.4) — SET routes through \`RadioService.SetRxAfGain\` (clamps to [-50, +20] dB to mirror Thetis ptbAF); GET reads \`state.RxAfGainDb\`. Single shared AF bus today, so all (trx,rx) combos mirror the same value until multi-RX lands.
- \`volume\` (legacy / Thetis-flavoured, not in the spec catalog) — wired the same way for back-compat.
- Handshake \`volume:\` field now reflects \`state.RxAfGainDb\` rounded to int dB instead of a hardcoded \`0\`.

## Two corrections vs the original 843a034

After re-reading the spec carefully:

1. **\`mon_volume\` stays a -20 dB stub.** Spec §5.5 defines \`mon_volume\` as the TX sidetone monitor — independent of RX audio gain. The original 843a034 wiring (\"mon_volume proxies RxAfGainDb until a dedicated monitor bus exists\") was conceptually wrong; this PR doesn't replicate that mistake. Real fix waits for a proper monitor bus.
2. **\`rx_volume\` is now the primary handler**, in addition to legacy \`volume\`. The original 843a034 only touched \`volume\` / \`mon_volume\`; spec §3.3 shows the post-handshake state-sync burst queries \`rx_volume:0,0;\`, so that's the canonical command and needs first-class support.

## Tests

- New theory \`BuildHandshake_VolumeFieldReflectsRxAfGainDb\` covers 0, -12.4, -37.6, +20, -50 dB.
- 585 passed / 102 skipped / 0 failed across the solution.

## Test plan

- [x] \`dotnet build Zeus.slnx\` clean
- [x] Full test suite green
- [ ] Smoke test: connect a TCI client, query \`rx_volume:0,0;\` → expect current dB; SET \`rx_volume:0,0,-20;\` → verify the web UI's AF gain slider tracks