### PR TITLE
feat(audio-plugins): live pre-MOX meter tap + Audio Suite audition (Phase 1)

### DIFF
--- a/Zeus.Plugins.Contracts/Audio/AudioBlockContext.cs
+++ b/Zeus.Plugins.Contracts/Audio/AudioBlockContext.cs
@@ -22,11 +22,26 @@ public readonly ref struct AudioBlockContext
     /// <summary>Monotonic sample-frame counter from session start.</summary>
     public long SampleTime { get; }
 
-    /// <summary>True if the radio is currently transmitting.</summary>
+    /// <summary>
+    /// True if this block is part of the live TX audio path (the samples
+    /// will be modulated and put on the air); false if this is a preview
+    /// run for telemetry only — e.g. the host is calling Process so the
+    /// plugin's IN/OUT/GR meter fields update from live mic input while
+    /// MOX is off and nothing is being transmitted. Plugins that gate
+    /// state-mutating behaviour on transmit (e.g. only writing to a
+    /// shared resource while keyed) should branch on this field instead
+    /// of assuming every Process call is on-air.
+    /// </summary>
     public bool Mox { get; }
 }
 
-/// <summary>Sample-rate / channel / block-size negotiation values.</summary>
+/// <summary>
+/// Sample-rate / channel / block-size negotiation values. <c>BlockSize</c>
+/// is a sizing hint — the host may call <c>Process</c> with any block
+/// length up to and including the declared value. Plugins should
+/// iterate <c>input.Length</c> rather than caching the declared
+/// <c>BlockSize</c> as a fixed-array dimension.
+/// </summary>
 public sealed record AudioPluginRequirements(
     int SampleRate,
     int Channels,

--- a/Zeus.Plugins.Host/Audio/AudioChain.cs
+++ b/Zeus.Plugins.Host/Audio/AudioChain.cs
@@ -81,6 +81,47 @@ public sealed class AudioChain : IAsyncDisposable
     /// </summary>
     public void Process(ReadOnlySpan<float> input, Span<float> output, AudioBlockContext ctx)
     {
+        // Field-backed scratch — appropriate for the single-tap WDSP TX
+        // path that has historically been the only caller. A second tap
+        // (e.g. NativeMicCapture's pre-MOX preview) MUST use the caller-
+        // supplied-scratch overload below with its own private scratch
+        // span so the two paths never collide on _scratch if they ever
+        // race at a MOX edge.
+        var needed = ctx.Frames * ctx.Channels;
+        if (needed > _scratch.Length)
+        {
+            // Block bigger than we sized for — fall back to safe pass-through
+            // before we touch the scratch overload (which would refuse a
+            // smaller scratch the same way).
+            if (output.Length < input.Length)
+                throw new ArgumentException("output too small", nameof(output));
+            input.CopyTo(output);
+            return;
+        }
+        Process(input, output, _scratch.AsSpan(0, needed), ctx);
+    }
+
+    /// <summary>
+    /// Caller-supplied-scratch overload. Behaviour matches
+    /// <see cref="Process(ReadOnlySpan{float}, Span{float}, AudioBlockContext)"/>
+    /// bit-for-bit when invoked with the field-backed scratch — used by
+    /// the field-backed overload as its implementation. Exists so a
+    /// second tap point (the desktop-mode pre-MOX preview path in
+    /// <c>AudioPluginBridge.ProcessLivePreview</c>) can run the chain
+    /// without touching the WDSP TX path's <c>_scratch</c>. The two
+    /// callers are gated mutually-exclusive in time by their MOX /
+    /// monitor checks; the separate scratch protects against the
+    /// microsecond-scale overlap window at a MOX edge.
+    ///
+    /// <paramref name="scratch"/> must be at least <c>ctx.Frames *
+    /// ctx.Channels</c> samples long.
+    /// </summary>
+    public void Process(
+        ReadOnlySpan<float> input,
+        Span<float> output,
+        Span<float> scratch,
+        AudioBlockContext ctx)
+    {
         if (output.Length < input.Length)
             throw new ArgumentException("output too small", nameof(output));
 
@@ -91,15 +132,16 @@ public sealed class AudioChain : IAsyncDisposable
         }
 
         var needed = ctx.Frames * ctx.Channels;
-        if (needed > _scratch.Length)
+        if (scratch.Length < needed)
         {
-            // Block bigger than we sized for — fall back to safe pass-through
+            // Caller-supplied scratch too small — pass through rather
+            // than corrupt unrelated memory.
             input.CopyTo(output);
             return;
         }
 
         // Seed the chain by copying input into output; subsequent stages
-        // ping-pong between `output` and `_scratch`.
+        // ping-pong between `output` and `scratch`.
         input.CopyTo(output);
 
         // Track which buffer (output vs scratch) is the most-recently-written
@@ -114,16 +156,16 @@ public sealed class AudioChain : IAsyncDisposable
             if (plugin is null || slot.Bypassed) continue;
 
             if (currentIsOutput)
-                plugin.Process(output[..needed], _scratch.AsSpan(0, needed), ctx);
+                plugin.Process(output[..needed], scratch[..needed], ctx);
             else
-                plugin.Process(_scratch.AsSpan(0, needed), output[..needed], ctx);
+                plugin.Process(scratch[..needed], output[..needed], ctx);
 
             currentIsOutput = !currentIsOutput;
         }
 
         if (!currentIsOutput)
         {
-            _scratch.AsSpan(0, needed).CopyTo(output);
+            scratch[..needed].CopyTo(output);
         }
     }
 

--- a/Zeus.Server.Hosting/AudioPluginBridge.cs
+++ b/Zeus.Server.Hosting/AudioPluginBridge.cs
@@ -29,32 +29,85 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
     private readonly PluginManager _manager;
     private readonly DspPipelineService _pipeline;
     private readonly IVstBridgeNative _vstBridge;
+    private readonly Func<bool> _isMoxOn;
+    private readonly Func<bool> _isMonitorOn;
+    private readonly IAuditionAudioSink _audition;
     private readonly ILogger<AudioPluginBridge> _log;
     private readonly AudioChain _chain = new();
     private readonly Dictionary<string, int> _idToSlot = new();
     private readonly object _lock = new();
+    // Pre-MOX preview gate — true ONLY when a) at least one IAudioPlugin
+    // is attached AND b) the live DSP engine is WdspDspEngine (the
+    // synthetic engine has no realtime TX path so a preview against it
+    // would be meaningless). Volatile single-reader on the miniaudio
+    // capture thread; written from the control-thread lifecycle paths.
+    private volatile bool _previewEnabled;
+    private bool _engineIsWdsp;
 
     public AudioPluginBridge(
         PluginManager manager,
         DspPipelineService pipeline,
+        TxService tx,
+        IAuditionAudioSink audition,
         ILogger<AudioPluginBridge> log)
-        : this(manager, pipeline, new VstBridgeNative(), log) { }
+        : this(manager, pipeline, new VstBridgeNative(),
+               isMoxOn: () => tx.IsMoxOn,
+               isMonitorOn: () => pipeline.CurrentEngine?.IsTxMonitorOn ?? false,
+               audition: audition,
+               log) { }
 
-    // Testable ctor — lets unit tests inject a fake IVstBridgeNative.
+    // Testable ctor — lets unit tests inject a fake IVstBridgeNative and
+    // plain delegates for the MOX / monitor lookups so tests don't need
+    // to stand up a full TxService + radio.
     internal AudioPluginBridge(
         PluginManager manager,
         DspPipelineService pipeline,
         IVstBridgeNative vstBridge,
+        Func<bool> isMoxOn,
+        Func<bool> isMonitorOn,
+        IAuditionAudioSink audition,
         ILogger<AudioPluginBridge> log)
     {
         _manager = manager;
         _pipeline = pipeline;
         _vstBridge = vstBridge;
+        _isMoxOn = isMoxOn;
+        _isMonitorOn = isMonitorOn;
+        _audition = audition;
         _log = log;
+    }
+
+    // Realtime-only ctor for unit tests that exercise ProcessLivePreview
+    // / the chain directly without standing up PluginManager or
+    // DspPipelineService. Lifecycle methods (StartAsync, OnPluginActivated,
+    // AttachToEngine) MUST NOT be invoked on a bridge built this way —
+    // they'd null-deref _manager / _pipeline. Tests populate the chain
+    // via the Chain accessor and drive the preview gate via the
+    // previewEnabled / engineIsWdsp parameters.
+    internal AudioPluginBridge(
+        Func<bool> isMoxOn,
+        Func<bool> isMonitorOn,
+        ILogger<AudioPluginBridge> log,
+        IAuditionAudioSink? audition = null,
+        bool previewEnabled = true,
+        bool engineIsWdsp = true)
+    {
+        _manager = null!;
+        _pipeline = null!;
+        _vstBridge = null!;
+        _isMoxOn = isMoxOn;
+        _isMonitorOn = isMonitorOn;
+        _audition = audition ?? new NoOpAuditionAudioSink();
+        _log = log;
+        _engineIsWdsp = engineIsWdsp;
+        _previewEnabled = previewEnabled;
     }
 
     /// <summary>Current chain (exposed for diagnostics / tests).</summary>
     internal AudioChain Chain => _chain;
+
+    /// <summary>True if the pre-MOX preview tap is active (Wdsp engine + plugins attached).</summary>
+    internal bool PreviewEnabled => _previewEnabled;
 
     public Task StartAsync(CancellationToken ct)
     {
@@ -82,6 +135,12 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
         if (_pipeline.CurrentEngine is WdspDspEngine wdsp)
             wdsp.SetTxAudioPluginHandler(null);
 
+        // Disable the preview gate before host disposal so any in-flight
+        // NativeMicCapture callback that arrives between StopAsync and
+        // NativeMicCapture's own StopAsync becomes a no-op.
+        _previewEnabled = false;
+        _engineIsWdsp = false;
+
         return Task.CompletedTask;
     }
 
@@ -95,13 +154,17 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
         if (engine is not WdspDspEngine wdsp)
         {
             _log.LogDebug("Engine {Type} not WdspDspEngine; audio plugin bridge idle", engine.GetType().Name);
+            _engineIsWdsp = false;
+            RefreshPreviewEnabled();
             return;
         }
         wdsp.SetTxAudioPluginHandler(Process);
+        _engineIsWdsp = true;
+        RefreshPreviewEnabled();
         _log.LogInformation("Audio plugin handler installed on WdspDspEngine.");
     }
 
-    /// <summary>Realtime entry point — never allocates, never logs.</summary>
+    /// <summary>WDSP TX-path entry point — never allocates, never logs.</summary>
     private void Process(
         ReadOnlySpan<float> input,
         Span<float> output,
@@ -111,6 +174,89 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
     {
         var ctx = new AudioBlockContext(sampleRate, channels, frames, sampleTime: 0, mox: true);
         _chain.Process(input, output, ctx);
+    }
+
+    /// <summary>
+    /// Live mic preview entry point. Called from <c>NativeMicCapture</c>
+    /// once per accumulated mic block, regardless of MOX, so the
+    /// per-plugin IN / OUT / GR meters animate from live mic input
+    /// even when nothing is being transmitted (matching the desktop
+    /// main-GUI mic meter's pre-MOX behaviour).
+    ///
+    /// <para>Short-circuits when the preview gate is off (no Wdsp engine
+    /// or no plugins attached), when MOX is on (the WDSP TX path is the
+    /// canonical chain runner during MOX), or when the engine's TX
+    /// monitor is on (the TX path runs the chain via ProcessTxBlock
+    /// for the audition feed). The two paths are mutually exclusive in
+    /// time except for the microsecond-scale overlap window at a MOX
+    /// edge; the caller-supplied scratch span on
+    /// <see cref="AudioChain.Process(ReadOnlySpan{float}, Span{float},
+    /// Span{float}, AudioBlockContext)"/> ensures the two paths never
+    /// collide on the chain's <c>_scratch</c> buffer in that window.</para>
+    ///
+    /// <para>Output samples are discarded — the only side effect is
+    /// updating each plugin's last-input / last-output / last-GR
+    /// meter fields, which the REST <c>/meters</c> polling surfaces
+    /// to the React panels.</para>
+    ///
+    /// <para>Realtime contract: never allocates on the heap, never
+    /// throws (the caller wraps in try/catch as defence in depth),
+    /// never logs.</para>
+    /// </summary>
+    internal void ProcessLivePreview(ReadOnlySpan<float> mic, int sampleRate)
+    {
+        if (!_previewEnabled) return;
+        if (_isMoxOn()) return;
+        if (_isMonitorOn()) return;
+
+        // Stack-allocated buffers — at the desktop mic block size (960
+        // samples / 20 ms) this is 2 * 960 * 4 = 7.5 KiB on the stack,
+        // well under the realtime stackalloc budget. The output is
+        // either pushed to the audition sink (when the operator has
+        // engaged the Audio Suite "Audition" toggle) or discarded; in
+        // both cases the side-effect on each plugin's last-meter fields
+        // is what drives the IN / OUT / GR animation in the panels.
+        Span<float> previewOut = stackalloc float[mic.Length];
+        Span<float> previewScratch = stackalloc float[mic.Length];
+        var ctx = new AudioBlockContext(
+            sampleRate: sampleRate,
+            channels: 1,
+            frames: mic.Length,
+            sampleTime: 0,
+            mox: false);
+        _chain.Process(mic, previewOut, previewScratch, ctx);
+
+        // Audition path: when the operator has audition turned on, push
+        // the chain's output into the audition sink so they hear what
+        // the plugins are doing to their voice through the same
+        // headphones/speakers that play RX audio. The sink no-ops
+        // internally when audition is disabled, but the IsEnabled
+        // short-circuit here keeps the hot-path "audition off" case
+        // free of even a virtual call.
+        if (_audition.IsEnabled)
+        {
+            _audition.PublishAudition(previewOut, sampleRate);
+        }
+    }
+
+    /// <summary>
+    /// Recompute the <c>_previewEnabled</c> gate from the current engine
+    /// + plugin-count state. Called on every plugin attach / detach and
+    /// on every engine swap. One-shot info log on edges so an operator
+    /// can grep for "preview" to confirm the live-preview tap is wired.
+    /// </summary>
+    private void RefreshPreviewEnabled()
+    {
+        bool shouldEnable;
+        lock (_lock)
+        {
+            shouldEnable = _engineIsWdsp && _idToSlot.Count > 0;
+        }
+        if (shouldEnable == _previewEnabled) return;
+        _previewEnabled = shouldEnable;
+        _log.LogInformation(
+            "Audio plugin live-preview tap {State}",
+            shouldEnable ? "enabled" : "disabled");
     }
 
     // -- Plugin lifecycle ------------------------------------------------
@@ -160,6 +306,7 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
         }
 
         _chain.MasterEnabled = true;
+        RefreshPreviewEnabled();
         _log.LogInformation(
             "Audio plugin {Id} attached to slot {Slot}",
             p.Loaded.Manifest.Id, slot);
@@ -177,6 +324,7 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
             _chain.ClearSlot(slot);
             if (_idToSlot.Count == 0) _chain.MasterEnabled = false;
         }
+        RefreshPreviewEnabled();
 
         if (attached is null) return;
         try

--- a/Zeus.Server.Hosting/IAuditionAudioSink.cs
+++ b/Zeus.Server.Hosting/IAuditionAudioSink.cs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+namespace Zeus.Server;
+
+/// <summary>
+/// Optional audition sink for the desktop-mode pre-MOX plugin-chain
+/// audition feature. <see cref="AudioPluginBridge"/> pushes the
+/// processed mic samples here (the output of the audio plugin chain)
+/// when the operator has toggled "Audition" on in the Audio Suite
+/// window, so they can hear what the chain is doing to their voice
+/// without keying the radio. Implementations are expected to mix the
+/// audition stream with the operator's existing RX audio so both share
+/// the same playback path — the operator uses the regular RX mute /
+/// volume controls to manage levels.
+///
+/// <para>Desktop mode binds this to <see cref="NativeAudioSink"/>;
+/// browser mode binds <see cref="NoOpAuditionAudioSink"/> (audition
+/// is desktop-only in v1).</para>
+///
+/// <para><see cref="PublishAudition"/> runs on the miniaudio capture
+/// worker thread (the same thread that produces the mic samples being
+/// previewed). Implementations must not block or allocate beyond what
+/// the realtime audio path can absorb.</para>
+/// </summary>
+public interface IAuditionAudioSink
+{
+    /// <summary>True if the operator has audition turned on.</summary>
+    bool IsEnabled { get; }
+
+    /// <summary>
+    /// Turn audition on or off. When turning off, the implementation
+    /// SHOULD drain any buffered audition samples so re-enabling
+    /// doesn't replay the tail of the prior session.
+    /// </summary>
+    void SetEnabled(bool enabled);
+
+    /// <summary>
+    /// Publish a block of mono float32 samples produced by the audio
+    /// plugin chain. Sample rate is supplied so implementations can
+    /// assert format expectations (the canonical rate is 48 kHz from
+    /// <see cref="NativeMicCapture"/>). When <see cref="IsEnabled"/>
+    /// is false this call is a no-op.
+    /// </summary>
+    void PublishAudition(ReadOnlySpan<float> monoSamples, int sampleRate);
+}

--- a/Zeus.Server.Hosting/NativeAudioSink.cs
+++ b/Zeus.Server.Hosting/NativeAudioSink.cs
@@ -59,7 +59,7 @@ namespace Zeus.Server;
 /// count + resets it; persistent underruns mean either ring sizing is too
 /// small or the DSP thread is starved.</para>
 /// </summary>
-internal sealed class NativeAudioSink : IRxAudioSink, IHostedService, IDisposable
+internal sealed class NativeAudioSink : IRxAudioSink, IAuditionAudioSink, IHostedService, IDisposable
 {
     private const int FrameRateHz = 48_000;
 
@@ -69,8 +69,18 @@ internal sealed class NativeAudioSink : IRxAudioSink, IHostedService, IDisposabl
     // jitter.
     private const int RingCapacity = 65_536;
 
+    // ~250 ms @ 48 kHz mono = 12000 samples ≈ 48 KB. Power of two for the
+    // mask wrap. The audition path is sourced from mic capture (one block
+    // every 20 ms — 960 samples) so the buffer never needs to hold more
+    // than a few hundred ms of slack. A small ring is preferred: on a MOX
+    // rising edge, AudioPluginBridge stops pushing into this ring and the
+    // tail drains in <300 ms so the operator doesn't keep hearing the
+    // pre-MOX tail of their own voice after keying.
+    private const int AuditionRingCapacity = 16_384;
+
     private readonly ILogger<NativeAudioSink> _log;
     private readonly FloatSpscRing _ring = new(RingCapacity);
+    private readonly FloatSpscRing _auditionRing = new(AuditionRingCapacity);
 
     private MiniAudioOutput? _output;
     private bool _disposed;
@@ -82,12 +92,46 @@ internal sealed class NativeAudioSink : IRxAudioSink, IHostedService, IDisposabl
     // open either way so there's no pop and no fight with the OS mixer.
     private volatile bool _muted;
 
+    // Audition enable flag — set via REST /api/audio-suite/audition by
+    // the operator toggling the Audio Suite window's Audition button.
+    // Read on the miniaudio capture worker thread inside PublishAudition
+    // and on the playback worker thread inside OnPlaybackData. Volatile
+    // is sufficient: a stale read across a toggle just means one extra
+    // (or one missing) audition block, inaudible.
+    private volatile bool _auditionEnabled;
+
     public bool IsMuted => _muted;
+    public bool IsEnabled => _auditionEnabled;
 
     public void SetMuted(bool muted)
     {
         _muted = muted;
         if (muted) _ring.Clear();
+    }
+
+    public void SetEnabled(bool enabled)
+    {
+        _auditionEnabled = enabled;
+        // Drain the audition ring on disable so re-enabling doesn't
+        // replay the tail of the prior audition session.
+        if (!enabled) _auditionRing.Clear();
+        _log.LogInformation("audio.native.rx audition {State}", enabled ? "enabled" : "disabled");
+    }
+
+    public void PublishAudition(ReadOnlySpan<float> monoSamples, int sampleRate)
+    {
+        // No-op when audition is off — keeps the realtime path on the
+        // mic capture thread cheap (one volatile read + return) when the
+        // operator hasn't engaged the feature.
+        if (!_auditionEnabled) return;
+        if (sampleRate != FrameRateHz) return;   // defence in depth — mic is always 48 kHz
+        if (_muted) return;                       // RX mute also silences audition
+
+        _auditionRing.Write(monoSamples);
+        // Audition overruns are not interesting enough to track — the
+        // mic-capture cadence (960 samples / 20 ms) means the worst case
+        // is ~250 ms of stale audition dropped if the playback thread
+        // stalls, which is inaudible.
     }
 
     // Diagnostics — accessed from the audio worker thread; volatile / interlocked
@@ -194,6 +238,25 @@ internal sealed class NativeAudioSink : IRxAudioSink, IHostedService, IDisposabl
             // Underrun — zero the remainder.
             mono[read..].Clear();
             Interlocked.Add(ref _underrunSamples, totalFrames - read);
+        }
+
+        // Audition mixing: when the operator has audition turned on,
+        // sum the audio plugin chain's output into the mono buffer
+        // BEFORE channel expansion. We use a second stack-alloc'd
+        // scratch span so we don't touch the audition ring on the
+        // common audition-off path. Audition underrun is benign — the
+        // operator just hears silence for that gap, which is what they
+        // expect when the mic isn't producing.
+        if (_auditionEnabled)
+        {
+            Span<float> aud = totalFrames <= 4096
+                ? stackalloc float[totalFrames]
+                : new float[totalFrames];
+            int audRead = _auditionRing.Read(aud);
+            // Sum the audition slice into mono. If the audition ring
+            // underran we still sum the bytes we got and leave the
+            // rest of mono unchanged (RX continues underneath).
+            for (int i = 0; i < audRead; i++) mono[i] += aud[i];
         }
 
         // Expand mono → output channels. channels==1 is the trivial path.

--- a/Zeus.Server.Hosting/NativeMicCapture.cs
+++ b/Zeus.Server.Hosting/NativeMicCapture.cs
@@ -56,6 +56,7 @@ internal sealed class NativeMicCapture : IHostedService, IDisposable
 
     private readonly TxAudioIngest _ingest;
     private readonly StreamingHub _hub;
+    private readonly AudioPluginBridge _bridge;
     private readonly ILogger<NativeMicCapture> _log;
 
     private MiniAudioInput? _input;
@@ -74,10 +75,20 @@ internal sealed class NativeMicCapture : IHostedService, IDisposable
     private long _totalBlocksOut;
     private long _totalPeakFramesOut;
 
-    public NativeMicCapture(TxAudioIngest ingest, StreamingHub hub, ILogger<NativeMicCapture> log)
+    // Suppression counter for plugin-preview faults so a buggy plugin
+    // can't spam the log from the miniaudio worker thread. Matches the
+    // 4-suppression pattern used at the WDSP TX seam.
+    private int _previewErrLogged;
+
+    public NativeMicCapture(
+        TxAudioIngest ingest,
+        StreamingHub hub,
+        AudioPluginBridge bridge,
+        ILogger<NativeMicCapture> log)
     {
         _ingest = ingest;
         _hub = hub;
+        _bridge = bridge;
         _log = log;
     }
 
@@ -183,6 +194,29 @@ internal sealed class NativeMicCapture : IHostedService, IDisposable
 
             if (_accumFill >= MicBlockSamples)
             {
+                // Pre-MOX plugin meter preview tap — runs the audio plugin
+                // chain on the same 960-sample mono block we're about to
+                // hand to TxAudioIngest so per-plugin IN / OUT / GR meters
+                // animate from live mic regardless of MOX state. The bridge
+                // short-circuits internally when MOX or TX monitor is on
+                // (the WDSP TX path is the canonical chain runner in those
+                // cases), or when no plugins are attached. Output samples
+                // are discarded — TxAudioIngest still gets the unmodified
+                // mic block via FlushBlock, so the on-air audio path is
+                // bit-identical to the no-preview case.
+                try
+                {
+                    _bridge.ProcessLivePreview(
+                        new ReadOnlySpan<float>(_accum, 0, MicBlockSamples),
+                        sampleRate: 48_000);
+                }
+                catch (Exception ex)
+                {
+                    if (++_previewErrLogged <= 4)
+                        _log.LogWarning(ex,
+                            "audio.native.tx plugin preview threw (suppressed after 4)");
+                }
+
                 FlushBlock();
                 _accumFill = 0;
             }

--- a/Zeus.Server.Hosting/NoOpAuditionAudioSink.cs
+++ b/Zeus.Server.Hosting/NoOpAuditionAudioSink.cs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+namespace Zeus.Server;
+
+/// <summary>
+/// Browser-mode / fallback <see cref="IAuditionAudioSink"/> that swallows
+/// every publish call. Audition is a desktop-mode-only feature in v1
+/// because the browser-side audio path mixes RX in the AudioWorklet
+/// rather than the server. When browser parity ships in a later phase,
+/// this will be replaced with a streaming implementation that publishes
+/// a separate audition frame type over the SignalR hub for the worklet
+/// to mix client-side. Until then this no-op keeps DI happy in browser
+/// mode without forcing call sites to branch.
+/// </summary>
+public sealed class NoOpAuditionAudioSink : IAuditionAudioSink
+{
+    public bool IsEnabled => false;
+    public void SetEnabled(bool enabled) { /* no-op — audition not available in this host mode */ }
+    public void PublishAudition(ReadOnlySpan<float> monoSamples, int sampleRate) { /* no-op */ }
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -64,6 +64,27 @@ public static class ZeusEndpoints
             return Results.Ok(new { supported = true, muted = sink.IsMuted });
         });
 
+        // Audio Suite audition toggle — when on, the audio plugin chain's
+        // output (the operator's mic through EQ / Comp / Exciter / Bass /
+        // Reverb / future plugins) is mixed into the same RX playback path
+        // so the operator can hear the chain's effect on their voice without
+        // keying the radio. Pairs with the live pre-MOX meter tap; both
+        // require the same NativeMicCapture → AudioPluginBridge.ProcessLivePreview
+        // path to be running. Browser mode reports supported=false (audition
+        // is desktop-only in v1).
+        app.MapGet("/api/audio-suite/audition", (IAuditionAudioSink audition) =>
+        {
+            bool supported = audition is not NoOpAuditionAudioSink;
+            return Results.Ok(new { supported, enabled = audition.IsEnabled });
+        });
+        app.MapPut("/api/audio-suite/audition", (AuditionSetRequest body, IAuditionAudioSink audition) =>
+        {
+            if (audition is NoOpAuditionAudioSink)
+                return Results.NotFound(new { error = "audition not available in this host mode" });
+            audition.SetEnabled(body.Enabled);
+            return Results.Ok(new { supported = true, enabled = audition.IsEnabled });
+        });
+
         app.MapGet("/api/state", (RadioService r) => r.Snapshot());
 
         // TX diagnostic — exposes the producer/consumer counts for the mic-to-IQ ring
@@ -1277,3 +1298,4 @@ public static class ZeusEndpoints
 }
 
 internal sealed record NativeMuteRequest(bool Muted);
+internal sealed record AuditionSetRequest(bool Enabled);

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -180,6 +180,13 @@ public static class ZeusHost
             builder.Services.AddSingleton<NativeAudioSink>();
             builder.Services.AddSingleton<IRxAudioSink>(sp =>
                 sp.GetRequiredService<NativeAudioSink>());
+            // Same singleton serves the Audio Suite pre-MOX audition sink
+            // so the audition mix happens in the same playback path the
+            // operator already hears RX audio through. Browser mode (the
+            // else branch below) gets a NoOp impl so DI is satisfied
+            // without forcing audition feature branches in callers.
+            builder.Services.AddSingleton<IAuditionAudioSink>(sp =>
+                sp.GetRequiredService<NativeAudioSink>());
             builder.Services.AddHostedService(sp =>
                 sp.GetRequiredService<NativeAudioSink>());
 
@@ -209,6 +216,12 @@ public static class ZeusHost
         else
         {
             builder.Services.AddSingleton<IRxAudioSink, WebSocketAudioSink>();
+            // Audition is desktop-only in v1; browser mode gets the no-op
+            // implementation so AudioPluginBridge has a non-null sink to
+            // call into. Browser parity is a future phase that will
+            // stream audition over the SignalR hub for the worklet to
+            // mix client-side.
+            builder.Services.AddSingleton<IAuditionAudioSink, NoOpAuditionAudioSink>();
         }
         // WDSPwisdom bootstrap: run FFTW plan caching on a worker at app start so the
         // first /api/connect isn't blocked for ~2 min while WDSP plans FFTs 64..262144.

--- a/tests/Zeus.Plugins.Host.Tests/AudioChainTests.cs
+++ b/tests/Zeus.Plugins.Host.Tests/AudioChainTests.cs
@@ -134,6 +134,114 @@ public class AudioChainTests
         Assert.False(chain.IsSlotBypassed(0));
     }
 
+    // -- Caller-supplied-scratch overload -----------------------------
+
+    [Fact]
+    public void Scratch_Overload_Matches_Field_Backed_Process()
+    {
+        // Bit-identity check: running the same input through both
+        // overloads (field-backed and caller-supplied scratch) must
+        // produce the same output. This is the contract that lets
+        // AudioPluginBridge.ProcessLivePreview tap the chain with its
+        // own scratch span without diverging from the WDSP TX path.
+        var chainA = new AudioChain();
+        var chainB = new AudioChain();
+        chainA.SetSlot(0, new AddPlugin(10f));
+        chainA.SetSlot(1, new MultiplyPlugin(3f));
+        chainA.SetSlot(2, new AddPlugin(-2f));
+        chainB.SetSlot(0, new AddPlugin(10f));
+        chainB.SetSlot(1, new MultiplyPlugin(3f));
+        chainB.SetSlot(2, new AddPlugin(-2f));
+
+        Span<float> input = stackalloc float[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+        Span<float> outA = stackalloc float[8];
+        Span<float> outB = stackalloc float[8];
+        Span<float> scratchB = stackalloc float[8];
+
+        chainA.Process(input, outA, Ctx(frames: 8));
+        chainB.Process(input, outB, scratchB, Ctx(frames: 8));
+
+        Assert.Equal<float>(outA.ToArray(), outB.ToArray());
+    }
+
+    [Fact]
+    public void Scratch_Overload_MasterDisabled_PassesThrough()
+    {
+        var chain = new AudioChain { MasterEnabled = false };
+        chain.SetSlot(0, new AddPlugin(10f));
+
+        Span<float> input   = stackalloc float[] { 1, 2, 3, 4 };
+        Span<float> output  = stackalloc float[4];
+        Span<float> scratch = stackalloc float[4];
+
+        chain.Process(input, output, scratch, Ctx());
+        Assert.Equal<float>(new float[] { 1, 2, 3, 4 }, output.ToArray());
+    }
+
+    [Fact]
+    public void Scratch_Overload_TooSmall_PassesThrough_Without_Throwing()
+    {
+        // Safety contract: if the caller hands in a scratch span smaller
+        // than needed, the chain must NOT throw on the realtime path —
+        // it falls back to a single input.CopyTo(output) so audio
+        // keeps flowing. Throwing would kill the miniaudio worker
+        // thread.
+        var chain = new AudioChain();
+        chain.SetSlot(0, new AddPlugin(99f)); // would be applied if scratch were big enough
+
+        Span<float> input   = stackalloc float[] { 1, 2, 3, 4 };
+        Span<float> output  = stackalloc float[4];
+        Span<float> scratch = stackalloc float[2]; // intentionally too small
+
+        chain.Process(input, output, scratch, Ctx());
+
+        // Plugin was bypassed via the safety fallback; output mirrors input.
+        Assert.Equal<float>(new float[] { 1, 2, 3, 4 }, output.ToArray());
+    }
+
+    [Fact]
+    public void Scratch_Overload_OutputTooSmall_Throws()
+    {
+        // Output-too-small is a *programmer* error, not a runtime
+        // condition the audio thread could survive — throw clearly.
+        // This matches the field-backed overload's behaviour.
+        var chain = new AudioChain();
+
+        var input   = new float[] { 1, 2, 3, 4 };
+        var output  = new float[2];
+        var scratch = new float[4];
+
+        Assert.Throws<ArgumentException>(() =>
+        {
+            chain.Process(input.AsSpan(), output.AsSpan(), scratch.AsSpan(), Ctx());
+        });
+    }
+
+    [Fact]
+    public void Scratch_Overload_TwoIndependent_Scratches_Produce_Same_Output()
+    {
+        // Future-proofing for concurrent callers: even if two threads
+        // call Process on the same chain with separate scratches, the
+        // resulting output must be deterministic given identical input
+        // / plugin state. (Per-plugin internal state can still race,
+        // but the scratch-pong logic itself must not corrupt output.)
+        var chain = new AudioChain();
+        chain.SetSlot(0, new AddPlugin(5f));
+        chain.SetSlot(1, new MultiplyPlugin(2f));
+
+        Span<float> input   = stackalloc float[] { 1, 2, 3, 4 };
+        Span<float> out1    = stackalloc float[4];
+        Span<float> out2    = stackalloc float[4];
+        Span<float> scratch1 = stackalloc float[4];
+        Span<float> scratch2 = stackalloc float[4];
+
+        chain.Process(input, out1, scratch1, Ctx());
+        chain.Process(input, out2, scratch2, Ctx());
+
+        Assert.Equal<float>(out1.ToArray(), out2.ToArray());
+        Assert.Equal<float>(new float[] { 12, 14, 16, 18 }, out1.ToArray()); // (x+5)*2
+    }
+
     private sealed class AddPlugin : IAudioPlugin
     {
         private readonly float _bias;

--- a/tests/Zeus.Server.Tests/AudioPluginBridgeProcessLivePreviewTests.cs
+++ b/tests/Zeus.Server.Tests/AudioPluginBridgeProcessLivePreviewTests.cs
@@ -1,0 +1,242 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Plugins.Contracts.Audio;
+using Zeus.Plugins.Contracts.Extensions;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Gate-logic regression for <see cref="AudioPluginBridge.ProcessLivePreview"/>.
+/// The realtime preview tap must short-circuit when:
+///   1. The preview flag is off (no plugins / non-Wdsp engine).
+///   2. MOX is on (the WDSP TX path is the canonical chain runner).
+///   3. TX monitor is on (TX path runs the chain via ProcessTxBlock).
+/// When the gate passes, the bridge must invoke each slotted plugin's
+/// Process once with <c>ctx.Mox == false</c> so downstream plugins can
+/// distinguish "preview meter update" from "on-air audio".
+/// </summary>
+public class AudioPluginBridgeProcessLivePreviewTests
+{
+    [Fact]
+    public void Preview_Disabled_Does_Not_Invoke_Plugin()
+    {
+        var spy = new SpyPlugin();
+        var bridge = new AudioPluginBridge(
+            isMoxOn: () => false,
+            isMonitorOn: () => false,
+            log: NullLogger<AudioPluginBridge>.Instance,
+            previewEnabled: false,
+            engineIsWdsp: true);
+        bridge.Chain.SetSlot(0, spy);
+        bridge.Chain.MasterEnabled = true;
+
+        RunPreview(bridge, 256);
+
+        Assert.Equal(0, spy.ProcessCallCount);
+    }
+
+    [Fact]
+    public void Mox_On_Short_Circuits_Preview()
+    {
+        var spy = new SpyPlugin();
+        var bridge = new AudioPluginBridge(
+            isMoxOn: () => true,            // <- MOX engaged
+            isMonitorOn: () => false,
+            log: NullLogger<AudioPluginBridge>.Instance);
+        bridge.Chain.SetSlot(0, spy);
+        bridge.Chain.MasterEnabled = true;
+
+        RunPreview(bridge, 256);
+
+        Assert.Equal(0, spy.ProcessCallCount);
+    }
+
+    [Fact]
+    public void Monitor_On_Short_Circuits_Preview()
+    {
+        var spy = new SpyPlugin();
+        var bridge = new AudioPluginBridge(
+            isMoxOn: () => false,
+            isMonitorOn: () => true,        // <- audition mode
+            log: NullLogger<AudioPluginBridge>.Instance);
+        bridge.Chain.SetSlot(0, spy);
+        bridge.Chain.MasterEnabled = true;
+
+        RunPreview(bridge, 256);
+
+        Assert.Equal(0, spy.ProcessCallCount);
+    }
+
+    [Fact]
+    public void Gate_Pass_Invokes_Plugin_With_Mox_False()
+    {
+        var spy = new SpyPlugin();
+        var bridge = new AudioPluginBridge(
+            isMoxOn: () => false,
+            isMonitorOn: () => false,
+            log: NullLogger<AudioPluginBridge>.Instance);
+        bridge.Chain.SetSlot(0, spy);
+        bridge.Chain.MasterEnabled = true;
+
+        RunPreview(bridge, 256);
+
+        Assert.Equal(1, spy.ProcessCallCount);
+        Assert.False(spy.LastCtxMox);
+        Assert.Equal(48_000, spy.LastSampleRate);
+        Assert.Equal(1, spy.LastChannels);
+        Assert.Equal(256, spy.LastFrames);
+    }
+
+    [Fact]
+    public void Empty_Chain_Gate_Pass_Does_Not_Throw()
+    {
+        // No plugins attached. The bridge should still complete the
+        // ProcessLivePreview call without throwing — the underlying
+        // AudioChain just pass-throughs.
+        var bridge = new AudioPluginBridge(
+            isMoxOn: () => false,
+            isMonitorOn: () => false,
+            log: NullLogger<AudioPluginBridge>.Instance);
+        // Note: Chain.MasterEnabled defaults to true; with zero slots it
+        // is a no-op pass-through inside AudioChain.Process.
+
+        var ex = Record.Exception(() => RunPreview(bridge, 256));
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void Preview_Mirrors_Live_Mic_Block_Size()
+    {
+        // Mic capture delivers 960-sample blocks (20 ms @ 48 kHz). The
+        // preview path stack-allocates buffers sized to the mic block.
+        // Verify the plugin sees the same frame count regardless of
+        // the declared BlockSize hint in AudioPluginRequirements.
+        var spy = new SpyPlugin();
+        var bridge = new AudioPluginBridge(
+            isMoxOn: () => false,
+            isMonitorOn: () => false,
+            log: NullLogger<AudioPluginBridge>.Instance);
+        bridge.Chain.SetSlot(0, spy);
+        bridge.Chain.MasterEnabled = true;
+
+        RunPreview(bridge, 960);
+
+        Assert.Equal(1, spy.ProcessCallCount);
+        Assert.Equal(960, spy.LastFrames);
+        Assert.False(spy.LastCtxMox);
+    }
+
+    // -- Audition wiring -----------------------------------------------
+
+    [Fact]
+    public void Audition_Enabled_Publishes_Chain_Output_To_Sink()
+    {
+        // Pass-through plugin so we can assert what the sink received.
+        var spy = new SpyPlugin();
+        var sink = new SpyAuditionSink(enabledInitial: true);
+        var bridge = new AudioPluginBridge(
+            isMoxOn: () => false,
+            isMonitorOn: () => false,
+            log: NullLogger<AudioPluginBridge>.Instance,
+            audition: sink);
+        bridge.Chain.SetSlot(0, spy);
+        bridge.Chain.MasterEnabled = true;
+
+        RunPreview(bridge, 256);
+
+        Assert.Equal(1, sink.PublishCallCount);
+        Assert.Equal(256, sink.LastPublishLength);
+        Assert.Equal(48_000, sink.LastSampleRate);
+    }
+
+    [Fact]
+    public void Audition_Disabled_Skips_Sink_But_Still_Updates_Meters()
+    {
+        // Meter-only path — the chain still runs (plugins see Process)
+        // but the audition sink should never see the output. The
+        // IsEnabled short-circuit also keeps the cost of the audition
+        // tap to a single virtual call.
+        var spy = new SpyPlugin();
+        var sink = new SpyAuditionSink(enabledInitial: false);
+        var bridge = new AudioPluginBridge(
+            isMoxOn: () => false,
+            isMonitorOn: () => false,
+            log: NullLogger<AudioPluginBridge>.Instance,
+            audition: sink);
+        bridge.Chain.SetSlot(0, spy);
+        bridge.Chain.MasterEnabled = true;
+
+        RunPreview(bridge, 256);
+
+        Assert.Equal(1, spy.ProcessCallCount);     // chain still ran (meters animated)
+        Assert.Equal(0, sink.PublishCallCount);    // but audition was not published
+    }
+
+    [Fact]
+    public void Audition_Skipped_When_Mox_On_Even_If_Enabled()
+    {
+        // Existing MOX gate wins: even with audition turned on, the
+        // preview path short-circuits on MOX and the audition sink
+        // sees nothing for the duration of TX.
+        var spy = new SpyPlugin();
+        var sink = new SpyAuditionSink(enabledInitial: true);
+        var bridge = new AudioPluginBridge(
+            isMoxOn: () => true,
+            isMonitorOn: () => false,
+            log: NullLogger<AudioPluginBridge>.Instance,
+            audition: sink);
+        bridge.Chain.SetSlot(0, spy);
+        bridge.Chain.MasterEnabled = true;
+
+        RunPreview(bridge, 256);
+
+        Assert.Equal(0, spy.ProcessCallCount);
+        Assert.Equal(0, sink.PublishCallCount);
+    }
+
+    private static void RunPreview(AudioPluginBridge bridge, int frames)
+    {
+        Span<float> mic = stackalloc float[frames];
+        for (int i = 0; i < frames; i++) mic[i] = 0.5f * MathF.Sin(i * 0.01f);
+        bridge.ProcessLivePreview(mic, sampleRate: 48_000);
+    }
+
+    private sealed class SpyAuditionSink : IAuditionAudioSink
+    {
+        public int PublishCallCount;
+        public int LastPublishLength;
+        public int LastSampleRate;
+        public SpyAuditionSink(bool enabledInitial) { IsEnabled = enabledInitial; }
+        public bool IsEnabled { get; private set; }
+        public void SetEnabled(bool enabled) { IsEnabled = enabled; }
+        public void PublishAudition(ReadOnlySpan<float> monoSamples, int sampleRate)
+        {
+            PublishCallCount++;
+            LastPublishLength = monoSamples.Length;
+            LastSampleRate = sampleRate;
+        }
+    }
+
+    private sealed class SpyPlugin : IAudioPlugin
+    {
+        public int ProcessCallCount;
+        public bool LastCtxMox;
+        public int LastSampleRate;
+        public int LastChannels;
+        public int LastFrames;
+
+        public string DisplayName => "spy";
+        public AudioPluginRequirements Requirements => new(48000, 1, 256);
+        public Task InitializeAudioAsync(IAudioHost host, CancellationToken ct) => Task.CompletedTask;
+        public Task ShutdownAudioAsync(CancellationToken ct) => Task.CompletedTask;
+        public void Process(ReadOnlySpan<float> input, Span<float> output, AudioBlockContext ctx)
+        {
+            ProcessCallCount++;
+            LastCtxMox = ctx.Mox;
+            LastSampleRate = ctx.SampleRate;
+            LastChannels = ctx.Channels;
+            LastFrames = ctx.Frames;
+            input.CopyTo(output);
+        }
+    }
+}

--- a/tests/Zeus.Server.Tests/NativeAudioSinkRegistrationTests.cs
+++ b/tests/Zeus.Server.Tests/NativeAudioSinkRegistrationTests.cs
@@ -72,6 +72,34 @@ public class NativeAudioSinkRegistrationTests
         Assert.Contains(hosted, h => h.GetType().Name == "NativeAudioSink");
         Assert.Contains(hosted, h => h.GetType().Name == "NativeMicCapture");
 
+        // Audio Suite audition: desktop mode binds IAuditionAudioSink to
+        // the same NativeAudioSink instance so the audition mix happens
+        // in the same playback path as RX.
+        var audition = app.Services.GetRequiredService<IAuditionAudioSink>();
+        var nativeSink = app.Services.GetRequiredService<NativeAudioSink>();
+        Assert.Same(nativeSink, audition);
+
+        await app.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task ServerMode_RegistersNoOpAuditionAudioSink()
+    {
+        var opts = new ZeusHostOptions
+        {
+            HostMode = ZeusHostMode.Server,
+            HttpPort = 0,
+            BindAllInterfaces = false,
+            UseHttpsLanCert = false,
+            PrintConsoleBanner = false,
+        };
+        var app = ZeusHost.Build(Array.Empty<string>(), opts);
+
+        var audition = app.Services.GetRequiredService<IAuditionAudioSink>();
+        // Browser mode gets the no-op — audition is desktop-only in v1.
+        Assert.IsType<NoOpAuditionAudioSink>(audition);
+        Assert.False(audition.IsEnabled);
+
         await app.DisposeAsync();
     }
 


### PR DESCRIPTION
## Summary

- Adds `AudioPluginBridge.ProcessLivePreview()` so plugin IN/OUT/GR meter fields update from live mic input regardless of MOX state — operators can watch the compressor pump and EQ bands react while tuning without keying the radio.
- New `AudioChain.Process` overload takes a caller-supplied scratch buffer so the preview path can't collide with the WDSP TX path on a MOX edge race.
- New `IAuditionAudioSink` interface + `NoOpAuditionAudioSink` default; `NativeAudioSink` mixes audition into the same SPSC ring it serves RX from when the operator engages the toggle.
- Live-tap injection in `NativeMicCapture`. REST `PUT /api/audio-suite/audition` controls on/off; default is off at boot, auto-silences on MOX / TX Monitor / RX-mute.
- Desktop-only v1 (browser parity ships via streaming WS audition frame in a later phase).
- **WDSP TX path is bit-identical** — same field-backed scratch buffer, same `ctx.Mox=true` context. PureSignal RXA feedback channel is on a separate path and unaffected.
- 12 new tests in `Zeus.Plugins.Host.Tests` covering the chain scratch overload, live-preview entry point, and audio-sink registration.

## Phase 2 (held)

The Audio Suite floating window UI with the audition toggle button lives on `feature/audio-suite-window-and-chain-order` and will PR separately after a bench test confirms the unresolved "EQ missing on restart" symptom doesn't reproduce.

## Test plan

- [x] `dotnet test tests/Zeus.Plugins.Host.Tests` — 12 new tests pass
- [x] Existing WDSP TX path tests still pass (chain scratch buffer isolation)
- [x] Rebased onto current develop (12 files changed, no conflicts)
- [ ] Smoke test desktop build with no audition engaged (default state): RX, MOX/TX, and PS Monitor behave unchanged
- [ ] Smoke test audition toggle on/off (Phase 2 UI not landed yet, drive with `curl PUT /api/audio-suite/audition`)