### PR TITLE
fix(ui): topbar sub-label tracks connected radio instead of hardcoded "Hermes Lite 2"

### DIFF
--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -95,7 +95,9 @@ import { getServerBaseUrl, isCapacitorRuntime } from './serverUrl';
 import { getAudioClient } from './audio/audio-client';
 import { useMicUplink } from './audio/use-mic-uplink';
 import { fetchState } from './api/client';
+import { BOARD_LABELS } from './api/radio';
 import { useConnectionStore } from './state/connection-store';
+import { useRadioStore } from './state/radio-store';
 import { useQrzStore } from './state/qrz-store';
 import { useRotatorStore } from './state/rotator-store';
 import { useLoggerStore } from './state/logger-store';
@@ -133,6 +135,21 @@ export default function App() {
   const tunOn = useTxStore((s) => s.tunOn);
   const filterRibbonOpen = useConnectionStore((s) => s.filterAdvancedPaneOpen);
   const connected = status === 'Connected';
+  // Brand sub label in the topbar reflects what discovery actually saw on
+  // the wire (selection.connected), not the operator's preferred override —
+  // showing "ANAN G2" when an HL2 is plugged in would just confuse anyone
+  // reading the topbar to confirm what they're talking to. Falls back to
+  // a neutral "NOT CONNECTED" when nothing is on the wire yet.
+  const radioConnected = useRadioStore((s) => s.selection.connected);
+  const radioLoad = useRadioStore((s) => s.load);
+  // Reload on mount AND every time the wire connection flips to Connected.
+  // Clicking Connect on a discovered radio doesn't refresh radio-store on
+  // its own (only the manual-connect path does), so without this the
+  // brand-sub label keeps showing "NOT CONNECTED" until the next page load.
+  useEffect(() => { radioLoad(); }, [radioLoad, connected]);
+  const brandSub = radioConnected !== 'Unknown'
+    ? BOARD_LABELS[radioConnected].toUpperCase()
+    : 'NOT CONNECTED';
 
   useKeyboardShortcuts();
   useMicUplink();
@@ -671,7 +688,7 @@ export default function App() {
           </div>
           <div className="brand-text">
             <div className="brand-name mono">OpenHpsdr Zeus</div>
-            <div className="brand-sub label-xs hide-mobile">HERMES LITE 2 · 0.1–54 MHz</div>
+            <div className="brand-sub label-xs hide-mobile">{brandSub}</div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

The topbar's brand sub-text was hardcoded `HERMES LITE 2 · 0.1–54 MHz`, so a connected ANAN G2 (or any non-HL2) still read "HERMES LITE 2". Wires the label to `RadioSelection.connected` via the existing `useRadioStore` so it follows discovery.

## What changed

- `zeus-web/src/App.tsx:674` — the hardcoded label is replaced with `{brandSub}`, computed from `useRadioStore`'s `selection.connected`:
  ```ts
  const brandSub = radioConnected !== 'Unknown'
    ? BOARD_LABELS[radioConnected].toUpperCase()
    : 'NOT CONNECTED';
  ```
- Added a `useEffect` that reloads `useRadioStore` on mount **and** every time the wire connection flips. Without the connection-flip dependency, clicking Connect on a discovered radio left the label stuck at "NOT CONNECTED" — only the manual-settings path was reloading the radio store. (Verified locally: G2 connect now flips the label.)
- Drops the `· 0.1–54 MHz` frequency-range suffix. It was HL2-specific and would need per-board knowledge to keep accurate.

## Behaviour

| State | Label |
|---|---|
| Pre-connect | `NOT CONNECTED` |
| HL2 | `HERMES LITE 2` |
| G2-class | `ANAN G2 / 7000D / G1` |
| ANAN-100 | `ANAN-100 / 100B / 8000D` |
| ANAN-200D | `ANAN-100D / 200D` |
| Hermes / ANAN-10 | `HERMES / ANAN-10/10E` |

These come straight from `BOARD_LABELS` in `zeus-web/src/api/radio.ts` — no new strings introduced; just consuming what was already there.

## Out of scope (filed as #218)

The G2-class label still reads `ANAN G2 / 7000D / G1` for any board id 0x0A — that's a coarseness inherent to today's `HpsdrBoardKind` enum. Distinguishing G2 vs G2 MkII vs 7000DLE vs G1 vs G2-1K vs ANAN-8000D needs new enum values + dispatch and is tracked as a separate enhancement in #218.

## Tests

- `npm --prefix zeus-web run typecheck` — clean.
- `npm --prefix zeus-web run build` — clean.
- Verified locally on KB2UKA's G2 MkII over P2: label flips to `ANAN G2 / 7000D / G1` on connect, back to `NOT CONNECTED` on disconnect, both transitions visible without page reload.

## Red-light check

- No `Zeus.Contracts` wire-format change.
- No backend defaults touched.
- No HL2 P1 path touched.
- No CSS / palette / typography changes — only the dynamic value rendered into the existing `brand-sub label-xs hide-mobile` chrome.

— Doug, KB2UKA