### PR TITLE
feat(panadapter): single tile header with always-on zoom slider

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,8 +8,8 @@
     <!-- Version Management -->
     <!-- When building from a tag (e.g., v0.1.0), GITHUB_REF_NAME will be set -->
     <!-- Otherwise, fall back to the in-development VersionPrefix below.    -->
-    <!-- Bump this when a release branch opens — current target: v0.4.1.    -->
-    <VersionPrefix Condition="'$(VersionPrefix)' == ''">0.4.1</VersionPrefix>
+    <!-- Bump this when a release branch opens — current target: v0.6.0.    -->
+    <VersionPrefix Condition="'$(VersionPrefix)' == ''">0.6.0</VersionPrefix>
     <VersionSuffix Condition="'$(VersionSuffix)' == '' AND '$(GITHUB_REF_TYPE)' != 'tag'">dev</VersionSuffix>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>

--- a/zeus-web/src/components/MobileZoomSlider.tsx
+++ b/zeus-web/src/components/MobileZoomSlider.tsx
@@ -42,7 +42,7 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { setZoom, ZOOM_MAX, ZOOM_MIN, type ZoomLevel } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
 
@@ -50,15 +50,17 @@ import { useConnectionStore } from '../state/connection-store';
  * Vertical zoom slider pinned to the right edge of the panadapter on mobile.
  * Allows zooming without finger-dragging on the spectrum (which tunes frequency).
  * Hidden on desktop via CSS.
+ *
+ * Send-on-change (mirrors ZoomControl): every step of the drag pushes via
+ * setZoom with the previous in-flight POST aborted. Optimistic setLocalZoom
+ * means the thumb stays where the operator put it, even if a touchend lands
+ * outside the input element.
  */
 export function MobileZoomSlider() {
   const serverZoom = useConnectionStore((s) => s.zoomLevel);
   const setLocalZoom = useConnectionStore((s) => s.setZoomLevel);
   const applyState = useConnectionStore((s) => s.applyState);
   const connected = useConnectionStore((s) => s.status === 'Connected');
-
-  const [dragValue, setDragValue] = useState<ZoomLevel | null>(null);
-  const value = dragValue ?? serverZoom;
 
   const inflightAbort = useRef<AbortController | null>(null);
   const latestSent = useRef<ZoomLevel>(serverZoom);
@@ -84,11 +86,6 @@ export function MobileZoomSlider() {
 
   useEffect(() => () => inflightAbort.current?.abort(), []);
 
-  const commit = () => {
-    if (dragValue !== null) sendValue(dragValue);
-    setDragValue(null);
-  };
-
   return (
     <div
       className="mobile-zoom-slider"
@@ -112,12 +109,9 @@ export function MobileZoomSlider() {
         min={ZOOM_MIN}
         max={ZOOM_MAX}
         step={1}
-        value={value}
+        value={serverZoom}
         disabled={!connected}
-        onChange={(e) => setDragValue(Number(e.currentTarget.value) as ZoomLevel)}
-        onMouseUp={commit}
-        onTouchEnd={commit}
-        onKeyUp={commit}
+        onChange={(e) => sendValue(Number(e.currentTarget.value) as ZoomLevel)}
         style={{
           writingMode: 'vertical-lr',
           direction: 'rtl',
@@ -141,7 +135,7 @@ export function MobileZoomSlider() {
           textShadow: '0 0 4px rgba(255, 160, 40, 0.6)',
         }}
       >
-        {value}×
+        {serverZoom}×
       </span>
     </div>
   );

--- a/zeus-web/src/components/ZoomControl.tsx
+++ b/zeus-web/src/components/ZoomControl.tsx
@@ -42,22 +42,26 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { setZoom, ZOOM_MAX, ZOOM_MIN, type ZoomLevel } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
 
 // Compact zoom slider styled as a panel-head chip. Lives in the hero
-// panel header (above the panadapter) so the operator always sees the
-// current zoom level alongside HZ/PX. Uses the same abort-inflight
-// pattern as use-keyboard-shortcuts so rapid drags don't queue POSTs.
+// tile header (above the panadapter) so the operator always sees the
+// current zoom level alongside HZ/PX.
+//
+// Send-on-change (no deferred mouseup commit): every step of the drag
+// pushes via setZoom, with the previous in-flight request aborted so
+// only the final value's echo survives. The optimistic setZoomLevel
+// update means the thumb tracks user intent immediately and isn't
+// yanked back by the next state broadcast — which is what made the
+// old "commit on mouseup" pattern unreliable when the release point
+// missed the input element.
 export function ZoomControl() {
   const serverZoom = useConnectionStore((s) => s.zoomLevel);
   const setLocalZoom = useConnectionStore((s) => s.setZoomLevel);
   const applyState = useConnectionStore((s) => s.applyState);
   const connected = useConnectionStore((s) => s.status === 'Connected');
-
-  const [dragValue, setDragValue] = useState<ZoomLevel | null>(null);
-  const value = dragValue ?? serverZoom;
 
   const inflightAbort = useRef<AbortController | null>(null);
   const latestSent = useRef<ZoomLevel>(serverZoom);
@@ -83,25 +87,29 @@ export function ZoomControl() {
 
   useEffect(() => () => inflightAbort.current?.abort(), []);
 
-  const commit = () => {
-    if (dragValue !== null) sendValue(dragValue);
-    setDragValue(null);
-  };
-
   return (
-    <label className="chip mono" style={{ gap: 6, alignItems: 'center' }}>
-      <span className="k">ZOOM</span>
+    <label
+      className="mono"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        // Blend with the gradient tile header — no chip background / border.
+        background: 'transparent',
+        border: 'none',
+        padding: '0 2px',
+        fontSize: 10,
+      }}
+    >
+      <span className="k" style={{ color: 'var(--fg-2)', fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', fontSize: 9 }}>ZOOM</span>
       <input
         type="range"
         min={ZOOM_MIN}
         max={ZOOM_MAX}
         step={1}
-        value={value}
+        value={serverZoom}
         disabled={!connected}
-        onChange={(e) => setDragValue(Number(e.currentTarget.value) as ZoomLevel)}
-        onMouseUp={commit}
-        onTouchEnd={commit}
-        onKeyUp={commit}
+        onChange={(e) => sendValue(Number(e.currentTarget.value) as ZoomLevel)}
         aria-label="Zoom level"
         style={{
           width: 90,
@@ -110,8 +118,17 @@ export function ZoomControl() {
           margin: 0,
         }}
       />
-      <span className="v" style={{ minWidth: 18, textAlign: 'right' }}>
-        {value}×
+      <span
+        className="v"
+        style={{
+          minWidth: 18,
+          textAlign: 'right',
+          color: 'var(--fg-0)',
+          fontWeight: 700,
+          fontVariantNumeric: 'tabular-nums',
+        }}
+      >
+        {serverZoom}×
       </span>
     </label>
   );

--- a/zeus-web/src/layout/panels.ts
+++ b/zeus-web/src/layout/panels.ts
@@ -134,6 +134,11 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'spectrum',
     tags: ['panadapter', 'waterfall', 'spectrum', 'map'],
     component: HeroPanel,
+    // Headerless: HeroPanel draws its own .workspace-tile-header so the
+    // single strip can host the zoom slider, rotator chips (SP/LP/BEAM),
+    // ⌥ map-mode hint, and HZ/PX readout — instead of stacking those on
+    // top of the default TileChrome (the old "double header").
+    headerless: true,
   },
   vfo: {
     id: 'vfo',

--- a/zeus-web/src/layout/panels/HeroPanel.tsx
+++ b/zeus-web/src/layout/panels/HeroPanel.tsx
@@ -42,26 +42,25 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
+import type { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from 'react';
+import { GripVertical, X } from 'lucide-react';
 import { Panadapter } from '../../components/Panadapter';
 import { Waterfall } from '../../components/Waterfall';
+import { ZoomControl } from '../../components/ZoomControl';
 import { LeafletWorldMap } from '../../components/design/LeafletWorldMap';
 import { LeafletMapErrorBoundary } from '../../components/design/LeafletMapErrorBoundary';
 import { useConnectionStore } from '../../state/connection-store';
 import { useRotatorStore } from '../../state/rotator-store';
-import { useDisplayStore } from '../../state/display-store';
 import { useWorkspace } from '../WorkspaceContext';
 
-function useDisplayHzPerPixel(): string {
-  const v = useDisplayStore((s) => s.hzPerPixel);
-  if (!Number.isFinite(v) || v <= 0) return '—';
-  return v >= 1 ? `${v.toFixed(1)} Hz` : `${(v * 1000).toFixed(0)} mHz`;
-}
-
 // Hero panel: Panadapter + Waterfall with optional Leaflet world-map overlay.
-// Rendered inside a flexlayout tabset — the panel-head chrome is intentionally
-// kept here for Phase 1 so beam controls stay accessible. Phase 2+ can move
-// beam controls to flexlayout's onRenderTabSet header slot.
-export function HeroPanel() {
+// Registered as headerless in panels.ts — this component owns the single
+// .workspace-tile-header strip. The strip carries the RGL drag handle, the
+// zoom slider, rotator chips (SP/LP/BEAM) when terminator+contact are live,
+// the ⌥ map-mode hint, the HZ/PX readout, and the close X. Interactive
+// controls inside stop mousedown propagation so a click on a chip / slider /
+// input doesn't initiate a tile drag (mirrors the MetersPanel pattern).
+export function HeroPanel({ onRemove }: { onRemove?: () => void } = {}) {
   const {
     terminatorActive,
     imageMode,
@@ -86,7 +85,6 @@ export function HeroPanel() {
     submitBeam,
   } = useWorkspace();
   const connected = useConnectionStore((s) => s.status === 'Connected');
-  const hzPerPixel = useDisplayHzPerPixel();
 
   const handleRotateToBearing = (brg: number) => {
     const rot = useRotatorStore.getState();
@@ -98,74 +96,107 @@ export function HeroPanel() {
     }
   };
 
+  // Stop pointerdown/mousedown bubbling so RGL doesn't treat a click on
+  // the zoom slider, an SP/LP chip, the BEAM input, or the close X as a
+  // tile-drag start. The .workspace-tile-header strip itself stays the
+  // drag handle.
+  const stopDrag = (e: ReactPointerEvent | ReactMouseEvent) => e.stopPropagation();
+
   return (
     <div
-      className={`panel hero ${bgActive ? 'bg-active' : ''} ${mapInteractive ? 'map-mode' : ''}`}
+      className={`hero ${bgActive ? 'bg-active' : ''} ${mapInteractive ? 'map-mode' : ''}`}
       style={{ display: 'flex', flexDirection: 'column', height: '100%' }}
     >
-      <div className="panel-head">
-        <span className={`dot ${moxOn || tunOn ? 'tx' : 'on'}`} />
-        <span className="title">{heroTitle}</span>
-        <span className="spacer" style={{ flex: 1 }} />
-        {terminatorActive && contact && mapAvailable && (
-          <>
-            <button
-              type="button"
-              className="chip mono"
-              onClick={() => handleRotateToBearing(sp)}
-              title="Short path — click to rotate"
-            >
-              <span className="k">SP</span>
-              <span className="v">{sp.toFixed(0)}°</span>
-            </button>
-            <button
-              type="button"
-              className="chip mono"
-              onClick={() => handleRotateToBearing(lp)}
-              title="Long path — click to rotate"
-            >
-              <span className="k">LP</span>
-              <span className="v">{lp.toFixed(0)}°</span>
-            </button>
-            <form onSubmit={submitBeam} className="chip mono" style={{ gap: 4 }}>
-              <span className="k">BEAM</span>
-              <input
-                type="text"
-                inputMode="decimal"
-                value={beamInputStr}
-                onChange={(e) => setBeamInputStr(e.target.value)}
-                placeholder={(((rotLiveAz ?? beamOverrideDeg ?? sp) % 360 + 360) % 360).toFixed(0)}
-                style={{
-                  width: 40,
-                  background: 'transparent',
-                  border: '1px solid var(--line)',
-                  color: 'inherit',
-                  fontFamily: 'inherit',
-                  fontSize: 'inherit',
-                  padding: '0 2px',
-                }}
-              />
-              <button type="submit" className="btn sm" style={{ padding: '0 6px' }}>
-                Go
-              </button>
-            </form>
-          </>
-        )}
-        {terminatorActive && mapAvailable && (
-          <span
-            className={`chip mono ${mapInteractive ? 'accent' : ''}`}
-            title="Hold ⌥ (Alt) to zoom and pan the map (click-to-tune paused)"
-          >
-            <span className="k">⌥</span>
-            <span className="v">+ −</span>
-          </span>
-        )}
-        <span className="chip mono">
-          <span className="k">HZ/PX</span>
-          <span className="v">{hzPerPixel}</span>
+      <div className="workspace-tile-header hero-tile-header">
+        <span
+          className="workspace-tile-drag-handle"
+          aria-hidden="true"
+          title="Drag to reposition"
+        >
+          <GripVertical size={12} />
         </span>
+        <span className={`dot ${moxOn || tunOn ? 'tx' : 'on'}`} />
+        <span className="workspace-tile-title" title={typeof heroTitle === 'string' ? heroTitle : undefined}>
+          {heroTitle}
+        </span>
+        <div
+          className="hero-tile-controls"
+          onPointerDown={stopDrag}
+          onMouseDown={stopDrag}
+        >
+          <ZoomControl />
+          {terminatorActive && contact && mapAvailable && (
+            <>
+              <button
+                type="button"
+                className="chip mono"
+                onClick={() => handleRotateToBearing(sp)}
+                title="Short path — click to rotate"
+              >
+                <span className="k">SP</span>
+                <span className="v">{sp.toFixed(0)}°</span>
+              </button>
+              <button
+                type="button"
+                className="chip mono"
+                onClick={() => handleRotateToBearing(lp)}
+                title="Long path — click to rotate"
+              >
+                <span className="k">LP</span>
+                <span className="v">{lp.toFixed(0)}°</span>
+              </button>
+              <form onSubmit={submitBeam} className="chip mono" style={{ gap: 4 }}>
+                <span className="k">BEAM</span>
+                <input
+                  type="text"
+                  inputMode="decimal"
+                  value={beamInputStr}
+                  onChange={(e) => setBeamInputStr(e.target.value)}
+                  placeholder={(((rotLiveAz ?? beamOverrideDeg ?? sp) % 360 + 360) % 360).toFixed(0)}
+                  style={{
+                    width: 40,
+                    background: 'transparent',
+                    border: '1px solid var(--line)',
+                    color: 'inherit',
+                    fontFamily: 'inherit',
+                    fontSize: 'inherit',
+                    padding: '0 2px',
+                  }}
+                />
+                <button type="submit" className="btn sm" style={{ padding: '0 6px' }}>
+                  Go
+                </button>
+              </form>
+            </>
+          )}
+          {terminatorActive && mapAvailable && (
+            <span
+              className={`chip mono ${mapInteractive ? 'accent' : ''}`}
+              title="Hold ⌥ (Alt) to zoom and pan the map (click-to-tune paused)"
+            >
+              <span className="k">⌥</span>
+              <span className="v">+ −</span>
+            </span>
+          )}
+        </div>
+        {onRemove ? (
+          <button
+            type="button"
+            className="workspace-tile-close"
+            aria-label="Remove panel"
+            title="Remove panel"
+            onClick={(e) => {
+              e.stopPropagation();
+              onRemove();
+            }}
+            onPointerDown={(e) => e.stopPropagation()}
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            <X size={12} />
+          </button>
+        ) : null}
       </div>
-      <div className="panel-body hero-body" style={{ flex: 1, position: 'relative' }}>
+      <div className="hero-body" style={{ flex: 1, position: 'relative' }}>
         {imageMode && (
           <div
             className={`image-layer ${backgroundImageFit}`}

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -734,7 +734,26 @@
 
 /* ===== Spectrum + waterfall ===== */
 .hero { height: 100%; }
-.hero-body { position: relative; height: calc(100% - 32px); }
+/* hero-body sizes via the parent flex column (flex:1, min-height:0) — no
+ * fixed height calc, so the body always fills whatever vertical space
+ * remains after the workspace-tile-header strip. */
+.hero-body { position: relative; min-height: 0; }
+
+/* Hero owns its workspace-tile-header (panels.ts: hero.headerless = true)
+ * — the strip carries the zoom slider, rotator chips, ⌥ hint, HZ/PX, and
+ * close X alongside the drag grip + title. The controls cluster sits on
+ * the right; the title (flex:1) ellipsises before the cluster, so a
+ * narrow tile loses the title text first, not the controls. */
+.hero-tile-header .dot { flex-shrink: 0; }
+.hero-tile-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  /* Default cursor inside the controls — the surrounding header is the
+   * grab handle, but a chip / slider / input shouldn't show grab. */
+  cursor: default;
+}
 .spectrum-wrap {
   position: relative;
   width: 100%;


### PR DESCRIPTION
## Summary
- Hero panel becomes headerless and owns one `workspace-tile-header` strip — drag grip, status dot, title, zoom slider, rotor chips (SP / LP / BEAM, gated on terminator + contact), ⌥ map-mode hint, close X. Removes the previous double header (TileChrome + inner panel-head) and brings back the 0.5.0 zoom slider that disappeared in the all-flex default workspace.
- Zoom slider sends on every `onChange` (with abort-inflight) instead of deferring to mouseup/touchend/keyup. The old commit pattern silently dropped values when the release event landed outside the input element. Same fix applied to `MobileZoomSlider` for parity.
- Drops the HZ/PX readout and the chip background on the zoom control so the slider blends with the gradient strip.

## Test plan
- [x] `tsc -p tsconfig.app.json --noEmit` clean
- [x] `vitest run` — 204/204 pass
- [ ] Verify on a connected radio: drag zoom from min→max and back, confirm thumb tracks immediately and final value commits regardless of where the pointer is released
- [ ] Verify rotor chips appear when QRZ contact + terminator + map are active, and SP/LP click rotates the array as before