### PR TITLE
fix(puresignal): HL2 hw_peak default + dance hysteresis + cooldown + stall warning

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -222,6 +222,13 @@ public sealed record StateDto(
     double PsFeedbackLevel = 0.0,   // info[4] read-back, 0..256
     byte PsCalState = 0,            // info[15] enum
     bool PsCorrecting = false,      // info[14]
+    // Set by PsAutoAttenuateService when calcc has been alive (PS armed +
+    // keyed) for >5 s without producing a fit (CalibrationAttempts pinned
+    // at 0). Almost always means hw_peak is set higher than the actual TX
+    // envelope peak — calcc bin 15 never fills so COLLECT never advances.
+    // Frontend shows a banner pointing the operator at HW peak. See
+    // PsAutoAttenuateService stall detection + project_hl2_ps_hwpeak_calibration.
+    bool PsCalibrationStalled = false,
     // ---- TwoTone test generator (TXA PostGen mode=1; protocol-agnostic) ----
     // Standard PureSignal calibration excitation. Defaults match pihpsdr's
     // TwoTone defaults — 700/1900 Hz, 0.49 linear amplitude per tone.

--- a/Zeus.Server.Hosting/PsAutoAttenuateService.cs
+++ b/Zeus.Server.Hosting/PsAutoAttenuateService.cs
@@ -52,11 +52,20 @@ namespace Zeus.Server;
 /// </summary>
 public sealed class PsAutoAttenuateService : BackgroundService
 {
-    // Thetis ideal feedback target: 152.293 (PSForm.cs:745). Window 128..181
-    // matches the lblPSInfoFB green-LED thresholds (PSForm.cs:1123-1138).
+    // Thetis ideal feedback target: 152.293 (PSForm.cs:745).
     private const double IdealFeedback = 152.293;
-    private const int FeedbackLowThreshold = 128;
-    private const int FeedbackHighThreshold = 181;
+    // *** DEVIATION FROM mi0bot *** Window widened from mi0bot's 128/181 to
+    // 110/195 after bench-measuring 2026-05-16 on HL2: with mi0bot's narrow
+    // band, a single 2 dB correction overshoots and lands the other side of
+    // the window — dance oscillates 4↔6 dB roughly once per second, briefly
+    // disabling PS each cycle. Symptom for the operator: audible IMD3 bloom
+    // every second. A 110/195 band leaves a single 2 dB correction
+    // comfortably inside the dead zone (e.g. fb=190 → 4→6 → fb~151 in
+    // window; fb=117 → 6→4 → fb~189 also in window). mi0bot may not hit
+    // this because operators hand-tune hw_peak to land feedback closer to
+    // 152, narrowing the natural swing.
+    private const int FeedbackLowThreshold = 110;
+    private const int FeedbackHighThreshold = 195;
 
     // 10 Hz tick. Same cadence Thetis runs timer2code at when PS is armed and
     // the form has focus (PSForm.cs:204-209, m_bQuckAttenuate=false default).
@@ -83,6 +92,18 @@ public sealed class PsAutoAttenuateService : BackgroundService
     // Settle time after a step change: give the radio one wire-cycle to pick
     // up the new attenuator, then issue the reset so calcc starts fresh.
     private static readonly TimeSpan PostStepSettle = TimeSpan.FromMilliseconds(100);
+
+    // *** DEVIATION FROM mi0bot *** Per-dance cooldown. After a Monitor →
+    // SetNewValues → RestoreOperation cycle completes, refuse to start
+    // another dance for 3 s. mi0bot has no cooldown; the implicit assumption
+    // is that the operator tuned hw_peak so feedback would settle on its
+    // own. Bench 2026-05-16 showed Zeus chasing feedback into an oscillation
+    // (4↔6 dB once per second). The wider dead-band above eliminates the
+    // single-step overshoot; the cooldown protects against multi-step
+    // chasing if calcc converges quickly on a new attn value with the
+    // feedback still mildly OOB. Combined with the wider band it brings
+    // the steady-state dance rate to "rarely" instead of "every second".
+    private static readonly TimeSpan DanceCooldown = TimeSpan.FromSeconds(3);
 
     private readonly RadioService _radio;
     private readonly TxService _tx;
@@ -139,6 +160,22 @@ public sealed class PsAutoAttenuateService : BackgroundService
     private int _hl2DeltaDb;
     private bool _hl2SavedAuto;
     private bool _hl2SavedSingle;
+
+    // Cooldown timestamps. Updated when RestoreOperation completes; checked
+    // at the top of Monitor before allowing a new dance. 0 = never danced.
+    private long _hl2LastDanceEndTickMs;
+    private long _p2LastDanceEndTickMs;
+
+    // Stall detection for "calcc is alive but never produces a fit". Operator
+    // signature: PS armed + keyed for >StallThreshold seconds with
+    // CalibrationAttempts pinned at 0 → almost certainly hw_peak set higher
+    // than the actual TX envelope peak (calcc bin 15 never fills, COLLECT
+    // never advances to LCALC). See docs/lessons/hl2-ps-hwpeak-calibration.md.
+    // _stallStartTickMs is the first keyed tick where info5==0; _stallWarned
+    // suppresses repeat log lines once we've already warned for this stall.
+    private long _stallStartTickMs;
+    private bool _stallWarned;
+    private static readonly TimeSpan StallThreshold = TimeSpan.FromSeconds(5);
 
     // *** DEVIATION FROM mi0bot ***
     // Silent server-side auto-cal of WDSP hw_peak from observed TX envelope.
@@ -218,6 +255,16 @@ public sealed class PsAutoAttenuateService : BackgroundService
         }
     }
 
+    private void ClearStallFlag()
+    {
+        _stallStartTickMs = 0;
+        if (_stallWarned)
+        {
+            _stallWarned = false;
+            _radio.SetPsCalibrationStalled(false);
+        }
+    }
+
     // Diagnostic — emits one line per second tagging which gate short-
     // circuited Tick1. Without this the loop is invisible when it returns
     // early (the only visible signals were `psAutoAttn.armed` and
@@ -248,6 +295,10 @@ public sealed class PsAutoAttenuateService : BackgroundService
             _lastCalibrationAttempts = -1;
             _hl2State = Hl2AutoAttState.Monitor;
             _p2State = P2AutoAttState.Monitor;
+            _hl2LastDanceEndTickMs = 0;
+            _p2LastDanceEndTickMs = 0;
+            _stallStartTickMs = 0;
+            _stallWarned = false;
             _lastAutoCalTickMs = 0;
             _log.LogInformation("psAutoAttn.armed reset attn={Db}", _currentAttnDb);
         }
@@ -260,13 +311,40 @@ public sealed class PsAutoAttenuateService : BackgroundService
         {
             _hl2State = Hl2AutoAttState.Monitor;
             _p2State = P2AutoAttState.Monitor;
+            ClearStallFlag();
             LogGate("skip=PsEnabled-off");
             return;
         }
         if (!_tx.IsMoxOn && !_tx.IsTwoToneOn)
         {
+            // If MOX dropped while the dance was mid-flight (state == SetNewValues
+            // or RestoreOperation), Monitor-state has already issued
+            // SetPsControl(false, false) → calcc reset=1. Without a restore here,
+            // PS sits disabled in WDSP and the next key-up never re-enables it
+            // because DspPipelineService's _appliedPsAuto/_appliedPsSingle still
+            // equal the operator's saved values, so its equality check
+            // short-circuits.
+            var eng = _pipe.CurrentEngine;
+            if (eng is not null)
+            {
+                if (_hl2State != Hl2AutoAttState.Monitor)
+                {
+                    _log.LogInformation(
+                        "psAutoAttn.hl2.recover state={State} restore auto={Auto} single={Single}",
+                        _hl2State, _hl2SavedAuto, _hl2SavedSingle);
+                    eng.SetPsControl(_hl2SavedAuto, _hl2SavedSingle);
+                }
+                if (_p2State != P2AutoAttState.Monitor)
+                {
+                    _log.LogInformation(
+                        "psAutoAttn.p2.recover state={State} restore auto={Auto} single={Single}",
+                        _p2State, _p2SavedAuto, _p2SavedSingle);
+                    eng.SetPsControl(_p2SavedAuto, _p2SavedSingle);
+                }
+            }
             _hl2State = Hl2AutoAttState.Monitor;
             _p2State = P2AutoAttState.Monitor;
+            ClearStallFlag();
             LogGate("skip=not-keyed");
             return;
         }
@@ -276,8 +354,39 @@ public sealed class PsAutoAttenuateService : BackgroundService
         {
             _hl2State = Hl2AutoAttState.Monitor;
             _p2State = P2AutoAttState.Monitor;
+            ClearStallFlag();
             LogGate("skip=engine-null");
             return;
+        }
+
+        // Stall detection — calcc alive but never producing a fit. See
+        // _stallStartTickMs comment. PS armed + keyed + engine present at
+        // this point. info5 stuck at 0 for >StallThreshold ⇒ warn the
+        // operator that hw_peak is almost certainly miscalibrated. Surface
+        // a flag on RadioService so the frontend can show a banner.
+        var stallPsm = engine.GetPsStageMeters();
+        if (stallPsm.CalibrationAttempts == 0)
+        {
+            long now = Environment.TickCount64;
+            if (_stallStartTickMs == 0) _stallStartTickMs = now;
+            else if (!_stallWarned && now - _stallStartTickMs >= (long)StallThreshold.TotalMilliseconds)
+            {
+                _stallWarned = true;
+                _radio.SetPsCalibrationStalled(true);
+                _log.LogWarning(
+                    "psAutoAttn.stall info5=0 for {ElapsedMs}ms — hw_peak likely too high for current drive (calcc bin 15 never fills). Lower HW peak in PURESIGNAL panel.",
+                    now - _stallStartTickMs);
+            }
+        }
+        else if (_stallStartTickMs != 0)
+        {
+            _stallStartTickMs = 0;
+            if (_stallWarned)
+            {
+                _stallWarned = false;
+                _radio.SetPsCalibrationStalled(false);
+                _log.LogInformation("psAutoAttn.stall.cleared info5={Cal}", stallPsm.CalibrationAttempts);
+            }
         }
 
         // Auto-cal hw_peak from observed envelope. Independent of HL2/P2 path
@@ -380,6 +489,17 @@ public sealed class PsAutoAttenuateService : BackgroundService
                     return;
                 }
 
+                // Per-dance cooldown (DEVIATION FROM mi0bot — see DanceCooldown
+                // comment). After a completed dance, give calcc DanceCooldown
+                // to settle on the new attn before evaluating again.
+                long nowMs = Environment.TickCount64;
+                if (_hl2LastDanceEndTickMs > 0
+                    && nowMs - _hl2LastDanceEndTickMs < (long)DanceCooldown.TotalMilliseconds)
+                {
+                    LogGate($"hl2.skip=cooldown elapsed={nowMs - _hl2LastDanceEndTickMs}ms");
+                    return;
+                }
+
                 var psm = engine.GetPsStageMeters();
                 int feedback = (int)Math.Round(psm.FeedbackLevel);
 
@@ -469,6 +589,7 @@ public sealed class PsAutoAttenuateService : BackgroundService
                 // save_auto, 0). Engine.SetPsControl translates the saved
                 // (auto, single) pair into the same wire call.
                 engine.SetPsControl(autoCal: _hl2SavedAuto, singleCal: _hl2SavedSingle);
+                _hl2LastDanceEndTickMs = Environment.TickCount64;
                 _log.LogInformation(
                     "psAutoAttn.hl2.restoreOperation auto={Auto} single={Single}",
                     _hl2SavedAuto, _hl2SavedSingle);
@@ -502,6 +623,15 @@ public sealed class PsAutoAttenuateService : BackgroundService
                 if (!s.PsAutoAttenuate)
                 {
                     LogGate("p2.skip=AutoAttenuate-off");
+                    return;
+                }
+
+                // Per-dance cooldown — see DanceCooldown comment.
+                long nowMs = Environment.TickCount64;
+                if (_p2LastDanceEndTickMs > 0
+                    && nowMs - _p2LastDanceEndTickMs < (long)DanceCooldown.TotalMilliseconds)
+                {
+                    LogGate($"p2.skip=cooldown elapsed={nowMs - _p2LastDanceEndTickMs}ms");
                     return;
                 }
 
@@ -601,6 +731,7 @@ public sealed class PsAutoAttenuateService : BackgroundService
                 // (auto, single) pair into the same wire call. This re-arms
                 // calcc on the new envelope — single LRESET → LCOLLECT pass.
                 engine.SetPsControl(autoCal: _p2SavedAuto, singleCal: _p2SavedSingle);
+                _p2LastDanceEndTickMs = Environment.TickCount64;
                 _log.LogInformation(
                     "psAutoAttn.p2.restoreOperation auto={Auto} single={Single}",
                     _p2SavedAuto, _p2SavedSingle);

--- a/Zeus.Server.Hosting/PsAutoAttenuateService.cs
+++ b/Zeus.Server.Hosting/PsAutoAttenuateService.cs
@@ -52,20 +52,15 @@ namespace Zeus.Server;
 /// </summary>
 public sealed class PsAutoAttenuateService : BackgroundService
 {
-    // Thetis ideal feedback target: 152.293 (PSForm.cs:745).
+    // Thetis ideal feedback target: 152.293 (PSForm.cs:745). Window 128..181
+    // matches mi0bot's lblPSInfoFB green-LED thresholds (PSForm.cs:1123-1138).
+    // Bench-confirmed 2026-05-16 on EI6LF's HL2 with hw_peak=0.2400 (deskhpsdr
+    // parity): voice operation lands fb in the 140-149 range, comfortably
+    // inside mi0bot's window. The DanceCooldown below covers any rare
+    // single-step overshoot near the edges without requiring a wider band.
     private const double IdealFeedback = 152.293;
-    // *** DEVIATION FROM mi0bot *** Window widened from mi0bot's 128/181 to
-    // 110/195 after bench-measuring 2026-05-16 on HL2: with mi0bot's narrow
-    // band, a single 2 dB correction overshoots and lands the other side of
-    // the window — dance oscillates 4↔6 dB roughly once per second, briefly
-    // disabling PS each cycle. Symptom for the operator: audible IMD3 bloom
-    // every second. A 110/195 band leaves a single 2 dB correction
-    // comfortably inside the dead zone (e.g. fb=190 → 4→6 → fb~151 in
-    // window; fb=117 → 6→4 → fb~189 also in window). mi0bot may not hit
-    // this because operators hand-tune hw_peak to land feedback closer to
-    // 152, narrowing the natural swing.
-    private const int FeedbackLowThreshold = 110;
-    private const int FeedbackHighThreshold = 195;
+    private const int FeedbackLowThreshold = 128;
+    private const int FeedbackHighThreshold = 181;
 
     // 10 Hz tick. Same cadence Thetis runs timer2code at when PS is armed and
     // the form has focus (PSForm.cs:204-209, m_bQuckAttenuate=false default).

--- a/Zeus.Server.Hosting/PsSettingsStore.cs
+++ b/Zeus.Server.Hosting/PsSettingsStore.cs
@@ -25,14 +25,23 @@ using Zeus.Contracts;
 namespace Zeus.Server;
 
 // PureSignal settings persistence. Stores the operator's calibration tuning
-// (timing delays, ints/spi preset, ptol mode, auto-attenuate) so it survives
-// server restarts. Shares zeus-prefs.db with DspSettingsStore.
+// (timing delays, ints/spi preset, ptol mode, auto-attenuate, per-board
+// HW peak) so it survives server restarts. Shares zeus-prefs.db with
+// DspSettingsStore.
 //
 // Deliberately does NOT persist `PsEnabled` (the master arm) or `PsAuto` /
 // `PsSingle` (cal mode) — these reset to safe defaults each session. Same
 // pattern as MOX / TUN: arming PS is an operator action, never an automatic
-// "resume what we did last time" behaviour. PsHwPeak isn't persisted either
-// because RadioService re-derives it per-radio at connect time.
+// "resume what we did last time" behaviour.
+//
+// `HwPeakByBoard` IS persisted as of 2026-05-16. The earlier "re-derive per
+// radio at connect time" assumption clobbered operator-calibrated values
+// every reconnect — on chains that don't match the per-board factory
+// default (external amp sample taps, non-stock attenuator pads) the value
+// can legitimately differ from the resolved default and must survive a
+// restart. The dictionary is keyed by `{p1|p2}:{board}[:variant]` (variant
+// only when board is `OrionMkII` and we're on P2) so each physical chain
+// owns its own calibrated value.
 public sealed class PsSettingsStore : IDisposable
 {
     private readonly LiteDatabase _db;
@@ -105,5 +114,14 @@ public sealed class PsSettingsEntry
     public double TwoToneFreq1 { get; set; } = 700.0;
     public double TwoToneFreq2 { get; set; } = 1900.0;
     public double TwoToneMag { get; set; } = 0.49;
+    // Per-board HW peak overrides. Keyed by `{p1|p2}:{board}[:variant]` —
+    // e.g. "p2:OrionMkII:G2", "p1:HermesLite2", "p1:Hermes". Populated by
+    // RadioService.PersistPsState whenever the operator (or auto-cal)
+    // changes PsHwPeak while a radio is connected; consumed by
+    // ApplyPsHwPeakForConnection, which prefers a persisted entry over the
+    // per-board factory default. Empty on first run — no entry means "use
+    // the factory default from RadioService.ResolvePsHwPeak". See lengthy
+    // header comment above for the why.
+    public Dictionary<string, double> HwPeakByBoard { get; set; } = new();
     public DateTime UpdatedUtc { get; set; }
 }

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -1349,6 +1349,15 @@ public sealed class RadioService : IDisposable
         });
     }
 
+    // Surface calcc-stall state to the frontend. PsAutoAttenuateService raises
+    // this when info5 stays at 0 for >5s while keyed; the frontend renders a
+    // banner pointing operator at HW peak. No-ops if the flag isn't changing.
+    public void SetPsCalibrationStalled(bool stalled)
+    {
+        if (Snapshot().PsCalibrationStalled == stalled) return;
+        Mutate(s => s with { PsCalibrationStalled = stalled });
+    }
+
     /// <summary>
     /// Resolves the operator-correct PS hardware-peak default for the given
     /// protocol + board kind. Sources:
@@ -1379,7 +1388,12 @@ public sealed class RadioService : IDisposable
         // on connect — keeps Synthetic + tests deterministic.
         (isProtocol2, board) switch
         {
-            (false, HpsdrBoardKind.HermesLite2)              => 0.233,
+            // HL2: bench-measured 2026-05-16 — standard drive into a
+            // resonant antenna produces DDC3(tx) envelope peak ≈ 0.190
+            // (info5 stays 0 with default 0.233 because calcc bin 15 never
+            // fills). 0.20 puts the operator inside calcc's convergence
+            // window out of the box; the panel lets them retune per setup.
+            (false, HpsdrBoardKind.HermesLite2)              => 0.20,
             (false, _)                                        => 0.4072,
             // 0x0A wire byte: Saturn FPGA (G2 / G2-1K) reports the high
             // peak per Thetis clsHardwareSpecific.cs:313; everything else
@@ -1392,7 +1406,8 @@ public sealed class RadioService : IDisposable
                 OrionMkIIVariant.G2_1K  => 0.6121,
                 _                        => 0.2899,
             },
-            (true,  HpsdrBoardKind.HermesLite2)               => 0.233,
+            // HL2 P2: same bench measurement as P1 above.
+            (true,  HpsdrBoardKind.HermesLite2)               => 0.20,
             (true,  _)                                        => 0.2899,
         };
 

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -1388,12 +1388,17 @@ public sealed class RadioService : IDisposable
         // on connect — keeps Synthetic + tests deterministic.
         (isProtocol2, board) switch
         {
-            // HL2: bench-measured 2026-05-16 — standard drive into a
-            // resonant antenna produces DDC3(tx) envelope peak ≈ 0.190
-            // (info5 stays 0 with default 0.233 because calcc bin 15 never
-            // fills). 0.20 puts the operator inside calcc's convergence
-            // window out of the box; the panel lets them retune per setup.
-            (false, HpsdrBoardKind.HermesLite2)              => 0.20,
+            // HL2: tracks deskhpsdr's "measure then slightly increase" rule
+            // (transmitter.c:1347-1371, comment + value 0.2400 vs measured
+            // 0.2386). Zeus uses 0.2500 instead of deskhpsdr's 0.2400 — same
+            // rule, marginally more headroom so the operator's "Observed"
+            // indicator sits inside the dead zone rather than right at the
+            // fault edge with typical voice peaks (~0.240 on EI6LF's HL2 +
+            // resonant antenna, 2026-05-16). mi0bot returns 0.233
+            // (clsHardwareSpecific.cs:312) which sits slightly *under* the
+            // measured peak; voice envelopes clamp into calcc bin 15 rather
+            // than filling it cleanly.
+            (false, HpsdrBoardKind.HermesLite2)              => 0.2500,
             (false, _)                                        => 0.4072,
             // 0x0A wire byte: Saturn FPGA (G2 / G2-1K) reports the high
             // peak per Thetis clsHardwareSpecific.cs:313; everything else
@@ -1406,8 +1411,9 @@ public sealed class RadioService : IDisposable
                 OrionMkIIVariant.G2_1K  => 0.6121,
                 _                        => 0.2899,
             },
-            // HL2 P2: same bench measurement as P1 above.
-            (true,  HpsdrBoardKind.HermesLite2)               => 0.20,
+            // HL2 P2: same value as P1 above (HL2 hardware peak is the same
+            // regardless of protocol).
+            (true,  HpsdrBoardKind.HermesLite2)               => 0.2500,
             (true,  _)                                        => 0.2899,
         };
 

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -64,6 +64,12 @@ public sealed class RadioService : IDisposable
     private readonly PsSettingsStore? _psStore;
     private readonly FilterPresetStore? _filterPresetStore;
     private readonly RadioStateStore? _radioStateStore;
+    // Cached PS board key for the currently-connected radio. Set by
+    // ApplyPsHwPeakForConnection (P1 or P2 connect path) and read by
+    // PersistPsState to route HW Peak writes to the correct per-board slot.
+    // Empty when nothing is connected — PersistPsState skips HW Peak persistence
+    // in that case (no board → no slot to write).
+    private string _currentPsBoardKey = string.Empty;
     // Debounced state flush. Set to true in every Mutate(); a 1 Hz timer
     // calls FlushState() which writes to LiteDB and clears the flag.
     // Avoids hammering LiteDB during rapid VFO scroll or filter drags.
@@ -204,9 +210,12 @@ public sealed class RadioService : IDisposable
         }
 
         // Load persisted PS settings — operator's calibration tuning. Master
-        // arm and cal-mode are deliberately NOT persisted (parity with MOX);
-        // only the timing/preset/auto-att tuning is. PsHwPeak is left at the
-        // P1 default; ConnectAsync / ConnectP2Async overrides per-radio.
+        // arm flag is deliberately NOT persisted (parity with MOX); the
+        // timing/preset/auto-att/HW-peak tuning is. PsHwPeak is resolved
+        // per-radio in ApplyPsHwPeakForConnection (called from
+        // ConnectAsync / ConnectP2Async), which prefers the persisted
+        // per-board value when present and falls back to the factory
+        // default otherwise.
         var ps = _psStore?.Get();
 
         // RadioStateStore snapshot — hydrates active mode/VFO/filter/volume/zoom
@@ -289,14 +298,28 @@ public sealed class RadioService : IDisposable
     /// callers don't drop fields by writing only what they touched. Called
     /// from SetPs, SetPsAdvanced, SetPsFeedbackSource, and SetTwoTone.
     ///
-    /// PsEnabled / TwoToneEnabled (master arm flags) and PsHwPeak (per-radio
-    /// derived) are intentionally NOT in the entry — same operator-action
-    /// discipline as MOX/TUN.
+    /// PsEnabled / TwoToneEnabled (master arm flags) are intentionally NOT
+    /// in the entry — same operator-action discipline as MOX/TUN. PsHwPeak
+    /// IS persisted per-connected-board via the HwPeakByBoard dictionary;
+    /// when no board is currently connected the HwPeak portion of the write
+    /// is skipped (existing per-board entries are preserved untouched).
     /// </summary>
     private void PersistPsState()
     {
         if (_psStore is null) return;
         var snap = Snapshot();
+        // Preserve any existing per-board HW Peak map and only mutate the
+        // slot owned by the currently-connected radio. Reset / disconnect
+        // paths set _currentPsBoardKey back to empty, which skips the HW
+        // Peak write entirely — operators don't lose other-board entries.
+        var existing = _psStore.Get();
+        var hwPeakByBoard = existing?.HwPeakByBoard is { } map
+            ? new Dictionary<string, double>(map)
+            : new Dictionary<string, double>();
+        if (!string.IsNullOrEmpty(_currentPsBoardKey))
+        {
+            hwPeakByBoard[_currentPsBoardKey] = snap.PsHwPeak;
+        }
         _psStore.Upsert(new PsSettingsEntry
         {
             Auto = snap.PsAuto,
@@ -310,7 +333,23 @@ public sealed class RadioService : IDisposable
             TwoToneFreq1 = snap.TwoToneFreq1,
             TwoToneFreq2 = snap.TwoToneFreq2,
             TwoToneMag = snap.TwoToneMag,
+            HwPeakByBoard = hwPeakByBoard,
         });
+    }
+
+    /// <summary>
+    /// Build the per-board PS settings key used by PsSettingsEntry.HwPeakByBoard.
+    /// Format: `{p1|p2}:{board}[:variant]` where the variant suffix is only
+    /// present when board is `OrionMkII` and we're on P2 (the 0x0A wire-byte
+    /// alias family — G2, G2_1K, Anan7000DLE, Anan8000DLE, OrionMkII original,
+    /// AnvelinaPro3, RedPitaya — each has a distinct feedback chain).
+    /// </summary>
+    internal static string GetPsBoardKey(bool isProtocol2, HpsdrBoardKind board, OrionMkIIVariant variant)
+    {
+        string proto = isProtocol2 ? "p2" : "p1";
+        if (isProtocol2 && board == HpsdrBoardKind.OrionMkII)
+            return $"{proto}:{board}:{variant}";
+        return $"{proto}:{board}";
     }
 
     // Ribbon-visibility setter — frontend toggles via REST, server broadcasts
@@ -502,6 +541,11 @@ public sealed class RadioService : IDisposable
             AttOffsetDb = 0,
             AdcOverloadWarning = false,
         });
+        // Drop the PS board key — any SetPsAdvanced call between now and the
+        // next connect (e.g. operator dialling in the panel while
+        // disconnected) should NOT write into the previous radio's slot.
+        // ApplyPsHwPeakForConnection sets it again on next connect.
+        _currentPsBoardKey = string.Empty;
         return Snapshot();
     }
 
@@ -1418,26 +1462,46 @@ public sealed class RadioService : IDisposable
         };
 
     /// <summary>
-    /// Apply a per-radio PS hardware-peak default to the StateDto. Called by
+    /// Apply a per-radio PS hardware-peak to the StateDto. Called by
     /// DspPipelineService after a successful connect (P1 or P2) so the
     /// engine sees the correct curve scale before the operator arms PS.
-    /// Doesn't fire StateChanged unless the value actually moves.
+    ///
+    /// Resolution order:
+    ///   1. Operator-calibrated value from PsSettingsStore.HwPeakByBoard
+    ///      (set by SetPsAdvanced or the auto-cal control loop) — wins when
+    ///      present so chains that don't match the factory default
+    ///      (external amp sample taps, non-stock attenuator pads) keep
+    ///      their hard-won calibration across reconnects.
+    ///   2. Per-board factory default from ResolvePsHwPeak.
+    ///
+    /// PsHwPeakDefault always tracks (2) so the frontend can render a
+    /// "differs from factory default" hint when the operator value is
+    /// active. Doesn't fire StateChanged unless something actually moves.
     /// </summary>
     public void ApplyPsHwPeakForConnection(bool isProtocol2, HpsdrBoardKind board)
     {
-        double peak = ResolvePsHwPeak(isProtocol2, board, EffectiveOrionMkIIVariant);
-        // Snap PsHwPeakDefault to the resolved per-board value alongside
-        // PsHwPeak so the UI can compare them for a "differs from default"
-        // hint. mi0bot ref: PSForm.cs:830 reads HardwareSpecific.PSDefaultPeak
-        // (clsHardwareSpecific.cs:303-328) at the same boundary — radio
-        // change → re-resolve default.
+        var variant = EffectiveOrionMkIIVariant;
+        string boardKey = GetPsBoardKey(isProtocol2, board, variant);
+        double factoryDefault = ResolvePsHwPeak(isProtocol2, board, variant);
+        // Prefer a persisted operator-calibrated value for this exact
+        // board / variant. Missing entry → fall through to the factory
+        // default (first connect on a new board, or operator hasn't tuned).
+        var persisted = _psStore?.Get();
+        bool usingPersisted = persisted?.HwPeakByBoard is { } map
+            && map.TryGetValue(boardKey, out double saved)
+            && saved > 0.0;
+        double peak = usingPersisted ? persisted!.HwPeakByBoard[boardKey] : factoryDefault;
+        // Cache the board key so PersistPsState routes future SetPsAdvanced
+        // writes into the right slot.
+        _currentPsBoardKey = boardKey;
         Mutate(s =>
-            s.PsHwPeak == peak && s.PsHwPeakDefault == peak
+            s.PsHwPeak == peak && s.PsHwPeakDefault == factoryDefault
                 ? s
-                : s with { PsHwPeak = peak, PsHwPeakDefault = peak });
+                : s with { PsHwPeak = peak, PsHwPeakDefault = factoryDefault });
         _log.LogInformation(
-            "radio.applyPsHwPeak proto={Proto} board={Board} peak={Peak:F4}",
-            isProtocol2 ? "P2" : "P1", board, peak);
+            "radio.applyPsHwPeak proto={Proto} board={Board} variant={Variant} key={Key} peak={Peak:F4} default={Default:F4} source={Source}",
+            isProtocol2 ? "P2" : "P1", board, variant, boardKey, peak, factoryDefault,
+            usingPersisted ? "persisted" : "factory");
     }
 
     public StateDto SetZoom(int level)
@@ -1573,6 +1637,10 @@ public sealed class RadioService : IDisposable
             Status = ConnectionStatus.Disconnected,
             Endpoint = null,
         });
+        // Same reasoning as P1 DisconnectAsync — clear the board key so
+        // disconnected SetPsAdvanced writes don't leak into the previous
+        // radio's per-board HW Peak slot.
+        _currentPsBoardKey = string.Empty;
         P2Disconnected?.Invoke();
     }
 

--- a/tests/Zeus.Server.Tests/PsHwPeakResolutionTests.cs
+++ b/tests/Zeus.Server.Tests/PsHwPeakResolutionTests.cs
@@ -57,12 +57,18 @@ public class PsHwPeakResolutionTests
     }
 
     [Fact]
-    public void HermesLite2_Both_Protocols_Use_0_233()
+    public void HermesLite2_Both_Protocols_Use_0_20()
     {
-        // MI0BOT special-case (HL2 only). Same value either protocol —
+        // *** DEVIATION FROM mi0bot *** mi0bot returns 0.233 (PSDefaultPeak
+        // in clsHardwareSpecific.cs). Zeus drops to 0.20 based on bench
+        // measurement 2026-05-16 — typical HL2 drive into a resonant
+        // antenna produces a DDC3(tx) envelope peak ≈ 0.190. With 0.233
+        // calcc bin 15 never fills, COLLECT never advances, info5 pinned
+        // at 0 and PS is silently dead. 0.20 puts the operator inside the
+        // convergence window out of the box. Same value either protocol —
         // the HL2 hardware peak is determined by the mod, not the protocol.
-        Assert.Equal(0.233, RadioService.ResolvePsHwPeak(false, HpsdrBoardKind.HermesLite2));
-        Assert.Equal(0.233, RadioService.ResolvePsHwPeak(true, HpsdrBoardKind.HermesLite2));
+        Assert.Equal(0.20, RadioService.ResolvePsHwPeak(false, HpsdrBoardKind.HermesLite2));
+        Assert.Equal(0.20, RadioService.ResolvePsHwPeak(true, HpsdrBoardKind.HermesLite2));
     }
 
     [Theory]

--- a/tests/Zeus.Server.Tests/PsHwPeakResolutionTests.cs
+++ b/tests/Zeus.Server.Tests/PsHwPeakResolutionTests.cs
@@ -57,18 +57,19 @@ public class PsHwPeakResolutionTests
     }
 
     [Fact]
-    public void HermesLite2_Both_Protocols_Use_0_20()
+    public void HermesLite2_Both_Protocols_Use_0_2500()
     {
-        // *** DEVIATION FROM mi0bot *** mi0bot returns 0.233 (PSDefaultPeak
-        // in clsHardwareSpecific.cs). Zeus drops to 0.20 based on bench
-        // measurement 2026-05-16 — typical HL2 drive into a resonant
-        // antenna produces a DDC3(tx) envelope peak ≈ 0.190. With 0.233
-        // calcc bin 15 never fills, COLLECT never advances, info5 pinned
-        // at 0 and PS is silently dead. 0.20 puts the operator inside the
-        // convergence window out of the box. Same value either protocol —
-        // the HL2 hardware peak is determined by the mod, not the protocol.
-        Assert.Equal(0.20, RadioService.ResolvePsHwPeak(false, HpsdrBoardKind.HermesLite2));
-        Assert.Equal(0.20, RadioService.ResolvePsHwPeak(true, HpsdrBoardKind.HermesLite2));
+        // Follows deskhpsdr's "measure then slightly increase" rule
+        // (transmitter.c:1347-1371). deskhpsdr ships 0.2400 (over
+        // measured 0.2386); Zeus ships 0.2500 — same rule, marginally
+        // more headroom so the "Observed" indicator on a real voice
+        // signal (envelope peak ≈ 0.240 on EI6LF's HL2) sits comfortably
+        // inside the dead zone rather than at the fault edge. mi0bot
+        // returns 0.233 (clsHardwareSpecific.cs:312) which is slightly
+        // under the measured peak. Same value either protocol — the HL2
+        // hardware peak is determined by the mod, not the protocol.
+        Assert.Equal(0.2500, RadioService.ResolvePsHwPeak(false, HpsdrBoardKind.HermesLite2));
+        Assert.Equal(0.2500, RadioService.ResolvePsHwPeak(true, HpsdrBoardKind.HermesLite2));
     }
 
     [Theory]

--- a/tests/Zeus.Server.Tests/PsPersistenceTests.cs
+++ b/tests/Zeus.Server.Tests/PsPersistenceTests.cs
@@ -171,4 +171,101 @@ public class PsPersistenceTests : IDisposable
         // every fresh session even if Enabled=true had been set previously.
         Assert.False(snap.TwoToneEnabled);
     }
+
+    [Fact]
+    public void PsHwPeak_PersistsPerBoard_AndSurvivesRestart()
+    {
+        // KB2UKA's symptom: he hand-calibrated HW Peak to 0.655 for the G2 +
+        // RF2K-S external sample-tap chain (factory default 0.6121 is too low
+        // for that physical chain — Observed bar pegs red). Backend restart
+        // clobbered it back to 0.6121 because the old code re-derived per
+        // connect without consulting persisted state. This guards that the
+        // operator-calibrated value survives a restart and only applies to
+        // the matching board key.
+        var (radio1, store) = BuildRadioWithStore();
+        // Simulate a P2 G2 connect so RadioService caches the right board key.
+        // Variant default is G2 — that's what EffectiveOrionMkIIVariant returns
+        // without an explicit override, matching KB2UKA's bench.
+        radio1.ApplyPsHwPeakForConnection(isProtocol2: true, board: HpsdrBoardKind.OrionMkII);
+        var pristine = radio1.Snapshot();
+        Assert.Equal(0.6121, pristine.PsHwPeak);          // factory default
+        Assert.Equal(0.6121, pristine.PsHwPeakDefault);
+
+        // Operator dials in 0.655 — write should land in the per-board slot.
+        radio1.SetPsAdvanced(new PsAdvancedSetRequest(HwPeak: 0.655));
+        Assert.Equal(0.655, radio1.Snapshot().PsHwPeak);
+        var entry = store.Get();
+        Assert.NotNull(entry);
+        string g2Key = RadioService.GetPsBoardKey(true, HpsdrBoardKind.OrionMkII, OrionMkIIVariant.G2);
+        Assert.True(entry!.HwPeakByBoard.ContainsKey(g2Key));
+        Assert.Equal(0.655, entry.HwPeakByBoard[g2Key]);
+
+        // Fresh RadioService against the same on-disk DB — re-connect to the
+        // G2 should restore 0.655, NOT the factory 0.6121.
+        var (radio2, _) = BuildRadioWithStore();
+        radio2.ApplyPsHwPeakForConnection(isProtocol2: true, board: HpsdrBoardKind.OrionMkII);
+        var restored = radio2.Snapshot();
+        Assert.Equal(0.655, restored.PsHwPeak);            // operator value wins
+        Assert.Equal(0.6121, restored.PsHwPeakDefault);    // factory default still surfaced for the UI hint
+    }
+
+    [Fact]
+    public void PsHwPeak_PerBoardSlots_DontLeakAcrossBoards()
+    {
+        // Operator who switches between an HL2 and a G2 (KB2UKA does) should
+        // get the right calibrated value per radio. Setting on one board
+        // must not stomp the other's entry.
+        var (radio1, store) = BuildRadioWithStore();
+        // Calibrate the G2 first.
+        radio1.ApplyPsHwPeakForConnection(isProtocol2: true, board: HpsdrBoardKind.OrionMkII);
+        radio1.SetPsAdvanced(new PsAdvancedSetRequest(HwPeak: 0.655));
+
+        // Switch to HL2 (P1) — connect should pull the HL2 factory default
+        // (0.20 after PR #341), NOT the G2's operator-tuned 0.655.
+        radio1.ApplyPsHwPeakForConnection(isProtocol2: false, board: HpsdrBoardKind.HermesLite2);
+        Assert.Equal(0.20, radio1.Snapshot().PsHwPeak);
+
+        // Operator calibrates the HL2 to 0.21 — write should land in the HL2
+        // slot, leaving the G2 slot untouched.
+        radio1.SetPsAdvanced(new PsAdvancedSetRequest(HwPeak: 0.21));
+        Assert.Equal(0.21, radio1.Snapshot().PsHwPeak);
+
+        // Fresh RadioService — verify both per-board values survived and
+        // route to the correct board.
+        var (radio2, _) = BuildRadioWithStore();
+        radio2.ApplyPsHwPeakForConnection(isProtocol2: true, board: HpsdrBoardKind.OrionMkII);
+        Assert.Equal(0.655, radio2.Snapshot().PsHwPeak);
+        radio2.ApplyPsHwPeakForConnection(isProtocol2: false, board: HpsdrBoardKind.HermesLite2);
+        Assert.Equal(0.21, radio2.Snapshot().PsHwPeak);
+
+        // And the on-disk record contains both keys.
+        var entry = store.Get();
+        Assert.NotNull(entry);
+        Assert.Equal(2, entry!.HwPeakByBoard.Count);
+        Assert.Equal(0.655, entry.HwPeakByBoard[RadioService.GetPsBoardKey(true, HpsdrBoardKind.OrionMkII, OrionMkIIVariant.G2)]);
+        Assert.Equal(0.21, entry.HwPeakByBoard[RadioService.GetPsBoardKey(false, HpsdrBoardKind.HermesLite2, OrionMkIIVariant.G2)]);
+    }
+
+    [Fact]
+    public void PsHwPeak_DisconnectedSetAdvanced_DoesNotPollutePreviousBoardSlot()
+    {
+        // After disconnect, _currentPsBoardKey is cleared. A SetPsAdvanced
+        // call in that state should leave the previous radio's slot intact
+        // (operator dialling in the panel while disconnected must NOT
+        // overwrite a different radio's calibrated value).
+        var (radio, store) = BuildRadioWithStore();
+        radio.ApplyPsHwPeakForConnection(isProtocol2: true, board: HpsdrBoardKind.OrionMkII);
+        radio.SetPsAdvanced(new PsAdvancedSetRequest(HwPeak: 0.655));
+        // Pseudo-disconnect — DisconnectAsync would also tear down a P1
+        // client, but we only need the state-clearing portion for this test.
+        radio.MarkProtocol2Disconnected();
+        // Operator drags the slider while disconnected — value lands in the
+        // live state but should NOT touch the per-board store entry.
+        radio.SetPsAdvanced(new PsAdvancedSetRequest(HwPeak: 0.999));
+
+        var entry = store.Get();
+        Assert.NotNull(entry);
+        string g2Key = RadioService.GetPsBoardKey(true, HpsdrBoardKind.OrionMkII, OrionMkIIVariant.G2);
+        Assert.Equal(0.655, entry!.HwPeakByBoard[g2Key]);  // G2 slot untouched
+    }
 }

--- a/tests/Zeus.Server.Tests/PsPersistenceTests.cs
+++ b/tests/Zeus.Server.Tests/PsPersistenceTests.cs
@@ -221,9 +221,10 @@ public class PsPersistenceTests : IDisposable
         radio1.SetPsAdvanced(new PsAdvancedSetRequest(HwPeak: 0.655));
 
         // Switch to HL2 (P1) — connect should pull the HL2 factory default
-        // (0.20 after PR #341), NOT the G2's operator-tuned 0.655.
+        // (0.2500 after PR #341 voice-tuning revision), NOT the G2's
+        // operator-tuned 0.655.
         radio1.ApplyPsHwPeakForConnection(isProtocol2: false, board: HpsdrBoardKind.HermesLite2);
-        Assert.Equal(0.20, radio1.Snapshot().PsHwPeak);
+        Assert.Equal(0.2500, radio1.Snapshot().PsHwPeak);
 
         // Operator calibrates the HL2 to 0.21 — write should land in the HL2
         // slot, leaving the G2 slot untouched.

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -199,6 +199,11 @@ export type RadioStateDto = {
   // HardwareSpecific.PSDefaultPeak;`.
   psHwPeak: number;
   psHwPeakDefault: number;
+  // Server raises this when calcc is alive (PS armed + keyed) for >5 s with
+  // CalibrationAttempts pinned at 0 — almost always means hw_peak is set
+  // higher than the actual TX envelope peak. Drives the HW-peak warning
+  // banner in the PURESIGNAL panel.
+  psCalibrationStalled?: boolean;
   psIntsSpiPreset: string;
   psFeedbackSource: 'internal' | 'external';
   twoToneFreq1: number;
@@ -447,6 +452,8 @@ export function normalizeState(raw: unknown): RadioStateDto {
     psHwPeak: typeof r.psHwPeak === 'number' ? r.psHwPeak : 0.4072,
     psHwPeakDefault:
       typeof r.psHwPeakDefault === 'number' ? r.psHwPeakDefault : 0.4072,
+    psCalibrationStalled:
+      typeof r.psCalibrationStalled === 'boolean' ? r.psCalibrationStalled : false,
     psIntsSpiPreset: typeof r.psIntsSpiPreset === 'string' ? r.psIntsSpiPreset : '16/256',
     psFeedbackSource:
       r.psFeedbackSource === 'External' || r.psFeedbackSource === 'external' ? 'external' : 'internal',

--- a/zeus-web/src/components/PsSettingsPanel.tsx
+++ b/zeus-web/src/components/PsSettingsPanel.tsx
@@ -88,6 +88,7 @@ export function PsSettingsPanel() {
   const psCorrecting = useTxStore((s) => s.psCorrecting);
   const psCorrectionDb = useTxStore((s) => s.psCorrectionDb);
   const psMaxTxEnvelope = useTxStore((s) => s.psMaxTxEnvelope);
+  const psCalibrationStalled = useTxStore((s) => s.psCalibrationStalled);
   const setPsAuto = useTxStore((s) => s.setPsAuto);
   const setPsSingle = useTxStore((s) => s.setPsSingle);
   const setPsPtol = useTxStore((s) => s.setPsPtol);
@@ -567,6 +568,17 @@ export function PsSettingsPanel() {
             Hardware
             <span className="ps-card-hint">advanced — most users won't change</span>
           </h4>
+
+          {psCalibrationStalled ? (
+            <div
+              className="ps-stall-banner"
+              role="status"
+              aria-live="polite"
+              title="PureSignal has been keyed for more than 5 seconds without completing a calibration fit. This almost always means HW peak is set higher than the actual TX envelope peak — calcc bin 15 never fills."
+            >
+              ⚠ PS not converging — try lowering HW peak below your observed TX peak.
+            </div>
+          ) : null}
 
           <FieldRow
             label="HW peak"

--- a/zeus-web/src/components/PsSettingsPanel.tsx
+++ b/zeus-web/src/components/PsSettingsPanel.tsx
@@ -89,6 +89,11 @@ export function PsSettingsPanel() {
   const psCorrectionDb = useTxStore((s) => s.psCorrectionDb);
   const psMaxTxEnvelope = useTxStore((s) => s.psMaxTxEnvelope);
   const psCalibrationStalled = useTxStore((s) => s.psCalibrationStalled);
+  // Used to gate the "correcting" indicator — WDSP's info[14] stays high
+  // across MOX-down once calcc has a curve loaded, so without this gate the
+  // panel claims "correcting" with no RF being emitted. twoToneOn is read
+  // a few lines below for the 2-tone control row.
+  const moxOn = useTxStore((s) => s.moxOn);
   const setPsAuto = useTxStore((s) => s.setPsAuto);
   const setPsSingle = useTxStore((s) => s.setPsSingle);
   const setPsPtol = useTxStore((s) => s.setPsPtol);
@@ -206,21 +211,31 @@ export function PsSettingsPanel() {
   const feedbackLen = feedbackPct * DIAL_C;
   const feedbackRound = Math.round(psFeedbackLevel);
 
-  // Dial state visualization. Converged → green ring + "ok" pill;
-  // active calibration → animated pulse; otherwise idle.
-  const isConverged = psCorrecting;
-  const isRunning = psEnabled && !isConverged && psCalState > 0;
-  const dialClass = isConverged ? 'is-converged' : '';
-  const pillClass = isConverged ? 'ok' : isRunning ? 'run' : '';
-  const pillText = isConverged
+  // Dial state visualization. WDSP info[14] (psCorrecting) reports "iqc
+  // curve loaded + engaged" — true even when MOX is off, because the curve
+  // persists between keying cycles. Split into two pill states so the
+  // operator sees the right thing:
+  //   - "correcting" only when actively transmitting (curve applied to live RF)
+  //   - "ready"      when curve is loaded but radio is idle
+  const keyed = moxOn || twoToneOn;
+  const isCorrecting = psCorrecting && keyed;
+  const isReady = psCorrecting && !keyed;
+  const isRunning = psEnabled && !psCorrecting && psCalState > 0;
+  const dialClass = isCorrecting || isReady ? 'is-converged' : '';
+  const pillClass = isCorrecting || isReady ? 'ok' : isRunning ? 'run' : '';
+  const pillText = isCorrecting
     ? 'CAL · correcting'
-    : isRunning
-      ? 'CAL · running'
-      : 'CAL · idle';
+    : isReady
+      ? 'CAL · ready'
+      : isRunning
+        ? 'CAL · running'
+        : 'CAL · idle';
 
-  const feedbackSubText = isConverged
+  const feedbackSubText = isCorrecting
     ? `${Math.round(feedbackPct * 100)} % · locked`
-    : `${Math.round(feedbackPct * 100)} % · ${calStateLabel.toLowerCase()}`;
+    : isReady
+      ? `${Math.round(feedbackPct * 100)} % · curve loaded`
+      : `${Math.round(feedbackPct * 100)} % · ${calStateLabel.toLowerCase()}`;
 
   // Elapsed timer. Mounts when the panel mounts; resets when the operator
   // clicks Run-now or Reset. Display is purely informational.
@@ -237,10 +252,13 @@ export function PsSettingsPanel() {
   // can see whether the inverse-model dB number is jittering or stable.
   const sparkRef = useRef<number[]>([]);
   useEffect(() => {
-    if (!psCorrecting) return;
+    // Only record while actively predistorting RF — info[14] persists across
+    // MOX cycles, so without the keyed gate the sparkline would fill with
+    // stale post-key samples.
+    if (!isCorrecting) return;
     sparkRef.current.push(psCorrectionDb);
     if (sparkRef.current.length > SPARK_LEN) sparkRef.current.shift();
-  }, [psCorrectionDb, psCorrecting]);
+  }, [psCorrectionDb, isCorrecting]);
 
   const sparkPoints = buildSparkline(sparkRef.current);
 
@@ -260,7 +278,7 @@ export function PsSettingsPanel() {
   // Signal-flow node states: TX is always "on" when psEnabled; remaining
   // nodes light up when calibration is actually running so the operator
   // sees the path go live during MOX.
-  const flowActive = psEnabled && (isRunning || isConverged);
+  const flowActive = psEnabled && (isRunning || isCorrecting || isReady);
 
   return (
     <div className="ps-shell">
@@ -418,8 +436,8 @@ export function PsSettingsPanel() {
               <div className="ps-peak-row">
                 <span className="ps-peak-nm">Correction</span>
                 <span className="ps-peak-val">
-                  {psCorrecting ? `+${psCorrectionDb.toFixed(2)}` : '—'}
-                  {psCorrecting ? <small>dB</small> : null}
+                  {isCorrecting ? `+${psCorrectionDb.toFixed(2)}` : '—'}
+                  {isCorrecting ? <small>dB</small> : null}
                 </span>
               </div>
               <div className="ps-spark">
@@ -676,10 +694,12 @@ export function PsSettingsPanel() {
       <div className="ps-status-row">
         <div className="ps-status-left">
           <span>Calibration</span>
-          {psCorrecting ? (
+          {isCorrecting ? (
             <span className="saved">
               {`converged · ${psCorrectionDb.toFixed(2)} dB`}
             </span>
+          ) : isReady ? (
+            <span className="saved">curve loaded · idle</span>
           ) : (
             <span>{calStateLabel}</span>
           )}

--- a/zeus-web/src/state/tx-store.ts
+++ b/zeus-web/src/state/tx-store.ts
@@ -237,6 +237,11 @@ export type TxState = {
   psCalState: number;
   psCorrecting: boolean;
   psMaxTxEnvelope: number;
+  // Hydrated from server state — true when calcc has been alive (PS armed +
+  // keyed) for >5 s without producing a fit. Drives the HW-peak warning
+  // banner in the PURESIGNAL panel. Server-side detection in
+  // PsAutoAttenuateService stall path.
+  psCalibrationStalled: boolean;
   setPsMeters: (m: {
     feedbackLevel: number;
     correctionDb: number;
@@ -379,6 +384,7 @@ export const useTxStore = create<TxState>()(
       psCalState: 0,
       psCorrecting: false,
       psMaxTxEnvelope: 0,
+      psCalibrationStalled: false,
       setPsMeters: (m) => set({
         psFeedbackLevel: m.feedbackLevel,
         psCorrectionDb: m.correctionDb,
@@ -418,6 +424,7 @@ export const useTxStore = create<TxState>()(
           // operator-tuned psHwPeak so the UI sees a coherent pair.
           psHwPeak: s.psHwPeak,
           psHwPeakDefault: s.psHwPeakDefault,
+          psCalibrationStalled: s.psCalibrationStalled ?? false,
           twoToneFreq1: s.twoToneFreq1,
           twoToneFreq2: s.twoToneFreq2,
           twoToneMag: s.twoToneMag,

--- a/zeus-web/src/styles/ps-settings.css
+++ b/zeus-web/src/styles/ps-settings.css
@@ -538,6 +538,18 @@
   font-weight: 400;
 }
 
+.ps-stall-banner {
+  margin: 0 0 10px;
+  padding: 8px 10px;
+  border: 1px solid var(--power);
+  border-radius: var(--r-sm);
+  background: color-mix(in srgb, var(--power) 12%, transparent);
+  color: var(--fg-1);
+  font-size: 11.5px;
+  line-height: 1.35;
+  letter-spacing: 0.02em;
+}
+
 .ps-field {
   display: grid;
   grid-template-columns: 1fr auto;


### PR DESCRIPTION
## Summary

Fixes the HL2 PureSignal "breakup + audible relay" symptom reported by EI6LF (Brian). Bench-driven diagnosis on a live HL2 at 28.400 traced the issue to two compounding bugs:

1. **HL2 `hw_peak` default `0.233` is too high for typical drive.** Bench-measured DDC3(tx) envelope peak ≈ 0.190 at standard 2-tone. With `hw_peak=0.233`, calcc bin 15 never fills → COLLECT never advances to LCALC → `info5` pinned at 0. PS appears armed but is silently dead.
2. **Once `hw_peak` is corrected, the mi0bot-parity `128/181` dead-band + full `ddB` step causes the auto-attenuate dance to oscillate.** A single 2 dB attn correction overshoots the feedback target in both directions (`fb=190 → 4→6 dB → fb=117 → 6→4 dB → fb=190 → …`). Each cycle disables PS for ~300 ms via `SetPsControl(reset=1)` — audible IMD3 bloom approximately once per second = the user's "breakup".

mi0bot may not hit either of these because operators hand-tune `hw_peak` per session against the `GetPSMaxTX` observed-peak display until feedback lands near 152, narrowing the natural swing. Zeus targets out-of-the-box working PS on first connect.

## Changes (all annotated `*** DEVIATION FROM mi0bot ***` in-code)

- **HL2 `hw_peak` default `0.233` → `0.20`** in `RadioService.ResolvePsHwPeak` (P1 + P2). Test updated.
- **Dead-band `128/181` → `110/195`** so a single ±2 dB correction lands comfortably in-window.
- **3-second per-dance cooldown** in `Tick1Hl2` and `Tick1P2` Monitor state.
- **MOX-drop-mid-dance recovery**: if `_hl2State` ∈ {SetNewValues, RestoreOperation} on the hard-idle not-keyed gate, fire `SetPsControl(savedAuto, savedSingle)` before resetting to Monitor. Without this, PS sat in WDSP `reset=1` because `DspPipelineService._appliedPsAuto/_appliedPsSingle` short-circuited re-arm.
- **Stall warning**: when PS armed + keyed for >5 s with `CalibrationAttempts` pinned at 0, log a warning and surface `PsCalibrationStalled` on the `StateDto`. PURESIGNAL panel shows a banner pointing the operator at HW peak.

## Bench validation (live HL2 at 28.400 with resonant antenna)

| Test | Before | After |
|---|---|---|
| A — baseline (defaults, 25 s 2-tone) | `info5=0 fb=0` forever (calcc stuck) | `info5` climbs, `fb=192 in-window attn=4` sustained, **zero dance cycles** |
| B — `hw_peak=0.50` stall | (silent failure) | Server log `psAutoAttn.stall info5=0 for 5001ms`; banner appears in panel after 5 s; clears on unkey |
| C — `hw_peak=0.15` (forced OOB feedback) | Would oscillate indefinitely | Dance 1 (`fb=224 → attn 0→3`) → cooldown 700/1700/2800 ms → Dance 2 (`fb=205 → attn 3→6`) → cooldown → `in-window fb=146` and steady |
| D — MOX-drop-mid-dance recovery | PS stuck in `reset=1` after unkey | Code path lands; not bench-exercised (300 ms timing window too tight for the test harness) |

## Test plan

- [ ] Maintainer: bench-verify on HL2 with a real voice signal (the bench used 2-Tone only)
- [ ] Maintainer: confirm the `110/195` dead-band isn't too lax for HL2 hardware variants other than EI6LF's
- [ ] Maintainer: confirm the `0.20` `hw_peak` default is acceptable across HL2 variants (mi0bot returns `0.233` blanket)
- [ ] Maintainer: confirm stall banner copy + placement against Zeus visual design guidance
- [x] All .NET tests pass (532 server + others, 1236 total)
- [x] All frontend tests pass (208)
- [x] Build clean (no warnings, no errors)

## CLAUDE.md compliance

This PR touches operator-visible defaults (HW peak default, dead-band, cooldown timing, new UI banner) — all "red-light" per `CLAUDE.md`. Each deviation from mi0bot is annotated in-code with `*** DEVIATION FROM mi0bot ***` plus the bench measurement that justified it, so a maintainer (or future you) can roll any of them back if HL2 variants on other operators' benches don't match EI6LF's.