### PR TITLE
fix(hl2): propagate hardware-PTT/CW key state into host MOX

### DIFF
--- a/Zeus.Protocol1/IProtocol1Client.cs
+++ b/Zeus.Protocol1/IProtocol1Client.cs
@@ -128,6 +128,24 @@ public interface IProtocol1Client : IDisposable
     event Action<AdcOverloadStatus>? AdcOverloadObserved;
 
     /// <summary>
+    /// Raised on a level change of the hardware-PTT echo bit (C0[0]) coming
+    /// back from the radio. On HL2 the gateware ORs in the rear KEY tip and
+    /// the external PTT line, so this rises whenever the operator keys the
+    /// radio directly without going through the host. It ALSO rises as a
+    /// loopback of any host-issued <see cref="SetMox(bool)"/>, so consumers
+    /// must check the host's current MOX/TUN state to disambiguate.
+    /// Edge-triggered: handler is called once per change. Fires on the RX
+    /// thread; handlers must not block.
+    /// </summary>
+    event Action<bool>? HardwarePttChanged;
+
+    /// <summary>
+    /// Latest hardware-PTT echo level. Volatile; safe to read from any
+    /// thread. Updated from the RX loop on every received EP6 packet.
+    /// </summary>
+    bool HardwarePtt { get; }
+
+    /// <summary>
     /// Select the radio's wire-level board family. Affects the extended
     /// attenuator byte layout (HL2 vs bare HPSDR) and the N2ADR filter-board
     /// OC pin encoding. Defaults to <see cref="HpsdrBoardKind.HermesLite2"/>.

--- a/Zeus.Protocol1/PacketParser.cs
+++ b/Zeus.Protocol1/PacketParser.cs
@@ -98,6 +98,28 @@ internal static class PacketParser
     private const double Int24Scale = 1.0 / 8_388_608.0; // 1 / 2^23
 
     /// <summary>
+    /// Extract the hardware-PTT echo bit from a parsed EP6 packet — C0[0] of
+    /// each USB frame OR'd together. The HL2 gateware sets this whenever the
+    /// rear KEY tip is grounded or an external PTT line is asserted (HL2
+    /// protocol doc §"Hermes Lite 2-specific behaviour", line 200): "When the
+    /// tip is grounded, both C0[0] and C0[2] are sent as one." Same wire bit
+    /// also echoes a host-driven MOX request, so consumers MUST gate on the
+    /// host's current MOX state to disambiguate "external key" from "echo of
+    /// our own outbound MOX".
+    /// </summary>
+    /// <returns>true if either USB frame's C0[0] is set, false otherwise.
+    /// Returns false for packets shorter than expected (the only caller has
+    /// already validated length via <see cref="TryParsePacket(System.ReadOnlySpan{byte},System.Span{double},out uint,out int)"/>).</returns>
+    public static bool ExtractHardwarePtt(ReadOnlySpan<byte> packet)
+    {
+        if (packet.Length < PacketLength) return false;
+        // usb[3] is c0; bit 0 is the PTT/MOX echo.
+        byte c0Frame0 = packet[MetisHeaderLength + 3];
+        byte c0Frame1 = packet[MetisHeaderLength + UsbFrameLength + 3];
+        return ((c0Frame0 | c0Frame1) & 0x01) != 0;
+    }
+
+    /// <summary>
     /// Read a 24-bit big-endian signed integer with sign-extension to int32.
     /// </summary>
     public static int ReadInt24BigEndian(ReadOnlySpan<byte> b)

--- a/Zeus.Protocol1/Protocol1Client.cs
+++ b/Zeus.Protocol1/Protocol1Client.cs
@@ -150,6 +150,28 @@ public sealed class Protocol1Client : IProtocol1Client
 
     public event Action<TelemetryReading>? TelemetryReceived;
     public event Action<AdcOverloadStatus>? AdcOverloadObserved;
+    public event Action<bool>? HardwarePttChanged;
+
+    // 0/1; Volatile so the property read on any thread sees the latest value
+    // without needing a lock.
+    private int _hardwarePtt;
+    public bool HardwarePtt => Volatile.Read(ref _hardwarePtt) != 0;
+
+    /// <summary>
+    /// Update the cached hardware-PTT level from a freshly-parsed packet and
+    /// fire <see cref="HardwarePttChanged"/> if the level flipped. Called
+    /// exclusively from the RX loop (single writer) so a CAS isn't needed —
+    /// a plain Volatile.Write + compare is correct.
+    /// </summary>
+    private void UpdateHardwarePtt(bool ptt)
+    {
+        int prev = Volatile.Read(ref _hardwarePtt);
+        int next = ptt ? 1 : 0;
+        if (prev == next) return;
+        Volatile.Write(ref _hardwarePtt, next);
+        try { HardwarePttChanged?.Invoke(ptt); }
+        catch (Exception ex) { _log.LogWarning(ex, "HardwarePttChanged handler threw"); }
+    }
 
     // ---- PureSignal feedback (HL2-only, P1) -------------------------
     // 1024-sample paired blocks fed to WDSP `psccF`. Mirrors P2's
@@ -270,6 +292,10 @@ public sealed class Protocol1Client : IProtocol1Client
             }
             try { AdcOverloadObserved?.Invoke(AdcOverloadStatus.FromBits(overloadBits)); }
             catch (Exception ex) { _log.LogWarning(ex, "AdcOverloadObserved handler threw"); }
+
+            // Mirror the standard-path hardware-PTT level update so an
+            // external key released during PS+TX still propagates the edge.
+            UpdateHardwarePtt(PacketParser.ExtractHardwarePtt(packet));
 
             // DDC0 → IqFrame channel — keeps panadapter / audio alive during PS+TX.
             // Use a fresh rented buffer the channel can own; the ddc0 rental is
@@ -762,6 +788,11 @@ public sealed class Protocol1Client : IProtocol1Client
                 // needs cleared-frame signals as well as set ones to decay the offset.
                 try { AdcOverloadObserved?.Invoke(AdcOverloadStatus.FromBits(overloadBits)); }
                 catch (Exception ex) { _log.LogWarning(ex, "AdcOverloadObserved handler threw"); }
+
+                // Hardware-PTT (C0[0]) echo from the radio. Fires on edge so
+                // ExternalPttService can lift the host MOX when the operator
+                // keys the rear KEY jack or an external PTT line.
+                UpdateHardwarePtt(PacketParser.ExtractHardwarePtt(buffer.AsSpan(0, n)));
 
                 var rateHz = (HpsdrSampleRate)Volatile.Read(ref _rate) switch
                 {

--- a/Zeus.Server.Hosting/ExternalPttService.cs
+++ b/Zeus.Server.Hosting/ExternalPttService.cs
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Microsoft.Extensions.Hosting;
+using Zeus.Protocol1;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Promotes the radio's hardware-PTT echo (C0[0] of every inbound EP6 frame)
+/// into a host-side MOX request. The HL2 gateware generates a shaped CW
+/// envelope on its own whenever the rear KEY tip is grounded — protocol doc
+/// line 200 — so the radio transmits without any host involvement. Without
+/// this service the host stays unkeyed: the MOX UI indicator never lights,
+/// TX meters stay at idle cadence, PsAutoAttenuate doesn't engage, and the
+/// FR-6 120 s TX-timeout never arms.
+///
+/// State machine (per-connection):
+///   • inbound rising AND host MOX/TUN/TwoTone off → claim MOX via
+///     <c>TxService.TrySetMox(true)</c>, mark <c>_owned</c>.
+///   • inbound falling → arm a hang timer (<see cref="HangTime"/>). A rising
+///     edge inside the window cancels it (inter-character CW spaces).
+///   • hang elapsed AND inbound still low AND <c>_owned</c> → release MOX.
+///   • UI/TCI/trip drops MOX externally → <c>_owned</c> clears so the next
+///     hang timer doesn't re-release what someone else changed.
+///
+/// Inbound echo of host-initiated MOX (operator clicks the UI button) lands
+/// here too, but the <c>IsMoxOn || IsTunOn || IsTwoToneOn</c> gate ignores
+/// it because the host is already the source of truth.
+/// </summary>
+public sealed class ExternalPttService : IHostedService, IDisposable
+{
+    // CW operators expect TX to bridge inter-character spaces. 250 ms matches
+    // Thetis's default CW hang — long enough for a ~25 wpm character gap
+    // (~80 ms) plus margin, short enough that releasing a straight key feels
+    // immediate. Not configurable yet; if operators ask for a knob it lives
+    // on the per-mode DSP settings panel alongside the CW pitch.
+    private static readonly TimeSpan HangTime = TimeSpan.FromMilliseconds(250);
+
+    private readonly RadioService _radio;
+    private readonly TxService _tx;
+    private readonly ILogger<ExternalPttService> _log;
+
+    private readonly object _sync = new();
+    private IProtocol1Client? _client;
+    // True iff the most recent MOX-on we caused has not been released yet.
+    // Cleared by the hang-release path, by TxActiveChanged(false) from any
+    // other source, and by disconnect.
+    private bool _owned;
+    // Single-shot timer used to debounce falling edges. Created lazily and
+    // re-armed via Change(); the underlying System.Threading.Timer is thread
+    // safe so cancellation from the RX thread and fire-and-handle on the
+    // ThreadPool coexist cleanly.
+    private Timer? _hangTimer;
+
+    public ExternalPttService(RadioService radio, TxService tx, ILogger<ExternalPttService> log)
+    {
+        _radio = radio;
+        _tx = tx;
+        _log = log;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _radio.Connected += OnConnected;
+        _radio.Disconnected += OnDisconnected;
+        _tx.TxActiveChanged += OnTxActiveChanged;
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _radio.Connected -= OnConnected;
+        _radio.Disconnected -= OnDisconnected;
+        _tx.TxActiveChanged -= OnTxActiveChanged;
+        IProtocol1Client? client;
+        lock (_sync) { client = _client; _client = null; _owned = false; }
+        if (client is not null) client.HardwarePttChanged -= OnHardwarePttChanged;
+        _hangTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+        return Task.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _hangTimer?.Dispose();
+    }
+
+    private void OnConnected(IProtocol1Client client)
+    {
+        lock (_sync) { _client = client; _owned = false; }
+        client.HardwarePttChanged += OnHardwarePttChanged;
+    }
+
+    private void OnDisconnected()
+    {
+        IProtocol1Client? client;
+        lock (_sync) { client = _client; _client = null; _owned = false; }
+        if (client is not null) client.HardwarePttChanged -= OnHardwarePttChanged;
+        _hangTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+    }
+
+    private void OnHardwarePttChanged(bool on)
+    {
+        if (on) HandleRising();
+        else HandleFalling();
+    }
+
+    private void HandleRising()
+    {
+        // Cancel any pending hang-release — operator re-keyed before the
+        // window expired (inter-character CW gap).
+        _hangTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+
+        // Host is already the source of truth. Ignore the echo.
+        if (_tx.IsMoxOn || _tx.IsTunOn || _tx.IsTwoToneOn) return;
+
+        lock (_sync)
+        {
+            if (_owned) return;
+            _owned = true;
+        }
+
+        // TxService.TrySetMox locks, broadcasts via the hub, and pokes WDSP
+        // through DspPipelineService — work we don't want on the RX thread.
+        // The fire-and-forget Task.Run is OK because OnHardwarePttChanged is
+        // already edge-triggered (single rise per external press) and a
+        // subsequent fall is handled by HandleFalling regardless of ordering.
+        _ = Task.Run(() =>
+        {
+            if (_tx.TrySetMox(true, out var err))
+            {
+                _log.LogInformation("externalPtt.takeover.applied");
+            }
+            else
+            {
+                _log.LogWarning("externalPtt.takeover.rejected reason={Reason}", err);
+                lock (_sync) _owned = false;
+            }
+        });
+    }
+
+    private void HandleFalling()
+    {
+        // Arm or re-arm the single-shot hang timer. If we don't own the MOX
+        // (UI is driving) the eventual fire will short-circuit via _owned=false
+        // — but we still arm so a subsequent UI-release after the external key
+        // returns to the steady "external is low, _owned is false" state.
+        var timer = _hangTimer;
+        if (timer is null)
+        {
+            timer = new Timer(OnHangElapsed, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+            _hangTimer = timer;
+        }
+        timer.Change(HangTime, Timeout.InfiniteTimeSpan);
+    }
+
+    private void OnHangElapsed(object? _)
+    {
+        // Race guard: a rising edge inside the hang window cancels the timer,
+        // but the timer can already be in-flight on the ThreadPool when the
+        // cancel arrives. Re-check the latest level before acting.
+        var client = _client;
+        if (client is not null && client.HardwarePtt) return;
+
+        bool releaseNow;
+        lock (_sync) { releaseNow = _owned; _owned = false; }
+        if (!releaseNow) return;
+
+        if (_tx.TrySetMox(false, out var err))
+        {
+            _log.LogInformation("externalPtt.release.applied");
+        }
+        else
+        {
+            _log.LogWarning("externalPtt.release.rejected reason={Reason}", err);
+        }
+    }
+
+    private void OnTxActiveChanged(bool active)
+    {
+        // Any drop of TX-active state from outside our control (UI release,
+        // SWR trip, TCI ZZTX0, …) invalidates our ownership claim. The next
+        // external rise will re-acquire; the next external fall will no-op.
+        if (active) return;
+        lock (_sync) _owned = false;
+    }
+}

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -248,6 +248,11 @@ public static class ZeusHost
         // the 128..181 ideal window, so PS has a recovery path on first arm. Idle
         // when PS is off or AutoAttenuate is off — no wire, no engine pokes.
         builder.Services.AddHostedService<PsAutoAttenuateService>();
+        // Promote the radio's hardware-PTT echo (HL2 rear KEY tip, external
+        // PTT line) into a host MOX request — without it the gateware-driven
+        // CW carrier transmits while Zeus stays unkeyed (UI off, meters at
+        // idle cadence, FR-6 timeout disarmed).
+        builder.Services.AddHostedService<ExternalPttService>();
 
         // QRZ.com XML client. HttpClient default timeout is 100 s — cap at 10 s so a
         // hung login surfaces quickly in the UI.

--- a/tests/Zeus.Protocol1.Tests/PacketParserTests.cs
+++ b/tests/Zeus.Protocol1.Tests/PacketParserTests.cs
@@ -376,4 +376,51 @@ public class PacketParserTests
             out _, out _, out _, out _, out byte bits));
         Assert.Equal(0x03, bits);
     }
+
+    // ---- ExtractHardwarePtt -------------------------------------------------
+    // C0[0] is the PTT/MOX echo set by the HL2 gateware whenever the radio is
+    // keying — host-driven MOX, rear KEY tip grounded, or external PTT line
+    // asserted (HL2 protocol doc line 200). ExternalPttService consumes this
+    // edge to follow hardware-initiated TX.
+
+    [Fact]
+    public void ExtractHardwarePtt_BothFramesClear_ReturnsFalse()
+    {
+        byte[] packet = FramingTests.BuildValidPacket(1, new (int, int)[PacketParser.ComplexSamplesPerPacket]);
+        Assert.False(PacketParser.ExtractHardwarePtt(packet));
+    }
+
+    [Fact]
+    public void ExtractHardwarePtt_FirstFrameC0Bit0_ReturnsTrue()
+    {
+        byte[] packet = FramingTests.BuildValidPacket(1, new (int, int)[PacketParser.ComplexSamplesPerPacket]);
+        packet[8 + 3] |= 0x01;
+        Assert.True(PacketParser.ExtractHardwarePtt(packet));
+    }
+
+    [Fact]
+    public void ExtractHardwarePtt_SecondFrameC0Bit0_ReturnsTrue()
+    {
+        byte[] packet = FramingTests.BuildValidPacket(1, new (int, int)[PacketParser.ComplexSamplesPerPacket]);
+        packet[8 + 512 + 3] |= 0x01;
+        Assert.True(PacketParser.ExtractHardwarePtt(packet));
+    }
+
+    [Fact]
+    public void ExtractHardwarePtt_IgnoresOtherC0Bits()
+    {
+        // Bits 7:1 of C0 carry the address; only bit 0 is the PTT echo. Set
+        // every other bit on both frames and expect false.
+        byte[] packet = FramingTests.BuildValidPacket(1, new (int, int)[PacketParser.ComplexSamplesPerPacket]);
+        packet[8 + 3] = 0xFE;
+        packet[8 + 512 + 3] = 0xFE;
+        Assert.False(PacketParser.ExtractHardwarePtt(packet));
+    }
+
+    [Fact]
+    public void ExtractHardwarePtt_ShortPacket_ReturnsFalse()
+    {
+        // Defensive guard for callers that don't pre-validate length.
+        Assert.False(PacketParser.ExtractHardwarePtt(new byte[10]));
+    }
 }

--- a/tests/Zeus.Protocol1.Tests/Protocol1Client_HardwarePttEventTests.cs
+++ b/tests/Zeus.Protocol1.Tests/Protocol1Client_HardwarePttEventTests.cs
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using Xunit;
+using Zeus.Contracts;
+
+namespace Zeus.Protocol1.Tests;
+
+/// <summary>
+/// End-to-end test for the HardwarePttChanged event. Spins up a real
+/// Protocol1Client against a loopback UDP socket pretending to be a radio,
+/// sends EP6 packets with C0[0] toggled, and asserts the client raises the
+/// event exactly once per level change (edge-triggered, ignores no-op
+/// packets that keep the level the same).
+/// </summary>
+public class Protocol1Client_HardwarePttEventTests
+{
+    [Fact]
+    public async Task HardwarePttChanged_FiresOncePerLevelChange()
+    {
+        using var fakeRadio = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        fakeRadio.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        fakeRadio.ReceiveTimeout = 500;
+        var fakeRadioEp = (IPEndPoint)fakeRadio.LocalEndPoint!;
+
+        using var client = new Protocol1Client();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var observed = new List<bool>();
+        var firstEdgeGate = new TaskCompletionSource();
+        client.HardwarePttChanged += level =>
+        {
+            lock (observed)
+            {
+                observed.Add(level);
+                if (observed.Count == 1) firstEdgeGate.TrySetResult();
+            }
+        };
+
+        await client.ConnectAsync(fakeRadioEp, cts.Token);
+        await client.StartAsync(
+            new StreamConfig(HpsdrSampleRate.Rate192k, PreampOn: false, Atten: HpsdrAtten.Zero),
+            cts.Token);
+
+        // Drain Metis-start to learn the client's local port.
+        IPEndPoint clientEp = ReceiveFirstFromClient(fakeRadio);
+
+        // Send: off, off, on, on, off, on — expect events at levels 3, 5, 6
+        // (positions where the level *changed*). The initial run of "off"
+        // matches the client's startup state (_hardwarePtt=0) so the first
+        // event is the rise to "on".
+        var sequence = new[] { false, false, true, true, false, true };
+        for (uint seq = 0; seq < sequence.Length; seq++)
+        {
+            var packet = BuildEp6Packet(seq, hardwarePtt: sequence[seq]);
+            fakeRadio.SendTo(packet, clientEp);
+        }
+
+        await firstEdgeGate.Task.WaitAsync(TimeSpan.FromSeconds(2), cts.Token);
+        // Grace for the remaining packets to be drained by the RX loop.
+        await Task.Delay(200, cts.Token);
+
+        await client.StopAsync(CancellationToken.None);
+        await client.DisconnectAsync(CancellationToken.None);
+
+        List<bool> captured;
+        lock (observed) captured = new(observed);
+
+        // Exactly three edges from the input sequence.
+        Assert.Equal(new[] { true, false, true }, captured);
+        Assert.True(client.HardwarePtt, "final level read should match the last packet (PTT on)");
+    }
+
+    [Fact]
+    public async Task HardwarePttChanged_FiresOnEitherUsbFrameSettingTheBit()
+    {
+        using var fakeRadio = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        fakeRadio.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        fakeRadio.ReceiveTimeout = 500;
+        var fakeRadioEp = (IPEndPoint)fakeRadio.LocalEndPoint!;
+
+        using var client = new Protocol1Client();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var gate = new TaskCompletionSource<bool>();
+        client.HardwarePttChanged += level => gate.TrySetResult(level);
+
+        await client.ConnectAsync(fakeRadioEp, cts.Token);
+        await client.StartAsync(
+            new StreamConfig(HpsdrSampleRate.Rate192k, PreampOn: false, Atten: HpsdrAtten.Zero),
+            cts.Token);
+
+        IPEndPoint clientEp = ReceiveFirstFromClient(fakeRadio);
+
+        // First USB frame clear, second carries the PTT bit — combined OR
+        // should still raise the rising-edge event.
+        var packet = new byte[1032];
+        packet[0] = 0xEF; packet[1] = 0xFE; packet[2] = 0x01; packet[3] = 0x06;
+        BinaryPrimitives.WriteUInt32BigEndian(packet.AsSpan(4, 4), 0u);
+        for (int f = 0; f < 2; f++)
+        {
+            int fs = 8 + f * 512;
+            packet[fs + 0] = 0x7F; packet[fs + 1] = 0x7F; packet[fs + 2] = 0x7F;
+            packet[fs + 3] = 0x00;
+        }
+        // Set C0[0] on the second USB frame only.
+        packet[8 + 512 + 3] = 0x01;
+        fakeRadio.SendTo(packet, clientEp);
+
+        var observed = await gate.Task.WaitAsync(TimeSpan.FromSeconds(2), cts.Token);
+
+        await client.StopAsync(CancellationToken.None);
+        await client.DisconnectAsync(CancellationToken.None);
+
+        Assert.True(observed);
+    }
+
+    private static IPEndPoint ReceiveFirstFromClient(Socket fakeRadio)
+    {
+        var buf = new byte[2048];
+        EndPoint remote = new IPEndPoint(IPAddress.Any, 0);
+        fakeRadio.ReceiveFrom(buf, ref remote);
+        return (IPEndPoint)remote;
+    }
+
+    private static byte[] BuildEp6Packet(uint seq, bool hardwarePtt)
+    {
+        var packet = new byte[1032];
+        packet[0] = 0xEF; packet[1] = 0xFE; packet[2] = 0x01; packet[3] = 0x06;
+        BinaryPrimitives.WriteUInt32BigEndian(packet.AsSpan(4, 4), seq);
+
+        byte c0 = hardwarePtt ? (byte)0x01 : (byte)0x00;
+        for (int f = 0; f < 2; f++)
+        {
+            int fs = 8 + f * 512;
+            packet[fs + 0] = 0x7F; packet[fs + 1] = 0x7F; packet[fs + 2] = 0x7F;
+            packet[fs + 3] = c0; // C0[0] = PTT echo (bits 7:3 = 0 → non-AIN address)
+        }
+        return packet;
+    }
+}


### PR DESCRIPTION
## Summary

The HL2 gateware drives a shaped CW carrier on its own when the rear KEY tip is grounded (HL2 protocol doc line 200). It echoes the state in every EP6 USB frame as C0[0], but the parser discarded those bits — the radio transmitted while Zeus stayed unkeyed (MOX indicator off, TX meters at idle cadence, PsAutoAttenuate dormant, FR-6 timeout disarmed, SWR trip disarmed).

- \`PacketParser.ExtractHardwarePtt\` OR's C0[0] from both USB frames.
- \`Protocol1Client\` tracks the level (volatile) and raises \`HardwarePttChanged\` on edge.
- \`ExternalPttService\` (new hosted service) claims MOX via \`TxService.TrySetMox(true)\` on the rising edge — but only when the host isn't already driving MOX/TUN/TwoTone. Falling edge arms a 250 ms hang timer (matches Thetis CW hang) so inter-character CW gaps don't drop TX. Ownership is cleared on any external \`TxActiveChanged(false)\` so UI/TCI/trip releases can't be fought by a stale hang.

Closes bd \`zeus-xcz\`.

## Test plan

- [x] Unit: \`PacketParser.ExtractHardwarePtt\` across both USB frames, ignoring bits 7:1, short-packet guard.
- [x] Integration: \`Protocol1Client_HardwarePttEventTests\` drives a real client against a loopback UDP socket and asserts edge-trigger semantics end-to-end.
- [x] \`dotnet test Zeus.slnx\` — 191/191 in Protocol1 tests (7 new), full solution green.
- [x] Bench: HL2 + external CW paddle. MOX UI lights up on first dot, holds through inter-character gaps, releases ~250 ms after the last element. UI MOX button still works and is not affected by the hang timer.

## Out of scope

Protocol-2 hi-priority status already decodes \`PttIn\` but doesn't wire it into \`TxService\` either — same shape of fix in a separate PR.