### PR TITLE
chore(codeowners): co-own with @dl1bz (Heiko, DL1BZ)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,19 +1,21 @@
 # OpenHPSDR Zeus — Code Owners
 #
-# Every path is co-owned by @Kb2uka, @brianbruff, and @rampa069.
+# Every path is co-owned by @Kb2uka, @brianbruff, @rampa069, and @dl1bz.
 # Combined with branch protection on `develop` and `main` (require
-# approving review from a code owner), this means any one of the three
+# approving review from a code owner), this means any one of the four
 # can approve + merge a PR — but GitHub still blocks self-approval, so
-# the PR author always needs an approval from one of the other two.
+# the PR author always needs an approval from one of the others.
 #
 # Roles are still defined per CLAUDE.md; this file isn't about who
 # decides what merges:
 #   - Brian (@brianbruff, EI6LF) — visual design, UX, architecture
 #     authority. Plugin SDK / VST3 / contracts owner.
 #   - Ramón (@rampa069, EA5IUE) — protocol + radio-state contributor.
+#   - Heiko (@dl1bz, DL1BZ) — maintainer of upstream DeskHPSDR; one of
+#     Zeus's Protocol-2 / PureSignal / Saturn-class references.
 #   - Kb2uka (@Kb2uka, KB2UKA) — maintainer + audio-chain content
 #     owner (block choices, algorithm picks, defaults).
 #
 # Format reference: https://docs.github.com/en/repositories/managing-your-repositories-settings-and-security/customizing-your-repository/about-code-owners
 
-*       @Kb2uka @brianbruff @rampa069
+*       @Kb2uka @brianbruff @rampa069 @dl1bz


### PR DESCRIPTION
## Summary
- Add `@dl1bz` (Heiko, DL1BZ — maintainer of [DeskHPSDR](https://github.com/dl1bz/deskhpsdr)) to `.github/CODEOWNERS` alongside @Kb2uka, @brianbruff, and @rampa069.
- DeskHPSDR is already credited in CLAUDE.md and every SPDX header as one of Zeus's Protocol-2 / PureSignal / Saturn-class references.
- Effect: any one of the four can approve + merge PRs; GitHub still blocks self-approval, so the author always needs an approving review from one of the others.
- Pairs with the collaborator invite (`gh api PUT /repos/Kb2uka/openhpsdr-zeus/collaborators/dl1bz -f permission=push`) sent today.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, opening a fresh PR shows @dl1bz auto-requested for review alongside the other three code owners

🤖 Generated with [Claude Code](https://claude.com/claude-code)