### PR TITLE
fix(display): prevent RX/TX panadapter dB-scale drift during drag

### DIFF
--- a/zeus-web/src/components/DbScale.tsx
+++ b/zeus-web/src/components/DbScale.tsx
@@ -79,6 +79,7 @@ export function DbScale() {
     startDbMax: number;
     pointerId: number;
     containerHeight: number;
+    lastShiftApplied: number;
   } | null>(null);
 
   const onPointerDown = useCallback(
@@ -90,6 +91,7 @@ export function DbScale() {
         startDbMax: dbMax,
         pointerId: e.pointerId,
         containerHeight: rect.height,
+        lastShiftApplied: 0,
       };
       e.currentTarget.setPointerCapture(e.pointerId);
     },
@@ -106,11 +108,19 @@ export function DbScale() {
       // then sits lower in the visible range). Adding deltaDb achieves this.
       const dbPerPixel = (d.startDbMax - d.startDbMin) / d.containerHeight;
       const deltaDb = dySig * dbPerPixel;
-      const nextMin = d.startDbMin + deltaDb;
-      const targetShift = nextMin - dbMin;
-      if (Math.abs(targetShift) > 0.5) shift(targetShift);
+      // Apply the *incremental* shift since the last call, not the total
+      // shift since drag-start. The total-shift path read `dbMin` from the
+      // closure to compute "how much further to move", but the closure can
+      // be stale if a re-render hasn't committed yet — leading to
+      // accumulated drift that, after a MOX/RX swap, presents as the two
+      // panadapter ranges no longer being independent (issue #234).
+      const incrementalShift = deltaDb - d.lastShiftApplied;
+      if (Math.abs(incrementalShift) > 0.5) {
+        shift(incrementalShift);
+        d.lastShiftApplied = deltaDb;
+      }
     },
-    [dbMin, shift],
+    [shift],
   );
 
   const onPointerUp = useCallback(

--- a/zeus-web/src/components/WfDbScale.tsx
+++ b/zeus-web/src/components/WfDbScale.tsx
@@ -23,6 +23,7 @@ export function WfDbScale() {
     startDbMax: number;
     pointerId: number;
     containerHeight: number;
+    lastShiftApplied: number;
   } | null>(null);
 
   const onPointerDown = useCallback(
@@ -34,6 +35,7 @@ export function WfDbScale() {
         startDbMax: dbMax,
         pointerId: e.pointerId,
         containerHeight: rect.height,
+        lastShiftApplied: 0,
       };
       e.currentTarget.setPointerCapture(e.pointerId);
     },
@@ -47,11 +49,15 @@ export function WfDbScale() {
       const dySig = e.clientY - d.startY;
       const dbPerPixel = (d.startDbMax - d.startDbMin) / d.containerHeight;
       const deltaDb = dySig * dbPerPixel;
-      const nextMin = d.startDbMin + deltaDb;
-      const targetShift = nextMin - dbMin;
-      if (Math.abs(targetShift) > 0.5) shift(targetShift);
+      // Incremental, not total — see DbScale for the rationale; same
+      // stale-closure drift bug (issue #234) lived here too.
+      const incrementalShift = deltaDb - d.lastShiftApplied;
+      if (Math.abs(incrementalShift) > 0.5) {
+        shift(incrementalShift);
+        d.lastShiftApplied = deltaDb;
+      }
     },
-    [dbMin, shift],
+    [shift],
   );
 
   const onPointerUp = useCallback(


### PR DESCRIPTION
Fixes #234.

## Root cause

`DbScale.onPointerMove` computed the desired total shift from drag-start using `nextMin - dbMin`, where `dbMin` came from the render closure. While a continuous drag is in flight, each emitted `shift(...)` updates the store and triggers a re-render that recreates the move callback. Until that re-render commits, subsequent move events keep running with the stale closure — so the same delta is applied again, and the range slides further than the finger moved.

The two ranges (`dbMin/dbMax` for RX, `txDbMin/txDbMax` for TX) were already independent in `display-settings-store.ts`. What the user sees is each range drifting on its own; after a MOX → drag → un-MOX sequence, the RX scale is no longer where it was left, which reads as "the TX drag affected RX".

## Fix

Track `lastShiftApplied` inside the drag-state ref and emit only the incremental delta since the previous call. The handler no longer needs `dbMin` from the closure, so it is removed from the dependency array.

`WfDbScale` had the same shape and gets the same fix.

## Test plan

- [x] `cd zeus-web && npm test` — 192/192 pass
- [x] `dotnet build Zeus.slnx` — clean
- [ ] Manual: with the dev server running, set RX and TX dB scales to different values, drag each, switch in/out of MOX, confirm each scale stays where it was last set when the other is being dragged.

## Notes

- Same fix as PR #238 (against `main`), reapplied here against `develop` so it can land on the active development branch.
- Supersedes PR #238 once merged.