### PR TITLE
feat(theming): light theme + operator-tweakable colour palette

### DIFF
--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -63,6 +63,7 @@ import { PaTempChip } from './components/PaTempChip';
 import { QrzStatusPill } from './components/QrzStatusPill';
 import { RotatorStatusPill } from './components/RotatorStatusPill';
 import { SettingsView, type SettingsTabId } from './components/SettingsMenu';
+import { ThemeApplier } from './components/ThemeApplier';
 import { StepFavorites } from './components/toolbar/StepFavorites';
 import { TunButton } from './components/TunButton';
 import { BOARD_LABELS } from './api/radio';
@@ -642,6 +643,7 @@ export default function App() {
   if (isMobile) {
     return (
       <SpectrumWheelActionsContext.Provider value={spectrumWheelActions}>
+        <ThemeApplier />
         <MobileApp />
       </SpectrumWheelActionsContext.Provider>
     );
@@ -651,6 +653,7 @@ export default function App() {
     <BandPlanProvider>
     <WorkspaceContext.Provider value={workspaceCtx}>
     <SpectrumWheelActionsContext.Provider value={spectrumWheelActions}>
+    <ThemeApplier />
     <div className="app" data-screen-label="01 Main Console" style={{ position: 'relative' }}>
       {/* Left layout bar — issue #241. Spans the full app height; lists named
           layouts for the active radio with switch/add/delete/reset actions. */}

--- a/zeus-web/src/components/DisplayPanel.tsx
+++ b/zeus-web/src/components/DisplayPanel.tsx
@@ -14,11 +14,13 @@
 // in issue #241 — layout switching now lives entirely in the LeftLayoutBar.
 
 import { BackgroundSettingsPanel } from './BackgroundSettingsPanel';
+import { ThemeSettingsPanel } from './ThemeSettingsPanel';
 import { TraceColorPanel } from './TraceColorPanel';
 
 export function DisplayPanel() {
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 22 }}>
+      <ThemeSettingsPanel />
       <BackgroundSettingsPanel />
       <TraceColorPanel />
     </div>

--- a/zeus-web/src/components/ThemeApplier.tsx
+++ b/zeus-web/src/components/ThemeApplier.tsx
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+// See LICENSE for the full GPL text.
+
+import { useEffect, useMemo } from 'react';
+import { useThemeStore } from '../state/theme-store';
+
+// ThemeApplier — single mounted instance (in App.tsx) that:
+//   1. sets `data-theme` on <html> when the operator picks Dark / Light;
+//   2. injects a runtime <style> tag with `:root { --accent: #...; … }`
+//      so any operator colour overrides cascade *under* both theme overlays.
+//
+// Renders nothing visible. Kept as a top-level mount rather than a side
+// effect in App.tsx so the initial state (read from localStorage in the
+// store factory) lands on <html> before the first paint of the workspace.
+
+export function ThemeApplier(): null {
+  const theme = useThemeStore((s) => s.theme);
+  const overrides = useThemeStore((s) => s.overrides);
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+  }, [theme]);
+
+  // Build the override CSS body once per change. Empty overrides → empty
+  // rule, which is harmless. We keep this as a memoised string so React
+  // doesn't re-create the textContent of the <style> tag every render.
+  const css = useMemo(() => {
+    const entries = Object.entries(overrides);
+    if (entries.length === 0) return '';
+    const decls = entries
+      .map(([k, v]) => `  ${k}: ${v};`)
+      .join('\n');
+    return `:root {\n${decls}\n}\n`;
+  }, [overrides]);
+
+  useEffect(() => {
+    const id = 'zeus-theme-overrides';
+    let tag = document.getElementById(id) as HTMLStyleElement | null;
+    if (!tag) {
+      tag = document.createElement('style');
+      tag.id = id;
+      // Appending to <head> last keeps these declarations after tokens.css
+      // (which is imported at module load), so the overrides win the
+      // cascade against both the :root defaults and the [data-theme="light"]
+      // block.
+      document.head.appendChild(tag);
+    }
+    tag.textContent = css;
+  }, [css]);
+
+  return null;
+}

--- a/zeus-web/src/components/ThemeSettingsPanel.tsx
+++ b/zeus-web/src/components/ThemeSettingsPanel.tsx
@@ -1,0 +1,381 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+// See LICENSE for the full GPL text.
+
+import type { CSSProperties } from 'react';
+import {
+  TWEAKABLE_TOKENS,
+  useThemeStore,
+  type ThemeId,
+  type TweakableToken,
+} from '../state/theme-store';
+
+// Operator-facing label + default colour per tweakable token. The default
+// is the value that ships in tokens.css for the DARK theme; that's what
+// resetting an override falls back to (the light overlay then re-skins
+// surface colours independently). Keep this aligned with tokens.css —
+// the colour rectangle in the picker only matches when the default
+// matches the stylesheet.
+const TOKEN_META: Record<
+  TweakableToken,
+  { label: string; help: string; default: string }
+> = {
+  '--accent': {
+    label: 'Accent',
+    help: 'Active controls, selection rings, sidebar highlight.',
+    default: '#0c5f9c',
+  },
+  '--accent-bright': {
+    label: 'Accent (bright)',
+    help: 'Highlighted text — VFO label, value digits.',
+    default: '#4ea6ff',
+  },
+  '--tx': {
+    label: 'TX',
+    help: 'MOX / ON-AIR red, gain-reduction caps.',
+    default: '#ff4a59',
+  },
+  '--power': {
+    label: 'Power',
+    help: 'Forward-power, drive digits, yellow accents.',
+    default: '#ffb13c',
+  },
+  '--amber': {
+    label: 'Amber',
+    help: 'Warning band on meters, warm halo around LEDs.',
+    default: '#ffb13c',
+  },
+  '--cyan': {
+    label: 'Cyan',
+    help: 'Secondary signal indicators, scope grid.',
+    default: '#4dc9ff',
+  },
+  '--ok': {
+    label: 'OK / Green',
+    help: 'Healthy state, lower band of meter ramps.',
+    default: '#2dd566',
+  },
+  '--orange': {
+    label: 'Orange',
+    help: 'Mid band on meter ramps, intermediate signals.',
+    default: '#ff8a3c',
+  },
+};
+
+const THEME_OPTIONS: ReadonlyArray<{
+  id: ThemeId;
+  label: string;
+  blurb: string;
+  swatch: string;
+}> = [
+  {
+    id: 'dark',
+    label: 'Dark',
+    blurb: 'Near-black chrome, lit-display feel. The original Zeus aesthetic.',
+    swatch: '#0a0a0c',
+  },
+  {
+    id: 'light',
+    label: 'Light',
+    blurb: 'Brushed-silver chassis with dark display wells. Day-shack mode.',
+    swatch: '#c4c8ce',
+  },
+];
+
+function isHexColor(v: string): boolean {
+  return /^#[0-9A-Fa-f]{6}$/.test(v);
+}
+
+export function ThemeSettingsPanel() {
+  const theme = useThemeStore((s) => s.theme);
+  const overrides = useThemeStore((s) => s.overrides);
+  const setTheme = useThemeStore((s) => s.setTheme);
+  const setOverride = useThemeStore((s) => s.setOverride);
+  const resetOverrides = useThemeStore((s) => s.resetOverrides);
+
+  const hasOverrides = Object.keys(overrides).length > 0;
+
+  return (
+    <section style={{ display: 'flex', flexDirection: 'column', gap: 22 }}>
+      <div>
+        <div style={sectionHead}>
+          <h3 style={sectionH3}>Theme</h3>
+          <p style={sectionP}>
+            Pick the workspace look. Display surfaces (panadapter, gauges,
+            VFO) stay dark in both themes so signals stay readable.
+          </p>
+        </div>
+
+        <div style={themeGrid}>
+          {THEME_OPTIONS.map((opt) => {
+            const active = theme === opt.id;
+            return (
+              <button
+                key={opt.id}
+                type="button"
+                aria-pressed={active}
+                onClick={() => setTheme(opt.id)}
+                style={themeCard(active)}
+              >
+                <span style={{ ...themeSwatch, background: opt.swatch }} />
+                <span style={themeCardBody}>
+                  <span style={themeLabel}>{opt.label}</span>
+                  <span style={themeBlurb}>{opt.blurb}</span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div>
+        <div style={sectionHead}>
+          <h3 style={sectionH3}>Colour palette</h3>
+          <p style={sectionP}>
+            Tweak any of the accent colours. Changes apply to both themes.
+            Clearing a value (Reset) restores the default for that token.
+          </p>
+        </div>
+
+        <div style={paletteList}>
+          {TWEAKABLE_TOKENS.map((tok) => {
+            const meta = TOKEN_META[tok];
+            const overridden = overrides[tok];
+            const current = (overridden ?? meta.default).toUpperCase();
+            return (
+              <div key={tok} style={paletteRow}>
+                <div style={paletteLabels}>
+                  <span style={paletteLabel}>{meta.label}</span>
+                  <span style={paletteHelp}>{meta.help}</span>
+                </div>
+                <div style={paletteControls}>
+                  <input
+                    type="color"
+                    value={current}
+                    onChange={(e) =>
+                      setOverride(tok, e.target.value.toUpperCase())
+                    }
+                    style={pickerStyle}
+                    aria-label={`${meta.label} colour`}
+                  />
+                  <input
+                    type="text"
+                    value={current}
+                    onChange={(e) => {
+                      const raw = e.target.value.trim();
+                      const v = raw.startsWith('#') ? raw : `#${raw}`;
+                      if (isHexColor(v)) setOverride(tok, v.toUpperCase());
+                    }}
+                    maxLength={7}
+                    spellCheck={false}
+                    style={hexInput}
+                    aria-label={`${meta.label} hex value`}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setOverride(tok, null)}
+                    disabled={!overridden}
+                    style={resetBtn(!!overridden)}
+                    title="Restore default"
+                  >
+                    Reset
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div style={footerRow}>
+          <button
+            type="button"
+            onClick={resetOverrides}
+            disabled={!hasOverrides}
+            style={resetAllBtn(hasOverrides)}
+          >
+            Reset all colours
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+const sectionHead: CSSProperties = {
+  display: 'flex',
+  alignItems: 'baseline',
+  flexWrap: 'wrap',
+  gap: 10,
+  marginBottom: 12,
+};
+const sectionH3: CSSProperties = {
+  margin: 0,
+  fontSize: 11,
+  fontWeight: 700,
+  letterSpacing: '0.18em',
+  textTransform: 'uppercase',
+  color: 'var(--fg-0)',
+};
+const sectionP: CSSProperties = {
+  margin: 0,
+  fontSize: 12,
+  lineHeight: 1.5,
+  color: 'var(--fg-2)',
+};
+
+const themeGrid: CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(2, 1fr)',
+  gap: 10,
+};
+
+function themeCard(active: boolean): CSSProperties {
+  return {
+    display: 'flex',
+    gap: 12,
+    padding: 14,
+    background: active ? 'var(--bg-2)' : 'var(--bg-1)',
+    border: `1.5px solid ${active ? 'var(--accent)' : 'var(--line)'}`,
+    borderRadius: 'var(--r-md)',
+    cursor: 'pointer',
+    textAlign: 'left',
+    transition: 'border-color var(--dur-fast), background var(--dur-fast)',
+    boxShadow: active
+      ? '0 0 0 3px rgba(46,142,255,0.18)'
+      : 'inset 0 0 0 1px rgba(255,255,255,0.02)',
+  };
+}
+
+const themeSwatch: CSSProperties = {
+  width: 36,
+  height: 36,
+  flex: 'none',
+  borderRadius: 'var(--r-sm)',
+  border: '1px solid var(--line-strong)',
+  boxShadow: 'inset 0 0 0 1px rgba(255,255,255,0.06)',
+};
+
+const themeCardBody: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 4,
+  minWidth: 0,
+};
+
+const themeLabel: CSSProperties = {
+  fontSize: 13,
+  fontWeight: 600,
+  color: 'var(--fg-0)',
+  letterSpacing: '0.04em',
+};
+
+const themeBlurb: CSSProperties = {
+  fontSize: 11,
+  lineHeight: 1.4,
+  color: 'var(--fg-2)',
+};
+
+const paletteList: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  border: '1px solid var(--line)',
+  borderRadius: 'var(--r-md)',
+  background: 'var(--bg-1)',
+  overflow: 'hidden',
+};
+
+const paletteRow: CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: '1fr auto',
+  alignItems: 'center',
+  gap: 14,
+  padding: '11px 14px',
+  borderTop: '1px solid var(--line-soft)',
+};
+
+const paletteLabels: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 3,
+  minWidth: 0,
+};
+
+const paletteLabel: CSSProperties = {
+  fontSize: 12,
+  fontWeight: 600,
+  letterSpacing: '0.04em',
+  color: 'var(--fg-0)',
+};
+
+const paletteHelp: CSSProperties = {
+  fontSize: 11,
+  color: 'var(--fg-2)',
+  lineHeight: 1.4,
+};
+
+const paletteControls: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+};
+
+const pickerStyle: CSSProperties = {
+  width: 34,
+  height: 24,
+  borderRadius: 'var(--r-sm)',
+  border: '1px solid var(--line-strong)',
+  padding: 0,
+  background: 'transparent',
+  cursor: 'pointer',
+  overflow: 'hidden',
+};
+
+const hexInput: CSSProperties = {
+  background: 'var(--bg-2)',
+  border: '1px solid var(--line)',
+  color: 'var(--fg-0)',
+  borderRadius: 'var(--r-sm)',
+  padding: '5px 8px',
+  width: 92,
+  fontSize: 12,
+  letterSpacing: '0.04em',
+  fontFamily: 'var(--font-mono)',
+};
+
+function resetBtn(enabled: boolean): CSSProperties {
+  return {
+    background: 'transparent',
+    border: '1px solid var(--line-strong)',
+    color: enabled ? 'var(--fg-1)' : 'var(--fg-3)',
+    borderRadius: 'var(--r-sm)',
+    padding: '5px 10px',
+    fontSize: 11,
+    letterSpacing: '0.06em',
+    cursor: enabled ? 'pointer' : 'default',
+    opacity: enabled ? 1 : 0.5,
+  };
+}
+
+const footerRow: CSSProperties = {
+  display: 'flex',
+  justifyContent: 'flex-end',
+  marginTop: 10,
+};
+
+function resetAllBtn(enabled: boolean): CSSProperties {
+  return {
+    background: enabled ? 'var(--bg-2)' : 'transparent',
+    border: '1px solid var(--line-strong)',
+    color: enabled ? 'var(--fg-0)' : 'var(--fg-3)',
+    borderRadius: 'var(--r-sm)',
+    padding: '7px 14px',
+    fontSize: 11,
+    fontWeight: 600,
+    letterSpacing: '0.1em',
+    textTransform: 'uppercase',
+    cursor: enabled ? 'pointer' : 'default',
+    opacity: enabled ? 1 : 0.5,
+  };
+}

--- a/zeus-web/src/main.tsx
+++ b/zeus-web/src/main.tsx
@@ -68,6 +68,19 @@ import { installFetchInterceptor } from './serverUrl';
 // to a LAN address; on plain web this is a no-op (relative paths).
 installFetchInterceptor();
 
+// Seed the operator's chosen theme on <html> BEFORE React paints. The
+// ThemeApplier component reapplies on store changes; this just prevents
+// a flash of dark-chrome on first render when the operator's saved
+// preference is light. The store factory itself reads localStorage.
+try {
+  const saved = localStorage.getItem('zeus.theme');
+  if (saved === 'light' || saved === 'dark') {
+    document.documentElement.setAttribute('data-theme', saved);
+  }
+} catch {
+  /* private mode — falls back to dark, the default. */
+}
+
 // PERF_PASS_3_DEBUG: window debug helpers for playwright-driven validation.
 (window as unknown as Record<string, unknown>).__zeusPerf3 = {
   txStore: useTxStore,

--- a/zeus-web/src/state/theme-store.ts
+++ b/zeus-web/src/state/theme-store.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+// See LICENSE for the full GPL text.
+
+import { create } from 'zustand';
+
+// Theme + per-token colour overrides for the Zeus UI.
+//
+// `theme` flips the global `data-theme` attribute on <html>, which selects
+// either the default dark token set in tokens.css or the brushed-silver
+// LIGHT overlay (`:root[data-theme="light"]`). The operator can additionally
+// override individual CSS variables — e.g. nudge --accent from electric blue
+// to teal — and those overrides apply across BOTH themes because they're
+// injected via a runtime <style> tag that sets `:root { … }` after the
+// theme-block in the stylesheet.
+//
+// Stored in localStorage (not on the server) because:
+//   1. theming is per-browser ergonomics, not per-radio config — Brian on
+//      his laptop should be able to pick a light scheme without it flipping
+//      his shack tablet to silver as well;
+//   2. it parallels the existing `zeus.variant` / `zeus.fonts` keys already
+//      written from App.tsx;
+//   3. the user can wipe localStorage to factory-reset their chrome.
+
+export type ThemeId = 'dark' | 'light';
+
+// Tokens we expose in the operator-facing colour-tweak UI. These are the
+// "feel" tokens an operator notices: accent for active controls, signal
+// chain colours, and the warm halos on meters. Surface colours (--bg-0
+// etc.) are NOT tweakable here — they are governed by the theme overlay,
+// because flipping bg-0 in isolation tends to make text unreadable.
+// Add a token here + a label in TWEAKABLE_TOKEN_META if you want a new
+// slider in the Theme panel.
+export type TweakableToken =
+  | '--accent'
+  | '--accent-bright'
+  | '--tx'
+  | '--power'
+  | '--amber'
+  | '--cyan'
+  | '--ok'
+  | '--orange';
+
+export const TWEAKABLE_TOKENS: ReadonlyArray<TweakableToken> = [
+  '--accent',
+  '--accent-bright',
+  '--tx',
+  '--power',
+  '--amber',
+  '--cyan',
+  '--ok',
+  '--orange',
+];
+
+type ThemeState = {
+  theme: ThemeId;
+  // Map of CSS-variable-name → hex colour (e.g. `--accent` → `#FF00FF`).
+  // Only entries present here override the stylesheet default; deleting a
+  // key restores the original token value from tokens.css.
+  overrides: Partial<Record<TweakableToken, string>>;
+  setTheme: (t: ThemeId) => void;
+  setOverride: (token: TweakableToken, hex: string | null) => void;
+  resetOverrides: () => void;
+};
+
+const THEME_KEY = 'zeus.theme';
+const OVERRIDES_KEY = 'zeus.theme.overrides';
+
+function isThemeId(v: unknown): v is ThemeId {
+  return v === 'dark' || v === 'light';
+}
+
+function isHexColor(v: unknown): v is string {
+  return typeof v === 'string' && /^#[0-9A-Fa-f]{6}$/.test(v);
+}
+
+function readTheme(): ThemeId {
+  try {
+    if (typeof localStorage === 'undefined') return 'dark';
+    const raw = localStorage.getItem(THEME_KEY);
+    return isThemeId(raw) ? raw : 'dark';
+  } catch {
+    return 'dark';
+  }
+}
+
+function writeTheme(t: ThemeId): void {
+  try {
+    if (typeof localStorage !== 'undefined') localStorage.setItem(THEME_KEY, t);
+  } catch {
+    /* quota / private mode — accept silently */
+  }
+}
+
+function readOverrides(): Partial<Record<TweakableToken, string>> {
+  try {
+    if (typeof localStorage === 'undefined') return {};
+    const raw = localStorage.getItem(OVERRIDES_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as Partial<Record<string, unknown>>;
+    const out: Partial<Record<TweakableToken, string>> = {};
+    for (const k of TWEAKABLE_TOKENS) {
+      const v = parsed[k];
+      if (isHexColor(v)) out[k] = v.toUpperCase();
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function writeOverrides(o: Partial<Record<TweakableToken, string>>): void {
+  try {
+    if (typeof localStorage !== 'undefined')
+      localStorage.setItem(OVERRIDES_KEY, JSON.stringify(o));
+  } catch {
+    /* quota / private mode — accept silently */
+  }
+}
+
+export const useThemeStore = create<ThemeState>((set, get) => ({
+  theme: readTheme(),
+  overrides: readOverrides(),
+  setTheme: (theme) => {
+    writeTheme(theme);
+    set({ theme });
+  },
+  setOverride: (token, hex) => {
+    const next = { ...get().overrides };
+    if (hex == null) {
+      delete next[token];
+    } else {
+      if (!isHexColor(hex)) return;
+      next[token] = hex.toUpperCase();
+    }
+    writeOverrides(next);
+    set({ overrides: next });
+  },
+  resetOverrides: () => {
+    writeOverrides({});
+    set({ overrides: {} });
+  },
+}));

--- a/zeus-web/src/styles/tokens.css
+++ b/zeus-web/src/styles/tokens.css
@@ -188,6 +188,75 @@
 html[data-fonts="geist"] { --font-sans: 'Inter', sans-serif; --font-mono: 'JetBrains Mono', monospace; --font-display: 'Inter', sans-serif; }
 
 /* ===========================================================
+   LIGHT THEME — brushed silver chassis, dark displays
+   ===========================================================
+   Source: docs/designs "Zeus Lifted Dark v4" (chat1 — Brian's
+   light-theme direction: "strong silver element, not washed-out
+   white"). Chassis surfaces flip to cool silver while DISPLAY
+   wells (panadapter, VFO, S-meter, gauges, LED meters) stay dark
+   so the radio still reads as "lit instruments embedded in a
+   silver front panel" — classic transceiver aesthetic. Operator
+   colour overrides (theme-store) cascade *under* this block via
+   the runtime <style> tag injected by ThemeApplier, so per-token
+   tweaks survive a theme flip. */
+:root[data-theme="light"] {
+  /* Chassis surfaces — cool silver, never washed-out white */
+  --bg-app:       #b8bcc3;
+  --bg-workspace: #b8bcc3;
+  --bg-0:         #b8bcc3;
+  --bg-1:         #cdd1d7;
+  --bg-2:         #b3b8bf;
+  --bg-3:         #a3a8b0;
+
+  /* Display surfaces stay DARK — panadapter / VFO / S-meter /
+     gauges / LED-meter wells all look like screens embedded in
+     silver. */
+  --bg-inset:     #0e1014;
+  --bg-meter:     #050507;
+
+  /* Lines — darker silvers / steel for definition on light chassis */
+  --line:         #8a8f96;
+  --line-soft:    #a8adb4;
+  --line-strong:  #6a6e75;
+
+  /* Text on chassis flips to near-black */
+  --fg-0:         #1a1c20;
+  --fg-1:         #2f3239;
+  --fg-2:         #555a62;
+  --fg-3:         #797d84;
+  --fg-4:         #989ca2;
+
+  /* Panel chrome — brushed silver gradient (top → bottom) */
+  --panel-head-top: #d2d6dc;
+  --panel-head-bot: #c4c8ce;
+  --panel-border:   #8a8f96;
+  --panel-hl-top:   rgba(255,255,255,0.6);
+  --panel-top:      #d2d6dc;
+  --panel-bot:      #c4c8ce;
+  --panel-edge:     #8a8f96;
+  --panel-shadow:   0 1px 0 rgba(255,255,255,0.6) inset, 0 1px 2px rgba(0,0,0,0.18);
+
+  /* Buttons on silver — flat with steel edge */
+  --btn-top:        #c4c8ce;
+  --btn-bot:        #b3b8bf;
+  --btn-hl:         rgba(255,255,255,0.5);
+  --btn-edge:       #6a6e75;
+  --btn-text:       #1a1c20;
+  --btn-active-top: var(--accent);
+  --btn-active-bot: var(--accent);
+  --btn-active-text:#ffffff;
+}
+
+/* Brushed silver gradient washes — applied to the four chrome
+   strips so the chassis reads as a single machined panel.
+   Display surfaces (spec-bg, immersive-*) deliberately keep
+   their dark defaults from :root, so they appear as inset
+   screens against the silver. */
+:root[data-theme="light"] body {
+  background: linear-gradient(180deg, #c4c8ce 0%, #b3b8c0 100%);
+}
+
+/* ===========================================================
    Base resets
    =========================================================== */
 * { box-sizing: border-box; }


### PR DESCRIPTION
## Summary

- Adds a brushed-silver **Light** theme alongside the existing v3 Lifted Dark chrome (which is preserved as-is).
- Adds an operator-facing **colour palette** tweaker in Settings → DISPLAY so accent colours (Accent, TX, Power, Amber, Cyan, OK/Green, Orange) can be re-tinted with native colour pickers; overrides persist in localStorage and apply across both themes.
- Display wells (panadapter, VFO, S-meter, gauges, LED meters) deliberately stay dark in the light theme so they still read as lit instruments embedded in a silver front panel — the classic transceiver look from the [Zeus Lifted Dark v4](https://claude.ai/design) reference.

## Implementation

- `state/theme-store.ts` — zustand store (`theme: 'dark' | 'light'` + `overrides: Partial<Record<TweakableToken, string>>`), localStorage keys `zeus.theme` and `zeus.theme.overrides`.
- `components/ThemeApplier.tsx` — mounted once in App; sets `data-theme` on `<html>` and injects a runtime `<style id=\"zeus-theme-overrides\">` with `:root { … }` so overrides land *after* tokens.css in the cascade.
- `styles/tokens.css` — new `:root[data-theme=\"light\"]` block reskins chassis surfaces (`--bg-*`, `--line-*`, `--fg-*`, `--panel-*`); display wells (`--bg-inset`, `--bg-meter`, `--spec-bg`, `--immersive-*`) deliberately unchanged.
- `components/ThemeSettingsPanel.tsx` — Settings UI: two theme cards + a per-token list with hex input, picker, per-row Reset, and a global Reset-all.
- `components/DisplayPanel.tsx` — mounts the new panel at the top of the Display tab.
- `main.tsx` — seeds `data-theme` on `<html>` before React mounts so a saved light preference paints immediately on reload (no flash of dark chrome).

## Test plan

- [x] `npm --prefix zeus-web run build` — TS + Vite clean
- [x] `npm --prefix zeus-web test -- --run` — 208/208 tests pass
- [x] `dotnet build Zeus.slnx` — 0 warnings, 0 errors
- [x] Browser end-to-end (Playwright): set theme=light + `--accent=#FF00AA` in localStorage, reloaded, confirmed `data-theme=\"light\"`, `--bg-0=#b8bcc3`, `--fg-0=#1a1c20`, `--bg-inset=#0e1014` (display well stayed dark), `--accent=#FF00AA` applied via injected `<style>` tag, 0 console errors
- [ ] Maintainer review of the silver palette stops (`#b8bcc3` chassis, `#d2d6dc → #c4c8ce` panel gradient) — per CLAUDE.md, visual design defaults need EI6LF sign-off

## Notes for review

- Per CLAUDE.md, colour-palette defaults are red-light; this PR keeps the dark theme **identical** and only adds an opt-in light theme + an opt-in override system. The defaults exposed in the picker are the existing tokens.css values, not new choices.
- Light-theme palette taken verbatim from the Zeus Lifted Dark v4 reference (`brightenzeus/project/Zeus Lifted Dark v4.html`); the silver stops can be tuned without touching code.