### PR TITLE
feat: capabilities endpoint + UI feature gates for VST host

### DIFF
--- a/Zeus.Desktop/Program.cs
+++ b/Zeus.Desktop/Program.cs
@@ -25,6 +25,7 @@ using Zeus.Server;
 // no TOCTOU race with a concurrent listener.
 var hostOptions = new ZeusHostOptions
 {
+    HostMode = ZeusHostMode.Desktop,
     HttpPort = 0,
     BindAllInterfaces = false,
     UseHttpsLanCert = false,

--- a/Zeus.PluginHost/Native/SidecarLocator.cs
+++ b/Zeus.PluginHost/Native/SidecarLocator.cs
@@ -36,6 +36,31 @@ public static class SidecarLocator
             : "zeus-plughost";
 
     /// <summary>
+    /// Result of a non-spawning probe for the sidecar binary.
+    /// </summary>
+    /// <param name="Path">Resolved binary path, or null if not found.</param>
+    /// <param name="MissingReason">
+    /// Operator-facing explanation when <paramref name="Path"/> is null
+    /// (e.g. "sidecar binary 'zeus-plughost' was not found"). Null on success.
+    /// </param>
+    public readonly record struct ProbeResult(string? Path, string? MissingReason);
+
+    /// <summary>
+    /// Like <see cref="Locate"/>, but never logs a warning on a miss and
+    /// returns a structured reason for the capabilities endpoint to expose.
+    /// Safe to call at startup before the sidecar has ever been launched.
+    /// </summary>
+    public static ProbeResult Probe()
+    {
+        var path = Locate(NullPluginHostLog.Instance);
+        if (path != null) return new ProbeResult(path, null);
+        return new ProbeResult(
+            null,
+            $"Sidecar binary '{BinaryName}' was not found via {EnvVarName}, " +
+            "sibling checkout, or PATH.");
+    }
+
+    /// <summary>
     /// Resolve the sidecar path, or return <c>null</c> if no candidate is
     /// found. Callers (PluginHostManager) decide how to surface the
     /// missing-binary case to the operator.

--- a/Zeus.Server.Hosting/CapabilitiesService.cs
+++ b/Zeus.Server.Hosting/CapabilitiesService.cs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// CapabilitiesService — single source of truth for the /api/capabilities
+// endpoint. Captures host-mode, platform / architecture, and per-feature
+// availability once at construction and serves the same snapshot for the
+// lifetime of the process.
+//
+// Probe-once-at-startup is deliberate. Sidecar binaries don't appear or
+// disappear at runtime in normal operation; revisit if/when we ship a
+// hot-install path. The frontend caches the response anyway.
+//
+// Adding a new feature gate (issue #185 — amp manager, MIDI, …):
+//   1. Probe its availability here in the constructor.
+//   2. Add a field to FeatureMatrix and populate it in Snapshot().
+//   3. Update zeus-web/src/api/capabilities.ts to mirror the shape.
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Zeus.PluginHost.Native;
+
+namespace Zeus.Server;
+
+public sealed class CapabilitiesService
+{
+    private readonly CapabilitiesSnapshot _snapshot;
+
+    public CapabilitiesService(ZeusHostOptions options)
+    {
+        var version = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion ?? "unknown";
+
+        var platform = DetectPlatform();
+        var architecture = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
+
+        _snapshot = new CapabilitiesSnapshot(
+            Host: options.HostMode == ZeusHostMode.Desktop ? "desktop" : "server",
+            Platform: platform,
+            Architecture: architecture,
+            Version: version,
+            Features: new FeatureMatrix(VstHost: ProbeVstHost(platform)));
+    }
+
+    public CapabilitiesSnapshot Snapshot() => _snapshot;
+
+    // VST host availability gate. Today the C++ sidecar only ships for
+    // Linux; macOS and Windows builds are not in this release. The
+    // platform check stays here (server-side) so the frontend never has
+    // to duplicate the OS-support matrix. When we add macOS / Windows
+    // sidecar binaries this gate flips automatically.
+    private static FeatureGate ProbeVstHost(string platform)
+    {
+        if (platform != "linux")
+        {
+            return new FeatureGate(
+                Available: false,
+                Reason: "VST host is only supported on Linux in this release.",
+                SidecarPath: null);
+        }
+
+        var probe = SidecarLocator.Probe();
+        if (probe.Path == null)
+        {
+            return new FeatureGate(
+                Available: false,
+                Reason: probe.MissingReason,
+                SidecarPath: null);
+        }
+
+        return new FeatureGate(Available: true, Reason: null, SidecarPath: probe.Path);
+    }
+
+    private static string DetectPlatform()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return "linux";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return "darwin";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return "windows";
+        return "unknown";
+    }
+}
+
+// JSON shape returned by /api/capabilities. Property names land lower-case
+// on the wire via the default minimal-API camel-case policy, matching the
+// rest of the Zeus REST surface.
+
+public sealed record CapabilitiesSnapshot(
+    string Host,
+    string Platform,
+    string Architecture,
+    string Version,
+    FeatureMatrix Features);
+
+public sealed record FeatureMatrix(FeatureGate VstHost);
+
+public sealed record FeatureGate(
+    bool Available,
+    string? Reason,
+    string? SidecarPath);

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -34,6 +34,12 @@ public static class ZeusEndpoints
             return Results.Ok(new { version });
         });
 
+        // Capabilities snapshot — host-mode + platform + feature gates.
+        // Frontend fetches once on app mount and hides UI for unavailable
+        // features (e.g. TX Audio Tools when vstHost.available=false).
+        app.MapGet("/api/capabilities",
+            (CapabilitiesService caps) => Results.Ok(caps.Snapshot()));
+
         app.MapGet("/api/state", (RadioService r) => r.Snapshot());
 
         // TX diagnostic — exposes the producer/consumer counts for the mic-to-IQ ring

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -204,6 +204,14 @@ public static class ZeusHost
         builder.Services.AddSingleton<VstHostHostedService>();
         builder.Services.AddHostedService(sp => sp.GetRequiredService<VstHostHostedService>());
 
+        // Capabilities snapshot for /api/capabilities. Captures host-mode,
+        // platform, and feature gates (currently just vstHost) once at
+        // construction. The frontend uses this to hide unsupported UI
+        // (e.g. TX Audio Tools tab on macOS/Windows where the C++ sidecar
+        // binary isn't shipped yet).
+        builder.Services.AddSingleton(options);
+        builder.Services.AddSingleton<CapabilitiesService>();
+
         // TCI (Transceiver Control Interface) — ExpertSDR3-compatible WebSocket server
         // for remote control by loggers (Log4OM, N1MM+), digital-mode apps (JTDX, WSJT-X),
         // and SDR display tools. Disabled by default; enable via appsettings.json Tci:Enabled=true.

--- a/Zeus.Server.Hosting/ZeusHostOptions.cs
+++ b/Zeus.Server.Hosting/ZeusHostOptions.cs
@@ -2,12 +2,31 @@
 namespace Zeus.Server;
 
 /// <summary>
+/// Which entry-point built the host. Surfaced on /api/capabilities so the
+/// frontend can decide whether plugin GUIs (which open as native OS
+/// windows on the box running the host) are reachable to the operator.
+/// </summary>
+public enum ZeusHostMode
+{
+    /// <summary>Standalone server (Zeus.Server). Operator's browser may be remote.</summary>
+    Server,
+    /// <summary>Photino desktop shell (Zeus.Desktop). Operator is necessarily at the host's display.</summary>
+    Desktop,
+}
+
+/// <summary>
 /// Configuration for <see cref="ZeusHost"/>. Service mode (Zeus.Server) and
 /// desktop mode (Zeus.Desktop) construct different option shapes; everything
 /// else about the host is identical.
 /// </summary>
 public sealed class ZeusHostOptions
 {
+    /// <summary>
+    /// Which entry-point built the host. Defaults to <see cref="ZeusHostMode.Server"/>;
+    /// Zeus.Desktop sets <see cref="ZeusHostMode.Desktop"/> explicitly.
+    /// </summary>
+    public ZeusHostMode HostMode { get; init; } = ZeusHostMode.Server;
+
     /// <summary>HTTP listening port. Service-mode default 6060; desktop mode passes a free port.</summary>
     public int HttpPort { get; init; } = 6060;
 

--- a/tests/Zeus.Server.Tests/CapabilitiesEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/CapabilitiesEndpointTests.cs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// CapabilitiesEndpointTests — smoke for /api/capabilities. Exercises the
+// real endpoint via WebApplicationFactory; the inner platform / sidecar
+// gates are pure functions and don't need the test factory to fake them.
+
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class CapabilitiesEndpointTests : IClassFixture<CapabilitiesEndpointTests.Factory>
+{
+    private readonly Factory _factory;
+    public CapabilitiesEndpointTests(Factory factory) => _factory = factory;
+
+    [Fact]
+    public async Task Get_ReturnsExpectedShape()
+    {
+        using var client = _factory.CreateClient();
+        var resp = await client.GetAsync("/api/capabilities");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var body = await resp.Content.ReadFromJsonAsync<CapabilitiesResponse>();
+        Assert.NotNull(body);
+        // Default test factory leaves HostMode at the Server default.
+        Assert.Equal("server", body!.Host);
+        // Platform should be one of the known three (CI runs Linux; dev
+        // boxes are macOS / Windows). Anything else means the detector is
+        // broken.
+        Assert.Contains(body.Platform, new[] { "linux", "darwin", "windows" });
+        // Architecture is a runtime-info string lower-cased; assert it's
+        // populated rather than pinning to a specific value.
+        Assert.False(string.IsNullOrWhiteSpace(body.Architecture));
+        Assert.NotNull(body.Features);
+        Assert.NotNull(body.Features!.VstHost);
+
+        // Off-Linux: VST host must be unavailable with a reason. On Linux
+        // it depends on whether the sidecar binary resolves on the test
+        // host — assert the structural invariant only (reason set iff
+        // unavailable).
+        if (body.Platform != "linux")
+        {
+            Assert.False(body.Features.VstHost!.Available);
+            Assert.False(string.IsNullOrWhiteSpace(body.Features.VstHost.Reason));
+        }
+        else
+        {
+            var gate = body.Features.VstHost!;
+            if (gate.Available)
+            {
+                Assert.Null(gate.Reason);
+                Assert.False(string.IsNullOrWhiteSpace(gate.SidecarPath));
+            }
+            else
+            {
+                Assert.False(string.IsNullOrWhiteSpace(gate.Reason));
+            }
+        }
+    }
+
+    public sealed class Factory : WebApplicationFactory<Program>
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Test");
+            builder.ConfigureServices(services =>
+            {
+                // Keep the test surface tight: real CapabilitiesService
+                // resolves fine on its own (pure config + locator probe).
+                // Strip hosted services so the sidecar lifecycle / DSP
+                // pipeline don't run.
+                services.RemoveAll<IHostedService>();
+            });
+        }
+    }
+
+    private sealed record CapabilitiesResponse(
+        string Host,
+        string Platform,
+        string Architecture,
+        string Version,
+        FeaturesResponse Features);
+
+    private sealed record FeaturesResponse(VstHostResponse VstHost);
+
+    private sealed record VstHostResponse(
+        bool Available,
+        string? Reason,
+        string? SidecarPath);
+}

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -103,6 +103,7 @@ import { useTxStore } from './state/tx-store';
 import { useLayoutPreferenceStore } from './state/layout-preference-store';
 import { useLayoutStore } from './state/layout-store';
 import { useDisplaySettingsStore } from './state/display-settings-store';
+import { useCapabilitiesStore } from './state/capabilities-store';
 import { useKeyboardShortcuts } from './util/use-keyboard-shortcuts';
 import { SpectrumWheelActionsContext, type SpectrumWheelActions } from './util/use-pan-tune-gesture';
 import { registerServiceWorker } from './service-worker/registerSW';
@@ -156,6 +157,14 @@ export default function App() {
     return () => {
       stop();
     };
+  }, []);
+
+  // Fetch host capabilities once on mount. The backend snapshot is built
+  // at startup and doesn't change at runtime, so a single fetch is enough;
+  // failures fall back to "no features available" which hides feature-gated
+  // UI rather than rendering broken controls.
+  useEffect(() => {
+    void useCapabilitiesStore.getState().refresh();
   }, []);
 
   useEffect(() => {

--- a/zeus-web/src/api/capabilities.test.ts
+++ b/zeus-web/src/api/capabilities.test.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, expect, it } from 'vitest';
+
+import { isLoopbackHost, parseCapabilities } from './capabilities';
+
+describe('parseCapabilities', () => {
+  it('coerces a well-formed snapshot', () => {
+    const caps = parseCapabilities({
+      host: 'desktop',
+      platform: 'linux',
+      architecture: 'x64',
+      version: '0.6.0-alpha',
+      features: {
+        vstHost: {
+          available: true,
+          reason: null,
+          sidecarPath: '/opt/zeus-plughost',
+        },
+      },
+    });
+    expect(caps.host).toBe('desktop');
+    expect(caps.platform).toBe('linux');
+    expect(caps.features.vstHost.available).toBe(true);
+    expect(caps.features.vstHost.sidecarPath).toBe('/opt/zeus-plughost');
+  });
+
+  it('falls back to safe defaults on garbage input', () => {
+    const caps = parseCapabilities({});
+    expect(caps.host).toBe('server');
+    expect(caps.platform).toBe('unknown');
+    expect(caps.features.vstHost.available).toBe(false);
+    expect(caps.features.vstHost.reason).toBeNull();
+  });
+
+  it('clamps unknown host strings to "server"', () => {
+    const caps = parseCapabilities({ host: 'something-else' });
+    expect(caps.host).toBe('server');
+  });
+
+  it('clamps unknown platforms to "unknown"', () => {
+    const caps = parseCapabilities({ platform: 'plan9' });
+    expect(caps.platform).toBe('unknown');
+  });
+});
+
+describe('isLoopbackHost', () => {
+  it('treats explicit loopback URLs as local', () => {
+    expect(isLoopbackHost('http://localhost:6060')).toBe(true);
+    expect(isLoopbackHost('http://127.0.0.1:6060')).toBe(true);
+    expect(isLoopbackHost('http://[::1]:6060')).toBe(true);
+  });
+
+  it('treats LAN IPs as remote', () => {
+    expect(isLoopbackHost('http://192.168.1.23:6060')).toBe(false);
+    expect(isLoopbackHost('https://radio.lan:6060')).toBe(false);
+  });
+
+  it('falls back to window.location when base is empty', () => {
+    // Vitest's jsdom default is http://localhost — so the empty-base
+    // path resolves to a loopback hostname.
+    expect(isLoopbackHost('')).toBe(true);
+  });
+});

--- a/zeus-web/src/api/capabilities.ts
+++ b/zeus-web/src/api/capabilities.ts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Capabilities REST client. Mirrors GET /api/capabilities — host-mode +
+// platform + per-feature gates. Fetched once on app mount; the response
+// is treated as static for the lifetime of the page (the backend probe
+// runs at startup and doesn't change without a server restart).
+
+export type ZeusHostMode = 'desktop' | 'server';
+export type ZeusPlatform = 'linux' | 'darwin' | 'windows' | 'unknown';
+
+export type FeatureGate = {
+  available: boolean;
+  reason: string | null;
+  sidecarPath: string | null;
+};
+
+export type CapabilitiesFeatures = {
+  vstHost: FeatureGate;
+};
+
+export type Capabilities = {
+  host: ZeusHostMode;
+  platform: ZeusPlatform;
+  architecture: string;
+  version: string;
+  features: CapabilitiesFeatures;
+};
+
+function asString(v: unknown, fallback = ''): string {
+  return typeof v === 'string' ? v : fallback;
+}
+function asBool(v: unknown, fallback = false): boolean {
+  return typeof v === 'boolean' ? v : fallback;
+}
+
+function parseHostMode(v: unknown): ZeusHostMode {
+  return v === 'desktop' ? 'desktop' : 'server';
+}
+
+function parsePlatform(v: unknown): ZeusPlatform {
+  if (v === 'linux' || v === 'darwin' || v === 'windows') return v;
+  return 'unknown';
+}
+
+function parseGate(raw: unknown): FeatureGate {
+  const o = (raw ?? {}) as Record<string, unknown>;
+  return {
+    available: asBool(o.available),
+    reason: typeof o.reason === 'string' ? o.reason : null,
+    sidecarPath: typeof o.sidecarPath === 'string' ? o.sidecarPath : null,
+  };
+}
+
+export function parseCapabilities(raw: unknown): Capabilities {
+  const o = (raw ?? {}) as Record<string, unknown>;
+  const features = (o.features ?? {}) as Record<string, unknown>;
+  return {
+    host: parseHostMode(o.host),
+    platform: parsePlatform(o.platform),
+    architecture: asString(o.architecture, 'unknown'),
+    version: asString(o.version, 'unknown'),
+    features: {
+      vstHost: parseGate(features.vstHost),
+    },
+  };
+}
+
+export async function fetchCapabilities(
+  signal?: AbortSignal,
+): Promise<Capabilities> {
+  const res = await fetch('/api/capabilities', { signal });
+  if (!res.ok) {
+    throw new Error(`/api/capabilities ${res.status} ${res.statusText}`);
+  }
+  return parseCapabilities(await res.json());
+}
+
+// ---------------------------------------------------------------- locality
+
+const LOCALHOST_HOSTS = new Set([
+  'localhost',
+  '127.0.0.1',
+  '::1',
+  '[::1]',
+  '',
+]);
+
+/**
+ * True when the operator's browser is reaching Zeus via a loopback name —
+ * i.e. the browser and the host process are on the same box. Plugin GUIs
+ * (which open as native OS windows on the host's display) are reachable in
+ * that case.
+ *
+ * Pass `getServerBaseUrl()` to honour Capacitor / standalone-host overrides.
+ * Empty string falls back to the page's own host (the same-origin web flow).
+ */
+export function isLoopbackHost(serverBaseUrl: string): boolean {
+  if (typeof window === 'undefined') return false;
+  let hostname: string;
+  try {
+    const target = serverBaseUrl?.trim()
+      ? new URL(serverBaseUrl)
+      : new URL(window.location.href);
+    hostname = target.hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  return LOCALHOST_HOSTS.has(hostname);
+}

--- a/zeus-web/src/components/SettingsMenu.test.tsx
+++ b/zeus-web/src/components/SettingsMenu.test.tsx
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// SettingsMenu — verify the TX Audio Tools tab is gated by the VST host
+// availability flag from /api/capabilities. Other tabs are static and
+// don't need coverage here.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { SettingsMenu } from './SettingsMenu';
+import { useCapabilitiesStore } from '../state/capabilities-store';
+
+function seed(vstAvailable: boolean) {
+  useCapabilitiesStore.setState({
+    loaded: true,
+    inflight: false,
+    loadError: null,
+    capabilities: {
+      host: 'server',
+      platform: vstAvailable ? 'linux' : 'darwin',
+      architecture: 'x64',
+      version: 'test',
+      features: {
+        vstHost: {
+          available: vstAvailable,
+          reason: vstAvailable ? null : 'unsupported',
+          sidecarPath: vstAvailable ? '/x' : null,
+        },
+      },
+    },
+    localToServer: false,
+  });
+}
+
+describe('SettingsMenu — TX Audio Tools tab gate', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders TX AUDIO TOOLS when vstHost.available is true', () => {
+    seed(true);
+    act(() => {
+      root.render(<SettingsMenu open={true} onClose={() => {}} />);
+    });
+    const tabs = Array.from(
+      container.querySelectorAll('[role="tablist"] button'),
+    ).map((b) => b.textContent?.trim() ?? '');
+    expect(tabs).toContain('TX AUDIO TOOLS');
+  });
+
+  it('hides TX AUDIO TOOLS when vstHost.available is false', () => {
+    seed(false);
+    act(() => {
+      root.render(<SettingsMenu open={true} onClose={() => {}} />);
+    });
+    const tabs = Array.from(
+      container.querySelectorAll('[role="tablist"] button'),
+    ).map((b) => b.textContent?.trim() ?? '');
+    expect(tabs).not.toContain('TX AUDIO TOOLS');
+    // The other tabs are still there.
+    expect(tabs).toContain('PA SETTINGS');
+    expect(tabs).toContain('ABOUT');
+  });
+});

--- a/zeus-web/src/components/SettingsMenu.tsx
+++ b/zeus-web/src/components/SettingsMenu.tsx
@@ -19,7 +19,7 @@
 // (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
 // Both are GPL-2.0-or-later.
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { PaSettingsPanel } from './PaSettingsPanel';
 import { AboutPanel } from './AboutPanel';
 import { DisplayPanel } from './DisplayPanel';
@@ -29,6 +29,7 @@ import { ServerUrlPanel } from './ServerUrlPanel';
 import { TciSettingsPanel } from './TciSettingsPanel';
 import { RadioSelector } from './RadioSelector';
 import { usePaStore } from '../state/pa-store';
+import { useCapabilitiesStore } from '../state/capabilities-store';
 import { PsSettingsPanel } from './PsSettingsPanel';
 import { TxAudioToolsPanel } from './TxAudioToolsPanel';
 
@@ -43,7 +44,7 @@ type TabId =
   | 'server'
   | 'about';
 
-const TABS: ReadonlyArray<{ id: TabId; label: string }> = [
+const ALL_TABS: ReadonlyArray<{ id: TabId; label: string }> = [
   { id: 'pa', label: 'PA SETTINGS' },
   { id: 'ps', label: 'PURESIGNAL' },
   { id: 'tx-audio', label: 'TX AUDIO TOOLS' },
@@ -70,6 +71,27 @@ export function SettingsMenu({ open, onClose, initialTab }: Props) {
   const savePa = usePaStore((s) => s.save);
   const loadPa = usePaStore((s) => s.load);
   const paInflight = usePaStore((s) => s.inflight);
+  // Feature gates. The TX Audio Tools tab is hidden when the VST host is
+  // not available — today that means non-Linux builds and Linux builds
+  // missing the zeus-plughost sidecar binary. Hiding (rather than
+  // disabling) is deliberate: the operator can't act on a disabled tab
+  // until the platform ships its own sidecar.
+  const vstHostAvailable = useCapabilitiesStore(
+    (s) => s.capabilities?.features.vstHost.available ?? false,
+  );
+  const TABS = useMemo(
+    () => ALL_TABS.filter((t) => t.id !== 'tx-audio' || vstHostAvailable),
+    [vstHostAvailable],
+  );
+
+  // If the active tab gets filtered out (e.g. the operator was on
+  // tx-audio when the capabilities response came back saying it's
+  // unavailable), fall back to the first tab.
+  useEffect(() => {
+    if (!TABS.some((t) => t.id === active)) {
+      setActive(TABS[0]?.id ?? 'pa');
+    }
+  }, [TABS, active]);
 
   const handleApply = async () => {
     await savePa();

--- a/zeus-web/src/components/VstHostSlotRow.test.tsx
+++ b/zeus-web/src/components/VstHostSlotRow.test.tsx
@@ -125,6 +125,54 @@ describe('VstHostSlotRow', () => {
     expect(container.textContent).toContain('Bypass');
   });
 
+  it('remote mode hides LOAD on empty slots', () => {
+    act(() => {
+      root.render(
+        <VstHostSlotRow
+          index={0}
+          disabled={false}
+          remote={true}
+          onRequestLoad={() => {}}
+        />,
+      );
+    });
+    const labels = Array.from(container.querySelectorAll('button')).map(
+      (b) => b.textContent?.trim() ?? '',
+    );
+    expect(labels).not.toContain('LOAD');
+  });
+
+  it('remote mode keeps Bypass but hides EDIT/UNLOAD on loaded slots', () => {
+    withSlotPatched(1, {
+      plugin: {
+        name: 'TestEQ',
+        vendor: 'Acme',
+        version: '1.0',
+        path: '/p/eq.vst3',
+      },
+      parameterCount: 3,
+    });
+
+    act(() => {
+      root.render(
+        <VstHostSlotRow
+          index={1}
+          disabled={false}
+          remote={true}
+          onRequestLoad={() => {}}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain('TestEQ');
+    expect(container.textContent).toContain('Bypass');
+    const labels = Array.from(container.querySelectorAll('button')).map(
+      (b) => b.textContent?.trim() ?? '',
+    );
+    expect(labels).not.toContain('EDIT');
+    expect(labels).not.toContain('UNLOAD');
+  });
+
   it('clicking UNLOAD POSTs /api/plughost/slots/N/unload', async () => {
     withSlotPatched(0, {
       plugin: { name: 'EQ', vendor: 'V', version: '1', path: '/p' },

--- a/zeus-web/src/components/VstHostSlotRow.tsx
+++ b/zeus-web/src/components/VstHostSlotRow.tsx
@@ -25,11 +25,16 @@ type Props = {
   // Disabled when the master toggle is off — controls become read-only
   // hints. Load and parameter edits would just fail at the seam anyway.
   disabled: boolean;
+  // True when the operator's browser is reaching Zeus from a different
+  // machine. Plugin GUIs open on the server's display, so loading,
+  // editing, and parameter sliders are all hidden in that case; Bypass
+  // stays available because it's a useful remote kill-switch.
+  remote?: boolean;
   // Opens the plugin browser scoped to "load into this slot N".
   onRequestLoad: (index: number) => void;
 };
 
-export function VstHostSlotRow({ index, disabled, onRequestLoad }: Props) {
+export function VstHostSlotRow({ index, disabled, remote = false, onRequestLoad }: Props) {
   const slot = useVstHostStore((s) => s.master.slots[index]);
   const editor = useVstHostStore((s) => s.editors.get(index));
   const error = useVstHostStore((s) => s.slotErrors.get(index) ?? null);
@@ -92,7 +97,7 @@ export function VstHostSlotRow({ index, disabled, onRequestLoad }: Props) {
           {index + 1}
         </span>
 
-        {loaded && slot.plugin ? (
+        {loaded && slot.plugin && !remote ? (
           <button
             type="button"
             aria-label={expanded ? 'Collapse parameters' : 'Expand parameters'}
@@ -181,7 +186,7 @@ export function VstHostSlotRow({ index, disabled, onRequestLoad }: Props) {
               />
               Bypass
             </label>
-            {hasNativeEditor ? (
+            {!remote && hasNativeEditor ? (
               <button
                 type="button"
                 className="btn sm"
@@ -202,16 +207,18 @@ export function VstHostSlotRow({ index, disabled, onRequestLoad }: Props) {
                 {editorOpen ? 'CLOSE' : 'EDIT'}
               </button>
             ) : null}
-            <button
-              type="button"
-              className="btn sm"
-              disabled={disabled}
-              onClick={() => void unloadSlot(index)}
-            >
-              UNLOAD
-            </button>
+            {!remote ? (
+              <button
+                type="button"
+                className="btn sm"
+                disabled={disabled}
+                onClick={() => void unloadSlot(index)}
+              >
+                UNLOAD
+              </button>
+            ) : null}
           </>
-        ) : (
+        ) : !remote ? (
           <button
             type="button"
             className="btn sm"
@@ -220,7 +227,7 @@ export function VstHostSlotRow({ index, disabled, onRequestLoad }: Props) {
           >
             LOAD
           </button>
-        )}
+        ) : null}
       </div>
 
       {editorOpen && editor && editor.width > 0 ? (

--- a/zeus-web/src/components/VstHostSubmenu.test.tsx
+++ b/zeus-web/src/components/VstHostSubmenu.test.tsx
@@ -15,6 +15,7 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
 import { VstHostSubmenu } from './VstHostSubmenu';
+import { useCapabilitiesStore } from '../state/capabilities-store';
 import { useVstHostStore } from '../state/vst-host-store';
 import { VST_HOST_SLOT_COUNT } from '../api/vst-host';
 
@@ -66,12 +67,31 @@ function resetStore() {
   });
 }
 
+function seedCapabilities(localToServer: boolean) {
+  useCapabilitiesStore.setState({
+    loaded: true,
+    inflight: false,
+    loadError: null,
+    capabilities: {
+      host: localToServer ? 'desktop' : 'server',
+      platform: 'linux',
+      architecture: 'x64',
+      version: 'test',
+      features: {
+        vstHost: { available: true, reason: null, sidecarPath: '/x' },
+      },
+    },
+    localToServer,
+  });
+}
+
 describe('VstHostSubmenu', () => {
   let container: HTMLDivElement;
   let root: Root;
 
   beforeEach(() => {
     resetStore();
+    seedCapabilities(true);
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -96,6 +116,33 @@ describe('VstHostSubmenu', () => {
     // 8 slot rows render even with master OFF (visible-but-disabled).
     const slotLabels = container.querySelectorAll('[aria-label^="VST slot "]');
     expect(slotLabels.length).toBe(VST_HOST_SLOT_COUNT);
+  });
+
+  it('shows BROWSE PLUGINS when local to the server (desktop host)', () => {
+    act(() => {
+      root.render(<VstHostSubmenu />);
+    });
+    expect(container.textContent).toContain('BROWSE PLUGINS');
+    // The remote-mode notice must not be visible.
+    expect(container.textContent).not.toContain(
+      'editable only from the server console',
+    );
+  });
+
+  it('hides BROWSE PLUGINS and shows the remote-mode notice when not local', () => {
+    seedCapabilities(false);
+    act(() => {
+      root.render(<VstHostSubmenu />);
+    });
+    expect(container.textContent).not.toContain('BROWSE PLUGINS');
+    expect(container.textContent).toContain(
+      'editable only from the server console',
+    );
+    // The master toggle stays available even when remote.
+    const checkbox = container.querySelector(
+      'input[type="checkbox"][aria-label="Toggle VST chain"]',
+    );
+    expect(checkbox).toBeTruthy();
   });
 
   it('toggling the master checkbox calls /api/plughost/master', async () => {

--- a/zeus-web/src/components/VstHostSubmenu.tsx
+++ b/zeus-web/src/components/VstHostSubmenu.tsx
@@ -18,6 +18,7 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import { setTxMonitor } from '../api/client';
+import { useCapabilitiesStore } from '../state/capabilities-store';
 import { useTxStore } from '../state/tx-store';
 import { useVstHostStore } from '../state/vst-host-store';
 import { VST_HOST_SLOT_COUNT } from '../api/vst-host';
@@ -41,6 +42,14 @@ export function VstHostSubmenu() {
   // While a master-toggle POST is in flight, lock the toggle so a second
   // click doesn't race the first.
   const [masterPending, setMasterPending] = useState(false);
+
+  // Plugin GUIs open as native OS windows on the host running Zeus. When
+  // the operator's browser is on a different machine we hide the chain
+  // editor (load / unload / edit / parameter sliders) and the catalog
+  // browser, but keep the master toggle and per-slot Bypass — those are
+  // operationally important kill-switches that don't depend on the
+  // plugin's editor being on screen.
+  const localToServer = useCapabilitiesStore((s) => s.localToServer);
 
   // TX Monitor — audition path so the operator can hear the chain output
   // (post-bandpass / post-CFIR demod) at the actual TX bandwidth without
@@ -139,13 +148,15 @@ export function VstHostSubmenu() {
           <span className={`led ${txMonitorOn ? 'tx' : ''}`} style={{ marginRight: 8 }} />
           MONITOR
         </button>
-        <button
-          type="button"
-          className="btn sm"
-          onClick={() => setBrowserSlot(-1)}
-        >
-          BROWSE PLUGINS
-        </button>
+        {localToServer ? (
+          <button
+            type="button"
+            className="btn sm"
+            onClick={() => setBrowserSlot(-1)}
+          >
+            BROWSE PLUGINS
+          </button>
+        ) : null}
       </header>
 
       <p style={{ margin: 0, fontSize: 11, color: 'var(--fg-2)' }}>
@@ -153,6 +164,23 @@ export function VstHostSubmenu() {
         bypassed when the master toggle is off. Plugin editors open as
         native OS windows on this device — not inside the browser.
       </p>
+
+      {!localToServer ? (
+        <div
+          style={{
+            fontSize: 11,
+            color: 'var(--fg-2)',
+            background: 'var(--bg-2)',
+            border: '1px solid var(--panel-border)',
+            borderRadius: 4,
+            padding: '6px 8px',
+          }}
+        >
+          Plugin chain is editable only from the server console. You can
+          enable, disable, or bypass slots from here; loading plugins and
+          editing parameters requires being at the host running Zeus.
+        </div>
+      ) : null}
 
       {loadError ? (
         <div style={{ fontSize: 11, color: 'var(--tx)' }}>
@@ -206,6 +234,7 @@ export function VstHostSubmenu() {
             key={i}
             index={i}
             disabled={slotsDisabled}
+            remote={!localToServer}
             onRequestLoad={(idx) => setBrowserSlot(idx)}
           />
         ))}

--- a/zeus-web/src/state/capabilities-store.test.ts
+++ b/zeus-web/src/state/capabilities-store.test.ts
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Node 25 ships a stub `localStorage` global that lacks the Storage API
+// methods, shadowing jsdom's implementation. Install a minimal in-memory
+// stand-in BEFORE importing the module under test so its first read sees
+// a working API. Mirrors the shim in serverUrl.test.ts.
+function installLocalStorageShim() {
+  const store = new Map<string, string>();
+  const shim: Storage = {
+    getItem: (k) => (store.has(k) ? (store.get(k) as string) : null),
+    setItem: (k, v) => void store.set(k, String(v)),
+    removeItem: (k) => void store.delete(k),
+    clear: () => store.clear(),
+    key: (i) => Array.from(store.keys())[i] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: shim,
+  });
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: shim,
+  });
+}
+installLocalStorageShim();
+
+const { useCapabilitiesStore } = await import('./capabilities-store');
+const { setServerBaseUrl } = await import('../serverUrl');
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function resetStore() {
+  useCapabilitiesStore.setState({
+    loaded: false,
+    inflight: false,
+    loadError: null,
+    capabilities: null,
+    localToServer: false,
+  });
+}
+
+describe('useCapabilitiesStore', () => {
+  beforeEach(() => {
+    resetStore();
+    setServerBaseUrl('');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    setServerBaseUrl('');
+  });
+
+  it('hydrates from /api/capabilities and derives localToServer from desktop host', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({
+        host: 'desktop',
+        platform: 'linux',
+        architecture: 'x64',
+        version: '0.6.0',
+        features: {
+          vstHost: {
+            available: true,
+            reason: null,
+            sidecarPath: '/usr/local/bin/zeus-plughost',
+          },
+        },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await useCapabilitiesStore.getState().refresh();
+    const s = useCapabilitiesStore.getState();
+    expect(s.loaded).toBe(true);
+    expect(s.capabilities?.host).toBe('desktop');
+    expect(s.capabilities?.features.vstHost.available).toBe(true);
+    // Desktop host always = local regardless of browser hostname.
+    expect(s.localToServer).toBe(true);
+  });
+
+  it('marks server-host + LAN base URL as remote', async () => {
+    setServerBaseUrl('http://192.168.1.23:6060');
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({
+        host: 'server',
+        platform: 'linux',
+        architecture: 'x64',
+        version: '0.6.0',
+        features: {
+          vstHost: { available: true, reason: null, sidecarPath: '/x' },
+        },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await useCapabilitiesStore.getState().refresh();
+    expect(useCapabilitiesStore.getState().localToServer).toBe(false);
+  });
+
+  it('records loadError when the fetch fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn<typeof fetch>().mockResolvedValue(
+        new Response('boom', { status: 500 }),
+      ),
+    );
+
+    await useCapabilitiesStore.getState().refresh();
+    const s = useCapabilitiesStore.getState();
+    expect(s.loaded).toBe(false);
+    expect(s.loadError).not.toBeNull();
+  });
+});

--- a/zeus-web/src/state/capabilities-store.ts
+++ b/zeus-web/src/state/capabilities-store.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Capabilities store. Holds the /api/capabilities snapshot plus a derived
+// `localToServer` flag that gates the VST chain editor sub-tree.
+//
+// Lifecycle: App.tsx fires refresh() once on mount; the backend snapshot
+// is captured at startup and doesn't change at runtime, so re-fetching
+// during navigation isn't necessary.
+
+import { create } from 'zustand';
+
+import {
+  fetchCapabilities,
+  isLoopbackHost,
+  type Capabilities,
+} from '../api/capabilities';
+import { getServerBaseUrl, onServerBaseUrlChanged } from '../serverUrl';
+
+export type CapabilitiesStoreState = {
+  loaded: boolean;
+  inflight: boolean;
+  loadError: string | null;
+  capabilities: Capabilities | null;
+  // Derived from `capabilities.host === 'desktop'` OR (browser is talking
+  // to a loopback host). True means plugin GUIs that open on the host's
+  // display are reachable to the operator.
+  localToServer: boolean;
+  refresh: () => Promise<void>;
+};
+
+// Computed once and on serverUrl-change events. Browser host can change
+// at runtime when a Capacitor user re-points at a different LAN server.
+function computeLocality(caps: Capabilities | null): boolean {
+  if (caps?.host === 'desktop') return true;
+  return isLoopbackHost(getServerBaseUrl());
+}
+
+export const useCapabilitiesStore = create<CapabilitiesStoreState>((set, get) => ({
+  loaded: false,
+  inflight: false,
+  loadError: null,
+  capabilities: null,
+  localToServer: false,
+  refresh: async () => {
+    if (get().inflight) return;
+    set({ inflight: true, loadError: null });
+    try {
+      const caps = await fetchCapabilities();
+      set({
+        capabilities: caps,
+        loaded: true,
+        inflight: false,
+        loadError: null,
+        localToServer: computeLocality(caps),
+      });
+    } catch (err) {
+      set({
+        inflight: false,
+        loadError: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+}));
+
+// Re-evaluate locality whenever the operator changes the configured
+// server URL (Capacitor / standalone-host flow). Idempotent and inexpensive.
+if (typeof window !== 'undefined') {
+  onServerBaseUrlChanged(() => {
+    const caps = useCapabilitiesStore.getState().capabilities;
+    useCapabilitiesStore.setState({ localToServer: computeLocality(caps) });
+  });
+}


### PR DESCRIPTION
## Summary

First slice of the feature-matrix groundwork from #185, applied to the VST host shipped in #212.

The VST host's C++ sidecar only ships for Linux today, and plugin GUIs open as native OS windows on the box running Zeus — useless to a remote operator. Two gates address that:

1. **Hide the VST UI entirely on platforms / installs without a sidecar.**
2. **When VST is available but the operator is browsing remotely, show only the kill-switches** (master enable + per-slot Bypass) and hide the chain editor.

Both gates read from a new `/api/capabilities` snapshot — designed to grow into the broader plugin feature matrix #185 envisions (amp manager, MIDI, etc.).

## Backend (additive — no behaviour change to existing flows)

- New `ZeusHostMode` enum (`Server` / `Desktop`) on `ZeusHostOptions`. `Zeus.Desktop` sets `Desktop` explicitly; `Zeus.Server` keeps the `Server` default. Replaces inferring host-mode from `BindAllInterfaces`.
- `SidecarLocator.Probe()` — non-spawning lookup that returns either the resolved binary path or a structured "missing" reason.
- `CapabilitiesService` captures host-mode, platform, architecture, version, and the per-feature gate snapshot once at startup. Probe-once is deliberate — sidecar binaries don't appear / disappear at runtime in normal operation, and the frontend caches the response anyway.
- `GET /api/capabilities` returns the snapshot:

```json
{
  "host": "desktop" | "server",
  "platform": "linux" | "darwin" | "windows" | "unknown",
  "architecture": "x64" | "arm64" | ...,
  "version": "0.6.0-alpha",
  "features": {
    "vstHost": {
      "available": true,
      "reason": null,
      "sidecarPath": "/usr/local/bin/zeus-plughost"
    }
  }
}
```

- VST gate is `platform === linux` AND the sidecar binary resolves. Flips automatically when we ship macOS / Windows sidecar builds — the platform check stays server-side so the frontend never duplicates the OS-support matrix.

## Frontend

- `api/capabilities.ts` + `state/capabilities-store.ts` fetch once on `App` mount. The store derives a `localToServer` flag from `host === 'desktop'` OR a loopback hostname (`localhost` / `127.0.0.1` / `::1`), honouring the configured `serverBaseUrl` so Capacitor users pointing at a LAN host are correctly classified as remote. Re-evaluates on `serverBaseUrl` changes.
- `SettingsMenu`: filters out the TX AUDIO TOOLS tab when `vstHost.available === false`. If the operator was on that tab when the response arrived, falls back to the first tab. **Hidden, not disabled-with-tooltip** — operators on macOS / Windows have no path to enable it until their sidecar build ships, so a missing tab is more honest than a permanently-greyed one.
- `VstHostSubmenu`: when `!localToServer`:
  - **Hidden:** `BROWSE PLUGINS`, per-slot `LOAD` / `UNLOAD` / `EDIT`, and parameter sliders (the plugin GUI lives on the server's display; remote sliders are operator-hostile).
  - **Visible:** master `VST Chain` toggle, plugin name / vendor labels, per-slot Bypass — those are operationally important kill-switches that don't depend on the editor being on screen.
  - Plus a one-line note: *"Plugin chain is editable only from the server console. You can enable, disable, or bypass slots from here; loading plugins and editing parameters requires being at the host running Zeus."*

## Test plan

- [x] `dotnet test Zeus.slnx` — 643 passed, 137 skipped, 0 failed.
- [x] `npm --prefix zeus-web run typecheck` — clean.
- [x] `npm --prefix zeus-web run test` — 192 passed (was 176; six new).
- [x] `npm --prefix zeus-web run build` — production bundle clean.
- [x] New `CapabilitiesEndpointTests` asserts JSON shape + platform-gate structural invariants.
- [x] `capabilities.test.ts` — parser + `isLoopbackHost`.
- [x] `capabilities-store.test.ts` — hydrate / desktop locality / LAN-base remote / fetch-failure paths.
- [x] `SettingsMenu.test.tsx` — TX Audio Tools tab visibility based on the gate.
- [x] `VstHostSubmenu.test.tsx` — local mode shows BROWSE; remote mode hides it and shows the notice while keeping the master toggle.
- [x] `VstHostSlotRow.test.tsx` — remote mode hides LOAD on empty slots and EDIT/UNLOAD on loaded slots; Bypass stays.

## Manual verification still needed

I haven't booted Zeus to walk through the gated UI in a browser — the diff is small and well-typed but the maintainer should sanity-check the visual surface before merge:

- [ ] On a Linux box with the sidecar present: TX AUDIO TOOLS tab visible; same-origin browser sees full editor; LAN-IP browser sees only master + Bypass + the notice.
- [ ] On macOS / Windows: TX AUDIO TOOLS tab hidden entirely.
- [ ] Capacitor mobile pointed at a LAN server: tab visibility follows the server's `vstHost.available`; chain editor hidden as remote.

## Follow-ups (intentionally not in this PR)

- macOS / Windows sidecar builds — flips the gate automatically once shipped.
- Extending `features` with `ampManager`, `midi`, etc. as #185 proceeds — same shape, same gating pattern.

Closes the "feature toggle" half of the work referenced in #185, scoped to the VST host. Cross-references #106 (VST host implementation) and #212 (the merge that brought VST into release/0.5.0).