### PR TITLE
fix(ps): messaging

### DIFF
--- a/zeus-web/src/components/PsSettingsPanel.tsx
+++ b/zeus-web/src/components/PsSettingsPanel.tsx
@@ -215,13 +215,14 @@ export function PsSettingsPanel() {
 
   // Dial state visualization. WDSP info[14] (psCorrecting) reports "iqc
   // curve loaded + engaged" — true even when MOX is off, because the curve
-  // persists between keying cycles. Split into two pill states so the
-  // operator sees the right thing:
+  // persists between keying cycles. It also stays high after the operator
+  // disables PS until the curve is explicitly cleared, so gate on psEnabled
+  // too — otherwise the panel claims "correcting" with PS off.
   //   - "correcting" only when actively transmitting (curve applied to live RF)
   //   - "ready"      when curve is loaded but radio is idle
   const keyed = moxOn || tunOn || twoToneOn;
-  const isCorrecting = psCorrecting && keyed;
-  const isReady = psCorrecting && !keyed;
+  const isCorrecting = psEnabled && psCorrecting && keyed;
+  const isReady = psEnabled && psCorrecting && !keyed;
   const isRunning = psEnabled && !psCorrecting && psCalState > 0;
   const dialClass = isCorrecting || isReady ? 'is-converged' : '';
   const pillClass = isCorrecting || isReady ? 'ok' : isRunning ? 'run' : '';
@@ -265,17 +266,22 @@ export function PsSettingsPanel() {
   const sparkPoints = buildSparkline(sparkRef.current);
 
   // Peak meters share the same x-scale: 0..max(HW peak * 1.4, observed).
-  // Observed peak warns when within 5% of HW peak, faults at HW peak.
+  // calcc only sets scOK (= curve loaded) when bins 0..3 of the envelope
+  // histogram are full, which requires observed ∈ [0.80·hw_peak, hw_peak].
+  // Below that the top bins starve → PS sits in COLLECT forever;
+  // above hw_peak the envelope clips into bin 15.
   const meterScale = Math.max(psHwPeak * 1.4, psMaxTxEnvelope * 1.05, 0.001);
   const obsPct = Math.min(100, (psMaxTxEnvelope / meterScale) * 100);
   const hwRefPct = Math.min(100, (psHwPeak / meterScale) * 100);
   const hwSelfPct = Math.min(100, (psHwPeak / meterScale) * 100);
-  const obsClass =
-    psMaxTxEnvelope >= psHwPeak
-      ? 'bad'
-      : psMaxTxEnvelope > psHwPeak * 0.95
-        ? 'warn'
-        : '';
+  const obsClipping = psMaxTxEnvelope > psHwPeak;
+  const obsStarved = psMaxTxEnvelope > 0 && psMaxTxEnvelope < psHwPeak * 0.80;
+  const obsClass = obsClipping ? 'bad' : obsStarved ? 'warn' : '';
+  const obsHint = obsClipping
+    ? 'HW peak too low — Observed is clipping into the ADC ceiling.'
+    : obsStarved
+      ? 'HW peak too high — Observed needs to reach ≥ 90 % of it for the fit to converge.'
+      : 'Live feedback amplitude · should sit in the 90–100 % band of HW peak.';
 
   // Signal-flow node states: TX is always "on" when psEnabled; remaining
   // nodes light up when calibration is actually running so the operator
@@ -416,9 +422,7 @@ export function PsSettingsPanel() {
                 <div className="ps-mfill" style={{ width: `${obsPct}%` }} />
                 <div className="ps-ref" style={{ left: `${hwRefPct}%` }} />
               </div>
-              <div className="ps-help">
-                Live feedback amplitude · target near HW peak.
-              </div>
+              <div className="ps-help">{obsHint}</div>
             </div>
 
             <div className="ps-peak">

--- a/zeus-web/src/components/PsStatusPopover.tsx
+++ b/zeus-web/src/components/PsStatusPopover.tsx
@@ -64,8 +64,8 @@ export function PsStatusPopover() {
   const feedbackRound = Math.round(psFeedbackLevel);
 
   const keyed = moxOn || tunOn || twoToneOn;
-  const isCorrecting = psCorrecting && keyed;
-  const isReady = psCorrecting && !keyed;
+  const isCorrecting = psEnabled && psCorrecting && keyed;
+  const isReady = psEnabled && psCorrecting && !keyed;
   const isRunning = psEnabled && !psCorrecting && psCalState > 0;
   const dialClass = isCorrecting || isReady ? 'is-converged' : '';
   const armedLabel = !psEnabled
@@ -79,16 +79,19 @@ export function PsStatusPopover() {
           : 'ARMED';
 
   // Peak meter scale — same logic as the Settings hero so values map 1:1
-  // between the two views.
+  // between the two views. calcc needs observed ∈ [0.80·hw_peak, hw_peak]
+  // for scOK (top bins filled, no clip); outside that the fit stalls.
   const meterScale = Math.max(psHwPeak * 1.4, psMaxTxEnvelope * 1.05, 0.001);
   const obsPct = Math.min(100, (psMaxTxEnvelope / meterScale) * 100);
   const refPct = Math.min(100, (psHwPeak / meterScale) * 100);
-  const obsClass =
-    psMaxTxEnvelope >= psHwPeak
-      ? 'bad'
-      : psMaxTxEnvelope > psHwPeak * 0.95
-        ? 'warn'
-        : '';
+  const obsClipping = psMaxTxEnvelope > psHwPeak;
+  const obsStarved = psMaxTxEnvelope > 0 && psMaxTxEnvelope < psHwPeak * 0.80;
+  const obsClass = obsClipping ? 'bad' : obsStarved ? 'warn' : '';
+  const obsHint = obsClipping
+    ? 'HW peak too low — Observed clipping.'
+    : obsStarved
+      ? 'HW peak too high — Observed needs ≥ 90 %.'
+      : null;
 
   const modeLabel = psSingle ? 'Single' : psAuto ? 'Auto' : 'Manual';
 
@@ -140,7 +143,7 @@ export function PsStatusPopover() {
           <div className="ps-popover-row">
             <dt>Correction</dt>
             <dd className="mono">
-              {psCorrecting ? `+${psCorrectionDb.toFixed(2)} dB` : '—'}
+              {psEnabled && psCorrecting ? `+${psCorrectionDb.toFixed(2)} dB` : '—'}
             </dd>
           </div>
         </dl>
@@ -159,6 +162,7 @@ export function PsStatusPopover() {
           <span>HW peak</span>
           <span className="mono">{psHwPeak.toFixed(4)}</span>
         </div>
+        {obsHint ? <div className="ps-popover-peak-hint">{obsHint}</div> : null}
       </div>
 
       <div className="ps-popover-foot">

--- a/zeus-web/src/components/PsToggleButton.tsx
+++ b/zeus-web/src/components/PsToggleButton.tsx
@@ -131,7 +131,7 @@ export function PsToggleButton() {
         <span className={`led ${psEnabled ? 'on' : ''}`} style={{ marginRight: 8 }} />
         PS
       </button>
-      {open ? (
+      {open && psEnabled ? (
         <span
           id="ps-status-popover"
           className="ps-popover-anchor"

--- a/zeus-web/src/styles/ps-settings.css
+++ b/zeus-web/src/styles/ps-settings.css
@@ -981,6 +981,18 @@
   background: var(--fg-1);
   opacity: 0.7;
 }
+.ps-popover-peak-hint {
+  margin-top: 4px;
+  font-size: 10.5px;
+  letter-spacing: 0.01em;
+  color: var(--fg-2);
+}
+.ps-popover-peak.warn .ps-popover-peak-hint {
+  color: var(--ps-warn);
+}
+.ps-popover-peak.bad .ps-popover-peak-hint {
+  color: var(--ps-bad);
+}
 
 .ps-popover-foot {
   margin-top: 10px;


### PR DESCRIPTION
## Summary

Three messaging bugs in the PureSignal panel that all gave the operator the wrong mental model of what the engine was doing.

- **"CAL · correcting" pill stayed lit after disabling PS.** WDSP `info[14]` (curve-loaded flag) persists until the curve is explicitly cleared, so the pill claimed PS was correcting with PS off. Gate `isCorrecting` / `isReady` / the correction-dB readout on `psEnabled` in both `PsSettingsPanel` and `PsStatusPopover`.
- **PS hover popover opened over a disabled PS button.** Gate the anchor on `psEnabled` so it's suppressed when PS is off.
- **Observed-vs-HW-peak coloring was backwards.** `calcc.c:466` sets `scOK = true` (curve loadable) only when histogram bins 0..3 of the envelope are full — i.e. observed ∈ `[0.80·hw_peak, hw_peak]`. Below that the top bins starve and the state machine sits in COLLECT forever; above `hw_peak` it clips into bin 15. Old logic greened the starved case and warned on the productive case, so a well-meaning operator who raised `hw_peak` to "make the red go away" ended up stuck at "running" with no correction loaded. New scheme:

  | observed range          | class | meaning            |
  | ----------------------- | ----- | ------------------ |
  | `> hw_peak`             | bad   | clipping           |
  | `< 0.80 × hw_peak`      | warn  | starved            |
  | otherwise               | good  | in the fit window  |

  Help text under the Observed bar is now context-aware — it names the specific failure mode instead of the static "target near HW peak" that pointed operators in the wrong direction. Same short hint appears in the popover when out of band.

## Test plan

- [ ] PS off + radio idle → pill reads `CAL · idle`, popover does not open on hover.
- [ ] PS off + radio keyed → pill stays `CAL · idle` (no leftover "correcting").
- [ ] PS on + Auto + 2-tone, `HW peak` slightly above `Observed` → pill flips through `correcting`, Observed bar is **green**, hint says "Live feedback amplitude · should sit in the 90–100 % band of HW peak."
- [ ] PS on + raise `HW peak` to ~1.3 × Observed → Observed bar turns **amber**, hint says "HW peak too high — Observed needs to reach ≥ 90 % of it for the fit to converge."
- [ ] PS on + drop `HW peak` below `Observed` → Observed bar turns **red**, hint says "HW peak too low — Observed is clipping into the ADC ceiling."