### PR TITLE
fix(tci/web): kill phantom 'Configuration changed' warning on page load

### DIFF
--- a/zeus-web/src/state/tci-store.ts
+++ b/zeus-web/src/state/tci-store.ts
@@ -23,40 +23,17 @@ import {
   type TciTestResult,
 } from '../api/tci';
 
-// Persist the enabled/bindAddress/port the user has chosen so the settings
-// panel stays usable across reloads. The backend persists this to disk and
-// is the source of truth; this is just the form-default memory.
-const CONFIG_STORAGE_KEY = 'zeus.tci.config';
+// The backend (TciConfigStore on disk) is the source of truth for TCI runtime
+// config. The form initialises from /api/tci/status once it arrives; this
+// constant is only used as a transient placeholder until the first status
+// refresh completes. Do NOT seed from localStorage and do NOT auto-POST on
+// load — that produced a phantom "configuration changed — restart" warning
+// every page load when localStorage drifted from disk.
 const DEFAULT_CONFIG: TciConfig = {
   enabled: false,
   bindAddress: '127.0.0.1',
   port: 40001,
 };
-
-function readSavedConfig(): TciConfig {
-  try {
-    if (typeof localStorage === 'undefined') return DEFAULT_CONFIG;
-    const raw = localStorage.getItem(CONFIG_STORAGE_KEY);
-    if (!raw) return DEFAULT_CONFIG;
-    const parsed = JSON.parse(raw) as Partial<TciConfig>;
-    return {
-      enabled: Boolean(parsed.enabled),
-      bindAddress: typeof parsed.bindAddress === 'string' && parsed.bindAddress ? parsed.bindAddress : DEFAULT_CONFIG.bindAddress,
-      port: typeof parsed.port === 'number' && parsed.port > 0 ? parsed.port : DEFAULT_CONFIG.port,
-    };
-  } catch {
-    return DEFAULT_CONFIG;
-  }
-}
-
-function writeSavedConfig(cfg: TciConfig): void {
-  try {
-    if (typeof localStorage === 'undefined') return;
-    localStorage.setItem(CONFIG_STORAGE_KEY, JSON.stringify(cfg));
-  } catch {
-    /* quota — silent */
-  }
-}
 
 export type TciStoreState = {
   config: TciConfig;
@@ -69,8 +46,8 @@ export type TciStoreState = {
   test: (bindAddress: string, port: number) => Promise<TciTestResult>;
 };
 
-export const useTciStore = create<TciStoreState>((set) => ({
-  config: readSavedConfig(),
+export const useTciStore = create<TciStoreState>((set, get) => ({
+  config: DEFAULT_CONFIG,
   status: null,
   testInFlight: false,
   lastTestResult: null,
@@ -78,14 +55,30 @@ export const useTciStore = create<TciStoreState>((set) => ({
   refreshStatus: async () => {
     try {
       const status = await getTciStatus();
-      set({ status });
+      // Sync the form-default config from the backend's pending values
+      // (what will be applied on next restart) so the panel never shows a
+      // value that disagrees with disk-persisted state. Skip the sync if
+      // the user has unsaved local edits — saveConfig already pushed those
+      // and we don't want to clobber them mid-edit.
+      const current = get().config;
+      const synced =
+        current.enabled === status.pendingEnabled
+          && current.bindAddress === status.pendingBindAddress
+          && current.port === status.pendingPort;
+      set({
+        status,
+        config: synced ? current : {
+          enabled: status.pendingEnabled,
+          bindAddress: status.pendingBindAddress,
+          port: status.pendingPort,
+        },
+      });
     } catch {
       /* transient — next poll recovers */
     }
   },
 
   saveConfig: async (cfg) => {
-    writeSavedConfig(cfg);
     const status = await postTciConfig(cfg);
     set({ config: cfg, status });
     return status;
@@ -99,17 +92,11 @@ export const useTciStore = create<TciStoreState>((set) => ({
   },
 }));
 
-// Kick off an initial status probe at module load, then poll at 2 s while the
-// page is alive. When TCI config changes (requires restart), this updates the
-// UI to show the RequiresRestart flag and current client count.
+// Initial status probe at module load + 2 s polling while the page is alive.
+// Status changes drive the panel's RequiresRestart flag and client count.
 if (typeof window !== 'undefined') {
   void useTciStore.getState().refreshStatus();
   window.setInterval(() => {
     void useTciStore.getState().refreshStatus();
   }, 2000);
-
-  // Push the saved config to the backend on first load so the service knows
-  // what the user wants for next restart. Backend persists this to disk.
-  const initial = useTciStore.getState().config;
-  void useTciStore.getState().saveConfig(initial);
 }


### PR DESCRIPTION
## Symptom

Open the web UI on a freshly-started backend (TCI enabled, bound to \`0.0.0.0\`); the TCI settings panel immediately shows the yellow ⚠ \"Configuration changed — restart Zeus to apply\" banner, with the bind-address field reading \`127.0.0.1\` even though the user did not touch anything.

## Root cause

\`zeus-web/src/state/tci-store.ts\` was POSTing the localStorage-cached TCI config to \`/api/tci/config\` on every page load:

\`\`\`typescript
// removed
const initial = useTciStore.getState().config;
void useTciStore.getState().saveConfig(initial);
\`\`\`

That makes \`pendingBindAddress\` flip to whatever localStorage held (the \`127.0.0.1\` default seed for fresh browsers) while \`currentBindAddress\` stays at the actually-running value. \`requiresRestart\` becomes true, and the banner fires correctly — but for a config change the user never made.

## Fix

1. Remove the load-time auto-POST. \`TciConfigStore\` on disk is the single source of truth for the pending runtime config — the localStorage cache competed with it and added nothing.
2. Drive the form's config from the backend's \`pending*\` fields once status arrives. Guards against clobbering unsaved local edits mid-typing.

Old localStorage entries are simply ignored on the read side; no migration needed.

## Test plan

- [x] Build clean
- [ ] Cold-load web UI on a backend running with \`bindAddress: 0.0.0.0\` → panel shows \`0.0.0.0\` in the field, no restart banner
- [ ] Edit field, click SAVE → restart banner appears (correct behaviour)