### PR TITLE
fix(desktop): dispose miniaudio + WebApplication so Windows process exits cleanly

### DIFF
--- a/OpenhpsdrZeus/Program.cs
+++ b/OpenhpsdrZeus/Program.cs
@@ -247,6 +247,13 @@ public partial class Program
 
         Console.WriteLine("Window closed; stopping backend.");
         app.StopAsync().GetAwaiter().GetResult();
+        // DisposeAsync runs the DI container's disposal pass, which is the
+        // only thing that invokes IDisposable.Dispose() on singleton hosted
+        // services like NativeAudioSink / NativeMicCapture. Without it the
+        // miniaudio devices' ma_device_uninit is never called and the
+        // [STAThread] Main can't release its COM apartment cleanly on
+        // Windows — the process hangs after window close.
+        app.DisposeAsync().AsTask().GetAwaiter().GetResult();
         return 0;
     }
 
@@ -386,6 +393,10 @@ public partial class Program
 
         Console.WriteLine("Status window closed; stopping backend.");
         app.StopAsync().GetAwaiter().GetResult();
+        // See the matching comment in RunDesktop — DisposeAsync is what
+        // actually disposes the singleton hosted services (and Kestrel),
+        // which is required for a clean Windows process exit.
+        app.DisposeAsync().AsTask().GetAwaiter().GetResult();
         return 0;
     }
 }

--- a/Zeus.Server.Hosting/NativeAudioSink.cs
+++ b/Zeus.Server.Hosting/NativeAudioSink.cs
@@ -180,11 +180,19 @@ internal sealed class NativeAudioSink : IRxAudioSink, IAuditionAudioSink, IHoste
         return Task.CompletedTask;
     }
 
-    /// <summary>Hosted-service hook: stop the playback device. Idempotent.</summary>
+    /// <summary>Hosted-service hook: tear the playback device down. Idempotent.
+    /// We call Dispose() (ma_device_uninit) rather than Stop() (ma_device_stop)
+    /// because ma_device_stop only parks the device — miniaudio's WASAPI worker
+    /// thread keeps running until ma_device_uninit joins it. Leaving that
+    /// thread alive past StopAsync wedges process shutdown on Windows: the
+    /// worker holds WASAPI COM references that the [STAThread] Main owns, so
+    /// CLR COM-apartment teardown blocks waiting for them and the process
+    /// hangs after the Photino window closes.</summary>
     public Task StopAsync(CancellationToken cancellationToken)
     {
-        try { _output?.Stop(); }
+        try { _output?.Dispose(); }
         catch (Exception ex) { _log.LogWarning(ex, "audio.native.rx stop threw"); }
+        _output = null;
         return Task.CompletedTask;
     }
 

--- a/Zeus.Server.Hosting/NativeMicCapture.cs
+++ b/Zeus.Server.Hosting/NativeMicCapture.cs
@@ -120,8 +120,13 @@ internal sealed class NativeMicCapture : IHostedService, IDisposable
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
-        try { _input?.Stop(); }
+        // Dispose() (ma_device_uninit) rather than Stop() (ma_device_stop): the
+        // latter parks the device but leaves miniaudio's capture worker thread
+        // alive, which holds WASAPI COM references and wedges Windows process
+        // exit. See the matching note on NativeAudioSink.StopAsync.
+        try { _input?.Dispose(); }
         catch (Exception ex) { _log.LogWarning(ex, "audio.native.tx stop threw"); }
+        _input = null;
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
## Summary

Reproducing report: closing the Photino desktop window on Windows leaves `openhpsdrzeus.exe` running, and repeated launches accumulate orphan processes.

Two compounding bugs caused this:

1. **`NativeAudioSink.StopAsync` / `NativeMicCapture.StopAsync` only called `_output.Stop()` / `_input.Stop()`** — these map to `ma_device_stop` in the native shim, which only parks the device. miniaudio's WASAPI worker thread keeps running until `ma_device_uninit` joins it (`MiniAudioOutput.Dispose` already documents this). So after `StopAsync` returned, the audio worker thread was still alive holding WASAPI COM references.
2. **`Program.cs` never disposed the `WebApplication`** — `app.StopAsync()` runs hosted-service `StopAsync` methods but does not dispose the DI container, so the singletons' `IDisposable.Dispose()` (the only path that calls `ma_device_uninit`) never ran.

On Windows the leaked COM references stall CLR apartment teardown on the `[STAThread]` `Main` thread → process hangs after window close. macOS / Linux audio backends don't go through COM, so the same leak only manifested as background-thread cleanup and was invisible.

## Fix

- `NativeAudioSink.StopAsync` and `NativeMicCapture.StopAsync` now `Dispose()` the device (not `Stop()`) so the hosted-service contract is honest: when `StopAsync` returns, the audio worker thread is gone.
- `Program.RunDesktop` and `Program.RunServerWithStatus` follow `app.StopAsync()` with `app.DisposeAsync()` so the DI disposal pass runs — covers any other singleton `IDisposable`s (Photino / Kestrel / future).

## Test plan

- [x] `dotnet build Zeus.slnx` — clean, 0 warnings / 0 errors.
- [x] `dotnet test Zeus.slnx` — all 1,164 tests pass (96 skipped: WDSP-native-gated NR matrix on macOS).
- [ ] **Bench verification needed on Windows**: launch a `--desktop` build, close the window, confirm `openhpsdrzeus.exe` exits within a few seconds in Task Manager and that repeat launches don't pile up. Same check for `--server` mode.
- [ ] Linux smoke — close the Photino window in `--desktop` mode, confirm clean exit (no regression).

I was unable to bench-verify on Windows from the macOS dev box.