### PR TITLE
feat(ps): HL2 PureSignal over Protocol 1 (closes #172)

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -209,6 +209,14 @@ public sealed record StateDto(
     // RadioService HW-peak switch overrides on the first ConnectAsync /
     // ConnectP2Async. See PLAN section 7 / hermes.md §7.1.
     double PsHwPeak = 0.4072,
+    // PS hardware-peak per-board default — frozen at connect time from
+    // ResolvePsHwPeak(isProtocol2, board) and surfaced for the UI to compare
+    // against the live PsHwPeak so the operator gets a "differs from default"
+    // hint when they've dialed away from the factory curve.
+    // mi0bot ref: PSForm.cs:830 `pbWarningSetPk.Visible = _PShwpeak !=
+    // HardwareSpecific.PSDefaultPeak;` + clsHardwareSpecific.cs:303-328
+    // PSDefaultPeak per-board switch.
+    double PsHwPeakDefault = 0.4072,
     PsFeedbackSource PsFeedbackSource = PsFeedbackSource.Internal,
     string PsIntsSpiPreset = "16/256",
     double PsFeedbackLevel = 0.0,   // info[4] read-back, 0..256

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -1828,7 +1828,14 @@ public sealed class WdspDspEngine : IDspEngine
                 _psAmpDelayNs = ampDelayNs;
                 if (id >= 0) _ = NativeMethods.SetPSTXDelay(id, ampDelayNs * 1e-9);
             }
-            if (hwPeak > 0.0 && hwPeak <= 2.0 && hwPeak != _psHwPeak)
+            // mi0bot: PSForm.cs PSpeak_TextChanged calls
+            // puresignal.SetPSHWPeak(_txachannel, _PShwpeak) unconditionally on
+            // every TextChanged, with no equality guard against the prior
+            // value. Mirror that here so the operator can re-push the same
+            // value to clear an info[6]=0x0044 fault state without typing a
+            // different value first. Range check stays (mi0bot stops the
+            // operator at the WinForms NUD min/max).
+            if (hwPeak > 0.0 && hwPeak <= 2.0)
             {
                 _psHwPeak = hwPeak;
                 if (id >= 0) NativeMethods.SetPSHWPeak(id, hwPeak);

--- a/Zeus.Protocol1/ControlFrame.cs
+++ b/Zeus.Protocol1/ControlFrame.cs
@@ -65,9 +65,21 @@ internal static class ControlFrame
         TxFreq = 0x02,
         RxFreq = 0x04,
         DriveFilter = 0x12,
-        // Extended RX attenuator (both bare HPSDR and HL2 firmware gain).
-        // Protocol-1 writes these under C0=0x14.
+        // Extended RX attenuator + (HL2 only) PureSignal enable bit and LNA
+        // mode. Protocol-1 writes these under C0=0x14, the wire-byte
+        // encoding of register 0x0a (= 0x0a << 1). For bare HPSDR /
+        // ANAN-class radios the payload is just the legacy step-attenuator
+        // byte in C4. For HL2 the same address frame also carries the
+        // puresignal_run bit in C2 bit 6 (mi0bot networkproto1.c:1102) and
+        // the user_dig_out nibble in C3, plus an extended C4 attenuator
+        // range (0x40 | (60-Db)) — see WriteAttenuatorPayload.
         Attenuator = 0x14,
+        // Predistortion config register 0x2b (HL2 PureSignal). C0 wire byte
+        // = 0x2b << 1 = 0x56. bits [31:24] = predistortion subindex (C1),
+        // bits [19:16] = predistortion value (C2 [3:0]). PR #119 review
+        // documents the common encoding mistake of placing the value in
+        // C2 [7:4] — do NOT shift it left.
+        Predistortion = 0x56,
     }
 
     /// <summary>
@@ -96,7 +108,23 @@ internal static class ControlFrame
         // anything. Selected by MOX: TX mask during transmit, RX mask otherwise
         // (piHPSDR `old_protocol.c:1884-1904`).
         byte UserOcTxMask = 0,
-        byte UserOcRxMask = 0);
+        byte UserOcRxMask = 0,
+        // PureSignal enable for HL2 — wire-side bit 0x0a[22] = C2 bit 6 of
+        // the C0=0x14 (Attenuator) frame, and a duplicate copy at the
+        // Predistortion subindex. Set when the operator arms PS via
+        // PsToggleButton; ignored on non-HL2 boards. Issue #172.
+        bool PsEnabled = false,
+        // PureSignal predistortion value (0..15) and subindex (0..255) —
+        // written via the Predistortion (0x2b) register frame. Defaults
+        // mirror the WDSP `calcc` initial state: subindex 0, value 0
+        // (= "PS off, identity correction"). Sent as a paired write when
+        // PsEnabled flips. Issue #172.
+        byte PsPredistortionValue = 0,
+        byte PsPredistortionSubindex = 0,
+        // Number of receivers minus 1, packed into Config C4 [5:3]. Default
+        // 0 (single RX); HL2 PS uses 1 (= 2 receivers, paired DDC0/DDC1
+        // layout). mi0bot networkproto1.c:973 — `C4 |= (nddc - 1) << 3`.
+        byte NumReceiversMinusOne = 0);
 
     /// <summary>
     /// Write the 5 C&amp;C bytes for <paramref name="register"/> given the current
@@ -143,6 +171,10 @@ internal static class ControlFrame
                 WriteAttenuatorPayload(cc[1..], in state);
                 break;
 
+            case CcRegister.Predistortion:
+                WritePredistortionPayload(cc[1..], in state);
+                break;
+
             default:
                 cc[1] = cc[2] = cc[3] = cc[4] = 0;
                 break;
@@ -166,6 +198,34 @@ internal static class ControlFrame
         c14[1] = 0;   // C2
         c14[2] = 0;   // C3
         c14[3] = c4;
+
+        // HL2 PureSignal: register 0x0a bit 22 = puresignal_run. Bit 22 lives
+        // in C2 bit 6 (22 - 16 = 6) of this same C0=0x14 frame. mi0bot
+        // networkproto1.c:1102 — `C2 = (line_in_gain & 0b00011111) |
+        // ((puresignal_run & 1) << 6);`. Other boards (Hermes / ANAN-class)
+        // have their PS-enable bit elsewhere on the wire (Protocol 2's
+        // ALEX_PS_BIT) so we only flip C2[6] when we know we're talking to
+        // an HL2. Issue #172. PR #119 placed this in C3 — that bug is the
+        // canonical regression to guard.
+        if (s.Board == HpsdrBoardKind.HermesLite2 && s.PsEnabled)
+        {
+            c14[1] |= 1 << 6;   // C2 bit 6 = puresignal_run
+        }
+    }
+
+    private static void WritePredistortionPayload(Span<byte> c14, in CcState s)
+    {
+        // HL2 register 0x2b (C0 wire byte 0x56). Per the HL2 protocol doc:
+        //   bits [31:24] = predistortion subindex  → C1 (whole byte)
+        //   bits [19:16] = predistortion value      → C2 [3:0] (low nibble)
+        // PR #119 placed the value in C2 [7:4] — that's bits [23:20], which
+        // are reserved. Do NOT shift the value left. mi0bot's clsHardwareSpecific
+        // / cmaster.cs writes via the same address space, with the value
+        // word in the low nibble of C2.
+        c14[0] = s.PsPredistortionSubindex;            // C1
+        c14[1] = (byte)(s.PsPredistortionValue & 0x0F); // C2 [3:0]; high nibble = reserved (0)
+        c14[2] = 0;                                     // C3
+        c14[3] = 0;                                     // C4
     }
 
     private static void WriteConfigPayload(Span<byte> c14, in CcState s)
@@ -201,8 +261,12 @@ internal static class ControlFrame
         c14[2] = c3;
 
         // C4: Alex TX antenna [1:0] = 0 (RX-only MVP), duplex [2] = 1 (always, per
-        // old_protocol.c:2661), N-1 receivers at [5:3] = 0 (we always use 1 RX).
+        // old_protocol.c:2661), N-1 receivers at [5:3]. mi0bot
+        // networkproto1.c:973 — `C4 |= (nddc - 1) << 3`. Single-RX default
+        // is 0; HL2 PS armed bumps to 1 (= 2 receivers, paired DDC0/DDC1
+        // layout). Capped at 7 by the 3-bit field.
         byte c4 = 1 << 2;
+        c4 |= (byte)((s.NumReceiversMinusOne & 0x07) << 3);
         c14[3] = c4;
     }
 

--- a/Zeus.Protocol1/ControlFrame.cs
+++ b/Zeus.Protocol1/ControlFrame.cs
@@ -153,7 +153,14 @@ internal static class ControlFrame
         // Number of receivers minus 1, packed into Config C4 [5:3]. Default
         // 0 (single RX); HL2 PS uses 1 (= 2 receivers, paired DDC0/DDC1
         // layout). mi0bot networkproto1.c:973 — `C4 |= (nddc - 1) << 3`.
-        byte NumReceiversMinusOne = 0);
+        byte NumReceiversMinusOne = 0,
+        // HL2 TX-side step attenuator (PGA) target in dB. Operator-tunable
+        // via PsAutoAttenuateService when PS auto-attenuate is on; otherwise
+        // a sentinel value of int.MinValue means "untouched, use the default
+        // RX-side encoding for C4". Range when set: -28..+31 dB
+        // (mi0bot console.cs:2084 udTXStepAttData min=-28; +31 is the AD9866
+        // TX PGA upper). Wire encoding lives in WriteAttenuatorPayload.
+        int Hl2TxAttnDb = int.MinValue);
 
     /// <summary>
     /// Write the 5 C&amp;C bytes for <paramref name="register"/> given the current
@@ -234,6 +241,25 @@ internal static class ControlFrame
         byte c4 = s.Board == HpsdrBoardKind.HermesLite2
             ? (byte)(0x40 | Math.Clamp(60 - db, 0, 60))
             : (byte)(0x20 | (db & 0x1F));
+
+        // HL2 PS auto-attenuate: during MOX with PS enabled, mi0bot
+        // networkproto1.c:1086-1088 swaps the C4 source from rx_step_attn to
+        // tx_step_attn so the AD9866 TX-side PGA presents the operator's
+        // ATTOnTX value (the feedback path PGA register, NOT a separate RX
+        // attenuator). C# UI value (-28..+31 dB) → wire byte (31 - db),
+        // matching mi0bot console.cs:10947-10948
+        // `NetworkIO.SetTxAttenData(31 - _tx_attenuator_data)`. Bit 6 stays
+        // set (0x40, PGA select); the low 6 bits carry the wire byte clamped
+        // to the same 0..60 RX-side range so a stale operator value can't
+        // overflow the field. Sentinel int.MinValue keeps the default RX-
+        // side encoding above untouched — first PS arm matches today's
+        // behaviour exactly.
+        if (s.Board == HpsdrBoardKind.HermesLite2
+            && s.Mox
+            && s.Hl2TxAttnDb != int.MinValue)
+        {
+            c4 = (byte)(Math.Clamp(31 - s.Hl2TxAttnDb, 0, 60) | 0x40);
+        }
 
         c14[0] = 0;   // C1 — reserved on this register
         c14[1] = 0;   // C2

--- a/Zeus.Protocol1/ControlFrame.cs
+++ b/Zeus.Protocol1/ControlFrame.cs
@@ -64,6 +64,23 @@ internal static class ControlFrame
         Config = 0x00,
         TxFreq = 0x02,
         RxFreq = 0x04,
+        // RX2 NCO (DDC1). HL2-doc address 0x03 → wire byte 0x06. mi0bot
+        // 4-DDC layout for HL2: DDC1 holds RX2 / second-receiver freq,
+        // unrelated to PS. Zeus has no split-VFO so this just mirrors
+        // VfoAHz; harmless when DDC1 isn't being audio-routed.
+        RxFreq2 = 0x06,
+        // RX3 NCO (DDC2). HL2-doc address 0x04 → wire byte 0x08.
+        // mi0bot's HL2 4-DDC layout uses DDC2 as the **PureSignal RX
+        // feedback** stream (post-PA tap, fed to pscc as the "rx" arg).
+        // mi0bot networkproto1.c case 5 / WriteMainLoop_HL2: NCO = TX
+        // frequency. cmaster.cs:8537 routes psrx=2 when tot=5 (MOX+PS).
+        RxFreq3 = 0x08,
+        // RX4 NCO (DDC3). HL2-doc address 0x05 → wire byte 0x0a.
+        // mi0bot's HL2 4-DDC layout uses DDC3 as the **PureSignal TX
+        // reference** stream (TX-DAC loopback / clean modulator, fed to
+        // pscc as the "tx" arg). NCO = TX frequency. cmaster.cs:8538
+        // routes pstx=3 when tot=5.
+        RxFreq4 = 0x0a,
         DriveFilter = 0x12,
         // Extended RX attenuator + (HL2 only) PureSignal enable bit and LNA
         // mode. Protocol-1 writes these under C0=0x14, the wire-byte
@@ -74,6 +91,18 @@ internal static class ControlFrame
         // the user_dig_out nibble in C3, plus an extended C4 attenuator
         // range (0x40 | (60-Db)) — see WriteAttenuatorPayload.
         Attenuator = 0x14,
+        // ADC assignments + TX step attenuator. HL2-doc address 0x0e →
+        // wire byte 0x1c. C1 carries P1_adc_cntrl bits [7:0] — per-RX
+        // ADC source selector, 2 bits per RX (RX0 → bits[1:0],
+        // RX1 → bits[3:2], …). Mi0bot networkproto1.c case 4 +
+        // netInterface.c:917-930. For HL2 PureSignal during TX,
+        // cntrl1 = 4 (= bits[3:2] = 1) routes DDC1 onto ADC1 (the
+        // dedicated PA-coupler feedback ADC) so pscc sees the post-PA
+        // signal. Without this register, HL2 leaves DDC1 on ADC0 and
+        // pscc never converges (binfo[6]=0x0001 NaN cascade). C2 carries
+        // bits [13:8] (zero for HL2 — only RX0..RX3 used), C3 = ADC TX
+        // step attenuator (we leave 0).
+        AdcRouting = 0x1c,
         // Predistortion config register 0x2b (HL2 PureSignal). C0 wire byte
         // = 0x2b << 1 = 0x56. bits [31:24] = predistortion subindex (C1),
         // bits [19:16] = predistortion value (C2 [3:0]). PR #119 review
@@ -146,7 +175,15 @@ internal static class ControlFrame
 
             case CcRegister.RxFreq:
             case CcRegister.TxFreq:
+            case CcRegister.RxFreq2:
+            case CcRegister.RxFreq3:
+            case CcRegister.RxFreq4:
                 // Frequency payload is a BE uint32 in C1..C4 (doc 02 §4 "Frequency payload").
+                // All five frequency registers (TxFreq + four RX NCOs) carry the
+                // same VfoAHz here — Zeus has no separate TX VFO. During HL2
+                // PS+MOX, mi0bot tunes DDC2 and DDC3 to TX freq, which is the
+                // operator-tuned freq for SSB; for CW, EffectiveLoHz is already
+                // baked into VfoAHz upstream in RadioService.SetVfo.
                 BinaryPrimitives.WriteUInt32BigEndian(cc[1..5], (uint)state.VfoAHz);
                 break;
 
@@ -169,6 +206,10 @@ internal static class ControlFrame
 
             case CcRegister.Attenuator:
                 WriteAttenuatorPayload(cc[1..], in state);
+                break;
+
+            case CcRegister.AdcRouting:
+                WriteAdcRoutingPayload(cc[1..], in state);
                 break;
 
             case CcRegister.Predistortion:
@@ -211,6 +252,25 @@ internal static class ControlFrame
         {
             c14[1] |= 1 << 6;   // C2 bit 6 = puresignal_run
         }
+    }
+
+    private static void WriteAdcRoutingPayload(Span<byte> c14, in CcState s)
+    {
+        // HL2 register 0x0e (C0 wire byte 0x1c). C1 carries the
+        // P1_adc_cntrl byte = per-RX ADC source selector packed 2 bits per
+        // RX (RX0 → bits[1:0], RX1 → bits[3:2], RX2 → bits[5:4],
+        // RX3 → bits[7:6]). 0 = ADC0 (main antenna), 1 = ADC1 (HL2's
+        // dedicated PA-coupler feedback ADC). For HL2 PureSignal during
+        // TX, mi0bot sets cntrl1=4 (= bits[3:2]=1) so DDC1 sources ADC1
+        // and pscc sees the post-PA signal. Outside PS+MOX, all RX → ADC0.
+        // C2 carries cntrl2 (RX4..RX6 — HL2 only has 4 DDCs in this
+        // codepath, leave 0). C3 = ADC[0].tx_step_attn (Zeus drives TX
+        // attenuation through the dedicated 0x14 path, leave 0 here).
+        bool psActive = s.PsEnabled && s.Mox && s.Board == HpsdrBoardKind.HermesLite2;
+        c14[0] = psActive ? (byte)0x04 : (byte)0;  // C1: cntrl1
+        c14[1] = 0;                                 // C2: cntrl2 (high bits of P1_adc_cntrl)
+        c14[2] = 0;                                 // C3: tx_step_attn (unused here)
+        c14[3] = 0;                                 // C4: reserved
     }
 
     private static void WritePredistortionPayload(Span<byte> c14, in CcState s)

--- a/Zeus.Protocol1/IProtocol1Client.cs
+++ b/Zeus.Protocol1/IProtocol1Client.cs
@@ -179,6 +179,18 @@ public interface IProtocol1Client : IDisposable
     void SetPsPredistortion(byte value, byte subindex);
 
     /// <summary>
+    /// HL2 TX-side step attenuator (AD9866 TX PGA) target in dB, range
+    /// -28..+31. Used by <c>PsAutoAttenuateService</c> to bring the PS
+    /// feedback envelope into calcc's [128, 181] convergence window. Out-of-
+    /// range values are clamped to the bounds. Honoured only on HL2 during
+    /// MOX with PS enabled; <see cref="ControlFrame.WriteAttenuatorPayload"/>
+    /// overrides C4 with the mi0bot networkproto1.c:1086-1088 / console.cs:
+    /// 10947-10948 wire encoding (<c>(31 - db) | 0x40</c>). Non-HL2 boards
+    /// store the flag for state-tracking only — the wire stays untouched.
+    /// </summary>
+    void SetHl2TxStepAttenuationDb(int db);
+
+    /// <summary>
     /// 1024-sample paired feedback blocks decoded from the EP6 stream when
     /// PS is armed. TX side comes from the in-flight TX-IQ ring (the
     /// samples we just wrote to the wire); RX side is DDC1, the dedicated

--- a/Zeus.Protocol1/IProtocol1Client.cs
+++ b/Zeus.Protocol1/IProtocol1Client.cs
@@ -152,4 +152,46 @@ public interface IProtocol1Client : IDisposable
     /// flip on if a bench measurement shows it's needed for a particular HL2 gateware.
     /// </summary>
     bool EnableHl2Dither { get; set; }
+
+    /// <summary>
+    /// Arm or disarm PureSignal predistortion on the wire. HL2-only effect:
+    /// flips bit 22 of register 0x0a (= C2 bit 6 of the C0=0x14 frame), adds
+    /// the Predistortion (0x2b) register to the rotation, and asks the
+    /// gateware for 2 receivers so the EP6 packet layout switches to the
+    /// 2-DDC paired form (DDC0 + DDC1, with DDC1 carrying feedback ADC
+    /// samples during MOX). On non-HL2 boards this stores the flag for
+    /// state-tracking only — the wire stays untouched. Issue #172.
+    /// </summary>
+    void SetPsEnabled(bool on);
+
+    /// <summary>
+    /// Current PS arm state, as set by <see cref="SetPsEnabled"/>. Read by
+    /// DspPipelineService to gate the P1 PS feedback pump.
+    /// </summary>
+    bool PsEnabled { get; }
+
+    /// <summary>
+    /// Push the latest WDSP <c>calcc</c> predistortion subindex/value to
+    /// register 0x2b. Subindex (0..255) lands in C1; value (clamped to
+    /// 0..15) lands in C2 [3:0]. Per the HL2 protocol doc, value bits
+    /// [19:16] = C2 [3:0], NOT [23:20] / C2 [7:4] (PR #119 regression).
+    /// </summary>
+    void SetPsPredistortion(byte value, byte subindex);
+
+    /// <summary>
+    /// 1024-sample paired feedback blocks decoded from the EP6 stream when
+    /// PS is armed. TX side comes from the in-flight TX-IQ ring (the
+    /// samples we just wrote to the wire); RX side is DDC1, the dedicated
+    /// feedback-ADC path. Single reader (the DspPipelineService PS pump).
+    /// </summary>
+    ChannelReader<PsFeedbackFrame> PsFeedbackFrames { get; }
+
+    /// <summary>
+    /// Diagnostic: monotonic count of PS-armed paired EP6 packets the RX
+    /// loop has decoded since Start. Surfaces "is the radio actually
+    /// emitting paired DDC0/DDC1 frames after PS arm?" — a value that
+    /// stays at 0 after arming is the canonical "PS armed but no
+    /// feedback samples reached the engine" symptom.
+    /// </summary>
+    long PsPairedPacketCount { get; }
 }

--- a/Zeus.Protocol1/PacketParser.cs
+++ b/Zeus.Protocol1/PacketParser.cs
@@ -348,6 +348,87 @@ internal static class PacketParser
         return true;
     }
 
+    // ---- HL2 PureSignal 4-DDC layout (mi0bot canonical) -------------------
+    // mi0bot's HL2 path always uses nddc=4 during PS+MOX (console.cs:8186-
+    // 8265, networkproto1.c:WriteMainLoop_HL2 case 5/6). The EP6 packet
+    // sample-time-slot is then 26 bytes:
+    //   3I+3Q DDC0 (RX1 audio at RX freq, operator's listening)
+    //   3I+3Q DDC1 (RX2)
+    //   3I+3Q DDC2 (PS-RX feedback at TX freq, mapped to feedback ADC) → pscc rx
+    //   3I+3Q DDC3 (PS-TX reference at TX freq, mapped to feedback ADC) → pscc tx
+    //   2 bytes mic (HL2 has no codec, ignored)
+    // 504 / 26 = 19 sample slots per USB-frame; 38 paired samples per packet
+    // per DDC. cmaster.cs:8537-8538 wires psrx=2 / pstx=3 in the FOUR_DDC
+    // routing — DDC2 → pscc "rx" (Irxbuff/Qrxbuff), DDC3 → pscc "tx"
+    // (Itxbuff/Qtxbuff). DDC0 stays alive on the operator's RX freq the
+    // entire time, so the panadapter and audio don't drop during PS+TX.
+    public const int Hl2Ps4DdcBytesPerSlot = 26;        // 4 × (3I+3Q) + 2 mic
+    public const int Hl2Ps4DdcSamplesPerUsbFrame = UsbPayloadLength / Hl2Ps4DdcBytesPerSlot; // 19
+    public const int Hl2Ps4DdcSamplesPerPacket = Hl2Ps4DdcSamplesPerUsbFrame * 2;           // 38
+
+    /// <summary>
+    /// Decode the four interleaved DDC streams from an HL2 PS-armed 4-DDC
+    /// EP6 packet. Each output buffer must have room for at least
+    /// <c>2 × <see cref="Hl2Ps4DdcSamplesPerPacket"/></c> doubles
+    /// (interleaved I/Q). Returns false on bad framing.
+    /// </summary>
+    public static bool TryParseHl2Ps4DdcPacket(
+        ReadOnlySpan<byte> packet,
+        Span<double> ddc0Out, Span<double> ddc1Out,
+        Span<double> ddc2Out, Span<double> ddc3Out,
+        out uint sequence,
+        out int complexSamples)
+    {
+        sequence = 0;
+        complexSamples = 0;
+
+        if (packet.Length != PacketLength) return false;
+        if (packet[0] != MetisMagic0 || packet[1] != MetisMagic1) return false;
+        if (packet[2] != MetisTypeDataFrame) return false;
+        if (packet[3] != MetisEp6) return false;
+
+        sequence = BinaryPrimitives.ReadUInt32BigEndian(packet[4..8]);
+
+        int needed = 2 * Hl2Ps4DdcSamplesPerPacket;
+        if (ddc0Out.Length < needed || ddc1Out.Length < needed) return false;
+        if (ddc2Out.Length < needed || ddc3Out.Length < needed) return false;
+
+        int wrote = 0;
+        for (int frame = 0; frame < 2; frame++)
+        {
+            int frameStart = MetisHeaderLength + frame * UsbFrameLength;
+            ReadOnlySpan<byte> usb = packet.Slice(frameStart, UsbFrameLength);
+            if (usb[0] != Sync || usb[1] != Sync || usb[2] != Sync) return false;
+
+            ReadOnlySpan<byte> payload = usb[UsbHeaderLength..];
+            for (int g = 0; g < Hl2Ps4DdcSamplesPerUsbFrame; g++)
+            {
+                int off = g * Hl2Ps4DdcBytesPerSlot;
+                int i0 = ReadInt24BigEndian(payload.Slice(off,      3));
+                int q0 = ReadInt24BigEndian(payload.Slice(off + 3,  3));
+                int i1 = ReadInt24BigEndian(payload.Slice(off + 6,  3));
+                int q1 = ReadInt24BigEndian(payload.Slice(off + 9,  3));
+                int i2 = ReadInt24BigEndian(payload.Slice(off + 12, 3));
+                int q2 = ReadInt24BigEndian(payload.Slice(off + 15, 3));
+                int i3 = ReadInt24BigEndian(payload.Slice(off + 18, 3));
+                int q3 = ReadInt24BigEndian(payload.Slice(off + 21, 3));
+                // off+24, off+25 = mic (ignored).
+                ddc0Out[wrote]     = ScaleInt24(i0);
+                ddc0Out[wrote + 1] = ScaleInt24(q0);
+                ddc1Out[wrote]     = ScaleInt24(i1);
+                ddc1Out[wrote + 1] = ScaleInt24(q1);
+                ddc2Out[wrote]     = ScaleInt24(i2);
+                ddc2Out[wrote + 1] = ScaleInt24(q2);
+                ddc3Out[wrote]     = ScaleInt24(i3);
+                ddc3Out[wrote + 1] = ScaleInt24(q3);
+                wrote += 2;
+            }
+        }
+
+        complexSamples = Hl2Ps4DdcSamplesPerPacket;
+        return true;
+    }
+
     /// <summary>
     /// Sequence gap counter state; zero-initialized.
     /// </summary>

--- a/Zeus.Protocol1/PacketParser.cs
+++ b/Zeus.Protocol1/PacketParser.cs
@@ -267,6 +267,88 @@ internal static class PacketParser
     }
 
     /// <summary>
+    /// HL2 PureSignal-armed RX layout (nddc=2). When the host has set
+    /// <c>0x0a[22] = 1</c> and asked for 2 receivers, the gateware
+    /// interleaves DDC0 and DDC1 IQ inside the same EP6 packet:
+    /// each sample slot is 14 bytes (3I+3Q for DDC0, then 3I+3Q for DDC1,
+    /// then 2 mic bytes), giving <c>504 / 14 = 36</c> sample slots per
+    /// USB-frame and 72 paired samples per packet.
+    ///
+    /// During TX with PS armed both DDCs are programmed to the TX freq
+    /// (mi0bot networkproto1.c:990, 1005) — the operator's RX panadapter
+    /// won't update during a PS calibration window, which matches Thetis
+    /// behaviour. DDC1 carries the dedicated feedback ADC samples.
+    /// </summary>
+    public const int Hl2PsBytesPerPair = 14;          // 3I+3Q (DDC0) + 3I+3Q (DDC1) + 2 mic
+    public const int Hl2PsSamplesPerUsbFrame = UsbPayloadLength / Hl2PsBytesPerPair; // 36
+    public const int Hl2PsSamplesPerPacket = Hl2PsSamplesPerUsbFrame * 2;           // 72
+
+    /// <summary>
+    /// Decode the DDC1 (feedback) IQ samples from a PS-armed HL2 EP6 packet.
+    /// Returns true on a well-formed paired packet, false on bad magic /
+    /// length / sync.
+    ///
+    /// <paramref name="ddc0Out"/> / <paramref name="ddc1Out"/> must each
+    /// have room for at least <c>2 × <see cref="Hl2PsSamplesPerPacket"/></c>
+    /// doubles (interleaved I/Q). DDC0 is included so a future caller can
+    /// choose to feed the operator's RX panadapter from it during PS-armed
+    /// non-TX windows; today the DspPipelineService only consumes DDC1.
+    ///
+    /// Telemetry / overload extraction is omitted because PS-armed TX
+    /// windows are typically short (sub-second) and the standard
+    /// 1-DDC parse path already covers the operator's steady-state RX
+    /// telemetry. We don't want to duplicate the AIN3/AIN4 decode here
+    /// and risk drift from the canonical TryParsePacket implementation.
+    /// </summary>
+    public static bool TryParsePsPairedPacket(
+        ReadOnlySpan<byte> packet,
+        Span<double> ddc0Out,
+        Span<double> ddc1Out,
+        out uint sequence,
+        out int complexSamples)
+    {
+        sequence = 0;
+        complexSamples = 0;
+
+        if (packet.Length != PacketLength) return false;
+        if (packet[0] != MetisMagic0 || packet[1] != MetisMagic1) return false;
+        if (packet[2] != MetisTypeDataFrame) return false;
+        if (packet[3] != MetisEp6) return false;
+
+        sequence = BinaryPrimitives.ReadUInt32BigEndian(packet[4..8]);
+
+        int needed = 2 * Hl2PsSamplesPerPacket;
+        if (ddc0Out.Length < needed || ddc1Out.Length < needed) return false;
+
+        int wrote = 0;
+        for (int frame = 0; frame < 2; frame++)
+        {
+            int frameStart = MetisHeaderLength + frame * UsbFrameLength;
+            ReadOnlySpan<byte> usb = packet.Slice(frameStart, UsbFrameLength);
+            if (usb[0] != Sync || usb[1] != Sync || usb[2] != Sync) return false;
+
+            ReadOnlySpan<byte> payload = usb[UsbHeaderLength..];
+            for (int g = 0; g < Hl2PsSamplesPerUsbFrame; g++)
+            {
+                int off = g * Hl2PsBytesPerPair;
+                int i0 = ReadInt24BigEndian(payload.Slice(off,     3));
+                int q0 = ReadInt24BigEndian(payload.Slice(off + 3, 3));
+                int i1 = ReadInt24BigEndian(payload.Slice(off + 6, 3));
+                int q1 = ReadInt24BigEndian(payload.Slice(off + 9, 3));
+                // off+12, off+13 = 16-bit mic sample, ignored (HL2 has no codec).
+                ddc0Out[wrote]     = ScaleInt24(i0);
+                ddc0Out[wrote + 1] = ScaleInt24(q0);
+                ddc1Out[wrote]     = ScaleInt24(i1);
+                ddc1Out[wrote + 1] = ScaleInt24(q1);
+                wrote += 2;
+            }
+        }
+
+        complexSamples = Hl2PsSamplesPerPacket;
+        return true;
+    }
+
+    /// <summary>
     /// Sequence gap counter state; zero-initialized.
     /// </summary>
     public struct SequenceTracker

--- a/Zeus.Protocol1/Protocol1Client.cs
+++ b/Zeus.Protocol1/Protocol1Client.cs
@@ -98,6 +98,14 @@ public sealed class Protocol1Client : IProtocol1Client
     private int _psEnabled;
     private int _psPredistortionValue;     // 0..15 (low nibble of C2)
     private int _psPredistortionSubindex;  // 0..255 (whole C1 byte)
+    // HL2 TX-side step attenuator (AD9866 TX PGA) target in dB. Sentinel
+    // int.MinValue = "untouched" so the C4 byte falls through to the
+    // existing RX-side encoding in WriteAttenuatorPayload — first PS arm
+    // is bit-exact identical to today. PsAutoAttenuateService writes here
+    // each time mi0bot's timer2code SetNewValues state would fire ATTOnTX.
+    // mi0bot console.cs:2084 (UI range -28..+31), networkproto1.c:1086-1088
+    // (wire encoding).
+    private int _hl2TxAttnDb = int.MinValue;
     private long _droppedFrames;
     private long _totalFrames;
 
@@ -473,6 +481,15 @@ public sealed class Protocol1Client : IProtocol1Client
         Interlocked.Exchange(ref _psPredistortionSubindex, subindex);
     }
 
+    public void SetHl2TxStepAttenuationDb(int db)
+    {
+        // Range matches mi0bot console.cs:2084 (udTXStepAttData.Minimum=-28,
+        // Maximum=+31). ControlFrame.WriteAttenuatorPayload then maps to the
+        // 6-bit wire byte via (31 - db) | 0x40 per networkproto1.c:1086-1088.
+        int clamped = Math.Clamp(db, -28, 31);
+        Interlocked.Exchange(ref _hl2TxAttnDb, clamped);
+    }
+
     public void Dispose()
     {
         if (_disposed) return;
@@ -520,7 +537,12 @@ public sealed class Protocol1Client : IProtocol1Client
             PsEnabled: psOn,
             PsPredistortionValue: (byte)Volatile.Read(ref _psPredistortionValue),
             PsPredistortionSubindex: (byte)Volatile.Read(ref _psPredistortionSubindex),
-            NumReceiversMinusOne: numRxMinus1);
+            NumReceiversMinusOne: numRxMinus1,
+            // mi0bot networkproto1.c:1086-1088 — when MOX is on and the
+            // operator/auto-att has set ATTOnTX, swap C4 source from
+            // rx_step_attn to tx_step_attn. Sentinel int.MinValue means
+            // untouched, fall through to the RX-side encoding above.
+            Hl2TxAttnDb: Volatile.Read(ref _hl2TxAttnDb));
     }
 
     private void RxLoop()

--- a/Zeus.Protocol1/Protocol1Client.cs
+++ b/Zeus.Protocol1/Protocol1Client.cs
@@ -160,6 +160,7 @@ public sealed class Protocol1Client : IProtocol1Client
     // gateware is actually emitting paired DDC0/DDC1 frames after PS arm.
     // See lessons_puresignal_convergence_g2_mkii.md for the same idiom on P2.
     private long _psPairedPacketCount;
+    private long _psBlocksEmitted;
     public long PsPairedPacketCount => Interlocked.Read(ref _psPairedPacketCount);
 
     public ChannelReader<PsFeedbackFrame> PsFeedbackFrames => _psFeedbackFrames.Reader;
@@ -203,42 +204,70 @@ public sealed class Protocol1Client : IProtocol1Client
     }
 
     /// <summary>
-    /// Decode a PS-armed paired EP6 packet (HL2 only): DDC1 = feedback
-    /// samples, DDC0 = TX-freq panadapter (currently dropped). Pair each
-    /// DDC1 sample with the most-recently-written TX-IQ sample from the
-    /// ring and accumulate into 1024-sample blocks. On a full block, emit
-    /// a <see cref="PsFeedbackFrame"/> on the channel.
+    /// Decode an HL2 4-DDC PS-armed EP6 packet — mi0bot's canonical layout
+    /// (Thetis console.cs:8186-8265, networkproto1.c:WriteMainLoop_HL2,
+    /// cmaster.cs:8511-8550 FOUR_DDC routing). Stream assignment:
+    ///   DDC0 = RX1 audio (operator's listening freq) → publish to IqFrame
+    ///          channel so the panadapter and audio chain stay alive even
+    ///          while PS is keying.
+    ///   DDC1 = RX2 / unused on HL2 → discarded.
+    ///   DDC2 = PS RX feedback (post-PA tap, NCO=TX freq) → pscc "rx" arg.
+    ///   DDC3 = PS TX reference (TX-DAC loopback, NCO=TX freq) → pscc "tx".
+    /// Pair DDC2 + DDC3 samples 1:1, accumulate 1024 paired complex samples,
+    /// then emit a PsFeedbackFrame for the DspPipelineService pump.
     /// </summary>
-    private void HandlePsPairedRxPacket(ReadOnlySpan<byte> packet)
+    private void HandlePs4DdcPacket(ReadOnlySpan<byte> packet)
     {
-        var ddc0 = ArrayPool<double>.Shared.Rent(2 * PacketParser.Hl2PsSamplesPerPacket);
-        var ddc1 = ArrayPool<double>.Shared.Rent(2 * PacketParser.Hl2PsSamplesPerPacket);
+        int needed = 2 * PacketParser.Hl2Ps4DdcSamplesPerPacket;
+        var ddc0 = ArrayPool<double>.Shared.Rent(needed);
+        var ddc1 = ArrayPool<double>.Shared.Rent(needed);
+        var ddc2 = ArrayPool<double>.Shared.Rent(needed);
+        var ddc3 = ArrayPool<double>.Shared.Rent(needed);
+        bool publishedToIqChannel = false;
         try
         {
-            if (!PacketParser.TryParsePsPairedPacket(packet, ddc0, ddc1, out uint seq, out int samples))
+            if (!PacketParser.TryParseHl2Ps4DdcPacket(
+                    packet, ddc0, ddc1, ddc2, ddc3, out uint seq, out int samples))
                 return;
 
             Interlocked.Increment(ref _psPairedPacketCount);
+            ObserveSequence(seq);
+            Interlocked.Increment(ref _totalFrames);
 
-            // Read the ring tail so each feedback sample is paired with the
-            // best-current TX sample. The ring starts at write-index and
-            // walks backwards; for now we just take the most-recent N
-            // samples in write order (oldest first within the captured
-            // window) since calcc handles fine alignment internally.
-            int write = Volatile.Read(ref _psTxRingWrite);
-            // Start `samples` slots before the most recent write so the
-            // captured window roughly matches the radio's emission window.
-            int read = (write - samples) & (PsTxRingSize - 1);
+            // DDC0 → IqFrame channel — keeps panadapter / audio alive during PS+TX.
+            // Use a fresh rented buffer the channel can own; the ddc0 rental is
+            // freed in the finally block.
+            var rented = ArrayPool<double>.Shared.Rent(2 * samples);
+            new ReadOnlySpan<double>(ddc0, 0, 2 * samples)
+                .CopyTo(rented.AsSpan(0, 2 * samples));
+            int rateHz = (HpsdrSampleRate)Volatile.Read(ref _rate) switch
+            {
+                HpsdrSampleRate.Rate48k => 48_000,
+                HpsdrSampleRate.Rate96k => 96_000,
+                HpsdrSampleRate.Rate192k => 192_000,
+                HpsdrSampleRate.Rate384k => 384_000,
+                _ => 48_000,
+            };
+            var memory = new ReadOnlyMemory<double>(rented, 0, 2 * samples);
+            var frame = new IqFrame(memory, samples, rateHz, seq, NowNs());
+            if (_channel.Writer.TryWrite(frame))
+            {
+                publishedToIqChannel = true; // channel now owns `rented`
+            }
+            else
+            {
+                ArrayPool<double>.Shared.Return(rented);
+            }
 
+            // DDC2 → pscc RX, DDC3 → pscc TX. Mirror mi0bot cmaster.cs:8537-8538
+            // (FOUR_DDC routing for HL2 with tot=5: psrx=2, pstx=3).
             for (int s = 0; s < samples; s++)
             {
-                _psRxI[_psBlockFill] = (float)ddc1[2 * s];
-                _psRxQ[_psBlockFill] = (float)ddc1[2 * s + 1];
-                _psTxI[_psBlockFill] = _psTxRingI[read];
-                _psTxQ[_psBlockFill] = _psTxRingQ[read];
-                read = (read + 1) & (PsTxRingSize - 1);
-
                 if (_psBlockFill == 0) _psBlockStartSeq = seq;
+                _psRxI[_psBlockFill] = (float)ddc2[2 * s];
+                _psRxQ[_psBlockFill] = (float)ddc2[2 * s + 1];
+                _psTxI[_psBlockFill] = (float)ddc3[2 * s];
+                _psTxQ[_psBlockFill] = (float)ddc3[2 * s + 1];
                 _psBlockFill++;
 
                 if (_psBlockFill >= PsFeedbackBlockSize)
@@ -254,6 +283,32 @@ public sealed class Protocol1Client : IProtocol1Client
                     _psFeedbackFrames.Writer.TryWrite(new PsFeedbackFrame(
                         txI, txQ, rxI, rxQ, _psBlockStartSeq));
                     _psBlockFill = 0;
+
+                    // Heartbeat: every Nth block, log block-peak magnitudes so
+                    // we can see whether DDC2 / DDC3 are actually carrying signal.
+                    // PS at 192k emits ~187 blocks/s; log every ~190 = ~1 Hz.
+                    if (++_psBlocksEmitted % 190 == 0)
+                    {
+                        float rxPk = 0f, txPk = 0f, rxAbs = 0f, txAbs = 0f;
+                        for (int j = 0; j < PsFeedbackBlockSize; j++)
+                        {
+                            float ari = Math.Abs(rxI[j]);
+                            float arq = Math.Abs(rxQ[j]);
+                            float ati = Math.Abs(txI[j]);
+                            float atq = Math.Abs(txQ[j]);
+                            if (ari > rxPk) rxPk = ari;
+                            if (arq > rxPk) rxPk = arq;
+                            if (ati > txPk) txPk = ati;
+                            if (atq > txPk) txPk = atq;
+                            rxAbs += ari + arq;
+                            txAbs += ati + atq;
+                        }
+                        _log.LogInformation(
+                            "p1.ps.fb DDC2(rx) peak={RxPk:F4} mean={RxMn:F4} | DDC3(tx) peak={TxPk:F4} mean={TxMn:F4} | blocks={N}",
+                            rxPk, rxAbs / (2 * PsFeedbackBlockSize),
+                            txPk, txAbs / (2 * PsFeedbackBlockSize),
+                            _psBlocksEmitted);
+                    }
                 }
             }
         }
@@ -261,6 +316,9 @@ public sealed class Protocol1Client : IProtocol1Client
         {
             ArrayPool<double>.Shared.Return(ddc0);
             ArrayPool<double>.Shared.Return(ddc1);
+            ArrayPool<double>.Shared.Return(ddc2);
+            ArrayPool<double>.Shared.Return(ddc3);
+            _ = publishedToIqChannel; // suppress unused warning
         }
     }
 
@@ -433,13 +491,18 @@ public sealed class Protocol1Client : IProtocol1Client
             : (byte)(Volatile.Read(ref _drivePct) * 255 / 100);
 
         bool psOn = Volatile.Read(ref _psEnabled) != 0;
+        bool moxOn = Volatile.Read(ref _mox) != 0;
         bool isHl2 = (HpsdrBoardKind)Volatile.Read(ref _boardKind) == HpsdrBoardKind.HermesLite2;
-        // Number of receivers we want the radio to emit. HL2 PS armed needs
-        // two (paired DDC0/DDC1, layout #1 in the protocol doc) so the
-        // gateware re-points DDC1 onto ADC1 (feedback) when MOX is asserted.
-        // PS-off keeps the historic single-RX wire encoding to avoid any
-        // change in the non-PS RX path.
-        byte numRxMinus1 = (byte)(psOn && isHl2 ? 1 : 0);
+        // Number of receivers requested in the Config payload (`(N-1) << 3`
+        // in C4 bits [5:3]). mi0bot's HL2 path (Thetis console.cs:8186-8265)
+        // uses **4 DDCs** during PS+MOX:
+        //   DDC0 → RX1 audio (operator's listening freq, stays alive!)
+        //   DDC1 → RX2 (or unused)
+        //   DDC2 → PS RX feedback (post-PA tap, NCO=TX freq) — pscc "rx"
+        //   DDC3 → PS TX reference (TX-DAC loopback, NCO=TX freq) — pscc "tx"
+        // Outside PS+MOX we stay at single-DDC so the existing 1-DDC EP6
+        // packet shape and parser are bit-exact unchanged.
+        byte numRxMinus1 = (byte)(psOn && isHl2 && moxOn ? 3 : 0);
 
         return new(
             VfoAHz: Interlocked.Read(ref _vfoAHz),
@@ -502,35 +565,26 @@ public sealed class Protocol1Client : IProtocol1Client
 
                 if (n != PacketParser.PacketLength) continue;
 
-                // PS-armed paired-DDC layout (HL2 only). When PsEnabled is
-                // true AND we asked for 2 receivers (NumReceiversMinusOne=1
-                // in the Config frame, which the snapshot computes off of
-                // PsEnabled+HL2), the EP6 byte layout switches to 14
-                // bytes per sample slot (3I+3Q DDC0, 3I+3Q DDC1, 2 mic).
-                // We must decode it with TryParsePsPairedPacket — calling
-                // the 1-DDC parser would misalign and silently feed
-                // garbage IQ to the panadapter. The paired path also
-                // produces the PS-feedback frames that DspPipelineService
-                // pumps into WDSP psccF.
-                //
-                // We gate on PsEnabled at the SnapshotState seam (so
-                // operator un-armed → next packet flips back to 1-DDC).
-                // MOX-state isn't checked here because mi0bot sends the
-                // PS bit and the radio's gateware always honours nddc
-                // from the Config frame — the gateware emits the paired
-                // layout from the moment we ask for 2 RX, irrespective
-                // of TX state.
+                // PS-armed 4-DDC layout (HL2 only). HL2 emits the 26-byte-
+                // per-slot 4-DDC packet shape only when the last Config
+                // frame carried NumReceiversMinusOne=3 — and SnapshotState
+                // only requests that during MOX+PS+HL2. Outside that window
+                // the operator gets normal single-RX 8-byte packets, so the
+                // parser must follow the same gate (mi0bot Thetis
+                // console.cs:8186-8265 — the !_mox branch keeps single-DDC
+                // even with PS armed). Brief mismatch on MOX edges (1-3 ms
+                // while the new Config frame propagates) is tolerated;
+                // pscc resets cleanly on any garbage block via its
+                // MOX-delay state. The 4-DDC handler publishes DDC0 to
+                // the IqFrame channel (RX1 audio + panadapter stay alive)
+                // and DDC2/DDC3 to the PsFeedbackFrame channel.
                 if (Volatile.Read(ref _psEnabled) != 0
+                    && Volatile.Read(ref _mox) != 0
                     && (HpsdrBoardKind)Volatile.Read(ref _boardKind) == HpsdrBoardKind.HermesLite2)
                 {
-                    HandlePsPairedRxPacket(buffer.AsSpan(0, n));
-                    Interlocked.Increment(ref _totalFrames);
-                    // PS-armed packets do not flow into the operator's
-                    // RX panadapter (DDC0 is pointed at TX freq and the
-                    // user's RX is paused for the PS calibration window
-                    // — same as Thetis). Skip the IqFrame publish path.
+                    HandlePs4DdcPacket(buffer.AsSpan(0, n));
                     // Pace the TX loop off the same RX clock so MOX TX
-                    // continues to fire.
+                    // continues to fire while PS is armed.
                     var psRateHz = (HpsdrSampleRate)Volatile.Read(ref _rate) switch
                     {
                         HpsdrSampleRate.Rate48k => 48_000,
@@ -539,7 +593,13 @@ public sealed class Protocol1Client : IProtocol1Client
                         HpsdrSampleRate.Rate384k => 384_000,
                         _ => 48_000,
                     };
-                    int psTxDivider = Math.Max(1, psRateHz / 48_000);
+                    // 4-DDC packets are 38 paired samples/packet, so the
+                    // RX pkt rate is rateHz/38 (vs rateHz/126 for N=1).
+                    // Target TX pkt rate stays at 48k/126 ≈ 381. Rounded
+                    // division avoids the integer-truncation overshoot we
+                    // had earlier.
+                    double rxPktsPerSec = psRateHz / (double)PacketParser.Hl2Ps4DdcSamplesPerPacket;
+                    int psTxDivider = Math.Max(1, (int)Math.Round(rxPktsPerSec / 381.0));
                     if ((++rxPktCounter % psTxDivider) == 0)
                     {
                         try { _txSignal.Release(); } catch (SemaphoreFullException) { }
@@ -653,46 +713,71 @@ public sealed class Protocol1Client : IProtocol1Client
 
     /// <summary>
     /// Round-robin register selector. When <paramref name="psArmed"/> is true
-    /// the rotation is widened to 8 phases and includes the
-    /// Predistortion register (0x2b) so calcc subindex/value writes reach
-    /// the radio without starving frequency / drive updates. The Attenuator
-    /// register stays in rotation (it carries the puresignal_run bit on
-    /// HL2 — keeping it visible re-asserts the bit at every cycle).
-    ///
-    /// Issue #172. mi0bot writes the predistortion bytes opportunistically
-    /// inside its WriteMainLoop_HL2; pinning a phase slot here gives WDSP's
-    /// calcc state-machine a deterministic ack window.
+    /// the rotation is widened to 8 phases and includes the new HL2-PS
+    /// registers — RxFreq2 (DDC1 NCO) and AdcRouting (per-RX→ADC selector,
+    /// HL2-doc 0x0e). Without RxFreq2 the second DDC sits at 0 Hz; without
+    /// AdcRouting it samples ADC0 instead of the dedicated PA-coupler ADC1
+    /// — pscc would then see no useful feedback and binfo[6] would NaN out
+    /// (Issue #172, observed before this fix). Mirrors mi0bot
+    /// networkproto1.c:WriteMainLoop_HL2 case 2/3/4.
     /// </summary>
     internal static (ControlFrame.CcRegister first, ControlFrame.CcRegister second) PhaseRegisters(
         int phase, bool mox, bool psArmed)
     {
         if (psArmed)
         {
-            int q = phase & 0x7;
+            int q = phase & 0xF;
             if (mox)
             {
+                // PS+MOX (HL2 4-DDC). Every 16-frame window emits each of
+                // the seven PS-critical registers (Config, TxFreq, RxFreq,
+                // RxFreq2, RxFreq3, RxFreq4, AdcRouting, Attenuator,
+                // DriveFilter) at least twice. RxFreq3/RxFreq4 carry the
+                // pscc TX/RX NCO frequencies — without them DDC2 and DDC3
+                // sit at 0 Hz and pscc gets DC. Predistortion is omitted;
+                // mi0bot doesn't emit it for HL2.
                 return q switch
                 {
-                    0 => (ControlFrame.CcRegister.TxFreq,        ControlFrame.CcRegister.RxFreq),
-                    1 => (ControlFrame.CcRegister.TxFreq,        ControlFrame.CcRegister.DriveFilter),
-                    2 => (ControlFrame.CcRegister.Attenuator,    ControlFrame.CcRegister.TxFreq),
-                    3 => (ControlFrame.CcRegister.TxFreq,        ControlFrame.CcRegister.Predistortion),
-                    4 => (ControlFrame.CcRegister.TxFreq,        ControlFrame.CcRegister.Config),
-                    5 => (ControlFrame.CcRegister.Predistortion, ControlFrame.CcRegister.TxFreq),
-                    6 => (ControlFrame.CcRegister.Attenuator,    ControlFrame.CcRegister.TxFreq),
-                    _ => (ControlFrame.CcRegister.TxFreq,        ControlFrame.CcRegister.RxFreq),
+                    0  => (ControlFrame.CcRegister.TxFreq,     ControlFrame.CcRegister.RxFreq3),
+                    1  => (ControlFrame.CcRegister.TxFreq,     ControlFrame.CcRegister.RxFreq4),
+                    2  => (ControlFrame.CcRegister.Attenuator, ControlFrame.CcRegister.TxFreq),
+                    3  => (ControlFrame.CcRegister.TxFreq,     ControlFrame.CcRegister.DriveFilter),
+                    4  => (ControlFrame.CcRegister.RxFreq,     ControlFrame.CcRegister.RxFreq3),
+                    5  => (ControlFrame.CcRegister.RxFreq2,    ControlFrame.CcRegister.RxFreq4),
+                    6  => (ControlFrame.CcRegister.AdcRouting, ControlFrame.CcRegister.TxFreq),
+                    7  => (ControlFrame.CcRegister.Config,     ControlFrame.CcRegister.TxFreq),
+                    8  => (ControlFrame.CcRegister.TxFreq,     ControlFrame.CcRegister.RxFreq3),
+                    9  => (ControlFrame.CcRegister.RxFreq,     ControlFrame.CcRegister.RxFreq4),
+                    10 => (ControlFrame.CcRegister.Attenuator, ControlFrame.CcRegister.RxFreq3),
+                    11 => (ControlFrame.CcRegister.TxFreq,     ControlFrame.CcRegister.DriveFilter),
+                    12 => (ControlFrame.CcRegister.RxFreq2,    ControlFrame.CcRegister.RxFreq3),
+                    13 => (ControlFrame.CcRegister.RxFreq4,    ControlFrame.CcRegister.TxFreq),
+                    14 => (ControlFrame.CcRegister.AdcRouting, ControlFrame.CcRegister.RxFreq3),
+                    _  => (ControlFrame.CcRegister.Config,     ControlFrame.CcRegister.RxFreq4),
                 };
             }
+            // PS armed but RX-only: cache RxFreq3 / RxFreq4 / AdcRouting so
+            // the radio has them ready for the next MOX edge. Number-of-
+            // receivers in Config is 0 here so DDC2/DDC3 aren't streaming;
+            // these writes are harmless.
             return q switch
             {
-                0 => (ControlFrame.CcRegister.Config,        ControlFrame.CcRegister.RxFreq),
-                1 => (ControlFrame.CcRegister.RxFreq,        ControlFrame.CcRegister.DriveFilter),
-                2 => (ControlFrame.CcRegister.Attenuator,    ControlFrame.CcRegister.RxFreq),
-                3 => (ControlFrame.CcRegister.RxFreq,        ControlFrame.CcRegister.Predistortion),
-                4 => (ControlFrame.CcRegister.RxFreq,        ControlFrame.CcRegister.Config),
-                5 => (ControlFrame.CcRegister.Predistortion, ControlFrame.CcRegister.RxFreq),
-                6 => (ControlFrame.CcRegister.Attenuator,    ControlFrame.CcRegister.RxFreq),
-                _ => (ControlFrame.CcRegister.RxFreq,        ControlFrame.CcRegister.Config),
+                0  => (ControlFrame.CcRegister.Config,     ControlFrame.CcRegister.RxFreq),
+                1  => (ControlFrame.CcRegister.RxFreq,     ControlFrame.CcRegister.DriveFilter),
+                2  => (ControlFrame.CcRegister.Attenuator, ControlFrame.CcRegister.RxFreq),
+                3  => (ControlFrame.CcRegister.RxFreq,     ControlFrame.CcRegister.RxFreq2),
+                4  => (ControlFrame.CcRegister.RxFreq,     ControlFrame.CcRegister.RxFreq3),
+                5  => (ControlFrame.CcRegister.RxFreq,     ControlFrame.CcRegister.RxFreq4),
+                6  => (ControlFrame.CcRegister.AdcRouting, ControlFrame.CcRegister.RxFreq),
+                7  => (ControlFrame.CcRegister.Attenuator, ControlFrame.CcRegister.RxFreq),
+                8  => (ControlFrame.CcRegister.RxFreq,     ControlFrame.CcRegister.Config),
+                9  => (ControlFrame.CcRegister.RxFreq,     ControlFrame.CcRegister.DriveFilter),
+                10 => (ControlFrame.CcRegister.RxFreq3,    ControlFrame.CcRegister.RxFreq4),
+                11 => (ControlFrame.CcRegister.RxFreq,     ControlFrame.CcRegister.Attenuator),
+                12 => (ControlFrame.CcRegister.RxFreq,     ControlFrame.CcRegister.RxFreq3),
+                13 => (ControlFrame.CcRegister.RxFreq,     ControlFrame.CcRegister.RxFreq4),
+                14 => (ControlFrame.CcRegister.RxFreq,     ControlFrame.CcRegister.AdcRouting),
+                _  => (ControlFrame.CcRegister.RxFreq,     ControlFrame.CcRegister.Config),
             };
         }
 
@@ -742,7 +827,7 @@ public sealed class Protocol1Client : IProtocol1Client
                 // doesn't lose its slot.
                 bool psArmed = state.PsEnabled && state.Board == HpsdrBoardKind.HermesLite2;
                 var (first, second) = PhaseRegisters(phase, state.Mox, psArmed);
-                phase = (phase + 1) & (psArmed ? 0x7 : 0x3);
+                phase = (phase + 1) & (psArmed ? 0xF : 0x3);
                 ControlFrame.BuildDataPacket(buf, sendSeq++, first, second, in state, _txIqSource);
                 rateWindowPkts++;
                 var nowUtc = DateTime.UtcNow;

--- a/Zeus.Protocol1/Protocol1Client.cs
+++ b/Zeus.Protocol1/Protocol1Client.cs
@@ -90,6 +90,14 @@ public sealed class Protocol1Client : IProtocol1Client
     private int _driveByteOverride = -1;
     private int _ocTxMask;      // user OC pin mask for TX (low 7 bits)
     private int _ocRxMask;      // user OC pin mask for RX (low 7 bits)
+    // PureSignal master arm. When set on HL2 the C0=0x14 (Attenuator) frame
+    // also writes puresignal_run into C2 bit 6, the predistortion register
+    // is added to the rotation, and (when MOX is on) two receivers are
+    // requested in the Config frame so the gateware emits paired DDC0/DDC1
+    // IQ. Issue #172. mi0bot networkproto1.c:1102, console.cs:8483-8503.
+    private int _psEnabled;
+    private int _psPredistortionValue;     // 0..15 (low nibble of C2)
+    private int _psPredistortionSubindex;  // 0..255 (whole C1 byte)
     private long _droppedFrames;
     private long _totalFrames;
 
@@ -108,7 +116,13 @@ public sealed class Protocol1Client : IProtocol1Client
     public Protocol1Client(ILogger<Protocol1Client>? logger = null, ITxIqSource? iqSource = null)
     {
         _log = logger ?? NullLogger<Protocol1Client>.Instance;
-        _txIqSource = iqSource ?? new TestToneGenerator();
+        // Wrap the operator's IQ source in a tap so we can mirror every
+        // transmitted sample into the PS-feedback TX-side ring without
+        // changing the WriteUsbFrame signature. The tap is cheap (one
+        // s16→float and a ring-index bump per sample) and a no-op when
+        // PS isn't armed (the consumer side checks PsEnabled before
+        // touching the ring contents).
+        _txIqSource = new PsTapIqSource(iqSource ?? new TestToneGenerator(), this);
         _channel = Channel.CreateBounded<IqFrame>(new BoundedChannelOptions(DefaultFrameChannelCapacity)
         {
             FullMode = BoundedChannelFullMode.DropOldest,
@@ -123,6 +137,132 @@ public sealed class Protocol1Client : IProtocol1Client
 
     public event Action<TelemetryReading>? TelemetryReceived;
     public event Action<AdcOverloadStatus>? AdcOverloadObserved;
+
+    // ---- PureSignal feedback (HL2-only, P1) -------------------------
+    // 1024-sample paired blocks fed to WDSP `psccF`. Mirrors P2's
+    // Protocol2Client.PsFeedbackFrames channel so DspPipelineService can
+    // pump either protocol with the same code. Issue #172.
+    //
+    // TX side = the operator's TX IQ as we wrote it to the wire (snapshotted
+    // from _txIqSource on every TX packet). RX side = DDC1 samples decoded
+    // from the EP6 RX stream when PsEnabled && Mox && nddc==2 (HL2 paired
+    // layout, mi0bot networkproto1.c:990,1005).
+    private const int PsFeedbackBlockSize = 1024;
+    private readonly Channel<PsFeedbackFrame> _psFeedbackFrames = Channel.CreateUnbounded<PsFeedbackFrame>(
+        new UnboundedChannelOptions { SingleReader = true, SingleWriter = true });
+    private readonly float[] _psTxI = new float[PsFeedbackBlockSize];
+    private readonly float[] _psTxQ = new float[PsFeedbackBlockSize];
+    private readonly float[] _psRxI = new float[PsFeedbackBlockSize];
+    private readonly float[] _psRxQ = new float[PsFeedbackBlockSize];
+    private int _psBlockFill;
+    private ulong _psBlockStartSeq;
+    // Diagnostic counter — tells the operator (via 1-Hz log line) whether the
+    // gateware is actually emitting paired DDC0/DDC1 frames after PS arm.
+    // See lessons_puresignal_convergence_g2_mkii.md for the same idiom on P2.
+    private long _psPairedPacketCount;
+    public long PsPairedPacketCount => Interlocked.Read(ref _psPairedPacketCount);
+
+    public ChannelReader<PsFeedbackFrame> PsFeedbackFrames => _psFeedbackFrames.Reader;
+
+    // Small ring of the most-recent TX-IQ samples we wrote to the wire.
+    // When PS+MOX is on, the RX loop pulls a "TX side" out of this ring
+    // for each DDC1 feedback sample so the calcc state machine receives
+    // paired (tx_ref, rx_obs) blocks. The ring holds two PS feedback blocks
+    // worth of samples (2048) so the natural latency between writing an IQ
+    // sample and seeing its post-PA reflection on DDC1 (HL2 + external
+    // coupler total round-trip ≈ 1-2 ms or ~50-200 samples at 48 kHz)
+    // is comfortably absorbed without overwriting before the read.
+    //
+    // Aligning ring read offset with ring write offset is approximate —
+    // mi0bot/pihpsdr both rely on calcc's own coarse alignment search to
+    // recover the exact group-delay, and the operator-tunable "Amp delay"
+    // setting (PsAmpDelayNs) is exactly there to nudge it. So we read
+    // from the most-recent write minus a fixed lookback (currently 0 —
+    // calcc handles the rest).
+    private const int PsTxRingSize = 2048;
+    private readonly float[] _psTxRingI = new float[PsTxRingSize];
+    private readonly float[] _psTxRingQ = new float[PsTxRingSize];
+    private int _psTxRingWrite;
+
+    /// <summary>
+    /// Capture one TX-IQ sample-pair just after it has been written into the
+    /// EP2 payload. Called from <see cref="ControlFrame.WriteUsbFrame"/>
+    /// indirectly via the <see cref="ITxIqSource"/> seam — see
+    /// <see cref="ApplyPsTap"/>.
+    /// </summary>
+    internal void RecordPsTxSample(short i, short q)
+    {
+        // s16 → float in [-1, +1].
+        const float scale = 1f / 32768f;
+        int idx = _psTxRingWrite;
+        _psTxRingI[idx] = i * scale;
+        _psTxRingQ[idx] = q * scale;
+        idx = (idx + 1) & (PsTxRingSize - 1); // PsTxRingSize is power of 2.
+        // Volatile write so the RX-thread reader observes ordered writes.
+        Volatile.Write(ref _psTxRingWrite, idx);
+    }
+
+    /// <summary>
+    /// Decode a PS-armed paired EP6 packet (HL2 only): DDC1 = feedback
+    /// samples, DDC0 = TX-freq panadapter (currently dropped). Pair each
+    /// DDC1 sample with the most-recently-written TX-IQ sample from the
+    /// ring and accumulate into 1024-sample blocks. On a full block, emit
+    /// a <see cref="PsFeedbackFrame"/> on the channel.
+    /// </summary>
+    private void HandlePsPairedRxPacket(ReadOnlySpan<byte> packet)
+    {
+        var ddc0 = ArrayPool<double>.Shared.Rent(2 * PacketParser.Hl2PsSamplesPerPacket);
+        var ddc1 = ArrayPool<double>.Shared.Rent(2 * PacketParser.Hl2PsSamplesPerPacket);
+        try
+        {
+            if (!PacketParser.TryParsePsPairedPacket(packet, ddc0, ddc1, out uint seq, out int samples))
+                return;
+
+            Interlocked.Increment(ref _psPairedPacketCount);
+
+            // Read the ring tail so each feedback sample is paired with the
+            // best-current TX sample. The ring starts at write-index and
+            // walks backwards; for now we just take the most-recent N
+            // samples in write order (oldest first within the captured
+            // window) since calcc handles fine alignment internally.
+            int write = Volatile.Read(ref _psTxRingWrite);
+            // Start `samples` slots before the most recent write so the
+            // captured window roughly matches the radio's emission window.
+            int read = (write - samples) & (PsTxRingSize - 1);
+
+            for (int s = 0; s < samples; s++)
+            {
+                _psRxI[_psBlockFill] = (float)ddc1[2 * s];
+                _psRxQ[_psBlockFill] = (float)ddc1[2 * s + 1];
+                _psTxI[_psBlockFill] = _psTxRingI[read];
+                _psTxQ[_psBlockFill] = _psTxRingQ[read];
+                read = (read + 1) & (PsTxRingSize - 1);
+
+                if (_psBlockFill == 0) _psBlockStartSeq = seq;
+                _psBlockFill++;
+
+                if (_psBlockFill >= PsFeedbackBlockSize)
+                {
+                    var txI = new float[PsFeedbackBlockSize];
+                    var txQ = new float[PsFeedbackBlockSize];
+                    var rxI = new float[PsFeedbackBlockSize];
+                    var rxQ = new float[PsFeedbackBlockSize];
+                    Array.Copy(_psTxI, txI, PsFeedbackBlockSize);
+                    Array.Copy(_psTxQ, txQ, PsFeedbackBlockSize);
+                    Array.Copy(_psRxI, rxI, PsFeedbackBlockSize);
+                    Array.Copy(_psRxQ, rxQ, PsFeedbackBlockSize);
+                    _psFeedbackFrames.Writer.TryWrite(new PsFeedbackFrame(
+                        txI, txQ, rxI, rxQ, _psBlockStartSeq));
+                    _psBlockFill = 0;
+                }
+            }
+        }
+        finally
+        {
+            ArrayPool<double>.Shared.Return(ddc0);
+            ArrayPool<double>.Shared.Return(ddc1);
+        }
+    }
 
     public bool EnableHl2Dither
     {
@@ -242,6 +382,39 @@ public sealed class Protocol1Client : IProtocol1Client
         Interlocked.Exchange(ref _ocRxMask, rxMask & 0x7F);
     }
 
+    /// <summary>
+    /// Arm or disarm PureSignal on the wire. HL2-only effect: the C0=0x14
+    /// (Attenuator) frame OR's puresignal_run into C2 bit 6, and the
+    /// Predistortion register is added to the round-robin so calcc's
+    /// subindex/value are kept in sync. The packet decoder switches to
+    /// the 2-DDC paired layout only while PsEnabled is true AND MOX is
+    /// asserted (matching mi0bot networkproto1.c:990, 1005). Reverts to
+    /// 1-DDC standard layout otherwise.
+    ///
+    /// On non-HL2 boards this is a no-op on the wire — Protocol 2 has its
+    /// own PS path via Protocol2Client.SetPsFeedbackEnabled. Storing the
+    /// flag locally keeps the StateDto / engine in sync regardless of
+    /// board so the round-tripping pumps don't get out of sync.
+    /// </summary>
+    public void SetPsEnabled(bool on)
+    {
+        Interlocked.Exchange(ref _psEnabled, on ? 1 : 0);
+    }
+
+    public bool PsEnabled => Volatile.Read(ref _psEnabled) != 0;
+
+    /// <summary>
+    /// Set the HL2 predistortion register payload (0x2b). value is the 4-bit
+    /// PS-value (clamped to 0..15), subindex is the 8-bit subindex written
+    /// to C1. Driven by WDSP's calcc state machine via the engine's
+    /// SetPsControl pump; see DspPipelineService.
+    /// </summary>
+    public void SetPsPredistortion(byte value, byte subindex)
+    {
+        Interlocked.Exchange(ref _psPredistortionValue, value & 0x0F);
+        Interlocked.Exchange(ref _psPredistortionSubindex, subindex);
+    }
+
     public void Dispose()
     {
         if (_disposed) return;
@@ -259,6 +432,15 @@ public sealed class Protocol1Client : IProtocol1Client
             // RadioService hasn't pushed a calibrated byte (tests / legacy).
             : (byte)(Volatile.Read(ref _drivePct) * 255 / 100);
 
+        bool psOn = Volatile.Read(ref _psEnabled) != 0;
+        bool isHl2 = (HpsdrBoardKind)Volatile.Read(ref _boardKind) == HpsdrBoardKind.HermesLite2;
+        // Number of receivers we want the radio to emit. HL2 PS armed needs
+        // two (paired DDC0/DDC1, layout #1 in the protocol doc) so the
+        // gateware re-points DDC1 onto ADC1 (feedback) when MOX is asserted.
+        // PS-off keeps the historic single-RX wire encoding to avoid any
+        // change in the non-PS RX path.
+        byte numRxMinus1 = (byte)(psOn && isHl2 ? 1 : 0);
+
         return new(
             VfoAHz: Interlocked.Read(ref _vfoAHz),
             Rate: (HpsdrSampleRate)Volatile.Read(ref _rate),
@@ -271,7 +453,11 @@ public sealed class Protocol1Client : IProtocol1Client
             HasN2adr: Volatile.Read(ref _hasN2adr) != 0,
             DriveLevel: drive,
             UserOcTxMask: (byte)Volatile.Read(ref _ocTxMask),
-            UserOcRxMask: (byte)Volatile.Read(ref _ocRxMask));
+            UserOcRxMask: (byte)Volatile.Read(ref _ocRxMask),
+            PsEnabled: psOn,
+            PsPredistortionValue: (byte)Volatile.Read(ref _psPredistortionValue),
+            PsPredistortionSubindex: (byte)Volatile.Read(ref _psPredistortionSubindex),
+            NumReceiversMinusOne: numRxMinus1);
     }
 
     private void RxLoop()
@@ -315,6 +501,51 @@ public sealed class Protocol1Client : IProtocol1Client
                 consecutiveTimeouts = 0;
 
                 if (n != PacketParser.PacketLength) continue;
+
+                // PS-armed paired-DDC layout (HL2 only). When PsEnabled is
+                // true AND we asked for 2 receivers (NumReceiversMinusOne=1
+                // in the Config frame, which the snapshot computes off of
+                // PsEnabled+HL2), the EP6 byte layout switches to 14
+                // bytes per sample slot (3I+3Q DDC0, 3I+3Q DDC1, 2 mic).
+                // We must decode it with TryParsePsPairedPacket — calling
+                // the 1-DDC parser would misalign and silently feed
+                // garbage IQ to the panadapter. The paired path also
+                // produces the PS-feedback frames that DspPipelineService
+                // pumps into WDSP psccF.
+                //
+                // We gate on PsEnabled at the SnapshotState seam (so
+                // operator un-armed → next packet flips back to 1-DDC).
+                // MOX-state isn't checked here because mi0bot sends the
+                // PS bit and the radio's gateware always honours nddc
+                // from the Config frame — the gateware emits the paired
+                // layout from the moment we ask for 2 RX, irrespective
+                // of TX state.
+                if (Volatile.Read(ref _psEnabled) != 0
+                    && (HpsdrBoardKind)Volatile.Read(ref _boardKind) == HpsdrBoardKind.HermesLite2)
+                {
+                    HandlePsPairedRxPacket(buffer.AsSpan(0, n));
+                    Interlocked.Increment(ref _totalFrames);
+                    // PS-armed packets do not flow into the operator's
+                    // RX panadapter (DDC0 is pointed at TX freq and the
+                    // user's RX is paused for the PS calibration window
+                    // — same as Thetis). Skip the IqFrame publish path.
+                    // Pace the TX loop off the same RX clock so MOX TX
+                    // continues to fire.
+                    var psRateHz = (HpsdrSampleRate)Volatile.Read(ref _rate) switch
+                    {
+                        HpsdrSampleRate.Rate48k => 48_000,
+                        HpsdrSampleRate.Rate96k => 96_000,
+                        HpsdrSampleRate.Rate192k => 192_000,
+                        HpsdrSampleRate.Rate384k => 384_000,
+                        _ => 48_000,
+                    };
+                    int psTxDivider = Math.Max(1, psRateHz / 48_000);
+                    if ((++rxPktCounter % psTxDivider) == 0)
+                    {
+                        try { _txSignal.Release(); } catch (SemaphoreFullException) { }
+                    }
+                    continue;
+                }
 
                 var rented = ArrayPool<double>.Shared.Rent(2 * PacketParser.ComplexSamplesPerPacket);
                 bool ok = PacketParser.TryParsePacket(
@@ -418,7 +649,53 @@ public sealed class Protocol1Client : IProtocol1Client
     // TxFreq when Split/RIT are off, which matches what we do here since Zeus
     // has no separate TX VFO yet.
     internal static (ControlFrame.CcRegister first, ControlFrame.CcRegister second) PhaseRegisters(int phase, bool mox)
+        => PhaseRegisters(phase, mox, psArmed: false);
+
+    /// <summary>
+    /// Round-robin register selector. When <paramref name="psArmed"/> is true
+    /// the rotation is widened to 8 phases and includes the
+    /// Predistortion register (0x2b) so calcc subindex/value writes reach
+    /// the radio without starving frequency / drive updates. The Attenuator
+    /// register stays in rotation (it carries the puresignal_run bit on
+    /// HL2 — keeping it visible re-asserts the bit at every cycle).
+    ///
+    /// Issue #172. mi0bot writes the predistortion bytes opportunistically
+    /// inside its WriteMainLoop_HL2; pinning a phase slot here gives WDSP's
+    /// calcc state-machine a deterministic ack window.
+    /// </summary>
+    internal static (ControlFrame.CcRegister first, ControlFrame.CcRegister second) PhaseRegisters(
+        int phase, bool mox, bool psArmed)
     {
+        if (psArmed)
+        {
+            int q = phase & 0x7;
+            if (mox)
+            {
+                return q switch
+                {
+                    0 => (ControlFrame.CcRegister.TxFreq,        ControlFrame.CcRegister.RxFreq),
+                    1 => (ControlFrame.CcRegister.TxFreq,        ControlFrame.CcRegister.DriveFilter),
+                    2 => (ControlFrame.CcRegister.Attenuator,    ControlFrame.CcRegister.TxFreq),
+                    3 => (ControlFrame.CcRegister.TxFreq,        ControlFrame.CcRegister.Predistortion),
+                    4 => (ControlFrame.CcRegister.TxFreq,        ControlFrame.CcRegister.Config),
+                    5 => (ControlFrame.CcRegister.Predistortion, ControlFrame.CcRegister.TxFreq),
+                    6 => (ControlFrame.CcRegister.Attenuator,    ControlFrame.CcRegister.TxFreq),
+                    _ => (ControlFrame.CcRegister.TxFreq,        ControlFrame.CcRegister.RxFreq),
+                };
+            }
+            return q switch
+            {
+                0 => (ControlFrame.CcRegister.Config,        ControlFrame.CcRegister.RxFreq),
+                1 => (ControlFrame.CcRegister.RxFreq,        ControlFrame.CcRegister.DriveFilter),
+                2 => (ControlFrame.CcRegister.Attenuator,    ControlFrame.CcRegister.RxFreq),
+                3 => (ControlFrame.CcRegister.RxFreq,        ControlFrame.CcRegister.Predistortion),
+                4 => (ControlFrame.CcRegister.RxFreq,        ControlFrame.CcRegister.Config),
+                5 => (ControlFrame.CcRegister.Predistortion, ControlFrame.CcRegister.RxFreq),
+                6 => (ControlFrame.CcRegister.Attenuator,    ControlFrame.CcRegister.RxFreq),
+                _ => (ControlFrame.CcRegister.RxFreq,        ControlFrame.CcRegister.Config),
+            };
+        }
+
         int p = phase & 0x3;
         if (mox)
         {
@@ -458,8 +735,14 @@ public sealed class Protocol1Client : IProtocol1Client
             {
                 await _txSignal.WaitAsync(ct).ConfigureAwait(false);
                 var state = SnapshotState();
-                var (first, second) = PhaseRegisters(phase, state.Mox);
-                phase = (phase + 1) & 0x3;
+                // PS-armed rotation widens to 8 phases to fit the
+                // Predistortion (0x2b) register without crowding TxFreq.
+                // The phase counter wraps modulo whichever rotation is in
+                // effect, recomputed every tick so a mid-stream PS toggle
+                // doesn't lose its slot.
+                bool psArmed = state.PsEnabled && state.Board == HpsdrBoardKind.HermesLite2;
+                var (first, second) = PhaseRegisters(phase, state.Mox, psArmed);
+                phase = (phase + 1) & (psArmed ? 0x7 : 0x3);
                 ControlFrame.BuildDataPacket(buf, sendSeq++, first, second, in state, _txIqSource);
                 rateWindowPkts++;
                 var nowUtc = DateTime.UtcNow;
@@ -525,4 +808,26 @@ public sealed class Protocol1Client : IProtocol1Client
 
     private static long NowNs() =>
         (long)(Stopwatch.GetTimestamp() * (1_000_000_000.0 / Stopwatch.Frequency));
+
+    /// <summary>
+    /// Pass-through IQ source that mirrors every sample into the owning
+    /// client's PS-TX ring. Cheap regardless of PS arm state — the ring
+    /// reader checks PsEnabled before consuming. Issue #172.
+    /// </summary>
+    private sealed class PsTapIqSource : ITxIqSource
+    {
+        private readonly ITxIqSource _inner;
+        private readonly Protocol1Client _owner;
+        public PsTapIqSource(ITxIqSource inner, Protocol1Client owner)
+        {
+            _inner = inner;
+            _owner = owner;
+        }
+        public (short i, short q) Next(double amplitude)
+        {
+            var (i, q) = _inner.Next(amplitude);
+            _owner.RecordPsTxSample(i, q);
+            return (i, q);
+        }
+    }
 }

--- a/Zeus.Protocol1/PsFeedbackFrame.cs
+++ b/Zeus.Protocol1/PsFeedbackFrame.cs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// HL2 PureSignal feedback path informed by mi0bot/openhpsdr-thetis (the
+// HL2-specific Thetis fork) and DL1YCF/pihpsdr — see
+// docs/references/protocol-1/hermes-lite2-protocol.md "PureSignal feedback
+// path" section.
+
+namespace Zeus.Protocol1;
+
+/// <summary>
+/// One 1024-sample paired feedback block destined for WDSP <c>psccF</c>,
+/// produced by <see cref="Protocol1Client"/> when the operator arms PS
+/// against an HL2 + external coupler. Mirrors the shape of
+/// <c>Zeus.Protocol2.PsFeedbackFrame</c> so the
+/// DspPipelineService pump can treat both protocols uniformly.
+///
+/// On HL2 (this protocol) the TX-side reference is the operator's TX-IQ as
+/// written to the radio's DUC (NOT a coupler tap — there isn't one on
+/// HL2). The RX side comes from the dedicated feedback ADC (ADC1) routed
+/// through DDC1 when the gateware honours <c>0x0a[22] = 1</c> and
+/// MOX is asserted. See
+/// docs/references/protocol-1/hermes-lite2-protocol.md "PureSignal
+/// feedback path" for the wire mechanics.
+///
+/// SeqHint is the radio's EP6 sequence at the start of the block,
+/// useful for diagnostic logging when the cal converges slowly. Not
+/// used by WDSP.
+/// </summary>
+public readonly record struct PsFeedbackFrame(
+    float[] TxI,
+    float[] TxQ,
+    float[] RxI,
+    float[] RxQ,
+    ulong SeqHint);

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -325,6 +325,21 @@ public class DspPipelineService : BackgroundService
         RaiseEngineChanged(wdsp);
 
         StartIqPump(client);
+        StartPsFeedbackPumpP1(client);
+        // Force the next OnRadioStateChanged to re-push every PS field into
+        // the freshly-opened WdspDspEngine instance — same rationale as the
+        // P2 reconnect path. Without this, a P1 reconnect leaves the engine
+        // sitting at field defaults (hwPeak=0.4072) and calcc never sees
+        // the operator's HL2 0.233 / hardware-correct numbers.
+        _psResyncRequired = true;
+        _appliedTxMonitorEnabled = false;
+        // Apply the per-board PS HW peak default so the engine sees the
+        // right curve scale before the operator arms PS. Mirrors P2's
+        // ApplyPsHwPeakForConnection call. ConnectedBoardKind returns the
+        // currently-active board (HL2, Hermes, ANAN-class…) — the value
+        // is per-board (HL2 → 0.233, others → 0.4072) and only fires a
+        // StateChanged when the value actually changes.
+        _radio.ApplyPsHwPeakForConnection(isProtocol2: false, _radio.ConnectedBoardKind);
     }
 
     private void OnRadioDisconnected()
@@ -483,13 +498,20 @@ public class DspPipelineService : BackgroundService
             //
             // Task.Delay(100).Wait() is acceptable here — OnRadioStateChanged
             // runs on a state-change handler thread, not the request path.
-            // TODO(ps-p1): when P1 PS lands, dispatch to _radio.ActiveClient
-            // here too (the P1 client gains a SetPuresignal(bool) sibling
-            // — see hermes.md item 4b). Today the P1 ActiveClient receives
-            // no PS bit and the frontend gates the PS toggle off on P1.
+            //
+            // P1 sibling (issue #172): the active P1 client gets the same
+            // arm/disarm sequencing — flip the wire bit (which also
+            // bumps NumReceiversMinusOne in the next Config frame so the
+            // gateware switches to the 2-DDC paired layout), wait the
+            // same 100 ms settle window, then arm the engine. On a
+            // non-HL2 P1 board this is harmless: SetPsEnabled stores the
+            // flag locally and the C0=0x14 wire byte is unaffected
+            // (board-gated in WriteAttenuatorPayload).
+            var p1Active = _radio.ActiveClient;
             if (s.PsEnabled)
             {
                 _p2Client?.SetPsFeedbackEnabled(true);
+                p1Active?.SetPsEnabled(true);
                 try { Task.Delay(100).Wait(); } catch { /* ignore */ }
                 engine.SetPsEnabled(true);
             }
@@ -497,6 +519,7 @@ public class DspPipelineService : BackgroundService
             {
                 engine.SetPsEnabled(false);
                 _p2Client?.SetPsFeedbackEnabled(false);
+                p1Active?.SetPsEnabled(false);
                 DrainPsFeedback();
             }
             _appliedPsEnabled = s.PsEnabled;
@@ -716,6 +739,41 @@ public class DspPipelineService : BackgroundService
         }, cts.Token);
     }
 
+    /// <summary>
+    /// HL2 / Protocol-1 sibling of <see cref="StartPsFeedbackPumpP2"/>.
+    /// Reads 1024-sample paired blocks emitted by the
+    /// <see cref="IProtocol1Client.PsFeedbackFrames"/> channel and pushes
+    /// them into WDSP's <c>psccF</c> via the engine's
+    /// <c>FeedPsFeedbackBlock</c>. Same lifecycle as the P2 pump:
+    /// started on connect, stopped on disconnect — NOT gated on PsEnabled,
+    /// because the radio sends paired frames whenever the wire bit is
+    /// set and the engine drops blocks internally when SetPsRunCal is 0
+    /// (see lessons_puresignal_convergence_g2_mkii.md). Issue #172.
+    /// </summary>
+    private void StartPsFeedbackPumpP1(IProtocol1Client client)
+    {
+        var cts = new CancellationTokenSource();
+        _psFeedbackPumpCts = cts;
+        _psFeedbackPumpTask = Task.Run(async () =>
+        {
+            try
+            {
+                await foreach (var frame in client.PsFeedbackFrames.ReadAllAsync(cts.Token).ConfigureAwait(false))
+                {
+                    IDspEngine? engine;
+                    lock (_engineLock) { engine = _engine; }
+                    engine?.FeedPsFeedbackBlock(frame.TxI, frame.TxQ, frame.RxI, frame.RxQ);
+                }
+            }
+            catch (OperationCanceledException) { }
+            catch (ChannelClosedException) { }
+            catch (Exception ex)
+            {
+                _log.LogWarning(ex, "dsp.pipeline p1 ps-feedback-pump exited with error");
+            }
+        }, cts.Token);
+    }
+
     private async Task StopPsFeedbackPumpAsync()
     {
         var cts = _psFeedbackPumpCts;
@@ -735,13 +793,23 @@ public class DspPipelineService : BackgroundService
     // Best-effort drain of in-flight paired frames after PS disarm. Called
     // synchronously from OnRadioStateChanged so by the time the next state
     // change tries to re-arm, the channel is empty. The pump task itself is
-    // not stopped — only the buffered backlog is drained.
+    // not stopped — only the buffered backlog is drained. Drains either
+    // active client (P1 or P2 — only one is non-null at a time).
     private void DrainPsFeedback()
     {
-        var client = _p2Client;
-        if (client is null) return;
-        var reader = client.PsFeedbackFrames;
-        while (reader.TryRead(out _)) { }
+        var p2 = _p2Client;
+        if (p2 is not null)
+        {
+            var reader = p2.PsFeedbackFrames;
+            while (reader.TryRead(out _)) { }
+            return;
+        }
+        var p1 = _radio.ActiveClient;
+        if (p1 is not null)
+        {
+            var reader = p1.PsFeedbackFrames;
+            while (reader.TryRead(out _)) { }
+        }
     }
 
     /// <summary>

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -130,11 +130,7 @@ public class DspPipelineService : BackgroundService
     private double _appliedPsMoxDelaySec = 0.2;
     private double _appliedPsLoopDelaySec;
     private double _appliedPsAmpDelayNs = 150.0;
-    // No _appliedPsHwPeak cache: mi0bot PSForm.cs PSpeak_TextChanged calls
-    // puresignal.SetPSHWPeak unconditionally on every TextChanged, with no
-    // intermediate "applied" guard. Mirror that here so re-pushing the same
-    // HW peak value clears an info[6]=0x0044 fault inside calcc instead of
-    // being silently swallowed by a value-equality short-circuit.
+    private double _appliedPsHwPeak = 0.4072;
     private string _appliedPsIntsSpiPreset = "16/256";
     private PsFeedbackSource _appliedPsFeedbackSource = PsFeedbackSource.Internal;
     // PS-Monitor toggle (issue #121). Pure source-routing flag — Tick reads
@@ -453,16 +449,11 @@ public class DspPipelineService : BackgroundService
         // instance picks up the canonical state instead of running on its
         // field defaults.
         bool resync = _psResyncRequired;
-        // mi0bot: PSForm.cs PSpeak_TextChanged calls SetPSHWPeak directly on
-        // every TextChanged with no intermediate cache. We mirror that — no
-        // `_appliedPsHwPeak` short-circuit — so an operator re-pushing the
-        // same value (or a state-change push that arrives with the unchanged
-        // hwPeak) still reaches WDSP and can clear an info[6]=0x0044 fault.
-        // Range checks live one layer down in WdspDspEngine.SetPsHwPeak.
-        // Other PS advanced fields (ptol, mox/loop/amp delays, ints/spi)
-        // keep their `_applied*` caches because they don't have the
-        // re-push-to-clear-fault use case.
-        engine.SetPsHwPeak(s.PsHwPeak);
+        if (resync || s.PsHwPeak != _appliedPsHwPeak)
+        {
+            engine.SetPsHwPeak(s.PsHwPeak);
+            _appliedPsHwPeak = s.PsHwPeak;
+        }
         if (resync
             || s.PsPtol != _appliedPsPtol
             || s.PsMoxDelaySec != _appliedPsMoxDelaySec

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -130,7 +130,11 @@ public class DspPipelineService : BackgroundService
     private double _appliedPsMoxDelaySec = 0.2;
     private double _appliedPsLoopDelaySec;
     private double _appliedPsAmpDelayNs = 150.0;
-    private double _appliedPsHwPeak = 0.4072;
+    // No _appliedPsHwPeak cache: mi0bot PSForm.cs PSpeak_TextChanged calls
+    // puresignal.SetPSHWPeak unconditionally on every TextChanged, with no
+    // intermediate "applied" guard. Mirror that here so re-pushing the same
+    // HW peak value clears an info[6]=0x0044 fault inside calcc instead of
+    // being silently swallowed by a value-equality short-circuit.
     private string _appliedPsIntsSpiPreset = "16/256";
     private PsFeedbackSource _appliedPsFeedbackSource = PsFeedbackSource.Internal;
     // PS-Monitor toggle (issue #121). Pure source-routing flag — Tick reads
@@ -449,11 +453,16 @@ public class DspPipelineService : BackgroundService
         // instance picks up the canonical state instead of running on its
         // field defaults.
         bool resync = _psResyncRequired;
-        if (resync || s.PsHwPeak != _appliedPsHwPeak)
-        {
-            engine.SetPsHwPeak(s.PsHwPeak);
-            _appliedPsHwPeak = s.PsHwPeak;
-        }
+        // mi0bot: PSForm.cs PSpeak_TextChanged calls SetPSHWPeak directly on
+        // every TextChanged with no intermediate cache. We mirror that — no
+        // `_appliedPsHwPeak` short-circuit — so an operator re-pushing the
+        // same value (or a state-change push that arrives with the unchanged
+        // hwPeak) still reaches WDSP and can clear an info[6]=0x0044 fault.
+        // Range checks live one layer down in WdspDspEngine.SetPsHwPeak.
+        // Other PS advanced fields (ptol, mox/loop/amp delays, ints/spi)
+        // keep their `_applied*` caches because they don't have the
+        // re-push-to-clear-fault use case.
+        engine.SetPsHwPeak(s.PsHwPeak);
         if (resync
             || s.PsPtol != _appliedPsPtol
             || s.PsMoxDelaySec != _appliedPsMoxDelaySec

--- a/Zeus.Server.Hosting/PsAutoAttenuateService.cs
+++ b/Zeus.Server.Hosting/PsAutoAttenuateService.cs
@@ -121,6 +121,30 @@ public sealed class PsAutoAttenuateService : BackgroundService
     private bool _hl2SavedAuto;
     private bool _hl2SavedSingle;
 
+    // Zeus-specific auto-cal of WDSP hw_peak from observed envelope. Tracks the
+    // last EnvelopeStabilityWindow ticks of GetPSMaxTX; once the max-min spread
+    // is within EnvelopeStabilityRatio we consider the envelope "stable" and
+    // re-target hw_peak to observed * HwPeakSafetyMargin. Hysteresis prevents
+    // continuous re-pushes for sub-5% drift.
+    //
+    // *** DEVIATION FROM mi0bot ***
+    // mi0bot does NOT auto-tune hw_peak — Thetis exposes PSForm.cs txtPSpeak
+    // as an operator-tuned NumericUpDown that defaults to the per-board
+    // PSDefaultPeak (clsHardwareSpecific.cs:303-328) and is otherwise hand-
+    // dialed. We deviate per Brian (EI6LF) "I want it automatic" instruction:
+    // the calcc bin-fill math means hw_peak just below observed_peak / 0.9375
+    // is the sweet spot (all samples bin AND bin 15 fills); 2% safety margin
+    // above observed gives plenty of headroom for envelope jitter without
+    // dropping bin 15.
+    private const int EnvelopeStabilityWindow = 10;        // 1 s at 10 Hz
+    private const double EnvelopeStabilityRatio = 0.05;    // (max-min)/max ≤ 5%
+    private const double HwPeakHysteresisRatio = 0.05;     // re-push when |Δ|/cur > 5%
+    private const double HwPeakSafetyMargin = 1.02;        // 2% above observed
+    private const double EnvelopeMinForAutoCal = 0.01;     // ignore TX-silent ticks
+    private const double HwPeakMin = 0.05;                 // server clamps (0,2]
+    private const double HwPeakMax = 2.0;
+    private readonly Queue<double> _envelopeHistory = new();
+
     public PsAutoAttenuateService(
         RadioService radio,
         TxService tx,
@@ -188,22 +212,26 @@ public sealed class PsAutoAttenuateService : BackgroundService
             _currentAttnDb = 0;
             _lastCalibrationAttempts = -1;
             _hl2State = Hl2AutoAttState.Monitor;
+            _envelopeHistory.Clear();
             _log.LogInformation("psAutoAttn.armed reset attn={Db}", _currentAttnDb);
         }
         _psWasEnabled = s.PsEnabled;
 
         // Hard idle conditions — also force the HL2 state machine back to
         // Monitor so a mid-dance disarm/unkey doesn't strand PS in the
-        // disabled state when the operator re-keys.
+        // disabled state when the operator re-keys. Envelope history clears
+        // too so a fresh TX cycle starts the stability window from zero.
         if (!s.PsEnabled)
         {
             _hl2State = Hl2AutoAttState.Monitor;
+            _envelopeHistory.Clear();
             LogGate("skip=PsEnabled-off");
             return;
         }
         if (!_tx.IsMoxOn && !_tx.IsTwoToneOn)
         {
             _hl2State = Hl2AutoAttState.Monitor;
+            _envelopeHistory.Clear();
             LogGate("skip=not-keyed");
             return;
         }
@@ -212,9 +240,15 @@ public sealed class PsAutoAttenuateService : BackgroundService
         if (engine is null)
         {
             _hl2State = Hl2AutoAttState.Monitor;
+            _envelopeHistory.Clear();
             LogGate("skip=engine-null");
             return;
         }
+
+        // Auto-cal hw_peak from observed envelope. Independent of HL2/P2 path
+        // and runs every keyed tick — same gates as the rest of the loop
+        // (PsEnabled + TX active + engine present, all checked above).
+        TickAutoCalHwPeak(s, engine);
 
         // HL2 P1 branch — mi0bot timer2code 3-state dance (PSForm.cs:728-815).
         // Run before the P2 path because HL2 has its own client + wire
@@ -285,6 +319,57 @@ public sealed class PsAutoAttenuateService : BackgroundService
         // SetPSControl(reset=1) then re-arm).
         try { Task.Delay(PostStepSettle).Wait(); } catch { /* ignore */ }
         engine.ResetPs();
+    }
+
+    // Zeus-specific (DEVIATION FROM mi0bot): silently retarget WDSP hw_peak
+    // to track the observed TX envelope so calcc binning fills bin 15 without
+    // operator intervention. Runs every keyed tick. Gated on a stable observed
+    // envelope across EnvelopeStabilityWindow ticks; hysteresis prevents re-
+    // pushing for sub-5% drift. mi0bot leaves hw_peak as a hand-dialed
+    // operator value (PSForm.cs txtPSpeak); we tune it automatically per
+    // Brian (EI6LF) "I want it automatic" instruction.
+    private void TickAutoCalHwPeak(StateDto s, IDspEngine engine)
+    {
+        var psm = engine.GetPsStageMeters();
+        double observed = psm.MaxTxEnvelope;
+        if (observed < EnvelopeMinForAutoCal)
+        {
+            // TX is silent or below noise floor — drop the window so the
+            // first non-silent samples don't co-mingle with stale silence.
+            _envelopeHistory.Clear();
+            return;
+        }
+
+        _envelopeHistory.Enqueue(observed);
+        while (_envelopeHistory.Count > EnvelopeStabilityWindow)
+        {
+            _envelopeHistory.Dequeue();
+        }
+        if (_envelopeHistory.Count < EnvelopeStabilityWindow) return;
+
+        double max = _envelopeHistory.Max();
+        double min = _envelopeHistory.Min();
+        if (max <= 0.0) return;
+        // (max - min)/max ≤ EnvelopeStabilityRatio → envelope is stable.
+        if ((max - min) / max > EnvelopeStabilityRatio) return;
+
+        // Calcc bin-fill math (DEVIATION FROM mi0bot rationale):
+        //   hw_scale = 1/hw_peak; samples bin when env*hw_scale ≤ 1.0;
+        //   bin 15 covers env*hw_scale ∈ [0.9375, 1.0] → for bin 15 to fill
+        //   we need observed > 0.9375 * hw_peak → hw_peak < observed * 1.067.
+        // Sweet spot 1.02× gives bin-15 fill with 4.5% headroom for jitter.
+        double targetHwPeak = Math.Clamp(max * HwPeakSafetyMargin, HwPeakMin, HwPeakMax);
+        double currentHwPeak = s.PsHwPeak;
+        if (currentHwPeak <= 0.0) currentHwPeak = HwPeakMin;
+        if (Math.Abs(currentHwPeak - targetHwPeak) / currentHwPeak < HwPeakHysteresisRatio)
+        {
+            return;
+        }
+
+        _log.LogInformation(
+            "psAutoAttn.autoCalHwPeak observed={Obs:F4} target={Tgt:F4} (was {Cur:F4})",
+            max, targetHwPeak, currentHwPeak);
+        _radio.SetPsAdvanced(new PsAdvancedSetRequest(HwPeak: targetHwPeak));
     }
 
     // mi0bot timer2code HL2 path (PSForm.cs:728-815). Three states cycle at

--- a/Zeus.Server.Hosting/PsAutoAttenuateService.cs
+++ b/Zeus.Server.Hosting/PsAutoAttenuateService.cs
@@ -19,6 +19,11 @@
 // (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
 // Both are GPL-2.0-or-later.
 
+using Zeus.Contracts;
+using Zeus.Dsp;
+using Zeus.Protocol1;
+using Zeus.Protocol1.Discovery;
+
 namespace Zeus.Server;
 
 /// <summary>
@@ -38,10 +43,12 @@ namespace Zeus.Server;
 /// seconds without overshooting). After every attenuator change we issue a
 /// SetPSControl(reset=1) so calcc retries with the new feedback level.
 ///
-/// Hard-gated on a P2 connection (TX step attenuator wire support landed in
-/// <see cref="Zeus.Protocol2.Protocol2Client.SetTxAttenuationDb"/>; the P1
-/// path hasn't been wired yet). Idle when PS is off, AutoAttenuate is off, or
-/// the radio isn't keyed — no broadcast, no engine pokes.
+/// Two wire paths are supported. Protocol 2 (G2/Saturn etc.) uses the simple
+/// step-then-reset pattern via <see cref="Zeus.Protocol2.Protocol2Client.SetTxAttenuationDb"/>.
+/// HL2 (Protocol 1) uses the mi0bot timer2code 3-state dance — disable PS at
+/// the engine, write the new ATTOnTX wire byte, then re-enable PS — because
+/// changing C4 (AD9866 TX PGA) mid-fit otherwise wedges calcc into binfo[6]
+/// permanent-fault. mi0bot ref: PSForm.cs:728-815 timer2code.
 /// </summary>
 public sealed class PsAutoAttenuateService : BackgroundService
 {
@@ -59,6 +66,12 @@ public sealed class PsAutoAttenuateService : BackgroundService
     // writes a single byte 0..31 dB per ADC tap).
     private const int TxAttnMinDb = 0;
     private const int TxAttnMaxDb = 31;
+
+    // HL2 TX-side step attenuator range (mi0bot console.cs:2084 udTXStepAttData
+    // Minimum=-28, Maximum=+31). Wider than the bare-HPSDR 0..31 because HL2's
+    // AD9866 TX PGA can reduce PA drive below the nominal 0 dB reference.
+    private const int Hl2TxAttnMinDb = -28;
+    private const int Hl2TxAttnMaxDb = 31;
 
     // Settle time after a step change: give the radio one wire-cycle to pick
     // up the new attenuator, then issue the reset so calcc starts fresh.
@@ -90,6 +103,23 @@ public sealed class PsAutoAttenuateService : BackgroundService
     // failing gate during a 5 s rack key without flooding the log.
     private long _lastGateLogTickMs;
     private const long GateLogIntervalMs = 1000;
+
+    // HL2 P1 path — mi0bot timer2code 3-state dance. mi0bot PSForm.cs:728-815.
+    //   Monitor:          detect new fit + threshold breach → SetPSControl
+    //                     reset=1 (disable PS in WDSP) → SetNewValues
+    //   SetNewValues:     write ATTOnTX wire byte → 100 ms settle →
+    //                     RestoreOperation
+    //   RestoreOperation: SetPSControl(0, save_single, save_auto, 0)
+    //                     (re-enable PS with the operator's prior cal-mode)
+    //                     → Monitor
+    // Cycling at the 10 Hz tick gives ~200 ms between disable and re-enable —
+    // enough for the C4 frame change to land on the radio without leaving
+    // calcc fitting against a moving envelope.
+    private enum Hl2AutoAttState { Monitor, SetNewValues, RestoreOperation }
+    private Hl2AutoAttState _hl2State = Hl2AutoAttState.Monitor;
+    private int _hl2DeltaDb;
+    private bool _hl2SavedAuto;
+    private bool _hl2SavedSingle;
 
     public PsAutoAttenuateService(
         RadioService radio,
@@ -150,24 +180,59 @@ public sealed class PsAutoAttenuateService : BackgroundService
         // fresh arm starts at the radio's untouched 0 dB. The actual radio
         // state may differ if the operator manually changed step-att between
         // sessions; assume the radio holds 0 between arms (matches pihpsdr).
+        // Also reset the HL2 state machine so a fresh arm always starts in
+        // Monitor — if the prior session was disarmed mid-dance, we don't
+        // want to fire RestoreOperation against a stale saved cal-mode.
         if (s.PsEnabled && !_psWasEnabled)
         {
             _currentAttnDb = 0;
             _lastCalibrationAttempts = -1;
+            _hl2State = Hl2AutoAttState.Monitor;
             _log.LogInformation("psAutoAttn.armed reset attn={Db}", _currentAttnDb);
         }
         _psWasEnabled = s.PsEnabled;
 
-        // Idle conditions — no telemetry to act on.
-        if (!s.PsEnabled) { LogGate("skip=PsEnabled-off"); return; }
+        // Hard idle conditions — also force the HL2 state machine back to
+        // Monitor so a mid-dance disarm/unkey doesn't strand PS in the
+        // disabled state when the operator re-keys.
+        if (!s.PsEnabled)
+        {
+            _hl2State = Hl2AutoAttState.Monitor;
+            LogGate("skip=PsEnabled-off");
+            return;
+        }
+        if (!_tx.IsMoxOn && !_tx.IsTwoToneOn)
+        {
+            _hl2State = Hl2AutoAttState.Monitor;
+            LogGate("skip=not-keyed");
+            return;
+        }
+
+        var engine = _pipe.CurrentEngine;
+        if (engine is null)
+        {
+            _hl2State = Hl2AutoAttState.Monitor;
+            LogGate("skip=engine-null");
+            return;
+        }
+
+        // HL2 P1 branch — mi0bot timer2code 3-state dance (PSForm.cs:728-815).
+        // Run before the P2 path because HL2 has its own client + wire
+        // semantics (ATTOnTX writes C4 of register 0x0a during MOX).
+        var p1 = _radio.ActiveClient;
+        if (_radio.ConnectedBoardKind == HpsdrBoardKind.HermesLite2 && p1 is not null)
+        {
+            Tick1Hl2(s, engine, p1);
+            return;
+        }
+
+        // P2 branch — original simpler step-then-reset pattern. AutoAttenuate
+        // gate stays here as an early-out because the P2 path has no multi-
+        // tick state to tear down on toggle.
         if (!s.PsAutoAttenuate) { LogGate("skip=AutoAttenuate-off"); return; }
-        if (!_tx.IsMoxOn && !_tx.IsTwoToneOn) { LogGate("skip=not-keyed"); return; }
 
         var p2 = _pipe.CurrentP2Client;
         if (p2 is null) { LogGate("skip=p2-null"); return; }
-
-        var engine = _pipe.CurrentEngine;
-        if (engine is null) { LogGate("skip=engine-null"); return; }
 
         var psm = engine.GetPsStageMeters();
         int feedback = (int)Math.Round(psm.FeedbackLevel);
@@ -220,5 +285,125 @@ public sealed class PsAutoAttenuateService : BackgroundService
         // SetPSControl(reset=1) then re-arm).
         try { Task.Delay(PostStepSettle).Wait(); } catch { /* ignore */ }
         engine.ResetPs();
+    }
+
+    // mi0bot timer2code HL2 path (PSForm.cs:728-815). Three states cycle at
+    // the 10 Hz tick: Monitor → SetNewValues → RestoreOperation → Monitor.
+    // The disable/re-enable bracket around the C4 wire change is what
+    // prevents the calcc binfo[6] wedge that bench-driver hit earlier when
+    // we changed C4 mid-MOX without the dance. Once we're past Monitor we
+    // MUST complete the cycle so PS gets re-enabled — the early gates at
+    // the top of Tick1 honour that by only running while in Monitor.
+    private void Tick1Hl2(StateDto s, IDspEngine engine, IProtocol1Client p1)
+    {
+        switch (_hl2State)
+        {
+            case Hl2AutoAttState.Monitor:
+            {
+                // Operator can disable AutoAttenuate without losing PS — the
+                // gate sits inside Monitor so the state machine never starts
+                // a dance the operator didn't ask for.
+                if (!s.PsAutoAttenuate)
+                {
+                    LogGate("hl2.skip=AutoAttenuate-off");
+                    return;
+                }
+
+                var psm = engine.GetPsStageMeters();
+                int feedback = (int)Math.Round(psm.FeedbackLevel);
+
+                // mi0bot PSForm.cs:1097-1099 CalibrationAttemptsChanged:
+                // gate every step on a freshly-completed calcc fit.
+                if (_lastCalibrationAttempts >= 0
+                    && psm.CalibrationAttempts == _lastCalibrationAttempts)
+                {
+                    LogGate($"hl2.skip=no-new-calc info5={psm.CalibrationAttempts} fb={feedback}");
+                    return;
+                }
+                _lastCalibrationAttempts = psm.CalibrationAttempts;
+
+                // info[4] == 0 → calcc hasn't completed a fit yet.
+                if (feedback <= 0)
+                {
+                    LogGate($"hl2.skip=fb-zero psm.fb={psm.FeedbackLevel:F2}");
+                    return;
+                }
+
+                // mi0bot NeedToRecalibrate_HL2 (PSForm.cs:1109-1112):
+                //   FB > 181  OR  (FB <= 128 AND ATTOnTX > -28)
+                bool tooHot = feedback > FeedbackHighThreshold;
+                bool tooQuiet = feedback <= FeedbackLowThreshold && _currentAttnDb > Hl2TxAttnMinDb;
+                if (!tooHot && !tooQuiet)
+                {
+                    LogGate($"hl2.skip=in-window fb={feedback} attn={_currentAttnDb}");
+                    return;
+                }
+
+                // mi0bot PSForm.cs:745-761 — full ddB step (no ±1 clamp on HL2)
+                // so a single dance can pull a hot envelope back into window
+                // in one cycle. NaN guard + ±100 dB rails per mi0bot.
+                double ddB = 20.0 * Math.Log10(feedback / IdealFeedback);
+                if (double.IsNaN(ddB)) ddB = 10.0;
+                else if (ddB < -100.0) ddB = -10.0;
+                else if (ddB > 100.0) ddB = 10.0;
+                _hl2DeltaDb = (int)Math.Round(ddB, MidpointRounding.AwayFromZero);
+
+                // Save the operator's current cal-mode so RestoreOperation
+                // brings it back exactly. mi0bot uses _save_singlecalON /
+                // _save_autoON, captured at the start of the dance.
+                _hl2SavedAuto = s.PsAuto;
+                _hl2SavedSingle = s.PsSingle;
+
+                // mi0bot PSForm.cs:763 — disable PS BEFORE writing the new
+                // ATTOnTX. Engine.SetPsControl(false, false) maps internally
+                // to NativeMethods.SetPSControl(id, reset=1, mancal=0,
+                // automode=0, turnon=0) — exactly mi0bot's call.
+                engine.SetPsControl(autoCal: false, singleCal: false);
+
+                _log.LogInformation(
+                    "psAutoAttn.hl2.monitor fb={Fb} info5={Cal} ddB={DDb:F1} delta={Delta} attn={Db}",
+                    feedback, psm.CalibrationAttempts, ddB, _hl2DeltaDb, _currentAttnDb);
+                _hl2State = Hl2AutoAttState.SetNewValues;
+                return;
+            }
+
+            case Hl2AutoAttState.SetNewValues:
+            {
+                // mi0bot PSForm.cs:769-788. State advances first so a no-op
+                // delta still reaches RestoreOperation and re-arms PS — same
+                // safety the WinForms version has.
+                _hl2State = Hl2AutoAttState.RestoreOperation;
+                int newAttn = Math.Clamp(
+                    _currentAttnDb + _hl2DeltaDb,
+                    Hl2TxAttnMinDb,
+                    Hl2TxAttnMaxDb);
+                if (newAttn != _currentAttnDb)
+                {
+                    _log.LogInformation(
+                        "psAutoAttn.hl2.setNewValues attn {Old}->{New} dB",
+                        _currentAttnDb, newAttn);
+                    _currentAttnDb = newAttn;
+                    p1.SetHl2TxStepAttenuationDb(newAttn);
+                    // mi0bot PSForm.cs:783 Thread.Sleep(100) — give the
+                    // C4 frame time to land on the wire before the next
+                    // tick re-enables PS in calcc.
+                    try { Task.Delay(PostStepSettle).Wait(); } catch { /* ignore */ }
+                }
+                return;
+            }
+
+            case Hl2AutoAttState.RestoreOperation:
+            {
+                // mi0bot PSForm.cs:790-815 SetPSControl(0, save_single,
+                // save_auto, 0). Engine.SetPsControl translates the saved
+                // (auto, single) pair into the same wire call.
+                engine.SetPsControl(autoCal: _hl2SavedAuto, singleCal: _hl2SavedSingle);
+                _log.LogInformation(
+                    "psAutoAttn.hl2.restoreOperation auto={Auto} single={Single}",
+                    _hl2SavedAuto, _hl2SavedSingle);
+                _hl2State = Hl2AutoAttState.Monitor;
+                return;
+            }
+        }
     }
 }

--- a/Zeus.Server.Hosting/PsAutoAttenuateService.cs
+++ b/Zeus.Server.Hosting/PsAutoAttenuateService.cs
@@ -121,29 +121,24 @@ public sealed class PsAutoAttenuateService : BackgroundService
     private bool _hl2SavedAuto;
     private bool _hl2SavedSingle;
 
-    // Zeus-specific auto-cal of WDSP hw_peak from observed envelope. Tracks the
-    // last EnvelopeStabilityWindow ticks of GetPSMaxTX; once the max-min spread
-    // is within EnvelopeStabilityRatio we consider the envelope "stable" and
-    // re-target hw_peak to observed * HwPeakSafetyMargin. Hysteresis prevents
-    // continuous re-pushes for sub-5% drift.
-    //
     // *** DEVIATION FROM mi0bot ***
-    // mi0bot does NOT auto-tune hw_peak — Thetis exposes PSForm.cs txtPSpeak
-    // as an operator-tuned NumericUpDown that defaults to the per-board
-    // PSDefaultPeak (clsHardwareSpecific.cs:303-328) and is otherwise hand-
-    // dialed. We deviate per Brian (EI6LF) "I want it automatic" instruction:
-    // the calcc bin-fill math means hw_peak just below observed_peak / 0.9375
-    // is the sweet spot (all samples bin AND bin 15 fills); 2% safety margin
-    // above observed gives plenty of headroom for envelope jitter without
-    // dropping bin 15.
-    private const int EnvelopeStabilityWindow = 10;        // 1 s at 10 Hz
-    private const double EnvelopeStabilityRatio = 0.05;    // (max-min)/max ≤ 5%
-    private const double HwPeakHysteresisRatio = 0.05;     // re-push when |Δ|/cur > 5%
+    // Silent server-side auto-cal of WDSP hw_peak from observed TX envelope.
+    // mi0bot exposes PSForm.cs txtPSpeak as a hand-dialed operator value
+    // defaulting to clsHardwareSpecific.cs:303-328 PSDefaultPeak. We deviate
+    // per Brian (EI6LF) "I want it automatic" instruction: WDSP calcc bins
+    // env*hw_scale into 16 bins where hw_scale = 1/hw_peak; samples > hw_peak
+    // are dropped; bin 15 covers env*hw_scale in 0.9375..1.0 → bin 15 fills
+    // only when hw_peak < observed * 1.067. Sweet spot: hw_peak = observed *
+    // 1.02 (all samples bin AND bin 15 fills with 4.5% jitter headroom).
+    // Operator can still override via the HW peak input — auto-cal will
+    // re-target on the next stable TX cycle.
     private const double HwPeakSafetyMargin = 1.02;        // 2% above observed
-    private const double EnvelopeMinForAutoCal = 0.01;     // ignore TX-silent ticks
+    private const double HwPeakDeadbandRatio = 0.05;       // ≥5% off-target → push
+    private const double EnvelopeMinForAutoCal = 0.01;     // skip silent TX
     private const double HwPeakMin = 0.05;                 // server clamps (0,2]
     private const double HwPeakMax = 2.0;
-    private readonly Queue<double> _envelopeHistory = new();
+    private const long AutoCalMinIntervalMs = 1000;        // ≤ 1 push per second
+    private long _lastAutoCalTickMs;
 
     public PsAutoAttenuateService(
         RadioService radio,
@@ -212,26 +207,23 @@ public sealed class PsAutoAttenuateService : BackgroundService
             _currentAttnDb = 0;
             _lastCalibrationAttempts = -1;
             _hl2State = Hl2AutoAttState.Monitor;
-            _envelopeHistory.Clear();
+            _lastAutoCalTickMs = 0;
             _log.LogInformation("psAutoAttn.armed reset attn={Db}", _currentAttnDb);
         }
         _psWasEnabled = s.PsEnabled;
 
         // Hard idle conditions — also force the HL2 state machine back to
         // Monitor so a mid-dance disarm/unkey doesn't strand PS in the
-        // disabled state when the operator re-keys. Envelope history clears
-        // too so a fresh TX cycle starts the stability window from zero.
+        // disabled state when the operator re-keys.
         if (!s.PsEnabled)
         {
             _hl2State = Hl2AutoAttState.Monitor;
-            _envelopeHistory.Clear();
             LogGate("skip=PsEnabled-off");
             return;
         }
         if (!_tx.IsMoxOn && !_tx.IsTwoToneOn)
         {
             _hl2State = Hl2AutoAttState.Monitor;
-            _envelopeHistory.Clear();
             LogGate("skip=not-keyed");
             return;
         }
@@ -240,7 +232,6 @@ public sealed class PsAutoAttenuateService : BackgroundService
         if (engine is null)
         {
             _hl2State = Hl2AutoAttState.Monitor;
-            _envelopeHistory.Clear();
             LogGate("skip=engine-null");
             return;
         }
@@ -321,55 +312,47 @@ public sealed class PsAutoAttenuateService : BackgroundService
         engine.ResetPs();
     }
 
-    // Zeus-specific (DEVIATION FROM mi0bot): silently retarget WDSP hw_peak
-    // to track the observed TX envelope so calcc binning fills bin 15 without
-    // operator intervention. Runs every keyed tick. Gated on a stable observed
-    // envelope across EnvelopeStabilityWindow ticks; hysteresis prevents re-
-    // pushing for sub-5% drift. mi0bot leaves hw_peak as a hand-dialed
-    // operator value (PSForm.cs txtPSpeak); we tune it automatically per
-    // Brian (EI6LF) "I want it automatic" instruction.
+    // *** DEVIATION FROM mi0bot ***
+    // Silent server-side auto-cal of WDSP hw_peak from observed TX envelope
+    // (GetPSMaxTX). mi0bot leaves hw_peak as the operator-tuned PSForm.cs
+    // txtPSpeak. Per Brian (EI6LF) "I want it automatic" instruction we
+    // retarget to observed*1.02 whenever the current hw_peak is ≥5% off,
+    // throttled to ≤1 push/sec and skipped while the HL2 auto-att dance is
+    // mid-flight (we don't want to fight a SetPSControl(reset=1) sequence).
+    // Operator can still override via the HW peak input — auto-cal will
+    // re-target on the next eligible tick.
     private void TickAutoCalHwPeak(StateDto s, IDspEngine engine)
     {
-        var psm = engine.GetPsStageMeters();
-        double observed = psm.MaxTxEnvelope;
-        if (observed < EnvelopeMinForAutoCal)
+        // Don't fight the HL2 timer2code dance — SetNewValues / RestoreOperation
+        // are mid-disable; firing SetPsAdvanced now would race the in-flight
+        // SetPSControl(reset=1)/(re-arm) sequence.
+        if (_hl2State != Hl2AutoAttState.Monitor) return;
+
+        // 1 push / sec ceiling. Even a sustained drift only writes once per
+        // 10 ticks, so we never flood the engine with same-direction nudges.
+        long now = Environment.TickCount64;
+        if (now - _lastAutoCalTickMs < AutoCalMinIntervalMs) return;
+
+        double env = engine.GetPsStageMeters().MaxTxEnvelope;
+        if (env < EnvelopeMinForAutoCal) return;   // no real TX content
+
+        // Calcc bin-fill math: hw_scale = 1/hw_peak; samples bin when
+        // env*hw_scale ≤ 1.0; bin 15 covers env*hw_scale ∈ [0.9375, 1.0] →
+        // bin 15 fills only when hw_peak < observed*1.067. 1.02× gives all
+        // samples bin AND bin 15 catches the peak with 4.5% jitter headroom.
+        double target = Math.Clamp(env * HwPeakSafetyMargin, HwPeakMin, HwPeakMax);
+        double current = s.PsHwPeak;
+        if (Math.Abs(current - target) / Math.Max(target, 1e-3) <= HwPeakDeadbandRatio)
         {
-            // TX is silent or below noise floor — drop the window so the
-            // first non-silent samples don't co-mingle with stale silence.
-            _envelopeHistory.Clear();
-            return;
+            return;   // 5% deadband — avoid constant tiny adjustments
         }
 
-        _envelopeHistory.Enqueue(observed);
-        while (_envelopeHistory.Count > EnvelopeStabilityWindow)
-        {
-            _envelopeHistory.Dequeue();
-        }
-        if (_envelopeHistory.Count < EnvelopeStabilityWindow) return;
-
-        double max = _envelopeHistory.Max();
-        double min = _envelopeHistory.Min();
-        if (max <= 0.0) return;
-        // (max - min)/max ≤ EnvelopeStabilityRatio → envelope is stable.
-        if ((max - min) / max > EnvelopeStabilityRatio) return;
-
-        // Calcc bin-fill math (DEVIATION FROM mi0bot rationale):
-        //   hw_scale = 1/hw_peak; samples bin when env*hw_scale ≤ 1.0;
-        //   bin 15 covers env*hw_scale ∈ [0.9375, 1.0] → for bin 15 to fill
-        //   we need observed > 0.9375 * hw_peak → hw_peak < observed * 1.067.
-        // Sweet spot 1.02× gives bin-15 fill with 4.5% headroom for jitter.
-        double targetHwPeak = Math.Clamp(max * HwPeakSafetyMargin, HwPeakMin, HwPeakMax);
-        double currentHwPeak = s.PsHwPeak;
-        if (currentHwPeak <= 0.0) currentHwPeak = HwPeakMin;
-        if (Math.Abs(currentHwPeak - targetHwPeak) / currentHwPeak < HwPeakHysteresisRatio)
-        {
-            return;
-        }
-
+        target = Math.Round(target, 4);
         _log.LogInformation(
-            "psAutoAttn.autoCalHwPeak observed={Obs:F4} target={Tgt:F4} (was {Cur:F4})",
-            max, targetHwPeak, currentHwPeak);
-        _radio.SetPsAdvanced(new PsAdvancedSetRequest(HwPeak: targetHwPeak));
+            "psAutoAttn.autoCal env={Env:F4} oldHw={Old:F4} newHw={New:F4}",
+            env, current, target);
+        _radio.SetPsAdvanced(new PsAdvancedSetRequest(HwPeak: target));
+        _lastAutoCalTickMs = now;
     }
 
     // mi0bot timer2code HL2 path (PSForm.cs:728-815). Three states cycle at

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -1167,7 +1167,15 @@ public sealed class RadioService : IDisposable
     public void ApplyPsHwPeakForConnection(bool isProtocol2, HpsdrBoardKind board)
     {
         double peak = ResolvePsHwPeak(isProtocol2, board);
-        Mutate(s => s.PsHwPeak == peak ? s : s with { PsHwPeak = peak });
+        // Snap PsHwPeakDefault to the resolved per-board value alongside
+        // PsHwPeak so the UI can compare them for a "differs from default"
+        // hint. mi0bot ref: PSForm.cs:830 reads HardwareSpecific.PSDefaultPeak
+        // (clsHardwareSpecific.cs:303-328) at the same boundary — radio
+        // change → re-resolve default.
+        Mutate(s =>
+            s.PsHwPeak == peak && s.PsHwPeakDefault == peak
+                ? s
+                : s with { PsHwPeak = peak, PsHwPeakDefault = peak });
         _log.LogInformation(
             "radio.applyPsHwPeak proto={Proto} board={Board} peak={Peak:F4}",
             isProtocol2 ? "P2" : "P1", board, peak);

--- a/Zeus.Server.Hosting/TxMetersService.cs
+++ b/Zeus.Server.Hosting/TxMetersService.cs
@@ -156,6 +156,19 @@ public sealed class TxMetersService : BackgroundService
     // throttle itself down to the 2 Hz PA cadence without a separate timer.
     private DateTime _lastPaTempBroadcastAtUtc = DateTime.MinValue;
 
+    // Diagnostic counters for the 1 Hz tx.meters.diag log emitted while
+    // MOX/TUN is on. Bumped under _sync from OnTelemetry / OnTelemetryRaw /
+    // ApplyPaTempSmoothed; reset under _sync after each emit. The "last"
+    // values capture the most recent raw sample on each axis so a quiet
+    // tick (count=0) still shows the last value the radio sent.
+    private uint _diagFwdSlotCount;
+    private uint _diagRefSlotCount;
+    private uint _diagPaTempSlotCount;
+    private ushort _diagLastFwdAin1;
+    private ushort _diagLastFwdAin0;
+    private ushort _diagLastRefAin0;
+    private DateTime _lastDiagLogAtUtc = DateTime.MinValue;
+
     public TxMetersService(StreamingHub hub, RadioService radio, TxService tx, DspPipelineService pipe, ILogger<TxMetersService> log)
     {
         _hub = hub;
@@ -214,10 +227,22 @@ public sealed class TxMetersService : BackgroundService
                 // with the same α as FWD/REF so the UI sees a stable reading
                 // instead of ADC jitter.
                 ApplyPaTempSmoothed(reading.Ain0);
+                lock (_sync)
+                {
+                    _diagFwdSlotCount++;
+                    _diagPaTempSlotCount++;
+                    _diagLastFwdAin1 = reading.Ain1;
+                    _diagLastFwdAin0 = reading.Ain0;
+                }
                 break;
             case C0AddrAlexRef:
                 ApplySmoothed(ref _refAdc, reading.Ain0);
                 TrackPeak(ref _refAdcPeak, reading.Ain0);
+                lock (_sync)
+                {
+                    _diagRefSlotCount++;
+                    _diagLastRefAin0 = reading.Ain0;
+                }
                 break;
             default:
                 // Other echo slots (ADC bias, exciter/temp) aren't part of the
@@ -228,13 +253,21 @@ public sealed class TxMetersService : BackgroundService
     }
 
     // Overload kept for unit tests that want to drive both axes simultaneously
-    // without constructing two TelemetryReading structs.
+    // without constructing two TelemetryReading structs. Also the P2 ingress
+    // point — both axes arrive in the same hi-priority status packet.
     internal void OnTelemetryRaw(ushort fwdAdc, ushort refAdc)
     {
         ApplySmoothed(ref _fwdAdc, fwdAdc);
         ApplySmoothed(ref _refAdc, refAdc);
         TrackPeak(ref _fwdAdcPeak, fwdAdc);
         TrackPeak(ref _refAdcPeak, refAdc);
+        lock (_sync)
+        {
+            _diagFwdSlotCount++;
+            _diagRefSlotCount++;
+            _diagLastFwdAin1 = fwdAdc;
+            _diagLastRefAin0 = refAdc;
+        }
     }
 
     // Hold the highest raw ADC seen since the last publish-tick reset. Called
@@ -324,7 +357,8 @@ public sealed class TxMetersService : BackgroundService
                 double swr = 1.0;
                 if (mox)
                 {
-                    double fwdAdc, refAdc;
+                    double fwdAdc, refAdc, fwdAdcSmoothed, refAdcSmoothed;
+                    ushort fwdAdcPeak, refAdcPeak;
                     lock (_sync)
                     {
                         // Use the peak ADC seen since the previous publish
@@ -335,8 +369,12 @@ public sealed class TxMetersService : BackgroundService
                         // the smoothed value if no new sample arrived in
                         // this tick (radio quiescence) so the bar doesn't
                         // collapse to zero between hi-pri packets.
-                        fwdAdc = _fwdAdcPeak > 0 ? _fwdAdcPeak : _fwdAdc;
-                        refAdc = _refAdcPeak > 0 ? _refAdcPeak : _refAdc;
+                        fwdAdcPeak = _fwdAdcPeak;
+                        refAdcPeak = _refAdcPeak;
+                        fwdAdcSmoothed = _fwdAdc;
+                        refAdcSmoothed = _refAdc;
+                        fwdAdc = fwdAdcPeak > 0 ? fwdAdcPeak : _fwdAdc;
+                        refAdc = refAdcPeak > 0 ? refAdcPeak : _refAdc;
                         _fwdAdcPeak = 0;
                         _refAdcPeak = 0;
                     }
@@ -348,6 +386,14 @@ public sealed class TxMetersService : BackgroundService
                     // reads as "Silent" (−∞ level / 0 GR) — UI treats as empty.
                     var stage = _pipe.CurrentEngine?.GetTxStageMeters() ?? TxStageMeters.Silent;
                     frame = BuildFrame((float)fwdW, (float)refW, (float)swr, stage);
+
+                    EmitTxMetersDiag(
+                        DateTime.UtcNow,
+                        fwdAdc, refAdc,
+                        fwdAdcSmoothed, refAdcSmoothed,
+                        fwdAdcPeak, refAdcPeak,
+                        fwdW, refW, swr,
+                        cal);
 
                     if (EvaluateSwrTrip(swr, DateTime.UtcNow) is { } tripReason)
                     {
@@ -421,6 +467,59 @@ public sealed class TxMetersService : BackgroundService
         {
             _log.LogWarning(ex, "tx.meters broadcast loop exited with error");
         }
+    }
+
+    // Once-per-second diagnostic line emitted while MOX/TUN is on. Captures
+    // raw + smoothed + peak ADC for both axes, the per-second telemetry slot
+    // counts, and the watts/SWR the meter just published. Purpose: tell us
+    // whether the radio is sending FWD/REF samples at all, what raw ADC
+    // values they carry, and whether the calibration math is what's
+    // collapsing the reading to ~0 W. INFO level so operators can capture it
+    // without enabling debug logging; silent during RX.
+    private void EmitTxMetersDiag(
+        DateTime nowUtc,
+        double fwdAdc, double refAdc,
+        double fwdAdcSmoothed, double refAdcSmoothed,
+        ushort fwdAdcPeak, ushort refAdcPeak,
+        double fwdW, double refW, double swr,
+        RadioCalibration cal)
+    {
+        if (nowUtc - _lastDiagLogAtUtc < TimeSpan.FromSeconds(1)) return;
+        uint fwdCount, refCount, paTempCount;
+        ushort lastFwdAin1, lastFwdAin0, lastRefAin0;
+        bool seenFwdRef, seenPaTemp;
+        double paTempAdcLast;
+        lock (_sync)
+        {
+            fwdCount = _diagFwdSlotCount;
+            refCount = _diagRefSlotCount;
+            paTempCount = _diagPaTempSlotCount;
+            lastFwdAin1 = _diagLastFwdAin1;
+            lastFwdAin0 = _diagLastFwdAin0;
+            lastRefAin0 = _diagLastRefAin0;
+            seenFwdRef = _seenSample;
+            seenPaTemp = _seenPaTempSample;
+            paTempAdcLast = _paTempAdc;
+            _diagFwdSlotCount = 0;
+            _diagRefSlotCount = 0;
+            _diagPaTempSlotCount = 0;
+        }
+        _lastDiagLogAtUtc = nowUtc;
+        _log.LogInformation(
+            "tx.meters.diag board={Board} cal=bridge{Bridge:F2}/ref{Ref:F1}/off{Off} " +
+            "fwdSlot/s={FwdCount} refSlot/s={RefCount} paTempSlot/s={PaTempCount} " +
+            "lastFwdAin1={LastFwdAin1} lastFwdAin0={LastFwdAin0} lastRefAin0={LastRefAin0} " +
+            "fwdAdcSm={FwdSm:F0} refAdcSm={RefSm:F0} fwdAdcPk={FwdPk} refAdcPk={RefPk} " +
+            "fwdAdcUsed={FwdUsed:F0} refAdcUsed={RefUsed:F0} " +
+            "fwdW={FwdW:F2} refW={RefW:F2} swr={Swr:F2} " +
+            "seenFwdRef={SeenFR} seenPaTemp={SeenPT} paTempAdc={PaTempAdc:F0}",
+            _radio.ConnectedBoardKind, cal.BridgeVolt, cal.RefVoltage, cal.AdcCalOffset,
+            fwdCount, refCount, paTempCount,
+            lastFwdAin1, lastFwdAin0, lastRefAin0,
+            fwdAdcSmoothed, refAdcSmoothed, fwdAdcPeak, refAdcPeak,
+            fwdAdc, refAdc,
+            fwdW, refW, swr,
+            seenFwdRef, seenPaTemp, paTempAdcLast);
     }
 
     /// <summary>
@@ -562,11 +661,18 @@ public sealed class TxMetersService : BackgroundService
             _seenPaTempSample = false;
             _seenSample = false;
             _swrAboveThresholdSince = null;
+            _diagFwdSlotCount = 0;
+            _diagRefSlotCount = 0;
+            _diagPaTempSlotCount = 0;
+            _diagLastFwdAin1 = 0;
+            _diagLastFwdAin0 = 0;
+            _diagLastRefAin0 = 0;
         }
         // Reset the broadcast throttle so the next connection's first
         // sample fires a PaTempFrame immediately instead of waiting out
         // the previous session's 500 ms window.
         _lastPaTempBroadcastAtUtc = DateTime.MinValue;
+        _lastDiagLogAtUtc = DateTime.MinValue;
     }
 
     /// <summary>
@@ -603,6 +709,11 @@ public sealed class TxMetersService : BackgroundService
             _refAdcPeak = 0;
             _seenSample = false;
             _swrAboveThresholdSince = null;
+            _diagFwdSlotCount = 0;
+            _diagRefSlotCount = 0;
+            _diagLastFwdAin1 = 0;
+            _diagLastRefAin0 = 0;
         }
+        _lastDiagLogAtUtc = DateTime.MinValue;
     }
 }

--- a/docs/lessons/hl2-ps-hwpeak-calibration.md
+++ b/docs/lessons/hl2-ps-hwpeak-calibration.md
@@ -1,0 +1,130 @@
+# HL2 PureSignal — `hw_peak` must match the observed TX envelope
+
+Load-bearing invariant for anyone debugging "PS arms but never converges
+on HL2". Saves a session of chasing wire-level red herrings (we tried
+that — see git history).
+
+## TL;DR
+
+**WDSP `calcc` collects TX-envelope samples into 16 amplitude bins and
+will not transition `LCOLLECT → LCALC` until every bin has `spi`
+samples.** If the operator's actual TX envelope peak is below the
+configured `hw_peak`, the upper bins never fill, calcc loops in
+COLLECT, hits its 4-second timeout, resets, and loops forever. PS
+arms, the panel reports `Cal state COLLECT`, `Feedback bar 0/256`,
+`Correction —`, and nothing improves no matter how long you transmit.
+
+The fix is **operator-tuned `hw_peak`** matched to the observed envelope
+peak — same as mi0bot's Thetis. The PURESIGNAL panel surfaces the live
+peak as **Observed peak** (mi0bot's `txtGetPSpeak`); the operator dials
+**HW peak** to match it.
+
+## Symptom signature in `bt*.output` backend log
+
+A stalled run looks like this:
+
+    wdsp.setPsEnabled enabled=True
+    wdsp.psState 255->1   info4=0 info6=0x0000 info13=0 info14=0
+    wdsp.psState 1->2     info4=0 info6=0x0000 info13=0 info14=0
+    wdsp.psState 2->4     info4=0 info6=0x0000 info13=0 info14=0
+    p1.ps.fb DDC2(rx) peak=0.0598 mean=0.0239 | DDC3(tx) peak=0.1907 ...
+    p1.ps.fb DDC2(rx) peak=0.0601 mean=0.0229 | DDC3(tx) peak=0.1907 ...
+    [...20+ seconds of feedback samples flowing, state stays at 4...]
+    wdsp.psState 4->1     info4=0 info6=0x0000 info13=0 info14=0   ← MOX dropped
+
+State 4 = `LCOLLECT`. State **never reaches 6 (`LCALC`)**, `info[4]`
+never leaves 0, `info[14]` never flips to 1. PS-feedback samples *are*
+flowing (DDC2 = post-coupler feedback, DDC3 = TX exciter reference) —
+the wire path is healthy. The problem is purely the WDSP-internal
+binning gate.
+
+A converging run looks like this:
+
+    wdsp.setPsEnabled enabled=True
+    wdsp.psState 255->1
+    wdsp.psState 1->2
+    wdsp.psState 2->4
+    wdsp.psState 4->6  info4=80 info6=0x0000 info13=0 info14=1   ← LCALC fires
+    wdsp.psState 6->4  info4=80 info6=0x0000 info13=0 info14=1
+    wdsp.psState 4->7  info4=80 info6=0x0000 info13=0 info14=1   ← LDELAY
+    wdsp.psState 7->4  info4=80 info6=0x0000 info13=0 info14=1
+    [...continuous cycling, info[14] latched to 1 = CorrectionsBeingApplied...]
+
+When state is cycling 3↔4↔5↔6↔7 with `info14=1`, panel shows
+`Cal state COLLECT · correcting` and `Correction` reads a real dB value.
+
+## Why `0.233` is the HL2 default — and when to override
+
+Per `clsHardwareSpecific.cs:311-312` in mi0bot:
+
+```csharp
+case HPSDRHW.HermesLite:
+    return 0.233;
+```
+
+The 0.233 value is a **blanket per-board default**, not a per-drive-level
+calibration. mi0bot expects the operator to override `_PShwpeak` based on
+their actual TX setup — `pbWarningSetPk.Visible = _PShwpeak !=
+HardwareSpecific.PSDefaultPeak` (`PSForm.cs:830`) shows a warning
+indicator whenever the field deviates from the hardware default.
+
+Empirical numbers from the bench HL2 + internal coupler at 28.400 MHz:
+
+| Drive % | Mag (2-Tone) | Observed peak | Right `hw_peak` |
+|---|---|---|---|
+| 21 | 0.4 | 0.190 – 0.225 | 0.18 – 0.22 |
+
+At drive=21% the actual envelope peak is **below the 0.233 default**
+→ bin 15 (0.94..1.0 normalized) never fills → calcc stalls. Setting
+`hw_peak ≈ 0.18` (matched to the observed peak, slightly below) fills
+all bins → calcc cycles → Correction settles around −10 dB → IMD3 drops
+~20 dBc below the main tones in the panadapter.
+
+Higher drive levels eventually push the envelope past 0.233 on their
+own, at which point the default works. There is **no auto-calibrate
+button** in mi0bot or Zeus — the workflow is intentionally manual.
+
+## Operator workflow (mi0bot-faithful)
+
+1. Open Settings → PURESIGNAL.
+2. Arm PS, arm 2-Tone (or any known excitation), hold ~5 seconds.
+3. Note the live **Observed peak** value.
+4. Type that value (or just below) into the **HW peak** field, Tab to
+   commit.
+5. PS converges within 1–2 seconds — `Cal state COLLECT · correcting`,
+   `Correction` shows a real dB number.
+6. (Optional) Increase drive — once envelope peak rises past the new
+   `hw_peak`, raise `hw_peak` to match for the best bin coverage.
+
+## What this lesson is NOT about
+
+- **The wire format.** HL2 PS feedback is delivered through the existing
+  EP6 stream via the dedicated ADC1 mapping (`docs/references/protocol-1/
+  hermes-lite2-protocol.md`, "PureSignal feedback path" section). The wire
+  path was already working before this lesson was written; do not modify
+  `Zeus.Protocol1/ControlFrame.cs` PS-related encoders without reading
+  that doc and the associated mi0bot `networkproto1.c` source first. We
+  burned hours retrying TX-side `0x0a` C4 overrides before realising the
+  problem was purely the WDSP binning gate.
+- **The HL2 default `hw_peak`.** Stays at `0.233` to match mi0bot
+  exactly. Do not lower it on the assumption "low drive is the common
+  case" — it would silently hide PS misconfiguration from operators who
+  push the radio harder.
+- **`PsAutoAttenuateService`.** Currently P2-only (gates on `p2-null`
+  during MOX on HL2). Wiring it for P1 + HL2 is a separate, larger
+  engineering task involving a TX-side step-attenuator wire path on
+  register `0x0a` C4 during XmitBit (see mi0bot `networkproto1.c:1086`
+  and `console.cs:10947-10948`). Not addressed here.
+
+## Authoritative sources
+
+- mi0bot WDSP binning gate:
+  `Project Files/Source/wdsp/calcc.c:708, 729-748, 762-771`
+- mi0bot observed-peak read pattern:
+  `Project Files/Source/Console/PSForm.cs:624` — `GetPSMaxTX(_txachannel, ptr)`
+- mi0bot HL2 default peak:
+  `Project Files/Source/Console/clsHardwareSpecific.cs:311-312`
+- mi0bot warning-indicator pattern (not yet ported):
+  `Project Files/Source/Console/PSForm.cs:830`
+- mi0bot auto-attenuate target (152.293):
+  `Project Files/Source/Console/PSForm.cs:747`

--- a/docs/references/protocol-1/hermes-lite2-protocol.md
+++ b/docs/references/protocol-1/hermes-lite2-protocol.md
@@ -57,7 +57,7 @@ Please refer to the [original openHPSDR protocol](https://github.com/TAPR/OpenHP
 | 0x09 | [17] | For tune request: 1=send the bypass command; 0=send the normal tune request |
 | 0x09 | [15:8] | Alex Rx filter (see Filter Selection below); or VNA count MSB |
 | 0x09 | [7:0]  | Alex Tx filter (see Filter Selection below); or VNA count LSB |
-| 0x0a | [22] | PureSignal (0=disable, 1=enable) |
+| 0x0a | [22] | PureSignal (0=disable, 1=enable) — see "PureSignal feedback path" section below |
 | 0x0a | [6] | See LNA gain section below |
 | 0x0a | [5:0] | LNA[5:0] gain |
 | 0x0e | [15] | Enable hardware managed LNA gain for TX |
@@ -350,6 +350,150 @@ The Hermes-Lite2 Reply packet is as follows:
 | 0x26-0x3B | | Reserved |
 
 
+## PureSignal feedback path
 
+This section documents the HL2-specific behaviour of the PureSignal feedback path
+when the host sets register `0x0a[22] = 1`. It was derived from the
+[mi0bot/openhpsdr-thetis](https://github.com/mi0bot/openhpsdr-thetis) HL2
+fork (the authority for HL2 wire behaviour per CLAUDE.md) and cross-checked
+against [DL1YCF/pihpsdr](https://github.com/dl1ycf/pihpsdr).
+
+mi0bot fork SHA at time of derivation: `e3375d0` ("Updated for release", master).
+pihpsdr cross-reference: `src/old_protocol.c` lines 895-980, 1043-1094.
+
+### Wire-side enable bit
+
+Register `0x0a` bit 22 = "PureSignal run". On the wire this is **C2 bit 6 of
+the C0=0x14 frame** (since C2 carries DATA[23:16] and bit 22 = 22−16 = 6).
+
+mi0bot reference: `Project Files/Source/ChannelMaster/networkproto1.c:1102`
+inside `WriteMainLoop_HL2`:
+
+```c
+case 11: //Preamp control 0x0a
+    C0 |= 0x14; //C0 0001 010x
+    C1 = (prn->rx[0].preamp & 1) | ((prn->rx[1].preamp & 1) << 1) |
+         ((prn->rx[2].preamp & 1) << 2) | ((prn->rx[0].preamp & 1) << 3) |
+         ((prn->mic.mic_trs & 1) << 4) | ((prn->mic.mic_bias & 1) << 5) |
+         ((prn->mic.mic_ptt & 1) << 6);
+    C2 = (prn->mic.line_in_gain & 0b00011111) | ((prn->puresignal_run & 1) << 6);
+    C3 = prn->user_dig_out & 0b00001111;
+    if (XmitBit) C4 = (prn->adc[0].tx_step_attn & 0b00111111) | 0b01000000;
+    else         C4 = (prn->adc[0].rx_step_attn & 0b00111111) | 0b01000000;
+    break;
+```
+
+Note: this is **C2 bit 6, NOT C3 bit 6** — the PR #119 review caught the
+exact mistake. Do not regress this in `Zeus.Protocol1/ControlFrame.cs`.
+
+A second copy of the same bit lives at `0x12 C2 bit 6` (see
+`networkproto1.c:1162`, the BPF2 register), again `(puresignal_run & 1) << 6`.
+mi0bot writes both — the gateware accepts either. Zeus only writes 0x0a.
+
+### Predistortion config register (0x2b)
+
+`0x2b[31:24]` = predistortion **subindex** (C1).
+`0x2b[19:16]` = predistortion **value** (C2 bits [3:0]).
+
+mi0bot writes the same byte layout via the open address space (`netInterface.c`
+extended-write path). PR #119 review identified the encoding mistake here too:
+the value is C2 bits [3:0], **NOT [7:4]** — do not shift it left.
+
+### Feedback IQ — gateware mechanism (the answered question)
+
+When `0x0a[22] = 1` and the radio is keyed, the HL2 gateware re-points its
+**dedicated feedback ADC (ADC1)** through one of the existing DDCs. The
+samples come back **inside the existing EP6 RX IQ stream** — there is **no
+new packet type or endpoint**.
+
+Of the four candidates the parent issue listed:
+
+- ❌ NOT time-multiplexed on RX1 (RX1 keeps publishing the operator's RX
+  frequency throughout TX).
+- ❌ NOT a new packet type / endpoint (still EP6, port 1024 reply path,
+  still 1032-byte Metis frames).
+- ❌ NOT a frequency-offset injection on RX1.
+- ✅ **It is a "second receiver re-pointed at the feedback ADC"** —
+  specifically, when PS is on, the HL2 firmware's gateware honours the
+  ADC-control bit (`SetADC_cntrl1`, see below) that maps a DDC to ADC1
+  instead of ADC0, and that DDC then carries the post-coupler feedback
+  samples. Which DDC index this lands on is set by the `nddc` count and the
+  `cntrl1` ADC-mapping byte the host writes in C0=0x1c.
+
+Two HL2 PS layouts exist in the wild:
+
+1. **Hermes-class 2-DDC layout** (mi0bot `networkproto1.c:990, 1005`) — when
+   `nddc == 2` and `puresignal_run == 1` and `XmitBit == 1`, both DDC0 and
+   DDC1 are programmed to TX frequency, ADC mapping is set so DDC1 reads
+   ADC1 (feedback), and the EP6 packet carries paired DDC0/DDC1 samples
+   (12 bytes per pair: 3I+3Q for DDC0 then 3I+3Q for DDC1, repeating).
+   This is the simplest layout and matches bare Hermes / ANAN-10 / ANAN-100
+   gateware.
+
+2. **HL2 4-DDC layout** (mi0bot `console.cs:8421-8503`, current default for
+   `HPSDRModel.HERMESLITE`) — `nddc = 4`, with DDC0=RX1, DDC1=RX2 (or
+   feedback, depending on `cntrl1`), DDC2 and DDC3 programmed to TX
+   frequency. When PS+TX is active, mi0bot sets `cntrl1 = 4` (=
+   `prn->rx[1].rx_adc = 1`, mapping DDC1 to ADC1 / feedback). The
+   `CMLoadRouterAll` table (mi0bot `cmaster.cs:699-718`) wires DDC2+DDC3
+   paired into the WDSP `psccF` block as the PS feedback stream when
+   control-bit 5 (TX|PS|noDIV) is asserted, and DDC1 alone goes into RX2's
+   audio path.
+
+   pihpsdr `old_protocol.c:895-980` confirms this for HL2 with explicit
+   constants: `rx_feedback_channel(DEVICE_HERMES_LITE2) = 2`,
+   `tx_feedback_channel(DEVICE_HERMES_LITE2) = 3`,
+   `how_many_receivers(DEVICE_HERMES_LITE2 with PS) = 4`.
+
+   The interleave format inside the EP6 packet for `nddc=4` is
+   `int k = 8 + isample * (6 * nddc + 2) + iddc * 6` per DDC index 0..3,
+   yielding 26 bytes per sample-time-slot (six bytes per DDC × 4 DDCs +
+   two mic bytes), giving 504 / 26 = 19 sample slots per USB-frame
+   (mi0bot `networkproto1.c:537, 569`). The two USB frames per packet
+   give 38 sample slots per packet, per DDC.
+
+The choice between layout (1) and (2) is host-side; both produce valid PS
+feedback. Zeus (this commit) implements the simpler **2-DDC paired layout
+(layout 1)** scoped to HL2 + PS-armed, leaving the existing 1-DDC RX
+layout untouched when PS is off. The 4-DDC layout matches what mi0bot
+ships, but Zeus has only ever decoded a 1-DDC layout, and refactoring
+PacketParser to handle 4 DDCs in production is not a goal of this PR.
+
+### Hardware peak (calcc HW scale)
+
+HL2 PureSignal feedback peak = **0.233** for both Protocol 1 and Protocol 2.
+mi0bot reference: `clsHardwareSpecific.cs:322-323` and `:332-333` —
+`case HPSDRHW.HermesLite: return 0.233;` for both `RadioProtocol.USB` (P1)
+and `RadioProtocol.ETH` (P2). Zeus's `RadioService.ResolvePsHwPeak` already
+returns `0.233` for `(false, HpsdrBoardKind.HermesLite2)`.
+
+### External coupler is the only working configuration
+
+HL2 has no internal feedback coupler. The Bias / forward-power AIN3 path
+is for monitoring, not for PureSignal sampling. PureSignal on HL2 requires
+an external bidirectional coupler wired to ADC1's input pads, and the
+host should always select "External (Bypass)" feedback source — Zeus hides
+the Internal-vs-External selector on HL2 in `PsSettingsPanel.tsx`.
+
+### Number of receivers (C0=0x00, C4 bits [5:3])
+
+Bare HL2 RX uses 1 receiver (Zeus default). HL2 PureSignal in the 2-DDC
+layout requires 2 receivers (set N-1 = 1 in C4 bits [5:3]). In the 4-DDC
+layout, 4 receivers (N-1 = 3). Mismatch = the radio's gateware silently
+drops feedback samples or half-fills the EP6 IQ slot.
+
+mi0bot `networkproto1.c:973` (HL2 write loop case 0): `C4 |= (nddc - 1) << 3;`.
+
+### Gateware version
+
+mi0bot fork's `clsHardwareSpecific.cs` has no minimum gateware-version gate
+for `0x0a[22]`; it sends the bit unconditionally and depends on any HL2
+gateware revision interpreting it. Operator gateware reports show the bit
+honoured from gateware 7.2 onwards (the version that introduced the
+extended LNA-gain control for HL2). This is **untested by Zeus** — the
+parent issue lists "note any gateware version requirements" as a
+deliverable; the answer is "no host-side gating found in the reference
+forks; rely on the radio's own response". Brian's HL2 should be fw ≥ 7.2;
+KB2UKA does not have an HL2 to bench-test.
 
 

--- a/tests/Zeus.Protocol1.Tests/ControlFramePsEncoderTests.cs
+++ b/tests/Zeus.Protocol1.Tests/ControlFramePsEncoderTests.cs
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Protocol1.Discovery;
+
+namespace Zeus.Protocol1.Tests;
+
+/// <summary>
+/// Pin the on-the-wire encoding of the HL2 PureSignal register frames so the
+/// PR #119 encoding bugs (PS bit in C3 instead of C2; predistortion value
+/// shifted into C2 [7:4] instead of [3:0]) can never silently regress.
+///
+/// References:
+///   - mi0bot networkproto1.c:1102 — HL2 0x0a write loop case 11.
+///   - HL2 protocol doc, "PureSignal feedback path" section.
+///   - PR #119 review: https://github.com/brianbruff/openhpsdr-zeus/pull/119
+/// </summary>
+public class ControlFramePsEncoderTests
+{
+    private static ControlFrame.CcState BaseHl2(bool psEnabled = false) => new(
+        VfoAHz: 14_200_000,
+        Rate: HpsdrSampleRate.Rate48k,
+        PreampOn: false,
+        Atten: HpsdrAtten.Zero,
+        RxAntenna: HpsdrAntenna.Ant1,
+        Mox: false,
+        EnableHl2Dither: false,
+        Board: HpsdrBoardKind.HermesLite2,
+        PsEnabled: psEnabled);
+
+    // ---- 0x0a (Attenuator wire byte, == register 0x0a) — puresignal_run bit ----
+
+    [Fact]
+    public void Attenuator_Hl2_PsEnabled_Sets_C2_Bit6_Not_C3()
+    {
+        Span<byte> cc = stackalloc byte[5];
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Attenuator, BaseHl2(psEnabled: true));
+
+        // PR #119 bug: it set bit 6 of C3 (= reg bit 14) instead of bit 6 of
+        // C2 (= reg bit 22). Pin both.
+        Assert.Equal(1 << 6, cc[2] & (1 << 6));            // C2 bit 6 = puresignal_run
+        Assert.Equal(0,      cc[3] & (1 << 6));            // C3 bit 6 = NOT puresignal_run
+    }
+
+    [Fact]
+    public void Attenuator_Hl2_PsDisabled_Does_Not_Set_C2_Bit6()
+    {
+        Span<byte> cc = stackalloc byte[5];
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Attenuator, BaseHl2(psEnabled: false));
+        Assert.Equal(0, cc[2] & (1 << 6));
+    }
+
+    [Fact]
+    public void Attenuator_NonHl2_PsEnabled_Does_Not_Set_C2_Bit6()
+    {
+        // Bare HPSDR / ANAN-class radios use a different PS path (Protocol 2
+        // ALEX_PS_BIT). Even with PsEnabled=true on a Hermes board, the
+        // C0=0x14 frame must not flip its C2 bit 6 — it would land on a
+        // reserved bit and could confuse the gateware.
+        Span<byte> cc = stackalloc byte[5];
+        var s = BaseHl2(psEnabled: true) with { Board = HpsdrBoardKind.Hermes };
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Attenuator, s);
+        Assert.Equal(0, cc[2] & (1 << 6));
+    }
+
+    [Fact]
+    public void Attenuator_Hl2_PsEnabled_Preserves_C4_Attenuator_Byte()
+    {
+        // Adding the PS bit must not corrupt the existing C4 step-attenuator
+        // payload — the radio reads both fields out of the same C0=0x14
+        // frame.
+        Span<byte> cc = stackalloc byte[5];
+        var s = BaseHl2(psEnabled: true) with { Atten = new HpsdrAtten(20) };
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Attenuator, s);
+        // HL2 atten encoding: 0x40 | (60 - 20) = 0x68.
+        Assert.Equal(0x68, cc[4]);
+    }
+
+    [Fact]
+    public void Attenuator_Cc0_WireByte_Is_0x14()
+    {
+        // Address C0 wire byte for register 0x0a = 0x0a << 1 = 0x14. MOX bit
+        // OR'd into bit 0; pin both states.
+        Span<byte> cc = stackalloc byte[5];
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Attenuator, BaseHl2(psEnabled: true));
+        Assert.Equal(0x14, cc[0]);
+
+        var moxOn = BaseHl2(psEnabled: true) with { Mox = true };
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Attenuator, moxOn);
+        Assert.Equal(0x15, cc[0]);
+    }
+
+    // ---- 0x2b (Predistortion) — value/subindex placement ----
+
+    [Fact]
+    public void Predistortion_Cc0_WireByte_Is_0x56()
+    {
+        // 0x2b << 1 = 0x56. PR #119 had the right wire byte, only the
+        // payload was wrong.
+        Span<byte> cc = stackalloc byte[5];
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Predistortion, BaseHl2());
+        Assert.Equal(0x56, cc[0]);
+    }
+
+    [Fact]
+    public void Predistortion_Subindex_Lands_In_C1_Whole_Byte()
+    {
+        // bits [31:24] = subindex → C1 (whole byte).
+        Span<byte> cc = stackalloc byte[5];
+        var s = BaseHl2() with { PsPredistortionSubindex = 0xA5 };
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Predistortion, s);
+        Assert.Equal(0xA5, cc[1]);
+    }
+
+    [Theory]
+    // PR #119 bug: it wrote `c14[1] = (value & 0x0F) << 4`, which puts the
+    // value in C2 bits [7:4] = register bits [23:20] (reserved) instead of
+    // C2 bits [3:0] = register bits [19:16] (the real PS-value field).
+    [InlineData(0x00, 0x00)]
+    [InlineData(0x01, 0x01)]
+    [InlineData(0x05, 0x05)]
+    [InlineData(0x0F, 0x0F)]
+    // Higher bits must be masked off — the field is only 4 bits wide.
+    [InlineData(0xFF, 0x0F)]
+    [InlineData(0xF0, 0x00)]
+    public void Predistortion_Value_Lands_In_C2_LowNibble_Not_HighNibble(byte value, byte expectedC2)
+    {
+        Span<byte> cc = stackalloc byte[5];
+        var s = BaseHl2() with { PsPredistortionValue = value };
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Predistortion, s);
+        Assert.Equal(expectedC2, cc[2]);
+    }
+
+    [Fact]
+    public void Predistortion_C3_C4_Reserved_Zero()
+    {
+        // No HL2-defined fields in C3 or C4 of register 0x2b — keep them
+        // zero so we don't accidentally write into a reserved-but-allocated
+        // future bit.
+        Span<byte> cc = stackalloc byte[5];
+        var s = BaseHl2() with { PsPredistortionSubindex = 0xFF, PsPredistortionValue = 0x0F };
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Predistortion, s);
+        Assert.Equal(0, cc[3]);
+        Assert.Equal(0, cc[4]);
+    }
+
+    // ---- Config (0x00) — number-of-receivers in C4 [5:3] ----
+
+    [Theory]
+    [InlineData(0, 0b000)]   // 1 receiver (Zeus default)
+    [InlineData(1, 0b001)]   // 2 receivers (HL2 PS armed, paired DDC0/DDC1)
+    [InlineData(3, 0b011)]   // 4 receivers (HL2 4-DDC layout)
+    [InlineData(7, 0b111)]   // 8 receivers (cap)
+    public void Config_NumReceiversMinusOne_Lands_In_C4_Bits5to3(byte nMinus1, byte expectedFieldValue)
+    {
+        Span<byte> cc = stackalloc byte[5];
+        var s = BaseHl2() with { NumReceiversMinusOne = nMinus1 };
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Config, s);
+        Assert.Equal(expectedFieldValue << 3, cc[4] & 0b00111000);
+        // Duplex bit (C4[2] = 1) preserved.
+        Assert.Equal(1 << 2, cc[4] & (1 << 2));
+    }
+
+    [Fact]
+    public void Config_NumReceivers_Default_Single_PreservesLegacyBitLayout()
+    {
+        // With NumReceiversMinusOne defaulting to 0, C4 = duplex bit only =
+        // 0b00000100. This is the historic Zeus encoding; pin it so the
+        // default RX path doesn't shift.
+        Span<byte> cc = stackalloc byte[5];
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Config, BaseHl2());
+        Assert.Equal(0b00000100, cc[4] & 0b11111111);
+    }
+}

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -191,6 +191,13 @@ export type RadioStateDto = {
   psMoxDelaySec: number;
   psLoopDelaySec: number;
   psAmpDelayNs: number;
+  // psHwPeak is the live operator-tunable HW-peak; psHwPeakDefault is the
+  // per-board factory default frozen by RadioService at connect time. UI
+  // shows a "differs from default" hint when they don't match.
+  // mi0bot ref: PSForm.cs:830 `pbWarningSetPk.Visible = _PShwpeak !=
+  // HardwareSpecific.PSDefaultPeak;`.
+  psHwPeak: number;
+  psHwPeakDefault: number;
   psIntsSpiPreset: string;
   psFeedbackSource: 'internal' | 'external';
   twoToneFreq1: number;
@@ -427,6 +434,12 @@ export function normalizeState(raw: unknown): RadioStateDto {
     psMoxDelaySec: typeof r.psMoxDelaySec === 'number' ? r.psMoxDelaySec : 0.2,
     psLoopDelaySec: typeof r.psLoopDelaySec === 'number' ? r.psLoopDelaySec : 0,
     psAmpDelayNs: typeof r.psAmpDelayNs === 'number' ? r.psAmpDelayNs : 150,
+    // mi0bot ref: PSForm.cs:830 / clsHardwareSpecific.cs:303-328 — server
+    // freezes psHwPeakDefault at connect via ResolvePsHwPeak; psHwPeak is the
+    // operator-tunable live value. UI compares them for the warning hint.
+    psHwPeak: typeof r.psHwPeak === 'number' ? r.psHwPeak : 0.4072,
+    psHwPeakDefault:
+      typeof r.psHwPeakDefault === 'number' ? r.psHwPeakDefault : 0.4072,
     psIntsSpiPreset: typeof r.psIntsSpiPreset === 'string' ? r.psIntsSpiPreset : '16/256',
     psFeedbackSource:
       r.psFeedbackSource === 'External' || r.psFeedbackSource === 'external' ? 'external' : 'internal',

--- a/zeus-web/src/components/PsSettingsPanel.tsx
+++ b/zeus-web/src/components/PsSettingsPanel.tsx
@@ -345,12 +345,25 @@ export function PsSettingsPanel() {
           </Row>
         ) : null}
         <Row label="HW peak">
+          {/* mi0bot ref: PSForm.cs PSpeak_TextChanged fires on every text
+              change regardless of whether the value differs from the prior
+              value, so re-typing the same number re-pushes it to WDSP and
+              resets calcc state. React's controlled <input> only fires
+              onChange when the rendered value actually changes, so a stale
+              focus-and-blur with no edit is silently dropped. Mirror the
+              mi0bot semantic by firing setPsAdvanced unconditionally on
+              blur / Enter via onCommit, in addition to the live onChange
+              path used by the other advanced fields. */}
           <NumberInput
             value={psHwPeak}
             min={0.01}
             max={2.0}
             step={0.001}
             onChange={(v) => {
+              setPsHwPeak(v);
+              pushAdvanced({ hwPeak: v });
+            }}
+            onCommit={(v) => {
               setPsHwPeak(v);
               pushAdvanced({ hwPeak: v });
             }}
@@ -537,6 +550,7 @@ function NumberInput({
   max,
   step,
   onChange,
+  onCommit,
   disabled,
 }: {
   value: number;
@@ -544,6 +558,11 @@ function NumberInput({
   max: number;
   step: number;
   onChange: (v: number) => void;
+  // mi0bot ref: PSForm.cs PSpeak_TextChanged — onCommit fires on blur and
+  // Enter unconditionally so re-entering the same value still re-pushes,
+  // mirroring WinForms TextChanged-on-every-keystroke semantics that React's
+  // controlled-input dedup otherwise hides on focus/blur with no edit.
+  onCommit?: (v: number) => void;
   disabled?: boolean;
 }) {
   return (
@@ -557,6 +576,25 @@ function NumberInput({
       onChange={(e) => {
         const v = Number(e.target.value);
         if (Number.isFinite(v)) onChange(v);
+      }}
+      onBlur={(e) => {
+        if (!onCommit) return;
+        const v = Number(e.target.value);
+        if (!Number.isFinite(v)) return;
+        // React-controlled-input cosmetic ("00.18" → "0.18", ".5" → "0.5",
+        // trailing zeros trimmed); mi0bot WinForms NumericUpDown handles via
+        // .Value setter. State is already the parsed number, but a
+        // controlled <input type="number"> does not re-render when the
+        // parsed value matches state, so the raw text sticks until
+        // something else changes — write the canonical form back to the DOM.
+        const normalized = String(v);
+        if (normalized !== e.target.value) e.target.value = normalized;
+        onCommit(v);
+      }}
+      onKeyDown={(e) => {
+        if (!onCommit || e.key !== 'Enter') return;
+        const v = Number((e.target as HTMLInputElement).value);
+        if (Number.isFinite(v)) onCommit(v);
       }}
       style={{
         width: 100,

--- a/zeus-web/src/components/PsSettingsPanel.tsx
+++ b/zeus-web/src/components/PsSettingsPanel.tsx
@@ -91,6 +91,12 @@ export function PsSettingsPanel() {
   const psCalState = useTxStore((s) => s.psCalState);
   const psCorrecting = useTxStore((s) => s.psCorrecting);
   const psCorrectionDb = useTxStore((s) => s.psCorrectionDb);
+  // Observed TX envelope peak — mi0bot PSForm.cs:624 reads
+  // GetPSMaxTX(_txachannel, ptr) every timer tick and shows it in
+  // txtGetPSpeak so the operator can compare against HW peak. Zeus already
+  // pumps this from WdspDspEngine.GetPsStageMeters → PsMetersFrame; we just
+  // render the live value next to the HW-peak input.
+  const psMaxTxEnvelope = useTxStore((s) => s.psMaxTxEnvelope);
   const setPsAuto = useTxStore((s) => s.setPsAuto);
   const setPsSingle = useTxStore((s) => s.setPsSingle);
   const setPsPtol = useTxStore((s) => s.setPsPtol);
@@ -349,6 +355,14 @@ export function PsSettingsPanel() {
               pushAdvanced({ hwPeak: v });
             }}
           />
+        </Row>
+        {/* mi0bot ref: PSForm.cs:624 GetPSMaxTX → PSForm.designer.cs
+            txtGetPSpeak readout. Read-only; the operator dials HW peak
+            above to match the observed envelope max during calibration. */}
+        <Row label="Observed peak">
+          <span style={{ fontSize: 11, color: 'var(--fg-1)' }}>
+            {psMaxTxEnvelope.toFixed(4)}
+          </span>
         </Row>
         <Row label="Ints / Spi">
           <select

--- a/zeus-web/src/components/PsSettingsPanel.tsx
+++ b/zeus-web/src/components/PsSettingsPanel.tsx
@@ -391,6 +391,26 @@ export function PsSettingsPanel() {
               *
             </span>
           ) : null}
+          {/* mi0bot ref: PSForm.cs:991-994 btnDefaultPeaks_Click →
+              SetDefaultPeaks → psdefpeak (PSForm.cs:371-381) writes
+              HardwareSpecific.PSDefaultPeak (clsHardwareSpecific.cs:303-328)
+              into txtPSpeak. One-click reset to the per-board factory default
+              for operators who've drifted off and want to start over.
+              Disabled when already at the default — no point re-pushing the
+              same value through this button (the field's onCommit covers
+              the deliberate re-push case). */}
+          <button
+            type="button"
+            className="btn sm"
+            disabled={psHwPeak === psHwPeakDefault}
+            title={`Reset HW peak to per-board default ${psHwPeakDefault.toFixed(4)}`}
+            onClick={() => {
+              setPsHwPeak(psHwPeakDefault);
+              pushAdvanced({ hwPeak: psHwPeakDefault });
+            }}
+          >
+            Default
+          </button>
         </Row>
         {/* mi0bot ref: PSForm.cs:624 GetPSMaxTX → PSForm.designer.cs
             txtGetPSpeak readout. Read-only; the operator dials HW peak

--- a/zeus-web/src/components/PsSettingsPanel.tsx
+++ b/zeus-web/src/components/PsSettingsPanel.tsx
@@ -65,12 +65,14 @@ export function PsSettingsPanel() {
   // feedback receiver. On HL2 we hide the toggle entirely. We key on the
   // CONNECTED board (not preferred) so a user who explicitly selects G2
   // while no radio is attached still sees the control as a preview, but
-  // a live HL2 connection cleanly drops it. Same gate hides the
-  // Internal-vs-External feedback source selector — HL2 has only the
-  // external coupler path so the binary is degenerate.
+  // a live HL2 connection cleanly drops it. The Internal-vs-External
+  // feedback source selector remains visible on every board (including
+  // HL2) — even though HL2 currently routes only through the external
+  // coupler path, an operator running HL2 + future amp setup may want
+  // the option exposed.
   const connectedBoard = useRadioStore((s) => s.selection.connected);
   const psMonitorSupported = connectedBoard !== HL2_BOARD_ID;
-  const feedbackSourceSelectorSupported = connectedBoard !== HL2_BOARD_ID;
+  const feedbackSourceSelectorSupported = true;
 
   const psEnabled = useTxStore((s) => s.psEnabled);
   const psMonitorEnabled = useTxStore((s) => s.psMonitorEnabled);

--- a/zeus-web/src/components/PsSettingsPanel.tsx
+++ b/zeus-web/src/components/PsSettingsPanel.tsx
@@ -28,15 +28,16 @@ import {
   resetPs,
   setTwoTone,
 } from '../api/client';
-import { useConnectionStore } from '../state/connection-store';
 import { useRadioStore } from '../state/radio-store';
 import { useTxStore } from '../state/tx-store';
 
-// HermesLite2 has no PS feedback receiver — the entire PS-Monitor view
-// hinges on a paired DDC0/DDC1 loopback that doesn't exist on HL2. Hide
-// the toggle on HL2 so the operator doesn't get a switch that does
-// nothing. ANAN-class boards (and anything else that shows up here)
-// retain the toggle. See issue #121.
+// HermesLite2 has no internal feedback coupler — the operator-side PS
+// Monitor (post-PA loopback display) and the Internal/External feedback
+// source selector both reduce to a single working choice on HL2:
+// "External coupler". We hide the Internal/External selector on HL2 (the
+// operator can't pick anything else) and the PS-Monitor toggle on HL2
+// (no internal loopback to display). ANAN-class boards (and anything
+// else that shows up here) retain both controls. See issues #121 and #172.
 const HL2_BOARD_ID = 'HermesLite2';
 
 const CAL_STATE_NAMES = [
@@ -60,15 +61,16 @@ const CAL_STATE_NAMES = [
  * amber is reserved for the panadapter trace per CLAUDE.md.
  */
 export function PsSettingsPanel() {
-  const protocol = useConnectionStore((s) => s.connectedProtocol);
-  const p1Disabled = protocol === 'P1';
   // The PS-Monitor source switch only makes sense when there's a real PS
   // feedback receiver. On HL2 we hide the toggle entirely. We key on the
   // CONNECTED board (not preferred) so a user who explicitly selects G2
   // while no radio is attached still sees the control as a preview, but
-  // a live HL2 connection cleanly drops it.
+  // a live HL2 connection cleanly drops it. Same gate hides the
+  // Internal-vs-External feedback source selector — HL2 has only the
+  // external coupler path so the binary is degenerate.
   const connectedBoard = useRadioStore((s) => s.selection.connected);
   const psMonitorSupported = connectedBoard !== HL2_BOARD_ID;
+  const feedbackSourceSelectorSupported = connectedBoard !== HL2_BOARD_ID;
 
   const psEnabled = useTxStore((s) => s.psEnabled);
   const psMonitorEnabled = useTxStore((s) => s.psMonitorEnabled);
@@ -210,22 +212,6 @@ export function PsSettingsPanel() {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
-      {p1Disabled ? (
-        <div
-          style={{
-            padding: 10,
-            border: '1px solid var(--panel-border)',
-            borderRadius: 6,
-            background: 'var(--bg-1)',
-            color: 'var(--fg-2)',
-            fontSize: 11,
-          }}
-        >
-          PureSignal predistortion for Hermes / Protocol 1 is coming in a
-          follow-up. Two-tone test generator below works on both protocols.
-        </div>
-      ) : null}
-
       {/* Calibration */}
       <Section title="Calibration">
         <Row label="Mode">
@@ -235,7 +221,6 @@ export function PsSettingsPanel() {
               name="ps-mode"
               checked={psAuto && !psSingle}
               onChange={() => setMode(true, false)}
-              disabled={p1Disabled}
             />{' '}
             Auto
           </label>
@@ -245,7 +230,6 @@ export function PsSettingsPanel() {
               name="ps-mode"
               checked={psSingle}
               onChange={() => setMode(false, true)}
-              disabled={p1Disabled}
             />{' '}
             Single
           </label>
@@ -254,7 +238,6 @@ export function PsSettingsPanel() {
           <button
             type="button"
             onClick={onReset}
-            disabled={p1Disabled}
             className="btn sm"
           >
             Reset
@@ -269,7 +252,6 @@ export function PsSettingsPanel() {
               setPsAutoAttenuate(v);
               pushAdvanced({ autoAttenuate: v });
             }}
-            disabled={p1Disabled}
           />
         </Row>
       </Section>
@@ -286,7 +268,6 @@ export function PsSettingsPanel() {
               setPsMoxDelaySec(v);
               pushAdvanced({ moxDelaySec: v });
             }}
-            disabled={p1Disabled}
           />
         </Row>
         <Row label="Cal delay (s)">
@@ -299,7 +280,6 @@ export function PsSettingsPanel() {
               setPsLoopDelaySec(v);
               pushAdvanced({ loopDelaySec: v });
             }}
-            disabled={p1Disabled}
           />
         </Row>
         <Row label="Amp delay (ns)">
@@ -312,47 +292,50 @@ export function PsSettingsPanel() {
               setPsAmpDelayNs(v);
               pushAdvanced({ ampDelayNs: v });
             }}
-            disabled={p1Disabled}
           />
         </Row>
       </Section>
 
       {/* Hardware */}
       <Section title="Hardware">
-        <Row label="Feedback source">
-          {/* Two-way selector: Internal coupler (default) or External
-              (Bypass). On G2/MkII this flips ALEX_RX_ANTENNA_BYPASS in
-              alex0 during xmit + PS armed. WDSP cal/iqc are unaffected;
-              the HW-peak slider below stays shared across sources to
-              match pihpsdr/Thetis. Disabled on P1 because P1 PS isn't
-              wired through yet. */}
-          <label
-            style={{ display: 'inline-flex', alignItems: 'center', marginRight: 12 }}
-          >
-            <input
-              type="radio"
-              name="psFeedbackSource"
-              value="internal"
-              checked={psFeedbackSourceState === 'internal'}
-              onChange={() => onFeedbackSourceChange('internal')}
-              disabled={p1Disabled}
-              style={{ marginRight: 4 }}
-            />
-            <span style={{ fontSize: 11, color: 'var(--fg-1)' }}>Internal coupler</span>
-          </label>
-          <label style={{ display: 'inline-flex', alignItems: 'center' }}>
-            <input
-              type="radio"
-              name="psFeedbackSource"
-              value="external"
-              checked={psFeedbackSourceState === 'external'}
-              onChange={() => onFeedbackSourceChange('external')}
-              disabled={p1Disabled}
-              style={{ marginRight: 4 }}
-            />
-            <span style={{ fontSize: 11, color: 'var(--fg-1)' }}>External (Bypass)</span>
-          </label>
-        </Row>
+        {feedbackSourceSelectorSupported ? (
+          <Row label="Feedback source">
+            {/* Two-way selector: Internal coupler (default) or External
+                (Bypass). On G2/MkII this flips ALEX_RX_ANTENNA_BYPASS in
+                alex0 during xmit + PS armed. WDSP cal/iqc are unaffected;
+                the HW-peak slider below stays shared across sources to
+                match pihpsdr/Thetis.
+
+                Hidden on HL2: HL2 has no internal coupler, so the only
+                workable feedback path is external (issue #172). The
+                backend default already routes the wire bit appropriately
+                for HL2 — there's no operator choice to expose. */}
+            <label
+              style={{ display: 'inline-flex', alignItems: 'center', marginRight: 12 }}
+            >
+              <input
+                type="radio"
+                name="psFeedbackSource"
+                value="internal"
+                checked={psFeedbackSourceState === 'internal'}
+                onChange={() => onFeedbackSourceChange('internal')}
+                style={{ marginRight: 4 }}
+              />
+              <span style={{ fontSize: 11, color: 'var(--fg-1)' }}>Internal coupler</span>
+            </label>
+            <label style={{ display: 'inline-flex', alignItems: 'center' }}>
+              <input
+                type="radio"
+                name="psFeedbackSource"
+                value="external"
+                checked={psFeedbackSourceState === 'external'}
+                onChange={() => onFeedbackSourceChange('external')}
+                style={{ marginRight: 4 }}
+              />
+              <span style={{ fontSize: 11, color: 'var(--fg-1)' }}>External (Bypass)</span>
+            </label>
+          </Row>
+        ) : null}
         <Row label="HW peak">
           <NumberInput
             value={psHwPeak}
@@ -363,7 +346,6 @@ export function PsSettingsPanel() {
               setPsHwPeak(v);
               pushAdvanced({ hwPeak: v });
             }}
-            disabled={p1Disabled}
           />
         </Row>
         <Row label="Ints / Spi">
@@ -374,7 +356,6 @@ export function PsSettingsPanel() {
               setPsIntsSpiPreset(v);
               pushAdvanced({ intsSpiPreset: v });
             }}
-            disabled={p1Disabled}
           >
             <option value="16/256">16 / 256</option>
             <option value="8/512">8 / 512</option>
@@ -390,7 +371,6 @@ export function PsSettingsPanel() {
               setPsPtol(v);
               pushAdvanced({ ptol: v });
             }}
-            disabled={p1Disabled}
           />
         </Row>
       </Section>
@@ -407,7 +387,6 @@ export function PsSettingsPanel() {
               type="checkbox"
               checked={psMonitorEnabled}
               onChange={(e) => onPsMonitorToggle(e.target.checked)}
-              disabled={p1Disabled}
               title="Show post-correction signal in TX panadapter"
             />
             <span style={{ fontSize: 11, color: 'var(--fg-2)', marginLeft: 8 }}>

--- a/zeus-web/src/components/PsSettingsPanel.tsx
+++ b/zeus-web/src/components/PsSettingsPanel.tsx
@@ -85,6 +85,7 @@ export function PsSettingsPanel() {
   const psLoopDelaySec = useTxStore((s) => s.psLoopDelaySec);
   const psAmpDelayNs = useTxStore((s) => s.psAmpDelayNs);
   const psHwPeak = useTxStore((s) => s.psHwPeak);
+  const psHwPeakDefault = useTxStore((s) => s.psHwPeakDefault);
   const psIntsSpiPreset = useTxStore((s) => s.psIntsSpiPreset);
   const psFeedbackSourceState = useTxStore((s) => s.psFeedbackSource);
   const psFeedbackLevel = useTxStore((s) => s.psFeedbackLevel);
@@ -368,6 +369,28 @@ export function PsSettingsPanel() {
               pushAdvanced({ hwPeak: v });
             }}
           />
+          {/* mi0bot ref: PSForm.cs:830
+              `pbWarningSetPk.Visible = _PShwpeak != HardwareSpecific.PSDefaultPeak;`
+              + clsHardwareSpecific.cs:303-328 PSDefaultPeak per-board switch.
+              Show a small accent glyph after the input when the operator has
+              dialed PsHwPeak away from the per-board factory default. Title
+              attribute exposes the resolved default for the operator so they
+              know what value would clear the indicator. */}
+          {psHwPeak !== psHwPeakDefault ? (
+            <span
+              aria-label="HW peak differs from per-board default"
+              title={`Differs from default ${psHwPeakDefault.toFixed(4)}`}
+              style={{
+                color: 'var(--accent)',
+                fontSize: 12,
+                fontWeight: 700,
+                marginLeft: 4,
+                userSelect: 'none',
+              }}
+            >
+              *
+            </span>
+          ) : null}
         </Row>
         {/* mi0bot ref: PSForm.cs:624 GetPSMaxTX → PSForm.designer.cs
             txtGetPSpeak readout. Read-only; the operator dials HW peak

--- a/zeus-web/src/components/PsToggleButton.tsx
+++ b/zeus-web/src/components/PsToggleButton.tsx
@@ -32,14 +32,12 @@ const PS_MONITOR_UNSUPPORTED = new Set(['HermesLite2']);
 
 /**
  * PureSignal master arm. Optimistic update with rollback on server refusal —
- * same pattern as MoxButton. Disabled until a P2 radio is connected:
- * Protocol1 PureSignal is deferred to a follow-up because we can only
- * rack-test against a G2 / OrionMkII today. TODO(ps-p1): drop the gate
- * once Protocol1Client gains the SetPuresignal hooks.
+ * same pattern as MoxButton. Available on both Protocol 1 (HL2) and
+ * Protocol 2 (G2 / Orion / Saturn) once issue #172 lands the P1 wire-side
+ * encoders + feedback extractor.
  */
 export function PsToggleButton() {
   const connected = useConnectionStore((s) => s.status === 'Connected');
-  const protocol = useConnectionStore((s) => s.connectedProtocol);
   const psEnabled = useTxStore((s) => s.psEnabled);
   const psAuto = useTxStore((s) => s.psAuto);
   const psSingle = useTxStore((s) => s.psSingle);
@@ -48,15 +46,10 @@ export function PsToggleButton() {
   const setPsMonitorLocal = useTxStore((s) => s.setPsMonitorEnabled);
   const connectedBoard = useRadioStore((s) => s.selection.connected);
 
-  // P1 gate — backend forwards SetPsEnabled to the engine on either protocol
-  // but the wire-side feedback path is P2-only in v1.
-  const p1Disabled = protocol === 'P1';
-  const disabled = !connected || p1Disabled;
-  const tooltip = p1Disabled
-    ? 'PureSignal for Hermes coming in a follow-up'
-    : psEnabled
-      ? 'PureSignal armed — predistortion active'
-      : 'Arm PureSignal predistortion';
+  const disabled = !connected;
+  const tooltip = psEnabled
+    ? 'PureSignal armed — predistortion active'
+    : 'Arm PureSignal predistortion';
 
   const click = useCallback(() => {
     if (disabled) return;

--- a/zeus-web/src/components/filter/FilterPanel.tsx
+++ b/zeus-web/src/components/filter/FilterPanel.tsx
@@ -9,7 +9,7 @@
 // Operators drag any preset chip out of the ribbon onto one of the three
 // buttons here to pin it — same UX as the Mode/Band/Step toolbar groups.
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useConnectionStore } from '../../state/connection-store';
 import {
   setFilter,
@@ -19,6 +19,7 @@ import {
 } from '../../api/client';
 import { useFilterFavoritesStore, useFavoritesForMode } from '../../state/filter-favorites-store';
 import { FILTER_DRAG_MIME } from './FilterRibbon';
+import { getPresetsForMode } from './filterPresets';
 
 const RIBBON_OPEN_KEY = 'zeus.filter.advancedPaneOpen';
 
@@ -31,16 +32,29 @@ export function FilterPanel() {
   const updateFavorites = useFilterFavoritesStore((s) => s.update);
   const favoriteSlotNames = useFavoritesForMode(mode);
 
-  const [presets, setPresets] = useState<FilterPresetDto[]>([]);
+  // Seed from the local Thetis preset table so labels render correctly on
+  // first paint. Without this, the buttons collapse to raw slot names
+  // ("F4", "F5", "F6") for the time it takes /api/filter/presets to resolve,
+  // because the lookup `presets.find(...)` returns undefined against an
+  // empty array. Server VAR overrides land here too once the fetch completes.
+  const localPresets = useMemo<FilterPresetDto[]>(
+    () => getPresetsForMode(mode).map((p) => ({ ...p })),
+    [mode],
+  );
+  const [presets, setPresets] = useState<FilterPresetDto[]>(localPresets);
   const [dragOverIdx, setDragOverIdx] = useState<number | null>(null);
 
   useEffect(() => { void loadFavorites(mode); }, [mode, loadFavorites]);
 
+  // Reseed `presets` to the new mode's local table whenever the mode flips,
+  // so labels never reflect the old mode while the server fetch is in flight.
+  useEffect(() => { setPresets(localPresets); }, [localPresets]);
+
   useEffect(() => {
     let cancelled = false;
     getFilterPresets(mode)
-      .then((list) => { if (!cancelled) setPresets(list); })
-      .catch(() => { if (!cancelled) setPresets([]); });
+      .then((list) => { if (!cancelled && list.length > 0) setPresets(list); })
+      .catch(() => { /* keep local fallback */ });
     return () => { cancelled = true; };
   }, [mode]);
 

--- a/zeus-web/src/components/filter/filterPresets.ts
+++ b/zeus-web/src/components/filter/filterPresets.ts
@@ -143,6 +143,22 @@ export function getPresetsForMode(mode: RxMode): readonly FilterPresetSlot[] {
   return PRESET_MAP[mode] ?? USB;
 }
 
+// Per-mode favorite-slot defaults. Mirrors FilterPresetStore.GetFavoriteSlots
+// on the server so the client can render correct defaults synchronously,
+// before the /api/filter/favorites round-trip resolves. Without this, every
+// first paint shows the ascending ['F4','F5','F6'] generic fallback even
+// though USB/LSB really default to ['F6','F5','F4'] (descending = ascending
+// passband width).
+export function defaultFavoritesForMode(mode: RxMode): readonly string[] {
+  switch (mode) {
+    case 'USB': case 'LSB': case 'DIGL': case 'DIGU': return ['F6', 'F5', 'F4'];
+    case 'CWU': case 'CWL': return ['F4', 'F5', 'F6'];
+    case 'AM':  case 'SAM': return ['F7', 'F8', 'F9'];
+    case 'DSB': return ['F6', 'F7', 'F8'];
+    case 'FM':  return ['F6', 'F5', 'F4'];
+  }
+}
+
 export function formatFilterWidth(lowHz: number, highHz: number): string {
   const width = Math.abs(highHz - lowHz);
   if (width >= 1000) {

--- a/zeus-web/src/state/filter-favorites-store.ts
+++ b/zeus-web/src/state/filter-favorites-store.ts
@@ -11,8 +11,7 @@ import {
   setFavoriteFilterSlots,
   type RxMode,
 } from '../api/client';
-
-const DEFAULT_FAVORITES: readonly string[] = ['F4', 'F5', 'F6'];
+import { defaultFavoritesForMode } from '../components/filter/filterPresets';
 
 type FilterFavoritesState = {
   byMode: Partial<Record<RxMode, string[]>>;
@@ -31,12 +30,12 @@ export const useFilterFavoritesStore = create<FilterFavoritesState>((set, get) =
     try {
       const slots = await getFavoriteFilterSlots(mode);
       set((s) => ({
-        byMode: { ...s.byMode, [mode]: slots.length === 3 ? slots : [...DEFAULT_FAVORITES] },
+        byMode: { ...s.byMode, [mode]: slots.length === 3 ? slots : [...defaultFavoritesForMode(mode)] },
         loading: { ...s.loading, [mode]: false },
       }));
     } catch {
       set((s) => ({
-        byMode: { ...s.byMode, [mode]: [...DEFAULT_FAVORITES] },
+        byMode: { ...s.byMode, [mode]: [...defaultFavoritesForMode(mode)] },
         loading: { ...s.loading, [mode]: false },
       }));
     }
@@ -57,5 +56,5 @@ export const useFilterFavoritesStore = create<FilterFavoritesState>((set, get) =
 
 export function useFavoritesForMode(mode: RxMode): string[] {
   const slots = useFilterFavoritesStore((s) => s.byMode[mode]);
-  return slots ?? [...DEFAULT_FAVORITES];
+  return slots ?? [...defaultFavoritesForMode(mode)];
 }

--- a/zeus-web/src/state/tx-store.ts
+++ b/zeus-web/src/state/tx-store.ts
@@ -197,6 +197,11 @@ export type TxState = {
   setPsAmpDelayNs: (ns: number) => void;
   psHwPeak: number;
   setPsHwPeak: (p: number) => void;
+  // Per-board factory default resolved by the server at connect time. UI
+  // compares psHwPeak against this to show a "differs from default" hint.
+  // mi0bot ref: PSForm.cs:830 pbWarningSetPk.Visible = _PShwpeak !=
+  // HardwareSpecific.PSDefaultPeak.
+  psHwPeakDefault: number;
   psIntsSpiPreset: string;
   setPsIntsSpiPreset: (p: string) => void;
   // Feedback antenna source — Internal coupler (default) or External
@@ -351,6 +356,10 @@ export const useTxStore = create<TxState>()(
       setPsAmpDelayNs: (ns) => set({ psAmpDelayNs: ns }),
       psHwPeak: 0.4072,
       setPsHwPeak: (p) => set({ psHwPeak: p }),
+      // Pre-connect default mirrors PsHwPeak; ApplyPsHwPeakForConnection on
+      // the server will push the per-board value into the StateDto, and
+      // hydrateFromState below picks it up. mi0bot PSForm.cs:830 ref.
+      psHwPeakDefault: 0.4072,
       psIntsSpiPreset: '16/256',
       setPsIntsSpiPreset: (p) => set({ psIntsSpiPreset: p }),
       psFeedbackSource: 'internal',
@@ -398,6 +407,11 @@ export const useTxStore = create<TxState>()(
           psAmpDelayNs: s.psAmpDelayNs,
           psIntsSpiPreset: s.psIntsSpiPreset,
           psFeedbackSource: s.psFeedbackSource,
+          // mi0bot ref: PSForm.cs:830 — per-board factory default frozen by
+          // the server in ApplyPsHwPeakForConnection. Hydrated alongside the
+          // operator-tuned psHwPeak so the UI sees a coherent pair.
+          psHwPeak: s.psHwPeak,
+          psHwPeakDefault: s.psHwPeakDefault,
           twoToneFreq1: s.twoToneFreq1,
           twoToneFreq2: s.twoToneFreq2,
           twoToneMag: s.twoToneMag,


### PR DESCRIPTION
Closes #172.

## Summary

First-pass implementation of PureSignal predistortion on Hermes Lite 2 over Protocol 1, with external PA + external feedback coupler. The G2/Orion Protocol-2 PS path is shipped and unchanged — `Zeus.Protocol2/` and `Zeus.Dsp/` are untouched in this PR (verified empty diff against `release/0.5.0`).

**KB2UKA cannot rack-test (no HL2 on the bench).** Brian's HL2 rig is the first hardware contact. Push-to-test happened on https://github.com/brianbruff/openhpsdr-zeus/issues/172#issuecomment-4364873116 — Brian gave the green light to open this PR. The two design choices made under uncertainty are documented in the comment with override paths if the rack-test surfaces something.

## Phase 1 — research

mi0bot/openhpsdr-thetis (HL2 fork) cloned and treated as the authoritative reference per the issue body. Cross-checked against pihpsdr (DL1YCF). Key findings written to `docs/references/protocol-1/hermes-lite2-protocol.md` with file:line citations + commit SHA.

The blocking unknown — *"how does the gateware surface feedback IQ when register `0x0a[22]` is set?"* — is answered: feedback samples come back **inside the existing EP6 RX stream**, NOT a new packet type. The HL2 gateware re-points one of the DDCs onto the dedicated feedback ADC (ADC1) when `puresignal_run` is set. Two layouts work; this PR ships the **2-DDC paired layout** (smaller `PacketParser` change). Override path documented if rack-test wants 4-DDC.

PR #119's two encoding bugs are both confirmed real and corrected:
- PS enable bit `0x0a[22]` is **C2 bit 6** of the C0=0x14 frame (mi0bot `networkproto1.c:1102`), NOT C3 bit 6.
- Predistortion subindex `0x2b[19:16]` is **C2 [3:0]** (low nibble), NOT [7:4].

19 unit tests in `tests/Zeus.Protocol1.Tests/ControlFramePsEncoderTests.cs` pin both regressions.

HL2 hwPeak = **0.233** confirmed against mi0bot `clsHardwareSpecific.cs:322,332`.

## Phase 2 — implementation

5 commits. File-by-file:

- **`Zeus.Protocol1/ControlFrame.cs`** — `CcState` extended with `PsEnabled`, `PsPredistortionValue`, `PsPredistortionSubindex`, `NumReceiversMinusOne`. `WriteAttenuatorPayload` ORs PS bit into C2 bit 6 when HL2 + PsEnabled (preserves existing C4 atten payload). New `WritePredistortionPayload` for register 0x2b. New `CcRegister.Predistortion = 0x56`.
- **`Zeus.Protocol1/Protocol1Client.cs`** — adds `SetPsEnabled` / `SetPsPredistortion`, `PsFeedbackFrames` channel, `PsTapIqSource` (mirrors every TX sample into a 2048-deep ring), `HandlePsPairedRxPacket` (decodes DDC1 = feedback, pairs with TX-ring samples, emits 1024-sample blocks), `PsPairedPacketCount` diagnostic. RX loop dispatches to the paired parser when `PsEnabled && HL2`. `PhaseRegisters` gains an 8-phase `psArmed` rotation including the Predistortion register.
- **`Zeus.Protocol1/PacketParser.cs`** — adds `TryParsePsPairedPacket` (14-byte sample slot: 3I+3Q DDC0 + 3I+3Q DDC1 + 2 mic, 72 paired samples/packet). The legacy `TryParsePacket` is **untouched**.
- **`Zeus.Protocol1/PsFeedbackFrame.cs`** (new) — sibling of `Zeus.Protocol2.PsFeedbackFrame` with identical shape (no `Zeus.Contracts` touch).
- **`Zeus.Protocol1/IProtocol1Client.cs`** — interface gains `SetPsEnabled`, `PsEnabled`, `SetPsPredistortion`, `PsFeedbackFrames`, `PsPairedPacketCount`.
- **`Zeus.Server.Hosting/DspPipelineService.cs`** — adds `StartPsFeedbackPumpP1` (sibling of P2 pump, identical lifecycle). `OnRadioConnected` starts the new P1 pump, sets `_psResyncRequired`, and calls `ApplyPsHwPeakForConnection(isProtocol2: false, …)` — this is new on the P1 path and is the reason HL2's 0.233 default now reaches the engine on first connect. `OnRadioStateChanged` PS-arm block now dispatches `SetPsEnabled` to the active P1 client in addition to the existing P2 dispatch. `DrainPsFeedback` handles either client.
- **`tests/Zeus.Protocol1.Tests/ControlFramePsEncoderTests.cs`** (new) — 19 unit tests pinning both PR #119 regression bugs (PS bit in C2 not C3; predistortion value in C2 [3:0] not [7:4]), the non-HL2-board guard, and the C4 num-receivers field.
- **`zeus-web/src/components/PsToggleButton.tsx`** — drops the `p1Disabled` gate.
- **`zeus-web/src/components/PsSettingsPanel.tsx`** — drops the P1 banner + every `disabled={p1Disabled}`. Adds `feedbackSourceSelectorSupported = connectedBoard !== HL2_BOARD_ID` and gates the Internal/External row on it.

## Two design choices — overridable if rack-test wants

Both flagged in the issue comment for Brian's optional override:

1. **2-DDC vs 4-DDC paired layout** — picked 2-DDC (smaller surface). mi0bot ships 4-DDC by default for HL2 (`rx_feedback_channel=2, tx_feedback_channel=3, n_receivers=4` in pihpsdr too). Trade-off: with 2-DDC, RX1 panadapter pauses while PS is armed (DDC0 at TX freq). Override path is mechanical (`NumReceiversMinusOne = 3` + extend `TryParsePsPairedPacket` for the 4-DDC byte interleave). Canonical "wrong layout" symptom: `Protocol1Client.PsPairedPacketCount` flat-zero on first arm.
2. **Predistortion register write cadence** — picked **1 of 8 phases**. mi0bot writes opportunistically inside `WriteMainLoop_HL2`. The register persists in gateware once written, so 1-of-8 should be plenty; bump to 1-of-4 if convergence is slow on the rack.

## P2 regression sanity check — PASSED

```
git diff origin/release/0.5.0..HEAD -- Zeus.Protocol2/ Zeus.Dsp/
```

Returns **empty**. No edits to `Protocol2Client.cs`, the WdspDspEngine PS paths, the G2 `RadioCalibration.OrionMkII` bucket, or the G2 HW peak (`0.6121`). KB2UKA cherry-picked the 5 commits onto his local kb2uka/local and re-tested G2 PS on his MkII — armed cleanly, calcc converged, no operator-visible regression.

## Tests

- `dotnet build Zeus.slnx` — clean (0 warnings, 0 errors).
- `dotnet test Zeus.slnx` — **714 passed** (19 new). Per-project: P1=138, P2=36, Contracts=60, Server=278, PluginHost=40, Dsp=162.
- `npm --prefix zeus-web run typecheck` — clean.
- `npm --prefix zeus-web run build` — clean.
- `npm --prefix zeus-web run test` — 192 passed.

## Red-light items per CLAUDE.md needing maintainer sign-off

1. **HL2 hwPeak default = 0.233** on first P1 connect via `ApplyPsHwPeakForConnection(isProtocol2: false, …)`. Sourced from mi0bot but it's an operator-felt default.
2. **Hidden internal-feedback-source selector on HL2** in `PsSettingsPanel`. HL2 has no internal coupler; the selector row is hidden via the same `connectedBoard !== HL2_BOARD_ID` gate the panel already uses for `psMonitorSupported`.
3. **`p1Disabled` UI gate dropped** on `PsToggleButton` and `PsSettingsPanel`. PS controls go live on a Protocol-1 connection. The TODO comment at `PsToggleButton.tsx:32` (`TODO(ps-p1)`) explicitly anticipated this work.
4. **Predistortion register added to TX-loop rotation** (1 of 8 frames) when PS armed + HL2 connected. Tiny TX-side bandwidth shift but it's a wire-traffic change.

## What Brian needs to verify on the rack (recap from issue comment)

**On connect:**
- New log line: `radio.applyPsHwPeak proto=P1 board=HermesLite2 peak=0.2330`. Missing = the new P1 branch in `OnRadioConnected` didn't fire and PS won't arm cleanly.

**Arm PS, MOX off:**
- EP6 packets switch to 2-DDC layout. Panadapter pauses (DDC0 is at TX freq — expected with 2-DDC).
- `Protocol1Client.PsPairedPacketCount` should climb at the EP6 RX rate (~381 paired blocks/sec at 48 kSps).
- Flat-zero counter = canonical "wire bit set but gateware didn't emit paired frames" symptom. First debug step: bump to 4-DDC layout per the override path above.

**Arm PS, MOX on (two-tone):**
```
Set Two-Tone freq1 = 700, freq2 = 1900, mag = 0.7
Arm Two-Tone
Arm PS
Press TUN
```
- calcc state machine advances RESET → COLLECT → CALC.
- `PsCorrecting` flips to true within a few seconds.
- Correction-dB readout climbs to whatever the external PA's IMD3 actually is.
- IMD3 reduction visible on a spectrum analyser.

If calcc is slow to converge — first knob to turn is `PsAmpDelayNs`. Zeus's TX-IQ ↔ DDC1-feedback alignment is approximate (snapshot-and-walk-backwards in a 2048-sample ring); calcc's coarse delay search and `PsAmpDelayNs` should cover the rest.

## Out of scope

- Bare Hermes / Hermes-original PS (different gateware, separate issue).
- Internal-coupler PS on HL2 (hardware doesn't have one).
- 4-DDC layout migration (deferred until 2-DDC is validated or rejected on Brian's rack).

— Doug, KB2UKA
