### PR TITLE
fix(display): CW passband overlay off by cw_pitch (#429)

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -289,7 +289,15 @@ public sealed record StateDto(
     // (Thetis: Setup → DSP → Keyer → CW Pitch). On the wire now so
     // the frontend already consumes the live value — when the setting
     // lands, only the server-side source changes.
-    int CwPitchHz = 600);
+    int CwPitchHz = CwDefaults.PitchHz);
+
+/// <summary>Canonical CW constants shared between backend and wire DTOs.
+/// Single source of truth — CwOffset (server-side) and StateDto both
+/// reference these instead of duplicating magic numbers.</summary>
+public static class CwDefaults
+{
+    public const int PitchHz = 600;
+}
 
 public sealed record RadioInfo(
     string MacAddress,

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -282,7 +282,14 @@ public sealed record StateDto(
     // state hydration; RadioService snaps it to VfoHz at construction so the
     // displayed centre is never zero. Mirrors Thetis CTUN's frozen-NCO model
     // (console.cs:43143-43170), now Zeus's only tuning model.
-    long RadioLoHz = 0);
+    long RadioLoHz = 0,
+
+    // CW sidetone pitch in Hz. Currently a baked-in constant
+    // (CwDefaults.PitchHz); will become a user-settable preference
+    // (Thetis: Setup → DSP → Keyer → CW Pitch). On the wire now so
+    // the frontend already consumes the live value — when the setting
+    // lands, only the server-side source changes.
+    int CwPitchHz = 600);
 
 public sealed record RadioInfo(
     string MacAddress,

--- a/Zeus.Server.Hosting/CwOffset.cs
+++ b/Zeus.Server.Hosting/CwOffset.cs
@@ -21,7 +21,7 @@ namespace Zeus.Server;
 // 600 Hz off the signal to hear it.
 internal static class CwOffset
 {
-    public const int CwPitchHz = 600;
+    public const int CwPitchHz = CwDefaults.PitchHz;
 
     // Effective hardware LO for the supplied dial frequency. Non-CW modes
     // pass through unchanged so SSB / AM / FM / DIG behaviour is bit-for-bit

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -305,7 +305,8 @@ public sealed class RadioService : IDisposable
             // unconditional — see docs/prd/panfall_behavior.md.
             RadioLoHz: (rsSnap?.RadioLoHz ?? 0L) != 0L
                 ? rsSnap!.RadioLoHz
-                : (rsSnap?.VfoHz ?? 14_200_000));
+                : (rsSnap?.VfoHz ?? 14_200_000),
+            CwPitchHz: CwOffset.CwPitchHz);
 
         // Kick off the debounce flush timer. Fires every 1 s; only writes to
         // LiteDB when _stateDirty is set (i.e., at least one Mutate() has fired

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -231,6 +231,9 @@ export type RadioStateDto = {
   // external CAT). The legacy CTUN toggle was removed in the pure-pan rework
   // (PRD: docs/prd/panfall_behavior.md); this is now the only tuning model.
   radioLoHz: number;
+  // CW sidetone pitch in Hz. Today a baked-in constant (600); exposed so
+  // the frontend doesn't duplicate it. Will become configurable later.
+  cwPitchHz: number;
 };
 
 // CFC mirrors Zeus.Contracts.CfcConfig. Bands array is fixed at 10 entries
@@ -499,6 +502,7 @@ export function normalizeState(raw: unknown): RadioStateDto {
         : typeof r.vfoHz === 'number'
         ? r.vfoHz
         : 0,
+    cwPitchHz: typeof r.cwPitchHz === 'number' ? r.cwPitchHz : 600,
   };
 }
 

--- a/zeus-web/src/components/PassbandOverlay.tsx
+++ b/zeus-web/src/components/PassbandOverlay.tsx
@@ -59,8 +59,9 @@ import { useConnectionStore } from '../state/connection-store';
 //
 // CW fix (issue #429): filter edges are baseband Hz relative to the LO,
 // not the dial. In CW the LO sits ±cw_pitch from the dial, so we anchor
-// at loHz = vfoHz − cwPitch instead of vfoHz. Mirrors Thetis PanDisplay.cs.
-const CW_PITCH_HZ = 600;
+// at loHz = vfoHz − cwPitch instead of vfoHz. cwPitchHz comes from the
+// server (StateDto.CwPitchHz → CwDefaults.PitchHz). Mirrors Thetis
+// PanDisplay.cs:1213.
 export function PassbandOverlay() {
   const centerHz = useDisplayStore((s) => s.centerHz);
   const hzPerPixel = useDisplayStore((s) => s.hzPerPixel);
@@ -73,6 +74,7 @@ export function PassbandOverlay() {
   const filterHighHz = useConnectionStore((s) => s.filterHighHz);
   const vfoHz = useConnectionStore((s) => s.vfoHz);
   const mode = useConnectionStore((s) => s.mode);
+  const cwPitchHz = useConnectionStore((s) => s.cwPitchHz);
 
   if (!width || hzPerPixel <= 0) return null;
 
@@ -84,7 +86,7 @@ export function PassbandOverlay() {
   // sits cw_pitch below (CWU) or above (CWL) the dial; in all other
   // modes LO == dial. Mirrors Thetis PanDisplay.cs:1213-1214 which
   // positions filter edges relative to Low (the LO-based display edge).
-  const cwOffset = mode === 'CWU' ? CW_PITCH_HZ : mode === 'CWL' ? -CW_PITCH_HZ : 0;
+  const cwOffset = mode === 'CWU' ? cwPitchHz : mode === 'CWL' ? -cwPitchHz : 0;
   const loHz = vfoHz - cwOffset;
   const passLowHz = loHz + filterLowHz;
   const passHighHz = loHz + filterHighHz;

--- a/zeus-web/src/components/PassbandOverlay.tsx
+++ b/zeus-web/src/components/PassbandOverlay.tsx
@@ -56,6 +56,11 @@ import { useConnectionStore } from '../state/connection-store';
 // independently. Anchoring the passband to vfoHz — not centerHz — keeps the
 // filter overlay glued to the operator's tuned signal so clicking the
 // spectrum visibly slides the passband around the (stationary) waterfall.
+//
+// CW fix (issue #429): filter edges are baseband Hz relative to the LO,
+// not the dial. In CW the LO sits ±cw_pitch from the dial, so we anchor
+// at loHz = vfoHz − cwPitch instead of vfoHz. Mirrors Thetis PanDisplay.cs.
+const CW_PITCH_HZ = 600;
 export function PassbandOverlay() {
   const centerHz = useDisplayStore((s) => s.centerHz);
   const hzPerPixel = useDisplayStore((s) => s.hzPerPixel);
@@ -67,6 +72,7 @@ export function PassbandOverlay() {
   const filterLowHz = useConnectionStore((s) => s.filterLowHz);
   const filterHighHz = useConnectionStore((s) => s.filterHighHz);
   const vfoHz = useConnectionStore((s) => s.vfoHz);
+  const mode = useConnectionStore((s) => s.mode);
 
   if (!width || hzPerPixel <= 0) return null;
 
@@ -74,8 +80,14 @@ export function PassbandOverlay() {
   const center = Number(centerHz) + viewportOffsetHz;
   const startHz = center - spanHz / 2;
 
-  const passLowHz = vfoHz + filterLowHz;
-  const passHighHz = vfoHz + filterHighHz;
+  // Anchor the filter overlay at the LO, not at the dial. In CW the LO
+  // sits cw_pitch below (CWU) or above (CWL) the dial; in all other
+  // modes LO == dial. Mirrors Thetis PanDisplay.cs:1213-1214 which
+  // positions filter edges relative to Low (the LO-based display edge).
+  const cwOffset = mode === 'CWU' ? CW_PITCH_HZ : mode === 'CWL' ? -CW_PITCH_HZ : 0;
+  const loHz = vfoHz - cwOffset;
+  const passLowHz = loHz + filterLowHz;
+  const passHighHz = loHz + filterHighHz;
   const leftPct = ((passLowHz - startHz) / spanHz) * 100;
   const rightPct = ((passHighHz - startHz) / spanHz) * 100;
   const widthPct = rightPct - leftPct;

--- a/zeus-web/src/state/connection-store.ts
+++ b/zeus-web/src/state/connection-store.ts
@@ -69,6 +69,7 @@ export type ConnectionState = {
   // / external-CAT retunes; never by panadapter drags (those just move the
   // viewport visually until released past the IQ window edge).
   radioLoHz: number;
+  cwPitchHz: number;
   mode: RxMode;
   filterLowHz: number;
   filterHighHz: number;
@@ -126,6 +127,7 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
   endpoint: null,
   vfoHz: 14_200_000,
   radioLoHz: 14_200_000,
+  cwPitchHz: 600,
   mode: 'USB',
   filterLowHz: 150,
   filterHighHz: 2850,
@@ -159,6 +161,7 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
       endpoint: s.endpoint,
       vfoHz: s.vfoHz,
       radioLoHz: s.radioLoHz,
+      cwPitchHz: s.cwPitchHz,
       mode: s.mode,
       filterLowHz: s.filterLowHz,
       filterHighHz: s.filterHighHz,


### PR DESCRIPTION
Trying to use Zeus for real CW work, the operator sees the passband
overlay shifted away from the signal they're actually listening to.
A carrier at zero-beat sits on the VFO line but outside the filter
shading — confusing enough to make CW operation painful. This fixes
issue #429.

## What's wrong

PassbandOverlay.tsx anchors the filter edges at the dial (vfoHz), but
filter edges are baseband Hz relative to the LO. In SSB the LO equals
the dial so nobody notices. In CW the LO sits ±cw_pitch from the dial,
shifting the overlay by 600 Hz. Thetis doesn't have this problem — it
anchors at the LO (PanDisplay.cs:1213).

## What changes

- The passband overlay in CW now wraps around the signal, matching
  Thetis and matching what the operator's ears tell them.

- CwPitchHz is exposed in StateDto so the frontend reads the pitch
  from the server instead of hardcoding 600. When the pitch becomes a
  user setting (Thetis: Setup → DSP → Keyer → CW Pitch), the frontend
  follows without code changes.

- Single source of truth: CwDefaults.PitchHz in Zeus.Contracts.
  CwOffset.CwPitchHz is now an alias. No duplicate constants that
  could silently diverge.

## Test plan

- [ ] CWU: tune a CW signal, verify the filter overlay centres on it
- [ ] CWL: same check, mirrored
- [ ] USB/LSB/AM: unchanged (LO == VFO, no offset)
- [ ] CTUN + CW: overlay follows click-tune correctly
- [ ] `GET /api/state` includes `cwPitchHz: 600`