### PR TITLE
fix(analog-meter): give S readout 2x grid width, lock PO/SWR slots

### DIFF
--- a/zeus-web/src/components/analog-meter/AnalogMeterPanel.tsx
+++ b/zeus-web/src/components/analog-meter/AnalogMeterPanel.tsx
@@ -146,7 +146,11 @@ function ReadoutStrip({ enabled, values, showDbm, dbm, swrAlarm, activeScaleId }
   return (
     <div className="am-readout-strip">
       {items.map((it) => (
-        <div key={it.key} className={`am-ro ${it.active ? 'active' : ''} ${it.danger ? 'danger' : ''}`}>
+        <div
+          key={it.key}
+          className={`am-ro ${it.active ? 'active' : ''} ${it.danger ? 'danger' : ''}`}
+          data-scale={it.key}
+        >
           <div className="am-ro-label">{it.label}</div>
           <div className="am-ro-value">{it.value}</div>
         </div>

--- a/zeus-web/src/styles/analog-meter.css
+++ b/zeus-web/src/styles/analog-meter.css
@@ -136,14 +136,14 @@
 
 /* ── Readout strip ────────────────────────────────────────── */
 .am-readout-strip {
-  display: flex;
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr;
   gap: 1px;
   background: var(--panel-edge);
   border-top: 1px solid var(--panel-edge);
   flex-shrink: 0;
 }
 .am-ro {
-  flex: 1;
   padding: 8px 12px;
   background: var(--bg-1);
   display: flex;
@@ -152,6 +152,10 @@
   gap: 2px;
   min-width: 0;
 }
+.am-ro[data-scale="s"]   { grid-column: 1; }
+.am-ro[data-scale="po"]  { grid-column: 2; }
+.am-ro[data-scale="swr"] { grid-column: 3; }
+.am-ro.empty { grid-column: 1 / -1; }
 .am-ro.active { background: var(--accent-soft); }
 .am-ro.danger .am-ro-value { color: var(--tx); }
 .am-ro-label {


### PR DESCRIPTION
## Summary
- Convert the analog S-meter readout strip from flex to a 3-column CSS grid (`2fr 1fr 1fr`).
- Tag each readout with `data-scale` so S / PO / SWR always land in their fixed slots regardless of which scales are enabled — toggling PO or SWR off no longer reflows S into the wrong width.

## Why
At the meter's default width the longer `S / dBm` readout (e.g. `S9 + 20  ·  -53 dBm`) was getting crowded next to the PO and SWR columns. Giving signal twice the column width restores legibility without changing the dial face or any of the ballistic / scale logic.

## Test plan
- [ ] Open the S-Meter tile with all three scales enabled (S, PO, SWR) — S column visibly wider than PO and SWR.
- [ ] Toggle PO off — S stays at 2fr in column 1, SWR stays in column 3 (column 2 left blank rather than reflowing).
- [ ] Toggle all scales off — "No scales enabled" message spans the full strip.
- [ ] Light + dark themes both still pass the readout-strip border / `--accent-soft` active state.