### PR TITLE
perf: cut idle-RX frontend CPU ~22% via REST poll + mic-meter throttle

### DIFF
--- a/docs/performance_tuning.md
+++ b/docs/performance_tuning.md
@@ -1,0 +1,160 @@
+# Performance tuning — idle-RX CPU on the frontend
+
+This is a working log of the `feature/perf2` investigation: where the CPU
+goes when Zeus is idle on RX (HL2 connected, no TX, all panels open), what
+the two committed fixes actually moved, and where the remaining cost lives
+so the next pass doesn't have to re-discover any of this.
+
+Reproduce on a Mac mini (M1 / M2-class) with Chrome via Playwright:
+- Backend `Zeus.Server` on `:6060`
+- Vite dev on `:5173`
+- HL2 on the LAN, idle on 20 m USB
+- 31-sample `top -l 31 -s 1` per-process averages
+
+## Headline result
+
+| Process | Before fixes | After fixes | Δ |
+|---|---|---|---|
+| Renderer (Zeus tab) | 30.8 % | **24.3 %** | −6.5 pp |
+| Chrome GPU helper | 12.8 % | **9.9 %** | −2.9 pp |
+| **Zeus frontend stack** | **43.6 %** | **34.2 %** | **−22 %** |
+| Zeus.Server backend | 22.3 % | 23.6 % | noise |
+| WindowServer | 32.4 % | 35.2 % | system-wide; not attributable |
+
+Idle-RX HTTP fetch rate dropped 4.97 → ~2 req/sec; mic worklet → store push
+rate dropped 50 → 20 Hz.
+
+## What we changed
+
+### 1. `perf(rest-poll)` — `56dac59`
+
+Idle RX was making ~5 fetches/sec, dominated by three pollers:
+
+| Endpoint | Before | After | Source |
+|---|---|---|---|
+| `/api/state` | 3.46 Hz | 1.0 Hz | `App.tsx:99,194` |
+| `/api/rotator/status` | 1.0 Hz | 1.0 Hz when enabled, 0 when disabled | `state/rotator-store.ts:164` |
+| `/api/tci/status` | 0.5 Hz | 0 Hz when disabled | `state/tci-store.ts:99` |
+
+- `STATE_POLL_MS` 333 → 1000 ms. The poll only exists for "slow state" —
+  ADC overload flag, atten offset, NR settings — that the SignalR hub
+  doesn't push as a delta. 1 Hz is still well inside the operator's
+  reaction window for ADC overload; 333 ms was overkill and its main effect
+  was driving `useConnectionStore.applyState` + `useTxStore.hydrateFromState`
+  into the React tree three times a second.
+- Rotator and TCI pollers now check `config.enabled` inside their
+  `setInterval` callback. Disabled features stop touching the network.
+
+### 2. `perf(mic-meter)` — `7bb3808`
+
+The mic AudioWorklet emits a per-block peak every 20 ms (50 Hz). That value
+was going straight to `useTxStore.setMicDbfs`, which re-rendered the
+bottom-bar `MicMeter` component 50 times a second — even with the workspace
+empty and no panels visible. The `MicMeter` is always mounted; it is the
+primary persistent React subscriber to TX-store.
+
+Fix: `audio/use-mic-uplink.ts` now buckets the worklet's per-block peaks
+across a 50 ms window (20 Hz visual rate) and emits the **window's max** to
+the store. Clip indication stays accurate — a transient peak inside the
+window is preserved as the emitted value. Visual feel is unchanged at 20 Hz
+(smoother than TV).
+
+This was the single biggest win in absolute terms.
+
+## What we know (and what was a red herring)
+
+### Things that turned out *not* to be the bottleneck
+
+- **Canvas rAF rate.** Initial assumption was that panadapter + waterfall
+  rAF at 60 Hz. They don't. Both are event-driven via
+  `useDisplayStore.subscribe` and gate themselves with `if (rafHandle ===
+  0) requestAnimationFrame(redraw)`. They redraw at the backend's spectrum
+  push rate (~25 Hz), not 60. Capping rAF to 30 fps would have been a
+  no-op.
+- **Per-panel cost is small individually.** Closing only the panadapter
+  produced no measurable drop; closing *all* panels dropped renderer from
+  ~29 % to ~12 %. The cost is many small things (3 canvases, several
+  meters, RGL observers) summing — not one dominant component.
+- **Discovery scanning animation.** Inspected — it's a CSS `@keyframes`
+  pulse, not a canvas. CSS animations on the GPU compositor are
+  effectively free.
+- **Server-side meter rates.** `TxMetersService` is 10 Hz during MOX,
+  **2 Hz idle**. RX_METER (S-meter) is ~5 Hz. Already low. Not a hot path.
+
+### What we measured and currently believe
+
+- **Empty workspace, HL2 connected** ≈ 12 % renderer. This is the
+  always-on cost: SignalR ingress fan-out into stores, the bottom-bar
+  meters, RGL observers, Vite HMR client, audio scheduling, CSS animations
+  on the QRZ / rotator pills.
+- **Each canvas adds ~5–7 pp** on top of the 12 % floor. With panadapter +
+  waterfall + the meter canvases together that's ~17 pp. Closing one alone
+  is below the noise floor.
+- **WindowServer is system-global.** It composites every window on the
+  desktop, not just the browser. Reading it as "Zeus's compositor cost"
+  is wrong. It tracks workload across the whole machine.
+
+## What's left, and why we stopped here
+
+The remaining ~24 % renderer with all panels open splits roughly:
+
+- ~12 pp in canvas draw work (panadapter + waterfall + meters at ~25 Hz
+  each, with their existing `texSubImage2D` / `bufferSubData` per-frame
+  uploads).
+- ~12 pp in always-on app overhead (store fan-out, mic worklet now at 20
+  Hz, RGL, audio).
+
+Concrete next-pass candidates, ordered by expected payoff vs invasiveness:
+
+1. **Coalesce panadapter + waterfall into a shared rAF scheduler.** Both
+   currently schedule their own rAF on every store update, so each
+   spectrum frame produces two rAF wakeups. Combining into one shared
+   "draw bus" would save one wakeup per frame (~25/sec). Modest win
+   (~1–2 pp), small refactor across `Panadapter.tsx` + `Waterfall.tsx`.
+2. **Audit other persistent React subscribers.** `MicMeter` was the
+   obvious one; there may be similar always-mounted components subscribed
+   to high-rate fields. Candidates to check next: PA TEMP indicator,
+   bottom-bar mic level chip, any subscribers to `useRxMetersStore`.
+3. **Skip the `pushFrame` decode when nobody's subscribed to display
+   state.** When all canvases are closed, `decodeDisplayFrame` still runs
+   on every spectrum frame and pushes into a store with zero subscribers.
+   Cheap per-call, but free if we short-circuit. Touches `realtime/
+   ws-client.ts`. Medium-invasive — needs a "subscriber count" signal.
+4. **Reduce per-frame GPU work.** `texSubImage2D` (waterfall) +
+   `bufferSubData` (panadapter trace) on every frame is the biggest
+   single chunk of remaining renderer cost. Touching this is **red-light**
+   per `CLAUDE.md` (UX/visual feel) — would need maintainer review before
+   any change. Possible angles:
+     - Decimate waterfall row uploads to every Nth frame (already
+       partially in place via `WF_PUSH_EVERY_N`; the constant could be
+       tunable).
+     - Use `requestVideoFrameCallback` semantics or compositor-driven
+       paints to skip uploads when the tile is offscreen (already done
+       via IntersectionObserver — confirm gating is firing).
+
+## Investigation method (so this is reproducible)
+
+1. Open `http://localhost:5173/` via Playwright (or just Chrome) with HL2
+   on the LAN.
+2. Inject perf instruments into the page: a `requestAnimationFrame`
+   counter (FPS), a `PerformanceObserver({entryTypes:['longtask']})`, a
+   `fetch` wrapper that bins URLs, and a `setInterval(500ms)` heap
+   sampler from `performance.memory`.
+3. In a parallel shell, run `top -l 31 -s 1 -ncols 6 -stats
+   pid,command,cpu,rsize,th,mem -pid <backend> -pid <renderer>
+   -pid <gpu> -pid 409` (`409` is WindowServer on macOS).
+4. Average per-PID `cpu` across the 31 samples. WindowServer is a
+   reference for system-wide workload — not "Zeus's cost".
+5. To isolate any single panel's cost, close all panels first, baseline,
+   then re-add one panel and re-sample.
+
+The smoking-gun fetch list and per-PID averages live under `/tmp/zeus-perf/`
+during a session.
+
+## References
+
+- Commits: `56dac59`, `7bb3808` on `feature/perf2`.
+- Server-side meter rates: `Zeus.Server.Hosting/TxMetersService.cs:94-95`
+  (`MoxTick = 100 ms`, `IdleTick = 500 ms`).
+- Canvas DPR clamp + visibility gate (prior work): `9a36afe`,
+  `1c5859a`.

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -95,8 +95,10 @@ import type { QrzStation } from './api/qrz';
 import type { Contact } from './components/design/data';
 
 // See ../state/connection-store.ts — StateDto is REST-poll only; WS is binary
-// frames. 333 ms poll keeps slow state (atten offset, adc overload) fresh.
-const STATE_POLL_MS = 333;
+// frames. 1 s poll keeps slow state (atten offset, adc overload) fresh — the
+// previous 333 ms cadence accounted for ~3 of the ~5 idle-RX fetches/sec and
+// drove repeated applyState/hydrateFromState fan-out into the React tree.
+const STATE_POLL_MS = 1000;
 
 export default function App() {
   useSwUpdatePrompt();

--- a/zeus-web/src/audio/use-mic-uplink.ts
+++ b/zeus-web/src/audio/use-mic-uplink.ts
@@ -52,6 +52,14 @@ import { warnOnce } from '../util/logger';
 // render -∞ and so the bar snaps to fully-empty on a quiet mic.
 const MIC_DBFS_FLOOR = -100;
 
+// Visual update cadence for MicMeter. The mic worklet emits a peak per
+// 20 ms block (50 Hz); driving Zustand at that rate triggers ~50 React
+// reconciliations a second of the bottom-bar meter, which is invisible to
+// the operator but a real CPU drain. We bucket the worklet's per-block
+// peaks across a ~50 ms window (20 Hz visual rate, smoother than TV) and
+// emit the *maximum* of each window so clip indication stays accurate.
+const MIC_VISUAL_INTERVAL_MS = 50;
+
 /**
  * Opens the mic AudioWorklet on mount and keeps it running while the app
  * is live. Peak dBFS of every 20 ms block is pushed to tx-store so the
@@ -68,13 +76,23 @@ export function useMicUplink(): void {
   useEffect(() => {
     let handle: MicUplinkHandle | null = null;
     let disposed = false;
+    let windowPeak = 0;
+    let lastEmit = 0;
 
     startMicUplink((samples, peak) => {
-      // Level: always pushed so MicMeter animates on RX.
-      const dbfs = peak > 0
-        ? Math.max(MIC_DBFS_FLOOR, 20 * Math.log10(peak))
-        : MIC_DBFS_FLOOR;
-      useTxStore.getState().setMicDbfs(dbfs);
+      // Level: always pushed so MicMeter animates on RX. Bucket the
+      // per-block peaks across MIC_VISUAL_INTERVAL_MS and emit the max so
+      // a transient clip is never lost between visual ticks.
+      if (peak > windowPeak) windowPeak = peak;
+      const now = performance.now();
+      if (now - lastEmit >= MIC_VISUAL_INTERVAL_MS) {
+        const dbfs = windowPeak > 0
+          ? Math.max(MIC_DBFS_FLOOR, 20 * Math.log10(windowPeak))
+          : MIC_DBFS_FLOOR;
+        useTxStore.getState().setMicDbfs(dbfs);
+        lastEmit = now;
+        windowPeak = 0;
+      }
 
       // Samples: only forwarded to the server while keyed. Capturing always +
       // gating here avoids a ~300 ms getUserMedia cold-start on every MOX.

--- a/zeus-web/src/state/rotator-store.ts
+++ b/zeus-web/src/state/rotator-store.ts
@@ -157,11 +157,13 @@ export const useRotatorStore = create<RotatorStoreState>((set) => ({
 }));
 
 // Kick off an initial status probe at module load, then poll at 1 s while the
-// page is alive. When rotctld is enabled and connected, this keeps the pill's
-// current-az readout in sync without the UI having to subscribe to a WS stream.
+// page is alive AND rotctld is enabled. When disabled there's nothing to
+// reconcile — skip the fetch to avoid an idle-RX HTTP wakeup the user can't
+// see anyway.
 if (typeof window !== 'undefined') {
   void useRotatorStore.getState().refreshStatus();
   window.setInterval(() => {
+    if (!useRotatorStore.getState().config.enabled) return;
     void useRotatorStore.getState().refreshStatus();
   }, 1000);
 

--- a/zeus-web/src/state/tci-store.ts
+++ b/zeus-web/src/state/tci-store.ts
@@ -92,11 +92,14 @@ export const useTciStore = create<TciStoreState>((set, get) => ({
   },
 }));
 
-// Initial status probe at module load + 2 s polling while the page is alive.
-// Status changes drive the panel's RequiresRestart flag and client count.
+// Initial status probe at module load + 2 s polling while the page is alive
+// AND TCI is enabled. Status changes drive the panel's RequiresRestart flag
+// and client count — neither matters when the listener isn't running, so skip
+// the fetch in the disabled-default case.
 if (typeof window !== 'undefined') {
   void useTciStore.getState().refreshStatus();
   window.setInterval(() => {
+    if (!useTciStore.getState().config.enabled) return;
     void useTciStore.getState().refreshStatus();
   }, 2000);
 }


### PR DESCRIPTION
## Summary

- `/api/state` poll: 333 ms → 1000 ms; rotator + TCI status pollers now skip when their feature is disabled. Drops idle fetch rate ~5 → ~2 req/s and the React fan-out of `applyState` + `hydrateFromState` from 3 Hz to 1 Hz.
- Mic AudioWorklet → `useTxStore.setMicDbfs` throttled 50 Hz → 20 Hz, bucketing per-block peaks across the window so clip indication stays accurate. Bottom-bar `MicMeter` is always mounted, so this fires even with the workspace empty.
- New `docs/performance_tuning.md` captures the methodology, what turned out to be a red herring, what the remaining cost is, and ordered next-pass candidates.

## Measured impact

31-sample `top` averages on a Mac mini, HL2 connected, all panels open, idle RX:

| | Before | After | Δ |
|---|---|---|---|
| Renderer (Zeus tab) | 30.8 % | 24.3 % | −6.5 pp |
| Chrome GPU helper | 12.8 % | 9.9 % | −2.9 pp |
| **Zeus frontend stack** | **43.6 %** | **34.2 %** | **−22 %** |
| Backend | 22.3 % | 23.6 % | noise |

No regressions: 60 fps steady, 0 long tasks > 50 ms, JS heap unchanged, ADC-overload reaction still well inside the 1 s poll window.

## Test plan

- [ ] Idle RX (HL2 on 20 m USB, no TX): renderer CPU on Mac mini lower than `develop` baseline; FPS still 60; no console errors.
- [ ] Disable rotator in Settings: confirm `/api/rotator/status` stops being requested.
- [ ] TCI disabled (default): confirm `/api/tci/status` is not polled.
- [ ] Speak into mic on RX: bar reacts smoothly, peak indicator is accurate against transient claps.
- [ ] MOX a brief carrier: TX meters still update at the server's 10 Hz cadence, no stutter.
- [ ] ADC overload (drive a strong signal): warning surfaces within ~1 s.