### PR TITLE
fix(server): stop routing LAN cert private key through macOS keychain

### DIFF
--- a/Zeus.Server.Hosting/LanCertificate.cs
+++ b/Zeus.Server.Hosting/LanCertificate.cs
@@ -41,10 +41,16 @@ public static class LanCertificate
         {
             try
             {
+                // PersistKeySet would route the private key through the
+                // macOS login keychain (X509MoveToKeychain), which fails with
+                // "User interaction is not allowed" when the backend is
+                // launched from a non-GUI parent (CI, SSH, Claude Code's
+                // PTY). The PFX file on disk already handles persistence
+                // between runs; keychain persistence is redundant.
                 var existing = X509CertificateLoader.LoadPkcs12FromFile(
                     path,
                     string.Empty,
-                    X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+                    X509KeyStorageFlags.Exportable);
                 if (CoversAllIps(existing, ips) && existing.NotAfter > DateTime.UtcNow.AddDays(30))
                 {
                     log?.LogInformation("LAN certificate loaded from {Path} ({Subject}, expires {Expires:yyyy-MM-dd})",
@@ -116,7 +122,7 @@ public static class LanCertificate
         return X509CertificateLoader.LoadPkcs12(
             pfx,
             string.Empty,
-            X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+            X509KeyStorageFlags.Exportable);
     }
 
     private static bool CoversAllIps(X509Certificate2 cert, HashSet<IPAddress> required)


### PR DESCRIPTION
## Summary

Drop `X509KeyStorageFlags.PersistKeySet` from both `X509CertificateLoader` calls in `LanCertificate.cs`. On macOS this flag triggers `X509MoveToKeychain`, which fails outright with **"User interaction is not allowed"** when the backend is launched from any non-GUI parent — CI runners, SSH sessions, Claude Code's PTY, anything not directly tied to the window server.

The PFX file at `ResolveCertPath()` already handles persistence between runs. The keychain insertion was redundant for a self-signed dev cert, and it was the only thing making the backend impossible to start in non-interactive shells on macOS.

## Symptom this fixes

```
Unhandled exception. Interop+AppleCrypto+AppleCommonCryptoCryptographicException: User interaction is not allowed.
   at Interop.AppleCrypto.X509MoveToKeychain(...)
   at System.Security.Cryptography.X509Certificates.X509CertificateLoader.LoadPkcs12(...)
   at Zeus.Server.LanCertificate.Generate(HashSet`1 ips) in .../LanCertificate.cs:line 116
   at Zeus.Server.LanCertificate.GetOrCreate(ILogger log) in .../LanCertificate.cs:line 63
```

Hit when running `dotnet run --project Zeus.Server` from a Claude Code session or any shell whose process tree isn't tied to a GUI app. Linux is unaffected (no keychain plumbing). Windows is unaffected (different code path that doesn't require user prompt).

## Why this is safe

- `Exportable` is preserved, so the private key remains available in-process and HTTPS binding works exactly as before.
- The PFX file on disk is the persistence mechanism — the keychain copy was a side effect, not load-bearing.
- No external consumer reads Zeus's LAN cert from the macOS keychain.

## Test plan

- [x] `dotnet build Zeus.slnx` — 0 warnings, 0 errors.
- [x] Verified backend now binds 6060 + 6443 cleanly from a Claude Code PTY child shell where the previous code aborted at line 116.
- [ ] Manual cross-check on Linux + Windows that the existing HTTPS bind still works (no change expected, but worth a sanity check).