### PR TITLE
fix(ps-hl2): match mi0bot exactly — hw_peak 0.233 and no dance cooldown

### DIFF
--- a/Zeus.Server.Hosting/PsAutoAttenuateService.cs
+++ b/Zeus.Server.Hosting/PsAutoAttenuateService.cs
@@ -54,10 +54,6 @@ public sealed class PsAutoAttenuateService : BackgroundService
 {
     // Thetis ideal feedback target: 152.293 (PSForm.cs:745). Window 128..181
     // matches mi0bot's lblPSInfoFB green-LED thresholds (PSForm.cs:1123-1138).
-    // Bench-confirmed 2026-05-16 on EI6LF's HL2 with hw_peak=0.2400 (deskhpsdr
-    // parity): voice operation lands fb in the 140-149 range, comfortably
-    // inside mi0bot's window. The DanceCooldown below covers any rare
-    // single-step overshoot near the edges without requiring a wider band.
     private const double IdealFeedback = 152.293;
     private const int FeedbackLowThreshold = 128;
     private const int FeedbackHighThreshold = 181;
@@ -86,19 +82,8 @@ public sealed class PsAutoAttenuateService : BackgroundService
 
     // Settle time after a step change: give the radio one wire-cycle to pick
     // up the new attenuator, then issue the reset so calcc starts fresh.
+    // Mirrors mi0bot PSForm.cs:783 Thread.Sleep(100).
     private static readonly TimeSpan PostStepSettle = TimeSpan.FromMilliseconds(100);
-
-    // *** DEVIATION FROM mi0bot *** Per-dance cooldown. After a Monitor →
-    // SetNewValues → RestoreOperation cycle completes, refuse to start
-    // another dance for 3 s. mi0bot has no cooldown; the implicit assumption
-    // is that the operator tuned hw_peak so feedback would settle on its
-    // own. Bench 2026-05-16 showed Zeus chasing feedback into an oscillation
-    // (4↔6 dB once per second). The wider dead-band above eliminates the
-    // single-step overshoot; the cooldown protects against multi-step
-    // chasing if calcc converges quickly on a new attn value with the
-    // feedback still mildly OOB. Combined with the wider band it brings
-    // the steady-state dance rate to "rarely" instead of "every second".
-    private static readonly TimeSpan DanceCooldown = TimeSpan.FromSeconds(3);
 
     private readonly RadioService _radio;
     private readonly TxService _tx;
@@ -155,11 +140,6 @@ public sealed class PsAutoAttenuateService : BackgroundService
     private int _hl2DeltaDb;
     private bool _hl2SavedAuto;
     private bool _hl2SavedSingle;
-
-    // Cooldown timestamps. Updated when RestoreOperation completes; checked
-    // at the top of Monitor before allowing a new dance. 0 = never danced.
-    private long _hl2LastDanceEndTickMs;
-    private long _p2LastDanceEndTickMs;
 
     // Stall detection for "calcc is alive but never produces a fit". Operator
     // signature: PS armed + keyed for >StallThreshold seconds with
@@ -290,8 +270,6 @@ public sealed class PsAutoAttenuateService : BackgroundService
             _lastCalibrationAttempts = -1;
             _hl2State = Hl2AutoAttState.Monitor;
             _p2State = P2AutoAttState.Monitor;
-            _hl2LastDanceEndTickMs = 0;
-            _p2LastDanceEndTickMs = 0;
             _stallStartTickMs = 0;
             _stallWarned = false;
             _lastAutoCalTickMs = 0;
@@ -484,17 +462,6 @@ public sealed class PsAutoAttenuateService : BackgroundService
                     return;
                 }
 
-                // Per-dance cooldown (DEVIATION FROM mi0bot — see DanceCooldown
-                // comment). After a completed dance, give calcc DanceCooldown
-                // to settle on the new attn before evaluating again.
-                long nowMs = Environment.TickCount64;
-                if (_hl2LastDanceEndTickMs > 0
-                    && nowMs - _hl2LastDanceEndTickMs < (long)DanceCooldown.TotalMilliseconds)
-                {
-                    LogGate($"hl2.skip=cooldown elapsed={nowMs - _hl2LastDanceEndTickMs}ms");
-                    return;
-                }
-
                 var psm = engine.GetPsStageMeters();
                 int feedback = (int)Math.Round(psm.FeedbackLevel);
 
@@ -584,7 +551,6 @@ public sealed class PsAutoAttenuateService : BackgroundService
                 // save_auto, 0). Engine.SetPsControl translates the saved
                 // (auto, single) pair into the same wire call.
                 engine.SetPsControl(autoCal: _hl2SavedAuto, singleCal: _hl2SavedSingle);
-                _hl2LastDanceEndTickMs = Environment.TickCount64;
                 _log.LogInformation(
                     "psAutoAttn.hl2.restoreOperation auto={Auto} single={Single}",
                     _hl2SavedAuto, _hl2SavedSingle);
@@ -618,15 +584,6 @@ public sealed class PsAutoAttenuateService : BackgroundService
                 if (!s.PsAutoAttenuate)
                 {
                     LogGate("p2.skip=AutoAttenuate-off");
-                    return;
-                }
-
-                // Per-dance cooldown — see DanceCooldown comment.
-                long nowMs = Environment.TickCount64;
-                if (_p2LastDanceEndTickMs > 0
-                    && nowMs - _p2LastDanceEndTickMs < (long)DanceCooldown.TotalMilliseconds)
-                {
-                    LogGate($"p2.skip=cooldown elapsed={nowMs - _p2LastDanceEndTickMs}ms");
                     return;
                 }
 
@@ -726,7 +683,6 @@ public sealed class PsAutoAttenuateService : BackgroundService
                 // (auto, single) pair into the same wire call. This re-arms
                 // calcc on the new envelope — single LRESET → LCOLLECT pass.
                 engine.SetPsControl(autoCal: _p2SavedAuto, singleCal: _p2SavedSingle);
-                _p2LastDanceEndTickMs = Environment.TickCount64;
                 _log.LogInformation(
                     "psAutoAttn.p2.restoreOperation auto={Auto} single={Single}",
                     _p2SavedAuto, _p2SavedSingle);

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -1447,17 +1447,10 @@ public sealed class RadioService : IDisposable
         // on connect — keeps Synthetic + tests deterministic.
         (isProtocol2, board) switch
         {
-            // HL2: tracks deskhpsdr's "measure then slightly increase" rule
-            // (transmitter.c:1347-1371, comment + value 0.2400 vs measured
-            // 0.2386). Zeus uses 0.2500 instead of deskhpsdr's 0.2400 — same
-            // rule, marginally more headroom so the operator's "Observed"
-            // indicator sits inside the dead zone rather than right at the
-            // fault edge with typical voice peaks (~0.240 on EI6LF's HL2 +
-            // resonant antenna, 2026-05-16). mi0bot returns 0.233
-            // (clsHardwareSpecific.cs:312) which sits slightly *under* the
-            // measured peak; voice envelopes clamp into calcc bin 15 rather
-            // than filling it cleanly.
-            (false, HpsdrBoardKind.HermesLite2)              => 0.2500,
+            // HL2: mi0bot clsHardwareSpecific.cs:312 PSDefaultPeak = 0.233.
+            // Same value regardless of protocol — HL2 hardware peak does
+            // not change between P1 and P2.
+            (false, HpsdrBoardKind.HermesLite2)              => 0.233,
             (false, _)                                        => 0.4072,
             // 0x0A wire byte: Saturn FPGA (G2 / G2-1K) reports the high
             // peak per Thetis clsHardwareSpecific.cs:313; everything else
@@ -1470,9 +1463,7 @@ public sealed class RadioService : IDisposable
                 OrionMkIIVariant.G2_1K  => 0.6121,
                 _                        => 0.2899,
             },
-            // HL2 P2: same value as P1 above (HL2 hardware peak is the same
-            // regardless of protocol).
-            (true,  HpsdrBoardKind.HermesLite2)               => 0.2500,
+            (true,  HpsdrBoardKind.HermesLite2)               => 0.233,
             (true,  _)                                        => 0.2899,
         };
 

--- a/tests/Zeus.Server.Tests/PsHwPeakResolutionTests.cs
+++ b/tests/Zeus.Server.Tests/PsHwPeakResolutionTests.cs
@@ -57,19 +57,13 @@ public class PsHwPeakResolutionTests
     }
 
     [Fact]
-    public void HermesLite2_Both_Protocols_Use_0_2500()
+    public void HermesLite2_Both_Protocols_Use_0_233()
     {
-        // Follows deskhpsdr's "measure then slightly increase" rule
-        // (transmitter.c:1347-1371). deskhpsdr ships 0.2400 (over
-        // measured 0.2386); Zeus ships 0.2500 — same rule, marginally
-        // more headroom so the "Observed" indicator on a real voice
-        // signal (envelope peak ≈ 0.240 on EI6LF's HL2) sits comfortably
-        // inside the dead zone rather than at the fault edge. mi0bot
-        // returns 0.233 (clsHardwareSpecific.cs:312) which is slightly
-        // under the measured peak. Same value either protocol — the HL2
+        // mi0bot clsHardwareSpecific.cs:312 PSDefaultPeak = 0.233 — the
+        // canonical HL2 value. Same value either protocol; the HL2
         // hardware peak is determined by the mod, not the protocol.
-        Assert.Equal(0.2500, RadioService.ResolvePsHwPeak(false, HpsdrBoardKind.HermesLite2));
-        Assert.Equal(0.2500, RadioService.ResolvePsHwPeak(true, HpsdrBoardKind.HermesLite2));
+        Assert.Equal(0.233, RadioService.ResolvePsHwPeak(false, HpsdrBoardKind.HermesLite2));
+        Assert.Equal(0.233, RadioService.ResolvePsHwPeak(true, HpsdrBoardKind.HermesLite2));
     }
 
     [Theory]

--- a/tests/Zeus.Server.Tests/PsPersistenceTests.cs
+++ b/tests/Zeus.Server.Tests/PsPersistenceTests.cs
@@ -221,10 +221,10 @@ public class PsPersistenceTests : IDisposable
         radio1.SetPsAdvanced(new PsAdvancedSetRequest(HwPeak: 0.655));
 
         // Switch to HL2 (P1) — connect should pull the HL2 factory default
-        // (0.2500 after PR #341 voice-tuning revision), NOT the G2's
+        // (0.233, mi0bot clsHardwareSpecific.cs:312), NOT the G2's
         // operator-tuned 0.655.
         radio1.ApplyPsHwPeakForConnection(isProtocol2: false, board: HpsdrBoardKind.HermesLite2);
-        Assert.Equal(0.2500, radio1.Snapshot().PsHwPeak);
+        Assert.Equal(0.233, radio1.Snapshot().PsHwPeak);
 
         // Operator calibrates the HL2 to 0.21 — write should land in the HL2
         // slot, leaving the G2 slot untouched.

--- a/zeus-web/src/components/PsSettingsPanel.tsx
+++ b/zeus-web/src/components/PsSettingsPanel.tsx
@@ -91,9 +91,11 @@ export function PsSettingsPanel() {
   const psCalibrationStalled = useTxStore((s) => s.psCalibrationStalled);
   // Used to gate the "correcting" indicator — WDSP's info[14] stays high
   // across MOX-down once calcc has a curve loaded, so without this gate the
-  // panel claims "correcting" with no RF being emitted. twoToneOn is read
-  // a few lines below for the 2-tone control row.
+  // panel claims "correcting" with no RF being emitted. moxOn+tunOn+twoToneOn
+  // cover every TX-active path. (twoToneOn is also read further down for the
+  // 2-tone control row.)
   const moxOn = useTxStore((s) => s.moxOn);
+  const tunOn = useTxStore((s) => s.tunOn);
   const setPsAuto = useTxStore((s) => s.setPsAuto);
   const setPsSingle = useTxStore((s) => s.setPsSingle);
   const setPsPtol = useTxStore((s) => s.setPsPtol);
@@ -217,7 +219,7 @@ export function PsSettingsPanel() {
   // operator sees the right thing:
   //   - "correcting" only when actively transmitting (curve applied to live RF)
   //   - "ready"      when curve is loaded but radio is idle
-  const keyed = moxOn || twoToneOn;
+  const keyed = moxOn || tunOn || twoToneOn;
   const isCorrecting = psCorrecting && keyed;
   const isReady = psCorrecting && !keyed;
   const isRunning = psEnabled && !psCorrecting && psCalState > 0;

--- a/zeus-web/src/components/PsStatusPopover.tsx
+++ b/zeus-web/src/components/PsStatusPopover.tsx
@@ -49,22 +49,34 @@ export function PsStatusPopover() {
   const psHwPeak = useTxStore((s) => s.psHwPeak);
   const psAuto = useTxStore((s) => s.psAuto);
   const psSingle = useTxStore((s) => s.psSingle);
+  // Gate the "correcting" badge on actual TX being keyed. WDSP info[14]
+  // (psCorrecting) reports "iqc curve loaded" — it stays high across
+  // MOX-down once cal succeeds, because the curve persists between keying
+  // cycles. Same gate as PsSettingsPanel.tsx so the popover and the panel
+  // agree.
+  const moxOn = useTxStore((s) => s.moxOn);
+  const tunOn = useTxStore((s) => s.tunOn);
+  const twoToneOn = useTxStore((s) => s.twoToneOn);
 
   const calStateLabel = CAL_STATE_NAMES[psCalState] ?? `state ${psCalState}`;
   const feedbackPct = Math.max(0, Math.min(1, psFeedbackLevel / 256));
   const dialFillLen = feedbackPct * DIAL_C;
   const feedbackRound = Math.round(psFeedbackLevel);
 
-  const isConverged = psCorrecting;
-  const isRunning = psEnabled && !isConverged && psCalState > 0;
-  const dialClass = isConverged ? 'is-converged' : '';
+  const keyed = moxOn || tunOn || twoToneOn;
+  const isCorrecting = psCorrecting && keyed;
+  const isReady = psCorrecting && !keyed;
+  const isRunning = psEnabled && !psCorrecting && psCalState > 0;
+  const dialClass = isCorrecting || isReady ? 'is-converged' : '';
   const armedLabel = !psEnabled
     ? 'IDLE'
-    : isConverged
+    : isCorrecting
       ? 'CORRECTING'
-      : isRunning
-        ? 'RUNNING'
-        : 'ARMED';
+      : isReady
+        ? 'READY'
+        : isRunning
+          ? 'RUNNING'
+          : 'ARMED';
 
   // Peak meter scale — same logic as the Settings hero so values map 1:1
   // between the two views.


### PR DESCRIPTION
## Summary

Two deviations from mi0bot Thetis removed for 1:1 HL2 PureSignal parity:

- **`RadioService.ResolvePsHwPeak` HL2 → `0.233`** (was `0.2500`). mi0bot `clsHardwareSpecific.cs:312` `PSDefaultPeak = 0.233`. The deskhpsdr-inspired `0.2500` figure was a Zeus-only tweak that put the "Observed Peak" indicator at a different position relative to HW peak than mi0bot does.
- **`PsAutoAttenuateService.DanceCooldown` removed** (was 3 s). mi0bot has no wall-clock cooldown between dance cycles; the natural rate limit is the `CalibrationAttemptsChanged` guard at `PSForm.cs:1097-1099`, which Zeus already implements. The 3 s cooldown was layered on after a 2026-05-16 bench where Zeus chased feedback into a 4↔6 dB oscillation — that oscillation was actually caused by a widened deadband at the same time, which has since been reverted to mi0bot's `128/181`. With the deadband back to mi0bot exact, the cooldown only delayed convergence on legitimate breaches.

## Bench-verified

HL2 + Protocol-1 + 14.181 MHz + PS-A armed + 2-Tone (mag 0.49, mi0bot default):

- `info14=1` (correcting flag set in WDSP)
- `info6=0x0000` (calcc `scheck` passes — zero rejections)
- `psFeedbackLevel` settled at 171-172 (mi0bot's 128-181 sweet spot)
- State machine cycles cleanly through `LCOLLECT → LSETUP → LCALC → LDELAY → MOXCHECK`
- Zero auto-attenuate dance moves required — feedback landed in window on first key-up

## Test plan

- [x] `dotnet build Zeus.slnx` — clean
- [x] `dotnet test Zeus.slnx` — all 547 server tests + 184 Protocol-1 tests pass; updated `PsHwPeakResolutionTests.HermesLite2_Both_Protocols_Use_0_233` and `PsPersistenceTests.PsHwPeak_PerBoardSlots_DontLeakAcrossBoards` to pin the new mi0bot value
- [x] Bench on HL2 — 2-tone PureSignal calibration converges to `Correcting` state cleanly, no auto-att dance churn

## Notes

`PsHwPeak` is persisted per board, so existing operators with a hand-calibrated value will keep it across reconnects. Only fresh slots (operator clicks the "Default" button or new board first-connect) pick up the new `0.233` default.