### PR TITLE
fix(analog-meter): radio-aware PO scale + bolder dial typography

### DIFF
--- a/zeus-web/src/components/analog-meter/AnalogMeterFace.tsx
+++ b/zeus-web/src/components/analog-meter/AnalogMeterFace.tsx
@@ -41,7 +41,7 @@ function ScaleArc({ scale, radius, active, enabled, peakValueN }: ScaleArcProps)
   const trackOpacity = active ? 0.9 : 0.45;
   const trackWidth = active ? 2 : 1;
   const labelColor = active ? 'var(--fg-0)' : 'var(--fg-1)';
-  const labelOpacity = active ? 1 : 0.7;
+  const labelOpacity = active ? 1 : 0.85;
 
   const tickAngle = (v: number) => normToDeg(scale.n(v));
   const peakDeg = active && peakValueN != null ? normToDeg(peakValueN) : null;
@@ -103,7 +103,7 @@ function ScaleArc({ scale, radius, active, enabled, peakValueN }: ScaleArcProps)
       {scale.ticks.map((t, i) => {
         if (!t.label) return null;
         const ang = tickAngle(t.v);
-        const lr = radius + (t.major ? 28 : 22);
+        const lr = radius + (t.major ? 32 : 26);
         const [lx, ly] = pt(FACE.cx, FACE.cy, lr, ang);
         const isPlus = t.plus;
         return (
@@ -112,9 +112,9 @@ function ScaleArc({ scale, radius, active, enabled, peakValueN }: ScaleArcProps)
             x={lx}
             y={ly}
             fill={isPlus ? 'var(--accent)' : labelColor}
-            opacity={isPlus ? (active ? 1 : 0.75) : labelOpacity}
-            fontSize={t.major ? 16 : 13}
-            fontWeight={t.major ? 600 : 500}
+            opacity={isPlus ? (active ? 1 : 0.85) : labelOpacity}
+            fontSize={t.major ? 24 : 19}
+            fontWeight={t.major ? 800 : 700}
             fontFamily="var(--font-sans)"
             textAnchor="middle"
             dominantBaseline="middle"
@@ -132,9 +132,9 @@ function ScaleArc({ scale, radius, active, enabled, peakValueN }: ScaleArcProps)
             x={lx - 18}
             y={ly}
             fill={active ? 'var(--fg-0)' : 'var(--fg-1)'}
-            opacity={active ? 1 : 0.7}
-            fontSize={13}
-            fontWeight={700}
+            opacity={active ? 1 : 0.85}
+            fontSize={20}
+            fontWeight={800}
             fontFamily="var(--font-sans)"
             letterSpacing="0.08em"
             textAnchor="end"
@@ -149,14 +149,14 @@ function ScaleArc({ scale, radius, active, enabled, peakValueN }: ScaleArcProps)
         const tip = scale.ticks[scale.ticks.length - 1];
         if (!tip) return null;
         const ang = tickAngle(tip.v) + 2;
-        const [ux, uy] = pt(FACE.cx, FACE.cy, radius + 28, ang);
+        const [ux, uy] = pt(FACE.cx, FACE.cy, radius + 32, ang);
         return (
           <text
             x={ux + 4}
             y={uy}
             fill="var(--accent)"
-            fontSize={13}
-            fontWeight={600}
+            fontSize={20}
+            fontWeight={800}
             fontFamily="var(--font-sans)"
             textAnchor="start"
             dominantBaseline="middle"

--- a/zeus-web/src/components/analog-meter/AnalogMeterPanel.tsx
+++ b/zeus-web/src/components/analog-meter/AnalogMeterPanel.tsx
@@ -24,6 +24,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { GripVertical, Settings, X } from 'lucide-react';
 import { usePaStore } from '../../state/pa-store';
+import { useRadioStore } from '../../state/radio-store';
 import { useTxStore } from '../../state/tx-store';
 import { AnalogMeterFace } from './AnalogMeterFace';
 import { AnalogMeterConfig } from './AnalogMeterConfig';
@@ -190,18 +191,33 @@ export function AnalogMeterPanel({ onClose }: AnalogMeterPanelProps = {}) {
     return 'po';
   }, [mode, enabled.s, enabled.po, enabled.swr]);
 
-  // PO arc full-scale is derived from the rated PA power configured in the
-  // main PA Settings panel: max(10 W, 120% of rated). A 5 W HL2 → 10 W scale,
-  // a 100 W rig → 120 W scale. When the operator hasn't configured a rated
-  // power yet, fall back to a 100 W bench rig (matches TxStageMeters).
+  // PO arc full-scale tracks the connected radio. Resolution order matches
+  // TxStageMeters / ImmersiveMeters so the analog dial reads the same axis as
+  // the digital bar: operator PA override → board's published MaxPowerWatts
+  // (e.g. HL2 = 10 W) → 100 W last-ditch fallback.
   const paMaxPowerWatts = usePaStore((s) => s.settings.global.paMaxPowerWatts);
+  const boardMaxWatts = useRadioStore((s) => s.capabilities.maxPowerWatts);
   const poMax = useMemo(() => {
-    const ratedW = paMaxPowerWatts > 0 ? paMaxPowerWatts : 100;
-    return Math.max(10, ratedW * 1.2);
-  }, [paMaxPowerWatts]);
+    const ratedW =
+      paMaxPowerWatts > 0 ? paMaxPowerWatts : boardMaxWatts > 0 ? boardMaxWatts : 100;
+    return Math.max(1, ratedW);
+  }, [paMaxPowerWatts, boardMaxWatts]);
   const dynamicPoScale = useMemo(() => {
+    // Six evenly-spaced major ticks at 0, max/5, …, max — same shape as the
+    // digital PWR axis. HL2 (10 W) → 0/2/4/6/8/10; 100 W rig → 0/20/40/60/80/100.
+    const step = poMax / 5;
+    const decimals = step >= 1 ? 0 : 1;
+    const ticks = Array.from({ length: 6 }, (_, i) => {
+      const v = i * step;
+      return {
+        v,
+        label: v.toFixed(decimals),
+        major: true,
+      };
+    });
     return {
       ...PO_SCALE,
+      ticks,
       n: (w: number) => Math.min(1, Math.max(0, w) / poMax),
       fmt: (w: number) => `${w < 10 ? w.toFixed(1) : Math.round(w)} W`,
       fromN: (n: number) => Math.max(0, Math.min(1, n)) * poMax,


### PR DESCRIPTION
## Summary
- The analog S-Meter PO arc painted hard-coded 0/5/10/25/50/100/150 W tick labels and defaulted to a 120 W full scale when no operator PA override was set, so an HL2 dial read 100/150 while the digital PWR bar correctly showed 0..10.
- Resolve rated wattage the same way `TxStageMeters` / `ImmersiveMeters` do — operator `paMaxPowerWatts` → board `capabilities.maxPowerWatts` (e.g. HL2 = 10) → 100 W last-ditch fallback — then regenerate six evenly-spaced major ticks at 0, max/5, …, max. HL2 reads 0/2/4/6/8/10; a 100 W rig reads 0/20/40/60/80/100, matching the digital axis exactly.
- Bumped dial typography so labels are legible at typical tile size: tick majors 16 → 24 (weight 800), minors 13 → 19 (weight 700), scale label and unit 13 → 20 (weight 800), inactive-scale opacity 0.7 → 0.85.

## Files
- `zeus-web/src/components/analog-meter/AnalogMeterPanel.tsx` — wire `useRadioStore.capabilities.maxPowerWatts` into the PO scale; generate ticks from `poMax` instead of relying on the static `PO_SCALE.ticks` array.
- `zeus-web/src/components/analog-meter/AnalogMeterFace.tsx` — font-size / font-weight / opacity bumps on tick labels, scale label, and unit text.

## Test plan
- [x] `tsc -b && vite build` clean
- [x] Bench against HL2 in desktop mode — PO dial reads 0/2/4/6/8/10 instead of 0/5/10/25/50/100/150
- [ ] Verify on a 100 W-class radio that the dial reads 0/20/40/60/80/100
- [ ] Confirm dial typography is comfortably readable at the smallest practical S-Meter tile size