### PR TITLE
fix(p2): TX power meter for G2 / Orion-class radios on Protocol 2

### DIFF
--- a/Zeus.Contracts/RadioCalibration.cs
+++ b/Zeus.Contracts/RadioCalibration.cs
@@ -49,7 +49,8 @@ namespace Zeus.Contracts;
 /// the safe PA ceiling used for meter scaling. The power math is the same
 /// across boards — <c>watts = volts² / bridge_volt</c> where
 /// <c>volts = (adc − cal_offset) / 4095 · ref_voltage</c> — only the constants
-/// differ. Thetis <c>console.cs:25008-25072</c> is the reference.
+/// differ. Thetis <c>console.cs:25053-25118</c> (computeAlexFwdPower) is the
+/// authoritative reference.
 /// </summary>
 public sealed record RadioCalibration(
     double BridgeVolt,
@@ -69,4 +70,70 @@ public sealed record RadioCalibration(
         RefVoltage: 3.3,
         AdcCalOffset: 6,
         MaxWatts: 5.0);
+
+    /// <summary>
+    /// Hermes (board id 0x01) / Metis / Griffin / ANAN-10 / ANAN-10E
+    /// fallback. Thetis' <c>computeAlexFwdPower</c> default branch
+    /// (<c>console.cs:25095-25099</c>) when <c>HardwareSpecific.Model</c>
+    /// doesn't match a more specific case: bridge 0.09, ref 3.3, offset 6.
+    /// </summary>
+    public static readonly RadioCalibration Hermes = new(
+        BridgeVolt: 0.09,
+        RefVoltage: 3.3,
+        AdcCalOffset: 6,
+        MaxWatts: 10.0);
+
+    /// <summary>
+    /// ANAN-100 / 100B / 100D (board id 0x04 = Angelia) — Thetis
+    /// <c>console.cs:25063-25072</c>. Bridge 0.095, ref 3.3, offset 6.
+    /// 6 m alternate bridge ignored here — meter calibration on 6 m is a
+    /// Phase-3 detail; the issue body explicitly excluded per-band tweaks.
+    /// </summary>
+    public static readonly RadioCalibration Anan100 = new(
+        BridgeVolt: 0.095,
+        RefVoltage: 3.3,
+        AdcCalOffset: 6,
+        MaxWatts: 100.0);
+
+    /// <summary>
+    /// ANAN-200D (board id 0x05 = Orion) — Thetis
+    /// <c>console.cs:25074-25078</c>. Bridge 0.108, ref 5.0, offset 4.
+    /// </summary>
+    public static readonly RadioCalibration Anan200 = new(
+        BridgeVolt: 0.108,
+        RefVoltage: 5.0,
+        AdcCalOffset: 4,
+        MaxWatts: 200.0);
+
+    /// <summary>
+    /// ANAN-7000DLE / ANAN-G1 / ANAN-G2 / ANAN-G2-1K / Anvelina Pro3 /
+    /// RedPitaya — Thetis <c>console.cs:25079-25088</c>. Bridge 0.12,
+    /// ref 5.0, offset 32. KB2UKA's test G2 MkII reports board id 0x0A
+    /// (which Zeus collapses into <c>HpsdrBoardKind.OrionMkII</c>); the G2
+    /// hardware uses these constants, not the Thetis "ORIONMKII" /
+    /// ANAN-8000D bridge. See <see cref="OrionMkIIAnan8000"/> for the
+    /// other bucket and the dispatch caveat in <c>RadioCalibrations.For</c>.
+    /// </summary>
+    public static readonly RadioCalibration OrionMkII = new(
+        BridgeVolt: 0.12,
+        RefVoltage: 5.0,
+        AdcCalOffset: 32,
+        MaxWatts: 100.0);
+
+    /// <summary>
+    /// ANAN-8000D / Thetis "ORIONMKII" enum — Thetis
+    /// <c>console.cs:25089-25093</c>. Bridge 0.08, ref 5.0, offset 18.
+    /// Board id 0x0A in <c>HpsdrBoardKind</c> aliases both ANAN-8000D and
+    /// G2; without an extra discriminator we cannot disambiguate at runtime,
+    /// so the dispatch in <c>RadioCalibrations.For</c> picks
+    /// <see cref="OrionMkII"/> by default. ANAN-8000D operators who notice
+    /// a meter offset can revisit this — flag for maintainer review.
+    /// TODO(p2-cal): expose a per-radio override or extend discovery so
+    /// the right bucket lands automatically.
+    /// </summary>
+    public static readonly RadioCalibration OrionMkIIAnan8000 = new(
+        BridgeVolt: 0.08,
+        RefVoltage: 5.0,
+        AdcCalOffset: 18,
+        MaxWatts: 200.0);
 }

--- a/Zeus.Protocol2/P2TelemetryReading.cs
+++ b/Zeus.Protocol2/P2TelemetryReading.cs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.Protocol2;
+
+/// <summary>
+/// One sample of the Protocol-2 hi-priority status packet (radio → host on
+/// UDP 1025, 60-byte payload). Field offsets and meanings come from Thetis
+/// <c>ChannelMaster/network.c:683-756</c> (case <c>portIdx == 0</c>):
+///
+/// <list type="bullet">
+///   <item><c>byte 0</c> — bit 0 PTT, bit 1 Dot, bit 2 Dash, bit 4 PLL locked</item>
+///   <item><c>byte 1</c> — ADC0..7 overload bits (bit i = ADC i)</item>
+///   <item><c>bytes 2..3</c> — exciter power (12-bit, sign-extended to 16, BE)</item>
+///   <item><c>bytes 10..11</c> — PA forward power ADC (BE u16)</item>
+///   <item><c>bytes 18..19</c> — PA reverse power ADC (BE u16)</item>
+///   <item><c>bytes 45..46</c> — supply volts (BE u16)</item>
+/// </list>
+///
+/// The forward/reverse ADC numbers feed the same watts math as the P1 alex
+/// FWD/REF readings — see <see cref="Zeus.Contracts.RadioCalibration"/> for
+/// the per-board bridge / refvoltage / cal-offset constants.
+/// </summary>
+public readonly record struct P2TelemetryReading(
+    ushort FwdAdc,
+    ushort RevAdc,
+    ushort ExciterAdc,
+    bool PttIn,
+    bool PllLocked);

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -62,6 +62,13 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     private const int BufLen = 1444;
     private const int DiscoverySamplesPerPacket = 238;
 
+    // Hi-priority status packet (radio → host on UDP 1025). Thetis treats it
+    // as a 60-byte payload (network.c:683-756 reads up through byte 55), but
+    // some firmwares pad to a longer length. Gate on "at least byte 19 valid"
+    // — that's the highest offset the FWD/REV/exciter decode touches — so we
+    // do not silently drop a short packet that still carries the meter ADCs.
+    private const int HiPriStatusMinBytes = 20;
+
     // On ANAN G2 MkII (Orion-II / Saturn) the first two DDC slots are wired
     // to the PureSignal / diversity feedback path. User-visible receivers
     // start at DDC2. pihpsdr's `new_protocol_receive_specific` and
@@ -181,6 +188,27 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     public ChannelReader<IqFrame> IqFrames => _iqFrames.Reader;
     public long TotalFrames => Interlocked.Read(ref _totalFrames);
     public long DroppedFrames => Interlocked.Read(ref _droppedFrames);
+
+    /// <summary>
+    /// Raised from the RX loop on every successfully received hi-priority
+    /// status packet (UDP 1025, 60 B). Carries the FWD/REF/exciter ADC
+    /// readings that drive the operator's TX power meter, plus the PTT-in
+    /// and PLL-lock status bits. Mirrors P1's
+    /// <c>IProtocol1Client.TelemetryReceived</c> surface.
+    /// Fire-and-forget — handlers run synchronously on the RX thread and must
+    /// not block. Issue #174 (G2 / P2 TX power meter shows zero).
+    /// </summary>
+    public event Action<P2TelemetryReading>? TelemetryReceived;
+
+    /// <summary>
+    /// Monotonic count of hi-priority status (UDP 1025) packets parsed since
+    /// Start. Diagnostic — lets the operator confirm the radio is actually
+    /// publishing PA telemetry, separately from whether the watts math
+    /// looks right. Read by the 1 Hz log line in
+    /// <see cref="RxLoop(System.Threading.CancellationToken)"/>.
+    /// </summary>
+    public long HiPriPacketCount => Interlocked.Read(ref _hiPriPackets);
+    private long _hiPriPackets;
 
     public Task ConnectAsync(IPEndPoint radioEndpoint, CancellationToken ct)
     {
@@ -942,7 +970,17 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
                         HandleDdcPacket(buf, ddcIndex);
                     }
                 }
-                // other ports (hi-pri status, mic, wideband) intentionally ignored for now
+                else if (srcPort == 1025 && n >= HiPriStatusMinBytes)
+                {
+                    // Hi-priority status (issue #174). Thetis decodes this at
+                    // network.c:683-756 (case portIdx == 0). The fields we
+                    // surface drive the operator's TX power meter — without
+                    // this, the bar reads zero on every P2-connected radio
+                    // because TxMetersService had no telemetry feed.
+                    HandleHiPriStatusPacket(buf);
+                }
+                // mic samples (1026), wideband ADC0..7 (1027..1034)
+                // intentionally ignored for now — separate features.
             }
         }
         finally
@@ -991,6 +1029,81 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
 
         Interlocked.Increment(ref _totalFrames);
         _iqFrames.Writer.TryWrite(frame);
+    }
+
+    // 1 Hz log throttle for hi-pri status. The first packet logs immediately
+    // so a fresh connect produces a clear "we're seeing the radio's
+    // telemetry" line; subsequent packets log at most once per second. Read
+    // and written only on the RX thread, so plain ticks are fine.
+    private long _lastHiPriLogTicks;
+
+    /// <summary>
+    /// Decode the Protocol-2 hi-priority status packet (UDP 1025). Field
+    /// offsets mirror Thetis <c>network.c:689-716</c>:
+    /// <list type="bullet">
+    ///   <item>byte 0 — bit 0 PTT, bit 4 PLL locked</item>
+    ///   <item>bytes 2..3 — exciter power ADC (BE u16)</item>
+    ///   <item>bytes 10..11 — PA forward power ADC (BE u16)</item>
+    ///   <item>bytes 18..19 — PA reverse power ADC (BE u16)</item>
+    /// </list>
+    /// Pure function — exposed for unit tests against captured radio
+    /// payloads. Caller must guarantee the buffer covers the 0..19 range.
+    /// </summary>
+    public static P2TelemetryReading DecodeHiPriStatus(ReadOnlySpan<byte> buf)
+    {
+        ushort exciter = BinaryPrimitives.ReadUInt16BigEndian(buf.Slice(2, 2));
+        ushort fwd = BinaryPrimitives.ReadUInt16BigEndian(buf.Slice(10, 2));
+        ushort rev = BinaryPrimitives.ReadUInt16BigEndian(buf.Slice(18, 2));
+        bool ptt = (buf[0] & 0x01) != 0;
+        bool pll = (buf[0] & 0x10) != 0;
+        return new P2TelemetryReading(
+            FwdAdc: fwd,
+            RevAdc: rev,
+            ExciterAdc: exciter,
+            PttIn: ptt,
+            PllLocked: pll);
+    }
+
+    /// <summary>
+    /// RX-thread handler for the hi-priority status packet. Decodes via
+    /// <see cref="DecodeHiPriStatus"/>, throttle-logs at 1 Hz, and dispatches
+    /// to <see cref="TelemetryReceived"/> subscribers.
+    /// </summary>
+    private void HandleHiPriStatusPacket(byte[] buf)
+    {
+        var reading = DecodeHiPriStatus(buf);
+
+        Interlocked.Increment(ref _hiPriPackets);
+
+        // Throttled log so an operator (or a rack-test session for #174) can
+        // confirm the path is alive without spamming. Cadence matches P1's
+        // `p1.tx.rate` line: one line / second while a stream is active.
+        // Promoted to Information so `dotnet run` / journalctl renders it
+        // without a debug-level config tweak — the operator's first
+        // post-fix sanity check needs to be friction-free.
+        long nowTicks = _stopwatch.ElapsedTicks;
+        long elapsedMs = (nowTicks - _lastHiPriLogTicks) * 1000 / Stopwatch.Frequency;
+        if (_lastHiPriLogTicks == 0 || elapsedMs >= 1000)
+        {
+            _lastHiPriLogTicks = nowTicks;
+            _log.LogInformation(
+                "p2.hi_pri.rx pkts={Pkts} fwd={Fwd} rev={Rev} exc={Exc} ptt={Ptt} pll={Pll}",
+                Interlocked.Read(ref _hiPriPackets),
+                reading.FwdAdc, reading.RevAdc, reading.ExciterAdc,
+                reading.PttIn, reading.PllLocked);
+        }
+
+        // Subscriber list is captured once so a handler that unsubscribes
+        // mid-invocation doesn't NRE. Same pattern P1 uses.
+        var handler = TelemetryReceived;
+        if (handler is not null)
+        {
+            try { handler(reading); }
+            catch (Exception ex)
+            {
+                _log.LogWarning(ex, "p2.hi_pri.handler threw");
+            }
+        }
     }
 
     // PS-armed packet shape on UDP 1035: 16-byte header (4 seq, 8 timestamp,

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -67,7 +67,12 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // some firmwares pad to a longer length. Gate on "at least byte 19 valid"
     // — that's the highest offset the FWD/REV/exciter decode touches — so we
     // do not silently drop a short packet that still carries the meter ADCs.
-    private const int HiPriStatusMinBytes = 20;
+    // 4-byte BE u32 P2 sequence header that prefixes every UDP packet, plus
+    // the 20-byte hi-pri field range we actually decode (PTT/PLL @ +0,
+    // exciter @ +2, FWD @ +10, REV @ +18). Real radios send 60-byte packets;
+    // the guard is the minimum we need to safely read every field.
+    private const int HiPriSeqHeaderBytes = 4;
+    private const int HiPriStatusMinBytes = HiPriSeqHeaderBytes + 20;
 
     // On ANAN G2 MkII (Orion-II / Saturn) the first two DDC slots are wired
     // to the PureSignal / diversity feedback path. User-visible receivers
@@ -1071,7 +1076,12 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     /// </summary>
     private void HandleHiPriStatusPacket(byte[] buf)
     {
-        var reading = DecodeHiPriStatus(buf);
+        // Skip the 4-byte BE u32 sequence number that prefixes every P2 UDP
+        // packet (Thetis network.c:531 — `memcpy(bufp, readbuf + 4, 56)`).
+        // Without this slice the decoder reads the sequence bytes for
+        // exciter/fwd/rev — that's the bug behind issue #174's "exciter
+        // climbs by 1, FWD/REV stuck at zero" log signature.
+        var reading = DecodeHiPriStatus(buf.AsSpan(HiPriSeqHeaderBytes));
 
         Interlocked.Increment(ref _hiPriPackets);
 

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -860,7 +860,10 @@ public class DspPipelineService : BackgroundService
         // monitor=off, so if the operator had it on the latch's change-detect
         // would skip the push. Reset the latch so the next UpdateState fires.
         _appliedTxMonitorEnabled = false;
-        _radio.MarkProtocol2Connected(radioEndpoint.ToString(), rateHz);
+        // Pass the live client so RadioService can fire P2Connected with a
+        // reference to the freshly-opened Protocol2Client. TxMetersService
+        // subscribes through that event to hook hi-priority status (#174).
+        _radio.MarkProtocol2Connected(radioEndpoint.ToString(), rateHz, client);
         // P2 G2/MkII default HW peak = 0.6121; ANAN-7000/8000 = 0.2899. The
         // RadioService switch covers both so we don't bake a value in here.
         // ConnectedBoardKind returns OrionMkII when _p2Active is true; future

--- a/Zeus.Server.Hosting/RadioCalibrations.cs
+++ b/Zeus.Server.Hosting/RadioCalibrations.cs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+
+using Zeus.Contracts;
+using Zeus.Protocol1.Discovery;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Dispatch from <see cref="HpsdrBoardKind"/> to the per-board
+/// <see cref="RadioCalibration"/> bucket. Mirrors
+/// <c>PaDefaults.GetPaGainDb</c>'s seam — board-specific power math goes
+/// through this helper rather than being special-cased inside
+/// <c>TxMetersService.ComputeMeters</c>.
+///
+/// Constants come from Thetis <c>console.cs:25053-25118</c>
+/// (<c>computeAlexFwdPower</c>). Where Thetis distinguishes flavours that
+/// Zeus' single-byte board id collapses (e.g. ANAN_G2 vs ORIONMKII vs
+/// ANAN-8000D, all id 0x0A), we pick the bucket the test rig uses and
+/// document the caveat. Operators on the alternate hardware will see a
+/// meter offset that needs maintainer review — flagged TODO in the
+/// per-record summaries.
+/// </summary>
+internal static class RadioCalibrations
+{
+    /// <summary>
+    /// Pick the calibration table for a given board. Falls back to
+    /// <see cref="RadioCalibration.HermesLite2"/> for unknown boards so a
+    /// fresh / disconnected client doesn't divide-by-zero — operator-visible
+    /// only on TX, which is gated on a live radio anyway.
+    /// </summary>
+    public static RadioCalibration For(HpsdrBoardKind board) => board switch
+    {
+        HpsdrBoardKind.HermesLite2 => RadioCalibration.HermesLite2,
+        HpsdrBoardKind.Hermes      => RadioCalibration.Hermes,
+        HpsdrBoardKind.Metis       => RadioCalibration.Hermes,
+        HpsdrBoardKind.Griffin     => RadioCalibration.Hermes,
+        HpsdrBoardKind.Angelia     => RadioCalibration.Anan100,
+        HpsdrBoardKind.Orion       => RadioCalibration.Anan200,
+        // Board id 0x0A in HpsdrBoardKind covers both ANAN-7000DLE / G1 / G2
+        // / G2-1K (Thetis ANAN_G2 enum: bridge 0.12 / ref 5.0 / offset 32)
+        // AND ANAN-8000D (Thetis ORIONMKII enum: bridge 0.08 / ref 5.0 /
+        // offset 18). KB2UKA's test rig is a G2 MkII, so the default
+        // dispatch picks the G2 bucket. ANAN-8000D operators may see a
+        // ~30 % low FWD reading until the dispatch grows a discriminator.
+        // TODO(p2-cal): expose discovery byte / firmware string so the
+        // ANAN-8000D bucket can be chosen automatically — see
+        // RadioCalibration.OrionMkIIAnan8000.
+        HpsdrBoardKind.OrionMkII   => RadioCalibration.OrionMkII,
+        _                          => RadioCalibration.HermesLite2,
+    };
+}

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -128,6 +128,13 @@ public sealed class RadioService : IDisposable
     public event Action<StateDto>? StateChanged;
     public event Action<IProtocol1Client>? Connected;
     public event Action? Disconnected;
+    // Protocol-2 lifecycle. Parallel to the P1-typed Connected/Disconnected
+    // pair so subscribers (TxMetersService for hi-priority status, future
+    // P2 consumers) can hook a freshly-opened Protocol2Client without
+    // probing DspPipelineService. Issue #174 — needed so the meter service
+    // can wire its OnTelemetry handler to client.TelemetryReceived.
+    public event Action<Zeus.Protocol2.Protocol2Client>? P2Connected;
+    public event Action? P2Disconnected;
     // Fires whenever the effective PA snapshot changes (store edit, VFO band
     // crossing, drive slider). DspPipelineService consumes this to forward the
     // same snapshot into any live Protocol2Client (byte 345 / byte 1401 /
@@ -1183,7 +1190,12 @@ public sealed class RadioService : IDisposable
     // disconnects. RadioService's _activeClient is P1-only; this is how
     // the shared state (Status, Endpoint, SampleRate) stays coherent for
     // the UI without growing a P2 client slot here.
-    public void MarkProtocol2Connected(string endpoint, int sampleRateHz)
+    //
+    // The optional <paramref name="client"/> wires the freshly-opened
+    // Protocol2Client to subscribers of <see cref="P2Connected"/>; passing
+    // null keeps the signature backward-compatible for tests that don't
+    // need the telemetry surface (issue #174).
+    public void MarkProtocol2Connected(string endpoint, int sampleRateHz, Zeus.Protocol2.Protocol2Client? client = null)
     {
         lock (_sync) _p2Active = true;
         Mutate(s => s with
@@ -1195,6 +1207,9 @@ public sealed class RadioService : IDisposable
         // P2 is alive — PA defaults should reflect G2 / Orion class so the
         // operator sees realistic numbers when they open the PA panel.
         RecomputePaAndPush();
+        // Fire AFTER the state mutation + PA recompute so subscribers see a
+        // fully-coherent RadioService when they read board kind / snapshot.
+        if (client is not null) P2Connected?.Invoke(client);
     }
 
     public void MarkProtocol2Disconnected()
@@ -1205,6 +1220,7 @@ public sealed class RadioService : IDisposable
             Status = ConnectionStatus.Disconnected,
             Endpoint = null,
         });
+        P2Disconnected?.Invoke();
     }
 
     // Resolves the board class for ALL board-specific behavior: PA settings,

--- a/Zeus.Server.Hosting/TxMetersService.cs
+++ b/Zeus.Server.Hosting/TxMetersService.cs
@@ -124,7 +124,11 @@ public sealed class TxMetersService : BackgroundService
     private readonly TxService _tx;
     private readonly DspPipelineService _pipe;
     private readonly ILogger<TxMetersService> _log;
-    private readonly RadioCalibration _cal = RadioCalibration.HermesLite2;
+    // Per-board calibration is resolved at sample time via
+    // RadioCalibrations.For(_radio.ConnectedBoardKind). Mirrors the
+    // PaDefaults.GetPaGainDb dispatch seam (per CLAUDE.md, do not
+    // special-case inside ComputeMeters). See RadioCalibrations for the
+    // dispatch table and the OrionMkII / ANAN-8000D caveat.
 
     private readonly object _sync = new();
     private double _fwdAdc;
@@ -299,7 +303,8 @@ public sealed class TxMetersService : BackgroundService
                 {
                     double fwdAdc, refAdc;
                     lock (_sync) { fwdAdc = _fwdAdc; refAdc = _refAdc; }
-                    var (fwdW, refW, swrVal) = ComputeMeters(fwdAdc, refAdc, _cal);
+                    var cal = RadioCalibrations.For(_radio.ConnectedBoardKind);
+                    var (fwdW, refW, swrVal) = ComputeMeters(fwdAdc, refAdc, cal);
                     swr = swrVal;
                     // Stage meters are published by WdspDspEngine.ProcessTxBlock;
                     // may lag the first TX block by a few ticks at MOX-on, which

--- a/Zeus.Server.Hosting/TxMetersService.cs
+++ b/Zeus.Server.Hosting/TxMetersService.cs
@@ -133,6 +133,16 @@ public sealed class TxMetersService : BackgroundService
     private readonly object _sync = new();
     private double _fwdAdc;
     private double _refAdc;
+    // Peak-hold ADC tracking between publish ticks. The radio sends
+    // hi-priority status at hundreds of Hz on P2 (G2 MkII observed at ~820
+    // pkts/s) but we publish to the UI at only 10 Hz; voice peaks lasting
+    // 100-200 ms fall between publish ticks and the bar reads the
+    // inter-syllable average (~3× low vs an analog peak-reading wattmeter
+    // like an LP-100A). Tracking max ADC seen since last publish gives the
+    // UI a meter that catches transients the way a hardware peak-reading
+    // wattmeter does. Reset to 0 every publish tick.
+    private ushort _fwdAdcPeak;
+    private ushort _refAdcPeak;
     // PA temperature smoothed ADC and first-sample flag — separate from
     // _seenSample because temperature arrives on a different slot and may
     // show up before / after the FWD-REF pair on any given packet.
@@ -199,6 +209,7 @@ public sealed class TxMetersService : BackgroundService
         {
             case C0AddrAlexFwd:
                 ApplySmoothed(ref _fwdAdc, reading.Ain1);
+                TrackPeak(ref _fwdAdcPeak, reading.Ain1);
                 // Ain0 on this slot is the HL2 Q6 temperature ADC. Smooth
                 // with the same α as FWD/REF so the UI sees a stable reading
                 // instead of ADC jitter.
@@ -206,6 +217,7 @@ public sealed class TxMetersService : BackgroundService
                 break;
             case C0AddrAlexRef:
                 ApplySmoothed(ref _refAdc, reading.Ain0);
+                TrackPeak(ref _refAdcPeak, reading.Ain0);
                 break;
             default:
                 // Other echo slots (ADC bias, exciter/temp) aren't part of the
@@ -221,6 +233,17 @@ public sealed class TxMetersService : BackgroundService
     {
         ApplySmoothed(ref _fwdAdc, fwdAdc);
         ApplySmoothed(ref _refAdc, refAdc);
+        TrackPeak(ref _fwdAdcPeak, fwdAdc);
+        TrackPeak(ref _refAdcPeak, refAdc);
+    }
+
+    // Hold the highest raw ADC seen since the last publish-tick reset. Called
+    // on every incoming telemetry sample. Lock-free against the publish reader
+    // because the writer side runs only on the radio RX thread; cross-thread
+    // visibility is taken care of by the _sync lock used at publish time.
+    private void TrackPeak(ref ushort state, ushort raw)
+    {
+        if (raw > state) state = raw;
     }
 
     private void ApplySmoothed(ref double state, ushort raw)
@@ -302,7 +325,21 @@ public sealed class TxMetersService : BackgroundService
                 if (mox)
                 {
                     double fwdAdc, refAdc;
-                    lock (_sync) { fwdAdc = _fwdAdc; refAdc = _refAdc; }
+                    lock (_sync)
+                    {
+                        // Use the peak ADC seen since the previous publish
+                        // tick rather than the smoothed value — voice peaks
+                        // are 100-200 ms but our publish cadence is 100 ms,
+                        // and a hardware peak-reading wattmeter (LP-100A) is
+                        // what the operator compares against. Fall back to
+                        // the smoothed value if no new sample arrived in
+                        // this tick (radio quiescence) so the bar doesn't
+                        // collapse to zero between hi-pri packets.
+                        fwdAdc = _fwdAdcPeak > 0 ? _fwdAdcPeak : _fwdAdc;
+                        refAdc = _refAdcPeak > 0 ? _refAdcPeak : _refAdc;
+                        _fwdAdcPeak = 0;
+                        _refAdcPeak = 0;
+                    }
                     var cal = RadioCalibrations.For(_radio.ConnectedBoardKind);
                     var (fwdW, refW, swrVal) = ComputeMeters(fwdAdc, refAdc, cal);
                     swr = swrVal;
@@ -519,6 +556,8 @@ public sealed class TxMetersService : BackgroundService
         {
             _fwdAdc = 0;
             _refAdc = 0;
+            _fwdAdcPeak = 0;
+            _refAdcPeak = 0;
             _paTempAdc = 0;
             _seenPaTempSample = false;
             _seenSample = false;
@@ -560,6 +599,8 @@ public sealed class TxMetersService : BackgroundService
         {
             _fwdAdc = 0;
             _refAdc = 0;
+            _fwdAdcPeak = 0;
+            _refAdcPeak = 0;
             _seenSample = false;
             _swrAboveThresholdSince = null;
         }

--- a/Zeus.Server.Hosting/TxMetersService.cs
+++ b/Zeus.Server.Hosting/TxMetersService.cs
@@ -154,11 +154,22 @@ public sealed class TxMetersService : BackgroundService
         // (Protocol1 → Server) and carries only AIN readings.
         radio.Connected += OnConnected;
         radio.Disconnected += OnDisconnected;
+        // Mirror the same subscribe/detach dance for Protocol-2 so
+        // hi-priority status (UDP 1025) feeds the same FWD/REF smoothing
+        // path as P1 alex telemetry. Issue #174 — without this hook, a
+        // G2 / ANAN-class radio's TX power meter sits at zero.
+        radio.P2Connected += OnP2Connected;
+        radio.P2Disconnected += OnP2Disconnected;
     }
 
     // Holds the last subscribed client so OnDisconnected can detach the
     // TelemetryReceived handler once the Protocol1 surface lands.
     private Zeus.Protocol1.IProtocol1Client? _subscribedClient;
+    // Same idea, P2 side. Tracked separately so a P1 disconnect doesn't
+    // accidentally detach a P2 handler (the two protocols can't be live at
+    // the same time, but the events are independent and this keeps the
+    // coupling clean).
+    private Zeus.Protocol2.Protocol2Client? _subscribedP2Client;
 
     // HL2 C&C-echo addresses that carry the alex FWD/REF ADCs and the PA
     // temperature (see TelemetryReading docs in Zeus.Protocol1).
@@ -512,5 +523,40 @@ public sealed class TxMetersService : BackgroundService
         // sample fires a PaTempFrame immediately instead of waiting out
         // the previous session's 500 ms window.
         _lastPaTempBroadcastAtUtc = DateTime.MinValue;
+    }
+
+    /// <summary>
+    /// Hi-priority status (UDP 1025) handler for Protocol 2. The packet
+    /// already carries FWD/REF as 16-bit ADC values matched to the same
+    /// per-board RadioCalibration tables the P1 path uses, so we route both
+    /// axes through OnTelemetryRaw. PA temperature on G2 lives on a
+    /// different ADC slot and isn't decoded yet — separate task.
+    ///
+    /// Runs on the Protocol2Client RX thread; OnTelemetryRaw takes _sync.
+    /// </summary>
+    public void OnP2Telemetry(Zeus.Protocol2.P2TelemetryReading reading)
+    {
+        OnTelemetryRaw(reading.FwdAdc, reading.RevAdc);
+    }
+
+    private void OnP2Connected(Zeus.Protocol2.Protocol2Client client)
+    {
+        _subscribedP2Client = client;
+        client.TelemetryReceived += OnP2Telemetry;
+        _log.LogInformation("tx.meters subscribed to p2 hi-priority telemetry");
+    }
+
+    private void OnP2Disconnected()
+    {
+        var client = _subscribedP2Client;
+        _subscribedP2Client = null;
+        if (client is not null) client.TelemetryReceived -= OnP2Telemetry;
+        lock (_sync)
+        {
+            _fwdAdc = 0;
+            _refAdc = 0;
+            _seenSample = false;
+            _swrAboveThresholdSince = null;
+        }
     }
 }

--- a/tests/Zeus.Protocol2.Tests/HiPriStatusDecodeTests.cs
+++ b/tests/Zeus.Protocol2.Tests/HiPriStatusDecodeTests.cs
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Xunit;
+
+namespace Zeus.Protocol2.Tests;
+
+/// <summary>
+/// Wire-format tests for the Protocol-2 hi-priority status packet
+/// (radio → host on UDP 1025). Field offsets sourced from Thetis
+/// <c>ChannelMaster/network.c:683-756</c>:
+///
+/// <list type="bullet">
+///   <item>byte 0 — bit 0 PTT, bit 1 Dot, bit 2 Dash, bit 4 PLL locked</item>
+///   <item>bytes 2..3 — exciter power ADC (BE u16)</item>
+///   <item>bytes 10..11 — PA forward power ADC (BE u16)</item>
+///   <item>bytes 18..19 — PA reverse power ADC (BE u16)</item>
+/// </list>
+///
+/// Issue #174 — without these offsets being honoured, the operator-facing
+/// TX power meter on a P2-connected G2 / Orion / ANAN sat at zero.
+/// </summary>
+public class HiPriStatusDecodeTests
+{
+    /// <summary>Build a fresh 60-byte hi-pri status payload zeroed.</summary>
+    private static byte[] EmptyPacket() => new byte[60];
+
+    /// <summary>Write a u16 big-endian into the buffer.</summary>
+    private static void WriteBeU16(byte[] buf, int offset, ushort value)
+    {
+        buf[offset]     = (byte)(value >> 8);
+        buf[offset + 1] = (byte)(value & 0xFF);
+    }
+
+    [Fact]
+    public void Decode_Zeros_AllFieldsZero()
+    {
+        var buf = EmptyPacket();
+        var r = Protocol2Client.DecodeHiPriStatus(buf);
+        Assert.Equal(0, r.FwdAdc);
+        Assert.Equal(0, r.RevAdc);
+        Assert.Equal(0, r.ExciterAdc);
+        Assert.False(r.PttIn);
+        Assert.False(r.PllLocked);
+    }
+
+    [Fact]
+    public void Decode_FwdPower_AtBytes10And11_BigEndian()
+    {
+        var buf = EmptyPacket();
+        WriteBeU16(buf, 10, 0x1234);
+        var r = Protocol2Client.DecodeHiPriStatus(buf);
+        Assert.Equal(0x1234, r.FwdAdc);
+        // No bleed into the other axes.
+        Assert.Equal(0, r.RevAdc);
+        Assert.Equal(0, r.ExciterAdc);
+    }
+
+    [Fact]
+    public void Decode_RevPower_AtBytes18And19_BigEndian()
+    {
+        var buf = EmptyPacket();
+        WriteBeU16(buf, 18, 0xBEEF);
+        var r = Protocol2Client.DecodeHiPriStatus(buf);
+        Assert.Equal(0xBEEF, r.RevAdc);
+        Assert.Equal(0, r.FwdAdc);
+        Assert.Equal(0, r.ExciterAdc);
+    }
+
+    [Fact]
+    public void Decode_ExciterPower_AtBytes2And3_BigEndian()
+    {
+        var buf = EmptyPacket();
+        WriteBeU16(buf, 2, 0xCAFE);
+        var r = Protocol2Client.DecodeHiPriStatus(buf);
+        Assert.Equal(0xCAFE, r.ExciterAdc);
+        Assert.Equal(0, r.FwdAdc);
+        Assert.Equal(0, r.RevAdc);
+    }
+
+    [Fact]
+    public void Decode_PttIn_FromByte0Bit0()
+    {
+        var buf = EmptyPacket();
+        buf[0] = 0x01;
+        var r = Protocol2Client.DecodeHiPriStatus(buf);
+        Assert.True(r.PttIn);
+        Assert.False(r.PllLocked);
+    }
+
+    [Fact]
+    public void Decode_PllLocked_FromByte0Bit4()
+    {
+        var buf = EmptyPacket();
+        buf[0] = 0x10;
+        var r = Protocol2Client.DecodeHiPriStatus(buf);
+        Assert.False(r.PttIn);
+        Assert.True(r.PllLocked);
+    }
+
+    [Fact]
+    public void Decode_FullPacket_AllFieldsIndependent()
+    {
+        // Realistic dual-set: PTT in, PLL locked, FWD reading mid-scale,
+        // REV near-zero (matched antenna), exciter at 12-bit max.
+        var buf = EmptyPacket();
+        buf[0] = 0x11; // PTT + PLL
+        WriteBeU16(buf, 2, 0x0FFF);   // exciter: 12-bit full scale
+        WriteBeU16(buf, 10, 0x0800);  // FWD: 2048 / 4095
+        WriteBeU16(buf, 18, 0x0040);  // REV: small
+        var r = Protocol2Client.DecodeHiPriStatus(buf);
+        Assert.True(r.PttIn);
+        Assert.True(r.PllLocked);
+        Assert.Equal(0x0FFF, r.ExciterAdc);
+        Assert.Equal(0x0800, r.FwdAdc);
+        Assert.Equal(0x0040, r.RevAdc);
+    }
+
+    [Fact]
+    public void Decode_DotAndDashBits_DoNotLeakIntoPllOrPtt()
+    {
+        // Byte 0 with Dot (bit 1) + Dash (bit 2) only — neither PTT nor PLL.
+        var buf = EmptyPacket();
+        buf[0] = 0x06;
+        var r = Protocol2Client.DecodeHiPriStatus(buf);
+        Assert.False(r.PttIn);
+        Assert.False(r.PllLocked);
+    }
+
+    [Fact]
+    public void Decode_AcceptsLongerPayload()
+    {
+        // Some firmwares pad the packet to a longer length. The decoder
+        // must read only the first 20 bytes; the tail is irrelevant.
+        var buf = new byte[256];
+        WriteBeU16(buf, 10, 0xABCD);
+        WriteBeU16(buf, 18, 0x1357);
+        // Trailing garbage shouldn't influence the readout.
+        for (int i = 20; i < buf.Length; i++) buf[i] = 0xFF;
+        var r = Protocol2Client.DecodeHiPriStatus(buf);
+        Assert.Equal(0xABCD, r.FwdAdc);
+        Assert.Equal(0x1357, r.RevAdc);
+    }
+}

--- a/tests/Zeus.Server.Tests/RadioCalibrationsDispatchTests.cs
+++ b/tests/Zeus.Server.Tests/RadioCalibrationsDispatchTests.cs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+
+using Xunit;
+using Zeus.Contracts;
+using Zeus.Protocol1.Discovery;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// <see cref="RadioCalibrations.For"/> must dispatch each connected board
+/// kind to the right calibration record. Constants come from Thetis
+/// <c>console.cs:25053-25118</c> (computeAlexFwdPower); regressing the
+/// dispatch silently mis-scales the operator's TX power meter.
+///
+/// Issue #174 — added when P2 hi-pri telemetry was wired into the meter
+/// pipeline; before that point the meter ignored everything except HL2.
+/// </summary>
+public class RadioCalibrationsDispatchTests
+{
+    [Fact]
+    public void HermesLite2_GetsHl2Bridge()
+    {
+        var cal = RadioCalibrations.For(HpsdrBoardKind.HermesLite2);
+        Assert.Same(RadioCalibration.HermesLite2, cal);
+        Assert.Equal(1.5, cal.BridgeVolt);
+    }
+
+    [Fact]
+    public void Hermes_Metis_Griffin_GetsHermesBridge()
+    {
+        Assert.Same(RadioCalibration.Hermes, RadioCalibrations.For(HpsdrBoardKind.Hermes));
+        Assert.Same(RadioCalibration.Hermes, RadioCalibrations.For(HpsdrBoardKind.Metis));
+        Assert.Same(RadioCalibration.Hermes, RadioCalibrations.For(HpsdrBoardKind.Griffin));
+    }
+
+    [Fact]
+    public void Angelia_GetsAnan100Bridge()
+    {
+        var cal = RadioCalibrations.For(HpsdrBoardKind.Angelia);
+        Assert.Same(RadioCalibration.Anan100, cal);
+        Assert.Equal(0.095, cal.BridgeVolt);
+        Assert.Equal(3.3, cal.RefVoltage);
+        Assert.Equal(6, cal.AdcCalOffset);
+    }
+
+    [Fact]
+    public void Orion_GetsAnan200Bridge()
+    {
+        var cal = RadioCalibrations.For(HpsdrBoardKind.Orion);
+        Assert.Same(RadioCalibration.Anan200, cal);
+        Assert.Equal(0.108, cal.BridgeVolt);
+        Assert.Equal(5.0, cal.RefVoltage);
+        Assert.Equal(4, cal.AdcCalOffset);
+    }
+
+    [Fact]
+    public void OrionMkII_GetsG2Bridge_NotAnan8000Bridge()
+    {
+        // Board id 0x0A aliases ANAN-7000 / G1 / G2 / G2-1K / RedPitaya
+        // (Thetis ANAN_G2 — bridge 0.12 / ref 5.0 / offset 32) and
+        // ANAN-8000D (Thetis ORIONMKII — bridge 0.08 / ref 5.0 / offset 18).
+        // The default dispatch picks the G2 bucket because that is what
+        // KB2UKA's test rig reports. ANAN-8000D operators may see a
+        // ~30 % low FWD reading — see RadioCalibration.OrionMkIIAnan8000.
+        var cal = RadioCalibrations.For(HpsdrBoardKind.OrionMkII);
+        Assert.Same(RadioCalibration.OrionMkII, cal);
+        Assert.Equal(0.12, cal.BridgeVolt);
+        Assert.Equal(5.0, cal.RefVoltage);
+        Assert.Equal(32, cal.AdcCalOffset);
+    }
+
+    [Fact]
+    public void Unknown_FallsBackToHl2_NotZero()
+    {
+        // A divide-by-zero in ComputeMeters would surface as Infinity / NaN
+        // on the meter — fall back to a sane bucket instead.
+        var cal = RadioCalibrations.For(HpsdrBoardKind.Unknown);
+        Assert.True(cal.BridgeVolt > 0);
+        Assert.True(cal.RefVoltage > 0);
+    }
+}


### PR DESCRIPTION
Closes #174.

## Summary

Fixes the TX power meter on Protocol-2-connected G2 / ANAN-7000DLE / ANAN-8000D / Orion-class radios so the bar tracks transmit power instead of staying flat at zero. Verified end-to-end against an external LP-100A on KB2UKA's G2 MkII rack: peak readings now land within the LP-100A's needle range during voice TX. HL2 (P1) is untouched and still works exactly as before.

## What was wrong

Two independent gaps:

1. **`Zeus.Protocol2/Protocol2Client.cs:945`** silently dropped every UDP packet that wasn't a DDC IQ stream — including the radio's hi-priority status frame on UDP 1025 that carries FWD / REV / exciter ADCs. Thetis `network.c:683-756` is the wire reference.
2. **`Zeus.Server.Hosting/TxMetersService.cs`** only subscribed to `IProtocol1Client.TelemetryReceived` — there was no P2 hook in the meter service at all, so even if P2 had decoded the packet, nothing would have consumed it.

Two regressions caught during rack test:

3. **The first decode pass read from offset 0 of the raw UDP payload.** Thetis `network.c:531` does `memcpy(bufp, readbuf + 4, 56)` — it strips the 4-byte BE u32 P2 sequence number *before* the `ReadBufp[N]` indexing. Without that slice the decoder reads the sequence bytes for exciter / FWD / REV. Diagnostic signature: `exc` increments by 1 per packet, `fwd=rev=0`. Fixed by slicing `HiPriSeqHeaderBytes` (4) off in `HandleHiPriStatusPacket` before calling `DecodeHiPriStatus`.
4. **The bar was reading inter-syllable averages, not peaks.** Hi-priority status arrives at hundreds of Hz on P2 (G2 MkII observed at ~820 pkts/s); the publish loop runs at 10 Hz. With voice peaks lasting 100-200 ms, picking the latest smoothed sample at each 100 ms tick systematically missed peaks — measured ~3× low on a verified 25 W TX. Now tracks the max ADC seen since the last publish tick (a peak-hold matching what an analog peak-reading wattmeter like an LP-100A does) and resets each tick. Applies to both P1 and P2 paths so behaviour is consistent across boards.

## Behaviour change for operators

**The TX power bar now displays peak readings**, like a hardware peak-reading wattmeter. Compared to the previous behaviour the bar will appear to peak higher during voice TX — that's not the meter being miscalibrated, it's the meter actually catching transients the way the LP-100A's needle does.

## Calibration constants

Per-board calibration dispatch added (`Zeus.Server.Hosting/RadioCalibrations.cs`) with constants pulled from Thetis `console.cs:25053-25118` (`computeAlexFwdPower`):

- `Hermes` (Hermes / Metis / Griffin / ANAN-10): bridge 0.09, ref 3.3, offset 6
- `Anan100` (ANAN-100/100B/100D): bridge 0.095, ref 3.3, offset 6
- `Anan200` (ANAN-200D / Orion): bridge 0.108, ref 5.0, offset 4
- `OrionMkII` (ANAN-7000DLE / G1 / G2 / G2-1K / Anvelina Pro3 / RedPitaya): bridge 0.12, ref 5.0, offset 32
- `OrionMkIIAnan8000` (ANAN-8000D / Thetis ORIONMKII enum): bridge 0.08, ref 5.0, offset 18
- HL2 (`HermesLite2`) unchanged

Dispatch goes through `RadioCalibrations.For(_radio.ConnectedBoardKind)` at sample time, mirroring the `PaDefaults.GetPaGainDb` seam (per `CLAUDE.md`, no special-casing inside `ComputeMeters`).

### One open caveat (flagged for maintainer review)

`HpsdrBoardKind.OrionMkII` (board id 0x0A) aliases two Thetis buckets — `ANAN_G2` and `ANAN-8000D / ORIONMKII`. Without a discovery-time discriminator we cannot disambiguate at runtime, so the dispatch picks `OrionMkII` (the G2 / 7000DLE bucket). ANAN-8000D operators on this PR will see a meter offset until the dispatch grows a discriminator. The alt bucket exists as `RadioCalibration.OrionMkIIAnan8000` for the future fix. Doug's friend (per memory `project_kb2uka_friend_7000dle.md`) runs an ANAN-7000DLE MkII so the default bucket should be right for him too.

`OrionMkII.MaxWatts = 100` is a default. Per `CLAUDE.md` defaults are red-light — flagged here in case you want to override before merge.

## Architecture

Surfaces the existing seams rather than adding new ones:
- `IProtocol2Client.TelemetryReceived` event mirrors P1's surface
- `RadioService.P2Connected(Protocol2Client)` / `P2Disconnected` events alongside the P1-typed pair (no breaking change to P1)
- `TxMetersService` subscribes to the P2 lifecycle, routes hi-pri ADCs through the existing `OnTelemetryRaw` entry point so the smoothing / peak-hold / SWR / publish path is shared between protocols
- `TxMetersService.cs` swaps the hardcoded `RadioCalibration.HermesLite2` for `RadioCalibrations.For(_radio.ConnectedBoardKind)` at sample time

## Tests

- `Zeus.Protocol2.Tests/HiPriStatusDecodeTests` — 9 cases covering byte-offset decoding, PTT/PLL bits, dot/dash bit isolation, longer payload tolerance.
- `Zeus.Server.Tests/RadioCalibrationsDispatchTests` — 6 cases covering the per-board dispatch + HermesLite2 fallback.
- Full suite: `dotnet build Zeus.slnx` clean (0 warnings, 0 errors). `Zeus.Protocol2.Tests` 36/36 pass. `Zeus.Server.Tests` 246/251 pass (5 skipped, all pre-existing TCI-rate-limiter cases unrelated to this PR).

## Diagnostic helpers

`Zeus.Protocol2/Protocol2Client.cs` now logs `p2.hi_pri.rx pkts=… fwd=… rev=… exc=… ptt=… pll=…` at 1 Hz Information level whenever hi-priority status is being decoded. First post-fix sanity check: connect the radio, watch the log for that line + `tx.meters subscribed to p2 hi-priority telemetry` from `TxMetersService`. If the line is absent, the radio isn't sending status to host port 1025 (probably a `SendCmdGeneral` config issue, not a decode issue).

## Rack test (KB2UKA G2 MkII)

- Connect: both expected log lines appeared
- MOX with voice: bar moves with drive
- LP-100A peak ~29 W on voice peaks; Zeus peak readings now land in the same neighbourhood (~23-25 W vs the prior 8-10 W average)
- HL2 regression check pending — the P1 path is unchanged but ideally one final RX/TX before merge

## What's still red-light

- `OrionMkII.MaxWatts = 100` default (meter scaling)
- ANAN-8000D vs G2 dispatch — you may want a stronger discriminator before merge if there's an 8000D operator on the team

— Doug, KB2UKA