### PR TITLE
feat: meter smoothing + peak hold, NR accordion persistence, QRZ portrait rework

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -479,6 +479,20 @@ public sealed record DisplaySettingsSetRequest(
     string Mode,
     string Fit);
 
+// Per-mode disclosure state for the inline NR settings accordion that hangs
+// below the DSP NR toggle row. Three independent booleans — one per NR
+// algorithm. Persisted server-side (LiteDB) so the operator's "I always
+// have NR2 tunables open" preference follows them across browsers.
+public sealed record NrUiPrefsDto(
+    bool Nr1Expanded,
+    bool Nr2Expanded,
+    bool Nr4Expanded);
+
+public sealed record NrUiPrefsSetRequest(
+    bool Nr1Expanded,
+    bool Nr2Expanded,
+    bool Nr4Expanded);
+
 // Per-slot pin state for the classic-layout bottom row (Logbook + TX
 // Stage Meters). True = panel is pinned (full body visible). False =
 // collapsed to a chip strip below the pinned tier. Persisted server-side

--- a/Zeus.Server.Hosting/NrUiPrefsStore.cs
+++ b/Zeus.Server.Hosting/NrUiPrefsStore.cs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using LiteDB;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+// Persists the per-mode expand/collapse state of the inline NR settings
+// accordion that hangs below the DSP panel's NR toggle row (NR1/NR2/NR4
+// chevron-headers). The expanded flag was previously kept in a non-persisted
+// Zustand store on the client, so the panel collapsed on every reload —
+// operators who routinely tweak NR2 EMNR tunables had to re-open the
+// section every time. Moving it to LiteDB lets the choice follow them
+// across browsers + devices, same pattern as DisplaySettingsStore.
+//
+// Lives in zeus-prefs.db alongside the other non-sensitive preferences.
+public sealed class NrUiPrefsStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<NrUiPrefsEntry> _docs;
+    private readonly ILogger<NrUiPrefsStore> _log;
+    private readonly object _sync = new();
+
+    public NrUiPrefsStore(ILogger<NrUiPrefsStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _docs = _db.GetCollection<NrUiPrefsEntry>("nr_ui_prefs");
+
+        _log.LogInformation("NrUiPrefsStore initialized at {Path}", dbPath);
+    }
+
+    /// <summary>
+    /// Returns the persisted disclosure state. All three booleans default to
+    /// false on a fresh install — the dense NR2 gauge panel is too much for
+    /// the casual operator, so the historical "collapsed by default" UX is
+    /// preserved.
+    /// </summary>
+    public NrUiPrefsDto Get()
+    {
+        lock (_sync)
+        {
+            var e = _docs.FindAll().FirstOrDefault();
+            if (e is null)
+            {
+                return new NrUiPrefsDto(Nr1Expanded: false, Nr2Expanded: false, Nr4Expanded: false);
+            }
+            return new NrUiPrefsDto(
+                Nr1Expanded: e.Nr1Expanded,
+                Nr2Expanded: e.Nr2Expanded,
+                Nr4Expanded: e.Nr4Expanded);
+        }
+    }
+
+    public void Set(bool nr1Expanded, bool nr2Expanded, bool nr4Expanded)
+    {
+        lock (_sync)
+        {
+            var e = _docs.FindAll().FirstOrDefault() ?? new NrUiPrefsEntry();
+            e.Nr1Expanded = nr1Expanded;
+            e.Nr2Expanded = nr2Expanded;
+            e.Nr4Expanded = nr4Expanded;
+            e.UpdatedUtc = DateTime.UtcNow;
+            if (e.Id == 0) _docs.Insert(e);
+            else _docs.Update(e);
+        }
+    }
+
+    public void Dispose() => _db.Dispose();
+}
+
+public sealed class NrUiPrefsEntry
+{
+    public int Id { get; set; }
+    public bool Nr1Expanded { get; set; }
+    public bool Nr2Expanded { get; set; }
+    public bool Nr4Expanded { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -760,6 +760,18 @@ public static class ZeusEndpoints
             return Results.Ok(store.Get());
         });
 
+        // Inline NR settings accordion disclosure state (NR1 / NR2 / NR4).
+        // PUT writes all three flags atomically. Persisted in zeus-prefs.db
+        // so the chevron-open preference follows the operator across
+        // browsers / devices, same pattern as /api/bottom-pin.
+        app.MapGet("/api/nr-ui-prefs", (NrUiPrefsStore store) => Results.Ok(store.Get()));
+
+        app.MapPut("/api/nr-ui-prefs", (NrUiPrefsSetRequest req, NrUiPrefsStore store) =>
+        {
+            store.Set(req.Nr1Expanded, req.Nr2Expanded, req.Nr4Expanded);
+            return Results.Ok(store.Get());
+        });
+
         // Radio selection — operator preference seeding, with discovery as the
         // tiebreaker. Preferred=="Auto" removes the override (stored as absence,
         // not a sentinel enum value). Effective = Connected when connected (which

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -190,6 +190,7 @@ public static class ZeusHost
         builder.Services.AddSingleton<PsSettingsStore>();
         builder.Services.AddSingleton<FilterPresetStore>();
         builder.Services.AddSingleton<DisplaySettingsStore>();
+        builder.Services.AddSingleton<NrUiPrefsStore>();
         builder.Services.AddSingleton<BottomPinStore>();
         builder.Services.AddSingleton<RadioStateStore>();
         builder.Services.AddSingleton<QrzService>();

--- a/zeus-web/src/api/nrUiPrefs.ts
+++ b/zeus-web/src/api/nrUiPrefs.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// Tiny client for /api/nr-ui-prefs — persists the per-mode expand/collapse
+// state of the inline NR settings accordion (NR1/NR2/NR4) in LiteDB so the
+// chevron-open preference follows the operator across browsers + devices.
+// Mirrors src/api/bottom-pin.ts; same minimal-API call shape.
+
+export type NrUiPrefsState = {
+  nr1Expanded: boolean;
+  nr2Expanded: boolean;
+  nr4Expanded: boolean;
+};
+
+type NrUiPrefsDtoRaw = {
+  // C# records serialise camelCase via System.Text.Json defaults
+  // (JsonSerializerDefaults.Web on the ASP.NET minimal API).
+  nr1Expanded?: boolean;
+  nr2Expanded?: boolean;
+  nr4Expanded?: boolean;
+};
+
+function normalize(raw: NrUiPrefsDtoRaw): NrUiPrefsState {
+  return {
+    nr1Expanded: raw.nr1Expanded === true,
+    nr2Expanded: raw.nr2Expanded === true,
+    nr4Expanded: raw.nr4Expanded === true,
+  };
+}
+
+export async function fetchNrUiPrefs(signal?: AbortSignal): Promise<NrUiPrefsState> {
+  const res = await fetch('/api/nr-ui-prefs', { signal });
+  if (!res.ok) throw new Error(`GET /api/nr-ui-prefs → ${res.status}`);
+  return normalize((await res.json()) as NrUiPrefsDtoRaw);
+}
+
+export async function updateNrUiPrefs(
+  next: NrUiPrefsState,
+  signal?: AbortSignal,
+): Promise<NrUiPrefsState> {
+  const res = await fetch('/api/nr-ui-prefs', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      nr1Expanded: next.nr1Expanded,
+      nr2Expanded: next.nr2Expanded,
+      nr4Expanded: next.nr4Expanded,
+    }),
+    signal,
+  });
+  if (!res.ok) throw new Error(`PUT /api/nr-ui-prefs → ${res.status}`);
+  return normalize((await res.json()) as NrUiPrefsDtoRaw);
+}

--- a/zeus-web/src/components/TxStageMeters.tsx
+++ b/zeus-web/src/components/TxStageMeters.tsx
@@ -24,6 +24,7 @@ import { useTxStore } from '../state/tx-store';
 import { useConnectionStore } from '../state/connection-store';
 import { usePaStore } from '../state/pa-store';
 import { useRadioStore } from '../state/radio-store';
+import { useEmaSmoothed } from '../util/useEmaSmoothed';
 
 // ────────────────────────────────────────────────────────────────────────────
 // Overdrive indicator (re-exported so App.tsx can keep wiring it as the
@@ -124,20 +125,39 @@ export function OverdriveIndicator() {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
-// Peak-hold helper. Tracks the running max in a ref and decays at a fixed
-// rate so the held tick stays continuous across renders. Returns 0 while
-// the input is non-finite or below the floor — callers decide whether to
+// Peak-hold helper. Tracks the running max in a ref, holds the peak for
+// 1.5 s before decaying at a fixed rate so the held tick stays visible
+// long enough for the operator to read it on SSB peaks. A new sample at or
+// above the held peak refreshes the hold window. Returns 0 while the
+// input is non-finite or below the floor — callers decide whether to
 // render the tick at all (the design hides it when ≤ live value).
 // ────────────────────────────────────────────────────────────────────────────
+const PEAK_HOLD_MS = 1500;
+
 function usePeakHoldPct(currentPct: number, decayPctPerSec = 50): number {
-  const state = useRef<{ pct: number; ts: number }>({ pct: 0, ts: 0 });
+  const state = useRef<{ pct: number; ts: number; holdUntil: number }>({
+    pct: 0,
+    ts: 0,
+    holdUntil: 0,
+  });
   const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
   const prev = state.current;
+  // New peak (or first sample) — bump up and start the hold window.
+  if (currentPct > prev.pct) {
+    state.current = { pct: currentPct, ts: now, holdUntil: now + PEAK_HOLD_MS };
+    return currentPct;
+  }
+  // Inside the hold window — keep the peak pinned where it is.
+  if (now < prev.holdUntil) {
+    state.current = { ...prev, ts: now };
+    return prev.pct;
+  }
+  // Past the hold window — decay toward the current sample at the fixed
+  // pct-per-second rate so the held tick visibly bleeds back down.
   const dt = prev.ts === 0 ? 0 : Math.max(0, (now - prev.ts) / 1000);
-  const decayed = Math.max(0, prev.pct - decayPctPerSec * dt);
-  const held = Math.max(currentPct, decayed);
-  state.current = { pct: held, ts: now };
-  return held;
+  const decayed = Math.max(currentPct, prev.pct - decayPctPerSec * dt);
+  state.current = { pct: decayed, ts: now, holdUntil: prev.holdUntil };
+  return decayed;
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -535,13 +555,24 @@ function useMeterRefresh() {
 export function TxStageMeters() {
   useMeterRefresh();
 
-  const wdspMicPk = useTxStore((s) => s.wdspMicPk);
-  const alcGr = useTxStore((s) => s.alcGr);
-  const fwdWatts = useTxStore((s) => s.fwdWatts);
-  const swr = useTxStore((s) => s.swr);
+  const wdspMicPkRaw = useTxStore((s) => s.wdspMicPk);
+  const alcGrRaw = useTxStore((s) => s.alcGr);
+  const fwdWattsRaw = useTxStore((s) => s.fwdWatts);
+  const swrRaw = useTxStore((s) => s.swr);
   const moxOn = useTxStore((s) => s.moxOn);
   const tunOn = useTxStore((s) => s.tunOn);
   const transmitting = moxOn || tunOn;
+
+  // 90 ms EMA on each meter input. The wire frames land at ~10 Hz and the
+  // raf tick repaints at ~30 Hz, so a raw value snaps between frames.
+  // Smoothing the display value (bar + numeric readout) gives a fluid
+  // needle without lagging perceptibly behind voice dynamics on SSB.
+  // The absolute-peak refs below still consume the RAW value so true peaks
+  // aren't clipped by the smoother.
+  const wdspMicPk = useEmaSmoothed(wdspMicPkRaw, 90);
+  const alcGr = useEmaSmoothed(alcGrRaw, 90);
+  const fwdWatts = useEmaSmoothed(fwdWattsRaw, 90);
+  const swr = useEmaSmoothed(swrRaw, 90);
 
   // Rated PA power for the PWR axis. Resolution order:
   //   1. Operator override from the PA settings panel (paMaxPowerWatts > 0)
@@ -558,8 +589,12 @@ export function TxStageMeters() {
   const micBypassed = !isFinite(wdspMicPk) || isBypassed(wdspMicPk);
   const micPct = micPctOf(wdspMicPk);
   const micNow = micBypassed ? '—' : wdspMicPk.toFixed(1).replace('-', '−');
+  // Absolute peak consumes the RAW value so a true SSB transient isn't
+  // shaved off by the 90 ms smoother feeding the bar.
   const micPk = useRef<number>(MIC_FLOOR_DBFS);
-  if (!micBypassed && wdspMicPk > micPk.current) micPk.current = wdspMicPk;
+  if (isFinite(wdspMicPkRaw) && !isBypassed(wdspMicPkRaw) && wdspMicPkRaw > micPk.current) {
+    micPk.current = wdspMicPkRaw;
+  }
   if (micBypassed) micPk.current = MIC_FLOOR_DBFS;
   const micPkValue =
     micPk.current <= MIC_FLOOR_DBFS
@@ -572,7 +607,11 @@ export function TxStageMeters() {
   const alcPct = alcPctOf(alcGrClamped);
   const alcNow = alcBypassed ? '—' : alcGrClamped.toFixed(1);
   const alcPkRef = useRef<number>(0);
-  if (!alcBypassed && alcGrClamped > alcPkRef.current) alcPkRef.current = alcGrClamped;
+  // Peak tracks the RAW value (not the smoothed one) so true GR transients
+  // aren't shaved off.
+  const alcGrRawClamped =
+    !isFinite(alcGrRaw) || isBypassed(alcGrRaw) ? 0 : Math.max(0, alcGrRaw);
+  if (alcGrRawClamped > alcPkRef.current) alcPkRef.current = alcGrRawClamped;
   if (!transmitting) alcPkRef.current = 0;
   const alcPkValue = alcPkRef.current.toFixed(1);
 
@@ -580,7 +619,8 @@ export function TxStageMeters() {
   const pwrPct = pwrPctOf(fwdWatts, ratedW);
   const pwrNow = isFinite(fwdWatts) ? fwdWatts.toFixed(1) : '—';
   const pwrPkRef = useRef<number>(0);
-  if (isFinite(fwdWatts) && fwdWatts > pwrPkRef.current) pwrPkRef.current = fwdWatts;
+  // Peak tracks the RAW watts so true PEP isn't shaved by the 90 ms EMA.
+  if (isFinite(fwdWattsRaw) && fwdWattsRaw > pwrPkRef.current) pwrPkRef.current = fwdWattsRaw;
   if (!transmitting) pwrPkRef.current = 0;
   const pwrPkValue = pwrPkRef.current.toFixed(1);
   const pwrHot = transmitting && pwrPct > 95;
@@ -589,7 +629,8 @@ export function TxStageMeters() {
   const swrPct = swrPctOf(swr);
   const swrNow = isFinite(swr) ? swr.toFixed(2) : '—';
   const swrPkRef = useRef<number>(SWR_FLOOR);
-  if (isFinite(swr) && swr > swrPkRef.current) swrPkRef.current = swr;
+  // Peak tracks the RAW ratio so true SWR excursions aren't shaved.
+  if (isFinite(swrRaw) && swrRaw > swrPkRef.current) swrPkRef.current = swrRaw;
   if (!transmitting) swrPkRef.current = SWR_FLOOR;
   const swrPkValue = swrPkRef.current.toFixed(1);
   const swrHot = transmitting && swr > 2.5;

--- a/zeus-web/src/components/analog-meter/AnalogMeterConfig.tsx
+++ b/zeus-web/src/components/analog-meter/AnalogMeterConfig.tsx
@@ -3,47 +3,13 @@
 // Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
 // Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
 //
-// Header gear → slide-down config flyout. Three sections: RX (S-meter
-// ticks + dBm), TX (PO/SWR pills + full-scale + alarm), and Ballistics
-// (attack/decay/avg/peak hold). All controls drive the persisted
-// useAnalogMeterStore — operator changes survive a reload.
+// Header gear → slide-down config flyout. Slimmed to a single operator
+// toggle: Zeus mode. All other behaviour (scales shown, dBm readout, SWR
+// alarm, attack / decay / averaging / peak hold) is locked to the
+// ANALOG_METER_DEFAULTS — the previous "tweak everything" surface was
+// adding noise without much value for the typical operator.
 
 import { useAnalogMeterStore } from './analogMeterStore';
-
-interface SliderProps {
-  label: string;
-  value: number;
-  min: number;
-  max: number;
-  step: number;
-  unit: string;
-  hint?: string;
-  onChange: (v: number) => void;
-}
-
-function Slider({ label, value, min, max, step, unit, hint, onChange }: SliderProps) {
-  const fixed = step < 1 ? 2 : 0;
-  return (
-    <div className="am-slider">
-      <div className="am-slider-head">
-        <span className="am-slider-lbl">{label}</span>
-        <span className="am-slider-val">
-          {value.toFixed(fixed)}
-          <em>{unit}</em>
-        </span>
-      </div>
-      <input
-        type="range"
-        min={min}
-        max={max}
-        step={step}
-        value={value}
-        onChange={(e) => onChange(parseFloat(e.target.value))}
-      />
-      {hint && <div className="am-slider-hint">{hint}</div>}
-    </div>
-  );
-}
 
 interface CheckRowProps {
   checked: boolean;
@@ -65,37 +31,16 @@ function CheckRow({ checked, onChange, children, sub }: CheckRowProps) {
   );
 }
 
-interface PillProps {
-  on: boolean;
-  onClick: () => void;
-  children: React.ReactNode;
-}
-
-function Pill({ on, onClick, children }: PillProps) {
-  return (
-    <button type="button" className={`am-pill ${on ? 'on' : ''}`} onClick={onClick}>
-      {children}
-    </button>
-  );
-}
-
 interface AnalogMeterConfigProps {
   open: boolean;
   onClose: () => void;
 }
 
 export function AnalogMeterConfig({ open, onClose }: AnalogMeterConfigProps) {
-  const cfg = useAnalogMeterStore();
-  // The flyout is the dominant idle CPU cost on this panel — its 30+ form
-  // controls (sliders, checkboxes, tick buttons) were reconciled on every
-  // parent render even when the gear was closed, because the previous form
-  // returned the full tree and only toggled a CSS class. With
-  // AnalogMeterPanel's ballistic rAF loop driving renders at near-frame-rate,
-  // each invisible commit was re-applying ~580 input attributes per second
-  // observed via MutationObserver. Returning null when closed eliminates the
-  // entire reconcile + DOM-commit cost; the trade-off is that the slide-down
-  // animation is now a mount/unmount, which is fine for a settings flyout
-  // that opens infrequently.
+  const zeusMode = useAnalogMeterStore((s) => s.zeusMode);
+  const setZeusMode = useAnalogMeterStore((s) => s.setZeusMode);
+  // Mount/unmount instead of toggling .open keeps reconcile cost out of the
+  // ballistic rAF loop when the gear is closed.
   if (!open) return null;
 
   return (
@@ -103,103 +48,15 @@ export function AnalogMeterConfig({ open, onClose }: AnalogMeterConfigProps) {
       <div className="am-cf-grid">
         <section className="am-cf-sect">
           <header>
-            <h4>RX · Receiver</h4>
-            <CheckRow checked={cfg.scaleS} onChange={(v) => cfg.setScale('s', v)}>
-              Show S-meter
-            </CheckRow>
+            <h4>S-Meter</h4>
           </header>
           <div className="am-cf-body">
             <CheckRow
-              checked={cfg.showDbm}
-              onChange={cfg.setShowDbm}
-              sub="Append calibrated dBm to the S readout"
-            >
-              Show dBm
-            </CheckRow>
-            <CheckRow
-              checked={cfg.zeusMode}
-              onChange={cfg.setZeusMode}
+              checked={zeusMode}
+              onChange={setZeusMode}
               sub="Image fades in past S9, lightning crackles at S9+20"
             >
               Zeus mode
-            </CheckRow>
-          </div>
-        </section>
-
-        <section className="am-cf-sect">
-          <header>
-            <h4>TX · Transmitter</h4>
-            <div className="am-cf-pillrow">
-              <Pill on={cfg.scalePo} onClick={() => cfg.setScale('po', !cfg.scalePo)}>
-                Power
-              </Pill>
-              <Pill on={cfg.scaleSwr} onClick={() => cfg.setScale('swr', !cfg.scaleSwr)}>
-                SWR
-              </Pill>
-            </div>
-          </header>
-          <div className="am-cf-body">
-            <Slider
-              label="SWR alarm"
-              value={cfg.swrAlarm}
-              min={1.5}
-              max={5}
-              step={0.1}
-              unit=":1"
-              onChange={cfg.setSwrAlarm}
-              hint="Readout turns red above this"
-            />
-            <div className="am-slider-hint">
-              PA full-scale tracks the rated PA power from the PA Settings panel
-              (max of 10 W or 120% of rated).
-            </div>
-          </div>
-        </section>
-
-        <section className="am-cf-sect">
-          <header>
-            <h4>Needle ballistics</h4>
-            <button type="button" className="am-reset" onClick={cfg.resetBallistics}>
-              Reset
-            </button>
-          </header>
-          <div className="am-cf-body">
-            <Slider
-              label="Attack"
-              value={cfg.attack}
-              min={0.005}
-              max={0.5}
-              step={0.005}
-              unit=" s"
-              onChange={cfg.setAttack}
-              hint="Time constant on rising signals"
-            />
-            <Slider
-              label="Decay"
-              value={cfg.decay}
-              min={0.05}
-              max={2}
-              step={0.05}
-              unit=" s"
-              onChange={cfg.setDecay}
-              hint="Time constant on falling signals"
-            />
-            <Slider
-              label="Averaging"
-              value={cfg.avg}
-              min={1}
-              max={32}
-              step={1}
-              unit=" smp"
-              onChange={cfg.setAvg}
-              hint="Moving-average window before ballistics"
-            />
-            <CheckRow
-              checked={cfg.peakHold}
-              onChange={cfg.setPeakHold}
-              sub="Slow-decaying ghost needle marks recent peak"
-            >
-              Peak hold
             </CheckRow>
           </div>
         </section>

--- a/zeus-web/src/components/design/QrzCard.tsx
+++ b/zeus-web/src/components/design/QrzCard.tsx
@@ -85,20 +85,43 @@ export function QrzCard({ contact, enriching, lookupError, onLogQso, canLogQso, 
       </div>
     );
   }
+  // Layout note: the rig / antenna / power / qsl rows were dropped in the
+  // 2× portrait rework — those fields are rarely consulted in-shack and the
+  // operator usually wants the portrait + grid + location front-and-centre
+  // for a quick "who am I talking to?" read.
   const rows: [string, string][] = [
     ['Grid', contact.grid],
-    ['Rig', contact.rig],
     ['Lat/Lon', contact.latlon],
-    ['Antenna', contact.ant],
     ['CQ·ITU', `${contact.cq} · ${contact.itu}`],
-    ['Power', contact.power],
     ['Local', contact.local],
-    ['QSL', contact.qsl],
   ];
   return (
     <div className="qrz-card">
-      <div className="qrz-header">
-        <div className="qrz-portrait">
+      <div className="qrz-card-main">
+        <div className="qrz-info-col">
+          <div className="qrz-id">
+            <div className="qrz-call">{contact.callsign}</div>
+            <div className="qrz-name">{contact.name}</div>
+            <div className="qrz-loc">
+              {contact.flag} {contact.location}
+            </div>
+            <div className="qrz-tags">
+              <span className="qrz-tag">{contact.class}</span>
+              <span className="qrz-tag">Lic. {contact.licensed}</span>
+              <span className="qrz-tag">Age {contact.age}</span>
+            </div>
+          </div>
+          <div className="qrz-section-label">Location · Station</div>
+          <div className="qrz-grid-rows">
+            {rows.map(([k, v]) => (
+              <div key={k} className="qrz-row">
+                <span className="k label-xs">{k}</span>
+                <span className="v mono">{v}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="qrz-portrait qrz-portrait--large">
           <div className="qrz-portrait-bg" aria-hidden>
             <div className="qrz-grid" />
           </div>
@@ -119,28 +142,6 @@ export function QrzCard({ contact, enriching, lookupError, onLogQso, canLogQso, 
           )}
           {enriching && <div className="qrz-scan" />}
         </div>
-        <div className="qrz-id">
-          <div className="qrz-call">{contact.callsign}</div>
-          <div className="qrz-name">{contact.name}</div>
-          <div className="qrz-loc">
-            {contact.flag} {contact.location}
-          </div>
-          <div className="qrz-tags">
-            <span className="qrz-tag">{contact.class}</span>
-            <span className="qrz-tag">Lic. {contact.licensed}</span>
-            <span className="qrz-tag">Age {contact.age}</span>
-          </div>
-        </div>
-      </div>
-
-      <div className="qrz-section-label">Location · Station</div>
-      <div className="qrz-grid-rows">
-        {rows.map(([k, v]) => (
-          <div key={k} className="qrz-row">
-            <span className="k label-xs">{k}</span>
-            <span className="v mono">{v}</span>
-          </div>
-        ))}
       </div>
 
       <div className="qrz-footer">

--- a/zeus-web/src/components/immersive-meters/usePeakHold.ts
+++ b/zeus-web/src/components/immersive-meters/usePeakHold.ts
@@ -5,14 +5,14 @@
 //
 // Wall-clock peak hold for the immersive meter widgets. Mirrors the
 // prototype's peak/peakHold logic: a peak that bumps up immediately, holds
-// for a window (default 1.2 s), then decays at 0.5 fraction-units / sec
+// for a window (default 1.5 s), then decays at 0.5 fraction-units / sec
 // — measured in fractional [0..1] axis units, not dB, so the visual decay
 // rate is the same on every meter regardless of its native dB range.
 
 import { useRef } from 'react';
 import { isSilent } from './dbScale';
 
-const HOLD_MS_DEFAULT = 1200;
+const HOLD_MS_DEFAULT = 1500;
 const DECAY_FRAC_PER_SEC_DEFAULT = 0.5;
 
 interface PeakState {

--- a/zeus-web/src/components/meter-group/MeterRenderer.tsx
+++ b/zeus-web/src/components/meter-group/MeterRenderer.tsx
@@ -16,6 +16,7 @@ import {
   zoneTransitionTicks,
 } from '../meters/meterCatalog';
 import { useMeterReading } from '../meters/useMeterReading';
+import { useEmaSmoothed } from '../../util/useEmaSmoothed';
 import { BigArc } from '../immersive-meters/BigArc';
 import { VuColumn } from '../immersive-meters/VuColumn';
 import { PullDownArc } from '../immersive-meters/PullDownArc';
@@ -33,7 +34,11 @@ interface MeterRendererProps {
 
 export function MeterRenderer({ widget }: MeterRendererProps) {
   const def = METER_CATALOG[widget.reading];
-  const value = useMeterReading(widget.reading);
+  // 90 ms EMA smoothing on the raw 10 Hz feed kills inter-frame steppiness
+  // without lagging visibly behind voice dynamics on SSB. See
+  // useEmaSmoothed.ts for the alpha = 1 - exp(-dt/tau) ballistics.
+  const rawValue = useMeterReading(widget.reading);
+  const value = useEmaSmoothed(rawValue, 90);
 
   const settings = widget.settings ?? {};
   const min = settings.min ?? def.defaultMin;

--- a/zeus-web/src/components/nr/NrSettingsSection.tsx
+++ b/zeus-web/src/components/nr/NrSettingsSection.tsx
@@ -50,6 +50,11 @@ import {
   type RadioStateDto,
 } from '../../api/client';
 import { useConnectionStore } from '../../state/connection-store';
+import {
+  fetchNrUiPrefs,
+  updateNrUiPrefs,
+  type NrUiPrefsState,
+} from '../../api/nrUiPrefs';
 
 export type NrSettingsMode = 'Anr' | 'Emnr' | 'Sbnr';
 
@@ -61,21 +66,82 @@ export type NrSettingsSectionProps = {
 // state, so the panel survives any FlexLayout re-render that unmounts the
 // DSP tab content (drag, dock, tabset reflow). Keyed by mode so each NR
 // algorithm's accordion remembers its own open/closed state.
+//
+// Persisted server-side via /api/nr-ui-prefs (LiteDB) so the choice
+// follows the operator across browsers + devices, same pattern as
+// bottom-pin / display-settings. Hydration runs once at module load
+// (single global store, single fetch); toggles fire a debounced PUT.
 type NrSettingsUiState = {
   expanded: Record<NrSettingsMode, boolean>;
+  hydrated: boolean;
+  /** Set the persisted state from a server fetch (no PUT). */
+  hydrate: (next: NrUiPrefsState) => void;
+  /** Toggle one mode and schedule a debounced PUT to the backend. */
   toggle: (mode: NrSettingsMode) => void;
 };
 
+// Maps the wire DTO's three booleans to / from the per-mode keyed shape
+// the component already consumes. NR4 lives under the `Sbnr` key — the
+// reading-mode enum the surrounding panel uses.
+function fromWire(p: NrUiPrefsState): Record<NrSettingsMode, boolean> {
+  return { Anr: p.nr1Expanded, Emnr: p.nr2Expanded, Sbnr: p.nr4Expanded };
+}
+function toWire(e: Record<NrSettingsMode, boolean>): NrUiPrefsState {
+  return { nr1Expanded: e.Anr, nr2Expanded: e.Emnr, nr4Expanded: e.Sbnr };
+}
+
+const PERSIST_DEBOUNCE_NR_UI_MS = 150;
+let nrUiPersistTimer: ReturnType<typeof setTimeout> | null = null;
+
+function schedulePersist(state: Record<NrSettingsMode, boolean>): void {
+  if (nrUiPersistTimer) clearTimeout(nrUiPersistTimer);
+  nrUiPersistTimer = setTimeout(() => {
+    nrUiPersistTimer = null;
+    void updateNrUiPrefs(toWire(state)).catch(() => {
+      // Persistence is best-effort — a transient server hiccup leaves the
+      // in-memory state intact; the next toggle retries. We don't surface
+      // an error toast for a chevron-open preference.
+    });
+  }, PERSIST_DEBOUNCE_NR_UI_MS);
+}
+
 const useNrSettingsUi = create<NrSettingsUiState>((set) => ({
   expanded: { Anr: false, Emnr: false, Sbnr: false },
+  hydrated: false,
+  hydrate: (next) =>
+    set({ expanded: fromWire(next), hydrated: true }),
   toggle: (mode) =>
-    set((s) => ({ expanded: { ...s.expanded, [mode]: !s.expanded[mode] } })),
+    set((s) => {
+      const expanded = { ...s.expanded, [mode]: !s.expanded[mode] };
+      schedulePersist(expanded);
+      return { expanded };
+    }),
 }));
+
+// One-shot module-level hydration so every NrSettingsSection instance
+// (the DSP panel renders one per mode) reads from the same already-fetched
+// state. Errors are swallowed — a fresh install or an offline backend
+// just leaves the defaults (everything collapsed) in place.
+let nrUiHydrationStarted = false;
+function ensureNrUiHydration(): void {
+  if (nrUiHydrationStarted) return;
+  nrUiHydrationStarted = true;
+  void fetchNrUiPrefs()
+    .then((prefs) => useNrSettingsUi.getState().hydrate(prefs))
+    .catch(() => {
+      // Mark hydrated anyway so the first toggle's PUT doesn't race a
+      // late-arriving GET response (which would clobber the user's click).
+      useNrSettingsUi.setState({ hydrated: true });
+    });
+}
 
 export function NrSettingsSection({ mode }: NrSettingsSectionProps) {
   // Persisted disclosure: collapsed by default (the dense gauge panel is
   // too much for the casual operator), but stays open across remounts once
-  // the user opens it. The chevron telegraphs the click target.
+  // the user opens it. The chevron telegraphs the click target. State is
+  // sourced from /api/nr-ui-prefs (LiteDB) so the choice follows the
+  // operator across browsers + devices.
+  useEffect(() => { ensureNrUiHydration(); }, []);
   const expanded = useNrSettingsUi((s) => s.expanded[mode]);
   const toggle = useNrSettingsUi((s) => s.toggle);
 

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -1345,6 +1345,12 @@
 /* ===== QRZ card — gradient panel w/ portrait + rows ===== */
 .qrz-empty { padding: 20px; display: flex; align-items: center; justify-content: center; text-align: center; min-height: 140px; color: var(--fg-2); }
 .qrz-card { padding: 8px; display: flex; flex-direction: column; gap: 6px; background: var(--bg-1); }
+/* qrz-card-main: two-column body — operator info on the left, big portrait
+   on the right. Portrait spans the full height of the info column so it
+   reads as the dominant visual (matches the v2 QRZ panel rework). */
+.qrz-card-main { display: grid; grid-template-columns: 1fr auto; gap: 12px; align-items: stretch; }
+.qrz-info-col { display: flex; flex-direction: column; min-width: 0; }
+/* Legacy alias — kept for any consumer that still renders the old shape. */
 .qrz-header { display: flex; gap: 10px; align-items: stretch; }
 .qrz-id { flex: 1; min-width: 0; display: flex; flex-direction: column; justify-content: center; gap: 2px; }
 .qrz-call { font-size: 20px; font-weight: 700; color: var(--accent); text-shadow: 0 0 10px rgba(74,158,255,0.4); letter-spacing: 0.04em; font-family: var(--font-mono, 'Archivo Narrow', sans-serif); line-height: 1; }
@@ -1364,7 +1370,10 @@
   color: var(--fg-2); padding-bottom: 2px; border-bottom: 1px solid rgba(74,158,255,0.2);
   margin-top: 4px;
 }
-.qrz-grid-rows { display: grid; grid-template-columns: 1fr 1fr; gap: 2px 14px; }
+/* Single-column stack — the right column now hosts the 2× portrait, so
+   the data rows take the full info-column width. Each .qrz-row is its own
+   flex container that handles the k / v justify-between layout. */
+.qrz-grid-rows { display: flex; flex-direction: column; gap: 0; }
 .qrz-grid-rows .qrz-row { border-bottom: 1px dotted rgba(255,255,255,0.06); }
 .qrz-footer {
   display: flex; align-items: center; padding-top: 6px; margin-top: 2px;
@@ -1383,6 +1392,17 @@
   justify-content: center;
   box-shadow: none;
 }
+/* 2× portrait variant — anchored top-right inside .qrz-card-main, fills
+   the full height of the info column so the operator photo reads as the
+   dominant visual instead of a 72 px thumbnail. align-self: stretch makes
+   the grid row supply the height; aspect-ratio keeps it square. */
+.qrz-portrait.qrz-portrait--large {
+  width: 150px;
+  height: auto;
+  aspect-ratio: 1;
+  align-self: stretch;
+}
+.qrz-portrait.qrz-portrait--large .qrz-portrait-initials { font-size: 56px; }
 .qrz-portrait-bg { position: absolute; inset: 0; background: repeating-linear-gradient(45deg, rgba(255,255,255,0.03) 0 4px, transparent 4px 8px); }
 .qrz-grid {
   position: absolute; inset: 0;
@@ -1398,16 +1418,20 @@
 @keyframes qrz-scan { from { transform: translateY(-100%); } to { transform: translateY(100%); } }
 
 .qrz-rows { flex: 1; display: grid; grid-template-columns: 1fr; gap: 2px; min-width: 0; }
+/* Fixed-width label column + value column that hugs the label. Previously
+   used justify-content: space-between which pushed the value all the way
+   to the right edge of the info column, leaving it visually touching the
+   portrait now that the portrait sits in the right column. */
 .qrz-row {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 88px 1fr;
   align-items: baseline;
-  gap: 8px;
+  gap: 12px;
   padding: 2px 0;
   border-bottom: 1px dotted rgba(255,255,255,0.08);
 }
 .qrz-row .k { color: var(--fg-1); font-size: 11px; font-weight: 600; }
-.qrz-row .v { color: var(--fg-0); font-size: 12px; font-weight: 700; text-align: right; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.qrz-row .v { color: var(--fg-0); font-size: 12px; font-weight: 700; text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .qrz-row .v.accent { color: var(--accent); }
 
 .cs-input {

--- a/zeus-web/src/util/useEmaSmoothed.ts
+++ b/zeus-web/src/util/useEmaSmoothed.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// Exponential moving average smoother for meter readings. The wire frames
+// arrive at ~10 Hz and the render loop ticks at ~30 Hz, so a raw value
+// driven straight into a needle / bar visibly steps. A short-time-constant
+// EMA (default 90 ms) makes the visual motion fluid without lagging
+// noticeably behind voice dynamics on SSB.
+//
+// Pure ballistics: alpha = 1 - exp(-dt/tau), so a step input reaches
+//   ~63 % in 1 × tau, ~95 % in 3 × tau, ~99 % in ~4.6 × tau.
+//   tau =  90 ms  → ~270 ms to settle within 5 %.
+//   tau = 150 ms  → ~450 ms.
+// 90 ms is the sweet spot for SSB/CW: kills the 10 Hz steppiness without
+// turning the meter into a slow integrator.
+//
+// Sentinel handling — WDSP / the meter pipeline emits ≤ -200 dBFS for
+// "channel idle / bypassed". We pass that through verbatim and reset the
+// smoother so the next live sample doesn't lerp out of the sentinel; the
+// downstream widget renders an em-dash and we don't fight it.
+
+import { useRef } from 'react';
+
+const SILENT_SENTINEL = -200;
+
+interface EmaState {
+  smoothed: number;
+  ts: number; // performance.now() of last update
+}
+
+/**
+ * Smooth a scalar reading with an exponential moving average. Re-renders
+ * every time the input changes (callers control the cadence — typically
+ * a 30 Hz raf tick from useMeterRefresh).
+ *
+ * @param value  Latest sample from the store.
+ * @param tauMs  Time constant in ms. 90 ms is the meter default; set 0 to
+ *               bypass smoothing entirely.
+ */
+export function useEmaSmoothed(value: number, tauMs = 90): number {
+  const state = useRef<EmaState>({ smoothed: NaN, ts: 0 });
+
+  // Sentinel / non-finite — pass through and reset so the next live sample
+  // seeds the smoother fresh instead of lerping out of -∞.
+  if (!isFinite(value) || value <= SILENT_SENTINEL) {
+    state.current = { smoothed: value, ts: 0 };
+    return value;
+  }
+
+  // Bypass — caller asked for raw.
+  if (tauMs <= 0) {
+    state.current = { smoothed: value, ts: 0 };
+    return value;
+  }
+
+  const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+  const prev = state.current;
+
+  // First valid sample — seed the smoother so the meter doesn't visibly
+  // ramp from 0 on the first reading.
+  if (!isFinite(prev.smoothed) || prev.ts === 0) {
+    state.current = { smoothed: value, ts: now };
+    return value;
+  }
+
+  const dt = Math.max(0, now - prev.ts);
+  const alpha = 1 - Math.exp(-dt / tauMs);
+  const smoothed = prev.smoothed + (value - prev.smoothed) * alpha;
+  state.current = { smoothed, ts: now };
+  return smoothed;
+}


### PR DESCRIPTION
## Summary

Stacks several visual + UX improvements on top of the v3 Lifted Dark theme (see #327, which this branch also includes).

**Meters — 90 ms EMA smoothing + 1.5 s peak hold**
Raw frames land at ~10 Hz and the render loop ticks at ~30 Hz, so needles / bars visibly step between frames. New shared `useEmaSmoothed(value, tauMs)` util applies `alpha = 1 - exp(-dt/tau)` to every BigArc / VuColumn / PullDownArc / HBarMeter via `MeterRenderer`, and to MIC / ALC / PWR / SWR inside `TxStageMeters`. Sentinels (≤ -200 dBFS) pass through verbatim. Peak-hold ballistics across both renderer paths bumped to 1500 ms before decay; absolute-peak refs still consume the raw store value so true SSB transients aren't shaved off by the smoother.

**S-Meter config — collapsed to a single Zeus-mode toggle**
Header gear exposed 8+ controls (scales shown, dBm readout, SWR alarm, attack / decay / averaging / peak hold) that the typical operator never touched. Strips the UI to just Zeus mode (image fade past S9, lightning crackle at S9+20). Underlying store + defaults untouched, so persisted state from older sessions still hydrates without errors.

**NR1/NR2/NR4 accordion — persist disclosure state in LiteDB**
The inline NR settings section was using a non-persisted Zustand store, so the chevron collapsed on every browser reload. Adds a `nr_ui_prefs` LiteDB collection in `zeus-prefs.db` with three booleans, a `NrUiPrefsStore` server singleton, GET/PUT `/api/nr-ui-prefs` endpoints, and a debounced (150 ms) PUT on toggle. Module-level hydration runs once on first mount; failure is best-effort.

**QRZ panel rework**
2× operator portrait moves to the right side, anchored top-of-card and stretching the full height of the info column. Drops the rig / antenna / power / qsl rows that are rarely consulted in-shack. Remaining four rows (Grid / Lat-Lon / CQ·ITU / Local) stack single-column with values aligned next to their labels instead of pressing against the portrait edge.

**Theme commits from #327 (included)**
v3 Lifted Dark palette + Inter / JetBrains Mono fonts, brass instrument-plate headers with gold leading rail, deeper `#0c5f9c` accent, dropped redundant "Settings" caption under the gear glyph. PR #327 against this branch's first 3 commits — whichever lands first, the other should be closed.

## Test plan
- [x] `dotnet build Zeus.slnx` — 0 warnings / 0 errors
- [x] `dotnet test tests/Zeus.Server.Tests` — 506 pass / 5 skipped
- [x] `npm --prefix zeus-web run build` — clean (162 kB CSS, 33 kB gzipped)
- [x] `npm --prefix zeus-web test` — 208/208 pass
- [ ] Visual: connect to an HL2, key a few SSB peaks, confirm meters smooth out at ~90 ms and the peak tick holds for ~1.5 s before decaying
- [ ] Toggle NR2 chevron → reload browser → confirm it comes back open
- [ ] QRZ Lookup with a real call → confirm 2× portrait fills the right column