### PR TITLE
feat(flex): give each tabset classic .panel chrome

### DIFF
--- a/zeus-web/src/styles/flex-layout.css
+++ b/zeus-web/src/styles/flex-layout.css
@@ -12,11 +12,19 @@
   background: var(--bg-workspace, #657486);
 }
 
-/* Tabset (panel container) — borders removed; the dark splitter gaps now
-   provide separation, matching the default `.workspace` grid-gap look. */
+/* Tabset (panel container) — give each tabset the same beveled chrome as
+   the classic `.panel` (layout.css): dark outline, small rounded corners,
+   inset top highlight, drop shadow. The blue-gray splitter gutters then
+   read as proper gaps between distinct panels rather than flat dividers. */
 .flexlayout__tabset {
   background: var(--bg-1, #2a2b2e);
-  border: none;
+  border: 1px solid var(--panel-border, #0d0d10);
+  border-radius: var(--r-md, 4px);
+  box-shadow:
+    inset 0 1px 0 var(--panel-hl-top, rgba(255, 255, 255, 0.10)),
+    0 1px 0 rgba(0, 0, 0, 0.6),
+    0 2px 6px rgba(0, 0, 0, 0.4);
+  overflow: hidden;
 }
 
 .flexlayout__tabset_header {


### PR DESCRIPTION
## Summary

Followup to #205. With gutters switched to `--bg-workspace` blue-gray, flex tabsets had `border: none` and bled directly into the gutter — panels read as one continuous surface striped by grey, instead of as distinct beveled tiles like the classic `.workspace`.

This commit gives each `.flexlayout__tabset` the same chrome the classic `.panel` already has:

- 1 px `var(--panel-border)` outline
- `var(--r-md)` (4 px) rounded corners  
- inset top highlight + drop shadow

The values come straight from `.panel` in `layout.css:307-317` — no new tokens introduced.

## Test plan

- [ ] `?layout=flex`, hard-reload, click **RESET FLEX LAYOUT**
- [ ] Each tabset (Panadapter, S-Meter, DSP, etc.) should now read as a distinct rounded panel with a dark outline and a faint top highlight
- [ ] Side-by-side with `?layout=default` — panel chrome should match
- [ ] Drag/resize splitters — chrome travels with the tabset, no leaks