### PR TITLE
docs: update stale Zeus.Server paths to OpenhpsdrZeus + Hosting

### DIFF
--- a/.claude/skills/run/SKILL.md
+++ b/.claude/skills/run/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run
-description: Build the Zeus frontend into wwwroot, start the Vite dev server, and start the Zeus.Server backend. Kills any process already bound to the target ports first. Optional portOffset argument (e.g. `/run 10`) shifts both ports by that amount. Optional `fresh` flag (e.g. `/run fresh`) points the backend at a throw-away `zeus-prefs.db` so persisted state from a prior session doesn't leak into the dev run.
+description: Build the Zeus frontend into wwwroot, start the Vite dev server, and start the OpenhpsdrZeus backend. Kills any process already bound to the target ports first. Optional portOffset argument (e.g. `/run 10`) shifts both ports by that amount. Optional `fresh` flag (e.g. `/run fresh`) points the backend at a throw-away `zeus-prefs.db` so persisted state from a prior session doesn't leak into the dev run.
 ---
 
 # /run — start Zeus full stack
@@ -8,10 +8,18 @@ description: Build the Zeus frontend into wwwroot, start the Vite dev server, an
 Bring up Zeus for local development:
 
 1. Free the target ports (kill any existing listeners).
-2. Build the frontend into `Zeus.Server/wwwroot`.
+2. Build the frontend into `Zeus.Server.Hosting/wwwroot`.
 3. Start the Vite dev server (live-reload frontend).
-4. Start the .NET backend.
+4. Start the .NET backend (`OpenhpsdrZeus` — the only executable project).
 5. Report the bound ports back to the user.
+
+## Project layout (don't get this wrong)
+
+The host executable and its support library have similar names — read this before editing the skill or running `dotnet run`:
+
+- **`OpenhpsdrZeus/`** — the only executable project (`OutputType=Exe`, `net10.0`). `OpenhpsdrZeus/Program.cs` reads `ZEUS_PORT`. This is what `dotnet run --project ...` targets.
+- **`Zeus.Server.Hosting/`** — a class library referenced by the host. Owns `PrefsDbPath.cs` (reads `ZEUS_PREFS_PATH`) and the `wwwroot/` directory that Vite builds into. Trying to `dotnet run` this fails with "OutputType is Library".
+- Solution file is `Zeus.slnx` (no `.sln`).
 
 ## Arguments
 
@@ -31,7 +39,7 @@ Args can appear in any order. The skill scans each one and routes by type:
 
 Both services already read their config from env vars — no code patching needed:
 
-- Backend (`Zeus.Server/Program.cs`): reads `ZEUS_PORT` env var, defaults to 6060. Still uses `ListenAnyIP` so LAN access is preserved.
+- Backend (`OpenhpsdrZeus/Program.cs`): reads `ZEUS_PORT` env var, defaults to 6060. Still uses `ListenAnyIP` so LAN access is preserved.
 - Frontend (`zeus-web/vite.config.ts`): `/api` and `/ws` proxy target reads `BACKEND_PORT` env var, defaults to 6060. Vite's own listen port is set via `--port` on the CLI.
 - Backend prefs DB (`Zeus.Server.Hosting/PrefsDbPath.cs`): reads `ZEUS_PREFS_PATH` env var. When set, every store (PaSettings, DspSettings, RadioState, Display, …) writes to that single file instead of the platform default. The `fresh` flag wires this to a `/tmp` path.
 
@@ -75,7 +83,7 @@ Do NOT use `fuser` (not default on macOS).
 npm --prefix zeus-web run build
 ```
 
-This runs `tsc -b && vite build` and writes to `Zeus.Server/wwwroot/` (`emptyOutDir: true`). Must complete before the backend starts so served assets aren't stale. If this fails, stop — do not start the servers.
+This runs `tsc -b && vite build` and writes to `Zeus.Server.Hosting/wwwroot/` (`emptyOutDir: true`, configured in `zeus-web/vite.config.ts`). Must complete before the backend starts so served assets aren't stale. If this fails, stop — do not start the servers.
 
 ### 4. Start the Vite dev server (background)
 
@@ -91,14 +99,15 @@ BACKEND_PORT=$BACKEND_PORT npm --prefix zeus-web run dev -- --port $FRONTEND_POR
 
 ```bash
 if [ "$FRESH" = "1" ]; then
-  ZEUS_PORT=$BACKEND_PORT ZEUS_PREFS_PATH="$FRESH_DB" dotnet run --project Zeus.Server
+  ZEUS_PORT=$BACKEND_PORT ZEUS_PREFS_PATH="$FRESH_DB" dotnet run --project OpenhpsdrZeus
 else
-  ZEUS_PORT=$BACKEND_PORT dotnet run --project Zeus.Server
+  ZEUS_PORT=$BACKEND_PORT dotnet run --project OpenhpsdrZeus
 fi
 ```
 
 - Run with `run_in_background: true`.
-- `ZEUS_PORT` is read in `Zeus.Server/Program.cs` to drive `ListenAnyIP`. No source edits required.
+- The host project is **`OpenhpsdrZeus`** (the only `OutputType=Exe` in the solution). `Zeus.Server.Hosting` is a class library — do not pass it to `dotnet run`.
+- `ZEUS_PORT` is read in `OpenhpsdrZeus/Program.cs` to drive `ListenAnyIP`. No source edits required.
 - `ZEUS_PREFS_PATH` (set only when `fresh` was passed) is read in `Zeus.Server.Hosting/PrefsDbPath.cs` and routes every LiteDB-backed store to the throw-away file.
 
 ### 6. Verify both ports are listening, then report
@@ -117,8 +126,8 @@ Final message must name the ports explicitly. When `fresh` was passed, also surf
 ```
 Zeus is running:
   Vite dev:  http://localhost:<FRONTEND_PORT>   (proxies /api,/ws → :<BACKEND_PORT>)
-  Backend:   http://localhost:<BACKEND_PORT>
-  wwwroot:   built from zeus-web into Zeus.Server/wwwroot
+  Backend:   http://localhost:<BACKEND_PORT>    (OpenhpsdrZeus)
+  wwwroot:   built from zeus-web into Zeus.Server.Hosting/wwwroot
   prefs DB:  <FRESH_DB>   (throw-away — clean slate for this run)   # only when fresh
 ```
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ client/dist/
 zeus-web/node_modules/
 zeus-web/dist/
 zeus-web/dev-dist/
-Zeus.Server/wwwroot/
 Zeus.Server.Hosting/wwwroot/
 
 # Stray npm artifacts from running `npm install` at the repo root.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,8 +68,9 @@ Anti-pattern to watch for (the one KB2UKA's PA-menu refactor fell into): adding 
 Backend + frontend run independently during dev:
 
 ```bash
-# backend (listens on :6060)
-dotnet run --project Zeus.Server
+# backend (listens on :6060). OpenhpsdrZeus is the executable host;
+# Zeus.Server.Hosting next to it is a class library — don't pass it to dotnet run.
+dotnet run --project OpenhpsdrZeus
 
 # frontend (Vite dev server on :5173, proxies /api and /hub to :6060)
 npm --prefix zeus-web run dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,10 +50,12 @@ Three things to know before you write a line of code:
 The repo's README has full details; the short version:
 
 ```bash
-# Backend (listens on :6060)
-dotnet run --project Zeus.Server
+# Backend (listens on :6060). OpenhpsdrZeus is the executable host;
+# Zeus.Server.Hosting next to it is a class library — don't pass it to dotnet run.
+dotnet run --project OpenhpsdrZeus
 
-# Frontend (Vite dev server on :5173, proxies /api and /ws to :6060)
+# Frontend (Vite dev server on :5173, proxies /api and /ws to :6060;
+# `vite build` writes the production bundle into Zeus.Server.Hosting/wwwroot)
 npm --prefix zeus-web run dev
 ```
 

--- a/docs/BOARD_OVERRIDE_IMPLEMENTATION.md
+++ b/docs/BOARD_OVERRIDE_IMPLEMENTATION.md
@@ -28,7 +28,7 @@ Users with **Anvelina SDR + ANAN 200D PA** boards report that Zeus auto-detects 
    - `RadioSelectionSetRequest` now includes `bool? OverrideDetection`
    - Updated XML docs to explain override behavior and warnings
 
-4. **Zeus.Server/Program.cs** - Updated API endpoints
+4. **OpenhpsdrZeus/Program.cs** - Updated API endpoints
    - GET `/api/radio/selection` returns current `OverrideDetection` status
    - PUT `/api/radio/selection` accepts optional `OverrideDetection` flag
    - Calls `prefs.Set(chosen, req.OverrideDetection)` to persist
@@ -278,10 +278,10 @@ Manual testing with actual hardware:
 ## Files Modified
 
 ### Backend
-- `Zeus.Server/PreferredRadioStore.cs`
-- `Zeus.Server/RadioService.cs`
+- `Zeus.Server.Hosting/PreferredRadioStore.cs`
+- `Zeus.Server.Hosting/RadioService.cs`
 - `Zeus.Contracts/Dtos.cs`
-- `Zeus.Server/Program.cs`
+- `OpenhpsdrZeus/Program.cs`
 - `docs/rca/anvelina-200d-detection.md` (new)
 
 ### Frontend

--- a/docs/IMPLEMENTATION-SUMMARY.md
+++ b/docs/IMPLEMENTATION-SUMMARY.md
@@ -14,7 +14,7 @@ This implementation adds comprehensive native installer support and automated re
 - Reads version from git tags during CI builds (e.g., tag `v0.1.0` → version `0.1.0`)
 - Properties set: `Version`, `AssemblyVersion`, `FileVersion`, `InformationalVersion`
 
-**File: `Zeus.Server/Program.cs`**
+**File: `OpenhpsdrZeus/Program.cs`**
 - Added `/api/version` endpoint that returns the current version from assembly attributes
 - Example response: `{"version": "0.1.0"}` or `{"version": "0.0.0-dev"}`
 
@@ -28,7 +28,7 @@ This implementation adds comprehensive native installer support and automated re
 
 ### 2. .NET Publish Profiles
 
-**Directory: `Zeus.Server/Properties/PublishProfiles/`**
+**Directory: `OpenhpsdrZeus/Properties/PublishProfiles/`**
 
 Created publish profiles for each platform:
 - `win-x64.pubxml` - Windows 64-bit
@@ -143,12 +143,12 @@ Each profile configures:
 
 **Local development** - version shows as `0.0.0-dev`:
 ```bash
-dotnet run --project Zeus.Server
+dotnet run --project OpenhpsdrZeus
 ```
 
 **Test publish** for a specific platform:
 ```bash
-dotnet publish Zeus.Server/Zeus.Server.csproj -p:PublishProfile=linux-x64 -p:VersionPrefix=0.1.0
+dotnet publish OpenhpsdrZeus/OpenhpsdrZeus.csproj -p:PublishProfile=linux-x64 -p:VersionPrefix=0.1.0
 ```
 
 ### For Maintainers
@@ -266,7 +266,7 @@ These were considered but not implemented to keep changes minimal:
 
 ### Created:
 - `zeus-web/src/components/AboutPanel.tsx` (version display + update checker)
-- `Zeus.Server/Properties/PublishProfiles/*.pubxml` (4 files)
+- `OpenhpsdrZeus/Properties/PublishProfiles/*.pubxml` (4 files)
 - `installers/zeus-windows.iss`
 - `installers/create-macos-app.sh`
 - `installers/create-linux-package.sh`
@@ -277,7 +277,7 @@ These were considered but not implemented to keep changes minimal:
 
 ### Modified:
 - `Directory.Build.props` (version management)
-- `Zeus.Server/Program.cs` (added /api/version endpoint)
+- `OpenhpsdrZeus/Program.cs` (added /api/version endpoint)
 - `zeus-web/src/components/SettingsMenu.tsx` (added About tab)
 - `.gitignore` (added installer output dirs)
 

--- a/docs/lessons/desktop-subprocess-management.md
+++ b/docs/lessons/desktop-subprocess-management.md
@@ -49,7 +49,7 @@ app.StopAsync().GetAwaiter().GetResult();
 ## Zeus.Server (Separate Process Architecture)
 
 **Platform:** Windows, macOS, Linux
-**Entry Point:** `Zeus.Server/Program.cs`
+**Entry Point:** `OpenhpsdrZeus/Program.cs`
 **Process Model:** Backend runs as standalone process, browser connects as client
 
 The installer packages for Zeus.Server include launcher scripts that:
@@ -269,5 +269,5 @@ Before sending signals, we check if the process exists with `kill -0 "$SERVER_PI
 ## See Also
 
 - `Zeus.Desktop/Program.cs` — In-process backend hosting
-- `Zeus.Server/Program.cs` — Signal handlers for graceful shutdown
+- `OpenhpsdrZeus/Program.cs` — Signal handlers for graceful shutdown
 - `docs/lessons/wdsp-init-gotchas.md` — DSP initialization ordering

--- a/docs/lessons/dev-conventions.md
+++ b/docs/lessons/dev-conventions.md
@@ -11,7 +11,7 @@ Only **one** server instance at a time — binding conflicts otherwise. `lsof -i
 
 ## Static bundle vs Vite dev
 
-`Zeus.Server/wwwroot/` is gitignored but served by `app.UseStaticFiles()` from `Program.cs`. `npm run build` writes directly to `wwwroot/` (Vite config's `outDir`). When debugging a frontend change, rebuild **before** reloading the browser — otherwise you're testing an old bundle.
+`Zeus.Server.Hosting/wwwroot/` is gitignored but served by `app.UseStaticFiles()` from `OpenhpsdrZeus/Program.cs` (which references the `Zeus.Server.Hosting` library). `npm run build` writes directly there (Vite config's `outDir`). When debugging a frontend change, rebuild **before** reloading the browser — otherwise you're testing an old bundle.
 
 Vite dev mode (`npm run dev` on `:5173`) reads source directly and hot-reloads — handy for fast iteration but not what a live user's browser would hit.
 

--- a/docs/lessons/disconnection-troubleshooting.md
+++ b/docs/lessons/disconnection-troubleshooting.md
@@ -83,7 +83,7 @@ Check backend terminal for:
 - Out of memory errors
 
 **Resolution:**
-1. Restart `dotnet run --project Zeus.Server`
+1. Restart `dotnet run --project OpenhpsdrZeus`
 2. If it crashes immediately, check WDSP wisdom:
    - Did you wait for wisdom to complete on first run?
    - See [README.md](../../README.md) "First run — wait for WDSP wisdom"
@@ -143,7 +143,7 @@ If you see "RX: N consecutive socket timeouts" but UI still shows "Connected", y
 **Option 1: Build once, run production build**
 ```bash
 cd zeus-web && npm run build
-dotnet run --project Zeus.Server
+dotnet run --project OpenhpsdrZeus
 # Open http://localhost:6060 (no Vite dev server)
 ```
 No hot-reload, but no WebSocket disconnects either.
@@ -160,7 +160,7 @@ cd zeus-web && npm run build
 
 # Terminal 2: Run backend only
 cd ..
-dotnet run --project Zeus.Server
+dotnet run --project OpenhpsdrZeus
 
 # Connect via http://localhost:6060
 # No Vite = no dev disconnects

--- a/docs/lessons/hl2-drive-model.md
+++ b/docs/lessons/hl2-drive-model.md
@@ -99,7 +99,7 @@ reference. Those are piHPSDR-isms that don't apply to HL2's gateware.
 
 ## What Zeus now does
 
-`Zeus.Server/RadioDriveProfile.cs — HermesLite2DriveProfile.EncodeDriveByte`:
+`Zeus.Server.Hosting/RadioDriveProfile.cs — HermesLite2DriveProfile.EncodeDriveByte`:
 
     byte_raw = round( (drivePct/100) × (paGainDb/100) × 255 )
     byte     = round( byte_raw / 16 ) × 16            // nibble-quantise
@@ -186,8 +186,8 @@ the profile abstraction landed, and before this percentage-model fix.
 
 - `docs/references/protocol-1/hermes-lite2-protocol.md:51` — the one
   line that would have saved two days.
-- `Zeus.Server/RadioDriveProfile.cs` — `HermesLite2DriveProfile`.
-- `Zeus.Server/PaDefaults.cs` — `Hl2OutputPct` table (HF 100 / 6 m 38.8).
+- `Zeus.Server.Hosting/RadioDriveProfile.cs` — `HermesLite2DriveProfile`.
+- `Zeus.Server.Hosting/PaDefaults.cs` — `Hl2OutputPct` table (HF 100 / 6 m 38.8).
 - `Zeus.Protocol1/ControlFrame.cs` — `LastPeakAbs` / `LastDriveByte`
   instrumentation; `Protocol1Client.TxLoopAsync`'s `p1.tx.rate` log
   surfaces them at 1 Hz.

--- a/docs/lessons/native-lib-requirements.md
+++ b/docs/lessons/native-lib-requirements.md
@@ -72,7 +72,7 @@ For production use and actual radio operation, WDSP native libraries are require
 
 - `Zeus.Dsp/Wdsp/WdspNativeLoader.cs` — Native library resolution logic
 - `Zeus.Dsp/Wdsp/WdspWisdomInitializer.cs` — Wisdom file initialization
-- `Zeus.Server/WisdomBootstrapService.cs` — Kicks off wisdom generation at startup
+- `Zeus.Server.Hosting/WisdomBootstrapService.cs` — Kicks off wisdom generation at startup
 - `native/wdsp/CMakeLists.txt` — Cross-platform WDSP build configuration
 - `.github/workflows/build-native-libs.yml` — Automated build workflow
 

--- a/docs/perf/perf_pass_3_latency.md
+++ b/docs/perf/perf_pass_3_latency.md
@@ -356,7 +356,7 @@ window:
 
 ```bash
 git stash push -m 'perf-pass-3 latency instrumentation' -- \
-  Zeus.Server/Program.cs \
+  OpenhpsdrZeus/Program.cs \
   Zeus.Server.Hosting/ZeusHost.cs \
   Zeus.Server.Hosting/TxService.cs \
   Zeus.Server.Hosting/DspPipelineService.cs \

--- a/docs/perf/perf_pass_3_server.md
+++ b/docs/perf/perf_pass_3_server.md
@@ -7,8 +7,8 @@ quantification from `perf_pass_3_baseline.md` §3, and the expected delta
 on the alloc-rate / work-item / CPU axes captured from Brian's live HL2
 session.
 
-> **Measurement note.** Brian's live Zeus.Server (PID 13972, Debug,
-> `OPENHPSDR-Zeus/Zeus.Server/bin/Debug/net10.0`) is the only process on
+> **Measurement note.** Brian's live OpenhpsdrZeus (PID 13972, Debug,
+> `OPENHPSDR-Zeus/OpenhpsdrZeus/bin/Debug/net10.0`) is the only process on
 > the box currently driving the HL2 hot paths (RxLoop / StartIqPump /
 > TxLoop / StreamingHub broadcasts). The perf3 worktree's Release build
 > with no radio attached reaches a floor of **~31 KB/s alloc, ~62

--- a/docs/prds/plugins-system-architecture.md
+++ b/docs/prds/plugins-system-architecture.md
@@ -277,7 +277,7 @@ public interface IPluginContext
 
 **Lifecycle:**
 ```csharp
-// Zeus.Server/Plugins/PluginManager.cs
+// Zeus.Plugins.Host/PluginManager.cs
 public class PluginManager : IHostedService
 {
     private readonly List<AssemblyLoadContext> _contexts = new();
@@ -371,7 +371,7 @@ message RadioEvent {
 
 **Lifecycle:**
 ```csharp
-// Zeus.Server/Plugins/PluginProcess.cs
+// Zeus.Plugins.Host/PluginProcess.cs
 public class PluginProcess : IAsyncDisposable
 {
     private Process? _process;
@@ -644,7 +644,7 @@ Each plugin ships with `plugin.json` alongside its `.dll`:
 ### 5.4 Plugin lifecycle
 
 ```csharp
-// Zeus.Server/Plugins/PluginManager.cs (simplified)
+// Zeus.Plugins.Host/PluginManager.cs (simplified)
 public class PluginManager : IHostedService
 {
     private readonly List<PluginInstance> _plugins = new();
@@ -965,7 +965,7 @@ MyPlugin/
 
 ```
 Zeus.Contracts/Plugins/       — Plugin interfaces, DTOs
-Zeus.Server/Plugins/          — PluginManager, PluginContext, loader
+Zeus.Plugins.Host/          — PluginManager, PluginContext, loader
 Zeus.PluginHost/              — Separate process host (for isolated plugins)
 Zeus.Plugin.Template/         — dotnet new template
 ```
@@ -986,7 +986,7 @@ app.MapPluginEndpoints();  // Extension method iterates plugins, calls IPluginHt
 Plugins can subscribe to hub events:
 
 ```csharp
-// Zeus.Server/StreamingHub.cs
+// Zeus.Server.Hosting/StreamingHub.cs
 public event Action<DisplayFrame>? DisplayFrameReceived;
 public event Action<FrequencyChanged>? FrequencyChanged;
 // ... existing events become public for plugins
@@ -1033,7 +1033,7 @@ export function PluginLoader() {
 Each plugin gets scoped LiteDB collection:
 
 ```csharp
-// Zeus.Server/Plugins/PluginSettingsStore.cs
+// Zeus.Plugins.Host/PluginSettingsStore.cs
 public class PluginSettingsStore
 {
     private readonly ILiteDatabase _db;
@@ -1070,7 +1070,7 @@ public class PluginSettingsStore
 
 **Deliverables:**
 - `Zeus.Contracts/Plugins/` — interfaces.
-- `Zeus.Server/Plugins/PluginManager.cs` — loads `.dll` from `plugins/` dir.
+- `Zeus.Plugins.Host/PluginManager.cs` — loads `.dll` from `plugins/` dir.
 - Sample plugin: `HelloWorldPlugin` (logs "Hello from plugin!" on init).
 - REST API: `GET /api/plugins` (list), `POST /api/plugins/{id}/enable`.
 - zeus-web: `/settings/plugins` page.

--- a/docs/proposals/audio-chain/01-aethersdr-and-external-deps.md
+++ b/docs/proposals/audio-chain/01-aethersdr-and-external-deps.md
@@ -429,7 +429,7 @@ each paired with the legitimate alternative.
 | `src/core/ClientReverb.cpp` | Freeverb implementation | Use [verblib](https://github.com/blastbay/verblib) (single-file C89, MIT-or-public-domain) or [sinshu/freeverb](https://github.com/sinshu/freeverb) (Jezar's original, public domain) |
 | `src/core/ClientPudu.cpp` | Aphex Aural Exciter + Big Bottom in one file | High band: hand-author from [Airwindows Exciter](https://github.com/airwindows/airwindows) reference (MIT). Low band: see §3.4 — algorithm choice is open question |
 | `src/core/AudioEngine.cpp` | The TX/RX chain dispatcher loop | Hand-author Zeus's own block-chain dispatcher; the dispatcher is not novel and is straightforward to write |
-| `src/core/ChannelStripPresets.cpp` | JSON preset serialization | Hand-author using Zeus's existing System.Text.Json patterns from `Zeus.Server/RadioStateStore.cs` |
+| `src/core/ChannelStripPresets.cpp` | JSON preset serialization | Hand-author using Zeus's existing System.Text.Json patterns from `Zeus.Server.Hosting/RadioStateStore.cs` |
 
 ### 2.5 Plugin / weight licensing — not applicable to v1
 

--- a/docs/proposals/band-planning-prd.md
+++ b/docs/proposals/band-planning-prd.md
@@ -124,11 +124,11 @@ Mode-matching rules:
 
 ## 4. Default regional data (shipped with Zeus.Server)
 
-Ships as JSON under `Zeus.Server/BandPlans/` (one file per region). Loaded into a new
+Ships as JSON under `Zeus.Server.Hosting/BandPlans/` (one file per region). Loaded into a new
 `BandPlanStore` on startup. Layout:
 
 ```
-Zeus.Server/BandPlans/
+Zeus.Server.Hosting/BandPlans/
   regions.json                 # region catalog (id, display, shortCode, parentId)
   IARU_R1.segments.json        # generic Region 1 baseline
   IARU_R2.segments.json        # generic Region 2 baseline

--- a/docs/proposals/midi.md
+++ b/docs/proposals/midi.md
@@ -58,7 +58,7 @@ Zeus.Midi/
 - Device hot-plug surfaced via the library's watcher.
 - No knowledge of Zeus radio commands — pure I/O.
 
-### 4.2 `Zeus.Server/MidiService.cs` (hosted service)
+### 4.2 `Zeus.Server.Hosting/MidiService.cs` (hosted service)
 
 - Owns the `IMidiEngine` instance.
 - Loads / saves `midi-mappings.json`.

--- a/docs/rca/2026-04-21-tx-stage-meters-alc-gr-sign-mic-pk.md
+++ b/docs/rca/2026-04-21-tx-stage-meters-alc-gr-sign-mic-pk.md
@@ -54,7 +54,7 @@ browser-worklet mic level.
 |------|--------|
 | `Zeus.Dsp/TxStageMeters.cs` | Added `MicPk` field; documented `AlcGr` sign convention |
 | `Zeus.Dsp/Wdsp/WdspDspEngine.cs` | Store `MicPk` in snapshot; negate `alcGain` → `AlcGr` |
-| `Zeus.Server/TxMetersService.cs` | Use `stage.MicPk` for `TxMetersFrame.MicDbfs`; removed dead `MicDbfsPlaceholder` |
+| `Zeus.Server.Hosting/TxMetersService.cs` | Use `stage.MicPk` for `TxMetersFrame.MicDbfs`; removed dead `MicDbfsPlaceholder` |
 | `zeus-web/src/state/tx-store.ts` | Added `wdspMicPk` field; `setMeters` maps `m.micDbfs → wdspMicPk` |
 | `zeus-web/src/components/TxStageMeters.tsx` | Added MIC row at top of chain |
 

--- a/docs/rca/2026-04-23-disconnection-investigation.md
+++ b/docs/rca/2026-04-23-disconnection-investigation.md
@@ -67,7 +67,7 @@ const MAX_BACKOFF_MS = 8000;
 
 ### RadioService Connection Lifecycle
 
-**Location:** `Zeus.Server/RadioService.cs:156-240`
+**Location:** `Zeus.Server.Hosting/RadioService.cs:156-240`
 
 **Connection flow:**
 1. `ConnectAsync`: Creates Protocol1Client, sets state to Connecting
@@ -85,7 +85,7 @@ const MAX_BACKOFF_MS = 8000;
 
 ### StreamingHub Session Management
 
-**Location:** `Zeus.Server/StreamingHub.cs:86-107`
+**Location:** `Zeus.Server.Hosting/StreamingHub.cs:86-107`
 
 **Per-client lifecycle:**
 - Each WebSocket client gets a unique session

--- a/docs/rca/anvelina-200d-detection.md
+++ b/docs/rca/anvelina-200d-detection.md
@@ -102,7 +102,7 @@ This avoids architectural changes while solving the operator's immediate problem
 ## References
 - Zeus.Protocol1/Discovery/ReplyParser.cs - board ID mapping
 - Zeus.Protocol1/ControlFrame.cs - ATT and filter control encoding
-- Zeus.Server/RadioService.cs - ConnectedBoardKind vs EffectiveBoardKind
-- Zeus.Server/PreferredRadioStore.cs - board preference storage
-- Zeus.Server/PaDefaults.cs - per-board PA gain tables
+- Zeus.Server.Hosting/RadioService.cs - ConnectedBoardKind vs EffectiveBoardKind
+- Zeus.Server.Hosting/PreferredRadioStore.cs - board preference storage
+- Zeus.Server.Hosting/PaDefaults.cs - per-board PA gain tables
 - docs/references/supported-settings.md - capability matrix

--- a/docs/references/supported-settings.md
+++ b/docs/references/supported-settings.md
@@ -44,7 +44,7 @@ Legend: ✅ supported · ⚠️ partial / with caveat · ✗ not supported · �
 
 | Setting | HL2 | G2 (P1) | G2 (P2) | Notes / Zeus source |
 |---|:---:|:---:|:---:|---|
-| Max rated TX power (W) | 5 | 100 | 100 | `Zeus.Server/PaDefaults.cs` (per-board max) |
+| Max rated TX power (W) | 5 | 100 | 100 | `Zeus.Server.Hosting/PaDefaults.cs` (per-board max) |
 | PA gain defaults (dB) | 40.5 flat | 44.6–50.9 per band | *TODO — P2 tables not yet seeded* | PaDefaults.cs lines ~30–110 |
 | Drive level | ✅ C0 `0x09[31:28]` (4-bit) | ✅ | ✅ (P2 equivalent register) | |
 | PureSignal | ✅ (`0x0A[22]`) | ✅ | ✅ | |

--- a/docs/tci-test-plan.md
+++ b/docs/tci-test-plan.md
@@ -50,7 +50,7 @@ The new test cases under `TciTxAudioReceiverTests` cover:
 
 ### Setup
 
-1. **Backend:** `dotnet run --project Zeus.Server` (listens on :6060 by default; TCI on :40001 when enabled).
+1. **Backend:** `dotnet run --project OpenhpsdrZeus` (listens on :6060 by default; TCI on :40001 when enabled).
 2. **Frontend:** `npm --prefix zeus-web run dev` (Vite on :5173).
 3. **Enable TCI** in `appsettings.Development.json`:
    ```json

--- a/zeus-web/src/components/bandplan/BandPlanEditor.tsx
+++ b/zeus-web/src/components/bandplan/BandPlanEditor.tsx
@@ -162,7 +162,7 @@ export function BandPlanEditor() {
 
       <div style={{ fontSize: 10, color: 'var(--fg-3)', background: 'rgba(255,160,40,0.06)', border: '1px solid rgba(255,160,40,0.15)', borderRadius: 0, padding: '6px 10px' }}>
         Defaults are best-effort. You are responsible for operating within your licence.
-        Source files under Zeus.Server/BandPlans/ — corrections welcome as PRs.
+        Source files under Zeus.Server.Hosting/BandPlans/ — corrections welcome as PRs.
       </div>
 
       {error && (

--- a/zeus-web/src/state/pa-store.ts
+++ b/zeus-web/src/state/pa-store.ts
@@ -29,7 +29,7 @@ import {
   type PaSettings,
 } from '../api/pa';
 
-// Canonical HF band order — must match Zeus.Server/BandUtils.HfBands. The
+// Canonical HF band order — must match Zeus.Server.Hosting/BandUtils.HfBands. The
 // settings panel iterates this for a consistent row order even when the
 // backend returns bands in a different order or omits some.
 export const HF_BANDS: readonly string[] = [


### PR DESCRIPTION
## Summary
- The executable host is `OpenhpsdrZeus` (the only `OutputType=Exe` in the solution); shared backend code lives in `Zeus.Server.Hosting/`; plugin code in `Zeus.Plugins.Host/`. Many docs, the bundled `/run` skill, and a couple of TS comments still pointed at the dead `Zeus.Server/` prefix.
- This trips up `dotnet run --project Zeus.Server` (also `Zeus.Server.Hosting`, which is a class library and errors with *"OutputType is Library"*). Caught when running `/run` on a fresh checkout.
- Scope: `/run` skill, `CLAUDE.md`, `CONTRIBUTING.md`, 5 lessons, 3 RCAs, 4 PRDs/proposals, 2 perf docs, `references/supported-settings`, 2 historical implementation summaries, `tci-test-plan`, 2 TS comments, and `.gitignore` (drop dead `Zeus.Server/wwwroot/` entry).
- The `docs/perf/artifacts/*.speedscope.json` trace artefact retains its captured-at-write-time process name on purpose — modifying it would falsify the perf capture.
- No code behaviour changes.

## Test plan
- [x] `dotnet build Zeus.slnx -warnaserror` → 0 warnings, 0 errors
- [x] `dotnet test Zeus.slnx` → 1132 passed, 0 failed (107 skipped; xfail/integration, expected)
- [x] `npm --prefix zeus-web run build` → clean (writes to `Zeus.Server.Hosting/wwwroot/`)
- [x] `/run` skill end-to-end: backend on :6060 (`OpenhpsdrZeus`), Vite on :5173, both bind successfully

73 de EA5IUE