### PR TITLE
ci(triage): cut over issue triage from zeus-agent to kb2uka-agent

### DIFF
--- a/.github/workflows/kb2uka-triage.yml
+++ b/.github/workflows/kb2uka-triage.yml
@@ -1,4 +1,15 @@
-name: Zeus-Agent — Issue Triage
+name: KB2UKA-Agent — Issue Triage
+
+# Automated triage on newly-opened issues. Runs as KB2UKA-Agent (App ID
+# 3702876), distinct from kb2uka-agent.yml (which is the mention-based
+# coding bot). Replaces the previous zeus-agent.yml that ran under
+# Brian's Zeus-Agent App — that App is not installed on this repo
+# post-transfer, so it was failing on every issue event.
+#
+# Secrets required (set via `gh secret set`):
+#   - KB2UKA_AGENT_APP_ID      — GitHub App ID (3702876)
+#   - KB2UKA_AGENT_PRIVATE_KEY — Contents of the App's .pem private key
+#   - KB2UKA_OAUTH_TOKEN       — Anthropic Claude Code OAuth token
 
 on:
   issues:
@@ -6,7 +17,7 @@ on:
 
 jobs:
   triage:
-    name: Zeus-Agent
+    name: KB2UKA-Triage
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -14,28 +25,29 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Mint Zeus-Agent App token
+      - name: Mint KB2UKA-Agent App token
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.ZEUS_AGENT_APP_ID }}
-          private-key: ${{ secrets.ZEUS_AGENT_PRIVATE_KEY }}
+          app-id: ${{ secrets.KB2UKA_AGENT_APP_ID }}
+          private-key: ${{ secrets.KB2UKA_AGENT_PRIVATE_KEY }}
 
-      - name: Run Zeus-Agent
+      - name: Run KB2UKA-Agent triage
         uses: anthropics/claude-code-base-action@v0.0.63
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.KB2UKA_OAUTH_TOKEN }}
           allowed_tools: "Bash(gh label list),Bash(gh label list:*),Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh issue comment:*),Bash(gh search:*),Read,Glob,Grep"
           max_turns: "15"
           model: "claude-sonnet-4-6"
           prompt: |
-            You are **Zeus-Agent** 📡, the automated triage assistant for Zeus
+            You are **KB2UKA-Agent** 🛠, the automated triage assistant for Zeus
             (a cross-platform, web-frontend HPSDR client for original-protocol
-            radios — .NET 8 backend, Vite + React frontend, WDSP native DSP
-            engine via P/Invoke). Thetis is the sole authoritative upstream
-            reference.
+            and Protocol-2 radios — .NET 8 backend, Vite + React frontend, WDSP
+            native DSP engine via P/Invoke). Thetis is the sole authoritative
+            upstream reference; see CLAUDE.md for the red-light / green-light
+            rules.
 
             Issue #${{ github.event.issue.number }} was just opened:
             Title: ${{ github.event.issue.title }}
@@ -53,10 +65,11 @@ jobs:
             3. Post exactly ONE comment on the issue with:
                  - a 1–2 sentence summary of what's being reported,
                  - which area of the codebase it likely touches
-                   (Zeus.Server / Zeus.Dsp / Zeus.Protocol1 / Zeus.Contracts /
-                    zeus-web / WDSP-native / TX pipeline / rotctld / QRZ),
+                   (Zeus.Server / Zeus.Dsp / Zeus.Protocol1 / Zeus.Protocol2 /
+                    Zeus.Contracts / zeus-web / WDSP-native / TX pipeline /
+                    rotctld / QRZ),
                  - any clarifying questions the reporter should answer,
-                 - a sign-off line: "— Zeus-Agent 📡".
+                 - a sign-off line: "— KB2UKA-Agent 🛠".
 
             Rules:
             - Be concise. Prefer understatement. No "Great question!" openings.


### PR DESCRIPTION
## Summary

- Brian's Zeus-Agent GitHub App is not installed on `Kb2uka/openhpsdr-zeus` post-repo-transfer (2026-05-13), so every `issues:opened` event has been failing the "Mint Zeus-Agent App token" step with HTTP 404.
- Renames `.github/workflows/zeus-agent.yml` → `.github/workflows/kb2uka-triage.yml`, swaps to **KB2UKA-Agent** App credentials (App ID 3702876, secrets `KB2UKA_AGENT_APP_ID` / `KB2UKA_AGENT_PRIVATE_KEY` / `KB2UKA_OAUTH_TOKEN` — all already set on the repo since 2026-05-13).
- Rebrands persona + sign-off to "**KB2UKA-Agent** 🛠" and adds `Zeus.Protocol2` to the codebase-area hint list in the triage prompt.

Distinct from `kb2uka-agent.yml`, which is the mention-based coding bot gated on `@kb2uka-agent`. Both workflows now run under the same GitHub App identity but serve different roles:
- `kb2uka-agent.yml` — mention-based coding/Q&A bot (`@kb2uka-agent` in body/comment)
- `kb2uka-triage.yml` — auto-triage on every newly-opened issue (no mention needed)

## Reference

Most recent failure: https://github.com/Kb2uka/openhpsdr-zeus/actions/runs/25922154990

## Test plan

- [ ] PR merges to `main` (workflow files only run from default branch for `issues:` events, so this must land on `main` to take effect)
- [ ] Next opened issue triggers the new workflow successfully — App-token step succeeds, triage comment lands signed "— KB2UKA-Agent 🛠", appropriate labels applied
- [ ] No "Zeus-Agent" workflow runs appear in the Actions tab going forward