### PR TITLE
fix(ci): build miniaudio native libs in release + native-libs workflows

### DIFF
--- a/.github/workflows/build-native-libs.yml
+++ b/.github/workflows/build-native-libs.yml
@@ -1,4 +1,4 @@
-name: Build Native WDSP Libraries
+name: Build Native Libraries
 
 on:
   # Manual trigger only. The previous push-based auto-rebuild opened a PR
@@ -153,11 +153,35 @@ jobs:
           New-Item -ItemType Directory -Force -Path $destDir
           Copy-Item "native/build/Release/wdsp.dll" "$destDir/wdsp.dll"
 
+      # ---------- miniaudio (desktop-mode RX sink + TX mic capture) -------
+      #
+      # Pure C, no third-party deps — WASAPI is loaded dynamically at
+      # runtime, so no link libs and no vcpkg packages are required. Same
+      # VS 2022 generator + arch flag as wdsp above. We do NOT pass
+      # `-T ClangCL` here: that toolset was only needed because libspecbleach
+      # (NR4) uses a C99 VLA that MSVC rejects; miniaudio is plain MSVC-clean.
+      - name: Configure miniaudio (CMake)
+        run: |
+          $archFlag = if ("${{ matrix.arch }}" -eq "arm64") { "ARM64" } else { "x64" }
+          cmake -S native/miniaudio -B native/build-miniaudio `
+            -G "Visual Studio 17 2022" `
+            -A $archFlag
+
+      - name: Build miniaudio
+        run: cmake --build native/build-miniaudio --config Release --parallel
+
+      - name: Stage miniaudio DLL
+        run: |
+          $rid = "win-${{ matrix.arch }}"
+          Copy-Item "native/build-miniaudio/Release/miniaudio.dll" "Zeus.Dsp/runtimes/$rid/native/miniaudio.dll"
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
+          # Directory upload (not a single file) so the artifact carries both
+          # wdsp.dll and miniaudio.dll. Matches the linux job pattern below.
           name: wdsp-windows-${{ matrix.arch }}
-          path: Zeus.Dsp/runtimes/win-${{ matrix.arch }}/native/wdsp.dll
+          path: Zeus.Dsp/runtimes/win-${{ matrix.arch }}/native/
 
   build-linux:
     name: Build Linux Native Libraries
@@ -275,6 +299,37 @@ jobs:
           done
           ls -la "$destDir/"
           ldd "$destDir/libwdsp.so"
+
+      # ---------- miniaudio (desktop-mode RX sink + TX mic capture) -------
+      #
+      # Pure C, no third-party deps — ALSA / PulseAudio / JACK are loaded
+      # dynamically at runtime via dlopen. Link-time only needs -ldl,
+      # -lpthread, -lm, all libc-resident.
+      - name: Build & stage miniaudio (x64)
+        if: matrix.arch == 'x64'
+        run: |
+          set -eux
+          cmake -S native/miniaudio -B native/build-miniaudio -DCMAKE_BUILD_TYPE=Release
+          cmake --build native/build-miniaudio --config Release --parallel
+          cp native/build-miniaudio/libminiaudio.so Zeus.Dsp/runtimes/linux-x64/native/libminiaudio.so
+          ldd Zeus.Dsp/runtimes/linux-x64/native/libminiaudio.so
+
+      - name: Build & stage miniaudio (arm64)
+        if: matrix.arch == 'arm64'
+        run: |
+          # Reuse the aarch64-linux-gnu cross toolchain installed for wdsp
+          # above. No sysroot extras needed: pthread/dl/m come from the
+          # cross libc that ships with gcc-aarch64-linux-gnu.
+          set -eux
+          cmake -S native/miniaudio -B native/build-miniaudio \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_SYSTEM_NAME=Linux \
+            -DCMAKE_SYSTEM_PROCESSOR=aarch64 \
+            -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc \
+            -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++
+          cmake --build native/build-miniaudio --config Release --parallel
+          cp native/build-miniaudio/libminiaudio.so Zeus.Dsp/runtimes/linux-arm64/native/libminiaudio.so
+          file Zeus.Dsp/runtimes/linux-arm64/native/libminiaudio.so
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,9 +187,36 @@ jobs:
           New-Item -ItemType Directory -Force -Path $destDir
           Copy-Item "native/build/Release/wdsp.dll" "$destDir/wdsp.dll"
 
+      # ---------- miniaudio (desktop-mode RX sink + TX mic capture) -------
+      #
+      # Pure C, no third-party deps — WASAPI is loaded dynamically at
+      # runtime, so no link libs and no vcpkg packages are required. Same
+      # VS 2022 generator + arch flag as wdsp above. We do NOT pass
+      # `-T ClangCL` here: that toolset was needed only because libspecbleach
+      # (NR4) uses a C99 VLA that MSVC rejects; miniaudio is plain MSVC-clean.
+      - name: Configure miniaudio (CMake)
+        run: |
+          $archFlag = if ("${{ matrix.arch }}" -eq "arm64") { "ARM64" } else { "x64" }
+          cmake -S native/miniaudio -B native/build-miniaudio `
+            -G "Visual Studio 17 2022" `
+            -A $archFlag
+
+      - name: Build miniaudio
+        run: cmake --build native/build-miniaudio --config Release --parallel
+
+      - name: Stage miniaudio DLL
+        run: |
+          $rid = "win-${{ matrix.arch }}"
+          Copy-Item "native/build-miniaudio/Release/miniaudio.dll" "staged/$rid/miniaudio.dll"
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
+          # Artifact name kept as `wdsp-native-*` for compatibility with the
+          # build-release `Map RID to native artifact name` step; the staged
+          # dir now contains both wdsp.dll and miniaudio.dll, and the
+          # downstream `download-artifact` extracts the whole directory into
+          # Zeus.Dsp/runtimes/<rid>/native/.
           name: wdsp-native-win-${{ matrix.arch }}
           path: staged/win-${{ matrix.arch }}/
 
@@ -242,9 +269,28 @@ jobs:
           ls -la "$destDir/"
           ldd "$destDir/libwdsp.so"
 
+      # ---------- miniaudio (desktop-mode RX sink + TX mic capture) -------
+      #
+      # Pure C, no third-party deps — ALSA / PulseAudio / JACK are loaded
+      # dynamically at runtime via dlopen. Only -ldl + -lpthread + -lm are
+      # required at link time and all three live in libc / libpthread, which
+      # are already present in the build-essential toolchain installed
+      # above. No additional apt packages needed.
+      - name: Build & stage miniaudio
+        run: |
+          set -eux
+          cmake -S native/miniaudio -B native/build-miniaudio -DCMAKE_BUILD_TYPE=Release
+          cmake --build native/build-miniaudio --config Release --parallel
+          cp native/build-miniaudio/libminiaudio.so staged/linux-x64/libminiaudio.so
+          ldd staged/linux-x64/libminiaudio.so
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
+          # Staged dir now contains libwdsp.so + libfftw3.so.3 +
+          # libfftw3f.so.3 + libminiaudio.so. The downstream
+          # `download-artifact` extracts the whole directory into
+          # Zeus.Dsp/runtimes/linux-x64/native/.
           name: wdsp-native-linux-x64
           path: staged/linux-x64/
 
@@ -289,9 +335,24 @@ jobs:
           mkdir -p "$destDir"
           cp native/build/libwdsp.dylib "$destDir/libwdsp.dylib"
 
+      # ---------- miniaudio (desktop-mode RX sink + TX mic capture) -------
+      #
+      # Pure C, CoreAudio backend. cmake is already installed by the wdsp
+      # step above. macOS frameworks (CoreAudio / AudioToolbox / AudioUnit /
+      # CoreFoundation) come from the SDK that ships with Xcode CLT on
+      # macos-latest — no extra brew packages needed.
+      - name: Build & stage miniaudio
+        run: |
+          set -eux
+          cmake -S native/miniaudio -B native/build-miniaudio -DCMAKE_BUILD_TYPE=Release
+          cmake --build native/build-miniaudio --config Release --parallel
+          cp native/build-miniaudio/libminiaudio.dylib staged/osx-arm64/libminiaudio.dylib
+          otool -L staged/osx-arm64/libminiaudio.dylib
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
+          # Staged dir now contains libwdsp.dylib + libminiaudio.dylib.
           name: wdsp-native-osx-arm64
           path: staged/osx-arm64/
 


### PR DESCRIPTION
## Summary

On Windows, `OpenhpsdrZeus.exe --desktop` fails to open audio because
`Zeus.Dsp/runtimes/win-x64/native/miniaudio.dll` does not exist. Same
story on Linux x64 / Linux arm64 — only `osx-arm64` ever had a
committed `libminiaudio.dylib`. The release workflow rebuilds natives
fresh and ignores committed binaries, so even committing a Windows
DLL would not make it into the next tagged installer; the build needs
to produce miniaudio in CI alongside wdsp.

Symptom on a Windows operator running `--desktop` is silent no-audio + no-mic:

```
warn: Zeus.Server.NativeAudioSink[0]
      audio.native.rx open failed; RX audio output disabled
      System.DllNotFoundException: Unable to load DLL 'miniaudio' ...
warn: Zeus.Server.NativeAudioSink[0]
      audio.native.tx mic open failed; TX uplink disabled
      System.DllNotFoundException: Unable to load DLL 'miniaudio' ...
# steady-state:
info: Zeus.Server.NativeAudioSink[0]
      audio.native.rx stats in=242944 out=0 underrun=0 overrun=177408
```

DSP is producing samples (`in=242944`) but `out=0` because the playback device never opened.

## What changed

`release.yml` (load-bearing — this is what ships installers on tag):
- `build-native-windows` (x64, arm64): added miniaudio configure/build/stage. Staged dir now carries `wdsp.dll` + `miniaudio.dll`. Existing `wdsp-native-win-<arch>` artifact picks both up because the upload is already directory-based.
- `build-native-linux` (x64): added miniaudio build/stage. Staged dir carries `libwdsp.so` + `libfftw3.so.3` + `libfftw3f.so.3` + `libminiaudio.so`.
- `build-native-macos` (osx-arm64): added miniaudio build/stage so releases use the freshly-built dylib instead of the committed one.

`build-native-libs.yml` (manual `workflow_dispatch`, for refreshing committed binaries):
- `build-windows` (x64, arm64): miniaudio.dll built + staged into `Zeus.Dsp/runtimes/win-<arch>/native/`. Switched the Windows artifact upload from a single-file path to the native directory so it carries both DLLs (matches the existing Linux job pattern). Nothing downstream consumes this artifact name, so the path widening is safe.
- `build-linux` (x64, arm64): miniaudio built + staged. arm64 reuses the existing `aarch64-linux-gnu` cross toolchain installed for wdsp arm64 — pthread/dl/m come from the cross libc, no additional sysroot deps.
- Renamed workflow `Build Native WDSP Libraries` → `Build Native Libraries`.

miniaudio is pure C with no third-party deps — WASAPI / CoreAudio / ALSA are loaded dynamically at runtime, so no link libs and no vcpkg packages are required. MSVC default toolset is fine (the `-T ClangCL` that wdsp needs is only there for libspecbleach's C99 VLA which miniaudio doesn't have).

The `.NET` code is unchanged. `Zeus.Dsp.csproj` already globs `runtimes/**/*.dll`, `**/*.so*`, `**/*.dylib` with `CopyToOutputDirectory=PreserveNewest`, so the new miniaudio binaries land in the publish output for each RID without any csproj edits, just like wdsp.dll does today.

## Test plan

- [ ] On tag, `build-native-windows` x64 + arm64 jobs each emit `miniaudio.dll`; staged artifact contains both `wdsp.dll` and `miniaudio.dll`.
- [ ] `build-native-linux` x64 staged artifact contains `libminiaudio.so` alongside `libwdsp.so` + FFTW.
- [ ] `build-native-macos` staged artifact contains both dylibs.
- [ ] The Windows installer produced for v0.8.0 (or whichever tag follows merge) opens an audio device on `--desktop` — backend log shows `audio.native.rx open rate=...` instead of `open failed; ... DllNotFoundException`, and mic capture starts on PTT.