### PR TITLE
chore(agent): add KB2UKA-Agent workflow for personal @-mention bot

### DIFF
--- a/.github/workflows/kb2uka-agent.yml
+++ b/.github/workflows/kb2uka-agent.yml
@@ -1,0 +1,134 @@
+name: KB2UKA-Agent
+
+# KB2UKA's personal coding bot. Triggered by `@kb2uka-agent` mentions in
+# issues, issue comments, PR comments, and PR reviews. Runs as the
+# KB2UKA-Agent GitHub App identity (App ID 3702876) on KB2UKA's own
+# Anthropic OAuth token — completely separate from Brian's Zeus-Agent
+# (zeus-agent.yml) and the upstream @claude bot (claude.yml).
+#
+# Secrets required (set via `gh secret set`):
+#   - KB2UKA_OAUTH_TOKEN       — Anthropic Claude Code OAuth token (sk-ant-oat01-...)
+#   - KB2UKA_AGENT_APP_ID      — GitHub App ID (3702876)
+#   - KB2UKA_AGENT_PRIVATE_KEY — Contents of the App's .pem private key
+#
+# Permission notes:
+#   - `contents: write` so the bot can commit / push branches.
+#   - `pull-requests: write` so it can open / comment on PRs.
+#   - `issues: write` so it can comment on issues.
+#   - `workflows: write` NOT granted at the App level — the bot deliberately
+#     cannot rewrite its own .github/workflows/*.yml. Edits to workflow files
+#     must come from a human PR.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  kb2uka-agent:
+    name: KB2UKA-Agent
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@kb2uka-agent')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@kb2uka-agent')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@kb2uka-agent')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@kb2uka-agent') || contains(github.event.issue.title, '@kb2uka-agent')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Mint KB2UKA-Agent App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.KB2UKA_AGENT_APP_ID }}
+          private-key: ${{ secrets.KB2UKA_AGENT_PRIVATE_KEY }}
+
+      - name: Configure git identity (so commits are authored as KB2UKA-Agent)
+        run: |
+          git config --global user.name  "KB2UKA-Agent[bot]"
+          git config --global user.email "${{ steps.app-token.outputs.app-slug }}-bot@users.noreply.github.com"
+
+      - name: Run KB2UKA-Agent
+        uses: anthropics/claude-code-base-action@v0.0.63
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        with:
+          claude_code_oauth_token: ${{ secrets.KB2UKA_OAUTH_TOKEN }}
+          allowed_tools: "Bash,Read,Edit,Write,Glob,Grep,WebFetch,WebSearch"
+          max_turns: "30"
+          model: "claude-sonnet-4-6"
+          prompt: |
+            You are **KB2UKA-Agent** 🛠, KB2UKA's personal coding assistant for
+            the OpenHPSDR Zeus repo (a cross-platform, web-frontend HPSDR client
+            for original-protocol and Protocol-2 radios — .NET 8 backend,
+            Vite + React frontend, WDSP native DSP engine via P/Invoke). Thetis
+            is the sole authoritative upstream reference for protocol and DSP
+            behavior; see CLAUDE.md for the red-light / green-light rules.
+
+            ## Event context
+
+            Event: ${{ github.event_name }}
+            Repo:  ${{ github.repository }}
+            Actor: ${{ github.actor }}
+            ${{ github.event_name == 'issues' && format('Issue #{0}: {1}', github.event.issue.number, github.event.issue.title) || '' }}
+            ${{ github.event_name == 'issue_comment' && format('Issue #{0} comment by @{1}', github.event.issue.number, github.event.comment.user.login) || '' }}
+            ${{ github.event_name == 'pull_request_review_comment' && format('PR #{0} review-comment by @{1}', github.event.pull_request.number, github.event.comment.user.login) || '' }}
+            ${{ github.event_name == 'pull_request_review' && format('PR #{0} review by @{1}', github.event.pull_request.number, github.event.review.user.login) || '' }}
+
+            ## Your job
+
+            1. Read the triggering comment / issue / PR carefully. Understand
+               exactly what KB2UKA is asking you to do.
+            2. If the ask is a question or a triage request — answer it. Read
+               relevant code, docs, prior commits. Cite file:line at every
+               claim. Post one focused comment.
+            3. If the ask is to write or fix code:
+                 - Branch off `develop` with a `kb2uka-agent/<short-topic>` name.
+                 - Implement the change. Match the existing code style.
+                 - Build (`dotnet build Zeus.slnx`) — must be 0 warnings, 0 errors.
+                 - Run tests (`dotnet test Zeus.slnx`) — no regressions.
+                 - Commit with a conventional message (feat: / fix: / chore: / etc).
+                 - Push the branch.
+                 - Open a PR against `develop` (NEVER `main`). Title + body should
+                   reference the originating issue/PR. Sign off "— KB2UKA-Agent 🛠".
+                 - Post a follow-up comment on the originating thread linking to
+                   the new PR.
+
+            ## Rules (hard)
+
+            - **Never push directly to `develop` or `main`.** Always go through a PR.
+            - **Never edit `.github/workflows/*.yml`.** The App doesn't have
+              workflow write permission anyway — but don't try.
+            - **Never mention Anthropic or Claude in commit messages** (CLAUDE.md hard rule).
+            - **Never skip git hooks** (`--no-verify`) or bypass signing.
+            - **Respect CLAUDE.md red-light items** — visual design, UX behavior,
+              architecture changes, default-value changes that operators feel,
+              feature scope creep. Flag for KB2UKA review rather than committing.
+            - **Verify against Thetis source first** for protocol / DSP claims
+              (a local clone may exist at `/Users/kb2uka_mac/Programs/Thetis` on
+              KB2UKA's dev box but is NOT on the CI runner; use the inline code
+              comments + docs/references/ + docs/lessons/ here).
+            - **Be concise.** Prefer understatement. No "Great question!" openings.
+            - **One comment per turn** on the triggering thread. If you need a
+              follow-up after merging a PR, that's a separate comment.
+
+            ## Sign-off
+
+            End every comment / PR body with a separator line and:
+
+            > — KB2UKA-Agent 🛠


### PR DESCRIPTION
Adds a personal coding bot triggered by \`@kb2uka-agent\` mentions, running as the **KB2UKA-Agent GitHub App** (App ID 3702876) on KB2UKA's own Anthropic OAuth token. Parallel to (and independent of) Brian's existing automation.

## Three bots, three roles

| Workflow | Trigger | Identity | Job |
|---|---|---|---|
| \`zeus-agent.yml\` | issue opened | Zeus-Agent App (Brian's) | Triage / label new issues |
| \`claude.yml\` | \`@claude\` mention | anthropic-code-agent (upstream Anthropic App) | General assist as Brian |
| **\`kb2uka-agent.yml\` (this PR)** | \`@kb2uka-agent\` mention | **KB2UKA-Agent App (mine)** | Personal coding bot for KB2UKA's work |

## What this workflow does

- Fires on \`@kb2uka-agent\` mentions in issues, issue comments, PR review comments, and PR reviews — same trigger surface as \`claude.yml\` but with the new mention phrase.
- Mints a GitHub App token via \`actions/create-github-app-token@v1\` so commits are authored as **KB2UKA-Agent[bot]**, not as \`github-actions[bot]\`.
- Permissions: \`contents: write\` + \`pull-requests: write\` + \`issues: write\` so the bot can code (branch, commit, push, open PR). **\`workflows: write\` deliberately NOT granted** at the App level — bot cannot rewrite its own workflow files.
- Uses \`anthropics/claude-code-base-action\` with a coding-focused prompt that pins it to PRs against \`develop\` (never \`main\`), conventional commits, no Anthropic mentions in commit messages (CLAUDE.md hard rule), and explicit red-light awareness for visual/UX/defaults changes.
- Signs off \`— KB2UKA-Agent 🛠\`.

## Secrets

Already set on the repo (visible by name via \`gh secret list\`):
- \`KB2UKA_OAUTH_TOKEN\` — Anthropic OAuth token
- \`KB2UKA_AGENT_APP_ID\` — \`3702876\`
- \`KB2UKA_AGENT_PRIVATE_KEY\` — App private key

Brian's \`ZEUS_AGENT_*\` and \`CLAUDE_CODE_OAUTH_TOKEN\` are untouched.

## Sustainability note

This is intentionally a **per-user bot**, not a shared one — if Brian rotates his Anthropic credentials, his Zeus-Agent stops but mine keeps working (and vice versa). Decoupled, lower blast-radius.

## How to test after merge

Comment \`@kb2uka-agent\` on any issue or PR with a small ask (e.g., "summarise what's in CLAUDE.md" or "list the test files in tests/Zeus.Server.Tests/"). A GitHub Actions run should kick off; the bot should post a single comment back signed \`— KB2UKA-Agent 🛠\`.

If something's off with the secrets or App-token minting, the run will fail and the log will show where. Easy to iterate.