### PR TITLE
fix(audio-suite): include Noise Gate + bump Bass/Exciter/Reverb to v0.2.0

### DIFF
--- a/zeus-web/src/components/DownloadAudioSuiteButton.tsx
+++ b/zeus-web/src/components/DownloadAudioSuiteButton.tsx
@@ -4,9 +4,9 @@
 // Copyright (C) 2025-2026 Brian Keating (EI6LF),
 //                         Douglas J. Cerrato (KB2UKA), and contributors.
 //
-// "Download Audio Suite" — one-click install of the five v1 audio chain
-// plugins (EQ → Compressor → Exciter → Bass → Reverb) from the
-// Kb2uka/openhpsdr-zeus-plugins GitHub releases. The plugin host can't
+// "Download Audio Suite" — one-click install of the six audio chain
+// plugins (Noise Gate → EQ → Compressor → Exciter → Bass → Reverb) from
+// the Kb2uka/openhpsdr-zeus-plugins GitHub releases. The plugin host can't
 // register new endpoints / load new assemblies into the live process, so
 // after install finishes we show a modal telling the operator to restart
 // Zeus. No auto-restart — operator decides.
@@ -28,6 +28,11 @@ interface SuitePlugin {
 
 const AUDIO_SUITE: ReadonlyArray<SuitePlugin> = [
   {
+    id: 'com.openhpsdr.zeus.samples.noisegate',
+    label: 'Noise Gate',
+    url: 'https://github.com/Kb2uka/openhpsdr-zeus-plugins/releases/download/noisegate-v0.1.0/noisegate-0.1.0.zip',
+  },
+  {
     id: 'com.openhpsdr.zeus.samples.eq',
     label: 'EQ (10-band parametric)',
     url: 'https://github.com/Kb2uka/openhpsdr-zeus-plugins/releases/download/eq-v0.2.0/eq-0.2.0.zip',
@@ -40,17 +45,17 @@ const AUDIO_SUITE: ReadonlyArray<SuitePlugin> = [
   {
     id: 'com.openhpsdr.zeus.samples.exciter',
     label: 'Aural-Exciter',
-    url: 'https://github.com/Kb2uka/openhpsdr-zeus-plugins/releases/download/exciter-v0.1.0/exciter-0.1.0.zip',
+    url: 'https://github.com/Kb2uka/openhpsdr-zeus-plugins/releases/download/exciter-v0.2.0/exciter-0.2.0.zip',
   },
   {
     id: 'com.openhpsdr.zeus.samples.bass',
     label: 'Bass Enhancer',
-    url: 'https://github.com/Kb2uka/openhpsdr-zeus-plugins/releases/download/bass-v0.1.0/bass-0.1.0.zip',
+    url: 'https://github.com/Kb2uka/openhpsdr-zeus-plugins/releases/download/bass-v0.2.0/bass-0.2.0.zip',
   },
   {
     id: 'com.openhpsdr.zeus.samples.reverb',
     label: 'Reverb',
-    url: 'https://github.com/Kb2uka/openhpsdr-zeus-plugins/releases/download/reverb-v0.1.0/reverb-0.1.0.zip',
+    url: 'https://github.com/Kb2uka/openhpsdr-zeus-plugins/releases/download/reverb-v0.2.0/reverb-0.2.0.zip',
   },
 ];
 
@@ -156,7 +161,7 @@ export function DownloadAudioSuiteButton() {
         className="btn sm active"
         disabled={busy}
         onClick={runInstall}
-        title="Install the five v1 audio chain plugins (EQ, Compressor, Exciter, Bass, Reverb) from the official Zeus plugin repo"
+        title="Install the six audio chain plugins (Noise Gate, EQ, Compressor, Exciter, Bass, Reverb) from the official Zeus plugin repo"
         style={{ marginLeft: 'auto' }}
       >
         {busy ? 'Installing…' : 'Download Audio Suite'}


### PR DESCRIPTION
## Summary

- `DownloadAudioSuiteButton.tsx`'s `AUDIO_SUITE` array never picked up Noise Gate when it shipped in v0.8.0 — operators clicking "Download Audio Suite" silently got 5 of the 6 plugins. Operator report confirmed.
- Bass / Exciter / Reverb were also still pinned at v0.1.0 even though v0.2.0 of all three shipped alongside Noise Gate on 2026-05-19, so the suite was distributing last-week's versions.

## Fix

- Add Noise Gate at the head of the array (conventional voice-chain signal order: Gate → EQ → Comp → Exciter → Bass → Reverb).
- Bump Bass / Exciter / Reverb URLs to `v0.2.0`.
- Update the file header comment and button tooltip from "five" to "six" plugins.

All four release zip URLs verified `200` before commit.

## Test plan

- [x] Wiped `~/Library/Application Support/Zeus/plugins/com.openhpsdr.zeus.samples.*` (6 plugin dirs), launched desktop, clicked "Download Audio Suite" — backend log shows all 6 plugins downloaded and registered fresh.
- [x] Restarted desktop — Noise Gate v0.1.0 loads and attaches to its slot alongside the other 5.
- [ ] Verify a separate operator can repro the green-path install on their machine.