### PR TITLE
fix(host,installer): hide Windows console + auto-evict legacy installs (v0.8.0 follow-up)

### DIFF
--- a/OpenhpsdrZeus/Program.cs
+++ b/OpenhpsdrZeus/Program.cs
@@ -77,11 +77,32 @@ using Zeus.Server;
 
 public partial class Program
 {
+    // OpenhpsdrZeus.csproj defaults to OutputType=Exe (console subsystem) so that
+    // headless service mode keeps a usable banner / log on stdout. On Windows that
+    // also means a console window pops up alongside the Photino frame in --desktop
+    // and --server modes, which operators (correctly) read as "why is there a
+    // backend log spamming behind my UI?". FreeConsole detaches the inherited
+    // console from this process, hiding the window without affecting Kestrel,
+    // Photino, or any redirected output. It's a no-op on macOS / Linux (the
+    // P/Invoke target does not exist), so the call is guarded by an OS check.
+    [System.Runtime.InteropServices.DllImport("kernel32.dll", SetLastError = true)]
+    [return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.Bool)]
+    private static extern bool FreeConsole();
+
+    private static void HideConsoleOnWindows()
+    {
+        if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
+        {
+            FreeConsole();
+        }
+    }
+
     [STAThread]
     public static int Main(string[] args)
     {
         if (args.Contains("--desktop"))
         {
+            HideConsoleOnWindows();
             return RunDesktop(args);
         }
 
@@ -92,6 +113,7 @@ public partial class Program
             // place to read the LAN URL and a Stop Zeus button. Headless
             // deploys (Docker, Pi) keep using the no-flag path and never
             // load Photino.
+            HideConsoleOnWindows();
             return RunServerWithStatus(args);
         }
 

--- a/installers/create-linux-package.sh
+++ b/installers/create-linux-package.sh
@@ -204,6 +204,28 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 APPS_DIR="${HOME}/.local/share/applications"
 mkdir -p "${APPS_DIR}"
+
+# Evict any pre-existing .desktop entries whose Exec= still points at a
+# previous Zeus extraction directory. Without this the user ends up with
+# duplicate menu entries — one for the new install path and one for the
+# stale one — and clicks on the stale one launch nothing. We also flag
+# orphaned binaries at the old path so the operator can rm them by hand.
+for f in zeus-desktop.desktop zeus-server.desktop; do
+    existing="${APPS_DIR}/${f}"
+    if [ -f "${existing}" ]; then
+        old_exec=$(grep -E '^Exec=' "${existing}" | head -1 | sed 's/^Exec=//')
+        old_dir=$(dirname "${old_exec}" 2>/dev/null || echo "")
+        if [ -n "${old_dir}" ] && [ "${old_dir}" != "${SCRIPT_DIR}" ]; then
+            echo "removing stale entry ${existing} (was pointing at ${old_dir})"
+            if [ -d "${old_dir}" ] && [ -x "${old_dir}/OpenhpsdrZeus" ]; then
+                echo "  NOTE: an older Zeus install is still on disk at ${old_dir}"
+                echo "        rm -rf '${old_dir}' once you're satisfied the new install works."
+            fi
+            rm -f "${existing}"
+        fi
+    fi
+done
+
 for f in zeus-desktop.desktop zeus-server.desktop; do
     sed "s|__ZEUS_DIR__|${SCRIPT_DIR}|g" "${SCRIPT_DIR}/${f}" > "${APPS_DIR}/${f}"
     chmod +x "${APPS_DIR}/${f}"

--- a/installers/create-macos-app.sh
+++ b/installers/create-macos-app.sh
@@ -97,8 +97,9 @@ fi
 # directly) so we can pin DYLD_LIBRARY_PATH before the .NET runtime loads
 # libwdsp.dylib. CFBundleIdentifier reuses the historical service-mode ID
 # (com.ei6lf.zeus) so existing service-mode .app installs upgrade in
-# place. The older "com.ei6lf.zeus.desktop" bundle ID is dropped — users
-# with that .app must Trash it manually; release notes call this out.
+# place. The older "com.ei6lf.zeus.desktop" bundle ID is detected and
+# moved to the Trash by launch.sh on next start — see the cleanup block
+# in the launcher below.
 cat > "${APP_BUNDLE}/Contents/Info.plist" << EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -168,6 +169,24 @@ cd "$(dirname "$0")"
 # arm64 and x64 builds; the loader silently skips a path that does not
 # exist.
 export DYLD_LIBRARY_PATH="$(pwd)/runtimes/osx-arm64/native:$(pwd)/runtimes/osx-x64/native:${DYLD_LIBRARY_PATH}"
+
+# Evict legacy app bundles left behind by older installers:
+#   /Applications/Zeus Desktop.app   — pre-unified standalone (com.ei6lf.zeus.desktop)
+#   /Applications/Zeus.app           — pre-rename unified app (renamed to "OpenHPSDR Zeus.app")
+#   /Applications/Zeus Server.app    — pre-rename server wrapper
+# We move each to the Trash via Finder so the operator can recover if they
+# really wanted to keep it. Runs at every launch but is effectively a no-op
+# once the files are gone — the `-d` check is the only cost. We deliberately
+# do NOT evict "/Applications/OpenHPSDR Zeus.app" or
+# "/Applications/OpenHPSDR Zeus Server.app" — those are the current bundles.
+for legacy in \
+    "/Applications/Zeus Desktop.app" \
+    "/Applications/Zeus.app" \
+    "/Applications/Zeus Server.app"; do
+    if [ -d "${legacy}" ]; then
+        osascript -e "tell application \"Finder\" to delete POSIX file \"${legacy}\"" >/dev/null 2>&1 || true
+    fi
+done
 
 exec ./OpenhpsdrZeus --desktop
 EOF

--- a/installers/zeus-windows.iss
+++ b/installers/zeus-windows.iss
@@ -28,9 +28,10 @@
 [Setup]
 ; AppId pinned to the historical service-mode AppId so this installer
 ; upgrades existing service-mode installs in place. Operators who had the
-; separate "Zeus Desktop" edition (AppId B23E7F4A-...) keep that install
-; alongside the new combined product until they uninstall it manually from
-; Settings → Apps; the release notes call this out.
+; separate "Zeus Desktop" edition (AppId B23E7F4A-...) or one of the
+; legacy stray AppIds (8F2E3B1C-...4D) used by a short-lived prerelease are
+; silently uninstalled by the [Code] section below before install proceeds,
+; so the upgrader is not left with two Zeus entries in Settings → Apps.
 AppId={{8F2E3B1C-9A4D-4E6F-B7C3-1D5A9E8F2B4C}
 AppName={#MyAppName}
 AppVersion={#MyAppVersion}
@@ -83,6 +84,54 @@ Name: "{autodesktop}\{#MyAppShortName} Server"; Filename: "{app}\{#MyAppExeName}
 Filename: "{app}\{#MyAppExeName}"; Parameters: "--desktop"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
 
 [Code]
+// Legacy AppIds shipped by earlier Zeus installers. We silently uninstall
+// any present before the new files are laid down so the operator does not
+// end up with multiple "Zeus" / "Zeus Desktop" entries in Settings → Apps.
+//   B23E7F4A-1C8D-4DB6-9E5F-3A8C2B7D4E91 — old standalone "Zeus Desktop" build
+//   8F2E3B1C-9A4D-4E6F-B7C3-1D5A9E8F2B4D — typo'd AppId used by one prerelease
+// The current AppId (...B4C) is owned by THIS installer — never uninstall it,
+// or Inno will undo what it just installed.
+const
+  LegacyAppId_Desktop = '{B23E7F4A-1C8D-4DB6-9E5F-3A8C2B7D4E91}_is1';
+  LegacyAppId_Typo    = '{8F2E3B1C-9A4D-4E6F-B7C3-1D5A9E8F2B4D}_is1';
+
+function GetUninstallString(const AppId: String): String;
+var
+  RegPath: String;
+  Value: String;
+begin
+  Result := '';
+  RegPath := 'Software\Microsoft\Windows\CurrentVersion\Uninstall\' + AppId;
+  // Per-user installs land under HKCU; per-machine under HKLM (both 32- and
+  // 64-bit views). PrivilegesRequired=lowest means most installs are HKCU,
+  // but we check both so an operator who once ran the installer elevated
+  // still gets cleaned up.
+  if RegQueryStringValue(HKCU, RegPath, 'QuietUninstallString', Value) then
+    Result := Value
+  else if RegQueryStringValue(HKCU, RegPath, 'UninstallString', Value) then
+    Result := Value
+  else if RegQueryStringValue(HKLM, RegPath, 'QuietUninstallString', Value) then
+    Result := Value
+  else if RegQueryStringValue(HKLM, RegPath, 'UninstallString', Value) then
+    Result := Value;
+end;
+
+procedure UninstallLegacy(const AppId: String);
+var
+  UninstallCmd: String;
+  ResultCode: Integer;
+begin
+  UninstallCmd := GetUninstallString(AppId);
+  if UninstallCmd = '' then
+    Exit;
+  // Inno's UninstallString quotes the exe; pass the flags as the parameter
+  // half. /VERYSILENT suppresses UI, /SUPPRESSMSGBOXES eats the "really?"
+  // prompt, /NORESTART keeps us from rebooting the operator mid-install.
+  UninstallCmd := RemoveQuotes(UninstallCmd);
+  Exec(UninstallCmd, '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART',
+       '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+end;
+
 procedure InitializeWizard;
 begin
   WizardForm.LicenseAcceptedRadio.Checked := True;
@@ -95,5 +144,17 @@ begin
   begin
     MsgBox('This application requires Windows 64-bit.', mbError, MB_OK);
     Result := False;
+  end;
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  // ssInstall fires after the wizard has confirmed install but before files
+  // are copied — the right window to evict prior installs so their files
+  // don't linger on disk next to ours.
+  if CurStep = ssInstall then
+  begin
+    UninstallLegacy(LegacyAppId_Desktop);
+    UninstallLegacy(LegacyAppId_Typo);
   end;
 end;


### PR DESCRIPTION
## Summary
v0.8.0 follow-up — two issues reported on the new unified installer:

- **Windows console window** behind the Photino frame in `--desktop` / `--server` modes. `OpenhpsdrZeus.csproj` defaults to `OutputType=Exe` (console subsystem); the inherited console pops up alongside the UI and reads as "why is there a backend log spamming behind my UI?". Fix: P/Invoke `kernel32!FreeConsole` at the top of `RunDesktop` and `RunServerWithStatus`, guarded by `RuntimeInformation.IsOSPlatform(Windows)`. Headless service mode (no flag) keeps its console banner; macOS / Linux are unaffected (`.app` bundle is GUI subsystem; `.desktop` files set `Terminal=false`).

- **Legacy installs not removed** by the new installer. Cleanup added per platform:
  - **Windows** (`installers/zeus-windows.iss`): `[Code]` section runs legacy AppId uninstallers at `ssInstall` via `/VERYSILENT /SUPPRESSMSGBOXES /NORESTART`. Targets:
    - `B23E7F4A-1C8D-4DB6-9E5F-3A8C2B7D4E91` — old standalone "Zeus Desktop"
    - `8F2E3B1C-9A4D-4E6F-B7C3-1D5A9E8F2B4D` — prerelease typo'd service AppId
    - Current `…B4C` is intentionally not in the list — Inno's normal in-place upgrade handles it.
  - **macOS** (`installers/create-macos-app.sh`): `OpenHPSDR Zeus.app`'s `launch.sh` moves these to Trash via Finder osascript on next launch (recoverable):
    - `/Applications/Zeus Desktop.app` (pre-unified `com.ei6lf.zeus.desktop`)
    - `/Applications/Zeus.app` (pre-rename unified app)
    - `/Applications/Zeus Server.app` (pre-rename server wrapper)
  - **Linux** (`installers/create-linux-package.sh`): `install-icons.sh` detects pre-existing `zeus-*.desktop` entries whose `Exec=` points at a different extraction dir, removes the stale entry, and prints a one-line notice telling the operator to `rm -rf` the old install dir.

## Test plan
- [x] `dotnet build Zeus.slnx` clean, 0 warnings.
- [x] `dotnet test` — 725 passing, 0 failing on the develop-tip baseline (skipped tests gated on native WDSP).
- [x] `bash -n` syntax check passes on both installer scripts.
- [ ] **Needs Windows bench**: build the .iss, run on a Windows box with v0.7.x already installed, confirm no console window in `--desktop` mode and the legacy AppId is silently removed.
- [ ] **Needs macOS bench**: build the DMG with a stray `/Applications/Zeus.app` present, install + launch the new `OpenHPSDR Zeus.app`, confirm the old bundle ends up in Trash.

## Release-tag follow-up
Once merged, intent is to move the `v0.8.0` tag to the merge commit (force-update) rather than cut v0.8.1 — coordinated with @brianbruff. Binary artifacts on the GitHub release will need re-attaching after rebuild.