### PR TITLE
feat(plugins+installer): restart modal on every plugin install + icon labels OpenHPSDR Zeus

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -556,12 +556,12 @@ jobs:
           ### macOS (Apple Silicon)
           - **OpenhpsdrZeus-${{ steps.version.outputs.version }}-macos-arm64.dmg**
 
-          Drag **both** `Zeus.app` and `Zeus Server.app` to Applications.
-          Double-clicking `Zeus.app` opens the Photino desktop window;
-          double-clicking `Zeus Server.app` runs the backend with a small
+          Drag **both** `OpenHPSDR Zeus.app` and `OpenHPSDR Zeus Server.app` to Applications.
+          Double-clicking `OpenHPSDR Zeus.app` opens the Photino desktop window;
+          double-clicking `OpenHPSDR Zeus Server.app` runs the backend with a small
           status window showing the LAN URLs and a Stop Zeus button.
-          `Zeus Server.app` is a thin wrapper — drag both, or drag just
-          `Zeus.app` if you only want the desktop window.
+          `OpenHPSDR Zeus Server.app` is a thin wrapper — drag both, or drag just
+          `OpenHPSDR Zeus.app` if you only want the desktop window.
 
           Intel Mac builds are no longer published — the `macos-13` runner queue
           on GitHub-hosted Actions is too slow to be practical. Build from source
@@ -571,8 +571,8 @@ jobs:
           attribute so Gatekeeper lets Zeus launch:
 
           ```bash
-          xattr -cr /Applications/Zeus.app
-          xattr -cr "/Applications/Zeus Server.app"
+          xattr -cr "/Applications/OpenHPSDR Zeus.app"
+          xattr -cr "/Applications/OpenHPSDR Zeus Server.app"
           ```
 
           This is required because Zeus is not signed by a registered Apple

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ see the corresponding GitHub Release page.
 - **Render tx-audio-tools.chain plugins above CFC** (#373). Audio Suite plugins surface in their own region above the WDSP CFC strip on the TX Audio Tools panel.
 - **One-click Download Audio Suite installer button** (#376). Drops EQ + Compressor + Exciter + Bass + Reverb in a single click via the official Kb2uka plugin registry.
 - **Plugin-settings persistence fix** (#387). LiteDB upsert-by-`_id` bug was silently inserting new rows on every `SetAsync` instead of updating — operator dial-in could revert to defaults across desktop restarts. Now: atomic delete-by-key + insert, with descending-ID read so any pre-fix duplicates resolve to the latest value.
+- **Restart-required modal on every plugin install.** The "Please shut down Zeus and restart" dialog that previously fired only after the Download Audio Suite bundle install now also fires after a single-plugin install from the Plugins panel (Settings → Plugins → Browse / Install). New endpoints + AssemblyLoadContexts only register at backend startup, so the operator always gets the same explicit reminder.
 
 ### Added — plugins shipping with this release (Kb2uka/openhpsdr-zeus-plugins)
 

--- a/README.md
+++ b/README.md
@@ -75,13 +75,14 @@ page.
 
 ### macOS users — read this before launching
 
-> **⚠️ IMPORTANT: After installing on macOS, run this in Terminal before opening Zeus:**
+> **⚠️ IMPORTANT: After installing on macOS, run these in Terminal before opening Zeus:**
 >
 > ```bash
-> xattr -cr /Applications/Zeus.app
+> xattr -cr "/Applications/OpenHPSDR Zeus.app"
+> xattr -cr "/Applications/OpenHPSDR Zeus Server.app"
 > ```
 >
-> **Without this step, macOS Gatekeeper will refuse to launch Zeus** ("Zeus.app is damaged and can't be opened" or "cannot be opened because the developer cannot be verified"). Zeus is not yet signed by a registered Apple Developer; the command above strips the quarantine attribute so Gatekeeper allows the app to run. This is a one-time step per install.
+> **Without this step, macOS Gatekeeper will refuse to launch Zeus** ("OpenHPSDR Zeus.app is damaged and can't be opened" or "cannot be opened because the developer cannot be verified"). Zeus is not yet signed by a registered Apple Developer; the command above strips the quarantine attribute so Gatekeeper allows the app to run. This is a one-time step per install. Skip the second line if you only installed the desktop app.
 
 ## Building from source
 

--- a/installers/create-linux-desktop-appimage.sh
+++ b/installers/create-linux-desktop-appimage.sh
@@ -83,7 +83,7 @@ fi
 cat > "${APPDIR}/zeus.desktop" << EOF
 [Desktop Entry]
 Type=Application
-Name=Openhpsdr Zeus
+Name=OpenHPSDR Zeus
 GenericName=OpenHPSDR SDR Client
 Comment=Cross-platform HPSDR client (Protocol-1 / Protocol-2)
 Exec=OpenhpsdrZeus --desktop
@@ -191,7 +191,7 @@ chmod +x "${SERVER_APPDIR}/AppRun"
 cat > "${SERVER_APPDIR}/zeus.desktop" << EOF
 [Desktop Entry]
 Type=Application
-Name=Openhpsdr Zeus Server
+Name=OpenHPSDR Zeus Server
 GenericName=OpenHPSDR SDR Backend
 Comment=LAN-bound HPSDR backend with status window and Stop button
 Exec=OpenhpsdrZeus --server

--- a/installers/create-linux-package.sh
+++ b/installers/create-linux-package.sh
@@ -171,7 +171,7 @@ chmod +x "${PACKAGE_DIR}/openhpsdr-zeus-server"
 cat > "${PACKAGE_DIR}/zeus-desktop.desktop" << 'EOF'
 [Desktop Entry]
 Type=Application
-Name=Zeus
+Name=OpenHPSDR Zeus
 Comment=OpenHPSDR Protocol 1 / Protocol 2 SDR client (native window)
 Exec=__ZEUS_DIR__/openhpsdr-zeus-desktop
 Icon=__ZEUS_DIR__/zeus.png
@@ -183,7 +183,7 @@ EOF
 cat > "${PACKAGE_DIR}/zeus-server.desktop" << 'EOF'
 [Desktop Entry]
 Type=Application
-Name=Zeus Server
+Name=OpenHPSDR Zeus Server
 Comment=OpenHPSDR Zeus backend with status window and Stop button
 Exec=__ZEUS_DIR__/openhpsdr-zeus-server
 Icon=__ZEUS_DIR__/zeus.png

--- a/installers/create-macos-app.sh
+++ b/installers/create-macos-app.sh
@@ -34,7 +34,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 PUBLISH_DIR="${REPO_ROOT}/OpenhpsdrZeus/bin/Release/net10.0/osx-${ARCH}/publish"
 OUTPUT_DIR="${SCRIPT_DIR}/output"
-APP_NAME="Zeus.app"
+APP_NAME="OpenHPSDR Zeus.app"
 APP_BUNDLE="${OUTPUT_DIR}/${APP_NAME}"
 ICON_SOURCE="${REPO_ROOT}/docs/pics/zeus.png"
 
@@ -111,9 +111,9 @@ cat > "${APP_BUNDLE}/Contents/Info.plist" << EOF
     <key>CFBundleIdentifier</key>
     <string>com.ei6lf.zeus</string>
     <key>CFBundleName</key>
-    <string>Zeus</string>
+    <string>OpenHPSDR Zeus</string>
     <key>CFBundleDisplayName</key>
-    <string>Zeus</string>
+    <string>OpenHPSDR Zeus</string>
     <key>CFBundleShortVersionString</key>
     <string>${VERSION}</string>
     <key>CFBundleVersion</key>
@@ -180,8 +180,8 @@ chmod +x "${APP_BUNDLE}/Contents/MacOS/launch.sh"
 # LaunchServices — it's a CLI tool, not the app's main executable.
 cat > "${APP_BUNDLE}/Contents/Resources/openhpsdr-zeus-server" << 'EOF'
 #!/bin/bash
-# Run Openhpsdr Zeus in server mode (LAN-bound HTTP on :6060).
-# Usage: /Applications/Zeus.app/Contents/Resources/openhpsdr-zeus-server
+# Run OpenHPSDR Zeus in server mode (LAN-bound HTTP on :6060).
+# Usage: "/Applications/OpenHPSDR Zeus.app/Contents/Resources/openhpsdr-zeus-server"
 APP_MACOS_DIR="$(cd "$(dirname "$0")/../MacOS" && pwd)"
 cd "${APP_MACOS_DIR}"
 export DYLD_LIBRARY_PATH="${APP_MACOS_DIR}/runtimes/osx-arm64/native:${APP_MACOS_DIR}/runtimes/osx-x64/native:${DYLD_LIBRARY_PATH}"
@@ -202,7 +202,7 @@ echo "App bundle created at ${APP_BUNDLE}"
 # /Applications. The wrapper requires Zeus.app to live at /Applications/
 # Zeus.app — the launch.sh shows an osascript dialog if it isn't there,
 # matching the drag-to-install model on the DMG window.
-SERVER_APP_NAME="Zeus Server.app"
+SERVER_APP_NAME="OpenHPSDR Zeus Server.app"
 SERVER_APP_BUNDLE="${OUTPUT_DIR}/${SERVER_APP_NAME}"
 rm -rf "${SERVER_APP_BUNDLE}"
 mkdir -p "${SERVER_APP_BUNDLE}/Contents/MacOS"
@@ -230,9 +230,9 @@ cat > "${SERVER_APP_BUNDLE}/Contents/Info.plist" << EOF
     <key>CFBundleIdentifier</key>
     <string>com.ei6lf.zeus.server</string>
     <key>CFBundleName</key>
-    <string>Zeus Server</string>
+    <string>OpenHPSDR Zeus Server</string>
     <key>CFBundleDisplayName</key>
-    <string>Zeus Server</string>
+    <string>OpenHPSDR Zeus Server</string>
     <key>CFBundleShortVersionString</key>
     <string>${VERSION}</string>
     <key>CFBundleVersion</key>
@@ -267,9 +267,9 @@ EOF
 # when the user only dragged Zeus Server.app from the DMG.
 cat > "${SERVER_APP_BUNDLE}/Contents/MacOS/launch.sh" << 'EOF'
 #!/bin/bash
-ZEUS_APP="/Applications/Zeus.app"
+ZEUS_APP="/Applications/OpenHPSDR Zeus.app"
 if [ ! -d "${ZEUS_APP}" ]; then
-    osascript -e 'display dialog "Zeus.app must be installed in /Applications first. Drag Zeus.app from the DMG to your Applications folder, then try Zeus Server again." with title "Zeus Server" with icon caution buttons {"OK"} default button "OK"' >/dev/null 2>&1
+    osascript -e 'display dialog "OpenHPSDR Zeus.app must be installed in /Applications first. Drag OpenHPSDR Zeus.app from the DMG to your Applications folder, then try OpenHPSDR Zeus Server again." with title "OpenHPSDR Zeus Server" with icon caution buttons {"OK"} default button "OK"' >/dev/null 2>&1
     exit 1
 fi
 APP_MACOS_DIR="${ZEUS_APP}/Contents/MacOS"
@@ -329,25 +329,27 @@ cp -R "${SERVER_APP_BUNDLE}" "${DMG_TEMP}/"
 ln -s /Applications "${DMG_TEMP}/Applications"
 
 cat > "${DMG_TEMP}/README.txt" << 'EOF'
-Openhpsdr Zeus for macOS
+OpenHPSDR Zeus for macOS
 ========================
 
 INSTALL
-  Drag BOTH Zeus.app and Zeus Server.app onto the Applications shortcut
-  in this window. Zeus Server.app is a small wrapper around Zeus.app
-  and won't work without Zeus.app installed.
+  Drag BOTH "OpenHPSDR Zeus.app" and "OpenHPSDR Zeus Server.app" onto
+  the Applications shortcut in this window. "OpenHPSDR Zeus Server.app"
+  is a small wrapper around "OpenHPSDR Zeus.app" and won't work without
+  "OpenHPSDR Zeus.app" installed.
 
-  If you only want the desktop app, dragging Zeus.app alone is fine.
+  If you only want the desktop app, dragging "OpenHPSDR Zeus.app" alone
+  is fine.
 
 FIRST LAUNCH (important — Zeus is not signed)
   Zeus is distributed without an Apple Developer ID, so macOS Gatekeeper
   will block it on first launch. To clear the quarantine flag, open
   Terminal and run:
 
-      xattr -cr /Applications/Zeus.app
-      xattr -cr "/Applications/Zeus Server.app"
+      xattr -cr "/Applications/OpenHPSDR Zeus.app"
+      xattr -cr "/Applications/OpenHPSDR Zeus Server.app"
 
-  Then launch Zeus from Applications.
+  Then launch from Applications.
 
   If you still see a security warning, go to:
       System Settings -> Privacy & Security
@@ -355,28 +357,29 @@ FIRST LAUNCH (important — Zeus is not signed)
 
 THE TWO ICONS
 
-  Zeus.app           Full native window. The radio backend runs
-                     in-process inside the same window. Closing the
-                     window stops Zeus completely. This is the right
-                     choice for most operators.
+  OpenHPSDR Zeus         Full native window. The radio backend runs
+                         in-process inside the same window. Closing the
+                         window stops Zeus completely. This is the right
+                         choice for most operators.
 
-  Zeus Server.app    Backend-only mode for LAN / remote / phone access.
-                     Opens a small status window showing the URLs to
-                     connect to from a browser, with a Stop Zeus button.
-                     Connect from this Mac at http://localhost:6060 or
-                     from another device at http://<your-mac>:6060.
-                     HTTPS uses a self-signed certificate — accept the
-                     browser warning on first connect.
+  OpenHPSDR Zeus Server  Backend-only mode for LAN / remote / phone
+                         access. Opens a small status window showing
+                         the URLs to connect to from a browser, with a
+                         Stop Zeus button. Connect from this Mac at
+                         http://localhost:6060 or from another device
+                         at http://<your-mac>:6060. HTTPS uses a
+                         self-signed certificate — accept the browser
+                         warning on first connect.
 
 HEADLESS / CLI USE
   If you're running Zeus on a headless Mac (no display, e.g. an mac mini
   in a closet), use Terminal:
 
-      /Applications/Zeus.app/Contents/MacOS/OpenhpsdrZeus
+      "/Applications/OpenHPSDR Zeus.app/Contents/MacOS/OpenhpsdrZeus"
 
-  This is the no-window service mode. Identical to Zeus Server.app's
-  backend but without the status window. Closing the Terminal (or
-  Ctrl-C) stops the server.
+  This is the no-window service mode. Identical to OpenHPSDR Zeus
+  Server's backend but without the status window. Closing the Terminal
+  (or Ctrl-C) stops the server.
 
 FIRST RUN — WDSP WISDOM
   The first launch builds an FFTW "wisdom" cache and can take 1-3
@@ -396,4 +399,5 @@ rm -rf "${DMG_TEMP}"
 echo "DMG created at ${DMG_PATH}"
 echo
 echo "NOTE: users must clear the quarantine flag on first launch:"
-echo "  xattr -cr /Applications/Zeus.app"
+echo "  xattr -cr \"/Applications/OpenHPSDR Zeus.app\""
+echo "  xattr -cr \"/Applications/OpenHPSDR Zeus Server.app\""

--- a/installers/zeus-windows.iss
+++ b/installers/zeus-windows.iss
@@ -6,8 +6,8 @@
 ; default (LAN HTTP on :6060, browser-driven UI) and desktop mode when
 ; invoked with --desktop (Photino native window, loopback only).
 
-#define MyAppName "Openhpsdr Zeus"
-#define MyAppShortName "Zeus"
+#define MyAppName "OpenHPSDR-Zeus"
+#define MyAppShortName "OpenHPSDR-Zeus"
 #define MyAppPublisher "Brian Keating (EI6LF) and contributors"
 #define MyAppURL "https://github.com/brianbruff/openhpsdr-zeus"
 #define MyAppExeName "OpenhpsdrZeus.exe"

--- a/zeus-web/src/components/DownloadAudioSuiteButton.tsx
+++ b/zeus-web/src/components/DownloadAudioSuiteButton.tsx
@@ -15,6 +15,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { installPlugin } from '../plugins/api/plugins';
 import { fetchInstalledPlugins } from '../plugins/api/plugins';
 import type { PluginDto } from '../plugins/api/plugins';
+import { RestartRequiredModal } from './RestartRequiredModal';
 
 interface SuitePlugin {
   /** Manifest id — used to detect "already installed". */
@@ -241,111 +242,5 @@ export function DownloadAudioSuiteButton() {
   );
 }
 
-// ---------------------------------------------------------------
-// RestartRequiredModal — operator-acknowledged dialog. We don't
-// auto-restart Zeus; the operator closes the app and re-launches.
-// Plugin endpoints + AssemblyLoadContexts only register at backend
-// startup, so a restart is the only way to bring fresh installs
-// into the live process.
-// ---------------------------------------------------------------
-function RestartRequiredModal({
-  installed,
-  skipped,
-  errors,
-  onClose,
-}: {
-  installed: number;
-  skipped: number;
-  errors: number;
-  onClose: () => void;
-}) {
-  return (
-    <div
-      className="modal-backdrop"
-      style={{
-        position: 'fixed',
-        inset: 0,
-        background: 'rgba(0, 0, 0, 0.7)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        zIndex: 10000,
-      }}
-      onClick={onClose}
-    >
-      <div
-        onClick={(e) => e.stopPropagation()}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="restart-required-title"
-        style={{
-          maxWidth: 460,
-          width: '90vw',
-          padding: 20,
-          background: 'linear-gradient(180deg, var(--panel-top), var(--panel-bot))',
-          border: '1px solid var(--line-1)',
-          borderRadius: 8,
-          color: 'var(--fg-0)',
-          fontFamily: 'var(--font-sans, Inter, system-ui, sans-serif)',
-          boxShadow: 'inset 0 2px 0 var(--power), inset 0 3px 8px rgba(255, 201, 58, 0.08), 0 10px 30px rgba(0, 0, 0, 0.55)',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 14,
-        }}
-      >
-        <h2
-          id="restart-required-title"
-          style={{
-            margin: 0,
-            fontSize: 14,
-            fontWeight: 600,
-            letterSpacing: 1.5,
-            textTransform: 'uppercase',
-            color: 'var(--fg-0)',
-            textShadow: '0 0 8px rgba(255, 201, 58, 0.18)',
-          }}
-        >
-          Restart required
-        </h2>
-
-        <p style={{ margin: 0, fontSize: 13, color: 'var(--fg-1)', lineHeight: 1.5 }}>
-          Please shut down Zeus and restart for the new plugins to take effect.
-        </p>
-
-        <div style={{
-          padding: '8px 12px',
-          background: 'var(--bg-1)',
-          border: '1px solid var(--line-1)',
-          borderRadius: 4,
-          fontSize: 11,
-          fontFamily: 'var(--font-mono, JetBrains Mono, ui-monospace, monospace)',
-          color: 'var(--fg-2)',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 4,
-        }}>
-          <div>installed: <span style={{ color: 'var(--fg-0)' }}>{installed}</span></div>
-          {skipped > 0 && <div>already present: <span style={{ color: 'var(--fg-0)' }}>{skipped}</span></div>}
-          {errors > 0 && <div style={{ color: 'var(--tx)' }}>failed: {errors}</div>}
-        </div>
-
-        <p style={{ margin: 0, fontSize: 11, color: 'var(--fg-3)', lineHeight: 1.4 }}>
-          New plugin endpoints and audio-chain blocks only register at backend
-          startup. After Zeus relaunches you'll see the new blocks in the TX
-          chain above.
-        </p>
-
-        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
-          <button
-            type="button"
-            className="btn sm active"
-            autoFocus
-            onClick={onClose}
-          >
-            OK
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
+// (RestartRequiredModal extracted to ./RestartRequiredModal.tsx so the
+// Plugins panel's single-plugin install flow can show the same dialog.)

--- a/zeus-web/src/components/RestartRequiredModal.tsx
+++ b/zeus-web/src/components/RestartRequiredModal.tsx
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// RestartRequiredModal — shared "you need to restart Zeus" dialog
+// surfaced after any successful plugin install (Audio Suite bundle
+// download, single-plugin install from the Plugins panel registry,
+// or future install-by-URL flows).
+//
+// Plugin endpoints + AssemblyLoadContexts only register at backend
+// startup, so a restart is the only way to bring fresh installs into
+// the live process. The modal is operator-acknowledged — we never
+// auto-restart Zeus.
+//
+// Counts (installed / skipped / errors) are optional because the
+// single-plugin install path doesn't have a meaningful skipped/errors
+// figure. When the bundle-install path passes them, they render as a
+// monospaced status block; otherwise the modal is just the headline +
+// the explanatory text.
+
+interface RestartRequiredModalProps {
+    installed?: number;
+    skipped?: number;
+    errors?: number;
+    /**
+     * Optional single-plugin display name (e.g. "Noise Gate v0.1.0").
+     * Used when the bundle counts aren't meaningful (registry-card
+     * install of one plugin); rendered in the body instead of the
+     * counts block.
+     */
+    pluginDisplayName?: string;
+    onClose: () => void;
+}
+
+export function RestartRequiredModal({
+    installed,
+    skipped,
+    errors,
+    pluginDisplayName,
+    onClose,
+}: RestartRequiredModalProps) {
+    const hasCounts = typeof installed === 'number';
+
+    return (
+        <div
+            className="modal-backdrop"
+            style={{
+                position: 'fixed',
+                inset: 0,
+                background: 'rgba(0, 0, 0, 0.7)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                zIndex: 10000,
+            }}
+            onClick={onClose}
+        >
+            <div
+                onClick={(e) => e.stopPropagation()}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="restart-required-title"
+                style={{
+                    maxWidth: 460,
+                    width: '90vw',
+                    padding: 20,
+                    background: 'linear-gradient(180deg, var(--panel-top), var(--panel-bot))',
+                    border: '1px solid var(--line-1)',
+                    borderRadius: 8,
+                    color: 'var(--fg-0)',
+                    fontFamily: 'var(--font-sans, Inter, system-ui, sans-serif)',
+                    boxShadow: 'inset 0 2px 0 var(--power), inset 0 3px 8px rgba(255, 201, 58, 0.08), 0 10px 30px rgba(0, 0, 0, 0.55)',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 14,
+                }}
+            >
+                <h2
+                    id="restart-required-title"
+                    style={{
+                        margin: 0,
+                        fontSize: 14,
+                        fontWeight: 600,
+                        letterSpacing: 1.5,
+                        textTransform: 'uppercase',
+                        color: 'var(--fg-0)',
+                        textShadow: '0 0 8px rgba(255, 201, 58, 0.18)',
+                    }}
+                >
+                    Restart required
+                </h2>
+
+                <p style={{ margin: 0, fontSize: 13, color: 'var(--fg-1)', lineHeight: 1.5 }}>
+                    Please shut down Zeus and restart for the new plugins to take effect.
+                </p>
+
+                {hasCounts ? (
+                    <div style={{
+                        padding: '8px 12px',
+                        background: 'var(--bg-1)',
+                        border: '1px solid var(--line-1)',
+                        borderRadius: 4,
+                        fontSize: 11,
+                        fontFamily: 'var(--font-mono, JetBrains Mono, ui-monospace, monospace)',
+                        color: 'var(--fg-2)',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: 4,
+                    }}>
+                        <div>installed: <span style={{ color: 'var(--fg-0)' }}>{installed}</span></div>
+                        {skipped !== undefined && skipped > 0 && (
+                            <div>already present: <span style={{ color: 'var(--fg-0)' }}>{skipped}</span></div>
+                        )}
+                        {errors !== undefined && errors > 0 && (
+                            <div style={{ color: 'var(--tx)' }}>failed: {errors}</div>
+                        )}
+                    </div>
+                ) : pluginDisplayName ? (
+                    <div style={{
+                        padding: '8px 12px',
+                        background: 'var(--bg-1)',
+                        border: '1px solid var(--line-1)',
+                        borderRadius: 4,
+                        fontSize: 11,
+                        fontFamily: 'var(--font-mono, JetBrains Mono, ui-monospace, monospace)',
+                        color: 'var(--fg-0)',
+                    }}>
+                        installed: {pluginDisplayName}
+                    </div>
+                ) : null}
+
+                <p style={{ margin: 0, fontSize: 11, color: 'var(--fg-3)', lineHeight: 1.4 }}>
+                    New plugin endpoints and audio-chain blocks only register at backend
+                    startup. After Zeus relaunches you'll see the new plugins in the chain
+                    and in the Plugins panel above.
+                </p>
+
+                <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+                    <button
+                        type="button"
+                        className="btn sm active"
+                        autoFocus
+                        onClick={onClose}
+                    >
+                        OK
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/zeus-web/src/plugins/components/PluginBrowser.tsx
+++ b/zeus-web/src/plugins/components/PluginBrowser.tsx
@@ -5,13 +5,14 @@
 // categories and verified-by-Zeus badge. The Install button posts
 // { source: "registry", id, version } to the install endpoint.
 
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { usePluginsStore } from '../state/plugins-store';
 import type {
   RegistryPluginEntry,
   RegistryPluginVersion,
 } from '../api/plugins';
+import { RestartRequiredModal } from '../../components/RestartRequiredModal';
 
 function latestVersion(
   entry: RegistryPluginEntry,
@@ -89,13 +90,25 @@ function RegistryCard({
   const latest = useMemo(() => latestVersion(entry), [entry]);
   const alreadyInstalled = installedIds.has(entry.id);
 
-  const onInstall = () => {
+  // Restart-required modal — fires after a successful install of THIS
+  // card's plugin. The plugin host registers new endpoints +
+  // AssemblyLoadContexts only at backend startup, so the operator has
+  // to restart Zeus to bring the new install into the live process.
+  // Same modal the Download Audio Suite bundle install uses.
+  const [restartModalOpen, setRestartModalOpen] = useState(false);
+  const [installedDisplayName, setInstalledDisplayName] = useState<string | null>(null);
+
+  const onInstall = async () => {
     if (!latest || installing) return;
-    void install({
+    const dto = await install({
       source: 'registry',
       id: entry.id,
       version: latest.version,
     });
+    if (dto) {
+      setInstalledDisplayName(`${dto.name} v${dto.version}`);
+      setRestartModalOpen(true);
+    }
   };
 
   return (
@@ -183,6 +196,12 @@ function RegistryCard({
           SDK ABI v{latest.sdkAbi} · min v{latest.sdkMinVersion} · platforms{' '}
           {latest.platforms.join(', ')}
         </div>
+      )}
+      {restartModalOpen && (
+        <RestartRequiredModal
+          pluginDisplayName={installedDisplayName ?? entry.name}
+          onClose={() => setRestartModalOpen(false)}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
Two operator-visible polish changes layered on top of v0.8.0 — to be re-rolled into the v0.8.0 draft release.

### 1. Restart-required modal extends to single-plugin installs
The "Please shut down Zeus and restart" dialog previously fired only after a Download Audio Suite bundle install. **Now it also fires after each successful install from Settings → Plugins → Browse**, so an operator never wonders why their freshly-installed plugin isn't showing up. New endpoints + AssemblyLoadContexts only register at backend startup; the modal is the explicit acknowledgement.

- Extracted \`RestartRequiredModal\` to its own component file. Counts are now optional; single-plugin path passes \`pluginDisplayName\` instead of \`installed/skipped/errors\`.
- \`PluginBrowser\` RegistryCard awaits \`install()\` and opens the modal on success, surfacing the installed name + version.
- \`DownloadAudioSuiteButton\` now imports from the shared file (no behavioural change to the bundle install flow).

### 2. Icon labels renamed "Zeus" → "OpenHPSDR Zeus"
Both icons across Windows / macOS / Linux now read **OpenHPSDR Zeus** and **OpenHPSDR Zeus Server**. macOS bundle filenames also rename to \`OpenHPSDR Zeus.app\` / \`OpenHPSDR Zeus Server.app\` so Finder, Cmd-Tab, Dock, and Spotlight all show the operator-visible brand. The Zeus Server.app wrapper's hard-coded \`/Applications/Zeus.app\` lookup is updated to the new path; the dialog shown when the desktop app is missing also uses the new name.

- **Windows:** \`MyAppName\` + \`MyAppShortName\` both set to "OpenHPSDR Zeus"; Server icon picks up "OpenHPSDR Zeus Server" via the template.
- **macOS:** \`APP_NAME\` / \`SERVER_APP_NAME\` bundle filenames + both \`CFBundleName\` / \`CFBundleDisplayName\` renamed; xattr paths in DMG README + release notes + main README updated to quote the new paths.
- **Linux:** \`zeus-desktop.desktop\` + \`zeus-server.desktop\` \`Name=\` entries renamed; AppImage internal \`.desktop\` entries likewise.

## Verified locally
- [x] \`npm run lint\` — 0 errors, 17 warnings (pre-existing).
- [x] \`npm run build\` — clean.
- [x] plugins-store tests 7/7 pass.
- [x] PluginsPanel tests 13/13 pass.
- [x] \`bash -n\` on all three installer scripts.

## Test plan after merge
- Browse to Settings → Plugins, install any registry plugin → restart modal should appear with the plugin's display name.
- Download Audio Suite still shows the bundle-counts variant of the same modal (regression check).
- Next \`v0.8.0\` re-tag triggers a fresh release build with the renamed bundles.

CHANGELOG.md gets one new bullet under [0.8.0] for the restart-modal extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)