### PR TITLE
feat(audio-suite): master bypass for the whole plugin chain

### DIFF
--- a/Zeus.Contracts/AudioMasterBypassFrame.cs
+++ b/Zeus.Contracts/AudioMasterBypassFrame.cs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Buffers;
+
+namespace Zeus.Contracts;
+
+/// <summary>
+/// Audio Suite master-bypass broadcast. Carries a single boolean — the
+/// operator's master-bypass state for the whole plugin chain.
+///
+/// <para>Broadcast by <c>AudioChainMasterBypassService</c> on every
+/// operator toggle so all connected clients (LAN-share phone, second
+/// browser) stay in sync without polling.</para>
+///
+/// <para>Master bypass disengages the WHOLE plugin chain (NoiseGate,
+/// EQ, Comp, Exciter, Bass, Reverb). Per-plugin bypass states are
+/// untouched — when the operator flips master back off, each plugin
+/// resumes in the state it was last left in. CFC is downstream in
+/// WDSP and unaffected.</para>
+///
+/// <para>Payload: <c>[type:1][bypassed:u8]</c> — 2 bytes total.</para>
+/// </summary>
+public readonly record struct AudioMasterBypassFrame(bool Bypassed)
+{
+    public const int ByteLength = 2;
+
+    public void Serialize(IBufferWriter<byte> writer)
+    {
+        var span = writer.GetSpan(ByteLength);
+        span[0] = (byte)MsgType.AudioMasterBypass;
+        span[1] = Bypassed ? (byte)1 : (byte)0;
+        writer.Advance(ByteLength);
+    }
+
+    public static AudioMasterBypassFrame Deserialize(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length < ByteLength)
+            throw new InvalidDataException(
+                $"AudioMasterBypassFrame requires {ByteLength} bytes, got {bytes.Length}");
+        if (bytes[0] != (byte)MsgType.AudioMasterBypass)
+            throw new InvalidDataException(
+                $"expected AudioMasterBypass (0x{(byte)MsgType.AudioMasterBypass:X2}), got 0x{bytes[0]:X2}");
+        return new AudioMasterBypassFrame(Bypassed: bytes[1] != 0);
+    }
+}

--- a/Zeus.Contracts/MsgType.cs
+++ b/Zeus.Contracts/MsgType.cs
@@ -142,4 +142,15 @@ public enum MsgType : byte
     // compatibility with non-ASCII plugin IDs even though current IDs
     // are reverse-DNS ASCII. See AudioChainOrderFrame.cs.
     AudioChainOrder = 0x1E,
+
+    // Server → client (audio suite master bypass). Broadcast on every
+    // master-bypass toggle (operator click in the Audio Suite chain
+    // rail) so all connected clients update their toggle state in sync.
+    // Master bypass disengages the WHOLE plugin chain (NoiseGate / EQ /
+    // Comp / Exciter / Bass / Reverb) — per-plugin bypass states are
+    // untouched and resume when master bypass is released. CFC is
+    // downstream in WDSP and unaffected.
+    // Payload: [type:1][bypassed:u8] = 2 bytes total. See
+    // AudioMasterBypassFrame.cs.
+    AudioMasterBypass = 0x1F,
 }

--- a/Zeus.Plugins.Host/Audio/AudioChain.cs
+++ b/Zeus.Plugins.Host/Audio/AudioChain.cs
@@ -5,10 +5,19 @@ namespace Zeus.Plugins.Host.Audio;
 
 /// <summary>
 /// Serial chain of <see cref="IAudioPlugin"/> instances with master
-/// enable + per-slot bypass. The realtime <see cref="Process"/> method
+/// bypass + per-slot bypass. The realtime <see cref="Process"/> method
 /// allocates nothing, takes no locks, and short-circuits to a single
-/// memcpy when master enable is false — matching the bit-identical
+/// memcpy when master bypass is engaged — matching the bit-identical
 /// pass-through requirement from the v1 ADR (§5.7).
+///
+/// <para><b>Master bypass</b> is the operator's "disengage the whole
+/// Audio Suite" lever, surfaced via the Audio Suite UI and persisted
+/// by <c>AudioChainMasterBypassService</c>. Default in this realtime
+/// type is <c>false</c> (chain hot); the service writes the operator's
+/// persisted preference through on startup. Toggling does NOT touch
+/// per-slot bypass — when master goes from engaged back to off, the
+/// individual plugins resume in whatever bypass state the operator
+/// last left them in. CFC lives downstream in WDSP and is unaffected.</para>
 ///
 /// Slot mutation methods (<see cref="SetSlot"/>, <see cref="ClearSlot"/>,
 /// <see cref="SetSlotBypass"/>) are NOT realtime-safe — call from the
@@ -20,7 +29,7 @@ public sealed class AudioChain : IAsyncDisposable
 
     private readonly ChainSlot[] _slots = new ChainSlot[MaxSlots];
     private readonly float[] _scratch;
-    private volatile bool _masterEnabled = true;
+    private volatile bool _masterBypassed;
 
     public AudioChain(int maxFrames = 4096, int maxChannels = 2)
     {
@@ -30,10 +39,17 @@ public sealed class AudioChain : IAsyncDisposable
 
     public int SlotCount => MaxSlots;
 
-    public bool MasterEnabled
+    /// <summary>
+    /// Operator master bypass. <c>true</c> = chain inert, mic passes
+    /// through bit-identical to WDSP; <c>false</c> = chain hot, plugins
+    /// run in slot order. Single <c>volatile bool</c> — realtime read
+    /// in <see cref="Process"/>, control-thread write from
+    /// <c>AudioChainMasterBypassService</c>. No locks, no re-init.
+    /// </summary>
+    public bool MasterBypassed
     {
-        get => _masterEnabled;
-        set => _masterEnabled = value;
+        get => _masterBypassed;
+        set => _masterBypassed = value;
     }
 
     public IAudioPlugin? GetSlot(int index)
@@ -75,7 +91,7 @@ public sealed class AudioChain : IAsyncDisposable
     /// the internal scratch buffer to chain plugins without allocating
     /// per call.
     ///
-    /// When master is disabled, this is a single <c>input.CopyTo(output)</c>
+    /// When master bypass is engaged, this is a single <c>input.CopyTo(output)</c>
     /// and exits. Slots whose Plugin is null or Bypassed = true are
     /// skipped without a copy (handled by the ping-pong logic).
     /// </summary>
@@ -125,7 +141,7 @@ public sealed class AudioChain : IAsyncDisposable
         if (output.Length < input.Length)
             throw new ArgumentException("output too small", nameof(output));
 
-        if (!_masterEnabled)
+        if (_masterBypassed)
         {
             input.CopyTo(output);
             return;

--- a/Zeus.Server.Hosting/AudioChainMasterBypassService.cs
+++ b/Zeus.Server.Hosting/AudioChainMasterBypassService.cs
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using Microsoft.Extensions.Hosting;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Owns the Audio Suite master-bypass lever. One operator-facing
+/// toggle that disengages the entire plugin chain (NoiseGate / EQ /
+/// Comp / Exciter / Bass / Reverb) in a single click, instead of
+/// requiring per-plugin bypass clicks.
+///
+/// <para><b>Default on first install:</b> <c>true</c> (bypassed). A
+/// brand-new operator who just downloaded the Audio Suite installer
+/// gets an inert chain until they click master bypass off. This
+/// prevents an unfamiliar processing chain from quietly transforming
+/// their first TX before they've configured it.</para>
+///
+/// <para><b>Persistence:</b> <see cref="AudioChainSettingsStore"/>.
+/// On startup, this service reads the persisted state and writes it
+/// through to <see cref="AudioPluginBridge.SetMasterBypassed"/> BEFORE
+/// any audio flows. On every operator toggle, this service updates
+/// in-memory state, persists, writes through to the bridge, and
+/// broadcasts <see cref="AudioMasterBypassFrame"/> (0x1F) so all
+/// connected clients (LAN-share phone, second browser) stay in sync.</para>
+///
+/// <para><b>Independence from CFC:</b> master bypass only touches the
+/// plugin chain in <see cref="AudioChain"/>. WDSP's CFC sits one layer
+/// downstream and honours its own operator setting (TX panel "CFC"
+/// toggle) — never read or written by this service.</para>
+///
+/// <para><b>Independence from per-plugin bypass:</b> the per-slot
+/// bypass flags in <see cref="AudioChain"/> are not read or written
+/// by this service. Flipping master bypass back off restores the
+/// chain to whatever per-plugin bypass states the operator last left.</para>
+///
+/// <para><b>Thread safety:</b> all mutating methods take <c>_sync</c>.
+/// The write-through to the chain is a single <c>volatile bool</c>
+/// (no lock needed in the realtime path). Broadcast fires OFF the
+/// lock so a subscriber that calls back into the service can't
+/// deadlock.</para>
+/// </summary>
+public sealed class AudioChainMasterBypassService : IHostedService
+{
+    private readonly AudioChainSettingsStore _store;
+    private readonly AudioPluginBridge _bridge;
+    private readonly StreamingHub _hub;
+    private readonly ILogger<AudioChainMasterBypassService> _log;
+    private readonly object _sync = new();
+    private bool _bypassed;
+
+    /// <summary>
+    /// Fires AFTER the new state is persisted and written through to
+    /// the chain. Fired off-lock.
+    /// </summary>
+    public event Action<bool>? MasterBypassedChanged;
+
+    public AudioChainMasterBypassService(
+        AudioChainSettingsStore store,
+        AudioPluginBridge bridge,
+        StreamingHub hub,
+        ILogger<AudioChainMasterBypassService> log)
+    {
+        _store = store;
+        _bridge = bridge;
+        _hub = hub;
+        _log = log;
+    }
+
+    public Task StartAsync(CancellationToken ct)
+    {
+        // Read persisted state. Null on first run = "default to true
+        // (bypassed)" so a brand-new operator's chain is inert.
+        var persisted = _store.GetMasterBypassed();
+        var initial = persisted ?? true;
+
+        lock (_sync) _bypassed = initial;
+        _bridge.SetMasterBypassed(initial);
+
+        if (persisted is null)
+        {
+            _log.LogInformation(
+                "AudioChainMasterBypassService initialised; default master bypass = true (first run, no persisted row).");
+        }
+        else
+        {
+            _log.LogInformation(
+                "AudioChainMasterBypassService initialised; master bypass = {Bypassed} (persisted)",
+                initial);
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken ct) => Task.CompletedTask;
+
+    /// <summary>Current master-bypass state.</summary>
+    public bool IsBypassed
+    {
+        get { lock (_sync) return _bypassed; }
+    }
+
+    /// <summary>
+    /// Set master bypass. Updates in-memory state, persists, writes
+    /// through to the chain, broadcasts <see cref="AudioMasterBypassFrame"/>,
+    /// and fires <see cref="MasterBypassedChanged"/>. Idempotent — no
+    /// work / no broadcast if the new value matches the current value.
+    /// </summary>
+    public void SetMasterBypassed(bool bypassed)
+    {
+        bool changed;
+        lock (_sync)
+        {
+            changed = _bypassed != bypassed;
+            if (changed) _bypassed = bypassed;
+        }
+        if (!changed) return;
+
+        // Persist BEFORE write-through so a crash between the two
+        // leaves disk reflecting what the realtime engine will read
+        // on next boot (consistency on restart > a single muted block).
+        try
+        {
+            _store.SetMasterBypassed(bypassed);
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "AudioChainMasterBypassService persist threw");
+        }
+
+        _bridge.SetMasterBypassed(bypassed);
+
+        try
+        {
+            _hub.Broadcast(new AudioMasterBypassFrame(bypassed));
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "AudioChainMasterBypassService broadcast threw");
+        }
+
+        MasterBypassedChanged?.Invoke(bypassed);
+        _log.LogInformation("Audio suite master bypass set to {Bypassed}", bypassed);
+    }
+}

--- a/Zeus.Server.Hosting/AudioChainSettingsStore.cs
+++ b/Zeus.Server.Hosting/AudioChainSettingsStore.cs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using LiteDB;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Persists chain-level Audio Suite settings across server restarts.
+/// Currently one field: the operator's master-bypass state. Single-row
+/// collection ("audio_chain_settings") sharing zeus-prefs.db with the
+/// other preference stores. Mirrors the ChainOrderStore pattern.
+///
+/// <para>Why a dedicated store rather than a field on
+/// <see cref="ChainOrderStore"/>: chain order and chain master bypass
+/// are different concerns. Order is "which plugins in what sequence";
+/// master bypass is "should the entire chain run". Folding them into
+/// one row creates an unnecessary tight coupling and makes diff /
+/// migration harder if either grows new fields.</para>
+///
+/// <para>First-run semantics: <see cref="GetMasterBypassed"/> returns
+/// <c>null</c> on first run (no row yet). The caller
+/// (<c>AudioChainMasterBypassService</c>) interprets null as
+/// "default to true (bypassed)" so a brand-new operator's chain is
+/// inert until they engage it.</para>
+/// </summary>
+public sealed class AudioChainSettingsStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<AudioChainSettingsEntry> _state;
+    private readonly ILogger<AudioChainSettingsStore> _log;
+    private readonly object _sync = new();
+
+    public AudioChainSettingsStore(ILogger<AudioChainSettingsStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _state = _db.GetCollection<AudioChainSettingsEntry>("audio_chain_settings");
+
+        _log.LogInformation("AudioChainSettingsStore initialized at {Path}", dbPath);
+    }
+
+    /// <summary>
+    /// Returns the persisted master-bypass state, or null on first run
+    /// (no row yet). Null is the "use default" signal — the caller
+    /// (<c>AudioChainMasterBypassService</c>) substitutes <c>true</c>
+    /// so first-time operators get an inert chain.
+    /// </summary>
+    public bool? GetMasterBypassed()
+    {
+        lock (_sync)
+        {
+            var entry = _state.FindAll().FirstOrDefault();
+            return entry?.MasterBypassed;
+        }
+    }
+
+    public void SetMasterBypassed(bool bypassed)
+    {
+        lock (_sync)
+        {
+            var existing = _state.FindAll().FirstOrDefault();
+            var nowUtc = DateTime.UtcNow;
+            if (existing is null)
+            {
+                _state.Insert(new AudioChainSettingsEntry
+                {
+                    MasterBypassed = bypassed,
+                    UpdatedUtc = nowUtc,
+                });
+            }
+            else
+            {
+                existing.MasterBypassed = bypassed;
+                existing.UpdatedUtc = nowUtc;
+                _state.Update(existing);
+            }
+        }
+    }
+
+    public void Dispose() => _db.Dispose();
+}
+
+public sealed class AudioChainSettingsEntry
+{
+    public int Id { get; set; }
+    public bool MasterBypassed { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/AudioPluginBridge.cs
+++ b/Zeus.Server.Hosting/AudioPluginBridge.cs
@@ -117,6 +117,21 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
     /// <summary>True if the pre-MOX preview tap is active (Wdsp engine + plugins attached).</summary>
     internal bool PreviewEnabled => _previewEnabled;
 
+    /// <summary>
+    /// Operator master-bypass write-through. Called by
+    /// <c>AudioChainMasterBypassService</c> — on startup (apply persisted
+    /// state) and on every operator toggle (apply new state). Single
+    /// <c>volatile bool</c> write on the chain; no locks, no plugin
+    /// re-init, no clicks/pops.
+    /// </summary>
+    public void SetMasterBypassed(bool bypassed)
+    {
+        _chain.MasterBypassed = bypassed;
+    }
+
+    /// <summary>Current master bypass state (mirrors <c>AudioChain.MasterBypassed</c>).</summary>
+    public bool IsMasterBypassed => _chain.MasterBypassed;
+
     public Task StartAsync(CancellationToken ct)
     {
         _manager.PluginActivated   += OnPluginActivated;
@@ -226,6 +241,13 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
     internal void ProcessLivePreview(ReadOnlySpan<float> mic, int sampleRate)
     {
         if (!_previewEnabled) return;
+        // Master bypass — skip the entire preview pipeline (stackalloc +
+        // chain dispatch) when the operator has disengaged the suite.
+        // The chain itself would also short-circuit to a copy, but we
+        // save the stackallocs and the virtual call by bailing here.
+        // Per-plugin meters freeze on their last-active values, which
+        // matches operator intuition ("the engine isn't running").
+        if (_chain.MasterBypassed) return;
         if (_isMoxOn()) return;
         if (_isMonitorOn()) return;
 
@@ -354,7 +376,10 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
             return;
         }
 
-        _chain.MasterEnabled = true;
+        // Note: master bypass is owned by AudioChainMasterBypassService now;
+        // the bridge no longer auto-toggles _chain.MasterBypassed on attach.
+        // An attach into an operator-bypassed chain leaves the chain inert
+        // (correct behaviour — operator's choice stays sticky).
         RefreshPreviewEnabled();
         _log.LogInformation(
             "Audio plugin {Id} attached to slot {Slot}",
@@ -377,7 +402,10 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
             // close instead of leaving a hole in the middle of the
             // chain.
             if (_chainOrder is not null) ReapplySlotsUnderLock();
-            if (_idToSlot.Count == 0) _chain.MasterEnabled = false;
+            // Note: master bypass is owned by AudioChainMasterBypassService;
+            // bridge no longer flips _chain.MasterBypassed on last detach.
+            // The chain Process loop already no-ops cleanly on an empty
+            // slot table (all slots null → all iterations skipped).
         }
         _chainOrder?.OnPluginDetached(p.Loaded.Manifest.Id);
         RefreshPreviewEnabled();

--- a/Zeus.Server.Hosting/StreamingHub.cs
+++ b/Zeus.Server.Hosting/StreamingHub.cs
@@ -388,6 +388,19 @@ public sealed class StreamingHub
         }
     }
 
+    public void Broadcast(in AudioMasterBypassFrame frame)
+    {
+        if (_clients.IsEmpty) return;
+
+        var payload = new byte[AudioMasterBypassFrame.ByteLength];
+        var writer = new FixedBufferWriter(payload, AudioMasterBypassFrame.ByteLength);
+        frame.Serialize(writer);
+        foreach (var client in _clients.Values)
+        {
+            if (!client.TryEnqueue(payload)) System.Threading.Interlocked.Increment(ref _dropsOther);
+        }
+    }
+
     public void Broadcast(in AudioChainOrderFrame frame)
     {
         if (_clients.IsEmpty) return;

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -85,6 +85,23 @@ public static class ZeusEndpoints
             return Results.Ok(new { supported = true, enabled = audition.IsEnabled });
         });
 
+        // Audio Suite master bypass — single operator-facing toggle that
+        // disengages the entire plugin chain in one click. Default on first
+        // install is true (chain inert) so a fresh operator isn't surprised
+        // by an unfamiliar processing chain transforming their first TX.
+        // The state persists across server restarts via
+        // AudioChainSettingsStore. CFC is downstream in WDSP and unaffected;
+        // per-plugin bypass states are likewise untouched.
+        app.MapGet("/api/audio-suite/master-bypass", (AudioChainMasterBypassService svc) =>
+        {
+            return Results.Ok(new { bypassed = svc.IsBypassed });
+        });
+        app.MapPut("/api/audio-suite/master-bypass", (MasterBypassSetRequest body, AudioChainMasterBypassService svc) =>
+        {
+            svc.SetMasterBypassed(body.Bypassed);
+            return Results.Ok(new { bypassed = svc.IsBypassed });
+        });
+
         // Audio plugin chain order — operator's preferred sequence for
         // the plugins in the Audio Suite window. GET returns the
         // canonical ordered list of plugin IDs; PUT accepts a new
@@ -1332,3 +1349,4 @@ public static class ZeusEndpoints
 internal sealed record NativeMuteRequest(bool Muted);
 internal sealed record AuditionSetRequest(bool Enabled);
 internal sealed record ChainOrderSetRequest(List<string> PluginIds);
+internal sealed record MasterBypassSetRequest(bool Bypassed);

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -314,6 +314,18 @@ public static class ZeusHost
         builder.Services.AddSingleton<AudioPluginBridge>();
         builder.Services.AddHostedService(sp => sp.GetRequiredService<AudioPluginBridge>());
 
+        // AudioChainMasterBypassService — operator's "disengage the
+        // whole Audio Suite" lever. Default is true (bypassed) on first
+        // install so a brand-new operator's chain is inert until they
+        // engage it. Persists via AudioChainSettingsStore; broadcasts
+        // AudioMasterBypassFrame (0x1F) on every change. Registered
+        // AFTER AudioPluginBridge so its StartAsync runs after the
+        // bridge's, and the initial-state write-through finds a
+        // constructed chain.
+        builder.Services.AddSingleton<AudioChainSettingsStore>();
+        builder.Services.AddSingleton<AudioChainMasterBypassService>();
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<AudioChainMasterBypassService>());
+
         // TCI (Transceiver Control Interface) — ExpertSDR3-compatible WebSocket server
         // for remote control by loggers (Log4OM, N1MM+), digital-mode apps (JTDX, WSJT-X),
         // and SDR display tools. Disabled by default; enable via appsettings.json Tci:Enabled=true.

--- a/tests/Zeus.Plugins.Host.Tests/AudioChainTests.cs
+++ b/tests/Zeus.Plugins.Host.Tests/AudioChainTests.cs
@@ -22,9 +22,9 @@ public class AudioChainTests
     }
 
     [Fact]
-    public void MasterDisabled_AlwaysPassesThrough()
+    public void MasterBypassed_AlwaysPassesThrough()
     {
-        var chain = new AudioChain { MasterEnabled = false };
+        var chain = new AudioChain { MasterBypassed = true };
         chain.SetSlot(0, new AddPlugin(10f));
 
         Span<float> input  = stackalloc float[] { 1, 2, 3, 4 };
@@ -165,9 +165,9 @@ public class AudioChainTests
     }
 
     [Fact]
-    public void Scratch_Overload_MasterDisabled_PassesThrough()
+    public void Scratch_Overload_MasterBypassed_PassesThrough()
     {
-        var chain = new AudioChain { MasterEnabled = false };
+        var chain = new AudioChain { MasterBypassed = true };
         chain.SetSlot(0, new AddPlugin(10f));
 
         Span<float> input   = stackalloc float[] { 1, 2, 3, 4 };

--- a/tests/Zeus.Server.Tests/AudioChainMasterBypassServiceTests.cs
+++ b/tests/Zeus.Server.Tests/AudioChainMasterBypassServiceTests.cs
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// AudioChainMasterBypassService — startup default, persisted-state
+// restoration, bridge write-through, and orthogonality with per-slot
+// bypass (operator's per-plugin bypass choices must survive master
+// toggles).
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class AudioChainMasterBypassServiceTests : IDisposable
+{
+    private readonly string _dbPath;
+
+    public AudioChainMasterBypassServiceTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"zeus-prefs-masterbypass-{Guid.NewGuid():N}.db");
+    }
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+    }
+
+    private (AudioChainMasterBypassService svc, AudioPluginBridge bridge, AudioChainSettingsStore store) MakeService()
+    {
+        var store = new AudioChainSettingsStore(NullLogger<AudioChainSettingsStore>.Instance, _dbPath);
+        var bridge = new AudioPluginBridge(
+            isMoxOn: () => false,
+            isMonitorOn: () => false,
+            log: NullLogger<AudioPluginBridge>.Instance);
+        var hub = new StreamingHub(NullLogger<StreamingHub>.Instance);
+        var svc = new AudioChainMasterBypassService(
+            store, bridge, hub, NullLogger<AudioChainMasterBypassService>.Instance);
+        return (svc, bridge, store);
+    }
+
+    [Fact]
+    public async Task FirstRun_DefaultsBypassedTrue_AndWritesThroughToBridge()
+    {
+        var (svc, bridge, store) = MakeService();
+        try
+        {
+            await svc.StartAsync(CancellationToken.None);
+
+            Assert.True(svc.IsBypassed);
+            Assert.True(bridge.IsMasterBypassed);
+            // Persistence semantics: first run should NOT have written a
+            // row — only an explicit operator mutation writes to disk.
+            // (Matches ChainOrderStore's seed-but-don't-persist pattern.)
+            Assert.Null(store.GetMasterBypassed());
+        }
+        finally
+        {
+            store.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task PersistedFalse_RestoresChainHotOnRestart()
+    {
+        // Pre-seed the store as if a previous session had disengaged
+        // master bypass.
+        using (var store = new AudioChainSettingsStore(
+            NullLogger<AudioChainSettingsStore>.Instance, _dbPath))
+        {
+            store.SetMasterBypassed(false);
+        }
+
+        var (svc, bridge, store2) = MakeService();
+        try
+        {
+            await svc.StartAsync(CancellationToken.None);
+            Assert.False(svc.IsBypassed);
+            Assert.False(bridge.IsMasterBypassed);
+        }
+        finally
+        {
+            store2.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task SetMasterBypassed_PersistsAndWritesThrough()
+    {
+        var (svc, bridge, store) = MakeService();
+        try
+        {
+            await svc.StartAsync(CancellationToken.None);
+            // First-run default = true; operator clicks off.
+            svc.SetMasterBypassed(false);
+
+            Assert.False(svc.IsBypassed);
+            Assert.False(bridge.IsMasterBypassed);
+            Assert.NotNull(store.GetMasterBypassed());
+            Assert.False(store.GetMasterBypassed());
+        }
+        finally
+        {
+            store.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task SetMasterBypassed_IsIdempotent_NoOpOnSameValue()
+    {
+        var (svc, _, store) = MakeService();
+        try
+        {
+            await svc.StartAsync(CancellationToken.None);
+            // First-run state is true with no persisted row.
+            int eventFires = 0;
+            svc.MasterBypassedChanged += _ => eventFires++;
+            // Setting to true (same as current) must not write to store
+            // or fire the event.
+            svc.SetMasterBypassed(true);
+            Assert.Equal(0, eventFires);
+            Assert.Null(store.GetMasterBypassed());
+        }
+        finally
+        {
+            store.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task MasterToggle_DoesNotMutatePerSlotBypass()
+    {
+        var (svc, bridge, store) = MakeService();
+        try
+        {
+            await svc.StartAsync(CancellationToken.None);
+
+            // Set per-plugin bypass on slot 0 BEFORE master toggle.
+            bridge.Chain.SetSlotBypass(0, bypassed: true);
+            bridge.Chain.SetSlotBypass(1, bypassed: false);
+            bridge.Chain.SetSlotBypass(2, bypassed: true);
+
+            // Operator flips master off → on → off. Per-slot bypass
+            // states must be unchanged after each transition.
+            svc.SetMasterBypassed(false);
+            Assert.True(bridge.Chain.IsSlotBypassed(0));
+            Assert.False(bridge.Chain.IsSlotBypassed(1));
+            Assert.True(bridge.Chain.IsSlotBypassed(2));
+
+            svc.SetMasterBypassed(true);
+            Assert.True(bridge.Chain.IsSlotBypassed(0));
+            Assert.False(bridge.Chain.IsSlotBypassed(1));
+            Assert.True(bridge.Chain.IsSlotBypassed(2));
+
+            svc.SetMasterBypassed(false);
+            Assert.True(bridge.Chain.IsSlotBypassed(0));
+            Assert.False(bridge.Chain.IsSlotBypassed(1));
+            Assert.True(bridge.Chain.IsSlotBypassed(2));
+        }
+        finally
+        {
+            store.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task MasterBypassedChanged_Fires_OnChange()
+    {
+        var (svc, _, store) = MakeService();
+        try
+        {
+            await svc.StartAsync(CancellationToken.None);
+            bool? lastSeen = null;
+            int fires = 0;
+            svc.MasterBypassedChanged += b => { lastSeen = b; fires++; };
+
+            svc.SetMasterBypassed(false);
+            Assert.Equal(1, fires);
+            Assert.False(lastSeen);
+
+            svc.SetMasterBypassed(true);
+            Assert.Equal(2, fires);
+            Assert.True(lastSeen);
+        }
+        finally
+        {
+            store.Dispose();
+        }
+    }
+}

--- a/tests/Zeus.Server.Tests/AudioChainSettingsStoreTests.cs
+++ b/tests/Zeus.Server.Tests/AudioChainSettingsStoreTests.cs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// AudioChainSettingsStore — first-run = null (caller substitutes the
+// true-by-default master bypass) and round-trip after explicit set.
+// Pin the null-on-first-run contract because the operator-facing
+// default-true behaviour rides on it.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class AudioChainSettingsStoreTests : IDisposable
+{
+    private readonly string _dbPath;
+
+    public AudioChainSettingsStoreTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"zeus-prefs-audiochainsettings-{Guid.NewGuid():N}.db");
+    }
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+    }
+
+    private AudioChainSettingsStore NewStore() =>
+        new AudioChainSettingsStore(NullLogger<AudioChainSettingsStore>.Instance, _dbPath);
+
+    [Fact]
+    public void FirstRun_ReturnsNull()
+    {
+        using var store = NewStore();
+        Assert.Null(store.GetMasterBypassed());
+    }
+
+    [Fact]
+    public void SetThenGet_RoundTripsTrue()
+    {
+        using var store = NewStore();
+        store.SetMasterBypassed(true);
+        Assert.True(store.GetMasterBypassed());
+    }
+
+    [Fact]
+    public void SetThenGet_RoundTripsFalse()
+    {
+        using var store = NewStore();
+        // Explicit set to false even though that's the "uninitialized
+        // bool" value — verifies the row was actually written (vs the
+        // store returning null because no row exists).
+        store.SetMasterBypassed(false);
+        var got = store.GetMasterBypassed();
+        Assert.NotNull(got);
+        Assert.False(got);
+    }
+
+    [Fact]
+    public void SecondSet_OverwritesFirst()
+    {
+        using var store = NewStore();
+        store.SetMasterBypassed(true);
+        store.SetMasterBypassed(false);
+        var got = store.GetMasterBypassed();
+        Assert.NotNull(got);
+        Assert.False(got);
+    }
+
+    [Fact]
+    public void StatePersistsAcrossStoreInstances()
+    {
+        using (var first = NewStore())
+        {
+            first.SetMasterBypassed(false);
+        }
+        using var second = NewStore();
+        var got = second.GetMasterBypassed();
+        Assert.NotNull(got);
+        Assert.False(got);
+    }
+}

--- a/tests/Zeus.Server.Tests/AudioPluginBridgeProcessLivePreviewTests.cs
+++ b/tests/Zeus.Server.Tests/AudioPluginBridgeProcessLivePreviewTests.cs
@@ -28,7 +28,7 @@ public class AudioPluginBridgeProcessLivePreviewTests
             previewEnabled: false,
             engineIsWdsp: true);
         bridge.Chain.SetSlot(0, spy);
-        bridge.Chain.MasterEnabled = true;
+        bridge.Chain.MasterBypassed = false;
 
         RunPreview(bridge, 256);
 
@@ -44,7 +44,7 @@ public class AudioPluginBridgeProcessLivePreviewTests
             isMonitorOn: () => false,
             log: NullLogger<AudioPluginBridge>.Instance);
         bridge.Chain.SetSlot(0, spy);
-        bridge.Chain.MasterEnabled = true;
+        bridge.Chain.MasterBypassed = false;
 
         RunPreview(bridge, 256);
 
@@ -60,7 +60,7 @@ public class AudioPluginBridgeProcessLivePreviewTests
             isMonitorOn: () => true,        // <- audition mode
             log: NullLogger<AudioPluginBridge>.Instance);
         bridge.Chain.SetSlot(0, spy);
-        bridge.Chain.MasterEnabled = true;
+        bridge.Chain.MasterBypassed = false;
 
         RunPreview(bridge, 256);
 
@@ -76,7 +76,7 @@ public class AudioPluginBridgeProcessLivePreviewTests
             isMonitorOn: () => false,
             log: NullLogger<AudioPluginBridge>.Instance);
         bridge.Chain.SetSlot(0, spy);
-        bridge.Chain.MasterEnabled = true;
+        bridge.Chain.MasterBypassed = false;
 
         RunPreview(bridge, 256);
 
@@ -97,8 +97,8 @@ public class AudioPluginBridgeProcessLivePreviewTests
             isMoxOn: () => false,
             isMonitorOn: () => false,
             log: NullLogger<AudioPluginBridge>.Instance);
-        // Note: Chain.MasterEnabled defaults to true; with zero slots it
-        // is a no-op pass-through inside AudioChain.Process.
+        // Note: Chain.MasterBypassed defaults to false; with zero slots it
+        // is a no-op pass-through inside AudioChain.Process (all slots null).
 
         var ex = Record.Exception(() => RunPreview(bridge, 256));
         Assert.Null(ex);
@@ -117,7 +117,7 @@ public class AudioPluginBridgeProcessLivePreviewTests
             isMonitorOn: () => false,
             log: NullLogger<AudioPluginBridge>.Instance);
         bridge.Chain.SetSlot(0, spy);
-        bridge.Chain.MasterEnabled = true;
+        bridge.Chain.MasterBypassed = false;
 
         RunPreview(bridge, 960);
 
@@ -140,7 +140,7 @@ public class AudioPluginBridgeProcessLivePreviewTests
             log: NullLogger<AudioPluginBridge>.Instance,
             audition: sink);
         bridge.Chain.SetSlot(0, spy);
-        bridge.Chain.MasterEnabled = true;
+        bridge.Chain.MasterBypassed = false;
 
         RunPreview(bridge, 256);
 
@@ -164,7 +164,7 @@ public class AudioPluginBridgeProcessLivePreviewTests
             log: NullLogger<AudioPluginBridge>.Instance,
             audition: sink);
         bridge.Chain.SetSlot(0, spy);
-        bridge.Chain.MasterEnabled = true;
+        bridge.Chain.MasterBypassed = false;
 
         RunPreview(bridge, 256);
 
@@ -186,7 +186,7 @@ public class AudioPluginBridgeProcessLivePreviewTests
             log: NullLogger<AudioPluginBridge>.Instance,
             audition: sink);
         bridge.Chain.SetSlot(0, spy);
-        bridge.Chain.MasterEnabled = true;
+        bridge.Chain.MasterBypassed = false;
 
         RunPreview(bridge, 256);
 

--- a/tests/Zeus.Server.Tests/ChainOrderServiceTests.cs
+++ b/tests/Zeus.Server.Tests/ChainOrderServiceTests.cs
@@ -317,7 +317,7 @@ public class ChainOrderServiceTests
                     IAudioPlugin? p = id == addId ? addPlugin : id == mulId ? mulPlugin : null;
                     if (p is not null) { chain.SetSlot(idx, p); idx++; }
                 }
-                chain.MasterEnabled = idx > 0;
+                chain.MasterBypassed = idx == 0;
             }
             // Initial order is [add, mul] (attached in that order, both
             // append to v2-default positions in canonical, runtime view

--- a/zeus-web/src/components/AudioSuiteWindow.tsx
+++ b/zeus-web/src/components/AudioSuiteWindow.tsx
@@ -233,6 +233,9 @@ export function AudioSuiteWindow() {
   const auditionEnabled = useAudioSuiteStore((s) => s.auditionEnabled);
   const setAuditionEnabled = useAudioSuiteStore((s) => s.setAuditionEnabled);
   const loadAuditionState = useAudioSuiteStore((s) => s.loadAuditionState);
+  const loadMasterBypassFromServer = useAudioSuiteStore(
+    (s) => s.loadMasterBypassFromServer,
+  );
 
   const allPanels = usePluginPanels();
   const chainPanels = useMemo(
@@ -244,12 +247,19 @@ export function AudioSuiteWindow() {
   );
 
   // Fetch server-side state on first open. Subsequent updates arrive
-  // via the AudioChainOrder WS broadcast handler in ws-client.ts.
+  // via the AudioChainOrder + AudioMasterBypass WS broadcast handlers
+  // in ws-client.ts.
   useEffect(() => {
     if (!isOpen) return;
     loadChainOrderFromServer();
     loadAuditionState();
-  }, [isOpen, loadChainOrderFromServer, loadAuditionState]);
+    loadMasterBypassFromServer();
+  }, [
+    isOpen,
+    loadChainOrderFromServer,
+    loadAuditionState,
+    loadMasterBypassFromServer,
+  ]);
 
   // Escape closes the window — standard modal/popup keyboard
   // affordance. Listener only attached while the window is open

--- a/zeus-web/src/components/TxAudioToolsPanel.tsx
+++ b/zeus-web/src/components/TxAudioToolsPanel.tsx
@@ -13,7 +13,7 @@
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { CfcSettingsPanel } from './CfcSettingsPanel';
 import { DownloadAudioSuiteButton } from './DownloadAudioSuiteButton';
 import { usePluginPanels } from '../plugins/runtime/usePluginPanels';
@@ -53,6 +53,18 @@ function ChainFlow({ chainPanels }: { chainPanels: RegisteredPluginPanel[] }) {
     ];
   }, [chainPanels]);
 
+  const masterBypassed = useAudioSuiteStore((s) => s.masterBypassed);
+  const loadMasterBypassFromServer = useAudioSuiteStore(
+    (s) => s.loadMasterBypassFromServer,
+  );
+
+  // Pull the master-bypass state from the server once on mount so a
+  // fresh browser session reflects the persisted operator preference.
+  // Subsequent broadcasts (0x1F) keep us in sync without polling.
+  useEffect(() => {
+    loadMasterBypassFromServer();
+  }, [loadMasterBypassFromServer]);
+
   return (
     <div
       role="presentation"
@@ -73,32 +85,87 @@ function ChainFlow({ chainPanels }: { chainPanels: RegisteredPluginPanel[] }) {
         flexWrap: 'wrap',
       }}
     >
+      <MasterBypassButton />
       <span style={{ marginRight: 4, color: 'var(--fg-1)', fontWeight: 500 }}>TX chain</span>
-      {v1Slots.map((slot, i) => (
-        <span key={slot.id} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-          {i > 0 && (
-            <span aria-hidden style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono, JetBrains Mono, ui-monospace, monospace)' }}>›</span>
-          )}
-          <span
-            style={{
-              padding: '2px 8px',
-              borderRadius: 3,
-              background: slot.installed ? 'var(--bg-2)' : 'var(--bg-1)',
-              border: '1px solid ' + (slot.installed ? 'var(--accent)' : 'var(--line-1)'),
-              color: slot.installed ? 'var(--fg-0)' : 'var(--fg-3)',
-              opacity: slot.installed ? 1 : 0.5,
-              fontSize: 10,
-              fontWeight: 500,
-            }}
-            title={slot.installed ? 'Installed and active' : 'Not installed — click Download Audio Suite or Settings → Plugins → Install from URL'}
-          >
-            {slot.title}
+      {v1Slots.map((slot, i) => {
+        // CFC is downstream in WDSP and unaffected by master bypass —
+        // never dim it. Plugin slots dim to 45% when bypassed to mirror
+        // the per-plugin bypass visual convention (operator sees the
+        // chain is inert).
+        const dimForBypass = slot.id !== 'cfc' && masterBypassed;
+        return (
+          <span key={slot.id} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            {i > 0 && (
+              <span aria-hidden style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono, JetBrains Mono, ui-monospace, monospace)' }}>›</span>
+            )}
+            <span
+              style={{
+                padding: '2px 8px',
+                borderRadius: 3,
+                background: slot.installed ? 'var(--bg-2)' : 'var(--bg-1)',
+                border: '1px solid ' + (slot.installed ? 'var(--accent)' : 'var(--line-1)'),
+                color: slot.installed ? 'var(--fg-0)' : 'var(--fg-3)',
+                opacity: dimForBypass ? 0.45 : (slot.installed ? 1 : 0.5),
+                fontSize: 10,
+                fontWeight: 500,
+                transition: 'opacity 120ms ease-out',
+              }}
+              title={
+                dimForBypass
+                  ? 'Master bypass engaged — this stage is inert. Click BYPASS to engage the chain.'
+                  : slot.installed
+                  ? 'Installed and active'
+                  : 'Not installed — click Download Audio Suite or Settings → Plugins → Install from URL'
+              }
+            >
+              {slot.title}
+            </span>
           </span>
-        </span>
-      ))}
+        );
+      })}
       <AudioSuiteOpenButton />
       <DownloadAudioSuiteButton />
     </div>
+  );
+}
+
+// Master-bypass toggle for the whole plugin chain. One click instead of
+// six per-plugin bypass clicks. Sits at the head of the brass rail so
+// it's the first thing the operator's eye lands on. Visual convention
+// matches the per-plugin bypass (feedback_audio_plugin_bypass_convention):
+//   engaged   (bypassed) → --tx background, white text, "BYPASS" label
+//   released (chain hot) → --bg-2 background, --fg-2 text, "BYPASS" label
+function MasterBypassButton() {
+  const masterBypassed = useAudioSuiteStore((s) => s.masterBypassed);
+  const setMasterBypassed = useAudioSuiteStore((s) => s.setMasterBypassed);
+  return (
+    <button
+      type="button"
+      onClick={() => setMasterBypassed(!masterBypassed)}
+      aria-pressed={masterBypassed}
+      title={
+        masterBypassed
+          ? 'Master bypass ENGAGED — entire plugin chain (NoiseGate / EQ / Comp / Exciter / Bass / Reverb) is inert; mic passes through untouched. CFC is unaffected. Click to engage the chain.'
+          : 'Plugin chain ACTIVE — all installed plugins are processing your mic. Click to disengage the whole chain in one shot (per-plugin bypass states are preserved).'
+      }
+      style={{
+        padding: '4px 12px',
+        borderRadius: 4,
+        border: '1px solid ' + (masterBypassed ? 'var(--tx)' : 'var(--accent)'),
+        background: masterBypassed ? 'var(--tx)' : 'var(--bg-2)',
+        color: masterBypassed ? '#fff' : 'var(--fg-2)',
+        cursor: 'pointer',
+        fontSize: 10,
+        fontWeight: 700,
+        letterSpacing: 1.2,
+        textTransform: 'uppercase',
+        fontFamily: 'var(--font-sans, Inter, system-ui, sans-serif)',
+        minWidth: 72,
+        transition: 'background 120ms ease-out, color 120ms ease-out, border-color 120ms ease-out',
+      }}
+    >
+      Bypass
+    </button>
   );
 }
 

--- a/zeus-web/src/realtime/ws-client.ts
+++ b/zeus-web/src/realtime/ws-client.ts
@@ -154,6 +154,15 @@ const MIC_PEAK_BYTES = 1 + 4 + 8;
 // Contract: Zeus.Contracts/AudioChainOrderFrame.cs.
 export const MSG_TYPE_AUDIO_CHAIN_ORDER = 0x1e;
 
+// Audio Suite master-bypass broadcast. Server pushes this on every
+// operator toggle of the master bypass — disengages the WHOLE plugin
+// chain (NoiseGate / EQ / Comp / Exciter / Bass / Reverb) in a single
+// click. CFC is downstream in WDSP and unaffected; per-plugin bypass
+// states are untouched. Payload: [0x1F][bypassed:u8] = 2 bytes.
+// Contract: Zeus.Contracts/AudioMasterBypassFrame.cs.
+export const MSG_TYPE_AUDIO_MASTER_BYPASS = 0x1f;
+const AUDIO_MASTER_BYPASS_BYTES = 2;
+
 // Shared by startRealtime / sendMicPcm. Single WS instance at a time; writes
 // are no-ops when the socket isn't open.
 let activeWs: WebSocket | null = null;
@@ -333,6 +342,20 @@ export function startRealtime(path = '/ws'): () => void {
           // window (e.g. the no-plugins-installed first-run experience).
           void import('../state/audio-suite-store').then((m) => {
             m.useAudioSuiteStore.getState().setChainOrderFromServer(ids);
+          });
+          return;
+        }
+        if (peekType === MSG_TYPE_AUDIO_MASTER_BYPASS) {
+          if (ev.data.byteLength < AUDIO_MASTER_BYPASS_BYTES) {
+            warnOnce(
+              'ws-audio-master-bypass-short',
+              `audio master-bypass frame too short: ${ev.data.byteLength}`,
+            );
+            return;
+          }
+          const bypassed = new DataView(ev.data).getUint8(1) !== 0;
+          void import('../state/audio-suite-store').then((m) => {
+            m.useAudioSuiteStore.getState().setMasterBypassedFromServer(bypassed);
           });
           return;
         }

--- a/zeus-web/src/state/audio-suite-store.ts
+++ b/zeus-web/src/state/audio-suite-store.ts
@@ -18,6 +18,13 @@
 //     chain's output into the operator's RX playback path. Server
 //     state (IAuditionAudioSink.IsEnabled); store mirrors. Not
 //     persisted — defaults off on every fresh boot.
+//   - Master bypass: single operator-facing toggle that disengages
+//     the entire plugin chain (NoiseGate / EQ / Comp / Exciter / Bass
+//     / Reverb). Server-side default on first install is true
+//     (chain inert). State persists across server restarts via
+//     AudioChainSettingsStore. WS broadcast: AudioMasterBypassFrame
+//     (0x1F). Local store is NOT persisted to localStorage — server
+//     is authoritative; fetched on mount.
 //
 // What does NOT live here (handled elsewhere):
 //   - Per-plugin settings (bypass, knob positions) — owned by each
@@ -52,6 +59,12 @@ interface AudioSuiteState {
   auditionSupported: boolean;
   auditionEnabled: boolean;
 
+  // Master bypass — single operator-facing toggle that disengages the
+  // entire plugin chain. true = chain inert, mic passes bit-identical
+  // to WDSP; false = chain hot. Default on first launch is true; the
+  // server (AudioChainMasterBypassService) is the source of truth.
+  masterBypassed: boolean;
+
   // Drag state — transient, not persisted.
   isDragging: boolean;
 
@@ -71,6 +84,11 @@ interface AudioSuiteState {
   // Audition plumbing.
   loadAuditionState(): Promise<void>;
   setAuditionEnabled(enabled: boolean): Promise<void>;
+
+  // Master bypass plumbing.
+  setMasterBypassedFromServer(bypassed: boolean): void;
+  loadMasterBypassFromServer(): Promise<void>;
+  setMasterBypassed(bypassed: boolean): Promise<void>;
 }
 
 // Default window placement — top-left quadrant, room for plugin panels.
@@ -90,6 +108,11 @@ export const useAudioSuiteStore = create<AudioSuiteState>()(
       chainOrder: [],
       auditionSupported: false,
       auditionEnabled: false,
+      // Default to true (bypassed) so the UI starts in the inert state
+      // that matches the server's first-run default. The server load
+      // on Audio Suite window mount overrides this with the persisted
+      // value (if any) and any WS broadcast keeps it in sync after.
+      masterBypassed: true,
       isDragging: false,
 
       open: () => set({ isOpen: true }),
@@ -204,6 +227,47 @@ export const useAudioSuiteStore = create<AudioSuiteState>()(
           set({ auditionEnabled: prev });
           // eslint-disable-next-line no-console
           console.warn('audio-suite audition PUT threw', err);
+        }
+      },
+
+      setMasterBypassedFromServer: (bypassed) => set({ masterBypassed: bypassed }),
+
+      loadMasterBypassFromServer: async () => {
+        try {
+          const res = await fetch('/api/audio-suite/master-bypass');
+          if (!res.ok) return;
+          const body = (await res.json()) as { bypassed?: boolean };
+          if (typeof body.bypassed === 'boolean') {
+            set({ masterBypassed: body.bypassed });
+          }
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.warn('audio-suite master-bypass GET threw', err);
+        }
+      },
+
+      setMasterBypassed: async (bypassed) => {
+        const prev = get().masterBypassed;
+        if (prev === bypassed) return;
+        // Optimistic update so the toggle feels instant.
+        set({ masterBypassed: bypassed });
+        try {
+          const res = await fetch('/api/audio-suite/master-bypass', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ bypassed }),
+          });
+          if (!res.ok) {
+            set({ masterBypassed: prev });
+            // eslint-disable-next-line no-console
+            console.warn(
+              `audio-suite master-bypass PUT rejected: ${res.status} ${res.statusText}`,
+            );
+          }
+        } catch (err) {
+          set({ masterBypassed: prev });
+          // eslint-disable-next-line no-console
+          console.warn('audio-suite master-bypass PUT threw', err);
         }
       },
     }),


### PR DESCRIPTION
## Summary

One operator-facing toggle disengages the entire Audio Suite (NoiseGate, EQ, Comp, Exciter, Bass, Reverb) in a single click instead of six per-plugin bypass clicks. **CFC is downstream in WDSP and unaffected**; per-plugin bypass states are untouched and resume when master bypass is released.

Default on first install is **ON (chain inert)** so a brand-new operator isn't surprised by an unfamiliar processing chain transforming their first TX before they've configured it. State persists across server restarts via a new `AudioChainSettingsStore` (sister to `ChainOrderStore`).

## Architecture

- **`AudioChain.MasterEnabled`** is renamed and inverted to **`MasterBypassed`** (`volatile bool`, realtime read in `Process`, control-thread write). The two `AudioPluginBridge` auto-toggles that previously tracked "any plugins attached" via `MasterEnabled` are removed — the chain's per-slot null-check already handles an empty chain cleanly, and the auto-toggle collided with operator-controlled master bypass.
- **`AudioChainSettingsStore`** (new) — LiteDB store for chain-level settings. Single-row collection `audio_chain_settings`; missing row resolves to `null` so the caller substitutes the default.
- **`AudioChainMasterBypassService`** (new, `IHostedService`) — reads persisted state on `StartAsync`, applies the default-true when no row exists, writes through to the bridge before any audio flows. On every operator toggle: locks, persists, write-throughs, broadcasts. Registered AFTER `AudioPluginBridge` so the initial write-through finds a constructed chain.
- **`AudioMasterBypassFrame`** (0x1F, 2 bytes) carries the bool over the WS. Frontend lazy-imports the audio-suite store on receipt to avoid pulling the module into clients that never open the Audio Suite.
- **REST:** `GET` / `PUT /api/audio-suite/master-bypass`.
- **UI:** prominent `BYPASS` toggle at the head of the brass-plate chain rail in `TxAudioToolsPanel`. `--tx` red when engaged, `--bg-2` when released. Plugin slots dim to 45% opacity when master bypass is engaged (matches the per-plugin bypass convention). CFC stays at full opacity since it's not part of the plugin chain.

## Realtime safety

- Single `volatile bool` flip on the chain — no locks, no plugin re-init, no clicks/pops.
- Per-plugin bypass state lives on each `ChainSlot` and is never read or written by the master service.
- `ProcessLivePreview` short-circuits when bypassed (skips the `stackalloc` + chain dispatch).
- Persist-before-write-through ordering: if the process dies between disk and bridge, the next boot reads what the realtime engine will run.

## Tests

11 new (all passing):

- `AudioChainSettingsStoreTests` — first-run-null contract, set/get round-trip, persistence-across-instances
- `AudioChainMasterBypassServiceTests` — default-true on first run + bridge write-through, persisted-false-restore on restart, idempotency (no broadcast when value unchanged), **per-slot bypass orthogonality** (toggle master off→on→off, individual plugin bypass states unchanged), event firing

Existing `AudioChainTests` + `AudioPluginBridgeProcessLivePreviewTests` + `ChainOrderServiceTests` updated to the renamed/inverted property. Full solution suite: **1,186 tests pass**.

## Manual verification

Bench-tested locally end-to-end before opening this PR:

- [x] First-launch with no persisted row → chain inert, `BYPASS` lit `--tx` red, plugin tiles dimmed
- [x] CFC at full opacity (not part of the plugin chain — independent layer)
- [x] Click `BYPASS` off → chain hot, plugins process audio, meters animate
- [x] Persistence — state survives backend restart
- [x] Per-plugin bypass orthogonality — toggling master leaves individual plugin bypass states untouched

## Out of scope

- Plugin-side awareness of master bypass — the service writes through to `AudioChain.MasterBypassed`; each plugin's internal state is unchanged. If a future plugin wants to render a "globally bypassed" badge in its own panel, that's a separate task.
- Mobile / Android UI — Audio Suite isn't surfaced on mobile yet.