### PR TITLE
docs: point bd dolt remote at kb2uka in teammate setup

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,3 +1,3 @@
 no-git-ops: true
 
-sync.remote: "https://doltremoteapi.dolthub.com/brianbruff/openhpsdr-zeus"
+# sync.remote: "https://doltremoteapi.dolthub.com/kb2uka/openhpsdr-zeus"

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,3 +1,3 @@
 no-git-ops: true
 
-# sync.remote: "https://doltremoteapi.dolthub.com/kb2uka/openhpsdr-zeus"
+sync.remote: "https://doltremoteapi.dolthub.com/kb2uka/openhpsdr-zeus"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,13 +149,13 @@ bd close <id>         # Complete work
 
 The auto-generated block above mentions `refs/dolt/data` on the git remote as the default sync path. **Zeus does NOT use that.** Zeus syncs its bd Dolt database to a dedicated public DoltHub repo:
 
-> **DoltHub:** https://www.dolthub.com/repositories/brianbruff/openhpsdr-zeus
+> **DoltHub:** https://www.dolthub.com/repositories/kb2uka/openhpsdr-zeus
 
 ### One-time teammate setup
 
 ```bash
 dolt login                                                                   # browser flow → associate a key
-bd dolt remote add origin https://doltremoteapi.dolthub.com/brianbruff/openhpsdr-zeus
+bd dolt remote add origin https://doltremoteapi.dolthub.com/kb2uka/openhpsdr-zeus
 bd dolt pull origin main                                                     # fetch the team's issues
 ```
 


### PR DESCRIPTION
## Summary
- CLAUDE.md \"Beads — Team Sync (Zeus-specific)\" block named the wrong DoltHub repo, so a fresh teammate following the one-time setup would have run `bd dolt remote add origin https://doltremoteapi.dolthub.com/<wrong>/openhpsdr-zeus` and ended up pointing at a dead remote.
- Updated both the human-readable DoltHub link and the `bd dolt remote add` command to `kb2uka/openhpsdr-zeus`, matching what `.beads/config.yaml` (`sync.remote`) and `bd dolt remote list` already use.

## Test plan
- [ ] Read CLAUDE.md \"Beads — Team Sync (Zeus-specific)\" block on the PR and confirm both occurrences read `kb2uka/openhpsdr-zeus`.
- [ ] (Optional) On a fresh clone: `bd dolt remote add origin https://doltremoteapi.dolthub.com/kb2uka/openhpsdr-zeus && bd dolt pull origin main` succeeds.