### PR TITLE
release(infra): merge develop into main — CODEOWNERS expansion + PS rename

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,19 @@
 # OpenHPSDR Zeus — Code Owners
 #
-# Every path in this repo is owned by @Kb2uka. Combined with branch
-# protection on `develop` and `main` (require approving review from a
-# code owner), this enforces the maintainer's "I have to merge" rule —
-# any PR opened by another collaborator (e.g. @brianbruff, @rampa069)
-# requires @Kb2uka's review approval before it can be merged.
+# Every path is co-owned by @Kb2uka, @brianbruff, and @rampa069.
+# Combined with branch protection on `develop` and `main` (require
+# approving review from a code owner), this means any one of the three
+# can approve + merge a PR — but GitHub still blocks self-approval, so
+# the PR author always needs an approval from one of the other two.
 #
-# Brian (@brianbruff) remains the visual-design / UX / architecture
-# authority per CLAUDE.md, so his review still drives those decisions
-# on a per-PR basis; this file isn't about who decides what merges, it's
-# about who clicks merge.
+# Roles are still defined per CLAUDE.md; this file isn't about who
+# decides what merges:
+#   - Brian (@brianbruff, EI6LF) — visual design, UX, architecture
+#     authority. Plugin SDK / VST3 / contracts owner.
+#   - Ramón (@rampa069, EA5IUE) — protocol + radio-state contributor.
+#   - Kb2uka (@Kb2uka, KB2UKA) — maintainer + audio-chain content
+#     owner (block choices, algorithm picks, defaults).
 #
 # Format reference: https://docs.github.com/en/repositories/managing-your-repositories-settings-and-security/customizing-your-repository/about-code-owners
 
-*       @Kb2uka
+*       @Kb2uka @brianbruff @rampa069

--- a/Zeus.Protocol1/ControlFrame.cs
+++ b/Zeus.Protocol1/ControlFrame.cs
@@ -65,22 +65,47 @@ internal static class ControlFrame
         Config = 0x00,
         TxFreq = 0x02,
         RxFreq = 0x04,
-        // RX2 NCO (DDC1). HL2-doc address 0x03 → wire byte 0x06. mi0bot
-        // 4-DDC layout for HL2: DDC1 holds RX2 / second-receiver freq,
-        // unrelated to PS. Zeus has no split-VFO so this just mirrors
-        // VfoAHz; harmless when DDC1 isn't being audio-routed.
+        // RX2 NCO (DDC1). HL2-doc address 0x03 → wire byte 0x06. In the
+        // upstream HL2 gateware, DDC1 shares `mix2_2` with DDC3
+        // (rtl/radio_openhpsdr1/radio.sv:515-540) — they take the same
+        // ADC input. During PS+MOX `mix2_2.adc` is switched to
+        // `tx_data_dac` (line 521: `(tx_on & pure_signal) ? tx_data_dac
+        // : adcpipe[1]`), so DDC1 ends up demodulating the pre-PA DAC
+        // samples at whatever NCO we set here. Zeus has no split-VFO
+        // and consumes DDC1 only as audio (when PS is off), so this
+        // just mirrors VfoAHz; the demodulated stream during PS+MOX is
+        // ignored (DDC3 is the canonical TX reference for pscc).
         RxFreq2 = 0x06,
-        // RX3 NCO (DDC2). HL2-doc address 0x04 → wire byte 0x08.
-        // mi0bot's HL2 4-DDC layout uses DDC2 as the **PureSignal RX
-        // feedback** stream (post-PA tap, fed to pscc as the "rx" arg).
-        // mi0bot networkproto1.c case 5 / WriteMainLoop_HL2: NCO = TX
-        // frequency. cmaster.cs:8537 routes psrx=2 when tot=5 (MOX+PS).
+        // RX3 NCO (DDC2). HL2-doc address 0x04 → wire byte 0x08. DDC2
+        // is fed by `mix2_0` (rtl/radio_openhpsdr1/radio.sv:484-495),
+        // shared with DDC0 — i.e. DDC2 reads `adcpipe[0]`, the real
+        // RF signal from HL2's single ADC. It is NEVER switched to
+        // `tx_data_dac`. During PS+MOX Zeus tunes this NCO to TX freq
+        // so DDC2 demodulates whatever the antenna is receiving at TX
+        // frequency. While keyed that is the **RF-leakage of the
+        // radiated TX signal** coupling back into the RX frontend —
+        // functionally it serves as the pscc "rx" feedback, but the
+        // mechanism is electromagnetic leakage, NOT a hardware coupler
+        // (HL2 has no internal feedback coupler — see
+        // docs/references/protocol-1/hermes-lite2-protocol.md
+        // "External coupler is the only working configuration"). This
+        // is why per-board HW peak calibration is mandatory; the
+        // leakage level is hardware-unit specific. See
+        // docs/lessons/hl2-ps-hwpeak-calibration.md.
+        // mi0bot cmaster.cs:8537 also picks `psrx=2` when tot=5 (MOX+
+        // PS); the wire layout matches even though the mi0bot comments
+        // describe the topology incorrectly.
         RxFreq3 = 0x08,
-        // RX4 NCO (DDC3). HL2-doc address 0x05 → wire byte 0x0a.
-        // mi0bot's HL2 4-DDC layout uses DDC3 as the **PureSignal TX
-        // reference** stream (TX-DAC loopback / clean modulator, fed to
-        // pscc as the "tx" arg). NCO = TX frequency. cmaster.cs:8538
-        // routes pstx=3 when tot=5.
+        // RX4 NCO (DDC3). HL2-doc address 0x05 → wire byte 0x0a. DDC3
+        // is fed by `mix2_2` (shared with DDC1 — see RxFreq2 above).
+        // During PS+MOX `mix2_2.adc` is `tx_data_dac` (pre-PA DAC
+        // output, 12-bit cordic sum from rtl/radio_openhpsdr1/radio.sv
+        // ≈ line 1016). With NCO = TX freq, DDC3 produces a clean
+        // baseband copy of the TX waveform straight out of the DAC —
+        // this IS the pscc "tx" reference, and it's the only feedback
+        // path on HL2 that is genuinely deterministic (independent of
+        // antenna load, leakage, room coupling, etc.). mi0bot
+        // cmaster.cs:8538 picks `pstx=3` when tot=5.
         RxFreq4 = 0x0a,
         DriveFilter = 0x12,
         // Extended RX attenuator + (HL2 only) PureSignal enable bit and LNA
@@ -92,23 +117,57 @@ internal static class ControlFrame
         // the user_dig_out nibble in C3, plus an extended C4 attenuator
         // range (0x40 | (60-Db)) — see WriteAttenuatorPayload.
         Attenuator = 0x14,
-        // ADC assignments + TX step attenuator. HL2-doc address 0x0e →
-        // wire byte 0x1c. C1 carries P1_adc_cntrl bits [7:0] — per-RX
-        // ADC source selector, 2 bits per RX (RX0 → bits[1:0],
-        // RX1 → bits[3:2], …). Mi0bot networkproto1.c case 4 +
-        // netInterface.c:917-930. For HL2 PureSignal during TX,
-        // cntrl1 = 4 (= bits[3:2] = 1) routes DDC1 onto ADC1 (the
-        // dedicated PA-coupler feedback ADC) so pscc sees the post-PA
-        // signal. Without this register, HL2 leaves DDC1 on ADC0 and
-        // pscc never converges (binfo[6]=0x0001 NaN cascade). C2 carries
-        // bits [13:8] (zero for HL2 — only RX0..RX3 used), C3 = ADC TX
-        // step attenuator (we leave 0).
-        AdcRouting = 0x1c,
+        // HL2 AD9866 PGA stable-gain control. HL2-doc address 0x0e →
+        // wire byte 0x1c.
+        //
+        // NOTE: mi0bot Thetis (and prior Zeus comments) call this the
+        // "ADC routing" / `P1_adc_cntrl` register, asserting that C1=0x04
+        // "routes DDC1 onto ADC1 (the dedicated PA-coupler feedback ADC)".
+        // That interpretation is WRONG for the upstream HL2 gateware:
+        //   1. HL2 has no internal feedback coupler and no second ADC
+        //      decoded in the gateware command path (see
+        //      docs/references/protocol-1/hermes-lite2-protocol.md
+        //      "External coupler is the only working configuration",
+        //      and rtl/radio_openhpsdr1/radio.sv — no 6'h0e decoder).
+        //   2. The actual gateware decoder for 6'h0e lives in
+        //      rtl/ad9866.sv:137-140 (FAST_LNA block) and reads
+        //      cmd_data[15] (en_tx_gain), cmd_data[14], cmd_data[13:8]
+        //      = TX LNA gain — not C1 / not ADC routing.
+        //
+        // What Zeus's write (C1=0x04, C2=C3=C4=0) actually does on
+        // upstream HL2: cmd_data[15]=0 → en_tx_gain=0, forcing the
+        // AD9866 PGA to keep `rx_gain` (set via 0x0a) during TX instead
+        // of switching to `tx_gain`. That keeps the PGA stable across
+        // RX↔TX transitions, which the leakage-based PS feedback path
+        // needs to converge — the C1=0x04 byte itself is ignored. The
+        // empirical observation from Issue #172 (PS converges with this
+        // write, NaN-cascades without it) was real, but for a different
+        // reason than the original "ADC routing" comment claimed.
+        //
+        // The HL2 PS feedback in the upstream gateware is not from a
+        // physical coupler. DDC2 reads adcpipe[0] (RF antenna) via
+        // mix2_0 at TX-freq NCO → demodulates radiated-TX leakage during
+        // MOX (= "post-PA" only in the loosest electromagnetic sense),
+        // and DDC3 reads tx_data_dac via mix2_2 at TX-freq NCO →
+        // demodulates the pre-PA DAC samples (the true clean TX
+        // reference for pscc). See docs/lessons/hl2-ps-hwpeak-calibration.md
+        // for why this leakage dependency requires per-board HW peak
+        // calibration.
+        LnaTxGainStable = 0x1c,
         // Predistortion config register 0x2b (HL2 PureSignal). C0 wire byte
-        // = 0x2b << 1 = 0x56. bits [31:24] = predistortion subindex (C1),
-        // bits [19:16] = predistortion value (C2 [3:0]). PR #119 review
-        // documents the common encoding mistake of placing the value in
-        // C2 [7:4] — do NOT shift it left.
+        // = 0x2b << 1 = 0x56. The HL2-protocol doc table reserves bits
+        // [19:16] = predistortion value (C2 [3:0]) for the host to write,
+        // but the upstream gateware actually only reads cmd_data[17:16]
+        // (= C2 [1:0]). See rtl/radio_openhpsdr1/radio.sv:288-293:
+        //   6'h2b: if (cmd_data[31:24]==8'h00) tx_predistort_next = cmd_data[17:16];
+        // Valid values fit in 2 bits: 0=off (identity), 1=on (LUT),
+        // 2=EER envelope. Bits [19:18] are decoded but read as zero on
+        // those values — keep writing the full nibble to stay forward-
+        // compatible with any derivative gateware that widens the field.
+        // bits [31:24] = predistortion subindex (C1) — the subindex value
+        // must equal 0x00 for the gateware to accept the value. PR #119
+        // review documents the common encoding mistake of placing the
+        // value in C2 [7:4] — do NOT shift it left.
         Predistortion = 0x56,
     }
 
@@ -226,8 +285,8 @@ internal static class ControlFrame
                 WriteAttenuatorPayload(cc[1..], in state);
                 break;
 
-            case CcRegister.AdcRouting:
-                WriteAdcRoutingPayload(cc[1..], in state);
+            case CcRegister.LnaTxGainStable:
+                WriteLnaTxGainStablePayload(cc[1..], in state);
                 break;
 
             case CcRegister.Predistortion:
@@ -291,23 +350,43 @@ internal static class ControlFrame
         }
     }
 
-    private static void WriteAdcRoutingPayload(Span<byte> c14, in CcState s)
+    private static void WriteLnaTxGainStablePayload(Span<byte> c14, in CcState s)
     {
-        // HL2 register 0x0e (C0 wire byte 0x1c). C1 carries the
-        // P1_adc_cntrl byte = per-RX ADC source selector packed 2 bits per
-        // RX (RX0 → bits[1:0], RX1 → bits[3:2], RX2 → bits[5:4],
-        // RX3 → bits[7:6]). 0 = ADC0 (main antenna), 1 = ADC1 (HL2's
-        // dedicated PA-coupler feedback ADC). For HL2 PureSignal during
-        // TX, mi0bot sets cntrl1=4 (= bits[3:2]=1) so DDC1 sources ADC1
-        // and pscc sees the post-PA signal. Outside PS+MOX, all RX → ADC0.
-        // C2 carries cntrl2 (RX4..RX6 — HL2 only has 4 DDCs in this
-        // codepath, leave 0). C3 = ADC[0].tx_step_attn (Zeus drives TX
-        // attenuation through the dedicated 0x14 path, leave 0 here).
-        bool psActive = s.PsEnabled && s.Mox && s.Board == HpsdrBoardKind.HermesLite2;
-        c14[0] = psActive ? (byte)0x04 : (byte)0;  // C1: cntrl1
-        c14[1] = 0;                                 // C2: cntrl2 (high bits of P1_adc_cntrl)
-        c14[2] = 0;                                 // C3: tx_step_attn (unused here)
-        c14[3] = 0;                                 // C4: reserved
+        // HL2 register 0x0e (C0 wire byte 0x1c). The upstream HL2 gateware
+        // decoder for this address (rtl/ad9866.sv:137-140, FAST_LNA block)
+        // reads:
+        //   cmd_data[15]    → en_tx_gain   (1 = use hardware-managed TX LNA gain)
+        //   cmd_data[14]    → TX gain sign/mode helper
+        //   cmd_data[13:8]  → TX gain value
+        // These bits live in C3 / C2 of the CC frame, NOT C1.
+        //
+        // We send all zeros, which sets en_tx_gain=0. With en_tx_gain=0
+        // the AD9866 PGA gain stays at `rx_gain` (set via 0x0a) during
+        // TX instead of switching to `tx_gain` — i.e. the PGA is stable
+        // across RX↔TX transitions. PS feedback on HL2 depends on this
+        // stability because DDC2 carries RF-leakage from the radiated TX
+        // (gain-dependent) and any PGA step on the MOX edge would shift
+        // its amplitude.
+        //
+        // The historical c14[0]=0x04 byte (= mi0bot's `cntrl1=4` for
+        // "route DDC1 onto ADC1") falls in cmd_data[31:24], which the
+        // gateware doesn't read at this address. It is ignored. We zero
+        // it out to make the wire honest about what we're actually
+        // controlling. PS still converges because what mattered all
+        // along was the en_tx_gain=0 (cmd_data[15]) bit — not the
+        // imagined ADC routing.
+        //
+        // Outside PS+MOX we still emit zeros: this preserves the same
+        // stable-gain invariant whenever the radio key-ups (MOX may flip
+        // before the next register-rotation tick lands), and matches the
+        // operator's expectation that Zeus does not touch hardware-
+        // managed TX LNA gain. Any operator UI for TX-managed LNA gain
+        // would need its own register slot; today Zeus has none.
+        _ = s; // CcState reserved for future per-board branching.
+        c14[0] = 0;   // C1 — cmd_data[31:24]: not read by gateware at 0x0e
+        c14[1] = 0;   // C2 — cmd_data[23:16]: not read by gateware at 0x0e
+        c14[2] = 0;   // C3 — cmd_data[15:8]: en_tx_gain + TX gain. Zero → disabled.
+        c14[3] = 0;   // C4 — cmd_data[7:0]:  not read by gateware at 0x0e
     }
 
     private static void WritePredistortionPayload(Span<byte> c14, in CcState s)

--- a/Zeus.Protocol1/Protocol1Client.cs
+++ b/Zeus.Protocol1/Protocol1Client.cs
@@ -247,13 +247,24 @@ public sealed class Protocol1Client : IProtocol1Client
     /// <summary>
     /// Decode an HL2 4-DDC PS-armed EP6 packet — mi0bot's canonical layout
     /// (Thetis console.cs:8186-8265, networkproto1.c:WriteMainLoop_HL2,
-    /// cmaster.cs:8511-8550 FOUR_DDC routing). Stream assignment:
-    ///   DDC0 = RX1 audio (operator's listening freq) → publish to IqFrame
-    ///          channel so the panadapter and audio chain stay alive even
-    ///          while PS is keying.
-    ///   DDC1 = RX2 / unused on HL2 → discarded.
-    ///   DDC2 = PS RX feedback (post-PA tap, NCO=TX freq) → pscc "rx" arg.
-    ///   DDC3 = PS TX reference (TX-DAC loopback, NCO=TX freq) → pscc "tx".
+    /// cmaster.cs:8511-8550 FOUR_DDC routing). Stream assignment, cross-
+    /// checked against the upstream HL2 gateware (rtl/radio_openhpsdr1/
+    /// radio.sv:484-540, mix2_0 + mix2_2 + pure_signal switch):
+    ///   DDC0 = RX1 audio. mix2_0+adcpipe[0] at VfoAHz → operator's
+    ///          listening freq, panadapter and audio chain stay alive
+    ///          even while PS is keying. Published to IqFrame channel.
+    ///   DDC1 = mix2_2 input (shared with DDC3) at VfoAHz NCO. During
+    ///          MOX+PS that input is `tx_data_dac`, so this DDC carries
+    ///          a wrong-NCO copy of the DAC samples; functionally
+    ///          useless, discarded.
+    ///   DDC2 = mix2_0+adcpipe[0] at TX freq → pscc "rx" arg. The
+    ///          "feedback" mechanism on HL2 is RF leakage of the
+    ///          radiated TX coupling back into the RX frontend — NOT a
+    ///          hardware coupler tap (HL2 has no internal coupler).
+    ///          Hence per-board HW peak calibration is mandatory.
+    ///   DDC3 = mix2_2+tx_data_dac at TX freq → pscc "tx" arg. The only
+    ///          deterministic feedback path on HL2 (pre-PA DAC samples
+    ///          demodulated to baseband).
     /// Pair DDC2 + DDC3 samples 1:1, accumulate 1024 paired complex samples,
     /// then emit a PsFeedbackFrame for the DspPipelineService pump.
     /// </summary>
@@ -620,12 +631,15 @@ public sealed class Protocol1Client : IProtocol1Client
         // Number of receivers requested in the Config payload (`(N-1) << 3`
         // in C4 bits [5:3]). mi0bot's HL2 path (Thetis console.cs:8186-8265)
         // uses **4 DDCs** during PS+MOX:
-        //   DDC0 → RX1 audio (operator's listening freq, stays alive!)
-        //   DDC1 → RX2 (or unused)
-        //   DDC2 → PS RX feedback (post-PA tap, NCO=TX freq) — pscc "rx"
-        //   DDC3 → PS TX reference (TX-DAC loopback, NCO=TX freq) — pscc "tx"
-        // Outside PS+MOX we stay at single-DDC so the existing 1-DDC EP6
-        // packet shape and parser are bit-exact unchanged.
+        //   DDC0 → RX1 audio (mix2_0+adcpipe[0] at VfoAHz) — stays alive!
+        //   DDC1 → mix2_2 input at VfoAHz, demods to junk during MOX+PS
+        //          (mix2_2.adc is forced to tx_data_dac then) — discarded.
+        //   DDC2 → mix2_0+adcpipe[0] at TX freq → pscc "rx". On HL2 this
+        //          is RF leakage of the radiated TX (no coupler hardware).
+        //   DDC3 → mix2_2+tx_data_dac at TX freq → pscc "tx" (pre-PA DAC).
+        // See HandlePs4DdcPacket above for the cross-reference to upstream
+        // gateware. Outside PS+MOX we stay at single-DDC so the existing
+        // 1-DDC EP6 packet shape and parser are bit-exact unchanged.
         byte numRxMinus1 = (byte)(psOn && isHl2 && moxOn ? 3 : 0);
 
         return new(
@@ -870,13 +884,18 @@ public sealed class Protocol1Client : IProtocol1Client
 
     /// <summary>
     /// Round-robin register selector. When <paramref name="psArmed"/> is true
-    /// the rotation is widened to 8 phases and includes the new HL2-PS
-    /// registers — RxFreq2 (DDC1 NCO) and AdcRouting (per-RX→ADC selector,
-    /// HL2-doc 0x0e). Without RxFreq2 the second DDC sits at 0 Hz; without
-    /// AdcRouting it samples ADC0 instead of the dedicated PA-coupler ADC1
-    /// — pscc would then see no useful feedback and binfo[6] would NaN out
-    /// (Issue #172, observed before this fix). Mirrors mi0bot
-    /// networkproto1.c:WriteMainLoop_HL2 case 2/3/4.
+    /// the rotation is widened to 16 phases and includes the HL2-PS
+    /// registers — RxFreq2/3/4 (the four-DDC NCOs) and LnaTxGainStable
+    /// (HL2-doc 0x0e, AD9866 TX-LNA gain control). Without RxFreq3/RxFreq4
+    /// DDC2/DDC3 sit at 0 Hz and pscc gets DC; without LnaTxGainStable the
+    /// AD9866 PGA may switch gain between RX and TX (if a prior client set
+    /// en_tx_gain=1), shifting the leakage-based feedback level on DDC2
+    /// across MOX edges — binfo[6]=0x0001 NaN cascade in pscc (Issue #172,
+    /// observed before this fix). The original "AdcRouting" name for 0x0e
+    /// was derived from mi0bot Thetis comments and does NOT match upstream
+    /// HL2 gateware semantics — see CcRegister.LnaTxGainStable for the
+    /// long-form explanation. Mirrors mi0bot networkproto1.c:WriteMainLoop_HL2
+    /// case 2/3/4 wire-byte-by-wire-byte even though the comments diverge.
     /// </summary>
     internal static (ControlFrame.CcRegister first, ControlFrame.CcRegister second) PhaseRegisters(
         int phase, bool mox, bool psArmed)
@@ -887,8 +906,8 @@ public sealed class Protocol1Client : IProtocol1Client
             if (mox)
             {
                 // PS+MOX (HL2 4-DDC). Every 16-frame window emits each of
-                // the seven PS-critical registers (Config, TxFreq, RxFreq,
-                // RxFreq2, RxFreq3, RxFreq4, AdcRouting, Attenuator,
+                // the nine PS-critical registers (Config, TxFreq, RxFreq,
+                // RxFreq2, RxFreq3, RxFreq4, LnaTxGainStable, Attenuator,
                 // DriveFilter) at least twice. RxFreq3/RxFreq4 carry the
                 // pscc TX/RX NCO frequencies — without them DDC2 and DDC3
                 // sit at 0 Hz and pscc gets DC. Predistortion is omitted;
@@ -901,7 +920,7 @@ public sealed class Protocol1Client : IProtocol1Client
                     3  => (ControlFrame.CcRegister.TxFreq,     ControlFrame.CcRegister.DriveFilter),
                     4  => (ControlFrame.CcRegister.RxFreq,     ControlFrame.CcRegister.RxFreq3),
                     5  => (ControlFrame.CcRegister.RxFreq2,    ControlFrame.CcRegister.RxFreq4),
-                    6  => (ControlFrame.CcRegister.AdcRouting, ControlFrame.CcRegister.TxFreq),
+                    6  => (ControlFrame.CcRegister.LnaTxGainStable, ControlFrame.CcRegister.TxFreq),
                     7  => (ControlFrame.CcRegister.Config,     ControlFrame.CcRegister.TxFreq),
                     8  => (ControlFrame.CcRegister.TxFreq,     ControlFrame.CcRegister.RxFreq3),
                     9  => (ControlFrame.CcRegister.RxFreq,     ControlFrame.CcRegister.RxFreq4),
@@ -909,12 +928,12 @@ public sealed class Protocol1Client : IProtocol1Client
                     11 => (ControlFrame.CcRegister.TxFreq,     ControlFrame.CcRegister.DriveFilter),
                     12 => (ControlFrame.CcRegister.RxFreq2,    ControlFrame.CcRegister.RxFreq3),
                     13 => (ControlFrame.CcRegister.RxFreq4,    ControlFrame.CcRegister.TxFreq),
-                    14 => (ControlFrame.CcRegister.AdcRouting, ControlFrame.CcRegister.RxFreq3),
+                    14 => (ControlFrame.CcRegister.LnaTxGainStable, ControlFrame.CcRegister.RxFreq3),
                     _  => (ControlFrame.CcRegister.Config,     ControlFrame.CcRegister.RxFreq4),
                 };
             }
-            // PS armed but RX-only: cache RxFreq3 / RxFreq4 / AdcRouting so
-            // the radio has them ready for the next MOX edge. Number-of-
+            // PS armed but RX-only: cache RxFreq3 / RxFreq4 / LnaTxGainStable
+            // so the radio has them ready for the next MOX edge. Number-of-
             // receivers in Config is 0 here so DDC2/DDC3 aren't streaming;
             // these writes are harmless.
             return q switch
@@ -925,7 +944,7 @@ public sealed class Protocol1Client : IProtocol1Client
                 3  => (ControlFrame.CcRegister.RxFreq,     ControlFrame.CcRegister.RxFreq2),
                 4  => (ControlFrame.CcRegister.RxFreq,     ControlFrame.CcRegister.RxFreq3),
                 5  => (ControlFrame.CcRegister.RxFreq,     ControlFrame.CcRegister.RxFreq4),
-                6  => (ControlFrame.CcRegister.AdcRouting, ControlFrame.CcRegister.RxFreq),
+                6  => (ControlFrame.CcRegister.LnaTxGainStable, ControlFrame.CcRegister.RxFreq),
                 7  => (ControlFrame.CcRegister.Attenuator, ControlFrame.CcRegister.RxFreq),
                 8  => (ControlFrame.CcRegister.RxFreq,     ControlFrame.CcRegister.Config),
                 9  => (ControlFrame.CcRegister.RxFreq,     ControlFrame.CcRegister.DriveFilter),
@@ -933,7 +952,7 @@ public sealed class Protocol1Client : IProtocol1Client
                 11 => (ControlFrame.CcRegister.RxFreq,     ControlFrame.CcRegister.Attenuator),
                 12 => (ControlFrame.CcRegister.RxFreq,     ControlFrame.CcRegister.RxFreq3),
                 13 => (ControlFrame.CcRegister.RxFreq,     ControlFrame.CcRegister.RxFreq4),
-                14 => (ControlFrame.CcRegister.RxFreq,     ControlFrame.CcRegister.AdcRouting),
+                14 => (ControlFrame.CcRegister.RxFreq,     ControlFrame.CcRegister.LnaTxGainStable),
                 _  => (ControlFrame.CcRegister.RxFreq,     ControlFrame.CcRegister.Config),
             };
         }

--- a/docs/designs/radio-support-audit.md
+++ b/docs/designs/radio-support-audit.md
@@ -161,7 +161,7 @@ HL2-specific control-frame encoding; all other boards use standard Protocol-1 se
 | Attenuator (0x14) | C4 = 0x40 \| (60 - Db); RX attn = inverse gain | 241–243 |
 | Attenuator (0x14) | TX step-atten override during MOX + PS active | 257–262 |
 | Attenuator (0x14) | PureSignal enable → C2 bit 6 | 277–280 |
-| AdcRouting (0x1c) | cntrl1 = 0x04 (DDC1 → ADC1) when PS+MOX active | 295–296 |
+| LnaTxGainStable (0x1c) | All zeros → en_tx_gain=0; AD9866 PGA holds RX gain across MOX (stable PS feedback). Note: mi0bot's historical "cntrl1=0x04 → DDC1→ADC1" reading does NOT match upstream HL2 gateware — see ControlFrame.cs:LnaTxGainStable and hermes-lite2-protocol.md "Feedback IQ". | 295–296 |
 | Predistortion (0x2b) | Subindex in C1, value [3:0] in C2 | 311–312 |
 | Config (0x00) | N2ADR filter-board auto-OC mask | 330–333 |
 | IQ Payload | TX IQ written only for HL2 during MOX | 421–437 |
@@ -319,7 +319,7 @@ Per-board PS hardware-peak defaults. Applies to both RXA/TXA WDSP engine scaling
 - `Zeus.Server.Hosting/RadioService.cs` — ConnectedBoardKind, EffectiveBoardKind, ResolvePsHwPeak, RecomputePaAndPush
 
 ### Wire Format
-- `Zeus.Protocol1/ControlFrame.cs` — HL2-specific register encodings (DriveFilter, Attenuator, AdcRouting, Predistortion, Config, IQ payload)
+- `Zeus.Protocol1/ControlFrame.cs` — HL2-specific register encodings (DriveFilter, Attenuator, LnaTxGainStable, Predistortion, Config, IQ payload)
 
 ### Tests
 - `tests/Zeus.Server.Tests/EffectiveBoardKindTests.cs` — Board kind resolution (P1 only)

--- a/docs/references/protocol-1/hermes-lite2-protocol.md
+++ b/docs/references/protocol-1/hermes-lite2-protocol.md
@@ -401,10 +401,35 @@ the value is C2 bits [3:0], **NOT [7:4]** — do not shift it left.
 
 ### Feedback IQ — gateware mechanism (the answered question)
 
-When `0x0a[22] = 1` and the radio is keyed, the HL2 gateware re-points its
-**dedicated feedback ADC (ADC1)** through one of the existing DDCs. The
-samples come back **inside the existing EP6 RX IQ stream** — there is **no
-new packet type or endpoint**.
+When `0x0a[22] = 1` and the radio is keyed, the upstream HL2 gateware
+switches one of the existing DDC mixer inputs from the antenna ADC sample
+(`adcpipe[1]`) to the pre-PA TX DAC sample (`tx_data_dac`) — see
+`rtl/radio_openhpsdr1/radio.sv:514-526`. The feedback samples come back
+**inside the existing EP6 RX IQ stream** — there is **no new packet type
+or endpoint**.
+
+**Correction (2026-05):** earlier revisions of this section described the
+mechanism as "the HL2 gateware re-points its dedicated feedback ADC
+(ADC1)" via "the `cntrl1` ADC-mapping byte the host writes in C0=0x1c".
+That phrasing was inherited from mi0bot Thetis comments and does not
+match upstream HL2 gateware:
+
+- Upstream HL2 decodes **one** ADC in the Protocol-1 command path
+  (`rffe_ad9866_rx`). `rtl/radio_openhpsdr1/radio.sv` and
+  `rtl/control.sv` have no `6'h0e` decoder for ADC routing.
+- The gateware decoder for `cmd_addr == 6'h0e` lives in
+  `rtl/ad9866.sv:137-140` (FAST_LNA block) and uses the bits to set
+  the AD9866 PGA TX-LNA gain (`en_tx_gain`, `tx_gain[5:0]`). That
+  matches the register table above (lines 63-65 — `0x0e [15]` Enable
+  hardware-managed LNA gain for TX, `[13:8]` TX gain value).
+- The mi0bot host-side write at `C0=0x1c` with C1=0x04 lands in
+  `cmd_data[31:24]`, which the gateware does not read at this
+  address. What the gateware DOES read is `cmd_data[15]` (= C3 bit
+  7, zero in mi0bot's write), setting `en_tx_gain = 0`. That keeps
+  the AD9866 PGA at `rx_gain` across both RX and TX — i.e. a stable
+  PGA across MOX edges, which is what PS actually needed. The "ADC
+  routing" framing was a misattribution; the underlying behaviour
+  works for the right reason once you unpack the wire byte.
 
 Of the four candidates the parent issue listed:
 
@@ -413,35 +438,48 @@ Of the four candidates the parent issue listed:
 - ❌ NOT a new packet type / endpoint (still EP6, port 1024 reply path,
   still 1032-byte Metis frames).
 - ❌ NOT a frequency-offset injection on RX1.
-- ✅ **It is a "second receiver re-pointed at the feedback ADC"** —
-  specifically, when PS is on, the HL2 firmware's gateware honours the
-  ADC-control bit (`SetADC_cntrl1`, see below) that maps a DDC to ADC1
-  instead of ADC0, and that DDC then carries the post-coupler feedback
-  samples. Which DDC index this lands on is set by the `nddc` count and the
-  `cntrl1` ADC-mapping byte the host writes in C0=0x1c.
+- ✅ **It is "DDCs whose mixer ADC input is switched to the TX DAC tap
+  when keyed"** — specifically, `mix2_2` (the mixer that feeds DDC1
+  and DDC3) has its `adc` port hard-wired to
+  `(tx_on & pure_signal) ? tx_data_dac : adcpipe[1]`
+  (`rtl/radio_openhpsdr1/radio.sv:521`). Whichever NCO the host sets
+  on `rx_phase[1]` or `rx_phase[3]` determines what TX-DAC content
+  ends up on DDC1 / DDC3. DDC0 and DDC2 (fed by `mix2_0`) keep
+  reading `adcpipe[0]`, the antenna ADC sample, unchanged.
 
 Two HL2 PS layouts exist in the wild:
 
 1. **Hermes-class 2-DDC layout** (mi0bot `networkproto1.c:990, 1005`) — when
    `nddc == 2` and `puresignal_run == 1` and `XmitBit == 1`, both DDC0 and
-   DDC1 are programmed to TX frequency, ADC mapping is set so DDC1 reads
-   ADC1 (feedback), and the EP6 packet carries paired DDC0/DDC1 samples
-   (12 bytes per pair: 3I+3Q for DDC0 then 3I+3Q for DDC1, repeating).
-   This is the simplest layout and matches bare Hermes / ANAN-10 / ANAN-100
-   gateware.
+   DDC1 are programmed to TX frequency, and the EP6 packet carries paired
+   DDC0/DDC1 samples (12 bytes per pair: 3I+3Q for DDC0 then 3I+3Q for
+   DDC1, repeating). On bare Hermes / ANAN-10 / ANAN-100 the ADC routing
+   does map DDC1 to the dedicated PA-coupler ADC1. On upstream HL2, DDC0
+   carries antenna RF at TX freq (= RF leakage of the radiated TX) and
+   DDC1 carries the TX-DAC tap (via `mix2_2`) — functionally analogous
+   from pscc's perspective even though the gateware mechanism differs.
 
 2. **HL2 4-DDC layout** (mi0bot `console.cs:8421-8503`, current default for
-   `HPSDRModel.HERMESLITE`) — `nddc = 4`, with DDC0=RX1, DDC1=RX2 (or
-   feedback, depending on `cntrl1`), DDC2 and DDC3 programmed to TX
-   frequency. When PS+TX is active, mi0bot sets `cntrl1 = 4` (=
-   `prn->rx[1].rx_adc = 1`, mapping DDC1 to ADC1 / feedback). The
-   `CMLoadRouterAll` table (mi0bot `cmaster.cs:699-718`) wires DDC2+DDC3
-   paired into the WDSP `psccF` block as the PS feedback stream when
-   control-bit 5 (TX|PS|noDIV) is asserted, and DDC1 alone goes into RX2's
-   audio path.
+   `HPSDRModel.HERMESLITE`) — `nddc = 4`, DDC0 = RX1 audio at VfoAHz,
+   DDC1 = RX2 NCO (junk during PS+MOX because `mix2_2` is forced to
+   `tx_data_dac`), DDC2 and DDC3 programmed to TX frequency. Per
+   upstream HL2 gateware: DDC2 (`mix2_0` + `adcpipe[0]` at TX freq) =
+   antenna RF demodulated to baseband ≈ RF leakage of the radiated TX
+   signal during MOX → pscc "rx" feedback. DDC3 (`mix2_2` +
+   `tx_data_dac` at TX freq) = pre-PA DAC samples demodulated to
+   baseband → pscc "tx" reference (deterministic, independent of
+   antenna).
 
-   pihpsdr `old_protocol.c:895-980` confirms this for HL2 with explicit
-   constants: `rx_feedback_channel(DEVICE_HERMES_LITE2) = 2`,
+   mi0bot's `cntrl1 = 4` write at `C0=0x1c` is folklore that survives
+   from Hermes/ANAN-era ADC routing; on upstream HL2 it has no
+   ADC-routing effect (the bits aren't decoded that way at this
+   address) but its side-effect of `en_tx_gain=0` keeps the AD9866
+   PGA stable across MOX, which the leakage-based DDC2 feedback path
+   needs to converge.
+
+   pihpsdr `old_protocol.c:895-980` confirms the host-side layout for
+   HL2 with explicit constants:
+   `rx_feedback_channel(DEVICE_HERMES_LITE2) = 2`,
    `tx_feedback_channel(DEVICE_HERMES_LITE2) = 3`,
    `how_many_receivers(DEVICE_HERMES_LITE2 with PS) = 4`.
 


### PR DESCRIPTION
## Summary

Carry the two infra-shaped changes from develop into main:

- **#417** — `chore(codeowners): co-own with @brianbruff and @rampa069`. CODEOWNERS applies per-branch, so without this propagation main would still gate every PR on @Kb2uka only. Brian and Ramón need this on main so they can approve / merge release-merges and hotfixes without admin bypass.
- **#412** — `fix(ps): align HL2 PureSignal comments + identifier with upstream gateware` (@rampa069). Enum rename `AdcRouting` → `LnaTxGainStable` (identifier-only, byte value stable) plus expanded gateware-cross-reference comments and doc updates. No behavioral change.

Per CLAUDE.md "infra/workflow PRs target main": CODEOWNERS qualifies. PS rename is hitching a ride since it's already on develop and there's no reason to hold it back.

## Test plan

- [x] Both source PRs already merged on develop with green CI on all three platforms.
- [ ] After merge to main, open the standard back-merge `main → develop` PR to keep develop one commit ahead with the merge metadata, per the post-release convention.