### PR TITLE
Logbook + QRZ upload: force UTC on display and on the wire

### DIFF
--- a/Zeus.Server.Hosting/LogService.cs
+++ b/Zeus.Server.Hosting/LogService.cs
@@ -207,11 +207,24 @@ public sealed class LogService : IDisposable
         QrzLogId: doc.QrzLogId,
         QrzUploadedUtc: doc.QrzUploadedUtc);
 
-    private static void AppendAdifRecord(StringBuilder sb, LogEntryDocument doc)
+    /// <summary>Internal so AdifUtcTimezoneTests can pin the
+    /// <see cref="DateTime.Kind"/> behaviour without standing up a LiteDB
+    /// round-trip. The method itself remains a private detail of the ADIF
+    /// export path.</summary>
+    internal static void AppendAdifRecord(StringBuilder sb, LogEntryDocument doc)
     {
         AppendAdifField(sb, "CALL", doc.Callsign);
-        AppendAdifField(sb, "QSO_DATE", doc.QsoDateTimeUtc.ToString("yyyyMMdd"));
-        AppendAdifField(sb, "TIME_ON", doc.QsoDateTimeUtc.ToString("HHmmss"));
+        // .ToUniversalTime() is defensive: LiteDB's default BsonMapper
+        // serialises DateTime as Local on write and returns Kind=Local on
+        // read, so `doc.QsoDateTimeUtc` round-trips through the store with
+        // the wrong Kind even though we wrote DateTime.UtcNow at creation
+        // time. .ToString() doesn't do timezone conversion — it just
+        // formats whatever value the DateTime holds. Without the explicit
+        // ToUniversalTime() ADIF would emit local-time clocks, which broke
+        // the QRZ.com upload (the field name is qsoDateTimeUtc precisely
+        // because callers downstream rely on it being UTC).
+        AppendAdifField(sb, "QSO_DATE", doc.QsoDateTimeUtc.ToUniversalTime().ToString("yyyyMMdd"));
+        AppendAdifField(sb, "TIME_ON", doc.QsoDateTimeUtc.ToUniversalTime().ToString("HHmmss"));
         AppendAdifField(sb, "FREQ", doc.FrequencyMhz.ToString("F6", CultureInfo.InvariantCulture));
         AppendAdifField(sb, "BAND", doc.Band);
         AppendAdifField(sb, "MODE", doc.Mode);

--- a/Zeus.Server.Hosting/QrzService.cs
+++ b/Zeus.Server.Hosting/QrzService.cs
@@ -399,14 +399,23 @@ public sealed class QrzService
         return (false, null, reason ?? "Unknown error");
     }
 
-    private static string ConvertLogEntryToAdif(LogEntry entry)
+    /// <summary>Internal so AdifUtcTimezoneTests can verify the QRZ upload
+    /// path emits UTC clock values regardless of the incoming entry's
+    /// <see cref="DateTime.Kind"/>. The method is otherwise a private
+    /// detail of the publish path.</summary>
+    internal static string ConvertLogEntryToAdif(LogEntry entry)
     {
         var sb = new System.Text.StringBuilder();
 
         // Required fields
         AppendAdifField(sb, "CALL", entry.Callsign);
-        AppendAdifField(sb, "QSO_DATE", entry.QsoDateTimeUtc.ToString("yyyyMMdd"));
-        AppendAdifField(sb, "TIME_ON", entry.QsoDateTimeUtc.ToString("HHmmss"));
+        // .ToUniversalTime() guards against the LiteDB round-trip stripping
+        // the UTC kind off QsoDateTimeUtc — see LogService.AppendAdifRecord
+        // for the full story. Without it QRZ.com receives local-clock times
+        // and stamps the QSOs at the operator's wall-clock hour, breaking
+        // award credit and DXCC matching for anyone outside UTC.
+        AppendAdifField(sb, "QSO_DATE", entry.QsoDateTimeUtc.ToUniversalTime().ToString("yyyyMMdd"));
+        AppendAdifField(sb, "TIME_ON", entry.QsoDateTimeUtc.ToUniversalTime().ToString("HHmmss"));
         AppendAdifField(sb, "FREQ", entry.FrequencyMhz.ToString("F6", System.Globalization.CultureInfo.InvariantCulture));
         AppendAdifField(sb, "BAND", entry.Band);
         AppendAdifField(sb, "MODE", entry.Mode);

--- a/tests/Zeus.Server.Tests/AdifUtcTimezoneTests.cs
+++ b/tests/Zeus.Server.Tests/AdifUtcTimezoneTests.cs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// Regression for issue #486 (zeus-1sc): QRZ.com uploads (and ADIF
+// exports) used to emit local-clock times because LiteDB's default
+// BsonMapper round-trips DateTime with Kind=Local on read — even
+// when the field was DateTime.UtcNow at write time. .ToString()
+// formats the stored value without timezone conversion, so the
+// local-kinded value reached QRZ as if it were UTC and stamped
+// every QSO at the operator's wall-clock hour. Award credit and
+// DXCC matching for anyone outside UTC was wrong.
+//
+// The fix is a defensive .ToUniversalTime() at both ADIF format
+// sites. These tests pin the behaviour by passing a DateTime that
+// has Kind=Local but represents a known UTC moment — exactly what
+// LiteDB returns — and asserting the ADIF still carries UTC.
+
+using System.Text;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class AdifUtcTimezoneTests
+{
+    // 19:30:00 UTC on 2026-05-24. Pick a wall-clock hour high enough that
+    // a CET-summer browser (UTC+2) shifts it into the next day — without
+    // the fix, ToString("yyyyMMdd") on a Local-kinded version would emit
+    // either 20260524 or 20260525 depending on the test box's TZ, but
+    // never the right value consistently. With the fix it's always
+    // 20260524 / 193000.
+    private static readonly DateTime QsoUtc =
+        new(2026, 5, 24, 19, 30, 0, DateTimeKind.Utc);
+    private const string ExpectedDate = "20260524";
+    private const string ExpectedTime = "193000";
+
+    /// <summary>Build a Kind=Local DateTime that represents <see cref="QsoUtc"/>
+    /// in the test host's local zone. This is exactly what LiteDB's default
+    /// BsonMapper hands back to <c>LogService</c> after the round-trip:
+    /// the moment in time is right, but the <see cref="DateTime.Kind"/>
+    /// is wrong. A naive <c>.ToString("HHmmss")</c> on this value would
+    /// format the LOCAL clock, not the UTC clock.</summary>
+    private static DateTime QsoSeenAsLocal => QsoUtc.ToLocalTime();
+
+    [Fact]
+    public void LogService_AdifRecord_EmitsUtcClock_EvenWhenKindIsLocal()
+    {
+        var doc = new LogEntryDocument
+        {
+            Id = "test-id",
+            QsoDateTimeUtc = QsoSeenAsLocal,    // ← LiteDB shape
+            Callsign = "EA5IUE",
+            FrequencyMhz = 21.065,
+            Band = "15m",
+            Mode = "CW",
+            RstSent = "599",
+            RstRcvd = "599",
+        };
+        var sb = new StringBuilder();
+
+        LogService.AppendAdifRecord(sb, doc);
+
+        var adif = sb.ToString();
+        Assert.Contains($"<QSO_DATE:8>{ExpectedDate}", adif);
+        Assert.Contains($"<TIME_ON:6>{ExpectedTime}", adif);
+    }
+
+    [Fact]
+    public void QrzService_AdifConversion_EmitsUtcClock_EvenWhenKindIsLocal()
+    {
+        // Same shape, but exercising the QRZ publish path which converts a
+        // LogEntry DTO (not the LiteDB doc) — the DTO is built by
+        // LogService.MapDocumentToDto which copies QsoDateTimeUtc through
+        // unchanged, so the wrong Kind reaches QRZ the same way.
+        var entry = new LogEntry(
+            Id: "test-id",
+            QsoDateTimeUtc: QsoSeenAsLocal,
+            Callsign: "EA5IUE",
+            Name: null,
+            FrequencyMhz: 21.065,
+            Band: "15m",
+            Mode: "CW",
+            RstSent: "599",
+            RstRcvd: "599",
+            Grid: null,
+            Country: null,
+            Dxcc: null,
+            CqZone: null,
+            ItuZone: null,
+            State: null,
+            Comment: null,
+            CreatedUtc: DateTime.UtcNow);
+
+        var adif = QrzService.ConvertLogEntryToAdif(entry);
+
+        Assert.Contains($"<QSO_DATE:8>{ExpectedDate}", adif);
+        Assert.Contains($"<TIME_ON:6>{ExpectedTime}", adif);
+    }
+
+    [Fact]
+    public void LogService_AdifRecord_AlsoCorrectForActuallyUtcKind()
+    {
+        // Sanity check: when the DateTime ALREADY has Kind=Utc (which is
+        // the case for freshly-created entries before any LiteDB
+        // round-trip — see LogService.CreateLogEntryAsync setting
+        // QsoDateTimeUtc = DateTime.UtcNow), the .ToUniversalTime() call
+        // is a no-op and the output is still correct. This guards against
+        // a future "optimisation" that strips the ToUniversalTime() call
+        // believing it's redundant.
+        var doc = new LogEntryDocument
+        {
+            Id = "test-id",
+            QsoDateTimeUtc = QsoUtc,
+            Callsign = "EA5IUE",
+            FrequencyMhz = 21.065,
+            Band = "15m",
+            Mode = "CW",
+            RstSent = "599",
+            RstRcvd = "599",
+        };
+        var sb = new StringBuilder();
+
+        LogService.AppendAdifRecord(sb, doc);
+
+        var adif = sb.ToString();
+        Assert.Contains($"<QSO_DATE:8>{ExpectedDate}", adif);
+        Assert.Contains($"<TIME_ON:6>{ExpectedTime}", adif);
+    }
+}

--- a/zeus-web/src/components/design/LogbookLive.formatters.test.ts
+++ b/zeus-web/src/components/design/LogbookLive.formatters.test.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// Regression for issue #486: the logbook used to render QSO timestamps
+// in the browser's local timezone, drifting the clock by the user's
+// offset. Ham-radio convention is UTC always — both formatters must pin
+// timeZone:'UTC' regardless of where the operator's browser thinks it
+// is, otherwise an operator in CET would see an 19:30Z QSO logged at
+// "21:30" on a 21:30-wall-clock summer evening.
+
+import { describe, expect, it } from 'vitest';
+import { formatQsoDateUtc, formatQsoTimeUtc } from './LogbookLive';
+
+describe('LogbookLive formatters', () => {
+  // Pick a timestamp where UTC and any plausible local timezone clearly
+  // disagree on the calendar day, so a missing timeZone:'UTC' option
+  // would obviously land on the wrong date and hour.
+  const ISO_LATE_NIGHT_UTC = '2026-05-24T23:30:00Z';
+  const ISO_EARLY_MORNING_UTC = '2026-05-25T01:15:00Z';
+
+  it('formats time as the UTC clock value regardless of the browser TZ', () => {
+    // 23:30 UTC must render as "23:30" everywhere. A CET-summer browser
+    // (UTC+2) would render "01:30" if timeZone:'UTC' were missing.
+    // Time format is digit-only (24h) so this assertion is locale-stable.
+    expect(formatQsoTimeUtc(ISO_LATE_NIGHT_UTC)).toBe('23:30');
+    // Sanity-check a second value to catch a transposed hour/minute fix.
+    expect(formatQsoTimeUtc(ISO_EARLY_MORNING_UTC)).toBe('01:15');
+  });
+
+  it('formats date as the UTC calendar day, not the browser day', () => {
+    // The localised month name differs by environment ("May 24" in en-US,
+    // "24 may" in es-ES, "24 May" in en-GB, …) so we assert against the
+    // reference UTC formatter rather than a hard-coded string. The key
+    // property: format(localTz) === format(UTC) for THIS input only if
+    // the formatter pinned timeZone:'UTC'. The day-number check on top
+    // catches the "shifted to next day" failure mode that timezone bugs
+    // produce on late-night-UTC timestamps.
+    const refLateNight = new Date(ISO_LATE_NIGHT_UTC).toLocaleDateString([], {
+      month: 'short',
+      day: 'numeric',
+      timeZone: 'UTC',
+    });
+    const refEarlyMorning = new Date(ISO_EARLY_MORNING_UTC).toLocaleDateString([], {
+      month: 'short',
+      day: 'numeric',
+      timeZone: 'UTC',
+    });
+    expect(formatQsoDateUtc(ISO_LATE_NIGHT_UTC)).toBe(refLateNight);
+    expect(formatQsoDateUtc(ISO_EARLY_MORNING_UTC)).toBe(refEarlyMorning);
+
+    // Day-number must be 24 (the UTC day) — not 25, which is what a
+    // CET-summer browser would render without timeZone:'UTC'.
+    expect(formatQsoDateUtc(ISO_LATE_NIGHT_UTC)).toMatch(/\b24\b/);
+    expect(formatQsoDateUtc(ISO_EARLY_MORNING_UTC)).toMatch(/\b25\b/);
+  });
+});

--- a/zeus-web/src/components/design/LogbookLive.tsx
+++ b/zeus-web/src/components/design/LogbookLive.tsx
@@ -45,6 +45,37 @@
 import { useEffect } from 'react';
 import { useLoggerStore } from '../../state/logger-store';
 
+// QSO timestamps are stored / exported / uploaded to QRZ in UTC throughout
+// the server stack (Zeus.Server.Hosting/LogService.cs writes DateTime.UtcNow
+// when the client omits a value; QrzService.cs and the ADIF export both
+// pull QsoDateTimeUtc directly). The renderer used to drop into
+// browser-local time via Date.toLocale*String() with no timezone option —
+// which silently shifted the displayed clock for any operator outside
+// UTC. Ham-radio convention is to log + display QSO times in UTC always,
+// so both formatters pin timeZone:'UTC' and the column label carries a
+// "UTC" tag so the operator never has to guess.
+//
+// Exported so the test (LogbookLive.formatters.test.ts) can assert the
+// timezone behaviour without rendering the whole component.
+export function formatQsoTimeUtc(isoString: string): string {
+  const date = new Date(isoString);
+  return date.toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+    timeZone: 'UTC',
+  });
+}
+
+export function formatQsoDateUtc(isoString: string): string {
+  const date = new Date(isoString);
+  return date.toLocaleDateString([], {
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
 export function LogbookLive() {
   const entries = useLoggerStore((s) => s.entries);
   const totalCount = useLoggerStore((s) => s.totalCount);
@@ -64,16 +95,6 @@ export function LogbookLive() {
       return () => clearTimeout(timer);
     }
   }, [lastPublishResult, publishError, clearPublishResult]);
-
-  const formatTime = (isoString: string) => {
-    const date = new Date(isoString);
-    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
-  };
-
-  const formatDate = (isoString: string) => {
-    const date = new Date(isoString);
-    return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
-  };
 
   if (loading && entries.length === 0) {
     return (
@@ -99,8 +120,8 @@ export function LogbookLive() {
     <div className="logbook">
       <div className="log-head mono">
         <span style={{ width: '2rem' }}>✓</span>
-        <span>Date</span>
-        <span>Time</span>
+        <span title="QSO date in UTC">Date·UTC</span>
+        <span title="QSO time in UTC">Time·UTC</span>
         <span>Call</span>
         <span>Freq</span>
         <span>Mode</span>
@@ -124,8 +145,12 @@ export function LogbookLive() {
                 style={{ cursor: 'pointer', pointerEvents: 'none' }}
               />
             </span>
-            <span className="t-date">{formatDate(entry.qsoDateTimeUtc)}</span>
-            <span className="t-time">{formatTime(entry.qsoDateTimeUtc)}</span>
+            <span className="t-date" title={entry.qsoDateTimeUtc}>
+              {formatQsoDateUtc(entry.qsoDateTimeUtc)}
+            </span>
+            <span className="t-time" title={entry.qsoDateTimeUtc}>
+              {formatQsoTimeUtc(entry.qsoDateTimeUtc)}
+            </span>
             <span className="t-call">{entry.callsign}</span>
             <span>{entry.frequencyMhz.toFixed(3)}</span>
             <span className="t-mode">{entry.mode}</span>


### PR DESCRIPTION
Fixes #486 (zeus-1sc). Two-part fix for QSO timestamps drifting into local time — one on the UI side (cosmetic), one on the server side (the QRZ.com upload was actually broken).

## Background

Ham-radio convention is to log and display QSO times in UTC always. The Zeus log row is named \`qsoDateTimeUtc\` end-to-end and the server stores \`DateTime.UtcNow\` on entry creation, so on the surface everything looked right. An operator in CET reported:

1. The logbook column displayed \`21:30\` for a QSO logged at \`19:30 UTC\` — UI bug.
2. After the UI fix made the displayed clock UTC, they tested a QRZ.com publish and saw the SAME wrong-by-+2h timestamp arrive at QRZ — a real wire-side bug too.

## Bug 1 — UI display (commit \`9b767fd\`)

\`zeus-web/src/components/design/LogbookLive.tsx\` used \`Date.toLocaleTimeString()\` and \`Date.toLocaleDateString()\` with no \`timeZone\` option, which silently converts to the browser's local zone.

**Fix:**
- Hoist the two formatters out of the component into module-level exports (\`formatQsoTimeUtc\`, \`formatQsoDateUtc\`) so they're directly testable.
- Pin \`timeZone:'UTC'\` on both.
- Re-label the column headers \`Date·UTC\` / \`Time·UTC\` so the operator sees at a glance which zone they're reading. Title attributes on the headers and each cell carry the full ISO timestamp for hover-confirmation.
- New test (\`LogbookLive.formatters.test.ts\`) — locale-stable: 24h time assertion for the time formatter, reference-formatter comparison + day-number regex for the date formatter so it passes in en-US / es-ES / en-GB without hard-coding any one locale.

## Bug 2 — Server ADIF + QRZ upload (commit \`af0cf8c\`)

This was the more important one and was hidden in plain sight.

**Root cause:** LiteDB's default \`BsonMapper\` serialises \`DateTime\` as Local on write and returns \`Kind=Local\` on read. So even though \`LogService.CreateLogEntryAsync\` writes \`DateTime.UtcNow\` into the document, every subsequent \`GetLogEntryAsync\` / \`ExportToAdifAsync\` / \`PublishToQrz\` read gets back a \`Kind=Local\` value that REPRESENTS the same moment but in the operator's wall-clock zone. \`DateTime.ToString(\"HHmmss\")\` formats the stored value as-is — it does not do timezone conversion — so the local clock leaked all the way into the ADIF \`TIME_ON\` field that goes up to QRZ.com.

**Surface area:**
- \`Zeus.Server.Hosting/LogService.cs:AppendAdifRecord\` (ADIF file export)
- \`Zeus.Server.Hosting/QrzService.cs:ConvertLogEntryToAdif\` (QRZ.com publish)

**Fix:** add \`.ToUniversalTime()\` before \`.ToString()\` at both format sites. The transform is defensive, idempotent, and self-documenting: if the DateTime is already \`Utc\` (the fresh-write case before any LiteDB round-trip) \`.ToUniversalTime()\` is a no-op; if it's \`Local\` (post-round-trip) it converts. Either way the ADIF output is the operator's UTC clock.

**Visibility bump:** \`AppendAdifRecord\` / \`ConvertLogEntryToAdif\` go from private to internal so the regression suite can drive them. \`InternalsVisibleTo(\"Zeus.Server.Tests\")\` already exists.

**Tests:** \`tests/Zeus.Server.Tests/AdifUtcTimezoneTests.cs\` (3 cases). Constructs a \`DateTime\` with \`Kind=Local\` that represents a known UTC moment — exactly what LiteDB hands back — and asserts both code paths still emit the UTC clock in \`QSO_DATE\` / \`TIME_ON\`. A third case pins the \`Kind=Utc\` happy path so a future \"this looks redundant\" cleanup doesn't reintroduce the bug.

## Out of scope (follow-up)

The cleaner long-term fix is to configure the LiteDB \`BsonMapper\` for UTC round-trip globally. That would affect every store (CreatedUtc / QrzUploadedUtc / band-memory timestamps / etc.) so the risk surface is much broader; the surgical fix at the format sites is bulletproof and obvious, and the underlying LiteDB behaviour can be tightened in a separate follow-up issue.

## Test plan

- [x] \`dotnet test Zeus.slnx\` — 647 server (+3) + 84 contracts, 0 fail, 5 skip
- [x] \`npm --prefix zeus-web test\` — 223 vitest (+2), 0 fail
- [x] Bench-verified on a live HL2 (CET-summer operator): a fresh QSO logged at \`19:30 UTC\` now displays as \`19:30\` in the logbook and publishes to QRZ.com with \`QSO_DATE=20260524\` / \`TIME_ON=193000\` instead of the previous \`+2 h\` offset