### PR TITLE
refactor(meters): standardize S-meter header, auto-derive PA full-scale

### DIFF
--- a/zeus-web/src/components/analog-meter/AnalogMeterConfig.tsx
+++ b/zeus-web/src/components/analog-meter/AnalogMeterConfig.tsx
@@ -145,16 +145,6 @@ export function AnalogMeterConfig({ open, onClose }: AnalogMeterConfigProps) {
           </header>
           <div className="am-cf-body">
             <Slider
-              label="PA full-scale"
-              value={cfg.poMax}
-              min={10}
-              max={200}
-              step={5}
-              unit=" W"
-              onChange={cfg.setPoMax}
-              hint="Sets the right edge of the PO arc"
-            />
-            <Slider
               label="SWR alarm"
               value={cfg.swrAlarm}
               min={1.5}
@@ -164,13 +154,10 @@ export function AnalogMeterConfig({ open, onClose }: AnalogMeterConfigProps) {
               onChange={cfg.setSwrAlarm}
               hint="Readout turns red above this"
             />
-            <CheckRow
-              checked={cfg.followMox}
-              onChange={cfg.setFollowMox}
-              sub="Auto-switch when MOX/TUN engages"
-            >
-              Follow MOX
-            </CheckRow>
+            <div className="am-slider-hint">
+              PA full-scale tracks the rated PA power from the PA Settings panel
+              (max of 10 W or 120% of rated).
+            </div>
           </div>
         </section>
 

--- a/zeus-web/src/components/analog-meter/AnalogMeterPanel.tsx
+++ b/zeus-web/src/components/analog-meter/AnalogMeterPanel.tsx
@@ -3,9 +3,11 @@
 // Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
 // Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
 //
-// Analog S-Meter tile — header (RX/TX tabs + gear), animated dial face,
-// gear-flyout config, and footer readout strip. Live data comes from
-// useTxStore: rxDbm drives the S scale, fwdWatts drives PO, swr drives SWR.
+// Analog S-Meter tile — standard tile header (drag handle, title, gear, X),
+// animated dial face, gear-flyout config, and footer readout strip. Live
+// data comes from useTxStore: rxDbm drives the S scale, fwdWatts drives PO,
+// swr drives SWR. The panel auto-flips RX↔TX from moxOn/tunOn — the operator
+// never tells the meter which side to read.
 //
 // The needle is driven by a requestAnimationFrame loop that:
 //   1. samples raw rxDbm/fwdWatts/swr each frame,
@@ -19,6 +21,8 @@
 // flat without making the animation chunky.
 
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { GripVertical, Settings, X } from 'lucide-react';
+import { usePaStore } from '../../state/pa-store';
 import { useTxStore } from '../../state/tx-store';
 import { AnalogMeterFace } from './AnalogMeterFace';
 import { AnalogMeterConfig } from './AnalogMeterConfig';
@@ -38,76 +42,52 @@ import { useAnalogMeterStore } from './analogMeterStore';
 
 type Mode = 'rx' | 'tx';
 
-function GearIcon() {
-  return (
-    <svg
-      viewBox="0 0 16 16"
-      width={15}
-      height={15}
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={1.4}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <circle cx="8" cy="8" r="2.2" />
-      <path d="M8 1.5v2 M8 12.5v2 M1.5 8h2 M12.5 8h2 M3.3 3.3l1.4 1.4 M11.3 11.3l1.4 1.4 M3.3 12.7l1.4-1.4 M11.3 4.7l1.4-1.4" />
-    </svg>
-  );
-}
-
 interface TileHeaderProps {
-  mode: Mode;
-  onModeChange: (m: Mode) => void;
   configOpen: boolean;
   onGearClick: () => void;
   onClose?: () => void;
 }
 
-function TileHeader({ mode, onModeChange, configOpen, onGearClick, onClose }: TileHeaderProps) {
+function TileHeader({ configOpen, onGearClick, onClose }: TileHeaderProps) {
+  const stopDrag = (e: React.MouseEvent) => e.stopPropagation();
   return (
     <div className="am-header workspace-tile-header">
-      <div className="am-h-left">
-        <span className="am-status-dot" />
-        <span className="am-h-title">S-METER</span>
-      </div>
-
-      <div className="am-h-mode">
-        <button
-          type="button"
-          className={`am-mode-tab ${mode === 'rx' ? 'on' : ''}`}
-          onClick={() => onModeChange('rx')}
-        >
-          RX
-        </button>
-        <button
-          type="button"
-          className={`am-mode-tab ${mode === 'tx' ? 'on' : ''}`}
-          onClick={() => onModeChange('tx')}
-        >
-          TX
-        </button>
-      </div>
+      <span
+        className="workspace-tile-drag-handle"
+        aria-hidden="true"
+        title="Drag to reposition"
+      >
+        <GripVertical size={12} />
+      </span>
+      <span className="am-status-dot" />
+      <span className="workspace-tile-title am-h-title">S-METER</span>
 
       <button
         type="button"
         className={`am-h-gear ${configOpen ? 'on' : ''}`}
         onClick={onGearClick}
+        onMouseDown={stopDrag}
         aria-label="Configure meter"
+        aria-pressed={configOpen}
         title="Configure meter"
       >
-        <GearIcon />
+        <Settings size={14} />
       </button>
 
       {onClose && (
         <button
           type="button"
-          className="am-h-close workspace-tile-close"
-          onClick={onClose}
-          aria-label="Close panel"
-          title="Close"
+          className="workspace-tile-close"
+          onClick={(e) => {
+            e.stopPropagation();
+            onClose();
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+          onMouseDown={(e) => e.stopPropagation()}
+          aria-label="Remove S-Meter panel"
+          title="Remove panel"
         >
-          ×
+          <X size={12} />
         </button>
       )}
     </div>
@@ -185,12 +165,9 @@ export function AnalogMeterPanel({ onClose }: AnalogMeterPanelProps = {}) {
   const tunOn = useTxStore((s) => s.tunOn);
   const transmitting = moxOn || tunOn;
 
-  const [manualMode, setManualMode] = useState<Mode>('rx');
-  const mode: Mode = cfg.followMox ? (transmitting ? 'tx' : 'rx') : manualMode;
-  const onModeChange = (m: Mode) => {
-    setManualMode(m);
-    if (cfg.followMox) cfg.setFollowMox(false);
-  };
+  // The radio knows whether it's transmitting; the operator never has to tell
+  // the meter which side to read. RX while idle, TX during MOX/TUN.
+  const mode: Mode = transmitting ? 'tx' : 'rx';
 
   const [configOpen, setConfigOpen] = useState(false);
 
@@ -219,16 +196,23 @@ export function AnalogMeterPanel({ onClose }: AnalogMeterPanelProps = {}) {
     };
   }, [cfg.sTicks]);
 
-  // PO arc respects the operator's full-scale watts setting.
+  // PO arc full-scale is derived from the rated PA power configured in the
+  // main PA Settings panel: max(10 W, 120% of rated). A 5 W HL2 → 10 W scale,
+  // a 100 W rig → 120 W scale. When the operator hasn't configured a rated
+  // power yet, fall back to a 100 W bench rig (matches TxStageMeters).
+  const paMaxPowerWatts = usePaStore((s) => s.settings.global.paMaxPowerWatts);
+  const poMax = useMemo(() => {
+    const ratedW = paMaxPowerWatts > 0 ? paMaxPowerWatts : 100;
+    return Math.max(10, ratedW * 1.2);
+  }, [paMaxPowerWatts]);
   const dynamicPoScale = useMemo(() => {
-    const max = Math.max(10, cfg.poMax);
     return {
       ...PO_SCALE,
-      n: (w: number) => Math.min(1, Math.max(0, w) / max),
+      n: (w: number) => Math.min(1, Math.max(0, w) / poMax),
       fmt: (w: number) => `${w < 10 ? w.toFixed(1) : Math.round(w)} W`,
-      fromN: (n: number) => Math.max(0, Math.min(1, n)) * max,
+      fromN: (n: number) => Math.max(0, Math.min(1, n)) * poMax,
     };
-  }, [cfg.poMax]);
+  }, [poMax]);
 
   const activeScale = useMemo(() => {
     if (activeScaleId === 's') return customSScale;
@@ -335,8 +319,6 @@ export function AnalogMeterPanel({ onClose }: AnalogMeterPanelProps = {}) {
   return (
     <div className="am-tile" data-mode={mode}>
       <TileHeader
-        mode={mode}
-        onModeChange={onModeChange}
         configOpen={configOpen}
         onGearClick={() => setConfigOpen((o) => !o)}
         onClose={onClose}

--- a/zeus-web/src/components/analog-meter/analogMeterStore.ts
+++ b/zeus-web/src/components/analog-meter/analogMeterStore.ts
@@ -19,8 +19,6 @@ export interface AnalogMeterConfig {
   /** Subset of [1,3,5,7,8,9,11,13,15] — labels rendered on the S arc. */
   sTicks: number[];
   showDbm: boolean;
-  /** PO arc full-scale, watts (right edge). */
-  poMax: number;
   /** SWR threshold above which the readout switches to --tx. */
   swrAlarm: number;
   /** Needle ballistics (seconds). */
@@ -29,9 +27,6 @@ export interface AnalogMeterConfig {
   /** Pre-ballistic moving-average window, in samples (loop runs at rAF rate). */
   avg: number;
   peakHold: boolean;
-  /** When true, the panel auto-flips between RX and TX when MOX/TUN engages.
-   *  When false, the operator's manual mode-tab choice sticks. */
-  followMox: boolean;
   /** When true, an image of Zeus fades in over the S-meter face as the
    *  signal approaches S9+20, with a blue flicker glow. Pure visual flair —
    *  no protocol/DSP impact. Off by default. */
@@ -42,13 +37,11 @@ export interface AnalogMeterState extends AnalogMeterConfig {
   setScale: (id: 's' | 'po' | 'swr', on: boolean) => void;
   toggleSTick: (v: number) => void;
   setShowDbm: (on: boolean) => void;
-  setPoMax: (w: number) => void;
   setSwrAlarm: (r: number) => void;
   setAttack: (s: number) => void;
   setDecay: (s: number) => void;
   setAvg: (n: number) => void;
   setPeakHold: (on: boolean) => void;
-  setFollowMox: (on: boolean) => void;
   setZeusMode: (on: boolean) => void;
   resetBallistics: () => void;
 }
@@ -62,13 +55,11 @@ export const ANALOG_METER_DEFAULTS: AnalogMeterConfig = {
   // S8 omitted by default to match real moving-coil meters.
   sTicks: [1, 3, 5, 7, 9, 11, 13, 15],
   showDbm: true,
-  poMax: 100,
   swrAlarm: 3.0,
   attack: 0.05,
   decay: 0.6,
   avg: 6,
   peakHold: true,
-  followMox: true,
   zeusMode: false,
 };
 
@@ -89,13 +80,11 @@ export const useAnalogMeterStore = create<AnalogMeterState>()(
             : [...s.sTicks, v].sort((a, b) => a - b),
         })),
       setShowDbm: (on) => set({ showDbm: on }),
-      setPoMax: (w) => set({ poMax: Math.max(10, Math.min(1000, w)) }),
       setSwrAlarm: (r) => set({ swrAlarm: Math.max(1.5, Math.min(5, r)) }),
       setAttack: (s) => set({ attack: Math.max(0.005, Math.min(0.5, s)) }),
       setDecay: (s) => set({ decay: Math.max(0.05, Math.min(2, s)) }),
       setAvg: (n) => set({ avg: Math.max(1, Math.min(64, Math.round(n))) }),
       setPeakHold: (on) => set({ peakHold: on }),
-      setFollowMox: (on) => set({ followMox: on }),
       setZeusMode: (on) => set({ zeusMode: on }),
       resetBallistics: () =>
         set({

--- a/zeus-web/src/styles/analog-meter.css
+++ b/zeus-web/src/styles/analog-meter.css
@@ -16,88 +16,49 @@
   overflow: hidden;
 }
 
-/* ── Header ───────────────────────────────────────────────── */
-.am-header {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 6px 10px;
-  background: linear-gradient(180deg, var(--panel-top), var(--panel-bot));
-  border-bottom: 1px solid var(--panel-edge);
-  flex-shrink: 0;
-}
-.am-h-left {
-  display: flex;
-  align-items: center;
-  gap: 8px;
+/* ── Header ───────────────────────────────────────────────────
+ * The S-meter tile is registered headerless, so this strip plays the
+ * role of `.workspace-tile-header` (RGL drag handle). Sizing/colors
+ * inherit from all-panels.css; we only add the status dot and tweak
+ * the title spacing. */
+.am-header.workspace-tile-header {
+  gap: 6px;
 }
 .am-status-dot {
-  width: 8px;
-  height: 8px;
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
   background: var(--accent);
-  box-shadow: 0 0 0 3px var(--accent-soft);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+  flex-shrink: 0;
 }
 .am-h-title {
-  font-family: var(--font-sans);
-  font-size: 11px;
+  flex: 1;
   font-weight: 700;
-  letter-spacing: 0.2em;
-  color: var(--fg-0);
+  letter-spacing: 0.18em;
+  color: var(--fg-1);
 }
-.am-h-mode {
-  margin-left: 8px;
-  display: flex;
-  border: 1px solid var(--panel-edge);
-  border-radius: var(--r-md);
-  overflow: hidden;
-  background: var(--bg-2);
-}
-.am-mode-tab {
-  font-family: var(--font-sans);
-  font-size: 10.5px;
-  font-weight: 600;
-  letter-spacing: 0.16em;
-  padding: 4px 12px;
-  background: transparent;
+.am-h-gear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
   border: 0;
+  border-radius: var(--r-xs, 2px);
+  background: transparent;
   color: var(--fg-2);
   cursor: pointer;
   transition: color var(--dur-fast), background var(--dur-fast);
-}
-.am-mode-tab:hover { color: var(--fg-0); }
-.am-mode-tab.on {
-  background: var(--accent);
-  color: var(--bg-0);
-}
-.am-h-gear,
-.am-h-close {
-  width: 26px;
-  height: 26px;
-  border-radius: var(--r-md);
-  border: 1px solid var(--panel-edge);
-  background: var(--bg-2);
-  color: var(--fg-2);
-  display: grid;
-  place-items: center;
-  cursor: pointer;
-  transition: color var(--dur-fast), border-color var(--dur-fast), background var(--dur-fast);
   flex-shrink: 0;
 }
-.am-h-gear { margin-left: auto; }
-.am-h-gear:hover,
-.am-h-close:hover {
+.am-h-gear:hover {
   color: var(--fg-0);
-  border-color: var(--fg-3);
+  background: var(--bg-2);
 }
 .am-h-gear.on {
   background: var(--accent-soft);
-  border-color: var(--accent);
   color: var(--fg-0);
-}
-.am-h-close {
-  font-size: 16px;
-  line-height: 1;
 }
 
 /* ── Dial face ────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Drop RX/TX mode tabs and \`followMox\` from the analog S-meter — \`moxOn\`/\`tunOn\` already tell the panel which side to read, no operator input needed.
- Replace the bespoke 26×26 boxed close/gear with the standard \`workspace-tile-close\` + lucide \`X\`/\`Settings\` icons used by every other tile, so the header sits inside the standard 24 px chrome.
- Derive the PO arc full-scale from PA Settings rated power as \`max(10 W, 1.2 × rated)\`: 5 W HL2 → 10 W scale, 100 W rig → 120 W scale. The PA full-scale slider is gone from the gear flyout — one source of truth lives in PA Settings.

## Test plan
- [ ] Open the S-Meter tile: header drag handle / title / gear / X look identical to other tiles
- [ ] No RX/TX tabs in the header; needle flips to PO automatically when MOX/TUN engages
- [ ] Set PA Settings rated power to 5 W → PO arc reads 10 W full-scale
- [ ] Set PA Settings rated power to 100 W → PO arc reads 120 W full-scale
- [ ] Existing gear flyout still configures S-ticks / dBm / SWR alarm / ballistics / Zeus mode
- [ ] \`npm run typecheck\` clean; \`npm test\` 204/204 passing