### PR TITLE
fix(persist): drive and TUN drive % survive server restart

### DIFF
--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -238,6 +238,8 @@ public sealed class RadioService : IDisposable
             _amTxFilter = new(rsSnap.AmTxFilterLoAbs, rsSnap.AmTxFilterHiAbs);
             _fmTxFilter = new(rsSnap.FmTxFilterLoAbs, rsSnap.FmTxFilterHiAbs);
             _cwTxFilter = new(rsSnap.CwTxFilterLoAbs, rsSnap.CwTxFilterHiAbs);
+            _drivePct = Math.Clamp(rsSnap.DrivePct, 0, 100);
+            _tunePct = Math.Clamp(rsSnap.TunePct, 0, 100);
         }
 
         _state = new(
@@ -1003,6 +1005,7 @@ public sealed class RadioService : IDisposable
     {
         int clamped = Math.Clamp(percent, 0, 100);
         Interlocked.Exchange(ref _drivePct, clamped);
+        _stateDirty = true;
         RecomputePaAndPush();
     }
 
@@ -1012,6 +1015,7 @@ public sealed class RadioService : IDisposable
     {
         int clamped = Math.Clamp(percent, 0, 100);
         Interlocked.Exchange(ref _tunePct, clamped);
+        _stateDirty = true;
         RecomputePaAndPush();
     }
 
@@ -1582,6 +1586,8 @@ public sealed class RadioService : IDisposable
                 AmTxFilterLoAbs = amTx.LoAbs,   AmTxFilterHiAbs = amTx.HiAbs,
                 FmTxFilterLoAbs = fmTx.LoAbs,   FmTxFilterHiAbs = fmTx.HiAbs,
                 CwTxFilterLoAbs = cwTx.LoAbs,   CwTxFilterHiAbs = cwTx.HiAbs,
+                DrivePct = Volatile.Read(ref _drivePct),
+                TunePct = Volatile.Read(ref _tunePct),
                 UpdatedUtc = DateTime.UtcNow,
             });
         }

--- a/Zeus.Server.Hosting/RadioStateStore.cs
+++ b/Zeus.Server.Hosting/RadioStateStore.cs
@@ -149,6 +149,11 @@ public sealed class RadioStateEntry
     public bool AutoAgcEnabled { get; set; }
     public double RxAfGainDb { get; set; }
     public int ZoomLevel { get; set; } = 1;
+    // Drive slider % (0..100). Default 0 mirrors RadioService._drivePct seed.
+    public int DrivePct { get; set; }
+    // TUN drive slider % (0..100). Default 10 mirrors RadioService._tunePct seed —
+    // a 0 default would make pressing TUN appear to do nothing.
+    public int TunePct { get; set; } = 10;
     // Per-mode-family RX filter memory (abs values, always positive)
     public int SsbFilterLoAbs { get; set; } = 150;
     public int SsbFilterHiAbs { get; set; } = 2850;

--- a/tests/Zeus.Server.Tests/RadioStateStoreTests.cs
+++ b/tests/Zeus.Server.Tests/RadioStateStoreTests.cs
@@ -64,6 +64,8 @@ public class RadioStateStoreTests : IDisposable
                 SsbFilterLoAbs = 300, SsbFilterHiAbs = 2400,
                 CwFilterLoAbs = 400, CwFilterHiAbs = 800,
                 SsbTxFilterLoAbs = 300, SsbTxFilterHiAbs = 2400,
+                DrivePct = 47,
+                TunePct = 23,
                 UpdatedUtc = DateTime.UtcNow,
             });
         }
@@ -90,6 +92,19 @@ public class RadioStateStoreTests : IDisposable
         Assert.Equal(800, got.CwFilterHiAbs);
         Assert.Equal(300, got.SsbTxFilterLoAbs);
         Assert.Equal(2400, got.SsbTxFilterHiAbs);
+        Assert.Equal(47, got.DrivePct);
+        Assert.Equal(23, got.TunePct);
+    }
+
+    // Older rows written before DrivePct/TunePct existed must hydrate with the
+    // RadioService seed defaults (0, 10) so operators upgrading from an earlier
+    // build don't see a 0 % TUN drive that appears to do nothing on first key.
+    [Fact]
+    public void DrivePctAndTunePct_HaveCorrectDefaults_OnNewEntry()
+    {
+        var entry = new RadioStateEntry();
+        Assert.Equal(0, entry.DrivePct);
+        Assert.Equal(10, entry.TunePct);
     }
 
     // Snapshot is a single global row — saving twice should update, not insert.


### PR DESCRIPTION
## Summary

Drive and TUN-drive slider positions were lost on every backend restart. The values lived only in `RadioService._drivePct` / `_tunePct` private fields and were never written to `RadioStateStore` — even though every other adjacent operator setting (VFO, mode, filters, volume, zoom, AGC, attenuator) already round-trips through that same store. Reported by KB2UKA after the v0.7.5 desktop-mode rollup.

**Operator-visible symptom:** relaunch Zeus and the drive slider snaps back to 0, TUN snaps back to its compile-time 10 % default. Every time.

## Fix

Mirrors the existing pattern in `RadioStateEntry` / `FlushState` / constructor-hydration. Four small edits:

- **`RadioStateEntry`**: add `DrivePct` (default 0) and `TunePct` (default 10). Defaults match the `RadioService` field seeds so older rows written before this change hydrate sensibly without surprising operators with a 0 % TUN.
- **`RadioService` constructor**: when `rsSnap` exists, clamp-and-hydrate `_drivePct` / `_tunePct` from snapshot before the `StateDto` is built.
- **`SetDrive` / `SetTuneDrive`**: flip `_stateDirty` so the 1 s debounce flush picks the change up. (Neither was marking dirty before, which is why these fields wouldn't have persisted even if the schema had them.)
- **`FlushState`**: write `DrivePct` / `TunePct` via `Volatile.Read` on the private fields — same lock-free read pattern `Mutate` uses for the rest.

No wire-format change, no API change, no per-board behaviour change. Lives entirely on the LiteDB-prefs side.

## Test plan

- [x] `dotnet build Zeus.slnx` — 0 warnings, 0 errors
- [x] `dotnet test ... --filter RadioStateStore` — 9/9 pass (8 existing + 1 new defaults test, plus the round-trip extended with non-default `DrivePct=47` / `TunePct=23`)
- [ ] CI green on this PR
- [ ] After merge: bench-verify on G2 — set drive to non-default value, close desktop app, reopen, confirm slider hydrates to the previously-set value

## Files

- `Zeus.Server.Hosting/RadioStateStore.cs` — `DrivePct` + `TunePct` fields on `RadioStateEntry`
- `Zeus.Server.Hosting/RadioService.cs` — hydration in ctor, dirty flag in setters, write in `FlushState`
- `tests/Zeus.Server.Tests/RadioStateStoreTests.cs` — extended round-trip + new defaults test