### PR TITLE
fix(qrz): retry on-load status probe while silent re-login is in flight

### DIFF
--- a/zeus-web/src/api/qrz.ts
+++ b/zeus-web/src/api/qrz.ts
@@ -66,6 +66,11 @@ export type QrzStatus = {
   home: QrzStation | null;
   error: string | null;
   hasApiKey: boolean;
+  // True when the backend has username+password persisted in its credential
+  // store. The backend uses these to silently re-login on startup, so this
+  // flag tells the frontend "if connected is false but I'm trying" — useful
+  // for the on-load retry probe in qrz-store.ts.
+  hasStoredCredentials: boolean;
 };
 
 function toNum(v: unknown): number | null {
@@ -103,6 +108,7 @@ function normalizeStatus(raw: unknown): QrzStatus {
     home: r.home ? normalizeStation(r.home) : null,
     error: toStr(r.error),
     hasApiKey: Boolean(r.hasApiKey),
+    hasStoredCredentials: Boolean(r.hasStoredCredentials),
   };
 }
 

--- a/zeus-web/src/state/qrz-store.ts
+++ b/zeus-web/src/state/qrz-store.ts
@@ -175,4 +175,42 @@ export const useQrzStore = create<QrzStoreState>((set) => ({
 
 // Kick off a status probe at module load so reconnected sessions (backend still has
 // a session key from an earlier page) rehydrate without the user having to log in.
-void useQrzStore.getState().refreshStatus();
+//
+// Retry-on-load: a fresh backend has stored credentials in LiteDB but its
+// silent QRZ XML-API re-login takes ~400-1000 ms (TLS + auth). If the
+// frontend's first probe lands during that window, the response is
+// connected=false even though the operator IS about to be logged in. We
+// retry with backoff while the backend reports `hasStoredCredentials:true`
+// and `connected:false` — that combination is the unambiguous "in flight"
+// signal. Stops as soon as connected flips true, or hasStoredCredentials
+// flips false (operator never set creds, or just logged out elsewhere).
+async function probeStatusWithRetry(): Promise<void> {
+  // Total budget ~6.2 s — well past a typical QRZ silent-login + slack.
+  const backoffMs = [200, 400, 800, 1600, 3200];
+  for (let attempt = 0; ; attempt++) {
+    let status: QrzStatus;
+    try {
+      status = await qrzStatus();
+    } catch {
+      // Transient fetch failure (backend not yet listening on first
+      // attempt is the common case). Sleep and try again — but stop
+      // after the budget, no point hammering.
+      if (attempt >= backoffMs.length) return;
+      await new Promise((r) => setTimeout(r, backoffMs[attempt]));
+      continue;
+    }
+
+    useQrzStore.setState(applyStatus(status));
+
+    // Done — either we got connected, or the backend has nothing pending.
+    if (status.connected) return;
+    if (!status.hasStoredCredentials) return;
+
+    // Out of retries.
+    if (attempt >= backoffMs.length) return;
+
+    await new Promise((r) => setTimeout(r, backoffMs[attempt]));
+  }
+}
+
+void probeStatusWithRetry();


### PR DESCRIPTION
## Summary

The frontend fires a single status probe at module load to rehydrate the QRZ pill from a backend session left over from a previous page load. On a fresh backend the silent re-login takes ~400-1000 ms (TLS + XML-API auth to xmldata.qrz.com), and the probe lands during that window — the response is `connected:false` even though the operator IS about to be logged in. The pill then stays disconnected until the user manually reloads.

## Fix

- Surface the existing `hasStoredCredentials` field through `QrzStatus` and `normalizeStatus` (it was on the wire from the start, just not plumbed to the client).
- Replace the single-shot module-load probe with a retry loop that re-checks while the response combination is the unambiguous "silent login in flight" signal — `connected:false && hasStoredCredentials:true`. Stops as soon as connected flips true, hasStoredCredentials flips false (logged out elsewhere / no creds), or we run out of attempts.
- Backoff: 200 / 400 / 800 / 1600 / 3200 ms — total ~6.2 s, well past a slow QRZ XML-API auth + slack.

The public `refreshStatus()` action is unchanged (still a single-shot probe). Only the module-load probe gets the retry, since that's the window where the race lives.

## Test plan

- [ ] Restart backend with stored QRZ creds in `zeus-prefs.db`
- [ ] Reload frontend immediately — QRZ pill should land on "connected" within a few seconds without manual reload
- [ ] Backend log shows `Found stored QRZ credentials … attempting silent login` followed by 200 OK from xmldata.qrz.com
- [ ] No QRZ creds: pill stays disconnected (no retry storm; first probe sees `hasStoredCredentials:false`, returns)