### PR TITLE
style(web): flat-chrome experiment — square corners, horizontal gradients, flush panel edges

### DIFF
--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -705,22 +705,22 @@ export default function App() {
         {connected && <ConnectPanel compact />}
       </header>
 
-      <AlertBanner />
-
-      {/* Active layout's workspace, or the inline Settings view if the
-          operator picked the Settings slot in the LeftLayoutBar. Keying on
-          activeLayoutId forces a full unmount + remount when the operator
-          switches layouts so WebGL canvases / RAF loops / hub subscriptions
-          in the prior layout release rather than lingering hidden (issue
-          #241 requires that inactive layouts not consume DOM resources). */}
-      {settingsViewOpen ? (
-        <SettingsView
-          initialTab={settingsInitialTab as SettingsTabId | undefined}
-          onClose={() => setSettingsView(false)}
-        />
-      ) : (
-        <FlexWorkspace key={activeLayoutId} />
-      )}
+      {/* Workspace area — alert banner + active layout (or settings view).
+          Wrapped together so the grid only needs one row for both, which
+          keeps the gap between the topbar and the first panel a single
+          6px unit instead of stacking two grid gaps around an empty
+          alert row. */}
+      <div className="workspace-area">
+        <AlertBanner />
+        {settingsViewOpen ? (
+          <SettingsView
+            initialTab={settingsInitialTab as SettingsTabId | undefined}
+            onClose={() => setSettingsView(false)}
+          />
+        ) : (
+          <FlexWorkspace key={activeLayoutId} />
+        )}
+      </div>
 
       {/* Transport — MOX/TUN + audio + mic + macro buttons on the left,
           PA/PRE chips, then the per-radio status (radio IP, rotator, QRZ)

--- a/zeus-web/src/components/CfcSettingsPanel.css
+++ b/zeus-web/src/components/CfcSettingsPanel.css
@@ -37,7 +37,7 @@
   font-weight: 600;
   padding: 3px 7px;
   border: 1px solid color-mix(in oklab, var(--accent) 50%, var(--panel-border));
-  border-radius: 3px;
+  border-radius: 0;
   background: color-mix(in oklab, var(--accent) 8%, transparent);
   white-space: nowrap;
 }
@@ -80,7 +80,7 @@
   background: var(--bg-0);
   border: 1px solid var(--panel-border);
   color: var(--fg-1);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 3px 6px;
   font-family: var(--font-mono);
   font-size: 11px;
@@ -107,7 +107,7 @@
 .cfc-power .sw {
   width: 42px;
   height: 22px;
-  border-radius: 11px;
+  border-radius: 0;
   background: var(--bg-3);
   border: 1px solid var(--panel-border);
   position: relative;
@@ -163,7 +163,7 @@
 .cfc-check .box {
   width: 14px;
   height: 14px;
-  border-radius: 3px;
+  border-radius: 0;
   background: var(--bg-0);
   border: 1px solid var(--panel-border);
   display: inline-block;
@@ -203,7 +203,7 @@
   color: var(--fg-2);
   background: var(--bg-0);
   border: 1px solid var(--panel-border);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 4px 10px;
   cursor: pointer;
 }

--- a/zeus-web/src/components/ConnectPanel.tsx
+++ b/zeus-web/src/components/ConnectPanel.tsx
@@ -557,7 +557,7 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
                   padding: '6px 10px',
                   background: 'rgba(230,58,43,0.12)',
                   border: '1px solid rgba(230,58,43,0.35)',
-                  borderRadius: 4,
+                  borderRadius: 0,
                   color: 'var(--tx)',
                   fontSize: 11,
                 }}
@@ -594,7 +594,7 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
                         padding: '6px 10px',
                         background: 'var(--bg-2)',
                         border: '1px solid var(--panel-border)',
-                        borderRadius: 4,
+                        borderRadius: 0,
                       }}
                     >
                       <div style={{ display: 'flex', flexDirection: 'column', minWidth: 0 }}>
@@ -934,7 +934,7 @@ function ManualMode(p: ManualModeProps) {
             padding: '6px 10px',
             background: 'rgba(230,58,43,0.12)',
             border: '1px solid rgba(230,58,43,0.35)',
-            borderRadius: 4,
+            borderRadius: 0,
             color: 'var(--tx)',
             fontSize: 11,
           }}
@@ -966,7 +966,7 @@ function ManualMode(p: ManualModeProps) {
               padding: '10px 12px',
               background: 'var(--bg-2)',
               border: '1px dashed var(--panel-border)',
-              borderRadius: 4,
+              borderRadius: 0,
               textAlign: 'center',
             }}
           >
@@ -987,7 +987,7 @@ function ManualMode(p: ManualModeProps) {
                     padding: '6px 10px',
                     background: 'var(--bg-2)',
                     border: '1px solid var(--panel-border)',
-                    borderRadius: 4,
+                    borderRadius: 0,
                   }}
                 >
                   <div style={{ display: 'flex', flexDirection: 'column', minWidth: 0 }}>

--- a/zeus-web/src/components/RadioSelector.tsx
+++ b/zeus-web/src/components/RadioSelector.tsx
@@ -162,7 +162,7 @@ export function RadioSelector() {
             color: 'var(--tx)',
             background: 'var(--tx-soft)',
             padding: '2px 6px',
-            borderRadius: 2,
+            borderRadius: 0,
           }}
           title="Discovery disagrees with your selection. Discovery always wins for drive-byte math and PA defaults while connected — flip Override Detection on if you really want the selected board to win."
         >
@@ -258,7 +258,7 @@ export function RadioSelector() {
             color: 'var(--tx)',
             background: 'var(--tx-soft)',
             padding: '2px 6px',
-            borderRadius: 2,
+            borderRadius: 0,
           }}
           title="Override is active. Zeus uses the selected board for drive-byte math, ATT, filters, and PA defaults — discovery is ignored."
         >

--- a/zeus-web/src/components/TxStageMeters.tsx
+++ b/zeus-web/src/components/TxStageMeters.tsx
@@ -95,7 +95,7 @@ export function OverdriveIndicator() {
         alignItems: 'center',
         gap: 4,
         padding: '2px 6px',
-        borderRadius: 3,
+        borderRadius: 0,
         fontSize: 9,
         fontWeight: 700,
         letterSpacing: '0.08em',
@@ -312,7 +312,7 @@ function MeterRow({
             height: 14,
             background: 'var(--meter-bg)',
             border: '1px solid var(--panel-border)',
-            borderRadius: 2,
+            borderRadius: 0,
             boxShadow:
               'inset 0 1px 0 rgba(0,0,0,0.5), inset 0 0 0 0.5px rgba(255,255,255,0.02)',
             overflow: 'hidden',

--- a/zeus-web/src/components/VstHostPluginBrowser.tsx
+++ b/zeus-web/src/components/VstHostPluginBrowser.tsx
@@ -72,7 +72,7 @@ export function VstHostPluginBrowser({ open, targetSlot, onClose }: Props) {
         flexDirection: 'column',
         zIndex: 5,
         border: '1px solid var(--panel-border)',
-        borderRadius: 4,
+        borderRadius: 0,
       }}
     >
       <header
@@ -82,7 +82,7 @@ export function VstHostPluginBrowser({ open, targetSlot, onClose }: Props) {
           gap: 10,
           padding: '8px 12px',
           background:
-            'linear-gradient(180deg, var(--panel-head-top), var(--panel-head-bot))',
+            'linear-gradient(90deg, var(--panel-head-top), var(--panel-head-bot))',
           borderBottom: '1px solid var(--panel-border)',
           color: 'var(--fg-0)',
         }}
@@ -129,7 +129,7 @@ export function VstHostPluginBrowser({ open, targetSlot, onClose }: Props) {
             background: 'var(--bg-0)',
             color: 'var(--fg-1)',
             border: '1px solid var(--panel-border)',
-            borderRadius: 3,
+            borderRadius: 0,
             fontSize: 12,
           }}
         />

--- a/zeus-web/src/components/VstHostSearchPaths.tsx
+++ b/zeus-web/src/components/VstHostSearchPaths.tsx
@@ -112,7 +112,7 @@ export function VstHostSearchPaths() {
             background: 'var(--bg-0)',
             color: 'var(--fg-1)',
             border: '1px solid var(--panel-border)',
-            borderRadius: 3,
+            borderRadius: 0,
             fontSize: 12,
           }}
         />

--- a/zeus-web/src/components/VstHostSlotRow.tsx
+++ b/zeus-web/src/components/VstHostSlotRow.tsx
@@ -69,7 +69,7 @@ export function VstHostSlotRow({ index, disabled, remote = false, onRequestLoad 
     gap: 6,
     padding: '8px 10px',
     border: '1px solid var(--panel-border)',
-    borderRadius: 4,
+    borderRadius: 0,
     background: 'var(--bg-1)',
     opacity: disabled ? 0.55 : 1,
   };

--- a/zeus-web/src/components/VstHostSubmenu.tsx
+++ b/zeus-web/src/components/VstHostSubmenu.tsx
@@ -86,7 +86,7 @@ export function VstHostSubmenu() {
       style={{
         position: 'relative',
         border: '1px solid var(--panel-border)',
-        borderRadius: 6,
+        borderRadius: 0,
         padding: '10px 12px',
         background: 'var(--bg-1)',
         display: 'flex',
@@ -172,7 +172,7 @@ export function VstHostSubmenu() {
             color: 'var(--fg-2)',
             background: 'var(--bg-2)',
             border: '1px solid var(--panel-border)',
-            borderRadius: 4,
+            borderRadius: 0,
             padding: '6px 8px',
           }}
         >

--- a/zeus-web/src/components/bandplan/BandPlanEditor.tsx
+++ b/zeus-web/src/components/bandplan/BandPlanEditor.tsx
@@ -153,26 +153,26 @@ export function BandPlanEditor() {
             </span>
           </label>
           {store.txGuardIgnore && (
-            <span style={{ fontSize: 10, color: 'rgba(255,80,80,0.8)', background: 'rgba(255,0,0,0.08)', padding: '2px 6px', borderRadius: 4, border: '1px solid rgba(255,80,80,0.3)' }}>
+            <span style={{ fontSize: 10, color: 'rgba(255,80,80,0.8)', background: 'rgba(255,0,0,0.08)', padding: '2px 6px', borderRadius: 0, border: '1px solid rgba(255,80,80,0.3)' }}>
               ⚠ MOX will fire regardless of band legality
             </span>
           )}
         </div>
       </div>
 
-      <div style={{ fontSize: 10, color: 'var(--fg-3)', background: 'rgba(255,160,40,0.06)', border: '1px solid rgba(255,160,40,0.15)', borderRadius: 4, padding: '6px 10px' }}>
+      <div style={{ fontSize: 10, color: 'var(--fg-3)', background: 'rgba(255,160,40,0.06)', border: '1px solid rgba(255,160,40,0.15)', borderRadius: 0, padding: '6px 10px' }}>
         Defaults are best-effort. You are responsible for operating within your licence.
         Source files under Zeus.Server/BandPlans/ — corrections welcome as PRs.
       </div>
 
       {error && (
-        <div style={{ fontSize: 11, color: '#ff5555', background: 'rgba(255,0,0,0.08)', border: '1px solid rgba(255,80,80,0.3)', borderRadius: 4, padding: '6px 10px' }}>
+        <div style={{ fontSize: 11, color: '#ff5555', background: 'rgba(255,0,0,0.08)', border: '1px solid rgba(255,80,80,0.3)', borderRadius: 0, padding: '6px 10px' }}>
           {error}
         </div>
       )}
 
       {/* Segment table */}
-      <div style={{ flex: 1, minHeight: 0, overflow: 'auto', border: '1px solid var(--panel-border)', borderRadius: 4 }}>
+      <div style={{ flex: 1, minHeight: 0, overflow: 'auto', border: '1px solid var(--panel-border)', borderRadius: 0 }}>
         <table style={{ width: '100%', borderCollapse: 'collapse' }}>
           <thead>
             <tr style={{ background: 'var(--bg-0)', position: 'sticky', top: 0, zIndex: 1 }}>

--- a/zeus-web/src/components/design/LeafletWorldMap.tsx
+++ b/zeus-web/src/components/design/LeafletWorldMap.tsx
@@ -170,7 +170,7 @@ function callsignAvatarIcon(station: MapStation, tone: 'home' | 'target'): L.Div
         left: 50%;
         transform: translateX(-50%);
         padding: 1px 6px;
-        border-radius: 3px;
+        border-radius: 0;
         background: ${chipBg};
         border: 1px solid ${chipBorder};
         color: ${chipText};
@@ -217,7 +217,7 @@ function buildTargetPopup(
         ${hasRotator
           ? `<button type="button" data-lf-action="rotate" data-lf-bearing="${bearing.toFixed(1)}"
               style="
-                padding: 3px 8px; font-size: 11px; border-radius: 3px;
+                padding: 3px 8px; font-size: 11px; border-radius: 0;
                 border: 1px solid ${COLOR_CYAN}; background: rgba(0,221,255,0.15);
                 color: ${COLOR_CYAN}; cursor: pointer; font-family: inherit;
               ">Rotate ${brg}</button>`

--- a/zeus-web/src/components/meters/MeterWidget.tsx
+++ b/zeus-web/src/components/meters/MeterWidget.tsx
@@ -98,7 +98,7 @@ export function MeterWidget({
     alignItems: 'center',
     gap: 6,
     padding: '3px 6px',
-    background: 'linear-gradient(180deg, var(--panel-top), var(--panel-bot))',
+    background: 'linear-gradient(90deg, var(--panel-top), var(--panel-bot))',
     borderBottom: '1px solid var(--panel-border)',
     flexShrink: 0,
   };

--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -158,7 +158,7 @@ function WorkspaceCanvas({
   const rowHeight = useMemo(() => {
     if (containerHeight <= 0) return WORKSPACE_ROW_HEIGHT_PX;
     const margin = 6;
-    const containerPadding = 6;
+    const containerPadding = 0;
     const inner =
       containerHeight - 2 * containerPadding - margin * (WORKSPACE_TARGET_ROWS - 1);
     const computed = Math.floor(inner / WORKSPACE_TARGET_ROWS);
@@ -203,7 +203,7 @@ function WorkspaceCanvas({
           cols={{ lg: WORKSPACE_GRID_COLS }}
           rowHeight={rowHeight}
           margin={[6, 6]}
-          containerPadding={[6, 6]}
+          containerPadding={[0, 0]}
           // Position tiles via top/left rather than transform: translate3d.
           // RGL's default `transformStrategy` uses CSS transforms, which
           // (combined with the upstream stylesheet's `will-change: transform`)

--- a/zeus-web/src/mobile/mobile.css
+++ b/zeus-web/src/mobile/mobile.css
@@ -24,7 +24,7 @@
   align-items: center;
   gap: 10px;
   padding: 10px 12px;
-  background: linear-gradient(180deg, var(--panel-head-top) 0%, var(--panel-head-bot) 100%);
+  background: linear-gradient(90deg, var(--panel-head-top) 0%, var(--panel-head-bot) 100%);
   border-bottom: 1px solid var(--panel-border);
   position: sticky;
   top: 0;
@@ -114,7 +114,7 @@
   display: flex;
   align-items: center;
   padding: 10px 12px;
-  background: linear-gradient(180deg, var(--panel-head-top) 0%, var(--panel-head-bot) 100%);
+  background: linear-gradient(90deg, var(--panel-head-top) 0%, var(--panel-head-bot) 100%);
   border-bottom: 1px solid var(--panel-border);
 }
 .m-selector-title {
@@ -164,7 +164,7 @@
   align-items: center;
   gap: 8px;
   padding: 8px 10px;
-  background: linear-gradient(180deg, var(--panel-head-top) 0%, var(--panel-head-bot) 100%);
+  background: linear-gradient(90deg, var(--panel-head-top) 0%, var(--panel-head-bot) 100%);
   border-bottom: 1px solid var(--panel-border);
   font-family: var(--font-sans);
   font-size: 10px;

--- a/zeus-web/src/styles/all-panels.css
+++ b/zeus-web/src/styles/all-panels.css
@@ -138,7 +138,7 @@
   align-items: center;
   gap: 6px;
   padding: 0 8px;
-  background: linear-gradient(180deg, var(--panel-head-top, var(--panel-top)), var(--panel-head-bot, var(--panel-bot)));
+  background: linear-gradient(90deg, var(--panel-head-top, var(--panel-top)), var(--panel-head-bot, var(--panel-bot)));
   border-bottom: 1px solid var(--panel-border);
   /* Whole header is the drag handle (RGL dragConfig.handle). Show grab
    * cursor across the full width so the operator knows it's draggable —
@@ -273,7 +273,7 @@
   justify-content: space-between;
   padding: 12px 16px;
   border-bottom: 1px solid var(--panel-border);
-  background: linear-gradient(180deg, var(--panel-head-top, var(--panel-top)), var(--panel-head-bot, var(--panel-bot)));
+  background: linear-gradient(90deg, var(--panel-head-top, var(--panel-top)), var(--panel-head-bot, var(--panel-bot)));
 }
 .add-panel-modal-header h2 {
   margin: 0;

--- a/zeus-web/src/styles/analog-meter.css
+++ b/zeus-web/src/styles/analog-meter.css
@@ -327,7 +327,7 @@
   width: 100%;
   height: 4px;
   background: var(--bg-2);
-  border-radius: 2px;
+  border-radius: 0;
   outline: none;
   border: 1px solid var(--panel-edge);
 }

--- a/zeus-web/src/styles/filter-ribbon.css
+++ b/zeus-web/src/styles/filter-ribbon.css
@@ -25,7 +25,7 @@
   color: #edeef1;
   font-family: inherit;
   min-height: 0;
-  border-radius: 10px;
+  border-radius: 0;
   padding: 10px 12px 8px 12px;
   border: 1px solid rgba(255, 255, 255, 0.05);
   background: linear-gradient(180deg, #26292f 0%, #1e2025 100%);
@@ -50,7 +50,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 3px;
+  border-radius: 0;
 }
 .filter-ribbon__close:hover { color: #edeef1; background: rgba(255, 255, 255, 0.04); }
 
@@ -139,7 +139,7 @@
   flex: 1 1 auto;
   min-height: 102px;
   height: 122px;
-  border-radius: 4px;
+  border-radius: 0;
   overflow: hidden;
 }
 
@@ -157,7 +157,7 @@
 .filter-ribbon__presets {
   background: #2a2d33;
   border: 1px solid rgba(255, 255, 255, 0.05);
-  border-radius: 8px;
+  border-radius: 0;
   padding: 8px 8px 7px;
   display: flex;
   flex-direction: column;
@@ -202,7 +202,7 @@
   background: linear-gradient(180deg, #1f2126 0%, #1a1c20 100%);
   color: #edeef1;
   border: 1px solid #3a3e45;
-  border-radius: 3px;
+  border-radius: 0;
   font-variant-numeric: tabular-nums;
   outline: none;
 }
@@ -241,7 +241,7 @@
   border: 1px solid #4a4e55;
   border-top-color: #585c63;
   border-bottom-color: #32353b;
-  border-radius: 4px;
+  border-radius: 0;
   cursor: pointer;
   font-variant-numeric: tabular-nums;
   transition: border-color 120ms ease, filter 120ms ease, color 120ms ease;
@@ -300,7 +300,7 @@
   font-size: clamp(10px, 0.1vw + 9.5px, 12px);
   font-weight: 600;
   letter-spacing: 0.18em;
-  border-radius: 4px;
+  border-radius: 0;
   color: #e0e2e6;
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.10) 0%, rgba(255, 255, 255, 0) 45%, rgba(0, 0, 0, 0.12) 100%),

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -338,7 +338,7 @@
   height: 44px;
   padding: 0 14px;
   background: linear-gradient(
-    180deg,
+    90deg,
     var(--panel-head-top),
     var(--panel-head-bot)
   );
@@ -441,7 +441,7 @@
   align-items: center;
   gap: 10px;
   padding: 0 10px;
-  background: linear-gradient(180deg, var(--panel-top), var(--panel-bot));
+  background: linear-gradient(90deg, var(--panel-top), var(--panel-bot));
   border: 1px solid var(--panel-edge);
   border-radius: var(--r-lg);
   box-shadow: var(--panel-shadow);
@@ -548,7 +548,7 @@
   display: flex;
   gap: 12px;
   padding: 4px 10px;
-  background: linear-gradient(180deg, var(--panel-top), var(--panel-bot));
+  background: linear-gradient(90deg, var(--panel-top), var(--panel-bot));
   border: 1px solid var(--panel-edge);
   border-radius: var(--r-lg);
   box-shadow: var(--panel-shadow);
@@ -757,7 +757,7 @@
   align-items: center;
   gap: 6px;
   padding: 5px 10px;
-  background: linear-gradient(180deg, var(--panel-head-top), var(--panel-head-bot));
+  background: linear-gradient(90deg, var(--panel-head-top), var(--panel-head-bot));
   border-bottom: 1px solid var(--panel-border);
   box-shadow: inset 0 1px 0 rgba(255,255,255,0.08);
   min-height: 28px;
@@ -1096,7 +1096,7 @@
   color: #e0e8f5;
   padding: 2px 8px;
   background: rgba(0,0,0,0.55);
-  border-radius: 2px;
+  border-radius: 0;
   text-shadow: 0 1px 0 #000;
 }
 .spec-label.center { color: var(--tx); background: rgba(0,0,0,0.75); font-weight: 700; }
@@ -1178,7 +1178,7 @@
   height: 10px;
   background: #000;
   border: 1px solid rgba(0,0,0,0.8);
-  border-radius: 2px;
+  border-radius: 0;
   box-shadow: inset 0 1px 2px rgba(0,0,0,0.8);
   overflow: hidden;
 }
@@ -1204,7 +1204,7 @@
   padding: 6px;
   background: #000;
   border: 1px solid rgba(0,0,0,0.8);
-  border-radius: 3px;
+  border-radius: 0;
   box-shadow: inset 0 1px 3px rgba(0,0,0,0.8);
 }
 .smeter-s {
@@ -1219,7 +1219,7 @@
   width: 100%;
   height: 24%;
   background: #1a3050;
-  border-radius: 1px;
+  border-radius: 0;
   transition: background var(--dur-fast), box-shadow var(--dur-fast);
 }
 .smeter-s:nth-child(2) .smeter-bar { height: 34%; }
@@ -1338,7 +1338,7 @@
   width: 90px;
   background: #0a1220;
   border: 1px solid #000;
-  border-radius: 3px;
+  border-radius: 0;
   padding: 3px 8px;
   font-size: 12px;
   font-weight: 700;
@@ -1361,7 +1361,7 @@
   color: var(--fg-2);
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  background: linear-gradient(180deg, var(--panel-top), color-mix(in srgb, var(--panel-top) 60%, var(--panel-bot)));
+  background: linear-gradient(90deg, var(--panel-top), color-mix(in srgb, var(--panel-top) 60%, var(--panel-bot)));
   border-bottom: 1px solid rgba(0,0,0,0.4);
   box-shadow: inset 0 1px 0 rgba(255,255,255,0.08);
 }
@@ -1392,7 +1392,7 @@
   align-items: center;
   gap: 8px;
   border-top: 1px solid rgba(0,0,0,0.4);
-  background: linear-gradient(180deg, color-mix(in srgb, var(--panel-top) 60%, var(--panel-bot)), var(--panel-bot));
+  background: linear-gradient(90deg, color-mix(in srgb, var(--panel-top) 60%, var(--panel-bot)), var(--panel-bot));
 }
 
 /* ===== Memory ===== */
@@ -1435,14 +1435,14 @@
   height: 8px;
   background: #000;
   border: 1px solid rgba(0,0,0,0.6);
-  border-radius: 4px;
+  border-radius: 0;
   cursor: pointer;
   box-shadow: inset 0 1px 2px rgba(0,0,0,0.7);
 }
 .slider-fill {
   position: absolute; inset: 0 auto 0 0;
   background: linear-gradient(90deg, var(--accent), color-mix(in srgb, var(--accent) 70%, white));
-  border-radius: 4px 0 0 4px;
+  border-radius: 0;
 }
 .slider-thumb {
   position: absolute;
@@ -1451,7 +1451,7 @@
   width: 14px; height: 16px;
   background: linear-gradient(180deg, #c0cbd9, #7a8698);
   border: 1px solid #000;
-  border-radius: 2px;
+  border-radius: 0;
   box-shadow: inset 0 1px 0 rgba(255,255,255,0.6), 0 1px 2px rgba(0,0,0,0.6);
 }
 
@@ -1462,7 +1462,7 @@
   padding: 8px 10px;
   background: #000;
   border: 1px solid rgba(0,0,0,0.8);
-  border-radius: 3px;
+  border-radius: 0;
   font-size: 14px;
   color: var(--accent);
   letter-spacing: 0.2em;
@@ -1482,11 +1482,47 @@
   align-items: center;
   gap: 6px;
   padding: 0 10px;
-  background: linear-gradient(180deg, var(--panel-top), var(--panel-bot));
+  background: linear-gradient(90deg, var(--panel-top), var(--panel-bot));
   border: 1px solid var(--panel-edge);
   border-radius: var(--r-lg);
   box-shadow: var(--panel-shadow);
   height: 44px;
+}
+/* Transport buttons read as flat clickable regions of the toolbar, not raised
+   chiclets. TX (MOX-on) is excluded — it keeps its red bevel/pulse for safety. */
+.transport .btn {
+  background: transparent;
+  border: 1px solid transparent;
+  box-shadow: none;
+  text-shadow: none;
+  color: var(--fg-1);
+}
+.transport .btn:hover {
+  background: rgba(255,255,255,0.06);
+  filter: none;
+}
+.transport .btn:active,
+.transport .btn.pressed {
+  background: rgba(0,0,0,0.28);
+  box-shadow: inset 0 1px 2px rgba(0,0,0,0.4);
+  transform: none;
+}
+.transport .btn.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-color: rgba(74,158,255,0.35);
+  text-shadow: none;
+}
+.transport .btn.ghost {
+  background: transparent;
+}
+.transport .btn.ghost:hover { background: rgba(255,255,255,0.06); }
+/* Restore TX styling for MOX-on state — must remain visually loud. */
+.transport .btn.tx {
+  background: linear-gradient(180deg, var(--btn-top-c), var(--btn-bot-c));
+  border: 1px solid var(--btn-edge);
+  color: #ffd4d0;
+  text-shadow: 0 0 6px rgba(230,58,43,0.8);
 }
 .tx-btn { font-size: 14px; font-weight: 700; letter-spacing: 0.12em; min-width: 80px; }
 .tx-btn.tx {
@@ -1565,7 +1601,7 @@
 }
 .variant-card:hover { filter: brightness(1.1); }
 .variant-card.active { border-color: var(--accent); box-shadow: inset 0 1px 0 rgba(255,255,255,0.05), 0 0 8px var(--accent-soft); }
-.variant-swatch { display: flex; height: 20px; border-radius: 2px; overflow: hidden; border: 1px solid #000; }
+.variant-swatch { display: flex; height: 20px; border-radius: 0; overflow: hidden; border: 1px solid #000; }
 .variant-swatch .sw { flex: 1; }
 .variant-card[data-variant="console"] .sw.bg0 { background: #0f1a2e; }
 .variant-card[data-variant="console"] .sw.bg1 { background: #2d3e5a; }
@@ -1620,7 +1656,7 @@
   padding: 1px 6px;
   background: linear-gradient(180deg, var(--btn-top), var(--btn-bot));
   border: 1px solid #000;
-  border-radius: 2px;
+  border-radius: 0;
   font-size: 10px;
   font-weight: 700;
   margin-right: 6px;

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -22,7 +22,7 @@
 .app {
   display: grid;
   grid-template-columns: 60px 1fr;
-  grid-template-rows: 68px auto 1fr 44px;
+  grid-template-rows: 56px 1fr 44px;
   height: 100vh;
   width: 100vw;
   background: var(--bg-0);
@@ -33,10 +33,21 @@
 
 .app > .left-layout-bar   { grid-column: 1; grid-row: 1 / -1; }
 .app > .topbar            { grid-column: 2; grid-row: 1; }
-.app > .alert-banner      { grid-column: 2; grid-row: 2; }
-.app > .flex-workspace    { grid-column: 2; grid-row: 3; min-height: 0; overflow: auto; }
-.app > .settings-view     { grid-column: 2; grid-row: 3; min-height: 0; overflow: hidden; }
-.app > .transport         { grid-column: 2; grid-row: 4; }
+.app > .workspace-area    { grid-column: 2; grid-row: 2; min-height: 0; }
+.app > .transport         { grid-column: 2; grid-row: 3; }
+
+/* Workspace area — flex column owning the alert banner + the active
+   layout (or settings view). The empty alert banner returns a 0-height
+   placeholder, so with no flex gap the topbar→first-panel distance is
+   exactly the .app grid gap (6px), matching the inter-panel gap. */
+.workspace-area {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.workspace-area > .alert-banner { flex: 0 0 auto; }
+.workspace-area > .flex-workspace,
+.workspace-area > .settings-view { flex: 1; min-height: 0; }
 
 /* ===== Left layout bar — issue #241 ===== */
 .left-layout-bar {
@@ -445,7 +456,7 @@
   border: 1px solid var(--panel-edge);
   border-radius: var(--r-lg);
   box-shadow: var(--panel-shadow);
-  height: 68px;
+  height: 56px;
   overflow: hidden;
 }
 .topbar .topbar-controls {
@@ -458,6 +469,44 @@
      it from spilling into the workspace below. */
   overflow-x: auto;
   scrollbar-width: thin;
+}
+/* Topbar buttons read as flat regions of the bar, not raised chiclets.
+   The .ctrl-lbl above each .btn-row remains the visual anchor for the
+   group, so we lean on the label + .strip-divider for grouping rather
+   than per-button bevels. */
+.topbar .btn {
+  background: transparent;
+  border: 1px solid transparent;
+  box-shadow: none;
+  text-shadow: none;
+  color: var(--fg-1);
+}
+.topbar .btn:hover {
+  background: rgba(255,255,255,0.06);
+  filter: none;
+}
+.topbar .btn:active,
+.topbar .btn.pressed {
+  background: rgba(0,0,0,0.28);
+  box-shadow: inset 0 1px 2px rgba(0,0,0,0.4);
+  transform: none;
+}
+.topbar .btn.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-color: rgba(74,158,255,0.35);
+  text-shadow: none;
+}
+.topbar .btn.ghost { background: transparent; }
+.topbar .btn.ghost:hover { background: rgba(255,255,255,0.06); }
+/* Lift the group label slightly so it carries the grouping role that
+   button bevels used to. */
+.topbar .ctrl-group { gap: 2px; }
+.topbar .ctrl-lbl {
+  color: var(--fg-1);
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  opacity: 0.75;
 }
 .brand {
   display: flex;

--- a/zeus-web/src/styles/pa-settings.css
+++ b/zeus-web/src/styles/pa-settings.css
@@ -102,7 +102,7 @@
   height: 8px;
   background: var(--bg-2);
   border: 1px solid var(--panel-edge);
-  border-radius: 4px;
+  border-radius: 0;
   overflow: hidden;
   box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.30);
   min-width: 60px;

--- a/zeus-web/src/styles/ps-settings.css
+++ b/zeus-web/src/styles/ps-settings.css
@@ -352,7 +352,7 @@
 }
 .ps-peak .ps-meter {
   height: 6px;
-  border-radius: 3px;
+  border-radius: 0;
   background: var(--meter-bg);
   overflow: hidden;
   border: 1px solid var(--panel-border);
@@ -944,7 +944,7 @@
 .ps-popover-meter {
   position: relative;
   height: 5px;
-  border-radius: 3px;
+  border-radius: 0;
   background: var(--meter-bg);
   border: 1px solid var(--panel-border);
   overflow: hidden;

--- a/zeus-web/src/styles/tokens.css
+++ b/zeus-web/src/styles/tokens.css
@@ -73,10 +73,11 @@
   --font-display: 'Archivo Narrow', sans-serif;
 
   /* ----- Spacing / radius ----- */
-  --r-xs: 2px;
-  --r-sm: 3px;
-  --r-md: 4px;
-  --r-lg: 6px;
+  /* Square-edge experiment: all corner radii flattened. */
+  --r-xs: 0;
+  --r-sm: 0;
+  --r-md: 0;
+  --r-lg: 0;
 
   /* ----- Easing ----- */
   --ease-out: cubic-bezier(.22,.61,.36,1);

--- a/zeus-web/src/styles/toolbar-favorites.css
+++ b/zeus-web/src/styles/toolbar-favorites.css
@@ -37,7 +37,7 @@
   min-width: 240px;
   max-width: 360px;
   padding: 8px 10px 10px 10px;
-  border-radius: 10px;
+  border-radius: 0;
   border: 1px solid rgba(255, 255, 255, 0.06);
   background: linear-gradient(180deg, #26292f 0%, #1e2025 100%);
   box-shadow:
@@ -77,7 +77,7 @@
   border: 1px solid #4a4e55;
   border-top-color: #585c63;
   border-bottom-color: #32353b;
-  border-radius: 4px;
+  border-radius: 0;
   cursor: grab;
   font-variant-numeric: tabular-nums;
   transition: border-color 120ms ease, filter 120ms ease, color 120ms ease;


### PR DESCRIPTION
## Summary
Experimental flat-chrome pass on the frontend.

- **Square corners.** Zero `--r-xs/sm/md/lg` tokens and flatten remaining raw `border-radius` values across CSS and inline TSX. `50%` (dial faces, LEDs, slider thumbs) and `999px` (slider tracks) preserved.
- **Horizontal gradients on bars.** Flip `180deg → 90deg` on `.topbar`, `.transport`, `.control-strip`, `.panel-head`, `.settings-view-header`, log table head/foot, mobile panel heads, and inline panel-heads in `VstHostPluginBrowser` / `MeterWidget`. Whole-panel bodies (left rail, select-menu, floating panels, nr-settings container) keep vertical gradients.
- **Flat transport buttons.** `.transport .btn` renders transparent with hover/pressed wash and accent-blue tint when `.active`. `.btn.tx` (MOX-on) keeps its red bevel + pulse for safety.
- **Flat topbar buttons + tighter bar.** `.topbar .btn` flattened the same way; group labels (`.ctrl-lbl`) bumped slightly in contrast and tracking to carry the grouping role. Topbar height 68 → 56 px.
- **Single 6 px gap below the header.** App grid collapsed from 4 rows to 3 (no dedicated alert row); `<AlertBanner />` + workspace wrapped in a flex `.workspace-area`. The previous 12 px (two stacked grid gaps around the empty alert row) is now a single 6 px, matching the inter-panel gap.
- **Panels flush with header/footer edges.** RGL `containerPadding` 6 → 0. Workspace, topbar, and transport all live in column 2 of the app grid, so leftmost/rightmost panel edges now coincide with topbar/transport edges. Inter-panel margin (6 px) preserved.

This is a UX/visual change — flagging for maintainer review per the CLAUDE.md red-light rule on visual design.

## Test plan
- [x] `npm run test` (zeus-web) — 209 / 209 passing
- [x] `dotnet build Zeus.slnx` — 0 warnings, 0 errors
- [ ] Visual sanity-check on desktop (HL2): topbar / transport / panel headers / panels read correctly with flat chrome
- [ ] Mobile (≤ 768 px) sanity-check: `.topbar { height: 44px }` mobile override still applies; mobile panel-head gradients flipped to horizontal as expected
- [ ] Confirm panadapter/waterfall edges still align with panel chrome after RGL `containerPadding` change