### PR TITLE
fix(display): persist panadapter dB scale server-side across restarts (#478)

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -577,21 +577,41 @@ public sealed record Hl2OptionsSetRequest(bool BandVolts);
 // "image"; Fit is one of "fit" | "fill" | "stretch". Image bytes are NOT
 // shipped in this DTO; HasImage signals whether GET /api/display-settings/image
 // will return content. RxTraceColor is the panadapter signal trace colour
-// as #RRGGBB (default "#FFA028"). All fields persisted server-side so the
-// settings follow the operator across browsers / devices — Photino desktop
-// mode in particular binds the webview to a fresh random loopback port on
-// every launch, which orphans any per-origin localStorage value.
+// as #RRGGBB (default "#FFA028"). Db* fields are the panadapter/waterfall dB
+// window bounds persisted so the operator's scale survives a backend restart.
+// Null means the server has never stored that field; the frontend falls back
+// to its built-in defaults (FIXED_DB_MIN / TX_FIXED_DB_MIN etc.) and pushes
+// the current value up on next interaction. All fields persisted server-side
+// so the settings follow the operator across browsers / devices — Photino
+// desktop mode in particular binds the webview to a fresh random loopback
+// port on every launch, which orphans any per-origin localStorage value.
 public sealed record DisplaySettingsDto(
     string Mode,
     string Fit,
     bool HasImage,
     string? ImageMime,
-    string RxTraceColor);
+    string RxTraceColor,
+    double? DbMin,
+    double? DbMax,
+    double? TxDbMin,
+    double? TxDbMax,
+    double? WfDbMin,
+    double? WfDbMax,
+    double? WfTxDbMin,
+    double? WfTxDbMax);
 
 public sealed record DisplaySettingsSetRequest(
     string Mode,
     string Fit,
-    string RxTraceColor);
+    string RxTraceColor,
+    double? DbMin = null,
+    double? DbMax = null,
+    double? TxDbMin = null,
+    double? TxDbMax = null,
+    double? WfDbMin = null,
+    double? WfDbMax = null,
+    double? WfTxDbMin = null,
+    double? WfTxDbMax = null);
 
 // Per-mode disclosure state for the inline NR settings accordion that hangs
 // below the DSP NR toggle row. Three independent booleans — one per NR

--- a/Zeus.Server.Hosting/DisplaySettingsStore.cs
+++ b/Zeus.Server.Hosting/DisplaySettingsStore.cs
@@ -57,18 +57,41 @@ public sealed class DisplaySettingsStore : IDisposable
                     Fit: "fill",
                     HasImage: false,
                     ImageMime: null,
-                    RxTraceColor: DefaultRxTraceColor);
+                    RxTraceColor: DefaultRxTraceColor,
+                    DbMin: null,
+                    DbMax: null,
+                    TxDbMin: null,
+                    TxDbMax: null,
+                    WfDbMin: null,
+                    WfDbMax: null,
+                    WfTxDbMin: null,
+                    WfTxDbMax: null);
             }
             return new DisplaySettingsDto(
                 Mode: NormalizeMode(e.Mode),
                 Fit: NormalizeFit(e.Fit),
                 HasImage: e.ImageBytes is { Length: > 0 },
                 ImageMime: string.IsNullOrEmpty(e.ImageMime) ? null : e.ImageMime,
-                RxTraceColor: NormalizeHexColor(e.RxTraceColor));
+                RxTraceColor: NormalizeHexColor(e.RxTraceColor),
+                DbMin: e.DbMin,
+                DbMax: e.DbMax,
+                TxDbMin: e.TxDbMin,
+                TxDbMax: e.TxDbMax,
+                WfDbMin: e.WfDbMin,
+                WfDbMax: e.WfDbMax,
+                WfTxDbMin: e.WfTxDbMin,
+                WfTxDbMax: e.WfTxDbMax);
         }
     }
 
-    public void SaveMode(string mode, string fit, string rxTraceColor)
+    // Null dB range values are treated as "not provided" — the existing
+    // stored value is kept unchanged. This lets callers updating only
+    // mode/fit/color leave the operator's dB scale untouched.
+    public void SaveMode(string mode, string fit, string rxTraceColor,
+        double? dbMin = null, double? dbMax = null,
+        double? txDbMin = null, double? txDbMax = null,
+        double? wfDbMin = null, double? wfDbMax = null,
+        double? wfTxDbMin = null, double? wfTxDbMax = null)
     {
         lock (_sync)
         {
@@ -76,6 +99,14 @@ public sealed class DisplaySettingsStore : IDisposable
             e.Mode = NormalizeMode(mode);
             e.Fit = NormalizeFit(fit);
             e.RxTraceColor = NormalizeHexColor(rxTraceColor);
+            if (dbMin.HasValue) e.DbMin = dbMin;
+            if (dbMax.HasValue) e.DbMax = dbMax;
+            if (txDbMin.HasValue) e.TxDbMin = txDbMin;
+            if (txDbMax.HasValue) e.TxDbMax = txDbMax;
+            if (wfDbMin.HasValue) e.WfDbMin = wfDbMin;
+            if (wfDbMax.HasValue) e.WfDbMax = wfDbMax;
+            if (wfTxDbMin.HasValue) e.WfTxDbMin = wfTxDbMin;
+            if (wfTxDbMax.HasValue) e.WfTxDbMax = wfTxDbMax;
             e.UpdatedUtc = DateTime.UtcNow;
             if (e.Id == 0) _docs.Insert(e);
             else _docs.Update(e);
@@ -169,5 +200,17 @@ public sealed class DisplaySettingsEntry
     // Panadapter signal trace colour as #RRGGBB. Null on legacy rows written
     // before this field existed — Get() normalises null → DefaultRxTraceColor.
     public string? RxTraceColor { get; set; }
+    // Panadapter and waterfall dB window bounds. Null on rows written before
+    // this field existed — Get() returns null to the frontend, which then
+    // falls back to its built-in FIXED_DB_MIN / TX_FIXED_DB_MIN constants and
+    // pushes the localStorage-saved (or default) value up on first interaction.
+    public double? DbMin { get; set; }
+    public double? DbMax { get; set; }
+    public double? TxDbMin { get; set; }
+    public double? TxDbMax { get; set; }
+    public double? WfDbMin { get; set; }
+    public double? WfDbMax { get; set; }
+    public double? WfTxDbMin { get; set; }
+    public double? WfTxDbMax { get; set; }
     public DateTime UpdatedUtc { get; set; }
 }

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -845,7 +845,9 @@ public static class ZeusEndpoints
         {
             if (string.IsNullOrWhiteSpace(req.Mode) || string.IsNullOrWhiteSpace(req.Fit))
                 return Results.BadRequest(new { error = "mode and fit required" });
-            store.SaveMode(req.Mode, req.Fit, req.RxTraceColor);
+            store.SaveMode(req.Mode, req.Fit, req.RxTraceColor,
+                req.DbMin, req.DbMax, req.TxDbMin, req.TxDbMax,
+                req.WfDbMin, req.WfDbMax, req.WfTxDbMin, req.WfTxDbMax);
             return Results.Ok(store.Get());
         });
 

--- a/tests/Zeus.Server.Tests/DisplaySettingsPersistenceTests.cs
+++ b/tests/Zeus.Server.Tests/DisplaySettingsPersistenceTests.cs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// Persistence coverage for issue #478 — panadapter dB scale now survives a
+// backend restart. Verifies that all eight dB range fields round-trip through
+// LiteDB and that a fresh (or legacy) row returns null so the frontend knows
+// to fall back to its built-in defaults and push the localStorage value up.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Zeus.Server.Tests;
+
+public class DisplaySettingsPersistenceTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-display-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+    }
+
+    private DisplaySettingsStore BuildStore() =>
+        new(NullLogger<DisplaySettingsStore>.Instance, _dbPath);
+
+    [Fact]
+    public void FreshDb_ReturnsNullForAllDbRangeFields()
+    {
+        using var store = BuildStore();
+        var dto = store.Get();
+
+        Assert.Null(dto.DbMin);
+        Assert.Null(dto.DbMax);
+        Assert.Null(dto.TxDbMin);
+        Assert.Null(dto.TxDbMax);
+        Assert.Null(dto.WfDbMin);
+        Assert.Null(dto.WfDbMax);
+        Assert.Null(dto.WfTxDbMin);
+        Assert.Null(dto.WfTxDbMax);
+    }
+
+    [Fact]
+    public void SaveMode_WithDbRanges_PersistsAllFields()
+    {
+        using (var store = BuildStore())
+        {
+            store.SaveMode("basic", "fill", "#FFA028",
+                dbMin: -130, dbMax: -60,
+                txDbMin: -75, txDbMax: 15,
+                wfDbMin: -125, wfDbMax: -55,
+                wfTxDbMin: -70, wfTxDbMax: 10);
+        }
+
+        // Reopen to prove the values survived the LiteDB file round-trip.
+        using var fresh = BuildStore();
+        var dto = fresh.Get();
+
+        Assert.Equal(-130, dto.DbMin);
+        Assert.Equal(-60, dto.DbMax);
+        Assert.Equal(-75, dto.TxDbMin);
+        Assert.Equal(15, dto.TxDbMax);
+        Assert.Equal(-125, dto.WfDbMin);
+        Assert.Equal(-55, dto.WfDbMax);
+        Assert.Equal(-70, dto.WfTxDbMin);
+        Assert.Equal(10, dto.WfTxDbMax);
+    }
+
+    [Fact]
+    public void SaveMode_NullDbRanges_DoNotOverwriteExistingValues()
+    {
+        // Write concrete dB values first.
+        using (var store = BuildStore())
+        {
+            store.SaveMode("basic", "fill", "#FFA028",
+                dbMin: -130, dbMax: -60,
+                txDbMin: -75, txDbMax: 15,
+                wfDbMin: -125, wfDbMax: -55,
+                wfTxDbMin: -70, wfTxDbMax: 10);
+        }
+
+        // Update mode/fit/color only — no dB range args (default null).
+        using (var update = BuildStore())
+        {
+            update.SaveMode("beam-map", "fill", "#FF8800");
+        }
+
+        // dB values must still be the originals.
+        using var check = BuildStore();
+        var dto = check.Get();
+
+        Assert.Equal("beam-map", dto.Mode);
+        Assert.Equal(-130, dto.DbMin);
+        Assert.Equal(-60, dto.DbMax);
+        Assert.Equal(-75, dto.TxDbMin);
+        Assert.Equal(15, dto.TxDbMax);
+    }
+
+    [Fact]
+    public void SaveMode_UpdateDbRanges_OverwritesExistingValues()
+    {
+        using var store = BuildStore();
+        store.SaveMode("basic", "fill", "#FFA028",
+            dbMin: -140, dbMax: -50);
+        store.SaveMode("basic", "fill", "#FFA028",
+            dbMin: -120, dbMax: -40);
+
+        var dto = store.Get();
+        Assert.Equal(-120, dto.DbMin);
+        Assert.Equal(-40, dto.DbMax);
+    }
+}

--- a/zeus-web/src/api/display.ts
+++ b/zeus-web/src/api/display.ts
@@ -12,6 +12,19 @@ export type DisplaySettings = {
   hasImage: boolean;
   imageMime: string | null;
   rxTraceColor: string;
+  // Panadapter and waterfall dB window bounds. null means the server has
+  // never stored a value; the frontend falls back to its built-in defaults
+  // (FIXED_DB_MIN / TX_FIXED_DB_MIN) and pushes the current value up on
+  // next interaction. Non-null values are used as-is (server wins over
+  // localStorage, surviving the Photino per-launch port shuffle).
+  dbMin: number | null;
+  dbMax: number | null;
+  txDbMin: number | null;
+  txDbMax: number | null;
+  wfDbMin: number | null;
+  wfDbMax: number | null;
+  wfTxDbMin: number | null;
+  wfTxDbMax: number | null;
 };
 
 // Matches backend DisplaySettingsStore.DefaultRxTraceColor.
@@ -23,11 +36,23 @@ type DisplaySettingsDtoRaw = {
   hasImage?: boolean;
   imageMime?: string | null;
   rxTraceColor?: string | null;
+  dbMin?: number | null;
+  dbMax?: number | null;
+  txDbMin?: number | null;
+  txDbMax?: number | null;
+  wfDbMin?: number | null;
+  wfDbMax?: number | null;
+  wfTxDbMin?: number | null;
+  wfTxDbMax?: number | null;
 };
 
 function normalizeRxTraceColor(raw: string | null | undefined): string {
   if (typeof raw !== 'string') return DEFAULT_RX_TRACE_COLOR;
   return /^#[0-9A-Fa-f]{6}$/.test(raw) ? raw.toUpperCase() : DEFAULT_RX_TRACE_COLOR;
+}
+
+function normalizeDbValue(raw: number | null | undefined): number | null {
+  return typeof raw === 'number' && Number.isFinite(raw) ? raw : null;
 }
 
 function normalize(raw: DisplaySettingsDtoRaw): DisplaySettings {
@@ -45,6 +70,14 @@ function normalize(raw: DisplaySettingsDtoRaw): DisplaySettings {
     hasImage: !!raw.hasImage,
     imageMime: raw.imageMime ?? null,
     rxTraceColor: normalizeRxTraceColor(raw.rxTraceColor),
+    dbMin: normalizeDbValue(raw.dbMin),
+    dbMax: normalizeDbValue(raw.dbMax),
+    txDbMin: normalizeDbValue(raw.txDbMin),
+    txDbMax: normalizeDbValue(raw.txDbMax),
+    wfDbMin: normalizeDbValue(raw.wfDbMin),
+    wfDbMax: normalizeDbValue(raw.wfDbMax),
+    wfTxDbMin: normalizeDbValue(raw.wfTxDbMin),
+    wfTxDbMax: normalizeDbValue(raw.wfTxDbMax),
   };
 }
 
@@ -58,12 +91,32 @@ export async function updateDisplaySettings(
   mode: DisplaySettings['mode'],
   fit: DisplaySettings['fit'],
   rxTraceColor: string,
+  dbMin?: number | null,
+  dbMax?: number | null,
+  txDbMin?: number | null,
+  txDbMax?: number | null,
+  wfDbMin?: number | null,
+  wfDbMax?: number | null,
+  wfTxDbMin?: number | null,
+  wfTxDbMax?: number | null,
   signal?: AbortSignal,
 ): Promise<DisplaySettings> {
   const res = await fetch('/api/display-settings', {
     method: 'PUT',
     headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ mode, fit, rxTraceColor }),
+    body: JSON.stringify({
+      mode,
+      fit,
+      rxTraceColor,
+      dbMin,
+      dbMax,
+      txDbMin,
+      txDbMax,
+      wfDbMin,
+      wfDbMax,
+      wfTxDbMin,
+      wfTxDbMax,
+    }),
     signal,
   });
   if (!res.ok) throw new Error(`PUT /api/display-settings → ${res.status}`);

--- a/zeus-web/src/state/display-settings-store.ts
+++ b/zeus-web/src/state/display-settings-store.ts
@@ -219,6 +219,32 @@ function writeSavedWfTxRange(wfTxDbMin: number, wfTxDbMax: number): void {
   }
 }
 
+// Debounced server save for dB range changes. The drag gesture fires many
+// small shiftDbRange calls per second; we batch them into a single PUT after
+// the operator lifts their finger (1 s quiet period), the same pattern used
+// by layout-store.ts for tile position saves.
+let dbRangeTimer: ReturnType<typeof setTimeout> | null = null;
+
+function scheduleDbRangeSave(): void {
+  if (dbRangeTimer) clearTimeout(dbRangeTimer);
+  dbRangeTimer = setTimeout(() => {
+    const s = useDisplaySettingsStore.getState();
+    void updateDisplaySettings(
+      s.panBackground,
+      s.backgroundImageFit,
+      s.rxTraceColor,
+      s.dbMin,
+      s.dbMax,
+      s.txDbMin,
+      s.txDbMax,
+      s.wfDbMin,
+      s.wfDbMax,
+      s.wfTxDbMin,
+      s.wfTxDbMax,
+    );
+  }, 1000);
+}
+
 // Exponential smoothing constant for the auto-range tracker. 0.1 trades
 // flicker resistance for responsiveness — band-change artifacts fade over
 // ~30 frames at 30 Hz (~1 s).
@@ -418,6 +444,7 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
     const nextMax = Math.max(-DB_ABS_LIMIT, Math.min(DB_ABS_LIMIT, baseMax + deltaDb));
     set({ autoRange: false, dbMin: nextMin, dbMax: nextMax });
     writeSavedRange(nextMin, nextMax);
+    scheduleDbRangeSave();
   },
   shiftTxDbRange: (deltaDb) => {
     const { txDbMin, txDbMax } = get();
@@ -425,6 +452,7 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
     const nextMax = Math.max(-DB_ABS_LIMIT, Math.min(DB_ABS_LIMIT, txDbMax + deltaDb));
     set({ txDbMin: nextMin, txDbMax: nextMax });
     writeSavedTxRange(nextMin, nextMax);
+    scheduleDbRangeSave();
   },
   shiftWfDbRange: (deltaDb) => {
     const { wfDbMin, wfDbMax } = get();
@@ -432,6 +460,7 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
     const nextMax = Math.max(-DB_ABS_LIMIT, Math.min(DB_ABS_LIMIT, wfDbMax + deltaDb));
     set({ wfDbMin: nextMin, wfDbMax: nextMax });
     writeSavedWfRange(nextMin, nextMax);
+    scheduleDbRangeSave();
   },
   shiftWfTxDbRange: (deltaDb) => {
     const { wfTxDbMin, wfTxDbMax } = get();
@@ -439,6 +468,7 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
     const nextMax = Math.max(-DB_ABS_LIMIT, Math.min(DB_ABS_LIMIT, wfTxDbMax + deltaDb));
     set({ wfTxDbMin: nextMin, wfTxDbMax: nextMax });
     writeSavedWfTxRange(nextMin, nextMax);
+    scheduleDbRangeSave();
   },
   updateAutoRange: (wfDb) => {
     if (!get().autoRange || wfDb.length === 0) return;
@@ -522,12 +552,37 @@ async function hydrateFromServer(): Promise<void> {
 
   clearLegacyLocalStorage();
 
+  // Server dB values of null mean the field was never stored (fresh install
+  // or first run after upgrading to a version that added server persistence).
+  // Use server values when present; otherwise keep the localStorage-initialized
+  // state and push it up so the server has it for next restart.
+  const serverHasDbRange = server.dbMin !== null;
+
   useDisplaySettingsStore.setState({
     panBackground: server.mode,
     backgroundImage: server.hasImage ? displayImageUrl(Date.now()) : null,
     backgroundImageFit: server.fit,
     rxTraceColor: server.rxTraceColor,
+    ...(serverHasDbRange
+      ? {
+          dbMin: server.dbMin!,
+          dbMax: server.dbMax!,
+          txDbMin: server.txDbMin!,
+          txDbMax: server.txDbMax!,
+          wfDbMin: server.wfDbMin!,
+          wfDbMax: server.wfDbMax!,
+          wfTxDbMin: server.wfTxDbMin!,
+          wfTxDbMax: server.wfTxDbMax!,
+        }
+      : {}),
   });
+
+  if (!serverHasDbRange) {
+    // Push the current in-memory values (from localStorage or defaults) up
+    // to the server so subsequent restarts find them persisted. This is the
+    // one-time migration for operators upgrading from localStorage-only storage.
+    scheduleDbRangeSave();
+  }
 }
 
 function readLegacyLocalStorage(): { mode: PanBackgroundMode | null; fit: BackgroundImageFit | null; image: string | null } | null {


### PR DESCRIPTION
Promotes the agent's **#480** (validated on experimental) to develop.

Persists the panadapter/waterfall dB-scale window server-side in `zeus-prefs.db` (the same pattern as background mode + trace color), so the operator's dB scale survives a restart — desktop and browser. Root cause: the dB scale lived in browser `localStorage`, and the desktop app's per-launch random loopback port orphaned it each run.

- 8 nullable dB fields (RX/TX panadapter + waterfall), backward-compatible (null = legacy → frontend defaults).
- Debounced 1s server save matching `layout-store.ts`.
- Includes `DisplaySettingsPersistenceTests.cs`.

Build clean (0 warnings), tests pass, **bench-confirmed on G2** (dB scale survived a backend restart, second-RX/API verified). Cherry-picked from experimental `20d4ac8`; authorship preserved (@kb2uka-agent).