### PR TITLE
feat(panfall): draggable pan/wf split with LiteDB persistence (bd zeus-uj0)

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -635,6 +635,15 @@ public sealed record BottomPinSetRequest(
     bool Logbook,
     bool TxMeters);
 
+// Vertical split between the panadapter and the waterfall in the Hero
+// panel. PanPercent is the panadapter share, clamped 10..90; the
+// waterfall takes the remainder. Single global value for now. Persisted
+// server-side in zeus-prefs.db (same pattern as BottomPinDto) so the
+// choice follows the operator across browsers / devices.
+public sealed record PanWfSplitDto(double PanPercent);
+
+public sealed record PanWfSplitSetRequest(double PanPercent);
+
 // ---- PureSignal request records ----
 // PsControlSetRequest = master arm (Enabled) + mode (Auto vs Single).
 // PsAdvancedSetRequest = nullable so partial updates from the settings

--- a/Zeus.Server.Hosting/PanWfSplitStore.cs
+++ b/Zeus.Server.Hosting/PanWfSplitStore.cs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using LiteDB;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+// Persists the vertical split between the panadapter and the waterfall
+// inside the Hero panel. Value is the panadapter share as a percentage
+// (10..90); the waterfall takes the remainder. Single global value for
+// now — if multi-RX panadapters land we can key per-receiver later.
+//
+// Lives in zeus-prefs.db alongside the other UI prefs (BottomPin,
+// NrUiPrefs, ThemeSettings, …) so the choice follows the operator across
+// browsers / devices. Same pattern as BottomPinStore — server-side, not
+// localStorage, per project_litedb_tx_filter_persistence /
+// project_rotator_resume lessons.
+public sealed class PanWfSplitStore : IDisposable
+{
+    public const double DefaultPanPercent = 50.0;
+    public const double MinPanPercent = 10.0;
+    public const double MaxPanPercent = 90.0;
+
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<PanWfSplitEntry> _docs;
+    private readonly ILogger<PanWfSplitStore> _log;
+    private readonly object _sync = new();
+
+    public PanWfSplitStore(ILogger<PanWfSplitStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _docs = _db.GetCollection<PanWfSplitEntry>("pan_wf_split");
+
+        _log.LogInformation("PanWfSplitStore initialized at {Path}", dbPath);
+    }
+
+    public PanWfSplitDto Get()
+    {
+        lock (_sync)
+        {
+            var e = _docs.FindAll().FirstOrDefault();
+            if (e is null) return new PanWfSplitDto(PanPercent: DefaultPanPercent);
+            return new PanWfSplitDto(PanPercent: Clamp(e.PanPercent));
+        }
+    }
+
+    public PanWfSplitDto Save(double panPercent)
+    {
+        var clamped = Clamp(panPercent);
+        lock (_sync)
+        {
+            var e = _docs.FindAll().FirstOrDefault() ?? new PanWfSplitEntry();
+            e.PanPercent = clamped;
+            e.UpdatedUtc = DateTime.UtcNow;
+            if (e.Id == 0) _docs.Insert(e);
+            else _docs.Update(e);
+        }
+        return new PanWfSplitDto(PanPercent: clamped);
+    }
+
+    private static double Clamp(double v)
+    {
+        if (double.IsNaN(v) || double.IsInfinity(v)) return DefaultPanPercent;
+        if (v < MinPanPercent) return MinPanPercent;
+        if (v > MaxPanPercent) return MaxPanPercent;
+        return v;
+    }
+
+    public void Dispose() => _db.Dispose();
+}
+
+public sealed class PanWfSplitEntry
+{
+    public int Id { get; set; }
+    public double PanPercent { get; set; } = PanWfSplitStore.DefaultPanPercent;
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -896,6 +896,20 @@ public static class ZeusEndpoints
             return Results.Ok(store.Get());
         });
 
+        // Vertical split between the panadapter and the waterfall in the
+        // Hero panel. PanPercent (10..90) is the panadapter share; the
+        // waterfall fills the remainder. Persisted in zeus-prefs.db so the
+        // choice follows the operator across browsers / devices, same
+        // pattern as /api/bottom-pin. Frontend reads on mount and PUTs
+        // debounced on drag-end.
+        app.MapGet("/api/pan-wf-split", (PanWfSplitStore store) => Results.Ok(store.Get()));
+
+        app.MapPut("/api/pan-wf-split", (PanWfSplitSetRequest req, PanWfSplitStore store) =>
+        {
+            var saved = store.Save(req.PanPercent);
+            return Results.Ok(saved);
+        });
+
         // Inline NR settings accordion disclosure state (NR1 / NR2 / NR4).
         // PUT writes all three flags atomically. Persisted in zeus-prefs.db
         // so the chevron-open preference follows the operator across

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -275,6 +275,7 @@ public static class ZeusHost
         builder.Services.AddSingleton<NrUiPrefsStore>();
         builder.Services.AddSingleton<ThemeSettingsStore>();
         builder.Services.AddSingleton<BottomPinStore>();
+        builder.Services.AddSingleton<PanWfSplitStore>();
         builder.Services.AddSingleton<RadioStateStore>();
         builder.Services.AddSingleton<QrzService>();
         builder.Services.AddSingleton<LogService>();

--- a/zeus-web/src/api/pan-wf-split.ts
+++ b/zeus-web/src/api/pan-wf-split.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+// Hero-panel vertical split between the panadapter (top) and the
+// waterfall (bottom). panPercent is the panadapter share, clamped
+// 10..90; the waterfall takes the remainder. Persisted server-side in
+// zeus-prefs.db, same pattern as /api/bottom-pin.
+
+export const PAN_WF_DEFAULT_PERCENT = 50;
+export const PAN_WF_MIN_PERCENT = 10;
+export const PAN_WF_MAX_PERCENT = 90;
+
+export type PanWfSplit = {
+  panPercent: number;
+};
+
+type PanWfSplitDtoRaw = {
+  panPercent?: number;
+};
+
+function clamp(v: number): number {
+  if (!Number.isFinite(v)) return PAN_WF_DEFAULT_PERCENT;
+  if (v < PAN_WF_MIN_PERCENT) return PAN_WF_MIN_PERCENT;
+  if (v > PAN_WF_MAX_PERCENT) return PAN_WF_MAX_PERCENT;
+  return v;
+}
+
+function normalize(raw: PanWfSplitDtoRaw): PanWfSplit {
+  const v = typeof raw.panPercent === 'number' ? raw.panPercent : PAN_WF_DEFAULT_PERCENT;
+  return { panPercent: clamp(v) };
+}
+
+export async function fetchPanWfSplit(signal?: AbortSignal): Promise<PanWfSplit> {
+  const res = await fetch('/api/pan-wf-split', { signal });
+  if (!res.ok) throw new Error(`GET /api/pan-wf-split → ${res.status}`);
+  return normalize((await res.json()) as PanWfSplitDtoRaw);
+}
+
+export async function updatePanWfSplit(
+  next: PanWfSplit,
+  signal?: AbortSignal,
+): Promise<PanWfSplit> {
+  const res = await fetch('/api/pan-wf-split', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ panPercent: clamp(next.panPercent) }),
+    signal,
+  });
+  if (!res.ok) throw new Error(`PUT /api/pan-wf-split → ${res.status}`);
+  return normalize((await res.json()) as PanWfSplitDtoRaw);
+}

--- a/zeus-web/src/layout/panels/HeroPanel.tsx
+++ b/zeus-web/src/layout/panels/HeroPanel.tsx
@@ -42,6 +42,7 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
+import { useCallback, useRef } from 'react';
 import type { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from 'react';
 import { GripVertical, X } from 'lucide-react';
 import { Panadapter } from '../../components/Panadapter';
@@ -51,6 +52,8 @@ import { LeafletWorldMap } from '../../components/design/LeafletWorldMap';
 import { LeafletMapErrorBoundary } from '../../components/design/LeafletMapErrorBoundary';
 import { useConnectionStore } from '../../state/connection-store';
 import { useRotatorStore } from '../../state/rotator-store';
+import { usePanWfSplitStore } from '../../state/pan-wf-split-store';
+import { PAN_WF_MAX_PERCENT, PAN_WF_MIN_PERCENT } from '../../api/pan-wf-split';
 import { useWorkspace } from '../WorkspaceContext';
 
 // Hero panel: Panadapter + Waterfall with optional Leaflet world-map overlay.
@@ -85,6 +88,70 @@ export function HeroPanel({ onRemove }: { onRemove?: () => void } = {}) {
     submitBeam,
   } = useWorkspace();
   const connected = useConnectionStore((s) => s.status === 'Connected');
+  const panPercent = usePanWfSplitStore((s) => s.panPercent);
+  const setPanPercentLive = usePanWfSplitStore((s) => s.setPanPercentLive);
+  const persistPanPercent = usePanWfSplitStore((s) => s.persistPanPercent);
+
+  // Drag state for the pan/wf splitter. We measure the spectrum-stack box
+  // on pointerdown and translate pointer Y → panadapter share (%). The
+  // store update is cheap (CSS grid template), so we run it at pointer
+  // rate; persistence happens once on pointerup via the debounced
+  // persistPanPercent action.
+  const spectrumStackRef = useRef<HTMLDivElement | null>(null);
+  const dragRectRef = useRef<DOMRect | null>(null);
+  const draggingPctRef = useRef<number>(panPercent);
+
+  const clampPct = (v: number) =>
+    Math.max(PAN_WF_MIN_PERCENT, Math.min(PAN_WF_MAX_PERCENT, v));
+
+  const onSplitPointerMove = useCallback(
+    (ev: PointerEvent) => {
+      const rect = dragRectRef.current;
+      if (!rect || rect.height <= 0) return;
+      const pct = clampPct(((ev.clientY - rect.top) / rect.height) * 100);
+      draggingPctRef.current = pct;
+      setPanPercentLive(pct);
+    },
+    [setPanPercentLive],
+  );
+
+  const onSplitPointerUp = useCallback(
+    (ev: PointerEvent) => {
+      window.removeEventListener('pointermove', onSplitPointerMove);
+      window.removeEventListener('pointerup', onSplitPointerUp);
+      window.removeEventListener('pointercancel', onSplitPointerUp);
+      try {
+        (ev.target as Element | null)?.releasePointerCapture?.(ev.pointerId);
+      } catch {
+        /* not all targets support release; ignore */
+      }
+      dragRectRef.current = null;
+      document.body.style.cursor = '';
+      void persistPanPercent(draggingPctRef.current);
+    },
+    [onSplitPointerMove, persistPanPercent],
+  );
+
+  const onSplitPointerDown = useCallback(
+    (ev: ReactPointerEvent<HTMLDivElement>) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      const stack = spectrumStackRef.current;
+      if (!stack) return;
+      dragRectRef.current = stack.getBoundingClientRect();
+      draggingPctRef.current = panPercent;
+      try {
+        (ev.target as Element).setPointerCapture?.(ev.pointerId);
+      } catch {
+        /* fallback to window listeners below */
+      }
+      document.body.style.cursor = 'row-resize';
+      window.addEventListener('pointermove', onSplitPointerMove);
+      window.addEventListener('pointerup', onSplitPointerUp);
+      window.addEventListener('pointercancel', onSplitPointerUp);
+    },
+    [panPercent, onSplitPointerMove, onSplitPointerUp],
+  );
 
   const handleRotateToBearing = (brg: number) => {
     const rot = useRotatorStore.getState();
@@ -240,17 +307,52 @@ export function HeroPanel({ onRemove }: { onRemove?: () => void } = {}) {
           </LeafletMapErrorBoundary>
         </div>
         <div
+          ref={spectrumStackRef}
           data-spectrum-stack
           style={{
             position: 'absolute',
             inset: 0,
             display: 'grid',
-            gridTemplateRows: '1fr 1fr',
+            // panPercent is the panadapter share (10..90); waterfall fills
+            // the remainder. fr units so the canvases naturally absorb the
+            // remaining height when the splitter moves.
+            gridTemplateRows: `${panPercent}fr ${100 - panPercent}fr`,
             zIndex: 1,
           }}
         >
           {connected && <Panadapter />}
           {connected && <Waterfall transparent={bgActive} />}
+          {/* Splitter — sits on the panadapter/waterfall boundary. The
+              parent grid is two rows; we position the handle at the
+              boundary with an absolutely-placed strip whose top tracks
+              panPercent. Hairline default, brighter on hover/active.
+              Pointer events on the strip don't propagate to the tile
+              drag (workspace-tile-header is the RGL drag handle). */}
+          <div
+            className="pan-wf-split-handle"
+            role="separator"
+            aria-orientation="horizontal"
+            aria-label="Resize panadapter / waterfall split"
+            aria-valuemin={PAN_WF_MIN_PERCENT}
+            aria-valuemax={PAN_WF_MAX_PERCENT}
+            aria-valuenow={Math.round(panPercent)}
+            title="Drag to resize panadapter / waterfall"
+            style={{
+              position: 'absolute',
+              left: 0,
+              right: 0,
+              top: `${panPercent}%`,
+              transform: 'translateY(-50%)',
+              height: 8,
+              cursor: 'row-resize',
+              zIndex: 5,
+              touchAction: 'none',
+            }}
+            onPointerDown={onSplitPointerDown}
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            <div className="pan-wf-split-handle__line" />
+          </div>
         </div>
       </div>
     </div>

--- a/zeus-web/src/state/pan-wf-split-store.ts
+++ b/zeus-web/src/state/pan-wf-split-store.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+// See LICENSE for the full GPL text.
+
+import { create } from 'zustand';
+import {
+  fetchPanWfSplit,
+  updatePanWfSplit,
+  PAN_WF_DEFAULT_PERCENT,
+  PAN_WF_MIN_PERCENT,
+  PAN_WF_MAX_PERCENT,
+} from '../api/pan-wf-split';
+
+// Vertical pan/wf split (panadapter share, 10..90). Persisted server-side
+// in zeus-prefs.db (LiteDB) so the choice follows the operator across
+// browsers / devices — same pattern as BottomPin. NO localStorage mirror
+// per project_litedb_tx_filter_persistence / project_rotator_resume.
+//
+// Live drag: setPanPercentLive() updates the in-memory value at pointer
+// rate so the canvases reflow immediately. Persistence is a debounced
+// (~300 ms after drag-end) PUT via persistPanPercent(); we send a final
+// PUT when the operator releases. The store never mirrors to
+// localStorage.
+
+type PanWfSplitState = {
+  panPercent: number;
+  hydrated: boolean;
+  setPanPercentLive: (pct: number) => void;
+  persistPanPercent: (pct: number) => Promise<void>;
+};
+
+function clamp(v: number): number {
+  if (!Number.isFinite(v)) return PAN_WF_DEFAULT_PERCENT;
+  if (v < PAN_WF_MIN_PERCENT) return PAN_WF_MIN_PERCENT;
+  if (v > PAN_WF_MAX_PERCENT) return PAN_WF_MAX_PERCENT;
+  return v;
+}
+
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+export const usePanWfSplitStore = create<PanWfSplitState>((set) => ({
+  panPercent: PAN_WF_DEFAULT_PERCENT,
+  hydrated: false,
+  setPanPercentLive: (pct) => {
+    set({ panPercent: clamp(pct) });
+  },
+  persistPanPercent: async (pct) => {
+    const next = clamp(pct);
+    set({ panPercent: next });
+    if (debounceTimer !== null) {
+      clearTimeout(debounceTimer);
+      debounceTimer = null;
+    }
+    await new Promise<void>((resolve) => {
+      debounceTimer = setTimeout(async () => {
+        debounceTimer = null;
+        try {
+          const result = await updatePanWfSplit({ panPercent: next });
+          set({ panPercent: result.panPercent });
+        } catch {
+          // Network / server failure — keep the live value; next drag will
+          // try again. We deliberately do NOT roll back because the
+          // operator's intent is the local value they just dragged to.
+        }
+        resolve();
+      }, 300);
+    });
+  },
+}));
+
+async function hydrateFromServer(): Promise<void> {
+  try {
+    const server = await fetchPanWfSplit();
+    usePanWfSplitStore.setState({ panPercent: server.panPercent, hydrated: true });
+  } catch {
+    // Backend unreachable — keep the default 50%. The store stays unhydrated
+    // so the next successful fetch (or a drag-end PUT) can populate it.
+    usePanWfSplitStore.setState({ hydrated: false });
+  }
+}
+
+void hydrateFromServer();

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -1026,6 +1026,35 @@
 .hero.bg-active .spectrum-canvas { background: transparent !important; }
 .hero.bg-active .waterfall-canvas { background: transparent !important; }
 
+/* Pan / waterfall split drag handle. The handle strip is 8 px tall (easy
+ * pointer target) but renders only a 1 px hairline by default so the
+ * boundary stays visually quiet. Hover/active brighten the hairline with
+ * --accent-line so the operator can see the affordance, but no chrome /
+ * tokens change. Hidden when the map layer is interactive (same gate as
+ * spectrum-stack pointer-events). */
+.pan-wf-split-handle {
+  /* Touch / pointer target — invisible padding above and below the
+   * hairline so a pointer doesn't need pixel-perfect aim. */
+  display: flex;
+  align-items: center;
+  justify-content: stretch;
+}
+.pan-wf-split-handle__line {
+  width: 100%;
+  height: 1px;
+  background: var(--line);
+  opacity: 0.7;
+  transition: background 120ms ease, opacity 120ms ease, height 120ms ease;
+  pointer-events: none;
+}
+.pan-wf-split-handle:hover .pan-wf-split-handle__line,
+.pan-wf-split-handle:active .pan-wf-split-handle__line {
+  background: var(--accent-line, var(--accent));
+  opacity: 1;
+  height: 2px;
+}
+.hero.map-mode .pan-wf-split-handle { display: none; }
+
 /* User-supplied still image rendered behind the panadapter when
    panBackground === 'image'. Sized via the variant class set by
    backgroundImageFit. */


### PR DESCRIPTION
## Summary
- Replace the hard-coded 50/50 split in `HeroPanel.tsx` with a draggable separator clamped to **10–90%**, default **50%**.
- Persist via **LiteDB** (NOT localStorage — per the rotator + TX-filter lessons): new `PanWfSplitStore` mirrors `BottomPinStore` exactly, GET/PUT under `/api/pan-wf-split`.
- Splitter is a pointer-capture strip rendering a 1 px hairline (`--line`); hover/active brightens to `--accent-line` and grows to 2 px. **No new colors / tokens** — uses the existing palette.
- `role="separator"` with `aria-valuemin/max/now` for a11y; `cursor: row-resize`; pointer-move updates CSS grid template at pointer rate (cheap), pointer-up triggers a 300 ms debounced PUT.
- Hidden in `.hero.map-mode` (matches existing pointer-events gate).

## Files
- Backend: `Zeus.Server.Hosting/PanWfSplitStore.cs` (new), `ZeusHost.cs`, `ZeusEndpoints.cs`, `Zeus.Contracts/Dtos.cs`
- Frontend: `zeus-web/src/api/pan-wf-split.ts` (new), `zeus-web/src/state/pan-wf-split-store.ts` (new), `zeus-web/src/layout/panels/HeroPanel.tsx`, `zeus-web/src/styles/layout.css`

## Test plan
- [x] `dotnet build Zeus.slnx` clean
- [x] `npm --prefix zeus-web run build` clean
- [x] Existing test suite green (219/219 frontend, 152 + 593 backend at commit time)
- [ ] Drag the splitter at default 50% — confirm clamp at 10% and 90%
- [ ] Reload — split position restored from LiteDB
- [ ] Switch to map-mode — splitter hidden, grid reverts to default

Closes bd zeus-uj0