### PR TITLE
fix(ps): revert PS-A master arm persistence — was killing HL2 FWD/REF readout

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -170,10 +170,10 @@ public sealed record StateDto(
     double AgcOffsetDb = 0.0,
 
     // ---- PureSignal predistortion (TXA-side; WDSP calcc/iqc stages) ----
-    // PsEnabled is the master arm bit. Persisted via PsSettingsStore so the
-    // PS-A button is sticky across server restarts (Thetis parity — see
-    // PsSettingsStore header). The other PS fields are persisted alongside
-    // it so the operator's calibration tuning survives too.
+    // PsEnabled is the master arm bit. Deliberately NOT persisted server-side
+    // — operator must re-arm each session (parity with MOX). The other PS
+    // fields ARE persisted via PsSettingsStore so the operator's calibration
+    // tuning survives restarts.
     bool PsEnabled = false,
     // PsMonitorEnabled — operator-facing "Monitor PA output" toggle
     // (issue #121). When true AND PsEnabled AND PS has converged
@@ -184,7 +184,7 @@ public sealed record StateDto(
     // Thetis-style predistorted view. Hidden / disabled in the UI on
     // boards that have no PS feedback path (e.g. HermesLite2). NOT
     // persisted server-side: this is an operator viewing preference,
-    // resets to off each session (same discipline as MOX / TUN).
+    // resets to off each session same as PsEnabled.
     bool PsMonitorEnabled = false,
     // TX Monitor — operator-facing audition toggle (issue #106 follow-up).
     // When true, the engine demodulates the post-CFIR TX IQ back to mono
@@ -194,7 +194,7 @@ public sealed record StateDto(
     // is OFF so VST plugins receive samples and meters animate continuously.
     // RX audio is suppressed in the broadcast while monitor is on so the
     // operator hears only the TX audition. NOT persisted across sessions —
-    // resets to off each connect, matching MOX / TUN discipline.
+    // resets to off each connect, matching MOX/TUN/PsEnabled discipline.
     bool TxMonitorEnabled = false,
     bool PsAuto = true,             // continuous adapt by default once armed
     bool PsSingle = false,          // one-shot SetPSControl(1,1,0,0)

--- a/Zeus.Server.Hosting/PsSettingsStore.cs
+++ b/Zeus.Server.Hosting/PsSettingsStore.cs
@@ -25,18 +25,14 @@ using Zeus.Contracts;
 namespace Zeus.Server;
 
 // PureSignal settings persistence. Stores the operator's calibration tuning
-// (timing delays, ints/spi preset, ptol mode, auto-attenuate) plus the PS-A
-// master-arm bit so it all survives server restarts. Shares zeus-prefs.db
-// with DspSettingsStore.
+// (timing delays, ints/spi preset, ptol mode, auto-attenuate) so it survives
+// server restarts. Shares zeus-prefs.db with DspSettingsStore.
 //
-// PsEnabled (the PS-A master arm) IS persisted — matches Thetis, where the
-// PS-A button on the Console form is saved/restored by Common.SaveForm /
-// Console.GetStateList like every other CheckBoxTS. PsAuto / PsSingle (cal
-// mode) are persisted similarly. PsHwPeak is NOT persisted because
-// RadioService re-derives it per-radio at connect time. TwoToneEnabled
-// stays NOT persisted: in Thetis it's a transient ButtonTS toggle that
-// resets each session, and arming a test-tone generator on boot would be
-// a surprise.
+// Deliberately does NOT persist `PsEnabled` (the master arm) or `PsAuto` /
+// `PsSingle` (cal mode) — these reset to safe defaults each session. Same
+// pattern as MOX / TUN: arming PS is an operator action, never an automatic
+// "resume what we did last time" behaviour. PsHwPeak isn't persisted either
+// because RadioService re-derives it per-radio at connect time.
 public sealed class PsSettingsStore : IDisposable
 {
     private readonly LiteDatabase _db;
@@ -93,11 +89,6 @@ public sealed class PsSettingsEntry
 {
     public int Id { get; set; }
     public string ProfileId { get; set; } = string.Empty;
-    // PS-A master arm. Persisted to match Thetis (chkFWCATUBypass on the
-    // Console form survives application close/reopen via SaveForm). Defaults
-    // to false on a fresh install so the operator opts in once, not every
-    // session.
-    public bool Enabled { get; set; }
     // Cal-mode default — Auto = continuous adapt. Persisted because operators
     // who prefer single-shot calibration (and run TwoTone manually) want that
     // selection to stick across sessions.
@@ -114,9 +105,9 @@ public sealed class PsSettingsEntry
     public PsFeedbackSource Source { get; set; } = PsFeedbackSource.Internal;
     // Two-tone test generator settings. Persisted so an operator who has
     // dialled in custom IMD test tones (e.g. for a specific filter response
-    // or PA test) doesn't have to re-enter them every session. The
-    // TwoToneEnabled run-flag is NOT persisted — booting Zeus and finding
-    // the radio already injecting a two-tone test signal would be hostile.
+    // or PA test) doesn't have to re-enter them every session. PsEnabled and
+    // TwoToneEnabled are intentionally NOT persisted — same operator-action
+    // discipline as MOX/TUN — but the dialled-in freqs/mag are.
     // Defaults match tx-store.ts (700/1900/0.49) and pihpsdr.
     public double TwoToneFreq1 { get; set; } = 700.0;
     public double TwoToneFreq2 { get; set; } = 1900.0;

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -190,10 +190,10 @@ public sealed class RadioService : IDisposable
                 _lastPresetPerMode[m] = filterPresetStore.GetLastSelectedPreset(m);
         }
 
-        // Load persisted PS settings — operator's calibration tuning plus
-        // the PS-A master-arm bit (Thetis-faithful: chkFWCATUBypass survives
-        // app close/reopen via Common.SaveForm). PsHwPeak is left at the P1
-        // default; ConnectAsync / ConnectP2Async overrides per-radio.
+        // Load persisted PS settings — operator's calibration tuning. Master
+        // arm and cal-mode are deliberately NOT persisted (parity with MOX);
+        // only the timing/preset/auto-att tuning is. PsHwPeak is left at the
+        // P1 default; ConnectAsync / ConnectP2Async overrides per-radio.
         var ps = _psStore?.Get();
 
         _state = new(
@@ -215,13 +215,7 @@ public sealed class RadioService : IDisposable
             FilterPresetName: "VAR1",
             FilterAdvancedPaneOpen: filterPresetStore?.GetAdvancedPaneOpen() ?? false,
             // PS persisted fields (or DTO defaults when not persisted yet).
-            // PsEnabled IS persisted — Thetis-faithful sticky PS-A arm.
-            // DspPipelineService gates engine.SetPsEnabled on engine!=null,
-            // so a true value here is harmless until the operator connects;
-            // ConnectP2Async then sets _psResyncRequired so the next
-            // OnRadioStateChanged pushes the arm bit into the freshly-opened
-            // engine.
-            PsEnabled: ps?.Enabled ?? false,
+            // PsEnabled NOT persisted — always starts off each session.
             PsAuto: ps?.Auto ?? true,
             PsPtol: ps?.Ptol ?? false,
             PsAutoAttenuate: ps?.AutoAttenuate ?? true,
@@ -244,9 +238,9 @@ public sealed class RadioService : IDisposable
     /// callers don't drop fields by writing only what they touched. Called
     /// from SetPs, SetPsAdvanced, SetPsFeedbackSource, and SetTwoTone.
     ///
-    /// TwoToneEnabled (transient run-flag) and PsHwPeak (per-radio derived)
-    /// are intentionally NOT in the entry. PsEnabled IS persisted — see
-    /// PsSettingsStore header for the Thetis parity rationale.
+    /// PsEnabled / TwoToneEnabled (master arm flags) and PsHwPeak (per-radio
+    /// derived) are intentionally NOT in the entry — same operator-action
+    /// discipline as MOX/TUN.
     /// </summary>
     private void PersistPsState()
     {
@@ -254,7 +248,6 @@ public sealed class RadioService : IDisposable
         var snap = Snapshot();
         _psStore.Upsert(new PsSettingsEntry
         {
-            Enabled = snap.PsEnabled,
             Auto = snap.PsAuto,
             Ptol = snap.PsPtol,
             AutoAttenuate = snap.PsAutoAttenuate,
@@ -1079,8 +1072,9 @@ public sealed class RadioService : IDisposable
             PsAuto = req.Auto,
             PsSingle = req.Single,
         });
-        // Persist arm + cal-mode so the PS-A button is sticky across server
-        // restarts (Thetis parity).
+        // Persist Auto/Single change so the operator's cal-mode preference
+        // sticks across restarts. (PsEnabled is the master arm — not
+        // persisted; same discipline as MOX/TUN.)
         PersistPsState();
         return Snapshot();
     }
@@ -1123,7 +1117,7 @@ public sealed class RadioService : IDisposable
     /// from the PS-feedback analyzer instead of the post-CFIR TX analyzer
     /// so the operator sees the actual on-air RF rather than the
     /// predistorted baseband. Operator viewing preference — NOT persisted
-    /// across sessions (same discipline as MOX / TUN).
+    /// across sessions (same discipline as PsEnabled / MOX).
     /// </summary>
     public StateDto SetPsMonitor(PsMonitorSetRequest req)
     {
@@ -1137,8 +1131,7 @@ public sealed class RadioService : IDisposable
     /// next DspPipelineService.UpdateState tick latches the value into
     /// engine.SetTxMonitorEnabled. Mirrors PsMonitor's lifecycle — operator
     /// preference, not persisted across sessions; resets to off on each new
-    /// connect so the radio doesn't come up auditioning unintentionally
-    /// (same discipline as MOX / TUN).</summary>
+    /// connect so the radio doesn't come up auditioning unintentionally.</summary>
     public StateDto SetTxMonitor(TxMonitorSetRequest req)
     {
         ArgumentNullException.ThrowIfNull(req);

--- a/tests/Zeus.Server.Tests/PsPersistenceTests.cs
+++ b/tests/Zeus.Server.Tests/PsPersistenceTests.cs
@@ -30,9 +30,8 @@ namespace Zeus.Server.Tests;
 /// PureSignal settings persistence — guards the round-3 fix where SetPs and
 /// SetTwoTone silently failed to call _psStore.Upsert. After the fix, every
 /// Set* path that mutates a persisted PS field must drop a doc into the
-/// LiteDB-backed store. PsEnabled (PS-A) IS persisted (Thetis parity);
-/// TwoToneEnabled is NOT — it's a transient run-flag and arming a test
-/// generator on boot would be hostile.
+/// LiteDB-backed store. Master-arm flags (PsEnabled, TwoToneEnabled) are
+/// intentionally NOT persisted — same operator-action discipline as MOX/TUN.
 /// </summary>
 public class PsPersistenceTests : IDisposable
 {
@@ -72,18 +71,6 @@ public class PsPersistenceTests : IDisposable
         var entry = store.Get();
         Assert.NotNull(entry);
         Assert.False(entry!.Auto);
-    }
-
-    [Fact]
-    public void SetPs_PersistsEnabledFlag()
-    {
-        var (radio, store) = BuildRadioWithStore();
-
-        radio.SetPs(new PsControlSetRequest(Enabled: true, Auto: true, Single: false));
-
-        var entry = store.Get();
-        Assert.NotNull(entry);
-        Assert.True(entry!.Enabled);
     }
 
     [Fact]
@@ -180,21 +167,8 @@ public class PsPersistenceTests : IDisposable
         Assert.Equal(0.35, snap.PsMoxDelaySec);
         Assert.Equal("16/512", snap.PsIntsSpiPreset);
         Assert.Equal(PsFeedbackSource.External, snap.PsFeedbackSource);
-        // TwoToneEnabled is a transient run-flag — stays false on every fresh
-        // session even if it had been on previously.
+        // Master-arm flag should NOT survive — TwoToneEnabled stays false on
+        // every fresh session even if Enabled=true had been set previously.
         Assert.False(snap.TwoToneEnabled);
-    }
-
-    [Fact]
-    public void NewRadioService_RehydratesPsEnabled()
-    {
-        // PS-A (the master arm) must be sticky across server restarts —
-        // matches Thetis chkFWCATUBypass behaviour. If the operator armed PS
-        // last session, a fresh RadioService should snapshot PsEnabled=true.
-        var (radio1, _) = BuildRadioWithStore();
-        radio1.SetPs(new PsControlSetRequest(Enabled: true, Auto: true, Single: false));
-
-        var (radio2, _) = BuildRadioWithStore();
-        Assert.True(radio2.Snapshot().PsEnabled);
     }
 }


### PR DESCRIPTION
## Summary

Reverts `302cd0e feat(ps): persist PS-A master arm to LiteDB across restarts`. That change was merged into `release/0.5.0` via #222 and silently broke HL2 forward/reverse power readings.

## Why

When `PsEnabled` was persisted, every reconnect re-armed PS from disk. With PS armed, `ControlFrame.cs` writes `puresignal_run` (bit 22 of HL2 register 0x0a) on every Attenuator frame, regardless of MOX. The HL2 firmware appears to squelch the alex bridge ADC fields whenever that bit is high — so `lastFwdAin1=0` and `lastRefAin0=0` came back from the radio while PA temperature on the same C&C slot read normally.

Diag evidence captured today (PS-armed vs PS-disarmed on the same hardware, same TUN):

```
PS armed:   lastFwdAin1=0   lastRefAin0=0   fwdW=0.00
PS disarmed: lastFwdAin1=235,125,249,290…   fwdW=0.04 (reading)
```

The original `RadioService.cs` policy comment was correct — PS-A is operator-action discipline, same as MOX/TUN, and should not survive across restarts.

## Test plan

- [x] `dotnet build Zeus.slnx` clean (0 warnings)
- [x] `dotnet test Zeus.slnx` — 732 passed, 0 failed across 6 assemblies
- [x] Bench-tested on HL2: PWR meter reads with revert applied; reverts to 0W when PS is manually re-armed
- [ ] Maintainer to confirm: PureSignal still arms manually after the revert (not auto-restored) and converges normally