### PR TITLE
CW engine core: host-side keying, /api/cw/send, MoxSource ownership

### DIFF
--- a/Zeus.Contracts/CwEngineStatus.cs
+++ b/Zeus.Contracts/CwEngineStatus.cs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+
+namespace Zeus.Contracts;
+
+/// <summary>
+/// Top-level state of the host-side CW engine. Reported on
+/// <c>CwEngine.Status</c> events and (in a follow-up PR) broadcast over the
+/// streaming hub so the UI macro pad can show queue / playback state.
+/// </summary>
+public enum CwEngineState : byte
+{
+    /// <summary>No message in flight, queue empty.</summary>
+    Idle = 0,
+    /// <summary>Actively playing out a message. MOX is held by Cwx.</summary>
+    Sending = 1,
+    /// <summary>Graceful stop requested — current symbol finishes, then unkey.</summary>
+    Stopping = 2,
+    /// <summary>Hard abort requested — drop immediately, queue cleared.</summary>
+    Aborting = 3,
+}
+
+/// <summary>
+/// Snapshot of the CW engine that <c>CwEngine.SendAsync</c> / completion /
+/// abort transitions emit on the <c>Status</c> event. <see cref="Text"/> is
+/// the message currently being sent (empty when <see cref="State"/> is
+/// <see cref="CwEngineState.Idle"/>); <see cref="Wpm"/> is the requested
+/// speed of that message. <see cref="QueueDepth"/> counts messages still
+/// waiting after the current one.
+/// </summary>
+/// <remarks>
+/// Reason field is optional and only populated on error / abort transitions
+/// (e.g. "not in CW mode", "operator abort", "UI override dropped MOX"). It
+/// surfaces in server logs and — once the streaming-hub frame lands in
+/// PR 2 — in the UI status pill.
+/// </remarks>
+public sealed record CwEngineStatus(
+    CwEngineState State,
+    string Text,
+    int Wpm,
+    int QueueDepth,
+    string? Reason = null);

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -387,6 +387,13 @@ public sealed record AutoAgcSetRequest(bool Enabled);
 
 public sealed record TunSetRequest(bool On);
 
+// /api/cw/send body. Text is the ASCII transcript to key out; Wpm is the
+// playback speed (PARIS-method words per minute, clamped to 5..50 at the
+// engine seam). Wpm null means "use the operator's stored default" — at the
+// moment that's a fixed engine default; PR 2 hooks it into a persisted
+// CwSettingsStore.
+public sealed record CwSendRequest(string Text, int? Wpm = null);
+
 public sealed record MicGainSetRequest(int Db);
 
 // Leveler max-gain ceiling in dB. Server clamps to [0, 15]; outside that is

--- a/Zeus.Contracts/MoxSource.cs
+++ b/Zeus.Contracts/MoxSource.cs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+
+namespace Zeus.Contracts;
+
+/// <summary>
+/// Identifies who keyed MOX so the release path can refuse to drop the
+/// transmitter on behalf of a different source. Without this tag, a TCI
+/// peer's "trx false" while the CW engine is mid-message would silently
+/// truncate the transmission, and a hardware-PTT falling edge while a UI
+/// click is holding MOX would do the same in the other direction.
+///
+/// Release rule (enforced in <c>TxService.TrySetMox</c>):
+/// <list type="bullet">
+///   <item><c>UI</c> always wins — the operator's on-screen button is the
+///         master override and can release MOX no matter who claimed it.</item>
+///   <item>Any other source can release only what it itself claimed.</item>
+///   <item><c>TxService.TryTripForAlert</c> bypasses the check entirely —
+///         SWR / timeout trips must always cut RF.</item>
+/// </list>
+///
+/// Wire-stable byte values — appending only. Callers that don't care about
+/// the source path may pass <see cref="UI"/> and get the legacy behaviour.
+/// </summary>
+public enum MoxSource : byte
+{
+    /// <summary>The on-screen MOX button, REST <c>/api/tx/mox</c>, or any
+    /// in-process default. Master override.</summary>
+    UI = 0,
+    /// <summary>A TCI peer (MSHV, JTDX, …) keyed via <c>trx:true</c>.</summary>
+    Tci = 1,
+    /// <summary>Hardware PTT input (foot switch, mic PTT, hand key) read
+    /// through the radio's protocol C&amp;C status path.</summary>
+    Hardware = 2,
+    /// <summary>The host-side CW engine driving keying from
+    /// <c>/api/cw/send</c>.</summary>
+    Cwx = 3,
+}

--- a/Zeus.Server.Hosting/CwEngine.cs
+++ b/Zeus.Server.Hosting/CwEngine.cs
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// Host-side CW keyer. WDSP's CWX module is not exported by the libwdsp
+// binaries we ship today (verified 2026-05-24: `nm -D libwdsp.so | grep -i
+// CWX` is empty on linux-x64 and osx-arm64), so we generate the IQ here
+// instead and push it straight into the protocol-1 TX ring. The shape we
+// produce — a single tone at the CW pitch with raised-cosine rise/fall —
+// is what piHPSDR's `transmitter_send_cw` ends up emitting on the wire
+// anyway, so this is a wire-compatible substitute, not a fallback.
+//
+// PR 1 of zeus-4np epic: validates the end-to-end keying path (encoder →
+// engine → TxIqRing → EP2 → RF). UI, macros, TCI keyer, and sidetone
+// monitor land in subsequent PRs.
+
+using System.Threading.Channels;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Zeus.Contracts;
+using Zeus.Protocol1;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Queues text-to-CW jobs and drives them out as host-generated IQ. One
+/// instance per process — registered as a singleton hosted service. The
+/// engine claims MOX as <see cref="MoxSource.Cwx"/> for the life of each
+/// message and releases it on completion; <see cref="AbortAsync"/> is the
+/// hard cut for operator override, <see cref="StopAsync(CancellationToken)"/>
+/// is the graceful shutdown path used by host shutdown.
+///
+/// Audio shape: a 600 Hz tone (sign-flipped for CWL) at 48 kHz, envelope
+/// shaped with a 5 ms raised-cosine on each edge to keep the on-air signal
+/// inside the CW passband. Amplitude is full-scale (operator drives PA
+/// power via the normal drive % slider, not here).
+/// </summary>
+public sealed class CwEngine : BackgroundService
+{
+    // TX-side ring sample rate. Both P1 and P2 backends pull from TxIqRing
+    // at 48 kHz; see Zeus.Protocol1.TxIqRing class doc.
+    public const int SampleRateHz = 48_000;
+    // Raised-cosine ramp on each key edge. 5 ms ≈ ±100 Hz of skirt energy at
+    // the CW pitch — well under the WDSP RX CW bandpass (250 Hz wide). Below
+    // 2 ms produces audible clicks on the air; above 10 ms starts to round
+    // off short dits at 30+ WPM.
+    private const int RampMs = 5;
+    // Speed bounds. 5 WPM = 240 ms dit (very slow CW); 50 WPM = 24 ms dit
+    // (faster than most hand keys can copy). Clamping at ingest keeps the
+    // ramp/dit math sane and prevents divide-by-tiny artefacts.
+    private const int WpmMin = 5;
+    private const int WpmMax = 50;
+    private const int WpmDefault = 20;
+
+    // Chunk size used by the playback loop. 480 samples = 10 ms at 48 kHz —
+    // small enough that the ring stays well under its 340 ms drop-oldest
+    // threshold, large enough that the loop only wakes 100 times per second
+    // of TX (negligible CPU). Stay coherent with the ring's `Write(span)`
+    // path which is per-block.
+    private const int ChunkSamples = 480;
+
+    private readonly TxService _tx;
+    private readonly RadioService _radio;
+    private readonly TxIqRing _ring;
+    private readonly ILogger<CwEngine> _log;
+    private readonly Channel<CwJob> _jobs = Channel.CreateUnbounded<CwJob>(
+        new UnboundedChannelOptions { SingleReader = true, SingleWriter = false });
+
+    // Aborts the currently-playing job. Recreated on each new job so abort
+    // doesn't poison the next send.
+    private CancellationTokenSource? _currentAbort;
+    private readonly object _abortLock = new();
+
+    /// <summary>Raised on every state transition. Subscribers must not block;
+    /// fired from the playback worker thread.</summary>
+    public event Action<CwEngineStatus>? Status;
+
+    public CwEngine(TxService tx, RadioService radio, TxIqRing ring, ILogger<CwEngine> log)
+    {
+        _tx = tx;
+        _radio = radio;
+        _ring = ring;
+        _log = log;
+        // Drop the current send if the operator overrides MOX from the UI
+        // (or a trip happens). Owner==null on the falling edge means MOX
+        // was just released; if it wasn't us doing the release, cancel.
+        _tx.TxActiveChanged += OnTxActiveChanged;
+    }
+
+    /// <summary>
+    /// Enqueue <paramref name="text"/> for transmission at <paramref name="wpm"/>
+    /// (null = engine default, currently 20). Returns immediately; actual
+    /// keying happens on the worker thread.
+    /// </summary>
+    public ValueTask SendAsync(string text, int? wpm, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        int effective = Math.Clamp(wpm ?? WpmDefault, WpmMin, WpmMax);
+        return _jobs.Writer.WriteAsync(new CwJob(text, effective), ct);
+    }
+
+    /// <summary>Hard cancel. Drains the queue and signals the in-flight
+    /// playback to drop the rest of the symbols. MOX falls on the next
+    /// playback tick.</summary>
+    public void Abort(string reason = "operator abort")
+    {
+        // Drain queue first so cancelled jobs don't get picked up.
+        while (_jobs.Reader.TryRead(out _)) { /* discard */ }
+        CancellationTokenSource? cts;
+        lock (_abortLock) cts = _currentAbort;
+        try { cts?.Cancel(); }
+        catch (ObjectDisposedException) { /* race with worker disposal */ }
+        _log.LogInformation("cw.abort reason={Reason}", reason);
+    }
+
+    /// <summary>Tests only: snapshot queue depth without taking work.</summary>
+    internal int PendingJobCount => _jobs.Reader.Count;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            CwJob job;
+            try { job = await _jobs.Reader.ReadAsync(stoppingToken).ConfigureAwait(false); }
+            catch (OperationCanceledException) { return; }
+
+            var jobCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+            lock (_abortLock) _currentAbort = jobCts;
+            try
+            {
+                await PlayJobAsync(job, jobCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Either operator abort or host shutdown. Either way, unkey
+                // and re-emit Idle if MOX is still ours.
+                Notify(new CwEngineStatus(
+                    CwEngineState.Aborting, job.Text, job.Wpm, _jobs.Reader.Count,
+                    Reason: "aborted"));
+                TryReleaseMox("aborted");
+            }
+            catch (Exception ex)
+            {
+                _log.LogWarning(ex, "cw.play failed text={Text} wpm={Wpm}", Truncate(job.Text), job.Wpm);
+                TryReleaseMox("error");
+            }
+            finally
+            {
+                lock (_abortLock)
+                {
+                    if (ReferenceEquals(_currentAbort, jobCts)) _currentAbort = null;
+                }
+                jobCts.Dispose();
+            }
+
+            // Emit Idle once the queue actually drains. Mid-queue jobs roll
+            // into the next iteration without a flicker.
+            if (_jobs.Reader.Count == 0)
+                Notify(new CwEngineStatus(CwEngineState.Idle, string.Empty, 0, 0));
+        }
+    }
+
+    private async Task PlayJobAsync(CwJob job, CancellationToken ct)
+    {
+        var snap = _radio.Snapshot();
+        int pitchHz = PitchForMode(snap.Mode);
+
+        if (!_tx.TrySetMox(true, MoxSource.Cwx, out var err))
+        {
+            _log.LogWarning("cw.mox.refused text={Text} reason={Err}", Truncate(job.Text), err);
+            Notify(new CwEngineStatus(
+                CwEngineState.Idle, job.Text, job.Wpm, _jobs.Reader.Count,
+                Reason: err ?? "MOX refused"));
+            return;
+        }
+        Notify(new CwEngineStatus(CwEngineState.Sending, job.Text, job.Wpm, _jobs.Reader.Count));
+        _log.LogInformation("cw.send text={Text} wpm={Wpm} pitch={Pitch}Hz",
+            Truncate(job.Text), job.Wpm, pitchHz);
+
+        // Phase accumulator runs continuously across symbols so the tone
+        // stays coherent through inter-element gaps (no phase pop on
+        // each dit-onset). Reset per-job.
+        double phase = 0.0;
+        double phaseStep = 2.0 * Math.PI * pitchHz / SampleRateHz;
+        // Scratch buffer for chunked IQ writes. 2 floats per sample.
+        var iq = new float[ChunkSamples * 2];
+
+        foreach (var symbol in MorseEncoder.Encode(job.Text, job.Wpm))
+        {
+            ct.ThrowIfCancellationRequested();
+            int totalSamples = (int)((long)symbol.DurationMs * SampleRateHz / 1000);
+            int rampSamples = Math.Min(
+                (int)((long)RampMs * SampleRateHz / 1000),
+                totalSamples / 2);
+
+            int written = 0;
+            while (written < totalSamples)
+            {
+                ct.ThrowIfCancellationRequested();
+                int n = Math.Min(ChunkSamples, totalSamples - written);
+                for (int i = 0; i < n; i++)
+                {
+                    double env = symbol.KeyDown
+                        ? RaisedCosineEnvelope(written + i, totalSamples, rampSamples)
+                        : 0.0;
+                    iq[2 * i] = (float)(env * Math.Cos(phase));
+                    iq[2 * i + 1] = (float)(env * Math.Sin(phase));
+                    phase += phaseStep;
+                    // Keep phase bounded so cos/sin stays numerically clean
+                    // over multi-minute transmissions.
+                    if (phase > 2.0 * Math.PI) phase -= 2.0 * Math.PI;
+                }
+                _ring.Write(new ReadOnlySpan<float>(iq, 0, 2 * n));
+                written += n;
+                // Pace ourselves to the ring drain rate so the ring stays
+                // well below its 16384-pair drop-oldest threshold. EP2 drains
+                // ~42k pairs/s; we write at the same average rate, so a
+                // (chunk/rate) sleep keeps the ring at ~one-chunk depth.
+                int sleepMs = Math.Max(1, (n * 1000) / SampleRateHz - 1);
+                try { await Task.Delay(sleepMs, ct).ConfigureAwait(false); }
+                catch (OperationCanceledException) { throw; }
+            }
+        }
+
+        // Drop MOX after the final symbol. The ring still has up to ~10 ms
+        // of envelope tail queued; wait that long so the radio actually
+        // transmits the tail before MOX falls. (Shorter than the natural
+        // ring depth — we deliberately keep the ring shallow above.)
+        try { await Task.Delay(20, ct).ConfigureAwait(false); }
+        catch (OperationCanceledException) { throw; }
+        TryReleaseMox("done");
+    }
+
+    private void TryReleaseMox(string reason)
+    {
+        // Only release MOX if we still own it — UI or trip may have already
+        // dropped it under us. Idempotent at the TxService layer either way.
+        if (_tx.MoxOwner == MoxSource.Cwx)
+        {
+            _tx.TrySetMox(false, MoxSource.Cwx, out _);
+            _log.LogInformation("cw.mox.released reason={Reason}", reason);
+        }
+    }
+
+    private void OnTxActiveChanged(bool active)
+    {
+        if (active) return;
+        // MOX just fell. If we have a job in flight and the falling edge
+        // wasn't initiated by us (TryReleaseMox above), the operator hit
+        // the UI override or a trip fired — cancel the playback so the
+        // remaining symbols don't queue up against a closed transmitter.
+        CancellationTokenSource? cts;
+        lock (_abortLock) cts = _currentAbort;
+        if (cts is null) return;
+        // MoxOwner is null after the falling edge regardless of who caused
+        // it, so we can't disambiguate "we released" from "UI overrode" by
+        // owner alone. We don't need to: the worker's own release path
+        // tolerates a redundant cancel (the linked-token CTS is one-shot
+        // and the worker's loop tail finishes the next iteration silently).
+        try { cts.Cancel(); } catch (ObjectDisposedException) { }
+    }
+
+    /// <summary>Test seam: precompute the IQ stream for <paramref name="text"/>
+    /// at <paramref name="wpm"/> and <paramref name="mode"/>. Used to assert
+    /// the wire shape without standing up a hub/ring/transport.</summary>
+    internal static float[] RenderForTest(string text, int wpm, RxMode mode)
+    {
+        int pitchHz = PitchForMode(mode);
+        double phase = 0.0;
+        double phaseStep = 2.0 * Math.PI * pitchHz / SampleRateHz;
+        var buf = new System.Collections.Generic.List<float>();
+        foreach (var sym in MorseEncoder.Encode(text, wpm))
+        {
+            int total = (int)((long)sym.DurationMs * SampleRateHz / 1000);
+            int ramp = Math.Min((int)((long)RampMs * SampleRateHz / 1000), total / 2);
+            for (int i = 0; i < total; i++)
+            {
+                double env = sym.KeyDown ? RaisedCosineEnvelope(i, total, ramp) : 0.0;
+                buf.Add((float)(env * Math.Cos(phase)));
+                buf.Add((float)(env * Math.Sin(phase)));
+                phase += phaseStep;
+                if (phase > 2.0 * Math.PI) phase -= 2.0 * Math.PI;
+            }
+        }
+        return buf.ToArray();
+    }
+
+    private void Notify(CwEngineStatus status)
+    {
+        try { Status?.Invoke(status); }
+        catch (Exception ex) { _log.LogWarning(ex, "cw.status subscriber threw"); }
+    }
+
+    private static int PitchForMode(RxMode mode) => mode switch
+    {
+        // CWU: LO sits below the displayed VFO by CwPitchHz (see CwOffset),
+        // so +pitch baseband puts the carrier ON the displayed VFO.
+        RxMode.CWU => CwOffset.CwPitchHz,
+        // CWL: mirror image — LO above VFO, baseband tone is -pitch.
+        RxMode.CWL => -CwOffset.CwPitchHz,
+        // Operator not in CW. We still key — they may want a carrier on
+        // the displayed VFO for testing — but with no offset.
+        _ => 0,
+    };
+
+    private static double RaisedCosineEnvelope(int sample, int total, int ramp)
+    {
+        // Plateau region.
+        if (sample >= ramp && sample < total - ramp) return 1.0;
+        // Rising edge: 0.5 (1 - cos(π·t/ramp)) — Tukey window's leading half.
+        if (sample < ramp)
+            return 0.5 * (1.0 - Math.Cos(Math.PI * sample / ramp));
+        // Falling edge: same curve mirrored.
+        int into = sample - (total - ramp);
+        return 0.5 * (1.0 - Math.Cos(Math.PI * (ramp - into) / ramp));
+    }
+
+    private static string Truncate(string s) => s.Length <= 40 ? s : s[..40] + "…";
+
+    private readonly record struct CwJob(string Text, int Wpm);
+}

--- a/Zeus.Server.Hosting/CwEngine.cs
+++ b/Zeus.Server.Hosting/CwEngine.cs
@@ -66,6 +66,13 @@ public sealed class CwEngine : BackgroundService
     private readonly ILogger<CwEngine> _log;
     private readonly Channel<CwJob> _jobs = Channel.CreateUnbounded<CwJob>(
         new UnboundedChannelOptions { SingleReader = true, SingleWriter = false });
+    // .NET's default unbounded channel does NOT implement Reader.Count
+    // (CanCount=false), so calling _jobs.Reader.Count throws
+    // NotSupportedException. We need the depth for status reporting and
+    // idle gating, so track it ourselves via Interlocked. Incremented at
+    // the writer (SendAsync, Abort no-op), decremented after a successful
+    // worker read.
+    private int _pendingJobs;
 
     // Aborts the currently-playing job. Recreated on each new job so abort
     // doesn't poison the next send.
@@ -97,6 +104,7 @@ public sealed class CwEngine : BackgroundService
     {
         ArgumentNullException.ThrowIfNull(text);
         int effective = Math.Clamp(wpm ?? WpmDefault, WpmMin, WpmMax);
+        Interlocked.Increment(ref _pendingJobs);
         return _jobs.Writer.WriteAsync(new CwJob(text, effective), ct);
     }
 
@@ -105,8 +113,10 @@ public sealed class CwEngine : BackgroundService
     /// playback tick.</summary>
     public void Abort(string reason = "operator abort")
     {
-        // Drain queue first so cancelled jobs don't get picked up.
-        while (_jobs.Reader.TryRead(out _)) { /* discard */ }
+        // Drain queue first so cancelled jobs don't get picked up. Decrement
+        // the depth counter for every job we discard so the in-flight Status
+        // reports stay accurate.
+        while (_jobs.Reader.TryRead(out _)) Interlocked.Decrement(ref _pendingJobs);
         CancellationTokenSource? cts;
         lock (_abortLock) cts = _currentAbort;
         try { cts?.Cancel(); }
@@ -115,7 +125,7 @@ public sealed class CwEngine : BackgroundService
     }
 
     /// <summary>Tests only: snapshot queue depth without taking work.</summary>
-    internal int PendingJobCount => _jobs.Reader.Count;
+    internal int PendingJobCount => Volatile.Read(ref _pendingJobs);
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -124,19 +134,24 @@ public sealed class CwEngine : BackgroundService
             CwJob job;
             try { job = await _jobs.Reader.ReadAsync(stoppingToken).ConfigureAwait(false); }
             catch (OperationCanceledException) { return; }
+            // Decrement BEFORE the job runs so QueueDepth reported in the
+            // Sending status reflects "jobs still waiting after me", not
+            // "jobs including me".
+            int remaining = Interlocked.Decrement(ref _pendingJobs);
 
             var jobCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
             lock (_abortLock) _currentAbort = jobCts;
             try
             {
-                await PlayJobAsync(job, jobCts.Token).ConfigureAwait(false);
+                await PlayJobAsync(job, remaining, jobCts.Token).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
                 // Either operator abort or host shutdown. Either way, unkey
                 // and re-emit Idle if MOX is still ours.
                 Notify(new CwEngineStatus(
-                    CwEngineState.Aborting, job.Text, job.Wpm, _jobs.Reader.Count,
+                    CwEngineState.Aborting, job.Text, job.Wpm,
+                    Volatile.Read(ref _pendingJobs),
                     Reason: "aborted"));
                 TryReleaseMox("aborted");
             }
@@ -156,33 +171,52 @@ public sealed class CwEngine : BackgroundService
 
             // Emit Idle once the queue actually drains. Mid-queue jobs roll
             // into the next iteration without a flicker.
-            if (_jobs.Reader.Count == 0)
+            if (Volatile.Read(ref _pendingJobs) == 0)
                 Notify(new CwEngineStatus(CwEngineState.Idle, string.Empty, 0, 0));
         }
     }
 
-    private async Task PlayJobAsync(CwJob job, CancellationToken ct)
+    private async Task PlayJobAsync(CwJob job, int queueDepth, CancellationToken ct)
     {
+        // Before keying, force the hardware LO to the canonical CW offset
+        // of the dial — eliminates CTUN drift so the carrier lands on the
+        // operator's displayed VFO. No-op when CTUN wasn't in play; when it
+        // was, the panadapter view recenters, which matches Thetis CW-TX
+        // behaviour (the CTUN convenience is RX-only).
+        bool loRealigned = _radio.AlignLoForCwTx();
+
         var snap = _radio.Snapshot();
-        int pitchHz = PitchForMode(snap.Mode);
+        // Baseband offset = RadioLo − VFO. After AlignLoForCwTx this is
+        // exactly ∓ CwPitchHz (negative for CWU, positive for CWL) and the
+        // carrier lands at the dial. The formula is kept rather than
+        // hard-coding ±pitch so a future caller that skips AlignLoForCwTx
+        // (e.g. an operator who genuinely wants to TX off-centre under
+        // CTUN) still gets correct baseband math.
+        //
+        // Sign note (HL2 IQ convention): the HL2 emits the RF carrier at
+        // (LO − baseband_hz), not (LO + baseband_hz) — i.e. the "I − jQ"
+        // complex-baseband convention. Verified on a live HL2 2026-05-24
+        // (EA5IUE bench test).
+        int basebandHz = (int)(snap.RadioLoHz - snap.VfoHz);
 
         if (!_tx.TrySetMox(true, MoxSource.Cwx, out var err))
         {
             _log.LogWarning("cw.mox.refused text={Text} reason={Err}", Truncate(job.Text), err);
             Notify(new CwEngineStatus(
-                CwEngineState.Idle, job.Text, job.Wpm, _jobs.Reader.Count,
+                CwEngineState.Idle, job.Text, job.Wpm, queueDepth,
                 Reason: err ?? "MOX refused"));
             return;
         }
-        Notify(new CwEngineStatus(CwEngineState.Sending, job.Text, job.Wpm, _jobs.Reader.Count));
-        _log.LogInformation("cw.send text={Text} wpm={Wpm} pitch={Pitch}Hz",
-            Truncate(job.Text), job.Wpm, pitchHz);
+        Notify(new CwEngineStatus(CwEngineState.Sending, job.Text, job.Wpm, queueDepth));
+        _log.LogInformation(
+            "cw.send text={Text} wpm={Wpm} mode={Mode} vfo={Vfo}Hz lo={Lo}Hz baseband={Bb}Hz loRealigned={LoRealigned}",
+            Truncate(job.Text), job.Wpm, snap.Mode, snap.VfoHz, snap.RadioLoHz, basebandHz, loRealigned);
 
         // Phase accumulator runs continuously across symbols so the tone
         // stays coherent through inter-element gaps (no phase pop on
         // each dit-onset). Reset per-job.
         double phase = 0.0;
-        double phaseStep = 2.0 * Math.PI * pitchHz / SampleRateHz;
+        double phaseStep = 2.0 * Math.PI * basebandHz / SampleRateHz;
         // Scratch buffer for chunked IQ writes. 2 floats per sample.
         var iq = new float[ChunkSamples * 2];
 
@@ -262,13 +296,13 @@ public sealed class CwEngine : BackgroundService
     }
 
     /// <summary>Test seam: precompute the IQ stream for <paramref name="text"/>
-    /// at <paramref name="wpm"/> and <paramref name="mode"/>. Used to assert
-    /// the wire shape without standing up a hub/ring/transport.</summary>
-    internal static float[] RenderForTest(string text, int wpm, RxMode mode)
+    /// at <paramref name="wpm"/>. <paramref name="basebandHz"/> is the live
+    /// engine's <c>(VfoHz − RadioLoHz)</c> — pass +600 for CWU without CTUN,
+    /// -600 for CWL without CTUN, or any signed offset to exercise CTUN.</summary>
+    internal static float[] RenderForTest(string text, int wpm, int basebandHz)
     {
-        int pitchHz = PitchForMode(mode);
         double phase = 0.0;
-        double phaseStep = 2.0 * Math.PI * pitchHz / SampleRateHz;
+        double phaseStep = 2.0 * Math.PI * basebandHz / SampleRateHz;
         var buf = new System.Collections.Generic.List<float>();
         foreach (var sym in MorseEncoder.Encode(text, wpm))
         {
@@ -291,18 +325,6 @@ public sealed class CwEngine : BackgroundService
         try { Status?.Invoke(status); }
         catch (Exception ex) { _log.LogWarning(ex, "cw.status subscriber threw"); }
     }
-
-    private static int PitchForMode(RxMode mode) => mode switch
-    {
-        // CWU: LO sits below the displayed VFO by CwPitchHz (see CwOffset),
-        // so +pitch baseband puts the carrier ON the displayed VFO.
-        RxMode.CWU => CwOffset.CwPitchHz,
-        // CWL: mirror image — LO above VFO, baseband tone is -pitch.
-        RxMode.CWL => -CwOffset.CwPitchHz,
-        // Operator not in CW. We still key — they may want a carrier on
-        // the displayed VFO for testing — but with no offset.
-        _ => 0,
-    };
 
     private static double RaisedCosineEnvelope(int sample, int total, int ramp)
     {

--- a/Zeus.Server.Hosting/MorseEncoder.cs
+++ b/Zeus.Server.Hosting/MorseEncoder.cs
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution. Morse table seeded from the
+// Thetis CWX defaults (Project Files/Source/Console/cwx.cs, load_alpha at
+// the morsedef.txt boot). Thetis is GPL-2.0+; preserving the lineage.
+
+namespace Zeus.Server;
+
+/// <summary>
+/// One emitted CW timing symbol: a stretch of key-down (carrier on) or
+/// key-up (silence). Durations are in milliseconds at the active WPM.
+/// Concatenating the durations yields the full transmission timeline.
+/// </summary>
+public readonly record struct CwSymbol(bool KeyDown, int DurationMs);
+
+/// <summary>
+/// Pure ASCII-text → key-down/key-up timing stream. No side effects, no IO,
+/// no allocation past the returned iterator's local state — safe to call
+/// from any thread.
+///
+/// Timing follows the PARIS-method standard: unit = 1200 / WPM ms.
+/// <list type="bullet">
+///   <item>dit = 1 unit on</item>
+///   <item>dah = 3 units on</item>
+///   <item>intra-element gap (between elements of a char) = 1 unit off</item>
+///   <item>inter-character gap = 3 units off</item>
+///   <item>inter-word gap = 7 units off (absorbs the would-be inter-char gap)</item>
+/// </list>
+///
+/// Inputs are case-folded to upper. Characters not present in the table
+/// (and the Thetis-only macro escapes <c>" # $ &amp;</c>) are silently
+/// skipped — same as Thetis treats undefined entries in morsedef.txt.
+/// </summary>
+public static class MorseEncoder
+{
+    /// <summary>One PARIS dit-unit in ms at <paramref name="wpm"/> WPM.</summary>
+    public static int DitMs(int wpm) => 1200 / wpm;
+
+    // ASCII 32..95, seeded from Thetis morsedef.txt defaults. Entries with
+    // no defined pattern (slot is empty / whitespace-only) and the Thetis
+    // macro escapes (loop ", long-dash #, long-space $, multi-digit &,
+    // reserved _) are absent on purpose — we want a clean "skip unknown"
+    // contract, not a partial port of Thetis's CWX special-char DSL.
+    private static readonly Dictionary<char, string> Table = new()
+    {
+        // Punctuation + special procedural signals
+        ['!'] = "...-.",   // [SN]
+        ['%'] = ".-...",   // [AS]
+        ['('] = "-.--.",   // [KN]
+        ['*'] = "...-.-",  // [SK]
+        ['+'] = ".-.-.",   // [AR]
+        [','] = "--..--",
+        ['-'] = "-....-",
+        ['.'] = ".-.-.-",
+        ['/'] = "-..-.",
+        [':'] = "---...",
+        [';'] = "-.-.-.",
+        ['='] = "-...-",   // [BT]
+        ['?'] = "..--..",
+        ['@'] = ".--.-.",
+        ['\\'] = "-...-.-", // [BK]
+
+        // Digits
+        ['0'] = "-----",
+        ['1'] = ".----",
+        ['2'] = "..---",
+        ['3'] = "...--",
+        ['4'] = "....-",
+        ['5'] = ".....",
+        ['6'] = "-....",
+        ['7'] = "--...",
+        ['8'] = "---..",
+        ['9'] = "----.",
+
+        // Letters
+        ['A'] = ".-",
+        ['B'] = "-...",
+        ['C'] = "-.-.",
+        ['D'] = "-..",
+        ['E'] = ".",
+        ['F'] = "..-.",
+        ['G'] = "--.",
+        ['H'] = "....",
+        ['I'] = "..",
+        ['J'] = ".---",
+        ['K'] = "-.-",
+        ['L'] = ".-..",
+        ['M'] = "--",
+        ['N'] = "-.",
+        ['O'] = "---",
+        ['P'] = ".--.",
+        ['Q'] = "--.-",
+        ['R'] = ".-.",
+        ['S'] = "...",
+        ['T'] = "-",
+        ['U'] = "..-",
+        ['V'] = "...-",
+        ['W'] = ".--",
+        ['X'] = "-..-",
+        ['Y'] = "-.--",
+        ['Z'] = "--..",
+    };
+
+    /// <summary>
+    /// Lazily emit timing symbols for <paramref name="text"/> at
+    /// <paramref name="wpm"/>. Iterating to the end is allocation-light:
+    /// one tiny struct per dit/dah/gap.
+    /// </summary>
+    /// <param name="text">ASCII text. Lowercase is upcased; SPACE / TAB /
+    /// LF / CR all collapse to a single word gap.</param>
+    /// <param name="wpm">Words per minute. Must be ≥ 1; clamp at the call
+    /// site if your UI permits zero/negative.</param>
+    public static IEnumerable<CwSymbol> Encode(string text, int wpm)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        if (wpm < 1) throw new ArgumentOutOfRangeException(nameof(wpm), wpm, "WPM must be ≥ 1");
+
+        int unit = DitMs(wpm);
+        bool atWordStart = true;  // suppresses the leading inter-character gap
+
+        foreach (char raw in text)
+        {
+            char c = char.ToUpperInvariant(raw);
+
+            if (c is ' ' or '\t' or '\n' or '\r')
+            {
+                // Word gap absorbs the inter-character gap that would
+                // otherwise precede the next char, so we mark atWordStart.
+                // Suppress at the very start of the buffer — no point
+                // emitting 7 units of silence before the first character.
+                if (!atWordStart) yield return new CwSymbol(false, unit * 7);
+                atWordStart = true;
+                continue;
+            }
+
+            if (!Table.TryGetValue(c, out var pattern)) continue;
+
+            // Inter-character gap. Skipped when this is the first
+            // character of the buffer or of a fresh word (atWordStart).
+            if (!atWordStart) yield return new CwSymbol(false, unit * 3);
+            atWordStart = false;
+
+            for (int i = 0; i < pattern.Length; i++)
+            {
+                if (i > 0) yield return new CwSymbol(false, unit); // intra-element gap
+                yield return new CwSymbol(true, pattern[i] == '.' ? unit : unit * 3);
+            }
+        }
+    }
+}

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -683,6 +683,44 @@ public sealed class RadioService : IDisposable
         return Snapshot();
     }
 
+    /// <summary>
+    /// Force the hardware LO to the canonical CW-mode offset of the
+    /// displayed VFO (LO = VFO − pitch for CWU, LO = VFO + pitch for CWL)
+    /// so a CW transmission lands the carrier on the dial. No-op for non-CW
+    /// modes and when the LO is already aligned.
+    ///
+    /// Background: CTUN (centred tuning) lets the operator click-tune the
+    /// panadapter without moving the hardware LO; <see cref="SetVfo"/>
+    /// updates only the displayed VFO and lets WDSP's shift stage move the
+    /// signal to baseband. That trick works fine for RX, but TX shares the
+    /// same physical NCO — if we keyed the radio while CTUN was active, the
+    /// carrier would land at <c>LO ± pitch</c> in real RF, not at the dial.
+    /// The host-side CW engine calls this before each transmission to
+    /// guarantee the operator-tuned freq is what reaches the antenna; the
+    /// pattern is the TCI-equivalent of "external retune" — see issue
+    /// <c>zeus-drf</c> bench notes (2026-05-24).
+    ///
+    /// Returns true when the LO was actually moved (caller may want to
+    /// log it for diagnostics), false on no-op.
+    /// </summary>
+    public bool AlignLoForCwTx()
+    {
+        long vfo;
+        RxMode mode;
+        long currentLo;
+        lock (_sync)
+        {
+            vfo = _state.VfoHz;
+            mode = _state.Mode;
+            currentLo = _state.RadioLoHz;
+        }
+        if (mode != RxMode.CWU && mode != RxMode.CWL) return false;
+        long targetLo = CwOffset.EffectiveLoHz(mode, vfo);
+        if (targetLo == currentLo) return false;
+        SetRadioLo(targetLo);
+        return true;
+    }
+
     // Per-mode-family remembered filter magnitudes. Mode switching snapshots
     // the current abs-filter into the departing family's slot and restores the
     // target family's slot on entry — so FM→USB brings back the SSB width

--- a/Zeus.Server.Hosting/Tci/TciSession.cs
+++ b/Zeus.Server.Hosting/Tci/TciSession.cs
@@ -947,7 +947,7 @@ public sealed class TciSession : IDisposable
         // state, TrySetMox is a no-op and lying to MSHV/WSJT-X causes the
         // client to think MOX is on when it isn't. MSHV tolerates redundant
         // echoes — it does not tolerate desynchronised state.
-        _tx.TrySetMox(on, out _);
+        _tx.TrySetMox(on, MoxSource.Tci, out _);
         Send(TciProtocol.Command("trx", rx, _tx.IsMoxOn));
     }
 
@@ -1458,7 +1458,11 @@ public sealed class TciSession : IDisposable
                 break;
             case "ZZTX0":
                 _log.LogInformation("tci.run_cat_ex ZZTX0 → force-unkey");
-                _tx.TrySetMox(false, out _);
+                // Source-tagged: a remote CAT command can drop MOX it itself
+                // claimed via trx:true, but cannot truncate a Cwx- or
+                // Hardware-driven transmission. The operator's UI button is
+                // still the master override.
+                _tx.TrySetMox(false, MoxSource.Tci, out _);
                 break;
             default:
                 _log.LogDebug("tci.run_cat_ex unhandled cmd={Cmd}", cmd);

--- a/Zeus.Server.Hosting/TxService.cs
+++ b/Zeus.Server.Hosting/TxService.cs
@@ -58,6 +58,11 @@ public sealed class TxService
     private bool _tunOn;
     private DateTime? _moxStartedAt;
     private DateTime? _tunStartedAt;
+    // Who currently owns MOX, set on the rising edge and cleared on the
+    // falling one. See <see cref="MoxSource"/> for the release rule: only
+    // the owning source can drop MOX, except UI (master override) and
+    // <see cref="TryTripForAlert"/> (always wins). Null when MOX is off.
+    private MoxSource? _moxOwner;
 
     public TxService(RadioService radio, DspPipelineService pipeline, StreamingHub hub, IBandPlanService bandPlan, ILogger<TxService> log)
     {
@@ -70,6 +75,11 @@ public sealed class TxService
 
     public bool IsMoxOn { get { lock (_sync) return _moxOn; } }
     public bool IsTunOn { get { lock (_sync) return _tunOn; } }
+    /// <summary>Source that currently holds MOX, or null when MOX is off.
+    /// Subscribers (e.g. <c>CwEngine</c>) read this on the
+    /// <see cref="TxActiveChanged"/> falling edge to tell apart "I dropped
+    /// MOX myself" from "the operator overrode me from the UI".</summary>
+    public MoxSource? MoxOwner { get { lock (_sync) return _moxOwner; } }
 
     /// <summary>
     /// Fires on every change to combined TX-active state
@@ -155,7 +165,19 @@ public sealed class TxService
         return false;
     }
 
+    /// <summary>Back-compat shim: callers that don't tag a source get
+    /// <see cref="MoxSource.UI"/>, the master override. New callers should
+    /// pass an explicit source so the release path can reject foreign drops.</summary>
     public bool TrySetMox(bool on, out string? error)
+        => TrySetMox(on, MoxSource.UI, out error);
+
+    /// <summary>
+    /// Source-aware MOX setter. The <paramref name="source"/> tag determines
+    /// whether the call is allowed when MOX is already held by another
+    /// source — see <see cref="MoxSource"/> for the rule. UI always wins;
+    /// any other source can only drop MOX it itself raised.
+    /// </summary>
+    public bool TrySetMox(bool on, MoxSource source, out string? error)
     {
         // FR-1 interlock: no TX unless connected.
         if (on && !_radio.IsConnected) { error = "not connected"; return false; }
@@ -166,17 +188,35 @@ public sealed class TxService
         bool? txActiveCaptured;
         lock (_sync)
         {
-            if (_moxOn == on) { error = null; return true; }
+            if (_moxOn == on)
+            {
+                // No-op edge. Don't reseat ownership on a redundant key-on
+                // (first-claim semantics — whoever raised the rising edge owns
+                // it for the life of the transmission). Drops are rejected
+                // here too so a foreign source can't even silently match the
+                // current state, since that would let a hardware-PTT release
+                // race a UI-driven send.
+                error = null;
+                return true;
+            }
+            if (!on && source != MoxSource.UI && _moxOwner is not null && _moxOwner != source)
+            {
+                // Foreign source trying to release someone else's MOX. Refuse.
+                error = $"MOX held by {_moxOwner}; only UI can override";
+                return false;
+            }
             wasTunOn = _tunOn;
             if (on)
             {
                 _tunOn = false;  // MOX-on preempts TUN (PRD FR-7 mutual-exclusion)
                 _tunStartedAt = null;
                 _moxStartedAt = DateTime.UtcNow;
+                _moxOwner = source;
             }
             else
             {
                 _moxStartedAt = null;
+                _moxOwner = null;
             }
             _moxOn = on;
             txActiveCaptured = CaptureTxActiveChangeUnderLock();
@@ -246,11 +286,16 @@ public sealed class TxService
                 _tunStartedAt = null;
                 _moxOn = true;
                 _moxStartedAt = DateTime.UtcNow;
+                // TwoTone is a UI-driven feature; tag the owner so the source
+                // gate in TrySetMox correctly rejects a foreign drop while
+                // the two-tone test is armed.
+                _moxOwner = MoxSource.UI;
             }
             else
             {
                 _moxOn = false;
                 _moxStartedAt = null;
+                _moxOwner = null;
             }
             txActiveCaptured = CaptureTxActiveChangeUnderLock();
         }
@@ -310,6 +355,8 @@ public sealed class TxService
             {
                 _moxOn = false;  // TUN-on preempts MOX (PRD FR-7)
                 _moxStartedAt = null;
+                // Whoever owned MOX just lost the channel — TUN took it.
+                _moxOwner = null;
                 _tunStartedAt = DateTime.UtcNow;
             }
             else
@@ -362,6 +409,9 @@ public sealed class TxService
             // would keep re-firing against the stale start time after the trip.
             _moxStartedAt = null;
             _tunStartedAt = null;
+            // Trip always wins regardless of owner. Drop ownership so the
+            // next rising edge starts from a clean source.
+            _moxOwner = null;
             txActiveCaptured = CaptureTxActiveChangeUnderLock();
         }
 

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -450,6 +450,25 @@ public static class ZeusEndpoints
             return Results.Ok(new { moxOn = tx.IsMoxOn });
         });
 
+        // CW keyer (zeus-drf). Body: { text, wpm? }. Returns 202 immediately;
+        // playback happens on the engine's worker. WPM null = engine default
+        // (currently 20); the engine clamps to 5..50. Empty text is allowed —
+        // produces no symbols and resolves to Idle without keying.
+        app.MapPost("/api/cw/send", async (CwSendRequest req, CwEngine cw) =>
+        {
+            await cw.SendAsync(req.Text ?? string.Empty, req.Wpm, default).ConfigureAwait(false);
+            return Results.Accepted();
+        });
+
+        // Hard abort. Drops the queue and signals the in-flight playback to
+        // cancel. MOX falls on the next playback tick (≤ ChunkSamples / SR ≈
+        // 10 ms). Returns 200 unconditionally — abort is best-effort.
+        app.MapPost("/api/cw/abort", (CwEngine cw) =>
+        {
+            cw.Abort("api.cw.abort");
+            return Results.Ok();
+        });
+
         // Mic-gain: N dB in [-40, +10], scales WDSP TXA panel-gain-1 the same
         // way Thetis does (console.cs:28805 setAudioMicGain → Audio.MicPreamp =
         // 10^(db/20) → cmaster.CMSetTXAPanelGain1). The negative range is the

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -243,6 +243,11 @@ public static class ZeusHost
         // TxTuneDriver pumps silent mic blocks through WDSP TXA while TUN is on so
         // the post-gen tone actually reaches the ring (no mic uplink during TUN).
         builder.Services.AddHostedService<TxTuneDriver>();
+        // Host-side CW keyer (zeus-drf). Single instance, drains a job queue
+        // and pushes envelope-shaped IQ directly into TxIqRing while holding
+        // MOX as MoxSource.Cwx.
+        builder.Services.AddSingleton<CwEngine>();
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<CwEngine>());
         // PS auto-attenuate timer2code-equivalent: ramps the radio's TX step
         // attenuator (Protocol2 only today) when calcc feedback level lands outside
         // the 128..181 ideal window, so PS has a recovery path on first arm. Idle

--- a/tests/Zeus.Server.Tests/CwEngineTests.cs
+++ b/tests/Zeus.Server.Tests/CwEngineTests.cs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// CwEngine — host-side CW IQ generator. The encoder's correctness is
+// covered by MorseEncoderTests; this file covers the *render path*: that
+// the engine produces the right number of samples for a given message at
+// a given WPM, and that the carrier sideband flips between CWU and CWL.
+
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class CwEngineTests
+{
+    private const int Sr = CwEngine.SampleRateHz;   // 48 000
+
+    [Fact]
+    public void Render_E_At20Wpm_ProducesOneDitOfSamples()
+    {
+        // 'E' = dit. At 20 WPM the PARIS unit is 1200/20 = 60 ms.
+        // No leading or trailing inter-char gap (single char, single
+        // character of buffer), so the IQ stream is exactly 60 ms long.
+        var iq = CwEngine.RenderForTest("E", wpm: 20, mode: RxMode.CWU);
+
+        int expectedSamples = 60 * Sr / 1000;     // 2880 samples
+        Assert.Equal(2 * expectedSamples, iq.Length);
+    }
+
+    [Fact]
+    public void Render_T_At20Wpm_ProducesOneDahOfSamples()
+    {
+        // 'T' = dah. 3 units × 60 ms = 180 ms.
+        var iq = CwEngine.RenderForTest("T", wpm: 20, mode: RxMode.CWU);
+
+        int expectedSamples = 180 * Sr / 1000;    // 8640
+        Assert.Equal(2 * expectedSamples, iq.Length);
+    }
+
+    [Fact]
+    public void Render_CQ_At20Wpm_ProducesExpectedTotalDuration()
+    {
+        // 'CQ' at 20 WPM:
+        //   C = -.-.  → 3 + 1 + 1 + 1 + 3 + 1 + 1 = 11 units
+        //   inter-char gap                          =  3 units
+        //   Q = --.-  → 3 + 1 + 3 + 1 + 1 + 1 + 3 = 13 units
+        //   ------------------------------------------
+        //   total                                  = 27 units = 1620 ms
+        var iq = CwEngine.RenderForTest("CQ", wpm: 20, mode: RxMode.CWU);
+
+        int expectedSamples = 1620 * Sr / 1000;   // 77 760
+        Assert.Equal(2 * expectedSamples, iq.Length);
+    }
+
+    [Fact]
+    public void Render_CWU_vs_CWL_FlipsQSign_OnTheCarrier()
+    {
+        // The pitch sign distinguishes the sideband: CWU emits +pitch,
+        // CWL emits -pitch (CwOffset.CwPitchHz = 600 Hz). At the carrier
+        // peak (envelope = 1, phase past the ramp), I[n]/Q[n] for CWU and
+        // CWL should have the same I value and equal-and-opposite Q.
+        var u = CwEngine.RenderForTest("T", wpm: 20, mode: RxMode.CWU);
+        var l = CwEngine.RenderForTest("T", wpm: 20, mode: RxMode.CWL);
+
+        Assert.Equal(u.Length, l.Length);
+
+        // Sample at the midpoint of the dah — well past the 5 ms ramp,
+        // envelope is 1.0, so I/Q reflect the raw carrier.
+        int sampleIdx = (u.Length / 2) & ~1;   // even (I-position)
+        float iU = u[sampleIdx], qU = u[sampleIdx + 1];
+        float iL = l[sampleIdx], qL = l[sampleIdx + 1];
+
+        // I matches because cos(±θ) = cos(θ).
+        Assert.Equal(iU, iL, precision: 4);
+        // Q is opposite-signed: sin(-θ) = -sin(θ).
+        Assert.Equal(qU, -qL, precision: 4);
+        // And the carrier has real amplitude (sanity: not all zero).
+        Assert.True(Math.Abs(iU) > 0.5f || Math.Abs(qU) > 0.5f,
+            $"expected envelope near 1.0 at sample {sampleIdx}, got I={iU} Q={qU}");
+    }
+
+    [Fact]
+    public void Render_KeyUpGaps_AreSilent()
+    {
+        // 'EE' at 20 WPM: dit, 3-unit inter-char gap, dit.
+        // Inter-char gap is samples [dit..dit+gap] of the stream — pure zeros.
+        var iq = CwEngine.RenderForTest("EE", wpm: 20, mode: RxMode.CWU);
+
+        int ditSamples = 60 * Sr / 1000;
+        int gapSamples = 3 * 60 * Sr / 1000;
+
+        // Inspect a sample comfortably inside the gap (skip the very first
+        // sample at the boundary in case of rounding). 1000 samples in.
+        int probe = ditSamples + 1000;
+        Assert.True(probe < ditSamples + gapSamples, "probe must land inside the gap");
+
+        Assert.Equal(0f, iq[2 * probe]);
+        Assert.Equal(0f, iq[2 * probe + 1]);
+    }
+
+    [Fact]
+    public void Render_HasRaisedCosineRiseEdge_NoHardClick()
+    {
+        // The first key-down sample should be near zero (start of the raised-
+        // cosine ramp), not a hard step to full scale. This guards against
+        // accidentally removing the envelope shaper.
+        var iq = CwEngine.RenderForTest("E", wpm: 20, mode: RxMode.CWU);
+
+        // Sample 0: I = cos(0) × env(0) = 1 × 0 = 0. Q = sin(0) × env(0) = 0.
+        // Both must be effectively zero — the envelope IS the click suppressor.
+        Assert.Equal(0f, iq[0], precision: 5);
+        Assert.Equal(0f, iq[1], precision: 5);
+
+        // Mid-ramp (sample 120 = 2.5 ms in, half-way through the 5 ms / 240-
+        // sample ramp): envelope is 0.5(1 - cos(π/2)) = 0.5, so combined
+        // amplitude sqrt(I² + Q²) ≈ 0.5.
+        int mid = 120;
+        float mag = MathF.Sqrt(iq[2 * mid] * iq[2 * mid] + iq[2 * mid + 1] * iq[2 * mid + 1]);
+        Assert.InRange(mag, 0.3f, 0.7f);
+    }
+}

--- a/tests/Zeus.Server.Tests/CwEngineTests.cs
+++ b/tests/Zeus.Server.Tests/CwEngineTests.cs
@@ -17,13 +17,23 @@ public class CwEngineTests
 {
     private const int Sr = CwEngine.SampleRateHz;   // 48 000
 
+    // RenderForTest takes a SIGNED baseband Hz that matches the engine's
+    // live (RadioLoHz − VfoHz) computation. The sign reflects the HL2's
+    // "I − jQ" IQ convention: positive baseband puts the carrier BELOW the
+    // LO, negative baseband puts it above. So for CWU without CTUN the
+    // RadioService programs LO = VFO − 600, giving LO − VFO = −600 (carrier
+    // at LO + 600 = VFO). For CWL the LO is VFO + 600, giving +600 (carrier
+    // at LO − 600 = VFO).
+    private const int CwuNoCtun = -600;
+    private const int CwlNoCtun = +600;
+
     [Fact]
     public void Render_E_At20Wpm_ProducesOneDitOfSamples()
     {
         // 'E' = dit. At 20 WPM the PARIS unit is 1200/20 = 60 ms.
         // No leading or trailing inter-char gap (single char, single
         // character of buffer), so the IQ stream is exactly 60 ms long.
-        var iq = CwEngine.RenderForTest("E", wpm: 20, mode: RxMode.CWU);
+        var iq = CwEngine.RenderForTest("E", wpm: 20, basebandHz: CwuNoCtun);
 
         int expectedSamples = 60 * Sr / 1000;     // 2880 samples
         Assert.Equal(2 * expectedSamples, iq.Length);
@@ -33,7 +43,7 @@ public class CwEngineTests
     public void Render_T_At20Wpm_ProducesOneDahOfSamples()
     {
         // 'T' = dah. 3 units × 60 ms = 180 ms.
-        var iq = CwEngine.RenderForTest("T", wpm: 20, mode: RxMode.CWU);
+        var iq = CwEngine.RenderForTest("T", wpm: 20, basebandHz: CwuNoCtun);
 
         int expectedSamples = 180 * Sr / 1000;    // 8640
         Assert.Equal(2 * expectedSamples, iq.Length);
@@ -48,7 +58,7 @@ public class CwEngineTests
         //   Q = --.-  → 3 + 1 + 3 + 1 + 1 + 1 + 3 = 13 units
         //   ------------------------------------------
         //   total                                  = 27 units = 1620 ms
-        var iq = CwEngine.RenderForTest("CQ", wpm: 20, mode: RxMode.CWU);
+        var iq = CwEngine.RenderForTest("CQ", wpm: 20, basebandHz: CwuNoCtun);
 
         int expectedSamples = 1620 * Sr / 1000;   // 77 760
         Assert.Equal(2 * expectedSamples, iq.Length);
@@ -57,12 +67,12 @@ public class CwEngineTests
     [Fact]
     public void Render_CWU_vs_CWL_FlipsQSign_OnTheCarrier()
     {
-        // The pitch sign distinguishes the sideband: CWU emits +pitch,
-        // CWL emits -pitch (CwOffset.CwPitchHz = 600 Hz). At the carrier
-        // peak (envelope = 1, phase past the ramp), I[n]/Q[n] for CWU and
-        // CWL should have the same I value and equal-and-opposite Q.
-        var u = CwEngine.RenderForTest("T", wpm: 20, mode: RxMode.CWU);
-        var l = CwEngine.RenderForTest("T", wpm: 20, mode: RxMode.CWL);
+        // The baseband sign distinguishes the sideband: CWU without CTUN
+        // emits +600 Hz, CWL emits -600 Hz. At the carrier peak (envelope =
+        // 1, phase past the ramp), I[n]/Q[n] for CWU and CWL should have
+        // the same I value and equal-and-opposite Q.
+        var u = CwEngine.RenderForTest("T", wpm: 20, basebandHz: CwuNoCtun);
+        var l = CwEngine.RenderForTest("T", wpm: 20, basebandHz: CwlNoCtun);
 
         Assert.Equal(u.Length, l.Length);
 
@@ -82,11 +92,53 @@ public class CwEngineTests
     }
 
     [Fact]
+    public void Render_CtunOffset_ShiftsCarrierBaseband()
+    {
+        // Regression for the 2026-05-24 EA5IUE bench-test bug: with CTUN
+        // active the HL2 LO sits independent of the dial, and the engine
+        // must compensate so the carrier still lands at the operator's
+        // dial freq. Verify by comparing two renders that differ only in
+        // baseband Hz — the carrier-phase rate at the midpoint of the dah
+        // should match the supplied frequency.
+        var slow = CwEngine.RenderForTest("T", wpm: 20, basebandHz: 600);
+        var fast = CwEngine.RenderForTest("T", wpm: 20, basebandHz: 9600);
+
+        Assert.Equal(slow.Length, fast.Length);
+
+        // Count zero-crossings of I[n] in the steady-state region of the
+        // dah (skip the 5 ms ramp at start and end). At 600 Hz over an
+        // 80 ms window we expect ~48 crossings; at 9600 Hz, ~768.
+        int rampSamples = 5 * Sr / 1000;
+        int windowStart = rampSamples;
+        int windowEnd = (slow.Length / 2) - rampSamples;
+        int slowCrossings = CountZeroCrossingsI(slow, windowStart, windowEnd);
+        int fastCrossings = CountZeroCrossingsI(fast, windowStart, windowEnd);
+
+        // 9600 Hz is 16× the 600 Hz rate, so we expect ~16× the crossings.
+        // Allow ±5% slack for boundary effects at the window edges.
+        double ratio = (double)fastCrossings / slowCrossings;
+        Assert.InRange(ratio, 16.0 * 0.95, 16.0 * 1.05);
+    }
+
+    private static int CountZeroCrossingsI(float[] iq, int sampleStart, int sampleEnd)
+    {
+        int n = 0;
+        float prev = iq[2 * sampleStart];
+        for (int s = sampleStart + 1; s < sampleEnd; s++)
+        {
+            float cur = iq[2 * s];
+            if ((prev <= 0f && cur > 0f) || (prev >= 0f && cur < 0f)) n++;
+            prev = cur;
+        }
+        return n;
+    }
+
+    [Fact]
     public void Render_KeyUpGaps_AreSilent()
     {
         // 'EE' at 20 WPM: dit, 3-unit inter-char gap, dit.
         // Inter-char gap is samples [dit..dit+gap] of the stream — pure zeros.
-        var iq = CwEngine.RenderForTest("EE", wpm: 20, mode: RxMode.CWU);
+        var iq = CwEngine.RenderForTest("EE", wpm: 20, basebandHz: CwuNoCtun);
 
         int ditSamples = 60 * Sr / 1000;
         int gapSamples = 3 * 60 * Sr / 1000;
@@ -106,7 +158,7 @@ public class CwEngineTests
         // The first key-down sample should be near zero (start of the raised-
         // cosine ramp), not a hard step to full scale. This guards against
         // accidentally removing the envelope shaper.
-        var iq = CwEngine.RenderForTest("E", wpm: 20, mode: RxMode.CWU);
+        var iq = CwEngine.RenderForTest("E", wpm: 20, basebandHz: CwuNoCtun);
 
         // Sample 0: I = cos(0) × env(0) = 1 × 0 = 0. Q = sin(0) × env(0) = 0.
         // Both must be effectively zero — the envelope IS the click suppressor.

--- a/tests/Zeus.Server.Tests/MorseEncoderTests.cs
+++ b/tests/Zeus.Server.Tests/MorseEncoderTests.cs
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using Xunit;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class MorseEncoderTests
+{
+    // PARIS-method: 20 wpm → 60 ms per dit unit. Picked because the
+    // resulting timings stay whole-millisecond (1200/20 = 60) so the
+    // asserts read like a Morse-code primer.
+    private const int Wpm20Unit = 60;
+
+    [Theory]
+    [InlineData(20, 60)]
+    [InlineData(12, 100)]
+    [InlineData(40, 30)]
+    [InlineData(5, 240)]
+    public void DitMs_FollowsPARIS(int wpm, int expected)
+    {
+        Assert.Equal(expected, MorseEncoder.DitMs(wpm));
+    }
+
+    [Fact]
+    public void Encode_EmptyString_NoSymbols()
+    {
+        Assert.Empty(MorseEncoder.Encode(string.Empty, 20));
+    }
+
+    [Fact]
+    public void Encode_SingleE_OneDit()
+    {
+        // 'E' is a single dit. No surrounding gaps — leading
+        // inter-character gap is suppressed at the buffer start.
+        var sym = MorseEncoder.Encode("E", 20).ToList();
+        Assert.Single(sym);
+        Assert.True(sym[0].KeyDown);
+        Assert.Equal(Wpm20Unit, sym[0].DurationMs);
+    }
+
+    [Fact]
+    public void Encode_SingleT_OneDah()
+    {
+        // 'T' is a single dah (3 units on).
+        var sym = MorseEncoder.Encode("T", 20).ToList();
+        Assert.Single(sym);
+        Assert.True(sym[0].KeyDown);
+        Assert.Equal(Wpm20Unit * 3, sym[0].DurationMs);
+    }
+
+    [Fact]
+    public void Encode_LetterA_DitGapDah()
+    {
+        // 'A' = .- → dit, intra-element gap, dah.
+        var sym = MorseEncoder.Encode("A", 20).ToList();
+        Assert.Equal(3, sym.Count);
+        Assert.Equal(new CwSymbol(true, Wpm20Unit),     sym[0]); // dit
+        Assert.Equal(new CwSymbol(false, Wpm20Unit),    sym[1]); // intra gap
+        Assert.Equal(new CwSymbol(true, Wpm20Unit * 3), sym[2]); // dah
+    }
+
+    [Fact]
+    public void Encode_LowercaseFoldsToUpper()
+    {
+        Assert.Equal(MorseEncoder.Encode("A", 20), MorseEncoder.Encode("a", 20));
+        Assert.Equal(MorseEncoder.Encode("CQ", 20), MorseEncoder.Encode("cq", 20));
+    }
+
+    [Fact]
+    public void Encode_TwoLetters_HasInterCharGap()
+    {
+        // "EE" = dit, inter-char gap (3 units), dit.
+        var sym = MorseEncoder.Encode("EE", 20).ToList();
+        Assert.Equal(3, sym.Count);
+        Assert.Equal(new CwSymbol(true, Wpm20Unit),     sym[0]);
+        Assert.Equal(new CwSymbol(false, Wpm20Unit * 3), sym[1]);
+        Assert.Equal(new CwSymbol(true, Wpm20Unit),     sym[2]);
+    }
+
+    [Fact]
+    public void Encode_SpaceBetweenWords_EmitsSevenUnitGap()
+    {
+        // "E E" = dit, word gap (7 units, not 3+7), dit. The word gap
+        // absorbs the would-be inter-character gap, so we should see
+        // exactly one off-period between the two dits at 7 units total.
+        var sym = MorseEncoder.Encode("E E", 20).ToList();
+        Assert.Equal(3, sym.Count);
+        Assert.Equal(new CwSymbol(true, Wpm20Unit),     sym[0]);
+        Assert.Equal(new CwSymbol(false, Wpm20Unit * 7), sym[1]);
+        Assert.Equal(new CwSymbol(true, Wpm20Unit),     sym[2]);
+    }
+
+    [Fact]
+    public void Encode_LeadingSpaces_AreElided()
+    {
+        // Leading spaces shouldn't burn 7 units of silence before the
+        // first dit. Trailing spaces are NOT trimmed — they're harmless
+        // (silence after the last element) and dropping them would
+        // require a buffered emit. Documented here so the next reader
+        // knows it's deliberate, not a bug.
+        var sym = MorseEncoder.Encode("   E", 20).ToList();
+        Assert.Single(sym);
+        Assert.Equal(new CwSymbol(true, Wpm20Unit), sym[0]);
+    }
+
+    [Fact]
+    public void Encode_TrailingSpaces_EmitOneWordGap()
+    {
+        // Documents the deliberate "trailing word gap is not trimmed"
+        // behaviour. Any number of trailing whitespace chars collapse
+        // to a single 7-unit gap (the same word-gap collapsing rule
+        // that runs for inter-word spacing).
+        var sym = MorseEncoder.Encode("E    ", 20).ToList();
+        Assert.Equal(2, sym.Count);
+        Assert.Equal(new CwSymbol(true, Wpm20Unit), sym[0]);
+        Assert.Equal(new CwSymbol(false, Wpm20Unit * 7), sym[1]);
+    }
+
+    [Fact]
+    public void Encode_MultipleConsecutiveSpaces_CollapseToOneWordGap()
+    {
+        // Two spaces in a row should still emit only one 7-unit gap, not
+        // two. Same principle as Thetis: a word boundary is a word
+        // boundary regardless of how many spaces the operator typed.
+        var sym = MorseEncoder.Encode("E    E", 20).ToList();
+        var gaps = sym.Where(s => !s.KeyDown).ToList();
+        Assert.Single(gaps);
+        Assert.Equal(Wpm20Unit * 7, gaps[0].DurationMs);
+    }
+
+    [Theory]
+    [InlineData('\t')]
+    [InlineData('\n')]
+    [InlineData('\r')]
+    public void Encode_WhitespaceCharactersCountAsSpace(char ws)
+    {
+        var sym = MorseEncoder.Encode($"E{ws}E", 20).ToList();
+        Assert.Equal(3, sym.Count);
+        Assert.Equal(new CwSymbol(false, Wpm20Unit * 7), sym[1]);
+    }
+
+    [Fact]
+    public void Encode_UnknownCharsAreSilentlySkipped()
+    {
+        // '~' isn't in the table — it should disappear entirely, not
+        // synthesize a word gap or a "?" prosign. (Thetis treats unknown
+        // entries the same way: silently skip when morsedef.txt has no
+        // pattern for a slot.)
+        var direct = MorseEncoder.Encode("EE", 20).ToList();
+        var withTilde = MorseEncoder.Encode("E~E", 20).ToList();
+        Assert.Equal(direct, withTilde);
+    }
+
+    [Fact]
+    public void Encode_LoopAndLongDashMacros_AreSkippedAsUnknown()
+    {
+        // Thetis's `"` (loop), `#` (long-dash), `$` (long-space), `&`
+        // (digit macro), `_` (reserved) are deliberately absent from
+        // our table — they should behave like any other unmapped char
+        // and skip cleanly without producing weird timings.
+        foreach (char macro in new[] { '"', '#', '$', '&', '_' })
+        {
+            var sym = MorseEncoder.Encode($"E{macro}E", 20).ToList();
+            Assert.Equal(MorseEncoder.Encode("EE", 20), sym);
+        }
+    }
+
+    [Fact]
+    public void Encode_CQDE_ProducesExpectedSequence()
+    {
+        // Real-world phrase: "CQ DE" at 20 wpm.
+        // C = -.-. ; Q = --.- ; (word gap 7u) ; D = -.. ; E = .
+        // Expected total elements (key-down + gap) easy to sanity-check.
+        var sym = MorseEncoder.Encode("CQ DE", 20).ToList();
+        var keyDownCount = sym.Count(s => s.KeyDown);
+        // C=4 + Q=4 + D=3 + E=1 = 12 key-down events.
+        Assert.Equal(12, keyDownCount);
+
+        // Total transmission time at 20 wpm:
+        //   C(-.-.) = 3+1+1+1+3+1+1 = 11 units
+        //   inter-char = 3
+        //   Q(--.-) = 3+1+3+1+1+1+3 = 13 units
+        //   word gap = 7
+        //   D(-..)  = 3+1+1+1+1 = 7 units
+        //   inter-char = 3
+        //   E(.)    = 1 unit
+        // Total = 11+3+13+7+7+3+1 = 45 units = 45 * 60 = 2700 ms.
+        long totalMs = sym.Sum(s => (long)s.DurationMs);
+        Assert.Equal(45 * Wpm20Unit, totalMs);
+    }
+
+    [Fact]
+    public void Encode_LeadsAlternatesKeyDownAndKeyUp()
+    {
+        // A well-formed CW stream must never have two consecutive
+        // key-down or key-up symbols — that would mean we forgot a gap
+        // or fused two pulses. Spot-check on a substantial sample.
+        var sym = MorseEncoder.Encode("CQ CQ DE EI6LF EI6LF K", 20).ToList();
+        Assert.NotEmpty(sym);
+        for (int i = 1; i < sym.Count; i++)
+        {
+            Assert.NotEqual(sym[i - 1].KeyDown, sym[i].KeyDown);
+        }
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Encode_RejectsNonPositiveWpm(int wpm)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => MorseEncoder.Encode("E", wpm).ToList());
+    }
+
+    [Fact]
+    public void Encode_NullText_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => MorseEncoder.Encode(null!, 20).ToList());
+    }
+}

--- a/tests/Zeus.Server.Tests/MoxSourceOwnershipTests.cs
+++ b/tests/Zeus.Server.Tests/MoxSourceOwnershipTests.cs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// Ownership rules on TxService.TrySetMox(bool, MoxSource, …). The release
+// path must refuse to drop MOX on behalf of a foreign source, with two
+// exceptions: UI is a master override, and TryTripForAlert always wins.
+// Without these rules a TCI peer's `trx:false` could truncate a host-side
+// CW message, and a hardware-PTT falling edge could drop a UI-keyed TX.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class MoxSourceOwnershipTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-moxsrc-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+        try { if (File.Exists(_dbPath + ".pa")) File.Delete(_dbPath + ".pa"); } catch { }
+    }
+
+    private (RadioService radio, TxService tx) BuildConnectedRadioAndTx()
+    {
+        var loggerFactory = NullLoggerFactory.Instance;
+        var dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance, _dbPath);
+        var paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, _dbPath + ".pa");
+        var radio = new RadioService(loggerFactory, dspStore, paStore);
+        radio.MarkProtocol2Connected("127.0.0.1:1024", 48_000);
+        var hub = new StreamingHub(new NullLogger<StreamingHub>());
+        var pipeline = new DspPipelineService(radio, hub, Array.Empty<IRxAudioSink>(), loggerFactory);
+        var tx = new TxService(radio, pipeline, hub, NullBandPlanService.Instance, new NullLogger<TxService>());
+        return (radio, tx);
+    }
+
+    [Fact]
+    public void Hardware_CannotRelease_CwxOwnedMox()
+    {
+        var (_, tx) = BuildConnectedRadioAndTx();
+
+        Assert.True(tx.TrySetMox(true, MoxSource.Cwx, out _));
+        Assert.True(tx.IsMoxOn);
+        Assert.Equal(MoxSource.Cwx, tx.MoxOwner);
+
+        // External PTT falling edge — must NOT drop a CW-driven transmission.
+        bool ok = tx.TrySetMox(false, MoxSource.Hardware, out var err);
+
+        Assert.False(ok);
+        Assert.NotNull(err);
+        Assert.Contains("Cwx", err);
+        Assert.True(tx.IsMoxOn);
+        Assert.Equal(MoxSource.Cwx, tx.MoxOwner);
+    }
+
+    [Fact]
+    public void Cwx_CannotRelease_HardwareOwnedMox()
+    {
+        // Mirror of the above so the rule holds symmetrically — a stray
+        // /api/cw/abort while a hardware key is held shouldn't kill the
+        // operator's hand-keyed CW.
+        var (_, tx) = BuildConnectedRadioAndTx();
+
+        Assert.True(tx.TrySetMox(true, MoxSource.Hardware, out _));
+        Assert.Equal(MoxSource.Hardware, tx.MoxOwner);
+
+        bool ok = tx.TrySetMox(false, MoxSource.Cwx, out var err);
+
+        Assert.False(ok);
+        Assert.NotNull(err);
+        Assert.Contains("Hardware", err);
+        Assert.True(tx.IsMoxOn);
+    }
+
+    [Fact]
+    public void UI_AlwaysReleases_NoMatterWhoOwns()
+    {
+        // The operator's on-screen MOX button is the master override:
+        // pressing it must drop MOX no matter who claimed it.
+        foreach (var owner in new[] { MoxSource.Cwx, MoxSource.Hardware, MoxSource.Tci })
+        {
+            var (_, tx) = BuildConnectedRadioAndTx();
+
+            Assert.True(tx.TrySetMox(true, owner, out _));
+            Assert.Equal(owner, tx.MoxOwner);
+
+            bool ok = tx.TrySetMox(false, MoxSource.UI, out var err);
+
+            Assert.True(ok);
+            Assert.Null(err);
+            Assert.False(tx.IsMoxOn);
+            Assert.Null(tx.MoxOwner);
+        }
+    }
+
+    [Fact]
+    public void OwningSource_CanReleaseItsOwnMox()
+    {
+        var (_, tx) = BuildConnectedRadioAndTx();
+
+        Assert.True(tx.TrySetMox(true, MoxSource.Tci, out _));
+        Assert.Equal(MoxSource.Tci, tx.MoxOwner);
+
+        bool ok = tx.TrySetMox(false, MoxSource.Tci, out var err);
+
+        Assert.True(ok);
+        Assert.Null(err);
+        Assert.False(tx.IsMoxOn);
+    }
+
+    [Fact]
+    public void TripForAlert_AlwaysWins_RegardlessOfOwner()
+    {
+        // SWR / TX-timeout trips bypass the source rule completely — RF must
+        // cut even if the owning source isn't around to release voluntarily.
+        var (_, tx) = BuildConnectedRadioAndTx();
+
+        Assert.True(tx.TrySetMox(true, MoxSource.Cwx, out _));
+        Assert.True(tx.IsMoxOn);
+
+        tx.TryTripForAlert(AlertKind.SwrTrip, "test");
+
+        Assert.False(tx.IsMoxOn);
+        Assert.Null(tx.MoxOwner);
+    }
+
+    [Fact]
+    public void Owner_LatchesOnFirstClaim_RedundantKeyOnDoesNotReseat()
+    {
+        // First-claim semantics: if Cwx keys MOX and then UI also calls
+        // TrySetMox(true), ownership stays with Cwx. (UI hasn't actually
+        // changed state; the call is a no-op edge.) Without this, a UI poll
+        // that touches MOX while CW is running would convert the message's
+        // owner to UI and let foreign sources drop it.
+        var (_, tx) = BuildConnectedRadioAndTx();
+
+        Assert.True(tx.TrySetMox(true, MoxSource.Cwx, out _));
+        Assert.Equal(MoxSource.Cwx, tx.MoxOwner);
+
+        Assert.True(tx.TrySetMox(true, MoxSource.UI, out _));
+        Assert.Equal(MoxSource.Cwx, tx.MoxOwner);
+
+        // And a foreign drop is still rejected.
+        Assert.False(tx.TrySetMox(false, MoxSource.Tci, out _));
+        Assert.True(tx.IsMoxOn);
+    }
+
+    [Fact]
+    public void BackCompatOverload_DefaultsToUiSource()
+    {
+        // Callers that use the old 2-arg TrySetMox get MoxSource.UI behaviour
+        // implicitly. This keeps every existing test and call site working
+        // unchanged after the source-tag addition.
+        var (_, tx) = BuildConnectedRadioAndTx();
+
+        Assert.True(tx.TrySetMox(true, out _));
+        Assert.Equal(MoxSource.UI, tx.MoxOwner);
+
+        // Foreign drop still rejected (UI owns now).
+        Assert.False(tx.TrySetMox(false, MoxSource.Cwx, out _));
+        Assert.True(tx.IsMoxOn);
+
+        // UI can release its own MOX via the back-compat overload too.
+        Assert.True(tx.TrySetMox(false, out _));
+        Assert.False(tx.IsMoxOn);
+    }
+}


### PR DESCRIPTION
First slice of the host-side CW keyer epic ([[zeus-4np]]) — wire-path end-to-end so the rest of the work (UI, macros, TCI keyer, sidetone monitor) has a validated foundation to land on.

## What lands

**Morse encoder** (`Zeus.Server.Hosting/MorseEncoder.cs`)
Pure ASCII → (KeyDown, DurationMs) stream at PARIS-method timing. Table seeded from Thetis morsedef.txt; the Thetis-only macro escapes (\`\"\`/\`#\`/\`\$\`/\`&\`) deliberately absent so unknown chars skip silently. Lazy iterator, allocation-light, thread-safe. 24 unit tests cover the timing math, case folding, leading-space elision, word-gap collapsing, and the CQ-DE end-to-end timing.

**Host-side CW engine** (`Zeus.Server.Hosting/CwEngine.cs`)
Hosted singleton driving a channel-backed job queue. The libwdsp binaries we ship don't export CWX (\`nm -D libwdsp.{so,dylib} | grep -i CWX\` empty on linux-x64 and osx-arm64), so the engine generates IQ here — raised-cosine envelope (5 ms ramp), 600 Hz tone (sign-flipped for CWL via \`CwOffset.CwPitchHz\`), 480-sample (10 ms) chunks paced to the ring drain rate. Worker subscribes to \`TxService.TxActiveChanged\` so a UI override or trip cancels the in-flight send.

**MoxSource enum** (\`Zeus.Contracts/MoxSource.cs\`) — UI / Tci / Hardware / Cwx
\`TxService.TrySetMox\` grows a (bool, MoxSource, out string?) overload; the 2-arg shim defaults to \`MoxSource.UI\` so every existing call site keeps working unchanged. Rules:

- **First-claim semantics** — the owner is whoever raised the rising edge; redundant key-on calls don't reseat ownership
- **Release rule** — only the owning source can drop MOX. \`UI\` is the master override; \`TryTripForAlert\` always wins
- **TwoTone/TUN** set/clear ownership on their own state edges (UI-tagged)
- **TciSession.HandleTrx** and the \`ZZTX0\` CAT passthrough tag their MOX changes as \`MoxSource.Tci\`, so a remote peer can't truncate a Cwx- or Hardware-driven transmission

**Endpoints**

\`\`\`
POST /api/cw/send  { text, wpm? }  →  202 Accepted (engine-clamped 5..50)
POST /api/cw/abort                  →  200 OK (best-effort drop)
\`\`\`

## Three bench-test fixes folded in (commit 3)

Live-fire on the HL2 surfaced three issues that all landed in the same follow-up:

1. **CTUN sends the carrier to the wrong frequency.** The HL2's single physical NCO drifts from the displayed VFO under CTUN (\`SetVfo\` only updates the dial and lets WDSP's shift stage handle RX). The old engine assumed \`LO = VFO ∓ pitch\` always. Fix: new \`RadioService.AlignLoForCwTx()\` realigns the LO before keying, then \`baseband = RadioLo − VFO\` does the right thing. Mirrors the \`SetVfo(fromExternal:true)\` escape hatch we use for TCI.
2. **Wrong I/Q sideband convention.** The HL2 emits the RF carrier at \`(LO − baseband)\`, not \`(LO + baseband)\` — the \`I − jQ\` convention. Verified on air (LO = 21.074: +600 Hz baseband → ~21.0734; −9000 → 21.083). Baked into the baseband formula above.
3. **\`Channel<T>.Reader.Count\` tore down the host.** Default unbounded channel has \`CanCount=false\`; the first call lived inside the per-job try/catch (and correctly released MOX), the next iteration's call was outside and killed the BackgroundService → HostOptions \`StopHost\`. Soak test (10 queued copies of \"VVV DE EA5IUE…\") drained cleanly with 14–24 ms inter-copy gaps after the fix to an \`Interlocked\` counter.

## Out of scope (subsequent epic PRs)

- UI rewire + persisted settings — [[zeus-o27]]
- TCI keyer hookup — [[zeus-j3t]]
- Sidetone monitor + audio routing — [[zeus-5ue]]

## Test plan

- [x] \`dotnet test Zeus.slnx\` — 1121 pass, 0 fail, 107 skipped (unchanged from main)
- [x] Live HL2: \`curl -X POST /api/cw/send -d '{\"text\":\"CQ\",\"wpm\":20}'\` keys MOX, emits 4 elements at 20 WPM, drops MOX cleanly
- [x] Live HL2: 10 queued copies of \"VVV DE EA5IUE…\" — all 10 drain, no crash, MOX cycles 14–24 ms between copies
- [x] Live HL2: carrier confirmed in the panadapter at the displayed VFO after CTUN fix (visual check on 21.065 MHz with 9 kHz and 22.6 kHz CTUN offsets)
- [ ] Operator verification with an external CW-capable receiver (pending battery on bench RX 😅)

## Reviewer notes

- The big \`CwEngine.cs\` block-comment at top documents the WDSP-CWX availability check and the host-side fallback rationale so a future reader doesn't re-investigate
- \`AlignLoForCwTx()\` is public so a UI \"force-LO-to-dial\" button could call it directly later if useful
- The HL2 I−jQ convention finding is captured inline in the engine — if someone adds a TX path for a different board, the same convention check is worth re-verifying on that board before assuming