### PR TITLE
style(light): improve light mode, save mode in db

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -500,6 +500,21 @@ public sealed record NrUiPrefsSetRequest(
     bool Nr2Expanded,
     bool Nr4Expanded);
 
+// Operator UI theme + per-token colour overrides. `Theme` is one of "dark"
+// | "light" — the theme overlay attribute set on <html data-theme="…">.
+// `Overrides` maps CSS custom-property names (e.g. "--accent") to upper-case
+// 6-digit hex strings; an empty/missing map means "use stylesheet defaults".
+// Server-side LiteDB persistence (previously localStorage) so the operator's
+// look-and-feel follows them across browsers and devices pointed at the
+// same Zeus instance — same pattern as DisplaySettingsStore / NrUiPrefsStore.
+public sealed record ThemeSettingsDto(
+    string Theme,
+    IReadOnlyDictionary<string, string> Overrides);
+
+public sealed record ThemeSettingsSetRequest(
+    string Theme,
+    IReadOnlyDictionary<string, string> Overrides);
+
 // Per-slot pin state for the classic-layout bottom row (Logbook + TX
 // Stage Meters). True = panel is pinned (full body visible). False =
 // collapsed to a chip strip below the pinned tier. Persisted server-side

--- a/Zeus.Server.Hosting/ThemeSettingsStore.cs
+++ b/Zeus.Server.Hosting/ThemeSettingsStore.cs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using LiteDB;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+// Persists the operator's chosen theme ("dark" | "light") and the per-CSS-
+// variable colour overrides driven from the Theme Settings panel. Previously
+// kept in browser localStorage, which is per-origin and per-device — the
+// operator's tablet kept reverting to dark while their desktop sat in light.
+// Moving it to LiteDB lets a single look-and-feel follow the operator across
+// every browser pointed at the Zeus instance, same pattern as
+// DisplaySettingsStore + NrUiPrefsStore.
+public sealed class ThemeSettingsStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<ThemeSettingsEntry> _docs;
+    private readonly ILogger<ThemeSettingsStore> _log;
+    private readonly object _sync = new();
+
+    public ThemeSettingsStore(ILogger<ThemeSettingsStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _docs = _db.GetCollection<ThemeSettingsEntry>("theme_settings");
+
+        _log.LogInformation("ThemeSettingsStore initialized at {Path}", dbPath);
+    }
+
+    public ThemeSettingsDto Get()
+    {
+        lock (_sync)
+        {
+            var e = _docs.FindAll().FirstOrDefault();
+            if (e is null)
+            {
+                return new ThemeSettingsDto(
+                    Theme: "dark",
+                    Overrides: new Dictionary<string, string>());
+            }
+            return new ThemeSettingsDto(
+                Theme: NormalizeTheme(e.Theme),
+                Overrides: SanitiseOverrides(e.Overrides));
+        }
+    }
+
+    public void Set(string theme, IReadOnlyDictionary<string, string>? overrides)
+    {
+        lock (_sync)
+        {
+            var e = _docs.FindAll().FirstOrDefault() ?? new ThemeSettingsEntry();
+            e.Theme = NormalizeTheme(theme);
+            // Persist a defensive copy as a plain Dictionary<string,string> so
+            // LiteDB's BSON mapper has a concrete type to serialise. Sanitise
+            // here too — clients can't poison the DB with non-hex blobs.
+            e.Overrides = SanitiseOverrides(overrides)
+                .ToDictionary(kv => kv.Key, kv => kv.Value);
+            e.UpdatedUtc = DateTime.UtcNow;
+            if (e.Id == 0) _docs.Insert(e);
+            else _docs.Update(e);
+        }
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private static string NormalizeTheme(string? raw) =>
+        raw switch
+        {
+            "dark" or "light" => raw,
+            _ => "dark",
+        };
+
+    // Accept only CSS custom-property keys ("--xxx") with 6-digit hex values.
+    // Anything else is silently dropped — keeps malformed override blobs from
+    // making it into the stylesheet.
+    private static Dictionary<string, string> SanitiseOverrides(IReadOnlyDictionary<string, string>? raw)
+    {
+        var clean = new Dictionary<string, string>();
+        if (raw is null) return clean;
+        foreach (var kv in raw)
+        {
+            if (string.IsNullOrWhiteSpace(kv.Key) || !kv.Key.StartsWith("--", StringComparison.Ordinal)) continue;
+            if (kv.Value is null) continue;
+            var v = kv.Value.Trim().ToUpperInvariant();
+            if (v.Length != 7 || v[0] != '#') continue;
+            var hexOk = true;
+            for (var i = 1; i < 7; i++)
+            {
+                var c = v[i];
+                if (!((c >= '0' && c <= '9') || (c >= 'A' && c <= 'F'))) { hexOk = false; break; }
+            }
+            if (!hexOk) continue;
+            clean[kv.Key] = v;
+        }
+        return clean;
+    }
+}
+
+public sealed class ThemeSettingsEntry
+{
+    public int Id { get; set; }
+    public string Theme { get; set; } = "dark";
+    public Dictionary<string, string> Overrides { get; set; } = new();
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -777,6 +777,19 @@ public static class ZeusEndpoints
             return Results.Ok(store.Get());
         });
 
+        // Operator UI theme ("dark" | "light") + per-CSS-variable colour
+        // overrides. PUT replaces both atomically — overrides is a full snapshot,
+        // not a partial patch, because the picker tracks all rows together.
+        // Persisted in zeus-prefs.db so the look-and-feel follows the operator
+        // across browsers / devices, same pattern as /api/nr-ui-prefs.
+        app.MapGet("/api/theme-settings", (ThemeSettingsStore store) => Results.Ok(store.Get()));
+
+        app.MapPut("/api/theme-settings", (ThemeSettingsSetRequest req, ThemeSettingsStore store) =>
+        {
+            store.Set(req.Theme, req.Overrides);
+            return Results.Ok(store.Get());
+        });
+
         // Radio selection — operator preference seeding, with discovery as the
         // tiebreaker. Preferred=="Auto" removes the override (stored as absence,
         // not a sentinel enum value). Effective = Connected when connected (which

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -231,6 +231,7 @@ public static class ZeusHost
         builder.Services.AddSingleton<FilterPresetStore>();
         builder.Services.AddSingleton<DisplaySettingsStore>();
         builder.Services.AddSingleton<NrUiPrefsStore>();
+        builder.Services.AddSingleton<ThemeSettingsStore>();
         builder.Services.AddSingleton<BottomPinStore>();
         builder.Services.AddSingleton<RadioStateStore>();
         builder.Services.AddSingleton<QrzService>();

--- a/zeus-web/src/api/themeSettings.ts
+++ b/zeus-web/src/api/themeSettings.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// Tiny client for /api/theme-settings — persists the operator's chosen
+// theme ("dark" | "light") and per-CSS-variable colour overrides in LiteDB
+// so the look-and-feel follows them across browsers + devices.
+// Mirrors src/api/nrUiPrefs.ts; same minimal-API call shape.
+
+export type ThemeIdRaw = 'dark' | 'light';
+
+export type ThemeSettingsState = {
+  theme: ThemeIdRaw;
+  overrides: Record<string, string>;
+};
+
+type ThemeSettingsDtoRaw = {
+  theme?: string;
+  overrides?: Record<string, string> | null;
+};
+
+function normalize(raw: ThemeSettingsDtoRaw): ThemeSettingsState {
+  const theme: ThemeIdRaw = raw.theme === 'light' ? 'light' : 'dark';
+  const overrides: Record<string, string> = {};
+  if (raw.overrides) {
+    for (const [k, v] of Object.entries(raw.overrides)) {
+      if (typeof v === 'string' && /^#[0-9A-Fa-f]{6}$/.test(v)) {
+        overrides[k] = v.toUpperCase();
+      }
+    }
+  }
+  return { theme, overrides };
+}
+
+export async function fetchThemeSettings(signal?: AbortSignal): Promise<ThemeSettingsState> {
+  const res = await fetch('/api/theme-settings', { signal });
+  if (!res.ok) throw new Error(`GET /api/theme-settings → ${res.status}`);
+  return normalize((await res.json()) as ThemeSettingsDtoRaw);
+}
+
+export async function updateThemeSettings(
+  next: ThemeSettingsState,
+  signal?: AbortSignal,
+): Promise<ThemeSettingsState> {
+  const res = await fetch('/api/theme-settings', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ theme: next.theme, overrides: next.overrides }),
+    signal,
+  });
+  if (!res.ok) throw new Error(`PUT /api/theme-settings → ${res.status}`);
+  return normalize((await res.json()) as ThemeSettingsDtoRaw);
+}

--- a/zeus-web/src/components/PaSettingsPanel.tsx
+++ b/zeus-web/src/components/PaSettingsPanel.tsx
@@ -228,9 +228,7 @@ export function PaSettingsPanel() {
     <div className="pa-settings density-compact space-y-6">
       <section>
         <div className="mb-2 flex items-center justify-between gap-3">
-          <h3 className="text-xs font-semibold uppercase tracking-widest text-neutral-300">
-            Global
-          </h3>
+          <h3 className="pa-section-h">Global</h3>
           <button
             type="button"
             onClick={handleResetToDefaults}
@@ -246,19 +244,20 @@ export function PaSettingsPanel() {
             Reset to {resetTargetLabel}
           </button>
         </div>
-        <div className="grid grid-cols-1 gap-4 rounded bg-neutral-800/40 p-3 md:grid-cols-2">
-          <label className="flex items-center gap-2 text-xs text-neutral-300">
+        <div className="pa-card grid grid-cols-1 gap-4 p-3 md:grid-cols-2">
+          <label className="pa-field flex items-center gap-2 text-xs">
             <input
               type="checkbox"
               checked={settings.global.paEnabled}
               onChange={(e) => setGlobal({ paEnabled: e.target.checked })}
-              className="h-4 w-4 accent-[#4a9eff]"
+              className="h-4 w-4"
+              style={{ accentColor: 'var(--accent)' }}
             />
             PA Enabled
           </label>
 
           <label
-            className="flex items-center gap-2 text-xs text-neutral-300"
+            className="pa-field flex items-center gap-2 text-xs"
             title="Rated PA output in watts. Slider 100% targets this wattage. Seeded from the connected board kind — HL2 = 5 W, Hermes-class = 10 W, ANAN/Orion/G2 = 100 W. Set to 0 to fall back to the raw drive-byte mode (PA Gain field is ignored)."
           >
             Rated PA Output (W)
@@ -273,10 +272,10 @@ export function PaSettingsPanel() {
                   paMaxPowerWatts: clamp(Number(e.target.value) || 0, PA_MAX_W_MIN, PA_MAX_W_MAX),
                 })
               }
-              className="w-20 rounded border border-neutral-700 bg-neutral-900 px-2 py-0.5 text-right text-xs text-neutral-100"
+              className="pa-num-input w-20 rounded px-2 py-0.5 text-right text-xs"
             />
             {settings.global.paMaxPowerWatts === 0 && (
-              <span className="text-[10px] text-amber-400">
+              <span className="text-[10px]" style={{ color: 'var(--amber)' }}>
                 (0 = raw drive-byte mode — PA Gain ignored)
               </span>
             )}
@@ -285,18 +284,16 @@ export function PaSettingsPanel() {
       </section>
 
       <section>
-        <h3 className="mb-2 text-xs font-semibold uppercase tracking-widest text-neutral-300">
-          Per Band
-        </h3>
+        <h3 className="pa-section-h mb-2">Per Band</h3>
         {showAutoCol && (
-          <p className="mb-2 text-[10px] text-neutral-500">
+          <p className="pa-hint mb-2 text-[10px]">
             Auto column shows the N2ADR LPF mask the HL2 fires automatically on band change.
             These pins assert even when your OC TX / OC RX rows below are empty — pin colour matches state.
           </p>
         )}
-        <div className="overflow-x-auto rounded bg-neutral-800/40">
+        <div className="pa-card overflow-x-auto">
           <table className="w-full border-collapse text-xs">
-            <thead className="text-[10px] uppercase tracking-wider text-neutral-500">
+            <thead className="pa-col-head text-[10px] uppercase tracking-wider">
               <tr>
                 <th className="px-2 py-2 text-left">Band</th>
                 <th className="px-2 py-2 text-right" title={paFieldTitle}>
@@ -320,7 +317,7 @@ export function PaSettingsPanel() {
                 const b = settings.bands.find((x) => x.band === bandName);
                 if (!b) return null;
                 return (
-                  <tr key={bandName} className="pa-row border-t border-neutral-800 text-neutral-300">
+                  <tr key={bandName} className="pa-row pa-band-row">
                     <td className="px-2 font-mono">{b.band}</td>
                     <td className="px-2">
                       <PaSlider
@@ -341,7 +338,8 @@ export function PaSettingsPanel() {
                         type="checkbox"
                         checked={b.disablePa}
                         onChange={(e) => setBand(b.band, { disablePa: e.target.checked })}
-                        className="h-3 w-3 accent-[#4a9eff]"
+                        className="h-3 w-3"
+                        style={{ accentColor: 'var(--accent)' }}
                       />
                     </td>
                     {showAutoCol && (
@@ -375,7 +373,7 @@ export function PaSettingsPanel() {
         </div>
       </section>
 
-      <p className="text-[11px] text-neutral-500">
+      <p className="pa-hint text-[11px]">
         {inflight ? 'Saving…' : loaded ? 'Loaded from server — use APPLY below to persist edits' : 'Loading…'}
         {error ? ` · error: ${error}` : ''}
       </p>

--- a/zeus-web/src/components/ThemeApplier.tsx
+++ b/zeus-web/src/components/ThemeApplier.tsx
@@ -19,6 +19,17 @@ import { useThemeStore } from '../state/theme-store';
 export function ThemeApplier(): null {
   const theme = useThemeStore((s) => s.theme);
   const overrides = useThemeStore((s) => s.overrides);
+  const hydrate = useThemeStore((s) => s.hydrate);
+
+  // Pull the authoritative theme + overrides from the backend on mount.
+  // The store's initial values come from localStorage (synchronous, so
+  // [data-theme] lands before first paint — no light/dark flash); hydrate
+  // then reconciles against /api/theme-settings so the operator's choice
+  // follows them across browsers. Fire-and-forget — hydrate() catches its
+  // own errors and falls back to the local cache.
+  useEffect(() => {
+    void hydrate();
+  }, [hydrate]);
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);

--- a/zeus-web/src/components/ThemeSettingsPanel.tsx
+++ b/zeus-web/src/components/ThemeSettingsPanel.tsx
@@ -4,7 +4,7 @@
 // Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
 // See LICENSE for the full GPL text.
 
-import type { CSSProperties } from 'react';
+import { useEffect, useState, type CSSProperties } from 'react';
 import {
   TWEAKABLE_TOKENS,
   useThemeStore,
@@ -12,57 +12,131 @@ import {
   type TweakableToken,
 } from '../state/theme-store';
 
-// Operator-facing label + default colour per tweakable token. The default
-// is the value that ships in tokens.css for the DARK theme; that's what
-// resetting an override falls back to (the light overlay then re-skins
-// surface colours independently). Keep this aligned with tokens.css —
-// the colour rectangle in the picker only matches when the default
-// matches the stylesheet.
+// Operator-facing label + group per tweakable token. "group" controls which
+// section of the panel renders the row — accent tokens get the friendly
+// "tweak the feel" group, surface tokens get a separate section with a
+// warning that pushing them too far can break contrast.
+//
+// The shown swatch value is read live from the document's computed style
+// (so it tracks both the active theme overlay and any operator overrides),
+// not from a hardcoded default. This means surface tokens like --bg-0 show
+// the silver value in light mode and the near-black value in dark mode,
+// even before the user has saved an override.
+type TokenGroup = 'accent' | 'chassis' | 'line' | 'text';
+
 const TOKEN_META: Record<
   TweakableToken,
-  { label: string; help: string; default: string }
+  { label: string; help: string; group: TokenGroup }
 > = {
   '--accent': {
     label: 'Accent',
     help: 'Active controls, selection rings, sidebar highlight.',
-    default: '#0c5f9c',
+    group: 'accent',
   },
   '--accent-bright': {
     label: 'Accent (bright)',
     help: 'Highlighted text — VFO label, value digits.',
-    default: '#4ea6ff',
+    group: 'accent',
   },
   '--tx': {
     label: 'TX',
     help: 'MOX / ON-AIR red, gain-reduction caps.',
-    default: '#ff4a59',
+    group: 'accent',
   },
   '--power': {
     label: 'Power',
     help: 'Forward-power, drive digits, yellow accents.',
-    default: '#ffb13c',
+    group: 'accent',
   },
   '--amber': {
     label: 'Amber',
     help: 'Warning band on meters, warm halo around LEDs.',
-    default: '#ffb13c',
+    group: 'accent',
   },
   '--cyan': {
     label: 'Cyan',
     help: 'Secondary signal indicators, scope grid.',
-    default: '#4dc9ff',
+    group: 'accent',
   },
   '--ok': {
     label: 'OK / Green',
     help: 'Healthy state, lower band of meter ramps.',
-    default: '#2dd566',
+    group: 'accent',
   },
   '--orange': {
     label: 'Orange',
     help: 'Mid band on meter ramps, intermediate signals.',
-    default: '#ff8a3c',
+    group: 'accent',
+  },
+  '--bg-0': {
+    label: 'Chassis backdrop',
+    help: 'App backdrop and topbar — outermost chrome.',
+    group: 'chassis',
+  },
+  '--bg-1': {
+    label: 'Panel base',
+    help: 'Panel body fill — what the gauges sit on.',
+    group: 'chassis',
+  },
+  '--bg-2': {
+    label: 'Control surface',
+    help: 'Button/input rest state, settings card fill.',
+    group: 'chassis',
+  },
+  '--bg-3': {
+    label: 'Control hover',
+    help: 'Hover state for buttons and inputs.',
+    group: 'chassis',
+  },
+  '--line': {
+    label: 'Hairline',
+    help: 'Default border and divider colour.',
+    group: 'line',
+  },
+  '--line-soft': {
+    label: 'Hairline (soft)',
+    help: 'Subtle row separators, inset borders.',
+    group: 'line',
+  },
+  '--line-strong': {
+    label: 'Hairline (strong)',
+    help: 'Stronger borders — input outlines, vfo tab edge.',
+    group: 'line',
+  },
+  '--fg-0': {
+    label: 'Text — primary',
+    help: 'Strongest text colour: brand, readouts, headings.',
+    group: 'text',
+  },
+  '--fg-1': {
+    label: 'Text — secondary',
+    help: 'Most labels and chip values.',
+    group: 'text',
+  },
+  '--fg-2': {
+    label: 'Text — muted',
+    help: 'Help text, less-critical labels.',
+    group: 'text',
   },
 };
+
+// Read the live effective value of a CSS variable from the document root.
+// Falls back to '#000000' if the value isn't a 6-digit hex (e.g. rgba()).
+// Used so the colour swatch reflects the *currently rendered* colour even
+// when no override is set, which matters for surface tokens that flip
+// between themes.
+function readEffective(token: TweakableToken): string {
+  if (typeof window === 'undefined') return '#000000';
+  const raw = getComputedStyle(document.documentElement)
+    .getPropertyValue(token)
+    .trim()
+    .toLowerCase();
+  if (/^#[0-9a-f]{6}$/.test(raw)) return raw.toUpperCase();
+  if (/^#[0-9a-f]{3}$/.test(raw)) {
+    return ('#' + raw[1] + raw[1] + raw[2] + raw[2] + raw[3] + raw[3]).toUpperCase();
+  }
+  return '#000000';
+}
 
 const THEME_OPTIONS: ReadonlyArray<{
   id: ThemeId;
@@ -88,6 +162,36 @@ function isHexColor(v: string): boolean {
   return /^#[0-9A-Fa-f]{6}$/.test(v);
 }
 
+const GROUP_META: Record<
+  TokenGroup,
+  { title: string; blurb: string; warn?: boolean }
+> = {
+  accent: {
+    title: 'Accent palette',
+    blurb:
+      'Active controls, signal indicators, meter halos. Tweak any value; changes apply to both themes.',
+  },
+  chassis: {
+    title: 'Chassis surfaces',
+    blurb:
+      'App backdrop, panel chrome, button surfaces. These flip per theme — the swatch shows the current effective value.',
+    warn: true,
+  },
+  line: {
+    title: 'Lines & borders',
+    blurb: 'Hairlines, dividers, input outlines.',
+    warn: true,
+  },
+  text: {
+    title: 'Text',
+    blurb:
+      'Primary/secondary/muted text ramp. Pushing these too close to a chassis surface will break contrast.',
+    warn: true,
+  },
+};
+
+const GROUP_ORDER: ReadonlyArray<TokenGroup> = ['accent', 'chassis', 'line', 'text'];
+
 export function ThemeSettingsPanel() {
   const theme = useThemeStore((s) => s.theme);
   const overrides = useThemeStore((s) => s.overrides);
@@ -95,7 +199,29 @@ export function ThemeSettingsPanel() {
   const setOverride = useThemeStore((s) => s.setOverride);
   const resetOverrides = useThemeStore((s) => s.resetOverrides);
 
+  // Live effective colours — re-read whenever the theme flips or an override
+  // changes, so the swatches reflect what's actually on the page.
+  const [effective, setEffective] = useState<Partial<Record<TweakableToken, string>>>({});
+  useEffect(() => {
+    // Defer one frame so any pending ThemeApplier <style> tag has been
+    // applied to the document before we read computed styles.
+    const id = requestAnimationFrame(() => {
+      const next: Partial<Record<TweakableToken, string>> = {};
+      for (const tok of TWEAKABLE_TOKENS) next[tok] = readEffective(tok);
+      setEffective(next);
+    });
+    return () => cancelAnimationFrame(id);
+  }, [theme, overrides]);
+
   const hasOverrides = Object.keys(overrides).length > 0;
+
+  // Bucket tokens by group, preserving TWEAKABLE_TOKENS order within each.
+  const tokensByGroup: Record<TokenGroup, TweakableToken[]> = {
+    accent: [], chassis: [], line: [], text: [],
+  };
+  for (const tok of TWEAKABLE_TOKENS) {
+    tokensByGroup[TOKEN_META[tok].group].push(tok);
+  }
 
   return (
     <section style={{ display: 'flex', flexDirection: 'column', gap: 22 }}>
@@ -130,74 +256,84 @@ export function ThemeSettingsPanel() {
         </div>
       </div>
 
-      <div>
-        <div style={sectionHead}>
-          <h3 style={sectionH3}>Colour palette</h3>
-          <p style={sectionP}>
-            Tweak any of the accent colours. Changes apply to both themes.
-            Clearing a value (Reset) restores the default for that token.
-          </p>
-        </div>
+      {GROUP_ORDER.map((group) => {
+        const groupMeta = GROUP_META[group];
+        const tokens = tokensByGroup[group];
+        if (tokens.length === 0) return null;
+        return (
+          <div key={group}>
+            <div style={sectionHead}>
+              <h3 style={sectionH3}>{groupMeta.title}</h3>
+              <p style={sectionP}>{groupMeta.blurb}</p>
+              {groupMeta.warn && (
+                <p style={sectionWarn}>
+                  ⚠ Surface tokens flip per theme. Push too far from defaults
+                  and text may become unreadable — Reset to recover.
+                </p>
+              )}
+            </div>
 
-        <div style={paletteList}>
-          {TWEAKABLE_TOKENS.map((tok) => {
-            const meta = TOKEN_META[tok];
-            const overridden = overrides[tok];
-            const current = (overridden ?? meta.default).toUpperCase();
-            return (
-              <div key={tok} style={paletteRow}>
-                <div style={paletteLabels}>
-                  <span style={paletteLabel}>{meta.label}</span>
-                  <span style={paletteHelp}>{meta.help}</span>
-                </div>
-                <div style={paletteControls}>
-                  <input
-                    type="color"
-                    value={current}
-                    onChange={(e) =>
-                      setOverride(tok, e.target.value.toUpperCase())
-                    }
-                    style={pickerStyle}
-                    aria-label={`${meta.label} colour`}
-                  />
-                  <input
-                    type="text"
-                    value={current}
-                    onChange={(e) => {
-                      const raw = e.target.value.trim();
-                      const v = raw.startsWith('#') ? raw : `#${raw}`;
-                      if (isHexColor(v)) setOverride(tok, v.toUpperCase());
-                    }}
-                    maxLength={7}
-                    spellCheck={false}
-                    style={hexInput}
-                    aria-label={`${meta.label} hex value`}
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setOverride(tok, null)}
-                    disabled={!overridden}
-                    style={resetBtn(!!overridden)}
-                    title="Restore default"
-                  >
-                    Reset
-                  </button>
-                </div>
-              </div>
-            );
-          })}
-        </div>
+            <div style={paletteList}>
+              {tokens.map((tok) => {
+                const meta = TOKEN_META[tok];
+                const overridden = overrides[tok];
+                const current = (overridden ?? effective[tok] ?? '#000000').toUpperCase();
+                return (
+                  <div key={tok} style={paletteRow}>
+                    <div style={paletteLabels}>
+                      <span style={paletteLabel}>{meta.label}</span>
+                      <span style={paletteHelp}>{meta.help}</span>
+                    </div>
+                    <div style={paletteControls}>
+                      <input
+                        type="color"
+                        value={current}
+                        onChange={(e) =>
+                          setOverride(tok, e.target.value.toUpperCase())
+                        }
+                        style={pickerStyle}
+                        aria-label={`${meta.label} colour`}
+                      />
+                      <input
+                        type="text"
+                        value={current}
+                        onChange={(e) => {
+                          const raw = e.target.value.trim();
+                          const v = raw.startsWith('#') ? raw : `#${raw}`;
+                          if (isHexColor(v)) setOverride(tok, v.toUpperCase());
+                        }}
+                        maxLength={7}
+                        spellCheck={false}
+                        style={hexInput}
+                        aria-label={`${meta.label} hex value`}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setOverride(tok, null)}
+                        disabled={!overridden}
+                        style={resetBtn(!!overridden)}
+                        title="Restore default"
+                      >
+                        Reset
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
 
-        <div style={footerRow}>
-          <button
-            type="button"
-            onClick={resetOverrides}
-            disabled={!hasOverrides}
-            style={resetAllBtn(hasOverrides)}
-          >
-            Reset all colours
-          </button>
-        </div>
+      <div style={footerRow}>
+        <button
+          type="button"
+          onClick={resetOverrides}
+          disabled={!hasOverrides}
+          style={resetAllBtn(hasOverrides)}
+        >
+          Reset all colours
+        </button>
       </div>
     </section>
   );
@@ -223,6 +359,13 @@ const sectionP: CSSProperties = {
   fontSize: 12,
   lineHeight: 1.5,
   color: 'var(--fg-2)',
+};
+const sectionWarn: CSSProperties = {
+  margin: 0,
+  flexBasis: '100%',
+  fontSize: 11,
+  lineHeight: 1.5,
+  color: 'var(--amber)',
 };
 
 const themeGrid: CSSProperties = {
@@ -278,11 +421,12 @@ const themeBlurb: CSSProperties = {
 };
 
 const paletteList: CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
+  display: 'grid',
+  gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+  gap: 1,
   border: '1px solid var(--line)',
   borderRadius: 'var(--r-md)',
-  background: 'var(--bg-1)',
+  background: 'var(--line-soft)',
   overflow: 'hidden',
 };
 
@@ -292,7 +436,7 @@ const paletteRow: CSSProperties = {
   alignItems: 'center',
   gap: 14,
   padding: '11px 14px',
-  borderTop: '1px solid var(--line-soft)',
+  background: 'var(--bg-1)',
 };
 
 const paletteLabels: CSSProperties = {

--- a/zeus-web/src/components/filter/FilterMiniPan.tsx
+++ b/zeus-web/src/components/filter/FilterMiniPan.tsx
@@ -16,6 +16,7 @@
 import { useEffect, useRef } from 'react';
 import { registerFrameConsumer, useDisplayStore } from '../../state/display-store';
 import { useConnectionStore } from '../../state/connection-store';
+import { useThemeStore } from '../../state/theme-store';
 import { setFilter } from '../../api/client';
 import { formatCutOffset } from './filterPresets';
 
@@ -26,18 +27,16 @@ const DB_CEIL = -30;
 const DRAG_MIN_INTERVAL_MS = 50;
 const EDGE_HIT_PX = 6;
 
-// Mockup palette — neutral warm gray. Passband is bright silvery walls
-// with a soft neutral halo and square corner dots (NOT a cyan box).
-const COL_TRACE = 'rgba(210, 222, 238, 0.8)'; // spectrum line
-const COL_TICK_LABEL = '#7c8088';      // axis tick text
-const COL_TICK_LABEL_CENTER = '#edeef1'; // center (VFO) tick — brighter
+// Palette — passband walls / dots / halo are neutral silvery (read on both
+// themes), but the four *text* surfaces (LOW/HIGH CUT label + value, axis
+// ticks, VFO centre tick) and the spectrum trace are resolved from
+// --fg-0 / --fg-1 / --fg-2 at draw time so the Theme Settings token pickers
+// drive them.
 const COL_VFO_CENTER = 'rgba(200, 205, 215, 0.08)'; // very subtle neutral VFO line
 const COL_PB_WASH = 'rgba(220, 232, 245, 0.035)';   // almost-invisible interior wash
 const COL_WALL_HALO = 'rgba(220, 225, 232, 0.45)';  // soft neutral halo behind walls
 const COL_DOT = 'rgba(245, 247, 250, 0.95)';        // bright white corner dots
-const COL_CUT_KEY = '#7c8088';                       // "LOW CUT" / "HIGH CUT" key text
-const COL_CUT_VAL = '#edeef1';                       // value text
-const COL_CUT_TICK = 'rgba(220, 225, 232, 0.35)';    // hairline callout connecting label to wall
+const COL_CUT_TICK = 'rgba(220, 225, 232, 0.35)';   // hairline callout connecting label to wall
 
 type DragMode = 'lo' | 'hi' | 'inside';
 
@@ -99,6 +98,18 @@ export function FilterMiniPan() {
 
       ctx.clearRect(0, 0, w, h);
 
+      // Resolve theme-driven text colours once per frame. Operator overrides
+      // from the Theme Settings panel flow through these tokens.
+      const cs = getComputedStyle(document.documentElement);
+      const fg0 = cs.getPropertyValue('--fg-0').trim() || '#edeef1';
+      const fg1 = cs.getPropertyValue('--fg-1').trim() || '#cccccc';
+      const fg2 = cs.getPropertyValue('--fg-2').trim() || '#7c8088';
+      const colTrace = fg1;          // spectrum line — sits between primary and muted text
+      const colTickLabel = fg2;
+      const colTickLabelCenter = fg0;
+      const colCutKey = fg2;
+      const colCutVal = fg0;
+
       // Reserve the top ~22 px for LOW CUT / HIGH CUT wall callouts and the
       // bottom ~14 px for the x-axis labels so neither overlap the trace.
       const labelH = Math.round(22 * dpr);
@@ -122,7 +133,7 @@ export function FilterMiniPan() {
         const bins = binEnd - binStart;
         if (bins > 0) {
           ctx.lineWidth = 1 * dpr;
-          ctx.strokeStyle = COL_TRACE;
+          ctx.strokeStyle = colTrace;
           ctx.beginPath();
           for (let x = 0; x < w; x++) {
             const b0 = binStart + Math.floor((x * bins) / w);
@@ -239,13 +250,13 @@ export function FilterMiniPan() {
           // Key (top, muted, letter-spaced).
           ctx.textBaseline = 'top';
           ctx.textAlign = 'center';
-          ctx.fillStyle = COL_CUT_KEY;
+          ctx.fillStyle = colCutKey;
           ctx.fillText(key, cx, keyY);
 
           // Value (bold, brighter, no letter-spacing).
           ctx.letterSpacing = '0px';
           ctx.font = valFont;
-          ctx.fillStyle = COL_CUT_VAL;
+          ctx.fillStyle = colCutVal;
           ctx.fillText(value, cx, valY);
         };
 
@@ -259,7 +270,7 @@ export function FilterMiniPan() {
 
       // X-axis tick labels. One label every TICK_STEP_HZ (2 kHz), centered
       // on the VFO. VFO sits at the middle tick.
-      ctx.fillStyle = COL_TICK_LABEL;
+      ctx.fillStyle = colTickLabel;
       ctx.font = `${Math.round(9.5 * dpr)}px "SFMono-Regular", ui-monospace, monospace`;
       ctx.textBaseline = 'middle';
       const labelY = plotTop + plotH + Math.round(axisH / 2);
@@ -275,7 +286,7 @@ export function FilterMiniPan() {
         const text = formatTickMhz(absHz);
         const m = ctx.measureText(text);
         // Brighter fill on the VFO (center) tick, muted on the rest.
-        ctx.fillStyle = offHz === 0 ? COL_TICK_LABEL_CENTER : COL_TICK_LABEL;
+        ctx.fillStyle = offHz === 0 ? colTickLabelCenter : colTickLabel;
         ctx.fillText(text, Math.max(2, Math.min(w - m.width - 2, xPx - m.width / 2)), labelY);
       });
     };
@@ -293,6 +304,12 @@ export function FilterMiniPan() {
         if (rafHandle === 0) rafHandle = requestAnimationFrame(draw);
       }
     });
+    const unsubTheme = useThemeStore.subscribe((s, p) => {
+      if (s.theme !== p.theme || s.overrides !== p.overrides) {
+        lastSeq = -1;
+        if (rafHandle === 0) rafHandle = requestAnimationFrame(draw);
+      }
+    });
 
     const ro = new ResizeObserver(() => {
       lastSeq = -1;
@@ -305,6 +322,7 @@ export function FilterMiniPan() {
       if (rafHandle !== 0) cancelAnimationFrame(rafHandle);
       unsubDisplay();
       unsubConn();
+      unsubTheme();
       ro.disconnect();
       releaseFrameConsumer();
     };

--- a/zeus-web/src/components/immersive-meters/BigArc.tsx
+++ b/zeus-web/src/components/immersive-meters/BigArc.tsx
@@ -236,7 +236,7 @@ export function BigArc(props: BigArcProps) {
     background:
       'radial-gradient(80% 95% at 50% 95%, var(--immersive-lamp-bloom-1), var(--immersive-lamp-bloom-2) 45%, transparent 72%),' +
       ' radial-gradient(60% 60% at 50% 70%, var(--immersive-lamp-bloom-3), transparent 65%),' +
-      ' linear-gradient(180deg, #18181a 0%, #0c0c0e 100%)',
+      ' linear-gradient(180deg, var(--immersive-lamp-well-top) 0%, var(--immersive-lamp-well-bot) 100%)',
     border: '1px solid var(--immersive-lamp-border)',
     boxShadow:
       'inset 0 1px 0 var(--immersive-lamp-rim), inset 0 -22px 40px rgba(255,240,180,0.05), inset 0 0 50px rgba(0,0,0,0.55)',

--- a/zeus-web/src/components/immersive-meters/PullDownArc.tsx
+++ b/zeus-web/src/components/immersive-meters/PullDownArc.tsx
@@ -128,7 +128,7 @@ export function PullDownArc({
     background:
       'radial-gradient(80% 95% at 50% 100%, var(--immersive-lamp-bloom-1), var(--immersive-lamp-bloom-2) 50%, transparent 75%),' +
       ' radial-gradient(60% 60% at 50% 70%, var(--immersive-lamp-bloom-3), transparent 65%),' +
-      ' linear-gradient(180deg, #18181a 0%, #0c0c0e 100%)',
+      ' linear-gradient(180deg, var(--immersive-lamp-well-top) 0%, var(--immersive-lamp-well-bot) 100%)',
     border: '1px solid var(--immersive-lamp-border)',
     boxShadow:
       'inset 0 1px 0 var(--immersive-lamp-rim), inset 0 -22px 40px rgba(255,240,180,0.05), inset 0 0 40px rgba(0,0,0,0.45)',
@@ -141,8 +141,8 @@ export function PullDownArc({
     // Dark pill mask for legibility — preserved alongside the SVG
     // inset so labels read crisp even on the bloomed bg gradient
     // behind the card.
-    background: 'rgba(10, 11, 14, 0.78)',
-    border: '1px solid rgba(255,255,255,0.05)',
+    background: 'var(--immersive-chip-bg)',
+    border: '1px solid var(--immersive-line)',
     borderRadius: 4,
     padding: '3px 7px',
     fontSize: 9,
@@ -169,8 +169,8 @@ export function PullDownArc({
     // Same masking pill as the LEVELER · GR label — the arc curve also
     // passes through the upper-right corner so this needs the same
     // treatment for consistent legibility.
-    background: 'rgba(10, 11, 14, 0.78)',
-    border: '1px solid rgba(255,255,255,0.05)',
+    background: 'var(--immersive-chip-bg)',
+    border: '1px solid var(--immersive-line)',
     borderRadius: 4,
     padding: '3px 7px',
     fontFamily: 'var(--font-mono)',
@@ -188,8 +188,8 @@ export function PullDownArc({
     // label both land inside this readout's bounding rect, so without
     // a backdrop they'd visibly cut through "0.0 dB". Same recipe as
     // the upper-corner labels.
-    background: 'rgba(10, 11, 14, 0.78)',
-    border: '1px solid rgba(255,255,255,0.05)',
+    background: 'var(--immersive-chip-bg)',
+    border: '1px solid var(--immersive-line)',
     borderRadius: 4,
     padding: '4px 8px',
     fontFamily: 'var(--font-mono)',
@@ -214,8 +214,8 @@ export function PullDownArc({
     bottom: 10,
     // Dark pill mask — the arc's bottom-right endpoint and the "0 dB"
     // anchor pin both land inside this badge's bounding rect.
-    background: 'rgba(10, 11, 14, 0.78)',
-    border: '1px solid rgba(255,255,255,0.05)',
+    background: 'var(--immersive-chip-bg)',
+    border: '1px solid var(--immersive-line)',
     borderRadius: 4,
     padding: '3px 7px',
     fontSize: 8.5,

--- a/zeus-web/src/components/immersive-meters/VuColumn.tsx
+++ b/zeus-web/src/components/immersive-meters/VuColumn.tsx
@@ -66,7 +66,7 @@ export function VuColumn({ valueDb, name, sub, defsId, zoneTicks }: VuColumnProp
     background:
       'radial-gradient(80% 95% at 50% 100%, var(--immersive-lamp-bloom-1), var(--immersive-lamp-bloom-2) 50%, transparent 75%),' +
       ' radial-gradient(60% 60% at 50% 70%, var(--immersive-lamp-bloom-3), transparent 65%),' +
-      ' linear-gradient(180deg, #18181a 0%, #0c0c0e 100%)',
+      ' linear-gradient(180deg, var(--immersive-lamp-well-top) 0%, var(--immersive-lamp-well-bot) 100%)',
     border: '1px solid var(--immersive-lamp-border)',
     borderRadius: 7,
     padding: '10px 4px 10px',
@@ -170,8 +170,8 @@ export function VuColumn({ valueDb, name, sub, defsId, zoneTicks }: VuColumnProp
           width={COL_W}
           height={COL_HEIGHT}
           rx={2}
-          fill="#080a10"
-          stroke="rgba(255,255,255,0.06)"
+          fill="var(--immersive-vu-track)"
+          stroke="var(--immersive-rim)"
           strokeWidth={0.6}
         />
         {/* inset top shadow */}

--- a/zeus-web/src/state/theme-store.ts
+++ b/zeus-web/src/state/theme-store.ts
@@ -5,6 +5,7 @@
 // See LICENSE for the full GPL text.
 
 import { create } from 'zustand';
+import { fetchThemeSettings, updateThemeSettings } from '../api/themeSettings';
 
 // Theme + per-token colour overrides for the Zeus UI.
 //
@@ -16,24 +17,28 @@ import { create } from 'zustand';
 // injected via a runtime <style> tag that sets `:root { … }` after the
 // theme-block in the stylesheet.
 //
-// Stored in localStorage (not on the server) because:
-//   1. theming is per-browser ergonomics, not per-radio config — Brian on
-//      his laptop should be able to pick a light scheme without it flipping
-//      his shack tablet to silver as well;
-//   2. it parallels the existing `zeus.variant` / `zeus.fonts` keys already
-//      written from App.tsx;
-//   3. the user can wipe localStorage to factory-reset their chrome.
+// Persistence is two-layered:
+//   - localStorage acts as a fast-paint cache so the theme attribute lands
+//     on <html> before the first paint (no HTTP wait, no light/dark flash).
+//   - LiteDB (server) is the source of truth across devices — `hydrate()`
+//     pulls it on mount and reconciles, and every mutation fires a
+//     debounced PUT so a single setting follows the operator from desktop
+//     to tablet without a per-browser reset.
 
 export type ThemeId = 'dark' | 'light';
 
-// Tokens we expose in the operator-facing colour-tweak UI. These are the
-// "feel" tokens an operator notices: accent for active controls, signal
-// chain colours, and the warm halos on meters. Surface colours (--bg-0
-// etc.) are NOT tweakable here — they are governed by the theme overlay,
-// because flipping bg-0 in isolation tends to make text unreadable.
-// Add a token here + a label in TWEAKABLE_TOKEN_META if you want a new
-// slider in the Theme panel.
+// Tokens we expose in the operator-facing colour-tweak UI. Two groups:
+//   - ACCENT tokens — the "feel" tokens an operator notices: accent for
+//     active controls, signal chain colours, warm halos on meters.
+//   - SURFACE tokens — chassis / panel / line / text. These were historically
+//     hidden because flipping one surface in isolation can break contrast
+//     (e.g. a dark --bg-0 with light --fg-0 already painted by the theme).
+//     They're exposed now because Brian asked for per-shack chassis tuning;
+//     the panel renders them in a separate group with a warning that they
+//     can break contrast if pushed too far from the theme defaults.
+// Add a token here + a label in TOKEN_META if you want a new picker row.
 export type TweakableToken =
+  // Accent group
   | '--accent'
   | '--accent-bright'
   | '--tx'
@@ -41,7 +46,20 @@ export type TweakableToken =
   | '--amber'
   | '--cyan'
   | '--ok'
-  | '--orange';
+  | '--orange'
+  // Surface group — chassis
+  | '--bg-0'
+  | '--bg-1'
+  | '--bg-2'
+  | '--bg-3'
+  // Surface group — line / edge
+  | '--line'
+  | '--line-soft'
+  | '--line-strong'
+  // Surface group — text
+  | '--fg-0'
+  | '--fg-1'
+  | '--fg-2';
 
 export const TWEAKABLE_TOKENS: ReadonlyArray<TweakableToken> = [
   '--accent',
@@ -52,6 +70,16 @@ export const TWEAKABLE_TOKENS: ReadonlyArray<TweakableToken> = [
   '--cyan',
   '--ok',
   '--orange',
+  '--bg-0',
+  '--bg-1',
+  '--bg-2',
+  '--bg-3',
+  '--line',
+  '--line-soft',
+  '--line-strong',
+  '--fg-0',
+  '--fg-1',
+  '--fg-2',
 ];
 
 type ThemeState = {
@@ -60,9 +88,16 @@ type ThemeState = {
   // Only entries present here override the stylesheet default; deleting a
   // key restores the original token value from tokens.css.
   overrides: Partial<Record<TweakableToken, string>>;
+  // True once `hydrate()` has reconciled local cache with the server. Stays
+  // false on offline / first-launch failures so we don't keep flapping.
+  hydrated: boolean;
   setTheme: (t: ThemeId) => void;
   setOverride: (token: TweakableToken, hex: string | null) => void;
   resetOverrides: () => void;
+  // Pull the authoritative copy from /api/theme-settings and apply it if it
+  // differs from the localStorage fast-paint cache. Called once by
+  // ThemeApplier on mount; safe to invoke repeatedly.
+  hydrate: () => Promise<void>;
 };
 
 const THEME_KEY = 'zeus.theme';
@@ -120,12 +155,32 @@ function writeOverrides(o: Partial<Record<TweakableToken, string>>): void {
   }
 }
 
+// Debounced PUT to /api/theme-settings — collapses the colour-picker drag
+// stream into ~one write every 300 ms while still flushing the final value.
+// Fire-and-forget; persistence failures are logged but never block the UI.
+let pushTimer: ReturnType<typeof setTimeout> | null = null;
+function schedulePush(state: { theme: ThemeId; overrides: Partial<Record<TweakableToken, string>> }) {
+  if (pushTimer) clearTimeout(pushTimer);
+  pushTimer = setTimeout(() => {
+    pushTimer = null;
+    updateThemeSettings({ theme: state.theme, overrides: state.overrides as Record<string, string> })
+      .catch((err) => {
+        // Server unreachable / 5xx — keep the local change, retry on next mutation.
+        // Cast to keep this file lint-clean without pulling a logger.
+        // eslint-disable-next-line no-console
+        console.warn('theme-store: PUT /api/theme-settings failed', err);
+      });
+  }, 300);
+}
+
 export const useThemeStore = create<ThemeState>((set, get) => ({
   theme: readTheme(),
   overrides: readOverrides(),
+  hydrated: false,
   setTheme: (theme) => {
     writeTheme(theme);
     set({ theme });
+    schedulePush({ theme, overrides: get().overrides });
   },
   setOverride: (token, hex) => {
     const next = { ...get().overrides };
@@ -137,9 +192,38 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
     }
     writeOverrides(next);
     set({ overrides: next });
+    schedulePush({ theme: get().theme, overrides: next });
   },
   resetOverrides: () => {
     writeOverrides({});
     set({ overrides: {} });
+    schedulePush({ theme: get().theme, overrides: {} });
+  },
+  hydrate: async () => {
+    if (get().hydrated) return;
+    try {
+      const server = await fetchThemeSettings();
+      // Project the server overrides into the typed TweakableToken keyspace —
+      // anything the client doesn't know about is dropped (forward-compat:
+      // newer server, older client). Same shape readOverrides() returns.
+      const serverOverrides: Partial<Record<TweakableToken, string>> = {};
+      for (const k of TWEAKABLE_TOKENS) {
+        const v = server.overrides[k];
+        if (isHexColor(v)) serverOverrides[k] = v.toUpperCase();
+      }
+      // Apply server values to local state + cache. If they match what we
+      // already had, this is a no-op — but we mark hydrated either way so
+      // subsequent mutations push through schedulePush.
+      writeTheme(server.theme);
+      writeOverrides(serverOverrides);
+      set({ theme: server.theme, overrides: serverOverrides, hydrated: true });
+    } catch (err) {
+      // Backend unreachable — stay on the localStorage cache. Mark hydrated
+      // so we don't loop forever; the next mutation will attempt a PUT and
+      // recover the link. Surface for debugging.
+      // eslint-disable-next-line no-console
+      console.warn('theme-store: hydrate failed, using localStorage cache', err);
+      set({ hydrated: true });
+    }
   },
 }));

--- a/zeus-web/src/styles/all-panels.css
+++ b/zeus-web/src/styles/all-panels.css
@@ -228,6 +228,25 @@
   outline-offset: 1px;
 }
 
+/* Light theme — flip the brass-plate header gradient from hardcoded dark
+   to the brushed-silver --panel-head-top/-bot tokens so the header reads
+   as part of the silver chassis. Title amber-glow is dropped (vanishes on
+   silver); the leading amber rail (::before) stays — works on both. */
+:root[data-theme="light"] .workspace-tile-header {
+  background: linear-gradient(180deg, var(--panel-head-top) 0%, var(--panel-head-bot) 100%);
+  border-bottom: 1px solid var(--panel-border);
+  box-shadow:
+    inset 0 1px 0 var(--panel-hl-top),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.10);
+}
+:root[data-theme="light"] .workspace-tile-title {
+  color: var(--fg-0);
+  text-shadow: none;
+}
+:root[data-theme="light"] .workspace-tile-drag-handle {
+  color: var(--fg-2);
+}
+
 .workspace-tile-body {
   flex: 1;
   min-height: 0;

--- a/zeus-web/src/styles/analog-meter.css
+++ b/zeus-web/src/styles/analog-meter.css
@@ -97,6 +97,20 @@
   filter: drop-shadow(0 2px 0 rgba(0,0,0,0.3));
 }
 
+/* Light theme — silver chassis. The dark `--bg-inset` "embedded screen"
+   look reads as a black wedge against the brushed silver, and the warm
+   streetlamp glow was tuned for the dark base. Swap to a lifted-silver
+   well and drop the warm overlay; the SVG's own radial dial gradient
+   (--bg-2 → --bg-1 → --bg-0) handles the inside-the-arc shading. */
+:root[data-theme="light"] .am-tile .am-meter-face-wrap,
+:root[data-theme="light"] .am-tile .analog-meter-face-wrap {
+  background: linear-gradient(180deg, var(--bg-1) 0%, var(--bg-0) 100%);
+  border-bottom: 1px solid var(--line-soft);
+}
+:root[data-theme="light"] .am-tile .analog-meter-face {
+  filter: drop-shadow(0 1px 0 rgba(0, 0, 0, 0.12));
+}
+
 /* ── Zeus mode overlay ────────────────────────────────────── */
 .am-tile .am-zeus-overlay {
   position: absolute;

--- a/zeus-web/src/styles/filter-ribbon.css
+++ b/zeus-web/src/styles/filter-ribbon.css
@@ -406,3 +406,68 @@
   color: var(--accent);
   letter-spacing: 0.02em;
 }
+
+/* ===========================================================
+   Light theme — re-skin the filter ribbon's hardcoded warm-grey
+   palette to brushed silver. The original gradient (#26292f →
+   #1e2025) and chip family (#3a3e45 / #2a2d33 / #4a4e55) read as
+   a dark slab pasted onto the silver chassis, so we flip them
+   here. Active-state blue accent (#4a9eff) and signal colours
+   pass through unchanged — they read well on both backgrounds.
+   =========================================================== */
+:root[data-theme="light"] .filter-ribbon {
+  color: var(--fg-0);
+  background: linear-gradient(180deg, var(--panel-head-top) 0%, var(--panel-head-bot) 100%);
+  border: 1px solid var(--panel-border);
+  box-shadow:
+    inset 0 1px 0 var(--panel-hl-top),
+    0 1px 2px rgba(0, 0, 0, 0.12);
+}
+:root[data-theme="light"] .filter-ribbon__close { color: var(--fg-2); }
+:root[data-theme="light"] .filter-ribbon__close:hover {
+  color: var(--fg-0);
+  background: rgba(0, 0, 0, 0.06);
+}
+:root[data-theme="light"] .filter-ribbon__label { color: var(--fg-2); }
+:root[data-theme="light"] .filter-ribbon__topCol--bw .filter-ribbon__label,
+:root[data-theme="light"] .filter-ribbon__passband-unit { color: var(--fg-1); }
+:root[data-theme="light"] .filter-ribbon__freq,
+:root[data-theme="light"] .filter-ribbon__passband-value { color: var(--fg-0); }
+
+/* Preset panel + mini-pan surfaces */
+:root[data-theme="light"] .filter-ribbon__presets,
+:root[data-theme="light"] .filter-ribbon__minipan {
+  background: var(--bg-2);
+  border-color: var(--panel-border);
+  color: var(--fg-1);
+}
+:root[data-theme="light"] .filter-ribbon__section-label { color: var(--fg-2); }
+
+/* Preset chips — match light-theme button surfaces. Keep active
+   blue accent intact; just re-skin the rest state. */
+:root[data-theme="light"] .filter-ribbon__chip,
+:root[data-theme="light"] .filter-ribbon__custom {
+  color: var(--fg-1);
+  background: linear-gradient(180deg, var(--bg-2) 0%, var(--bg-3) 100%);
+  border: 1px solid var(--line-strong);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.4),
+    0 1px 0 rgba(0, 0, 0, 0.08);
+}
+:root[data-theme="light"] .filter-ribbon__chip:hover,
+:root[data-theme="light"] .filter-ribbon__custom:hover {
+  border-color: var(--fg-3);
+  filter: none;
+}
+:root[data-theme="light"] .filter-ribbon__chip.is-active,
+:root[data-theme="light"] .filter-ribbon__custom.is-active {
+  color: #ffffff;
+  background: linear-gradient(180deg, var(--accent) 0%, var(--accent) 100%);
+  border-color: var(--accent);
+}
+:root[data-theme="light"] .filter-ribbon__chip.is-drop-target {
+  border-color: var(--accent);
+  background:
+    linear-gradient(180deg, rgba(74, 158, 255, 0.18) 0%, rgba(74, 158, 255, 0.04) 50%, transparent 100%),
+    linear-gradient(180deg, var(--bg-2) 0%, var(--bg-3) 100%);
+}

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -523,6 +523,18 @@
   box-shadow: none;
 }
 
+/* Light theme — flip topbar tints from white-alpha (which vanishes on
+   silver) to black-alpha, and bump the group-label opacity so the
+   MODE / FILTER / BAND row stays legible against the silver chassis.
+   Brand text gets a touch more weight + tracking for the same reason. */
+:root[data-theme="light"] .topbar .btn:hover         { background: rgba(0,0,0,0.08); }
+:root[data-theme="light"] .topbar .btn:active,
+:root[data-theme="light"] .topbar .btn.pressed       { background: rgba(0,0,0,0.14); box-shadow: inset 0 1px 2px rgba(0,0,0,0.2); }
+:root[data-theme="light"] .topbar .btn.ghost:hover   { background: rgba(0,0,0,0.08); }
+:root[data-theme="light"] .topbar .ctrl-lbl          { color: var(--fg-1); opacity: 1; }
+:root[data-theme="light"] .brand-name                { font-weight: 700; letter-spacing: 0; color: var(--fg-0); }
+:root[data-theme="light"] .brand-sub                 { color: var(--fg-1); }
+
 /* VFO tab — the big embossed freq readout */
 .vfo-group { display: flex; gap: 4px; align-items: stretch; }
 .vfo-tab {
@@ -841,6 +853,25 @@
   min-height: 0;
   overflow: hidden;
 }
+
+/* Light theme — flip the .panel-head "brass plate" gradient from hardcoded
+   dark (#1c1c21 → #141418) to the brushed-silver --panel-head-top/-bot
+   tokens, so panel headers read as a single machined strip on the silver
+   chassis. The title's amber glow vanishes (low contrast on silver) and
+   the inset-bottom shadow softens; the amber leading rail (::before) is
+   kept — it works on both backgrounds and is part of the brand. */
+:root[data-theme="light"] .panel-head {
+  background: linear-gradient(180deg, var(--panel-head-top) 0%, var(--panel-head-bot) 100%);
+  border-bottom: 1px solid var(--panel-border);
+  box-shadow:
+    inset 0 1px 0 var(--panel-hl-top),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.10);
+}
+:root[data-theme="light"] .panel-head .title {
+  color: var(--fg-0);
+  text-shadow: none;
+}
+
 .panel.t1000-panel { animation: t1000-in 500ms var(--ease-out) both; }
 @keyframes t1000-in {
   from { opacity: 0; transform: scale(0.96) translateY(8px); filter: blur(4px); }

--- a/zeus-web/src/styles/pa-settings.css
+++ b/zeus-web/src/styles/pa-settings.css
@@ -145,3 +145,45 @@
   font-size: 9.5px;
   letter-spacing: 0.16em;
 }
+
+/* ── tokenised chrome ────────────────────────────────────────
+   Replaces the previous bg-neutral-* / text-neutral-* Tailwind
+   palette so the panel flips cleanly with [data-theme="light"].
+   Surfaces lean on --bg-2 (card body), --line (separators), and
+   the standard fg ramp (--fg-0 strong → --fg-3 hint). Tested
+   against both dark and light theme tokens — see tokens.css. */
+.pa-settings .pa-section-h {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--fg-1);
+  margin: 0;
+}
+.pa-settings .pa-card {
+  background: var(--bg-2);
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+}
+.pa-settings .pa-field {
+  color: var(--fg-1);
+}
+.pa-settings .pa-num-input {
+  background: var(--bg-1);
+  border: 1px solid var(--line-strong);
+  color: var(--fg-0);
+}
+.pa-settings .pa-num-input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+.pa-settings .pa-hint {
+  color: var(--fg-3);
+}
+.pa-settings .pa-col-head {
+  color: var(--fg-2);
+}
+.pa-settings .pa-band-row {
+  border-top: 1px solid var(--line-soft);
+  color: var(--fg-1);
+}

--- a/zeus-web/src/styles/tokens.css
+++ b/zeus-web/src/styles/tokens.css
@@ -137,6 +137,16 @@
      tokens are kept separate from the existing immersive-* palette so a
      future operator preference toggle can swap lamp colour temperature
      without touching component code. */
+  /* Inner well base gradient — the dark stage behind each lamp's bloom
+     layers. Was previously inlined as `#18181a → #0c0c0e` in BigArc /
+     VuColumn / PullDownArc; promoted to tokens so light theme can flip the
+     stage to silver without touching component code. */
+  --immersive-lamp-well-top: #18181a;
+  --immersive-lamp-well-bot: #0c0c0e;
+  /* VU column track + digital chip background — was hardcoded `#080a10` /
+     `rgba(10,11,14,0.78)`. Tokenised for the same reason. */
+  --immersive-vu-track: #080a10;
+  --immersive-chip-bg: rgba(10, 11, 14, 0.78);
   --immersive-lamp-bloom-1: rgba(255,250,210,0.22);
   --immersive-lamp-bloom-2: rgba(245,235,180,0.10);
   --immersive-lamp-bloom-3: rgba(255,250,220,0.10);
@@ -210,9 +220,13 @@ html[data-fonts="geist"] { --font-sans: 'Inter', sans-serif; --font-mono: 'JetBr
 
   /* Display surfaces stay DARK — panadapter / VFO / S-meter /
      gauges / LED-meter wells all look like screens embedded in
-     silver. */
-  --bg-inset:     #0e1014;
-  --bg-meter:     #050507;
+     silver. Lifted off pitch-black in this theme so they don't
+     read as gouges against the silver chassis (operator feedback
+     2026-05-16: meter wells "still a little too dark"). The
+     panadapter / waterfall WebGL surfaces still draw their own
+     black background and aren't affected by this token. */
+  --bg-inset:     #2a2f37;
+  --bg-meter:     #1f2329;
 
   /* Lines — darker silvers / steel for definition on light chassis */
   --line:         #8a8f96;
@@ -249,11 +263,62 @@ html[data-fonts="geist"] { --font-sans: 'Inter', sans-serif; --font-mono: 'JetBr
 
 /* Brushed silver gradient washes — applied to the four chrome
    strips so the chassis reads as a single machined panel.
-   Display surfaces (spec-bg, immersive-*) deliberately keep
-   their dark defaults from :root, so they appear as inset
+   The spec-bg + panadapter / waterfall WebGL surfaces deliberately
+   keep their dark defaults from :root so they appear as inset
    screens against the silver. */
 :root[data-theme="light"] body {
   background: linear-gradient(180deg, #c4c8ce 0%, #b3b8c0 100%);
+}
+
+/* TX Stage Meters (immersive panel) — flip the section cards + lamp wells
+   to a silver palette. The hot/warn/good fill gradients on the active
+   needles are unchanged (semantic). Warm lamp blooms become near-transparent
+   in light mode because they were tuned for a black stage. */
+:root[data-theme="light"] {
+  --immersive-bg:           var(--bg-0);
+  --immersive-panel:        var(--bg-1);
+  --immersive-panel-2:      var(--bg-1);
+  --immersive-well:         var(--bg-0);
+  --immersive-well-2:       var(--bg-1);
+  --immersive-rim:          rgba(255, 255, 255, 0.55);
+  --immersive-rim-strong:   rgba(255, 255, 255, 0.70);
+  --immersive-line:         var(--line);
+  --immersive-line-2:       var(--line-strong);
+  --immersive-accent:       var(--accent);
+  --immersive-accent-glow:  rgba(12, 95, 156, 0.30);
+
+  /* Lamp wells — was a near-black stage with warm bloom. Light theme
+     uses a brushed-silver stage so the chrome reads as inset on the
+     chassis instead of a black hole. */
+  --immersive-lamp-well-top: #cdd1d7;
+  --immersive-lamp-well-bot: #b3b8bf;
+  --immersive-vu-track:      #e2e5ea;
+  --immersive-chip-bg:       rgba(255, 255, 255, 0.55);
+
+  /* Warm incandescent blooms are tuned for a black stage. On silver they
+     wash to muddy grey; fade them out and let the chrome carry the form. */
+  --immersive-lamp-bloom-1:  transparent;
+  --immersive-lamp-bloom-2:  transparent;
+  --immersive-lamp-bloom-3:  transparent;
+  --immersive-lamp-bloom-blob: transparent;
+  --immersive-lamp-border:   var(--line);
+  --immersive-lamp-rim:      rgba(255, 255, 255, 0.50);
+
+  /* Text on the lit faces flips to near-black. The chip-text stays warm
+     since the chip itself stays dark (back-lit readout). */
+  --immersive-lamp-tick:     rgba(60, 65, 72, 0.65);
+  --immersive-lamp-label:    var(--fg-1);
+  --immersive-lamp-units:    var(--fg-2);
+  --immersive-lamp-readout:  var(--fg-0);
+  --immersive-lamp-readout-glow: transparent;
+  --immersive-lamp-corner:    var(--fg-2);
+  --immersive-lamp-corner-em: var(--fg-1);
+  --immersive-lamp-needle:    var(--fg-0);
+  --immersive-lamp-needle-bri: var(--accent);
+  --immersive-lamp-pin:       var(--accent);
+  --immersive-lamp-pin-glow:  rgba(12, 95, 156, 0.45);
+  --immersive-lamp-hub-glow:  rgba(12, 95, 156, 0.50);
+  --immersive-lamp-active-glow: rgba(12, 95, 156, 0.18);
 }
 
 /* ===========================================================


### PR DESCRIPTION
## Summary

Light theme polish pass + server-side persistence for the operator's theme choice and per-token colour overrides. Previously the theme lived only in `localStorage`, so the same operator on a different device saw stock dark.

### Persistence
- New `ThemeSettingsStore` (LiteDB) + `GET`/`PUT /api/theme-settings`, same shape as `DisplaySettingsStore` / `NrUiPrefsStore`.
- `ThemeApplier` hydrates from the server on mount; `localStorage` stays as the fast-paint cache so `[data-theme]` still lands before first paint (no light/dark flash). Mutations debounce to a single `PUT`.
- `ThemeSettingsDto` + `ThemeSettingsSetRequest` added to `Zeus.Contracts`.

### Light-theme rendering fixes
- **TX Stage Meters** — `BigArc` / `VuColumn` / `PullDownArc` had inlined hex (`#18181a → #0c0c0e`, `#080a10`, `rgba(10,11,14,0.78)`) for the lamp wells / VU track / chip backgrounds. Promoted to four new tokens (`--immersive-lamp-well-top/bot`, `--immersive-vu-track`, `--immersive-chip-bg`) and added a light-theme override that flips the wells to silver and fades the warm cream blooms (tuned for a black stage, read as muddy grey on silver).
- **Analog S-meter** — dial wrap was `--bg-inset` (kept dark by design) with a warm streetlamp glow on top; in light mode that combination read as a black wedge against the chassis. Override swaps the well to a vertical silver gradient and drops the warm overlay; the SVG's own dial gradient continues to do the inside-the-arc shading.
- **Filter ribbon** — existing light-theme overrides targeted classes that don't render (`.filter-ribbon__preset-panel`, `.filter-ribbon__minipan-label`, `.filter-ribbon__value`). Corrected to the actual class names. The mini-pan canvas (LOW/HIGH CUT callouts, axis ticks, spectrum trace) was painting hardcoded `#edeef1` / `#7c8088`; now resolves `--fg-0` / `--fg-1` / `--fg-2` at draw time and subscribes to the theme store so live token tweaks redraw the canvas without waiting for the next display frame.
- **Topbar / panel headers / PA Settings** — small overrides so button hover states use black-alpha (white-alpha vanishes on silver), brand text weight bumps, tile header gradient comes from the silver `--panel-head-top/bot` tokens instead of inlined hex.

### Theme Settings panel
- Tokens grouped into Accent / Chassis / Lines / Text. Chassis / line / text are surfaced now (previously hidden) with a contrast-warning so operators can tune the chassis per shack.
- Colour swatches read the live computed value, not a hardcoded default — they track both the active theme overlay and operator overrides (e.g. `--bg-0` shows silver in light, near-black in dark).
- Colour-override grid is now 2 columns, separated by hairlines via a 1px-gap grid trick.

## Test plan
- [x] `dotnet build Zeus.slnx` clean (0 warn / 0 err)
- [x] `dotnet test Zeus.slnx` — all 6 suites green (1085 passed, 0 failed)
- [x] `npm --prefix zeus-web run build` — clean type-check + bundle
- [x] Bench tested live in light mode (server mode, HL2 on 28.400 MHz): filter ribbon, analog S-meter, TX Stage Meters all read on the silver chassis
- [ ] Verify `ThemeSettingsStore` round-trips: change theme/overrides → restart backend → settings restored