### PR TITLE
chore(audio-suite): bump bundled EQ to v0.2.0

### DIFF
--- a/zeus-web/src/components/DownloadAudioSuiteButton.tsx
+++ b/zeus-web/src/components/DownloadAudioSuiteButton.tsx
@@ -29,7 +29,7 @@ const AUDIO_SUITE: ReadonlyArray<SuitePlugin> = [
   {
     id: 'com.openhpsdr.zeus.samples.eq',
     label: 'EQ (10-band parametric)',
-    url: 'https://github.com/Kb2uka/openhpsdr-zeus-plugins/releases/download/eq-v0.1.0/eq-0.1.0.zip',
+    url: 'https://github.com/Kb2uka/openhpsdr-zeus-plugins/releases/download/eq-v0.2.0/eq-0.2.0.zip',
   },
   {
     id: 'com.openhpsdr.zeus.samples.compressor',


### PR DESCRIPTION
## Summary
- Bumps the EQ entry in \`DownloadAudioSuiteButton\`'s pinned suite list from \`eq-v0.1.0\` → \`eq-v0.2.0\`.
- Operators clicking *Download Audio Suite* now get the v0.2.0 build (Input/Output gain stages + live FFT spectrum overlay).

## Test plan
- [x] Local desktop build loads \`com.openhpsdr.zeus.samples.eq v0.2.0\` and attaches to slot 0.
- [x] KB2UKA bench-confirmed v0.2.0 on his G2.
- [ ] Click *Download Audio Suite* with no prior plugins installed → EQ row reports v0.2.0 (after merge of plugins-repo PR #20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)