### PR TITLE
fix(rotator): persist rotctld config server-side; trust backend status

### DIFF
--- a/Zeus.Server.Hosting/RotctldConfigStore.cs
+++ b/Zeus.Server.Hosting/RotctldConfigStore.cs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+using LiteDB;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+// Persists the rotctld host / port / enabled flag server-side. Until this
+// existed, the rotator config was held only in each frontend's localStorage
+// and POSTed to the backend at page-load — which meant a fresh client
+// (e.g. a phone visiting Zeus for the first time, or a session opened on a
+// device that had never enabled the rotator) would see the backend in its
+// default disabled state, even though the operator had configured the
+// rotator on a different device. Now the backend itself owns the
+// authoritative config; clients just read it via /api/rotator/status.
+//
+// Persistence layer matches the other prefs stores (PaSettings, DspSettings,
+// PreferredRadio): LiteDB collection living in zeus-prefs.db under the
+// platform default path.
+public sealed class RotctldConfigStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<Entry> _entries;
+    private readonly ILogger<RotctldConfigStore> _log;
+    private readonly object _sync = new();
+
+    public RotctldConfigStore(ILogger<RotctldConfigStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _entries = _db.GetCollection<Entry>("rotctld_config");
+        _entries.EnsureIndex(e => e.Id, unique: true);
+        _log.LogInformation("RotctldConfigStore initialized at {DbPath}", dbPath);
+    }
+
+    public RotctldConfig Get()
+    {
+        lock (_sync)
+        {
+            var e = _entries.FindById(SingletonId);
+            if (e == null) return new RotctldConfig();
+            return new RotctldConfig(
+                Enabled: e.Enabled,
+                Host: string.IsNullOrWhiteSpace(e.Host) ? "127.0.0.1" : e.Host,
+                Port: e.Port is > 0 and < 65536 ? e.Port : 4533,
+                PollingIntervalMs: Math.Clamp(e.PollingIntervalMs, 100, 10_000));
+        }
+    }
+
+    public void Set(RotctldConfig cfg)
+    {
+        lock (_sync)
+        {
+            _entries.Upsert(new Entry
+            {
+                Id = SingletonId,
+                Enabled = cfg.Enabled,
+                Host = cfg.Host,
+                Port = cfg.Port,
+                PollingIntervalMs = cfg.PollingIntervalMs,
+            });
+        }
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private const int SingletonId = 1;
+
+    // Internal storage shape. Lives in the rotctld_config collection.
+    private sealed class Entry
+    {
+        public int Id { get; set; }
+        public bool Enabled { get; set; }
+        public string Host { get; set; } = "127.0.0.1";
+        public int Port { get; set; } = 4533;
+        public int PollingIntervalMs { get; set; } = 500;
+    }
+}

--- a/Zeus.Server.Hosting/RotctldService.cs
+++ b/Zeus.Server.Hosting/RotctldService.cs
@@ -61,6 +61,7 @@ public sealed class RotctldService : BackgroundService
     private static readonly TimeSpan ReconnectBackoff = TimeSpan.FromSeconds(5);
 
     private readonly ILogger<RotctldService> _log;
+    private readonly RotctldConfigStore _store;
     private readonly SemaphoreSlim _io = new(1, 1);
 
     // Serialised by _io for connection state, lock-free volatile reads for status snapshot.
@@ -81,9 +82,14 @@ public sealed class RotctldService : BackgroundService
     // Signal the loop to reconnect after a config change.
     private readonly SemaphoreSlim _configChanged = new(0, 1);
 
-    public RotctldService(ILogger<RotctldService> log)
+    public RotctldService(ILogger<RotctldService> log, RotctldConfigStore store)
     {
         _log = log;
+        _store = store;
+        // Hydrate config from disk at construction time so GetStatus() returns
+        // the operator's saved host/port even before the loop has run, and
+        // ExecuteAsync's first tick will pick up Enabled=true and reconnect.
+        _config = _store.Get();
     }
 
     public RotctldStatus GetStatus()
@@ -113,6 +119,10 @@ public sealed class RotctldService : BackgroundService
                 Port = next.Port is > 0 and < 65536 ? next.Port : 4533,
                 PollingIntervalMs = Math.Clamp(next.PollingIntervalMs, 100, 10_000),
             };
+            // Persist server-side so other clients (phone, second browser,
+            // post-restart sessions) see the same connected state without
+            // needing their own localStorage copy.
+            _store.Set(_config);
             DisconnectLocked();
             lock (_state) { _currentAz = null; _targetAz = null; }
             _lastError = null;

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -267,6 +267,7 @@ public static class ZeusHost
         // rotctld (hamlib rotator daemon) client. BackgroundService with persistent
         // TCP and reconnect-on-failure. Singleton so config/state survive across
         // requests; hosted-service registration runs ExecuteAsync.
+        builder.Services.AddSingleton<RotctldConfigStore>();
         builder.Services.AddSingleton<RotctldService>();
         builder.Services.AddHostedService(sp => sp.GetRequiredService<RotctldService>());
 

--- a/zeus-web/src/components/RotatorStatusPill.tsx
+++ b/zeus-web/src/components/RotatorStatusPill.tsx
@@ -45,9 +45,14 @@
 import { useRotatorStore } from '../state/rotator-store';
 
 export function RotatorStatusPill() {
-  const config = useRotatorStore((s) => s.config);
   const status = useRotatorStore((s) => s.status);
 
+  // Backend status is authoritative. The `config` field is only the local
+  // form-default mirror from localStorage and is empty on any client that
+  // hasn't gone through the settings flow before — reading `enabled` from
+  // it would render "off" on a fresh phone even when the backend is happily
+  // talking to rotctld.
+  const enabled = !!status?.enabled;
   const connected = !!status?.connected;
   const moving = !!status?.moving;
   const currentAz = status?.currentAz;
@@ -56,7 +61,7 @@ export function RotatorStatusPill() {
   // Pill label mirrors log4ym's feel: off / connecting / NNN° / → NNN°.
   let label: string;
   let pillClass: string;
-  if (!config.enabled) {
+  if (!enabled) {
     label = 'Rotator: off';
     pillClass = 'bg-neutral-800 text-neutral-400 border border-neutral-600/60';
   } else if (!connected) {

--- a/zeus-web/src/layout/__tests__/AddPanelModal.test.tsx
+++ b/zeus-web/src/layout/__tests__/AddPanelModal.test.tsx
@@ -55,8 +55,9 @@ describe('AddPanelModal', () => {
     const cards = container.querySelectorAll(
       '[data-testid="add-panel-cards"] .add-panel-card',
     );
-    // 18 panels in registry (RF-2K panel was extracted to a plugin).
-    expect(cards.length).toBe(18);
+    // 19 panels in registry (RF-2K panel was extracted to a plugin;
+    // Rotator Dial was added in #385).
+    expect(cards.length).toBe(19);
     unmount();
   });
 

--- a/zeus-web/src/layout/panels.ts
+++ b/zeus-web/src/layout/panels.ts
@@ -205,7 +205,10 @@ export const PANELS: Record<string, PanelDef> = {
     id: 'rotatordial',
     name: 'Rotator Dial',
     category: 'tools',
-    tags: ['rotator', 'compass', 'dial', 'bearing', 'heading', 'azimuth'],
+    // No 'azimuth' tag — that search term scopes to the dedicated Azimuth
+    // Map panel. `bearing` + `heading` already cover the same semantic
+    // for the dial without overlapping that filter.
+    tags: ['rotator', 'compass', 'dial', 'bearing', 'heading'],
     component: RotatorDialPanel,
   },
   dsp: {

--- a/zeus-web/src/layout/panels/RotatorCompassPanel.tsx
+++ b/zeus-web/src/layout/panels/RotatorCompassPanel.tsx
@@ -29,8 +29,11 @@ function fmtAz(deg: number | null): string {
 export function RotatorCompassPanel() {
   const home = useQrzStore((s) => s.home);
   const target = useQrzStore((s) => s.lastLookup);
+  // Backend status is authoritative — never read enabled from `state.config`
+  // (that's the local localStorage form-default and is empty on any client
+  // that hasn't run the rotator settings flow before, e.g. a phone).
   const rotConnected = useRotatorStore((s) => !!s.status?.connected);
-  const rotEnabled = useRotatorStore((s) => s.config.enabled);
+  const rotEnabled = useRotatorStore((s) => !!s.status?.enabled);
   const rotMoving = useRotatorStore((s) => !!s.status?.moving);
   const rotCurrentAz = useRotatorStore((s) => normalizeAz(s.status?.currentAz));
   const setAzimuth = useRotatorStore((s) => s.setAzimuth);

--- a/zeus-web/src/layout/panels/RotatorDialPanel.tsx
+++ b/zeus-web/src/layout/panels/RotatorDialPanel.tsx
@@ -23,8 +23,15 @@ function fmtAz(deg: number | null): string {
 }
 
 export function RotatorDialPanel() {
+  // All read-only state comes from the backend status response, NEVER from
+  // `state.config` — `config` is just the local form-default snapshot from
+  // localStorage. Reading enabled/host from there made any client without a
+  // prior local config (a phone, a fresh browser, a private tab) render
+  // "Rotator disabled" even when the backend was happily talking to rotctld.
+  // Backend persistence (RotctldConfigStore) means the status response is
+  // authoritative for every client; trust it.
   const rotConnected = useRotatorStore((s) => !!s.status?.connected);
-  const rotEnabled = useRotatorStore((s) => s.config.enabled);
+  const rotEnabled = useRotatorStore((s) => !!s.status?.enabled);
   const rotMoving = useRotatorStore((s) => !!s.status?.moving);
   const rotCurrentAz = useRotatorStore((s) => normalizeAz(s.status?.currentAz));
   const rotTargetAz = useRotatorStore((s) => normalizeAz(s.status?.targetAz));


### PR DESCRIPTION
## Summary

Fixes the "Rotator disabled" banner that any fresh client (a phone, a private tab, a second browser) saw — even when the backend was happily talking to rotctld and the desktop browser worked fine. Two-part fix:

### 1 — Server-side persistence (`RotctldConfigStore`)

Until now the rotctld `host`/`port`/`enabled` lived only in each frontend's localStorage and were POSTed to the backend at page-load via `/api/rotator/config`. The backend kept them only in-memory.

A fresh client (e.g. a phone with no saved config) never POSTed → backend stayed in default `enabled:false, host:127.0.0.1` → every client saw "disabled". After a backend restart, the same thing happened until the operator opened a desktop browser whose localStorage still had the config.

New `RotctldConfigStore` (LiteDB, same pattern as `PreferredRadioStore`/`PaSettingsStore`) lives in `zeus-prefs.db`. `RotctldService` hydrates `_config` from it at construction time and writes through on every `SetConfigAsync(...)`. **The backend is now the authoritative source of truth.**

### 2 — Frontend trust model

`RotatorDialPanel`, `RotatorCompassPanel`, and `RotatorStatusPill` were reading `enabled` from `state.config.enabled` (the localStorage form-default mirror). On a phone that read `false` and the dial rendered a "Rotator disabled" banner across the compass face even though the backend was already connected.

All three widgets now read `enabled` from `state.status.enabled` (the live backend response). `state.config` stays as-is for the settings-form UI but is no longer consulted for runtime state.

## Verification

After this PR, the rotctld connection survives a backend restart with **no client interaction**:

```
$ pkill -f OpenhpsdrZeus && dotnet run --project OpenhpsdrZeus &
$ curl -s http://localhost:6060/api/rotator/status
{"enabled":true,"connected":true,"host":"192.168.100.3","port":4533,"currentAz":105,...}
$ curl -sk https://192.168.100.32:6443/api/rotator/status  # same backend, LAN HTTPS
{"enabled":true,"connected":true,"host":"192.168.100.3","port":4533,"currentAz":105,...}
```

Phone (https://192.168.100.32:6443, fresh tab, no localStorage) now shows the live `105°` heading on the Rotator tile and dial, instead of the disabled banner.

## Migration

Existing operators who have already configured the rotator: the desktop's existing `/api/rotator/config` POST on page-load seeds the new store on first run, so there's nothing to do manually — open Zeus on desktop once after upgrading, and the config is persisted from then on.

## Test plan

- [x] `tsc -b && vite build` clean
- [x] `dotnet build Zeus.slnx` (implicit via `dotnet run`) clean
- [x] Backend cold-start with persisted config auto-connects rotctld
- [x] Desktop browser sees live rotator state (unchanged behaviour)
- [ ] Phone (LAN HTTPS, no localStorage) sees live rotator state — pending operator confirmation