### PR TITLE
fix(tx-audio): keep TX Audio Tools tab visible; gate only VST submenu

### DIFF
--- a/zeus-web/src/components/SettingsMenu.test.tsx
+++ b/zeus-web/src/components/SettingsMenu.test.tsx
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 //
-// SettingsMenu — verify the TX Audio Tools tab is gated by the VST host
-// availability flag from /api/capabilities. Other tabs are static and
-// don't need coverage here.
+// SettingsMenu — verify the TX Audio Tools tab is always present and that
+// the VST host submenu inside it is gated by /api/capabilities. CFC is
+// WDSP-driven and must remain visible regardless of the sidecar.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
@@ -33,7 +33,7 @@ function seed(vstAvailable: boolean) {
   });
 }
 
-describe('SettingsMenu — TX Audio Tools tab gate', () => {
+describe('SettingsMenu — TX Audio Tools', () => {
   let container: HTMLDivElement;
   let root: Root;
 
@@ -51,8 +51,8 @@ describe('SettingsMenu — TX Audio Tools tab gate', () => {
     vi.unstubAllGlobals();
   });
 
-  it('renders TX AUDIO TOOLS when vstHost.available is true', () => {
-    seed(true);
+  it('always renders the TX AUDIO TOOLS tab', () => {
+    seed(false);
     act(() => {
       root.render(<SettingsMenu open={true} onClose={() => {}} />);
     });
@@ -62,17 +62,25 @@ describe('SettingsMenu — TX Audio Tools tab gate', () => {
     expect(tabs).toContain('TX AUDIO TOOLS');
   });
 
-  it('hides TX AUDIO TOOLS when vstHost.available is false', () => {
+  it('shows CFC and the VST host submenu when vstHost.available is true', () => {
+    seed(true);
+    act(() => {
+      root.render(
+        <SettingsMenu open={true} onClose={() => {}} initialTab="tx-audio" />,
+      );
+    });
+    expect(container.textContent).toContain('Continuous Frequency Compressor');
+    expect(container.textContent).toContain('VST Host');
+  });
+
+  it('shows CFC but hides the VST host submenu when vstHost.available is false', () => {
     seed(false);
     act(() => {
-      root.render(<SettingsMenu open={true} onClose={() => {}} />);
+      root.render(
+        <SettingsMenu open={true} onClose={() => {}} initialTab="tx-audio" />,
+      );
     });
-    const tabs = Array.from(
-      container.querySelectorAll('[role="tablist"] button'),
-    ).map((b) => b.textContent?.trim() ?? '');
-    expect(tabs).not.toContain('TX AUDIO TOOLS');
-    // The other tabs are still there.
-    expect(tabs).toContain('PA SETTINGS');
-    expect(tabs).toContain('ABOUT');
+    expect(container.textContent).toContain('Continuous Frequency Compressor');
+    expect(container.textContent).not.toContain('VST Host');
   });
 });

--- a/zeus-web/src/components/SettingsMenu.tsx
+++ b/zeus-web/src/components/SettingsMenu.tsx
@@ -19,7 +19,7 @@
 // (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
 // Both are GPL-2.0-or-later.
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { PaSettingsPanel } from './PaSettingsPanel';
 import { BandPlanEditor } from './bandplan/BandPlanEditor';
 import { AboutPanel } from './AboutPanel';
@@ -30,7 +30,6 @@ import { ServerUrlPanel } from './ServerUrlPanel';
 import { TciSettingsPanel } from './TciSettingsPanel';
 import { RadioSelector } from './RadioSelector';
 import { usePaStore } from '../state/pa-store';
-import { useCapabilitiesStore } from '../state/capabilities-store';
 import { PsSettingsPanel } from './PsSettingsPanel';
 import { TxAudioToolsPanel } from './TxAudioToolsPanel';
 
@@ -46,7 +45,7 @@ type TabId =
   | 'server'
   | 'about';
 
-const ALL_TABS: ReadonlyArray<{ id: TabId; label: string }> = [
+const TABS: ReadonlyArray<{ id: TabId; label: string }> = [
   { id: 'pa', label: 'PA SETTINGS' },
   { id: 'ps', label: 'PURESIGNAL' },
   { id: 'tx-audio', label: 'TX AUDIO TOOLS' },
@@ -74,27 +73,6 @@ export function SettingsMenu({ open, onClose, initialTab }: Props) {
   const savePa = usePaStore((s) => s.save);
   const loadPa = usePaStore((s) => s.load);
   const paInflight = usePaStore((s) => s.inflight);
-  // Feature gates. The TX Audio Tools tab is hidden when the VST host is
-  // not available — today that means non-Linux builds and Linux builds
-  // missing the zeus-plughost sidecar binary. Hiding (rather than
-  // disabling) is deliberate: the operator can't act on a disabled tab
-  // until the platform ships its own sidecar.
-  const vstHostAvailable = useCapabilitiesStore(
-    (s) => s.capabilities?.features.vstHost.available ?? false,
-  );
-  const TABS = useMemo(
-    () => ALL_TABS.filter((t) => t.id !== 'tx-audio' || vstHostAvailable),
-    [vstHostAvailable],
-  );
-
-  // If the active tab gets filtered out (e.g. the operator was on
-  // tx-audio when the capabilities response came back saying it's
-  // unavailable), fall back to the first tab.
-  useEffect(() => {
-    if (!TABS.some((t) => t.id === active)) {
-      setActive(TABS[0]?.id ?? 'pa');
-    }
-  }, [TABS, active]);
 
   const handleApply = async () => {
     await savePa();

--- a/zeus-web/src/components/TxAudioToolsPanel.tsx
+++ b/zeus-web/src/components/TxAudioToolsPanel.tsx
@@ -15,20 +15,20 @@
 
 import { CfcSettingsPanel } from './CfcSettingsPanel';
 import { VstHostSubmenu } from './VstHostSubmenu';
+import { useCapabilitiesStore } from '../state/capabilities-store';
 
-/**
- * "TX Audio Tools" settings tab — host for digital-domain TX shaping
- * controls. Issue #123 lands the 10-band CFC; issue #106 lands the VST
- * host submenu (out-of-process sidecar with an 8-slot chain). The
- * legacy in-process TX EQ remains paused — operators with EQ needs go
- * through a VST instead.
- */
+// CFC is WDSP-driven and always available. The VST host submenu is gated
+// on the zeus-plughost sidecar (today: Linux only) — when unavailable we
+// hide the submenu rather than the whole tab, so CFC stays reachable.
 export function TxAudioToolsPanel() {
+  const vstHostAvailable = useCapabilitiesStore(
+    (s) => s.capabilities?.features.vstHost.available ?? false,
+  );
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
       <CfcSettingsPanel />
 
-      <VstHostSubmenu />
+      {vstHostAvailable && <VstHostSubmenu />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- The `/api/capabilities` VST host gate added in ccd3570 was applied at the tab level, hiding the entire **TX AUDIO TOOLS** tab — and with it the CFC settings panel — whenever `zeus-plughost` wasn't reachable. Today that means every non-Linux build, plus Linux without the sidecar binary.
- CFC is WDSP-driven (`SetTXACFCOMPprofile` etc.) and has no dependency on the sidecar; only `VstHostSubmenu` does.
- Move the gate down from `SettingsMenu` into `TxAudioToolsPanel`. The tab is always shown, CFC is always reachable, and only the VST submenu inside the tab is hidden when `vstHost.available` is false.

Closes #257.

## Test plan

- [x] `npm run test` (zeus-web) — 204 pass
- [x] `npm run lint` — 0 errors
- [x] `npx tsc --noEmit` — clean
- [x] `dotnet build Zeus.slnx` — clean
- [x] `dotnet test Zeus.slnx` — 608 pass
- [ ] Manual: open Settings on macOS / Windows build, confirm **TX AUDIO TOOLS** is in the tab strip and CFC controls render
- [ ] Manual: on Linux with the sidecar present, confirm both CFC and the VST host submenu are visible