### PR TITLE
feat(#427): CTUN (Click-Tune) — freeze radio NCO while dial roams

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -254,7 +254,24 @@ public sealed record StateDto(
     // Independent TUN drive slider 0..100. Same persistence pattern as
     // DrivePct. Default 10 mirrors RadioService._tunePct seed — a 0 default
     // would make pressing TUN appear to do nothing on first key.
-    int TunePct = 10);
+    int TunePct = 10,
+
+    // ---- CTUN (Click-Tune) — issue #427 ----
+    // When CtunEnabled is false (default), VfoHz drives both the radio's
+    // hardware NCO and the panadapter centre — clicking the spectrum retunes
+    // the radio. When true, the hardware NCO is frozen at RadioLoHz and
+    // clicking only moves VfoHz around within the displayed bandwidth; WDSP's
+    // RX bandpass is shifted by (VfoHz - RadioLoHz) so the audio still
+    // resolves the operator's tuned signal. Mirrors Thetis chkFWCATU /
+    // ClickTuneDisplay (console.cs:43143-43170, 10857-10867).
+    bool CtunEnabled = false,
+    // Hardware NCO frequency in Hz. Tracks VfoHz when CTUN is OFF; frozen at
+    // the value VfoHz had when CTUN was toggled ON. RadioService is
+    // authoritative; persisted to LiteDB so the radio re-tunes to the same
+    // hardware centre on reconnect when CTUN was on. Zero on a fresh server
+    // before the first state hydration; RadioService snaps it to VfoHz at
+    // construction so the displayed centre is never zero.
+    long RadioLoHz = 0);
 
 public sealed record RadioInfo(
     string MacAddress,
@@ -277,6 +294,8 @@ public sealed record ConnectRequest(
     byte? BoardId = null);
 
 public sealed record VfoSetRequest(long Hz);
+
+public sealed record CtunSetRequest(bool Enabled);
 
 public sealed record ModeSetRequest(RxMode Mode);
 

--- a/Zeus.Dsp/IDspEngine.cs
+++ b/Zeus.Dsp/IDspEngine.cs
@@ -62,6 +62,16 @@ public interface IDspEngine : IDisposable
     void SetMode(int channelId, RxMode mode);
     void SetFilter(int channelId, int lowHz, int highHz);
     void SetVfoHz(int channelId, long vfoHz);
+
+    /// <summary>
+    /// CTUN frequency shift — moves the IF by <paramref name="shiftHz"/>
+    /// before demodulation so the bandpass filter sees the tuned signal at
+    /// baseband while the radio's hardware NCO stays put. Pass 0 to disable
+    /// the shift stage (legacy behaviour). Mirrors Thetis radio.cs:1419-1420
+    /// (the WDSP <c>SetRXAShiftFreq</c> + <c>RXANBPSetShiftFrequency</c>
+    /// pair). Issue #427.
+    /// </summary>
+    void SetCtunShift(int channelId, int shiftHz);
     void SetAgcTop(int channelId, double topDb);
 
     /// <summary>Set the RX master AF gain in dB. Drives WDSP's

--- a/Zeus.Dsp/SyntheticDspEngine.cs
+++ b/Zeus.Dsp/SyntheticDspEngine.cs
@@ -98,6 +98,8 @@ public sealed class SyntheticDspEngine : IDspEngine
         if (_channels.TryGetValue(channelId, out var s)) s.VfoHz = vfoHz;
     }
 
+    public void SetCtunShift(int channelId, int shiftHz) { /* synthetic has no IF stage */ }
+
     public void SetAgcTop(int channelId, double topDb) { /* synthetic has no AGC */ }
 
     public void SetRxAfGainDb(int channelId, double db) { /* synthetic has no audio path */ }

--- a/Zeus.Dsp/Wdsp/NativeMethods.cs
+++ b/Zeus.Dsp/Wdsp/NativeMethods.cs
@@ -104,6 +104,29 @@ internal static partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial void SetRXABandpassRun(int channel, int run);
 
+    // CTUN frequency shift — WDSP's `shift` stage (wdsp/shift.c). Mirrors the
+    // Thetis trio at radio.cs:1419: when the operator clicks off-centre while
+    // CTUN is on we shift the IF by (dial - radioLoHz) so the tuned signal
+    // lands at baseband for the (unmodified) bandpass filter. Calling
+    // SetRXABandpassFreqs with a shifted range works for the bp1 stage but
+    // breaks SSB (the nbp0 stage that actually enforces the SSB passband
+    // expects sideband-signed values; a negative-going CTUN offset on USB
+    // crashes WDSP). The shift stage is the correct seam. Issue #427.
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetRXAShiftFreq(int channel, double freq);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetRXAShiftRun(int channel, int run);
+
+    // Paired with SetRXAShiftFreq — Thetis radio.cs:1420 calls both together.
+    // nbp0 is the SSB-enforcing notch-bandpass stage and needs the same
+    // shift applied to keep its passband centred on the tuned signal.
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void RXANBPSetShiftFrequency(int channel, double freq);
+
     [LibraryImport(LibraryName)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial void SetRXABandpassWindow(int channel, int wintype);

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -525,6 +525,18 @@ public sealed class WdspDspEngine : IDspEngine
         // tuner; frequency translation happens at the protocol seam.
     }
 
+    public void SetCtunShift(int channelId, int shiftHz)
+    {
+        if (!_channels.TryGetValue(channelId, out var _)) return;
+        // Mirrors Thetis radio.cs:1419-1420. Note the negation: Thetis tracks
+        // an `rx_osc = -(dial - centre)` then calls SetRXAShiftFreq(-osc), so
+        // the net argument is (dial - centre) = our shiftHz. Same goes to
+        // the nbp0 stage that enforces SSB sideband.
+        NativeMethods.SetRXAShiftFreq(channelId, shiftHz);
+        NativeMethods.RXANBPSetShiftFrequency(channelId, shiftHz);
+        NativeMethods.SetRXAShiftRun(channelId, shiftHz != 0 ? 1 : 0);
+    }
+
     public void SetAgcTop(int channelId, double topDb)
     {
         if (!_channels.TryGetValue(channelId, out var state)) return;

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -126,6 +126,13 @@ public class DspPipelineService : BackgroundService,
     private RxMode _appliedMode = RxMode.USB;
     private int _appliedLowHz;
     private int _appliedHighHz;
+    // CTUN bandpass shift currently applied to the WDSP RX filter (Hz). Equals
+    // (EffectiveLoHz(VfoHz) - RadioLoHz) when CtunEnabled, 0 otherwise. The
+    // filter low/high pushed to WDSP is the operator-set passband + this
+    // offset. Tracked separately from FilterLowHz/HighHz so re-pushing the
+    // filter when CTUN moves the dial doesn't require Mutate-ing the StateDto.
+    // Issue #427.
+    private int _appliedCtunOffsetHz;
     private int _appliedTxLowHz;
     private int _appliedTxHighHz;
     private double _appliedAgcTopDb;
@@ -497,8 +504,14 @@ public class DspPipelineService : BackgroundService,
         // ActiveClient is null for P2 connections, so the radio never learns
         // about tune changes without this forward. Sample rate / mode follow
         // here too when P2-side support is added.
+        //
+        // CTUN — issue #427. When CTUN is on the hardware NCO is frozen at
+        // RadioLoHz: every state change must push that frozen value (not the
+        // operator's roaming dial) so dial movements stay confined to the
+        // WDSP filter-shift path and don't physically retune the radio.
         var p2 = _p2Client;
-        p2?.SetVfoAHz(CwOffset.EffectiveLoHz(s));
+        long p2TargetHz = s.CtunEnabled ? s.RadioLoHz : CwOffset.EffectiveLoHz(s);
+        p2?.SetVfoAHz(p2TargetHz);
 
         // iter5 pass-2: lock-free engine pointer read. The lock previously
         // here only provided pointer atomicity (the engine.* calls below
@@ -523,6 +536,22 @@ public class DspPipelineService : BackgroundService,
             engine.SetFilter(channel, s.FilterLowHz, s.FilterHighHz);
             _appliedLowHz = s.FilterLowHz;
             _appliedHighHz = s.FilterHighHz;
+        }
+        // CTUN frequency shift — issue #427. When CtunEnabled, the operator's
+        // dial sits off-centre on the WDSP IF (the radio's NCO is frozen at
+        // RadioLoHz). WDSP's `shift` stage moves the IF by shiftHz before
+        // demodulation, so the unmodified bandpass filter sees the tuned
+        // signal at baseband. Disabled (shiftHz=0) when CtunEnabled is false,
+        // which collapses to legacy behaviour. This is the seam Thetis uses
+        // (radio.cs:1419-1420); shifting SetRXABandpassFreqs directly broke
+        // SSB demod because the nbp0 stage rejects sign-inverted ranges.
+        int ctunShiftHz = s.CtunEnabled
+            ? (int)(CwOffset.EffectiveLoHz(s.Mode, s.VfoHz) - s.RadioLoHz)
+            : 0;
+        if (ctunShiftHz != _appliedCtunOffsetHz)
+        {
+            engine.SetCtunShift(channel, ctunShiftHz);
+            _appliedCtunOffsetHz = ctunShiftHz;
         }
         if (s.TxFilterLowHz != _appliedTxLowHz || s.TxFilterHighHz != _appliedTxHighHz)
         {
@@ -790,6 +819,14 @@ public class DspPipelineService : BackgroundService,
         engine.SetFilter(channelId, s.FilterLowHz, s.FilterHighHz);
         engine.SetTxFilter(s.TxFilterLowHz, s.TxFilterHighHz);
         engine.SetVfoHz(channelId, s.VfoHz);
+        // Replay any CTUN shift on fresh-channel open so a connect landing
+        // with CtunEnabled already true (persisted across restart) is
+        // demodulating the same dial the operator saw last session.
+        // Issue #427.
+        int ctunShiftHz = s.CtunEnabled
+            ? (int)(CwOffset.EffectiveLoHz(s.Mode, s.VfoHz) - s.RadioLoHz)
+            : 0;
+        engine.SetCtunShift(channelId, ctunShiftHz);
         double effectiveAgc = s.AgcTopDb + s.AgcOffsetDb;
         engine.SetAgcTop(channelId, effectiveAgc);
         engine.SetRxAfGainDb(channelId, s.RxAfGainDb);
@@ -798,6 +835,7 @@ public class DspPipelineService : BackgroundService,
         _appliedMode = s.Mode;
         _appliedLowHz = s.FilterLowHz;
         _appliedHighHz = s.FilterHighHz;
+        _appliedCtunOffsetHz = ctunShiftHz;
         _appliedTxLowHz = s.TxFilterLowHz;
         _appliedTxHighHz = s.TxFilterHighHz;
         _appliedAgcTopDb = s.AgcTopDb;
@@ -1476,7 +1514,15 @@ public class DspPipelineService : BackgroundService,
             // extra contract field needed, per task #7 scope note.
             int zoomLevel = Math.Max(1, state.ZoomLevel);
             float hzPerPixel = (float)((double)sampleRate / zoomLevel / Width);
-            long centerHz = CwOffset.EffectiveLoHz(state);
+            // Panadapter centre = the radio's actual NCO. When CTUN is off this
+            // equals EffectiveLoHz(dial) (legacy behaviour). When CTUN is on the
+            // hardware is frozen at RadioLoHz while the dial roams, so the
+            // pan/waterfall must not follow the dial — they stay anchored to
+            // RadioLoHz so the spectrum doesn't slide under the operator on
+            // every click. Issue #427.
+            long centerHz = state.CtunEnabled
+                ? state.RadioLoHz
+                : CwOffset.EffectiveLoHz(state);
 
             // Cache for the frequency-calibration service (issue #325). The
             // cal reads from this cache to avoid racing for WDSP's "fresh

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -291,7 +291,15 @@ public sealed class RadioService : IDisposable
             // rsSnap block; mirror them into the StateDto so SetDrive doesn't
             // become the only path that puts these into the broadcast.
             DrivePct: Volatile.Read(ref _drivePct),
-            TunePct: Volatile.Read(ref _tunePct));
+            TunePct: Volatile.Read(ref _tunePct),
+            // CTUN — issue #427. Persisted in RadioStateStore so the operator's
+            // last click-tune mode survives restart. RadioLoHz snaps to VfoHz
+            // on legacy rows (RadioLoHz==0) so the panadapter centre is never
+            // zero on a fresh row written by an older build.
+            CtunEnabled: rsSnap?.CtunEnabled ?? false,
+            RadioLoHz: (rsSnap?.RadioLoHz ?? 0L) != 0L
+                ? rsSnap!.RadioLoHz
+                : (rsSnap?.VfoHz ?? 14_200_000));
 
         // Kick off the debounce flush timer. Fires every 1 s; only writes to
         // LiteDB when _stateDirty is set (i.e., at least one Mutate() has fired
@@ -470,7 +478,14 @@ public sealed class RadioService : IDisposable
                 }
             }
             await client.StartAsync(new StreamConfig(hpsdrRate, _preampOn, _atten), ct).ConfigureAwait(false);
-            client.SetVfoAHz(CwOffset.EffectiveLoHz(Snapshot()));
+            // CTUN-on across restart: retune the radio to the persisted hardware
+            // NCO (RadioLoHz), not to EffectiveLoHz(dial), so the operator's
+            // last frozen centre is restored. Issue #427.
+            var connectSnap = Snapshot();
+            long connectLoHz = connectSnap.CtunEnabled
+                ? connectSnap.RadioLoHz
+                : CwOffset.EffectiveLoHz(connectSnap);
+            client.SetVfoAHz(connectLoHz);
 
             // Default-on the N2ADR 7-relay filter board for HL2 — mirrors
             // Thetis's HERCULES preset (setup.cs:14642). Most HL2 deployments
@@ -563,13 +578,24 @@ public sealed class RadioService : IDisposable
         long clamped = Math.Clamp(hz, 0L, 60_000_000L);
         long previous;
         RxMode currentMode;
-        lock (_sync) { previous = _state.VfoHz; currentMode = _state.Mode; }
-        Mutate(s => s with { VfoHz = clamped });
-        // CW retunes the LO cw_pitch below/above the dial so the listening
-        // freq lands on the +cw_pitch / -cw_pitch audio passband. In SSB /
-        // AM / FM / DIG modes EffectiveLoHz returns the dial value
-        // unchanged, preserving prior behaviour.
-        ActiveClient?.SetVfoAHz(CwOffset.EffectiveLoHz(currentMode, clamped));
+        bool ctun;
+        lock (_sync) { previous = _state.VfoHz; currentMode = _state.Mode; ctun = _state.CtunEnabled; }
+        // CTUN ON: don't retune the hardware NCO. The radio stays at RadioLoHz
+        // and WDSP's RX bandpass is shifted by DspPipelineService so the
+        // operator's tuned signal still lands inside the passband. Issue #427.
+        // CTUN OFF: legacy behaviour — RadioLoHz tracks VfoHz so the radio is
+        // re-tuned to the clamped dial.
+        Mutate(s => ctun
+            ? s with { VfoHz = clamped }
+            : s with { VfoHz = clamped, RadioLoHz = clamped });
+        if (!ctun)
+        {
+            // CW retunes the LO cw_pitch below/above the dial so the listening
+            // freq lands on the +cw_pitch / -cw_pitch audio passband. In SSB /
+            // AM / FM / DIG modes EffectiveLoHz returns the dial value
+            // unchanged, preserving prior behaviour.
+            ActiveClient?.SetVfoAHz(CwOffset.EffectiveLoHz(currentMode, clamped));
+        }
         // Band edge crossed? Per-band PA gain / OC bits may have swapped — push
         // the new snapshot before the next TX frame ships. Cheap when no
         // crossing occurred (same bytes re-pushed).
@@ -577,6 +603,49 @@ public sealed class RadioService : IDisposable
         {
             RecomputePaAndPush();
         }
+        return Snapshot();
+    }
+
+    /// <summary>
+    /// Toggle CTUN (Click-Tune) mode. On enable, the hardware NCO is frozen at
+    /// the current VfoHz — subsequent SetVfo calls update the dial without
+    /// retuning the radio, and the DSP pipeline shifts the RX bandpass to keep
+    /// the operator's tuned signal demodulated. On disable, RadioLoHz snaps
+    /// back to VfoHz and the radio is re-tuned to the current dial so the
+    /// hardware centre matches what the operator sees again. Mirrors Thetis
+    /// chkFWCATU_CheckedChanged (console.cs:43143-43170). Issue #427.
+    /// </summary>
+    public StateDto SetCtun(bool enabled)
+    {
+        long retuneTo = 0;
+        RxMode currentMode = RxMode.USB;
+        bool retune = false;
+        Mutate(s =>
+        {
+            if (s.CtunEnabled == enabled) return s;
+            currentMode = s.Mode;
+            if (enabled)
+            {
+                // Freeze the hardware NCO at its CURRENT value — which equals
+                // EffectiveLoHz(dial), accounting for cw_pitch in CWU/CWL. Using
+                // s.VfoHz directly would be wrong on CW: the hardware is at
+                // dial ± cw_pitch, not at the dial itself.
+                return s with
+                {
+                    CtunEnabled = true,
+                    RadioLoHz = CwOffset.EffectiveLoHz(s.Mode, s.VfoHz),
+                };
+            }
+            // Re-snap the hardware NCO to the operator's current dial and
+            // retune the radio to match below, outside the lock. RadioLoHz
+            // tracks the dial when CTUN is off so SetVfo's CTUN-off branch
+            // can keep RadioLoHz == VfoHz invariant.
+            retune = true;
+            retuneTo = s.VfoHz;
+            return s with { CtunEnabled = false, RadioLoHz = s.VfoHz };
+        });
+        if (retune)
+            ActiveClient?.SetVfoAHz(CwOffset.EffectiveLoHz(currentMode, retuneTo));
         return Snapshot();
     }
 
@@ -1597,6 +1666,8 @@ public sealed class RadioService : IDisposable
                 CwTxFilterLoAbs = cwTx.LoAbs,   CwTxFilterHiAbs = cwTx.HiAbs,
                 DrivePct = snap.DrivePct,
                 TunePct = snap.TunePct,
+                CtunEnabled = snap.CtunEnabled,
+                RadioLoHz = snap.RadioLoHz,
                 UpdatedUtc = DateTime.UtcNow,
             });
         }

--- a/Zeus.Server.Hosting/RadioStateStore.cs
+++ b/Zeus.Server.Hosting/RadioStateStore.cs
@@ -154,6 +154,16 @@ public sealed class RadioStateEntry
     // TUN drive slider % (0..100). Default 10 mirrors RadioService._tunePct seed —
     // a 0 default would make pressing TUN appear to do nothing.
     public int TunePct { get; set; } = 10;
+    // CTUN — issue #427. When true, RadioLoHz is frozen and clicking the
+    // panadapter moves VfoHz instead of the radio. Persisted so the operator's
+    // last click-tune mode survives restart; missing on legacy rows defaults
+    // to false (Thetis parity).
+    public bool CtunEnabled { get; set; }
+    // Hardware NCO at last flush. Persisted alongside CtunEnabled so a
+    // restart-while-CTUN-on retunes the radio to the same physical centre.
+    // Zero on legacy rows; RadioService snaps it to VfoHz on hydration in
+    // that case.
+    public long RadioLoHz { get; set; }
     // Per-mode-family RX filter memory (abs values, always positive)
     public int SsbFilterLoAbs { get; set; } = 150;
     public int SsbFilterHiAbs { get; set; } = 2850;

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -289,6 +289,16 @@ public static class ZeusEndpoints
             return r.SetVfo(req.Hz);
         });
 
+        // CTUN (Click-Tune) — issue #427. When enabled the hardware NCO is
+        // frozen at the current VfoHz so subsequent SetVfo calls move only the
+        // dial / WDSP filter offset, not the radio. RadioService.SetCtun
+        // handles the radio retune on disable.
+        app.MapPost("/api/ctun", (CtunSetRequest req, RadioService r) =>
+        {
+            log.LogInformation("api.ctun enabled={Enabled}", req.Enabled);
+            return r.SetCtun(req.Enabled);
+        });
+
         app.MapPost("/api/mode", (ModeSetRequest req, RadioService r) =>
         {
             log.LogInformation("api.mode mode={Mode}", req.Mode);

--- a/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
@@ -178,6 +178,7 @@ public class MicGainEndpointTests : IClassFixture<MicGainEndpointTests.Factory>
         public void SetMode(int channelId, RxMode mode) { }
         public void SetFilter(int channelId, int lowHz, int highHz) { }
         public void SetVfoHz(int channelId, long vfoHz) { }
+        public void SetCtunShift(int channelId, int shiftHz) { }
         public void SetAgcTop(int channelId, double topDb) { }
         public void SetRxAfGainDb(int channelId, double db) { }
         public void SetNoiseReduction(int channelId, NrConfig cfg) { }

--- a/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
+++ b/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
@@ -86,6 +86,7 @@ public class TxAudioIngestTests
         public void SetMode(int channelId, RxMode mode) { }
         public void SetFilter(int channelId, int lowHz, int highHz) { }
         public void SetVfoHz(int channelId, long vfoHz) { }
+        public void SetCtunShift(int channelId, int shiftHz) { }
         public void SetAgcTop(int channelId, double topDb) { }
         public void SetRxAfGainDb(int channelId, double db) { }
         public void SetNoiseReduction(int channelId, NrConfig cfg) { }

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -77,7 +77,7 @@ import { getServerBaseUrl, isCapacitorRuntime } from './serverUrl';
 import { getAudioClient } from './audio/audio-client';
 import { setAudioHostMode } from './audio/host-mode';
 import { useMicUplink } from './audio/use-mic-uplink';
-import { fetchState } from './api/client';
+import { fetchState, setCtun } from './api/client';
 import { useConnectionStore } from './state/connection-store';
 import { useRadioStore } from './state/radio-store';
 import { useQrzStore } from './state/qrz-store';
@@ -114,6 +114,8 @@ export default function App() {
   const vfoHz = useConnectionStore((s) => s.vfoHz);
   const mode = useConnectionStore((s) => s.mode);
   const preampOn = useConnectionStore((s) => s.preampOn);
+  const ctunEnabled = useConnectionStore((s) => s.ctunEnabled);
+  const applyState = useConnectionStore((s) => s.applyState);
   const moxOn = useTxStore((s) => s.moxOn);
   const tunOn = useTxStore((s) => s.tunOn);
   const endpoint = useConnectionStore((s) => s.endpoint);
@@ -770,6 +772,25 @@ export default function App() {
         <button type="button" className="btn ghost hide-mobile">SPLIT</button>
         <button type="button" className="btn ghost hide-mobile">RIT</button>
         <button type="button" className="btn ghost hide-mobile">SAVE MEM</button>
+        <button
+          type="button"
+          className={`btn ghost hide-mobile ${ctunEnabled ? 'active' : ''}`}
+          aria-pressed={ctunEnabled}
+          title={
+            ctunEnabled
+              ? 'CTUN ON — panadapter clicks move the dial; radio NCO stays put'
+              : 'CTUN OFF — panadapter clicks retune the radio. Click to enable.'
+          }
+          onClick={() => {
+            setCtun(!ctunEnabled)
+              .then(applyState)
+              .catch(() => {
+                /* next poll reconciles */
+              });
+          }}
+        >
+          CTUN
+        </button>
         <div className="spacer" style={{ flex: 1 }} />
         <PaTempChip />
         <div className="chip hide-mobile">

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -219,6 +219,13 @@ export type RadioStateDto = {
   // after normalisation; falls back to CFC_CONFIG_DEFAULT when the server
   // omits it (legacy state frames).
   cfc: CfcConfigDto;
+  // CTUN (Click-Tune) — issue #427. When true, panadapter clicks move the
+  // dial (vfoHz) without retuning the radio; the WDSP RX filter is shifted
+  // by (vfoHz - radioLoHz) on the server so the audio still demodulates the
+  // operator's tuned signal. radioLoHz is the actual hardware NCO and is
+  // what the panadapter centres on.
+  ctunEnabled: boolean;
+  radioLoHz: number;
 };
 
 // CFC mirrors Zeus.Contracts.CfcConfig. Bands array is fixed at 10 entries
@@ -472,6 +479,15 @@ export function normalizeState(raw: unknown): RadioStateDto {
     twoToneFreq2: typeof r.twoToneFreq2 === 'number' ? r.twoToneFreq2 : 1900,
     twoToneMag: typeof r.twoToneMag === 'number' ? r.twoToneMag : 0.49,
     cfc: normalizeCfc(r.cfc),
+    // CTUN — issue #427. Legacy server without the fields → CTUN off and
+    // radioLoHz falls back to vfoHz so the panadapter centre stays sensible.
+    ctunEnabled: typeof r.ctunEnabled === 'boolean' ? r.ctunEnabled : false,
+    radioLoHz:
+      typeof r.radioLoHz === 'number' && r.radioLoHz > 0
+        ? r.radioLoHz
+        : typeof r.vfoHz === 'number'
+        ? r.vfoHz
+        : 0,
   };
 }
 
@@ -636,6 +652,22 @@ export function disconnectP2(signal?: AbortSignal): Promise<unknown> {
     '/api/disconnect/p2',
     { method: 'POST', signal },
     (raw) => raw,
+  );
+}
+
+export function setCtun(
+  enabled: boolean,
+  signal?: AbortSignal,
+): Promise<RadioStateDto> {
+  return jsonFetch(
+    '/api/ctun',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ enabled }),
+      signal,
+    },
+    normalizeState,
   );
 }
 

--- a/zeus-web/src/components/Panadapter.tsx
+++ b/zeus-web/src/components/Panadapter.tsx
@@ -46,6 +46,7 @@ import { useEffect, useRef } from 'react';
 import { createPanRenderer, hexToRgbFloats } from '../gl/panadapter';
 import { planWaterfallUpdate } from '../gl/wf-shift';
 import { cancelDrawBusFrame, requestDrawBusFrame } from '../realtime/draw-bus';
+import { useConnectionStore } from '../state/connection-store';
 import { registerFrameConsumer, useDisplayStore } from '../state/display-store';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
 import { useTxStore } from '../state/tx-store';
@@ -107,7 +108,22 @@ export function Panadapter() {
       const dbMax = keyed ? s.txDbMax : s.dbMax;
       const { r, g, b } = hexToRgbFloats(s.rxTraceColor);
       renderer.setTraceColor(r, g, b);
-      renderer.draw(drawPan, dbMin, dbMax, drawOffsetPx);
+      // CTUN cursor X offset — issue #427. The orange dial cursor in
+      // panadapter.ts is drawn in clip space; default x=0 = panadapter
+      // centre. When CTUN is on and the dial has roamed off the (frozen)
+      // hardware NCO, shift the cursor by (vfoHz - centerHz) / (spanHz/2)
+      // so it tracks the operator's tuned frequency. When CTUN is off
+      // vfoHz == centerHz and the offset stays 0, matching legacy behaviour.
+      const display = useDisplayStore.getState();
+      const cn = useConnectionStore.getState();
+      let cursorXOffset = 0;
+      const panLen = display.panDb?.length ?? 0;
+      if (panLen > 0 && display.hzPerPixel > 0) {
+        const spanHz = panLen * display.hzPerPixel;
+        const centerHz = Number(display.centerHz);
+        cursorXOffset = (cn.vfoHz - centerHz) / (spanHz / 2);
+      }
+      renderer.draw(drawPan, dbMin, dbMax, drawOffsetPx, cursorXOffset);
     };
     const requestRedraw = () => {
       if (!isActive()) return;
@@ -234,10 +250,23 @@ export function Panadapter() {
       }
     });
 
+    // CTUN — issue #427. When CTUN is on the spectrum stays anchored on the
+    // frozen radio LO but the operator's dial (vfoHz) roams independently;
+    // the cursor X-offset is recomputed inside redraw() from vfoHz, so we
+    // need a repaint whenever vfoHz moves even though no fresh pan frame
+    // arrives. ctunEnabled also matters: toggling it off must reset the
+    // cursor back to centre immediately.
+    const unsubConn = useConnectionStore.subscribe((state, prev) => {
+      if (state.vfoHz !== prev.vfoHz || state.ctunEnabled !== prev.ctunEnabled) {
+        requestRedraw();
+      }
+    });
+
     return () => {
       unsub();
       unsubSettings();
       unsubTx();
+      unsubConn();
       ro.disconnect();
       io.disconnect();
       document.removeEventListener('visibilitychange', onVisibilityChange);

--- a/zeus-web/src/components/PassbandOverlay.tsx
+++ b/zeus-web/src/components/PassbandOverlay.tsx
@@ -47,16 +47,24 @@ import { useConnectionStore } from '../state/connection-store';
 
 // Translucent rectangle drawn inside the panadapter container to show the
 // active receive filter passband, mapped from [filterLowHz, filterHighHz]
-// relative to the VFO centre. Asymmetric by design: USB lives to the right
-// of carrier, LSB to the left, CW narrow around zero, AM symmetric.
+// relative to the tuned dial (VfoHz). Asymmetric by design: USB lives to the
+// right of carrier, LSB to the left, CW narrow around zero, AM symmetric.
 // Positioned by percentage of the total span so it tracks resize and tune
 // without measuring DOM width.
+//
+// CTUN (issue #427): when CTUN is on, the panadapter centres on radioLoHz
+// (the frozen hardware NCO) while vfoHz roams independently. Anchoring the
+// passband to vfoHz — not centerHz — keeps the filter overlay glued to the
+// operator's tuned signal so clicking the spectrum visibly slides the
+// passband around the (stationary) waterfall. When CTUN is off vfoHz equals
+// centerHz so this collapses to legacy behaviour.
 export function PassbandOverlay() {
   const centerHz = useDisplayStore((s) => s.centerHz);
   const hzPerPixel = useDisplayStore((s) => s.hzPerPixel);
   const width = useDisplayStore((s) => s.panDb?.length ?? 0);
   const filterLowHz = useConnectionStore((s) => s.filterLowHz);
   const filterHighHz = useConnectionStore((s) => s.filterHighHz);
+  const vfoHz = useConnectionStore((s) => s.vfoHz);
 
   if (!width || hzPerPixel <= 0) return null;
 
@@ -64,8 +72,8 @@ export function PassbandOverlay() {
   const center = Number(centerHz);
   const startHz = center - spanHz / 2;
 
-  const passLowHz = center + filterLowHz;
-  const passHighHz = center + filterHighHz;
+  const passLowHz = vfoHz + filterLowHz;
+  const passHighHz = vfoHz + filterHighHz;
   const leftPct = ((passLowHz - startHz) / spanHz) * 100;
   const rightPct = ((passHighHz - startHz) / spanHz) * 100;
   const widthPct = rightPct - leftPct;

--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -46,6 +46,7 @@ import { useEffect, useRef } from 'react';
 import { COLORMAPS } from '../gl/colormap';
 import { createWfRenderer } from '../gl/waterfall';
 import { cancelDrawBusFrame, requestDrawBusFrame } from '../realtime/draw-bus';
+import { useConnectionStore } from '../state/connection-store';
 import { registerFrameConsumer, useDisplayStore } from '../state/display-store';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
 import { useTxStore } from '../state/tx-store';
@@ -72,6 +73,23 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
   const setAutoRange = useDisplaySettingsStore((s) => s.setAutoRange);
   const colormap = useDisplaySettingsStore((s) => s.colormap);
   const setColormap = useDisplaySettingsStore((s) => s.setColormap);
+  // Tuning-cursor position. The waterfall canvas centres on the radio's
+  // hardware NCO (centerHz) which equals VfoHz outside CTUN — so on the
+  // legacy path the cursor sits at 50%. With CTUN on the hardware stays
+  // frozen at RadioLoHz while VfoHz roams; the cursor must track the dial
+  // (VfoHz) so the operator can see where they're listening, not where the
+  // radio is anchored. Computed off panDb width × hzPerPixel for span,
+  // identical math to FreqAxis's dial marker. Issue #427.
+  const cursorCenterHz = useDisplayStore((s) => s.centerHz);
+  const cursorHzPerPixel = useDisplayStore((s) => s.hzPerPixel);
+  const cursorWidth = useDisplayStore((s) => s.panDb?.length ?? 0);
+  const cursorVfoHz = useConnectionStore((s) => s.vfoHz);
+  const cursorPct = (() => {
+    if (!cursorWidth || cursorHzPerPixel <= 0) return 50;
+    const span = cursorWidth * cursorHzPerPixel;
+    const start = Number(cursorCenterHz) - span / 2;
+    return ((cursorVfoHz - start) / span) * 100;
+  })();
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -248,7 +266,7 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       <WfDbScale />
       <div
         className="tuning-cursor"
-        style={{ left: '50%', pointerEvents: 'none' }}
+        style={{ left: `${cursorPct}%`, pointerEvents: 'none' }}
       />
       <div style={{ position: 'absolute', top: 6, right: 6, display: 'flex', alignItems: 'center', gap: 4 }}>
         <div role="radiogroup" aria-label="Colormap" className="btn-row">

--- a/zeus-web/src/gl/panadapter.ts
+++ b/zeus-web/src/gl/panadapter.ts
@@ -59,6 +59,11 @@ export type PanRenderer = {
     dbMin: number,
     dbMax: number,
     offsetPx: number,
+    // CTUN cursor X offset in clip space (range [-1, +1]). 0 = dead centre
+    // (the default; CTUN off or dial == frozen radio LO). When non-zero the
+    // orange tuning-cursor line shifts horizontally to follow the dial while
+    // the spectrum stays anchored on the hardware NCO. Issue #427.
+    cursorXOffset?: number,
   ) => void;
   // Update the trace + fill colour. Components 0..1, premultiplied alpha is
   // applied inside draw via the FILL_ALPHA_TOP uniform; callers pass plain
@@ -135,6 +140,7 @@ export function createPanRenderer(gl: WebGL2RenderingContext): PanRenderer {
 
   const cursorProg = buildProgram(gl, CURSOR_VS, CURSOR_FS);
   const uCursorColor = gl.getUniformLocation(cursorProg, 'uColor');
+  const uCursorXOffset = gl.getUniformLocation(cursorProg, 'uXOffset');
   const cursorVao = gl.createVertexArray()!;
   const cursorVbo = gl.createBuffer()!;
   gl.bindVertexArray(cursorVao);
@@ -152,7 +158,7 @@ export function createPanRenderer(gl: WebGL2RenderingContext): PanRenderer {
     resize(w, h) {
       gl.viewport(0, 0, w, h);
     },
-    draw(panDb, dbMin, dbMax, offsetPx) {
+    draw(panDb, dbMin, dbMax, offsetPx, cursorXOffset = 0) {
       gl.clearColor(0, 0, 0, 0);
       gl.clear(gl.COLOR_BUFFER_BIT);
 
@@ -222,6 +228,10 @@ export function createPanRenderer(gl: WebGL2RenderingContext): PanRenderer {
       gl.useProgram(cursorProg);
       gl.bindVertexArray(cursorVao);
       gl.uniform3f(uCursorColor, 0.96, 0.74, 0.18);
+      // Clip-space X is [-1, +1] (full panadapter width). Clamp so a wild
+      // off-screen offset doesn't disappear silently — the cursor sticks to
+      // the edge as the operator clicks beyond the displayed bandwidth.
+      gl.uniform1f(uCursorXOffset, Math.max(-1, Math.min(1, cursorXOffset)));
       gl.drawArrays(gl.LINES, 0, 2);
 
       gl.bindVertexArray(null);

--- a/zeus-web/src/gl/shaders.ts
+++ b/zeus-web/src/gl/shaders.ts
@@ -93,7 +93,12 @@ void main() { fragColor = vec4(uColor * v_alpha, v_alpha); }`;
 
 export const CURSOR_VS = /* glsl */ `#version 300 es
 layout(location = 0) in vec2 aPos;
-void main() { gl_Position = vec4(aPos, 0.0, 1.0); }`;
+// uXOffset = clip-space X shift, range [-1, +1]. 0 = panadapter centre
+// (CTUN off, or CTUN on with the dial at the frozen radio LO). Non-zero
+// when CTUN is on and the operator's dial has roamed away from the frozen
+// hardware NCO — caller computes (vfoHz - centerHz) / (spanHz/2). Issue #427.
+uniform float uXOffset;
+void main() { gl_Position = vec4(aPos.x + uXOffset, aPos.y, 0.0, 1.0); }`;
 
 export const CURSOR_FS = /* glsl */ `#version 300 es
 precision highp float;

--- a/zeus-web/src/state/connection-store.ts
+++ b/zeus-web/src/state/connection-store.ts
@@ -63,6 +63,14 @@ export type ConnectionState = {
   status: ConnectionStatus;
   endpoint: string | null;
   vfoHz: number;
+  // CTUN (Click-Tune) — issue #427. When true, panadapter clicks move vfoHz
+  // without retuning the radio; the hardware stays at radioLoHz and WDSP's RX
+  // filter is shifted to keep the operator's tuned signal in the passband.
+  ctunEnabled: boolean;
+  // Hardware NCO. Tracks vfoHz when ctunEnabled is false; frozen otherwise.
+  // The panadapter centres on radioLoHz so the spectrum doesn't slide on
+  // every click while CTUN is on.
+  radioLoHz: number;
   mode: RxMode;
   filterLowHz: number;
   filterHighHz: number;
@@ -119,6 +127,8 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
   status: 'Disconnected',
   endpoint: null,
   vfoHz: 14_200_000,
+  ctunEnabled: false,
+  radioLoHz: 14_200_000,
   mode: 'USB',
   filterLowHz: 150,
   filterHighHz: 2850,
@@ -151,6 +161,8 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
       status: s.status,
       endpoint: s.endpoint,
       vfoHz: s.vfoHz,
+      ctunEnabled: s.ctunEnabled,
+      radioLoHz: s.radioLoHz,
       mode: s.mode,
       filterLowHz: s.filterLowHz,
       filterHighHz: s.filterHighHz,


### PR DESCRIPTION
Closes #427 (leave open until release ships, per release-hygiene rule).

## Summary

Adds CTUN (Click-Tune) — Thetis parity for `chkFWCATU` / `ClickTuneDisplay`.

When CTUN is on, panadapter clicks move only the dial (VfoHz); the radio's hardware NCO stays frozen at `RadioLoHz` and WDSP's `shift` stage shifts the IF by `(VfoHz − RadioLoHz)` so the operator's tuned signal still demodulates at baseband. When CTUN is off, behaviour is unchanged: VfoHz drives the radio + panadapter centre 1:1.

UI: new **CTUN** button in the transport footer (right of SAVE MEM), same `btn ghost hide-mobile` style as SPLIT / RIT, accent-blue when active.

## Backend

- `StateDto.CtunEnabled` + `StateDto.RadioLoHz`; both persisted via `RadioStateStore` so a restart-while-CTUN-on retunes the radio to the same physical centre.
- `POST /api/ctun {enabled: bool}` → `RadioService.SetCtun`. On enable freezes `RadioLoHz = EffectiveLoHz(VfoHz)` (handles cw_pitch); on disable re-snaps `RadioLoHz = VfoHz` and retunes the radio to the current dial.
- `RadioService.SetVfo` skips the P1 `SetVfoAHz` retune when CTUN is on.
- `DspPipelineService.OnRadioStateChanged` also gates the P2 retune on CTUN — pushes RadioLoHz (frozen) when on, EffectiveLoHz(VfoHz) when off.
- `ConnectAsync` re-tunes the radio to RadioLoHz (not the dial) when CTUN was persisted on.
- New `IDspEngine.SetCtunShift(channelId, shiftHz)` wired through the WDSP `shift` stage via `SetRXAShiftFreq` + `RXANBPSetShiftFrequency` + `SetRXAShiftRun`. Mirrors Thetis `radio.cs:1419-1420` exactly. (First attempt was to shift `SetRXABandpassFreqs` instead — that native-crashes WDSP on SSB because the `nbp0` stage that enforces sideband rejects sign-inverted ranges. The dedicated shift stage is the correct seam.)

## Frontend

- `RadioStateDto` + normalizer carry `ctunEnabled` / `radioLoHz`; legacy server falls back to `ctunEnabled=false`, `radioLoHz=vfoHz`.
- `setCtun(enabled)` API helper.
- `connection-store` tracks both fields.
- `PassbandOverlay` anchors at `vfoHz` instead of `centerHz` so the filter visibly slides when CTUN is on.
- Panadapter GL cursor (the orange dial line) takes a per-frame `uXOffset` uniform; subscribes to `vfoHz` so it repaints between server tick frames.
- Waterfall DOM `tuning-cursor` follows `vfoHz` with the same math.

## Out-of-scope follow-ups

- Keyboard shortcut (Thetis uses Ctrl-?) — easy add later if useful.
- Per-RX CTUN — Zeus is single-RX today; matches current architecture.

## Test plan
- [x] `dotnet build Zeus.slnx` clean
- [x] `dotnet test tests/Zeus.Server.Tests` 573 passing
- [x] `npm --prefix zeus-web run build` clean (TS + Vite)
- [x] Bench: ANAN-G2 (P2 / OrionMkII), USB, CTUN on/off, click-tune sweep — radio NCO stayed put, dial + filter overlay tracked correctly, audio demodulated through WDSP shift stage. CTUN off behaviour unchanged.
- [ ] HL2 bench-test (P1) — not done locally. Worth a smoke-test before release-merge to confirm Protocol 1 SetVfo branch behaves identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)