### PR TITLE
fix(plugins): keep plugin-panel tiles across layout reparse

### DIFF
--- a/zeus-web/src/layout/workspace.ts
+++ b/zeus-web/src/layout/workspace.ts
@@ -9,7 +9,6 @@
 // blob (schemaVersion + tiles[]) round-trips through /api/ui/layout via the
 // existing layout-store debounced PUT path.
 
-import { PANELS } from './panels';
 
 /** Outer-grid column count. Matches MetersPanel's inner grid so the mental
  *  model is identical at both levels. */
@@ -118,10 +117,13 @@ export function placeTileInGrid(
 /** Best-effort parser + validator for the opaque /api/ui/layout JSON blob.
  *  Anything malformed falls through to the empty layout — never throws. The
  *  caller is expected to substitute DEFAULT_WORKSPACE_LAYOUT when this
- *  returns the empty value. Tiles whose panelId is no longer in PANELS are
- *  silently dropped (e.g. a future PanelDef removal); instanceConfig is
- *  preserved verbatim regardless of shape so per-panel parsers can validate
- *  it on their own terms. */
+ *  returns the empty value. Unknown panelIds are kept rather than dropped —
+ *  plugin panels register asynchronously at startup, and dropping their
+ *  tiles on each layout deserialise would mean operators have to re-add
+ *  plugin panels after every tab switch / page reload. The tile renderer
+ *  treats an unresolved panelId as "render nothing until it shows up"
+ *  (PanelTile / PanelBody both early-return null on missing def), so a
+ *  tile pointing at a permanently-removed panel id is harmless. */
 export function parseWorkspaceLayout(raw: unknown): WorkspaceLayout {
   if (!raw || typeof raw !== 'object') return EMPTY_WORKSPACE_LAYOUT;
   const obj = raw as Partial<WorkspaceLayout>;
@@ -133,7 +135,6 @@ export function parseWorkspaceLayout(raw: unknown): WorkspaceLayout {
     const tile = t as Partial<WorkspaceTile>;
     if (typeof tile.uid !== 'string' || tile.uid.length === 0) continue;
     if (typeof tile.panelId !== 'string') continue;
-    if (!(tile.panelId in PANELS)) continue;
     if (
       !Number.isFinite(tile.x) ||
       !Number.isFinite(tile.y) ||

--- a/zeus-web/src/state/__tests__/layout-store.test.ts
+++ b/zeus-web/src/state/__tests__/layout-store.test.ts
@@ -127,17 +127,22 @@ describe('parseWorkspaceLayout', () => {
     expect(parseWorkspaceLayout(future)).toEqual(EMPTY_WORKSPACE_LAYOUT);
   });
 
-  it('drops tiles whose panelId is not in the registry', () => {
+  it('keeps tiles whose panelId is not in the static registry (plugin-panel tiles register asynchronously)', () => {
+    // Plugin panels register after the layout deserialises — if the parser
+    // dropped unknown panelIds, every tab switch / reload would erase any
+    // plugin tile (e.g. RF-2K, PGXL, antenna-genius). The renderer treats
+    // an unresolved panelId as "render nothing until it shows up" so a
+    // tile pointing at a permanently-removed panel id is harmless.
     const dirty = {
       schemaVersion: 7,
       tiles: [
         { uid: 'a', panelId: 'hero', x: 0, y: 0, w: 9, h: 12 },
-        { uid: 'b', panelId: 'no-such-panel', x: 0, y: 0, w: 1, h: 1 },
+        { uid: 'b', panelId: 'com.example.plugin.panel', x: 0, y: 0, w: 1, h: 1 },
       ],
     };
     const parsed = parseWorkspaceLayout(dirty);
-    expect(parsed.tiles).toHaveLength(1);
-    expect(parsed.tiles[0]?.uid).toBe('a');
+    expect(parsed.tiles).toHaveLength(2);
+    expect(parsed.tiles.map((t) => t.uid)).toEqual(['a', 'b']);
   });
 
   it('drops tiles missing required numeric fields', () => {


### PR DESCRIPTION
Tiny pure-fix PR. Cherry-pick of `2093a80` from `feature/plugin-host-runtime`, which never made it into PR #370 — only its sibling commit `6f94668` (the runtime wiring) was included in the merge.

## Symptom

Add a plugin-contributed panel (e.g. RF-2K, PGXL, antenna-genius) to a layout, switch layouts, switch back → the plugin tile is gone. Layout has reverted to the default for any non-built-in panel.

## Cause

`parseWorkspaceLayout` (in `zeus-web/src/layout/workspace.ts`) filtered out any tile whose `panelId` wasn't in the static `PANELS` map. Plugin panels register **asynchronously** after `pluginRuntime` fetches `/api/plugins` and dynamic-imports each module — so during the initial deserialise pass, the plugin-panel ids aren't in `PANELS` yet, and the tile gets dropped before the plugin even has a chance to load.

## Fix

Drop the `if (!(tile.panelId in PANELS)) continue;` gate (and the `import { PANELS }` it relied on). Keep the unknown panelId in the layout; `PanelTile` and `PanelBody` already early-return `null` on missing def, so the tile renders as nothing until the plugin finishes loading — then the tile appears with the correct component.

A tile pointing at a permanently-removed panel id becomes invisible but harmless (until the operator removes the empty tile themselves).

## Scope

Every branch off develop right now is affected — this is independent of the in-flight RF-2K extraction work, so worth landing on its own.

Also included (as the same patch) in the companion PR `feature/extract-rf2k-plugin`; if this fix merges first, that PR's copy will de-duplicate on rebase.