### PR TITLE
Release v0.7.3 — develop → main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,70 @@ see the corresponding GitHub Release page.
 
 ---
 
+## [0.7.3] — 2026-05-14
+
+A polish + correctness release. Major visible refresh of the **v3 Lifted Dark
+theme** — flat near-black chrome, brass instrument-plate panel headers, blue
+VFO aurora behind 200-weight Inter digits, warm amber meter glow. Under the
+chrome: **meter rendering smoothed** with 90 ms EMA + 1.5 s peak hold; **HL2
+Band Volts PWM** is now an in-app toggle for external amplifier band
+following; **macOS users can launch the backend from any shell again** (the
+LAN cert handshake stopped routing through the keychain); and a small **MOX
+edge click on RX audio is gone**.
+
+### Fixed
+
+- **macOS: backend launches from non-GUI shells again.** *(KB2UKA, PR #323)*
+  - `LanCertificate.cs` was passing `X509KeyStorageFlags.PersistKeySet` on certificate load, which triggers `Interop+AppleCrypto+X509MoveToKeychain`. On macOS that call fails outright with `"User interaction is not allowed."` whenever the backend's parent process isn't tied to the window server — CI runners, SSH, terminal multiplexers, and anything launched from VS Code's integrated terminal all hit this.
+  - Fix: drop the flag from both `X509CertificateLoader` calls. The PFX file on disk at `ResolveCertPath()` is the actual persistence mechanism; the keychain copy was a redundant side-effect for a self-signed dev cert. HTTPS binding behaviour is unchanged on every platform; the in-process private key remains available (`Exportable` is preserved).
+  - Linux + Windows unaffected — they hit different code paths that don't require a window-server prompt in the first place.
+
+- **MOX edge click on RX audio.** *(KB2UKA, PR #326)*
+  - Some audio endpoints (USB DACs, pro audio interfaces) produced an audible click on the MOX rising / falling edges, occasionally accompanied by a small panadapter blip. Bench investigation traced it to the RX broadcast → browser playback boundary: WDSP's `SetChannelState` damps the outgoing side on MOX-on (`dmp=1`) but resumes with `dmp=0`, and the audio-client's buffer-drain endpoint sits on whatever the last broadcast sample happened to be.
+  - Fix: `DspPipelineService` now applies a one-shot 5 ms linear ramp to the first RX audio block after each MOX edge. Rising edge ramps the last block out + zero-fills so the browser's final played sample is 0.0; falling edge ramps the resume block in. Steady-state RX audio is byte-for-byte identical to before.
+  - Engine-agnostic — affects HL2, ANAN-class, and Saturn-family equally.
+
+### Added
+
+- **HL2 Band Volts PWM toggle** (RADIO settings tab). *(Brian Keating / EI6LF, PR #314, closes #279)*
+  - Lets HL2 operators enable the firmware's Band Volts feature so an external amplifier (e.g. Xiegu XPA125B) follows Zeus's band changes automatically. Wire bit is C3 bit 3 of the Config frame (address `0x00` bit 11, "Fan or Band Volts PWM" per `docs/references/protocol-1/hermes-lite2-protocol.md` line 39).
+  - Renames the legacy `EnableHl2Dither` flag to `EnableHl2BandVolts` so the in-code name matches the wire-doc terminology. mi0bot's HL2 fork uses the same one-bit repurpose. Wire encoding in `ControlFrame.WriteConfigPayload` unchanged.
+  - Persists per-radio in `PreferredRadioStore` (LiteDB). Older rows hydrate as `false` — matches HL2 firmware default where the PWM line drives Fan Control unless explicitly switched.
+  - New `HasHl2OptionalToggles` capability flag, true only for `HpsdrBoardKind.HermesLite2`. Frontend gates the new RADIO tab on this — invisible on non-HL2 boards. Square SDR discovers as HL2-compatible and gets the tab on the same path.
+  - New endpoints `GET /api/radio/hl2-options` and `PUT /api/radio/hl2-options` returning `{ "bandVolts": bool }`. Object-shaped so future mi0bot HL2-specific toggles (e.g. "Disable PS Sync") slot in without breaking the contract.
+
+- **Meter smoothing + peak hold across every meter.** *(Brian Keating / EI6LF, PR #328)*
+  - Raw meter frames land at ~10 Hz; the render loop ticks at ~30 Hz, so needles and bars visibly stepped between frames. New shared `useEmaSmoothed(value, tauMs)` hook applies `alpha = 1 - exp(-dt/tau)` (90 ms time constant) to every BigArc / VuColumn / PullDownArc / HBarMeter via `MeterRenderer`, and to the MIC / ALC / PWR / SWR meters inside `TxStageMeters`. Sentinels (≤ -200 dBFS) pass through verbatim so "no signal" still reads correctly.
+  - Peak-hold ballistics across both renderer paths bumped to **1500 ms** before decay so SSB / FT8 transients are visible long enough to read. Absolute-peak refs still consume the raw store value, so true peaks are never shaved off by the smoother.
+
+- **NR1 / NR2 / NR4 accordion disclosure state persists across browser reloads.** *(Brian Keating / EI6LF, PR #328)*
+  - The inline NR settings section was using a non-persisted Zustand store, so its chevron collapsed every page reload even if the operator preferred it open. New `nr_ui_prefs` LiteDB collection in `zeus-prefs.db` holds three booleans (one per NR engine), surfaced via `GET` / `PUT /api/nr-ui-prefs` with a 150 ms debounced write on toggle. Module-level hydration runs once on first mount; failure is best-effort (does not block UI).
+
+- **QRZ Lookup: Clear button.** *(KB2UKA, PR #320, closes #318, requested by EI8KV)*
+  - One-click reset for the callsign input + lookup result. Useful for cycling between contacts during a contest or net. Renders as a `btn sm` in the card footer (left of "Log QSO") and below the "Not found" error block. Enabled whenever there's something to clear — a current contact, an error, or a non-empty input.
+
+### Changed
+
+- **v3 Lifted Dark theme.** *(Brian Keating / EI6LF, PR #327)*
+  - Palette in `tokens.css` remapped to a neutral near-black (`--bg-0..3`, `--bg-inset`, `--bg-meter`); type stack swapped to **Inter** for UI and **JetBrains Mono** for fixed-width. Sidebar, topbar, transport, and panel chrome flatten — no more beveled gradients or inset highlights.
+  - **VFO `freq-display` blue aurora**: three layered radial-gradients + a blurred ellipse behind 200-weight Inter digits, so the tuned frequency reads at a glance with the chrome stepping out of the way.
+  - **TX stage-meter wells**: warm amber halo via `box-shadow`; analog gauges bake in the "streetlamp pool" `hsla(31, 30%, 65%, 0.19)` gradient.
+  - **Brass instrument-plate panel headers**: subtle vertical gradient, 2 px gold (`--power`) leading rail with a soft bloom, specular top highlight, warm-amber-soft bottom hairline, engraved-style uppercase title with a faint amber text-shadow. Applied to every panel head and workspace tile.
+  - `--accent` deepened from `#2e8eff` to `#0c5f9c` so the active-button glow and VFO aurora read closer to the Hermes Lite 2 hardware blue.
+  - **NR2 advanced settings card** lifts to `--bg-2` so it visibly sits above the DSP panel base.
+  - **Sidebar gear button**: dropped the redundant "Settings" caption — the cog glyph is self-evident.
+
+- **QRZ Lookup panel: portrait rework.** *(Brian Keating / EI6LF, PR #328)*
+  - 2× operator portrait moves to the right side, anchored at the top of the card and stretching the full height of the info column. Drops the rig / antenna / power / qsl rows that were rarely consulted in-shack. Remaining four rows (Grid / Lat-Lon / CQ · ITU / Local) stack single-column with values aligned next to their labels.
+
+- **S-Meter config: collapsed to a single "Zeus mode" toggle.** *(Brian Keating / EI6LF, PR #328)*
+  - The header gear previously exposed 8+ controls (scales shown, dBm readout, SWR alarm, attack / decay / averaging / peak hold) the typical operator never touched. Strips the UI to just Zeus mode — image fade past S9, lightning crackle at S9+20. Underlying store + defaults untouched, so persisted state from older sessions still hydrates cleanly.
+
+### Known issues
+- **ANAN-10E / Hermes-class on Protocol-1**: TX fix (#324) is staged but not yet merged — still under bench verification by @RonnieC82 on a real 10E. Operators on non-HL2 P1 boards (Hermes / 10E / 100D / Orion) should continue using Thetis for now or follow #294 for the rollout signal.
+
+---
+
 ## [0.7.2] — 2026-05-13
 
 A correctness-focused release with two big on-air wins: **audio dropouts when

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,8 +8,8 @@
     <!-- Version Management -->
     <!-- When building from a tag (e.g., v0.1.0), GITHUB_REF_NAME will be set -->
     <!-- Otherwise, fall back to the in-development VersionPrefix below.    -->
-    <!-- Bump this when a release branch opens — current target: v0.7.2.    -->
-    <VersionPrefix Condition="'$(VersionPrefix)' == ''">0.7.2</VersionPrefix>
+    <!-- Bump this when a release branch opens — current target: v0.7.3.    -->
+    <VersionPrefix Condition="'$(VersionPrefix)' == ''">0.7.3</VersionPrefix>
     <VersionSuffix Condition="'$(VersionSuffix)' == '' AND '$(GITHUB_REF_TYPE)' != 'tag'">dev</VersionSuffix>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -479,6 +479,20 @@ public sealed record DisplaySettingsSetRequest(
     string Mode,
     string Fit);
 
+// Per-mode disclosure state for the inline NR settings accordion that hangs
+// below the DSP NR toggle row. Three independent booleans — one per NR
+// algorithm. Persisted server-side (LiteDB) so the operator's "I always
+// have NR2 tunables open" preference follows them across browsers.
+public sealed record NrUiPrefsDto(
+    bool Nr1Expanded,
+    bool Nr2Expanded,
+    bool Nr4Expanded);
+
+public sealed record NrUiPrefsSetRequest(
+    bool Nr1Expanded,
+    bool Nr2Expanded,
+    bool Nr4Expanded);
+
 // Per-slot pin state for the classic-layout bottom row (Logbook + TX
 // Stage Meters). True = panel is pinned (full body visible). False =
 // collapsed to a chip strip below the pinned tier. Persisted server-side

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -198,6 +198,18 @@ public class DspPipelineService : BackgroundService,
     private int _rxMeterTickMod;
     private const int RxMeterTickModulus = 6;
 
+    // RX audio fade envelope across MOX edges. WDSP's RXA SetChannelState
+    // (dmp=1 on TX-engage) damps the outgoing side internally, but the resume
+    // edge (dmp=0 at MOX-off) and the buffer-drain endpoint in the browser
+    // audio-client both produce audible clicks under some setups (audio
+    // interfaces, USB-DAC headphones). Smoothing here is cheap insurance: the
+    // first ~5 ms after each edge gets a linear ramp applied before the
+    // AudioFrame is broadcast. Both flags are pipeline-thread-only after the
+    // initial volatile read in OnRadioMoxChanged sets them.
+    private const int RxFadeSamples = 240;          // 5 ms @ 48 kHz
+    private volatile bool _rxFadeOutPending;        // first RX block after MOX↑
+    private volatile bool _rxFadeInPending;         // first RX block after MOX↓
+
     // ---- iter5 single-DSP-thread scaffolding -----------------------------
     // The pipeline now owns its hot path via IRxPacketSink: when a radio
     // connects we AttachRxSink to the protocol client and every IQ/PS-feedback
@@ -960,6 +972,12 @@ public class DspPipelineService : BackgroundService,
     private void OnRadioMoxChanged(bool on)
     {
         _keyed = on;
+        // Arm a one-shot fade envelope on the first audio block Tick reads
+        // after this edge. Rising edge → ramp current audio out so the post-
+        // MOX silent stretch isn't a hard cut. Falling edge → ramp the resume
+        // audio in so the dmp=0 RXA up doesn't pop through to the browser.
+        if (on) _rxFadeOutPending = true;
+        else _rxFadeInPending = true;
         _p2Client?.SetMox(on);
         // Falling edge: pick up any PS knob changes that OnRadioStateChanged
         // deferred while we were keyed (HwPeak / Ptol / Advanced / Control).
@@ -1400,6 +1418,35 @@ public class DspPipelineService : BackgroundService,
         int audioSampleCount = engine.ReadAudio(channel, audioBuf);
         if (audioSampleCount > 0)
         {
+            // MOX-edge fade envelope. Ramps the first ~5 ms of this block
+            // either down (rising edge: last block before TX silence) or up
+            // (falling edge: first block of RX resume). Each flag is a
+            // one-shot — cleared after applying so steady-state audio is
+            // untouched. See _rxFadeOutPending / _rxFadeInPending declarations
+            // for the click pathology this addresses.
+            if (_rxFadeOutPending)
+            {
+                int n = Math.Min(RxFadeSamples, audioSampleCount);
+                for (int i = 0; i < n; i++)
+                {
+                    float ramp = 1f - (float)(i + 1) / n;
+                    audioBuf[i] *= ramp;
+                }
+                if (audioSampleCount > n)
+                    Array.Clear(audioBuf, n, audioSampleCount - n);
+                _rxFadeOutPending = false;
+            }
+            else if (_rxFadeInPending)
+            {
+                int n = Math.Min(RxFadeSamples, audioSampleCount);
+                for (int i = 0; i < n; i++)
+                {
+                    float ramp = (float)(i + 1) / n;
+                    audioBuf[i] *= ramp;
+                }
+                _rxFadeInPending = false;
+            }
+
             // VST plugin host is TX-only by design (operator decision
             // 2026-04-30). The chain is configured for the TX bandwidth,
             // tuned for voice processing, and shares one set of plugin

--- a/Zeus.Server.Hosting/LanCertificate.cs
+++ b/Zeus.Server.Hosting/LanCertificate.cs
@@ -41,10 +41,16 @@ public static class LanCertificate
         {
             try
             {
+                // PersistKeySet would route the private key through the
+                // macOS login keychain (X509MoveToKeychain), which fails with
+                // "User interaction is not allowed" when the backend is
+                // launched from a non-GUI parent (CI, SSH, Claude Code's
+                // PTY). The PFX file on disk already handles persistence
+                // between runs; keychain persistence is redundant.
                 var existing = X509CertificateLoader.LoadPkcs12FromFile(
                     path,
                     string.Empty,
-                    X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+                    X509KeyStorageFlags.Exportable);
                 if (CoversAllIps(existing, ips) && existing.NotAfter > DateTime.UtcNow.AddDays(30))
                 {
                     log?.LogInformation("LAN certificate loaded from {Path} ({Subject}, expires {Expires:yyyy-MM-dd})",
@@ -116,7 +122,7 @@ public static class LanCertificate
         return X509CertificateLoader.LoadPkcs12(
             pfx,
             string.Empty,
-            X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+            X509KeyStorageFlags.Exportable);
     }
 
     private static bool CoversAllIps(X509Certificate2 cert, HashSet<IPAddress> required)

--- a/Zeus.Server.Hosting/NrUiPrefsStore.cs
+++ b/Zeus.Server.Hosting/NrUiPrefsStore.cs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using LiteDB;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+// Persists the per-mode expand/collapse state of the inline NR settings
+// accordion that hangs below the DSP panel's NR toggle row (NR1/NR2/NR4
+// chevron-headers). The expanded flag was previously kept in a non-persisted
+// Zustand store on the client, so the panel collapsed on every reload —
+// operators who routinely tweak NR2 EMNR tunables had to re-open the
+// section every time. Moving it to LiteDB lets the choice follow them
+// across browsers + devices, same pattern as DisplaySettingsStore.
+//
+// Lives in zeus-prefs.db alongside the other non-sensitive preferences.
+public sealed class NrUiPrefsStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<NrUiPrefsEntry> _docs;
+    private readonly ILogger<NrUiPrefsStore> _log;
+    private readonly object _sync = new();
+
+    public NrUiPrefsStore(ILogger<NrUiPrefsStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _docs = _db.GetCollection<NrUiPrefsEntry>("nr_ui_prefs");
+
+        _log.LogInformation("NrUiPrefsStore initialized at {Path}", dbPath);
+    }
+
+    /// <summary>
+    /// Returns the persisted disclosure state. All three booleans default to
+    /// false on a fresh install — the dense NR2 gauge panel is too much for
+    /// the casual operator, so the historical "collapsed by default" UX is
+    /// preserved.
+    /// </summary>
+    public NrUiPrefsDto Get()
+    {
+        lock (_sync)
+        {
+            var e = _docs.FindAll().FirstOrDefault();
+            if (e is null)
+            {
+                return new NrUiPrefsDto(Nr1Expanded: false, Nr2Expanded: false, Nr4Expanded: false);
+            }
+            return new NrUiPrefsDto(
+                Nr1Expanded: e.Nr1Expanded,
+                Nr2Expanded: e.Nr2Expanded,
+                Nr4Expanded: e.Nr4Expanded);
+        }
+    }
+
+    public void Set(bool nr1Expanded, bool nr2Expanded, bool nr4Expanded)
+    {
+        lock (_sync)
+        {
+            var e = _docs.FindAll().FirstOrDefault() ?? new NrUiPrefsEntry();
+            e.Nr1Expanded = nr1Expanded;
+            e.Nr2Expanded = nr2Expanded;
+            e.Nr4Expanded = nr4Expanded;
+            e.UpdatedUtc = DateTime.UtcNow;
+            if (e.Id == 0) _docs.Insert(e);
+            else _docs.Update(e);
+        }
+    }
+
+    public void Dispose() => _db.Dispose();
+}
+
+public sealed class NrUiPrefsEntry
+{
+    public int Id { get; set; }
+    public bool Nr1Expanded { get; set; }
+    public bool Nr2Expanded { get; set; }
+    public bool Nr4Expanded { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -760,6 +760,18 @@ public static class ZeusEndpoints
             return Results.Ok(store.Get());
         });
 
+        // Inline NR settings accordion disclosure state (NR1 / NR2 / NR4).
+        // PUT writes all three flags atomically. Persisted in zeus-prefs.db
+        // so the chevron-open preference follows the operator across
+        // browsers / devices, same pattern as /api/bottom-pin.
+        app.MapGet("/api/nr-ui-prefs", (NrUiPrefsStore store) => Results.Ok(store.Get()));
+
+        app.MapPut("/api/nr-ui-prefs", (NrUiPrefsSetRequest req, NrUiPrefsStore store) =>
+        {
+            store.Set(req.Nr1Expanded, req.Nr2Expanded, req.Nr4Expanded);
+            return Results.Ok(store.Get());
+        });
+
         // Radio selection — operator preference seeding, with discovery as the
         // tiebreaker. Preferred=="Auto" removes the override (stored as absence,
         // not a sentinel enum value). Effective = Connected when connected (which

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -190,6 +190,7 @@ public static class ZeusHost
         builder.Services.AddSingleton<PsSettingsStore>();
         builder.Services.AddSingleton<FilterPresetStore>();
         builder.Services.AddSingleton<DisplaySettingsStore>();
+        builder.Services.AddSingleton<NrUiPrefsStore>();
         builder.Services.AddSingleton<BottomPinStore>();
         builder.Services.AddSingleton<RadioStateStore>();
         builder.Services.AddSingleton<QrzService>();

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -384,6 +384,11 @@ export default function App() {
     });
   }, [contact, qrzLookup, mode, vfoHz, addLogEntry]);
 
+  const handleClearQrz = useCallback(() => {
+    useQrzStore.getState().clearLookup();
+    setCallsign('');
+  }, [setCallsign]);
+
   const [wpm, setWpm] = useState(22);
   const nrState = useConnectionStore((s) => s.nr);
   const dspActive =
@@ -610,6 +615,7 @@ export default function App() {
     onCallsignSubmit,
     submitBeam,
     handleLogQso,
+    handleClearQrz,
     dspActive,
     wpm,
     setWpm,
@@ -625,7 +631,7 @@ export default function App() {
     // heroTitle and logbookActions are ReactNodes (new objects each render);
     // their underlying primitive deps are already above, so omit them here.
     dspActive, wpm, logbookTitle,
-    handleLogQso, runQrzLookup,
+    handleLogQso, handleClearQrz, runQrzLookup,
   ]);
 
   // Mobile viewport short-circuit. All initialization hooks above (realtime,

--- a/zeus-web/src/api/nrUiPrefs.ts
+++ b/zeus-web/src/api/nrUiPrefs.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// Tiny client for /api/nr-ui-prefs — persists the per-mode expand/collapse
+// state of the inline NR settings accordion (NR1/NR2/NR4) in LiteDB so the
+// chevron-open preference follows the operator across browsers + devices.
+// Mirrors src/api/bottom-pin.ts; same minimal-API call shape.
+
+export type NrUiPrefsState = {
+  nr1Expanded: boolean;
+  nr2Expanded: boolean;
+  nr4Expanded: boolean;
+};
+
+type NrUiPrefsDtoRaw = {
+  // C# records serialise camelCase via System.Text.Json defaults
+  // (JsonSerializerDefaults.Web on the ASP.NET minimal API).
+  nr1Expanded?: boolean;
+  nr2Expanded?: boolean;
+  nr4Expanded?: boolean;
+};
+
+function normalize(raw: NrUiPrefsDtoRaw): NrUiPrefsState {
+  return {
+    nr1Expanded: raw.nr1Expanded === true,
+    nr2Expanded: raw.nr2Expanded === true,
+    nr4Expanded: raw.nr4Expanded === true,
+  };
+}
+
+export async function fetchNrUiPrefs(signal?: AbortSignal): Promise<NrUiPrefsState> {
+  const res = await fetch('/api/nr-ui-prefs', { signal });
+  if (!res.ok) throw new Error(`GET /api/nr-ui-prefs → ${res.status}`);
+  return normalize((await res.json()) as NrUiPrefsDtoRaw);
+}
+
+export async function updateNrUiPrefs(
+  next: NrUiPrefsState,
+  signal?: AbortSignal,
+): Promise<NrUiPrefsState> {
+  const res = await fetch('/api/nr-ui-prefs', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      nr1Expanded: next.nr1Expanded,
+      nr2Expanded: next.nr2Expanded,
+      nr4Expanded: next.nr4Expanded,
+    }),
+    signal,
+  });
+  if (!res.ok) throw new Error(`PUT /api/nr-ui-prefs → ${res.status}`);
+  return normalize((await res.json()) as NrUiPrefsDtoRaw);
+}

--- a/zeus-web/src/components/AboutPanel.tsx
+++ b/zeus-web/src/components/AboutPanel.tsx
@@ -24,7 +24,7 @@ import { useEffect, useState } from 'react';
 // Release date for the version this build ships against. Bump whenever
 // VersionPrefix in Directory.Build.props bumps. ISO 8601 so toLocaleDateString
 // renders sensibly in any locale.
-const RELEASE_DATE_ISO = '2026-05-13';
+const RELEASE_DATE_ISO = '2026-05-14';
 
 type VersionInfo = {
   version: string;

--- a/zeus-web/src/components/LeftLayoutBar.tsx
+++ b/zeus-web/src/components/LeftLayoutBar.tsx
@@ -192,7 +192,6 @@ export function LeftLayoutBar() {
           aria-pressed={settingsViewOpen}
         >
           <span className="lb-tab-icon" aria-hidden>⚙</span>
-          <span className="lb-tab-name">Settings</span>
         </button>
       </div>
 

--- a/zeus-web/src/components/TxStageMeters.tsx
+++ b/zeus-web/src/components/TxStageMeters.tsx
@@ -24,6 +24,7 @@ import { useTxStore } from '../state/tx-store';
 import { useConnectionStore } from '../state/connection-store';
 import { usePaStore } from '../state/pa-store';
 import { useRadioStore } from '../state/radio-store';
+import { useEmaSmoothed } from '../util/useEmaSmoothed';
 
 // ────────────────────────────────────────────────────────────────────────────
 // Overdrive indicator (re-exported so App.tsx can keep wiring it as the
@@ -124,20 +125,39 @@ export function OverdriveIndicator() {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
-// Peak-hold helper. Tracks the running max in a ref and decays at a fixed
-// rate so the held tick stays continuous across renders. Returns 0 while
-// the input is non-finite or below the floor — callers decide whether to
+// Peak-hold helper. Tracks the running max in a ref, holds the peak for
+// 1.5 s before decaying at a fixed rate so the held tick stays visible
+// long enough for the operator to read it on SSB peaks. A new sample at or
+// above the held peak refreshes the hold window. Returns 0 while the
+// input is non-finite or below the floor — callers decide whether to
 // render the tick at all (the design hides it when ≤ live value).
 // ────────────────────────────────────────────────────────────────────────────
+const PEAK_HOLD_MS = 1500;
+
 function usePeakHoldPct(currentPct: number, decayPctPerSec = 50): number {
-  const state = useRef<{ pct: number; ts: number }>({ pct: 0, ts: 0 });
+  const state = useRef<{ pct: number; ts: number; holdUntil: number }>({
+    pct: 0,
+    ts: 0,
+    holdUntil: 0,
+  });
   const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
   const prev = state.current;
+  // New peak (or first sample) — bump up and start the hold window.
+  if (currentPct > prev.pct) {
+    state.current = { pct: currentPct, ts: now, holdUntil: now + PEAK_HOLD_MS };
+    return currentPct;
+  }
+  // Inside the hold window — keep the peak pinned where it is.
+  if (now < prev.holdUntil) {
+    state.current = { ...prev, ts: now };
+    return prev.pct;
+  }
+  // Past the hold window — decay toward the current sample at the fixed
+  // pct-per-second rate so the held tick visibly bleeds back down.
   const dt = prev.ts === 0 ? 0 : Math.max(0, (now - prev.ts) / 1000);
-  const decayed = Math.max(0, prev.pct - decayPctPerSec * dt);
-  const held = Math.max(currentPct, decayed);
-  state.current = { pct: held, ts: now };
-  return held;
+  const decayed = Math.max(currentPct, prev.pct - decayPctPerSec * dt);
+  state.current = { pct: decayed, ts: now, holdUntil: prev.holdUntil };
+  return decayed;
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -535,13 +555,24 @@ function useMeterRefresh() {
 export function TxStageMeters() {
   useMeterRefresh();
 
-  const wdspMicPk = useTxStore((s) => s.wdspMicPk);
-  const alcGr = useTxStore((s) => s.alcGr);
-  const fwdWatts = useTxStore((s) => s.fwdWatts);
-  const swr = useTxStore((s) => s.swr);
+  const wdspMicPkRaw = useTxStore((s) => s.wdspMicPk);
+  const alcGrRaw = useTxStore((s) => s.alcGr);
+  const fwdWattsRaw = useTxStore((s) => s.fwdWatts);
+  const swrRaw = useTxStore((s) => s.swr);
   const moxOn = useTxStore((s) => s.moxOn);
   const tunOn = useTxStore((s) => s.tunOn);
   const transmitting = moxOn || tunOn;
+
+  // 90 ms EMA on each meter input. The wire frames land at ~10 Hz and the
+  // raf tick repaints at ~30 Hz, so a raw value snaps between frames.
+  // Smoothing the display value (bar + numeric readout) gives a fluid
+  // needle without lagging perceptibly behind voice dynamics on SSB.
+  // The absolute-peak refs below still consume the RAW value so true peaks
+  // aren't clipped by the smoother.
+  const wdspMicPk = useEmaSmoothed(wdspMicPkRaw, 90);
+  const alcGr = useEmaSmoothed(alcGrRaw, 90);
+  const fwdWatts = useEmaSmoothed(fwdWattsRaw, 90);
+  const swr = useEmaSmoothed(swrRaw, 90);
 
   // Rated PA power for the PWR axis. Resolution order:
   //   1. Operator override from the PA settings panel (paMaxPowerWatts > 0)
@@ -558,8 +589,12 @@ export function TxStageMeters() {
   const micBypassed = !isFinite(wdspMicPk) || isBypassed(wdspMicPk);
   const micPct = micPctOf(wdspMicPk);
   const micNow = micBypassed ? '—' : wdspMicPk.toFixed(1).replace('-', '−');
+  // Absolute peak consumes the RAW value so a true SSB transient isn't
+  // shaved off by the 90 ms smoother feeding the bar.
   const micPk = useRef<number>(MIC_FLOOR_DBFS);
-  if (!micBypassed && wdspMicPk > micPk.current) micPk.current = wdspMicPk;
+  if (isFinite(wdspMicPkRaw) && !isBypassed(wdspMicPkRaw) && wdspMicPkRaw > micPk.current) {
+    micPk.current = wdspMicPkRaw;
+  }
   if (micBypassed) micPk.current = MIC_FLOOR_DBFS;
   const micPkValue =
     micPk.current <= MIC_FLOOR_DBFS
@@ -572,7 +607,11 @@ export function TxStageMeters() {
   const alcPct = alcPctOf(alcGrClamped);
   const alcNow = alcBypassed ? '—' : alcGrClamped.toFixed(1);
   const alcPkRef = useRef<number>(0);
-  if (!alcBypassed && alcGrClamped > alcPkRef.current) alcPkRef.current = alcGrClamped;
+  // Peak tracks the RAW value (not the smoothed one) so true GR transients
+  // aren't shaved off.
+  const alcGrRawClamped =
+    !isFinite(alcGrRaw) || isBypassed(alcGrRaw) ? 0 : Math.max(0, alcGrRaw);
+  if (alcGrRawClamped > alcPkRef.current) alcPkRef.current = alcGrRawClamped;
   if (!transmitting) alcPkRef.current = 0;
   const alcPkValue = alcPkRef.current.toFixed(1);
 
@@ -580,7 +619,8 @@ export function TxStageMeters() {
   const pwrPct = pwrPctOf(fwdWatts, ratedW);
   const pwrNow = isFinite(fwdWatts) ? fwdWatts.toFixed(1) : '—';
   const pwrPkRef = useRef<number>(0);
-  if (isFinite(fwdWatts) && fwdWatts > pwrPkRef.current) pwrPkRef.current = fwdWatts;
+  // Peak tracks the RAW watts so true PEP isn't shaved by the 90 ms EMA.
+  if (isFinite(fwdWattsRaw) && fwdWattsRaw > pwrPkRef.current) pwrPkRef.current = fwdWattsRaw;
   if (!transmitting) pwrPkRef.current = 0;
   const pwrPkValue = pwrPkRef.current.toFixed(1);
   const pwrHot = transmitting && pwrPct > 95;
@@ -589,7 +629,8 @@ export function TxStageMeters() {
   const swrPct = swrPctOf(swr);
   const swrNow = isFinite(swr) ? swr.toFixed(2) : '—';
   const swrPkRef = useRef<number>(SWR_FLOOR);
-  if (isFinite(swr) && swr > swrPkRef.current) swrPkRef.current = swr;
+  // Peak tracks the RAW ratio so true SWR excursions aren't shaved.
+  if (isFinite(swrRaw) && swrRaw > swrPkRef.current) swrPkRef.current = swrRaw;
   if (!transmitting) swrPkRef.current = SWR_FLOOR;
   const swrPkValue = swrPkRef.current.toFixed(1);
   const swrHot = transmitting && swr > 2.5;

--- a/zeus-web/src/components/TxStageMeters.tsx
+++ b/zeus-web/src/components/TxStageMeters.tsx
@@ -324,10 +324,16 @@ function MeterRow({
             position: 'relative',
             height: 14,
             background: 'var(--meter-bg)',
-            border: '1px solid var(--panel-border)',
-            borderRadius: 0,
+            border: '1px solid var(--line)',
+            borderRadius: 2,
+            // v3 Lifted Dark: warm amber halo around the meter well — the
+            // "lit instruments on a black bench" look. Inner inset stays
+            // for depth; outer halos give the column a soft glow.
             boxShadow:
-              'inset 0 1px 0 rgba(0,0,0,0.5), inset 0 0 0 0.5px rgba(255,255,255,0.02)',
+              'inset 0 1px 3px rgba(0,0,0,0.8),' +
+              ' inset 0 0 0 1px rgba(255,255,255,0.03),' +
+              ' 0 0 18px rgba(255,140,40,0.18),' +
+              ' 0 0 6px rgba(255,170,80,0.12)',
             overflow: 'hidden',
           }}
         >

--- a/zeus-web/src/components/analog-meter/AnalogMeterConfig.tsx
+++ b/zeus-web/src/components/analog-meter/AnalogMeterConfig.tsx
@@ -3,47 +3,13 @@
 // Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
 // Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
 //
-// Header gear → slide-down config flyout. Three sections: RX (S-meter
-// ticks + dBm), TX (PO/SWR pills + full-scale + alarm), and Ballistics
-// (attack/decay/avg/peak hold). All controls drive the persisted
-// useAnalogMeterStore — operator changes survive a reload.
+// Header gear → slide-down config flyout. Slimmed to a single operator
+// toggle: Zeus mode. All other behaviour (scales shown, dBm readout, SWR
+// alarm, attack / decay / averaging / peak hold) is locked to the
+// ANALOG_METER_DEFAULTS — the previous "tweak everything" surface was
+// adding noise without much value for the typical operator.
 
 import { useAnalogMeterStore } from './analogMeterStore';
-
-interface SliderProps {
-  label: string;
-  value: number;
-  min: number;
-  max: number;
-  step: number;
-  unit: string;
-  hint?: string;
-  onChange: (v: number) => void;
-}
-
-function Slider({ label, value, min, max, step, unit, hint, onChange }: SliderProps) {
-  const fixed = step < 1 ? 2 : 0;
-  return (
-    <div className="am-slider">
-      <div className="am-slider-head">
-        <span className="am-slider-lbl">{label}</span>
-        <span className="am-slider-val">
-          {value.toFixed(fixed)}
-          <em>{unit}</em>
-        </span>
-      </div>
-      <input
-        type="range"
-        min={min}
-        max={max}
-        step={step}
-        value={value}
-        onChange={(e) => onChange(parseFloat(e.target.value))}
-      />
-      {hint && <div className="am-slider-hint">{hint}</div>}
-    </div>
-  );
-}
 
 interface CheckRowProps {
   checked: boolean;
@@ -65,37 +31,16 @@ function CheckRow({ checked, onChange, children, sub }: CheckRowProps) {
   );
 }
 
-interface PillProps {
-  on: boolean;
-  onClick: () => void;
-  children: React.ReactNode;
-}
-
-function Pill({ on, onClick, children }: PillProps) {
-  return (
-    <button type="button" className={`am-pill ${on ? 'on' : ''}`} onClick={onClick}>
-      {children}
-    </button>
-  );
-}
-
 interface AnalogMeterConfigProps {
   open: boolean;
   onClose: () => void;
 }
 
 export function AnalogMeterConfig({ open, onClose }: AnalogMeterConfigProps) {
-  const cfg = useAnalogMeterStore();
-  // The flyout is the dominant idle CPU cost on this panel — its 30+ form
-  // controls (sliders, checkboxes, tick buttons) were reconciled on every
-  // parent render even when the gear was closed, because the previous form
-  // returned the full tree and only toggled a CSS class. With
-  // AnalogMeterPanel's ballistic rAF loop driving renders at near-frame-rate,
-  // each invisible commit was re-applying ~580 input attributes per second
-  // observed via MutationObserver. Returning null when closed eliminates the
-  // entire reconcile + DOM-commit cost; the trade-off is that the slide-down
-  // animation is now a mount/unmount, which is fine for a settings flyout
-  // that opens infrequently.
+  const zeusMode = useAnalogMeterStore((s) => s.zeusMode);
+  const setZeusMode = useAnalogMeterStore((s) => s.setZeusMode);
+  // Mount/unmount instead of toggling .open keeps reconcile cost out of the
+  // ballistic rAF loop when the gear is closed.
   if (!open) return null;
 
   return (
@@ -103,103 +48,15 @@ export function AnalogMeterConfig({ open, onClose }: AnalogMeterConfigProps) {
       <div className="am-cf-grid">
         <section className="am-cf-sect">
           <header>
-            <h4>RX · Receiver</h4>
-            <CheckRow checked={cfg.scaleS} onChange={(v) => cfg.setScale('s', v)}>
-              Show S-meter
-            </CheckRow>
+            <h4>S-Meter</h4>
           </header>
           <div className="am-cf-body">
             <CheckRow
-              checked={cfg.showDbm}
-              onChange={cfg.setShowDbm}
-              sub="Append calibrated dBm to the S readout"
-            >
-              Show dBm
-            </CheckRow>
-            <CheckRow
-              checked={cfg.zeusMode}
-              onChange={cfg.setZeusMode}
+              checked={zeusMode}
+              onChange={setZeusMode}
               sub="Image fades in past S9, lightning crackles at S9+20"
             >
               Zeus mode
-            </CheckRow>
-          </div>
-        </section>
-
-        <section className="am-cf-sect">
-          <header>
-            <h4>TX · Transmitter</h4>
-            <div className="am-cf-pillrow">
-              <Pill on={cfg.scalePo} onClick={() => cfg.setScale('po', !cfg.scalePo)}>
-                Power
-              </Pill>
-              <Pill on={cfg.scaleSwr} onClick={() => cfg.setScale('swr', !cfg.scaleSwr)}>
-                SWR
-              </Pill>
-            </div>
-          </header>
-          <div className="am-cf-body">
-            <Slider
-              label="SWR alarm"
-              value={cfg.swrAlarm}
-              min={1.5}
-              max={5}
-              step={0.1}
-              unit=":1"
-              onChange={cfg.setSwrAlarm}
-              hint="Readout turns red above this"
-            />
-            <div className="am-slider-hint">
-              PA full-scale tracks the rated PA power from the PA Settings panel
-              (max of 10 W or 120% of rated).
-            </div>
-          </div>
-        </section>
-
-        <section className="am-cf-sect">
-          <header>
-            <h4>Needle ballistics</h4>
-            <button type="button" className="am-reset" onClick={cfg.resetBallistics}>
-              Reset
-            </button>
-          </header>
-          <div className="am-cf-body">
-            <Slider
-              label="Attack"
-              value={cfg.attack}
-              min={0.005}
-              max={0.5}
-              step={0.005}
-              unit=" s"
-              onChange={cfg.setAttack}
-              hint="Time constant on rising signals"
-            />
-            <Slider
-              label="Decay"
-              value={cfg.decay}
-              min={0.05}
-              max={2}
-              step={0.05}
-              unit=" s"
-              onChange={cfg.setDecay}
-              hint="Time constant on falling signals"
-            />
-            <Slider
-              label="Averaging"
-              value={cfg.avg}
-              min={1}
-              max={32}
-              step={1}
-              unit=" smp"
-              onChange={cfg.setAvg}
-              hint="Moving-average window before ballistics"
-            />
-            <CheckRow
-              checked={cfg.peakHold}
-              onChange={cfg.setPeakHold}
-              sub="Slow-decaying ghost needle marks recent peak"
-            >
-              Peak hold
             </CheckRow>
           </div>
         </section>

--- a/zeus-web/src/components/design/QrzCard.tsx
+++ b/zeus-web/src/components/design/QrzCard.tsx
@@ -50,9 +50,11 @@ type QrzCardProps = {
   lookupError?: string | null;
   onLogQso?: () => void;
   canLogQso?: boolean;
+  onClear?: () => void;
+  canClear?: boolean;
 };
 
-export function QrzCard({ contact, enriching, lookupError, onLogQso, canLogQso }: QrzCardProps) {
+export function QrzCard({ contact, enriching, lookupError, onLogQso, canLogQso, onClear, canClear }: QrzCardProps) {
   // Show "Not found" if there's a lookup error
   if (lookupError) {
     return (
@@ -60,6 +62,16 @@ export function QrzCard({ contact, enriching, lookupError, onLogQso, canLogQso }
         <div className="label-xs" style={{ color: 'var(--fg-error)', opacity: 0.8 }}>
           Not found: {lookupError}
         </div>
+        {onClear && canClear && (
+          <button
+            type="button"
+            onClick={onClear}
+            className="btn sm"
+            style={{ marginTop: '0.5rem', padding: '0.25rem 0.5rem', fontSize: 10 }}
+          >
+            Clear
+          </button>
+        )}
       </div>
     );
   }
@@ -136,6 +148,16 @@ export function QrzCard({ contact, enriching, lookupError, onLogQso, canLogQso }
           {contact.email}
         </span>
         <span style={{ flex: 1 }} />
+        {onClear && canClear && (
+          <button
+            type="button"
+            onClick={onClear}
+            className="btn sm"
+            style={{ marginRight: '0.5rem', padding: '0.25rem 0.5rem', fontSize: 10 }}
+          >
+            Clear
+          </button>
+        )}
         {onLogQso && canLogQso && (
           <button
             type="button"

--- a/zeus-web/src/components/design/QrzCard.tsx
+++ b/zeus-web/src/components/design/QrzCard.tsx
@@ -85,20 +85,43 @@ export function QrzCard({ contact, enriching, lookupError, onLogQso, canLogQso, 
       </div>
     );
   }
+  // Layout note: the rig / antenna / power / qsl rows were dropped in the
+  // 2× portrait rework — those fields are rarely consulted in-shack and the
+  // operator usually wants the portrait + grid + location front-and-centre
+  // for a quick "who am I talking to?" read.
   const rows: [string, string][] = [
     ['Grid', contact.grid],
-    ['Rig', contact.rig],
     ['Lat/Lon', contact.latlon],
-    ['Antenna', contact.ant],
     ['CQ·ITU', `${contact.cq} · ${contact.itu}`],
-    ['Power', contact.power],
     ['Local', contact.local],
-    ['QSL', contact.qsl],
   ];
   return (
     <div className="qrz-card">
-      <div className="qrz-header">
-        <div className="qrz-portrait">
+      <div className="qrz-card-main">
+        <div className="qrz-info-col">
+          <div className="qrz-id">
+            <div className="qrz-call">{contact.callsign}</div>
+            <div className="qrz-name">{contact.name}</div>
+            <div className="qrz-loc">
+              {contact.flag} {contact.location}
+            </div>
+            <div className="qrz-tags">
+              <span className="qrz-tag">{contact.class}</span>
+              <span className="qrz-tag">Lic. {contact.licensed}</span>
+              <span className="qrz-tag">Age {contact.age}</span>
+            </div>
+          </div>
+          <div className="qrz-section-label">Location · Station</div>
+          <div className="qrz-grid-rows">
+            {rows.map(([k, v]) => (
+              <div key={k} className="qrz-row">
+                <span className="k label-xs">{k}</span>
+                <span className="v mono">{v}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="qrz-portrait qrz-portrait--large">
           <div className="qrz-portrait-bg" aria-hidden>
             <div className="qrz-grid" />
           </div>
@@ -119,28 +142,6 @@ export function QrzCard({ contact, enriching, lookupError, onLogQso, canLogQso, 
           )}
           {enriching && <div className="qrz-scan" />}
         </div>
-        <div className="qrz-id">
-          <div className="qrz-call">{contact.callsign}</div>
-          <div className="qrz-name">{contact.name}</div>
-          <div className="qrz-loc">
-            {contact.flag} {contact.location}
-          </div>
-          <div className="qrz-tags">
-            <span className="qrz-tag">{contact.class}</span>
-            <span className="qrz-tag">Lic. {contact.licensed}</span>
-            <span className="qrz-tag">Age {contact.age}</span>
-          </div>
-        </div>
-      </div>
-
-      <div className="qrz-section-label">Location · Station</div>
-      <div className="qrz-grid-rows">
-        {rows.map(([k, v]) => (
-          <div key={k} className="qrz-row">
-            <span className="k label-xs">{k}</span>
-            <span className="v mono">{v}</span>
-          </div>
-        ))}
       </div>
 
       <div className="qrz-footer">

--- a/zeus-web/src/components/immersive-meters/usePeakHold.ts
+++ b/zeus-web/src/components/immersive-meters/usePeakHold.ts
@@ -5,14 +5,14 @@
 //
 // Wall-clock peak hold for the immersive meter widgets. Mirrors the
 // prototype's peak/peakHold logic: a peak that bumps up immediately, holds
-// for a window (default 1.2 s), then decays at 0.5 fraction-units / sec
+// for a window (default 1.5 s), then decays at 0.5 fraction-units / sec
 // — measured in fractional [0..1] axis units, not dB, so the visual decay
 // rate is the same on every meter regardless of its native dB range.
 
 import { useRef } from 'react';
 import { isSilent } from './dbScale';
 
-const HOLD_MS_DEFAULT = 1200;
+const HOLD_MS_DEFAULT = 1500;
 const DECAY_FRAC_PER_SEC_DEFAULT = 0.5;
 
 interface PeakState {

--- a/zeus-web/src/components/meter-group/MeterRenderer.tsx
+++ b/zeus-web/src/components/meter-group/MeterRenderer.tsx
@@ -16,6 +16,7 @@ import {
   zoneTransitionTicks,
 } from '../meters/meterCatalog';
 import { useMeterReading } from '../meters/useMeterReading';
+import { useEmaSmoothed } from '../../util/useEmaSmoothed';
 import { BigArc } from '../immersive-meters/BigArc';
 import { VuColumn } from '../immersive-meters/VuColumn';
 import { PullDownArc } from '../immersive-meters/PullDownArc';
@@ -33,7 +34,11 @@ interface MeterRendererProps {
 
 export function MeterRenderer({ widget }: MeterRendererProps) {
   const def = METER_CATALOG[widget.reading];
-  const value = useMeterReading(widget.reading);
+  // 90 ms EMA smoothing on the raw 10 Hz feed kills inter-frame steppiness
+  // without lagging visibly behind voice dynamics on SSB. See
+  // useEmaSmoothed.ts for the alpha = 1 - exp(-dt/tau) ballistics.
+  const rawValue = useMeterReading(widget.reading);
+  const value = useEmaSmoothed(rawValue, 90);
 
   const settings = widget.settings ?? {};
   const min = settings.min ?? def.defaultMin;

--- a/zeus-web/src/components/nr/NrSettingsSection.tsx
+++ b/zeus-web/src/components/nr/NrSettingsSection.tsx
@@ -50,6 +50,11 @@ import {
   type RadioStateDto,
 } from '../../api/client';
 import { useConnectionStore } from '../../state/connection-store';
+import {
+  fetchNrUiPrefs,
+  updateNrUiPrefs,
+  type NrUiPrefsState,
+} from '../../api/nrUiPrefs';
 
 export type NrSettingsMode = 'Anr' | 'Emnr' | 'Sbnr';
 
@@ -61,21 +66,82 @@ export type NrSettingsSectionProps = {
 // state, so the panel survives any FlexLayout re-render that unmounts the
 // DSP tab content (drag, dock, tabset reflow). Keyed by mode so each NR
 // algorithm's accordion remembers its own open/closed state.
+//
+// Persisted server-side via /api/nr-ui-prefs (LiteDB) so the choice
+// follows the operator across browsers + devices, same pattern as
+// bottom-pin / display-settings. Hydration runs once at module load
+// (single global store, single fetch); toggles fire a debounced PUT.
 type NrSettingsUiState = {
   expanded: Record<NrSettingsMode, boolean>;
+  hydrated: boolean;
+  /** Set the persisted state from a server fetch (no PUT). */
+  hydrate: (next: NrUiPrefsState) => void;
+  /** Toggle one mode and schedule a debounced PUT to the backend. */
   toggle: (mode: NrSettingsMode) => void;
 };
 
+// Maps the wire DTO's three booleans to / from the per-mode keyed shape
+// the component already consumes. NR4 lives under the `Sbnr` key — the
+// reading-mode enum the surrounding panel uses.
+function fromWire(p: NrUiPrefsState): Record<NrSettingsMode, boolean> {
+  return { Anr: p.nr1Expanded, Emnr: p.nr2Expanded, Sbnr: p.nr4Expanded };
+}
+function toWire(e: Record<NrSettingsMode, boolean>): NrUiPrefsState {
+  return { nr1Expanded: e.Anr, nr2Expanded: e.Emnr, nr4Expanded: e.Sbnr };
+}
+
+const PERSIST_DEBOUNCE_NR_UI_MS = 150;
+let nrUiPersistTimer: ReturnType<typeof setTimeout> | null = null;
+
+function schedulePersist(state: Record<NrSettingsMode, boolean>): void {
+  if (nrUiPersistTimer) clearTimeout(nrUiPersistTimer);
+  nrUiPersistTimer = setTimeout(() => {
+    nrUiPersistTimer = null;
+    void updateNrUiPrefs(toWire(state)).catch(() => {
+      // Persistence is best-effort — a transient server hiccup leaves the
+      // in-memory state intact; the next toggle retries. We don't surface
+      // an error toast for a chevron-open preference.
+    });
+  }, PERSIST_DEBOUNCE_NR_UI_MS);
+}
+
 const useNrSettingsUi = create<NrSettingsUiState>((set) => ({
   expanded: { Anr: false, Emnr: false, Sbnr: false },
+  hydrated: false,
+  hydrate: (next) =>
+    set({ expanded: fromWire(next), hydrated: true }),
   toggle: (mode) =>
-    set((s) => ({ expanded: { ...s.expanded, [mode]: !s.expanded[mode] } })),
+    set((s) => {
+      const expanded = { ...s.expanded, [mode]: !s.expanded[mode] };
+      schedulePersist(expanded);
+      return { expanded };
+    }),
 }));
+
+// One-shot module-level hydration so every NrSettingsSection instance
+// (the DSP panel renders one per mode) reads from the same already-fetched
+// state. Errors are swallowed — a fresh install or an offline backend
+// just leaves the defaults (everything collapsed) in place.
+let nrUiHydrationStarted = false;
+function ensureNrUiHydration(): void {
+  if (nrUiHydrationStarted) return;
+  nrUiHydrationStarted = true;
+  void fetchNrUiPrefs()
+    .then((prefs) => useNrSettingsUi.getState().hydrate(prefs))
+    .catch(() => {
+      // Mark hydrated anyway so the first toggle's PUT doesn't race a
+      // late-arriving GET response (which would clobber the user's click).
+      useNrSettingsUi.setState({ hydrated: true });
+    });
+}
 
 export function NrSettingsSection({ mode }: NrSettingsSectionProps) {
   // Persisted disclosure: collapsed by default (the dense gauge panel is
   // too much for the casual operator), but stays open across remounts once
-  // the user opens it. The chevron telegraphs the click target.
+  // the user opens it. The chevron telegraphs the click target. State is
+  // sourced from /api/nr-ui-prefs (LiteDB) so the choice follows the
+  // operator across browsers + devices.
+  useEffect(() => { ensureNrUiHydration(); }, []);
   const expanded = useNrSettingsUi((s) => s.expanded[mode]);
   const toggle = useNrSettingsUi((s) => s.toggle);
 

--- a/zeus-web/src/layout/WorkspaceContext.tsx
+++ b/zeus-web/src/layout/WorkspaceContext.tsx
@@ -101,6 +101,7 @@ export interface WorkspaceCtx {
   onCallsignSubmit: (e: FormEvent<HTMLFormElement>) => void;
   submitBeam: (e: FormEvent<HTMLFormElement>) => void;
   handleLogQso: () => void;
+  handleClearQrz: () => void;
 
   // DSP
   dspActive: boolean;

--- a/zeus-web/src/layout/panels/QrzPanel.tsx
+++ b/zeus-web/src/layout/panels/QrzPanel.tsx
@@ -53,6 +53,7 @@ export function QrzPanel() {
     enriching,
     qrzLookupError,
     handleLogQso,
+    handleClearQrz,
     qrzActive,
     csInputRef,
     onCallsignSubmit,
@@ -80,6 +81,8 @@ export function QrzPanel() {
           lookupError={qrzLookupError}
           onLogQso={handleLogQso}
           canLogQso={qrzActive && !!contact}
+          onClear={handleClearQrz}
+          canClear={!!contact || !!qrzLookupError || callsign.length > 0}
         />
       </div>
     </div>

--- a/zeus-web/src/styles/all-panels.css
+++ b/zeus-web/src/styles/all-panels.css
@@ -23,10 +23,10 @@
   width: 100%;
   height: 100%;
   overflow: auto;
-  /* Use the dark token (--bg-0) for the workspace ground so the gap
-   * between tiles reads like the dark band between the top toolbar
-   * and the second control row — not the blue-gray gutter. */
-  background: var(--bg-0);
+  /* v3 Lifted Dark: workspace ground is the distinct mid-grey "table"
+   * (--bg-workspace), so the chrome (--bg-0) and the panels (--bg-1) each
+   * read as their own surface. */
+  background: var(--bg-workspace);
 }
 
 .all-panels-grid.react-grid-layout {

--- a/zeus-web/src/styles/all-panels.css
+++ b/zeus-web/src/styles/all-panels.css
@@ -128,23 +128,43 @@
     0 2px 6px rgba(0, 0, 0, 0.4);
 }
 
-/* Tile chrome header — title + drag-handle + remove-X. Always-visible X
- * (locked decision); width budget tight at narrow tile widths but the
- * title ellipsises before the X gets in its way. */
+/* Tile chrome header — "brass instrument plate".
+ * Each panel reads as a piece of equipment with an engraved label plate
+ * above it: subtle vertical gradient lifts the header off the panel base,
+ * a 2 px --power amber rail runs the leading edge as a single decisive
+ * accent, a 1 px specular highlight catches across the top, and the
+ * bottom hairline carries a hint of lamp warmth instead of neutral grey.
+ * Title is rendered in engraved-uppercase (open tracking + faint amber
+ * text-shadow) so it pops without resorting to colored type. */
 .workspace-tile-header {
-  height: 24px;
+  position: relative;
+  height: 26px;
   flex-shrink: 0;
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 0 8px;
-  background: linear-gradient(90deg, var(--panel-head-top, var(--panel-top)), var(--panel-head-bot, var(--panel-bot)));
-  border-bottom: 1px solid var(--panel-border);
-  /* Whole header is the drag handle (RGL dragConfig.handle). Show grab
-   * cursor across the full width so the operator knows it's draggable —
-   * tiny grip-only target meant tiles with their own pointer logic
-   * (panadapter canvas) couldn't be moved. */
+  padding: 0 8px 0 10px;
+  background:
+    linear-gradient(180deg, #1c1c21 0%, #141418 100%);
+  border-bottom: 1px solid rgba(255, 177, 60, 0.14);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.045),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.35);
   cursor: grab;
+}
+/* Leading-edge gold rail — the brass plate's mounting screw line. Sits
+ * inside the rounded tile corner via the parent's overflow: hidden. */
+.workspace-tile-header::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--power);
+  box-shadow:
+    0 0 6px rgba(255, 177, 60, 0.55),
+    0 0 14px rgba(255, 177, 60, 0.22);
 }
 .workspace-tile-header:active {
   cursor: grabbing;
@@ -159,12 +179,14 @@
   color: var(--fg-3);
   cursor: grab;
   flex-shrink: 0;
+  transition: color var(--dur-fast);
 }
 .workspace-tile-drag-handle:active {
   cursor: grabbing;
 }
+.workspace-tile-header:hover .workspace-tile-drag-handle,
 .workspace-tile-drag-handle:hover {
-  color: var(--fg-1);
+  color: var(--power);
 }
 
 .workspace-tile-title {
@@ -175,9 +197,11 @@
   white-space: nowrap;
   font-size: 11px;
   font-family: var(--font-sans);
-  letter-spacing: 0.08em;
+  font-weight: 600;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--fg-1);
+  color: var(--fg-0);
+  text-shadow: 0 0 8px rgba(255, 177, 60, 0.10);
   user-select: none;
 }
 

--- a/zeus-web/src/styles/analog-meter.css
+++ b/zeus-web/src/styles/analog-meter.css
@@ -72,11 +72,17 @@
 .am-tile .am-meter-face-wrap,
 .am-tile .analog-meter-face-wrap {
   position: relative;
+  /* v3 Lifted Dark: warm "streetlamp pool" glow rising from the bottom of the
+     gauge well. Final values from Brian's tweak session: hue 31, sat 30%,
+     opacity 19%, ellipse 150% × 83%, anchored at 50% 100%. */
   background:
-    radial-gradient(120% 70% at 50% 110%, var(--accent-soft), transparent 60%),
-    var(--bg-0);
+    radial-gradient(ellipse 150% 83% at 50% 100%,
+      hsla(31, 30%, 65%, 0.19) 0%,
+      hsla(31, 30%, 65%, 0.067) 40%,
+      transparent 75%),
+    var(--bg-inset);
   padding: 12px 14px 4px;
-  border-bottom: 1px solid var(--panel-edge);
+  border-bottom: 1px solid var(--line);
   flex: 1;
   min-height: 0;
   display: flex;

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -1345,6 +1345,12 @@
 /* ===== QRZ card — gradient panel w/ portrait + rows ===== */
 .qrz-empty { padding: 20px; display: flex; align-items: center; justify-content: center; text-align: center; min-height: 140px; color: var(--fg-2); }
 .qrz-card { padding: 8px; display: flex; flex-direction: column; gap: 6px; background: var(--bg-1); }
+/* qrz-card-main: two-column body — operator info on the left, big portrait
+   on the right. Portrait spans the full height of the info column so it
+   reads as the dominant visual (matches the v2 QRZ panel rework). */
+.qrz-card-main { display: grid; grid-template-columns: 1fr auto; gap: 12px; align-items: stretch; }
+.qrz-info-col { display: flex; flex-direction: column; min-width: 0; }
+/* Legacy alias — kept for any consumer that still renders the old shape. */
 .qrz-header { display: flex; gap: 10px; align-items: stretch; }
 .qrz-id { flex: 1; min-width: 0; display: flex; flex-direction: column; justify-content: center; gap: 2px; }
 .qrz-call { font-size: 20px; font-weight: 700; color: var(--accent); text-shadow: 0 0 10px rgba(74,158,255,0.4); letter-spacing: 0.04em; font-family: var(--font-mono, 'Archivo Narrow', sans-serif); line-height: 1; }
@@ -1364,7 +1370,10 @@
   color: var(--fg-2); padding-bottom: 2px; border-bottom: 1px solid rgba(74,158,255,0.2);
   margin-top: 4px;
 }
-.qrz-grid-rows { display: grid; grid-template-columns: 1fr 1fr; gap: 2px 14px; }
+/* Single-column stack — the right column now hosts the 2× portrait, so
+   the data rows take the full info-column width. Each .qrz-row is its own
+   flex container that handles the k / v justify-between layout. */
+.qrz-grid-rows { display: flex; flex-direction: column; gap: 0; }
 .qrz-grid-rows .qrz-row { border-bottom: 1px dotted rgba(255,255,255,0.06); }
 .qrz-footer {
   display: flex; align-items: center; padding-top: 6px; margin-top: 2px;
@@ -1383,6 +1392,17 @@
   justify-content: center;
   box-shadow: none;
 }
+/* 2× portrait variant — anchored top-right inside .qrz-card-main, fills
+   the full height of the info column so the operator photo reads as the
+   dominant visual instead of a 72 px thumbnail. align-self: stretch makes
+   the grid row supply the height; aspect-ratio keeps it square. */
+.qrz-portrait.qrz-portrait--large {
+  width: 150px;
+  height: auto;
+  aspect-ratio: 1;
+  align-self: stretch;
+}
+.qrz-portrait.qrz-portrait--large .qrz-portrait-initials { font-size: 56px; }
 .qrz-portrait-bg { position: absolute; inset: 0; background: repeating-linear-gradient(45deg, rgba(255,255,255,0.03) 0 4px, transparent 4px 8px); }
 .qrz-grid {
   position: absolute; inset: 0;
@@ -1398,16 +1418,20 @@
 @keyframes qrz-scan { from { transform: translateY(-100%); } to { transform: translateY(100%); } }
 
 .qrz-rows { flex: 1; display: grid; grid-template-columns: 1fr; gap: 2px; min-width: 0; }
+/* Fixed-width label column + value column that hugs the label. Previously
+   used justify-content: space-between which pushed the value all the way
+   to the right edge of the info column, leaving it visually touching the
+   portrait now that the portrait sits in the right column. */
 .qrz-row {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 88px 1fr;
   align-items: baseline;
-  gap: 8px;
+  gap: 12px;
   padding: 2px 0;
   border-bottom: 1px dotted rgba(255,255,255,0.08);
 }
 .qrz-row .k { color: var(--fg-1); font-size: 11px; font-weight: 600; }
-.qrz-row .v { color: var(--fg-0); font-size: 12px; font-weight: 700; text-align: right; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.qrz-row .v { color: var(--fg-0); font-size: 12px; font-weight: 700; text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .qrz-row .v.accent { color: var(--accent); }
 
 .cs-input {

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -788,16 +788,34 @@
   overflow: hidden;
   min-height: 0;
 }
+/* Panel head matches the .workspace-tile-header "brass plate" treatment:
+   subtle vertical gradient, gold leading rail (synthesized via ::before),
+   specular top highlight, warm hairline at the bottom. */
 .panel-head {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 9px;
-  padding: 9px 12px 9px 14px;
-  background: var(--bg-1);
-  border-bottom: 1px solid var(--line-soft);
-  box-shadow: none;
+  padding: 9px 12px 9px 16px;
+  background: linear-gradient(180deg, #1c1c21 0%, #141418 100%);
+  border-bottom: 1px solid rgba(255, 177, 60, 0.14);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.045),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.35);
   min-height: 32px;
   flex-shrink: 0;
+}
+.panel-head::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--power);
+  box-shadow:
+    0 0 6px rgba(255, 177, 60, 0.55),
+    0 0 14px rgba(255, 177, 60, 0.22);
 }
 .panel-head .title {
   font-size: 11px;
@@ -805,7 +823,7 @@
   letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--fg-0);
-  text-shadow: none;
+  text-shadow: 0 0 8px rgba(255, 177, 60, 0.10);
   flex: 0 1 auto;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -21,14 +21,14 @@
 
 .app {
   display: grid;
-  grid-template-columns: 60px 1fr;
-  grid-template-rows: 56px 1fr 44px;
+  grid-template-columns: 56px 1fr;
+  grid-template-rows: 60px 1fr 38px;
   height: 100vh;
   width: 100vw;
   background: var(--bg-0);
   color: var(--fg-0);
-  padding: 6px;
-  gap: 6px;
+  padding: 0;
+  gap: 0;
 }
 
 .app > .left-layout-bar   { grid-column: 1; grid-row: 1 / -1; }
@@ -44,22 +44,30 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
+  /* Outer frame stays black so the strip between the chrome (header /
+     sidebar / footer at --bg-0) and the inner workspace surface reads as
+     continuous chrome. The inner .all-panels-workspace owns the grey
+     canvas the panels sit on. */
+  background: var(--bg-0);
+  padding: 6px;
+  gap: 6px;
 }
 .workspace-area > .alert-banner { flex: 0 0 auto; }
 .workspace-area > .flex-workspace,
 .workspace-area > .settings-view { flex: 1; min-height: 0; }
 
-/* ===== Left layout bar — issue #241 ===== */
+/* ===== Left layout bar — issue #241 (v3 Lifted Dark: flat near-black) ===== */
 .left-layout-bar {
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  padding: 6px 4px;
-  background: linear-gradient(180deg, var(--panel-top), var(--panel-bot));
-  border: 1px solid var(--panel-edge);
-  border-radius: var(--r-lg);
-  box-shadow: var(--panel-shadow);
+  gap: 2px;
+  padding: 8px 4px;
+  background: var(--bg-0);
+  border: 0;
+  border-right: 1px solid var(--line);
+  border-radius: 0;
+  box-shadow: none;
   min-height: 0;
   overflow: hidden;
 }
@@ -83,51 +91,9 @@
   --lb-tint-g: 158;
   --lb-tint-b: 255;
 }
-.left-layout-bar::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  z-index: 0;
-  background: linear-gradient(
-    to bottom,
-    rgba(var(--lb-wash-r), var(--lb-wash-g), var(--lb-wash-b), 0.55) 0%,
-    rgba(var(--lb-wash-r), var(--lb-wash-g), var(--lb-wash-b), 0.55) 50%,
-    rgba(var(--lb-wash-r), var(--lb-wash-g), var(--lb-wash-b), 0.00) 70%,
-    rgba(var(--lb-wash-r), var(--lb-wash-g), var(--lb-wash-b), 0.00) 100%
-  );
-}
-.left-layout-bar::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  z-index: 0;
-  background:
-    radial-gradient(circle,
-      rgba(var(--lb-tint-r), var(--lb-tint-g), var(--lb-tint-b), 0.22) 1px,
-      transparent 1.5px)
-    0 0 / 8px 8px;
-  /* Dots only paint in the 50–70% band: fully transparent above 50%, fade
-     in to ~60% peak, fully transparent again by 70% so the bar's bottom
-     half stays clean. */
-  -webkit-mask-image: linear-gradient(
-    to bottom,
-    transparent 0%,
-    transparent 50%,
-    black 60%,
-    transparent 70%,
-    transparent 100%
-  );
-          mask-image: linear-gradient(
-    to bottom,
-    transparent 0%,
-    transparent 50%,
-    black 60%,
-    transparent 70%,
-    transparent 100%
-  );
-}
+/* v3 Lifted Dark: no decorative wash on the sidebar — flat near-black. */
+.left-layout-bar::before,
+.left-layout-bar::after { content: none; }
 
 /* Direct children sit above the accent layer so layout buttons / actions
    stay fully readable and clickable. */
@@ -159,23 +125,41 @@
   align-items: center;
   justify-content: center;
   gap: 3px;
-  padding: 6px 4px 5px;
-  color: var(--fg-1);
-  background: linear-gradient(180deg, var(--btn-top), var(--btn-bot));
-  border: 1px solid var(--btn-edge);
+  padding: 6px 2px 5px;
+  color: var(--fg-2);
+  background: transparent;
+  border: 1px solid transparent;
   border-radius: var(--r-sm);
-  box-shadow: inset 0 1px 0 var(--btn-hl);
+  box-shadow: none;
   cursor: pointer;
   text-align: center;
   min-height: 50px;
+  position: relative;
   transition: background var(--dur-fast), border-color var(--dur-fast),
-    color var(--dur-fast), box-shadow var(--dur-fast);
+    color var(--dur-fast);
 }
-.left-layout-bar .lb-tab:hover { filter: brightness(1.12); }
+.left-layout-bar .lb-tab:hover {
+  background: var(--bg-2);
+  color: var(--fg-0);
+  filter: none;
+}
 .left-layout-bar .lb-item.active .lb-tab {
-  border-color: var(--accent);
+  background: var(--bg-2);
+  border-color: var(--line-strong);
   color: var(--accent);
-  box-shadow: inset 0 1px 0 var(--btn-hl), 0 0 8px var(--accent-soft);
+  box-shadow: none;
+}
+.left-layout-bar .lb-item.active .lb-tab::before {
+  content: "";
+  position: absolute;
+  left: -5px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 2px;
+  height: 60%;
+  background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+  border-radius: 1px;
 }
 .left-layout-bar .lb-tab-icon {
   font-size: 18px;
@@ -450,13 +434,14 @@
 .topbar {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 0 10px;
-  background: linear-gradient(90deg, var(--panel-top), var(--panel-bot));
-  border: 1px solid var(--panel-edge);
-  border-radius: var(--r-lg);
-  box-shadow: var(--panel-shadow);
-  height: 56px;
+  gap: 18px;
+  padding: 0 14px;
+  background: var(--bg-0);
+  border: 0;
+  border-bottom: 1px solid var(--line);
+  border-radius: 0;
+  box-shadow: none;
+  height: 60px;
   overflow: hidden;
 }
 .topbar .topbar-controls {
@@ -492,10 +477,11 @@
   transform: none;
 }
 .topbar .btn.active {
-  background: var(--accent-soft);
-  color: var(--accent);
-  border-color: rgba(74,158,255,0.35);
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
   text-shadow: none;
+  box-shadow: 0 0 0 1px rgba(46,142,255,0.5), 0 0 14px rgba(46,142,255,0.35);
 }
 .topbar .btn.ghost { background: transparent; }
 .topbar .btn.ghost:hover { background: rgba(255,255,255,0.06); }
@@ -521,10 +507,10 @@
 .brand-text { display: flex; flex-direction: column; }
 .brand-name {
   font-size: 15px;
-  font-weight: 700;
-  letter-spacing: 0.02em;
+  font-weight: 600;
+  letter-spacing: -0.01em;
   color: var(--fg-0);
-  text-shadow: 0 1px 0 rgba(0,0,0,0.5);
+  text-shadow: none;
 }
 .brand-sub {
   font-size: 9px;
@@ -533,31 +519,28 @@
 }
 .topbar-divider {
   width: 1px; height: 32px;
-  background: rgba(0,0,0,0.4);
-  box-shadow: 1px 0 0 rgba(255,255,255,0.06);
+  background: var(--line);
+  box-shadow: none;
 }
 
 /* VFO tab — the big embossed freq readout */
 .vfo-group { display: flex; gap: 4px; align-items: stretch; }
 .vfo-tab {
-  padding: 2px 14px;
-  background: linear-gradient(180deg, #0a1220 0%, #14243e 100%);
-  border: 1px solid #000;
+  padding: 4px 14px;
+  background: var(--bg-2);
+  border: 1px solid var(--line-strong);
   border-radius: var(--r-md);
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   justify-content: center;
   min-width: 120px;
-  box-shadow:
-    inset 0 1px 2px rgba(0,0,0,0.6),
-    inset 0 -1px 0 rgba(255,255,255,0.04),
-    0 1px 0 rgba(255,255,255,0.05);
+  box-shadow: none;
   cursor: pointer;
   transition: all var(--dur-fast);
 }
-.vfo-tab:hover { border-color: var(--accent); }
-.vfo-tab.active { border-color: var(--accent); box-shadow: inset 0 1px 2px rgba(0,0,0,0.6), 0 0 8px var(--accent-soft); }
+.vfo-tab:hover { border-color: var(--accent-line); }
+.vfo-tab.active { border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent-line), 0 0 14px var(--accent-soft); }
 .vfo-tab.active .vfo-freq { color: var(--accent); }
 .vfo-label { font-size: 9px; color: var(--fg-2); font-weight: 600; letter-spacing: 0.06em; }
 .vfo-freq {
@@ -597,10 +580,10 @@
   display: flex;
   gap: 12px;
   padding: 4px 10px;
-  background: linear-gradient(90deg, var(--panel-top), var(--panel-bot));
-  border: 1px solid var(--panel-edge);
+  background: var(--bg-1);
+  border: 1px solid var(--line);
   border-radius: var(--r-lg);
-  box-shadow: var(--panel-shadow);
+  box-shadow: none;
   height: 68px;
   align-items: center;
   overflow: hidden;
@@ -664,73 +647,80 @@
   min-height: 280px;
 }
 
-/* ===== Buttons — chunky dark gradient chrome (matches reference) ===== */
+/* ===== Buttons — v3 Lifted Dark: flat, blue ON state with glow ===== */
 .btn {
-  --btn-top-c: var(--btn-top);
-  --btn-bot-c: var(--btn-bot);
+  --btn-top-c: var(--bg-2);
+  --btn-bot-c: var(--bg-2);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 4px;
-  /* Fluid sizing: stays ~current on MBA/QHD/ultrawide, bumps on 4K+ below.
-     em-padding so the box tracks font-size automatically. */
   padding: 0.5em 0.85em;
   font-size: clamp(11px, 0.15vw + 10px, 13.5px);
-  font-weight: 700;
-  letter-spacing: 0.03em;
-  color: var(--btn-text);
-  background: linear-gradient(180deg, var(--btn-top-c), var(--btn-bot-c));
-  border: 1px solid var(--btn-edge);
-  border-radius: var(--r-sm);
-  box-shadow:
-    inset 0 1px 0 var(--btn-hl),
-    inset 0 -1px 0 rgba(0,0,0,0.3),
-    0 1px 0 rgba(0,0,0,0.5);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--fg-1);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--r-md);
+  box-shadow: none;
   cursor: pointer;
-  transition: filter var(--dur-fast), background var(--dur-fast);
-  text-shadow: 0 1px 0 rgba(0,0,0,0.6);
+  transition: background var(--dur-fast), color var(--dur-fast),
+    border-color var(--dur-fast), box-shadow var(--dur-fast);
+  text-shadow: none;
   white-space: nowrap;
   user-select: none;
 }
 .btn:hover {
-  filter: brightness(1.15);
+  background: var(--bg-2);
+  color: var(--fg-0);
+  filter: none;
 }
 .btn:active,
 .btn.pressed {
-  background: linear-gradient(0deg, var(--btn-top-c), var(--btn-bot-c));
-  box-shadow:
-    inset 0 2px 3px rgba(0,0,0,0.5),
-    inset 0 -1px 0 rgba(255,255,255,0.04);
-  transform: translateY(1px);
+  background: var(--bg-3);
+  box-shadow: none;
+  transform: none;
 }
 .btn.active {
-  --btn-top-c: var(--btn-active-top);
-  --btn-bot-c: var(--btn-active-bot);
+  background: var(--accent);
   color: var(--btn-active-text);
-  text-shadow: 0 1px 0 rgba(0,0,0,0.6), 0 0 8px rgba(74,158,255,0.4);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px rgba(46,142,255,0.5), 0 0 14px rgba(46,142,255,0.35);
+  text-shadow: none;
 }
 .btn.sm { padding: 0.3em 0.7em;  font-size: clamp(10px, 0.1vw + 9.5px, 12px); }
 .btn.lg { padding: 0.55em 1em;   font-size: clamp(13px, 0.2vw + 10px, 15px); }
 .btn.ghost {
-  background: linear-gradient(180deg, #2e2f33, #1c1d20);
+  background: var(--bg-2);
+  border-color: var(--line-strong);
   color: var(--fg-1);
 }
+.btn.ghost:hover { background: var(--bg-3); color: var(--fg-0); }
 .btn.tx {
-  --btn-top-c: #7c1510;
-  --btn-bot-c: #3a0a07;
-  color: #ffd4d0;
-  text-shadow: 0 0 6px rgba(230,58,43,0.8);
+  background: transparent;
+  border-color: var(--line-strong);
+  color: var(--tx);
+  text-shadow: none;
+}
+.btn.tx:hover {
+  background: var(--tx-soft);
+  border-color: var(--tx);
 }
 .btn.tx.active {
-  --btn-top-c: #e63a2b;
-  --btn-bot-c: #8a1a10;
+  background: var(--tx);
+  border-color: var(--tx);
   color: #fff;
+  box-shadow: 0 0 0 1px rgba(255,74,89,0.5), 0 0 14px rgba(255,74,89,0.35);
 }
 .btn.orange {
-  --btn-top-c: var(--orange);
-  --btn-bot-c: #b45410;
+  background: var(--orange);
+  border-color: var(--orange);
   color: #fff;
-  text-shadow: 0 1px 0 rgba(0,0,0,0.4);
+  text-shadow: none;
+}
+.btn.orange:hover {
+  filter: brightness(1.1);
 }
 
 /* 4K-and-above bump. 34" ultrawide (3440 CSS px) stays under this threshold
@@ -787,42 +777,46 @@
 }
 .mono { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
 
-/* ===== Panel chrome (Dockable wrapper) ===== */
+/* ===== Panel chrome (Dockable wrapper) — v3 Lifted Dark: flat ===== */
 .panel {
   display: flex;
   flex-direction: column;
   background: var(--bg-1);
-  border: 1px solid var(--panel-border);
-  border-radius: var(--r-md);
-  box-shadow:
-    inset 0 1px 0 var(--panel-hl-top),
-    0 1px 0 rgba(0,0,0,0.6),
-    0 2px 6px rgba(0,0,0,0.4);
+  border: 1px solid var(--line);
+  border-radius: var(--r-lg);
+  box-shadow: none;
   overflow: hidden;
   min-height: 0;
 }
 .panel-head {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 5px 10px;
-  background: linear-gradient(90deg, var(--panel-head-top), var(--panel-head-bot));
-  border-bottom: 1px solid var(--panel-border);
-  box-shadow: inset 0 1px 0 rgba(255,255,255,0.08);
-  min-height: 28px;
+  gap: 9px;
+  padding: 9px 12px 9px 14px;
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--line-soft);
+  box-shadow: none;
+  min-height: 32px;
   flex-shrink: 0;
 }
 .panel-head .title {
   font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.06em;
+  font-weight: 600;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--fg-0);
-  text-shadow: 0 1px 0 rgba(0,0,0,0.5);
+  text-shadow: none;
   flex: 0 1 auto;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+/* v3 blue "section dot" leading the title — applied wherever a .panel-head
+   has a .dot, but also synthesized via ::before when absent. */
+.panel-head .dot {
+  width: 5px; height: 5px; border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
 }
 .panel-body {
   flex: 1;
@@ -1168,40 +1162,54 @@
   height: 100%;
   min-height: 0;
 }
+/* v3 Lifted Dark — VFO card with pronounced blue aurora behind the digits.
+   Three radial gradients layered over the panel base + a blurred ::before
+   ellipse give the digits a soft bloom of electric blue. */
 .freq-display {
-  padding: 16px 20px;
-  background: linear-gradient(180deg, #0a1220, #14243e);
-  border: 1px solid #000;
-  border-radius: var(--r-md);
-  box-shadow: inset 0 1px 3px rgba(0,0,0,0.7);
+  padding: 28px 20px 20px;
+  background:
+    radial-gradient(ellipse 55% 95% at 50% 55%, rgba(46,142,255,0.22), transparent 70%),
+    radial-gradient(ellipse 80% 60% at 50% 40%, rgba(46,142,255,0.10), transparent 75%),
+    radial-gradient(ellipse 100% 60% at 50% 110%, rgba(46,142,255,0.06), transparent 70%),
+    var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: var(--r-lg);
+  box-shadow: none;
   flex: 1 1 auto;
-  /* Always tall enough for the 38px-floor digits + the top/bottom hint
-     rows + padding. If a flexlayout split squeezes the panel below this,
-     the parent .freq-panel's overflow: auto produces a scrollbar rather
-     than clipping the digits. */
   min-height: 91px;
   display: flex;
   flex-direction: column;
   justify-content: center;
   container-type: size;
+  position: relative;
+  overflow: hidden;
 }
+.freq-display::before {
+  content: "";
+  position: absolute;
+  left: 50%; top: 50%;
+  transform: translate(-50%, -50%);
+  width: 60%; height: 80%;
+  background: radial-gradient(ellipse at center, rgba(78,166,255,0.18), transparent 60%);
+  filter: blur(20px);
+  pointer-events: none;
+}
+.freq-display > * { position: relative; z-index: 1; }
 .freq-top, .freq-bot { display: flex; align-items: center; font-size: 10px; }
 .freq-digits {
   display: flex;
   align-items: baseline;
-  font-family: var(--font-num);
-  font-weight: 700;
-  /* Scales with container WIDTH — digits flow horizontally so width is
-     the axis that decides fit. Floor at 38px keeps the docked-tab
-     baseline; ceiling caps the look on very wide layouts. */
+  font-family: var(--font-sans);
+  /* v3: thin 200-weight Inter, white digits, subtle blue text-shadow */
+  font-weight: 200;
   font-size: clamp(38px, 9cqw, 140px);
-  letter-spacing: 0.01em;
+  letter-spacing: -0.025em;
   color: var(--fg-0);
   font-variant-numeric: tabular-nums;
   line-height: 1.05;
   margin: 4px 0;
   justify-content: center;
-  text-shadow: 0 0 10px var(--accent-soft);
+  text-shadow: 0 0 12px rgba(78,166,255,0.25);
 }
 .freq-digits .digit {
   background: none; border: none; color: inherit; font: inherit;
@@ -1213,8 +1221,8 @@
   color: var(--accent);
   text-shadow: 0 0 10px var(--accent);
 }
-.freq-digits .digit.leading { color: var(--fg-3); }
-.freq-digits .sep { color: var(--fg-2); padding: 0 3px; }
+.freq-digits .digit.leading { color: var(--fg-4); }
+.freq-digits .sep { color: var(--fg-1); padding: 0 1px; font-weight: 200; }
 .vfo-swap { display: flex; align-items: center; gap: 6px; }
 
 /* ===== Meter ===== */
@@ -1327,10 +1335,11 @@
 .qrz-tags { display: flex; gap: 3px; margin-top: 3px; flex-wrap: wrap; }
 .qrz-tag {
   font-size: 8px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;
-  padding: 1px 5px;
-  background: linear-gradient(180deg, rgba(255,255,255,0.08), rgba(0,0,0,0.2));
-  border: 1px solid rgba(74,158,255,0.3);
-  color: var(--fg-1);
+  padding: 2px 6px;
+  background: var(--bg-2);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-xs);
+  color: var(--accent-bright);
 }
 .qrz-section-label {
   font-size: 9px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase;
@@ -1347,14 +1356,14 @@
   flex-shrink: 0;
   width: 72px; height: 72px;
   position: relative;
-  background: linear-gradient(180deg, #2a3a55, #101a2e);
-  border: 1px solid #000;
+  background: var(--bg-2);
+  border: 1px solid var(--line-strong);
   border-radius: var(--r-sm);
   overflow: hidden;
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,0.6);
+  box-shadow: none;
 }
 .qrz-portrait-bg { position: absolute; inset: 0; background: repeating-linear-gradient(45deg, rgba(255,255,255,0.03) 0 4px, transparent 4px 8px); }
 .qrz-grid {
@@ -1385,16 +1394,21 @@
 
 .cs-input {
   width: 90px;
-  background: #0a1220;
-  border: 1px solid #000;
-  border-radius: 0;
-  padding: 3px 8px;
+  background: transparent;
+  border: 1px solid var(--accent-line);
+  border-radius: var(--r-md);
+  padding: 6px 10px;
   font-size: 12px;
-  font-weight: 700;
+  font-weight: 600;
   color: var(--fg-0);
-  letter-spacing: 0.06em;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,0.6);
+  box-shadow: none;
+}
+.cs-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(46,142,255,0.15);
 }
 .cs-input:focus { outline: none; border-color: var(--accent); box-shadow: inset 0 1px 2px rgba(0,0,0,0.6), 0 0 0 1px var(--accent-soft); }
 
@@ -1481,27 +1495,27 @@
 .slider-val { font-size: 11px; font-weight: 700; color: var(--fg-0); }
 .slider-track {
   position: relative;
-  height: 8px;
-  background: #000;
-  border: 1px solid rgba(0,0,0,0.6);
-  border-radius: 0;
+  height: 4px;
+  background: var(--line);
+  border: 0;
+  border-radius: 4px;
   cursor: pointer;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,0.7);
+  box-shadow: none;
 }
 .slider-fill {
   position: absolute; inset: 0 auto 0 0;
-  background: linear-gradient(90deg, var(--accent), color-mix(in srgb, var(--accent) 70%, white));
-  border-radius: 0;
+  background: var(--accent);
+  border-radius: 4px;
 }
 .slider-thumb {
   position: absolute;
   top: 50%;
   transform: translate(-50%, -50%);
-  width: 14px; height: 16px;
-  background: linear-gradient(180deg, #c0cbd9, #7a8698);
-  border: 1px solid #000;
-  border-radius: 0;
-  box-shadow: inset 0 1px 0 rgba(255,255,255,0.6), 0 1px 2px rgba(0,0,0,0.6);
+  width: 14px; height: 14px;
+  background: #ffffff;
+  border: 0;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.5), 0 1px 4px rgba(0,0,0,0.5);
 }
 
 /* ===== CW ===== */
@@ -1525,17 +1539,18 @@
 .cw-cursor { animation: blink 1s steps(2) infinite; color: var(--accent); }
 @keyframes blink { 50% { opacity: 0.2; } }
 
-/* ===== Transport bar ===== */
+/* ===== Transport bar — v3 Lifted Dark: flat near-black ===== */
 .transport {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 0 10px;
-  background: linear-gradient(90deg, var(--panel-top), var(--panel-bot));
-  border: 1px solid var(--panel-edge);
-  border-radius: var(--r-lg);
-  box-shadow: var(--panel-shadow);
-  height: 44px;
+  padding: 0 14px;
+  background: var(--bg-0);
+  border: 0;
+  border-top: 1px solid var(--line);
+  border-radius: 0;
+  box-shadow: none;
+  height: 38px;
 }
 /* Transport buttons read as flat clickable regions of the toolbar, not raised
    chiclets. TX (MOX-on) is excluded — it keeps its red bevel/pulse for safety. */
@@ -1557,21 +1572,22 @@
   transform: none;
 }
 .transport .btn.active {
-  background: var(--accent-soft);
-  color: var(--accent);
-  border-color: rgba(74,158,255,0.35);
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
   text-shadow: none;
+  box-shadow: 0 0 0 1px rgba(46,142,255,0.5), 0 0 14px rgba(46,142,255,0.35);
 }
 .transport .btn.ghost {
   background: transparent;
 }
-.transport .btn.ghost:hover { background: rgba(255,255,255,0.06); }
-/* Restore TX styling for MOX-on state — must remain visually loud. */
+.transport .btn.ghost:hover { background: var(--bg-2); color: var(--fg-0); }
+/* MOX-on must remain visually loud — keep the red but in v3 flat style. */
 .transport .btn.tx {
-  background: linear-gradient(180deg, var(--btn-top-c), var(--btn-bot-c));
-  border: 1px solid var(--btn-edge);
-  color: #ffd4d0;
-  text-shadow: 0 0 6px rgba(230,58,43,0.8);
+  background: var(--tx-soft);
+  border: 1px solid var(--tx);
+  color: var(--tx);
+  text-shadow: none;
 }
 .tx-btn { font-size: 14px; font-weight: 700; letter-spacing: 0.12em; min-width: 80px; }
 .tx-btn.tx {
@@ -1584,7 +1600,7 @@
   0%, 100% { box-shadow: inset 0 1px 0 var(--btn-hl), 0 0 0 rgba(255,56,56,0); }
   50% { box-shadow: inset 0 1px 0 var(--btn-hl), 0 0 12px rgba(255,56,56,0.9); }
 }
-.transport-sep { width: 1px; height: 28px; background: rgba(0,0,0,0.4); box-shadow: 1px 0 0 rgba(255,255,255,0.06); margin: 0 4px; }
+.transport-sep { width: 1px; height: 18px; background: var(--line); box-shadow: none; margin: 0 4px; }
 .knob-group { display: flex; align-items: center; gap: 8px; min-width: 130px; }
 .knob-group > .label-xs { min-width: 32px; color: var(--fg-1); white-space: nowrap; }
 .knob-group > .slider { flex: 1; }

--- a/zeus-web/src/styles/nr-settings.css
+++ b/zeus-web/src/styles/nr-settings.css
@@ -18,10 +18,12 @@
   color: var(--fg-1);
   font-family: var(--font-sans);
   font-size: 12px;
-  border: 1px solid var(--panel-edge);
+  border: 1px solid var(--line);
   border-radius: var(--r-lg);
-  background: linear-gradient(180deg, var(--panel-top) 0%, var(--panel-bot) 100%);
-  box-shadow: inset 0 1px 0 var(--panel-hl-top);
+  /* Nested under the DSP panel — needs to lift visibly off the panel's own
+     --bg-1 base, so we step up one rung to --bg-2. v3 layered-surface feel. */
+  background: var(--bg-2);
+  box-shadow: none;
 }
 
 .nr-settings__title {

--- a/zeus-web/src/styles/tokens.css
+++ b/zeus-web/src/styles/tokens.css
@@ -42,7 +42,7 @@
   --fg-4: #3a3a40;          /* extra-muted for borders/sep */
 
   /* ----- Accents — blue as accent ONLY, not a surface tint ----- */
-  --accent:        #2e8eff;
+  --accent:        #0c5f9c;
   --accent-bright: #4ea6ff;
   --accent-soft:   rgba(46,142,255,0.14);
   --accent-line:   rgba(46,142,255,0.55);

--- a/zeus-web/src/styles/tokens.css
+++ b/zeus-web/src/styles/tokens.css
@@ -1,54 +1,74 @@
 /* ===========================================================
-   Zeus SDR — Design tokens (pulled from Hermes Lite 2 reference)
-   Near-black chrome, mid-gray workspace, classic SDR colors
+   Zeus SDR — Design tokens (v3 "Lifted Dark")
+   Neutral near-black surfaces, electric blue accent, warm amber
+   halos on meters, blue aurora on the VFO. Source of truth.
    =========================================================== */
+
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap');
 
 @font-face { font-display: swap; }
 
 :root {
   /* ----- Workspace ----- */
-  --bg-app:       #657486;  /* mid blue-gray behind panels */
-  --bg-workspace: #575e6b;  /* slightly darker for contrast */
+  --bg-app:       #0a0a0c;  /* app backdrop — header / sidebar / footer chrome */
+  /* Workspace canvas reverts to near-black so the whole layout reads as one
+     continuous dark surface; only the panels (at --bg-1) lift off it. */
+  --bg-workspace: #0a0a0c;
 
-  /* ----- Panels / chrome (near-black like ref) ----- */
-  --bg-0: #1a1b1e;
-  --bg-1: #2a2b2e;
-  --bg-2: #323236;
-  --bg-3: #3a3b3f;
+  /* ----- Surfaces — neutral near-black, no blue tint ----- */
+  --bg-0: #0a0a0c;          /* app backdrop */
+  --bg-1: #111114;          /* panel base */
+  --bg-2: #1a1a1e;          /* raised control / button rest */
+  --bg-3: #232328;          /* hover */
+  --bg-inset:  #060608;     /* deepest wells (panadapter, gauge bg) */
+  --bg-meter:  #050507;     /* LED-meter well, near-pitch */
 
-  /* Panel head bar — matches the "Hermes Lite 2" top bar in ref */
-  --panel-head-top: #3a3b3f;
-  --panel-head-bot: #232427;
-  --panel-border:   #0d0d10;
-  --panel-hl-top:   rgba(255,255,255,0.10);
+  /* Lines — neutral grays */
+  --line:        #1f1f23;
+  --line-soft:   #16161a;
+  --line-strong: #2c2c32;
+
+  /* Panel head — flat (no beveled gradient anymore) */
+  --panel-head-top: var(--bg-1);
+  --panel-head-bot: var(--bg-1);
+  --panel-border:   var(--line);
+  --panel-hl-top:   transparent;
 
   /* ----- Foreground ----- */
   --fg-0: #ffffff;
-  --fg-1: #d4d5d8;
-  --fg-2: #9a9b9f;
-  --fg-3: #6b6c70;
+  --fg-1: #cccccc;
+  --fg-2: #8a8a90;
+  --fg-3: #5a5a60;
+  --fg-4: #3a3a40;          /* extra-muted for borders/sep */
 
-  /* ----- Accents (reference exact) ----- */
-  --accent:      #4a9eff;   /* LSB/USB blue text (like "FAST" blue & frequency blue) */
-  --accent-soft: rgba(74,158,255,0.15);
-  --tx:          #e63a2b;   /* TX red (like "TX: OFF" red) */
-  --tx-soft:     rgba(230,58,43,0.18);
-  --power:       #ffc93a;   /* yellow digits like "20W" */
-  --power-soft:  rgba(255,201,58,0.16);
-  --ok:          #2e7a2e;   /* healthy / normal-range green for meter zones */
-  --ok-soft:     rgba(46,122,46,0.18);
-  --orange:      #f28524;   /* Lookup button top */
-  --orange-dk:   #6b1100;   /* Lookup button shadow edge */
+  /* ----- Accents — blue as accent ONLY, not a surface tint ----- */
+  --accent:        #2e8eff;
+  --accent-bright: #4ea6ff;
+  --accent-soft:   rgba(46,142,255,0.14);
+  --accent-line:   rgba(46,142,255,0.55);
+  --tx:            #ff4a59;
+  --tx-soft:       rgba(255,74,89,0.18);
+  --power:         #ffb13c;
+  --power-soft:    rgba(255,177,60,0.16);
+  --ok:            #2dd566;
+  --ok-soft:       rgba(45,213,102,0.18);
+  --green-soft:    #1aa84e;
+  --amber:         #ffb13c;
+  --amber-soft:    rgba(255,177,60,0.18);
+  --orange:        #ff8a3c;
+  --orange-dk:     #6b1100;
+  --cyan:          #4dc9ff;
+  --yellow:        #e4d645;
 
-  /* ----- Button chrome (matches the ref's chunky dark buttons) ----- */
-  --btn-top:     #4a4b4f;
-  --btn-bot:     #26272a;
-  --btn-hl:      rgba(255,255,255,0.14);
-  --btn-edge:    #0a0a0c;
-  --btn-text:    #e8e9ec;
+  /* ----- Button chrome — flat, no chunky gradient ----- */
+  --btn-top:     var(--bg-2);
+  --btn-bot:     var(--bg-2);
+  --btn-hl:      transparent;
+  --btn-edge:    var(--line-strong);
+  --btn-text:    var(--fg-1);
 
-  --btn-active-top: #5a9cd8;
-  --btn-active-bot: #2e5a8a;
+  --btn-active-top: var(--accent);
+  --btn-active-bot: var(--accent);
   --btn-active-text: #ffffff;
 
   /* ----- Spectrum + waterfall ----- */
@@ -67,8 +87,10 @@
   --wf-6: #c23030;
 
   /* ----- Meters ----- */
-  --meter-bg:    #0d0e10;
-  --meter-fill:  linear-gradient(90deg, #2e7a2e 0%, #4aa04a 55%, #d4a42a 80%, #d04040 100%);
+  --meter-bg:    var(--bg-meter);
+  --meter-fill:  linear-gradient(90deg, var(--ok) 0%, var(--ok) 70%, var(--amber) 90%, var(--tx) 100%);
+  /* Warm amber halo around LED meter columns — "lit instruments on black" */
+  --meter-halo:  0 0 18px rgba(255,140,40,0.18), 0 0 6px rgba(255,170,80,0.12);
 
   /* ----- Immersive meter chrome (BigArc / VuColumn / PullDownArc) -----
      Deeper-than-meter-bg fills used inside the immersive Meters panel so
@@ -79,11 +101,11 @@
      (#161a23 / #11151c / #0c1019) — flattened to neutral greys per the
      operator's "less blues, more greys" feedback. The *-glow tokens
      carry the bloom alpha used by SVG drop-shadows + filters. */
-  --immersive-bg:        #07080a;
-  --immersive-panel:     #1a1c20;
-  --immersive-panel-2:   #16181c;
-  --immersive-well:      #101216;
-  --immersive-well-2:    #0a0b0e;
+  --immersive-bg:        var(--bg-0);
+  --immersive-panel:     var(--bg-1);
+  --immersive-panel-2:   var(--bg-1);
+  --immersive-well:      var(--bg-inset);
+  --immersive-well-2:    var(--bg-meter);
   --immersive-rim:       rgba(255,255,255,0.06);
   --immersive-rim-strong:rgba(255,255,255,0.10);
   --immersive-line:      rgba(255,255,255,0.05);
@@ -138,17 +160,16 @@
   --immersive-lamp-chip-text-glow: rgba(255,245,200,0.16);
   --immersive-lamp-active-glow: rgba(245,240,180,0.18);
 
-  /* ----- Type ----- */
-  --font-sans: 'Archivo Narrow', 'Arial Narrow', sans-serif;
-  --font-mono: 'Archivo Narrow', 'Arial Narrow', sans-serif;
-  --font-display: 'Archivo Narrow', sans-serif;
+  /* ----- Type — v3 Lifted Dark: Inter + JetBrains Mono ----- */
+  --font-sans:    'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+  --font-mono:    'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  --font-display: 'Inter', sans-serif;
 
-  /* ----- Spacing / radius ----- */
-  /* Square-edge experiment: all corner radii flattened. */
-  --r-xs: 0;
-  --r-sm: 0;
-  --r-md: 0;
-  --r-lg: 0;
+  /* ----- Spacing / radius — v3 introduces gentle rounding ----- */
+  --r-xs: 2px;
+  --r-sm: 3px;
+  --r-md: 4px;
+  --r-lg: 6px;
 
   /* ----- Easing ----- */
   --ease-out: cubic-bezier(.22,.61,.36,1);
@@ -157,14 +178,14 @@
   --dur-med:  240ms;
 
   /* ----- Aliases for panel chrome (used across layout.css) ----- */
-  --panel-top:    var(--panel-head-top);
-  --panel-bot:    var(--panel-head-bot);
-  --panel-edge:   var(--panel-border);
-  --panel-shadow: inset 0 1px 0 rgba(255,255,255,0.08), 0 1px 0 rgba(0,0,0,0.6), 0 2px 4px rgba(0,0,0,0.4);
+  --panel-top:    var(--bg-1);
+  --panel-bot:    var(--bg-1);
+  --panel-edge:   var(--line);
+  --panel-shadow: none;
 }
 
-/* Font swapping via [data-fonts] — keep all mapped to Archivo Narrow by default */
-html[data-fonts="geist"] { --font-sans: 'Archivo Narrow', sans-serif; --font-mono: 'Archivo Narrow', sans-serif; --font-display: 'Archivo Narrow', sans-serif; }
+/* Font swapping via [data-fonts] — v3 Lifted Dark defaults to Inter */
+html[data-fonts="geist"] { --font-sans: 'Inter', sans-serif; --font-mono: 'JetBrains Mono', monospace; --font-display: 'Inter', sans-serif; }
 
 /* ===========================================================
    Base resets
@@ -172,14 +193,67 @@ html[data-fonts="geist"] { --font-sans: 'Archivo Narrow', sans-serif; --font-mon
 * { box-sizing: border-box; }
 html, body { height: 100%; margin: 0; }
 body {
-  background: var(--bg-app);
+  background: var(--bg-0);
   color: var(--fg-0);
   font-family: var(--font-sans);
-  font-size: 13px;
+  font-size: 12px;
   line-height: 1.4;
-  letter-spacing: 0.01em;
+  letter-spacing: 0;
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   overflow: hidden;
 }
 button { font-family: inherit; color: inherit; border: 0; background: transparent; cursor: pointer; }
 input { font-family: inherit; color: inherit; }
+
+/* ===========================================================
+   Native range inputs — v3 Lifted Dark: flat blue fill, white round thumb.
+   Scoped to the app shell so panels that opt into native chrome (rare —
+   AnalogMeterConfig already has its own) can still override locally.
+   =========================================================== */
+input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  height: 4px;
+  border-radius: 4px;
+  background: var(--line);
+  outline: none;
+  cursor: pointer;
+}
+input[type="range"]::-webkit-slider-runnable-track {
+  height: 4px;
+  border-radius: 4px;
+  background: var(--line);
+}
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #ffffff;
+  border: 0;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.5), 0 1px 4px rgba(0,0,0,0.5);
+  margin-top: -5px;
+  cursor: pointer;
+}
+input[type="range"]::-moz-range-track {
+  height: 4px;
+  border-radius: 4px;
+  background: var(--line);
+  border: 0;
+}
+input[type="range"]::-moz-range-progress {
+  height: 4px;
+  border-radius: 4px;
+  background: var(--accent);
+}
+input[type="range"]::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #ffffff;
+  border: 0;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.5), 0 1px 4px rgba(0,0,0,0.5);
+  cursor: pointer;
+}

--- a/zeus-web/src/util/useEmaSmoothed.ts
+++ b/zeus-web/src/util/useEmaSmoothed.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// Exponential moving average smoother for meter readings. The wire frames
+// arrive at ~10 Hz and the render loop ticks at ~30 Hz, so a raw value
+// driven straight into a needle / bar visibly steps. A short-time-constant
+// EMA (default 90 ms) makes the visual motion fluid without lagging
+// noticeably behind voice dynamics on SSB.
+//
+// Pure ballistics: alpha = 1 - exp(-dt/tau), so a step input reaches
+//   ~63 % in 1 × tau, ~95 % in 3 × tau, ~99 % in ~4.6 × tau.
+//   tau =  90 ms  → ~270 ms to settle within 5 %.
+//   tau = 150 ms  → ~450 ms.
+// 90 ms is the sweet spot for SSB/CW: kills the 10 Hz steppiness without
+// turning the meter into a slow integrator.
+//
+// Sentinel handling — WDSP / the meter pipeline emits ≤ -200 dBFS for
+// "channel idle / bypassed". We pass that through verbatim and reset the
+// smoother so the next live sample doesn't lerp out of the sentinel; the
+// downstream widget renders an em-dash and we don't fight it.
+
+import { useRef } from 'react';
+
+const SILENT_SENTINEL = -200;
+
+interface EmaState {
+  smoothed: number;
+  ts: number; // performance.now() of last update
+}
+
+/**
+ * Smooth a scalar reading with an exponential moving average. Re-renders
+ * every time the input changes (callers control the cadence — typically
+ * a 30 Hz raf tick from useMeterRefresh).
+ *
+ * @param value  Latest sample from the store.
+ * @param tauMs  Time constant in ms. 90 ms is the meter default; set 0 to
+ *               bypass smoothing entirely.
+ */
+export function useEmaSmoothed(value: number, tauMs = 90): number {
+  const state = useRef<EmaState>({ smoothed: NaN, ts: 0 });
+
+  // Sentinel / non-finite — pass through and reset so the next live sample
+  // seeds the smoother fresh instead of lerping out of -∞.
+  if (!isFinite(value) || value <= SILENT_SENTINEL) {
+    state.current = { smoothed: value, ts: 0 };
+    return value;
+  }
+
+  // Bypass — caller asked for raw.
+  if (tauMs <= 0) {
+    state.current = { smoothed: value, ts: 0 };
+    return value;
+  }
+
+  const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+  const prev = state.current;
+
+  // First valid sample — seed the smoother so the meter doesn't visibly
+  // ramp from 0 on the first reading.
+  if (!isFinite(prev.smoothed) || prev.ts === 0) {
+    state.current = { smoothed: value, ts: now };
+    return value;
+  }
+
+  const dt = Math.max(0, now - prev.ts);
+  const alpha = 1 - Math.exp(-dt / tauMs);
+  const smoothed = prev.smoothed + (value - prev.smoothed) * alpha;
+  state.current = { smoothed, ts: now };
+  return smoothed;
+}


### PR DESCRIPTION
Release-merge gate for **v0.7.3**.

Everything on `develop` ahead of `main` flows in. After merge: tag `v0.7.3` on `main`, push, CI builds artifacts.

## What ships in 0.7.3

See [\`CHANGELOG.md\`](https://github.com/Kb2uka/openhpsdr-zeus/blob/develop/CHANGELOG.md) for the operator-readable release notes. Short list:

**Added**
- HL2 Band Volts PWM toggle for external amplifier band following (#314, EI6LF — closes #279)
- QRZ Lookup Clear button (#320, KB2UKA — closes #318)
- Meter smoothing (90 ms EMA + 1.5 s peak hold) (#328, EI6LF)
- NR1/NR2/NR4 accordion disclosure state now persists across browser reloads (#328, EI6LF)

**Fixed**
- macOS LAN cert no longer fails on non-GUI launch (CI, SSH, IDE terminals) (#323, KB2UKA)
- RX audio click at MOX edges via 5 ms fade envelope (#326, KB2UKA)

**Changed (visible)**
- v3 Lifted Dark theme — flat near-black chrome, brass instrument-plate panel headers, blue VFO aurora, deeper `#0c5f9c` accent (#327, EI6LF)
- QRZ panel portrait moved to right column, 2× size; rig/antenna/power/qsl rows dropped (#328, EI6LF)
- S-Meter config collapsed to a single Zeus-mode toggle (#328, EI6LF)

**Deliberately NOT included**
- PR #324 (Hermes-class P1 TX). Verified working on @RonnieC82's ANAN-10E but still in PA dial-in; held for 0.7.4 after one more bench round.

## Test plan

- [x] PR #329 (the release-prep) CI green on ubuntu/windows/macos/android-apk
- [ ] After merge → tag pushed → `release.yml` builds windows-installer / macOS DMG / linux AppImage + tarball / android APK → GitHub Release page auto-created

## Merge strategy

**Merge commit** (not squash) so `main`'s history preserves the develop topology and individual PR commits, matching previous release-merges.