### PR TITLE
fix(p2): route HermesC10 / ANAN-G2E RX through DDC0 (#425)

### DIFF
--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -946,18 +946,23 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     /// Per-board base DDC index for the user-visible RX. OrionMkII/Saturn/G2
     /// family reserves DDC0/DDC1 for PureSignal feedback so the operator's RX
     /// lives at DDC2. Single-ADC Hermes-class radios (Brick2 on wire byte
-    /// 0x01; ANAN-10E / ANAN-100B on wire byte 0x02) have no reserved PS
-    /// feedback slots — the RX is at DDC0. Default OrionMkII preserves Zeus'
-    /// historical P2 wire shape for every existing board.
+    /// 0x01; ANAN-10E / ANAN-100B on wire byte 0x02; ANAN-G2E / HermesC10 on
+    /// wire byte 0x14) have no reserved PS feedback slots — the RX is at
+    /// DDC0. Default OrionMkII preserves Zeus' historical P2 wire shape for
+    /// every existing board.
     /// Reference: deskhpsdr <c>src/new_protocol.c:1692-1698</c> — only
     /// <c>NEW_DEVICE_ANGELIA / ORION / ORION2 / SATURN</c> use the
     /// <c>ddc = 2 + i</c> offset; <c>NEW_DEVICE_HERMES</c> and
     /// <c>NEW_DEVICE_HERMES2</c> both fall through to <c>ddc = i</c>.
+    /// Thetis groups HermesC10 alongside Hermes/HermesII in its P2 channel
+    /// setup (Console/console.cs:8610-8612) — the N1GP G2E firmware emulates
+    /// a single-ADC Hermes-class device on the wire.
     /// </summary>
     public static int RxBaseDdc(HpsdrBoardKind board) => board switch
     {
         HpsdrBoardKind.Hermes    => HermesRxDdc,
         HpsdrBoardKind.HermesII  => HermesRxDdc,
+        HpsdrBoardKind.HermesC10 => HermesRxDdc,
         _                        => G2RxDdc,
     };
 
@@ -985,12 +990,14 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         {
             // PS feedback layout is OrionMkII/Saturn-specific (DDC0+DDC1
             // paired with bit 1363 sync). Single-ADC Hermes-class radios
-            // (Hermes/0x01, HermesII/0x02) don't have this hardware — leave
-            // the PS block alone. psEnabled should never be set true for
-            // these boards upstream, but if it ever is we'd rather silently
-            // no-op than scribble bytes the radio will reject.
+            // (Hermes/0x01, HermesII/0x02, HermesC10/0x14) don't have this
+            // hardware — leave the PS block alone. psEnabled should never
+            // be set true for these boards upstream, but if it ever is we'd
+            // rather silently no-op than scribble bytes the radio will
+            // reject.
             if (boardKind != HpsdrBoardKind.Hermes &&
-                boardKind != HpsdrBoardKind.HermesII)
+                boardKind != HpsdrBoardKind.HermesII &&
+                boardKind != HpsdrBoardKind.HermesC10)
             {
                 ddcEnable |= 0x01;
                 p[17] = 0x00;

--- a/tests/Zeus.Protocol2.Tests/HermesP2DdcMappingTests.cs
+++ b/tests/Zeus.Protocol2.Tests/HermesP2DdcMappingTests.cs
@@ -13,20 +13,23 @@ using Zeus.Contracts;
 namespace Zeus.Protocol2.Tests;
 
 /// <summary>
-/// Hermes-on-Protocol-2 RX DDC mapping (issue #171 Brick2; ANAN-10E follow-up).
+/// Hermes-on-Protocol-2 RX DDC mapping (issue #171 Brick2; ANAN-10E follow-up;
+/// issue #425 ANAN-G2E / HermesC10).
 ///
-/// Single-ADC Hermes-class radios — Hermes/Brick2 on wire byte 0x01 and
-/// HermesII (ANAN-10E / ANAN-100B) on wire byte 0x02 — have one ADC and no
+/// Single-ADC Hermes-class radios — Hermes/Brick2 on wire byte 0x01,
+/// HermesII (ANAN-10E / ANAN-100B) on wire byte 0x02, and HermesC10
+/// (ANAN-G2E, N1GP firmware) on wire byte 0x14 — have one ADC and no
 /// PureSignal feedback DDCs reserved at the front of the pool. receiver[i]
 /// maps to DDC[i] (deskhpsdr <c>src/new_protocol.c:1692-1698</c> — only
 /// <c>NEW_DEVICE_ANGELIA / ORION / ORION2 / SATURN</c> apply the
-/// <c>ddc = 2 + i</c> offset). Every other family Zeus supports on P2 puts
-/// the operator's RX0 at DDC2, so the OrionMkII default must remain the
-/// wire shape we've been shipping.
+/// <c>ddc = 2 + i</c> offset; Thetis Console/console.cs:8610-8612 groups
+/// HermesC10 alongside Hermes/HermesII in its P2 channel setup). Every
+/// other family Zeus supports on P2 puts the operator's RX0 at DDC2, so
+/// the OrionMkII default must remain the wire shape we've been shipping.
 ///
-/// These tests pin the byte-offsets so a Brick2 or ANAN-10E owner running
-/// this branch sees DDC0 enabled, the DDC0 config block populated at
-/// offset 17, and IQ arriving on UDP 1035 (instead of 1037).
+/// These tests pin the byte-offsets so a Brick2, ANAN-10E, or ANAN-G2E
+/// owner running this branch sees DDC0 enabled, the DDC0 config block
+/// populated at offset 17, and IQ arriving on UDP 1035 (instead of 1037).
 /// </summary>
 public class HermesP2DdcMappingTests
 {
@@ -44,9 +47,18 @@ public class HermesP2DdcMappingTests
         Assert.Equal(0, Protocol2Client.RxBaseDdc(HpsdrBoardKind.HermesII));
     }
 
+    [Fact]
+    public void RxBaseDdc_HermesC10_Is_Zero()
+    {
+        // ANAN-G2E / HermesC10 firmware (wire byte 0x14): single ADC, no PS
+        // DDCs reserved. The N1GP G2E firmware emulates a Hermes-class device
+        // on the wire — Thetis Console/console.cs:8610-8612 groups HermesC10
+        // with Hermes / HermesII in its P2 channel setup. Issue #425.
+        Assert.Equal(0, Protocol2Client.RxBaseDdc(HpsdrBoardKind.HermesC10));
+    }
+
     [Theory]
     [InlineData(HpsdrBoardKind.OrionMkII)]
-    [InlineData(HpsdrBoardKind.HermesC10)]
     [InlineData(HpsdrBoardKind.Orion)]
     [InlineData(HpsdrBoardKind.Angelia)]
     [InlineData(HpsdrBoardKind.HermesLite2)]
@@ -55,10 +67,10 @@ public class HermesP2DdcMappingTests
     public void RxBaseDdc_NonHermes_Stays_At_Two(HpsdrBoardKind board)
     {
         // Anti-regression: only single-ADC Hermes-class wire bytes (0x01,
-        // 0x02) flip to DDC0. Anything else MUST continue to report DDC2 —
-        // that's what every shipped P2 wire format in Zeus assumes (every
-        // test in PsWireFormatTests asserts on offset 29 = 17 + 12, i.e.
-        // DDC2's config block).
+        // 0x02, 0x14) flip to DDC0. Anything else MUST continue to report
+        // DDC2 — that's what every shipped P2 wire format in Zeus assumes
+        // (every test in PsWireFormatTests asserts on offset 29 = 17 + 12,
+        // i.e. DDC2's config block).
         Assert.Equal(2, Protocol2Client.RxBaseDdc(board));
     }
 
@@ -147,6 +159,50 @@ public class HermesP2DdcMappingTests
         var p = Protocol2Client.ComposeCmdRxBuffer(
             seq: 1, numAdc: 1, sampleRateKhz: 96, psEnabled: true,
             boardKind: HpsdrBoardKind.HermesII);
+
+        Assert.Equal((byte)0x00, p[1363]);
+        Assert.Equal((byte)0x01, p[7]);
+        Assert.Equal((byte)0x00, p[23]);
+        Assert.Equal((byte)0x00, p[28]);
+    }
+
+    [Fact]
+    public void CmdRx_HermesC10_EnablesDdc0_Not_Ddc2()
+    {
+        // ANAN-G2E (HermesC10, N1GP firmware) is single-ADC Hermes-class —
+        // RX0 at DDC0, not DDC2. Issue #425.
+        var p = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 1, numAdc: 1, sampleRateKhz: 48, psEnabled: false,
+            boardKind: HpsdrBoardKind.HermesC10);
+
+        Assert.Equal((byte)0x01, p[7]);
+    }
+
+    [Fact]
+    public void CmdRx_HermesC10_Writes_DDC0_Config_At_Offset_17()
+    {
+        var p = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 1, numAdc: 1, sampleRateKhz: 48, psEnabled: false,
+            boardKind: HpsdrBoardKind.HermesC10);
+
+        Assert.Equal((byte)0x00, p[17]);          // ADC0
+        Assert.Equal((byte)0x00, p[18]);          // 48 kHz BE high
+        Assert.Equal((byte)48,   p[19]);          // 48 kHz BE low
+        Assert.Equal((byte)24,   p[22]);          // 24-bit
+        Assert.Equal((byte)0x00, p[29]);          // DDC2 block stays zero
+        Assert.Equal((byte)0x00, p[31]);
+        Assert.Equal((byte)0x00, p[34]);
+    }
+
+    [Fact]
+    public void CmdRx_HermesC10_Does_Not_Set_DDC1_Sync_Or_PS_Block()
+    {
+        // Same single-ADC no-PS-hardware story as Hermes/HermesII: psEnabled=true
+        // is a no-op on HermesC10 so we don't scribble OrionMkII shape onto the
+        // wire.
+        var p = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 1, numAdc: 1, sampleRateKhz: 96, psEnabled: true,
+            boardKind: HpsdrBoardKind.HermesC10);
 
         Assert.Equal((byte)0x00, p[1363]);
         Assert.Equal((byte)0x01, p[7]);


### PR DESCRIPTION
## Summary

Routes HermesC10 / ANAN-G2E (wire byte `0x14`) RX through DDC0 instead of DDC2. PR #308's HermesC10 → DDC2 default was wrong — the N1GP G2E firmware is single-ADC Hermes-class and has no PureSignal-feedback DDCs reserved at the front of the pool, so a hi-priority status stream comes up but the radio never sends IQ packets back. Reporter saw panadapter dead + audio dead even though discovery, connect, and MOX all worked.

## Why

Thetis `Console/console.cs:8610-8612` groups HermesC10 alongside Hermes/HermesII in its P2 channel setup. deskhpsdr `src/new_protocol.c:1692-1698` only applies the `ddc = 2 + i` offset for `NEW_DEVICE_ANGELIA / ORION / ORION2 / SATURN` — Hermes-class fall through to `ddc = i`.

## Changes

- `Protocol2Client.RxBaseDdc`: add `HermesC10 → 0`
- `Protocol2Client.ComposeCmdRxBuffer`: extend the "skip OrionMkII PS-feedback layout" guard to include HermesC10 (defensive — `psEnabled=true` should never reach this path for a HermesC10 board, but if it does we silently no-op instead of scribbling bytes the radio will reject)
- Tests: pin DDC0 enable + offset-17 config block + DDC1 sync / DDC2 block stay zero for HermesC10; drop HermesC10 from the `Stays_At_Two` theory inputs

## Regression safety

Switch-case is isolated to `HermesC10`. Every other board (OrionMkII, Orion, Angelia, HermesLite2, ANAN-7000, Hermes, HermesII) takes the same path it did before — verified by the unchanged `RxBaseDdc_NonHermes_Stays_At_Two` theory.

## Test plan

- [x] Unit tests pass — three new `CmdRx_HermesC10_*` facts + `RxBaseDdc_HermesC10_Is_Zero`.
- [x] Bench-confirmed on G2E hardware (N1GP firmware, "Hermes_C10 / ANAN-G1") by reporter @lb5va — RX panadapter + audio live, TX produces power.
- [x] Dry-run release build green across all 4 platforms ([workflow run](https://github.com/Kb2uka/openhpsdr-zeus/actions/runs/26290799099)).

## Out of scope (reporter-surfaced, not regressions)

@lb5va also flagged headphone-jack output and back-panel PTT-in not working on his G2E. These are pre-existing Zeus board-feature gaps for HermesC10 peripherals, not introduced by this fix. Worth tracking as separate issues.

## Refs

Refs #425 — leave issue OPEN until the develop→main release-merge ships this fix.