### PR TITLE
fix(installer): bundle Visual C++ Runtime so fresh Windows installs work

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -526,6 +526,24 @@ jobs:
 
       # ---------- Installer packaging (one per OS, two launch modes) ------
 
+      # Download the Microsoft Visual C++ 2015-2022 Redistributable matching
+      # this installer's architecture. zeus-windows.iss bundles this file via
+      # the [Files] section and runs it at install time, guarded by a
+      # VCRedistNeeded() registry check so it skips on machines that already
+      # have a compatible runtime. Without this, every fresh-Windows operator
+      # who downloads Zeus gets a silently broken install — see issue #452.
+      # aka.ms URLs are Microsoft's stable redirects; the resolved binary
+      # tracks the latest 14.x service pack on each fetch (binary-compatible).
+      - name: Download Visual C++ Redistributable
+        if: matrix.config.os == 'windows'
+        shell: pwsh
+        run: |
+          $url = "https://aka.ms/vs/17/release/vc_redist.${{ matrix.config.arch }}.exe"
+          $out = "installers\vc_redist.${{ matrix.config.arch }}.exe"
+          Write-Host "Downloading $url -> $out"
+          Invoke-WebRequest -Uri $url -OutFile $out -UseBasicParsing
+          Get-Item $out | Select-Object Name, Length
+
       - name: Build Windows Installer (Inno Setup)
         if: matrix.config.os == 'windows'
         shell: pwsh

--- a/installers/.gitignore
+++ b/installers/.gitignore
@@ -1,0 +1,13 @@
+# Microsoft Visual C++ Redistributable binaries — downloaded on-demand by
+# the release CI (release.yml "Download Visual C++ Redistributable" step)
+# before iscc bundles them into the Windows installer. Local iscc builds
+# need the matching file fetched manually; see the comment block on the
+# Source: line in zeus-windows.iss for the curl commands. Never commit
+# these binaries — they bloat the repo and Microsoft's aka.ms redirect is
+# the authoritative source.
+vc_redist.x64.exe
+vc_redist.arm64.exe
+vc_redist.x86.exe
+
+# Inno Setup build output goes into installers/output/ at install time.
+output/

--- a/installers/zeus-windows.iss
+++ b/installers/zeus-windows.iss
@@ -62,6 +62,20 @@ Name: "desktopiconserver"; Description: "Create a &server-mode desktop icon (Zeu
 
 [Files]
 Source: "..\OpenhpsdrZeus\bin\Release\net10.0\win-{#Arch}\publish\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+; Microsoft Visual C++ 2015-2022 Redistributable — required for wdsp.dll and
+; miniaudio.dll to load. Fresh Windows installs do not include this runtime,
+; and without it Zeus silently falls back to its synthetic DSP engine
+; (blank panadapter, no audio, no transmit power). The release CI downloads
+; the matching vc_redist.{#Arch}.exe from Microsoft (https://aka.ms/vs/17/release/)
+; into this directory before iscc runs. The file is then bundled with the
+; installer and run during install via the [Run] section below, skipped via
+; VCRedistInstalled() if a compatible runtime is already present.
+;
+; For LOCAL iscc builds (developers), download the matching redist into the
+; installers/ folder manually:
+;   x64:   curl -L -o installers/vc_redist.x64.exe   https://aka.ms/vs/17/release/vc_redist.x64.exe
+;   arm64: curl -L -o installers/vc_redist.arm64.exe https://aka.ms/vs/17/release/vc_redist.arm64.exe
+Source: "vc_redist.{#Arch}.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall; Check: VCRedistNeeded
 
 [Icons]
 ; Two Start Menu shortcuts under the "Openhpsdr Zeus" group:
@@ -78,6 +92,14 @@ Name: "{autodesktop}\{#MyAppShortName}";        Filename: "{app}\{#MyAppExeName}
 Name: "{autodesktop}\{#MyAppShortName} Server"; Filename: "{app}\{#MyAppExeName}"; Parameters: "--server";  IconFilename: "{app}\{#MyAppExeName}"; Tasks: desktopiconserver
 
 [Run]
+; Install the Microsoft Visual C++ 2015-2022 Redistributable BEFORE launching
+; Zeus. wdsp.dll and miniaudio.dll are MSVC-linked and will not load without
+; vcruntime140.dll / msvcp140.dll present in the system. Skipped via
+; VCRedistNeeded() if a compatible runtime is already installed (avoids the
+; ~10-second silent reinstall and the UAC prompt for operators who already
+; have it). See issue #452 for the symptoms this fix prevents.
+Filename: "{tmp}\vc_redist.{#Arch}.exe"; Parameters: "/install /quiet /norestart"; StatusMsg: "Installing Microsoft Visual C++ Runtime..."; Check: VCRedistNeeded; Flags: waituntilterminated
+
 ; Post-install launch lands the operator in the desktop window — no console,
 ; no browser dance. Server mode is one Start Menu click away for the LAN /
 ; remote operator.
@@ -145,6 +167,39 @@ begin
     MsgBox('This application requires Windows 64-bit.', mbError, MB_OK);
     Result := False;
   end;
+end;
+
+// VCRedistNeeded — returns True when the Microsoft Visual C++ 2015-2022
+// Redistributable is NOT already installed on this machine. The [Files]
+// entry for vc_redist.{#Arch}.exe and the [Run] step that invokes it are
+// both gated on this so we don't waste ~10 seconds reinstalling the runtime
+// and triggering a needless UAC prompt for operators who already have it.
+//
+// Detection: registry presence under HKLM\SOFTWARE\Microsoft\VisualStudio\
+// 14.0\VC\Runtimes\<arch> is the Microsoft-blessed signal. The 14.0 line
+// covers the entire 2015..2022 ABI-compatible family — any 14.x install
+// satisfies our DLL dependencies.
+//
+// Per-arch keys: x64 is checked under the 64-bit registry view; arm64 ships
+// to a sibling key with the same shape. The "Installed" DWORD = 1 indicates
+// presence.
+function VCRedistInstalled: Boolean;
+var
+  InstalledFlag: Cardinal;
+begin
+  // The {#Arch} preprocessor token expands to "x64" or "arm64" at iscc time,
+  // so the resulting Pascal string is the literal registry path for whichever
+  // installer flavour we're building.
+  Result := False;
+  if RegQueryDWordValue(HKLM64,
+       'SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\{#Arch}',
+       'Installed', InstalledFlag) and (InstalledFlag = 1) then
+    Result := True;
+end;
+
+function VCRedistNeeded: Boolean;
+begin
+  Result := not VCRedistInstalled;
 end;
 
 procedure CurStepChanged(CurStep: TSetupStep);


### PR DESCRIPTION
Closes #452.

## Summary

Every Windows operator since v0.8.0 who installed Zeus on a fresh Windows machine without a prior MSVC-linked desktop app (Office, Visual Studio, a major game, etc.) has been getting a silently broken install: **blank panadapter, no audio, MOX keys the radio but no power output**. Cause: `wdsp.dll` and `miniaudio.dll` are MSVC-linked and need `vcruntime140.dll` / `msvcp140.dll` present at load time. The Zeus installer shipped neither and never checked. Confirmed via fresh Windows 11 VM reproduction — both runtime DLLs absent from System32, both natives failing to load with `System.DllNotFoundException: Unable to load DLL 'miniaudio' or one of its dependencies` (and the matching `wdsp` error).

## Fix

**Three small changes, all in service of "the installer makes sure the runtime is present before launching Zeus."**

### `installers/zeus-windows.iss`
- `[Files]` bundles `vc_redist.{#Arch}.exe` into the installer's `{tmp}` dir with `deleteafterinstall`.
- `[Run]` invokes it **before** the post-install Zeus launch with `/install /quiet /norestart`, `waituntilterminated` so we don't race the first Zeus startup.
- Both gated on a new `VCRedistNeeded()` check (in `[Code]`) so machines with a compatible runtime already installed skip the ~10-second silent reinstall and the UAC prompt. Detection: `HKLM\SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\{#Arch}\Installed == 1` via the 64-bit registry view. 14.0 covers the entire 2015..2022 ABI-compatible family — any 14.x install satisfies the DLLs.

### `.github/workflows/release.yml`
- New `Download Visual C++ Redistributable` step runs **before iscc** on the windows-latest runner. Pulls `https://aka.ms/vs/17/release/vc_redist.{x64|arm64}.exe` (Microsoft's stable redirect — always tracks the latest 14.x service pack) into `installers/`. The .iss `[Files]` entry then bundles whatever lands there.
- Adds about 13 MB to each Windows installer (54 MB → ~67 MB). Acceptable cost; every Windows operator gets a working DSP path on first launch.

### `installers/.gitignore` (new file)
- Ignore `vc_redist.{x64,arm64,x86}.exe` so a local iscc build that fetched the redist manually doesn't accidentally commit a 13 MB binary.
- Also ignore `installers/output/` (Inno Setup's build output dir).

## Local dev workflow

For developers running `iscc` locally (not via CI), the .iss comment block has the curl commands:

```
curl -L -o installers/vc_redist.x64.exe   https://aka.ms/vs/17/release/vc_redist.x64.exe
curl -L -o installers/vc_redist.arm64.exe https://aka.ms/vs/17/release/vc_redist.arm64.exe
```

## Test plan

- [ ] CI green on this PR (workflow-syntax check + the new download step actually runs on windows-latest as part of the build matrix)
- [ ] After merge: trigger a nightly run; download the produced `nightly` win-x64 installer; install on the (currently-broken) Windows 11 VM where `vcruntime140.dll` is absent. Confirm:
  - Installer runs the redist step silently (visible "Installing Microsoft Visual C++ Runtime..." status)
  - After install, `vcruntime140.dll` and `msvcp140.dll` are present in `C:\Windows\System32`
  - Launching Zeus produces a working panadapter, real WDSP wisdom build runs, audio comes up — i.e., the exact symptoms from #452 are gone
- [ ] Repeat on a Windows machine that ALREADY has the runtime (e.g. one with Office installed) — confirm the redist step is **skipped** (the `VCRedistNeeded()` check works) so existing operators don't see a needless UAC prompt or 10-second delay during upgrade

## Out of scope

- Statically linking `wdsp.dll` / `miniaudio.dll` against the MSVC runtime (compiler switch `/MT` instead of `/MD`). Worth considering long-term but a larger change than this hotfix.
- x86 redist (we don't ship a 32-bit Zeus installer).
- macOS and Linux — CRT shipping is not a problem there.

## Suggested release

This is the kind of fix that justifies a quick **v0.8.3 hotfix** because every operator running v0.8.0/0.8.1/0.8.2 on a fresh Windows is silently broken. Worth getting it out before the YouTube launch lands a wave of first-install Windows operators on the existing broken installer.