### PR TITLE
feat(layout): icon + description settings panel for named layouts

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -359,11 +359,28 @@ public sealed record UiLayoutSetRequest(string LayoutJson);
 // Multi-layout shape (issue #241). Layouts are keyed per radio (board kind /
 // "default" while disconnected). Each radio holds a list of named layouts and
 // remembers which one was active.
-public sealed record NamedLayoutDto(string Id, string Name, string LayoutJson, long UpdatedUtc);
+//
+// `Icon` is a short string (typically a single emoji) shown above the layout
+// label in the LeftLayoutBar; `Description` is a longer free-form string used
+// as the hover tooltip. Both are optional — older layouts without these
+// fields render with a letter fallback and the layout name as tooltip.
+public sealed record NamedLayoutDto(
+    string Id,
+    string Name,
+    string LayoutJson,
+    long UpdatedUtc,
+    string? Icon = null,
+    string? Description = null);
 
 public sealed record RadioLayoutsDto(string RadioKey, IReadOnlyList<NamedLayoutDto> Layouts, string ActiveLayoutId);
 
-public sealed record SaveNamedLayoutRequest(string RadioKey, string LayoutId, string Name, string LayoutJson);
+public sealed record SaveNamedLayoutRequest(
+    string RadioKey,
+    string LayoutId,
+    string Name,
+    string LayoutJson,
+    string? Icon = null,
+    string? Description = null);
 
 public sealed record SetActiveLayoutRequest(string RadioKey, string LayoutId);
 

--- a/Zeus.Server.Hosting/LayoutStore.cs
+++ b/Zeus.Server.Hosting/LayoutStore.cs
@@ -177,12 +177,22 @@ public sealed class LayoutStore : IDisposable
     /// <summary>
     /// Upsert one named layout. Creates the radio's row on first call.
     /// If there is no active layout yet, the new layout becomes active.
+    /// `icon` and `description` are optional; null means "leave as-is on
+    /// existing rows / empty on insert".
     /// </summary>
-    public RadioLayoutsDto UpsertNamed(string radioKey, string layoutId, string name, string layoutJson)
+    public RadioLayoutsDto UpsertNamed(
+        string radioKey,
+        string layoutId,
+        string name,
+        string layoutJson,
+        string? icon = null,
+        string? description = null)
     {
         radioKey = NormalizeRadioKey(radioKey);
         layoutId = NormalizeLayoutId(layoutId);
         if (string.IsNullOrWhiteSpace(name)) name = layoutId;
+        var normalisedIcon = NormalizeIcon(icon);
+        var normalisedDescription = NormalizeDescription(description);
 
         lock (_lock)
         {
@@ -202,6 +212,8 @@ public sealed class LayoutStore : IDisposable
                     Name = name,
                     LayoutJson = layoutJson,
                     UpdatedUtc = DateTime.UtcNow,
+                    Icon = normalisedIcon ?? string.Empty,
+                    Description = normalisedDescription ?? string.Empty,
                 });
             }
             else
@@ -209,6 +221,8 @@ public sealed class LayoutStore : IDisposable
                 existing.Name = name;
                 existing.LayoutJson = layoutJson;
                 existing.UpdatedUtc = DateTime.UtcNow;
+                if (icon is not null) existing.Icon = normalisedIcon ?? string.Empty;
+                if (description is not null) existing.Description = normalisedDescription ?? string.Empty;
             }
 
             if (string.IsNullOrEmpty(entry.ActiveLayoutId))
@@ -271,7 +285,9 @@ public sealed class LayoutStore : IDisposable
                 l.LayoutId,
                 l.Name,
                 l.LayoutJson,
-                new DateTimeOffset(l.UpdatedUtc).ToUnixTimeMilliseconds()))
+                new DateTimeOffset(l.UpdatedUtc).ToUnixTimeMilliseconds(),
+                string.IsNullOrEmpty(l.Icon) ? null : l.Icon,
+                string.IsNullOrEmpty(l.Description) ? null : l.Description))
             .ToList(),
         e.ActiveLayoutId);
 
@@ -295,6 +311,26 @@ public sealed class LayoutStore : IDisposable
         var safe = new string(trimmed.Where(c =>
             char.IsLetterOrDigit(c) || c == '-' || c == '_').ToArray());
         return string.IsNullOrEmpty(safe) ? "default" : safe;
+    }
+
+    // Icons are typically a single emoji. We don't restrict the codepoint set
+    // (emoji + variation selectors + ZWJ sequences would be hostile to enumerate)
+    // but we do cap the length so a misbehaving client can't park an essay in
+    // the icon field.
+    private static string? NormalizeIcon(string? raw)
+    {
+        if (raw is null) return null;
+        var trimmed = raw.Trim();
+        if (trimmed.Length == 0) return string.Empty;
+        return trimmed.Length > 16 ? trimmed[..16] : trimmed;
+    }
+
+    private static string? NormalizeDescription(string? raw)
+    {
+        if (raw is null) return null;
+        var trimmed = raw.Trim();
+        if (trimmed.Length == 0) return string.Empty;
+        return trimmed.Length > 256 ? trimmed[..256] : trimmed;
     }
 
     public void Dispose() => _db.Dispose();
@@ -330,4 +366,8 @@ public sealed class NamedLayoutEntry
     public string Name { get; set; } = string.Empty;
     public string LayoutJson { get; set; } = string.Empty;
     public DateTime UpdatedUtc { get; set; }
+    // Optional presentation fields (issue #241 follow-up). Older rows that
+    // predate these columns deserialise as empty strings under LiteDB.
+    public string Icon { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
 }

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -816,7 +816,13 @@ public static class ZeusEndpoints
                 if (named?.LayoutJson is { } njson && !string.IsNullOrWhiteSpace(njson)
                     && !string.IsNullOrWhiteSpace(named.LayoutId))
                 {
-                    store.UpsertNamed(named.RadioKey ?? "default", named.LayoutId, named.Name ?? named.LayoutId, njson);
+                    store.UpsertNamed(
+                        named.RadioKey ?? "default",
+                        named.LayoutId,
+                        named.Name ?? named.LayoutId,
+                        njson,
+                        named.Icon,
+                        named.Description);
                 }
                 else
                 {
@@ -842,7 +848,13 @@ public static class ZeusEndpoints
                 return Results.BadRequest(new { error = "layoutJson required" });
             if (string.IsNullOrWhiteSpace(req.LayoutId))
                 return Results.BadRequest(new { error = "layoutId required" });
-            return Results.Ok(store.UpsertNamed(req.RadioKey ?? "default", req.LayoutId, req.Name ?? req.LayoutId, req.LayoutJson));
+            return Results.Ok(store.UpsertNamed(
+                req.RadioKey ?? "default",
+                req.LayoutId,
+                req.Name ?? req.LayoutId,
+                req.LayoutJson,
+                req.Icon,
+                req.Description));
         });
 
         app.MapPost("/api/ui/layouts/active", (SetActiveLayoutRequest req, LayoutStore store) =>

--- a/zeus-web/src/components/LeftLayoutBar.tsx
+++ b/zeus-web/src/components/LeftLayoutBar.tsx
@@ -12,8 +12,9 @@
 //
 // Issue #241: visual chrome reuses tokens.css; no new colors are introduced.
 
-import { useState } from 'react';
+import { useMemo, useState, type CSSProperties } from 'react';
 import { useLayoutStore } from '../state/layout-store';
+import { useDisplaySettingsStore } from '../state/display-settings-store';
 import {
   LayoutSettingsModal,
   type LayoutSettingsValue,
@@ -33,6 +34,31 @@ export function LeftLayoutBar() {
   const updateLayoutMeta = useLayoutStore((s) => s.updateLayoutMeta);
   const resetActiveLayout = useLayoutStore((s) => s.resetActiveLayout);
   const isLoaded = useLayoutStore((s) => s.isLoaded);
+  // The bar's blue gradient + dot wash follows the operator's panadapter
+  // trace colour from the Display tab. CLAUDE.md flags trace amber as
+  // "panadapter-only", but the maintainer explicitly asked for the chrome
+  // to track the trace selection — so the bar tints to whatever hue the
+  // operator chose. Wash uses a 0.25× darkened variant so the original
+  // top-half-fades-out gradient style is preserved at any hue.
+  const rxTraceColor = useDisplaySettingsStore((s) => s.rxTraceColor);
+  const tintStyle = useMemo<CSSProperties | undefined>(() => {
+    const m = /^#([0-9A-Fa-f]{2})([0-9A-Fa-f]{2})([0-9A-Fa-f]{2})$/.exec(rxTraceColor);
+    if (!m || !m[1] || !m[2] || !m[3]) return undefined;
+    const r = parseInt(m[1], 16);
+    const g = parseInt(m[2], 16);
+    const b = parseInt(m[3], 16);
+    const dr = Math.round(r * 0.25);
+    const dg = Math.round(g * 0.25);
+    const db = Math.round(b * 0.25);
+    return {
+      ['--lb-tint-r' as string]: r,
+      ['--lb-tint-g' as string]: g,
+      ['--lb-tint-b' as string]: b,
+      ['--lb-wash-r' as string]: dr,
+      ['--lb-wash-g' as string]: dg,
+      ['--lb-wash-b' as string]: db,
+    };
+  }, [rxTraceColor]);
 
   const [modal, setModal] = useState<ModalState>({ kind: 'closed' });
 
@@ -73,7 +99,7 @@ export function LeftLayoutBar() {
     modal.kind === 'edit' ? layouts.find((l) => l.id === modal.id) : undefined;
 
   return (
-    <aside className="left-layout-bar" aria-label="Layouts">
+    <aside className="left-layout-bar" aria-label="Layouts" style={tintStyle}>
       <div className="lb-list" role="tablist" aria-orientation="vertical">
         {!isLoaded ? (
           <div className="lb-empty" aria-hidden>…</div>

--- a/zeus-web/src/components/LeftLayoutBar.tsx
+++ b/zeus-web/src/components/LeftLayoutBar.tsx
@@ -4,14 +4,25 @@
 // Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
 //
 // LeftLayoutBar — vertical bar listing the current radio's named layouts.
-// Click to switch active, "+" creates a new one (seeded from the default
-// workspace), "✕" deletes the focused layout, "⟳" resets the active layout
-// to its default tile arrangement.
+// Each item shows a large emoji icon with a small label beneath. Clicking
+// switches to that layout; the gear opens LayoutSettingsModal to edit the
+// label, icon, and tooltip description. The "+" button opens the same modal
+// in create mode; "✕" deletes the active layout; "⟳" resets it to the
+// default tile arrangement.
 //
 // Issue #241: visual chrome reuses tokens.css; no new colors are introduced.
 
 import { useState } from 'react';
 import { useLayoutStore } from '../state/layout-store';
+import {
+  LayoutSettingsModal,
+  type LayoutSettingsValue,
+} from '../layout/LayoutSettingsModal';
+
+type ModalState =
+  | { kind: 'closed' }
+  | { kind: 'create' }
+  | { kind: 'edit'; id: string };
 
 export function LeftLayoutBar() {
   const layouts = useLayoutStore((s) => s.layouts);
@@ -19,19 +30,13 @@ export function LeftLayoutBar() {
   const setActiveLayout = useLayoutStore((s) => s.setActiveLayout);
   const addLayout = useLayoutStore((s) => s.addLayout);
   const removeLayout = useLayoutStore((s) => s.removeLayout);
-  const renameLayout = useLayoutStore((s) => s.renameLayout);
+  const updateLayoutMeta = useLayoutStore((s) => s.updateLayoutMeta);
   const resetActiveLayout = useLayoutStore((s) => s.resetActiveLayout);
   const isLoaded = useLayoutStore((s) => s.isLoaded);
 
-  const [renamingId, setRenamingId] = useState<string | null>(null);
-  const [renameText, setRenameText] = useState('');
+  const [modal, setModal] = useState<ModalState>({ kind: 'closed' });
 
-  const handleAdd = () => {
-    const proposed = `Layout ${layouts.length + 1}`;
-    const name = window.prompt('Name for the new layout', proposed)?.trim();
-    if (!name) return;
-    addLayout(name);
-  };
+  const handleAdd = () => setModal({ kind: 'create' });
 
   const handleDelete = (id: string, name: string) => {
     if (layouts.length <= 1) return;
@@ -46,18 +51,26 @@ export function LeftLayoutBar() {
     resetActiveLayout();
   };
 
-  const startRename = (id: string, currentName: string) => {
-    setRenamingId(id);
-    setRenameText(currentName);
+  const openEdit = (id: string) => setModal({ kind: 'edit', id });
+
+  const handleModalSave = (value: LayoutSettingsValue) => {
+    if (modal.kind === 'create') {
+      addLayout(value.name, {
+        icon: value.icon || undefined,
+        description: value.description || undefined,
+      });
+    } else if (modal.kind === 'edit') {
+      updateLayoutMeta(modal.id, {
+        name: value.name,
+        icon: value.icon,
+        description: value.description,
+      });
+    }
+    setModal({ kind: 'closed' });
   };
 
-  const commitRename = () => {
-    if (!renamingId) return;
-    const name = renameText.trim();
-    if (name) renameLayout(renamingId, name);
-    setRenamingId(null);
-    setRenameText('');
-  };
+  const editingLayout =
+    modal.kind === 'edit' ? layouts.find((l) => l.id === modal.id) : undefined;
 
   return (
     <aside className="left-layout-bar" aria-label="Layouts">
@@ -67,38 +80,37 @@ export function LeftLayoutBar() {
         ) : (
           layouts.map((l) => {
             const active = l.id === activeLayoutId;
-            const renaming = renamingId === l.id;
+            const tooltip = l.description?.trim()
+              ? `${l.name} — ${l.description}`
+              : `${l.name} (gear to edit)`;
             return (
               <div key={l.id} className={`lb-item ${active ? 'active' : ''}`}>
-                {renaming ? (
-                  <input
-                    autoFocus
-                    className="lb-rename"
-                    value={renameText}
-                    onChange={(e) => setRenameText(e.target.value)}
-                    onBlur={commitRename}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') commitRename();
-                      else if (e.key === 'Escape') {
-                        setRenamingId(null);
-                        setRenameText('');
-                      }
-                    }}
-                  />
-                ) : (
-                  <button
-                    type="button"
-                    className="lb-tab"
-                    role="tab"
-                    aria-selected={active}
-                    onClick={() => setActiveLayout(l.id)}
-                    onDoubleClick={() => startRename(l.id, l.name)}
-                    title={`${l.name} (double-click to rename)`}
+                <button
+                  type="button"
+                  className="lb-tab"
+                  role="tab"
+                  aria-selected={active}
+                  onClick={() => setActiveLayout(l.id)}
+                  title={tooltip}
+                >
+                  <span
+                    className={`lb-tab-icon ${l.icon ? '' : 'lb-tab-icon-fallback'}`}
+                    aria-hidden
                   >
-                    <span className="lb-tab-name">{l.name}</span>
-                  </button>
-                )}
-                {active && layouts.length > 1 && !renaming && (
+                    {l.icon || initialLetter(l.name)}
+                  </span>
+                  <span className="lb-tab-name">{l.name}</span>
+                </button>
+                <button
+                  type="button"
+                  className="lb-gear"
+                  onClick={() => openEdit(l.id)}
+                  title={`Edit ${l.name}`}
+                  aria-label={`Edit ${l.name}`}
+                >
+                  ⚙
+                </button>
+                {active && layouts.length > 1 && (
                   <button
                     type="button"
                     className="lb-x"
@@ -136,6 +148,36 @@ export function LeftLayoutBar() {
           ⟳
         </button>
       </div>
+
+      {modal.kind === 'create' && (
+        <LayoutSettingsModal
+          title="New layout"
+          initial={{
+            name: `Layout ${layouts.length + 1}`,
+            icon: '',
+            description: '',
+          }}
+          onSave={handleModalSave}
+          onClose={() => setModal({ kind: 'closed' })}
+        />
+      )}
+      {modal.kind === 'edit' && editingLayout && (
+        <LayoutSettingsModal
+          title="Layout settings"
+          initial={{
+            name: editingLayout.name,
+            icon: editingLayout.icon ?? '',
+            description: editingLayout.description ?? '',
+          }}
+          onSave={handleModalSave}
+          onClose={() => setModal({ kind: 'closed' })}
+        />
+      )}
     </aside>
   );
+}
+
+function initialLetter(name: string): string {
+  const ch = name.trim().charAt(0);
+  return ch ? ch.toUpperCase() : '·';
 }

--- a/zeus-web/src/layout/LayoutSettingsModal.tsx
+++ b/zeus-web/src/layout/LayoutSettingsModal.tsx
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// LayoutSettingsModal — edit the presentation metadata of a NamedLayout.
+// Replaces the double-click-to-rename interaction in the LeftLayoutBar with
+// a small modal that captures: short label (what shows under the icon), the
+// icon itself (an emoji selected from a quick palette or freely typed), and
+// a longer description used as the hover tooltip.
+//
+// The same modal is reused for "create new layout" — when no layout id is
+// supplied the parent treats Save as addLayout(name, {icon, description}).
+
+import { useEffect, useRef, useState } from 'react';
+
+const ICON_PALETTE = [
+  '📡', '🎙', '📻', '🎧', '🛰', '📶',
+  '⚡', '🌐', '🌍', '🌅', '🌙', '☀️',
+  '⭐', '🏠', '🚗', '🏕', '⛰', '🌊',
+  '🎯', '📊', '📈', '🔧', '🔬', '🎛',
+  '🔵', '🟢', '🟡', '🟠', '🔴', '🟣',
+];
+
+export interface LayoutSettingsValue {
+  name: string;
+  icon: string;
+  description: string;
+}
+
+interface LayoutSettingsModalProps {
+  /** Modal title. "Layout settings" for edit, "New layout" for create. */
+  title: string;
+  initial: LayoutSettingsValue;
+  onSave: (value: LayoutSettingsValue) => void;
+  onClose: () => void;
+}
+
+export function LayoutSettingsModal({
+  title,
+  initial,
+  onSave,
+  onClose,
+}: LayoutSettingsModalProps) {
+  const [name, setName] = useState(initial.name);
+  const [icon, setIcon] = useState(initial.icon);
+  const [description, setDescription] = useState(initial.description);
+  const nameRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    nameRef.current?.focus();
+    nameRef.current?.select();
+  }, []);
+
+  const handleSave = () => {
+    const trimmedName = name.trim();
+    if (!trimmedName) return;
+    onSave({
+      name: trimmedName,
+      icon: icon.trim(),
+      description: description.trim(),
+    });
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') onClose();
+    else if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) handleSave();
+  };
+
+  return (
+    <div
+      className="modal-backdrop layout-settings-backdrop"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0, 0, 0, 0.7)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 10000,
+      }}
+      onClick={onClose}
+    >
+      <div
+        className="layout-settings-modal"
+        role="dialog"
+        aria-label={title}
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={handleKeyDown}
+      >
+        <div className="layout-settings-header">
+          <h2>{title}</h2>
+          <button
+            type="button"
+            className="workspace-tile-close"
+            aria-label="Close layout settings"
+            onClick={onClose}
+            style={{ width: 22, height: 22 }}
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="layout-settings-body">
+          <div className="layout-settings-preview" aria-hidden>
+            <div className="layout-settings-preview-tile">
+              <span className="layout-settings-preview-icon">
+                {icon || initialLetter(name)}
+              </span>
+              <span className="layout-settings-preview-label">
+                {(name || 'Layout').slice(0, 12)}
+              </span>
+            </div>
+          </div>
+
+          <label className="layout-settings-field">
+            <span className="layout-settings-field-label">Label</span>
+            <input
+              ref={nameRef}
+              type="text"
+              className="layout-settings-input"
+              value={name}
+              maxLength={24}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. SOTA"
+              aria-label="Layout label"
+            />
+            <span className="layout-settings-field-hint">
+              Short — appears below the icon.
+            </span>
+          </label>
+
+          <div className="layout-settings-field">
+            <span className="layout-settings-field-label">Icon</span>
+            <div className="layout-settings-icon-row">
+              <input
+                type="text"
+                className="layout-settings-icon-input"
+                value={icon}
+                maxLength={8}
+                onChange={(e) => setIcon(e.target.value)}
+                placeholder="📡"
+                aria-label="Layout icon (emoji)"
+              />
+              {icon && (
+                <button
+                  type="button"
+                  className="btn ghost sm"
+                  onClick={() => setIcon('')}
+                  aria-label="Clear icon"
+                  title="Clear icon"
+                >
+                  Clear
+                </button>
+              )}
+            </div>
+            <div
+              className="layout-settings-icon-grid"
+              role="listbox"
+              aria-label="Suggested icons"
+            >
+              {ICON_PALETTE.map((emoji) => {
+                const selected = emoji === icon;
+                return (
+                  <button
+                    key={emoji}
+                    type="button"
+                    className={`layout-settings-icon-chip ${
+                      selected ? 'selected' : ''
+                    }`}
+                    role="option"
+                    aria-selected={selected}
+                    onClick={() => setIcon(emoji)}
+                    title={emoji}
+                  >
+                    {emoji}
+                  </button>
+                );
+              })}
+            </div>
+            <span className="layout-settings-field-hint">
+              Pick from the palette, or paste any emoji
+              (macOS: ⌃⌘Space, Windows: Win + .)
+            </span>
+          </div>
+
+          <label className="layout-settings-field">
+            <span className="layout-settings-field-label">Description</span>
+            <textarea
+              className="layout-settings-textarea"
+              value={description}
+              maxLength={256}
+              rows={2}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Shown on hover — e.g. Portable HF, 5 W, no rotator"
+              aria-label="Layout description"
+            />
+          </label>
+        </div>
+
+        <div className="layout-settings-actions">
+          <button
+            type="button"
+            className="btn ghost"
+            onClick={onClose}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="btn active"
+            onClick={handleSave}
+            disabled={!name.trim()}
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function initialLetter(name: string): string {
+  const ch = name.trim().charAt(0);
+  return ch ? ch.toUpperCase() : '·';
+}

--- a/zeus-web/src/state/layout-store.ts
+++ b/zeus-web/src/state/layout-store.ts
@@ -32,12 +32,30 @@ export interface NamedLayout {
   name: string;
   /** Serialized WorkspaceLayout (parseWorkspaceLayout-ready). */
   layoutJson: string;
+  /** Optional emoji or short glyph rendered above the label in the
+   *  LeftLayoutBar. Empty/undefined → letter-fallback badge. */
+  icon?: string;
+  /** Optional longer description shown as the hover tooltip. */
+  description?: string;
 }
 
 interface RadioLayoutsResponse {
   radioKey: string;
-  layouts: Array<{ id: string; name: string; layoutJson: string; updatedUtc: number }>;
+  layouts: Array<{
+    id: string;
+    name: string;
+    layoutJson: string;
+    updatedUtc: number;
+    icon?: string | null;
+    description?: string | null;
+  }>;
   activeLayoutId: string;
+}
+
+export interface LayoutMetaUpdate {
+  name?: string;
+  icon?: string;
+  description?: string;
 }
 
 interface LayoutState {
@@ -71,13 +89,16 @@ interface LayoutState {
   // Layout-level mutators (LeftLayoutBar API):
   /** Create a new layout for the current radio, seeded from
    *  DEFAULT_WORKSPACE_LAYOUT, and switch to it. Returns the new id. */
-  addLayout: (name: string) => string;
+  addLayout: (name: string, meta?: { icon?: string; description?: string }) => string;
   /** Delete a layout. If it was active, the server promotes the first
    *  remaining layout to active; if there are zero remaining the client
    *  re-seeds Default. */
   removeLayout: (id: string) => void;
-  /** Rename an existing layout. */
+  /** Rename an existing layout. Shim over updateLayoutMeta. */
   renameLayout: (id: string, name: string) => void;
+  /** Update presentation metadata (name / icon / description) for a layout.
+   *  Pass undefined for fields you do not want to change. Persists via PUT. */
+  updateLayoutMeta: (id: string, patch: LayoutMetaUpdate) => void;
   /** Switch the active layout. Re-parses the layout's JSON into `workspace`
    *  and POSTs the new active id to the server. */
   setActiveLayout: (id: string) => void;
@@ -154,6 +175,8 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
         id: l.id,
         name: l.name,
         layoutJson: l.layoutJson,
+        ...(l.icon ? { icon: l.icon } : {}),
+        ...(l.description ? { description: l.description } : {}),
       }));
       let activeId = dto.activeLayoutId || layouts[0]?.id || DEFAULT_LAYOUT_ID;
       // Empty radio → seed a Default and persist.
@@ -203,6 +226,8 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
       layoutId: active.id,
       name: active.name,
       layoutJson: serializeWorkspace(workspace),
+      icon: active.icon ?? '',
+      description: active.description ?? '',
     });
     const blob = new Blob([body], { type: 'application/json' });
     if (!navigator.sendBeacon('/api/ui/layout-beacon', blob)) {
@@ -215,10 +240,16 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
     }
   },
 
-  addLayout: (name) => {
+  addLayout: (name, meta) => {
     const id = `layout-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
     const json = serializeWorkspace(DEFAULT_WORKSPACE_LAYOUT);
-    const next: NamedLayout = { id, name: name || 'Untitled', layoutJson: json };
+    const next: NamedLayout = {
+      id,
+      name: name || 'Untitled',
+      layoutJson: json,
+      ...(meta?.icon ? { icon: meta.icon } : {}),
+      ...(meta?.description ? { description: meta.description } : {}),
+    };
     const layouts = [...get().layouts, next];
     set({
       layouts,
@@ -251,10 +282,29 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
   },
 
   renameLayout: (id, name) => {
-    const layouts = get().layouts.map((l) => (l.id === id ? { ...l, name } : l));
+    get().updateLayoutMeta(id, { name });
+  },
+
+  updateLayoutMeta: (id, patch) => {
+    const layouts = get().layouts.map((l) => {
+      if (l.id !== id) return l;
+      const next: NamedLayout = { ...l };
+      if (patch.name !== undefined) next.name = patch.name || l.name;
+      if (patch.icon !== undefined) {
+        const trimmed = patch.icon.trim();
+        if (trimmed.length === 0) delete next.icon;
+        else next.icon = trimmed;
+      }
+      if (patch.description !== undefined) {
+        const trimmed = patch.description.trim();
+        if (trimmed.length === 0) delete next.description;
+        else next.description = trimmed;
+      }
+      return next;
+    });
     set({ layouts });
-    const renamed = findActive(layouts, id);
-    if (renamed) void putNamedLayout(get().radioKey, renamed);
+    const updated = findActive(layouts, id);
+    if (updated) void putNamedLayout(get().radioKey, updated);
   },
 
   setActiveLayout: (id) => {
@@ -386,6 +436,8 @@ function putNamedLayout(radioKey: string, layout: NamedLayout): Promise<unknown>
       layoutId: layout.id,
       name: layout.name,
       layoutJson: layout.layoutJson,
+      icon: layout.icon ?? '',
+      description: layout.description ?? '',
     }),
   });
 }

--- a/zeus-web/src/styles/all-panels.css
+++ b/zeus-web/src/styles/all-panels.css
@@ -386,3 +386,162 @@
   font-size: 11px;
   color: var(--fg-2);
 }
+
+/* Layout settings modal — edit a NamedLayout's label, icon, and tooltip
+ * description. Reuses the modal-backdrop scrim from AddPanelModal. */
+.layout-settings-modal {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-1);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--r-md);
+  width: 90%;
+  max-width: 460px;
+  max-height: 85vh;
+  overflow: hidden;
+}
+.layout-settings-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--panel-border);
+  background: linear-gradient(180deg,
+    var(--panel-head-top, var(--panel-top)),
+    var(--panel-head-bot, var(--panel-bot)));
+}
+.layout-settings-header h2 {
+  margin: 0;
+  font-size: 13px;
+  font-family: var(--font-sans);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--fg-1);
+}
+.layout-settings-body {
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  overflow-y: auto;
+}
+.layout-settings-preview {
+  display: flex;
+  justify-content: center;
+  padding: 8px 0 4px;
+}
+.layout-settings-preview-tile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 10px;
+  min-width: 64px;
+  background: linear-gradient(180deg, var(--btn-top), var(--btn-bot));
+  border: 1px solid var(--accent);
+  border-radius: var(--r-sm);
+  box-shadow: inset 0 1px 0 var(--btn-hl), 0 0 8px var(--accent-soft);
+  color: var(--accent);
+}
+.layout-settings-preview-icon {
+  font-size: 22px;
+  line-height: 1;
+  font-family: 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji',
+    var(--font-sans);
+}
+.layout-settings-preview-label {
+  font-family: var(--font-sans);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.layout-settings-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.layout-settings-field-label {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--fg-2);
+  font-family: var(--font-sans);
+}
+.layout-settings-field-hint {
+  font-size: 10px;
+  color: var(--fg-3);
+}
+.layout-settings-input,
+.layout-settings-textarea,
+.layout-settings-icon-input {
+  width: 100%;
+  padding: 6px 10px;
+  background: var(--bg-0);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--r-sm);
+  color: var(--fg-0);
+  font-size: 12px;
+  font-family: var(--font-sans);
+}
+.layout-settings-textarea {
+  resize: vertical;
+  min-height: 44px;
+  font-family: var(--font-sans);
+}
+.layout-settings-input:focus,
+.layout-settings-textarea:focus,
+.layout-settings-icon-input:focus {
+  outline: 1px solid var(--accent);
+  outline-offset: 0;
+  border-color: var(--accent);
+}
+.layout-settings-icon-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.layout-settings-icon-input {
+  width: 80px;
+  text-align: center;
+  font-size: 18px;
+  font-family: 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji',
+    var(--font-sans);
+}
+.layout-settings-icon-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 4px;
+  margin-top: 6px;
+}
+.layout-settings-icon-chip {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 32px;
+  font-size: 18px;
+  background: var(--bg-0);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  font-family: 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji',
+    var(--font-sans);
+  transition: background var(--dur-fast), border-color var(--dur-fast);
+}
+.layout-settings-icon-chip:hover {
+  background: var(--bg-2);
+  border-color: var(--accent);
+}
+.layout-settings-icon-chip.selected {
+  background: var(--bg-2);
+  border-color: var(--accent);
+  box-shadow: 0 0 6px var(--accent-soft);
+}
+.layout-settings-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 10px 16px;
+  border-top: 1px solid var(--panel-border);
+  background: var(--bg-0);
+}

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -52,14 +52,25 @@
   overflow: hidden;
 }
 
-/* Subtle blue brand accent overlay. Two layers:
-   - ::before is the deep-blue wash (matches the VFO frequency-display blue).
-     Solid 0–50%, fades out across 50–70%, fully transparent below 70%.
+/* Subtle tint overlay. Two layers:
+   - ::before is the top-half wash (matches the VFO frequency-display blue at
+     the default). Solid 0–50%, fades out across 50–70%, fully transparent
+     below 70%.
    - ::after is the diffused dot matrix. Invisible above 50%, fades in across
      50–70%, gone by 70%.
-   Both layers use raw VFO-tab colors (#14243e ≈ rgba(20,36,62,…)) +
-   var(--accent) for the dots; the bar's panel chrome shows through cleanly
-   below 70%. */
+   The hue is sourced from --lb-wash-{r,g,b} (a darkened 0.25× variant of
+   the operator's panadapter trace colour) and --lb-tint-{r,g,b} (the trace
+   colour itself). Defaults preserve the original VFO-blue + accent-blue
+   look when the JS hasn't injected the operator's choice yet. The 70% mark
+   keeps the bar's lower half clean so action buttons stay readable. */
+.left-layout-bar {
+  --lb-wash-r: 20;
+  --lb-wash-g: 36;
+  --lb-wash-b: 62;
+  --lb-tint-r: 74;
+  --lb-tint-g: 158;
+  --lb-tint-b: 255;
+}
 .left-layout-bar::before {
   content: '';
   position: absolute;
@@ -68,10 +79,10 @@
   z-index: 0;
   background: linear-gradient(
     to bottom,
-    rgba(20, 36, 62, 0.55) 0%,
-    rgba(20, 36, 62, 0.55) 50%,
-    rgba(20, 36, 62, 0.00) 70%,
-    rgba(20, 36, 62, 0.00) 100%
+    rgba(var(--lb-wash-r), var(--lb-wash-g), var(--lb-wash-b), 0.55) 0%,
+    rgba(var(--lb-wash-r), var(--lb-wash-g), var(--lb-wash-b), 0.55) 50%,
+    rgba(var(--lb-wash-r), var(--lb-wash-g), var(--lb-wash-b), 0.00) 70%,
+    rgba(var(--lb-wash-r), var(--lb-wash-g), var(--lb-wash-b), 0.00) 100%
   );
 }
 .left-layout-bar::after {
@@ -81,7 +92,9 @@
   pointer-events: none;
   z-index: 0;
   background:
-    radial-gradient(circle, rgba(74, 158, 255, 0.22) 1px, transparent 1.5px)
+    radial-gradient(circle,
+      rgba(var(--lb-tint-r), var(--lb-tint-g), var(--lb-tint-b), 0.22) 1px,
+      transparent 1.5px)
     0 0 / 8px 8px;
   /* Dots only paint in the 50–70% band: fully transparent above 50%, fade
      in to ~60% peak, fully transparent again by 70% so the bar's bottom

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -130,13 +130,11 @@
 .left-layout-bar .lb-tab {
   flex: 1;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 6px 4px;
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+  gap: 3px;
+  padding: 6px 4px 5px;
   color: var(--fg-1);
   background: linear-gradient(180deg, var(--btn-top), var(--btn-bot));
   border: 1px solid var(--btn-edge);
@@ -144,9 +142,7 @@
   box-shadow: inset 0 1px 0 var(--btn-hl);
   cursor: pointer;
   text-align: center;
-  min-height: 36px;
-  word-break: break-word;
-  hyphens: auto;
+  min-height: 50px;
   transition: background var(--dur-fast), border-color var(--dur-fast),
     color var(--dur-fast), box-shadow var(--dur-fast);
 }
@@ -156,25 +152,77 @@
   color: var(--accent);
   box-shadow: inset 0 1px 0 var(--btn-hl), 0 0 8px var(--accent-soft);
 }
-.left-layout-bar .lb-tab-name {
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  line-clamp: 3;
-  overflow: hidden;
+.left-layout-bar .lb-tab-icon {
+  font-size: 18px;
+  line-height: 1;
+  /* Force the OS colour-emoji palette so the chosen glyph stays vivid even
+     when the active state recolours the surrounding text. */
+  font-family: 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji',
+    sans-serif;
+  filter: none;
 }
-.left-layout-bar .lb-rename {
-  flex: 1;
-  width: 100%;
-  background: #0a1220;
-  border: 1px solid var(--accent);
-  border-radius: var(--r-sm);
-  color: var(--fg-0);
-  font-size: 10px;
+.left-layout-bar .lb-tab-icon.lb-tab-icon-fallback {
+  /* Letter fallback for layouts without an icon — render in the tab's
+     current colour so it picks up the active state. */
+  font-family: var(--font-sans);
   font-weight: 700;
-  text-align: center;
+  font-size: 16px;
+  letter-spacing: 0;
   text-transform: uppercase;
-  padding: 6px 4px;
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: 1px solid currentColor;
+  opacity: 0.85;
+}
+.left-layout-bar .lb-tab-name {
+  font-family: var(--font-sans);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  line-height: 1.1;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  line-clamp: 2;
+  overflow: hidden;
+  word-break: break-word;
+  hyphens: auto;
+  max-width: 100%;
+}
+.left-layout-bar .lb-gear {
+  position: absolute;
+  bottom: -4px;
+  right: -4px;
+  width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  background: linear-gradient(180deg, #2e2f33, #1c1d20);
+  border: 1px solid var(--btn-edge);
+  border-radius: 50%;
+  color: var(--fg-2);
+  cursor: pointer;
+  line-height: 1;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+  opacity: 0;
+  transition: opacity var(--dur-fast), color var(--dur-fast),
+    border-color var(--dur-fast);
+}
+.left-layout-bar .lb-item:hover .lb-gear,
+.left-layout-bar .lb-item.active .lb-gear,
+.left-layout-bar .lb-gear:focus-visible {
+  opacity: 1;
+}
+.left-layout-bar .lb-gear:hover {
+  color: var(--accent);
+  border-color: var(--accent);
 }
 .left-layout-bar .lb-x {
   position: absolute;


### PR DESCRIPTION
## Summary
- Replaces double-click-to-rename in the LeftLayoutBar with a dedicated **LayoutSettingsModal** (label + emoji icon + tooltip description), opened from a small ⚙ gear that appears on hover / active.
- Each layout tab now renders the **icon on top** with the **short label below** in small caps. Layouts without an icon fall back to a circled initial letter so existing rows still read clearly.
- Backend gains optional `Icon` / `Description` columns on `NamedLayoutDto` / `NamedLayoutEntry` (length-capped at the boundary, 16 / 256). Old LiteDB rows deserialize the new fields as empty strings — no explicit migration needed.

## What's in the modal
- Live preview tile so the operator sees the icon + label as they'll appear in the bar.
- 30-emoji palette of radio / comms glyphs (📡 🎙 📻 🎧 🛰 📶 ⚡ 🌐 …) **plus** a free-form input — any OS emoji picker still works (⌃⌘Space on macOS, Win+. on Windows).
- Description field used as the hover tooltip on the layout tab.

## Files
- **Backend:** `Zeus.Contracts/Dtos.cs`, `Zeus.Server.Hosting/LayoutStore.cs`, `Zeus.Server.Hosting/ZeusEndpoints.cs`
- **Frontend store:** `zeus-web/src/state/layout-store.ts` — adds `updateLayoutMeta(id, {name?, icon?, description?})`; `renameLayout` is now a shim.
- **Frontend UI:** new `zeus-web/src/layout/LayoutSettingsModal.tsx`; reworked `zeus-web/src/components/LeftLayoutBar.tsx`; styling in `styles/layout.css` + `styles/all-panels.css` (no new colors — reuses tokens.css).

## Maintainer notes
- Visual chrome additions (gear button, vertical tab layout, modal styling) reuse `tokens.css` variables only — no new palette entries. Per CLAUDE.md the visual design is still subject to maintainer review; flagging in case the icon-on-top vs. inline-with-label proportion or the gear placement want tweaks.

## Test plan
- [x] `dotnet build Zeus.slnx` clean (0 warnings, 0 errors)
- [x] `npx tsc --noEmit` clean
- [x] `npm test -- --run src/state/__tests__/layout-store.test.ts` — 13/13 pass
- [x] `npx vite build` clean (production bundle into `Zeus.Server.Hosting/wwwroot`)
- [ ] Manual: create a layout, give it an emoji + description, reload — icon, label, and tooltip all persist.
- [ ] Manual: edit an existing layout from the gear — clearing the icon falls back to the circled-letter glyph.
- [ ] Manual: delete + re-add a layout — server round-trip keeps the icon/description fields.