### PR TITLE
feat(p2): ANAN-10E support via HermesII DDC0 path

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -248,7 +248,13 @@ public sealed record ConnectRequest(
     string Endpoint,
     int SampleRate = 192_000,
     bool? PreampOn = null,
-    int? Atten = null);
+    int? Atten = null,
+    // Raw HPSDR board byte from discovery (P2's reply parser maps this to
+    // <see cref="HpsdrBoardKind"/>). When provided on /api/connect/p2 the
+    // server uses it as the connected board kind instead of the historical
+    // "P2 active ⇒ assume OrionMkII" fallback. Null/omitted = legacy
+    // behaviour. Issue #171.
+    byte? BoardId = null);
 
 public sealed record VfoSetRequest(long Hz);
 

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -45,9 +45,12 @@
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Net;
+using System.Net.NetworkInformation;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
+using Zeus.Contracts;
 
 namespace Zeus.Protocol2;
 
@@ -82,6 +85,13 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // 1035 + 2 = 1037.
     private const int G2RxDdc = 2;
 
+    // Hermes-class radios (Brick2 is the live consumer) use a single ADC
+    // and have no PureSignal feedback DDCs reserved at the front of the pool.
+    // The user-visible RX maps to DDC0 directly. Radio sends DDC0 IQ from
+    // port 1035. Reference: deskhpsdr src/new_protocol.c:1692-1698 — Hermes
+    // sets `receiver[i].ddc = i` (not `i + 2` as for Orion/Angelia/MkII).
+    private const int HermesRxDdc = 0;
+
     // 2^32 / 122_880_000 — converts Hz to a 32-bit phase-increment word
     // when the general packet is in "send phase word" mode (bit 3 of
     // CmdGeneral[37], which pihpsdr and Thetis both set).
@@ -99,6 +109,12 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     private int _sampleRateKhz = 48;
     private uint _rxFreqHz = 14_200_000;
     private byte _numAdc = 2;
+    // Connected board kind, plumbed from RadioService's ConnectedBoardKind via
+    // DspPipelineService at connect time. Used by HandleDdcPacket for the
+    // Hermes-on-P2 48 kHz amplitude correction (Brick2 firmware delivers IQ
+    // ~29 dB hotter at 48 kHz than at higher rates — deskhpsdr
+    // src/new_protocol.c:2516-2530). Unknown == no correction applied.
+    private HpsdrBoardKind _boardKind = HpsdrBoardKind.Unknown;
     // Mercury preamp defaults OFF — on a G2 the ADC has enough dynamic range
     // that the preamp is a crutch, not a default. Operator enables it when
     // needed via the UI. Attenuator 0 dB so the front-end isn't knocked down.
@@ -240,6 +256,20 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
 
         _sampleRateKhz = sampleRateKhz;
 
+        // macOS-only: pre-prime the kernel ARP table for the radio's IP
+        // before we fire off any real packets. The Brick2 firmware answers
+        // ARP requests incorrectly (DL1BZ in Zeus issue #171: deskhpsdr hit
+        // the same problem and shipped this workaround at
+        // src/new_protocol.c:453-474). Without an entry the first SendTo
+        // races the ARP resolution and the radio's streams never start.
+        // Linux/Windows hosts haven't shown the same symptom; gate strictly
+        // on macOS so we don't introduce side-effects on platforms where the
+        // OS handles ARP correctly out of the box.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            PrimeMacOSUdpRoute(_radioEndpoint!.Address, _log);
+        }
+
         // Startup sequence matches Thetis SendStart() and Priapus/NextGenSDR:
         // CmdGeneral → CmdRx → CmdTx → CmdHighPriority(run=1). Skipping CmdTx
         // leaves the G2 MkII in a half-configured state where its BPF board
@@ -307,6 +337,45 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         {
             SendCmdRx();
         }
+    }
+
+    /// <summary>
+    /// Set the connected board kind. Should be called once at connect time,
+    /// before <see cref="StartAsync"/>. Plumbed from
+    /// <c>DspPipelineService.ConnectP2Async</c> so RX-decode quirks scoped to
+    /// specific board families can be applied without polluting the hot path
+    /// with an out-of-band lookup.
+    /// </summary>
+    public void SetBoardKind(HpsdrBoardKind kind)
+    {
+        _boardKind = kind;
+    }
+
+    /// <summary>
+    /// Per-board, per-sample-rate gain correction applied on top of the
+    /// int24→[-1,+1] normalisation in <c>HandleDdcPacket</c>.
+    ///
+    /// Hermes-class radios on Protocol 2 (notably the Brick2 SDR, which is
+    /// Hermes-fork firmware on Hermes-Lite-style hardware) deliver RX IQ at
+    /// 48 kHz with ~+29 dB more amplitude than at higher sample rates,
+    /// because the on-board CIC/decimator gain isn't compensated by the
+    /// firmware at the lowest decimation factor. Without this scaler the
+    /// S-meter and panadapter clip / saturate at 48 kHz on Brick2 — the
+    /// symptom that left linoobs's waterfall blank in issue #171.
+    ///
+    /// Reference: deskhpsdr <c>src/new_protocol.c:2516-2530</c>.
+    /// Constant <c>0.0354813389</c> is <c>10^(-29/20)</c>.
+    ///
+    /// All other (board, rate) combinations return 1.0 — vanilla HL2, ANAN
+    /// G2 / 7000DLE / 8000DLE / Orion, etc. are unaffected.
+    /// </summary>
+    public static double IqGainCorrection(HpsdrBoardKind board, int sampleRateKhz)
+    {
+        if (board == HpsdrBoardKind.Hermes && sampleRateKhz == 48)
+        {
+            return 0.0354813389; // -29 dB
+        }
+        return 1.0;
     }
 
     public void SetNumAdc(byte numAdc)
@@ -579,32 +648,154 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1024));
     }
 
+    // macOS IP_BOUND_IF socket-option name. Defined in `netinet/in.h` as 25;
+    // not exposed as a named constant in .NET so we declare it here.
+    // Behavior: forces traffic on this socket to egress a specific interface
+    // by ifindex, bypassing the routing table's interface selection.
+    private const int IP_BOUND_IF = 25;
+
+    /// <summary>
+    /// Best-effort macOS ARP-priming workaround. Sends a single zero-byte
+    /// UDP datagram to the radio's port 1024 bound (via IP_BOUND_IF) to the
+    /// interface the kernel chose for the radio's IP. The kernel resolves
+    /// ARP as a side effect so subsequent real packets ship promptly instead
+    /// of racing the first SendTo. Mirrors deskhpsdr's <c>p2_prime_route()</c>
+    /// at <c>src/new_protocol.c:453-474</c>.
+    ///
+    /// Caller is the only authority on platform gating — this helper assumes
+    /// it's being invoked on macOS already. Every failure path is swallowed
+    /// and logged; the priming is opportunistic, never load-bearing for the
+    /// connect succeeding.
+    /// </summary>
+    internal static void PrimeMacOSUdpRoute(IPAddress radioIp, ILogger log)
+    {
+        try
+        {
+            // Step 1: ask the kernel which local IP it would use to reach
+            // the radio. UDP Connect doesn't generate any traffic — it only
+            // installs a "default destination" in the socket and resolves
+            // the route — so LocalEndPoint after Connect is the local IP
+            // the kernel routes through.
+            int ifIndex;
+            using (var probe = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
+            {
+                probe.Connect(new IPEndPoint(radioIp, 1024));
+                var localIp = (probe.LocalEndPoint as IPEndPoint)?.Address;
+                if (localIp is null)
+                {
+                    log.LogDebug("p2.prime.macos no localIp for radio={Radio}", radioIp);
+                    return;
+                }
+                ifIndex = FindInterfaceIndexForLocalAddress(localIp);
+                if (ifIndex <= 0)
+                {
+                    log.LogDebug("p2.prime.macos no interface for local={Local} radio={Radio}", localIp, radioIp);
+                    return;
+                }
+            }
+
+            // Step 2: open a fresh UDP socket, bind it to that interface
+            // index, and send a single byte to port 1024 on the radio. The
+            // datagram is intentionally garbage — port 1024 (CmdGeneral
+            // from-host) is one the radio's protocol layer ignores on a
+            // payload it can't parse, but the link-layer ARP exchange that
+            // *gets* it there is the whole point.
+            using var prime = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            var ifIndexBytes = BitConverter.GetBytes(ifIndex);
+            prime.SetRawSocketOption(
+                optionLevel: (int)SocketOptionLevel.IP,
+                optionName: IP_BOUND_IF,
+                optionValue: ifIndexBytes);
+            prime.SendTo(new byte[] { 0 }, new IPEndPoint(radioIp, 1024));
+            log.LogInformation("p2.prime.macos sent radio={Radio} ifIndex={Ix}", radioIp, ifIndex);
+        }
+        catch (Exception ex)
+        {
+            // ARP priming is opportunistic; the regular SendCmdGeneral that
+            // follows will resolve ARP eventually. Don't fail the connect
+            // over a priming hiccup.
+            log.LogDebug(ex, "p2.prime.macos failed radio={Radio}", radioIp);
+        }
+    }
+
+    /// <summary>
+    /// Look up the OS interface index for the NIC that owns
+    /// <paramref name="localAddr"/>. Returns 0 if no match — the priming
+    /// caller treats that as "skip priming and continue."
+    /// </summary>
+    internal static int FindInterfaceIndexForLocalAddress(IPAddress localAddr)
+    {
+        foreach (var nic in NetworkInterface.GetAllNetworkInterfaces())
+        {
+            var props = nic.GetIPProperties();
+            foreach (var ua in props.UnicastAddresses)
+            {
+                if (ua.Address.Equals(localAddr))
+                {
+                    var ipv4 = props.GetIPv4Properties();
+                    return ipv4?.Index ?? 0;
+                }
+            }
+        }
+        return 0;
+    }
+
+    /// <summary>
+    /// Per-board base DDC index for the user-visible RX. OrionMkII/Saturn/G2
+    /// family reserves DDC0/DDC1 for PureSignal feedback so the operator's RX
+    /// lives at DDC2. Hermes-class radios (Brick2) have one ADC and no
+    /// reserved PS feedback slots — the RX is at DDC0. Default OrionMkII
+    /// preserves Zeus' historical P2 wire shape for every existing board.
+    /// Reference: deskhpsdr <c>src/new_protocol.c:1692-1698</c>.
+    /// </summary>
+    public static int RxBaseDdc(HpsdrBoardKind board) => board switch
+    {
+        HpsdrBoardKind.Hermes => HermesRxDdc,
+        _                     => G2RxDdc,
+    };
+
     // Static byte composer — pure function over (seq, numAdc, sampleRateKhz,
-    // psEnabled). Exposed internal so wire-format tests don't need a live
-    // socket. SendCmdRx constructs the same bytes and pushes to UDP.
-    internal static byte[] ComposeCmdRxBuffer(uint seq, byte numAdc, ushort sampleRateKhz, bool psEnabled)
+    // psEnabled, boardKind). Exposed internal so wire-format tests don't
+    // need a live socket. SendCmdRx constructs the same bytes and pushes to
+    // UDP. boardKind defaults to OrionMkII for backward compat — every
+    // pre-Brick2 caller (and every pre-Brick2 test) keeps the DDC2 wire shape.
+    internal static byte[] ComposeCmdRxBuffer(
+        uint seq,
+        byte numAdc,
+        ushort sampleRateKhz,
+        bool psEnabled,
+        HpsdrBoardKind boardKind = HpsdrBoardKind.OrionMkII)
     {
         var p = new byte[BufLen];
         WriteBeU32(p, 0, seq);
         p[4] = numAdc;
         p[5] = 0;
         p[6] = 0;
-        byte ddcEnable = (byte)(1 << G2RxDdc);
+        int rxDdc = RxBaseDdc(boardKind);
+        byte ddcEnable = (byte)(1 << rxDdc);
 
         if (psEnabled)
         {
-            ddcEnable |= 0x01;
-            p[17] = 0x00;
-            WriteBeU16(p, 18, 192);
-            p[22] = 24;
-            p[23] = numAdc;
-            WriteBeU16(p, 24, 192);
-            p[28] = 24;
-            p[1363] = 0x02;
+            // PS feedback layout is OrionMkII/Saturn-specific (DDC0+DDC1
+            // paired with bit 1363 sync). For Hermes-class radios that don't
+            // have this hardware, leave the PS block alone — psEnabled should
+            // never be set true for Hermes upstream, but if it ever is we'd
+            // rather silently no-op than scribble bytes the radio will reject.
+            if (boardKind != HpsdrBoardKind.Hermes)
+            {
+                ddcEnable |= 0x01;
+                p[17] = 0x00;
+                WriteBeU16(p, 18, 192);
+                p[22] = 24;
+                p[23] = numAdc;
+                WriteBeU16(p, 24, 192);
+                p[28] = 24;
+                p[1363] = 0x02;
+            }
         }
 
         p[7] = ddcEnable;
-        int off = 17 + G2RxDdc * 6;
+        int off = 17 + rxDdc * 6;
         p[off + 0] = 0x00;
         WriteBeU16(p, off + 1, sampleRateKhz);
         p[off + 5] = 24;
@@ -621,7 +812,7 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         //   ComposeCmdRxBuffer also enables DDC0, configures DDC0/1 at
         //   192 kHz / 24-bit, and sets byte 1363 = 0x02 to sync DDC1→DDC0
         //   (pihpsdr new_protocol.c:1611-1630).
-        var p = ComposeCmdRxBuffer(_seqCmdRx++, _numAdc, (ushort)_sampleRateKhz, _psFeedbackEnabled);
+        var p = ComposeCmdRxBuffer(_seqCmdRx++, _numAdc, (ushort)_sampleRateKhz, _psFeedbackEnabled, _boardKind);
         _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1025));
     }
 
@@ -713,10 +904,13 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         // reads a 32-bit phase increment, not Hz. pihpsdr computes this as
         //   phase = freq_hz * 2^32 / 122_880_000
         // The G2 MkII puts the user-visible RX0 at DDC slot 2, so the phase
-        // goes to bytes 9 + 2*4 = 17..20. Bytes 9..16 (DDC0/1) are normally
-        // left as zero (non-PS path). TX DUC phase is written to 329..332.
+        // goes to bytes 9 + 2*4 = 17..20. Hermes-class (Brick2) puts RX0 at
+        // DDC slot 0, so the phase goes to bytes 9..12 (`9 + 0*4`). Bytes
+        // not used by the active RX slot stay zero on the non-PS path. TX
+        // DUC phase is written to 329..332 regardless of board.
         uint rxPhase = (uint)(_rxFreqHz * HzToPhase);
-        WriteBeU32(p, 9 + G2RxDdc * 4, rxPhase);
+        int rxDdc = RxBaseDdc(_boardKind);
+        WriteBeU32(p, 9 + rxDdc * 4, rxPhase);
         WriteBeU32(p, 329, rxPhase);
 
         // PureSignal — when armed, DDC0 + DDC1 phase words also need to
@@ -1013,7 +1207,9 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         // plain GC allocation is both simpler and correct.
         const int samplesPerPacket = DiscoverySamplesPerPacket;
         var samples = new double[samplesPerPacket * 2];
-        const double scale = 1.0 / 8388608.0;
+        // 1/2^23 normalises int24 to [-1,+1]; the per-board correction is 1.0
+        // for everything except Hermes@48 kHz (Brick2 quirk — see IqGainCorrection).
+        double scale = (1.0 / 8388608.0) * IqGainCorrection(_boardKind, _sampleRateKhz);
         for (int i = 0; i < samplesPerPacket; i++)
         {
             int off = 16 + i * 6;

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -363,11 +363,17 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     /// S-meter and panadapter clip / saturate at 48 kHz on Brick2 — the
     /// symptom that left linoobs's waterfall blank in issue #171.
     ///
-    /// Reference: deskhpsdr <c>src/new_protocol.c:2516-2530</c>.
-    /// Constant <c>0.0354813389</c> is <c>10^(-29/20)</c>.
+    /// Reference: deskhpsdr <c>src/new_protocol.c:2516-2530</c> — the
+    /// scaler is gated on <c>NEW_DEVICE_HERMES</c> (wire byte 0x01) only,
+    /// NOT on <c>NEW_DEVICE_HERMES2</c> (wire byte 0x02). HermesII firmware
+    /// (ANAN-10E / ANAN-100B) does not exhibit the +29 dB 48 kHz lift, so
+    /// the scaler must stay gated on <see cref="HpsdrBoardKind.Hermes"/>
+    /// alone — widening it to HermesII would knock 29 dB off legitimate
+    /// ANAN-10E / ANAN-100B RX. Constant <c>0.0354813389</c> is
+    /// <c>10^(-29/20)</c>.
     ///
     /// All other (board, rate) combinations return 1.0 — vanilla HL2, ANAN
-    /// G2 / 7000DLE / 8000DLE / Orion, etc. are unaffected.
+    /// 10E / 100B, ANAN G2 / 7000DLE / 8000DLE / Orion, etc. are unaffected.
     /// </summary>
     public static double IqGainCorrection(HpsdrBoardKind board, int sampleRateKhz)
     {
@@ -743,15 +749,20 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     /// <summary>
     /// Per-board base DDC index for the user-visible RX. OrionMkII/Saturn/G2
     /// family reserves DDC0/DDC1 for PureSignal feedback so the operator's RX
-    /// lives at DDC2. Hermes-class radios (Brick2) have one ADC and no
-    /// reserved PS feedback slots — the RX is at DDC0. Default OrionMkII
-    /// preserves Zeus' historical P2 wire shape for every existing board.
-    /// Reference: deskhpsdr <c>src/new_protocol.c:1692-1698</c>.
+    /// lives at DDC2. Single-ADC Hermes-class radios (Brick2 on wire byte
+    /// 0x01; ANAN-10E / ANAN-100B on wire byte 0x02) have no reserved PS
+    /// feedback slots — the RX is at DDC0. Default OrionMkII preserves Zeus'
+    /// historical P2 wire shape for every existing board.
+    /// Reference: deskhpsdr <c>src/new_protocol.c:1692-1698</c> — only
+    /// <c>NEW_DEVICE_ANGELIA / ORION / ORION2 / SATURN</c> use the
+    /// <c>ddc = 2 + i</c> offset; <c>NEW_DEVICE_HERMES</c> and
+    /// <c>NEW_DEVICE_HERMES2</c> both fall through to <c>ddc = i</c>.
     /// </summary>
     public static int RxBaseDdc(HpsdrBoardKind board) => board switch
     {
-        HpsdrBoardKind.Hermes => HermesRxDdc,
-        _                     => G2RxDdc,
+        HpsdrBoardKind.Hermes    => HermesRxDdc,
+        HpsdrBoardKind.HermesII  => HermesRxDdc,
+        _                        => G2RxDdc,
     };
 
     // Static byte composer — pure function over (seq, numAdc, sampleRateKhz,
@@ -777,11 +788,13 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         if (psEnabled)
         {
             // PS feedback layout is OrionMkII/Saturn-specific (DDC0+DDC1
-            // paired with bit 1363 sync). For Hermes-class radios that don't
-            // have this hardware, leave the PS block alone — psEnabled should
-            // never be set true for Hermes upstream, but if it ever is we'd
-            // rather silently no-op than scribble bytes the radio will reject.
-            if (boardKind != HpsdrBoardKind.Hermes)
+            // paired with bit 1363 sync). Single-ADC Hermes-class radios
+            // (Hermes/0x01, HermesII/0x02) don't have this hardware — leave
+            // the PS block alone. psEnabled should never be set true for
+            // these boards upstream, but if it ever is we'd rather silently
+            // no-op than scribble bytes the radio will reject.
+            if (boardKind != HpsdrBoardKind.Hermes &&
+                boardKind != HpsdrBoardKind.HermesII)
             {
                 ddcEnable |= 0x01;
                 p[17] = 0x00;

--- a/Zeus.Server.Hosting/BoardCapabilitiesTable.cs
+++ b/Zeus.Server.Hosting/BoardCapabilitiesTable.cs
@@ -90,6 +90,12 @@ internal static class BoardCapabilitiesTable
     };
 
     // Hermes / Metis / ANAN-10 — small-signal Hermes-class single-RX. ~10 W.
+    // Brick2 SDR (Sergey EU1SW) announces as wire byte 0x01 → HpsdrBoardKind.Hermes
+    // and inherits this fingerprint. Brick2's hardware reality (1 ADC, no Alex
+    // BPF, no Apollo LPF, no on-board telemetry, internal step attenuator
+    // 0-31 dB on RX1 only) matches the row exactly; see Zeus issue #171.
+    // MaxPowerWatts=10 is conservative for Brick2 (rated 15 W); operator
+    // overrides per-rig in the PA panel.
     private static readonly BoardCapabilities HermesClass = new(
         RxAdcCount: 1,
         MkiiBpf: false,

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -847,6 +847,10 @@ public class DspPipelineService : BackgroundService
         var client = new Zeus.Protocol2.Protocol2Client(
             _loggerFactory.CreateLogger<Zeus.Protocol2.Protocol2Client>());
         client.SetNumAdc(numAdc);
+        // Tell the P2 client which board it's talking to so RX-decode quirks
+        // (Hermes-on-P2 48 kHz IQ gain correction; future per-board branches)
+        // are gated correctly. boardKind == Unknown leaves all quirks off.
+        client.SetBoardKind(boardKind);
         await client.ConnectAsync(radioEndpoint, ct).ConfigureAwait(false);
         // Seed the operator's RX front-end (preamp + step attenuator) BEFORE
         // StartAsync so the very first CmdHighPriority emitted inside the

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -832,7 +832,12 @@ public class DspPipelineService : BackgroundService
     /// only); both swap the engine to WDSP and start a pump. Only one client
     /// at a time.
     /// </summary>
-    public async Task ConnectP2Async(IPEndPoint radioEndpoint, int sampleRateKhz, byte numAdc, CancellationToken ct)
+    public async Task ConnectP2Async(
+        IPEndPoint radioEndpoint,
+        int sampleRateKhz,
+        byte numAdc,
+        CancellationToken ct,
+        HpsdrBoardKind boardKind = HpsdrBoardKind.Unknown)
     {
         if (_p2Client is not null)
             throw new InvalidOperationException("Already connected (P2).");
@@ -945,11 +950,12 @@ public class DspPipelineService : BackgroundService
         // Pass the live client so RadioService can fire P2Connected with a
         // reference to the freshly-opened Protocol2Client. TxMetersService
         // subscribes through that event to hook hi-priority status (#174).
-        _radio.MarkProtocol2Connected(radioEndpoint.ToString(), rateHz, client);
+        _radio.MarkProtocol2Connected(radioEndpoint.ToString(), rateHz, client, boardKind);
         // P2 G2/MkII default HW peak = 0.6121; ANAN-7000/8000 = 0.2899. The
         // RadioService switch covers both so we don't bake a value in here.
-        // ConnectedBoardKind returns OrionMkII when _p2Active is true; future
-        // P2 discovery work can refine it.
+        // ConnectedBoardKind now returns the discovered board kind when the
+        // caller plumbed it through (issue #171); falls back to OrionMkII when
+        // the byte wasn't supplied.
         _radio.ApplyPsHwPeakForConnection(isProtocol2: true, _radio.ConnectedBoardKind);
         // Push current PA snapshot into the brand-new client so byte 345 /
         // byte 1401 / CmdGeneral[58] reflect PaSettingsStore from frame 1.

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -94,6 +94,12 @@ public sealed class RadioService : IDisposable
     // the user is on a G2 MkII / Saturn (P2 discovery flow skips
     // Protocol1Client entirely).
     private bool _p2Active;
+    // Discovered board kind for the active P2 connection. Set by
+    // MarkProtocol2Connected from the connect-API request byte (issue #171 —
+    // Brick2 is Hermes-on-P2, not OrionMkII). Unknown when the caller didn't
+    // supply a byte, in which case ConnectedBoardKind falls back to OrionMkII
+    // for backward compat.
+    private HpsdrBoardKind _p2BoardKind = HpsdrBoardKind.Unknown;
     private bool _preampOn;
     // Auto-ATT defaults on; the user baseline starts at 0 dB and the control
     // loop ramps _attOffsetDb up to 31 dB on observed ADC overloads (Thetis
@@ -1289,9 +1295,17 @@ public sealed class RadioService : IDisposable
     // Protocol2Client to subscribers of <see cref="P2Connected"/>; passing
     // null keeps the signature backward-compatible for tests that don't
     // need the telemetry surface (issue #174).
-    public void MarkProtocol2Connected(string endpoint, int sampleRateHz, Zeus.Protocol2.Protocol2Client? client = null)
+    public void MarkProtocol2Connected(
+        string endpoint,
+        int sampleRateHz,
+        Zeus.Protocol2.Protocol2Client? client = null,
+        HpsdrBoardKind boardKind = HpsdrBoardKind.Unknown)
     {
-        lock (_sync) _p2Active = true;
+        lock (_sync)
+        {
+            _p2Active = true;
+            _p2BoardKind = boardKind;
+        }
         Mutate(s => s with
         {
             Status = ConnectionStatus.Connected,
@@ -1308,7 +1322,11 @@ public sealed class RadioService : IDisposable
 
     public void MarkProtocol2Disconnected()
     {
-        lock (_sync) _p2Active = false;
+        lock (_sync)
+        {
+            _p2Active = false;
+            _p2BoardKind = HpsdrBoardKind.Unknown;
+        }
         Mutate(s => s with
         {
             Status = ConnectionStatus.Disconnected,
@@ -1344,7 +1362,18 @@ public sealed class RadioService : IDisposable
 
                 // Normal path: use discovery result.
                 if (_activeClient is not null) return _activeClient.BoardKind;
-                if (_p2Active) return HpsdrBoardKind.OrionMkII;
+                if (_p2Active)
+                {
+                    // Brick2 announces as Hermes (0x01) on P2; older Zeus
+                    // assumed every P2 radio was OrionMkII because the connect
+                    // API didn't carry the discovered byte (issue #171). The
+                    // byte is now plumbed through MarkProtocol2Connected — fall
+                    // back to OrionMkII only when the caller didn't supply it
+                    // (legacy tests, older frontends).
+                    return _p2BoardKind != HpsdrBoardKind.Unknown
+                        ? _p2BoardKind
+                        : HpsdrBoardKind.OrionMkII;
+                }
                 return HpsdrBoardKind.Unknown;
             }
         }

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -177,9 +177,14 @@ public static class ZeusEndpoints
                 _ => 192,
             };
 
+            // Plumb the discovered board byte through so RadioService can
+            // surface the real board kind instead of defaulting to OrionMkII
+            // for every P2 connection (issue #171 — Brick2 is Hermes/0x01 on P2).
+            var boardKind = req.BoardId is byte b ? MapBoardByte(b) : HpsdrBoardKind.Unknown;
+
             try
             {
-                await dsp.ConnectP2Async(ipEndpoint, rateKhz, numAdc: 2, ctx.RequestAborted);
+                await dsp.ConnectP2Async(ipEndpoint, rateKhz, numAdc: 2, ctx.RequestAborted, boardKind);
                 return Results.Ok(new { protocol = "P2", endpoint = req.Endpoint, sampleRateKhz = rateKhz });
             }
             catch (InvalidOperationException ex)
@@ -1453,6 +1458,23 @@ public static class ZeusEndpoints
         ep = new IPEndPoint(ip, port);
         return true;
     }
+
+    // Mirrors the byte→enum maps in Zeus.Protocol1.Discovery.ReplyParser and
+    // Zeus.Protocol2.Discovery.ReplyParser. Kept inline (not factored to a
+    // shared helper) because those parsers are deliberately self-contained
+    // per protocol; this is the connect-time projection of the same table.
+    static HpsdrBoardKind MapBoardByte(byte raw) => raw switch
+    {
+        0x00 => HpsdrBoardKind.Metis,
+        0x01 => HpsdrBoardKind.Hermes,
+        0x02 => HpsdrBoardKind.HermesII,
+        0x04 => HpsdrBoardKind.Angelia,
+        0x05 => HpsdrBoardKind.Orion,
+        0x06 => HpsdrBoardKind.HermesLite2,
+        0x0A => HpsdrBoardKind.OrionMkII,
+        0x14 => HpsdrBoardKind.HermesC10,
+        _    => HpsdrBoardKind.Unknown,
+    };
 
     static HpsdrBoardKind? ParseBoardKind(string? raw)
     {

--- a/tests/Zeus.Protocol2.Tests/HermesP2DdcMappingTests.cs
+++ b/tests/Zeus.Protocol2.Tests/HermesP2DdcMappingTests.cs
@@ -13,17 +13,20 @@ using Zeus.Contracts;
 namespace Zeus.Protocol2.Tests;
 
 /// <summary>
-/// Hermes-on-Protocol-2 RX DDC mapping (issue #171, Brick2).
+/// Hermes-on-Protocol-2 RX DDC mapping (issue #171 Brick2; ANAN-10E follow-up).
 ///
-/// Hermes-class radios have one ADC and no PureSignal feedback DDCs reserved
-/// at the front of the pool — receiver[i] maps to DDC[i] (deskhpsdr
-/// <c>src/new_protocol.c:1692-1698</c>). Every other family Zeus supports on
-/// P2 puts the operator's RX0 at DDC2, so the OrionMkII default must remain
-/// the wire shape we've been shipping.
+/// Single-ADC Hermes-class radios — Hermes/Brick2 on wire byte 0x01 and
+/// HermesII (ANAN-10E / ANAN-100B) on wire byte 0x02 — have one ADC and no
+/// PureSignal feedback DDCs reserved at the front of the pool. receiver[i]
+/// maps to DDC[i] (deskhpsdr <c>src/new_protocol.c:1692-1698</c> — only
+/// <c>NEW_DEVICE_ANGELIA / ORION / ORION2 / SATURN</c> apply the
+/// <c>ddc = 2 + i</c> offset). Every other family Zeus supports on P2 puts
+/// the operator's RX0 at DDC2, so the OrionMkII default must remain the
+/// wire shape we've been shipping.
 ///
-/// These tests pin the byte-offsets so the next Brick2 owner running this
-/// branch sees DDC0 enabled, the DDC0 config block populated at offset 17,
-/// and IQ arriving on UDP 1035 (instead of 1037).
+/// These tests pin the byte-offsets so a Brick2 or ANAN-10E owner running
+/// this branch sees DDC0 enabled, the DDC0 config block populated at
+/// offset 17, and IQ arriving on UDP 1035 (instead of 1037).
 /// </summary>
 public class HermesP2DdcMappingTests
 {
@@ -33,21 +36,29 @@ public class HermesP2DdcMappingTests
         Assert.Equal(0, Protocol2Client.RxBaseDdc(HpsdrBoardKind.Hermes));
     }
 
+    [Fact]
+    public void RxBaseDdc_HermesII_Is_Zero()
+    {
+        // ANAN-10E / ANAN-100B firmware (wire byte 0x02): single ADC, no PS
+        // DDCs reserved. Same DDC0 mapping as Hermes/Brick2 per deskhpsdr.
+        Assert.Equal(0, Protocol2Client.RxBaseDdc(HpsdrBoardKind.HermesII));
+    }
+
     [Theory]
     [InlineData(HpsdrBoardKind.OrionMkII)]
     [InlineData(HpsdrBoardKind.HermesC10)]
     [InlineData(HpsdrBoardKind.Orion)]
     [InlineData(HpsdrBoardKind.Angelia)]
     [InlineData(HpsdrBoardKind.HermesLite2)]
-    [InlineData(HpsdrBoardKind.HermesII)]
     [InlineData(HpsdrBoardKind.Metis)]
     [InlineData(HpsdrBoardKind.Unknown)]
     public void RxBaseDdc_NonHermes_Stays_At_Two(HpsdrBoardKind board)
     {
-        // Anti-regression: only Hermes flips to DDC0. Anything else MUST
-        // continue to report DDC2 — that's what every shipped P2 wire format
-        // in Zeus assumes (every test in PsWireFormatTests asserts on
-        // offset 29 = 17 + 12, i.e. DDC2's config block).
+        // Anti-regression: only single-ADC Hermes-class wire bytes (0x01,
+        // 0x02) flip to DDC0. Anything else MUST continue to report DDC2 —
+        // that's what every shipped P2 wire format in Zeus assumes (every
+        // test in PsWireFormatTests asserts on offset 29 = 17 + 12, i.e.
+        // DDC2's config block).
         Assert.Equal(2, Protocol2Client.RxBaseDdc(board));
     }
 
@@ -97,6 +108,49 @@ public class HermesP2DdcMappingTests
         Assert.Equal((byte)0x00, p[1363]);        // no DDC1→DDC0 sync
         Assert.Equal((byte)0x01, p[7]);           // only DDC0 enable
         Assert.Equal((byte)0x00, p[23]);          // DDC1 config block untouched
+        Assert.Equal((byte)0x00, p[28]);
+    }
+
+    [Fact]
+    public void CmdRx_HermesII_EnablesDdc0_Not_Ddc2()
+    {
+        // ANAN-10E (HermesII firmware) shares the single-ADC DDC0 wire shape
+        // with Hermes/Brick2 — see deskhpsdr new_protocol.c:1692-1698.
+        var p = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 1, numAdc: 1, sampleRateKhz: 48, psEnabled: false,
+            boardKind: HpsdrBoardKind.HermesII);
+
+        Assert.Equal((byte)0x01, p[7]);
+    }
+
+    [Fact]
+    public void CmdRx_HermesII_Writes_DDC0_Config_At_Offset_17()
+    {
+        var p = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 1, numAdc: 1, sampleRateKhz: 48, psEnabled: false,
+            boardKind: HpsdrBoardKind.HermesII);
+
+        Assert.Equal((byte)0x00, p[17]);          // ADC0
+        Assert.Equal((byte)0x00, p[18]);          // 48 kHz BE high
+        Assert.Equal((byte)48,   p[19]);          // 48 kHz BE low
+        Assert.Equal((byte)24,   p[22]);          // 24-bit
+        Assert.Equal((byte)0x00, p[29]);          // DDC2 block stays zero
+        Assert.Equal((byte)0x00, p[31]);
+        Assert.Equal((byte)0x00, p[34]);
+    }
+
+    [Fact]
+    public void CmdRx_HermesII_Does_Not_Set_DDC1_Sync_Or_PS_Block()
+    {
+        // Same single-ADC no-PS-hardware story as Hermes: psEnabled=true is a
+        // no-op on HermesII so we don't scribble OrionMkII shape onto the wire.
+        var p = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 1, numAdc: 1, sampleRateKhz: 96, psEnabled: true,
+            boardKind: HpsdrBoardKind.HermesII);
+
+        Assert.Equal((byte)0x00, p[1363]);
+        Assert.Equal((byte)0x01, p[7]);
+        Assert.Equal((byte)0x00, p[23]);
         Assert.Equal((byte)0x00, p[28]);
     }
 

--- a/tests/Zeus.Protocol2.Tests/HermesP2DdcMappingTests.cs
+++ b/tests/Zeus.Protocol2.Tests/HermesP2DdcMappingTests.cs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Xunit;
+using Zeus.Contracts;
+
+namespace Zeus.Protocol2.Tests;
+
+/// <summary>
+/// Hermes-on-Protocol-2 RX DDC mapping (issue #171, Brick2).
+///
+/// Hermes-class radios have one ADC and no PureSignal feedback DDCs reserved
+/// at the front of the pool — receiver[i] maps to DDC[i] (deskhpsdr
+/// <c>src/new_protocol.c:1692-1698</c>). Every other family Zeus supports on
+/// P2 puts the operator's RX0 at DDC2, so the OrionMkII default must remain
+/// the wire shape we've been shipping.
+///
+/// These tests pin the byte-offsets so the next Brick2 owner running this
+/// branch sees DDC0 enabled, the DDC0 config block populated at offset 17,
+/// and IQ arriving on UDP 1035 (instead of 1037).
+/// </summary>
+public class HermesP2DdcMappingTests
+{
+    [Fact]
+    public void RxBaseDdc_Hermes_Is_Zero()
+    {
+        Assert.Equal(0, Protocol2Client.RxBaseDdc(HpsdrBoardKind.Hermes));
+    }
+
+    [Theory]
+    [InlineData(HpsdrBoardKind.OrionMkII)]
+    [InlineData(HpsdrBoardKind.HermesC10)]
+    [InlineData(HpsdrBoardKind.Orion)]
+    [InlineData(HpsdrBoardKind.Angelia)]
+    [InlineData(HpsdrBoardKind.HermesLite2)]
+    [InlineData(HpsdrBoardKind.HermesII)]
+    [InlineData(HpsdrBoardKind.Metis)]
+    [InlineData(HpsdrBoardKind.Unknown)]
+    public void RxBaseDdc_NonHermes_Stays_At_Two(HpsdrBoardKind board)
+    {
+        // Anti-regression: only Hermes flips to DDC0. Anything else MUST
+        // continue to report DDC2 — that's what every shipped P2 wire format
+        // in Zeus assumes (every test in PsWireFormatTests asserts on
+        // offset 29 = 17 + 12, i.e. DDC2's config block).
+        Assert.Equal(2, Protocol2Client.RxBaseDdc(board));
+    }
+
+    [Fact]
+    public void CmdRx_Hermes_EnablesDdc0_Not_Ddc2()
+    {
+        var p = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 1, numAdc: 1, sampleRateKhz: 48, psEnabled: false,
+            boardKind: HpsdrBoardKind.Hermes);
+
+        // Bit 0 set = DDC0 enable; bit 2 (DDC2) MUST stay clear.
+        Assert.Equal((byte)0x01, p[7]);
+    }
+
+    [Fact]
+    public void CmdRx_Hermes_Writes_DDC0_Config_At_Offset_17()
+    {
+        var p = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 1, numAdc: 1, sampleRateKhz: 48, psEnabled: false,
+            boardKind: HpsdrBoardKind.Hermes);
+
+        // DDC0 config block: byte 17 = ADC0, bytes 18..19 = sample-rate BE,
+        // byte 22 = bit depth (24).
+        Assert.Equal((byte)0x00, p[17]);          // ADC0
+        Assert.Equal((byte)0x00, p[18]);          // 48 kHz BE high
+        Assert.Equal((byte)48,   p[19]);          // 48 kHz BE low
+        Assert.Equal((byte)24,   p[22]);          // 24-bit
+
+        // DDC2's config block (offset 29) MUST stay zero on Hermes — the
+        // radio rejects the packet otherwise.
+        Assert.Equal((byte)0x00, p[29]);
+        Assert.Equal((byte)0x00, p[31]);
+        Assert.Equal((byte)0x00, p[34]);
+    }
+
+    [Fact]
+    public void CmdRx_Hermes_Does_Not_Set_DDC1_Sync_Or_PS_Block()
+    {
+        // psEnabled=true gets ignored for Hermes — the PS feedback layout is
+        // OrionMkII-specific (DDC0+DDC1 paired with byte 1363 sync). If a
+        // future code path tries to arm PS on Hermes we want to no-op the PS
+        // bytes, not scribble OrionMkII shape onto the wire.
+        var p = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 1, numAdc: 1, sampleRateKhz: 96, psEnabled: true,
+            boardKind: HpsdrBoardKind.Hermes);
+
+        Assert.Equal((byte)0x00, p[1363]);        // no DDC1→DDC0 sync
+        Assert.Equal((byte)0x01, p[7]);           // only DDC0 enable
+        Assert.Equal((byte)0x00, p[23]);          // DDC1 config block untouched
+        Assert.Equal((byte)0x00, p[28]);
+    }
+
+    [Fact]
+    public void CmdRx_DefaultBoardKind_Preserves_OrionMkII_WireShape()
+    {
+        // The 4-arg overload (no boardKind) was the entire P2 surface before
+        // this change. Calling the 5-arg form WITHOUT specifying boardKind
+        // must produce byte-identical output to the legacy shape. This is
+        // what protects every existing G2 / 7000DLE / 8000DLE / Saturn
+        // operator on the next release.
+        var withDefault = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 42, numAdc: 2, sampleRateKhz: 192, psEnabled: false);
+        var explicitG2 = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 42, numAdc: 2, sampleRateKhz: 192, psEnabled: false,
+            boardKind: HpsdrBoardKind.OrionMkII);
+        Assert.Equal(withDefault, explicitG2);
+
+        // And the legacy single bit lights up DDC2.
+        Assert.Equal((byte)0x04, withDefault[7]);
+    }
+}

--- a/tests/Zeus.Protocol2.Tests/IqGainCorrectionTests.cs
+++ b/tests/Zeus.Protocol2.Tests/IqGainCorrectionTests.cs
@@ -65,4 +65,20 @@ public class IqGainCorrectionTests
     {
         Assert.Equal(1.0, Protocol2Client.IqGainCorrection(board, rateKhz));
     }
+
+    [Theory]
+    [InlineData(48)]
+    [InlineData(96)]
+    [InlineData(192)]
+    [InlineData(384)]
+    public void HermesII_Never_Applies_Scaler(int rateKhz)
+    {
+        // ANAN-10E / ANAN-100B firmware (wire byte 0x02) shares the
+        // single-ADC DDC0 wire shape with Hermes/Brick2 but does NOT exhibit
+        // the +29 dB lift at 48 kHz — deskhpsdr only gates the scaler on
+        // NEW_DEVICE_HERMES (0x01). Widening it to HermesII would knock
+        // 29 dB off legitimate ANAN-10E / ANAN-100B RX. Pin to 1.0 at every
+        // P2 sample rate so a future refactor can't silently drift the gate.
+        Assert.Equal(1.0, Protocol2Client.IqGainCorrection(HpsdrBoardKind.HermesII, rateKhz));
+    }
 }

--- a/tests/Zeus.Protocol2.Tests/IqGainCorrectionTests.cs
+++ b/tests/Zeus.Protocol2.Tests/IqGainCorrectionTests.cs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Xunit;
+using Zeus.Contracts;
+
+namespace Zeus.Protocol2.Tests;
+
+/// <summary>
+/// Per-board, per-sample-rate RX IQ gain correction (issue #171, Brick2).
+/// Reference: deskhpsdr <c>src/new_protocol.c:2516-2530</c>.
+///
+/// Anti-regression discipline: every non-Hermes board AND every non-48 kHz
+/// Hermes rate MUST return exactly 1.0. The whole point of the gate is that
+/// the correction is invisible to vanilla HL2 / ANAN-G2 / OrionMkII / Saturn
+/// operators — if one of these returns anything other than 1.0, somebody's
+/// S-meter has just silently shifted on their main rig.
+/// </summary>
+public class IqGainCorrectionTests
+{
+    [Fact]
+    public void Hermes_At_48Khz_Applies_Minus29dB()
+    {
+        // 10^(-29/20) ≈ 0.0354813389 — match deskhpsdr literal exactly so
+        // a Brick2 user comparing S-meter readings across the two clients
+        // gets the same number.
+        Assert.Equal(0.0354813389, Protocol2Client.IqGainCorrection(HpsdrBoardKind.Hermes, 48));
+    }
+
+    [Theory]
+    [InlineData(96)]
+    [InlineData(192)]
+    [InlineData(384)]
+    public void Hermes_Above_48Khz_Unaffected(int rateKhz)
+    {
+        Assert.Equal(1.0, Protocol2Client.IqGainCorrection(HpsdrBoardKind.Hermes, rateKhz));
+    }
+
+    [Theory]
+    [InlineData(HpsdrBoardKind.Metis)]
+    [InlineData(HpsdrBoardKind.HermesII)]
+    [InlineData(HpsdrBoardKind.Angelia)]
+    [InlineData(HpsdrBoardKind.Orion)]
+    [InlineData(HpsdrBoardKind.HermesLite2)]
+    [InlineData(HpsdrBoardKind.OrionMkII)]
+    [InlineData(HpsdrBoardKind.HermesC10)]
+    [InlineData(HpsdrBoardKind.Unknown)]
+    public void NonHermes_Boards_At_48Khz_Unaffected(HpsdrBoardKind board)
+    {
+        Assert.Equal(1.0, Protocol2Client.IqGainCorrection(board, 48));
+    }
+
+    [Theory]
+    [InlineData(HpsdrBoardKind.HermesLite2, 96)]
+    [InlineData(HpsdrBoardKind.OrionMkII, 192)]
+    [InlineData(HpsdrBoardKind.HermesC10, 384)]
+    [InlineData(HpsdrBoardKind.Unknown, 48)]
+    public void NonHermes_Boards_At_Any_Rate_Unaffected(HpsdrBoardKind board, int rateKhz)
+    {
+        Assert.Equal(1.0, Protocol2Client.IqGainCorrection(board, rateKhz));
+    }
+}

--- a/tests/Zeus.Protocol2.Tests/MacOSUdpPrimeTests.cs
+++ b/tests/Zeus.Protocol2.Tests/MacOSUdpPrimeTests.cs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Net;
+using System.Net.NetworkInformation;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Zeus.Protocol2.Tests;
+
+/// <summary>
+/// Coverage for the helpers underpinning the macOS UDP route-priming
+/// workaround (issue #171, Brick2 ARP quirk).
+///
+/// The priming SendTo can't be unit-tested without a real radio on the LAN,
+/// but the interface-lookup helper and the never-throws contract of
+/// <see cref="Protocol2Client.PrimeMacOSUdpRoute"/> both have deterministic
+/// fingerprints we can pin in CI.
+/// </summary>
+public class MacOSUdpPrimeTests
+{
+    [Fact]
+    public void FindInterfaceIndexForLocalAddress_ReturnsZero_ForUnknownAddress()
+    {
+        // 0.0.0.0 is not owned by any NIC, so the lookup must fall through
+        // and the caller will skip priming. This is the "safe-to-call-anywhere"
+        // contract — never throw on an address the host doesn't recognise.
+        Assert.Equal(0, Protocol2Client.FindInterfaceIndexForLocalAddress(IPAddress.Any));
+    }
+
+    [Fact]
+    public void FindInterfaceIndexForLocalAddress_FindsLoopback_WhenPresent()
+    {
+        // Skip in the rare CI environment without a loopback interface; the
+        // assertion would have nothing to compare against. Every developer
+        // machine and every standard CI runner has at least one loopback NIC.
+        var loopback = FindLoopbackInterfaceIndex();
+        if (loopback <= 0) return; // host doesn't expose loopback IPv4
+
+        Assert.Equal(loopback, Protocol2Client.FindInterfaceIndexForLocalAddress(IPAddress.Loopback));
+    }
+
+    [Fact]
+    public void PrimeMacOSUdpRoute_NeverThrows_ForUnreachableAddress()
+    {
+        // Calling priming with a TEST-NET-1 address (RFC 5737, guaranteed
+        // unroutable) on any host must produce a clean no-throw. The
+        // priming is best-effort — every failure path is swallowed by
+        // design because the regular SendCmdGeneral that follows will do
+        // ARP eventually on hosts that don't need the workaround.
+        var doc = IPAddress.Parse("192.0.2.1");
+        var ex = Record.Exception(() =>
+            Protocol2Client.PrimeMacOSUdpRoute(doc, NullLogger.Instance));
+        Assert.Null(ex);
+    }
+
+    private static int FindLoopbackInterfaceIndex()
+    {
+        foreach (var nic in NetworkInterface.GetAllNetworkInterfaces())
+        {
+            if (nic.NetworkInterfaceType != NetworkInterfaceType.Loopback) continue;
+            foreach (var ua in nic.GetIPProperties().UnicastAddresses)
+            {
+                if (ua.Address.Equals(IPAddress.Loopback))
+                {
+                    var ipv4 = nic.GetIPProperties().GetIPv4Properties();
+                    return ipv4?.Index ?? 0;
+                }
+            }
+        }
+        return 0;
+    }
+}

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -270,6 +270,12 @@ export type ConnectRequest = {
   preampOn?: boolean;
   // Server accepts 0..3 (→ 0/10/20/30 dB attenuation).
   atten?: number;
+  // Raw HPSDR board byte from discovery's details.rawBoardId. Passed to
+  // /api/connect/p2 so the server knows the real board kind instead of
+  // defaulting to OrionMkII for every P2 connection (issue #171 — Brick2
+  // identifies as Hermes/0x01 on P2). Omit for manual connects where the
+  // board is unknown.
+  boardId?: number;
 };
 
 // System.Text.Json can serialize enums as either numbers (default) or strings

--- a/zeus-web/src/components/ConnectPanel.tsx
+++ b/zeus-web/src/components/ConnectPanel.tsx
@@ -106,6 +106,16 @@ function errorMessage(err: unknown): string {
   return String(err);
 }
 
+// Discovery surfaces rawBoardId as a hex string like "0x01" (Hermes) /
+// "0x0A" (OrionMkII). Parse it back to a byte so we can hand it to the
+// connect endpoint — issue #171.
+function parseRawBoardId(raw: string | undefined): number | null {
+  if (!raw) return null;
+  const n = parseInt(raw, 16);
+  if (!Number.isFinite(n) || n < 0 || n > 0xff) return null;
+  return n;
+}
+
 // Post-connect side-effects shared by discover-click and manual-connect: push
 // persisted TX values so the radio doesn't key at its boot default, and resume
 // the AudioContext on the gesture so the user doesn't need a second Play click.
@@ -237,7 +247,15 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
       setError(null);
       try {
         if (isP2) {
-          await apiConnectP2({ endpoint: ep, sampleRate: DEFAULT_SAMPLE_RATE });
+          // Pass the discovered board byte (e.g. 0x01 = Hermes for Brick2).
+          // Without this the server falls back to OrionMkII for every P2
+          // connection — issue #171.
+          const rawBoardId = parseRawBoardId(r.details?.rawBoardId);
+          await apiConnectP2({
+            endpoint: ep,
+            sampleRate: DEFAULT_SAMPLE_RATE,
+            boardId: rawBoardId ?? undefined,
+          });
           const fresh = await fetchState();
           applyState(fresh);
           hydrateTxFromState(fresh);


### PR DESCRIPTION
## Summary

Adds Protocol-2 RX support for the **ANAN-10E** (HermesII wire byte `0x02`). ANAN-10E is a single-ADC Hermes-class radio with the same DDC0 wire shape Brick2 needed in #171 — without this change Zeus enables DDC2 on the RX command packet and the radio never streams IQ.

Branched from `develop`. Cherry-picks two commits from `feature/brick2_support` (PR #171) and extends one of them.

## Changes

1. **`af245e2` (cherry-pick of `75989cf`)** — `fix(p2): propagate discovered board kind on connect`. Plumb the discovered wire byte through `/api/connect/p2` -> `ConnectP2Async` -> `MarkProtocol2Connected` so `RadioService.ConnectedBoardKind` returns the right board (not the hardcoded `OrionMkII` it returned before). Required for every non-G2 board on P2.

2. **`ab50878` (cherry-pick of `282dace`)** — `feat(p2): Brick2/Hermes-on-Protocol-2 support`. Adds `IqGainCorrection` (Hermes-only 48 kHz −29 dB scaler), `RxBaseDdc` (Hermes -> DDC0, default DDC2), PS no-op for Hermes-class, and macOS UDP route priming. Tests included.

3. **`9879701` (new)** — `feat(p2): extend Hermes-on-P2 DDC0 path to HermesII (ANAN-10E / 100B)`. The key delta for this PR:
   - `RxBaseDdc(HermesII)` -> DDC0 (was DDC2 via default).
   - `ComposeCmdRxBuffer` no-ops the PS feedback block for HermesII as well (single-ADC, no PS hardware).
   - `IqGainCorrection` **stays gated on `Hermes` alone** — the +29 dB 48 kHz lift is a Brick2 firmware quirk per deskhpsdr `new_protocol.c:2516` (keyed on `NEW_DEVICE_HERMES`, not `NEW_DEVICE_HERMES2`). Widening it to HermesII would knock 29 dB off legitimate ANAN-10E RX.
   - Tests: HermesII parity in `HermesP2DdcMappingTests` (DDC0 enable, config block at offset 17, PS no-op); HermesII pinned to 1.0 across 48/96/192/384 kHz in `IqGainCorrectionTests`.

## Reference

deskhpsdr `src/new_protocol.c:1692-1698`:
```c
int ddc = i;
if (device == NEW_DEVICE_ANGELIA  || device == NEW_DEVICE_ORION ||
    device == NEW_DEVICE_ORION2 || device == NEW_DEVICE_SATURN) { ddc = 2 + i; }
```
`NEW_DEVICE_HERMES` and `NEW_DEVICE_HERMES2` both fall through to `ddc = i`.

deskhpsdr `radio.c:1860-1880` — `NEW_DEVICE_HERMES2` sets `n_adc = 1`, matching Zeus's `HermesIIClass` fingerprint (single ADC, no PS reserved DDCs).

## Not addressed (deliberate)

- **0x02 wire-byte collision with ANAN-100B.** ANAN-100B also reports `HermesII` on the wire but has different PA gains (50 dB vs 41 dB) and rated power (100 W vs 10/30 W). Zeus currently bakes 10E values into `HermesIIClass` / `HermesGains`. A follow-up variant selector (analogous to `OrionMkIIVariant`) would be needed if a 100B owner shows up. Flagging only — not blocking 10E support.
- **Protocol 1 `anan10E` IQ-buffer layout quirk** (deskhpsdr `old_protocol.c:1511,1553,1688` — "use RX2 for TX DAC in the HERMES case"). P1-only, not addressed here.

## Test plan

- [x] `dotnet build Zeus.slnx` clean
- [x] `dotnet test Zeus.slnx --no-build` clean — `Zeus.Protocol2.Tests` 84/84; full solution: 954 passed / 0 failed / 137 skipped (DSP env-gated).
- [x] `tsc --noEmit` in `zeus-web` clean.
- [ ] **Bench test on real ANAN-10E required before merge** — RX should now stream IQ from the discovered HermesII without operator intervention. No HL2 regression expected (HermesLite2 path is untouched and the `RxBaseDdc` default for HL2 wasn't changed).