### PR TITLE
chore(oc-diag): add OC mask logging at three seams for zeus-jgp investigation

### DIFF
--- a/Zeus.Protocol1/Protocol1Client.cs
+++ b/Zeus.Protocol1/Protocol1Client.cs
@@ -974,10 +974,12 @@ public sealed class Protocol1Client : IProtocol1Client
                 if (elapsed >= TimeSpan.FromSeconds(1))
                 {
                     _log.LogInformation(
-                        "p1.tx.rate pkts={Pkts} in {Ms:F0}ms = {Rate:F0} pkt/s (target 381) | wire: peak={Peak}/32767 mean={Mean} firstI={I} firstQ={Q} drv={Drv}",
+                        "p1.tx.rate pkts={Pkts} in {Ms:F0}ms = {Rate:F0} pkt/s (target 381) | wire: peak={Peak}/32767 mean={Mean} firstI={I} firstQ={Q} drv={Drv} ocTx=0x{OcTx:X2} ocRx=0x{OcRx:X2} mox={Mox}",
                         rateWindowPkts, elapsed.TotalMilliseconds, rateWindowPkts / elapsed.TotalSeconds,
                         ControlFrame.LastPeakAbs, ControlFrame.LastMeanAbs,
-                        ControlFrame.LastFirstI, ControlFrame.LastFirstQ, ControlFrame.LastDriveByte);
+                        ControlFrame.LastFirstI, ControlFrame.LastFirstQ, ControlFrame.LastDriveByte,
+                        (byte)Volatile.Read(ref _ocTxMask), (byte)Volatile.Read(ref _ocRxMask),
+                        Volatile.Read(ref _mox) != 0);
                     rateWindowStart = nowUtc;
                     rateWindowPkts = 0;
                 }

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -1225,6 +1225,12 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         WriteBeU32(p, 1428, alex1);
         WriteBeU32(p, 1432, alex0);
         _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1027));
+
+        _log.LogInformation(
+            "p2.cmd_hp.tx run={Run} mox={Mox} tun={Tun} board={Board} variant={Variant} ocTx=0x{OcTx:X2} ocRx=0x{OcRx:X2} ocDxTx=0x{OcDxTx:X2} ocDxRx=0x{OcDxRx:X2} -> p[1401]=0x{B1401:X2} p[1397]=0x{B1397:X2}",
+            run, _moxOn, _tuneActive, _boardKind, _variant,
+            _ocTxMask, _ocRxMask, _ocDxTxMask, _ocDxRxMask,
+            p[1401], p[1397]);
     }
 
     // ANAN-7000 / Orion-II / Saturn (G2 MkII) BPF board constants. Copied

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -1227,8 +1227,9 @@ public sealed class RadioService : IDisposable
         bool paEnabled = cfg.Global.PaEnabled && !bandCfg.DisablePa;
 
         _log.LogInformation(
-            "pa.recompute tunActive={Tun} pct={Pct} band={Band} gainDb={Gain:F2} maxW={Max} profile={Profile} -> byte={Byte} paEn={PaEn}",
-            tunActive, activePct, bandName ?? "?", bandCfg.PaGainDb, cfg.Global.PaMaxPowerWatts, driveProfile.BoardLabel, driveByte, paEnabled);
+            "pa.recompute tunActive={Tun} pct={Pct} band={Band} gainDb={Gain:F2} maxW={Max} profile={Profile} -> byte={Byte} paEn={PaEn} ocTx=0x{OcTx:X2} ocRx=0x{OcRx:X2} ocDxTx=0x{OcDxTx:X2} ocDxRx=0x{OcDxRx:X2}",
+            tunActive, activePct, bandName ?? "?", bandCfg.PaGainDb, cfg.Global.PaMaxPowerWatts, driveProfile.BoardLabel, driveByte, paEnabled,
+            bandCfg.OcTx, bandCfg.OcRx, bandCfg.OcDxTx, bandCfg.OcDxRx);
 
         ActiveClient?.SetDriveByte(driveByte);
         ActiveClient?.SetOcMasks(bandCfg.OcTx, bandCfg.OcRx);


### PR DESCRIPTION
## Summary

Diagnostic logging only — no behaviour change. Targets [zeus-jgp](beads issue) where a tester reports OC 1-7 not working on any board (Anvelina-PRO3 plus correctly-autodetected boards). An audit of the OC code shows the data flow looks intact end-to-end (UI → /api/pa → PaSettingsStore → Changed event → RadioService.RecomputePaAndPush → ActiveClient.SetOcMasks / SetOcDxMasks → ControlFrame / Protocol2Client wire encode), with correct C2[7:1] / byte 1401 / byte 1397 layouts per spec.

Symptom is "no pin ever goes high" — we need wire-level evidence to localise the break.

### Three log emissions

| Where | Log key | What it proves |
|---|---|---|
| `RadioService.RecomputePaAndPush` | extends `pa.recompute` | what was read from `PaSettingsStore` for the active band |
| `Protocol1Client.TxLoopAsync` (1Hz) | extends `p1.tx.rate` | what the P1 wire builder sees on every Config-register frame |
| `Protocol2Client.SendCmdHighPriority` (edge) | new `p2.cmd_hp.tx` | the actual byte values written to `p[1401]` (standard OC) and `p[1397]` (Anvelina DX OC) |

Diffing the three lines after a UI toggle pinpoints which leg is wrong: store, mask propagation, or wire encode.

## Test plan
- [x] `dotnet build Zeus.slnx` — clean, 0 warnings, 0 errors
- [x] `dotnet test Zeus.slnx` — 740 passed / 0 failed / 96 skipped
- [ ] Bench: connect HL2, toggle OC TX bit 1 on 10m, key MOX briefly on 28400, grep server log for the three keys, paste the three lines back on zeus-jgp
- [ ] Bench: same on Anvelina-PRO3 (tester) to capture both `p2.cmd_hp.tx` p[1401] and p[1397] values