### PR TITLE
chore: bump version to 0.7.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,8 +8,8 @@
     <!-- Version Management -->
     <!-- When building from a tag (e.g., v0.1.0), GITHUB_REF_NAME will be set -->
     <!-- Otherwise, fall back to the in-development VersionPrefix below.    -->
-    <!-- Bump this when a release branch opens — current target: v0.7.0.    -->
-    <VersionPrefix Condition="'$(VersionPrefix)' == ''">0.7.0</VersionPrefix>
+    <!-- Bump this when a release branch opens — current target: v0.7.1.    -->
+    <VersionPrefix Condition="'$(VersionPrefix)' == ''">0.7.1</VersionPrefix>
     <VersionSuffix Condition="'$(VersionSuffix)' == '' AND '$(GITHUB_REF_TYPE)' != 'tag'">dev</VersionSuffix>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>

--- a/zeus-web/src/components/AboutPanel.tsx
+++ b/zeus-web/src/components/AboutPanel.tsx
@@ -24,7 +24,7 @@ import { useEffect, useState } from 'react';
 // Release date for the version this build ships against. Bump whenever
 // VersionPrefix in Directory.Build.props bumps. ISO 8601 so toLocaleDateString
 // renders sensibly in any locale.
-const RELEASE_DATE_ISO = '2026-05-10';
+const RELEASE_DATE_ISO = '2026-05-12';
 
 type VersionInfo = {
   version: string;


### PR DESCRIPTION
Pre-release version bump for v0.7.1. Two trivial edits:

- \`Directory.Build.props\` — \`VersionPrefix\` 0.7.0 → 0.7.1 (canonical .NET version; \`/api/version\` will start reporting 0.7.1-dev on this commit)
- \`zeus-web/src/components/AboutPanel.tsx\` — \`RELEASE_DATE_ISO\` 2026-05-10 → 2026-05-12 (the comment on \`VersionPrefix\` explicitly says to bump these together)

\`zeus-web/package.json\` and \`zeus-mobile/package.json\` intentionally **not** touched — they stay at 0.0.1 (npm-side, not a release-display field). Already that way for 0.7.0.

## Release sequence (this is step 1 of 4)

1. **This PR** → land version bump on develop.
2. Open follow-up PR \`develop → main\` for the release-merge.
3. \`git tag v0.7.1\` on main, push tag → triggers \`build-native-libs.yml\` + release packaging.
4. After build, edit release notes + CHANGELOG.

Per Brian's instruction to KB2UKA.