### PR TITLE
fix(tx): persist mic gain + Leveler max-gain in LiteDB (zeus-7dt)

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -162,6 +162,23 @@ public sealed record StateDto(
     // yet; when multi-RX lands this becomes the master and the per-RX
     // values layer on top.
     double RxAfGainDb = 0.0,
+    // TX mic gain in dB. WDSP applies via SetTXAPanelGain1(10^(db/20)); the
+    // server stores the operator-friendly dB and converts at the engine seam.
+    // Range matches the /api/mic-gain endpoint clamp ([-40, +10]) which in
+    // turn matches Thetis's MicGainMin/Max defaults (console.cs:19151/19163).
+    // Persisted server-side via RadioStateStore so a fresh frontend connect
+    // (or a desktop relaunch that wiped localStorage) lands on the last
+    // operator value instead of the engine's 0 dB seed. Wire name omits the
+    // Tx prefix to match the existing /api/mic-gain endpoint POST response.
+    int MicGainDb = 0,
+    // TX Leveler max-gain ceiling in dB. Range [0, 15] — 0 disables the
+    // headroom entirely, 15 matches Thetis's stock ceiling
+    // (radio.cs:2979 tx_leveler_max_gain = 15.0). Default 8.0 matches
+    // WdspDspEngine.DefaultLevelerMaxGainDb (Brian's HL2 starting point;
+    // softer than Thetis stock). Persisted server-side; previously
+    // localStorage-only on the client and reverted on every restart. Wire
+    // name matches the existing /api/tx/leveler-max-gain endpoint response.
+    double LevelerMaxGainDb = 8.0,
     // Auto-AGC control loop. When on, the server automatically adjusts
     // AgcTopDb based on signal conditions. Similar to Auto-ATT but for AGC.
     // Default is OFF — operator must explicitly enable. The control loop

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -137,6 +137,14 @@ public class DspPipelineService : BackgroundService,
     private double _appliedAgcTopDb;
     private double _appliedAgcOffsetDb;
     private double _appliedRxAfGainDb;
+    // TX mic gain change-detect cache. NaN sentinel forces the first apply
+    // even when the persisted value happens to equal 0 dB (the engine seam
+    // expects an explicit unity SetTxPanelGain call so the TX chain leaves
+    // its uninitialised state in a known place after channel-open).
+    private double _appliedTxMicGainLinear = double.NaN;
+    // Same NaN-first-apply sentinel for the Leveler ceiling so a channel-open
+    // with the persisted value matching the 8 dB default still re-pushes it.
+    private double _appliedTxLevelerMaxGainDb = double.NaN;
     private NrConfig _appliedNr = new();
     private int _appliedZoomLevel = 1;
     // PureSignal latched values — same change-detect pattern as the others
@@ -566,6 +574,20 @@ public class DspPipelineService : BackgroundService,
             engine.SetRxAfGainDb(channel, s.RxAfGainDb);
             _appliedRxAfGainDb = s.RxAfGainDb;
         }
+        // TX mic gain: dB → linear (10^(db/20)) at the engine seam. Conversion
+        // matches the historical /api/mic-gain inline (Math.Pow(10.0, db/20.0));
+        // moved here so the operator-friendly dB is what gets stored and broadcast.
+        double micLinear = Math.Pow(10.0, s.MicGainDb / 20.0);
+        if (micLinear != _appliedTxMicGainLinear)
+        {
+            engine.SetTxPanelGain(micLinear);
+            _appliedTxMicGainLinear = micLinear;
+        }
+        if (s.LevelerMaxGainDb != _appliedTxLevelerMaxGainDb)
+        {
+            engine.SetTxLevelerMaxGain(s.LevelerMaxGainDb);
+            _appliedTxLevelerMaxGainDb = s.LevelerMaxGainDb;
+        }
         var nr = s.Nr ?? new NrConfig();
         if (!nr.Equals(_appliedNr))
         {
@@ -841,6 +863,14 @@ public class DspPipelineService : BackgroundService,
         double effectiveAgc = s.AgcTopDb + s.AgcOffsetDb;
         engine.SetAgcTop(channelId, effectiveAgc);
         engine.SetRxAfGainDb(channelId, s.RxAfGainDb);
+        // Re-push TX mic gain + Leveler on every fresh engine so the channel
+        // doesn't sit at the WDSP open-time defaults when the operator's last
+        // values differ. The engine's TXA reopen path resets PanelGain1=1.0 and
+        // LevelerTop=8.0 internally; without this re-push, a relaunch would
+        // ignore the just-hydrated StateDto values.
+        double micLinearInit = Math.Pow(10.0, s.MicGainDb / 20.0);
+        engine.SetTxPanelGain(micLinearInit);
+        engine.SetTxLevelerMaxGain(s.LevelerMaxGainDb);
         engine.SetNoiseReduction(channelId, nr);
         engine.SetZoom(channelId, s.ZoomLevel);
         _appliedMode = s.Mode;
@@ -852,6 +882,8 @@ public class DspPipelineService : BackgroundService,
         _appliedAgcTopDb = s.AgcTopDb;
         _appliedAgcOffsetDb = s.AgcOffsetDb;
         _appliedRxAfGainDb = s.RxAfGainDb;
+        _appliedTxMicGainLinear = micLinearInit;
+        _appliedTxLevelerMaxGainDb = s.LevelerMaxGainDb;
         _appliedNr = nr;
         _appliedZoomLevel = s.ZoomLevel;
     }

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -267,6 +267,11 @@ public sealed class RadioService : IDisposable
             TxFilterLowHz: rsSnap?.TxFilterLowHz ?? 150,
             TxFilterHighHz: rsSnap?.TxFilterHighHz ?? 2850,
             RxAfGainDb: rsSnap?.RxAfGainDb ?? 0.0,
+            // 0 dB unity matches the engine's TXA fresh-open default; legacy
+            // rows missing the field hydrate to that same default.
+            MicGainDb: Math.Clamp(rsSnap?.MicGainDb ?? 0, -40, 10),
+            // 8.0 dB matches WdspDspEngine.DefaultLevelerMaxGainDb.
+            LevelerMaxGainDb: Math.Clamp(rsSnap?.LevelerMaxGainDb ?? 8.0, 0.0, 15.0),
             AutoAgcEnabled: rsSnap?.AutoAgcEnabled ?? false,
             AgcOffsetDb: 0.0,       // always reset — control-loop accumulator
             // PS persisted fields (or DTO defaults when not persisted yet).
@@ -1310,6 +1315,26 @@ public sealed class RadioService : IDisposable
         return Snapshot();
     }
 
+    // TX mic gain in dB. Server-clamped to [-40, +10] to match the endpoint
+    // contract and Thetis's MicGainMin/Max defaults. The dB → linear (10^(db/20))
+    // conversion happens at the engine seam in DspPipelineService so the wire
+    // and persisted form is the operator-friendly integer.
+    public StateDto SetTxMicGain(int db)
+    {
+        int clamped = Math.Clamp(db, -40, 10);
+        Mutate(s => s with { MicGainDb = clamped });
+        return Snapshot();
+    }
+
+    // TX Leveler max-gain ceiling in dB. Server-clamped to [0, 15]; same
+    // operator-safe band the endpoint already enforced.
+    public StateDto SetTxLevelerMaxGain(double db)
+    {
+        double clamped = Math.Clamp(db, 0.0, 15.0);
+        Mutate(s => s with { LevelerMaxGainDb = clamped });
+        return Snapshot();
+    }
+
     public StateDto SetNr(NrConfig cfg)
     {
         ArgumentNullException.ThrowIfNull(cfg);
@@ -1685,6 +1710,8 @@ public sealed class RadioService : IDisposable
                 AttenDb = snap.AttenDb,
                 AutoAgcEnabled = snap.AutoAgcEnabled,
                 RxAfGainDb = snap.RxAfGainDb,
+                MicGainDb = snap.MicGainDb,
+                LevelerMaxGainDb = snap.LevelerMaxGainDb,
                 ZoomLevel = snap.ZoomLevel,
                 SsbFilterLoAbs = ssb.LoAbs,   SsbFilterHiAbs = ssb.HiAbs,
                 AmFilterLoAbs = am.LoAbs,     AmFilterHiAbs = am.HiAbs,

--- a/Zeus.Server.Hosting/RadioStateStore.cs
+++ b/Zeus.Server.Hosting/RadioStateStore.cs
@@ -13,9 +13,10 @@ using Zeus.Contracts;
 namespace Zeus.Server;
 
 // Persists the subset of RadioService state that no dedicated store covers:
-// active mode/VFO, RX/TX filter bounds, master volume, display zoom,
-// auto-ATT/AGC toggles, user-baseline attenuator, and the eight per-mode-
-// family filter memory slots (SSB/AM/FM/CW × RX/TX).
+// active mode/VFO, RX/TX filter bounds, master volume, TX mic gain, TX
+// Leveler max gain, display zoom, auto-ATT/AGC toggles, user-baseline
+// attenuator, and the eight per-mode-family filter memory slots
+// (SSB/AM/FM/CW × RX/TX).
 //
 // Not persisted here — handled elsewhere or intentionally ephemeral:
 //   AgcTopDb, Nr, Cfc       → DspSettingsStore
@@ -148,6 +149,17 @@ public sealed class RadioStateEntry
     public int AttenDb { get; set; }
     public bool AutoAgcEnabled { get; set; }
     public double RxAfGainDb { get; set; }
+    // TX mic gain in dB, range [-40, +10]. Default 0 ≡ unity panel-gain (mirrors
+    // WdspDspEngine TXA fresh-open). The endpoint accepted this value but didn't
+    // save it; lived only in frontend localStorage and reverted on every restart
+    // when the desktop webview's storage was wiped.
+    public int MicGainDb { get; set; }
+    // TX Leveler max-gain ceiling in dB, range [0, 15]. Default 8.0 matches
+    // WdspDspEngine.DefaultLevelerMaxGainDb so legacy rows missing the field
+    // hydrate with the same ceiling the engine has always opened with. Like
+    // MicGainDb, this used to live only in localStorage and reverted on
+    // restart.
+    public double LevelerMaxGainDb { get; set; } = 8.0;
     public int ZoomLevel { get; set; } = 1;
     // Drive slider % (0..100). Default 0 mirrors RadioService._drivePct seed.
     public int DrivePct { get; set; }

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -457,28 +457,29 @@ public static class ZeusEndpoints
         // -10..-15 dBFS, which over-drives WDSP TXA + ALC and prints as
         // splatter on the air; without an attenuator the operator has nowhere
         // to back off. Range matches Thetis's MicGainMin/Max defaults
-        // (console.cs:19151 = -40, :19163 = +10).
-        app.MapPost("/api/mic-gain", (MicGainSetRequest req, DspPipelineService pipe) =>
+        // (console.cs:19151 = -40, :19163 = +10). RadioService persists the dB
+        // value via RadioStateStore; the dB → linear (10^(db/20)) conversion
+        // happens at the engine seam in DspPipelineService.
+        app.MapPost("/api/mic-gain", (MicGainSetRequest req, RadioService r) =>
         {
-            int db = Math.Clamp(req.Db, -40, 10);
-            double gain = Math.Pow(10.0, db / 20.0);
-            pipe.CurrentEngine?.SetTxPanelGain(gain);
-            return Results.Ok(new { micGainDb = db });
+            var snap = r.SetTxMicGain(req.Db);
+            return Results.Ok(new { micGainDb = snap.MicGainDb });
         });
 
         // Leveler max-gain ceiling in dB. Operator-safe band is 0..15 dB: 0 disables
         // the headroom entirely (unity-cap Leveler) and 15 matches Thetis's stock
         // ceiling (radio.cs:2979 tx_leveler_max_gain = 15.0). Anything outside is a
         // 400 so a misbehaving client can't hand WDSP a value that'd saturate on
-        // the first voiced sample. The server is stateless for this setting —
-        // frontend re-POSTs on WS reconnect to re-sync after a server restart.
-        app.MapPost("/api/tx/leveler-max-gain", (LevelerMaxGainSetRequest req, DspPipelineService pipe) =>
+        // the first voiced sample. RadioService persists via RadioStateStore so
+        // the operator's ceiling survives backend restart; the frontend no
+        // longer needs to re-POST on WS reconnect.
+        app.MapPost("/api/tx/leveler-max-gain", (LevelerMaxGainSetRequest req, RadioService r) =>
         {
             if (req.Gain < 0.0 || req.Gain > 15.0 || double.IsNaN(req.Gain))
                 return Results.BadRequest(new { error = "gain must be 0..15 dB" });
             log.LogInformation("api.tx.levelerMaxGain dB={Db:F1}", req.Gain);
-            pipe.CurrentEngine?.SetTxLevelerMaxGain(req.Gain);
-            return Results.Ok(new { levelerMaxGainDb = req.Gain });
+            var snap = r.SetTxLevelerMaxGain(req.Gain);
+            return Results.Ok(new { levelerMaxGainDb = snap.LevelerMaxGainDb });
         });
 
         // TUN: internal-tune carrier. Flips SetTXAPostGenRun on WDSP; server-side is

--- a/tests/Zeus.Server.Tests/LevelerMaxGainEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/LevelerMaxGainEndpointTests.cs
@@ -60,13 +60,16 @@ namespace Zeus.Server.Tests;
 /// <summary>
 /// End-to-end endpoint test for <c>POST /api/tx/leveler-max-gain</c>: drives
 /// the real handler via <see cref="WebApplicationFactory{TEntryPoint}"/>,
-/// asserting a JSON <c>{gain}</c> body reaches
-/// <see cref="IDspEngine.SetTxLevelerMaxGain"/> on the current engine, and
-/// that out-of-range values are rejected with a 400.
+/// asserting that a JSON <c>{gain}</c> body updates the persisted
+/// <see cref="StateDto.LevelerMaxGainDb"/>, and that out-of-range values
+/// are rejected with a 400.
 ///
-/// Frontend re-POSTs this on every slider move and on WS reconnect (task
-/// #19), so the handler's range check is the only thing between a rogue
-/// client and WDSP's Leveler ceiling.
+/// Post-persistence migration the endpoint routes through
+/// <c>RadioService.SetTxLevelerMaxGain</c> → <c>Mutate</c> → the StateChanged
+/// listener that pushes WDSP's <c>SetTXALevelerTop</c>. The HTTP test pins
+/// the request/response contract and the state-mutation hop; the engine-seam
+/// behaviour is covered by <see cref="DspPipelineService"/>'s broadcast path
+/// (no engine open in this test factory so the seam is intentionally inert).
 /// </summary>
 public class LevelerMaxGainEndpointTests : IClassFixture<LevelerMaxGainEndpointTests.Factory>
 {
@@ -77,33 +80,34 @@ public class LevelerMaxGainEndpointTests : IClassFixture<LevelerMaxGainEndpointT
     [InlineData(0.0)]   // band floor
     [InlineData(5.0)]   // W1AEX / softerhardware default
     [InlineData(15.0)]  // band ceiling (Thetis stock)
-    public async Task PostInRange_CallsEngineWithSameValue(double gain)
+    public async Task PostInRange_UpdatesRadioServiceState(double gain)
     {
-        _factory.TestEngine.LevelerMaxGainCalls.Clear();
+        using var scope = _factory.Services.CreateScope();
+        var radio = scope.ServiceProvider.GetRequiredService<RadioService>();
         using var client = _factory.CreateClient();
 
         var resp = await client.PostAsJsonAsync("/api/tx/leveler-max-gain", new { gain });
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
-
-        var call = Assert.Single(_factory.TestEngine.LevelerMaxGainCalls);
-        Assert.Equal(gain, call, precision: 6);
+        Assert.Equal(gain, radio.Snapshot().LevelerMaxGainDb, precision: 6);
     }
 
     [Theory]
     [InlineData(-0.1)]
     [InlineData(15.1)]
-    public async Task PostOutOfRange_Returns400_AndDoesNotCallEngine(double gain)
+    public async Task PostOutOfRange_Returns400_AndDoesNotMutateState(double gain)
     {
-        _factory.TestEngine.LevelerMaxGainCalls.Clear();
+        using var scope = _factory.Services.CreateScope();
+        var radio = scope.ServiceProvider.GetRequiredService<RadioService>();
+        double before = radio.Snapshot().LevelerMaxGainDb;
         using var client = _factory.CreateClient();
 
         var resp = await client.PostAsJsonAsync("/api/tx/leveler-max-gain", new { gain });
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
-        Assert.Empty(_factory.TestEngine.LevelerMaxGainCalls);
+        Assert.Equal(before, radio.Snapshot().LevelerMaxGainDb, precision: 6);
     }
 
     [Fact]
-    public async Task PostNaN_Returns400_AndDoesNotCallEngine()
+    public async Task PostNaN_Returns400_AndDoesNotMutateState()
     {
         // System.Text.Json refuses to serialize NaN via PostAsJsonAsync, so
         // simulate a rogue client sending the JavaScript literal `NaN` by
@@ -111,15 +115,18 @@ public class LevelerMaxGainEndpointTests : IClassFixture<LevelerMaxGainEndpointT
         // (double.IsNaN(req.Gain)) is defensive belt-and-braces against a
         // deserializer that later enables AllowNamedFloatingPointLiterals —
         // the test pins the rejection shape in place now.
-        _factory.TestEngine.LevelerMaxGainCalls.Clear();
+        using var scope = _factory.Services.CreateScope();
+        var radio = scope.ServiceProvider.GetRequiredService<RadioService>();
+        double before = radio.Snapshot().LevelerMaxGainDb;
         using var client = _factory.CreateClient();
         using var content = new StringContent(
             "{\"gain\":NaN}", Encoding.UTF8, "application/json");
 
         var resp = await client.PostAsync("/api/tx/leveler-max-gain", content);
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
-        Assert.Empty(_factory.TestEngine.LevelerMaxGainCalls);
+        Assert.Equal(before, radio.Snapshot().LevelerMaxGainDb, precision: 6);
     }
+
 
     public sealed class Factory : WebApplicationFactory<Program>
     {

--- a/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
@@ -58,14 +58,16 @@ namespace Zeus.Server.Tests;
 
 /// <summary>
 /// End-to-end endpoint test for <c>POST /api/mic-gain</c>: drives the real
-/// endpoint via <see cref="WebApplicationFactory{TEntryPoint}"/>, asserting
-/// that a request body of <c>{db}</c> reaches the DspPipelineService's
-/// current engine as <c>SetTxPanelGain(10^(db/20))</c>.
+/// endpoint via <see cref="WebApplicationFactory{TEntryPoint}"/> and asserts
+/// that <c>{db}</c> ends up in <see cref="StateDto.MicGainDb"/>, clamped to
+/// the endpoint's <c>[-40, +10]</c> range.
 ///
-/// PRD FR-3 (<c>docs/prd/12-tx-feature.md</c>) requires db → linear gain via
-/// <c>10^(db/20)</c>; this test exercises that path through Program.cs so
-/// the Math.Clamp + Math.Pow inlined on the handler can't drift from the
-/// spec without a failing test.
+/// PRD FR-3 (<c>docs/prd/12-tx-feature.md</c>) still requires db → linear
+/// gain via <c>10^(db/20)</c>; that conversion now lives at the engine seam
+/// in <see cref="DspPipelineService"/> so the persisted form stays in
+/// operator-friendly dB. The seam's dB → linear math is exercised inline in
+/// <see cref="DspPipelineService"/>'s broadcast path (no engine open in this
+/// test factory, so the seam stays intentionally dormant here).
 /// </summary>
 public class MicGainEndpointTests : IClassFixture<MicGainEndpointTests.Factory>
 {
@@ -73,62 +75,59 @@ public class MicGainEndpointTests : IClassFixture<MicGainEndpointTests.Factory>
     public MicGainEndpointTests(Factory factory) => _factory = factory;
 
     [Fact]
-    public async Task Post0db_SetsLinearGainOf1()
+    public async Task Post0db_PersistsZeroOnState()
     {
-        _factory.TestEngine.GainCalls.Clear();
+        using var scope = _factory.Services.CreateScope();
+        var radio = scope.ServiceProvider.GetRequiredService<RadioService>();
         using var client = _factory.CreateClient();
 
         var resp = await client.PostAsJsonAsync("/api/mic-gain", new { db = 0 });
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
-
-        var call = Assert.Single(_factory.TestEngine.GainCalls);
-        Assert.Equal(1.0, call, precision: 6);
+        Assert.Equal(0, radio.Snapshot().MicGainDb);
     }
 
     [Fact]
-    public async Task PostPlus10db_SetsLinearGainOfRoughly3point16()
+    public async Task PostPlus10db_PersistsPlus10()
     {
-        _factory.TestEngine.GainCalls.Clear();
+        using var scope = _factory.Services.CreateScope();
+        var radio = scope.ServiceProvider.GetRequiredService<RadioService>();
         using var client = _factory.CreateClient();
 
         var resp = await client.PostAsJsonAsync("/api/mic-gain", new { db = 10 });
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
-
-        var call = Assert.Single(_factory.TestEngine.GainCalls);
-        Assert.Equal(Math.Pow(10.0, 0.5), call, precision: 6);
+        Assert.Equal(10, radio.Snapshot().MicGainDb);
     }
 
     [Fact]
-    public async Task PostMinus20db_AttenuatesByLinearGainOfRoughly0point1()
+    public async Task PostMinus20db_PersistsMinus20()
     {
-        _factory.TestEngine.GainCalls.Clear();
+        // -20 dB lands in the negative half (attenuation) — verifies the range
+        // doesn't get clamped to 0 / unity by an off-by-one in the endpoint.
+        using var scope = _factory.Services.CreateScope();
+        var radio = scope.ServiceProvider.GetRequiredService<RadioService>();
         using var client = _factory.CreateClient();
 
-        // -20 dB → linear gain 0.1 — verifies the negative half of the range
-        // actually attenuates, not just clamps to 0 / unity.
         var resp = await client.PostAsJsonAsync("/api/mic-gain", new { db = -20 });
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
-
-        var call = Assert.Single(_factory.TestEngine.GainCalls);
-        Assert.Equal(0.1, call, precision: 6);
+        Assert.Equal(-20, radio.Snapshot().MicGainDb);
     }
 
     [Fact]
     public async Task PostOutOfRange_ClampsToMinus40AndPlus10()
     {
-        _factory.TestEngine.GainCalls.Clear();
+        using var scope = _factory.Services.CreateScope();
+        var radio = scope.ServiceProvider.GetRequiredService<RadioService>();
         using var client = _factory.CreateClient();
 
-        // db=-100 clamps to -40 → gain 10^(-2) = 0.01
+        // db=-100 clamps to -40.
         Assert.Equal(HttpStatusCode.OK,
             (await client.PostAsJsonAsync("/api/mic-gain", new { db = -100 })).StatusCode);
-        // db=50 clamps to +10 → gain 10^(0.5) ≈ 3.1623
+        Assert.Equal(-40, radio.Snapshot().MicGainDb);
+
+        // db=50 clamps to +10.
         Assert.Equal(HttpStatusCode.OK,
             (await client.PostAsJsonAsync("/api/mic-gain", new { db = 50 })).StatusCode);
-
-        Assert.Collection(_factory.TestEngine.GainCalls,
-            v => Assert.Equal(0.01, v, precision: 6),
-            v => Assert.Equal(Math.Pow(10.0, 0.5), v, precision: 6));
+        Assert.Equal(10, radio.Snapshot().MicGainDb);
     }
 
     public sealed class Factory : WebApplicationFactory<Program>

--- a/tests/Zeus.Server.Tests/RadioStateStoreTests.cs
+++ b/tests/Zeus.Server.Tests/RadioStateStoreTests.cs
@@ -60,6 +60,8 @@ public class RadioStateStoreTests : IDisposable
                 AttenDb = 12,
                 AutoAgcEnabled = true,
                 RxAfGainDb = -6.5,
+                MicGainDb = -7,
+                LevelerMaxGainDb = 12.5,
                 ZoomLevel = 4,
                 SsbFilterLoAbs = 300, SsbFilterHiAbs = 2400,
                 CwFilterLoAbs = 400, CwFilterHiAbs = 800,
@@ -85,6 +87,8 @@ public class RadioStateStoreTests : IDisposable
         Assert.Equal(12, got.AttenDb);
         Assert.True(got.AutoAgcEnabled);
         Assert.Equal(-6.5, got.RxAfGainDb);
+        Assert.Equal(-7, got.MicGainDb);
+        Assert.Equal(12.5, got.LevelerMaxGainDb);
         Assert.Equal(4, got.ZoomLevel);
         Assert.Equal(300, got.SsbFilterLoAbs);
         Assert.Equal(2400, got.SsbFilterHiAbs);
@@ -105,6 +109,18 @@ public class RadioStateStoreTests : IDisposable
         var entry = new RadioStateEntry();
         Assert.Equal(0, entry.DrivePct);
         Assert.Equal(10, entry.TunePct);
+    }
+
+    // Older rows written before the TX mic-gain / Leveler-max-gain fields
+    // existed must hydrate with the engine's open-time defaults so a build
+    // upgrade doesn't surprise the operator with a 0 dB Leveler ceiling (no
+    // headroom at all) on the first key after restart.
+    [Fact]
+    public void MicAndLevelerMaxGain_HaveCorrectDefaults_OnNewEntry()
+    {
+        var entry = new RadioStateEntry();
+        Assert.Equal(0, entry.MicGainDb);
+        Assert.Equal(8.0, entry.LevelerMaxGainDb);
     }
 
     // Snapshot is a single global row — saving twice should update, not insert.

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -176,6 +176,12 @@ export type RadioStateDto = {
   autoAgcEnabled: boolean;
   agcOffsetDb: number;
   rxAfGainDb: number;
+  // TX mic gain in dB ([-40, +10]) and TX Leveler max-gain ceiling in dB
+  // ([0, 15]). Server is authoritative; hydrated into tx-store on every fresh
+  // RadioStateDto. Previously localStorage-only and reverted on every restart
+  // when the desktop webview wiped its storage.
+  micGainDb: number;
+  levelerMaxGainDb: number;
   attenDb: number;
   autoAttEnabled: boolean;
   attOffsetDb: number;
@@ -436,6 +442,12 @@ export function normalizeState(raw: unknown): RadioStateDto {
     autoAgcEnabled: typeof r.autoAgcEnabled === 'boolean' ? r.autoAgcEnabled : false,
     agcOffsetDb: typeof r.agcOffsetDb === 'number' ? r.agcOffsetDb : 0,
     rxAfGainDb: typeof r.rxAfGainDb === 'number' ? r.rxAfGainDb : 0,
+    // 0 dB = unity panel-gain (WDSP TXA open-time default).
+    micGainDb: typeof r.micGainDb === 'number' ? r.micGainDb : 0,
+    // 8 dB matches WdspDspEngine.DefaultLevelerMaxGainDb so older servers
+    // without the field hydrate to the same ceiling the engine opens with.
+    levelerMaxGainDb:
+      typeof r.levelerMaxGainDb === 'number' ? r.levelerMaxGainDb : 8,
     // Attenuator value in dB, range 0..31 (HpsdrAtten.MaxDb). 4-button UI
     // sends 0/10/20/30 today; #23 will unlock the full fine-grained range.
     attenDb: typeof r.attenDb === 'number' ? r.attenDb : 0,

--- a/zeus-web/src/components/ConnectPanel.tsx
+++ b/zeus-web/src/components/ConnectPanel.tsx
@@ -50,8 +50,6 @@ import {
   disconnectP2 as apiDisconnectP2,
   fetchRadios,
   fetchState,
-  setLevelerMaxGain,
-  setMicGain,
   type RadioInfoDto,
 } from '../api/client';
 import {
@@ -116,21 +114,16 @@ function parseRawBoardId(raw: string | undefined): number | null {
 
 // Post-connect side-effects shared by discover-click and manual-connect.
 //
-// Drive / TUN drive are now authoritative on the server (StateDto.DrivePct /
-// TunePct, persisted via RadioStateStore). The connect-time response already
-// carries the hydrated values; tx-store.hydrateFromState picks them up from
-// the RadioStateDto returned by /api/connect. Pushing the localStorage mirror
-// back here would clobber the server's just-hydrated values, which is exactly
-// the bug reported for relaunches that didn't restore drive.
-//
-// micGainDb / levelerMaxGainDb don't have a server-authoritative path yet, so
-// they continue to push from localStorage. Migrating them to the same
-// StateDto pattern is the natural follow-up.
+// Drive / TUN drive, mic gain, and Leveler max-gain are all authoritative on
+// the server (StateDto.DrivePct / TunePct / MicGainDb / LevelerMaxGainDb,
+// persisted via RadioStateStore). The connect-time response carries the
+// hydrated values and tx-store.hydrateFromState picks them up; pushing the
+// localStorage mirror back here would clobber the server's just-hydrated
+// values, which is the bug reported for relaunches that didn't restore drive
+// (and the same bug that left mic gain + Leveler reverting on every desktop
+// launch when Photino wiped its storage).
 function applyPostConnectEffects() {
   void getAudioClient().start();
-  const tx = useTxStore.getState();
-  void setMicGain(tx.micGainDb).catch(() => {});
-  void setLevelerMaxGain(tx.levelerMaxGainDb).catch(() => {});
 }
 
 export interface ConnectPanelProps {

--- a/zeus-web/src/state/tx-store.ts
+++ b/zeus-web/src/state/tx-store.ts
@@ -429,6 +429,10 @@ export const useTxStore = create<TxState>()(
           // a first-paint flicker before this hydrate runs.
           drivePercent: s.drivePercent,
           tunePercent: s.tunePercent,
+          // Mic gain + Leveler max-gain — server-authoritative (RadioStateStore).
+          // Previously localStorage-only and reverted on every desktop relaunch.
+          micGainDb: s.micGainDb,
+          levelerMaxGainDb: s.levelerMaxGainDb,
           psAuto: s.psAuto,
           psPtol: s.psPtol,
           psAutoAttenuate: s.psAutoAttenuate,


### PR DESCRIPTION
## Summary
- TX **mic gain** and **Leveler max-gain** previously lived only in frontend `localStorage` and were re-POSTed on connect, so they reverted to defaults whenever the desktop webview wiped its storage between launches.
- Migrate both to the same server-authoritative `RadioStateStore` pattern Drive/TUN/RxAfGain already use. Wire names stay `micGainDb` / `levelerMaxGainDb` to match the existing endpoint POST responses.
- Volume (`RxAfGainDb`) was already wired correctly — `zeus-prefs.db` on disk confirms the last operator value survives restart, so no changes there. If AF still appears to revert, that's a separate bug we should repro together.

## Changes
- `Zeus.Contracts`: new `MicGainDb` (int, [-40, +10]) + `LevelerMaxGainDb` (double, [0, 15]) on `StateDto`.
- `Zeus.Server.Hosting`:
  - `RadioStateStore`: new fields with engine-matching defaults (mic 0, leveler 8.0 ≡ `WdspDspEngine.DefaultLevelerMaxGainDb`).
  - `RadioService`: hydrate on construction; `SetTxMicGain` / `SetTxLevelerMaxGain` mutate state and ride the debounce flush.
  - `DspPipelineService`: apply on broadcast and at channel open. dB → linear (10^(db/20)) for mic gain moves from the endpoint to the engine seam so the persisted form stays operator-friendly dB. NaN-sentinel on the `_applied*` fields forces a first apply even when persisted value equals engine default.
  - `ZeusEndpoints`: route through `RadioService` instead of pushing direct to the engine.
- `zeus-web`:
  - `client.ts`: `RadioStateDto` carries `micGainDb` + `levelerMaxGainDb`; `normalizeState` parses them with the engine defaults as fallback for older servers.
  - `tx-store.hydrateFromState`: pulls both from the DTO.
  - `ConnectPanel.applyPostConnectEffects`: drop the `setMicGain` / `setLevelerMaxGain` localStorage push — it was clobbering the just-hydrated server values.
- Tests:
  - `RadioStateStoreTests`: round-trip + defaults for both fields.
  - `MicGainEndpointTests` / `LevelerMaxGainEndpointTests`: assert against `RadioService.Snapshot()` (the engine call now happens on the `StateChanged` broadcast path; the test factory has no engine open).

## Test plan
- [x] `dotnet test` — 594 server / 152 DSP tests pass
- [x] `npm test` — 213 frontend tests pass
- [x] `dotnet build Zeus.slnx` — clean
- [ ] Bench: HL2, set mic gain to e.g. -10 dB and Leveler to e.g. 3.0 dB, restart `OpenhpsdrZeus`, confirm both sliders come back at the operator-set values (not 0 / 8.0).

## Notes
- Closes zeus-7dt.
- Local `LocalApplicationData` resolves to `~/Library/Application Support/Zeus/zeus-prefs.db` on this Mac — the new fields land alongside the existing `radio_state` row.
- The localStorage mirror in `tx-store`'s `partialize` is left in place — it's still useful in web-mode for first-paint flicker before the server hydrate lands; it's just no longer load-bearing for cross-session persistence.