### PR TITLE
chore(repo): add CODEOWNERS — @Kb2uka owns all paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# OpenHPSDR Zeus — Code Owners
+#
+# Every path in this repo is owned by @Kb2uka. Combined with branch
+# protection on `develop` and `main` (require approving review from a
+# code owner), this enforces the maintainer's "I have to merge" rule —
+# any PR opened by another collaborator (e.g. @brianbruff, @rampa069)
+# requires @Kb2uka's review approval before it can be merged.
+#
+# Brian (@brianbruff) remains the visual-design / UX / architecture
+# authority per CLAUDE.md, so his review still drives those decisions
+# on a per-PR basis; this file isn't about who decides what merges, it's
+# about who clicks merge.
+#
+# Format reference: https://docs.github.com/en/repositories/managing-your-repositories-settings-and-security/customizing-your-repository/about-code-owners
+
+*       @Kb2uka


### PR DESCRIPTION
Companion to inviting @rampa069 as Write collaborator alongside @brianbruff. CODEOWNERS routes the required-review on protected branches so every PR opened by a non-Kb2uka collaborator needs @Kb2uka's approval before merge.

Doesn't change anyone's existing red-light review authority — Brian still owns visual / UX / architecture decisions per CLAUDE.md, this file is strictly about who clicks merge.

Pairs with branch-protection updates on develop + main that require code-owner review (applied separately via API since GitHub doesn't read CODEOWNERS until it's on the protected branch).

## Test plan

- [x] File lints cleanly (single `*` line + comments)
- [ ] CI green
- [ ] After merge: update branch protection on develop and main to require code-owner approval