### PR TITLE
Release v0.7.5 — hotfix for v0.7.4 TX-audio regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,7 @@ thanks for the careful, well-tested patches.
 
 ### A teaser for what's next
 
-If you've been asking for **a real in-process voice audio chain** — gate, EQ, compressor, leveler, de-esser, all wired into the TX path before WDSP — that's the headline feature in flight for the **next release**. RFC is up at #332, and the work extends the existing `feature/plugins-foundation` foundation Brian has been landing. The goal is the AetherSDR-style operator experience: drop a chain on TX in-app, no external Loopback / VST host, every block deterministic and CPU-cheap enough to run alongside PureSignal. Watch #332 for the v1 block cut sign-off.
+Big things coming in the next release — including one many of you have been asking about for a while. Stay tuned.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ see the corresponding GitHub Release page.
 
 ---
 
+## [0.7.5] — 2026-05-16
+
+Same-day hotfix for v0.7.4 — fixes a TX-audio regression introduced by v0.7.4's PR #343. If you installed v0.7.4 today and heard chopped / intermittent carrier on SSB mic or WSJT-X / JTDX over TCI, **install this build — it's the fix**. Browser-based UI was unaffected; the regression only bit Photino-based `Zeus.Desktop` users.
+
+### Fixed
+
+- **Choppy TX audio on Zeus.Desktop after v0.7.4 — both SSB mic uplink and TCI (WSJT-X) transmission.** *(KB2UKA-Agent, PR #351, fixes #346 — reported by @rampa069)*
+  - **Root cause:** v0.7.4's PR #343 (`MoxStateFrame` broadcast for TCI TX-meter visibility) flipped the frontend `moxOn` flag on **any** MOX edge, including TCI-driven ones. The browser mic uplink worklet was gated on `moxOn`, so a TCI key-up caused the browser to start pushing silent mic PCM blocks into `TxAudioIngest._accumulator` in parallel with the TCI audio path. Both producers appended into the same `_accumulator` under `_sync`, interleaving WSJT-X tone blocks with near-silence blocks at 50 Hz. WDSP TXA processed alternating signal/silence, producing the audible "carrier cuts in and out every ~1 second" symptom and the on-wire signature `peak=1386 / 380 / 500 / 0 / 32641 …`.
+  - **Fix:** new `localMicArmed` flag in `tx-store`, raised only by local operator interaction (`MoxButton` click, spacebar PTT, `MobilePttButton` press) and lowered on the corresponding release, on server-forced MOX-off (`MoxStateFrame` off-edge, SWR trip, TCI key-up), and on WS close. `use-mic-uplink.ts` is now gated on `localMicArmed` instead of `moxOn`. Server-driven MOX-on (the TCI case) never raises the flag — that asymmetry closes the dual-feed path without breaking any of the v0.7.4 TCI TX-meter wiring. Six frontend files, no backend changes. `MoxStateFrame` wire format and the `moxOn` UI indicator are untouched.
+
+---
+
 ## [0.7.4] — 2026-05-16
 
 A correctness, capability, and polish release. **Hermes-class Protocol-1 boards

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ see the corresponding GitHub Release page.
 
 ## [0.7.5] — 2026-05-16
 
-Same-day hotfix for v0.7.4 — fixes a TX-audio regression introduced by v0.7.4's PR #343. If you installed v0.7.4 today and heard chopped / intermittent carrier on SSB mic or WSJT-X / JTDX over TCI, **install this build — it's the fix**. Browser-based UI was unaffected; the regression only bit Photino-based `Zeus.Desktop` users.
+> **🛠 THIS IS A HOTFIX RELEASE FOR v0.7.4.** If you installed v0.7.4 earlier today and heard chopped / intermittent carrier on SSB mic or WSJT-X / JTDX over TCI on the Photino-based **Zeus.Desktop** build, **install v0.7.5 — it's the fix**. Browser-based UI users on v0.7.4 were unaffected. **All v0.7.4 Zeus.Desktop operators should upgrade.**
+
+Huge thanks to **@rampa069 (Ramon Martinez)** for catching this on his bench the day v0.7.4 went out and filing a precise reproduction (#346) with on-wire packet captures that pinpointed the dual-feed pattern. That kind of report-with-evidence is what made the same-day hotfix possible.
 
 ### Fixed
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,8 +8,8 @@
     <!-- Version Management -->
     <!-- When building from a tag (e.g., v0.1.0), GITHUB_REF_NAME will be set -->
     <!-- Otherwise, fall back to the in-development VersionPrefix below.    -->
-    <!-- Bump this when a release branch opens — current target: v0.7.4.    -->
-    <VersionPrefix Condition="'$(VersionPrefix)' == ''">0.7.4</VersionPrefix>
+    <!-- Bump this when a release branch opens — current target: v0.7.5.    -->
+    <VersionPrefix Condition="'$(VersionPrefix)' == ''">0.7.5</VersionPrefix>
     <VersionSuffix Condition="'$(VersionSuffix)' == '' AND '$(GITHUB_REF_TYPE)' != 'tag'">dev</VersionSuffix>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>

--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ macOS Gatekeeper xattr step, first-run WDSP wisdom wait) is on the wiki's
 [Installation](https://github.com/Kb2uka/openhpsdr-zeus/wiki/Installation)
 page.
 
+### macOS users — read this before launching
+
+> **⚠️ IMPORTANT: After installing on macOS, run this in Terminal before opening Zeus:**
+>
+> ```bash
+> xattr -cr /Applications/Zeus.app
+> ```
+>
+> **Without this step, macOS Gatekeeper will refuse to launch Zeus** ("Zeus.app is damaged and can't be opened" or "cannot be opened because the developer cannot be verified"). Zeus is not yet signed by a registered Apple Developer; the command above strips the quarantine attribute so Gatekeeper allows the app to run. This is a one-time step per install.
+
 ## Building from source
 
 See the wiki's [Developer Guide](https://github.com/Kb2uka/openhpsdr-zeus/wiki/Developer-Guide)

--- a/zeus-web/src/audio/use-mic-uplink.ts
+++ b/zeus-web/src/audio/use-mic-uplink.ts
@@ -94,9 +94,13 @@ export function useMicUplink(): void {
         windowPeak = 0;
       }
 
-      // Samples: only forwarded to the server while keyed. Capturing always +
+      // Samples: only forwarded when the local operator has actually keyed
+      // (MoxButton / spacebar PTT / MobilePttButton). Capturing always +
       // gating here avoids a ~300 ms getUserMedia cold-start on every MOX.
-      if (useTxStore.getState().moxOn) sendMicPcm(samples);
+      // Gated on localMicArmed rather than moxOn so a server-side MOX edge
+      // from a TCI client (WSJT-X / MSHV) doesn't make the browser race the
+      // TCI audio path into TxAudioIngest._accumulator. See issue #346.
+      if (useTxStore.getState().localMicArmed) sendMicPcm(samples);
     })
       .then((h) => {
         if (disposed) { void h.stop(); return; }

--- a/zeus-web/src/components/AboutPanel.tsx
+++ b/zeus-web/src/components/AboutPanel.tsx
@@ -25,6 +25,7 @@ import { useEffect, useState } from 'react';
 // VersionPrefix in Directory.Build.props bumps. ISO 8601 so toLocaleDateString
 // renders sensibly in any locale.
 const RELEASE_DATE_ISO = '2026-05-16';
+// Note: v0.7.5 is the same-day hotfix for v0.7.4 (PR #351 — TCI dual-feed regression).
 
 type VersionInfo = {
   version: string;

--- a/zeus-web/src/components/MobilePttButton.tsx
+++ b/zeus-web/src/components/MobilePttButton.tsx
@@ -56,20 +56,25 @@ export function MobilePttButton() {
   const connected = useConnectionStore((s) => s.status === 'Connected');
   const moxOn = useTxStore((s) => s.moxOn);
   const setMoxOn = useTxStore((s) => s.setMoxOn);
+  const setLocalMicArmed = useTxStore((s) => s.setLocalMicArmed);
   const abortRef = useRef<AbortController | null>(null);
 
   const drive = useCallback(
     (on: boolean) => {
       if (useTxStore.getState().moxOn === on) return;
       setMoxOn(on);
+      setLocalMicArmed(on);
       abortRef.current?.abort();
       const ctrl = new AbortController();
       abortRef.current = ctrl;
       setMox(on, ctrl.signal).catch(() => {
-        if (!ctrl.signal.aborted) setMoxOn(!on);
+        if (!ctrl.signal.aborted) {
+          setMoxOn(!on);
+          setLocalMicArmed(!on);
+        }
       });
     },
-    [setMoxOn],
+    [setMoxOn, setLocalMicArmed],
   );
 
   const onDown = useCallback(

--- a/zeus-web/src/components/MoxButton.tsx
+++ b/zeus-web/src/components/MoxButton.tsx
@@ -56,16 +56,19 @@ export function MoxButton() {
   const connected = useConnectionStore((s) => s.status === 'Connected');
   const moxOn = useTxStore((s) => s.moxOn);
   const setMoxOn = useTxStore((s) => s.setMoxOn);
+  const setLocalMicArmed = useTxStore((s) => s.setLocalMicArmed);
 
   const click = useCallback(() => {
     const next = !moxOn;
     // PERF_PASS_3_DEBUG: t0 — operator-initiated MOX edge wall-clock. Uncommitted.
     console.log('mox.client.release', performance.now(), 'next=', next);
     setMoxOn(next);
+    setLocalMicArmed(next);
     setMox(next).catch(() => {
       setMoxOn(!next);
+      setLocalMicArmed(!next);
     });
-  }, [moxOn, setMoxOn]);
+  }, [moxOn, setMoxOn, setLocalMicArmed]);
 
   return (
     <button

--- a/zeus-web/src/realtime/ws-client.ts
+++ b/zeus-web/src/realtime/ws-client.ts
@@ -209,7 +209,9 @@ export function startRealtime(path = '/ws'): () => void {
       // Server-side, StreamingHub drops MOX on its end — this is the paired
       // client-side cleanup so the MOX button reverts to RX even if we can't
       // round-trip a POST (the HTTP path may be down too).
-      if (useTxStore.getState().moxOn) useTxStore.getState().setMoxOn(false);
+      const txOnClose = useTxStore.getState();
+      if (txOnClose.moxOn) txOnClose.setMoxOn(false);
+      if (txOnClose.localMicArmed) txOnClose.setLocalMicArmed(false);
       if (activeWs === ws) activeWs = null;
       ws = null;
       schedule();
@@ -400,6 +402,12 @@ export function startRealtime(path = '/ws'): () => void {
           } else {
             txStore.setMoxOn(false);
             txStore.setTunOn(false);
+            // Server forced MOX off (SWR trip, TX timeout, TCI key-up) — also
+            // disarm the local mic so the browser stops pushing samples even if
+            // the operator never released their MoxButton / spacebar. Inverse
+            // is intentional asymmetric: server-side MOX-on never raises
+            // localMicArmed (only local interaction does — see issue #346).
+            if (txStore.localMicArmed) txStore.setLocalMicArmed(false);
           }
           return;
         }

--- a/zeus-web/src/state/tx-store.ts
+++ b/zeus-web/src/state/tx-store.ts
@@ -104,6 +104,15 @@ export type Alert = {
 export type TxState = {
   moxOn: boolean;
   setMoxOn: (on: boolean) => void;
+  // Gates the mic-uplink WS push (use-mic-uplink.ts). Raised only by local
+  // operator interaction — MoxButton click, spacebar PTT, MobilePttButton —
+  // and lowered on the same interaction's release or when the server forces
+  // MOX off (SWR trip, TX timeout, MoxStateFrame off-edge). NOT raised when
+  // moxOn flips because of a TCI-driven server broadcast (issue #346): if
+  // we raised it there, the browser would push silent mic samples in
+  // parallel with the TCI audio path and corrupt the TX accumulator.
+  localMicArmed: boolean;
+  setLocalMicArmed: (on: boolean) => void;
   // PRD FR-7: TUN keys a single-tone carrier via WDSP SetTXAPostGen*.
   // Mutually exclusive with MOX — one is always canceled by the other so the
   // backend never sees both keyed. Exclusion is enforced inside the setters.
@@ -283,6 +292,8 @@ export const useTxStore = create<TxState>()(
     (set) => ({
       moxOn: false,
       setMoxOn: (on) => set(on ? { moxOn: true, tunOn: false } : { moxOn: false }),
+      localMicArmed: false,
+      setLocalMicArmed: (on) => set({ localMicArmed: on }),
       tunOn: false,
       setTunOn: (on) => set(on ? { tunOn: true, moxOn: false } : { tunOn: false }),
       drivePercent: 10,

--- a/zeus-web/src/util/use-keyboard-shortcuts.ts
+++ b/zeus-web/src/util/use-keyboard-shortcuts.ts
@@ -146,11 +146,16 @@ export function useKeyboardShortcuts() {
       const tx = useTxStore.getState();
       if (tx.moxOn === on) return;
       tx.setMoxOn(on);
+      tx.setLocalMicArmed(on);
       moxAbort?.abort();
       const ctrl = new AbortController();
       moxAbort = ctrl;
       setMox(on, ctrl.signal).catch(() => {
-        if (!ctrl.signal.aborted) useTxStore.getState().setMoxOn(!on);
+        if (!ctrl.signal.aborted) {
+          const t = useTxStore.getState();
+          t.setMoxOn(!on);
+          t.setLocalMicArmed(!on);
+        }
       });
     };
 


### PR DESCRIPTION
Release-merge PR opening **v0.7.5** to \`main\`. Same-day hotfix for v0.7.4 — fixes the TCI / SSB mic dual-feed regression introduced by v0.7.4's PR #343.

After this merges, the \`v0.7.5\` tag will be pushed on \`main\` HEAD and \`release.yml\` will rebuild the installers + auto-create the GitHub Release.

## Single fix shipping in v0.7.5

- **PR #351** (KB2UKA-Agent, fixes #346 — reported by **@rampa069**): gate browser mic uplink on a new \`localMicArmed\` flag (raised only by local operator interaction, not by server-driven MOX edges) to prevent dual-feed into the TX accumulator when TCI keys the radio. Six frontend files, no backend changes. \`MoxStateFrame\` wire format is untouched.

## Why same-day

YouTube launch incoming on a 24k-subscriber ham radio channel. v0.7.4 Zeus.Desktop users heard chopped TX audio the moment they tried SSB or WSJT-X — the exact path a viewer will take. Browser-based UI users were unaffected, but the auto-recommended installer is Desktop. Fixing this before viewers land is the right move.

## Issues that close on this merge

- #346 — auto-closes via PR #351's \"Fixes #346\"

## Test plan

- [x] CI green on the release-prep PR (#355)
- [ ] CI green on this PR
- [ ] After merge: push annotated \`v0.7.5\` tag on \`main\` HEAD — release.yml builds installers + creates GitHub Release
- [ ] Edit the auto-created release body with the operator-readable copy (What's New above Downloads)
- [ ] Pin new v0.7.5 announcement issue, unpin + close #353
- [ ] Sync \`main → develop\` after tag-cut