### PR TITLE
feat(plugins): frontend plugin runtime + fix host route-mapping race

### DIFF
--- a/Zeus.Plugins.Contracts/PluginManifest.cs
+++ b/Zeus.Plugins.Contracts/PluginManifest.cs
@@ -127,6 +127,16 @@ public sealed record PanelContribution
     /// </summary>
     [JsonPropertyName("slot")]
     public required string Slot { get; init; }
+
+    /// <summary>
+    /// Add Panel modal category the panel appears under. Known values
+    /// mirror the built-in PanelCategory enum in zeus-web/panels.ts
+    /// (spectrum / vfo / meters / dsp / log / tools / amplifiers /
+    /// controls / switches / plugins). Defaults to "plugins" when
+    /// omitted so legacy manifests keep working.
+    /// </summary>
+    [JsonPropertyName("category")]
+    public string Category { get; init; } = "plugins";
 }
 
 public sealed record AudioBlock

--- a/Zeus.Plugins.Host/PluginEndpoints.cs
+++ b/Zeus.Plugins.Host/PluginEndpoints.cs
@@ -89,6 +89,44 @@ public static class PluginEndpoints
             }
         });
 
+        // Static UI module files. Plugins ship ES modules under
+        // <PluginRoot>/<id>/ui/<file>.js; the frontend dynamic-imports
+        // them via this route to register panels with the workspace.
+        app.MapGet("/api/plugins/{id}/ui/{*path}", (string id, string path, HttpContext http) =>
+        {
+            var p = manager.Find(id);
+            if (p is null) return Results.NotFound();
+
+            // Dev iteration aid: re-installs swap the file on disk; without
+            // no-cache headers the browser holds the previous module forever
+            // since the URL is stable. Production hosting can fingerprint
+            // these later if needed.
+            http.Response.Headers["Cache-Control"] = "no-store, no-cache, must-revalidate";
+            http.Response.Headers["Pragma"] = "no-cache";
+
+            var pluginDir = Path.Combine(PluginRoot.Get(), id);
+            var uiDir = Path.GetFullPath(Path.Combine(pluginDir, "ui"));
+            var fullPath = Path.GetFullPath(Path.Combine(uiDir, path));
+
+            // Guard against `../` traversal.
+            if (!fullPath.StartsWith(uiDir + Path.DirectorySeparatorChar, StringComparison.Ordinal)
+                && fullPath != uiDir)
+                return Results.NotFound();
+
+            if (!File.Exists(fullPath)) return Results.NotFound();
+
+            var contentType = Path.GetExtension(fullPath).ToLowerInvariant() switch
+            {
+                ".js"   => "application/javascript",
+                ".mjs"  => "application/javascript",
+                ".css"  => "text/css",
+                ".json" => "application/json",
+                ".map"  => "application/json",
+                _        => "application/octet-stream",
+            };
+            return Results.File(fullPath, contentType);
+        });
+
         // Per-plugin endpoints from IBackendPlugin
         foreach (var p in manager.Active)
         {
@@ -139,6 +177,7 @@ public static class PluginEndpoints
                 Title = panel.Title,
                 Icon = panel.Icon,
                 Slot = panel.Slot,
+                Category = panel.Category,
             }).ToArray(),
         },
         Audio = p.Loaded.Manifest.Audio is { } a ? new PluginAudioDto
@@ -184,6 +223,7 @@ public sealed record PluginPanelDto
     public string Title { get; init; } = "";
     public string Icon { get; init; } = "";
     public string Slot { get; init; } = "";
+    public string Category { get; init; } = "plugins";
 }
 
 public sealed record PluginAudioDto

--- a/Zeus.Plugins.Host/PluginManager.cs
+++ b/Zeus.Plugins.Host/PluginManager.cs
@@ -21,6 +21,7 @@ public sealed class PluginManager : IHostedService, IAsyncDisposable
     private readonly PluginManagerOptions _options;
 
     private readonly ConcurrentDictionary<string, ActivatedPlugin> _active = new();
+    private int _started; // 0 = pending, 1 = StartAsync ran
 
     public PluginManager(
         PluginLoader loader,
@@ -58,6 +59,14 @@ public sealed class PluginManager : IHostedService, IAsyncDisposable
 
     public async Task StartAsync(CancellationToken ct)
     {
+        // StartAsync may be invoked manually before app.Run() so that
+        // PluginEndpoints.MapAll sees an already-populated Active set;
+        // the hosted-service path then re-invokes it. Guard against the
+        // second call, otherwise activated plugins would be torn down
+        // and replaced — invalidating any backend-route closures that
+        // captured the first instance.
+        if (Interlocked.Exchange(ref _started, 1) == 1) return;
+
         if (_options.SafeMode)
         {
             _log.LogWarning("Plugin safe mode enabled — skipping plugin discovery.");

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -398,8 +398,15 @@ public static class ZeusHost
         }
 
         app.MapZeusEndpoints();
-        Zeus.Plugins.Host.PluginEndpoints.MapAll(app,
-            app.Services.GetRequiredService<Zeus.Plugins.Host.PluginManager>());
+        // PluginEndpoints.MapAll iterates manager.Active to wire each
+        // IBackendPlugin's MapEndpoints into the route table. The hosted-
+        // service StartAsync fires later (during app.Run), so we have to
+        // activate plugins synchronously here or their routes never land.
+        // ActivateAsync is idempotent per id, so the runtime's StartAsync
+        // call below is a no-op.
+        var pluginManager = app.Services.GetRequiredService<Zeus.Plugins.Host.PluginManager>();
+        pluginManager.StartAsync(default).GetAwaiter().GetResult();
+        Zeus.Plugins.Host.PluginEndpoints.MapAll(app, pluginManager);
 
         // Optional startup banner — service mode prints to its console window
         // (operator-facing UI), desktop mode hides the console and skips this.

--- a/zeus-web/index.html
+++ b/zeus-web/index.html
@@ -14,6 +14,19 @@
       href="https://fonts.googleapis.com/css2?family=Archivo+Narrow:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
+    <!-- Import map for plugin ES modules. Plugins bundle their own JSX
+         runtime but external-ise `react` / `react/jsx-runtime`; the
+         browser resolves those bare specifiers through this map to
+         host-served shims that re-export from window.__zeus, so plugin
+         and host share one React instance (required for hooks). -->
+    <script type="importmap">
+      {
+        "imports": {
+          "react": "/zeus-sdk/react.js",
+          "react/jsx-runtime": "/zeus-sdk/react-jsx-runtime.js"
+        }
+      }
+    </script>
   </head>
   <body style="height:100%;margin:0">
     <div id="root" style="height:100%"></div>

--- a/zeus-web/public/zeus-sdk/react-jsx-runtime.js
+++ b/zeus-web/public/zeus-sdk/react-jsx-runtime.js
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// react/jsx-runtime shim — see ./react.js for rationale. Some plugin
+// builds emit `import { jsx as _jsx } from 'react/jsx-runtime'` instead
+// of inlining the runtime. Map to host's runtime so JSX produces
+// elements compatible with the host's React reconciler.
+
+const JR = window.__zeus?.ReactJsxRuntime;
+if (!JR) {
+  throw new Error('zeus-sdk/react-jsx-runtime: window.__zeus.ReactJsxRuntime not initialised');
+}
+
+export const jsx = JR.jsx;
+export const jsxs = JR.jsxs;
+export const jsxDEV = JR.jsxDEV;
+export const Fragment = JR.Fragment;

--- a/zeus-web/public/zeus-sdk/react.js
+++ b/zeus-web/public/zeus-sdk/react.js
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// React shim for plugin ES modules. The plugin's bundle imports `react`
+// as a bare specifier; the browser can't resolve that at runtime, so
+// the host index.html declares an import map mapping `react` to this
+// file. Re-exports from window.__zeus.React (set in main.tsx) so plugin
+// and host share a single React instance — required for hooks to work
+// (ReactCurrentDispatcher is module-local).
+
+const R = window.__zeus?.React;
+if (!R) {
+  throw new Error('zeus-sdk/react: window.__zeus.React not initialised yet — plugin loaded before host?');
+}
+
+export default R;
+
+export const Children = R.Children;
+export const Component = R.Component;
+export const Fragment = R.Fragment;
+export const Profiler = R.Profiler;
+export const PureComponent = R.PureComponent;
+export const StrictMode = R.StrictMode;
+export const Suspense = R.Suspense;
+export const cloneElement = R.cloneElement;
+export const createContext = R.createContext;
+export const createElement = R.createElement;
+export const createRef = R.createRef;
+export const forwardRef = R.forwardRef;
+export const isValidElement = R.isValidElement;
+export const lazy = R.lazy;
+export const memo = R.memo;
+export const startTransition = R.startTransition;
+export const useCallback = R.useCallback;
+export const useContext = R.useContext;
+export const useDebugValue = R.useDebugValue;
+export const useDeferredValue = R.useDeferredValue;
+export const useEffect = R.useEffect;
+export const useId = R.useId;
+export const useImperativeHandle = R.useImperativeHandle;
+export const useInsertionEffect = R.useInsertionEffect;
+export const useLayoutEffect = R.useLayoutEffect;
+export const useMemo = R.useMemo;
+export const useReducer = R.useReducer;
+export const useRef = R.useRef;
+export const useState = R.useState;
+export const useSyncExternalStore = R.useSyncExternalStore;
+export const useTransition = R.useTransition;
+export const version = R.version;

--- a/zeus-web/src/layout/AddPanelModal.tsx
+++ b/zeus-web/src/layout/AddPanelModal.tsx
@@ -15,11 +15,12 @@
 
 import { useState } from 'react';
 import {
-  PANELS,
+  getAllPanels,
   PANEL_CATEGORIES,
   PANEL_CATEGORY_LABELS,
   type PanelCategory,
 } from './panels';
+import { usePluginPanels } from '../plugins/runtime/usePluginPanels';
 
 interface AddPanelModalProps {
   /** Set of panelIds currently in the workspace (one entry per id, regardless
@@ -36,8 +37,12 @@ export function AddPanelModal({ existingPanels, onAdd, onClose }: AddPanelModalP
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedCategory, setSelectedCategory] =
     useState<CategoryFilter>('all');
+  // Subscribe to plugin runtime so the picker re-renders when plugin
+  // panels load (or change after install/uninstall). Return value is
+  // unused — getAllPanels() reads the same registry directly.
+  usePluginPanels();
 
-  const availablePanels = Object.values(PANELS).filter((panel) => {
+  const availablePanels = getAllPanels().filter((panel) => {
     // Single-instance panels disappear from the list once added; multi-
     // instance panels stay visible (the badge changes to "+ Add another").
     if (existingPanels.has(panel.id) && !panel.multiInstance) return false;

--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -26,7 +26,8 @@ import {
 import { absoluteStrategy } from 'react-grid-layout/core';
 import { useWorkspace } from './WorkspaceContext';
 import { useLayoutStore } from '../state/layout-store';
-import { PANELS } from './panels';
+import { getPanelDef } from './panels';
+import { usePluginPanels } from '../plugins/runtime/usePluginPanels';
 import {
   WORKSPACE_GRID_COLS,
   WORKSPACE_ROW_HEIGHT_MIN_PX,
@@ -137,6 +138,10 @@ function WorkspaceCanvas({
   // measurement. mounted=false on first paint to avoid the 1280-px width
   // flash before the observer fires. Same pattern MetersCanvas uses.
   const { width, containerRef, mounted } = useContainerWidth();
+  // Subscribe to plugin-registered panels so rglLayouts recomputes once
+  // plugin modules load at startup (getPanelDef inside the useMemo would
+  // otherwise return undefined and never re-resolve).
+  const pluginPanels = usePluginPanels();
   // Track container height so rowHeight can scale with the viewport — this
   // is what gives panels their "anchor: bottom" feel: hero (h=18) fills the
   // available vertical space, right-column tiles distribute proportionally,
@@ -173,7 +178,7 @@ function WorkspaceCanvas({
   const rglLayouts = useMemo(
     () => ({
       lg: tiles.map((t) => {
-        const def = PANELS[t.panelId];
+        const def = getPanelDef(t.panelId);
         return {
           i: t.uid,
           x: t.x,
@@ -187,7 +192,7 @@ function WorkspaceCanvas({
         };
       }),
     }),
-    [tiles],
+    [tiles, pluginPanels],
   );
 
   return (
@@ -258,7 +263,7 @@ const PanelTile = memo(function PanelTile({
     () => onRemoveTile(tile.uid),
     [onRemoveTile, tile.uid],
   );
-  const def = PANELS[tile.panelId];
+  const def = getPanelDef(tile.panelId);
   if (!def) return null;
   // Headerless panels own their entire tile surface and draw their own
   // header (if any). They MUST include an element with class
@@ -293,7 +298,7 @@ function PanelBody({
   if (tile.panelId === 'metergroup') {
     return <MeterGroupTileBody tile={tile} onRemove={onRemove} />;
   }
-  const def = PANELS[tile.panelId];
+  const def = getPanelDef(tile.panelId);
   if (!def) return null;
   const Component = def.component;
   // Headerless single-instance panels that own their own header receive

--- a/zeus-web/src/layout/panels.ts
+++ b/zeus-web/src/layout/panels.ts
@@ -71,7 +71,9 @@ export type PanelCategory =
   | 'log'
   | 'tools'
   | 'amplifiers'
-  | 'controls';
+  | 'controls'
+  | 'switches'
+  | 'plugins';
 
 /** Human-friendly category labels for the Add Panel modal's left rail. The
  *  rail shows these in a fixed order; "All" is rendered separately as a
@@ -85,6 +87,8 @@ export const PANEL_CATEGORIES: ReadonlyArray<PanelCategory> = [
   'tools',
   'amplifiers',
   'controls',
+  'switches',
+  'plugins',
 ];
 export const PANEL_CATEGORY_LABELS: Record<PanelCategory, string> = {
   spectrum: 'Spectrum',
@@ -95,7 +99,11 @@ export const PANEL_CATEGORY_LABELS: Record<PanelCategory, string> = {
   tools: 'Tools',
   amplifiers: 'Amplifiers',
   controls: 'Controls',
+  switches: 'Switches',
+  plugins: 'Plugins',
 };
+
+const VALID_PANEL_CATEGORIES = new Set<string>(PANEL_CATEGORIES);
 
 /** Most panels render with no props — the workspace tile renders them as
  *  `<def.component />`. Multi-instance panels with per-instance config
@@ -291,4 +299,37 @@ export const PANELS: Record<string, PanelDef> = {
     headerless: true,
   },
 };
+
+// Plugin-contributed panels. Loaded at app startup by pluginRuntime; the
+// workspace and AddPanelModal go through these helpers instead of reading
+// PANELS directly so plugin panels show up in both surfaces.
+
+import { listRegisteredPanels } from '../plugins/runtime/pluginRuntime';
+
+function pluginPanelDef(p: import('../plugins/runtime/pluginRuntime').RegisteredPluginPanel): PanelDef {
+  const category = (VALID_PANEL_CATEGORIES.has(p.category)
+    ? p.category
+    : 'plugins') as PanelCategory;
+  return {
+    id: p.panelId,
+    name: p.title,
+    category,
+    tags: ['plugin', p.pluginId],
+    component: p.component as ComponentType<PanelComponentProps>,
+  };
+}
+
+export function getPanelDef(id: string): PanelDef | undefined {
+  const builtIn = PANELS[id];
+  if (builtIn) return builtIn;
+  const plugin = listRegisteredPanels().find((p) => p.panelId === id);
+  return plugin ? pluginPanelDef(plugin) : undefined;
+}
+
+export function getAllPanels(): PanelDef[] {
+  return [
+    ...Object.values(PANELS),
+    ...listRegisteredPanels().map(pluginPanelDef),
+  ];
+}
 

--- a/zeus-web/src/main.tsx
+++ b/zeus-web/src/main.tsx
@@ -43,7 +43,30 @@
 // License for details.
 
 import { StrictMode } from 'react';
+import * as React from 'react';
+import * as ReactJsxRuntime from 'react/jsx-runtime';
 import { createRoot } from 'react-dom/client';
+
+// Plugins import `react` and `react/jsx-runtime` as bare specifiers; the
+// import map in index.html points them at /zeus-sdk/{react,react-jsx-runtime}.js
+// which read from these globals. Has to happen before any plugin module
+// loads — set it synchronously here, before installFetchInterceptor and
+// loadInstalledPluginUis.
+(window as unknown as { __zeus: { React: typeof React; ReactJsxRuntime: typeof ReactJsxRuntime } }).__zeus = {
+  React,
+  ReactJsxRuntime,
+};
+
+// Plugin bundles built with Vite often retain `process.env.NODE_ENV`
+// references (React's dev/prod detection) even when react is externalised.
+// Browser has no `process`, so shim it minimally — this is what every
+// "browser process polyfill" does. Production-only flag avoids React's
+// dev-time invariants firing in plugin code.
+if (typeof (window as unknown as { process?: unknown }).process === 'undefined') {
+  (window as unknown as { process: { env: Record<string, string> } }).process = {
+    env: { NODE_ENV: 'production' },
+  };
+}
 // PERF_PASS_3_DEBUG: expose tx-store + audio client on window so playwright
 // can drive MOX edges from synthetic mode (no radio = no MOX button).
 // Uncommitted local edit; stash before merge.
@@ -63,10 +86,16 @@ import './styles/pa-settings.css';
 import './styles/analog-meter.css';
 import App from './App.tsx';
 import { installFetchInterceptor } from './serverUrl';
+import { loadInstalledPluginUis } from './plugins/runtime/pluginRuntime';
 
 // Capacitor / standalone-host builds set localStorage["zeus.serverUrl"]
 // to a LAN address; on plain web this is a no-op (relative paths).
 installFetchInterceptor();
+
+// Fire and forget — plugin UIs join the workspace once their ES modules
+// finish loading. The Add Panel modal subscribes via usePluginPanels()
+// and re-renders when entries land.
+void loadInstalledPluginUis();
 
 // Seed the operator's chosen theme on <html> BEFORE React paints. The
 // ThemeApplier component reapplies on store changes; this just prevents

--- a/zeus-web/src/plugins/api/plugins.ts
+++ b/zeus-web/src/plugins/api/plugins.ts
@@ -27,6 +27,8 @@ export type PluginPanelDto = {
   title: string;
   icon: string;
   slot: string;
+  /** Add Panel modal category — see PanelCategory in layout/panels.ts. */
+  category: string;
 };
 
 export type PluginUiDto = {
@@ -132,6 +134,7 @@ function parsePanel(raw: unknown): PluginPanelDto {
     title: asString(o.title),
     icon: asString(o.icon),
     slot: asString(o.slot),
+    category: asString(o.category, 'plugins'),
   };
 }
 

--- a/zeus-web/src/plugins/runtime/pluginRuntime.ts
+++ b/zeus-web/src/plugins/runtime/pluginRuntime.ts
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Runtime that loads installed-plugin UI modules at app startup. The
+// host serves each module at /api/plugins/{id}/ui/{file}; we
+// dynamic-import them, hand the module's default export a small API
+// surface (registerPanel + callBackend), and capture every panel the
+// plugin registers so it can show up in the workspace Add Panel modal.
+
+import type { ComponentType } from 'react';
+import { fetchInstalledPlugins, type PluginDto, type PluginPanelDto } from '../api/plugins';
+
+export interface ZeusPluginApi {
+  registerPanel(spec: { id: string; component: ComponentType }): void;
+  callBackend(method: string, path: string, body?: unknown): Promise<Response>;
+}
+
+export interface RegisteredPluginPanel {
+  panelId: string;
+  pluginId: string;
+  title: string;
+  icon: string;
+  category: string;
+  component: ComponentType;
+}
+
+type PluginModule = {
+  default?: (api: ZeusPluginApi) => void;
+};
+
+const registered = new Map<string, RegisteredPluginPanel>();
+const listeners = new Set<() => void>();
+let loaded = false;
+let loading: Promise<void> | null = null;
+
+function emit() {
+  for (const fn of listeners) fn();
+}
+
+function makeApi(plugin: PluginDto, registerPanel: (spec: { id: string; component: ComponentType }) => void): ZeusPluginApi {
+  return {
+    registerPanel,
+    callBackend(method, path, body) {
+      const url = `/api/plugins/${encodeURIComponent(plugin.id)}${path.startsWith('/') ? path : '/' + path}`;
+      const init: RequestInit = { method };
+      if (body !== undefined) {
+        init.headers = { 'content-type': 'application/json' };
+        init.body = JSON.stringify(body);
+      }
+      return fetch(url, init);
+    },
+  };
+}
+
+async function loadOne(plugin: PluginDto): Promise<void> {
+  if (!plugin.ui || plugin.ui.modules.length === 0) return;
+
+  const panelMetaById = new Map<string, PluginPanelDto>();
+  for (const p of plugin.ui.panels) panelMetaById.set(p.id, p);
+
+  const captured = new Map<string, ComponentType>();
+  const register = (spec: { id: string; component: ComponentType }) => {
+    captured.set(spec.id, spec.component);
+  };
+  const api = makeApi(plugin, register);
+
+  for (const modulePath of plugin.ui.modules) {
+    const url = `/api/plugins/${encodeURIComponent(plugin.id)}/${modulePath.replace(/^\/+/, '')}`;
+    try {
+      const mod = (await import(/* @vite-ignore */ url)) as PluginModule;
+      if (typeof mod.default === 'function') {
+        mod.default(api);
+      } else {
+        console.warn(`[plugin/${plugin.id}] module ${modulePath} has no default export`);
+      }
+    } catch (err) {
+      console.error(`[plugin/${plugin.id}] failed to load ${modulePath}`, err);
+    }
+  }
+
+  for (const [panelId, component] of captured) {
+    const meta = panelMetaById.get(panelId);
+    if (!meta) {
+      console.warn(`[plugin/${plugin.id}] registered panel '${panelId}' not declared in manifest`);
+      continue;
+    }
+    registered.set(`${plugin.id}::${panelId}`, {
+      panelId,
+      pluginId: plugin.id,
+      title: meta.title,
+      icon: meta.icon,
+      category: meta.category,
+      component,
+    });
+  }
+}
+
+export async function loadInstalledPluginUis(): Promise<void> {
+  if (loading) return loading;
+  loading = (async () => {
+    const list = await fetchInstalledPlugins();
+    await Promise.all(list.plugins.map(loadOne));
+    loaded = true;
+    emit();
+  })();
+  return loading;
+}
+
+export function listRegisteredPanels(): RegisteredPluginPanel[] {
+  return Array.from(registered.values());
+}
+
+export function isLoaded(): boolean {
+  return loaded;
+}
+
+export function subscribe(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}

--- a/zeus-web/src/plugins/runtime/usePluginPanels.ts
+++ b/zeus-web/src/plugins/runtime/usePluginPanels.ts
@@ -1,0 +1,8 @@
+import { useEffect, useState } from 'react';
+import { listRegisteredPanels, subscribe, type RegisteredPluginPanel } from './pluginRuntime';
+
+export function usePluginPanels(): RegisteredPluginPanel[] {
+  const [panels, setPanels] = useState<RegisteredPluginPanel[]>(() => listRegisteredPanels());
+  useEffect(() => subscribe(() => setPanels(listRegisteredPanels())), []);
+  return panels;
+}


### PR DESCRIPTION
## Summary

Lands the frontend half of the plugin system v2 (Add Panel modal sees plugin-contributed panels; workspace renders them; HTTP `callBackend` works) and fixes two backend bugs that block any `IBackendPlugin` from being reachable.

Verified end-to-end against the [4O3A Antenna Genius plugin](https://github.com/Kb2uka/openhpsdr-zeus-plugins/pull/2): UDP discovery on 9007, live SwitchAroo status polled at 1 Hz, A/B antenna selection round-trips through `POST /api/plugins/{id}/select-antenna`.

## What landed

**Backend route-mapping race (fixed):**
- `ZeusHost.cs` was calling `PluginEndpoints.MapAll` *before* the hosted-service `PluginManager.StartAsync` had populated `manager.Active`, so the `foreach (var p in manager.Active)` that wires each `IBackendPlugin.MapEndpoints` iterated an empty list.
- Fix: manually `pluginManager.StartAsync(default).GetAwaiter().GetResult()` before `MapAll`. Guarded `PluginManager.StartAsync` with an `Interlocked` single-shot flag so the hosted-service re-invocation is a no-op — otherwise the second activation would tear down the first instance and invalidate route closures that captured it.

**Plugin UI static files served from `<PluginRoot>/<id>/ui/`:**
- New `GET /api/plugins/{id}/ui/{*path}` route. Path-traversal guarded (resolves against `Path.GetFullPath` and verifies `StartsWith(uiDir)`). No-cache headers so dev reinstall iterations pick up fresh bundles.

**Plugin-declared panel category:**
- `PanelContribution.Category` field on the manifest record (mirrored to `PluginPanelDto`). Plugins pick which Add Panel category they live under; defaults to `\"plugins\"`. The frontend's `PanelCategory` gains a `\"switches\"` member; new categories can be added as needed.

**Frontend plugin runtime (new):**
- `zeus-web/src/plugins/runtime/pluginRuntime.ts` — fetches `/api/plugins`, dynamic-imports each plugin's UI module, builds a small `ZeusPluginApi` (`registerPanel`, `callBackend(method, path, body?)`), calls the module's default export, captures registered components keyed by panel id. Pub/sub for re-render. `usePluginPanels` hook.
- `loadInstalledPluginUis()` fires at boot from `main.tsx`.

**React shim for plugin ES modules:**
- Plugin bundles built with Vite typically `external: ['react']` — they emit bare `import 'react'` which the browser can't resolve at runtime.
- New import map in `index.html` points `react` and `react/jsx-runtime` at `/zeus-sdk/{react,react-jsx-runtime}.js` (in `public/`). The shims re-export from `window.__zeus.{React, ReactJsxRuntime}` set synchronously in `main.tsx`.
- One React instance shared host↔plugin → hooks work (ReactCurrentDispatcher is module-local).
- `main.tsx` also adds a minimal `globalThis.process = { env: { NODE_ENV: 'production' } }` polyfill so Vite-built plugin bundles that retain `process.env.NODE_ENV` references don't crash on evaluation.

**Workspace integration:**
- `panels.ts` exposes `getPanelDef(id)` and `getAllPanels()` that merge built-in `PANELS` with the live plugin registry.
- `FlexWorkspace` and `AddPanelModal` switched off direct `PANELS[id]` lookups onto the merged helpers; both subscribe to `pluginRuntime` so plugin panels appear once modules finish loading.

## Test plan

- [x] `dotnet build Zeus.slnx` clean
- [x] `npm --prefix zeus-web run build` clean
- [x] Install AntennaGenius plugin via `POST /api/plugins/install` (file source)
- [x] Backend: `GET /api/plugins/{id}/status` returns live device state (200, populated)
- [x] Backend: `GET /api/plugins/{id}/ui/antennagenius.es.js` serves with `Cache-Control: no-store`
- [x] Frontend: plugin module dynamic-imports cleanly via import map shim (zero console errors)
- [x] Frontend: panel appears in **Add Panel → Switches**
- [x] Frontend: dropping the panel into the workspace renders the AG widget; status polling and `POST /select-antenna` work
- [ ] Existing plugin host tests still pass — `dotnet test tests/Zeus.Plugins.Host.Tests/` (run before merge)

## Notes for review

- The plugin-system docs (`docs/plugins/author-guide.md`) describe the end state of this contract but didn't have a frontend runtime to back the "register a panel" claim. After this lands the author guide matches behaviour.
- The host's plugin manifest schema gains an optional `ui.panels[].category` field. The plugin registry's `manifest.schema.json` in `Kb2uka/openhpsdr-zeus-plugins` should be updated to allow this — separate PR there.
- React-version compatibility: plugin bundles must build against the host's React (currently 19). React 18 bundles fail because the bundled `jsx-runtime` references `ReactCurrentOwner` which was removed in 19. Worth a one-liner in the author guide.