### PR TITLE
feat(layout): pin/unpin bottom panels with LiteDB persistence

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -399,6 +399,19 @@ public sealed record DisplaySettingsSetRequest(
     string Mode,
     string Fit);
 
+// Per-slot pin state for the classic-layout bottom row (Logbook + TX
+// Stage Meters). True = panel is pinned (full body visible). False =
+// collapsed to a chip strip below the pinned tier. Persisted server-side
+// so the layout choice follows the operator across browsers / devices,
+// same as DisplaySettings.
+public sealed record BottomPinDto(
+    bool Logbook,
+    bool TxMeters);
+
+public sealed record BottomPinSetRequest(
+    bool Logbook,
+    bool TxMeters);
+
 // ---- PureSignal request records ----
 // PsControlSetRequest = master arm (Enabled) + mode (Auto vs Single).
 // PsAdvancedSetRequest = nullable so partial updates from the settings

--- a/Zeus.Server.Hosting/BottomPinStore.cs
+++ b/Zeus.Server.Hosting/BottomPinStore.cs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using LiteDB;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+// Persists the classic-layout bottom-row per-slot pin state (Logbook,
+// TX Stage Meters). Lives in the same zeus-prefs.db as PA / band-memory
+// / layout / display-settings. Server-side rather than localStorage so
+// the layout choice follows the operator across desktops, phones, and
+// every browser pointed at the Zeus instance.
+public sealed class BottomPinStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<BottomPinEntry> _docs;
+    private readonly ILogger<BottomPinStore> _log;
+    private readonly object _sync = new();
+
+    public BottomPinStore(ILogger<BottomPinStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? GetDatabasePath();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _docs = _db.GetCollection<BottomPinEntry>("bottom_pin");
+
+        _log.LogInformation("BottomPinStore initialized at {Path}", dbPath);
+    }
+
+    public BottomPinDto Get()
+    {
+        lock (_sync)
+        {
+            var e = _docs.FindAll().FirstOrDefault();
+            // Default = both pinned. Matches the historical layout, so a new
+            // operator opens the app with the familiar full-body bottom row.
+            if (e is null) return new BottomPinDto(Logbook: true, TxMeters: true);
+            return new BottomPinDto(Logbook: e.Logbook, TxMeters: e.TxMeters);
+        }
+    }
+
+    public void Save(bool logbook, bool txMeters)
+    {
+        lock (_sync)
+        {
+            var e = _docs.FindAll().FirstOrDefault() ?? new BottomPinEntry();
+            e.Logbook = logbook;
+            e.TxMeters = txMeters;
+            e.UpdatedUtc = DateTime.UtcNow;
+            if (e.Id == 0) _docs.Insert(e);
+            else _docs.Update(e);
+        }
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private static string GetDatabasePath()
+    {
+        var appDataDir = Environment.GetFolderPath(
+            Environment.SpecialFolder.LocalApplicationData,
+            Environment.SpecialFolderOption.Create);
+        return Path.Combine(appDataDir, "Zeus", "zeus-prefs.db");
+    }
+}
+
+public sealed class BottomPinEntry
+{
+    public int Id { get; set; }
+    public bool Logbook { get; set; } = true;
+    public bool TxMeters { get; set; } = true;
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -668,6 +668,18 @@ public static class ZeusEndpoints
             return Results.Ok(store.Get());
         });
 
+        // Classic-layout bottom-row pin state — Logbook + TX Stage Meters.
+        // GET returns current state; PUT replaces both flags atomically.
+        // Persisted in zeus-prefs.db so the layout choice follows the
+        // operator across browsers / devices.
+        app.MapGet("/api/bottom-pin", (BottomPinStore store) => Results.Ok(store.Get()));
+
+        app.MapPut("/api/bottom-pin", (BottomPinSetRequest req, BottomPinStore store) =>
+        {
+            store.Save(req.Logbook, req.TxMeters);
+            return Results.Ok(store.Get());
+        });
+
         // Radio selection — operator preference seeding, with discovery as the
         // tiebreaker. Preferred=="Auto" removes the override (stored as absence,
         // not a sentinel enum value). Effective = Connected when connected (which

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -182,6 +182,7 @@ public static class ZeusHost
         builder.Services.AddSingleton<PsSettingsStore>();
         builder.Services.AddSingleton<FilterPresetStore>();
         builder.Services.AddSingleton<DisplaySettingsStore>();
+        builder.Services.AddSingleton<BottomPinStore>();
         builder.Services.AddSingleton<QrzService>();
         builder.Services.AddSingleton<LogService>();
 

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -81,6 +81,8 @@ import { AzimuthMap } from './components/design/AzimuthMap';
 import { CONTACTS, bandOf } from './components/design/data';
 import { TuningStepWidget } from './components/TuningStepWidget';
 import { Dockable } from './components/design/Dockable';
+import { CollapsibleBottomSlot } from './components/design/CollapsibleBottomSlot';
+import { useBottomPinStore } from './state/bottom-pin-store';
 import { DspPanel } from './components/DspPanel';
 import { TxFilterPanel } from './components/TxFilterPanel';
 import { LogbookLive } from './components/design/LogbookLive';
@@ -257,6 +259,10 @@ export default function App() {
   const terminatorActive = panBackground === 'beam-map';
   const imageMode = panBackground === 'image' && !!backgroundImage;
   const bgActive = terminatorActive || imageMode;
+  // Per-slot pin state for the bottom row. Layout (pinned-tier vs
+  // chip-tier vs grid-template-columns) is driven by the JSX below
+  // and the .bottom-tier--* rules in layout.css.
+  const bottomPinned = useBottomPinStore((s) => s.pinned);
   // While 'M' is held and the map is showing, the spectrum canvas stack goes
   // pointer-events:none and the Leaflet map underneath takes drag/zoom input.
   // Click-to-tune is suspended for the duration of the modifier.
@@ -1001,23 +1007,69 @@ export default function App() {
         </div>
 
         {/* Bottom row — Logbook + TX Stage Meters on desktop; big PTT on
-            mobile. (QRZ Lookup lives in the side-stack under the S-Meter
-            when terminator is engaged.) */}
+            mobile. The row has two tiers:
+              - .bottom-tier--pinned   : pinned panels share the row width
+                (2fr 1fr when both pinned, 1fr when only one is pinned).
+              - .bottom-tier--unpinned : unpinned chips sit below the
+                pinned tier, left-aligned, auto-sized to their label.
+            Both tiers are conditionally rendered, so when both are
+            unpinned only a thin chip strip remains and the panadapter
+            grows into the freed vertical space. */}
         <div className="bottom-row">
-          <div className="bottom-slot hide-mobile">
-            <Dockable title={logbookTitle} ledOn actions={logbookActions}>
-              <LogbookLive />
-            </Dockable>
-          </div>
-          <div className="bottom-slot hide-mobile">
-            <Dockable
-              title="TX Stage Meters"
-              ledOn={moxOn || tunOn}
-              actions={<OverdriveIndicator />}
-            >
-              <TxStageMeters />
-            </Dockable>
-          </div>
+          {(bottomPinned.logbook || bottomPinned.txmeters) && (
+            <div className={`bottom-tier bottom-tier--pinned hide-mobile ${
+              bottomPinned.logbook && bottomPinned.txmeters ? 'has-both' : 'has-one'
+            }`}>
+              {bottomPinned.logbook && (
+                <div className="bottom-slot">
+                  <CollapsibleBottomSlot
+                    slotId="logbook"
+                    title={logbookTitle}
+                    ledOn
+                    actions={logbookActions}
+                  >
+                    <LogbookLive />
+                  </CollapsibleBottomSlot>
+                </div>
+              )}
+              {bottomPinned.txmeters && (
+                <div className="bottom-slot">
+                  <CollapsibleBottomSlot
+                    slotId="txmeters"
+                    title="TX Stage Meters"
+                    ledOn={moxOn || tunOn}
+                    actions={<OverdriveIndicator />}
+                  >
+                    <TxStageMeters />
+                  </CollapsibleBottomSlot>
+                </div>
+              )}
+            </div>
+          )}
+          {(!bottomPinned.logbook || !bottomPinned.txmeters) && (
+            <div className="bottom-tier bottom-tier--unpinned hide-mobile">
+              {!bottomPinned.logbook && (
+                <CollapsibleBottomSlot
+                  slotId="logbook"
+                  title={logbookTitle}
+                  ledOn
+                  actions={logbookActions}
+                >
+                  <LogbookLive />
+                </CollapsibleBottomSlot>
+              )}
+              {!bottomPinned.txmeters && (
+                <CollapsibleBottomSlot
+                  slotId="txmeters"
+                  title="TX Stage Meters"
+                  ledOn={moxOn || tunOn}
+                  actions={<OverdriveIndicator />}
+                >
+                  <TxStageMeters />
+                </CollapsibleBottomSlot>
+              )}
+            </div>
+          )}
           <div className="bottom-slot show-mobile mobile-ptt-slot">
             <MobilePttButton />
           </div>

--- a/zeus-web/src/api/bottom-pin.ts
+++ b/zeus-web/src/api/bottom-pin.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+export type BottomPinState = {
+  logbook: boolean;
+  txmeters: boolean;
+};
+
+type BottomPinDtoRaw = {
+  // C# record properties serialise camelCase via System.Text.Json defaults
+  // (ASP.NET minimal API uses JsonSerializerDefaults.Web).
+  logbook?: boolean;
+  txMeters?: boolean;
+};
+
+function normalize(raw: BottomPinDtoRaw): BottomPinState {
+  return {
+    logbook: typeof raw.logbook === 'boolean' ? raw.logbook : true,
+    txmeters: typeof raw.txMeters === 'boolean' ? raw.txMeters : true,
+  };
+}
+
+export async function fetchBottomPin(signal?: AbortSignal): Promise<BottomPinState> {
+  const res = await fetch('/api/bottom-pin', { signal });
+  if (!res.ok) throw new Error(`GET /api/bottom-pin → ${res.status}`);
+  return normalize((await res.json()) as BottomPinDtoRaw);
+}
+
+export async function updateBottomPin(
+  next: BottomPinState,
+  signal?: AbortSignal,
+): Promise<BottomPinState> {
+  const res = await fetch('/api/bottom-pin', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ logbook: next.logbook, txMeters: next.txmeters }),
+    signal,
+  });
+  if (!res.ok) throw new Error(`PUT /api/bottom-pin → ${res.status}`);
+  return normalize((await res.json()) as BottomPinDtoRaw);
+}

--- a/zeus-web/src/components/design/CollapsibleBottomSlot.tsx
+++ b/zeus-web/src/components/design/CollapsibleBottomSlot.tsx
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+// See LICENSE for the full GPL text.
+
+import type { ReactNode } from 'react';
+import { Pin, PinOff } from 'lucide-react';
+import { Dockable } from './Dockable';
+import { useBottomPinStore, type BottomSlotId } from '../../state/bottom-pin-store';
+
+type CollapsibleBottomSlotProps = {
+  slotId: BottomSlotId;
+  title: ReactNode;
+  children: ReactNode;
+  ledOn?: boolean;
+  ledTx?: boolean;
+  // Caller-supplied action buttons (e.g. Publish / Export on the Logbook).
+  // We append the pin toggle to the right of these so the pin always sits
+  // closest to the drag handle.
+  actions?: ReactNode;
+};
+
+export function CollapsibleBottomSlot({
+  slotId,
+  title,
+  children,
+  ledOn,
+  ledTx,
+  actions,
+}: CollapsibleBottomSlotProps) {
+  const pinned = useBottomPinStore((s) => s.pinned[slotId]);
+  const togglePin = useBottomPinStore((s) => s.togglePin);
+
+  const pinButton = (
+    <button
+      type="button"
+      className="btn ghost sm"
+      title={pinned ? 'Unpin — collapse to header' : 'Pin — keep panel open'}
+      aria-label={pinned ? 'Unpin panel' : 'Pin panel'}
+      aria-pressed={!pinned}
+      onClick={() => togglePin(slotId)}
+      style={{ display: 'inline-flex', alignItems: 'center' }}
+    >
+      {pinned ? <Pin size={12} /> : <PinOff size={12} />}
+    </button>
+  );
+
+  // When unpinned we hide the body and let the panel sit at the top of its
+  // grid cell — see .panel--unpinned in layout.css. The actions row, LED
+  // and title remain visible so the operator can still see the live LED
+  // state (e.g. TX active on the meters strip) and click the pin to bring
+  // the body back.
+  return (
+    <Dockable
+      title={title}
+      ledOn={ledOn}
+      ledTx={ledTx}
+      className={pinned ? '' : 'panel--unpinned'}
+      actions={
+        <>
+          {actions}
+          {pinButton}
+        </>
+      }
+    >
+      {children}
+    </Dockable>
+  );
+}

--- a/zeus-web/src/state/bottom-pin-store.ts
+++ b/zeus-web/src/state/bottom-pin-store.ts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+// See LICENSE for the full GPL text.
+
+import { create } from 'zustand';
+import { fetchBottomPin, updateBottomPin } from '../api/bottom-pin';
+
+// Per-slot pin state for the classic-layout bottom row (Logbook + TX
+// Stage Meters). Persisted server-side in zeus-prefs.db so the layout
+// choice follows the operator across browsers / devices.
+//
+// Initial render uses an optimistic both-pinned default until the
+// hydrateFromServer call below resolves. After that, every togglePin
+// PUTs the new state to /api/bottom-pin and rolls back on error.
+
+export type BottomSlotId = 'logbook' | 'txmeters';
+
+const LEGACY_STORAGE_KEY = 'zeus.classic.bottomPin';
+
+type BottomPinState = {
+  pinned: Record<BottomSlotId, boolean>;
+  togglePin: (slot: BottomSlotId) => Promise<void>;
+};
+
+export const useBottomPinStore = create<BottomPinState>((set, get) => ({
+  // Optimistic defaults — replaced when hydrateFromServer resolves. New
+  // operators will see "both pinned" briefly even while the fetch is in
+  // flight, which matches the historical layout.
+  pinned: { logbook: true, txmeters: true },
+  togglePin: async (slot) => {
+    const prev = get().pinned;
+    const next = { ...prev, [slot]: !prev[slot] };
+    set({ pinned: next });
+    try {
+      const result = await updateBottomPin(next);
+      // If the server normalised anything, reflect that.
+      if (result.logbook !== next.logbook || result.txmeters !== next.txmeters) {
+        set({ pinned: result });
+      }
+    } catch {
+      // Network / server failure: revert the optimistic toggle so the UI
+      // stays consistent with the persisted state.
+      set({ pinned: prev });
+    }
+  },
+}));
+
+function readLegacyLocalStorage(): Partial<Record<BottomSlotId, boolean>> | null {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(LEGACY_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<Record<BottomSlotId, boolean>>;
+    return {
+      logbook: typeof parsed.logbook === 'boolean' ? parsed.logbook : undefined,
+      txmeters: typeof parsed.txmeters === 'boolean' ? parsed.txmeters : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function clearLegacyLocalStorage(): void {
+  try {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.removeItem(LEGACY_STORAGE_KEY);
+    }
+  } catch {
+    /* private mode — nothing to clean up */
+  }
+}
+
+async function hydrateFromServer(): Promise<void> {
+  let server: Awaited<ReturnType<typeof fetchBottomPin>>;
+  try {
+    server = await fetchBottomPin();
+  } catch {
+    // Backend unreachable; keep the defaults. Subsequent togglePin calls
+    // will retry via PUT.
+    return;
+  }
+
+  // One-shot migration: if the server is at default state and the browser
+  // has a non-default localStorage entry from the v1 implementation, push
+  // it up to the server so the operator's choice survives the move.
+  const serverIsDefault = server.logbook && server.txmeters;
+  const legacy = readLegacyLocalStorage();
+  const legacyHasContent =
+    legacy && (legacy.logbook === false || legacy.txmeters === false);
+
+  if (serverIsDefault && legacyHasContent && legacy) {
+    try {
+      const migrated = await updateBottomPin({
+        logbook: legacy.logbook ?? true,
+        txmeters: legacy.txmeters ?? true,
+      });
+      server = migrated;
+    } catch {
+      // Migration failed — leave the legacy key in place so we retry next
+      // load. Don't clear it.
+      useBottomPinStore.setState({ pinned: server });
+      return;
+    }
+  }
+
+  clearLegacyLocalStorage();
+  useBottomPinStore.setState({ pinned: server });
+}
+
+void hydrateFromServer();

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -387,7 +387,10 @@
 .workspace {
   display: grid;
   grid-template-columns: 1fr 320px;
-  grid-template-rows: 1fr 200px;
+  /* Bottom track sizes to its content (pinned tier + optional chip tier),
+     so when both bottom panels are unpinned the row shrinks to a thin
+     chip strip and the hero greedy-1fr row grows into the freed space. */
+  grid-template-rows: 1fr auto;
   gap: 6px;
   overflow: hidden;
   min-height: 0;
@@ -413,13 +416,46 @@
 .bottom-row {
   grid-column: 1;
   grid-row: 2;
-  display: grid;
-  grid-template-columns: 2fr 1fr;
+  display: flex;
+  flex-direction: column;
   gap: 6px;
   min-height: 0;
 }
+
+/* Pinned tier — full-bodied panels. When both are pinned, Logbook gets
+   2fr and TX Stage Meters gets 1fr (historical split). When only one
+   is pinned, that one fills the whole row.
+   Fixed 200 px height so the panel content has its usual room. */
+.bottom-tier--pinned {
+  display: grid;
+  gap: 6px;
+  height: 200px;
+  min-height: 0;
+}
+.bottom-tier--pinned.has-both { grid-template-columns: 2fr 1fr; }
+.bottom-tier--pinned.has-one  { grid-template-columns: 1fr; }
 .bottom-slot { display: flex; min-height: 0; }
 .bottom-slot > * { flex: 1; min-height: 0; }
+
+/* Unpinned tier — chips, left-aligned, content-width. Sits below the
+   pinned tier so a chip never steals horizontal space from a pinned
+   sibling. The .panel--unpinned class on the chip's panel hides the
+   panel body so only the head (LED + title + actions + pin icon)
+   shows; see .panel--unpinned below. */
+.bottom-tier--unpinned {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: flex-start;
+  flex: 0 0 auto;
+}
+.bottom-tier--unpinned > .panel--unpinned {
+  flex: 0 0 auto;
+}
+.panel--unpinned .panel-body {
+  display: none;
+}
 
 /* ===== Spectrum + waterfall ===== */
 .hero { height: 100%; }


### PR DESCRIPTION
## Summary

Lets the operator collapse the **Logbook** and **TX Stage Meters** panels in the classic layout to a slim chip strip, freeing the row's vertical space for the panadapter / waterfall.

## UX

- Pin / PinOff button (lucide-react) in each panel header
- **Pinned tier** — both pinned shares the row `2fr 1fr` (Logbook wider, historical default); only one pinned takes the full row
- **Unpinned tier** — chips packed left, never steal horizontal space from a pinned sibling
- **Both unpinned** — `.workspace` bottom grid track shrinks 200 px → `auto` so the hero grows into the freed ~136 px

## Persistence

| layer | what |
|---|---|
| `Zeus.Contracts/Dtos.cs` | `BottomPinDto` + `BottomPinSetRequest` records |
| `Zeus.Server.Hosting/BottomPinStore.cs` | LiteDB collection `bottom_pin` in the existing `zeus-prefs.db` (alongside `display_settings`) |
| `Zeus.Server.Hosting/ZeusHost.cs` | `AddSingleton<BottomPinStore>()` |
| `Zeus.Server.Hosting/ZeusEndpoints.cs` | `GET/PUT /api/bottom-pin` |
| `zeus-web/src/api/bottom-pin.ts` | `fetchBottomPin` / `updateBottomPin` |
| `zeus-web/src/state/bottom-pin-store.ts` | Hydrates from server on load, optimistic-with-rollback PUT on toggle, one-shot localStorage→server migration |

Server-side rather than per-origin localStorage so the layout choice follows the operator across desktops, phones, and every browser pointed at the Zeus instance — same rationale as `DisplaySettings`.

## Test plan

- [ ] Open `?layout=default` — Pin icon visible at the right of Logbook + TX Stage Meters headers
- [ ] Click each pin: panel collapses to chip strip, sibling panel takes full row width
- [ ] Unpin both: chips packed left in a thin strip, panadapter expands into the freed space
- [ ] Re-pin one: chip moves back to top tier, sibling chip stays below
- [ ] Refresh page — pin state persists across reload (LiteDB-backed)
- [ ] Open the same Zeus instance from a different browser/device — same pin state visible (server-side, not localStorage)
- [ ] Backend log on startup: `BottomPinStore initialized at .../zeus-prefs.db`