### PR TITLE
feat(flex): tighten widget separation to match classic workspace

### DIFF
--- a/zeus-web/src/layout/defaultLayout.ts
+++ b/zeus-web/src/layout/defaultLayout.ts
@@ -51,9 +51,10 @@
 export const DEFAULT_LAYOUT = {
   global: {
     tabEnableClose: true,
-    tabSetMinHeight: 60,
+    tabSetMinHeight: 40,
     tabSetMinWidth: 80,
     tabSetTabStripHeight: 28,
+    splitterSize: 6,
   },
   borders: [],
   layout: {

--- a/zeus-web/src/styles/flex-layout.css
+++ b/zeus-web/src/styles/flex-layout.css
@@ -4,11 +4,12 @@
    console look. Uses the same CSS variables as layout.css / tokens.css.
    ================================================================ */
 
-/* Container — match the default `.app` background (--bg-0) so unfilled
-   space and splitter "gaps" read like the default workspace's 6px gutters
-   rather than the lighter --bg-workspace blue-gray. */
+/* Container — match the classic `.workspace` background (--bg-workspace)
+   so the splitter gutters read the same way they do in the classic
+   layout's grid-gap, rather than the higher-contrast near-black --bg-0
+   that previously made the gaps look wider than they actually are. */
 .flexlayout__layout {
-  background: var(--bg-0, #1a1b1e);
+  background: var(--bg-workspace, #657486);
 }
 
 /* Tabset (panel container) — borders removed; the dark splitter gaps now
@@ -82,11 +83,11 @@
   overflow: visible;
 }
 
-/* Splitter (resize handle) — same color as the outer container so the
-   gap between tabsets reads as a flat dark gutter (like default's
-   `.workspace { gap: 6px }`). Accent only on hover/drag. */
+/* Splitter (resize handle) — same colour as the outer container so the
+   gap between tabsets reads as the classic blue-gray gutter (matching
+   default's `.workspace { gap: 6px }`). Accent only on hover/drag. */
 .flexlayout__splitter {
-  background: var(--bg-0, #1a1b1e);
+  background: var(--bg-workspace, #657486);
   transition: background 120ms;
 }
 


### PR DESCRIPTION
## Summary

Three small layout-config tweaks to bring the flex layout's perceived spacing closer to the classic `.workspace` look:

- `tabSetMinHeight: 60 → 40` — was forcing compact panels (S-Meter, Tuning Step, DSP) into containers taller than their content needs. Most of the visible "extra separation" came from this floor.
- `splitterSize: 6` — explicit override of flexlayout-react's `8` default, matching the classic `.workspace { gap: 6px }`.
- `.flexlayout__layout` + `.flexlayout__splitter` background `--bg-0` → `--bg-workspace` — the near-black gutter punched harder against `--bg-1` panels than the classic blue-gray, making the same px-width gap *read* wider than it actually was.

Tabset header chrome, padding, and panel internal spacing are all unchanged.

## Heads-up — saved layout JSON

Existing operators have a flex-layout JSON cached in `zeus-prefs.db` that captured the old `tabSetMinHeight: 60`. To pick up the new floor on existing layouts, click **RESET FLEX LAYOUT** in the Display panel (it nukes the saved JSON and rehydrates from `DEFAULT_LAYOUT`).

## Test plan

- [ ] Open `?layout=flex` and click **RESET FLEX LAYOUT**
- [ ] Compare side-by-side with `?layout=default` — gutters should read the same blue-gray, not near-black
- [ ] S-Meter / Tuning Step / DSP panels should sit closer to their content height instead of the old 60 px floor
- [ ] Tab dragging / docking / splitter dragging still work (no behaviour-side changes, only sizing)