### PR TITLE
docs(p2): clarify byte 37 = 0x08 + HzToPhase comments — bit 3 not decoded on upstream HDL (#416)

### DIFF
--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -700,11 +700,21 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         p[26] = 16;
         p[27] = 0;
         p[28] = 32;
-        // Matches pihpsdr new_protocol_general for ORION2/SATURN hardware:
-        // [37] bit 3 = phase-word mode (radio reads phase increments at the
-        // DDC-frequency offsets, not raw Hz), [38] = hardware-timer enable,
-        // [58] = PA enable, [59] = Alex0|Alex1 enable (0x03 is required on
-        // MkII for the BPF board to honour the alex bits further down).
+        // Matches pihpsdr new_protocol_general for ORION2/SATURN hardware.
+        //
+        // [37] = 0x08: pihpsdr writes this on ORION2/SATURN. The upstream
+        // HDL `General_CC.v:136-140` (Hermes Protocol-2 v10.7 and
+        // Orion_MkII v2.2.10) only decodes `cmd_data[0]` at byte 37
+        // (Time_stamp/VITA_49/VNA — all driven from the same bit). Bit 3
+        // is NOT read by `General_CC.v`, and the radio is already in
+        // phase-word mode by default — `Hermes.v` / `Orion.v` wire the
+        // host-supplied 32-bit phase word straight into the receiver
+        // mixers (see `C122_phase_word` in Hermes.v line 1135 and 1284).
+        // Kept at 0x08 for parity with pihpsdr; no observable effect on
+        // this gateware revision. Issue #416.
+        //
+        // [38] = 0x01: hardware-timer enable (`HW_timer_enable`, decoded
+        // at `General_CC.v:141`).
         p[37] = 0x08;
         p[38] = 0x01;
         // [58] bit 0 = PA enable (piHPSDR `new_protocol.c:658-677`; Thetis

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -92,9 +92,16 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // sets `receiver[i].ddc = i` (not `i + 2` as for Orion/Angelia/MkII).
     private const int HermesRxDdc = 0;
 
-    // 2^32 / 122_880_000 — converts Hz to a 32-bit phase-increment word
-    // when the general packet is in "send phase word" mode (bit 3 of
-    // CmdGeneral[37], which pihpsdr and Thetis both set).
+    // 2^32 / 122_880_000 — converts Hz to a 32-bit phase-increment word.
+    // The HPSDR Protocol-2 receiver mixers always operate on phase-word
+    // input: the upstream HDL wires the host-supplied 32-bit phase
+    // straight into the receiver cores (see `C122_phase_word` in
+    // `Hermes.v:1135` and `Hermes.v:1284`, identical pattern in
+    // `Orion.v`). The "bit 3 of CmdGeneral[37]" mode-select pihpsdr and
+    // Thetis both set has no decoder in `General_CC.v` (and no
+    // secondary decoder elsewhere in `Hermes.v` / `Orion.v` —
+    // verified). Kept for parity with pihpsdr; this constant is the
+    // unconditional Hz→phase scale. Issue #416.
     private const double HzToPhase = 34.952533333333333;
 
     private readonly ILogger<Protocol2Client> _log;


### PR DESCRIPTION
Closes #416 (will remain open until next release per CONTRIBUTING.md hygiene).

## Summary

Doc-only fix. Two comments in `Zeus.Protocol2/Protocol2Client.cs` claimed bit 3 of CmdGeneral byte 37 enables "phase-word mode" on the radio. RTL audit against OpenHPSDR-Firmware Protocol 2 v10.7 (Hermes) and v2.2.10 (Orion_MkII) shows bit 3 has no decoder anywhere — the radio is permanently in phase-word mode by design.

## Addressing @kb2uka-agent's clarifying questions on #416

> **Q1**: Have you checked the top-level Hermes.v / Orion.v files (not just General_CC.v) for any secondary decode of `udp_rx_data[3]` on CC address 37?

**Verified — no secondary decoder.** Grep across all `.v` files in both extracted bitfile sources:

- Files that reference `byte_number` at all: only the four C&C decoder modules (`General_CC.v`, `High_Priority_CC.v`, `Tx_specific_C&C.v`, `Rx_specific_C&C.v`). `Hermes.v` and `Orion.v` top-level do not.
- `General_CC.v:136-140` is the only place byte 37 is parsed, and it only reads `udp_rx_data[0]`.
- The radio is permanently in phase-word mode: `C122_phase_word` is wired straight from the host frequency word into the receiver mixers (`Hermes.v:1135` and `Hermes.v:1284`; identical pattern in `Orion.v`).

> **Q2**: Does the existing `HzToPhase` constant comment originate from the same unverified pihpsdr cargo-culting?

**Yes.** Original comment at `Protocol2Client.cs:95-97` claimed:
> "converts Hz to a 32-bit phase-increment word when the general packet is in 'send phase word' mode (bit 3 of CmdGeneral[37], which pihpsdr and Thetis both set)"

Same misattribution. Updated in the second commit on this PR.

## What changed

- `Zeus.Protocol2/Protocol2Client.cs:703-719` — comment block above `p[37] = 0x08; p[38] = 0x01;` cites the exact HDL file:line and notes the radio is already in phase-word mode by default.
- `Zeus.Protocol2/Protocol2Client.cs:95-104` — `HzToPhase` constant comment rewritten the same way; the scale is unconditional.

## What did NOT change

- **No wire bytes.** `p[37] = 0x08` is preserved.
- No identifier renames, no test changes, no API changes.
- No public-API impact.

## Test plan

- [x] `dotnet build Zeus.slnx` — 0 warnings, 0 errors.
- [x] `dotnet test Zeus.Protocol2.Tests` — 90/90 pass.
- [ ] Not required for doc-only.

## References

- Issue: #416
- HDL: OpenHPSDR-Firmware `Protocol 2/Hermes (ANAN-10 and 100)/Hermes_1000T_firmware/Hermes_Protocol_2_v10.7.qar` and `Protocol 2/Orion_MkII (ANAN-7000DLE-8000DLE)/Orion2_P2_v2.2.10.qar` (`.qar` extracted to inspect the Verilog).

## Notes for reviewer

@kb2uka-agent's comment on the issue flagged "maintainer sign-off needed before touching Protocol 2 send paths even for doc-only edits, per CLAUDE.md". This PR doesn't touch the send path itself, only comments around it. Happy to defer to your judgement.