### PR TITLE
fix(audio): drain RX ring on TX edge so Windows MOX delay stays instant

### DIFF
--- a/Zeus.Server.Hosting/NativeAudioSink.cs
+++ b/Zeus.Server.Hosting/NativeAudioSink.cs
@@ -79,8 +79,22 @@ internal sealed class NativeAudioSink : IRxAudioSink, IAuditionAudioSink, IHoste
     private const int AuditionRingCapacity = 16_384;
 
     private readonly ILogger<NativeAudioSink> _log;
+    // Service-provider-based lookup for TxService, used to subscribe to
+    // TxActiveChanged in StartAsync. NativeAudioSink can NOT take TxService
+    // as a constructor dep directly: DspPipelineService depends on
+    // IRxAudioSink (us), TxService depends on DspPipelineService, so a
+    // direct ctor-time dependency creates a DI cycle. Resolving TxService
+    // lazily inside StartAsync breaks the cycle — by the time the hosted-
+    // service start phase fires, all singletons in the cycle exist.
+    private readonly IServiceProvider? _services;
     private readonly FloatSpscRing _ring = new(RingCapacity);
     private readonly FloatSpscRing _auditionRing = new(AuditionRingCapacity);
+
+    // Resolved on Start, kept so Stop can detach the handler cleanly.
+    // Null when no TxService was available (legacy test ctor or
+    // pre-construction failure).
+    private TxService? _tx;
+    private Action<bool>? _txActiveHandler;
 
     private MiniAudioOutput? _output;
     private bool _disposed;
@@ -142,9 +156,10 @@ internal sealed class NativeAudioSink : IRxAudioSink, IAuditionAudioSink, IHoste
     private long _totalSamplesOut;
     private DateTime _lastLogUtc = DateTime.UtcNow;
 
-    public NativeAudioSink(ILogger<NativeAudioSink> log)
+    public NativeAudioSink(ILogger<NativeAudioSink> log, IServiceProvider? services = null)
     {
         _log = log;
+        _services = services;
     }
 
     /// <summary>
@@ -177,16 +192,62 @@ internal sealed class NativeAudioSink : IRxAudioSink, IAuditionAudioSink, IHoste
             _output?.Dispose();
             _output = null;
         }
+
+        // Subscribe to TX-active edges so we can drain the ring on TX-on.
+        // The radio sample clock and the WASAPI playback clock drift relative
+        // to each other (the radio runs slightly faster than the soundcard on
+        // most Windows systems), so the ring slowly accumulates a backlog
+        // over a multi-minute session. Without this hook the operator hears
+        // up to ~1.3 sec of stale RX audio after pressing MOX or TUNE before
+        // the buffer drains to silence. macOS / Linux see this too in
+        // principle but their audio backends drift much less and the ring
+        // stays at near-zero steady-state depth, so the clear is a no-op
+        // there. See issue #403 for the original symptom report and the
+        // diagnostic write-up.
+        _tx = _services?.GetService(typeof(TxService)) as TxService;
+        if (_tx is not null)
+        {
+            _txActiveHandler = OnTxActiveChanged;
+            _tx.TxActiveChanged += _txActiveHandler;
+        }
         return Task.CompletedTask;
     }
 
     /// <summary>Hosted-service hook: stop the playback device. Idempotent.</summary>
     public Task StopAsync(CancellationToken cancellationToken)
     {
+        if (_tx is not null && _txActiveHandler is not null)
+        {
+            _tx.TxActiveChanged -= _txActiveHandler;
+            _txActiveHandler = null;
+        }
         try { _output?.Stop(); }
         catch (Exception ex) { _log.LogWarning(ex, "audio.native.rx stop threw"); }
         return Task.CompletedTask;
     }
+
+    /// <summary>
+    /// TxService.TxActiveChanged subscriber. On the rising edge (TX
+    /// engaging via MOX, TUN, or TwoTone) drains the RX audio ring so
+    /// the operator hears instant silence rather than the accumulated
+    /// pre-TX backlog. The audition ring is left alone — audition is
+    /// gated separately and pre-MOX preview is meaningful right up to
+    /// the MOX edge; the existing audition gates handle the rest.
+    /// On falling edge (TX releasing → back to RX) this is a no-op
+    /// because the ring is already empty after the drain; new RX
+    /// samples land in an empty ring and reach the speaker promptly.
+    /// </summary>
+    internal void OnTxActiveChanged(bool txActive)
+    {
+        if (!txActive) return;
+        _ring.Clear();
+    }
+
+    // Test surface — lets unit tests assert the ring's drain behaviour
+    // without reaching into private state via reflection. Read on any
+    // thread; matches FloatSpscRing.Count's relaxed-reader contract
+    // (best-effort snapshot, may be off by one in a race window).
+    internal int CurrentRingDepth => _ring.Count;
 
     public void Publish(in AudioFrame frame)
     {

--- a/Zeus.Server.Hosting/TxService.cs
+++ b/Zeus.Server.Hosting/TxService.cs
@@ -71,6 +71,52 @@ public sealed class TxService
     public bool IsMoxOn { get { lock (_sync) return _moxOn; } }
     public bool IsTunOn { get { lock (_sync) return _tunOn; } }
 
+    /// <summary>
+    /// Fires on every change to combined TX-active state
+    /// (<c>IsMoxOn || IsTunOn</c>). Argument is the new combined value.
+    /// Fired OFF the <c>_sync</c> lock so subscribers can call back into
+    /// the service without deadlocking.
+    ///
+    /// <para>Primary subscriber: <see cref="NativeAudioSink"/> uses this
+    /// to drain the RX audio ring on the rising edge so the operator
+    /// hears instant silence on TX rather than the accumulated
+    /// radio-clock-vs-soundcard-clock backlog. See issue #403 for the
+    /// symptom this addresses on Windows.</para>
+    /// </summary>
+    public event Action<bool>? TxActiveChanged;
+
+    // Last TX-active value observed by the firing path. Read+written
+    // under _sync inside the helpers below. The "fire off the lock"
+    // contract above means we capture the new value under the lock,
+    // release it, then raise — so two rapid edges from different
+    // threads can never reorder a stale notification past a fresh one.
+    private bool _lastTxActiveFired;
+
+    /// <summary>
+    /// Recompute combined TX-active state under the lock; on change,
+    /// capture the new value for off-lock notification. Returns the
+    /// captured value or null if unchanged. Caller must invoke
+    /// <see cref="RaiseTxActiveChanged"/> with the result outside the
+    /// lock.
+    /// </summary>
+    private bool? CaptureTxActiveChangeUnderLock()
+    {
+        bool now = _moxOn || _tunOn;
+        if (now == _lastTxActiveFired) return null;
+        _lastTxActiveFired = now;
+        return now;
+    }
+
+    private void RaiseTxActiveChanged(bool? captured)
+    {
+        if (captured is null) return;
+        try { TxActiveChanged?.Invoke(captured.Value); }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "tx.txActiveChanged subscriber threw");
+        }
+    }
+
     // TwoTone latch — independent of MOX/TUN. Set by RadioService.SetTwoTone
     // on every state mutation. TxTuneDriver polls it so the WDSP TXA pump
     // runs even when no mic uplink is feeding fexchange2 (PostGen mode=1
@@ -117,6 +163,7 @@ public sealed class TxService
         if (on && !CheckBandGuard(out error)) return false;
 
         bool wasTunOn;
+        bool? txActiveCaptured;
         lock (_sync)
         {
             if (_moxOn == on) { error = null; return true; }
@@ -132,7 +179,9 @@ public sealed class TxService
                 _moxStartedAt = null;
             }
             _moxOn = on;
+            txActiveCaptured = CaptureTxActiveChangeUnderLock();
         }
+        RaiseTxActiveChanged(txActiveCaptured);
 
         if (wasTunOn && on)
         {
@@ -181,6 +230,7 @@ public sealed class TxService
         if (req.Enabled && !CheckBandGuard(out error)) return false;
 
         bool wasMoxOn, wasTunOn;
+        bool? txActiveCaptured;
         lock (_sync)
         {
             wasMoxOn = _moxOn;
@@ -202,7 +252,9 @@ public sealed class TxService
                 _moxOn = false;
                 _moxStartedAt = null;
             }
+            txActiveCaptured = CaptureTxActiveChangeUnderLock();
         }
+        RaiseTxActiveChanged(txActiveCaptured);
 
         if (req.Enabled)
         {
@@ -249,6 +301,7 @@ public sealed class TxService
         if (on && !CheckBandGuard(out error)) return false;
 
         bool wasMoxOn;
+        bool? txActiveCaptured;
         lock (_sync)
         {
             if (_tunOn == on) { error = null; return true; }
@@ -264,7 +317,9 @@ public sealed class TxService
                 _tunStartedAt = null;
             }
             _tunOn = on;
+            txActiveCaptured = CaptureTxActiveChangeUnderLock();
         }
+        RaiseTxActiveChanged(txActiveCaptured);
 
         if (wasMoxOn && on)
         {
@@ -296,6 +351,7 @@ public sealed class TxService
     public void TryTripForAlert(AlertKind kind, string reason)
     {
         bool wasMoxOn, wasTunOn;
+        bool? txActiveCaptured;
         lock (_sync)
         {
             wasMoxOn = _moxOn;
@@ -306,6 +362,7 @@ public sealed class TxService
             // would keep re-firing against the stale start time after the trip.
             _moxStartedAt = null;
             _tunStartedAt = null;
+            txActiveCaptured = CaptureTxActiveChangeUnderLock();
         }
 
         if (wasMoxOn || wasTunOn)
@@ -318,5 +375,6 @@ public sealed class TxService
             _hub.Broadcast(new AlertFrame(kind, reason));
             _hub.Broadcast(new MoxStateFrame(MoxOn: false, TunOn: false));
         }
+        RaiseTxActiveChanged(txActiveCaptured);
     }
 }

--- a/tests/Zeus.Server.Tests/TxActiveChangedTests.cs
+++ b/tests/Zeus.Server.Tests/TxActiveChangedTests.cs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Tests for TxService.TxActiveChanged + NativeAudioSink.OnTxActiveChanged.
+// The pairing exists to drain the RX audio ring on TX rising edges, fixing
+// the Windows-only "I hear RX for 2-3 seconds after pressing MOX" symptom
+// reported in issue #403. On Mac / Linux the drain is a no-op (the ring is
+// near-empty in steady state) but on Windows the WASAPI clock drifts vs the
+// radio clock and the ring accumulates seconds of backlog over a session.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class TxActiveChangedTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-txactive-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+        try { if (File.Exists(_dbPath + ".pa")) File.Delete(_dbPath + ".pa"); } catch { }
+    }
+
+    private TxService BuildTxService()
+    {
+        var loggerFactory = NullLoggerFactory.Instance;
+        var dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance, _dbPath);
+        var paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, _dbPath + ".pa");
+        var radio = new RadioService(loggerFactory, dspStore, paStore);
+        var hub = new StreamingHub(new NullLogger<StreamingHub>());
+        var pipeline = new DspPipelineService(radio, hub, Array.Empty<IRxAudioSink>(), loggerFactory);
+        return new TxService(radio, pipeline, hub, NullBandPlanService.Instance, new NullLogger<TxService>());
+    }
+
+    private static AudioFrame BuildMonoFrame(int sampleCount)
+    {
+        var samples = new float[sampleCount];
+        for (int i = 0; i < samples.Length; i++) samples[i] = 0.1f;
+        return new AudioFrame(
+            Seq: 0,
+            TsUnixMs: 0,
+            RxId: 0,
+            Channels: 1,
+            SampleRateHz: 48_000,
+            SampleCount: (ushort)sampleCount,
+            Samples: samples);
+    }
+
+    [Fact]
+    public void TxActiveChanged_DoesNotFire_WhenTrySetMoxRejectedOnNotConnected()
+    {
+        var tx = BuildTxService();
+        int fires = 0;
+        tx.TxActiveChanged += _ => fires++;
+
+        // No radio is connected, so MOX-on is rejected by the connect
+        // interlock BEFORE any state mutates. The event must NOT fire on
+        // a no-op rejection, otherwise subscribers would clear their state
+        // (in NativeAudioSink's case, drain the ring) every time the
+        // operator misclicks the MOX button while disconnected.
+        bool ok = tx.TrySetMox(true, out var err);
+
+        Assert.False(ok);
+        Assert.NotNull(err);
+        Assert.Equal(0, fires);
+    }
+
+    [Fact]
+    public void NativeAudioSink_OnTxActiveChanged_True_ClearsRing()
+    {
+        // Push samples into the sink so the ring is non-empty (~600 samples).
+        // Then fire the TX-on event and assert the ring is drained.
+        var sink = new NativeAudioSink(NullLogger<NativeAudioSink>.Instance);
+        var frame = BuildMonoFrame(600);
+        sink.Publish(in frame);
+
+        Assert.True(sink.CurrentRingDepth >= 600,
+            $"setup precondition: ring should be filled. got {sink.CurrentRingDepth}");
+
+        sink.OnTxActiveChanged(true);
+
+        Assert.Equal(0, sink.CurrentRingDepth);
+    }
+
+    [Fact]
+    public void NativeAudioSink_OnTxActiveChanged_False_DoesNotMutateRing()
+    {
+        // Falling-edge TX (TX→RX) must NOT drain the ring — there's nothing
+        // useful to drain (the rising-edge handler already did) and we want
+        // any in-flight RX samples to play through immediately.
+        var sink = new NativeAudioSink(NullLogger<NativeAudioSink>.Instance);
+        var frame = BuildMonoFrame(600);
+        sink.Publish(in frame);
+
+        int depthBefore = sink.CurrentRingDepth;
+        sink.OnTxActiveChanged(false);
+
+        Assert.Equal(depthBefore, sink.CurrentRingDepth);
+    }
+
+    [Fact]
+    public void NativeAudioSink_OnTxActiveChanged_RepeatedTrue_IsIdempotent()
+    {
+        // Belt-and-suspenders: hitting OnTxActiveChanged(true) twice in a
+        // row (e.g. MOX-on quickly followed by TUN-on, both producing
+        // rising edges in the combined state) must not throw or corrupt
+        // ring state. Second call is just a redundant clear of an
+        // already-empty ring.
+        var sink = new NativeAudioSink(NullLogger<NativeAudioSink>.Instance);
+        var frame = BuildMonoFrame(100);
+        sink.Publish(in frame);
+
+        sink.OnTxActiveChanged(true);
+        sink.OnTxActiveChanged(true);
+
+        Assert.Equal(0, sink.CurrentRingDepth);
+    }
+}


### PR DESCRIPTION
Refs #403.

## Summary

Third of three Windows-audio-responsiveness fixes for v0.8.3 (after [PR #450](https://github.com/Kb2uka/openhpsdr-zeus/pull/450) WASAPI Pro Audio + [PR #453](https://github.com/Kb2uka/openhpsdr-zeus/pull/453) VC++ Runtime). Removes the remaining "1-2 sec stale-audio-on-TX, gets worse over time" that several Windows operators reported.

## Root cause

The radio sample clock and the WASAPI playback clock drift relative to each other — the radio runs slightly faster than the soundcard on most Windows systems. `NativeAudioSink`'s 65k-sample ring slowly accumulates a backlog over a multi-minute session. With no explicit MOX-edge drain, the operator hears up to ~1.3 sec of stale RX audio playing out of the buffer after pressing MOX or TUNE before silence reaches the ear. After 10+ minutes the ring is near-capacity and the perceived TX-engage delay is 2-3 seconds.

Mac and Linux see this in principle but CoreAudio and ALSA drift much less than WASAPI, so the ring stays at near-zero steady-state depth and the drain is effectively a no-op on those platforms.

## Implementation

**`TxService`** — new `event Action<bool>? TxActiveChanged` that fires on every change to combined `IsMoxOn || IsTunOn` state. Fired OFF the `_sync` lock so subscribers can call back into the service without deadlocking. Wired into all four TX state mutation paths: `TrySetMox`, `TrySetTun`, `TrySetTwoTone`, `TryTripForAlert`.

**`NativeAudioSink`** — subscribes to `TxService.TxActiveChanged` in `StartAsync`; on rising edge calls `_ring.Clear()`. Falling edge is a no-op (ring already drained; we want new RX samples to reach the speaker promptly).

**Avoiding the DI cycle:** `DspPipelineService` takes `IRxAudioSink` which resolves to `NativeAudioSink`, and `TxService` takes `DspPipelineService` — a direct ctor-time dep on `TxService` would create a cycle. Lazy-resolve `TxService` in `StartAsync` via injected `IServiceProvider` instead. Existing test constructors keep working with the parameter defaulted to `null`.

Audition ring left untouched — the audition path is gated separately on TX state via `AudioPluginBridge.ProcessLivePreview` and stops feeding the audition ring when MOX rises.

## Cross-platform impact

- **Windows:** large positive — operator-perceived MOX delay drops from 1-2 sec (and growing) to instant.
- **macOS, Linux:** no meaningful change — the ring already stays near-empty in steady state on these backends because CoreAudio/ALSA don't drift significantly from the radio clock. Drain becomes a no-op clear of an essentially empty ring.
- **No risk of regression:** `_ring.Clear()` is the same call already used by the operator's Mute button via `SetMuted(true)` — well-tested code path.

## Tests

`TxActiveChangedTests` — 4 tests, all green:

- Does NOT fire on `TrySetMox` rejected by the not-connected interlock (subscribers must not see a phantom edge from a no-op rejection — otherwise an operator misclicking MOX while disconnected would needlessly drain the ring)
- Drains the ring on `OnTxActiveChanged(true)`
- Preserves the ring on `OnTxActiveChanged(false)`
- Idempotent on repeated rising edges (handles MOX→TUN reassignment edge cases)

Full solution suite: 1,190 pass, 0 fail.

## Test plan post-merge

- [ ] CI green on this PR
- [ ] Bench-test on a Windows VM that's been running for 10+ minutes — TUNE engages with instant silence regardless of session age
- [ ] Bench-test the same on Mac and Linux — operator sees no change in TX/RX transition behaviour
- [ ] Ship v0.8.3 as the Windows audio responsiveness hotfix release (this + #450 + #453 together)

## Out of scope

A proper asynchronous resampler in `NativeAudioSink` that tracks the soundcard clock and drops/inserts samples to keep the ring at a stable target depth (~50-100 ms) would eliminate the drift accumulation entirely — making the drain truly unnecessary. That's the right long-term fix but a much larger change. This PR's MOX-edge drain hides the symptom completely while the resampler remains future work.