### PR TITLE
chore: bump version to 0.7.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,8 +8,8 @@
     <!-- Version Management -->
     <!-- When building from a tag (e.g., v0.1.0), GITHUB_REF_NAME will be set -->
     <!-- Otherwise, fall back to the in-development VersionPrefix below.    -->
-    <!-- Bump this when a release branch opens — current target: v0.7.1.    -->
-    <VersionPrefix Condition="'$(VersionPrefix)' == ''">0.7.1</VersionPrefix>
+    <!-- Bump this when a release branch opens — current target: v0.7.2.    -->
+    <VersionPrefix Condition="'$(VersionPrefix)' == ''">0.7.2</VersionPrefix>
     <VersionSuffix Condition="'$(VersionSuffix)' == '' AND '$(GITHUB_REF_TYPE)' != 'tag'">dev</VersionSuffix>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>

--- a/zeus-web/src/components/AboutPanel.tsx
+++ b/zeus-web/src/components/AboutPanel.tsx
@@ -24,7 +24,7 @@ import { useEffect, useState } from 'react';
 // Release date for the version this build ships against. Bump whenever
 // VersionPrefix in Directory.Build.props bumps. ISO 8601 so toLocaleDateString
 // renders sensibly in any locale.
-const RELEASE_DATE_ISO = '2026-05-12';
+const RELEASE_DATE_ISO = '2026-05-13';
 
 type VersionInfo = {
   version: string;


### PR DESCRIPTION
Pre-release version bump for v0.7.2. Two trivial edits: Directory.Build.props VersionPrefix 0.7.1 → 0.7.2, AboutPanel.tsx RELEASE_DATE_ISO 2026-05-12 → 2026-05-13.

Step 1 of 4 in the v0.7.2 release sequence (this PR → develop → main release-merge → tag-and-push).