### PR TITLE
docs(readme): add Contributing section linking to CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ See [`ATTRIBUTIONS.md`](ATTRIBUTIONS.md) for the full provenance statement,
 per-component licensing, and the per-file header convention OpenHPSDR Zeus
 uses to carry this acknowledgement through every source file.
 
+## Contributing
+
+Bug reports, feature suggestions, and PRs welcome. Please read
+[`CONTRIBUTING.md`](CONTRIBUTING.md) before opening a PR — it covers the
+branch model, what's red-light vs green-light, hot paths to leave alone, and
+the commit / review conventions the project follows.
+
 ## License
 
 OpenHPSDR Zeus is free software: you can redistribute it and/or modify it


### PR DESCRIPTION
Three-line Contributing section in README pointing at CONTRIBUTING.md (added in PR #305). Casual visitors who only read the README now see the contribution doc; GitHub's auto-banner on New Issue / New PR pages catches the rest, but the README is the highest-traffic surface and should still link out.

Tight per CLAUDE.md's README-stays-brief rule — single paragraph, no how-to ceremony in README itself, all of which lives in CONTRIBUTING.md.

Pure docs change, zero code impact.