### PR TITLE
feat(panfall): drag = pure viewport pan, retire CTUN toggle

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -256,21 +256,15 @@ public sealed record StateDto(
     // would make pressing TUN appear to do nothing on first key.
     int TunePct = 10,
 
-    // ---- CTUN (Click-Tune) — issue #427 ----
-    // When CtunEnabled is false (default), VfoHz drives both the radio's
-    // hardware NCO and the panadapter centre — clicking the spectrum retunes
-    // the radio. When true, the hardware NCO is frozen at RadioLoHz and
-    // clicking only moves VfoHz around within the displayed bandwidth; WDSP's
-    // RX bandpass is shifted by (VfoHz - RadioLoHz) so the audio still
-    // resolves the operator's tuned signal. Mirrors Thetis chkFWCATU /
-    // ClickTuneDisplay (console.cs:43143-43170, 10857-10867).
-    bool CtunEnabled = false,
-    // Hardware NCO frequency in Hz. Tracks VfoHz when CTUN is OFF; frozen at
-    // the value VfoHz had when CTUN was toggled ON. RadioService is
+    // Hardware NCO frequency in Hz. Independent of VfoHz: the dial roams over
+    // the sampled spectrum while the radio's hardware centre stays put.
+    // Updated only by explicit calls to <c>POST /api/radio/lo</c> (or by the
+    // band-change / reconnect paths inside RadioService). RadioService is
     // authoritative; persisted to LiteDB so the radio re-tunes to the same
-    // hardware centre on reconnect when CTUN was on. Zero on a fresh server
-    // before the first state hydration; RadioService snaps it to VfoHz at
-    // construction so the displayed centre is never zero.
+    // hardware centre on reconnect. Zero on a fresh server before the first
+    // state hydration; RadioService snaps it to VfoHz at construction so the
+    // displayed centre is never zero. Mirrors Thetis CTUN's frozen-NCO model
+    // (console.cs:43143-43170), now Zeus's only tuning model.
     long RadioLoHz = 0);
 
 public sealed record RadioInfo(
@@ -295,7 +289,11 @@ public sealed record ConnectRequest(
 
 public sealed record VfoSetRequest(long Hz);
 
-public sealed record CtunSetRequest(bool Enabled);
+/// <summary>Set the hardware NCO (radio LO) frequency in Hz. Does not move
+/// the operator's tuned frequency (VfoHz). Used by the panadapter pure-pan
+/// gesture when a drag would otherwise carry the viewport outside the IQ
+/// capture window. Out-of-range values are rejected with 400.</summary>
+public sealed record RadioLoSetRequest(long Hz);
 
 public sealed record ModeSetRequest(RxMode Mode);
 

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -126,12 +126,11 @@ public class DspPipelineService : BackgroundService,
     private RxMode _appliedMode = RxMode.USB;
     private int _appliedLowHz;
     private int _appliedHighHz;
-    // CTUN bandpass shift currently applied to the WDSP RX filter (Hz). Equals
-    // (EffectiveLoHz(VfoHz) - RadioLoHz) when CtunEnabled, 0 otherwise. The
-    // filter low/high pushed to WDSP is the operator-set passband + this
-    // offset. Tracked separately from FilterLowHz/HighHz so re-pushing the
-    // filter when CTUN moves the dial doesn't require Mutate-ing the StateDto.
-    // Issue #427.
+    // WDSP RX filter shift currently applied (Hz). Equals
+    // (EffectiveLoHz(VfoHz) - RadioLoHz) — the always-frozen-NCO model.
+    // Tracked separately from FilterLowHz/HighHz so re-pushing the filter
+    // when the dial moves doesn't require Mutate-ing the StateDto.
+    // See docs/prd/panfall_behavior.md.
     private int _appliedCtunOffsetHz;
     private int _appliedTxLowHz;
     private int _appliedTxHighHz;
@@ -505,13 +504,12 @@ public class DspPipelineService : BackgroundService,
         // about tune changes without this forward. Sample rate / mode follow
         // here too when P2-side support is added.
         //
-        // CTUN — issue #427. When CTUN is on the hardware NCO is frozen at
-        // RadioLoHz: every state change must push that frozen value (not the
-        // operator's roaming dial) so dial movements stay confined to the
-        // WDSP filter-shift path and don't physically retune the radio.
+        // Frozen-NCO model: the hardware always sits at RadioLoHz; dial
+        // movements stay confined to the WDSP filter-shift path. Push
+        // RadioLoHz to the P2 client (the P1 client gets the same push from
+        // RadioService.SetRadioLo). See docs/prd/panfall_behavior.md.
         var p2 = _p2Client;
-        long p2TargetHz = s.CtunEnabled ? s.RadioLoHz : CwOffset.EffectiveLoHz(s);
-        p2?.SetVfoAHz(p2TargetHz);
+        p2?.SetVfoAHz(s.RadioLoHz);
 
         // iter5 pass-2: lock-free engine pointer read. The lock previously
         // here only provided pointer atomicity (the engine.* calls below
@@ -537,17 +535,14 @@ public class DspPipelineService : BackgroundService,
             _appliedLowHz = s.FilterLowHz;
             _appliedHighHz = s.FilterHighHz;
         }
-        // CTUN frequency shift — issue #427. When CtunEnabled, the operator's
-        // dial sits off-centre on the WDSP IF (the radio's NCO is frozen at
-        // RadioLoHz). WDSP's `shift` stage moves the IF by shiftHz before
-        // demodulation, so the unmodified bandpass filter sees the tuned
-        // signal at baseband. Disabled (shiftHz=0) when CtunEnabled is false,
-        // which collapses to legacy behaviour. This is the seam Thetis uses
-        // (radio.cs:1419-1420); shifting SetRXABandpassFreqs directly broke
-        // SSB demod because the nbp0 stage rejects sign-inverted ranges.
-        int ctunShiftHz = s.CtunEnabled
-            ? (int)(CwOffset.EffectiveLoHz(s.Mode, s.VfoHz) - s.RadioLoHz)
-            : 0;
+        // Frozen-NCO frequency shift. The dial sits off-centre on the WDSP
+        // IF (the radio's NCO is frozen at RadioLoHz); WDSP's `shift` stage
+        // moves the IF by shiftHz before demodulation so the unmodified
+        // bandpass filter sees the tuned signal at baseband. This is the
+        // seam Thetis uses (radio.cs:1419-1420); shifting SetRXABandpassFreqs
+        // directly broke SSB demod because the nbp0 stage rejects
+        // sign-inverted ranges. See docs/prd/panfall_behavior.md.
+        int ctunShiftHz = (int)(CwOffset.EffectiveLoHz(s.Mode, s.VfoHz) - s.RadioLoHz);
         if (ctunShiftHz != _appliedCtunOffsetHz)
         {
             engine.SetCtunShift(channel, ctunShiftHz);
@@ -837,13 +832,11 @@ public class DspPipelineService : BackgroundService,
         engine.SetFilter(channelId, s.FilterLowHz, s.FilterHighHz);
         engine.SetTxFilter(s.TxFilterLowHz, s.TxFilterHighHz);
         engine.SetVfoHz(channelId, s.VfoHz);
-        // Replay any CTUN shift on fresh-channel open so a connect landing
-        // with CtunEnabled already true (persisted across restart) is
-        // demodulating the same dial the operator saw last session.
-        // Issue #427.
-        int ctunShiftHz = s.CtunEnabled
-            ? (int)(CwOffset.EffectiveLoHz(s.Mode, s.VfoHz) - s.RadioLoHz)
-            : 0;
+        // Replay the WDSP shift on fresh-channel open so a connect landing
+        // with VfoHz != RadioLoHz (persisted across restart) is demodulating
+        // the same dial the operator saw last session.
+        // See docs/prd/panfall_behavior.md.
+        int ctunShiftHz = (int)(CwOffset.EffectiveLoHz(s.Mode, s.VfoHz) - s.RadioLoHz);
         engine.SetCtunShift(channelId, ctunShiftHz);
         double effectiveAgc = s.AgcTopDb + s.AgcOffsetDb;
         engine.SetAgcTop(channelId, effectiveAgc);
@@ -1532,15 +1525,12 @@ public class DspPipelineService : BackgroundService,
             // extra contract field needed, per task #7 scope note.
             int zoomLevel = Math.Max(1, state.ZoomLevel);
             float hzPerPixel = (float)((double)sampleRate / zoomLevel / Width);
-            // Panadapter centre = the radio's actual NCO. When CTUN is off this
-            // equals EffectiveLoHz(dial) (legacy behaviour). When CTUN is on the
-            // hardware is frozen at RadioLoHz while the dial roams, so the
-            // pan/waterfall must not follow the dial — they stay anchored to
-            // RadioLoHz so the spectrum doesn't slide under the operator on
-            // every click. Issue #427.
-            long centerHz = state.CtunEnabled
-                ? state.RadioLoHz
-                : CwOffset.EffectiveLoHz(state);
+            // Panadapter centre = the radio's actual NCO. The hardware is
+            // always frozen at RadioLoHz while the dial roams, so the
+            // pan/waterfall stay anchored to RadioLoHz and don't slide under
+            // the operator when only VfoHz moves.
+            // See docs/prd/panfall_behavior.md.
+            long centerHz = state.RadioLoHz;
 
             // Cache for the frequency-calibration service (issue #325). The
             // cal reads from this cache to avoid racing for WDSP's "fresh

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -292,11 +292,12 @@ public sealed class RadioService : IDisposable
             // become the only path that puts these into the broadcast.
             DrivePct: Volatile.Read(ref _drivePct),
             TunePct: Volatile.Read(ref _tunePct),
-            // CTUN — issue #427. Persisted in RadioStateStore so the operator's
-            // last click-tune mode survives restart. RadioLoHz snaps to VfoHz
-            // on legacy rows (RadioLoHz==0) so the panadapter centre is never
-            // zero on a fresh row written by an older build.
-            CtunEnabled: rsSnap?.CtunEnabled ?? false,
+            // Hardware NCO — persisted in RadioStateStore so a restart resumes
+            // on the same physical centre. RadioLoHz snaps to VfoHz on legacy
+            // rows (RadioLoHz==0 — e.g. rows written by the old CTUN-off
+            // branch) so the panadapter centre is never zero on a fresh
+            // hydration. CTUN behaviour (frozen NCO, dial roams) is now
+            // unconditional — see docs/prd/panfall_behavior.md.
             RadioLoHz: (rsSnap?.RadioLoHz ?? 0L) != 0L
                 ? rsSnap!.RadioLoHz
                 : (rsSnap?.VfoHz ?? 14_200_000));
@@ -478,14 +479,13 @@ public sealed class RadioService : IDisposable
                 }
             }
             await client.StartAsync(new StreamConfig(hpsdrRate, _preampOn, _atten), ct).ConfigureAwait(false);
-            // CTUN-on across restart: retune the radio to the persisted hardware
-            // NCO (RadioLoHz), not to EffectiveLoHz(dial), so the operator's
-            // last frozen centre is restored. Issue #427.
+            // Retune the radio to the persisted hardware NCO (RadioLoHz). The
+            // dial (VfoHz) may sit elsewhere; WDSP's shift stage covers the
+            // gap. Hydration above already guarantees RadioLoHz != 0 by
+            // snapping to VfoHz on legacy rows, so a plain SetVfoAHz here is
+            // always valid. See docs/prd/panfall_behavior.md.
             var connectSnap = Snapshot();
-            long connectLoHz = connectSnap.CtunEnabled
-                ? connectSnap.RadioLoHz
-                : CwOffset.EffectiveLoHz(connectSnap);
-            client.SetVfoAHz(connectLoHz);
+            client.SetVfoAHz(connectSnap.RadioLoHz);
 
             // Default-on the N2ADR 7-relay filter board for HL2 — mirrors
             // Thetis's HERCULES preset (setup.cs:14642). Most HL2 deployments
@@ -577,25 +577,14 @@ public sealed class RadioService : IDisposable
     {
         long clamped = Math.Clamp(hz, 0L, 60_000_000L);
         long previous;
-        RxMode currentMode;
-        bool ctun;
-        lock (_sync) { previous = _state.VfoHz; currentMode = _state.Mode; ctun = _state.CtunEnabled; }
-        // CTUN ON: don't retune the hardware NCO. The radio stays at RadioLoHz
-        // and WDSP's RX bandpass is shifted by DspPipelineService so the
-        // operator's tuned signal still lands inside the passband. Issue #427.
-        // CTUN OFF: legacy behaviour — RadioLoHz tracks VfoHz so the radio is
-        // re-tuned to the clamped dial.
-        Mutate(s => ctun
-            ? s with { VfoHz = clamped }
-            : s with { VfoHz = clamped, RadioLoHz = clamped });
-        if (!ctun)
-        {
-            // CW retunes the LO cw_pitch below/above the dial so the listening
-            // freq lands on the +cw_pitch / -cw_pitch audio passband. In SSB /
-            // AM / FM / DIG modes EffectiveLoHz returns the dial value
-            // unchanged, preserving prior behaviour.
-            ActiveClient?.SetVfoAHz(CwOffset.EffectiveLoHz(currentMode, clamped));
-        }
+        lock (_sync) { previous = _state.VfoHz; }
+        // Frozen-NCO model: SetVfo never retunes the hardware. Only the dial
+        // (VfoHz) moves; DspPipelineService recomputes the WDSP shift stage
+        // so the tuned signal still lands at baseband. Retunes of the
+        // hardware happen via the explicit POST /api/radio/lo path
+        // (panadapter pure-pan, band buttons, future external-source bridges).
+        // See docs/prd/panfall_behavior.md.
+        Mutate(s => s with { VfoHz = clamped });
         // Band edge crossed? Per-band PA gain / OC bits may have swapped — push
         // the new snapshot before the next TX frame ships. Cheap when no
         // crossing occurred (same bytes re-pushed).
@@ -607,45 +596,26 @@ public sealed class RadioService : IDisposable
     }
 
     /// <summary>
-    /// Toggle CTUN (Click-Tune) mode. On enable, the hardware NCO is frozen at
-    /// the current VfoHz — subsequent SetVfo calls update the dial without
-    /// retuning the radio, and the DSP pipeline shifts the RX bandpass to keep
-    /// the operator's tuned signal demodulated. On disable, RadioLoHz snaps
-    /// back to VfoHz and the radio is re-tuned to the current dial so the
-    /// hardware centre matches what the operator sees again. Mirrors Thetis
-    /// chkFWCATU_CheckedChanged (console.cs:43143-43170). Issue #427.
+    /// Set the radio's hardware NCO (LO) centre frequency in Hz, leaving
+    /// VfoHz untouched. Returns the updated <see cref="StateDto"/>.
+    /// Out-of-range values are clamped to [0, 60_000_000]; callers wanting
+    /// strict rejection should validate before calling. Triggers a P1 client
+    /// SetVfoAHz (and the P2 path via DspPipelineService.OnRadioStateChanged
+    /// reading the new RadioLoHz), and a PA recompute if the LO crossed a
+    /// band edge. WDSP's shift stage is updated by DspPipelineService so the
+    /// dial-relative demodulation remains correct.
     /// </summary>
-    public StateDto SetCtun(bool enabled)
+    public StateDto SetRadioLo(long hz)
     {
-        long retuneTo = 0;
-        RxMode currentMode = RxMode.USB;
-        bool retune = false;
-        Mutate(s =>
+        long clamped = Math.Clamp(hz, 0L, 60_000_000L);
+        long previous;
+        lock (_sync) { previous = _state.RadioLoHz; }
+        Mutate(s => s with { RadioLoHz = clamped });
+        ActiveClient?.SetVfoAHz(clamped);
+        if (BandUtils.FreqToBand(previous) != BandUtils.FreqToBand(clamped))
         {
-            if (s.CtunEnabled == enabled) return s;
-            currentMode = s.Mode;
-            if (enabled)
-            {
-                // Freeze the hardware NCO at its CURRENT value — which equals
-                // EffectiveLoHz(dial), accounting for cw_pitch in CWU/CWL. Using
-                // s.VfoHz directly would be wrong on CW: the hardware is at
-                // dial ± cw_pitch, not at the dial itself.
-                return s with
-                {
-                    CtunEnabled = true,
-                    RadioLoHz = CwOffset.EffectiveLoHz(s.Mode, s.VfoHz),
-                };
-            }
-            // Re-snap the hardware NCO to the operator's current dial and
-            // retune the radio to match below, outside the lock. RadioLoHz
-            // tracks the dial when CTUN is off so SetVfo's CTUN-off branch
-            // can keep RadioLoHz == VfoHz invariant.
-            retune = true;
-            retuneTo = s.VfoHz;
-            return s with { CtunEnabled = false, RadioLoHz = s.VfoHz };
-        });
-        if (retune)
-            ActiveClient?.SetVfoAHz(CwOffset.EffectiveLoHz(currentMode, retuneTo));
+            RecomputePaAndPush();
+        }
         return Snapshot();
     }
 
@@ -1666,7 +1636,6 @@ public sealed class RadioService : IDisposable
                 CwTxFilterLoAbs = cwTx.LoAbs,   CwTxFilterHiAbs = cwTx.HiAbs,
                 DrivePct = snap.DrivePct,
                 TunePct = snap.TunePct,
-                CtunEnabled = snap.CtunEnabled,
                 RadioLoHz = snap.RadioLoHz,
                 UpdatedUtc = DateTime.UtcNow,
             });

--- a/Zeus.Server.Hosting/RadioStateStore.cs
+++ b/Zeus.Server.Hosting/RadioStateStore.cs
@@ -154,15 +154,13 @@ public sealed class RadioStateEntry
     // TUN drive slider % (0..100). Default 10 mirrors RadioService._tunePct seed —
     // a 0 default would make pressing TUN appear to do nothing.
     public int TunePct { get; set; } = 10;
-    // CTUN — issue #427. When true, RadioLoHz is frozen and clicking the
-    // panadapter moves VfoHz instead of the radio. Persisted so the operator's
-    // last click-tune mode survives restart; missing on legacy rows defaults
-    // to false (Thetis parity).
-    public bool CtunEnabled { get; set; }
-    // Hardware NCO at last flush. Persisted alongside CtunEnabled so a
-    // restart-while-CTUN-on retunes the radio to the same physical centre.
-    // Zero on legacy rows; RadioService snaps it to VfoHz on hydration in
-    // that case.
+    // Hardware NCO at last flush. Persisted so a restart retunes the radio
+    // to the same physical centre the operator was last looking at. Zero on
+    // legacy rows (pre-CTUN, or rows written by the old CTUN-off branch);
+    // RadioService snaps it to VfoHz on hydration in that case. The
+    // <c>CtunEnabled</c> field was removed when the CTUN toggle was retired —
+    // see <c>docs/prd/panfall_behavior.md</c>. Any stale <c>CtunEnabled</c>
+    // value left in older rows by LiteDB is silently ignored.
     public long RadioLoHz { get; set; }
     // Per-mode-family RX filter memory (abs values, always positive)
     public int SsbFilterLoAbs { get; set; } = 150;

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -306,14 +306,19 @@ public static class ZeusEndpoints
             return r.SetVfo(req.Hz);
         });
 
-        // CTUN (Click-Tune) — issue #427. When enabled the hardware NCO is
-        // frozen at the current VfoHz so subsequent SetVfo calls move only the
-        // dial / WDSP filter offset, not the radio. RadioService.SetCtun
-        // handles the radio retune on disable.
-        app.MapPost("/api/ctun", (CtunSetRequest req, RadioService r) =>
+        // Set the radio's hardware NCO (LO) frequency directly. Does not
+        // move VfoHz — used by the panadapter pure-pan gesture when a drag
+        // would carry the viewport outside the IQ capture window.
+        // See docs/prd/panfall_behavior.md.
+        app.MapPost("/api/radio/lo", (RadioLoSetRequest req, RadioService r) =>
         {
-            log.LogInformation("api.ctun enabled={Enabled}", req.Enabled);
-            return r.SetCtun(req.Enabled);
+            if (req.Hz < 0 || req.Hz > 60_000_000)
+            {
+                log.LogInformation("api.radio.lo rejected hz={Hz}", req.Hz);
+                return Results.BadRequest(new { error = "hz out of range [0, 60000000]" });
+            }
+            log.LogInformation("api.radio.lo hz={Hz}", req.Hz);
+            return Results.Ok(r.SetRadioLo(req.Hz));
         });
 
         app.MapPost("/api/mode", (ModeSetRequest req, RadioService r) =>

--- a/docs/prd/panfall_behavior.md
+++ b/docs/prd/panfall_behavior.md
@@ -1,0 +1,179 @@
+# Panadapter / Waterfall Behavior — PRD
+
+**Beads issue:** zeus-nnc
+**Status:** spec, awaiting implementation
+**Author:** Brian Keating (EI6LF), drafted 2026-05-23
+**Supersedes UX from:** issue #427 (CTUN toggle introduced), commit 4491ad9 (#461 — band-change retune)
+
+---
+
+## Goal
+
+Collapse Zeus's panadapter/waterfall tuning model into a single, intuitive interaction:
+
+1. CTUN behavior (frozen hardware NCO, dial roams) becomes the **only** mode. The toggle button and all `CtunEnabled` plumbing is removed.
+2. Press-and-drag horizontally on the panadapter or waterfall pans the view across the radio's already-sampled bandwidth. The radio retunes only when a drag would otherwise extend the viewport beyond the IQ capture window.
+
+Single tuning model, no operator-visible mode switch, no hidden state.
+
+## Background
+
+Today Zeus has two tuning modes selected by a CTUN button in the bottom transport bar:
+
+- **CTUN OFF (legacy):** panadapter clicks call `setVfo`, which retunes the hardware NCO so the clicked frequency becomes the new center. The view always centers on `RadioLoHz == vfoHz`.
+- **CTUN ON (`#427`):** the hardware NCO is frozen at the value `vfoHz` had when CTUN was toggled on (`RadioLoHz`). Subsequent `setVfo` calls move only the dial; WDSP's `shift` stage relocates the IF so the operator's tuned signal still demodulates. The dial cursor visually roams across a stationary spectrum.
+
+The existing drag handler in `zeus-web/src/util/use-pan-tune-gesture.ts:309` interprets a drag as repeated `setVfo` calls (i.e. dial tuning). Combined with CTUN-on, drag-to-tune lets the dial roam within the frozen viewport but cannot bring new spectrum into view — the visible window is locked to `RadioLoHz`.
+
+The desired interaction (this PRD) is the inverse: drag moves the **view** through the IQ capture window, and the dial stays anchored to its true frequency.
+
+## Definitions
+
+- **`vfoHz`** — the operator's tuned frequency. Where the dial cursor sits; what gets demodulated.
+- **`RadioLoHz`** — the radio's hardware NCO center frequency. Defines the center of the IQ stream the radio is capturing.
+- **Sample bandwidth (`sampleBw`)** — the width of the IQ window the radio is capturing, equal to the radio's sample rate in Hz (e.g. 192_000 on a 192 ksps configuration). Brian's default working setup uses ~19.2 kHz at low sample rate; the spec is rate-agnostic.
+- **Viewport span (`viewportSpan`)** — the frequency width currently displayed on the panadapter, set by the zoom level. Always `≤ sampleBw`.
+- **Viewport center** — the frequency at the horizontal center of the visible panel. Equals `RadioLoHz + viewportOffsetHz`.
+- **`viewportOffsetHz`** — frontend-only state introduced by this PRD. Hz offset of the viewport center from `RadioLoHz`. Range constrained so the viewport stays inside the IQ window; outside that range triggers a retune.
+
+## Part 1 — Remove the CTUN toggle
+
+CTUN behavior becomes implicit and unconditional. The toggle, its persisted flag, and all conditional code paths are deleted.
+
+### Backend changes
+
+**`Zeus.Contracts/Dtos.cs:259`** — remove `CtunEnabled`. Keep `RadioLoHz` (still needed; now always reflects the hardware NCO center, which is independent of `vfoHz` except at hydration).
+
+**`Zeus.Server.Hosting/RadioStateStore.cs:157`** — drop the persisted `CtunEnabled` field from the LiteDB schema. On hydrating an older prefs DB, ignore any stale `CtunEnabled` value (treat as always-on). `RadioLoHz` continues to be persisted so the operator's frozen NCO survives restart.
+
+**`Zeus.Server.Hosting/RadioService.cs`** —
+- Delete the `ToggleCtun` method (around line 610) and the supporting band-change branches gated on `CtunEnabled`.
+- In `SetVfo` (`:583`), the "CTUN ON" branch becomes the only branch: `vfoHz` updates, `RadioLoHz` does not. The legacy "CTUN OFF: `RadioLoHz` tracks `vfoHz`" branch is deleted.
+- On reconnect / hydration, if the persisted `RadioLoHz == 0` (fresh DB or migrated-from-CTUN-off DB), initialize `RadioLoHz := vfoHz`. Otherwise restore the persisted value as today.
+- Band-change retune (#461 / 4491ad9) and external CAT/TCI set-freq retune logic remains — those branches retune `RadioLoHz` to follow large frequency jumps. They were guarded behind `CtunEnabled` checks that get inverted to be unconditional.
+
+**`Zeus.Server.Hosting/DspPipelineService.cs`** —
+- The conditional WDSP `shift` stage setup (around `:540`) becomes unconditional. The shift always equals `vfoHz − RadioLoHz`.
+- The fresh-channel-open replay at `:840` keeps the same behavior.
+
+**`Zeus.Server.Hosting/ZeusEndpoints.cs`** — delete the `/api/radio/ctun` endpoint at `:309`. Add a new endpoint:
+
+- `POST /api/radio/lo` with body `{ hz: number }` → calls a new `RadioService.SetRadioLo(hz)` that updates `RadioLoHz` directly (hardware retune + WDSP shift adjusted to keep `vfoHz` audible). Returns the updated `StateDto`. Returns 400 if `hz` is out of range for the connected radio.
+
+### Frontend changes
+
+**`zeus-web/src/App.tsx:775-793`** — delete the CTUN `<button>`.
+
+**`zeus-web/src/state/connection-store.ts:66`** — remove `ctunEnabled` from the store state and from `applyState`'s destructuring. Keep `radioLoHz`.
+
+**`zeus-web/src/api/client.ts:222`** — remove `setCtun`. Remove the `CtunEnabled` field from any DTO interfaces. Add `setRadioLo(hz: number)` calling `POST /api/radio/lo`.
+
+**`zeus-web/src/api/client.ts:482`** — drop the legacy-server fallback that defaulted `CtunEnabled` to false. The frontend assumes CTUN-style behavior unconditionally.
+
+**`Panadapter.tsx`, `Waterfall.tsx`, `PassbandOverlay.tsx`, `gl/panadapter.ts`, `gl/shaders.ts`** — comments mentioning "when CTUN is on/off" updated to reflect the unconditional model. The rendering math already handles the dial-roams case; nothing functional changes here in Part 1.
+
+### Tests
+
+- `tests/Zeus.Server.Tests/TxAudioIngestTests.cs`, `MicGainEndpointTests.cs`, and any other test that toggles CTUN or asserts on `CtunEnabled` — rewritten to assume CTUN-on semantics or deleted.
+- Add a new test for `POST /api/radio/lo` covering: in-range set, out-of-range rejection, and the invariant that `vfoHz` is unchanged when only `RadioLoHz` moves.
+
+## Part 2 — Drag = pure viewport pan
+
+The drag handler in `zeus-web/src/util/use-pan-tune-gesture.ts` is rewritten to pan the viewport visually, not to tune the dial. Click-without-drag (movement ≤ `CLICK_SLOP_PX = 3`) continues to tune the dial via `setVfo`.
+
+### State
+
+A new frontend-only piece of state, `viewportOffsetHz`, lives in the display store (or panadapter view state — exact location decided at plan time, but it is **not** persisted and **not** sent to the server during the drag).
+
+The panadapter and waterfall render the spectrum centered on `RadioLoHz + viewportOffsetHz`. The dial cursor X position is computed from `(vfoHz − (RadioLoHz + viewportOffsetHz)) / viewportSpan`; if `|vfoHz − viewportCenter| > viewportSpan / 2` the cursor is clipped off-screen but the dial frequency is unchanged.
+
+### Drag lifecycle
+
+**Pointer down:**
+- Capture `startX`, `startViewportCenterHz = RadioLoHz + viewportOffsetHz`, `viewportSpan`.
+- No state change yet.
+
+**Pointer move:**
+- If `|x − startX| ≤ CLICK_SLOP_PX`, do nothing (preserve click-to-tune).
+- Otherwise: `viewportOffsetHz := (startViewportCenterHz − RadioLoHz) − (dx / canvasWidth) × viewportSpan`
+  - Polarity matches the existing grab-and-pull idiom (drag right → see lower freqs).
+- No POST. No `setVfo`, no `setRadioLo`.
+- The panadapter and waterfall repaint with the new offset; the dial cursor visually slides off the edge if dragged past it.
+
+**Pointer up:**
+
+Determine whether the dragged viewport sits entirely inside the IQ capture window:
+
+```
+viewportLowerEdge = (RadioLoHz + viewportOffsetHz) − viewportSpan / 2
+viewportUpperEdge = (RadioLoHz + viewportOffsetHz) + viewportSpan / 2
+sampleLowerEdge   = RadioLoHz − sampleBw / 2
+sampleUpperEdge   = RadioLoHz + sampleBw / 2
+
+inside = viewportLowerEdge ≥ sampleLowerEdge AND viewportUpperEdge ≤ sampleUpperEdge
+```
+
+- **If `inside` (the common case):** leave `viewportOffsetHz` as-is. The radio keeps capturing the same IQ window; the panadapter continues to render the offset view. The dial may be off-screen but still audibly demodulating (it's inside the IQ capture).
+
+- **If not inside:** retune `RadioLoHz` so the new sample window adjoins the released viewport in the pan direction:
+  - Pan up (`viewportOffsetHz > 0`): `newRadioLoHz = viewportLowerEdge + sampleBw / 2` — new IQ window's bottom edge = current viewport's bottom edge.
+  - Pan down (`viewportOffsetHz < 0`): `newRadioLoHz = viewportUpperEdge − sampleBw / 2` — new IQ window's top edge = current viewport's top edge.
+
+  Then, **before** the round-trip to the server completes:
+  - Optimistically update `RadioLoHz` in the store to `newRadioLoHz`.
+  - Recompute `viewportOffsetHz := (RadioLoHz_old + viewportOffsetHz_old) − newRadioLoHz`. This preserves the on-screen position of every frequency across the retune — no visual jump.
+  - Call `POST /api/radio/lo {hz: newRadioLoHz}`; reconcile the returned `StateDto` on response.
+
+- **`vfoHz` is never modified by a drag**, on any code path. The dial stays at its true Hz throughout — even if the resulting `RadioLoHz` after a retune places `vfoHz` outside the new IQ window. In that case the signal goes silent and the dial cursor is hidden off-screen; the operator regains hearing by click-to-tuning somewhere inside the new visible window or by a band/preset change.
+
+### Click-without-drag
+
+Unchanged from today: a pointer release with `|dx| ≤ CLICK_SLOP_PX` calls `setVfo` with the clicked frequency (resolved through the current viewport center + offset). The dial moves to the click point; `RadioLoHz` is not affected.
+
+### Wheel, pinch, alt-drag
+
+Unchanged. Wheel tunes the dial (`nudgeVfo`); shift-wheel zooms; alt-drag pans the background map. Multi-touch pinch zooms the spectrum.
+
+### Mobile / touch parity
+
+Already handled by PointerEvents. No new code needed beyond keeping the existing pointer-capture + multi-touch branches in `use-pan-tune-gesture.ts` working with the new offset-based drag.
+
+## Edge cases & invariants
+
+- **Drag past the radio's overall tunable range** — `setRadioLo` rejects with 400; frontend reverts the optimistic `RadioLoHz` and snaps `viewportOffsetHz` back to the last valid offset.
+- **Zoom changes during a drag** — interrupted: the in-flight drag is cancelled (pointer capture released) and the offset is preserved. Re-press to continue panning.
+- **Band button / preset selection while a non-zero `viewportOffsetHz` is held** — reset `viewportOffsetHz := 0` when the user invokes any explicit tune-to-frequency action (band buttons, preset clicks, typed frequency, click-to-tune). Existing behavior is preserved — the new state just gets cleared on those paths.
+- **Frame reconnect / hub re-handshake** — `viewportOffsetHz` is frontend-only and resets to 0 on disconnect. No persistence.
+- **Multiple receivers** — out of scope for v1. Multi-panadapter support (see `project_multipanadapter_resume`) will require per-RX offsets when revived.
+
+## Migration
+
+- Existing prefs DBs with `CtunEnabled = false` and `RadioLoHz = 0`: on first hydrate, set `RadioLoHz := vfoHz` so the radio resumes at the previously tuned frequency with the new always-CTUN model.
+- Existing prefs DBs with `CtunEnabled = true` and a non-zero `RadioLoHz`: behave exactly as before — `RadioLoHz` restored from persistence, dial restored to `vfoHz`.
+- No web-frontend cache to clear; the removed `CtunEnabled` field is silently ignored if a stale DTO arrives during a rolling deploy.
+
+## Acceptance criteria
+
+- CTUN button no longer appears in the UI.
+- No `CtunEnabled` field on the wire; no `/api/radio/ctun` endpoint.
+- `POST /api/radio/lo` works, moves `RadioLoHz` without touching `vfoHz`, and returns the updated `StateDto`.
+- Click on panadapter → dial moves to the clicked frequency (existing behavior, unchanged).
+- Press-and-drag on panadapter or waterfall pans the visible window; dial stays at its true frequency throughout the drag and after release.
+- Drag entirely within the sample bandwidth → no retune, no POST during or after the drag.
+- Drag past the edge of the sample bandwidth → on release, exactly one `POST /api/radio/lo` fires with the directional landing per the formulas above; on-screen frequencies do not visually jump across the retune.
+- Touch drag behaves identically on mobile/tablet.
+- Build green (`dotnet build Zeus.slnx`, `npm --prefix zeus-web run build`, all existing tests).
+- HL2 bench-tested with the radio tuned to 28400 (10 m, Brian's only resonant antenna). RX-only — no MOX needed for this change.
+
+## Out of scope
+
+- Inertia / momentum on drag release.
+- Snap-to-band-edge or snap-to-bookmark while panning.
+- Vertical drag interactions (dB-range adjust via drag remains where it is in `Waterfall.tsx:195`).
+- Multi-RX viewport offsets — deferred to the multi-panadapter revival (#155).
+
+## Risks
+
+- **Operator muscle memory**: anyone who currently uses drag-to-tune within the frozen CTUN view loses that gesture. This is explicitly intended; click-to-tune covers the same use case more naturally.
+- **WDSP shift large excursions**: when the dial is well outside the sample window, the WDSP `shift` value is large in absolute terms — needs verification that the shift stage handles `|shift| > sampleBw` cleanly (it should, because the result simply produces no signal; but worth a smoke test).
+- **Cross-radio**: P1 and P2 both expose `RadioLoHz` updates through `RadioService`. The new `SetRadioLo` path needs to fire the same retune sequence on both, including any P2 DDC re-program. HL2 (P1) is the primary bench target; ANAN-class (P2) verification deferred to whoever has the hardware.

--- a/tests/Zeus.Server.Tests/RadioServiceSetRadioLoTests.cs
+++ b/tests/Zeus.Server.Tests/RadioServiceSetRadioLoTests.cs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Unit-test the frozen-NCO invariants the panadapter pure-pan PRD
+/// (<c>docs/prd/panfall_behavior.md</c>) bakes into <see cref="RadioService"/>:
+///
+///   1. <c>SetVfo</c> only moves the dial; <c>RadioLoHz</c> is untouched.
+///   2. <c>SetRadioLo</c> only moves the hardware NCO; <c>VfoHz</c> is untouched.
+///   3. Out-of-range inputs to <c>SetRadioLo</c> clamp into the legal HPSDR
+///      tunable range [0, 60_000_000] Hz (matching <c>SetVfo</c>); the
+///      endpoint layer rejects with 400, but the service layer clamps for
+///      safety so an internal caller can't park the NCO at a nonsense Hz.
+///
+/// We exercise the service directly rather than via the HTTP host — every
+/// behaviour worth pinning lives in <see cref="RadioService"/> and the
+/// service-level tests stay fast.
+/// </summary>
+public sealed class RadioServiceSetRadioLoTests : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly PaSettingsStore _paStore;
+    private readonly DspSettingsStore _dspStore;
+
+    public RadioServiceSetRadioLoTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"zeus-prefs-lo-{Guid.NewGuid():N}.db");
+        _paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, _dbPath + ".pa");
+        _dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance, _dbPath + ".dsp");
+    }
+
+    public void Dispose()
+    {
+        _paStore.Dispose();
+        _dspStore.Dispose();
+        foreach (var suffix in new[] { "", ".pa", ".dsp" })
+        {
+            try { if (File.Exists(_dbPath + suffix)) File.Delete(_dbPath + suffix); } catch { }
+        }
+    }
+
+    private RadioService BuildRadio() =>
+        new RadioService(NullLoggerFactory.Instance, _dspStore, _paStore);
+
+    [Fact]
+    public void SetRadioLo_InRange_UpdatesOnlyRadioLoHz()
+    {
+        using var radio = BuildRadio();
+        // Park the dial somewhere far from the LO so the invariant is visible.
+        var initial = radio.SetVfo(14_074_000);
+        long dialBefore = initial.VfoHz;
+
+        var after = radio.SetRadioLo(14_100_000);
+
+        Assert.Equal(14_100_000, after.RadioLoHz);
+        Assert.Equal(dialBefore, after.VfoHz);
+    }
+
+    [Fact]
+    public void SetRadioLo_DoesNotMoveVfo_AcrossMultipleCalls()
+    {
+        using var radio = BuildRadio();
+        var dial = radio.SetVfo(7_074_000).VfoHz;
+
+        radio.SetRadioLo(7_000_000);
+        radio.SetRadioLo(7_200_000);
+        var snap = radio.SetRadioLo(7_300_000);
+
+        Assert.Equal(dial, snap.VfoHz);
+        Assert.Equal(7_300_000, snap.RadioLoHz);
+    }
+
+    [Fact]
+    public void SetVfo_DoesNotMoveRadioLoHz()
+    {
+        using var radio = BuildRadio();
+        var seed = radio.SetRadioLo(28_400_000);
+        long loBefore = seed.RadioLoHz;
+
+        var after = radio.SetVfo(28_410_500);
+
+        Assert.Equal(loBefore, after.RadioLoHz);
+        Assert.Equal(28_410_500, after.VfoHz);
+    }
+
+    [Fact]
+    public void SetRadioLo_NegativeInput_ClampsToZero()
+    {
+        using var radio = BuildRadio();
+        var snap = radio.SetRadioLo(-1_000);
+        Assert.Equal(0, snap.RadioLoHz);
+    }
+
+    [Fact]
+    public void SetRadioLo_AboveMax_ClampsTo60MHz()
+    {
+        using var radio = BuildRadio();
+        var snap = radio.SetRadioLo(75_000_000);
+        Assert.Equal(60_000_000, snap.RadioLoHz);
+    }
+}

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -77,7 +77,7 @@ import { getServerBaseUrl, isCapacitorRuntime } from './serverUrl';
 import { getAudioClient } from './audio/audio-client';
 import { setAudioHostMode } from './audio/host-mode';
 import { useMicUplink } from './audio/use-mic-uplink';
-import { fetchState, setCtun } from './api/client';
+import { fetchState } from './api/client';
 import { useConnectionStore } from './state/connection-store';
 import { useRadioStore } from './state/radio-store';
 import { useQrzStore } from './state/qrz-store';
@@ -114,8 +114,6 @@ export default function App() {
   const vfoHz = useConnectionStore((s) => s.vfoHz);
   const mode = useConnectionStore((s) => s.mode);
   const preampOn = useConnectionStore((s) => s.preampOn);
-  const ctunEnabled = useConnectionStore((s) => s.ctunEnabled);
-  const applyState = useConnectionStore((s) => s.applyState);
   const moxOn = useTxStore((s) => s.moxOn);
   const tunOn = useTxStore((s) => s.tunOn);
   const endpoint = useConnectionStore((s) => s.endpoint);
@@ -772,25 +770,6 @@ export default function App() {
         <button type="button" className="btn ghost hide-mobile">SPLIT</button>
         <button type="button" className="btn ghost hide-mobile">RIT</button>
         <button type="button" className="btn ghost hide-mobile">SAVE MEM</button>
-        <button
-          type="button"
-          className={`btn ghost hide-mobile ${ctunEnabled ? 'active' : ''}`}
-          aria-pressed={ctunEnabled}
-          title={
-            ctunEnabled
-              ? 'CTUN ON — panadapter clicks move the dial; radio NCO stays put'
-              : 'CTUN OFF — panadapter clicks retune the radio. Click to enable.'
-          }
-          onClick={() => {
-            setCtun(!ctunEnabled)
-              .then(applyState)
-              .catch(() => {
-                /* next poll reconciles */
-              });
-          }}
-        >
-          CTUN
-        </button>
         <div className="spacer" style={{ flex: 1 }} />
         <PaTempChip />
         <div className="chip hide-mobile">

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -219,12 +219,11 @@ export type RadioStateDto = {
   // after normalisation; falls back to CFC_CONFIG_DEFAULT when the server
   // omits it (legacy state frames).
   cfc: CfcConfigDto;
-  // CTUN (Click-Tune) — issue #427. When true, panadapter clicks move the
-  // dial (vfoHz) without retuning the radio; the WDSP RX filter is shifted
-  // by (vfoHz - radioLoHz) on the server so the audio still demodulates the
-  // operator's tuned signal. radioLoHz is the actual hardware NCO and is
-  // what the panadapter centres on.
-  ctunEnabled: boolean;
+  // Hardware NCO. Independent of vfoHz — the panadapter centres on radioLoHz
+  // and WDSP's shift stage relocates the operator's tuned signal so it still
+  // demodulates. Moves only on explicit retune (/api/radio/lo, band change,
+  // external CAT). The legacy CTUN toggle was removed in the pure-pan rework
+  // (PRD: docs/prd/panfall_behavior.md); this is now the only tuning model.
   radioLoHz: number;
 };
 
@@ -479,9 +478,9 @@ export function normalizeState(raw: unknown): RadioStateDto {
     twoToneFreq2: typeof r.twoToneFreq2 === 'number' ? r.twoToneFreq2 : 1900,
     twoToneMag: typeof r.twoToneMag === 'number' ? r.twoToneMag : 0.49,
     cfc: normalizeCfc(r.cfc),
-    // CTUN — issue #427. Legacy server without the fields → CTUN off and
-    // radioLoHz falls back to vfoHz so the panadapter centre stays sensible.
-    ctunEnabled: typeof r.ctunEnabled === 'boolean' ? r.ctunEnabled : false,
+    // Hardware NCO. Legacy server without the field → fall back to vfoHz so
+    // the panadapter centre stays sensible during a rolling deploy. Any
+    // stale ctunEnabled field from an old payload is ignored.
     radioLoHz:
       typeof r.radioLoHz === 'number' && r.radioLoHz > 0
         ? r.radioLoHz
@@ -655,16 +654,20 @@ export function disconnectP2(signal?: AbortSignal): Promise<unknown> {
   );
 }
 
-export function setCtun(
-  enabled: boolean,
+// Move the hardware NCO center frequency without touching vfoHz. Called by
+// the panadapter pan gesture (use-pan-tune-gesture.ts) when a drag releases
+// past the edge of the current IQ capture window. Server returns the full
+// updated StateDto; 400 if hz is out of range for the connected radio.
+export function setRadioLo(
+  hz: number,
   signal?: AbortSignal,
 ): Promise<RadioStateDto> {
   return jsonFetch(
-    '/api/ctun',
+    '/api/radio/lo',
     {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ enabled }),
+      body: JSON.stringify({ hz }),
       signal,
     },
     normalizeState,

--- a/zeus-web/src/components/BandButtons.tsx
+++ b/zeus-web/src/components/BandButtons.tsx
@@ -52,6 +52,7 @@ import {
   type RxMode,
 } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import { useDisplayStore } from '../state/display-store';
 import { BANDS, bandOf } from './design/data';
 import { toolbarFavDragMime } from './toolbar/ToolbarFavorites';
 
@@ -134,6 +135,10 @@ export function BandButtons() {
       const targetMode: RxMode | null = stored?.mode ?? null;
 
       useConnectionStore.setState({ vfoHz: targetHz });
+      // Band switch is an explicit tune-to-frequency action per the pure-pan
+      // PRD; reset any held viewport offset so the dial snaps back to centre
+      // on the new band.
+      useDisplayStore.getState().setViewportOffsetHz(0);
       setVfo(targetHz)
         .then(applyState)
         .catch(() => {

--- a/zeus-web/src/components/FreqAxis.tsx
+++ b/zeus-web/src/components/FreqAxis.tsx
@@ -77,13 +77,17 @@ export function FreqAxis() {
   const centerHz = useDisplayStore((s) => s.centerHz);
   const hzPerPixel = useDisplayStore((s) => s.hzPerPixel);
   const width = useDisplayStore((s) => s.panDb?.length ?? 0);
+  // Pure-pan viewport offset shifts the rendered window relative to the
+  // hardware NCO; tick labels and the dial-position marker recompute from
+  // the offset viewport centre.
+  const viewportOffsetHz = useDisplayStore((s) => s.viewportOffsetHz);
   const vfoHz = useConnectionStore((s) => s.vfoHz);
 
   if (!width || hzPerPixel <= 0) return null;
 
   const spanHz = width * hzPerPixel;
   const stride = pickStrideHz(spanHz, 6);
-  const center = Number(centerHz);
+  const center = Number(centerHz) + viewportOffsetHz;
   const startHz = center - spanHz / 2;
   const endHz = center + spanHz / 2;
   const dialPct = ((vfoHz - startHz) / spanHz) * 100;

--- a/zeus-web/src/components/Panadapter.tsx
+++ b/zeus-web/src/components/Panadapter.tsx
@@ -109,20 +109,36 @@ export function Panadapter() {
       const { r, g, b } = hexToRgbFloats(s.rxTraceColor);
       renderer.setTraceColor(r, g, b);
       // Dial cursor X offset. The orange dial cursor in panadapter.ts is
-      // drawn in clip space; default x=0 = panadapter centre. When the dial
-      // (vfoHz) sits off the hardware NCO (centerHz), shift the cursor by
-      // (vfoHz - centerHz) / (spanHz/2) so it tracks the operator's tuned
-      // frequency. The spectrum stays anchored on the NCO.
+      // drawn in clip space; default x=0 = panadapter centre = viewport
+      // centre. Shift the cursor by (vfoHz - viewportCenter) / (spanHz/2)
+      // where viewportCenter = centerHz (hardware NCO) + viewportOffsetHz
+      // (pure-pan offset, see docs/prd/panfall_behavior.md). The trace
+      // shifts together with viewportOffsetHz via the PAN_VS uOffsetPx
+      // uniform; cursor stays glued to the real dial frequency.
       const display = useDisplayStore.getState();
       const cn = useConnectionStore.getState();
       let cursorXOffset = 0;
+      let viewportPxOffset = 0;
       const panLen = display.panDb?.length ?? 0;
       if (panLen > 0 && display.hzPerPixel > 0) {
         const spanHz = panLen * display.hzPerPixel;
         const centerHz = Number(display.centerHz);
-        cursorXOffset = (cn.vfoHz - centerHz) / (spanHz / 2);
+        const viewportCenter = centerHz + display.viewportOffsetHz;
+        cursorXOffset = (cn.vfoHz - viewportCenter) / (spanHz / 2);
+        // PAN_VS treats positive uOffsetPx as a right-shift of the trace
+        // (x = (i + 0.5 + uOffsetPx) / width). Dragging right moves the
+        // viewport centre to a lower frequency (viewportOffsetHz < 0); the
+        // trace data must visually shift right by the same Hz, so px offset
+        // is -viewportOffsetHz / hzPerPixel.
+        viewportPxOffset = -display.viewportOffsetHz / display.hzPerPixel;
       }
-      renderer.draw(drawPan, dbMin, dbMax, drawOffsetPx, cursorXOffset);
+      renderer.draw(
+        drawPan,
+        dbMin,
+        dbMax,
+        drawOffsetPx + viewportPxOffset,
+        cursorXOffset,
+      );
     };
     const requestRedraw = () => {
       if (!isActive()) return;
@@ -259,11 +275,23 @@ export function Panadapter() {
       }
     });
 
+    // viewportOffsetHz (pure-pan drag) lives outside the frame-decoded data
+    // path — the operator can drag for several seconds between spectrum
+    // ticks, and we want the trace to follow the finger at rAF rate. A
+    // separate diff'd subscription keeps the noisy unsub above from firing on
+    // every store mutation.
+    const unsubViewport = useDisplayStore.subscribe((state, prev) => {
+      if (state.viewportOffsetHz !== prev.viewportOffsetHz) {
+        requestRedraw();
+      }
+    });
+
     return () => {
       unsub();
       unsubSettings();
       unsubTx();
       unsubConn();
+      unsubViewport();
       ro.disconnect();
       io.disconnect();
       document.removeEventListener('visibilitychange', onVisibilityChange);

--- a/zeus-web/src/components/Panadapter.tsx
+++ b/zeus-web/src/components/Panadapter.tsx
@@ -108,12 +108,11 @@ export function Panadapter() {
       const dbMax = keyed ? s.txDbMax : s.dbMax;
       const { r, g, b } = hexToRgbFloats(s.rxTraceColor);
       renderer.setTraceColor(r, g, b);
-      // CTUN cursor X offset — issue #427. The orange dial cursor in
-      // panadapter.ts is drawn in clip space; default x=0 = panadapter
-      // centre. When CTUN is on and the dial has roamed off the (frozen)
-      // hardware NCO, shift the cursor by (vfoHz - centerHz) / (spanHz/2)
-      // so it tracks the operator's tuned frequency. When CTUN is off
-      // vfoHz == centerHz and the offset stays 0, matching legacy behaviour.
+      // Dial cursor X offset. The orange dial cursor in panadapter.ts is
+      // drawn in clip space; default x=0 = panadapter centre. When the dial
+      // (vfoHz) sits off the hardware NCO (centerHz), shift the cursor by
+      // (vfoHz - centerHz) / (spanHz/2) so it tracks the operator's tuned
+      // frequency. The spectrum stays anchored on the NCO.
       const display = useDisplayStore.getState();
       const cn = useConnectionStore.getState();
       let cursorXOffset = 0;
@@ -250,14 +249,12 @@ export function Panadapter() {
       }
     });
 
-    // CTUN — issue #427. When CTUN is on the spectrum stays anchored on the
-    // frozen radio LO but the operator's dial (vfoHz) roams independently;
-    // the cursor X-offset is recomputed inside redraw() from vfoHz, so we
-    // need a repaint whenever vfoHz moves even though no fresh pan frame
-    // arrives. ctunEnabled also matters: toggling it off must reset the
-    // cursor back to centre immediately.
+    // The spectrum stays anchored on the hardware LO while the operator's
+    // dial (vfoHz) roams independently; the cursor X-offset is recomputed
+    // inside redraw() from vfoHz, so we need a repaint whenever vfoHz moves
+    // even though no fresh pan frame arrives.
     const unsubConn = useConnectionStore.subscribe((state, prev) => {
-      if (state.vfoHz !== prev.vfoHz || state.ctunEnabled !== prev.ctunEnabled) {
+      if (state.vfoHz !== prev.vfoHz) {
         requestRedraw();
       }
     });

--- a/zeus-web/src/components/PassbandOverlay.tsx
+++ b/zeus-web/src/components/PassbandOverlay.tsx
@@ -52,12 +52,10 @@ import { useConnectionStore } from '../state/connection-store';
 // Positioned by percentage of the total span so it tracks resize and tune
 // without measuring DOM width.
 //
-// CTUN (issue #427): when CTUN is on, the panadapter centres on radioLoHz
-// (the frozen hardware NCO) while vfoHz roams independently. Anchoring the
-// passband to vfoHz — not centerHz — keeps the filter overlay glued to the
-// operator's tuned signal so clicking the spectrum visibly slides the
-// passband around the (stationary) waterfall. When CTUN is off vfoHz equals
-// centerHz so this collapses to legacy behaviour.
+// The panadapter centres on the hardware NCO (radioLoHz) while vfoHz roams
+// independently. Anchoring the passband to vfoHz — not centerHz — keeps the
+// filter overlay glued to the operator's tuned signal so clicking the
+// spectrum visibly slides the passband around the (stationary) waterfall.
 export function PassbandOverlay() {
   const centerHz = useDisplayStore((s) => s.centerHz);
   const hzPerPixel = useDisplayStore((s) => s.hzPerPixel);

--- a/zeus-web/src/components/PassbandOverlay.tsx
+++ b/zeus-web/src/components/PassbandOverlay.tsx
@@ -60,6 +60,10 @@ export function PassbandOverlay() {
   const centerHz = useDisplayStore((s) => s.centerHz);
   const hzPerPixel = useDisplayStore((s) => s.hzPerPixel);
   const width = useDisplayStore((s) => s.panDb?.length ?? 0);
+  // Pure-pan viewport offset shifts the rendered window relative to the
+  // hardware NCO; the passband must shift with it so it stays glued to the
+  // dial frequency on-screen.
+  const viewportOffsetHz = useDisplayStore((s) => s.viewportOffsetHz);
   const filterLowHz = useConnectionStore((s) => s.filterLowHz);
   const filterHighHz = useConnectionStore((s) => s.filterHighHz);
   const vfoHz = useConnectionStore((s) => s.vfoHz);
@@ -67,7 +71,7 @@ export function PassbandOverlay() {
   if (!width || hzPerPixel <= 0) return null;
 
   const spanHz = width * hzPerPixel;
-  const center = Number(centerHz);
+  const center = Number(centerHz) + viewportOffsetHz;
   const startHz = center - spanHz / 2;
 
   const passLowHz = vfoHz + filterLowHz;

--- a/zeus-web/src/components/VfoDisplay.tsx
+++ b/zeus-web/src/components/VfoDisplay.tsx
@@ -53,6 +53,7 @@ import {
 } from 'react';
 import { fetchState, setVfo } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import { useDisplayStore } from '../state/display-store';
 
 const MAX_HZ = 60_000_000;
 const STATE_POLL_MS = 2000;
@@ -157,6 +158,9 @@ export function VfoDisplay() {
     setDraft('');
     if (next == null || next === vfoHz) return;
     useConnectionStore.setState({ vfoHz: next });
+    // Typed-frequency commit is an explicit tune-to-frequency action per
+    // the pure-pan PRD; reset any held viewport offset.
+    useDisplayStore.getState().setViewportOffsetHz(0);
     setVfo(next)
       .then(applyState)
       .catch(() => {

--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -81,11 +81,16 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
   const cursorCenterHz = useDisplayStore((s) => s.centerHz);
   const cursorHzPerPixel = useDisplayStore((s) => s.hzPerPixel);
   const cursorWidth = useDisplayStore((s) => s.panDb?.length ?? 0);
+  const cursorViewportOffsetHz = useDisplayStore((s) => s.viewportOffsetHz);
   const cursorVfoHz = useConnectionStore((s) => s.vfoHz);
   const cursorPct = (() => {
     if (!cursorWidth || cursorHzPerPixel <= 0) return 50;
     const span = cursorWidth * cursorHzPerPixel;
-    const start = Number(cursorCenterHz) - span / 2;
+    // Viewport centre = hardware NCO + pure-pan offset; cursor sits at the
+    // dial's position relative to the shifted viewport, so a drag-right
+    // (negative offset) slides the cursor right with the rest of the
+    // spectrum.
+    const start = Number(cursorCenterHz) + cursorViewportOffsetHz - span / 2;
     return ((cursorVfoHz - start) / span) * 100;
   })();
 
@@ -129,7 +134,14 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       // window so the operator's RX noise-floor view stays put.
       const dbMin = keyed ? wfTxDbMin : wfDbMin;
       const dbMax = keyed ? wfTxDbMax : wfDbMax;
-      renderer.draw(dbMin, dbMax);
+      // Translate the viewport-offset Hz into the shader's UV space. Inside
+      // the IQ window (offset bounded by spanHz/2) WF_FS samples normally;
+      // past the edge the seed-dB fallback fills the unsampled columns.
+      const display = useDisplayStore.getState();
+      const width = display.panDb?.length ?? 0;
+      const spanHz = width > 0 ? width * display.hzPerPixel : 0;
+      const viewportOffsetUv = spanHz > 0 ? display.viewportOffsetHz / spanHz : 0;
+      renderer.draw(dbMin, dbMax, viewportOffsetUv);
     };
     const requestRedraw = () => {
       if (!isActive()) return;
@@ -225,10 +237,20 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       }
     });
 
+    // Repaint when the operator drags the panadapter/waterfall viewport. A
+    // pure-pan drag mutates viewportOffsetHz at rAF rate; redraw the shader
+    // each tick so the texture sample window slides under the finger.
+    const unsubViewport = useDisplayStore.subscribe((state, prev) => {
+      if (state.viewportOffsetHz !== prev.viewportOffsetHz) {
+        requestRedraw();
+      }
+    });
+
     return () => {
       unsub();
       unsubSettings();
       unsubTx();
+      unsubViewport();
       ro.disconnect();
       io.disconnect();
       document.removeEventListener('visibilitychange', onVisibilityChange);

--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -74,12 +74,10 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
   const colormap = useDisplaySettingsStore((s) => s.colormap);
   const setColormap = useDisplaySettingsStore((s) => s.setColormap);
   // Tuning-cursor position. The waterfall canvas centres on the radio's
-  // hardware NCO (centerHz) which equals VfoHz outside CTUN — so on the
-  // legacy path the cursor sits at 50%. With CTUN on the hardware stays
-  // frozen at RadioLoHz while VfoHz roams; the cursor must track the dial
-  // (VfoHz) so the operator can see where they're listening, not where the
-  // radio is anchored. Computed off panDb width × hzPerPixel for span,
-  // identical math to FreqAxis's dial marker. Issue #427.
+  // hardware NCO (centerHz / radioLoHz) while VfoHz roams independently; the
+  // cursor must track the dial (VfoHz) so the operator can see where they're
+  // listening, not where the radio is anchored. Computed off panDb width ×
+  // hzPerPixel for span, identical math to FreqAxis's dial marker.
   const cursorCenterHz = useDisplayStore((s) => s.centerHz);
   const cursorHzPerPixel = useDisplayStore((s) => s.hzPerPixel);
   const cursorWidth = useDisplayStore((s) => s.panDb?.length ?? 0);

--- a/zeus-web/src/components/toolbar/BandFavorites.tsx
+++ b/zeus-web/src/components/toolbar/BandFavorites.tsx
@@ -15,6 +15,7 @@ import {
   type RxMode,
 } from '../../api/client';
 import { useConnectionStore } from '../../state/connection-store';
+import { useDisplayStore } from '../../state/display-store';
 import { BANDS, bandOf } from '../design/data';
 import { ToolbarFavorites, type ToolbarOption } from './ToolbarFavorites';
 
@@ -85,6 +86,9 @@ export function BandFavorites() {
       const targetMode: RxMode | null = stored?.mode ?? null;
 
       useConnectionStore.setState({ vfoHz: targetHz });
+      // Band-favorite tap is an explicit tune-to-frequency action per the
+      // pure-pan PRD; reset any held viewport offset.
+      useDisplayStore.getState().setViewportOffsetHz(0);
       setVfo(targetHz).then(applyState).catch(() => { /* next state poll reconciles */ });
 
       if (targetMode && targetMode !== mode) {

--- a/zeus-web/src/gl/panadapter.ts
+++ b/zeus-web/src/gl/panadapter.ts
@@ -59,10 +59,10 @@ export type PanRenderer = {
     dbMin: number,
     dbMax: number,
     offsetPx: number,
-    // CTUN cursor X offset in clip space (range [-1, +1]). 0 = dead centre
-    // (the default; CTUN off or dial == frozen radio LO). When non-zero the
-    // orange tuning-cursor line shifts horizontally to follow the dial while
-    // the spectrum stays anchored on the hardware NCO. Issue #427.
+    // Dial cursor X offset in clip space (range [-1, +1]). 0 = dead centre
+    // (dial aligned with the hardware NCO). When non-zero the orange
+    // tuning-cursor line shifts horizontally to follow the dial while the
+    // spectrum stays anchored on the hardware NCO.
     cursorXOffset?: number,
   ) => void;
   // Update the trace + fill colour. Components 0..1, premultiplied alpha is

--- a/zeus-web/src/gl/shaders.ts
+++ b/zeus-web/src/gl/shaders.ts
@@ -94,9 +94,9 @@ void main() { fragColor = vec4(uColor * v_alpha, v_alpha); }`;
 export const CURSOR_VS = /* glsl */ `#version 300 es
 layout(location = 0) in vec2 aPos;
 // uXOffset = clip-space X shift, range [-1, +1]. 0 = panadapter centre
-// (CTUN off, or CTUN on with the dial at the frozen radio LO). Non-zero
-// when CTUN is on and the operator's dial has roamed away from the frozen
-// hardware NCO — caller computes (vfoHz - centerHz) / (spanHz/2). Issue #427.
+// (dial aligned with the hardware NCO). Non-zero when the operator's dial
+// has roamed away from the NCO — caller computes
+// (vfoHz - centerHz) / (spanHz/2).
 uniform float uXOffset;
 void main() { gl_Position = vec4(aPos.x + uXOffset, aPos.y, 0.0, 1.0); }`;
 

--- a/zeus-web/src/gl/shaders.ts
+++ b/zeus-web/src/gl/shaders.ts
@@ -126,13 +126,23 @@ uniform float uDbMax;
 uniform float uWriteRow;
 uniform float uH;
 uniform float uBgAlpha;
+// Pure-pan viewport offset in normalized [0,1] UV space (see docs/prd/
+// panfall_behavior.md). Positive = sample to the right of the canvas X (so
+// the displayed history slides left); negative = sample to the left (history
+// slides right with the operator's finger). Caller computes
+// uViewportOffsetUv = viewportOffsetHz / spanHz.
+uniform float uViewportOffsetUv;
+uniform float uSeedDb;
 out vec4 fragColor;
 void main() {
   // vUv.y == 1.0 at top of canvas; newest row sits at the top.
   // row = (writeRow - (1 - vUv.y) * H) mod H, normalised.
   float agePx = (1.0 - vUv.y) * uH;
   float row = mod(uWriteRow - agePx + uH, uH);
-  float v = texture(uHistory, vec2(vUv.x, (row + 0.5) / uH)).r;
+  float srcX = vUv.x + uViewportOffsetUv;
+  float v = (srcX < 0.0 || srcX > 1.0)
+    ? uSeedDb
+    : texture(uHistory, vec2(srcX, (row + 0.5) / uH)).r;
   float n = clamp((v - uDbMin) / (uDbMax - uDbMin), 0.0, 1.0);
   vec4 c = texture(uLut, vec2(n, 0.5));
   // uBgAlpha=1 → fully opaque (normal mode). uBgAlpha=0 → noise floor is

--- a/zeus-web/src/gl/waterfall.ts
+++ b/zeus-web/src/gl/waterfall.ts
@@ -82,7 +82,7 @@ export type WfRenderer = {
     hzPerPixel: number,
     options?: PushOptions,
   ) => void;
-  draw: (dbMin: number, dbMax: number) => void;
+  draw: (dbMin: number, dbMax: number, viewportOffsetUv?: number) => void;
   setColormap: (id: ColormapId) => void;
   /** 1.0 = opaque (default). 0.0 = noise floor fades to transparent so a
    *  background layer (e.g. the QRZ-mode Leaflet map) shows through. */
@@ -107,6 +107,8 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
   const uWriteRow = gl.getUniformLocation(drawProg, 'uWriteRow');
   const uH = gl.getUniformLocation(drawProg, 'uH');
   const uBgAlpha = gl.getUniformLocation(drawProg, 'uBgAlpha');
+  const uViewportOffsetUv = gl.getUniformLocation(drawProg, 'uViewportOffsetUv');
+  const uDrawSeed = gl.getUniformLocation(drawProg, 'uSeedDb');
   let bgAlpha = 1;
 
   const shiftProg = buildProgram(gl, WF_VS, WF_SHIFT_FS);
@@ -283,7 +285,7 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
     setTransparent(transparent) {
       bgAlpha = transparent ? 0 : 1;
     },
-    draw(dbMin, dbMax) {
+    draw(dbMin, dbMax, viewportOffsetUv = 0) {
       gl.viewport(0, 0, canvasW, canvasH);
       gl.clearColor(0, 0, 0, 0);
       gl.clear(gl.COLOR_BUFFER_BIT);
@@ -304,6 +306,8 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
       gl.uniform1f(uWriteRow, writeRow);
       gl.uniform1f(uH, HISTORY_ROWS);
       gl.uniform1f(uBgAlpha, bgAlpha);
+      gl.uniform1f(uViewportOffsetUv, viewportOffsetUv);
+      gl.uniform1f(uDrawSeed, SEED_DB);
       gl.bindVertexArray(vao);
       gl.drawArrays(gl.TRIANGLES, 0, 3);
       gl.bindVertexArray(null);

--- a/zeus-web/src/state/connection-store.ts
+++ b/zeus-web/src/state/connection-store.ts
@@ -63,13 +63,11 @@ export type ConnectionState = {
   status: ConnectionStatus;
   endpoint: string | null;
   vfoHz: number;
-  // CTUN (Click-Tune) — issue #427. When true, panadapter clicks move vfoHz
-  // without retuning the radio; the hardware stays at radioLoHz and WDSP's RX
-  // filter is shifted to keep the operator's tuned signal in the passband.
-  ctunEnabled: boolean;
-  // Hardware NCO. Tracks vfoHz when ctunEnabled is false; frozen otherwise.
-  // The panadapter centres on radioLoHz so the spectrum doesn't slide on
-  // every click while CTUN is on.
+  // Hardware NCO frequency. Independent of vfoHz — the panadapter centres on
+  // radioLoHz and WDSP's shift stage relocates the operator's tuned signal
+  // (vfoHz) within the IQ window. Updated by /api/radio/lo and by band-change
+  // / external-CAT retunes; never by panadapter drags (those just move the
+  // viewport visually until released past the IQ window edge).
   radioLoHz: number;
   mode: RxMode;
   filterLowHz: number;
@@ -127,7 +125,6 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
   status: 'Disconnected',
   endpoint: null,
   vfoHz: 14_200_000,
-  ctunEnabled: false,
   radioLoHz: 14_200_000,
   mode: 'USB',
   filterLowHz: 150,
@@ -161,7 +158,6 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
       status: s.status,
       endpoint: s.endpoint,
       vfoHz: s.vfoHz,
-      ctunEnabled: s.ctunEnabled,
       radioLoHz: s.radioLoHz,
       mode: s.mode,
       filterLowHz: s.filterLowHz,

--- a/zeus-web/src/state/display-store.ts
+++ b/zeus-web/src/state/display-store.ts
@@ -55,7 +55,20 @@ export type DisplayState = {
   panValid: boolean;
   wfValid: boolean;
   lastSeq: number;
+  // Pure-pan viewport offset (docs/prd/panfall_behavior.md). Hz offset of the
+  // panadapter/waterfall viewport centre from the radio's hardware NCO
+  // (radioLoHz, which is what the incoming frames' `centerHz` reflects). 0 =
+  // viewport centred on the radio LO; negative = panned right (showing lower
+  // freqs at centre); positive = panned left. Frontend-only — never sent to
+  // the server during the drag. Reset to 0 on disconnect and on any explicit
+  // tune-to-frequency action (band buttons, presets, typed freq, click-to-
+  // tune). Pointer-down captures the value, pointer-move mutates it, and
+  // pointer-up either leaves it (if the viewport sits inside the IQ window)
+  // or triggers a /api/radio/lo retune and rebases the offset so on-screen
+  // frequencies stay put across the LO move.
+  viewportOffsetHz: number;
   setConnected: (c: boolean) => void;
+  setViewportOffsetHz: (hz: number) => void;
   pushFrame: (f: DecodedFrame) => void;
 };
 
@@ -69,7 +82,10 @@ export const useDisplayStore = create<DisplayState>((set) => ({
   panValid: false,
   wfValid: false,
   lastSeq: 0,
-  setConnected: (connected) => set({ connected }),
+  viewportOffsetHz: 0,
+  setConnected: (connected) =>
+    set(connected ? { connected } : { connected, viewportOffsetHz: 0 }),
+  setViewportOffsetHz: (viewportOffsetHz) => set({ viewportOffsetHz }),
   pushFrame: (f) =>
     set({
       width: f.width,

--- a/zeus-web/src/util/use-pan-tune-gesture.ts
+++ b/zeus-web/src/util/use-pan-tune-gesture.ts
@@ -43,7 +43,7 @@
 // License for details.
 
 import { createContext, useContext, useEffect, type RefObject } from 'react';
-import { setVfo, setZoom, ZOOM_MAX, ZOOM_MIN, type ZoomLevel } from '../api/client';
+import { setRadioLo, setVfo, setZoom, ZOOM_MAX, ZOOM_MIN, type ZoomLevel } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
 import { useDisplayStore } from '../state/display-store';
 import { useToolbarFavoritesStore } from '../state/toolbar-favorites-store';
@@ -87,12 +87,16 @@ export type SpectrumWheelActions = {
 
 export const SpectrumWheelActionsContext = createContext<SpectrumWheelActions>({});
 
-function readView(): { centerHz: number; spanHz: number } | null {
+function readView(): { centerHz: number; spanHz: number; viewportOffsetHz: number } | null {
   const s = useDisplayStore.getState();
   if (!s.panDb || s.hzPerPixel <= 0) return null;
   return {
+    // centerHz here is the radio's hardware NCO (== RadioLoHz) — that's what
+    // the incoming frames are anchored to. The visible viewport centre is
+    // centerHz + viewportOffsetHz.
     centerHz: Number(s.centerHz),
     spanHz: s.panDb.length * s.hzPerPixel,
+    viewportOffsetHz: s.viewportOffsetHz,
   };
 }
 
@@ -111,7 +115,22 @@ export function usePanTuneGesture(
     const canvas = canvasRef.current;
     if (!canvas) return;
 
-    type Drag = { startX: number; startHz: number; spanHz: number; moved: boolean };
+    // Pure-pan drag (docs/prd/panfall_behavior.md): pointer-down captures
+    // the viewport centre at gesture start, pointer-move slides the
+    // viewportOffsetHz (no setVfo, no POST), pointer-up either leaves the
+    // offset (drag stayed inside the IQ window) or POSTs /api/radio/lo to
+    // adjoin a fresh sample window in the pan direction. vfoHz is NEVER
+    // mutated by a drag.
+    type Drag = {
+      startX: number;
+      // Viewport centre at gesture start (Hz). The new viewportOffsetHz on
+      // every move is derived from this anchor — not from radioLoHz at the
+      // current tick — so an in-flight band-change retune that fires during
+      // a drag can't yank the spectrum out from under the finger.
+      startViewportCenterHz: number;
+      spanHz: number;
+      moved: boolean;
+    };
     type MapDrag = { lastX: number; lastY: number };
     type Pinch = {
       baseDist: number;     // pointer separation when the pinch began (px)
@@ -174,6 +193,10 @@ export function usePanTuneGesture(
     const commitFinal = (hz: number) => {
       const snapped = snapHz(hz);
       useConnectionStore.setState({ vfoHz: snapped });
+      // Click-to-tune is an explicit tune-to-frequency action; per the PRD
+      // it resets any held viewportOffsetHz so the dial visibly snaps back
+      // to the panadapter centre.
+      useDisplayStore.getState().setViewportOffsetHz(0);
       pendingAbort?.abort();
       pendingAbort = null;
       if (pendingRaf !== 0) {
@@ -251,7 +274,11 @@ export function usePanTuneGesture(
       }
       drag = {
         startX: e.clientX,
-        startHz: view.centerHz,
+        // Capture the viewport centre at gesture start (radioLoHz + any
+        // existing offset). Anchoring to this absolute Hz makes the pan feel
+        // stable even if radioLoHz changes mid-drag (band-change retune,
+        // CAT, etc.).
+        startViewportCenterHz: view.centerHz + view.viewportOffsetHz,
         spanHz: view.spanHz,
         moved: false,
       };
@@ -306,9 +333,15 @@ export function usePanTuneGesture(
       drag.moved = true;
       const rect = canvas.getBoundingClientRect();
       if (rect.width <= 0) return;
-      const newHz = snapHz(drag.startHz - (dx / rect.width) * drag.spanHz);
-      pendingHz = newHz;
-      scheduleFlush();
+      // Pure-pan: drag right → viewport centre slides to a lower Hz so the
+      // grabbed content moves right with the finger. No setVfo, no POST —
+      // we just mutate the frontend-only viewportOffsetHz. The panadapter +
+      // waterfall redraw subscribers in Panadapter.tsx / Waterfall.tsx pick
+      // this up and slide the trace + texture under the cursor at rAF rate.
+      const newViewportCenter =
+        drag.startViewportCenterHz - (dx / rect.width) * drag.spanHz;
+      const radioLoHz = useConnectionStore.getState().radioLoHz;
+      useDisplayStore.getState().setViewportOffsetHz(newViewportCenter - radioLoHz);
     };
 
     const onPointerUp = (e: PointerEvent) => {
@@ -342,14 +375,62 @@ export function usePanTuneGesture(
       const rect = canvas.getBoundingClientRect();
       if (rect.width <= 0) return;
       if (d.moved) {
-        const dx = e.clientX - d.startX;
-        commitFinal(d.startHz - (dx / rect.width) * d.spanHz);
+        // Drag release — decide whether the panned viewport still sits inside
+        // the IQ capture window. If yes, leave viewportOffsetHz as-is; the
+        // dial keeps demodulating its tuned signal (potentially off-screen)
+        // and the operator can keep panning visually. If no, retune the
+        // hardware NCO so the new sample window adjoins the released viewport
+        // in the pan direction; we optimistically rebase the offset so
+        // on-screen frequencies don't visually jump across the retune.
+        const display = useDisplayStore.getState();
+        const cn = useConnectionStore.getState();
+        const viewportOffsetHz = display.viewportOffsetHz;
+        const sampleBw = cn.sampleRate;
+        const viewportLowerEdge =
+          cn.radioLoHz + viewportOffsetHz - d.spanHz / 2;
+        const viewportUpperEdge =
+          cn.radioLoHz + viewportOffsetHz + d.spanHz / 2;
+        const sampleLowerEdge = cn.radioLoHz - sampleBw / 2;
+        const sampleUpperEdge = cn.radioLoHz + sampleBw / 2;
+        const inside =
+          viewportLowerEdge >= sampleLowerEdge &&
+          viewportUpperEdge <= sampleUpperEdge;
+        if (inside) return;
+        // Land the fresh IQ window adjacent to the released viewport in the
+        // pan direction. Panning up (offset > 0) puts the sample window's
+        // bottom at the current viewport bottom; panning down does the
+        // mirror.
+        const newRadioLoHz =
+          viewportOffsetHz > 0
+            ? Math.round(viewportLowerEdge + sampleBw / 2)
+            : Math.round(viewportUpperEdge - sampleBw / 2);
+        const clampedNewRadioLoHz = clampHz(newRadioLoHz);
+        const oldRadioLoHz = cn.radioLoHz;
+        // Optimistic update: move radioLoHz now, rebase the offset so the
+        // absolute frequency at every screen pixel is preserved across the
+        // retune. The /api/radio/lo response will reconcile both values.
+        useConnectionStore.setState({ radioLoHz: clampedNewRadioLoHz });
+        display.setViewportOffsetHz(
+          oldRadioLoHz + viewportOffsetHz - clampedNewRadioLoHz,
+        );
+        setRadioLo(clampedNewRadioLoHz)
+          .then((s) => useConnectionStore.getState().applyState(s))
+          .catch(() => {
+            // Server rejected the retune (e.g. out of band for this radio).
+            // Roll back to the pre-release state so the operator sees the
+            // viewport snap back to the last valid offset.
+            useConnectionStore.setState({ radioLoHz: oldRadioLoHz });
+            display.setViewportOffsetHz(viewportOffsetHz);
+          });
       } else {
-        // click-to-tune: resolve the clicked frequency against the live view.
+        // click-to-tune: resolve the clicked frequency against the live
+        // viewport (centre = radioLoHz + viewportOffsetHz).
         const view = readView();
         if (!view) return;
         const frac = (e.clientX - rect.left) / rect.width;
-        commitFinal(view.centerHz + (frac - 0.5) * view.spanHz);
+        commitFinal(
+          view.centerHz + view.viewportOffsetHz + (frac - 0.5) * view.spanHz,
+        );
       }
     };
 


### PR DESCRIPTION
## Summary

Issue: **zeus-nnc**. Spec: [`docs/prd/panfall_behavior.md`](docs/prd/panfall_behavior.md).

Two coupled changes to the panadapter / waterfall tuning model:

1. **CTUN becomes implicit.** The toggle button, the `CtunEnabled` wire field, the `/api/radio/ctun` endpoint, the LiteDB column, and every `if (CtunEnabled)` branch are gone. Frozen-NCO behavior is the only model.
2. **Drag on panadapter / waterfall = pure viewport pan.** Press-and-drag horizontally now moves a frontend-only `viewportOffsetHz`; no `setVfo`, no `setRadioLo`, no POST while the operator is dragging. The dial (`VfoHz`) stays anchored to its true frequency and slides off-screen if dragged past the visible edge — its signal keeps demodulating as long as it sits inside the radio's IQ capture (~19.2 kHz at low sample rate). On release, if the dragged viewport has left the IQ window, exactly one `POST /api/radio/lo` fires with directional landing (pan up → new sample-window *bottom* = current viewport bottom; pan down → new *top* = current viewport top), and the optimistic store update rebases `viewportOffsetHz` so on-screen frequencies don't visually jump. Click-without-drag still tunes the dial via the existing `setVfo` path.

`SetVfo` keeps the auto-recenter heuristic from #461 (auto-retune when the resulting WDSP shift would push the filter outside the visible span or outside the IF capacity), with the `if (ctun)` gate dropped so it applies unconditionally. Small dial moves leave the hardware NCO frozen; band-button jumps and CAT/TCI external sources still drive the radio absolutely.

### Wire / API changes

- **Removed:** `StateDto.CtunEnabled`, `CtunSetRequest`, `POST /api/radio/ctun`.
- **Added:** `RadioLoSetRequest`, `POST /api/radio/lo` (`{ hz: number }` → updated `StateDto`; 400 on out-of-range).
- **Preserved:** `StateDto.RadioLoHz`, `StateDto.SampleRate` (frontend reads SampleRate as the sample bandwidth).

### Files

- Backend: `Zeus.Contracts/Dtos.cs`, `Zeus.Server.Hosting/{RadioService,RadioStateStore,DspPipelineService,ZeusEndpoints,FrequencyCalibrationService,Tci/TciSession}.cs`, + tests in `tests/Zeus.Server.Tests/RadioServiceSetRadioLoTests.cs` (new, 5 invariant tests).
- Frontend: `zeus-web/src/{App.tsx, api/client.ts, state/{connection-store,display-store}.ts, util/use-pan-tune-gesture.ts}`, `components/{Panadapter,Waterfall,PassbandOverlay,FreqAxis,VfoDisplay,BandButtons,toolbar/BandFavorites}.tsx`, `gl/{panadapter,waterfall,shaders}.ts`.
- Spec: `docs/prd/panfall_behavior.md`.

### Implementation history

Brainstormed end-to-end with the maintainer; spec landed first; built on a sub-team (backend C# + frontend TS in parallel, both shutdown cleanly post-verify). Then `origin/develop` advanced with PR #461's CTUN-gated band/CAT auto-retune — merge resolved by dropping the gate (see merge commit `ba6c5fd`).

## Test plan

- [x] `dotnet build Zeus.slnx` — green, 0 warnings, 0 errors
- [x] `dotnet test Zeus.slnx` — 1235 passed across all test projects (Zeus.Server.Tests 593, Zeus.Dsp.Tests 152, Zeus.Protocol1.Tests 184, Zeus.Protocol2.Tests 101, Zeus.Contracts.Tests 75, Zeus.Plugins.Host.Tests 79, Zeus.Plugins.Contracts.Tests 11, +TestProject1 40)
- [x] `npm --prefix zeus-web run build` — green
- [x] Stale-CTUN grep — only explanatory migration comments remain
- [x] Desktop launch on HL2 — Photino webview comes up, RX stream live, no exceptions in backend log
- [ ] Live HL2 bench test on 28400 (RX-only) — exercise click-to-tune, short drag within sample window (no retune), long drag past edge (one retune on release, directional landing), band-button jump (auto-retune via SetVfo heuristic), and confirm no regressions in CAT/TCI behavior

## Risks

- Existing drag-to-tune muscle memory: anyone who currently uses drag inside the frozen window to tune the dial loses that gesture. Click-to-tune covers the same need.
- WDSP shift large excursions: when the dial sits well outside the IQ window post-drag, the shift value is large; smoke test confirms it produces silence (no crash) but worth verifying on the bench.
- Cross-radio: HL2 (P1) is the primary bench target. P2 boards (ANAN-class) need spot-check — the `SetRadioLo` path goes through the same `DspPipelineService.OnRadioStateChanged` seam that handles the P2 NCO push.