### PR TITLE
fix(display): independent waterfall dB-scale ranges for RX and TX

### DIFF
--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -47,6 +47,7 @@ import { COLORMAPS, type ColormapId } from '../gl/colormap';
 import { createWfRenderer } from '../gl/waterfall';
 import { useDisplayStore } from '../state/display-store';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
+import { useTxStore } from '../state/tx-store';
 import { usePanTuneGesture } from '../util/use-pan-tune-gesture';
 import { WfDbScale } from './WfDbScale';
 
@@ -95,8 +96,14 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
 
     const redraw = () => {
       rafHandle = 0;
-      const { wfDbMin, wfDbMax } = useDisplaySettingsStore.getState();
-      renderer.draw(wfDbMin, wfDbMax);
+      const { wfDbMin, wfDbMax, wfTxDbMin, wfTxDbMax } = useDisplaySettingsStore.getState();
+      const { moxOn, tunOn } = useTxStore.getState();
+      const keyed = moxOn || tunOn;
+      // Mirror DbScale.tsx — keyed (MOX/TUN) renders the TX waterfall
+      // window so the operator's RX noise-floor view stays put.
+      const dbMin = keyed ? wfTxDbMin : wfDbMin;
+      const dbMax = keyed ? wfTxDbMax : wfDbMax;
+      renderer.draw(dbMin, dbMax);
     };
     const requestRedraw = () => {
       if (rafHandle === 0) rafHandle = requestAnimationFrame(redraw);
@@ -143,9 +150,16 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       requestRedraw();
     });
 
+    // Repaint when MOX/TUN flips so the RX↔TX waterfall window swap lands
+    // immediately instead of waiting for the next server frame or scale drag.
+    const unsubTx = useTxStore.subscribe(() => {
+      requestRedraw();
+    });
+
     return () => {
       unsub();
       unsubSettings();
+      unsubTx();
       ro.disconnect();
       if (rafHandle !== 0) cancelAnimationFrame(rafHandle);
       renderer.dispose();

--- a/zeus-web/src/components/WfDbScale.tsx
+++ b/zeus-web/src/components/WfDbScale.tsx
@@ -6,16 +6,33 @@
 
 import { useCallback, useRef } from 'react';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
+import { useTxStore } from '../state/tx-store';
 
 const TICK_STRIDE_DB = 10;
 
 // Draggable dB scale on the waterfall, mirroring DbScale's look and feel
 // but bound to the waterfall's independent dB window so panadapter and
-// waterfall noise floors can be set separately.
+// waterfall noise floors can be set separately. Mirrors DbScale's RX/TX
+// swap so the operator can drag the waterfall scale during MOX/TUN without
+// disturbing their RX waterfall view.
 export function WfDbScale() {
-  const dbMin = useDisplaySettingsStore((s) => s.wfDbMin);
-  const dbMax = useDisplaySettingsStore((s) => s.wfDbMax);
-  const shift = useDisplaySettingsStore((s) => s.shiftWfDbRange);
+  const rxDbMin = useDisplaySettingsStore((s) => s.wfDbMin);
+  const rxDbMax = useDisplaySettingsStore((s) => s.wfDbMax);
+  const txDbMin = useDisplaySettingsStore((s) => s.wfTxDbMin);
+  const txDbMax = useDisplaySettingsStore((s) => s.wfTxDbMax);
+  const shiftRx = useDisplaySettingsStore((s) => s.shiftWfDbRange);
+  const shiftTx = useDisplaySettingsStore((s) => s.shiftWfTxDbRange);
+  const moxOn = useTxStore((s) => s.moxOn);
+  const tunOn = useTxStore((s) => s.tunOn);
+  const keyed = moxOn || tunOn;
+
+  // Pick the active range + shifter based on whether we're keyed. Mirrors
+  // DbScale.tsx — each side has its own waterfall Grid Min/Max so the
+  // operator can hide the silence-time TX floor without moving the RX
+  // noise-floor view.
+  const dbMin = keyed ? txDbMin : rxDbMin;
+  const dbMax = keyed ? txDbMax : rxDbMax;
+  const shift = keyed ? shiftTx : shiftRx;
 
   const dragState = useRef<{
     startY: number;

--- a/zeus-web/src/state/display-settings-store.ts
+++ b/zeus-web/src/state/display-settings-store.ts
@@ -71,6 +71,7 @@ export const TX_FIXED_DB_MAX = 20;
 const STORAGE_KEY = 'zeus.display.dbRange';
 const TX_STORAGE_KEY = 'zeus.display.txDbRange';
 const WF_STORAGE_KEY = 'zeus.display.wfDbRange';
+const WF_TX_STORAGE_KEY = 'zeus.display.wfTxDbRange';
 const RX_TRACE_COLOR_KEY = 'zeus.display.rxTraceColor';
 
 // Legacy localStorage keys — pre-server-side storage. Read once on first
@@ -193,6 +194,32 @@ function writeSavedWfRange(wfDbMin: number, wfDbMax: number): void {
   }
 }
 
+function readSavedWfTxRange(): { wfTxDbMin: number; wfTxDbMax: number } {
+  try {
+    if (typeof localStorage === 'undefined') return { wfTxDbMin: TX_FIXED_DB_MIN, wfTxDbMax: TX_FIXED_DB_MAX };
+    const raw = localStorage.getItem(WF_TX_STORAGE_KEY);
+    if (!raw) return { wfTxDbMin: TX_FIXED_DB_MIN, wfTxDbMax: TX_FIXED_DB_MAX };
+    const parsed = JSON.parse(raw);
+    const wfTxDbMin = typeof parsed?.wfTxDbMin === 'number' ? parsed.wfTxDbMin : TX_FIXED_DB_MIN;
+    const wfTxDbMax = typeof parsed?.wfTxDbMax === 'number' ? parsed.wfTxDbMax : TX_FIXED_DB_MAX;
+    if (!(wfTxDbMin < wfTxDbMax) || !Number.isFinite(wfTxDbMin) || !Number.isFinite(wfTxDbMax)) {
+      return { wfTxDbMin: TX_FIXED_DB_MIN, wfTxDbMax: TX_FIXED_DB_MAX };
+    }
+    return { wfTxDbMin, wfTxDbMax };
+  } catch {
+    return { wfTxDbMin: TX_FIXED_DB_MIN, wfTxDbMax: TX_FIXED_DB_MAX };
+  }
+}
+
+function writeSavedWfTxRange(wfTxDbMin: number, wfTxDbMax: number): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(WF_TX_STORAGE_KEY, JSON.stringify({ wfTxDbMin, wfTxDbMax }));
+  } catch {
+    // quota exceeded / private mode — accept silently.
+  }
+}
+
 // Exponential smoothing constant for the auto-range tracker. 0.1 trades
 // flicker resistance for responsiveness — band-change artifacts fade over
 // ~30 frames at 30 Hz (~1 s).
@@ -218,6 +245,11 @@ export type DisplaySettingsState = {
   // the panadapter's noise-floor view. Driven by its own DbScale slider.
   wfDbMin: number;
   wfDbMax: number;
+  // Separate dB range for TX waterfall (rendered during MOX/TUN). Mirrors
+  // the TX panadapter pair so the operator can darken/brighten the keyed
+  // waterfall window independently of their RX waterfall view.
+  wfTxDbMin: number;
+  wfTxDbMax: number;
   // Separate dB range for TX panadapter (rendered during MOX/TUN). Thetis
   // parity — see TX_FIXED_DB_MIN/MAX constants.
   txDbMin: number;
@@ -252,6 +284,8 @@ export type DisplaySettingsState = {
   shiftTxDbRange: (deltaDb: number) => void;
   // Same as shiftDbRange but for the waterfall's independent range.
   shiftWfDbRange: (deltaDb: number) => void;
+  // Same as shiftWfDbRange but for the TX-specific waterfall range.
+  shiftWfTxDbRange: (deltaDb: number) => void;
 };
 
 const DB_ABS_LIMIT = 200;
@@ -259,6 +293,7 @@ const DB_ABS_LIMIT = 200;
 const initialRange = readSavedRange();
 const initialTxRange = readSavedTxRange();
 const initialWfRange = readSavedWfRange();
+const initialWfTxRange = readSavedWfTxRange();
 
 export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) => ({
   autoRange: false,
@@ -266,6 +301,8 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
   dbMax: initialRange.dbMax,
   wfDbMin: initialWfRange.wfDbMin,
   wfDbMax: initialWfRange.wfDbMax,
+  wfTxDbMin: initialWfTxRange.wfTxDbMin,
+  wfTxDbMax: initialWfTxRange.wfTxDbMax,
   txDbMin: initialTxRange.txDbMin,
   txDbMax: initialTxRange.txDbMax,
   colormap: 'blue',
@@ -372,6 +409,13 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
     const nextMax = Math.max(-DB_ABS_LIMIT, Math.min(DB_ABS_LIMIT, wfDbMax + deltaDb));
     set({ wfDbMin: nextMin, wfDbMax: nextMax });
     writeSavedWfRange(nextMin, nextMax);
+  },
+  shiftWfTxDbRange: (deltaDb) => {
+    const { wfTxDbMin, wfTxDbMax } = get();
+    const nextMin = Math.max(-DB_ABS_LIMIT, Math.min(DB_ABS_LIMIT, wfTxDbMin + deltaDb));
+    const nextMax = Math.max(-DB_ABS_LIMIT, Math.min(DB_ABS_LIMIT, wfTxDbMax + deltaDb));
+    set({ wfTxDbMin: nextMin, wfTxDbMax: nextMax });
+    writeSavedWfTxRange(nextMin, nextMax);
   },
   updateAutoRange: (wfDb) => {
     if (!get().autoRange || wfDb.length === 0) return;


### PR DESCRIPTION
Closes #246

## Summary

The panadapter dB-scale slider already keeps independent ranges for RX and TX (`DbScale.tsx:58-74` watches `useTxStore` for `keyed = moxOn || tunOn` and swaps between `dbMin`/`txDbMin` plus the matching shifters). The waterfall slider did not — `WfDbScale.tsx` exposed a single `wfDbMin`/`wfDbMax` pair shared across RX and TX, so dragging the waterfall scale while keyed silently overwrote the operator's RX waterfall view.

This PR mirrors the panadapter's pattern on the waterfall.

## Why this matters operationally

The RX waterfall scale is typically set with the floor pulled up so weak signals read clearly above the noise. Reusing that same scale on TX paints the waterfall with what looks like splatter — even when adaptive predistortion (PureSignal) is engaged and the transmission is genuinely clean. The "splatter" is a scaling artifact: TX signal levels sit tens of dB above receiver-noise levels, and the colour map maps that energy into the same visible window the operator tuned for weak-signal RX, so legitimately low IMD products and shoulder energy paint as bright pixels and look like a dirty signal. Independent RX and TX waterfall ranges let the operator set a TX floor appropriate to the actual TX signal level — so a PS-corrected transmission renders as a clean trace on the waterfall instead of a wash of false-splatter colour, while the RX floor stays where weak-signal copy needs it.

## Changes

- **`zeus-web/src/state/display-settings-store.ts`** — adds `wfTxDbMin` / `wfTxDbMax` state, `shiftWfTxDbRange` action, `WF_TX_STORAGE_KEY = 'zeus.display.wfTxDbRange'`, and `readSavedWfTxRange` / `writeSavedWfTxRange` helpers. Defaults to `TX_FIXED_DB_MIN` / `TX_FIXED_DB_MAX` (-80 / +20 dBFS) so the visual transition between the panadapter and waterfall TX windows feels coherent on first key.
- **`zeus-web/src/components/WfDbScale.tsx`** — reads both RX and TX waterfall pairs, watches `useTxStore`, picks the active triple (`dbMin`, `dbMax`, `shift`) based on `keyed`. Drag math, ticks, and DOM unchanged.
- **`zeus-web/src/components/Waterfall.tsx`** — `redraw()` consults both range pairs and tx-store, passes the right pair to `renderer.draw(...)`. Adds a `useTxStore.subscribe(requestRedraw)` so the canvas snaps the moment MOX/TUN flips instead of waiting for the next server frame; cleanup is wired.

Diff is purely additive — 81 insertions, 6 deletions, no removed behaviour.

## Test plan

- [x] `npm --prefix zeus-web run typecheck` — clean
- [x] `npm --prefix zeus-web run build` — clean (only the pre-existing PWA bundle-size + workbox-window dynamic-import warnings, unrelated)
- [x] Sanity grep — `wfDbMin|wfDbMax|wfTxDbMin|wfTxDbMax` references confined to the three modified files; no other consumer needs updating
- [x] Bench-tested locally on KB2UKA's HL2:
  - Drag the waterfall scale on RX → only the RX window moves and persists
  - Key MOX/TUN → waterfall snaps to the TX window (defaults to -80/+20 on first key)
  - Drag while keyed → only the TX window moves and persists
  - Unkey → RX window restores untouched
  - Reload → both saved ranges come back
- [ ] Pending PS rack-test: with PureSignal armed and converged, confirm a clean TX renders as a clean waterfall trace once the TX floor is set appropriately for the TX signal level (no false-splatter wash).

## Red-light check

Per `CLAUDE.md` boundaries this is green-light: behaviour-parity fix between two components that should already match, no new defaults an operator will feel on first connect, no `Zeus.Contracts` / wire-format touch, no new dependencies. Visual design untouched (drag affordance, tick rendering, colours, layout all unchanged).