### PR TITLE
fix(tuning): revert CTUN frozen-NCO — radio follows the dial again

### DIFF
--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -602,54 +602,26 @@ public sealed class RadioService : IDisposable
     {
         long clamped = Math.Clamp(hz, 0L, 60_000_000L);
         long previous;
-        long radioLo;
         RxMode currentMode;
-        int sampleRate;
-        int zoomLevel;
-        int filterLow;
-        int filterHigh;
         lock (_sync)
         {
             previous = _state.VfoHz;
             currentMode = _state.Mode;
-            radioLo = _state.RadioLoHz;
-            sampleRate = _state.SampleRate;
-            zoomLevel = Math.Max(1, _state.ZoomLevel);
-            filterLow = _state.FilterLowHz;
-            filterHigh = _state.FilterHighHz;
         }
-        bool retune;
-        if (!fromExternal)
-        {
-            long effectiveLoNew = CwOffset.EffectiveLoHz(currentMode, clamped);
-            long proposedShift = effectiveLoNew - radioLo;
-            long lMargin = Math.Max(0, -filterLow);
-            long hMargin = Math.Max(0, filterHigh);
-            double dispWidth = (double)sampleRate / zoomLevel;
-            double dispMarginHz = dispWidth * 0.05;
-            double lDisp = -dispWidth / 2.0 + dispMarginHz;
-            double hDisp = dispWidth / 2.0 - dispMarginHz;
-            bool outsideVisible = (proposedShift - lMargin) < lDisp
-                               || (proposedShift + hMargin) > hDisp;
-            long ifCapacity = (long)(sampleRate * 0.46);
-            bool outsideIf = Math.Abs(proposedShift) > ifCapacity;
-            retune = outsideVisible || outsideIf;
-        }
-        else
-        {
-            retune = true;
-        }
+        // Classic "radio follows the dial" tuning. The CTUN frozen-NCO model
+        // (#470) was reverted: it pinned the hardware NCO at the panadapter
+        // centre and offset RX in WDSP, but neither protocol client has a
+        // separate TX VFO (ControlFrame writes one VfoAHz to every freq
+        // register), so TX transmitted on the frozen centre instead of the
+        // dial. Every tune now retunes the radio so RX *and* TX track the dial;
+        // RadioLoHz follows the dial's effective LO (CW: dial ∓ pitch), which
+        // leaves the WDSP CTUN-shift stage at zero. The fromExternal flag is
+        // kept for API compatibility but no longer changes behaviour — all
+        // tunes retune now.
+        _ = fromExternal;
         long radioLoNew = CwOffset.EffectiveLoHz(currentMode, clamped);
-        Mutate(s => retune
-            ? s with { VfoHz = clamped, RadioLoHz = radioLoNew }
-            : s with { VfoHz = clamped });
-        if (retune)
-        {
-            // CW retunes the LO cw_pitch below/above the dial so the listening
-            // freq lands on the +cw_pitch / -cw_pitch audio passband. In SSB /
-            // AM / FM / DIG modes EffectiveLoHz returns the dial unchanged.
-            ActiveClient?.SetVfoAHz(radioLoNew);
-        }
+        Mutate(s => s with { VfoHz = clamped, RadioLoHz = radioLoNew });
+        ActiveClient?.SetVfoAHz(radioLoNew);
         // Band edge crossed? Per-band PA gain / OC bits may have swapped — push
         // the new snapshot before the next TX frame ships. Cheap when no
         // crossing occurred (same bytes re-pushed).

--- a/tests/Zeus.Server.Tests/RadioServiceSetRadioLoTests.cs
+++ b/tests/Zeus.Server.Tests/RadioServiceSetRadioLoTests.cs
@@ -13,10 +13,12 @@ using Zeus.Server;
 namespace Zeus.Server.Tests;
 
 /// <summary>
-/// Unit-test the frozen-NCO invariants the panadapter pure-pan PRD
-/// (<c>docs/prd/panfall_behavior.md</c>) bakes into <see cref="RadioService"/>:
+/// Unit-test the tuning invariants in <see cref="RadioService"/> after the
+/// CTUN frozen-NCO model was reverted to classic "radio follows the dial":
 ///
-///   1. <c>SetVfo</c> only moves the dial; <c>RadioLoHz</c> is untouched.
+///   1. <c>SetVfo</c> retunes the radio — <c>RadioLoHz</c> tracks the dial's
+///      effective LO (== dial for SSB/AM/FM/DIG, dial ∓ pitch for CW) so RX
+///      and TX both land on the dial. (Was frozen under the old CTUN model.)
 ///   2. <c>SetRadioLo</c> only moves the hardware NCO; <c>VfoHz</c> is untouched.
 ///   3. Out-of-range inputs to <c>SetRadioLo</c> clamp into the legal HPSDR
 ///      tunable range [0, 60_000_000] Hz (matching <c>SetVfo</c>); the
@@ -82,16 +84,22 @@ public sealed class RadioServiceSetRadioLoTests : IDisposable
     }
 
     [Fact]
-    public void SetVfo_DoesNotMoveRadioLoHz()
+    public void SetVfo_MovesRadioLoToTrackDial()
     {
         using var radio = BuildRadio();
-        var seed = radio.SetRadioLo(28_400_000);
-        long loBefore = seed.RadioLoHz;
+        radio.SetRadioLo(28_400_000);
 
         var after = radio.SetVfo(28_410_500);
 
-        Assert.Equal(loBefore, after.RadioLoHz);
+        // Classic "radio follows the dial" (CTUN frozen-NCO reverted): SetVfo
+        // now retunes the LO to the dial's effective LO so RX and TX track the
+        // dial, instead of leaving it frozen at the old centre (28_400_000).
         Assert.Equal(28_410_500, after.VfoHz);
+        Assert.NotEqual(28_400_000, after.RadioLoHz);
+        // RadioLoHz lands on the dial (± CW pitch, which is well under 2 kHz),
+        // mode-agnostic so the test doesn't depend on the default RxMode.
+        Assert.True(Math.Abs(after.RadioLoHz - 28_410_500) <= 2_000,
+            $"RadioLoHz {after.RadioLoHz} should track dial 28410500 within CW pitch");
     }
 
     [Fact]

--- a/zeus-web/src/util/use-pan-tune-gesture.ts
+++ b/zeus-web/src/util/use-pan-tune-gesture.ts
@@ -43,7 +43,7 @@
 // License for details.
 
 import { createContext, useContext, useEffect, type RefObject } from 'react';
-import { setRadioLo, setVfo, setZoom, ZOOM_MAX, ZOOM_MIN, type ZoomLevel } from '../api/client';
+import { setVfo, setZoom, ZOOM_MAX, ZOOM_MIN, type ZoomLevel } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
 import { useDisplayStore } from '../state/display-store';
 import { useToolbarFavoritesStore } from '../state/toolbar-favorites-store';
@@ -333,15 +333,17 @@ export function usePanTuneGesture(
       drag.moved = true;
       const rect = canvas.getBoundingClientRect();
       if (rect.width <= 0) return;
-      // Pure-pan: drag right → viewport centre slides to a lower Hz so the
-      // grabbed content moves right with the finger. No setVfo, no POST —
-      // we just mutate the frontend-only viewportOffsetHz. The panadapter +
-      // waterfall redraw subscribers in Panadapter.tsx / Waterfall.tsx pick
-      // this up and slide the trace + texture under the cursor at rAF rate.
-      const newViewportCenter =
-        drag.startViewportCenterHz - (dx / rect.width) * drag.spanHz;
-      const radioLoHz = useConnectionStore.getState().radioLoHz;
-      useDisplayStore.getState().setViewportOffsetHz(newViewportCenter - radioLoHz);
+      // Drag-to-tune (classic, CTUN pure-pan reverted): the frequency under the
+      // cursor becomes the dial, streamed through the coalesced setVfo pipeline
+      // so the radio retunes live as you drag. No viewport offset — RadioLoHz
+      // follows the dial server-side, RX and TX both track it.
+      const view = readView();
+      if (!view) return;
+      const frac = (e.clientX - rect.left) / rect.width;
+      pendingHz = clampHz(
+        Math.round(view.centerHz + view.viewportOffsetHz + (frac - 0.5) * view.spanHz),
+      );
+      scheduleFlush();
     };
 
     const onPointerUp = (e: PointerEvent) => {
@@ -374,64 +376,13 @@ export function usePanTuneGesture(
       }
       const rect = canvas.getBoundingClientRect();
       if (rect.width <= 0) return;
-      if (d.moved) {
-        // Drag release — decide whether the panned viewport still sits inside
-        // the IQ capture window. If yes, leave viewportOffsetHz as-is; the
-        // dial keeps demodulating its tuned signal (potentially off-screen)
-        // and the operator can keep panning visually. If no, retune the
-        // hardware NCO so the new sample window adjoins the released viewport
-        // in the pan direction; we optimistically rebase the offset so
-        // on-screen frequencies don't visually jump across the retune.
-        const display = useDisplayStore.getState();
-        const cn = useConnectionStore.getState();
-        const viewportOffsetHz = display.viewportOffsetHz;
-        const sampleBw = cn.sampleRate;
-        const viewportLowerEdge =
-          cn.radioLoHz + viewportOffsetHz - d.spanHz / 2;
-        const viewportUpperEdge =
-          cn.radioLoHz + viewportOffsetHz + d.spanHz / 2;
-        const sampleLowerEdge = cn.radioLoHz - sampleBw / 2;
-        const sampleUpperEdge = cn.radioLoHz + sampleBw / 2;
-        const inside =
-          viewportLowerEdge >= sampleLowerEdge &&
-          viewportUpperEdge <= sampleUpperEdge;
-        if (inside) return;
-        // Land the fresh IQ window adjacent to the released viewport in the
-        // pan direction. Panning up (offset > 0) puts the sample window's
-        // bottom at the current viewport bottom; panning down does the
-        // mirror.
-        const newRadioLoHz =
-          viewportOffsetHz > 0
-            ? Math.round(viewportLowerEdge + sampleBw / 2)
-            : Math.round(viewportUpperEdge - sampleBw / 2);
-        const clampedNewRadioLoHz = clampHz(newRadioLoHz);
-        const oldRadioLoHz = cn.radioLoHz;
-        // Optimistic update: move radioLoHz now, rebase the offset so the
-        // absolute frequency at every screen pixel is preserved across the
-        // retune. The /api/radio/lo response will reconcile both values.
-        useConnectionStore.setState({ radioLoHz: clampedNewRadioLoHz });
-        display.setViewportOffsetHz(
-          oldRadioLoHz + viewportOffsetHz - clampedNewRadioLoHz,
-        );
-        setRadioLo(clampedNewRadioLoHz)
-          .then((s) => useConnectionStore.getState().applyState(s))
-          .catch(() => {
-            // Server rejected the retune (e.g. out of band for this radio).
-            // Roll back to the pre-release state so the operator sees the
-            // viewport snap back to the last valid offset.
-            useConnectionStore.setState({ radioLoHz: oldRadioLoHz });
-            display.setViewportOffsetHz(viewportOffsetHz);
-          });
-      } else {
-        // click-to-tune: resolve the clicked frequency against the live
-        // viewport (centre = radioLoHz + viewportOffsetHz).
-        const view = readView();
-        if (!view) return;
-        const frac = (e.clientX - rect.left) / rect.width;
-        commitFinal(
-          view.centerHz + view.viewportOffsetHz + (frac - 0.5) * view.spanHz,
-        );
-      }
+      // Drag or click — both tune to the frequency at the release point. CTUN
+      // pure-pan (leave-offset / retune-NCO-on-release) is gone: a release
+      // always commits a dial tune so RX and TX track where you let go.
+      const view = readView();
+      if (!view) return;
+      const frac = (e.clientX - rect.left) / rect.width;
+      commitFinal(view.centerHz + view.viewportOffsetHz + (frac - 0.5) * view.spanHz);
     };
 
     const onWheel = (e: WheelEvent) => {


### PR DESCRIPTION
## What
Reverts the CTUN frozen-NCO tuning behavior back to classic **"radio follows the dial."**

## Why
CTUN's frozen-NCO model (#470) pinned the hardware NCO at the panadapter center and offset RX in WDSP — but neither the P1 nor P2 client has a **separate TX VFO** (`ControlFrame.cs:264` writes one `VfoAHz` to every freq register). So the **TX carrier transmitted on the frozen center instead of the dial**. Confirmed on a G2 with a second receiver: dial at 3993.5 kHz, carrier stuck on 3999 — out-of-band TX risk.

## How (3 files, minimal)
- `RadioService.SetVfo` — always retunes; `RadioLoHz` tracks the dial's effective LO → RX *and* TX track the dial (fixes both P1 + P2).
- `use-pan-tune-gesture.ts` — panadapter drag/click tune again (pure-pan removed).
- `RadioServiceSetRadioLoTests.cs` — the one frozen-NCO test rewritten to the new contract.

Everything else (WDSP shift, `/api/radio/lo`, CW/TCI/calibration/persistence, **and #484 pan/waterfall split**) is left untouched — all former-CTUN paths become correct no-ops because `RadioLoHz` now always equals the dial.

## Test
- `dotnet build` clean (0 warnings), `dotnet test` 5/5 pass.
- **Bench-confirmed on G2 (Protocol 2):** dial 3999 → 3993.5, TX carrier now lands on 3993.5 (second-RX verified).
- Still needs an **HL2 (Protocol 1)** bench confirm.

Behavior-revert agreed by Doug + Brian (CTUN author).