### PR TITLE
feat(ps): auto-enable PS Monitor when arming PureSignal

### DIFF
--- a/zeus-web/src/components/PsToggleButton.tsx
+++ b/zeus-web/src/components/PsToggleButton.tsx
@@ -20,9 +20,15 @@
 // Both are GPL-2.0-or-later.
 
 import { useCallback } from 'react';
-import { setPs } from '../api/client';
+import { setPs, setPsMonitor } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import { useRadioStore } from '../state/radio-store';
 import { useTxStore } from '../state/tx-store';
+
+// Connected board kinds that don't have a real PS feedback receiver. PS
+// Monitor (post-PA loopback display source) is only meaningful where the
+// board has a feedback path, so we don't auto-enable it for these.
+const PS_MONITOR_UNSUPPORTED = new Set(['HermesLite2']);
 
 /**
  * PureSignal master arm. Optimistic update with rollback on server refusal —
@@ -37,7 +43,10 @@ export function PsToggleButton() {
   const psEnabled = useTxStore((s) => s.psEnabled);
   const psAuto = useTxStore((s) => s.psAuto);
   const psSingle = useTxStore((s) => s.psSingle);
+  const psMonitorEnabled = useTxStore((s) => s.psMonitorEnabled);
   const setPsEnabled = useTxStore((s) => s.setPsEnabled);
+  const setPsMonitorLocal = useTxStore((s) => s.setPsMonitorEnabled);
+  const connectedBoard = useRadioStore((s) => s.selection.connected);
 
   // P1 gate — backend forwards SetPsEnabled to the engine on either protocol
   // but the wire-side feedback path is P2-only in v1.
@@ -56,7 +65,30 @@ export function PsToggleButton() {
     setPs({ enabled: next, auto: psAuto, single: psSingle }).catch(() => {
       setPsEnabled(!next);
     });
-  }, [disabled, psEnabled, psAuto, psSingle, setPsEnabled]);
+    // When arming PS, also turn on PS Monitor by default — operators almost
+    // always want to see the post-PA loopback while PS is correcting, and
+    // having it default off forced an extra trip to Settings every session.
+    // Only auto-toggles up; disarming PS doesn't force the monitor off so
+    // the operator can keep watching the trace if they had it on
+    // pre-arming. Skip on boards without a real feedback receiver (HL2).
+    if (
+      next
+      && !psMonitorEnabled
+      && !PS_MONITOR_UNSUPPORTED.has(connectedBoard)
+    ) {
+      setPsMonitorLocal(true);
+      setPsMonitor(true).catch(() => setPsMonitorLocal(false));
+    }
+  }, [
+    disabled,
+    psEnabled,
+    psAuto,
+    psSingle,
+    psMonitorEnabled,
+    connectedBoard,
+    setPsEnabled,
+    setPsMonitorLocal,
+  ]);
 
   return (
     <button


### PR DESCRIPTION
## Summary

Clicking the PS button to arm PureSignal now also turns on the PS Monitor (post-PA loopback display source) by default. Operators almost always want to watch the loopback trace while PS is correcting, and defaulting it off forced an extra trip to Settings → PureSignal every session.

## Behaviour

| Action | PS Monitor result |
|---|---|
| Click PS to arm, monitor was off | **Auto-on** (optimistic local + POST, rolls back on POST failure) |
| Click PS to arm, monitor already on | Unchanged |
| Click PS to disarm | **Unchanged** — operator can keep watching the trace if they had it on |
| Toggle monitor manually after arming | Unchanged — operator's later choice wins |
| Connected board is HL2 (no feedback receiver) | Skipped — same gate the PS Settings panel uses to hide the toggle |

## What changed

- `zeus-web/src/components/PsToggleButton.tsx` — extends the click handler to also call `setPsMonitor(true)` (REST) + `useTxStore.setPsMonitorEnabled(true)` (local) when:
  1. PS is transitioning off → on, AND
  2. PS Monitor is currently off, AND
  3. The connected board is not HL2.

  POST failure rolls back the local checkbox, same pattern as the manual toggle in `PsSettingsPanel.onPsMonitorToggle`.

## Out of scope

- No new state. Reuses `useTxStore.psMonitorEnabled` / `setPsMonitorEnabled`.
- No new endpoint. Reuses `setPsMonitor` REST in `api/client.ts`.
- No backend change. Server-side PS Monitor latch in `DspPipelineService.cs` is unchanged.

## Tests

- `npm --prefix zeus-web run typecheck` — clean.
- `npm --prefix zeus-web run build` — clean.
- Verified locally on KB2UKA's G2 MkII over P2: clicking PS turns on PsMonitor automatically; clicking PS off leaves PsMonitor where it is; manually toggling PsMonitor while PS is armed still works.

## Red-light check

- No `Zeus.Contracts` wire-format change.
- No backend defaults touched.
- No HL2 P1 path touched (HL2 explicitly skipped).
- No CSS / palette / typography changes.
- This *is* a behaviour change for an operator who explicitly preferred PS armed with monitor off — they'll need to manually toggle the monitor off after each arm. That's the trade-off; happy to revisit if anyone hits it on the rack.

— Doug, KB2UKA