### PR TITLE
chore(agent): bump KB2UKA-Agent max_turns 30 → 100

### DIFF
--- a/.github/workflows/kb2uka-agent.yml
+++ b/.github/workflows/kb2uka-agent.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.KB2UKA_OAUTH_TOKEN }}
           allowed_tools: "Bash,Read,Edit,Write,Glob,Grep,WebFetch,WebSearch"
-          max_turns: "30"
+          max_turns: "100"
           model: "claude-sonnet-4-6"
           prompt: |
             You are **KB2UKA-Agent** 🛠, KB2UKA's personal coding assistant for


### PR DESCRIPTION
First open-ended invocation on #294 hit `error_max_turns` at 30 turns mid-analysis (read the code, ran out of turn budget before posting the conclusion comment). 100 turns gives comfortable headroom; worst-case cost per invocation rises proportionally to ~$2.30 — acceptable for a personal bot.