### PR TITLE
ci(triage): bump KB2UKA-Agent max_turns 15 → 30 (#371)

### DIFF
--- a/.github/workflows/kb2uka-triage.yml
+++ b/.github/workflows/kb2uka-triage.yml
@@ -39,7 +39,11 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.KB2UKA_OAUTH_TOKEN }}
           allowed_tools: "Bash(gh label list),Bash(gh label list:*),Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh issue comment:*),Bash(gh search:*),Read,Glob,Grep"
-          max_turns: "15"
+          # Bumped 15 → 30 after issue #371 ran out of budget on research
+          # before reaching the mandatory comment step. The agent now has
+          # room to do a few rounds of repo grep + closed-issue search and
+          # still post the triage comment the prompt requires.
+          max_turns: "30"
           model: "claude-sonnet-4-6"
           prompt: |
             You are **KB2UKA-Agent** 🛠, the automated triage assistant for Zeus


### PR DESCRIPTION
Issue #371 hit the limit — the triage agent fired correctly but exhausted its 15-turn budget on research (closed-issue search + codebase grep) before reaching the mandatory `gh issue comment` step. Labels applied (via the issue template's `labels:` field), but no triage comment landed.

Bumping to 30 turns gives the agent room for deeper research while still preserving the comment-required contract. Mention-bot's max_turns is already 100; triage at 30 sits between the two extremes.

## Test plan

- [x] One-line workflow change, no source touched
- [ ] CI green
- [ ] Manually verified Jim's #371 already has a hand-posted triage comment so the fix isn't blocking him today — this is for the next issue that lands

Refs #371