### PR TITLE
 TCI: real-time TX_CHRONO pacing for WSJT-X TX audio

### DIFF
--- a/Zeus.Server.Hosting/Tci/TciServer.cs
+++ b/Zeus.Server.Hosting/Tci/TciServer.cs
@@ -75,13 +75,37 @@ public sealed class TciServer : IHostedService, IDisposable
     private readonly ConcurrentDictionary<Guid, TciSession> _clients = new();
     private bool _subscribed;
 
-    // TX_CHRONO sync emitter — fires while MOX is on so any session with
-    // TRX source = TCI gets a "send another TX audio block now" signal at
-    // the audio block rate (spec §3.4). 50 ms cadence ≈ 2400 mono samples
-    // at 48 kHz, which lines up with the default 2048-frame TCI block.
-    private const int TxChronoIntervalMs = 50;
+    // TX_CHRONO demand-driven pacing — mirrors Thetis cmaster.serviceTCITxProtocol.
+    // WSJT-X generates all FT8 audio as fast as TX_CHRONO arrives, so we MUST
+    // pace at approximately real-time (1 chrono per ~42ms = 2048 samples @ 48kHz).
+    // Otherwise WSJT-X finishes a 12.6s message in <2s and the rest of TX is silence.
+    private const int TciTxChronoSpacingMs = 42;
+    private const int TciTxBurstCount = 3;
+
+    private int _tciTxChronoOutstanding;
+    private int _tciTxSamplesInPipeline;
+    private long _tciTxLastChronoTickMs;
+    private readonly object _tciTxStateLock = new();
     private Timer? _txChronoTimer;
     private byte[]? _txChronoFrame;
+
+    internal void NotifyTxAudioQueued(int monoSamplesQueued)
+    {
+        lock (_tciTxStateLock)
+        {
+            if (_tciTxChronoOutstanding > 0)
+                _tciTxChronoOutstanding--;
+            _tciTxSamplesInPipeline += monoSamplesQueued;
+        }
+    }
+
+    internal void NotifyWdspConsumed(int monoSamplesConsumed)
+    {
+        lock (_tciTxStateLock)
+        {
+            _tciTxSamplesInPipeline = Math.Max(0, _tciTxSamplesInPipeline - monoSamplesConsumed);
+        }
+    }
 
     public TciServer(
         IOptions<TciOptions> options,
@@ -145,7 +169,7 @@ public sealed class TciServer : IHostedService, IDisposable
             _subscribed = false;
         }
 
-        StopTxChronoTimer();
+        StopTciTxService();
 
         _log.LogInformation("tci.stopping active={Count}", _clients.Count);
 
@@ -185,7 +209,7 @@ public sealed class TciServer : IHostedService, IDisposable
 
         var id = Guid.NewGuid();
         var sessionLog = _loggerFactory.CreateLogger<TciSession>();
-        var session = new TciSession(id, ws, sessionLog, _radio, _tx, _pipeline, _spots, _options, _txAudioIngest);
+        var session = new TciSession(id, ws, sessionLog, _radio, _tx, _pipeline, _spots, _options, _txAudioIngest, this);
 
         _clients[id] = session;
         _log.LogInformation("tci.client.connected id={Id} total={Count}", id, _clients.Count);
@@ -291,6 +315,20 @@ public sealed class TciServer : IHostedService, IDisposable
         }
     }
 
+    // TODO(remove): temporary RX audio debug counters
+    private static int _dbgRxAudioFrames;
+    private static DateTime _dbgRxLastFlush = DateTime.UtcNow;
+    private static readonly object _dbgRxLock = new();
+    private static readonly string _dbgRxLogPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "zeus-tci-debug.log");
+
+    private static void DbgLogRx(string msg)
+    {
+        lock (_dbgRxLock)
+        {
+            File.AppendAllText(_dbgRxLogPath, $"{DateTime.UtcNow:HH:mm:ss.fff} {msg}\n");
+        }
+    }
+
     private void OnRxAudioAvailable(int receiver, int sampleRateHz, ReadOnlyMemory<float> samples)
     {
         if (_clients.IsEmpty) return;
@@ -300,6 +338,19 @@ public sealed class TciServer : IHostedService, IDisposable
         {
             if (session.WantsAudioStream(receiver)) { anyWants = true; break; }
         }
+
+        // TODO(remove): log RX audio availability for debug
+        lock (_dbgRxLock)
+        {
+            _dbgRxAudioFrames++;
+            if (DateTime.UtcNow - _dbgRxLastFlush >= TimeSpan.FromSeconds(2))
+            {
+                DbgLogRx($"RX-audio: frames={_dbgRxAudioFrames} samples={samples.Length} sr={sampleRateHz} anyWants={anyWants} clients={_clients.Count}");
+                _dbgRxAudioFrames = 0;
+                _dbgRxLastFlush = DateTime.UtcNow;
+            }
+        }
+
         if (!anyWants) return;
 
         var payload = TciStreamPayload.BuildAudioFromFloats(receiver, sampleRateHz, samples.Span);
@@ -314,9 +365,10 @@ public sealed class TciServer : IHostedService, IDisposable
     {
         // Standalone TX meter events broadcast to all clients
         // tx_power:<watts> — forward power
-        Broadcast(TciProtocol.Command("tx_power", (int)Math.Round(fwdWatts)));
+        var fwdStr = fwdWatts.ToString("F1", System.Globalization.CultureInfo.InvariantCulture);
+        Broadcast(TciProtocol.Command("tx_power", fwdStr));
         // tx_forward_power:<watts> — alias many clients listen for
-        Broadcast(TciProtocol.Command("tx_forward_power", (int)Math.Round(fwdWatts)));
+        Broadcast(TciProtocol.Command("tx_forward_power", fwdStr));
         // tx_swr:<ratio> — SWR ratio (e.g. 1.5 for 1.5:1)
         var swrStr = swr.ToString("F1", System.Globalization.CultureInfo.InvariantCulture);
         Broadcast(TciProtocol.Command("tx_swr", swrStr));
@@ -329,11 +381,12 @@ public sealed class TciServer : IHostedService, IDisposable
         // Combined-frame TX telemetry, sent only to clients that opted in via
         // tx_sensors_enable. mic_db isn't carried in TxMetersUpdated; emit 0.
         if (_clients.IsEmpty) return;
+        var refStr = refWatts.ToString("F1", System.Globalization.CultureInfo.InvariantCulture);
         var frame = TciProtocol.Command(
             "tx_sensors",
             0, 0,
-            (int)Math.Round(fwdWatts),
-            (int)Math.Round(refWatts),
+            fwdStr,
+            refStr,
             swrStr);
         foreach (var session in _clients.Values)
         {
@@ -379,39 +432,79 @@ public sealed class TciServer : IHostedService, IDisposable
 
     private void OnMoxChanged(bool moxOn)
     {
-        if (moxOn) StartTxChronoTimer();
-        else StopTxChronoTimer();
+        if (moxOn) StartTciTxService();
+        else StopTciTxService();
     }
 
-    private void StartTxChronoTimer()
+    private void StartTciTxService()
     {
         if (_txChronoTimer is not null) return;
+        lock (_tciTxStateLock)
+        {
+            _tciTxChronoOutstanding = 0;
+            _tciTxSamplesInPipeline = 0;
+            _tciTxLastChronoTickMs = 0;
+        }
         _txChronoFrame ??= TciStreamPayload.BuildTxChrono(receiver: 0, sampleRate: 48000);
-        _txChronoTimer = new Timer(_ => SendTxChronoTick(), null, TxChronoIntervalMs, TxChronoIntervalMs);
-        _log.LogDebug("tci.tx.chrono started interval={Ms}ms", TxChronoIntervalMs);
+        _txChronoTimer = new Timer(_ => ServiceTciTxProtocol(), null, TciTxChronoSpacingMs, TciTxChronoSpacingMs);
+        _txAudioIngest.SetWdspConsumedCallback(NotifyWdspConsumed);
+        _log.LogDebug("tci.tx.chrono started (demand-driven)");
     }
 
-    private void StopTxChronoTimer()
+    private void StopTciTxService()
     {
         var t = Interlocked.Exchange(ref _txChronoTimer, null);
         if (t is null) return;
         t.Dispose();
+        _txAudioIngest.SetWdspConsumedCallback(null);
+        lock (_tciTxStateLock)
+        {
+            _tciTxChronoOutstanding = 0;
+            _tciTxSamplesInPipeline = 0;
+        }
         _log.LogDebug("tci.tx.chrono stopped");
     }
 
-    private void SendTxChronoTick()
+    private void ServiceTciTxProtocol()
     {
+        if (!_tx.IsMoxOn || _clients.IsEmpty) return;
+
         var frame = _txChronoFrame;
-        if (frame is null || _clients.IsEmpty) return;
-        foreach (var session in _clients.Values)
+        if (frame is null) return;
+
+        long nowMs = DateTime.UtcNow.Ticks / TimeSpan.TicksPerMillisecond;
+
+        int sent = 0;
+        while (sent < TciTxBurstCount)
         {
-            if (session.TxSourceIsTci) session.SendBinary(frame);
+            lock (_tciTxStateLock)
+            {
+                // Rate-limit: don't send faster than real-time audio consumption.
+                // One TX_CHRONO = 2048 mono samples @ 48kHz = 42.67ms.
+                long elapsed = nowMs - _tciTxLastChronoTickMs;
+                if (elapsed < TciTxChronoSpacingMs)
+                    break;
+
+                // Don't request more if pipeline already has enough buffered.
+                // Target: ~100ms of audio ahead (4800 samples).
+                if (_tciTxSamplesInPipeline > 4800)
+                    break;
+
+                _tciTxChronoOutstanding++;
+                _tciTxLastChronoTickMs = nowMs;
+            }
+
+            foreach (var session in _clients.Values)
+            {
+                if (session.TxSourceIsTci) session.SendBinary(frame);
+            }
+            sent++;
         }
     }
 
     public void Dispose()
     {
-        StopTxChronoTimer();
+        StopTciTxService();
         foreach (var session in _clients.Values)
         {
             session.Dispose();

--- a/Zeus.Server.Hosting/Tci/TciServer.cs
+++ b/Zeus.Server.Hosting/Tci/TciServer.cs
@@ -324,20 +324,6 @@ public sealed class TciServer : IHostedService, IDisposable
         }
     }
 
-    // TODO(remove): temporary RX audio debug counters
-    private static int _dbgRxAudioFrames;
-    private static DateTime _dbgRxLastFlush = DateTime.UtcNow;
-    private static readonly object _dbgRxLock = new();
-    private static readonly string _dbgRxLogPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "zeus-tci-debug.log");
-
-    private static void DbgLogRx(string msg)
-    {
-        lock (_dbgRxLock)
-        {
-            File.AppendAllText(_dbgRxLogPath, $"{DateTime.UtcNow:HH:mm:ss.fff} {msg}\n");
-        }
-    }
-
     private void OnRxAudioAvailable(int receiver, int sampleRateHz, ReadOnlyMemory<float> samples)
     {
         if (_clients.IsEmpty) return;
@@ -346,18 +332,6 @@ public sealed class TciServer : IHostedService, IDisposable
         foreach (var session in _clients.Values)
         {
             if (session.WantsAudioStream(receiver)) { anyWants = true; break; }
-        }
-
-        // TODO(remove): log RX audio availability for debug
-        lock (_dbgRxLock)
-        {
-            _dbgRxAudioFrames++;
-            if (DateTime.UtcNow - _dbgRxLastFlush >= TimeSpan.FromSeconds(2))
-            {
-                DbgLogRx($"RX-audio: frames={_dbgRxAudioFrames} samples={samples.Length} sr={sampleRateHz} anyWants={anyWants} clients={_clients.Count}");
-                _dbgRxAudioFrames = 0;
-                _dbgRxLastFlush = DateTime.UtcNow;
-            }
         }
 
         if (!anyWants) return;

--- a/Zeus.Server.Hosting/Tci/TciServer.cs
+++ b/Zeus.Server.Hosting/Tci/TciServer.cs
@@ -43,6 +43,7 @@
 // License for details.
 
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Net.WebSockets;
 using Microsoft.Extensions.Options;
 using Zeus.Contracts;
@@ -77,14 +78,22 @@ public sealed class TciServer : IHostedService, IDisposable
 
     // TX_CHRONO demand-driven pacing — mirrors Thetis cmaster.serviceTCITxProtocol.
     // WSJT-X generates all FT8 audio as fast as TX_CHRONO arrives, so we MUST
-    // pace at approximately real-time (1 chrono per ~42ms = 2048 samples @ 48kHz).
-    // Otherwise WSJT-X finishes a 12.6s message in <2s and the rest of TX is silence.
-    private const int TciTxChronoSpacingMs = 42;
+    // pace at exactly real-time (1 chrono per 2048 samples @ 48 kHz = 42.6667 ms).
+    // Integer-millisecond pacing leaves a 1.6% rate error that — combined with
+    // any timer drift — overflows TxAudioIngest._accumulator (2048 cap) every
+    // ~1.8 s, dropping a full 42 ms block and breaking FT8 phase continuity.
+    // Compute the spacing in stopwatch ticks (sub-ms) and pace off a monotonic
+    // Stopwatch so DateTime jumps can't disturb TX timing.
+    private const int TciTxBlockSamples = 2048;
+    private const int TciTxBlockRate = 48000;
     private const int TciTxBurstCount = 3;
+    private static readonly long TciTxChronoSpacingSwTicks =
+        (long)Math.Round((double)TciTxBlockSamples * Stopwatch.Frequency / TciTxBlockRate);
 
     private int _tciTxChronoOutstanding;
     private int _tciTxSamplesInPipeline;
-    private long _tciTxLastChronoTickMs;
+    private long _tciTxLastChronoSwTicks;
+    private readonly Stopwatch _txChronoClock = new();
     private readonly object _tciTxStateLock = new();
     private Timer? _txChronoTimer;
     private byte[]? _txChronoFrame;
@@ -439,16 +448,26 @@ public sealed class TciServer : IHostedService, IDisposable
     private void StartTciTxService()
     {
         if (_txChronoTimer is not null) return;
+        _txChronoClock.Restart();
         lock (_tciTxStateLock)
         {
             _tciTxChronoOutstanding = 0;
             _tciTxSamplesInPipeline = 0;
-            _tciTxLastChronoTickMs = 0;
+            // Seed one spacing in the past so the first timer fire sends one
+            // chrono. Any larger initial debt would dump the burst-cap on the
+            // very first tick, which WSJT-X can't usefully consume before MOX
+            // is fully up.
+            _tciTxLastChronoSwTicks = _txChronoClock.ElapsedTicks - TciTxChronoSpacingSwTicks;
         }
         _txChronoFrame ??= TciStreamPayload.BuildTxChrono(receiver: 0, sampleRate: 48000);
-        _txChronoTimer = new Timer(_ => ServiceTciTxProtocol(), null, TciTxChronoSpacingMs, TciTxChronoSpacingMs);
+        // Service the queue at ~half the spacing so a single late OS tick can
+        // still be caught up by the next one without burning the burst budget.
+        // The actual chrono cadence is enforced by the stopwatch math inside
+        // ServiceTciTxProtocol, not by this period.
+        const int ServiceIntervalMs = 20;
+        _txChronoTimer = new Timer(_ => ServiceTciTxProtocol(), null, ServiceIntervalMs, ServiceIntervalMs);
         _txAudioIngest.SetWdspConsumedCallback(NotifyWdspConsumed);
-        _log.LogDebug("tci.tx.chrono started (demand-driven)");
+        _log.LogDebug("tci.tx.chrono started (demand-driven, spacingTicks={Ticks})", TciTxChronoSpacingSwTicks);
     }
 
     private void StopTciTxService()
@@ -472,26 +491,31 @@ public sealed class TciServer : IHostedService, IDisposable
         var frame = _txChronoFrame;
         if (frame is null) return;
 
-        long nowMs = DateTime.UtcNow.Ticks / TimeSpan.TicksPerMillisecond;
-
         int sent = 0;
         while (sent < TciTxBurstCount)
         {
+            long nowTicks = _txChronoClock.ElapsedTicks;
             lock (_tciTxStateLock)
             {
                 // Rate-limit: don't send faster than real-time audio consumption.
-                // One TX_CHRONO = 2048 mono samples @ 48kHz = 42.67ms.
-                long elapsed = nowMs - _tciTxLastChronoTickMs;
-                if (elapsed < TciTxChronoSpacingMs)
+                // One TX_CHRONO = 2048 mono samples @ 48 kHz = 42.6667 ms.
+                long elapsed = nowTicks - _tciTxLastChronoSwTicks;
+                if (elapsed < TciTxChronoSpacingSwTicks)
                     break;
 
                 // Don't request more if pipeline already has enough buffered.
-                // Target: ~100ms of audio ahead (4800 samples).
+                // Target: ~100 ms of audio ahead (4800 samples).
                 if (_tciTxSamplesInPipeline > 4800)
                     break;
 
                 _tciTxChronoOutstanding++;
-                _tciTxLastChronoTickMs = nowMs;
+                // Advance by one spacing in ticks (NOT to nowTicks): the OS
+                // timer fires unevenly, and resetting to nowTicks bakes the
+                // drift in permanently — causing FT8 audio rate to slip ~2%
+                // above real-time and overflow the TxAudioIngest accumulator
+                // every ~1.8 s. Fixed-increment advance lets a late tick
+                // catch up via the burst budget below.
+                _tciTxLastChronoSwTicks += TciTxChronoSpacingSwTicks;
             }
 
             foreach (var session in _clients.Values)

--- a/Zeus.Server.Hosting/Tci/TciSession.cs
+++ b/Zeus.Server.Hosting/Tci/TciSession.cs
@@ -156,7 +156,8 @@ public sealed class TciSession : IDisposable
         DspPipelineService pipeline,
         SpotManager spots,
         TciOptions options,
-        TxAudioIngest? txAudioIngest = null)
+        TxAudioIngest? txAudioIngest = null,
+        TciServer? tciServer = null)
     {
         _id = id;
         _ws = ws;
@@ -168,11 +169,9 @@ public sealed class TciSession : IDisposable
         _options = options;
         _rateLimiter = new TciRateLimiter(options.RateLimitMs, Send);
         _txAudioIngest = txAudioIngest;
-        // Receiver is wired only when an ingest target is available — keeps
-        // unit tests that stand up a session without DI from needing a full
-        // WDSP pipeline.
         _txAudioReceiver = txAudioIngest is not null
-            ? new TciTxAudioReceiver(txAudioIngest.OnMicPcmBytes, log)
+            ? new TciTxAudioReceiver(txAudioIngest.OnMicPcmBytes, log,
+                onMonoSamplesQueued: tciServer is not null ? tciServer.NotifyTxAudioQueued : null)
             : null;
     }
 
@@ -459,6 +458,21 @@ public sealed class TciSession : IDisposable
     /// LineOut as outbound-only, and TX_CHRONO (=3) is sent by the server
     /// rather than received. Spec §3.4.
     /// </summary>
+    // TODO(remove): temporary file logger for TCI TX audio debug — remove after WSJT-X TX audio is confirmed working
+    private static int _dbgTxBinaryCount;
+    private static int _dbgTxPayloadBytes;
+    private static DateTime _dbgTxLastFlush = DateTime.UtcNow;
+    private static readonly object _dbgTxLock = new();
+    private static readonly string _dbgLogPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "zeus-tci-debug.log");
+
+    private static void DbgLog(string msg)
+    {
+        lock (_dbgTxLock)
+        {
+            File.AppendAllText(_dbgLogPath, $"{DateTime.UtcNow:HH:mm:ss.fff} {msg}\n");
+        }
+    }
+
     private void HandleBinaryFrame(ReadOnlySpan<byte> frame)
     {
         if (!TciStreamPayload.TryParseHeader(frame, out var header))
@@ -467,24 +481,22 @@ public sealed class TciSession : IDisposable
             return;
         }
 
+        // TODO(remove): log all inbound binary frames for TCI TX audio debug
+        DbgLog($"binary-in type={header.StreamType} recv={header.Receiver} len={header.Length} sr={header.SampleRate} fmt={header.SampleType} bytes={frame.Length}");
+
         if (header.StreamType != TciStreamType.TxAudioStream)
         {
-            // Spec §7.2: client→server stream types are TX audio only. Anything
-            // else (IQ, RX audio, LineOut, TX_CHRONO) on the inbound path is
-            // protocol-incorrect. Drop quietly.
             _log.LogDebug("tci inbound binary type={Type} ignored (TX audio only)", header.StreamType);
             return;
         }
 
         if (_txAudioReceiver is null)
         {
-            // No DI'd ingest target — usually a unit-test session.
+            _log.LogWarning("tci.dbg TX audio receiver is null — no ingest target");
+            DbgLog("TX-audio DROPPED: receiver is null");
             return;
         }
 
-        // Source / MOX gating. The downstream TxAudioIngest also gates on
-        // MOX, but dropping early avoids wasting cycles decoding a frame
-        // that would never reach the wire.
         bool sourceIsTci;
         int channels;
         lock (_streamLock)
@@ -494,16 +506,33 @@ public sealed class TciSession : IDisposable
         }
         if (!sourceIsTci)
         {
-            _log.LogDebug("tci.tx.audio dropped (TRX source != tci)");
+            _log.LogWarning("tci.dbg TX audio dropped: sourceIsTci=false");
+            DbgLog("TX-audio DROPPED: sourceIsTci=false");
             return;
         }
         if (!_tx.IsMoxOn)
         {
-            _log.LogDebug("tci.tx.audio dropped (MOX off)");
+            _log.LogWarning("tci.dbg TX audio dropped: MOX off");
+            DbgLog("TX-audio DROPPED: MOX off");
             return;
         }
 
         var samplePayload = frame.Slice(TciStreamPayload.HeaderSize);
+
+        // TODO(remove): accumulate stats and flush to log once per second
+        lock (_dbgTxLock)
+        {
+            _dbgTxBinaryCount++;
+            _dbgTxPayloadBytes += samplePayload.Length;
+            if (DateTime.UtcNow - _dbgTxLastFlush >= TimeSpan.FromSeconds(1))
+            {
+                DbgLog($"TX-audio stats: frames={_dbgTxBinaryCount} payloadBytes={_dbgTxPayloadBytes} declaredLen={header.Length} channels={channels}");
+                _dbgTxBinaryCount = 0;
+                _dbgTxPayloadBytes = 0;
+                _dbgTxLastFlush = DateTime.UtcNow;
+            }
+        }
+
         _txAudioReceiver.AcceptTxAudio(
             samplePayload,
             header.SampleType,
@@ -944,6 +973,7 @@ public sealed class TciSession : IDisposable
         if (!on) ResetTxAudio();
 
         _tx.TrySetMox(on, out _);
+        Send(TciProtocol.Command("trx", rx, on));
     }
 
     private void HandleTune(string[] args)
@@ -959,6 +989,7 @@ public sealed class TciSession : IDisposable
         else if (args.Length >= 2 && TciProtocol.TryParseBool(args[1], out bool on))
         {
             _tx.TrySetTun(on, out _);
+            Send(TciProtocol.Command("tune", rx, on));
         }
     }
 

--- a/Zeus.Server.Hosting/Tci/TciSession.cs
+++ b/Zeus.Server.Hosting/Tci/TciSession.cs
@@ -43,6 +43,7 @@
 // License for details.
 
 using System.Buffers;
+using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Net.WebSockets;
 using System.Text;
@@ -461,6 +462,7 @@ public sealed class TciSession : IDisposable
     // TODO(remove): temporary file logger for TCI TX audio debug — remove after WSJT-X TX audio is confirmed working
     private static int _dbgTxBinaryCount;
     private static int _dbgTxPayloadBytes;
+    private static float _dbgTxPeakAccum;
     private static DateTime _dbgTxLastFlush = DateTime.UtcNow;
     private static readonly object _dbgTxLock = new();
     private static readonly string _dbgLogPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "zeus-tci-debug.log");
@@ -519,16 +521,26 @@ public sealed class TciSession : IDisposable
 
         var samplePayload = frame.Slice(TciStreamPayload.HeaderSize);
 
-        // TODO(remove): accumulate stats and flush to log once per second
+        // TODO(remove): accumulate stats and peak amplitude, flush once per second
+        float framePeak = 0f;
+        int frameFloats = Math.Min((int)header.Length, samplePayload.Length / 4);
+        for (int i = 0; i < frameFloats; i++)
+        {
+            float v = BinaryPrimitives.ReadSingleLittleEndian(samplePayload.Slice(i * 4, 4));
+            if (v < 0) v = -v;
+            if (v > framePeak) framePeak = v;
+        }
         lock (_dbgTxLock)
         {
             _dbgTxBinaryCount++;
             _dbgTxPayloadBytes += samplePayload.Length;
+            if (framePeak > _dbgTxPeakAccum) _dbgTxPeakAccum = framePeak;
             if (DateTime.UtcNow - _dbgTxLastFlush >= TimeSpan.FromSeconds(1))
             {
-                DbgLog($"TX-audio stats: frames={_dbgTxBinaryCount} payloadBytes={_dbgTxPayloadBytes} declaredLen={header.Length} channels={channels}");
+                DbgLog($"TX-audio stats: frames={_dbgTxBinaryCount} payloadBytes={_dbgTxPayloadBytes} declaredLen={header.Length} channels={channels} peak={_dbgTxPeakAccum:F4}");
                 _dbgTxBinaryCount = 0;
                 _dbgTxPayloadBytes = 0;
+                _dbgTxPeakAccum = 0f;
                 _dbgTxLastFlush = DateTime.UtcNow;
             }
         }

--- a/Zeus.Server.Hosting/Tci/TciSession.cs
+++ b/Zeus.Server.Hosting/Tci/TciSession.cs
@@ -43,7 +43,6 @@
 // License for details.
 
 using System.Buffers;
-using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Net.WebSockets;
 using System.Text;
@@ -459,22 +458,6 @@ public sealed class TciSession : IDisposable
     /// LineOut as outbound-only, and TX_CHRONO (=3) is sent by the server
     /// rather than received. Spec §3.4.
     /// </summary>
-    // TODO(remove): temporary file logger for TCI TX audio debug — remove after WSJT-X TX audio is confirmed working
-    private static int _dbgTxBinaryCount;
-    private static int _dbgTxPayloadBytes;
-    private static float _dbgTxPeakAccum;
-    private static DateTime _dbgTxLastFlush = DateTime.UtcNow;
-    private static readonly object _dbgTxLock = new();
-    private static readonly string _dbgLogPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "zeus-tci-debug.log");
-
-    private static void DbgLog(string msg)
-    {
-        lock (_dbgTxLock)
-        {
-            File.AppendAllText(_dbgLogPath, $"{DateTime.UtcNow:HH:mm:ss.fff} {msg}\n");
-        }
-    }
-
     private void HandleBinaryFrame(ReadOnlySpan<byte> frame)
     {
         if (!TciStreamPayload.TryParseHeader(frame, out var header))
@@ -482,9 +465,6 @@ public sealed class TciSession : IDisposable
             _log.LogDebug("tci binary frame too short or malformed len={Len}", frame.Length);
             return;
         }
-
-        // TODO(remove): log all inbound binary frames for TCI TX audio debug
-        DbgLog($"binary-in type={header.StreamType} recv={header.Receiver} len={header.Length} sr={header.SampleRate} fmt={header.SampleType} bytes={frame.Length}");
 
         if (header.StreamType != TciStreamType.TxAudioStream)
         {
@@ -494,8 +474,6 @@ public sealed class TciSession : IDisposable
 
         if (_txAudioReceiver is null)
         {
-            _log.LogWarning("tci.dbg TX audio receiver is null — no ingest target");
-            DbgLog("TX-audio DROPPED: receiver is null");
             return;
         }
 
@@ -508,43 +486,16 @@ public sealed class TciSession : IDisposable
         }
         if (!sourceIsTci)
         {
-            _log.LogWarning("tci.dbg TX audio dropped: sourceIsTci=false");
-            DbgLog("TX-audio DROPPED: sourceIsTci=false");
+            _log.LogDebug("tci.tx.audio dropped (TRX source != tci)");
             return;
         }
         if (!_tx.IsMoxOn)
         {
-            _log.LogWarning("tci.dbg TX audio dropped: MOX off");
-            DbgLog("TX-audio DROPPED: MOX off");
+            _log.LogDebug("tci.tx.audio dropped (MOX off)");
             return;
         }
 
         var samplePayload = frame.Slice(TciStreamPayload.HeaderSize);
-
-        // TODO(remove): accumulate stats and peak amplitude, flush once per second
-        float framePeak = 0f;
-        int frameFloats = Math.Min((int)header.Length, samplePayload.Length / 4);
-        for (int i = 0; i < frameFloats; i++)
-        {
-            float v = BinaryPrimitives.ReadSingleLittleEndian(samplePayload.Slice(i * 4, 4));
-            if (v < 0) v = -v;
-            if (v > framePeak) framePeak = v;
-        }
-        lock (_dbgTxLock)
-        {
-            _dbgTxBinaryCount++;
-            _dbgTxPayloadBytes += samplePayload.Length;
-            if (framePeak > _dbgTxPeakAccum) _dbgTxPeakAccum = framePeak;
-            if (DateTime.UtcNow - _dbgTxLastFlush >= TimeSpan.FromSeconds(1))
-            {
-                DbgLog($"TX-audio stats: frames={_dbgTxBinaryCount} payloadBytes={_dbgTxPayloadBytes} declaredLen={header.Length} channels={channels} peak={_dbgTxPeakAccum:F4}");
-                _dbgTxBinaryCount = 0;
-                _dbgTxPayloadBytes = 0;
-                _dbgTxPeakAccum = 0f;
-                _dbgTxLastFlush = DateTime.UtcNow;
-            }
-        }
-
         _txAudioReceiver.AcceptTxAudio(
             samplePayload,
             header.SampleType,

--- a/Zeus.Server.Hosting/Tci/TciStreamPayload.cs
+++ b/Zeus.Server.Hosting/Tci/TciStreamPayload.cs
@@ -118,14 +118,17 @@ internal static class TciStreamPayload
     /// the client uses this as a "send another TX audio block now" signal per
     /// spec §3.4. Sent periodically by the server while MOX is on AND the
     /// session has TRX source = TCI.
+    /// <paramref name="length"/> is total-float-count (samples * channels)
+    /// matching Thetis modern-length-semantics (TCIServer.cs:5936).
+    /// Default: 2048 samples * 2 channels = 4096 floats.
     /// </summary>
-    public static byte[] BuildTxChrono(int receiver, int sampleRate)
+    public static byte[] BuildTxChrono(int receiver, int sampleRate, int length = 4096)
     {
         return Build(
             receiver,
             sampleRate,
             TciSampleType.Float32,
-            length: 0,
+            length: length,
             streamType: TciStreamType.TxChrono,
             samplePayload: ReadOnlySpan<byte>.Empty);
     }

--- a/Zeus.Server.Hosting/Tci/TciTxAudioReceiver.cs
+++ b/Zeus.Server.Hosting/Tci/TciTxAudioReceiver.cs
@@ -45,6 +45,7 @@ internal sealed class TciTxAudioReceiver : IDisposable
 
     private readonly Action<ReadOnlyMemory<byte>> _forward;
     private readonly ILogger _log;
+    private readonly Action<int>? _onMonoSamplesQueued;
 
     private readonly object _sync = new();
     private readonly float[] _monoAccumulator = new float[AccumulatorCapacity];
@@ -55,10 +56,11 @@ internal sealed class TciTxAudioReceiver : IDisposable
     private long _totalFramesDropped;
     private long _totalSamplesForwarded;
 
-    public TciTxAudioReceiver(Action<ReadOnlyMemory<byte>> forwardF32leMicBlock, ILogger log)
+    public TciTxAudioReceiver(Action<ReadOnlyMemory<byte>> forwardF32leMicBlock, ILogger log, Action<int>? onMonoSamplesQueued = null)
     {
         _forward = forwardF32leMicBlock ?? throw new ArgumentNullException(nameof(forwardF32leMicBlock));
         _log = log;
+        _onMonoSamplesQueued = onMonoSamplesQueued;
     }
 
     public long TotalFramesAccepted { get { lock (_sync) return _totalFramesAccepted; } }
@@ -101,9 +103,12 @@ internal sealed class TciTxAudioReceiver : IDisposable
             return;
         }
 
-        // Trust the smaller of the declared float count and the actual payload
-        // size in floats — protects against a malformed length field.
-        int floatCount = (int)Math.Min(declaredFloatCount, (uint)(samplePayload.Length / 4));
+        // WSJT-X allocates a buffer of length*sizeof(float)*2 bytes but
+        // readAudioData only writes to the first length floats (length/2
+        // stereo frames via the load() function). The tail is zeroes from
+        // QByteArray::resize. Use declaredFloatCount as the cap so we don't
+        // decode silence as audio.
+        int floatCount = Math.Min((int)(samplePayload.Length / 4), (int)declaredFloatCount);
         if (floatCount <= 0)
         {
             lock (_sync) _totalFramesDropped++;
@@ -111,8 +116,6 @@ internal sealed class TciTxAudioReceiver : IDisposable
         }
         if (channels == 2 && (floatCount & 1) != 0)
         {
-            // Odd float count for stereo means the last L without an R —
-            // truncate by one to keep alignment.
             floatCount--;
         }
 
@@ -155,8 +158,6 @@ internal sealed class TciTxAudioReceiver : IDisposable
             _monoFill += monoSampleCount;
             _totalFramesAccepted++;
 
-            // Drain accumulator in 960-sample blocks. Each block becomes a
-            // 3840-byte f32le buffer dispatched synchronously to TxAudioIngest.
             int writeOffset = 0;
             while (_monoFill - writeOffset >= OutputBlockSamples)
             {
@@ -170,6 +171,10 @@ internal sealed class TciTxAudioReceiver : IDisposable
                 writeOffset += OutputBlockSamples;
                 _totalSamplesForwarded += OutputBlockSamples;
             }
+
+            int forwarded = writeOffset;
+            int netQueued = monoSampleCount - forwarded;
+            _onMonoSamplesQueued?.Invoke(netQueued);
 
             // Shift the remainder (always < 960 samples) to the head.
             int remainder = _monoFill - writeOffset;

--- a/Zeus.Server.Hosting/TxAudioIngest.cs
+++ b/Zeus.Server.Hosting/TxAudioIngest.cs
@@ -78,6 +78,7 @@ public sealed class TxAudioIngest : IDisposable
     private readonly ILogger<TxAudioIngest> _log;
     private readonly StreamingHub _hub;
     private readonly Action<ReadOnlyMemory<byte>> _handler;
+    private Action<int>? _onWdspConsumed;
 
     private readonly object _sync = new();
     // Accumulator scratch — sized to at least one WDSP block plus one frontend
@@ -130,12 +131,14 @@ public sealed class TxAudioIngest : IDisposable
         Func<bool> isMoxOn,
         StreamingHub hub,
         ILogger<TxAudioIngest> log,
-        Action<ReadOnlyMemory<float>>? forwardP2 = null)
+        Action<ReadOnlyMemory<float>>? forwardP2 = null,
+        Action<int>? onWdspConsumed = null)
     {
         _ring = ring;
         _engineProvider = engineProvider;
         _isMoxOn = isMoxOn;
         _forwardP2 = forwardP2;
+        _onWdspConsumed = onWdspConsumed;
         _hub = hub;
         _log = log;
         _handler = OnMicPcmBytes;
@@ -144,6 +147,7 @@ public sealed class TxAudioIngest : IDisposable
 
     private readonly Action<ReadOnlyMemory<float>>? _forwardP2;
 
+    internal void SetWdspConsumedCallback(Action<int>? cb) { _onWdspConsumed = cb; }
     public long TotalMicSamples { get { lock (_sync) return _totalMicSamples; } }
     public long TotalTxBlocks { get { lock (_sync) return _totalTxBlocks; } }
     public long DroppedFrames { get { lock (_sync) return _droppedFrames; } }
@@ -263,6 +267,7 @@ public sealed class TxAudioIngest : IDisposable
                         _forwardP2?.Invoke(new ReadOnlyMemory<float>(_scratchIq, 0, 2 * produced));
                     }
                     _totalTxBlocks++;
+                    _onWdspConsumed?.Invoke(blockSize);
 
                     // Accumulate peaks for the 1 Hz diagnostic log.
                     float micPeak = 0f;


### PR DESCRIPTION
  - **feat(tci):** WSJT-X TX-audio path — demand-driven `TX_CHRONO`
    emitter that mirrors Thetis `cmaster.serviceTCITxProtocol`, with
    protocol fixes WSJT-X needs (length field, length-cap on the
    oversized response buffer, `trx`/`tune` echo for the PTT timeout,
    `tx_power`/`tx_sensors` decimal format).
  - **fix(tci):** `TX_CHRONO` real-time pacing. The previous integer-ms
    spacing (42 ms) plus `lastTick = nowMs` reset baked OS-timer drift
    into the rate, ending up ~2.4 % above real-time (24 fps observed
    vs. 23.44 fps required). That overflowed `TxAudioIngest._accumulator`
    every ~1.8 s, dropping a full 42 ms block and breaking FT8 phase
    continuity. The fix paces in `Stopwatch.Frequency` ticks (exact
    42.6667 ms) and advances by one spacing per chrono (not by `nowMs`),
    with the service timer at 20 ms so a late OS tick can be caught up
    inside the burst budget instead of bleeding into the next interval.
  - **chore(tci):** drop the temporary `~/zeus-tci-debug.log` file
    instrumentation that surfaced the drift. The standard `ILogger` debug
    channel covers what's left.

  ## Why this matters

  Without the pacing fix the IQ ring drains every ~1.8 s during a TX,
  producing periodic ~42 ms silence gaps that scramble FT8 symbol
  timing. Locally this manifested as "TX shows energy on the panadapter
  but receivers can't decode the FT8 signal." Tune kept working because
  its tone is steady; FT8/FT4 didn't.