### PR TITLE
feat(mobile): replace Settings tab with Tools drawer + per-tool pages

### DIFF
--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -651,10 +651,12 @@ export default function App() {
   // still required because Panadapter depends on the gesture context.
   if (isMobile) {
     return (
-      <SpectrumWheelActionsContext.Provider value={spectrumWheelActions}>
-        <ThemeApplier />
-        <MobileApp />
-      </SpectrumWheelActionsContext.Provider>
+      <WorkspaceContext.Provider value={workspaceCtx}>
+        <SpectrumWheelActionsContext.Provider value={spectrumWheelActions}>
+          <ThemeApplier />
+          <MobileApp />
+        </SpectrumWheelActionsContext.Provider>
+      </WorkspaceContext.Provider>
     );
   }
 

--- a/zeus-web/src/layout/panels.ts
+++ b/zeus-web/src/layout/panels.ts
@@ -49,6 +49,7 @@ import { SMeterPanel } from './panels/SMeterPanel';
 import { QrzPanel } from './panels/QrzPanel';
 import { AzimuthPanel } from './panels/AzimuthPanel';
 import { RotatorCompassPanel } from './panels/RotatorCompassPanel';
+import { RotatorDialPanel } from './panels/RotatorDialPanel';
 import { DspFlexPanel } from './panels/DspFlexPanel';
 import { CwPanel } from './panels/CwPanel';
 import { LogbookPanel } from './panels/LogbookPanel';
@@ -199,6 +200,13 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'tools',
     tags: ['rotator', 'compass', 'bearing', 'heading', 'sp', 'lp', 'map'],
     component: RotatorCompassPanel,
+  },
+  rotatordial: {
+    id: 'rotatordial',
+    name: 'Rotator Dial',
+    category: 'tools',
+    tags: ['rotator', 'compass', 'dial', 'bearing', 'heading', 'azimuth'],
+    component: RotatorDialPanel,
   },
   dsp: {
     id: 'dsp',

--- a/zeus-web/src/layout/panels/RotatorDialPanel.tsx
+++ b/zeus-web/src/layout/panels/RotatorDialPanel.tsx
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+import { forwardRef, useRef, useState, type PointerEvent } from 'react';
+import { useRotatorStore } from '../../state/rotator-store';
+
+function normalizeAz(deg: number | null | undefined): number | null {
+  if (deg == null || !Number.isFinite(deg)) return null;
+  return ((deg % 360) + 360) % 360;
+}
+
+function fmtAz(deg: number | null): string {
+  if (deg == null) return '---°';
+  return `${deg.toFixed(0).padStart(3, '0')}°`;
+}
+
+export function RotatorDialPanel() {
+  const rotConnected = useRotatorStore((s) => !!s.status?.connected);
+  const rotEnabled = useRotatorStore((s) => s.config.enabled);
+  const rotMoving = useRotatorStore((s) => !!s.status?.moving);
+  const rotCurrentAz = useRotatorStore((s) => normalizeAz(s.status?.currentAz));
+  const rotTargetAz = useRotatorStore((s) => normalizeAz(s.status?.targetAz));
+  const setAzimuth = useRotatorStore((s) => s.setAzimuth);
+  const stopRotator = useRotatorStore((s) => s.stop);
+
+  const rotReady = rotEnabled && rotConnected;
+  const dialRef = useRef<SVGSVGElement | null>(null);
+  const [manualInput, setManualInput] = useState('');
+
+  const manualHeadingDeg = (() => {
+    const n = Number.parseFloat(manualInput);
+    if (!Number.isFinite(n)) return null;
+    return ((n % 360) + 360) % 360;
+  })();
+  const manualHeadingValid = manualHeadingDeg != null && manualInput.trim() !== '';
+
+  const submitManualHeading = () => {
+    if (!rotReady || manualHeadingDeg == null) return;
+    void setAzimuth(Math.round(manualHeadingDeg));
+  };
+
+  const handleDialPointerDown = (e: PointerEvent<SVGSVGElement>) => {
+    if (!rotReady) return;
+    const svg = dialRef.current;
+    if (!svg) return;
+    const rect = svg.getBoundingClientRect();
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+    const dx = e.clientX - cx;
+    const dy = e.clientY - cy;
+    // Reject clicks too close to the hub (avoid accidental commands).
+    const dist = Math.hypot(dx, dy);
+    if (dist < Math.min(rect.width, rect.height) * 0.12) return;
+    // N = 0° at top, clockwise. atan2(dx, -dy) yields that convention.
+    const rad = Math.atan2(dx, -dy);
+    let deg = (rad * 180) / Math.PI;
+    if (deg < 0) deg += 360;
+    void setAzimuth(Math.round(deg));
+  };
+
+  const statusLabel = !rotEnabled
+    ? 'Rotator disabled'
+    : !rotConnected
+      ? 'Connecting…'
+      : null;
+
+  return (
+    <div className={`rotator-dial${rotReady ? '' : ' disabled'}`}>
+      <div className="rd-stage">
+        <CompassDial
+          ref={dialRef}
+          currentAz={rotCurrentAz}
+          targetAz={rotMoving ? rotTargetAz : null}
+          interactive={rotReady}
+          onPointerDown={handleDialPointerDown}
+        />
+        <div className="rd-readout">
+          <span className="rd-readout-label">HDG</span>
+          <span className="rd-readout-now">{fmtAz(rotCurrentAz)}</span>
+          {rotMoving && rotTargetAz != null && (
+            <span className="rd-readout-tgt">→ {fmtAz(rotTargetAz)}</span>
+          )}
+        </div>
+        {statusLabel && (
+          <div className="rd-offline-banner" role="status">{statusLabel}</div>
+        )}
+      </div>
+
+      <div className="rd-controls">
+        <form
+          className="rd-manual"
+          onSubmit={(e) => {
+            e.preventDefault();
+            submitManualHeading();
+          }}
+        >
+          <input
+            type="number"
+            inputMode="numeric"
+            min={0}
+            max={359}
+            step={1}
+            className="rd-input"
+            placeholder="HDG"
+            value={manualInput}
+            onChange={(e) => setManualInput(e.currentTarget.value)}
+            aria-label="Heading in degrees"
+            disabled={!rotReady}
+          />
+          <button
+            type="submit"
+            className="rd-btn rd-btn--go"
+            disabled={!rotReady || !manualHeadingValid}
+            title={rotReady ? 'Rotate to entered heading' : 'Rotator not connected'}
+          >
+            GO
+          </button>
+        </form>
+        <button
+          type="button"
+          className="rd-btn rd-btn--stop"
+          onClick={() => { void stopRotator(); }}
+          disabled={!rotReady || !rotMoving}
+          title={rotMoving ? 'Stop rotator' : 'Rotator is idle'}
+        >
+          STOP
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// CompassDial — SVG, 200×200 viewBox, scales to fit container.
+// ============================================================================
+
+type CompassDialProps = {
+  currentAz: number | null;
+  targetAz: number | null;
+  interactive: boolean;
+  onPointerDown?: (e: PointerEvent<SVGSVGElement>) => void;
+};
+
+const C = 100;
+const NEEDLE_TRANSITION = 'transform 320ms cubic-bezier(.22,.61,.36,1)';
+
+const CompassDial = forwardRef<SVGSVGElement, CompassDialProps>(function CompassDial(
+  { currentAz, targetAz, interactive, onPointerDown },
+  ref,
+) {
+  // Ticks every 5°; major at 30°; cardinal at 90°.
+  const ticks: Array<{ deg: number; tier: 'cardinal' | 'major' | 'minor' }> = [];
+  for (let d = 0; d < 360; d += 5) {
+    ticks.push({
+      deg: d,
+      tier: d % 90 === 0 ? 'cardinal' : d % 30 === 0 ? 'major' : 'minor',
+    });
+  }
+
+  const labels: ReadonlyArray<{ deg: number; text: string; size: 'lg' | 'sm'; cls?: string }> = [
+    { deg: 0, text: 'N', size: 'lg', cls: 'rd-cardinal-n' },
+    { deg: 45, text: 'NE', size: 'sm' },
+    { deg: 90, text: 'E', size: 'lg' },
+    { deg: 135, text: 'SE', size: 'sm' },
+    { deg: 180, text: 'S', size: 'lg' },
+    { deg: 225, text: 'SW', size: 'sm' },
+    { deg: 270, text: 'W', size: 'lg' },
+    { deg: 315, text: 'NW', size: 'sm' },
+  ];
+
+  // Inner degree numerals at every 30° (skip cardinals — those have letters).
+  const numerals: number[] = [];
+  for (let d = 0; d < 360; d += 30) {
+    if (d % 90 !== 0) numerals.push(d);
+  }
+
+  function polar(deg: number, r: number): [number, number] {
+    const rad = (deg * Math.PI) / 180;
+    return [C + r * Math.sin(rad), C - r * Math.cos(rad)];
+  }
+
+  const showNeedle = currentAz != null;
+  const showTarget = targetAz != null && Math.abs((targetAz ?? 0) - (currentAz ?? targetAz ?? 0)) > 0.5;
+
+  return (
+    <svg
+      ref={ref}
+      className="rd-dial"
+      viewBox="0 0 200 200"
+      preserveAspectRatio="xMidYMid meet"
+      onPointerDown={onPointerDown}
+      role="img"
+      aria-label="Rotator compass dial"
+    >
+      <defs>
+        <radialGradient id="rd-face" cx="50%" cy="50%" r="55%">
+          <stop offset="0%" stopColor="var(--immersive-lamp-well-top)" />
+          <stop offset="100%" stopColor="var(--immersive-lamp-well-bot)" />
+        </radialGradient>
+        <linearGradient id="rd-bezel" x1="0%" y1="0%" x2="0%" y2="100%">
+          <stop offset="0%" stopColor="var(--immersive-rim-strong)" />
+          <stop offset="48%" stopColor="var(--immersive-rim)" />
+          <stop offset="100%" stopColor="rgba(0,0,0,0.55)" />
+        </linearGradient>
+        <radialGradient id="rd-bloom" cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stopColor="var(--immersive-lamp-bloom-1)" />
+          <stop offset="55%" stopColor="var(--immersive-lamp-bloom-3)" />
+          <stop offset="100%" stopColor="rgba(0,0,0,0)" />
+        </radialGradient>
+        <filter id="rd-needle-glow" x="-30%" y="-30%" width="160%" height="160%">
+          <feGaussianBlur stdDeviation="1.2" result="b" />
+          <feMerge>
+            <feMergeNode in="b" />
+            <feMergeNode in="SourceGraphic" />
+          </feMerge>
+        </filter>
+        <filter id="rd-target-glow" x="-30%" y="-30%" width="160%" height="160%">
+          <feGaussianBlur stdDeviation="1.6" />
+        </filter>
+      </defs>
+
+      {/* outer chassis disc — gives the bezel its dark seat */}
+      <circle cx={C} cy={C} r={98} fill="var(--bg-1)" />
+      {/* brushed bezel ring */}
+      <circle cx={C} cy={C} r={96} fill="url(#rd-bezel)" stroke="var(--line-strong)" strokeWidth="1" />
+      <circle cx={C} cy={C} r={89} fill="none" stroke="var(--immersive-lamp-rim)" strokeWidth="0.6" />
+
+      {/* face */}
+      <circle cx={C} cy={C} r={87} fill="url(#rd-face)" stroke="var(--immersive-lamp-border)" strokeWidth="0.6" />
+      {/* warm bloom in well — fades to transparent in light theme via tokens */}
+      <circle cx={C} cy={C} r={82} fill="url(#rd-bloom)" pointerEvents="none" />
+      {/* inset shadow rim — subtle */}
+      <circle cx={C} cy={C} r={87} fill="none" stroke="var(--immersive-arc-track-shadow)" strokeWidth="1.4" opacity="0.55" pointerEvents="none" />
+
+      {/* tick marks */}
+      <g className="rd-ticks">
+        {ticks.map(({ deg, tier }) => {
+          const rOut = 80;
+          const rIn = tier === 'cardinal' ? 66 : tier === 'major' ? 70 : 75;
+          const [x1, y1] = polar(deg, rOut);
+          const [x2, y2] = polar(deg, rIn);
+          return (
+            <line
+              key={`t-${deg}`}
+              x1={x1} y1={y1} x2={x2} y2={y2}
+              className={`rd-tick rd-tick--${tier}`}
+            />
+          );
+        })}
+      </g>
+
+      {/* inner degree numerals (small) */}
+      <g className="rd-numerals">
+        {numerals.map((deg) => {
+          const [x, y] = polar(deg, 56);
+          return (
+            <text
+              key={`n-${deg}`}
+              x={x} y={y}
+              textAnchor="middle"
+              dominantBaseline="central"
+              className="rd-numeral"
+              transform={`rotate(${deg} ${x} ${y})`}
+            >
+              {deg.toString().padStart(3, '0')}
+            </text>
+          );
+        })}
+      </g>
+
+      {/* cardinal + intercardinal labels */}
+      <g className="rd-labels">
+        {labels.map(({ deg, text, size, cls }) => {
+          const r = size === 'lg' ? 41 : 44;
+          const [x, y] = polar(deg, r);
+          return (
+            <text
+              key={`l-${text}`}
+              x={x} y={y}
+              textAnchor="middle"
+              dominantBaseline="central"
+              className={`rd-label rd-label--${size}${cls ? ` ${cls}` : ''}`}
+            >
+              {text}
+            </text>
+          );
+        })}
+      </g>
+
+      {/* fixed lubber-line at top — the "you are pointing here" reference */}
+      <g className="rd-lubber" pointerEvents="none">
+        <polygon points={`${C - 3.2},6 ${C + 3.2},6 ${C},12`} />
+      </g>
+
+      {/* target heading marker (pending rotation) */}
+      {showTarget && targetAz != null && (
+        <g
+          className="rd-target"
+          transform={`rotate(${targetAz} ${C} ${C})`}
+          style={{ transition: NEEDLE_TRANSITION }}
+          pointerEvents="none"
+        >
+          <line x1={C} y1={20} x2={C} y2={32} className="rd-target-line" />
+          <polygon points={`${C - 4},20 ${C + 4},20 ${C},14`} className="rd-target-tip" />
+        </g>
+      )}
+
+      {/* needle — drawn pointing north, rotated to currentAz */}
+      {showNeedle && currentAz != null && (
+        <g
+          className="rd-needle"
+          transform={`rotate(${currentAz} ${C} ${C})`}
+          style={{ transition: NEEDLE_TRANSITION }}
+          filter="url(#rd-needle-glow)"
+          pointerEvents="none"
+        >
+          {/* tail (back half, subdued) */}
+          <polygon
+            points={`${C - 2.6},${C} ${C + 2.6},${C} ${C},${C + 38}`}
+            className="rd-needle-tail"
+          />
+          {/* head (front half, bright) */}
+          <polygon
+            points={`${C - 3.2},${C} ${C + 3.2},${C} ${C},${C - 64}`}
+            className="rd-needle-head"
+          />
+        </g>
+      )}
+
+      {/* hub cap */}
+      <circle cx={C} cy={C} r={7} className="rd-hub-base" pointerEvents="none" />
+      <circle cx={C} cy={C} r={4.2} className="rd-hub-ring" pointerEvents="none" />
+      <circle cx={C} cy={C} r={2.2} className="rd-hub-pin" pointerEvents="none" />
+
+      {/* invisible hit-target — makes the whole face clickable while
+          the visible artwork is non-interactive */}
+      {interactive && (
+        <circle
+          cx={C} cy={C} r={87}
+          fill="rgba(0,0,0,0)"
+          style={{ cursor: 'crosshair' }}
+        />
+      )}
+    </svg>
+  );
+});

--- a/zeus-web/src/main.tsx
+++ b/zeus-web/src/main.tsx
@@ -84,6 +84,7 @@ import './styles/all-panels.css';
 import './styles/ps-settings.css';
 import './styles/pa-settings.css';
 import './styles/analog-meter.css';
+import './styles/rotator-dial.css';
 import App from './App.tsx';
 import { installFetchInterceptor } from './serverUrl';
 import { loadInstalledPluginUis } from './plugins/runtime/pluginRuntime';

--- a/zeus-web/src/mobile/MobileApp.tsx
+++ b/zeus-web/src/mobile/MobileApp.tsx
@@ -34,6 +34,10 @@ import { ConnectPanel } from '../components/ConnectPanel';
 import { LeafletWorldMap } from '../components/design/LeafletWorldMap';
 import { LeafletMapErrorBoundary } from '../components/design/LeafletMapErrorBoundary';
 import { bandOf } from '../components/design/data';
+import { RotatorDialPanel } from '../layout/panels/RotatorDialPanel';
+import { QrzPanel } from '../layout/panels/QrzPanel';
+import { DspFlexPanel } from '../layout/panels/DspFlexPanel';
+import { useRotatorStore } from '../state/rotator-store';
 import './mobile.css';
 
 const MODES: readonly RxMode[] = ['LSB', 'USB', 'CWL', 'CWU', 'AM', 'FM', 'DIGU'];
@@ -64,7 +68,18 @@ export function useIsMobileViewport(): boolean {
   return mobile;
 }
 
-type MobileTab = 'radio' | 'settings';
+type MobileTab = 'radio' | 'tools';
+type MobileToolId = 'tx' | 'rotator' | 'qrz' | 'dsp';
+
+function normalizeAzimuth(deg: number | null | undefined): number | null {
+  if (deg == null || !Number.isFinite(deg)) return null;
+  return ((deg % 360) + 360) % 360;
+}
+
+function compassPoint(deg: number): string {
+  const points = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'] as const;
+  return points[Math.round((deg % 360) / 45) % 8] ?? 'N';
+}
 
 export function MobileApp() {
   const status = useConnectionStore((s) => s.status);
@@ -81,6 +96,9 @@ export function MobileApp() {
   const freqMHz = (vfoHz / 1_000_000).toFixed(3);
 
   const [activeTab, setActiveTab] = useState<MobileTab>('radio');
+  // When activeTab === 'tools', toolOpen=null shows the tile grid;
+  // toolOpen='tx' (etc) shows that tool's detail page with a back button.
+  const [toolOpen, setToolOpen] = useState<MobileToolId | null>(null);
 
   // Force the waterfall into AUTO dB-range whenever the mobile shell mounts.
   // FIXED mode (the desktop default) reads grainy on a phone where there's
@@ -162,11 +180,15 @@ export function MobileApp() {
           <button
             type="button"
             role="tab"
-            aria-selected={activeTab === 'settings'}
-            className={`m-tab ${activeTab === 'settings' ? 'on' : ''}`}
-            onClick={() => setActiveTab('settings')}
+            aria-selected={activeTab === 'tools'}
+            className={`m-tab ${activeTab === 'tools' ? 'on' : ''}`}
+            onClick={() => {
+              setActiveTab('tools');
+              // Tapping the tab while inside a tool returns to the grid.
+              setToolOpen(null);
+            }}
           >
-            Settings
+            Tools
           </button>
         </nav>
         <button
@@ -307,22 +329,10 @@ export function MobileApp() {
               </div>
             </Section>
           </>
+        ) : toolOpen == null ? (
+          <ToolsGrid onPick={setToolOpen} />
         ) : (
-          <Section label="Controls">
-            <div className="m-controls">
-              <div className="m-control-row m-control-row--1">
-                <label className="m-control">
-                  <span className="m-control-lbl">Step</span>
-                  <TuningStepWidget />
-                </label>
-              </div>
-              <div className="m-slider-row"><AgcSlider /></div>
-              <div className="m-slider-row m-slider-row--lbl"><DriveSlider /></div>
-              <div className="m-slider-row m-slider-row--lbl"><TunePowerSlider /></div>
-              <div className="m-slider-row m-slider-row--lbl"><MicGainSlider /></div>
-              <div className="m-ps-row"><PsToggleButton /></div>
-            </div>
-          </Section>
+          <ToolDetail tool={toolOpen} onBack={() => setToolOpen(null)} />
         )}
       </main>
     </div>
@@ -496,6 +506,192 @@ function Section({
       </header>
       <div className="m-section-body">{children}</div>
     </section>
+  );
+}
+
+// ============================================================================
+// Tools tab — drawer (2-col tile grid) and per-tool detail pages.
+//
+// Per the maintainer brief: no new widgets. Every tool detail page embeds
+// the existing desktop panel inside a positioned wrapper so it scales
+// down to the 480-wide mobile column. The tile grid + back-button chrome
+// is the only mobile-specific UI here.
+// ============================================================================
+
+const TOOL_META: Record<MobileToolId, { name: string; desc: string; sub: string; icon: ReactNode }> = {
+  tx: {
+    name: 'TX Controls',
+    desc: 'Step, AGC-T, drive, tune, mic gain',
+    sub: 'VFO A',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden>
+        <circle cx="12" cy="12" r="3" />
+        <path d="M5.6 5.6a9 9 0 0 0 0 12.8M18.4 5.6a9 9 0 0 1 0 12.8" />
+        <path d="M2.8 2.8a13 13 0 0 0 0 18.4M21.2 2.8a13 13 0 0 1 0 18.4" />
+      </svg>
+    ),
+  },
+  rotator: {
+    name: 'Rotator',
+    desc: 'Compass heading & antenna jog',
+    sub: 'Heading',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden>
+        <circle cx="12" cy="12" r="9" />
+        <path d="M12 4v2M12 18v2M4 12h2M18 12h2" />
+        <path d="M14.5 8 12 14l-2.5-6 5 0z" fill="currentColor" stroke="none" opacity="0.85" />
+      </svg>
+    ),
+  },
+  qrz: {
+    name: 'QRZ Lookup',
+    desc: 'Find callsigns, grids & bios',
+    sub: 'Online',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden>
+        <circle cx="11" cy="11" r="6" />
+        <path d="m20 20-4.5-4.5" />
+        <path d="M9 11h4M11 9v4" opacity="0.6" />
+      </svg>
+    ),
+  },
+  dsp: {
+    name: 'DSP Control',
+    desc: 'NB, NR2, ANF, notch & filters',
+    sub: 'Filters',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden>
+        <path d="M3 12h2M19 12h2" />
+        <path d="M6 12c1 0 1-6 2-6s1 12 2 12 1-9 2-9 1 6 2 6 1-3 2-3" />
+      </svg>
+    ),
+  },
+};
+
+function ToolsGrid({ onPick }: { onPick: (id: MobileToolId) => void }) {
+  // Surface live-state badges on each tile so the operator sees what's
+  // actually doing something at a glance — drives the design's "Active" /
+  // "072° NE" / "NR2 On" chips without inventing new state.
+  const rotConnected = useRotatorStore((s) => !!s.status?.connected);
+  const rotAz = useRotatorStore((s) => normalizeAzimuth(s.status?.currentAz));
+  const txBadge = useTxStore((s) => (s.moxOn ? 'TX' : s.tunOn ? 'TUN' : 'Ready'));
+
+  const tools: ReadonlyArray<{
+    id: MobileToolId;
+    badge: { text: string; tone: 'green' | 'amber' | 'muted' };
+  }> = [
+    { id: 'tx', badge: { text: txBadge, tone: txBadge === 'Ready' ? 'green' : 'amber' } },
+    {
+      id: 'rotator',
+      badge: rotConnected && rotAz != null
+        ? { text: `${Math.round(rotAz).toString().padStart(3, '0')}° ${compassPoint(rotAz)}`, tone: 'muted' }
+        : { text: 'Offline', tone: 'muted' },
+    },
+    { id: 'qrz', badge: { text: 'Online', tone: 'muted' } },
+    { id: 'dsp', badge: { text: 'Ready', tone: 'green' } },
+  ];
+
+  return (
+    <>
+      <div className="m-tools-head">
+        <span className="m-section-led" />
+        <span className="m-tools-title">Tools</span>
+        <span className="m-tools-sub">{tools.length} available</span>
+      </div>
+      <div className="m-tools-grid">
+        {tools.map(({ id, badge }) => {
+          const meta = TOOL_META[id];
+          return (
+            <button
+              key={id}
+              type="button"
+              className="m-tool-tile"
+              onClick={() => onPick(id)}
+              aria-label={`Open ${meta.name}`}
+            >
+              <div className="m-tool-tile-icon">{meta.icon}</div>
+              <div className="m-tool-tile-text">
+                <div className="m-tool-tile-name">{meta.name}</div>
+                <div className="m-tool-tile-desc">{meta.desc}</div>
+              </div>
+              <span className={`m-tool-tile-tag m-tool-tile-tag--${badge.tone}`}>{badge.text}</span>
+            </button>
+          );
+        })}
+      </div>
+      <p className="m-tools-foot">
+        Tools are configured on the desktop application.<br />
+        Available widgets appear here.
+      </p>
+    </>
+  );
+}
+
+function ToolDetail({ tool, onBack }: { tool: MobileToolId; onBack: () => void }) {
+  const meta = TOOL_META[tool];
+  return (
+    <>
+      <header className="m-tool-page-head">
+        <button
+          type="button"
+          className="m-back-btn"
+          onClick={onBack}
+          aria-label="Back to tools"
+        >
+          <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden>
+            <path
+              d="M15 18l-6-6 6-6"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+        <span className="m-tool-page-title">{meta.name}</span>
+        <span className="m-tool-page-sub">{meta.sub}</span>
+      </header>
+      {tool === 'tx' && <TxToolView />}
+      {tool === 'rotator' && (
+        <div className="m-tool-embed m-tool-embed--rotator">
+          <RotatorDialPanel />
+        </div>
+      )}
+      {tool === 'qrz' && (
+        <div className="m-tool-embed m-tool-embed--qrz">
+          <QrzPanel />
+        </div>
+      )}
+      {tool === 'dsp' && (
+        <div className="m-tool-embed m-tool-embed--dsp">
+          <DspFlexPanel />
+        </div>
+      )}
+    </>
+  );
+}
+
+// TX tool view — the controls that previously lived under the Settings tab.
+// Lifted verbatim into its own component so the Tools router can route to it
+// without inflating MobileApp.
+function TxToolView() {
+  return (
+    <Section label="Controls">
+      <div className="m-controls">
+        <div className="m-control-row m-control-row--1">
+          <label className="m-control">
+            <span className="m-control-lbl">Step</span>
+            <TuningStepWidget />
+          </label>
+        </div>
+        <div className="m-slider-row"><AgcSlider /></div>
+        <div className="m-slider-row m-slider-row--lbl"><DriveSlider /></div>
+        <div className="m-slider-row m-slider-row--lbl"><TunePowerSlider /></div>
+        <div className="m-slider-row m-slider-row--lbl"><MicGainSlider /></div>
+        <div className="m-ps-row"><PsToggleButton /></div>
+      </div>
+    </Section>
   );
 }
 

--- a/zeus-web/src/mobile/mobile.css
+++ b/zeus-web/src/mobile/mobile.css
@@ -684,3 +684,182 @@
    chrome), so we neutralise both classes within .m-app. */
 .m-app .hide-mobile { display: revert !important; }
 .m-app .show-mobile { display: none !important; }
+
+/* ============================================================
+   Tools tab — 2-col tile grid (drawer view).
+   The grid lives at the same indent as .m-section so it lines up
+   with the radio-page panels above it.
+   ============================================================ */
+.m-tools-head {
+  display: flex; align-items: center; gap: 10px;
+  padding: 2px 4px 0;
+}
+.m-tools-title {
+  font: 700 12px/1 var(--font-sans);
+  letter-spacing: 0.22em;
+  color: var(--fg-0);
+  text-transform: uppercase;
+}
+.m-tools-sub {
+  margin-left: auto;
+  font: 500 11px/1 var(--font-sans);
+  color: var(--fg-3);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.m-tools-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.m-tool-tile {
+  background: var(--bg-1);
+  border: 1px solid var(--line-strong);
+  border-radius: 12px;
+  padding: 18px 14px 14px;
+  cursor: pointer;
+  text-align: left;
+  color: var(--fg-0);
+  font: inherit;
+  display: flex; flex-direction: column; gap: 14px;
+  min-height: 160px;
+  position: relative;
+  overflow: hidden;
+  transition: transform 0.12s ease, border-color 0.15s ease, background 0.15s ease;
+}
+.m-tool-tile:hover {
+  border-color: var(--accent-line);
+  background: var(--bg-2);
+}
+.m-tool-tile:active { transform: scale(0.98); }
+.m-tool-tile::after {
+  content: ""; position: absolute; top: 0; right: 0;
+  width: 38%; height: 38%;
+  background: radial-gradient(circle at 100% 0%, var(--ok-soft), transparent 60%);
+  pointer-events: none;
+}
+
+.m-tool-tile-icon {
+  width: 44px; height: 44px;
+  border-radius: 10px;
+  background: var(--bg-2);
+  border: 1px solid var(--line-strong);
+  display: grid; place-items: center;
+  color: var(--ok);
+  flex: none;
+}
+.m-tool-tile-icon svg {
+  width: 22px; height: 22px;
+  stroke: currentColor; fill: none;
+  stroke-width: 1.7;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.m-tool-tile-text { min-width: 0; }
+.m-tool-tile-name {
+  font: 700 15px/1.15 var(--font-sans);
+  color: var(--fg-0);
+  letter-spacing: 0.01em;
+}
+.m-tool-tile-desc {
+  font: 500 11px/1.4 var(--font-sans);
+  color: var(--fg-3);
+  margin-top: 4px;
+  letter-spacing: 0.02em;
+}
+
+.m-tool-tile-tag {
+  margin-top: auto;
+  align-self: flex-start;
+  font: 600 9px/1 var(--font-mono);
+  padding: 4px 7px;
+  border-radius: 3px;
+  letter-spacing: 0.1em;
+  border: 1px solid;
+}
+.m-tool-tile-tag--green {
+  color: var(--ok);
+  background: var(--ok-soft);
+  border-color: rgba(45, 213, 102, 0.35);
+}
+.m-tool-tile-tag--amber {
+  color: var(--amber);
+  background: var(--amber-soft);
+  border-color: rgba(255, 177, 60, 0.32);
+}
+.m-tool-tile-tag--muted {
+  color: var(--fg-3);
+  background: transparent;
+  border-color: var(--line-strong);
+}
+
+.m-tools-foot {
+  margin: 4px 4px 0;
+  padding: 14px 4px;
+  font: 500 11px/1.5 var(--font-sans);
+  color: var(--fg-3);
+  letter-spacing: 0.02em;
+  text-align: center;
+}
+
+/* ============================================================
+   Tool detail page — back header + embedded desktop panel.
+   ============================================================ */
+.m-tool-page-head {
+  display: flex; align-items: center; gap: 12px;
+  padding: 2px 4px 0;
+}
+.m-back-btn {
+  width: 36px; height: 36px;
+  border-radius: 8px;
+  background: var(--bg-1);
+  border: 1px solid var(--line-strong);
+  color: var(--fg-1);
+  display: grid; place-items: center;
+  cursor: pointer;
+  flex: none;
+}
+.m-back-btn:hover {
+  color: var(--fg-0);
+  border-color: var(--accent-line);
+}
+.m-tool-page-title {
+  font: 700 14px/1 var(--font-sans);
+  color: var(--fg-0);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+.m-tool-page-sub {
+  margin-left: auto;
+  font: 500 11px/1 var(--font-sans);
+  color: var(--fg-3);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+/* Embedded desktop panel wrapper. RotatorDialPanel uses
+   position: absolute; inset: 0 — needs a positioned parent with a
+   definite size. QrzPanel and DspFlexPanel use flex columns — they
+   just need a definite height to scroll inside. */
+.m-tool-embed {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-1);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--r-md);
+  overflow: hidden;
+}
+.m-tool-embed--rotator { aspect-ratio: 1 / 1.05; min-height: 380px; }
+.m-tool-embed--qrz { min-height: 520px; }
+.m-tool-embed--dsp { min-height: 600px; }
+
+/* Mobile-only tweaks that let the embedded panels read inside the
+   480-wide column without their desktop-tile chrome fighting the
+   single-column layout. */
+.m-tool-embed > * { min-width: 0; max-width: 100%; }
+.m-tool-embed .rotator-dial { padding: 6px; }
+.m-tool-embed .rd-controls { gap: 8px; }

--- a/zeus-web/src/styles/rotator-dial.css
+++ b/zeus-web/src/styles/rotator-dial.css
@@ -1,0 +1,300 @@
+/* ===========================================================
+   Rotator Dial panel — pure compass widget (no map, no QRZ).
+   Lifted-Dark instrument language: dark face with warm lamp
+   bloom in dark theme, brushed silver chassis in light theme.
+   Adapts via --immersive-lamp-* tokens defined in tokens.css.
+   =========================================================== */
+
+.rotator-dial {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-1);
+  padding: 8px;
+  gap: 8px;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+/* Disabled state — face dims, controls greyed out via :disabled below. */
+.rotator-dial.disabled .rd-dial { opacity: 0.42; }
+.rotator-dial.disabled .rd-readout { opacity: 0.55; }
+
+/* Stage: fills available space, centres the square dial inside. */
+.rd-stage {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.rd-dial {
+  display: block;
+  width: 100%;
+  height: 100%;
+  max-width: min(100%, 100cqh);
+  max-height: min(100%, 100cqw);
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: manipulation;
+}
+
+/* ---------- Dial primitives ---------- */
+
+.rd-tick {
+  stroke-linecap: round;
+}
+.rd-tick--cardinal {
+  stroke: var(--immersive-lamp-readout);
+  stroke-width: 1.6;
+  opacity: 0.95;
+}
+.rd-tick--major {
+  stroke: var(--immersive-lamp-tick);
+  stroke-width: 1.0;
+  opacity: 0.85;
+}
+.rd-tick--minor {
+  stroke: var(--immersive-lamp-tick);
+  stroke-width: 0.55;
+  opacity: 0.5;
+}
+
+.rd-numeral {
+  font-family: var(--font-mono);
+  font-size: 6.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  fill: var(--immersive-lamp-units);
+  opacity: 0.85;
+}
+
+.rd-label {
+  font-family: var(--font-display);
+  fill: var(--immersive-lamp-label);
+  paint-order: stroke fill;
+}
+.rd-label--lg {
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+.rd-label--sm {
+  font-size: 7.5px;
+  font-weight: 600;
+  letter-spacing: 0.10em;
+  fill: var(--immersive-lamp-units);
+}
+/* North marker — warm-red conventional. In light theme this still
+   reads as a distinct accent because --tx is unchanged across themes. */
+.rd-cardinal-n {
+  fill: var(--tx);
+  text-shadow: 0 0 6px var(--tx-soft);
+}
+
+/* Lubber line — fixed reference triangle at top of face. */
+.rd-lubber polygon {
+  fill: var(--immersive-lamp-readout);
+  filter: drop-shadow(0 0 3px var(--immersive-lamp-readout-glow));
+}
+
+/* Needle — drawn pointing N at C=100, rotated by transform. */
+.rd-needle-head {
+  fill: var(--immersive-lamp-needle-bri);
+}
+.rd-needle-tail {
+  fill: var(--immersive-lamp-needle);
+  opacity: 0.55;
+}
+
+/* Target (pending) marker — TX red so it reads as "destination". */
+.rd-target-line {
+  stroke: var(--tx);
+  stroke-width: 2;
+  stroke-linecap: round;
+  filter: drop-shadow(0 0 4px var(--tx-soft));
+}
+.rd-target-tip {
+  fill: var(--tx);
+  filter: drop-shadow(0 0 4px var(--tx-soft));
+}
+
+/* Hub cap — small lit pin at centre. */
+.rd-hub-base {
+  fill: var(--bg-meter);
+  stroke: var(--immersive-lamp-rim);
+  stroke-width: 0.8;
+}
+.rd-hub-ring {
+  fill: none;
+  stroke: var(--immersive-lamp-border);
+  stroke-width: 0.6;
+}
+.rd-hub-pin {
+  fill: var(--immersive-lamp-pin);
+  filter: drop-shadow(0 0 4px var(--immersive-lamp-pin-glow));
+}
+
+/* ---------- Readout overlay ---------- */
+
+.rd-readout {
+  position: absolute;
+  left: 50%;
+  bottom: 16%;
+  transform: translateX(-50%);
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 3px 10px;
+  border-radius: var(--r-sm);
+  background: var(--immersive-chip-bg);
+  border: 1px solid var(--immersive-lamp-border);
+  box-shadow:
+    inset 0 1px 0 var(--immersive-lamp-rim),
+    0 1px 3px rgba(0, 0, 0, 0.55);
+  font-family: var(--font-mono);
+  pointer-events: none;
+  white-space: nowrap;
+}
+.rd-readout-label {
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  color: var(--immersive-lamp-units);
+}
+.rd-readout-now {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--immersive-lamp-readout);
+  text-shadow: 0 0 8px var(--immersive-lamp-readout-glow);
+}
+.rd-readout-tgt {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--tx);
+  text-shadow: 0 0 6px var(--tx-soft);
+}
+
+/* Offline banner — sits across the face when the rotator isn't ready. */
+.rd-offline-banner {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  padding: 4px 10px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--immersive-lamp-units);
+  background: var(--immersive-chip-bg);
+  border: 1px solid var(--immersive-lamp-border);
+  border-radius: var(--r-sm);
+  pointer-events: none;
+  text-shadow: 0 0 4px rgba(0, 0, 0, 0.6);
+}
+
+/* ---------- Controls row ---------- */
+
+.rd-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding-top: 2px;
+  flex-wrap: wrap;
+}
+
+.rd-manual {
+  display: inline-flex;
+  align-items: stretch;
+  gap: 4px;
+}
+
+.rd-input {
+  width: 72px;
+  padding: 5px 8px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-align: center;
+  color: var(--immersive-lamp-readout);
+  background: var(--bg-meter);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-sm);
+  outline: none;
+  appearance: textfield;
+  -moz-appearance: textfield;
+}
+.rd-input::-webkit-outer-spin-button,
+.rd-input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+.rd-input:focus {
+  border-color: var(--accent-bright);
+  box-shadow: 0 0 0 1px var(--accent-soft);
+}
+.rd-input::placeholder {
+  color: var(--fg-3);
+  letter-spacing: 0.16em;
+  font-weight: 600;
+}
+.rd-input:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* Buttons — flat, take cues from --btn-* tokens so light theme adapts. */
+.rd-btn {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 5px 12px;
+  border-radius: var(--r-sm);
+  background: linear-gradient(180deg, var(--btn-top), var(--btn-bot));
+  border: 1px solid var(--btn-edge);
+  color: var(--btn-text);
+  cursor: pointer;
+  transition: filter 90ms ease, border-color 90ms ease, background 90ms ease;
+}
+.rd-btn:hover:not(:disabled) {
+  filter: brightness(1.18);
+  border-color: var(--accent-bright);
+}
+.rd-btn:disabled {
+  opacity: 0.42;
+  cursor: not-allowed;
+}
+
+.rd-btn--go {
+  background: linear-gradient(180deg, var(--accent), var(--accent));
+  border-color: var(--accent-bright);
+  color: var(--btn-active-text);
+  box-shadow: 0 0 8px var(--accent-soft);
+}
+.rd-btn--go:disabled {
+  background: linear-gradient(180deg, var(--btn-top), var(--btn-bot));
+  border-color: var(--btn-edge);
+  color: var(--btn-text);
+  box-shadow: none;
+}
+
+.rd-btn--stop {
+  background: linear-gradient(180deg, var(--bg-2), var(--bg-2));
+  border-color: var(--tx);
+  color: var(--tx);
+}
+.rd-btn--stop:hover:not(:disabled) {
+  background: var(--tx);
+  color: #ffffff;
+  border-color: var(--tx);
+}


### PR DESCRIPTION
## Summary

The mobile shell's second tab becomes **Tools** — a 2×2 tile grid that opens per-tool detail pages — instead of the flat Controls column.

Each tool detail page **embeds the existing desktop panel**; no new mobile-only widget logic. Per the brief: *don't invent anything new, use the existing widgets with a mobile view only*.

| Tile | Detail page embeds | Live-state badge |
|------|---------------------|------------------|
| TX Controls | The five sliders that used to live under Settings (Step / AGC-T / DRV / TUN / MIC / PS) | `Ready` · `TX` · `TUN` |
| Rotator | `<RotatorDialPanel />` | `072° NE` or `Offline` |
| QRZ Lookup | `<QrzPanel />` | `Online` |
| DSP Control | `<DspFlexPanel />` | `Ready` |

The **Radio** tab is unchanged.

## Dependencies

This branch includes the `feat(rotator-dial)` commit from **#385** because the mobile Rotator tile reuses that widget. When #385 merges to `develop` first, this PR's diff will shrink to the mobile-only commit on rebase.

## Implementation notes

- `App.tsx` now wraps the mobile branch in `WorkspaceContext.Provider` (the same context the desktop branch already builds). This lets the embedded `<QrzPanel />` consume `useWorkspace()` without a parallel mobile-only QRZ implementation.
- Embedded panels sit inside `.m-tool-embed--{rotator|qrz|dsp}` wrappers that supply a positioned parent + definite height; the panels' internal layouts (absolute-inset for the dial, flex-column for QRZ/DSP) are untouched.
- The 2-col tile grid + back-button chrome are the only mobile-specific UI introduced.

## Test plan

- [x] `tsc -b && vite build` clean.
- [x] Mobile viewport (390×844, `?mobile=1`) verified in browser:
  - [x] Tools grid renders all four tiles with live badges (live HL2 rotctld at 062° showed `062° NE`).
  - [x] Each tile opens the corresponding detail page; back button returns to grid.
  - [x] TX detail = previous Settings content, intact.
  - [x] Rotator detail = compass dial scaled to fit the 480-wide column.
  - [x] QRZ detail = call input + result card (uses `useWorkspace()` via the new mobile provider).
  - [x] DSP detail = NB/NR2/ANF/SNB chips, EMNR knobs, all functional.
  - [x] Radio tab unchanged.
- [ ] Verify on a physical phone (Brian).