### PR TITLE
refactor(s-meter): drop configurable S-unit dial selector

### DIFF
--- a/zeus-web/src/components/analog-meter/AnalogMeterConfig.tsx
+++ b/zeus-web/src/components/analog-meter/AnalogMeterConfig.tsx
@@ -8,7 +8,7 @@
 // (attack/decay/avg/peak hold). All controls drive the persisted
 // useAnalogMeterStore — operator changes survive a reload.
 
-import { ALL_S_TICKS, useAnalogMeterStore } from './analogMeterStore';
+import { useAnalogMeterStore } from './analogMeterStore';
 
 interface SliderProps {
   label: string;
@@ -79,8 +79,6 @@ function Pill({ on, onClick, children }: PillProps) {
   );
 }
 
-const labelForS = (v: number): string => (v <= 9 ? `S${v}` : `+${(v - 9) * 10}`);
-
 interface AnalogMeterConfigProps {
   open: boolean;
   onClose: () => void;
@@ -111,20 +109,6 @@ export function AnalogMeterConfig({ open, onClose }: AnalogMeterConfigProps) {
             </CheckRow>
           </header>
           <div className="am-cf-body">
-            <div className="am-cf-sublbl">S-units shown on dial</div>
-            <div className="am-tickgrid">
-              {ALL_S_TICKS.map((v) => (
-                <button
-                  type="button"
-                  key={v}
-                  className={`am-tick ${cfg.sTicks.includes(v) ? 'on' : ''}`}
-                  onClick={() => cfg.toggleSTick(v)}
-                  disabled={!cfg.scaleS}
-                >
-                  {labelForS(v)}
-                </button>
-              ))}
-            </div>
             <CheckRow
               checked={cfg.showDbm}
               onChange={cfg.setShowDbm}

--- a/zeus-web/src/components/analog-meter/AnalogMeterPanel.tsx
+++ b/zeus-web/src/components/analog-meter/AnalogMeterPanel.tsx
@@ -190,14 +190,6 @@ export function AnalogMeterPanel({ onClose }: AnalogMeterPanelProps = {}) {
     return 'po';
   }, [mode, enabled.s, enabled.po, enabled.swr]);
 
-  // Filtered S-tick subset rendered onto the dial (operator-selectable).
-  const customSScale = useMemo(() => {
-    return {
-      ...S_SCALE,
-      ticks: S_SCALE.ticks.filter((t) => cfg.sTicks.includes(t.v)),
-    };
-  }, [cfg.sTicks]);
-
   // PO arc full-scale is derived from the rated PA power configured in the
   // main PA Settings panel: max(10 W, 120% of rated). A 5 W HL2 → 10 W scale,
   // a 100 W rig → 120 W scale. When the operator hasn't configured a rated
@@ -217,10 +209,10 @@ export function AnalogMeterPanel({ onClose }: AnalogMeterPanelProps = {}) {
   }, [poMax]);
 
   const activeScale = useMemo(() => {
-    if (activeScaleId === 's') return customSScale;
+    if (activeScaleId === 's') return S_SCALE;
     if (activeScaleId === 'po') return dynamicPoScale;
     return SWR_SCALE;
-  }, [activeScaleId, customSScale, dynamicPoScale]);
+  }, [activeScaleId, dynamicPoScale]);
 
   // Ballistics state. Stored in a ref so the rAF loop can mutate without
   // triggering renders; `tick` is the only state we touch from the loop.
@@ -342,12 +334,10 @@ export function AnalogMeterPanel({ onClose }: AnalogMeterPanelProps = {}) {
     };
   }, [activeScaleId, activeScale, cfg.attack, cfg.decay, cfg.peakHold]);
 
-  // The face needs the operator-filtered S-arc; we override SCALES.s for the
-  // duration of this render via a wrapper that hands AnalogMeterFace the
-  // same object shape.
+  // PO arc tracks rated PA power dynamically; S/SWR are static.
   const scalesForFace = useMemo(
-    () => ({ s: customSScale, po: dynamicPoScale, swr: SWR_SCALE }),
-    [customSScale, dynamicPoScale],
+    () => ({ s: S_SCALE, po: dynamicPoScale, swr: SWR_SCALE }),
+    [dynamicPoScale],
   );
 
   // Convert needle position back to scale value for the readout.

--- a/zeus-web/src/components/analog-meter/analogMeterShared.ts
+++ b/zeus-web/src/components/analog-meter/analogMeterShared.ts
@@ -73,7 +73,6 @@ export const S_SCALE: ScaleDef = {
     { v: 3, label: '3', major: true },
     { v: 5, label: '5', major: true },
     { v: 7, label: '7', major: true },
-    { v: 8, label: '8', major: false },
     { v: 9, label: '9', major: true },
     { v: 11, label: '+20', major: true, plus: true },
     { v: 13, label: '+40', major: true, plus: true },

--- a/zeus-web/src/components/analog-meter/analogMeterStore.ts
+++ b/zeus-web/src/components/analog-meter/analogMeterStore.ts
@@ -16,8 +16,6 @@ export interface AnalogMeterConfig {
   scaleS: boolean;
   scalePo: boolean;
   scaleSwr: boolean;
-  /** Subset of [1,3,5,7,8,9,11,13,15] — labels rendered on the S arc. */
-  sTicks: number[];
   showDbm: boolean;
   /** SWR threshold above which the readout switches to --tx. */
   swrAlarm: number;
@@ -35,7 +33,6 @@ export interface AnalogMeterConfig {
 
 export interface AnalogMeterState extends AnalogMeterConfig {
   setScale: (id: 's' | 'po' | 'swr', on: boolean) => void;
-  toggleSTick: (v: number) => void;
   setShowDbm: (on: boolean) => void;
   setSwrAlarm: (r: number) => void;
   setAttack: (s: number) => void;
@@ -46,14 +43,10 @@ export interface AnalogMeterState extends AnalogMeterConfig {
   resetBallistics: () => void;
 }
 
-export const ALL_S_TICKS: ReadonlyArray<number> = [1, 3, 5, 7, 8, 9, 11, 13, 15];
-
 export const ANALOG_METER_DEFAULTS: AnalogMeterConfig = {
   scaleS: true,
   scalePo: true,
   scaleSwr: true,
-  // S8 omitted by default to match real moving-coil meters.
-  sTicks: [1, 3, 5, 7, 9, 11, 13, 15],
   showDbm: true,
   swrAlarm: 3.0,
   attack: 0.05,
@@ -73,12 +66,6 @@ export const useAnalogMeterStore = create<AnalogMeterState>()(
           if (id === 'po') return { ...s, scalePo: on };
           return { ...s, scaleSwr: on };
         }),
-      toggleSTick: (v) =>
-        set((s) => ({
-          sTicks: s.sTicks.includes(v)
-            ? s.sTicks.filter((x) => x !== v)
-            : [...s.sTicks, v].sort((a, b) => a - b),
-        })),
       setShowDbm: (on) => set({ showDbm: on }),
       setSwrAlarm: (r) => set({ swrAlarm: Math.max(1.5, Math.min(5, r)) }),
       setAttack: (s) => set({ attack: Math.max(0.005, Math.min(0.5, s)) }),


### PR DESCRIPTION
## Summary
- Remove the "S-units shown on dial" tick grid from the S-meter config flyout — the dial now always renders the canonical default ticks: S1, S3, S5, S7, S9, +20, +40, +60.
- Drop the persisted `sTicks` / `toggleSTick` from `useAnalogMeterStore` and the `ALL_S_TICKS` export.
- Remove S8 from `S_SCALE.ticks` (it was only present as an opt-in tick) and collapse the `customSScale` memo onto `S_SCALE` in `AnalogMeterPanel`.

## Test plan
- [ ] Open the S-meter settings flyout — RX section now shows only Show S-meter / Show dBm / Zeus mode (no tick grid).
- [ ] Confirm the analog dial renders S1 / S3 / S5 / S7 / S9 / +20 / +40 / +60 (no S8).
- [ ] Existing operators with a persisted `sTicks` value in localStorage still see a working dial (zustand persist ignores unknown keys on rehydrate).