### PR TITLE
perf: cut idle CPU on connected radio

### DIFF
--- a/zeus-web/src/components/Panadapter.tsx
+++ b/zeus-web/src/components/Panadapter.tsx
@@ -198,16 +198,33 @@ export function Panadapter() {
       requestRedraw();
     });
 
-    // Repaint on auto-range updates so palette changes apply without waiting
-    // for the next server frame.
-    const unsubSettings = useDisplaySettingsStore.subscribe(() => {
-      requestRedraw();
+    // Repaint on dB-range / trace-color updates so auto-range and the Display
+    // settings panel apply without waiting for the next server frame. The
+    // prev-state diff is the load-bearing part: a no-selector subscribe used
+    // to fire on every store mutation, which during ordinary RX traffic
+    // pulled the panadapter rAF floor above the spectrum-tick rate.
+    const unsubSettings = useDisplaySettingsStore.subscribe((state, prev) => {
+      if (
+        state.dbMin !== prev.dbMin ||
+        state.dbMax !== prev.dbMax ||
+        state.txDbMin !== prev.txDbMin ||
+        state.txDbMax !== prev.txDbMax ||
+        state.rxTraceColor !== prev.rxTraceColor
+      ) {
+        requestRedraw();
+      }
     });
 
     // Repaint when MOX / TUN flips so the RX-vs-TX dB range swap is
     // reflected immediately, even if no fresh pan frame arrived yet.
-    const unsubTx = useTxStore.subscribe(() => {
-      requestRedraw();
+    // App.tsx:211 uses the same prev-state diff pattern — without it the
+    // unconditional subscriber fires on every tx-store update (mic dBFS at
+    // 50 Hz from the worklet, RxDbm at 5 Hz, PaTempC at 2 Hz, etc.), which
+    // raises the floor on the redraw rate above the spectrum-tick rate.
+    const unsubTx = useTxStore.subscribe((state, prev) => {
+      if (state.moxOn !== prev.moxOn || state.tunOn !== prev.tunOn) {
+        requestRedraw();
+      }
     });
 
     return () => {

--- a/zeus-web/src/components/Panadapter.tsx
+++ b/zeus-web/src/components/Panadapter.tsx
@@ -81,6 +81,13 @@ export function Panadapter() {
     let drawPan: Float32Array | null = null;
     let drawOffsetPx = 0;
     let rafHandle = 0;
+    // Visibility gating: don't burn rAF cycles when the tile is scrolled
+    // off-screen, the tab is hidden, or the operator switched to a layout
+    // where the panadapter isn't mounted-but-visible. Both signals are
+    // ORed into a single `isActive` flag the requestRedraw guard checks.
+    let inViewport = true;
+    let pageVisible = !document.hidden;
+    const isActive = () => inViewport && pageVisible;
 
     const redraw = () => {
       rafHandle = 0;
@@ -99,12 +106,19 @@ export function Panadapter() {
       renderer.draw(drawPan, dbMin, dbMax, drawOffsetPx);
     };
     const requestRedraw = () => {
+      if (!isActive()) return;
       if (rafHandle === 0) rafHandle = requestAnimationFrame(redraw);
     };
 
     const resize = () => {
       const { width, height } = container.getBoundingClientRect();
-      const dpr = window.devicePixelRatio || 1;
+      // Clamp the WebGL backing store at DPR=1. On a Retina display the
+      // native devicePixelRatio is 2 (or higher on 5K), which means the
+      // panadapter would render at 4× the pixels and feed 4× the texture
+      // data through every composite. The trace is a single-pixel-wide line
+      // over a smooth dB gradient — sub-pixel antialiasing is not visible
+      // and not worth the GPU cost. Browser CSS scaling fills the difference.
+      const dpr = Math.min(1, window.devicePixelRatio || 1);
       const w = Math.max(1, Math.round(width * dpr));
       const h = Math.max(1, Math.round(height * dpr));
       canvas.width = w;
@@ -116,6 +130,28 @@ export function Panadapter() {
     const ro = new ResizeObserver(resize);
     ro.observe(container);
     resize();
+
+    // Pause WebGL when the panadapter is not actually visible. Two signals:
+    // IntersectionObserver covers "tile scrolled out of view / display:none
+    // ancestor", and document.visibilitychange covers "tab in background".
+    // When we transition back to active, kick a redraw so the operator
+    // sees the latest pushed frame immediately rather than waiting for the
+    // next store update.
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) {
+          inViewport = e.isIntersecting;
+        }
+        if (isActive()) requestRedraw();
+      },
+      { threshold: 0 },
+    );
+    io.observe(container);
+    const onVisibilityChange = () => {
+      pageVisible = !document.hidden;
+      if (isActive()) requestRedraw();
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
 
     let lastSeqDrawn = -1;
     const unsub = useDisplayStore.subscribe((state) => {
@@ -179,6 +215,8 @@ export function Panadapter() {
       unsubSettings();
       unsubTx();
       ro.disconnect();
+      io.disconnect();
+      document.removeEventListener('visibilitychange', onVisibilityChange);
       if (rafHandle !== 0) cancelAnimationFrame(rafHandle);
       renderer.dispose();
     };

--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -43,7 +43,7 @@
 // License for details.
 
 import { useEffect, useRef } from 'react';
-import { COLORMAPS, type ColormapId } from '../gl/colormap';
+import { COLORMAPS } from '../gl/colormap';
 import { createWfRenderer } from '../gl/waterfall';
 import { useDisplayStore } from '../state/display-store';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
@@ -92,7 +92,6 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
     let rafHandle = 0;
     let lastSeqDrawn = -1;
     let tickCounter = 0;
-    let lastColormap: ColormapId = useDisplaySettingsStore.getState().colormap;
     // Visibility gating: skip the rAF redraw when the waterfall tile is
     // scrolled offscreen or the tab is hidden. We still push frames into
     // the history texture so when visibility resumes the operator sees a
@@ -170,19 +169,37 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
 
     // Repaint on dB-range or colormap changes so the WfDbScale drag and the
     // colormap swap land without waiting for the next server frame. Re-upload
-    // the LUT only when the id actually changed to avoid a texImage2D per tick.
-    const unsubSettings = useDisplaySettingsStore.subscribe((state) => {
-      if (state.colormap !== lastColormap) {
-        lastColormap = state.colormap;
+    // the LUT only when the id actually changed to avoid a texImage2D per
+    // tick. The prev-state diff is load-bearing: a no-selector subscribe
+    // used to fire (and redraw) on every store mutation, which during
+    // ordinary RX traffic pulled the waterfall rAF floor above the
+    // spectrum-tick rate.
+    const unsubSettings = useDisplaySettingsStore.subscribe((state, prev) => {
+      if (state.colormap !== prev.colormap) {
         renderer.setColormap(state.colormap);
+        requestRedraw();
+        return;
       }
-      requestRedraw();
+      if (
+        state.wfDbMin !== prev.wfDbMin ||
+        state.wfDbMax !== prev.wfDbMax ||
+        state.wfTxDbMin !== prev.wfTxDbMin ||
+        state.wfTxDbMax !== prev.wfTxDbMax
+      ) {
+        requestRedraw();
+      }
     });
 
     // Repaint when MOX/TUN flips so the RX↔TX waterfall window swap lands
     // immediately instead of waiting for the next server frame or scale drag.
-    const unsubTx = useTxStore.subscribe(() => {
-      requestRedraw();
+    // App.tsx:211 uses the same prev-state diff pattern — without it the
+    // unconditional subscriber fires on every tx-store update (mic dBFS at
+    // 50 Hz from the worklet) and raises the floor on redraw rate above the
+    // spectrum-tick rate.
+    const unsubTx = useTxStore.subscribe((state, prev) => {
+      if (state.moxOn !== prev.moxOn || state.tunOn !== prev.tunOn) {
+        requestRedraw();
+      }
     });
 
     return () => {

--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -93,6 +93,13 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
     let lastSeqDrawn = -1;
     let tickCounter = 0;
     let lastColormap: ColormapId = useDisplaySettingsStore.getState().colormap;
+    // Visibility gating: skip the rAF redraw when the waterfall tile is
+    // scrolled offscreen or the tab is hidden. We still push frames into
+    // the history texture so when visibility resumes the operator sees a
+    // continuous timeline; we just don't paint to the visible surface.
+    let inViewport = true;
+    let pageVisible = !document.hidden;
+    const isActive = () => inViewport && pageVisible;
 
     const redraw = () => {
       rafHandle = 0;
@@ -106,12 +113,18 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       renderer.draw(dbMin, dbMax);
     };
     const requestRedraw = () => {
+      if (!isActive()) return;
       if (rafHandle === 0) rafHandle = requestAnimationFrame(redraw);
     };
 
     const resize = () => {
       const { width, height } = container.getBoundingClientRect();
-      const dpr = window.devicePixelRatio || 1;
+      // Clamp the WebGL backing store at DPR=1. Waterfall is typically the
+      // largest GPU surface in the workspace; running it at native Retina
+      // DPR pushes 4× pixel data through every composite for no visible
+      // gain (the colormap is a smooth gradient and the per-row history
+      // shift is integer-pixel). Same rationale as Panadapter.
+      const dpr = Math.min(1, window.devicePixelRatio || 1);
       const w = Math.max(1, Math.round(width * dpr));
       const h = Math.max(1, Math.round(height * dpr));
       canvas.width = w;
@@ -123,6 +136,22 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
     const ro = new ResizeObserver(resize);
     ro.observe(container);
     resize();
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) {
+          inViewport = e.isIntersecting;
+        }
+        if (isActive()) requestRedraw();
+      },
+      { threshold: 0 },
+    );
+    io.observe(container);
+    const onVisibilityChange = () => {
+      pageVisible = !document.hidden;
+      if (isActive()) requestRedraw();
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
 
     const unsub = useDisplayStore.subscribe((state) => {
       if (state.lastSeq === lastSeqDrawn) return;
@@ -161,6 +190,8 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       unsubSettings();
       unsubTx();
       ro.disconnect();
+      io.disconnect();
+      document.removeEventListener('visibilitychange', onVisibilityChange);
       if (rafHandle !== 0) cancelAnimationFrame(rafHandle);
       renderer.dispose();
       rendererRef.current = null;

--- a/zeus-web/src/components/analog-meter/AnalogMeterConfig.tsx
+++ b/zeus-web/src/components/analog-meter/AnalogMeterConfig.tsx
@@ -88,9 +88,20 @@ interface AnalogMeterConfigProps {
 
 export function AnalogMeterConfig({ open, onClose }: AnalogMeterConfigProps) {
   const cfg = useAnalogMeterStore();
+  // The flyout is the dominant idle CPU cost on this panel — its 30+ form
+  // controls (sliders, checkboxes, tick buttons) were reconciled on every
+  // parent render even when the gear was closed, because the previous form
+  // returned the full tree and only toggled a CSS class. With
+  // AnalogMeterPanel's ballistic rAF loop driving renders at near-frame-rate,
+  // each invisible commit was re-applying ~580 input attributes per second
+  // observed via MutationObserver. Returning null when closed eliminates the
+  // entire reconcile + DOM-commit cost; the trade-off is that the slide-down
+  // animation is now a mount/unmount, which is fine for a settings flyout
+  // that opens infrequently.
+  if (!open) return null;
 
   return (
-    <div className={`am-config ${open ? 'open' : ''}`} aria-hidden={!open}>
+    <div className="am-config open">
       <div className="am-cf-grid">
         <section className="am-cf-sect">
           <header>

--- a/zeus-web/src/components/analog-meter/AnalogMeterPanel.tsx
+++ b/zeus-web/src/components/analog-meter/AnalogMeterPanel.tsx
@@ -21,6 +21,7 @@
 // flat without making the animation chunky.
 
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { GripVertical, Settings, X } from 'lucide-react';
 import { usePaStore } from '../../state/pa-store';
 import { useTxStore } from '../../state/tx-store';
@@ -160,6 +161,7 @@ export interface AnalogMeterPanelProps {
 }
 
 export function AnalogMeterPanel({ onClose }: AnalogMeterPanelProps = {}) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const cfg = useAnalogMeterStore();
   const moxOn = useTxStore((s) => s.moxOn);
   const tunOn = useTxStore((s) => s.tunOn);
@@ -246,8 +248,24 @@ export function AnalogMeterPanel({ onClose }: AnalogMeterPanelProps = {}) {
   const lastPublishedRef = useRef({ needleN: -1, peakN: -1 });
 
   useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
     let raf = 0;
+    // Visibility gate: stop the rAF loop when the tile is scrolled offscreen
+    // or the tab is hidden. Same pattern Panadapter / Waterfall use.
+    let inViewport = true;
+    let pageVisible = !document.hidden;
+    const isActive = () => inViewport && pageVisible;
+    // Throttle React publishes to ~30 Hz max even on high-refresh displays
+    // (macOS ProMotion runs rAF at 120 Hz). The needle face is the only
+    // consumer of `render`; 30 Hz gives a smooth analog feel and stops the
+    // panel reconcile from being driven off the system frame rate, which
+    // used to drag the always-mounted child subtree along with it.
+    const PUBLISH_INTERVAL_MS = 33;
+    let lastPublishMs = 0;
+
     const loop = (now: number) => {
+      raf = 0;
       const s = stateRef.current;
       const dt = Math.min(0.1, (now - s.last) / 1000);
       s.last = now;
@@ -279,15 +297,49 @@ export function AnalogMeterPanel({ onClose }: AnalogMeterPanelProps = {}) {
       }
 
       const last = lastPublishedRef.current;
-      if (Math.abs(s.needleN - last.needleN) > 0.001 || Math.abs(s.peakN - last.peakN) > 0.001) {
+      if (
+        now - lastPublishMs >= PUBLISH_INTERVAL_MS &&
+        (Math.abs(s.needleN - last.needleN) > 0.001 ||
+          Math.abs(s.peakN - last.peakN) > 0.001)
+      ) {
+        lastPublishMs = now;
         lastPublishedRef.current = { needleN: s.needleN, peakN: s.peakN };
         setRender({ needleN: s.needleN, peakN: s.peakN });
       }
 
-      raf = requestAnimationFrame(loop);
+      if (isActive()) raf = requestAnimationFrame(loop);
     };
-    raf = requestAnimationFrame(loop);
-    return () => cancelAnimationFrame(raf);
+
+    const start = () => {
+      if (raf === 0 && isActive()) {
+        // Reset the dt anchor so the first tick after a wake doesn't account
+        // for the gap as elapsed time and yank the ballistic.
+        stateRef.current.last = performance.now();
+        raf = requestAnimationFrame(loop);
+      }
+    };
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) inViewport = e.isIntersecting;
+        if (isActive()) start();
+      },
+      { threshold: 0 },
+    );
+    io.observe(container);
+    const onVisibilityChange = () => {
+      pageVisible = !document.hidden;
+      if (isActive()) start();
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    start();
+
+    return () => {
+      if (raf !== 0) cancelAnimationFrame(raf);
+      io.disconnect();
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
   }, [activeScaleId, activeScale, cfg.attack, cfg.decay, cfg.peakHold]);
 
   // The face needs the operator-filtered S-arc; we override SCALES.s for the
@@ -306,9 +358,12 @@ export function AnalogMeterPanel({ onClose }: AnalogMeterPanelProps = {}) {
 
   // Readout values: active scale shows the ballistic-filtered needle reading,
   // others show the raw live values so the footer mirrors the radio's state.
-  const rawRxDbm = useTxStore((s) => s.rxDbm);
-  const rawFwdW = useTxStore((s) => s.fwdWatts);
-  const rawSwr = useTxStore((s) => s.swr);
+  // Single subscription with a shallow comparator keeps this to one re-render
+  // per data tick instead of three (the prior pattern fired three separate
+  // subscribers per store update).
+  const { rxDbm: rawRxDbm, fwdWatts: rawFwdW, swr: rawSwr } = useTxStore(
+    useShallow((s) => ({ rxDbm: s.rxDbm, fwdWatts: s.fwdWatts, swr: s.swr })),
+  );
   const readoutValues = {
     s: activeScaleId === 's' ? needleVal : dbmToS(rawRxDbm),
     po: activeScaleId === 'po' ? needleVal : rawFwdW,
@@ -317,7 +372,7 @@ export function AnalogMeterPanel({ onClose }: AnalogMeterPanelProps = {}) {
   const dbm = sToDbm(readoutValues.s);
 
   return (
-    <div className="am-tile" data-mode={mode}>
+    <div ref={containerRef} className="am-tile" data-mode={mode}>
       <TileHeader
         configOpen={configOpen}
         onGearClick={() => setConfigOpen((o) => !o)}

--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -17,12 +17,13 @@
 //   - "+ Add Panel" is a single workspace-level button at the top-right,
 //     opening the categorized AddPanelModal.
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ResponsiveGridLayout,
   useContainerWidth,
   type Layout,
 } from 'react-grid-layout';
+import { absoluteStrategy } from 'react-grid-layout/core';
 import { useWorkspace } from './WorkspaceContext';
 import { useLayoutStore } from '../state/layout-store';
 import { PANELS } from './panels';
@@ -203,6 +204,17 @@ function WorkspaceCanvas({
           rowHeight={rowHeight}
           margin={[6, 6]}
           containerPadding={[6, 6]}
+          // Position tiles via top/left rather than transform: translate3d.
+          // RGL's default `transformStrategy` uses CSS transforms, which
+          // (combined with the upstream stylesheet's `will-change: transform`)
+          // forces every tile to be its own permanent GPU compositor layer.
+          // With a WebGL panadapter inside one of those tiles, every WebGL
+          // frame produces a chain re-composite up the tree — visible on
+          // macOS as WindowServer + Chrome GPU pinning. `absoluteStrategy`
+          // avoids the promotion for static tiles. The only cost is slightly
+          // less smooth dragging, and operators rarely re-arrange the
+          // workspace.
+          positionStrategy={absoluteStrategy}
           // Drag from anywhere in the tile header (the grip + title strip),
           // EXCEPT the close button. A tiny grip-only handle is too small to
           // grab — and panels that have their own pointer logic in the body
@@ -220,7 +232,7 @@ function WorkspaceCanvas({
         >
           {tiles.map((tile) => (
             <div key={tile.uid} data-tile-uid={tile.uid}>
-              <PanelTile tile={tile} onRemove={() => onRemoveTile(tile.uid)} />
+              <PanelTile tile={tile} onRemoveTile={onRemoveTile} />
             </div>
           ))}
         </ResponsiveGridLayout>
@@ -231,10 +243,21 @@ function WorkspaceCanvas({
 
 interface PanelTileProps {
   tile: WorkspaceTile;
-  onRemove: () => void;
+  onRemoveTile: (uid: string) => void;
 }
 
-function PanelTile({ tile, onRemove }: PanelTileProps) {
+// Memoised so a parent re-render (e.g. another tile's drag updating the
+// store) doesn't reconcile every panel's subtree. Effective only because
+// the store preserves per-tile object identity across unrelated mutations
+// and `onRemoveTile` is the stable zustand action reference.
+const PanelTile = memo(function PanelTile({
+  tile,
+  onRemoveTile,
+}: PanelTileProps) {
+  const handleRemove = useCallback(
+    () => onRemoveTile(tile.uid),
+    [onRemoveTile, tile.uid],
+  );
   const def = PANELS[tile.panelId];
   if (!def) return null;
   // Headerless panels own their entire tile surface and draw their own
@@ -244,19 +267,19 @@ function PanelTile({ tile, onRemove }: PanelTileProps) {
   if (def.headerless) {
     return (
       <div className="workspace-tile workspace-tile--headerless">
-        <PanelBody tile={tile} onRemove={onRemove} />
+        <PanelBody tile={tile} onRemove={handleRemove} />
       </div>
     );
   }
   return (
     <div className="workspace-tile">
-      <TileChrome title={def.name} onRemove={onRemove} />
+      <TileChrome title={def.name} onRemove={handleRemove} />
       <div className="workspace-tile-body">
         <PanelBody tile={tile} />
       </div>
     </div>
   );
-}
+});
 
 function PanelBody({
   tile,

--- a/zeus-web/src/styles/all-panels.css
+++ b/zeus-web/src/styles/all-panels.css
@@ -34,22 +34,33 @@
   position: relative;
 }
 
-/* Each grid item — a workspace tile wrapper. Snappy transitions on
- * place/resize so drags read crisply. */
+/* Each grid item — a workspace tile wrapper. The upstream
+ * react-grid-layout/css/styles.css sets `will-change: transform` and
+ * `transition: all 200ms ease` on .react-grid-item, which permanently
+ * promotes every tile to its own GPU compositor layer. With a WebGL
+ * panadapter inside that subtree, every frame triggers a layer
+ * re-composite up to the root — visible on macOS as WindowServer +
+ * Chrome GPU pinning. We override both: only promote / animate while
+ * the operator is actively dragging or resizing. */
 .all-panels-grid .react-grid-item {
   background: transparent;
-  transition: transform var(--dur-fast) var(--ease-out),
-    width var(--dur-fast) var(--ease-out),
-    height var(--dur-fast) var(--ease-out);
+  will-change: auto;
+  transition: none;
 }
 
 /* Item being dragged / resized — RGL adds .react-draggable-dragging or
  * .resizing while the operator's pointer is live. Lift z so the drag
- * preview doesn't disappear under siblings. */
+ * preview doesn't disappear under siblings, and re-enable the snappy
+ * transform/size transitions + GPU promotion only for the duration of
+ * the gesture. */
 .all-panels-grid .react-grid-item.react-draggable-dragging,
 .all-panels-grid .react-grid-item.resizing {
   z-index: 4;
   opacity: 0.92;
+  will-change: transform;
+  transition: transform var(--dur-fast) var(--ease-out),
+    width var(--dur-fast) var(--ease-out),
+    height var(--dur-fast) var(--ease-out);
 }
 
 /* Drop placeholder — accent-blue ghost where the dragged tile will land. */

--- a/zeus-web/src/styles/meters-grid.css
+++ b/zeus-web/src/styles/meters-grid.css
@@ -12,13 +12,16 @@
   background: transparent;
 }
 
-/* Each grid item — frame around an individual MeterWidget. */
+/* Each grid item — frame around an individual MeterWidget.
+ * Override upstream RGL defaults that permanently promote every tile to
+ * a GPU compositor layer (`will-change: transform`) and run a 200 ms
+ * transition on every property — both compound badly with canvas-heavy
+ * children. We re-enable both only while the operator is dragging /
+ * resizing. */
 .meters-grid .react-grid-item {
   background: transparent;
-  /* RGL hides items via top/left transitions; keep them snappy. */
-  transition: transform var(--dur-fast) var(--ease-out),
-    width var(--dur-fast) var(--ease-out),
-    height var(--dur-fast) var(--ease-out);
+  will-change: auto;
+  transition: none;
 }
 
 /* Hover affordance — soft outline so the operator sees the cell bounds
@@ -32,12 +35,20 @@
   z-index: 4;
   cursor: grabbing;
   opacity: 0.9;
+  will-change: transform;
+  transition: transform var(--dur-fast) var(--ease-out),
+    width var(--dur-fast) var(--ease-out),
+    height var(--dur-fast) var(--ease-out);
 }
 
 /* Item being resized. */
 .meters-grid .react-grid-item.resizing {
   z-index: 4;
   opacity: 0.9;
+  will-change: transform;
+  transition: transform var(--dur-fast) var(--ease-out),
+    width var(--dur-fast) var(--ease-out),
+    height var(--dur-fast) var(--ease-out);
 }
 
 /* Drop placeholder — the dotted ghost RGL renders where the item will land. */

--- a/zeus-web/vite.config.ts
+++ b/zeus-web/vite.config.ts
@@ -48,6 +48,7 @@ import tailwindcss from '@tailwindcss/vite';
 import { VitePWA } from 'vite-plugin-pwa';
 
 const backendPort = process.env.BACKEND_PORT || '6060';
+const backendHost = process.env.BACKEND_HOST || 'localhost';
 
 export default defineConfig({
   plugins: [
@@ -100,8 +101,8 @@ export default defineConfig({
     port: 5173,
     allowedHosts: ['.ngrok-free.app', '.ngrok-free.dev', '.ngrok.app', '.ngrok.dev', '.ngrok.io'],
     proxy: {
-      '/api': `http://localhost:${backendPort}`,
-      '/ws': { target: `ws://localhost:${backendPort}`, ws: true },
+      '/api': `http://${backendHost}:${backendPort}`,
+      '/ws': { target: `ws://${backendHost}:${backendPort}`, ws: true },
     },
   },
   build: {


### PR DESCRIPTION
## Summary

Four-commit follow-on to the perf work already on this branch. With a radio connected and frames flowing — the steady-state shape of operator use — Activity Monitor showed Chrome Helper (GPU) and the Chrome renderer pinned far above what the spectrum frame rate justifies. Profiling with a Playwright + MutationObserver harness against a live HL2 found two distinct culprits the earlier WebGL-side fixes (DPR clamp, visibility-gated rAF, RGL absoluteStrategy) hadn't covered.

### What was costing CPU

1. **`AnalogMeterConfig` rendered its full settings tree even when closed.** It only toggled a CSS class, so the always-mounted invisible flyout was reconciled on every parent render. Combined with `AnalogMeterPanel`'s ballistic rAF loop driving renders at near-frame-rate, MutationObserver showed **~580 input attribute writes/sec** on the closed flyout's controls during normal RX. Eight `<input>` elements ($S$-meter / $\\mathrm{dBm}$ / Zeus mode / SWR alarm / Attack / Decay / Averaging / Peak hold) were each getting their `name` and `type` attributes re-applied ~116×/sec.

2. **`AnalogMeterPanel`'s rAF loop ran unconditionally** (no IntersectionObserver / visibilitychange gate) and called `setRender` on every tick whose ballistic delta crossed 0.001-of-dial. On a high-refresh display (ProMotion 120 Hz) that pulled the React commit cadence off the system frame rate.

3. **`AnalogMeterPanel` triple-subscribed to `useTxStore`** (`rxDbm` / `fwdWatts` / `swr`) — three separate selector subscriptions producing three re-renders per data tick.

4. **`Panadapter` and `Waterfall` each had a no-selector `useTxStore.subscribe(() => requestRedraw())`** whose intent was to redraw on MOX/TUN flips. With mic capture running it actually fired on every `setMicDbfs` (50 Hz from the 20 ms mic worklet), pulling the WebGL rAF floor above the ~30 Hz spectrum-tick rate. Same pattern on `useDisplaySettingsStore`.

### What changed

- `AnalogMeterConfig` early-returns `null` when `open === false`. The slide-in is now a mount/unmount instead of a CSS class toggle — fine for a settings flyout that opens infrequently.
- `AnalogMeterPanel` rAF loop is gated on IntersectionObserver + `visibilitychange` (same pattern Panadapter / Waterfall use), and `setRender` is throttled to a max of one publish per 33 ms (~30 Hz). The needle still animates smoothly; offscreen / hidden costs zero rAFs.
- `AnalogMeterPanel` collapses the three tx-store selectors into one `useShallow` subscription.
- `Panadapter` and `Waterfall` now use the prev-state diff pattern `App.tsx:211` already uses on its own tx-store subscription — only redraw when `moxOn` / `tunOn` actually flip. Same for `useDisplaySettingsStore`: only fields each draw consumes (dB ranges + trace color for Pan, WF dB ranges + colormap for WF) trigger a redraw.
- Added `BACKEND_HOST` env override to `vite.config.ts` (mirrors the existing `BACKEND_PORT`) so a dev can point Vite at a remote backend without editing the file. Default stays `localhost`.

### Measured impact (Playwright harness against live HL2, idle RX)

| Metric | Before | After | Δ |
| --- | --- | --- | --- |
| `<input>` elements in DOM | 20 | 12 | −8 (closed flyout entirely gone) |
| Closed-config input attr mutations / 5 s | ~4 640 | **0** | **−100%** |
| Top per-input mutation rate | 116/s on 8 invisible inputs | 14/s on 4 visible toolbar pills | **−87%** |
| VFO-panel container total mutations / 5 s | 4 805 | 1 495 | **−69%** |
| `attributes:input` / 5 s in that subtree | 2 772 | 276 | **−90%** |
| `drawArrays` / s | ~130 | ~118 | −9% |
| `texSubImage2D` / s | ~48 | ~44 | −9% |
| `bufferSubData` / s | ~32 | ~29 | −9% |

The GL drop is modest because **headless Playwright cannot grant mic permission**, so the 50 Hz `setMicDbfs` subscriber-storm that was supposed to push Pan/WF redraws above spectrum-tick can't be reproduced in this harness. On a real session with mic capture running, the Pan/WF prev-state-diff fix should drop the redraw floor from ~50 Hz back to the ~30 Hz spectrum-tick.

### Risk / scope

All four changes are perf-only (green-light per `CLAUDE.md` — no defaults, UX, or visual changes). No protocol or contract touched. The `vite.config.ts` change is dev-only (default behavior unchanged).

## Test plan

- [ ] `npm run typecheck` — clean (passes locally)
- [ ] `npx vitest run` — 204/204 pass (passes locally)
- [ ] Open the workspace with the **Analog S-Meter** panel mounted; gear closed → idle CPU should be flat in Activity Monitor; gear open → the slide-down still mounts the form, all controls still work and persist across reload.
- [ ] Drag a tile (RGL) → workspace still feels responsive.
- [ ] Drag the dB scale on panadapter / waterfall → redraws still land instantly (prev-state diff covers `dbMin/dbMax/wfDbMin/wfDbMax` + colormap).
- [ ] MOX / TUN → RX↔TX dB-range swap still lands immediately on both surfaces.
- [ ] Optional: open Activity Monitor's Chrome Helper (Renderer) view and confirm idle CPU is materially lower with mic enabled.