### PR TITLE
docs(changelog): soften v0.7.4 next-release teaser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,7 @@ thanks for the careful, well-tested patches.
 
 ### A teaser for what's next
 
-If you've been asking for **a real in-process voice audio chain** — gate, EQ, compressor, leveler, de-esser, all wired into the TX path before WDSP — that's the headline feature in flight for the **next release**. RFC is up at #332, and the work extends the existing `feature/plugins-foundation` foundation Brian has been landing. The goal is the AetherSDR-style operator experience: drop a chain on TX in-app, no external Loopback / VST host, every block deterministic and CPU-cheap enough to run alongside PureSignal. Watch #332 for the v1 block cut sign-off.
+Big things coming in the next release — including one many of you have been asking about for a while. Stay tuned.
 
 ---
 


### PR DESCRIPTION
## Summary

Replaces the specific in-process-voice-audio-chain teaser at the bottom of the v0.7.4 changelog entry with a generic "big things coming" line. The audio chain RFC (#332) still has open questions on v1 block cut, license posture, and Phase 7 removal timing — promising it as the v0.7.5 headline was premature.

The release body on the v0.7.4 GitHub Release page has already been edited to match.

## Test plan

- [ ] CI green on this PR