### PR TITLE
docs(audio-chain): Phase 0 proposal for #332

### DIFF
--- a/docs/proposals/audio-chain-phase0.md
+++ b/docs/proposals/audio-chain-phase0.md
@@ -1,0 +1,169 @@
+# OpenHPSDR Zeus voice audio chain — Phase 0 master PRD
+
+**Issue:** [#332](https://github.com/Kb2uka/openhpsdr-zeus/issues/332) · **Phase:** 0 (research + sign-off, **docs-only**) · **Branch:** `feature/332-audio-chain-phase0` · **Authority:** KB2UKA per [feedback_audio_plugin_authority](https://github.com/Kb2uka/openhpsdr-zeus) (Brian retains plugin-system architecture; audio-chain content is KB2UKA's call).
+
+This document synthesizes three Phase 0 research streams into the unified plan and the sign-off list. The full research lives in the sibling files under `docs/proposals/audio-chain/` — this PRD points at them rather than restating them.
+
+| Sibling | Topic |
+|---|---|
+| `audio-chain/01-aethersdr-and-external-deps.md` | AetherSDR chain analysis (reference-only), GPL-2/GPL-3 license posture, external-dependency evaluation per v1 block |
+| `audio-chain/02-wdsp-gap-analysis.md` | What WDSP already exposes vs. what we hand-author vs. what we pull from external libraries, per v1 block |
+| `audio-chain/03-ux-and-integration.md` | Chain-panel UX, slot semantics, CPU budget, integration with `WdspDspEngine` |
+
+---
+
+## 1. What's locked
+
+### v1 block list — KB2UKA-locked 2026-05-17
+
+Five blocks, in proposed signal order:
+
+1. **8-10 band parametric EQ** (per-band freq / gain / Q)
+2. **Compressor** — single-stage VCA-style (threshold / ratio / attack / release + makeup gain)
+3. **Exciter** — Aural-Exciter-style top-end harmonic enhancement (frequency / amount / mix)
+4. **Bass enhancer** — Aphex 204 "Big Bottom" / Waves MaxxBass-style **psychoacoustic missing-fundamental synthesis** (NOT a low-frequency boost — synthesizes upper harmonics of low content so the ear perceives bass without the radio transmitting frequencies the antenna can't radiate)
+5. **Reverb** — short-tail spatial enhancement (size / decay / mix)
+
+Explicit non-v1 (worth surfacing to KB2UKA as "want to add these?" rather than panel work to skip silently): Gate, De-esser, Tube saturation, Limiter (downstream WDSP ALC covers it). Leveler stays in WDSP upstream of the new chain.
+
+### Deployment model — each block is a registry plugin
+
+Per Brian's plugin system rebuild ([PR #368](https://github.com/Kb2uka/openhpsdr-zeus/pull/368), merged to `develop` at `a5f5df4` 2026-05-17), each of the five blocks ships as a **separate Zeus-native registry plugin**, NOT as code baked into Zeus core. The blocks are managed .NET assemblies authored by Zeus contributors and distributed through `Kb2uka/openhpsdr-zeus-plugins`. They are **not VST3 plugins** and have no relationship to the Steinberg ecosystem; the operational "MaxxBass" / "Aphex 204" / "Aural Exciter" naming refers to the well-known *processing techniques* we reimplement, not to any third-party plugin product.
+
+Each block implements:
+
+- `IZeusPlugin` (base)
+- `IAudioPlugin` — `Process(ReadOnlySpan<float> input, Span<float> output, AudioBlockContext ctx)`, realtime, no-allocate, no-lock, no-IO
+- `IBackendPlugin` — parameter get/set under `/api/plugins/{id}/...`
+- `IUiPlugin` — operator-facing parameter panel in the chain-panel tile
+
+Slot routing comes from `plugin.json` (`audio.slot = "tx.pre-cfc"` for all five blocks). Block size / sample rate / channel count are negotiated via `AudioPluginRequirements` so the same plugin runs unchanged across Protocol 1 (1024 frames @ 48 kHz) and Protocol 2 (2048 frames @ 96 kHz).
+
+### Source-of-truth integration seam
+
+The integration seam is **shipped** as of #368, no longer speculative:
+
+- `Zeus.Plugins.Contracts/Audio/AudioBlockContext.cs` — `AudioBlockContext` (read-only ref struct: `SampleRate`, `Channels`, `Frames`, `SampleTime`, `Mox`), `AudioPluginRequirements` record, `IAudioHost` interface (exposes `CurrentSampleRate` / `CurrentChannels` / `CurrentBlockSize` / `Slot`).
+- `Zeus.Plugins.Contracts/Extensions/IAudioPlugin.cs` — the realtime-audio extension interface our blocks implement.
+- `Zeus.Plugins.Host/Audio/AudioChain.cs` — generic 8-slot serial chain (stays in core).
+- `Zeus.Server.Hosting/AudioPluginBridge.cs` — hosted service that taps `WdspDspEngine.ProcessTxBlock` via `SetTxAudioPluginHandler`. Bit-identical passthrough when no audio plugins are loaded (single `Span.CopyTo`, no virtual dispatch).
+
+The `Process` call gets a `ReadOnlySpan<float> input` and `Span<float> output` of `Requirements.BlockSize * Requirements.Channels` planar floats. In-place processing (copy input to output, then mutate output) is acceptable. Bypassed slots **should** `input.CopyTo(output)` rather than skip the call — the host handles chain-disabled short-circuit.
+
+### License posture
+
+- **AetherSDR is GPL-3-or-later**; Zeus is **GPL-2-or-later**. Copying AetherSDR `.cpp` would convert Zeus to GPL-3, breaking Zeus's existing GPL-2 license contract with operators. **Clean-room rule:** read AetherSDR headers / comments / paper citations for algorithm structure, never copy implementation.
+- AetherSDR's `Client*.h` files are catalogued in `audio-chain/01-aethersdr-and-external-deps.md` with an explicit "do this instead" mapping per tempting file.
+- **External libraries we DO pull in** must be GPL-2-or-later-compatible (BSD, MIT, public-domain, Apache 2.0). Per-library evaluation is in the sibling doc.
+
+### Per-block source plan (Phase 1 scoping)
+
+| Block | Source | Notes |
+|---|---|---|
+| 8-10 band parametric EQ | **HAND-AUTHOR** (cascaded biquad IIR per Audio EQ Cookbook) | WDSP `eq.c` exists but exposes only on/off toggle, not per-band tuning — cleaner to author against EQ Cookbook formulas than wrap WDSP's opaque API |
+| Compressor | **HAND-AUTHOR** (envelope follower + gain stage) | Same WDSP-cookie story — `compress.c` exists, opaque tuning API. Hand-author keeps the parameter surface honest |
+| Exciter | **HAND-AUTHOR** (highpass + waveshaper + mix) | No WDSP primitive. ~150-250 lines. No dependencies. |
+| Bass enhancer | **HAND-AUTHOR** (port of Bankstown's MIT Rust LV2 to managed C#) | Bankstown ([github.com/chadmed/bankstown](https://github.com/chadmed/bankstown)) is the only license-clean public Family B implementation. ~150 Rust lines port to ~250 C# lines per the gap analysis. Zeus would become the first HPSDR client to ship this technique. |
+| Reverb | **EXTERNAL-DEP candidate** — verblib (MIT/public-domain single-file C89 Freeverb) | Hand-authoring a passable reverb is its own project (~400 lines + tuning). verblib via P/Invoke is 1 file + ~30 lines of bindings. **Open question** (#3 below) — managed-only stance might force hand-author. |
+
+### CPU budget
+
+Per the UX-and-integration analysis, total all-on chain CPU is **~16-22% of one core** on a 12-core M-series Mac running Zeus desktop mode. Today's Zeus baseline is 14-34% single-core during TX; chain adds ~18% peak, landing the total around 40-48% single-core (~3.5% of total system CPU). Reverb is the heaviest at 6-8%; EQ + Compressor are 3-4% each; Exciter and Bass enhancer are 3-4% each.
+
+If field telemetry shows sustained > 80% single-core, defaults can be tuned (reverb off, bass enhancer off) without code changes.
+
+### UX panel
+
+The chain panel sits in **Settings → TX Audio Tools** as a tab next to CFC. Master enable + preset dropdown at the top, then five collapsible block cards, then per-block bypass + whole-chain bypass for A/B comparison. Full UX prose lives in `audio-chain/03-ux-and-integration.md`. All colors via existing `tokens.css` tokens; no raw hex. Fonts unchanged (Inter UI, JetBrains Mono numerics). Meter slots reuse existing `HBarMeter` primitive.
+
+### Sensible-defaults principle
+
+A first-time operator who enables the master toggle and turns on every block should **not sound worse than no chain**. Default state per block:
+
+- EQ: flat (every band gain = 0 dB)
+- Compressor: 3:1 / -18 dBFS threshold / 5 ms attack / 100 ms release / 0 dB makeup
+- Exciter: minimal mix (10%) on a useful default frequency (3-5 kHz)
+- Bass enhancer: minimal amount (10%) on a low default frequency (100-150 Hz)
+- Reverb: 0% mix (effectively off until operator dials it in)
+
+---
+
+## 2. Sign-off questions
+
+Per [feedback_audio_plugin_authority](https://github.com/Kb2uka/openhpsdr-zeus), all algorithm / block-content / default-value questions go to **KB2UKA**. System / contracts / loader questions go to **Brian**.
+
+### KB2UKA decides
+
+1. **Bass-enhancer Family A vs Family B.** Family A = Aphex 204 dynamic-EQ + saturation (more bass). Family B = MaxxBass missing-fundamental harmonic synthesis (fake bass without transmitting lows). On an HF antenna that can't radiate sub-100 Hz, Family B is the technically correct call. **Confirm Family B** before Phase 1 starts.
+2. **EQ band count.** Fixed 10 (simpler defaults, fits the "10-band parametric EQ" naming convention) or operator-tunable 8-10 (more flexible, more UI complexity)?
+3. **Reverb library path.** Hand-authored managed Schroeder reverberator (~300-400 lines, no native dep) vs. verblib P/Invoke (1 file + ~30 lines bindings) vs. C# port of a FOSS reverb (e.g. mverb)? Managed-only is the simplest distribution story for a registry plugin.
+4. **Exciter + bass enhancer combined panel or separate?** The actual Aphex 204 hardware combined them as a single front panel ("Aural Exciter + Big Bottom"). Two separate cards is cleaner block-as-plugin model; one combined card preserves operator familiarity.
+5. **Chain reorderability.** Fixed order EQ → Comp → Exciter → Bass → Reverb (simpler UI) or operator drag-to-reorder?
+6. **Parameter visibility tier.** All parameters always visible (AetherSDR pattern) or Basic / Advanced split (modern voice-plugin convention)?
+7. **Bass-enhancer source path.** Direct C# port of Bankstown's algorithm (MIT, clean-room) vs. FFI to Bankstown as a Rust cdylib vs. independent algorithm derived from the MaxxBass paper directly? Pure C# port keeps the managed-only distribution story; FFI adds a Rust toolchain dependency we don't currently have.
+8. **Initial Phase 1 block.** Recommended: **Compressor first** — simplest algorithm (well-understood envelope-follower + gain stage), shortest path to validating the end-to-end pipeline (build → package as registry plugin → install → load → process → meter → persist params). Once the pipeline is proven on one block, the harder blocks (EQ UX, bass enhancer algorithm, reverb library choice) can be built without architecture risk.
+
+### Brian decides (system / contracts)
+
+These came out of Brian's prompt to KB2UKA dated 2026-05-17 about the broader plugin-system restructuring. Audio-chain work flushes them out as concrete questions:
+
+9. **Multi-slot conflict policy.** `AudioChain` is 8 slots serial. If two installed plugins both declare `audio.slot = "tx.pre-cfc"`, what happens today? (Last-wins? Error? User picks order?) For five blocks all targeting `tx.pre-cfc`, the chain order matters — `AudioChain`'s current implementation may need a chain-position field on the manifest, or an operator-facing reorder UI.
+10. **Native bridge distribution model.** Our v1 blocks are managed-only (assuming KB2UKA rules out verblib P/Invoke and the Bankstown Rust FFI in Q3/Q7 above). If any future plugin needs a native binary, does the binary ship inside the plugin zip per-OS, or via a separate per-OS download path? Worth establishing the policy now even though v1 doesn't trigger it.
+
+### Already locked (not asking again)
+
+- License posture: clean-room reference-only against AetherSDR (GPL-2 ↔ GPL-3 incompatibility).
+- v1 block list: 5 blocks per §1 above, KB2UKA-locked.
+- Insertion point: post-Leveler / pre-CFC (matches existing `AudioPluginBridge` TX seam).
+- Visual design constraint: existing `tokens.css` palette + Inter / JetBrains Mono + existing meter primitives.
+
+---
+
+## 3. What ships in Phase 0 (this PRD)
+
+- This document (`docs/proposals/audio-chain-phase0.md`).
+- The three sibling research files in `docs/proposals/audio-chain/`.
+- **No code.** Phase 0 is docs-only, green-light per `CLAUDE.md` (additions under `docs/proposals/`, no architecture / protocol / UI / defaults change).
+
+When this PR merges, Phase 0 is closed. Phase 1 begins with KB2UKA's answers to the ten sign-off questions above.
+
+---
+
+## 4. Phase 1 entry plan (preview, NOT in scope of this PR)
+
+1. **Repo setup** for the first plugin. Either:
+   - A new repo `Kb2uka/zeus-plugin-compressor` (matches Brian's stated pattern of "one plugin = one repo")
+   - A shared monorepo `Kb2uka/zeus-audio-chain-plugins` containing all five plugins (simpler ops; needs Brian's input)
+2. **Skeleton plugin** implementing `IZeusPlugin + IAudioPlugin` with a no-op `Process` (passthrough). Validates: build → package as zip per the manifest schema → SHA-256 → registry entry → install via Zeus's `POST /api/plugins/install` → AssemblyLoadContext load → tap on `AudioPluginBridge` → `Process` called → uninstall.
+3. **First real algorithm** — recommended: Compressor. Smallest correct implementation ships first.
+4. **Operator-facing UI** for the compressor via `IUiPlugin` + `IBackendPlugin` for parameter persistence.
+5. **Bench verify** on HL2 at 28.4 MHz (the only safe TX frequency per [`CLAUDE.md`](https://github.com/Kb2uka/openhpsdr-zeus/blob/main/CLAUDE.md)).
+6. **Iterate**: EQ → Exciter → Bass enhancer → Reverb on the proven pipeline.
+
+---
+
+## 5. Out of scope (explicit)
+
+- **VST3 third-party plugin support.** The existing VST host in Zeus core (PR #368) is queued for removal once the native chain ships — per #332's Phase 7 plan. **Brian's separate proposal** to extract the VST host as its own external plugin (so operators retain third-party VST3 capability) is NOT being adopted here — KB2UKA's plan is removal, not extraction. This is a divergence worth coordinating with Brian before VST code starts getting deleted, but it's not Phase 0 / Phase 1 work.
+- **RX-side audio plugins.** All five v1 blocks are TX-only. Brian's prompt proposes adding an `SetRxAudioPluginHandler` mirror; that work doesn't block our chain and isn't part of this proposal.
+- **Block presets library.** Per-block presets ("SSB contest", "FT8 macro", "podcast voice") are queued for Phase 1.6 or Phase 2. v1 ships with sensible defaults + operator-editable parameters only.
+- **Multi-band EQ curve display.** A live spectrum-overlay EQ curve panel is a Phase 2 enhancement. v1 EQ is per-band sliders only.
+- **Operator-tunable chain CPU budget.** No "limit each block to X% CPU" knob in v1. Defaults plus operator-disable-blocks is the v1 mitigation.
+
+---
+
+## 6. References
+
+- Audio EQ Cookbook (Bristow-Johnson): <https://webaudio.github.io/Audio-EQ-Cookbook/audio-eq-cookbook.html>
+- Bankstown (MIT, Rust LV2 Family B bass enhancer): <https://github.com/chadmed/bankstown>
+- verblib (MIT/public-domain single-file Schroeder reverb): <https://github.com/blastbay/verblib>
+- AetherSDR (GPL-3 reference-only): <https://github.com/ten9876/AetherSDR>
+- Larsen & Aarts, *Audio Bandwidth Extension* (Wiley 2005) — psychoacoustic-bass theory
+- Aphex 204 owner's manual: <https://cdn.aphex.com/assets/pdf/Aphex_Exciter_OM.pdf>
+- PR #368 unified plugin system: <https://github.com/Kb2uka/openhpsdr-zeus/pull/368>
+- Issue #332 RFC: <https://github.com/Kb2uka/openhpsdr-zeus/issues/332>
+- CLAUDE.md autonomous-agent boundaries: `/CLAUDE.md`
+
+---
+
+**Phase 0 complete on merge of this PR.** Awaiting KB2UKA sign-off on the ten questions above before Phase 1 begins.

--- a/docs/proposals/audio-chain/01-aethersdr-and-external-deps.md
+++ b/docs/proposals/audio-chain/01-aethersdr-and-external-deps.md
@@ -1,0 +1,962 @@
+# Audio Voice Chain — Phase 0: AetherSDR Reference, License Posture, External Dependencies
+
+Status: Research output (no architecture commitments)
+Authors: KB2UKA
+Date: 2026-05-17
+Issue: #332 (in-process voice audio chain — replaces the out-of-process VST host
+proposal in `docs/proposals/vst-host.md` for Zeus's stock voice processing path)
+Companion: `docs/proposals/audio-chain/03-ux-and-integration.md`
+
+This document is **Phase 0 research only**. It catalogs AetherSDR's voice-DSP
+subsystem as a reference design, fixes the license-compatibility posture, and
+surveys external DSP libraries that the locked v1 block list might pull from.
+Per the coordinator update of 2026-05-17 the v1 chain is locked at **EQ →
+Compressor → Exciter → Bass Enhancer → Reverb**; gate, de-esser, tube, and
+limiter are explicitly deferred (WDSP's upstream Leveler stays in place, and
+the downstream ALC / brickwall path already exists). The analysis below is
+scoped to those five blocks. No interface designs, no Phase 1 architecture,
+no code.
+
+Open questions raised by the research surface at the end of the file, prefixed
+`> **Open question for sign-off:**`, for inclusion in the master PRD sign-off
+list.
+
+---
+
+## 1. AetherSDR chain analysis (reference-only)
+
+[AetherSDR](https://github.com/ten9876/AetherSDR) (ten9876, GPL-3.0-or-later)
+is a Qt/C++ HPSDR client whose "Aetherial Audio Channel Strip" is the closest
+public reference to what issue #332 wants Zeus to ship. Its block list, chain
+ordering, and per-block parameter ranges inform Zeus's design even though no
+AetherSDR source will be copied (see §2).
+
+This section catalogs the full AetherSDR chain as a reference, then maps each
+AetherSDR block to KB2UKA's locked v1 list — including the blocks Zeus is
+explicitly **not** shipping in v1 — so the design decisions in §3 and the
+sign-off list at the bottom are anchored against the same reference points.
+
+### 1.1 Full block catalog and chain order
+
+AetherSDR's TX and RX chains are defined as enums in
+[`src/core/AudioEngine.h`](https://github.com/ten9876/AetherSDR/blob/main/src/core/AudioEngine.h)
+(quoted verbatim from the file):
+
+```cpp
+enum class TxChainStage : uint8_t {
+    None   = 0,   // sentinel / end-of-list marker
+    Gate   = 1,
+    Eq     = 2,
+    DeEss  = 3,
+    Comp   = 4,
+    Tube   = 5,
+    Enh    = 6,   // PUDU slot (Aphex / SX3040 exciter family)
+    Reverb = 7,
+};
+
+enum class RxChainStage : uint8_t {
+    None  = 0,
+    Eq    = 1,
+    Gate  = 2,
+    Comp  = 3,
+    Tube  = 4,
+    Pudu  = 5,
+    DeEss = 6,
+};
+```
+
+The header comment on `applyClientTxDspFloat32()` calls out the **canonical
+TX order** as `[Gate, Eq, DeEss, Comp, Tube, Enh]`, then `Reverb`, then
+`FinalLimiter` (the brickwall is a fixed terminator outside the user-orderable
+chain — see [`ClientFinalLimiter.h`](https://github.com/ten9876/AetherSDR/blob/main/src/core/ClientFinalLimiter.h)).
+
+The user-visible block roster, mapped to its implementing file:
+
+| Block | Header file | Role |
+|---|---|---|
+| Gate | `src/core/ClientGate.h` | Downward expander / hard gate (TX path only as shipped) |
+| EQ | `src/core/ClientEq.h` | Up-to-16-band parametric EQ (default 10) |
+| De-Esser | `src/core/ClientDeEss.h` | Single-band sidechain dynamics |
+| Compressor | `src/core/ClientComp.h` | Feed-forward peak compressor w/ brickwall ceiling |
+| Tube | `src/core/ClientTube.h` | Soft-clip waveshaper (3 selectable curves) |
+| Exciter (`Enh` / `Pudu`) | `src/core/ClientPudu.h` | **Aphex Aural Exciter + Aphex 204 Big Bottom** (Mode A), or Behringer SX3040 (Mode B). Two-band: "Doo" (high) + "Poo" (low) |
+| Reverb | `src/core/ClientReverb.h` | Freeverb (8 comb + 4 allpass) |
+| Final Limiter | `src/core/ClientFinalLimiter.h` | Feed-forward peak limiter (TX terminator, not in user enum) |
+
+Notes on the catalog:
+
+- **There is no separate "leveler" or "AGC" block in AetherSDR's user chain.**
+  Leveling is left to the upstream radio DSP (in WDSP's case the LEV/CFC
+  blocks). The exciter / Pudu block is the closest analog to KB2UKA's
+  "exciter + bass enhancer" requirement — and crucially it is **two-band by
+  design**, with the low-band ("Poo") implementing an Aphex 204 Big Bottom
+  model. AetherSDR fuses what Zeus's locked v1 list separates into "exciter"
+  and "bass enhancer" into one combined block. This is the most important
+  design tension in §3.
+- The TX user-orderable chain ends at `Reverb`; the brickwall limiter is a
+  fixed safety stage downstream of the user chain. Operators cannot reorder
+  it, disable it, or change its position.
+- The RX chain omits the Reverb and FinalLimiter stages — there is no point
+  reverberating noise back at the receiver, and brickwall limiting downstream
+  of the soundcard is the operator's headphone amp.
+- Preset persistence is JSON, key-per-block, with a `"chain"` array recording
+  the user's ordering. Quoted from [`ChannelStripPresets.h`](https://github.com/ten9876/AetherSDR/blob/main/src/core/ChannelStripPresets.h):
+
+  ```json
+  {
+    "version": 1,
+    "presets": {
+      "PresetName": {
+        "chain": ["Gate","Eq","DeEss","Comp","Tube","Pudu","Reverb"],
+        "gate": {...}, "eq": {...}, "comp": {...},
+        "deess": {...}, "tube": {...}, "pudu": {...}, "reverb": {...}
+      }
+    }
+  }
+  ```
+
+  The example preset names called out in the header are `"Broadcast Voice"`
+  and `"Contest Punch"`.
+
+### 1.2 Per-block specifications (AetherSDR)
+
+Tables below quote the parameter ranges and defaults visible in each
+`Client*.h` header. These ranges inform Zeus's eventual control surfaces but
+do not constrain them — KB2UKA may pick wider, narrower, or differently named
+ranges in v1.
+
+#### 1.2.1 ClientGate (TX gate / expander) — **NOT in Zeus v1**
+
+| Parameter | Range | Default |
+|---|---|---|
+| Threshold | −80…0 dB | −40 dB |
+| Ratio | 1.0…10.0 | 2.0 |
+| Attack | 0.1…100 ms | 0.5 ms |
+| Release | 5…2000 ms | 100 ms |
+| Hold | 0…500 ms | 20 ms |
+| Floor | −80…0 dB | −15 dB |
+| Return (hysteresis) | 0…20 dB | 2 dB |
+| Lookahead | 0…5 ms | 0 ms |
+| Mode | `Expander` (2:1, −15 dB range) \| `Gate` (10:1, −40 dB range) | — |
+
+Algorithm: Schmitt-trigger hysteresis (gate reopens when signal drops to
+`threshold - return`), separate hold phase before release, lookahead via
+delay line. Source: `src/core/ClientGate.h`.
+
+#### 1.2.2 ClientEq (parametric EQ) — **MAPS to Zeus v1 EQ**
+
+Per [`src/core/ClientEq.h`](https://github.com/ten9876/AetherSDR/blob/main/src/core/ClientEq.h):
+
+| Aspect | Value |
+|---|---|
+| Maximum bands | 16 |
+| Default band count | 10 |
+| Default layout | HP / LowShelf / 6× Peak / HighShelf / LP, logarithmically spaced 40 Hz – 12 kHz |
+| HP/LP cascade depth | Up to 4 biquad sections (12/24/36/48 dB/octave) |
+| Per-band parameters | `freqHz` (default 1000), `gainDb` (default 0), `q` (default 0.707), `slopeDbPerOct` (12/24/36/48 for HP/LP), `enabled` |
+| Filter families (HP/LP) | Butterworth / Chebyshev / Bessel / Elliptic |
+| Filter types (per band) | Peak, LowShelf, HighShelf, LowPass, HighPass |
+| Smoothing | One-pole per-block, ~15 ms time constant (prevents zipper noise on knob drag) |
+| Threading | UI atomics + per-band version counters; audio thread recomputes coefficients on version bump only |
+
+The 10-band default layout is the key reference point for KB2UKA's "8–10 band
+parametric EQ" requirement. AetherSDR's choice — HP at the bottom, LP at the
+top, and shelves anchoring the band cluster — is a sound voice-processing
+default because it lets the operator low-cut rumble and high-cut hiss without
+spending peaking bands on the extremes.
+
+#### 1.2.3 ClientComp (TX compressor) — **MAPS to Zeus v1 Compressor**
+
+Per [`src/core/ClientComp.h`](https://github.com/ten9876/AetherSDR/blob/main/src/core/ClientComp.h):
+
+| Parameter | Range | Default |
+|---|---|---|
+| Threshold | dBFS (negative) | −18.0 dB |
+| Ratio | 1.0…20.0 | 3.0 |
+| Attack | (no explicit cap) | 20.0 ms |
+| Release | (no explicit cap) | 200.0 ms |
+| Knee | dB | 6.0 dB |
+| Makeup | dB | 0.0 dB |
+
+Algorithm notes (quoted from header comments):
+
+- **Feed-forward topology** — the envelope is driven by `max(|L|, |R|)` for
+  stereo-linked detection.
+- **Peak detection in linear domain.** The header explicitly justifies this:
+  *"log-domain smoothing of a sine would settle ~4 dB below the peak"* — i.e.
+  log-domain envelope tracking is biased low for sine-like signals, so
+  AetherSDR follows the linear-domain envelope and converts to dB only for
+  the static curve calculation.
+- **Stereo linking** — both channels receive the same gain multiplier to
+  preserve phase coherence.
+- **Brickwall peak limiter** ships in the same class with an independent
+  ceiling parameter (`-12…0 dBFS`), but Zeus's downstream WDSP ALC plus
+  CESSB and the existing brickwall make this redundant for our purposes.
+
+This is the right baseline for Zeus's v1 compressor. Single-stage VCA-style,
+feed-forward, linear-domain peak detection.
+
+#### 1.2.4 ClientDeEss — **NOT in Zeus v1**
+
+Single-band sidechain dynamics. Per `src/core/ClientDeEss.h`:
+
+| Parameter | Range |
+|---|---|
+| Frequency (bandpass center) | 1000…12000 Hz |
+| Q | 0.5…5.0 |
+| Threshold | −60…0 dB |
+| Amount (max attenuation) | −24…0 dB |
+| Attack | 0.1…30 ms |
+| Release | 10…500 ms |
+
+Mode: input split through 2–10 kHz bandpass → envelope detector → broadband
+attenuation capped at `Amount`. AetherSDR notes the design parallels Ableton
+DeEsser and FabFilter Pro-DS.
+
+#### 1.2.5 ClientTube (soft-clip waveshaper) — **NOT in Zeus v1** (exciter likely covers it)
+
+Per `src/core/ClientTube.h`:
+
+| Parameter | Range |
+|---|---|
+| Drive | 0–24 dB |
+| Bias Amount | 0…1 (asymmetry — 0 = symmetric) |
+| Output Gain | −24…+24 dB |
+| Dry/Wet Mix | 0…1 |
+| Tone Filter | −1…+1 (pre-saturation tilt) |
+| Model | `A` (soft tanh) \| `B` (hard-clip + tanh hybrid, odd harmonics) \| `C` (asymmetric, even harmonics) |
+| Envelope-modulated drive | −1…+1 bipolar |
+
+Three selectable waveshaping curves (tanh / hybrid / asymmetric), per-sample,
+no oversampling. The Aetherial Audio Channel Strip's tube block is
+intentionally minimal — there is no per-stage filter network or transformer
+model, just a `shape()` function with envelope-driven drive modulation.
+
+#### 1.2.6 ClientPudu (Aphex-style exciter) — **MAPS to Zeus v1 Exciter + Bass Enhancer (combined)**
+
+This is the most informative AetherSDR file for KB2UKA's locked v1 list,
+because the **Pudu block is the only public open-source reference for both an
+Aural-Exciter-style top-end enhancer and an Aphex 204 Big Bottom-style bass
+psychoacoustic enhancer in a single file**. Per `src/core/ClientPudu.h`:
+
+| Mode | Reference design |
+|---|---|
+| `Aphex` (0) | "Aural Exciter + Big Bottom" — original Aphex two-box model |
+| `Behringer` (1) | "SX 3040 Sonic Exciter" — Behringer clone family |
+
+Bands:
+
+- **"Doo" (high band — Aural Exciter):** HPF → variable-gain amplifier →
+  asymmetric soft-clip → DC block. Parameters: `dooTuneHz` 1–10 kHz,
+  `dooHarmonicsDb` 0–24 dB, `dooMix` 0–1.
+- **"Poo" (low band — Big Bottom):** LPF → envelope-follower **dynamic EQ**
+  → saturation. Parameters: `pooDriveDb` 0–24 dB, `pooTuneHz` 50–160 Hz,
+  `pooMix` 0–1.
+
+For the Behringer mode the header notes a different topology: symmetric
+soft-saturation HPF on the high band; frequency-selective compressor with
+all-pass phase rotator on the low band.
+
+**Critical observation:** AetherSDR's "Big Bottom" implementation is **a
+dynamic-EQ + saturation hybrid in the 50–160 Hz band, parallel-mixed back to
+dry**. It is *not* a psychoacoustic missing-fundamental synthesizer (the
+MaxxBass / Larsen–Aarts approach). It is a sustain-and-density tool that
+matches Aphex's own marketing description of the 204 ("dynamically contours
+the bass response of a complex range of shapes in the 20 Hz to 120 Hz range"
+— see Aphex 204 review, [Home Theater HiFi
+2004](https://hometheaterhifi.com/volume_11_3/aphex-204-big-bottom-7-2004.html)),
+and the patent claim that Big Bottom *"increases the perception of low
+frequencies without significantly increasing the maximum peak output"* by
+**stretching the existing low-frequency content in time and dynamics**, not
+by synthesizing harmonics of frequencies the radio cannot transmit.
+
+KB2UKA's coordinator-update brief, however, explicitly asks for a
+**MaxxBass-style** algorithm — *"synthesizes upper-harmonics of low-frequency
+content so the human ear perceives bass without the radio needing to transmit
+the actual low frequencies (which the antenna can't radiate efficiently
+anyway)."* That is the Waves MaxxBass / Larsen–Aarts virtual-bass approach,
+which is a *different* algorithm family from the Aphex 204. This is the
+single biggest decision the master PRD must resolve — see §3.4 and the open
+question at the bottom of this file.
+
+#### 1.2.7 ClientReverb (Freeverb) — **MAPS to Zeus v1 Reverb**
+
+Per `src/core/ClientReverb.h`:
+
+| Parameter | Range | Default |
+|---|---|---|
+| Size | 0…1 | 0.5 |
+| DecayS | 0.3…5 s | 1.2 s |
+| Damping | 0…1 | 0.5 |
+| PreDelayMs | 0…100 ms | 20.0 ms |
+| Mix | 0…1 | 0.15 |
+| Enabled | bool | `false` |
+| Width | fixed at 23 samples L↔R | (not exposed) |
+
+Algorithm: classic Freeverb — 8 parallel lowpass-feedback comb filters summed
+through 4 series allpass filters. The header explicitly calls this "a
+voice-oriented design with no studio parameters" — wet/dry, size, and damping
+only. Width is hardcoded.
+
+The 0.15 mix default is voice-appropriate (subtle), not music-mastering-loud.
+That's the right reference number for Zeus's default; the audible effect at
+0.15 mix is a near-imperceptible room sense, not a perceptible reverb tail.
+
+#### 1.2.8 ClientFinalLimiter (TX brickwall) — **NOT in Zeus v1** (downstream WDSP ALC + brickwall already covers it)
+
+Per `src/core/ClientFinalLimiter.h`:
+
+- Feed-forward peak limiter, per-block smoothed envelope, "fast attack,
+  moderately fast release."
+- **No lookahead, no oversampling, no inter-sample-peak handling.** The
+  header explicitly states this is a per-block safety fence, not a mastering
+  limiter.
+- Parameters: Ceiling (−12…0 dBFS), Output Trim (−12…+12 dB), DC-block HPF
+  (~25 Hz, optional). RMS metering with 300 ms smoothing for level display.
+- Stereo-linked gain to preserve imaging.
+
+This is the right minimum-viable brickwall reference, but Zeus has WDSP's
+ALC + the existing TX-stage limiting path, so an explicit limiter block in
+the new chain is redundant.
+
+### 1.3 Mapping AetherSDR blocks to Zeus v1
+
+| Zeus v1 block | AetherSDR analog | Notes |
+|---|---|---|
+| 8–10 band parametric EQ | `ClientEq` (10-band default of HP/LS/6×Peak/HS/LP, log spaced 40 Hz–12 kHz) | Layout is a good v1 default. **Band count tunability is an open question for sign-off.** |
+| Single-stage VCA compressor | `ClientComp` | Feed-forward, linear-domain peak detection. Good baseline. |
+| Exciter (top-end / "presence" / "air") | `ClientPudu` Doo band (Mode A: HPF→VGA→asymmetric soft-clip→DC block) | Aural Exciter reference is well-established. |
+| Bass enhancer (psychoacoustic) | `ClientPudu` Poo band — but algorithm mismatch | AetherSDR's "Poo" is Aphex 204 (dynamic EQ + saturation) not MaxxBass (harmonic synthesis). **§3.4 and open question.** |
+| Reverb | `ClientReverb` | Freeverb, voice-tuned defaults. |
+| Gate | `ClientGate` | Deferred from v1. |
+| De-esser | `ClientDeEss` | Deferred from v1. |
+| Tube saturator | `ClientTube` | Deferred from v1 (exciter is the primary harmonic-content block). |
+| Final limiter | `ClientFinalLimiter` | Deferred — WDSP ALC + brickwall covers it downstream. |
+
+### 1.4 UI patterns worth noting
+
+These are observed in the AetherSDR file inventory (`src/gui` directory
+listing) and are reference data points for Zeus's eventual chain UI; no
+visual decisions are made here.
+
+- **Per-block "applet" pattern.** AetherSDR ships an "applet" per block
+  (`ClientRxDspApplet`, `ClientChainApplet`, etc.) — small dockable panels
+  with the block's own controls and metering. Inspired by Reaper's track FX
+  paradigm. Zeus should not necessarily clone this; existing Zeus panel
+  vocabulary (DspPanel, TxFilterPanel) already provides a similar "block of
+  related controls" idiom.
+- **Wall-clock-accurate scope per channel.** AetherSDR's channel strip
+  exposes a scope view per side (RX, TX). This is mentioned in the README
+  feature list. Zeus already has equivalent meter and waveform infrastructure
+  in the TX-stage meter pipeline.
+- **Preset library is global, not per-block.** AetherSDR snapshots the full
+  chain — block order + every block's state — into one preset. Per-block
+  preset libraries are not in evidence.
+- **Two-tier parameter visibility is NOT visible in the headers.** AetherSDR
+  exposes every parameter for every block. There is no "Basic / Advanced"
+  split. This is a design choice Zeus could keep or change — flagged as open
+  question.
+
+---
+
+## 2. License posture
+
+### 2.1 Project license summary
+
+| Project | License | Source |
+|---|---|---|
+| Zeus | GPL-2.0-or-later | [`/LICENSE`](../../../LICENSE) — header reads *"either version 2 of the License, or (at your option) any later version"* |
+| AetherSDR | GPL-3.0-or-later | [AetherSDR `LICENSE`](https://github.com/ten9876/AetherSDR/blob/main/LICENSE) — *"GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007"* with §14 "any later version" clause |
+
+### 2.2 The compatibility hazard, plainly stated
+
+Zeus is GPL-2.0-**or**-later. AetherSDR is GPL-3.0-**or**-later. The "or
+later" suffix on Zeus is what saves us: Zeus can be relicensed to GPL-3.0 by
+any downstream consumer, so a GPL-3.0 codebase *can* legally consume Zeus
+source. **The reverse is not true.** Code copied verbatim from AetherSDR
+(GPL-3.0) into Zeus (GPL-2.0-or-later) would force Zeus to drop the "or
+GPL-2" option for the resulting binary, because anyone exercising the GPL-2
+option would be in violation of GPL-3's additional terms (anti-tivoization,
+patent retaliation language, etc.). The cleanest answer is: **don't copy
+AetherSDR source.**
+
+This is consistent with how the existing VST host ADR
+(`docs/proposals/vst-host.md` §6) handled JUCE: JUCE was rejected on license
+grounds because its dual license is incompatible with GPL-2.0-or-later;
+AetherSDR has the same hazard for the same reason. The fact that AetherSDR is
+already GPL doesn't help — it's the *version* mismatch that bites.
+
+### 2.3 The reference-only rule, what it means in practice
+
+The rule for Zeus's v1 audio chain is: **read AetherSDR for ideas, copy
+nothing.** Specifically:
+
+1. **Algorithm ideas, parameter ranges, chain orderings, and default values
+   are facts about how voice processing works.** These are not copyrightable.
+   We can adopt AetherSDR's 10-band EQ default layout, its 0.15 reverb mix
+   default, its `Doo`/`Poo` exciter band naming convention, and its 3.0:1
+   compressor default ratio without copying a single line of code.
+2. **Source code, comments, structure, and naming of internal types are
+   copyrightable.** Even one verbatim `process()` loop, copy-pasted, taints
+   the GPL-2 option. Do not paste.
+3. **Every DSP line Zeus ships must be authored from one of:**
+   - **Hand-written by a Zeus contributor** (clean-room, against the C++/Rust
+     algorithm description in the AetherSDR header *comments*, not the
+     implementation in the corresponding `.cpp`)
+   - **Derived from WDSP primitives** (WDSP is GPL-2-compatible — `Zeus.Dsp`
+     already P/Invokes it; see `native/wdsp/eq.c`, `native/wdsp/compress.c`,
+     `native/wdsp/cfcomp.c`)
+   - **Pulled in from a separately-license-cleared third-party library** —
+     each candidate library passes the §3 evaluation gate below
+
+4. **The clean-room boundary is the `.h` file.** Reading AetherSDR's `.h`
+   files to learn parameter names and ranges is fine — those are interface
+   facts about the algorithm. Reading the corresponding `.cpp` files is
+   contamination risk. Zeus contributors implementing the v1 chain should
+   **read the algorithm description in the header comments** (which describe
+   *what* the block does) but **not the `.cpp` implementation** (which is
+   *how* AetherSDR does it). The implementation is where copyright bites.
+
+### 2.4 Tempting-to-copy files — explicit "do not copy" mapping
+
+These are AetherSDR source files a Zeus contributor might be tempted to lift,
+each paired with the legitimate alternative.
+
+| AetherSDR file | Temptation | Do this instead |
+|---|---|---|
+| `src/core/ClientEq.cpp` | 10-band parametric EQ with BiQuad cookbook coefficients | Hand-author against [Audio EQ Cookbook (Bristow-Johnson)](https://webaudio.github.io/Audio-EQ-Cookbook/audio-eq-cookbook.html) — public-domain reference; or thin C# wrapper over WDSP `eq.c` |
+| `src/core/ClientComp.cpp` | Feed-forward peak compressor, linear-domain envelope | Hand-author from textbook — Reiss/McPherson *Audio Effects* Ch. 6; or thin C# wrapper over WDSP `compress.c` |
+| `src/core/ClientReverb.cpp` | Freeverb implementation | Use [verblib](https://github.com/blastbay/verblib) (single-file C89, MIT-or-public-domain) or [sinshu/freeverb](https://github.com/sinshu/freeverb) (Jezar's original, public domain) |
+| `src/core/ClientPudu.cpp` | Aphex Aural Exciter + Big Bottom in one file | High band: hand-author from [Airwindows Exciter](https://github.com/airwindows/airwindows) reference (MIT). Low band: see §3.4 — algorithm choice is open question |
+| `src/core/AudioEngine.cpp` | The TX/RX chain dispatcher loop | Hand-author Zeus's own block-chain dispatcher; the dispatcher is not novel and is straightforward to write |
+| `src/core/ChannelStripPresets.cpp` | JSON preset serialization | Hand-author using Zeus's existing System.Text.Json patterns from `Zeus.Server/RadioStateStore.cs` |
+
+### 2.5 Plugin / weight licensing — not applicable to v1
+
+The vst-host ADR (`docs/proposals/vst-host.md` §6) addresses the
+operator-loads-a-VST-plugin-at-runtime case, citing FSF's host/plugin
+position. That analysis does *not* apply here, because the v1 audio chain
+ships its DSP **statically inside `Zeus.Server`**, not as runtime-loaded
+plugins. Every byte of DSP code in the v1 chain is linked into the Zeus
+binary at build time, so every byte must clear the GPL-2-or-later test
+above. No neural-NR model weights (RNNoise, DeepFilterNet, etc.) are in v1
+scope — model-weight licensing is deferred until a future NR block is
+proposed.
+
+---
+
+## 3. External dependency evaluation
+
+Per the coordinator update, RNNoise drops out (no NR in v1). The libraries
+evaluated below are scoped to the five v1 blocks. The §3.4 bass-enhancer
+section receives the most depth because it is the least-obvious algorithm to
+implement and has the smallest body of FOSS prior art.
+
+### 3.1 Quick license-compatibility primer for this section
+
+| Third-party license | Compatible with Zeus GPL-2-or-later when… |
+|---|---|
+| Public domain / Unlicense / CC0 | Always |
+| MIT, BSD-2/3-Clause, ISC, Apache-2.0 | Always |
+| LGPL-2.1, LGPL-3.0 | **Conditionally** — fine if Zeus dynamically links to the LGPL lib (operator can swap it). Static-linking an LGPL-3 lib into a GPL-2-or-later binary forces the binary's effective license to GPL-3 (loses the GPL-2 option). For Zeus's deployment model (single-process .NET 8 server), "dynamic linking" means **a separate shared library distributed alongside Zeus**, not a NuGet/static-linked package. |
+| GPL-2.0-only | Forces Zeus to drop "or-later" for distributed binaries — usually fine for end users but irritates downstream repackagers |
+| GPL-3.0-only or GPL-3.0-or-later | Forces Zeus binary to GPL-3. Loses GPL-2 option but legal. |
+| AGPL / commercial-source-available / "research only" / CC-BY-NC | **NO** — incompatible with Zeus's distribution model |
+
+The decision matrix below uses these categories.
+
+### 3.2 Block 1 — Parametric EQ (8–10 band)
+
+**Recommendation: hand-author against WDSP primitives or the Audio EQ
+Cookbook.** No external library is needed. EQ is the most-documented DSP
+block in the world; the BiQuad coefficient formulas are in every audio-DSP
+textbook and on every audio-engineering wiki. WDSP already ships `eq.c`
+(graphic-style fixed-band EQ) and the cookbook is the canonical reference
+for parametric biquads.
+
+Reference libraries surveyed:
+
+| Library | URL | License | Notes |
+|---|---|---|---|
+| WDSP `eq.c` | bundled in `native/wdsp/eq.c` | GPL-2-or-later (per WDSP) | Already in Zeus tree. Graphic, not parametric — would need extension or a sibling C source file. |
+| NWaves (BiquadFilter, PeakFilter, ShelfFilter) | [github.com/ar1st0crat/NWaves](https://github.com/ar1st0crat/NWaves) | MIT | Pure C# / .NET. 100% managed. Includes BiQuad, Butterworth, Chebyshev, Bessel, Elliptic — all the filter families AetherSDR's EQ exposes. **Strongest external candidate** if "managed-only" is the design preference. |
+| NAudio (BiQuadFilter) | [github.com/naudio/NAudio](https://github.com/naudio/NAudio) | MIT | Pure C#. Has BiQuad with low-pass / high-pass / peaking / shelving. No compressor, limiter, or specialized voice tools. Already a candidate for Zeus's audio I/O but not strictly necessary for EQ alone. |
+
+> **Open question for sign-off:** Pure-managed (NWaves) or hand-authored
+> against WDSP? NWaves gives us the full filter-family palette (Butterworth /
+> Chebyshev / Bessel / Elliptic — matching AetherSDR's EQ — and is MIT,
+> so the static-linking question is moot. Hand-authored gives us zero new
+> dependencies and full control of cache layout / SIMD. Recommend NWaves for
+> v1 (faster to ship, well-tested) but the choice is the maintainer's.
+
+> **Open question for sign-off:** Operator-tunable band count (1–16, default
+> 10) per AetherSDR, or fixed-10 to simplify the UI? Fixed-10 is the simpler
+> UI; the cost is one operator who wants a single extra band finds the EQ
+> insufficient. AetherSDR's 16-band cap with a 10-band default seems like a
+> good compromise — the UI can ship "show 10 bands by default" with a
+> "show all bands" toggle. Maintainer call.
+
+### 3.3 Block 2 — Compressor (single-stage VCA)
+
+**Recommendation: hand-author against the AetherSDR header comment
+description, OR thin C# wrapper over WDSP `compress.c` / `cfcomp.c`.** No
+external library is needed.
+
+Reference libraries surveyed:
+
+| Library | URL | License | Notes |
+|---|---|---|---|
+| WDSP `compress.c` | bundled in `native/wdsp/compress.c` | GPL-2-or-later | Already in Zeus tree. Hard-knee peak compressor — fine baseline. |
+| WDSP `cfcomp.c` | bundled in `native/wdsp/cfcomp.c` | GPL-2-or-later | Continuous Frequency Compressor (multi-band, FFT-based). Out of scope for v1 (KB2UKA's brief: single-stage). |
+| NWaves (`Compressor`, `Limiter`, `Expander`, `NoiseGate`) | [github.com/ar1st0crat/NWaves](https://github.com/ar1st0crat/NWaves) | MIT | Pure C#. Reasonable defaults; documented as "dynamics" group. Worth using if NWaves is adopted for EQ anyway. |
+| FAUST `co.compressor_mono` | [github.com/grame-cncm/faustlibraries](https://github.com/grame-cncm/faustlibraries) | STK-4.3 / MIT | FAUST language; transpiles to C++. Useful as algorithm reference, not as a runtime dependency. |
+
+> **Open question for sign-off:** Wrap WDSP `compress.c` (one fewer
+> dependency, consistent with the rest of Zeus's DSP path which is already
+> P/Invoke) or use NWaves' Compressor (managed, faster iteration)?
+> Recommend WDSP wrap — keeps Zeus's "DSP lives in WDSP, C# is the
+> orchestrator" architectural invariant intact.
+
+### 3.4 Block 3 + Block 4 — Exciter and Bass Enhancer
+
+This is the most-researched section of this document because (a) it
+encompasses two of the five v1 blocks, (b) the algorithm choice for the bass
+enhancer is the *only* algorithm in the v1 chain that doesn't have an
+obvious "lift from WDSP" answer, and (c) the coordinator update of 2026-05-17
+specifically called out psychoacoustic bass synthesis (MaxxBass / Aphex 204)
+as the most valuable contribution of this Phase 0 doc.
+
+#### 3.4.1 Two algorithm families — pick one
+
+There are **two distinct algorithm families** described in the prior art,
+and KB2UKA's brief asks for the second one but the only public FOSS
+reference (AetherSDR's `ClientPudu`) implements the first one. The master
+PRD must explicitly decide which family Zeus v1 targets.
+
+**Family A — Aphex 204 "Big Bottom" model.** Time-domain dynamic processing
+on the existing low-frequency content: low-pass-filtered sidechain →
+envelope follower → dynamic gain / saturation → mixed back to dry. The
+psychoacoustic effect comes from **stretching the existing bass content in
+time** so the ear perceives it as louder without raising peak amplitude.
+
+- Patent (now expired, ~1989–2008 window): Aphex 204 dynamics + phase
+  filtering on the 20–120 Hz band.
+- Marketing description: *"dynamically contours the bass response... in the
+  20 Hz to 120 Hz range"* — [Home Theater HiFi 2004
+  review](https://hometheaterhifi.com/volume_11_3/aphex-204-big-bottom-7-2004.html).
+- Patent-level description: *"together the dynamics processor and time
+  delay create sustained bass frequencies that are perceived as being louder
+  yet do not noticeably increase peak output"* — quoted in same review.
+- Public FOSS implementation: **AetherSDR `ClientPudu.cpp` (GPL-3, no copy)**.
+  Algorithm description visible in the header comment block (see §1.2.6
+  above). Hand-author-replicable from the header description.
+- Requires: a 20-bit signal to operate on, i.e. the radio is actually
+  transmitting energy at 80–120 Hz. **For SSB-on-an-HF-radio, that is
+  exactly the case** — typical SSB bandwidth is 100–2700 Hz or wider, so
+  there *is* low-frequency content to "stretch."
+
+**Family B — MaxxBass / Larsen–Aarts "Virtual Bass" model.** Synthesize
+*upper-harmonics* of low-frequency content. The fundamental at 50–80 Hz is
+filtered out; harmonics at 100–500 Hz are synthesized via nonlinear
+distortion and mixed back. The ear perceives the missing fundamental via
+the [missing-fundamental
+phenomenon](https://en.wikipedia.org/wiki/Missing_fundamental). The radio
+never needs to transmit the actual low frequency.
+
+- Patent (Meir Shashoua / Waves, mid-1999, **expired 2006–2008**):
+  MaxxBass — "divides the audio signal, generates weighted harmonics for
+  frequencies below the loudspeaker cutoff, and combines the signals to
+  stimulate auditory sensation up to 1.5 octaves below the cutoff with no
+  increase in size or power requirements."
+- Foundational academic reference: Larsen & Aarts, *Audio Bandwidth
+  Extension: Application of Psychoacoustics, Signal Processing and
+  Loudspeaker Design*, Wiley 2005 — the textbook on nonlinear-device-based
+  virtual bass.
+- Survey paper: [Synthesis and Implementation of Virtual Bass System with
+  a Phase-Vocoder
+  Approach](https://www.researchgate.net/publication/228362764) (Bai &
+  Lin, 2006) — phase-vocoder alternative to nonlinear-device approach.
+- Most relevant for KB2UKA's brief: this is the algorithm that lets the
+  operator's audio **sound bassy on an HF antenna that physically cannot
+  radiate 60–80 Hz** because the HF amateur bands' antennas are
+  high-pass-filtered far above the speech fundamental anyway. This is the
+  Phase 0 brief's stated goal.
+- Public FOSS implementations: **two candidates**, both surveyed below.
+
+**The two families are not the same algorithm**, and the audible
+differences matter. Family A (Aphex 204) only works if the radio is actually
+transmitting low-frequency content; for an SSB voice mode with the HPF set
+at 100 Hz, Family A still has plenty to work with. Family B (MaxxBass) is
+the algorithm of choice when the **radio's transmit filter has already
+removed the low-frequency content** before the bass enhancer runs — at
+which point Family A has nothing to "stretch" and Family B is the only
+option that produces an audible "bassy" voice.
+
+> **Open question for sign-off:** Which family does Zeus v1 ship? KB2UKA's
+> 2026-05-17 brief explicitly cites MaxxBass / missing-fundamental
+> synthesis ("which the antenna can't radiate efficiently anyway"), so the
+> stated preference is **Family B**. But Family B requires more DSP work
+> (a real implementation of harmonic synthesis with proper
+> psychoacoustic-loudness compensation) and is fundamentally a noisier
+> algorithm than Family A. Recommend Family B for v1 to match the brief,
+> with the explicit understanding that it is a 3–6 week implementation
+> (vs. Family A's ~1 week). Final call is the maintainer's.
+
+#### 3.4.2 Public FOSS prior art — Family B (MaxxBass-style) candidates
+
+Two FOSS plugins implement the Family B (missing-fundamental synthesis)
+approach.
+
+##### Bankstown (Rust LV2)
+
+[github.com/chadmed/bankstown](https://github.com/chadmed/bankstown) —
+**MIT license**, Rust, LV2 plugin format.
+
+Algorithm: three-stage psychoacoustic bass approximation. From
+inspection of `src/lib.rs`:
+
+1. **Band-pass split:** high-pass filter at `floor` (default 20 Hz) →
+   low-pass at `ceil` (default 200 Hz). Selects the bass content to
+   process.
+2. **Nonlinear harmonic generation:** modified-Error-function saturation.
+   The implementation comment says *"Saturation is performed with a
+   modified Error function, which allows us to avoid hard clipping as
+   x→inf."* Second-harmonic (asymmetric, negatives only) and
+   third-harmonic (symmetric) are generated separately and crossfaded via
+   a `blend` coefficient.
+3. **Final reconstruction:** a `clamp_pass` filter at `ceil × 3` shapes
+   the synthesized harmonics, then a final high-pass at `final_hp`
+   (default 200 Hz) removes the original low-frequency band before
+   summing back with dry.
+
+LV2 ports (from
+[`bankstown.ttl`](https://github.com/chadmed/bankstown/blob/main/bankstown.ttl)):
+
+| Symbol | Name | Default | Min | Max | Unit |
+|---|---|---|---|---|---|
+| `bypass` | Bypass | 0 | 0 | 1 | toggle |
+| `amt` | Amount | 1.0 | 0.0 | 15.0 | — |
+| `floor` | Floor Frequency | 20 | 10 | 250 | Hz |
+| `ceil` | Ceiling Frequency | 200 | 10 | 250 | Hz |
+| `final_hp` | Output HPF | 200 | 10 | 250 | Hz |
+| `sat_second` | Second Harmonic | 1.0 | 0.0 | 15.0 | — |
+| `sat_third` | Third Harmonic | 1.0 | 0.0 | 15.0 | — |
+| `blend` | Harmonic Ratio | 0.5 | 0.0 | 1.0 | — |
+
+**Why Bankstown matters for Zeus.** The MIT license makes it the only
+"copyable-with-attribution" FOSS reference for Family B that we have.
+The algorithm is small (~150 lines of Rust per inspection) and well-
+parameterized. Zeus could ship one of:
+
+- A pure C# port of Bankstown's algorithm (license-clean under MIT
+  attribution; preserves Zeus's managed-DSP preference)
+- A direct FFI to a Rust `cdylib` build of Bankstown (preserves the
+  original algorithm and the upstream maintenance burden)
+- A C reimplementation of the same algorithm, dropped into
+  `native/wdsp/` as a sibling source file
+
+The algorithm is **demonstrably simple enough to hand-author from the
+header comment + the LV2 port spec** — three stages, two saturation
+functions, one mixer. The C# port path is the recommended one.
+
+##### DeaDBeeF virtual-bass plugin (C)
+
+[github.com/alpo/DeaDBeeF-virtual-bass-plugin](https://github.com/alpo/DeaDBeeF-virtual-bass-plugin)
+— **MIT license**, C.
+
+A research project; algorithm cites the academic literature directly:
+
+- Oo, Gan & Lim (2010) — Arc-Tangent Square Root nonlinear processing
+- Gan, Kuo & Toh (2001) — virtual bass for consumer electronics
+- Bai & Lin (2006) — phase-vocoder methodology
+- Arora, Moon & Jang (2006) — low-complexity algorithms
+- Shi, Mu & Gan (2013) — psychoacoustical preprocessing
+
+README quote: *"this algorithm adds some distortion to the low-frequency
+part of the spectrum in order to simulate missing low frequencies... if
+the distortion level is low then the bass enhancing effect is too subtle
+and if the distortion level too high then this is perceived as a
+distorted signal."*
+
+The DeaDBeeF plugin is closer to a research prototype than a polished
+production block (the author calls it "a research project"). It's most
+useful as a reading reference for the underlying papers, not as a
+direct source for Zeus to port.
+
+##### Comparison
+
+| Aspect | Bankstown | DeaDBeeF VB |
+|---|---|---|
+| License | MIT | MIT |
+| Language | Rust | C |
+| Maturity | Polished, in active use (Asahi Linux audio chain) | Research prototype |
+| Lines of code | ~150 (algorithm core) | Larger, multi-algorithm |
+| Algorithm | Three-stage nonlinear saturation + reconstruction | Multi-algorithm comparison harness from cited papers |
+| Documentation | Inline + LV2 ttl ports | README + paper citations |
+| Recommendation | **Use as v1 reference** | Use as academic reading; not for direct port |
+
+#### 3.4.3 Public FOSS prior art — Family A (Aphex 204-style) candidates
+
+For completeness, in case the maintainer chooses Family A for v1:
+
+| Library | URL | License | Notes |
+|---|---|---|---|
+| AetherSDR `ClientPudu.cpp` | (GPL-3) | NO copy | Read header comment for algorithm description, hand-author |
+| Calf Bass Enhancer | [github.com/calf-studio-gear/calf](https://github.com/calf-studio-gear/calf) | LGPL-2.1 | **The most-tempting public reference for Family A.** Calf's documentation describes the algorithm as "the distortion routine from TAP Tubewarmth... restricted in range and added to the original signal." Source files: implementation appears bandlimited-saturator-style; Calf's bass-enhancer plug is built atop their Saturator module. LGPL-2.1 means dynamic linking is required if used as-is. Recommend reading-only for algorithm guidance; the algorithm itself is small and well-described in the [Calf Bass Enhancer manual](https://calf-studio-gear.org/doc/Bass%20Enhancer.html). |
+
+#### 3.4.4 Exciter (top-end / "presence") — separate-block candidates
+
+The "exciter" block in Zeus v1 is the top-end Aural-Exciter-style harmonic
+enhancement — separate from the bass enhancer. Candidates:
+
+| Library | URL | License | Notes |
+|---|---|---|---|
+| Airwindows Exciter | [github.com/airwindows/airwindows](https://github.com/airwindows/airwindows) | MIT | Chris Johnson's plugin suite. "Aural Exciter that can be both subtle and extreme." MIT licensed, C++, no JUCE. The Exciter plugin is small enough to read and port. Also their **Pafnuty** is a Chebyshev-filter aliasing-free harmonic enhancer that's worth a look as a separate candidate. |
+| Calf Exciter | [github.com/calf-studio-gear/calf](https://github.com/calf-studio-gear/calf) | LGPL-2.1 | Same TAP-Tubewarmth saturation-routine basis as their Bass Enhancer, but bandpass-filtered to the high band. Read-only for algorithm. |
+| AetherSDR `ClientPudu.cpp` Doo band | (GPL-3) | NO copy | Read the Doo-band algorithm comment in `ClientPudu.h`: *"HPF → VGA → asymmetric soft-clip → DC block"* — that single sentence is the entire algorithm. Hand-authorable. |
+
+> **Open question for sign-off:** The two-band combined-Pudu approach
+> (AetherSDR's pattern) vs. two separate single-band blocks (Zeus v1's
+> stated approach). KB2UKA's brief lists Exciter and Bass Enhancer as
+> *two separate v1 blocks* — this is a small departure from AetherSDR's
+> design and means the chain UI has one extra slot. Recommend Zeus's
+> approach (two separate blocks) — it gives the operator independent
+> enable/bypass for each, which is what an HF radio operator wants
+> (most ops will want bass enhancer ON for SSB and exciter OFF for
+> contesting, or vice versa). Maintainer call.
+
+### 3.5 Block 5 — Reverb
+
+**Recommendation: use [verblib](https://github.com/blastbay/verblib) as the
+v1 reverb.** It's a single-file C89 implementation of Schroeder/Freeverb,
+under MIT-No-Attribution-or-public-domain dual license, with no
+dependencies. Compiles into Zeus's existing `native/wdsp/` build as a
+sibling source file.
+
+Surveyed candidates:
+
+| Library | URL | License | Notes |
+|---|---|---|---|
+| verblib | [github.com/blastbay/verblib](https://github.com/blastbay/verblib) | MIT-No-Attribution or public domain (dual) | **Recommended.** Single-file C89, Schroeder reverb (i.e. Freeverb-style 8-comb + 4-allpass). Parameters: room size, damping, stereo width. No external deps. 22050+ Hz sample rates. |
+| sinshu/freeverb | [github.com/sinshu/freeverb](https://github.com/sinshu/freeverb) | Public domain | Jezar's original C++ Freeverb. Slightly more code than verblib (separate Comb/Allpass classes), same algorithm. Either is acceptable. |
+| irh/freeverb-rs | [github.com/irh/freeverb-rs](https://github.com/irh/freeverb-rs) | MIT | Rust port; adds FFI overhead for no algorithmic gain. Avoid. |
+| Calf Reverb | (Calf project, LGPL-2.1) | LGPL-2.1 | Larger, more parameters, but LGPL-2.1 static-linking concern as noted in §3.1. Avoid for v1; verblib is simpler. |
+| AetherSDR `ClientReverb.cpp` | (GPL-3) | NO copy | Reference for parameter defaults (size 0.5, decay 1.2 s, damping 0.5, mix 0.15). |
+| NWaves reverb effects | [github.com/ar1st0crat/NWaves](https://github.com/ar1st0crat/NWaves) | MIT | NWaves doesn't ship a reverb effect (its dynamics group covers gate/compressor/limiter, not reverb). Excluded. |
+
+verblib is the right answer for Zeus v1: it is **the same Freeverb algorithm
+AetherSDR uses** (8 parallel lowpass-feedback comb filters → 4 series
+allpass), it's MIT, it's single-file, and it slots into Zeus's existing
+P/Invoke pattern with minimal effort.
+
+> **Open question for sign-off:** Native (verblib C, P/Invoke from Zeus.Dsp)
+> or pure-managed (port the algorithm to C# — Freeverb is ~200 lines)?
+> The pure-managed route keeps the Zeus.Dsp project's dependency footprint
+> minimal but adds a maintenance burden. The native route matches the
+> existing WDSP pattern. Recommend native (verblib in `native/`) — it's the
+> shortest path and matches the existing architecture. Maintainer call.
+
+### 3.6 Libraries explicitly dropped from v1 consideration
+
+| Library | URL | Reason for exclusion |
+|---|---|---|
+| RNNoise | [github.com/xiph/rnnoise](https://github.com/xiph/rnnoise) | No NR block in v1 (per 2026-05-17 brief). License (BSD-3) is fine; revisit if NR ships in v2. |
+| libspecbleach | [github.com/lucianodato/libspecbleach](https://github.com/lucianodato/libspecbleach) | No NR block in v1. License (LGPL-2.1) is conditionally compatible; revisit if NR ships in v2. Requires FFTW3 which adds binary-size cost. |
+| DeepFilterNet | [github.com/Rikorose/DeepFilterNet](https://github.com/Rikorose/DeepFilterNet) | No NR block in v1. Rust+Python, libDF dual MIT/Apache. Model weights have a separate license check that wasn't completed in this Phase 0 (the libDF Cargo.toml URL returned 404 on direct fetch — re-investigate in NR-Phase 0 if NR ever ships). |
+| JUCE | [github.com/juce-framework/JUCE](https://github.com/juce-framework/JUCE) | Already rejected in `docs/proposals/vst-host.md` §6 on license-incompatibility grounds. Same answer here. |
+
+### 3.7 Summary recommendation table
+
+| v1 block | Recommended source | License | Pure-managed possible? |
+|---|---|---|---|
+| EQ | NWaves `BiquadFilter` (managed) **or** hand-authored against Audio EQ Cookbook | MIT / public-domain | Yes |
+| Compressor | Thin C# wrapper over WDSP `compress.c` | GPL-2-or-later (Zeus-compatible) | No (P/Invoke) |
+| Exciter | Hand-author from Airwindows Exciter algorithm | MIT (reference only) | Yes |
+| Bass Enhancer | C# port of Bankstown's three-stage algorithm | MIT (Bankstown attribution) | Yes |
+| Reverb | verblib (native C, P/Invoke from Zeus.Dsp) | MIT-No-Attribution / public-domain | No (native, by recommendation) |
+
+If the maintainer prefers **maximum managed-DSP coverage**, four of five
+blocks (all except the WDSP compressor wrapper) can be pure C#. If the
+maintainer prefers **minimum new dependencies**, all five can route through
+`native/wdsp/` (compressor via existing `compress.c`, reverb via verblib
+dropped in `native/`, EQ via WDSP `eq.c` extension, exciter + bass enhancer
+hand-authored into `native/wdsp/` as new sibling files). Either is
+architecturally valid; the choice is the maintainer's.
+
+---
+
+## 4. Surprises and findings worth flagging to maintainer
+
+These are observations from the research that the master PRD should incorporate:
+
+1. **AetherSDR's "Big Bottom" is not MaxxBass.** This is the single most
+   important finding. AetherSDR's only public bass-enhancer reference
+   implements Family A (Aphex 204 dynamic-EQ + saturation), not Family B
+   (MaxxBass missing-fundamental synthesis). KB2UKA's brief asks for
+   Family B. The two are different algorithms with different audible
+   behavior on an HF antenna. The design must explicitly pick one. See
+   §3.4.1 open question.
+
+2. **AetherSDR uses GPL-3-or-later, Zeus is GPL-2-or-later.** Copying
+   AetherSDR source into Zeus is a license-tainting operation. The
+   reference-only / clean-room rule (read `.h` headers and comments only,
+   not `.cpp` implementations) is non-negotiable. See §2.
+
+3. **AetherSDR fuses exciter and bass enhancer into one block (`ClientPudu`).**
+   KB2UKA's v1 list splits them into two. This is a small but real design
+   departure that gives operators independent enable/bypass. Recommended,
+   but flagged. See §3.4.4 open question.
+
+4. **Bankstown's algorithm is small enough to port directly.** ~150 lines
+   of Rust for a complete three-stage Family B bass enhancer. MIT-licensed.
+   This is the most-leverage finding for the bass-enhancer block: a
+   well-defined, documented, license-clean reference implementation that
+   Zeus can port to C# in a single day. See §3.4.2.
+
+5. **verblib is a single-file MIT/public-domain Freeverb.** Zero
+   dependencies, drop-in. The reverb block is essentially a solved
+   problem. See §3.5.
+
+6. **deskHPSDR has no bass-enhancer block.** Despite being the closest
+   HPSDR cousin to Zeus's voice-DSP ambitions, deskHPSDR's TX audio chain
+   stops at EQ + WDSP's stock compressor / leveler. Zeus's bass-enhancer
+   block has no HPSDR-ecosystem precedent — Zeus would be the first
+   HPSDR client to ship one. This affects the operator-facing
+   communication strategy but does not affect the technical design.
+
+7. **All five v1 blocks can be implemented in pure-managed C#** if the
+   maintainer prefers — every external library candidate is either MIT
+   (managed-friendly) or has a managed equivalent. The decision to wrap
+   WDSP (per §3.3 recommendation) is an architectural preference, not a
+   technical necessity.
+
+8. **No model-weight licensing risk in v1.** All five v1 blocks are
+   classical DSP — no neural NR weights, no model files. Weight-license
+   complexity (CC-BY-NC research-only weights, etc.) is deferred to a
+   future NR PRD.
+
+---
+
+## Open questions for sign-off
+
+> **Open question for sign-off:** Bass-enhancer algorithm family — **Family
+> A (Aphex 204 dynamic-EQ + saturation)** or **Family B (MaxxBass
+> missing-fundamental harmonic synthesis)**? KB2UKA's 2026-05-17 brief
+> explicitly cites Family B ("synthesizes upper-harmonics of low-frequency
+> content so the human ear perceives bass without the radio needing to
+> transmit the actual low frequencies"). Family B is the algorithm that
+> matters for an HF antenna whose low-end is filtered out by physics.
+> Family A is the algorithm AetherSDR ships, and is simpler to
+> implement. Recommend Family B for v1 to match the brief; note that
+> implementation is 3–6 weeks vs. ~1 week for Family A. See §3.4.1.
+
+> **Open question for sign-off:** EQ band count — fixed-10 or
+> operator-tunable (1–16, default 10)? AetherSDR allows 16. Fixed-10 is
+> the simpler UI. Operator-tunable is the more powerful UI. Recommend
+> AetherSDR's compromise (default 10 visible, "show all 16" toggle).
+> See §3.2.
+
+> **Open question for sign-off:** Compressor implementation — wrap
+> existing WDSP `compress.c` (Zeus's "DSP in WDSP, C# orchestrates" pattern)
+> or use NWaves's managed `Compressor` (faster iteration, no
+> P/Invoke)? Recommend WDSP wrap to preserve the architectural invariant.
+> See §3.3.
+
+> **Open question for sign-off:** EQ implementation — wrap/extend WDSP
+> `eq.c` (graphic, needs work to make parametric), use NWaves's managed
+> BiQuad/Peak/Shelf filters (MIT, well-tested, full filter-family
+> palette), or hand-author against the Audio EQ Cookbook? Recommend
+> NWaves for v1 if the architecture allows new managed deps; recommend
+> hand-author against the cookbook if "minimum new deps" is the
+> preference. See §3.2.
+
+> **Open question for sign-off:** Reverb implementation — native
+> (verblib, P/Invoke) or pure-managed (C# port of Freeverb)? Recommend
+> verblib (native) to match the existing architecture. See §3.5.
+
+> **Open question for sign-off:** Exciter and Bass Enhancer — one
+> combined block (AetherSDR's `ClientPudu` pattern, two-band exciter
+> handles both) or two separate blocks (KB2UKA's v1 list)? Recommend
+> two separate blocks per the v1 list — gives operators independent
+> enable/bypass per side. See §3.4.4.
+
+> **Open question for sign-off:** Bass-enhancer source — direct C# port
+> of Bankstown's three-stage algorithm (MIT, ~150 lines), C
+> reimplementation in `native/wdsp/`, or FFI to Bankstown as a Rust
+> cdylib? Recommend C# port — preserves Zeus's managed-DSP preference,
+> license-clean under MIT attribution, no new toolchain dependency.
+> See §3.4.2.
+
+> **Open question for sign-off:** AetherSDR's chain dispatcher exposes
+> the block ordering to the operator (`"chain": ["Gate","Eq",...]` in
+> the preset JSON). Zeus v1 — fixed order (EQ → Comp → Exciter → Bass →
+> Reverb), or operator-reorderable? Fixed is simpler UI; reorderable is
+> more flexible. **No recommendation** — pure visual/UX call. Brian's.
+
+> **Open question for sign-off:** Two-tier parameter visibility
+> ("Basic / Advanced" split) as is common in modern voice plugins, or
+> all-parameters-always-visible (AetherSDR's pattern)? **No
+> recommendation** — pure UX call. Brian's.
+
+> **Open question for sign-off:** All five v1 blocks can be either pure-
+> managed (C#) or native (P/Invoke into WDSP / verblib / hand-authored
+> C). The architecture allows either. No technical answer is forced.
+> Recommend a mixed approach (compressor via WDSP wrap, reverb via
+> native verblib, EQ / exciter / bass-enhancer pure-managed C#) — but
+> the choice is the maintainer's preference for codebase-shape.
+
+---
+
+## Citations
+
+- AetherSDR repo: <https://github.com/ten9876/AetherSDR>
+- AetherSDR audio engine: `src/core/AudioEngine.h`
+- AetherSDR per-block headers: `src/core/ClientGate.h`, `ClientEq.h`,
+  `ClientComp.h`, `ClientDeEss.h`, `ClientTube.h`, `ClientPudu.h`,
+  `ClientReverb.h`, `ClientFinalLimiter.h`
+- AetherSDR preset format: `src/core/ChannelStripPresets.h`
+- AetherSDR LICENSE: <https://github.com/ten9876/AetherSDR/blob/main/LICENSE>
+- Zeus LICENSE: `/LICENSE` at repo root
+- Aphex 204 review (Home Theater HiFi, 2004):
+  <https://hometheaterhifi.com/volume_11_3/aphex-204-big-bottom-7-2004.html>
+- Aphex 204 owner's manual:
+  <https://cdn.aphex.com/assets/pdf/Aphex_Exciter_OM.pdf>
+- MaxxBass paper (AES, Ben-Tzur):
+  *The Effect of MaxxBass Psychoacoustic Bass Enhancement on Loudspeaker
+  Design* — <https://www.aes.org/e-lib/download.cfm?ID=8288>
+- Larsen & Aarts, *Audio Bandwidth Extension*, Wiley 2005 (textbook)
+- Missing-fundamental phenomenon (Wikipedia):
+  <https://en.wikipedia.org/wiki/Missing_fundamental>
+- Bankstown (Family B FOSS implementation, MIT):
+  <https://github.com/chadmed/bankstown>
+- DeaDBeeF virtual-bass plugin (academic-reference C plugin, MIT):
+  <https://github.com/alpo/DeaDBeeF-virtual-bass-plugin>
+- Calf Bass Enhancer documentation:
+  <https://calf-studio-gear.org/doc/Bass%20Enhancer.html>
+- Calf source repo: <https://github.com/calf-studio-gear/calf>
+- Airwindows Exciter and Pafnuty:
+  <https://github.com/airwindows/airwindows>
+- verblib (Schroeder reverb, single-file C89, MIT/public-domain):
+  <https://github.com/blastbay/verblib>
+- sinshu/freeverb (Jezar's original Freeverb, public domain):
+  <https://github.com/sinshu/freeverb>
+- NWaves (.NET DSP library, MIT):
+  <https://github.com/ar1st0crat/NWaves>
+- NAudio (.NET audio I/O + BiQuad filters, MIT):
+  <https://github.com/naudio/NAudio>
+- Audio EQ Cookbook (Bristow-Johnson):
+  <https://webaudio.github.io/Audio-EQ-Cookbook/audio-eq-cookbook.html>
+- RNNoise (excluded from v1, BSD-3):
+  <https://github.com/xiph/rnnoise>
+- libspecbleach (excluded from v1, LGPL-2.1):
+  <https://github.com/lucianodato/libspecbleach>
+- DeepFilterNet (excluded from v1, MIT/Apache):
+  <https://github.com/Rikorose/DeepFilterNet>
+- deskHPSDR (HPSDR cousin, GPL-3):
+  <https://github.com/dl1bz/deskhpsdr>
+- WDSP source bundled at `native/wdsp/` — see `eq.c`, `compress.c`,
+  `cfcomp.c`
+- Zeus VST host ADR (companion document for plugin-route DSP):
+  `docs/proposals/vst-host.md`
+- Phase 0 sibling document on UX integration:
+  `docs/proposals/audio-chain/03-ux-and-integration.md`

--- a/docs/proposals/audio-chain/02-wdsp-gap-analysis.md
+++ b/docs/proposals/audio-chain/02-wdsp-gap-analysis.md
@@ -1,0 +1,304 @@
+# WDSP Gap Analysis: TX Voice Audio Chain v1 Blocks (Issue #332)
+
+**Status:** Phase 0 research output for issue #332
+**Scope:** Gap analysis for the 5 v1 voice audio chain blocks: parametric EQ, compressor, exciter, bass enhancer, and reverb. Inventory of WDSP TX chain primitives available for reuse.
+
+---
+
+## 1. Current WDSP TX Chain Inventory
+
+### 1.1 TX Audio Path (TXA Channel)
+
+The Zeus TX audio chain (TXA channel) operates at 48 kHz mono input and processes through WDSP's TXA block. The insertion point for Phase 1 hand-authored blocks is post-Leveler / pre-CFC per `WdspDspEngine.cs:2354-2369`:
+
+```
+Mic Input (48 kHz mono)
+  ↓
+[Panel Gain] — SetTXAPanelGain1 (operator: -40..+10 dB)
+  ↓
+[ALC] — SetTXAALCSt (always on; fixed: 1 ms attack, 10 ms decay, +3 dB max)
+  ↓
+[Leveler/WCPAGC] — SetTXALevelerSt / SetTXALevelerTop (operator: 0..+15 dB max-gain)
+  ↓
+[**VST SEAM — Phase 1 hand-authored blocks inserted here**]
+  ↓
+[CFC] — SetTXACFCOMPRun + profile (10-band multiband compressor; operator-tunable)
+  ↓
+[Output] → fexchange2 modulation → TX IQ
+```
+
+### 1.2 WDSP Stages Exposed via P/Invoke
+
+The NativeMethods.cs exposes the following TXA control functions:
+
+| Stage | P/Invoke Functions | Run Toggle | Tuning Functions | Meter Output | Status |
+|---|---|---|---|---|---|
+| **Mic Gain** | `SetTXAPanelGain1(ch, linear_gain)` | N/A | Direct dB→linear setter | MIC_PK, MIC_AV | Wired; operator-controllable |
+| **ALC** | `SetTXAALCSt` / `SetTXAALCMaxGain` / `SetTXAALCAttack` / `SetTXAALCDecay` | `SetTXAALCSt(run)` | MaxGain, Attack, Decay available | ALC_PK, ALC_AV, ALC_GAIN | On; params hardcoded (not operator-tunable) |
+| **Leveler** | `SetTXALevelerSt` / `SetTXALevelerTop` | `SetTXALevelerSt(run)` | MaxGain setter available | LVLR_PK, LVLR_AV, LVLR_GAIN | Wired; operator-tunable (0..+15 dB) |
+| **Compressor** | `SetTXACompressorRun(ch, run)` | Yes | **None visible**; params opaque | COMP_PK, COMP_AV | Off; no tuning API exposed |
+| **EQ** | `SetTXAEQRun(ch, run)` | Yes | **None visible**; params opaque | EQ_PK, EQ_AV | Off; no tuning API exposed |
+| **AMSQ (Gate)** | `SetTXAAMSQRun(ch, run)` | Yes | **None visible**; params opaque | (none) | Off; not operator-tuned for SSB |
+| **CFC** | `SetTXACFCOMPRun` / `SetTXACFCOMPprofile` / `SetTXACFCOMPPrecomp` / `SetTXACFCOMPPrePeq` / `SetTXACFCOMPPeqRun` | `SetTXACFCOMPRun(run)` | Full profile (10 bands × compression/gain, pre-scalars) | CFC_PK, CFC_AV, CFC_GAIN | Operator-tunable; always post-new-chain |
+| **Bandpass** | `SetTXABandpassFreqs` / `SetTXABandpassWindow` / `SetTXABandpassRun` | `SetTXABandpassRun(run)` | Frequency setter | (none) | BP0 always on; coupled to TX filter |
+| **CFIR** | `SetTXACFIRRun(ch, run)` | Yes | (none) | (none) | P1: off; P2: on (corrects upsample droop) |
+| **PHROT** | `SetTXAPHROTRun(ch, run)` | Yes | (none) | (none) | Off; unclear purpose in TX context |
+| **osctrl** | `SetTXAosctrlRun(ch, run)` | Yes | (none) | (none) | Off; unclear purpose |
+| **PostGen (TUN/2-tone)** | `SetTXAPostGenRun` / `SetTXAPostGenMode` / `SetTXAPostGenTone*` / `SetTXAPostGenTT*` | Yes | Tone freq/mag setters | (none) | Disabled; used for TUN carrier + two-tone test |
+
+**Key finding:** WDSP exposes only **on/off toggles** for Compressor and EQ (no tuning API). CFC is the only fully parametric multi-band compressor in the TX chain.
+
+### 1.3 Sample Rate and Block Constraints
+
+| Profile | Mic Input | WDSP DSP Rate | IQ Output | Block Size | Notes |
+|---|---|---|---|---|---|
+| **P1** | 1024@48k | 1024@48k | 1024@48k | 1024 frames | Flat 48 kHz; CFIR off |
+| **P2** | 512@48k | 1024@96k | 2048@192k | 512 mic / 1024 DSP / 2048 IQ | 48k→96k→192k upsample; CFIR on |
+
+**Phase 1 blocks must handle:** 48 kHz mono input (VSTseam rate); can optionally run at WDSP's internal DSP rate (96 kHz on P2) if they need higher precision.
+
+---
+
+## 2. Gap Analysis: The 5 v1 Blocks
+
+### 2.1 Block 1: Parametric EQ (8–10 Band)
+
+**v1 Requirement:** Multiband parametric equalization. Likely GUI: slider per band (center freq fixed, gain variable ±12 dB).
+
+#### WDSP EQ Primitive
+
+**Current exposure:** `SetTXAEQRun(ch, run)` only. No tuning API visible in NativeMethods.cs or comments.
+
+**Assessment:** WDSP likely has an EQ stage internally (pihpsdr / Thetis may use it on RX), but the TX-side tuning functions are not P/Invoke'd here. Requires:
+1. Audit of WDSP library sources (`wdsp/eqp.c` if available) to confirm what knobs exist
+2. If knobs exist: extend NativeMethods + RadioService (150–200 lines)
+3. If opaque: HAND-AUTHOR
+
+**Recommendation:** 
+- **REUSE (conditional):** IF WDSP exposes 8–10 parametric band setters (likely names: `SetTXAEQBand`, `SetTXAEQGain`, etc.), then extend P/Invoke and wire UI. Effort: **Moderate** (200 lines).
+- **HAND-AUTHOR (likely):** If WDSP EQ is opaque or doesn't exist on TX, implement 8–10 Butterworth biquad cascade. Effort: **Significant** (300–400 lines for biquad design + phase/gain compensation).
+
+**CPU Cost (estimate):** 10 biquads @ 48 kHz ~= 30–50 MAC/sample (acceptable on modern CPU).
+
+---
+
+### 2.2 Block 2: Compressor (Single-Stage VCA-style)
+
+**v1 Requirement:** Single broadband compressor. Typical controls: ratio, threshold, attack, release, makeup gain.
+
+#### WDSP Compressor Primitive
+
+**Current exposure:** `SetTXACompressorRun(ch, run)` only. No ratio/threshold/attack/release setters visible.
+
+**Assessment:** WDSP has a Compressor stage (likely `compressor.c`), but like EQ, only the run toggle is exposed. Requires same audit as EQ.
+
+**Recommendation:**
+- **REUSE (conditional):** IF WDSP exposes `SetTXACompRatio`, `SetTXACompThreshold`, etc., extend P/Invoke. Effort: **Moderate** (200 lines).
+- **HAND-AUTHOR (likely):** If opaque, implement VCA-style soft-knee compressor (peak detector → log domain → soft knee → makeup). Effort: **Significant** (250–350 lines for state machine + time constants).
+
+**CPU Cost (estimate):** VCA compressor ~= 10–20 MAC/sample (acceptable).
+
+---
+
+### 2.3 Block 3: Exciter (Aural Exciter-style Top-End Enhancement)
+
+**v1 Requirement:** Harmonic enhancement in high frequencies (typically 4–8 kHz and upper midrange). Adds "presence" and sizzle to voice.
+
+#### WDSP Harmonic Primitives
+
+**Current exposure:** No explicit harmonic generation or top-end boosting in TXA NativeMethods. RX side has EMNR (noise reduction with psychoacoustic post-processing), but no harmonic synthesis.
+
+**Assessment:** WDSP does not expose a harmonic enhancement or "exciter" function. Must HAND-AUTHOR from scratch.
+
+**Algorithm outline:**
+```
+1. High-pass filter (e.g., 4 kHz Butterworth high-pass)
+2. Soft-clipping or waveshaper (tanh / polynomial) to generate harmonics
+3. Level-matched re-injection into main path (mix dry + processed)
+Tuning: amount (0–100%), saturation drive, feedback loop
+```
+
+**Recommendation:** **HAND-AUTHOR.** Effort: **Moderate–Significant** (150–250 lines for filter + waveshaper + mixing).
+
+**CPU Cost (estimate):** High-pass filter + soft-clip ~= 20–30 MAC/sample (acceptable).
+
+---
+
+### 2.4 Block 4: Bass Enhancer (Psychoacoustic Lower-Octave Synthesis)
+
+**v1 Requirement:** Aphex 204 "Big Bottom" style. Synthesizes upper harmonics of low-frequency content (typically sub-100 Hz fundamentals) so the ear perceives bass depth without the radio transmitting actual lows. Critical for SSB where the radio may not pass sub-200 Hz well.
+
+#### WDSP Bass/Psychoacoustic Primitives
+
+**Current exposure:** 
+- `SetRXAEMNRaeRun`, `SetRXAEMNRpost2Run` etc. hint at psychoacoustic noise reduction on RX, but these are post-processing, not synthesis.
+- No explicit bass enhancement, harmonic doubler, or octave synthesizer in TXA.
+
+**Assessment:** WDSP does not expose bass-enhancement synthesis. Must HAND-AUTHOR.
+
+**Algorithm outline:**
+```
+1. Low-pass filter (e.g., 200 Hz cutoff, steep rolloff for sub-200 separation)
+2. Harmonic doubler / octave shifter on the low-pass output
+   (Pitch-shift by +1 octave, or heterodyne-style synthesis at 2×f)
+3. High-pass filtered copy of original (remove true lows)
+4. Level-matched re-injection (psychoacoustic level matching ~= -6 dB for octave shift)
+5. Mix: attenuated low-pass + doubled/shifted high-octave content back into main path
+Tuning: amount (intensity of synthesis, 0–100%), low-pass cutoff (100–300 Hz), makeup level
+```
+
+**Complexity:** Requires pitch-shift or harmonic synthesis (more complex than simple saturation). Typical approaches:
+- **Phase vocoder variant:** FFT-based pitch shift (heavy CPU, ~100+ MAC/sample). Acceptable but overkill for low-freq synth.
+- **Time-domain pitch doubling (heterodyne):** Modulate low-pass signal with 2× frequency sine wave, extract envelope (200–300 MAC/sample). Acceptable.
+- **Simplified octave synth:** Just attenuate low-pass and mix (treats as "pseudo-bass": not true harmonics, but mimics presence). Simplest, ~30 MAC/sample.
+
+**Recommendation:** **HAND-AUTHOR.** Start with simplified octave synth (fast enough); prototype with time-domain heterodyne if needed for harmonics. Effort: **Significant** (250–400 lines depending on algorithm choice).
+
+**CPU Cost (estimate):** Simplified (attenuation + mixing): 20–30 MAC/sample. Full heterodyne: 100–150 MAC/sample. Both acceptable on modern CPU.
+
+**⚠️ Key gap:** Bass enhancer is the most algorithmically specific block in the v1 chain. There is **no WDSP primitive** to reuse. Must author from scratch with careful design of the frequency split and harmonic synthesis method.
+
+---
+
+### 2.5 Block 5: Reverb
+
+**v1 Requirement:** Spatial reverb effect. Typical: small room (100–300 ms decay). Used to add warmth / presence to voice SSB.
+
+#### WDSP Reverb Primitives
+
+**Current exposure:** None. No reverb stage in TXA or RXA (Thetis doesn't ship reverb either; it's typically a post-processing effect in the audio interface).
+
+**Assessment:** WDSP does not include reverb. Must use external library or HAND-AUTHOR.
+
+**Options:**
+1. **EXTERNAL-DEP (Freeverb GPL):** Widely available, proven algorithm, easy to integrate. ~500 lines of C glue code. Latency ~50 ms (acceptable for SSB). CPU ~= 50–100 MAC/sample moderate-complexity IR.
+2. **HAND-AUTHOR (Schroeder reverberator):** Classic Schroeder design (parallel comb + series allpass filters). Algorithm complexity is high but well-documented. Effort: **Significant** (300–400 lines for filter chains + parameter mapping).
+
+**Recommendation:** **EXTERNAL-DEP preferred.** Freeverb is GPL-compatible and battle-tested. If licensing concerns, deferred to sibling doc `01-aethersdr-and-external-deps.md`. Effort to integrate: **Moderate** (200 lines wrapper + parameter mapping).
+
+**CPU Cost (estimate):** Freeverb-like IR ~= 50–100 MAC/sample (modest overhead, acceptable).
+
+---
+
+## 3. Insertion Point and Chain Order
+
+### 3.1 Confirmed Location
+
+Per `WdspDspEngine.cs:2354–2369`:
+- **Pre-condition:** Post Leveler (slow auto-gain already running)
+- **Post-condition:** Pre-CFC (so operator's final-stage compressor is the authority)
+- **Rate:** 48 kHz mono (both P1 and P2 profiles feed mic at 48 kHz; WDSP upsamples downstream)
+- **Bypass:** Zero-cost when disabled (volatile-bool short-circuit)
+
+### 3.2 Proposed v1 Order (subject to sign-off)
+
+```
+Mic Input (48 kHz)
+  ↓
+[Panel Gain] — WDSP (operator: -40..+10 dB)
+  ↓
+[ALC] — WDSP (always on; fast 1 ms attack)
+  ↓
+[Leveler] — WDSP (operator: 0..+15 dB max-gain slider)
+  ↓
+**[=== PHASE 1 HAND-AUTHORED BLOCKS START ===]**
+  ↓
+[EQ] — 8–10 band parametric (REUSE or HAND-AUTHOR TBD)
+  ↓
+[Compressor] — Single VCA-style (REUSE or HAND-AUTHOR TBD)
+  ↓
+[Exciter] — Top-end harmonic enhancement (HAND-AUTHOR)
+  ↓
+[Bass Enhancer] — Psychoacoustic octave synth (HAND-AUTHOR)
+  ↓
+[Reverb] — Spatial effect (EXTERNAL-DEP or HAND-AUTHOR)
+  ↓
+**[=== PHASE 1 HAND-AUTHORED BLOCKS END ===]**
+  ↓
+[CFC] — WDSP multiband (operator-tuned; always post-chain)
+  ↓
+[Output] → fexchange2 modulation → TX IQ
+```
+
+**Rationale:**
+- **EQ early:** Shape tone before compression so compressor sees the intended spectrum.
+- **Compressor mid-chain:** Narrow dynamic range before final limiting effects.
+- **Exciter + Bass:** Harmonic enhancement after dynamic control (so compression doesn't mute the synthesis).
+- **Reverb last (in chain):** Adds space to the final compressed/enhanced signal so reflections don't trigger CFC re-compression.
+- **CFC final (WDSP):** Operator's preferred multiband limiter; always the ultimate gain authority.
+
+### 3.3 Latency Budget
+
+- **Per-block latency:** ~10 ms (one 1024-sample block @ 48 kHz).
+- **Cumulative:** Panel Gain (0) + ALC (0) + Leveler (0) + EQ (5 ms filter state) + Compressor (0) + Exciter (0) + Bass (5 ms filter state) + Reverb (50 ms tail) + CFC (0) + CFIR (0) **≈ 60 ms total**.
+- **Acceptable?** Yes, typical for radio audio chains. Report to operator in UI (Thetis does this).
+
+---
+
+## 4. Reusability Scoring Summary
+
+| Block | WDSP Available? | Classification | Estimated Effort | Notes |
+|---|---|---|---|---|
+| **Parametric EQ** | Toggle only; tuning opaque | REUSE (if audit succeeds) OR HAND-AUTHOR | Moderate (if REUSE) / Significant (HAND-AUTHOR) | Requires WDSP library audit for band setters |
+| **Compressor** | Toggle only; tuning opaque | REUSE (if audit succeeds) OR HAND-AUTHOR | Moderate (if REUSE) / Significant (HAND-AUTHOR) | Requires WDSP library audit for ratio/threshold |
+| **Exciter** | None | HAND-AUTHOR | Moderate (150–250 lines) | Simple waveshaper + high-pass; no dependencies |
+| **Bass Enhancer** | None | HAND-AUTHOR | Significant (250–400 lines) | Requires careful psychoacoustic algorithm; most complex block |
+| **Reverb** | None | EXTERNAL-DEP preferred / HAND-AUTHOR fallback | Moderate (EXTERNAL-DEP) / Significant (HAND-AUTHOR) | Freeverb integration recommended; defer licensing to sibling doc |
+
+---
+
+## 5. Open Questions for Sign-Off
+
+> **Q1: Are EQ and Compressor tuning functions available in the WDSP library?**
+>
+> **Action:** Audit `wdsp/eqp.c` and `wdsp/compressor.c` (or equivalent) for band/ratio/threshold setters. If found, extend NativeMethods + RadioService to expose them. If not, mark HAND-AUTHOR and allocate implementation time.
+
+> **Q2: For Bass Enhancer, which psychoacoustic algorithm should Phase 1 target?**
+>
+> Options:
+> - Simplified octave synth (attenuation + mixing, ~30 MAC/sample) — fast to implement, less authentic.
+> - Time-domain heterodyne (modulation-based frequency doubling, ~100–150 MAC/sample) — more authentic harmonics.
+> - FFT-based pitch shift (heavy but highest quality, ~100+ MAC/sample) — overkill for low-freq synth.
+>
+> **Recommendation:** Start with simplified octave synth for Phase 1; prototype full heterodyne in Phase 1.1 if operator feedback warrants. Coordinate with psychoacoustics SME if available.
+
+> **Q3: Should Reverb be sourced from an external library (Freeverb GPL) or hand-authored?**
+>
+> **Action:** Defer licensing audit to sibling doc `01-aethersdr-and-external-deps.md`. If GPL-2.0-or-later is acceptable, recommend Freeverb integration. If custom required, plan HAND-AUTHOR (300–400 lines Schroeder reverberator).
+
+> **Q4: What is the approved v1 chain order and bypass strategy?**
+>
+> **Current proposal:** EQ → Compressor → Exciter → Bass → Reverb → CFC. Each block individually bypassable? Master bypass?
+>
+> **Action:** Confirm order and UI model (per-block toggles vs. master chain enable).
+
+> **Q5: Should hand-authored blocks run at 48 kHz or WDSP's DSP rate (96 kHz on P2)?**
+>
+> **48 kHz (simpler):** Matches VST seam rate; less CPU; ~5% precision loss on P2. **96 kHz (better):** Matches internal WDSP DSP rate; more CPU; full precision.
+>
+> **Recommendation:** Prototype at 48 kHz for Phase 1. Optimize to DSP rate in Phase 1.1 if CPU budget allows.
+
+> **Q6: Does Phase 1 wire each v1 block behind an IZeusAudioPlugin abstraction (contract), or directly into DspPipelineService?**
+>
+> **Action:** Gated on Brian's `feature/plugins-foundation` landing. Phase 1 may proceed with direct wiring; Phase 1.1 refactors behind plugin contract once available.
+
+---
+
+## 6. File References
+
+| File | Line Range | Content |
+|---|---|---|---|
+| `WdspDspEngine.cs` | 2354–2369 | VST seam insertion point; insertion rationale |
+| `WdspDspEngine.cs` | 1140–1350 | TXA channel initialization; ALC/Leveler/CFC setup |
+| `WdspDspEngine.cs` | 2432–2510 | TX meter snapshot (LVLR_PK/AV/GAIN, CFC_PK/AV/GAIN, etc.) |
+| `NativeMethods.cs` | 542–752 | All TXA P/Invoke bindings (SetTXA*, GetTXA*) |
+| `IDspEngine.cs` | 145–189 | TX public interface (SetTxPanelGain, SetTxLevelerMaxGain, SetTxMode, ProcessTxBlock, etc.) |
+| `RadioService.cs` | 1286–1307 | SetCfc public method; radio-layer CFC wiring |
+| `ZeusEndpoints.cs` | 386–407 | `/api/mic-gain` and `/api/tx/leveler-max-gain` REST endpoints |
+| `tx-store.ts` | 50–290 | Frontend TX state (micGainDb, levelerMaxGainDb, cfcConfig, metering) |
+| `vst-host-phase2-wire.md` | — | VST IPC seam placement and contract |
+
+---
+
+**Generated:** 2026-05-17
+**Analyst:** Claude Code (Phase 0 research)

--- a/docs/proposals/audio-chain/03-ux-and-integration.md
+++ b/docs/proposals/audio-chain/03-ux-and-integration.md
@@ -1,0 +1,498 @@
+# Audio Voice Chain — UX & Integration Design (Phase 0)
+
+Status: Research proposal (awaiting maintainer sign-off)
+Authors: KB2UKA
+Date: 2026-05-17
+Companion: [01-rfc.md](./01-rfc.md), [02-block-catalog.md](./02-block-catalog.md)
+
+This document proposes how the v1 audio processing chain (5 blocks: EQ, Compressor, Exciter, Bass Enhancer, Reverb) slots into Zeus's existing UI vocabulary and integrates with the WDSP DSP engine. It makes no architectural commitments — all visual and wire-level choices are flagged for Brian (EI6LF) sign-off.
+
+---
+
+## 1. Design Language Analysis
+
+### 1.1 Global Palette (source of truth: `tokens.css`)
+
+Zeus's visual design is a **near-black beveled-panel aesthetic** matching the Hermes Lite 2 hardware front panel. The operator reads the interface as *lit instruments on a dark bench*.
+
+**Palette summary:**
+- **Workspace background:** `--bg-app` (#0a0a0c) — app chrome backdrop; same as workspace canvas so panels "lift off" the background via `--bg-1` (#111114).
+- **Panel base:** `--bg-1` (#111114) — the raised surface all controls sit on; gives ~3dB visual lift over workspace.
+- **Control surfaces:** `--bg-2` (#1a1a1e) for button rest, `--bg-3` (#232328) for hover. These are incremental lifts.
+- **Deepest wells:** `--bg-inset` (#060608) for panadapter, gauge backgrounds; and `--bg-meter` (#050507) for LED meter wells — "lit instruments in dark recesses."
+- **Accent:** `--accent` (#0c5f9c, dark blue) for UI focus and active state. When active, buttons adopt `--accent` fill + white text. This is the ONLY global UI accent; never use it to tint backgrounds.
+- **TX/gain-reduction:** `--tx` (#ff4a59, warm red) — semantic meaning "you are transmitting" or "gain reduction active." Never a mere decoration.
+- **Power output:** `--power` (#ffb13c, warm yellow) — meter peak indicator and output-power dial.
+- **Signal visualization:** Amber `#FFA028` (via `--immersive-warn` fallback) applied **by varying alpha only**, never by hue shift. Low signal = dim; high signal = full. This matches the panadapter trace color.
+- **Foreground text:** `--fg-0` (#ffffff) for headings, `--fg-1` (#cccccc) for body, `--fg-2` (#8a8a90) for muted labels, `--fg-3` (#5a5a60) for extra-muted borders.
+- **Lines & separators:** `--line` (#1f1f23) for panel dividers, `--line-soft` (#16161a) for subtle background lines, `--line-strong` (#2c2c32) for stronger definition.
+
+**Critical rule:** All color must come from `tokens.css` variables. Raw hex is forbidden except where the token system is unavailable (e.g., inline SVG `fill` attributes that can't reference CSS vars — those use the canonical hex constants from the token file). Do NOT invent new colors.
+
+### 1.2 Panel Structure Vocabulary
+
+Existing panels (CFC, DspPanel, TxFilterPanel) establish three control patterns:
+
+#### Header with master enable/disable
+CFC and DspPanel both begin with a **labeled toggle** that turns the whole feature on or off:
+```
+[✓ toggle]  <LABEL>    [optional: subtitle or tagline]
+```
+
+The toggle is a native HTML checkbox styled per `tokens.css` button semantics (flat `--bg-2`, `--accent` when checked). Label sits to the right. The font is `--font-sans` (Inter) at 12px body weight, 400–600 depending on prominence.
+
+#### Section dividers
+CFC uses `var(--line)` horizontal rules to separate logical sections. Padding is 12px above and below.
+
+#### Control rows (slider + label)
+Slider is a native `<input type="range">` styled per `tokens.css`: dark `--line` track, white round thumb with shadow. Label on the left at 12px `--fg-1`. Optional unit suffix (e.g. "dB", "ms", "Hz") to the right in `--fg-3`.
+
+#### Preset / preset-chip selector
+CFC exposes preset chips as flat buttons. When active, the chip shows `--accent` fill + white text. Inactive chips are `--bg-2` with `--fg-1` text.
+
+#### Advanced / expandable sections
+A right-chevron disclosure button (`▶ Advanced`) that toggles a conditional render. The main controls stay visible; tertiary controls hide by default.
+
+### 1.3 Meter Primitives
+
+Zeus has meter widget types suitable for audio-chain monitoring:
+
+1. **HBarMeter** — horizontal bar with numeric readout, scale ticks, and peak-hold tick. Used in TX Stage Meters. Great for gain reduction (shows compressor action) and level monitors. Fill gradient: good (green) → warn (yellow) → tx (red). Label on the left, readout on the right.
+
+2. **Activity LED** — small indicator light (16×16 px), filled with `--ok` (green) or `--fg-4` (dark gray). Used for binary on/off states (e.g. exciter is active, bass enhancer is synthesizing).
+
+**Meter-per-block recommendation (v1 blocks):**
+- **EQ:** Optional graphical EQ-curve display (Phase 1 or Phase 2 open question). No real-time meter required for v1.
+- **Compressor:** HBarMeter for gain reduction (GR). Shows how much the compressor is pushing down the signal. Gradient: good (no GR) → tx (heavy GR).
+- **Exciter:** Activity LED (green when adding harmonic content, gray when silent/off). Optional: small spectrum zoom on upper band (Phase 2).
+- **Bass Enhancer:** Activity LED (green when synthesizing bass harmonics, gray when idle). Meter shows energy in the synthesized band (Phase 2).
+- **Reverb:** No dedicated meter (reverb tail is audible, difficult to meter visually in v1).
+
+---
+
+## 2. Chain Panel Proposal (v1: 5 blocks)
+
+### 2.1 Where the panel lives
+
+**Decision: Tab in the Settings menu, under "TX Audio Tools"** (alongside CFC and VST host).
+
+In the browser:
+```
+Settings menu (gear icon)
+  └─ TX Audio Tools (tab)
+      ├─ CFC Settings Panel
+      ├─ Audio Voice Chain Panel  ← NEW (v1: EQ, Comp, Exciter, Bass, Reverb)
+      └─ VST Host Submenu (if available)
+```
+
+### 2.2 Top-level chain structure
+
+```
+┌─────────────────────────────────────────────────────┐
+│  [✓ Chain]    Audio Voice Chain    [Presets ▼]      │
+├─────────────────────────────────────────────────────┤
+│  Flow visualization:                                 │
+│  [MIC] → [EQ] → [Comp] → [Exciter] → [Bass] → [Rev] │
+│          ↑       ↑        ↑           ↑       ↑      │
+│         ON      ON       OFF         OFF      OFF    │
+│                                                      │
+│  Block 1: Parametric EQ (10 bands)      [bypass]    │
+│  ├─ Band 1 (100 Hz):   __________ dB, Q: ____       │
+│  ├─ Band 2 (200 Hz):   __________ dB, Q: ____       │
+│  └─ [Show more bands ▼] [Advanced ▶]                │
+│                                                      │
+│  Block 2: Compressor                    [bypass]    │
+│  ├─ Threshold: __________ dB                        │
+│  ├─ Ratio:     __________ :1                        │
+│  ├─ Attack:    __________ ms  [Advanced ▶]          │
+│  └─ GR Meter:  [███░░░░░░░░░░░]  −2.4 dB            │
+│                                                      │
+│  Block 3: Exciter                       [bypass]    │
+│  ├─ Frequency: __________ Hz                        │
+│  ├─ Amount:    __________ %    [Activity indicator] │
+│                                                      │
+│  Block 4: Bass Enhancer                 [bypass]    │
+│  ├─ Split freq: __________ Hz                       │
+│  ├─ Amount:     __________ %    [Activity indicator]│
+│                                                      │
+│  Block 5: Reverb                        [bypass]    │
+│  ├─ Size:  __________ %                             │
+│  ├─ Decay: __________ ms        [Advanced ▶]        │
+│  ├─ Mix:   __________ % (Dry/Wet)                   │
+│                                                      │
+└─────────────────────────────────────────────────────┘
+```
+
+**Chain enable toggle (top-left):** Labeled `[✓ Chain]` or `[✓ Audio Voice Chain]`. When disabled, all blocks report "OFF" in the flow visualization but retain their settings.
+
+**Flow visualization (below header):** A single-line ordered diagram showing all 5 blocks' on/off status at a glance. Shows:
+- Block order left → right: `[MIC] → [EQ] → [Comp] → [Exciter] → [Bass] → [Rev] → [OUT]`.
+- Status indicator (small colored dot) per block: bright (`--accent` or `--ok`) for on, dim `--fg-4` for off.
+- Clicking a status indicator toggles that block's enable without opening its settings.
+
+**Preset dropdown (top-right):** Label "Presets" with a `▼` chevron. Opens a dropdown with predefined chains:
+- "Default" (all off, chain disabled)
+- "Podcast voice" (EQ + Compressor tuned for clarity, Exciter subtle, Bass/Reverb off)
+- "SSB contest" (light EQ, fast compressor, all others off)
+- "FT8 macro" (minimal coloration, light compression only)
+- "Custom" (shown when the operator edits away from a preset)
+
+Preset selection applies all block settings at once. Operator can then tweak and the label reverts to "Custom".
+
+**Persistence story:** Per the established server-authoritative pattern (from `project_drive_tune_persistence`), chain config persists to `zeus-prefs.db` via `RadioStateStore`. Browser fetches the saved config on connect; operator edits push via `/api/tx/audio-chain` (new endpoint, Phase 1). Preset library lives on the server.
+
+### 2.3 Per-block layout
+
+Each block is a collapsible card with header and body:
+
+#### Header
+```
+[✓ toggle]  Parametric EQ          [bypass]  [Advanced ▶]
+```
+
+- Left: checkbox toggle (enable/disable this block).
+- Center: block name (e.g. "Parametric EQ", "Compressor"). 12px `--font-sans` bold.
+- Right: two buttons:
+  - "Bypass" button: toggles per-block bypass independently of block enable. Styled as a small flat button; when active (bypass ON), shows `--tx` red background to indicate block is off.
+  - "Advanced ▶" disclosure button (if the block has secondary controls): right-chevron, 10px. Click to expand the Advanced section.
+
+#### Body: Parametric EQ (10 bands)
+
+Primary display: 10 rows, one per band (100 Hz, 200 Hz, 300 Hz, 500 Hz, 750 Hz, 1 kHz, 2 kHz, 3 kHz, 5 kHz, 8 kHz — standard modern voice frequencies).
+
+```
+Band 1 (100 Hz):   Gain [slider] dB    Q [input] ___
+Band 2 (200 Hz):   Gain [slider] dB    Q [input] ___
+...
+Band 10 (8 kHz):   Gain [slider] dB    Q [input] ___
+```
+
+- Gain: ±12 dB range, centered at 0 dB (flat). Label "Gain", unit "dB".
+- Q (quality factor): 0.5–4.0 range (broader to narrower), default 1.0. Label "Q", no unit (it's a ratio).
+- Gain slider takes up most width; Q is a smaller input box to the right (read numeric value, not a slider, for precision).
+
+**Open question for sign-off:** Should the v1 EQ expose a **graphical curve display** (showing all 10 band filters overlaid on a dB-vs-Hz graph)? This would be Phase 1 or Phase 2 work. For v1, the operator adjusts by ear (slider per band, no visualization). Recommend deferring the curve to Phase 1.
+
+#### Body: Compressor
+
+```
+Threshold: [slider]       dB
+Ratio:     [slider]       :1
+Attack:    [Advanced ▶]   ms
+Release:   [Advanced ▶]   ms
+Makeup gain: [Advanced ▶] dB
+
+GR Meter:  [████░░░░░░░░░░]  −2.4 dB
+```
+
+- Threshold: −60 to 0 dB range, default −18 dB. Label "Threshold", unit "dB".
+- Ratio: 1:1 to 8:1 range, default 3:1. Label "Ratio", unit ":1".
+- Attack: 10 ms to 1 s range, default 50 ms. Hidden in Advanced section.
+- Release: 50 ms to 2 s range, default 300 ms. Hidden in Advanced section.
+- Makeup gain: ±12 dB, default 0 dB (operated calculates from ratio on some plugins, but we expose it for operator override). Hidden in Advanced section.
+
+**Meter:** HBarMeter showing gain reduction in real-time. Label "GR" (gain reduction), readout in dB (0 dB = no GR, −X dB when compressing).
+
+#### Body: Exciter
+
+```
+Frequency: [slider]    Hz
+Amount:    [slider]    %
+
+[Activity: ● (green when active, gray when silent)]
+```
+
+- Frequency: 2 kHz to 12 kHz range, default 5 kHz. Controls the center of the harmonic boost. Label "Frequency", unit "Hz".
+- Amount: 0–100%, default 20%. Controls the intensity of the added harmonics. Label "Amount", unit "%".
+
+**Indicator:** Small activity LED. Green when the exciter is adding noticeable harmonic content (signal energy above the boost frequency); gray when silent or amount is 0.
+
+#### Body: Bass Enhancer
+
+```
+Split frequency: [slider]  Hz
+Amount:          [slider]  %
+
+[Activity: ● (green when synthesizing, gray when idle)]
+```
+
+- Split frequency: 40 Hz to 200 Hz range, default 100 Hz. The boundary below which psychoacoustic bass synthesis is applied. Label "Split freq", unit "Hz".
+- Amount: 0–100%, default 30%. Controls the intensity of synthesized bass harmonics. Label "Amount", unit "%".
+
+**Indicator:** Small activity LED. Green when the bass enhancer is synthesizing noticeable harmonics; gray when idle.
+
+**Design note:** The bass enhancer is conceptually hard to understand (Aphex 204 / MaxxBass synthesizes harmonics of low-frequency content, so the TX bandwidth can stay narrow while the operator *hears* bass). The UI should be minimal: two controls, one indicator. Avoid technical jargon in labels.
+
+#### Body: Reverb
+
+```
+Size:  [slider]     %
+Decay: [Advanced ▶] ms
+Mix:   [slider]     % (Dry/Wet)
+```
+
+- Size: 0–100%, default 30%. "Room size" in Freeverb terminology — larger = longer tail.
+- Decay: 0.5 s to 5 s range, default 2 s. Time for the reverb tail to decay to silence. Hidden in Advanced.
+- Mix (Dry/Wet): 0–100%, default 15% (subtle on TX, as convention). At 0%, reverb is off (signal is dry). At 100%, signal is fully wet (reverb only, no dry voice).
+
+**No preset selection** for reverb types (spring/plate/hall). In v1, the operator uses one reverb algorithm; presets are handled by the preset library (e.g. preset "Podcast voice" applies the full chain with reverb disabled).
+
+**Design note:** On TX, reverb is traditionally subtle (15–30% mix) to avoid sounding cavernous. Sensible default: Mix = 15%, Size = 30%, Decay = 2 s. Operator can increase if they want a dramatic effect, but the default shouldn't scare them.
+
+#### Advanced section (hidden by default)
+
+Example (Compressor Advanced):
+```
+┌─ Advanced ▼
+│  Attack:       [slider]  ms
+│  Release:      [slider]  ms
+│  Makeup gain:  [slider]  dB
+└─ (end Advanced section)
+```
+
+Styled identically to main controls but indented or in a sub-card with `--bg-2` background for visual grouping. Typography and spacing match the body section.
+
+---
+
+## 3. Integration: WDSP Insertion Point
+
+### 3.1 TX block-processing seam
+
+**Location:** `Zeus.Dsp/Wdsp/WdspDspEngine.cs`, method `ProcessTxBlock`, lines 2354–2369.
+
+Current code structure (simplified):
+```csharp
+// Line ~2354–2369: VST plugin-host seam
+if (_vstChainEnabled)
+{
+    ProcessTxMicVstChain(iin, inSize, _txaInputRateHz);  // mic buffer in-place mutation
+}
+
+NativeMethods.fexchange2(txa, ref iin[0], ref qin[0], ref iout[0], ref qout[0], out int err);
+// ... (TX-stage meters, monitor, analyzer follow)
+```
+
+**The WDSP call sequence at this seam:**
+
+1. **Input:** `iin` (float array, mono mic buffer, length `inSize`)
+   - Size depends on the radio profile: P1 = 1024 samples (48 kHz, ~21 ms), P2 = 2048 samples (96 kHz, ~21 ms).
+   - Sample rate: always 48 kHz for the mic input (`_txaInputRateHz` is the source-of-truth).
+   - Ownership: Zeus owns the buffer; audio-chain blocks are allowed to mutate in-place.
+
+2. **WDSP TXA processing:** `fexchange2(txa, &iin[0], &qin[0], &iout[0], &qout[0], &err)`
+   - Takes the mic buffer `iin`, IQ buffers `qin`, `iout`, `qout`.
+   - Internal WDSP stages (in order per TXA.c):
+     - Meter (MIC_PK, MIC_AV)
+     - Equalizer (if enabled)
+     - Leveler (xleveler, always enabled in Zeus)
+     - Compressor (if enabled; always off in shipped Zeus)
+     - CFC (Continuous Frequency Compressor, if enabled)
+     - Pre-distortion (if PureSignal enabled, P2 only)
+     - IQ output (CFIR re-sampling)
+   - Output: `iout`, `qout` (IQ complex samples, ready for TX modulation)
+
+### 3.2 Proposed integration hook signature
+
+**Placement:** Between VST host seam (line ~2364) and `fexchange2` call (line ~2371).
+
+```csharp
+// New audio-chain seam (line 2370, before fexchange2)
+if (_audioChainEnabled)
+{
+    ProcessAudioChain(iin, inSize, _txaInputRateHz);  // mic buffer in-place or new buffer
+}
+```
+
+**Hook signature (proposed):**
+```csharp
+private void ProcessAudioChain(
+    float[] iin,           // input: mono mic buffer (in-place mutation OK)
+    int frameCount,        // sample count in iin (typically 1024 for P1, 2048 for P2)
+    int sampleRateHz)      // 48000 (always, for mic input)
+```
+
+**Buffer semantics:**
+- Input buffer `iin` is shared with the caller (ProcessTxBlock). The chain MAY mutate it in-place.
+- No output buffer; the chain writes back to `iin` (same ownership as VST host).
+- Ownership remains with ProcessTxBlock; the chain does not allocate or free.
+- Thread-safety: called from the WDSP worker thread (inside `_txaLock`). The chain must not block or allocate on the TX path.
+
+### 3.3 Per-block processing order (v1) and wire contract
+
+The chain processes blocks in this order:
+
+```
+MIC input (48 kHz mono float32, frameCount samples)
+  ↓
+[1] Parametric EQ (10-band shelving + peaking)
+  ↓
+[2] Compressor (VCA-style ratio-based gain reduction)
+  ↓
+[3] Exciter (harmonic enhancement at selectable frequency)
+  ↓
+[4] Bass Enhancer (psychoacoustic synthesis of low-frequency harmonics)
+  ↓
+[5] Reverb (room simulation, subtle on TX)
+  ↓
+[Output to fexchange2 → TX modulation]
+```
+
+**Open question for sign-off:** Is this the canonical v1 block order? Should any blocks be reordered? For example, some engineers prefer Reverb before Compressor (so the compressor doesn't "hear" the reverb tail). Current proposal: EQ → Comp → Exciter → Bass → Reverb. Signal this is an open question if the order should differ.
+
+**Per-block contract:**
+- Each block receives a float buffer (either in-place or a work buffer).
+- Each block outputs the same buffer (mutated in-place).
+- No allocations per block, per frame. All per-block state (meters, coefficients, IIR history) is pre-allocated in the initializer.
+- Blocks are lockfree; no cross-block communication during audio processing.
+
+### 3.4 Meter & telemetry reporting
+
+Each block exposes read-only meters via an immutable snapshot:
+
+```csharp
+public struct AudioChainBlockMetrics
+{
+    public float InputLevel { get; }        // input level (dBFS)
+    public float OutputLevel { get; }       // output level (dBFS)
+    public float GainReduction { get; }     // for compressor (dB, ≤ 0)
+    public bool IsActive { get; }           // for exciter, bass, reverb (true when producing effect)
+}
+```
+
+Meters are sampled once per DSP tick and pushed to the frontend via SignalR (same pattern as existing TX Stage Meters). Sample rate: ~48 packets/sec (one per 21 ms block at P1).
+
+### 3.5 Thread-safety and CPU budget
+
+**Thread:** Runs on the WDSP worker thread inside `ProcessTxBlock`, under `_txaLock`. No cross-thread coordination needed; the chain is a single-threaded hot path.
+
+**CPU budget per block (v1 proposal):**
+- **EQ (10 bands):** 3–4% per tick (10 biquad IIR filters cascaded).
+- **Compressor:** 2–3% per tick (envelope follower + gain curve, makeup gain).
+- **Exciter:** 2–3% per tick (narrow bandpass filter on input, harmonic synthesizer).
+- **Bass Enhancer:** 3–4% per tick (psychoacoustic analysis, harmonic synthesis in low band).
+- **Reverb:** 6–8% per tick (Freeverb, largest per-block cost in v1).
+
+**Total budget (all 5 blocks, all on):** ~16–22% per tick, leaving headroom for WDSP's core TX path (CFC, leveler, CFIR resampling ≈ 15–20%), panadapter render (~5%), and radio protocol overhead.
+
+Real-world Zeus TX today runs ~14–34% single-core on a 12-core M-series Mac (from `project_drive_tune_persistence` telemetry). Adding the chain should push peak to ~35–45%, still well below saturation on modern systems.
+
+---
+
+## 4. Operator Workflow & First-Run Experience
+
+### 4.1 Discovery and initial setup
+
+**First time an operator opens Settings > TX Audio Tools:**
+- CFC panel is visible (always available, can be off).
+- Audio chain panel appears below it.
+- Chain is **disabled by default** (master toggle OFF).
+- All 5 blocks are visible in the flow visualization but disabled individually.
+
+**Operator flow (minimal friction):**
+1. Click the chain master toggle to enable.
+2. Preset dropdown defaults to "Default (all off)". Operator can pick "Podcast voice" or "SSB contest" for sensible starting point.
+3. Operator tunes the compressor threshold while monitoring the GR meter.
+4. Operator enables per-block bypass to compare "with chain" vs. "without."
+
+### 4.2 Sensible defaults (v1)
+
+When the chain is first enabled, all blocks start with neutral (no-effect) settings:
+- **EQ:** All 10 bands at 0 dB gain, Q = 1.0 (flat response).
+- **Compressor:** Ratio 3:1, Threshold −18 dB, Attack 50 ms, Release 300 ms, Makeup 0 dB (net effect: light to medium compression). GR meter reads 0 dB (idle).
+- **Exciter:** Frequency 5 kHz, Amount 0% (off, no effect). Activity LED gray.
+- **Bass Enhancer:** Split freq 100 Hz, Amount 0% (off). Activity LED gray.
+- **Reverb:** Size 30%, Decay 2 s, Mix 0% (off, all dry).
+
+This ensures the operator hears **zero audible change** on first enable (all blocks except compressor at neutral; compressor is light enough to be subtle). Presets then offer opinionated starting points:
+- "Podcast voice": EQ sculpted for clarity, compressor moderate, exciter subtle (30%), bass enhancer subtle (20%), reverb off.
+- "SSB contest": EQ minimal, compressor fast & tight, all others off.
+- "FT8 macro": light compression only, all others off.
+
+### 4.3 Persistence
+
+**Server-authoritative model** (established pattern in `project_drive_tune_persistence`):
+- Chain config (enabled, preset name, per-block settings, per-block bypass state) persists to `zeus-prefs.db` via the RadioStateStore.
+- Browser sends PUT requests to `/api/tx/audio-chain` with the full chain state.
+- On reconnect, browser fetches the saved config via `/api/tx/audio-chain` (GET) and renders the UI in the saved state.
+
+**Preset persistence:**
+- Preset library (names + block configs) also lives in `zeus-prefs.db`.
+- Operator can save the current chain state as a new named preset ("My SSB EQ", "Field day settings", etc.).
+- Presets are immutable once saved; editing reverts to "Custom" and allows the operator to save a new variant or overwrite a preset.
+
+### 4.4 A-B comparison affordance (bypass & quick toggle)
+
+**Per-block bypass:** Each block's header has a "Bypass" button. When active (highlighted in `--tx` red), the block is skipped on the audio path (input feeds directly to output, no processing). Independent of the block's enable toggle and allows quick A/B comparison during TX.
+
+Use case: Operator enables the compressor and monitors GR meter. To compare "with compression" vs. "without," they toggle the Bypass button repeatedly without losing settings.
+
+**Whole-chain bypass:** The main chain header also has a "Bypass" button. When active, all blocks are skipped (entire chain is pass-through). Allows flip between "pristine mic" and "processed mic" with one click.
+
+---
+
+## 5. CPU Budget Justification
+
+WDSP TXA fires at the radio sample rate. For the two common profiles:
+
+- **P1 (Protocol 1, 48 kHz):** 1024 frames per block ≈ 21 ms per tick.
+- **P2 (Protocol 2, 96 kHz):** 2048 frames per block ≈ 21 ms per tick.
+
+Existing Zeus TX pipeline (per 21 ms block):
+- WDSP TXA leveler + CFC: ~15–20% single-core CPU.
+- Mic input / output buffering: ~1%.
+- TCP egress (protocol push): ~2–3%.
+- Panadapter render + WebGL: ~5%.
+
+**Proposed v1 chain add-on budget:**
+- EQ (10 bands) + Compressor + Exciter + Bass Enhancer + Reverb: ~16–22% cumulative.
+
+**Total TX CPU post-chain:** ~40–48% single-core (worst case, all blocks active at once).
+
+On the test machine (12-core M3 Max Mac), baseline TX is 14–34% single-core. Adding the chain brings peak to ~40–48%, still **below saturation** on a modern multi-core system. Headroom remains for disk I/O, UI updates, and radio protocol housekeeping.
+
+If in-field telemetry later shows sustained > 80% single-core usage, blocks can be disabled by default (e.g., reverb off, bass enhancer off; EQ + comp on). The architecture supports this tuning without code changes.
+
+---
+
+## 6. Open Questions for Maintainer Sign-off
+
+> **Open question for sign-off:** Should the audio-chain panel be **collapsible (accordion) within TxAudioToolsPanel**, or a **separate scrollable section** below CFC? The current proposal assumes separate section (better mobile responsiveness, less nesting). If Brian prefers accordion (fewer visual sections), I can revise the layout sketch accordingly.
+
+> **Open question for sign-off:** The flow visualization (line diagram of 5 blocks with on/off indicators) is a novel UI pattern in Zeus. Is this the right level of abstraction? Alternative: hide the flow diagram by default and only show it on hover (less visual clutter, more detail on demand). Or: replace it with a simple "X blocks active" counter badge?
+
+> **Open question for sign-off:** Should the **Parametric EQ expose a graphical curve display** (all 10 band filters overlaid on a dB-vs-Hz graph)? This would be Phase 1 or Phase 2 work. For v1, the operator adjusts by ear (slider per band, no visualization). Recommend deferring the curve to Phase 1 or Phase 2 based on operator feedback.
+
+> **Open question for sign-off:** Per-band **Q factor (quality) in the EQ** — should operators edit it (current proposal), or should it be fixed per band for simplicity? Recommend allowing operator tuning (more flexibility, matches modern EQ UX), but confirm with Brian.
+
+> **Open question for sign-off:** The v1 block order: **EQ → Comp → Exciter → Bass → Reverb.** Should any blocks be reordered? For example, some engineers prefer Reverb before Compressor (so the compressor doesn't "hear" the reverb tail). Is the proposed order sensible for voice TX?
+
+> **Open question for sign-off:** Preset persistence: should presets be **per-band** (one set of presets shared across all bands, applied to whatever is selected) or **per-band-stashed** (band A has "SSB contesting", band B has "FT8 macro", each band remembers its own preset)? Current proposal is per-band-stashed (more flexible). Confirm with Brian.
+
+> **Open question for sign-off:** The bass enhancer is conceptually hard to understand (Aphex 204 / MaxxBass). Should we add a brief tooltip or blurb explaining what it does (e.g. "Synthesizes low-frequency harmonics for perceived bass without transmitting extreme lows")? Or keep the UI minimal (2 controls, 1 indicator) and rely on presets to demonstrate the effect?
+
+> **Open question for sign-off:** UI color for the exciter / bass enhancer activity indicators — should they use `--ok` (green, "effect is active") or something more neutral? The red `--tx` is wrong (that's "transmitting", not "activity"). Current proposal: `--ok` green when active, `--fg-4` dark gray when idle. Confirm with Brian.
+
+---
+
+## 7. Design System Compliance
+
+All colors reference `tokens.css` variables. No raw hex.
+
+All fonts: `--font-sans` (Inter) for UI, `--font-mono` (JetBrains Mono) for numerics. Per PR #327.
+
+All spacing: 8px or 12px grid. No arbitrary padding.
+
+All controls: use existing patterns (sliders, toggles, buttons) from CFC and DspPanel.
+
+Meter styling: reuse `HBarMeter` from the immersive-meters package. Same fill gradient (good → warn → tx) and LED segment lines as TX Stage Meters.
+
+---
+
+## Summary
+
+The v1 audio voice chain (5 blocks: Parametric EQ, Compressor, Exciter, Bass Enhancer, Reverb) slots into Zeus's existing TX Audio Tools tab as a collapsible section with a master enable toggle and a flow visualization showing all five blocks' on/off status. Each block is a card with primary controls, optional meters (HBarMeter for compressor GR, activity LEDs for exciter/bass), and an Advanced disclosure for secondary settings. Presets ("Podcast voice", "SSB contest", "FT8 macro") allow one-click setup with sensible defaults.
+
+The integration point in `WdspDspEngine.ProcessTxBlock` is between the VST host seam and the WDSP `fexchange2` call. The chain processes a single 48 kHz mono float buffer in-place, respecting the same buffer ownership and thread-safety constraints as the existing VST host. Per-block CPU budget totals ~16–22% per 21 ms tick (worst case, all on), leaving headroom in the current 14–34% TX baseline.
+
+All visual design defers to existing tokens and established panel vocabulary (CFC, DspPanel). No new colors, fonts, or layout patterns are introduced. Six open questions are flagged for Brian's sign-off: accordion vs. section layout, flow diagram prominence, EQ graphical curve display timing, block order, preset stashing strategy, and bass enhancer UI explanation.
+


### PR DESCRIPTION
Closes Phase 0 of #332. **Docs-only — no code.** Green-light per CLAUDE.md (additions under \`docs/proposals/\`, no architecture/protocol/UI/defaults change).

## What's in this PR

| File | Lines | What |
|---|---|---|
| \`docs/proposals/audio-chain-phase0.md\` | 169 | Master PRD — what's locked, what needs sign-off |
| \`docs/proposals/audio-chain/01-aethersdr-and-external-deps.md\` | 962 | AetherSDR chain analysis, GPL-2/GPL-3 license posture, per-block external-dep evaluation |
| \`docs/proposals/audio-chain/02-wdsp-gap-analysis.md\` | 304 | REUSE / HAND-AUTHOR / EXTERNAL-DEP scoping per v1 block |
| \`docs/proposals/audio-chain/03-ux-and-integration.md\` | 498 | Chain-panel UX, CPU budget, integration with \`WdspDspEngine\` |

## v1 chain — KB2UKA-locked

Five blocks, each shipped as a separate **Zeus-native** registry plugin (implementing \`IAudioPlugin\` per \`Zeus.Plugins.Contracts\`):

1. **8-10 band parametric EQ**
2. **Compressor**
3. **Exciter**
4. **Bass enhancer** (Aphex 204 / MaxxBass Family-B psychoacoustic synthesis)
5. **Reverb**

Insertion seam is the \`AudioPluginBridge\` tap on \`WdspDspEngine.ProcessTxBlock\` that PR #368 shipped — bit-identical passthrough when no audio plugins loaded.

## Headline finding

**AetherSDR's \"Big Bottom\" is Family A (Aphex 204 dynamic-EQ + saturation), NOT Family B (MaxxBass missing-fundamental).** On an HF antenna that can't radiate sub-100 Hz efficiently, Family B is the correct call. **Bankstown** ([github.com/chadmed/bankstown](https://github.com/chadmed/bankstown), MIT, ~150 Rust lines) is the only license-clean public Family B implementation — portable to managed C# in a day. Zeus would become the first HPSDR client to ship this technique.

## Authority

Per [\`feedback_audio_plugin_authority\`](https://github.com/Kb2uka/openhpsdr-zeus): KB2UKA decides audio-chain content (block choices, algorithm picks, defaults); Brian decides plugin-system architecture (contracts, loader, VST3 bridge). The ten open questions in the master PRD are split accordingly.

## Out of scope (explicit)

- VST3 third-party plugin support — VST host queued for removal per #332 Phase 7, not extracted-and-kept per Brian's separate proposal (alignment with Brian needed before VST code starts getting deleted)
- RX-side audio plugins — all five v1 blocks are TX-only
- Block presets library — Phase 1.6+
- EQ curve display, operator-tunable CPU budget — Phase 2+

## What's next

When this PR merges, Phase 0 is closed. **Phase 1 begins when KB2UKA signs off on the ten open questions in the master PRD.** Recommended Phase 1 entry: **Compressor first** — simplest algorithm, fastest path to validating the full registry-plugin pipeline (build → package → install → load → process → meter → persist) before tackling the harder blocks.

## Test plan

- [x] No source files touched — pure markdown additions.
- [ ] CI green on this PR.