### PR TITLE
feat(ui): sliders stream values live during drag, commit on release (bd zeus-5k0)

### DIFF
--- a/zeus-web/src/components/AfGainSlider.tsx
+++ b/zeus-web/src/components/AfGainSlider.tsx
@@ -42,9 +42,10 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { setRxAfGain } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import { useLiveSlider } from '../hooks/useLiveSlider';
 
 // Master RX AF gain in dB. Drives WDSP's SetRXAPanelGain1(linear) server-side
 // after a dB→linear conversion; the browser audio GainNode stays at 1.0 so
@@ -63,49 +64,23 @@ export function AfGainSlider() {
   const [dragValue, setDragValue] = useState<number | null>(null);
   const value = dragValue ?? serverAf;
 
-  const inflightAbort = useRef<AbortController | null>(null);
-  const latestSent = useRef<number>(serverAf);
-
-  const sendValue = useCallback(
-    (v: number) => {
-      if (v === latestSent.current) return;
-      latestSent.current = v;
-      inflightAbort.current?.abort();
-      const ac = new AbortController();
-      inflightAbort.current = ac;
-      setRxAfGain(v, ac.signal)
-        .then((next) => {
-          if (!ac.signal.aborted) applyState(next);
-        })
-        .catch(() => {
-          /* next poll will reconcile; don't noisily log on abort */
-        });
-    },
-    [applyState],
-  );
-
-  // Debounced send while dragging — 100ms is fast enough to feel immediate
-  // but prevents excessive API calls during a quick slider sweep.
-  const debounceTimer = useRef<number | null>(null);
-  const sendDebounced = useCallback(
-    (v: number) => {
-      if (debounceTimer.current !== null) {
-        clearTimeout(debounceTimer.current);
-      }
-      debounceTimer.current = window.setTimeout(() => {
-        sendValue(v);
-        debounceTimer.current = null;
-      }, 100);
-    },
-    [sendValue],
-  );
-
-  useEffect(() => () => {
-    inflightAbort.current?.abort();
-    if (debounceTimer.current !== null) {
-      clearTimeout(debounceTimer.current);
-    }
-  }, []);
+  // Stream during drag (rAF coalesced — ~16 ms at 60 Hz), flush on release.
+  // The previous 100 ms debounce was perceptible as a lag in the audible AF
+  // response on a fast sweep; rAF is fast enough to feel instant while still
+  // capping the wire rate to one POST per paint.
+  const liveSlider = useLiveSlider<number>({
+    send: useCallback(
+      (v: number, signal: AbortSignal) =>
+        setRxAfGain(v, signal)
+          .then((next) => {
+            if (!signal.aborted) applyState(next);
+          })
+          .catch(() => {
+            /* next poll will reconcile; don't noisily log on abort */
+          }),
+      [applyState],
+    ),
+  });
 
   return (
     <label className="knob-group" style={{ minWidth: 170 }}>
@@ -120,36 +95,18 @@ export function AfGainSlider() {
         onChange={(e) => {
           const newValue = Number(e.currentTarget.value);
           setDragValue(newValue);
-          sendDebounced(newValue);
+          liveSlider.push(newValue);
         }}
         onMouseUp={() => {
-          if (dragValue !== null) {
-            if (debounceTimer.current !== null) {
-              clearTimeout(debounceTimer.current);
-              debounceTimer.current = null;
-            }
-            sendValue(dragValue);
-          }
+          liveSlider.flush();
           setDragValue(null);
         }}
         onTouchEnd={() => {
-          if (dragValue !== null) {
-            if (debounceTimer.current !== null) {
-              clearTimeout(debounceTimer.current);
-              debounceTimer.current = null;
-            }
-            sendValue(dragValue);
-          }
+          liveSlider.flush();
           setDragValue(null);
         }}
         onKeyUp={() => {
-          if (dragValue !== null) {
-            if (debounceTimer.current !== null) {
-              clearTimeout(debounceTimer.current);
-              debounceTimer.current = null;
-            }
-            sendValue(dragValue);
-          }
+          liveSlider.flush();
           setDragValue(null);
         }}
         style={{ flex: 1, cursor: 'pointer', accentColor: 'var(--accent)' }}

--- a/zeus-web/src/components/AgcSlider.tsx
+++ b/zeus-web/src/components/AgcSlider.tsx
@@ -45,6 +45,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { setAgcTop, setAutoAgc } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import { useLiveSlider } from '../hooks/useLiveSlider';
 
 // AGC top (max gain) in dB. 80 is the Thetis AGC_MEDIUM default; the WDSP
 // docs call this the upper gain limit before compression kicks in.
@@ -67,27 +68,23 @@ export function AgcSlider() {
   const sliderValue = dragValue ?? userAgc;
   const effective = Math.round(Math.max(MIN, Math.min(MAX, sliderValue + offsetDb)));
 
-  const inflightAbort = useRef<AbortController | null>(null);
-  const latestSent = useRef<number>(userAgc);
   const autoAbort = useRef<AbortController | null>(null);
 
-  const sendValue = useCallback(
-    (v: number) => {
-      if (v === latestSent.current) return;
-      latestSent.current = v;
-      inflightAbort.current?.abort();
-      const ac = new AbortController();
-      inflightAbort.current = ac;
-      setAgcTop(v, ac.signal)
-        .then((next) => {
-          if (!ac.signal.aborted) applyState(next);
-        })
-        .catch(() => {
-          /* next poll will reconcile; don't noisily log on abort */
-        });
-    },
-    [applyState],
-  );
+  // Stream during drag (rAF coalesced), flush on release. The hook owns
+  // abort-on-supersede so a fast drag doesn't queue stale POSTs.
+  const liveSlider = useLiveSlider<number>({
+    send: useCallback(
+      (v: number, signal: AbortSignal) =>
+        setAgcTop(v, signal)
+          .then((next) => {
+            if (!signal.aborted) applyState(next);
+          })
+          .catch(() => {
+            /* next poll will reconcile; don't noisily log on abort */
+          }),
+      [applyState],
+    ),
+  });
 
   const toggleAuto = useCallback(() => {
     if (!connected) return;
@@ -105,7 +102,6 @@ export function AgcSlider() {
 
   useEffect(
     () => () => {
-      inflightAbort.current?.abort();
       autoAbort.current?.abort();
     },
     [],
@@ -136,17 +132,21 @@ export function AgcSlider() {
         step={1}
         value={sliderValue}
         disabled={!connected || autoEnabled}
-        onChange={(e) => setDragValue(Number(e.currentTarget.value))}
+        onChange={(e) => {
+          const v = Number(e.currentTarget.value);
+          setDragValue(v);
+          liveSlider.push(v);
+        }}
         onMouseUp={() => {
-          if (dragValue !== null) sendValue(dragValue);
+          liveSlider.flush();
           setDragValue(null);
         }}
         onTouchEnd={() => {
-          if (dragValue !== null) sendValue(dragValue);
+          liveSlider.flush();
           setDragValue(null);
         }}
         onKeyUp={() => {
-          if (dragValue !== null) sendValue(dragValue);
+          liveSlider.flush();
           setDragValue(null);
         }}
         style={{ flex: 1, cursor: 'pointer', accentColor: 'var(--accent)' }}

--- a/zeus-web/src/components/AttenuatorSlider.tsx
+++ b/zeus-web/src/components/AttenuatorSlider.tsx
@@ -45,6 +45,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { setAttenuator, setAutoAtt } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import { useLiveSlider } from '../hooks/useLiveSlider';
 
 // HpsdrAtten range — the server clamps to [MIN, MAX], but pinning the UI
 // to the same bounds avoids a round-trip that would visually snap the thumb.
@@ -65,27 +66,25 @@ export function AttenuatorSlider() {
   const sliderValue = dragValue ?? userAtten;
   const effective = Math.min(MAX, sliderValue + offsetDb);
 
-  const attenAbort = useRef<AbortController | null>(null);
-  const latestSent = useRef<number>(userAtten);
   const autoAbort = useRef<AbortController | null>(null);
 
-  const sendValue = useCallback(
-    (v: number) => {
-      if (v === latestSent.current) return;
-      latestSent.current = v;
-      attenAbort.current?.abort();
-      const ac = new AbortController();
-      attenAbort.current = ac;
-      setAttenuator(v, ac.signal)
-        .then((next) => {
-          if (!ac.signal.aborted) applyState(next);
-        })
-        .catch(() => {
-          /* next poll will reconcile; don't noisily log on abort */
-        });
-    },
-    [applyState],
-  );
+  // Stream during drag (rAF coalesced), flush on release — see useLiveSlider
+  // notes in hooks/useLiveSlider.ts. Previously the wire POST only fired on
+  // mouseUp / touchEnd / keyUp so the attenuator didn't change audibly until
+  // release; now it tracks the thumb in real time.
+  const liveSlider = useLiveSlider<number>({
+    send: useCallback(
+      (v: number, signal: AbortSignal) =>
+        setAttenuator(v, signal)
+          .then((next) => {
+            if (!signal.aborted) applyState(next);
+          })
+          .catch(() => {
+            /* next poll will reconcile; don't noisily log on abort */
+          }),
+      [applyState],
+    ),
+  });
 
   const toggleAuto = useCallback(() => {
     if (!connected) return;
@@ -103,7 +102,6 @@ export function AttenuatorSlider() {
 
   useEffect(
     () => () => {
-      attenAbort.current?.abort();
       autoAbort.current?.abort();
     },
     [],
@@ -138,17 +136,21 @@ export function AttenuatorSlider() {
         step={1}
         value={sliderValue}
         disabled={!connected || autoEnabled}
-        onChange={(e) => setDragValue(Number(e.currentTarget.value))}
+        onChange={(e) => {
+          const v = Number(e.currentTarget.value);
+          setDragValue(v);
+          liveSlider.push(v);
+        }}
         onMouseUp={() => {
-          if (dragValue !== null) sendValue(dragValue);
+          liveSlider.flush();
           setDragValue(null);
         }}
         onTouchEnd={() => {
-          if (dragValue !== null) sendValue(dragValue);
+          liveSlider.flush();
           setDragValue(null);
         }}
         onKeyUp={() => {
-          if (dragValue !== null) sendValue(dragValue);
+          liveSlider.flush();
           setDragValue(null);
         }}
         style={{ flex: 1, cursor: 'pointer', accentColor: 'var(--accent)' }}

--- a/zeus-web/src/components/DriveSlider.tsx
+++ b/zeus-web/src/components/DriveSlider.tsx
@@ -42,18 +42,19 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import { setDrive } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
 import { useTxStore } from '../state/tx-store';
 import { usePaStore } from '../state/pa-store';
+import { useLiveSlider } from '../hooks/useLiveSlider';
 
-// PRD FR-4 drive range: 0..100 percent. Per-pixel POSTs would flood the
-// server during a drag — trailing-edge debounce keeps the wire quiet while
-// still giving a responsive thumb because the store updates optimistically.
+// PRD FR-4 drive range: 0..100 percent. Stream during drag via rAF coalesce
+// (one POST per paint at most) so the radio's drive byte tracks the thumb in
+// real time during MOX — previously a 100 ms trailing-edge debounce caused
+// audible lag on a fast sweep.
 const MIN = 0;
 const MAX = 100;
-const DEBOUNCE_MS = 100;
 
 export function DriveSlider() {
   const connected = useConnectionStore((s) => s.status === 'Connected');
@@ -66,40 +67,29 @@ export function DriveSlider() {
   const paMaxWatts = usePaStore((s) => s.settings.global.paMaxPowerWatts);
   const targetWatts = paMaxWatts > 0 ? Math.round((paMaxWatts * drivePercent) / 100) : null;
 
-  const inflightAbort = useRef<AbortController | null>(null);
-  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const lastSent = useRef<number>(drivePercent);
+  // Tracks the most recently acknowledged value so we can roll back on error.
   const previousOnError = useRef<number>(drivePercent);
 
-  const sendDebounced = useCallback((v: number) => {
-    if (debounceTimer.current != null) clearTimeout(debounceTimer.current);
-    debounceTimer.current = setTimeout(() => {
-      if (v === lastSent.current) return;
-      inflightAbort.current?.abort();
-      const ac = new AbortController();
-      inflightAbort.current = ac;
-      const prevValue = lastSent.current;
-      lastSent.current = v;
-      previousOnError.current = prevValue;
-      setDrive(v, ac.signal)
-        .then((r) => {
-          if (ac.signal.aborted) return;
-          if (r.drivePercent !== v) setDrivePercent(r.drivePercent);
-        })
-        .catch((err) => {
-          if (ac.signal.aborted) return;
-          if (err instanceof DOMException && err.name === 'AbortError') return;
-          // Roll back the optimistic update so the user sees the real state.
-          setDrivePercent(previousOnError.current);
-          lastSent.current = previousOnError.current;
-        });
-    }, DEBOUNCE_MS);
-  }, [setDrivePercent]);
-
-  useEffect(() => () => {
-    inflightAbort.current?.abort();
-    if (debounceTimer.current != null) clearTimeout(debounceTimer.current);
-  }, []);
+  const liveSlider = useLiveSlider<number>({
+    send: useCallback(
+      (v: number, signal: AbortSignal) => {
+        const prevValue = previousOnError.current;
+        return setDrive(v, signal)
+          .then((r) => {
+            if (signal.aborted) return;
+            previousOnError.current = r.drivePercent;
+            if (r.drivePercent !== v) setDrivePercent(r.drivePercent);
+          })
+          .catch((err) => {
+            if (signal.aborted) return;
+            if (err instanceof DOMException && err.name === 'AbortError') return;
+            // Roll back the optimistic update so the user sees the real state.
+            setDrivePercent(prevValue);
+          });
+      },
+      [setDrivePercent],
+    ),
+  });
 
   // Server is now authoritative for drivePercent (StateDto.DrivePct, persisted
   // via RadioStateStore, hydrated into tx-store by tx-store.hydrateFromState
@@ -110,7 +100,7 @@ export function DriveSlider() {
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const v = Number(e.currentTarget.value);
     setDrivePercent(v);
-    sendDebounced(v);
+    liveSlider.push(v);
   };
 
   return (
@@ -124,6 +114,9 @@ export function DriveSlider() {
         value={drivePercent}
         disabled={!connected}
         onChange={onChange}
+        onMouseUp={() => liveSlider.flush()}
+        onTouchEnd={() => liveSlider.flush()}
+        onKeyUp={() => liveSlider.flush()}
         style={{ flex: 1, cursor: 'pointer', accentColor: 'var(--accent)' }}
       />
       <span className="mono" style={{ width: 40, textAlign: 'right', color: 'var(--power)', fontSize: 11, fontWeight: 700 }}>

--- a/zeus-web/src/components/LevelerMaxGainSlider.tsx
+++ b/zeus-web/src/components/LevelerMaxGainSlider.tsx
@@ -10,9 +10,10 @@
 // option) any later version. See the LICENSE file at the root of this
 // repository for the full text, or https://www.gnu.org/licenses/.
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import { setLevelerMaxGain } from '../api/client';
 import { useTxStore } from '../state/tx-store';
+import { useLiveSlider } from '../hooks/useLiveSlider';
 
 // Leveler max-gain (TX): how much the WDSP TXA Leveler can boost quiet
 // speech before the ALC catches it. Default +5 dB matches the W1AEX /
@@ -25,7 +26,6 @@ import { useTxStore } from '../state/tx-store';
 const MIN = 0;
 const MAX = 15;
 const STEP = 0.5;
-const DEBOUNCE_MS = 100;
 
 function quantize(v: number): number {
   const snapped = Math.round(v / STEP) * STEP;
@@ -37,44 +37,32 @@ export function LevelerMaxGainSlider() {
   const value = useTxStore((s) => s.levelerMaxGainDb);
   const setValue = useTxStore((s) => s.setLevelerMaxGainDb);
 
-  const inflightAbort = useRef<AbortController | null>(null);
-  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const lastSent = useRef<number>(value);
   const previousOnError = useRef<number>(value);
 
-  const sendDebounced = useCallback((v: number) => {
-    if (debounceTimer.current != null) clearTimeout(debounceTimer.current);
-    debounceTimer.current = setTimeout(() => {
-      if (v === lastSent.current) return;
-      inflightAbort.current?.abort();
-      const ac = new AbortController();
-      inflightAbort.current = ac;
-      const prevValue = lastSent.current;
-      lastSent.current = v;
-      previousOnError.current = prevValue;
-      setLevelerMaxGain(v, ac.signal)
-        .then((r) => {
-          if (ac.signal.aborted) return;
-          if (r.levelerMaxGainDb !== v) setValue(r.levelerMaxGainDb);
-        })
-        .catch((err) => {
-          if (ac.signal.aborted) return;
-          if (err instanceof DOMException && err.name === 'AbortError') return;
-          setValue(previousOnError.current);
-          lastSent.current = previousOnError.current;
-        });
-    }, DEBOUNCE_MS);
-  }, [setValue]);
-
-  useEffect(() => () => {
-    inflightAbort.current?.abort();
-    if (debounceTimer.current != null) clearTimeout(debounceTimer.current);
-  }, []);
+  const liveSlider = useLiveSlider<number>({
+    send: useCallback(
+      (v: number, signal: AbortSignal) => {
+        const prevValue = previousOnError.current;
+        return setLevelerMaxGain(v, signal)
+          .then((r) => {
+            if (signal.aborted) return;
+            previousOnError.current = r.levelerMaxGainDb;
+            if (r.levelerMaxGainDb !== v) setValue(r.levelerMaxGainDb);
+          })
+          .catch((err) => {
+            if (signal.aborted) return;
+            if (err instanceof DOMException && err.name === 'AbortError') return;
+            setValue(prevValue);
+          });
+      },
+      [setValue],
+    ),
+  });
 
   const onInput = (e: React.FormEvent<HTMLInputElement>) => {
     const q = quantize(Number(e.currentTarget.value));
     setValue(q);
-    sendDebounced(q);
+    liveSlider.push(q);
   };
 
   return (
@@ -91,6 +79,9 @@ export function LevelerMaxGainSlider() {
         value={value}
         onInput={onInput}
         onChange={onInput}
+        onMouseUp={() => liveSlider.flush()}
+        onTouchEnd={() => liveSlider.flush()}
+        onKeyUp={() => liveSlider.flush()}
         style={{ flex: 1, cursor: 'pointer', accentColor: 'var(--accent)' }}
       />
       <span

--- a/zeus-web/src/components/MicGainSlider.tsx
+++ b/zeus-web/src/components/MicGainSlider.tsx
@@ -42,9 +42,10 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import { setMicGain } from '../api/client';
 import { useTxStore } from '../state/tx-store';
+import { useLiveSlider } from '../hooks/useLiveSlider';
 
 // Mic-gain range: −40..+10 dB, default 0 dB (= unity, no behaviour change
 // for operators who never moved the slider). Matches Thetis's defaults at
@@ -60,45 +61,32 @@ import { useTxStore } from '../state/tx-store';
 // operator can dial in level against the live mic meter before keying.
 const MIN = -40;
 const MAX = 10;
-const DEBOUNCE_MS = 100;
 
 export function MicGainSlider() {
   const micGainDb = useTxStore((s) => s.micGainDb);
   const setMicGainDb = useTxStore((s) => s.setMicGainDb);
 
-  const inflightAbort = useRef<AbortController | null>(null);
-  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const lastSent = useRef<number>(micGainDb);
   const previousOnError = useRef<number>(micGainDb);
 
-  const sendDebounced = useCallback((v: number) => {
-    if (debounceTimer.current != null) clearTimeout(debounceTimer.current);
-    debounceTimer.current = setTimeout(() => {
-      if (v === lastSent.current) return;
-      inflightAbort.current?.abort();
-      const ac = new AbortController();
-      inflightAbort.current = ac;
-      const prevValue = lastSent.current;
-      lastSent.current = v;
-      previousOnError.current = prevValue;
-      setMicGain(v, ac.signal)
-        .then((r) => {
-          if (ac.signal.aborted) return;
-          if (r.micGainDb !== v) setMicGainDb(r.micGainDb);
-        })
-        .catch((err) => {
-          if (ac.signal.aborted) return;
-          if (err instanceof DOMException && err.name === 'AbortError') return;
-          setMicGainDb(previousOnError.current);
-          lastSent.current = previousOnError.current;
-        });
-    }, DEBOUNCE_MS);
-  }, [setMicGainDb]);
-
-  useEffect(() => () => {
-    inflightAbort.current?.abort();
-    if (debounceTimer.current != null) clearTimeout(debounceTimer.current);
-  }, []);
+  const liveSlider = useLiveSlider<number>({
+    send: useCallback(
+      (v: number, signal: AbortSignal) => {
+        const prevValue = previousOnError.current;
+        return setMicGain(v, signal)
+          .then((r) => {
+            if (signal.aborted) return;
+            previousOnError.current = r.micGainDb;
+            if (r.micGainDb !== v) setMicGainDb(r.micGainDb);
+          })
+          .catch((err) => {
+            if (signal.aborted) return;
+            if (err instanceof DOMException && err.name === 'AbortError') return;
+            setMicGainDb(prevValue);
+          });
+      },
+      [setMicGainDb],
+    ),
+  });
 
   // Rounded on send / display so the wire contract stays integer dB, but the
   // slider itself uses 0.5-step so micro-drags cross a step boundary on the
@@ -109,7 +97,7 @@ export function MicGainSlider() {
   const onInput = (e: React.FormEvent<HTMLInputElement>) => {
     const v = Number(e.currentTarget.value);
     setMicGainDb(v);
-    sendDebounced(Math.round(v));
+    liveSlider.push(Math.round(v));
   };
 
   return (
@@ -123,6 +111,9 @@ export function MicGainSlider() {
         value={micGainDb}
         onInput={onInput}
         onChange={onInput}
+        onMouseUp={() => liveSlider.flush()}
+        onTouchEnd={() => liveSlider.flush()}
+        onKeyUp={() => liveSlider.flush()}
         style={{ flex: 1, cursor: 'pointer', accentColor: 'var(--accent)' }}
       />
       <span className="mono" style={{ width: 52, textAlign: 'right', color: 'var(--fg-1)', fontSize: 11 }}>

--- a/zeus-web/src/components/MobileZoomSlider.tsx
+++ b/zeus-web/src/components/MobileZoomSlider.tsx
@@ -42,9 +42,10 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback } from 'react';
 import { setZoom, ZOOM_MAX, ZOOM_MIN, type ZoomLevel } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import { useLiveSlider } from '../hooks/useLiveSlider';
 
 /**
  * Vertical zoom slider pinned to the right edge of the panadapter on mobile.
@@ -62,29 +63,28 @@ export function MobileZoomSlider() {
   const applyState = useConnectionStore((s) => s.applyState);
   const connected = useConnectionStore((s) => s.status === 'Connected');
 
-  const inflightAbort = useRef<AbortController | null>(null);
-  const latestSent = useRef<ZoomLevel>(serverZoom);
+  // rAF-coalesced live stream — see ZoomControl for rationale.
+  const liveSlider = useLiveSlider<ZoomLevel>({
+    send: useCallback(
+      (v: ZoomLevel, signal: AbortSignal) =>
+        setZoom(v, signal)
+          .then((next) => {
+            if (!signal.aborted) applyState(next);
+          })
+          .catch(() => {
+            /* next state poll will reconcile */
+          }),
+      [applyState],
+    ),
+  });
 
-  const sendValue = useCallback(
+  const onSlide = useCallback(
     (v: ZoomLevel) => {
-      if (v === latestSent.current) return;
-      latestSent.current = v;
       setLocalZoom(v);
-      inflightAbort.current?.abort();
-      const ac = new AbortController();
-      inflightAbort.current = ac;
-      setZoom(v, ac.signal)
-        .then((next) => {
-          if (!ac.signal.aborted) applyState(next);
-        })
-        .catch(() => {
-          /* next state poll will reconcile */
-        });
+      liveSlider.push(v);
     },
-    [applyState, setLocalZoom],
+    [liveSlider, setLocalZoom],
   );
-
-  useEffect(() => () => inflightAbort.current?.abort(), []);
 
   return (
     <div
@@ -111,7 +111,10 @@ export function MobileZoomSlider() {
         step={1}
         value={serverZoom}
         disabled={!connected}
-        onChange={(e) => sendValue(Number(e.currentTarget.value) as ZoomLevel)}
+        onChange={(e) => onSlide(Number(e.currentTarget.value) as ZoomLevel)}
+        onMouseUp={() => liveSlider.flush()}
+        onTouchEnd={() => liveSlider.flush()}
+        onKeyUp={() => liveSlider.flush()}
         style={{
           writingMode: 'vertical-lr',
           direction: 'rtl',

--- a/zeus-web/src/components/TunePowerSlider.tsx
+++ b/zeus-web/src/components/TunePowerSlider.tsx
@@ -19,18 +19,18 @@
 // (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
 // Both are GPL-2.0-or-later.
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import { setTuneDrive } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
 import { useTxStore } from '../state/tx-store';
 import { usePaStore } from '../state/pa-store';
+import { useLiveSlider } from '../hooks/useLiveSlider';
 
-// Same 0..100 range and debounce shape as DriveSlider; the backend picks
-// between the two sources based on TUN keying state so the UX/wire are
+// Same 0..100 range and stream-during-drag shape as DriveSlider; the backend
+// picks between the two sources based on TUN keying state so the UX/wire are
 // symmetric.
 const MIN = 0;
 const MAX = 100;
-const DEBOUNCE_MS = 100;
 
 export function TunePowerSlider() {
   const connected = useConnectionStore((s) => s.status === 'Connected');
@@ -40,39 +40,27 @@ export function TunePowerSlider() {
   const paMaxWatts = usePaStore((s) => s.settings.global.paMaxPowerWatts);
   const targetWatts = paMaxWatts > 0 ? Math.round((paMaxWatts * tunePercent) / 100) : null;
 
-  const inflightAbort = useRef<AbortController | null>(null);
-  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const lastSent = useRef<number>(tunePercent);
   const previousOnError = useRef<number>(tunePercent);
 
-  const sendDebounced = useCallback((v: number) => {
-    if (debounceTimer.current != null) clearTimeout(debounceTimer.current);
-    debounceTimer.current = setTimeout(() => {
-      if (v === lastSent.current) return;
-      inflightAbort.current?.abort();
-      const ac = new AbortController();
-      inflightAbort.current = ac;
-      const prevValue = lastSent.current;
-      lastSent.current = v;
-      previousOnError.current = prevValue;
-      setTuneDrive(v, ac.signal)
-        .then((r) => {
-          if (ac.signal.aborted) return;
-          if (r.tunePercent !== v) setTunePercent(r.tunePercent);
-        })
-        .catch((err) => {
-          if (ac.signal.aborted) return;
-          if (err instanceof DOMException && err.name === 'AbortError') return;
-          setTunePercent(previousOnError.current);
-          lastSent.current = previousOnError.current;
-        });
-    }, DEBOUNCE_MS);
-  }, [setTunePercent]);
-
-  useEffect(() => () => {
-    inflightAbort.current?.abort();
-    if (debounceTimer.current != null) clearTimeout(debounceTimer.current);
-  }, []);
+  const liveSlider = useLiveSlider<number>({
+    send: useCallback(
+      (v: number, signal: AbortSignal) => {
+        const prevValue = previousOnError.current;
+        return setTuneDrive(v, signal)
+          .then((r) => {
+            if (signal.aborted) return;
+            previousOnError.current = r.tunePercent;
+            if (r.tunePercent !== v) setTunePercent(r.tunePercent);
+          })
+          .catch((err) => {
+            if (signal.aborted) return;
+            if (err instanceof DOMException && err.name === 'AbortError') return;
+            setTunePercent(prevValue);
+          });
+      },
+      [setTunePercent],
+    ),
+  });
 
   // Server is authoritative for tunePercent (StateDto.TunePct, persisted via
   // RadioStateStore, hydrated into tx-store on every fresh RadioStateDto).
@@ -82,7 +70,7 @@ export function TunePowerSlider() {
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const v = Number(e.currentTarget.value);
     setTunePercent(v);
-    sendDebounced(v);
+    liveSlider.push(v);
   };
 
   return (
@@ -96,6 +84,9 @@ export function TunePowerSlider() {
         value={tunePercent}
         disabled={!connected}
         onChange={onChange}
+        onMouseUp={() => liveSlider.flush()}
+        onTouchEnd={() => liveSlider.flush()}
+        onKeyUp={() => liveSlider.flush()}
         style={{ flex: 1, cursor: 'pointer', accentColor: 'var(--accent)' }}
       />
       <span

--- a/zeus-web/src/components/ZoomControl.tsx
+++ b/zeus-web/src/components/ZoomControl.tsx
@@ -42,9 +42,10 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback } from 'react';
 import { setZoom, ZOOM_MAX, ZOOM_MIN, type ZoomLevel } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import { useLiveSlider } from '../hooks/useLiveSlider';
 
 // Compact zoom slider styled as a panel-head chip. Lives in the hero
 // tile header (above the panadapter) so the operator always sees the
@@ -63,29 +64,31 @@ export function ZoomControl() {
   const applyState = useConnectionStore((s) => s.applyState);
   const connected = useConnectionStore((s) => s.status === 'Connected');
 
-  const inflightAbort = useRef<AbortController | null>(null);
-  const latestSent = useRef<ZoomLevel>(serverZoom);
+  // rAF-coalesced live stream — keeps the panadapter zoom tracking the thumb
+  // during a fast drag while capping POSTs to one per paint (zoom triggers a
+  // backend panadapter recompute, so flooding is real if onChange ever fires
+  // faster than rAF).
+  const liveSlider = useLiveSlider<ZoomLevel>({
+    send: useCallback(
+      (v: ZoomLevel, signal: AbortSignal) =>
+        setZoom(v, signal)
+          .then((next) => {
+            if (!signal.aborted) applyState(next);
+          })
+          .catch(() => {
+            /* next state poll will reconcile */
+          }),
+      [applyState],
+    ),
+  });
 
-  const sendValue = useCallback(
+  const onSlide = useCallback(
     (v: ZoomLevel) => {
-      if (v === latestSent.current) return;
-      latestSent.current = v;
       setLocalZoom(v);
-      inflightAbort.current?.abort();
-      const ac = new AbortController();
-      inflightAbort.current = ac;
-      setZoom(v, ac.signal)
-        .then((next) => {
-          if (!ac.signal.aborted) applyState(next);
-        })
-        .catch(() => {
-          /* next state poll will reconcile */
-        });
+      liveSlider.push(v);
     },
-    [applyState, setLocalZoom],
+    [liveSlider, setLocalZoom],
   );
-
-  useEffect(() => () => inflightAbort.current?.abort(), []);
 
   return (
     <label
@@ -109,7 +112,10 @@ export function ZoomControl() {
         step={1}
         value={serverZoom}
         disabled={!connected}
-        onChange={(e) => sendValue(Number(e.currentTarget.value) as ZoomLevel)}
+        onChange={(e) => onSlide(Number(e.currentTarget.value) as ZoomLevel)}
+        onMouseUp={() => liveSlider.flush()}
+        onTouchEnd={() => liveSlider.flush()}
+        onKeyUp={() => liveSlider.flush()}
         aria-label="Zoom level"
         style={{
           width: 90,

--- a/zeus-web/src/hooks/useLiveSlider.test.tsx
+++ b/zeus-web/src/hooks/useLiveSlider.test.tsx
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Unit tests for useLiveSlider — the shared "stream during drag, commit
+// on release" helper used by every slider component (issue zeus-5k0).
+//
+// What we lock down here:
+//   * push() coalesces multiple values per animation frame so we POST at
+//     most once per paint (no endpoint flooding from a wild drag).
+//   * flush() dispatches the latest pending value immediately and is a
+//     no-op when nothing is pending (safe to wire to pointerUp blindly).
+//   * Successive dispatches abort the previous request's AbortSignal so
+//     stale acknowledgements don't yank the slider back.
+//   * Cleanup on unmount cancels pending rAF and aborts in-flight.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useLiveSlider, type LiveSliderSender } from './useLiveSlider';
+
+// rAF in jsdom is unreliable; the hook falls back to setTimeout(0) when
+// requestAnimationFrame isn't a function. We force that path so vi.runAllTimers()
+// gives us deterministic flush points.
+function stubRafAsTimers() {
+  // Make typeof window.requestAnimationFrame !== 'function' to trigger the
+  // setTimeout fallback. We can't delete it on the global, so reassign.
+  (window as unknown as { requestAnimationFrame?: unknown }).requestAnimationFrame = undefined;
+  (window as unknown as { cancelAnimationFrame?: unknown }).cancelAnimationFrame = undefined;
+}
+
+interface Harness<T> {
+  push: (v: T) => void;
+  flush: () => void;
+  unmount: () => void;
+}
+
+function mount<T>(send: LiveSliderSender<T>): Harness<T> {
+  const captured: { push: (v: T) => void; flush: () => void } = {
+    push: () => {},
+    flush: () => {},
+  };
+  function Probe() {
+    const api = useLiveSlider<T>({ send });
+    captured.push = api.push;
+    captured.flush = api.flush;
+    return null;
+  }
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+  act(() => {
+    root.render(<Probe />);
+  });
+  return {
+    push: (v) => captured.push(v),
+    flush: () => captured.flush(),
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+describe('useLiveSlider', () => {
+  beforeEach(() => {
+    stubRafAsTimers();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('coalesces multiple push() calls within one frame into a single dispatch', () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const h = mount<number>(send);
+    h.push(1);
+    h.push(2);
+    h.push(3);
+    expect(send).not.toHaveBeenCalled();
+    act(() => {
+      vi.runAllTimers();
+    });
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0]?.[0]).toBe(3);
+    h.unmount();
+  });
+
+  it('flush() dispatches the latest pending value immediately', () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const h = mount<number>(send);
+    h.push(7);
+    h.push(8);
+    expect(send).not.toHaveBeenCalled();
+    act(() => h.flush());
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0]?.[0]).toBe(8);
+    h.unmount();
+  });
+
+  it('flush() is a no-op when nothing is pending', () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const h = mount<number>(send);
+    act(() => h.flush());
+    expect(send).not.toHaveBeenCalled();
+    h.unmount();
+  });
+
+  it('does not redispatch the same value back-to-back', () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const h = mount<number>(send);
+    h.push(5);
+    act(() => vi.runAllTimers());
+    h.push(5);
+    act(() => vi.runAllTimers());
+    expect(send).toHaveBeenCalledTimes(1);
+    h.unmount();
+  });
+
+  it('aborts the previous in-flight request when a newer value supersedes it', async () => {
+    const signals: AbortSignal[] = [];
+    const send = vi.fn().mockImplementation((_v: number, signal: AbortSignal) => {
+      signals.push(signal);
+      return new Promise<void>(() => { /* never resolves */ });
+    });
+    const h = mount<number>(send);
+    h.push(1);
+    act(() => vi.runAllTimers());
+    h.push(2);
+    act(() => vi.runAllTimers());
+    expect(signals).toHaveLength(2);
+    expect(signals[0]?.aborted).toBe(true);
+    expect(signals[1]?.aborted).toBe(false);
+    h.unmount();
+  });
+
+  it('aborts in-flight on unmount', () => {
+    const signals: AbortSignal[] = [];
+    const send = vi.fn().mockImplementation((_v: number, signal: AbortSignal) => {
+      signals.push(signal);
+      return new Promise<void>(() => {});
+    });
+    const h = mount<number>(send);
+    h.push(42);
+    act(() => vi.runAllTimers());
+    expect(signals[0]?.aborted).toBe(false);
+    h.unmount();
+    expect(signals[0]?.aborted).toBe(true);
+  });
+});

--- a/zeus-web/src/hooks/useLiveSlider.ts
+++ b/zeus-web/src/hooks/useLiveSlider.ts
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Shared "stream during drag, commit on release" helper for slider inputs.
+//
+// Background (issue zeus-5k0): every slider in Zeus should feel live —
+// the operator hears / sees the change as the thumb moves, not just on
+// mouseUp. Previously some sliders (AGC-T, S-ATT) only POSTed on release;
+// others (AF, DRV, TUN, MIC, LVLR) debounced 100 ms which is noticeable
+// on a fast drag.
+//
+// This hook standardises the contract:
+//   * Intermediate values are coalesced via requestAnimationFrame so we
+//     post at most once per paint (~16 ms at 60 Hz) — feels instant to
+//     the operator while preventing endpoint flooding from a wild drag.
+//   * In-flight requests are aborted when a newer value supersedes them
+//     so the backend always sees the latest intent (and the slider isn't
+//     yanked back by a stale echo).
+//   * flush() commits the latest pending value immediately — call from
+//     pointerUp / mouseUp / touchEnd / keyUp / blur so the final value is
+//     guaranteed to land regardless of throttle alignment.
+//
+// Optimistic store updates remain the caller's responsibility (every
+// existing slider does this in its own onChange — we don't want to bake
+// the store shape into a generic hook).
+
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * Callback shape every slider already has: take a value, return a promise
+ * that resolves when the server has acknowledged. The hook passes an
+ * AbortSignal so the caller can plumb it through fetch().
+ */
+export type LiveSliderSender<T> = (value: T, signal: AbortSignal) => Promise<void>;
+
+export interface UseLiveSliderOptions<T> {
+  /**
+   * Send the value to the backend. The hook calls this with the latest
+   * pending value at most once per animation frame; older calls are
+   * superseded (their AbortSignals are aborted).
+   */
+  send: LiveSliderSender<T>;
+
+  /**
+   * Equality check — by default `Object.is`. Override for slider values
+   * that are objects (rare; most are numbers).
+   */
+  equals?: (a: T, b: T) => boolean;
+}
+
+export interface UseLiveSliderApi<T> {
+  /**
+   * Queue a value to be sent on the next animation frame, coalescing
+   * with any later push() calls that arrive in the same frame.
+   */
+  push: (value: T) => void;
+  /**
+   * Send the latest pending value immediately (no rAF wait). Safe to
+   * call from pointerUp / mouseUp / touchEnd / keyUp / blur handlers
+   * even if no value is pending — it no-ops in that case.
+   */
+  flush: () => void;
+}
+
+/**
+ * Stream slider values during drag, commit on release.
+ *
+ * Cleanup (cancel rAF + abort in-flight) happens automatically on unmount.
+ */
+export function useLiveSlider<T>(opts: UseLiveSliderOptions<T>): UseLiveSliderApi<T> {
+  const { send, equals = Object.is } = opts;
+
+  // Keep the latest send in a ref so callers don't have to memoise it —
+  // we only ever read it inside the rAF tick, where stale closures would
+  // otherwise be a footgun (an old `send` would post to the wrong store).
+  const sendRef = useRef(send);
+  sendRef.current = send;
+  const equalsRef = useRef(equals);
+  equalsRef.current = equals;
+
+  // Pending value waiting for the next rAF tick. `hasPending` is needed
+  // (vs. just checking pendingRef.current) because T might legitimately
+  // be 0 / null / undefined and we still want to fire.
+  const pendingRef = useRef<T | undefined>(undefined);
+  const hasPendingRef = useRef(false);
+
+  // rAF handle so we can cancel on flush / unmount.
+  const rafRef = useRef<number | null>(null);
+
+  // Last value actually dispatched to send() — used to short-circuit
+  // duplicate posts (operator drags away and back to the same value).
+  const lastDispatchedRef = useRef<T | undefined>(undefined);
+  const hasDispatchedRef = useRef(false);
+
+  // In-flight AbortController — aborted when a newer value comes in.
+  const inflightRef = useRef<AbortController | null>(null);
+
+  const dispatch = useCallback((value: T) => {
+    if (hasDispatchedRef.current && equalsRef.current(value, lastDispatchedRef.current as T)) {
+      return;
+    }
+    lastDispatchedRef.current = value;
+    hasDispatchedRef.current = true;
+    inflightRef.current?.abort();
+    const ac = new AbortController();
+    inflightRef.current = ac;
+    // Fire-and-forget — error handling is the sender's responsibility
+    // (every existing slider already does rollback / silent ignore on
+    // AbortError, and we don't want to swallow those decisions here).
+    void sendRef.current(value, ac.signal).catch(() => {
+      /* sender owns error handling */
+    });
+  }, []);
+
+  const push = useCallback((value: T) => {
+    pendingRef.current = value;
+    hasPendingRef.current = true;
+    if (rafRef.current != null) return;
+    // Use rAF when available, fall back to setTimeout(0) for non-browser
+    // (jsdom) test environments where rAF is stubbed or absent.
+    const schedule: (cb: () => void) => number =
+      typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function'
+        ? (cb) => window.requestAnimationFrame(cb)
+        : (cb) => setTimeout(cb, 0) as unknown as number;
+    rafRef.current = schedule(() => {
+      rafRef.current = null;
+      if (!hasPendingRef.current) return;
+      const v = pendingRef.current as T;
+      hasPendingRef.current = false;
+      pendingRef.current = undefined;
+      dispatch(v);
+    });
+  }, [dispatch]);
+
+  const flush = useCallback(() => {
+    if (rafRef.current != null) {
+      if (typeof window !== 'undefined' && typeof window.cancelAnimationFrame === 'function') {
+        window.cancelAnimationFrame(rafRef.current);
+      } else {
+        clearTimeout(rafRef.current as unknown as ReturnType<typeof setTimeout>);
+      }
+      rafRef.current = null;
+    }
+    if (!hasPendingRef.current) return;
+    const v = pendingRef.current as T;
+    hasPendingRef.current = false;
+    pendingRef.current = undefined;
+    dispatch(v);
+  }, [dispatch]);
+
+  useEffect(() => () => {
+    if (rafRef.current != null) {
+      if (typeof window !== 'undefined' && typeof window.cancelAnimationFrame === 'function') {
+        window.cancelAnimationFrame(rafRef.current);
+      } else {
+        clearTimeout(rafRef.current as unknown as ReturnType<typeof setTimeout>);
+      }
+      rafRef.current = null;
+    }
+    inflightRef.current?.abort();
+  }, []);
+
+  return { push, flush };
+}


### PR DESCRIPTION
## Summary
- Per operator request: every slider should react **live** as it moves, not just on release.
- New shared hook `zeus-web/src/hooks/useLiveSlider.ts` — `push()` coalesces via `requestAnimationFrame` (≈16 ms / 60 Hz cap, `setTimeout(0)` fallback for jsdom), `flush()` commits the latest pending value on release, in-flight `AbortController` aborted on supersede, full cleanup on unmount.
- Optimistic store updates + rollback shapes stay per-component (each slider's store contract differs).

## Sliders migrated (9)
`AfGainSlider`, `AgcSlider`, `AttenuatorSlider`, `DriveSlider`, `TunePowerSlider`, `LevelerMaxGainSlider`, `MicGainSlider`, `ZoomControl`, `MobileZoomSlider`.

The worst offenders were **AGC-T** and **S-ATT** — both POSTed only on `mouseUp`/`touchEnd`/`keyUp`, so the audible/visible response landed at the *end* of the drag. AF / DRV / TUN / MIC / LVLR were on a 100 ms debounce (perceptible lag on a fast sweep). Zoom controls already streamed but now have a rate cap.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` 227/227 pass (includes 6 new tests for `useLiveSlider`: coalesce, flush, no-op flush, dedupe, abort-on-supersede, abort-on-unmount)
- [x] `dotnet build Zeus.slnx` clean
- [ ] Drag each slider — the radio response should track the drag, not jump on release
- [ ] Keyboard + touch paths behave the same as mouse

Closes bd zeus-5k0