### PR TITLE
feat(tx-audio-tools): render tx-audio-tools.chain plugins above CFC

### DIFF
--- a/zeus-web/src/components/TxAudioToolsPanel.tsx
+++ b/zeus-web/src/components/TxAudioToolsPanel.tsx
@@ -13,13 +13,147 @@
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 
+import { useMemo } from 'react';
 import { CfcSettingsPanel } from './CfcSettingsPanel';
+import { usePluginPanels } from '../plugins/runtime/usePluginPanels';
+import type { RegisteredPluginPanel } from '../plugins/runtime/pluginRuntime';
 
-// CFC is WDSP-driven and always available. The plugin extension point
-// will reattach here once the rebuilt plugin system lands.
-export function TxAudioToolsPanel() {
+// ---------------------------------------------------------------
+// Audio-chain plugin slot — installed plugins whose manifest declares
+// `ui.panels[].slot === "tx-audio-tools.chain"` render here, in chain
+// order, above the always-on CFC section. The fixed v1 chain order is
+// per issue #332 Phase 0 (KB2UKA-locked 2026-05-17):
+//
+//   EQ → Compressor → Exciter → Bass enhancer → Reverb → CFC
+//
+// Plugins not in this list (e.g. third-party chain blocks added later)
+// render after the known v1 blocks, sorted by panel id for determinism.
+// ---------------------------------------------------------------
+const CHAIN_SLOT = 'tx-audio-tools.chain';
+
+const V1_CHAIN_ORDER: ReadonlyArray<string> = [
+  'com.openhpsdr.zeus.samples.eq',
+  'com.openhpsdr.zeus.samples.compressor',
+  'com.openhpsdr.zeus.samples.exciter',
+  'com.openhpsdr.zeus.samples.bass',
+  'com.openhpsdr.zeus.samples.reverb',
+];
+
+function chainPosition(pluginId: string): number {
+  const idx = V1_CHAIN_ORDER.indexOf(pluginId);
+  // Unknown plugins (third-party, future blocks) sort after the known v1
+  // set. Using +Infinity puts them at the bottom; the secondary sort by
+  // panel id then keeps them deterministic relative to each other.
+  return idx === -1 ? Number.POSITIVE_INFINITY : idx;
+}
+
+// Sort registered panels into the fixed v1 chain order.
+function sortChainPanels(panels: RegisteredPluginPanel[]): RegisteredPluginPanel[] {
+  return [...panels].sort((a, b) => {
+    const da = chainPosition(a.pluginId);
+    const db = chainPosition(b.pluginId);
+    if (da !== db) return da - db;
+    return a.panelId.localeCompare(b.panelId);
+  });
+}
+
+// ---------------------------------------------------------------
+// Master signal-flow strip — one-glance read of which chain blocks
+// are installed and active, drawn in Zeus tokens (brass-plate rail
+// matching v3 Lifted Dark). Uninstalled blocks render dim; CFC is
+// always on (WDSP-driven, can't be uninstalled).
+// ---------------------------------------------------------------
+function ChainFlow({ chainPanels }: { chainPanels: RegisteredPluginPanel[] }) {
+  const v1Slots: Array<{ id: string; title: string; installed: boolean }> = useMemo(() => {
+    const installedIds = new Set(chainPanels.map((p) => p.pluginId));
+    return [
+      { id: 'eq',      title: 'EQ',      installed: installedIds.has('com.openhpsdr.zeus.samples.eq') },
+      { id: 'comp',    title: 'COMP',    installed: installedIds.has('com.openhpsdr.zeus.samples.compressor') },
+      { id: 'exciter', title: 'EXCITER', installed: installedIds.has('com.openhpsdr.zeus.samples.exciter') },
+      { id: 'bass',    title: 'BASS',    installed: installedIds.has('com.openhpsdr.zeus.samples.bass') },
+      { id: 'reverb',  title: 'REVERB',  installed: installedIds.has('com.openhpsdr.zeus.samples.reverb') },
+      { id: 'cfc',     title: 'CFC',     installed: true }, // WDSP-driven, always present
+    ];
+  }, [chainPanels]);
+
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+    <div
+      role="presentation"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 6,
+        padding: '8px 12px',
+        background: 'linear-gradient(180deg, var(--panel-top), var(--panel-bot))',
+        border: '1px solid var(--line-1)',
+        borderRadius: 6,
+        boxShadow: 'inset 0 2px 0 var(--power), inset 0 3px 8px rgba(255, 201, 58, 0.08)',
+        fontFamily: 'var(--font-sans, Inter, system-ui, sans-serif)',
+        fontSize: 11,
+        letterSpacing: 1.2,
+        textTransform: 'uppercase',
+        color: 'var(--fg-2)',
+        flexWrap: 'wrap',
+      }}
+    >
+      <span style={{ marginRight: 4, color: 'var(--fg-1)', fontWeight: 500 }}>TX chain</span>
+      {v1Slots.map((slot, i) => (
+        <span key={slot.id} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          {i > 0 && (
+            <span aria-hidden style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono, JetBrains Mono, ui-monospace, monospace)' }}>›</span>
+          )}
+          <span
+            style={{
+              padding: '2px 8px',
+              borderRadius: 3,
+              background: slot.installed ? 'var(--bg-2)' : 'var(--bg-1)',
+              border: '1px solid ' + (slot.installed ? 'var(--accent)' : 'var(--line-1)'),
+              color: slot.installed ? 'var(--fg-0)' : 'var(--fg-3)',
+              opacity: slot.installed ? 1 : 0.5,
+              fontSize: 10,
+              fontWeight: 500,
+            }}
+            title={slot.installed ? 'Installed and active' : 'Not installed — Settings → Plugins → Install from URL'}
+          >
+            {slot.title}
+          </span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------
+// TxAudioToolsPanel — chain plugins above, CFC below.
+//
+// Audio-chain plugins (issue #332) declare panel slot
+// `tx-audio-tools.chain`; we filter `usePluginPanels()` to that slot,
+// sort by the fixed v1 chain order, and render each plugin's component
+// inline. CFC stays at the bottom — it's WDSP-driven and ships in Zeus
+// core, not as a plugin, so it doesn't move.
+// ---------------------------------------------------------------
+export function TxAudioToolsPanel() {
+  const allPanels = usePluginPanels();
+  const chainPanels = useMemo(
+    () => sortChainPanels(allPanels.filter((p) => p.slot === CHAIN_SLOT)),
+    [allPanels],
+  );
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <ChainFlow chainPanels={chainPanels} />
+
+      {/* Chain plugins in v1 order. Empty until at least one is installed. */}
+      {chainPanels.map((panel) => {
+        const Component = panel.component;
+        return (
+          <div key={`${panel.pluginId}::${panel.panelId}`} data-plugin-id={panel.pluginId}>
+            <Component />
+          </div>
+        );
+      })}
+
+      {/* CFC — WDSP-driven, always available, always last in the chain. */}
       <CfcSettingsPanel />
     </div>
   );

--- a/zeus-web/src/plugins/runtime/pluginRuntime.ts
+++ b/zeus-web/src/plugins/runtime/pluginRuntime.ts
@@ -20,6 +20,11 @@ export interface RegisteredPluginPanel {
   title: string;
   icon: string;
   category: string;
+  // Manifest's panel slot — e.g. "workspace.amplifier" for an Add-Panel
+  // tile, "tx-audio-tools.chain" for a TX audio-chain block. Consumers
+  // filter on this when rendering plugin contributions into a specific
+  // surface (the chain panel below CFC, for instance).
+  slot: string;
   component: ComponentType;
 }
 
@@ -89,6 +94,7 @@ async function loadOne(plugin: PluginDto): Promise<void> {
       title: meta.title,
       icon: meta.icon,
       category: meta.category,
+      slot: meta.slot,
       component,
     });
   }


### PR DESCRIPTION
Wires Zeus's **Settings → TX Audio Tools** tab to query the installed-plugin runtime for panels declaring slot `tx-audio-tools.chain` and render them in the fixed v1 chain order before CFC. Closes the slot-query gap Brian flagged at `TxAudioToolsPanel.tsx:18` ("plugin extension point will reattach here once the rebuilt plugin system lands").

## Changes

- **`zeus-web/src/plugins/runtime/pluginRuntime.ts`** — capture the manifest's `slot` field on the registered panel so downstream surfaces can filter by it. Previously only `category` (the Add-Panel modal taxonomy) made it through, which is fine for the workspace tile flow but doesn't reach chain rendering.
- **`zeus-web/src/components/TxAudioToolsPanel.tsx`** — read `usePluginPanels()`, filter to slot `tx-audio-tools.chain`, sort by the locked v1 chain order (EQ → Comp → Exciter → Bass enhancer → Reverb → CFC per [#332 Phase 0](https://github.com/Kb2uka/openhpsdr-zeus/blob/develop/docs/proposals/audio-chain-phase0.md)), render each plugin component above CFC. Adds a master signal-flow strip at the top — installed blocks render with `--accent` border, uninstalled dim. CFC stays in core (WDSP-driven), always last, unchanged.

## What this unlocks

- `com.openhpsdr.zeus.samples.compressor` (today) — panel surfaces immediately above CFC once installed via Settings → Plugins → Install from URL with the v0.1.1 zip
- EQ / Exciter / Bass / Reverb (Phase 2+) — drop into reserved positions in the chain order automatically when shipped
- Third-party plugins targeting the same slot — sort after the v1 set, deterministic by panel id

## Authority

Per [feedback_audio_plugin_authority](https://github.com/Kb2uka/openhpsdr-zeus), zeus-side integration plumbing for the audio chain is KB2UKA's responsibility, not Brian's. This PR is the first of the queued items in `project_pending_zeus_side_prs`.

## Test plan

- [x] `npm --prefix zeus-web run typecheck` — clean
- [x] `npm --prefix zeus-web test -- --run` — **213 / 213 passing**, including `SettingsMenu.test` which exercises `TxAudioToolsPanel` rendering
- [ ] CI green
- [ ] Bench post-merge: install `compressor-v0.1.1` via Settings → Plugins → Install from URL, open Settings → TX Audio Tools, confirm the brass-plate panel renders with rotary knobs + transfer curve + LED meters above CFC

Refs Kb2uka/openhpsdr-zeus#332 Phase 1.5