### PR TITLE
chore(codeowners): co-own with @brianbruff and @rampa069

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,19 @@
 # OpenHPSDR Zeus — Code Owners
 #
-# Every path in this repo is owned by @Kb2uka. Combined with branch
-# protection on `develop` and `main` (require approving review from a
-# code owner), this enforces the maintainer's "I have to merge" rule —
-# any PR opened by another collaborator (e.g. @brianbruff, @rampa069)
-# requires @Kb2uka's review approval before it can be merged.
+# Every path is co-owned by @Kb2uka, @brianbruff, and @rampa069.
+# Combined with branch protection on `develop` and `main` (require
+# approving review from a code owner), this means any one of the three
+# can approve + merge a PR — but GitHub still blocks self-approval, so
+# the PR author always needs an approval from one of the other two.
 #
-# Brian (@brianbruff) remains the visual-design / UX / architecture
-# authority per CLAUDE.md, so his review still drives those decisions
-# on a per-PR basis; this file isn't about who decides what merges, it's
-# about who clicks merge.
+# Roles are still defined per CLAUDE.md; this file isn't about who
+# decides what merges:
+#   - Brian (@brianbruff, EI6LF) — visual design, UX, architecture
+#     authority. Plugin SDK / VST3 / contracts owner.
+#   - Ramón (@rampa069, EA5IUE) — protocol + radio-state contributor.
+#   - Kb2uka (@Kb2uka, KB2UKA) — maintainer + audio-chain content
+#     owner (block choices, algorithm picks, defaults).
 #
 # Format reference: https://docs.github.com/en/repositories/managing-your-repositories-settings-and-security/customizing-your-repository/about-code-owners
 
-*       @Kb2uka
+*       @Kb2uka @brianbruff @rampa069


### PR DESCRIPTION
## Summary

Expand `.github/CODEOWNERS` from `* @Kb2uka` to `* @Kb2uka @brianbruff @rampa069` so all three active collaborators can approve + merge any PR.

Net effect:
- Any of @Kb2uka, @brianbruff, or @rampa069 can approve a PR opened by one of the other two — that single approval satisfies the develop / main code-owner branch protection rule.
- GitHub still blocks self-approval, so the PR author always needs the other two (or one of them) to sign off. The spirit of the maintainer-gate is preserved — no one merges their own work without a second pair of eyes.
- Per-domain decision authority is unchanged (Brian on design/UX/architecture, Ramón on protocol, Kb2uka on audio-chain content + final maintainer call). I added the role breakdown into the file header so the "approval vs decision" distinction is explicit, not buried in CLAUDE.md.

## Why now

End of the v0.8.2 ship cycle. Brian and Ramón both had merge-blocked PRs queued up this week that ended up flowing through @Kb2uka admin-bypass merges — that doesn't scale. Co-ownership turns those into normal "Brian approves Ramón, Ramón approves Brian, etc." flows.

## Test plan

- [x] Diff is the two-line CODEOWNERS change + header reword.
- [ ] After merge to develop: open a back-merge PR develop → main so main picks up the same CODEOWNERS file (file applies per-branch, so main needs it too).
- [ ] Verify post-merge: Brian or Ramón opens a follow-up PR and can self-approve via the other's signoff without admin bypass.