### PR TITLE
refactor(layout): inline SettingsView and rework LeftLayoutBar slots

### DIFF
--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -62,7 +62,7 @@ import { PsToggleButton } from './components/PsToggleButton';
 import { PaTempChip } from './components/PaTempChip';
 import { QrzStatusPill } from './components/QrzStatusPill';
 import { RotatorStatusPill } from './components/RotatorStatusPill';
-import { SettingsMenu } from './components/SettingsMenu';
+import { SettingsView, type SettingsTabId } from './components/SettingsMenu';
 import { StepFavorites } from './components/toolbar/StepFavorites';
 import { TunButton } from './components/TunButton';
 import { BOARD_LABELS } from './api/radio';
@@ -100,8 +100,9 @@ const STATE_POLL_MS = 333;
 
 export default function App() {
   useSwUpdatePrompt();
-  const [settingsOpen, setSettingsOpen] = useState(false);
-  const [settingsInitialTab, setSettingsInitialTab] = useState<'pa' | 'qrz' | 'rotator' | 'server' | 'about' | undefined>();
+  const settingsViewOpen = useLayoutStore((s) => s.settingsViewOpen);
+  const settingsInitialTab = useLayoutStore((s) => s.settingsInitialTab);
+  const setSettingsView = useLayoutStore((s) => s.setSettingsView);
   const [updateAvailable, setUpdateAvailable] = useState(false);
   const [installUpdate, setInstallUpdate] = useState<(() => Promise<void>) | null>(null);
   const status = useConnectionStore((s) => s.status);
@@ -223,7 +224,7 @@ export default function App() {
   }, []);
 
   // Handle deeplink via URL hash (#qrz, #rotator, #pa, #server, #about).
-  // Opens settings menu and navigates to the specified tab.
+  // Opens the settings view and navigates to the specified tab.
   useEffect(() => {
     const handleHash = () => {
       const hash = window.location.hash.slice(1); // Remove '#'
@@ -234,8 +235,7 @@ export default function App() {
         hash === 'server' ||
         hash === 'about'
       ) {
-        setSettingsInitialTab(hash);
-        setSettingsOpen(true);
+        setSettingsView(true, hash as SettingsTabId);
         // Clear the hash after handling it
         window.history.replaceState(null, '', window.location.pathname + window.location.search);
       }
@@ -247,7 +247,7 @@ export default function App() {
     // Listen for hash changes
     window.addEventListener('hashchange', handleHash);
     return () => window.removeEventListener('hashchange', handleHash);
-  }, []);
+  }, [setSettingsView]);
 
   // First-run UX for native shells (Capacitor): if there is no server URL
   // configured, the app would spin trying to reach the WebView's own host.
@@ -256,9 +256,8 @@ export default function App() {
   useEffect(() => {
     if (!isCapacitorRuntime()) return;
     if (getServerBaseUrl()) return;
-    setSettingsInitialTab('server');
-    setSettingsOpen(true);
-  }, []);
+    setSettingsView(true, 'server');
+  }, [setSettingsView]);
 
   // --- Design-mock state (QRZ, DSP grid toggles, CW WPM, memories) ---
   const [callsign, setCallsign] = useState('');
@@ -697,29 +696,29 @@ export default function App() {
 
         <div className="spacer" style={{ flex: 1 }} />
 
-        {/* Settings comes first, then Disconnect. Rotator / QRZ pills and the
-            radio IP moved to the BottomStatusBar — no need to duplicate them
-            up here. While disconnected the centre overlay owns Discover so
-            we mount only one ConnectPanel at a time. */}
-        <button
-          type="button"
-          className="btn"
-          onClick={() => setSettingsOpen(true)}
-          title="Open settings menu"
-        >
-          ⚙
-        </button>
+        {/* Settings is reached from the LeftLayoutBar (bottom slot). The
+            top bar is now reserved for Disconnect when connected; while
+            disconnected the centre overlay owns Discover so we mount only
+            one ConnectPanel at a time. */}
         {connected && <ConnectPanel compact />}
       </header>
 
       <AlertBanner />
 
-      {/* Active layout's workspace. Keying on activeLayoutId forces a full
-          unmount + remount when the operator switches layouts so WebGL
-          canvases / RAF loops / hub subscriptions in the prior layout
-          release rather than lingering hidden (issue #241 requires that
-          inactive layouts not consume DOM resources). */}
-      <FlexWorkspace key={activeLayoutId} />
+      {/* Active layout's workspace, or the inline Settings view if the
+          operator picked the Settings slot in the LeftLayoutBar. Keying on
+          activeLayoutId forces a full unmount + remount when the operator
+          switches layouts so WebGL canvases / RAF loops / hub subscriptions
+          in the prior layout release rather than lingering hidden (issue
+          #241 requires that inactive layouts not consume DOM resources). */}
+      {settingsViewOpen ? (
+        <SettingsView
+          initialTab={settingsInitialTab as SettingsTabId | undefined}
+          onClose={() => setSettingsView(false)}
+        />
+      ) : (
+        <FlexWorkspace key={activeLayoutId} />
+      )}
 
       {/* Transport — MOX/TUN + audio + mic + macro buttons on the left,
           PA/PRE chips, then the per-radio status (radio IP, rotator, QRZ)
@@ -749,18 +748,38 @@ export default function App() {
         </span>
         <RotatorStatusPill />
         <QrzStatusPill />
+        {/* Add Panel + Reset live together at the bottom-right: both act on
+            the active layout's tile arrangement, so keeping them adjacent
+            makes the relationship obvious. Disabled while the Settings
+            view is showing (no active workspace to mutate). */}
         <button
           type="button"
-          className="btn sm"
+          className="btn"
           onClick={() => useLayoutStore.getState().setAddPanelOpen(true)}
+          disabled={settingsViewOpen}
           title="Add a panel to the active layout"
         >
           + Add Panel
         </button>
+        <button
+          type="button"
+          className="btn ghost"
+          onClick={() => {
+            const s = useLayoutStore.getState();
+            const active = s.layouts.find((l) => l.id === s.activeLayoutId);
+            if (!active) return;
+            if (!window.confirm(`Reset “${active.name}” to the default panel arrangement?`)) return;
+            s.resetActiveLayout();
+          }}
+          disabled={settingsViewOpen}
+          title="Reset active layout to default"
+          aria-label="Reset active layout to default"
+        >
+          ⟳ Default
+        </button>
       </div>
 
       {disconnectedOverlay}
-      <SettingsMenu open={settingsOpen} onClose={() => setSettingsOpen(false)} initialTab={settingsInitialTab} />
       <UpdatePrompt show={updateAvailable} onUpdate={installUpdate} />
     </div>
     </SpectrumWheelActionsContext.Provider>

--- a/zeus-web/src/components/LeftLayoutBar.tsx
+++ b/zeus-web/src/components/LeftLayoutBar.tsx
@@ -6,9 +6,21 @@
 // LeftLayoutBar — vertical bar listing the current radio's named layouts.
 // Each item shows a large emoji icon with a small label beneath. Clicking
 // switches to that layout; the gear opens LayoutSettingsModal to edit the
-// label, icon, and tooltip description. The "+" button opens the same modal
-// in create mode; "✕" deletes the active layout; "⟳" resets it to the
-// default tile arrangement.
+// label, icon, and tooltip description.
+//
+// Layout-list anatomy (top → bottom):
+//   • One tab per saved NamedLayout (icon + label, optional gear/✕).
+//   • A trailing dashed "+" placeholder tab — always present — that opens
+//     LayoutSettingsModal in create mode. The "+" is a slot, not a button:
+//     adding a layout slides it down so the next "+" sits below the new
+//     layout. This replaces the earlier separate "+" / "⟳" actions row.
+//   • A horizontal divider, then the bottom-pinned Settings slot. Clicking
+//     it flips layout-store.settingsViewOpen so App swaps the workspace
+//     for SettingsView. Picking any layout tab clears that flag.
+//
+// The "Reset to default" affordance lives on the bottom transport bar
+// alongside "+ Add Panel" — both act on the active layout's tile
+// arrangement, so they read naturally as a pair there.
 //
 // Issue #241: visual chrome reuses tokens.css; no new colors are introduced.
 
@@ -32,8 +44,9 @@ export function LeftLayoutBar() {
   const addLayout = useLayoutStore((s) => s.addLayout);
   const removeLayout = useLayoutStore((s) => s.removeLayout);
   const updateLayoutMeta = useLayoutStore((s) => s.updateLayoutMeta);
-  const resetActiveLayout = useLayoutStore((s) => s.resetActiveLayout);
   const isLoaded = useLayoutStore((s) => s.isLoaded);
+  const settingsViewOpen = useLayoutStore((s) => s.settingsViewOpen);
+  const setSettingsView = useLayoutStore((s) => s.setSettingsView);
   // The bar's blue gradient + dot wash follows the operator's panadapter
   // trace colour from the Display tab. CLAUDE.md flags trace amber as
   // "panadapter-only", but the maintainer explicitly asked for the chrome
@@ -70,13 +83,6 @@ export function LeftLayoutBar() {
     removeLayout(id);
   };
 
-  const handleReset = () => {
-    const active = layouts.find((l) => l.id === activeLayoutId);
-    if (!active) return;
-    if (!window.confirm(`Reset “${active.name}” to the default panel arrangement?`)) return;
-    resetActiveLayout();
-  };
-
   const openEdit = (id: string) => setModal({ kind: 'edit', id });
 
   const handleModalSave = (value: LayoutSettingsValue) => {
@@ -104,74 +110,89 @@ export function LeftLayoutBar() {
         {!isLoaded ? (
           <div className="lb-empty" aria-hidden>…</div>
         ) : (
-          layouts.map((l) => {
-            const active = l.id === activeLayoutId;
-            const tooltip = l.description?.trim()
-              ? `${l.name} — ${l.description}`
-              : `${l.name} (gear to edit)`;
-            return (
-              <div key={l.id} className={`lb-item ${active ? 'active' : ''}`}>
-                <button
-                  type="button"
-                  className="lb-tab"
-                  role="tab"
-                  aria-selected={active}
-                  onClick={() => setActiveLayout(l.id)}
-                  title={tooltip}
-                >
-                  <span
-                    className={`lb-tab-icon ${l.icon ? '' : 'lb-tab-icon-fallback'}`}
-                    aria-hidden
-                  >
-                    {l.icon || initialLetter(l.name)}
-                  </span>
-                  <span className="lb-tab-name">{l.name}</span>
-                </button>
-                <button
-                  type="button"
-                  className="lb-gear"
-                  onClick={() => openEdit(l.id)}
-                  title={`Edit ${l.name}`}
-                  aria-label={`Edit ${l.name}`}
-                >
-                  ⚙
-                </button>
-                {active && layouts.length > 1 && (
+          <>
+            {layouts.map((l) => {
+              // While the Settings view is showing no layout tab is active —
+              // it's a sibling view, not a layout. The flag is cleared the
+              // moment the operator clicks any layout tab (setActiveLayout).
+              const active = !settingsViewOpen && l.id === activeLayoutId;
+              const tooltip = l.description?.trim()
+                ? `${l.name} — ${l.description}`
+                : `${l.name} (gear to edit)`;
+              return (
+                <div key={l.id} className={`lb-item ${active ? 'active' : ''}`}>
                   <button
                     type="button"
-                    className="lb-x"
-                    onClick={() => handleDelete(l.id, l.name)}
-                    title={`Delete ${l.name}`}
-                    aria-label={`Delete ${l.name}`}
+                    className="lb-tab"
+                    role="tab"
+                    aria-selected={active}
+                    onClick={() => setActiveLayout(l.id)}
+                    title={tooltip}
                   >
-                    ✕
+                    <span
+                      className={`lb-tab-icon ${l.icon ? '' : 'lb-tab-icon-fallback'}`}
+                      aria-hidden
+                    >
+                      {l.icon || initialLetter(l.name)}
+                    </span>
+                    <span className="lb-tab-name">{l.name}</span>
                   </button>
-                )}
-              </div>
-            );
-          })
+                  <button
+                    type="button"
+                    className="lb-gear"
+                    onClick={() => openEdit(l.id)}
+                    title={`Edit ${l.name}`}
+                    aria-label={`Edit ${l.name}`}
+                  >
+                    ⚙
+                  </button>
+                  {active && layouts.length > 1 && (
+                    <button
+                      type="button"
+                      className="lb-x"
+                      onClick={() => handleDelete(l.id, l.name)}
+                      title={`Delete ${l.name}`}
+                      aria-label={`Delete ${l.name}`}
+                    >
+                      ✕
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+            {/* Trailing placeholder slot — always at the end of the list.
+                Adding a layout pushes this slot down one row, so the "+"
+                stays the bottom-most tab. */}
+            <div className="lb-item lb-item-add">
+              <button
+                type="button"
+                className="lb-tab lb-tab-add"
+                onClick={handleAdd}
+                title="Add a new layout"
+                aria-label="Add a new layout"
+              >
+                <span className="lb-tab-icon lb-tab-icon-fallback" aria-hidden>
+                  +
+                </span>
+                <span className="lb-tab-name">Add</span>
+              </button>
+            </div>
+          </>
         )}
       </div>
 
-      <div className="lb-actions">
+      <div className="lb-divider" aria-hidden />
+
+      <div className="lb-settings-slot">
         <button
           type="button"
-          className="btn sm lb-action"
-          onClick={handleAdd}
-          title="Add a new layout"
-          aria-label="Add a new layout"
+          className={`lb-tab lb-tab-settings ${settingsViewOpen ? 'active' : ''}`}
+          onClick={() => setSettingsView(!settingsViewOpen)}
+          title="Open settings"
+          aria-pressed={settingsViewOpen}
         >
-          +
-        </button>
-        <button
-          type="button"
-          className="btn ghost sm lb-action"
-          onClick={handleReset}
-          title="Reset active layout to default"
-          aria-label="Reset active layout to default"
-          disabled={!isLoaded || layouts.length === 0}
-        >
-          ⟳
+          <span className="lb-tab-icon" aria-hidden>⚙</span>
+          <span className="lb-tab-name">Settings</span>
         </button>
       </div>
 

--- a/zeus-web/src/components/SettingsMenu.test.tsx
+++ b/zeus-web/src/components/SettingsMenu.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 //
-// SettingsMenu — verify the TX Audio Tools tab is always present and that
+// SettingsView — verify the TX Audio Tools tab is always present and that
 // the VST host submenu inside it is gated by /api/capabilities. CFC is
 // WDSP-driven and must remain visible regardless of the sidecar.
 
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
-import { SettingsMenu } from './SettingsMenu';
+import { SettingsView } from './SettingsMenu';
 import { useCapabilitiesStore } from '../state/capabilities-store';
 
 function seed(vstAvailable: boolean) {
@@ -33,7 +33,7 @@ function seed(vstAvailable: boolean) {
   });
 }
 
-describe('SettingsMenu — TX Audio Tools', () => {
+describe('SettingsView — TX Audio Tools', () => {
   let container: HTMLDivElement;
   let root: Root;
 
@@ -54,7 +54,7 @@ describe('SettingsMenu — TX Audio Tools', () => {
   it('always renders the TX AUDIO TOOLS tab', () => {
     seed(false);
     act(() => {
-      root.render(<SettingsMenu open={true} onClose={() => {}} />);
+      root.render(<SettingsView onClose={() => {}} />);
     });
     const tabs = Array.from(
       container.querySelectorAll('[role="tablist"] button'),
@@ -65,9 +65,7 @@ describe('SettingsMenu — TX Audio Tools', () => {
   it('shows CFC and the VST host submenu when vstHost.available is true', () => {
     seed(true);
     act(() => {
-      root.render(
-        <SettingsMenu open={true} onClose={() => {}} initialTab="tx-audio" />,
-      );
+      root.render(<SettingsView onClose={() => {}} initialTab="tx-audio" />);
     });
     expect(container.textContent).toContain('Continuous Frequency Compressor');
     expect(container.textContent).toContain('VST Host');
@@ -76,9 +74,7 @@ describe('SettingsMenu — TX Audio Tools', () => {
   it('shows CFC but hides the VST host submenu when vstHost.available is false', () => {
     seed(false);
     act(() => {
-      root.render(
-        <SettingsMenu open={true} onClose={() => {}} initialTab="tx-audio" />,
-      );
+      root.render(<SettingsView onClose={() => {}} initialTab="tx-audio" />);
     });
     expect(container.textContent).toContain('Continuous Frequency Compressor');
     expect(container.textContent).not.toContain('VST Host');

--- a/zeus-web/src/components/SettingsMenu.tsx
+++ b/zeus-web/src/components/SettingsMenu.tsx
@@ -19,7 +19,7 @@
 // (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
 // Both are GPL-2.0-or-later.
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { PaSettingsPanel } from './PaSettingsPanel';
 import { BandPlanEditor } from './bandplan/BandPlanEditor';
 import { AboutPanel } from './AboutPanel';
@@ -33,7 +33,7 @@ import { usePaStore } from '../state/pa-store';
 import { PsSettingsPanel } from './PsSettingsPanel';
 import { TxAudioToolsPanel } from './TxAudioToolsPanel';
 
-type TabId =
+export type SettingsTabId =
   | 'pa'
   | 'ps'
   | 'tx-audio'
@@ -45,7 +45,7 @@ type TabId =
   | 'server'
   | 'about';
 
-const TABS: ReadonlyArray<{ id: TabId; label: string }> = [
+const TABS: ReadonlyArray<{ id: SettingsTabId; label: string }> = [
   { id: 'pa', label: 'PA SETTINGS' },
   { id: 'ps', label: 'PURESIGNAL' },
   { id: 'tx-audio', label: 'TX AUDIO TOOLS' },
@@ -59,20 +59,31 @@ const TABS: ReadonlyArray<{ id: TabId; label: string }> = [
 ];
 
 type Props = {
-  open: boolean;
+  initialTab?: SettingsTabId;
   onClose: () => void;
-  initialTab?: TabId;
 };
 
-// Floating, draggable settings panel. Deliberately has NO backdrop: the operator
-// must be able to MOX / TUN / tune the radio while the panel is open. The only
-// event-capture surface is the panel rectangle itself; everything outside
-// (panadapter, top-bar buttons) stays clickable.
-export function SettingsMenu({ open, onClose, initialTab }: Props) {
-  const [active, setActive] = useState<TabId>(initialTab ?? 'pa');
+// SettingsView — settings is a workspace-replacing view, not a popover. The
+// parent (App) renders it in the same grid cell as FlexWorkspace whenever
+// layout-store.settingsViewOpen is true. Clicking any layout tab in the
+// LeftLayoutBar returns to the workspace (setActiveLayout clears the flag).
+export function SettingsView({ initialTab, onClose }: Props) {
+  const [active, setActive] = useState<SettingsTabId>(initialTab ?? 'pa');
   const savePa = usePaStore((s) => s.save);
   const loadPa = usePaStore((s) => s.load);
   const paInflight = usePaStore((s) => s.inflight);
+
+  useEffect(() => {
+    if (initialTab) setActive(initialTab);
+  }, [initialTab]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
 
   const handleApply = async () => {
     await savePa();
@@ -83,158 +94,19 @@ export function SettingsMenu({ open, onClose, initialTab }: Props) {
     await loadPa();
     onClose();
   };
-  // null = use the initial-centering flex layout on first render; after the
-  // first drag (or the post-mount centering effect), a concrete {x,y} takes
-  // over and the panel positions absolutely. Off-screen values are allowed —
-  // the user explicitly wanted to be able to drag the window off-screen.
-  const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
-  const panelRef = useRef<HTMLDivElement>(null);
-  const dragRef = useRef<{ dx: number; dy: number } | null>(null);
-
-  // Set the active tab when initialTab prop changes
-  useEffect(() => {
-    if (initialTab) setActive(initialTab);
-  }, [initialTab]);
-
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [open, onClose]);
-
-  // Center on first open: measure the panel's natural rect and pin it there,
-  // switching from flex-centering to absolute positioning so dragging starts
-  // from a stable origin.
-  useEffect(() => {
-    if (!open) {
-      setPos(null);
-      return;
-    }
-    if (pos !== null) return;
-    const el = panelRef.current;
-    if (!el) return;
-    const rect = el.getBoundingClientRect();
-    setPos({
-      x: Math.max(8, (window.innerWidth - rect.width) / 2),
-      y: Math.max(8, (window.innerHeight - rect.height) / 2),
-    });
-  }, [open, pos]);
-
-  // Global mousemove/up while a drag is in flight. Listener is always mounted
-  // so we can start dragging from the header's mousedown without remounting.
-  useEffect(() => {
-    const move = (e: MouseEvent) => {
-      const d = dragRef.current;
-      if (!d) return;
-      setPos({ x: e.clientX - d.dx, y: e.clientY - d.dy });
-    };
-    const up = () => {
-      dragRef.current = null;
-    };
-    window.addEventListener('mousemove', move);
-    window.addEventListener('mouseup', up);
-    return () => {
-      window.removeEventListener('mousemove', move);
-      window.removeEventListener('mouseup', up);
-    };
-  }, []);
-
-  const startDrag = (e: React.MouseEvent<HTMLDivElement>) => {
-    const el = panelRef.current;
-    if (!el) return;
-    const rect = el.getBoundingClientRect();
-    dragRef.current = {
-      dx: e.clientX - rect.left,
-      dy: e.clientY - rect.top,
-    };
-    e.preventDefault();
-  };
-
-  if (!open) return null;
-
-  const basePanel: React.CSSProperties = {
-    position: 'fixed',
-    width: 'min(1100px, 92vw)',
-    height: 'min(840px, 85vh)',
-    zIndex: 50,
-    background: 'var(--bg-1)',
-    border: '1px solid var(--panel-border)',
-    borderRadius: 'var(--r-md)',
-    boxShadow: '0 20px 60px rgba(0,0,0,0.55), 0 0 0 1px rgba(255,255,255,0.03)',
-    color: 'var(--fg-1)',
-    display: 'flex',
-    flexDirection: 'column',
-    overflow: 'hidden',
-  };
-  const panelStyle: React.CSSProperties =
-    pos === null
-      ? { ...basePanel, left: '50%', top: '50%', transform: 'translate(-50%, -50%)' }
-      : { ...basePanel, left: `${pos.x}px`, top: `${pos.y}px` };
 
   return (
-    <div
-      ref={panelRef}
-      style={panelStyle}
-      role="dialog"
-      aria-modal="false"
-      aria-labelledby="settings-title"
-    >
-      <div
-        onMouseDown={startDrag}
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          cursor: 'move',
-          userSelect: 'none',
-          height: 44,
-          padding: '0 14px',
-          background:
-            'linear-gradient(180deg, var(--panel-head-top), var(--panel-head-bot))',
-          borderBottom: '1px solid var(--panel-border)',
-          boxShadow: 'inset 0 1px 0 var(--panel-hl-top)',
-        }}
-        title="Drag to move"
-      >
-        <h2
-          id="settings-title"
-          style={{
-            margin: 0,
-            fontSize: 12,
-            fontWeight: 700,
-            letterSpacing: '0.18em',
-            color: 'var(--fg-0)',
-            textTransform: 'uppercase',
-          }}
-        >
+    <div className="settings-view" role="region" aria-label="Settings">
+      <div className="settings-view-header">
+        <h2 className="settings-view-title" id="settings-title">
           Settings
         </h2>
         <button
           type="button"
           onClick={onClose}
-          onMouseDown={(e) => e.stopPropagation()}
-          aria-label="Close"
-          style={{
-            width: 26,
-            height: 26,
-            borderRadius: 'var(--r-sm)',
-            color: 'var(--fg-2)',
-            fontSize: 18,
-            lineHeight: 1,
-            background: 'transparent',
-            cursor: 'pointer',
-          }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.background = 'rgba(255,255,255,0.06)';
-            e.currentTarget.style.color = 'var(--fg-0)';
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.background = 'transparent';
-            e.currentTarget.style.color = 'var(--fg-2)';
-          }}
+          aria-label="Close settings"
+          className="settings-view-close"
+          title="Close (Esc)"
         >
           ×
         </button>
@@ -242,21 +114,11 @@ export function SettingsMenu({ open, onClose, initialTab }: Props) {
 
       <RadioSelector />
 
-      <div style={{ display: 'flex', flex: 1, minHeight: 0 }}>
+      <div className="settings-view-body">
         <nav
           role="tablist"
           aria-label="Settings sections"
-          style={{
-            width: 168,
-            flexShrink: 0,
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 2,
-            padding: '10px 8px',
-            background: 'var(--bg-0)',
-            borderRight: '1px solid var(--panel-border)',
-            overflowY: 'auto',
-          }}
+          className="settings-view-tabs"
         >
           {TABS.map((t) => {
             const isActive = t.id === active;
@@ -267,34 +129,7 @@ export function SettingsMenu({ open, onClose, initialTab }: Props) {
                 role="tab"
                 aria-selected={isActive}
                 onClick={() => setActive(t.id)}
-                style={{
-                  textAlign: 'left',
-                  padding: '8px 12px',
-                  borderRadius: 'var(--r-sm)',
-                  fontSize: 11,
-                  fontWeight: 700,
-                  letterSpacing: '0.12em',
-                  textTransform: 'uppercase',
-                  color: isActive ? 'var(--fg-0)' : 'var(--fg-2)',
-                  background: isActive ? 'var(--bg-2)' : 'transparent',
-                  borderLeft: isActive
-                    ? '2px solid var(--accent)'
-                    : '2px solid transparent',
-                  cursor: 'pointer',
-                  transition: 'background var(--dur-fast), color var(--dur-fast)',
-                }}
-                onMouseEnter={(e) => {
-                  if (!isActive) {
-                    e.currentTarget.style.background = 'rgba(255,255,255,0.03)';
-                    e.currentTarget.style.color = 'var(--fg-1)';
-                  }
-                }}
-                onMouseLeave={(e) => {
-                  if (!isActive) {
-                    e.currentTarget.style.background = 'transparent';
-                    e.currentTarget.style.color = 'var(--fg-2)';
-                  }
-                }}
+                className={`settings-view-tab${isActive ? ' active' : ''}`}
               >
                 {t.label}
               </button>
@@ -302,20 +137,7 @@ export function SettingsMenu({ open, onClose, initialTab }: Props) {
           })}
         </nav>
 
-        <div
-          role="tabpanel"
-          style={{
-            flex: 1,
-            minWidth: 0,
-            overflow: 'auto',
-            padding: '18px 22px',
-            background: 'var(--bg-1)',
-            color: 'var(--fg-1)',
-            fontSize: 12,
-            display: 'flex',
-            flexDirection: 'column',
-          }}
-        >
+        <div role="tabpanel" className="settings-view-panel">
           {active === 'pa' && <PaSettingsPanel />}
           {active === 'ps' && <PsSettingsPanel />}
           {active === 'tx-audio' && <TxAudioToolsPanel />}
@@ -330,17 +152,7 @@ export function SettingsMenu({ open, onClose, initialTab }: Props) {
       </div>
 
       {active === 'pa' && (
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'flex-end',
-            gap: 6,
-            padding: '10px 14px',
-            background: 'var(--bg-0)',
-            borderTop: '1px solid var(--panel-border)',
-          }}
-        >
+        <div className="settings-view-footer">
           <button type="button" className="btn sm" onClick={handleCancel} disabled={paInflight}>
             CANCEL
           </button>

--- a/zeus-web/src/state/layout-store.ts
+++ b/zeus-web/src/state/layout-store.ts
@@ -80,6 +80,16 @@ interface LayoutState {
   addPanelOpen: boolean;
   setAddPanelOpen: (open: boolean) => void;
 
+  // Settings is rendered as a workspace-replacing view (not a popover).
+  // While settingsViewOpen is true the App renders <SettingsView /> in
+  // place of <FlexWorkspace />. settingsInitialTab seeds the active tab
+  // when the view opens (used by hash deeplinks like #qrz, #server).
+  // setActiveLayout(...) clears this so picking a layout returns to the
+  // workspace.
+  settingsViewOpen: boolean;
+  settingsInitialTab?: string;
+  setSettingsView: (open: boolean, tab?: string) => void;
+
   /** Switch the radio key and reload the layouts list from the server.
    *  No-op when the key already matches and isLoaded is true. */
   loadForRadio: (radioKey: string) => Promise<void>;
@@ -163,6 +173,13 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
   isLoaded: false,
   addPanelOpen: false,
   setAddPanelOpen: (open) => set({ addPanelOpen: open }),
+
+  settingsViewOpen: false,
+  setSettingsView: (open, tab) =>
+    set({
+      settingsViewOpen: open,
+      settingsInitialTab: open ? tab : undefined,
+    }),
 
   loadForRadio: async (radioKey) => {
     const safeKey = radioKey || 'default';
@@ -314,6 +331,11 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
     set({
       activeLayoutId: id,
       workspace: parseLayoutOrDefault(target.layoutJson),
+      // Picking a layout always returns to the workspace view — clearing
+      // any active settings overlay keeps the operator's mental model
+      // consistent.
+      settingsViewOpen: false,
+      settingsInitialTab: undefined,
     });
     void postActiveLayout(radioKey, id);
   },

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -35,6 +35,7 @@
 .app > .topbar            { grid-column: 2; grid-row: 1; }
 .app > .alert-banner      { grid-column: 2; grid-row: 2; }
 .app > .flex-workspace    { grid-column: 2; grid-row: 3; min-height: 0; overflow: auto; }
+.app > .settings-view     { grid-column: 2; grid-row: 3; min-height: 0; overflow: hidden; }
 .app > .transport         { grid-column: 2; grid-row: 4; }
 
 /* ===== Left layout bar — issue #241 ===== */
@@ -259,17 +260,176 @@
   color: var(--tx);
   border-color: var(--tx);
 }
-.left-layout-bar .lb-actions {
+/* Placeholder add-layout slot — sits at the end of the layout list and
+   uses the same .lb-tab footprint so it reads as the next layout-to-be
+   rather than a separate "action" button. Dashed border + reduced
+   opacity tell the eye it's a slot, not a real layout. */
+.left-layout-bar .lb-item-add { opacity: 0.85; }
+.left-layout-bar .lb-tab-add {
+  background: transparent;
+  border: 1px dashed var(--btn-edge);
+  color: var(--fg-2);
+  box-shadow: none;
+}
+.left-layout-bar .lb-tab-add:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: rgba(255, 255, 255, 0.02);
+  filter: none;
+}
+.left-layout-bar .lb-tab-add .lb-tab-icon-fallback {
+  border-color: currentColor;
+  font-weight: 700;
+  opacity: 1;
+}
+
+/* Horizontal spacer between the layout list and the bottom Settings slot.
+   Reuses the bar's existing tinted shadow vocabulary so it doesn't read as
+   foreign chrome. */
+.left-layout-bar .lb-divider {
+  flex: 0 0 auto;
+  height: 1px;
+  margin: 6px 2px 4px;
+  background: linear-gradient(
+    to right,
+    transparent,
+    rgba(255, 255, 255, 0.18),
+    transparent
+  );
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.55);
+}
+
+/* Bottom-pinned settings slot. Uses the same .lb-tab visual vocabulary so
+   the gear reads as a sibling of the layout tabs, not an outside action.
+   .active fires while the SettingsView is showing (settingsViewOpen). */
+.left-layout-bar .lb-settings-slot {
+  flex: 0 0 auto;
+  display: flex;
+}
+.left-layout-bar .lb-tab-settings {
+  flex: 1;
+}
+.left-layout-bar .lb-tab-settings.active {
+  border-color: var(--accent);
+  color: var(--accent);
+  box-shadow: inset 0 1px 0 var(--btn-hl), 0 0 8px var(--accent-soft);
+}
+
+/* ===== Settings view — workspace-replacing pane =====
+   Renders in the same grid cell as .flex-workspace when
+   layout-store.settingsViewOpen is true. Uses the same panel chrome as
+   the rest of the app (panel-top/bot gradient, panel-edge border) so it
+   reads as part of the workspace, not a foreign overlay. */
+.settings-view {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  background: var(--bg-1);
+  border: 1px solid var(--panel-edge);
+  border-radius: var(--r-lg);
+  box-shadow: var(--panel-shadow);
+  color: var(--fg-1);
+  overflow: hidden;
+  min-height: 0;
+}
+.settings-view-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 44px;
+  padding: 0 14px;
+  background: linear-gradient(
+    180deg,
+    var(--panel-head-top),
+    var(--panel-head-bot)
+  );
+  border-bottom: 1px solid var(--panel-border);
+  box-shadow: inset 0 1px 0 var(--panel-hl-top);
   flex: 0 0 auto;
 }
-.left-layout-bar .lb-action {
-  width: 100%;
-  padding: 6px 0;
-  font-size: 14px;
+.settings-view-title {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  color: var(--fg-0);
+  text-transform: uppercase;
+}
+.settings-view-close {
+  width: 26px;
+  height: 26px;
+  border-radius: var(--r-sm);
+  color: var(--fg-2);
+  font-size: 18px;
   line-height: 1;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: background var(--dur-fast), color var(--dur-fast);
+}
+.settings-view-close:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--fg-0);
+}
+.settings-view-body {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+.settings-view-tabs {
+  width: 200px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 8px;
+  background: var(--bg-0);
+  border-right: 1px solid var(--panel-border);
+  overflow-y: auto;
+}
+.settings-view-tab {
+  text-align: left;
+  padding: 10px 14px;
+  border-radius: var(--r-sm);
+  border: none;
+  border-left: 2px solid transparent;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--fg-2);
+  background: transparent;
+  cursor: pointer;
+  transition: background var(--dur-fast), color var(--dur-fast);
+}
+.settings-view-tab:hover {
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--fg-1);
+}
+.settings-view-tab.active {
+  color: var(--fg-0);
+  background: var(--bg-2);
+  border-left-color: var(--accent);
+}
+.settings-view-panel {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: auto;
+  padding: 18px 22px;
+  background: var(--bg-1);
+  color: var(--fg-1);
+  font-size: 12px;
+  display: flex;
+  flex-direction: column;
+}
+.settings-view-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  padding: 10px 14px;
+  background: var(--bg-0);
+  border-top: 1px solid var(--panel-border);
+  flex: 0 0 auto;
 }
 
 /* ===== Top bar — issue #241 =====


### PR DESCRIPTION
## Summary
- Convert `SettingsMenu` from a modal into an inline `SettingsView` driven through `layout-store` (`settingsViewOpen`, `settingsInitialTab`, `setSettingsView`).
- `LeftLayoutBar` gains a bottom-pinned **Settings** slot and a trailing dashed **+** placeholder that opens `LayoutSettingsModal` in create mode.
- Drop the standalone `+ / ⟳` actions row from the layout bar — **Reset** moves to the bottom transport bar next to **+ Add Panel**, where it reads naturally alongside the other tile-arrangement action.

## Test plan
- [ ] Click each layout tab — workspace renders the layout's tiles.
- [ ] Click the bottom **Settings** slot — workspace swaps to `SettingsView`; clicking any layout tab clears it.
- [ ] Click the trailing dashed **+** — `LayoutSettingsModal` opens in create mode; saving adds a new layout and the **+** slides down below it.
- [ ] Deeplink hashes (`#qrz`, `#rotator`, `#pa`, `#server`, `#about`) open `SettingsView` on the right tab.
- [ ] First-run Capacitor path (no server URL configured) opens `SettingsView` on the **Server** tab.
- [ ] **+ Add Panel** and **Reset** on the bottom transport bar both act on the active layout.
- [ ] No design-token changes (palette unchanged).