### PR TITLE
fix(tx-meters): smoothed-SWR + per-mode trip thresholds (#362)

### DIFF
--- a/Zeus.Server.Hosting/TxMetersService.cs
+++ b/Zeus.Server.Hosting/TxMetersService.cs
@@ -379,7 +379,15 @@ public sealed class TxMetersService : BackgroundService
                         _refAdcPeak = 0;
                     }
                     var cal = RadioCalibrations.For(_radio.ConnectedBoardKind, _radio.EffectiveOrionMkIIVariant);
-                    var (fwdW, refW, swrVal) = ComputeMeters(fwdAdc, refAdc, cal);
+                    // Watts use peak-hold (matches LP-100A peak-reading
+                    // wattmeter). SWR uses the smoothed ADC pair instead:
+                    // peak(FWD) vs peak(REF) are two uncorrelated transient
+                    // maxima and their ratio is not a physical standing-wave
+                    // ratio — on HL2 both rails can saturate together during
+                    // PA-on / LPF-relay transients, with REF clamping a few
+                    // counts above FWD, which the trip logic reads as 9:1.
+                    var (fwdW, refW, _) = ComputeMeters(fwdAdc, refAdc, cal);
+                    var (_, _, swrVal) = ComputeMeters(fwdAdcSmoothed, refAdcSmoothed, cal);
                     swr = swrVal;
                     // Stage meters are published by WdspDspEngine.ProcessTxBlock;
                     // may lag the first TX block by a few ticks at MOX-on, which

--- a/Zeus.Server.Hosting/TxMetersService.cs
+++ b/Zeus.Server.Hosting/TxMetersService.cs
@@ -79,10 +79,24 @@ public sealed class TxMetersService : BackgroundService
     private const double SwrMinFwdWatts = 2.0;
     private const double SwrMax = 9.0;
 
-    // PRD FR-6: SWR > 2.5 sustained 500 ms → trip MOX/TUN. Tighter than the
-    // original 3.0 threshold; chosen to protect HL2 PA aggressively.
-    private const double SwrTripThreshold = 2.5;
-    private static readonly TimeSpan SwrTripDuration = TimeSpan.FromMilliseconds(500);
+    // Per-mode SWR trip thresholds and sustain windows. MOX keeps the
+    // conservative PRD FR-6 default (2.5:1 sustained 500 ms). TUN is
+    // relaxed to 6:1 because TUN's whole purpose is to drive a carrier
+    // into a not-yet-matched load so an ATU / operator can find a
+    // match — tripping at 2.5:1 on TUN makes TUN useless. Values follow
+    // Thetis / piHPSDR convention. See issue #362.
+    private const double SwrTripThresholdMox = 2.5;
+    private const double SwrTripThresholdTun = 6.0;
+    private static readonly TimeSpan SwrTripDurationMox = TimeSpan.FromMilliseconds(500);
+    private static readonly TimeSpan SwrTripDurationTun = TimeSpan.FromMilliseconds(500);
+
+    // Startup grace after the keying edge: suppress SWR trip evaluation
+    // during the PA-bias / LPF-relay settle window where the bridge can
+    // transiently read above threshold before the actual antenna match
+    // is engaged. Per-mode so MOX still trips quickly on a genuine bad
+    // match while TUN gives the ATU time to do its work.
+    private static readonly TimeSpan SwrStartupGraceMox = TimeSpan.FromMilliseconds(300);
+    private static readonly TimeSpan SwrStartupGraceTun = TimeSpan.FromMilliseconds(500);
 
     // PRD FR-6: a single MOX/TUN transmission may not exceed 120 s. Catches
     // stuck spacebars, jammed buttons, or a client that forgot to unkey. The
@@ -403,7 +417,9 @@ public sealed class TxMetersService : BackgroundService
                         fwdW, refW, swr,
                         cal);
 
-                    if (EvaluateSwrTrip(swr, DateTime.UtcNow) is { } tripReason)
+                    bool isTun = _tx.IsTunOn;
+                    DateTime keyedAt = (isTun ? _tx.TunStartedAt : _tx.MoxStartedAt) ?? DateTime.UtcNow;
+                    if (EvaluateSwrTrip(swr, DateTime.UtcNow, isTun, keyedAt) is { } tripReason)
                     {
                         // TryTripForAlert is idempotent — a second caller on the
                         // same tick (e.g. timeout firing concurrently) finds MOX
@@ -531,28 +547,41 @@ public sealed class TxMetersService : BackgroundService
     }
 
     /// <summary>
-    /// Evaluate the SWR sustain window and return the operator-facing trip
-    /// message when the threshold has been exceeded for ≥500 ms, or null if
-    /// not yet. Exposed as <c>internal</c> so unit tests can drive synthetic
-    /// timestamps without a <see cref="DateTime"/> abstraction — the
-    /// production caller passes <see cref="DateTime.UtcNow"/>. Firing resets
-    /// the timer so the caller gets exactly one trip per sustained excursion.
+    /// Evaluate the per-mode SWR sustain window and return the operator-facing
+    /// trip message when the active-mode threshold has been exceeded for the
+    /// active-mode sustain duration, or null if not yet. Honours the per-mode
+    /// startup-grace window after the keying edge so a bridge-settle transient
+    /// at MOX/TUN-on does not arm the trip before the load has stabilised.
+    /// Exposed as <c>internal</c> so unit tests can drive synthetic timestamps
+    /// without a <see cref="DateTime"/> abstraction — the production caller
+    /// passes <see cref="DateTime.UtcNow"/>. Firing resets the timer so the
+    /// caller gets exactly one trip per sustained excursion.
     /// </summary>
-    internal string? EvaluateSwrTrip(double swr, DateTime now)
+    internal string? EvaluateSwrTrip(double swr, DateTime now, bool isTun, DateTime keyedAt)
     {
+        var threshold = isTun ? SwrTripThresholdTun : SwrTripThresholdMox;
+        var sustain   = isTun ? SwrTripDurationTun  : SwrTripDurationMox;
+        var grace     = isTun ? SwrStartupGraceTun  : SwrStartupGraceMox;
+
         lock (_sync)
         {
-            if (swr > SwrTripThreshold)
+            if (now - keyedAt < grace)
+            {
+                _swrAboveThresholdSince = null;
+                return null;
+            }
+
+            if (swr > threshold)
             {
                 if (_swrAboveThresholdSince is null)
                 {
                     _swrAboveThresholdSince = now;
                     return null;
                 }
-                if (now - _swrAboveThresholdSince.Value >= SwrTripDuration)
+                if (now - _swrAboveThresholdSince.Value >= sustain)
                 {
                     _swrAboveThresholdSince = null;
-                    return $"SWR {swr:F1}:1 sustained >500 ms — dropped TX to protect PA";
+                    return $"SWR {swr:F1}:1 sustained >{(int)sustain.TotalMilliseconds} ms — dropped TX to protect PA";
                 }
                 return null;
             }

--- a/tests/Zeus.Server.Tests/TxMetersSwrTripTests.cs
+++ b/tests/Zeus.Server.Tests/TxMetersSwrTripTests.cs
@@ -53,10 +53,12 @@ using Xunit;
 namespace Zeus.Server.Tests;
 
 /// <summary>
-/// PRD FR-6 SWR auto-trip: TxMetersService must drop MOX/TUN if SWR &gt; 2.5
-/// sustained for ≥500 ms, but NOT trip on brief spikes. The trip logic is
-/// exercised directly via the internal <c>EvaluateSwrTrip(swr, now)</c>
-/// seam so tests can drive synthetic timestamps without wall-clock delays.
+/// PRD FR-6 SWR auto-trip: TxMetersService must drop MOX/TUN when SWR sustains
+/// above the per-mode threshold for the per-mode sustain duration, honour the
+/// per-mode startup-grace window after the keying edge, and NOT trip on brief
+/// spikes. The trip logic is exercised directly via the internal
+/// <c>EvaluateSwrTrip(swr, now, isTun, keyedAt)</c> seam so tests can drive
+/// synthetic timestamps without wall-clock delays. Issue #362.
 /// </summary>
 public class TxMetersSwrTripTests : IDisposable
 {
@@ -112,61 +114,135 @@ public class TxMetersSwrTripTests : IDisposable
         Assert.True(Math.Abs(swr - 2.5) < 0.1, $"Expected SWR ≈ 2.5, got {swr}");
     }
 
+    // Keyed-at sentinel that is well before any synthetic `now` the tests
+    // construct, so the per-mode startup grace is already past and the
+    // tests exercise the pure sustain-window logic. The grace behaviour
+    // gets its own dedicated tests below.
+    private static readonly DateTime KeyedAtPastGrace =
+        new DateTime(2026, 4, 18, 11, 0, 0, DateTimeKind.Utc);
+
     [Fact]
-    public void EvaluateSwrTrip_FiresAtExactly500msSustained_NotBefore()
+    public void EvaluateSwrTrip_Mox_FiresAtExactly500msSustained_NotBefore()
     {
         var svc = BuildService(out _, out _);
         var t0 = new DateTime(2026, 4, 18, 12, 0, 0, DateTimeKind.Utc);
 
         // First exceedance: starts the timer, no trip yet.
-        Assert.Null(svc.EvaluateSwrTrip(3.0, t0));
+        Assert.Null(svc.EvaluateSwrTrip(3.0, t0, isTun: false, KeyedAtPastGrace));
         // 100 ms in: still sustaining, not yet 500 ms.
-        Assert.Null(svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(100)));
+        Assert.Null(svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(100), isTun: false, KeyedAtPastGrace));
         // 499 ms in: one tick below the threshold duration — MUST NOT trip.
-        Assert.Null(svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(499)));
+        Assert.Null(svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(499), isTun: false, KeyedAtPastGrace));
         // Exactly 500 ms: trip fires.
-        var reason = svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(500));
+        var reason = svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(500), isTun: false, KeyedAtPastGrace);
         Assert.NotNull(reason);
         Assert.Contains("SWR", reason);
     }
 
     [Fact]
-    public void EvaluateSwrTrip_BriefSpikeThenClears_DoesNotTrip()
+    public void EvaluateSwrTrip_Mox_BriefSpikeThenClears_DoesNotTrip()
     {
         var svc = BuildService(out _, out _);
         var t0 = new DateTime(2026, 4, 18, 12, 0, 0, DateTimeKind.Utc);
 
         // 300 ms burst above threshold, then below.
-        Assert.Null(svc.EvaluateSwrTrip(3.0, t0));
-        Assert.Null(svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(100)));
-        Assert.Null(svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(300)));
+        Assert.Null(svc.EvaluateSwrTrip(3.0, t0, isTun: false, KeyedAtPastGrace));
+        Assert.Null(svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(100), isTun: false, KeyedAtPastGrace));
+        Assert.Null(svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(300), isTun: false, KeyedAtPastGrace));
         // SWR drops — timer clears.
-        Assert.Null(svc.EvaluateSwrTrip(1.5, t0.AddMilliseconds(350)));
+        Assert.Null(svc.EvaluateSwrTrip(1.5, t0.AddMilliseconds(350), isTun: false, KeyedAtPastGrace));
         // Now sustained ≥500 ms window past t0 has elapsed in wall-time, but
         // because we dipped below threshold at 350, the sustain timer restarted
         // on the next exceedance and must NOT carry the earlier excursion over.
-        Assert.Null(svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(600)));
-        Assert.Null(svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(1000)));
+        Assert.Null(svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(600), isTun: false, KeyedAtPastGrace));
+        Assert.Null(svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(1000), isTun: false, KeyedAtPastGrace));
         // Full 500 ms from the second exceedance onset (600) → trip at 1100.
-        var reason = svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(1100));
+        var reason = svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(1100), isTun: false, KeyedAtPastGrace);
         Assert.NotNull(reason);
     }
 
     [Fact]
-    public void EvaluateSwrTrip_FiresOnceThenResets_NoRepeatSpam()
+    public void EvaluateSwrTrip_Mox_FiresOnceThenResets_NoRepeatSpam()
     {
         var svc = BuildService(out _, out _);
         var t0 = new DateTime(2026, 4, 18, 12, 0, 0, DateTimeKind.Utc);
 
-        svc.EvaluateSwrTrip(3.0, t0);                          // start
-        Assert.NotNull(svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(500))); // fire
+        svc.EvaluateSwrTrip(3.0, t0, isTun: false, KeyedAtPastGrace);                          // start
+        Assert.NotNull(svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(500), isTun: false, KeyedAtPastGrace)); // fire
         // Immediately after the trip, repeated high-SWR ticks must NOT fire again
         // until a full new 500 ms sustain window completes from a fresh onset.
-        Assert.Null(svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(550)));
-        Assert.Null(svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(700)));
-        Assert.Null(svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(1049)));
+        Assert.Null(svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(550), isTun: false, KeyedAtPastGrace));
+        Assert.Null(svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(700), isTun: false, KeyedAtPastGrace));
+        Assert.Null(svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(1049), isTun: false, KeyedAtPastGrace));
         // 500 ms past the 550 onset = 1050. Fires.
-        Assert.NotNull(svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(1050)));
+        Assert.NotNull(svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(1050), isTun: false, KeyedAtPastGrace));
+    }
+
+    [Fact]
+    public void EvaluateSwrTrip_Mox_StartupGrace_SuppressesTripDuringFirst300ms()
+    {
+        var svc = BuildService(out _, out _);
+        var keyedAt = new DateTime(2026, 4, 18, 12, 0, 0, DateTimeKind.Utc);
+
+        // High SWR right after keying — MUST NOT trip within the 300 ms grace
+        // even if sustained the entire window. This is the HL2 bridge-settle
+        // / PA-bias transient case from issue #362.
+        Assert.Null(svc.EvaluateSwrTrip(3.0, keyedAt, isTun: false, keyedAt));
+        Assert.Null(svc.EvaluateSwrTrip(3.0, keyedAt.AddMilliseconds(100), isTun: false, keyedAt));
+        Assert.Null(svc.EvaluateSwrTrip(3.0, keyedAt.AddMilliseconds(299), isTun: false, keyedAt));
+        // From 300 ms onward grace is over; first post-grace tick starts the
+        // sustain timer, and the trip fires 500 ms after that onset.
+        Assert.Null(svc.EvaluateSwrTrip(3.0, keyedAt.AddMilliseconds(300), isTun: false, keyedAt));
+        Assert.Null(svc.EvaluateSwrTrip(3.0, keyedAt.AddMilliseconds(799), isTun: false, keyedAt));
+        var reason = svc.EvaluateSwrTrip(3.0, keyedAt.AddMilliseconds(800), isTun: false, keyedAt);
+        Assert.NotNull(reason);
+    }
+
+    [Fact]
+    public void EvaluateSwrTrip_Tun_HighThreshold_DoesNotTripAt3To1()
+    {
+        var svc = BuildService(out _, out _);
+        var t0 = new DateTime(2026, 4, 18, 12, 0, 0, DateTimeKind.Utc);
+
+        // 3:1 sustained well past the MOX threshold/sustain window — MUST NOT
+        // trip on TUN, because TUN's job is to drive a not-yet-matched load.
+        Assert.Null(svc.EvaluateSwrTrip(3.0, t0, isTun: true, KeyedAtPastGrace));
+        Assert.Null(svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(500), isTun: true, KeyedAtPastGrace));
+        Assert.Null(svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(1000), isTun: true, KeyedAtPastGrace));
+        Assert.Null(svc.EvaluateSwrTrip(3.0, t0.AddMilliseconds(5000), isTun: true, KeyedAtPastGrace));
+    }
+
+    [Fact]
+    public void EvaluateSwrTrip_Tun_FiresAt6To1Sustained()
+    {
+        var svc = BuildService(out _, out _);
+        var t0 = new DateTime(2026, 4, 18, 12, 0, 0, DateTimeKind.Utc);
+
+        // Genuine bad match — 7:1 sustained ≥500 ms on TUN should still trip.
+        Assert.Null(svc.EvaluateSwrTrip(7.0, t0, isTun: true, KeyedAtPastGrace));
+        Assert.Null(svc.EvaluateSwrTrip(7.0, t0.AddMilliseconds(499), isTun: true, KeyedAtPastGrace));
+        var reason = svc.EvaluateSwrTrip(7.0, t0.AddMilliseconds(500), isTun: true, KeyedAtPastGrace);
+        Assert.NotNull(reason);
+        Assert.Contains("SWR", reason);
+    }
+
+    [Fact]
+    public void EvaluateSwrTrip_Tun_StartupGrace_SuppressesTripDuringFirst500ms()
+    {
+        var svc = BuildService(out _, out _);
+        var keyedAt = new DateTime(2026, 4, 18, 12, 0, 0, DateTimeKind.Utc);
+
+        // Even a 9:1 reading during the 500 ms TUN grace must not arm the
+        // trip — the ATU is by design seeing a wildly mismatched load while
+        // hunting for a match.
+        Assert.Null(svc.EvaluateSwrTrip(9.0, keyedAt, isTun: true, keyedAt));
+        Assert.Null(svc.EvaluateSwrTrip(9.0, keyedAt.AddMilliseconds(250), isTun: true, keyedAt));
+        Assert.Null(svc.EvaluateSwrTrip(9.0, keyedAt.AddMilliseconds(499), isTun: true, keyedAt));
+        // From 500 ms onward grace is over; sustain timer starts and trip
+        // fires 500 ms later.
+        Assert.Null(svc.EvaluateSwrTrip(9.0, keyedAt.AddMilliseconds(500), isTun: true, keyedAt));
+        var reason = svc.EvaluateSwrTrip(9.0, keyedAt.AddMilliseconds(1000), isTun: true, keyedAt);
+        Assert.NotNull(reason);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes the false 9:1 SWR trip on HL2 and brings the MOX/TUN
protection contract in line with Thetis / piHPSDR. Two commits,
both green-lit by @Kb2uka in #362.

- `b01010b` — `EvaluateSwrTrip` reads the smoothed ADC pair for the
  SWR axis; watts axis continues to use peak-hold. Peak(FWD) vs
  peak(REF) over a 100 ms window are two uncorrelated transient
  maxima — their ratio is not a standing-wave ratio, and on HL2
  the bridge saturates both rails together with REF clamping a few
  counts above FWD, which the trip math read as SWR = 9.0:1 and
  tripped MOX/TUN after 500 ms even though the actual match was
  ~1.0–1.3:1.
- `10befff` — split the single 2.5:1 / 500 ms trip into per-mode
  thresholds with a startup-grace window: **MOX 2.5:1 / 500 ms +
  300 ms grace**, **TUN 6:1 / 500 ms + 500 ms grace**. TUN exists
  to drive a carrier into a not-yet-matched load so an ATU /
  operator can find a match; the previous 2.5:1 trip on TUN was
  wrong by design.

Threshold and grace values held as code constants per maintainer
guidance — no preferences surface in v1. Soft-start drive ramp
explicitly deferred.

## Test plan

- [x] Build clean: `dotnet build Zeus.slnx` → 0 warnings, 0 errors.
- [x] `Zeus.Server.Tests` suite: 563 pass, 5 skipped (TCI rate
      limiter — unrelated and pre-existing), 0 fail.
- [x] New unit tests: per-mode trip thresholds + startup grace
      (9 tests in `TxMetersSwrTripTests`, all pass).
- [x] Bench-tested on HL2 (30 m, drive 28 % TUN, antenna SWR ~1.01):
      no false trips with both patches active; `tx.meters.diag`
      logs show saturated peaks no longer feeding into the trip
      math while the smoothed values produce a sensible 1.0:1.
- [ ] **G2 bench testing not available locally — please verify on
      @Kb2uka's G2 before merge** (per #362 comment requesting
      cross-platform sanity check: false-trip elimination AND
      genuine bad-match trip).

## Scope notes

- No `Zeus.Contracts` wire-format change.
- No `Program.cs` / `vite.config.ts` change.
- No new dependencies.
- `EvaluateSwrTrip` signature gained two parameters (`isTun`,
  `keyedAt`); existing tests adapted with a `KeyedAtPastGrace`
  sentinel so the pre-existing sustain-window cases are unchanged
  semantically.

Refs #362

73 de EA5IUE
