### PR TITLE
docs(readme): bold macOS xattr Gatekeeper warning under Download

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ macOS Gatekeeper xattr step, first-run WDSP wisdom wait) is on the wiki's
 [Installation](https://github.com/Kb2uka/openhpsdr-zeus/wiki/Installation)
 page.
 
+### macOS users — read this before launching
+
+> **⚠️ IMPORTANT: After installing on macOS, run this in Terminal before opening Zeus:**
+>
+> ```bash
+> xattr -cr /Applications/Zeus.app
+> ```
+>
+> **Without this step, macOS Gatekeeper will refuse to launch Zeus** ("Zeus.app is damaged and can't be opened" or "cannot be opened because the developer cannot be verified"). Zeus is not yet signed by a registered Apple Developer; the command above strips the quarantine attribute so Gatekeeper allows the app to run. This is a one-time step per install.
+
 ## Building from source
 
 See the wiki's [Developer Guide](https://github.com/Kb2uka/openhpsdr-zeus/wiki/Developer-Guide)


### PR DESCRIPTION
## Summary

Adds a bold callout block under the Download section with the macOS xattr quarantine fix command. Prepping for a 24k-subscriber YouTube launch where the audience will skim the README and double-click the installer rather than read the wiki.

The warning includes the exact Gatekeeper error strings users will actually see ("damaged and can't be opened" / "cannot be opened because the developer cannot be verified") so a Ctrl-F lands them on the fix.

Per CLAUDE.md: README additions are green-light; this is an addition (not a restructure) and stays within the README scope by linking back to the wiki for full install detail.

## Test plan

- [ ] CI green