### PR TITLE
release: develop → main (perf2/perf3 + flat-chrome + windows-arm + audio fix)

### DIFF
--- a/.github/workflows/build-native-libs.yml
+++ b/.github/workflows/build-native-libs.yml
@@ -27,15 +27,37 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install FFTW via vcpkg (static-md triplet, dynamic CRT)
+      - name: Install FFTW via vcpkg
         run: |
-          # static-md = FFTW linked statically into wdsp.dll, but using the
-          # default dynamic CRT (/MD) so no CRT mismatch with CMake defaults.
-          # Result: a single self-contained wdsp.dll, no fftw3.dll needed.
-          # vcpkg's fftw3 port builds all three precisions (fftw3, fftw3f,
-          # fftw3l) by default, so libspecbleach (NR4) gets fftw3f from the
-          # same install.
-          vcpkg install fftw3:${{ matrix.arch }}-windows-static-md
+          # CRT linkage is per-arch:
+          #
+          # x64 uses the static-md triplet — FFTW is linked statically into
+          # wdsp.dll, but the resulting DLL still imports the dynamic CRT
+          # (vcruntime140.dll, ucrtbase.dll). On x64 boxes vcruntime140.dll
+          # is effectively ubiquitous (Office, Steam, .NET SDK, the bulk of
+          # Windows installer programs all ship the VC++ Redistributable),
+          # so this is fine and matches the choice that has been working
+          # for x64 for the entire Zeus 0.x line.
+          #
+          # arm64 uses the static triplet — FFTW *and* the CRT are linked
+          # into wdsp.dll (matched on the CMake side by
+          # CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded). Win-ARM does NOT
+          # ship the ARM64 VC++ Redistributable by default and a fresh
+          # Surface Pro X / Snapdragon X Elite system has no other
+          # ARM64 native software to drag it in. With the static-md
+          # triplet the resulting wdsp.dll loads VCRUNTIME140.dll at
+          # runtime and we ship to a "module could not be found" error
+          # the first time anything in WdspNativeLoader tries to open a
+          # channel. The static-CRT build has zero non-Windows-shipped
+          # imports — verified locally with llvm-objdump.
+          $triplet = if ("${{ matrix.arch }}" -eq "arm64") {
+            "arm64-windows-static"
+          } else {
+            "x64-windows-static-md"
+          }
+          vcpkg install fftw3:$triplet
+          # Persist for the Configure CMake step so we don't re-derive.
+          echo "VCPKG_TRIPLET=$triplet" >> $env:GITHUB_ENV
           echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" >> $env:GITHUB_ENV
 
       - name: Configure CMake
@@ -55,14 +77,28 @@ jobs:
           # WDSP_WITH_NR4=ON pulls in native/libspecbleach/ as a STATIC sub-
           # target embedded into wdsp.dll. NR3 stays OFF (librnnoise not
           # vendored). Both flags are explicit for build-log clarity.
+          #
+          # arm64 also passes CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded so
+          # WDSP itself is built with /MT, matching the static-CRT FFTW
+          # produced by the arm64-windows-static vcpkg triplet. Without
+          # this match the link step trips LNK2038 ("mismatch detected
+          # for 'RuntimeLibrary'") because vcpkg's libfftw3-3.lib expects
+          # /MT and CMake's MSVC default is /MD. See the FFTW step above
+          # for why arm64 needs static CRT in the first place.
+          $extraArgs = if ("${{ matrix.arch }}" -eq "arm64") {
+            @("-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded")
+          } else {
+            @()
+          }
           cmake -S native/wdsp -B native/build `
             -G "Visual Studio 17 2022" `
             -A $archFlag `
             -T ClangCL `
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
-            -DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-windows-static-md `
+            -DVCPKG_TARGET_TRIPLET=$env:VCPKG_TRIPLET `
             -DWDSP_WITH_NR3=OFF `
-            -DWDSP_WITH_NR4=ON
+            -DWDSP_WITH_NR4=ON `
+            @extraArgs
 
       - name: Build
         run: |

--- a/.github/workflows/build-native-libs.yml
+++ b/.github/workflows/build-native-libs.yml
@@ -56,13 +56,21 @@ jobs:
             "x64-windows-static-md"
           }
           vcpkg install fftw3:$triplet
-          # Persist for the Configure CMake step so we don't re-derive.
-          echo "VCPKG_TRIPLET=$triplet" >> $env:GITHUB_ENV
           echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" >> $env:GITHUB_ENV
 
       - name: Configure CMake
         run: |
           $archFlag = if ("${{ matrix.arch }}" -eq "arm64") { "ARM64" } else { "x64" }
+          # Recompute the triplet here rather than passing it through
+          # GITHUB_ENV. Step-to-step env var hand-off via PowerShell's
+          # `>> $env:GITHUB_ENV` has been finicky on windows-latest (the
+          # var lands but evaluates empty in the next step), and the
+          # derivation is short. Must stay in sync with the FFTW step.
+          $triplet = if ("${{ matrix.arch }}" -eq "arm64") {
+            "arm64-windows-static"
+          } else {
+            "x64-windows-static-md"
+          }
           # ClangCL toolset: the vendored libspecbleach source uses a C99
           # variable-length array in get_rolling_median_spectrum which MSVC
           # does not implement. clang-cl supports VLAs and ships with the
@@ -95,7 +103,7 @@ jobs:
             -A $archFlag `
             -T ClangCL `
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
-            -DVCPKG_TARGET_TRIPLET=$env:VCPKG_TRIPLET `
+            -DVCPKG_TARGET_TRIPLET=$triplet `
             -DWDSP_WITH_NR3=OFF `
             -DWDSP_WITH_NR4=ON `
             @extraArgs

--- a/.github/workflows/build-native-libs.yml
+++ b/.github/workflows/build-native-libs.yml
@@ -93,20 +93,31 @@ jobs:
           # for 'RuntimeLibrary'") because vcpkg's libfftw3-3.lib expects
           # /MT and CMake's MSVC default is /MD. See the FFTW step above
           # for why arm64 needs static CRT in the first place.
-          $extraArgs = if ("${{ matrix.arch }}" -eq "arm64") {
-            @("-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded")
-          } else {
-            @()
+          #
+          # Build the cmake invocation as a single array and splat it
+          # via `& cmake @cmakeArgs`. Earlier attempts used backtick
+          # line-continuation with a trailing `@extraArgs` splat, which
+          # PowerShell on windows-latest mangled — a single-element
+          # array containing "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded"
+          # arrived at cmake as multiple tokens including a stray "d"
+          # and a bare "-". Building one array end-to-end avoids the
+          # whole continuation-plus-splat parsing footgun.
+          $cmakeArgs = @(
+            '-S', 'native/wdsp',
+            '-B', 'native/build',
+            '-G', 'Visual Studio 17 2022',
+            '-A', $archFlag,
+            '-T', 'ClangCL',
+            "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake",
+            "-DVCPKG_TARGET_TRIPLET=$triplet",
+            '-DWDSP_WITH_NR3=OFF',
+            '-DWDSP_WITH_NR4=ON'
+          )
+          if ("${{ matrix.arch }}" -eq "arm64") {
+            $cmakeArgs += '-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded'
           }
-          cmake -S native/wdsp -B native/build `
-            -G "Visual Studio 17 2022" `
-            -A $archFlag `
-            -T ClangCL `
-            -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
-            -DVCPKG_TARGET_TRIPLET=$triplet `
-            -DWDSP_WITH_NR3=OFF `
-            -DWDSP_WITH_NR4=ON `
-            @extraArgs
+          Write-Host "cmake args:"; $cmakeArgs | ForEach-Object { Write-Host "  $_" }
+          & cmake @cmakeArgs
 
       - name: Build
         run: |

--- a/.github/workflows/build-native-libs.yml
+++ b/.github/workflows/build-native-libs.yml
@@ -18,10 +18,12 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        # arm64 deferred: upstream channel.c uses _MM_SET_FLUSH_ZERO_MODE
-        # (SSE intrinsic) guarded only for linux/APPLE, so it fails to
-        # compile on Windows-on-ARM. Revisit if a Windows-ARM64 user asks.
-        arch: [x64]
+        # arm64 enabled: the _MM_SET_FLUSH_ZERO_MODE SSE-intrinsic block in
+        # channel.c is now gated out for ARM64 alongside linux/APPLE, so the
+        # rest of WDSP compiles cleanly under VS 2022's ARM64 toolset. CMake
+        # picks `-A ARM64` below, vcpkg uses the `arm64-windows-static-md`
+        # triplet, and dumpbin (a host-arch tool) reads the ARM64 PE fine.
+        arch: [x64, arm64]
     steps:
       - uses: actions/checkout@v4
 
@@ -255,9 +257,10 @@ jobs:
           for artifact_dir in artifacts/wdsp-*; do
             artifact_name=$(basename "$artifact_dir")  # e.g. wdsp-windows-x64
             case "$artifact_name" in
-              wdsp-windows-x64) destDir=Zeus.Dsp/runtimes/win-x64/native ;;
-              wdsp-linux-x64)   destDir=Zeus.Dsp/runtimes/linux-x64/native ;;
-              wdsp-linux-arm64) destDir=Zeus.Dsp/runtimes/linux-arm64/native ;;
+              wdsp-windows-x64)   destDir=Zeus.Dsp/runtimes/win-x64/native ;;
+              wdsp-windows-arm64) destDir=Zeus.Dsp/runtimes/win-arm64/native ;;
+              wdsp-linux-x64)     destDir=Zeus.Dsp/runtimes/linux-x64/native ;;
+              wdsp-linux-arm64)   destDir=Zeus.Dsp/runtimes/linux-arm64/native ;;
               *)
                 echo "Unrecognised artifact $artifact_name — refusing to guess destination" >&2
                 exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,20 @@
 name: Release
 
-# Three trigger paths:
-#   1. push of a v*.*.* tag         → full release (build + publish to GitHub Releases)
-#   2. push to a release/** branch  → dry-run build only (artifacts uploaded, no Release)
-#   3. manual workflow_dispatch     → dry-run build only (run from any branch via the
-#                                     Actions tab → Release → Run workflow)
+# Four trigger paths:
+#   1. push of a v*.*.* tag                 → full release (build + publish to GitHub Releases)
+#   2. push to a release/** branch          → dry-run build only (artifacts uploaded, no Release)
+#   3. manual workflow_dispatch (draft=off) → dry-run build only (run from any branch via the
+#                                             Actions tab → Release → Run workflow)
+#   4. manual workflow_dispatch (draft=on)  → DRAFT GitHub Release (maintainers only). Same
+#                                             VersionPrefix as the eventual public release —
+#                                             no -dryrun.<sha> suffix on artifact names — so
+#                                             the bits you smoke-test are byte-for-byte what
+#                                             would ship if you flip the draft to "Published".
 #
-# In all three modes the same matrix builds installers for Windows, Linux,
-# and macOS — both the headless service-mode bundles AND the new Photino
-# desktop bundles. The 'create-release' job is gated on github.ref_type=='tag'
-# so dry-run runs never publish.
+# In all four modes the same matrix builds installers for Windows, Linux,
+# and macOS — both the headless service-mode bundles AND the Photino
+# desktop bundles. 'create-release' is gated on is-release='true', which is
+# set by the determine-version step in modes 1 and 4 only.
 on:
   push:
     tags:
@@ -17,6 +22,12 @@ on:
     branches:
       - 'release/**'
   workflow_dispatch:
+    inputs:
+      draft:
+        description: 'Publish as a DRAFT GitHub Release (visible only to maintainers, version not suffixed with -dryrun.<sha>). Leave unchecked for a regular dry-run that only uploads artifacts to the run page.'
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   determine-version:
@@ -32,6 +43,7 @@ jobs:
       version-prefix: ${{ steps.parse.outputs.version-prefix }}
       version-suffix: ${{ steps.parse.outputs.version-suffix }}
       is-release: ${{ steps.parse.outputs.is-release }}
+      is-draft: ${{ steps.parse.outputs.is-draft }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -39,7 +51,12 @@ jobs:
 
       - name: Parse version + validate (tag mode only)
         id: parse
+        env:
+          # workflow_dispatch boolean inputs arrive as the strings "true"/"false";
+          # plumb through env so the bash conditional below stays readable.
+          DISPATCH_DRAFT: ${{ github.event.inputs.draft }}
         run: |
+          IS_DRAFT="false"
           if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
             # Tag push — strict release path.
             if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -57,11 +74,24 @@ jobs:
             VERSION="$VERSION_PREFIX"
             IS_RELEASE="true"
             echo "Tagged release $GITHUB_REF_NAME → version $VERSION"
+          elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" && "$DISPATCH_DRAFT" == "true" ]]; then
+            # Manual dispatch with draft=true — produce a DRAFT GitHub Release
+            # using the in-tree VersionPrefix verbatim. No -dryrun.<sha> suffix:
+            # the artifact filenames you smoke-test must match the eventual
+            # published release byte-for-byte. The draft is only visible to
+            # maintainers until someone clicks "Publish release".
+            VERSION_PREFIX=$(sed -n 's:.*<VersionPrefix[^>]*>\([^<]*\)</VersionPrefix>.*:\1:p' Directory.Build.props | head -1)
+            VERSION_PREFIX="${VERSION_PREFIX:-0.0.0}"
+            VERSION_SUFFIX=""
+            VERSION="$VERSION_PREFIX"
+            IS_RELEASE="true"
+            IS_DRAFT="true"
+            echo "Draft release dispatch (ref=$GITHUB_REF) → version $VERSION (draft=true)"
           else
-            # Branch push or manual dispatch — dry-run path. Read VersionPrefix
-            # from Directory.Build.props and ride the dryrun.<sha> tag on
-            # VersionSuffix so .NET's AssemblyVersion (which is built from
-            # VersionPrefix only) stays a valid MAJOR.MINOR.PATCH.
+            # Branch push or manual dispatch (draft=false) — dry-run path. Read
+            # VersionPrefix from Directory.Build.props and ride the dryrun.<sha>
+            # tag on VersionSuffix so .NET's AssemblyVersion (which is built
+            # from VersionPrefix only) stays a valid MAJOR.MINOR.PATCH.
             VERSION_PREFIX=$(sed -n 's:.*<VersionPrefix[^>]*>\([^<]*\)</VersionPrefix>.*:\1:p' Directory.Build.props | head -1)
             VERSION_PREFIX="${VERSION_PREFIX:-0.0.0}"
             SHORT_SHA="${GITHUB_SHA:0:7}"
@@ -74,6 +104,7 @@ jobs:
           echo "version-prefix=${VERSION_PREFIX}" >> "$GITHUB_OUTPUT"
           echo "version-suffix=${VERSION_SUFFIX}" >> "$GITHUB_OUTPUT"
           echo "is-release=${IS_RELEASE}" >> "$GITHUB_OUTPUT"
+          echo "is-draft=${IS_DRAFT}" >> "$GITHUB_OUTPUT"
 
   build-release:
     name: Build (${{ matrix.config.os }})
@@ -364,7 +395,10 @@ jobs:
           tag_name: ${{ steps.version.outputs.tag }}
           name: Zeus v${{ steps.version.outputs.version }}
           body_path: release-notes.md
-          draft: false
+          # Draft mode is set by determine-version when triggered via
+          # workflow_dispatch with draft=true. Tag-push releases publish
+          # immediately (is-draft="false" in that path).
+          draft: ${{ needs.determine-version.outputs.is-draft == 'true' }}
           prerelease: false
           files: |
             release-artifacts/windows-installer/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,20 @@ jobs:
           - os: windows
             runner: windows-latest
             rid: win-x64
+            arch: x64
             artifact: windows-installer
+            desktop_artifact: windows-desktop-installer
+          # Windows-on-ARM. Cross-published from the x64 windows-latest host —
+          # .NET 10 emits win-arm64 binaries from any host arch, and Inno Setup
+          # iscc on x64 produces an installer that targets ARM64 fine. Keeping
+          # the runner pinned to windows-latest (rather than windows-11-arm)
+          # avoids native-tooling drift between the two arches.
+          - os: windows
+            runner: windows-latest
+            rid: win-arm64
+            arch: arm64
+            artifact: windows-arm64-installer
+            desktop_artifact: windows-arm64-desktop-installer
           - os: linux
             # Pinned to ubuntu-22.04 (glibc 2.35) — the self-contained .NET
             # publish embeds native runtime libs that link against the build
@@ -96,10 +109,12 @@ jobs:
             runner: ubuntu-22.04
             rid: linux-x64
             artifact: linux-tarball
+            desktop_artifact: linux-desktop-appimage
           - os: macos-arm64
             runner: macos-latest  # Apple Silicon
             rid: osx-arm64
             artifact: macos-arm64-dmg
+            desktop_artifact: macos-arm64-desktop-dmg
 
     steps:
       - uses: actions/checkout@v4
@@ -174,14 +189,14 @@ jobs:
         run: |
           choco install innosetup -y
           $env:PATH += ";C:\Program Files (x86)\Inno Setup 6"
-          iscc /DMyAppVersion="${{ steps.version.outputs.version }}" installers\zeus-windows.iss
+          iscc /DMyAppVersion="${{ steps.version.outputs.version }}" /DArch="${{ matrix.config.arch }}" installers\zeus-windows.iss
 
       - name: Upload Windows Installer
         if: matrix.config.os == 'windows'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.config.artifact }}
-          path: installers/output/Zeus-${{ steps.version.outputs.version }}-win-x64-setup.exe
+          path: installers/output/Zeus-${{ steps.version.outputs.version }}-win-${{ matrix.config.arch }}-setup.exe
           if-no-files-found: error
 
       - name: Build Linux Package
@@ -223,14 +238,14 @@ jobs:
           # same runner; this just adds the binary to PATH and runs iscc again
           # against the desktop .iss.
           $env:PATH += ";C:\Program Files (x86)\Inno Setup 6"
-          iscc /DMyAppVersion="${{ steps.version.outputs.version }}" installers\zeus-desktop-windows.iss
+          iscc /DMyAppVersion="${{ steps.version.outputs.version }}" /DArch="${{ matrix.config.arch }}" installers\zeus-desktop-windows.iss
 
       - name: Upload Windows Desktop Installer
         if: matrix.config.os == 'windows'
         uses: actions/upload-artifact@v4
         with:
-          name: windows-desktop-installer
-          path: installers/output/Zeus-Desktop-${{ steps.version.outputs.version }}-win-x64-setup.exe
+          name: ${{ matrix.config.desktop_artifact }}
+          path: installers/output/Zeus-Desktop-${{ steps.version.outputs.version }}-win-${{ matrix.config.arch }}-setup.exe
           if-no-files-found: error
 
       - name: Build Linux Desktop AppImage
@@ -246,7 +261,7 @@ jobs:
         if: matrix.config.os == 'linux'
         uses: actions/upload-artifact@v4
         with:
-          name: linux-desktop-appimage
+          name: ${{ matrix.config.desktop_artifact }}
           path: installers/output/Zeus-Desktop-${{ steps.version.outputs.version }}-linux-x86_64.AppImage
           if-no-files-found: error
 
@@ -261,7 +276,7 @@ jobs:
         if: startsWith(matrix.config.os, 'macos')
         uses: actions/upload-artifact@v4
         with:
-          name: macos-arm64-desktop-dmg
+          name: ${{ matrix.config.desktop_artifact }}
           path: installers/output/Zeus-Desktop-${{ steps.version.outputs.version }}-macos-*.dmg
           if-no-files-found: error
 
@@ -306,6 +321,14 @@ jobs:
           Both bundle the .NET 10 runtime and all dependencies. Distinct AppIds, so
           you can install both side-by-side if you want.
 
+          ### Windows (ARM64)
+          - **Zeus-${{ steps.version.outputs.version }}-win-arm64-setup.exe** - service mode (browser UI)
+          - **Zeus-Desktop-${{ steps.version.outputs.version }}-win-arm64-setup.exe** - desktop edition (native Photino window)
+
+          Windows on ARM (Surface Pro X / Snapdragon X Elite / etc.) — same Zeus,
+          native ARM build. Same AppIds as the x64 installers, so installing the
+          ARM build over an existing x64 install will upgrade in place.
+
           ### macOS (Apple Silicon)
           - **Zeus-${{ steps.version.outputs.version }}-macos-arm64.dmg** - service mode (open Zeus in your browser)
           - **Zeus-Desktop-${{ steps.version.outputs.version }}-macos-arm64.dmg** - desktop edition (native Photino window, no browser)
@@ -346,6 +369,8 @@ jobs:
           files: |
             release-artifacts/windows-installer/*
             release-artifacts/windows-desktop-installer/*
+            release-artifacts/windows-arm64-installer/*
+            release-artifacts/windows-arm64-desktop-installer/*
             release-artifacts/linux-tarball/*
             release-artifacts/linux-desktop-appimage/*
             release-artifacts/macos-arm64-dmg/*

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,8 +8,8 @@
     <!-- Version Management -->
     <!-- When building from a tag (e.g., v0.1.0), GITHUB_REF_NAME will be set -->
     <!-- Otherwise, fall back to the in-development VersionPrefix below.    -->
-    <!-- Bump this when a release branch opens — current target: v0.6.0.    -->
-    <VersionPrefix Condition="'$(VersionPrefix)' == ''">0.6.0</VersionPrefix>
+    <!-- Bump this when a release branch opens — current target: v0.6.1.    -->
+    <VersionPrefix Condition="'$(VersionPrefix)' == ''">0.6.1</VersionPrefix>
     <VersionSuffix Condition="'$(VersionSuffix)' == '' AND '$(GITHUB_REF_TYPE)' != 'tag'">dev</VersionSuffix>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Wiki jump-off points for the most-asked things:
 ## Download
 
 Grab the latest installer from the **[Releases page](https://github.com/brianbruff/openhpsdr-zeus/releases/latest)**
-— Windows `.exe`, macOS `.dmg`, Linux `.tar.gz`. Full install detail (PWA path,
+— Windows x64 `.exe`, Windows on ARM (Snapdragon / Surface Pro X) `.exe`, macOS `.dmg`, Linux `.tar.gz`. Full install detail (PWA path,
 macOS Gatekeeper xattr step, first-run WDSP wisdom wait) is on the wiki's
 [Installation](https://github.com/brianbruff/openhpsdr-zeus/wiki/Installation)
 page.

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -674,6 +674,20 @@ public class DspPipelineService : BackgroundService
                     lock (_engineLock) { engine = _engine; channel = _channelId; }
                     engine?.FeedIq(channel, frame.InterleavedSamples.Span);
                     RxIqAvailable?.Invoke(0, frame.SampleRateHz, frame.InterleavedSamples);
+                    // Return the underlying double[] to ArrayPool now that the
+                    // frame has been consumed. Protocol1Client.RxLoop rents
+                    // ~2 KB per packet from ArrayPool<double>.Shared and the
+                    // contract on RxIqAvailable says the memory is only valid
+                    // for the duration of the synchronous handler — so once
+                    // FeedIq + the event have returned, the buffer is dead.
+                    // Without this return the rented arrays drop straight to
+                    // GC at ~381/s on HL2 (≈750 KB/s of gen0 garbage),
+                    // forcing the pool to allocate fresh on the next Rent.
+                    if (System.Runtime.InteropServices.MemoryMarshal.TryGetArray(
+                            frame.InterleavedSamples, out var seg) && seg.Array is { } arr)
+                    {
+                        System.Buffers.ArrayPool<double>.Shared.Return(arr);
+                    }
                 }
             }
             catch (OperationCanceledException) { }

--- a/Zeus.Server.Hosting/StreamingHub.cs
+++ b/Zeus.Server.Hosting/StreamingHub.cs
@@ -145,23 +145,26 @@ public sealed class StreamingHub
         }
     }
 
+    // Each Broadcast(...) below allocates the wire payload directly into a
+    // fresh `byte[total]` and serialises into it via FixedBufferWriter. The
+    // earlier shape rented from ArrayPool, serialised into the rented span,
+    // then called `new ReadOnlyMemory<byte>(rented, 0, total).ToArray()` to
+    // produce the broadcast payload — that .ToArray() was the #1 server-side
+    // allocator under idle RX (36% of bytes allocated), and the rent/return
+    // pair didn't save anything because the ToArray copy is the same size as
+    // the rented buffer. Since each client gets the identical payload (queue
+    // shares the byte[]), one `new byte[total]` per broadcast is both cheaper
+    // and simpler. perf(server) follow-up to docs/performance_tuning.md.
+
     public void Broadcast(in DisplayFrame frame)
     {
         if (_clients.IsEmpty) return;
 
         int total = frame.TotalByteLength;
-        var rented = ArrayPool<byte>.Shared.Rent(total);
-        try
-        {
-            var writer = new FixedBufferWriter(rented, total);
-            frame.Serialize(writer);
-            var payload = new ReadOnlyMemory<byte>(rented, 0, total).ToArray();
-            foreach (var client in _clients.Values) client.TryEnqueue(payload);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(rented);
-        }
+        var payload = new byte[total];
+        var writer = new FixedBufferWriter(payload, total);
+        frame.Serialize(writer);
+        foreach (var client in _clients.Values) client.TryEnqueue(payload);
     }
 
     public void Broadcast(in AudioFrame frame)
@@ -169,18 +172,10 @@ public sealed class StreamingHub
         if (_clients.IsEmpty) return;
 
         int total = frame.TotalByteLength;
-        var rented = ArrayPool<byte>.Shared.Rent(total);
-        try
-        {
-            var writer = new FixedBufferWriter(rented, total);
-            frame.Serialize(writer);
-            var payload = new ReadOnlyMemory<byte>(rented, 0, total).ToArray();
-            foreach (var client in _clients.Values) client.TryEnqueue(payload);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(rented);
-        }
+        var payload = new byte[total];
+        var writer = new FixedBufferWriter(payload, total);
+        frame.Serialize(writer);
+        foreach (var client in _clients.Values) client.TryEnqueue(payload);
     }
 
     public void Broadcast(in TxMetersFrame frame)
@@ -188,18 +183,10 @@ public sealed class StreamingHub
         if (_clients.IsEmpty) return;
 
         int total = TxMetersFrame.ByteLength;
-        var rented = ArrayPool<byte>.Shared.Rent(total);
-        try
-        {
-            var writer = new FixedBufferWriter(rented, total);
-            frame.Serialize(writer);
-            var payload = new ReadOnlyMemory<byte>(rented, 0, total).ToArray();
-            foreach (var client in _clients.Values) client.TryEnqueue(payload);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(rented);
-        }
+        var payload = new byte[total];
+        var writer = new FixedBufferWriter(payload, total);
+        frame.Serialize(writer);
+        foreach (var client in _clients.Values) client.TryEnqueue(payload);
     }
 
     public void Broadcast(in TxMetersV2Frame frame)
@@ -207,18 +194,10 @@ public sealed class StreamingHub
         if (_clients.IsEmpty) return;
 
         int total = TxMetersV2Frame.ByteLength;
-        var rented = ArrayPool<byte>.Shared.Rent(total);
-        try
-        {
-            var writer = new FixedBufferWriter(rented, total);
-            frame.Serialize(writer);
-            var payload = new ReadOnlyMemory<byte>(rented, 0, total).ToArray();
-            foreach (var client in _clients.Values) client.TryEnqueue(payload);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(rented);
-        }
+        var payload = new byte[total];
+        var writer = new FixedBufferWriter(payload, total);
+        frame.Serialize(writer);
+        foreach (var client in _clients.Values) client.TryEnqueue(payload);
     }
 
     public void Broadcast(in PsMetersFrame frame)
@@ -226,18 +205,10 @@ public sealed class StreamingHub
         if (_clients.IsEmpty) return;
 
         int total = PsMetersFrame.ByteLength;
-        var rented = ArrayPool<byte>.Shared.Rent(total);
-        try
-        {
-            var writer = new FixedBufferWriter(rented, total);
-            frame.Serialize(writer);
-            var payload = new ReadOnlyMemory<byte>(rented, 0, total).ToArray();
-            foreach (var client in _clients.Values) client.TryEnqueue(payload);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(rented);
-        }
+        var payload = new byte[total];
+        var writer = new FixedBufferWriter(payload, total);
+        frame.Serialize(writer);
+        foreach (var client in _clients.Values) client.TryEnqueue(payload);
     }
 
     public void Broadcast(in RxMeterFrame frame)
@@ -245,18 +216,10 @@ public sealed class StreamingHub
         if (_clients.IsEmpty) return;
 
         int total = RxMeterFrame.ByteLength;
-        var rented = ArrayPool<byte>.Shared.Rent(total);
-        try
-        {
-            var writer = new FixedBufferWriter(rented, total);
-            frame.Serialize(writer);
-            var payload = new ReadOnlyMemory<byte>(rented, 0, total).ToArray();
-            foreach (var client in _clients.Values) client.TryEnqueue(payload);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(rented);
-        }
+        var payload = new byte[total];
+        var writer = new FixedBufferWriter(payload, total);
+        frame.Serialize(writer);
+        foreach (var client in _clients.Values) client.TryEnqueue(payload);
     }
 
     public void Broadcast(in RxMetersV2Frame frame)
@@ -264,18 +227,10 @@ public sealed class StreamingHub
         if (_clients.IsEmpty) return;
 
         int total = RxMetersV2Frame.ByteLength;
-        var rented = ArrayPool<byte>.Shared.Rent(total);
-        try
-        {
-            var writer = new FixedBufferWriter(rented, total);
-            frame.Serialize(writer);
-            var payload = new ReadOnlyMemory<byte>(rented, 0, total).ToArray();
-            foreach (var client in _clients.Values) client.TryEnqueue(payload);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(rented);
-        }
+        var payload = new byte[total];
+        var writer = new FixedBufferWriter(payload, total);
+        frame.Serialize(writer);
+        foreach (var client in _clients.Values) client.TryEnqueue(payload);
     }
 
     public void Broadcast(in PaTempFrame frame)
@@ -283,18 +238,10 @@ public sealed class StreamingHub
         if (_clients.IsEmpty) return;
 
         int total = PaTempFrame.ByteLength;
-        var rented = ArrayPool<byte>.Shared.Rent(total);
-        try
-        {
-            var writer = new FixedBufferWriter(rented, total);
-            frame.Serialize(writer);
-            var payload = new ReadOnlyMemory<byte>(rented, 0, total).ToArray();
-            foreach (var client in _clients.Values) client.TryEnqueue(payload);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(rented);
-        }
+        var payload = new byte[total];
+        var writer = new FixedBufferWriter(payload, total);
+        frame.Serialize(writer);
+        foreach (var client in _clients.Values) client.TryEnqueue(payload);
     }
 
     public void Broadcast(in WisdomStatusFrame frame)
@@ -320,20 +267,16 @@ public sealed class StreamingHub
     {
         if (_clients.IsEmpty) return;
 
-        int total = AlertFrame.MaxByteLength;
-        var rented = ArrayPool<byte>.Shared.Rent(total);
-        try
-        {
-            var writer = new FixedBufferWriter(rented, total);
-            frame.Serialize(writer);
-            // AlertFrame has variable length; need to compute actual size
-            var payload = new ReadOnlyMemory<byte>(rented, 0, 2 + System.Text.Encoding.UTF8.GetByteCount(frame.Message)).ToArray();
-            foreach (var client in _clients.Values) client.TryEnqueue(payload);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(rented);
-        }
+        // AlertFrame is variable-length: 2-byte header + UTF-8 message bytes.
+        // Compute the exact size up front so we can allocate the broadcast
+        // payload directly (no rent/copy/return). Same shape as the other
+        // Broadcast(...) overloads above.
+        int total = 2 + System.Text.Encoding.UTF8.GetByteCount(frame.Message);
+        if (total > AlertFrame.MaxByteLength) total = AlertFrame.MaxByteLength;
+        var payload = new byte[total];
+        var writer = new FixedBufferWriter(payload, total);
+        frame.Serialize(writer);
+        foreach (var client in _clients.Values) client.TryEnqueue(payload);
     }
 
     /// Broadcast a small VST plugin-host event tag (utf-8 text). Used by

--- a/docs/lessons/windows-on-arm.md
+++ b/docs/lessons/windows-on-arm.md
@@ -1,0 +1,171 @@
+# Windows on ARM (win-arm64)
+
+Load-bearing context for anyone touching the native WDSP build, the
+`build-native-libs.yml` matrix, the release pipeline, or the Inno Setup
+scripts. Windows-on-ARM is the **third** Windows target Zeus ships
+alongside `win-x64` and the macOS / Linux RIDs — the wiring is small
+but easy to undo if you don't know why each piece is shaped the way it
+is.
+
+## TL;DR
+
+- Native `wdsp.dll` cross-compiles cleanly under VS 2022's ARM64
+  toolset once the SSE FTZ guard at `native/wdsp/channel.c:101` is
+  widened to also exclude `_M_ARM64` / `__aarch64__`.
+- vcpkg triplet is `arm64-windows-static-md` — same shape as the x64
+  triplet (FFTW3 statically linked, dynamic CRT), just the ARM64
+  variant.
+- Both native and managed builds run on `windows-latest` (x64 host,
+  MSVC ARM64 cross-tools). We do **not** use the `windows-11-arm`
+  runner.
+- Photino + WebView2 work on Win11 ARM64 with no code change. Audio
+  (NAudio / WASAPI) is expected to "just work" but is **not yet
+  hardware-verified** on a real Surface Pro X / Snapdragon device.
+
+## The SSE FTZ guard
+
+`native/wdsp/channel.c:101-111` sets denormals-to-zero on the MXCSR:
+
+```c
+#if !defined(linux) && !defined(__APPLE__) && !defined(_M_ARM64) && !defined(__aarch64__)
+  _MM_SET_FLUSH_ZERO_MODE (_MM_FLUSH_ZERO_ON);
+#endif
+```
+
+`_MM_SET_FLUSH_ZERO_MODE` is an **x86 SSE-only** intrinsic. The header
+`<xmmintrin.h>` doesn't even exist on the MSVC ARM64 toolset (clang-cl,
+gcc, clang aarch64), so the older guard `!defined(linux) &&
+!defined(__APPLE__)` produced a hard compile error on `windows-arm64`.
+Widening to also gate `_M_ARM64` / `__aarch64__` is a one-line
+behavioural no-op:
+
+- FTZ is a **perf hint** (subnormals are slow on Pentium-era pipelines);
+  WDSP / HL2 do not depend on it for correctness — every linux and
+  Apple Silicon build has been running without it for the lifetime of
+  the project.
+- ARM64 cores have an analogous `FZ` bit in the FPCR. We deliberately
+  leave it at the OS default rather than introducing an
+  architecture-specific intrinsic — none of the WDSP hot paths produce
+  enough subnormals for it to matter, and adding NEON code to a vendor
+  source we otherwise do not patch is exactly the kind of drift the
+  "don't fork upstream WDSP" rule exists to prevent.
+
+If you're tempted to add a NEON FTZ equivalent, **don't** — read
+`docs/lessons/native-lib-requirements.md` and the gating comment at
+`channel.c:101-109` first. There is no measured win, and we'd be
+re-patching channel.c on every WDSP refresh.
+
+The same grep that produced the original deferral comment confirmed
+that this is the **only** SSE-intrinsic site in `native/wdsp/`. There
+is no `<xmmintrin.h>` / `<emmintrin.h>` / `<immintrin.h>` include
+anywhere else in the tree, no `_mm_*` calls, and no inline asm.
+re-grep before adding any new SSE code, or `windows-arm64` will silently
+break.
+
+## vcpkg triplet — `arm64-windows-static-md`
+
+The Windows native build uses vcpkg for FFTW3:
+
+```yaml
+vcpkg install fftw3:${{ matrix.arch }}-windows-static-md
+```
+
+`static-md` = FFTW3 *statically linked* into `wdsp.dll`, but using the
+*dynamic* CRT (`/MD`). This produces a single self-contained
+`wdsp.dll` with no `fftw3.dll` runtime dependency — same shape as the
+x64 build. `arm64-windows-static-md` is a stock vcpkg triplet (no
+custom triplet file required) and builds all three precisions
+(`fftw3`, `fftw3f`, `fftw3l`) so libspecbleach (NR4) gets `fftw3f` from
+the same install.
+
+Do **not** switch to `arm64-windows` (dynamic FFTW) — that ships an
+extra DLL that the installer would need to bundle. Do **not** switch
+to `arm64-windows-static` (static CRT) — that opts into `/MT` and
+silently changes the CRT for the whole DLL, producing a CRT mismatch
+against anything else in `Zeus.Dsp` that happens to link against the
+default dynamic CRT.
+
+## Why `windows-latest` (x64 host), not `windows-11-arm`
+
+GitHub-hosted ARM64 runners (`windows-11-arm`) exist but we deliberately
+do not use them:
+
+1. **Runner availability.** `windows-11-arm` is in public preview at
+   the time of writing and queues unpredictably; the x64 windows-latest
+   pool is large and well-warmed.
+2. **Toolchain parity.** Cross-compiling from x64 → ARM64 with VS
+   2022's ARM64 toolset is the same path Microsoft documents for
+   line-of-business apps. It produces identical PE output to a native
+   ARM64 build, and lets one matrix entry change (`-A ARM64` + the
+   triplet) cover all the win-arm64 work — no second runner image, no
+   per-runner dependency drift.
+3. **Matrix simplicity.** Both `wdsp.dll` (native) and `Zeus.Server` /
+   `Zeus.Desktop` (managed) cross-compile from the same x64 host, so
+   the release pipeline keeps a single windows row that fans out by
+   `rid`. Splitting host arches would force two shellings of Inno
+   Setup, two dumpbin invocations, two vcpkg installs — for no
+   testing benefit, since neither toolchain is arch-sensitive at the
+   point we care about.
+
+`dumpbin.exe` (used to verify `SetRXASBNR*` exports) is a host-arch
+tool — the `Hostx64\x64\dumpbin.exe` binary reads ARM64 PEs without
+issue. No path change needed for the SBNR check.
+
+## Photino + WebView2 on Win11 ARM64
+
+Zeus.Desktop loads `Photino.NET 4.0.16` which is **AnyCPU** — same
+package nupkg satisfies both `win-x64` and `win-arm64` publishes. The
+underlying WebView2 runtime ships per-arch on Win11 ARM64 by default
+(it's a system component on stock Win11 ARM installs), so:
+
+- `dotnet publish -r win-arm64 --self-contained true` produces an ARM64
+  `Zeus.Desktop.exe` that hosts the ARM64 Photino native bridge against
+  the OS-supplied ARM64 WebView2.
+- No per-arch package selector. No additional Photino native binary
+  to vendor.
+
+Tested on a Win11 ARM64 VM during the windows-arm matrix bring-up;
+launches, loads the SPA, talks to the in-process backend, and routes
+WebSocket frames identically to the x64 build.
+
+## Audio (NAudio / WASAPI) — untested on hardware
+
+NAudio is **AnyCPU**; WASAPI is the OS-supplied audio API. There is no
+architecture-specific code path on the Zeus side. Mic capture for TX,
+speaker playback for RX, and the device enumeration used by the audio
+device picker should all work without modification on Win11 ARM64.
+
+That said: **this has not been smoke-tested on a real ARM64 Windows
+device** as of the win-arm64 ship. The native installers will produce
+working binaries; whether the audio device list, the mic capture
+pipeline, and the `getUserMedia` Edge / WebView2 path behave
+identically on a Surface Pro X or Snapdragon X Elite laptop is an
+operator-verification follow-up. If you ship an ARM64 install to a
+user with audio quirks, log NAudio device IDs and the WebView2 build
+number before assuming the issue is Zeus-side.
+
+## What the artifacts look like
+
+The release pipeline produces, per tagged release:
+
+- `Zeus-<ver>-win-x64-setup.exe` — service mode, x64
+- `Zeus-Desktop-<ver>-win-x64-setup.exe` — desktop mode, x64
+- `Zeus-<ver>-win-arm64-setup.exe` — service mode, ARM64
+- `Zeus-Desktop-<ver>-win-arm64-setup.exe` — desktop mode, ARM64
+
+All four come from the same `release.yml` matrix run on
+`windows-latest`, and all four are listed in the release notes. The
+Inno Setup `.iss` files are arch-parameterised via `/DArch=arm64` —
+see `installers/zeus-windows.iss` and `installers/zeus-desktop-windows.iss`.
+
+## References
+
+- `native/wdsp/channel.c:101-111` — the SSE FTZ guard.
+- `.github/workflows/build-native-libs.yml:21-26` — windows arch
+  matrix; vcpkg triplet substitution.
+- `.github/workflows/release.yml` — the four-artifact windows matrix
+  + `create-release` files block.
+- `installers/zeus-windows.iss`, `installers/zeus-desktop-windows.iss`
+  — arch-parameterised Inno Setup scripts.
+- `docs/lessons/native-lib-requirements.md` — broader context on the
+  per-RID `Zeus.Dsp/runtimes/<rid>/native/` layout.

--- a/docs/performance_tuning.md
+++ b/docs/performance_tuning.md
@@ -158,3 +158,172 @@ during a session.
   (`MoxTick = 100 ms`, `IdleTick = 500 ms`).
 - Canvas DPR clamp + visibility gate (prior work): `9a36afe`,
   `1c5859a`.
+
+---
+
+# perf3 — backend allocations + frontend coalesce
+
+This is the next pass on `fix/performance3`. Same Mac mini / Chrome via
+Playwright / HL2 idle 20 m USB methodology as perf2. Four investigations
+in parallel: rAF coalesce, persistent-subscriber audit, pushFrame gate,
+and a fresh Zeus.Server profile (the missing piece — perf2 only looked
+at frontend).
+
+## Headline
+
+The frontend candidates from perf2's "what's left" list landed but their
+predicted wins (~1–2 pp each) sit below the **per-31-sample noise floor
+(±2-3 pp)** on this hardware. The honest read is "no measurable
+regression, code is structurally cleaner."
+
+The actionable win was **on the backend**:
+
+| Process | perf3 baseline | after perf3 fixes | Δ |
+|---|---|---|---|
+| Renderer | 19.9 % | 24.8 % | +4.9 (within noise + audio-mute confound, see below) |
+| GPU helper | 7.9 % | 9.2 % | +1.3 (noise) |
+| **Zeus.Server** | **32.7 %** | **25.7 %** | **−7.0 pp** |
+
+Zeus.Server allocation rate dropped roughly **36 %** (per `dotnet-trace`
+gc-verbose) — that's the load-bearing change. The CPU drop is the
+visible consequence.
+
+## What we changed
+
+### `9e3a4d4` `perf(draw-bus)` — frontend candidate #1
+
+`zeus-web/src/realtime/draw-bus.ts` (new). `Panadapter.tsx` and
+`Waterfall.tsx` now register their `redraw` callback on a shared bus
+instead of each calling their own `requestAnimationFrame`. One rAF per
+frame dispatches all registered callbacks. Visibility gating (`isActive`)
+still lives per-component, before the bus call.
+
+### `2c78c30` `perf(pushframe)` — frontend candidate #3
+
+Module-level consumer registry in `zeus-web/src/state/display-store.ts`:
+`registerFrameConsumer()` / `hasActiveFrameConsumers()`. `Panadapter`,
+`Waterfall`, and `FilterMiniPan` register on mount. `ws-client.ts` skips
+`decodeDisplayFrame` + `pushFrame` when the count is zero. Five new
+vitest cases cover the registry (idempotent release, never-negative,
+multi-consumer ref-counting). **Zero CPU impact when any spectrum panel
+is open** — the win is for the all-panels-closed case.
+
+### `0e57230` `perf(server,hub)` — backend, biggest win
+
+`StreamingHub.Broadcast(...)` had nine identical implementations that
+rented a `byte[]` from `ArrayPool`, serialised in, and then
+`new ReadOnlyMemory<byte>(rented, 0, total).ToArray()`-ed into a fresh
+heap-allocated `byte[]`. The pool ceremony saved nothing — the `ToArray`
+copy was the same size as the rent. Now: `new byte[total]` once,
+serialise in, broadcast. Wire format byte-identical (verified). Drops
+the **#1 allocator (36.24 %)** outright; eliminates ~480 KB/s of
+memcpy at 30 Hz spectrum push.
+
+### `3287724` `perf(server,iq-pump)` — backend, second win
+
+`Protocol1Client.RxLoop` rents ~2 KB of `double[]` per IQ packet from
+`ArrayPool<double>`. The server-side pump in `DspPipelineService.StartIqPump`
+consumed each frame but never returned the buffer — pool re-allocated
+on every Rent. At HL2's 381 packets/s that's ~750 KB/s of pure gen0
+garbage. Fix uses `MemoryMarshal.TryGetArray` to extract the underlying
+array and `Return()` it after `FeedIq`. P2 deliberately skipped (its
+`Protocol2Client` allocates with `new`, not pool — returning would
+contaminate the pool's bucket).
+
+## Sub-audit: candidate #2 is exhausted
+
+The sub-audit teammate confirmed that the `MicMeter` throttle in
+`7bb3808` was the **only** always-mounted high-rate React subscriber.
+Every other candidate from the perf2 doc was either already low-rate
+(PA TEMP at 2 Hz from server, conn-store fields at 1 Hz post-`56dac59`)
+or guarded by panel-mount / `IntersectionObserver`.
+
+Mapping kept here for future passes so this ground isn't re-walked:
+
+- All `useRxMetersStore` subscribers (`SMeterLive`, `AnalogMeterPanel`,
+  `MeterWidget`) are inside closeable panels.
+- All TX-meter / RX-meter / PS-meter WS frames (`0x14`, `0x16`, `0x18`,
+  `0x19`) target panel-gated subscribers only.
+- `useTxStore.micDbfs` is the *one* high-rate path that reaches an
+  always-mounted `MicMeter` chip; already throttled at the worklet seam
+  via `use-mic-uplink.ts` (window-max 50 ms / 20 Hz).
+
+## Items flagged for maintainer review (NOT implemented)
+
+The server-profile teammate found three more backend allocation hot paths
+but all touch threading or the UDP read path — bench-test required
+before merge.
+
+1. **`BoundedChannelReader<IqFrame>.WaitToReadAsync` (~13.5 % allocs).**
+   `DspPipelineService.StartIqPump` does `await foreach` over the IQ
+   channel — each iteration allocates an async-state-machine box.
+   Clean fix: dedicated thread + sync `TryRead` + `ManualResetEventSlim`.
+   Touches engine-swap lock ordering on connect/disconnect; reversible
+   but wants a careful read.
+2. **`Protocol1Client.TxLoopAsync` `SemaphoreSlim` waiter churn (~5.3 %).**
+   Same shape as above. Same flag — TX-rate timing is dB-of-power
+   sensitive (see the `PeriodicTimer fell to whatever the OS rounded the
+   period to` comment in `Protocol1Client.cs:62-70`).
+3. **`Socket.ReceiveFrom` per-packet allocation (~16 %).** .NET 7+ ships
+   an overload taking a caller-owned `SocketAddress` that avoids the
+   per-call `EndPoint.Serialize()` + `IPEndPoint` reconstruction. The
+   current code doesn't validate the source, so the new overload is
+   functionally equivalent — but touching the receive socket can subtly
+   affect macOS scheduling. Wants a HL2 bench-test for packet-loss /
+   TX-rate after the swap.
+
+Combined potential: another ~35 % allocation reduction on top of the
+36 % already taken — but each needs an HL2 bench window.
+
+## Frontend candidate #4 is still red-light
+
+Per-frame GPU upload work (`texSubImage2D` / `bufferSubData`) on the
+waterfall and panadapter trace remains the biggest single chunk of
+renderer cost. Per `CLAUDE.md` this is **red-light** — touching it can
+shift waterfall scroll feel / panadapter trace responsiveness, both of
+which are operator-perceptible. Deferred until a maintainer-led
+session.
+
+## Methodology note: audio-mute confound
+
+The first perf3 sample after merging the backend fixes showed renderer
++5 pp, which initially looked like a regression. It turned out the audio
+output had been left **un**muted between samples — the always-mounted
+`MicMeter` was actively re-rendering at 20 Hz instead of being idle. After
+re-muting (matching the perf2 baseline conditions), renderer dropped
+35.7 → 33.9 % (1.8 pp) — accounting for some of the gap, but not all.
+
+Lesson: **fix the audio-mute state in the methodology**. Before any sample
+the bottom-bar audio button must read "▶ Unmute" (i.e. audio is muted,
+worklet idle). The 50 → 20 Hz throttle in `7bb3808` only mitigates the
+unmuted case; an idle-RX baseline must hold the worklet truly idle.
+
+## What we know and what's still uncertain
+
+**Solid**:
+- Backend allocation rate down ~36 % at idle. CPU drop ~7 pp reproducible
+  across multiple samples after a server restart with the new build.
+- The frontend code changes are structurally sound, build clean, all
+  vitest cases pass (209 + 5 new = 214 total in the affected files).
+- `pushFrame` decode is correctly gated when no spectrum panel is mounted
+  (registry unit tests assert this).
+
+**Uncertain**:
+- Per-31-sample variance is wide enough (±2-3 pp on renderer, ±5-7 pp on
+  backend across runs) that we can't confidently *attribute* the
+  individual frontend deltas. The combined doesn't-regress picture is
+  the strongest claim we can defend.
+- `/api/state` reads at ~1.49 Hz when averaged over a 45 s window
+  including page load. Steady state is ~1.0 Hz (the `App.tsx:185` poller
+  alone) — the extra rate is mount-time fetches from `ConnectPanel:182`
+  and `VfoDisplay:129`. Not a bug; flag for the methodology.
+
+## References
+
+- Commits: `9e3a4d4`, `2c78c30`, `0e57230`, `3287724` on
+  `fix/performance3`.
+- Server profile artefacts: `/tmp/zeus-perf3/server-profile.md` (full
+  writeup, top-N tables) and `/tmp/zeus-perf3/server-fresh.nettrace`
+  (raw `dotnet-trace` capture).
+- Per-merge sample tables: `/tmp/zeus-perf3/baseline.md`,
+  `after_raf.md`, `after_raf_pushframe.md`, `after_all_muted.top.txt`.

--- a/docs/performance_tuning.md
+++ b/docs/performance_tuning.md
@@ -284,6 +284,24 @@ shift waterfall scroll feel / panadapter trace responsiveness, both of
 which are operator-perceptible. Deferred until a maintainer-led
 session.
 
+## Sample series
+
+All averages from `top -l 31 -s 1` per PID, HL2 idle 20 m USB, layout
+"Default" with all panels open. "Frontend" = renderer + GPU helper.
+
+| Stage | Branch HEAD | Audio | Renderer | GPU | Frontend | Backend |
+|---|---|---|---|---|---|---|
+| baseline | `cd3a7d3` (post-perf2) | muted | 19.9 | 7.9 | **27.8** | **32.7** |
+| after raf-coalesce | `e49afc2` | muted | 21.1 | 8.5 | 29.7 | 25.2 |
+| after raf + pushframe | `67bf47c` | muted | 21.5 | 8.8 | 30.3 | 25.0 |
+| after server-profile (transient) | `77dd595`, fresh server | unmuted | 25.7 | 9.5 | 35.3 | 25.2 |
+| after server-profile (steady) | `77dd595` | unmuted | 26.1 | 9.6 | 35.7 | 25.8 |
+| after server-profile (re-muted) | `77dd595` | muted | 24.8 | 9.2 | **33.9** | **25.7** |
+
+Backend swing 32.7 → 25.0–25.8 across multiple post-merge samples is the
+reproducible win. Frontend deltas are all within the ±2-3 pp per-31-sample
+noise band.
+
 ## Methodology note: audio-mute confound
 
 The first perf3 sample after merging the backend fixes showed renderer
@@ -291,7 +309,25 @@ The first perf3 sample after merging the backend fixes showed renderer
 output had been left **un**muted between samples — the always-mounted
 `MicMeter` was actively re-rendering at 20 Hz instead of being idle. After
 re-muting (matching the perf2 baseline conditions), renderer dropped
-35.7 → 33.9 % (1.8 pp) — accounting for some of the gap, but not all.
+35.7 → 33.9 % (1.8 pp). That accounted for some of the gap but **not
+all**: ~3 pp of the perf3-baseline-vs-after-all gap remained unexplained
+even with audio muted.
+
+Candidates for the residual ~3 pp (not isolated yet — flagged for the
+next pass):
+
+- **Rotator.** At baseline the rotator pill read "Rotator: —" (no
+  rotator response, idle 1 Hz `/api/rotator/status` poll only). After
+  the restart the rotator was responding ("Rotator: 287°"), so each
+  poll's response triggers store + pill re-renders.
+- **Heap state warm-up.** Baseline was sampled within ~2 minutes of
+  page load (heap 33.6 MB). The post-merge sample was 5+ minutes in
+  (heap stabilised at ~40 MB). More retained store state can mean more
+  subscriber callbacks fire on each high-rate WS frame.
+- **Discovery panel teardown lingering observers.** The page reload +
+  reconnect flow mounts the discovery card, then unmounts when status
+  flips to Connected. If any observer/timer leaks from that transition
+  the cost shows up only post-reconnect, not on first-load baseline.
 
 Lesson: **fix the audio-mute state in the methodology**. Before any sample
 the bottom-bar audio button must read "▶ Unmute" (i.e. audio is muted,

--- a/docs/performance_tuning.md
+++ b/docs/performance_tuning.md
@@ -1,0 +1,160 @@
+# Performance tuning — idle-RX CPU on the frontend
+
+This is a working log of the `feature/perf2` investigation: where the CPU
+goes when Zeus is idle on RX (HL2 connected, no TX, all panels open), what
+the two committed fixes actually moved, and where the remaining cost lives
+so the next pass doesn't have to re-discover any of this.
+
+Reproduce on a Mac mini (M1 / M2-class) with Chrome via Playwright:
+- Backend `Zeus.Server` on `:6060`
+- Vite dev on `:5173`
+- HL2 on the LAN, idle on 20 m USB
+- 31-sample `top -l 31 -s 1` per-process averages
+
+## Headline result
+
+| Process | Before fixes | After fixes | Δ |
+|---|---|---|---|
+| Renderer (Zeus tab) | 30.8 % | **24.3 %** | −6.5 pp |
+| Chrome GPU helper | 12.8 % | **9.9 %** | −2.9 pp |
+| **Zeus frontend stack** | **43.6 %** | **34.2 %** | **−22 %** |
+| Zeus.Server backend | 22.3 % | 23.6 % | noise |
+| WindowServer | 32.4 % | 35.2 % | system-wide; not attributable |
+
+Idle-RX HTTP fetch rate dropped 4.97 → ~2 req/sec; mic worklet → store push
+rate dropped 50 → 20 Hz.
+
+## What we changed
+
+### 1. `perf(rest-poll)` — `56dac59`
+
+Idle RX was making ~5 fetches/sec, dominated by three pollers:
+
+| Endpoint | Before | After | Source |
+|---|---|---|---|
+| `/api/state` | 3.46 Hz | 1.0 Hz | `App.tsx:99,194` |
+| `/api/rotator/status` | 1.0 Hz | 1.0 Hz when enabled, 0 when disabled | `state/rotator-store.ts:164` |
+| `/api/tci/status` | 0.5 Hz | 0 Hz when disabled | `state/tci-store.ts:99` |
+
+- `STATE_POLL_MS` 333 → 1000 ms. The poll only exists for "slow state" —
+  ADC overload flag, atten offset, NR settings — that the SignalR hub
+  doesn't push as a delta. 1 Hz is still well inside the operator's
+  reaction window for ADC overload; 333 ms was overkill and its main effect
+  was driving `useConnectionStore.applyState` + `useTxStore.hydrateFromState`
+  into the React tree three times a second.
+- Rotator and TCI pollers now check `config.enabled` inside their
+  `setInterval` callback. Disabled features stop touching the network.
+
+### 2. `perf(mic-meter)` — `7bb3808`
+
+The mic AudioWorklet emits a per-block peak every 20 ms (50 Hz). That value
+was going straight to `useTxStore.setMicDbfs`, which re-rendered the
+bottom-bar `MicMeter` component 50 times a second — even with the workspace
+empty and no panels visible. The `MicMeter` is always mounted; it is the
+primary persistent React subscriber to TX-store.
+
+Fix: `audio/use-mic-uplink.ts` now buckets the worklet's per-block peaks
+across a 50 ms window (20 Hz visual rate) and emits the **window's max** to
+the store. Clip indication stays accurate — a transient peak inside the
+window is preserved as the emitted value. Visual feel is unchanged at 20 Hz
+(smoother than TV).
+
+This was the single biggest win in absolute terms.
+
+## What we know (and what was a red herring)
+
+### Things that turned out *not* to be the bottleneck
+
+- **Canvas rAF rate.** Initial assumption was that panadapter + waterfall
+  rAF at 60 Hz. They don't. Both are event-driven via
+  `useDisplayStore.subscribe` and gate themselves with `if (rafHandle ===
+  0) requestAnimationFrame(redraw)`. They redraw at the backend's spectrum
+  push rate (~25 Hz), not 60. Capping rAF to 30 fps would have been a
+  no-op.
+- **Per-panel cost is small individually.** Closing only the panadapter
+  produced no measurable drop; closing *all* panels dropped renderer from
+  ~29 % to ~12 %. The cost is many small things (3 canvases, several
+  meters, RGL observers) summing — not one dominant component.
+- **Discovery scanning animation.** Inspected — it's a CSS `@keyframes`
+  pulse, not a canvas. CSS animations on the GPU compositor are
+  effectively free.
+- **Server-side meter rates.** `TxMetersService` is 10 Hz during MOX,
+  **2 Hz idle**. RX_METER (S-meter) is ~5 Hz. Already low. Not a hot path.
+
+### What we measured and currently believe
+
+- **Empty workspace, HL2 connected** ≈ 12 % renderer. This is the
+  always-on cost: SignalR ingress fan-out into stores, the bottom-bar
+  meters, RGL observers, Vite HMR client, audio scheduling, CSS animations
+  on the QRZ / rotator pills.
+- **Each canvas adds ~5–7 pp** on top of the 12 % floor. With panadapter +
+  waterfall + the meter canvases together that's ~17 pp. Closing one alone
+  is below the noise floor.
+- **WindowServer is system-global.** It composites every window on the
+  desktop, not just the browser. Reading it as "Zeus's compositor cost"
+  is wrong. It tracks workload across the whole machine.
+
+## What's left, and why we stopped here
+
+The remaining ~24 % renderer with all panels open splits roughly:
+
+- ~12 pp in canvas draw work (panadapter + waterfall + meters at ~25 Hz
+  each, with their existing `texSubImage2D` / `bufferSubData` per-frame
+  uploads).
+- ~12 pp in always-on app overhead (store fan-out, mic worklet now at 20
+  Hz, RGL, audio).
+
+Concrete next-pass candidates, ordered by expected payoff vs invasiveness:
+
+1. **Coalesce panadapter + waterfall into a shared rAF scheduler.** Both
+   currently schedule their own rAF on every store update, so each
+   spectrum frame produces two rAF wakeups. Combining into one shared
+   "draw bus" would save one wakeup per frame (~25/sec). Modest win
+   (~1–2 pp), small refactor across `Panadapter.tsx` + `Waterfall.tsx`.
+2. **Audit other persistent React subscribers.** `MicMeter` was the
+   obvious one; there may be similar always-mounted components subscribed
+   to high-rate fields. Candidates to check next: PA TEMP indicator,
+   bottom-bar mic level chip, any subscribers to `useRxMetersStore`.
+3. **Skip the `pushFrame` decode when nobody's subscribed to display
+   state.** When all canvases are closed, `decodeDisplayFrame` still runs
+   on every spectrum frame and pushes into a store with zero subscribers.
+   Cheap per-call, but free if we short-circuit. Touches `realtime/
+   ws-client.ts`. Medium-invasive — needs a "subscriber count" signal.
+4. **Reduce per-frame GPU work.** `texSubImage2D` (waterfall) +
+   `bufferSubData` (panadapter trace) on every frame is the biggest
+   single chunk of remaining renderer cost. Touching this is **red-light**
+   per `CLAUDE.md` (UX/visual feel) — would need maintainer review before
+   any change. Possible angles:
+     - Decimate waterfall row uploads to every Nth frame (already
+       partially in place via `WF_PUSH_EVERY_N`; the constant could be
+       tunable).
+     - Use `requestVideoFrameCallback` semantics or compositor-driven
+       paints to skip uploads when the tile is offscreen (already done
+       via IntersectionObserver — confirm gating is firing).
+
+## Investigation method (so this is reproducible)
+
+1. Open `http://localhost:5173/` via Playwright (or just Chrome) with HL2
+   on the LAN.
+2. Inject perf instruments into the page: a `requestAnimationFrame`
+   counter (FPS), a `PerformanceObserver({entryTypes:['longtask']})`, a
+   `fetch` wrapper that bins URLs, and a `setInterval(500ms)` heap
+   sampler from `performance.memory`.
+3. In a parallel shell, run `top -l 31 -s 1 -ncols 6 -stats
+   pid,command,cpu,rsize,th,mem -pid <backend> -pid <renderer>
+   -pid <gpu> -pid 409` (`409` is WindowServer on macOS).
+4. Average per-PID `cpu` across the 31 samples. WindowServer is a
+   reference for system-wide workload — not "Zeus's cost".
+5. To isolate any single panel's cost, close all panels first, baseline,
+   then re-add one panel and re-sample.
+
+The smoking-gun fetch list and per-PID averages live under `/tmp/zeus-perf/`
+during a session.
+
+## References
+
+- Commits: `56dac59`, `7bb3808` on `feature/perf2`.
+- Server-side meter rates: `Zeus.Server.Hosting/TxMetersService.cs:94-95`
+  (`MoxTick = 100 ms`, `IdleTick = 500 ms`).
+- Canvas DPR clamp + visibility gate (prior work): `9a36afe`,
+  `1c5859a`.

--- a/installers/zeus-desktop-windows.iss
+++ b/installers/zeus-desktop-windows.iss
@@ -18,6 +18,14 @@
   #define MyAppVersion "0.0.0"
 #endif
 
+; Target architecture: pass /DArch=arm64 from CI to build the Windows-on-ARM
+; installer. Defaults to x64 so local iscc runs without explicit args still
+; produce the historical x64 installer. Inno Setup 6.3+ accepts both "x64"
+; and "arm64" as ArchitecturesAllowed identifiers.
+#ifndef Arch
+  #define Arch "x64"
+#endif
+
 [Setup]
 ; Distinct AppId from the service-mode installer (8F2E3B1C-... in
 ; zeus-windows.iss) so installing the desktop edition does NOT uninstall
@@ -35,12 +43,12 @@ DefaultGroupName={#MyAppShortName}
 DisableProgramGroupPage=yes
 LicenseFile=..\LICENSE
 OutputDir=.\output
-OutputBaseFilename=Zeus-Desktop-{#MyAppVersion}-win-x64-setup
+OutputBaseFilename=Zeus-Desktop-{#MyAppVersion}-win-{#Arch}-setup
 Compression=lzma2
 SolidCompression=yes
 WizardStyle=modern
-ArchitecturesInstallIn64BitMode=x64
-ArchitecturesAllowed=x64
+ArchitecturesInstallIn64BitMode=x64 arm64
+ArchitecturesAllowed={#Arch}
 PrivilegesRequired=lowest
 UninstallDisplayIcon={app}\{#MyAppExeName}
 
@@ -51,7 +59,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"
 
 [Files]
-Source: "..\Zeus.Desktop\bin\Release\net10.0\win-x64\publish\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "..\Zeus.Desktop\bin\Release\net10.0\win-{#Arch}\publish\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Icons]
 ; Shortcuts launch Zeus.Desktop.exe directly — Photino is the UI, no

--- a/installers/zeus-windows.iss
+++ b/installers/zeus-windows.iss
@@ -11,6 +11,14 @@
   #define MyAppVersion "0.0.0"
 #endif
 
+; Target architecture: pass /DArch=arm64 from CI to build the Windows-on-ARM
+; installer. Defaults to x64 so local iscc runs without explicit args still
+; produce the historical x64 installer. Inno Setup 6.3+ accepts both "x64"
+; and "arm64" as ArchitecturesAllowed identifiers.
+#ifndef Arch
+  #define Arch "x64"
+#endif
+
 [Setup]
 AppId={{8F2E3B1C-9A4D-4E6F-B7C3-1D5A9E8F2B4C}
 AppName={#MyAppName}
@@ -24,12 +32,12 @@ DefaultGroupName={#MyAppName}
 DisableProgramGroupPage=yes
 LicenseFile=..\LICENSE
 OutputDir=.\output
-OutputBaseFilename=Zeus-{#MyAppVersion}-win-x64-setup
+OutputBaseFilename=Zeus-{#MyAppVersion}-win-{#Arch}-setup
 Compression=lzma2
 SolidCompression=yes
 WizardStyle=modern
-ArchitecturesInstallIn64BitMode=x64
-ArchitecturesAllowed=x64
+ArchitecturesInstallIn64BitMode=x64 arm64
+ArchitecturesAllowed={#Arch}
 PrivilegesRequired=lowest
 UninstallDisplayIcon={app}\{#MyAppExeName}
 
@@ -40,7 +48,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"
 
 [Files]
-Source: "..\Zeus.Server\bin\Release\net10.0\win-x64\publish\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "..\Zeus.Server\bin\Release\net10.0\win-{#Arch}\publish\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "zeus-windows-launcher.cmd"; DestDir: "{app}"; DestName: "zeus.cmd"; Flags: ignoreversion
 
 [Icons]

--- a/native/wdsp/channel.c
+++ b/native/wdsp/channel.c
@@ -98,7 +98,15 @@ void OpenChannel (int channel, int in_size, int dsp_size, int input_samplerate, 
     InterlockedBitTestAndSet (&ch[channel].exchange, 0);
   }
 
-#if !defined(linux) && !defined(__APPLE__)
+#if !defined(linux) && !defined(__APPLE__) && !defined(_M_ARM64) && !defined(__aarch64__)
+  // _MM_SET_FLUSH_ZERO_MODE is an x86 SSE-only perf hint (denormals→zero in
+  // the MXCSR). It does not exist on ARM64 toolchains (MSVC clang-cl, gcc,
+  // clang) and the header <xmmintrin.h> isn't available there either, so the
+  // call is gated out for Windows-on-ARM and aarch64 in addition to the
+  // pre-existing linux/Apple gates. ARM64 cores have an analogous flush-to-
+  // zero bit in FPCR (FZ); WDSP / HL2 do not depend on FTZ for correctness
+  // and we deliberately leave FPCR at the OS default rather than introducing
+  // an architecture-specific intrinsic here.
   _MM_SET_FLUSH_ZERO_MODE (_MM_FLUSH_ZERO_ON);
 #endif
 }

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -62,7 +62,7 @@ import { PsToggleButton } from './components/PsToggleButton';
 import { PaTempChip } from './components/PaTempChip';
 import { QrzStatusPill } from './components/QrzStatusPill';
 import { RotatorStatusPill } from './components/RotatorStatusPill';
-import { SettingsMenu } from './components/SettingsMenu';
+import { SettingsView, type SettingsTabId } from './components/SettingsMenu';
 import { StepFavorites } from './components/toolbar/StepFavorites';
 import { TunButton } from './components/TunButton';
 import { BOARD_LABELS } from './api/radio';
@@ -100,8 +100,9 @@ const STATE_POLL_MS = 333;
 
 export default function App() {
   useSwUpdatePrompt();
-  const [settingsOpen, setSettingsOpen] = useState(false);
-  const [settingsInitialTab, setSettingsInitialTab] = useState<'pa' | 'qrz' | 'rotator' | 'server' | 'about' | undefined>();
+  const settingsViewOpen = useLayoutStore((s) => s.settingsViewOpen);
+  const settingsInitialTab = useLayoutStore((s) => s.settingsInitialTab);
+  const setSettingsView = useLayoutStore((s) => s.setSettingsView);
   const [updateAvailable, setUpdateAvailable] = useState(false);
   const [installUpdate, setInstallUpdate] = useState<(() => Promise<void>) | null>(null);
   const status = useConnectionStore((s) => s.status);
@@ -223,7 +224,7 @@ export default function App() {
   }, []);
 
   // Handle deeplink via URL hash (#qrz, #rotator, #pa, #server, #about).
-  // Opens settings menu and navigates to the specified tab.
+  // Opens the settings view and navigates to the specified tab.
   useEffect(() => {
     const handleHash = () => {
       const hash = window.location.hash.slice(1); // Remove '#'
@@ -234,8 +235,7 @@ export default function App() {
         hash === 'server' ||
         hash === 'about'
       ) {
-        setSettingsInitialTab(hash);
-        setSettingsOpen(true);
+        setSettingsView(true, hash as SettingsTabId);
         // Clear the hash after handling it
         window.history.replaceState(null, '', window.location.pathname + window.location.search);
       }
@@ -247,7 +247,7 @@ export default function App() {
     // Listen for hash changes
     window.addEventListener('hashchange', handleHash);
     return () => window.removeEventListener('hashchange', handleHash);
-  }, []);
+  }, [setSettingsView]);
 
   // First-run UX for native shells (Capacitor): if there is no server URL
   // configured, the app would spin trying to reach the WebView's own host.
@@ -256,9 +256,8 @@ export default function App() {
   useEffect(() => {
     if (!isCapacitorRuntime()) return;
     if (getServerBaseUrl()) return;
-    setSettingsInitialTab('server');
-    setSettingsOpen(true);
-  }, []);
+    setSettingsView(true, 'server');
+  }, [setSettingsView]);
 
   // --- Design-mock state (QRZ, DSP grid toggles, CW WPM, memories) ---
   const [callsign, setCallsign] = useState('');
@@ -697,29 +696,29 @@ export default function App() {
 
         <div className="spacer" style={{ flex: 1 }} />
 
-        {/* Settings comes first, then Disconnect. Rotator / QRZ pills and the
-            radio IP moved to the BottomStatusBar — no need to duplicate them
-            up here. While disconnected the centre overlay owns Discover so
-            we mount only one ConnectPanel at a time. */}
-        <button
-          type="button"
-          className="btn"
-          onClick={() => setSettingsOpen(true)}
-          title="Open settings menu"
-        >
-          ⚙
-        </button>
+        {/* Settings is reached from the LeftLayoutBar (bottom slot). The
+            top bar is now reserved for Disconnect when connected; while
+            disconnected the centre overlay owns Discover so we mount only
+            one ConnectPanel at a time. */}
         {connected && <ConnectPanel compact />}
       </header>
 
       <AlertBanner />
 
-      {/* Active layout's workspace. Keying on activeLayoutId forces a full
-          unmount + remount when the operator switches layouts so WebGL
-          canvases / RAF loops / hub subscriptions in the prior layout
-          release rather than lingering hidden (issue #241 requires that
-          inactive layouts not consume DOM resources). */}
-      <FlexWorkspace key={activeLayoutId} />
+      {/* Active layout's workspace, or the inline Settings view if the
+          operator picked the Settings slot in the LeftLayoutBar. Keying on
+          activeLayoutId forces a full unmount + remount when the operator
+          switches layouts so WebGL canvases / RAF loops / hub subscriptions
+          in the prior layout release rather than lingering hidden (issue
+          #241 requires that inactive layouts not consume DOM resources). */}
+      {settingsViewOpen ? (
+        <SettingsView
+          initialTab={settingsInitialTab as SettingsTabId | undefined}
+          onClose={() => setSettingsView(false)}
+        />
+      ) : (
+        <FlexWorkspace key={activeLayoutId} />
+      )}
 
       {/* Transport — MOX/TUN + audio + mic + macro buttons on the left,
           PA/PRE chips, then the per-radio status (radio IP, rotator, QRZ)
@@ -749,18 +748,38 @@ export default function App() {
         </span>
         <RotatorStatusPill />
         <QrzStatusPill />
+        {/* Add Panel + Reset live together at the bottom-right: both act on
+            the active layout's tile arrangement, so keeping them adjacent
+            makes the relationship obvious. Disabled while the Settings
+            view is showing (no active workspace to mutate). */}
         <button
           type="button"
-          className="btn sm"
+          className="btn"
           onClick={() => useLayoutStore.getState().setAddPanelOpen(true)}
+          disabled={settingsViewOpen}
           title="Add a panel to the active layout"
         >
           + Add Panel
         </button>
+        <button
+          type="button"
+          className="btn ghost"
+          onClick={() => {
+            const s = useLayoutStore.getState();
+            const active = s.layouts.find((l) => l.id === s.activeLayoutId);
+            if (!active) return;
+            if (!window.confirm(`Reset “${active.name}” to the default panel arrangement?`)) return;
+            s.resetActiveLayout();
+          }}
+          disabled={settingsViewOpen}
+          title="Reset active layout to default"
+          aria-label="Reset active layout to default"
+        >
+          ⟳ Default
+        </button>
       </div>
 
       {disconnectedOverlay}
-      <SettingsMenu open={settingsOpen} onClose={() => setSettingsOpen(false)} initialTab={settingsInitialTab} />
       <UpdatePrompt show={updateAvailable} onUpdate={installUpdate} />
     </div>
     </SpectrumWheelActionsContext.Provider>

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -95,8 +95,10 @@ import type { QrzStation } from './api/qrz';
 import type { Contact } from './components/design/data';
 
 // See ../state/connection-store.ts — StateDto is REST-poll only; WS is binary
-// frames. 333 ms poll keeps slow state (atten offset, adc overload) fresh.
-const STATE_POLL_MS = 333;
+// frames. 1 s poll keeps slow state (atten offset, adc overload) fresh — the
+// previous 333 ms cadence accounted for ~3 of the ~5 idle-RX fetches/sec and
+// drove repeated applyState/hydrateFromState fan-out into the React tree.
+const STATE_POLL_MS = 1000;
 
 export default function App() {
   useSwUpdatePrompt();

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -705,22 +705,22 @@ export default function App() {
         {connected && <ConnectPanel compact />}
       </header>
 
-      <AlertBanner />
-
-      {/* Active layout's workspace, or the inline Settings view if the
-          operator picked the Settings slot in the LeftLayoutBar. Keying on
-          activeLayoutId forces a full unmount + remount when the operator
-          switches layouts so WebGL canvases / RAF loops / hub subscriptions
-          in the prior layout release rather than lingering hidden (issue
-          #241 requires that inactive layouts not consume DOM resources). */}
-      {settingsViewOpen ? (
-        <SettingsView
-          initialTab={settingsInitialTab as SettingsTabId | undefined}
-          onClose={() => setSettingsView(false)}
-        />
-      ) : (
-        <FlexWorkspace key={activeLayoutId} />
-      )}
+      {/* Workspace area — alert banner + active layout (or settings view).
+          Wrapped together so the grid only needs one row for both, which
+          keeps the gap between the topbar and the first panel a single
+          6px unit instead of stacking two grid gaps around an empty
+          alert row. */}
+      <div className="workspace-area">
+        <AlertBanner />
+        {settingsViewOpen ? (
+          <SettingsView
+            initialTab={settingsInitialTab as SettingsTabId | undefined}
+            onClose={() => setSettingsView(false)}
+          />
+        ) : (
+          <FlexWorkspace key={activeLayoutId} />
+        )}
+      </div>
 
       {/* Transport — MOX/TUN + audio + mic + macro buttons on the left,
           PA/PRE chips, then the per-radio status (radio IP, rotator, QRZ)

--- a/zeus-web/src/audio/mic-uplink.ts
+++ b/zeus-web/src/audio/mic-uplink.ts
@@ -81,7 +81,7 @@ export async function startMicUplink(
     throw new Error('getUserMedia not available in this environment');
   }
   const stream = await navigator.mediaDevices.getUserMedia(MIC_CONSTRAINTS);
-  const context = new AudioContext({ sampleRate: 48000, latencyHint: 'interactive' });
+  const context = new AudioContext({ sampleRate: 48000, latencyHint: 0.04 });
 
   const cleanupStream = () => {
     for (const t of stream.getTracks()) {

--- a/zeus-web/src/audio/use-mic-uplink.ts
+++ b/zeus-web/src/audio/use-mic-uplink.ts
@@ -52,6 +52,14 @@ import { warnOnce } from '../util/logger';
 // render -∞ and so the bar snaps to fully-empty on a quiet mic.
 const MIC_DBFS_FLOOR = -100;
 
+// Visual update cadence for MicMeter. The mic worklet emits a peak per
+// 20 ms block (50 Hz); driving Zustand at that rate triggers ~50 React
+// reconciliations a second of the bottom-bar meter, which is invisible to
+// the operator but a real CPU drain. We bucket the worklet's per-block
+// peaks across a ~50 ms window (20 Hz visual rate, smoother than TV) and
+// emit the *maximum* of each window so clip indication stays accurate.
+const MIC_VISUAL_INTERVAL_MS = 50;
+
 /**
  * Opens the mic AudioWorklet on mount and keeps it running while the app
  * is live. Peak dBFS of every 20 ms block is pushed to tx-store so the
@@ -68,13 +76,23 @@ export function useMicUplink(): void {
   useEffect(() => {
     let handle: MicUplinkHandle | null = null;
     let disposed = false;
+    let windowPeak = 0;
+    let lastEmit = 0;
 
     startMicUplink((samples, peak) => {
-      // Level: always pushed so MicMeter animates on RX.
-      const dbfs = peak > 0
-        ? Math.max(MIC_DBFS_FLOOR, 20 * Math.log10(peak))
-        : MIC_DBFS_FLOOR;
-      useTxStore.getState().setMicDbfs(dbfs);
+      // Level: always pushed so MicMeter animates on RX. Bucket the
+      // per-block peaks across MIC_VISUAL_INTERVAL_MS and emit the max so
+      // a transient clip is never lost between visual ticks.
+      if (peak > windowPeak) windowPeak = peak;
+      const now = performance.now();
+      if (now - lastEmit >= MIC_VISUAL_INTERVAL_MS) {
+        const dbfs = windowPeak > 0
+          ? Math.max(MIC_DBFS_FLOOR, 20 * Math.log10(windowPeak))
+          : MIC_DBFS_FLOOR;
+        useTxStore.getState().setMicDbfs(dbfs);
+        lastEmit = now;
+        windowPeak = 0;
+      }
 
       // Samples: only forwarded to the server while keyed. Capturing always +
       // gating here avoids a ~300 ms getUserMedia cold-start on every MOX.

--- a/zeus-web/src/components/CfcSettingsPanel.css
+++ b/zeus-web/src/components/CfcSettingsPanel.css
@@ -37,7 +37,7 @@
   font-weight: 600;
   padding: 3px 7px;
   border: 1px solid color-mix(in oklab, var(--accent) 50%, var(--panel-border));
-  border-radius: 3px;
+  border-radius: 0;
   background: color-mix(in oklab, var(--accent) 8%, transparent);
   white-space: nowrap;
 }
@@ -80,7 +80,7 @@
   background: var(--bg-0);
   border: 1px solid var(--panel-border);
   color: var(--fg-1);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 3px 6px;
   font-family: var(--font-mono);
   font-size: 11px;
@@ -107,7 +107,7 @@
 .cfc-power .sw {
   width: 42px;
   height: 22px;
-  border-radius: 11px;
+  border-radius: 0;
   background: var(--bg-3);
   border: 1px solid var(--panel-border);
   position: relative;
@@ -163,7 +163,7 @@
 .cfc-check .box {
   width: 14px;
   height: 14px;
-  border-radius: 3px;
+  border-radius: 0;
   background: var(--bg-0);
   border: 1px solid var(--panel-border);
   display: inline-block;
@@ -203,7 +203,7 @@
   color: var(--fg-2);
   background: var(--bg-0);
   border: 1px solid var(--panel-border);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 4px 10px;
   cursor: pointer;
 }

--- a/zeus-web/src/components/ConnectPanel.tsx
+++ b/zeus-web/src/components/ConnectPanel.tsx
@@ -557,7 +557,7 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
                   padding: '6px 10px',
                   background: 'rgba(230,58,43,0.12)',
                   border: '1px solid rgba(230,58,43,0.35)',
-                  borderRadius: 4,
+                  borderRadius: 0,
                   color: 'var(--tx)',
                   fontSize: 11,
                 }}
@@ -594,7 +594,7 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
                         padding: '6px 10px',
                         background: 'var(--bg-2)',
                         border: '1px solid var(--panel-border)',
-                        borderRadius: 4,
+                        borderRadius: 0,
                       }}
                     >
                       <div style={{ display: 'flex', flexDirection: 'column', minWidth: 0 }}>
@@ -934,7 +934,7 @@ function ManualMode(p: ManualModeProps) {
             padding: '6px 10px',
             background: 'rgba(230,58,43,0.12)',
             border: '1px solid rgba(230,58,43,0.35)',
-            borderRadius: 4,
+            borderRadius: 0,
             color: 'var(--tx)',
             fontSize: 11,
           }}
@@ -966,7 +966,7 @@ function ManualMode(p: ManualModeProps) {
               padding: '10px 12px',
               background: 'var(--bg-2)',
               border: '1px dashed var(--panel-border)',
-              borderRadius: 4,
+              borderRadius: 0,
               textAlign: 'center',
             }}
           >
@@ -987,7 +987,7 @@ function ManualMode(p: ManualModeProps) {
                     padding: '6px 10px',
                     background: 'var(--bg-2)',
                     border: '1px solid var(--panel-border)',
-                    borderRadius: 4,
+                    borderRadius: 0,
                   }}
                 >
                   <div style={{ display: 'flex', flexDirection: 'column', minWidth: 0 }}>

--- a/zeus-web/src/components/LeftLayoutBar.tsx
+++ b/zeus-web/src/components/LeftLayoutBar.tsx
@@ -6,9 +6,21 @@
 // LeftLayoutBar — vertical bar listing the current radio's named layouts.
 // Each item shows a large emoji icon with a small label beneath. Clicking
 // switches to that layout; the gear opens LayoutSettingsModal to edit the
-// label, icon, and tooltip description. The "+" button opens the same modal
-// in create mode; "✕" deletes the active layout; "⟳" resets it to the
-// default tile arrangement.
+// label, icon, and tooltip description.
+//
+// Layout-list anatomy (top → bottom):
+//   • One tab per saved NamedLayout (icon + label, optional gear/✕).
+//   • A trailing dashed "+" placeholder tab — always present — that opens
+//     LayoutSettingsModal in create mode. The "+" is a slot, not a button:
+//     adding a layout slides it down so the next "+" sits below the new
+//     layout. This replaces the earlier separate "+" / "⟳" actions row.
+//   • A horizontal divider, then the bottom-pinned Settings slot. Clicking
+//     it flips layout-store.settingsViewOpen so App swaps the workspace
+//     for SettingsView. Picking any layout tab clears that flag.
+//
+// The "Reset to default" affordance lives on the bottom transport bar
+// alongside "+ Add Panel" — both act on the active layout's tile
+// arrangement, so they read naturally as a pair there.
 //
 // Issue #241: visual chrome reuses tokens.css; no new colors are introduced.
 
@@ -32,8 +44,9 @@ export function LeftLayoutBar() {
   const addLayout = useLayoutStore((s) => s.addLayout);
   const removeLayout = useLayoutStore((s) => s.removeLayout);
   const updateLayoutMeta = useLayoutStore((s) => s.updateLayoutMeta);
-  const resetActiveLayout = useLayoutStore((s) => s.resetActiveLayout);
   const isLoaded = useLayoutStore((s) => s.isLoaded);
+  const settingsViewOpen = useLayoutStore((s) => s.settingsViewOpen);
+  const setSettingsView = useLayoutStore((s) => s.setSettingsView);
   // The bar's blue gradient + dot wash follows the operator's panadapter
   // trace colour from the Display tab. CLAUDE.md flags trace amber as
   // "panadapter-only", but the maintainer explicitly asked for the chrome
@@ -70,13 +83,6 @@ export function LeftLayoutBar() {
     removeLayout(id);
   };
 
-  const handleReset = () => {
-    const active = layouts.find((l) => l.id === activeLayoutId);
-    if (!active) return;
-    if (!window.confirm(`Reset “${active.name}” to the default panel arrangement?`)) return;
-    resetActiveLayout();
-  };
-
   const openEdit = (id: string) => setModal({ kind: 'edit', id });
 
   const handleModalSave = (value: LayoutSettingsValue) => {
@@ -104,74 +110,89 @@ export function LeftLayoutBar() {
         {!isLoaded ? (
           <div className="lb-empty" aria-hidden>…</div>
         ) : (
-          layouts.map((l) => {
-            const active = l.id === activeLayoutId;
-            const tooltip = l.description?.trim()
-              ? `${l.name} — ${l.description}`
-              : `${l.name} (gear to edit)`;
-            return (
-              <div key={l.id} className={`lb-item ${active ? 'active' : ''}`}>
-                <button
-                  type="button"
-                  className="lb-tab"
-                  role="tab"
-                  aria-selected={active}
-                  onClick={() => setActiveLayout(l.id)}
-                  title={tooltip}
-                >
-                  <span
-                    className={`lb-tab-icon ${l.icon ? '' : 'lb-tab-icon-fallback'}`}
-                    aria-hidden
-                  >
-                    {l.icon || initialLetter(l.name)}
-                  </span>
-                  <span className="lb-tab-name">{l.name}</span>
-                </button>
-                <button
-                  type="button"
-                  className="lb-gear"
-                  onClick={() => openEdit(l.id)}
-                  title={`Edit ${l.name}`}
-                  aria-label={`Edit ${l.name}`}
-                >
-                  ⚙
-                </button>
-                {active && layouts.length > 1 && (
+          <>
+            {layouts.map((l) => {
+              // While the Settings view is showing no layout tab is active —
+              // it's a sibling view, not a layout. The flag is cleared the
+              // moment the operator clicks any layout tab (setActiveLayout).
+              const active = !settingsViewOpen && l.id === activeLayoutId;
+              const tooltip = l.description?.trim()
+                ? `${l.name} — ${l.description}`
+                : `${l.name} (gear to edit)`;
+              return (
+                <div key={l.id} className={`lb-item ${active ? 'active' : ''}`}>
                   <button
                     type="button"
-                    className="lb-x"
-                    onClick={() => handleDelete(l.id, l.name)}
-                    title={`Delete ${l.name}`}
-                    aria-label={`Delete ${l.name}`}
+                    className="lb-tab"
+                    role="tab"
+                    aria-selected={active}
+                    onClick={() => setActiveLayout(l.id)}
+                    title={tooltip}
                   >
-                    ✕
+                    <span
+                      className={`lb-tab-icon ${l.icon ? '' : 'lb-tab-icon-fallback'}`}
+                      aria-hidden
+                    >
+                      {l.icon || initialLetter(l.name)}
+                    </span>
+                    <span className="lb-tab-name">{l.name}</span>
                   </button>
-                )}
-              </div>
-            );
-          })
+                  <button
+                    type="button"
+                    className="lb-gear"
+                    onClick={() => openEdit(l.id)}
+                    title={`Edit ${l.name}`}
+                    aria-label={`Edit ${l.name}`}
+                  >
+                    ⚙
+                  </button>
+                  {active && layouts.length > 1 && (
+                    <button
+                      type="button"
+                      className="lb-x"
+                      onClick={() => handleDelete(l.id, l.name)}
+                      title={`Delete ${l.name}`}
+                      aria-label={`Delete ${l.name}`}
+                    >
+                      ✕
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+            {/* Trailing placeholder slot — always at the end of the list.
+                Adding a layout pushes this slot down one row, so the "+"
+                stays the bottom-most tab. */}
+            <div className="lb-item lb-item-add">
+              <button
+                type="button"
+                className="lb-tab lb-tab-add"
+                onClick={handleAdd}
+                title="Add a new layout"
+                aria-label="Add a new layout"
+              >
+                <span className="lb-tab-icon lb-tab-icon-fallback" aria-hidden>
+                  +
+                </span>
+                <span className="lb-tab-name">Add</span>
+              </button>
+            </div>
+          </>
         )}
       </div>
 
-      <div className="lb-actions">
+      <div className="lb-divider" aria-hidden />
+
+      <div className="lb-settings-slot">
         <button
           type="button"
-          className="btn sm lb-action"
-          onClick={handleAdd}
-          title="Add a new layout"
-          aria-label="Add a new layout"
+          className={`lb-tab lb-tab-settings ${settingsViewOpen ? 'active' : ''}`}
+          onClick={() => setSettingsView(!settingsViewOpen)}
+          title="Open settings"
+          aria-pressed={settingsViewOpen}
         >
-          +
-        </button>
-        <button
-          type="button"
-          className="btn ghost sm lb-action"
-          onClick={handleReset}
-          title="Reset active layout to default"
-          aria-label="Reset active layout to default"
-          disabled={!isLoaded || layouts.length === 0}
-        >
-          ⟳
+          <span className="lb-tab-icon" aria-hidden>⚙</span>
+          <span className="lb-tab-name">Settings</span>
         </button>
       </div>
 

--- a/zeus-web/src/components/Panadapter.tsx
+++ b/zeus-web/src/components/Panadapter.tsx
@@ -45,7 +45,7 @@
 import { useEffect, useRef } from 'react';
 import { createPanRenderer, hexToRgbFloats } from '../gl/panadapter';
 import { planWaterfallUpdate } from '../gl/wf-shift';
-import { useDisplayStore } from '../state/display-store';
+import { registerFrameConsumer, useDisplayStore } from '../state/display-store';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
 import { useTxStore } from '../state/tx-store';
 import { usePanTuneGesture } from '../util/use-pan-tune-gesture';
@@ -67,6 +67,11 @@ export function Panadapter() {
       console.error('WebGL2 not available');
       return;
     }
+
+    // Tell the realtime client that decoded spectrum frames are needed —
+    // ws-client.ts skips decodeDisplayFrame entirely when no consumer is
+    // registered (all spectrum surfaces closed).
+    const releaseFrameConsumer = registerFrameConsumer();
 
     const renderer = createPanRenderer(gl);
     // Mirror the waterfall's shift state so pan and wf agree on what a VFO
@@ -236,6 +241,7 @@ export function Panadapter() {
       document.removeEventListener('visibilitychange', onVisibilityChange);
       if (rafHandle !== 0) cancelAnimationFrame(rafHandle);
       renderer.dispose();
+      releaseFrameConsumer();
     };
   }, []);
 

--- a/zeus-web/src/components/Panadapter.tsx
+++ b/zeus-web/src/components/Panadapter.tsx
@@ -198,16 +198,33 @@ export function Panadapter() {
       requestRedraw();
     });
 
-    // Repaint on auto-range updates so palette changes apply without waiting
-    // for the next server frame.
-    const unsubSettings = useDisplaySettingsStore.subscribe(() => {
-      requestRedraw();
+    // Repaint on dB-range / trace-color updates so auto-range and the Display
+    // settings panel apply without waiting for the next server frame. The
+    // prev-state diff is the load-bearing part: a no-selector subscribe used
+    // to fire on every store mutation, which during ordinary RX traffic
+    // pulled the panadapter rAF floor above the spectrum-tick rate.
+    const unsubSettings = useDisplaySettingsStore.subscribe((state, prev) => {
+      if (
+        state.dbMin !== prev.dbMin ||
+        state.dbMax !== prev.dbMax ||
+        state.txDbMin !== prev.txDbMin ||
+        state.txDbMax !== prev.txDbMax ||
+        state.rxTraceColor !== prev.rxTraceColor
+      ) {
+        requestRedraw();
+      }
     });
 
     // Repaint when MOX / TUN flips so the RX-vs-TX dB range swap is
     // reflected immediately, even if no fresh pan frame arrived yet.
-    const unsubTx = useTxStore.subscribe(() => {
-      requestRedraw();
+    // App.tsx:211 uses the same prev-state diff pattern — without it the
+    // unconditional subscriber fires on every tx-store update (mic dBFS at
+    // 50 Hz from the worklet, RxDbm at 5 Hz, PaTempC at 2 Hz, etc.), which
+    // raises the floor on the redraw rate above the spectrum-tick rate.
+    const unsubTx = useTxStore.subscribe((state, prev) => {
+      if (state.moxOn !== prev.moxOn || state.tunOn !== prev.tunOn) {
+        requestRedraw();
+      }
     });
 
     return () => {

--- a/zeus-web/src/components/Panadapter.tsx
+++ b/zeus-web/src/components/Panadapter.tsx
@@ -45,6 +45,7 @@
 import { useEffect, useRef } from 'react';
 import { createPanRenderer, hexToRgbFloats } from '../gl/panadapter';
 import { planWaterfallUpdate } from '../gl/wf-shift';
+import { cancelDrawBusFrame, requestDrawBusFrame } from '../realtime/draw-bus';
 import { useDisplayStore } from '../state/display-store';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
 import { useTxStore } from '../state/tx-store';
@@ -80,7 +81,6 @@ export function Panadapter() {
     let lastWidth = 0;
     let drawPan: Float32Array | null = null;
     let drawOffsetPx = 0;
-    let rafHandle = 0;
     // Visibility gating: don't burn rAF cycles when the tile is scrolled
     // off-screen, the tab is hidden, or the operator switched to a layout
     // where the panadapter isn't mounted-but-visible. Both signals are
@@ -90,7 +90,6 @@ export function Panadapter() {
     const isActive = () => inViewport && pageVisible;
 
     const redraw = () => {
-      rafHandle = 0;
       if (!drawPan) return;
       const s = useDisplaySettingsStore.getState();
       // While keyed (MOX or TUN — server already feeds TX pixels via
@@ -107,7 +106,10 @@ export function Panadapter() {
     };
     const requestRedraw = () => {
       if (!isActive()) return;
-      if (rafHandle === 0) rafHandle = requestAnimationFrame(redraw);
+      // Shared draw bus: panadapter + waterfall coalesce onto a single rAF
+      // per frame. The bus dedupes repeated requests for the same callback,
+      // matching the prior `if (rafHandle === 0)` gate.
+      requestDrawBusFrame(redraw);
     };
 
     const resize = () => {
@@ -234,7 +236,7 @@ export function Panadapter() {
       ro.disconnect();
       io.disconnect();
       document.removeEventListener('visibilitychange', onVisibilityChange);
-      if (rafHandle !== 0) cancelAnimationFrame(rafHandle);
+      cancelDrawBusFrame(redraw);
       renderer.dispose();
     };
   }, []);

--- a/zeus-web/src/components/Panadapter.tsx
+++ b/zeus-web/src/components/Panadapter.tsx
@@ -81,6 +81,13 @@ export function Panadapter() {
     let drawPan: Float32Array | null = null;
     let drawOffsetPx = 0;
     let rafHandle = 0;
+    // Visibility gating: don't burn rAF cycles when the tile is scrolled
+    // off-screen, the tab is hidden, or the operator switched to a layout
+    // where the panadapter isn't mounted-but-visible. Both signals are
+    // ORed into a single `isActive` flag the requestRedraw guard checks.
+    let inViewport = true;
+    let pageVisible = !document.hidden;
+    const isActive = () => inViewport && pageVisible;
 
     const redraw = () => {
       rafHandle = 0;
@@ -99,12 +106,19 @@ export function Panadapter() {
       renderer.draw(drawPan, dbMin, dbMax, drawOffsetPx);
     };
     const requestRedraw = () => {
+      if (!isActive()) return;
       if (rafHandle === 0) rafHandle = requestAnimationFrame(redraw);
     };
 
     const resize = () => {
       const { width, height } = container.getBoundingClientRect();
-      const dpr = window.devicePixelRatio || 1;
+      // Clamp the WebGL backing store at DPR=1. On a Retina display the
+      // native devicePixelRatio is 2 (or higher on 5K), which means the
+      // panadapter would render at 4× the pixels and feed 4× the texture
+      // data through every composite. The trace is a single-pixel-wide line
+      // over a smooth dB gradient — sub-pixel antialiasing is not visible
+      // and not worth the GPU cost. Browser CSS scaling fills the difference.
+      const dpr = Math.min(1, window.devicePixelRatio || 1);
       const w = Math.max(1, Math.round(width * dpr));
       const h = Math.max(1, Math.round(height * dpr));
       canvas.width = w;
@@ -116,6 +130,28 @@ export function Panadapter() {
     const ro = new ResizeObserver(resize);
     ro.observe(container);
     resize();
+
+    // Pause WebGL when the panadapter is not actually visible. Two signals:
+    // IntersectionObserver covers "tile scrolled out of view / display:none
+    // ancestor", and document.visibilitychange covers "tab in background".
+    // When we transition back to active, kick a redraw so the operator
+    // sees the latest pushed frame immediately rather than waiting for the
+    // next store update.
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) {
+          inViewport = e.isIntersecting;
+        }
+        if (isActive()) requestRedraw();
+      },
+      { threshold: 0 },
+    );
+    io.observe(container);
+    const onVisibilityChange = () => {
+      pageVisible = !document.hidden;
+      if (isActive()) requestRedraw();
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
 
     let lastSeqDrawn = -1;
     const unsub = useDisplayStore.subscribe((state) => {
@@ -179,6 +215,8 @@ export function Panadapter() {
       unsubSettings();
       unsubTx();
       ro.disconnect();
+      io.disconnect();
+      document.removeEventListener('visibilitychange', onVisibilityChange);
       if (rafHandle !== 0) cancelAnimationFrame(rafHandle);
       renderer.dispose();
     };

--- a/zeus-web/src/components/RadioSelector.tsx
+++ b/zeus-web/src/components/RadioSelector.tsx
@@ -162,7 +162,7 @@ export function RadioSelector() {
             color: 'var(--tx)',
             background: 'var(--tx-soft)',
             padding: '2px 6px',
-            borderRadius: 2,
+            borderRadius: 0,
           }}
           title="Discovery disagrees with your selection. Discovery always wins for drive-byte math and PA defaults while connected — flip Override Detection on if you really want the selected board to win."
         >
@@ -258,7 +258,7 @@ export function RadioSelector() {
             color: 'var(--tx)',
             background: 'var(--tx-soft)',
             padding: '2px 6px',
-            borderRadius: 2,
+            borderRadius: 0,
           }}
           title="Override is active. Zeus uses the selected board for drive-byte math, ATT, filters, and PA defaults — discovery is ignored."
         >

--- a/zeus-web/src/components/SettingsMenu.test.tsx
+++ b/zeus-web/src/components/SettingsMenu.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 //
-// SettingsMenu — verify the TX Audio Tools tab is always present and that
+// SettingsView — verify the TX Audio Tools tab is always present and that
 // the VST host submenu inside it is gated by /api/capabilities. CFC is
 // WDSP-driven and must remain visible regardless of the sidecar.
 
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
-import { SettingsMenu } from './SettingsMenu';
+import { SettingsView } from './SettingsMenu';
 import { useCapabilitiesStore } from '../state/capabilities-store';
 
 function seed(vstAvailable: boolean) {
@@ -33,7 +33,7 @@ function seed(vstAvailable: boolean) {
   });
 }
 
-describe('SettingsMenu — TX Audio Tools', () => {
+describe('SettingsView — TX Audio Tools', () => {
   let container: HTMLDivElement;
   let root: Root;
 
@@ -54,7 +54,7 @@ describe('SettingsMenu — TX Audio Tools', () => {
   it('always renders the TX AUDIO TOOLS tab', () => {
     seed(false);
     act(() => {
-      root.render(<SettingsMenu open={true} onClose={() => {}} />);
+      root.render(<SettingsView onClose={() => {}} />);
     });
     const tabs = Array.from(
       container.querySelectorAll('[role="tablist"] button'),
@@ -65,9 +65,7 @@ describe('SettingsMenu — TX Audio Tools', () => {
   it('shows CFC and the VST host submenu when vstHost.available is true', () => {
     seed(true);
     act(() => {
-      root.render(
-        <SettingsMenu open={true} onClose={() => {}} initialTab="tx-audio" />,
-      );
+      root.render(<SettingsView onClose={() => {}} initialTab="tx-audio" />);
     });
     expect(container.textContent).toContain('Continuous Frequency Compressor');
     expect(container.textContent).toContain('VST Host');
@@ -76,9 +74,7 @@ describe('SettingsMenu — TX Audio Tools', () => {
   it('shows CFC but hides the VST host submenu when vstHost.available is false', () => {
     seed(false);
     act(() => {
-      root.render(
-        <SettingsMenu open={true} onClose={() => {}} initialTab="tx-audio" />,
-      );
+      root.render(<SettingsView onClose={() => {}} initialTab="tx-audio" />);
     });
     expect(container.textContent).toContain('Continuous Frequency Compressor');
     expect(container.textContent).not.toContain('VST Host');

--- a/zeus-web/src/components/SettingsMenu.tsx
+++ b/zeus-web/src/components/SettingsMenu.tsx
@@ -19,7 +19,7 @@
 // (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
 // Both are GPL-2.0-or-later.
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { PaSettingsPanel } from './PaSettingsPanel';
 import { BandPlanEditor } from './bandplan/BandPlanEditor';
 import { AboutPanel } from './AboutPanel';
@@ -33,7 +33,7 @@ import { usePaStore } from '../state/pa-store';
 import { PsSettingsPanel } from './PsSettingsPanel';
 import { TxAudioToolsPanel } from './TxAudioToolsPanel';
 
-type TabId =
+export type SettingsTabId =
   | 'pa'
   | 'ps'
   | 'tx-audio'
@@ -45,7 +45,7 @@ type TabId =
   | 'server'
   | 'about';
 
-const TABS: ReadonlyArray<{ id: TabId; label: string }> = [
+const TABS: ReadonlyArray<{ id: SettingsTabId; label: string }> = [
   { id: 'pa', label: 'PA SETTINGS' },
   { id: 'ps', label: 'PURESIGNAL' },
   { id: 'tx-audio', label: 'TX AUDIO TOOLS' },
@@ -59,20 +59,31 @@ const TABS: ReadonlyArray<{ id: TabId; label: string }> = [
 ];
 
 type Props = {
-  open: boolean;
+  initialTab?: SettingsTabId;
   onClose: () => void;
-  initialTab?: TabId;
 };
 
-// Floating, draggable settings panel. Deliberately has NO backdrop: the operator
-// must be able to MOX / TUN / tune the radio while the panel is open. The only
-// event-capture surface is the panel rectangle itself; everything outside
-// (panadapter, top-bar buttons) stays clickable.
-export function SettingsMenu({ open, onClose, initialTab }: Props) {
-  const [active, setActive] = useState<TabId>(initialTab ?? 'pa');
+// SettingsView — settings is a workspace-replacing view, not a popover. The
+// parent (App) renders it in the same grid cell as FlexWorkspace whenever
+// layout-store.settingsViewOpen is true. Clicking any layout tab in the
+// LeftLayoutBar returns to the workspace (setActiveLayout clears the flag).
+export function SettingsView({ initialTab, onClose }: Props) {
+  const [active, setActive] = useState<SettingsTabId>(initialTab ?? 'pa');
   const savePa = usePaStore((s) => s.save);
   const loadPa = usePaStore((s) => s.load);
   const paInflight = usePaStore((s) => s.inflight);
+
+  useEffect(() => {
+    if (initialTab) setActive(initialTab);
+  }, [initialTab]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
 
   const handleApply = async () => {
     await savePa();
@@ -83,158 +94,19 @@ export function SettingsMenu({ open, onClose, initialTab }: Props) {
     await loadPa();
     onClose();
   };
-  // null = use the initial-centering flex layout on first render; after the
-  // first drag (or the post-mount centering effect), a concrete {x,y} takes
-  // over and the panel positions absolutely. Off-screen values are allowed —
-  // the user explicitly wanted to be able to drag the window off-screen.
-  const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
-  const panelRef = useRef<HTMLDivElement>(null);
-  const dragRef = useRef<{ dx: number; dy: number } | null>(null);
-
-  // Set the active tab when initialTab prop changes
-  useEffect(() => {
-    if (initialTab) setActive(initialTab);
-  }, [initialTab]);
-
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [open, onClose]);
-
-  // Center on first open: measure the panel's natural rect and pin it there,
-  // switching from flex-centering to absolute positioning so dragging starts
-  // from a stable origin.
-  useEffect(() => {
-    if (!open) {
-      setPos(null);
-      return;
-    }
-    if (pos !== null) return;
-    const el = panelRef.current;
-    if (!el) return;
-    const rect = el.getBoundingClientRect();
-    setPos({
-      x: Math.max(8, (window.innerWidth - rect.width) / 2),
-      y: Math.max(8, (window.innerHeight - rect.height) / 2),
-    });
-  }, [open, pos]);
-
-  // Global mousemove/up while a drag is in flight. Listener is always mounted
-  // so we can start dragging from the header's mousedown without remounting.
-  useEffect(() => {
-    const move = (e: MouseEvent) => {
-      const d = dragRef.current;
-      if (!d) return;
-      setPos({ x: e.clientX - d.dx, y: e.clientY - d.dy });
-    };
-    const up = () => {
-      dragRef.current = null;
-    };
-    window.addEventListener('mousemove', move);
-    window.addEventListener('mouseup', up);
-    return () => {
-      window.removeEventListener('mousemove', move);
-      window.removeEventListener('mouseup', up);
-    };
-  }, []);
-
-  const startDrag = (e: React.MouseEvent<HTMLDivElement>) => {
-    const el = panelRef.current;
-    if (!el) return;
-    const rect = el.getBoundingClientRect();
-    dragRef.current = {
-      dx: e.clientX - rect.left,
-      dy: e.clientY - rect.top,
-    };
-    e.preventDefault();
-  };
-
-  if (!open) return null;
-
-  const basePanel: React.CSSProperties = {
-    position: 'fixed',
-    width: 'min(1100px, 92vw)',
-    height: 'min(840px, 85vh)',
-    zIndex: 50,
-    background: 'var(--bg-1)',
-    border: '1px solid var(--panel-border)',
-    borderRadius: 'var(--r-md)',
-    boxShadow: '0 20px 60px rgba(0,0,0,0.55), 0 0 0 1px rgba(255,255,255,0.03)',
-    color: 'var(--fg-1)',
-    display: 'flex',
-    flexDirection: 'column',
-    overflow: 'hidden',
-  };
-  const panelStyle: React.CSSProperties =
-    pos === null
-      ? { ...basePanel, left: '50%', top: '50%', transform: 'translate(-50%, -50%)' }
-      : { ...basePanel, left: `${pos.x}px`, top: `${pos.y}px` };
 
   return (
-    <div
-      ref={panelRef}
-      style={panelStyle}
-      role="dialog"
-      aria-modal="false"
-      aria-labelledby="settings-title"
-    >
-      <div
-        onMouseDown={startDrag}
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          cursor: 'move',
-          userSelect: 'none',
-          height: 44,
-          padding: '0 14px',
-          background:
-            'linear-gradient(180deg, var(--panel-head-top), var(--panel-head-bot))',
-          borderBottom: '1px solid var(--panel-border)',
-          boxShadow: 'inset 0 1px 0 var(--panel-hl-top)',
-        }}
-        title="Drag to move"
-      >
-        <h2
-          id="settings-title"
-          style={{
-            margin: 0,
-            fontSize: 12,
-            fontWeight: 700,
-            letterSpacing: '0.18em',
-            color: 'var(--fg-0)',
-            textTransform: 'uppercase',
-          }}
-        >
+    <div className="settings-view" role="region" aria-label="Settings">
+      <div className="settings-view-header">
+        <h2 className="settings-view-title" id="settings-title">
           Settings
         </h2>
         <button
           type="button"
           onClick={onClose}
-          onMouseDown={(e) => e.stopPropagation()}
-          aria-label="Close"
-          style={{
-            width: 26,
-            height: 26,
-            borderRadius: 'var(--r-sm)',
-            color: 'var(--fg-2)',
-            fontSize: 18,
-            lineHeight: 1,
-            background: 'transparent',
-            cursor: 'pointer',
-          }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.background = 'rgba(255,255,255,0.06)';
-            e.currentTarget.style.color = 'var(--fg-0)';
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.background = 'transparent';
-            e.currentTarget.style.color = 'var(--fg-2)';
-          }}
+          aria-label="Close settings"
+          className="settings-view-close"
+          title="Close (Esc)"
         >
           ×
         </button>
@@ -242,21 +114,11 @@ export function SettingsMenu({ open, onClose, initialTab }: Props) {
 
       <RadioSelector />
 
-      <div style={{ display: 'flex', flex: 1, minHeight: 0 }}>
+      <div className="settings-view-body">
         <nav
           role="tablist"
           aria-label="Settings sections"
-          style={{
-            width: 168,
-            flexShrink: 0,
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 2,
-            padding: '10px 8px',
-            background: 'var(--bg-0)',
-            borderRight: '1px solid var(--panel-border)',
-            overflowY: 'auto',
-          }}
+          className="settings-view-tabs"
         >
           {TABS.map((t) => {
             const isActive = t.id === active;
@@ -267,34 +129,7 @@ export function SettingsMenu({ open, onClose, initialTab }: Props) {
                 role="tab"
                 aria-selected={isActive}
                 onClick={() => setActive(t.id)}
-                style={{
-                  textAlign: 'left',
-                  padding: '8px 12px',
-                  borderRadius: 'var(--r-sm)',
-                  fontSize: 11,
-                  fontWeight: 700,
-                  letterSpacing: '0.12em',
-                  textTransform: 'uppercase',
-                  color: isActive ? 'var(--fg-0)' : 'var(--fg-2)',
-                  background: isActive ? 'var(--bg-2)' : 'transparent',
-                  borderLeft: isActive
-                    ? '2px solid var(--accent)'
-                    : '2px solid transparent',
-                  cursor: 'pointer',
-                  transition: 'background var(--dur-fast), color var(--dur-fast)',
-                }}
-                onMouseEnter={(e) => {
-                  if (!isActive) {
-                    e.currentTarget.style.background = 'rgba(255,255,255,0.03)';
-                    e.currentTarget.style.color = 'var(--fg-1)';
-                  }
-                }}
-                onMouseLeave={(e) => {
-                  if (!isActive) {
-                    e.currentTarget.style.background = 'transparent';
-                    e.currentTarget.style.color = 'var(--fg-2)';
-                  }
-                }}
+                className={`settings-view-tab${isActive ? ' active' : ''}`}
               >
                 {t.label}
               </button>
@@ -302,20 +137,7 @@ export function SettingsMenu({ open, onClose, initialTab }: Props) {
           })}
         </nav>
 
-        <div
-          role="tabpanel"
-          style={{
-            flex: 1,
-            minWidth: 0,
-            overflow: 'auto',
-            padding: '18px 22px',
-            background: 'var(--bg-1)',
-            color: 'var(--fg-1)',
-            fontSize: 12,
-            display: 'flex',
-            flexDirection: 'column',
-          }}
-        >
+        <div role="tabpanel" className="settings-view-panel">
           {active === 'pa' && <PaSettingsPanel />}
           {active === 'ps' && <PsSettingsPanel />}
           {active === 'tx-audio' && <TxAudioToolsPanel />}
@@ -330,17 +152,7 @@ export function SettingsMenu({ open, onClose, initialTab }: Props) {
       </div>
 
       {active === 'pa' && (
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'flex-end',
-            gap: 6,
-            padding: '10px 14px',
-            background: 'var(--bg-0)',
-            borderTop: '1px solid var(--panel-border)',
-          }}
-        >
+        <div className="settings-view-footer">
           <button type="button" className="btn sm" onClick={handleCancel} disabled={paInflight}>
             CANCEL
           </button>

--- a/zeus-web/src/components/TxStageMeters.tsx
+++ b/zeus-web/src/components/TxStageMeters.tsx
@@ -95,7 +95,7 @@ export function OverdriveIndicator() {
         alignItems: 'center',
         gap: 4,
         padding: '2px 6px',
-        borderRadius: 3,
+        borderRadius: 0,
         fontSize: 9,
         fontWeight: 700,
         letterSpacing: '0.08em',
@@ -312,7 +312,7 @@ function MeterRow({
             height: 14,
             background: 'var(--meter-bg)',
             border: '1px solid var(--panel-border)',
-            borderRadius: 2,
+            borderRadius: 0,
             boxShadow:
               'inset 0 1px 0 rgba(0,0,0,0.5), inset 0 0 0 0.5px rgba(255,255,255,0.02)',
             overflow: 'hidden',

--- a/zeus-web/src/components/VstHostPluginBrowser.tsx
+++ b/zeus-web/src/components/VstHostPluginBrowser.tsx
@@ -72,7 +72,7 @@ export function VstHostPluginBrowser({ open, targetSlot, onClose }: Props) {
         flexDirection: 'column',
         zIndex: 5,
         border: '1px solid var(--panel-border)',
-        borderRadius: 4,
+        borderRadius: 0,
       }}
     >
       <header
@@ -82,7 +82,7 @@ export function VstHostPluginBrowser({ open, targetSlot, onClose }: Props) {
           gap: 10,
           padding: '8px 12px',
           background:
-            'linear-gradient(180deg, var(--panel-head-top), var(--panel-head-bot))',
+            'linear-gradient(90deg, var(--panel-head-top), var(--panel-head-bot))',
           borderBottom: '1px solid var(--panel-border)',
           color: 'var(--fg-0)',
         }}
@@ -129,7 +129,7 @@ export function VstHostPluginBrowser({ open, targetSlot, onClose }: Props) {
             background: 'var(--bg-0)',
             color: 'var(--fg-1)',
             border: '1px solid var(--panel-border)',
-            borderRadius: 3,
+            borderRadius: 0,
             fontSize: 12,
           }}
         />

--- a/zeus-web/src/components/VstHostSearchPaths.tsx
+++ b/zeus-web/src/components/VstHostSearchPaths.tsx
@@ -112,7 +112,7 @@ export function VstHostSearchPaths() {
             background: 'var(--bg-0)',
             color: 'var(--fg-1)',
             border: '1px solid var(--panel-border)',
-            borderRadius: 3,
+            borderRadius: 0,
             fontSize: 12,
           }}
         />

--- a/zeus-web/src/components/VstHostSlotRow.tsx
+++ b/zeus-web/src/components/VstHostSlotRow.tsx
@@ -69,7 +69,7 @@ export function VstHostSlotRow({ index, disabled, remote = false, onRequestLoad 
     gap: 6,
     padding: '8px 10px',
     border: '1px solid var(--panel-border)',
-    borderRadius: 4,
+    borderRadius: 0,
     background: 'var(--bg-1)',
     opacity: disabled ? 0.55 : 1,
   };

--- a/zeus-web/src/components/VstHostSubmenu.tsx
+++ b/zeus-web/src/components/VstHostSubmenu.tsx
@@ -86,7 +86,7 @@ export function VstHostSubmenu() {
       style={{
         position: 'relative',
         border: '1px solid var(--panel-border)',
-        borderRadius: 6,
+        borderRadius: 0,
         padding: '10px 12px',
         background: 'var(--bg-1)',
         display: 'flex',
@@ -172,7 +172,7 @@ export function VstHostSubmenu() {
             color: 'var(--fg-2)',
             background: 'var(--bg-2)',
             border: '1px solid var(--panel-border)',
-            borderRadius: 4,
+            borderRadius: 0,
             padding: '6px 8px',
           }}
         >

--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -45,7 +45,7 @@
 import { useEffect, useRef } from 'react';
 import { COLORMAPS } from '../gl/colormap';
 import { createWfRenderer } from '../gl/waterfall';
-import { useDisplayStore } from '../state/display-store';
+import { registerFrameConsumer, useDisplayStore } from '../state/display-store';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
 import { useTxStore } from '../state/tx-store';
 import { usePanTuneGesture } from '../util/use-pan-tune-gesture';
@@ -82,6 +82,11 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       console.error('WebGL2 not available');
       return;
     }
+
+    // Tell the realtime client that decoded spectrum frames are needed —
+    // ws-client.ts skips decodeDisplayFrame entirely when no consumer is
+    // registered (all spectrum surfaces closed).
+    const releaseFrameConsumer = registerFrameConsumer();
 
     const renderer = createWfRenderer(gl);
     rendererRef.current = renderer;
@@ -212,6 +217,7 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       if (rafHandle !== 0) cancelAnimationFrame(rafHandle);
       renderer.dispose();
       rendererRef.current = null;
+      releaseFrameConsumer();
     };
   }, []);
 

--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -43,7 +43,7 @@
 // License for details.
 
 import { useEffect, useRef } from 'react';
-import { COLORMAPS, type ColormapId } from '../gl/colormap';
+import { COLORMAPS } from '../gl/colormap';
 import { createWfRenderer } from '../gl/waterfall';
 import { useDisplayStore } from '../state/display-store';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
@@ -92,7 +92,6 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
     let rafHandle = 0;
     let lastSeqDrawn = -1;
     let tickCounter = 0;
-    let lastColormap: ColormapId = useDisplaySettingsStore.getState().colormap;
     // Visibility gating: skip the rAF redraw when the waterfall tile is
     // scrolled offscreen or the tab is hidden. We still push frames into
     // the history texture so when visibility resumes the operator sees a
@@ -170,19 +169,37 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
 
     // Repaint on dB-range or colormap changes so the WfDbScale drag and the
     // colormap swap land without waiting for the next server frame. Re-upload
-    // the LUT only when the id actually changed to avoid a texImage2D per tick.
-    const unsubSettings = useDisplaySettingsStore.subscribe((state) => {
-      if (state.colormap !== lastColormap) {
-        lastColormap = state.colormap;
+    // the LUT only when the id actually changed to avoid a texImage2D per
+    // tick. The prev-state diff is load-bearing: a no-selector subscribe
+    // used to fire (and redraw) on every store mutation, which during
+    // ordinary RX traffic pulled the waterfall rAF floor above the
+    // spectrum-tick rate.
+    const unsubSettings = useDisplaySettingsStore.subscribe((state, prev) => {
+      if (state.colormap !== prev.colormap) {
         renderer.setColormap(state.colormap);
+        requestRedraw();
+        return;
       }
-      requestRedraw();
+      if (
+        state.wfDbMin !== prev.wfDbMin ||
+        state.wfDbMax !== prev.wfDbMax ||
+        state.wfTxDbMin !== prev.wfTxDbMin ||
+        state.wfTxDbMax !== prev.wfTxDbMax
+      ) {
+        requestRedraw();
+      }
     });
 
     // Repaint when MOX/TUN flips so the RX↔TX waterfall window swap lands
     // immediately instead of waiting for the next server frame or scale drag.
-    const unsubTx = useTxStore.subscribe(() => {
-      requestRedraw();
+    // App.tsx:211 uses the same prev-state diff pattern — without it the
+    // unconditional subscriber fires on every tx-store update (mic dBFS at
+    // 50 Hz from the worklet) and raises the floor on redraw rate above the
+    // spectrum-tick rate.
+    const unsubTx = useTxStore.subscribe((state, prev) => {
+      if (state.moxOn !== prev.moxOn || state.tunOn !== prev.tunOn) {
+        requestRedraw();
+      }
     });
 
     return () => {

--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -45,6 +45,7 @@
 import { useEffect, useRef } from 'react';
 import { COLORMAPS } from '../gl/colormap';
 import { createWfRenderer } from '../gl/waterfall';
+import { cancelDrawBusFrame, requestDrawBusFrame } from '../realtime/draw-bus';
 import { useDisplayStore } from '../state/display-store';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
 import { useTxStore } from '../state/tx-store';
@@ -89,7 +90,6 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
     // (e.g. after a resize that cycles the canvas).
     renderer.setColormap(useDisplaySettingsStore.getState().colormap);
     renderer.setTransparent(transparent);
-    let rafHandle = 0;
     let lastSeqDrawn = -1;
     let tickCounter = 0;
     // Visibility gating: skip the rAF redraw when the waterfall tile is
@@ -101,7 +101,6 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
     const isActive = () => inViewport && pageVisible;
 
     const redraw = () => {
-      rafHandle = 0;
       const { wfDbMin, wfDbMax, wfTxDbMin, wfTxDbMax } = useDisplaySettingsStore.getState();
       const { moxOn, tunOn } = useTxStore.getState();
       const keyed = moxOn || tunOn;
@@ -113,7 +112,10 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
     };
     const requestRedraw = () => {
       if (!isActive()) return;
-      if (rafHandle === 0) rafHandle = requestAnimationFrame(redraw);
+      // Shared draw bus: panadapter + waterfall coalesce onto a single rAF
+      // per frame. The bus dedupes repeated requests for the same callback,
+      // matching the prior `if (rafHandle === 0)` gate.
+      requestDrawBusFrame(redraw);
     };
 
     const resize = () => {
@@ -209,7 +211,7 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       ro.disconnect();
       io.disconnect();
       document.removeEventListener('visibilitychange', onVisibilityChange);
-      if (rafHandle !== 0) cancelAnimationFrame(rafHandle);
+      cancelDrawBusFrame(redraw);
       renderer.dispose();
       rendererRef.current = null;
     };

--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -93,6 +93,13 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
     let lastSeqDrawn = -1;
     let tickCounter = 0;
     let lastColormap: ColormapId = useDisplaySettingsStore.getState().colormap;
+    // Visibility gating: skip the rAF redraw when the waterfall tile is
+    // scrolled offscreen or the tab is hidden. We still push frames into
+    // the history texture so when visibility resumes the operator sees a
+    // continuous timeline; we just don't paint to the visible surface.
+    let inViewport = true;
+    let pageVisible = !document.hidden;
+    const isActive = () => inViewport && pageVisible;
 
     const redraw = () => {
       rafHandle = 0;
@@ -106,12 +113,18 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       renderer.draw(dbMin, dbMax);
     };
     const requestRedraw = () => {
+      if (!isActive()) return;
       if (rafHandle === 0) rafHandle = requestAnimationFrame(redraw);
     };
 
     const resize = () => {
       const { width, height } = container.getBoundingClientRect();
-      const dpr = window.devicePixelRatio || 1;
+      // Clamp the WebGL backing store at DPR=1. Waterfall is typically the
+      // largest GPU surface in the workspace; running it at native Retina
+      // DPR pushes 4× pixel data through every composite for no visible
+      // gain (the colormap is a smooth gradient and the per-row history
+      // shift is integer-pixel). Same rationale as Panadapter.
+      const dpr = Math.min(1, window.devicePixelRatio || 1);
       const w = Math.max(1, Math.round(width * dpr));
       const h = Math.max(1, Math.round(height * dpr));
       canvas.width = w;
@@ -123,6 +136,22 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
     const ro = new ResizeObserver(resize);
     ro.observe(container);
     resize();
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) {
+          inViewport = e.isIntersecting;
+        }
+        if (isActive()) requestRedraw();
+      },
+      { threshold: 0 },
+    );
+    io.observe(container);
+    const onVisibilityChange = () => {
+      pageVisible = !document.hidden;
+      if (isActive()) requestRedraw();
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
 
     const unsub = useDisplayStore.subscribe((state) => {
       if (state.lastSeq === lastSeqDrawn) return;
@@ -161,6 +190,8 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       unsubSettings();
       unsubTx();
       ro.disconnect();
+      io.disconnect();
+      document.removeEventListener('visibilitychange', onVisibilityChange);
       if (rafHandle !== 0) cancelAnimationFrame(rafHandle);
       renderer.dispose();
       rendererRef.current = null;

--- a/zeus-web/src/components/analog-meter/AnalogMeterConfig.tsx
+++ b/zeus-web/src/components/analog-meter/AnalogMeterConfig.tsx
@@ -88,9 +88,20 @@ interface AnalogMeterConfigProps {
 
 export function AnalogMeterConfig({ open, onClose }: AnalogMeterConfigProps) {
   const cfg = useAnalogMeterStore();
+  // The flyout is the dominant idle CPU cost on this panel — its 30+ form
+  // controls (sliders, checkboxes, tick buttons) were reconciled on every
+  // parent render even when the gear was closed, because the previous form
+  // returned the full tree and only toggled a CSS class. With
+  // AnalogMeterPanel's ballistic rAF loop driving renders at near-frame-rate,
+  // each invisible commit was re-applying ~580 input attributes per second
+  // observed via MutationObserver. Returning null when closed eliminates the
+  // entire reconcile + DOM-commit cost; the trade-off is that the slide-down
+  // animation is now a mount/unmount, which is fine for a settings flyout
+  // that opens infrequently.
+  if (!open) return null;
 
   return (
-    <div className={`am-config ${open ? 'open' : ''}`} aria-hidden={!open}>
+    <div className="am-config open">
       <div className="am-cf-grid">
         <section className="am-cf-sect">
           <header>

--- a/zeus-web/src/components/analog-meter/AnalogMeterPanel.tsx
+++ b/zeus-web/src/components/analog-meter/AnalogMeterPanel.tsx
@@ -21,6 +21,7 @@
 // flat without making the animation chunky.
 
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { GripVertical, Settings, X } from 'lucide-react';
 import { usePaStore } from '../../state/pa-store';
 import { useTxStore } from '../../state/tx-store';
@@ -160,6 +161,7 @@ export interface AnalogMeterPanelProps {
 }
 
 export function AnalogMeterPanel({ onClose }: AnalogMeterPanelProps = {}) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const cfg = useAnalogMeterStore();
   const moxOn = useTxStore((s) => s.moxOn);
   const tunOn = useTxStore((s) => s.tunOn);
@@ -246,8 +248,24 @@ export function AnalogMeterPanel({ onClose }: AnalogMeterPanelProps = {}) {
   const lastPublishedRef = useRef({ needleN: -1, peakN: -1 });
 
   useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
     let raf = 0;
+    // Visibility gate: stop the rAF loop when the tile is scrolled offscreen
+    // or the tab is hidden. Same pattern Panadapter / Waterfall use.
+    let inViewport = true;
+    let pageVisible = !document.hidden;
+    const isActive = () => inViewport && pageVisible;
+    // Throttle React publishes to ~30 Hz max even on high-refresh displays
+    // (macOS ProMotion runs rAF at 120 Hz). The needle face is the only
+    // consumer of `render`; 30 Hz gives a smooth analog feel and stops the
+    // panel reconcile from being driven off the system frame rate, which
+    // used to drag the always-mounted child subtree along with it.
+    const PUBLISH_INTERVAL_MS = 33;
+    let lastPublishMs = 0;
+
     const loop = (now: number) => {
+      raf = 0;
       const s = stateRef.current;
       const dt = Math.min(0.1, (now - s.last) / 1000);
       s.last = now;
@@ -279,15 +297,49 @@ export function AnalogMeterPanel({ onClose }: AnalogMeterPanelProps = {}) {
       }
 
       const last = lastPublishedRef.current;
-      if (Math.abs(s.needleN - last.needleN) > 0.001 || Math.abs(s.peakN - last.peakN) > 0.001) {
+      if (
+        now - lastPublishMs >= PUBLISH_INTERVAL_MS &&
+        (Math.abs(s.needleN - last.needleN) > 0.001 ||
+          Math.abs(s.peakN - last.peakN) > 0.001)
+      ) {
+        lastPublishMs = now;
         lastPublishedRef.current = { needleN: s.needleN, peakN: s.peakN };
         setRender({ needleN: s.needleN, peakN: s.peakN });
       }
 
-      raf = requestAnimationFrame(loop);
+      if (isActive()) raf = requestAnimationFrame(loop);
     };
-    raf = requestAnimationFrame(loop);
-    return () => cancelAnimationFrame(raf);
+
+    const start = () => {
+      if (raf === 0 && isActive()) {
+        // Reset the dt anchor so the first tick after a wake doesn't account
+        // for the gap as elapsed time and yank the ballistic.
+        stateRef.current.last = performance.now();
+        raf = requestAnimationFrame(loop);
+      }
+    };
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) inViewport = e.isIntersecting;
+        if (isActive()) start();
+      },
+      { threshold: 0 },
+    );
+    io.observe(container);
+    const onVisibilityChange = () => {
+      pageVisible = !document.hidden;
+      if (isActive()) start();
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    start();
+
+    return () => {
+      if (raf !== 0) cancelAnimationFrame(raf);
+      io.disconnect();
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
   }, [activeScaleId, activeScale, cfg.attack, cfg.decay, cfg.peakHold]);
 
   // The face needs the operator-filtered S-arc; we override SCALES.s for the
@@ -306,9 +358,12 @@ export function AnalogMeterPanel({ onClose }: AnalogMeterPanelProps = {}) {
 
   // Readout values: active scale shows the ballistic-filtered needle reading,
   // others show the raw live values so the footer mirrors the radio's state.
-  const rawRxDbm = useTxStore((s) => s.rxDbm);
-  const rawFwdW = useTxStore((s) => s.fwdWatts);
-  const rawSwr = useTxStore((s) => s.swr);
+  // Single subscription with a shallow comparator keeps this to one re-render
+  // per data tick instead of three (the prior pattern fired three separate
+  // subscribers per store update).
+  const { rxDbm: rawRxDbm, fwdWatts: rawFwdW, swr: rawSwr } = useTxStore(
+    useShallow((s) => ({ rxDbm: s.rxDbm, fwdWatts: s.fwdWatts, swr: s.swr })),
+  );
   const readoutValues = {
     s: activeScaleId === 's' ? needleVal : dbmToS(rawRxDbm),
     po: activeScaleId === 'po' ? needleVal : rawFwdW,
@@ -317,7 +372,7 @@ export function AnalogMeterPanel({ onClose }: AnalogMeterPanelProps = {}) {
   const dbm = sToDbm(readoutValues.s);
 
   return (
-    <div className="am-tile" data-mode={mode}>
+    <div ref={containerRef} className="am-tile" data-mode={mode}>
       <TileHeader
         configOpen={configOpen}
         onGearClick={() => setConfigOpen((o) => !o)}

--- a/zeus-web/src/components/bandplan/BandPlanEditor.tsx
+++ b/zeus-web/src/components/bandplan/BandPlanEditor.tsx
@@ -153,26 +153,26 @@ export function BandPlanEditor() {
             </span>
           </label>
           {store.txGuardIgnore && (
-            <span style={{ fontSize: 10, color: 'rgba(255,80,80,0.8)', background: 'rgba(255,0,0,0.08)', padding: '2px 6px', borderRadius: 4, border: '1px solid rgba(255,80,80,0.3)' }}>
+            <span style={{ fontSize: 10, color: 'rgba(255,80,80,0.8)', background: 'rgba(255,0,0,0.08)', padding: '2px 6px', borderRadius: 0, border: '1px solid rgba(255,80,80,0.3)' }}>
               ⚠ MOX will fire regardless of band legality
             </span>
           )}
         </div>
       </div>
 
-      <div style={{ fontSize: 10, color: 'var(--fg-3)', background: 'rgba(255,160,40,0.06)', border: '1px solid rgba(255,160,40,0.15)', borderRadius: 4, padding: '6px 10px' }}>
+      <div style={{ fontSize: 10, color: 'var(--fg-3)', background: 'rgba(255,160,40,0.06)', border: '1px solid rgba(255,160,40,0.15)', borderRadius: 0, padding: '6px 10px' }}>
         Defaults are best-effort. You are responsible for operating within your licence.
         Source files under Zeus.Server/BandPlans/ — corrections welcome as PRs.
       </div>
 
       {error && (
-        <div style={{ fontSize: 11, color: '#ff5555', background: 'rgba(255,0,0,0.08)', border: '1px solid rgba(255,80,80,0.3)', borderRadius: 4, padding: '6px 10px' }}>
+        <div style={{ fontSize: 11, color: '#ff5555', background: 'rgba(255,0,0,0.08)', border: '1px solid rgba(255,80,80,0.3)', borderRadius: 0, padding: '6px 10px' }}>
           {error}
         </div>
       )}
 
       {/* Segment table */}
-      <div style={{ flex: 1, minHeight: 0, overflow: 'auto', border: '1px solid var(--panel-border)', borderRadius: 4 }}>
+      <div style={{ flex: 1, minHeight: 0, overflow: 'auto', border: '1px solid var(--panel-border)', borderRadius: 0 }}>
         <table style={{ width: '100%', borderCollapse: 'collapse' }}>
           <thead>
             <tr style={{ background: 'var(--bg-0)', position: 'sticky', top: 0, zIndex: 1 }}>

--- a/zeus-web/src/components/design/LeafletWorldMap.tsx
+++ b/zeus-web/src/components/design/LeafletWorldMap.tsx
@@ -170,7 +170,7 @@ function callsignAvatarIcon(station: MapStation, tone: 'home' | 'target'): L.Div
         left: 50%;
         transform: translateX(-50%);
         padding: 1px 6px;
-        border-radius: 3px;
+        border-radius: 0;
         background: ${chipBg};
         border: 1px solid ${chipBorder};
         color: ${chipText};
@@ -217,7 +217,7 @@ function buildTargetPopup(
         ${hasRotator
           ? `<button type="button" data-lf-action="rotate" data-lf-bearing="${bearing.toFixed(1)}"
               style="
-                padding: 3px 8px; font-size: 11px; border-radius: 3px;
+                padding: 3px 8px; font-size: 11px; border-radius: 0;
                 border: 1px solid ${COLOR_CYAN}; background: rgba(0,221,255,0.15);
                 color: ${COLOR_CYAN}; cursor: pointer; font-family: inherit;
               ">Rotate ${brg}</button>`

--- a/zeus-web/src/components/filter/FilterMiniPan.tsx
+++ b/zeus-web/src/components/filter/FilterMiniPan.tsx
@@ -14,7 +14,7 @@
 // of scissor-clipping or sharing the main panadapter's GL context.
 
 import { useEffect, useRef } from 'react';
-import { useDisplayStore } from '../../state/display-store';
+import { registerFrameConsumer, useDisplayStore } from '../../state/display-store';
 import { useConnectionStore } from '../../state/connection-store';
 import { setFilter } from '../../api/client';
 import { formatCutOffset } from './filterPresets';
@@ -72,6 +72,11 @@ export function FilterMiniPan() {
     if (!canvas) return;
     const ctx = canvas.getContext('2d', { alpha: true });
     if (!ctx) return;
+
+    // Tell the realtime client that decoded spectrum frames are needed —
+    // ws-client.ts skips decodeDisplayFrame entirely when no consumer is
+    // registered (all spectrum surfaces closed).
+    const releaseFrameConsumer = registerFrameConsumer();
 
     let rafHandle = 0;
     let lastSeq = -1;
@@ -301,6 +306,7 @@ export function FilterMiniPan() {
       unsubDisplay();
       unsubConn();
       ro.disconnect();
+      releaseFrameConsumer();
     };
   }, []);
 

--- a/zeus-web/src/components/meters/MeterWidget.tsx
+++ b/zeus-web/src/components/meters/MeterWidget.tsx
@@ -98,7 +98,7 @@ export function MeterWidget({
     alignItems: 'center',
     gap: 6,
     padding: '3px 6px',
-    background: 'linear-gradient(180deg, var(--panel-top), var(--panel-bot))',
+    background: 'linear-gradient(90deg, var(--panel-top), var(--panel-bot))',
     borderBottom: '1px solid var(--panel-border)',
     flexShrink: 0,
   };

--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -17,12 +17,13 @@
 //   - "+ Add Panel" is a single workspace-level button at the top-right,
 //     opening the categorized AddPanelModal.
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ResponsiveGridLayout,
   useContainerWidth,
   type Layout,
 } from 'react-grid-layout';
+import { absoluteStrategy } from 'react-grid-layout/core';
 import { useWorkspace } from './WorkspaceContext';
 import { useLayoutStore } from '../state/layout-store';
 import { PANELS } from './panels';
@@ -203,6 +204,17 @@ function WorkspaceCanvas({
           rowHeight={rowHeight}
           margin={[6, 6]}
           containerPadding={[6, 6]}
+          // Position tiles via top/left rather than transform: translate3d.
+          // RGL's default `transformStrategy` uses CSS transforms, which
+          // (combined with the upstream stylesheet's `will-change: transform`)
+          // forces every tile to be its own permanent GPU compositor layer.
+          // With a WebGL panadapter inside one of those tiles, every WebGL
+          // frame produces a chain re-composite up the tree — visible on
+          // macOS as WindowServer + Chrome GPU pinning. `absoluteStrategy`
+          // avoids the promotion for static tiles. The only cost is slightly
+          // less smooth dragging, and operators rarely re-arrange the
+          // workspace.
+          positionStrategy={absoluteStrategy}
           // Drag from anywhere in the tile header (the grip + title strip),
           // EXCEPT the close button. A tiny grip-only handle is too small to
           // grab — and panels that have their own pointer logic in the body
@@ -220,7 +232,7 @@ function WorkspaceCanvas({
         >
           {tiles.map((tile) => (
             <div key={tile.uid} data-tile-uid={tile.uid}>
-              <PanelTile tile={tile} onRemove={() => onRemoveTile(tile.uid)} />
+              <PanelTile tile={tile} onRemoveTile={onRemoveTile} />
             </div>
           ))}
         </ResponsiveGridLayout>
@@ -231,10 +243,21 @@ function WorkspaceCanvas({
 
 interface PanelTileProps {
   tile: WorkspaceTile;
-  onRemove: () => void;
+  onRemoveTile: (uid: string) => void;
 }
 
-function PanelTile({ tile, onRemove }: PanelTileProps) {
+// Memoised so a parent re-render (e.g. another tile's drag updating the
+// store) doesn't reconcile every panel's subtree. Effective only because
+// the store preserves per-tile object identity across unrelated mutations
+// and `onRemoveTile` is the stable zustand action reference.
+const PanelTile = memo(function PanelTile({
+  tile,
+  onRemoveTile,
+}: PanelTileProps) {
+  const handleRemove = useCallback(
+    () => onRemoveTile(tile.uid),
+    [onRemoveTile, tile.uid],
+  );
   const def = PANELS[tile.panelId];
   if (!def) return null;
   // Headerless panels own their entire tile surface and draw their own
@@ -244,19 +267,19 @@ function PanelTile({ tile, onRemove }: PanelTileProps) {
   if (def.headerless) {
     return (
       <div className="workspace-tile workspace-tile--headerless">
-        <PanelBody tile={tile} onRemove={onRemove} />
+        <PanelBody tile={tile} onRemove={handleRemove} />
       </div>
     );
   }
   return (
     <div className="workspace-tile">
-      <TileChrome title={def.name} onRemove={onRemove} />
+      <TileChrome title={def.name} onRemove={handleRemove} />
       <div className="workspace-tile-body">
         <PanelBody tile={tile} />
       </div>
     </div>
   );
-}
+});
 
 function PanelBody({
   tile,

--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -158,7 +158,7 @@ function WorkspaceCanvas({
   const rowHeight = useMemo(() => {
     if (containerHeight <= 0) return WORKSPACE_ROW_HEIGHT_PX;
     const margin = 6;
-    const containerPadding = 6;
+    const containerPadding = 0;
     const inner =
       containerHeight - 2 * containerPadding - margin * (WORKSPACE_TARGET_ROWS - 1);
     const computed = Math.floor(inner / WORKSPACE_TARGET_ROWS);
@@ -203,7 +203,7 @@ function WorkspaceCanvas({
           cols={{ lg: WORKSPACE_GRID_COLS }}
           rowHeight={rowHeight}
           margin={[6, 6]}
-          containerPadding={[6, 6]}
+          containerPadding={[0, 0]}
           // Position tiles via top/left rather than transform: translate3d.
           // RGL's default `transformStrategy` uses CSS transforms, which
           // (combined with the upstream stylesheet's `will-change: transform`)

--- a/zeus-web/src/mobile/mobile.css
+++ b/zeus-web/src/mobile/mobile.css
@@ -24,7 +24,7 @@
   align-items: center;
   gap: 10px;
   padding: 10px 12px;
-  background: linear-gradient(180deg, var(--panel-head-top) 0%, var(--panel-head-bot) 100%);
+  background: linear-gradient(90deg, var(--panel-head-top) 0%, var(--panel-head-bot) 100%);
   border-bottom: 1px solid var(--panel-border);
   position: sticky;
   top: 0;
@@ -114,7 +114,7 @@
   display: flex;
   align-items: center;
   padding: 10px 12px;
-  background: linear-gradient(180deg, var(--panel-head-top) 0%, var(--panel-head-bot) 100%);
+  background: linear-gradient(90deg, var(--panel-head-top) 0%, var(--panel-head-bot) 100%);
   border-bottom: 1px solid var(--panel-border);
 }
 .m-selector-title {
@@ -164,7 +164,7 @@
   align-items: center;
   gap: 8px;
   padding: 8px 10px;
-  background: linear-gradient(180deg, var(--panel-head-top) 0%, var(--panel-head-bot) 100%);
+  background: linear-gradient(90deg, var(--panel-head-top) 0%, var(--panel-head-bot) 100%);
   border-bottom: 1px solid var(--panel-border);
   font-family: var(--font-sans);
   font-size: 10px;

--- a/zeus-web/src/realtime/draw-bus.ts
+++ b/zeus-web/src/realtime/draw-bus.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+// Distributed under GPL-2.0-or-later. See LICENSE at the repository root.
+
+// Shared draw bus — coalesces panadapter + waterfall (and any other canvas
+// that opts in) into a single requestAnimationFrame wakeup per frame.
+//
+// Background: each canvas component used to call its own
+//   if (rafHandle === 0) rafHandle = requestAnimationFrame(redraw)
+// from inside a `useDisplayStore.subscribe` handler. With panadapter and
+// waterfall both reacting to the same `lastSeq` update, every server
+// spectrum push (~25 Hz) produced two independent rAF wakeups. The renderer
+// did the same total work either way, but two callbacks meant two scheduler
+// turns and two paint-commit fences per frame.
+//
+// The bus collapses that to one. Components register a redraw callback via
+// `requestDrawBusFrame(cb)`; the first request in a frame schedules a
+// single rAF, which fans out to every pending callback in registration
+// order. Re-requesting the same callback before the rAF fires is a no-op
+// (Set-deduped), matching the existing `if (rafHandle === 0)` gate.
+//
+// On the rAF tick we snapshot and clear the pending set first, so a
+// callback that re-requests a redraw (e.g. on a new store update mid-flush)
+// lands on the *next* rAF, not this one. This preserves the natural
+// back-pressure of the previous per-component pattern.
+//
+// `cancelDrawBusFrame(cb)` is the unmount safety hatch — components must
+// call it in their effect cleanup so a stale closure doesn't fire after
+// the WebGL context has been disposed.
+
+type DrawCallback = () => void;
+
+const pending = new Set<DrawCallback>();
+let rafHandle = 0;
+
+const flush = () => {
+  rafHandle = 0;
+  // Snapshot before invoking so a callback that re-arms itself lands on
+  // the next frame rather than this one. Iteration order is insertion
+  // order on Set, which keeps the panadapter-then-waterfall ordering
+  // stable across frames.
+  const cbs = Array.from(pending);
+  pending.clear();
+  for (const cb of cbs) {
+    try {
+      cb();
+    } catch (err) {
+      // One bad callback shouldn't abort the rest. Log and keep flushing.
+      // eslint-disable-next-line no-console
+      console.error('draw-bus callback threw', err);
+    }
+  }
+};
+
+/**
+ * Schedule `cb` to run on the next animation frame. Idempotent — repeated
+ * requests for the same callback within a frame are coalesced. Multiple
+ * distinct callbacks share a single rAF wakeup.
+ */
+export function requestDrawBusFrame(cb: DrawCallback): void {
+  pending.add(cb);
+  if (rafHandle === 0) {
+    rafHandle = requestAnimationFrame(flush);
+  }
+}
+
+/**
+ * Drop a pending request for `cb`. Components MUST call this in their
+ * unmount cleanup so a stale callback (closed over a disposed WebGL
+ * context) doesn't fire after teardown.
+ */
+export function cancelDrawBusFrame(cb: DrawCallback): void {
+  pending.delete(cb);
+}
+
+/**
+ * Test helper — reset the bus between tests. Not exported from a barrel.
+ */
+export function _resetDrawBusForTest(): void {
+  pending.clear();
+  if (rafHandle !== 0) {
+    cancelAnimationFrame(rafHandle);
+    rafHandle = 0;
+  }
+}

--- a/zeus-web/src/realtime/ws-client.ts
+++ b/zeus-web/src/realtime/ws-client.ts
@@ -46,7 +46,7 @@ import { decodeDisplayFrame, FrameDecodeError, MSG_TYPE_DISPLAY_FRAME } from './
 import { AudioFrameDecodeError, MSG_TYPE_AUDIO_PCM, decodeAudioFrame } from '../audio/frame';
 import { getAudioClient } from '../audio/audio-client';
 import { useConnectionStore, type WisdomPhase } from '../state/connection-store';
-import { useDisplayStore } from '../state/display-store';
+import { hasActiveFrameConsumers, useDisplayStore } from '../state/display-store';
 import { useTxStore } from '../state/tx-store';
 import { useBandPlanStore } from '../state/bandPlan';
 import { useRxMetersStore } from '../state/rx-meters-store';
@@ -215,6 +215,14 @@ export function startRealtime(path = '/ws'): () => void {
       try {
         const peekType = new DataView(ev.data).getUint8(0);
         if (peekType === MSG_TYPE_DISPLAY_FRAME) {
+          // Skip the decode + push when no spectrum surface is mounted.
+          // decodeDisplayFrame allocates two Float32Arrays per tick and
+          // pushFrame fans the new state through every store subscriber —
+          // both are wasted when the panadapter, waterfall, and filter
+          // mini-pan are all closed. Consumers register via
+          // registerFrameConsumer() in display-store.ts; the moment any of
+          // them mounts we resume decoding on the next tick.
+          if (!hasActiveFrameConsumers()) return;
           const frame = decodeDisplayFrame(ev.data);
           pushFrame(frame);
           return;

--- a/zeus-web/src/state/display-store.test.ts
+++ b/zeus-web/src/state/display-store.test.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Verifies the active-consumer registry that gates decodeDisplayFrame in
+// ws-client.ts. The contract: hasActiveFrameConsumers() reports whether at
+// least one panadapter / waterfall / filter mini-pan is mounted; ws-client
+// short-circuits the per-frame decode when it returns false.
+
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  _resetFrameConsumerCount,
+  hasActiveFrameConsumers,
+  registerFrameConsumer,
+} from './display-store';
+
+afterEach(() => {
+  _resetFrameConsumerCount();
+});
+
+describe('frame consumer registry', () => {
+  it('reports no consumers initially', () => {
+    expect(hasActiveFrameConsumers()).toBe(false);
+  });
+
+  it('flips to true while a consumer is registered', () => {
+    const release = registerFrameConsumer();
+    expect(hasActiveFrameConsumers()).toBe(true);
+    release();
+    expect(hasActiveFrameConsumers()).toBe(false);
+  });
+
+  it('stays true while at least one consumer remains', () => {
+    const a = registerFrameConsumer();
+    const b = registerFrameConsumer();
+    expect(hasActiveFrameConsumers()).toBe(true);
+    a();
+    expect(hasActiveFrameConsumers()).toBe(true);
+    b();
+    expect(hasActiveFrameConsumers()).toBe(false);
+  });
+
+  it('release is idempotent', () => {
+    const release = registerFrameConsumer();
+    release();
+    release();
+    expect(hasActiveFrameConsumers()).toBe(false);
+    // A second consumer must still flip the flag back on.
+    const next = registerFrameConsumer();
+    expect(hasActiveFrameConsumers()).toBe(true);
+    next();
+  });
+
+  it('count never goes negative under bad release ordering', () => {
+    const a = registerFrameConsumer();
+    a();
+    a();
+    expect(hasActiveFrameConsumers()).toBe(false);
+    const b = registerFrameConsumer();
+    expect(hasActiveFrameConsumers()).toBe(true);
+    b();
+    expect(hasActiveFrameConsumers()).toBe(false);
+  });
+});

--- a/zeus-web/src/state/display-store.ts
+++ b/zeus-web/src/state/display-store.ts
@@ -86,3 +86,40 @@ export const useDisplayStore = create<DisplayState>((set) => ({
 export function subscribeFrames(cb: (s: DisplayState) => void): () => void {
   return useDisplayStore.subscribe(cb);
 }
+
+// Active-consumer registry. The realtime client (ws-client.ts) consults this
+// before invoking decodeDisplayFrame + pushFrame on every spectrum tick. When
+// every spectrum surface (panadapter, waterfall, filter mini-pan) is closed,
+// decoding still happens for a store with no subscribers; the per-frame cost
+// is small but it scales with backend tick rate (~25 Hz) and allocates two
+// Float32Arrays per call. Components register on mount and unregister on
+// unmount; whilever count > 0 we keep decoding, otherwise we short-circuit.
+//
+// Deliberately a module-level counter (not in the store) so toggling consumer
+// presence doesn't itself fan out as a store update through React.
+let frameConsumerCount = 0;
+
+/**
+ * Mark this caller as a live consumer of decoded display frames. Returns a
+ * single-shot unregister function — call it on cleanup. Idempotent if the
+ * returned function is invoked more than once.
+ */
+export function registerFrameConsumer(): () => void {
+  frameConsumerCount++;
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    frameConsumerCount = Math.max(0, frameConsumerCount - 1);
+  };
+}
+
+/** True when at least one consumer is mounted and needs decoded frames. */
+export function hasActiveFrameConsumers(): boolean {
+  return frameConsumerCount > 0;
+}
+
+/** Test-only escape hatch; not part of the public API. */
+export function _resetFrameConsumerCount(): void {
+  frameConsumerCount = 0;
+}

--- a/zeus-web/src/state/layout-store.ts
+++ b/zeus-web/src/state/layout-store.ts
@@ -80,6 +80,16 @@ interface LayoutState {
   addPanelOpen: boolean;
   setAddPanelOpen: (open: boolean) => void;
 
+  // Settings is rendered as a workspace-replacing view (not a popover).
+  // While settingsViewOpen is true the App renders <SettingsView /> in
+  // place of <FlexWorkspace />. settingsInitialTab seeds the active tab
+  // when the view opens (used by hash deeplinks like #qrz, #server).
+  // setActiveLayout(...) clears this so picking a layout returns to the
+  // workspace.
+  settingsViewOpen: boolean;
+  settingsInitialTab?: string;
+  setSettingsView: (open: boolean, tab?: string) => void;
+
   /** Switch the radio key and reload the layouts list from the server.
    *  No-op when the key already matches and isLoaded is true. */
   loadForRadio: (radioKey: string) => Promise<void>;
@@ -163,6 +173,13 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
   isLoaded: false,
   addPanelOpen: false,
   setAddPanelOpen: (open) => set({ addPanelOpen: open }),
+
+  settingsViewOpen: false,
+  setSettingsView: (open, tab) =>
+    set({
+      settingsViewOpen: open,
+      settingsInitialTab: open ? tab : undefined,
+    }),
 
   loadForRadio: async (radioKey) => {
     const safeKey = radioKey || 'default';
@@ -314,6 +331,11 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
     set({
       activeLayoutId: id,
       workspace: parseLayoutOrDefault(target.layoutJson),
+      // Picking a layout always returns to the workspace view — clearing
+      // any active settings overlay keeps the operator's mental model
+      // consistent.
+      settingsViewOpen: false,
+      settingsInitialTab: undefined,
     });
     void postActiveLayout(radioKey, id);
   },

--- a/zeus-web/src/state/rotator-store.ts
+++ b/zeus-web/src/state/rotator-store.ts
@@ -157,11 +157,13 @@ export const useRotatorStore = create<RotatorStoreState>((set) => ({
 }));
 
 // Kick off an initial status probe at module load, then poll at 1 s while the
-// page is alive. When rotctld is enabled and connected, this keeps the pill's
-// current-az readout in sync without the UI having to subscribe to a WS stream.
+// page is alive AND rotctld is enabled. When disabled there's nothing to
+// reconcile — skip the fetch to avoid an idle-RX HTTP wakeup the user can't
+// see anyway.
 if (typeof window !== 'undefined') {
   void useRotatorStore.getState().refreshStatus();
   window.setInterval(() => {
+    if (!useRotatorStore.getState().config.enabled) return;
     void useRotatorStore.getState().refreshStatus();
   }, 1000);
 

--- a/zeus-web/src/state/tci-store.ts
+++ b/zeus-web/src/state/tci-store.ts
@@ -92,11 +92,14 @@ export const useTciStore = create<TciStoreState>((set, get) => ({
   },
 }));
 
-// Initial status probe at module load + 2 s polling while the page is alive.
-// Status changes drive the panel's RequiresRestart flag and client count.
+// Initial status probe at module load + 2 s polling while the page is alive
+// AND TCI is enabled. Status changes drive the panel's RequiresRestart flag
+// and client count — neither matters when the listener isn't running, so skip
+// the fetch in the disabled-default case.
 if (typeof window !== 'undefined') {
   void useTciStore.getState().refreshStatus();
   window.setInterval(() => {
+    if (!useTciStore.getState().config.enabled) return;
     void useTciStore.getState().refreshStatus();
   }, 2000);
 }

--- a/zeus-web/src/styles/all-panels.css
+++ b/zeus-web/src/styles/all-panels.css
@@ -34,22 +34,33 @@
   position: relative;
 }
 
-/* Each grid item — a workspace tile wrapper. Snappy transitions on
- * place/resize so drags read crisply. */
+/* Each grid item — a workspace tile wrapper. The upstream
+ * react-grid-layout/css/styles.css sets `will-change: transform` and
+ * `transition: all 200ms ease` on .react-grid-item, which permanently
+ * promotes every tile to its own GPU compositor layer. With a WebGL
+ * panadapter inside that subtree, every frame triggers a layer
+ * re-composite up to the root — visible on macOS as WindowServer +
+ * Chrome GPU pinning. We override both: only promote / animate while
+ * the operator is actively dragging or resizing. */
 .all-panels-grid .react-grid-item {
   background: transparent;
-  transition: transform var(--dur-fast) var(--ease-out),
-    width var(--dur-fast) var(--ease-out),
-    height var(--dur-fast) var(--ease-out);
+  will-change: auto;
+  transition: none;
 }
 
 /* Item being dragged / resized — RGL adds .react-draggable-dragging or
  * .resizing while the operator's pointer is live. Lift z so the drag
- * preview doesn't disappear under siblings. */
+ * preview doesn't disappear under siblings, and re-enable the snappy
+ * transform/size transitions + GPU promotion only for the duration of
+ * the gesture. */
 .all-panels-grid .react-grid-item.react-draggable-dragging,
 .all-panels-grid .react-grid-item.resizing {
   z-index: 4;
   opacity: 0.92;
+  will-change: transform;
+  transition: transform var(--dur-fast) var(--ease-out),
+    width var(--dur-fast) var(--ease-out),
+    height var(--dur-fast) var(--ease-out);
 }
 
 /* Drop placeholder — accent-blue ghost where the dragged tile will land. */

--- a/zeus-web/src/styles/all-panels.css
+++ b/zeus-web/src/styles/all-panels.css
@@ -138,7 +138,7 @@
   align-items: center;
   gap: 6px;
   padding: 0 8px;
-  background: linear-gradient(180deg, var(--panel-head-top, var(--panel-top)), var(--panel-head-bot, var(--panel-bot)));
+  background: linear-gradient(90deg, var(--panel-head-top, var(--panel-top)), var(--panel-head-bot, var(--panel-bot)));
   border-bottom: 1px solid var(--panel-border);
   /* Whole header is the drag handle (RGL dragConfig.handle). Show grab
    * cursor across the full width so the operator knows it's draggable —
@@ -273,7 +273,7 @@
   justify-content: space-between;
   padding: 12px 16px;
   border-bottom: 1px solid var(--panel-border);
-  background: linear-gradient(180deg, var(--panel-head-top, var(--panel-top)), var(--panel-head-bot, var(--panel-bot)));
+  background: linear-gradient(90deg, var(--panel-head-top, var(--panel-top)), var(--panel-head-bot, var(--panel-bot)));
 }
 .add-panel-modal-header h2 {
   margin: 0;

--- a/zeus-web/src/styles/analog-meter.css
+++ b/zeus-web/src/styles/analog-meter.css
@@ -327,7 +327,7 @@
   width: 100%;
   height: 4px;
   background: var(--bg-2);
-  border-radius: 2px;
+  border-radius: 0;
   outline: none;
   border: 1px solid var(--panel-edge);
 }

--- a/zeus-web/src/styles/filter-ribbon.css
+++ b/zeus-web/src/styles/filter-ribbon.css
@@ -25,7 +25,7 @@
   color: #edeef1;
   font-family: inherit;
   min-height: 0;
-  border-radius: 10px;
+  border-radius: 0;
   padding: 10px 12px 8px 12px;
   border: 1px solid rgba(255, 255, 255, 0.05);
   background: linear-gradient(180deg, #26292f 0%, #1e2025 100%);
@@ -50,7 +50,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 3px;
+  border-radius: 0;
 }
 .filter-ribbon__close:hover { color: #edeef1; background: rgba(255, 255, 255, 0.04); }
 
@@ -139,7 +139,7 @@
   flex: 1 1 auto;
   min-height: 102px;
   height: 122px;
-  border-radius: 4px;
+  border-radius: 0;
   overflow: hidden;
 }
 
@@ -157,7 +157,7 @@
 .filter-ribbon__presets {
   background: #2a2d33;
   border: 1px solid rgba(255, 255, 255, 0.05);
-  border-radius: 8px;
+  border-radius: 0;
   padding: 8px 8px 7px;
   display: flex;
   flex-direction: column;
@@ -202,7 +202,7 @@
   background: linear-gradient(180deg, #1f2126 0%, #1a1c20 100%);
   color: #edeef1;
   border: 1px solid #3a3e45;
-  border-radius: 3px;
+  border-radius: 0;
   font-variant-numeric: tabular-nums;
   outline: none;
 }
@@ -241,7 +241,7 @@
   border: 1px solid #4a4e55;
   border-top-color: #585c63;
   border-bottom-color: #32353b;
-  border-radius: 4px;
+  border-radius: 0;
   cursor: pointer;
   font-variant-numeric: tabular-nums;
   transition: border-color 120ms ease, filter 120ms ease, color 120ms ease;
@@ -300,7 +300,7 @@
   font-size: clamp(10px, 0.1vw + 9.5px, 12px);
   font-weight: 600;
   letter-spacing: 0.18em;
-  border-radius: 4px;
+  border-radius: 0;
   color: #e0e2e6;
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.10) 0%, rgba(255, 255, 255, 0) 45%, rgba(0, 0, 0, 0.12) 100%),

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -338,7 +338,7 @@
   height: 44px;
   padding: 0 14px;
   background: linear-gradient(
-    180deg,
+    90deg,
     var(--panel-head-top),
     var(--panel-head-bot)
   );
@@ -441,7 +441,7 @@
   align-items: center;
   gap: 10px;
   padding: 0 10px;
-  background: linear-gradient(180deg, var(--panel-top), var(--panel-bot));
+  background: linear-gradient(90deg, var(--panel-top), var(--panel-bot));
   border: 1px solid var(--panel-edge);
   border-radius: var(--r-lg);
   box-shadow: var(--panel-shadow);
@@ -548,7 +548,7 @@
   display: flex;
   gap: 12px;
   padding: 4px 10px;
-  background: linear-gradient(180deg, var(--panel-top), var(--panel-bot));
+  background: linear-gradient(90deg, var(--panel-top), var(--panel-bot));
   border: 1px solid var(--panel-edge);
   border-radius: var(--r-lg);
   box-shadow: var(--panel-shadow);
@@ -757,7 +757,7 @@
   align-items: center;
   gap: 6px;
   padding: 5px 10px;
-  background: linear-gradient(180deg, var(--panel-head-top), var(--panel-head-bot));
+  background: linear-gradient(90deg, var(--panel-head-top), var(--panel-head-bot));
   border-bottom: 1px solid var(--panel-border);
   box-shadow: inset 0 1px 0 rgba(255,255,255,0.08);
   min-height: 28px;
@@ -1096,7 +1096,7 @@
   color: #e0e8f5;
   padding: 2px 8px;
   background: rgba(0,0,0,0.55);
-  border-radius: 2px;
+  border-radius: 0;
   text-shadow: 0 1px 0 #000;
 }
 .spec-label.center { color: var(--tx); background: rgba(0,0,0,0.75); font-weight: 700; }
@@ -1178,7 +1178,7 @@
   height: 10px;
   background: #000;
   border: 1px solid rgba(0,0,0,0.8);
-  border-radius: 2px;
+  border-radius: 0;
   box-shadow: inset 0 1px 2px rgba(0,0,0,0.8);
   overflow: hidden;
 }
@@ -1204,7 +1204,7 @@
   padding: 6px;
   background: #000;
   border: 1px solid rgba(0,0,0,0.8);
-  border-radius: 3px;
+  border-radius: 0;
   box-shadow: inset 0 1px 3px rgba(0,0,0,0.8);
 }
 .smeter-s {
@@ -1219,7 +1219,7 @@
   width: 100%;
   height: 24%;
   background: #1a3050;
-  border-radius: 1px;
+  border-radius: 0;
   transition: background var(--dur-fast), box-shadow var(--dur-fast);
 }
 .smeter-s:nth-child(2) .smeter-bar { height: 34%; }
@@ -1338,7 +1338,7 @@
   width: 90px;
   background: #0a1220;
   border: 1px solid #000;
-  border-radius: 3px;
+  border-radius: 0;
   padding: 3px 8px;
   font-size: 12px;
   font-weight: 700;
@@ -1361,7 +1361,7 @@
   color: var(--fg-2);
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  background: linear-gradient(180deg, var(--panel-top), color-mix(in srgb, var(--panel-top) 60%, var(--panel-bot)));
+  background: linear-gradient(90deg, var(--panel-top), color-mix(in srgb, var(--panel-top) 60%, var(--panel-bot)));
   border-bottom: 1px solid rgba(0,0,0,0.4);
   box-shadow: inset 0 1px 0 rgba(255,255,255,0.08);
 }
@@ -1392,7 +1392,7 @@
   align-items: center;
   gap: 8px;
   border-top: 1px solid rgba(0,0,0,0.4);
-  background: linear-gradient(180deg, color-mix(in srgb, var(--panel-top) 60%, var(--panel-bot)), var(--panel-bot));
+  background: linear-gradient(90deg, color-mix(in srgb, var(--panel-top) 60%, var(--panel-bot)), var(--panel-bot));
 }
 
 /* ===== Memory ===== */
@@ -1435,14 +1435,14 @@
   height: 8px;
   background: #000;
   border: 1px solid rgba(0,0,0,0.6);
-  border-radius: 4px;
+  border-radius: 0;
   cursor: pointer;
   box-shadow: inset 0 1px 2px rgba(0,0,0,0.7);
 }
 .slider-fill {
   position: absolute; inset: 0 auto 0 0;
   background: linear-gradient(90deg, var(--accent), color-mix(in srgb, var(--accent) 70%, white));
-  border-radius: 4px 0 0 4px;
+  border-radius: 0;
 }
 .slider-thumb {
   position: absolute;
@@ -1451,7 +1451,7 @@
   width: 14px; height: 16px;
   background: linear-gradient(180deg, #c0cbd9, #7a8698);
   border: 1px solid #000;
-  border-radius: 2px;
+  border-radius: 0;
   box-shadow: inset 0 1px 0 rgba(255,255,255,0.6), 0 1px 2px rgba(0,0,0,0.6);
 }
 
@@ -1462,7 +1462,7 @@
   padding: 8px 10px;
   background: #000;
   border: 1px solid rgba(0,0,0,0.8);
-  border-radius: 3px;
+  border-radius: 0;
   font-size: 14px;
   color: var(--accent);
   letter-spacing: 0.2em;
@@ -1482,11 +1482,47 @@
   align-items: center;
   gap: 6px;
   padding: 0 10px;
-  background: linear-gradient(180deg, var(--panel-top), var(--panel-bot));
+  background: linear-gradient(90deg, var(--panel-top), var(--panel-bot));
   border: 1px solid var(--panel-edge);
   border-radius: var(--r-lg);
   box-shadow: var(--panel-shadow);
   height: 44px;
+}
+/* Transport buttons read as flat clickable regions of the toolbar, not raised
+   chiclets. TX (MOX-on) is excluded — it keeps its red bevel/pulse for safety. */
+.transport .btn {
+  background: transparent;
+  border: 1px solid transparent;
+  box-shadow: none;
+  text-shadow: none;
+  color: var(--fg-1);
+}
+.transport .btn:hover {
+  background: rgba(255,255,255,0.06);
+  filter: none;
+}
+.transport .btn:active,
+.transport .btn.pressed {
+  background: rgba(0,0,0,0.28);
+  box-shadow: inset 0 1px 2px rgba(0,0,0,0.4);
+  transform: none;
+}
+.transport .btn.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-color: rgba(74,158,255,0.35);
+  text-shadow: none;
+}
+.transport .btn.ghost {
+  background: transparent;
+}
+.transport .btn.ghost:hover { background: rgba(255,255,255,0.06); }
+/* Restore TX styling for MOX-on state — must remain visually loud. */
+.transport .btn.tx {
+  background: linear-gradient(180deg, var(--btn-top-c), var(--btn-bot-c));
+  border: 1px solid var(--btn-edge);
+  color: #ffd4d0;
+  text-shadow: 0 0 6px rgba(230,58,43,0.8);
 }
 .tx-btn { font-size: 14px; font-weight: 700; letter-spacing: 0.12em; min-width: 80px; }
 .tx-btn.tx {
@@ -1565,7 +1601,7 @@
 }
 .variant-card:hover { filter: brightness(1.1); }
 .variant-card.active { border-color: var(--accent); box-shadow: inset 0 1px 0 rgba(255,255,255,0.05), 0 0 8px var(--accent-soft); }
-.variant-swatch { display: flex; height: 20px; border-radius: 2px; overflow: hidden; border: 1px solid #000; }
+.variant-swatch { display: flex; height: 20px; border-radius: 0; overflow: hidden; border: 1px solid #000; }
 .variant-swatch .sw { flex: 1; }
 .variant-card[data-variant="console"] .sw.bg0 { background: #0f1a2e; }
 .variant-card[data-variant="console"] .sw.bg1 { background: #2d3e5a; }
@@ -1620,7 +1656,7 @@
   padding: 1px 6px;
   background: linear-gradient(180deg, var(--btn-top), var(--btn-bot));
   border: 1px solid #000;
-  border-radius: 2px;
+  border-radius: 0;
   font-size: 10px;
   font-weight: 700;
   margin-right: 6px;

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -35,6 +35,7 @@
 .app > .topbar            { grid-column: 2; grid-row: 1; }
 .app > .alert-banner      { grid-column: 2; grid-row: 2; }
 .app > .flex-workspace    { grid-column: 2; grid-row: 3; min-height: 0; overflow: auto; }
+.app > .settings-view     { grid-column: 2; grid-row: 3; min-height: 0; overflow: hidden; }
 .app > .transport         { grid-column: 2; grid-row: 4; }
 
 /* ===== Left layout bar — issue #241 ===== */
@@ -259,17 +260,176 @@
   color: var(--tx);
   border-color: var(--tx);
 }
-.left-layout-bar .lb-actions {
+/* Placeholder add-layout slot — sits at the end of the layout list and
+   uses the same .lb-tab footprint so it reads as the next layout-to-be
+   rather than a separate "action" button. Dashed border + reduced
+   opacity tell the eye it's a slot, not a real layout. */
+.left-layout-bar .lb-item-add { opacity: 0.85; }
+.left-layout-bar .lb-tab-add {
+  background: transparent;
+  border: 1px dashed var(--btn-edge);
+  color: var(--fg-2);
+  box-shadow: none;
+}
+.left-layout-bar .lb-tab-add:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: rgba(255, 255, 255, 0.02);
+  filter: none;
+}
+.left-layout-bar .lb-tab-add .lb-tab-icon-fallback {
+  border-color: currentColor;
+  font-weight: 700;
+  opacity: 1;
+}
+
+/* Horizontal spacer between the layout list and the bottom Settings slot.
+   Reuses the bar's existing tinted shadow vocabulary so it doesn't read as
+   foreign chrome. */
+.left-layout-bar .lb-divider {
+  flex: 0 0 auto;
+  height: 1px;
+  margin: 6px 2px 4px;
+  background: linear-gradient(
+    to right,
+    transparent,
+    rgba(255, 255, 255, 0.18),
+    transparent
+  );
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.55);
+}
+
+/* Bottom-pinned settings slot. Uses the same .lb-tab visual vocabulary so
+   the gear reads as a sibling of the layout tabs, not an outside action.
+   .active fires while the SettingsView is showing (settingsViewOpen). */
+.left-layout-bar .lb-settings-slot {
+  flex: 0 0 auto;
+  display: flex;
+}
+.left-layout-bar .lb-tab-settings {
+  flex: 1;
+}
+.left-layout-bar .lb-tab-settings.active {
+  border-color: var(--accent);
+  color: var(--accent);
+  box-shadow: inset 0 1px 0 var(--btn-hl), 0 0 8px var(--accent-soft);
+}
+
+/* ===== Settings view — workspace-replacing pane =====
+   Renders in the same grid cell as .flex-workspace when
+   layout-store.settingsViewOpen is true. Uses the same panel chrome as
+   the rest of the app (panel-top/bot gradient, panel-edge border) so it
+   reads as part of the workspace, not a foreign overlay. */
+.settings-view {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  background: var(--bg-1);
+  border: 1px solid var(--panel-edge);
+  border-radius: var(--r-lg);
+  box-shadow: var(--panel-shadow);
+  color: var(--fg-1);
+  overflow: hidden;
+  min-height: 0;
+}
+.settings-view-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 44px;
+  padding: 0 14px;
+  background: linear-gradient(
+    180deg,
+    var(--panel-head-top),
+    var(--panel-head-bot)
+  );
+  border-bottom: 1px solid var(--panel-border);
+  box-shadow: inset 0 1px 0 var(--panel-hl-top);
   flex: 0 0 auto;
 }
-.left-layout-bar .lb-action {
-  width: 100%;
-  padding: 6px 0;
-  font-size: 14px;
+.settings-view-title {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  color: var(--fg-0);
+  text-transform: uppercase;
+}
+.settings-view-close {
+  width: 26px;
+  height: 26px;
+  border-radius: var(--r-sm);
+  color: var(--fg-2);
+  font-size: 18px;
   line-height: 1;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: background var(--dur-fast), color var(--dur-fast);
+}
+.settings-view-close:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--fg-0);
+}
+.settings-view-body {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+.settings-view-tabs {
+  width: 200px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 8px;
+  background: var(--bg-0);
+  border-right: 1px solid var(--panel-border);
+  overflow-y: auto;
+}
+.settings-view-tab {
+  text-align: left;
+  padding: 10px 14px;
+  border-radius: var(--r-sm);
+  border: none;
+  border-left: 2px solid transparent;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--fg-2);
+  background: transparent;
+  cursor: pointer;
+  transition: background var(--dur-fast), color var(--dur-fast);
+}
+.settings-view-tab:hover {
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--fg-1);
+}
+.settings-view-tab.active {
+  color: var(--fg-0);
+  background: var(--bg-2);
+  border-left-color: var(--accent);
+}
+.settings-view-panel {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: auto;
+  padding: 18px 22px;
+  background: var(--bg-1);
+  color: var(--fg-1);
+  font-size: 12px;
+  display: flex;
+  flex-direction: column;
+}
+.settings-view-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  padding: 10px 14px;
+  background: var(--bg-0);
+  border-top: 1px solid var(--panel-border);
+  flex: 0 0 auto;
 }
 
 /* ===== Top bar — issue #241 =====

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -22,7 +22,7 @@
 .app {
   display: grid;
   grid-template-columns: 60px 1fr;
-  grid-template-rows: 68px auto 1fr 44px;
+  grid-template-rows: 56px 1fr 44px;
   height: 100vh;
   width: 100vw;
   background: var(--bg-0);
@@ -33,10 +33,21 @@
 
 .app > .left-layout-bar   { grid-column: 1; grid-row: 1 / -1; }
 .app > .topbar            { grid-column: 2; grid-row: 1; }
-.app > .alert-banner      { grid-column: 2; grid-row: 2; }
-.app > .flex-workspace    { grid-column: 2; grid-row: 3; min-height: 0; overflow: auto; }
-.app > .settings-view     { grid-column: 2; grid-row: 3; min-height: 0; overflow: hidden; }
-.app > .transport         { grid-column: 2; grid-row: 4; }
+.app > .workspace-area    { grid-column: 2; grid-row: 2; min-height: 0; }
+.app > .transport         { grid-column: 2; grid-row: 3; }
+
+/* Workspace area — flex column owning the alert banner + the active
+   layout (or settings view). The empty alert banner returns a 0-height
+   placeholder, so with no flex gap the topbar→first-panel distance is
+   exactly the .app grid gap (6px), matching the inter-panel gap. */
+.workspace-area {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.workspace-area > .alert-banner { flex: 0 0 auto; }
+.workspace-area > .flex-workspace,
+.workspace-area > .settings-view { flex: 1; min-height: 0; }
 
 /* ===== Left layout bar — issue #241 ===== */
 .left-layout-bar {
@@ -445,7 +456,7 @@
   border: 1px solid var(--panel-edge);
   border-radius: var(--r-lg);
   box-shadow: var(--panel-shadow);
-  height: 68px;
+  height: 56px;
   overflow: hidden;
 }
 .topbar .topbar-controls {
@@ -458,6 +469,44 @@
      it from spilling into the workspace below. */
   overflow-x: auto;
   scrollbar-width: thin;
+}
+/* Topbar buttons read as flat regions of the bar, not raised chiclets.
+   The .ctrl-lbl above each .btn-row remains the visual anchor for the
+   group, so we lean on the label + .strip-divider for grouping rather
+   than per-button bevels. */
+.topbar .btn {
+  background: transparent;
+  border: 1px solid transparent;
+  box-shadow: none;
+  text-shadow: none;
+  color: var(--fg-1);
+}
+.topbar .btn:hover {
+  background: rgba(255,255,255,0.06);
+  filter: none;
+}
+.topbar .btn:active,
+.topbar .btn.pressed {
+  background: rgba(0,0,0,0.28);
+  box-shadow: inset 0 1px 2px rgba(0,0,0,0.4);
+  transform: none;
+}
+.topbar .btn.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-color: rgba(74,158,255,0.35);
+  text-shadow: none;
+}
+.topbar .btn.ghost { background: transparent; }
+.topbar .btn.ghost:hover { background: rgba(255,255,255,0.06); }
+/* Lift the group label slightly so it carries the grouping role that
+   button bevels used to. */
+.topbar .ctrl-group { gap: 2px; }
+.topbar .ctrl-lbl {
+  color: var(--fg-1);
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  opacity: 0.75;
 }
 .brand {
   display: flex;

--- a/zeus-web/src/styles/meters-grid.css
+++ b/zeus-web/src/styles/meters-grid.css
@@ -12,13 +12,16 @@
   background: transparent;
 }
 
-/* Each grid item — frame around an individual MeterWidget. */
+/* Each grid item — frame around an individual MeterWidget.
+ * Override upstream RGL defaults that permanently promote every tile to
+ * a GPU compositor layer (`will-change: transform`) and run a 200 ms
+ * transition on every property — both compound badly with canvas-heavy
+ * children. We re-enable both only while the operator is dragging /
+ * resizing. */
 .meters-grid .react-grid-item {
   background: transparent;
-  /* RGL hides items via top/left transitions; keep them snappy. */
-  transition: transform var(--dur-fast) var(--ease-out),
-    width var(--dur-fast) var(--ease-out),
-    height var(--dur-fast) var(--ease-out);
+  will-change: auto;
+  transition: none;
 }
 
 /* Hover affordance — soft outline so the operator sees the cell bounds
@@ -32,12 +35,20 @@
   z-index: 4;
   cursor: grabbing;
   opacity: 0.9;
+  will-change: transform;
+  transition: transform var(--dur-fast) var(--ease-out),
+    width var(--dur-fast) var(--ease-out),
+    height var(--dur-fast) var(--ease-out);
 }
 
 /* Item being resized. */
 .meters-grid .react-grid-item.resizing {
   z-index: 4;
   opacity: 0.9;
+  will-change: transform;
+  transition: transform var(--dur-fast) var(--ease-out),
+    width var(--dur-fast) var(--ease-out),
+    height var(--dur-fast) var(--ease-out);
 }
 
 /* Drop placeholder — the dotted ghost RGL renders where the item will land. */

--- a/zeus-web/src/styles/pa-settings.css
+++ b/zeus-web/src/styles/pa-settings.css
@@ -102,7 +102,7 @@
   height: 8px;
   background: var(--bg-2);
   border: 1px solid var(--panel-edge);
-  border-radius: 4px;
+  border-radius: 0;
   overflow: hidden;
   box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.30);
   min-width: 60px;

--- a/zeus-web/src/styles/ps-settings.css
+++ b/zeus-web/src/styles/ps-settings.css
@@ -352,7 +352,7 @@
 }
 .ps-peak .ps-meter {
   height: 6px;
-  border-radius: 3px;
+  border-radius: 0;
   background: var(--meter-bg);
   overflow: hidden;
   border: 1px solid var(--panel-border);
@@ -944,7 +944,7 @@
 .ps-popover-meter {
   position: relative;
   height: 5px;
-  border-radius: 3px;
+  border-radius: 0;
   background: var(--meter-bg);
   border: 1px solid var(--panel-border);
   overflow: hidden;

--- a/zeus-web/src/styles/tokens.css
+++ b/zeus-web/src/styles/tokens.css
@@ -73,10 +73,11 @@
   --font-display: 'Archivo Narrow', sans-serif;
 
   /* ----- Spacing / radius ----- */
-  --r-xs: 2px;
-  --r-sm: 3px;
-  --r-md: 4px;
-  --r-lg: 6px;
+  /* Square-edge experiment: all corner radii flattened. */
+  --r-xs: 0;
+  --r-sm: 0;
+  --r-md: 0;
+  --r-lg: 0;
 
   /* ----- Easing ----- */
   --ease-out: cubic-bezier(.22,.61,.36,1);

--- a/zeus-web/src/styles/toolbar-favorites.css
+++ b/zeus-web/src/styles/toolbar-favorites.css
@@ -37,7 +37,7 @@
   min-width: 240px;
   max-width: 360px;
   padding: 8px 10px 10px 10px;
-  border-radius: 10px;
+  border-radius: 0;
   border: 1px solid rgba(255, 255, 255, 0.06);
   background: linear-gradient(180deg, #26292f 0%, #1e2025 100%);
   box-shadow:
@@ -77,7 +77,7 @@
   border: 1px solid #4a4e55;
   border-top-color: #585c63;
   border-bottom-color: #32353b;
-  border-radius: 4px;
+  border-radius: 0;
   cursor: grab;
   font-variant-numeric: tabular-nums;
   transition: border-color 120ms ease, filter 120ms ease, color 120ms ease;

--- a/zeus-web/vite.config.ts
+++ b/zeus-web/vite.config.ts
@@ -48,6 +48,7 @@ import tailwindcss from '@tailwindcss/vite';
 import { VitePWA } from 'vite-plugin-pwa';
 
 const backendPort = process.env.BACKEND_PORT || '6060';
+const backendHost = process.env.BACKEND_HOST || 'localhost';
 
 export default defineConfig({
   plugins: [
@@ -100,8 +101,8 @@ export default defineConfig({
     port: 5173,
     allowedHosts: ['.ngrok-free.app', '.ngrok-free.dev', '.ngrok.app', '.ngrok.dev', '.ngrok.io'],
     proxy: {
-      '/api': `http://localhost:${backendPort}`,
-      '/ws': { target: `ws://localhost:${backendPort}`, ws: true },
+      '/api': `http://${backendHost}:${backendPort}`,
+      '/ws': { target: `ws://${backendHost}:${backendPort}`, ws: true },
     },
   },
   build: {


### PR DESCRIPTION
## Summary
38 commits on develop ahead of main. Bundles the last several merged feature/perf branches into a release-style merge.

### Performance
- **perf2 / PR #273** — cut idle-RX frontend CPU ~22% via REST poll + mic-meter throttle.
- **perf3 / PR #275** — backend allocation cuts (-36%) + frontend rAF coalesce (panadapter + waterfall on a single rAF, ArrayPool returns, broadcast copy elision, display-frame decode skipped when no consumer).
- **performance-rgl / PR #271** — RGL + WebGL compositor overhead reduction; selective store subs; visibility-gated meter rAF; clamp DPR on waterfall.

### Fixes
- **firefox mic / PR #269** — widen mic-uplink AudioWorklet buffer to absorb Firefox renderer bursts.
- **windows-arm / PR #267** — static-CRT wdsp.dll for win-arm64 + CI fixes (cmake args splat, vcpkg triplet derivation inline).

### Layout / UX
- **settings-view-inline / PR #272** — inline SettingsView + rework LeftLayoutBar slots.
- **flat-chrome / PR #276** — square corners, horizontal panel-head/toolbar gradients, flat topbar + transport buttons, panels flush with header/footer edges.

### Docs
- perf2 + perf3 investigation logs + sample-series table.

## Test plan
- [x] feature branches each green on their own merge into develop
- [x] PR #276 (most recent): 209/209 frontend tests passing, dotnet build clean
- [ ] CI on this PR (Ubuntu, Windows, macOS, Android APK)
- [ ] Smoke-test on HL2 hardware before tagging a release

## Notes
- Previous develop → main (PR #199) was reverted by #200. Surfacing that history; proceed at maintainer discretion. No version bump in this PR — release branch / tagging left for a follow-up if desired.