### PR TITLE
ci(nightly): fix 422 on publish — pre-create tag, drop softprops

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -823,31 +823,44 @@ jobs:
           echo "" >> nightly-notes.md
           echo "Source: <https://github.com/${{ github.repository }}/commit/${{ steps.version.outputs.short-sha }}>" >> nightly-notes.md
 
-      - name: Delete previous nightly tag + release
+      - name: Publish nightly release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Force-recreate the rolling release so the tag moves to the new
-          # SHA and old assets disappear. `|| true` because the first nightly
-          # run has nothing to delete.
-          gh release delete nightly --yes --cleanup-tag --repo "${{ github.repository }}" || true
+          # Force-recreate the rolling `nightly` release/tag so the rolling
+          # pointer moves to the new build SHA and old assets disappear.
+          #
+          # We deliberately do NOT use softprops/action-gh-release@v1 with
+          # `target_commitish: <sha>` here: that path 422s when the tag
+          # doesn't already exist (GitHub: "tag_name is not a valid tag").
+          # Instead we pre-create the tag via the Git refs API and then
+          # attach the release to the now-existing tag via `gh release
+          # create`, which is robust on both first and subsequent runs.
+          SHA="${{ steps.version.outputs.short-sha }}"
+          REPO="${{ github.repository }}"
 
-      - name: Publish nightly release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: nightly
-          target_commitish: ${{ steps.version.outputs.short-sha }}
-          name: Openhpsdr Zeus nightly — ${{ steps.version.outputs.date }} (${{ steps.version.outputs.short-sha }})
-          body_path: nightly-notes.md
-          prerelease: true
-          # Force-overwrite assets in case --cleanup-tag above raced with a
-          # concurrent dispatch (concurrency: group=nightly on the caller
-          # should prevent this, defensive).
-          files: |
-            release-artifacts/windows-installer/*
-            release-artifacts/windows-arm64-installer/*
-            release-artifacts/linux-tarball/*
-            release-artifacts/linux-appimage/*
+          # Drop the previous release if any (keep the tag — we'll move it
+          # next). `|| true` because the first nightly has nothing to delete.
+          gh release delete nightly --yes --repo "$REPO" || true
+
+          # Force-create or move refs/tags/nightly to the build SHA via the
+          # Git refs API, independent of local checkout state.
+          if gh api "repos/$REPO/git/refs/tags/nightly" >/dev/null 2>&1; then
+            gh api "repos/$REPO/git/refs/tags/nightly" \
+              -X PATCH -F sha="$SHA" -F force=true >/dev/null
+          else
+            gh api "repos/$REPO/git/refs" \
+              -X POST -f ref="refs/tags/nightly" -f sha="$SHA" >/dev/null
+          fi
+
+          # Create the prerelease against the freshly pointed tag.
+          gh release create nightly \
+            --prerelease \
+            --title "Openhpsdr Zeus nightly — ${{ steps.version.outputs.date }} ($SHA)" \
+            --notes-file nightly-notes.md \
+            --repo "$REPO" \
+            release-artifacts/windows-installer/* \
+            release-artifacts/windows-arm64-installer/* \
+            release-artifacts/linux-tarball/* \
+            release-artifacts/linux-appimage/* \
             release-artifacts/macos-arm64-dmg/*
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The nightly workflow's **Publish nightly prerelease** step has been failing with HTTP 422 (`tag_name is not a valid tag` + `target_commitish is invalid`) on every run since the cron landed on main (PR #441). All six platform builds succeed; only the final publish step fails, so no \`nightly\` release ever gets created.

Reproduced cleanly in run [26305138378](https://github.com/Kb2uka/openhpsdr-zeus/actions/runs/26305138378) — manual dispatch immediately after PR #441 merged. Six platform artifacts built green; \`Publish nightly prerelease\` 422'd three times and aborted.

## Root cause

The step ordering is the bug:

1. \`gh release delete nightly --yes --cleanup-tag\` removes both the previous release **and** the \`nightly\` tag.
2. \`softprops/action-gh-release@v1\` then tries to create a release with \`tag_name: nightly\` and \`target_commitish: <short-sha>\`.

softprops v1 with a SHA \`target_commitish\` and a tag that doesn't already exist hits a known GitHub API quirk that returns 422. Verified by inspecting [the action's create-release code path](https://github.com/softprops/action-gh-release/blob/v1/src/main.ts) and the error response in the failing run log.

## Fix

Collapse into one \`gh\`-CLI step that:

1. Deletes the previous release **without** \`--cleanup-tag\` (we move the tag explicitly instead).
2. Force-creates or fast-forwards \`refs/tags/nightly\` to the build SHA via the Git refs API (POST on first run, PATCH \`--force\` on subsequent runs). Independent of the workflow's local checkout.
3. Publishes the prerelease via \`gh release create nightly\` against the now-existing tag — no \`target_commitish\`, no 422.

Diff is 36 / 23. No matrix changes, no other workflow files touched, no behavioural change to tagged-release path (the \`is-nightly == 'true'\` gate is unchanged).

## Test plan

- [ ] CI green on this PR (build-test matrix should be unaffected — only \`release.yml\` changes, and only the \`create-nightly-release\` job is touched)
- [ ] After merge, re-trigger Actions → Nightly → Run workflow → \`main\` → Run
- [ ] Verify \`https://github.com/Kb2uka/openhpsdr-zeus/releases/tag/nightly\` populates with all six assets and a title like \`Openhpsdr Zeus nightly — YYYY-MM-DD (<sha>)\`
- [ ] Verify the latest tagged release (\`v0.8.2\`) retains the green "Latest" badge (prerelease flag preserved)

🐛 Discovered via [Actions run 26305138378](https://github.com/Kb2uka/openhpsdr-zeus/actions/runs/26305138378)