### PR TITLE
fix(flex): stop content clicks bubbling into flexlayout drag-detection

### DIFF
--- a/zeus-web/src/components/nr/NrSettingsSection.tsx
+++ b/zeus-web/src/components/nr/NrSettingsSection.tsx
@@ -17,6 +17,7 @@
 // matching Thetis's Setup-form pattern.
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { create } from 'zustand';
 import {
   Activity,
   BarChart3,
@@ -56,17 +57,27 @@ export type NrSettingsSectionProps = {
   mode: NrSettingsMode;
 };
 
-export function NrSettingsSection({ mode }: NrSettingsSectionProps) {
-  // Collapsed by default — the dense gauge panel is too much to keep on
-  // screen for the casual operator. The chevron in the title bar telegraphs
-  // that there's more behind the click.
-  const [expanded, setExpanded] = useState(false);
+// Per-mode disclosure state lives in a global store, not local component
+// state, so the panel survives any FlexLayout re-render that unmounts the
+// DSP tab content (drag, dock, tabset reflow). Keyed by mode so each NR
+// algorithm's accordion remembers its own open/closed state.
+type NrSettingsUiState = {
+  expanded: Record<NrSettingsMode, boolean>;
+  toggle: (mode: NrSettingsMode) => void;
+};
 
-  // Reset when the user cycles to a different NR algorithm — each panel's
-  // disclosure state stays local to its own session.
-  useEffect(() => {
-    setExpanded(false);
-  }, [mode]);
+const useNrSettingsUi = create<NrSettingsUiState>((set) => ({
+  expanded: { Anr: false, Emnr: false, Sbnr: false },
+  toggle: (mode) =>
+    set((s) => ({ expanded: { ...s.expanded, [mode]: !s.expanded[mode] } })),
+}));
+
+export function NrSettingsSection({ mode }: NrSettingsSectionProps) {
+  // Persisted disclosure: collapsed by default (the dense gauge panel is
+  // too much for the casual operator), but stays open across remounts once
+  // the user opens it. The chevron telegraphs the click target.
+  const expanded = useNrSettingsUi((s) => s.expanded[mode]);
+  const toggle = useNrSettingsUi((s) => s.toggle);
 
   const title =
     mode === 'Anr' ? 'NR1 — ANR' : mode === 'Emnr' ? 'NR2 — EMNR' : 'NR4 — SBNR';
@@ -77,7 +88,15 @@ export function NrSettingsSection({ mode }: NrSettingsSectionProps) {
         type="button"
         className="nr-settings__title-btn"
         aria-expanded={expanded}
-        onClick={() => setExpanded((v) => !v)}
+        onClick={(e) => {
+          // Belt-and-braces: stop bubbling so any pointer-down on the
+          // ancestor flexlayout tabset can't fire its drag-detection on
+          // an accordion-toggle click. (The factory wrapper in
+          // FlexWorkspace also catches this, but covering it here keeps
+          // the fix robust to changes in the wrapper.)
+          e.stopPropagation();
+          toggle(mode);
+        }}
       >
         <span className="nr-settings__chevron" aria-hidden>
           {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}

--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -42,7 +42,7 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type MouseEvent, type PointerEvent } from 'react';
 import {
   Actions,
   BorderNode,
@@ -64,12 +64,30 @@ import { DEFAULT_LAYOUT } from './defaultLayout';
 import { TerminatorLines } from '../components/design/TerminatorLines';
 import { AddPanelModal } from './AddPanelModal';
 
+// Stop pointer/mouse-down events inside panel content from bubbling up to
+// flexlayout-react's parent tabset, which uses them to start its own
+// drag-detection. When that detection fires on a normal control click it
+// triggers Actions.selectTab and forces FlexLayout to re-render the active
+// tab — symptoms include the panadapter canvas restarting, accordion
+// buttons appearing dead because their local useState resets on remount,
+// and inline forms losing focus mid-keystroke. The tab-strip header lives
+// outside this wrapper, so tab dragging / reordering / docking are all
+// unaffected.
+const stopPropagationProps = {
+  onPointerDown: (e: PointerEvent) => e.stopPropagation(),
+  onMouseDown: (e: MouseEvent) => e.stopPropagation(),
+} as const;
+
 function factory(node: TabNode) {
   const id = node.getComponent();
   const panel = id ? PANELS[id] : undefined;
   if (!panel) return null;
   const Component = panel.component;
-  return <Component />;
+  return (
+    <div className="flex-panel-content" style={{ width: '100%', height: '100%' }} {...stopPropagationProps}>
+      <Component />
+    </div>
+  );
 }
 
 // FlexWorkspace: renders the movable/dockable panel layout when ?layout=flex


### PR DESCRIPTION
## Summary

Clicks anywhere inside a flex panel were being intercepted by flexlayout-react's parent-tabset `onPointerDown` handler, which calls `Actions.selectTab` on every interaction. The active tab re-renders, with three visible symptoms:

- panadapter WebGL canvas restarts/flickers on every click
- NR2 — EMNR accordion title button appears dead (its `useState` resets to `false` on every mount, so the panel never stays open)
- inline inputs can lose focus mid-keystroke

## Fix

**Layer 1 — global chokepoint** in `FlexWorkspace.factory()`. Every panel is now wrapped in a `<div>` that swallows `onPointerDown` and `onMouseDown`. One wrapper, all 15 flex panels (HeroPanel, DspFlexPanel, QrzPanel, …) covered.

The tab-strip header lives **outside** this wrapper (it's `__tabset_header`, a sibling of `__tab_moveable`), so tab dragging, reordering, and docking still work. The wrapper only insulates panel *content*.

**Layer 2 — per-component hardening** in `NrSettingsSection`:
- title-button `onClick` calls `e.stopPropagation()` before `toggle(mode)` (belt-and-braces, in case the wrapper is ever bypassed)
- disclosure state moved from `useState` to a tiny zustand store keyed by mode. Each NR algorithm's accordion (ANR / EMNR / SBNR) remembers its own open/closed state independently and survives any future remount path. The previous mode-change reset `useEffect` is no longer needed.

## Test plan

- [ ] Open `?layout=flex`, click anywhere inside the DSP / S-Meter / QRZ / Filter panels — panadapter must not flicker
- [ ] Click NR2 — EMNR accordion header — panel expands and stays open across clicks
- [ ] Drag a flex tab to another tabset — drag still works (header is unaffected)
- [ ] Resize the browser / drag a splitter — NR2 accordion stays open through the relayout
- [ ] Switch NR mode (NR1 / NR2 / NR4 buttons) — each mode's accordion remembers its own open/closed state