### PR TITLE
fix(plugins): persist settings by Key, not by auto-Id

### DIFF
--- a/Zeus.Plugins.Host/PluginSettingsStore.cs
+++ b/Zeus.Plugins.Host/PluginSettingsStore.cs
@@ -71,7 +71,14 @@ public sealed class PluginSettingsStore : IDisposable
         {
             lock (_store._lock)
             {
-                var doc = _store.CollectionFor(_pluginId).FindOne(x => x.Key == key);
+                // OrderByDescending on Id: defensive against duplicate rows
+                // for the same Key that may exist from before the SetAsync
+                // dedupe fix below. SetAsync clears them out on next write.
+                var doc = _store.CollectionFor(_pluginId)
+                    .Query()
+                    .Where(x => x.Key == key)
+                    .OrderByDescending(x => x.Id)
+                    .FirstOrDefault();
                 if (doc is null) return Task.FromResult<T?>(default);
                 try
                 {
@@ -90,8 +97,16 @@ public sealed class PluginSettingsStore : IDisposable
             var json = JsonSerializer.Serialize(value, JsonOpts);
             lock (_store._lock)
             {
+                // Upsert by Key (not by LiteDB _id). The old code used
+                // `coll.Upsert(new SettingDoc { ... })` which left Id at 0
+                // and so LiteDB treated every Set as a new row, growing
+                // the collection without bound and stranding the latest
+                // value behind a wall of stale duplicates. DeleteMany +
+                // Insert is atomic under _store._lock and idempotent on
+                // the existing duplicate corpus.
                 var coll = _store.CollectionFor(_pluginId);
-                coll.Upsert(new SettingDoc { Key = key, JsonValue = json });
+                coll.DeleteMany(x => x.Key == key);
+                coll.Insert(new SettingDoc { Key = key, JsonValue = json });
             }
             return Task.CompletedTask;
         }


### PR DESCRIPTION
## Summary
Plugin settings appeared to not persist across desktop restarts — operator dial-in (drive %, threshold dB, filter bands, etc.) reverted to defaults or stale values every time Zeus came up.

## Root cause
\`PluginSettingsStore.SetAsync\` called LiteDB \`Upsert\` with \`new SettingDoc { Key = key, JsonValue = json }\`. \`SettingDoc.Id\` was always \`0\` (the C# default for int). LiteDB treats \`_id == 0\` as "no primary key supplied" and auto-generates a fresh one on every call — meaning every \`SetAsync\` **inserted** a new row instead of **updating** the existing one. The collection grew without bound (KB2UKA's running session accumulated 88+ duplicate \`threshold_db\` rows after one bench-test) and \`FindOne(x => x.Key == key)\` could resolve to a stale row depending on LiteDB's internal iteration order.

## Fix
- \`SetAsync\`: \`DeleteMany(x => x.Key == key)\` then \`Insert\` under the existing \`_lock\`. Atomic for the store and idempotent on the existing duplicate corpus (every key gets cleaned up on its next write).
- \`GetAsync\`: \`OrderByDescending(x => x.Id).FirstOrDefault()\` so any pre-fix duplicates resolve to the most-recent (highest-Id) row until natural cleanup completes.

## Test plan
- [x] \`dotnet build Zeus.slnx -c Release\` — 0 warnings, 0 errors.
- [x] \`dotnet test Zeus.Plugins.Host.Tests --filter "Settings"\` — 7/7 pass unchanged.
- [x] End-to-end on KB2UKA's machine: POST \`thresholdDb=-22, attackMs=7.5\` to NoiseGate via REST → kill desktop → relaunch → GET returns the same values. EQ and Compressor pre-existing settings also survived the restart.

## Impact
Affects every audio-chain plugin (EQ, Compressor, Exciter, Bass, Reverb, NoiseGate) plus the RF2K-S plugin and any future plugin using \`IPluginSettings\`. Pure store-layer fix; no plugin code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)