### PR TITLE
ci: nightly builds — rolling prerelease from develop tip

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,41 @@
+name: Nightly
+
+# Nightly build of `develop` tip. Calls release.yml as a reusable workflow
+# with mode=nightly + ref=develop so the same matrix that ships tagged
+# releases also publishes a rolling `nightly` GitHub prerelease for end-user
+# testing. See docs/designs/nightly-builds.md for the design + caveats.
+#
+# Two triggers:
+#   1. schedule (03:00 UTC) — fires only after this workflow file reaches the
+#                             repo's default branch (main). GitHub Actions
+#                             does not honour `schedule:` on non-default
+#                             branches, so until the next develop→main merge
+#                             the cron trigger is dormant.
+#   2. workflow_dispatch    — works from any branch immediately, always
+#                             builds develop tip (ref is hard-coded below).
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+# Required so the called workflow's create-nightly-release step can manage
+# the rolling tag + release on this repo.
+permissions:
+  contents: write
+
+# Avoid a cron run racing with a manual dispatch (e.g. maintainer testing).
+# cancel-in-progress=false makes the second run queue rather than killing
+# the first, which would leave the nightly release in a half-baked state.
+concurrency:
+  group: nightly
+  cancel-in-progress: false
+
+jobs:
+  nightly:
+    name: Build + publish nightly
+    uses: ./.github/workflows/release.yml
+    with:
+      mode: nightly
+      ref: develop
+    permissions:
+      contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: Release
 
-# Four trigger paths:
+# Five trigger paths:
 #   1. push of a v*.*.* tag                 → full release (build + publish to GitHub Releases)
 #   2. push to a release/** branch          → dry-run build only (artifacts uploaded, no Release)
 #   3. manual workflow_dispatch (draft=off) → dry-run build only (run from any branch via the
@@ -10,13 +10,17 @@ name: Release
 #                                             no -dryrun.<sha> suffix on artifact names — so
 #                                             the bits you smoke-test are byte-for-byte what
 #                                             would ship if you flip the draft to "Published".
+#   5. workflow_call (mode=nightly)         → nightly build invoked by .github/workflows/nightly.yml.
+#                                             Builds develop tip (caller passes ref=develop), versions
+#                                             artifacts as <prefix>-nightly.YYYYMMDD.<shortsha>, and
+#                                             publishes a rolling prerelease at tag `nightly`.
 #
-# In all four modes the same matrix builds one installer per platform.
+# In all five modes the same matrix builds one installer per platform.
 # The shipped installer wraps a single `OpenhpsdrZeus` binary that serves
 # both modes: launched with no args it runs as the LAN-bound HTTP service;
 # launched with `--desktop` it runs as a Photino native shell. 'create-release'
-# is gated on is-release='true', which is set by the determine-version step
-# in modes 1 and 4 only.
+# is gated on is-release='true' (modes 1 and 4); 'create-nightly-release' is
+# gated on is-nightly='true' (mode 5 only).
 on:
   push:
     tags:
@@ -30,6 +34,18 @@ on:
         type: boolean
         required: false
         default: false
+  workflow_call:
+    inputs:
+      mode:
+        description: 'Build mode when invoked as a reusable workflow. Currently only `nightly` is consumed by the parse step; other values fall through to the dry-run path.'
+        type: string
+        required: false
+        default: dryrun
+      ref:
+        description: 'Git ref to check out in every job. Empty string keeps existing behaviour (use the triggering SHA). Nightly callers pass `develop` so the schedule-trigger (which fires on the default branch, main) still builds develop tip.'
+        type: string
+        required: false
+        default: ''
 
 jobs:
   determine-version:
@@ -46,10 +62,12 @@ jobs:
       version-suffix: ${{ steps.parse.outputs.version-suffix }}
       is-release: ${{ steps.parse.outputs.is-release }}
       is-draft: ${{ steps.parse.outputs.is-draft }}
+      is-nightly: ${{ steps.parse.outputs.is-nightly }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ inputs.ref }}
 
       - name: Parse version + validate (tag mode only)
         id: parse
@@ -57,9 +75,27 @@ jobs:
           # workflow_dispatch boolean inputs arrive as the strings "true"/"false";
           # plumb through env so the bash conditional below stays readable.
           DISPATCH_DRAFT: ${{ github.event.inputs.draft }}
+          # workflow_call input — empty unless invoked by nightly.yml (or any
+          # other reusable caller). Drives the IS_NIGHTLY branch below.
+          INPUT_MODE: ${{ inputs.mode }}
         run: |
           IS_DRAFT="false"
-          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+          IS_NIGHTLY="false"
+          if [[ "$INPUT_MODE" == "nightly" ]]; then
+            # Nightly mode — caller (nightly.yml) has already pointed checkout
+            # at develop via `inputs.ref`, so HEAD reflects develop tip rather
+            # than the schedule-trigger ref (main). Read SHA from git, not from
+            # $GITHUB_SHA, for the same reason.
+            VERSION_PREFIX=$(sed -n 's:.*<VersionPrefix[^>]*>\([^<]*\)</VersionPrefix>.*:\1:p' Directory.Build.props | head -1)
+            VERSION_PREFIX="${VERSION_PREFIX:-0.0.0}"
+            DATE_STAMP=$(date -u +%Y%m%d)
+            SHORT_SHA=$(git rev-parse --short=7 HEAD)
+            VERSION_SUFFIX="nightly.${DATE_STAMP}.${SHORT_SHA}"
+            VERSION="${VERSION_PREFIX}-${VERSION_SUFFIX}"
+            IS_RELEASE="false"
+            IS_NIGHTLY="true"
+            echo "Nightly build (ref=$GITHUB_REF, head=$SHORT_SHA) → version $VERSION"
+          elif [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
             # Tag push — strict release path.
             if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               echo "::error::Tag '$GITHUB_REF_NAME' does not match vMAJOR.MINOR.PATCH (e.g. v1.2.3)."
@@ -107,6 +143,7 @@ jobs:
           echo "version-suffix=${VERSION_SUFFIX}" >> "$GITHUB_OUTPUT"
           echo "is-release=${IS_RELEASE}" >> "$GITHUB_OUTPUT"
           echo "is-draft=${IS_DRAFT}" >> "$GITHUB_OUTPUT"
+          echo "is-nightly=${IS_NIGHTLY}" >> "$GITHUB_OUTPUT"
 
   # ---------- Native WDSP rebuild (always-fresh natives in releases) -------
   #
@@ -129,6 +166,8 @@ jobs:
         arch: [x64, arm64]
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Install FFTW via vcpkg
         run: |
@@ -231,6 +270,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Install dependencies
         run: |
@@ -300,6 +341,8 @@ jobs:
     runs-on: macos-latest  # Apple Silicon — matches release.yml macos-arm64 host
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Install build dependencies
         run: |
@@ -400,6 +443,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Determine version
         id: version
@@ -557,6 +602,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Determine version
         id: version
@@ -673,6 +720,129 @@ jobs:
           # immediately (is-draft="false" in that path).
           draft: ${{ needs.determine-version.outputs.is-draft == 'true' }}
           prerelease: false
+          files: |
+            release-artifacts/windows-installer/*
+            release-artifacts/windows-arm64-installer/*
+            release-artifacts/linux-tarball/*
+            release-artifacts/linux-appimage/*
+            release-artifacts/macos-arm64-dmg/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ---------- Nightly rolling prerelease ----------------------------------
+  #
+  # Only fires when determine-version set is-nightly=true, i.e. the workflow
+  # was invoked via workflow_call with mode=nightly (see nightly.yml). Force-
+  # recreates a single GitHub Release at tag `nightly` so end users have a
+  # stable URL pointing at the latest develop tip.
+  create-nightly-release:
+    name: Publish nightly prerelease
+    needs: [determine-version, build-release]
+    if: needs.determine-version.outputs.is-nightly == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - name: Determine version
+        id: version
+        run: |
+          VERSION="${{ needs.determine-version.outputs.version }}"
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          DATE_STAMP=$(date -u +%Y-%m-%d)
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "short-sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "date=${DATE_STAMP}" >> "$GITHUB_OUTPUT"
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-artifacts
+
+      - name: Display artifact structure
+        run: ls -R release-artifacts
+
+      - name: Build commit list since last tagged release
+        id: commits
+        run: |
+          # Find the most recent v*.*.* tag reachable from HEAD; fall back to
+          # "no previous tag" if the repo has never been tagged (unlikely but
+          # cheap to guard).
+          LAST_TAG=$(git describe --tags --abbrev=0 --match='v*.*.*' 2>/dev/null || echo "")
+          if [[ -n "$LAST_TAG" ]]; then
+            echo "Last tag: $LAST_TAG"
+            git log --pretty=format:'- %s (%h)' "${LAST_TAG}..HEAD" > commits.txt
+          else
+            echo "No previous v*.*.* tag found; listing last 50 commits"
+            git log --pretty=format:'- %s (%h)' -n 50 > commits.txt
+          fi
+          echo "last-tag=${LAST_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Create nightly release notes
+        run: |
+          cat > nightly-notes.md << EOF
+          # Openhpsdr Zeus nightly build
+
+          **Built from \`develop\` at commit \`${{ steps.version.outputs.short-sha }}\` on ${{ steps.version.outputs.date }} (UTC).**
+          **Version string:** \`${{ steps.version.outputs.version }}\`
+
+          > ⚠️  This is a **development build**, not a release. It rolls forward
+          > nightly and is not signed, tested, or supported in the same way as
+          > tagged releases. Use it to try the latest changes; do not rely on it
+          > for production operation. Uninstall before installing a tagged
+          > release.
+
+          Same one-binary, three-launch-modes layout as a tagged release —
+          see the project README for headless / server / desktop semantics.
+
+          ## Downloads
+
+          - **openhpsdr-zeus-${{ steps.version.outputs.version }}-win-x64-setup.exe** — Windows x64 installer
+          - **openhpsdr-zeus-${{ steps.version.outputs.version }}-win-arm64-setup.exe** — Windows ARM64 installer
+          - **openhpsdr-zeus-${{ steps.version.outputs.version }}-linux-x64.tar.gz** — Linux x64 tarball
+          - **OpenhpsdrZeus-${{ steps.version.outputs.version }}-linux-x86_64.AppImage** — Linux desktop AppImage
+          - **OpenhpsdrZeus-Server-${{ steps.version.outputs.version }}-linux-x86_64.AppImage** — Linux server AppImage
+          - **OpenhpsdrZeus-${{ steps.version.outputs.version }}-macos-arm64.dmg** — macOS Apple Silicon DMG
+
+          macOS users still need to clear the quarantine attribute after
+          install — see the latest tagged release notes for the \`xattr -cr\`
+          command and Linux AppImage dependencies.
+
+          ## Changes since ${{ steps.commits.outputs.last-tag }}
+          EOF
+          if [[ -s commits.txt ]]; then
+            cat commits.txt >> nightly-notes.md
+          else
+            echo "_(no changes since last tag)_" >> nightly-notes.md
+          fi
+          echo "" >> nightly-notes.md
+          echo "" >> nightly-notes.md
+          echo "Source: <https://github.com/${{ github.repository }}/commit/${{ steps.version.outputs.short-sha }}>" >> nightly-notes.md
+
+      - name: Delete previous nightly tag + release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Force-recreate the rolling release so the tag moves to the new
+          # SHA and old assets disappear. `|| true` because the first nightly
+          # run has nothing to delete.
+          gh release delete nightly --yes --cleanup-tag --repo "${{ github.repository }}" || true
+
+      - name: Publish nightly release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: nightly
+          target_commitish: ${{ steps.version.outputs.short-sha }}
+          name: Openhpsdr Zeus nightly — ${{ steps.version.outputs.date }} (${{ steps.version.outputs.short-sha }})
+          body_path: nightly-notes.md
+          prerelease: true
+          # Force-overwrite assets in case --cleanup-tag above raced with a
+          # concurrent dispatch (concurrency: group=nightly on the caller
+          # should prevent this, defensive).
           files: |
             release-artifacts/windows-installer/*
             release-artifacts/windows-arm64-installer/*

--- a/docs/designs/nightly-builds.md
+++ b/docs/designs/nightly-builds.md
@@ -1,0 +1,118 @@
+# Nightly builds
+
+## Goal
+
+Give end users a stable URL to pick up the latest `develop` tip without waiting
+for a tagged release. Run unattended each night and on-demand from the Actions
+tab.
+
+## Shape
+
+One new workflow file (`nightly.yml`), one additive change to `release.yml`.
+No code outside `.github/workflows/`.
+
+### `release.yml` — additive
+
+Two additions:
+
+1. **`workflow_call:` trigger** with two inputs:
+   - `mode` — string, default `dryrun`, values `release | dryrun | nightly`.
+     Only the nightly path is new; the existing tag-push and `workflow_dispatch`
+     paths keep working unchanged because they don't enter the `workflow_call`
+     branch.
+   - `ref` — string, default `''`. When non-empty, every `actions/checkout@v4`
+     step in the workflow uses `ref: ${{ inputs.ref }}`. When empty, behaviour
+     matches today (checks out the triggering SHA).
+
+2. **`determine-version` gains a nightly branch**:
+   - Version string: `<VersionPrefix>-nightly.YYYYMMDD.<shortsha>` (e.g.
+     `0.7.6-nightly.20260521.abc1234`). `VersionPrefix` stays numeric so
+     `AssemblyVersion` keeps validating; the `nightly.YYYYMMDD.sha` text rides
+     on `VersionSuffix` and lands in `InformationalVersion`, mirroring the
+     existing dry-run path.
+   - New output `is-nightly=true`.
+   - `is-release` stays `false`, so the existing `create-release` job does not
+     fire.
+
+3. **New `create-nightly-release` job** gated on `is-nightly == 'true'`:
+   - `gh release delete nightly --yes --cleanup-tag || true` — wipe the rolling
+     tag + release so the next step can recreate it pointing at the new SHA.
+   - `softprops/action-gh-release@v1` with `tag_name: nightly`,
+     `prerelease: true`, `name: 'Openhpsdr Zeus nightly — <YYYY-MM-DD> (<shortsha>)'`.
+   - Release notes: short banner ("development build, not a release —
+     uninstall before installing a tagged release"), commit list since the most
+     recent `v*.*.*` tag, link to the source SHA.
+   - Same artifact set as a tagged release: Windows x64/arm64 installers, Linux
+     tarball, Linux desktop + server AppImages, macOS arm64 DMG.
+
+### `nightly.yml` — new
+
+```yaml
+name: Nightly
+
+on:
+  schedule:
+    - cron: '0 3 * * *'   # 03:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write           # required so the called workflow can
+                            # create/update the nightly tag + release
+
+concurrency:
+  group: nightly            # manual dispatch waits behind cron run
+  cancel-in-progress: false
+
+jobs:
+  nightly:
+    uses: ./.github/workflows/release.yml
+    with:
+      mode: nightly
+      ref: develop
+    permissions:
+      contents: write
+```
+
+## Why `ref: develop` is explicit
+
+GitHub fires `schedule:` triggers only on the **default branch**
+(`main` per `gh repo view`). When the cron fires, `github.ref` is
+`refs/heads/main` and a plain `actions/checkout@v4` would build main, not
+develop. Passing `ref: develop` through the workflow_call input forces every
+checkout in `release.yml` to use develop regardless of which branch the trigger
+came from.
+
+Same mechanism covers manual `workflow_dispatch`: it always builds develop tip,
+not whatever branch the user dispatched from.
+
+## Operational caveats
+
+- **Schedule activation lag.** GitHub only honours `schedule:` for workflow
+  files on the default branch. `nightly.yml` lands on develop in this PR and
+  starts firing on cron only after the next develop → main merge train.
+  Manual `workflow_dispatch` works immediately from develop.
+- **Rolling tag means git tag history is lossy.** The `nightly` tag is force-
+  recreated each run. If a user references a specific nightly by tag they need
+  to use the dated artifact name embedded in the version string, not the tag.
+- **Concurrency.** `cancel-in-progress: false` means if cron fires while a
+  manual dispatch is still building, the cron run queues behind it rather than
+  killing it. Avoids producing a half-baked nightly when a maintainer is
+  iterating.
+
+## Rollback
+
+Revert the PR. The dangling `nightly` tag + release can be removed manually:
+
+```bash
+gh release delete nightly --cleanup-tag
+```
+
+## Out of scope
+
+Red-light per `CLAUDE.md` — propose, don't ship in this PR:
+
+- Code-signing nightly installers (macOS notarisation, Windows Authenticode).
+- Auto-posting nightly availability to Slack/Discord/email.
+- README/wiki link to the nightly URL (visible UX change, maintainer call).
+- Pruning old nightly assets older than N days (current design overwrites the
+  single rolling release so there's nothing to prune).


### PR DESCRIPTION
## Summary

- Add a `Nightly` workflow that runs at 03:00 UTC and on-demand via the Actions tab; calls `release.yml` as a reusable workflow with `mode=nightly` + `ref=develop`.
- Reuse the full release matrix (Windows x64/arm64 installers, Linux tarball + AppImages, macOS arm64 DMG) so nightly artifacts are byte-for-byte the same shape as a tagged release.
- Publish a rolling **`nightly`** GitHub prerelease that gets force-recreated each run, so end users have a stable URL to grab the cutting edge from. Version string is `<prefix>-nightly.YYYYMMDD.<shortsha>` (e.g. `0.7.6-nightly.20260521.abc1234`).

Design notes are in `docs/designs/nightly-builds.md`.

## What changed

| File | Change |
|---|---|
| `.github/workflows/release.yml` | + `workflow_call:` trigger with `mode` and `ref` inputs. + new branch in `determine-version` for `mode=nightly`. + `create-nightly-release` job gated on `is-nightly=true`. Every `actions/checkout@v4` step threads `ref: ${{ inputs.ref }}` (empty default preserves existing behaviour). |
| `.github/workflows/nightly.yml` | new — schedule + workflow_dispatch; calls `release.yml` with `mode: nightly`, `ref: develop`; `concurrency: group=nightly`. |
| `docs/designs/nightly-builds.md` | new — design + operational caveats. |

## Operational caveats (read before merging)

1. **The schedule trigger only activates after `nightly.yml` reaches `main`.** GitHub Actions only fires `schedule:` triggers for workflow files on the default branch (`main`). So after this PR merges to develop, the cron stays dormant until the next develop → main merge. **Manual `workflow_dispatch` works the moment this lands on develop** — you can verify the workflow end-to-end without waiting.
2. **First manual run will publish the first `nightly` prerelease.** It's marked prerelease=true and won't show up in the Releases sidebar as "latest" — it'll be under "All releases".
3. **Rolling tag means git tag history is lossy.** `nightly` is force-recreated each run; the dated SHA lives in the version string and artifact filenames.
4. **Concurrency.** `cancel-in-progress: false` queues a cron run behind a manual dispatch rather than killing it. Prevents a half-baked release.

## Out of scope (red-light per CLAUDE.md)

- Code-signing nightly installers (macOS notarisation, Windows Authenticode).
- Posting nightly availability to Slack/Discord/email.
- README or wiki link to the nightly URL (visible UX change, maintainer call).

## Test plan

- [ ] After merge to develop, trigger `Nightly` manually via Actions → Nightly → Run workflow.
- [ ] Confirm matrix completes for all four RIDs (win-x64, win-arm64, linux-x64, osx-arm64) and a `nightly` prerelease appears at <https://github.com/Kb2uka/openhpsdr-zeus/releases/tag/nightly>.
- [ ] Download one artifact (e.g. Linux tarball) and confirm version banner reads `0.7.6-nightly.YYYYMMDD.<sha>`.
- [ ] Re-run `Nightly` manually a second time; confirm the previous `nightly` tag/release was replaced (not duplicated) and points at the latest develop SHA.
- [ ] After next develop → main merge, confirm the 03:00 UTC cron fires (check Actions tab the following morning).

## Rollback

Revert the PR. The dangling `nightly` tag + release can be removed with `gh release delete nightly --cleanup-tag` if needed.