### PR TITLE
fix(meters): meter-group tile auto-fits to widget set, bars left-aligned (zeus-b5d)

### DIFF
--- a/zeus-web/src/components/meter-group/MeterGroupPanel.tsx
+++ b/zeus-web/src/components/meter-group/MeterGroupPanel.tsx
@@ -28,6 +28,7 @@ import {
   Trash2,
 } from 'lucide-react';
 import {
+  effectiveKind,
   EMPTY_METER_GROUP_CONFIG,
   newWidgetUid,
   type MeterGroupConfig,
@@ -40,6 +41,19 @@ import {
   MeterReadingId,
   type MeterDefaultKind,
 } from '../meters/meterCatalog';
+
+// Per-kind intrinsic main-axis size (px). The panel body sizes each
+// widget to its own natural footprint and `justify-content: flex-start`
+// packs them to the leading edge — no stretch, no centering. That keeps
+// a single vertical VU bar at bar-width even when the tile is wider, and
+// makes additional bars line up to the left rather than spreading to
+// fill the row.
+const KIND_INTRINSIC_PX: Record<MeterDefaultKind, number> = {
+  vucolumn: 70,   // 60-unit viewBox + lamp-card padding
+  bigarc: 200,    // 240×150 viewBox arc, modest display size
+  pulldown: 230,  // 280×150 viewBox arc
+  hbar: 240,      // wide horizontal bar reads better with room
+};
 
 interface MeterGroupPanelProps {
   /** Per-instance config blob from the workspace store. */
@@ -386,7 +400,16 @@ export function MeterGroupPanel({
             Empty group — tap + to add a meter.
           </div>
         ) : (
-          config.widgets.map((w) => (
+          config.widgets.map((w) => {
+            const intrinsic = KIND_INTRINSIC_PX[effectiveKind(w)];
+            // Main axis = direction; cross axis stretches via the parent's
+            // `alignItems: 'stretch'`. `flex: 0 0 <px>` blocks both grow
+            // and shrink so each widget always reads at its natural size.
+            const sizeAxis =
+              config.direction === 'row'
+                ? { width: intrinsic, flex: `0 0 ${intrinsic}px` as const }
+                : { height: intrinsic, flex: `0 0 ${intrinsic}px` as const };
+            return (
             <div
               key={w.uid}
               data-widget-uid={w.uid}
@@ -396,7 +419,7 @@ export function MeterGroupPanel({
               }
               style={{
                 position: 'relative',
-                flex: '1 1 0',
+                ...sizeAxis,
                 minWidth: 0,
                 minHeight: 0,
                 display: 'flex',
@@ -428,7 +451,8 @@ export function MeterGroupPanel({
                 <Trash2 size={11} />
               </button>
             </div>
-          ))
+            );
+          })
         )}
       </div>
 

--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -17,7 +17,7 @@
 //   - "+ Add Panel" is a single workspace-level button at the top-right,
 //     opening the categorized AddPanelModal.
 
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ResponsiveGridLayout,
   useContainerWidth,
@@ -320,6 +320,7 @@ function MeterGroupTileBody({
   const updateTileInstanceConfig = useLayoutStore(
     (s) => s.updateTileInstanceConfig,
   );
+  const updateTilePlacement = useLayoutStore((s) => s.updateTilePlacement);
   const config: MeterGroupConfig = useMemo(
     () => parseMeterGroupConfig(tile.instanceConfig),
     [tile.instanceConfig],
@@ -330,6 +331,33 @@ function MeterGroupTileBody({
     },
     [tile.uid, updateTileInstanceConfig],
   );
+
+  // Auto-fit the tile to its widget set. Operators add a Meter Group, drop
+  // in two vertical bars, and expect the tile to snap to bar-width — not
+  // to leave four grid columns of empty space waiting to be filled. The
+  // effect deps are widget count + direction only (live tile geometry is
+  // read through a ref) so an operator can still drag-resize the cross
+  // axis without the effect snapping it back on every render.
+  const tileRef = useRef(tile);
+  tileRef.current = tile;
+  useEffect(() => {
+    const t = tileRef.current;
+    const widgetCount = Math.max(1, config.widgets.length);
+    // Row: one grid col per widget on the main axis. Column: ~3 grid rows
+    // per widget so vertical bars get enough vertical span to read.
+    const targetW = config.direction === 'row' ? widgetCount : t.w;
+    const targetH =
+      config.direction === 'column' ? Math.max(3, widgetCount * 3) : t.h;
+    if (targetW !== t.w || targetH !== t.h) {
+      updateTilePlacement(t.uid, {
+        x: t.x,
+        y: t.y,
+        w: targetW,
+        h: targetH,
+      });
+    }
+  }, [config.widgets.length, config.direction, updateTilePlacement]);
+
   return (
     <MeterGroupPanel config={config} setConfig={setConfig} onRemove={onRemove} />
   );

--- a/zeus-web/src/layout/workspace.ts
+++ b/zeus-web/src/layout/workspace.ts
@@ -85,6 +85,11 @@ export const DEFAULT_TILE_SPAN: Record<string, { w: number; h: number }> = {
   band: { w: 6, h: 2 },
   mode: { w: 4, h: 2 },
   meters: { w: 6, h: 8 },
+  // Meter Group auto-fits to its widget set (see MeterGroupTileBody in
+  // FlexWorkspace.tsx) — start at the smallest grid footprint so the
+  // freshly-added tile shows just the empty-state hint, not 4 columns of
+  // blank space waiting for widgets.
+  metergroup: { w: 1, h: 6 },
 };
 
 const FALLBACK_SPAN = { w: 4, h: 4 };


### PR DESCRIPTION
## Summary
- Meter Group widgets sit at their kind's intrinsic main-axis width (vucolumn 70 px, bigarc 200 px, pulldown 230 px, hbar 240 px) and pack to the leading edge — no more flex-grow stretching or centered layout when one or two bars are dropped in.
- The tile itself auto-fits: row direction → width tracks widget count (1 grid col per widget); column direction → height tracks widget count (~3 rows per widget). Cross axis is left alone so manual drag-resize on that axis still sticks.
- Fresh Meter Group tiles default to 1×6 instead of the generic 4×4 fallback, so an empty group doesn't mint four columns of blank space.

Closes zeus-b5d.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` clean in `zeus-web/`
- [x] `npx vitest run` — 24 files, 213 tests pass
- [x] Bench-tested in desktop mode on HL2 — single VU column drops in at bar-width, second column makes it grow to two, removing widgets shrinks the tile back. Cross-axis drag-resize is sticky.
- [ ] Existing persisted Meter Group tiles collapse to fit on next page load (run on a clone with stored layout)