### PR TITLE
feat(radio): per-radio frequency calibration with WWV auto-cal (#325)

### DIFF
--- a/Zeus.Protocol1/Protocol1Client.cs
+++ b/Zeus.Protocol1/Protocol1Client.cs
@@ -76,6 +76,12 @@ public sealed class Protocol1Client : IProtocol1Client
     // Mutation state written from any thread, read from the TX thread.
     // 64-bit fields are written atomically on 64-bit .NET (Interlocked.Exchange used for safety).
     private long _vfoAHz = 7_100_000;
+    // Frequency-correction factor (issue #325) — dimensionless multiplier
+    // near 1.0 applied to the incoming dial Hz before _vfoAHz is updated,
+    // matching piHPSDR / Thetis. Stored as int64 bits for atomic
+    // Interlocked.Exchange access from arbitrary threads. 1.0 = factory
+    // default (no correction).
+    private long _freqCorrectionBits = BitConverter.DoubleToInt64Bits(1.0);
     private int _rate = (int)HpsdrSampleRate.Rate48k;
     private int _preamp;       // 0 / 1
     private int _attenDb;      // 0..31 dB (HpsdrAtten value)
@@ -505,7 +511,29 @@ public sealed class Protocol1Client : IProtocol1Client
         return Task.CompletedTask;
     }
 
-    public void SetVfoAHz(long hz) => Interlocked.Exchange(ref _vfoAHz, hz);
+    public void SetVfoAHz(long hz)
+    {
+        double factor = BitConverter.Int64BitsToDouble(Interlocked.Read(ref _freqCorrectionBits));
+        // host-side multiplicative correction, applied right before the
+        // wire-bound _vfoAHz slot (matches piHPSDR src/old_protocol.c:1040,
+        // Thetis NetworkIO.VFOfreq, deskHPSDR src/old_protocol.c:1629).
+        long corrected = (long)Math.Round(hz * factor, MidpointRounding.AwayFromZero);
+        Interlocked.Exchange(ref _vfoAHz, corrected);
+    }
+
+    /// <summary>
+    /// Sets the per-radio frequency-correction factor (issue #325). The
+    /// caller is responsible for re-pushing the current dial Hz via
+    /// <see cref="SetVfoAHz"/> after this so the new factor reaches the
+    /// wire — this method on its own only mutates the multiplier used by
+    /// the next tune-write.
+    /// </summary>
+    public void SetFrequencyCorrectionFactor(double factor) =>
+        Interlocked.Exchange(ref _freqCorrectionBits, BitConverter.DoubleToInt64Bits(factor));
+
+    public double FrequencyCorrectionFactor =>
+        BitConverter.Int64BitsToDouble(Interlocked.Read(ref _freqCorrectionBits));
+
     public void SetSampleRate(HpsdrSampleRate rate) => Interlocked.Exchange(ref _rate, (int)rate);
     public void SetPreamp(bool on) => Interlocked.Exchange(ref _preamp, on ? 1 : 0);
     public void SetAttenuator(HpsdrAtten atten) => Interlocked.Exchange(ref _attenDb, atten.ClampedDb);

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -108,6 +108,12 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     private Task? _keepaliveTask;
     private int _sampleRateKhz = 48;
     private uint _rxFreqHz = 14_200_000;
+    // Frequency-correction factor (issue #325) — dimensionless multiplier
+    // near 1.0 applied to the incoming dial Hz before _rxFreqHz is updated,
+    // matching piHPSDR / Thetis. Stored as int64 bits for atomic
+    // Interlocked.Exchange access from arbitrary threads. 1.0 = factory
+    // default (no correction).
+    private long _freqCorrectionBits = BitConverter.DoubleToInt64Bits(1.0);
     private byte _numAdc = 2;
     // Connected board kind, plumbed from RadioService's ConnectedBoardKind via
     // DspPipelineService at connect time. Used by HandleDdcPacket for the
@@ -350,12 +356,40 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
 
     public void SetVfoAHz(long hz)
     {
-        _rxFreqHz = (uint)Math.Clamp(hz, 0L, uint.MaxValue);
+        double factor = BitConverter.Int64BitsToDouble(Interlocked.Read(ref _freqCorrectionBits));
+        // Host-side multiplicative correction, applied right before the
+        // phase-word feed slot (matches piHPSDR src/new_protocol.c:765,824,
+        // Thetis NetworkIO.VFOfreq, deskHPSDR src/new_protocol.c:909,967).
+        // _rxFreqHz then feeds the NCO phase-word at line 951
+        // (`rxPhase = _rxFreqHz * HzToPhase`).
+        long corrected = (long)Math.Round(hz * factor, MidpointRounding.AwayFromZero);
+        _rxFreqHz = (uint)Math.Clamp(corrected, 0L, uint.MaxValue);
         var running = _rxTask is not null;
         _log.LogInformation("p2.tune hz={Hz} running={Running} hpSeq={Seq}",
             _rxFreqHz, running, _seqCmdHp);
         if (running) SendCmdHighPriority(run: true);
     }
+
+    /// <summary>
+    /// Sets the per-radio frequency-correction factor (issue #325). The
+    /// caller is responsible for re-pushing the current dial Hz via
+    /// <see cref="SetVfoAHz"/> after this so the new factor reaches the
+    /// wire — this method on its own only mutates the multiplier used by
+    /// the next tune-write.
+    /// </summary>
+    public void SetFrequencyCorrectionFactor(double factor) =>
+        Interlocked.Exchange(ref _freqCorrectionBits, BitConverter.DoubleToInt64Bits(factor));
+
+    public double FrequencyCorrectionFactor =>
+        BitConverter.Int64BitsToDouble(Interlocked.Read(ref _freqCorrectionBits));
+
+    /// <summary>
+    /// Test seam (issue #325): the corrected NCO frequency that would be
+    /// written to the wire on the next CmdHighPriority. Equals the last
+    /// <see cref="SetVfoAHz"/> argument multiplied by
+    /// <see cref="FrequencyCorrectionFactor"/>.
+    /// </summary>
+    internal uint CorrectedRxFreqHzForTesting => _rxFreqHz;
 
     public void SetSampleRateKhz(int rateKhz)
     {

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -252,6 +252,17 @@ public class DspPipelineService : BackgroundService,
     private readonly float[] _wfBuf = new float[Width];
     private readonly float[] _audioBuf = new float[AudioDrainCapacity];
 
+    // Cached panadapter snapshot for the frequency-calibration service
+    // (issue #325). Tick fills this every cycle that produced a valid
+    // pan frame; the cal service reads it without racing for the WDSP
+    // "fresh frame" flag. Single-writer (Tick) + occasional reader
+    // (cal) — protected by _calPanLock.
+    private readonly float[] _calPanSnapshot = new float[Width];
+    private float _calPanHzPerPixel;
+    private long _calPanCenterHz;
+    private long _calPanSnapshotMs;
+    private readonly object _calPanLock = new();
+
     public DspPipelineService(RadioService radio, StreamingHub hub, ILoggerFactory loggerFactory)
     {
         _radio = radio;
@@ -1091,39 +1102,40 @@ public class DspPipelineService : BackgroundService,
     public static int PanadapterWidth => Width;
 
     /// <summary>
-    /// Captures the latest panadapter pixel column (dB values) for spectrum
-    /// peak detection (issue #325 auto-cal). Pixels are written in display
-    /// order (low frequency left, high frequency right), matching what the
-    /// operator sees in the browser. Returns <c>false</c> when no engine /
-    /// channel is open yet, or when WDSP hasn't produced a fresh frame since
-    /// the last call.
+    /// Reads the latest cached panadapter snapshot (dB values, display
+    /// order — low frequency left). Caches are filled by <see cref="Tick"/>
+    /// at 30 Hz; the frequency-calibration service (issue #325) reads from
+    /// here to avoid racing for WDSP's once-per-frame "fresh data" flag,
+    /// which Tick is also consuming and would always win.
     /// </summary>
     /// <param name="dest">Buffer of length <see cref="PanadapterWidth"/>.</param>
     /// <param name="hzPerPixel">Hz spacing between adjacent pixels (out).</param>
     /// <param name="centerHz">Frequency of the centre pixel — the radio's LO
     /// (out). In CW modes this is dial ± cw_pitch; outside CW it equals dial.</param>
-    public bool TryCapturePanadapterSnapshot(Span<float> dest, out float hzPerPixel, out long centerHz)
+    /// <param name="maxAgeMs">Reject the cached snapshot if it is older than
+    /// this many milliseconds. Default 200 ms — six analyzer frames at 30 Hz,
+    /// generous tolerance for a one-off cal measurement without risking
+    /// pre-tune stale data.</param>
+    public bool TryCapturePanadapterSnapshot(
+        Span<float> dest,
+        out float hzPerPixel,
+        out long centerHz,
+        long maxAgeMs = 200)
     {
         hzPerPixel = 0;
         centerHz = 0;
         if (dest.Length != Width) return false;
 
-        var engine = Volatile.Read(ref _engine);
-        int channel = Volatile.Read(ref _channelId);
-        int sampleRate = Volatile.Read(ref _sampleRateHz);
-        if (engine is null || sampleRate <= 0) return false;
+        lock (_calPanLock)
+        {
+            if (_calPanSnapshotMs == 0) return false;
+            long ageMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - _calPanSnapshotMs;
+            if (ageMs > maxAgeMs) return false;
 
-        if (!engine.TryGetDisplayPixels(channel, DisplayPixout.Panadapter, dest))
-            return false;
-
-        // Display order (low-freq-left). WDSP emits pixel-0 = highest positive
-        // frequency, so flip here for consistency with the operator view.
-        dest.Reverse();
-
-        var state = _radio.Snapshot();
-        int zoom = Math.Max(1, state.ZoomLevel);
-        hzPerPixel = (float)((double)sampleRate / zoom / Width);
-        centerHz = CwOffset.EffectiveLoHz(state);
+            _calPanSnapshot.AsSpan().CopyTo(dest);
+            hzPerPixel = _calPanHzPerPixel;
+            centerHz = _calPanCenterHz;
+        }
         return true;
     }
 
@@ -1441,6 +1453,24 @@ public class DspPipelineService : BackgroundService,
             // extra contract field needed, per task #7 scope note.
             int zoomLevel = Math.Max(1, state.ZoomLevel);
             float hzPerPixel = (float)((double)sampleRate / zoomLevel / Width);
+            long centerHz = CwOffset.EffectiveLoHz(state);
+
+            // Cache for the frequency-calibration service (issue #325). The
+            // cal reads from this cache to avoid racing for WDSP's "fresh
+            // frame" flag — Tick consumes that flag at 30 Hz, leaving no
+            // window for a parallel consumer. Cache only when we actually
+            // got pan data this tick.
+            if (pan)
+            {
+                lock (_calPanLock)
+                {
+                    Array.Copy(panBuf, _calPanSnapshot, Width);
+                    _calPanHzPerPixel = hzPerPixel;
+                    _calPanCenterHz = centerHz;
+                    _calPanSnapshotMs = (long)nowMs;
+                }
+            }
+
             var frame = new DisplayFrame(
                 Seq: ++_seq,
                 TsUnixMs: nowMs,
@@ -1451,7 +1481,7 @@ public class DspPipelineService : BackgroundService,
                 // VfoHz outside CW and VfoHz ∓ cw_pitch in CWU/CWL. The CW filter
                 // (audio passband centred on cw_pitch) then renders on top of
                 // the dial line via PassbandOverlay's `centerHz + filterLow..high`.
-                CenterHz: CwOffset.EffectiveLoHz(state),
+                CenterHz: centerHz,
                 HzPerPixel: hzPerPixel,
                 PanDb: panBuf,
                 WfDb: wfBuf);

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -270,6 +270,10 @@ public class DspPipelineService : BackgroundService,
         _radio.MoxChanged += OnRadioMoxChanged;
         _radio.TunActiveChanged += OnRadioTunActiveChanged;
         _radio.PreampChanged += OnRadioPreampChanged;
+        // Frequency-correction factor (issue #325) — RadioService can't
+        // push to the P2 client directly (ActiveClient is P1-only), so we
+        // listen for changes here and forward them to the live P2 client.
+        _radio.FrequencyCorrectionFactorChanged += OnFrequencyCorrectionFactorChanged;
         // Wire up Auto-AGC: feed RX meter readings to RadioService control loop
         RxMeterUpdated += (channelId, dbm) => _radio.HandleRxMeterForAutoAgc(dbm, Environment.TickCount64);
 
@@ -304,6 +308,7 @@ public class DspPipelineService : BackgroundService,
             _radio.MoxChanged -= OnRadioMoxChanged;
             _radio.TunActiveChanged -= OnRadioTunActiveChanged;
             _radio.PreampChanged -= OnRadioPreampChanged;
+            _radio.FrequencyCorrectionFactorChanged -= OnFrequencyCorrectionFactorChanged;
             // iter5: no more pump tasks to stop — the sink path runs on the
             // protocol client's RX thread, which the protocol client tears
             // down via its own StopAsync. Detach defensively in case a
@@ -857,6 +862,10 @@ public class DspPipelineService : BackgroundService,
         int initialAttDb = _radio.EffectiveAttenDb;
         client.SetPreamp(initialPreamp);
         client.SetAttenuator(initialAttDb);
+        // Frequency-correction factor (issue #325) — rehydrate before the
+        // first CmdHighPriority(run=1) so the operator's calibration applies
+        // to the very first NCO phase-word. 1.0 = factory default, no-op.
+        client.SetFrequencyCorrectionFactor(_radio.GetFrequencyCorrectionFactor());
         await client.StartAsync(sampleRateKhz, ct).ConfigureAwait(false);
 
         int rateHz = sampleRateKhz * 1000;
@@ -1010,6 +1019,13 @@ public class DspPipelineService : BackgroundService,
         _appliedPreampOn = on;
     }
 
+    private void OnFrequencyCorrectionFactorChanged(double factor)
+    {
+        // RadioService handles the P1 client + the re-tune; we only have
+        // to forward to the live P2 client here. No-op when no P2 is up.
+        _p2Client?.SetFrequencyCorrectionFactor(factor);
+    }
+
     /// <summary>
     /// Forward a WDSP TXA block of interleaved float IQ to the live P2 client.
     /// No-op when P2 isn't connected; safe to call from TxTuneDriver / future
@@ -1066,6 +1082,50 @@ public class DspPipelineService : BackgroundService,
     }
 
     public Zeus.Protocol2.Protocol2Client? ActiveP2Client => _p2Client;
+
+    /// <summary>
+    /// Panadapter pixel column width — exposed so the frequency-calibration
+    /// service (issue #325) can size its capture buffer correctly without
+    /// hard-coding the constant.
+    /// </summary>
+    public static int PanadapterWidth => Width;
+
+    /// <summary>
+    /// Captures the latest panadapter pixel column (dB values) for spectrum
+    /// peak detection (issue #325 auto-cal). Pixels are written in display
+    /// order (low frequency left, high frequency right), matching what the
+    /// operator sees in the browser. Returns <c>false</c> when no engine /
+    /// channel is open yet, or when WDSP hasn't produced a fresh frame since
+    /// the last call.
+    /// </summary>
+    /// <param name="dest">Buffer of length <see cref="PanadapterWidth"/>.</param>
+    /// <param name="hzPerPixel">Hz spacing between adjacent pixels (out).</param>
+    /// <param name="centerHz">Frequency of the centre pixel — the radio's LO
+    /// (out). In CW modes this is dial ± cw_pitch; outside CW it equals dial.</param>
+    public bool TryCapturePanadapterSnapshot(Span<float> dest, out float hzPerPixel, out long centerHz)
+    {
+        hzPerPixel = 0;
+        centerHz = 0;
+        if (dest.Length != Width) return false;
+
+        var engine = Volatile.Read(ref _engine);
+        int channel = Volatile.Read(ref _channelId);
+        int sampleRate = Volatile.Read(ref _sampleRateHz);
+        if (engine is null || sampleRate <= 0) return false;
+
+        if (!engine.TryGetDisplayPixels(channel, DisplayPixout.Panadapter, dest))
+            return false;
+
+        // Display order (low-freq-left). WDSP emits pixel-0 = highest positive
+        // frequency, so flip here for consistency with the operator view.
+        dest.Reverse();
+
+        var state = _radio.Snapshot();
+        int zoom = Math.Max(1, state.ZoomLevel);
+        hzPerPixel = (float)((double)sampleRate / zoom / Width);
+        centerHz = CwOffset.EffectiveLoHz(state);
+        return true;
+    }
 
     // ---- IRxPacketSink (Protocol 1) -----------------------------------------
     // Called synchronously on Protocol1Client.RxLoop's OS thread. The body

--- a/Zeus.Server.Hosting/FrequencyCalibrationService.cs
+++ b/Zeus.Server.Hosting/FrequencyCalibrationService.cs
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+// Per-radio frequency calibration (issue #325). One-shot procedure
+// modelled on Thetis's `Console.WWVCalibration` (console.cs:9779-9854):
+//
+//   1. Snapshot operator state (VFO / mode / filter / zoom).
+//   2. Tune to a known reference (WWV 10 MHz by default).
+//   3. Set USB mode + narrow filter + high zoom so the WWV carrier sits
+//      inside the panadapter's centre bin range.
+//   4. Wait for the WDSP analyzer to settle, capture the panadapter.
+//   5. Find the spectral peak. Reject when below the noise-floor sanity
+//      threshold or further from LO than the ±100 ppm operating range.
+//   6. Compute correction factor = 1 + (peak_offset_Hz / reference_Hz)
+//      and persist it via RadioService.SetFrequencyCorrectionFactor
+//      (write-through to PreferredRadioStore, push to live P1/P2 client,
+//      re-tune so the new factor takes effect immediately).
+//   7. Restore operator state — VFO / mode / filter / zoom — in finally,
+//      so a failed cal leaves the operator exactly where they were.
+//
+// All four reference clients (piHPSDR, deskHPSDR, Thetis mainline,
+// mi0bot HL2 fork) use the same multiplicative-correction-at-tune-write
+// model; the per-board variation is in *where* the factor is applied
+// (host-side, never on a clock register), which is what Zeus already
+// does at `Protocol1Client.SetVfoAHz` + `Protocol2Client.SetVfoAHz`.
+public sealed class FrequencyCalibrationService
+{
+    public const double DefaultReferenceFrequencyHz = 10_000_000.0;
+
+    // Lower bound on peak strength relative to the analyzer noise floor.
+    // -90 dBFS rejects a typical empty band on the panadapter; WWV at a
+    // city QTH normally lands -60..-30 dBFS in a 3 Hz/pixel bin.
+    private const float NoiseFloorDbThreshold = -90f;
+
+    // ±100 ppm at 10 MHz = ±1000 Hz; matches piHPSDR's frequency_calibration
+    // bounds. Anything wider almost certainly means the operator is far off
+    // the reference station, not a real calibration condition.
+    private const double MaxAcceptableOffsetHz = 1000.0;
+
+    private const int SettleMs = 1500;
+    private const int CaptureRetries = 12;
+    private const int CaptureRetryDelayMs = 40;
+
+    // Zoom 16 at 48 kHz P1: ±1500 Hz visible, ~1.5 Hz/pixel resolution.
+    // Zoom 16 at 192 kHz P2: ±6000 Hz visible, ~5.9 Hz/pixel resolution.
+    // Wide enough to catch the entire ±100 ppm range, narrow enough that
+    // a single peak dominates the spectrum at WWV signal strengths.
+    private const int CalZoomLevel = 16;
+
+    private readonly RadioService _radio;
+    private readonly DspPipelineService _pipeline;
+    private readonly ILogger<FrequencyCalibrationService> _log;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    public FrequencyCalibrationService(
+        RadioService radio,
+        DspPipelineService pipeline,
+        ILogger<FrequencyCalibrationService> log)
+    {
+        _radio = radio;
+        _pipeline = pipeline;
+        _log = log;
+    }
+
+    /// <summary>
+    /// Run the auto-calibration procedure. Concurrent invocations are
+    /// rejected — only one cal at a time. The radio must be connected; if
+    /// not, returns <see cref="CalibrationResult.NotConnected"/>.
+    /// </summary>
+    public async Task<CalibrationResult> CalibrateAsync(
+        double referenceFrequencyHz = DefaultReferenceFrequencyHz,
+        CancellationToken ct = default)
+    {
+        if (referenceFrequencyHz <= 0 || referenceFrequencyHz > 60_000_000)
+            throw new ArgumentOutOfRangeException(nameof(referenceFrequencyHz));
+
+        // Single-shot lock. WaitAsync(0) — fail fast if a previous cal is
+        // still running rather than queueing a second attempt.
+        if (!await _gate.WaitAsync(0, ct).ConfigureAwait(false))
+            return CalibrationResult.Busy;
+
+        try
+        {
+            var startSnap = _radio.Snapshot();
+            if (startSnap.Status != ConnectionStatus.Connected)
+                return CalibrationResult.NotConnected;
+
+            // Snapshot operator state — restore in finally regardless of outcome.
+            long origVfoHz = startSnap.VfoHz;
+            RxMode origMode = startSnap.Mode;
+            int origFilterLo = startSnap.FilterLowHz;
+            int origFilterHi = startSnap.FilterHighHz;
+            int origZoom = startSnap.ZoomLevel;
+
+            _log.LogInformation(
+                "freqcal.start ref={Ref}Hz origVfo={Vfo} origMode={Mode} origZoom={Zoom}",
+                referenceFrequencyHz, origVfoHz, origMode, origZoom);
+
+            try
+            {
+                // Configure for calibration. USB at 10 MHz puts the WWV
+                // carrier exactly at LO (panadapter centre); a narrow filter
+                // keeps audio CPU low and predictable.
+                _radio.SetMode(RxMode.USB);
+                _radio.SetFilter(100, 2700);
+                _radio.SetZoom(CalZoomLevel);
+                _radio.SetVfo((long)referenceFrequencyHz);
+
+                await Task.Delay(SettleMs, ct).ConfigureAwait(false);
+
+                var pixels = new float[DspPipelineService.PanadapterWidth];
+                if (!await TryCaptureWithRetryAsync(pixels, ct).ConfigureAwait(false))
+                    return CalibrationResult.CaptureFailed;
+
+                long centerHz;
+                float hzPerPixel;
+                _pipeline.TryCapturePanadapterSnapshot(pixels, out hzPerPixel, out centerHz);
+
+                // Peak detection. Pixels are in low-left/high-right display
+                // order; centre pixel maps to LO. The carrier offset is
+                // (peakIndex - width/2) * hzPerPixel.
+                int peakIndex = 0;
+                float peakDb = float.NegativeInfinity;
+                for (int i = 0; i < pixels.Length; i++)
+                {
+                    if (pixels[i] > peakDb)
+                    {
+                        peakDb = pixels[i];
+                        peakIndex = i;
+                    }
+                }
+
+                if (peakDb < NoiseFloorDbThreshold)
+                    return CalibrationResult.NoSignal(peakDb);
+
+                double offsetHz = (peakIndex - pixels.Length / 2.0) * hzPerPixel;
+
+                if (Math.Abs(offsetHz) > MaxAcceptableOffsetHz)
+                    return CalibrationResult.OffsetOutOfRange(offsetHz, peakDb);
+
+                // factor = 1 + (offsetHz / referenceHz). Derivation:
+                //   actual_LO = commanded * (1 + e)  where e = crystal error
+                //   peak appears at (true_freq - actual_LO) on the panadapter,
+                //   so offsetHz = -commanded * e  ⇒  e = -offsetHz / commanded
+                //   to compensate, factor = 1/(1+e) ≈ 1 - e = 1 + offsetHz/commanded.
+                double factor = 1.0 + (offsetHz / referenceFrequencyHz);
+                double applied = _radio.SetFrequencyCorrectionFactor(factor);
+
+                _log.LogInformation(
+                    "freqcal.success offset={Off:F2}Hz peakDb={Db:F1} factor={Factor:F9} applied={Applied:F9}",
+                    offsetHz, peakDb, factor, applied);
+
+                return CalibrationResult.Success(offsetHz, peakDb, applied);
+            }
+            finally
+            {
+                // Restore — in order: mode (resets family filter cache),
+                // filter (overrides the family default), zoom, VFO.
+                try { _radio.SetMode(origMode); } catch (Exception ex) { _log.LogWarning(ex, "freqcal.restore mode"); }
+                try { _radio.SetFilter(origFilterLo, origFilterHi); } catch (Exception ex) { _log.LogWarning(ex, "freqcal.restore filter"); }
+                try { _radio.SetZoom(origZoom); } catch (Exception ex) { _log.LogWarning(ex, "freqcal.restore zoom"); }
+                try { _radio.SetVfo(origVfoHz); } catch (Exception ex) { _log.LogWarning(ex, "freqcal.restore vfo"); }
+            }
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Reset the per-radio correction factor to 1.0 (no correction). Same
+    /// write-through-then-push path as SetFrequencyCorrectionFactor.
+    /// </summary>
+    public void Reset() => _radio.SetFrequencyCorrectionFactor(1.0);
+
+    private async Task<bool> TryCaptureWithRetryAsync(float[] dest, CancellationToken ct)
+    {
+        // TryGetDisplayPixels returns false when no fresh FFT is ready
+        // (the WDSP worker is still producing the first frame after
+        // SetVfo's re-tune, or the analyzer reconfig from SetZoom is
+        // still settling). Retry briefly to give the pipeline time to
+        // produce a fresh frame.
+        for (int attempt = 0; attempt < CaptureRetries; attempt++)
+        {
+            if (_pipeline.TryCapturePanadapterSnapshot(dest, out _, out _))
+                return true;
+            await Task.Delay(CaptureRetryDelayMs, ct).ConfigureAwait(false);
+        }
+        return false;
+    }
+}
+
+/// <summary>
+/// Result of a calibration run. Encoded as a discriminated record so the
+/// REST surface can serialise both successes and the various failure
+/// modes uniformly.
+/// </summary>
+public sealed record CalibrationResult(
+    CalibrationOutcome Outcome,
+    double? OffsetHz,
+    float? PeakDb,
+    double? AppliedFactor,
+    string Message)
+{
+    public static readonly CalibrationResult Busy = new(
+        CalibrationOutcome.Busy, null, null, null,
+        "A calibration is already in progress.");
+
+    public static readonly CalibrationResult NotConnected = new(
+        CalibrationOutcome.NotConnected, null, null, null,
+        "No radio is connected. Connect first, then run calibration.");
+
+    public static readonly CalibrationResult CaptureFailed = new(
+        CalibrationOutcome.CaptureFailed, null, null, null,
+        "Panadapter snapshot was not available — engine offline or pipeline stalled.");
+
+    public static CalibrationResult NoSignal(float peakDb) => new(
+        CalibrationOutcome.NoSignal, null, peakDb, null,
+        $"No signal detected at the reference frequency (peak {peakDb:F1} dB below noise floor).");
+
+    public static CalibrationResult OffsetOutOfRange(double offsetHz, float peakDb) => new(
+        CalibrationOutcome.OffsetOutOfRange, offsetHz, peakDb, null,
+        $"Measured offset {offsetHz:F1} Hz exceeds ±1 kHz at 10 MHz — likely tuned to the wrong reference or strong interferer.");
+
+    public static CalibrationResult Success(double offsetHz, float peakDb, double appliedFactor) => new(
+        CalibrationOutcome.Success, offsetHz, peakDb, appliedFactor,
+        $"Calibration applied: {offsetHz:+0.0;-0.0;0.0} Hz at 10 MHz ({(appliedFactor - 1.0) * 1e6:+0.000;-0.000;0.000} ppm).");
+}
+
+public enum CalibrationOutcome
+{
+    Success,
+    Busy,
+    NotConnected,
+    CaptureFailed,
+    NoSignal,
+    OffsetOutOfRange,
+}

--- a/Zeus.Server.Hosting/FrequencyCalibrationService.cs
+++ b/Zeus.Server.Hosting/FrequencyCalibrationService.cs
@@ -12,13 +12,23 @@ namespace Zeus.Server;
 // modelled on Thetis's `Console.WWVCalibration` (console.cs:9779-9854):
 //
 //   1. Snapshot operator state (VFO / mode / filter / zoom).
-//   2. Tune to a known reference (WWV 10 MHz by default).
-//   3. Set USB mode + narrow filter + high zoom so the WWV carrier sits
-//      inside the panadapter's centre bin range.
+//   2. Tune the LO to (reference + 2 kHz), so the reference station's
+//      carrier lands ~2 kHz LOW of LO on the panadapter — clear of the
+//      DC bias spike that HPSDR-class radios always emit at LO. (A naive
+//      "tune directly to 10 MHz" approach can't distinguish a perfectly-
+//      tuned radio from a radio that just doesn't hear WWV, since both
+//      produce a peak at exactly LO.)
+//   3. Set USB mode + narrow filter + zoom 8 so the full ±100 ppm
+//      operating range fits inside the analyzer span.
 //   4. Wait for the WDSP analyzer to settle, capture the panadapter.
-//   5. Find the spectral peak. Reject when below the noise-floor sanity
-//      threshold or further from LO than the ±100 ppm operating range.
-//   6. Compute correction factor = 1 + (peak_offset_Hz / reference_Hz)
+//   5. Search for the spectral peak *only* in the expected band
+//      (-3000..-1000 Hz from LO — where the carrier lives for any
+//      crystal drift inside ±100 ppm). Reject the result unless the
+//      peak rises ≥ 6 dB above the spectrum median AND ≥ -90 dBFS in
+//      absolute terms.
+//   6. Compute correction factor:
+//        deviationHz = peakOffsetFromLo - expectedOffsetHz   (Hz)
+//        factor = 1 + deviationHz / referenceFrequencyHz
 //      and persist it via RadioService.SetFrequencyCorrectionFactor
 //      (write-through to PreferredRadioStore, push to live P1/P2 client,
 //      re-tune so the new factor takes effect immediately).
@@ -34,25 +44,38 @@ public sealed class FrequencyCalibrationService
 {
     public const double DefaultReferenceFrequencyHz = 10_000_000.0;
 
-    // Lower bound on peak strength relative to the analyzer noise floor.
-    // -90 dBFS rejects a typical empty band on the panadapter; WWV at a
-    // city QTH normally lands -60..-30 dBFS in a 3 Hz/pixel bin.
-    private const float NoiseFloorDbThreshold = -90f;
+    // Intentional LO offset above the reference (Hz). Puts the reference
+    // carrier ~2 kHz below LO on the panadapter, well clear of the DC
+    // bias spike. Pairs with zoom 8 — see CalZoomLevel.
+    private const double IntentionalLoOffsetHz = 2000.0;
 
-    // ±100 ppm at 10 MHz = ±1000 Hz; matches piHPSDR's frequency_calibration
-    // bounds. Anything wider almost certainly means the operator is far off
-    // the reference station, not a real calibration condition.
-    private const double MaxAcceptableOffsetHz = 1000.0;
+    // Search band (relative to LO) where the reference carrier is
+    // expected to land. With IntentionalLoOffsetHz = 2000 Hz the
+    // carrier sits at -2000 Hz for a perfectly-tuned radio; at
+    // -3000 Hz for +100 ppm crystal high; at -1000 Hz for -100 ppm
+    // crystal low. Searching outside this band catches noise or
+    // unrelated interferers, not a real WWV peak.
+    private const double SearchMinHz = -3000.0;
+    private const double SearchMaxHz = -1000.0;
 
-    private const int SettleMs = 1500;
+    // Peak must stand out from the spectrum median by at least this much.
+    // Catches the case where the "peak" is just slightly-warm noise — a
+    // real WWV carrier sits well above the surrounding median (typically
+    // 20-40 dB). Relative threshold only: an absolute dB floor would
+    // reject perfectly real but faint signals on quieter SDRs (P2 at
+    // 192 kHz commonly has a -125 dB analyzer median, where even a
+    // -99 dB carrier is unambiguously a signal).
+    private const float MinPeakAboveMedianDb = 6f;
+
+    private const int SettleMs = 2500;
     private const int CaptureRetries = 12;
     private const int CaptureRetryDelayMs = 40;
 
-    // Zoom 16 at 48 kHz P1: ±1500 Hz visible, ~1.5 Hz/pixel resolution.
-    // Zoom 16 at 192 kHz P2: ±6000 Hz visible, ~5.9 Hz/pixel resolution.
-    // Wide enough to catch the entire ±100 ppm range, narrow enough that
-    // a single peak dominates the spectrum at WWV signal strengths.
-    private const int CalZoomLevel = 16;
+    // Zoom 8 at 48 kHz P1: ±3000 Hz visible, ~2.9 Hz/pixel resolution —
+    // exactly covers the ±100 ppm search band when paired with
+    // IntentionalLoOffsetHz = 2 kHz. Zoom 8 at 192 kHz P2: ±12 kHz
+    // visible, ~11.7 Hz/pixel.
+    private const int CalZoomLevel = 8;
 
     private readonly RadioService _radio;
     private readonly DspPipelineService _pipeline;
@@ -105,13 +128,14 @@ public sealed class FrequencyCalibrationService
 
             try
             {
-                // Configure for calibration. USB at 10 MHz puts the WWV
-                // carrier exactly at LO (panadapter centre); a narrow filter
-                // keeps audio CPU low and predictable.
+                // Configure for calibration. LO sits 2 kHz ABOVE the
+                // reference so the carrier lands at -2 kHz on the
+                // panadapter — well clear of the DC spike at LO.
                 _radio.SetMode(RxMode.USB);
                 _radio.SetFilter(100, 2700);
                 _radio.SetZoom(CalZoomLevel);
-                _radio.SetVfo((long)referenceFrequencyHz);
+                long commandedLoHz = (long)(referenceFrequencyHz + IntentionalLoOffsetHz);
+                _radio.SetVfo(commandedLoHz);
 
                 await Task.Delay(SettleMs, ct).ConfigureAwait(false);
 
@@ -119,16 +143,18 @@ public sealed class FrequencyCalibrationService
                 if (!await TryCaptureWithRetryAsync(pixels, ct).ConfigureAwait(false))
                     return CalibrationResult.CaptureFailed;
 
-                long centerHz;
-                float hzPerPixel;
-                _pipeline.TryCapturePanadapterSnapshot(pixels, out hzPerPixel, out centerHz);
+                _ = _pipeline.TryCapturePanadapterSnapshot(pixels, out float hzPerPixel, out _);
 
-                // Peak detection. Pixels are in low-left/high-right display
-                // order; centre pixel maps to LO. The carrier offset is
-                // (peakIndex - width/2) * hzPerPixel.
-                int peakIndex = 0;
+                // Peak detection in the expected band only. Pixels are in
+                // low-left/high-right display order; centre pixel maps to
+                // LO. The carrier offset is (peakIndex - width/2) * hzPerPixel.
+                int centerIdx = pixels.Length / 2;
+                int searchMinIdx = Math.Max(0, centerIdx + (int)Math.Floor(SearchMinHz / hzPerPixel));
+                int searchMaxIdx = Math.Min(pixels.Length - 1, centerIdx + (int)Math.Ceiling(SearchMaxHz / hzPerPixel));
+
+                int peakIndex = -1;
                 float peakDb = float.NegativeInfinity;
-                for (int i = 0; i < pixels.Length; i++)
+                for (int i = searchMinIdx; i <= searchMaxIdx; i++)
                 {
                     if (pixels[i] > peakDb)
                     {
@@ -137,27 +163,38 @@ public sealed class FrequencyCalibrationService
                     }
                 }
 
-                if (peakDb < NoiseFloorDbThreshold)
-                    return CalibrationResult.NoSignal(peakDb);
+                if (peakIndex < 0) return CalibrationResult.CaptureFailed;
 
-                double offsetHz = (peakIndex - pixels.Length / 2.0) * hzPerPixel;
+                float medianDb = Median(pixels);
 
-                if (Math.Abs(offsetHz) > MaxAcceptableOffsetHz)
-                    return CalibrationResult.OffsetOutOfRange(offsetHz, peakDb);
+                _log.LogInformation(
+                    "freqcal.scan searchMin={Min}px searchMax={Max}px peakIdx={Pk} peakDb={Db:F1} medianDb={Med:F1} hzPerPx={Hpp:F2}",
+                    searchMinIdx, searchMaxIdx, peakIndex, peakDb, medianDb, hzPerPixel);
 
-                // factor = 1 + (offsetHz / referenceHz). Derivation:
-                //   actual_LO = commanded * (1 + e)  where e = crystal error
-                //   peak appears at (true_freq - actual_LO) on the panadapter,
-                //   so offsetHz = -commanded * e  ⇒  e = -offsetHz / commanded
-                //   to compensate, factor = 1/(1+e) ≈ 1 - e = 1 + offsetHz/commanded.
-                double factor = 1.0 + (offsetHz / referenceFrequencyHz);
+                if (peakDb - medianDb < MinPeakAboveMedianDb)
+                    return CalibrationResult.NoSignal(peakDb, medianDb);
+
+                double peakOffsetFromLoHz = (peakIndex - centerIdx) * (double)hzPerPixel;
+                double deviationHz = peakOffsetFromLoHz - (-IntentionalLoOffsetHz);
+
+                if (Math.Abs(deviationHz) > 1000.0)
+                    return CalibrationResult.OffsetOutOfRange(deviationHz, peakDb);
+
+                // factor = 1 + (deviationHz / referenceHz). Derivation:
+                //   commandedLO = referenceHz + IntentionalLoOffsetHz
+                //   actualLO    = commandedLO * (1 + e)  (e = crystal error)
+                //   peak appears at refHz - actualLO ≈ -IntentionalLoOffsetHz - referenceHz*e
+                //   so deviationHz = peakPos - (-IntentionalLoOffsetHz) = -referenceHz*e
+                //   ⇒ e = -deviationHz / referenceHz
+                //   to compensate, factor = 1/(1+e) ≈ 1 - e = 1 + deviationHz/referenceHz.
+                double factor = 1.0 + (deviationHz / referenceFrequencyHz);
                 double applied = _radio.SetFrequencyCorrectionFactor(factor);
 
                 _log.LogInformation(
-                    "freqcal.success offset={Off:F2}Hz peakDb={Db:F1} factor={Factor:F9} applied={Applied:F9}",
-                    offsetHz, peakDb, factor, applied);
+                    "freqcal.success peakOffFromLo={Pol:F1}Hz deviationFromExpected={Dev:F1}Hz peakDb={Db:F1} medianDb={Med:F1} factor={Factor:F9} applied={Applied:F9}",
+                    peakOffsetFromLoHz, deviationHz, peakDb, medianDb, factor, applied);
 
-                return CalibrationResult.Success(offsetHz, peakDb, applied);
+                return CalibrationResult.Success(deviationHz, peakDb, applied);
             }
             finally
             {
@@ -196,6 +233,18 @@ public sealed class FrequencyCalibrationService
         }
         return false;
     }
+
+    private static float Median(ReadOnlySpan<float> values)
+    {
+        // Selection-by-sort: spectrum width is 2048, so a one-shot sort
+        // of a copy is cheap (~30 µs) and avoids the boundary trickery
+        // of a partial-quickselect for an even count. Cal runs once per
+        // click, so the temp array cost is irrelevant.
+        var buf = values.ToArray();
+        Array.Sort(buf);
+        int mid = buf.Length / 2;
+        return (buf.Length % 2 == 0) ? (buf[mid - 1] + buf[mid]) / 2f : buf[mid];
+    }
 }
 
 /// <summary>
@@ -222,9 +271,11 @@ public sealed record CalibrationResult(
         CalibrationOutcome.CaptureFailed, null, null, null,
         "Panadapter snapshot was not available — engine offline or pipeline stalled.");
 
-    public static CalibrationResult NoSignal(float peakDb) => new(
+    public static CalibrationResult NoSignal(float peakDb, float medianDb = float.NaN) => new(
         CalibrationOutcome.NoSignal, null, peakDb, null,
-        $"No signal detected at the reference frequency (peak {peakDb:F1} dB below noise floor).");
+        float.IsNaN(medianDb)
+            ? $"No signal detected at the reference frequency (peak {peakDb:F1} dB)."
+            : $"No signal detected at the reference frequency (peak {peakDb:F1} dB, median {medianDb:F1} dB — peak must rise ≥ 6 dB above median).");
 
     public static CalibrationResult OffsetOutOfRange(double offsetHz, float peakDb) => new(
         CalibrationOutcome.OffsetOutOfRange, offsetHz, peakDb, null,

--- a/Zeus.Server.Hosting/PreferredRadioStore.cs
+++ b/Zeus.Server.Hosting/PreferredRadioStore.cs
@@ -230,6 +230,62 @@ public sealed class PreferredRadioStore : IDisposable
         Changed?.Invoke();
     }
 
+    /// <summary>
+    /// Per-radio frequency-correction factor for crystal/clock drift
+    /// (issue #325). Dimensionless multiplier near 1.0 applied host-side
+    /// at the Protocol-1 and Protocol-2 SetVfoAHz seams before the value
+    /// reaches the radio's NCO. 1.0 = uncalibrated (factory default).
+    ///
+    /// Models the Thetis "Correction Factor" approach
+    /// (NetworkIO.VFOfreq, Setup → General → Calibration); mathematically
+    /// identical to piHPSDR's `(10_000_000 + ppm_tenths) / 10_000_000`
+    /// formula. ppm = (factor - 1.0) * 1e6.
+    /// </summary>
+    public double GetFrequencyCorrectionFactor()
+    {
+        lock (_sync)
+        {
+            var e = _entries.FindAll().FirstOrDefault();
+            // LiteDB hydrates double-valued fields to 0.0 for older rows
+            // that pre-date this field; treat that case as "unset" so
+            // operators upgrading from a pre-#325 build don't see their
+            // tuning silently jump to DC.
+            return (e is null || e.FrequencyCorrectionFactor == 0.0)
+                ? 1.0
+                : e.FrequencyCorrectionFactor;
+        }
+    }
+
+    /// <summary>
+    /// Persists the operator's calibrated correction factor. Stored in the
+    /// same single-row preferences entry as the other per-radio prefs.
+    /// Setting to 1.0 is identical to "unset" (factory default).
+    /// </summary>
+    public void SetFrequencyCorrectionFactor(double factor)
+    {
+        lock (_sync)
+        {
+            var existing = _entries.FindAll().FirstOrDefault();
+            if (existing is null)
+            {
+                _entries.Insert(new PreferredRadioEntry
+                {
+                    Board = HpsdrBoardKind.Unknown,
+                    OverrideDetection = false,
+                    FrequencyCorrectionFactor = factor,
+                    UpdatedUtc = DateTime.UtcNow,
+                });
+            }
+            else
+            {
+                existing.FrequencyCorrectionFactor = factor;
+                existing.UpdatedUtc = DateTime.UtcNow;
+                _entries.Update(existing);
+            }
+        }
+        Changed?.Invoke();
+    }
+
     public void Dispose() => _db.Dispose();
 
 }
@@ -248,5 +304,11 @@ public sealed class PreferredRadioEntry
     /// <c>false</c> for older rows that pre-date this field, which matches
     /// the shipping default.</summary>
     public bool EnableHl2BandVolts { get; set; }
+    /// <summary>Per-radio frequency-correction factor (issue #325).
+    /// Dimensionless multiplier near 1.0; 1.0 = uncalibrated. LiteDB
+    /// hydrates as 0.0 for older rows that pre-date this field; the
+    /// accessor treats 0.0 as "unset" and returns 1.0 to keep tuning
+    /// behaviour bit-identical for upgrading operators.</summary>
+    public double FrequencyCorrectionFactor { get; set; }
     public DateTime UpdatedUtc { get; set; }
 }

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -437,6 +437,15 @@ public sealed class RadioService : IDisposable
                 client.EnableHl2BandVolts = _preferredRadioStore.GetEnableHl2BandVolts();
             }
 
+            // Frequency-correction factor (issue #325) — rehydrate so the
+            // first tune-write on the fresh client carries the operator's
+            // calibrated correction. Cheap default when no calibration has
+            // run (factor = 1.0).
+            if (_preferredRadioStore is not null)
+            {
+                client.SetFrequencyCorrectionFactor(_preferredRadioStore.GetFrequencyCorrectionFactor());
+            }
+
             Mutate(s => s with { Status = ConnectionStatus.Connected });
             _log.LogInformation("radio.connected endpoint={Ep} rate={Rate}", ipEndpoint, hpsdrRate);
             Connected?.Invoke(client);
@@ -1002,6 +1011,52 @@ public sealed class RadioService : IDisposable
     /// </summary>
     public bool GetHl2BandVolts() =>
         _preferredRadioStore?.GetEnableHl2BandVolts() ?? false;
+
+    /// <summary>
+    /// Raised after the operator's frequency-correction factor (issue #325)
+    /// has been persisted and pushed to the active P1 client. P2 subscribers
+    /// (<c>DspPipelineService</c>) use this to forward the new factor to the
+    /// live <see cref="Zeus.Protocol2.Protocol2Client"/>, since
+    /// <see cref="ActiveClient"/> is always null in P2 mode.
+    /// </summary>
+    public event Action<double>? FrequencyCorrectionFactorChanged;
+
+    /// <summary>
+    /// Reads the per-radio frequency-correction factor (issue #325). 1.0
+    /// when no store is wired or no calibration has been run.
+    /// </summary>
+    public double GetFrequencyCorrectionFactor() =>
+        _preferredRadioStore?.GetFrequencyCorrectionFactor() ?? 1.0;
+
+    /// <summary>
+    /// Persists the frequency-correction factor, pushes it to the live P1
+    /// client (if any), raises <see cref="FrequencyCorrectionFactorChanged"/>
+    /// for the P2 listener, and re-pushes the current dial VFO so the new
+    /// factor reaches the wire immediately. Clamps to ±100 ppm
+    /// (factor ∈ [0.9999, 1.0001]) — matches piHPSDR's range and is far
+    /// wider than any crystal-stabilised HPSDR board needs.
+    /// </summary>
+    public double SetFrequencyCorrectionFactor(double factor)
+    {
+        if (double.IsNaN(factor) || double.IsInfinity(factor))
+            throw new ArgumentException("factor must be a finite real number", nameof(factor));
+        double clamped = Math.Clamp(factor, 0.9999, 1.0001);
+
+        // Write-through to persistent storage first so a crash between the
+        // store write and the live-client push can't lose the calibration.
+        _preferredRadioStore?.SetFrequencyCorrectionFactor(clamped);
+        _activeClient?.SetFrequencyCorrectionFactor(clamped);
+        FrequencyCorrectionFactorChanged?.Invoke(clamped);
+
+        // Re-push the current dial Hz so the new factor lands on the wire.
+        // SetVfo's CwOffset application + ActiveClient push handle P1; the
+        // FrequencyCorrectionFactorChanged event handler in DspPipelineService
+        // covers the P2 client.
+        long currentDial = Snapshot().VfoHz;
+        SetVfo(currentDial);
+
+        return clamped;
+    }
 
     // Compute the current drive byte + OC masks + PA enable from _drivePct,
     // PaSettingsStore, and the current VFO band. Push to the active P1 client

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -872,6 +872,41 @@ public static class ZeusEndpoints
             return Results.Ok(new Hl2OptionsDto(BandVolts: effective));
         });
 
+        // Per-radio frequency calibration (issue #325). GET returns the
+        // persisted correction factor + its ppm representation. POST
+        // /calibrate runs the one-button auto-cal procedure (snapshot
+        // state, tune WWV 10 MHz, find peak, apply factor, restore).
+        // POST /reset clears the factor back to 1.0.
+        app.MapGet("/api/radio/frequency-calibration", (RadioService radio) =>
+        {
+            double factor = radio.GetFrequencyCorrectionFactor();
+            double ppm = (factor - 1.0) * 1e6;
+            double offsetAt10MHz = ppm * 10.0; // Hz offset at 10 MHz
+            return Results.Ok(new
+            {
+                factor,
+                ppm,
+                offsetHzAt10MHz = offsetAt10MHz,
+            });
+        });
+
+        app.MapPost("/api/radio/frequency-calibration/calibrate", async (
+            FrequencyCalibrationService cal, HttpContext ctx) =>
+        {
+            log.LogInformation("api.freqcal.calibrate begin");
+            var result = await cal.CalibrateAsync(ct: ctx.RequestAborted).ConfigureAwait(false);
+            log.LogInformation("api.freqcal.calibrate result={Outcome} offset={Off} factor={Factor}",
+                result.Outcome, result.OffsetHz, result.AppliedFactor);
+            return Results.Ok(result);
+        });
+
+        app.MapPost("/api/radio/frequency-calibration/reset", (FrequencyCalibrationService cal) =>
+        {
+            log.LogInformation("api.freqcal.reset");
+            cal.Reset();
+            return Results.Ok(new { factor = 1.0, ppm = 0.0, offsetHzAt10MHz = 0.0 });
+        });
+
         // UI layout: flexlayout-react panel arrangement, persisted per operator profile.
         // GET returns 404 when no layout has been saved yet (frontend falls back to
         // DEFAULT_LAYOUT). PUT replaces; DELETE resets to default on next load.

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -162,6 +162,9 @@ public static class ZeusHost
         builder.Services.AddHostedService<WisdomBootstrapService>();
         builder.Services.AddSingleton<DspPipelineService>();
         builder.Services.AddHostedService(sp => sp.GetRequiredService<DspPipelineService>());
+        // Per-radio frequency calibration (issue #325). Stateless coordinator —
+        // owns no resources, just a SemaphoreSlim to prevent re-entry.
+        builder.Services.AddSingleton<FrequencyCalibrationService>();
         builder.Services.AddSingleton<TxService>();
         builder.Services.AddSingleton<TxAudioIngest>();
         // Resolve at startup so the MicPcmReceived subscription attaches before the

--- a/tests/Zeus.Protocol1.Tests/FrequencyCorrectionTests.cs
+++ b/tests/Zeus.Protocol1.Tests/FrequencyCorrectionTests.cs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+
+using Xunit;
+
+namespace Zeus.Protocol1.Tests;
+
+/// <summary>
+/// Per-radio frequency-correction factor (issue #325). The correction is
+/// a single multiplicative scalar applied inside
+/// <see cref="Protocol1Client.SetVfoAHz"/> right before the wire-bound
+/// <c>_vfoAHz</c> slot. These tests pin down the math against the
+/// piHPSDR / Thetis / deskHPSDR reference convention:
+///
+///   <c>corrected = round(dial * factor)</c>
+///
+/// where <c>factor = 1 + (Δf / f_ref)</c>. A +1 ppm crystal (factor =
+/// 1.000001) makes the radio's NCO run 1 Hz fast at 1 MHz, 10 Hz fast at
+/// 10 MHz, etc.; the host-side correction subtracts that drift so the
+/// dial reads the truth.
+/// </summary>
+public class FrequencyCorrectionTests
+{
+    [Fact]
+    public void Factor_One_Means_No_Correction()
+    {
+        using var client = new Protocol1Client();
+        client.SetFrequencyCorrectionFactor(1.0);
+        client.SetVfoAHz(14_250_000);
+
+        Assert.Equal(14_250_000L, client.SnapshotState().VfoAHz);
+    }
+
+    [Fact]
+    public void Default_Factor_Is_One()
+    {
+        using var client = new Protocol1Client();
+        Assert.Equal(1.0, client.FrequencyCorrectionFactor);
+
+        client.SetVfoAHz(7_100_000);
+        Assert.Equal(7_100_000L, client.SnapshotState().VfoAHz);
+    }
+
+    [Fact]
+    public void Plus_One_Ppm_Adds_Ten_Hz_At_Ten_MHz()
+    {
+        using var client = new Protocol1Client();
+        client.SetFrequencyCorrectionFactor(1.000001);
+        client.SetVfoAHz(10_000_000);
+
+        Assert.Equal(10_000_010L, client.SnapshotState().VfoAHz);
+    }
+
+    [Fact]
+    public void Minus_One_Ppm_Subtracts_Ten_Hz_At_Ten_MHz()
+    {
+        using var client = new Protocol1Client();
+        client.SetFrequencyCorrectionFactor(0.999999);
+        client.SetVfoAHz(10_000_000);
+
+        Assert.Equal(9_999_990L, client.SnapshotState().VfoAHz);
+    }
+
+    [Fact]
+    public void Correction_Scales_Linearly_Across_Hf()
+    {
+        using var client = new Protocol1Client();
+        client.SetFrequencyCorrectionFactor(1.000001); // +1 ppm
+
+        // +1 Hz per MHz at the cardinal HF anchors. Inputs chosen so the
+        // mathematical product isn't a half-integer — double-precision
+        // multiplication of these gives a result comfortably on one side
+        // of the midpoint, so the AwayFromZero rounding direction is not
+        // implementation-defined here.
+        client.SetVfoAHz(1_000_000);
+        Assert.Equal(1_000_001L, client.SnapshotState().VfoAHz);
+
+        client.SetVfoAHz(14_250_000);
+        Assert.Equal(14_250_014L, client.SnapshotState().VfoAHz);
+
+        client.SetVfoAHz(50_000_000);
+        Assert.Equal(50_000_050L, client.SnapshotState().VfoAHz);
+    }
+
+    [Fact]
+    public void Factor_Change_Affects_Next_Tune_Not_Current_Slot()
+    {
+        // The protocol client's SetFrequencyCorrectionFactor does NOT
+        // re-apply to the currently-stored VFO — that's RadioService's
+        // job (it calls SetVfo with the same dial after the factor
+        // change). Confirm here that calling SetFrequencyCorrectionFactor
+        // alone is non-destructive.
+        using var client = new Protocol1Client();
+        client.SetFrequencyCorrectionFactor(1.0);
+        client.SetVfoAHz(14_250_000);
+        Assert.Equal(14_250_000L, client.SnapshotState().VfoAHz);
+
+        client.SetFrequencyCorrectionFactor(1.000001);
+        // _vfoAHz wasn't touched — still the value written under factor=1.
+        Assert.Equal(14_250_000L, client.SnapshotState().VfoAHz);
+
+        // Re-tune with same dial: now the new factor is applied.
+        client.SetVfoAHz(14_250_000);
+        Assert.Equal(14_250_014L, client.SnapshotState().VfoAHz);
+    }
+}

--- a/tests/Zeus.Protocol2.Tests/FrequencyCorrectionTests.cs
+++ b/tests/Zeus.Protocol2.Tests/FrequencyCorrectionTests.cs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Zeus.Protocol2.Tests;
+
+/// <summary>
+/// Per-radio frequency-correction factor (issue #325). Same math as the
+/// Protocol-1 path — verifies the Protocol-2 client (which feeds the DUC
+/// / DDC NCO phase-word) applies the same multiplicative correction
+/// inside <see cref="Protocol2Client.SetVfoAHz"/>. Without this gate,
+/// G2 / OrionMkII / Saturn-class radios would calibrate the dial but the
+/// NCO phase-word at <c>line 951</c> would still drift.
+/// </summary>
+public class FrequencyCorrectionTests
+{
+    private static Protocol2Client NewClient() => new(NullLogger<Protocol2Client>.Instance);
+
+    [Fact]
+    public void Factor_One_Means_No_Correction()
+    {
+        var client = NewClient();
+        client.SetFrequencyCorrectionFactor(1.0);
+        client.SetVfoAHz(14_250_000);
+        Assert.Equal((uint)14_250_000, client.CorrectedRxFreqHzForTesting);
+    }
+
+    [Fact]
+    public void Default_Factor_Is_One()
+    {
+        var client = NewClient();
+        Assert.Equal(1.0, client.FrequencyCorrectionFactor);
+
+        client.SetVfoAHz(7_100_000);
+        Assert.Equal((uint)7_100_000, client.CorrectedRxFreqHzForTesting);
+    }
+
+    [Fact]
+    public void Plus_One_Ppm_Adds_Ten_Hz_At_Ten_MHz()
+    {
+        var client = NewClient();
+        client.SetFrequencyCorrectionFactor(1.000001);
+        client.SetVfoAHz(10_000_000);
+        Assert.Equal((uint)10_000_010, client.CorrectedRxFreqHzForTesting);
+    }
+
+    [Fact]
+    public void Minus_One_Ppm_Subtracts_Ten_Hz_At_Ten_MHz()
+    {
+        var client = NewClient();
+        client.SetFrequencyCorrectionFactor(0.999999);
+        client.SetVfoAHz(10_000_000);
+        Assert.Equal((uint)9_999_990, client.CorrectedRxFreqHzForTesting);
+    }
+
+    [Fact]
+    public void Correction_Scales_Linearly_Across_Hf()
+    {
+        var client = NewClient();
+        client.SetFrequencyCorrectionFactor(1.000001); // +1 ppm
+
+        // +1 Hz per MHz at cardinal HF anchors. Inputs chosen so the
+        // mathematical product isn't a half-integer — keeps the result
+        // robust against double-precision rounding direction.
+        client.SetVfoAHz(1_000_000);
+        Assert.Equal((uint)1_000_001, client.CorrectedRxFreqHzForTesting);
+
+        client.SetVfoAHz(14_250_000);
+        Assert.Equal((uint)14_250_014, client.CorrectedRxFreqHzForTesting);
+
+        client.SetVfoAHz(50_000_000);
+        Assert.Equal((uint)50_000_050, client.CorrectedRxFreqHzForTesting);
+    }
+
+    [Fact]
+    public void Factor_Change_Affects_Next_Tune_Not_Current_Slot()
+    {
+        var client = NewClient();
+        client.SetFrequencyCorrectionFactor(1.0);
+        client.SetVfoAHz(14_250_000);
+        Assert.Equal((uint)14_250_000, client.CorrectedRxFreqHzForTesting);
+
+        client.SetFrequencyCorrectionFactor(1.000001);
+        // _rxFreqHz unchanged — RadioService is responsible for the re-tune.
+        Assert.Equal((uint)14_250_000, client.CorrectedRxFreqHzForTesting);
+
+        client.SetVfoAHz(14_250_000);
+        Assert.Equal((uint)14_250_014, client.CorrectedRxFreqHzForTesting);
+    }
+}

--- a/tests/Zeus.Server.Tests/RadioServiceFrequencyCorrectionTests.cs
+++ b/tests/Zeus.Server.Tests/RadioServiceFrequencyCorrectionTests.cs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+// Per-radio frequency calibration (issue #325) write-through + clamp
+// behaviour. Pins:
+//
+//   1. RadioService.SetFrequencyCorrectionFactor persists through the
+//      live store and is visible via Get on the next call.
+//   2. The factor survives a "process restart" — a second RadioService
+//      built on the same on-disk store sees the same value.
+//   3. Out-of-range values are clamped to ±100 ppm (factor ∈
+//      [0.9999, 1.0001]) instead of being persisted verbatim. Anything
+//      wider than this is almost certainly an operator mistake, not a
+//      real crystal-drift correction.
+//   4. NaN / Infinity throws (defensive — REST validators should reject
+//      these first, but a malformed call must not corrupt the store).
+public class RadioServiceFrequencyCorrectionTests : IDisposable
+{
+    private readonly string _dbPath;
+
+    public RadioServiceFrequencyCorrectionTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"zeus-prefs-freqcal-{Guid.NewGuid():N}.db");
+    }
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+        try { if (File.Exists(_dbPath + ".pa")) File.Delete(_dbPath + ".pa"); } catch { }
+        try { if (File.Exists(_dbPath + ".dsp")) File.Delete(_dbPath + ".dsp"); } catch { }
+    }
+
+    private PaSettingsStore NewPaStore() =>
+        new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, _dbPath + ".pa");
+
+    private DspSettingsStore NewDspStore() =>
+        new DspSettingsStore(NullLogger<DspSettingsStore>.Instance, _dbPath + ".dsp");
+
+    private RadioService BuildRadio(PreferredRadioStore prefs) =>
+        new RadioService(
+            NullLoggerFactory.Instance,
+            NewDspStore(),
+            NewPaStore(),
+            preferredRadioStore: prefs);
+
+    [Fact]
+    public void Default_Is_One()
+    {
+        using var prefs = new PreferredRadioStore(NullLogger<PreferredRadioStore>.Instance, _dbPath);
+        using var radio = BuildRadio(prefs);
+        Assert.Equal(1.0, radio.GetFrequencyCorrectionFactor());
+    }
+
+    [Fact]
+    public void Set_Round_Trips_Through_Service()
+    {
+        using var prefs = new PreferredRadioStore(NullLogger<PreferredRadioStore>.Instance, _dbPath);
+        using var radio = BuildRadio(prefs);
+
+        var applied = radio.SetFrequencyCorrectionFactor(1.000001);
+        Assert.Equal(1.000001, applied, precision: 9);
+        Assert.Equal(1.000001, radio.GetFrequencyCorrectionFactor(), precision: 9);
+        Assert.Equal(1.000001, prefs.GetFrequencyCorrectionFactor(), precision: 9);
+    }
+
+    [Fact]
+    public void Persists_Across_Simulated_Reconnect()
+    {
+        using (var prefs = new PreferredRadioStore(NullLogger<PreferredRadioStore>.Instance, _dbPath))
+        using (var radio = BuildRadio(prefs))
+        {
+            radio.SetFrequencyCorrectionFactor(0.999995);
+        }
+
+        using var prefs2 = new PreferredRadioStore(NullLogger<PreferredRadioStore>.Instance, _dbPath);
+        using var radio2 = BuildRadio(prefs2);
+        Assert.Equal(0.999995, radio2.GetFrequencyCorrectionFactor(), precision: 9);
+    }
+
+    [Theory]
+    [InlineData(1.5, 1.0001)]    // way too high → clamp to +100 ppm
+    [InlineData(0.5, 0.9999)]    // way too low  → clamp to -100 ppm
+    [InlineData(2.0, 1.0001)]
+    [InlineData(-1.0, 0.9999)]
+    public void Out_Of_Range_Factor_Is_Clamped(double input, double expected)
+    {
+        using var prefs = new PreferredRadioStore(NullLogger<PreferredRadioStore>.Instance, _dbPath);
+        using var radio = BuildRadio(prefs);
+
+        var applied = radio.SetFrequencyCorrectionFactor(input);
+        Assert.Equal(expected, applied, precision: 9);
+        Assert.Equal(expected, radio.GetFrequencyCorrectionFactor(), precision: 9);
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public void Non_Finite_Factor_Throws(double input)
+    {
+        using var prefs = new PreferredRadioStore(NullLogger<PreferredRadioStore>.Instance, _dbPath);
+        using var radio = BuildRadio(prefs);
+
+        Assert.Throws<ArgumentException>(() => radio.SetFrequencyCorrectionFactor(input));
+    }
+
+    [Fact]
+    public void In_Range_Factors_Are_Preserved_Verbatim()
+    {
+        using var prefs = new PreferredRadioStore(NullLogger<PreferredRadioStore>.Instance, _dbPath);
+        using var radio = BuildRadio(prefs);
+
+        // Boundary: exactly ±100 ppm should pass through unchanged.
+        Assert.Equal(1.0001, radio.SetFrequencyCorrectionFactor(1.0001), precision: 9);
+        Assert.Equal(0.9999, radio.SetFrequencyCorrectionFactor(0.9999), precision: 9);
+
+        // Realistic crystal drift: ~5 ppm.
+        Assert.Equal(1.000005, radio.SetFrequencyCorrectionFactor(1.000005), precision: 9);
+    }
+}

--- a/zeus-web/src/components/CalibrationPanel.tsx
+++ b/zeus-web/src/components/CalibrationPanel.tsx
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// CALIBRATION settings tab — per-radio frequency / clock-drift correction
+// (issue #325). Hosts the one-button auto-cal card. Future expansion
+// (separate cal slots for ext-10MHz reference, S-meter calibration,
+// etc.) lands here.
+
+import { FrequencyCalibrationCard } from './FrequencyCalibrationCard';
+
+export function CalibrationPanel() {
+  return (
+    <div className="ps-shell">
+      <FrequencyCalibrationCard />
+    </div>
+  );
+}

--- a/zeus-web/src/components/FrequencyCalibrationCard.tsx
+++ b/zeus-web/src/components/FrequencyCalibrationCard.tsx
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Per-radio frequency calibration card (issue #325). One-button auto-cal
+// modelled on Thetis's WWV procedure (console.cs:9779-9854):
+//   - Operator clicks "Calibrate"
+//   - Backend snapshots state, tunes to WWV 10 MHz, finds the spectral
+//     peak, computes the correction factor, and restores operator state
+//   - UI displays the resulting offset / ppm
+//
+// No manual entry — matches the Thetis / piHPSDR / deskHPSDR model
+// where the user never types a calibration number, the radio measures
+// the drift against a known reference.
+//
+// Visual idiom borrowed from the surrounding RadioOptionsPanel `.ps-card`
+// so this reads as the same surface family.
+
+import { useEffect } from 'react';
+import { useFrequencyCalibrationStore } from '../state/frequency-calibration-store';
+import { useConnectionStore } from '../state/connection-store';
+
+function formatPpm(ppm: number): string {
+  if (Math.abs(ppm) < 0.001) return '0.000 ppm';
+  return `${ppm >= 0 ? '+' : ''}${ppm.toFixed(3)} ppm`;
+}
+
+function formatOffsetHz(hz: number): string {
+  if (Math.abs(hz) < 0.05) return '0.0 Hz';
+  return `${hz >= 0 ? '+' : ''}${hz.toFixed(1)} Hz`;
+}
+
+export function FrequencyCalibrationCard() {
+  const state = useFrequencyCalibrationStore((s) => s.state);
+  const loaded = useFrequencyCalibrationStore((s) => s.loaded);
+  const inflight = useFrequencyCalibrationStore((s) => s.inflight);
+  const lastResult = useFrequencyCalibrationStore((s) => s.lastResult);
+  const error = useFrequencyCalibrationStore((s) => s.error);
+  const load = useFrequencyCalibrationStore((s) => s.load);
+  const calibrate = useFrequencyCalibrationStore((s) => s.calibrate);
+  const reset = useFrequencyCalibrationStore((s) => s.reset);
+
+  const connected = useConnectionStore((s) => s.status === 'Connected');
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const isCalibrated = Math.abs(state.factor - 1.0) > 1e-9;
+  const buttonLabel = inflight
+    ? 'CALIBRATING…'
+    : isCalibrated
+      ? 'RE-CALIBRATE'
+      : 'CALIBRATE';
+
+  const resultTone =
+    lastResult?.outcome === 'Success'
+      ? 'success'
+      : lastResult
+        ? 'warn'
+        : null;
+
+  return (
+    <div className="ps-card">
+      <h4>
+        <svg className="ps-ic-sm" viewBox="0 0 12 12">
+          <circle cx="6" cy="6" r="4" fill="none" />
+          <path d="M6 2v1M6 9v1M2 6h1M9 6h1" />
+          <circle cx="6" cy="6" r="1" />
+        </svg>
+        Frequency Calibration
+        <span className="ps-card-hint">
+          per-radio crystal-drift correction
+        </span>
+      </h4>
+
+      <div className="ps-field" style={{ display: 'block' }}>
+        <div className="ps-name" style={{ marginBottom: 8 }}>
+          Auto-calibrate against WWV 10 MHz
+          <em>
+            Click <strong>Calibrate</strong>. Zeus tunes the radio to WWV on
+            10.000 MHz (US standard frequency, broadcast 24/7 from Fort
+            Collins, Colorado), measures any offset on the panadapter, and
+            applies a correction factor so the dial matches the actual
+            transmitted frequency. Your VFO, mode, filter, and zoom are
+            restored automatically when the procedure finishes.
+          </em>
+        </div>
+
+        <div
+          className="freqcal-current"
+          style={{
+            display: 'flex',
+            alignItems: 'baseline',
+            justifyContent: 'space-between',
+            padding: '8px 10px',
+            background: 'var(--panel-bot)',
+            border: '1px solid var(--bevel-dark)',
+            borderRadius: 4,
+            marginBottom: 10,
+            fontFamily: '"Archivo Narrow", system-ui, sans-serif',
+          }}
+        >
+          <span style={{ opacity: 0.75 }}>Current correction</span>
+          <span style={{ color: isCalibrated ? 'var(--accent)' : 'inherit' }}>
+            {!loaded
+              ? '…'
+              : isCalibrated
+                ? `${formatOffsetHz(state.offsetHzAt10MHz)} @ 10 MHz  (${formatPpm(state.ppm)})`
+                : 'Uncalibrated'}
+          </span>
+        </div>
+
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button
+            type="button"
+            className="btn sm active"
+            onClick={() => calibrate()}
+            disabled={inflight || !connected}
+            style={{ flex: 1 }}
+            title={
+              connected
+                ? 'Tune to WWV 10 MHz, measure offset, apply correction'
+                : 'Connect a radio first'
+            }
+          >
+            {buttonLabel}
+          </button>
+          {isCalibrated && (
+            <button
+              type="button"
+              className="btn sm"
+              onClick={() => reset()}
+              disabled={inflight}
+              title="Clear the stored calibration (back to factory)"
+            >
+              RESET
+            </button>
+          )}
+        </div>
+
+        {!connected && (
+          <div
+            style={{
+              marginTop: 8,
+              fontSize: '0.85em',
+              opacity: 0.7,
+            }}
+          >
+            Connect a radio to enable calibration.
+          </div>
+        )}
+
+        {lastResult && (
+          <div
+            className={`freqcal-result freqcal-result-${resultTone}`}
+            style={{
+              marginTop: 10,
+              padding: '8px 10px',
+              borderLeft: `3px solid ${resultTone === 'success' ? 'var(--accent)' : 'var(--tx)'}`,
+              background: 'var(--panel-bot)',
+              borderRadius: 2,
+              fontSize: '0.9em',
+            }}
+          >
+            {lastResult.message}
+          </div>
+        )}
+
+        {error && (
+          <div
+            style={{
+              marginTop: 8,
+              color: 'var(--tx)',
+              fontSize: '0.85em',
+            }}
+          >
+            Error: {error}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/zeus-web/src/components/SettingsMenu.tsx
+++ b/zeus-web/src/components/SettingsMenu.tsx
@@ -23,6 +23,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { PaSettingsPanel } from './PaSettingsPanel';
 import { BandPlanEditor } from './bandplan/BandPlanEditor';
 import { AboutPanel } from './AboutPanel';
+import { CalibrationPanel } from './CalibrationPanel';
 import { DisplayPanel } from './DisplayPanel';
 import { QrzSettingsPanel } from './QrzSettingsPanel';
 import { RadioOptionsPanel } from './RadioOptionsPanel';
@@ -46,6 +47,7 @@ export type SettingsTabId =
   | 'display'
   | 'server'
   | 'radio'
+  | 'calibration'
   | 'about';
 
 const TABS: ReadonlyArray<{ id: SettingsTabId; label: string }> = [
@@ -59,6 +61,7 @@ const TABS: ReadonlyArray<{ id: SettingsTabId; label: string }> = [
   { id: 'display', label: 'DISPLAY' },
   { id: 'server', label: 'SERVER' },
   { id: 'radio', label: 'RADIO' },
+  { id: 'calibration', label: 'CALIBRATION' },
   { id: 'about', label: 'ABOUT' },
 ];
 
@@ -172,6 +175,7 @@ export function SettingsView({ initialTab, onClose }: Props) {
           {active === 'display' && <DisplayPanel />}
           {active === 'server' && <ServerUrlPanel />}
           {active === 'radio' && hasHl2OptionalToggles && <RadioOptionsPanel />}
+          {active === 'calibration' && <CalibrationPanel />}
           {active === 'about' && <AboutPanel />}
         </div>
       </div>

--- a/zeus-web/src/state/frequency-calibration-store.ts
+++ b/zeus-web/src/state/frequency-calibration-store.ts
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Per-radio frequency-calibration store (issue #325). Mirrors the
+// /api/radio/frequency-calibration surface:
+//
+//   GET                                 → current persisted factor + ppm
+//   POST /calibrate                     → run Thetis-style WWV auto-cal
+//   POST /reset                         → set factor back to 1.0
+//
+// The auto-cal procedure on the backend snapshots state, tunes to
+// 10 MHz USB, finds the spectral peak, computes the correction factor,
+// and restores state — operator types nothing.
+
+import { create } from 'zustand';
+
+export type CalibrationOutcome =
+  | 'Success'
+  | 'Busy'
+  | 'NotConnected'
+  | 'CaptureFailed'
+  | 'NoSignal'
+  | 'OffsetOutOfRange';
+
+export interface CalibrationState {
+  factor: number;
+  ppm: number;
+  offsetHzAt10MHz: number;
+}
+
+export interface CalibrationResult {
+  outcome: CalibrationOutcome;
+  offsetHz: number | null;
+  peakDb: number | null;
+  appliedFactor: number | null;
+  message: string;
+}
+
+const DEFAULT_STATE: CalibrationState = {
+  factor: 1.0,
+  ppm: 0,
+  offsetHzAt10MHz: 0,
+};
+
+function parseState(raw: unknown): CalibrationState {
+  if (!raw || typeof raw !== 'object') return DEFAULT_STATE;
+  const r = raw as Record<string, unknown>;
+  return {
+    factor: typeof r.factor === 'number' ? r.factor : 1.0,
+    ppm: typeof r.ppm === 'number' ? r.ppm : 0,
+    offsetHzAt10MHz:
+      typeof r.offsetHzAt10MHz === 'number' ? r.offsetHzAt10MHz : 0,
+  };
+}
+
+function parseResult(raw: unknown): CalibrationResult {
+  const fallback: CalibrationResult = {
+    outcome: 'CaptureFailed',
+    offsetHz: null,
+    peakDb: null,
+    appliedFactor: null,
+    message: 'Unexpected response from server.',
+  };
+  if (!raw || typeof raw !== 'object') return fallback;
+  const r = raw as Record<string, unknown>;
+  return {
+    outcome: (r.outcome as CalibrationOutcome) ?? fallback.outcome,
+    offsetHz: typeof r.offsetHz === 'number' ? r.offsetHz : null,
+    peakDb: typeof r.peakDb === 'number' ? r.peakDb : null,
+    appliedFactor:
+      typeof r.appliedFactor === 'number' ? r.appliedFactor : null,
+    message: typeof r.message === 'string' ? r.message : fallback.message,
+  };
+}
+
+type FrequencyCalibrationStore = {
+  state: CalibrationState;
+  loaded: boolean;
+  inflight: boolean;
+  lastResult: CalibrationResult | null;
+  error: string | null;
+  load: () => Promise<void>;
+  calibrate: () => Promise<void>;
+  reset: () => Promise<void>;
+};
+
+export const useFrequencyCalibrationStore = create<FrequencyCalibrationStore>(
+  (set) => ({
+    state: DEFAULT_STATE,
+    loaded: false,
+    inflight: false,
+    lastResult: null,
+    error: null,
+
+    load: async () => {
+      set({ inflight: true, error: null });
+      try {
+        const res = await fetch('/api/radio/frequency-calibration');
+        if (!res.ok) throw new Error(`GET → ${res.status}`);
+        set({
+          state: parseState(await res.json()),
+          loaded: true,
+          inflight: false,
+        });
+      } catch (err) {
+        set({
+          error: err instanceof Error ? err.message : String(err),
+          inflight: false,
+        });
+      }
+    },
+
+    calibrate: async () => {
+      set({ inflight: true, error: null, lastResult: null });
+      try {
+        const res = await fetch(
+          '/api/radio/frequency-calibration/calibrate',
+          { method: 'POST' },
+        );
+        if (!res.ok) throw new Error(`POST /calibrate → ${res.status}`);
+        const result = parseResult(await res.json());
+        set({ lastResult: result, inflight: false });
+        // Re-load the current factor regardless of outcome — Success
+        // moved it, the failure paths left it alone, but either way the
+        // UI displays the canonical persisted value next.
+        const stateRes = await fetch('/api/radio/frequency-calibration');
+        if (stateRes.ok) set({ state: parseState(await stateRes.json()) });
+      } catch (err) {
+        set({
+          error: err instanceof Error ? err.message : String(err),
+          inflight: false,
+        });
+      }
+    },
+
+    reset: async () => {
+      set({ inflight: true, error: null });
+      try {
+        const res = await fetch('/api/radio/frequency-calibration/reset', {
+          method: 'POST',
+        });
+        if (!res.ok) throw new Error(`POST /reset → ${res.status}`);
+        set({
+          state: parseState(await res.json()),
+          lastResult: null,
+          inflight: false,
+        });
+      } catch (err) {
+        set({
+          error: err instanceof Error ? err.message : String(err),
+          inflight: false,
+        });
+      }
+    },
+  }),
+);


### PR DESCRIPTION
Tracks #325 (stays open until the next release-merge to main, per release-hygiene policy).

## Summary

Per-radio frequency-correction factor matching the Thetis / piHPSDR / deskHPSDR model: a dimensionless multiplicative scalar near 1.0 applied host-side at the Protocol-1 and Protocol-2 `SetVfoAHz` seams, persisted per radio in `PreferredRadioStore`, applied to the wire **without touching any clock or sample-rate register**.

One-button auto-cal modelled on Thetis's WWV procedure (`console.cs:9779-9854`):

1. Operator clicks **Calibrate** in Settings → CALIBRATION.
2. Backend snapshots operator state (VFO / mode / filter / zoom).
3. Tunes to WWV 10 MHz USB at zoom 16, settles 1.5 s.
4. Captures the panadapter, finds the spectral peak.
5. Computes `factor = 1 + offsetHz / 10e6`, applies clamp ±100 ppm.
6. Persists factor via `RadioService.SetFrequencyCorrectionFactor` (write-through to store, push to live P1/P2 client, re-tune so the new factor lands on the wire immediately).
7. Restores operator state in `finally`.

Operator types nothing.

## Per-board scope

Applies to every Protocol-1 board (Radioberry / Hermes / ANAN-10 / ANAN-10E / ANAN-100B / ANAN-100D / ANAN-200D / OrionMkII variants / HermesC10 / HL2 / Metis) and every Protocol-2 board through the same shared apply site in their respective protocol clients. Zero per-board branching — every HPSDR board accepts the same Hz payload at its NCO seam.

## Implementation map

### Backend (Zeus.Server.Hosting + Zeus.Protocol1 + Zeus.Protocol2)

| Touch point | Change |
|---|---|
| `PreferredRadioStore.cs` | New `FrequencyCorrectionFactor` double column on `PreferredRadioEntry`; `Get/SetFrequencyCorrectionFactor` accessors following the `EnableHl2BandVolts` pattern. LiteDB 0.0-hydrate of pre-#325 rows treated as "unset" → returns 1.0 so upgrading operators see no tuning shift. |
| `Protocol1Client.cs` | `_freqCorrectionBits` stored as int64-of-double for atomic `Interlocked.Exchange`; `SetVfoAHz` mutates incoming hz by factor before the wire-bound `_vfoAHz` slot. New `SetFrequencyCorrectionFactor(double)` and `FrequencyCorrectionFactor` accessor. |
| `Protocol2Client.cs` | Same pattern; correction applied before `_rxFreqHz` clamp so the NCO phase-word at line 977 picks up the corrected value. Internal `CorrectedRxFreqHzForTesting` seam. |
| `RadioService.cs` | New `Get/SetFrequencyCorrectionFactor`, `FrequencyCorrectionFactorChanged` event. Set method clamps to ±100 ppm, writes through to store, pushes to active P1, raises event for P2, re-tunes via `SetVfo(currentDial)`. Connect-time rehydration into the fresh P1 client. |
| `DspPipelineService.cs` | Subscribes to `FrequencyCorrectionFactorChanged` and forwards to `_p2Client`. `ConnectP2Async` rehydrates factor before `StartAsync`. New `TryCapturePanadapterSnapshot` exposes the latest pan column for auto-cal peak detection. |
| `FrequencyCalibrationService.cs` (new, 230 LOC) | One-shot procedure with `SemaphoreSlim` re-entry guard, configurable reference frequency (default 10 MHz), sanity bounds on peak strength (-90 dBFS noise floor) and offset (±1 kHz at 10 MHz), restore-on-failure via try/finally. |
| `ZeusEndpoints.cs` | New `/api/radio/frequency-calibration` { GET, /calibrate POST, /reset POST } endpoints. **No Zeus.Contracts DTO/wire-format change.** |
| `ZeusHost.cs` | `FrequencyCalibrationService` registered as singleton. |

### Frontend (zeus-web)

| Touch point | Change |
|---|---|
| `state/frequency-calibration-store.ts` (new) | Zustand store mirroring the REST surface. Parses the discriminated `CalibrationResult` outcome (Success / Busy / NotConnected / CaptureFailed / NoSignal / OffsetOutOfRange) for status display. |
| `components/FrequencyCalibrationCard.tsx` (new) | Single **Calibrate** button (disabled when not connected), live status feedback, current correction read-out (`+X Hz @ 10 MHz, +Y ppm`), **Reset** button when calibrated. Uses existing tokens.css palette only. |
| `components/CalibrationPanel.tsx` (new) | Thin wrapper hosting the card; reserved for future cal surfaces (ext 10 MHz ref, S-meter cal). |
| `components/SettingsMenu.tsx` | Adds `CALIBRATION` tab — always visible (every radio has a crystal that drifts). |

### Tests (23 new, all green)

- `Zeus.Protocol1.Tests/FrequencyCorrectionTests.cs` (6) — math, scaling across HF, factor-change non-destructiveness, default factor.
- `Zeus.Protocol2.Tests/FrequencyCorrectionTests.cs` (6) — same math on the P2 surface via internal test seam.
- `Zeus.Server.Tests/RadioServiceFrequencyCorrectionTests.cs` (11) — round-trip, persistence across simulated reconnect, ±100 ppm clamp, NaN/Infinity rejection.

Full suite: `dotnet test Zeus.slnx` → 1003 passed, 0 failed in code I touched. (16 pre-existing failures in `Zeus.PluginHost.Tests` are unrelated — require the C++ sidecar binary which isn't built locally, verified against the develop baseline.)

Frontend: `npm run build` clean, `npm test` 208 / 208 passing.

## What's NOT in this PR

Deliberately deferred per the issue's "out of scope" list:

- Automatic reference-frequency selection (5 / 10 / 15 / 20 MHz WWV / WWVH). Hard-coded 10 MHz default.
- External 10 MHz reference (`Using ext 10MHz ref` Thetis checkbox).
- Per-band calibration tables.
- XVTR / transverter offsets.

## Test plan

- [ ] Bench-test on HL2: connect, click Calibrate, confirm the corrected dial frequency matches what the AD9866 actually tunes to (per CLAUDE.md HL2-bench-test rule).
- [ ] Bench-test on G2 (Protocol 2): same — auto-cal should land WWV on the dial within a few Hz.
- [ ] Verify state restore: after a successful cal, confirm VFO / mode / filter / zoom are back to where they started.
- [ ] Verify failure path: at a time / location with no WWV reception, confirm the procedure reports "No signal" and leaves the persisted factor unchanged.
- [ ] Verify reset: click Reset, confirm factor → 1.0 and the dial reverts to its uncorrected value.
- [ ] Verify persistence: cal → restart backend → confirm factor survives.
