### PR TITLE
fix(display): persist RX trace colour server-side

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -515,17 +515,22 @@ public sealed record Hl2OptionsSetRequest(bool BandVolts);
 // Panadapter background settings — Mode is one of "basic" | "beam-map" |
 // "image"; Fit is one of "fit" | "fill" | "stretch". Image bytes are NOT
 // shipped in this DTO; HasImage signals whether GET /api/display-settings/image
-// will return content. Persisted server-side so the setting follows the
-// operator across browsers / devices.
+// will return content. RxTraceColor is the panadapter signal trace colour
+// as #RRGGBB (default "#FFA028"). All fields persisted server-side so the
+// settings follow the operator across browsers / devices — Photino desktop
+// mode in particular binds the webview to a fresh random loopback port on
+// every launch, which orphans any per-origin localStorage value.
 public sealed record DisplaySettingsDto(
     string Mode,
     string Fit,
     bool HasImage,
-    string? ImageMime);
+    string? ImageMime,
+    string RxTraceColor);
 
 public sealed record DisplaySettingsSetRequest(
     string Mode,
-    string Fit);
+    string Fit,
+    string RxTraceColor);
 
 // Per-mode disclosure state for the inline NR settings accordion that hangs
 // below the DSP NR toggle row. Three independent booleans — one per NR

--- a/Zeus.Server.Hosting/DisplaySettingsStore.cs
+++ b/Zeus.Server.Hosting/DisplaySettingsStore.cs
@@ -52,23 +52,30 @@ public sealed class DisplaySettingsStore : IDisposable
             var e = _docs.FindAll().FirstOrDefault();
             if (e is null)
             {
-                return new DisplaySettingsDto(Mode: "basic", Fit: "fill", HasImage: false, ImageMime: null);
+                return new DisplaySettingsDto(
+                    Mode: "basic",
+                    Fit: "fill",
+                    HasImage: false,
+                    ImageMime: null,
+                    RxTraceColor: DefaultRxTraceColor);
             }
             return new DisplaySettingsDto(
                 Mode: NormalizeMode(e.Mode),
                 Fit: NormalizeFit(e.Fit),
                 HasImage: e.ImageBytes is { Length: > 0 },
-                ImageMime: string.IsNullOrEmpty(e.ImageMime) ? null : e.ImageMime);
+                ImageMime: string.IsNullOrEmpty(e.ImageMime) ? null : e.ImageMime,
+                RxTraceColor: NormalizeHexColor(e.RxTraceColor));
         }
     }
 
-    public void SaveMode(string mode, string fit)
+    public void SaveMode(string mode, string fit, string rxTraceColor)
     {
         lock (_sync)
         {
             var e = _docs.FindAll().FirstOrDefault() ?? new DisplaySettingsEntry();
             e.Mode = NormalizeMode(mode);
             e.Fit = NormalizeFit(fit);
+            e.RxTraceColor = NormalizeHexColor(rxTraceColor);
             e.UpdatedUtc = DateTime.UtcNow;
             if (e.Id == 0) _docs.Insert(e);
             else _docs.Update(e);
@@ -129,6 +136,23 @@ public sealed class DisplaySettingsStore : IDisposable
             _ => "fill",
         };
 
+    // Matches the frontend's DEFAULT_RX_TRACE_COLOR in display-settings-store.ts
+    // and the original hard-coded #FFA028 in gl/panadapter.ts.
+    public const string DefaultRxTraceColor = "#FFA028";
+
+    private static string NormalizeHexColor(string? raw)
+    {
+        if (string.IsNullOrEmpty(raw)) return DefaultRxTraceColor;
+        if (raw.Length != 7 || raw[0] != '#') return DefaultRxTraceColor;
+        for (var i = 1; i < 7; i++)
+        {
+            var c = raw[i];
+            var ok = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+            if (!ok) return DefaultRxTraceColor;
+        }
+        return raw.ToUpperInvariant();
+    }
+
 }
 
 public sealed class DisplaySettingsEntry
@@ -142,5 +166,8 @@ public sealed class DisplaySettingsEntry
     // id here instead.
     public byte[]? ImageBytes { get; set; }
     public string? ImageMime { get; set; }
+    // Panadapter signal trace colour as #RRGGBB. Null on legacy rows written
+    // before this field existed — Get() normalises null → DefaultRxTraceColor.
+    public string? RxTraceColor { get; set; }
     public DateTime UpdatedUtc { get; set; }
 }

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -791,7 +791,7 @@ public static class ZeusEndpoints
         {
             if (string.IsNullOrWhiteSpace(req.Mode) || string.IsNullOrWhiteSpace(req.Fit))
                 return Results.BadRequest(new { error = "mode and fit required" });
-            store.SaveMode(req.Mode, req.Fit);
+            store.SaveMode(req.Mode, req.Fit, req.RxTraceColor);
             return Results.Ok(store.Get());
         });
 

--- a/zeus-web/src/api/display.ts
+++ b/zeus-web/src/api/display.ts
@@ -11,14 +11,24 @@ export type DisplaySettings = {
   fit: 'fit' | 'fill' | 'stretch';
   hasImage: boolean;
   imageMime: string | null;
+  rxTraceColor: string;
 };
+
+// Matches backend DisplaySettingsStore.DefaultRxTraceColor.
+const DEFAULT_RX_TRACE_COLOR = '#FFA028';
 
 type DisplaySettingsDtoRaw = {
   mode?: string;
   fit?: string;
   hasImage?: boolean;
   imageMime?: string | null;
+  rxTraceColor?: string | null;
 };
+
+function normalizeRxTraceColor(raw: string | null | undefined): string {
+  if (typeof raw !== 'string') return DEFAULT_RX_TRACE_COLOR;
+  return /^#[0-9A-Fa-f]{6}$/.test(raw) ? raw.toUpperCase() : DEFAULT_RX_TRACE_COLOR;
+}
 
 function normalize(raw: DisplaySettingsDtoRaw): DisplaySettings {
   const mode =
@@ -34,6 +44,7 @@ function normalize(raw: DisplaySettingsDtoRaw): DisplaySettings {
     fit,
     hasImage: !!raw.hasImage,
     imageMime: raw.imageMime ?? null,
+    rxTraceColor: normalizeRxTraceColor(raw.rxTraceColor),
   };
 }
 
@@ -46,12 +57,13 @@ export async function fetchDisplaySettings(signal?: AbortSignal): Promise<Displa
 export async function updateDisplaySettings(
   mode: DisplaySettings['mode'],
   fit: DisplaySettings['fit'],
+  rxTraceColor: string,
   signal?: AbortSignal,
 ): Promise<DisplaySettings> {
   const res = await fetch('/api/display-settings', {
     method: 'PUT',
     headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ mode, fit }),
+    body: JSON.stringify({ mode, fit, rxTraceColor }),
     signal,
   });
   if (!res.ok) throw new Error(`PUT /api/display-settings → ${res.status}`);

--- a/zeus-web/src/state/display-settings-store.ts
+++ b/zeus-web/src/state/display-settings-store.ts
@@ -72,18 +72,18 @@ const STORAGE_KEY = 'zeus.display.dbRange';
 const TX_STORAGE_KEY = 'zeus.display.txDbRange';
 const WF_STORAGE_KEY = 'zeus.display.wfDbRange';
 const WF_TX_STORAGE_KEY = 'zeus.display.wfTxDbRange';
-const RX_TRACE_COLOR_KEY = 'zeus.display.rxTraceColor';
 
 // Legacy localStorage keys — pre-server-side storage. Read once on first
-// load to migrate the operator's existing image up to the backend, then
-// removed. New code should never read or write these.
+// load to migrate the operator's existing image / colour up to the backend,
+// then removed. New code should never read or write these.
 const LEGACY_PAN_BG_KEY = 'zeus.display.panBackground';
 const LEGACY_BG_IMAGE_KEY = 'zeus.display.backgroundImage';
 const LEGACY_BG_FIT_KEY = 'zeus.display.backgroundImageFit';
+const LEGACY_RX_TRACE_COLOR_KEY = 'zeus.display.rxTraceColor';
 
 // Default RX panadapter trace colour — warm amber, matching the original
-// hardcoded constant in gl/panadapter.ts. Operators can pick another colour
-// from the Display tab; the choice is persisted to localStorage.
+// hardcoded constant in gl/panadapter.ts and the backend's
+// DisplaySettingsStore.DefaultRxTraceColor.
 export const DEFAULT_RX_TRACE_COLOR = '#FFA028';
 
 function isHexColor(v: unknown): v is string {
@@ -102,17 +102,16 @@ export type PanBackgroundMode = 'basic' | 'beam-map' | 'image';
 // 'stretch' → 100% 100% (distorts to fit exactly)
 export type BackgroundImageFit = 'fit' | 'fill' | 'stretch';
 
-function readRxTraceColor(): string {
+function readLegacyRxTraceColor(): string | null {
   try {
-    if (typeof localStorage === 'undefined') return DEFAULT_RX_TRACE_COLOR;
-    const raw = localStorage.getItem(RX_TRACE_COLOR_KEY);
-    return isHexColor(raw) ? raw.toUpperCase() : DEFAULT_RX_TRACE_COLOR;
+    if (typeof localStorage === 'undefined') return null;
+    const raw = localStorage.getItem(LEGACY_RX_TRACE_COLOR_KEY);
+    if (!isHexColor(raw)) return null;
+    const norm = raw.toUpperCase();
+    return norm === DEFAULT_RX_TRACE_COLOR ? null : norm;
   } catch {
-    return DEFAULT_RX_TRACE_COLOR;
+    return null;
   }
-}
-function writeRxTraceColor(v: string): void {
-  try { if (typeof localStorage !== 'undefined') localStorage.setItem(RX_TRACE_COLOR_KEY, v); } catch { /* quota */ }
 }
 
 function readSavedRange(): { dbMin: number; dbMax: number } {
@@ -266,12 +265,15 @@ export type DisplaySettingsState = {
   backgroundImage: string | null;
   backgroundImageFit: BackgroundImageFit;
   // RX panadapter trace colour as #RRGGBB. Drives both the sharp trace line
-  // and the fill underneath in gl/panadapter.ts (kept in lockstep).
+  // and the fill underneath in gl/panadapter.ts (kept in lockstep). Persisted
+  // server-side alongside panBackground / backgroundImage so it survives the
+  // Photino-desktop port shuffle (per-launch random loopback port = fresh
+  // localStorage origin = orphaned setting).
   rxTraceColor: string;
   setPanBackground: (v: PanBackgroundMode) => Promise<void>;
   setBackgroundImage: (dataUrl: string | null) => Promise<boolean>;
   setBackgroundImageFit: (v: BackgroundImageFit) => Promise<void>;
-  setRxTraceColor: (v: string) => void;
+  setRxTraceColor: (v: string) => Promise<void>;
   setAutoRange: (v: boolean) => void;
   setColormap: (id: ColormapId) => void;
   updateAutoRange: (wfDb: Float32Array) => void;
@@ -313,12 +315,19 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
   panBackground: 'basic',
   backgroundImage: null,
   backgroundImageFit: 'fill',
-  rxTraceColor: readRxTraceColor(),
+  // Hydrated from the server on module load (see hydrateFromServer). Until
+  // that resolves the operator briefly sees the default amber trace — same
+  // first-paint trade-off as panBackground / backgroundImage.
+  rxTraceColor: DEFAULT_RX_TRACE_COLOR,
   setPanBackground: async (panBackground) => {
     const prev = get().panBackground;
     set({ panBackground });
     try {
-      const result = await updateDisplaySettings(panBackground, get().backgroundImageFit);
+      const result = await updateDisplaySettings(
+        panBackground,
+        get().backgroundImageFit,
+        get().rxTraceColor,
+      );
       // If the server normalised the value (unknown input → 'basic'), reflect that.
       if (result.mode !== panBackground) set({ panBackground: result.mode });
     } catch {
@@ -358,17 +367,31 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
     const prev = get().backgroundImageFit;
     set({ backgroundImageFit });
     try {
-      const result = await updateDisplaySettings(get().panBackground, backgroundImageFit);
+      const result = await updateDisplaySettings(
+        get().panBackground,
+        backgroundImageFit,
+        get().rxTraceColor,
+      );
       if (result.fit !== backgroundImageFit) set({ backgroundImageFit: result.fit });
     } catch {
       set({ backgroundImageFit: prev });
     }
   },
-  setRxTraceColor: (v) => {
+  setRxTraceColor: async (v) => {
     if (!isHexColor(v)) return;
     const norm = v.toUpperCase();
-    writeRxTraceColor(norm);
+    const prev = get().rxTraceColor;
     set({ rxTraceColor: norm });
+    try {
+      const result = await updateDisplaySettings(
+        get().panBackground,
+        get().backgroundImageFit,
+        norm,
+      );
+      if (result.rxTraceColor !== norm) set({ rxTraceColor: result.rxTraceColor });
+    } catch {
+      set({ rxTraceColor: prev });
+    }
   },
   setAutoRange: (autoRange) => {
     if (autoRange) {
@@ -470,19 +493,24 @@ async function hydrateFromServer(): Promise<void> {
   }
 
   const legacy = readLegacyLocalStorage();
+  const legacyColor = readLegacyRxTraceColor();
   const serverHasContent =
-    server.hasImage || server.mode !== 'basic' || server.fit !== 'fill';
+    server.hasImage ||
+    server.mode !== 'basic' ||
+    server.fit !== 'fill' ||
+    server.rxTraceColor !== DEFAULT_RX_TRACE_COLOR;
 
-  if (!serverHasContent && legacy && (legacy.image || legacy.mode || legacy.fit)) {
+  if (!serverHasContent && (legacy?.image || legacy?.mode || legacy?.fit || legacyColor)) {
     try {
-      if (legacy.mode || legacy.fit) {
+      if (legacy?.mode || legacy?.fit || legacyColor) {
         const next = await updateDisplaySettings(
-          legacy.mode ?? server.mode,
-          legacy.fit ?? server.fit,
+          legacy?.mode ?? server.mode,
+          legacy?.fit ?? server.fit,
+          legacyColor ?? server.rxTraceColor,
         );
         server = next;
       }
-      if (legacy.image) {
+      if (legacy?.image) {
         const blob = await dataUrlToBlob(legacy.image);
         server = await uploadDisplayImage(blob);
       }
@@ -498,6 +526,7 @@ async function hydrateFromServer(): Promise<void> {
     panBackground: server.mode,
     backgroundImage: server.hasImage ? displayImageUrl(Date.now()) : null,
     backgroundImageFit: server.fit,
+    rxTraceColor: server.rxTraceColor,
   });
 }
 
@@ -524,6 +553,7 @@ function clearLegacyLocalStorage(): void {
     localStorage.removeItem(LEGACY_PAN_BG_KEY);
     localStorage.removeItem(LEGACY_BG_IMAGE_KEY);
     localStorage.removeItem(LEGACY_BG_FIT_KEY);
+    localStorage.removeItem(LEGACY_RX_TRACE_COLOR_KEY);
   } catch {
     /* private mode — nothing to clean up */
   }


### PR DESCRIPTION
## Summary
- Move \`rxTraceColor\` out of browser localStorage and into \`DisplaySettingsStore\` (LiteDB), the same persistence path \`panBackground\` / \`backgroundImage\` already use.
- Symptom: the operator picks a panadapter trace colour, closes the desktop, and on next launch it's back to the default amber.

## Why the bug existed
Photino desktop mode binds the webview to a **fresh OS-assigned random loopback port on every launch** (\`OpenhpsdrZeus/Program.cs\` — \`HttpPort = 0\`). Browser localStorage is keyed by origin (\`scheme://host:port\`), so the operator's colour was orphaned to the previous launch's port namespace and the next launch read an empty store.

\`panBackground\` had the same problem and was already moved server-side ([\`DisplaySettingsStore.cs:14-24\`](../blob/develop/Zeus.Server.Hosting/DisplaySettingsStore.cs#L14-L24)). \`rxTraceColor\` was added later and missed that migration.

Same problem still applies to the four dB-range keys in this store (\`zeus.display.dbRange\` / \`txDbRange\` / \`wfDbRange\` / \`wfTxDbRange\`) — kept out of scope for this PR.

## Changes
- \`Zeus.Contracts/Dtos.cs\` — extend \`DisplaySettingsDto\` + \`DisplaySettingsSetRequest\` with \`RxTraceColor\`.
- \`Zeus.Server.Hosting/DisplaySettingsStore.cs\` — store the colour on the entry, normalise on read/write, default \`#FFA028\`.
- \`Zeus.Server.Hosting/ZeusEndpoints.cs\` — pass through the new field on PUT.
- \`zeus-web/src/api/display.ts\` — extend type + PUT body.
- \`zeus-web/src/state/display-settings-store.ts\` — \`setRxTraceColor\` is now async + server-backed; hydration pulls from server; legacy localStorage key migrated once then cleared.

## Test plan
- [x] \`dotnet build Zeus.slnx\` — green, 0 warnings.
- [x] \`npm --prefix zeus-web run build\` — green.
- [x] \`vitest run src/state/display-settings-store.test.ts\` — 6/6 pass.
- [x] **End-to-end on G2 + macOS desktop mode**: launched, picked white, closed, relaunched (fresh random port), white came up. Verified by KB2UKA.
- [ ] (Web flow) Existing operator with legacy localStorage colour → upgrade hydrates server with their colour once, then clears the legacy key. Not bench-tested here; logic mirrors the existing legacy panBackground migration path.