### PR TITLE
feat(rotator): rotator compass panel + inline SP/LP in QRZ lookup

### DIFF
--- a/zeus-web/src/components/design/AzimuthMap.tsx
+++ b/zeus-web/src/components/design/AzimuthMap.tsx
@@ -42,6 +42,7 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
+import { useEffect, useRef, useState } from 'react';
 import type { Contact } from './data';
 
 type AzimuthMapProps = {
@@ -52,8 +53,26 @@ type AzimuthMapProps = {
 const RINGS_KM = [2500, 5000, 10000, 15000, 20000];
 const MAX_KM = 20000;
 const BEARING_LABELS = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
+const MIN_MAP_PX = 80;
 
 export function AzimuthMap({ myGrid = 'EM48', target }: AzimuthMapProps) {
+  const mapAreaRef = useRef<HTMLDivElement>(null);
+  const [mapSize, setMapSize] = useState(0);
+
+  useEffect(() => {
+    const el = mapAreaRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      const { width, height } = entry.contentRect;
+      setMapSize(Math.floor(Math.min(width, height)));
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const showMap = mapSize >= MIN_MAP_PX;
   const size = 280;
   const cx = size / 2;
   const cy = size / 2;
@@ -61,7 +80,14 @@ export function AzimuthMap({ myGrid = 'EM48', target }: AzimuthMapProps) {
 
   return (
     <div className="az-map">
-      <svg viewBox={`0 0 ${size} ${size}`} width="100%" height="100%" preserveAspectRatio="xMidYMid meet">
+      <div className="az-map-area" ref={mapAreaRef}>
+        {showMap && (
+          <svg
+            viewBox={`0 0 ${size} ${size}`}
+            width={mapSize}
+            height={mapSize}
+            preserveAspectRatio="xMidYMid meet"
+          >
         <defs>
           <radialGradient id="az-grad" cx="50%" cy="50%" r="50%">
             <stop offset="0%" stopColor="var(--bg-2)" stopOpacity="1" />
@@ -144,7 +170,9 @@ export function AzimuthMap({ myGrid = 'EM48', target }: AzimuthMapProps) {
             </g>
           );
         })()}
-      </svg>
+          </svg>
+        )}
+      </div>
       <div className="az-stats">
         <div>
           <span className="label-xs">Home</span>

--- a/zeus-web/src/components/design/QrzCard.tsx
+++ b/zeus-web/src/components/design/QrzCard.tsx
@@ -43,6 +43,9 @@
 // License for details.
 
 import type { Contact } from './data';
+import { bearingDeg } from './geo';
+import { useQrzStore } from '../../state/qrz-store';
+import { useRotatorStore } from '../../state/rotator-store';
 
 type QrzCardProps = {
   contact: Contact | null;
@@ -54,7 +57,15 @@ type QrzCardProps = {
   canClear?: boolean;
 };
 
+function fmtBearing(deg: number): string {
+  return `${Math.round(((deg % 360) + 360) % 360).toString().padStart(3, '0')}°`;
+}
+
 export function QrzCard({ contact, enriching, lookupError, onLogQso, canLogQso, onClear, canClear }: QrzCardProps) {
+  const qrzHome = useQrzStore((s) => s.home);
+  const rotConnected = useRotatorStore((s) => !!s.status?.connected);
+  const setRotatorAz = useRotatorStore((s) => s.setAzimuth);
+
   // Show "Not found" if there's a lookup error
   if (lookupError) {
     return (
@@ -66,8 +77,8 @@ export function QrzCard({ contact, enriching, lookupError, onLogQso, canLogQso, 
           <button
             type="button"
             onClick={onClear}
-            className="btn sm"
-            style={{ marginTop: '0.5rem', padding: '0.25rem 0.5rem', fontSize: 10 }}
+            className="rc-btn rc-btn--neutral qrz-footer-rotate-btn"
+            style={{ marginTop: '0.5rem' }}
           >
             Clear
           </button>
@@ -148,12 +159,36 @@ export function QrzCard({ contact, enriching, lookupError, onLogQso, canLogQso, 
           {contact.email}
         </span>
         <span style={{ flex: 1 }} />
+        {rotConnected && qrzHome?.lat != null && qrzHome?.lon != null
+          && contact.lat != null && contact.lon != null && (() => {
+          const sp = bearingDeg(qrzHome.lat, qrzHome.lon, contact.lat, contact.lon);
+          const lp = (sp + 180) % 360;
+          return (
+            <>
+              <button
+                type="button"
+                onClick={() => { void setRotatorAz(Math.round(sp)); }}
+                className="rc-btn rc-btn--path qrz-footer-rotate-btn"
+                title="Rotate short-path"
+              >
+                SP {fmtBearing(sp)}
+              </button>
+              <button
+                type="button"
+                onClick={() => { void setRotatorAz(Math.round(lp)); }}
+                className="rc-btn rc-btn--path qrz-footer-rotate-btn"
+                title="Rotate long-path"
+              >
+                LP {fmtBearing(lp)}
+              </button>
+            </>
+          );
+        })()}
         {onClear && canClear && (
           <button
             type="button"
             onClick={onClear}
-            className="btn sm"
-            style={{ marginRight: '0.5rem', padding: '0.25rem 0.5rem', fontSize: 10 }}
+            className="rc-btn rc-btn--neutral qrz-footer-rotate-btn"
           >
             Clear
           </button>
@@ -162,8 +197,7 @@ export function QrzCard({ contact, enriching, lookupError, onLogQso, canLogQso, 
           <button
             type="button"
             onClick={onLogQso}
-            className="btn sm"
-            style={{ marginRight: '0.5rem', padding: '0.25rem 0.5rem', fontSize: 10 }}
+            className="rc-btn rc-btn--neutral qrz-footer-rotate-btn"
           >
             Log QSO
           </button>

--- a/zeus-web/src/layout/__tests__/AddPanelModal.test.tsx
+++ b/zeus-web/src/layout/__tests__/AddPanelModal.test.tsx
@@ -55,8 +55,8 @@ describe('AddPanelModal', () => {
     const cards = container.querySelectorAll(
       '[data-testid="add-panel-cards"] .add-panel-card',
     );
-    // 18 panels in registry.
-    expect(cards.length).toBe(18);
+    // 19 panels in registry.
+    expect(cards.length).toBe(19);
     unmount();
   });
 

--- a/zeus-web/src/layout/panels.ts
+++ b/zeus-web/src/layout/panels.ts
@@ -48,6 +48,7 @@ import { VfoPanel } from './panels/VfoPanel';
 import { SMeterPanel } from './panels/SMeterPanel';
 import { QrzPanel } from './panels/QrzPanel';
 import { AzimuthPanel } from './panels/AzimuthPanel';
+import { RotatorCompassPanel } from './panels/RotatorCompassPanel';
 import { DspFlexPanel } from './panels/DspFlexPanel';
 import { CwPanel } from './panels/CwPanel';
 import { LogbookPanel } from './panels/LogbookPanel';
@@ -181,6 +182,13 @@ export const PANELS: Record<string, PanelDef> = {
     tags: ['azimuth', 'map', 'bearing', 'great-circle'],
     component: AzimuthPanel,
     maxW: 3,
+  },
+  rotatorcompass: {
+    id: 'rotatorcompass',
+    name: 'Rotator Compass',
+    category: 'tools',
+    tags: ['rotator', 'compass', 'bearing', 'heading', 'sp', 'lp', 'map'],
+    component: RotatorCompassPanel,
   },
   dsp: {
     id: 'dsp',

--- a/zeus-web/src/layout/panels/AzimuthPanel.tsx
+++ b/zeus-web/src/layout/panels/AzimuthPanel.tsx
@@ -47,10 +47,5 @@ import { useWorkspace } from '../WorkspaceContext';
 
 export function AzimuthPanel() {
   const { contact } = useWorkspace();
-
-  return (
-    <div style={{ flex: 1, overflow: 'hidden' }}>
-      <AzimuthMap target={contact} myGrid="EM48" />
-    </div>
-  );
+  return <AzimuthMap target={contact} myGrid="EM48" />;
 }

--- a/zeus-web/src/layout/panels/RotatorCompassPanel.tsx
+++ b/zeus-web/src/layout/panels/RotatorCompassPanel.tsx
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+import { useState } from 'react';
+import { LeafletWorldMap } from '../../components/design/LeafletWorldMap';
+import { LeafletMapErrorBoundary } from '../../components/design/LeafletMapErrorBoundary';
+import { bearingDeg, distanceKm } from '../../components/design/geo';
+import { useQrzStore } from '../../state/qrz-store';
+import { useRotatorStore } from '../../state/rotator-store';
+
+function normalizeAz(deg: number | null | undefined): number | null {
+  if (deg == null || !Number.isFinite(deg)) return null;
+  return ((deg % 360) + 360) % 360;
+}
+
+function fmtAz(deg: number | null): string {
+  if (deg == null) return '---°';
+  return `${deg.toFixed(0).padStart(3, '0')}°`;
+}
+
+export function RotatorCompassPanel() {
+  const home = useQrzStore((s) => s.home);
+  const target = useQrzStore((s) => s.lastLookup);
+  const rotConnected = useRotatorStore((s) => !!s.status?.connected);
+  const rotEnabled = useRotatorStore((s) => s.config.enabled);
+  const rotMoving = useRotatorStore((s) => !!s.status?.moving);
+  const rotCurrentAz = useRotatorStore((s) => normalizeAz(s.status?.currentAz));
+  const setAzimuth = useRotatorStore((s) => s.setAzimuth);
+  const stopRotator = useRotatorStore((s) => s.stop);
+
+  const hasHome = !!(home && home.lat != null && home.lon != null);
+  const hasTarget = hasHome && !!(target && target.lat != null && target.lon != null);
+
+  const spBearing = hasTarget
+    ? bearingDeg(home!.lat as number, home!.lon as number, target!.lat as number, target!.lon as number)
+    : null;
+  const lpBearing = spBearing == null ? null : (spBearing + 180) % 360;
+  const dist = hasTarget
+    ? distanceKm(home!.lat as number, home!.lon as number, target!.lat as number, target!.lon as number)
+    : null;
+
+  const [path, setPath] = useState<'sp' | 'lp'>('sp');
+  const [manualInput, setManualInput] = useState('');
+
+  const rotReady = rotEnabled && rotConnected;
+  const manualHeadingDeg = (() => {
+    const n = Number.parseFloat(manualInput);
+    if (!Number.isFinite(n)) return null;
+    return ((n % 360) + 360) % 360;
+  })();
+  const manualHeadingValid = manualHeadingDeg != null && manualInput.trim() !== '';
+  const submitManualHeading = () => {
+    if (!rotReady || manualHeadingDeg == null) return;
+    void setAzimuth(Math.round(manualHeadingDeg));
+  };
+
+  const targetVisibleAz = path === 'lp' ? lpBearing : spBearing;
+  const beamForMap = rotConnected && rotCurrentAz != null
+    ? rotCurrentAz
+    : targetVisibleAz ?? undefined;
+
+  return (
+    <div className="rotator-compass">
+      <div className="rc-map">
+        <LeafletMapErrorBoundary onError={() => { /* silent */ }} fallback={null}>
+          {hasHome && (
+            <LeafletWorldMap
+              home={{
+                call: home!.callsign,
+                lat: home!.lat as number,
+                lon: home!.lon as number,
+                grid: home!.grid,
+                imageUrl: home!.imageUrl,
+              }}
+              target={
+                hasTarget
+                  ? {
+                      call: target!.callsign,
+                      lat: target!.lat as number,
+                      lon: target!.lon as number,
+                      grid: target!.grid,
+                      imageUrl: target!.imageUrl,
+                    }
+                  : null
+              }
+              beamBearing={beamForMap}
+              beamRangeKm={6000}
+              beamHalfWidthDeg={10}
+              active={true}
+              interactive={false}
+              onRotateToBearing={(deg) => { void setAzimuth(Math.round(deg)); }}
+            />
+          )}
+        </LeafletMapErrorBoundary>
+        {!hasHome && (
+          <div className="rc-empty">
+            <span className="label-xs">No QRZ home location</span>
+            <span className="rc-empty-hint">Log in via the QRZ panel to enable the map.</span>
+          </div>
+        )}
+      </div>
+
+      <div className="rc-overlay">
+        <div className="rc-now-badge">
+          <span className="label-xs">NOW</span>
+          <span className="mono">{fmtAz(rotCurrentAz)}</span>
+          {rotMoving && targetVisibleAz != null && (
+            <span className="rc-arrow">→ {fmtAz(targetVisibleAz)}</span>
+          )}
+        </div>
+
+        <div className="rc-controls">
+          {hasTarget && dist != null && (
+            <div className="rc-badge rc-badge--right">
+              <span className="label-xs">DIST</span>
+              <span className="mono">{Math.round(dist).toLocaleString()} km</span>
+            </div>
+          )}
+          <div className="rc-sp-lp">
+            <button
+              type="button"
+              className={`rc-btn rc-btn--path${path === 'sp' ? ' selected' : ''}`}
+              onClick={() => {
+                setPath('sp');
+                if (spBearing != null) void setAzimuth(Math.round(spBearing));
+              }}
+              disabled={!hasTarget || !rotReady}
+              title={hasTarget ? 'Rotate short-path' : 'Look up a QRZ callsign for SP / LP'}
+            >
+              SP {fmtAz(spBearing)}
+            </button>
+            <button
+              type="button"
+              className={`rc-btn rc-btn--path${path === 'lp' ? ' selected' : ''}`}
+              onClick={() => {
+                setPath('lp');
+                if (lpBearing != null) void setAzimuth(Math.round(lpBearing));
+              }}
+              disabled={!hasTarget || !rotReady}
+              title={hasTarget ? 'Rotate long-path' : 'Look up a QRZ callsign for SP / LP'}
+            >
+              LP {fmtAz(lpBearing)}
+            </button>
+          </div>
+          <form
+            className="rc-manual"
+            onSubmit={(e) => {
+              e.preventDefault();
+              submitManualHeading();
+            }}
+          >
+            <input
+              type="number"
+              inputMode="numeric"
+              min={0}
+              max={359}
+              step={1}
+              className="rc-input"
+              placeholder="HDG"
+              value={manualInput}
+              onChange={(e) => setManualInput(e.currentTarget.value)}
+              aria-label="Heading in degrees"
+            />
+            <button
+              type="submit"
+              className="rc-btn rc-btn--go"
+              disabled={!rotReady || !manualHeadingValid}
+              title={rotReady ? 'Rotate to entered heading' : 'Rotator not connected'}
+            >
+              GO
+            </button>
+          </form>
+          <button
+            type="button"
+            className="rc-btn rc-btn--stop"
+            onClick={() => { void stopRotator(); }}
+            disabled={!rotReady || !rotMoving}
+            title={rotMoving ? 'Stop rotator' : 'Rotator is idle'}
+          >
+            STOP
+          </button>
+          {!rotEnabled && <span className="rc-hint">Rotator disabled</span>}
+          {rotEnabled && !rotConnected && <span className="rc-hint">Connecting…</span>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -1331,6 +1331,180 @@
 .az-map { position: absolute; inset: 0; display: flex; flex-direction: column; padding: 6px; background: var(--bg-1); overflow: hidden; box-sizing: border-box; }
 .az-map-area { flex: 1; min-height: 0; min-width: 0; display: flex; align-items: center; justify-content: center; overflow: hidden; }
 .az-map-area svg { display: block; }
+
+/* ===== Rotator Compass — leaflet backdrop + SVG compass overlay ===== */
+.rotator-compass { position: absolute; inset: 0; background: var(--bg-1); overflow: hidden; }
+/* z-index: 0 + isolation contains leaflet's internal pane z-indexes (200–700)
+ * so they can't escape the map layer and paint over our overlay. */
+.rotator-compass .rc-map { position: absolute; inset: 0; z-index: 0; isolation: isolate; }
+.rotator-compass .rc-map .leaflet-world-map { position: absolute; inset: 0; width: 100%; height: 100%; }
+.rotator-compass .rc-map .leaflet-world-map .leaflet-host { position: absolute; inset: 0; width: 100%; height: 100%; }
+.rotator-compass .rc-map .leaflet-world-map .leaflet-container { width: 100%; height: 100%; background: #030812; font: inherit; }
+.rotator-compass .rc-empty {
+  position: absolute; inset: 0; display: flex; flex-direction: column;
+  align-items: center; justify-content: center; gap: 4px; color: var(--fg-2);
+  background: linear-gradient(180deg, var(--bg-2), var(--bg-1));
+  text-align: center; padding: 0 16px;
+}
+.rotator-compass .rc-empty-hint { font-size: 11px; color: var(--fg-3); }
+
+.rotator-compass .rc-overlay {
+  position: absolute; inset: 0; z-index: 1; pointer-events: none;
+}
+.rotator-compass .rc-now-badge {
+  position: absolute; top: 8px; left: 8px;
+  display: inline-flex; align-items: center; gap: 6px; padding: 3px 8px;
+  background: linear-gradient(180deg, #1c1c21 0%, #0e0e12 100%);
+  border: 1px solid rgba(255, 201, 58, 0.45);
+  border-radius: 3px;
+  font-family: var(--font-mono); font-size: 12px; color: #ffd66b;
+  text-shadow: 0 0 6px rgba(255, 201, 58, 0.22);
+  pointer-events: none;
+  box-shadow: inset 0 1px 0 rgba(255, 201, 58, 0.08), 0 1px 4px rgba(0,0,0,0.55);
+}
+.rotator-compass .rc-now-badge .label-xs { color: rgba(255, 201, 58, 0.65); font-size: 9px; letter-spacing: 0.12em; }
+.rotator-compass .rc-now-badge .mono { font-weight: 700; color: #ffe28a; }
+.rotator-compass .rc-now-badge .rc-arrow { color: var(--power); font-weight: 700; text-shadow: 0 0 8px rgba(255, 201, 58, 0.45); }
+
+.rotator-compass .rc-controls {
+  position: absolute; top: 8px; right: 8px;
+  display: flex; flex-direction: column; align-items: stretch; gap: 6px;
+  pointer-events: auto; min-width: 150px;
+}
+.rotator-compass .rc-sp-lp { display: flex; gap: 4px; }
+.rotator-compass .rc-sp-lp > .rc-btn { flex: 1; min-width: 0; }
+
+.rotator-compass .rc-badge {
+  display: inline-flex; align-items: center; justify-content: space-between; gap: 6px;
+  padding: 3px 8px;
+  background: linear-gradient(180deg, #1c1c21 0%, #0e0e12 100%);
+  border: 1px solid rgba(255, 201, 58, 0.45);
+  border-radius: 3px;
+  font-family: var(--font-mono); font-size: 12px; color: #ffd66b;
+  text-shadow: 0 0 6px rgba(255, 201, 58, 0.25);
+  pointer-events: none;
+  box-shadow: inset 0 1px 0 rgba(255, 201, 58, 0.08), 0 1px 4px rgba(0,0,0,0.5);
+}
+.rotator-compass .rc-badge .label-xs { color: rgba(255, 201, 58, 0.65); font-size: 9px; letter-spacing: 0.12em; }
+.rotator-compass .rc-badge .mono { font-weight: 700; color: #ffe28a; }
+
+.rotator-compass .rc-hint {
+  color: rgba(255, 201, 58, 0.6); font-size: 11px; font-family: var(--font-mono);
+  padding: 4px 8px; background: rgba(14, 14, 18, 0.85);
+  border: 1px solid rgba(255, 201, 58, 0.18);
+  border-radius: 3px; text-align: center; letter-spacing: 0.06em;
+}
+/* Brass-instrument-plate aesthetic — near-black ground, gold engraving.
+ * Matches .workspace-tile-header so the controls read like another row
+ * of the same equipment plate. */
+.rc-btn {
+  font-family: var(--font-mono); font-size: 11px; font-weight: 700;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  padding: 6px 10px; border-radius: 3px;
+  background: linear-gradient(180deg, #1c1c21 0%, #0e0e12 100%);
+  border: 1px solid rgba(255, 201, 58, 0.45);
+  color: #ffd66b;
+  text-shadow: 0 0 6px rgba(255, 201, 58, 0.22);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 201, 58, 0.10),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.55),
+    0 1px 4px rgba(0, 0, 0, 0.55);
+  cursor: pointer;
+  transition: filter 90ms ease, border-color 90ms ease, background 90ms ease;
+}
+.rc-btn:hover {
+  border-color: rgba(255, 201, 58, 0.75);
+  filter: brightness(1.18);
+}
+.rc-btn:disabled {
+  opacity: 0.4; cursor: not-allowed;
+  color: rgba(255, 201, 58, 0.5);
+  border-color: rgba(255, 201, 58, 0.2);
+  text-shadow: none;
+}
+
+/* SP / LP — selected state lights the gold rail. */
+.rc-btn--path.selected {
+  background: linear-gradient(180deg, #2a2410 0%, #150f04 100%);
+  border-color: var(--power);
+  color: #fff1b8;
+  text-shadow: 0 0 8px rgba(255, 201, 58, 0.55);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 201, 58, 0.25),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.55),
+    0 0 10px rgba(255, 201, 58, 0.25);
+}
+
+/* GO — primary action gets the lit-rail treatment by default. */
+.rc-btn--go {
+  background: linear-gradient(180deg, #2a2410 0%, #150f04 100%);
+  border-color: var(--power); color: #fff1b8;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 201, 58, 0.25),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.55),
+    0 0 8px rgba(255, 201, 58, 0.25);
+}
+.rc-btn--go:disabled {
+  background: linear-gradient(180deg, #1c1c21 0%, #0e0e12 100%);
+  box-shadow: none;
+}
+
+/* Neutral white-outline variant — same brass plate body, but the rail
+ * and engraving stay white instead of gold. Used for "supporting" actions
+ * (Clear, Log QSO) that sit beside the gold primary actions (SP / LP / GO). */
+.rc-btn--neutral {
+  border-color: rgba(255, 255, 255, 0.45);
+  color: #f0f3f8;
+  text-shadow: 0 0 6px rgba(255, 255, 255, 0.18);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.10),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.55),
+    0 1px 4px rgba(0, 0, 0, 0.55);
+}
+.rc-btn--neutral:hover {
+  border-color: rgba(255, 255, 255, 0.75);
+  filter: brightness(1.18);
+}
+.rc-btn--neutral:disabled {
+  color: rgba(255, 255, 255, 0.5);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+/* STOP — same plate, but warns red on hover/active. */
+.rc-btn--stop { letter-spacing: 0.18em; }
+.rc-btn--stop:not(:disabled) {
+  border-color: rgba(230, 58, 43, 0.6); color: #ffb3a8;
+  text-shadow: 0 0 6px rgba(230, 58, 43, 0.4);
+}
+.rc-btn--stop:not(:disabled):hover {
+  background: linear-gradient(180deg, #2a1410 0%, #15080a 100%);
+  border-color: var(--tx); color: #ffe0d8;
+}
+
+.rotator-compass .rc-manual { display: flex; align-items: stretch; gap: 4px; }
+.rotator-compass .rc-input {
+  flex: 1; min-width: 0; padding: 5px 6px; border-radius: 3px;
+  border: 1px solid rgba(255, 201, 58, 0.45);
+  background: linear-gradient(180deg, #0e0e12 0%, #1c1c21 100%);
+  color: #ffe28a;
+  font-family: var(--font-mono); font-size: 12px; font-weight: 700;
+  text-align: center; letter-spacing: 0.05em;
+  box-shadow:
+    inset 0 1px 2px rgba(0, 0, 0, 0.6),
+    inset 0 -1px 0 rgba(255, 201, 58, 0.06);
+}
+.rotator-compass .rc-input::placeholder { color: rgba(255, 201, 58, 0.45); }
+.rotator-compass .rc-input:focus {
+  outline: none; border-color: var(--power);
+  box-shadow:
+    inset 0 1px 2px rgba(0, 0, 0, 0.6),
+    0 0 0 1px var(--power),
+    0 0 8px rgba(255, 201, 58, 0.35);
+}
+/* Hide the spin buttons — they take up too much room next to the GO button. */
+.rotator-compass .rc-input::-webkit-outer-spin-button,
+.rotator-compass .rc-input::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
+.rotator-compass .rc-input { -moz-appearance: textfield; }
 .az-stats {
   display: flex;
   justify-content: space-between;
@@ -1370,6 +1544,13 @@
 .qrz-footer {
   display: flex; align-items: center; padding-top: 6px; margin-top: 2px;
   border-top: 1px solid rgba(74,158,255,0.2);
+}
+/* SP / LP rotator buttons inline in the QRZ footer — only rendered when a
+ * rotator is connected and both home + contact have coordinates. Sized to
+ * match the existing Clear / Log QSO 10px footer buttons so the row stays
+ * flush. */
+.qrz-footer-rotate-btn {
+  padding: 3px 6px; font-size: 10px; margin-right: 0.5rem;
 }
 .qrz-portrait {
   flex-shrink: 0;

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -1328,8 +1328,9 @@
 .smeter-val .unit { font-size: 11px; color: var(--fg-2); }
 
 /* ===== Azimuth Map ===== */
-.az-map { width: 100%; height: 100%; display: flex; flex-direction: column; padding: 6px; background: var(--bg-1); }
-.az-map svg { flex: 1; min-height: 0; aspect-ratio: 1 / 1; object-fit: contain; max-width: 100%; max-height: 100%; }
+.az-map { position: absolute; inset: 0; display: flex; flex-direction: column; padding: 6px; background: var(--bg-1); overflow: hidden; box-sizing: border-box; }
+.az-map-area { flex: 1; min-height: 0; min-width: 0; display: flex; align-items: center; justify-content: center; overflow: hidden; }
+.az-map-area svg { display: block; }
 .az-stats {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary

- **New "Rotator Compass" panel** (category: Tools) — full-bleed Esri satellite Leaflet map with the operator's QRZ home + lookup target, the great-circle arc, and the existing beam-wedge overlay. A right-rail column carries a `DIST` badge, side-by-side `SP NNN°` / `LP NNN°` buttons, a numeric `HDG` input + `GO`, and `STOP`. A `NOW NNN° → tgt` chip sits top-left and tracks live rotator status.
- **Inline `SP` / `LP` rotation in the QRZ Lookup footer** — appears alongside Clear / Log QSO **only when rotctld is connected** and both home + contact have lat/lon, so a one-click slew is reachable straight from the lookup card.
- **Shared brass-instrument-plate button family** (`.rc-btn` + `--path` / `--go` / `--stop` / `--neutral`) — gold-on-black for primary rotate actions, white-on-black for supporting Clear / Log QSO actions, on the same near-black plate as the tile header rail. Clear / Log QSO are upgraded from the unstyled `.btn sm` to the outlined neutral variant so the QRZ footer reads as one consistent row.

## Test plan

- [ ] Add the new **Rotator Compass** tile from the workspace's "+ Add Panel" → Tools list — confirm the map, great-circle arc, beam wedge, and badge / button column all render.
- [ ] Rotate via `SP`, `LP`, `HDG` + `GO`, and the marker popup's `Rotate to NNN°` — confirm the rotator status reflects each command and `STOP` halts movement.
- [ ] Look up a callsign in **QRZ Lookup**; with `rotctld` enabled + connected, confirm `SP` and `LP` buttons appear in the footer next to Clear / Log QSO and slew correctly. Disable rotctld and confirm the row collapses to just Clear / Log QSO.
- [ ] Resize the Rotator Compass tile small enough that the controls would overflow — confirm the right-rail column stays visible and the map continues to render.
- [ ] `dotnet build Zeus.slnx` and `npm --prefix zeus-web run test` both green (208/208 vitest, 0 warnings dotnet).