### PR TITLE
fix(ci): pin Linux build runners to ubuntu-22.04 for glibc compat

### DIFF
--- a/.github/workflows/build-native-libs.yml
+++ b/.github/workflows/build-native-libs.yml
@@ -105,7 +105,13 @@ jobs:
 
   build-linux:
     name: Build Linux Native Libraries
-    runs-on: ubuntu-latest
+    # Pinned to ubuntu-22.04 (glibc 2.35) so libwdsp.so loads on Ubuntu 22.04,
+    # Debian 12, RHEL 9 and equivalents. ubuntu-latest moved to 24.04 (glibc
+    # 2.39) and produced binaries that fail with `version GLIBC_2.38 not
+    # found` on every older distro. Do NOT bump this without a deliberate
+    # decision to drop those users — same applies to the arm64 cross-compile
+    # below, whose aarch64 sysroot comes from this host's apt.
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         arch: [x64, arm64]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,12 @@ jobs:
             rid: win-x64
             artifact: windows-installer
           - os: linux
-            runner: ubuntu-latest
+            # Pinned to ubuntu-22.04 (glibc 2.35) — the self-contained .NET
+            # publish embeds native runtime libs that link against the build
+            # host's glibc, so building on ubuntu-latest (24.04, glibc 2.39)
+            # produces a tarball that fails on Ubuntu 22.04 / Debian 12 / RHEL
+            # 9 with `version GLIBC_2.38 not found`. Match build-native-libs.yml.
+            runner: ubuntu-22.04
             rid: linux-x64
             artifact: linux-tarball
           - os: macos-arm64


### PR DESCRIPTION
## Summary

- `ubuntu-latest` moved to Ubuntu 24.04 (glibc 2.39), so the Linux artifacts shipped from CI link against a glibc that is missing on every still-supported "older" distro: Ubuntu 22.04 LTS (glibc 2.35), Debian 12 Bookworm (2.36), Mint 21.x, RHEL 9 derivatives, etc.
- Reported against `zeus-0.4.1-linux-x64` by on8ei. The .NET host found `runtimes/linux-x64/native/libwdsp.so` correctly but the loader bailed with:

  ```
  /runtimes/linux-x64/native/libwdsp.so: version `GLIBC_2.38' not found
  ```

  The other "cannot open shared object file" lines in the stack are just the loader's fallback name search after the GLIBC failure — noise.

- Pin both Linux native-lib and release runners to **`ubuntu-22.04`** (glibc 2.35). Covers every reasonable current distro and is a supported GitHub Actions image through 2027. No C/C++ change — runner image only.

## Files

- `.github/workflows/build-native-libs.yml` — `build-linux` job (produces `libwdsp.so` for both x64 and arm64; arm64 cross-compile picks its aarch64 sysroot from the host's apt, so the same pin protects both).
- `.github/workflows/release.yml` — linux matrix entry (the `dotnet publish --self-contained` output embeds glibc-linked native runtime libs that bake in the build host's glibc).
- `build-test.yml` is intentionally left on `ubuntu-latest` — it doesn't ship artifacts.

Inline comments on both edits warn against bumping the pin without a deliberate decision to drop older-distro users.

## Shipping the fix

This PR alone won't help on8ei — the rebuilt `libwdsp.so` and the next Linux tarball need to land in a tagged release. After merge:

1. Merge develop → main on the next release-train cycle.
2. Cut a `v0.4.2` tag on main; `release.yml` will rebuild the Linux tarball on the pinned runner.

## Test plan

- [ ] CI green on this branch (build-test, release dry-run if it fires)
- [ ] Sanity-check the rebuilt `libwdsp.so` artifact: `ldd` shows no `GLIBC_2.3{8,9}` requirement
- [ ] After release tag, confirm on8ei (or any Ubuntu 22.04 / Debian 12 box) can launch Zeus without the `GLIBC_2.38 not found` error