### PR TITLE
fix(audio): drain RX ring on TX→RX edge so MOX-off RX resume is instant

### DIFF
--- a/Zeus.Server.Hosting/NativeAudioSink.cs
+++ b/Zeus.Server.Hosting/NativeAudioSink.cs
@@ -193,17 +193,20 @@ internal sealed class NativeAudioSink : IRxAudioSink, IAuditionAudioSink, IHoste
             _output = null;
         }
 
-        // Subscribe to TX-active edges so we can drain the ring on TX-on.
-        // The radio sample clock and the WASAPI playback clock drift relative
-        // to each other (the radio runs slightly faster than the soundcard on
-        // most Windows systems), so the ring slowly accumulates a backlog
-        // over a multi-minute session. Without this hook the operator hears
-        // up to ~1.3 sec of stale RX audio after pressing MOX or TUNE before
-        // the buffer drains to silence. macOS / Linux see this too in
-        // principle but their audio backends drift much less and the ring
-        // stays at near-zero steady-state depth, so the clear is a no-op
-        // there. See issue #403 for the original symptom report and the
-        // diagnostic write-up.
+        // Subscribe to TX-active edges so we can drain the ring on BOTH
+        // the TX-on and TX-off transitions. The radio sample clock and the
+        // WASAPI playback clock drift relative to each other (the radio runs
+        // slightly faster than the soundcard on most Windows systems), so the
+        // ring slowly accumulates a backlog. Without the TX-on clear the
+        // operator hears up to ~1.3 sec of stale RX audio after pressing MOX
+        // or TUNE before the buffer drains to silence (issue #403). The same
+        // drift refills the ring over the TX period, so without the TX-off
+        // clear the operator then waits ~1-2 sec for that stale backlog to
+        // play out before fresh post-MOX RX audio reaches the ear (the TX→RX
+        // half of issue #468). macOS / Linux see this too in principle but
+        // their audio backends drift much less and the ring stays at near-
+        // zero steady-state depth, so both clears are no-ops there. See
+        // OnTxActiveChanged for the full per-edge rationale.
         _tx = _services?.GetService(typeof(TxService)) as TxService;
         if (_tx is not null)
         {
@@ -227,19 +230,40 @@ internal sealed class NativeAudioSink : IRxAudioSink, IAuditionAudioSink, IHoste
     }
 
     /// <summary>
-    /// TxService.TxActiveChanged subscriber. On the rising edge (TX
-    /// engaging via MOX, TUN, or TwoTone) drains the RX audio ring so
-    /// the operator hears instant silence rather than the accumulated
-    /// pre-TX backlog. The audition ring is left alone — audition is
-    /// gated separately and pre-MOX preview is meaningful right up to
-    /// the MOX edge; the existing audition gates handle the rest.
-    /// On falling edge (TX releasing → back to RX) this is a no-op
-    /// because the ring is already empty after the drain; new RX
-    /// samples land in an empty ring and reach the speaker promptly.
+    /// TxService.TxActiveChanged subscriber. Drains the RX audio ring on
+    /// BOTH edges of TX-active (MOX / TUN / TwoTone):
+    ///
+    /// <para><b>Rising edge (RX→TX):</b> clears the pre-TX backlog so the
+    /// operator hears instant silence rather than seconds of stale RX audio
+    /// playing out while keyed. This is the original PR #454 / issue #403
+    /// fix and is unchanged.</para>
+    ///
+    /// <para><b>Falling edge (TX→RX):</b> ALSO clears the ring. While keyed,
+    /// the RX demod chain keeps producing audio (WDSP RXA is damped but
+    /// <c>fexchange0</c> still cycles and the pipeline keeps calling
+    /// <c>ReadAudio</c> → <c>Publish</c>), so the ring re-accumulates a
+    /// backlog over the TX period for exactly the same radio-clock-vs-
+    /// soundcard-clock drift reason described on the rising edge. On Windows
+    /// (WASAPI) that backlog is up to ~1–2 sec by the time the operator
+    /// un-keys, and without this clear the fresh post-MOX RX audio queues
+    /// <em>behind</em> the stale backlog — the operator waits for the stale
+    /// samples to play out before live RX reaches the ear. That is the
+    /// "MOX delay still in 0.8.3 on TX→RX" half of issue #468. Draining
+    /// here lets the next pipeline tick's fresh RX audio land in an empty
+    /// ring and reach the speaker within one playback period. The brief
+    /// gap until the first fresh sample arrives is covered by the existing
+    /// underrun→silence path — it is the same gap as the post-MOX RX
+    /// resume itself, not an extra dropout. macOS / Linux drift far less,
+    /// so as with the rising edge this is effectively a no-op there.</para>
+    ///
+    /// <para>The audition ring is left alone on both edges — audition is
+    /// gated separately and pre-MOX preview is meaningful right up to the
+    /// MOX edge; the existing audition gates handle the rest.</para>
     /// </summary>
     internal void OnTxActiveChanged(bool txActive)
     {
-        if (!txActive) return;
+        // Drain on either edge — see the XML doc for why the falling edge
+        // (TX→RX) needs the clear just as much as the rising edge.
         _ring.Clear();
     }
 

--- a/tests/Zeus.Server.Tests/TxActiveChangedTests.cs
+++ b/tests/Zeus.Server.Tests/TxActiveChangedTests.cs
@@ -86,19 +86,28 @@ public class TxActiveChangedTests : IDisposable
     }
 
     [Fact]
-    public void NativeAudioSink_OnTxActiveChanged_False_DoesNotMutateRing()
+    public void NativeAudioSink_OnTxActiveChanged_False_ClearsRing()
     {
-        // Falling-edge TX (TX→RX) must NOT drain the ring — there's nothing
-        // useful to drain (the rising-edge handler already did) and we want
-        // any in-flight RX samples to play through immediately.
+        // Falling-edge TX (TX→RX) ALSO drains the ring. While keyed the RX
+        // demod chain keeps producing audio and the pipeline keeps publishing
+        // it, so the ring re-accumulates a backlog over the TX period (same
+        // radio-clock-vs-soundcard-clock drift as the rising edge). On Windows
+        // that stale backlog is up to ~1-2 sec by un-key time; if it isn't
+        // cleared the fresh post-MOX RX audio queues behind it and the
+        // operator waits for the stale samples to play out before live RX
+        // reaches the ear — the TX→RX half of issue #468. Draining on the
+        // falling edge lets the next tick's fresh RX audio reach the speaker
+        // within one playback period.
         var sink = new NativeAudioSink(NullLogger<NativeAudioSink>.Instance);
         var frame = BuildMonoFrame(600);
         sink.Publish(in frame);
 
-        int depthBefore = sink.CurrentRingDepth;
+        Assert.True(sink.CurrentRingDepth >= 600,
+            $"setup precondition: ring should be filled. got {sink.CurrentRingDepth}");
+
         sink.OnTxActiveChanged(false);
 
-        Assert.Equal(depthBefore, sink.CurrentRingDepth);
+        Assert.Equal(0, sink.CurrentRingDepth);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Going **TX → RX** (un-key, MOX off) on the Windows desktop app left ~1–2 sec of delay before RX audio resumed, while **RX → TX** (key up) was instant. This is the desktop native-audio path (Photino + miniaudio/WASAPI), not the browser. It is the TX→RX half of #468; #494 already handled the browser audio-client reset.

### Root cause — the asymmetry

PR #454 made the RX→TX edge instant by draining `NativeAudioSink`'s RX audio ring on the **TX-on** edge (`NativeAudioSink.OnTxActiveChanged`). The **TX-off** edge was a deliberate no-op, on the stated assumption that "the ring is already empty after the rising-edge drain." That assumption does not hold:

- While keyed, the RX demod chain keeps running. WDSP RXA is damped (`WdspDspEngine.SetMox` → `SetChannelState(rxaId, 0, 1)` at `Zeus.Dsp/Wdsp/WdspDspEngine.cs:1379`), but the worker's `fexchange0` still cycles every IQ frame and pushes output into the WDSP audio ring (`WdspDspEngine.cs:2703` + `PushAudio` at `:898`).
- The pipeline's audio publish is gated on **TX monitor**, not on MOX, so it keeps draining WDSP audio into `NativeAudioSink` during the entire TX period (`DspPipelineService.cs:1617-1671`).
- The same radio-clock-vs-WASAPI-clock drift that PR #454 documents therefore **re-accumulates a backlog in the ring over the TX period**. By un-key time the ring holds up to ~1–2 sec of stale samples.
- On TX-off, fresh post-MOX RX audio queues **behind** that stale backlog. The operator waits for the stale tail to play out before live RX reaches the ear → the ~1–2 sec delay. The TX-off edge was a no-op (`OnTxActiveChanged`: `if (!txActive) return;`), so nothing cleared it.

`NativeAudioSink` itself has no `BUFFER_TARGET_SECS` / re-anchor (that lives only in the browser `audio-client.ts`, handled by #494) — on desktop the cause is purely the stale ring backlog described above.

## What changed

- **`Zeus.Server.Hosting/NativeAudioSink.cs`** — `OnTxActiveChanged` now drains the RX ring on **both** edges instead of only the rising edge. The next pipeline tick's fresh RX audio lands in an empty ring and reaches the speaker within one playback period (~10 ms). The brief gap until that first fresh sample arrives is covered by the existing underrun→silence path — it is the **same** gap as the post-MOX RX resume itself, not an added dropout. macOS / Linux drift far less, so both clears stay effective no-ops there. The instant RX→TX behaviour from #454 is unchanged (rising edge still drains, as before). Updated the surrounding comments to reflect the two-edge rationale.
- **`tests/Zeus.Server.Tests/TxActiveChangedTests.cs`** — the falling-edge test now asserts the ring is **cleared** on TX-off (was: asserts it is preserved), matching the new behaviour and pinning it.

Minimal and focused: only the one-line drain condition + comments + the one test changed. No pipeline refactor, no default an operator feels, no change to the RX→TX path.

## Test plan (Windows desktop bench — needs operator confirm)

1. Build/run the desktop app on Windows, connect to the radio, let RX audio run a few minutes (so any clock drift has time to build a ring backlog).
2. **Key up (MOX on):** RX audio should cut to silence **instantly** (unchanged from #454 — confirm no regression).
3. **Un-key (MOX off):** RX audio should resume **fast** (well under a second), not after a ~1–2 sec lag.
4. Repeat with **TUNE** instead of MOX — same expectation on both edges.
5. Listen for **dropouts/clicks/underrun** on the RX resume — there should be none beyond the normal brief post-MOX gap.
6. Do a longer session (10+ min) and several key cycles — the resume should stay fast and not get worse over time (the drift backlog is what made it grow before).

Build: `dotnet build Zeus.slnx` → 0 warnings, 0 errors. Tests: `dotnet test Zeus.slnx` → all projects pass (`TxActiveChangedTests` 4/4 green).

## ⚠️ RED-LIGHT note

This touches the **realtime audio hot path** (`NativeAudioSink` RX ring on the miniaudio/WASAPI side). The reasoning above is sound and the change is minimal, but it was developed on macOS — **I cannot bench-test Windows audio timing.** Please get the operator's on-Windows bench confirm (instant key-up, fast un-key, no dropouts on both MOX and TUN) **before promoting this to develop.**

Refs #468.
