### PR TITLE
feat(mobile): add ?desktop=1 query param to suppress mobile layout swap

### DIFF
--- a/zeus-web/src/main.tsx
+++ b/zeus-web/src/main.tsx
@@ -111,6 +111,20 @@ try {
   /* private mode — falls back to dark, the default. */
 }
 
+// ?desktop=1 — operator wants the desktop layout preserved in a narrow
+// window (e.g. a small touchscreen as a secondary control surface).
+// Set the attribute synchronously so the ≤900px media block in layout.css
+// (which is scoped to html:not([data-force-desktop="1"])) never applies.
+// useIsMobileViewport() in mobile/MobileApp.tsx honours the same param to
+// suppress the shell swap.
+try {
+  if (new URLSearchParams(window.location.search).get('desktop') === '1') {
+    document.documentElement.setAttribute('data-force-desktop', '1');
+  }
+} catch {
+  /* no-op */
+}
+
 // PERF_PASS_3_DEBUG: window debug helpers for playwright-driven validation.
 (window as unknown as Record<string, unknown>).__zeusPerf3 = {
   txStore: useTxStore,

--- a/zeus-web/src/mobile/MobileApp.tsx
+++ b/zeus-web/src/mobile/MobileApp.tsx
@@ -45,12 +45,15 @@ const MODES: readonly RxMode[] = ['LSB', 'USB', 'CWL', 'CWU', 'AM', 'FM', 'DIGU'
 const MOBILE_QUERY = '(max-width: 900px)';
 
 // Reactive viewport check. `?mobile=1` forces the mobile shell on for desktop
-// previews; everything else honours the matchMedia breakpoint and updates
-// when the window is resized or the device rotates.
+// previews; `?desktop=1` forces it off so the desktop layout survives narrow
+// windows (e.g. a small touchscreen used as a secondary control surface).
+// `?desktop=1` wins when both are present. Otherwise honours the matchMedia
+// breakpoint and updates on resize / device rotation.
 export function useIsMobileViewport(): boolean {
   const [mobile, setMobile] = useState<boolean>(() => {
     if (typeof window === 'undefined') return false;
     const params = new URLSearchParams(window.location.search);
+    if (params.get('desktop') === '1') return false;
     if (params.get('mobile') === '1') return true;
     return window.matchMedia(MOBILE_QUERY).matches;
   });
@@ -58,7 +61,8 @@ export function useIsMobileViewport(): boolean {
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const params = new URLSearchParams(window.location.search);
-    if (params.get('mobile') === '1') return; // forced — no listener needed
+    if (params.get('desktop') === '1') return; // forced off — no listener needed
+    if (params.get('mobile') === '1') return; // forced on — no listener needed
     const mq = window.matchMedia(MOBILE_QUERY);
     const onChange = (e: MediaQueryListEvent) => setMobile(e.matches);
     mq.addEventListener('change', onChange);

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -2047,19 +2047,25 @@
 }
 .mobile-ptt-btn.tx .mobile-ptt-hint { color: rgba(255,255,255,0.85); }
 
-/* ===== Mobile responsive layout (≤640 px) =====
+/* ===== Mobile responsive layout (≤900 px) =====
    Shows only frequency (VFO), signal (S-meter), mic level, power level (drive),
    the panadapter/waterfall stack, and a big hold-to-talk PTT button where the
    logbook sits on desktop. Everything else — QRZ, azimuth map, DSP, CW keyer,
    logbook, TX stage meters, mode/bandwidth, front-end, AGC, zoom, status chips,
-   tweaks panel — is hidden via the .hide-mobile utility. */
+   tweaks panel — is hidden via the .hide-mobile utility.
+
+   Every rule is scoped to html:not([data-force-desktop="1"]) so that the
+   `?desktop=1` query-param override (set in main.tsx) preserves the full
+   desktop layout in a narrow window — used when a small touchscreen is
+   docked as a secondary control surface. */
 @media (max-width: 900px) {
-  .hide-mobile { display: none !important; }
-  .show-mobile { display: flex; }
+  html:not([data-force-desktop="1"]) .hide-mobile { display: none !important; }
+  html:not([data-force-desktop="1"]) .show-mobile { display: flex; }
 
-  html, body { overflow-x: hidden; }
+  html:not([data-force-desktop="1"]),
+  html:not([data-force-desktop="1"]) body { overflow-x: hidden; }
 
-  .app {
+  html:not([data-force-desktop="1"]) .app {
     grid-template-rows: 44px 52px auto 1fr 44px;
     width: 100%;
     padding: 4px;
@@ -2067,20 +2073,20 @@
     overflow-x: hidden;
   }
 
-  .topbar {
+  html:not([data-force-desktop="1"]) .topbar {
     height: 44px;
     padding: 0 8px;
     gap: 6px;
     min-width: 0;
   }
-  .brand { padding: 0 4px; gap: 6px; }
-  .brand-mark { width: 22px; height: 22px; }
-  .brand-name { font-size: 13px; }
+  html:not([data-force-desktop="1"]) .brand { padding: 0 4px; gap: 6px; }
+  html:not([data-force-desktop="1"]) .brand-mark { width: 22px; height: 22px; }
+  html:not([data-force-desktop="1"]) .brand-name { font-size: 13px; }
   /* Compact the connected "RADIO x.x.x.x:pppp" chip — the mono IP overflows
      a 390 px viewport when the Disconnect button sits next to it. */
-  .topbar .chip.accent .v { max-width: 100px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: inline-block; }
+  html:not([data-force-desktop="1"]) .topbar .chip.accent .v { max-width: 100px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: inline-block; }
 
-  .control-strip {
+  html:not([data-force-desktop="1"]) .control-strip {
     height: 52px;
     padding: 2px 6px;
     gap: 8px;
@@ -2089,17 +2095,17 @@
   }
   /* Override inline min-width on the visible ZOOM ctrl-group so it shrinks
      to fit narrow viewports. */
-  .control-strip .ctrl-group { min-width: 0 !important; }
-  .control-strip .btn-row { min-width: 0; flex: 1; }
-  .control-strip .knob-group { min-width: 0; flex: 1; }
+  html:not([data-force-desktop="1"]) .control-strip .ctrl-group { min-width: 0 !important; }
+  html:not([data-force-desktop="1"]) .control-strip .btn-row { min-width: 0; flex: 1; }
+  html:not([data-force-desktop="1"]) .control-strip .knob-group { min-width: 0; flex: 1; }
 
-  .workspace {
+  html:not([data-force-desktop="1"]) .workspace {
     grid-template-columns: 1fr;
     grid-template-rows: minmax(0, 1.4fr) minmax(0, 0.85fr) auto;
     gap: 4px;
   }
-  .workspace .hero { grid-column: 1; grid-row: 1; }
-  .workspace .side-stack {
+  html:not([data-force-desktop="1"]) .workspace .hero { grid-column: 1; grid-row: 1; }
+  html:not([data-force-desktop="1"]) .workspace .side-stack {
     grid-column: 1;
     grid-row: 2;
     flex-direction: column;
@@ -2107,44 +2113,45 @@
     overflow-x: hidden;
     gap: 4px;
   }
-  .workspace .side-stack .side-slot {
+  html:not([data-force-desktop="1"]) .workspace .side-stack .side-slot {
     flex: 0 0 auto;
     min-width: 0;
   }
-  .workspace .side-stack .side-slot.grow {
+  html:not([data-force-desktop="1"]) .workspace .side-stack .side-slot.grow {
     flex: 0 0 auto;
     min-height: 0;
   }
-  .workspace .bottom-row {
+  html:not([data-force-desktop="1"]) .workspace .bottom-row {
     grid-column: 1;
     grid-row: 3;
     grid-template-columns: 1fr;
     min-height: 72px;
   }
 
-  .freq-digits { font-size: 26px; margin: 2px 0; }
-  .freq-panel { padding: 6px; gap: 4px; }
-  .smeter { padding: 6px 8px; gap: 4px; }
-  .smeter-scale { height: 40px; padding: 4px; }
+  html:not([data-force-desktop="1"]) .freq-digits { font-size: 26px; margin: 2px 0; }
+  html:not([data-force-desktop="1"]) .freq-panel { padding: 6px; gap: 4px; }
+  html:not([data-force-desktop="1"]) .smeter { padding: 6px 8px; gap: 4px; }
+  html:not([data-force-desktop="1"]) .smeter-scale { height: 40px; padding: 4px; }
 
-  .transport {
+  html:not([data-force-desktop="1"]) .transport {
     height: 44px;
     padding: 0 6px;
     gap: 4px;
     min-width: 0;
     overflow-x: hidden;
   }
-  .transport .knob-group { min-width: 0; flex: 1; }
+  html:not([data-force-desktop="1"]) .transport .knob-group { min-width: 0; flex: 1; }
 
-  .tweaks-fab,
-  .tweaks-panel { display: none !important; }
+  html:not([data-force-desktop="1"]) .tweaks-fab,
+  html:not([data-force-desktop="1"]) .tweaks-panel { display: none !important; }
 }
 
 /* Touch-target floor for coarse pointers (phones, tablets). Keyed off pointer
    type rather than width so a narrow desktop window doesn't inherit the
-   bigger tap zones. Apple HIG: 44 px minimum for primary targets. */
+   bigger tap zones. Apple HIG: 44 px minimum for primary targets.
+   Scoped the same way so ?desktop=1 keeps the desktop click targets. */
 @media (pointer: coarse) and (max-width: 900px) {
-  .btn     { min-height: 36px; }
-  .btn.lg  { min-height: 44px; }
-  .btn-row { gap: 6px; }
+  html:not([data-force-desktop="1"]) .btn     { min-height: 36px; }
+  html:not([data-force-desktop="1"]) .btn.lg  { min-height: 44px; }
+  html:not([data-force-desktop="1"]) .btn-row { gap: 6px; }
 }


### PR DESCRIPTION
Closes #472

## Problem

When a Zeus browser window is resized below 900 px wide, the app auto-swaps to the mobile shell (\`MobileApp\`) and discards the operator's custom desktop layout. There was no way to opt out.

This blocked a dual-screen workflow a user reported: panadapter on the main monitor in one browser window, a custom-built control layout on a small touchscreen in a second window. As soon as the touchscreen window was sized to its native (narrow) resolution, the desktop layout was replaced by the mobile interface.

## Fix

Mirror the existing \`?mobile=1\` override with \`?desktop=1\` that forces the desktop layout on regardless of viewport width.

There were actually **two** layers of narrow-width behaviour, both gated:

1. **Shell swap** — \`useIsMobileViewport()\` in \`zeus-web/src/mobile/MobileApp.tsx\`. Now checks \`?desktop=1\` first and returns \`false\` (short-circuiting the matchMedia listener) before falling through to \`?mobile=1\` and then the media query. \`?desktop=1\` wins when both params are set.
2. **CSS \`@media (max-width: 900px)\` block** in \`zeus-web/src/styles/layout.css\`. It hides \`.hide-mobile\` topbar controls and rewrites the \`.app\` grid for a phone-sized viewport — that still fired even with the shell-swap suppressed, which is what made the bottom transport jump up and the workspace contents disappear behind it. Fix: set \`data-force-desktop=\"1\"\` on \`<html>\` synchronously in \`main.tsx\` before React mounts, and scope every rule inside both narrow-width media blocks (the layout block and the \`(pointer: coarse) and (max-width: 900px)\` touch-target block) to \`html:not([data-force-desktop=\"1\"])\`.

KISS — no settings panel, no prefs key, just the query param mirror.

## Use case

Operator opens two browser windows pointed at the same backend:

- Window A (main monitor): \`http://host:6060/\` — panadapter + waterfall.
- Window B (touchscreen, narrow): \`http://host:6060/?desktop=1\` — custom control layout, preserved at small size.

## Test plan

- [x] Frontend typecheck (\`npm --prefix zeus-web run typecheck\`) clean.
- [ ] \`http://localhost:5173/?desktop=1\` — resize narrower than 900 px → desktop layout preserved, topbar controls visible, transport pinned at bottom (no jump-up).
- [ ] \`http://localhost:5173/\` — same narrow width → mobile shell still takes over (default behaviour unchanged).
- [ ] \`http://localhost:5173/?mobile=1\` — wide window → still forces mobile on.
- [ ] \`http://localhost:5173/?desktop=1&mobile=1\` — \`?desktop=1\` wins.