### PR TITLE
fix(persist): drive / TUN drive hydrate from server, stop client clobber

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -241,7 +241,20 @@ public sealed record StateDto(
     // Nullable so legacy state frames (no Cfc field) deserialize unchanged;
     // null at the engine seam means "use CfcConfig.Default" — same pattern
     // as the Nr field above. Persisted globally via DspSettingsStore.
-    CfcConfig? Cfc = null);
+    CfcConfig? Cfc = null,
+
+    // ---- Drive slider state ----
+    // Operator drive slider position 0..100 (% of MaxPowerWatts via the
+    // per-board PA-gain table). Server is authoritative: persisted to LiteDB
+    // via RadioStateStore, hydrated on construction, and broadcast on every
+    // SetDrive so a fresh frontend connect lands on the persisted value
+    // instead of pushing its own localStorage default back over the wire.
+    // Default 0 mirrors RadioService._drivePct seed.
+    int DrivePct = 0,
+    // Independent TUN drive slider 0..100. Same persistence pattern as
+    // DrivePct. Default 10 mirrors RadioService._tunePct seed — a 0 default
+    // would make pressing TUN appear to do nothing on first key.
+    int TunePct = 10);
 
 public sealed record RadioInfo(
     string MacAddress,

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -284,7 +284,14 @@ public sealed class RadioService : IDisposable
             TwoToneFreq1: ps?.TwoToneFreq1 ?? 700.0,
             TwoToneFreq2: ps?.TwoToneFreq2 ?? 1900.0,
             TwoToneMag: ps?.TwoToneMag ?? 0.49,
-            Cfc: persistedCfc);
+            Cfc: persistedCfc,
+            // Hydrate drive sliders from RadioStateStore so a fresh frontend
+            // connect lands on the operator's last-set values. The private
+            // fields above (_drivePct / _tunePct) were already hydrated in the
+            // rsSnap block; mirror them into the StateDto so SetDrive doesn't
+            // become the only path that puts these into the broadcast.
+            DrivePct: Volatile.Read(ref _drivePct),
+            TunePct: Volatile.Read(ref _tunePct));
 
         // Kick off the debounce flush timer. Fires every 1 s; only writes to
         // LiteDB when _stateDirty is set (i.e., at least one Mutate() has fired
@@ -1005,7 +1012,11 @@ public sealed class RadioService : IDisposable
     {
         int clamped = Math.Clamp(percent, 0, 100);
         Interlocked.Exchange(ref _drivePct, clamped);
-        _stateDirty = true;
+        // Mutate() broadcasts the new StateDto to subscribed clients and
+        // flips _stateDirty so the debounce flush persists to LiteDB. Without
+        // the broadcast a fresh client connect would not see the hydrated
+        // value until something else dirtied the state.
+        Mutate(s => s with { DrivePct = clamped });
         RecomputePaAndPush();
     }
 
@@ -1015,7 +1026,7 @@ public sealed class RadioService : IDisposable
     {
         int clamped = Math.Clamp(percent, 0, 100);
         Interlocked.Exchange(ref _tunePct, clamped);
-        _stateDirty = true;
+        Mutate(s => s with { TunePct = clamped });
         RecomputePaAndPush();
     }
 
@@ -1586,8 +1597,8 @@ public sealed class RadioService : IDisposable
                 AmTxFilterLoAbs = amTx.LoAbs,   AmTxFilterHiAbs = amTx.HiAbs,
                 FmTxFilterLoAbs = fmTx.LoAbs,   FmTxFilterHiAbs = fmTx.HiAbs,
                 CwTxFilterLoAbs = cwTx.LoAbs,   CwTxFilterHiAbs = cwTx.HiAbs,
-                DrivePct = Volatile.Read(ref _drivePct),
-                TunePct = Volatile.Read(ref _tunePct),
+                DrivePct = snap.DrivePct,
+                TunePct = snap.TunePct,
                 UpdatedUtc = DateTime.UtcNow,
             });
         }

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -206,6 +206,12 @@ export type RadioStateDto = {
   psCalibrationStalled?: boolean;
   psIntsSpiPreset: string;
   psFeedbackSource: 'internal' | 'external';
+  // Drive slider state — server is authoritative, hydrated into tx-store on
+  // every fresh RadioStateDto so a relaunch picks up the operator's last
+  // value instead of the localStorage default clobbering the server's
+  // persisted value on connect.
+  drivePercent: number;
+  tunePercent: number;
   twoToneFreq1: number;
   twoToneFreq2: number;
   twoToneMag: number;
@@ -457,6 +463,11 @@ export function normalizeState(raw: unknown): RadioStateDto {
     psIntsSpiPreset: typeof r.psIntsSpiPreset === 'string' ? r.psIntsSpiPreset : '16/256',
     psFeedbackSource:
       r.psFeedbackSource === 'External' || r.psFeedbackSource === 'external' ? 'external' : 'internal',
+    // Drive sliders — server is authoritative. Defaults mirror RadioService
+    // private-field seeds (_drivePct=0, _tunePct=10) so a state frame from an
+    // older server (no DrivePct/TunePct fields) deserialises cleanly.
+    drivePercent: typeof r.drivePct === 'number' ? r.drivePct : 0,
+    tunePercent: typeof r.tunePct === 'number' ? r.tunePct : 10,
     twoToneFreq1: typeof r.twoToneFreq1 === 'number' ? r.twoToneFreq1 : 700,
     twoToneFreq2: typeof r.twoToneFreq2 === 'number' ? r.twoToneFreq2 : 1900,
     twoToneMag: typeof r.twoToneMag === 'number' ? r.twoToneMag : 0.49,

--- a/zeus-web/src/components/ConnectPanel.tsx
+++ b/zeus-web/src/components/ConnectPanel.tsx
@@ -50,8 +50,6 @@ import {
   disconnectP2 as apiDisconnectP2,
   fetchRadios,
   fetchState,
-  setDrive,
-  setTuneDrive,
   setLevelerMaxGain,
   setMicGain,
   type RadioInfoDto,
@@ -116,14 +114,21 @@ function parseRawBoardId(raw: string | undefined): number | null {
   return n;
 }
 
-// Post-connect side-effects shared by discover-click and manual-connect: push
-// persisted TX values so the radio doesn't key at its boot default, and resume
-// the AudioContext on the gesture so the user doesn't need a second Play click.
+// Post-connect side-effects shared by discover-click and manual-connect.
+//
+// Drive / TUN drive are now authoritative on the server (StateDto.DrivePct /
+// TunePct, persisted via RadioStateStore). The connect-time response already
+// carries the hydrated values; tx-store.hydrateFromState picks them up from
+// the RadioStateDto returned by /api/connect. Pushing the localStorage mirror
+// back here would clobber the server's just-hydrated values, which is exactly
+// the bug reported for relaunches that didn't restore drive.
+//
+// micGainDb / levelerMaxGainDb don't have a server-authoritative path yet, so
+// they continue to push from localStorage. Migrating them to the same
+// StateDto pattern is the natural follow-up.
 function applyPostConnectEffects() {
   void getAudioClient().start();
   const tx = useTxStore.getState();
-  void setDrive(tx.drivePercent).catch(() => {});
-  void setTuneDrive(tx.tunePercent).catch(() => {});
   void setMicGain(tx.micGainDb).catch(() => {});
   void setLevelerMaxGain(tx.levelerMaxGainDb).catch(() => {});
 }

--- a/zeus-web/src/components/DriveSlider.tsx
+++ b/zeus-web/src/components/DriveSlider.tsx
@@ -101,18 +101,11 @@ export function DriveSlider() {
     if (debounceTimer.current != null) clearTimeout(debounceTimer.current);
   }, []);
 
-  // Push the zustand-persisted drivePercent to the server once per connect.
-  // Server defaults _drivePct=10 on startup; without this the slider shows
-  // the persisted value (e.g. 100%) while the radio stays at 10%.
-  const syncedRef = useRef(false);
-  useEffect(() => {
-    if (!connected) { syncedRef.current = false; return; }
-    if (syncedRef.current) return;
-    syncedRef.current = true;
-    lastSent.current = drivePercent;
-    setDrive(drivePercent).catch(() => { /* next drag will retry */ });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [connected]);
+  // Server is now authoritative for drivePercent (StateDto.DrivePct, persisted
+  // via RadioStateStore, hydrated into tx-store by tx-store.hydrateFromState
+  // on every fresh RadioStateDto). The previous push-on-connect that ran here
+  // would clobber the server's hydrated value with the localStorage mirror
+  // every time the operator (re)connected. Removed deliberately.
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const v = Number(e.currentTarget.value);

--- a/zeus-web/src/components/TunePowerSlider.tsx
+++ b/zeus-web/src/components/TunePowerSlider.tsx
@@ -74,18 +74,10 @@ export function TunePowerSlider() {
     if (debounceTimer.current != null) clearTimeout(debounceTimer.current);
   }, []);
 
-  // Push the zustand-persisted tunePercent to the server once per connect.
-  // RadioService starts with _tunePct=10; without this resync the slider
-  // shows 100% from localStorage while the radio stays at 10%.
-  const syncedRef = useRef(false);
-  useEffect(() => {
-    if (!connected) { syncedRef.current = false; return; }
-    if (syncedRef.current) return;
-    syncedRef.current = true;
-    lastSent.current = tunePercent;
-    setTuneDrive(tunePercent).catch(() => { /* next drag will retry */ });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [connected]);
+  // Server is authoritative for tunePercent (StateDto.TunePct, persisted via
+  // RadioStateStore, hydrated into tx-store on every fresh RadioStateDto).
+  // The previous push-on-connect clobbered the server's hydrated value with
+  // the localStorage mirror. Removed deliberately — see DriveSlider.tsx.
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const v = Number(e.currentTarget.value);

--- a/zeus-web/src/state/tx-store.ts
+++ b/zeus-web/src/state/tx-store.ts
@@ -422,6 +422,13 @@ export const useTxStore = create<TxState>()(
 
       hydrateFromState: (s) =>
         set({
+          // Drive sliders — server is the source of truth. Persisted via
+          // RadioStateStore and broadcast on every SetDrive/SetTuneDrive so
+          // the operator's last-set values come back on relaunch. The
+          // localStorage mirror in `partialize` below exists only to avoid
+          // a first-paint flicker before this hydrate runs.
+          drivePercent: s.drivePercent,
+          tunePercent: s.tunePercent,
           psAuto: s.psAuto,
           psPtol: s.psPtol,
           psAutoAttenuate: s.psAutoAttenuate,


### PR DESCRIPTION
## Summary

Follow-up to PR #359. The backend persistence landed correctly — bench log on the next session shows `pa.recompute pct=25` on the first recompute of the new connect (exactly the value set in the prior session). **The backend hydrated.** But within a second the frontend connected, pushed its own localStorage default (10) back to the server through three push-on-connect sites, and clobbered the just-hydrated value. Operator-visible result: drive / TUN appear "not retained" across restarts even though the backend's `RadioStateStore` is doing its job.

The shape of this fix matches the pattern PureSignal already uses — **server is the source of truth, broadcasts via `StateDto`, frontend hydrates its local store from the incoming `StateDto` and stops pushing its own initial value on connect.** The localStorage mirror stays as a first-paint flicker shield.

## Bench evidence from yesterday's relaunch (the bug)

Prior session (set drive=25, TUN=20, then closed):
```
api.tx.drive percent=25
api.tx.tune-drive percent=20
```

New session (drive should hydrate to 25):
```
pa.recompute pct=25 ...  ← backend correctly hydrated to 25
api.tx.tune-drive percent=10  ← frontend pushed its default
api.tx.drive percent=10       ← frontend pushed its default
pa.recompute pct=10 ...  ← server's hydrated 25 is now clobbered
```

This PR removes the three frontend push sites and adds server → frontend hydrate via the existing StateDto pattern.

## Changes — backend

- **`Zeus.Contracts/Dtos.cs`** — add `DrivePct = 0` and `TunePct = 10` to `StateDto`.
- **`Zeus.Server.Hosting/RadioService.cs`**:
  - Initial state construction reads hydrated `_drivePct` / `_tunePct` (already pulled from `rsSnap` by PR #359's ctor block) into the `StateDto` so the first `/api/state` response carries them.
  - `SetDrive` / `SetTuneDrive` use `Mutate(s => s with { DrivePct = clamped })` so changes broadcast via `StateChanged` AND dirty the flush timer in one step. Without broadcast, fresh clients wouldn't see the hydrated value until some other mutation fired.
  - `FlushState` reads from `snap.DrivePct` / `snap.TunePct` (cleaner than `Volatile.Read` on the private fields).

## Changes — frontend

- **`zeus-web/src/api/client.ts`** — add `drivePercent` / `tunePercent` to `RadioStateDto` type and `normalizeState`.
- **`zeus-web/src/state/tx-store.ts`** — `hydrateFromState` overlays `drivePercent` / `tunePercent` so the operator's persisted value lands the moment the connect response comes back.
- **`zeus-web/src/components/DriveSlider.tsx`** / **`TunePowerSlider.tsx`** — drop the `syncedRef` push-on-connect effects. They were exactly the clobber path. Replaced with explanatory comments so the next person doesn't reintroduce.
- **`zeus-web/src/components/ConnectPanel.tsx`** — drop the post-connect `setDrive` / `setTuneDrive` pushes from `applyPostConnectEffects`. (`micGainDb` / `levelerMaxGainDb` still push from localStorage — they don't yet have a server-authoritative path; natural follow-up.)

## Test plan

- [x] `dotnet build Zeus.slnx` — 0 warnings, 0 errors
- [x] `dotnet test ... --filter RadioStateStore|RadioService|StateDto` — 26/26 pass
- [x] `npm typecheck` — clean
- [x] `npm test` — 224/224 pass
- [ ] CI green on this PR
- [ ] After merge: bench-verify on G2 — set drive to non-default, close desktop, reopen, confirm slider rehydrates without the frontend clobbering

## Notes

- The localStorage `partialize` mirror for `drivePercent` / `tunePercent` stays in `tx-store` — it's no longer the source of truth but it eliminates first-paint flicker before the server hydrate lands. Same pattern PureSignal uses.