### PR TITLE
fix(audio-suite): lint errors from #391 (no-empty + no-case-declarations)

### DIFF
--- a/zeus-web/src/components/AudioSuiteWindow.tsx
+++ b/zeus-web/src/components/AudioSuiteWindow.tsx
@@ -152,7 +152,7 @@ function ResizeHandle({ edge }: { edge: ResizeEdge }) {
     (e: React.PointerEvent<HTMLDivElement>) => {
       const d = dragRef.current;
       if (!d || d.pointerId !== e.pointerId) return;
-      try { e.currentTarget.releasePointerCapture(e.pointerId); } catch {}
+      try { e.currentTarget.releasePointerCapture(e.pointerId); } catch { /* release after capture is best-effort */ }
       dragRef.current = null;
     },
     [],
@@ -187,10 +187,11 @@ function shortLabelFor(pluginId: string, panelTitle: string): string {
     case 'com.openhpsdr.zeus.samples.exciter':    return 'EXCITER';
     case 'com.openhpsdr.zeus.samples.bass':       return 'BASS';
     case 'com.openhpsdr.zeus.samples.reverb':     return 'REVERB';
-    default:
+    default: {
       if (panelTitle && panelTitle.length > 0) return panelTitle.toUpperCase();
       const seg = pluginId.split('.').pop() ?? pluginId;
       return seg.toUpperCase().slice(0, 8);
+    }
   }
 }
 
@@ -338,7 +339,7 @@ export function AudioSuiteWindow() {
     (e: React.PointerEvent<HTMLDivElement>) => {
       const ds = dragStateRef.current;
       if (!ds || ds.pointerId !== e.pointerId) return;
-      try { e.currentTarget.releasePointerCapture(e.pointerId); } catch {}
+      try { e.currentTarget.releasePointerCapture(e.pointerId); } catch { /* release after capture is best-effort */ }
       dragStateRef.current = null;
       setDragging(false);
     },


### PR DESCRIPTION
## Summary
The Lint frontend job has been red on develop since PR #391 (Phase 2 audio-suite) merged. ESLint flagged 3 errors in \`zeus-web/src/components/AudioSuiteWindow.tsx\`:

| Line | Rule | Problem |
|---|---|---|
| 155:73 | \`no-empty\` | empty \`catch {}\` on \`releasePointerCapture\` |
| 192:7  | \`no-case-declarations\` | \`const seg\` declared inside a switch \`default:\` case without braces |
| 341:73 | \`no-empty\` | second empty \`catch {}\` on \`releasePointerCapture\` |

These cascaded through PR #392 too (same lint job runs the whole repo).

## Fix
- Both empty catches now carry a one-line comment explaining the best-effort intent of \`releasePointerCapture\` (per the Pointer Events spec it can throw if the capture has already been released — silently swallowing is correct behaviour, the comment satisfies \`no-empty\`).
- The switch's \`default\` case wraps its lexical declaration in braces.

## Verify
- [x] \`npm run lint\` locally — 0 errors, 17 warnings (all pre-existing).
- Build test job should now go green on both ubuntu-latest and macos-latest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)