### PR TITLE
feat(ps): redesign PURESIGNAL settings + live status popover

### DIFF
--- a/zeus-web/src/components/PsSettingsPanel.tsx
+++ b/zeus-web/src/components/PsSettingsPanel.tsx
@@ -19,24 +19,22 @@
 // (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
 // Both are GPL-2.0-or-later.
 
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   setPs,
   setPsAdvanced,
   setPsFeedbackSource,
   setPsMonitor,
   resetPs,
+  setTwoTone,
 } from '../api/client';
 import { useRadioStore } from '../state/radio-store';
 import { useTxStore } from '../state/tx-store';
 
-// HermesLite2 has no internal feedback coupler — the operator-side PS
-// Monitor (post-PA loopback display) and the Internal/External feedback
-// source selector both reduce to a single working choice on HL2:
-// "External coupler". We hide the Internal/External selector on HL2 (the
-// operator can't pick anything else) and the PS-Monitor toggle on HL2
-// (no internal loopback to display). ANAN-class boards (and anything
-// else that shows up here) retain both controls. See issues #121 and #172.
+// HermesLite2 has no PS-Monitor display source path (no internal feedback
+// loopback) but DOES have an internal coupler — so the Internal/External
+// feedback-source selector is shown on every board, while PS-Monitor is
+// hidden on HL2. See issues #121 and #172.
 const HL2_BOARD_ID = 'HermesLite2';
 
 const CAL_STATE_NAMES = [
@@ -52,26 +50,24 @@ const CAL_STATE_NAMES = [
   'TURNON',
 ];
 
+// Dial geometry (must match the SVG circle below).
+const DIAL_R = 78;
+const DIAL_C = 2 * Math.PI * DIAL_R;
+
+const SPARK_LEN = 60;
+
 /**
- * PureSignal + Two-tone control surface. Lives inside the Settings modal
+ * PureSignal calibration dashboard. Lives inside the Settings modal
  * (SettingsMenu) and as a standalone dockable panel (PsFlexPanel).
  *
- * Uses the same neutral fg/accent tokens as the other settings tabs;
- * amber is reserved for the panadapter trace per CLAUDE.md.
+ * Layout: hero strip with a convergence dial, a TX → PA → coupler →
+ * feedback signal-flow diagram, and live peak meters. Mode + actions
+ * row below, then a two-column timing / hardware grid, then the
+ * standard PS-Monitor and two-tone test sections.
  */
 export function PsSettingsPanel() {
-  // The PS-Monitor source switch only makes sense when there's a real PS
-  // feedback receiver. On HL2 we hide the toggle entirely. We key on the
-  // CONNECTED board (not preferred) so a user who explicitly selects G2
-  // while no radio is attached still sees the control as a preview, but
-  // a live HL2 connection cleanly drops it. The Internal-vs-External
-  // feedback source selector remains visible on every board (including
-  // HL2) — even though HL2 currently routes only through the external
-  // coupler path, an operator running HL2 + future amp setup may want
-  // the option exposed.
   const connectedBoard = useRadioStore((s) => s.selection.connected);
   const psMonitorSupported = connectedBoard !== HL2_BOARD_ID;
-  const feedbackSourceSelectorSupported = true;
 
   const psEnabled = useTxStore((s) => s.psEnabled);
   const psMonitorEnabled = useTxStore((s) => s.psMonitorEnabled);
@@ -91,11 +87,6 @@ export function PsSettingsPanel() {
   const psCalState = useTxStore((s) => s.psCalState);
   const psCorrecting = useTxStore((s) => s.psCorrecting);
   const psCorrectionDb = useTxStore((s) => s.psCorrectionDb);
-  // Observed TX envelope peak — mi0bot PSForm.cs:624 reads
-  // GetPSMaxTX(_txachannel, ptr) every timer tick and shows it in
-  // txtGetPSpeak so the operator can compare against HW peak. Zeus already
-  // pumps this from WdspDspEngine.GetPsStageMeters → PsMetersFrame; we just
-  // render the live value next to the HW-peak input.
   const psMaxTxEnvelope = useTxStore((s) => s.psMaxTxEnvelope);
   const setPsAuto = useTxStore((s) => s.setPsAuto);
   const setPsSingle = useTxStore((s) => s.setPsSingle);
@@ -108,7 +99,15 @@ export function PsSettingsPanel() {
   const setPsIntsSpiPreset = useTxStore((s) => s.setPsIntsSpiPreset);
   const setPsFeedbackSourceLocal = useTxStore((s) => s.setPsFeedbackSource);
 
-  // Cal-mode radio buttons send the new combination on every change.
+  const twoToneOn = useTxStore((s) => s.twoToneOn);
+  const twoToneFreq1 = useTxStore((s) => s.twoToneFreq1);
+  const twoToneFreq2 = useTxStore((s) => s.twoToneFreq2);
+  const twoToneMag = useTxStore((s) => s.twoToneMag);
+  const setTwoToneOn = useTxStore((s) => s.setTwoToneOn);
+  const setTwoToneFreq1 = useTxStore((s) => s.setTwoToneFreq1);
+  const setTwoToneFreq2 = useTxStore((s) => s.setTwoToneFreq2);
+  const setTwoToneMag = useTxStore((s) => s.setTwoToneMag);
+
   const setMode = useCallback(
     (auto: boolean, single: boolean) => {
       setPsAuto(auto);
@@ -137,9 +136,13 @@ export function PsSettingsPanel() {
     resetPs().catch(() => {});
   }, []);
 
-  // Feedback antenna source — Internal coupler vs External (Bypass).
-  // Optimistic local set + POST. Rolls back on POST failure so the radio's
-  // alex bit and the UI stay in sync.
+  // "Run now" — re-arm a single calibration pass. Maps to the existing
+  // single-shot path; safe to invoke regardless of current Auto/Single
+  // selection (mi0bot PSForm.cs treats Single as a one-shot trigger).
+  const onRunNow = useCallback(() => {
+    setMode(false, true);
+  }, [setMode]);
+
   const onFeedbackSourceChange = useCallback(
     (next: 'internal' | 'external') => {
       const prev = psFeedbackSourceState;
@@ -149,9 +152,6 @@ export function PsSettingsPanel() {
     [psFeedbackSourceState, setPsFeedbackSourceLocal],
   );
 
-  // PS-Monitor — operator-facing display source switch (issue #121).
-  // Optimistic local set + POST, rolls back on failure so the analyzer
-  // routing the backend uses and the UI checkbox stay in sync.
   const onPsMonitorToggle = useCallback(
     (next: boolean) => {
       const prev = psMonitorEnabled;
@@ -161,334 +161,636 @@ export function PsSettingsPanel() {
     [psMonitorEnabled, setPsMonitorLocal],
   );
 
+  const onTwoToneToggle = useCallback(() => {
+    const next = !twoToneOn;
+    setTwoToneOn(next);
+    setTwoTone({
+      enabled: next,
+      freq1: twoToneFreq1,
+      freq2: twoToneFreq2,
+      mag: twoToneMag,
+    }).catch(() => setTwoToneOn(!next));
+  }, [twoToneOn, twoToneFreq1, twoToneFreq2, twoToneMag, setTwoToneOn]);
+
+  const onTwoToneFreq1Change = useCallback(
+    (hz: number) => {
+      const v = Math.max(50, Math.min(5000, Math.round(hz)));
+      setTwoToneFreq1(v);
+      setTwoTone({ enabled: twoToneOn, freq1: v }).catch(() => {});
+    },
+    [twoToneOn, setTwoToneFreq1],
+  );
+
+  const onTwoToneFreq2Change = useCallback(
+    (hz: number) => {
+      const v = Math.max(50, Math.min(5000, Math.round(hz)));
+      setTwoToneFreq2(v);
+      setTwoTone({ enabled: twoToneOn, freq2: v }).catch(() => {});
+    },
+    [twoToneOn, setTwoToneFreq2],
+  );
+
+  const onTwoToneMagChange = useCallback(
+    (mag: number) => {
+      const v = Math.max(0, Math.min(1, mag));
+      setTwoToneMag(v);
+      setTwoTone({ enabled: twoToneOn, mag: v }).catch(() => {});
+    },
+    [twoToneOn, setTwoToneMag],
+  );
+
   const calStateLabel = CAL_STATE_NAMES[psCalState] ?? `state ${psCalState}`;
-  // Feedback level is 0..256 raw; UI shows 0..1.
-  const feedbackBar = Math.max(0, Math.min(1, psFeedbackLevel / 256));
+  // Feedback level is 0..256 raw; UI shows 0..1 normalized for the dial.
+  const feedbackPct = Math.max(0, Math.min(1, psFeedbackLevel / 256));
+  const feedbackLen = feedbackPct * DIAL_C;
+  const feedbackRound = Math.round(psFeedbackLevel);
+
+  // Dial state visualization. Converged → green ring + "ok" pill;
+  // active calibration → animated pulse; otherwise idle.
+  const isConverged = psCorrecting;
+  const isRunning = psEnabled && !isConverged && psCalState > 0;
+  const dialClass = isConverged ? 'is-converged' : '';
+  const pillClass = isConverged ? 'ok' : isRunning ? 'run' : '';
+  const pillText = isConverged
+    ? 'CAL · correcting'
+    : isRunning
+      ? 'CAL · running'
+      : 'CAL · idle';
+
+  const feedbackSubText = isConverged
+    ? `${Math.round(feedbackPct * 100)} % · locked`
+    : `${Math.round(feedbackPct * 100)} % · ${calStateLabel.toLowerCase()}`;
+
+  // Elapsed timer. Mounts when the panel mounts; resets when the operator
+  // clicks Run-now or Reset. Display is purely informational.
+  const t0Ref = useRef<number>(Date.now());
+  const [, setElapsedTick] = useState(0);
+  useEffect(() => {
+    const id = window.setInterval(() => setElapsedTick((n) => n + 1), 1000);
+    return () => window.clearInterval(id);
+  }, []);
+  const elapsedMs = Date.now() - t0Ref.current;
+  const elapsedLabel = formatElapsed(elapsedMs);
+
+  // Correction sparkline — keep a short rolling history so the operator
+  // can see whether the inverse-model dB number is jittering or stable.
+  const sparkRef = useRef<number[]>([]);
+  useEffect(() => {
+    if (!psCorrecting) return;
+    sparkRef.current.push(psCorrectionDb);
+    if (sparkRef.current.length > SPARK_LEN) sparkRef.current.shift();
+  }, [psCorrectionDb, psCorrecting]);
+
+  const sparkPoints = buildSparkline(sparkRef.current);
+
+  // Peak meters share the same x-scale: 0..max(HW peak * 1.4, observed).
+  // Observed peak warns when within 5% of HW peak, faults at HW peak.
+  const meterScale = Math.max(psHwPeak * 1.4, psMaxTxEnvelope * 1.05, 0.001);
+  const obsPct = Math.min(100, (psMaxTxEnvelope / meterScale) * 100);
+  const hwRefPct = Math.min(100, (psHwPeak / meterScale) * 100);
+  const hwSelfPct = Math.min(100, (psHwPeak / meterScale) * 100);
+  const obsClass =
+    psMaxTxEnvelope >= psHwPeak
+      ? 'bad'
+      : psMaxTxEnvelope > psHwPeak * 0.95
+        ? 'warn'
+        : '';
+
+  // Signal-flow node states: TX is always "on" when psEnabled; remaining
+  // nodes light up when calibration is actually running so the operator
+  // sees the path go live during MOX.
+  const flowActive = psEnabled && (isRunning || isConverged);
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
-      {/* Calibration */}
-      <Section title="Calibration">
-        <Row label="Mode">
-          <label style={{ marginRight: 12 }}>
-            <input
-              type="radio"
-              name="ps-mode"
-              checked={psAuto && !psSingle}
-              onChange={() => setMode(true, false)}
-            />{' '}
-            Auto
-          </label>
-          <label>
-            <input
-              type="radio"
-              name="ps-mode"
-              checked={psSingle}
-              onChange={() => setMode(false, true)}
-            />{' '}
-            Single
-          </label>
-        </Row>
-        <Row label="">
+    <div className="ps-shell">
+
+      {/* ── Calibration hero ─────────────────────────────── */}
+      <section>
+        <div className="ps-section-head">
+          <h3>Calibration</h3>
+          <p>
+            Live linearization adapts the predistorter to your PA. Key down
+            (MOX/TUN) to begin sampling.
+          </p>
+          <span className="ps-elapsed">{elapsedLabel}</span>
+        </div>
+
+        <div className="ps-hero">
+
+          {/* Dial */}
+          <div className="ps-dial-col">
+            <div className={`ps-dial ${dialClass}`}>
+              <svg viewBox="0 0 200 200">
+                <circle
+                  className="ps-dial-track"
+                  cx="100"
+                  cy="100"
+                  r={DIAL_R}
+                />
+                <circle
+                  className="ps-dial-fill"
+                  cx="100"
+                  cy="100"
+                  r={DIAL_R}
+                  style={{
+                    strokeDasharray: `${feedbackLen} ${DIAL_C - feedbackLen}`,
+                  }}
+                />
+              </svg>
+              <div className="ps-dial-center">
+                <div className="ps-dial-state">{calStateLabel}</div>
+                <div className="ps-dial-num">
+                  {feedbackRound}
+                  <small>/256</small>
+                </div>
+                <div className="ps-dial-sub">{feedbackSubText}</div>
+              </div>
+            </div>
+            <span className={`ps-pill ${pillClass}`}>
+              <span className="ps-pdot" />
+              <span>{pillText}</span>
+            </span>
+          </div>
+
+          {/* Signal flow */}
+          <div className="ps-flow-col">
+            <div className="ps-flow-title">Signal Flow</div>
+            <div className="ps-flow">
+              <FlowNode
+                label="TX"
+                sub={
+                  psMaxTxEnvelope > 0
+                    ? `${(20 * Math.log10(psMaxTxEnvelope / Math.max(psHwPeak, 0.0001))).toFixed(1)} dBFS`
+                    : 'idle'
+                }
+                active={psEnabled}
+              >
+                <svg className="ps-ic" viewBox="0 0 16 16">
+                  <path d="M3 12l3-3M6 9l3-3M9 6l3-3" />
+                  <circle cx="3" cy="13" r="1.4" />
+                  <circle cx="13" cy="3" r="1.4" />
+                </svg>
+              </FlowNode>
+              <div className={`ps-arr ${flowActive ? 'live' : ''}`} />
+              <FlowNode label="PA" sub="amplifier" active={flowActive}>
+                <svg className="ps-ic" viewBox="0 0 16 16">
+                  <rect x="2.5" y="5" width="11" height="6" rx="1.2" />
+                  <path d="M5 5V3M11 5V3M5 13v-2M11 13v-2" />
+                </svg>
+              </FlowNode>
+              <div className={`ps-arr ${flowActive ? 'live' : ''}`} />
+              <FlowNode
+                label={
+                  psFeedbackSourceState === 'external' ? 'EXT COUPLER' : 'COUPLER'
+                }
+                sub={psFeedbackSourceState === 'external' ? 'bypass' : 'internal'}
+                active={flowActive}
+              >
+                <svg className="ps-ic" viewBox="0 0 16 16">
+                  <path d="M2 10l4-6 2 4 2-2 4 4" />
+                  <path d="M2 13h12" />
+                </svg>
+              </FlowNode>
+              <div className={`ps-arr ${flowActive ? 'live' : ''}`} />
+              <FlowNode label="FEEDBACK" sub="RX path" active={flowActive}>
+                <svg className="ps-ic" viewBox="0 0 16 16">
+                  <path d="M2 8h3l1.5-3 3 6 1.5-3H14" />
+                </svg>
+              </FlowNode>
+            </div>
+            <div className="ps-source-tabs">
+              <button
+                type="button"
+                className={`ps-source-tab ${psFeedbackSourceState === 'internal' ? 'is-active' : ''}`}
+                onClick={() => onFeedbackSourceChange('internal')}
+              >
+                <span className="ps-rd" />
+                <span className="ps-rd-label">
+                  <strong>Internal coupler</strong>
+                  <em>Use the radio's built-in directional coupler</em>
+                </span>
+              </button>
+              <button
+                type="button"
+                className={`ps-source-tab ${psFeedbackSourceState === 'external' ? 'is-active' : ''}`}
+                onClick={() => onFeedbackSourceChange('external')}
+              >
+                <span className="ps-rd" />
+                <span className="ps-rd-label">
+                  <strong>External (bypass)</strong>
+                  <em>External coupler on RX2 antenna jack</em>
+                </span>
+              </button>
+            </div>
+          </div>
+
+          {/* Peaks */}
+          <div className="ps-peaks-col">
+            <div className={`ps-peak ${obsClass}`}>
+              <div className="ps-peak-row">
+                <span className="ps-peak-nm">Observed peak</span>
+                <span className="ps-peak-val">{psMaxTxEnvelope.toFixed(4)}</span>
+              </div>
+              <div className="ps-meter">
+                <div className="ps-mfill" style={{ width: `${obsPct}%` }} />
+                <div className="ps-ref" style={{ left: `${hwRefPct}%` }} />
+              </div>
+              <div className="ps-help">
+                Live feedback amplitude · target near HW peak.
+              </div>
+            </div>
+
+            <div className="ps-peak">
+              <div className="ps-peak-row">
+                <span className="ps-peak-nm">HW peak</span>
+                <span className="ps-peak-val">{psHwPeak.toFixed(4)}</span>
+              </div>
+              <div className="ps-meter">
+                <div className="ps-mfill" style={{ width: `${hwSelfPct}%` }} />
+              </div>
+              <div className="ps-help">
+                ADC clip threshold for the feedback path.
+              </div>
+            </div>
+
+            <div className="ps-peak">
+              <div className="ps-peak-row">
+                <span className="ps-peak-nm">Correction</span>
+                <span className="ps-peak-val">
+                  {psCorrecting ? `+${psCorrectionDb.toFixed(2)}` : '—'}
+                  {psCorrecting ? <small>dB</small> : null}
+                </span>
+              </div>
+              <div className="ps-spark">
+                <svg viewBox="0 0 200 14" preserveAspectRatio="none">
+                  <polyline
+                    fill="none"
+                    stroke="var(--accent)"
+                    strokeWidth="1.4"
+                    points={sparkPoints}
+                  />
+                </svg>
+              </div>
+              <div className="ps-help">
+                Last samples · stability of the inverse model.
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Mode + actions */}
+        <div className="ps-mode-row">
           <button
             type="button"
-            onClick={onReset}
-            className="btn sm"
+            className={`ps-mode-card ${psAuto && !psSingle ? 'is-active' : ''}`}
+            onClick={() => setMode(true, false)}
           >
-            Reset
+            <span className="ps-rd" />
+            <div className="ps-mode-info">
+              <h4>Auto</h4>
+              <p>Continuously refine while transmitting. Recommended.</p>
+            </div>
           </button>
-        </Row>
-        <Row label="Auto-Attenuate">
-          <input
-            type="checkbox"
-            checked={psAutoAttenuate}
-            onChange={(e) => {
-              const v = e.target.checked;
-              setPsAutoAttenuate(v);
-              pushAdvanced({ autoAttenuate: v });
-            }}
-          />
-        </Row>
-      </Section>
-
-      {/* Timing */}
-      <Section title="Timing">
-        <Row label="MOX delay (s)">
-          <NumberInput
-            value={psMoxDelaySec}
-            min={0.0}
-            max={10.0}
-            step={0.1}
-            onChange={(v) => {
-              setPsMoxDelaySec(v);
-              pushAdvanced({ moxDelaySec: v });
-            }}
-          />
-        </Row>
-        <Row label="Cal delay (s)">
-          <NumberInput
-            value={psLoopDelaySec}
-            min={0.0}
-            max={100.0}
-            step={0.5}
-            onChange={(v) => {
-              setPsLoopDelaySec(v);
-              pushAdvanced({ loopDelaySec: v });
-            }}
-          />
-        </Row>
-        <Row label="Amp delay (ns)">
-          <NumberInput
-            value={psAmpDelayNs}
-            min={0}
-            max={25_000_000}
-            step={50}
-            onChange={(v) => {
-              setPsAmpDelayNs(v);
-              pushAdvanced({ ampDelayNs: v });
-            }}
-          />
-        </Row>
-      </Section>
-
-      {/* Hardware */}
-      <Section title="Hardware">
-        {feedbackSourceSelectorSupported ? (
-          <Row label="Feedback source">
-            {/* Two-way selector: Internal coupler (default) or External
-                (Bypass). On G2/MkII this flips ALEX_RX_ANTENNA_BYPASS in
-                alex0 during xmit + PS armed. WDSP cal/iqc are unaffected;
-                the HW-peak slider below stays shared across sources to
-                match pihpsdr/Thetis.
-
-                Hidden on HL2: HL2 has no internal coupler, so the only
-                workable feedback path is external (issue #172). The
-                backend default already routes the wire bit appropriately
-                for HL2 — there's no operator choice to expose. */}
-            <label
-              style={{ display: 'inline-flex', alignItems: 'center', marginRight: 12 }}
+          <button
+            type="button"
+            className={`ps-mode-card ${psSingle ? 'is-active' : ''}`}
+            onClick={() => setMode(false, true)}
+          >
+            <span className="ps-rd" />
+            <div className="ps-mode-info">
+              <h4>Single</h4>
+              <p>Run one calibration pass and lock the result.</p>
+            </div>
+          </button>
+          <div className="ps-action-stack">
+            <button
+              type="button"
+              className="ps-btn primary"
+              onClick={onRunNow}
+              title="Trigger a single calibration pass"
             >
-              <input
-                type="radio"
-                name="psFeedbackSource"
-                value="internal"
-                checked={psFeedbackSourceState === 'internal'}
-                onChange={() => onFeedbackSourceChange('internal')}
-                style={{ marginRight: 4 }}
+              <svg className="ps-ic-sm" viewBox="0 0 12 12">
+                <path d="M3 2l7 4-7 4z" fill="currentColor" stroke="none" />
+              </svg>
+              Run now
+            </button>
+            <button
+              type="button"
+              className="ps-btn danger"
+              onClick={() => {
+                t0Ref.current = Date.now();
+                sparkRef.current = [];
+                onReset();
+              }}
+              title="Reset PS state"
+            >
+              <svg className="ps-ic-sm" viewBox="0 0 12 12">
+                <path d="M3 2v3h3M3 5a4 4 0 1 1-1 3" />
+              </svg>
+              Reset
+            </button>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Lower grid: Timing + Hardware ─────────────────── */}
+      <div className="ps-grid2">
+
+        <div className="ps-card">
+          <h4>
+            <svg className="ps-ic-sm" viewBox="0 0 12 12">
+              <circle cx="6" cy="6" r="4.5" />
+              <path d="M6 3.5V6l1.5 1" />
+            </svg>
+            Timing
+            <span className="ps-card-hint">defaults assume your radio</span>
+          </h4>
+
+          <FieldRow
+            label="MOX delay"
+            help="Hold-off after key-down before sampling"
+          >
+            <NumberInput
+              value={psMoxDelaySec}
+              min={0.0}
+              max={10.0}
+              step={0.1}
+              unit="s"
+              onChange={(v) => {
+                setPsMoxDelaySec(v);
+                pushAdvanced({ moxDelaySec: v });
+              }}
+            />
+          </FieldRow>
+
+          <FieldRow
+            label="Cal delay"
+            help="Time between calibration iterations"
+          >
+            <NumberInput
+              value={psLoopDelaySec}
+              min={0.0}
+              max={100.0}
+              step={0.5}
+              unit="s"
+              onChange={(v) => {
+                setPsLoopDelaySec(v);
+                pushAdvanced({ loopDelaySec: v });
+              }}
+            />
+          </FieldRow>
+
+          <FieldRow
+            label="Amp delay"
+            help="RF propagation through the PA chain"
+          >
+            <NumberInput
+              value={psAmpDelayNs}
+              min={0}
+              max={25_000_000}
+              step={50}
+              unit="ns"
+              onChange={(v) => {
+                setPsAmpDelayNs(v);
+                pushAdvanced({ ampDelayNs: v });
+              }}
+            />
+          </FieldRow>
+        </div>
+
+        <div className="ps-card">
+          <h4>
+            <svg className="ps-ic-sm" viewBox="0 0 12 12">
+              <rect x="2" y="4" width="8" height="4" rx="1" />
+              <path d="M4 4V2M8 4V2M4 10V8M8 10V8" />
+            </svg>
+            Hardware
+            <span className="ps-card-hint">advanced — most users won't change</span>
+          </h4>
+
+          <FieldRow
+            label="HW peak"
+            help="Override coupler ADC ceiling"
+          >
+            <span className="ps-hwpeak-cell">
+              <NumberInput
+                value={psHwPeak}
+                min={0.01}
+                max={2.0}
+                step={0.001}
+                onChange={(v) => {
+                  setPsHwPeak(v);
+                  pushAdvanced({ hwPeak: v });
+                }}
+                onCommit={(v) => {
+                  setPsHwPeak(v);
+                  pushAdvanced({ hwPeak: v });
+                }}
               />
-              <span style={{ fontSize: 11, color: 'var(--fg-1)' }}>Internal coupler</span>
-            </label>
-            <label style={{ display: 'inline-flex', alignItems: 'center' }}>
-              <input
-                type="radio"
-                name="psFeedbackSource"
-                value="external"
-                checked={psFeedbackSourceState === 'external'}
-                onChange={() => onFeedbackSourceChange('external')}
-                style={{ marginRight: 4 }}
-              />
-              <span style={{ fontSize: 11, color: 'var(--fg-1)' }}>External (Bypass)</span>
-            </label>
-          </Row>
-        ) : null}
-        <Row label="HW peak">
-          {/* mi0bot ref: PSForm.cs PSpeak_TextChanged fires on every text
-              change regardless of whether the value differs from the prior
-              value, so re-typing the same number re-pushes it to WDSP and
-              resets calcc state. React's controlled <input> only fires
-              onChange when the rendered value actually changes, so a stale
-              focus-and-blur with no edit is silently dropped. Mirror the
-              mi0bot semantic by firing setPsAdvanced unconditionally on
-              blur / Enter via onCommit, in addition to the live onChange
-              path used by the other advanced fields. */}
-          <NumberInput
-            value={psHwPeak}
-            min={0.01}
-            max={2.0}
-            step={0.001}
-            onChange={(v) => {
-              setPsHwPeak(v);
-              pushAdvanced({ hwPeak: v });
-            }}
-            onCommit={(v) => {
-              setPsHwPeak(v);
-              pushAdvanced({ hwPeak: v });
-            }}
-          />
-          {/* mi0bot ref: PSForm.cs:830
-              `pbWarningSetPk.Visible = _PShwpeak != HardwareSpecific.PSDefaultPeak;`
-              + clsHardwareSpecific.cs:303-328 PSDefaultPeak per-board switch.
-              Show a small accent glyph after the input when the operator has
-              dialed PsHwPeak away from the per-board factory default. Title
-              attribute exposes the resolved default for the operator so they
-              know what value would clear the indicator. */}
-          {psHwPeak !== psHwPeakDefault ? (
-            <span
-              aria-label="HW peak differs from per-board default"
-              title={`Differs from default ${psHwPeakDefault.toFixed(4)}`}
-              style={{
-                color: 'var(--accent)',
-                fontSize: 12,
-                fontWeight: 700,
-                marginLeft: 4,
-                userSelect: 'none',
+              {psHwPeak !== psHwPeakDefault ? (
+                <span
+                  className="ps-diff-mark"
+                  aria-label="HW peak differs from per-board default"
+                  title={`Differs from default ${psHwPeakDefault.toFixed(4)}`}
+                >
+                  *
+                </span>
+              ) : null}
+              <button
+                type="button"
+                className="ps-default-btn"
+                disabled={psHwPeak === psHwPeakDefault}
+                title={`Reset HW peak to per-board default ${psHwPeakDefault.toFixed(4)}`}
+                onClick={() => {
+                  setPsHwPeak(psHwPeakDefault);
+                  pushAdvanced({ hwPeak: psHwPeakDefault });
+                }}
+              >
+                Default
+              </button>
+            </span>
+          </FieldRow>
+
+          <FieldRow
+            label="Ints / Spi"
+            help="Iterations per spectral pass"
+          >
+            <select
+              className="ps-select-mini"
+              value={psIntsSpiPreset}
+              onChange={(e) => {
+                const v = e.target.value;
+                setPsIntsSpiPreset(v);
+                pushAdvanced({ intsSpiPreset: v });
               }}
             >
-              *
-            </span>
-          ) : null}
-          {/* mi0bot ref: PSForm.cs:991-994 btnDefaultPeaks_Click →
-              SetDefaultPeaks → psdefpeak (PSForm.cs:371-381) writes
-              HardwareSpecific.PSDefaultPeak (clsHardwareSpecific.cs:303-328)
-              into txtPSpeak. One-click reset to the per-board factory default
-              for operators who've drifted off and want to start over.
-              Disabled when already at the default — no point re-pushing the
-              same value through this button (the field's onCommit covers
-              the deliberate re-push case). */}
-          <button
-            type="button"
-            className="btn sm"
-            disabled={psHwPeak === psHwPeakDefault}
-            title={`Reset HW peak to per-board default ${psHwPeakDefault.toFixed(4)}`}
-            onClick={() => {
-              setPsHwPeak(psHwPeakDefault);
-              pushAdvanced({ hwPeak: psHwPeakDefault });
-            }}
-          >
-            Default
-          </button>
-        </Row>
-        {/* mi0bot ref: PSForm.cs:624 GetPSMaxTX → PSForm.designer.cs
-            txtGetPSpeak readout. Read-only; the operator dials HW peak
-            above to match the observed envelope max during calibration. */}
-        <Row label="Observed peak">
-          <span style={{ fontSize: 11, color: 'var(--fg-1)' }}>
-            {psMaxTxEnvelope.toFixed(4)}
-          </span>
-        </Row>
-        <Row label="Ints / Spi">
-          <select
-            value={psIntsSpiPreset}
-            onChange={(e) => {
-              const v = e.target.value;
-              setPsIntsSpiPreset(v);
-              pushAdvanced({ intsSpiPreset: v });
-            }}
-          >
-            <option value="16/256">16 / 256</option>
-            <option value="8/512">8 / 512</option>
-            <option value="4/1024">4 / 1024</option>
-          </select>
-        </Row>
-        <Row label="Relax phase tol">
-          <input
-            type="checkbox"
-            checked={psPtol}
-            onChange={(e) => {
-              const v = e.target.checked;
-              setPsPtol(v);
-              pushAdvanced({ ptol: v });
-            }}
-          />
-        </Row>
-      </Section>
+              <option value="16/256">16 / 256</option>
+              <option value="8/512">8 / 512</option>
+              <option value="4/1024">4 / 1024</option>
+            </select>
+          </FieldRow>
 
-      {/* Display — issue #121. Hidden on HL2 (no PS feedback Rx). The
-          control is operator opt-in; default off preserves the Thetis-
-          style predistorted-IQ panadapter view. The backend gates the
-          actual analyzer swap on PsEnabled && PsCorrecting in addition
-          to this flag, so flipping it on while PS is off is harmless. */}
-      {psMonitorSupported ? (
-        <Section title="Display">
-          <Row label="Monitor PA output">
-            <input
-              type="checkbox"
-              checked={psMonitorEnabled}
-              onChange={(e) => onPsMonitorToggle(e.target.checked)}
-              title="Show post-correction signal in TX panadapter"
+          <FieldRow
+            label="Auto-attenuate"
+            help="Drop drive when feedback clips"
+          >
+            <Checkbox
+              checked={psAutoAttenuate}
+              onChange={(v) => {
+                setPsAutoAttenuate(v);
+                pushAdvanced({ autoAttenuate: v });
+              }}
+              label={psAutoAttenuate ? 'Enabled' : 'Disabled'}
             />
-            <span style={{ fontSize: 11, color: 'var(--fg-2)', marginLeft: 8 }}>
-              Show post-correction signal in TX panadapter
+          </FieldRow>
+
+          <FieldRow
+            label="Relax phase tolerance"
+            help="Allow looser convergence on weak PAs"
+          >
+            <Checkbox
+              checked={psPtol}
+              onChange={(v) => {
+                setPsPtol(v);
+                pushAdvanced({ ptol: v });
+              }}
+              label={psPtol ? 'Enabled' : 'Disabled'}
+            />
+          </FieldRow>
+        </div>
+      </div>
+
+      {/* ── Status (last cal) ─────────────────────────────── */}
+      <div className="ps-status-row">
+        <div className="ps-status-left">
+          <span>Calibration</span>
+          {psCorrecting ? (
+            <span className="saved">
+              {`converged · ${psCorrectionDb.toFixed(2)} dB`}
             </span>
-          </Row>
-        </Section>
+          ) : (
+            <span>{calStateLabel}</span>
+          )}
+        </div>
+      </div>
+
+      {/* ── Display: PS Monitor (hidden on HL2) ──────────── */}
+      {psMonitorSupported ? (
+        <div className="ps-card">
+          <h4>
+            <svg className="ps-ic-sm" viewBox="0 0 12 12">
+              <rect x="1.5" y="2.5" width="9" height="6" rx="0.8" />
+              <path d="M4 10h4M6 8.5v1.5" />
+            </svg>
+            Display
+          </h4>
+          <FieldRow
+            label="Monitor PA output"
+            help="Show post-correction signal in TX panadapter"
+          >
+            <Checkbox
+              checked={psMonitorEnabled}
+              onChange={onPsMonitorToggle}
+              label={psMonitorEnabled ? 'Enabled' : 'Disabled'}
+            />
+          </FieldRow>
+        </div>
       ) : null}
 
-      {/* Read-out */}
-      <Section title="Read-out">
-        <Row label="Feedback">
-          <Bar value={feedbackBar} />
-          <span style={{ fontSize: 11, color: 'var(--fg-2)', marginLeft: 8 }}>
-            {psFeedbackLevel.toFixed(0)} / 256
-          </span>
-        </Row>
-        <Row label="Cal state">
-          <span style={{ fontSize: 11, color: 'var(--fg-1)' }}>
-            {calStateLabel}
-            {psCorrecting ? ' · correcting' : ''}
-          </span>
-        </Row>
-        <Row label="Correction">
-          <span style={{ fontSize: 11, color: 'var(--fg-1)' }}>
-            {psCorrecting ? `${psCorrectionDb.toFixed(1)} dB` : '—'}
-          </span>
-        </Row>
-      </Section>
+      {/* ── Two-tone test signal ─────────────────────────── */}
+      <div className="ps-card">
+        <h4>
+          <svg className="ps-ic-sm" viewBox="0 0 12 12">
+            <path d="M1.5 6c1-3 3-3 3 0s2 3 3 0 2-3 3 0" />
+          </svg>
+          Two-tone test signal
+        </h4>
 
+        <FieldRow
+          label="Generator"
+          help="Standard PureSignal calibration excitation"
+        >
+          <button
+            type="button"
+            className={`ps-btn ${twoToneOn ? 'primary' : ''}`}
+            onClick={onTwoToneToggle}
+          >
+            {twoToneOn ? '2-Tone ON' : '2-Tone OFF'}
+          </button>
+        </FieldRow>
+
+        <FieldRow label="Freq 1" help="Lower test tone">
+          <NumberInput
+            value={twoToneFreq1}
+            min={50}
+            max={5000}
+            step={10}
+            unit="Hz"
+            onChange={onTwoToneFreq1Change}
+          />
+        </FieldRow>
+
+        <FieldRow label="Freq 2" help="Upper test tone">
+          <NumberInput
+            value={twoToneFreq2}
+            min={50}
+            max={5000}
+            step={10}
+            unit="Hz"
+            onChange={onTwoToneFreq2Change}
+          />
+        </FieldRow>
+
+        <FieldRow label="Magnitude" help="Per-tone amplitude (0..1)">
+          <NumberInput
+            value={twoToneMag}
+            min={0}
+            max={1}
+            step={0.01}
+            onChange={onTwoToneMagChange}
+          />
+        </FieldRow>
+      </div>
     </div>
   );
 }
 
-function Section({
-  title,
+function FlowNode({
+  label,
+  sub,
+  active,
   children,
 }: {
-  title: string;
+  label: string;
+  sub: string;
+  active: boolean;
   children: React.ReactNode;
 }) {
   return (
-    <section
-      style={{
-        border: '1px solid var(--panel-border)',
-        borderRadius: 6,
-        padding: '10px 12px',
-        background: 'var(--bg-1)',
-      }}
-    >
-      <h3
-        style={{
-          margin: 0,
-          marginBottom: 8,
-          fontSize: 11,
-          fontWeight: 700,
-          letterSpacing: '0.12em',
-          textTransform: 'uppercase',
-          color: 'var(--fg-1)',
-        }}
-      >
-        {title}
-      </h3>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-        {children}
-      </div>
-    </section>
+    <div className={`ps-node ${active ? 'active' : 'dim'}`}>
+      <div className="ps-ico">{children}</div>
+      <div className="ps-nm">{label}</div>
+      <div className="ps-sub">{sub}</div>
+    </div>
   );
 }
 
-function Row({ label, children }: { label: string; children: React.ReactNode }) {
+function FieldRow({
+  label,
+  help,
+  children,
+}: {
+  label: string;
+  help?: string;
+  children: React.ReactNode;
+}) {
   return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 10,
-        fontSize: 12,
-      }}
-    >
-      <span style={{ minWidth: 110, color: 'var(--fg-2)' }}>{label}</span>
-      <span style={{ display: 'flex', alignItems: 'center', flex: 1, gap: 6 }}>
-        {children}
-      </span>
+    <div className="ps-field">
+      <div className="ps-name">
+        {label}
+        {help ? <em>{help}</em> : null}
+      </div>
+      <div>{children}</div>
     </div>
   );
 }
@@ -498,6 +800,7 @@ function NumberInput({
   min,
   max,
   step,
+  unit,
   onChange,
   onCommit,
   disabled,
@@ -506,6 +809,7 @@ function NumberInput({
   min: number;
   max: number;
   step: number;
+  unit?: string;
   onChange: (v: number) => void;
   // mi0bot ref: PSForm.cs PSpeak_TextChanged — onCommit fires on blur and
   // Enter unconditionally so re-entering the same value still re-pushes,
@@ -515,69 +819,79 @@ function NumberInput({
   disabled?: boolean;
 }) {
   return (
-    <input
-      type="number"
-      value={value}
-      min={min}
-      max={max}
-      step={step}
-      disabled={disabled}
-      onChange={(e) => {
-        const v = Number(e.target.value);
-        if (Number.isFinite(v)) onChange(v);
-      }}
-      onBlur={(e) => {
-        if (!onCommit) return;
-        const v = Number(e.target.value);
-        if (!Number.isFinite(v)) return;
-        // React-controlled-input cosmetic ("00.18" → "0.18", ".5" → "0.5",
-        // trailing zeros trimmed); mi0bot WinForms NumericUpDown handles via
-        // .Value setter. State is already the parsed number, but a
-        // controlled <input type="number"> does not re-render when the
-        // parsed value matches state, so the raw text sticks until
-        // something else changes — write the canonical form back to the DOM.
-        const normalized = String(v);
-        if (normalized !== e.target.value) e.target.value = normalized;
-        onCommit(v);
-      }}
-      onKeyDown={(e) => {
-        if (!onCommit || e.key !== 'Enter') return;
-        const v = Number((e.target as HTMLInputElement).value);
-        if (Number.isFinite(v)) onCommit(v);
-      }}
-      style={{
-        width: 100,
-        padding: '3px 6px',
-        background: 'var(--bg-0)',
-        color: 'var(--fg-1)',
-        border: '1px solid var(--panel-border)',
-        borderRadius: 3,
-        fontSize: 12,
-      }}
-    />
+    <span className="ps-ninput">
+      <input
+        type="number"
+        className={unit ? '' : 'no-unit'}
+        value={value}
+        min={min}
+        max={max}
+        step={step}
+        disabled={disabled}
+        onChange={(e) => {
+          const v = Number(e.target.value);
+          if (Number.isFinite(v)) onChange(v);
+        }}
+        onBlur={(e) => {
+          if (!onCommit) return;
+          const v = Number(e.target.value);
+          if (!Number.isFinite(v)) return;
+          const normalized = String(v);
+          if (normalized !== e.target.value) e.target.value = normalized;
+          onCommit(v);
+        }}
+        onKeyDown={(e) => {
+          if (!onCommit || e.key !== 'Enter') return;
+          const v = Number((e.target as HTMLInputElement).value);
+          if (Number.isFinite(v)) onCommit(v);
+        }}
+      />
+      {unit ? <span className="ps-unit">{unit}</span> : null}
+    </span>
   );
 }
 
-function Bar({ value }: { value: number }) {
-  const pct = Math.max(0, Math.min(1, value)) * 100;
+function Checkbox({
+  checked,
+  onChange,
+  label,
+}: {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  label: string;
+}) {
   return (
-    <div
-      style={{
-        width: 140,
-        height: 8,
-        background: 'var(--accent-soft)',
-        borderRadius: 2,
-        overflow: 'hidden',
-      }}
-    >
-      <div
-        style={{
-          width: `${pct}%`,
-          height: '100%',
-          background: 'var(--accent)',
-          transition: 'width 80ms linear',
-        }}
+    <label className="ps-check">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
       />
-    </div>
+      <span className="ps-check-box" />
+      <span>{label}</span>
+    </label>
   );
+}
+
+function formatElapsed(ms: number): string {
+  const s = Math.max(0, Math.floor(ms / 1000));
+  const m = Math.floor(s / 60);
+  const r = s % 60;
+  return `Elapsed ${m}:${String(r).padStart(2, '0')}`;
+}
+
+function buildSparkline(history: number[]): string {
+  if (history.length === 0) return '';
+  const n = SPARK_LEN;
+  // Auto-scale so the trace stays visible regardless of dB magnitude.
+  const min = Math.min(...history, 0);
+  const max = Math.max(...history, min + 0.5);
+  const range = Math.max(0.1, max - min);
+  return history
+    .map((v, i) => {
+      const x = (i / (n - 1)) * 200;
+      const y = 13 - ((v - min) / range) * 11 - 1;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(' ');
 }

--- a/zeus-web/src/components/PsStatusPopover.tsx
+++ b/zeus-web/src/components/PsStatusPopover.tsx
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+import { useTxStore } from '../state/tx-store';
+
+const CAL_STATE_NAMES = [
+  'RESET',
+  'WAIT',
+  'MOXDELAY',
+  'SETUP',
+  'COLLECT',
+  'MOXCHECK',
+  'CALC',
+  'DELAY',
+  'STAYON',
+  'TURNON',
+];
+
+// Dial geometry — must match the SVG circle below.
+const DIAL_R = 36;
+const DIAL_C = 2 * Math.PI * DIAL_R;
+
+/**
+ * Live PureSignal status popover. Anchored above the transport-bar PS
+ * button, surfaces the same telemetry as the Settings → PURESIGNAL hero
+ * (convergence dial, cal state, observed/HW peaks, correction dB) but
+ * compact enough to scan in a glance during MOX without leaving the
+ * panadapter view.
+ */
+export function PsStatusPopover() {
+  const psEnabled = useTxStore((s) => s.psEnabled);
+  const psFeedbackLevel = useTxStore((s) => s.psFeedbackLevel);
+  const psCalState = useTxStore((s) => s.psCalState);
+  const psCorrecting = useTxStore((s) => s.psCorrecting);
+  const psCorrectionDb = useTxStore((s) => s.psCorrectionDb);
+  const psMaxTxEnvelope = useTxStore((s) => s.psMaxTxEnvelope);
+  const psHwPeak = useTxStore((s) => s.psHwPeak);
+  const psAuto = useTxStore((s) => s.psAuto);
+  const psSingle = useTxStore((s) => s.psSingle);
+
+  const calStateLabel = CAL_STATE_NAMES[psCalState] ?? `state ${psCalState}`;
+  const feedbackPct = Math.max(0, Math.min(1, psFeedbackLevel / 256));
+  const dialFillLen = feedbackPct * DIAL_C;
+  const feedbackRound = Math.round(psFeedbackLevel);
+
+  const isConverged = psCorrecting;
+  const isRunning = psEnabled && !isConverged && psCalState > 0;
+  const dialClass = isConverged ? 'is-converged' : '';
+  const armedLabel = !psEnabled
+    ? 'IDLE'
+    : isConverged
+      ? 'CORRECTING'
+      : isRunning
+        ? 'RUNNING'
+        : 'ARMED';
+
+  // Peak meter scale — same logic as the Settings hero so values map 1:1
+  // between the two views.
+  const meterScale = Math.max(psHwPeak * 1.4, psMaxTxEnvelope * 1.05, 0.001);
+  const obsPct = Math.min(100, (psMaxTxEnvelope / meterScale) * 100);
+  const refPct = Math.min(100, (psHwPeak / meterScale) * 100);
+  const obsClass =
+    psMaxTxEnvelope >= psHwPeak
+      ? 'bad'
+      : psMaxTxEnvelope > psHwPeak * 0.95
+        ? 'warn'
+        : '';
+
+  const modeLabel = psSingle ? 'Single' : psAuto ? 'Auto' : 'Manual';
+
+  return (
+    <div className="ps-popover" role="status" aria-live="polite">
+      <div className="ps-popover-head">
+        <span className="ps-popover-title">PureSignal</span>
+        <span className={`ps-popover-state ${psEnabled ? 'on' : 'off'}`}>
+          {armedLabel}
+        </span>
+      </div>
+
+      <div className="ps-popover-body">
+        <div className={`ps-popover-dial ${dialClass}`}>
+          <svg viewBox="0 0 88 88">
+            <circle
+              className="ps-dial-track"
+              cx="44"
+              cy="44"
+              r={DIAL_R}
+              transform="rotate(-90 44 44)"
+            />
+            <circle
+              className="ps-dial-fill"
+              cx="44"
+              cy="44"
+              r={DIAL_R}
+              transform="rotate(-90 44 44)"
+              style={{
+                strokeDasharray: `${dialFillLen} ${DIAL_C - dialFillLen}`,
+              }}
+            />
+          </svg>
+          <div className="ps-popover-dial-center">
+            <div className="ps-popover-dial-num">{feedbackRound}</div>
+            <div className="ps-popover-dial-sub">/ 256</div>
+          </div>
+        </div>
+
+        <dl className="ps-popover-rows">
+          <div className="ps-popover-row">
+            <dt>State</dt>
+            <dd className="mono">{calStateLabel}</dd>
+          </div>
+          <div className="ps-popover-row">
+            <dt>Mode</dt>
+            <dd>{modeLabel}</dd>
+          </div>
+          <div className="ps-popover-row">
+            <dt>Correction</dt>
+            <dd className="mono">
+              {psCorrecting ? `+${psCorrectionDb.toFixed(2)} dB` : '—'}
+            </dd>
+          </div>
+        </dl>
+      </div>
+
+      <div className={`ps-popover-peak ${obsClass}`}>
+        <div className="ps-popover-peak-row">
+          <span>Observed</span>
+          <span className="mono">{psMaxTxEnvelope.toFixed(4)}</span>
+        </div>
+        <div className="ps-popover-meter">
+          <div className="ps-popover-mfill" style={{ width: `${obsPct}%` }} />
+          <div className="ps-popover-ref" style={{ left: `${refPct}%` }} />
+        </div>
+        <div className="ps-popover-peak-row sub">
+          <span>HW peak</span>
+          <span className="mono">{psHwPeak.toFixed(4)}</span>
+        </div>
+      </div>
+
+      <div className="ps-popover-foot">
+        Click PS to {psEnabled ? 'disarm' : 'arm'} · open Settings → PURESIGNAL
+        for full controls
+      </div>
+    </div>
+  );
+}

--- a/zeus-web/src/components/PsToggleButton.tsx
+++ b/zeus-web/src/components/PsToggleButton.tsx
@@ -19,31 +19,17 @@
 // (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
 // Both are GPL-2.0-or-later.
 
-import { useCallback, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { setPs, setPsMonitor } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
 import { useRadioStore } from '../state/radio-store';
 import { useTxStore } from '../state/tx-store';
+import { PsStatusPopover } from './PsStatusPopover';
 
 // Connected board kinds that don't have a real PS feedback receiver. PS
 // Monitor (post-PA loopback display source) is only meaningful where the
 // board has a feedback path, so we don't auto-enable it for these.
 const PS_MONITOR_UNSUPPORTED = new Set(['HermesLite2']);
-
-// Mirrors PsSettingsPanel — keep the indices aligned with the WDSP CalcC
-// state numbering so the hover read-out and the settings panel agree.
-const CAL_STATE_NAMES = [
-  'RESET',
-  'WAIT',
-  'MOXDELAY',
-  'SETUP',
-  'COLLECT',
-  'MOXCHECK',
-  'CALC',
-  'DELAY',
-  'STAYON',
-  'TURNON',
-];
 
 /**
  * PureSignal master arm. Optimistic update with rollback on server refusal —
@@ -60,8 +46,6 @@ export function PsToggleButton() {
   const setPsEnabled = useTxStore((s) => s.setPsEnabled);
   const setPsMonitorLocal = useTxStore((s) => s.setPsMonitorEnabled);
   const connectedBoard = useRadioStore((s) => s.selection.connected);
-
-  const [hover, setHover] = useState(false);
 
   const disabled = !connected;
   const tooltip = psEnabled
@@ -100,11 +84,41 @@ export function PsToggleButton() {
     setPsMonitorLocal,
   ]);
 
+  // Hover-pinned popover — appears above the button while either the button
+  // or the popover itself is hovered (a small close delay lets the operator
+  // slide their cursor off the button onto the popover without it
+  // collapsing). Click still toggles the arm state; the popover is purely
+  // informational. Native title tooltip is suppressed while armed so it
+  // doesn't overlay the popover.
+  const [open, setOpen] = useState(false);
+  const closeTimer = useRef<number | null>(null);
+
+  const cancelClose = useCallback(() => {
+    if (closeTimer.current != null) {
+      window.clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+  }, []);
+  const scheduleClose = useCallback(() => {
+    cancelClose();
+    closeTimer.current = window.setTimeout(() => setOpen(false), 120);
+  }, [cancelClose]);
+
+  useEffect(() => () => cancelClose(), [cancelClose]);
+
   return (
-    <div
-      style={{ position: 'relative', display: 'inline-flex' }}
-      onMouseEnter={() => setHover(true)}
-      onMouseLeave={() => setHover(false)}
+    <span
+      className="ps-button-wrap"
+      onMouseEnter={() => {
+        cancelClose();
+        setOpen(true);
+      }}
+      onMouseLeave={scheduleClose}
+      onFocus={() => {
+        cancelClose();
+        setOpen(true);
+      }}
+      onBlur={scheduleClose}
     >
       <button
         type="button"
@@ -112,139 +126,20 @@ export function PsToggleButton() {
         onClick={click}
         className={`btn tx-btn ${psEnabled ? 'active' : ''}`}
         title={psEnabled ? undefined : tooltip}
+        aria-describedby={open ? 'ps-status-popover' : undefined}
       >
         <span className={`led ${psEnabled ? 'on' : ''}`} style={{ marginRight: 8 }} />
         PS
       </button>
-      {psEnabled && hover ? <PsHoverReadout /> : null}
-    </div>
-  );
-}
-
-// Hover popover — live PS read-out (Feedback / Cal state / Correction).
-// Only mounted while psEnabled && hovering, so the store subscriptions and
-// peak-decay re-render path stay idle when PS is off.
-function PsHoverReadout() {
-  const psFeedbackLevel = useTxStore((s) => s.psFeedbackLevel);
-  const psCalState = useTxStore((s) => s.psCalState);
-  const psCorrecting = useTxStore((s) => s.psCorrecting);
-  const psCorrectionDb = useTxStore((s) => s.psCorrectionDb);
-
-  const calStateLabel = CAL_STATE_NAMES[psCalState] ?? `state ${psCalState}`;
-  const feedbackPct = Math.max(0, Math.min(1, psFeedbackLevel / 256)) * 100;
-
-  return (
-    <div
-      role="status"
-      aria-label="PureSignal read-out"
-      style={{
-        position: 'absolute',
-        bottom: 'calc(100% + 8px)',
-        left: 0,
-        zIndex: 50,
-        minWidth: 260,
-        padding: '10px 12px 11px',
-        background: 'var(--bg-1)',
-        border: '1px solid var(--panel-border)',
-        borderRadius: 6,
-        boxShadow: '0 8px 22px rgba(0,0,0,0.55)',
-        fontFamily: 'var(--font-mono)',
-      }}
-    >
-      <div
-        style={{
-          fontSize: 9.5,
-          fontWeight: 700,
-          letterSpacing: '0.18em',
-          textTransform: 'uppercase',
-          color: 'var(--fg-3)',
-          marginBottom: 8,
-        }}
-      >
-        Read-out
-      </div>
-      <ReadoutRow label="Feedback">
-        <div
-          style={{
-            position: 'relative',
-            flex: 1,
-            height: 8,
-            background: 'var(--meter-bg)',
-            border: '1px solid var(--panel-border)',
-            borderRadius: 2,
-            overflow: 'hidden',
-            boxShadow: 'inset 0 1px 0 rgba(0,0,0,0.5)',
-          }}
-        >
-          <div
-            aria-hidden="true"
-            style={{
-              position: 'absolute',
-              left: 0,
-              top: 0,
-              bottom: 0,
-              width: `${feedbackPct}%`,
-              background: 'var(--accent)',
-              transition: 'width 80ms linear',
-            }}
-          />
-        </div>
+      {open ? (
         <span
-          style={{
-            minWidth: 60,
-            textAlign: 'right',
-            fontSize: 10.5,
-            color: 'var(--fg-1)',
-            letterSpacing: '0.04em',
-          }}
+          id="ps-status-popover"
+          className="ps-popover-anchor"
+          role="presentation"
         >
-          {psFeedbackLevel.toFixed(0)}
-          <span style={{ color: 'var(--fg-3)' }}> / 256</span>
+          <PsStatusPopover />
         </span>
-      </ReadoutRow>
-      <ReadoutRow label="Cal state">
-        <span style={{ fontSize: 11, color: 'var(--fg-1)', letterSpacing: '0.04em' }}>
-          {calStateLabel}
-          {psCorrecting ? (
-            <span style={{ color: 'var(--fg-3)' }}> · correcting</span>
-          ) : null}
-        </span>
-      </ReadoutRow>
-      <ReadoutRow label="Correction">
-        <span style={{ fontSize: 11, color: 'var(--fg-1)', letterSpacing: '0.04em' }}>
-          {psCorrecting ? `${psCorrectionDb.toFixed(1)} dB` : '—'}
-        </span>
-      </ReadoutRow>
-    </div>
-  );
-}
-
-function ReadoutRow({ label, children }: { label: string; children: ReactNode }) {
-  return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 10,
-        height: 18,
-        marginTop: 5,
-      }}
-    >
-      <span
-        style={{
-          minWidth: 80,
-          fontSize: 9,
-          fontWeight: 600,
-          letterSpacing: '0.18em',
-          textTransform: 'uppercase',
-          color: 'var(--fg-3)',
-        }}
-      >
-        {label}
-      </span>
-      <span style={{ display: 'flex', alignItems: 'center', flex: 1, gap: 8 }}>
-        {children}
-      </span>
-    </div>
+      ) : null}
+    </span>
   );
 }

--- a/zeus-web/src/main.tsx
+++ b/zeus-web/src/main.tsx
@@ -52,6 +52,7 @@ import './styles/toolbar-favorites.css';
 import './styles/nr-settings.css';
 import './styles/meters-grid.css';
 import './styles/all-panels.css';
+import './styles/ps-settings.css';
 import App from './App.tsx';
 import { installFetchInterceptor } from './serverUrl';
 

--- a/zeus-web/src/styles/ps-settings.css
+++ b/zeus-web/src/styles/ps-settings.css
@@ -1,0 +1,981 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later
+ * PureSignal settings — diagnostic-first calibration dashboard.
+ * Layout/structure inspired by the redesigned mockup; palette and
+ * typography use Zeus tokens (Archivo Narrow + the standard --accent
+ * blue / --tx red / --power yellow accents — never amber, which is
+ * reserved for the panadapter trace).
+ */
+
+.ps-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  --ps-good: #4aa04a;
+  --ps-warn: var(--power);
+  --ps-bad: var(--tx);
+}
+
+.ps-section-head {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.ps-section-head h3 {
+  margin: 0;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  color: var(--fg-0);
+  font-weight: 700;
+  text-transform: uppercase;
+}
+.ps-section-head p {
+  margin: 0;
+  font-size: 12px;
+  color: var(--fg-2);
+  line-height: 1.4;
+  flex: 1;
+}
+.ps-section-head .ps-elapsed {
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  color: var(--fg-3);
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+/* ── Hero: dial / flow / peaks ─────────────────────────── */
+.ps-hero {
+  border: 1px solid var(--panel-border);
+  border-radius: var(--r-md);
+  background: linear-gradient(180deg, var(--bg-2), var(--bg-1));
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: 220px 1fr 220px;
+}
+
+@media (max-width: 920px) {
+  .ps-hero {
+    grid-template-columns: 1fr;
+  }
+  .ps-dial-col,
+  .ps-flow-col {
+    border-right: none !important;
+    border-bottom: 1px solid var(--panel-border);
+  }
+}
+
+.ps-dial-col {
+  padding: 16px;
+  border-right: 1px solid var(--panel-border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  background: radial-gradient(80% 70% at 50% 0%,
+    rgba(74, 158, 255, 0.08), transparent 70%);
+}
+
+.ps-dial {
+  position: relative;
+  width: 168px;
+  height: 168px;
+}
+.ps-dial svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+.ps-dial-track {
+  stroke: var(--bg-3);
+  stroke-width: 8;
+  fill: none;
+}
+.ps-dial-fill {
+  stroke: var(--accent);
+  stroke-width: 8;
+  fill: none;
+  stroke-linecap: round;
+  transition: stroke-dasharray 0.25s ease, stroke 0.25s;
+}
+.ps-dial.is-converged .ps-dial-fill {
+  stroke: var(--ps-good);
+}
+.ps-dial.is-error .ps-dial-fill {
+  stroke: var(--ps-bad);
+}
+.ps-dial-center {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 2px;
+}
+.ps-dial-state {
+  font-size: 9.5px;
+  letter-spacing: 0.22em;
+  color: var(--fg-2);
+  text-transform: uppercase;
+  font-weight: 700;
+}
+.ps-dial-num {
+  font-size: 32px;
+  font-weight: 700;
+  color: var(--fg-0);
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+.ps-dial-num small {
+  font-size: 12px;
+  color: var(--fg-3);
+  font-weight: 500;
+  margin-left: 2px;
+}
+.ps-dial-sub {
+  font-size: 10.5px;
+  color: var(--fg-2);
+  letter-spacing: 0.04em;
+}
+
+.ps-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--panel-border);
+  background: var(--bg-0);
+  font-size: 11px;
+  color: var(--fg-1);
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+}
+.ps-pdot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--fg-3);
+}
+.ps-pill.ok .ps-pdot {
+  background: var(--ps-good);
+  box-shadow: 0 0 0 3px rgba(74, 160, 74, 0.25);
+}
+.ps-pill.run .ps-pdot {
+  background: var(--accent);
+  box-shadow: 0 0 0 3px rgba(74, 158, 255, 0.25);
+  animation: ps-pulse 1.6s ease-in-out infinite;
+}
+.ps-pill.err .ps-pdot {
+  background: var(--ps-bad);
+}
+@keyframes ps-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+/* ── Signal flow ───────────────────────────────────────── */
+.ps-flow-col {
+  padding: 16px;
+  border-right: 1px solid var(--panel-border);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  justify-content: center;
+}
+.ps-flow-title {
+  font-size: 9.5px;
+  letter-spacing: 0.22em;
+  color: var(--fg-3);
+  text-transform: uppercase;
+  font-weight: 700;
+}
+.ps-flow {
+  display: grid;
+  grid-template-columns: 1fr 18px 1fr 18px 1fr 18px 1fr;
+  align-items: center;
+  background: var(--bg-0);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--r-sm);
+  padding: 12px 10px;
+}
+.ps-flow .ps-node {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  text-align: center;
+}
+.ps-flow .ps-node .ps-ico {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--r-sm);
+  background: var(--bg-2);
+  border: 1px solid var(--panel-border);
+  display: grid;
+  place-items: center;
+  color: var(--fg-1);
+}
+.ps-flow .ps-node.active .ps-ico {
+  border-color: var(--accent);
+  color: #fff;
+  background: rgba(74, 158, 255, 0.18);
+  box-shadow: 0 0 0 2px rgba(74, 158, 255, 0.15);
+}
+.ps-flow .ps-node.dim {
+  opacity: 0.36;
+}
+.ps-flow .ps-node .ps-nm {
+  font-size: 9.5px;
+  letter-spacing: 0.12em;
+  color: var(--fg-1);
+  text-transform: uppercase;
+  font-weight: 700;
+}
+.ps-flow .ps-node .ps-sub {
+  font-size: 9.5px;
+  color: var(--fg-3);
+  letter-spacing: 0.04em;
+}
+
+.ps-flow .ps-arr {
+  height: 2px;
+  align-self: center;
+  margin-top: 6px;
+  background: repeating-linear-gradient(90deg, var(--panel-border) 0 4px, transparent 4px 8px);
+}
+.ps-flow .ps-arr.live {
+  background: linear-gradient(90deg, transparent, var(--accent), transparent);
+  background-size: 28px 100%;
+  background-repeat: repeat-x;
+  animation: ps-flowing 1.4s linear infinite;
+}
+@keyframes ps-flowing {
+  from { background-position: 0 0; }
+  to { background-position: 28px 0; }
+}
+
+.ps-source-tabs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+}
+.ps-source-tab {
+  border: 1px solid var(--panel-border);
+  background: var(--bg-0);
+  border-radius: var(--r-sm);
+  padding: 8px 10px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  text-align: left;
+  color: var(--fg-1);
+  transition: background var(--dur-fast), border-color var(--dur-fast);
+}
+.ps-source-tab:hover {
+  background: var(--bg-2);
+  border-color: var(--panel-border);
+}
+.ps-source-tab.is-active {
+  border-color: var(--accent);
+  background: rgba(74, 158, 255, 0.12);
+  box-shadow: 0 0 0 1px var(--accent) inset;
+}
+.ps-source-tab .ps-rd {
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  border: 1.5px solid var(--fg-3);
+  flex: 0 0 auto;
+}
+.ps-source-tab.is-active .ps-rd {
+  border-color: var(--accent);
+  background: radial-gradient(circle at center, var(--accent) 0 3.5px, transparent 4px);
+}
+.ps-source-tab .ps-rd-label {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.ps-source-tab .ps-rd-label strong {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--fg-0);
+}
+.ps-source-tab .ps-rd-label em {
+  font-style: normal;
+  color: var(--fg-2);
+  font-size: 10.5px;
+}
+
+/* ── Peaks column ──────────────────────────────────────── */
+.ps-peaks-col {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  justify-content: center;
+  background: var(--bg-0);
+}
+.ps-peak {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.ps-peak .ps-peak-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}
+.ps-peak .ps-peak-nm {
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  color: var(--fg-2);
+  text-transform: uppercase;
+  font-weight: 700;
+}
+.ps-peak .ps-peak-val {
+  font-size: 14px;
+  color: var(--fg-0);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.ps-peak .ps-peak-val small {
+  font-size: 10px;
+  color: var(--fg-3);
+  font-weight: 500;
+  margin-left: 2px;
+}
+.ps-peak .ps-meter {
+  height: 6px;
+  border-radius: 3px;
+  background: var(--meter-bg);
+  overflow: hidden;
+  border: 1px solid var(--panel-border);
+  position: relative;
+}
+.ps-peak .ps-mfill {
+  height: 100%;
+  background: var(--accent);
+  transition: width 0.18s ease, background var(--dur-fast);
+}
+.ps-peak.warn .ps-mfill {
+  background: var(--ps-warn);
+}
+.ps-peak.bad .ps-mfill {
+  background: var(--ps-bad);
+}
+.ps-peak .ps-ref {
+  position: absolute;
+  top: -2px;
+  bottom: -2px;
+  width: 1.5px;
+  background: var(--fg-1);
+  opacity: 0.7;
+}
+.ps-peak .ps-help {
+  font-size: 10.5px;
+  color: var(--fg-3);
+  line-height: 1.4;
+}
+.ps-spark {
+  height: 16px;
+  position: relative;
+}
+.ps-spark svg {
+  width: 100%;
+  height: 100%;
+}
+
+/* ── Mode + actions row ────────────────────────────────── */
+.ps-mode-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: 10px;
+  align-items: stretch;
+  margin-top: 12px;
+}
+@media (max-width: 720px) {
+  .ps-mode-row {
+    grid-template-columns: 1fr;
+  }
+}
+.ps-mode-card {
+  border: 1px solid var(--panel-border);
+  background: var(--bg-1);
+  border-radius: var(--r-sm);
+  padding: 10px 14px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  transition: background var(--dur-fast), border-color var(--dur-fast);
+  text-align: left;
+  color: var(--fg-1);
+  font: inherit;
+}
+.ps-mode-card:hover {
+  background: var(--bg-2);
+}
+.ps-mode-card.is-active {
+  border-color: var(--accent);
+  background: rgba(74, 158, 255, 0.10);
+  box-shadow: 0 0 0 1px var(--accent) inset;
+}
+.ps-mode-card .ps-rd {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 1.5px solid var(--fg-3);
+  flex: 0 0 auto;
+}
+.ps-mode-card.is-active .ps-rd {
+  border-color: var(--accent);
+  background: radial-gradient(circle at center, var(--accent) 0 4px, transparent 4.5px);
+}
+.ps-mode-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.ps-mode-info h4 {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--fg-0);
+  letter-spacing: 0.04em;
+}
+.ps-mode-info p {
+  margin: 0;
+  font-size: 11.5px;
+  color: var(--fg-2);
+  line-height: 1.3;
+}
+
+.ps-action-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.ps-btn {
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 8px 14px;
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  border: 1px solid var(--panel-border);
+  background: linear-gradient(180deg, var(--btn-top), var(--btn-bot));
+  color: var(--btn-text);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  white-space: nowrap;
+  transition: filter var(--dur-fast);
+}
+.ps-btn:hover:not(:disabled) {
+  filter: brightness(1.12);
+}
+.ps-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.ps-btn.primary {
+  background: linear-gradient(180deg, var(--btn-active-top), var(--btn-active-bot));
+  border-color: var(--accent);
+  color: var(--btn-active-text);
+}
+.ps-btn.danger {
+  color: #ff8a82;
+  border-color: rgba(230, 58, 43, 0.5);
+}
+.ps-btn.danger:hover:not(:disabled) {
+  background: linear-gradient(180deg, rgba(230, 58, 43, 0.18), var(--btn-bot));
+  color: #ffb6b1;
+}
+
+/* ── Lower grid: timing / hardware ─────────────────────── */
+.ps-grid2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+@media (max-width: 720px) {
+  .ps-grid2 {
+    grid-template-columns: 1fr;
+  }
+}
+
+.ps-card {
+  border: 1px solid var(--panel-border);
+  background: var(--bg-1);
+  border-radius: var(--r-md);
+  padding: 12px 14px;
+}
+.ps-card h4 {
+  margin: 0 0 8px;
+  font-size: 10.5px;
+  letter-spacing: 0.18em;
+  color: var(--fg-1);
+  font-weight: 700;
+  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.ps-card h4 .ps-card-hint {
+  margin-left: auto;
+  font-size: 10.5px;
+  letter-spacing: 0.04em;
+  color: var(--fg-3);
+  text-transform: none;
+  font-weight: 400;
+}
+
+.ps-field {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  padding: 7px 0;
+  gap: 10px;
+  border-bottom: 1px dashed rgba(13, 13, 16, 0.7);
+}
+.ps-field:last-child {
+  border-bottom: none;
+}
+.ps-field .ps-name {
+  font-size: 12.5px;
+  color: var(--fg-1);
+}
+.ps-field .ps-name em {
+  display: block;
+  font-style: normal;
+  font-size: 10.5px;
+  color: var(--fg-3);
+  margin-top: 1px;
+  letter-spacing: 0.02em;
+}
+
+.ps-ninput {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+.ps-ninput input {
+  width: 110px;
+  background: var(--bg-0);
+  border: 1px solid var(--panel-border);
+  color: var(--fg-0);
+  border-radius: var(--r-sm);
+  padding: 6px 32px 6px 10px;
+  font: inherit;
+  font-size: 12.5px;
+  letter-spacing: 0.02em;
+  text-align: right;
+}
+.ps-ninput input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
+}
+.ps-ninput input.no-unit {
+  padding-right: 10px;
+}
+.ps-ninput .ps-unit {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 10.5px;
+  color: var(--fg-3);
+  letter-spacing: 0.04em;
+  pointer-events: none;
+}
+
+.ps-select-mini {
+  background: var(--bg-0);
+  border: 1px solid var(--panel-border);
+  color: var(--fg-0);
+  border-radius: var(--r-sm);
+  padding: 6px 10px;
+  width: 110px;
+  font: inherit;
+  font-size: 12px;
+  appearance: none;
+}
+.ps-select-mini:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.ps-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12.5px;
+  color: var(--fg-1);
+  cursor: pointer;
+  user-select: none;
+}
+.ps-check input {
+  display: none;
+}
+.ps-check .ps-check-box {
+  width: 16px;
+  height: 16px;
+  border-radius: var(--r-xs);
+  border: 1.5px solid var(--fg-3);
+  background: var(--bg-0);
+  display: grid;
+  place-items: center;
+  transition: background var(--dur-fast), border-color var(--dur-fast);
+}
+.ps-check input:checked + .ps-check-box {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+.ps-check input:checked + .ps-check-box::after {
+  content: "";
+  width: 8px;
+  height: 5px;
+  border-left: 2px solid #0b1220;
+  border-bottom: 2px solid #0b1220;
+  transform: rotate(-45deg) translate(1px, -1px);
+}
+
+.ps-hwpeak-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.ps-hwpeak-cell .ps-diff-mark {
+  color: var(--accent);
+  font-size: 14px;
+  font-weight: 700;
+  user-select: none;
+  margin: 0 2px;
+}
+.ps-hwpeak-cell .ps-default-btn {
+  font: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 6px 10px;
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  border: 1px solid var(--panel-border);
+  background: linear-gradient(180deg, var(--btn-top), var(--btn-bot));
+  color: var(--btn-text);
+  white-space: nowrap;
+}
+.ps-hwpeak-cell .ps-default-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* ── Status / monitor / two-tone footer cards ──────────── */
+.ps-status-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 9px 14px;
+  border: 1px solid var(--panel-border);
+  border-radius: var(--r-md);
+  background: var(--bg-1);
+}
+.ps-status-row .ps-status-left {
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  color: var(--fg-3);
+  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.ps-status-row .ps-status-left .saved {
+  color: var(--ps-good);
+  letter-spacing: 0.06em;
+}
+
+/* Two-tone & monitor — keep dense form rows */
+.ps-tt-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.ps-tt-row .ps-name {
+  font-size: 12px;
+  color: var(--fg-2);
+  min-width: 90px;
+}
+
+.ps-ic {
+  width: 14px;
+  height: 14px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.ps-ic-sm {
+  width: 11px;
+  height: 11px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+/* ===========================================================
+   Transport-bar PS popover
+   =========================================================== */
+
+.ps-button-wrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.ps-popover-anchor {
+  position: absolute;
+  /* Anchor above the transport row; the small gap clears the panel rim
+     and gives the pointer room to cross from button to popover without
+     dropping into "neither hovered" briefly. */
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 60;
+  pointer-events: auto;
+  /* Keep clear of the viewport edges on narrow windows. */
+  max-width: calc(100vw - 24px);
+}
+
+.ps-popover {
+  --ps-good: #4aa04a;
+  --ps-warn: var(--power);
+  --ps-bad: var(--tx);
+
+  width: 300px;
+  padding: 12px 14px 10px;
+  background: linear-gradient(180deg, var(--bg-2), var(--bg-1));
+  border: 1px solid var(--panel-border);
+  border-radius: var(--r-md);
+  box-shadow:
+    0 14px 38px -8px rgba(0, 0, 0, 0.65),
+    0 0 0 1px rgba(255, 255, 255, 0.02) inset;
+  color: var(--fg-1);
+  font-family: inherit;
+  font-size: 12px;
+  line-height: 1.3;
+  letter-spacing: 0.01em;
+  /* Caret pointing down to the button below. */
+  position: relative;
+}
+.ps-popover::after,
+.ps-popover::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0;
+  height: 0;
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
+}
+.ps-popover::after {
+  top: 100%;
+  border-top: 7px solid var(--bg-1);
+}
+.ps-popover::before {
+  top: calc(100% + 1px);
+  border-top: 7px solid var(--panel-border);
+  z-index: -1;
+}
+
+.ps-popover-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  padding-bottom: 8px;
+  border-bottom: 1px dashed rgba(13, 13, 16, 0.7);
+  margin-bottom: 10px;
+}
+.ps-popover-title {
+  font-size: 10.5px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--fg-0);
+}
+.ps-popover-state {
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-weight: 700;
+  padding: 3px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--panel-border);
+  background: var(--bg-0);
+  color: var(--fg-2);
+}
+.ps-popover-state.on {
+  color: var(--accent);
+  border-color: rgba(74, 158, 255, 0.5);
+  background: rgba(74, 158, 255, 0.1);
+}
+
+.ps-popover-body {
+  display: grid;
+  grid-template-columns: 88px 1fr;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.ps-popover-dial {
+  position: relative;
+  width: 88px;
+  height: 88px;
+}
+.ps-popover-dial svg {
+  width: 100%;
+  height: 100%;
+}
+.ps-popover-dial .ps-dial-track {
+  stroke: var(--bg-3);
+  stroke-width: 6;
+  fill: none;
+}
+.ps-popover-dial .ps-dial-fill {
+  stroke: var(--accent);
+  stroke-width: 6;
+  fill: none;
+  stroke-linecap: round;
+  transition: stroke-dasharray 0.2s ease, stroke 0.2s;
+}
+.ps-popover-dial.is-converged .ps-dial-fill {
+  stroke: var(--ps-good);
+}
+.ps-popover-dial-center {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  pointer-events: none;
+}
+.ps-popover-dial-num {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--fg-0);
+  letter-spacing: -0.01em;
+  line-height: 1;
+}
+.ps-popover-dial-sub {
+  font-size: 9px;
+  color: var(--fg-3);
+  letter-spacing: 0.08em;
+  margin-top: 2px;
+}
+
+.ps-popover-rows {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.ps-popover-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 11.5px;
+}
+.ps-popover-row dt {
+  margin: 0;
+  font-size: 9.5px;
+  letter-spacing: 0.16em;
+  color: var(--fg-3);
+  text-transform: uppercase;
+  font-weight: 700;
+}
+.ps-popover-row dd {
+  margin: 0;
+  color: var(--fg-0);
+  font-weight: 600;
+}
+.ps-popover-row dd.mono,
+.ps-popover .mono {
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+}
+
+.ps-popover-peak {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 10px;
+  background: var(--bg-0);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--r-sm);
+}
+.ps-popover-peak-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 11px;
+  color: var(--fg-1);
+}
+.ps-popover-peak-row.sub {
+  color: var(--fg-3);
+}
+.ps-popover-meter {
+  position: relative;
+  height: 5px;
+  border-radius: 3px;
+  background: var(--meter-bg);
+  border: 1px solid var(--panel-border);
+  overflow: hidden;
+  margin: 2px 0;
+}
+.ps-popover-mfill {
+  height: 100%;
+  background: var(--accent);
+  transition: width 0.18s ease, background var(--dur-fast);
+}
+.ps-popover-peak.warn .ps-popover-mfill {
+  background: var(--ps-warn);
+}
+.ps-popover-peak.bad .ps-popover-mfill {
+  background: var(--ps-bad);
+}
+.ps-popover-ref {
+  position: absolute;
+  top: -2px;
+  bottom: -2px;
+  width: 1.5px;
+  background: var(--fg-1);
+  opacity: 0.7;
+}
+
+.ps-popover-foot {
+  margin-top: 10px;
+  padding-top: 8px;
+  border-top: 1px dashed rgba(13, 13, 16, 0.7);
+  font-size: 10.5px;
+  letter-spacing: 0.02em;
+  color: var(--fg-3);
+  line-height: 1.35;
+}


### PR DESCRIPTION
## Summary

- Replaces the form-stack PURESIGNAL settings panel with a diagnostic-first dashboard: convergence dial (live `psFeedbackLevel` / 256), TX → PA → COUPLER → FEEDBACK signal-flow diagram, and live peak meters (observed envelope vs HW peak with reference tick + correction-dB sparkline).
- Mode (Auto/Single) becomes selectable cards with explicit Run-now / Reset action stack; Timing and Hardware collapse into a two-column grid below.
- Transport-bar PS button gains a richer hover popover that mirrors the same telemetry — dial, cal state, mode, correction dB, observed/HW peak meter — so the operator can scan PS status without leaving the panadapter view.

Builds on top of the existing release/0.5.0 hover-popover work (#226) — replaces the basic Feedback/Cal-state/Correction read-out with the dashboard-style popover, while keeping the "drop red active styling" change (`btn tx-btn active`, `led on`) that came in 181cbd0 and the PS-Monitor auto-on behaviour from earlier.

## What's preserved

- Two-tone test signal section retained in the settings panel (per maintainer ack on this branch)
- Internal vs External feedback-source selector visible on every board including HL2 (HL2 has an internal coupler — see CLAUDE.md)
- PS-Monitor toggle still hidden on HL2 (issue #121)
- HW-peak per-board "differs from default" indicator + Default reset button (mi0bot parity)
- All store wiring → API client paths unchanged (`setPs`, `setPsAdvanced`, `setPsFeedbackSource`, `setPsMonitor`, `resetPs`, `setTwoTone`)

## Visual-design note

Layout/structure inspired by an HTML/CSS design handoff. Palette and typography stay within the Zeus token system per CLAUDE.md — Archivo Narrow, `--accent` blue / `--tx` red / `--power` yellow; no amber, no Inter/JetBrains Mono, no oklch palette, no new hues introduced.

CLAUDE.md flags layout/UX as red-light, so please bench-test against an HL2 (and ideally a G2) before merging — particularly that the new compact 2-column Timing / Hardware grid fits comfortably inside the Settings modal at smaller widths, and that the popover anchor doesn't collide with the transport bar's left edge on narrow windows.

## Test plan

- [ ] `npm --prefix zeus-web run build` succeeds (✅ verified locally)
- [ ] `npm --prefix zeus-web test` — all 192 vitest tests pass (✅ verified locally)
- [ ] `dotnet build Zeus.slnx` clean (✅ verified locally — 0 warnings)
- [ ] Live HL2 bench: open Settings → PURESIGNAL, verify dial + flow diagram + peak meters render and update during MOX/TUN
- [ ] Live HL2 bench: verify Internal/External feedback-source selector still toggles ALEX bit
- [ ] Live HL2 bench: verify "Run now" triggers a single calibration pass
- [ ] Live HL2 bench: hover the transport-bar PS button — verify popover appears above, shows live values, and closes ~120ms after cursor leaves
- [ ] Verify popover state pill reads IDLE / ARMED / RUNNING / CORRECTING correctly across the cal-state machine
- [ ] Confirm two-tone test signal still arms / disarms and freq/mag fields still POST through `setTwoTone`