### PR TITLE
CW UI rewire + persisted settings + Telegraph Console redesign

### DIFF
--- a/Zeus.Contracts/CwEngineStatusFrame.cs
+++ b/Zeus.Contracts/CwEngineStatusFrame.cs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Text;
+
+namespace Zeus.Contracts;
+
+/// <summary>
+/// Wire frame for <see cref="CwEngineStatus"/>. Broadcast on every state
+/// edge of the host-side CW engine so the macro pad can show in-flight
+/// text + queue depth without polling. Format:
+///
+/// <code>
+/// [type:1=0x30][state:u8][wpm:u16 LE][queueDepth:u16 LE]
+/// [textLen:u16 LE][text:UTF-8 textLen bytes]
+/// </code>
+///
+/// 9-byte fixed header + variable text payload. Text is capped at
+/// <see cref="MaxTextBytes"/> so a runaway macro can't blow the wire — the
+/// frontend reconstructs per-character position from <see cref="Wpm"/> +
+/// the local-arrival timestamp (cheap to do client-side; no need to push
+/// per-character progress frames at audio rate).
+///
+/// Wire-frozen: state is <see cref="CwEngineState"/> as a byte; future
+/// additions append-only at the tail.
+/// </summary>
+public readonly record struct CwEngineStatusFrame(
+    CwEngineState State,
+    int Wpm,
+    int QueueDepth,
+    string Text)
+{
+    /// <summary>Hard cap on the text payload — well above any realistic CW
+    /// macro length. Senders that hand us a longer string get truncated to
+    /// this size; the frame stays under one MTU on a typical LAN.</summary>
+    public const int MaxTextBytes = 512;
+
+    public const int HeaderByteLength = 9;
+
+    public void Serialize(IBufferWriter<byte> writer)
+    {
+        // Encode text first so we know the actual byte count (UTF-8 may be
+        // longer than .Length for non-ASCII macros).
+        var rawBytes = Encoding.UTF8.GetBytes(Text ?? string.Empty);
+        int textBytes = Math.Min(rawBytes.Length, MaxTextBytes);
+        int total = HeaderByteLength + textBytes;
+        var span = writer.GetSpan(total);
+        span[0] = (byte)MsgType.CwEngineStatus;
+        span[1] = (byte)State;
+        // Clamp Wpm / QueueDepth to u16 so a logic bug upstream can't write
+        // a wider integer and silently truncate at the bit boundary.
+        ushort wpmU16 = (ushort)Math.Clamp(Wpm, 0, ushort.MaxValue);
+        ushort depthU16 = (ushort)Math.Clamp(QueueDepth, 0, ushort.MaxValue);
+        BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(2, 2), wpmU16);
+        BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(4, 2), depthU16);
+        BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(6, 2), (ushort)textBytes);
+        if (textBytes > 0)
+            rawBytes.AsSpan(0, textBytes).CopyTo(span.Slice(HeaderByteLength, textBytes));
+        writer.Advance(total);
+    }
+
+    public static CwEngineStatusFrame Deserialize(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length < HeaderByteLength)
+            throw new InvalidDataException(
+                $"CwEngineStatusFrame requires ≥{HeaderByteLength} bytes, got {bytes.Length}");
+        if (bytes[0] != (byte)MsgType.CwEngineStatus)
+            throw new InvalidDataException(
+                $"expected CwEngineStatus (0x{(byte)MsgType.CwEngineStatus:X2}), got 0x{bytes[0]:X2}");
+        var state = (CwEngineState)bytes[1];
+        int wpm = BinaryPrimitives.ReadUInt16LittleEndian(bytes.Slice(2, 2));
+        int depth = BinaryPrimitives.ReadUInt16LittleEndian(bytes.Slice(4, 2));
+        int textLen = BinaryPrimitives.ReadUInt16LittleEndian(bytes.Slice(6, 2));
+        if (HeaderByteLength + textLen > bytes.Length)
+            throw new InvalidDataException(
+                $"CwEngineStatusFrame textLen {textLen} exceeds payload");
+        string text = textLen == 0
+            ? string.Empty
+            : Encoding.UTF8.GetString(bytes.Slice(HeaderByteLength, textLen));
+        return new CwEngineStatusFrame(state, wpm, depth, text);
+    }
+
+    /// <summary>Lift a <see cref="CwEngineStatus"/> into the wire shape.</summary>
+    public static CwEngineStatusFrame FromStatus(CwEngineStatus s) =>
+        new(s.State, s.Wpm, s.QueueDepth, s.Text ?? string.Empty);
+}

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -404,10 +404,34 @@ public sealed record TunSetRequest(bool On);
 
 // /api/cw/send body. Text is the ASCII transcript to key out; Wpm is the
 // playback speed (PARIS-method words per minute, clamped to 5..50 at the
-// engine seam). Wpm null means "use the operator's stored default" — at the
-// moment that's a fixed engine default; PR 2 hooks it into a persisted
-// CwSettingsStore.
+// engine seam). Wpm null means "use the operator's stored CwSettings.Wpm
+// default" (CwSettingsStore — written by /api/cw/settings).
 public sealed record CwSendRequest(string Text, int? Wpm = null);
+
+// Persisted CW operator settings. Wpm is the default speed for new sends
+// when /api/cw/send is called without an explicit wpm. FarnsworthWpm is
+// the character-rate floor for Farnsworth spacing (null = pure WPM, no
+// Farnsworth). Macros is exactly six slots — the macro pad is a fixed
+// 2×3 grid; empty strings are valid (renders a "(empty)" button). The
+// sidetone fields are surfaced here so the UI sliders persist alongside
+// the macros, even though sidetone audio routing itself lands later
+// (zeus-5ue) — keeps the wire shape stable across the epic.
+public sealed record CwSettingsDto(
+    int Wpm,
+    int? FarnsworthWpm,
+    string[] Macros,
+    double SidetoneGainDb,
+    int SidetoneHz);
+
+// PATCH-shaped: every field nullable so the frontend can save one slider
+// (or one macro) without re-sending the whole record. Server merges on top
+// of the persisted row before applying.
+public sealed record CwSettingsSetRequest(
+    int? Wpm = null,
+    int? FarnsworthWpm = null,
+    string[]? Macros = null,
+    double? SidetoneGainDb = null,
+    int? SidetoneHz = null);
 
 public sealed record MicGainSetRequest(int Db);
 

--- a/Zeus.Contracts/MsgType.cs
+++ b/Zeus.Contracts/MsgType.cs
@@ -153,4 +153,14 @@ public enum MsgType : byte
     // Payload: [type:1][bypassed:u8] = 2 bytes total. See
     // AudioMasterBypassFrame.cs.
     AudioMasterBypass = 0x1F,
+
+    // Server → client (CW engine status). Broadcast on every state edge of
+    // the host-side CW keyer (Idle ↔ Sending, Stopping, Aborting). Carries
+    // enough context for the UI macro pad to show what's in flight and how
+    // much queue is left without polling. Payload: [type:1][state:u8]
+    // [wpm:u16 LE][queueDepth:u16 LE][textLen:u16 LE][text:UTF-8…].
+    // See CwEngineStatusFrame.cs. New nibble 0x3x for control-plane
+    // feedback frames (0x1x is full); UI ignores unknown types so older
+    // builds tolerate this cleanly.
+    CwEngineStatus = 0x30,
 }

--- a/Zeus.Server.Hosting/CwEngine.cs
+++ b/Zeus.Server.Hosting/CwEngine.cs
@@ -63,6 +63,8 @@ public sealed class CwEngine : BackgroundService
     private readonly TxService _tx;
     private readonly RadioService _radio;
     private readonly TxIqRing _ring;
+    private readonly StreamingHub _hub;
+    private readonly CwSettingsStore _settings;
     private readonly ILogger<CwEngine> _log;
     private readonly Channel<CwJob> _jobs = Channel.CreateUnbounded<CwJob>(
         new UnboundedChannelOptions { SingleReader = true, SingleWriter = false });
@@ -83,29 +85,44 @@ public sealed class CwEngine : BackgroundService
     /// fired from the playback worker thread.</summary>
     public event Action<CwEngineStatus>? Status;
 
-    public CwEngine(TxService tx, RadioService radio, TxIqRing ring, ILogger<CwEngine> log)
+    public CwEngine(TxService tx, RadioService radio, TxIqRing ring, StreamingHub hub, CwSettingsStore settings, ILogger<CwEngine> log)
     {
         _tx = tx;
         _radio = radio;
         _ring = ring;
+        _hub = hub;
+        _settings = settings;
         _log = log;
         // Drop the current send if the operator overrides MOX from the UI
         // (or a trip happens). Owner==null on the falling edge means MOX
         // was just released; if it wasn't us doing the release, cancel.
         _tx.TxActiveChanged += OnTxActiveChanged;
+        // Bridge the in-process Status event onto the wire so connected
+        // clients (the React macro pad) see state edges without polling.
+        Status += BroadcastStatus;
     }
 
     /// <summary>
-    /// Enqueue <paramref name="text"/> for transmission at <paramref name="wpm"/>
-    /// (null = engine default, currently 20). Returns immediately; actual
-    /// keying happens on the worker thread.
+    /// Enqueue <paramref name="text"/> for transmission at <paramref name="wpm"/>.
+    /// When <paramref name="wpm"/> is null the engine reads the operator's
+    /// persisted default from <see cref="CwSettingsStore"/>; if the store
+    /// hasn't been initialised yet (test seam) it falls back to
+    /// <see cref="WpmDefault"/>. Returns immediately; keying happens on
+    /// the worker thread.
     /// </summary>
     public ValueTask SendAsync(string text, int? wpm, CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(text);
-        int effective = Math.Clamp(wpm ?? WpmDefault, WpmMin, WpmMax);
+        int requested = wpm ?? _settings?.Get().Wpm ?? WpmDefault;
+        int effective = Math.Clamp(requested, WpmMin, WpmMax);
         Interlocked.Increment(ref _pendingJobs);
         return _jobs.Writer.WriteAsync(new CwJob(text, effective), ct);
+    }
+
+    private void BroadcastStatus(CwEngineStatus s)
+    {
+        try { _hub.Broadcast(CwEngineStatusFrame.FromStatus(s)); }
+        catch (Exception ex) { _log.LogWarning(ex, "cw.status hub broadcast failed"); }
     }
 
     /// <summary>Hard cancel. Drains the queue and signals the in-flight

--- a/Zeus.Server.Hosting/CwSettingsStore.cs
+++ b/Zeus.Server.Hosting/CwSettingsStore.cs
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+
+using LiteDB;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Persists the CW operator's preferences (WPM, Farnsworth split, 6 macro
+/// slots, sidetone gain/pitch) so the macro pad and slider state survive
+/// server restarts. Shares <c>zeus-prefs.db</c> with the other Stores —
+/// CW settings aren't sensitive.
+///
+/// Single-row schema (one operator per backend). Macros is stored as a
+/// fixed-length string[6]; absent / shorter persisted arrays are padded
+/// to 6 with the seeded defaults on read, so legacy DBs hydrate cleanly.
+/// </summary>
+public sealed class CwSettingsStore : IDisposable
+{
+    /// <summary>Default macros — match the previously-hardcoded list in
+    /// <c>zeus-web/src/components/design/CwKeyer.tsx</c> so a fresh install
+    /// shows the same six buttons the UI used pre-persistence.</summary>
+    public static readonly string[] DefaultMacros =
+        { "CQ CQ CQ", "TU 73", "QRZ?", "AGN?", "5NN TU", "UR RST" };
+
+    public const int DefaultWpm = 22;
+    public const double DefaultSidetoneGainDb = -10.0;
+    public const int DefaultSidetoneHz = 600;
+    /// <summary>Hard cap on the total number of macros — keeps the UI
+    /// list manageable and bounds the broadcast frame size. Operators can
+    /// add up to this many slots; <see cref="DefaultMacros"/> seeds the
+    /// first six on a fresh install.</summary>
+    public const int MaxMacros = 32;
+    /// <summary>Hard cap on a single macro to keep wire frames small and
+    /// reject runaway paste / accidental long strings at the API edge.</summary>
+    public const int MaxMacroChars = 200;
+
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<CwSettingsEntry> _docs;
+    private readonly ILogger<CwSettingsStore> _log;
+    private readonly object _sync = new();
+
+    public CwSettingsStore(ILogger<CwSettingsStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _docs = _db.GetCollection<CwSettingsEntry>("cw_settings");
+
+        _log.LogInformation("CwSettingsStore initialized at {Path}", dbPath);
+    }
+
+    public CwSettingsDto Get()
+    {
+        lock (_sync)
+        {
+            var e = _docs.FindAll().FirstOrDefault();
+            if (e is null)
+                return new CwSettingsDto(
+                    Wpm: DefaultWpm,
+                    FarnsworthWpm: null,
+                    Macros: (string[])DefaultMacros.Clone(),
+                    SidetoneGainDb: DefaultSidetoneGainDb,
+                    SidetoneHz: DefaultSidetoneHz);
+
+            return new CwSettingsDto(
+                Wpm: e.Wpm,
+                FarnsworthWpm: e.FarnsworthWpm,
+                Macros: SanitizeStored(e.Macros),
+                SidetoneGainDb: e.SidetoneGainDb,
+                SidetoneHz: e.SidetoneHz);
+        }
+    }
+
+    /// <summary>
+    /// Merge a PATCH-shaped request on top of the persisted row. Null
+    /// fields preserve their current value; non-null fields are validated
+    /// (Wpm clamped 5..50, sidetone clamped to sane ranges, macros padded /
+    /// truncated to <see cref="MacroSlotCount"/> with per-string length cap).
+    /// Returns the post-merge snapshot.
+    /// </summary>
+    public CwSettingsDto Save(CwSettingsSetRequest req)
+    {
+        ArgumentNullException.ThrowIfNull(req);
+        lock (_sync)
+        {
+            var existing = _docs.FindAll().FirstOrDefault();
+            var entry = existing ?? SeedDefaultsEntry();
+
+            if (req.Wpm is int w)
+                entry.Wpm = Math.Clamp(w, 5, 50);
+            if (req.FarnsworthWpm is int fw)
+                entry.FarnsworthWpm = fw <= 0 ? null : Math.Clamp(fw, 5, 50);
+            else if (req.FarnsworthWpm is null && existing is not null)
+            {
+                // Null in the request keeps the existing value (PATCH semantics).
+                // No-op here, just being explicit about the contract.
+            }
+            if (req.Macros is { } macros)
+                entry.Macros = NormalizeMacros(macros);
+            if (req.SidetoneGainDb is double g)
+                // Operator-safe sidetone band: -60..+0 dB. Above 0 risks
+                // hard-clipping; below -60 is effectively silent.
+                entry.SidetoneGainDb = Math.Clamp(g, -60.0, 0.0);
+            if (req.SidetoneHz is int hz)
+                // CW pitch operator preference range. Below 200 is sub-bass
+                // and below the WDSP RX bandpass; above 1200 is uncomfortable.
+                entry.SidetoneHz = Math.Clamp(hz, 200, 1200);
+
+            entry.UpdatedUtc = DateTime.UtcNow;
+            if (existing is null) _docs.Insert(entry);
+            else _docs.Update(entry);
+
+            return new CwSettingsDto(
+                Wpm: entry.Wpm,
+                FarnsworthWpm: entry.FarnsworthWpm,
+                Macros: SanitizeStored(entry.Macros),
+                SidetoneGainDb: entry.SidetoneGainDb,
+                SidetoneHz: entry.SidetoneHz);
+        }
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private static CwSettingsEntry SeedDefaultsEntry() => new()
+    {
+        Wpm = DefaultWpm,
+        FarnsworthWpm = null,
+        Macros = (string[])DefaultMacros.Clone(),
+        SidetoneGainDb = DefaultSidetoneGainDb,
+        SidetoneHz = DefaultSidetoneHz,
+    };
+
+    /// <summary>Normalise a persisted Macros array on read. LiteDB
+    /// serialises empty strings as null on the round-trip — translate
+    /// back to empty so the wire shape is consistent. Variable length:
+    /// honours whatever the operator saved, up to <see cref="MaxMacros"/>.</summary>
+    private static string[] SanitizeStored(string[]? persisted)
+    {
+        if (persisted is null || persisted.Length == 0) return Array.Empty<string>();
+        int n = Math.Min(persisted.Length, MaxMacros);
+        var result = new string[n];
+        for (int i = 0; i < n; i++) result[i] = persisted[i] ?? string.Empty;
+        return result;
+    }
+
+    /// <summary>Validate + length-cap a user-supplied Macros array. The
+    /// length is preserved (operator chooses how many macros to keep —
+    /// add and delete are first-class operations) but capped at
+    /// <see cref="MaxMacros"/>; per-string content is capped at
+    /// <see cref="MaxMacroChars"/>. Null entries become empty strings.</summary>
+    private static string[] NormalizeMacros(string[] macros)
+    {
+        int n = Math.Min(macros.Length, MaxMacros);
+        var result = new string[n];
+        for (int i = 0; i < n; i++)
+        {
+            string raw = macros[i] ?? string.Empty;
+            result[i] = raw.Length > MaxMacroChars ? raw[..MaxMacroChars] : raw;
+        }
+        return result;
+    }
+}
+
+public sealed class CwSettingsEntry
+{
+    public int Id { get; set; }
+    public int Wpm { get; set; } = CwSettingsStore.DefaultWpm;
+    public int? FarnsworthWpm { get; set; }
+    public string[] Macros { get; set; } = (string[])CwSettingsStore.DefaultMacros.Clone();
+    public double SidetoneGainDb { get; set; } = CwSettingsStore.DefaultSidetoneGainDb;
+    public int SidetoneHz { get; set; } = CwSettingsStore.DefaultSidetoneHz;
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/StreamingHub.cs
+++ b/Zeus.Server.Hosting/StreamingHub.cs
@@ -334,6 +334,24 @@ public sealed class StreamingHub
         }
     }
 
+    public void Broadcast(in CwEngineStatusFrame frame)
+    {
+        if (_clients.IsEmpty) return;
+        // Variable-length: 9-byte header + UTF-8 text bytes (capped at
+        // MaxTextBytes). Compute exact size up front so the broadcast
+        // payload allocates once — same shape as AlertFrame above.
+        int textBytes = System.Text.Encoding.UTF8.GetByteCount(frame.Text ?? string.Empty);
+        if (textBytes > CwEngineStatusFrame.MaxTextBytes) textBytes = CwEngineStatusFrame.MaxTextBytes;
+        int total = CwEngineStatusFrame.HeaderByteLength + textBytes;
+        var payload = new byte[total];
+        var writer = new FixedBufferWriter(payload, total);
+        frame.Serialize(writer);
+        foreach (var client in _clients.Values)
+        {
+            if (!client.TryEnqueue(payload)) System.Threading.Interlocked.Increment(ref _dropsOther);
+        }
+    }
+
     public void Broadcast(in WisdomStatusFrame frame)
     {
         SetWisdomPhase(frame.Phase);

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -469,6 +469,18 @@ public static class ZeusEndpoints
             return Results.Ok();
         });
 
+        // Persisted CW operator settings (WPM, Farnsworth, 6 macros,
+        // sidetone gain/pitch). PATCH-shaped PUT: every field nullable so
+        // the UI can save one slider or one macro without round-tripping
+        // the whole record. Returns the post-merge snapshot so the client
+        // can reconcile its store with what the server actually stored
+        // (e.g. clamped values).
+        app.MapGet("/api/cw/settings", (CwSettingsStore store) =>
+            Results.Ok(store.Get()));
+
+        app.MapPut("/api/cw/settings", (CwSettingsSetRequest req, CwSettingsStore store) =>
+            Results.Ok(store.Save(req)));
+
         // Mic-gain: N dB in [-40, +10], scales WDSP TXA panel-gain-1 the same
         // way Thetis does (console.cs:28805 setAudioMicGain → Audio.MicPreamp =
         // 10^(db/20) → cmaster.CMSetTXAPanelGain1). The negative range is the

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -246,6 +246,7 @@ public static class ZeusHost
         // Host-side CW keyer (zeus-drf). Single instance, drains a job queue
         // and pushes envelope-shaped IQ directly into TxIqRing while holding
         // MOX as MoxSource.Cwx.
+        builder.Services.AddSingleton<CwSettingsStore>();
         builder.Services.AddSingleton<CwEngine>();
         builder.Services.AddHostedService(sp => sp.GetRequiredService<CwEngine>());
         // PS auto-attenuate timer2code-equivalent: ramps the radio's TX step

--- a/tests/Zeus.Contracts.Tests/CwEngineStatusFrameTests.cs
+++ b/tests/Zeus.Contracts.Tests/CwEngineStatusFrameTests.cs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+
+using System.Buffers;
+using Zeus.Contracts;
+using Xunit;
+
+namespace Zeus.Contracts.Tests;
+
+public class CwEngineStatusFrameTests
+{
+    [Fact]
+    public void SerializeDeserialize_RoundTrip()
+    {
+        var frame = new CwEngineStatusFrame(
+            State: CwEngineState.Sending,
+            Wpm: 22,
+            QueueDepth: 3,
+            Text: "CQ CQ CQ DE EA5IUE");
+        var writer = new ArrayBufferWriter<byte>();
+        frame.Serialize(writer);
+
+        var decoded = CwEngineStatusFrame.Deserialize(writer.WrittenSpan);
+
+        Assert.Equal(CwEngineState.Sending, decoded.State);
+        Assert.Equal(22, decoded.Wpm);
+        Assert.Equal(3, decoded.QueueDepth);
+        Assert.Equal("CQ CQ CQ DE EA5IUE", decoded.Text);
+    }
+
+    [Fact]
+    public void Serialize_WritesCorrectMsgType()
+    {
+        var frame = new CwEngineStatusFrame(CwEngineState.Idle, 20, 0, "");
+        var writer = new ArrayBufferWriter<byte>();
+        frame.Serialize(writer);
+
+        Assert.Equal((byte)MsgType.CwEngineStatus, writer.WrittenSpan[0]);
+    }
+
+    [Fact]
+    public void Serialize_EmptyText_Produces9ByteFrame()
+    {
+        var frame = new CwEngineStatusFrame(CwEngineState.Idle, 0, 0, "");
+        var writer = new ArrayBufferWriter<byte>();
+        frame.Serialize(writer);
+
+        // 1 byte type + 1 state + 2 wpm + 2 depth + 2 textLen + 0 text = 9.
+        Assert.Equal(CwEngineStatusFrame.HeaderByteLength, writer.WrittenSpan.Length);
+    }
+
+    [Fact]
+    public void Serialize_Utf8Text_RoundTripsCleanly()
+    {
+        // UTF-8-encoded macro lengths can exceed .Length; the frame must
+        // round-trip the bytes, not the char count.
+        var frame = new CwEngineStatusFrame(CwEngineState.Sending, 18, 1, "73 — gud QSO");
+        var writer = new ArrayBufferWriter<byte>();
+        frame.Serialize(writer);
+        var decoded = CwEngineStatusFrame.Deserialize(writer.WrittenSpan);
+
+        Assert.Equal("73 — gud QSO", decoded.Text);
+    }
+
+    [Fact]
+    public void Serialize_OversizedText_TruncatesToMax()
+    {
+        // Defensive cap so a runaway macro can't blow a single broadcast
+        // frame. Truncation happens silently at the serializer; deserialize
+        // sees only the truncated text and is still well-formed.
+        var huge = new string('X', CwEngineStatusFrame.MaxTextBytes * 2);
+        var frame = new CwEngineStatusFrame(CwEngineState.Sending, 20, 0, huge);
+        var writer = new ArrayBufferWriter<byte>();
+        frame.Serialize(writer);
+
+        var decoded = CwEngineStatusFrame.Deserialize(writer.WrittenSpan);
+        Assert.Equal(CwEngineStatusFrame.MaxTextBytes, decoded.Text.Length);
+    }
+
+    [Fact]
+    public void Deserialize_RejectsWrongMsgType()
+    {
+        var bytes = new byte[CwEngineStatusFrame.HeaderByteLength];
+        bytes[0] = (byte)MsgType.Alert;       // wrong type
+        Assert.Throws<InvalidDataException>(() => CwEngineStatusFrame.Deserialize(bytes));
+    }
+
+    [Fact]
+    public void Deserialize_RejectsTruncatedHeader()
+    {
+        var bytes = new byte[CwEngineStatusFrame.HeaderByteLength - 1];
+        bytes[0] = (byte)MsgType.CwEngineStatus;
+        Assert.Throws<InvalidDataException>(() => CwEngineStatusFrame.Deserialize(bytes));
+    }
+
+    [Fact]
+    public void Deserialize_RejectsTruncatedText()
+    {
+        // Header claims 50 bytes of text but only 10 follow — the frame
+        // is malformed and must be rejected rather than silently returning
+        // a short string.
+        var frame = new CwEngineStatusFrame(CwEngineState.Sending, 20, 0, new string('A', 50));
+        var writer = new ArrayBufferWriter<byte>();
+        frame.Serialize(writer);
+        var truncated = writer.WrittenSpan.Slice(0, CwEngineStatusFrame.HeaderByteLength + 10).ToArray();
+
+        Assert.Throws<InvalidDataException>(() => CwEngineStatusFrame.Deserialize(truncated));
+    }
+
+    [Fact]
+    public void FromStatus_LiftsDtoFieldsOntoWire()
+    {
+        var status = new CwEngineStatus(
+            State: CwEngineState.Stopping,
+            Text: "AGN?",
+            Wpm: 25,
+            QueueDepth: 7,
+            Reason: "operator request");
+
+        var frame = CwEngineStatusFrame.FromStatus(status);
+
+        Assert.Equal(CwEngineState.Stopping, frame.State);
+        Assert.Equal(25, frame.Wpm);
+        Assert.Equal(7, frame.QueueDepth);
+        Assert.Equal("AGN?", frame.Text);
+        // Reason is intentionally not in the wire frame — frontend doesn't
+        // need it; logged server-side only. Just sanity-check the lift
+        // didn't crash on the nullable.
+    }
+}

--- a/tests/Zeus.Server.Tests/CwSettingsStoreTests.cs
+++ b/tests/Zeus.Server.Tests/CwSettingsStoreTests.cs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class CwSettingsStoreTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-cwset-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+    }
+
+    private CwSettingsStore Build() =>
+        new(NullLogger<CwSettingsStore>.Instance, _dbPath);
+
+    [Fact]
+    public void Get_OnFreshDb_ReturnsSeededDefaults()
+    {
+        using var store = Build();
+
+        var s = store.Get();
+
+        Assert.Equal(CwSettingsStore.DefaultWpm, s.Wpm);
+        Assert.Null(s.FarnsworthWpm);
+        Assert.Equal(CwSettingsStore.DefaultSidetoneGainDb, s.SidetoneGainDb);
+        Assert.Equal(CwSettingsStore.DefaultSidetoneHz, s.SidetoneHz);
+        // Fresh install gets the six seeded defaults — operator can grow
+        // the list to MaxMacros via PATCH.
+        Assert.Equal(CwSettingsStore.DefaultMacros.Length, s.Macros.Length);
+        Assert.Equal(CwSettingsStore.DefaultMacros, s.Macros);
+    }
+
+    [Fact]
+    public void Save_RoundtripsSingleField_LeavesOthersUntouched()
+    {
+        // PATCH semantics — saving Wpm alone must not wipe the macros.
+        using var store = Build();
+
+        var after = store.Save(new CwSettingsSetRequest(Wpm: 30));
+
+        Assert.Equal(30, after.Wpm);
+        Assert.Equal(CwSettingsStore.DefaultMacros, after.Macros);
+        Assert.Equal(CwSettingsStore.DefaultSidetoneGainDb, after.SidetoneGainDb);
+    }
+
+    [Fact]
+    public void Save_ClampsOutOfRangeFields()
+    {
+        // The store is the last line of defence before LiteDB persists —
+        // any pathological value (UI bug, hand-rolled curl) must clamp
+        // rather than write garbage that survives restarts.
+        using var store = Build();
+
+        var after = store.Save(new CwSettingsSetRequest(
+            Wpm: 999,
+            FarnsworthWpm: 999,
+            SidetoneGainDb: +10.0,
+            SidetoneHz: 50));
+
+        Assert.Equal(50, after.Wpm);                  // clamped to WpmMax
+        Assert.Equal(50, after.FarnsworthWpm);
+        Assert.Equal(0.0, after.SidetoneGainDb);      // clamped to ≤ 0
+        Assert.Equal(200, after.SidetoneHz);          // clamped to ≥ 200
+    }
+
+    [Fact]
+    public void Save_PreservesMacroLength_AndDoesNotPad()
+    {
+        // Variable-length: if the operator saves two macros, only two are
+        // persisted (add/delete are first-class operations from the UI).
+        // The previous fixed-6 padding behaviour would have hidden a
+        // genuine "user deleted 4 of 6 macros" intent behind invisible
+        // empty slots that the macro pad would still render.
+        using var store = Build();
+
+        var raw = new[] { "ONE", "TWO" };
+        var after = store.Save(new CwSettingsSetRequest(Macros: raw));
+
+        Assert.Equal(2, after.Macros.Length);
+        Assert.Equal("ONE", after.Macros[0]);
+        Assert.Equal("TWO", after.Macros[1]);
+    }
+
+    [Fact]
+    public void Save_CapsMacroCount_AtMaxMacros()
+    {
+        // Defensive upper bound — a programmatic mass-save (or a bug in
+        // an upcoming "import macros" feature) can't blow past the cap.
+        using var store = Build();
+        var huge = Enumerable.Range(0, CwSettingsStore.MaxMacros * 2)
+            .Select(i => $"M{i}")
+            .ToArray();
+
+        var after = store.Save(new CwSettingsSetRequest(Macros: huge));
+
+        Assert.Equal(CwSettingsStore.MaxMacros, after.Macros.Length);
+    }
+
+    [Fact]
+    public void Save_CapsMacroLength()
+    {
+        using var store = Build();
+        string huge = new string('A', CwSettingsStore.MaxMacroChars * 3);
+
+        var after = store.Save(new CwSettingsSetRequest(Macros: new[] { huge }));
+
+        Assert.Equal(CwSettingsStore.MaxMacroChars, after.Macros[0].Length);
+    }
+
+    [Fact]
+    public void Get_AfterDispose_AndReopen_ReturnsPersistedValues()
+    {
+        // Survives a backend restart — the whole point of the store.
+        // Empty-string slots in the middle of the list are preserved
+        // (LiteDB serialises "" as null; SanitizeStored maps back).
+        using (var store = Build())
+        {
+            store.Save(new CwSettingsSetRequest(
+                Wpm: 28,
+                Macros: new[] { "X", "Y", "Z", "", "M5" }));
+        }
+
+        using var reopened = Build();
+        var s = reopened.Get();
+
+        Assert.Equal(28, s.Wpm);
+        Assert.Equal(5, s.Macros.Length);
+        Assert.Equal("X", s.Macros[0]);
+        Assert.Equal("Y", s.Macros[1]);
+        Assert.Equal("Z", s.Macros[2]);
+        Assert.Equal(string.Empty, s.Macros[3]);
+        Assert.Equal("M5", s.Macros[4]);
+    }
+}

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -400,7 +400,8 @@ export default function App() {
     setCallsign('');
   }, [setCallsign]);
 
-  const [wpm, setWpm] = useState(22);
+  // CW WPM is now persisted server-side via /api/cw/settings and read
+  // through useCwStore — no longer threaded through the workspace context.
   const nrState = useConnectionStore((s) => s.nr);
   const dspActive =
     nrState.nrMode !== 'Off' ||
@@ -628,8 +629,6 @@ export default function App() {
     handleLogQso,
     handleClearQrz,
     dspActive,
-    wpm,
-    setWpm,
     logbookTitle,
     logbookActions,
   }), [
@@ -641,7 +640,7 @@ export default function App() {
     beamOverrideDeg, beamInputStr, rotLiveAz, sp, lp, dist,
     // heroTitle and logbookActions are ReactNodes (new objects each render);
     // their underlying primitive deps are already above, so omit them here.
-    dspActive, wpm, logbookTitle,
+    dspActive, logbookTitle,
     handleLogQso, handleClearQrz, runQrzLookup,
   ]);
 

--- a/zeus-web/src/api/cw.ts
+++ b/zeus-web/src/api/cw.ts
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+
+// CW endpoints: /api/cw/send, /api/cw/abort, /api/cw/settings.
+// Backend lives in Zeus.Server.Hosting/CwEngine.cs (engine) +
+// CwSettingsStore.cs (persistence). Status feedback for in-flight
+// playback arrives over WebSocket as MsgType.CwEngineStatus (0x30) —
+// consumed in realtime/ws-client.ts and pushed into useCwStore.
+
+export type CwSettings = {
+  wpm: number;
+  // Farnsworth char-rate floor (slower than wpm). null = pure WPM, no
+  // Farnsworth — current default.
+  farnsworthWpm: number | null;
+  // Exactly 6 slots; empty strings are valid (renders the slot as an
+  // unlabelled placeholder button in the 2×3 grid).
+  macros: string[];
+  sidetoneGainDb: number;
+  sidetoneHz: number;
+};
+
+type CwSettingsDtoRaw = {
+  wpm?: number;
+  farnsworthWpm?: number | null;
+  macros?: string[];
+  sidetoneGainDb?: number;
+  sidetoneHz?: number;
+};
+
+const DEFAULT_MACROS = ['CQ CQ CQ', 'TU 73', 'QRZ?', 'AGN?', '5NN TU', 'UR RST'];
+
+// Single source of truth for the fallback shape — used when the backend
+// is unreachable on first load so the UI still renders a sensible macro
+// pad. Server has the authoritative defaults; this just mirrors them so
+// the UI doesn't flicker through "empty" on slow networks.
+export const DEFAULT_CW_SETTINGS: CwSettings = {
+  wpm: 22,
+  farnsworthWpm: null,
+  macros: [...DEFAULT_MACROS],
+  sidetoneGainDb: -10,
+  sidetoneHz: 600,
+};
+
+function normalize(raw: CwSettingsDtoRaw): CwSettings {
+  // Variable-length: pass through whatever the server sent (operator
+  // chose the count). Map non-string entries to empty strings defensively
+  // so a malformed wire payload never crashes the renderer.
+  const macros = (raw.macros ?? []).map((m) => (typeof m === 'string' ? m : ''));
+  return {
+    wpm: typeof raw.wpm === 'number' ? raw.wpm : DEFAULT_CW_SETTINGS.wpm,
+    farnsworthWpm:
+      typeof raw.farnsworthWpm === 'number' ? raw.farnsworthWpm : null,
+    macros,
+    sidetoneGainDb:
+      typeof raw.sidetoneGainDb === 'number'
+        ? raw.sidetoneGainDb
+        : DEFAULT_CW_SETTINGS.sidetoneGainDb,
+    sidetoneHz:
+      typeof raw.sidetoneHz === 'number'
+        ? raw.sidetoneHz
+        : DEFAULT_CW_SETTINGS.sidetoneHz,
+  };
+}
+
+export async function fetchCwSettings(signal?: AbortSignal): Promise<CwSettings> {
+  const res = await fetch('/api/cw/settings', { signal });
+  if (!res.ok) throw new Error(`GET /api/cw/settings → ${res.status}`);
+  return normalize((await res.json()) as CwSettingsDtoRaw);
+}
+
+/** PATCH-shaped PUT — only the fields you pass are sent. */
+export async function saveCwSettings(
+  patch: Partial<CwSettings>,
+  signal?: AbortSignal,
+): Promise<CwSettings> {
+  const body: CwSettingsDtoRaw = {};
+  if (patch.wpm !== undefined) body.wpm = patch.wpm;
+  if (patch.farnsworthWpm !== undefined) body.farnsworthWpm = patch.farnsworthWpm;
+  if (patch.macros !== undefined) body.macros = patch.macros;
+  if (patch.sidetoneGainDb !== undefined) body.sidetoneGainDb = patch.sidetoneGainDb;
+  if (patch.sidetoneHz !== undefined) body.sidetoneHz = patch.sidetoneHz;
+
+  const res = await fetch('/api/cw/settings', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+    signal,
+  });
+  if (!res.ok) throw new Error(`PUT /api/cw/settings → ${res.status}`);
+  return normalize((await res.json()) as CwSettingsDtoRaw);
+}
+
+/** Enqueue text for transmission. Returns when the server has accepted
+ * the job (HTTP 202) — playback happens on the engine worker. WPM omitted
+ * = use the persisted operator default (CwSettingsStore.Wpm). */
+export async function sendCw(text: string, wpm?: number, signal?: AbortSignal): Promise<void> {
+  const res = await fetch('/api/cw/send', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(wpm === undefined ? { text } : { text, wpm }),
+    signal,
+  });
+  if (!res.ok && res.status !== 202) {
+    throw new Error(`POST /api/cw/send → ${res.status}`);
+  }
+}
+
+/** Hard abort. Drops the queue + cancels in-flight playback. Best-effort
+ * — always returns OK (server-side too). */
+export async function abortCw(signal?: AbortSignal): Promise<void> {
+  await fetch('/api/cw/abort', { method: 'POST', signal });
+}

--- a/zeus-web/src/components/design/CwKeyer.tsx
+++ b/zeus-web/src/components/design/CwKeyer.tsx
@@ -1,74 +1,253 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 //
 // Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
-// Copyright (C) 2025-2026 Brian Keating (EI6LF),
-//                         Douglas J. Cerrato (KB2UKA), and contributors.
-//
-// This program is free software: you can redistribute it and/or modify it
-// under the terms of the GNU General Public License as published by the
-// Free Software Foundation, either version 2 of the License, or (at your
-// option) any later version. See the LICENSE file at the root of this
-// repository for the full text, or https://www.gnu.org/licenses/.
-//
-// Zeus is an independent reimplementation in .NET — not a fork. Its
-// Protocol-1 / Protocol-2 framing, WDSP integration, meter pipelines, and
-// TX behaviour were informed by studying the Thetis project
-// (https://github.com/ramdor/Thetis), the authoritative reference
-// implementation in the OpenHPSDR ecosystem. Zeus gratefully acknowledges
-// the Thetis contributors whose work made this possible:
-//
-//   Richard Samphire (MW0LGE), Warren Pratt (NR0V),
-//   Laurence Barker (G8NJJ),   Rick Koch (N1GP),
-//   Bryan Rambo (W4WMT),       Chris Codella (W2PA),
-//   Doug Wigley (W5WC),        FlexRadio Systems,
-//   Richard Allen (W5SD),      Joe Torrey (WD5Y),
-//   Andrew Mansfield (M0YGG),  Reid Campbell (MI0BOT),
-//   Sigi Jetzlsperger (DH1KLM).
-//
-// Thetis itself continues the GPL-governed lineage of FlexRadio PowerSDR
-// and the OpenHPSDR (TAPR/OpenHPSDR) ecosystem; that lineage is preserved
-// here. See ATTRIBUTIONS.md at the repository root for the full provenance
-// statement and per-component attribution.
-//
-// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
-// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
-// Wüllen (DL1YCF); and by DeskHPSDR
-// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
-// Both are GPL-2.0-or-later.
-//
-// WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
-// (NR0V), distributed under GPL v2 or later.
-//
-// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
-// License for details.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
 
-import { Slider } from './Slider';
+import { useState } from 'react';
+import type { CwEngineStatus } from '../../state/cw-store';
 
-type CwKeyerProps = {
+export type CwKeyerProps = {
   wpm: number;
-  setWpm: (v: number) => void;
-  onSend?: (macro: string) => void;
+  /** Tracks the slider while dragging — local-only, no PUT. */
+  setWpmLocal: (v: number) => void;
+  /** Schedules the server save after the operator stops moving. */
+  setWpmCommit: (v: number) => void;
+  macros: string[];
+  onSend: (macro: string) => void;
+  onAbort: () => void;
+  onMacroEdit: (index: number, value: string) => void;
+  onMacroDelete: (index: number) => void;
+  onMacroAdd: () => void;
+  /** Hard cap from the backend — disables the Add button at the limit. */
+  maxMacros: number;
+  /** Live engine status from the WS hub. Idle when nothing in flight. */
+  status: CwEngineStatus;
 };
 
-const MACROS = ['CQ CQ CQ', 'TU 73', 'QRZ?', 'AGN?', '5NN TU', 'UR RST'];
+const WPM_MIN = 5;
+const WPM_MAX = 40;
 
-export function CwKeyer({ wpm, setWpm, onSend }: CwKeyerProps) {
+export function CwKeyer({
+  wpm,
+  setWpmLocal,
+  setWpmCommit,
+  macros,
+  onSend,
+  onAbort,
+  onMacroEdit,
+  onMacroDelete,
+  onMacroAdd,
+  maxMacros,
+  status,
+}: CwKeyerProps) {
+  // Index of the macro slot currently in edit mode. null = no inline
+  // editor open. The editor is opened by clicking the ✎ icon next to a
+  // slot; click elsewhere or press Enter/Esc to close.
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  const [editDraft, setEditDraft] = useState<string>('');
+
+  const isSending = status.state === 'sending' || status.state === 'stopping';
+  const atMacroLimit = macros.length >= maxMacros;
+
+  const startEditing = (index: number, current: string) => {
+    setEditDraft(current);
+    setEditingIndex(index);
+  };
+
+  const commitEdit = (index: number) => {
+    if (editDraft !== macros[index]) onMacroEdit(index, editDraft);
+    setEditingIndex(null);
+  };
+
   return (
-    <div className="cw">
-      <div className="cw-row">
-        <Slider label="WPM" value={wpm} onChange={setWpm} min={5} max={40} />
+    <div className="cw cw-console">
+      <CwStream status={status} />
+
+      <div className="cw-control-strip">
+        <div className={`cw-wpm-readout ${isSending ? 'is-active' : ''}`}>
+          <span className="cw-wpm-label">WPM</span>
+          <span className="cw-wpm-value mono">{wpm}</span>
+        </div>
+        <div className="cw-wpm-track">
+          <input
+            type="range"
+            min={WPM_MIN}
+            max={WPM_MAX}
+            step={1}
+            value={wpm}
+            onChange={(e) => {
+              const v = Number(e.currentTarget.value);
+              setWpmLocal(v);
+              setWpmCommit(v);
+            }}
+            aria-label="Words per minute"
+          />
+          <div className="cw-wpm-scale">
+            <span>{WPM_MIN}</span>
+            <span>{WPM_MAX}</span>
+          </div>
+        </div>
+        <button
+          type="button"
+          className={`cw-stop ${isSending ? 'is-armed' : ''}`}
+          onClick={onAbort}
+          disabled={!isSending}
+          title="Abort current transmission and drain queue"
+          aria-label="STOP"
+        >
+          STOP
+        </button>
       </div>
-      <div className="cw-macros">
-        {MACROS.map((m) => (
-          <button key={m} type="button" className="btn sm" onClick={() => onSend?.(m)}>
-            {m}
-          </button>
+
+      <div className="cw-macro-list" role="list">
+        {macros.map((m, i) => (
+          <div key={i} className="cw-macro-row" role="listitem">
+            <span className="cw-macro-num mono" aria-hidden="true">
+              {String(i + 1).padStart(2, '0')}
+            </span>
+            {editingIndex === i ? (
+              <input
+                className="cw-macro-edit"
+                autoFocus
+                value={editDraft}
+                onChange={(e) => setEditDraft(e.target.value)}
+                onBlur={() => commitEdit(i)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') e.currentTarget.blur();
+                  else if (e.key === 'Escape') setEditingIndex(null);
+                }}
+              />
+            ) : (
+              <button
+                type="button"
+                className={`cw-macro-send ${m === '' ? 'is-empty' : ''}`}
+                onClick={() => m !== '' && onSend(m)}
+                disabled={m === ''}
+                title={m === '' ? 'Empty slot — edit to set' : `Send "${m}"`}
+              >
+                {m === '' ? <em>empty — edit me</em> : m}
+              </button>
+            )}
+            <button
+              type="button"
+              className="cw-macro-icon"
+              onClick={() => startEditing(i, m)}
+              title="Edit macro"
+              aria-label={`Edit macro ${i + 1}`}
+            >
+              <EditGlyph />
+            </button>
+            <button
+              type="button"
+              className="cw-macro-icon is-danger"
+              onClick={() => onMacroDelete(i)}
+              title="Delete macro"
+              aria-label={`Delete macro ${i + 1}`}
+            >
+              <DeleteGlyph />
+            </button>
+          </div>
         ))}
-      </div>
-      <div className="cw-stream mono">
-        <span className="cw-cursor">▮</span>
-        <span style={{ color: 'var(--fg-2)' }}>·  — ·  — · — ·  · — · ·  — — —</span>
+        <button
+          type="button"
+          className="cw-macro-add"
+          onClick={onMacroAdd}
+          disabled={atMacroLimit}
+          title={atMacroLimit ? `Maximum ${maxMacros} macros reached` : 'Add a new macro slot'}
+        >
+          <span className="cw-macro-add-plus" aria-hidden="true">+</span>
+          <span className="cw-macro-add-label">
+            {atMacroLimit ? `LIMIT — ${maxMacros} macros` : 'ADD MACRO'}
+          </span>
+        </button>
       </div>
     </div>
+  );
+}
+
+/* ---- Stream display (HERO) ----
+ * Renders what's being keyed right now as a "telegraph tape" across the
+ * top of the panel. Always present (no layout shift on idle ↔ sending);
+ * a small LED + state label on the left and a queue-depth chip on the
+ * right; the centre carries the live text with a JetBrains-Mono cursor
+ * estimated from elapsed-time × WPM. Server only emits status frames on
+ * state edges, so per-character animation has to be reconstructed
+ * client-side.
+ */
+function CwStream({ status }: { status: CwEngineStatus }) {
+  const [nowMs, setNowMs] = useState<number>(() => Date.now());
+  const active = status.state === 'sending' || status.state === 'stopping';
+  if (active) {
+    requestAnimationFrame(() => setNowMs(Date.now()));
+  }
+
+  const unitMs = status.wpm > 0 ? 1200 / status.wpm : 60;
+  const elapsedMs = Math.max(0, nowMs - status.receivedAtMs);
+  const charIdx = active
+    ? Math.min(status.text.length, Math.floor(elapsedMs / (10 * unitMs)))
+    : 0;
+
+  const stateLabel: Record<CwEngineStatus['state'], string> = {
+    idle: 'READY',
+    sending: 'SENDING',
+    stopping: 'STOPPING',
+    aborting: 'ABORTING',
+  };
+
+  return (
+    <div
+      className={`cw-stream-hero ${active ? 'is-active' : 'is-idle'}`}
+      data-state={status.state}
+    >
+      <div className="cw-stream-tag">
+        <span className="cw-stream-led" aria-hidden="true" />
+        <span className="cw-stream-label">{stateLabel[status.state]}</span>
+      </div>
+      <div className="cw-stream-tape mono">
+        {active ? (
+          <>
+            <span className="cw-stream-sent">{status.text.slice(0, charIdx)}</span>
+            <span className="cw-stream-cursor">
+              {status.text.charAt(charIdx) || '▮'}
+            </span>
+            <span className="cw-stream-pending">{status.text.slice(charIdx + 1)}</span>
+          </>
+        ) : (
+          <span className="cw-stream-placeholder">—— STAND BY ——</span>
+        )}
+      </div>
+      <div className="cw-stream-queue mono" aria-live="polite">
+        {status.queueDepth > 0 ? `+${status.queueDepth}` : '·'}
+      </div>
+    </div>
+  );
+}
+
+/* ---- Glyphs ----
+ * Inline SVGs so the icon weight matches Inter at the panel's text size
+ * (Unicode pencil / ✕ were inconsistent across platforms — heavy on macOS,
+ * thin on Linux). 12 px viewport, currentColor stroke so they pick up the
+ * button's text colour for free.
+ */
+function EditGlyph() {
+  return (
+    <svg viewBox="0 0 12 12" width="12" height="12" aria-hidden="true">
+      <path
+        d="M1.5 9.5 L8.5 2.5 L10 4 L3 11 L1 11 L1.5 9.5 Z"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1"
+        strokeLinejoin="round"
+      />
+      <path d="M7.5 3.5 L9 5" fill="none" stroke="currentColor" strokeWidth="1" />
+    </svg>
+  );
+}
+
+function DeleteGlyph() {
+  return (
+    <svg viewBox="0 0 12 12" width="12" height="12" aria-hidden="true">
+      <path d="M2 2 L10 10 M10 2 L2 10" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" />
+    </svg>
   );
 }

--- a/zeus-web/src/layout/WorkspaceContext.tsx
+++ b/zeus-web/src/layout/WorkspaceContext.tsx
@@ -106,9 +106,8 @@ export interface WorkspaceCtx {
   // DSP
   dspActive: boolean;
 
-  // CW
-  wpm: number;
-  setWpm: (v: number) => void;
+  // CW state lives in src/state/cw-store.ts (persisted server-side via
+  // /api/cw/settings) — no longer threaded through the workspace context.
 
   // Logbook
   logbookTitle: string;

--- a/zeus-web/src/layout/panels/CwPanel.tsx
+++ b/zeus-web/src/layout/panels/CwPanel.tsx
@@ -1,56 +1,49 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 //
 // Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
-// Copyright (C) 2025-2026 Brian Keating (EI6LF),
-//                         Douglas J. Cerrato (KB2UKA), and contributors.
-//
-// This program is free software: you can redistribute it and/or modify it
-// under the terms of the GNU General Public License as published by the
-// Free Software Foundation, either version 2 of the License, or (at your
-// option) any later version. See the LICENSE file at the root of this
-// repository for the full text, or https://www.gnu.org/licenses/.
-//
-// Zeus is an independent reimplementation in .NET — not a fork. Its
-// Protocol-1 / Protocol-2 framing, WDSP integration, meter pipelines, and
-// TX behaviour were informed by studying the Thetis project
-// (https://github.com/ramdor/Thetis), the authoritative reference
-// implementation in the OpenHPSDR ecosystem. Zeus gratefully acknowledges
-// the Thetis contributors whose work made this possible:
-//
-//   Richard Samphire (MW0LGE), Warren Pratt (NR0V),
-//   Laurence Barker (G8NJJ),   Rick Koch (N1GP),
-//   Bryan Rambo (W4WMT),       Chris Codella (W2PA),
-//   Doug Wigley (W5WC),        FlexRadio Systems,
-//   Richard Allen (W5SD),      Joe Torrey (WD5Y),
-//   Andrew Mansfield (M0YGG),  Reid Campbell (MI0BOT),
-//   Sigi Jetzlsperger (DH1KLM).
-//
-// Thetis itself continues the GPL-governed lineage of FlexRadio PowerSDR
-// and the OpenHPSDR (TAPR/OpenHPSDR) ecosystem; that lineage is preserved
-// here. See ATTRIBUTIONS.md at the repository root for the full provenance
-// statement and per-component attribution.
-//
-// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
-// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
-// Wüllen (DL1YCF); and by DeskHPSDR
-// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
-// Both are GPL-2.0-or-later.
-//
-// WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
-// (NR0V), distributed under GPL v2 or later.
-//
-// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
-// License for details.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
 
 import { CwKeyer } from '../../components/design/CwKeyer';
-import { useWorkspace } from '../WorkspaceContext';
+import { abortCw, sendCw } from '../../api/cw';
+import { useCwStore } from '../../state/cw-store';
+
+// Hard cap mirrors Zeus.Server.Hosting/CwSettingsStore.cs MaxMacros. If
+// the server bumps the cap, also bump this so the UI's "Add" button
+// matches. (We could fetch it dynamically, but a constant is cheaper
+// and only changes during epic-scale revisits.)
+const MAX_MACROS = 32;
 
 export function CwPanel() {
-  const { wpm, setWpm } = useWorkspace();
+  const settings = useCwStore((s) => s.settings);
+  const status = useCwStore((s) => s.status);
+  const setSettingsLocal = useCwStore((s) => s.setSettingsLocal);
+  const commitDebounced = useCwStore((s) => s.commitDebounced);
+  const setMacro = useCwStore((s) => s.setMacro);
+  const addMacro = useCwStore((s) => s.addMacro);
+  const removeMacro = useCwStore((s) => s.removeMacro);
 
   return (
     <div style={{ flex: 1, overflow: 'auto' }}>
-      <CwKeyer wpm={wpm} setWpm={setWpm} />
+      <CwKeyer
+        wpm={settings.wpm}
+        // Split-write pattern fixes the "slider snaps back" race. The
+        // local setter updates the store immediately so the slider
+        // tracks the pointer; the debounced commit schedules a single
+        // PUT after the operator stops dragging.
+        setWpmLocal={(v) => setSettingsLocal({ wpm: v })}
+        setWpmCommit={(v) => commitDebounced({ wpm: v })}
+        macros={settings.macros}
+        // Pass the current WPM explicitly so a slider change that hasn't
+        // round-tripped to the server yet still keys at the operator's
+        // intended speed.
+        onSend={(macro) => void sendCw(macro, settings.wpm)}
+        onAbort={() => void abortCw()}
+        onMacroEdit={(i, v) => void setMacro(i, v)}
+        onMacroDelete={(i) => void removeMacro(i)}
+        onMacroAdd={() => void addMacro()}
+        maxMacros={MAX_MACROS}
+        status={status}
+      />
     </div>
   );
 }

--- a/zeus-web/src/realtime/ws-client.ts
+++ b/zeus-web/src/realtime/ws-client.ts
@@ -163,6 +163,19 @@ export const MSG_TYPE_AUDIO_CHAIN_ORDER = 0x1e;
 export const MSG_TYPE_AUDIO_MASTER_BYPASS = 0x1f;
 const AUDIO_MASTER_BYPASS_BYTES = 2;
 
+// CW engine status — broadcast on every state edge of the host-side CW
+// keyer so the macro pad can render in-flight text + queue depth without
+// polling. Variable-length frame: 9-byte header + UTF-8 text. Contract:
+// Zeus.Contracts/CwEngineStatusFrame.cs.
+//
+// Wire shape:
+//   [0x30][state:u8][wpm:u16 LE][queueDepth:u16 LE][textLen:u16 LE][text:utf8…]
+//
+// 0x3x is the new "control-plane feedback" nibble (0x1x exhausted as of
+// AudioMasterBypass).
+export const MSG_TYPE_CW_ENGINE_STATUS = 0x30;
+const CW_ENGINE_STATUS_HEADER_BYTES = 9;
+
 // Shared by startRealtime / sendMicPcm. Single WS instance at a time; writes
 // are no-ops when the socket isn't open.
 let activeWs: WebSocket | null = null;
@@ -342,6 +355,49 @@ export function startRealtime(path = '/ws'): () => void {
           // window (e.g. the no-plugins-installed first-run experience).
           void import('../state/audio-suite-store').then((m) => {
             m.useAudioSuiteStore.getState().setChainOrderFromServer(ids);
+          });
+          return;
+        }
+        if (peekType === MSG_TYPE_CW_ENGINE_STATUS) {
+          if (ev.data.byteLength < CW_ENGINE_STATUS_HEADER_BYTES) {
+            warnOnce(
+              'ws-cw-status-short',
+              `cw status frame too short: ${ev.data.byteLength}`,
+            );
+            return;
+          }
+          const dv = new DataView(ev.data);
+          const stateByte = dv.getUint8(1);
+          const wpm = dv.getUint16(2, true);
+          const queueDepth = dv.getUint16(4, true);
+          const textLen = dv.getUint16(6, true);
+          if (ev.data.byteLength < CW_ENGINE_STATUS_HEADER_BYTES + textLen) {
+            warnOnce(
+              'ws-cw-status-truncated',
+              `cw status text claims ${textLen} bytes but only ${
+                ev.data.byteLength - CW_ENGINE_STATUS_HEADER_BYTES
+              } follow`,
+            );
+            return;
+          }
+          const text =
+            textLen === 0
+              ? ''
+              : new TextDecoder('utf-8').decode(
+                  new Uint8Array(ev.data, CW_ENGINE_STATUS_HEADER_BYTES, textLen),
+                );
+          // Lazy import keeps the cw-store off the critical path for
+          // clients that never open the CW panel (the macro pad is
+          // typically closed by default).
+          void import('../state/cw-store').then((m) => {
+            const state = m.CW_STATE_FROM_BYTE[stateByte] ?? 'idle';
+            m.useCwStore.getState().setStatusFromServer({
+              state,
+              text,
+              wpm,
+              queueDepth,
+              receivedAtMs: Date.now(),
+            });
           });
           return;
         }

--- a/zeus-web/src/state/cw-store.test.ts
+++ b/zeus-web/src/state/cw-store.test.ts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_CW_SETTINGS } from '../api/cw';
+import { useCwStore } from './cw-store';
+
+// The store hydrates on module load via a fetch — stub it to a no-op
+// before each test so we're always working from the API defaults.
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  useCwStore.setState({
+    settings: { ...DEFAULT_CW_SETTINGS, macros: [...DEFAULT_CW_SETTINGS.macros] },
+    status: {
+      state: 'idle',
+      text: '',
+      wpm: 0,
+      queueDepth: 0,
+      receivedAtMs: 0,
+    },
+  });
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('cw-store', () => {
+  it('seeds the default settings', () => {
+    const { settings } = useCwStore.getState();
+    expect(settings.wpm).toBe(22);
+    expect(settings.macros).toHaveLength(6);
+    expect(settings.macros[0]).toBe('CQ CQ CQ');
+  });
+
+  it('patchSettings PUTs once and applies the server response', async () => {
+    // Server normalises the wpm to a clamped value — store must re-apply.
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ...DEFAULT_CW_SETTINGS,
+        wpm: 40,  // server clamped from a hypothetical 999
+      }),
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    await useCwStore.getState().patchSettings({ wpm: 999 });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const call = fetchSpy.mock.calls[0]!;
+    expect(call[0]).toBe('/api/cw/settings');
+    expect(call[1]).toMatchObject({ method: 'PUT' });
+    const body = JSON.parse(call[1].body as string);
+    expect(body).toEqual({ wpm: 999 });
+    // Re-applied with server-normalised value.
+    expect(useCwStore.getState().settings.wpm).toBe(40);
+  });
+
+  it('patchSettings reverts the optimistic update on network failure', async () => {
+    globalThis.fetch = (() => Promise.reject(new Error('offline'))) as unknown as typeof fetch;
+
+    await useCwStore.getState().patchSettings({ wpm: 30 });
+
+    // Reverted to the seeded default — the operator sees their edit roll
+    // back, which is the honest signal that the save failed.
+    expect(useCwStore.getState().settings.wpm).toBe(22);
+  });
+
+  it('setMacro PATCHes only the macros field', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ...DEFAULT_CW_SETTINGS,
+        macros: ['HELLO', 'TU 73', 'QRZ?', 'AGN?', '5NN TU', 'UR RST'],
+      }),
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    await useCwStore.getState().setMacro(0, 'HELLO');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1].body as string);
+    // Only macros is in the body — wpm, sidetone etc. stay server-side.
+    expect(Object.keys(body)).toEqual(['macros']);
+    expect(body.macros[0]).toBe('HELLO');
+    expect(body.macros).toHaveLength(6);
+    expect(useCwStore.getState().settings.macros[0]).toBe('HELLO');
+  });
+
+  it('addMacro appends an empty slot and PUTs', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ...DEFAULT_CW_SETTINGS,
+        macros: [...DEFAULT_CW_SETTINGS.macros, ''],
+      }),
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    await useCwStore.getState().addMacro();
+
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1].body as string);
+    expect(body.macros).toHaveLength(DEFAULT_CW_SETTINGS.macros.length + 1);
+    expect(body.macros[DEFAULT_CW_SETTINGS.macros.length]).toBe('');
+    expect(useCwStore.getState().settings.macros).toHaveLength(
+      DEFAULT_CW_SETTINGS.macros.length + 1,
+    );
+  });
+
+  it('removeMacro drops the named index and PUTs', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ...DEFAULT_CW_SETTINGS,
+        macros: DEFAULT_CW_SETTINGS.macros.filter((_, i) => i !== 2),
+      }),
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    await useCwStore.getState().removeMacro(2);
+
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1].body as string);
+    expect(body.macros).toHaveLength(DEFAULT_CW_SETTINGS.macros.length - 1);
+    expect(body.macros).not.toContain(DEFAULT_CW_SETTINGS.macros[2]);
+  });
+
+  it('commitDebounced only PUTs once for a burst of calls', async () => {
+    // Regression for the "slider snaps back" bug: rapid pointer moves
+    // used to fire one PUT per tick, and out-of-order responses could
+    // clobber the operator's final value. commitDebounced coalesces.
+    vi.useFakeTimers();
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ...DEFAULT_CW_SETTINGS, wpm: 35 }),
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { commitDebounced } = useCwStore.getState();
+    commitDebounced({ wpm: 30 });
+    commitDebounced({ wpm: 31 });
+    commitDebounced({ wpm: 35 });
+    expect(fetchSpy).toHaveBeenCalledTimes(0);
+
+    vi.advanceTimersByTime(300);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1].body as string);
+    expect(body.wpm).toBe(35);
+
+    vi.useRealTimers();
+  });
+
+  it('setStatusFromServer replaces the in-flight status', () => {
+    useCwStore.getState().setStatusFromServer({
+      state: 'sending',
+      text: 'CQ CQ CQ',
+      wpm: 22,
+      queueDepth: 2,
+      receivedAtMs: 123456,
+    });
+
+    const { status } = useCwStore.getState();
+    expect(status.state).toBe('sending');
+    expect(status.text).toBe('CQ CQ CQ');
+    expect(status.wpm).toBe(22);
+    expect(status.queueDepth).toBe(2);
+    expect(status.receivedAtMs).toBe(123456);
+  });
+});

--- a/zeus-web/src/state/cw-store.ts
+++ b/zeus-web/src/state/cw-store.ts
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+
+import { create } from 'zustand';
+import {
+  DEFAULT_CW_SETTINGS,
+  fetchCwSettings,
+  saveCwSettings,
+  type CwSettings,
+} from '../api/cw';
+
+// CW engine state — must match the byte values of the C# CwEngineState
+// enum (Zeus.Contracts/CwEngineStatus.cs). Idle is the resting state with
+// no MOX; Sending is mid-playback; Stopping/Aborting are transitional.
+export type CwEngineState = 'idle' | 'sending' | 'stopping' | 'aborting';
+
+export const CW_STATE_FROM_BYTE: Record<number, CwEngineState> = {
+  0: 'idle',
+  1: 'sending',
+  2: 'stopping',
+  3: 'aborting',
+};
+
+export type CwEngineStatus = {
+  state: CwEngineState;
+  /** Text currently being keyed out (empty when state is idle). */
+  text: string;
+  /** Playback WPM for the current message — needed by the macro pad to
+   * estimate per-character progress without polling. */
+  wpm: number;
+  /** Jobs still waiting in the queue after the current one. 0 when idle. */
+  queueDepth: number;
+  /** Local timestamp (ms) when the most recent status frame arrived.
+   * Used by the panel to highlight the active character based on elapsed
+   * time × WPM — server only emits frames on state edges, so the per-
+   * character animation is reconstructed client-side. */
+  receivedAtMs: number;
+};
+
+const IDLE_STATUS: CwEngineStatus = {
+  state: 'idle',
+  text: '',
+  wpm: 0,
+  queueDepth: 0,
+  receivedAtMs: 0,
+};
+
+type CwStore = {
+  settings: CwSettings;
+  /** Optimistic save: caller mutates the store immediately, then the PUT
+   * either succeeds (server may normalise — re-apply the response) or
+   * fails (revert). Use this for one-shot saves (macro edit, slider
+   * release). For high-frequency updates (slider drag) use
+   * <see cref="setSettingsLocal"/> + <see cref="commitDebounced"/>. */
+  patchSettings: (patch: Partial<CwSettings>) => Promise<void>;
+  /** Update settings in-memory only; does NOT round-trip to the server.
+   * Used by the WPM slider during drag so the UI tracks the pointer
+   * without a 100-PUT thundering herd. Pair with <see cref="commitDebounced"/>
+   * to schedule the final save. */
+  setSettingsLocal: (patch: Partial<CwSettings>) => void;
+  /** Schedule a server PUT for the named field after a quiet period.
+   * The latest scheduled value wins — earlier scheduled PUTs are
+   * cancelled. Fixes the "slider snaps back" race where rapid PUTs
+   * from drag could complete out of order. */
+  commitDebounced: (patch: Partial<CwSettings>) => void;
+  setMacro: (index: number, value: string) => Promise<void>;
+  /** Append a new empty macro slot. The operator typically clicks edit
+   * on the freshly-added slot to fill it in. */
+  addMacro: () => Promise<void>;
+  removeMacro: (index: number) => Promise<void>;
+  status: CwEngineStatus;
+  /** Called by the WS dispatcher on every CwEngineStatus frame. */
+  setStatusFromServer: (s: CwEngineStatus) => void;
+};
+
+// Debounce timer for commitDebounced. Lives at module scope so a re-render
+// of CwPanel doesn't reset it; we only ever want one PUT in flight per
+// "burst" of operator input.
+const DEBOUNCE_MS = 250;
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+export const useCwStore = create<CwStore>((set, get) => ({
+  // Mirror the API's defaults — backend Get() ships the same values on
+  // a fresh install, so the UI doesn't flicker through "empty" while the
+  // hydrate fetch is in flight.
+  settings: DEFAULT_CW_SETTINGS,
+  patchSettings: async (patch) => {
+    const prev = get().settings;
+    const next = { ...prev, ...patch };
+    set({ settings: next });
+    try {
+      const server = await saveCwSettings(patch);
+      // Server may normalise (clamp WPM, truncate a long macro, etc.).
+      // Re-apply only if it actually changed something, to avoid an extra
+      // render on the common no-op-normalisation path.
+      if (!shallowEqualCwSettings(server, next)) {
+        set({ settings: server });
+      }
+    } catch {
+      // Roll back the optimistic update so the UI stays consistent with
+      // what the server actually persisted. The user will see their edit
+      // revert, which is the honest signal that the save failed.
+      set({ settings: prev });
+    }
+  },
+  setSettingsLocal: (patch) => {
+    set((s) => ({ settings: { ...s.settings, ...patch } }));
+  },
+  commitDebounced: (patch) => {
+    if (debounceTimer !== null) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      // Don't roll back on debounced saves — the operator has moved on,
+      // and a stale rollback that flips the slider back mid-typing would
+      // be more disorienting than a silent failure. The next save will
+      // retry; if the backend is truly down, the operator's next page
+      // load will resync from the persisted state.
+      void saveCwSettings(patch).catch(() => undefined);
+    }, DEBOUNCE_MS);
+  },
+  setMacro: async (index, value) => {
+    const macros = [...get().settings.macros];
+    macros[index] = value;
+    await get().patchSettings({ macros });
+  },
+  addMacro: async () => {
+    const macros = [...get().settings.macros, ''];
+    await get().patchSettings({ macros });
+  },
+  removeMacro: async (index) => {
+    const macros = get().settings.macros.filter((_, i) => i !== index);
+    await get().patchSettings({ macros });
+  },
+  status: IDLE_STATUS,
+  setStatusFromServer: (s) => set({ status: s }),
+}));
+
+function shallowEqualCwSettings(a: CwSettings, b: CwSettings): boolean {
+  if (
+    a.wpm !== b.wpm ||
+    a.farnsworthWpm !== b.farnsworthWpm ||
+    a.sidetoneGainDb !== b.sidetoneGainDb ||
+    a.sidetoneHz !== b.sidetoneHz
+  )
+    return false;
+  if (a.macros.length !== b.macros.length) return false;
+  for (let i = 0; i < a.macros.length; i++) {
+    if (a.macros[i] !== b.macros[i]) return false;
+  }
+  return true;
+}
+
+// Hydrate on module load. Same pattern as bottom-pin-store; tolerates a
+// failed fetch by leaving the defaults in place — subsequent patchSettings
+// will retry via PUT.
+export async function hydrateCwSettings(): Promise<void> {
+  try {
+    const server = await fetchCwSettings();
+    useCwStore.setState({ settings: server });
+  } catch {
+    /* network failure — keep defaults */
+  }
+}
+
+void hydrateCwSettings();

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -1773,26 +1773,392 @@
   box-shadow: 0 0 0 1px rgba(0,0,0,0.5), 0 1px 4px rgba(0,0,0,0.5);
 }
 
-/* ===== CW ===== */
-.cw { padding: 10px; display: flex; flex-direction: column; gap: 10px; background: var(--bg-1); }
-.cw-macros { display: grid; grid-template-columns: repeat(3, 1fr); gap: 4px; }
-.cw-stream {
+/* ===== CW — Telegraph Console layout =====
+   Three regions stacked top-down:
+     1. Stream HERO   — the always-on telegraph tape with state LED + queue chip
+     2. Control strip — chunky WPM readout, dial, and STOP kill-switch
+     3. Macro list    — numbered tiles + dashed Add tile
+   Designed around the 280–360 px-wide dockable panel; the column-flex
+   structure copes with both ends of that range without media queries.
+
+   Aesthetic: "lit instruments on a black bench" — the existing Zeus
+   immersive direction. Stream and STOP are the only places with semantic
+   colour (accent blue when sending, TX red when armed); everything else
+   stays in the neutral grey palette so a glance at the panel reads the
+   transmit state without parsing text. */
+
+.cw.cw-console {
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: var(--bg-1);
+}
+
+/* ---- Stream HERO -------------------------------------------------- */
+/* Inset well across the top — same depth treatment as the panadapter
+   and immersive meter wells (var(--bg-inset)), so the stream reads as
+   a screen embedded in the panel chrome rather than a regular row. */
+.cw-stream-hero {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 10px;
   padding: 8px 10px;
-  background: #000;
-  border: 1px solid rgba(0,0,0,0.8);
-  border-radius: 0;
-  font-size: 14px;
-  color: var(--accent);
-  letter-spacing: 0.2em;
-  min-height: 32px;
+  min-height: 44px;
+  background: var(--bg-inset);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-md);
+  box-shadow:
+    inset 0 1px 0 rgba(0,0,0,0.6),
+    inset 0 -1px 0 rgba(255,255,255,0.02);
+  /* Subtle horizontal scanlines so the tape reads as a backlit display
+     instead of a flat <div>. Stays under the text. */
+  background-image:
+    var(--bg-inset, #060608),
+    repeating-linear-gradient(
+      to bottom,
+      rgba(255,255,255,0.012) 0px,
+      rgba(255,255,255,0.012) 1px,
+      transparent 1px,
+      transparent 3px
+    );
+}
+.cw-stream-tag {
   display: flex;
   align-items: center;
   gap: 6px;
-  box-shadow: inset 0 1px 3px rgba(0,0,0,0.8);
-  text-shadow: 0 0 6px var(--accent);
+  /* Width-stable across state changes so the tape doesn't reflow on
+     idle → sending transitions. "ABORTING" (8 chars) is the widest. */
+  min-width: 78px;
 }
-.cw-cursor { animation: blink 1s steps(2) infinite; color: var(--accent); }
-@keyframes blink { 50% { opacity: 0.2; } }
+.cw-stream-led {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--fg-4);
+  box-shadow: inset 0 0 2px rgba(0,0,0,0.6);
+  transition: background var(--dur-fast) var(--ease-out),
+              box-shadow var(--dur-fast) var(--ease-out);
+}
+.cw-stream-label {
+  font: 500 10px/1 var(--font-sans);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--fg-2);
+  transition: color var(--dur-fast) var(--ease-out);
+}
+.cw-stream-hero.is-active .cw-stream-led {
+  background: var(--accent-bright);
+  box-shadow:
+    0 0 6px var(--accent-bright),
+    0 0 12px var(--accent-soft);
+  animation: cwLedPulse 1.2s ease-in-out infinite;
+}
+.cw-stream-hero.is-active .cw-stream-label { color: var(--accent-bright); }
+.cw-stream-hero[data-state="aborting"] .cw-stream-led {
+  background: var(--tx);
+  box-shadow: 0 0 6px var(--tx), 0 0 12px var(--tx-soft);
+}
+.cw-stream-hero[data-state="aborting"] .cw-stream-label { color: var(--tx); }
+@keyframes cwLedPulse {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50%      { transform: scale(1.15); opacity: 0.75; }
+}
+
+.cw-stream-tape {
+  font: 500 14px/1.25 var(--font-mono);
+  letter-spacing: 0.08em;
+  color: var(--fg-1);
+  min-width: 0;       /* let the flexbox shrink for ellipsis */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cw-stream-sent { color: var(--fg-3); }      /* already-keyed = dim */
+.cw-stream-pending { color: var(--fg-2); }   /* upcoming = medium */
+.cw-stream-cursor {
+  color: var(--accent-bright);
+  text-shadow: 0 0 6px var(--accent-soft);
+  animation: cwCursorBlink 1s steps(2) infinite;
+}
+@keyframes cwCursorBlink { 50% { opacity: 0.25; } }
+.cw-stream-placeholder {
+  color: var(--fg-3);
+  letter-spacing: 0.3em;
+  font-size: 11px;
+}
+
+.cw-stream-queue {
+  font: 600 11px/1 var(--font-mono);
+  color: var(--fg-2);
+  padding: 3px 6px;
+  min-width: 28px;
+  text-align: center;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-sm);
+  background: rgba(0,0,0,0.3);
+}
+.cw-stream-hero.is-active .cw-stream-queue {
+  color: var(--accent-bright);
+  border-color: var(--accent-line);
+}
+
+/* ---- Control strip — WPM readout + dial + STOP ------------------- */
+.cw-control-strip {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: stretch;
+  gap: 8px;
+}
+/* "Readout well" — a sunken digital chip that pairs with the stream's
+   inset treatment. The big numeric value is the chunky front-panel
+   element the operator's eye finds first; the small WPM label sits
+   above-left like the units printed on a piece of test equipment. */
+.cw-wpm-readout {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 4px 10px 4px 8px;
+  background: var(--bg-meter);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-md);
+  box-shadow:
+    inset 0 1px 0 rgba(0,0,0,0.7),
+    inset 0 -1px 0 rgba(255,255,255,0.03);
+  min-width: 72px;
+}
+.cw-wpm-label {
+  font: 600 9px/1 var(--font-sans);
+  letter-spacing: 0.22em;
+  color: var(--fg-3);
+  text-transform: uppercase;
+}
+.cw-wpm-value {
+  font: 700 26px/1 var(--font-mono);
+  color: var(--fg-0);
+  letter-spacing: -0.01em;
+  margin-top: 2px;
+  /* Faint accent halo so the readout looks "lit" against the well */
+  text-shadow: 0 0 8px rgba(78, 166, 255, 0.18);
+  font-variant-numeric: tabular-nums;
+}
+.cw-wpm-readout.is-active .cw-wpm-value {
+  color: var(--accent-bright);
+  text-shadow: 0 0 10px var(--accent-soft);
+}
+
+.cw-wpm-track {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+  min-width: 0;
+}
+.cw-wpm-track input[type="range"] { width: 100%; }
+.cw-wpm-scale {
+  display: flex;
+  justify-content: space-between;
+  font: 500 9px/1 var(--font-mono);
+  letter-spacing: 0.08em;
+  color: var(--fg-3);
+}
+
+/* STOP — kill-switch styling. Dim and locked when nothing to abort;
+   hot red with a soft halo when sending so the operator can find it
+   with peripheral vision without parsing text. Matches the visual
+   weight of the WPM readout so the strip reads as two paired controls
+   with a thin "dial" between. */
+.cw-stop {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 14px;
+  min-width: 60px;
+  font: 700 11px/1 var(--font-sans);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  background: var(--bg-2);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-md);
+  cursor: not-allowed;
+  transition: background var(--dur-fast) var(--ease-out),
+              color var(--dur-fast) var(--ease-out),
+              border-color var(--dur-fast) var(--ease-out),
+              box-shadow var(--dur-fast) var(--ease-out);
+}
+.cw-stop.is-armed {
+  color: #fff;
+  background: var(--tx);
+  border-color: var(--tx);
+  cursor: pointer;
+  box-shadow:
+    0 0 0 1px rgba(255,255,255,0.05) inset,
+    0 0 12px var(--tx-soft);
+  animation: cwStopArm 1.6s ease-in-out infinite;
+}
+.cw-stop.is-armed:hover { background: #ff5e6c; }
+.cw-stop.is-armed:active { transform: translateY(1px); }
+@keyframes cwStopArm {
+  0%, 100% { box-shadow: 0 0 0 1px rgba(255,255,255,0.05) inset, 0 0 12px var(--tx-soft); }
+  50%      { box-shadow: 0 0 0 1px rgba(255,255,255,0.10) inset, 0 0 18px rgba(255,74,89,0.30); }
+}
+
+/* ---- Macro list -------------------------------------------------- */
+.cw-macro-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* Each row: [00 index][primary send button][edit][delete].
+   The icons sit in dedicated columns at 32 px so they never crowd the
+   text and the click target is always thumb-friendly. */
+.cw-macro-row {
+  display: grid;
+  grid-template-columns: 28px 1fr 32px 32px;
+  align-items: stretch;
+  gap: 2px;
+  /* Mid-grey divider line under each row, dropping the last one. The
+     numbered prefix + dividers give the list the feel of a logbook
+     page rather than a stack of buttons. */
+  border-bottom: 1px solid var(--line-soft);
+}
+.cw-macro-list > .cw-macro-row:last-of-type { border-bottom: 0; }
+
+.cw-macro-num {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font: 600 10px/1 var(--font-mono);
+  color: var(--fg-3);
+  letter-spacing: 0.04em;
+}
+
+/* Send button — full-width text tile. Default state is calm and
+   typographic; on hover the left edge picks up an accent line to
+   advertise "this is the action target." Empty slots are dimmed and
+   italicised, click-disabled. */
+.cw-macro-send {
+  display: flex;
+  align-items: center;
+  padding: 8px 10px;
+  font: 500 13px/1.2 var(--font-sans);
+  color: var(--fg-1);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out),
+              border-color var(--dur-fast) var(--ease-out),
+              color var(--dur-fast) var(--ease-out);
+  /* Left accent rail when hovered — appears via box-shadow so the
+     layout doesn't shift. */
+  box-shadow: inset 2px 0 0 transparent;
+}
+.cw-macro-send:not(:disabled):hover {
+  background: var(--bg-2);
+  color: var(--fg-0);
+  box-shadow: inset 2px 0 0 var(--accent-bright);
+}
+.cw-macro-send:not(:disabled):active {
+  background: var(--bg-3);
+}
+.cw-macro-send.is-empty {
+  color: var(--fg-3);
+  cursor: not-allowed;
+}
+.cw-macro-send.is-empty em {
+  font-style: italic;
+  font-weight: 400;
+  letter-spacing: 0.02em;
+}
+
+/* Inline macro editor — overlays the send cell. Border matches the
+   accent rail so the field looks like the send tile lit up for input. */
+.cw-macro-edit {
+  font: 500 13px/1.2 var(--font-sans);
+  padding: 7px 9px;
+  background: var(--bg-meter);
+  color: var(--fg-0);
+  border: 1px solid var(--accent-line);
+  border-radius: var(--r-sm);
+  outline: none;
+  box-shadow: inset 2px 0 0 var(--accent-bright);
+}
+.cw-macro-edit:focus { border-color: var(--accent-bright); }
+
+/* Icon buttons — sit in their own 32 px columns so they never crowd
+   the macro text. Dim by default, accent / TX on hover, with a subtle
+   tile background that appears on hover only (no fixed chrome at rest
+   keeps the row visually quiet). */
+.cw-macro-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  width: 32px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  color: var(--fg-3);
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out),
+              color var(--dur-fast) var(--ease-out),
+              border-color var(--dur-fast) var(--ease-out);
+}
+.cw-macro-icon:hover {
+  background: var(--bg-2);
+  color: var(--accent-bright);
+  border-color: var(--line-strong);
+}
+.cw-macro-icon.is-danger:hover {
+  color: var(--tx);
+}
+.cw-macro-icon:active { transform: translateY(1px); }
+
+/* Add tile — dashed border so it advertises "this is empty space waiting
+   for content" rather than "this is another macro." Matches the height
+   of a macro row so the bottom of the list doesn't ramp down. */
+.cw-macro-add {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin-top: 6px;
+  padding: 10px 12px;
+  background: transparent;
+  border: 1px dashed var(--line-strong);
+  border-radius: var(--r-md);
+  color: var(--fg-2);
+  font: 600 10px/1 var(--font-sans);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out),
+              border-color var(--dur-fast) var(--ease-out),
+              color var(--dur-fast) var(--ease-out);
+}
+.cw-macro-add:not(:disabled):hover {
+  background: var(--bg-2);
+  border-color: var(--accent-line);
+  border-style: solid;
+  color: var(--accent-bright);
+}
+.cw-macro-add:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+.cw-macro-add-plus {
+  font: 600 14px/1 var(--font-mono);
+  letter-spacing: 0;
+}
+.cw-macro-add-label { letter-spacing: 0.22em; }
+
+/* ===== End CW — Telegraph Console ===== */
 
 /* ===== Transport bar — v3 Lifted Dark: flat near-black ===== */
 .transport {


### PR DESCRIPTION
PR 2 of the [[zeus-4np]] epic. Connects the existing CW Keyer panel to the engine landed in #477 and persists the operator's preferences server-side. Closes [[zeus-o27]].

Based on \`develop\` (one commit on top of the merged engine PR — clean rebase, no conflicts).

## Backend

- **\`CwSettingsStore\`** — LiteDB-backed, same shape as the other settings stores in \`zeus-prefs.db\`. Fields: \`Wpm\` (default 22), \`FarnsworthWpm\` (null), \`Macros\` (variable-length, seeded from the previously-hardcoded six, capped at 32 slots × 200 chars), \`SidetoneGainDb\` (-10), \`SidetoneHz\` (600). Sidetone fields are wire-stable now even though their audio routing lands later (\`zeus-5ue\`) — keeps the contract from churning across the epic.
- **\`GET /api/cw/settings\`** + **\`PUT /api/cw/settings\`** (PATCH-shaped: every field nullable so the UI saves one slider or one macro without round-tripping the whole record).
- **\`CwEngine\`** reads the store's WPM as the default when the caller omits \`wpm\` on \`/api/cw/send\`.
- **\`CwEngineStatusFrame\`** — new wire frame, \`MsgType 0x30\` (new 0x3x \"control-plane feedback\" nibble — 0x1x exhausted as of \`AudioMasterBypass\`). Variable-length: 9-byte header \`[type][state][wpm:u16][queueDepth:u16][textLen:u16]\` + UTF-8 text capped at 512 B. Engine bridges its in-process \`Status\` event onto the hub on every \`Idle ↔ Sending\` edge.

## Frontend

- **\`api/cw.ts\`** — wrappers for send / abort / getSettings / saveSettings.
- **\`state/cw-store.ts\`** — zustand store with:
  - \`patchSettings\` — one-shot optimistic save, revert on failure
  - \`setSettingsLocal\` — in-memory only (slider drag path)
  - \`commitDebounced\` — 250 ms after last change, fire-and-forget. Fixes the slider snap-back race where rapid PUTs from drag completed out of order.
  - \`setMacro\` / \`addMacro\` / \`removeMacro\`
- **\`realtime/ws-client.ts\`** — dispatch case for \`MsgType 0x30\` → \`useCwStore.setStatusFromServer\` with a local \`receivedAtMs\` so the macro pad reconstructs per-character progress.
- Removed dead \`wpm\` state from \`WorkspaceContext\` + \`App.tsx\` (lives in the store now).

## Telegraph Console redesign

After the first cut of the panel landed visually, the operator (live HL2 bench session) reported:
- ✎/✕ icons crowded against the macro text and hard to read
- \`+ Add macro\` was a weak terminal button
- Stream display invisible when traffic was flying
- WPM / STOP and the macro pad lacked visual hierarchy

The keyer was rebuilt as a three-region \"Telegraph Console\" designed for the 280–360 px dockable panel:

\`\`\`
┌─────────────────────────────────────────────┐
│ ◉ SENDING   VVV DE EA5IUE EA5│UE ⋯    +2  │ ← Stream HERO: inset
│             ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  │   well, scanlines, LED
├─────────────────────────────────────────────┤   pulse, queue chip
│ ┌────┐                                ┌───┐ │
│ │WPM │  ━━━━━━●━━━━━━━━━━━━━━━        │STOP│ │ ← Chunky readout +
│ │ 22 │  5                       40    │   │ │   dial + kill switch
│ └────┘                                └───┘ │
├─────────────────────────────────────────────┤
│ 01  CQ CQ CQ                       ✎   ✕   │
│ 02  TU 73                          ✎   ✕   │ ← Numbered tiles,
│ 03  QRZ?                           ✎   ✕   │   icons in dedicated
│ ...                                         │   32 px columns
│ ┌─────────────────────────────────────────┐ │
│ ┊  +  ADD MACRO                          ┊ │ ← Dashed tile matching
│ └─────────────────────────────────────────┘ │   row geometry
└─────────────────────────────────────────────┘
\`\`\`

Design notes:
- All chrome inside the existing token palette — no new colours, no new fonts. Stream + STOP carry semantic colour (accent blue on \`Sending\`, TX red on \`Aborting\` / \`is-armed\`); everything else stays neutral so a glance reads transmit state without parsing text.
- SVG glyphs replace Unicode \`✎\`/\`✕\` (Unicode pencils render heavy on macOS, thin on Linux).
- Stream height is fixed across idle↔sending so the layout doesn't jump on state edges.
- Macro rows use a grid with dedicated 32 px icon columns — never crowd the text.

## Slider WPM bugfix

Symptom: dragging the WPM slider returned to the prior value on release. Two compounding causes:
1. Slider passed floats (e.g. \`22.43\`) to \`onChange\`; server's \`int?\` deserialiser rejected with 400, optimistic update rolled back.
2. Even with rounding, rapid PUTs from a drag could complete out of order and clobber the operator's final value.

Fix: round to int at the keyer's \`onChange\` AND route slider input through \`setSettingsLocal\` + \`commitDebounced\` so only the final value PUTs once, 250 ms after the operator stops moving.

## Out of scope (follow-up PRs)

- TCI keyer hookup — [[zeus-j3t]]
- Sidetone monitor + audio routing — [[zeus-5ue]] (gain / pitch sliders may surface in this PR but the WS-side routing lands later)
- Observed carrier-width anomaly on the bench panadapter (\`+2 kHz\` wider than expected) — [[zeus-3ix]], filed for investigation

## Test plan

- [x] \`dotnet test Zeus.slnx\` — 644 server + 84 contracts, 0 fail, 5 skip
- [x] \`npm --prefix zeus-web test\` — 221 vitest, 0 fail
- [x] Live HL2 bench session: \`PUT /api/cw/settings\` round-trips, macro click \`POST /api/cw/send\` keys MOX, STOP aborts the in-flight transmission, the WPM slider doesn't snap back, macros are editable and persist across server restart, the Telegraph Console renders as designed
- [x] \`cw-store.test.ts\` regression for \`commitDebounced\` coalescing — would have caught the slider-snap-back race