### PR TITLE
chore(release): 0.8.1 — same-day hotfix for v0.8.0 Windows shutdown wedge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ see the corresponding GitHub Release page.
 
 ---
 
+## [0.8.1] — 2026-05-19
+
+> **🛠 THIS IS A SAME-DAY HOTFIX FOR v0.8.0.** If you installed v0.8.0 earlier today and saw `openhpsdrzeus.exe` linger in Task Manager after closing the Zeus window on Windows, **install v0.8.1 — it's the fix**. macOS and Linux operators were not affected; upgrade is still recommended for the cleaner shutdown behaviour. See [0.8.0](#080--2026-05-19) below for the full release feature list — v0.8.1 contains only the fix described here.
+
+### Fixed
+
+- **Windows: OpenhpsdrZeus.exe no longer lingers in Task Manager after closing the desktop window** (#400, **@brianbruff**). v0.8.0 registered an `AppDomain.CurrentDomain.ProcessExit` handler in both `--desktop` and `--server` modes that called `window.Close()`. That event fires *during* exit, after `Main` returned and Photino's native state was being torn down — the handler then re-entered a half-disposed WebView2/COM apartment on the `[STAThread]` main thread, deadlocking for ~30 s. v0.8.1 deletes the handler in two lines: `Console.CancelKeyPress` already handled Ctrl-C translation; `ProcessExit` was never the right hook for shutdown.
+
+  Bench-verified on Windows 11: process exits in ~2.2 s after window close (down from >30 s of hang). Subsequent relaunches no longer pile up orphan processes.
+
+---
+
 ## [0.8.0] — 2026-05-19
 
 > **🎉 Headline:** in-process **Audio Suite** with live pre-MOX meters and audition, **dual desktop icons** on every platform (Zeus + Zeus Server with a Photino status window), single-binary Zeus that hosts both modes, and Ramon's smoothed-SWR meter improvements.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,8 +8,8 @@
     <!-- Version Management -->
     <!-- When building from a tag (e.g., v0.1.0), GITHUB_REF_NAME will be set -->
     <!-- Otherwise, fall back to the in-development VersionPrefix below.    -->
-    <!-- Bump this when a release branch opens — current target: v0.8.0.    -->
-    <VersionPrefix Condition="'$(VersionPrefix)' == ''">0.8.0</VersionPrefix>
+    <!-- Bump this when a release branch opens — current target: v0.8.1.    -->
+    <VersionPrefix Condition="'$(VersionPrefix)' == ''">0.8.1</VersionPrefix>
     <VersionSuffix Condition="'$(VersionSuffix)' == '' AND '$(GITHUB_REF_TYPE)' != 'tag'">dev</VersionSuffix>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>

--- a/zeus-web/src/components/AboutPanel.tsx
+++ b/zeus-web/src/components/AboutPanel.tsx
@@ -25,10 +25,11 @@ import { useEffect, useState } from 'react';
 // VersionPrefix in Directory.Build.props bumps. ISO 8601 so toLocaleDateString
 // renders sensibly in any locale.
 const RELEASE_DATE_ISO = '2026-05-19';
-// Note: v0.8.0 brings the in-process Audio Suite (live meters, audition,
-// reorderable chain), the dual-icon installer (Zeus + Zeus Server with
-// --server status window), Brian's single-binary + native-audio rollup,
-// and Ramon's smoothed-SWR / per-mode trip thresholds.
+// Note: v0.8.1 is a same-day hotfix for v0.8.0 — drops the Photino
+// ProcessExit handler that was wedging Windows shutdown and leaving
+// OpenhpsdrZeus.exe lingering in Task Manager. See CHANGELOG for v0.8.0
+// for the bulk of changes (Audio Suite, dual-icon installer, plugin
+// system rebuild, smoothed-SWR, persistence fixes).
 
 type VersionInfo = {
   version: string;


### PR DESCRIPTION
## Summary
Same-day hotfix release for v0.8.0. Bumps the three sites required by [[feedback_release_bumps_about]] and prepends a CHANGELOG entry for v0.8.1.

The only code fix in v0.8.1 is **#400 (@brianbruff)** — drops the Photino `ProcessExit` handler that was wedging Windows shutdown. See CHANGELOG `[0.8.1]` for details; refer to `[0.8.0]` for the bulk of changes (Audio Suite, dual-icon installer, plugin system, persistence fixes).

After merge → tag v0.8.1 on main → CI builds release artifacts → publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)