### PR TITLE
feat(desktop): share session over LAN HTTPS so phones can connect

### DIFF
--- a/OpenhpsdrZeus/Program.cs
+++ b/OpenhpsdrZeus/Program.cs
@@ -49,8 +49,11 @@ using Photino.NET;
 using Zeus.Server;
 
 // Single binary, two modes:
-//   OpenhpsdrZeus              → service mode (LAN bind, HTTPS, banner)
-//   OpenhpsdrZeus --desktop    → Photino shell (loopback only, no HTTPS, no banner)
+//   OpenhpsdrZeus              → service mode (LAN HTTP + HTTPS, console banner)
+//   OpenhpsdrZeus --desktop    → Photino shell (loopback HTTP for the webview,
+//                                 plus LAN HTTPS so a phone can pick up the
+//                                 session while the operator is away from the
+//                                 shack PC — see ShareOverLan)
 //
 // We use a classic `Main` (not top-level statements) so we can hang [STAThread]
 // off it — Photino on Windows wraps WebView2 (COM), and CoreWebView2 has to be
@@ -110,16 +113,21 @@ public partial class Program
         // Photino calls below stay on the main thread; Kestrel runs on its own
         // thread pool either way and is unaffected.
 
-        // Loopback-only, OS-assigned port, no LAN HTTPS, no console banner — the
-        // Photino webview is the only consumer. Picking port 0 lets the OS hand us
-        // a guaranteed-free port; we read it back from IServer after StartAsync so
-        // no TOCTOU race with a concurrent listener.
+        // Two listeners: loopback HTTP on an OS-assigned port (the Photino webview
+        // is the only consumer of this one — picking port 0 lets the OS hand us
+        // a guaranteed-free port; we read it back from IServer after StartAsync
+        // so there's no TOCTOU race with a concurrent listener), plus LAN HTTPS
+        // on :6443 with the existing self-signed cert so a phone or laptop on
+        // the same network can pick up the session while the operator is away
+        // from the shack PC. ShareOverLan=true is what decouples the two listener
+        // bindings inside ZeusHost — see the comment by Kestrel.ConfigureKestrel.
         var hostOptions = new ZeusHostOptions
         {
             HostMode = ZeusHostMode.Desktop,
             HttpPort = 0,
             BindAllInterfaces = false,
-            UseHttpsLanCert = false,
+            UseHttpsLanCert = true,
+            ShareOverLan = true,
             PrintConsoleBanner = false,
         };
 
@@ -127,16 +135,31 @@ public partial class Program
         ZeusHost.InitializeAsync(app).GetAwaiter().GetResult();
         app.StartAsync().GetAwaiter().GetResult();
 
-        // Resolve the bound URL after Start — Kestrel writes the OS-assigned port
-        // into IServerAddressesFeature here. Exactly one HTTP address because
-        // hostOptions.UseHttpsLanCert=false and BindAllInterfaces=false.
+        // Resolve the bound URLs after Start — Kestrel writes the OS-assigned
+        // loopback port (plus the LAN HTTPS port we configured) into
+        // IServerAddressesFeature here. Photino must load the loopback HTTP URL:
+        // pointing the webview at the LAN HTTPS URL would trip the self-signed
+        // cert's interstitial inside the embedded WebKit/WebView2, which has no
+        // UI to accept the warning.
         var addresses = app.Services.GetRequiredService<IServer>()
             .Features.Get<IServerAddressesFeature>()
             ?? throw new InvalidOperationException("Kestrel did not expose IServerAddressesFeature.");
-        var startUrl = addresses.Addresses.FirstOrDefault()
-            ?? throw new InvalidOperationException("Kestrel reported no listening addresses.");
+        var startUrl = addresses.Addresses
+            .FirstOrDefault(a => a.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+            ?? throw new InvalidOperationException("Kestrel reported no loopback HTTP address.");
 
         Console.WriteLine($"OpenhpsdrZeus (desktop) hosting backend at {startUrl}");
+
+        // LAN URL surface for the "walk to the kitchen, pick up phone" flow.
+        // GetLanIps already filters to up + non-loopback interfaces, so the
+        // operator gets a copy-pasteable URL per NIC. If for some reason no LAN
+        // NIC is visible (offline laptop, ethernet down) we just skip this
+        // line — the Photino window still works.
+        var lanHttpsPort = LanCertificate.GetHttpsPort();
+        foreach (var ip in LanCertificate.GetLanIps())
+        {
+            Console.WriteLine($"OpenhpsdrZeus (desktop) LAN share: https://{ip}:{lanHttpsPort}");
+        }
 
         // SetUseOsDefaultLocation(false)+Center so first launch doesn't drop the
         // window in the corner. Title is the marketing name; we prefix "Openhpsdr"

--- a/Zeus.Server.Hosting/CapabilitiesService.cs
+++ b/Zeus.Server.Hosting/CapabilitiesService.cs
@@ -14,8 +14,10 @@
 //   2. Add a field to FeatureMatrix and populate it in Snapshot().
 //   3. Update zeus-web/src/api/capabilities.ts to mirror the shape.
 
+using System.Net;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using Microsoft.AspNetCore.Http;
 using Zeus.PluginHost.Native;
 
 namespace Zeus.Server;
@@ -23,6 +25,7 @@ namespace Zeus.Server;
 public sealed class CapabilitiesService
 {
     private readonly CapabilitiesSnapshot _snapshot;
+    private readonly bool _shareOverLan;
 
     public CapabilitiesService(ZeusHostOptions options)
     {
@@ -39,9 +42,30 @@ public sealed class CapabilitiesService
             Architecture: architecture,
             Version: version,
             Features: new FeatureMatrix(VstHost: ProbeVstHost(platform)));
+
+        _shareOverLan = options.HostMode == ZeusHostMode.Desktop && options.ShareOverLan;
     }
 
     public CapabilitiesSnapshot Snapshot() => _snapshot;
+
+    /// <summary>
+    /// Per-request snapshot. When the host is desktop + ShareOverLan, the
+    /// captured "desktop" host string is overridden to "server" for non-loopback
+    /// requests so a LAN browser enables its WS audio decoder + mic uplink, while
+    /// the Photino webview (loopback) keeps "desktop" and the native miniaudio
+    /// path. Without this distinction Photino would double-play (miniaudio AND
+    /// the browser audio worklet) or LAN browsers would be silent.
+    /// </summary>
+    public CapabilitiesSnapshot Snapshot(HttpContext ctx)
+    {
+        if (!_shareOverLan) return _snapshot;
+
+        var local = ctx.Connection.LocalIpAddress;
+        var isLoopback = local is not null && IPAddress.IsLoopback(local);
+        if (isLoopback) return _snapshot;
+
+        return _snapshot with { Host = "server" };
+    }
 
     // VST host availability gate. Today the C++ sidecar only ships for
     // Linux; macOS and Windows builds are not in this release. The

--- a/Zeus.Server.Hosting/NativeAudioSink.cs
+++ b/Zeus.Server.Hosting/NativeAudioSink.cs
@@ -75,6 +75,21 @@ internal sealed class NativeAudioSink : IRxAudioSink, IHostedService, IDisposabl
     private MiniAudioOutput? _output;
     private bool _disposed;
 
+    // Mute flag for the Photino-side Mute/Unmute button. Read on the DSP
+    // tick thread inside Publish, written from the REST request thread —
+    // volatile is the right tool. On mute we drain the ring so unmute
+    // doesn't replay ~1 s of stale audio; the miniaudio device stays
+    // open either way so there's no pop and no fight with the OS mixer.
+    private volatile bool _muted;
+
+    public bool IsMuted => _muted;
+
+    public void SetMuted(bool muted)
+    {
+        _muted = muted;
+        if (muted) _ring.Clear();
+    }
+
     // Diagnostics — accessed from the audio worker thread; volatile / interlocked
     // suffices since they're write-only there and read-only on the timer thread.
     private long _underrunSamples;
@@ -131,6 +146,12 @@ internal sealed class NativeAudioSink : IRxAudioSink, IHostedService, IDisposabl
 
     public void Publish(in AudioFrame frame)
     {
+        // Muted at the door: don't enqueue and let the ring drain to silence
+        // on the playback callback's underrun path. Cheaper than gating in
+        // the audio worker thread and avoids any sample-rate / channel-count
+        // negotiation with the producer.
+        if (_muted) return;
+
         // The DSP tick produces mono float32 @ 48 kHz. We assert the format
         // softly: anything else is logged and dropped rather than corrupting
         // the ring. (The format is set in DspPipelineService.AudioOutputRateHz

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -36,9 +36,33 @@ public static class ZeusEndpoints
 
         // Capabilities snapshot — host-mode + platform + feature gates.
         // Frontend fetches once on app mount and hides UI for unavailable
-        // features (e.g. TX Audio Tools when vstHost.available=false).
+        // features (e.g. TX Audio Tools when vstHost.available=false). The
+        // HttpContext-aware Snapshot overload lets desktop + ShareOverLan
+        // report host="server" to LAN clients while loopback Photino keeps
+        // host="desktop" — see CapabilitiesService.Snapshot(HttpContext).
         app.MapGet("/api/capabilities",
-            (CapabilitiesService caps) => Results.Ok(caps.Snapshot()));
+            (HttpContext ctx, CapabilitiesService caps) => Results.Ok(caps.Snapshot(ctx)));
+
+        // Native RX audio (miniaudio) — desktop-mode mute control. The
+        // Mute/Unmute button in the Photino window POSTs here to silence
+        // the OS playback device. NativeAudioSink is only registered in
+        // desktop mode, so GetService returns null in server mode and the
+        // endpoint reports supported=false; the SPA's AudioToggle uses
+        // its in-browser AudioContext path there instead.
+        app.MapGet("/api/audio/native", (IServiceProvider sp) =>
+        {
+            var sink = sp.GetService<NativeAudioSink>();
+            return sink is null
+                ? Results.Ok(new { supported = false, muted = false })
+                : Results.Ok(new { supported = true, muted = sink.IsMuted });
+        });
+        app.MapPost("/api/audio/native/mute", (NativeMuteRequest body, IServiceProvider sp) =>
+        {
+            var sink = sp.GetService<NativeAudioSink>();
+            if (sink is null) return Results.NotFound(new { error = "native audio not active in this host mode" });
+            sink.SetMuted(body.Muted);
+            return Results.Ok(new { supported = true, muted = sink.IsMuted });
+        });
 
         app.MapGet("/api/state", (RadioService r) => r.Snapshot());
 
@@ -1596,3 +1620,5 @@ public static class ZeusEndpoints
         _ => throw new ArgumentOutOfRangeException(nameof(hz), hz, "validate before calling"),
     };
 }
+
+internal sealed record NativeMuteRequest(bool Muted);

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -99,28 +99,34 @@ public static class ZeusHost
 
         // HTTPS bind for mobile-browser parity. Browsers refuse getUserMedia on a
         // non-secure context, which kills mic-uplink TX from any phone reaching
-        // the server by LAN IP. Desktop mode skips HTTPS entirely (Photino
-        // webview is same-origin localhost, no cert needed).
+        // the server by LAN IP. Plain desktop mode skips HTTPS entirely (Photino
+        // webview is same-origin localhost, no cert needed); desktop + ShareOverLan
+        // re-enables HTTPS on the LAN so a phone can pick up the session while the
+        // operator is away from the shack PC.
         var httpsPort = options.UseHttpsLanCert
             ? (options.HttpsPort > 0 ? options.HttpsPort : LanCertificate.GetHttpsPort())
             : 0;
         var lanCert = options.UseHttpsLanCert ? LanCertificate.GetOrCreate() : null;
+        var httpsAnyIp = options.BindAllInterfaces || options.ShareOverLan;
 
         builder.WebHost.ConfigureKestrel(k =>
         {
-            // BindAllInterfaces=true (service mode) makes the SPA + API reachable
-            // from other hosts on the LAN (doc 01 §Deployment: local single-user,
-            // same LAN as radio). Desktop mode (false) binds explicit loopback.
-            // Kestrel rejects ListenLocalhost(0) — use Listen(IPAddress.Loopback,
-            // 0) when we want an OS-assigned port for desktop mode.
+            // HTTP listener: BindAllInterfaces=true (service mode) reaches the
+            // SPA + API from other LAN hosts. Desktop mode (false) binds explicit
+            // loopback — Photino webview only. Kestrel rejects ListenLocalhost(0),
+            // so use Listen(IPAddress.Loopback, 0) for an OS-assigned loopback port.
             if (options.BindAllInterfaces)
                 k.ListenAnyIP(options.HttpPort);
             else
                 k.Listen(IPAddress.Loopback, options.HttpPort);
 
+            // HTTPS listener: decoupled from the HTTP listener so desktop +
+            // ShareOverLan keeps HTTP on loopback (Photino) while exposing HTTPS
+            // to the LAN (phone). Plain service mode hits the same ListenAnyIP
+            // branch as before the option was introduced.
             if (httpsPort > 0 && lanCert is not null)
             {
-                if (options.BindAllInterfaces)
+                if (httpsAnyIp)
                     k.ListenAnyIP(httpsPort, l => l.UseHttps(lanCert));
                 else
                     k.Listen(IPAddress.Loopback, httpsPort, l => l.UseHttps(lanCert));
@@ -177,13 +183,25 @@ public static class ZeusHost
             builder.Services.AddHostedService(sp =>
                 sp.GetRequiredService<NativeAudioSink>());
 
+            // ShareOverLan: also register the WebSocket sink so any LAN
+            // browser hitting https://<lan-ip>:6443 gets RX audio. The hub
+            // short-circuits on _clients.IsEmpty, so with zero LAN clients
+            // attached this is effectively a no-op (one virtual call + one
+            // atomic int read per AudioFrame).
+            if (options.ShareOverLan)
+            {
+                builder.Services.AddSingleton<IRxAudioSink, WebSocketAudioSink>();
+            }
+
             // Mic capture: replaces the browser → WS MicPcm uplink in
             // desktop mode. TxAudioIngest still subscribes to
-            // StreamingHub.MicPcmReceived (harmless — the SPA's mic worklet
-            // is disabled by Phase 2c, so no frames arrive), and
-            // NativeMicCapture feeds the same OnMicPcmBytes entry point
-            // directly so the WDSP TXA chain, IQ ring, and protocol
-            // packers don't see any difference between transports.
+            // StreamingHub.MicPcmReceived — with ShareOverLan on, that
+            // subscription becomes the live phone-mic path, so a paired
+            // phone can MOX and transmit. NativeMicCapture continues to
+            // feed OnMicPcmBytes directly for the shack-PC mic. Either
+            // source goes through the same TxAudioIngest entry point so
+            // WDSP / IQ ring / protocol packers don't see a transport
+            // difference.
             builder.Services.AddSingleton<NativeMicCapture>();
             builder.Services.AddHostedService(sp =>
                 sp.GetRequiredService<NativeMicCapture>());

--- a/Zeus.Server.Hosting/ZeusHostOptions.cs
+++ b/Zeus.Server.Hosting/ZeusHostOptions.cs
@@ -49,6 +49,16 @@ public sealed class ZeusHostOptions
     public bool UseHttpsLanCert { get; init; } = true;
 
     /// <summary>
+    /// Desktop-mode LAN sharing. When true the HTTPS listener binds
+    /// <c>ListenAnyIP</c> even though <see cref="BindAllInterfaces"/> is false,
+    /// so the Photino webview keeps its loopback HTTP socket while phones /
+    /// laptops on the same LAN can reach the SPA at <c>https://&lt;lan-ip&gt;:6443</c>.
+    /// Ignored when <see cref="BindAllInterfaces"/> is already true (server mode
+    /// covers that case).
+    /// </summary>
+    public bool ShareOverLan { get; init; }
+
+    /// <summary>
     /// Print the multi-line startup banner to stdout. Service mode = true (the
     /// console window is the operator-facing UI). Desktop mode = false (Photino
     /// is the UI; the console is hidden anyway).

--- a/zeus-web/src/components/AudioToggle.tsx
+++ b/zeus-web/src/components/AudioToggle.tsx
@@ -46,16 +46,39 @@ import { useEffect, useState } from 'react';
 import { getAudioClient, type AudioClientState } from '../audio/audio-client';
 import { useCapabilitiesStore } from '../state/capabilities-store';
 
+// Desktop-mode (Photino) Mute/Unmute path. The webview's in-browser audio
+// decoder is opted out — RX audio reaches the operator via NativeAudioSink
+// (miniaudio) on the host. We render the same button as server mode and
+// route clicks through /api/audio/native, which flips a flag on the sink
+// that drops frames before they hit the OS device.
+async function fetchNativeMuted(): Promise<boolean> {
+  const r = await fetch('/api/audio/native');
+  if (!r.ok) throw new Error(`GET /api/audio/native ${r.status}`);
+  const j = (await r.json()) as { supported: boolean; muted: boolean };
+  return j.muted;
+}
+
+async function postNativeMuted(muted: boolean): Promise<boolean> {
+  const r = await fetch('/api/audio/native/mute', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ muted }),
+  });
+  if (!r.ok) throw new Error(`POST /api/audio/native/mute ${r.status}`);
+  const j = (await r.json()) as { muted: boolean };
+  return j.muted;
+}
+
 export function AudioToggle() {
   const [state, setState] = useState<AudioClientState>({ kind: 'idle' });
-  // Phase 2c — in desktop mode the host process renders RX audio through
-  // its native miniaudio sink, so the Mute/Unmute button (which gates an
-  // in-browser AudioContext) is meaningless. Render a passive status
-  // indicator in its place. The AF slider next door still drives the
-  // server-side WDSP gain, so volume control is fully functional in both
-  // modes without touching this component.
   const hostMode = useCapabilitiesStore((s) => s.capabilities?.host ?? null);
   const nativeAudio = hostMode === 'desktop';
+
+  // Server-side mute state for the desktop path. Hydrated from
+  // /api/audio/native on mount and after each toggle.
+  const [nativeMuted, setNativeMuted] = useState<boolean | null>(null);
+  const [nativeBusy, setNativeBusy] = useState(false);
+  const [nativeError, setNativeError] = useState<string | null>(null);
 
   useEffect(() => {
     return getAudioClient().subscribe((s) => {
@@ -63,20 +86,56 @@ export function AudioToggle() {
     });
   }, []);
 
+  useEffect(() => {
+    if (!nativeAudio) return;
+    let cancelled = false;
+    fetchNativeMuted()
+      .then((m) => { if (!cancelled) setNativeMuted(m); })
+      .catch((err) => { if (!cancelled) setNativeError(err.message ?? String(err)); });
+    return () => { cancelled = true; };
+  }, [nativeAudio]);
+
+  // Desktop path: server-side mute via REST. Same visual treatment as the
+  // browser path so the two host modes look identical to the operator.
   if (nativeAudio) {
+    const muted = nativeMuted ?? false;
+    const onClick = async () => {
+      if (nativeBusy) return;
+      setNativeBusy(true);
+      setNativeError(null);
+      try {
+        const next = await postNativeMuted(!muted);
+        setNativeMuted(next);
+      } catch (err) {
+        setNativeError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setNativeBusy(false);
+      }
+    };
+    const label = nativeBusy ? 'Loading…' : muted ? '▶ Unmute' : '■ Mute';
     return (
-      <div
-        style={{ display: 'flex', alignItems: 'center', gap: 6 }}
-        title="RX audio is playing through the host's default output device."
-      >
-        <span className="chip">
-          <span className="k">AUDIO</span>
-          <span className="v">native (default device)</span>
-        </span>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+        <button
+          type="button"
+          onPointerUp={onClick}
+          disabled={nativeBusy}
+          className={`btn tx-btn ${muted ? 'active' : ''}`}
+          title={nativeError ?? 'RX audio is playing through the host\'s default output device.'}
+        >
+          <span className={`led ${muted ? 'on' : ''}`} style={{ marginRight: 6 }} />
+          {label}
+        </button>
+        {nativeError && (
+          <span className="label-xs" style={{ color: 'var(--tx)' }}>
+            audio error
+          </span>
+        )}
       </div>
     );
   }
 
+  // Browser path (server mode + any LAN client of a shared desktop): the
+  // button gates the in-browser AudioContext that decodes WS audio frames.
   const onClick = async () => {
     const client = getAudioClient();
     if (state.kind === 'playing' || state.kind === 'loading') {


### PR DESCRIPTION
## Summary

Adds an opt-in `ShareOverLan` flag to desktop mode so the operator can leave the shack PC running and pick up the same session on a phone or laptop over the LAN — no extra binary, no separate server-mode instance, no external dependencies.

- Photino webview keeps loopback HTTP on its OS-assigned port (unchanged — avoids cert prompts inside the embedded webview).
- Kestrel now also binds `ListenAnyIP(6443)` HTTPS with the existing self-signed LAN cert in desktop mode, so phones reach the SPA at `https://<lan-ip>:6443`.
- RX audio sink is tee'd: `NativeAudioSink` keeps feeding miniaudio on the shack PC, and `WebSocketAudioSink` is also registered so LAN browsers receive frames. `StreamingHub.Broadcast` short-circuits on `_clients.IsEmpty`, so the WS path is effectively free when no phone is attached.
- `/api/capabilities` is loopback-aware: returns `host=desktop` to the Photino webview (miniaudio path) and `host=server` to LAN clients (in-browser AudioContext + mic uplink). The SPA already keys its audio routing off this field.
- Restores the **Mute/Unmute button on desktop**. Phase 2c had swapped it for a passive chip because the in-browser decoder is opted out in desktop mode. The button now POSTs to a new `/api/audio/native/mute` endpoint that flips a flag on `NativeAudioSink`. When muted, `Publish()` drops frames at the door and the miniaudio ring drains to silence — device stays open (no pop, no fight with the OS mixer). LAN browser clients keep the existing in-browser button behaviour unchanged.

## Use case

Walk to the kitchen, open `https://<shack-pc>:6443` on the phone, pick up the same conversation. No second backend instance, no separate prefs DB, no port forwarding.

## Out of scope (deferred to phase 2)

Remote/internet access via Cloudflare Tunnel or similar — that needs a different authentication story and was scoped out. The LAN path is uncondionally trusted today, same as server mode.

## Test plan

- [x] `dotnet build Zeus.slnx` — clean (0 warnings, 0 errors)
- [x] `dotnet test Zeus.slnx` — 1086 passed, 137 skipped (runtime-gated), 0 failed
- [x] Smoke-tested on macOS: `dotnet run --project OpenhpsdrZeus -- --desktop` opens the Photino window on a loopback port AND prints `LAN share: https://<ip>:6443`
- [x] `curl https://<lan-ip>:6443/api/capabilities` returns `host=server`
- [x] `curl http://127.0.0.1:<loopback>/api/capabilities` returns `host=desktop`
- [x] Mute button click round-trip: server `muted:true` → label flips to "▶ Unmute", miniaudio goes silent; click again → `muted:false`, audio resumes
- [ ] Bench-verify on the Hermes-Lite 2 with a phone attached (10m / 28400 only — Brian's resonant antenna)

## Files touched

- `Zeus.Server.Hosting/ZeusHostOptions.cs` — new `ShareOverLan` init bool
- `Zeus.Server.Hosting/ZeusHost.cs` — Kestrel HTTP/HTTPS bind decoupled; second `IRxAudioSink` registered when sharing
- `Zeus.Server.Hosting/CapabilitiesService.cs` — new `Snapshot(HttpContext)` overload; loopback → "desktop", non-loopback → "server"
- `Zeus.Server.Hosting/ZeusEndpoints.cs` — `/api/audio/native` GET + POST
- `Zeus.Server.Hosting/NativeAudioSink.cs` — `_muted` flag + drain-on-mute
- `OpenhpsdrZeus/Program.cs` — desktop block flips `UseHttpsLanCert=true`, `ShareOverLan=true`; address picker grabs the loopback HTTP URL for Photino; prints LAN URL per NIC
- `zeus-web/src/components/AudioToggle.tsx` — desktop branch now renders a real button that hits `/api/audio/native/mute`