### PR TITLE
fix(audio): widen mic-uplink AudioWorklet buffer to absorb Firefox renderer bursts

### DIFF
--- a/zeus-web/src/audio/mic-uplink.ts
+++ b/zeus-web/src/audio/mic-uplink.ts
@@ -81,7 +81,7 @@ export async function startMicUplink(
     throw new Error('getUserMedia not available in this environment');
   }
   const stream = await navigator.mediaDevices.getUserMedia(MIC_CONSTRAINTS);
-  const context = new AudioContext({ sampleRate: 48000, latencyHint: 'interactive' });
+  const context = new AudioContext({ sampleRate: 48000, latencyHint: 0.04 });
 
   const cleanupStream = () => {
     for (const t of stream.getTracks()) {


### PR DESCRIPTION
Fixes #268.

## Summary

One-line change. `zeus-web/src/audio/mic-uplink.ts:84` — `latencyHint: 'interactive'` → `latencyHint: 0.04`.

## Why

Under Firefox, the mic-side AudioWorklet runs in the same content process as the panadapter / waterfall / meters / VFO. When that process spikes to 80-97% CPU (which it does often, every ~10 s), the worklet thread misses block deadlines. Firefox fills the gap with zeros or repeats the last block; over the air the listener hears "digital robot" or "cuts in and out."

Reproduced cross-platform Firefox: Linux 2026-05-05 evening, Mac mini M4 Pro 2026-05-06. Same Zeus build, same symptom.

Full diagnostic write-up (with all the suspects we ruled out — CFC, PureSignal, panadapter, mic clip) is in #268.

## Trade-off

- **+20-30 ms mic-to-RF latency** — invisible on SSB voice
- **CW operators may want low-latency back** — see follow-up suggestion in #268 about making this user-configurable. This PR just changes the default; doesn't add a config UI.

## Test plan

- [x] Build the frontend (`npm --prefix zeus-web run build`) — clean
- [x] On Mac mini M4 Pro, Firefox: TX a 30 s recording, listened back via OTA monitor — **clean** (no robot, no cut-out). Tested with CFC on AND off, renderer still spiking to 90%+.
- [ ] @brianbruff please double-check on your Linux+Firefox setup before merging. If you can also test Chrome (which probably doesn't need this) to confirm there's no regression there.

## Maintainer review needed (red-light per CLAUDE.md)

This is an operator-visible audio default change. Per CLAUDE.md autonomous-agent rules I am not merging this — your call. Filed for visibility and as the candidate fix.

73, KB2UKA