### PR TITLE
feat(installer): sign + notarize macOS DMGs in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -596,12 +596,218 @@ jobs:
           path: installers/output/OpenhpsdrZeus*-${{ steps.version.outputs.version }}-linux-x86_64.AppImage
           if-no-files-found: error
 
+      # ---------- macOS code-signing + notarization ------------------------
+      #
+      # Five steps gated on (is-release || is-nightly): import the Developer
+      # ID cert into an ephemeral keychain, run the existing builder with
+      # CODESIGN_IDENTITY exported (the script signs apps + DMG inside-out
+      # hardened-runtime, see installers/create-macos-app.sh), submit to
+      # Apple notary, staple the ticket into the DMG, and verify Gatekeeper
+      # acceptance. The dry-run path falls through to the original
+      # unsigned-build step further down.
+      #
+      # Why gated:
+      #   - Notarization burns 2-15 min of macos-latest runner time (10x
+      #     Linux cost) and counts against Apple's API submission quota.
+      #     dry-run builds don't need either.
+      #   - Apple's API key (.p8) only exists as a secret in the repo; PRs
+      #     from forks running release.yml as a dry-run would otherwise hit
+      #     a "secret missing" error mid-job.
+      #
+      # The ephemeral keychain name embeds run_id + run_attempt so two
+      # concurrent dispatches (e.g. nightly cron racing with a maintainer's
+      # manual run) never collide on /Users/runner/Library/Keychains.
+      - name: macOS — dry-run notice (signing/notarization skipped)
+        if: ${{ startsWith(matrix.config.os, 'macos') && needs.determine-version.outputs.is-release != 'true' && needs.determine-version.outputs.is-nightly != 'true' }}
+        run: |
+          echo "::notice::macOS DMG will NOT be signed or notarized in dry-run mode. The artifact will require xattr -cr on first launch."
+
+      - name: macOS — import Developer ID certificate
+        if: ${{ startsWith(matrix.config.os, 'macos') && (needs.determine-version.outputs.is-release == 'true' || needs.determine-version.outputs.is-nightly == 'true') }}
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN_PATH="$RUNNER_TEMP/build-${{ github.run_id }}-${{ github.run_attempt }}.keychain-db"
+          CERT_PATH="$RUNNER_TEMP/macos-cert.p12"
+          INTERMEDIATE_PATH="$RUNNER_TEMP/DeveloperIDG2CA.cer"
+
+          # Decode the base64-encoded .p12 to a temp file. `security import`
+          # cannot read from stdin so we have to materialize it; we shred it
+          # below once it's in the keychain.
+          echo "$MACOS_CERTIFICATE" | base64 --decode > "$CERT_PATH"
+
+          # Download Apple's Developer ID Certification Authority (G2)
+          # intermediate cert. A .p12 exported from Keychain Access ships
+          # only the leaf + private key, NOT the intermediate. On a dev
+          # Mac the intermediate is already in login.keychain from prior
+          # Xcode use, so the chain validates fine — but a fresh GitHub
+          # Actions runner only has Apple Root CA in its trust store, so
+          # codesign warns "unable to build chain to self-signed root"
+          # and notarytool rejects the resulting bundle. URL is Apple's
+          # stable publication endpoint; cert is valid through 2031.
+          curl -fsSL --retry 3 \
+              https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer \
+              -o "$INTERMEDIATE_PATH"
+
+          # Per-run ephemeral keychain so concurrent dispatches don't trample
+          # each other and so cleanup is just `security delete-keychain`.
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          # 6h timeout — comfortably longer than any release build wall clock.
+          # Default is 5 minutes auto-lock which would break a slow notarization.
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Import the intermediate FIRST so chain validation works the
+          # moment the leaf .p12 lands in the keychain.
+          security import "$INTERMEDIATE_PATH" \
+              -k "$KEYCHAIN_PATH" \
+              -T /usr/bin/codesign
+
+          # -A allows all apps to use the key without prompting (no GUI on CI).
+          # -T whitelists specific tools so set-key-partition-list below can
+          # set a durable ACL — without it codesign would still prompt for
+          # the keychain password on first private-key access.
+          security import "$CERT_PATH" \
+              -P "$MACOS_CERTIFICATE_PWD" \
+              -A -t cert -f pkcs12 \
+              -k "$KEYCHAIN_PATH" \
+              -T /usr/bin/codesign \
+              -T /usr/bin/security
+
+          # Make the codesign ACL durable. Without this codesign hangs on
+          # CI waiting for a human to acknowledge the keychain prompt.
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+              -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" >/dev/null
+
+          # Prepend the temp keychain to the user search list. codesign
+          # defaults to login.keychain otherwise and never finds our cert.
+          # Capture the existing list into a bash array — string-mangling
+          # via tr corrupts paths in edge cases (we saw a local-test run
+          # end up with the search list set to a single mangled entry
+          # containing literal "-d -db" fragments).
+          ORIGINAL_KEYCHAINS=()
+          while IFS= read -r line; do
+              clean=$(echo "$line" | sed -E 's/^[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/')
+              [ -n "$clean" ] && ORIGINAL_KEYCHAINS+=("$clean")
+          done < <(security list-keychains -d user)
+          security list-keychains -d user -s "$KEYCHAIN_PATH" "${ORIGINAL_KEYCHAINS[@]}"
+
+          # Shred the on-disk cert files — both are safely in the keychain
+          # now. macOS `rm -P` overwrites with 0xff/0x00/0xff before unlink.
+          # The intermediate is public so shredding it is paranoia, but
+          # cheap and keeps the cleanup symmetric.
+          rm -P "$CERT_PATH" 2>/dev/null || rm -f "$CERT_PATH"
+          rm -P "$INTERMEDIATE_PATH" 2>/dev/null || rm -f "$INTERMEDIATE_PATH"
+
+          # Propagate KEYCHAIN_PATH to subsequent steps. create-macos-app.sh
+          # picks this up as the --keychain arg for every codesign call.
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+
+          # Sanity check: the identity must be findable, otherwise the build
+          # step will fail mid-way through codesign with a less helpful error.
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
       - name: Build macOS Package
         if: startsWith(matrix.config.os, 'macos')
+        env:
+          # Ternary: signed only when is-release || is-nightly. In dry-run
+          # the value is the empty string regardless of whether
+          # MACOS_SIGNING_IDENTITY is configured — keeps an accidentally-set
+          # secret from sneaking signing into a dry-run build.
+          CODESIGN_IDENTITY: ${{ (needs.determine-version.outputs.is-release == 'true' || needs.determine-version.outputs.is-nightly == 'true') && secrets.MACOS_SIGNING_IDENTITY || '' }}
+          ENTITLEMENTS_PATH: ${{ github.workspace }}/installers/zeus-macos.entitlements
+          # KEYCHAIN_PATH flows in via $GITHUB_ENV from the import step above.
         run: |
+          set -e
           chmod +x installers/create-macos-app.sh
           ARCH="${{ matrix.config.rid == 'osx-arm64' && 'arm64' || 'x64' }}"
           installers/create-macos-app.sh ${{ steps.version.outputs.version }} $ARCH
+
+      - name: macOS — notarize DMG
+        if: ${{ startsWith(matrix.config.os, 'macos') && (needs.determine-version.outputs.is-release == 'true' || needs.determine-version.outputs.is-nightly == 'true') }}
+        env:
+          APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
+          APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+          APPSTORE_API_KEY_P8: ${{ secrets.APPSTORE_API_KEY_P8 }}
+        run: |
+          set -euo pipefail
+          ARCH="${{ matrix.config.rid == 'osx-arm64' && 'arm64' || 'x64' }}"
+          DMG_PATH="installers/output/OpenhpsdrZeus-${{ steps.version.outputs.version }}-macos-${ARCH}.dmg"
+          KEY_PATH="$RUNNER_TEMP/AuthKey.p8"
+
+          # The .p8 secret is stored base64-encoded to avoid newline mangling
+          # in GitHub's secret editor. If you ever rotate the key, paste the
+          # `base64 < AuthKey_XXXXXX.p8` output as the secret value.
+          echo "$APPSTORE_API_KEY_P8" | base64 --decode > "$KEY_PATH"
+
+          # notarytool submit blocks until accepted/invalid (~2-15 min). We
+          # capture stdout to parse the submission ID, then drive the
+          # accept/reject branch from --output-format json status field.
+          # Don't use `set -e` around the submit itself — we want to fetch
+          # the log on rejection before exiting.
+          set +e
+          SUBMIT_OUT=$(xcrun notarytool submit "$DMG_PATH" \
+              --key "$KEY_PATH" \
+              --key-id "$APPSTORE_KEY_ID" \
+              --issuer "$APPSTORE_ISSUER_ID" \
+              --wait \
+              --output-format json)
+          SUBMIT_RC=$?
+          set -e
+          echo "$SUBMIT_OUT"
+
+          # Parse with python3 (preinstalled on macos-latest) rather than jq
+          # to avoid an extra brew install.
+          SUBMISSION_ID=$(echo "$SUBMIT_OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('id',''))" 2>/dev/null || true)
+          STATUS=$(echo "$SUBMIT_OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('status',''))" 2>/dev/null || true)
+
+          if [ "$STATUS" != "Accepted" ] || [ "$SUBMIT_RC" -ne 0 ]; then
+              echo "::error::Notarization failed (status=$STATUS, rc=$SUBMIT_RC, id=$SUBMISSION_ID)"
+              if [ -n "$SUBMISSION_ID" ]; then
+                  echo "::group::notarytool log $SUBMISSION_ID"
+                  xcrun notarytool log "$SUBMISSION_ID" \
+                      --key "$KEY_PATH" \
+                      --key-id "$APPSTORE_KEY_ID" \
+                      --issuer "$APPSTORE_ISSUER_ID" || true
+                  echo "::endgroup::"
+              else
+                  echo "::error::No submission ID returned — submit failed before Apple accepted it. Check network / quota / cert validity."
+              fi
+              rm -P "$KEY_PATH" 2>/dev/null || rm -f "$KEY_PATH"
+              exit 1
+          fi
+
+          rm -P "$KEY_PATH" 2>/dev/null || rm -f "$KEY_PATH"
+          echo "Notarization accepted (id=$SUBMISSION_ID)"
+
+      - name: macOS — staple notarization ticket
+        if: ${{ startsWith(matrix.config.os, 'macos') && (needs.determine-version.outputs.is-release == 'true' || needs.determine-version.outputs.is-nightly == 'true') }}
+        run: |
+          set -euo pipefail
+          ARCH="${{ matrix.config.rid == 'osx-arm64' && 'arm64' || 'x64' }}"
+          DMG_PATH="installers/output/OpenhpsdrZeus-${{ steps.version.outputs.version }}-macos-${ARCH}.dmg"
+          # Stapling embeds the ticket into the DMG so first launch works
+          # offline. Without staple, Gatekeeper has to call out to Apple to
+          # verify notarization on every first launch — which fails for
+          # users behind firewalls / on planes.
+          xcrun stapler staple "$DMG_PATH"
+          xcrun stapler validate "$DMG_PATH"
+
+      - name: macOS — Gatekeeper assess
+        if: ${{ startsWith(matrix.config.os, 'macos') && (needs.determine-version.outputs.is-release == 'true' || needs.determine-version.outputs.is-nightly == 'true') }}
+        run: |
+          set -euo pipefail
+          ARCH="${{ matrix.config.rid == 'osx-arm64' && 'arm64' || 'x64' }}"
+          DMG_PATH="installers/output/OpenhpsdrZeus-${{ steps.version.outputs.version }}-macos-${ARCH}.dmg"
+          # `--type open` is the context Gatekeeper uses when the user
+          # double-clicks the DMG to mount it. Primary-signature context
+          # forces it to read the DMG's own signature, not anything cached.
+          # Any rejection here (e.g. stale notarization, wrong identity)
+          # would fail before users see a broken download.
+          spctl --assess --type open --context context:primary-signature --verbose=2 "$DMG_PATH"
 
       - name: Upload macOS Package
         if: startsWith(matrix.config.os, 'macos')
@@ -610,6 +816,24 @@ jobs:
           name: ${{ matrix.config.artifact }}
           path: installers/output/OpenhpsdrZeus-${{ steps.version.outputs.version }}-macos-*.dmg
           if-no-files-found: error
+
+      # Defensive cleanup — the macos-latest runner is ephemeral and gets
+      # torn down after the job, but explicit removal of the temp keychain
+      # + any leftover .p8/.p12 means a `if: always()` run on a future
+      # runner image that caches $RUNNER_TEMP between jobs won't leak.
+      - name: macOS — clean up signing material
+        if: ${{ always() && startsWith(matrix.config.os, 'macos') && (needs.determine-version.outputs.is-release == 'true' || needs.determine-version.outputs.is-nightly == 'true') }}
+        run: |
+          set +e
+          if [ -n "${KEYCHAIN_PATH:-}" ] && [ -f "$KEYCHAIN_PATH" ]; then
+              security delete-keychain "$KEYCHAIN_PATH"
+          fi
+          rm -P "$RUNNER_TEMP/macos-cert.p12"        2>/dev/null || rm -f "$RUNNER_TEMP/macos-cert.p12"
+          rm -P "$RUNNER_TEMP/AuthKey.p8"            2>/dev/null || rm -f "$RUNNER_TEMP/AuthKey.p8"
+          rm -P "$RUNNER_TEMP/DeveloperIDG2CA.cer"   2>/dev/null || rm -f "$RUNNER_TEMP/DeveloperIDG2CA.cer"
+          # Restore the default user keychain search list to login only.
+          security list-keychains -d user -s login.keychain-db || true
+          true
 
   create-release:
     name: Create GitHub Release
@@ -693,16 +917,9 @@ jobs:
           on GitHub-hosted Actions is too slow to be practical. Build from source
           if you need one.
 
-          **IMPORTANT for macOS users**: After installation, clear the quarantine
-          attribute so Gatekeeper lets Zeus launch:
-
-          ```bash
-          xattr -cr "/Applications/OpenHPSDR Zeus.app"
-          xattr -cr "/Applications/OpenHPSDR Zeus Server.app"
-          ```
-
-          This is required because Zeus is not signed by a registered Apple
-          Developer.
+          The DMG and both `.app` bundles are signed with a Developer ID
+          Application certificate and notarized by Apple, so Gatekeeper
+          accepts them directly — no `xattr -cr` workaround needed.
 
           ### Linux (x64)
           - **openhpsdr-zeus-${{ steps.version.outputs.version }}-linux-x64.tar.gz**
@@ -826,9 +1043,9 @@ jobs:
           - **OpenhpsdrZeus-Server-${{ steps.version.outputs.version }}-linux-x86_64.AppImage** — Linux server AppImage
           - **OpenhpsdrZeus-${{ steps.version.outputs.version }}-macos-arm64.dmg** — macOS Apple Silicon DMG
 
-          macOS users still need to clear the quarantine attribute after
-          install — see the latest tagged release notes for the \`xattr -cr\`
-          command and Linux AppImage dependencies.
+          The macOS DMG is signed and notarized — no \`xattr -cr\` workaround
+          needed even on nightlies. Linux AppImage dependencies are listed
+          in the latest tagged release notes.
 
           ## Changes since ${{ steps.commits.outputs.last-tag }}
           EOF

--- a/installers/create-macos-app.sh
+++ b/installers/create-macos-app.sh
@@ -300,31 +300,92 @@ chmod +x "${SERVER_APP_BUNDLE}/Contents/MacOS/launch.sh"
 
 echo "Server wrapper bundle created at ${SERVER_APP_BUNDLE}"
 
-# --- Codesigning hook (opt-in) ------------------------------------------
+# --- Codesigning (opt-in via env) ---------------------------------------
 #
-# Ad-hoc signing or Developer ID signing happens here. Default behaviour
-# is to do nothing — the bundle ships unsigned and the user clears the
-# quarantine xattr on first launch (see DMG README).
+# Hardened-runtime, Developer-ID signing for notarization. Triggered when
+# CODESIGN_IDENTITY is set in the environment. CI populates it from the
+# MACOS_SIGNING_IDENTITY secret; a developer can export it locally for
+# off-the-cuff signed builds.
 #
-# To produce a Developer ID Application signed bundle:
-#   export APPLE_DEVELOPER_ID="Developer ID Application: Brian Keating (TEAMID)"
-#   ./create-macos-app.sh 0.4.1 arm64
-# Notarisation is a separate step (notarytool submit ... --wait) once the
-# Apple ID + app-specific password is configured locally — keep that out
-# of the script for now so the unsigned path stays the default and CI
-# doesn't trip over missing secrets.
-if [ -n "${APPLE_DEVELOPER_ID:-}" ]; then
-    echo "Codesigning with: ${APPLE_DEVELOPER_ID}"
-    codesign --force --deep --options runtime --timestamp \
-        --sign "${APPLE_DEVELOPER_ID}" "${APP_BUNDLE}"
-    codesign --verify --verbose=2 "${APP_BUNDLE}"
-    # Sign Zeus Server.app too — Gatekeeper otherwise pops a separate
-    # "unidentified developer" prompt for the wrapper.
-    codesign --force --deep --options runtime --timestamp \
-        --sign "${APPLE_DEVELOPER_ID}" "${SERVER_APP_BUNDLE}"
-    codesign --verify --verbose=2 "${SERVER_APP_BUNDLE}"
+#   CODESIGN_IDENTITY   "Developer ID Application: Name (TEAMID)"
+#                       (empty/unset → unsigned ad-hoc build, original
+#                       behaviour, user clears xattr on first launch.)
+#   KEYCHAIN_PATH       Optional path to a temp keychain (CI uses a
+#                       per-run keychain). Empty → codesign uses the
+#                       default keychain search list (dev-local).
+#   ENTITLEMENTS_PATH   Path to the hardened-runtime entitlements plist.
+#                       Defaults to installers/zeus-macos.entitlements.
+#
+# Why --deep (Apple-deprecated but unavoidable here):
+#
+# Apple's bundle convention says Contents/MacOS/ holds only code (Mach-O)
+# and Contents/Resources/ holds everything else. A .NET self-contained
+# publish dumps the entire payload alongside the main binary in
+# Contents/MacOS/: ~300 managed .dlls, runtime configs, web assets
+# (wwwroot/), BandPlans/*.json, etc. Without --deep, codesign refuses to
+# sign the outer bundle with "code object is not signed at all / In
+# subcomponent: <first-non-MachO-it-finds>" — it treats every file under
+# MacOS/ as a sub-bundle that must be pre-signed.
+#
+# --deep walks the bundle once and signs every nested Mach-O with the
+# outer flags (--options runtime + --entitlements + --timestamp). The
+# result is bit-equivalent to a per-item signing pass:
+#   - every dylib (libwdsp, libminiaudio, Photino.Native, .NET runtime)
+#     gets hardened runtime + timestamp + Team ID signature
+#   - the main exec (OpenhpsdrZeus) gets the same plus entitlements
+#   - non-MachO files (JSON, dll, png) are hashed into CodeResources
+#     as data and stop tripping the "subcomponent unsigned" check
+# Notarization accepts --deep-signed .NET bundles (every Mach-O has the
+# right flags; the deprecation warning is about ergonomics, not validity).
+#
+# --options runtime  enables hardened runtime (required for notarization).
+# --timestamp        embeds a trusted Apple timestamp so the signature
+#                    stays valid after the cert expires AND because
+#                    notarization rejects untimestamped signatures.
+if [ -n "${CODESIGN_IDENTITY:-}" ]; then
+    set -e
+    if [ -z "${ENTITLEMENTS_PATH:-}" ]; then
+        ENTITLEMENTS_PATH="${SCRIPT_DIR}/zeus-macos.entitlements"
+    fi
+    if [ ! -f "${ENTITLEMENTS_PATH}" ]; then
+        echo "ERROR: ENTITLEMENTS_PATH '${ENTITLEMENTS_PATH}' not found" >&2
+        exit 1
+    fi
+    echo "Codesigning with: ${CODESIGN_IDENTITY}"
+    echo "Entitlements:     ${ENTITLEMENTS_PATH}"
+    if [ -n "${KEYCHAIN_PATH:-}" ]; then
+        echo "Keychain:         ${KEYCHAIN_PATH}"
+    fi
+
+    # Pass --keychain only when KEYCHAIN_PATH is set; codesign default
+    # search list otherwise. Done via an array so we can splat or skip.
+    KEYCHAIN_FLAG=()
+    if [ -n "${KEYCHAIN_PATH:-}" ]; then
+        KEYCHAIN_FLAG=(--keychain "${KEYCHAIN_PATH}")
+    fi
+
+    sign_bundle() {
+        local bundle="$1"
+        echo "  → ${bundle}"
+
+        codesign --force --deep --options runtime --timestamp \
+            "${KEYCHAIN_FLAG[@]}" \
+            --entitlements "${ENTITLEMENTS_PATH}" \
+            --sign "${CODESIGN_IDENTITY}" \
+            "${bundle}"
+
+        # Verify the bundle and every nested Mach-O. --strict catches
+        # bad signature flags / missing hardened runtime / unsigned
+        # subcomponents that codesign --sign wouldn't have noticed.
+        codesign --verify --deep --strict "${bundle}"
+    }
+
+    sign_bundle "${APP_BUNDLE}"
+    sign_bundle "${SERVER_APP_BUNDLE}"
+    WILL_SIGN=1
 else
-    echo "(unsigned — set APPLE_DEVELOPER_ID to enable codesigning)"
+    echo "(unsigned — set CODESIGN_IDENTITY to enable codesigning)"
+    WILL_SIGN=0
 fi
 
 # --- DMG ----------------------------------------------------------------
@@ -347,7 +408,15 @@ cp -R "${APP_BUNDLE}" "${DMG_TEMP}/"
 cp -R "${SERVER_APP_BUNDLE}" "${DMG_TEMP}/"
 ln -s /Applications "${DMG_TEMP}/Applications"
 
-cat > "${DMG_TEMP}/README.txt" << 'EOF'
+# README inside the DMG. Two flavours, picked from WILL_SIGN above:
+#   - signed/notarized   → drag-to-Applications + first-run notes only.
+#                          No xattr; Gatekeeper accepts the .app directly.
+#   - unsigned (dryrun)  → original README with the xattr -cr workaround,
+#                          which is the only way to launch an unsigned
+#                          .app on modern macOS without right-click +
+#                          Open Anyway acrobatics.
+if [ "${WILL_SIGN}" -eq 1 ]; then
+    cat > "${DMG_TEMP}/README.txt" << 'EOF'
 OpenHPSDR Zeus for macOS
 ========================
 
@@ -360,19 +429,8 @@ INSTALL
   If you only want the desktop app, dragging "OpenHPSDR Zeus.app" alone
   is fine.
 
-FIRST LAUNCH (important — Zeus is not signed)
-  Zeus is distributed without an Apple Developer ID, so macOS Gatekeeper
-  will block it on first launch. To clear the quarantine flag, open
-  Terminal and run:
-
-      xattr -cr "/Applications/OpenHPSDR Zeus.app"
-      xattr -cr "/Applications/OpenHPSDR Zeus Server.app"
-
-  Then launch from Applications.
-
-  If you still see a security warning, go to:
-      System Settings -> Privacy & Security
-  and click "Open Anyway".
+  Then launch from Applications normally — Zeus is signed and notarized,
+  so Gatekeeper lets it open without any xattr workaround.
 
 THE TWO ICONS
 
@@ -391,7 +449,7 @@ THE TWO ICONS
                          warning on first connect.
 
 HEADLESS / CLI USE
-  If you're running Zeus on a headless Mac (no display, e.g. an mac mini
+  If you're running Zeus on a headless Mac (no display, e.g. a mac mini
   in a closet), use Terminal:
 
       "/Applications/OpenHPSDR Zeus.app/Contents/MacOS/OpenhpsdrZeus"
@@ -407,6 +465,71 @@ FIRST RUN — WDSP WISDOM
 
 More info: https://github.com/Kb2uka/openhpsdr-zeus
 EOF
+else
+    cat > "${DMG_TEMP}/README.txt" << 'EOF'
+OpenHPSDR Zeus for macOS  (UNSIGNED DEV BUILD)
+==============================================
+
+INSTALL
+  Drag BOTH "OpenHPSDR Zeus.app" and "OpenHPSDR Zeus Server.app" onto
+  the Applications shortcut in this window. "OpenHPSDR Zeus Server.app"
+  is a small wrapper around "OpenHPSDR Zeus.app" and won't work without
+  "OpenHPSDR Zeus.app" installed.
+
+  If you only want the desktop app, dragging "OpenHPSDR Zeus.app" alone
+  is fine.
+
+FIRST LAUNCH (important — this is an unsigned dev build)
+  This DMG is a dry-run / preview build and is NOT signed by an Apple
+  Developer ID. macOS Gatekeeper will block it on first launch. To clear
+  the quarantine flag, open Terminal and run:
+
+      xattr -cr "/Applications/OpenHPSDR Zeus.app"
+      xattr -cr "/Applications/OpenHPSDR Zeus Server.app"
+
+  Then launch from Applications.
+
+  If you still see a security warning, go to:
+      System Settings -> Privacy & Security
+  and click "Open Anyway".
+
+  Tagged release and nightly builds are signed + notarized and do NOT
+  need this step.
+
+THE TWO ICONS
+
+  OpenHPSDR Zeus         Full native window. The radio backend runs
+                         in-process inside the same window. Closing the
+                         window stops Zeus completely. This is the right
+                         choice for most operators.
+
+  OpenHPSDR Zeus Server  Backend-only mode for LAN / remote / phone
+                         access. Opens a small status window showing
+                         the URLs to connect to from a browser, with a
+                         Stop Zeus button. Connect from this Mac at
+                         http://localhost:6060 or from another device
+                         at http://<your-mac>:6060. HTTPS uses a
+                         self-signed certificate — accept the browser
+                         warning on first connect.
+
+HEADLESS / CLI USE
+  If you're running Zeus on a headless Mac (no display, e.g. a mac mini
+  in a closet), use Terminal:
+
+      "/Applications/OpenHPSDR Zeus.app/Contents/MacOS/OpenhpsdrZeus"
+
+  This is the no-window service mode. Identical to OpenHPSDR Zeus
+  Server's backend but without the status window. Closing the Terminal
+  (or Ctrl-C) stops the server.
+
+FIRST RUN — WDSP WISDOM
+  The first launch builds an FFTW "wisdom" cache and can take 1-3
+  minutes. The window will load, but do NOT click Discover/Connect
+  until the wisdom build settles. Subsequent launches are instant.
+
+More info: https://github.com/Kb2uka/openhpsdr-zeus
+EOF
+fi
 
 hdiutil create -volname "Openhpsdr Zeus v${VERSION}" \
     -srcfolder "${DMG_TEMP}" \
@@ -415,8 +538,31 @@ hdiutil create -volname "Openhpsdr Zeus v${VERSION}" \
 
 rm -rf "${DMG_TEMP}"
 
+# Sign the DMG itself when WILL_SIGN=1. The DMG is a separate signed
+# container from the .app bundles inside it — Gatekeeper's "open" assess
+# context (mounting a DMG) reads the DMG signature, not the nested app
+# signatures. notarize+staple in the CI workflow operate on this signed
+# DMG. DMGs don't take entitlements or --options runtime (those are
+# Mach-O concepts), just --sign + --timestamp.
+if [ "${WILL_SIGN}" -eq 1 ]; then
+    KEYCHAIN_FLAG=()
+    if [ -n "${KEYCHAIN_PATH:-}" ]; then
+        KEYCHAIN_FLAG=(--keychain "${KEYCHAIN_PATH}")
+    fi
+    echo "Signing DMG..."
+    codesign --force --timestamp \
+        "${KEYCHAIN_FLAG[@]}" \
+        --sign "${CODESIGN_IDENTITY}" \
+        "${DMG_PATH}"
+    codesign --verify --verbose=2 "${DMG_PATH}"
+fi
+
 echo "DMG created at ${DMG_PATH}"
-echo
-echo "NOTE: users must clear the quarantine flag on first launch:"
-echo "  xattr -cr \"/Applications/OpenHPSDR Zeus.app\""
-echo "  xattr -cr \"/Applications/OpenHPSDR Zeus Server.app\""
+if [ "${WILL_SIGN}" -eq 1 ]; then
+    echo "DMG is signed; CI will run notarytool submit + stapler staple as follow-up steps."
+else
+    echo
+    echo "NOTE: this is an unsigned dev build — users must clear the quarantine flag on first launch:"
+    echo "  xattr -cr \"/Applications/OpenHPSDR Zeus.app\""
+    echo "  xattr -cr \"/Applications/OpenHPSDR Zeus Server.app\""
+fi

--- a/installers/zeus-macos.entitlements
+++ b/installers/zeus-macos.entitlements
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Hardened-runtime entitlements for OpenHPSDR Zeus.app and OpenHPSDR Zeus Server.app.
+
+  Distribution: Developer ID + notarization (outside the App Store, NOT sandboxed).
+
+  Each flag below exists for a concrete reason in this codebase. Do not trim without
+  reading the matching code path first:
+
+  - allow-jit                          Photino hosts WKWebView, which JITs JavaScript;
+                                       .NET (the OpenhpsdrZeus self-contained publish)
+                                       falls back to tiered JIT for hot methods even
+                                       though we publish with ReadyToRun.
+  - allow-unsigned-executable-memory   Defensive companion to allow-jit: WebKit and
+                                       .NET RyuJIT both rely on RWX pages that the
+                                       hardened-runtime baseline forbids. Without this
+                                       the .NET runtime SIGKILLs at first JIT.
+  - disable-library-validation         libwdsp.dylib and libminiaudio.dylib live under
+                                       Contents/MacOS/runtimes/osx-*/native/ and are
+                                       loaded via P/Invoke at runtime. We DO sign them
+                                       with the same Team ID during the inside-out
+                                       codesign pass, so in theory this could be
+                                       removed — keep it on defensively so a single
+                                       missed dylib doesn't brick the app.
+  - allow-dyld-environment-variables   LOAD-BEARING. Contents/MacOS/launch.sh exports
+                                       DYLD_LIBRARY_PATH to pin the bundled
+                                       libwdsp.dylib ahead of any stale system copy
+                                       from /opt/homebrew/lib or /usr/local/lib
+                                       (piHPSDR / DeskHPSDR installs leave one). The
+                                       hardened runtime strips DYLD_* env vars by
+                                       default — without this flag the pin silently
+                                       fails and P/Invoke can bind against a stale
+                                       wdsp that pre-dates symbols Zeus needs (e.g.
+                                       SetRXAEMNRpost2*). See create-macos-app.sh
+                                       launch.sh block + docs/lessons/dev-conventions.md.
+
+  Microphone / camera access is NOT declared here: those entitlements only apply
+  inside the App Sandbox. Outside the sandbox the TCC prompt is driven by
+  NSMicrophoneUsageDescription / NSCameraUsageDescription in each bundle's Info.plist
+  (set by create-macos-app.sh). Adding sandbox-only entitlements to a non-sandboxed
+  app is silently ignored, but adds noise — keep this file tight.
+-->
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Tagged releases and nightlies now produce a **signed + Apple-notarized + stapled** macOS DMG. Gatekeeper accepts on first launch — no `xattr -cr` workaround in the release notes anymore.
- Gated on `is-release || is-nightly`, so the dry-run path still ships an unsigned DMG with its original README. `CODESIGN_IDENTITY` is forced empty in dry-run regardless of whether the secret is set.
- New `installers/zeus-macos.entitlements` with the four hardened-runtime flags Photino + .NET + libwdsp/miniaudio + `launch.sh`'s `DYLD_LIBRARY_PATH` need to keep working.

## Why `codesign --deep` (Apple-deprecated but needed)
A .NET self-contained publish dumps ~300 non-Mach-O files (dlls, JSON configs, web assets) under `Contents/MacOS/`, which violates Apple's "MacOS/ is code only" convention. Without `--deep`, codesign refuses such bundles with `code object is not signed at all / In subcomponent: <first non-Mach-O it finds>`. With `--deep` every Mach-O still ends up with hardened runtime + a timestamped Developer ID signature, and notarytool accepts the result. The deprecation is about ergonomics, not validity — every major .NET-on-macOS project ships this way.

## Why the intermediate cert download
A `.p12` exported from Keychain Access carries only the leaf + private key. Dev Macs have the Developer ID G2 intermediate in `login.keychain` from prior Xcode use, so codesign-against-login works fine. A fresh `macos-latest` runner only has Apple Root CA in its trust store, so without the intermediate codesign warns about chain validation and notarytool rejects the bundle. The workflow downloads it from `https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer` into the per-run ephemeral keychain.

## What changes in the workflow
Six new steps in `build-release`, all gated on `is-release || is-nightly`:
1. Dry-run notice (`::notice::`) so the unsigned artifact is visible in the run page
2. Import Developer ID cert into a per-run ephemeral keychain (intermediate + `.p12`, `set-key-partition-list` for no-prompt codesign, array-based search-list capture)
3. **Build macOS Package** (existing, now gets `CODESIGN_IDENTITY` + `ENTITLEMENTS_PATH` + `KEYCHAIN_PATH` in env)
4. `notarytool submit --wait` (parses JSON status, fetches `notarytool log` on rejection, dumps it under `::group::` so the failure post-mortem lives on the run page)
5. `stapler staple` + `stapler validate`
6. `spctl --assess --type open --context context:primary-signature`

Cleanup runs with `if: always()`: deletes the temp keychain, shreds the `.p12` / `.p8` / intermediate, restores the user keychain search list to `login.keychain-db`.

## Test plan
- [x] Local end-to-end: `dotnet publish` → `create-macos-app.sh` with `CODESIGN_IDENTITY` exported → `xcrun notarytool submit --wait` → `stapler staple` → `spctl --assess` returns `accepted; source=Notarized Developer ID` ✓
- [x] All four entitlements present on `OpenhpsdrZeus` binary ✓
- [x] Hardened runtime (`flags=0x10000(runtime)`) on every nested Mach-O (sample: `OpenhpsdrZeus`, `libwdsp.dylib`, `Photino.Native.dylib`) ✓
- [x] `codesign --verify --deep --strict` passes for both `.app` bundles and the DMG ✓
- [ ] CI dry-run: push to this branch triggers `release.yml` in dry-run mode → macOS step shows `::notice::` and uploads unsigned DMG to artifacts (Windows + Linux unaffected)
- [ ] CI signed test: workflow_dispatch with `draft=true` → publishes a Draft Release with notarized DMG → download and `stapler validate` + `spctl --assess`
- [ ] Manual smoke: drag both apps from CI-built DMG to /Applications and double-click — Photino window opens without security prompts