### PR TITLE
fix(p2): branch Alex BPF/HPF bits by board — classic Alex vs ANAN-7000 (#413)

### DIFF
--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -1032,7 +1032,7 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         // harmonics. Alex1 additionally gets RX_GNDonTX to short the RX input
         // while keyed, protecting the ADC.
         bool xmit = _moxOn || _tuneActive;
-        uint alexCommon = ComputeAlexWord(_rxFreqHz, _rxFreqHz, txAnt: 1);
+        uint alexCommon = ComputeAlexWord(_rxFreqHz, _rxFreqHz, txAnt: 1, board: _boardKind);
         uint alex0 = alexCommon | (xmit ? ALEX_TX_RELAY : 0u);
         uint alex1 = alexCommon | (xmit ? ALEX_TX_RELAY | ALEX1_ANAN7000_RX_GNDonTX : 0u);
         // ALEX_PS_BIT (0x00040000): pihpsdr new_protocol.c:994-998 ORs this
@@ -1102,6 +1102,19 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // back-feed into the Mercury ADC (pihpsdr alex.h ANAN7000_RX_GNDonTX).
     private const uint ALEX1_ANAN7000_RX_GNDonTX = 0x00000100;
 
+    // Classic Alex RX HPF bits (Hermes / ANAN-10/100/100D/200D / HermesII).
+    // pihpsdr alex.h:78-84. Note these bit positions collide with
+    // ANAN7000 RX BPF bits — they're the same bits in the Alex0 word
+    // but mean DIFFERENT filters depending on which board is connected.
+    // Issue #413.
+    private const uint ALEX_13MHZ_HPF  = 0x00000002;  // bit 1
+    private const uint ALEX_20MHZ_HPF  = 0x00000004;  // bit 2
+    private const uint ALEX_6M_PREAMP  = 0x00000008;  // bit 3 (35 MHz HPF + LNA)
+    private const uint ALEX_9_5MHZ_HPF = 0x00000010;  // bit 4
+    private const uint ALEX_6_5MHZ_HPF = 0x00000020;  // bit 5
+    private const uint ALEX_1_5MHZ_HPF = 0x00000040;  // bit 6
+    private const uint ALEX_BYPASS_HPF = 0x00001000;  // bit 12
+
     /// <summary>
     /// Compose the alex0 word the way <see cref="SendCmdHighPriority"/>
     /// does, exposed internal so wire-format tests can assert the
@@ -1112,20 +1125,27 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         uint rxFreqHz,
         bool moxOn,
         bool psEnabled,
-        bool psExternal)
+        bool psExternal,
+        HpsdrBoardKind board = HpsdrBoardKind.OrionMkII)
     {
-        uint alexCommon = ComputeAlexWord(rxFreqHz, rxFreqHz, txAnt: 1);
+        uint alexCommon = ComputeAlexWord(rxFreqHz, rxFreqHz, txAnt: 1, board: board);
         uint alex0 = alexCommon | (moxOn ? ALEX_TX_RELAY : 0u);
         if (psEnabled && moxOn) alex0 |= AlexPsBit;
         if (psEnabled && psExternal && moxOn) alex0 |= AlexRxAntennaBypass;
         return alex0;
     }
 
-    internal static uint ComputeAlexWord(uint rxFreqHz, uint txFreqHz, int txAnt)
+    internal static uint ComputeAlexWord(uint rxFreqHz, uint txFreqHz, int txAnt, HpsdrBoardKind board = HpsdrBoardKind.OrionMkII)
     {
         uint word = 0;
-        word |= BpfBitsAnan7000(rxFreqHz);
-        word |= LpfBitsAnan7000(txFreqHz);
+        word |= board is HpsdrBoardKind.Hermes or HpsdrBoardKind.HermesII
+            ? BpfBitsClassicAlex(rxFreqHz)
+            : BpfBitsAnan7000(rxFreqHz);
+        // LPF bit positions and band thresholds are identical across both
+        // filter-board generations (classic Alex on Hermes/ANAN-100 vs
+        // ANAN-7000/Saturn BPF board) — confirmed against pihpsdr alex.h
+        // and new_protocol.c. Same call for every board.
+        word |= LpfBits(txFreqHz);
         word |= txAnt switch
         {
             1 => ALEX_TX_ANTENNA_1,
@@ -1138,6 +1158,8 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
 
     // RX BPF band splits lifted from pihpsdr new_protocol.c
     // (function new_protocol_high_priority, ADC0 BPFfreq selection).
+    // ANAN-7000 / Orion-II / Saturn filter board only — see
+    // BpfBitsClassicAlex for the Hermes / ANAN-100 layout.
     internal static uint BpfBitsAnan7000(uint freqHz)
     {
         if (freqHz <  1_500_000u) return ALEX_ANAN7000_RX_BYPASS_BPF;
@@ -1149,11 +1171,33 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         return ALEX_ANAN7000_RX_6_PRE_BPF;
     }
 
+    // RX HPF band splits for the classic Alex filter board (Hermes,
+    // ANAN-10, ANAN-100, ANAN-100D, ANAN-200D, HermesII / ANAN-10E,
+    // ANAN-100B). Bit positions and thresholds lifted from pihpsdr
+    // alex.h and new_protocol.c:1154-1168. Note these are high-pass
+    // filters (not band-pass like the ANAN-7000 BPF board) — same low
+    // bits in the Alex0 word but different semantic per board.
+    // Issue #413.
+    internal static uint BpfBitsClassicAlex(uint freqHz)
+    {
+        if (freqHz <  1_800_000u) return ALEX_BYPASS_HPF;
+        if (freqHz <  6_500_000u) return ALEX_1_5MHZ_HPF;
+        if (freqHz <  9_500_000u) return ALEX_6_5MHZ_HPF;
+        if (freqHz < 13_000_000u) return ALEX_9_5MHZ_HPF;
+        if (freqHz < 20_000_000u) return ALEX_13MHZ_HPF;
+        if (freqHz < 50_000_000u) return ALEX_20MHZ_HPF;
+        return ALEX_6M_PREAMP;
+    }
+
     // TX LPF band splits. Thresholds match pihpsdr new_protocol.c:1204-1218
     // exactly (strict > rather than >= so the band edges route the way the
     // LPF board expects; off-by-one on a threshold lets the wrong filter
-    // pass harmonics at e.g. 24.9 MHz or 16.4 MHz).
-    internal static uint LpfBitsAnan7000(uint freqHz)
+    // pass harmonics at e.g. 24.9 MHz or 16.4 MHz). Bit positions and
+    // thresholds are identical across classic Alex and ANAN-7000 BPF
+    // boards — only the RX filter selection differs per board. Issue #413
+    // renamed this from LpfBitsAnan7000 to LpfBits to reflect the shared
+    // scope.
+    internal static uint LpfBits(uint freqHz)
     {
         if (freqHz > 35_600_000u) return ALEX_6_BYPASS_LPF;
         if (freqHz > 24_000_000u) return ALEX_12_10_LPF;

--- a/tests/Zeus.Protocol2.Tests/HermesAlexBitsTests.cs
+++ b/tests/Zeus.Protocol2.Tests/HermesAlexBitsTests.cs
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Xunit;
+using Zeus.Contracts;
+
+namespace Zeus.Protocol2.Tests;
+
+/// <summary>
+/// Hermes / HermesII Alex bit-selection divergence (issue #413).
+///
+/// The classic Alex filter board shipped on Hermes / ANAN-10 / ANAN-100 /
+/// ANAN-100D / ANAN-200D / HermesII (ANAN-10E / ANAN-100B) uses RX HPFs
+/// at low bits of the Alex0 word. The ANAN-7000 / Orion-II / Saturn BPF
+/// board uses RX BPFs at the *same* low bits with *different* semantic
+/// meaning per band. Picking the wrong table silently selects the wrong
+/// filter (or none) — see pihpsdr alex.h comments and
+/// <c>new_protocol.c:1154-1168</c>.
+///
+/// These tests pin the per-board branch in
+/// <see cref="Protocol2Client.ComputeAlexWord"/>: Hermes/HermesII route
+/// through <see cref="Protocol2Client.BpfBitsClassicAlex"/>, everything
+/// else routes through <see cref="Protocol2Client.BpfBitsAnan7000"/>.
+/// </summary>
+public class HermesAlexBitsTests
+{
+    // 7 MHz (40m) — clearest divergence: classic Alex selects the
+    // 6.5 MHz HPF (bit 5, 0x20), ANAN-7000 selects the 40/30m BPF
+    // (bit 4, 0x10). Different bit values, so the test fails loudly
+    // if the branch routes the wrong way.
+    [Fact]
+    public void Hermes_40m_Selects_ClassicAlex_6_5MHz_HPF()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: 7_100_000, moxOn: false, psEnabled: false, psExternal: false,
+            board: HpsdrBoardKind.Hermes);
+
+        Assert.Equal(0x00000020u, alex0 & 0xFFFFu);
+    }
+
+    [Fact]
+    public void HermesII_40m_Selects_ClassicAlex_6_5MHz_HPF()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: 7_100_000, moxOn: false, psEnabled: false, psExternal: false,
+            board: HpsdrBoardKind.HermesII);
+
+        Assert.Equal(0x00000020u, alex0 & 0xFFFFu);
+    }
+
+    [Fact]
+    public void OrionMkII_40m_Selects_Anan7000_40_30_BPF()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: 7_100_000, moxOn: false, psEnabled: false, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII);
+
+        Assert.Equal(0x00000010u, alex0 & 0xFFFFu);
+    }
+
+    // 3.5 MHz (80m) — another divergence:
+    // classic = ALEX_1_5MHZ_HPF (bit 6, 0x40); ANAN-7000 = ALEX_ANAN7000_RX_80_60_BPF (bit 5, 0x20).
+    [Fact]
+    public void Hermes_80m_Selects_ClassicAlex_1_5MHz_HPF()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: 3_500_000, moxOn: false, psEnabled: false, psExternal: false,
+            board: HpsdrBoardKind.Hermes);
+
+        Assert.Equal(0x00000040u, alex0 & 0xFFFFu);
+    }
+
+    [Fact]
+    public void OrionMkII_80m_Selects_Anan7000_80_60_BPF()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: 3_500_000, moxOn: false, psEnabled: false, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII);
+
+        Assert.Equal(0x00000020u, alex0 & 0xFFFFu);
+    }
+
+    // < 1.8 MHz on classic Alex selects ALEX_BYPASS_HPF (bit 12) — the
+    // classic board has no 160m HPF (only a bypass at low freq). The
+    // ANAN-7000 BPF board has a dedicated 160m BPF at bit 6 plus bypass
+    // at bit 12 below 1.5 MHz. Test 1.0 MHz to assert both pick bit 12
+    // (same bit value, same meaning — sanity check that not all bands
+    // diverge).
+    [Fact]
+    public void Hermes_Below_1_8MHz_Selects_BypassHpf()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: 1_000_000, moxOn: false, psEnabled: false, psExternal: false,
+            board: HpsdrBoardKind.Hermes);
+
+        Assert.Equal(0x00001000u, alex0 & 0xFFFFu);
+    }
+
+    // 50 MHz (6m) — both layouts pick the bit-3 filter (classic =
+    // ALEX_6M_PREAMP; ANAN-7000 = ALEX_ANAN7000_RX_6_PRE_BPF). Same
+    // bit value, similar effective meaning. Sanity check.
+    [Fact]
+    public void Hermes_6m_Selects_6M_Preamp()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: 50_100_000, moxOn: false, psEnabled: false, psExternal: false,
+            board: HpsdrBoardKind.Hermes);
+
+        Assert.Equal(0x00000008u, alex0 & 0xFFFFu);
+    }
+
+    // LPF bits are shared across both filter boards. Same TX freq,
+    // any board, same LPF. Asserted via the public ComputeAlexWord
+    // entry on its own.
+    [Fact]
+    public void LpfBits_Are_Shared_Across_Boards()
+    {
+        uint a = Protocol2Client.ComputeAlexWord(
+            rxFreqHz: 14_100_000, txFreqHz: 14_100_000, txAnt: 1,
+            board: HpsdrBoardKind.Hermes);
+        uint b = Protocol2Client.ComputeAlexWord(
+            rxFreqHz: 14_100_000, txFreqHz: 14_100_000, txAnt: 1,
+            board: HpsdrBoardKind.OrionMkII);
+
+        // Both will pick the 30/20m LPF (bit 20 = 0x00100000). The RX
+        // filter (low bits) is allowed to differ; mask it out and assert
+        // the LPF + TX_ANT bits match.
+        const uint highMask = 0xFFFF0000u;
+        Assert.Equal(a & highMask, b & highMask);
+    }
+}


### PR DESCRIPTION
Closes #413 (stays open until next release per CONTRIBUTING.md hygiene).

## Summary

The classic Alex filter board (Hermes / ANAN-10 / ANAN-100 / ANAN-100D / ANAN-200D / HermesII = ANAN-10E / ANAN-100B) uses RX **HPFs** at the low bits of the Alex0 word. The ANAN-7000 / Orion-II / Saturn BPF board uses RX **BPFs** at the *same* low bits with different per-band meaning. `ComputeAlexWord` was unconditionally selecting ANAN-7000 BPF bits — Hermes / ANAN-100 owners running Protocol 2 would silently get wrong filter selection (or none) for most bands.

This PR adds a board-aware branch in `ComputeAlexWord` — same pattern already used in `RxBaseDdc`.

## Addressing @kb2uka-agent feedback on #413

> Note that the LPF constants (bytes 1076–1082) may be shared between layouts; the BPF constants are the diverging ones.

**Confirmed via pihpsdr `alex.h`** — bit positions and band thresholds for LPF are identical (`ALEX_30_20_LPF` = 0x00100000 etc.). Applied as a rename: `LpfBitsAnan7000` → `LpfBits` so the shared scope is visible at the function name. Only the BPF/HPF function diverges per board.

> A maintainer with bench access to a Hermes or ANAN-100 should verify before merge.

Acknowledged. I don't have a Hermes / ANAN-100 to bench-test. The change is fail-safe — Orion_MkII path is bit-exact unchanged (default parameter preserves the existing call site behaviour); Hermes path moves from "wrong bits, silent" to "correct bits per pihpsdr alex.h".

> Clarifying questions for the reporter (board, symptom, RX/TX)

Those remain for any field reporter — this PR is a code-audit fix derived from RTL + pihpsdr cross-reference rather than a field report.

## Changes

- `Zeus.Protocol2/Protocol2Client.cs:1105-1112` — 7 new private constants for classic Alex HPF bits (`ALEX_13MHZ_HPF` through `ALEX_BYPASS_HPF`, per `pihpsdr alex.h:78-84`).
- `Zeus.Protocol2/Protocol2Client.cs:1140-1152` — `ComputeAlexWord` takes a new `HpsdrBoardKind board` parameter (default `OrionMkII`); routes through `BpfBitsClassicAlex` for Hermes / HermesII, `BpfBitsAnan7000` for everything else.
- `Zeus.Protocol2/Protocol2Client.cs:1181-1190` — new `BpfBitsClassicAlex(uint freqHz)` returning the classic-Alex HPF bits per band (thresholds from `pihpsdr new_protocol.c:1154-1168`).
- `Zeus.Protocol2/Protocol2Client.cs:1192-1207` — `LpfBitsAnan7000` → `LpfBits` rename + comment.
- `Zeus.Protocol2/Protocol2Client.cs:1111-1116` — `ComposeAlex0ForTest` gains the board parameter (default `OrionMkII`).
- `Zeus.Protocol2/Protocol2Client.cs:1035` — `SendCmdHighPriority` passes `_boardKind` into `ComputeAlexWord`.
- `tests/Zeus.Protocol2.Tests/HermesAlexBitsTests.cs` — 8 new tests pinning per-board branch for 7 MHz, 3.5 MHz, 1 MHz, 50 MHz; LPF shared-scope assertion.

## What did NOT change

- Orion_MkII / G2 / Saturn behaviour is bit-exact unchanged. All existing tests still pass; the default parameter on `ComputeAlexWord` / `ComposeAlex0ForTest` preserves every call site.
- No `Zeus.Contracts` change, no UI, no removal of public API.

## Test plan

- [x] `dotnet build Zeus.slnx` — 0 warnings, 0 errors.
- [x] `dotnet test Zeus.Protocol2.Tests` — 98/98 pass (8 new in `HermesAlexBitsTests`).
- [ ] **Bench-verify on Hermes / ANAN-100 over Protocol 2**: tune to 40 m (7.1 MHz) and confirm the filter board selects the 6.5 MHz HPF (audible by listening for in-band noise that disappears when tuned below 6.5 MHz). Without bench access I can't do this — flagging for a maintainer or operator who has one.

## References

- Issue: #413
- pihpsdr: `src/alex.h:78-84` (classic HPF bits), `src/new_protocol.c:1154-1168` (band thresholds).
- HDL audit (cross-reference): `OpenHPSDR-Firmware/Protocol 2/Hermes (ANAN-10 and 100)/Hermes_1000T_firmware/Hermes_Protocol_2_v10.7.qar` and Orion_MkII v2.2.10.
- Sibling PRs from the same audit: #419 (#416 doc), #422 (#415 byte 1442), #423 (#414 byte 1400).