### PR TITLE
fix(ctun): retune the radio on band changes and external (CAT/TCI) set-freq (#461)

### DIFF
--- a/Zeus.Server.Hosting/FrequencyCalibrationService.cs
+++ b/Zeus.Server.Hosting/FrequencyCalibrationService.cs
@@ -135,7 +135,8 @@ public sealed class FrequencyCalibrationService
                 _radio.SetFilter(100, 2700);
                 _radio.SetZoom(CalZoomLevel);
                 long commandedLoHz = (long)(referenceFrequencyHz + IntentionalLoOffsetHz);
-                _radio.SetVfo(commandedLoHz);
+                // Calibration drives the LO absolutely; CTUN must not interpose.
+                _radio.SetVfo(commandedLoHz, fromExternal: true);
 
                 await Task.Delay(SettleMs, ct).ConfigureAwait(false);
 
@@ -203,7 +204,7 @@ public sealed class FrequencyCalibrationService
                 try { _radio.SetMode(origMode); } catch (Exception ex) { _log.LogWarning(ex, "freqcal.restore mode"); }
                 try { _radio.SetFilter(origFilterLo, origFilterHi); } catch (Exception ex) { _log.LogWarning(ex, "freqcal.restore filter"); }
                 try { _radio.SetZoom(origZoom); } catch (Exception ex) { _log.LogWarning(ex, "freqcal.restore zoom"); }
-                try { _radio.SetVfo(origVfoHz); } catch (Exception ex) { _log.LogWarning(ex, "freqcal.restore vfo"); }
+                try { _radio.SetVfo(origVfoHz, fromExternal: true); } catch (Exception ex) { _log.LogWarning(ex, "freqcal.restore vfo"); }
             }
         }
         finally

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -573,22 +573,85 @@ public sealed class RadioService : IDisposable
         return Snapshot();
     }
 
-    public StateDto SetVfo(long hz)
+    public StateDto SetVfo(long hz) => SetVfo(hz, fromExternal: false);
+
+    /// <summary>
+    /// Set the VFO frequency. <paramref name="fromExternal"/> tags the source
+    /// as a CAT/TCI/calibration caller (vs. UI / panadapter click). External
+    /// callers bypass the CTUN auto-recenter heuristics and always retune the
+    /// hardware — matching Thetis's <c>CATChangesCenterFreq=true</c> default
+    /// (console.cs:32082, CATCommands.cs:2690). Without this, a 5–10 kHz FT8
+    /// → FT4 hop via TCI would stay inside the IF, leave CTUN's WDSP shift in
+    /// place, and the radio would TX on the wrong frequency.
+    /// </summary>
+    public StateDto SetVfo(long hz, bool fromExternal)
     {
         long clamped = Math.Clamp(hz, 0L, 60_000_000L);
         long previous;
+        long radioLo;
         RxMode currentMode;
         bool ctun;
-        lock (_sync) { previous = _state.VfoHz; currentMode = _state.Mode; ctun = _state.CtunEnabled; }
-        // CTUN ON: don't retune the hardware NCO. The radio stays at RadioLoHz
-        // and WDSP's RX bandpass is shifted by DspPipelineService so the
-        // operator's tuned signal still lands inside the passband. Issue #427.
-        // CTUN OFF: legacy behaviour — RadioLoHz tracks VfoHz so the radio is
-        // re-tuned to the clamped dial.
-        Mutate(s => ctun
-            ? s with { VfoHz = clamped }
-            : s with { VfoHz = clamped, RadioLoHz = clamped });
-        if (!ctun)
+        int sampleRate;
+        int zoomLevel;
+        int filterLow;
+        int filterHigh;
+        lock (_sync)
+        {
+            previous = _state.VfoHz;
+            currentMode = _state.Mode;
+            ctun = _state.CtunEnabled;
+            radioLo = _state.RadioLoHz;
+            sampleRate = _state.SampleRate;
+            zoomLevel = Math.Max(1, _state.ZoomLevel);
+            filterLow = _state.FilterLowHz;
+            filterHigh = _state.FilterHighHz;
+        }
+        // CTUN auto-recenter — mirrors Thetis txtVFOAFreq_LostFocus
+        // (console.cs:32189-32257) for UI-sourced changes. With CTUN on, two
+        // conditions force a hardware retune so the radio doesn't get "stuck":
+        //   (a) the resulting WDSP shift would push the filter edge outside
+        //       the visible panadapter span (Thetis dispMargin = 5% inset),
+        //   (b) the shift exceeds the IF capacity (Thetis uses
+        //       sample_rate * 0.92 / 2 — mirrored as sampleRate * 0.46).
+        // CAT / TCI / calibration callers (fromExternal=true) bypass both
+        // checks: those sources are expected to drive the radio absolutely
+        // (digital-mode workflows, memory recall, etc.) and CTUN should not
+        // hold the LO behind. Mirrors Thetis CATChangesCenterFreq=true default
+        // (console.cs:32082, CATCommands.cs:2690 ZZFA / 2741 ZZFB).
+        // Either way, when retune fires the CTUN state stays on; the NCO just
+        // snaps to the new dial and ctunShiftHz returns to 0 until the next
+        // panadapter-local movement. Issue #461.
+        bool retune;
+        if (ctun && !fromExternal)
+        {
+            long effectiveLoNew = CwOffset.EffectiveLoHz(currentMode, clamped);
+            long proposedShift = effectiveLoNew - radioLo;
+            long lMargin = Math.Max(0, -filterLow);
+            long hMargin = Math.Max(0, filterHigh);
+            double dispWidth = (double)sampleRate / zoomLevel;
+            double dispMarginHz = dispWidth * 0.05;
+            double lDisp = -dispWidth / 2.0 + dispMarginHz;
+            double hDisp = dispWidth / 2.0 - dispMarginHz;
+            bool outsideVisible = (proposedShift - lMargin) < lDisp
+                               || (proposedShift + hMargin) > hDisp;
+            long ifCapacity = (long)(sampleRate * 0.46);
+            bool outsideIf = Math.Abs(proposedShift) > ifCapacity;
+            retune = outsideVisible || outsideIf;
+        }
+        else
+        {
+            retune = true;
+        }
+        // CTUN-off path stores the raw dial in RadioLoHz (panadapter centre
+        // and P2 push both re-derive via EffectiveLoHz). CTUN-on auto-recenter
+        // path freezes the post-cw_pitch NCO so ctunShiftHz settles at 0.
+        long radioLoNew = ctun
+            ? CwOffset.EffectiveLoHz(currentMode, clamped)
+            : clamped;
+        Mutate(s => retune
+            ? s with { VfoHz = clamped, RadioLoHz = radioLoNew }
+            : s with { VfoHz = clamped });
+        if (retune)
         {
             // CW retunes the LO cw_pitch below/above the dial so the listening
             // freq lands on the +cw_pitch / -cw_pitch audio passband. In SSB /

--- a/Zeus.Server.Hosting/Tci/TciSession.cs
+++ b/Zeus.Server.Hosting/Tci/TciSession.cs
@@ -817,7 +817,9 @@ public sealed class TciSession : IDisposable
             // Spec §8.5: vfo:trx,vfo,0 is invalid — never set a VFO to 0 Hz.
             // Reject silently rather than driving the radio to an out-of-range freq.
             if (hz <= 0) return;
-            _radio.SetVfo(hz);
+            // TCI is a CAT-like external source — bypass CTUN auto-recenter.
+            // Mirrors Thetis CATChangesCenterFreq default. Issue #461.
+            _radio.SetVfo(hz, fromExternal: true);
             // Don't echo back immediately — the StateChanged event will broadcast it
         }
     }
@@ -836,8 +838,8 @@ public sealed class TciSession : IDisposable
         }
         else if (args.Length >= 2 && TciProtocol.TryParseLong(args[1], out long hz))
         {
-            // Set DDS (same as VFO for single-RX)
-            _radio.SetVfo(hz);
+            // Set DDS (same as VFO for single-RX). External source — see HandleVfo.
+            _radio.SetVfo(hz, fromExternal: true);
         }
     }
 


### PR DESCRIPTION
## Summary

- `RadioService.SetVfo` now mirrors Thetis's two CTUN safeguards from `txtVFOAFreq_LostFocus` (console.cs:32171, 32189-32257): UI changes auto-recenter when the WDSP shift would leave the visible span or exceed the IF capacity, and CAT/TCI/calibration callers pass `fromExternal=true` to bypass the heuristic and always retune the hardware.
- `Tci.TciSession.HandleVfo` / `HandleDds` and `FrequencyCalibrationService` set `fromExternal=true` so digital-mode workflows behave like Thetis with `CATChangesCenterFreq=true` (its shipping default — console.cs:32082, CATCommands.cs:2690/2741).

## Why

GH #461: with CTUN on, the VFO digits update but the radio physically stays on the old band. Two real-world repros:

| Source | Shift | Old behaviour | New behaviour |
|---|---|---|---|
| UI band button (15m → 20m) | ~7 MHz | NCO frozen, audio silent, TX on the old band | Out-of-IF check fires, retune, panadapter snaps |
| TCI FT8 → FT4 inside 20m | ~6 kHz | Stays in CTUN, TX on the wrong digital slot | `fromExternal=true` forces retune |
| Panadapter click within the visible span | small | Classic CTUN (WDSP shift) | Unchanged |

CTUN itself stays enabled after the retune; only the hardware NCO snaps to the new dial. Reverts to the pre-CTUN behaviour for the use cases CTUN never made sense for (external set-freq, band changes) while preserving CTUN where it earns its keep (small panadapter movements that fit the IF).

Reported by @nir4x6fk on an ANAN 7000 DLE MKII (UI-driven, no CAT). Verified locally against the same UI repro plus a TCI FT8 → FT4 sub-band hop.

## Test plan

- [ ] CTUN on, click a band button (e.g. 15m → 20m): panadapter snaps to the new band, VFO digits match, audio resolves
- [ ] CTUN on, TCI vfo set within the same band (FT8 → FT4): radio physically retunes, TX lands on the new slot
- [ ] CTUN on, panadapter click ±20 kHz from current centre: classic CTUN preserved (panadapter stays, WDSP shift kicks in)
- [ ] CTUN off path unchanged (no regressions in any of the above)

Closes #461.