### PR TITLE
fix(rotator): collapse to LiteDB as sole source of truth (zeus-0xg)

### DIFF
--- a/Zeus.Server.Hosting/RotctldService.cs
+++ b/Zeus.Server.Hosting/RotctldService.cs
@@ -53,7 +53,11 @@ namespace Zeus.Server;
 /// Persistent TCP client for hamlib's rotctld. Holds a single socket,
 /// sends commands, polls position at <see cref="RotctldConfig.PollingIntervalMs"/>,
 /// and reconnects with 5-second backoff on failure. Shape mirrors Log4YM's
-/// RotatorService but keeps state in-memory (single-operator).
+/// RotatorService. Config (host / port / enabled flag / polling interval) is
+/// persisted by <see cref="RotctldConfigStore"/> in zeus-prefs.db and hydrated
+/// at construction so a clean exit with Enabled=true reconnects automatically
+/// on next startup. Live socket state (current azimuth, target, error) is
+/// in-memory only.
 /// </summary>
 public sealed class RotctldService : BackgroundService
 {
@@ -91,6 +95,10 @@ public sealed class RotctldService : BackgroundService
         // ExecuteAsync's first tick will pick up Enabled=true and reconnect.
         _config = _store.Get();
     }
+
+    /// <summary>Returns the live config snapshot (host / port / enabled / polling interval).
+    /// Hydrated from <see cref="RotctldConfigStore"/> at construction; updated by <see cref="SetConfigAsync"/>.</summary>
+    public RotctldConfig GetConfig() => _config;
 
     public RotctldStatus GetStatus()
     {

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -1222,6 +1222,8 @@ public static class ZeusEndpoints
 
         app.MapGet("/api/rotator/status", (RotctldService rot) => rot.GetStatus());
 
+        app.MapGet("/api/rotator/config", (RotctldService rot) => rot.GetConfig());
+
         app.MapPost("/api/rotator/config", async (RotctldConfig req, RotctldService rot, HttpContext ctx) =>
         {
             log.LogInformation("api.rotator.config enabled={En} host={Host} port={Port}", req.Enabled, req.Host, req.Port);

--- a/zeus-web/src/api/rotator.ts
+++ b/zeus-web/src/api/rotator.ts
@@ -104,6 +104,23 @@ export function getRotatorStatus(signal?: AbortSignal): Promise<RotctldStatus> {
   return jsonFetch('/api/rotator/status', { signal }, normalizeStatus);
 }
 
+function normalizeConfig(raw: unknown): RotctldConfig {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  return {
+    enabled: Boolean(r.enabled),
+    host: typeof r.host === 'string' && r.host ? r.host : '127.0.0.1',
+    port: typeof r.port === 'number' && r.port > 0 ? r.port : 4533,
+    pollingIntervalMs:
+      typeof r.pollingIntervalMs === 'number' && r.pollingIntervalMs > 0
+        ? r.pollingIntervalMs
+        : 500,
+  };
+}
+
+export function getRotatorConfig(signal?: AbortSignal): Promise<RotctldConfig> {
+  return jsonFetch('/api/rotator/config', { signal }, normalizeConfig);
+}
+
 export function postRotatorConfig(cfg: RotctldConfig, signal?: AbortSignal): Promise<RotctldStatus> {
   return jsonFetch(
     '/api/rotator/config',

--- a/zeus-web/src/components/RotatorSettingsPanel.tsx
+++ b/zeus-web/src/components/RotatorSettingsPanel.tsx
@@ -241,8 +241,9 @@ export function RotatorSettingsPanel() {
           <span style={{ fontFamily: 'monospace' }}>
             rotctld -m 2 -r /dev/ttyUSB0 -s 9600 -t 4533
           </span>{' '}
-          (model 2 = dummy rotor for testing). Settings are remembered locally; the backend holds no
-          persistent state across restarts.
+          (model 2 = dummy rotor for testing). Settings are saved server-side in zeus-prefs.db and
+          shared across browsers and sessions; Zeus only auto-connects on startup if Enabled was
+          checked at last clean exit.
         </div>
       </form>
     </div>

--- a/zeus-web/src/state/rotator-store.ts
+++ b/zeus-web/src/state/rotator-store.ts
@@ -44,6 +44,7 @@
 
 import { create } from 'zustand';
 import {
+  getRotatorConfig,
   getRotatorStatus,
   postRotatorConfig,
   setRotatorAz,
@@ -54,10 +55,9 @@ import {
   type RotctldTestResult,
 } from '../api/rotator';
 
-// Persist the host/port/enabled/interval the user has chosen so the pill
-// stays usable across reloads. The backend is the source of truth while
-// connected; this is just the form-default memory.
-const CONFIG_STORAGE_KEY = 'zeus.rotator.config';
+// Defaults match the backend record so the form has sensible values until the
+// first /api/rotator/config response lands. The backend is the sole source of
+// truth — config is persisted server-side in zeus-prefs.db, not in localStorage.
 const DEFAULT_CONFIG: RotctldConfig = {
   enabled: false,
   host: '127.0.0.1',
@@ -65,41 +65,13 @@ const DEFAULT_CONFIG: RotctldConfig = {
   pollingIntervalMs: 500,
 };
 
-function readSavedConfig(): RotctldConfig {
-  try {
-    if (typeof localStorage === 'undefined') return DEFAULT_CONFIG;
-    const raw = localStorage.getItem(CONFIG_STORAGE_KEY);
-    if (!raw) return DEFAULT_CONFIG;
-    const parsed = JSON.parse(raw) as Partial<RotctldConfig>;
-    return {
-      enabled: Boolean(parsed.enabled),
-      host: typeof parsed.host === 'string' && parsed.host ? parsed.host : DEFAULT_CONFIG.host,
-      port: typeof parsed.port === 'number' && parsed.port > 0 ? parsed.port : DEFAULT_CONFIG.port,
-      pollingIntervalMs:
-        typeof parsed.pollingIntervalMs === 'number' && parsed.pollingIntervalMs > 0
-          ? parsed.pollingIntervalMs
-          : DEFAULT_CONFIG.pollingIntervalMs,
-    };
-  } catch {
-    return DEFAULT_CONFIG;
-  }
-}
-
-function writeSavedConfig(cfg: RotctldConfig): void {
-  try {
-    if (typeof localStorage === 'undefined') return;
-    localStorage.setItem(CONFIG_STORAGE_KEY, JSON.stringify(cfg));
-  } catch {
-    /* quota — silent */
-  }
-}
-
 export type RotatorStoreState = {
   config: RotctldConfig;
   status: RotctldStatus | null;
   testInFlight: boolean;
   lastTestResult: RotctldTestResult | null;
 
+  refreshConfig: () => Promise<void>;
   refreshStatus: () => Promise<void>;
   saveConfig: (cfg: RotctldConfig) => Promise<RotctldStatus>;
   setAzimuth: (az: number) => Promise<RotctldStatus | null>;
@@ -108,10 +80,19 @@ export type RotatorStoreState = {
 };
 
 export const useRotatorStore = create<RotatorStoreState>((set) => ({
-  config: readSavedConfig(),
+  config: DEFAULT_CONFIG,
   status: null,
   testInFlight: false,
   lastTestResult: null,
+
+  refreshConfig: async () => {
+    try {
+      const config = await getRotatorConfig();
+      set({ config });
+    } catch {
+      /* transient — leave defaults in place */
+    }
+  },
 
   refreshStatus: async () => {
     try {
@@ -123,7 +104,6 @@ export const useRotatorStore = create<RotatorStoreState>((set) => ({
   },
 
   saveConfig: async (cfg) => {
-    writeSavedConfig(cfg);
     const status = await postRotatorConfig(cfg);
     set({ config: cfg, status });
     return status;
@@ -156,22 +136,18 @@ export const useRotatorStore = create<RotatorStoreState>((set) => ({
   },
 }));
 
-// Kick off an initial status probe at module load, then poll at 1 s while the
-// page is alive AND rotctld is enabled. When disabled there's nothing to
-// reconcile — skip the fetch to avoid an idle-RX HTTP wakeup the user can't
-// see anyway.
+// Hydrate config + status from the backend at module load, then poll status at
+// 1 s while the page is alive AND rotctld is enabled. When disabled there's
+// nothing to reconcile — skip the fetch to avoid an idle-RX HTTP wakeup.
+//
+// Note: we deliberately do NOT POST anything on load. The backend hydrates its
+// own config from LiteDB at startup; pushing a cached client copy here would
+// race that hydration and re-enable a rotator the operator already turned off.
 if (typeof window !== 'undefined') {
+  void useRotatorStore.getState().refreshConfig();
   void useRotatorStore.getState().refreshStatus();
   window.setInterval(() => {
     if (!useRotatorStore.getState().config.enabled) return;
     void useRotatorStore.getState().refreshStatus();
   }, 1000);
-
-  // Push the saved config to the backend on first load so the service is in the
-  // same state the UI will render (Enabled flag, host/port). Backend state is
-  // in-memory only — a restart resets to defaults.
-  const initial = useRotatorStore.getState().config;
-  if (initial.enabled) {
-    void useRotatorStore.getState().saveConfig(initial);
-  }
 }


### PR DESCRIPTION
## Summary

Fixes [zeus-0xg](https://www.dolthub.com/repositories/kb2uka/openhpsdr-zeus) — _Rotator desktop autostart + LiteDB unification (bottom bar shows connected while Settings unselected)._

On a fresh desktop launch the bottom-bar rotator pill could show "Connected" to 127.0.0.1 while the Settings panel showed the rotator as unselected. Two coupled bugs:

1. **Frontend localStorage mirror auto-POSTed on load.** `rotator-store.ts` cached `RotctldConfig` in `localStorage` and re-POSTed it to `/api/rotator/config` at every page load, clobbering the backend's LiteDB-hydrated config and re-enabling rotators the operator had turned off.
2. **Pill and Settings read different sources of truth.** `RotatorStatusPill` read `status.enabled` (backend), but `RotatorSettingsPanel` form read `config.enabled` (localStorage). When they diverged → exactly the reported symptom.

The backend already persisted config to LiteDB (`RotctldConfigStore`) and hydrated `_config` at construction; the only missing piece was letting the frontend _read_ that config instead of POSTing its own stale copy.

## Changes

**Backend** (`Zeus.Server.Hosting/`):
- `RotctldService.GetConfig()` — new accessor for the live LiteDB-hydrated config.
- `RotctldService` class docstring — drop stale "in-memory (single-operator)" wording; document the actual LiteDB persistence + auto-reconnect contract.
- `ZeusEndpoints.cs` — new `GET /api/rotator/config` endpoint.

**Frontend** (`zeus-web/src/`):
- `api/rotator.ts` — `getRotatorConfig()` + `normalizeConfig()`.
- `state/rotator-store.ts` — deleted the entire localStorage mirror (`CONFIG_STORAGE_KEY`, `readSavedConfig`, `writeSavedConfig`) and the on-load auto-POST. New `refreshConfig()` hydrates from `/api/rotator/config` once at startup. Polling loop unchanged.
- `components/RotatorSettingsPanel.tsx` — footer copy now reflects that settings persist server-side in `zeus-prefs.db` and Zeus only auto-connects on startup if Enabled was checked at last clean exit.

`RotatorCompassPanel` / `RotatorDialPanel` already read from `status.*`, so no changes needed.

## Why the bench evidence in the desktop log is useful

A pre-fix `dotnet run` session captured exactly the failure mode:

```
RotctldConfigStore initialized at .../zeus-prefs.db
rotctld connected 192.168.100.3:4533            ← backend auto-connected from LiteDB ✓
api.rotator.config enabled=True host=192.168.100.3 port=4533
rotctld disconnect
rotctld connected 192.168.100.3:4533
api.rotator.config enabled=True host=192.168.100.3 port=4533   ← the offending auto-POST
rotctld disconnect
...
```

Backend hydration was already correct; the disconnect/reconnect churn was the frontend's localStorage auto-POST landing after the backend had already connected. That auto-POST is the path removed in this PR.

## Test plan

- [x] `dotnet build Zeus.slnx` — clean, 0 warnings
- [x] `dotnet test Zeus.slnx` — all suites pass (588/588 in `Zeus.Server.Tests`, 0 failures across all projects)
- [x] `tsc --noEmit` in `zeus-web` — clean
- [x] `vitest run` in `zeus-web` — 213/213 pass
- [ ] **Bench-verify next desktop launch** with `Enabled=false` already in LiteDB: pill should show "Rotator: off", Settings checkbox should be unchecked, no spurious `api.rotator.config` POST or `rotctld connected` line in the log.
- [ ] **Bench-verify clean-exit re-enable**: tick Enabled, Save, restart — backend should auto-connect (`rotctld connected …`) without the frontend POSTing anything.

## Wire-format note

`Zeus.Contracts` is unchanged. `RotctldConfig` (already public via the existing POST endpoint) and `RotctldStatus` keep their existing fields — the new `GET /api/rotator/config` returns the existing `RotctldConfig` record. No DTO surgery, no migration.