### PR TITLE
feat(p2): expose ADC1/RX1 step attenuator (byte 1442) (#415)

### DIFF
--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -147,6 +147,13 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // typically drive unconnected hardware. Variant-aware gating is a
     // separable follow-up. Issue #414.
     private byte _dleOutputs;
+    // Second ADC step attenuator (0..31 dB) for ADC1 — bytes the upstream
+    // HDL decodes at `High_Priority_CC.v:186-189` as `Attenuator1`. Used
+    // by operators running dual-RX on dual-ADC boards (Orion_MkII, G2,
+    // Saturn) where RX0/RX1 sit on separate ADCs and need independent
+    // gain. Default 0 dB matches the radio's power-on state; no UI surface
+    // yet, but the wire byte is in place. Issue #415.
+    private byte _rx1StepAttnDb;
     // TX step attenuator (0..31 dB) — Thetis network.c:1238-1242 writes the
     // same value to bytes 57/58/59 of CmdTx (one per ADC tap). The PS
     // auto-attenuate loop adjusts this when info[4] feedback level lands
@@ -520,6 +527,18 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         _dleOutputs = enabled
             ? (byte)(_dleOutputs | 0x04)
             : (byte)(_dleOutputs & ~0x04);
+        if (_rxTask is not null) SendCmdHighPriority(run: true);
+    }
+
+    /// <summary>
+    /// Set the second-ADC RX step attenuator (0..31 dB), written to byte
+    /// 1442 of the High Priority Command (`Attenuator1` per
+    /// `High_Priority_CC.v:186-189`). Used for dual-RX dual-ADC boards
+    /// where RX1 sits on a separate ADC and needs independent gain.
+    /// </summary>
+    public void SetRx1Attenuator(int db)
+    {
+        _rx1StepAttnDb = (byte)Math.Clamp(db, 0, 31);
         if (_rxTask is not null) SendCmdHighPriority(run: true);
     }
 
@@ -1097,6 +1116,11 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         p[1403] = (byte)(_preampOn ? 0x01 : 0x00);
 
         // ADC0 step attenuator (0-31 dB). Thetis network.c:1057.
+        // ADC1 step attenuator (0-31 dB) at byte 1442 — `Attenuator1` per
+        // `High_Priority_CC.v:186-189` (both Hermes and Orion_MkII RTL).
+        // Defaults to 0; set via SetRx1Attenuator for dual-RX dual-ADC
+        // boards. Issue #415.
+        p[1442] = _rx1StepAttnDb;
         p[1443] = _rxStepAttnDb;
 
         // Alex words. Bit positions and BPF selections per pihpsdr's alex.h +


### PR DESCRIPTION
Closes #415 (stays open until next release per CONTRIBUTING.md hygiene).

## Summary

Adds backend wiring for the second-ADC step attenuator that the HPSDR P2 HDL has always decoded (`High_Priority_CC.v:186-189` on both Hermes and Orion_MkII) but Zeus has been leaving at 0.

@kb2uka-agent on #415 confirmed the approach:

> The suggested fix (add `_rx1StepAttnDb`, a `SetRx1AttenuationDb(byte)` setter, and `p[1442] = _rx1StepAttnDb` in `SendCmdHighPriority`) is a straightforward backend-only change; no wire-format (`Zeus.Contracts`) changes needed.

(Named the setter `SetRx1Attenuator` to match the existing `SetAttenuator` naming for byte 1443 rather than `SetRx1AttenuationDb`.)

## RTL evidence

`High_Priority_CC.v:186-189` (identical in Hermes v10.7 and Orion_MkII v2.2.10):

```verilog
1442: begin Attenuator1 <= udp_rx_data[4:0]; Alex_data_ready <= 1'b1; end
1443: begin Attenuator0 <= udp_rx_data[4:0]; Alex_data_ready <= 1'b0; end
```

Both fields are 5-bit (0..31 dB). Symmetric to byte 1443 which has been working in production.

## Changes

- `Zeus.Protocol2/Protocol2Client.cs:128-134` — new `_rx1StepAttnDb` field, defaulted to 0.
- `Zeus.Protocol2/Protocol2Client.cs:467-477` — `SetRx1Attenuator(int)` setter, clamped 0..31, fires fresh `SendCmdHighPriority` when live.
- `Zeus.Protocol2/Protocol2Client.cs:1029-1034` — `p[1442] = _rx1StepAttnDb;` sitting next to the existing `p[1443] = _rxStepAttnDb;`.

## Scope notes

- No UI surface. Dual-RX dual-ADC workflow is its own project; this PR just lays the wire so callers can drive it when the UI lands.
- No `Zeus.Contracts` change.
- No public API removal — only addition.

## Tests

`SendCmdHighPriority` lacks a static `Compose` seam (unlike `SendCmdRx` / `SendCmdTx` which have `ComposeCmdRxBuffer` / `ComposeCmdTxBuffer` for wire-format tests). Adding the seam is a separable refactor and I didn't bundle it into this change — the change is mechanically symmetric to byte 1443 which has been on-air for months.

If a reviewer wants the test seam in this PR I'm happy to add it; flagging it as a sibling future improvement rather than scope creep here.

## Test plan

- [x] `dotnet build Zeus.slnx` — 0 warnings, 0 errors.
- [x] `dotnet test Zeus.Protocol2.Tests` — 90/90 pass.
- [ ] Bench: not required (no behaviour change for any operator who isn't calling the new setter; default 0 dB matches current state).

## Reference

- Issue: #415
- HDL: `OpenHPSDR-Firmware/Protocol 2/.../High_Priority_CC.v:186-189` (both boards).