### PR TITLE
chore(release): 0.8.2 — Audio Suite installer hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ see the corresponding GitHub Release page.
 
 ---
 
+## [0.8.2] — 2026-05-20
+
+> **🛠 THIS IS A HOTFIX FOR v0.8.0/v0.8.1's Audio Suite installer.** If you installed v0.8.0 or v0.8.1 and clicked **Download Audio Suite**, you got 5 of the 6 audio plugins — Noise Gate was silently skipped. v0.8.2 fixes the one-click installer to deliver all six, and also catches Bass / Exciter / Reverb up from v0.1.0 to the v0.2.0 versions that shipped alongside Noise Gate on 2026-05-19. See [0.8.0](#080--2026-05-19) below for the full feature list — v0.8.2 contains only the fix described here.
+
+### Fixed
+
+- **Download Audio Suite now installs all six audio plugins, not five** (#405). The `AUDIO_SUITE` array in `DownloadAudioSuiteButton.tsx` was never updated when Noise Gate shipped with v0.8.0, so one-click installs left operators without the gate plugin. The same fix bumps the URLs for Bass / Exciter / Reverb from v0.1.0 to v0.2.0 (which shipped on 2026-05-19 alongside Noise Gate) so the suite now distributes the current releases. If you have v0.1.0 of any of those three already installed, the suite installer will mark them as "already present" and skip — uninstall the v0.1.0 version via Plugins → Browse and click Download Audio Suite again to pick up v0.2.0.
+
+  Manifest IDs and versions distributed by Download Audio Suite as of v0.8.2 (in install order; conventional voice-chain signal flow):
+  - `com.openhpsdr.zeus.samples.noisegate` **v0.1.0** (new in suite)
+  - `com.openhpsdr.zeus.samples.eq` v0.2.0
+  - `com.openhpsdr.zeus.samples.compressor` v0.1.2
+  - `com.openhpsdr.zeus.samples.exciter` **v0.2.0** (bumped from v0.1.0)
+  - `com.openhpsdr.zeus.samples.bass` **v0.2.0** (bumped from v0.1.0)
+  - `com.openhpsdr.zeus.samples.reverb` **v0.2.0** (bumped from v0.1.0)
+
+  Bench-verified end-to-end: wiped the plugins directory of all six audio plugins, clicked Download Audio Suite, all six installed fresh and loaded on next desktop restart.
+
+---
+
 ## [0.8.1] — 2026-05-19
 
 > **🛠 THIS IS A SAME-DAY HOTFIX FOR v0.8.0.** If you installed v0.8.0 earlier today and saw `openhpsdrzeus.exe` linger in Task Manager after closing the Zeus window on Windows, **install v0.8.1 — it's the fix**. macOS and Linux operators were not affected; upgrade is still recommended for the cleaner shutdown behaviour. See [0.8.0](#080--2026-05-19) below for the full release feature list — v0.8.1 contains only the fix described here.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,8 +8,8 @@
     <!-- Version Management -->
     <!-- When building from a tag (e.g., v0.1.0), GITHUB_REF_NAME will be set -->
     <!-- Otherwise, fall back to the in-development VersionPrefix below.    -->
-    <!-- Bump this when a release branch opens — current target: v0.8.1.    -->
-    <VersionPrefix Condition="'$(VersionPrefix)' == ''">0.8.1</VersionPrefix>
+    <!-- Bump this when a release branch opens — current target: v0.8.2.    -->
+    <VersionPrefix Condition="'$(VersionPrefix)' == ''">0.8.2</VersionPrefix>
     <VersionSuffix Condition="'$(VersionSuffix)' == '' AND '$(GITHUB_REF_TYPE)' != 'tag'">dev</VersionSuffix>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>

--- a/zeus-web/src/components/AboutPanel.tsx
+++ b/zeus-web/src/components/AboutPanel.tsx
@@ -24,12 +24,13 @@ import { useEffect, useState } from 'react';
 // Release date for the version this build ships against. Bump whenever
 // VersionPrefix in Directory.Build.props bumps. ISO 8601 so toLocaleDateString
 // renders sensibly in any locale.
-const RELEASE_DATE_ISO = '2026-05-19';
-// Note: v0.8.1 is a same-day hotfix for v0.8.0 — drops the Photino
-// ProcessExit handler that was wedging Windows shutdown and leaving
-// OpenhpsdrZeus.exe lingering in Task Manager. See CHANGELOG for v0.8.0
-// for the bulk of changes (Audio Suite, dual-icon installer, plugin
-// system rebuild, smoothed-SWR, persistence fixes).
+const RELEASE_DATE_ISO = '2026-05-20';
+// Note: v0.8.2 is a hotfix for v0.8.0/v0.8.1 — the Download Audio Suite
+// button's plugin array was missing Noise Gate (silently skipped on
+// one-click installs) and pinning v0.1.0 of Bass/Exciter/Reverb instead
+// of the v0.2.0 versions that shipped on 2026-05-19. See CHANGELOG for
+// v0.8.0 for the bulk of changes (Audio Suite, dual-icon installer,
+// plugin system rebuild, smoothed-SWR, persistence fixes).
 
 type VersionInfo = {
   version: string;


### PR DESCRIPTION
## Summary

- Bumps `Directory.Build.props` `VersionPrefix` 0.8.1 → 0.8.2.
- Bumps `AboutPanel.tsx` `RELEASE_DATE_ISO` to 2026-05-20.
- Adds CHANGELOG.md `[0.8.2]` entry above [0.8.1], with the hotfix callout, the operator-facing impact, and the full manifest-id/version table for the Audio Suite as it now ships.

Per the release-bumps-About rule, all three are in this one commit.

## Release contents

v0.8.2 is a hotfix on top of v0.8.1 carrying:
- #405 — Audio Suite installer: include Noise Gate + bump Bass/Exciter/Reverb to v0.2.0.
- #404 — Recognize Ramón Martínez (EA5IUE) as a core contributor.

## Test plan

- [x] `dotnet build` succeeds at 0.8.2 (verified locally before bump commit by the build that produced the wwwroot SPA used during bench-test).
- [x] AboutPanel renders the new date — covered by the desktop session where Audio Suite install was bench-verified.
- [ ] After this lands on develop and develop → main, tag `v0.8.2` and create the GitHub release with the changelog excerpt above the installer assets.