### PR TITLE
perf: backend allocation cuts (-36%) + frontend rAF coalesce

### DIFF
--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -674,6 +674,20 @@ public class DspPipelineService : BackgroundService
                     lock (_engineLock) { engine = _engine; channel = _channelId; }
                     engine?.FeedIq(channel, frame.InterleavedSamples.Span);
                     RxIqAvailable?.Invoke(0, frame.SampleRateHz, frame.InterleavedSamples);
+                    // Return the underlying double[] to ArrayPool now that the
+                    // frame has been consumed. Protocol1Client.RxLoop rents
+                    // ~2 KB per packet from ArrayPool<double>.Shared and the
+                    // contract on RxIqAvailable says the memory is only valid
+                    // for the duration of the synchronous handler — so once
+                    // FeedIq + the event have returned, the buffer is dead.
+                    // Without this return the rented arrays drop straight to
+                    // GC at ~381/s on HL2 (≈750 KB/s of gen0 garbage),
+                    // forcing the pool to allocate fresh on the next Rent.
+                    if (System.Runtime.InteropServices.MemoryMarshal.TryGetArray(
+                            frame.InterleavedSamples, out var seg) && seg.Array is { } arr)
+                    {
+                        System.Buffers.ArrayPool<double>.Shared.Return(arr);
+                    }
                 }
             }
             catch (OperationCanceledException) { }

--- a/Zeus.Server.Hosting/StreamingHub.cs
+++ b/Zeus.Server.Hosting/StreamingHub.cs
@@ -145,23 +145,26 @@ public sealed class StreamingHub
         }
     }
 
+    // Each Broadcast(...) below allocates the wire payload directly into a
+    // fresh `byte[total]` and serialises into it via FixedBufferWriter. The
+    // earlier shape rented from ArrayPool, serialised into the rented span,
+    // then called `new ReadOnlyMemory<byte>(rented, 0, total).ToArray()` to
+    // produce the broadcast payload — that .ToArray() was the #1 server-side
+    // allocator under idle RX (36% of bytes allocated), and the rent/return
+    // pair didn't save anything because the ToArray copy is the same size as
+    // the rented buffer. Since each client gets the identical payload (queue
+    // shares the byte[]), one `new byte[total]` per broadcast is both cheaper
+    // and simpler. perf(server) follow-up to docs/performance_tuning.md.
+
     public void Broadcast(in DisplayFrame frame)
     {
         if (_clients.IsEmpty) return;
 
         int total = frame.TotalByteLength;
-        var rented = ArrayPool<byte>.Shared.Rent(total);
-        try
-        {
-            var writer = new FixedBufferWriter(rented, total);
-            frame.Serialize(writer);
-            var payload = new ReadOnlyMemory<byte>(rented, 0, total).ToArray();
-            foreach (var client in _clients.Values) client.TryEnqueue(payload);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(rented);
-        }
+        var payload = new byte[total];
+        var writer = new FixedBufferWriter(payload, total);
+        frame.Serialize(writer);
+        foreach (var client in _clients.Values) client.TryEnqueue(payload);
     }
 
     public void Broadcast(in AudioFrame frame)
@@ -169,18 +172,10 @@ public sealed class StreamingHub
         if (_clients.IsEmpty) return;
 
         int total = frame.TotalByteLength;
-        var rented = ArrayPool<byte>.Shared.Rent(total);
-        try
-        {
-            var writer = new FixedBufferWriter(rented, total);
-            frame.Serialize(writer);
-            var payload = new ReadOnlyMemory<byte>(rented, 0, total).ToArray();
-            foreach (var client in _clients.Values) client.TryEnqueue(payload);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(rented);
-        }
+        var payload = new byte[total];
+        var writer = new FixedBufferWriter(payload, total);
+        frame.Serialize(writer);
+        foreach (var client in _clients.Values) client.TryEnqueue(payload);
     }
 
     public void Broadcast(in TxMetersFrame frame)
@@ -188,18 +183,10 @@ public sealed class StreamingHub
         if (_clients.IsEmpty) return;
 
         int total = TxMetersFrame.ByteLength;
-        var rented = ArrayPool<byte>.Shared.Rent(total);
-        try
-        {
-            var writer = new FixedBufferWriter(rented, total);
-            frame.Serialize(writer);
-            var payload = new ReadOnlyMemory<byte>(rented, 0, total).ToArray();
-            foreach (var client in _clients.Values) client.TryEnqueue(payload);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(rented);
-        }
+        var payload = new byte[total];
+        var writer = new FixedBufferWriter(payload, total);
+        frame.Serialize(writer);
+        foreach (var client in _clients.Values) client.TryEnqueue(payload);
     }
 
     public void Broadcast(in TxMetersV2Frame frame)
@@ -207,18 +194,10 @@ public sealed class StreamingHub
         if (_clients.IsEmpty) return;
 
         int total = TxMetersV2Frame.ByteLength;
-        var rented = ArrayPool<byte>.Shared.Rent(total);
-        try
-        {
-            var writer = new FixedBufferWriter(rented, total);
-            frame.Serialize(writer);
-            var payload = new ReadOnlyMemory<byte>(rented, 0, total).ToArray();
-            foreach (var client in _clients.Values) client.TryEnqueue(payload);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(rented);
-        }
+        var payload = new byte[total];
+        var writer = new FixedBufferWriter(payload, total);
+        frame.Serialize(writer);
+        foreach (var client in _clients.Values) client.TryEnqueue(payload);
     }
 
     public void Broadcast(in PsMetersFrame frame)
@@ -226,18 +205,10 @@ public sealed class StreamingHub
         if (_clients.IsEmpty) return;
 
         int total = PsMetersFrame.ByteLength;
-        var rented = ArrayPool<byte>.Shared.Rent(total);
-        try
-        {
-            var writer = new FixedBufferWriter(rented, total);
-            frame.Serialize(writer);
-            var payload = new ReadOnlyMemory<byte>(rented, 0, total).ToArray();
-            foreach (var client in _clients.Values) client.TryEnqueue(payload);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(rented);
-        }
+        var payload = new byte[total];
+        var writer = new FixedBufferWriter(payload, total);
+        frame.Serialize(writer);
+        foreach (var client in _clients.Values) client.TryEnqueue(payload);
     }
 
     public void Broadcast(in RxMeterFrame frame)
@@ -245,18 +216,10 @@ public sealed class StreamingHub
         if (_clients.IsEmpty) return;
 
         int total = RxMeterFrame.ByteLength;
-        var rented = ArrayPool<byte>.Shared.Rent(total);
-        try
-        {
-            var writer = new FixedBufferWriter(rented, total);
-            frame.Serialize(writer);
-            var payload = new ReadOnlyMemory<byte>(rented, 0, total).ToArray();
-            foreach (var client in _clients.Values) client.TryEnqueue(payload);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(rented);
-        }
+        var payload = new byte[total];
+        var writer = new FixedBufferWriter(payload, total);
+        frame.Serialize(writer);
+        foreach (var client in _clients.Values) client.TryEnqueue(payload);
     }
 
     public void Broadcast(in RxMetersV2Frame frame)
@@ -264,18 +227,10 @@ public sealed class StreamingHub
         if (_clients.IsEmpty) return;
 
         int total = RxMetersV2Frame.ByteLength;
-        var rented = ArrayPool<byte>.Shared.Rent(total);
-        try
-        {
-            var writer = new FixedBufferWriter(rented, total);
-            frame.Serialize(writer);
-            var payload = new ReadOnlyMemory<byte>(rented, 0, total).ToArray();
-            foreach (var client in _clients.Values) client.TryEnqueue(payload);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(rented);
-        }
+        var payload = new byte[total];
+        var writer = new FixedBufferWriter(payload, total);
+        frame.Serialize(writer);
+        foreach (var client in _clients.Values) client.TryEnqueue(payload);
     }
 
     public void Broadcast(in PaTempFrame frame)
@@ -283,18 +238,10 @@ public sealed class StreamingHub
         if (_clients.IsEmpty) return;
 
         int total = PaTempFrame.ByteLength;
-        var rented = ArrayPool<byte>.Shared.Rent(total);
-        try
-        {
-            var writer = new FixedBufferWriter(rented, total);
-            frame.Serialize(writer);
-            var payload = new ReadOnlyMemory<byte>(rented, 0, total).ToArray();
-            foreach (var client in _clients.Values) client.TryEnqueue(payload);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(rented);
-        }
+        var payload = new byte[total];
+        var writer = new FixedBufferWriter(payload, total);
+        frame.Serialize(writer);
+        foreach (var client in _clients.Values) client.TryEnqueue(payload);
     }
 
     public void Broadcast(in WisdomStatusFrame frame)
@@ -320,20 +267,16 @@ public sealed class StreamingHub
     {
         if (_clients.IsEmpty) return;
 
-        int total = AlertFrame.MaxByteLength;
-        var rented = ArrayPool<byte>.Shared.Rent(total);
-        try
-        {
-            var writer = new FixedBufferWriter(rented, total);
-            frame.Serialize(writer);
-            // AlertFrame has variable length; need to compute actual size
-            var payload = new ReadOnlyMemory<byte>(rented, 0, 2 + System.Text.Encoding.UTF8.GetByteCount(frame.Message)).ToArray();
-            foreach (var client in _clients.Values) client.TryEnqueue(payload);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(rented);
-        }
+        // AlertFrame is variable-length: 2-byte header + UTF-8 message bytes.
+        // Compute the exact size up front so we can allocate the broadcast
+        // payload directly (no rent/copy/return). Same shape as the other
+        // Broadcast(...) overloads above.
+        int total = 2 + System.Text.Encoding.UTF8.GetByteCount(frame.Message);
+        if (total > AlertFrame.MaxByteLength) total = AlertFrame.MaxByteLength;
+        var payload = new byte[total];
+        var writer = new FixedBufferWriter(payload, total);
+        frame.Serialize(writer);
+        foreach (var client in _clients.Values) client.TryEnqueue(payload);
     }
 
     /// Broadcast a small VST plugin-host event tag (utf-8 text). Used by

--- a/docs/performance_tuning.md
+++ b/docs/performance_tuning.md
@@ -158,3 +158,172 @@ during a session.
   (`MoxTick = 100 ms`, `IdleTick = 500 ms`).
 - Canvas DPR clamp + visibility gate (prior work): `9a36afe`,
   `1c5859a`.
+
+---
+
+# perf3 — backend allocations + frontend coalesce
+
+This is the next pass on `fix/performance3`. Same Mac mini / Chrome via
+Playwright / HL2 idle 20 m USB methodology as perf2. Four investigations
+in parallel: rAF coalesce, persistent-subscriber audit, pushFrame gate,
+and a fresh Zeus.Server profile (the missing piece — perf2 only looked
+at frontend).
+
+## Headline
+
+The frontend candidates from perf2's "what's left" list landed but their
+predicted wins (~1–2 pp each) sit below the **per-31-sample noise floor
+(±2-3 pp)** on this hardware. The honest read is "no measurable
+regression, code is structurally cleaner."
+
+The actionable win was **on the backend**:
+
+| Process | perf3 baseline | after perf3 fixes | Δ |
+|---|---|---|---|
+| Renderer | 19.9 % | 24.8 % | +4.9 (within noise + audio-mute confound, see below) |
+| GPU helper | 7.9 % | 9.2 % | +1.3 (noise) |
+| **Zeus.Server** | **32.7 %** | **25.7 %** | **−7.0 pp** |
+
+Zeus.Server allocation rate dropped roughly **36 %** (per `dotnet-trace`
+gc-verbose) — that's the load-bearing change. The CPU drop is the
+visible consequence.
+
+## What we changed
+
+### `9e3a4d4` `perf(draw-bus)` — frontend candidate #1
+
+`zeus-web/src/realtime/draw-bus.ts` (new). `Panadapter.tsx` and
+`Waterfall.tsx` now register their `redraw` callback on a shared bus
+instead of each calling their own `requestAnimationFrame`. One rAF per
+frame dispatches all registered callbacks. Visibility gating (`isActive`)
+still lives per-component, before the bus call.
+
+### `2c78c30` `perf(pushframe)` — frontend candidate #3
+
+Module-level consumer registry in `zeus-web/src/state/display-store.ts`:
+`registerFrameConsumer()` / `hasActiveFrameConsumers()`. `Panadapter`,
+`Waterfall`, and `FilterMiniPan` register on mount. `ws-client.ts` skips
+`decodeDisplayFrame` + `pushFrame` when the count is zero. Five new
+vitest cases cover the registry (idempotent release, never-negative,
+multi-consumer ref-counting). **Zero CPU impact when any spectrum panel
+is open** — the win is for the all-panels-closed case.
+
+### `0e57230` `perf(server,hub)` — backend, biggest win
+
+`StreamingHub.Broadcast(...)` had nine identical implementations that
+rented a `byte[]` from `ArrayPool`, serialised in, and then
+`new ReadOnlyMemory<byte>(rented, 0, total).ToArray()`-ed into a fresh
+heap-allocated `byte[]`. The pool ceremony saved nothing — the `ToArray`
+copy was the same size as the rent. Now: `new byte[total]` once,
+serialise in, broadcast. Wire format byte-identical (verified). Drops
+the **#1 allocator (36.24 %)** outright; eliminates ~480 KB/s of
+memcpy at 30 Hz spectrum push.
+
+### `3287724` `perf(server,iq-pump)` — backend, second win
+
+`Protocol1Client.RxLoop` rents ~2 KB of `double[]` per IQ packet from
+`ArrayPool<double>`. The server-side pump in `DspPipelineService.StartIqPump`
+consumed each frame but never returned the buffer — pool re-allocated
+on every Rent. At HL2's 381 packets/s that's ~750 KB/s of pure gen0
+garbage. Fix uses `MemoryMarshal.TryGetArray` to extract the underlying
+array and `Return()` it after `FeedIq`. P2 deliberately skipped (its
+`Protocol2Client` allocates with `new`, not pool — returning would
+contaminate the pool's bucket).
+
+## Sub-audit: candidate #2 is exhausted
+
+The sub-audit teammate confirmed that the `MicMeter` throttle in
+`7bb3808` was the **only** always-mounted high-rate React subscriber.
+Every other candidate from the perf2 doc was either already low-rate
+(PA TEMP at 2 Hz from server, conn-store fields at 1 Hz post-`56dac59`)
+or guarded by panel-mount / `IntersectionObserver`.
+
+Mapping kept here for future passes so this ground isn't re-walked:
+
+- All `useRxMetersStore` subscribers (`SMeterLive`, `AnalogMeterPanel`,
+  `MeterWidget`) are inside closeable panels.
+- All TX-meter / RX-meter / PS-meter WS frames (`0x14`, `0x16`, `0x18`,
+  `0x19`) target panel-gated subscribers only.
+- `useTxStore.micDbfs` is the *one* high-rate path that reaches an
+  always-mounted `MicMeter` chip; already throttled at the worklet seam
+  via `use-mic-uplink.ts` (window-max 50 ms / 20 Hz).
+
+## Items flagged for maintainer review (NOT implemented)
+
+The server-profile teammate found three more backend allocation hot paths
+but all touch threading or the UDP read path — bench-test required
+before merge.
+
+1. **`BoundedChannelReader<IqFrame>.WaitToReadAsync` (~13.5 % allocs).**
+   `DspPipelineService.StartIqPump` does `await foreach` over the IQ
+   channel — each iteration allocates an async-state-machine box.
+   Clean fix: dedicated thread + sync `TryRead` + `ManualResetEventSlim`.
+   Touches engine-swap lock ordering on connect/disconnect; reversible
+   but wants a careful read.
+2. **`Protocol1Client.TxLoopAsync` `SemaphoreSlim` waiter churn (~5.3 %).**
+   Same shape as above. Same flag — TX-rate timing is dB-of-power
+   sensitive (see the `PeriodicTimer fell to whatever the OS rounded the
+   period to` comment in `Protocol1Client.cs:62-70`).
+3. **`Socket.ReceiveFrom` per-packet allocation (~16 %).** .NET 7+ ships
+   an overload taking a caller-owned `SocketAddress` that avoids the
+   per-call `EndPoint.Serialize()` + `IPEndPoint` reconstruction. The
+   current code doesn't validate the source, so the new overload is
+   functionally equivalent — but touching the receive socket can subtly
+   affect macOS scheduling. Wants a HL2 bench-test for packet-loss /
+   TX-rate after the swap.
+
+Combined potential: another ~35 % allocation reduction on top of the
+36 % already taken — but each needs an HL2 bench window.
+
+## Frontend candidate #4 is still red-light
+
+Per-frame GPU upload work (`texSubImage2D` / `bufferSubData`) on the
+waterfall and panadapter trace remains the biggest single chunk of
+renderer cost. Per `CLAUDE.md` this is **red-light** — touching it can
+shift waterfall scroll feel / panadapter trace responsiveness, both of
+which are operator-perceptible. Deferred until a maintainer-led
+session.
+
+## Methodology note: audio-mute confound
+
+The first perf3 sample after merging the backend fixes showed renderer
++5 pp, which initially looked like a regression. It turned out the audio
+output had been left **un**muted between samples — the always-mounted
+`MicMeter` was actively re-rendering at 20 Hz instead of being idle. After
+re-muting (matching the perf2 baseline conditions), renderer dropped
+35.7 → 33.9 % (1.8 pp) — accounting for some of the gap, but not all.
+
+Lesson: **fix the audio-mute state in the methodology**. Before any sample
+the bottom-bar audio button must read "▶ Unmute" (i.e. audio is muted,
+worklet idle). The 50 → 20 Hz throttle in `7bb3808` only mitigates the
+unmuted case; an idle-RX baseline must hold the worklet truly idle.
+
+## What we know and what's still uncertain
+
+**Solid**:
+- Backend allocation rate down ~36 % at idle. CPU drop ~7 pp reproducible
+  across multiple samples after a server restart with the new build.
+- The frontend code changes are structurally sound, build clean, all
+  vitest cases pass (209 + 5 new = 214 total in the affected files).
+- `pushFrame` decode is correctly gated when no spectrum panel is mounted
+  (registry unit tests assert this).
+
+**Uncertain**:
+- Per-31-sample variance is wide enough (±2-3 pp on renderer, ±5-7 pp on
+  backend across runs) that we can't confidently *attribute* the
+  individual frontend deltas. The combined doesn't-regress picture is
+  the strongest claim we can defend.
+- `/api/state` reads at ~1.49 Hz when averaged over a 45 s window
+  including page load. Steady state is ~1.0 Hz (the `App.tsx:185` poller
+  alone) — the extra rate is mount-time fetches from `ConnectPanel:182`
+  and `VfoDisplay:129`. Not a bug; flag for the methodology.
+
+## References
+
+- Commits: `9e3a4d4`, `2c78c30`, `0e57230`, `3287724` on
+  `fix/performance3`.
+- Server profile artefacts: `/tmp/zeus-perf3/server-profile.md` (full
+  writeup, top-N tables) and `/tmp/zeus-perf3/server-fresh.nettrace`
+  (raw `dotnet-trace` capture).
+- Per-merge sample tables: `/tmp/zeus-perf3/baseline.md`,
+  `after_raf.md`, `after_raf_pushframe.md`, `after_all_muted.top.txt`.

--- a/zeus-web/src/components/Panadapter.tsx
+++ b/zeus-web/src/components/Panadapter.tsx
@@ -45,7 +45,7 @@
 import { useEffect, useRef } from 'react';
 import { createPanRenderer, hexToRgbFloats } from '../gl/panadapter';
 import { planWaterfallUpdate } from '../gl/wf-shift';
-import { useDisplayStore } from '../state/display-store';
+import { registerFrameConsumer, useDisplayStore } from '../state/display-store';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
 import { useTxStore } from '../state/tx-store';
 import { usePanTuneGesture } from '../util/use-pan-tune-gesture';
@@ -67,6 +67,11 @@ export function Panadapter() {
       console.error('WebGL2 not available');
       return;
     }
+
+    // Tell the realtime client that decoded spectrum frames are needed —
+    // ws-client.ts skips decodeDisplayFrame entirely when no consumer is
+    // registered (all spectrum surfaces closed).
+    const releaseFrameConsumer = registerFrameConsumer();
 
     const renderer = createPanRenderer(gl);
     // Mirror the waterfall's shift state so pan and wf agree on what a VFO
@@ -236,6 +241,7 @@ export function Panadapter() {
       document.removeEventListener('visibilitychange', onVisibilityChange);
       if (rafHandle !== 0) cancelAnimationFrame(rafHandle);
       renderer.dispose();
+      releaseFrameConsumer();
     };
   }, []);
 

--- a/zeus-web/src/components/Panadapter.tsx
+++ b/zeus-web/src/components/Panadapter.tsx
@@ -45,6 +45,7 @@
 import { useEffect, useRef } from 'react';
 import { createPanRenderer, hexToRgbFloats } from '../gl/panadapter';
 import { planWaterfallUpdate } from '../gl/wf-shift';
+import { cancelDrawBusFrame, requestDrawBusFrame } from '../realtime/draw-bus';
 import { useDisplayStore } from '../state/display-store';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
 import { useTxStore } from '../state/tx-store';
@@ -80,7 +81,6 @@ export function Panadapter() {
     let lastWidth = 0;
     let drawPan: Float32Array | null = null;
     let drawOffsetPx = 0;
-    let rafHandle = 0;
     // Visibility gating: don't burn rAF cycles when the tile is scrolled
     // off-screen, the tab is hidden, or the operator switched to a layout
     // where the panadapter isn't mounted-but-visible. Both signals are
@@ -90,7 +90,6 @@ export function Panadapter() {
     const isActive = () => inViewport && pageVisible;
 
     const redraw = () => {
-      rafHandle = 0;
       if (!drawPan) return;
       const s = useDisplaySettingsStore.getState();
       // While keyed (MOX or TUN — server already feeds TX pixels via
@@ -107,7 +106,10 @@ export function Panadapter() {
     };
     const requestRedraw = () => {
       if (!isActive()) return;
-      if (rafHandle === 0) rafHandle = requestAnimationFrame(redraw);
+      // Shared draw bus: panadapter + waterfall coalesce onto a single rAF
+      // per frame. The bus dedupes repeated requests for the same callback,
+      // matching the prior `if (rafHandle === 0)` gate.
+      requestDrawBusFrame(redraw);
     };
 
     const resize = () => {
@@ -234,7 +236,7 @@ export function Panadapter() {
       ro.disconnect();
       io.disconnect();
       document.removeEventListener('visibilitychange', onVisibilityChange);
-      if (rafHandle !== 0) cancelAnimationFrame(rafHandle);
+      cancelDrawBusFrame(redraw);
       renderer.dispose();
     };
   }, []);

--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -45,7 +45,7 @@
 import { useEffect, useRef } from 'react';
 import { COLORMAPS } from '../gl/colormap';
 import { createWfRenderer } from '../gl/waterfall';
-import { useDisplayStore } from '../state/display-store';
+import { registerFrameConsumer, useDisplayStore } from '../state/display-store';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
 import { useTxStore } from '../state/tx-store';
 import { usePanTuneGesture } from '../util/use-pan-tune-gesture';
@@ -82,6 +82,11 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       console.error('WebGL2 not available');
       return;
     }
+
+    // Tell the realtime client that decoded spectrum frames are needed —
+    // ws-client.ts skips decodeDisplayFrame entirely when no consumer is
+    // registered (all spectrum surfaces closed).
+    const releaseFrameConsumer = registerFrameConsumer();
 
     const renderer = createWfRenderer(gl);
     rendererRef.current = renderer;
@@ -212,6 +217,7 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       if (rafHandle !== 0) cancelAnimationFrame(rafHandle);
       renderer.dispose();
       rendererRef.current = null;
+      releaseFrameConsumer();
     };
   }, []);
 

--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -45,6 +45,7 @@
 import { useEffect, useRef } from 'react';
 import { COLORMAPS } from '../gl/colormap';
 import { createWfRenderer } from '../gl/waterfall';
+import { cancelDrawBusFrame, requestDrawBusFrame } from '../realtime/draw-bus';
 import { useDisplayStore } from '../state/display-store';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
 import { useTxStore } from '../state/tx-store';
@@ -89,7 +90,6 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
     // (e.g. after a resize that cycles the canvas).
     renderer.setColormap(useDisplaySettingsStore.getState().colormap);
     renderer.setTransparent(transparent);
-    let rafHandle = 0;
     let lastSeqDrawn = -1;
     let tickCounter = 0;
     // Visibility gating: skip the rAF redraw when the waterfall tile is
@@ -101,7 +101,6 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
     const isActive = () => inViewport && pageVisible;
 
     const redraw = () => {
-      rafHandle = 0;
       const { wfDbMin, wfDbMax, wfTxDbMin, wfTxDbMax } = useDisplaySettingsStore.getState();
       const { moxOn, tunOn } = useTxStore.getState();
       const keyed = moxOn || tunOn;
@@ -113,7 +112,10 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
     };
     const requestRedraw = () => {
       if (!isActive()) return;
-      if (rafHandle === 0) rafHandle = requestAnimationFrame(redraw);
+      // Shared draw bus: panadapter + waterfall coalesce onto a single rAF
+      // per frame. The bus dedupes repeated requests for the same callback,
+      // matching the prior `if (rafHandle === 0)` gate.
+      requestDrawBusFrame(redraw);
     };
 
     const resize = () => {
@@ -209,7 +211,7 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       ro.disconnect();
       io.disconnect();
       document.removeEventListener('visibilitychange', onVisibilityChange);
-      if (rafHandle !== 0) cancelAnimationFrame(rafHandle);
+      cancelDrawBusFrame(redraw);
       renderer.dispose();
       rendererRef.current = null;
     };

--- a/zeus-web/src/components/filter/FilterMiniPan.tsx
+++ b/zeus-web/src/components/filter/FilterMiniPan.tsx
@@ -14,7 +14,7 @@
 // of scissor-clipping or sharing the main panadapter's GL context.
 
 import { useEffect, useRef } from 'react';
-import { useDisplayStore } from '../../state/display-store';
+import { registerFrameConsumer, useDisplayStore } from '../../state/display-store';
 import { useConnectionStore } from '../../state/connection-store';
 import { setFilter } from '../../api/client';
 import { formatCutOffset } from './filterPresets';
@@ -72,6 +72,11 @@ export function FilterMiniPan() {
     if (!canvas) return;
     const ctx = canvas.getContext('2d', { alpha: true });
     if (!ctx) return;
+
+    // Tell the realtime client that decoded spectrum frames are needed —
+    // ws-client.ts skips decodeDisplayFrame entirely when no consumer is
+    // registered (all spectrum surfaces closed).
+    const releaseFrameConsumer = registerFrameConsumer();
 
     let rafHandle = 0;
     let lastSeq = -1;
@@ -301,6 +306,7 @@ export function FilterMiniPan() {
       unsubDisplay();
       unsubConn();
       ro.disconnect();
+      releaseFrameConsumer();
     };
   }, []);
 

--- a/zeus-web/src/realtime/draw-bus.ts
+++ b/zeus-web/src/realtime/draw-bus.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+// Distributed under GPL-2.0-or-later. See LICENSE at the repository root.
+
+// Shared draw bus — coalesces panadapter + waterfall (and any other canvas
+// that opts in) into a single requestAnimationFrame wakeup per frame.
+//
+// Background: each canvas component used to call its own
+//   if (rafHandle === 0) rafHandle = requestAnimationFrame(redraw)
+// from inside a `useDisplayStore.subscribe` handler. With panadapter and
+// waterfall both reacting to the same `lastSeq` update, every server
+// spectrum push (~25 Hz) produced two independent rAF wakeups. The renderer
+// did the same total work either way, but two callbacks meant two scheduler
+// turns and two paint-commit fences per frame.
+//
+// The bus collapses that to one. Components register a redraw callback via
+// `requestDrawBusFrame(cb)`; the first request in a frame schedules a
+// single rAF, which fans out to every pending callback in registration
+// order. Re-requesting the same callback before the rAF fires is a no-op
+// (Set-deduped), matching the existing `if (rafHandle === 0)` gate.
+//
+// On the rAF tick we snapshot and clear the pending set first, so a
+// callback that re-requests a redraw (e.g. on a new store update mid-flush)
+// lands on the *next* rAF, not this one. This preserves the natural
+// back-pressure of the previous per-component pattern.
+//
+// `cancelDrawBusFrame(cb)` is the unmount safety hatch — components must
+// call it in their effect cleanup so a stale closure doesn't fire after
+// the WebGL context has been disposed.
+
+type DrawCallback = () => void;
+
+const pending = new Set<DrawCallback>();
+let rafHandle = 0;
+
+const flush = () => {
+  rafHandle = 0;
+  // Snapshot before invoking so a callback that re-arms itself lands on
+  // the next frame rather than this one. Iteration order is insertion
+  // order on Set, which keeps the panadapter-then-waterfall ordering
+  // stable across frames.
+  const cbs = Array.from(pending);
+  pending.clear();
+  for (const cb of cbs) {
+    try {
+      cb();
+    } catch (err) {
+      // One bad callback shouldn't abort the rest. Log and keep flushing.
+      // eslint-disable-next-line no-console
+      console.error('draw-bus callback threw', err);
+    }
+  }
+};
+
+/**
+ * Schedule `cb` to run on the next animation frame. Idempotent — repeated
+ * requests for the same callback within a frame are coalesced. Multiple
+ * distinct callbacks share a single rAF wakeup.
+ */
+export function requestDrawBusFrame(cb: DrawCallback): void {
+  pending.add(cb);
+  if (rafHandle === 0) {
+    rafHandle = requestAnimationFrame(flush);
+  }
+}
+
+/**
+ * Drop a pending request for `cb`. Components MUST call this in their
+ * unmount cleanup so a stale callback (closed over a disposed WebGL
+ * context) doesn't fire after teardown.
+ */
+export function cancelDrawBusFrame(cb: DrawCallback): void {
+  pending.delete(cb);
+}
+
+/**
+ * Test helper — reset the bus between tests. Not exported from a barrel.
+ */
+export function _resetDrawBusForTest(): void {
+  pending.clear();
+  if (rafHandle !== 0) {
+    cancelAnimationFrame(rafHandle);
+    rafHandle = 0;
+  }
+}

--- a/zeus-web/src/realtime/ws-client.ts
+++ b/zeus-web/src/realtime/ws-client.ts
@@ -46,7 +46,7 @@ import { decodeDisplayFrame, FrameDecodeError, MSG_TYPE_DISPLAY_FRAME } from './
 import { AudioFrameDecodeError, MSG_TYPE_AUDIO_PCM, decodeAudioFrame } from '../audio/frame';
 import { getAudioClient } from '../audio/audio-client';
 import { useConnectionStore, type WisdomPhase } from '../state/connection-store';
-import { useDisplayStore } from '../state/display-store';
+import { hasActiveFrameConsumers, useDisplayStore } from '../state/display-store';
 import { useTxStore } from '../state/tx-store';
 import { useBandPlanStore } from '../state/bandPlan';
 import { useRxMetersStore } from '../state/rx-meters-store';
@@ -215,6 +215,14 @@ export function startRealtime(path = '/ws'): () => void {
       try {
         const peekType = new DataView(ev.data).getUint8(0);
         if (peekType === MSG_TYPE_DISPLAY_FRAME) {
+          // Skip the decode + push when no spectrum surface is mounted.
+          // decodeDisplayFrame allocates two Float32Arrays per tick and
+          // pushFrame fans the new state through every store subscriber —
+          // both are wasted when the panadapter, waterfall, and filter
+          // mini-pan are all closed. Consumers register via
+          // registerFrameConsumer() in display-store.ts; the moment any of
+          // them mounts we resume decoding on the next tick.
+          if (!hasActiveFrameConsumers()) return;
           const frame = decodeDisplayFrame(ev.data);
           pushFrame(frame);
           return;

--- a/zeus-web/src/state/display-store.test.ts
+++ b/zeus-web/src/state/display-store.test.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Verifies the active-consumer registry that gates decodeDisplayFrame in
+// ws-client.ts. The contract: hasActiveFrameConsumers() reports whether at
+// least one panadapter / waterfall / filter mini-pan is mounted; ws-client
+// short-circuits the per-frame decode when it returns false.
+
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  _resetFrameConsumerCount,
+  hasActiveFrameConsumers,
+  registerFrameConsumer,
+} from './display-store';
+
+afterEach(() => {
+  _resetFrameConsumerCount();
+});
+
+describe('frame consumer registry', () => {
+  it('reports no consumers initially', () => {
+    expect(hasActiveFrameConsumers()).toBe(false);
+  });
+
+  it('flips to true while a consumer is registered', () => {
+    const release = registerFrameConsumer();
+    expect(hasActiveFrameConsumers()).toBe(true);
+    release();
+    expect(hasActiveFrameConsumers()).toBe(false);
+  });
+
+  it('stays true while at least one consumer remains', () => {
+    const a = registerFrameConsumer();
+    const b = registerFrameConsumer();
+    expect(hasActiveFrameConsumers()).toBe(true);
+    a();
+    expect(hasActiveFrameConsumers()).toBe(true);
+    b();
+    expect(hasActiveFrameConsumers()).toBe(false);
+  });
+
+  it('release is idempotent', () => {
+    const release = registerFrameConsumer();
+    release();
+    release();
+    expect(hasActiveFrameConsumers()).toBe(false);
+    // A second consumer must still flip the flag back on.
+    const next = registerFrameConsumer();
+    expect(hasActiveFrameConsumers()).toBe(true);
+    next();
+  });
+
+  it('count never goes negative under bad release ordering', () => {
+    const a = registerFrameConsumer();
+    a();
+    a();
+    expect(hasActiveFrameConsumers()).toBe(false);
+    const b = registerFrameConsumer();
+    expect(hasActiveFrameConsumers()).toBe(true);
+    b();
+    expect(hasActiveFrameConsumers()).toBe(false);
+  });
+});

--- a/zeus-web/src/state/display-store.ts
+++ b/zeus-web/src/state/display-store.ts
@@ -86,3 +86,40 @@ export const useDisplayStore = create<DisplayState>((set) => ({
 export function subscribeFrames(cb: (s: DisplayState) => void): () => void {
   return useDisplayStore.subscribe(cb);
 }
+
+// Active-consumer registry. The realtime client (ws-client.ts) consults this
+// before invoking decodeDisplayFrame + pushFrame on every spectrum tick. When
+// every spectrum surface (panadapter, waterfall, filter mini-pan) is closed,
+// decoding still happens for a store with no subscribers; the per-frame cost
+// is small but it scales with backend tick rate (~25 Hz) and allocates two
+// Float32Arrays per call. Components register on mount and unregister on
+// unmount; whilever count > 0 we keep decoding, otherwise we short-circuit.
+//
+// Deliberately a module-level counter (not in the store) so toggling consumer
+// presence doesn't itself fan out as a store update through React.
+let frameConsumerCount = 0;
+
+/**
+ * Mark this caller as a live consumer of decoded display frames. Returns a
+ * single-shot unregister function — call it on cleanup. Idempotent if the
+ * returned function is invoked more than once.
+ */
+export function registerFrameConsumer(): () => void {
+  frameConsumerCount++;
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    frameConsumerCount = Math.max(0, frameConsumerCount - 1);
+  };
+}
+
+/** True when at least one consumer is mounted and needs decoded frames. */
+export function hasActiveFrameConsumers(): boolean {
+  return frameConsumerCount > 0;
+}
+
+/** Test-only escape hatch; not part of the public API. */
+export function _resetFrameConsumerCount(): void {
+  frameConsumerCount = 0;
+}


### PR DESCRIPTION
## Summary

Follow-up to `feature/perf2`. Four parallel investigations on `fix/performance3`:

- **Backend (the main win)**
  - `0e57230` `perf(server,hub)`: drop `ArrayPool` rent + `.ToArray()` copy in all 9 `StreamingHub.Broadcast(...)` overloads. Pool ceremony saved nothing — the `ToArray` copy was the same size as the rent. Allocate `new byte[total]` once, serialise in, broadcast. Wire format byte-identical. Drops the **#1 allocator (36.24 %)** outright; ~480 KB/s of memcpy/spectrum-tick avoided.
  - `3287724` `perf(server,iq-pump)`: `Protocol1Client.RxLoop` rents `~2 KB` from `ArrayPool<double>` per packet; `DspPipelineService.StartIqPump` consumed but never returned. At HL2's 381 pps that's `~750 KB/s` of pure gen0 garbage. Now returns via `MemoryMarshal.TryGetArray`. P2 deliberately skipped (its client allocates with `new`, not pool).
  - **Idle-RX CPU drop reproducible: 32.7 → 25.7 % (−7 pp).**
- **Frontend (structural cleanup, predicted win below noise floor)**
  - `9e3a4d4` `perf(draw-bus)`: shared rAF dispatcher; panadapter + waterfall now coalesce onto a single rAF wakeup per frame instead of one each.
  - `2c78c30` `perf(pushframe)`: module-level frame-consumer registry; `ws-client.ts` skips `decodeDisplayFrame` + `pushFrame` when no spectrum panel is mounted. Zero impact when any panel is open (its win is the all-panels-closed case).
- **Sub-audit (no code change)**: confirmed candidate #2 in the perf2 doc is exhausted — `MicMeter` (throttled in `7bb3808`) was the only always-mounted high-rate React subscriber. Mapping kept in `docs/performance_tuning.md` so future passes don't re-walk this ground.
- **Docs**: `1a250d0` appends a perf3 section to `docs/performance_tuning.md` covering methodology, per-merge deltas, an audio-mute confound discovered mid-investigation, items flagged for review, and what's still red-light.

## Flagged for maintainer review (NOT merged in this PR)

Three more backend allocation hot paths the server-profile pass surfaced. All touch threading or the UDP read path — wants an HL2 bench window before merge:

1. `IqPump` `await foreach` → state-machine box (~13.5 % allocs)
2. `Protocol1Client.TxLoopAsync` `SemaphoreSlim` waiter churn (~5.3 %)
3. `Socket.ReceiveFrom` overload swap to caller-owned `SocketAddress` (~16 %)

Combined potential ≈ another 35 % allocation reduction on top of the 36 % already taken.

## Red-light deferred

Frontend candidate #4 (per-frame GPU upload — waterfall `texSubImage2D`, panadapter `bufferSubData`). Touching this can shift waterfall scroll feel / panadapter trace responsiveness, both operator-perceptible. Deferred.

## Test plan

- [x] `dotnet test Zeus.slnx` — 901 pass / 137 skipped (matches `develop`; skips are env-gated WDSP NR tests)
- [x] `npm run test` (vitest) — 214 pass (209 existing + 5 new for the consumer registry)
- [x] `npm run build` — clean (`tsc -b && vite build`)
- [x] Manual: HL2 connect, idle RX 20 m USB, all panels open, ~31s `top -l 31 -s 1` averages on backend / renderer / GPU PIDs
- [ ] Bench-test on HL2 to confirm TX rate / packet loss unaffected (Broadcast + IqPump changes don't touch the TX or UDP-recv path, but worth a sanity pass before merging the flagged follow-ups)