### PR TITLE
feat(p2): expose DLE_outputs byte 1400 — XVTR / IO1 / AUTO_TUNE (#414)

### DIFF
--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -126,6 +126,20 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // needed via the UI. Attenuator 0 dB so the front-end isn't knocked down.
     private bool _preampOn;
     private byte _rxStepAttnDb;
+    // DLE_outputs byte (`High_Priority_CC.v:195` on Orion_MkII, byte 1400).
+    // Drives three physical control lines on ANAN-8000DLE / AnvelinaPro3
+    // chassis (`Orion.v:2119,2122,2125`):
+    //   bit 0 = XVTR_enable        (0=disabled, 1=enabled)
+    //   bit 1 = IO1                (0=enabled,  1=muted)  — inverted polarity
+    //   bit 2 = AUTO_TUNE          (0=disabled, 1=enabled)
+    // Defaults 0 (current effective state — Zeus has been leaving the byte
+    // zeroed since the buffer is `new byte[BufLen]`). Use SetXvtrEnabled /
+    // SetIo1Muted / SetAutoTuneEnabled to compose. Hermes RTL doesn't
+    // decode byte 1400, so emission is harmless on non-Orion_MkII boards.
+    // On non-8000DLE Orion_MkII variants (G2, G2 MkII) the pins exist but
+    // typically drive unconnected hardware. Variant-aware gating is a
+    // separable follow-up. Issue #414.
+    private byte _dleOutputs;
     // TX step attenuator (0..31 dB) — Thetis network.c:1238-1242 writes the
     // same value to bytes 57/58/59 of CmdTx (one per ADC tap). The PS
     // auto-attenuate loop adjusts this when info[4] feedback level lands
@@ -459,6 +473,46 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     public void SetAttenuator(int db)
     {
         _rxStepAttnDb = (byte)Math.Clamp(db, 0, 31);
+        if (_rxTask is not null) SendCmdHighPriority(run: true);
+    }
+
+    /// <summary>
+    /// Enable / disable the XVTR control line on ANAN-8000DLE / Anvelina
+    /// chassis (`DLE_outputs[0]` per `Orion.v:2119`). Other boards / variants:
+    /// no observable effect (Hermes doesn't decode byte 1400; non-8000DLE
+    /// Orion_MkII variants leave the pin unconnected).
+    /// </summary>
+    public void SetXvtrEnabled(bool enabled)
+    {
+        _dleOutputs = enabled
+            ? (byte)(_dleOutputs | 0x01)
+            : (byte)(_dleOutputs & ~0x01);
+        if (_rxTask is not null) SendCmdHighPriority(run: true);
+    }
+
+    /// <summary>
+    /// Mute / unmute the IO1 control line on ANAN-8000DLE / Anvelina
+    /// chassis (`DLE_outputs[1]` per `Orion.v:2122`). Polarity is inverted:
+    /// the RTL comment is "low to enable, high to mute" — `muted=true` sets
+    /// the bit.
+    /// </summary>
+    public void SetIo1Muted(bool muted)
+    {
+        _dleOutputs = muted
+            ? (byte)(_dleOutputs | 0x02)
+            : (byte)(_dleOutputs & ~0x02);
+        if (_rxTask is not null) SendCmdHighPriority(run: true);
+    }
+
+    /// <summary>
+    /// Enable / disable AUTO_TUNE on ANAN-8000DLE / Anvelina chassis
+    /// (`DLE_outputs[2]` per `Orion.v:2125`).
+    /// </summary>
+    public void SetAutoTuneEnabled(bool enabled)
+    {
+        _dleOutputs = enabled
+            ? (byte)(_dleOutputs | 0x04)
+            : (byte)(_dleOutputs & ~0x04);
         if (_rxTask is not null) SendCmdHighPriority(run: true);
     }
 
@@ -1014,6 +1068,12 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         // tune carrier and damage the finals. Thetis behaves this way too.
         byte ocBits = (_moxOn || _tuneActive) ? _ocTxMask : _ocRxMask;
         p[1401] = (byte)((ocBits & 0x7F) << 1);
+
+        // DLE_outputs byte for ANAN-8000DLE / AnvelinaPro3 (`Orion.v` line
+        // 2119/2122/2125). Default 0; flipped by SetXvtrEnabled /
+        // SetIo1Muted / SetAutoTuneEnabled. Hermes RTL doesn't decode byte
+        // 1400, so emission is harmless on non-Orion_MkII boards. Issue #414.
+        p[1400] = _dleOutputs;
 
         // Mercury attenuator byte: bit 0 = RX0 preamp, bit 1 = RX1 preamp
         // (Thetis network.c:1037).


### PR DESCRIPTION
Closes #414 (stays open until next release per CONTRIBUTING.md hygiene).

## Summary

Adds backend wiring for the `DLE_outputs` control byte (byte 1400 in the High Priority Command) that Orion_MkII HDL decodes for ANAN-8000DLE / AnvelinaPro3 physical control lines. Zeus has been leaving the byte at 0; this PR makes it explicitly settable.

## Resolving @kb2uka-agent's clarifying questions on #414

> **Q1**: Can you confirm the exact bit assignment for `DLE_outputs` (bit 0 = XVTR_enable, bit 1 = IO1)?

**Found it in the RTL itself** — `Orion.v` lines 2119/2122/2125 (more authoritative than a pihpsdr cross-reference):

```verilog
wire XVTR_ENABLE, AUTO_TUNE;
assign XVTR_ENABLE = DLE_outputs[0];
...
assign IO1 = DLE_outputs[1];           // low to enable, high to mute
...
assign AUTO_TUNE = DLE_outputs[2];     // high to enable auto-tune
```

So there are **three** controls, not two:
- bit 0 = XVTR_enable (0=disabled, 1=enabled)
- bit 1 = IO1 (0=enabled, 1=muted) — **inverted polarity**, called out in the setter name `SetIo1Muted`
- bit 2 = AUTO_TUNE (0=disabled, 1=enabled)

The issue body only mentioned XVTR + IO1; the RTL audit caught AUTO_TUNE too. All three are now exposed.

> **Q2**: Is this reproducible on real hardware, or inferred from RTL audit?

Inferred from the RTL audit only (I don't have an 8000DLE / Anvelina to bench-test). The change is fail-safe: default `_dleOutputs = 0` keeps the byte at 0, matching the current effective behaviour. A bench-equipped operator can verify by setting one bit at a time and watching the physical line.

> **Q3**: Should these share a fix branch with #413?

Kept separate per CONTRIBUTING.md "one feature per PR". #413 (Hermes Alex bit positions) is a different concern.

## Changes

- `Zeus.Protocol2/Protocol2Client.cs:129-143` — new `_dleOutputs` field with documentation of the bit layout.
- `Zeus.Protocol2/Protocol2Client.cs:467-505` — three semantic setters (`SetXvtrEnabled`, `SetIo1Muted`, `SetAutoTuneEnabled`).
- `Zeus.Protocol2/Protocol2Client.cs:1029-1033` — `p[1400] = _dleOutputs;` in `SendCmdHighPriority`.

## What did NOT change

- No variant gating (only emit on 8000DLE / Anvelina). The agent flagged this as desirable; plumbing `OrionMkIIVariant` into `Protocol2Client` is a separable refactor. Current always-emit form is harmless: Hermes RTL doesn't decode byte 1400, and on non-8000DLE Orion_MkII variants the pins drive unconnected hardware. Default 0 preserves existing behaviour.
- No UI surface. Operator-facing UI is red-light per CONTRIBUTING.md.
- No tests in this PR — `SendCmdHighPriority` lacks a static `Compose` seam (same constraint noted on #422 for #415).

## Test plan

- [x] `dotnet build Zeus.slnx` — 0 warnings, 0 errors.
- [x] `dotnet test Zeus.Protocol2.Tests` — 90/90 pass.
- [ ] Bench-verify on a real ANAN-8000DLE: call `SetXvtrEnabled(true)` and observe the XVTR control line goes high. No volunteer with 8000DLE access yet.

## References

- Issue: #414
- HDL: `OpenHPSDR-Firmware/Protocol 2/Orion_MkII (ANAN-7000DLE-8000DLE)/Orion.v` lines 2119/2122/2125, `High_Priority_CC.v:195`.
- Sibling: #422 (#415 backend wiring with the same scope-limitation note).