### PR TITLE
chore(agent): bump max_turns to 100 + stream progress as 3 milestone comments

### DIFF
--- a/.github/workflows/kb2uka-agent.yml
+++ b/.github/workflows/kb2uka-agent.yml
@@ -98,16 +98,43 @@ jobs:
                relevant code, docs, prior commits. Cite file:line at every
                claim. Post one focused comment.
             3. If the ask is to write or fix code:
+                 - **Post a "starting work" comment first** with a 2–4 bullet
+                   plan of what you'll touch and what done looks like. This is
+                   the first of three progress comments (see below). Do this
+                   BEFORE you branch or edit any files.
                  - Branch off `develop` with a `kb2uka-agent/<short-topic>` name.
                  - Implement the change. Match the existing code style.
                  - Build (`dotnet build Zeus.slnx`) — must be 0 warnings, 0 errors.
                  - Run tests (`dotnet test Zeus.slnx`) — no regressions.
+                 - **Post a "build/test results" comment** with one-line status
+                   per check (build, .NET tests, frontend lint/typecheck/test
+                   if you touched the frontend). If anything fails, say so and
+                   what you're doing about it.
                  - Commit with a conventional message (feat: / fix: / chore: / etc).
                  - Push the branch.
                  - Open a PR against `develop` (NEVER `main`). Title + body should
                    reference the originating issue/PR. Sign off "— KB2UKA-Agent 🛠".
-                 - Post a follow-up comment on the originating thread linking to
-                   the new PR.
+                 - **Post a final "PR opened" comment** on the originating thread
+                   linking to the new PR.
+
+            ## Progress visibility (when writing code)
+
+            KB2UKA wants to watch you work. Post **three** brief progress
+            comments on the triggering thread, in order:
+
+            1. **Starting / plan** — before you edit any files. Bullet list:
+               what files you'll touch, what the user-visible outcome is, any
+               red-light concerns you'll flag for review instead of committing.
+            2. **Build/test status** — after `dotnet build` and any other
+               check commands but before you commit. One line per check.
+            3. **PR opened** — link to the new PR after `gh pr create` succeeds.
+
+            Three is the cap. Don't post intermediate "still working" pings —
+            KB2UKA can see the workflow status. If you get blocked or need to
+            change direction, that's fine, post a 4th comment explaining; but
+            don't narrate every file read or grep.
+
+            Each progress comment ends with the sign-off line below.
 
             ## Rules (hard)
 
@@ -124,8 +151,10 @@ jobs:
               KB2UKA's dev box but is NOT on the CI runner; use the inline code
               comments + docs/references/ + docs/lessons/ here).
             - **Be concise.** Prefer understatement. No "Great question!" openings.
-            - **One comment per turn** on the triggering thread. If you need a
-              follow-up after merging a PR, that's a separate comment.
+            - **Comments are capped at three for code work** (plan, build/test
+              status, PR-opened) plus one extra if you get blocked. For
+              question/triage asks it's still one comment. Never spam the
+              thread.
 
             ## Sign-off
 


### PR DESCRIPTION
## Summary

Two small KB2UKA-Agent workflow tweaks bundled together:

1. **`max_turns: 30 → 100`** (already on this branch as `2f76208`) — the previous cap was tripping the agent on multi-step work.
2. **Streaming progress comments** (new commit `570a794`) — for code-work asks, the agent now posts three milestone comments on the originating thread: (a) starting + plan, (b) build/test results, (c) PR-opened link. Question/triage asks remain a single comment. Cap is three (+1 if blocked) — no narration spam.

## Why

KB2UKA wants to watch the agent work in real time on issue threads rather than seeing one big drop at the end. Three comments at meaningful milestones gives that visibility without flooding the thread.

## Test plan

- [x] Workflow YAML is valid (this PR triggers `Build and Test` CI on the workflow file itself; the agent workflow itself isn't exercised by CI but the syntax is checked).
- [ ] After merge: re-comment `@kb2uka-agent` on issue #318 and confirm three milestone comments land in order.