### PR TITLE
chore(beads): point sync.remote at kb2uka/openhpsdr-zeus

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,3 +1,3 @@
 no-git-ops: true
 
-sync.remote: "https://doltremoteapi.dolthub.com/brianbruff/openhpsdr-zeus"
+# sync.remote: "https://doltremoteapi.dolthub.com/kb2uka/openhpsdr-zeus"

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,3 +1,3 @@
 no-git-ops: true
 
-# sync.remote: "https://doltremoteapi.dolthub.com/kb2uka/openhpsdr-zeus"
+sync.remote: "https://doltremoteapi.dolthub.com/kb2uka/openhpsdr-zeus"


### PR DESCRIPTION
## Summary

Switches the bd Dolt sync remote from `brianbruff/openhpsdr-zeus` to `kb2uka/openhpsdr-zeus` (the new official team source-of-truth). Two commits because that's what `bd dolt remote remove origin && bd dolt remote add origin <url>` produced as separate config.yaml writes — combined effect is the single line change.

## Test plan
- [x] `bd dolt push origin main` succeeds against kb2uka/openhpsdr-zeus (verified during session that produced these commits)
- [ ] Teammates will need to run `bd dolt remote add origin https://doltremoteapi.dolthub.com/kb2uka/openhpsdr-zeus` (or re-clone via `bd bootstrap`) on their local clones — the config.yaml carries the team-wide remote URL but the local Dolt DB still needs `origin` set