### PR TITLE
feat(layout): default workspace rework + maxW anchoring + responsive rowHeight

### DIFF
--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -17,7 +17,7 @@
 //   - "+ Add Panel" is a single workspace-level button at the top-right,
 //     opening the categorized AddPanelModal.
 
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ResponsiveGridLayout,
   useContainerWidth,
@@ -28,7 +28,9 @@ import { useLayoutStore } from '../state/layout-store';
 import { PANELS } from './panels';
 import {
   WORKSPACE_GRID_COLS,
+  WORKSPACE_ROW_HEIGHT_MIN_PX,
   WORKSPACE_ROW_HEIGHT_PX,
+  WORKSPACE_TARGET_ROWS,
   WORKSPACE_TILE_MIN_H,
   WORKSPACE_TILE_MIN_W,
   type WorkspaceTile,
@@ -134,20 +136,55 @@ function WorkspaceCanvas({
   // measurement. mounted=false on first paint to avoid the 1280-px width
   // flash before the observer fires. Same pattern MetersCanvas uses.
   const { width, containerRef, mounted } = useContainerWidth();
+  // Track container height so rowHeight can scale with the viewport — this
+  // is what gives panels their "anchor: bottom" feel: hero (h=18) fills the
+  // available vertical space, right-column tiles distribute proportionally,
+  // window resize re-flows automatically.
+  const [containerHeight, setContainerHeight] = useState(0);
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    setContainerHeight(el.getBoundingClientRect().height);
+    const ro = new ResizeObserver((entries) => {
+      for (const e of entries) setContainerHeight(e.contentRect.height);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [containerRef]);
+  // Responsive rowHeight: solve containerHeight ≈ rowHeight*N + margin*(N-1)
+  // + 2*containerPadding. Margin and containerPadding here mirror the props
+  // passed to ResponsiveGridLayout below — keep them in sync if those change.
+  const rowHeight = useMemo(() => {
+    if (containerHeight <= 0) return WORKSPACE_ROW_HEIGHT_PX;
+    const margin = 6;
+    const containerPadding = 6;
+    const inner =
+      containerHeight - 2 * containerPadding - margin * (WORKSPACE_TARGET_ROWS - 1);
+    const computed = Math.floor(inner / WORKSPACE_TARGET_ROWS);
+    return Math.max(WORKSPACE_ROW_HEIGHT_MIN_PX, computed);
+  }, [containerHeight]);
 
   // RGL needs a stable per-render layouts.lg array. Memoise against the
   // tile list identity so we don't push a new prop on every parent render.
+  // Per-panel maxW/maxH (when defined in panels.ts) is propagated here so
+  // RGL clamps user resize drags — that's what gives right-column panels
+  // (vfo/smeter/dsp/txmeters/tx) their "grow in height only" feel.
   const rglLayouts = useMemo(
     () => ({
-      lg: tiles.map((t) => ({
-        i: t.uid,
-        x: t.x,
-        y: t.y,
-        w: t.w,
-        h: t.h,
-        minW: WORKSPACE_TILE_MIN_W,
-        minH: WORKSPACE_TILE_MIN_H,
-      })),
+      lg: tiles.map((t) => {
+        const def = PANELS[t.panelId];
+        return {
+          i: t.uid,
+          x: t.x,
+          y: t.y,
+          w: t.w,
+          h: t.h,
+          minW: WORKSPACE_TILE_MIN_W,
+          minH: WORKSPACE_TILE_MIN_H,
+          ...(def?.maxW !== undefined ? { maxW: def.maxW } : {}),
+          ...(def?.maxH !== undefined ? { maxH: def.maxH } : {}),
+        };
+      }),
     }),
     [tiles],
   );
@@ -163,7 +200,7 @@ function WorkspaceCanvas({
           width={width}
           breakpoints={{ lg: 0 }}
           cols={{ lg: WORKSPACE_GRID_COLS }}
-          rowHeight={WORKSPACE_ROW_HEIGHT_PX}
+          rowHeight={rowHeight}
           margin={[6, 6]}
           containerPadding={[6, 6]}
           // Drag from anywhere in the tile header (the grip + title strip),

--- a/zeus-web/src/layout/defaultLayout.ts
+++ b/zeus-web/src/layout/defaultLayout.ts
@@ -4,30 +4,35 @@
 // Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
 //
 // Default workspace layout for the react-grid-layout (RGL) substrate. 12-col
-// grid. Bumped to schemaVersion 7: removed logbook + tuning-step from the
-// default tile set and relocated TX Stage Meters into the right-hand
-// column. Operators can still add any of those panels back via "+ Add".
+// grid. The right column is a stack of fixed-width tiles (vfo/smeter/tx/
+// txmeters/dsp); width caps live in panels.ts via maxW so the operator can
+// only resize them vertically. The left column is BANDWIDTH FILTER on top
+// and the panadapter hero filling the remaining vertical space — both grow
+// horizontally with the window. Combined with the responsive rowHeight in
+// FlexWorkspace.tsx, the whole layout scales to fill the viewport without
+// the operator having to re-tune sizes.
+//
+// Total height = WORKSPACE_TARGET_ROWS (24) so the default fills the
+// available viewport exactly with the responsive rowHeight calculation.
 //
 // ASCII sanity check (columns 0..11):
 //
 //   ┌───────────────────────────────────────────────┬─────────────┐  y=0
-//   │              filter (0..8, h=2)                │    vfo      │
-//   ├───────────────────────────────────────────────┤   (h=4)     │  y=2
+//   │              filter (0..8, h=6)                │    vfo      │
+//   │                                                │   (h=4)     │
+//   │                                                ├─────────────┤  y=4
+//   │                                                │   smeter    │
+//   ├───────────────────────────────────────────────┤   (h=2)     │  y=6
 //   │                                                ├─────────────┤
-//   │                                                │   smeter    │  y=4
-//   │                                                │   (h=2)     │
-//   │              hero (0..8, h=18)                 ├─────────────┤  y=6
-//   │                                                │     dsp     │
-//   │                                                │   (h=3)     │  y=9
-//   │                                                ├─────────────┤
-//   │                                                │  txmeters   │
-//   │                                                │   (h=6)     │  y=15
-//   │                                                ├─────────────┤
-//   │                                                │  azimuth    │
+//   │                                                │     tx      │
 //   │                                                │   (h=5)     │
-//   ├───────────────────────────────────────────────┤             │
-//   │                  qrz (0..8, h=2)              │             │
-//   └───────────────────────────────────────────────┴─────────────┘  y=20
+//   │                                                ├─────────────┤  y=11
+//   │              hero (0..8, h=18)                 │  txmeters   │
+//   │                                                │   (h=6)     │
+//   │                                                ├─────────────┤  y=17
+//   │                                                │     dsp     │
+//   │                                                │   (h=7)     │
+//   └───────────────────────────────────────────────┴─────────────┘  y=24
 
 import type { WorkspaceLayout } from './workspace';
 
@@ -35,15 +40,14 @@ export const DEFAULT_WORKSPACE_LAYOUT: WorkspaceLayout = {
   schemaVersion: 7,
   tiles: [
     // Stable uids (not random) for the default layout — lets a future
-    // migration map "the old default 'qrz' tile" to a new layout without
+    // migration map "the old default 'vfo' tile" to a new layout without
     // losing operator overrides.
-    { uid: 'tile-filter',   panelId: 'filter',   x: 0, y: 0,  w: 9, h: 2 },
-    { uid: 'tile-hero',     panelId: 'hero',     x: 0, y: 2,  w: 9, h: 16 },
-    { uid: 'tile-qrz',      panelId: 'qrz',      x: 0, y: 18, w: 9, h: 2 },
+    { uid: 'tile-filter',   panelId: 'filter',   x: 0, y: 0,  w: 9, h: 6 },
+    { uid: 'tile-hero',     panelId: 'hero',     x: 0, y: 6,  w: 9, h: 18 },
     { uid: 'tile-vfo',      panelId: 'vfo',      x: 9, y: 0,  w: 3, h: 4 },
     { uid: 'tile-smeter',   panelId: 'smeter',   x: 9, y: 4,  w: 3, h: 2 },
-    { uid: 'tile-dsp',      panelId: 'dsp',      x: 9, y: 6,  w: 3, h: 3 },
-    { uid: 'tile-txmeters', panelId: 'txmeters', x: 9, y: 9,  w: 3, h: 6 },
-    { uid: 'tile-azimuth',  panelId: 'azimuth',  x: 9, y: 15, w: 3, h: 5 },
+    { uid: 'tile-tx',       panelId: 'tx',       x: 9, y: 6,  w: 3, h: 5 },
+    { uid: 'tile-txmeters', panelId: 'txmeters', x: 9, y: 11, w: 3, h: 6 },
+    { uid: 'tile-dsp',      panelId: 'dsp',      x: 9, y: 17, w: 3, h: 7 },
   ],
 };

--- a/zeus-web/src/layout/panels.ts
+++ b/zeus-web/src/layout/panels.ts
@@ -112,6 +112,16 @@ export interface PanelDef {
    *  toolbars (Meters has gear / library / settings drawers; Panadapter has
    *  band/zoom/cursor strip; Azimuth has SP/LP toggles). */
   headerless?: boolean;
+  /** Width cap in 12-col grid units. When set, RGL won't let the operator
+   *  drag the tile any wider — the closest analogue to "anchor: top, right"
+   *  in a Windows-Forms-style designer. Right-column stack panels (vfo /
+   *  smeter / dsp / txmeters / azimuth / tx) cap at 3 so they grow only in
+   *  height, never sprawling into the panadapter column. Omit for
+   *  freely-sizable panels. */
+  maxW?: number;
+  /** Height cap in grid rows. Optional ceiling on vertical growth.
+   *  Omit for freely-sizable panels. */
+  maxH?: number;
 }
 
 // Panel registry: maps component-id strings (used in the flexlayout JSON model)
@@ -131,6 +141,7 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'vfo',
     tags: ['frequency', 'vfo', 'tuning'],
     component: VfoPanel,
+    maxW: 3,
   },
   smeter: {
     id: 'smeter',
@@ -138,6 +149,7 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'meters',
     tags: ['signal', 'meter', 'rx', 'smeter'],
     component: SMeterPanel,
+    maxW: 3,
   },
   qrz: {
     id: 'qrz',
@@ -152,6 +164,7 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'tools',
     tags: ['azimuth', 'map', 'bearing', 'great-circle'],
     component: AzimuthPanel,
+    maxW: 3,
   },
   dsp: {
     id: 'dsp',
@@ -159,6 +172,7 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'dsp',
     tags: ['dsp', 'noise', 'filter', 'nr', 'anf'],
     component: DspFlexPanel,
+    maxW: 3,
   },
   cw: {
     id: 'cw',
@@ -180,6 +194,7 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'meters',
     tags: ['tx', 'power', 'swr', 'alc', 'meters'],
     component: TxMetersPanel,
+    maxW: 3,
   },
   tx: {
     id: 'tx',
@@ -187,6 +202,7 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'controls',
     tags: ['tx', 'drive', 'tune', 'mic', 'mic-gain', 'power', 'filter', 'bandpass'],
     component: TxPanel,
+    maxW: 3,
   },
   filter: {
     id: 'filter',

--- a/zeus-web/src/layout/workspace.ts
+++ b/zeus-web/src/layout/workspace.ts
@@ -14,9 +14,20 @@ import { PANELS } from './panels';
 /** Outer-grid column count. Matches MetersPanel's inner grid so the mental
  *  model is identical at both levels. */
 export const WORKSPACE_GRID_COLS = 12;
-/** Outer-grid row height in CSS pixels. Smaller than MetersPanel's 40 px
- *  inner row so the workspace can do finer pixel-grain placement. */
+/** Fallback row height in CSS pixels, used before the workspace container's
+ *  ResizeObserver fires. The live rowHeight is computed responsively in
+ *  FlexWorkspace (= viewport / WORKSPACE_TARGET_ROWS) so the default layout
+ *  fills the available height. */
 export const WORKSPACE_ROW_HEIGHT_PX = 30;
+/** Target row count the responsive rowHeight calc divides into the
+ *  measured container height. Matches the total y+h of the default layout
+ *  so a fresh radio fills the viewport exactly. Custom layouts taller than
+ *  this row out below the fold (workspace scrolls); shorter layouts leave
+ *  empty space at the bottom. */
+export const WORKSPACE_TARGET_ROWS = 24;
+/** Floor on the responsive rowHeight so tiles stay readable on small
+ *  windows. Below this, the workspace scrolls instead of cramming. */
+export const WORKSPACE_ROW_HEIGHT_MIN_PX = 18;
 /** Default minW/minH for every tile. minW=1 (≈ 1/12 of the workspace
  *  width) lets short-control tiles like Mode / Tuning Step / Band shrink
  *  down to a narrow column when the operator wants to dock them tight,
@@ -70,7 +81,7 @@ export const DEFAULT_TILE_SPAN: Record<string, { w: number; h: number }> = {
   azimuth: { w: 3, h: 8 },
   step: { w: 3, h: 3 },
   cw: { w: 4, h: 4 },
-  tx: { w: 4, h: 5 },
+  tx: { w: 3, h: 5 },
   ps: { w: 4, h: 5 },
   band: { w: 6, h: 2 },
   mode: { w: 4, h: 2 },

--- a/zeus-web/src/state/__tests__/layout-store.test.ts
+++ b/zeus-web/src/state/__tests__/layout-store.test.ts
@@ -49,13 +49,13 @@ describe('layout-store / workspace tile mutators', () => {
   });
 
   it('addTile places the new tile at y = max(existing y+h)', () => {
-    // DEFAULT_WORKSPACE_LAYOUT's tallest existing y+h is qrz/logbook/txmeters
-    // at y=14, h=6 → 20. So the new tile should land at y=20.
+    // DEFAULT_WORKSPACE_LAYOUT's tallest existing y+h is hero/dsp at
+    // y=6+18 / y=17+7 = 24. So the new tile should land at y=24.
     const uid = useLayoutStore.getState().addTile('cw');
     const tile = useLayoutStore
       .getState()
       .workspace.tiles.find((t) => t.uid === uid);
-    expect(tile?.y).toBe(20);
+    expect(tile?.y).toBe(24);
     expect(tile?.x).toBe(0);
   });
 


### PR DESCRIPTION
## Summary

- **New default layout** matching the requested image: BANDWIDTH FILTER on top-left (9w × 6h), panadapter hero below it (9w × 18h), right-column stack VFO → S-METER → TX → TX STAGE METERS → DSP (all 3w). Total = 24 rows. QRZ + Azimuth dropped from default; operators can re-add via "+ Add Panel". Schema version held at 7 so existing operator layouts are preserved — only fresh radios get the new default.
- **Per-panel maxW** as a Windows-Forms-style "anchor" knob. `PanelDef` gains optional `maxW`/`maxH`; right-column panels (`vfo`, `smeter`, `dsp`, `txmeters`, `azimuth`, `tx`) get `maxW: 3`. RGL clamps user resize drags so these tiles grow in height only — they never sprawl into the panadapter column.
- **Responsive `rowHeight`** so the layout fills the viewport. A `ResizeObserver` on the workspace container drives `rowHeight = (height − padding − margin·(rows−1)) / WORKSPACE_TARGET_ROWS` (24), with an 18 px floor. Window resize re-flows panels proportionally without the operator having to retune sizes.

## Caveat (worth flagging)

RGL columns scale with container width, so right-column panels still get *visually* wider when the window grows (just proportionally — they stay at 3/12). True fixed-pixel right rail (independent of window width) would require lifting those tiles out of the grid; out of scope here.

## Test plan

- [x] `npm --prefix zeus-web run typecheck` clean
- [x] `npm --prefix zeus-web test` — 204 / 204 passing
- [x] `npm --prefix zeus-web run build` clean
- [ ] Manual: fresh radio (clear `zeus-prefs.db` or new boardKey) shows the new default layout
- [ ] Manual: existing radio with custom layout opens unchanged (schema 7 preserved)
- [ ] Manual: drag right-column DSP/VFO/etc. — width drag is clamped at column 3, vertical drag is free
- [ ] Manual: resize browser window — panels scale vertically with viewport, hero panadapter grows/shrinks to fill