### PR TITLE
fix(layout): stretch hero panel to fill grid row when filter ribbon is open

### DIFF
--- a/zeus-web/src/styles/filter-ribbon.css
+++ b/zeus-web/src/styles/filter-ribbon.css
@@ -16,7 +16,7 @@
   grid-template-rows: auto 1fr 200px;
 }
 .workspace.has-filter-ribbon .filter-ribbon { grid-column: 1; grid-row: 1; }
-.workspace.has-filter-ribbon .hero         { grid-row: 2; }
+.workspace.has-filter-ribbon .hero         { grid-row: 2; align-self: stretch; }
 .workspace.has-filter-ribbon .bottom-row   { grid-row: 3; }
 .workspace.has-filter-ribbon .side-stack   { grid-row: 1 / span 3; }
 


### PR DESCRIPTION
## Summary
- One-line CSS fix for #230: panadapter no longer sticks to the bottom in the default layout when the filter ribbon is enabled.
- Adds `align-self: stretch` to `.workspace.has-filter-ribbon .hero` so the hero (panadapter) cell fills the `1fr` middle grid row instead of collapsing to its content height.

## Why a fresh PR
Replaces #231, which was branched from `main` and so carried ~90 unrelated files even though its base was set to `release/0.5.0`. This PR is branched cleanly from `release/0.5.0` and contains only the intended one-line change.

## Test plan
- [ ] On `release/0.5.0` with the filter ribbon enabled in the default layout, panadapter expands to fill the row and aligns to the bottom.
- [ ] No visual regression with the filter ribbon disabled.