### PR TITLE
feat(web/settings): redesign Display tab

### DIFF
--- a/zeus-web/src/components/BackgroundSettingsPanel.tsx
+++ b/zeus-web/src/components/BackgroundSettingsPanel.tsx
@@ -20,10 +20,58 @@ import {
   type PanBackgroundMode,
 } from '../state/display-settings-store';
 
-const MODE_OPTIONS: ReadonlyArray<{ id: PanBackgroundMode; label: string; help: string }> = [
-  { id: 'basic', label: 'Basic', help: 'Plain panadapter and waterfall — no overlay.' },
-  { id: 'beam-map', label: 'Beam Map', help: 'World map behind the panadapter, with QRZ contact and rotator overlays when configured.' },
-  { id: 'image', label: 'Image', help: 'Show a custom image behind the panadapter.' },
+type ModeOption = {
+  id: PanBackgroundMode;
+  label: string;
+  help: string;
+  icon: React.ReactNode;
+};
+
+const iconSvg: React.CSSProperties = {
+  width: 13,
+  height: 13,
+  stroke: 'currentColor',
+  fill: 'none',
+  strokeWidth: 1.6,
+  strokeLinecap: 'round',
+  strokeLinejoin: 'round',
+};
+
+const MODE_OPTIONS: ReadonlyArray<ModeOption> = [
+  {
+    id: 'basic',
+    label: 'Basic',
+    help: 'Plain panadapter and waterfall — no overlay.',
+    icon: (
+      <svg viewBox="0 0 16 16" style={iconSvg}>
+        <path d="M2 11l3-3 3 3 3-4 3 3" />
+        <path d="M2 14h12" />
+      </svg>
+    ),
+  },
+  {
+    id: 'beam-map',
+    label: 'Beam Map',
+    help: 'World map with QRZ contact and rotator overlays.',
+    icon: (
+      <svg viewBox="0 0 16 16" style={iconSvg}>
+        <circle cx="8" cy="8" r="6" />
+        <path d="M2 8h12M8 2c2.5 2.7 2.5 9.3 0 12M8 2c-2.5 2.7-2.5 9.3 0 12" />
+      </svg>
+    ),
+  },
+  {
+    id: 'image',
+    label: 'Image',
+    help: 'Show a custom image behind the panadapter.',
+    icon: (
+      <svg viewBox="0 0 16 16" style={iconSvg}>
+        <rect x="2" y="3" width="12" height="10" rx="1.5" />
+        <circle cx="6" cy="7" r="1.2" />
+        <path d="M2 11l3-3 4 4 2-2 3 3" />
+      </svg>
+    ),
+  },
 ];
 
 const FIT_OPTIONS: ReadonlyArray<{ id: BackgroundImageFit; label: string }> = [
@@ -127,36 +175,36 @@ export function BackgroundSettingsPanel() {
 
   return (
     <section>
-      <h3 style={sectionH3}>Panadapter Background</h3>
-      <p style={sectionP}>
-        Choose what's drawn behind the panadapter and waterfall. Beam Map needs
-        QRZ configured under the QRZ tab to populate contact lookups.
-      </p>
+      <div style={sectionHead}>
+        <h3 style={sectionH3}>Panadapter Background</h3>
+        <p style={sectionP}>Beam Map needs QRZ configured to populate contact lookups.</p>
+      </div>
 
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <div role="radiogroup" aria-label="Panadapter background mode" style={segmentedGrid(3)}>
         {MODE_OPTIONS.map((opt) => {
           const active = panBackground === opt.id;
           return (
-            <label key={opt.id} style={modeRowStyle(active)}>
-              <input
-                type="radio"
-                name="pan-background"
-                value={opt.id}
-                checked={active}
-                onChange={() => { void setPanBackground(opt.id); }}
-                style={{ cursor: 'pointer' }}
-              />
-              <div style={{ flex: 1 }}>
-                <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--fg-0)' }}>{opt.label}</div>
-                <div style={{ fontSize: 11, color: 'var(--fg-2)', marginTop: 2 }}>{opt.help}</div>
+            <button
+              key={opt.id}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              onClick={() => { void setPanBackground(opt.id); }}
+              style={segCardStyle(active)}
+            >
+              <span style={checkDotStyle(active)} aria-hidden />
+              <div style={segTopRow}>
+                <span style={segIconBoxStyle(active)} aria-hidden>{opt.icon}</span>
+                <span style={segTitle}>{opt.label}</span>
               </div>
-            </label>
+              <span style={segHelp}>{opt.help}</span>
+            </button>
           );
         })}
       </div>
 
       {panBackground === 'image' && (
-        <div style={{ marginTop: 16, display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div style={{ marginTop: 14, display: 'flex', flexDirection: 'column', gap: 12 }}>
           <div
             onDragEnter={onDragEnter}
             onDragOver={onDragOver}
@@ -200,10 +248,8 @@ export function BackgroundSettingsPanel() {
           {busy && <div style={{ fontSize: 11, color: 'var(--fg-2)' }}>Processing…</div>}
           {error && <div style={{ fontSize: 11, color: 'var(--tx)' }}>{error}</div>}
 
-          <div>
-            <div style={{ fontSize: 11, fontWeight: 600, color: 'var(--fg-1)', marginBottom: 6 }}>
-              Sizing
-            </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
+            <span style={inlineLabel}>Sizing</span>
             <div style={{ display: 'flex', gap: 6 }}>
               {FIT_OPTIONS.map((opt) => {
                 const active = backgroundImageFit === opt.id;
@@ -219,52 +265,127 @@ export function BackgroundSettingsPanel() {
                 );
               })}
             </div>
+            {backgroundImage && (
+              <button
+                type="button"
+                className="btn sm"
+                style={{ marginLeft: 'auto' }}
+                onClick={() => { void setBackgroundImage(null); }}
+              >
+                CLEAR IMAGE
+              </button>
+            )}
           </div>
-
-          {backgroundImage && (
-            <button
-              type="button"
-              className="btn sm"
-              style={{ alignSelf: 'flex-start' }}
-              onClick={() => { void setBackgroundImage(null); }}
-            >
-              CLEAR IMAGE
-            </button>
-          )}
         </div>
       )}
     </section>
   );
 }
 
+const sectionHead: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'baseline',
+  flexWrap: 'wrap',
+  gap: 10,
+  marginBottom: 10,
+};
 const sectionH3: React.CSSProperties = {
-  margin: '0 0 10px 0',
+  margin: 0,
   fontSize: 11,
   fontWeight: 700,
-  letterSpacing: '0.12em',
+  letterSpacing: '0.18em',
   textTransform: 'uppercase',
   color: 'var(--fg-0)',
 };
 const sectionP: React.CSSProperties = {
-  margin: '0 0 12px 0',
+  margin: 0,
   fontSize: 12,
   lineHeight: 1.5,
   color: 'var(--fg-2)',
 };
-function modeRowStyle(active: boolean): React.CSSProperties {
+const inlineLabel: React.CSSProperties = {
+  fontSize: 10,
+  letterSpacing: '0.16em',
+  textTransform: 'uppercase',
+  color: 'var(--fg-2)',
+  fontWeight: 600,
+};
+
+function segmentedGrid(cols: number): React.CSSProperties {
   return {
-    display: 'flex',
-    alignItems: 'center',
+    display: 'grid',
+    gridTemplateColumns: `repeat(${cols}, 1fr)`,
     gap: 8,
-    padding: '8px 12px',
-    borderRadius: 'var(--r-sm)',
-    background: active ? 'var(--bg-2)' : 'transparent',
-    border: '1px solid',
-    borderColor: active ? 'var(--accent)' : 'var(--line)',
-    cursor: 'pointer',
-    transition: 'all var(--dur-fast)',
   };
 }
+
+function segCardStyle(active: boolean): React.CSSProperties {
+  return {
+    position: 'relative',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 6,
+    minHeight: 76,
+    padding: '12px 12px 11px',
+    textAlign: 'left',
+    border: '1px solid',
+    borderColor: active ? 'var(--accent)' : 'var(--line)',
+    background: active ? 'var(--accent-soft)' : 'var(--bg-1)',
+    boxShadow: active ? 'inset 0 0 0 1px var(--accent)' : 'none',
+    borderRadius: 'var(--r-md)',
+    cursor: 'pointer',
+    color: 'var(--fg-1)',
+    transition: 'background var(--dur-fast), border-color var(--dur-fast)',
+  };
+}
+
+function segIconBoxStyle(active: boolean): React.CSSProperties {
+  return {
+    width: 22,
+    height: 22,
+    display: 'inline-grid',
+    placeItems: 'center',
+    borderRadius: 'var(--r-sm)',
+    background: active ? 'var(--accent)' : 'var(--bg-3)',
+    border: active ? '1px solid var(--accent)' : '1px solid var(--line)',
+    color: active ? '#0b1220' : 'var(--fg-1)',
+    flexShrink: 0,
+  };
+}
+
+function checkDotStyle(active: boolean): React.CSSProperties {
+  return {
+    position: 'absolute',
+    top: 9,
+    right: 9,
+    width: 14,
+    height: 14,
+    borderRadius: '50%',
+    border: `1.5px solid ${active ? 'var(--accent)' : 'var(--line)'}`,
+    background: active
+      ? 'radial-gradient(circle at center, var(--accent) 0 4px, transparent 4.5px)'
+      : 'transparent',
+    transition: 'border-color var(--dur-fast), background var(--dur-fast)',
+  };
+}
+
+const segTopRow: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+};
+const segTitle: React.CSSProperties = {
+  fontSize: 13,
+  fontWeight: 700,
+  color: 'var(--fg-0)',
+  letterSpacing: '0.02em',
+};
+const segHelp: React.CSSProperties = {
+  fontSize: 11.5,
+  color: 'var(--fg-2)',
+  lineHeight: 1.45,
+};
+
 function dropZoneStyle(active: boolean): React.CSSProperties {
   return {
     border: '2px dashed',
@@ -272,7 +393,7 @@ function dropZoneStyle(active: boolean): React.CSSProperties {
     borderRadius: 'var(--r-sm)',
     padding: 14,
     cursor: 'pointer',
-    background: active ? 'rgba(74, 158, 255, 0.06)' : 'rgba(255,255,255,0.02)',
+    background: active ? 'var(--accent-soft)' : 'rgba(255,255,255,0.02)',
     transition: 'all var(--dur-fast)',
   };
 }

--- a/zeus-web/src/components/DisplayPanel.tsx
+++ b/zeus-web/src/components/DisplayPanel.tsx
@@ -24,14 +24,58 @@ import { useLayoutStore } from '../state/layout-store';
 import { BackgroundSettingsPanel } from './BackgroundSettingsPanel';
 import { TraceColorPanel } from './TraceColorPanel';
 
+type LayoutOption = {
+  id: LayoutMode;
+  label: string;
+  help: string;
+  icon: React.ReactNode;
+};
+
+const iconSvg: React.CSSProperties = {
+  width: 13,
+  height: 13,
+  stroke: 'currentColor',
+  fill: 'none',
+  strokeWidth: 1.6,
+  strokeLinecap: 'round',
+  strokeLinejoin: 'round',
+};
+
+const LAYOUT_OPTIONS: ReadonlyArray<LayoutOption> = [
+  {
+    id: 'default',
+    label: 'Default Layout',
+    help: 'Fixed panel positions, consistent spacing.',
+    icon: (
+      <svg viewBox="0 0 16 16" style={iconSvg}>
+        <rect x="2" y="2" width="12" height="12" rx="1.5" />
+        <path d="M2 6h12M6 6v8" />
+      </svg>
+    ),
+  },
+  {
+    id: 'flex',
+    label: 'Flex Layout',
+    help: 'Dockable panels, customizable arrangement.',
+    icon: (
+      <svg viewBox="0 0 16 16" style={iconSvg}>
+        <rect x="2" y="2" width="5" height="5" rx="1" />
+        <rect x="9" y="2" width="5" height="5" rx="1" />
+        <rect x="2" y="9" width="5" height="5" rx="1" />
+        <rect x="9" y="9" width="5" height="5" rx="1" />
+      </svg>
+    ),
+  },
+];
+
 export function DisplayPanel() {
   const layoutMode = useLayoutPreferenceStore((s) => s.layoutMode);
   const setLayoutMode = useLayoutPreferenceStore((s) => s.setLayoutMode);
   const resetLayout = useLayoutStore((s) => s.resetLayout);
 
   const handleLayoutChange = (mode: LayoutMode) => {
+    if (mode === layoutMode) return;
     setLayoutMode(mode);
-    // Reload the page to apply the new layout mode
     window.location.reload();
   };
 
@@ -43,129 +87,149 @@ export function DisplayPanel() {
   };
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
       <BackgroundSettingsPanel />
 
       <TraceColorPanel />
 
       <section>
-        <h3 style={{
-          margin: '0 0 10px 0',
-          fontSize: 11,
-          fontWeight: 700,
-          letterSpacing: '0.12em',
-          textTransform: 'uppercase',
-          color: 'var(--fg-0)',
-        }}>
-          Layout Mode
-        </h3>
-        <p style={{
-          margin: '0 0 12px 0',
-          fontSize: 12,
-          lineHeight: 1.5,
-          color: 'var(--fg-2)',
-        }}>
-          Choose between the default fixed layout or the flexible dockable layout.
-          Changes require a page reload.
-        </p>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-          <label
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 8,
-              padding: '8px 12px',
-              borderRadius: 'var(--r-sm)',
-              background: layoutMode === 'default' ? 'var(--bg-2)' : 'transparent',
-              border: '1px solid',
-              borderColor: layoutMode === 'default' ? 'var(--accent)' : 'var(--line)',
-              cursor: 'pointer',
-              transition: 'all var(--dur-fast)',
-            }}
-          >
-            <input
-              type="radio"
-              name="layout-mode"
-              value="default"
-              checked={layoutMode === 'default'}
-              onChange={() => handleLayoutChange('default')}
-              style={{ cursor: 'pointer' }}
-            />
-            <div style={{ flex: 1 }}>
-              <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--fg-0)' }}>
-                Default Layout
-              </div>
-              <div style={{ fontSize: 11, color: 'var(--fg-2)', marginTop: 2 }}>
-                Fixed panel positions, consistent spacing
-              </div>
-            </div>
-          </label>
-          <label
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 8,
-              padding: '8px 12px',
-              borderRadius: 'var(--r-sm)',
-              background: layoutMode === 'flex' ? 'var(--bg-2)' : 'transparent',
-              border: '1px solid',
-              borderColor: layoutMode === 'flex' ? 'var(--accent)' : 'var(--line)',
-              cursor: 'pointer',
-              transition: 'all var(--dur-fast)',
-            }}
-          >
-            <input
-              type="radio"
-              name="layout-mode"
-              value="flex"
-              checked={layoutMode === 'flex'}
-              onChange={() => handleLayoutChange('flex')}
-              style={{ cursor: 'pointer' }}
-            />
-            <div style={{ flex: 1 }}>
-              <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--fg-0)' }}>
-                Flex Layout
-              </div>
-              <div style={{ fontSize: 11, color: 'var(--fg-2)', marginTop: 2 }}>
-                Dockable panels, customizable arrangement
-              </div>
-            </div>
-          </label>
+        <div style={sectionHead}>
+          <h3 style={sectionH3}>Layout Mode</h3>
+          <p style={sectionP}>Changes require a page reload.</p>
         </div>
-      </section>
 
-      {layoutMode === 'flex' && (
-        <section>
-          <h3 style={{
-            margin: '0 0 10px 0',
-            fontSize: 11,
-            fontWeight: 700,
-            letterSpacing: '0.12em',
-            textTransform: 'uppercase',
-            color: 'var(--fg-0)',
-          }}>
-            Flex Layout Options
-          </h3>
-          <p style={{
-            margin: '0 0 12px 0',
-            fontSize: 12,
-            lineHeight: 1.5,
-            color: 'var(--fg-2)',
-          }}>
-            Reset the flex layout to restore the default panel arrangement.
-          </p>
-          <button
-            type="button"
-            className="btn sm"
-            onClick={handleResetFlexLayout}
-            style={{
-              width: 'fit-content',
-            }}
-          >
-            RESET FLEX LAYOUT
-          </button>
-        </section>
-      )}
+        <div role="radiogroup" aria-label="Layout mode" style={segmentedGrid(2)}>
+          {LAYOUT_OPTIONS.map((opt) => {
+            const active = layoutMode === opt.id;
+            return (
+              <button
+                key={opt.id}
+                type="button"
+                role="radio"
+                aria-checked={active}
+                onClick={() => handleLayoutChange(opt.id)}
+                style={segCardStyle(active, true)}
+              >
+                <span style={checkDotStyle(active)} aria-hidden />
+                <div style={segTopRow}>
+                  <span style={segIconBoxStyle(active)} aria-hidden>{opt.icon}</span>
+                  <span style={segTitle}>{opt.label}</span>
+                </div>
+                <span style={segHelp}>{opt.help}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        {layoutMode === 'flex' && (
+          <div style={{ marginTop: 12 }}>
+            <button
+              type="button"
+              className="btn sm"
+              onClick={handleResetFlexLayout}
+            >
+              RESET FLEX LAYOUT
+            </button>
+          </div>
+        )}
+      </section>
     </div>
   );
 }
+
+const sectionHead: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'baseline',
+  flexWrap: 'wrap',
+  gap: 10,
+  marginBottom: 10,
+};
+const sectionH3: React.CSSProperties = {
+  margin: 0,
+  fontSize: 11,
+  fontWeight: 700,
+  letterSpacing: '0.18em',
+  textTransform: 'uppercase',
+  color: 'var(--fg-0)',
+};
+const sectionP: React.CSSProperties = {
+  margin: 0,
+  fontSize: 12,
+  lineHeight: 1.5,
+  color: 'var(--fg-2)',
+};
+
+function segmentedGrid(cols: number): React.CSSProperties {
+  return {
+    display: 'grid',
+    gridTemplateColumns: `repeat(${cols}, 1fr)`,
+    gap: 8,
+  };
+}
+
+function segCardStyle(active: boolean, compact: boolean): React.CSSProperties {
+  return {
+    position: 'relative',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 6,
+    minHeight: compact ? undefined : 76,
+    padding: compact ? '10px 12px' : '12px 12px 11px',
+    textAlign: 'left',
+    border: '1px solid',
+    borderColor: active ? 'var(--accent)' : 'var(--line)',
+    background: active ? 'var(--accent-soft)' : 'var(--bg-1)',
+    boxShadow: active ? 'inset 0 0 0 1px var(--accent)' : 'none',
+    borderRadius: 'var(--r-md)',
+    cursor: 'pointer',
+    color: 'var(--fg-1)',
+    transition: 'background var(--dur-fast), border-color var(--dur-fast)',
+  };
+}
+
+function segIconBoxStyle(active: boolean): React.CSSProperties {
+  return {
+    width: 22,
+    height: 22,
+    display: 'inline-grid',
+    placeItems: 'center',
+    borderRadius: 'var(--r-sm)',
+    background: active ? 'var(--accent)' : 'var(--bg-3)',
+    border: active ? '1px solid var(--accent)' : '1px solid var(--line)',
+    color: active ? '#0b1220' : 'var(--fg-1)',
+    flexShrink: 0,
+  };
+}
+
+function checkDotStyle(active: boolean): React.CSSProperties {
+  return {
+    position: 'absolute',
+    top: 9,
+    right: 9,
+    width: 14,
+    height: 14,
+    borderRadius: '50%',
+    border: `1.5px solid ${active ? 'var(--accent)' : 'var(--line)'}`,
+    background: active
+      ? 'radial-gradient(circle at center, var(--accent) 0 4px, transparent 4.5px)'
+      : 'transparent',
+    transition: 'border-color var(--dur-fast), background var(--dur-fast)',
+  };
+}
+
+const segTopRow: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+};
+const segTitle: React.CSSProperties = {
+  fontSize: 13,
+  fontWeight: 700,
+  color: 'var(--fg-0)',
+  letterSpacing: '0.02em',
+};
+const segHelp: React.CSSProperties = {
+  fontSize: 11.5,
+  color: 'var(--fg-2)',
+  lineHeight: 1.45,
+};

--- a/zeus-web/src/components/TraceColorPanel.tsx
+++ b/zeus-web/src/components/TraceColorPanel.tsx
@@ -13,119 +13,280 @@
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 
+import { useId, useMemo } from 'react';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
 
-const SWATCHES: ReadonlyArray<{ id: string; label: string; color: string }> = [
-  { id: 'amber',   label: 'Amber',   color: '#FFA028' },
-  { id: 'orange',  label: 'Orange',  color: '#FF7A2E' },
-  { id: 'yellow',  label: 'Yellow',  color: '#FFD93A' },
-  { id: 'red',     label: 'Red',     color: '#FF4A5B' },
-  { id: 'lime',    label: 'Lime',    color: '#A8E63A' },
-  { id: 'green',   label: 'Green',   color: '#33D17A' },
-  { id: 'mint',    label: 'Mint',    color: '#3AE6C5' },
-  { id: 'cyan',    label: 'Cyan',    color: '#5BE5FF' },
-  { id: 'sky',     label: 'Sky',     color: '#4A9EFF' },
-  { id: 'purple',  label: 'Purple',  color: '#A66BFF' },
-  { id: 'magenta', label: 'Magenta', color: '#FF5BC8' },
-  { id: 'white',   label: 'White',   color: '#E8ECF4' },
+const SWATCHES: ReadonlyArray<string> = [
+  '#FFA028', '#FF7A1A', '#FFD93D', '#FF5C72', '#B8E83C', '#3CCB6E',
+  '#3CE0B5', '#5BD4FF', '#4D8BFF', '#A777FF', '#FF55C8', '#E6E8EE',
+  '#FFFFFF', '#A0A6B2', '#5C6470', '#262A33', '#FF3B30', '#34C759',
+  '#0A84FF', '#BF5AF2', '#FF9F0A', '#5AC8FA', '#FFD60A', '#30D158',
 ];
+
+function isHexColor(v: string): boolean {
+  return /^#[0-9A-Fa-f]{6}$/.test(v);
+}
+
+// Generate a canned panadapter trace that's recomputed only when the panel
+// mounts. We don't want it dancing on every render — the purpose is to show
+// how the user's chosen RX color reads against typical spectrum content, not
+// to animate.
+function buildTracePath(): string {
+  const W = 360;
+  const H = 108;
+  const N = 90;
+  const peaks = [
+    { x: 80, h: 60, w: 4 },
+    { x: 180, h: 40, w: 6 },
+    { x: 270, h: 70, w: 3 },
+  ];
+  let d = `M0 ${H} `;
+  let seed = 1337;
+  const rand = () => {
+    // Mulberry32 — small, repeatable. Lets the preview look "noisy" without
+    // re-rolling on every render.
+    seed = (seed + 0x6d2b79f5) | 0;
+    let t = seed;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+  for (let i = 0; i <= N; i++) {
+    const x = (i / N) * W;
+    let y = 80 + Math.sin(i * 0.4) * 4 + (rand() - 0.5) * 6;
+    for (const p of peaks) y -= p.h * Math.exp(-Math.pow((x - p.x) / p.w, 2));
+    d += `L${x.toFixed(1)} ${Math.max(4, y).toFixed(1)} `;
+  }
+  return d + `L${W} ${H} Z`;
+}
 
 export function TraceColorPanel() {
   const rxTraceColor = useDisplaySettingsStore((s) => s.rxTraceColor);
   const setRxTraceColor = useDisplaySettingsStore((s) => s.setRxTraceColor);
   const norm = rxTraceColor.toUpperCase();
+  const gradId = useId();
+  const tracePath = useMemo(() => buildTracePath(), []);
 
   return (
     <section>
-      <h3 style={sectionH3}>RX Trace Color</h3>
-      <p style={sectionP}>
-        Color of the RX panadapter trace and its fill. Affects only the
-        spectrum graph — meters, S-meter, and passband overlays keep their
-        own colors.
-      </p>
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)', gap: 8 }}>
-        {SWATCHES.map((s) => {
-          const active = s.color.toUpperCase() === norm;
-          return (
-            <button
-              key={s.id}
-              type="button"
-              title={s.label}
-              aria-label={s.label}
-              aria-pressed={active}
-              onClick={() => setRxTraceColor(s.color)}
-              style={swatchStyle(s.color, active)}
-            />
-          );
-        })}
+      <div style={sectionHead}>
+        <h3 style={sectionH3}>RX Trace Color</h3>
+        <p style={sectionP}>
+          Affects only the spectrum graph — meters and passband keep their own colors.
+        </p>
       </div>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginTop: 14 }}>
-        <label
-          htmlFor="rx-trace-color-custom"
-          style={{
-            fontSize: 11,
-            fontWeight: 600,
-            color: 'var(--fg-1)',
-            textTransform: 'uppercase',
-            letterSpacing: '0.08em',
-          }}
-        >
-          Custom
-        </label>
-        <input
-          id="rx-trace-color-custom"
-          type="color"
-          value={norm}
-          onChange={(e) => setRxTraceColor(e.target.value.toUpperCase())}
-          style={{
-            width: 44,
-            height: 28,
-            padding: 0,
-            border: '1px solid var(--line)',
-            borderRadius: 'var(--r-xs)',
-            background: 'transparent',
-            cursor: 'pointer',
-          }}
-        />
-        <span
-          style={{
-            fontSize: 11,
-            color: 'var(--fg-2)',
-            fontFamily: 'var(--font-mono, ui-monospace, monospace)',
-            letterSpacing: '0.04em',
-          }}
-        >
-          {norm}
-        </span>
+
+      <div style={colorCard}>
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          <div style={swatchesGrid}>
+            {SWATCHES.map((c) => {
+              const active = c.toUpperCase() === norm;
+              return (
+                <button
+                  key={c}
+                  type="button"
+                  title={c}
+                  aria-label={c}
+                  aria-pressed={active}
+                  onClick={() => setRxTraceColor(c)}
+                  style={swatchStyle(c, active)}
+                />
+              );
+            })}
+          </div>
+
+          <div style={customRow}>
+            <span style={inlineLabel}>Custom</span>
+            <input
+              type="color"
+              value={norm}
+              onChange={(e) => setRxTraceColor(e.target.value.toUpperCase())}
+              style={pickerStyle}
+              aria-label="Custom RX trace color"
+            />
+            <input
+              type="text"
+              value={norm}
+              onChange={(e) => {
+                const v = e.target.value.startsWith('#') ? e.target.value : `#${e.target.value}`;
+                if (isHexColor(v)) setRxTraceColor(v.toUpperCase());
+              }}
+              maxLength={7}
+              spellCheck={false}
+              style={hexInputStyle}
+              aria-label="Hex color value"
+            />
+          </div>
+        </div>
+
+        <div style={previewCard} aria-hidden>
+          <div style={previewHead}>
+            <span>RX SPECTRUM</span>
+            <span style={{ color: 'var(--fg-1)' }}>14.074 MHz</span>
+          </div>
+          <div style={previewCanvas}>
+            <svg
+              viewBox="0 0 360 108"
+              preserveAspectRatio="none"
+              style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }}
+            >
+              <defs>
+                <linearGradient id={gradId} x1="0" x2="0" y1="0" y2="1">
+                  <stop offset="0" stopColor={norm} stopOpacity="0.5" />
+                  <stop offset="1" stopColor={norm} stopOpacity="0.04" />
+                </linearGradient>
+              </defs>
+              <path
+                d={tracePath}
+                fill={`url(#${gradId})`}
+                stroke={norm}
+                strokeWidth={1.4}
+                strokeLinejoin="round"
+              />
+            </svg>
+          </div>
+          <div style={previewFoot}>
+            <span>Trace</span>
+            <span style={{ color: 'var(--fg-0)' }}>{norm}</span>
+          </div>
+        </div>
       </div>
     </section>
   );
 }
 
+const sectionHead: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'baseline',
+  flexWrap: 'wrap',
+  gap: 10,
+  marginBottom: 10,
+};
 const sectionH3: React.CSSProperties = {
-  margin: '0 0 10px 0',
+  margin: 0,
   fontSize: 11,
   fontWeight: 700,
-  letterSpacing: '0.12em',
+  letterSpacing: '0.18em',
   textTransform: 'uppercase',
   color: 'var(--fg-0)',
 };
 const sectionP: React.CSSProperties = {
-  margin: '0 0 12px 0',
+  margin: 0,
   fontSize: 12,
   lineHeight: 1.5,
   color: 'var(--fg-2)',
 };
+const inlineLabel: React.CSSProperties = {
+  fontSize: 10,
+  letterSpacing: '0.16em',
+  textTransform: 'uppercase',
+  color: 'var(--fg-2)',
+  fontWeight: 600,
+};
+
+const colorCard: React.CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: '1fr 230px',
+  gap: 18,
+  alignItems: 'stretch',
+  padding: 14,
+  background: 'linear-gradient(180deg, var(--bg-1), var(--bg-0))',
+  border: '1px solid var(--line)',
+  borderRadius: 'var(--r-md)',
+};
+
+const swatchesGrid: React.CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(12, 1fr)',
+  gap: 6,
+};
+
 function swatchStyle(color: string, active: boolean): React.CSSProperties {
   return {
     width: '100%',
-    aspectRatio: '1.6 / 1',
+    aspectRatio: '1 / 1',
     padding: 0,
     borderRadius: 'var(--r-sm)',
     background: color,
-    border: '2px solid',
-    borderColor: active ? 'var(--accent)' : 'var(--line)',
+    border: active ? '1.5px solid var(--fg-0)' : '1.5px solid transparent',
+    boxShadow: active
+      ? '0 0 0 2px var(--bg-1), 0 0 0 3px var(--fg-0), inset 0 0 0 1px rgba(255,255,255,0.08)'
+      : 'inset 0 0 0 1px rgba(255,255,255,0.08), inset 0 -6px 10px -6px rgba(0,0,0,0.35)',
     cursor: 'pointer',
-    transition: 'border-color var(--dur-fast)',
+    transition: 'transform var(--dur-fast), border-color var(--dur-fast)',
+    transform: active ? 'translateY(-1px)' : 'none',
   };
 }
+
+const customRow: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 10,
+  marginTop: 12,
+  paddingTop: 12,
+  borderTop: '1px dashed var(--line)',
+};
+
+const pickerStyle: React.CSSProperties = {
+  width: 30,
+  height: 22,
+  borderRadius: 'var(--r-sm)',
+  border: '1px solid var(--line)',
+  padding: 0,
+  background: 'transparent',
+  cursor: 'pointer',
+  overflow: 'hidden',
+};
+
+const hexInputStyle: React.CSSProperties = {
+  background: 'var(--bg-2)',
+  border: '1px solid var(--line)',
+  color: 'var(--fg-0)',
+  borderRadius: 'var(--r-sm)',
+  padding: '5px 8px',
+  width: 96,
+  fontSize: 12,
+  letterSpacing: '0.04em',
+};
+
+const previewCard: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  border: '1px solid var(--line)',
+  borderRadius: 'var(--r-sm)',
+  background: 'var(--spec-bg)',
+  overflow: 'hidden',
+};
+
+const previewHead: React.CSSProperties = {
+  padding: '6px 10px',
+  borderBottom: '1px solid var(--line)',
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  fontSize: 9.5,
+  letterSpacing: '0.14em',
+  color: 'var(--fg-3)',
+  textTransform: 'uppercase',
+};
+
+const previewCanvas: React.CSSProperties = {
+  flex: 1,
+  position: 'relative',
+  height: 108,
+  background: [
+    'repeating-linear-gradient(0deg, rgba(255,255,255,0.04) 0 1px, transparent 1px 22px)',
+    'repeating-linear-gradient(90deg, rgba(255,255,255,0.04) 0 1px, transparent 1px 36px)',
+    'radial-gradient(60% 80% at 50% 100%, rgba(255,255,255,0.04), transparent 70%)',
+  ].join(', '),
+};
+
+const previewFoot: React.CSSProperties = {
+  padding: '6px 10px',
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  borderTop: '1px solid var(--line)',
+  fontSize: 10,
+  color: 'var(--fg-2)',
+};


### PR DESCRIPTION
## Summary
- Background mode picker: stacked radio rows → 3-card horizontal grid (Basic / Beam Map / Image) with icons + circular check indicator. Image upload UI sits below when "Image" is active.
- RX Trace Color: expanded to a 24-swatch color-card paired with a live SVG panadapter preview that re-renders fill/stroke as you pick. Custom row keeps the native color picker plus a hex input.
- Layout Mode: stacked rows → 2-card row matching the new background style; "Reset Flex Layout" demoted to a small button shown only in flex mode.

Implemented from a Claude Design handoff bundle (`Display Settings.html`). The mockup's OKLCH palette and Inter / JetBrains Mono fonts are deliberately **not** adopted — Zeus's `tokens.css` and Archivo Narrow remain the source of truth, so the new chrome composes from `--bg-0/1/2/3`, `--accent`, `--accent-soft`, and `--line` only.

Visual / UX change → red-light per `CLAUDE.md`. Maintainer review specifically wanted on:
- Swatch palette growing 12 → 24 colors
- Adding a live SVG preview pane to the settings tab

Store contracts (`PanBackgroundMode`, `BackgroundImageFit`, `LayoutMode`) and persistence wiring are unchanged.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` — no new warnings in touched files
- [x] `npm run test` — 192/192 pass
- [x] `npm run build` — production bundle succeeds
- [ ] Visual smoke: open Settings → Display, verify card hover/active states, swatch active ring, hex input typing, color-picker chip, "Image" upload still works (drag-drop + click), "Default → Flex" reload still triggers