### PR TITLE
fix(filter): stop top-bar buttons flashing F4/F5/F6 raw slot names

### DIFF
--- a/zeus-web/src/components/filter/FilterPanel.tsx
+++ b/zeus-web/src/components/filter/FilterPanel.tsx
@@ -9,7 +9,7 @@
 // Operators drag any preset chip out of the ribbon onto one of the three
 // buttons here to pin it — same UX as the Mode/Band/Step toolbar groups.
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useConnectionStore } from '../../state/connection-store';
 import {
   setFilter,
@@ -19,6 +19,7 @@ import {
 } from '../../api/client';
 import { useFilterFavoritesStore, useFavoritesForMode } from '../../state/filter-favorites-store';
 import { FILTER_DRAG_MIME } from './FilterRibbon';
+import { getPresetsForMode } from './filterPresets';
 
 const RIBBON_OPEN_KEY = 'zeus.filter.advancedPaneOpen';
 
@@ -31,16 +32,29 @@ export function FilterPanel() {
   const updateFavorites = useFilterFavoritesStore((s) => s.update);
   const favoriteSlotNames = useFavoritesForMode(mode);
 
-  const [presets, setPresets] = useState<FilterPresetDto[]>([]);
+  // Seed from the local Thetis preset table so labels render correctly on
+  // first paint. Without this, the buttons collapse to raw slot names
+  // ("F4", "F5", "F6") for the time it takes /api/filter/presets to resolve,
+  // because the lookup `presets.find(...)` returns undefined against an
+  // empty array. Server VAR overrides land here too once the fetch completes.
+  const localPresets = useMemo<FilterPresetDto[]>(
+    () => getPresetsForMode(mode).map((p) => ({ ...p })),
+    [mode],
+  );
+  const [presets, setPresets] = useState<FilterPresetDto[]>(localPresets);
   const [dragOverIdx, setDragOverIdx] = useState<number | null>(null);
 
   useEffect(() => { void loadFavorites(mode); }, [mode, loadFavorites]);
 
+  // Reseed `presets` to the new mode's local table whenever the mode flips,
+  // so labels never reflect the old mode while the server fetch is in flight.
+  useEffect(() => { setPresets(localPresets); }, [localPresets]);
+
   useEffect(() => {
     let cancelled = false;
     getFilterPresets(mode)
-      .then((list) => { if (!cancelled) setPresets(list); })
-      .catch(() => { if (!cancelled) setPresets([]); });
+      .then((list) => { if (!cancelled && list.length > 0) setPresets(list); })
+      .catch(() => { /* keep local fallback */ });
     return () => { cancelled = true; };
   }, [mode]);
 

--- a/zeus-web/src/components/filter/filterPresets.ts
+++ b/zeus-web/src/components/filter/filterPresets.ts
@@ -143,6 +143,22 @@ export function getPresetsForMode(mode: RxMode): readonly FilterPresetSlot[] {
   return PRESET_MAP[mode] ?? USB;
 }
 
+// Per-mode favorite-slot defaults. Mirrors FilterPresetStore.GetFavoriteSlots
+// on the server so the client can render correct defaults synchronously,
+// before the /api/filter/favorites round-trip resolves. Without this, every
+// first paint shows the ascending ['F4','F5','F6'] generic fallback even
+// though USB/LSB really default to ['F6','F5','F4'] (descending = ascending
+// passband width).
+export function defaultFavoritesForMode(mode: RxMode): readonly string[] {
+  switch (mode) {
+    case 'USB': case 'LSB': case 'DIGL': case 'DIGU': return ['F6', 'F5', 'F4'];
+    case 'CWU': case 'CWL': return ['F4', 'F5', 'F6'];
+    case 'AM':  case 'SAM': return ['F7', 'F8', 'F9'];
+    case 'DSB': return ['F6', 'F7', 'F8'];
+    case 'FM':  return ['F6', 'F5', 'F4'];
+  }
+}
+
 export function formatFilterWidth(lowHz: number, highHz: number): string {
   const width = Math.abs(highHz - lowHz);
   if (width >= 1000) {

--- a/zeus-web/src/state/filter-favorites-store.ts
+++ b/zeus-web/src/state/filter-favorites-store.ts
@@ -11,8 +11,7 @@ import {
   setFavoriteFilterSlots,
   type RxMode,
 } from '../api/client';
-
-const DEFAULT_FAVORITES: readonly string[] = ['F4', 'F5', 'F6'];
+import { defaultFavoritesForMode } from '../components/filter/filterPresets';
 
 type FilterFavoritesState = {
   byMode: Partial<Record<RxMode, string[]>>;
@@ -31,12 +30,12 @@ export const useFilterFavoritesStore = create<FilterFavoritesState>((set, get) =
     try {
       const slots = await getFavoriteFilterSlots(mode);
       set((s) => ({
-        byMode: { ...s.byMode, [mode]: slots.length === 3 ? slots : [...DEFAULT_FAVORITES] },
+        byMode: { ...s.byMode, [mode]: slots.length === 3 ? slots : [...defaultFavoritesForMode(mode)] },
         loading: { ...s.loading, [mode]: false },
       }));
     } catch {
       set((s) => ({
-        byMode: { ...s.byMode, [mode]: [...DEFAULT_FAVORITES] },
+        byMode: { ...s.byMode, [mode]: [...defaultFavoritesForMode(mode)] },
         loading: { ...s.loading, [mode]: false },
       }));
     }
@@ -57,5 +56,5 @@ export const useFilterFavoritesStore = create<FilterFavoritesState>((set, get) =
 
 export function useFavoritesForMode(mode: RxMode): string[] {
   const slots = useFilterFavoritesStore((s) => s.byMode[mode]);
-  return slots ?? [...DEFAULT_FAVORITES];
+  return slots ?? [...defaultFavoritesForMode(mode)];
 }


### PR DESCRIPTION
## Summary
- The top control-strip filter buttons rendered raw slot names (\`F4\`, \`F5\`, \`F6\`) on first paint and on every mode change, because the favorites store and preset list both started empty and had to wait on \`/api/filter/favorites\` and \`/api/filter/presets\`.
- Seed \`presets\` in \`FilterPanel\` from the local Thetis table via \`getPresetsForMode(mode)\` so labels (e.g. \`3.3k\`, \`2.9k\`, \`2.7k\`) render synchronously. Server VAR overrides still merge in when the fetch lands.
- Add \`defaultFavoritesForMode(mode)\` mirroring \`FilterPresetStore.GetFavoriteSlots\` on the server (USB/LSB → \`F6,F5,F4\`, CW → \`F4,F5,F6\`, AM/SAM → \`F7,F8,F9\`, DSB → \`F6,F7,F8\`, DIGL/DIGU → \`F6,F5,F4\`) so the favorites store renders correct per-mode defaults before the fetch resolves, instead of the generic \`F4,F5,F6\` fallback.

## Why this is the right scope
- \`FilterRibbon\` already uses the local Thetis table as a baseline (see \`mergePresets\` in \`FilterRibbon.tsx\`), so this just gives \`FilterPanel\` the same synchronous-paint discipline.
- No protocol, DSP, or visual-design change — purely a render-time fallback fix.

## Test plan
- [x] \`npm test -- --run\` (zeus-web): 192/192 pass
- [x] \`dotnet build Zeus.slnx\`: 0 warnings, 0 errors
- [ ] Reload the web UI on USB and confirm the FILTER buttons paint as \`2.7k / 2.9k / 3.3k\` with no flash to raw \`F4 F5 F6\`
- [ ] Switch USB → CWU → AM and confirm each mode's buttons paint with proper labels and per-mode favorite ordering