### PR TITLE
style(theme): v3 Lifted Dark — flat chrome, brass headers, deeper accent

### DIFF
--- a/zeus-web/src/components/LeftLayoutBar.tsx
+++ b/zeus-web/src/components/LeftLayoutBar.tsx
@@ -192,7 +192,6 @@ export function LeftLayoutBar() {
           aria-pressed={settingsViewOpen}
         >
           <span className="lb-tab-icon" aria-hidden>⚙</span>
-          <span className="lb-tab-name">Settings</span>
         </button>
       </div>
 

--- a/zeus-web/src/components/TxStageMeters.tsx
+++ b/zeus-web/src/components/TxStageMeters.tsx
@@ -324,10 +324,16 @@ function MeterRow({
             position: 'relative',
             height: 14,
             background: 'var(--meter-bg)',
-            border: '1px solid var(--panel-border)',
-            borderRadius: 0,
+            border: '1px solid var(--line)',
+            borderRadius: 2,
+            // v3 Lifted Dark: warm amber halo around the meter well — the
+            // "lit instruments on a black bench" look. Inner inset stays
+            // for depth; outer halos give the column a soft glow.
             boxShadow:
-              'inset 0 1px 0 rgba(0,0,0,0.5), inset 0 0 0 0.5px rgba(255,255,255,0.02)',
+              'inset 0 1px 3px rgba(0,0,0,0.8),' +
+              ' inset 0 0 0 1px rgba(255,255,255,0.03),' +
+              ' 0 0 18px rgba(255,140,40,0.18),' +
+              ' 0 0 6px rgba(255,170,80,0.12)',
             overflow: 'hidden',
           }}
         >

--- a/zeus-web/src/styles/all-panels.css
+++ b/zeus-web/src/styles/all-panels.css
@@ -23,10 +23,10 @@
   width: 100%;
   height: 100%;
   overflow: auto;
-  /* Use the dark token (--bg-0) for the workspace ground so the gap
-   * between tiles reads like the dark band between the top toolbar
-   * and the second control row — not the blue-gray gutter. */
-  background: var(--bg-0);
+  /* v3 Lifted Dark: workspace ground is the distinct mid-grey "table"
+   * (--bg-workspace), so the chrome (--bg-0) and the panels (--bg-1) each
+   * read as their own surface. */
+  background: var(--bg-workspace);
 }
 
 .all-panels-grid.react-grid-layout {

--- a/zeus-web/src/styles/all-panels.css
+++ b/zeus-web/src/styles/all-panels.css
@@ -128,23 +128,43 @@
     0 2px 6px rgba(0, 0, 0, 0.4);
 }
 
-/* Tile chrome header — title + drag-handle + remove-X. Always-visible X
- * (locked decision); width budget tight at narrow tile widths but the
- * title ellipsises before the X gets in its way. */
+/* Tile chrome header — "brass instrument plate".
+ * Each panel reads as a piece of equipment with an engraved label plate
+ * above it: subtle vertical gradient lifts the header off the panel base,
+ * a 2 px --power amber rail runs the leading edge as a single decisive
+ * accent, a 1 px specular highlight catches across the top, and the
+ * bottom hairline carries a hint of lamp warmth instead of neutral grey.
+ * Title is rendered in engraved-uppercase (open tracking + faint amber
+ * text-shadow) so it pops without resorting to colored type. */
 .workspace-tile-header {
-  height: 24px;
+  position: relative;
+  height: 26px;
   flex-shrink: 0;
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 0 8px;
-  background: linear-gradient(90deg, var(--panel-head-top, var(--panel-top)), var(--panel-head-bot, var(--panel-bot)));
-  border-bottom: 1px solid var(--panel-border);
-  /* Whole header is the drag handle (RGL dragConfig.handle). Show grab
-   * cursor across the full width so the operator knows it's draggable —
-   * tiny grip-only target meant tiles with their own pointer logic
-   * (panadapter canvas) couldn't be moved. */
+  padding: 0 8px 0 10px;
+  background:
+    linear-gradient(180deg, #1c1c21 0%, #141418 100%);
+  border-bottom: 1px solid rgba(255, 177, 60, 0.14);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.045),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.35);
   cursor: grab;
+}
+/* Leading-edge gold rail — the brass plate's mounting screw line. Sits
+ * inside the rounded tile corner via the parent's overflow: hidden. */
+.workspace-tile-header::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--power);
+  box-shadow:
+    0 0 6px rgba(255, 177, 60, 0.55),
+    0 0 14px rgba(255, 177, 60, 0.22);
 }
 .workspace-tile-header:active {
   cursor: grabbing;
@@ -159,12 +179,14 @@
   color: var(--fg-3);
   cursor: grab;
   flex-shrink: 0;
+  transition: color var(--dur-fast);
 }
 .workspace-tile-drag-handle:active {
   cursor: grabbing;
 }
+.workspace-tile-header:hover .workspace-tile-drag-handle,
 .workspace-tile-drag-handle:hover {
-  color: var(--fg-1);
+  color: var(--power);
 }
 
 .workspace-tile-title {
@@ -175,9 +197,11 @@
   white-space: nowrap;
   font-size: 11px;
   font-family: var(--font-sans);
-  letter-spacing: 0.08em;
+  font-weight: 600;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--fg-1);
+  color: var(--fg-0);
+  text-shadow: 0 0 8px rgba(255, 177, 60, 0.10);
   user-select: none;
 }
 

--- a/zeus-web/src/styles/analog-meter.css
+++ b/zeus-web/src/styles/analog-meter.css
@@ -72,11 +72,17 @@
 .am-tile .am-meter-face-wrap,
 .am-tile .analog-meter-face-wrap {
   position: relative;
+  /* v3 Lifted Dark: warm "streetlamp pool" glow rising from the bottom of the
+     gauge well. Final values from Brian's tweak session: hue 31, sat 30%,
+     opacity 19%, ellipse 150% × 83%, anchored at 50% 100%. */
   background:
-    radial-gradient(120% 70% at 50% 110%, var(--accent-soft), transparent 60%),
-    var(--bg-0);
+    radial-gradient(ellipse 150% 83% at 50% 100%,
+      hsla(31, 30%, 65%, 0.19) 0%,
+      hsla(31, 30%, 65%, 0.067) 40%,
+      transparent 75%),
+    var(--bg-inset);
   padding: 12px 14px 4px;
-  border-bottom: 1px solid var(--panel-edge);
+  border-bottom: 1px solid var(--line);
   flex: 1;
   min-height: 0;
   display: flex;

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -788,16 +788,34 @@
   overflow: hidden;
   min-height: 0;
 }
+/* Panel head matches the .workspace-tile-header "brass plate" treatment:
+   subtle vertical gradient, gold leading rail (synthesized via ::before),
+   specular top highlight, warm hairline at the bottom. */
 .panel-head {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 9px;
-  padding: 9px 12px 9px 14px;
-  background: var(--bg-1);
-  border-bottom: 1px solid var(--line-soft);
-  box-shadow: none;
+  padding: 9px 12px 9px 16px;
+  background: linear-gradient(180deg, #1c1c21 0%, #141418 100%);
+  border-bottom: 1px solid rgba(255, 177, 60, 0.14);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.045),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.35);
   min-height: 32px;
   flex-shrink: 0;
+}
+.panel-head::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--power);
+  box-shadow:
+    0 0 6px rgba(255, 177, 60, 0.55),
+    0 0 14px rgba(255, 177, 60, 0.22);
 }
 .panel-head .title {
   font-size: 11px;
@@ -805,7 +823,7 @@
   letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--fg-0);
-  text-shadow: none;
+  text-shadow: 0 0 8px rgba(255, 177, 60, 0.10);
   flex: 0 1 auto;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -21,14 +21,14 @@
 
 .app {
   display: grid;
-  grid-template-columns: 60px 1fr;
-  grid-template-rows: 56px 1fr 44px;
+  grid-template-columns: 56px 1fr;
+  grid-template-rows: 60px 1fr 38px;
   height: 100vh;
   width: 100vw;
   background: var(--bg-0);
   color: var(--fg-0);
-  padding: 6px;
-  gap: 6px;
+  padding: 0;
+  gap: 0;
 }
 
 .app > .left-layout-bar   { grid-column: 1; grid-row: 1 / -1; }
@@ -44,22 +44,30 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
+  /* Outer frame stays black so the strip between the chrome (header /
+     sidebar / footer at --bg-0) and the inner workspace surface reads as
+     continuous chrome. The inner .all-panels-workspace owns the grey
+     canvas the panels sit on. */
+  background: var(--bg-0);
+  padding: 6px;
+  gap: 6px;
 }
 .workspace-area > .alert-banner { flex: 0 0 auto; }
 .workspace-area > .flex-workspace,
 .workspace-area > .settings-view { flex: 1; min-height: 0; }
 
-/* ===== Left layout bar — issue #241 ===== */
+/* ===== Left layout bar — issue #241 (v3 Lifted Dark: flat near-black) ===== */
 .left-layout-bar {
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  padding: 6px 4px;
-  background: linear-gradient(180deg, var(--panel-top), var(--panel-bot));
-  border: 1px solid var(--panel-edge);
-  border-radius: var(--r-lg);
-  box-shadow: var(--panel-shadow);
+  gap: 2px;
+  padding: 8px 4px;
+  background: var(--bg-0);
+  border: 0;
+  border-right: 1px solid var(--line);
+  border-radius: 0;
+  box-shadow: none;
   min-height: 0;
   overflow: hidden;
 }
@@ -83,51 +91,9 @@
   --lb-tint-g: 158;
   --lb-tint-b: 255;
 }
-.left-layout-bar::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  z-index: 0;
-  background: linear-gradient(
-    to bottom,
-    rgba(var(--lb-wash-r), var(--lb-wash-g), var(--lb-wash-b), 0.55) 0%,
-    rgba(var(--lb-wash-r), var(--lb-wash-g), var(--lb-wash-b), 0.55) 50%,
-    rgba(var(--lb-wash-r), var(--lb-wash-g), var(--lb-wash-b), 0.00) 70%,
-    rgba(var(--lb-wash-r), var(--lb-wash-g), var(--lb-wash-b), 0.00) 100%
-  );
-}
-.left-layout-bar::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  z-index: 0;
-  background:
-    radial-gradient(circle,
-      rgba(var(--lb-tint-r), var(--lb-tint-g), var(--lb-tint-b), 0.22) 1px,
-      transparent 1.5px)
-    0 0 / 8px 8px;
-  /* Dots only paint in the 50–70% band: fully transparent above 50%, fade
-     in to ~60% peak, fully transparent again by 70% so the bar's bottom
-     half stays clean. */
-  -webkit-mask-image: linear-gradient(
-    to bottom,
-    transparent 0%,
-    transparent 50%,
-    black 60%,
-    transparent 70%,
-    transparent 100%
-  );
-          mask-image: linear-gradient(
-    to bottom,
-    transparent 0%,
-    transparent 50%,
-    black 60%,
-    transparent 70%,
-    transparent 100%
-  );
-}
+/* v3 Lifted Dark: no decorative wash on the sidebar — flat near-black. */
+.left-layout-bar::before,
+.left-layout-bar::after { content: none; }
 
 /* Direct children sit above the accent layer so layout buttons / actions
    stay fully readable and clickable. */
@@ -159,23 +125,41 @@
   align-items: center;
   justify-content: center;
   gap: 3px;
-  padding: 6px 4px 5px;
-  color: var(--fg-1);
-  background: linear-gradient(180deg, var(--btn-top), var(--btn-bot));
-  border: 1px solid var(--btn-edge);
+  padding: 6px 2px 5px;
+  color: var(--fg-2);
+  background: transparent;
+  border: 1px solid transparent;
   border-radius: var(--r-sm);
-  box-shadow: inset 0 1px 0 var(--btn-hl);
+  box-shadow: none;
   cursor: pointer;
   text-align: center;
   min-height: 50px;
+  position: relative;
   transition: background var(--dur-fast), border-color var(--dur-fast),
-    color var(--dur-fast), box-shadow var(--dur-fast);
+    color var(--dur-fast);
 }
-.left-layout-bar .lb-tab:hover { filter: brightness(1.12); }
+.left-layout-bar .lb-tab:hover {
+  background: var(--bg-2);
+  color: var(--fg-0);
+  filter: none;
+}
 .left-layout-bar .lb-item.active .lb-tab {
-  border-color: var(--accent);
+  background: var(--bg-2);
+  border-color: var(--line-strong);
   color: var(--accent);
-  box-shadow: inset 0 1px 0 var(--btn-hl), 0 0 8px var(--accent-soft);
+  box-shadow: none;
+}
+.left-layout-bar .lb-item.active .lb-tab::before {
+  content: "";
+  position: absolute;
+  left: -5px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 2px;
+  height: 60%;
+  background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+  border-radius: 1px;
 }
 .left-layout-bar .lb-tab-icon {
   font-size: 18px;
@@ -450,13 +434,14 @@
 .topbar {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 0 10px;
-  background: linear-gradient(90deg, var(--panel-top), var(--panel-bot));
-  border: 1px solid var(--panel-edge);
-  border-radius: var(--r-lg);
-  box-shadow: var(--panel-shadow);
-  height: 56px;
+  gap: 18px;
+  padding: 0 14px;
+  background: var(--bg-0);
+  border: 0;
+  border-bottom: 1px solid var(--line);
+  border-radius: 0;
+  box-shadow: none;
+  height: 60px;
   overflow: hidden;
 }
 .topbar .topbar-controls {
@@ -492,10 +477,11 @@
   transform: none;
 }
 .topbar .btn.active {
-  background: var(--accent-soft);
-  color: var(--accent);
-  border-color: rgba(74,158,255,0.35);
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
   text-shadow: none;
+  box-shadow: 0 0 0 1px rgba(46,142,255,0.5), 0 0 14px rgba(46,142,255,0.35);
 }
 .topbar .btn.ghost { background: transparent; }
 .topbar .btn.ghost:hover { background: rgba(255,255,255,0.06); }
@@ -521,10 +507,10 @@
 .brand-text { display: flex; flex-direction: column; }
 .brand-name {
   font-size: 15px;
-  font-weight: 700;
-  letter-spacing: 0.02em;
+  font-weight: 600;
+  letter-spacing: -0.01em;
   color: var(--fg-0);
-  text-shadow: 0 1px 0 rgba(0,0,0,0.5);
+  text-shadow: none;
 }
 .brand-sub {
   font-size: 9px;
@@ -533,31 +519,28 @@
 }
 .topbar-divider {
   width: 1px; height: 32px;
-  background: rgba(0,0,0,0.4);
-  box-shadow: 1px 0 0 rgba(255,255,255,0.06);
+  background: var(--line);
+  box-shadow: none;
 }
 
 /* VFO tab — the big embossed freq readout */
 .vfo-group { display: flex; gap: 4px; align-items: stretch; }
 .vfo-tab {
-  padding: 2px 14px;
-  background: linear-gradient(180deg, #0a1220 0%, #14243e 100%);
-  border: 1px solid #000;
+  padding: 4px 14px;
+  background: var(--bg-2);
+  border: 1px solid var(--line-strong);
   border-radius: var(--r-md);
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   justify-content: center;
   min-width: 120px;
-  box-shadow:
-    inset 0 1px 2px rgba(0,0,0,0.6),
-    inset 0 -1px 0 rgba(255,255,255,0.04),
-    0 1px 0 rgba(255,255,255,0.05);
+  box-shadow: none;
   cursor: pointer;
   transition: all var(--dur-fast);
 }
-.vfo-tab:hover { border-color: var(--accent); }
-.vfo-tab.active { border-color: var(--accent); box-shadow: inset 0 1px 2px rgba(0,0,0,0.6), 0 0 8px var(--accent-soft); }
+.vfo-tab:hover { border-color: var(--accent-line); }
+.vfo-tab.active { border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent-line), 0 0 14px var(--accent-soft); }
 .vfo-tab.active .vfo-freq { color: var(--accent); }
 .vfo-label { font-size: 9px; color: var(--fg-2); font-weight: 600; letter-spacing: 0.06em; }
 .vfo-freq {
@@ -597,10 +580,10 @@
   display: flex;
   gap: 12px;
   padding: 4px 10px;
-  background: linear-gradient(90deg, var(--panel-top), var(--panel-bot));
-  border: 1px solid var(--panel-edge);
+  background: var(--bg-1);
+  border: 1px solid var(--line);
   border-radius: var(--r-lg);
-  box-shadow: var(--panel-shadow);
+  box-shadow: none;
   height: 68px;
   align-items: center;
   overflow: hidden;
@@ -664,73 +647,80 @@
   min-height: 280px;
 }
 
-/* ===== Buttons — chunky dark gradient chrome (matches reference) ===== */
+/* ===== Buttons — v3 Lifted Dark: flat, blue ON state with glow ===== */
 .btn {
-  --btn-top-c: var(--btn-top);
-  --btn-bot-c: var(--btn-bot);
+  --btn-top-c: var(--bg-2);
+  --btn-bot-c: var(--bg-2);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 4px;
-  /* Fluid sizing: stays ~current on MBA/QHD/ultrawide, bumps on 4K+ below.
-     em-padding so the box tracks font-size automatically. */
   padding: 0.5em 0.85em;
   font-size: clamp(11px, 0.15vw + 10px, 13.5px);
-  font-weight: 700;
-  letter-spacing: 0.03em;
-  color: var(--btn-text);
-  background: linear-gradient(180deg, var(--btn-top-c), var(--btn-bot-c));
-  border: 1px solid var(--btn-edge);
-  border-radius: var(--r-sm);
-  box-shadow:
-    inset 0 1px 0 var(--btn-hl),
-    inset 0 -1px 0 rgba(0,0,0,0.3),
-    0 1px 0 rgba(0,0,0,0.5);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--fg-1);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--r-md);
+  box-shadow: none;
   cursor: pointer;
-  transition: filter var(--dur-fast), background var(--dur-fast);
-  text-shadow: 0 1px 0 rgba(0,0,0,0.6);
+  transition: background var(--dur-fast), color var(--dur-fast),
+    border-color var(--dur-fast), box-shadow var(--dur-fast);
+  text-shadow: none;
   white-space: nowrap;
   user-select: none;
 }
 .btn:hover {
-  filter: brightness(1.15);
+  background: var(--bg-2);
+  color: var(--fg-0);
+  filter: none;
 }
 .btn:active,
 .btn.pressed {
-  background: linear-gradient(0deg, var(--btn-top-c), var(--btn-bot-c));
-  box-shadow:
-    inset 0 2px 3px rgba(0,0,0,0.5),
-    inset 0 -1px 0 rgba(255,255,255,0.04);
-  transform: translateY(1px);
+  background: var(--bg-3);
+  box-shadow: none;
+  transform: none;
 }
 .btn.active {
-  --btn-top-c: var(--btn-active-top);
-  --btn-bot-c: var(--btn-active-bot);
+  background: var(--accent);
   color: var(--btn-active-text);
-  text-shadow: 0 1px 0 rgba(0,0,0,0.6), 0 0 8px rgba(74,158,255,0.4);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px rgba(46,142,255,0.5), 0 0 14px rgba(46,142,255,0.35);
+  text-shadow: none;
 }
 .btn.sm { padding: 0.3em 0.7em;  font-size: clamp(10px, 0.1vw + 9.5px, 12px); }
 .btn.lg { padding: 0.55em 1em;   font-size: clamp(13px, 0.2vw + 10px, 15px); }
 .btn.ghost {
-  background: linear-gradient(180deg, #2e2f33, #1c1d20);
+  background: var(--bg-2);
+  border-color: var(--line-strong);
   color: var(--fg-1);
 }
+.btn.ghost:hover { background: var(--bg-3); color: var(--fg-0); }
 .btn.tx {
-  --btn-top-c: #7c1510;
-  --btn-bot-c: #3a0a07;
-  color: #ffd4d0;
-  text-shadow: 0 0 6px rgba(230,58,43,0.8);
+  background: transparent;
+  border-color: var(--line-strong);
+  color: var(--tx);
+  text-shadow: none;
+}
+.btn.tx:hover {
+  background: var(--tx-soft);
+  border-color: var(--tx);
 }
 .btn.tx.active {
-  --btn-top-c: #e63a2b;
-  --btn-bot-c: #8a1a10;
+  background: var(--tx);
+  border-color: var(--tx);
   color: #fff;
+  box-shadow: 0 0 0 1px rgba(255,74,89,0.5), 0 0 14px rgba(255,74,89,0.35);
 }
 .btn.orange {
-  --btn-top-c: var(--orange);
-  --btn-bot-c: #b45410;
+  background: var(--orange);
+  border-color: var(--orange);
   color: #fff;
-  text-shadow: 0 1px 0 rgba(0,0,0,0.4);
+  text-shadow: none;
+}
+.btn.orange:hover {
+  filter: brightness(1.1);
 }
 
 /* 4K-and-above bump. 34" ultrawide (3440 CSS px) stays under this threshold
@@ -787,42 +777,46 @@
 }
 .mono { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
 
-/* ===== Panel chrome (Dockable wrapper) ===== */
+/* ===== Panel chrome (Dockable wrapper) — v3 Lifted Dark: flat ===== */
 .panel {
   display: flex;
   flex-direction: column;
   background: var(--bg-1);
-  border: 1px solid var(--panel-border);
-  border-radius: var(--r-md);
-  box-shadow:
-    inset 0 1px 0 var(--panel-hl-top),
-    0 1px 0 rgba(0,0,0,0.6),
-    0 2px 6px rgba(0,0,0,0.4);
+  border: 1px solid var(--line);
+  border-radius: var(--r-lg);
+  box-shadow: none;
   overflow: hidden;
   min-height: 0;
 }
 .panel-head {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 5px 10px;
-  background: linear-gradient(90deg, var(--panel-head-top), var(--panel-head-bot));
-  border-bottom: 1px solid var(--panel-border);
-  box-shadow: inset 0 1px 0 rgba(255,255,255,0.08);
-  min-height: 28px;
+  gap: 9px;
+  padding: 9px 12px 9px 14px;
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--line-soft);
+  box-shadow: none;
+  min-height: 32px;
   flex-shrink: 0;
 }
 .panel-head .title {
   font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.06em;
+  font-weight: 600;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--fg-0);
-  text-shadow: 0 1px 0 rgba(0,0,0,0.5);
+  text-shadow: none;
   flex: 0 1 auto;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+/* v3 blue "section dot" leading the title — applied wherever a .panel-head
+   has a .dot, but also synthesized via ::before when absent. */
+.panel-head .dot {
+  width: 5px; height: 5px; border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
 }
 .panel-body {
   flex: 1;
@@ -1168,40 +1162,54 @@
   height: 100%;
   min-height: 0;
 }
+/* v3 Lifted Dark — VFO card with pronounced blue aurora behind the digits.
+   Three radial gradients layered over the panel base + a blurred ::before
+   ellipse give the digits a soft bloom of electric blue. */
 .freq-display {
-  padding: 16px 20px;
-  background: linear-gradient(180deg, #0a1220, #14243e);
-  border: 1px solid #000;
-  border-radius: var(--r-md);
-  box-shadow: inset 0 1px 3px rgba(0,0,0,0.7);
+  padding: 28px 20px 20px;
+  background:
+    radial-gradient(ellipse 55% 95% at 50% 55%, rgba(46,142,255,0.22), transparent 70%),
+    radial-gradient(ellipse 80% 60% at 50% 40%, rgba(46,142,255,0.10), transparent 75%),
+    radial-gradient(ellipse 100% 60% at 50% 110%, rgba(46,142,255,0.06), transparent 70%),
+    var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: var(--r-lg);
+  box-shadow: none;
   flex: 1 1 auto;
-  /* Always tall enough for the 38px-floor digits + the top/bottom hint
-     rows + padding. If a flexlayout split squeezes the panel below this,
-     the parent .freq-panel's overflow: auto produces a scrollbar rather
-     than clipping the digits. */
   min-height: 91px;
   display: flex;
   flex-direction: column;
   justify-content: center;
   container-type: size;
+  position: relative;
+  overflow: hidden;
 }
+.freq-display::before {
+  content: "";
+  position: absolute;
+  left: 50%; top: 50%;
+  transform: translate(-50%, -50%);
+  width: 60%; height: 80%;
+  background: radial-gradient(ellipse at center, rgba(78,166,255,0.18), transparent 60%);
+  filter: blur(20px);
+  pointer-events: none;
+}
+.freq-display > * { position: relative; z-index: 1; }
 .freq-top, .freq-bot { display: flex; align-items: center; font-size: 10px; }
 .freq-digits {
   display: flex;
   align-items: baseline;
-  font-family: var(--font-num);
-  font-weight: 700;
-  /* Scales with container WIDTH — digits flow horizontally so width is
-     the axis that decides fit. Floor at 38px keeps the docked-tab
-     baseline; ceiling caps the look on very wide layouts. */
+  font-family: var(--font-sans);
+  /* v3: thin 200-weight Inter, white digits, subtle blue text-shadow */
+  font-weight: 200;
   font-size: clamp(38px, 9cqw, 140px);
-  letter-spacing: 0.01em;
+  letter-spacing: -0.025em;
   color: var(--fg-0);
   font-variant-numeric: tabular-nums;
   line-height: 1.05;
   margin: 4px 0;
   justify-content: center;
-  text-shadow: 0 0 10px var(--accent-soft);
+  text-shadow: 0 0 12px rgba(78,166,255,0.25);
 }
 .freq-digits .digit {
   background: none; border: none; color: inherit; font: inherit;
@@ -1213,8 +1221,8 @@
   color: var(--accent);
   text-shadow: 0 0 10px var(--accent);
 }
-.freq-digits .digit.leading { color: var(--fg-3); }
-.freq-digits .sep { color: var(--fg-2); padding: 0 3px; }
+.freq-digits .digit.leading { color: var(--fg-4); }
+.freq-digits .sep { color: var(--fg-1); padding: 0 1px; font-weight: 200; }
 .vfo-swap { display: flex; align-items: center; gap: 6px; }
 
 /* ===== Meter ===== */
@@ -1327,10 +1335,11 @@
 .qrz-tags { display: flex; gap: 3px; margin-top: 3px; flex-wrap: wrap; }
 .qrz-tag {
   font-size: 8px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;
-  padding: 1px 5px;
-  background: linear-gradient(180deg, rgba(255,255,255,0.08), rgba(0,0,0,0.2));
-  border: 1px solid rgba(74,158,255,0.3);
-  color: var(--fg-1);
+  padding: 2px 6px;
+  background: var(--bg-2);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-xs);
+  color: var(--accent-bright);
 }
 .qrz-section-label {
   font-size: 9px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase;
@@ -1347,14 +1356,14 @@
   flex-shrink: 0;
   width: 72px; height: 72px;
   position: relative;
-  background: linear-gradient(180deg, #2a3a55, #101a2e);
-  border: 1px solid #000;
+  background: var(--bg-2);
+  border: 1px solid var(--line-strong);
   border-radius: var(--r-sm);
   overflow: hidden;
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,0.6);
+  box-shadow: none;
 }
 .qrz-portrait-bg { position: absolute; inset: 0; background: repeating-linear-gradient(45deg, rgba(255,255,255,0.03) 0 4px, transparent 4px 8px); }
 .qrz-grid {
@@ -1385,16 +1394,21 @@
 
 .cs-input {
   width: 90px;
-  background: #0a1220;
-  border: 1px solid #000;
-  border-radius: 0;
-  padding: 3px 8px;
+  background: transparent;
+  border: 1px solid var(--accent-line);
+  border-radius: var(--r-md);
+  padding: 6px 10px;
   font-size: 12px;
-  font-weight: 700;
+  font-weight: 600;
   color: var(--fg-0);
-  letter-spacing: 0.06em;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,0.6);
+  box-shadow: none;
+}
+.cs-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(46,142,255,0.15);
 }
 .cs-input:focus { outline: none; border-color: var(--accent); box-shadow: inset 0 1px 2px rgba(0,0,0,0.6), 0 0 0 1px var(--accent-soft); }
 
@@ -1481,27 +1495,27 @@
 .slider-val { font-size: 11px; font-weight: 700; color: var(--fg-0); }
 .slider-track {
   position: relative;
-  height: 8px;
-  background: #000;
-  border: 1px solid rgba(0,0,0,0.6);
-  border-radius: 0;
+  height: 4px;
+  background: var(--line);
+  border: 0;
+  border-radius: 4px;
   cursor: pointer;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,0.7);
+  box-shadow: none;
 }
 .slider-fill {
   position: absolute; inset: 0 auto 0 0;
-  background: linear-gradient(90deg, var(--accent), color-mix(in srgb, var(--accent) 70%, white));
-  border-radius: 0;
+  background: var(--accent);
+  border-radius: 4px;
 }
 .slider-thumb {
   position: absolute;
   top: 50%;
   transform: translate(-50%, -50%);
-  width: 14px; height: 16px;
-  background: linear-gradient(180deg, #c0cbd9, #7a8698);
-  border: 1px solid #000;
-  border-radius: 0;
-  box-shadow: inset 0 1px 0 rgba(255,255,255,0.6), 0 1px 2px rgba(0,0,0,0.6);
+  width: 14px; height: 14px;
+  background: #ffffff;
+  border: 0;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.5), 0 1px 4px rgba(0,0,0,0.5);
 }
 
 /* ===== CW ===== */
@@ -1525,17 +1539,18 @@
 .cw-cursor { animation: blink 1s steps(2) infinite; color: var(--accent); }
 @keyframes blink { 50% { opacity: 0.2; } }
 
-/* ===== Transport bar ===== */
+/* ===== Transport bar — v3 Lifted Dark: flat near-black ===== */
 .transport {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 0 10px;
-  background: linear-gradient(90deg, var(--panel-top), var(--panel-bot));
-  border: 1px solid var(--panel-edge);
-  border-radius: var(--r-lg);
-  box-shadow: var(--panel-shadow);
-  height: 44px;
+  padding: 0 14px;
+  background: var(--bg-0);
+  border: 0;
+  border-top: 1px solid var(--line);
+  border-radius: 0;
+  box-shadow: none;
+  height: 38px;
 }
 /* Transport buttons read as flat clickable regions of the toolbar, not raised
    chiclets. TX (MOX-on) is excluded — it keeps its red bevel/pulse for safety. */
@@ -1557,21 +1572,22 @@
   transform: none;
 }
 .transport .btn.active {
-  background: var(--accent-soft);
-  color: var(--accent);
-  border-color: rgba(74,158,255,0.35);
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
   text-shadow: none;
+  box-shadow: 0 0 0 1px rgba(46,142,255,0.5), 0 0 14px rgba(46,142,255,0.35);
 }
 .transport .btn.ghost {
   background: transparent;
 }
-.transport .btn.ghost:hover { background: rgba(255,255,255,0.06); }
-/* Restore TX styling for MOX-on state — must remain visually loud. */
+.transport .btn.ghost:hover { background: var(--bg-2); color: var(--fg-0); }
+/* MOX-on must remain visually loud — keep the red but in v3 flat style. */
 .transport .btn.tx {
-  background: linear-gradient(180deg, var(--btn-top-c), var(--btn-bot-c));
-  border: 1px solid var(--btn-edge);
-  color: #ffd4d0;
-  text-shadow: 0 0 6px rgba(230,58,43,0.8);
+  background: var(--tx-soft);
+  border: 1px solid var(--tx);
+  color: var(--tx);
+  text-shadow: none;
 }
 .tx-btn { font-size: 14px; font-weight: 700; letter-spacing: 0.12em; min-width: 80px; }
 .tx-btn.tx {
@@ -1584,7 +1600,7 @@
   0%, 100% { box-shadow: inset 0 1px 0 var(--btn-hl), 0 0 0 rgba(255,56,56,0); }
   50% { box-shadow: inset 0 1px 0 var(--btn-hl), 0 0 12px rgba(255,56,56,0.9); }
 }
-.transport-sep { width: 1px; height: 28px; background: rgba(0,0,0,0.4); box-shadow: 1px 0 0 rgba(255,255,255,0.06); margin: 0 4px; }
+.transport-sep { width: 1px; height: 18px; background: var(--line); box-shadow: none; margin: 0 4px; }
 .knob-group { display: flex; align-items: center; gap: 8px; min-width: 130px; }
 .knob-group > .label-xs { min-width: 32px; color: var(--fg-1); white-space: nowrap; }
 .knob-group > .slider { flex: 1; }

--- a/zeus-web/src/styles/nr-settings.css
+++ b/zeus-web/src/styles/nr-settings.css
@@ -18,10 +18,12 @@
   color: var(--fg-1);
   font-family: var(--font-sans);
   font-size: 12px;
-  border: 1px solid var(--panel-edge);
+  border: 1px solid var(--line);
   border-radius: var(--r-lg);
-  background: linear-gradient(180deg, var(--panel-top) 0%, var(--panel-bot) 100%);
-  box-shadow: inset 0 1px 0 var(--panel-hl-top);
+  /* Nested under the DSP panel — needs to lift visibly off the panel's own
+     --bg-1 base, so we step up one rung to --bg-2. v3 layered-surface feel. */
+  background: var(--bg-2);
+  box-shadow: none;
 }
 
 .nr-settings__title {

--- a/zeus-web/src/styles/tokens.css
+++ b/zeus-web/src/styles/tokens.css
@@ -42,7 +42,7 @@
   --fg-4: #3a3a40;          /* extra-muted for borders/sep */
 
   /* ----- Accents — blue as accent ONLY, not a surface tint ----- */
-  --accent:        #2e8eff;
+  --accent:        #0c5f9c;
   --accent-bright: #4ea6ff;
   --accent-soft:   rgba(46,142,255,0.14);
   --accent-line:   rgba(46,142,255,0.55);

--- a/zeus-web/src/styles/tokens.css
+++ b/zeus-web/src/styles/tokens.css
@@ -1,54 +1,74 @@
 /* ===========================================================
-   Zeus SDR — Design tokens (pulled from Hermes Lite 2 reference)
-   Near-black chrome, mid-gray workspace, classic SDR colors
+   Zeus SDR — Design tokens (v3 "Lifted Dark")
+   Neutral near-black surfaces, electric blue accent, warm amber
+   halos on meters, blue aurora on the VFO. Source of truth.
    =========================================================== */
+
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap');
 
 @font-face { font-display: swap; }
 
 :root {
   /* ----- Workspace ----- */
-  --bg-app:       #657486;  /* mid blue-gray behind panels */
-  --bg-workspace: #575e6b;  /* slightly darker for contrast */
+  --bg-app:       #0a0a0c;  /* app backdrop — header / sidebar / footer chrome */
+  /* Workspace canvas reverts to near-black so the whole layout reads as one
+     continuous dark surface; only the panels (at --bg-1) lift off it. */
+  --bg-workspace: #0a0a0c;
 
-  /* ----- Panels / chrome (near-black like ref) ----- */
-  --bg-0: #1a1b1e;
-  --bg-1: #2a2b2e;
-  --bg-2: #323236;
-  --bg-3: #3a3b3f;
+  /* ----- Surfaces — neutral near-black, no blue tint ----- */
+  --bg-0: #0a0a0c;          /* app backdrop */
+  --bg-1: #111114;          /* panel base */
+  --bg-2: #1a1a1e;          /* raised control / button rest */
+  --bg-3: #232328;          /* hover */
+  --bg-inset:  #060608;     /* deepest wells (panadapter, gauge bg) */
+  --bg-meter:  #050507;     /* LED-meter well, near-pitch */
 
-  /* Panel head bar — matches the "Hermes Lite 2" top bar in ref */
-  --panel-head-top: #3a3b3f;
-  --panel-head-bot: #232427;
-  --panel-border:   #0d0d10;
-  --panel-hl-top:   rgba(255,255,255,0.10);
+  /* Lines — neutral grays */
+  --line:        #1f1f23;
+  --line-soft:   #16161a;
+  --line-strong: #2c2c32;
+
+  /* Panel head — flat (no beveled gradient anymore) */
+  --panel-head-top: var(--bg-1);
+  --panel-head-bot: var(--bg-1);
+  --panel-border:   var(--line);
+  --panel-hl-top:   transparent;
 
   /* ----- Foreground ----- */
   --fg-0: #ffffff;
-  --fg-1: #d4d5d8;
-  --fg-2: #9a9b9f;
-  --fg-3: #6b6c70;
+  --fg-1: #cccccc;
+  --fg-2: #8a8a90;
+  --fg-3: #5a5a60;
+  --fg-4: #3a3a40;          /* extra-muted for borders/sep */
 
-  /* ----- Accents (reference exact) ----- */
-  --accent:      #4a9eff;   /* LSB/USB blue text (like "FAST" blue & frequency blue) */
-  --accent-soft: rgba(74,158,255,0.15);
-  --tx:          #e63a2b;   /* TX red (like "TX: OFF" red) */
-  --tx-soft:     rgba(230,58,43,0.18);
-  --power:       #ffc93a;   /* yellow digits like "20W" */
-  --power-soft:  rgba(255,201,58,0.16);
-  --ok:          #2e7a2e;   /* healthy / normal-range green for meter zones */
-  --ok-soft:     rgba(46,122,46,0.18);
-  --orange:      #f28524;   /* Lookup button top */
-  --orange-dk:   #6b1100;   /* Lookup button shadow edge */
+  /* ----- Accents — blue as accent ONLY, not a surface tint ----- */
+  --accent:        #2e8eff;
+  --accent-bright: #4ea6ff;
+  --accent-soft:   rgba(46,142,255,0.14);
+  --accent-line:   rgba(46,142,255,0.55);
+  --tx:            #ff4a59;
+  --tx-soft:       rgba(255,74,89,0.18);
+  --power:         #ffb13c;
+  --power-soft:    rgba(255,177,60,0.16);
+  --ok:            #2dd566;
+  --ok-soft:       rgba(45,213,102,0.18);
+  --green-soft:    #1aa84e;
+  --amber:         #ffb13c;
+  --amber-soft:    rgba(255,177,60,0.18);
+  --orange:        #ff8a3c;
+  --orange-dk:     #6b1100;
+  --cyan:          #4dc9ff;
+  --yellow:        #e4d645;
 
-  /* ----- Button chrome (matches the ref's chunky dark buttons) ----- */
-  --btn-top:     #4a4b4f;
-  --btn-bot:     #26272a;
-  --btn-hl:      rgba(255,255,255,0.14);
-  --btn-edge:    #0a0a0c;
-  --btn-text:    #e8e9ec;
+  /* ----- Button chrome — flat, no chunky gradient ----- */
+  --btn-top:     var(--bg-2);
+  --btn-bot:     var(--bg-2);
+  --btn-hl:      transparent;
+  --btn-edge:    var(--line-strong);
+  --btn-text:    var(--fg-1);
 
-  --btn-active-top: #5a9cd8;
-  --btn-active-bot: #2e5a8a;
+  --btn-active-top: var(--accent);
+  --btn-active-bot: var(--accent);
   --btn-active-text: #ffffff;
 
   /* ----- Spectrum + waterfall ----- */
@@ -67,8 +87,10 @@
   --wf-6: #c23030;
 
   /* ----- Meters ----- */
-  --meter-bg:    #0d0e10;
-  --meter-fill:  linear-gradient(90deg, #2e7a2e 0%, #4aa04a 55%, #d4a42a 80%, #d04040 100%);
+  --meter-bg:    var(--bg-meter);
+  --meter-fill:  linear-gradient(90deg, var(--ok) 0%, var(--ok) 70%, var(--amber) 90%, var(--tx) 100%);
+  /* Warm amber halo around LED meter columns — "lit instruments on black" */
+  --meter-halo:  0 0 18px rgba(255,140,40,0.18), 0 0 6px rgba(255,170,80,0.12);
 
   /* ----- Immersive meter chrome (BigArc / VuColumn / PullDownArc) -----
      Deeper-than-meter-bg fills used inside the immersive Meters panel so
@@ -79,11 +101,11 @@
      (#161a23 / #11151c / #0c1019) — flattened to neutral greys per the
      operator's "less blues, more greys" feedback. The *-glow tokens
      carry the bloom alpha used by SVG drop-shadows + filters. */
-  --immersive-bg:        #07080a;
-  --immersive-panel:     #1a1c20;
-  --immersive-panel-2:   #16181c;
-  --immersive-well:      #101216;
-  --immersive-well-2:    #0a0b0e;
+  --immersive-bg:        var(--bg-0);
+  --immersive-panel:     var(--bg-1);
+  --immersive-panel-2:   var(--bg-1);
+  --immersive-well:      var(--bg-inset);
+  --immersive-well-2:    var(--bg-meter);
   --immersive-rim:       rgba(255,255,255,0.06);
   --immersive-rim-strong:rgba(255,255,255,0.10);
   --immersive-line:      rgba(255,255,255,0.05);
@@ -138,17 +160,16 @@
   --immersive-lamp-chip-text-glow: rgba(255,245,200,0.16);
   --immersive-lamp-active-glow: rgba(245,240,180,0.18);
 
-  /* ----- Type ----- */
-  --font-sans: 'Archivo Narrow', 'Arial Narrow', sans-serif;
-  --font-mono: 'Archivo Narrow', 'Arial Narrow', sans-serif;
-  --font-display: 'Archivo Narrow', sans-serif;
+  /* ----- Type — v3 Lifted Dark: Inter + JetBrains Mono ----- */
+  --font-sans:    'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+  --font-mono:    'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  --font-display: 'Inter', sans-serif;
 
-  /* ----- Spacing / radius ----- */
-  /* Square-edge experiment: all corner radii flattened. */
-  --r-xs: 0;
-  --r-sm: 0;
-  --r-md: 0;
-  --r-lg: 0;
+  /* ----- Spacing / radius — v3 introduces gentle rounding ----- */
+  --r-xs: 2px;
+  --r-sm: 3px;
+  --r-md: 4px;
+  --r-lg: 6px;
 
   /* ----- Easing ----- */
   --ease-out: cubic-bezier(.22,.61,.36,1);
@@ -157,14 +178,14 @@
   --dur-med:  240ms;
 
   /* ----- Aliases for panel chrome (used across layout.css) ----- */
-  --panel-top:    var(--panel-head-top);
-  --panel-bot:    var(--panel-head-bot);
-  --panel-edge:   var(--panel-border);
-  --panel-shadow: inset 0 1px 0 rgba(255,255,255,0.08), 0 1px 0 rgba(0,0,0,0.6), 0 2px 4px rgba(0,0,0,0.4);
+  --panel-top:    var(--bg-1);
+  --panel-bot:    var(--bg-1);
+  --panel-edge:   var(--line);
+  --panel-shadow: none;
 }
 
-/* Font swapping via [data-fonts] — keep all mapped to Archivo Narrow by default */
-html[data-fonts="geist"] { --font-sans: 'Archivo Narrow', sans-serif; --font-mono: 'Archivo Narrow', sans-serif; --font-display: 'Archivo Narrow', sans-serif; }
+/* Font swapping via [data-fonts] — v3 Lifted Dark defaults to Inter */
+html[data-fonts="geist"] { --font-sans: 'Inter', sans-serif; --font-mono: 'JetBrains Mono', monospace; --font-display: 'Inter', sans-serif; }
 
 /* ===========================================================
    Base resets
@@ -172,14 +193,67 @@ html[data-fonts="geist"] { --font-sans: 'Archivo Narrow', sans-serif; --font-mon
 * { box-sizing: border-box; }
 html, body { height: 100%; margin: 0; }
 body {
-  background: var(--bg-app);
+  background: var(--bg-0);
   color: var(--fg-0);
   font-family: var(--font-sans);
-  font-size: 13px;
+  font-size: 12px;
   line-height: 1.4;
-  letter-spacing: 0.01em;
+  letter-spacing: 0;
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   overflow: hidden;
 }
 button { font-family: inherit; color: inherit; border: 0; background: transparent; cursor: pointer; }
 input { font-family: inherit; color: inherit; }
+
+/* ===========================================================
+   Native range inputs — v3 Lifted Dark: flat blue fill, white round thumb.
+   Scoped to the app shell so panels that opt into native chrome (rare —
+   AnalogMeterConfig already has its own) can still override locally.
+   =========================================================== */
+input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  height: 4px;
+  border-radius: 4px;
+  background: var(--line);
+  outline: none;
+  cursor: pointer;
+}
+input[type="range"]::-webkit-slider-runnable-track {
+  height: 4px;
+  border-radius: 4px;
+  background: var(--line);
+}
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #ffffff;
+  border: 0;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.5), 0 1px 4px rgba(0,0,0,0.5);
+  margin-top: -5px;
+  cursor: pointer;
+}
+input[type="range"]::-moz-range-track {
+  height: 4px;
+  border-radius: 4px;
+  background: var(--line);
+  border: 0;
+}
+input[type="range"]::-moz-range-progress {
+  height: 4px;
+  border-radius: 4px;
+  background: var(--accent);
+}
+input[type="range"]::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #ffffff;
+  border: 0;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.5), 0 1px 4px rgba(0,0,0,0.5);
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- Remaps `tokens.css` to a neutral near-black palette (`--bg-0..3`, `--bg-inset`, `--bg-meter`) and swaps the type stack to Inter + JetBrains Mono. Sidebar, topbar, transport, and panel chrome flatten to match: no more beveled gradients or inset highlights.
- VFO `freq-display` gains a pronounced blue aurora (three layered radial-gradients + a blurred ellipse) behind 200-weight Inter digits. TX stage-meter wells pick up the warm amber halo `box-shadow`; analog gauges bake in the "streetlamp pool" `hsla(31, 30%, 65%, 0.19)` gradient that Brian dialed in.
- Workspace tile + panel-head become "brass instrument plates": subtle vertical gradient, 2 px gold (`--power`) leading rail with a soft bloom, specular top highlight, warm-amber-soft bottom hairline, engraved-style uppercase title with a faint amber text-shadow.
- `--accent` moves from `#2e8eff` to `#0c5f9c` so the active-button glow and VFO aurora read closer to the Hermes Lite 2 hardware blue. NR2 advanced settings card lifts to `--bg-2` so it visibly sits above the DSP panel base. Sidebar gear button drops the redundant "Settings" caption (cog glyph is self-evident).

## Test plan
- [x] `npm --prefix zeus-web run build` — clean (161 kB CSS, 33 kB gzipped)
- [x] `dotnet build Zeus.slnx` — 0 warnings / 0 errors
- [x] `npm --prefix zeus-web test` — 208/208 pass
- [ ] Visual: connect to an HL2, confirm VFO aurora reads, gauge pools glow warmly, gold header rails visible across every panel
- [ ] Confirm no regression on Tweaks/Display/Background settings panels