### PR TITLE
feat(audio-suite): floating window + reorderable chain (#332 Phase 2)

### DIFF
--- a/Zeus.Contracts/AudioChainOrderFrame.cs
+++ b/Zeus.Contracts/AudioChainOrderFrame.cs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using System.Buffers;
+using System.Text;
+
+namespace Zeus.Contracts;
+
+/// <summary>
+/// Audio plugin chain order broadcast. Carries the operator's
+/// current chain order as a comma-separated list of plugin IDs
+/// (head first = first in chain, processes mic first; tail =
+/// last in chain, output goes downstream to WDSP TXA).
+///
+/// Broadcast by <c>ChainOrderService</c> whenever the order
+/// changes — either because the operator drag-dropped a tile in
+/// the Audio Suite window, or because a plugin was installed /
+/// uninstalled. Other connected clients (LAN-share phone,
+/// second browser) update their tile strip on receipt without
+/// polling.
+///
+/// Payload: <c>[type:1][csvUtf8…]</c>. Capped at
+/// <see cref="MaxByteLength"/> bytes so clients can stack-allocate
+/// a decode buffer. The cap is conservative for the v1 chain
+/// (8 plugins × ~50 chars + commas ≈ 410 bytes) — third-party
+/// plugins with very long IDs that overflow are dropped on the
+/// server side with a log warning, not throw.
+/// </summary>
+public readonly record struct AudioChainOrderFrame(IReadOnlyList<string> PluginIds)
+{
+    public const int MaxByteLength = 1024;
+
+    public void Serialize(IBufferWriter<byte> writer)
+    {
+        var csv = string.Join(",", PluginIds);
+        var msgBytes = Encoding.UTF8.GetBytes(csv);
+        int totalLen = 1 + msgBytes.Length;
+        if (totalLen > MaxByteLength)
+            throw new InvalidOperationException(
+                $"AudioChainOrderFrame too long: {totalLen} bytes (max {MaxByteLength}). " +
+                $"Plugin IDs combined are longer than the contract's per-frame cap.");
+
+        var span = writer.GetSpan(totalLen);
+        span[0] = (byte)MsgType.AudioChainOrder;
+        msgBytes.CopyTo(span.Slice(1));
+        writer.Advance(totalLen);
+    }
+
+    public static AudioChainOrderFrame Deserialize(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length < 1)
+            throw new InvalidDataException(
+                $"AudioChainOrderFrame requires ≥1 byte, got {bytes.Length}");
+        if (bytes[0] != (byte)MsgType.AudioChainOrder)
+            throw new InvalidDataException(
+                $"expected AudioChainOrder (0x{(byte)MsgType.AudioChainOrder:X2}), got 0x{bytes[0]:X2}");
+
+        var csv = Encoding.UTF8.GetString(bytes.Slice(1));
+        // Empty payload encodes "empty chain" — chain order with no
+        // plugins, e.g. after the last plugin is uninstalled.
+        var ids = csv.Length == 0
+            ? Array.Empty<string>()
+            : csv.Split(',');
+        return new AudioChainOrderFrame(ids);
+    }
+}

--- a/Zeus.Contracts/MsgType.cs
+++ b/Zeus.Contracts/MsgType.cs
@@ -132,4 +132,14 @@ public enum MsgType : byte
     // renumbered to 0x1D on merge with develop to resolve the collision
     // with MoxState above.
     MicPeak = 0x1D,
+
+    // Server → client (audio plugin chain order). Broadcast whenever a
+    // user reorders the chain via the Audio Suite window's tile strip,
+    // OR when a plugin is installed / uninstalled (so other connected
+    // clients refresh their tile order without polling). Payload:
+    // [type:1][csvUtf8…] — comma-separated plugin IDs in chain order
+    // (head = first in chain, drives mic first). UTF-8 for forward
+    // compatibility with non-ASCII plugin IDs even though current IDs
+    // are reverse-DNS ASCII. See AudioChainOrderFrame.cs.
+    AudioChainOrder = 0x1E,
 }

--- a/Zeus.Server.Hosting/AudioPluginBridge.cs
+++ b/Zeus.Server.Hosting/AudioPluginBridge.cs
@@ -32,10 +32,13 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
     private readonly Func<bool> _isMoxOn;
     private readonly Func<bool> _isMonitorOn;
     private readonly IAuditionAudioSink _audition;
+    private readonly ChainOrderService? _chainOrder;
     private readonly ILogger<AudioPluginBridge> _log;
     private readonly AudioChain _chain = new();
     private readonly Dictionary<string, int> _idToSlot = new();
+    private readonly Dictionary<string, IAudioPlugin> _idToPlugin = new();
     private readonly object _lock = new();
+    private Action<IReadOnlyList<string>>? _orderChangedHandler;
     // Pre-MOX preview gate — true ONLY when a) at least one IAudioPlugin
     // is attached AND b) the live DSP engine is WdspDspEngine (the
     // synthetic engine has no realtime TX path so a preview against it
@@ -49,11 +52,13 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
         DspPipelineService pipeline,
         TxService tx,
         IAuditionAudioSink audition,
+        ChainOrderService chainOrder,
         ILogger<AudioPluginBridge> log)
         : this(manager, pipeline, new VstBridgeNative(),
                isMoxOn: () => tx.IsMoxOn,
                isMonitorOn: () => pipeline.CurrentEngine?.IsTxMonitorOn ?? false,
                audition: audition,
+               chainOrder: chainOrder,
                log) { }
 
     // Testable ctor — lets unit tests inject a fake IVstBridgeNative and
@@ -66,6 +71,7 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
         Func<bool> isMoxOn,
         Func<bool> isMonitorOn,
         IAuditionAudioSink audition,
+        ChainOrderService? chainOrder,
         ILogger<AudioPluginBridge> log)
     {
         _manager = manager;
@@ -74,6 +80,7 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
         _isMoxOn = isMoxOn;
         _isMonitorOn = isMonitorOn;
         _audition = audition;
+        _chainOrder = chainOrder;
         _log = log;
     }
 
@@ -98,6 +105,7 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
         _isMoxOn = isMoxOn;
         _isMonitorOn = isMonitorOn;
         _audition = audition ?? new NoOpAuditionAudioSink();
+        _chainOrder = null;
         _log = log;
         _engineIsWdsp = engineIsWdsp;
         _previewEnabled = previewEnabled;
@@ -115,6 +123,12 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
         _manager.PluginDeactivated += OnPluginDeactivated;
         _pipeline.EngineChanged    += OnEngineChanged;
 
+        if (_chainOrder is not null)
+        {
+            _orderChangedHandler = ApplyChainOrder;
+            _chainOrder.OrderChanged += _orderChangedHandler;
+        }
+
         // Adopt any plugins already active (PluginManager might have
         // finished startup before us depending on hosted-service ordering).
         foreach (var p in _manager.Active) OnPluginActivated(p);
@@ -131,6 +145,12 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
         _manager.PluginActivated   -= OnPluginActivated;
         _manager.PluginDeactivated -= OnPluginDeactivated;
         _pipeline.EngineChanged    -= OnEngineChanged;
+
+        if (_chainOrder is not null && _orderChangedHandler is not null)
+        {
+            _chainOrder.OrderChanged -= _orderChangedHandler;
+            _orderChangedHandler = null;
+        }
 
         if (_pipeline.CurrentEngine is WdspDspEngine wdsp)
             wdsp.SetTxAudioPluginHandler(null);
@@ -269,16 +289,45 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
         int slot;
         lock (_lock)
         {
-            slot = FindFreeSlot();
-            if (slot < 0)
+            if (_chainOrder is not null)
             {
-                _log.LogWarning(
-                    "Audio chain full (8 slots); ignoring plugin {Id}",
-                    p.Loaded.Manifest.Id);
-                return;
+                // ChainOrderService-driven slot assignment: pull the
+                // operator's canonical order, find the new plugin's
+                // place in it (appending to the end if first install),
+                // and re-slot the entire chain so the new plugin lands
+                // in the right position relative to the existing ones.
+                _idToPlugin[p.Loaded.Manifest.Id] = audioPlugin;
+                var attachedIds = _idToPlugin.Keys.ToList();
+                slot = _chainOrder.OnPluginAttached(p.Loaded.Manifest.Id, attachedIds);
+                ReapplySlotsUnderLock();
+                if (!_idToSlot.TryGetValue(p.Loaded.Manifest.Id, out slot))
+                {
+                    // Defensive fallback — ReapplySlotsUnderLock should have
+                    // populated _idToSlot from the order. If not, the chain
+                    // is in a bad state; log and bail.
+                    _log.LogError(
+                        "Audio plugin {Id} not slotted after ReapplySlotsUnderLock; chain may be inconsistent",
+                        p.Loaded.Manifest.Id);
+                    _idToPlugin.Remove(p.Loaded.Manifest.Id);
+                    return;
+                }
             }
-            _idToSlot[p.Loaded.Manifest.Id] = slot;
-            _chain.SetSlot(slot, audioPlugin);
+            else
+            {
+                // Legacy / test path — no ChainOrderService injected; use
+                // the historical first-free-slot behaviour.
+                slot = FindFreeSlot();
+                if (slot < 0)
+                {
+                    _log.LogWarning(
+                        "Audio chain full (8 slots); ignoring plugin {Id}",
+                        p.Loaded.Manifest.Id);
+                    return;
+                }
+                _idToSlot[p.Loaded.Manifest.Id] = slot;
+                _idToPlugin[p.Loaded.Manifest.Id] = audioPlugin;
+                _chain.SetSlot(slot, audioPlugin);
+            }
         }
 
         // Realtime-safe init off-thread before the chain dispatches. The
@@ -320,10 +369,17 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
         {
             if (!_idToSlot.TryGetValue(p.Loaded.Manifest.Id, out slot)) return;
             _idToSlot.Remove(p.Loaded.Manifest.Id);
+            _idToPlugin.Remove(p.Loaded.Manifest.Id);
             attached = _chain.GetSlot(slot);
             _chain.ClearSlot(slot);
+            // Re-slot remaining plugins so the chain compacts when
+            // ChainOrderService is active — gaps from a removed plugin
+            // close instead of leaving a hole in the middle of the
+            // chain.
+            if (_chainOrder is not null) ReapplySlotsUnderLock();
             if (_idToSlot.Count == 0) _chain.MasterEnabled = false;
         }
+        _chainOrder?.OnPluginDetached(p.Loaded.Manifest.Id);
         RefreshPreviewEnabled();
 
         if (attached is null) return;
@@ -368,6 +424,77 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
         for (int i = 0; i < _chain.SlotCount; i++)
             if (_chain.GetSlot(i) is null) return i;
         return -1;
+    }
+
+    /// <summary>
+    /// Event handler for <see cref="ChainOrderService.OrderChanged"/>.
+    /// Re-slots the chain so the runtime sequence matches the
+    /// canonical order the operator chose via the Audio Suite tile
+    /// strip. Fired off the chain order's _sync lock; we take
+    /// _lock here for the slot mutation.
+    /// </summary>
+    private void ApplyChainOrder(IReadOnlyList<string> _)
+    {
+        // We don't use the supplied order argument directly because
+        // ReapplySlotsUnderLock reads CurrentOrder fresh from the
+        // service inside the lock — same semantics, but it picks up
+        // the latest snapshot in the rare case the order changes again
+        // between the OrderChanged fire and our lock acquisition.
+        lock (_lock) ReapplySlotsUnderLock();
+        _log.LogInformation("Audio plugin chain re-slotted to operator order");
+    }
+
+    /// <summary>
+    /// Clears every chain slot and re-populates them so plugins in
+    /// <see cref="_idToPlugin"/> land at indices matching their
+    /// position in <see cref="ChainOrderService.CurrentOrder"/>,
+    /// skipping IDs that aren't currently attached. CALLER must
+    /// hold <see cref="_lock"/>.
+    ///
+    /// <para>Plugins not present in the canonical order (e.g. a
+    /// third-party plugin that landed before ChainOrderService had
+    /// a chance to append it) get appended to the end in
+    /// deterministic order (by ID).</para>
+    /// </summary>
+    private void ReapplySlotsUnderLock()
+    {
+        if (_chainOrder is null) return;
+        var canonical = _chainOrder.CurrentOrder;
+        var canonicalSet = new HashSet<string>(canonical, StringComparer.Ordinal);
+
+        // Clear current slot assignments. AudioChain.SetSlot replaces
+        // the slot's plugin reference and clears bypass; ClearSlot
+        // nulls it and clears bypass. Use ClearSlot for the wipe so
+        // bypass state doesn't leak across reorders.
+        for (int i = 0; i < _chain.SlotCount; i++) _chain.ClearSlot(i);
+        _idToSlot.Clear();
+
+        // Re-slot in canonical order, plus any orphans appended.
+        int slotIndex = 0;
+        for (int i = 0; i < canonical.Count && slotIndex < _chain.SlotCount; i++)
+        {
+            var id = canonical[i];
+            if (!_idToPlugin.TryGetValue(id, out var plugin)) continue;
+            _chain.SetSlot(slotIndex, plugin);
+            _idToSlot[id] = slotIndex;
+            slotIndex++;
+        }
+        // Append orphans (attached but not in canonical order) at the
+        // end, sorted for determinism.
+        foreach (var kvp in _idToPlugin
+                     .Where(k => !canonicalSet.Contains(k.Key))
+                     .OrderBy(k => k.Key, StringComparer.Ordinal))
+        {
+            if (slotIndex >= _chain.SlotCount)
+            {
+                _log.LogWarning(
+                    "Audio chain full at re-slot; dropping {Id}", kvp.Key);
+                continue;
+            }
+            _chain.SetSlot(slotIndex, kvp.Value);
+            _idToSlot[kvp.Key] = slotIndex;
+            slotIndex++;
+        }
     }
 
     public async ValueTask DisposeAsync()

--- a/Zeus.Server.Hosting/ChainOrderService.cs
+++ b/Zeus.Server.Hosting/ChainOrderService.cs
@@ -4,44 +4,56 @@ using Zeus.Contracts;
 namespace Zeus.Server;
 
 /// <summary>
-/// Owns the canonical Audio Suite chain order — the ordered list of
-/// installed audio plugin IDs that drives the slot assignment in
-/// <see cref="AudioPluginBridge"/> and the tile sequence in the
-/// frontend's Audio Suite window.
+/// Owns the Audio Suite chain order. Two layered concepts:
 ///
-/// <para>Source of truth flow:</para>
+/// <para><b>Canonical order</b> — the persisted, position-preserving
+/// list of every plugin ID ever seen. Includes IDs that are not
+/// currently installed so that a reinstall restores the operator's
+/// previously chosen position. Seeded on first run with
+/// <see cref="DefaultOrder"/>.</para>
+///
+/// <para><b>Runtime order</b> — the canonical order filtered to only
+/// the currently-attached plugins. This is what clients see via
+/// <see cref="CurrentOrder"/>, what
+/// <c>GET /api/plugins/chain/order</c> returns, and what the
+/// AudioChainOrder WS broadcast carries. The Audio Suite tile strip
+/// renders this directly with no further filtering.</para>
+///
+/// <para>Source-of-truth flow:</para>
 /// <list type="number">
-/// <item>On construction, load the persisted order from
+/// <item>On construction, load the persisted canonical from
 /// <see cref="ChainOrderStore"/>. If null (first run), seed with
-/// <see cref="DefaultOrder"/>.</item>
+/// <see cref="DefaultOrder"/> and DO NOT persist (only persist on
+/// the first explicit mutation).</item>
 /// <item>When a plugin attaches, <see cref="AudioPluginBridge"/>
-/// calls <see cref="OnPluginAttached"/>; if the ID isn't already
-/// in the order, append to the end. Either way return the slot
-/// index the plugin should occupy.</item>
+/// calls <see cref="OnPluginAttached"/>. The ID is added to
+/// <c>_attached</c>. If the ID isn't already in the canonical
+/// order, insert at the position dictated by
+/// <see cref="DefaultOrder"/> (preserves v2 layout for new
+/// installs); fall through to "append" if the ID isn't a known
+/// v2/v3 plugin. Returns the runtime slot index the plugin should
+/// occupy.</item>
 /// <item>When a plugin detaches, <see cref="OnPluginDetached"/>
-/// is called; the ID stays in the persisted order (so re-install
-/// restores the operator's chosen position) but is not present in
-/// the runtime chain.</item>
+/// removes the ID from <c>_attached</c>. The ID stays in the
+/// canonical order so re-install restores position.</item>
 /// <item>When the operator drags tiles in the Audio Suite window,
-/// the frontend PUTs the new order to /api/plugins/chain/order
-/// which calls <see cref="SetOrder"/>. The service validates
-/// (must be a permutation of currently-attached IDs PLUS optional
-/// known-but-uninstalled IDs), persists, and raises
-/// <see cref="OrderChanged"/> so <see cref="AudioPluginBridge"/>
-/// re-slots the chain.</item>
+/// the frontend PUTs the new RUNTIME order (installed plugins only)
+/// to <c>/api/plugins/chain/order</c>, which calls
+/// <see cref="TrySetOrder"/>. The service validates the PUT body
+/// is exactly the currently-attached set, then merges by
+/// position-replacement back into canonical: walk canonical, and
+/// every slot occupied by an attached plugin gets replaced by the
+/// next entry from the PUT body. Uninstalled IDs stay where they
+/// were in canonical. Persists, raises <see cref="OrderChanged"/>,
+/// and broadcasts the new runtime order.</item>
 /// </list>
 ///
-/// <para>Default order matches the v2 roadmap (issue #332): Gate
-/// → DownExp → Tube → EQ → Comp → Exciter → Bass → Reverb. Plugins
-/// not in this list (third-party blocks) append to the end in
-/// install order.</para>
-///
 /// <para>Thread safety: all mutating methods take <c>_sync</c>.
-/// Reads of <see cref="CurrentOrder"/> return a fresh snapshot
-/// (defensive copy) so callers can iterate without holding the
-/// lock. The bridge subscribes to <see cref="OrderChanged"/> off
-/// the lock; the event fires AFTER the lock is released so a
-/// subscriber that calls back into the service can't deadlock.</para>
+/// Reads of <see cref="CurrentOrder"/> return a fresh snapshot so
+/// callers can iterate without holding the lock.
+/// <see cref="OrderChanged"/> and the WS broadcast fire OFF the
+/// lock so a subscriber that calls back into the service can't
+/// deadlock.</para>
 /// </summary>
 public sealed class ChainOrderService
 {
@@ -51,9 +63,8 @@ public sealed class ChainOrderService
     /// mic noise → DownExp shapes dynamics below threshold → Tube
     /// adds saturation color → EQ corrective shaping → Compressor
     /// level control → Exciter harmonic excitement → Bass low-end
-    /// enhancement → Reverb spatial. Plugins later in the list that
-    /// aren't installed (Gate / DownExp / Tube ship in Phase 4) are
-    /// skipped at runtime — order honors the IDs that are present.
+    /// enhancement → Reverb spatial. Seeded into the canonical order
+    /// so new installs of these IDs land in their intended v2 slot.
     /// </summary>
     public static readonly IReadOnlyList<string> DefaultOrder = new[]
     {
@@ -71,12 +82,20 @@ public sealed class ChainOrderService
     private readonly StreamingHub _hub;
     private readonly ILogger<ChainOrderService> _log;
     private readonly object _sync = new();
-    private readonly List<string> _order;
+    // Canonical: the persisted, position-preserving order across all
+    // ever-seen plugin IDs. May contain IDs that are not currently
+    // attached — that's the whole point (preserves position on reinstall).
+    private readonly List<string> _canonical;
+    // Runtime: which IDs are currently attached. Mutated by
+    // OnPluginAttached / OnPluginDetached. The runtime order is
+    // derived as _canonical.Where(_attached.Contains).
+    private readonly HashSet<string> _attached = new(StringComparer.Ordinal);
 
     /// <summary>
-    /// Fires AFTER the order is persisted, with the new order as
-    /// the argument. Listeners (notably <see cref="AudioPluginBridge"/>)
-    /// react by re-slotting the runtime chain. Fired off-lock.
+    /// Fires AFTER the order is persisted, with the new RUNTIME
+    /// order as the argument. Listeners (notably
+    /// <see cref="AudioPluginBridge"/>) react by re-slotting the
+    /// runtime chain. Fired off-lock.
     /// </summary>
     public event Action<IReadOnlyList<string>>? OrderChanged;
 
@@ -89,167 +108,236 @@ public sealed class ChainOrderService
         var persisted = _store.GetOrder();
         if (persisted is null || persisted.Count == 0)
         {
-            // First run — seed with the default v2 order. Don't
-            // persist yet; only persist on the first explicit
-            // mutation (operator drag or plugin install/uninstall).
-            _order = DefaultOrder.ToList();
+            // First run — seed canonical with the default v2 order so
+            // the FIRST install of each v2 plugin lands in its
+            // intended slot. Don't persist yet; only persist on the
+            // first explicit mutation (plugin attach with new ID OR
+            // operator drag).
+            _canonical = DefaultOrder.ToList();
             _log.LogInformation(
-                "ChainOrderService seeded with default v2 order ({Count} entries)",
-                _order.Count);
+                "ChainOrderService seeded canonical with default v2 order ({Count} entries)",
+                _canonical.Count);
         }
         else
         {
-            _order = persisted.ToList();
+            _canonical = persisted.ToList();
             _log.LogInformation(
-                "ChainOrderService loaded {Count} persisted entries", _order.Count);
+                "ChainOrderService loaded {Count} canonical entries", _canonical.Count);
         }
     }
 
     /// <summary>
-    /// Snapshot of the canonical order. Returns a fresh copy so
-    /// the caller can iterate / index without holding _sync.
+    /// Snapshot of the RUNTIME order — the canonical order filtered
+    /// to only the currently-attached plugins. Returns a fresh copy
+    /// so the caller can iterate without holding _sync. This is what
+    /// the REST GET / WS broadcast carry — clients never see the
+    /// uninstalled entries that may be sitting in canonical.
     /// </summary>
     public IReadOnlyList<string> CurrentOrder
     {
-        get { lock (_sync) return _order.ToList(); }
+        get { lock (_sync) return RuntimeOrderUnderLock(); }
+    }
+
+    /// <summary>
+    /// Test helper — snapshot of the canonical (persisted) order
+    /// including any uninstalled entries. Tests use this to verify
+    /// that position-preserve-on-detach behaviour works.
+    /// </summary>
+    internal IReadOnlyList<string> CanonicalOrderForTest
+    {
+        get { lock (_sync) return _canonical.ToList(); }
+    }
+
+    private List<string> RuntimeOrderUnderLock()
+    {
+        var result = new List<string>(_attached.Count);
+        for (int i = 0; i < _canonical.Count; i++)
+        {
+            if (_attached.Contains(_canonical[i])) result.Add(_canonical[i]);
+        }
+        return result;
     }
 
     /// <summary>
     /// Called by <see cref="AudioPluginBridge"/> when a plugin
-    /// activates. Appends the ID to the end of the order if it's
-    /// not already present (preserving any persisted position
-    /// from a previous install). Returns the slot index the
-    /// plugin should occupy among the currently-installed subset
-    /// (computed off the order). The bridge uses the returned
-    /// index as <c>_chain.SetSlot(index, plugin)</c>.
+    /// activates. Marks the ID as attached, inserts into the
+    /// canonical order at the v2-default position if it's a new
+    /// (never-seen) ID, persists if anything changed, broadcasts
+    /// the new runtime order. Returns the runtime slot index the
+    /// plugin should occupy — the bridge uses it as
+    /// <c>_chain.SetSlot(index, plugin)</c>.
     /// </summary>
-    public int OnPluginAttached(string pluginId, IReadOnlyCollection<string> currentlyAttachedIds)
+    /// <param name="pluginId">Plugin ID being attached.</param>
+    /// <param name="_">Currently-attached IDs (legacy parameter, no
+    /// longer used — the service now tracks attachment internally
+    /// via <c>_attached</c>). Kept on the signature so the bridge
+    /// call site doesn't need to change.</param>
+    public int OnPluginAttached(string pluginId, IReadOnlyCollection<string> _)
     {
-        bool changed = false;
-        IReadOnlyList<string>? snapshotForEvent = null;
+        bool changed;
+        List<string>? snapshot = null;
+        int slotIndex;
         lock (_sync)
         {
-            if (!_order.Contains(pluginId))
+            changed = _attached.Add(pluginId);
+            if (!_canonical.Contains(pluginId))
             {
-                _order.Add(pluginId);
-                changed = true;
+                InsertByDefaultOrderUnderLock(pluginId);
+                _store.SetOrder(_canonical);
+                changed = true; // canonical mutated even if _attached.Add returned false (shouldn't happen but defensive)
             }
             if (changed)
             {
-                _store.SetOrder(_order);
-                snapshotForEvent = _order.ToList();
+                snapshot = RuntimeOrderUnderLock();
             }
+            slotIndex = SlotIndexUnderLock(pluginId);
         }
-        if (changed)
-        {
-            BroadcastOrder(snapshotForEvent!);
-            // We don't raise OrderChanged here — the bridge is
-            // the caller, it's already in the middle of slotting,
-            // and raising the event would re-enter the bridge
-            // with a stale snapshot. The bridge uses the slot
-            // index we return directly.
-        }
-        return ComputeSlotForAttached(pluginId, currentlyAttachedIds);
+        if (snapshot is not null) BroadcastOrder(snapshot);
+        return slotIndex;
     }
 
     /// <summary>
     /// Called by <see cref="AudioPluginBridge"/> when a plugin
-    /// deactivates. The ID stays in the persisted order — if the
-    /// operator reinstalls it, the position is restored. We don't
-    /// re-slot the rest of the chain on detach; the bridge just
-    /// clears its slot and other plugins keep their indices.
+    /// deactivates. Removes the ID from <c>_attached</c> so it stops
+    /// appearing in the runtime order, but leaves it in the
+    /// canonical order so the operator's chosen position is
+    /// restored on re-install. Broadcasts the new runtime order so
+    /// clients refresh their tile strip.
     /// </summary>
     public void OnPluginDetached(string pluginId)
     {
-        // No state change on detach — we keep the ID so reinstall
-        // restores position. This is a hook for future telemetry
-        // / logging; today it's a no-op aside from the log line.
-        _log.LogDebug("ChainOrderService noted detach of {Id}", pluginId);
+        List<string>? snapshot = null;
+        lock (_sync)
+        {
+            if (_attached.Remove(pluginId))
+                snapshot = RuntimeOrderUnderLock();
+        }
+        if (snapshot is not null) BroadcastOrder(snapshot);
     }
 
     /// <summary>
-    /// REST endpoint entry point — operator drag-dropped a tile
-    /// and the frontend sent a new ordering. Validates the new
-    /// order is a permutation of the current persisted order
-    /// (no IDs added, no IDs dropped; just resequenced), persists,
-    /// raises <see cref="OrderChanged"/>, and broadcasts the new
-    /// order to all connected clients.
+    /// REST endpoint entry point — operator drag-dropped a tile and
+    /// the frontend sent a new RUNTIME ordering (installed plugins
+    /// only). Validates the PUT body is exactly the currently-
+    /// attached set, then merges by position-replacement back into
+    /// canonical so uninstalled entries keep their slot. Persists,
+    /// raises <see cref="OrderChanged"/>, broadcasts the new
+    /// runtime order.
     ///
     /// <para>Returns true on success, false with <paramref name="error"/>
     /// populated on validation failure.</para>
     /// </summary>
-    public bool TrySetOrder(IReadOnlyList<string> newOrder, out string? error)
+    public bool TrySetOrder(IReadOnlyList<string> newRuntimeOrder, out string? error)
     {
-        IReadOnlyList<string>? snapshotForEvent = null;
+        List<string>? snapshot = null;
         lock (_sync)
         {
-            var current = new HashSet<string>(_order, StringComparer.Ordinal);
-            var proposed = new HashSet<string>(newOrder, StringComparer.Ordinal);
-            if (!current.SetEquals(proposed))
+            if (newRuntimeOrder.Count != _attached.Count)
             {
                 error =
-                    $"chain order PUT must be a permutation of the current order ({_order.Count} entries); " +
-                    $"got {newOrder.Count} entries with {proposed.Count - current.Count} difference. " +
+                    $"chain order PUT must contain exactly the currently-attached plugins " +
+                    $"({_attached.Count} entries); got {newRuntimeOrder.Count}. " +
                     $"Install / uninstall plugins to change set membership.";
                 return false;
             }
-            _order.Clear();
-            _order.AddRange(newOrder);
-            _store.SetOrder(_order);
-            snapshotForEvent = _order.ToList();
+            var proposed = new HashSet<string>(newRuntimeOrder, StringComparer.Ordinal);
+            if (!_attached.SetEquals(proposed))
+            {
+                error =
+                    "chain order PUT must be exactly the currently-attached plugins (same set, just reordered); " +
+                    "got a different set of IDs.";
+                return false;
+            }
+            // Merge by position-replacement: walk canonical; each slot
+            // occupied by an attached ID gets replaced with the next
+            // entry from the PUT body. Uninstalled IDs stay put.
+            int j = 0;
+            for (int i = 0; i < _canonical.Count; i++)
+            {
+                if (_attached.Contains(_canonical[i]))
+                    _canonical[i] = newRuntimeOrder[j++];
+            }
+            _store.SetOrder(_canonical);
+            snapshot = RuntimeOrderUnderLock();
         }
         // Raise + broadcast OFF the lock so subscribers (including
         // ones that call back into ChainOrderService) can't deadlock.
-        OrderChanged?.Invoke(snapshotForEvent!);
-        BroadcastOrder(snapshotForEvent!);
+        OrderChanged?.Invoke(snapshot!);
+        BroadcastOrder(snapshot!);
         error = null;
         return true;
     }
 
     /// <summary>
-    /// Compute the canonical slot index for a plugin given the
-    /// current set of attached plugin IDs. The slot index is the
-    /// plugin's position in the persisted order among the subset
-    /// that is currently attached — so if the persisted order is
-    /// [Gate, DownExp, Tube, EQ, Comp] but only [EQ, Comp] are
-    /// installed, EQ gets slot 0 and Comp gets slot 1 (Gate /
-    /// DownExp / Tube are skipped as they're not present).
+    /// Returns the plugin's runtime slot index — its position in
+    /// canonical among the currently-attached subset. Caller must
+    /// hold <c>_sync</c>.
     /// </summary>
-    private int ComputeSlotForAttached(string pluginId, IReadOnlyCollection<string> currentlyAttachedIds)
+    private int SlotIndexUnderLock(string pluginId)
     {
-        IReadOnlyList<string> snapshot;
-        lock (_sync) snapshot = _order.ToList();
-
-        var attachedSet = currentlyAttachedIds is HashSet<string> hs
-            ? hs
-            : new HashSet<string>(currentlyAttachedIds, StringComparer.Ordinal);
-
-        int slotIndex = 0;
-        for (int i = 0; i < snapshot.Count; i++)
+        int idx = 0;
+        for (int i = 0; i < _canonical.Count; i++)
         {
-            var id = snapshot[i];
-            if (string.Equals(id, pluginId, StringComparison.Ordinal))
-                return slotIndex;
-            if (attachedSet.Contains(id)) slotIndex++;
+            var id = _canonical[i];
+            if (string.Equals(id, pluginId, StringComparison.Ordinal)) return idx;
+            if (_attached.Contains(id)) idx++;
         }
-        // Defensive — pluginId wasn't in _order. OnPluginAttached
-        // should have already appended it before this is reached;
-        // fall back to the end of the chain.
-        return slotIndex;
+        // Defensive — pluginId not in canonical. OnPluginAttached
+        // always inserts before reaching here; fall back to end.
+        return idx;
     }
 
-    private void BroadcastOrder(IReadOnlyList<string> order)
+    /// <summary>
+    /// Insert a new plugin ID into canonical at the position
+    /// dictated by <see cref="DefaultOrder"/>. If the ID isn't in
+    /// the default list (third-party plugin), append to the end so
+    /// it lands at the bottom of the chain. Caller must hold
+    /// <c>_sync</c>.
+    /// </summary>
+    private void InsertByDefaultOrderUnderLock(string pluginId)
+    {
+        int defaultIdx = IndexInDefaultOrder(pluginId);
+        if (defaultIdx < 0)
+        {
+            _canonical.Add(pluginId);
+            return;
+        }
+        // Find the first existing canonical entry with a HIGHER
+        // default index — insert before it.
+        for (int i = 0; i < _canonical.Count; i++)
+        {
+            int existingDefaultIdx = IndexInDefaultOrder(_canonical[i]);
+            if (existingDefaultIdx < 0 || existingDefaultIdx > defaultIdx)
+            {
+                _canonical.Insert(i, pluginId);
+                return;
+            }
+        }
+        _canonical.Add(pluginId);
+    }
+
+    private static int IndexInDefaultOrder(string pluginId)
+    {
+        for (int i = 0; i < DefaultOrder.Count; i++)
+        {
+            if (string.Equals(DefaultOrder[i], pluginId, StringComparison.Ordinal))
+                return i;
+        }
+        return -1;
+    }
+
+    private void BroadcastOrder(IReadOnlyList<string> runtimeOrder)
     {
         try
         {
-            _hub.Broadcast(new AudioChainOrderFrame(order));
+            _hub.Broadcast(new AudioChainOrderFrame(runtimeOrder));
         }
         catch (Exception ex)
         {
-            // Broadcast failure is non-fatal — the persisted order
-            // is the source of truth; clients reconnect and pull
-            // it via GET /api/plugins/chain/order if they missed
-            // the broadcast.
+            // Broadcast failure is non-fatal — the persisted canonical
+            // is the source of truth; clients reconnect and pull the
+            // runtime order via GET /api/plugins/chain/order if they
+            // missed the broadcast.
             _log.LogWarning(ex, "ChainOrderService broadcast threw");
         }
     }

--- a/Zeus.Server.Hosting/ChainOrderService.cs
+++ b/Zeus.Server.Hosting/ChainOrderService.cs
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Owns the canonical Audio Suite chain order — the ordered list of
+/// installed audio plugin IDs that drives the slot assignment in
+/// <see cref="AudioPluginBridge"/> and the tile sequence in the
+/// frontend's Audio Suite window.
+///
+/// <para>Source of truth flow:</para>
+/// <list type="number">
+/// <item>On construction, load the persisted order from
+/// <see cref="ChainOrderStore"/>. If null (first run), seed with
+/// <see cref="DefaultOrder"/>.</item>
+/// <item>When a plugin attaches, <see cref="AudioPluginBridge"/>
+/// calls <see cref="OnPluginAttached"/>; if the ID isn't already
+/// in the order, append to the end. Either way return the slot
+/// index the plugin should occupy.</item>
+/// <item>When a plugin detaches, <see cref="OnPluginDetached"/>
+/// is called; the ID stays in the persisted order (so re-install
+/// restores the operator's chosen position) but is not present in
+/// the runtime chain.</item>
+/// <item>When the operator drags tiles in the Audio Suite window,
+/// the frontend PUTs the new order to /api/plugins/chain/order
+/// which calls <see cref="SetOrder"/>. The service validates
+/// (must be a permutation of currently-attached IDs PLUS optional
+/// known-but-uninstalled IDs), persists, and raises
+/// <see cref="OrderChanged"/> so <see cref="AudioPluginBridge"/>
+/// re-slots the chain.</item>
+/// </list>
+///
+/// <para>Default order matches the v2 roadmap (issue #332): Gate
+/// → DownExp → Tube → EQ → Comp → Exciter → Bass → Reverb. Plugins
+/// not in this list (third-party blocks) append to the end in
+/// install order.</para>
+///
+/// <para>Thread safety: all mutating methods take <c>_sync</c>.
+/// Reads of <see cref="CurrentOrder"/> return a fresh snapshot
+/// (defensive copy) so callers can iterate without holding the
+/// lock. The bridge subscribes to <see cref="OrderChanged"/> off
+/// the lock; the event fires AFTER the lock is released so a
+/// subscriber that calls back into the service can't deadlock.</para>
+/// </summary>
+public sealed class ChainOrderService
+{
+    /// <summary>
+    /// Default Audio Suite chain order (v2 roadmap, KB2UKA confirmed
+    /// 2026-05-18). Order is signal flow top → bottom: Gate cleans
+    /// mic noise → DownExp shapes dynamics below threshold → Tube
+    /// adds saturation color → EQ corrective shaping → Compressor
+    /// level control → Exciter harmonic excitement → Bass low-end
+    /// enhancement → Reverb spatial. Plugins later in the list that
+    /// aren't installed (Gate / DownExp / Tube ship in Phase 4) are
+    /// skipped at runtime — order honors the IDs that are present.
+    /// </summary>
+    public static readonly IReadOnlyList<string> DefaultOrder = new[]
+    {
+        "com.openhpsdr.zeus.samples.gate",
+        "com.openhpsdr.zeus.samples.downexp",
+        "com.openhpsdr.zeus.samples.tube",
+        "com.openhpsdr.zeus.samples.eq",
+        "com.openhpsdr.zeus.samples.compressor",
+        "com.openhpsdr.zeus.samples.exciter",
+        "com.openhpsdr.zeus.samples.bass",
+        "com.openhpsdr.zeus.samples.reverb",
+    };
+
+    private readonly ChainOrderStore _store;
+    private readonly StreamingHub _hub;
+    private readonly ILogger<ChainOrderService> _log;
+    private readonly object _sync = new();
+    private readonly List<string> _order;
+
+    /// <summary>
+    /// Fires AFTER the order is persisted, with the new order as
+    /// the argument. Listeners (notably <see cref="AudioPluginBridge"/>)
+    /// react by re-slotting the runtime chain. Fired off-lock.
+    /// </summary>
+    public event Action<IReadOnlyList<string>>? OrderChanged;
+
+    public ChainOrderService(ChainOrderStore store, StreamingHub hub, ILogger<ChainOrderService> log)
+    {
+        _store = store;
+        _hub = hub;
+        _log = log;
+
+        var persisted = _store.GetOrder();
+        if (persisted is null || persisted.Count == 0)
+        {
+            // First run — seed with the default v2 order. Don't
+            // persist yet; only persist on the first explicit
+            // mutation (operator drag or plugin install/uninstall).
+            _order = DefaultOrder.ToList();
+            _log.LogInformation(
+                "ChainOrderService seeded with default v2 order ({Count} entries)",
+                _order.Count);
+        }
+        else
+        {
+            _order = persisted.ToList();
+            _log.LogInformation(
+                "ChainOrderService loaded {Count} persisted entries", _order.Count);
+        }
+    }
+
+    /// <summary>
+    /// Snapshot of the canonical order. Returns a fresh copy so
+    /// the caller can iterate / index without holding _sync.
+    /// </summary>
+    public IReadOnlyList<string> CurrentOrder
+    {
+        get { lock (_sync) return _order.ToList(); }
+    }
+
+    /// <summary>
+    /// Called by <see cref="AudioPluginBridge"/> when a plugin
+    /// activates. Appends the ID to the end of the order if it's
+    /// not already present (preserving any persisted position
+    /// from a previous install). Returns the slot index the
+    /// plugin should occupy among the currently-installed subset
+    /// (computed off the order). The bridge uses the returned
+    /// index as <c>_chain.SetSlot(index, plugin)</c>.
+    /// </summary>
+    public int OnPluginAttached(string pluginId, IReadOnlyCollection<string> currentlyAttachedIds)
+    {
+        bool changed = false;
+        IReadOnlyList<string>? snapshotForEvent = null;
+        lock (_sync)
+        {
+            if (!_order.Contains(pluginId))
+            {
+                _order.Add(pluginId);
+                changed = true;
+            }
+            if (changed)
+            {
+                _store.SetOrder(_order);
+                snapshotForEvent = _order.ToList();
+            }
+        }
+        if (changed)
+        {
+            BroadcastOrder(snapshotForEvent!);
+            // We don't raise OrderChanged here — the bridge is
+            // the caller, it's already in the middle of slotting,
+            // and raising the event would re-enter the bridge
+            // with a stale snapshot. The bridge uses the slot
+            // index we return directly.
+        }
+        return ComputeSlotForAttached(pluginId, currentlyAttachedIds);
+    }
+
+    /// <summary>
+    /// Called by <see cref="AudioPluginBridge"/> when a plugin
+    /// deactivates. The ID stays in the persisted order — if the
+    /// operator reinstalls it, the position is restored. We don't
+    /// re-slot the rest of the chain on detach; the bridge just
+    /// clears its slot and other plugins keep their indices.
+    /// </summary>
+    public void OnPluginDetached(string pluginId)
+    {
+        // No state change on detach — we keep the ID so reinstall
+        // restores position. This is a hook for future telemetry
+        // / logging; today it's a no-op aside from the log line.
+        _log.LogDebug("ChainOrderService noted detach of {Id}", pluginId);
+    }
+
+    /// <summary>
+    /// REST endpoint entry point — operator drag-dropped a tile
+    /// and the frontend sent a new ordering. Validates the new
+    /// order is a permutation of the current persisted order
+    /// (no IDs added, no IDs dropped; just resequenced), persists,
+    /// raises <see cref="OrderChanged"/>, and broadcasts the new
+    /// order to all connected clients.
+    ///
+    /// <para>Returns true on success, false with <paramref name="error"/>
+    /// populated on validation failure.</para>
+    /// </summary>
+    public bool TrySetOrder(IReadOnlyList<string> newOrder, out string? error)
+    {
+        IReadOnlyList<string>? snapshotForEvent = null;
+        lock (_sync)
+        {
+            var current = new HashSet<string>(_order, StringComparer.Ordinal);
+            var proposed = new HashSet<string>(newOrder, StringComparer.Ordinal);
+            if (!current.SetEquals(proposed))
+            {
+                error =
+                    $"chain order PUT must be a permutation of the current order ({_order.Count} entries); " +
+                    $"got {newOrder.Count} entries with {proposed.Count - current.Count} difference. " +
+                    $"Install / uninstall plugins to change set membership.";
+                return false;
+            }
+            _order.Clear();
+            _order.AddRange(newOrder);
+            _store.SetOrder(_order);
+            snapshotForEvent = _order.ToList();
+        }
+        // Raise + broadcast OFF the lock so subscribers (including
+        // ones that call back into ChainOrderService) can't deadlock.
+        OrderChanged?.Invoke(snapshotForEvent!);
+        BroadcastOrder(snapshotForEvent!);
+        error = null;
+        return true;
+    }
+
+    /// <summary>
+    /// Compute the canonical slot index for a plugin given the
+    /// current set of attached plugin IDs. The slot index is the
+    /// plugin's position in the persisted order among the subset
+    /// that is currently attached — so if the persisted order is
+    /// [Gate, DownExp, Tube, EQ, Comp] but only [EQ, Comp] are
+    /// installed, EQ gets slot 0 and Comp gets slot 1 (Gate /
+    /// DownExp / Tube are skipped as they're not present).
+    /// </summary>
+    private int ComputeSlotForAttached(string pluginId, IReadOnlyCollection<string> currentlyAttachedIds)
+    {
+        IReadOnlyList<string> snapshot;
+        lock (_sync) snapshot = _order.ToList();
+
+        var attachedSet = currentlyAttachedIds is HashSet<string> hs
+            ? hs
+            : new HashSet<string>(currentlyAttachedIds, StringComparer.Ordinal);
+
+        int slotIndex = 0;
+        for (int i = 0; i < snapshot.Count; i++)
+        {
+            var id = snapshot[i];
+            if (string.Equals(id, pluginId, StringComparison.Ordinal))
+                return slotIndex;
+            if (attachedSet.Contains(id)) slotIndex++;
+        }
+        // Defensive — pluginId wasn't in _order. OnPluginAttached
+        // should have already appended it before this is reached;
+        // fall back to the end of the chain.
+        return slotIndex;
+    }
+
+    private void BroadcastOrder(IReadOnlyList<string> order)
+    {
+        try
+        {
+            _hub.Broadcast(new AudioChainOrderFrame(order));
+        }
+        catch (Exception ex)
+        {
+            // Broadcast failure is non-fatal — the persisted order
+            // is the source of truth; clients reconnect and pull
+            // it via GET /api/plugins/chain/order if they missed
+            // the broadcast.
+            _log.LogWarning(ex, "ChainOrderService broadcast threw");
+        }
+    }
+}

--- a/Zeus.Server.Hosting/ChainOrderStore.cs
+++ b/Zeus.Server.Hosting/ChainOrderStore.cs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using LiteDB;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Persists the operator's preferred Audio Suite chain order across
+/// server restarts. Single-row collection ("audio_chain_order")
+/// sharing zeus-prefs.db with the other preference stores. Mirrors
+/// the PsSettingsStore / RadioStateStore pattern: a typed POCO,
+/// LiteDB upsert, no schema migrations because LiteDB is happy to
+/// deserialise rows written by older builds with missing fields.
+///
+/// <para>Why a dedicated store rather than a field on
+/// <see cref="RadioStateStore"/>: chain order is plugin-runtime state,
+/// not RadioService state. The RadioStateStore comment explicitly
+/// scopes itself to "RadioService state" with sister stores for
+/// DSP / PA / PS / filter presets / band memory. Audio chain order
+/// is its own concern — a flat list of plugin IDs — so it gets its
+/// own store and stays out of the way of the radio state churn.</para>
+/// </summary>
+public sealed class ChainOrderStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<ChainOrderEntry> _state;
+    private readonly ILogger<ChainOrderStore> _log;
+    private readonly object _sync = new();
+
+    public ChainOrderStore(ILogger<ChainOrderStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _state = _db.GetCollection<ChainOrderEntry>("audio_chain_order");
+
+        _log.LogInformation("ChainOrderStore initialized at {Path}", dbPath);
+    }
+
+    /// <summary>
+    /// Returns the persisted order, or null on first run (no row yet).
+    /// Null is the "use default seed" signal — the caller (ChainOrderService)
+    /// substitutes the v2 default order in that case.
+    /// </summary>
+    public IReadOnlyList<string>? GetOrder()
+    {
+        lock (_sync)
+        {
+            var entry = _state.FindAll().FirstOrDefault();
+            return entry?.PluginIds;
+        }
+    }
+
+    public void SetOrder(IReadOnlyList<string> pluginIds)
+    {
+        lock (_sync)
+        {
+            var existing = _state.FindAll().FirstOrDefault();
+            var nowUtc = DateTime.UtcNow;
+            if (existing is null)
+            {
+                _state.Insert(new ChainOrderEntry
+                {
+                    PluginIds = pluginIds.ToList(),
+                    UpdatedUtc = nowUtc,
+                });
+            }
+            else
+            {
+                existing.PluginIds = pluginIds.ToList();
+                existing.UpdatedUtc = nowUtc;
+                _state.Update(existing);
+            }
+        }
+    }
+
+    public void Dispose() => _db.Dispose();
+}
+
+public sealed class ChainOrderEntry
+{
+    public int Id { get; set; }
+    public List<string> PluginIds { get; set; } = new();
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/StreamingHub.cs
+++ b/Zeus.Server.Hosting/StreamingHub.cs
@@ -388,6 +388,40 @@ public sealed class StreamingHub
         }
     }
 
+    public void Broadcast(in AudioChainOrderFrame frame)
+    {
+        if (_clients.IsEmpty) return;
+
+        // Variable-length CSV payload. Compute exact size before
+        // allocating so we don't over-rent on a typical 5-8 plugin
+        // chain (~410 bytes). The frame's Serialize method enforces
+        // the AudioChainOrderFrame.MaxByteLength cap; here we trust
+        // it and just size the buffer to whatever the cap permits.
+        int csvLen = 0;
+        for (int i = 0; i < frame.PluginIds.Count; i++)
+        {
+            if (i > 0) csvLen += 1; // comma
+            csvLen += System.Text.Encoding.UTF8.GetByteCount(frame.PluginIds[i]);
+        }
+        int total = 1 + csvLen;
+        if (total > AudioChainOrderFrame.MaxByteLength)
+        {
+            // Defence in depth — Serialize would throw; drop the
+            // broadcast instead so a bad plugin ID doesn't blow up
+            // the hub. The order is still persisted; clients fall
+            // back to GET /api/plugins/chain/order.
+            System.Threading.Interlocked.Increment(ref _dropsOther);
+            return;
+        }
+        var payload = new byte[total];
+        var writer = new FixedBufferWriter(payload, total);
+        frame.Serialize(writer);
+        foreach (var client in _clients.Values)
+        {
+            if (!client.TryEnqueue(payload)) System.Threading.Interlocked.Increment(ref _dropsOther);
+        }
+    }
+
     /// <summary>
     /// Broadcasts a BandPlanChanged (0x1B) notification. Payload: type byte +
     /// UTF-8 region ID. Clients refetch /api/bands/current on receipt.

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -85,6 +85,28 @@ public static class ZeusEndpoints
             return Results.Ok(new { supported = true, enabled = audition.IsEnabled });
         });
 
+        // Audio plugin chain order — operator's preferred sequence for
+        // the plugins in the Audio Suite window. GET returns the
+        // canonical ordered list of plugin IDs; PUT accepts a new
+        // ordering and validates it's a permutation of the current
+        // set (no IDs added, no IDs dropped — install / uninstall
+        // plugins to change membership). On PUT, the bridge re-slots
+        // the runtime chain via ChainOrderService.OrderChanged and
+        // broadcasts AudioChainOrderFrame (0x1E) so other connected
+        // clients update their tile strip without polling.
+        app.MapGet("/api/plugins/chain/order", (ChainOrderService chainOrder) =>
+        {
+            return Results.Ok(new { pluginIds = chainOrder.CurrentOrder });
+        });
+        app.MapPut("/api/plugins/chain/order", (ChainOrderSetRequest body, ChainOrderService chainOrder) =>
+        {
+            if (body?.PluginIds is null)
+                return Results.BadRequest(new { error = "pluginIds is required" });
+            if (chainOrder.TrySetOrder(body.PluginIds, out var err))
+                return Results.Ok(new { pluginIds = chainOrder.CurrentOrder });
+            return Results.BadRequest(new { error = err });
+        });
+
         app.MapGet("/api/state", (RadioService r) => r.Snapshot());
 
         // TX diagnostic — exposes the producer/consumer counts for the mic-to-IQ ring
@@ -1299,3 +1321,4 @@ public static class ZeusEndpoints
 
 internal sealed record NativeMuteRequest(bool Muted);
 internal sealed record AuditionSetRequest(bool Enabled);
+internal sealed record ChainOrderSetRequest(List<string> PluginIds);

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -296,6 +296,17 @@ public static class ZeusHost
         // mounted below via PluginEndpoints.MapAll under /api/plugins/...
         builder.Services.AddZeusPlugins(prefsDbPathProvider: PrefsDbPath.Get);
 
+        // ChainOrderService — owns the canonical Audio Suite plugin
+        // chain order (drag-droppable tile sequence in the Audio Suite
+        // window). Persists to zeus-prefs.db via ChainOrderStore so the
+        // operator's order survives backend restarts. Broadcasts
+        // AudioChainOrderFrame (0x1E) on every change so other
+        // connected clients (LAN-share phone, second browser) update
+        // their tile strip without polling. AudioPluginBridge subscribes
+        // to OrderChanged and re-slots the runtime chain.
+        builder.Services.AddSingleton<ChainOrderStore>();
+        builder.Services.AddSingleton<ChainOrderService>();
+
         // AudioPluginBridge wires PluginManager's audio-bearing plugins
         // into WdspDspEngine's realtime TX seam. No-op when no plugins
         // declare an audio component; subscribes to engine swaps so it

--- a/tests/Zeus.Contracts.Tests/AudioChainOrderFrameTests.cs
+++ b/tests/Zeus.Contracts.Tests/AudioChainOrderFrameTests.cs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using System.Buffers;
+using Zeus.Contracts;
+
+namespace Zeus.Contracts.Tests;
+
+public class AudioChainOrderFrameTests
+{
+    [Fact]
+    public void RoundTrip_PreservesOrderAndIds()
+    {
+        var input = new AudioChainOrderFrame(new[]
+        {
+            "com.openhpsdr.zeus.samples.gate",
+            "com.openhpsdr.zeus.samples.eq",
+            "com.openhpsdr.zeus.samples.compressor",
+        });
+
+        var writer = new ArrayBufferWriter<byte>(AudioChainOrderFrame.MaxByteLength);
+        input.Serialize(writer);
+
+        var decoded = AudioChainOrderFrame.Deserialize(writer.WrittenSpan);
+        Assert.Equal(input.PluginIds.Count, decoded.PluginIds.Count);
+        for (int i = 0; i < input.PluginIds.Count; i++)
+            Assert.Equal(input.PluginIds[i], decoded.PluginIds[i]);
+    }
+
+    [Fact]
+    public void Empty_Chain_RoundTrips_Cleanly()
+    {
+        // "No plugins installed" — an empty chain order is valid
+        // and must decode back to an empty list, not a list with
+        // one empty string.
+        var input = new AudioChainOrderFrame(Array.Empty<string>());
+
+        var writer = new ArrayBufferWriter<byte>(AudioChainOrderFrame.MaxByteLength);
+        input.Serialize(writer);
+
+        var decoded = AudioChainOrderFrame.Deserialize(writer.WrittenSpan);
+        Assert.Empty(decoded.PluginIds);
+    }
+
+    [Fact]
+    public void Serialize_StartsWithMsgTypeByte()
+    {
+        var frame = new AudioChainOrderFrame(new[] { "x" });
+        var writer = new ArrayBufferWriter<byte>(8);
+        frame.Serialize(writer);
+
+        // The frame multiplexer in ws-client.ts peeks byte 0 to
+        // dispatch — verify our serialiser puts MsgType there.
+        Assert.Equal((byte)MsgType.AudioChainOrder, writer.WrittenSpan[0]);
+    }
+
+    [Fact]
+    public void Deserialize_WrongTypeByte_Throws()
+    {
+        // Heap array (not stackalloc) — can't capture a ref struct
+        // (Span<byte>) inside a lambda passed to Assert.Throws.
+        var bad = new byte[] { 0xFF, (byte)'a', (byte)'b' };
+        Assert.Throws<InvalidDataException>(() => AudioChainOrderFrame.Deserialize(bad));
+    }
+
+    [Fact]
+    public void Serialize_OverMaxLength_Throws_NotSilent()
+    {
+        // Concoct an absurdly long ID to overflow the cap.
+        var longId = new string('x', AudioChainOrderFrame.MaxByteLength);
+        var frame = new AudioChainOrderFrame(new[] { longId });
+        var writer = new ArrayBufferWriter<byte>(AudioChainOrderFrame.MaxByteLength * 2);
+
+        Assert.Throws<InvalidOperationException>(() => frame.Serialize(writer));
+    }
+}

--- a/tests/Zeus.Server.Tests/ChainOrderServiceTests.cs
+++ b/tests/Zeus.Server.Tests/ChainOrderServiceTests.cs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="ChainOrderService"/> — the source of
+/// truth for the Audio Suite chain order. Covers default seeding,
+/// persistence round-trip, attach/detach order maintenance, and the
+/// PUT-permutation validation that protects against the frontend
+/// trying to "install" plugins via the order endpoint.
+/// </summary>
+public class ChainOrderServiceTests
+{
+    private static (ChainOrderService svc, ChainOrderStore store, StreamingHub hub, string dbPath) MakeService()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"chain-order-test-{Guid.NewGuid():N}.db");
+        var store = new ChainOrderStore(NullLogger<ChainOrderStore>.Instance, dbPath);
+        // Real StreamingHub with no clients — Broadcast(...) short-
+        // circuits on _clients.IsEmpty so the test doesn't exercise
+        // the wire path. Broadcast invocation correctness is covered
+        // by AudioChainOrderFrame's own round-trip tests + manual
+        // integration testing.
+        var hub = new StreamingHub(NullLogger<StreamingHub>.Instance);
+        var svc = new ChainOrderService(store, hub, NullLogger<ChainOrderService>.Instance);
+        return (svc, store, hub, dbPath);
+    }
+
+    [Fact]
+    public void First_Run_Seeds_With_Default_Order()
+    {
+        var (svc, store, _, dbPath) = MakeService();
+        try
+        {
+            var order = svc.CurrentOrder;
+            Assert.Equal(ChainOrderService.DefaultOrder, order);
+            // First run does NOT persist — only explicit mutations
+            // persist. A fresh process should see null from the store.
+            Assert.Null(store.GetOrder());
+        }
+        finally { store.Dispose(); File.Delete(dbPath); }
+    }
+
+    [Fact]
+    public void OnPluginAttached_NewId_Appends_And_Persists()
+    {
+        var (svc, store, _, dbPath) = MakeService();
+        try
+        {
+            var attached = new HashSet<string>(StringComparer.Ordinal);
+
+            // Attach an ID not in the default order — should append.
+            var customId = "com.example.thirdparty.plugin";
+            attached.Add(customId);
+            svc.OnPluginAttached(customId, attached);
+
+            var order = svc.CurrentOrder;
+            Assert.Equal(customId, order[^1]);
+            // First mutation persists; subsequent boots restore.
+            var persisted = store.GetOrder();
+            Assert.NotNull(persisted);
+            Assert.Equal(customId, persisted![^1]);
+        }
+        finally { store.Dispose(); File.Delete(dbPath); }
+    }
+
+    [Fact]
+    public void OnPluginAttached_KnownId_Does_Not_Duplicate()
+    {
+        var (svc, store, _, dbPath) = MakeService();
+        try
+        {
+            var attached = new HashSet<string>(StringComparer.Ordinal);
+            var knownId = ChainOrderService.DefaultOrder[3]; // EQ
+
+            attached.Add(knownId);
+            svc.OnPluginAttached(knownId, attached);
+            svc.OnPluginAttached(knownId, attached);
+
+            var order = svc.CurrentOrder;
+            Assert.Equal(ChainOrderService.DefaultOrder.Count,
+                order.Count(id => id == knownId == false ? false : true) +
+                order.Count(id => id != knownId));
+            // Sharper assertion: EQ appears exactly once.
+            Assert.Equal(1, order.Count(id => id == knownId));
+        }
+        finally { store.Dispose(); File.Delete(dbPath); }
+    }
+
+    [Fact]
+    public void OnPluginAttached_Returns_Slot_Index_Among_Attached_Subset()
+    {
+        var (svc, store, _, dbPath) = MakeService();
+        try
+        {
+            var attached = new HashSet<string>(StringComparer.Ordinal);
+            // Default order: gate(0) downexp(1) tube(2) eq(3) comp(4) exciter(5) bass(6) reverb(7)
+            // Attach only EQ and Compressor — slots should be 0 and 1
+            // (their position within the attached subset), not 3 and 4
+            // (their position in the full canonical order).
+            var eqId = ChainOrderService.DefaultOrder[3];
+            var compId = ChainOrderService.DefaultOrder[4];
+
+            attached.Add(eqId);
+            var eqSlot = svc.OnPluginAttached(eqId, attached);
+
+            attached.Add(compId);
+            var compSlot = svc.OnPluginAttached(compId, attached);
+
+            Assert.Equal(0, eqSlot);
+            Assert.Equal(1, compSlot);
+        }
+        finally { store.Dispose(); File.Delete(dbPath); }
+    }
+
+    [Fact]
+    public void TrySetOrder_Permutation_Succeeds_And_Fires_OrderChanged()
+    {
+        var (svc, store, _, dbPath) = MakeService();
+        try
+        {
+            int orderChangedCount = 0;
+            IReadOnlyList<string>? lastOrder = null;
+            svc.OrderChanged += order => { orderChangedCount++; lastOrder = order; };
+
+            var current = svc.CurrentOrder.ToList();
+            current.Reverse(); // still a permutation
+
+            var ok = svc.TrySetOrder(current, out var err);
+
+            Assert.True(ok);
+            Assert.Null(err);
+            Assert.Equal(current, svc.CurrentOrder);
+            Assert.Equal(1, orderChangedCount);
+            Assert.Equal(current, lastOrder);
+            Assert.Equal(current, store.GetOrder());
+        }
+        finally { store.Dispose(); File.Delete(dbPath); }
+    }
+
+    [Fact]
+    public void TrySetOrder_NonPermutation_Fails_Without_Mutating()
+    {
+        var (svc, store, _, dbPath) = MakeService();
+        try
+        {
+            int orderChangedCount = 0;
+            svc.OrderChanged += _ => orderChangedCount++;
+            var before = svc.CurrentOrder.ToList();
+
+            // Drop one entry — set membership change, not allowed.
+            var bad = before.Take(before.Count - 1).ToList();
+            var ok = svc.TrySetOrder(bad, out var err);
+
+            Assert.False(ok);
+            Assert.NotNull(err);
+            Assert.Equal(before, svc.CurrentOrder);
+            Assert.Equal(0, orderChangedCount);
+        }
+        finally { store.Dispose(); File.Delete(dbPath); }
+    }
+
+    [Fact]
+    public void Persisted_Order_Survives_Service_Restart()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"chain-order-restart-{Guid.NewGuid():N}.db");
+        try
+        {
+            // Session 1 — seed + reorder + dispose.
+            {
+                var store = new ChainOrderStore(NullLogger<ChainOrderStore>.Instance, dbPath);
+                var svc = new ChainOrderService(store, new StreamingHub(NullLogger<StreamingHub>.Instance), NullLogger<ChainOrderService>.Instance);
+                var reordered = svc.CurrentOrder.Reverse().ToList();
+                svc.TrySetOrder(reordered, out _);
+                store.Dispose();
+            }
+            // Session 2 — re-open; the reversed order should be loaded.
+            {
+                var store = new ChainOrderStore(NullLogger<ChainOrderStore>.Instance, dbPath);
+                var svc = new ChainOrderService(store, new StreamingHub(NullLogger<StreamingHub>.Instance), NullLogger<ChainOrderService>.Instance);
+                var expected = ChainOrderService.DefaultOrder.Reverse().ToList();
+                Assert.Equal(expected, svc.CurrentOrder);
+                store.Dispose();
+            }
+        }
+        finally { if (File.Exists(dbPath)) File.Delete(dbPath); }
+    }
+
+}

--- a/tests/Zeus.Server.Tests/ChainOrderServiceTests.cs
+++ b/tests/Zeus.Server.Tests/ChainOrderServiceTests.cs
@@ -1,15 +1,19 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Plugins.Contracts.Audio;
+using Zeus.Plugins.Contracts.Extensions;
+using Zeus.Plugins.Host.Audio;
 using Zeus.Server;
 
 namespace Zeus.Server.Tests;
 
 /// <summary>
 /// Unit tests for <see cref="ChainOrderService"/> — the source of
-/// truth for the Audio Suite chain order. Covers default seeding,
-/// persistence round-trip, attach/detach order maintenance, and the
-/// PUT-permutation validation that protects against the frontend
-/// trying to "install" plugins via the order endpoint.
+/// truth for the Audio Suite chain order. Verifies the canonical
+/// vs runtime split (canonical preserves uninstalled positions,
+/// runtime exposes only attached plugins), v2-default seeded
+/// position-on-insert, PUT permutation validation against attached
+/// set, and persistence round-trip.
 /// </summary>
 public class ChainOrderServiceTests
 {
@@ -17,47 +21,70 @@ public class ChainOrderServiceTests
     {
         var dbPath = Path.Combine(Path.GetTempPath(), $"chain-order-test-{Guid.NewGuid():N}.db");
         var store = new ChainOrderStore(NullLogger<ChainOrderStore>.Instance, dbPath);
-        // Real StreamingHub with no clients — Broadcast(...) short-
-        // circuits on _clients.IsEmpty so the test doesn't exercise
-        // the wire path. Broadcast invocation correctness is covered
-        // by AudioChainOrderFrame's own round-trip tests + manual
-        // integration testing.
         var hub = new StreamingHub(NullLogger<StreamingHub>.Instance);
         var svc = new ChainOrderService(store, hub, NullLogger<ChainOrderService>.Instance);
         return (svc, store, hub, dbPath);
     }
 
+    /// <summary>
+    /// First-run boot with no plugins attached: canonical is seeded
+    /// with the v2 default order (so future installs land in the
+    /// right slot), but the runtime CurrentOrder is empty because
+    /// nothing is attached yet. Nothing persisted yet — only
+    /// explicit mutations persist.
+    /// </summary>
     [Fact]
-    public void First_Run_Seeds_With_Default_Order()
+    public void First_Run_Runtime_Order_Is_Empty_Even_Though_Canonical_Is_Seeded()
     {
         var (svc, store, _, dbPath) = MakeService();
         try
         {
-            var order = svc.CurrentOrder;
-            Assert.Equal(ChainOrderService.DefaultOrder, order);
-            // First run does NOT persist — only explicit mutations
-            // persist. A fresh process should see null from the store.
+            Assert.Empty(svc.CurrentOrder);
+            Assert.Equal(ChainOrderService.DefaultOrder, svc.CanonicalOrderForTest);
+            // No mutation yet = no persistence yet.
             Assert.Null(store.GetOrder());
         }
         finally { store.Dispose(); File.Delete(dbPath); }
     }
 
     [Fact]
-    public void OnPluginAttached_NewId_Appends_And_Persists()
+    public void Attaching_A_Known_v2_Id_Returns_Its_Default_Position_Among_Attached()
     {
         var (svc, store, _, dbPath) = MakeService();
         try
         {
-            var attached = new HashSet<string>(StringComparer.Ordinal);
+            // EQ is at canonical index 3 (after Gate/DownExp/Tube).
+            // With nothing else attached, EQ is the only runtime entry,
+            // so its runtime slot is 0.
+            var eq = ChainOrderService.DefaultOrder[3];
+            var comp = ChainOrderService.DefaultOrder[4];
 
-            // Attach an ID not in the default order — should append.
+            var eqSlot = svc.OnPluginAttached(eq, new[] { eq });
+            Assert.Equal(0, eqSlot);
+            Assert.Single(svc.CurrentOrder);
+            Assert.Equal(eq, svc.CurrentOrder[0]);
+
+            var compSlot = svc.OnPluginAttached(comp, new[] { eq, comp });
+            Assert.Equal(1, compSlot);
+            Assert.Equal(new[] { eq, comp }, svc.CurrentOrder);
+        }
+        finally { store.Dispose(); File.Delete(dbPath); }
+    }
+
+    [Fact]
+    public void Attaching_A_NonDefault_Id_Appends_To_Canonical_And_Persists()
+    {
+        var (svc, store, _, dbPath) = MakeService();
+        try
+        {
             var customId = "com.example.thirdparty.plugin";
-            attached.Add(customId);
-            svc.OnPluginAttached(customId, attached);
+            svc.OnPluginAttached(customId, new[] { customId });
 
-            var order = svc.CurrentOrder;
-            Assert.Equal(customId, order[^1]);
-            // First mutation persists; subsequent boots restore.
+            // Custom ID goes to the end of canonical (not in DefaultOrder).
+            Assert.Equal(customId, svc.CanonicalOrderForTest[^1]);
+            // Only this one is attached, so it's the sole runtime entry.
+            Assert.Equal(new[] { customId }, svc.CurrentOrder);
+            // First mutation persists.
             var persisted = store.GetOrder();
             Assert.NotNull(persisted);
             Assert.Equal(customId, persisted![^1]);
@@ -66,125 +93,311 @@ public class ChainOrderServiceTests
     }
 
     [Fact]
-    public void OnPluginAttached_KnownId_Does_Not_Duplicate()
+    public void Attaching_Same_Id_Twice_Does_Not_Duplicate_In_Canonical()
     {
         var (svc, store, _, dbPath) = MakeService();
         try
         {
-            var attached = new HashSet<string>(StringComparer.Ordinal);
-            var knownId = ChainOrderService.DefaultOrder[3]; // EQ
+            var eq = ChainOrderService.DefaultOrder[3];
+            svc.OnPluginAttached(eq, new[] { eq });
+            svc.OnPluginAttached(eq, new[] { eq });
 
-            attached.Add(knownId);
-            svc.OnPluginAttached(knownId, attached);
-            svc.OnPluginAttached(knownId, attached);
-
-            var order = svc.CurrentOrder;
-            Assert.Equal(ChainOrderService.DefaultOrder.Count,
-                order.Count(id => id == knownId == false ? false : true) +
-                order.Count(id => id != knownId));
-            // Sharper assertion: EQ appears exactly once.
-            Assert.Equal(1, order.Count(id => id == knownId));
+            var canonical = svc.CanonicalOrderForTest;
+            Assert.Equal(1, canonical.Count(id => id == eq));
         }
         finally { store.Dispose(); File.Delete(dbPath); }
     }
 
     [Fact]
-    public void OnPluginAttached_Returns_Slot_Index_Among_Attached_Subset()
+    public void Detaching_Removes_From_Runtime_But_Keeps_Position_In_Canonical()
     {
         var (svc, store, _, dbPath) = MakeService();
         try
         {
-            var attached = new HashSet<string>(StringComparer.Ordinal);
-            // Default order: gate(0) downexp(1) tube(2) eq(3) comp(4) exciter(5) bass(6) reverb(7)
-            // Attach only EQ and Compressor — slots should be 0 and 1
-            // (their position within the attached subset), not 3 and 4
-            // (their position in the full canonical order).
-            var eqId = ChainOrderService.DefaultOrder[3];
-            var compId = ChainOrderService.DefaultOrder[4];
+            var eq = ChainOrderService.DefaultOrder[3];
+            svc.OnPluginAttached(eq, new[] { eq });
+            Assert.Single(svc.CurrentOrder);
 
-            attached.Add(eqId);
-            var eqSlot = svc.OnPluginAttached(eqId, attached);
+            svc.OnPluginDetached(eq);
 
-            attached.Add(compId);
-            var compSlot = svc.OnPluginAttached(compId, attached);
-
-            Assert.Equal(0, eqSlot);
-            Assert.Equal(1, compSlot);
+            Assert.Empty(svc.CurrentOrder);
+            // Canonical still has EQ at its v2-default position so a
+            // re-install restores the slot.
+            Assert.Contains(eq, svc.CanonicalOrderForTest);
         }
         finally { store.Dispose(); File.Delete(dbPath); }
     }
 
     [Fact]
-    public void TrySetOrder_Permutation_Succeeds_And_Fires_OrderChanged()
+    public void TrySetOrder_Accepts_Permutation_Of_Attached_Set()
     {
         var (svc, store, _, dbPath) = MakeService();
         try
         {
+            // Attach EQ, Comp, Exciter — 3 of the 8 v2 defaults.
+            var eq = ChainOrderService.DefaultOrder[3];
+            var comp = ChainOrderService.DefaultOrder[4];
+            var exc = ChainOrderService.DefaultOrder[5];
+            svc.OnPluginAttached(eq, new[] { eq });
+            svc.OnPluginAttached(comp, new[] { eq, comp });
+            svc.OnPluginAttached(exc, new[] { eq, comp, exc });
+            Assert.Equal(new[] { eq, comp, exc }, svc.CurrentOrder);
+
             int orderChangedCount = 0;
-            IReadOnlyList<string>? lastOrder = null;
-            svc.OrderChanged += order => { orderChangedCount++; lastOrder = order; };
+            IReadOnlyList<string>? lastEvent = null;
+            svc.OrderChanged += order => { orderChangedCount++; lastEvent = order; };
 
-            var current = svc.CurrentOrder.ToList();
-            current.Reverse(); // still a permutation
+            // Reverse the runtime view.
+            var reordered = new[] { exc, comp, eq };
+            var ok = svc.TrySetOrder(reordered, out var err);
 
-            var ok = svc.TrySetOrder(current, out var err);
-
-            Assert.True(ok);
+            Assert.True(ok, err);
             Assert.Null(err);
-            Assert.Equal(current, svc.CurrentOrder);
+            Assert.Equal(reordered, svc.CurrentOrder);
             Assert.Equal(1, orderChangedCount);
-            Assert.Equal(current, lastOrder);
-            Assert.Equal(current, store.GetOrder());
+            Assert.Equal(reordered, lastEvent);
         }
         finally { store.Dispose(); File.Delete(dbPath); }
     }
 
     [Fact]
-    public void TrySetOrder_NonPermutation_Fails_Without_Mutating()
+    public void TrySetOrder_Preserves_Uninstalled_Canonical_Entries_In_Position()
     {
         var (svc, store, _, dbPath) = MakeService();
         try
         {
+            // Attach only EQ and Comp; Gate/DownExp/Tube/Exciter/Bass/Reverb
+            // are NOT installed but still occupy canonical slots.
+            var eq = ChainOrderService.DefaultOrder[3];
+            var comp = ChainOrderService.DefaultOrder[4];
+            svc.OnPluginAttached(eq, new[] { eq });
+            svc.OnPluginAttached(comp, new[] { eq, comp });
+
+            // Operator reorders the runtime view: [Comp, EQ].
+            var ok = svc.TrySetOrder(new[] { comp, eq }, out var err);
+            Assert.True(ok, err);
+
+            // Canonical should still have all 8 v2 defaults; the two
+            // installed slots (originally EQ=idx3, Comp=idx4) now hold
+            // [Comp, EQ] respectively — uninstalled IDs unchanged.
+            var canonical = svc.CanonicalOrderForTest;
+            Assert.Equal(8, canonical.Count);
+            Assert.Equal(ChainOrderService.DefaultOrder[0], canonical[0]); // Gate unchanged
+            Assert.Equal(ChainOrderService.DefaultOrder[1], canonical[1]); // DownExp unchanged
+            Assert.Equal(ChainOrderService.DefaultOrder[2], canonical[2]); // Tube unchanged
+            Assert.Equal(comp, canonical[3]); // was EQ, now Comp (position-replacement)
+            Assert.Equal(eq, canonical[4]);   // was Comp, now EQ
+            Assert.Equal(ChainOrderService.DefaultOrder[5], canonical[5]); // Exciter unchanged
+            Assert.Equal(ChainOrderService.DefaultOrder[6], canonical[6]); // Bass unchanged
+            Assert.Equal(ChainOrderService.DefaultOrder[7], canonical[7]); // Reverb unchanged
+        }
+        finally { store.Dispose(); File.Delete(dbPath); }
+    }
+
+    [Fact]
+    public void TrySetOrder_Rejects_Wrong_Count()
+    {
+        var (svc, store, _, dbPath) = MakeService();
+        try
+        {
+            var eq = ChainOrderService.DefaultOrder[3];
+            var comp = ChainOrderService.DefaultOrder[4];
+            svc.OnPluginAttached(eq, new[] { eq });
+            svc.OnPluginAttached(comp, new[] { eq, comp });
+
             int orderChangedCount = 0;
             svc.OrderChanged += _ => orderChangedCount++;
-            var before = svc.CurrentOrder.ToList();
 
-            // Drop one entry — set membership change, not allowed.
-            var bad = before.Take(before.Count - 1).ToList();
-            var ok = svc.TrySetOrder(bad, out var err);
+            // Drop one — wrong count.
+            var ok = svc.TrySetOrder(new[] { eq }, out var err);
 
             Assert.False(ok);
             Assert.NotNull(err);
-            Assert.Equal(before, svc.CurrentOrder);
+            Assert.Equal(new[] { eq, comp }, svc.CurrentOrder);
             Assert.Equal(0, orderChangedCount);
         }
         finally { store.Dispose(); File.Delete(dbPath); }
     }
 
     [Fact]
-    public void Persisted_Order_Survives_Service_Restart()
+    public void TrySetOrder_Rejects_Different_Id_Set()
+    {
+        var (svc, store, _, dbPath) = MakeService();
+        try
+        {
+            var eq = ChainOrderService.DefaultOrder[3];
+            var comp = ChainOrderService.DefaultOrder[4];
+            svc.OnPluginAttached(eq, new[] { eq });
+            svc.OnPluginAttached(comp, new[] { eq, comp });
+
+            // Same count but different set — should reject.
+            var ok = svc.TrySetOrder(new[] { eq, "com.example.nope" }, out var err);
+
+            Assert.False(ok);
+            Assert.NotNull(err);
+            Assert.Equal(new[] { eq, comp }, svc.CurrentOrder);
+        }
+        finally { store.Dispose(); File.Delete(dbPath); }
+    }
+
+    [Fact]
+    public void Persisted_Canonical_Order_Survives_Service_Restart()
     {
         var dbPath = Path.Combine(Path.GetTempPath(), $"chain-order-restart-{Guid.NewGuid():N}.db");
         try
         {
-            // Session 1 — seed + reorder + dispose.
+            // Session 1: attach EQ + Comp, reorder them.
             {
                 var store = new ChainOrderStore(NullLogger<ChainOrderStore>.Instance, dbPath);
                 var svc = new ChainOrderService(store, new StreamingHub(NullLogger<StreamingHub>.Instance), NullLogger<ChainOrderService>.Instance);
-                var reordered = svc.CurrentOrder.Reverse().ToList();
-                svc.TrySetOrder(reordered, out _);
+                var eq = ChainOrderService.DefaultOrder[3];
+                var comp = ChainOrderService.DefaultOrder[4];
+                svc.OnPluginAttached(eq, new[] { eq });
+                svc.OnPluginAttached(comp, new[] { eq, comp });
+                svc.TrySetOrder(new[] { comp, eq }, out _);
                 store.Dispose();
             }
-            // Session 2 — re-open; the reversed order should be loaded.
+            // Session 2: re-open. Canonical should retain the merged order.
             {
                 var store = new ChainOrderStore(NullLogger<ChainOrderStore>.Instance, dbPath);
                 var svc = new ChainOrderService(store, new StreamingHub(NullLogger<StreamingHub>.Instance), NullLogger<ChainOrderService>.Instance);
-                var expected = ChainOrderService.DefaultOrder.Reverse().ToList();
-                Assert.Equal(expected, svc.CurrentOrder);
+                var canonical = svc.CanonicalOrderForTest;
+                var eq = ChainOrderService.DefaultOrder[3];
+                var comp = ChainOrderService.DefaultOrder[4];
+                Assert.Equal(comp, canonical[3]); // operator's choice preserved
+                Assert.Equal(eq, canonical[4]);
+                // Runtime is still empty until plugins attach this session.
+                Assert.Empty(svc.CurrentOrder);
                 store.Dispose();
             }
         }
         finally { if (File.Exists(dbPath)) File.Delete(dbPath); }
     }
 
+    /// <summary>
+    /// End-to-end signal-flow proof: reordering the chain via
+    /// TrySetOrder MUST actually change the order in which audio
+    /// samples flow through the plugins, not just the visual /
+    /// metadata order. This test mirrors what AudioPluginBridge
+    /// does when ChainOrderService.OrderChanged fires:
+    /// ReapplySlotsUnderLock clears all AudioChain slots and
+    /// repopulates them in CurrentOrder sequence at sequential
+    /// indices. Combined with AudioChain's existing
+    /// "TwoSlots_Compose_Left_To_Right" semantics, this proves
+    /// that a UI reorder produces a real DSP reorder.
+    /// </summary>
+    [Fact]
+    public void Reorder_Changes_Actual_Signal_Flow_Through_AudioChain()
+    {
+        var (svc, store, _, dbPath) = MakeService();
+        try
+        {
+            // Two synthetic plugins with non-commutative effects so
+            // we can audibly distinguish ordering by inspecting the
+            // chain's output. AddOne adds 1.0 to every sample;
+            // MultiplyByTwo multiplies. (a+1)*2 != (a*2)+1 for any a.
+            var addId = "test.add-one";
+            var mulId = "test.multiply-two";
+            var addPlugin = new AddOnePlugin();
+            var mulPlugin = new MultiplyTwoPlugin();
+            svc.OnPluginAttached(addId, new[] { addId });
+            svc.OnPluginAttached(mulId, new[] { addId, mulId });
+
+            var chain = new AudioChain();
+            // Re-slot helper that mirrors AudioPluginBridge.ReapplySlotsUnderLock:
+            // clear all 8 slots, then walk CurrentOrder and SetSlot each
+            // plugin at sequential indices. This is the EXACT data flow
+            // the production bridge applies on OrderChanged.
+            void Reslot()
+            {
+                for (int i = 0; i < chain.SlotCount; i++) chain.ClearSlot(i);
+                int idx = 0;
+                foreach (var id in svc.CurrentOrder)
+                {
+                    IAudioPlugin? p = id == addId ? addPlugin : id == mulId ? mulPlugin : null;
+                    if (p is not null) { chain.SetSlot(idx, p); idx++; }
+                }
+                chain.MasterEnabled = idx > 0;
+            }
+            // Initial order is [add, mul] (attached in that order, both
+            // append to v2-default positions in canonical, runtime view
+            // mirrors). Wire the OrderChanged event to the Reslot helper
+            // so subsequent TrySetOrder calls re-slot automatically.
+            svc.OrderChanged += _ => Reslot();
+            Reslot();
+            Assert.Equal(new[] { addId, mulId }, svc.CurrentOrder);
+
+            // Process [1, 2, 3, 4] through chain [add, mul] → (x+1)*2.
+            Span<float> input = stackalloc float[] { 1f, 2f, 3f, 4f };
+            Span<float> output = stackalloc float[4];
+            var ctx = new AudioBlockContext(48000, 1, 4, 0, false);
+            chain.Process(input, output, ctx);
+            Assert.Equal<float>(new float[] { 4f, 6f, 8f, 10f }, output.ToArray());
+
+            // Reorder to [mul, add]; this should change the signal flow.
+            var ok = svc.TrySetOrder(new[] { mulId, addId }, out var err);
+            Assert.True(ok, err);
+            Assert.Equal(new[] { mulId, addId }, svc.CurrentOrder);
+
+            // Re-run with the same input through chain [mul, add] → (x*2)+1.
+            // If only the UI changed and the chain ignored the reorder,
+            // we'd still see (x+1)*2 → [4, 6, 8, 10]. The new expected
+            // values [3, 5, 7, 9] PROVE the signal flow follows the
+            // reorder, not just the metadata.
+            chain.Process(input, output, ctx);
+            Assert.Equal<float>(new float[] { 3f, 5f, 7f, 9f }, output.ToArray());
+        }
+        finally { store.Dispose(); File.Delete(dbPath); }
+    }
+
+    private sealed class AddOnePlugin : IAudioPlugin
+    {
+        public string DisplayName => "add+1";
+        public AudioPluginRequirements Requirements => new(48000, 1, 256);
+        public Task InitializeAudioAsync(IAudioHost host, CancellationToken ct) => Task.CompletedTask;
+        public Task ShutdownAudioAsync(CancellationToken ct) => Task.CompletedTask;
+        public void Process(ReadOnlySpan<float> input, Span<float> output, AudioBlockContext ctx)
+        {
+            for (int i = 0; i < input.Length; i++) output[i] = input[i] + 1f;
+        }
+    }
+
+    private sealed class MultiplyTwoPlugin : IAudioPlugin
+    {
+        public string DisplayName => "mul*2";
+        public AudioPluginRequirements Requirements => new(48000, 1, 256);
+        public Task InitializeAudioAsync(IAudioHost host, CancellationToken ct) => Task.CompletedTask;
+        public Task ShutdownAudioAsync(CancellationToken ct) => Task.CompletedTask;
+        public void Process(ReadOnlySpan<float> input, Span<float> output, AudioBlockContext ctx)
+        {
+            for (int i = 0; i < input.Length; i++) output[i] = input[i] * 2f;
+        }
+    }
+
+    [Fact]
+    public void Reattach_Restores_Operator_Chosen_Position()
+    {
+        var (svc, store, _, dbPath) = MakeService();
+        try
+        {
+            // Attach three, reorder to [c, b, a], detach b, re-attach b.
+            // b should land back between c and a (where the operator
+            // put it), not at the end.
+            var a = ChainOrderService.DefaultOrder[3]; // eq
+            var b = ChainOrderService.DefaultOrder[4]; // comp
+            var c = ChainOrderService.DefaultOrder[5]; // exciter
+            svc.OnPluginAttached(a, new[] { a });
+            svc.OnPluginAttached(b, new[] { a, b });
+            svc.OnPluginAttached(c, new[] { a, b, c });
+            svc.TrySetOrder(new[] { c, b, a }, out _);
+            Assert.Equal(new[] { c, b, a }, svc.CurrentOrder);
+
+            svc.OnPluginDetached(b);
+            Assert.Equal(new[] { c, a }, svc.CurrentOrder);
+
+            svc.OnPluginAttached(b, new[] { a, b, c });
+            Assert.Equal(new[] { c, b, a }, svc.CurrentOrder); // b restored to chosen slot
+        }
+        finally { store.Dispose(); File.Delete(dbPath); }
+    }
 }

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -48,6 +48,7 @@ import { FlexWorkspace } from './layout/FlexWorkspace';
 import { AfGainSlider } from './components/AfGainSlider';
 import { AgcSlider } from './components/AgcSlider';
 import { AlertBanner } from './components/AlertBanner';
+import { AudioSuiteWindow } from './components/AudioSuiteWindow';
 import { AttenuatorSlider } from './components/AttenuatorSlider';
 import { AudioToggle } from './components/AudioToggle';
 import { BandFavorites } from './components/toolbar/BandFavorites';
@@ -745,6 +746,13 @@ export default function App() {
           <FlexWorkspace key={activeLayoutId} />
         )}
       </div>
+
+      {/* Audio Suite floating window — position:fixed overlay rendered
+          outside the workspace grid so it can drift to wherever the
+          operator drags it without getting clipped by a parent. Mounted
+          unconditionally (returns null when closed) so the open/close
+          state in the store is the single source of truth. */}
+      <AudioSuiteWindow />
 
       {/* Transport — MOX/TUN + audio + mic + macro buttons on the left,
           PA/PRE chips, then the per-radio status (radio IP, rotator, QRZ)

--- a/zeus-web/src/components/AudioSuiteWindow.tsx
+++ b/zeus-web/src/components/AudioSuiteWindow.tsx
@@ -16,9 +16,153 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { usePluginPanels } from '../plugins/runtime/usePluginPanels';
 import type { RegisteredPluginPanel } from '../plugins/runtime/pluginRuntime';
-import { useAudioSuiteStore } from '../state/audio-suite-store';
+import {
+  AUDIO_SUITE_WINDOW_MIN_WIDTH,
+  AUDIO_SUITE_WINDOW_MIN_HEIGHT,
+  useAudioSuiteStore,
+} from '../state/audio-suite-store';
 
 const CHAIN_SLOT = 'tx-audio-tools.chain';
+
+/** Edge codes for the resize handles — 4 edges + 4 corners. */
+type ResizeEdge = 'n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw';
+
+const RESIZE_HANDLE_PX = 6; // grab thickness for each edge
+
+const CURSOR_FOR_EDGE: Record<ResizeEdge, string> = {
+  n: 'ns-resize',
+  s: 'ns-resize',
+  e: 'ew-resize',
+  w: 'ew-resize',
+  ne: 'nesw-resize',
+  sw: 'nesw-resize',
+  nw: 'nwse-resize',
+  se: 'nwse-resize',
+};
+
+/**
+ * Compute the absolute-position style for a resize handle on the
+ * given edge. Handles cover only their edge / corner — clicks in
+ * the interior pass through to the window content.
+ */
+function handleStyleFor(edge: ResizeEdge): React.CSSProperties {
+  const base: React.CSSProperties = {
+    position: 'absolute',
+    zIndex: 1,
+    cursor: CURSOR_FOR_EDGE[edge],
+    touchAction: 'none',
+  };
+  switch (edge) {
+    case 'n':  return { ...base, top: 0, left: RESIZE_HANDLE_PX, right: RESIZE_HANDLE_PX, height: RESIZE_HANDLE_PX };
+    case 's':  return { ...base, bottom: 0, left: RESIZE_HANDLE_PX, right: RESIZE_HANDLE_PX, height: RESIZE_HANDLE_PX };
+    case 'e':  return { ...base, top: RESIZE_HANDLE_PX, bottom: RESIZE_HANDLE_PX, right: 0, width: RESIZE_HANDLE_PX };
+    case 'w':  return { ...base, top: RESIZE_HANDLE_PX, bottom: RESIZE_HANDLE_PX, left: 0, width: RESIZE_HANDLE_PX };
+    case 'ne': return { ...base, top: 0, right: 0, width: RESIZE_HANDLE_PX, height: RESIZE_HANDLE_PX };
+    case 'nw': return { ...base, top: 0, left: 0, width: RESIZE_HANDLE_PX, height: RESIZE_HANDLE_PX };
+    case 'se': return { ...base, bottom: 0, right: 0, width: RESIZE_HANDLE_PX, height: RESIZE_HANDLE_PX };
+    case 'sw': return { ...base, bottom: 0, left: 0, width: RESIZE_HANDLE_PX, height: RESIZE_HANDLE_PX };
+  }
+}
+
+/**
+ * One resize handle. Invisible 6px region on its assigned edge /
+ * corner; the cursor changes on hover so operators can see where
+ * the grab regions are. Pointer Events with capture so the drag
+ * keeps tracking even if the cursor leaves the handle while
+ * dragging.
+ */
+function ResizeHandle({ edge }: { edge: ResizeEdge }) {
+  const x = useAudioSuiteStore((s) => s.x);
+  const y = useAudioSuiteStore((s) => s.y);
+  const width = useAudioSuiteStore((s) => s.width);
+  const height = useAudioSuiteStore((s) => s.height);
+  const setPosition = useAudioSuiteStore((s) => s.setPosition);
+  const setSize = useAudioSuiteStore((s) => s.setSize);
+
+  const dragRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    origX: number;
+    origY: number;
+    origW: number;
+    origH: number;
+  } | null>(null);
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      e.stopPropagation();
+      e.preventDefault();
+      e.currentTarget.setPointerCapture(e.pointerId);
+      dragRef.current = {
+        pointerId: e.pointerId,
+        startX: e.clientX,
+        startY: e.clientY,
+        origX: x, origY: y,
+        origW: width, origH: height,
+      };
+    },
+    [x, y, width, height],
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const d = dragRef.current;
+      if (!d || d.pointerId !== e.pointerId) return;
+      const dx = e.clientX - d.startX;
+      const dy = e.clientY - d.startY;
+      let nX = d.origX;
+      let nY = d.origY;
+      let nW = d.origW;
+      let nH = d.origH;
+      if (edge.includes('e')) nW = d.origW + dx;
+      if (edge.includes('s')) nH = d.origH + dy;
+      if (edge.includes('w')) { nX = d.origX + dx; nW = d.origW - dx; }
+      if (edge.includes('n')) { nY = d.origY + dy; nH = d.origH - dy; }
+
+      // Enforce minimums; when shrinking from the left / top, prevent
+      // the window's x/y from drifting past the would-be max.
+      if (nW < AUDIO_SUITE_WINDOW_MIN_WIDTH) {
+        if (edge.includes('w')) nX = d.origX + d.origW - AUDIO_SUITE_WINDOW_MIN_WIDTH;
+        nW = AUDIO_SUITE_WINDOW_MIN_WIDTH;
+      }
+      if (nH < AUDIO_SUITE_WINDOW_MIN_HEIGHT) {
+        if (edge.includes('n')) nY = d.origY + d.origH - AUDIO_SUITE_WINDOW_MIN_HEIGHT;
+        nH = AUDIO_SUITE_WINDOW_MIN_HEIGHT;
+      }
+
+      // Edges that include a dimension update push both position
+      // and size in one render; setting them in order so the store
+      // sees the combined change as a single React render.
+      setPosition(nX, nY);
+      setSize(nW, nH);
+    },
+    [edge, setPosition, setSize],
+  );
+
+  const onPointerUp = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const d = dragRef.current;
+      if (!d || d.pointerId !== e.pointerId) return;
+      try { e.currentTarget.releasePointerCapture(e.pointerId); } catch {}
+      dragRef.current = null;
+    },
+    [],
+  );
+
+  return (
+    <div
+      data-no-drag
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerUp}
+      style={handleStyleFor(edge)}
+    />
+  );
+}
+
+const RESIZE_EDGES: ResizeEdge[] = ['n', 's', 'e', 'w', 'ne', 'nw', 'se', 'sw'];
 
 /**
  * Short display name for a chain tile, derived from the plugin ID.
@@ -212,6 +356,12 @@ export function AudioSuiteWindow() {
         overflow: 'hidden',
       }}
     >
+      {/* Resize handles — 4 edges + 4 corners. Each is a 6px invisible
+          grab region absolutely positioned on its edge; cursor changes
+          on hover so the grab area is discoverable. zIndex:1 so they
+          sit above the content but below dialogs / dropdowns. */}
+      {RESIZE_EDGES.map((e) => <ResizeHandle key={e} edge={e} />)}
+
       {/* Header — drag handle. Brass-plate styling per the v3 Lifted
           Dark spec ([[project_audio_chain_visual_direction]]). */}
       <div

--- a/zeus-web/src/components/AudioSuiteWindow.tsx
+++ b/zeus-web/src/components/AudioSuiteWindow.tsx
@@ -1,0 +1,385 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// AudioSuiteWindow — draggable floating window containing the audio
+// plugin chain. Replaces the inline rendering that used to live in
+// TxAudioToolsPanel (per Phase 2 of issue #332). Operators open it
+// via the "Audio Suite" button on TX Audio Tools, drag tiles at the
+// top to reorder the chain, toggle audition to hear the chain output
+// in their RX playback path, and adjust per-plugin settings in the
+// stacked panels below.
+//
+// Drag-and-drop is vanilla HTML5 (no npm dep per CLAUDE.md red-line
+// on new deps). Window dragging uses Pointer Events with capture.
+// All chrome is in Zeus tokens — no raw hex per the design rules in
+// docs/lessons/dev-conventions.md.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { usePluginPanels } from '../plugins/runtime/usePluginPanels';
+import type { RegisteredPluginPanel } from '../plugins/runtime/pluginRuntime';
+import { useAudioSuiteStore } from '../state/audio-suite-store';
+
+const CHAIN_SLOT = 'tx-audio-tools.chain';
+
+/**
+ * Short display name for a chain tile, derived from the plugin ID.
+ * Recognised v1/v2 plugins get a hand-tuned label; others fall back
+ * to the panel title or the trailing segment of the plugin ID.
+ */
+function shortLabelFor(pluginId: string, panelTitle: string): string {
+  switch (pluginId) {
+    case 'com.openhpsdr.zeus.samples.gate':       return 'GATE';
+    case 'com.openhpsdr.zeus.samples.downexp':    return 'D-EXP';
+    case 'com.openhpsdr.zeus.samples.tube':       return 'TUBE';
+    case 'com.openhpsdr.zeus.samples.eq':         return 'EQ';
+    case 'com.openhpsdr.zeus.samples.compressor': return 'COMP';
+    case 'com.openhpsdr.zeus.samples.exciter':    return 'EXCITER';
+    case 'com.openhpsdr.zeus.samples.bass':       return 'BASS';
+    case 'com.openhpsdr.zeus.samples.reverb':     return 'REVERB';
+    default:
+      if (panelTitle && panelTitle.length > 0) return panelTitle.toUpperCase();
+      const seg = pluginId.split('.').pop() ?? pluginId;
+      return seg.toUpperCase().slice(0, 8);
+  }
+}
+
+/**
+ * Sort the chain panels into the canonical order from the store.
+ * Plugins present locally but missing from the canonical order
+ * (e.g. server hasn't pushed an update yet) sort to the end in
+ * panel-id order for determinism.
+ */
+function sortChainPanels(
+  panels: RegisteredPluginPanel[],
+  canonicalOrder: string[],
+): RegisteredPluginPanel[] {
+  const orderIndex = new Map<string, number>();
+  canonicalOrder.forEach((id, i) => orderIndex.set(id, i));
+  return [...panels].sort((a, b) => {
+    const ia = orderIndex.get(a.pluginId) ?? Number.POSITIVE_INFINITY;
+    const ib = orderIndex.get(b.pluginId) ?? Number.POSITIVE_INFINITY;
+    if (ia !== ib) return ia - ib;
+    return a.panelId.localeCompare(b.panelId);
+  });
+}
+
+export function AudioSuiteWindow() {
+  const isOpen = useAudioSuiteStore((s) => s.isOpen);
+  const close = useAudioSuiteStore((s) => s.close);
+  const x = useAudioSuiteStore((s) => s.x);
+  const y = useAudioSuiteStore((s) => s.y);
+  const width = useAudioSuiteStore((s) => s.width);
+  const height = useAudioSuiteStore((s) => s.height);
+  const setPosition = useAudioSuiteStore((s) => s.setPosition);
+  const setDragging = useAudioSuiteStore((s) => s.setDragging);
+  const chainOrder = useAudioSuiteStore((s) => s.chainOrder);
+  const reorderChain = useAudioSuiteStore((s) => s.reorderChain);
+  const loadChainOrderFromServer = useAudioSuiteStore(
+    (s) => s.loadChainOrderFromServer,
+  );
+  const auditionSupported = useAudioSuiteStore((s) => s.auditionSupported);
+  const auditionEnabled = useAudioSuiteStore((s) => s.auditionEnabled);
+  const setAuditionEnabled = useAudioSuiteStore((s) => s.setAuditionEnabled);
+  const loadAuditionState = useAudioSuiteStore((s) => s.loadAuditionState);
+
+  const allPanels = usePluginPanels();
+  const chainPanels = useMemo(
+    () => sortChainPanels(
+      allPanels.filter((p) => p.slot === CHAIN_SLOT),
+      chainOrder,
+    ),
+    [allPanels, chainOrder],
+  );
+
+  // Fetch server-side state on first open. Subsequent updates arrive
+  // via the AudioChainOrder WS broadcast handler in ws-client.ts.
+  useEffect(() => {
+    if (!isOpen) return;
+    loadChainOrderFromServer();
+    loadAuditionState();
+  }, [isOpen, loadChainOrderFromServer, loadAuditionState]);
+
+  // --- Window dragging via Pointer Events --------------------------
+  const dragStateRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    offsetX: number;
+    offsetY: number;
+  } | null>(null);
+
+  const onHeaderPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      // Ignore drags initiated on header controls (close button etc).
+      const target = e.target as HTMLElement;
+      if (target.closest('[data-no-drag]')) return;
+      e.currentTarget.setPointerCapture(e.pointerId);
+      dragStateRef.current = {
+        pointerId: e.pointerId,
+        startX: e.clientX,
+        startY: e.clientY,
+        offsetX: x,
+        offsetY: y,
+      };
+      setDragging(true);
+    },
+    [x, y, setDragging],
+  );
+
+  const onHeaderPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const ds = dragStateRef.current;
+      if (!ds || ds.pointerId !== e.pointerId) return;
+      const dx = e.clientX - ds.startX;
+      const dy = e.clientY - ds.startY;
+      // Clamp so the header can't drag off-screen (always leave at
+      // least 80px visible on every edge so the operator can grab it).
+      const minX = -width + 80;
+      const minY = 0;
+      const maxX = window.innerWidth - 80;
+      const maxY = window.innerHeight - 40;
+      const nextX = Math.min(maxX, Math.max(minX, ds.offsetX + dx));
+      const nextY = Math.min(maxY, Math.max(minY, ds.offsetY + dy));
+      setPosition(nextX, nextY);
+    },
+    [width, setPosition],
+  );
+
+  const onHeaderPointerUp = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const ds = dragStateRef.current;
+      if (!ds || ds.pointerId !== e.pointerId) return;
+      try { e.currentTarget.releasePointerCapture(e.pointerId); } catch {}
+      dragStateRef.current = null;
+      setDragging(false);
+    },
+    [setDragging],
+  );
+
+  // --- Tile drag-and-drop (HTML5 d&d) -----------------------------
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+  const draggedFromRef = useRef<number | null>(null);
+
+  const onTileDragStart = (idx: number) => (e: React.DragEvent) => {
+    draggedFromRef.current = idx;
+    e.dataTransfer.effectAllowed = 'move';
+    // Some browsers require a payload to start a drag.
+    e.dataTransfer.setData('text/plain', String(idx));
+  };
+
+  const onTileDragOver = (idx: number) => (e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    if (dragOverIndex !== idx) setDragOverIndex(idx);
+  };
+
+  const onTileDragLeave = () => setDragOverIndex(null);
+
+  const onTileDrop = (idx: number) => (e: React.DragEvent) => {
+    e.preventDefault();
+    const from = draggedFromRef.current;
+    setDragOverIndex(null);
+    draggedFromRef.current = null;
+    if (from === null || from === idx) return;
+    void reorderChain(from, idx);
+  };
+
+  const onTileDragEnd = () => {
+    setDragOverIndex(null);
+    draggedFromRef.current = null;
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Audio Suite"
+      style={{
+        position: 'fixed',
+        left: x,
+        top: y,
+        width,
+        height,
+        zIndex: 60,
+        display: 'flex',
+        flexDirection: 'column',
+        background: 'linear-gradient(180deg, var(--panel-top), var(--panel-bot))',
+        border: '1px solid var(--line-1)',
+        borderRadius: 8,
+        boxShadow: '0 12px 32px rgba(0, 0, 0, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.04)',
+        color: 'var(--fg-0)',
+        fontFamily: 'var(--font-sans, Inter, system-ui, sans-serif)',
+        overflow: 'hidden',
+      }}
+    >
+      {/* Header — drag handle. Brass-plate styling per the v3 Lifted
+          Dark spec ([[project_audio_chain_visual_direction]]). */}
+      <div
+        onPointerDown={onHeaderPointerDown}
+        onPointerMove={onHeaderPointerMove}
+        onPointerUp={onHeaderPointerUp}
+        onPointerCancel={onHeaderPointerUp}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          padding: '8px 12px',
+          background: 'linear-gradient(180deg, var(--panel-top), var(--panel-bot))',
+          borderBottom: '1px solid var(--line-1)',
+          boxShadow: 'inset 0 2px 0 var(--power), inset 0 3px 8px rgba(255, 201, 58, 0.08)',
+          cursor: 'grab',
+          userSelect: 'none',
+        }}
+      >
+        <span
+          style={{
+            color: 'var(--fg-1)',
+            fontSize: 12,
+            fontWeight: 600,
+            letterSpacing: 1.4,
+            textTransform: 'uppercase',
+          }}
+        >
+          Audio Suite
+        </span>
+
+        {/* Audition toggle. Disabled when host mode is server (audition
+            sink is a no-op in browser mode v1 per Phase 1 ADR). */}
+        <button
+          type="button"
+          data-no-drag
+          disabled={!auditionSupported}
+          onClick={() => setAuditionEnabled(!auditionEnabled)}
+          title={
+            auditionSupported
+              ? auditionEnabled
+                ? 'Audition is ON — chain output is mixed into your RX playback'
+                : 'Audition is OFF — click to hear the chain on your headphones'
+              : 'Audition is desktop-only in this version'
+          }
+          style={{
+            marginLeft: 'auto',
+            padding: '4px 12px',
+            borderRadius: 4,
+            border: '1px solid ' + (auditionEnabled ? 'var(--tx)' : 'var(--line-1)'),
+            background: auditionEnabled ? 'var(--tx)' : 'var(--bg-2)',
+            color: auditionEnabled ? 'var(--fg-0)' : 'var(--fg-2)',
+            cursor: auditionSupported ? 'pointer' : 'not-allowed',
+            opacity: auditionSupported ? 1 : 0.5,
+            fontSize: 11,
+            fontWeight: 600,
+            letterSpacing: 1,
+            textTransform: 'uppercase',
+            fontFamily: 'inherit',
+          }}
+        >
+          Audition {auditionEnabled ? 'ON' : 'OFF'}
+        </button>
+
+        <button
+          type="button"
+          data-no-drag
+          onClick={close}
+          aria-label="Close Audio Suite window"
+          title="Close"
+          style={{
+            padding: '2px 10px',
+            borderRadius: 4,
+            border: '1px solid var(--line-1)',
+            background: 'var(--bg-2)',
+            color: 'var(--fg-2)',
+            cursor: 'pointer',
+            fontSize: 14,
+            fontWeight: 600,
+            fontFamily: 'inherit',
+            lineHeight: 1,
+          }}
+        >
+          ×
+        </button>
+      </div>
+
+      {/* Tile strip — drag to reorder. Vanilla HTML5 d&d. */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+          padding: '8px 12px',
+          background: 'var(--bg-1)',
+          borderBottom: '1px solid var(--line-1)',
+          flexWrap: 'wrap',
+          fontSize: 10,
+          letterSpacing: 1.2,
+          textTransform: 'uppercase',
+        }}
+      >
+        <span style={{ color: 'var(--fg-3)', marginRight: 4, fontWeight: 500 }}>
+          Chain
+        </span>
+        {chainPanels.length === 0 && (
+          <span style={{ color: 'var(--fg-3)', fontStyle: 'italic', textTransform: 'none' }}>
+            No audio plugins installed — use Download Audio Suite on the TX Audio Tools panel.
+          </span>
+        )}
+        {chainPanels.map((panel, idx) => {
+          const label = shortLabelFor(panel.pluginId, panel.title);
+          const isDragTarget = dragOverIndex === idx;
+          return (
+            <div key={panel.pluginId} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              {idx > 0 && (
+                <span aria-hidden style={{ color: 'var(--fg-3)' }}>›</span>
+              )}
+              <div
+                draggable
+                onDragStart={onTileDragStart(idx)}
+                onDragOver={onTileDragOver(idx)}
+                onDragLeave={onTileDragLeave}
+                onDrop={onTileDrop(idx)}
+                onDragEnd={onTileDragEnd}
+                title={`${panel.pluginId} — drag to reorder`}
+                style={{
+                  padding: '4px 10px',
+                  borderRadius: 3,
+                  background: isDragTarget ? 'var(--accent)' : 'var(--bg-2)',
+                  border: '1px solid ' + (isDragTarget ? 'var(--accent)' : 'var(--line-1)'),
+                  color: isDragTarget ? 'var(--fg-0)' : 'var(--fg-1)',
+                  cursor: 'grab',
+                  fontSize: 10,
+                  fontWeight: 500,
+                  userSelect: 'none',
+                }}
+              >
+                {label}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Plugin panels stacked vertically in chain order. */}
+      <div
+        style={{
+          flex: 1,
+          overflowY: 'auto',
+          padding: 12,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 12,
+        }}
+      >
+        {chainPanels.map((panel) => {
+          const Component = panel.component;
+          return (
+            <div
+              key={`${panel.pluginId}::${panel.panelId}`}
+              data-plugin-id={panel.pluginId}
+            >
+              <Component />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/zeus-web/src/components/AudioSuiteWindow.tsx
+++ b/zeus-web/src/components/AudioSuiteWindow.tsx
@@ -43,7 +43,10 @@ const CURSOR_FOR_EDGE: Record<ResizeEdge, string> = {
 /**
  * Compute the absolute-position style for a resize handle on the
  * given edge. Handles cover only their edge / corner — clicks in
- * the interior pass through to the window content.
+ * the interior pass through to the window content. Corners get a
+ * faint L-shaped border in --fg-3 as a discoverability hint so
+ * operators see "there's a resize handle here" without the cursor
+ * change being the only cue.
  */
 function handleStyleFor(edge: ResizeEdge): React.CSSProperties {
   const base: React.CSSProperties = {
@@ -52,15 +55,20 @@ function handleStyleFor(edge: ResizeEdge): React.CSSProperties {
     cursor: CURSOR_FOR_EDGE[edge],
     touchAction: 'none',
   };
+  const cornerBorder = '1px solid var(--fg-3)';
   switch (edge) {
     case 'n':  return { ...base, top: 0, left: RESIZE_HANDLE_PX, right: RESIZE_HANDLE_PX, height: RESIZE_HANDLE_PX };
     case 's':  return { ...base, bottom: 0, left: RESIZE_HANDLE_PX, right: RESIZE_HANDLE_PX, height: RESIZE_HANDLE_PX };
     case 'e':  return { ...base, top: RESIZE_HANDLE_PX, bottom: RESIZE_HANDLE_PX, right: 0, width: RESIZE_HANDLE_PX };
     case 'w':  return { ...base, top: RESIZE_HANDLE_PX, bottom: RESIZE_HANDLE_PX, left: 0, width: RESIZE_HANDLE_PX };
-    case 'ne': return { ...base, top: 0, right: 0, width: RESIZE_HANDLE_PX, height: RESIZE_HANDLE_PX };
-    case 'nw': return { ...base, top: 0, left: 0, width: RESIZE_HANDLE_PX, height: RESIZE_HANDLE_PX };
-    case 'se': return { ...base, bottom: 0, right: 0, width: RESIZE_HANDLE_PX, height: RESIZE_HANDLE_PX };
-    case 'sw': return { ...base, bottom: 0, left: 0, width: RESIZE_HANDLE_PX, height: RESIZE_HANDLE_PX };
+    case 'ne': return { ...base, top: 0, right: 0, width: RESIZE_HANDLE_PX, height: RESIZE_HANDLE_PX,
+                        borderTop: cornerBorder, borderRight: cornerBorder, opacity: 0.6 };
+    case 'nw': return { ...base, top: 0, left: 0, width: RESIZE_HANDLE_PX, height: RESIZE_HANDLE_PX,
+                        borderTop: cornerBorder, borderLeft: cornerBorder, opacity: 0.6 };
+    case 'se': return { ...base, bottom: 0, right: 0, width: RESIZE_HANDLE_PX, height: RESIZE_HANDLE_PX,
+                        borderBottom: cornerBorder, borderRight: cornerBorder, opacity: 0.6 };
+    case 'sw': return { ...base, bottom: 0, left: 0, width: RESIZE_HANDLE_PX, height: RESIZE_HANDLE_PX,
+                        borderBottom: cornerBorder, borderLeft: cornerBorder, opacity: 0.6 };
   }
 }
 
@@ -242,6 +250,39 @@ export function AudioSuiteWindow() {
     loadAuditionState();
   }, [isOpen, loadChainOrderFromServer, loadAuditionState]);
 
+  // Escape closes the window — standard modal/popup keyboard
+  // affordance. Listener only attached while the window is open
+  // so it doesn't fight other Escape handlers (e.g. closing the
+  // panadapter cursor crosshair) when the suite is hidden.
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [isOpen, close]);
+
+  // Viewport-resize clamp — if the operator shrinks their browser
+  // window after the suite is positioned, the suite's stored x/y
+  // could end up off-screen and unreachable (no header to grab,
+  // no resize handle to grab either). Re-apply the same clamp
+  // rules used during drag whenever the viewport size changes.
+  useEffect(() => {
+    if (!isOpen) return;
+    const onResize = () => {
+      const minX = -width + 80;
+      const minY = 64;
+      const maxX = window.innerWidth - 80;
+      const maxY = window.innerHeight - 40;
+      const nextX = Math.min(maxX, Math.max(minX, x));
+      const nextY = Math.min(maxY, Math.max(minY, y));
+      if (nextX !== x || nextY !== y) setPosition(nextX, nextY);
+    };
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, [isOpen, x, y, width, setPosition]);
+
   // --- Window dragging via Pointer Events --------------------------
   const dragStateRef = useRef<{
     pointerId: number;
@@ -305,11 +346,20 @@ export function AudioSuiteWindow() {
   );
 
   // --- Tile drag-and-drop (HTML5 d&d) -----------------------------
+  // Two pieces of drag state:
+  //   - draggedFromRef: synchronous source-index access in the drop
+  //     handler (set in dragStart, cleared in drop/dragEnd).
+  //   - draggedFromIdx (state): triggers re-render so the SOURCE
+  //     tile dims to opacity 0.4 during drag, giving the operator
+  //     a visible "I'm moving this one" cue alongside the target
+  //     highlight.
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+  const [draggedFromIdx, setDraggedFromIdx] = useState<number | null>(null);
   const draggedFromRef = useRef<number | null>(null);
 
   const onTileDragStart = (idx: number) => (e: React.DragEvent) => {
     draggedFromRef.current = idx;
+    setDraggedFromIdx(idx);
     e.dataTransfer.effectAllowed = 'move';
     // Some browsers require a payload to start a drag.
     e.dataTransfer.setData('text/plain', String(idx));
@@ -327,6 +377,7 @@ export function AudioSuiteWindow() {
     e.preventDefault();
     const from = draggedFromRef.current;
     setDragOverIndex(null);
+    setDraggedFromIdx(null);
     draggedFromRef.current = null;
     if (from === null || from === idx) return;
     void reorderChain(from, idx);
@@ -334,6 +385,7 @@ export function AudioSuiteWindow() {
 
   const onTileDragEnd = () => {
     setDragOverIndex(null);
+    setDraggedFromIdx(null);
     draggedFromRef.current = null;
   };
 
@@ -489,6 +541,7 @@ export function AudioSuiteWindow() {
         {chainPanels.map((panel, idx) => {
           const label = shortLabelFor(panel.pluginId, panel.title);
           const isDragTarget = dragOverIndex === idx;
+          const isDragSource = draggedFromIdx === idx;
           return (
             <div key={panel.pluginId} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
               {idx > 0 && (
@@ -506,9 +559,11 @@ export function AudioSuiteWindow() {
                   padding: '4px 10px',
                   borderRadius: 3,
                   background: isDragTarget ? 'var(--accent)' : 'var(--bg-2)',
-                  border: '1px solid ' + (isDragTarget ? 'var(--accent)' : 'var(--line-1)'),
+                  border: '1px dashed ' + (isDragTarget ? 'var(--accent)' : 'var(--line-1)'),
+                  borderStyle: isDragSource ? 'dashed' : 'solid',
                   color: isDragTarget ? 'var(--fg-0)' : 'var(--fg-1)',
                   cursor: 'grab',
+                  opacity: isDragSource ? 0.4 : 1,
                   fontSize: 10,
                   fontWeight: 500,
                   userSelect: 'none',

--- a/zeus-web/src/components/AudioSuiteWindow.tsx
+++ b/zeus-web/src/components/AudioSuiteWindow.tsx
@@ -277,8 +277,13 @@ export function AudioSuiteWindow() {
       const dy = e.clientY - ds.startY;
       // Clamp so the header can't drag off-screen (always leave at
       // least 80px visible on every edge so the operator can grab it).
+      // minY = 64 keeps the header from sliding under the 60-px Zeus
+      // topbar — the operator must always have somewhere to grab to
+      // pull the window back down. zIndex on the window root puts us
+      // above the topbar visually anyway, but enforcing the clamp
+      // avoids covering the radio chrome unnecessarily.
       const minX = -width + 80;
-      const minY = 0;
+      const minY = 64;
       const maxX = window.innerWidth - 80;
       const maxY = window.innerHeight - 40;
       const nextX = Math.min(maxX, Math.max(minX, ds.offsetX + dx));
@@ -341,10 +346,19 @@ export function AudioSuiteWindow() {
       style={{
         position: 'fixed',
         left: x,
-        top: y,
+        // Render-time clamp on top so a persisted y < 64 (e.g. from a
+        // session before the topbar-clearance fix) doesn't ship the
+        // window under the topbar. The drag clamp prevents new drags
+        // from going there; this self-heals stuck stored positions on
+        // first render after upgrade.
+        top: Math.max(64, y),
         width,
         height,
-        zIndex: 60,
+        // Above the Zeus topbar (zIndex 300) so the operator's window
+        // is never hidden by app chrome. Below modal dialogs
+        // (AddPanelModal etc at zIndex 10000) so critical overlays
+        // still win.
+        zIndex: 400,
         display: 'flex',
         flexDirection: 'column',
         background: 'linear-gradient(180deg, var(--panel-top), var(--panel-bot))',

--- a/zeus-web/src/components/TxAudioToolsPanel.tsx
+++ b/zeus-web/src/components/TxAudioToolsPanel.tsx
@@ -18,45 +18,21 @@ import { CfcSettingsPanel } from './CfcSettingsPanel';
 import { DownloadAudioSuiteButton } from './DownloadAudioSuiteButton';
 import { usePluginPanels } from '../plugins/runtime/usePluginPanels';
 import type { RegisteredPluginPanel } from '../plugins/runtime/pluginRuntime';
+import { useAudioSuiteStore } from '../state/audio-suite-store';
 
 // ---------------------------------------------------------------
 // Audio-chain plugin slot — installed plugins whose manifest declares
-// `ui.panels[].slot === "tx-audio-tools.chain"` render here, in chain
-// order, above the always-on CFC section. The fixed v1 chain order is
-// per issue #332 Phase 0 (KB2UKA-locked 2026-05-17):
+// `ui.panels[].slot === "tx-audio-tools.chain"` are owned by the
+// Audio Suite floating window (Phase 2 of issue #332). The chain
+// flow strip here is a read-only one-glance view; the "Audio Suite"
+// button opens the floating window where plugins can be reordered
+// (drag-and-drop tiles), auditioned through the operator's headphones,
+// and tuned via their per-plugin panels stacked vertically.
 //
-//   EQ → Compressor → Exciter → Bass enhancer → Reverb → CFC
-//
-// Plugins not in this list (e.g. third-party chain blocks added later)
-// render after the known v1 blocks, sorted by panel id for determinism.
+// CFC stays below — it's WDSP-driven, ships in Zeus core (not as a
+// plugin), so it's not part of the reorderable chain.
 // ---------------------------------------------------------------
 const CHAIN_SLOT = 'tx-audio-tools.chain';
-
-const V1_CHAIN_ORDER: ReadonlyArray<string> = [
-  'com.openhpsdr.zeus.samples.eq',
-  'com.openhpsdr.zeus.samples.compressor',
-  'com.openhpsdr.zeus.samples.exciter',
-  'com.openhpsdr.zeus.samples.bass',
-  'com.openhpsdr.zeus.samples.reverb',
-];
-
-function chainPosition(pluginId: string): number {
-  const idx = V1_CHAIN_ORDER.indexOf(pluginId);
-  // Unknown plugins (third-party, future blocks) sort after the known v1
-  // set. Using +Infinity puts them at the bottom; the secondary sort by
-  // panel id then keeps them deterministic relative to each other.
-  return idx === -1 ? Number.POSITIVE_INFINITY : idx;
-}
-
-// Sort registered panels into the fixed v1 chain order.
-function sortChainPanels(panels: RegisteredPluginPanel[]): RegisteredPluginPanel[] {
-  return [...panels].sort((a, b) => {
-    const da = chainPosition(a.pluginId);
-    const db = chainPosition(b.pluginId);
-    if (da !== db) return da - db;
-    return a.panelId.localeCompare(b.panelId);
-  });
-}
 
 // ---------------------------------------------------------------
 // Master signal-flow strip — one-glance read of which chain blocks
@@ -120,40 +96,63 @@ function ChainFlow({ chainPanels }: { chainPanels: RegisteredPluginPanel[] }) {
           </span>
         </span>
       ))}
+      <AudioSuiteOpenButton />
       <DownloadAudioSuiteButton />
     </div>
   );
 }
 
+// Opens the Audio Suite floating window. Disabled (visually dimmed) when
+// no chain plugins are installed — there's nothing to show, and the
+// Download Audio Suite button to its right is the right action.
+function AudioSuiteOpenButton() {
+  const open = useAudioSuiteStore((s) => s.open);
+  return (
+    <button
+      type="button"
+      onClick={open}
+      style={{
+        marginLeft: 'auto',
+        padding: '4px 12px',
+        borderRadius: 4,
+        border: '1px solid var(--accent)',
+        background: 'var(--bg-2)',
+        color: 'var(--fg-0)',
+        cursor: 'pointer',
+        fontSize: 10,
+        fontWeight: 600,
+        letterSpacing: 1,
+        textTransform: 'uppercase',
+        fontFamily: 'var(--font-sans, Inter, system-ui, sans-serif)',
+      }}
+      title="Open the Audio Suite window to reorder, audition, and tune chain plugins"
+    >
+      Audio Suite
+    </button>
+  );
+}
+
 // ---------------------------------------------------------------
-// TxAudioToolsPanel — chain plugins above, CFC below.
+// TxAudioToolsPanel — chain-flow strip + CFC.
 //
-// Audio-chain plugins (issue #332) declare panel slot
-// `tx-audio-tools.chain`; we filter `usePluginPanels()` to that slot,
-// sort by the fixed v1 chain order, and render each plugin's component
-// inline. CFC stays at the bottom — it's WDSP-driven and ships in Zeus
-// core, not as a plugin, so it doesn't move.
+// Audio-chain plugins (issue #332, Phase 2 onward) live in the Audio
+// Suite floating window — click the "Audio Suite" button in the chain
+// strip header to open it. The strip here is purely informational:
+// one tile per known v1/v2 block showing whether it's installed, so
+// the operator can see at a glance what's loaded without opening the
+// window. CFC stays inline — it's WDSP-driven, ships in Zeus core,
+// and isn't part of the reorderable plugin chain.
 // ---------------------------------------------------------------
 export function TxAudioToolsPanel() {
   const allPanels = usePluginPanels();
   const chainPanels = useMemo(
-    () => sortChainPanels(allPanels.filter((p) => p.slot === CHAIN_SLOT)),
+    () => allPanels.filter((p) => p.slot === CHAIN_SLOT),
     [allPanels],
   );
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
       <ChainFlow chainPanels={chainPanels} />
-
-      {/* Chain plugins in v1 order. Empty until at least one is installed. */}
-      {chainPanels.map((panel) => {
-        const Component = panel.component;
-        return (
-          <div key={`${panel.pluginId}::${panel.panelId}`} data-plugin-id={panel.pluginId}>
-            <Component />
-          </div>
-        );
-      })}
 
       {/* CFC — WDSP-driven, always available, always last in the chain. */}
       <CfcSettingsPanel />

--- a/zeus-web/src/realtime/ws-client.ts
+++ b/zeus-web/src/realtime/ws-client.ts
@@ -146,6 +146,14 @@ const MIC_PCM_BYTES = 1 + MIC_PCM_SAMPLES * 4;
 export const MSG_TYPE_MIC_PEAK = 0x1d;
 const MIC_PEAK_BYTES = 1 + 4 + 8;
 
+// Audio Suite chain-order broadcast. Server pushes this whenever the
+// operator reorders the chain via the tile strip (any client), or
+// when a plugin is installed / uninstalled — so other connected
+// clients update their tile sequence without polling. Payload:
+// [0x1E][csvUtf8…] — comma-separated plugin IDs in chain order.
+// Contract: Zeus.Contracts/AudioChainOrderFrame.cs.
+export const MSG_TYPE_AUDIO_CHAIN_ORDER = 0x1e;
+
 // Shared by startRealtime / sendMicPcm. Single WS instance at a time; writes
 // are no-ops when the socket isn't open.
 let activeWs: WebSocket | null = null;
@@ -312,6 +320,20 @@ export function startRealtime(path = '/ws'): () => void {
           // clock we'll see).
           const tsUnixMs = Number(dv.getBigInt64(5, true));
           useMicPeakStore.getState().setPeak(peakDbfs, tsUnixMs);
+          return;
+        }
+        if (peekType === MSG_TYPE_AUDIO_CHAIN_ORDER) {
+          // Variable-length CSV payload — empty payload encodes the
+          // "no plugins installed" empty-chain case.
+          const bytes = new Uint8Array(ev.data, 1);
+          const csv = new TextDecoder('utf-8').decode(bytes);
+          const ids = csv.length === 0 ? [] : csv.split(',');
+          // Lazy import keeps the audio-suite-store out of the ws-client
+          // module graph for clients that never open the Audio Suite
+          // window (e.g. the no-plugins-installed first-run experience).
+          void import('../state/audio-suite-store').then((m) => {
+            m.useAudioSuiteStore.getState().setChainOrderFromServer(ids);
+          });
           return;
         }
         if (peekType === MSG_TYPE_PA_TEMP) {

--- a/zeus-web/src/state/audio-suite-store.ts
+++ b/zeus-web/src/state/audio-suite-store.ts
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Audio Suite window state — operator UI for the audio-plugin chain.
+//
+// What lives here:
+//   - Window open / closed flag (persisted across reloads).
+//   - Window position (x, y) + size — also persisted so the operator's
+//     "I put it over here" choice survives a refresh.
+//   - Chain order: the canonical ordered list of plugin IDs in the
+//     audio chain. Server is the source of truth (ChainOrderService);
+//     this store mirrors what the server publishes via the
+//     /api/plugins/chain/order REST endpoint and the AudioChainOrder
+//     (0x1E) WebSocket broadcast frame. The local store is NOT
+//     persisted to localStorage — on reload we fetch fresh from the
+//     server to avoid drift if the operator reorders on a second
+//     client (or a backend restart loaded a different order).
+//   - Audition state: whether the Audio Suite is mixing the plugin
+//     chain's output into the operator's RX playback path. Server
+//     state (IAuditionAudioSink.IsEnabled); store mirrors. Not
+//     persisted — defaults off on every fresh boot.
+//
+// What does NOT live here (handled elsewhere):
+//   - Per-plugin settings (bypass, knob positions) — owned by each
+//     plugin's own panel via its REST endpoint.
+//   - Chain meter values (IN/OUT/GR per plugin) — polled from each
+//     plugin's /meters endpoint inside its panel component.
+
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+/** Minimum window dimensions enforced on drag-resize. */
+export const AUDIO_SUITE_WINDOW_MIN_WIDTH = 480;
+export const AUDIO_SUITE_WINDOW_MIN_HEIGHT = 360;
+
+interface AudioSuiteState {
+  // Window placement
+  isOpen: boolean;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+
+  // Chain order — head = first in chain (processes mic first).
+  // Mirrored from the server; updated by:
+  //   (1) loadChainOrderFromServer() on window open
+  //   (2) AudioChainOrder WS broadcast (any client's reorder)
+  //   (3) reorderChain() local optimistic update before PUT
+  chainOrder: string[];
+
+  // Audition (desktop-only feature; server returns supported=false on
+  // browser mode and the toggle is disabled).
+  auditionSupported: boolean;
+  auditionEnabled: boolean;
+
+  // Drag state — transient, not persisted.
+  isDragging: boolean;
+
+  // Actions
+  open(): void;
+  close(): void;
+  toggle(): void;
+  setPosition(x: number, y: number): void;
+  setSize(width: number, height: number): void;
+  setDragging(on: boolean): void;
+
+  // Chain order plumbing.
+  setChainOrderFromServer(ids: string[]): void;
+  reorderChain(fromIndex: number, toIndex: number): Promise<void>;
+  loadChainOrderFromServer(): Promise<void>;
+
+  // Audition plumbing.
+  loadAuditionState(): Promise<void>;
+  setAuditionEnabled(enabled: boolean): Promise<void>;
+}
+
+// Default window placement — top-left quadrant, room for plugin panels.
+const DEFAULT_X = 80;
+const DEFAULT_Y = 80;
+const DEFAULT_WIDTH = 640;
+const DEFAULT_HEIGHT = 720;
+
+export const useAudioSuiteStore = create<AudioSuiteState>()(
+  persist(
+    (set, get) => ({
+      isOpen: false,
+      x: DEFAULT_X,
+      y: DEFAULT_Y,
+      width: DEFAULT_WIDTH,
+      height: DEFAULT_HEIGHT,
+      chainOrder: [],
+      auditionSupported: false,
+      auditionEnabled: false,
+      isDragging: false,
+
+      open: () => set({ isOpen: true }),
+      close: () => set({ isOpen: false }),
+      toggle: () => set((s) => ({ isOpen: !s.isOpen })),
+
+      setPosition: (x, y) => set({ x, y }),
+      setSize: (width, height) =>
+        set({
+          width: Math.max(AUDIO_SUITE_WINDOW_MIN_WIDTH, width),
+          height: Math.max(AUDIO_SUITE_WINDOW_MIN_HEIGHT, height),
+        }),
+      setDragging: (on) => set({ isDragging: on }),
+
+      setChainOrderFromServer: (ids) => set({ chainOrder: ids }),
+
+      reorderChain: async (fromIndex, toIndex) => {
+        const current = get().chainOrder;
+        if (
+          fromIndex < 0 ||
+          fromIndex >= current.length ||
+          toIndex < 0 ||
+          toIndex >= current.length ||
+          fromIndex === toIndex
+        ) {
+          return;
+        }
+        // Optimistic local update — the WS broadcast handler will
+        // reconcile if the server's persisted order ends up different
+        // (shouldn't happen for valid permutations). The non-null
+        // assertion on splice's return is safe because we already
+        // bounds-checked fromIndex above.
+        const next = current.slice();
+        const moved = next.splice(fromIndex, 1)[0]!;
+        next.splice(toIndex, 0, moved);
+        set({ chainOrder: next });
+
+        try {
+          const res = await fetch('/api/plugins/chain/order', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ pluginIds: next }),
+          });
+          if (!res.ok) {
+            // Roll back on server-side validation failure (e.g. set
+            // membership changed between our GET and PUT).
+            set({ chainOrder: current });
+            // eslint-disable-next-line no-console
+            console.warn(
+              `audio-suite chain-order PUT rejected: ${res.status} ${res.statusText}`,
+            );
+          }
+        } catch (err) {
+          set({ chainOrder: current });
+          // eslint-disable-next-line no-console
+          console.warn('audio-suite chain-order PUT threw', err);
+        }
+      },
+
+      loadChainOrderFromServer: async () => {
+        try {
+          const res = await fetch('/api/plugins/chain/order');
+          if (!res.ok) return;
+          const body = (await res.json()) as { pluginIds?: string[] };
+          if (Array.isArray(body.pluginIds)) {
+            set({ chainOrder: body.pluginIds });
+          }
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.warn('audio-suite chain-order GET threw', err);
+        }
+      },
+
+      loadAuditionState: async () => {
+        try {
+          const res = await fetch('/api/audio-suite/audition');
+          if (!res.ok) {
+            set({ auditionSupported: false, auditionEnabled: false });
+            return;
+          }
+          const body = (await res.json()) as {
+            supported?: boolean;
+            enabled?: boolean;
+          };
+          set({
+            auditionSupported: body.supported ?? false,
+            auditionEnabled: body.enabled ?? false,
+          });
+        } catch {
+          set({ auditionSupported: false, auditionEnabled: false });
+        }
+      },
+
+      setAuditionEnabled: async (enabled) => {
+        const prev = get().auditionEnabled;
+        // Optimistic update so the toggle feels instant.
+        set({ auditionEnabled: enabled });
+        try {
+          const res = await fetch('/api/audio-suite/audition', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ enabled }),
+          });
+          if (!res.ok) {
+            set({ auditionEnabled: prev });
+            // eslint-disable-next-line no-console
+            console.warn(
+              `audio-suite audition PUT rejected: ${res.status} ${res.statusText}`,
+            );
+          }
+        } catch (err) {
+          set({ auditionEnabled: prev });
+          // eslint-disable-next-line no-console
+          console.warn('audio-suite audition PUT threw', err);
+        }
+      },
+    }),
+    {
+      name: 'zeus-audio-suite',
+      // Persist only window placement + open flag. Chain order and
+      // audition state come from the server on every mount.
+      partialize: (s) => ({
+        isOpen: s.isOpen,
+        x: s.x,
+        y: s.y,
+        width: s.width,
+        height: s.height,
+      }),
+    },
+  ),
+);


### PR DESCRIPTION
## Summary
Audio chain v2 **Phase 2**. Builds on the Phase 1 live pre-MOX meter tap (#390, already merged) and gives operators a draggable Audio Suite window with reorderable plugin tiles. KB2UKA bench-confirmed on G2: rebased onto current develop, EQ/Bass/Exciter/Reverb v0.2.0 + NoiseGate v0.1.0 + Compressor all attach, persistence holds across desktop restart.

## What's in the 5 commits

### \`e2ac353\` — ChainOrderService + persistence + REST + broadcast (backend)
- New \`ChainOrderStore\` (LiteDB single-row, sibling of PsSettingsStore pattern) persists canonical chain order.
- New \`ChainOrderService\` — canonical vs. runtime separation (canonical preserves position of uninstalled plugins, runtime is canonical filtered to currently-attached set). Raises \`OrderChanged\` event.
- \`AudioPluginBridge\` subscribes to \`OrderChanged\` and re-slots \`AudioChain\` under its existing \`_lock\`.
- REST: \`GET / PUT /api/plugins/chain/order\`.
- New wire frame \`AudioChainOrderFrame\` (\`MsgType.AudioChainOrder = 0x1E\`, CSV plugin-IDs, 1 KiB cap) — broadcast on every order change.
- DI registration in \`ZeusHost.cs\`.
- 12 backend tests + 5 contract tests.

### \`9cdbc44\` — draggable window + reorderable tiles + audition (frontend)
- New \`audio-suite-store.ts\` (Zustand + persist) — window x/y/width/height persisted client-side; chain order + audition state from server.
- New \`AudioSuiteWindow.tsx\` — draggable floating window opened from \`TxAudioToolsPanel\` Audio Suite button. Vertical stack of plugin panels; reorderable HTML5 D&D tile strip at top; audition toggle.
- \`TxAudioToolsPanel.tsx\` — removed inline chain plugin rendering (now in window); kept chain-flow strip + CFC + Download Audio Suite button.
- \`ws-client.ts\` — handler for \`MsgType 0x1E\` decodes CSV and updates the store.

### \`92ee713\` — canonical-vs-runtime tile reorder fix
Original bug: server seeded \`_order\` with 8-entry v2 default but only 5 plugins installed; GET returned all 8; frontend rendered 5 tiles but spliced against the 8-entry array, clobbering uninstalled entries; PUT validated as non-permutation; server rolled back; UI looked broken.

Fix: \`ChainOrderService\` splits canonical (persisted, position-preserves uninstalled) from \`_attached\` (currently-loaded set). \`CurrentOrder\` / GET / WS all return runtime view. \`TrySetOrder\` validates body == attached set, merges by position-replacement back into canonical so uninstalled entries keep their slot. Signal-flow proof test: \`(x+1)*2\` vs \`x*2+1\` confirms reorder changes actual DSP.

### \`321c207\` — keep window above Zeus topbar + reachable from drag
- \`zIndex 60 → 400\` (above topbar 300, below modals 10000).
- Drag clamp \`minY 0 → 64\` (topbar is 60 px); render-time \`top: Math.max(64, y)\` self-heals stuck persisted positions.

### \`f56b768\` — final polish
- 8 edge/corner resize handles (Pointer Events with capture); corner handles get faint L-shaped border hints.
- Source tile dims to 0.4 opacity + dashed border during drag.
- Escape key closes window.
- Viewport-resize listener re-clamps window position so a shrinking browser can't trap it.

## Test plan
- [x] Rebased clean onto current develop (Phase 1 + #387 persistence + #382 EQ URL all already merged).
- [x] \`npm --prefix zeus-web run build\` — clean, single chunk warning on size unchanged.
- [x] Desktop launches with all 6 audio plugins attaching.
- [x] **KB2UKA bench-confirmed end-to-end** on his G2: EQ visible, audio chain functioning, persistence survives desktop restart.
- [x] Backend tests pass (\`ChainOrderService\`, \`AudioPluginBridge\` re-slot, signal-flow proof).

## Related
- Phase 1 #390 (live pre-MOX meter tap) — already on develop, foundation for the audition path here
- #387 (plugin settings persistence) — fixed the LiteDB upsert bug that bit operator dial-in last night; Phase 2's chain-order persistence is unaffected (different store, same fix shape was correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)