### PR TITLE
fix(pa): Hermes/HermesII/Metis MaxPowerWatts 10 → 100 (Brick2 "1 W at max TUN")

### DIFF
--- a/Zeus.Server.Hosting/PaDefaults.cs
+++ b/Zeus.Server.Hosting/PaDefaults.cs
@@ -164,9 +164,19 @@ internal static class PaDefaults
     public static int GetMaxPowerWatts(HpsdrBoardKind board, OrionMkIIVariant variant) => board switch
     {
         HpsdrBoardKind.HermesLite2 => 5,      // HL2: class-A 5 W stock
-        HpsdrBoardKind.Hermes      => 10,     // Hermes / ANAN-10 / ANAN-10E: 10 W
-        HpsdrBoardKind.Metis       => 10,     // Metis boards paired with 10 W PA
-        HpsdrBoardKind.HermesII     => 10,
+        // Hermes / Metis / HermesII share the 100 W "HermesGains" PA-gain
+        // bracket lifted from Thetis setup.cs:482-544. Those gains assume a
+        // 100 W output target — Thetis's drive slider is 0..100 *watts*, so
+        // slider=100 → 100 W target → byte=255 regardless of whether the
+        // physical radio is a 10 W ANAN-10 / Brick2 or a 100 W build (the
+        // radio just self-clamps to its rated max). Zeus's slider is a
+        // percent of MaxWatts, so MaxWatts must match the gain-bracket
+        // assumption (100) — not the radio's rated output — or 100 % drive
+        // asks the DAC for 10× too little and a 10 W radio puts out ~1 W
+        // at "max TUNE". See docs/lessons/hermes-pa-maxwatts.md.
+        HpsdrBoardKind.Hermes      => 100,    // Hermes / ANAN-10 / Brick2
+        HpsdrBoardKind.Metis       => 100,    // Metis paired with HermesGains bracket
+        HpsdrBoardKind.HermesII     => 100,    // HermesII / ANAN-10E
         HpsdrBoardKind.Angelia     => 100,    // ANAN-100 / ANAN-100B / ANAN-8000D: 100 W
         HpsdrBoardKind.Orion       => 100,    // ANAN-100D / ANAN-200D: 100 W
         HpsdrBoardKind.OrionMkII   => variant switch

--- a/docs/lessons/hermes-pa-maxwatts.md
+++ b/docs/lessons/hermes-pa-maxwatts.md
@@ -1,0 +1,104 @@
+# Hermes / Brick2 / ANAN-10(E) — `MaxPowerWatts` must match the gain-bracket assumption, not the rated output
+
+Load-bearing invariant for anyone touching `PaDefaults.GetMaxPowerWatts`,
+the `HermesGains` table, or the drive-byte math in
+`RadioDriveProfile.cs:DriveByteMath.ComputeFullByte`. Misreading this
+makes a Brick2 (or any Hermes-class 10 W radio) put out **~1 W at max
+TUN** while every meter in Zeus says "100 %".
+
+## TL;DR
+
+Thetis's drive slider is **0..100 watts** (a target output in real
+watts). Zeus's slider is **0..100 percent of `MaxPowerWatts`**. The
+`HermesGains` PA-gain bracket (38.8 dB on 10 m) was lifted from Thetis
+`setup.cs:482-544`, which calibrates that gain assuming a **100 W
+target**. Drive byte = 255 then corresponds to 100 W at the antenna —
+the physical radio just self-clamps to whatever it can actually deliver.
+
+If you set Zeus's `MaxPowerWatts = 10` for a Hermes-class board (the
+rated output of an ANAN-10 / ANAN-10E / Brick2), the percent-of-max
+math asks the DAC for **10 W** at slider=100, which through 38.8 dB of
+PA gain is a 1.3 mW (-29 dBm) DAC ask → byte ≈ 82 → ~32 % of full DAC
+amplitude → ~10 % of full power → **~1 W** out of a radio rated for 10 W.
+
+The fix is `MaxPowerWatts = 100` for Hermes / HermesII / Metis. The
+radio's rated max is **not** what this field means — it's the calibrated
+output that pairs with the gain bracket so byte=255 at slider=100.
+
+## The symptom
+
+- Brick2 / ANAN-10E / ANAN-10 puts out ~1 W at max TUN on every HF band.
+- Drive slider at 100 % during MOX produces the same ~1 W.
+- `pa.recompute` log in `RadioService.RecomputePaAndPush` shows
+  `byte=82 pct=100 gainDb=38.8 maxW=10` on 10 m — math is consistent,
+  it's the inputs that are wrong.
+
+## Why the two clients disagree on slider semantics
+
+In Thetis (`console.cs:46724` `SetPowerUsingTargetDBM`):
+
+    new_pwr      = slider.Value                   // 0..100 *WATTS*
+    target_dbm   = 10 * log10(new_pwr * 1000)
+    target_dbm  -= GainByBand(band, new_pwr)
+    target_volts = sqrt(10^(target_dbm/10) * 0.05)
+    RadioVolume  = min(target_volts / 0.8, 1.0)
+    // NetworkIO.SetOutputPower(RadioVolume * 1.02)
+    //   → wire byte = (int)(255 * value * swr_protect)
+
+Slider=100 → 100 W target → byte=255 regardless of whether the radio is
+physically 10 W or 100 W. A 10 W radio just hits its own ceiling.
+
+In Zeus (`RadioDriveProfile.cs:DriveByteMath.ComputeFullByte`):
+
+    targetWatts = MaxPowerWatts * drivePct / 100
+    sourceWatts = targetWatts / 10^(paGainDb/10)
+    sourceVolts = sqrt(sourceWatts * 50)
+    norm        = clamp(sourceVolts / 0.8, 0, 1)
+    driveByte   = round(norm * 255)
+
+If `MaxPowerWatts = 10` and the gain bracket assumes 100 W at byte=255,
+the operator can never reach byte=255 — the math caps at 1/10 the
+amplitude (≈ byte 82, which is sqrt(1/10) × 255 ≈ 80).
+
+## Rule for new boards
+
+When seeding `PaDefaults.GetMaxPowerWatts`:
+
+- **`MaxPowerWatts` is the target watts at which the chosen gain bracket
+  reaches byte=255.** Set it to whatever the Thetis bracket you copied
+  from was calibrated against (typically 100 for HF, 200 for 8000DLE,
+  1000 for G2-1K). Do **not** set it to the physical radio's rated
+  output unless the gain bracket was also calibrated for that output.
+- HL2 is the exception — its `IRadioDriveProfile` does not consult
+  `MaxPowerWatts` at all, so the field is cosmetic on that board and
+  the rated 5 W is fine (see `hl2-drive-model.md`).
+
+## Verifying a new board
+
+1. Pick a band — 10 m is convenient because most boards have a
+   `HermesGains["10m"]`-like 38–47 dB seed there.
+2. Compute the byte the math produces at `drivePct=100`. With
+   `MaxPowerWatts=100`, `paGainDb=38.8`, `drivePct=100`:
+
+        targetWatts = 100
+        sourceWatts = 100 / 7586 = 0.01318
+        sourceVolts = sqrt(0.01318 * 50) = 0.812
+        norm        = min(0.812/0.8, 1) = 1.0
+        driveByte   = 255  ✓
+
+3. On the wire, the `p1.tx.rate` log line (`Protocol1Client.TxLoopAsync`)
+   reports `drv=255` at the EP2 packer when MOX/TUN is keyed at max
+   drive. If `drv` saturates well below 255 at 100 % slider, the
+   `MaxPowerWatts` / `PaGainDb` pair don't match the gain bracket — fix
+   one before recalibrating per-band gains.
+
+## References
+
+- Thetis `console.cs:46724-46842` — `SetPowerUsingTargetDBM` (slider-watts → bytes).
+- Thetis `audio.cs:262-271` — `RadioVolume` setter → `NetworkIO.SetOutputPower`.
+- Thetis `HPSDR/NetworkIO.cs:199-212` — drive-byte serialisation.
+- Thetis `setup.cs:482-544` — HERMES / HPSDR / ORIONMKII / ANAN10 /
+  ANAN10E PA-gain bracket (the source of `HermesGains`).
+- `RadioDriveProfile.cs` (Zeus) — `DriveByteMath.ComputeFullByte`.
+- `PaDefaults.cs` (Zeus) — `GetMaxPowerWatts` / `HermesGains`.
+- `hl2-drive-model.md` — the analogous lesson for HL2's percentage model.

--- a/tests/Zeus.Server.Tests/PaSettingsStoreDefaultsTests.cs
+++ b/tests/Zeus.Server.Tests/PaSettingsStoreDefaultsTests.cs
@@ -67,6 +67,27 @@ public class PaSettingsStoreDefaultsTests : IDisposable
         Assert.Equal(38.8, FindGain(s, "10m"));
     }
 
+    [Theory]
+    [InlineData(HpsdrBoardKind.Hermes)]
+    [InlineData(HpsdrBoardKind.HermesII)]
+    [InlineData(HpsdrBoardKind.Metis)]
+    public void HermesClass_MaxPowerWatts_Matches_GainBracket_Assumption(HpsdrBoardKind board)
+    {
+        // The HermesGains bracket (HermesGains["10m"] = 38.8 dB) was lifted
+        // from Thetis setup.cs:482-544, which calibrates for a 100 W output
+        // target. Thetis's drive slider is 0..100 *watts*, so slider=100 →
+        // 100 W target → byte=255, regardless of the radio's rated max (the
+        // radio self-clamps). Zeus's slider is a percent of MaxWatts, so
+        // MaxWatts must match the bracket assumption (100), not the rated
+        // output, or 100 % drive asks the DAC for 10× too little and a
+        // physically-10 W radio (ANAN-10 / ANAN-10E / Brick2) makes ~1 W at
+        // max TUNE. Regression pin for the issue.
+        using var store = NewStore();
+        var d = store.GetDefaults(board);
+        Assert.Equal(100, d.Global.PaMaxPowerWatts);
+        Assert.Equal(38.8, FindGain(d, "10m"));
+    }
+
     [Fact]
     public void OrionMkII_Uses_G2_Class_Defaults()
     {


### PR DESCRIPTION
## Summary

Hermes / HermesII / Metis seed `PaMaxPowerWatts = 10` in `PaDefaults`, but the `HermesGains` PA-gain bracket they share (38.8 dB on 10 m) was lifted from Thetis `setup.cs:482-544` which calibrates that gain against a **100 W target**. Zeus's drive slider is "percent of `MaxPowerWatts`" (Thetis's is "0..100 watts"), so with `MaxPowerWatts=10` the slider at 100 % only ever asks the DAC for 10 % of the amplitude Thetis would. Result: a 10 W Hermes-class radio (ANAN-10, ANAN-10E, **Brick2**) puts out **~1 W at max TUN**.

This bumps `MaxPowerWatts` to 100 on those three boards so byte=255 is reachable at slider=100; physical 10 W radios just self-clamp to their rated max, same as in Thetis.

Math reproducing the symptom on Brick2 (announces as Hermes `0x01` on P2 via deskhpsdr), 10 m, TUN drive=100 %, pre-fix:

```
targetWatts = MaxPowerWatts * pct/100 = 10 * 100/100 = 10
sourceWatts = 10 / 10^(38.8/10)       = 0.00132
sourceVolts = sqrt(0.00132 * 50)      = 0.257 V
norm        = 0.257 / 0.8             = 0.321
driveByte   = round(0.321 * 255)      = 82      ← only 32 % of full DAC amplitude
```

Thetis sends byte=255 for the same hardware/band/slider — `console.cs:46724` `SetPowerUsingTargetDBM` + `audio.cs:262` `RadioVolume` + `HPSDR/NetworkIO.cs:199` `SetOutputPower`. After this fix Zeus's math reaches byte=255 at slider=100 too.

## Scope

- `Zeus.Server.Hosting/PaDefaults.cs` — three switch arms (`Hermes`, `Metis`, `HermesII`) from `10` to `100`, plus a block comment explaining the slider-watts vs slider-percent semantic mismatch and why "rated output" is not what this field means.
- `tests/Zeus.Server.Tests/PaSettingsStoreDefaultsTests.cs` — new `[Theory]` pinning `MaxPowerWatts == 100` and `PaGainDb["10m"] == 38.8` for all three boards.
- `docs/lessons/hermes-pa-maxwatts.md` — new lesson explaining the math and the rule for seeding `MaxPowerWatts` on future boards (paired with the existing `hl2-drive-model.md`).

Unaffected:
- `HermesLite2` — `HermesLite2DriveProfile` ignores `MaxPowerWatts` entirely (percentage-based model).
- `Angelia` / `Orion` / `OrionMkII*` / `HermesC10` — already at 100 W (or per-variant ratings), already consistent with their respective gain brackets.

## Operator-visible impact (red-light per CLAUDE.md)

This **is** a default-value change that operators will feel:

- On Hermes-class boards, the drive slider now sweeps the full power range. Pre-fix the slider topped out at ~10 % of available drive amplitude even at 100 %.
- TUN power at the default `_tunePct = 10` is also affected proportionally (operators using the default TUN-drive setting will see a louder TUN carrier).
- No-op for HL2, ANAN-100/100B/100D/200D, G2 / G2-1K / 8000DLE, ANAN-G2E.

Flagging for maintainer review per the "Default values" red-light rule in `CLAUDE.md` — please confirm before merge.

## Test plan

- [x] `dotnet build Zeus.slnx` — 0 errors, 0 warnings
- [x] `dotnet test Zeus.slnx` — 694 passed, 0 failed, 101 skipped (WDSP-gated)
- [x] New regression test pins `MaxPowerWatts == 100` for Hermes / HermesII / Metis
- [ ] Bench verification on Brick2 — 10 W radio should now hit nameplate at slider=100 (not 1 W)
- [ ] Bench verification on a 100 W Hermes-class radio if available — no change expected; byte=255 already reachable through clamping at any reasonable per-band cal

## References

- Thetis `console.cs:46724-46842` — `SetPowerUsingTargetDBM` (slider-in-watts → drive byte)
- Thetis `audio.cs:262-271` + `HPSDR/NetworkIO.cs:199-212` — drive byte serialisation
- Thetis `setup.cs:482-544` — HERMES / HPSDR / ANAN10 / ANAN10E PA-gain bracket (source of `HermesGains`)
- `docs/lessons/hermes-pa-maxwatts.md` (new) — analogous to `hl2-drive-model.md`