### PR TITLE
chore(release): 0.7.5 (hotfix for v0.7.4 TX-audio regression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ see the corresponding GitHub Release page.
 
 ---
 
+## [0.7.5] — 2026-05-16
+
+Same-day hotfix for v0.7.4 — fixes a TX-audio regression introduced by v0.7.4's PR #343. If you installed v0.7.4 today and heard chopped / intermittent carrier on SSB mic or WSJT-X / JTDX over TCI, **install this build — it's the fix**. Browser-based UI was unaffected; the regression only bit Photino-based `Zeus.Desktop` users.
+
+### Fixed
+
+- **Choppy TX audio on Zeus.Desktop after v0.7.4 — both SSB mic uplink and TCI (WSJT-X) transmission.** *(KB2UKA-Agent, PR #351, fixes #346 — reported by @rampa069)*
+  - **Root cause:** v0.7.4's PR #343 (`MoxStateFrame` broadcast for TCI TX-meter visibility) flipped the frontend `moxOn` flag on **any** MOX edge, including TCI-driven ones. The browser mic uplink worklet was gated on `moxOn`, so a TCI key-up caused the browser to start pushing silent mic PCM blocks into `TxAudioIngest._accumulator` in parallel with the TCI audio path. Both producers appended into the same `_accumulator` under `_sync`, interleaving WSJT-X tone blocks with near-silence blocks at 50 Hz. WDSP TXA processed alternating signal/silence, producing the audible "carrier cuts in and out every ~1 second" symptom and the on-wire signature `peak=1386 / 380 / 500 / 0 / 32641 …`.
+  - **Fix:** new `localMicArmed` flag in `tx-store`, raised only by local operator interaction (`MoxButton` click, spacebar PTT, `MobilePttButton` press) and lowered on the corresponding release, on server-forced MOX-off (`MoxStateFrame` off-edge, SWR trip, TCI key-up), and on WS close. `use-mic-uplink.ts` is now gated on `localMicArmed` instead of `moxOn`. Server-driven MOX-on (the TCI case) never raises the flag — that asymmetry closes the dual-feed path without breaking any of the v0.7.4 TCI TX-meter wiring. Six frontend files, no backend changes. `MoxStateFrame` wire format and the `moxOn` UI indicator are untouched.
+
+---
+
 ## [0.7.4] — 2026-05-16
 
 A correctness, capability, and polish release. **Hermes-class Protocol-1 boards

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ see the corresponding GitHub Release page.
 
 ## [0.7.5] — 2026-05-16
 
-Same-day hotfix for v0.7.4 — fixes a TX-audio regression introduced by v0.7.4's PR #343. If you installed v0.7.4 today and heard chopped / intermittent carrier on SSB mic or WSJT-X / JTDX over TCI, **install this build — it's the fix**. Browser-based UI was unaffected; the regression only bit Photino-based `Zeus.Desktop` users.
+> **🛠 THIS IS A HOTFIX RELEASE FOR v0.7.4.** If you installed v0.7.4 earlier today and heard chopped / intermittent carrier on SSB mic or WSJT-X / JTDX over TCI on the Photino-based **Zeus.Desktop** build, **install v0.7.5 — it's the fix**. Browser-based UI users on v0.7.4 were unaffected. **All v0.7.4 Zeus.Desktop operators should upgrade.**
+
+Huge thanks to **@rampa069 (Ramon Martinez)** for catching this on his bench the day v0.7.4 went out and filing a precise reproduction (#346) with on-wire packet captures that pinpointed the dual-feed pattern. That kind of report-with-evidence is what made the same-day hotfix possible.
 
 ### Fixed
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,8 +8,8 @@
     <!-- Version Management -->
     <!-- When building from a tag (e.g., v0.1.0), GITHUB_REF_NAME will be set -->
     <!-- Otherwise, fall back to the in-development VersionPrefix below.    -->
-    <!-- Bump this when a release branch opens — current target: v0.7.4.    -->
-    <VersionPrefix Condition="'$(VersionPrefix)' == ''">0.7.4</VersionPrefix>
+    <!-- Bump this when a release branch opens — current target: v0.7.5.    -->
+    <VersionPrefix Condition="'$(VersionPrefix)' == ''">0.7.5</VersionPrefix>
     <VersionSuffix Condition="'$(VersionSuffix)' == '' AND '$(GITHUB_REF_TYPE)' != 'tag'">dev</VersionSuffix>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>

--- a/zeus-web/src/components/AboutPanel.tsx
+++ b/zeus-web/src/components/AboutPanel.tsx
@@ -25,6 +25,7 @@ import { useEffect, useState } from 'react';
 // VersionPrefix in Directory.Build.props bumps. ISO 8601 so toLocaleDateString
 // renders sensibly in any locale.
 const RELEASE_DATE_ISO = '2026-05-16';
+// Note: v0.7.5 is the same-day hotfix for v0.7.4 (PR #351 — TCI dual-feed regression).
 
 type VersionInfo = {
   version: string;


### PR DESCRIPTION
## Summary

Same-day **hotfix release** cutting v0.7.5 from current develop. Ships PR #351 — the fix for #346 (TCI / SSB mic dual-feed into TX accumulator) which was a regression introduced by v0.7.4's PR #343.

## Why now

YouTube launch incoming on a 24k-subscriber ham radio channel. v0.7.4 Zeus.Desktop users hit chopped TX audio the moment they try SSB or WSJT-X — the exact path a viewer will take. Browser-based UI users are unaffected, but the auto-recommended installer is Desktop. Fixing this before viewers land is the right move.

## Changes

- `Directory.Build.props` — `VersionPrefix` 0.7.4 → 0.7.5
- `zeus-web/src/components/AboutPanel.tsx` — `RELEASE_DATE_ISO` annotated as v0.7.5 (same date as v0.7.4 — same-day hotfix)
- `CHANGELOG.md` — new `[0.7.5]` section above `[0.7.4]`

## Test plan

- [x] `dotnet build Zeus.slnx` — 0 warnings, 0 errors
- [ ] CI green on this PR
- [ ] After merge → develop → main release-merge → tag `v0.7.5` on main → release.yml builds installers + GitHub Release
- [ ] Edit release body, rotate pinned issue (#353 → new v0.7.5 announcement)