### PR TITLE
refactor(audio): introduce IRxAudioSink seam between DSP and transport

### DIFF
--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -66,6 +66,7 @@ public class DspPipelineService : BackgroundService,
 
     private readonly RadioService _radio;
     private readonly StreamingHub _hub;
+    private readonly IRxAudioSink[] _audioSinks;
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<DspPipelineService> _log;
 
@@ -263,12 +264,25 @@ public class DspPipelineService : BackgroundService,
     private long _calPanSnapshotMs;
     private readonly object _calPanLock = new();
 
-    public DspPipelineService(RadioService radio, StreamingHub hub, ILoggerFactory loggerFactory)
+    public DspPipelineService(
+        RadioService radio,
+        StreamingHub hub,
+        IEnumerable<IRxAudioSink> audioSinks,
+        ILoggerFactory loggerFactory)
     {
         _radio = radio;
         _hub = hub;
+        // Materialise once at construction so the per-tick fan-out is an
+        // array-index loop (no enumerator allocation, no LINQ on the hot path).
+        _audioSinks = audioSinks.ToArray();
         _loggerFactory = loggerFactory;
         _log = loggerFactory.CreateLogger<DspPipelineService>();
+    }
+
+    private void PublishAudio(in AudioFrame frame)
+    {
+        for (int i = 0; i < _audioSinks.Length; i++)
+            _audioSinks[i].Publish(in frame);
     }
 
     protected override async Task ExecuteAsync(CancellationToken ct)
@@ -1558,7 +1572,7 @@ public class DspPipelineService : BackgroundService,
                     SampleRateHz: (uint)AudioOutputRateHz,
                     SampleCount: (ushort)audioSampleCount,
                     Samples: new ReadOnlyMemory<float>(audioBuf, 0, audioSampleCount));
-                _hub.Broadcast(audioFrame);
+                PublishAudio(in audioFrame);
                 RxAudioAvailable?.Invoke(0, AudioOutputRateHz, new ReadOnlyMemory<float>(audioBuf, 0, audioSampleCount));
             }
         }
@@ -1581,7 +1595,7 @@ public class DspPipelineService : BackgroundService,
                     SampleRateHz: (uint)AudioOutputRateHz,
                     SampleCount: (ushort)monCount,
                     Samples: new ReadOnlyMemory<float>(audioBuf, 0, monCount));
-                _hub.Broadcast(monFrame);
+                PublishAudio(in monFrame);
             }
         }
 

--- a/Zeus.Server.Hosting/IRxAudioSink.cs
+++ b/Zeus.Server.Hosting/IRxAudioSink.cs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Receives demodulated audio frames produced by DspPipelineService.Tick.
+/// Both the regular RX path and the TX-monitor path publish through this
+/// seam, so an implementation handles whatever audio reaches the operator's
+/// speakers.
+///
+/// Default registration is <see cref="WebSocketAudioSink"/>, which fans out
+/// to connected WS clients via <c>StreamingHub.Broadcast(in AudioFrame)</c>.
+/// Desktop mode swaps in a native miniaudio sink in place of the WebSocket
+/// fan-out (Phase 2b).
+///
+/// Publish runs on the DSP tick thread and must not block or allocate
+/// beyond what the existing Broadcast already does — see
+/// <c>StreamingHub.Broadcast(in AudioFrame)</c> for the cost model.
+/// </summary>
+public interface IRxAudioSink
+{
+    void Publish(in AudioFrame frame);
+}

--- a/Zeus.Server.Hosting/WebSocketAudioSink.cs
+++ b/Zeus.Server.Hosting/WebSocketAudioSink.cs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Default <see cref="IRxAudioSink"/>: fans demodulated audio out to
+/// connected WebSocket clients via <see cref="StreamingHub"/>. Bit-for-bit
+/// equivalent of the pre-seam direct hub call — the wrapper exists so
+/// desktop mode can register a native sink in its place without touching
+/// the DSP tick.
+/// </summary>
+internal sealed class WebSocketAudioSink : IRxAudioSink
+{
+    private readonly StreamingHub _hub;
+
+    public WebSocketAudioSink(StreamingHub hub) => _hub = hub;
+
+    public void Publish(in AudioFrame frame) => _hub.Broadcast(in frame);
+}

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -155,6 +155,12 @@ public static class ZeusHost
             sp.GetRequiredService<Zeus.Protocol1.TxIqRing>());
         builder.Services.AddSingleton<RadioService>();
         builder.Services.AddSingleton<StreamingHub>();
+        // RX audio publish seam (Phase 1). DspPipelineService.PublishAudio
+        // fans each AudioFrame across every registered IRxAudioSink. The
+        // default WebSocketAudioSink reproduces the pre-seam direct hub
+        // broadcast; desktop mode registers NativeAudioSink in its place
+        // (Phase 2b) so the audio bypasses the WS path entirely.
+        builder.Services.AddSingleton<IRxAudioSink, WebSocketAudioSink>();
         // WDSPwisdom bootstrap: run FFTW plan caching on a worker at app start so the
         // first /api/connect isn't blocked for ~2 min while WDSP plans FFTs 64..262144.
         // Clients are told to keep Connect disabled until phase=Ready.

--- a/tests/Zeus.Server.Tests/LevelerMaxGainEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/LevelerMaxGainEndpointTests.cs
@@ -154,7 +154,7 @@ public class LevelerMaxGainEndpointTests : IClassFixture<LevelerMaxGainEndpointT
             RadioService radio,
             StreamingHub hub,
             ILoggerFactory logs,
-            MicGainEndpointTests.StubEngine engine) : DspPipelineService(radio, hub, logs)
+            MicGainEndpointTests.StubEngine engine) : DspPipelineService(radio, hub, Array.Empty<IRxAudioSink>(), logs)
         {
             public override IDspEngine CurrentEngine => engine;
         }

--- a/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
@@ -223,7 +223,7 @@ public class MicGainEndpointTests : IClassFixture<MicGainEndpointTests.Factory>
         RadioService radio,
         StreamingHub hub,
         ILoggerFactory logs,
-        StubEngine engine) : DspPipelineService(radio, hub, logs)
+        StubEngine engine) : DspPipelineService(radio, hub, Array.Empty<IRxAudioSink>(), logs)
     {
         public override IDspEngine CurrentEngine => engine;
     }

--- a/tests/Zeus.Server.Tests/TwoToneLatchTests.cs
+++ b/tests/Zeus.Server.Tests/TwoToneLatchTests.cs
@@ -54,7 +54,7 @@ public class TwoToneLatchTests : IDisposable
         var paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, _dbPath + ".pa");
         var radio = new RadioService(loggerFactory, dspStore, paStore);
         var hub = new StreamingHub(new NullLogger<StreamingHub>());
-        var pipeline = new DspPipelineService(radio, hub, loggerFactory);
+        var pipeline = new DspPipelineService(radio, hub, Array.Empty<IRxAudioSink>(), loggerFactory);
         return new TxService(radio, pipeline, hub, NullBandPlanService.Instance, new NullLogger<TxService>());
     }
 
@@ -112,7 +112,7 @@ public class TwoToneLatchTests : IDisposable
         // ConnectP2Async; here we shortcut.
         radio.MarkProtocol2Connected("127.0.0.1:1024", 48_000);
         var hub = new StreamingHub(new NullLogger<StreamingHub>());
-        var pipeline = new DspPipelineService(radio, hub, loggerFactory);
+        var pipeline = new DspPipelineService(radio, hub, Array.Empty<IRxAudioSink>(), loggerFactory);
         return (radio, new TxService(radio, pipeline, hub, NullBandPlanService.Instance, new NullLogger<TxService>()));
     }
 

--- a/tests/Zeus.Server.Tests/TxMetersSwrTripTests.cs
+++ b/tests/Zeus.Server.Tests/TxMetersSwrTripTests.cs
@@ -98,7 +98,7 @@ public class TxMetersSwrTripTests : IDisposable
         var paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, _dbPath + ".pa");
         var radio = new RadioService(loggerFactory, dspStore, paStore);
         hub = new StreamingHub(new NullLogger<StreamingHub>());
-        var pipeline = new DspPipelineService(radio, hub, loggerFactory);
+        var pipeline = new DspPipelineService(radio, hub, Array.Empty<IRxAudioSink>(), loggerFactory);
         tx = new TxService(radio, pipeline, hub, NullBandPlanService.Instance, new NullLogger<TxService>());
         return new TxMetersService(hub, radio, tx, pipeline, new NullLogger<TxMetersService>());
     }

--- a/tests/Zeus.Server.Tests/TxTimeoutTests.cs
+++ b/tests/Zeus.Server.Tests/TxTimeoutTests.cs
@@ -73,7 +73,7 @@ public class TxTimeoutTests : IDisposable
         var paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, _dbPath + ".pa");
         var radio = new RadioService(loggerFactory, dspStore, paStore);
         var hub = new StreamingHub(new NullLogger<StreamingHub>());
-        var pipeline = new DspPipelineService(radio, hub, loggerFactory);
+        var pipeline = new DspPipelineService(radio, hub, Array.Empty<IRxAudioSink>(), loggerFactory);
         tx = new TxService(radio, pipeline, hub, NullBandPlanService.Instance, new NullLogger<TxService>());
         return new TxMetersService(hub, radio, tx, pipeline, new NullLogger<TxMetersService>());
     }


### PR DESCRIPTION
## Summary

Phase 1 of a larger audio re-architecture. Introduces `IRxAudioSink` as the seam between `DspPipelineService.Tick` and the WebSocket transport, so a future native-audio sink (miniaudio in desktop mode) can replace the WS fan-out without touching the DSP tick path.

- New `IRxAudioSink` interface with single `Publish(in AudioFrame)` method
- New `WebSocketAudioSink` wrapping the existing `StreamingHub.Broadcast(in AudioFrame)` call — bit-for-bit identical pre-seam behaviour
- `DspPipelineService` materialises the registered sinks into an array once at construction (no enumerator alloc on the hot path) and fans each AudioFrame across them via a new private `PublishAudio` helper
- Two direct `_hub.Broadcast(audioFrame)` / `_hub.Broadcast(monFrame)` call sites replaced
- DI registers `WebSocketAudioSink` as the default `IRxAudioSink` in `ZeusHost.Build`

## Why now

Browser-side Web Audio adds ~300 ms of jitter buffer that is wasted latency when the operator is at the host machine (Photino desktop mode). Phase 2b will register a native miniaudio sink in place of `WebSocketAudioSink` when `--desktop` is passed, dropping end-to-end audio latency to ~20-30 ms. This PR lands the seam alone so the change is reviewable in isolation.

## What's *not* in this PR

- No native audio code yet (Phase 2b)
- No binary collapse / `--desktop` flag (Phase 2a)
- No frontend mode-awareness (Phase 2c)
- No wire-format changes — `AudioFrame` contract is untouched
- TX mic path is untouched in Phase 1; the TX-side seam is part of Phase 2b
- Volume control is already server-side (`RxAfGainDb` → WDSP `SetRXAPanelGain1` runs upstream of the sink) so no plumbing change is needed for the existing slider to drive native output once 2b lands

## Test plan

- [x] `dotnet build Zeus.slnx` — 0 warnings, 0 errors
- [x] `dotnet test Zeus.slnx` — 1049 passed, 0 failed (137 skipped, same as before)
- [ ] **Maintainer bench**: connect to HL2 on 28400, verify RX audio in the browser sounds identical to develop (no glitching, jitter buffer behaviour unchanged). The path runs through `WebSocketAudioSink` → `StreamingHub.Broadcast(in AudioFrame)` which is the original code, so this is the smoke test for the seam wiring.

## Maintainer review note

Per `CLAUDE.md`, signal-routing restructures are red-light. This is a deliberate, narrow refactor introducing a single seam — no behaviour change. Flagging anyway since it touches `DspPipelineService.Tick`.