### PR TITLE
fix(ps): correct PS stall banner direction + add usage doc

### DIFF
--- a/docs/puresignal_usage.md
+++ b/docs/puresignal_usage.md
@@ -1,0 +1,109 @@
+# PURESIGNAL panel — plain-English tour
+
+PureSignal corrects your PA's distortion. It listens to what comes out of the PA, compares it to what you sent in, and pre-distorts the outgoing signal so the result is clean.
+
+For that to work, the engine needs **feedback samples that span the full drive range** without clipping the ADC. Most of the controls are about making that feedback path healthy.
+
+---
+
+## The dial — "148/256, 58% locked"
+
+How "hot" the feedback signal looks to the engine.
+
+- **Below 128** → too quiet (the engine can't see enough to fit a curve)
+- **128–181** → green zone (what you want)
+- **Above 181** → too hot (ADC near clipping)
+- **Above 256** → ADC clipping; corrections will be garbage
+
+The "% locked" is just the dial position as a percentage. "correcting" means the curve is loaded and being applied to live RF.
+
+## Signal flow — TX → PA → coupler → feedback
+
+A diagram of what's happening, not a control. Lights up when keyed.
+
+- **TX `-0.5 dBFS`** = how close your TX envelope is to the engine's ceiling (HW peak). 0 dBFS = right at the ceiling. Mildly negative = good headroom. Positive = clipping the engine's bin scale.
+
+## Internal vs External coupler
+
+Where the feedback comes from.
+
+- **Internal** = the directional coupler built into the radio (HL2 has one; some boards don't).
+- **External (bypass)** = you've tapped the antenna line yourself and fed it back into the RX2 jack. Used when you have a Helmut DC6NY sampler or similar.
+
+For an external sampler, aim for ~-15 to -18 dBm at the RX input at full TX.
+
+---
+
+## Right-hand peaks column
+
+### Observed peak
+The largest TX envelope sample the engine has seen recently. Live number.
+
+### HW peak
+The **ceiling** you're telling the engine to expect. The engine divides every sample by this number to bin it.
+
+**The rule: HW peak should sit just slightly above observed peak (~5% above).**
+
+- If HW peak is **way above** observed → the top bin never fills → engine can't fit the top of the curve → stuck in COLLECT, no correction.
+- If HW peak is **below** observed → samples get dropped → engine fits only the bottom of the curve → bad correction.
+
+Example: observed 0.237, HW peak 0.25 → 5.5% above → ideal.
+
+The little `*` next to it means "you've moved this off the per-board default" (HL2 default is 0.233). **Default** button puts it back.
+
+### Correction (±x.xx dB)
+How much the engine is currently massaging the outgoing I/Q to cancel the PA's distortion. The sparkline is the last ~60 samples. **Flat = stable = good.** Movement means conditions are changing.
+
+---
+
+## Auto / Single / Run now / Reset
+
+- **Auto** = keep recalibrating continuously while you transmit. Recommended.
+- **Single** = run one calibration, then freeze the curve. Use for "I'm done dialling, lock it in."
+- **Run now** = trigger one Single pass. Convenient for forcing a fresh measurement.
+- **Reset** = throw away everything and start over.
+
+---
+
+## TIMING card
+
+Things measured in time. Defaults are right for HL2.
+
+- **MOX delay (0.2 s)** — how long after you key down before the engine starts sampling. Lets PA bias settle, relays close, etc.
+- **Cal delay (0 s)** — gap between calibration passes. Zero = back-to-back as fast as samples arrive.
+- **Amp delay (150 ns)** — compensation for the propagation delay through your PA + filters. Don't touch unless you actually know your PA chain group delay.
+
+---
+
+## HARDWARE card
+
+The "calibration constants" — most users never touch these.
+
+- **HW peak** — see above. The one knob that actually matters here.
+- **Ints / Spi (16/256)** — resolution of the correction curve. 16/256 = "0.5 dB resolution," the standard. The other presets trade resolution for compute.
+- **Auto-attenuate (Enabled)** — when feedback drifts out of the green zone, automatically adjust the **TX step attenuator** (–28 to +31 dB on HL2) to push feedback back into the window. Leave it on.
+- **Relax phase tolerance (Disabled)** — loosen the engine's quality bar. Only turn on if the engine refuses to produce a curve on a noisy/weak PA. Increases the risk of accepting a bad curve.
+
+---
+
+## Status row
+
+- **CALIBRATION CONVERGED · -x.xx dB** = engine has a stable curve loaded and is correcting by that many dB. That's the bottom line — if you see this and stay in the green dial, PureSignal is working.
+
+---
+
+## Two-tone test signal
+
+A built-in test source — two pure sine tones at the carrier offsets you pick (e.g. 700 Hz + 1900 Hz). Used to check on-air IMD with a spectrum analyser or another receiver. Magnitude 0.49 per tone keeps the peak under 1.0 if they momentarily align.
+
+- **2-Tone ON** drops two tones into the TX chain instead of mic audio.
+- Use it to make a clean, repeatable IMD pattern for PS to chew on.
+
+---
+
+## TL;DR — the only two things that really matter for day-to-day
+
+1. **HW peak sits ~5% above observed peak.** If it's not, fix HW peak (not auto-attenuate).
+2. **Dial number is 128–181.** If it isn't, leave auto-attenuate on and it'll handle it.
+
+Everything else has a sensible default.

--- a/zeus-web/src/components/PsSettingsPanel.tsx
+++ b/zeus-web/src/components/PsSettingsPanel.tsx
@@ -596,7 +596,7 @@ export function PsSettingsPanel() {
               aria-live="polite"
               title="PureSignal has been keyed for more than 5 seconds without completing a calibration fit. This almost always means HW peak is set higher than the actual TX envelope peak — calcc bin 15 never fills."
             >
-              ⚠ PS not converging — try lowering HW peak below your observed TX peak.
+              ⚠ PS not converging — set HW peak just above your observed TX peak (~5%).
             </div>
           ) : null}
 


### PR DESCRIPTION
## Summary

- Fixes the PURESIGNAL stall banner wording in `PsSettingsPanel.tsx`. The banner used to say *"try lowering HW peak below your observed TX peak"*, but pushing HW peak below observed env triggers calcc's sample-drop path (the **opposite** failure mode from the empty-bin-15 stall the banner is diagnosing). New wording: *"set HW peak just above your observed TX peak (~5%)"*, which matches the bin-fill math already documented in `PsAutoAttenuateService.cs:160`.
- Adds `docs/puresignal_usage.md` — a plain-English tour of every control on the PURESIGNAL panel (dial, peaks column, timing, hardware, two-tone). Written for operators, not implementers; the existing mi0bot spec at `../OpenHPSDR-Thetis/ps.md` remains the authoritative implementation reference.

## Why
Operator report: stall banner told them to lower HW peak below observed, they did, calibration got worse. Raising HW peak slightly above observed unblocked convergence. The banner's tooltip is already correct ("HW peak is set higher than the actual TX envelope peak — calcc bin 15 never fills"); only the action sentence was inverted.

## Test plan
- [ ] Build frontend (`npm --prefix zeus-web run build`) — passed locally.
- [ ] On HL2: induce a stall (set HW peak to 1.0, key on 28400 at modest drive), confirm the banner shows the new wording.
- [ ] Follow the new advice (set HW peak ≈ observed × 1.05) and confirm calibration converges within a few seconds.