### PR TITLE
ci: run Build and Test on experimental branch PRs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,9 +2,9 @@ name: Build and Test
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, experimental]
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, experimental]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Agent PRs target `experimental`, but `build-test.yml` only triggered on `main`/`develop` — so PRs to experimental (every `@kb2uka-agent` PR) got **no CI**, despite the "experimental = CI-gated" intent.

This adds `experimental` to the `push` and `pull_request` branch filters. Targets `develop` so the `develop→experimental` auto-sync carries it onto the experimental branch (GitHub evaluates `pull_request` CI from the base branch's workflow file, so it must live on experimental for experimental PRs to be checked).

No behavior change for main/develop CI.