### PR TITLE
feat(audio): WASAPI Pro Audio MMCSS hint on miniaudio playback + capture

### DIFF
--- a/native/miniaudio/zeus_miniaudio.c
+++ b/native/miniaudio/zeus_miniaudio.c
@@ -151,6 +151,17 @@ ZEUS_MA_EXPORT void* zeus_ma_output_create(
     /* Linear resampler: lowest CPU + lowest added latency. Adequate for
      * voice / SSB / FM audio at 48 kHz. */
     cfg.resampling.algorithm = ma_resample_algorithm_linear;
+    /* Performance + scheduler hints. Documented intent: ask the OS for the
+     * smallest period the driver supports (functionally the default on
+     * miniaudio — ma_performance_profile_low_latency == 0 and the config
+     * struct is zero-init), and tell Windows WASAPI this is a real-time
+     * audio app so AvSetMmThreadCharacteristics raises the audio worker
+     * thread to the "Pro Audio" MMCSS class. The Pro Audio class biases
+     * the scheduler away from preempting our callback under load, which
+     * is the OS-side counterpart to the dropout-resilience the C# ring
+     * already provides. wasapi.usage is a no-op on macOS / Linux backends. */
+    cfg.performanceProfile = ma_performance_profile_low_latency;
+    cfg.wasapi.usage       = ma_wasapi_usage_pro_audio;
 
     if (ma_device_init(NULL, &cfg, &h->device) != MA_SUCCESS) {
         free(h);
@@ -228,6 +239,13 @@ ZEUS_MA_EXPORT void* zeus_ma_input_create(
     cfg.notificationCallback = zeus_ma_input_notify_proc;
     cfg.pUserData          = h;
     cfg.resampling.algorithm = ma_resample_algorithm_linear;
+    /* Same performance + scheduler hints as the playback side — see the
+     * comment in zeus_ma_output_create. The mic-capture worker runs
+     * continuously while desktop mode is up, so MMCSS Pro Audio class
+     * helps it survive OS-level preemption the same way it helps the
+     * playback thread. */
+    cfg.performanceProfile = ma_performance_profile_low_latency;
+    cfg.wasapi.usage       = ma_wasapi_usage_pro_audio;
 
     if (ma_device_init(NULL, &cfg, &h->device) != MA_SUCCESS) {
         free(h);


### PR DESCRIPTION
## Summary

Single commit. Sets two device-config knobs on every `ma_device_config` created by `zeus_miniaudio.c`:

```c
cfg.performanceProfile = ma_performance_profile_low_latency;
cfg.wasapi.usage       = ma_wasapi_usage_pro_audio;
```

- **`wasapi.usage`** — the real change. On Windows, miniaudio's WASAPI backend calls `AvSetMmThreadCharacteristics("Pro Audio")` on the audio worker thread, putting it in the Pro Audio MMCSS scheduling class. Biases the Windows scheduler away from preempting the audio callback under load. **No-op on macOS CoreAudio / Linux ALSA / PulseAudio.**
- **`performanceProfile`** — documentation only. Value is `0` and `ma_device_config_init` zero-inits the struct, so this was already the default; setting it explicitly makes intent obvious to a future reader.
- Applied to **both** playback (`zeus_ma_output_create`) and capture (`zeus_ma_input_create`).
- **Does NOT** change shared- vs exclusive-mode (still shared) — other apps keep access to the DAC.
- **Does NOT** disable hardware offloading.

Refs #336, #248.

## Maintainer-review flag

Scheduler / thread-priority hints are borderline per CLAUDE.md — they don't change RX/TX behaviour but affect *how* audio behaves on Windows under contention. Specifically:

- No before/after measurement on a real HL2 + USB DAC yet.
- The change won't take effect until `Zeus.Dsp/runtimes/*/native/miniaudio.*` is rebuilt via the `build-native-libs` workflow. Source-only PR until then.

## Test plan

- [x] `dotnet build Zeus.slnx -c Debug` — clean, 0 warnings, 0 errors.
- [ ] `build-native-libs` workflow rebuilds `miniaudio.{dll,dylib,so}` for all five RIDs cleanly.
- [ ] Bench-test on Windows + USB DAC: confirm no audio regression, MOX cycle behaviour unchanged or improved.
- [ ] Bench-test on macOS: confirm no audio regression (the `wasapi.*` field is ignored by CoreAudio backend).
- [ ] Confirm shared-mode behaviour unchanged: another app keeps access to the same DAC while Zeus is running.

## Files

- `native/miniaudio/zeus_miniaudio.c` — +18 lines, 2 sites.