### PR TITLE
feat(cw): Zero Beat — snap VFO to strongest CW carrier (#300)

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -396,6 +396,12 @@ public sealed record Nr2CoreConfigSetRequest(
 // the discrete factor on the wire.
 public sealed record ZoomSetRequest(int Level);
 
+/// <summary>Body for POST /api/rx/zero-beat. <paramref name="RxId"/> is
+/// optional and defaults to 0 (RX1); kept on the wire from day 1 to leave
+/// room for multi-RX without breaking the contract. See
+/// docs/designs/cw-zero-beat.md §Future for the migration plan.</summary>
+public sealed record ZeroBeatRequest(byte? RxId = 0);
+
 public sealed record AutoAttSetRequest(bool Enabled);
 
 public sealed record AutoAgcSetRequest(bool Enabled);

--- a/Zeus.Dsp/IDspEngine.cs
+++ b/Zeus.Dsp/IDspEngine.cs
@@ -86,6 +86,17 @@ public interface IDspEngine : IDisposable
 
     bool TryGetDisplayPixels(int channelId, DisplayPixout which, Span<float> dbOut);
 
+    /// <summary>Pull the next raw FFT magnitudes frame from the WDSP analyzer
+    /// for the given channel. Blocks for up to ~33 ms waiting for the next
+    /// FFT tick at the analyzer's fixed 30 Hz cadence; returns <c>false</c>
+    /// on timeout or when the engine has no FFT (synthetic).
+    /// <para><paramref name="outMagnitudesDb"/> length must be at least
+    /// <c>16384</c> (the WDSP analyzer FFT size). On success the buffer is
+    /// filled with dB magnitudes in FFT-shifted order: index 0 is the most
+    /// negative frequency, index 8192 is DC, index 16383 is the most
+    /// positive frequency.</para></summary>
+    bool TrySnapRawSpectrum(int channelId, Span<double> outMagnitudesDb);
+
     /// <summary>TX panadapter / waterfall pixels in dBm, sourced from a
     /// dedicated WDSP analyzer fed with the post-CFIR TX IQ. Returns false
     /// when TXA is not open or no fresh FFT is ready. The TX analyzer is

--- a/Zeus.Dsp/SyntheticDspEngine.cs
+++ b/Zeus.Dsp/SyntheticDspEngine.cs
@@ -211,6 +211,9 @@ public sealed class SyntheticDspEngine : IDspEngine
     public int ReadTxMonitorAudio(Span<float> output) => 0;
     public bool IsTxMonitorOn => false;
 
+    // Synthetic has no FFT spectrum snap capability.
+    public bool TrySnapRawSpectrum(int channelId, Span<double> outMagnitudesDb) => false;
+
     // Synthetic has no TX analyzer; the TX panadapter stays on the RX trace.
     // Returning false tells DspPipelineService.Tick to leave the display alone
     // while MOX is on, matching the existing "no new data" semantics.

--- a/Zeus.Dsp/Wdsp/NativeMethods.cs
+++ b/Zeus.Dsp/Wdsp/NativeMethods.cs
@@ -262,6 +262,20 @@ internal static partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial void GetPixels(int disp, int pixout, ref float pix, out int flag);
 
+    // SnapSpectrumTimeout — pulls a raw complex FFT snapshot (Re/Im interleaved
+    // doubles) from the analyzer identified by (disp, ss, LO). Blocks up to
+    // timeoutMs milliseconds for a fresh frame. flag is set to 1 on success,
+    // 0 on timeout. analyzer.c:1633.
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SnapSpectrumTimeout(
+        int disp,
+        int ss,
+        int LO,
+        ref double snap_buff,
+        uint timeoutMs,
+        ref int flag);
+
     [LibraryImport(LibraryName)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial void fexchange0(

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -43,6 +43,7 @@
 // License for details.
 
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -209,6 +210,14 @@ public sealed class WdspDspEngine : IDspEngine
     // a coherent set rather than a half-updated tuple.
     private RxStageMeters _latestRxStageMeters = RxStageMeters.Silent;
     private readonly object _rxMeterPublishLock = new();
+
+    // Pre-allocated 2 × AnalyzerFftSize doubles for SnapSpectrumTimeout output
+    // (Re/Im interleaved). Reused across Zero Beat invocations to avoid hot-
+    // path allocation. AnalyzerFftSize is 16384 → 32768 doubles ≈ 256 KB.
+    private readonly double[] _snapBuf = new double[AnalyzerFftSize * 2];
+    // Serialises concurrent Zero Beat calls and ensures _snapBuf is never
+    // passed to two concurrent SnapSpectrumTimeout invocations.
+    private readonly object _snapLock = new();
 
     // TX panadapter analyzer. Separate WDSP `disp` slot from RXA's, fed with
     // the post-CFIR IQ from ProcessTxBlock so the operator can see the on-air
@@ -1003,6 +1012,42 @@ public sealed class WdspDspEngine : IDspEngine
         {
             NativeMethods.GetPixels(channelId, (int)which, ref MemoryMarshal.GetReference(dbOut), out int flag);
             return flag == 1;
+        }
+    }
+
+    public bool TrySnapRawSpectrum(int channelId, Span<double> outMagnitudesDb)
+    {
+        if (_disposed != 0) return false;
+        if (outMagnitudesDb.Length < AnalyzerFftSize) return false;
+
+        // Multi-RX is not in scope yet (see docs/designs/cw-zero-beat.md
+        // §Future). When it lands, channelId will need to map to disp/channel.
+        Debug.Assert(channelId == 0, "TrySnapRawSpectrum is single-RX only for now");
+
+        lock (_snapLock)
+        {
+            int flag = 0;
+            try
+            {
+                NativeMethods.SnapSpectrumTimeout(
+                    disp: 0, ss: 0, LO: 0,
+                    snap_buff: ref _snapBuf[0],
+                    timeoutMs: 100,
+                    flag: ref flag);
+            }
+            catch (EntryPointNotFoundException)
+            {
+                return false;  // older libwdsp without the export
+            }
+            if (flag == 0) return false;
+
+            for (int i = 0; i < AnalyzerFftSize; i++)
+            {
+                double re = _snapBuf[i * 2];
+                double im = _snapBuf[i * 2 + 1];
+                outMagnitudesDb[i] = 10.0 * Math.Log10(re * re + im * im + 1e-60);
+            }
+            return true;
         }
     }
 

--- a/Zeus.Dsp/ZeroBeatAlgorithm.cs
+++ b/Zeus.Dsp/ZeroBeatAlgorithm.cs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is an independent reimplementation in .NET — not a fork. Its
+// Protocol-1 / Protocol-2 framing, WDSP integration, meter pipelines, and
+// TX behaviour were informed by studying the Thetis project
+// (https://github.com/ramdor/Thetis), the authoritative reference
+// implementation in the OpenHPSDR ecosystem. Zeus gratefully acknowledges
+// the Thetis contributors whose work made this possible:
+//
+//   Richard Samphire (MW0LGE), Warren Pratt (NR0V),
+//   Laurence Barker (G8NJJ),   Rick Koch (N1GP),
+//   Bryan Rambo (W4WMT),       Chris Codella (W2PA),
+//   Doug Wigley (W5WC),        FlexRadio Systems,
+//   Richard Allen (W5SD),      Joe Torrey (WD5Y),
+//   Andrew Mansfield (M0YGG),  Reid Campbell (MI0BOT),
+//   Sigi Jetzlsperger (DH1KLM).
+//
+// Thetis itself continues the GPL-governed lineage of FlexRadio PowerSDR
+// and the OpenHPSDR (TAPR/OpenHPSDR) ecosystem; that lineage is preserved
+// here. See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
+// WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
+// (NR0V), distributed under GPL v2 or later.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+namespace Zeus.Dsp;
+
+/// <summary>Pure static math for the Zero Beat feature (issue #300).
+/// No WDSP, no I/O, no allocations on the hot path beyond what the caller provides.
+/// All sizes are in FFT bins; the caller does Hz↔bin conversion.</summary>
+public static class ZeroBeatAlgorithm
+{
+    // Indistinguishable from floating-point noise at dB scale (max |denom|
+    // for a strongly peaked dB triplet is ~40; 1e-12 leaves 11+ orders of
+    // headroom). Below this, treat the triplet as flat and skip interpolation.
+    private const double ParabolicDenomEpsilon = 1e-12;
+
+    /// <summary>Linear scan over <paramref name="bins"/> in the inclusive
+    /// range <c>[lowBin, highBin]</c>, returns the bin with the maximum value
+    /// and its value. Caller must ensure <c>0 ≤ lowBin ≤ highBin &lt; bins.Length</c>.</summary>
+    public static (int bin, double db) FindPeakInPassband(
+        ReadOnlySpan<double> bins, int lowBin, int highBin)
+    {
+        int peakIdx = lowBin;
+        double peakDb = bins[lowBin];
+        for (int i = lowBin + 1; i <= highBin; i++)
+        {
+            if (bins[i] > peakDb) { peakDb = bins[i]; peakIdx = i; }
+        }
+        return (peakIdx, peakDb);
+    }
+
+    /// <summary>Sub-bin offset of the true peak between bins
+    /// <c>peak-1, peak, peak+1</c>, derived by fitting a parabola through the
+    /// three dB magnitudes. Returns a value in <c>[-0.5, +0.5]</c>; positive
+    /// means the true peak is between the center bin and the right neighbour.
+    /// Caller adds this offset to the integer peak-bin index for sub-bin
+    /// frequency resolution.</summary>
+    public static double ParabolicInterpolate(double yLeft, double yPeak, double yRight)
+    {
+        double denom = yLeft - 2.0 * yPeak + yRight;
+        if (Math.Abs(denom) < ParabolicDenomEpsilon) return 0.0;            // flat triplet → no info
+        double offset = 0.5 * (yLeft - yRight) / denom;
+        return Math.Clamp(offset, -0.5, 0.5);
+    }
+
+    /// <summary>Median dB value across the passband bins <c>[lowBin, highBin]</c>.
+    /// Used as the noise-floor baseline for the SNR gate. Allocates a temporary
+    /// copy of the passband; the caller is responsible for keeping passbands
+    /// narrow enough (max a few thousand bins) that this stays cheap.</summary>
+    public static double MedianDb(ReadOnlySpan<double> bins, int lowBin, int highBin)
+    {
+        int n = highBin - lowBin + 1;
+        var buf = new double[n];
+        for (int i = 0; i < n; i++) buf[i] = bins[lowBin + i];
+        Array.Sort(buf);
+        return buf[(n - 1) / 2];   // lower-middle for even counts
+    }
+}

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -70,6 +70,10 @@ public sealed class RadioService : IDisposable
     // Empty when nothing is connected — PersistPsState skips HW Peak persistence
     // in that case (no board → no slot to write).
     private string _currentPsBoardKey = string.Empty;
+    // Zero Beat engine provider (issue #300). Null until DspPipelineService
+    // registers its CurrentEngine delegate (wired in ZeusEndpoints / ZeusHost).
+    // Tests inject a fake engine directly via the internal constructor overload.
+    private readonly Func<IDspEngine?>? _engineProvider;
     // Debounced state flush. Set to true in every Mutate(); a 1 Hz timer
     // calls FlushState() which writes to LiteDB and clears the flag.
     // Avoids hammering LiteDB during rapid VFO scroll or filter drags.
@@ -179,7 +183,7 @@ public sealed class RadioService : IDisposable
     // to its internal test-tone generator (dev / tests without a hub).
     private readonly Zeus.Protocol1.ITxIqSource? _txIqSource;
 
-    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, FilterPresetStore? filterPresetStore = null, Zeus.Protocol1.ITxIqSource? txIqSource = null, PreferredRadioStore? preferredRadioStore = null, PsSettingsStore? psStore = null, RadioStateStore? radioStateStore = null)
+    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, FilterPresetStore? filterPresetStore = null, Zeus.Protocol1.ITxIqSource? txIqSource = null, PreferredRadioStore? preferredRadioStore = null, PsSettingsStore? psStore = null, RadioStateStore? radioStateStore = null, Func<IDspEngine?>? engineProvider = null)
     {
         _loggerFactory = loggerFactory;
         _log = loggerFactory.CreateLogger<RadioService>();
@@ -189,6 +193,7 @@ public sealed class RadioService : IDisposable
         _psStore = psStore;
         _filterPresetStore = filterPresetStore;
         _radioStateStore = radioStateStore;
+        _engineProvider = engineProvider;
         _paStore.Changed += RecomputePaAndPush;
         if (_preferredRadioStore is not null)
             _preferredRadioStore.Changed += RecomputePaAndPush;
@@ -692,6 +697,152 @@ public sealed class RadioService : IDisposable
         if (targetLo == currentLo) return false;
         SetRadioLo(targetLo);
         return true;
+    }
+
+    // Zero Beat constants (issue #300). Baked-in; see docs/designs/cw-zero-beat.md
+    // §"Why baked-in 500 ms / 1.5 s / 6 dB" for why these are not user-tunable.
+    private const int ZeroBeatPhase1Frames = 30;       // ~1000 ms at 30 Hz
+    private const double ZeroBeatSnrThresholdDb = 6.0; // peak − median floor
+    private const int ZeroBeatFftSize = 16384;         // matches WdspDspEngine.AnalyzerFftSize
+    private const int ZeroBeatDcBin = ZeroBeatFftSize / 2;
+
+    /// <summary>One-shot Zero Beat (issue #300). Snaps the VFO of the given RX
+    /// onto the strongest CW carrier in the current filter passband, via raw
+    /// FFT peak-hold + parabolic interpolation. Two-phase: coarse tune after
+    /// ~500 ms, fine refinement after ~1.5 s more. Silent no-op if the SNR
+    /// gate trips (peak − median noise floor &lt; 6 dB). Mode-gated to CWL/CWU.</summary>
+    /// <param name="rxId">Receiver identifier. 0 = RX1 (only supported value
+    /// until multi-RX lands). See design doc §Future.</param>
+    /// <returns>Updated StateDto on success (or no-op completion); null when
+    /// mode is not CW or when the SNR gate aborts with no VFO movement.</returns>
+    public StateDto? ZeroBeat(byte rxId = 0)
+    {
+        var engine = _engineProvider?.Invoke();
+        if (engine is null)
+        {
+            _log.LogInformation("zero-beat.exit reason=engine-null");
+            return null;
+        }
+
+        var snap = Snapshot();
+        if (snap.Mode != RxMode.CWL && snap.Mode != RxMode.CWU)
+        {
+            _log.LogInformation("zero-beat.exit reason=mode-not-cw mode={Mode}", snap.Mode);
+            return null;
+        }
+
+        _log.LogInformation(
+            "zero-beat.start mode={Mode} vfoHz={VfoHz} sampleRate={SampleRate} filter=[{FLo},{FHi}]",
+            snap.Mode, snap.VfoHz, snap.SampleRate, snap.FilterLowHz, snap.FilterHighHz);
+
+        // Phase 1: collect 15 frames at 30 Hz (≈500 ms), max-hold per bin.
+        var held = new double[ZeroBeatFftSize];
+        for (int i = 0; i < held.Length; i++) held[i] = double.NegativeInfinity;
+        var frame = new double[ZeroBeatFftSize];
+
+        for (int i = 0; i < ZeroBeatPhase1Frames; i++)
+        {
+            if (!engine.TrySnapRawSpectrum(channelId: 0, frame))
+            {
+                _log.LogWarning("zero-beat.exit reason=raw-fft-fail phase=1 frame={Frame}", i);
+                return null;
+            }
+            for (int b = 0; b < held.Length; b++)
+                if (frame[b] > held[b]) held[b] = frame[b];
+        }
+
+        // Compute the passband bin range from the current state.
+        // WDSP SnapSpectrumTimeout FFT layout: DC at bin 8192, POSITIVE
+        // frequencies (USB/CWU) grow DOWNWARD (bin 8191, 8190, ...),
+        // negative frequencies grow UPWARD (bin 8193, 8194, ...).
+        // This is the opposite of textbook FFT-shift convention.
+        static (int lo, int hi) PassbandBins(StateDto s)
+        {
+            double hzPerBin = (double)s.SampleRate / ZeroBeatFftSize;
+            int lo = ZeroBeatDcBin - (int)(s.FilterHighHz / hzPerBin);
+            int hi = ZeroBeatDcBin - (int)(s.FilterLowHz  / hzPerBin);
+            if (lo < 1) lo = 1;
+            if (hi > ZeroBeatFftSize - 2) hi = ZeroBeatFftSize - 2;
+            return (lo, hi);
+        }
+
+        var (lowBin, highBin) = PassbandBins(snap);
+        double hzPerBinSnap = (double)snap.SampleRate / ZeroBeatFftSize;
+        if (lowBin >= highBin)
+        {
+            _log.LogWarning("zero-beat.exit reason=degenerate-passband-bins lowBin={Lo} highBin={Hi} hzPerBin={HzPerBin:F2}",
+                lowBin, highBin, hzPerBinSnap);
+            return null;
+        }
+
+        // DEBUG: find the top 5 bins across the FULL FFT to verify bin layout
+        var top5 = new (int bin, double db)[5];
+        for (int t = 0; t < 5; t++) top5[t] = (0, double.NegativeInfinity);
+        for (int i = 1; i < ZeroBeatFftSize - 1; i++)
+        {
+            if (held[i] > top5[4].db)
+            {
+                top5[4] = (i, held[i]);
+                Array.Sort(top5, (a, b) => b.db.CompareTo(a.db));
+            }
+        }
+        _log.LogInformation(
+            "zero-beat.fft-top5 bin0={B0}@{D0:F1} bin1={B1}@{D1:F1} bin2={B2}@{D2:F1} bin3={B3}@{D3:F1} bin4={B4}@{D4:F1} dcBin={Dc} hzPerBin={Hz:F2}",
+            top5[0].bin, top5[0].db, top5[1].bin, top5[1].db, top5[2].bin, top5[2].db,
+            top5[3].bin, top5[3].db, top5[4].bin, top5[4].db, ZeroBeatDcBin, hzPerBinSnap);
+
+        var (peakBin, peakDb) = ZeroBeatAlgorithm.FindPeakInPassband(held, lowBin, highBin);
+        double floorDb = ZeroBeatAlgorithm.MedianDb(held, lowBin, highBin);
+        double snrDb = peakDb - floorDb;
+
+        _log.LogInformation(
+            "zero-beat.phase1 lowBin={Lo} highBin={Hi} widthBins={W} hzPerBin={HzPerBin:F2} peakBin={PB} peakDb={Peak:F1} floorDb={Floor:F1} snrDb={Snr:F1}",
+            lowBin, highBin, highBin - lowBin + 1, hzPerBinSnap, peakBin, peakDb, floorDb, snrDb);
+
+        // SNR threshold adjustment for sample rate. The 6 dB constant was
+        // calibrated at 48 kHz (2.93 Hz/bin). At higher rates the bin width
+        // grows and each bin captures more noise power while the CW carrier
+        // (narrower than any bin) stays the same → per-bin SNR drops by
+        // 10·log10(rate/48000). We compensate with a floor of 2 dB.
+        double snrAdjustDb = 10.0 * Math.Log10((double)snap.SampleRate / 48000.0);
+        double effectiveSnrThreshold = Math.Max(2.0, ZeroBeatSnrThresholdDb - snrAdjustDb);
+        _log.LogInformation("zero-beat.snr-adjust rate={Rate} hzPerBin={HzPerBin:F2} adjustDb={Adj:F1} effectiveThreshold={Thr:F1}",
+            snap.SampleRate, hzPerBinSnap, snrAdjustDb, effectiveSnrThreshold);
+
+        // The zero-beat target in the FFT is NOT at DC (bin 8192). In CW modes
+        // the radio LO is offset by ±cw_pitch from the dial, so a carrier that's
+        // exactly zero-beat sits at +cw_pitch (CWU) or -cw_pitch (CWL) in the
+        // baseband FFT. The delta must be measured from THAT position, not from DC.
+        double cwPitchInBaseband = snap.Mode switch
+        {
+            RxMode.CWU =>  CwOffset.CwPitchHz,
+            RxMode.CWL => -CwOffset.CwPitchHz,
+            _ => 0.0,
+        };
+
+        bool gatePassed = snrDb >= effectiveSnrThreshold;
+        if (!gatePassed)
+        {
+            _log.LogInformation("zero-beat.exit reason=snr-gate-failed");
+            return null;
+        }
+
+        double subBin = ZeroBeatAlgorithm.ParabolicInterpolate(
+            held[peakBin - 1], held[peakBin], held[peakBin + 1]);
+        // Inverted axis: lower bin = higher positive frequency
+        double rawOffsetHz = (ZeroBeatDcBin - (peakBin + subBin)) * hzPerBinSnap;
+        double deltaHz = rawOffsetHz - cwPitchInBaseband;
+        long delta = (long)Math.Round(deltaHz);
+        _log.LogInformation("zero-beat.applied subBin={Sub:F3} rawOffsetHz={Raw:F1} cwPitch={Pitch} deltaHz={Delta} newVfoHz={New}",
+            subBin, rawOffsetHz, cwPitchInBaseband, delta, snap.VfoHz + delta);
+        if (delta != 0)
+        {
+            SetVfo(snap.VfoHz + delta);
+        }
+
+        _log.LogInformation("zero-beat.done totalDeltaHz={Total} finalVfoHz={Final}",
+            (Snapshot().VfoHz - snap.VfoHz), Snapshot().VfoHz);
+        return Snapshot();
     }
 
     // Per-mode-family remembered filter magnitudes. Mode switching snapshots

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -727,6 +727,20 @@ public static class ZeusEndpoints
             return Results.Ok(r.SetZoom(req.Level));
         });
 
+        // CW Zero Beat (issue #300). Acquires ~1 s of spectrum, finds the
+        // loudest carrier in the passband, and retunes the VFO so it lands
+        // at the CW pitch. Returns the updated StateDto (200 OK) or 422
+        // Unprocessable Entity when no signal clears the SNR gate.
+        app.MapPost("/api/rx/zero-beat", (ZeroBeatRequest? req, RadioService r) =>
+        {
+            var rxId = req?.RxId ?? 0;
+            log.LogInformation("api.rx.zero-beat rxId={RxId}", rxId);
+            var state = r.ZeroBeat(rxId);
+            return state is null
+                ? Results.UnprocessableEntity(new { error = "no-signal" })
+                : Results.Ok(state);
+        });
+
         // Band memory: last-used (hz, mode) per HF band. GET returns the full map so
         // the BandButtons UI can restore on load with one round-trip. PUT upserts one
         // entry — the web debounces writes so tuning doesn't hammer LiteDB.

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -159,7 +159,34 @@ public static class ZeusHost
         builder.Services.AddSingleton<Zeus.Protocol1.TxIqRing>();
         builder.Services.AddSingleton<Zeus.Protocol1.ITxIqSource>(sp =>
             sp.GetRequiredService<Zeus.Protocol1.TxIqRing>());
-        builder.Services.AddSingleton<RadioService>();
+        // Wire engineProvider lazily so RadioService.ZeroBeat can read the
+        // currently-active DSP engine. The lambda defers resolution of
+        // DspPipelineService until the first ZeroBeat call (not at
+        // construction), which avoids the circular-dependency that would arise
+        // if we tried to GetRequiredService<DspPipelineService>() eagerly inside
+        // the RadioService factory (DspPipelineService's constructor takes
+        // RadioService, so eager resolution would deadlock the container).
+        builder.Services.AddSingleton<RadioService>(sp =>
+        {
+            var lf   = sp.GetRequiredService<ILoggerFactory>();
+            var dsp  = sp.GetRequiredService<DspSettingsStore>();
+            var pa   = sp.GetRequiredService<PaSettingsStore>();
+            var fp   = sp.GetRequiredService<FilterPresetStore>();
+            var tx   = sp.GetRequiredService<Zeus.Protocol1.ITxIqSource>();
+            var pref = sp.GetRequiredService<PreferredRadioStore>();
+            var ps   = sp.GetRequiredService<PsSettingsStore>();
+            var rs   = sp.GetRequiredService<RadioStateStore>();
+            return new RadioService(
+                loggerFactory: lf,
+                dspSettingsStore: dsp,
+                paStore: pa,
+                filterPresetStore: fp,
+                txIqSource: tx,
+                preferredRadioStore: pref,
+                psStore: ps,
+                radioStateStore: rs,
+                engineProvider: () => sp.GetRequiredService<DspPipelineService>().CurrentEngine);
+        });
         builder.Services.AddSingleton<StreamingHub>();
         // RX audio publish seam (Phase 1). DspPipelineService.PublishAudio
         // fans each AudioFrame across every registered IRxAudioSink.

--- a/docs/designs/cw-zero-beat.md
+++ b/docs/designs/cw-zero-beat.md
@@ -1,0 +1,385 @@
+# Design: CW Zero Beat (issue #300, PR 1 of 2)
+
+> **Status: ACCEPTED — cleared to implement.**
+> Maintainer (Doug, KB2UKA) reviewed and greenlit on 2026-05-15:
+> backend approach approved in full, all four UX questions answered
+> (Brian's UI bypassed-with-defaults — he can iterate post-merge).
+> Task 1 (panadapter FFT flow investigation) completed and folded
+> below. Implementation continues on the `iu3qez/cw-zero-beat`
+> branch; on-air validation remains a hard merge gate.
+
+Pairs with issue [#300](https://github.com/Kb2uka/openhpsdr-zeus/issues/300).
+APF is the sibling feature in a separate PR; this doc covers **Zero Beat only**.
+
+**Goal:** add a one-shot Zero Beat action to Zeus that snaps the VFO onto
+the strongest CW carrier in the current passband, with sub-Hz resolution
+and graceful fallback when no carrier is present.
+
+## Status legend (per `CLAUDE.md`)
+
+- 🟢 **green** — backend / engine plumbing; agent-autonomous.
+- 🟡 **yellow** — operator-felt default or new control surface; maintainer review before merge.
+- 🔴 **red** — architecture or visual design; maintainer alignment *before* code lands.
+
+## Background
+
+Issue #300 lists two CW-only features (Zero Beat, APF) and suggests both
+go through WDSP entry points (`SetRXAAMSQRun`, `SetRXAAPFRun`). After
+reading Thetis source and the WDSP Guide rev 1.23 (NR0V) the picture is
+different in a load-bearing way:
+
+### Zero Beat is not a WDSP feature in Thetis
+
+This is common for Thetis given its long history tracing back to
+PowerSDR: many features live frontend-side rather than inside WDSP,
+and Zero Beat is one of them. The actual Thetis path is purely
+display-side FFT peak detection. From
+`Project Files/Source/Console/console.cs`:
+
+```csharp
+// console.cs:36185-36258 — FindPeakFreqInPassband()
+double hz_per_bucket = sample_rate_rx1 / (double)specRX.GetSpecRX(0).FFTSize;
+// ... walk bins between filter low/high cuts, track max(I²+Q²) ...
+int peak_hz = (int)((max_bucket - zero_hz_bucket) * hz_per_bucket);
+return peak_hz;
+
+// console.cs btnZeroBeat_Click — applies the offset:
+VFOAFreq += peak_hz * 0.0000010;   // Hz → MHz
+```
+Keeping Zero Beat outside WDSP is fine for Zeus too. Implications:
+1. **No new WDSP P/Invoke is needed** for Zero Beat.
+2. The work lives in `Zeus.Server` (read panadapter FFT, find peak,
+   retune VFO) and `zeus-web` (trigger + visual feedback).
+
+## Proposed design
+
+### Server-side action
+
+Single new method `RadioService.ZeroBeat(byte rxId = 0)` (see Task 1
+findings below — the work fits naturally in `RadioService`, no new
+service class needed). It reads the **raw 16384-bin FFT** directly
+from the WDSP analyzer via a new `SnapSpectrumTimeout` P/Invoke, NOT
+the 2048-pixel pre-zoomed `PanDb` exposed to the frontend. Raw FFT
+gives ~2.93 Hz/bin at 48 kHz sample rate (vs ~23 Hz/pixel for the
+pixel path with no zoom), and is independent of the operator's
+current panadapter zoom level. See the rationale in §"Task 1
+findings" below.
+
+1. Check mode is CWL or CWU; else return state unchanged.
+2. Begin peak-hold accumulation by repeatedly calling
+   `engine.TrySnapRawSpectrum(channelId, magnitudesDb)`. Each call
+   blocks for ~33 ms (the next FFT frame at 30 Hz fixed cadence) and
+   returns 16384 dB magnitudes. Track `max[i]` per bin across frames.
+3. **Phase 1 — coarse tune at 500 ms.** After ~500 ms of peak-hold,
+   inside the bins corresponding to the current filter passband, find
+   the max bin and:
+   - **SNR gate**: if `peak_dBm − median_dBm < 6 dB`, do NOT yet
+     abort — fall through to phase 2 and let more signal accumulate.
+   - Otherwise: parabolic 3-point interpolation → Δ₁ = `peak_hz −
+     target_pitch_hz` (target = `CwOffset.CwPitchHz`, negated for CWL).
+     **Retune the VFO by Δ₁ immediately** through the existing tuning
+     path.
+4. **Phase 2 — fine refinement (up to ~1.5 s more).** Continue
+   peak-hold for an additional window of up to ~1.5 s, then recompute
+   the peak and parabolic interpolation against the *new* (already
+   shifted) passband.
+   - If a coarse Δ₁ was applied: compute Δ₂ as the residual and apply
+     it. Most cases Δ₂ ≈ 0 ±1 Hz.
+   - If phase 1's SNR gate had failed: do the SNR check now. If it
+     still fails, abort with "no signal" (no VFO movement, since
+     phase 1 didn't move it either).
+5. **Parabolic 3-point interpolation** (used in both phases): vertex
+   formula on the three dB magnitudes around the peak bin gives ~10×
+   sub-bin frequency resolution. Three lines of math, costs nothing.
+
+**Why two-phase instead of one long wait:** a single 2 s window means
+the operator presses the button and sees nothing happen for two
+seconds — it feels broken, and people will press again. Splitting at
+500 ms means the VFO snaps to the right ballpark immediately
+(perceived latency ≈ display frame rate, not "two whole seconds"),
+and the fine pass that follows is invisible to the operator unless
+they happen to be watching the dial — by which point it's already
+settled. This is consistent with how other rigs handle the same
+problem.
+
+**Why peak-hold at all:** Thetis takes one frame and tells operators
+"set display to AVG mode" via tooltip. That fails if the snapshot
+lands during an inter-element gap, an operator pause, a QSB null, or
+simply when the remote operator's hand is off the key — the "peak"
+then is just the loudest noise bin and
+the VFO jumps to garbage. Max-holding across multiple frames catches
+at least one dit at any sane CW speed (50 ms dit at 25 WPM, 100 ms
+at 12 WPM) while noise stays roughly stationary, so signal pulses
+clearly clear the noise floor in the held buffer.
+
+**Why baked-in 500 ms / 1.5 s / 6 dB:** these are best-effort tuning
+constants, not operator-facing knobs. Exposing sliders would clutter
+the CW UI with parameters most operators will never touch.
+
+The numbers themselves are **initial estimates that need on-air
+validation before the PR merges.** Unit tests with synthetic FFT
+magnitudes can prove the algorithm is correct, but they cannot tell us
+whether 500 ms is enough to land within ±10 Hz on a real weak signal
+at 25 WPM, whether 6 dB above the median is the right SNR gate for the
+panadapter Zeus actually serves, or whether 1.5 s of phase 2 is enough
+to settle the residual. Plan: bench-test on real CW traffic (a mix of
+slow / fast / weak / strong / fading), tune the constants once based
+on what we observe, and only then merge. If a constant needs to change
+post-merge we change it in code with a small follow-up PR — still no
+slider.
+
+**Why not "correlate the window with the configured CW WPM":**
+considered and rejected. The relevant speed is the speed of the
+*received* station, not our local keyer setting; correlating to the
+local WPM would be wrong as often as right, and there is no clean way
+to detect the remote's speed before doing exactly the work this
+feature is for. Fixed 500 ms + 1.5 s wins on simplicity and on being
+right at any incoming speed.
+
+### Wire surface
+
+```
+POST /api/rx/zero-beat
+  body: { "rxId": 0 }   // optional; missing body defaults to RX1
+  response: 200 → updated StateDto (new VFOA), or
+            422 → { error: "no-signal" } with state unchanged
+```
+
+The `rxId` field is in place from day 1 to keep the contract
+forward-compatible with multi-RX hardware (see §Future). No new DTO
+fields on `StateDto`. No `ZeroBeatConfig` record. No new persisted
+setting in `DspSettingsStore`. The action is fire-and-forget; its
+only durable effect is the VFO move, which already round-trips
+through the existing state mechanism.
+
+### Frontend
+
+Button in `zeus-web/src/layout/panels/CwPanel.tsx` invoking the endpoint,
+plus `Z` keybind via `use-keyboard-shortcuts.ts`. Mode-gated render to
+CWL/CWU. Visual feedback during the action: accent border on the
+button. Full details in §Decisions below.
+
+### What is explicitly out of scope for PR1
+
+- **RIT-mode Zero Beat** — Thetis offers it as an alternative target
+  (tune RIT by Δ instead of the main VFO). Genuinely useful and
+  standard on most modern transceivers, but **Zeus has no RIT/XIT
+  plumbing yet** — the only references in-tree are a placeholder
+  button in `zeus-web/src/App.tsx:743` and TCI protocol stubs at
+  `Zeus.Server.Hosting/Tci/TciSession.cs:1095-1134` that explicitly
+  ignore RIT/XIT set commands. There is no `Rit*` field in
+  `Zeus.Contracts`, no `RadioService.SetRit(...)`, no persisted
+  setting. So RIT-mode Zero Beat is deferred *because the substrate
+  doesn't exist*, not because we don't want it. When Zeus grows
+  RIT/XIT (separate effort outside #300), Zero Beat should gain a
+  RIT-target toggle as a follow-up PR.
+- **CAT command** — Thetis exposes `ZZZB`; not in scope.
+- **AM / FM / SAM / digital modes** — out of scope; Zero Beat is
+  treated as a CW-only feature in this PR.
+- **The APF feature** — separate PR, separate design doc.
+- **Auto VFO step → 1 Hz when APF is enabled** — this is part of the
+  APF feature's UX bridge for the Matched filter (which needs sub-Hz
+  alignment). It belongs in the APF PR, not here.
+
+## Task 1 findings — panadapter FFT flow
+
+Where panadapter FFT magnitudes live, who produces them, and what hook
+Zero Beat uses.
+
+**Producer:** `Zeus.Server.Hosting.DspPipelineService.Tick()`
+(`DspPipelineService.cs:1249`) drives a 30 Hz fixed loop
+(`TickPeriod = TimeSpan.FromMilliseconds(1000.0 / 30.0)`, line 65).
+On each tick it calls `engine.TryGetDisplayPixels(...)` (line 1342)
+which wraps WDSP's `GetPixels` export. Output is a `float[2048]` of
+dB magnitudes, **already pixel-resampled and zoom-clipped** by WDSP,
+packed into a `DisplayFrame` record (Width=2048, CenterHz, HzPerPixel,
+PanDb, WfDb) and broadcast via SignalR.
+
+**Two access paths considered:**
+
+| Path | Resolution @ 48k | Resolution @ 192k | Zoom-dependent | Code to add |
+|---|---|---|---|---|
+| Pixel `PanDb` (already exposed) | 23 Hz/px no-zoom, ~5.9 @ 4× | 94 Hz/px, ~11.7 @ 8× | yes | ~5 lines (event hook in DspPipelineService) |
+| **Raw FFT via `SnapSpectrumTimeout`** | **2.93 Hz/bin always** | **11.7 Hz/bin always** | **no** | ~30 lines (new P/Invoke + engine method) |
+
+**Decision: raw FFT.** The pixel path's resolution depends on whatever
+zoom the operator currently has on the panadapter; with a wide-zoom
+display Zero Beat lands tens of Hz off. Raw FFT keeps a fixed
+2.93 Hz/bin grid at 48 kHz regardless of UI state, which is
+exactly what the Matched APF companion (BW 10–30 Hz) needs.
+
+Parabolic 3-point interpolation on top still applies and yields
+sub-Hz accuracy in practice.
+
+**WDSP entry point:** `SnapSpectrumTimeout(int disp, int ss, int LO,
+double* snap_buff, DWORD timeout, int* flag)` in
+`native/wdsp/analyzer.c:1633`. The function blocks until the next FFT
+frame is ready (or `timeout` expires), then copies the FFT output into
+the caller's buffer as `2 × AnalyzerFftSize` doubles (Re/Im interleaved,
+FFT-shifted so the negative-frequency half precedes the positive half).
+
+`AnalyzerFftSize = 16384` (`WdspDspEngine.cs:110`). Caller buffer size
+= 32768 doubles ≈ 256 KB, allocated once and reused.
+
+**Bin → Hz math:**
+- `hzPerBin = sampleRate / 16384`
+- After unpacking, the DC bin sits at index `8192` (centre of the
+  unpacked array).
+- `hzOffsetFromLO = (binIndex - 8192) * hzPerBin`
+- Add the `CwOffset.CwPitchHz` correction for CW pitch.
+
+**Filter passband bins:** `RadioService.Snapshot().FilterLowHz/HighHz`
+gives signed Hz around baseband; convert to bin indices around 8192
+and walk only those bins for the peak.
+
+**Implementation home:** `RadioService.ZeroBeat(byte rxId = 0)`.
+- Zero Beat is fundamentally a VFO-adjustment action; it belongs next
+  to `SetVfo` / `SetMode` / `SetFilter` in `RadioService`.
+- Injects `IDspEngine` (already available to `RadioService`).
+- The pull-on-demand model of `SnapSpectrumTimeout` (each call blocks
+  ~33 ms for the next FFT frame) means **no new event/subscription
+  surface is needed on `DspPipelineService`**. The two FFT consumers
+  (existing `GetPixels` for pan display, new `SnapSpectrumTimeout` for
+  Zero Beat) are independent drains and don't interfere.
+
+**No-go zones cleared:** the FFT path does not touch
+`audio-client.ts`, PureSignal methods in `WdspDspEngine.cs`, or
+`PsAutoAttenuateService.cs`.
+
+## Decisions (UX confirmed by maintainer 2026-05-15)
+
+Doug (KB2UKA) provided the UX answers directly to unblock implementation;
+Brian (EI6LF) keeps the right to iterate the UI post-merge. The defaults
+below are the implementation contract.
+
+### Visibility
+Hide Zero Beat (and APF) controls outside CWL/CWU. Mode-gated rendering
+in the React tree — not just disabled.
+
+### Trigger location
+Button in `zeus-web/src/layout/panels/CwPanel.tsx` **plus** `Z` keybind
+via `use-keyboard-shortcuts.ts`. Mode-gated to CWL/CWU on both surfaces.
+
+### Visual feedback during the action
+Button gets an accent border (`var(--accent)`) while running — from
+press until both phases complete. Result is then communicated by the
+VFO move (or its absence). No spinner, no overlay. Total runtime
+≤ ~2 s (500 ms phase 1 + 1.5 s phase 2).
+
+### No-signal path (SNR gate failure)
+Silent. The VFO simply does not move. No toast, no red flash, no log
+line surfaced to the operator. The button returns to its normal state
+at end-of-window, and the operator infers "nothing happened" from the
+fact that the dial didn't move. Matches Thetis and convention in most
+CW rigs.
+
+### Style constraints (from `CLAUDE.md` + Doug's reminder)
+- Tokens from `zeus-web/src/styles/tokens.css` only — never raw hex.
+- Reuse existing `.btn` / `.btn.sm` classes.
+- Match the wiring shape and sizing of a recent CW/filter button.
+- Archivo Narrow is global; no font overrides.
+
+### Thetis-divergent improvements (approved)
+
+Three places where this PR deviates from Thetis, all confirmed by the
+maintainer:
+
+1. **Two-phase peak-hold** (500 ms coarse + 1.5 s refinement) instead
+   of a single snapshot — addresses Thetis's "set display to AVG mode"
+   workaround for the operator-pause / inter-element-gap problem.
+2. **Parabolic interpolation** instead of bin-truncation — ~10× sub-bin
+   accuracy on top of the raw FFT's already-finer grid.
+3. **SNR gate** instead of "silently jump to noise" — refuses to move
+   the VFO when no carrier is present, matching the convention of
+   every modern CW rig.
+
+All three are pure backend, cost ~tens of lines each, and address real
+operator-visible weaknesses in Thetis. None changes any default that
+an existing Thetis operator would feel beyond "Zero Beat just works
+better".
+
+## Implementation tasks
+
+1. ✅ **Investigate** (done): panadapter FFT flow folded into the
+   "Task 1 findings" section above. Decision: raw FFT via
+   `SnapSpectrumTimeout`, served from `RadioService.ZeroBeat()`.
+2. 🟢 Add P/Invoke for `SnapSpectrumTimeout` in
+   `Zeus.Dsp/Wdsp/NativeMethods.cs` and a `TrySnapRawSpectrum(int
+   channelId, Span<double> outMagDb)` method on `IDspEngine` (with
+   no-op in `SyntheticDspEngine`). Allocate the 32k-double Re/Im
+   buffer once inside `WdspDspEngine`, reuse on each call.
+3. 🟢 Implement `RadioService.ZeroBeat(byte rxId = 0)`: two-phase
+   peak-hold (15 frames + 45 frames at 30 Hz fixed cadence), SNR
+   gate at peak − median ≥ 6 dB, parabolic 3-point interpolation,
+   VFO retune through existing tuning path. Constants are private
+   compile-time fields (no DTO, no persisted setting, no slider).
+4. 🟢 Endpoint `POST /api/rx/zero-beat` in `ZeusEndpoints.cs`,
+   accepting an optional `ZeroBeatRequest { byte? RxId = 0 }` body.
+   Returns 200 + updated `StateDto` on success, 422 with
+   `{ "error": "no-signal" }` on SNR gate failure.
+5. 🟢 Client binding `zeroBeat()` in `zeus-web/src/api/client.ts`.
+6. 🟡 Frontend: button in `CwPanel.tsx` with `var(--accent)` border
+   while running, plus `Z` keybind via `use-keyboard-shortcuts.ts`.
+   Mode-gated render to CWL/CWU.
+7. 🟢 Unit tests on the peak-hold + interpolation + SNR gate (synthetic
+   FFT magnitudes, deterministic). No on-air dependency. Prove the
+   algorithm; do NOT prove the constants.
+8. 🟡 **On-air validation before merge.** Bench-test on real CW
+   traffic across the operating envelope: slow (≤12 WPM) and fast
+   (~25–30 WPM); weak (near noise floor, SNR gate exercised) and
+   strong (S5+); steady and fading. Observe phase-1 landing accuracy,
+   phase-2 residual, and SNR-gate false-positive / false-negative
+   rate. Record findings in the PR description and adjust the three
+   constants if needed before requesting merge. This is the gate
+   that's load-bearing — unit tests alone are not enough.
+9. 🟢 Lesson: `docs/lessons/cw-zero-beat.md` summarizing the
+   Thetis-divergence rationale (peak-hold two-phase, parabolic, SNR)
+   *and* the on-air-validated values of the three constants, so it
+   survives the PR and future maintainers see *why*, not just *what*.
+
+## Future: multi-RX / multi-slice support
+
+Zero Beat is single-slice today (RX1 only). The shape is forward-
+compatible with multi-RX hardware (RX1 + RX2 on the same board) at
+near-zero cost.
+
+**Existing Zeus precedent.** The wire format already carries a
+`byte RxId` as the first body byte of both `DisplayFrame.cs:62` and
+`AudioFrame.cs:54`, currently hard-coded to `0` in
+`DspPipelineService.cs:1369, 1419, 1442`. `BoardCapabilities` records
+`HasSteppedAttenuationRx2` per board, and `docs/designs/radio-support-plan.md`
+already plans an RX2 attenuator UI. So `byte RxId` is the
+established disambiguator across the codebase.
+
+**Adopted in this design:**
+- Method signature is `RadioService.ZeroBeat(byte rxId = 0)`. Default
+  preserves current single-RX behaviour.
+- Endpoint accepts an optional body `{ "rxId": 0 }` (and a missing
+  body defaults to `0`). This is in-place from day 1 so the wire
+  contract does not need to break when RX2 lands.
+- Internally, `rxId` maps to WDSP `disp` (and the matching `channel`
+  for the RXA chain). A small resolver function centralises the
+  mapping rather than hard-coding `disp=0, ss=0, LO=0` at the call
+  site.
+
+**Multi-slice (WDSP sub-receivers via different `LO` on the same
+display) is explicitly NOT in scope.** No Zeus doc, capability, or DTO
+references sub-receivers today; introducing one for Zero Beat would
+be speculative. If Zeus ever adds sub-receivers, the same `byte RxId`
+slot can grow into a richer slice descriptor (or a sibling byte added
+to the wire) without touching the algorithmic core of this feature.
+
+## Notes / receipts
+
+- Thetis source consulted via shallow clone of `ramdor/Thetis` at
+  `/tmp/thetis-research`.
+- WDSP Guide rev 1.23 by Warren Pratt (NR0V) at
+  `Documentation/Radio/WDSP Guide, Rev 1.23.pdf` in the Thetis repo —
+  the source of truth for the SPCW (APF) entry points and parameters,
+  not consulted for Zero Beat (Zero Beat is not a WDSP feature in
+  Thetis).
+- N2PK / MW0LGE Discord commentary on the four APF types is captured in
+  the sibling APF design doc (to follow).
+- Personal operating experience using Thetis in CW-only mode — source
+  of the perceived-latency, silent-on-no-signal, and APF/Zero Beat
+  companion choices.

--- a/tests/Zeus.Dsp.Tests/SyntheticDspEngineTests.cs
+++ b/tests/Zeus.Dsp.Tests/SyntheticDspEngineTests.cs
@@ -96,6 +96,15 @@ public class SyntheticDspEngineTests
         eng.SetMox(false);
     }
 
+    [Fact]
+    public void TrySnapRawSpectrum_synthetic_returns_false()
+    {
+        using var engine = new SyntheticDspEngine();
+        Span<double> buf = new double[16384];
+        bool ok = engine.TrySnapRawSpectrum(channelId: 0, buf);
+        Assert.False(ok);
+    }
+
     private static int ArgMax(ReadOnlySpan<float> s)
     {
         int best = 0;

--- a/tests/Zeus.Dsp.Tests/ZeroBeatAlgorithmTests.cs
+++ b/tests/Zeus.Dsp.Tests/ZeroBeatAlgorithmTests.cs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is an independent reimplementation in .NET — not a fork. Its
+// Protocol-1 / Protocol-2 framing, WDSP integration, meter pipelines, and
+// TX behaviour were informed by studying the Thetis project
+// (https://github.com/ramdor/Thetis), the authoritative reference
+// implementation in the OpenHPSDR ecosystem. Zeus gratefully acknowledges
+// the Thetis contributors whose work made this possible:
+//
+//   Richard Samphire (MW0LGE), Warren Pratt (NR0V),
+//   Laurence Barker (G8NJJ),   Rick Koch (N1GP),
+//   Bryan Rambo (W4WMT),       Chris Codella (W2PA),
+//   Doug Wigley (W5WC),        FlexRadio Systems,
+//   Richard Allen (W5SD),      Joe Torrey (WD5Y),
+//   Andrew Mansfield (M0YGG),  Reid Campbell (MI0BOT),
+//   Sigi Jetzlsperger (DH1KLM).
+//
+// Thetis itself continues the GPL-governed lineage of FlexRadio PowerSDR
+// and the OpenHPSDR (TAPR/OpenHPSDR) ecosystem; that lineage is preserved
+// here. See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
+// WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
+// (NR0V), distributed under GPL v2 or later.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using Xunit;
+
+namespace Zeus.Dsp.Tests;
+
+public class ZeroBeatAlgorithmTests
+{
+    [Fact]
+    public void FindPeakInPassband_returns_index_of_max_in_range()
+    {
+        // bins[10..14] = sloping peak with max at index 12
+        double[] bins = new double[20];
+        bins[10] = -90; bins[11] = -70; bins[12] = -50; bins[13] = -65; bins[14] = -85;
+        // outside passband — should be ignored even though louder
+        bins[5] = -10; bins[18] = -10;
+
+        var (idx, db) = ZeroBeatAlgorithm.FindPeakInPassband(bins, lowBin: 10, highBin: 14);
+
+        Assert.Equal(12, idx);
+        Assert.Equal(-50, db);
+    }
+
+    [Fact]
+    public void FindPeakInPassband_handles_single_bin_range()
+    {
+        double[] bins = { -100, -50, -100 };
+        var (idx, db) = ZeroBeatAlgorithm.FindPeakInPassband(bins, lowBin: 1, highBin: 1);
+        Assert.Equal(1, idx);
+        Assert.Equal(-50, db);
+    }
+
+    [Fact]
+    public void ParabolicInterpolate_returns_zero_for_symmetric_peak()
+    {
+        // Symmetric (-70, -50, -70) → vertex is exactly at peak bin
+        double offset = ZeroBeatAlgorithm.ParabolicInterpolate(-70, -50, -70);
+        Assert.Equal(0.0, offset, precision: 9);
+    }
+
+    [Fact]
+    public void ParabolicInterpolate_returns_positive_when_right_is_higher()
+    {
+        // (-70, -50, -60) → true peak is between center and right → positive offset
+        double offset = ZeroBeatAlgorithm.ParabolicInterpolate(-70, -50, -60);
+        Assert.InRange(offset, 0.0, 0.5);
+    }
+
+    [Fact]
+    public void ParabolicInterpolate_returns_negative_when_left_is_higher()
+    {
+        double offset = ZeroBeatAlgorithm.ParabolicInterpolate(-60, -50, -70);
+        Assert.InRange(offset, -0.5, 0.0);
+    }
+
+    [Fact]
+    public void ParabolicInterpolate_clamps_to_half_bin_when_neighbours_equal_peak()
+    {
+        // Degenerate case: denominator → 0; clamped output prevents NaN/explosion
+        double offset = ZeroBeatAlgorithm.ParabolicInterpolate(-50, -50, -50);
+        Assert.InRange(offset, -0.5, 0.5);
+    }
+
+    [Fact]
+    public void MedianDb_returns_middle_value_of_passband()
+    {
+        double[] bins = { 0, 0, 0, -90, -80, -70, -60, -50, 0, 0 };
+        // sorted passband [3..7] = -90, -80, -70, -60, -50 → median = -70
+        double m = ZeroBeatAlgorithm.MedianDb(bins, lowBin: 3, highBin: 7);
+        Assert.Equal(-70, m);
+    }
+
+    [Fact]
+    public void MedianDb_handles_even_count_with_lower_middle()
+    {
+        double[] bins = { -100, -90, -80, -70 };  // 4 values
+        double m = ZeroBeatAlgorithm.MedianDb(bins, lowBin: 0, highBin: 3);
+        // Lower-middle of two centre values → -90 (we don't need statistical
+        // perfection; SNR gate is robust to a couple dB either way)
+        Assert.Equal(-90, m);
+    }
+}

--- a/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
@@ -185,6 +185,7 @@ public class MicGainEndpointTests : IClassFixture<MicGainEndpointTests.Factory>
         public int ReadAudio(int channelId, Span<float> output) => 0;
         public bool TryGetDisplayPixels(int channelId, DisplayPixout which, Span<float> dbOut) => false;
         public bool TryGetTxDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
+        public bool TrySnapRawSpectrum(int channelId, Span<double> outMagnitudesDb) => false;
         public bool TryGetPsFeedbackDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
         public int OpenTxChannel(int outputRateHz = 48_000) => 0;
         public void SetMox(bool moxOn) { }

--- a/tests/Zeus.Server.Tests/RadioServiceZeroBeatTests.cs
+++ b/tests/Zeus.Server.Tests/RadioServiceZeroBeatTests.cs
@@ -1,0 +1,476 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Zeus.Contracts;
+using Zeus.Dsp;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class RadioServiceZeroBeatTests
+{
+    // Number of frames in phase 1 (mirrors RadioService.ZeroBeatPhase1Frames).
+    private const int Phase1Frames = 15;
+
+    /// <summary>
+    /// Engine stub that returns a synthetic FFT with a single peak at a
+    /// chosen offset from DC for every snap call.
+    ///
+    /// <para>For tests that need phase 2 to be a silent no-op (so the
+    /// assertion only measures the phase-1 move), set
+    /// <see cref="Phase2PeakDb"/> to a value less than
+    /// <see cref="FloorDb"/> + 6 so the SNR gate blocks the second
+    /// refinement step.</para>
+    /// </summary>
+    private sealed class PeakAtBinEngine : IDspEngine
+    {
+        // Phase 1 (first ZeroBeatPhase1Frames calls = 15)
+        public int Phase1PeakBin { get; init; } = 8192;
+        public double Phase1PeakDb { get; init; } = -30;
+
+        // Phase 2 (calls 16..60 = next 45)
+        public int? Phase2PeakBin { get; init; } = null;   // null = same as phase 1
+        public double? Phase2PeakDb { get; init; } = null; // null = same as phase 1
+
+        public double FloorDb { get; init; } = -90;
+
+        // Phase boundary at 15 frames (matches RadioService.ZeroBeatPhase1Frames).
+        private const int Phase1Boundary = 15;
+        private int _callCount;
+
+        public bool TrySnapRawSpectrum(int channelId, Span<double> outMagnitudesDb)
+        {
+            _callCount++;
+            bool inPhase2 = _callCount > Phase1Boundary;
+            int peakBin = inPhase2 ? (Phase2PeakBin ?? Phase1PeakBin) : Phase1PeakBin;
+            double peakDb = inPhase2 ? (Phase2PeakDb ?? Phase1PeakDb) : Phase1PeakDb;
+
+            for (int i = 0; i < outMagnitudesDb.Length; i++) outMagnitudesDb[i] = FloorDb;
+            outMagnitudesDb[peakBin] = peakDb;
+            return true;
+        }
+
+        // --- Unused IDspEngine members — safe no-ops or throws; Zero Beat
+        //     tests only exercise TrySnapRawSpectrum. Pattern copied from
+        //     TxAudioIngestTests.StubEngine in the same test assembly. ---
+        public int TxBlockSamples => 1024;
+        public int TxOutputSamples => 1024;
+        public int OpenChannel(int sampleRateHz, int pixelWidth) => 0;
+        public void CloseChannel(int channelId) { }
+        public void FeedIq(int channelId, ReadOnlySpan<double> interleavedIqSamples) { }
+        public void SetMode(int channelId, RxMode mode) { }
+        public void SetFilter(int channelId, int lowHz, int highHz) { }
+        public void SetVfoHz(int channelId, long vfoHz) { }
+        public void SetAgcTop(int channelId, double topDb) { }
+        public void SetRxAfGainDb(int channelId, double db) { }
+        public void SetNoiseReduction(int channelId, NrConfig cfg) { }
+        public void SetZoom(int channelId, int level) { }
+        public int ReadAudio(int channelId, Span<float> output) => 0;
+        public bool TryGetDisplayPixels(int channelId, DisplayPixout which, Span<float> dbOut) => false;
+        public bool TryGetTxDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
+        public bool TryGetPsFeedbackDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
+        public int OpenTxChannel(int outputRateHz = 48_000) => 0;
+        public void SetMox(bool moxOn) { }
+        public double GetRxaSignalDbm(int channelId) => -140.0;
+        public RxStageMeters GetRxStageMeters(int channelId) => RxStageMeters.Silent;
+        public void SetTxMode(RxMode mode) { }
+        public void SetTxFilter(int lowHz, int highHz) { }
+        public int ProcessTxBlock(ReadOnlySpan<float> micMono, Span<float> iqInterleaved) => 0;
+        public void SetTxPanelGain(double linearGain) { }
+        public void SetTxLevelerMaxGain(double maxGainDb) { }
+        public void SetTxTune(bool on) { }
+        public TxStageMeters GetTxStageMeters() => TxStageMeters.Silent;
+        public void SetTwoTone(bool on, double freq1, double freq2, double mag) { }
+        public void SetPsEnabled(bool enabled) { }
+        public void SetPsControl(bool autoCal, bool singleCal) { }
+        public void SetPsAdvanced(bool ptol, double moxDelaySec, double loopDelaySec,
+                                  double ampDelayNs, double hwPeak, int ints, int spi) { }
+        public void SetPsHwPeak(double hwPeak) { }
+        public void FeedPsFeedbackBlock(ReadOnlySpan<float> txI, ReadOnlySpan<float> txQ,
+                                        ReadOnlySpan<float> rxI, ReadOnlySpan<float> rxQ) { }
+        public PsStageMeters GetPsStageMeters() => PsStageMeters.Silent;
+        public void ResetPs() { }
+        public void SavePsCorrection(string path) { }
+        public void RestorePsCorrection(string path) { }
+        public void SetCfcConfig(CfcConfig cfg) { }
+        public bool ProcessRxVstChain(Span<float> audio, int frames, int sampleRateHz) => false;
+        public bool ProcessTxMicVstChain(Span<float> audio, int frames, int sampleRateHz) => false;
+        public void SetTxMonitorEnabled(bool enabled) { }
+        public int ReadTxMonitorAudio(Span<float> output) => 0;
+        public bool IsTxMonitorOn => false;
+        public void SetCtunShift(int channelId, int shiftHz) { /* CTUN: irrelevant for Zero Beat tests */ }
+        public void Dispose() { }
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 1: Peak exactly at DC — no VFO movement expected.
+    //
+    // With PeakBin = ZeroBeatDcBin (8192), deltaHz = (8192 + 0 - 8192) * hzPerBin = 0.
+    // After both phases the VFO must be unchanged and ZeroBeat must return
+    // a non-null StateDto (the "phase 1 SNR gate passed but delta=0" branch
+    // returns Snapshot() at the end rather than null).
+    // -------------------------------------------------------------------------
+    [Fact]
+    public void ZeroBeat_in_CWU_with_on_frequency_peak_does_not_move_VFO()
+    {
+        var engine = new PeakAtBinEngine { Phase1PeakBin = 8192, Phase2PeakBin = 8192 };
+        using var radio = TestRadioServiceFactory.WithEngine(engine, mode: RxMode.CWU, vfoHz: 14_060_000);
+
+        long before = radio.Snapshot().VfoHz;
+        var result = radio.ZeroBeat();
+        long after = radio.Snapshot().VfoHz;
+
+        Assert.Equal(before, after);   // peak already at DC → zero delta
+        Assert.NotNull(result);
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 2: Peak 10 bins above DC → coarse tune of ~+29 Hz.
+    //
+    // 48 kHz / 16 384 bins → hzPerBin ≈ 2.93 Hz.  10 bins × 2.93 ≈ 29.3 Hz.
+    // Phase 1 fires (SNR 60 dB >> 6 dB gate) and moves VFO by round(29.3) = 29 Hz.
+    // Phase 2 is silenced by the PeakAtBinEngine returning floor-level after the
+    // first Phase1Frames calls, so the SNR gate blocks the second refinement step
+    // and the net delta is just the phase-1 move.
+    //
+    // Allow ±2 Hz tolerance for floating-point rounding (2.93 Hz/bin is
+    // irrational at exactly 48000/16384).
+    // -------------------------------------------------------------------------
+    [Fact]
+    public void ZeroBeat_with_peak_above_DC_moves_VFO_up()
+    {
+        // Phase 2: carrier has shifted to DC after phase-1 tune; SNR gate blocks second move.
+        var engine = new PeakAtBinEngine { Phase1PeakBin = 8202, Phase2PeakBin = 8192, Phase2PeakDb = -30 };
+        using var radio = TestRadioServiceFactory.WithEngine(engine, mode: RxMode.CWU, vfoHz: 14_060_000);
+
+        radio.ZeroBeat();
+        long after = radio.Snapshot().VfoHz;
+        long delta = after - 14_060_000;
+
+        // 10 bins × (48000/16384) ≈ 29.3 Hz → rounds to 29.
+        // ±2 Hz tolerance accounts for floating-point imprecision.
+        Assert.InRange(delta, 27, 31);
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 3: Non-CW mode → ZeroBeat is a silent no-op.
+    //
+    // Mode-gate: only CWL/CWU invoke the algorithm. Any other mode must
+    // return null and leave the VFO unchanged.
+    // -------------------------------------------------------------------------
+    [Fact]
+    public void ZeroBeat_outside_CW_modes_is_noop()
+    {
+        var engine = new PeakAtBinEngine { Phase1PeakBin = 8500 };
+        using var radio = TestRadioServiceFactory.WithEngine(engine, mode: RxMode.USB, vfoHz: 14_200_000);
+
+        var result = radio.ZeroBeat();
+
+        Assert.Null(result);
+        Assert.Equal(14_200_000, radio.Snapshot().VfoHz);
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 4: Flat noise floor (peak − floor < 6 dB SNR gate) → no VFO move.
+    //
+    // Both phases see peak − floor = 2 dB which is below the 6 dB threshold.
+    // Neither phase moves the VFO and ZeroBeat returns null (no-signal path).
+    // -------------------------------------------------------------------------
+    [Fact]
+    public void ZeroBeat_with_flat_noise_floor_does_not_move_VFO()
+    {
+        var engine = new PeakAtBinEngine
+        {
+            Phase1PeakBin = 8500,
+            Phase1PeakDb  = -88,   // peak − floor = −88 − (−90) = 2 dB < 6 dB SNR gate
+            Phase2PeakDb  = -88,   // phase 2 also below threshold
+            FloorDb       = -90,
+        };
+        using var radio = TestRadioServiceFactory.WithEngine(engine, mode: RxMode.CWU, vfoHz: 14_060_000);
+
+        var result = radio.ZeroBeat();
+
+        Assert.Null(result);
+        Assert.Equal(14_060_000, radio.Snapshot().VfoHz);
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 5: Phase 1 quiet, phase 2 has a real carrier.
+    //
+    // Phase 1: only noise (peak = floor → SNR 0 dB, gate fails → no Δ₁).
+    // Phase 2: carrier appears 10 bins above DC (Δ₂ ≈ +29 Hz at 48 kHz).
+    // Expected: VFO moves +29 Hz from phase 2 alone, despite phase 1's failure.
+    // This exercises the previously-unreachable fall-through path.
+    // -------------------------------------------------------------------------
+    [Fact]
+    public void ZeroBeat_phase1_quiet_phase2_signal_moves_VFO_from_phase2_only()
+    {
+        // Phase 1: only noise (peak = floor, SNR = 0 dB, gate fails → no Δ₁).
+        // Phase 2: a real carrier appears 10 bins above DC (Δ₂ ≈ +29 Hz at 48 kHz).
+        // Expected: VFO moves +29 Hz from phase 2 alone, despite phase 1's failure.
+        var engine = new PeakAtBinEngine
+        {
+            Phase1PeakBin = 8192,
+            Phase1PeakDb  = -90,   // = FloorDb → SNR 0 dB → phase 1 gate fails
+            Phase2PeakBin = 8202,  // 10 bins above DC ≈ +29 Hz
+            Phase2PeakDb  = -30,   // strong signal
+            FloorDb       = -90,
+        };
+        using var radio = TestRadioServiceFactory.WithEngine(engine, mode: RxMode.CWU, vfoHz: 14_060_000);
+
+        var result = radio.ZeroBeat();
+        long after = radio.Snapshot().VfoHz;
+
+        Assert.NotNull(result);
+        Assert.InRange(after - 14_060_000, 27, 31);
+    }
+}
+
+/// <summary>
+/// Endpoint integration tests for POST /api/rx/zero-beat. Drives the real
+/// endpoint via <see cref="WebApplicationFactory{TEntryPoint}"/>, asserting
+/// both response shapes: 200 OK with <see cref="StateDto"/> when a signal is
+/// found, and 422 Unprocessable Entity when the SNR gate rejects the spectrum
+/// (flat noise / no signal / no radio connected).
+///
+/// The test factory replaces <see cref="DspPipelineService"/> with a stub
+/// whose <c>CurrentEngine</c> returns a <see cref="PeakAtBinEngine"/> wired
+/// for each scenario. Because <see cref="RadioService"/> is now registered via
+/// a factory lambda that defers <c>GetRequiredService&lt;DspPipelineService&gt;</c>
+/// until the first <c>ZeroBeat</c> call, the stub flows through cleanly
+/// without circular-dependency issues during container construction.
+/// </summary>
+public class ZeroBeatEndpointTests : IClassFixture<ZeroBeatEndpointTests.NoSignalFactory>,
+                                     IClassFixture<ZeroBeatEndpointTests.StrongSignalFactory>
+{
+    private readonly NoSignalFactory _noSignal;
+    private readonly StrongSignalFactory _strong;
+
+    public ZeroBeatEndpointTests(NoSignalFactory noSignal, StrongSignalFactory strong)
+    {
+        _noSignal = noSignal;
+        _strong   = strong;
+    }
+
+    // -------------------------------------------------------------------------
+    // 422 path: mode CWU, wide filter, flat noise floor (SNR 2 dB < 6 dB gate).
+    // Both phases fail the SNR gate → ZeroBeat returns null → 422.
+    // -------------------------------------------------------------------------
+    [Fact]
+    public async Task Post_returns_422_when_no_signal()
+    {
+        using var client = _noSignal.CreateClient();
+
+        // Put the radio into CWU so the mode gate passes (the test verifies
+        // the SNR gate, not the mode gate).
+        var modeResp = await client.PostAsJsonAsync("/api/mode", new { mode = "CWU" });
+        Assert.Equal(HttpStatusCode.OK, modeResp.StatusCode);
+
+        // Set a wide CWU filter so the peak at bin 8300 is inside the passband
+        // regardless of the default CW pitch / family-filter stored state.
+        // FilterLowHz=0 → lo = DC; FilterHighHz=3000 → hi ≈ DC+255 bins at 192 kHz.
+        var bwResp = await client.PostAsJsonAsync("/api/bandwidth", new { low = 0, high = 3000 });
+        Assert.Equal(HttpStatusCode.OK, bwResp.StatusCode);
+
+        var resp = await client.PostAsync("/api/rx/zero-beat", null);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, resp.StatusCode);
+
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("no-signal", body.GetProperty("error").GetString());
+    }
+
+    // -------------------------------------------------------------------------
+    // 200 path: mode CWU, wide filter, strong carrier at a fixed bin.
+    // ZeroBeat sees peak − floor = 60 dB >> 6 dB SNR → returns non-null → 200.
+    // -------------------------------------------------------------------------
+    [Fact]
+    public async Task Post_returns_200_with_state_when_signal_present()
+    {
+        using var client = _strong.CreateClient();
+
+        // Put the radio into CWU so the mode gate passes.
+        var modeResp = await client.PostAsJsonAsync("/api/mode", new { mode = "CWU" });
+        Assert.Equal(HttpStatusCode.OK, modeResp.StatusCode);
+
+        // Set a wide CWU filter so the peak at bin 8300 is inside the passband.
+        var bwResp = await client.PostAsJsonAsync("/api/bandwidth", new { low = 0, high = 3000 });
+        Assert.Equal(HttpStatusCode.OK, bwResp.StatusCode);
+
+        var resp = await client.PostAsync("/api/rx/zero-beat", null);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        // StateDto has a VfoHz field — confirm shape is correct.
+        Assert.True(body.TryGetProperty("vfoHz", out _),
+            "Expected 'vfoHz' in the 200 response body (StateDto shape).");
+    }
+
+    // -------------------------------------------------------------------------
+    // Test factories
+    // -------------------------------------------------------------------------
+
+    // Flat noise. Peak bin 8300 inside the wide CWU filter (0..3000 Hz) set by
+    // the test. peakDb -88 dB, FloorDb -90 dB → SNR 2 dB < 6 dB gate →
+    // ZeroBeat returns null → endpoint 422.
+    public sealed class NoSignalFactory : WebApplicationFactory<Program>
+    {
+        private static readonly PeakAtBinEngine _engine = new()
+        {
+            Phase1PeakBin = 8300,
+            Phase1PeakDb  = -88,
+            Phase2PeakDb  = -88,
+            FloorDb       = -90,
+        };
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Test");
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<IHostedService>();
+                services.RemoveAll<DspPipelineService>();
+                services.AddSingleton<DspPipelineService>(sp =>
+                    new TestPipeline(
+                        sp.GetRequiredService<RadioService>(),
+                        sp.GetRequiredService<StreamingHub>(),
+                        sp.GetRequiredService<ILoggerFactory>(),
+                        _engine));
+            });
+        }
+    }
+
+    // Strong carrier. Peak bin 8300 inside the wide CWU filter (0..3000 Hz) set
+    // by the test. Phase1PeakDb -30 dB, FloorDb -90 dB → SNR 60 dB >> 6 dB
+    // gate → ZeroBeat returns non-null → endpoint 200.
+    public sealed class StrongSignalFactory : WebApplicationFactory<Program>
+    {
+        private static readonly PeakAtBinEngine _engine = new()
+        {
+            Phase1PeakBin = 8300,   // inside the wide CWU filter set by the test
+            Phase2PeakBin = 8300,
+            Phase1PeakDb  = -30,
+            FloorDb       = -90,
+        };
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Test");
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<IHostedService>();
+                services.RemoveAll<DspPipelineService>();
+                services.AddSingleton<DspPipelineService>(sp =>
+                    new TestPipeline(
+                        sp.GetRequiredService<RadioService>(),
+                        sp.GetRequiredService<StreamingHub>(),
+                        sp.GetRequiredService<ILoggerFactory>(),
+                        _engine));
+            });
+        }
+    }
+
+    // Non-hosted TestPipeline that overrides CurrentEngine to return the
+    // caller-supplied stub. Mirrors the pattern in MicGainEndpointTests.
+    private sealed class TestPipeline(
+        RadioService radio,
+        StreamingHub hub,
+        ILoggerFactory logs,
+        IDspEngine engine) : DspPipelineService(radio, hub, Array.Empty<IRxAudioSink>(), logs)
+    {
+        public override IDspEngine? CurrentEngine => engine;
+    }
+
+    // Minimal IDspEngine stub — only TrySnapRawSpectrum matters for ZeroBeat.
+    // Reuses the same PeakAtBinEngine pattern from RadioServiceZeroBeatTests.
+    private sealed class PeakAtBinEngine : IDspEngine
+    {
+        public int Phase1PeakBin { get; init; } = 8192;
+        public double Phase1PeakDb { get; init; } = -30;
+        public int? Phase2PeakBin { get; init; } = null;
+        public double? Phase2PeakDb { get; init; } = null;
+        public double FloorDb { get; init; } = -90;
+
+        private const int Phase1Boundary = 15;
+        private int _callCount;
+
+        public bool TrySnapRawSpectrum(int channelId, Span<double> outMagnitudesDb)
+        {
+            _callCount++;
+            bool inPhase2 = _callCount > Phase1Boundary;
+            int peakBin   = inPhase2 ? (Phase2PeakBin ?? Phase1PeakBin) : Phase1PeakBin;
+            double peakDb = inPhase2 ? (Phase2PeakDb  ?? Phase1PeakDb)  : Phase1PeakDb;
+            for (int i = 0; i < outMagnitudesDb.Length; i++) outMagnitudesDb[i] = FloorDb;
+            outMagnitudesDb[peakBin] = peakDb;
+            return true;
+        }
+
+        public int TxBlockSamples => 1024;
+        public int TxOutputSamples => 1024;
+        public int OpenChannel(int sampleRateHz, int pixelWidth) => 0;
+        public void CloseChannel(int channelId) { }
+        public void FeedIq(int channelId, ReadOnlySpan<double> interleavedIqSamples) { }
+        public void SetMode(int channelId, RxMode mode) { }
+        public void SetFilter(int channelId, int lowHz, int highHz) { }
+        public void SetVfoHz(int channelId, long vfoHz) { }
+        public void SetAgcTop(int channelId, double topDb) { }
+        public void SetRxAfGainDb(int channelId, double db) { }
+        public void SetNoiseReduction(int channelId, NrConfig cfg) { }
+        public void SetZoom(int channelId, int level) { }
+        public int ReadAudio(int channelId, Span<float> output) => 0;
+        public bool TryGetDisplayPixels(int channelId, DisplayPixout which, Span<float> dbOut) => false;
+        public bool TryGetTxDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
+        public bool TryGetPsFeedbackDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
+        public int OpenTxChannel(int outputRateHz = 48_000) => 0;
+        public void SetMox(bool moxOn) { }
+        public double GetRxaSignalDbm(int channelId) => -140.0;
+        public RxStageMeters GetRxStageMeters(int channelId) => RxStageMeters.Silent;
+        public void SetTxMode(RxMode mode) { }
+        public void SetTxFilter(int lowHz, int highHz) { }
+        public int ProcessTxBlock(ReadOnlySpan<float> micMono, Span<float> iqInterleaved) => 0;
+        public void SetTxPanelGain(double linearGain) { }
+        public void SetTxLevelerMaxGain(double maxGainDb) { }
+        public void SetTxTune(bool on) { }
+        public TxStageMeters GetTxStageMeters() => TxStageMeters.Silent;
+        public void SetTwoTone(bool on, double freq1, double freq2, double mag) { }
+        public void SetPsEnabled(bool enabled) { }
+        public void SetPsControl(bool autoCal, bool singleCal) { }
+        public void SetPsAdvanced(bool ptol, double moxDelaySec, double loopDelaySec,
+                                  double ampDelayNs, double hwPeak, int ints, int spi) { }
+        public void SetPsHwPeak(double hwPeak) { }
+        public void FeedPsFeedbackBlock(ReadOnlySpan<float> txI, ReadOnlySpan<float> txQ,
+                                        ReadOnlySpan<float> rxI, ReadOnlySpan<float> rxQ) { }
+        public PsStageMeters GetPsStageMeters() => PsStageMeters.Silent;
+        public void ResetPs() { }
+        public void SavePsCorrection(string path) { }
+        public void RestorePsCorrection(string path) { }
+        public void SetCfcConfig(CfcConfig cfg) { }
+        public bool ProcessRxVstChain(Span<float> audio, int frames, int sampleRateHz) => false;
+        public bool ProcessTxMicVstChain(Span<float> audio, int frames, int sampleRateHz) => false;
+        public void SetTxMonitorEnabled(bool enabled) { }
+        public int ReadTxMonitorAudio(Span<float> output) => 0;
+        public bool IsTxMonitorOn => false;
+        public void SetCtunShift(int channelId, int shiftHz) { /* CTUN: irrelevant for Zero Beat endpoint tests */ }
+        public void Dispose() { }
+    }
+}

--- a/tests/Zeus.Server.Tests/TestRadioServiceFactory.cs
+++ b/tests/Zeus.Server.Tests/TestRadioServiceFactory.cs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Dsp;
+using Zeus.Protocol1;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Test-only factory that constructs a minimal <see cref="RadioService"/>
+/// wired to a caller-supplied <see cref="IDspEngine"/> stub and a known
+/// initial state (mode, VFO, filter, sample rate). Exercises the public
+/// surface only — no UDP sockets, no LiteDB, no background threads.
+/// </summary>
+internal static class TestRadioServiceFactory
+{
+    /// <summary>
+    /// Build a <see cref="RadioService"/> configured for Zero Beat unit tests:
+    /// <list type="bullet">
+    ///   <item>Engine provider returns <paramref name="engine"/>.</item>
+    ///   <item>Mode is set to <paramref name="mode"/>.</item>
+    ///   <item>VFO is set to <paramref name="vfoHz"/>.</item>
+    ///   <item>Filter is set to <paramref name="filterLowHz"/>..<paramref name="filterHighHz"/>.</item>
+    ///   <item>Sample rate is 48 000 Hz (matching the 2.93 Hz/bin test math).</item>
+    /// </list>
+    /// The returned service does NOT call any Protocol1Client methods (no
+    /// active connection), so all radio-wire calls on the service are safe
+    /// no-ops.
+    /// </summary>
+    public static RadioService WithEngine(
+        IDspEngine engine,
+        RxMode mode = RxMode.CWU,
+        long vfoHz = 14_060_000,
+        int filterLowHz = -1000,
+        int filterHighHz = 1000)
+    {
+        // Use throw-away in-memory stores — no file I/O in tests.
+        var dbPath = Path.Combine(Path.GetTempPath(), $"zeus-zb-test-{Guid.NewGuid():N}.db");
+        var dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance, dbPath + ".dsp");
+        var paStore  = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, dbPath + ".pa");
+
+        var radio = new RadioService(
+            NullLoggerFactory.Instance,
+            dspStore,
+            paStore,
+            engineProvider: () => engine);
+
+        // Drive the service into the test-desired initial state via the same
+        // public API that production code uses. SetMode first so the mode-
+        // based filter-sign logic runs before SetFilter overrides it.
+        radio.SetMode(mode);
+        radio.SetVfo(vfoHz);
+        // Override the filter with a caller-specified symmetric window.
+        // SetFilter accepts signed values directly; a (-1000,+1000) window
+        // covers ±341 bins at 48 kHz / 16 384 bins and includes the
+        // off-DC test peaks used in RadioServiceZeroBeatTests.
+        radio.SetFilter(filterLowHz, filterHighHz);
+        radio.SetSampleRate(HpsdrSampleRate.Rate48k);
+
+        return radio;
+    }
+}

--- a/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
+++ b/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
@@ -95,6 +95,7 @@ public class TxAudioIngestTests
         public bool TryGetDisplayPixels(int channelId, DisplayPixout which, Span<float> dbOut) => false;
         public bool TryGetTxDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
         public bool TryGetPsFeedbackDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
+        public bool TrySnapRawSpectrum(int channelId, Span<double> outMagnitudesDb) => false;
         public int OpenTxChannel(int outputRateHz = 48_000) => 0;
         public void SetMox(bool moxOn) { }
         public double GetRxaSignalDbm(int channelId) => -140.0;

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -1128,6 +1128,31 @@ export function setNr4(
   );
 }
 
+/**
+ * One-shot CW Zero Beat (issue #300). Snaps the VFO onto the strongest CW
+ * carrier in the current filter passband. Mode-gated to CWL/CWU server-side;
+ * outside CW modes the call is a no-op.
+ *
+ * Returns the updated radio state on success, or `null` when the SNR gate
+ * tripped (no carrier detected — silent no-op, the VFO does not move).
+ * Any other failure throws.
+ */
+export function zeroBeat(
+  rxId: number = 0,
+  signal?: AbortSignal,
+): Promise<RadioStateDto | null> {
+  return fetch('/api/rx/zero-beat', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ rxId }),
+    signal,
+  }).then(async (r) => {
+    if (r.status === 422) return null;  // SNR gate tripped — silent no-op
+    if (!r.ok) throw new Error(`zero-beat failed: ${r.status}`);
+    return normalizeState(await r.json());
+  });
+}
+
 // MOX endpoint returns {moxOn} — not a full StateDto — because MOX is
 // transient and deliberately absent from the persisted state snapshot.
 // 409 while disconnected surfaces as ApiError with the server's message.

--- a/zeus-web/src/components/ZeroBeatButton.tsx
+++ b/zeus-web/src/components/ZeroBeatButton.tsx
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is an independent reimplementation in .NET — not a fork. Its
+// Protocol-1 / Protocol-2 framing, WDSP integration, meter pipelines, and
+// TX behaviour were informed by studying the Thetis project
+// (https://github.com/ramdor/Thetis), the authoritative reference
+// implementation in the OpenHPSDR ecosystem. Zeus gratefully acknowledges
+// the Thetis contributors whose work made this possible:
+//
+//   Richard Samphire (MW0LGE), Warren Pratt (NR0V),
+//   Laurence Barker (G8NJJ),   Rick Koch (N1GP),
+//   Bryan Rambo (W4WMT),       Chris Codella (W2PA),
+//   Doug Wigley (W5WC),        FlexRadio Systems,
+//   Richard Allen (W5SD),      Joe Torrey (WD5Y),
+//   Andrew Mansfield (M0YGG),  Reid Campbell (MI0BOT),
+//   Sigi Jetzlsperger (DH1KLM).
+//
+// Thetis itself continues the GPL-governed lineage of FlexRadio PowerSDR
+// and the OpenHPSDR (TAPR/OpenHPSDR) ecosystem; that lineage is preserved
+// here. See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
+// WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
+// (NR0V), distributed under GPL v2 or later.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+import { useCallback, useState } from 'react';
+import { zeroBeat } from '../api/client';
+import { useConnectionStore } from '../state/connection-store';
+
+/**
+ * One-shot CW Zero Beat trigger (issue #300).
+ *
+ * Renders only when the current mode is CWL or CWU. While running, the
+ * button gets an `var(--accent)` border via the `running` class so the
+ * operator sees the action took effect. The ~2 s perceived latency is
+ * dominated by phase 1 (~500 ms); phase 2 settles silently after the dial
+ * has already moved.
+ *
+ * No toast on failure: the VFO not moving is itself the signal that
+ * nothing was found. Matches Thetis / standard CW-rig convention.
+ */
+export function ZeroBeatButton() {
+  const mode = useConnectionStore((s) => s.mode);
+  const applyState = useConnectionStore((s) => s.applyState);
+  const [running, setRunning] = useState(false);
+
+  const onClick = useCallback(async () => {
+    if (running) return;
+    setRunning(true);
+    try {
+      const next = await zeroBeat();
+      if (next) applyState(next);
+    } catch {
+      // swallow — no toast, no flash; VFO stays put
+    } finally {
+      setRunning(false);
+    }
+  }, [running, applyState]);
+
+  if (mode !== 'CWL' && mode !== 'CWU') return null;
+
+  return (
+    <button
+      type="button"
+      className={`btn sm${running ? ' running' : ''}`}
+      onClick={onClick}
+      disabled={running}
+      title="Zero Beat — snap VFO to strongest CW carrier in passband (Z)"
+    >
+      0 BEAT
+    </button>
+  );
+}

--- a/zeus-web/src/layout/panels/CwPanel.tsx
+++ b/zeus-web/src/layout/panels/CwPanel.tsx
@@ -4,13 +4,10 @@
 // Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
 
 import { CwKeyer } from '../../components/design/CwKeyer';
+import { ZeroBeatButton } from '../../components/ZeroBeatButton';
 import { abortCw, sendCw } from '../../api/cw';
 import { useCwStore } from '../../state/cw-store';
 
-// Hard cap mirrors Zeus.Server.Hosting/CwSettingsStore.cs MaxMacros. If
-// the server bumps the cap, also bump this so the UI's "Add" button
-// matches. (We could fetch it dynamically, but a constant is cheaper
-// and only changes during epic-scale revisits.)
 const MAX_MACROS = 32;
 
 export function CwPanel() {
@@ -24,18 +21,14 @@ export function CwPanel() {
 
   return (
     <div style={{ flex: 1, overflow: 'auto' }}>
+      <div className="btn-row" style={{ padding: '4px 6px' }}>
+        <ZeroBeatButton />
+      </div>
       <CwKeyer
         wpm={settings.wpm}
-        // Split-write pattern fixes the "slider snaps back" race. The
-        // local setter updates the store immediately so the slider
-        // tracks the pointer; the debounced commit schedules a single
-        // PUT after the operator stops dragging.
         setWpmLocal={(v) => setSettingsLocal({ wpm: v })}
         setWpmCommit={(v) => commitDebounced({ wpm: v })}
         macros={settings.macros}
-        // Pass the current WPM explicitly so a slider change that hasn't
-        // round-tripped to the server yet still keys at the operator's
-        // intended speed.
         onSend={(macro) => void sendCw(macro, settings.wpm)}
         onAbort={() => void abortCw()}
         onMacroEdit={(i, v) => void setMacro(i, v)}

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -701,6 +701,12 @@
   box-shadow: 0 0 0 1px rgba(46,142,255,0.5), 0 0 14px rgba(46,142,255,0.35);
   text-shadow: none;
 }
+/* .btn.running — in-progress accent glow (e.g. Zero Beat, issue #300).
+   Matches the accent treatment used elsewhere (CTUN, MOX active). */
+.btn.running {
+  border-color: var(--accent);
+  box-shadow: 0 0 6px var(--accent);
+}
 .btn.sm { padding: 0.3em 0.7em;  font-size: clamp(10px, 0.1vw + 9.5px, 12px); }
 .btn.lg { padding: 0.55em 1em;   font-size: clamp(13px, 0.2vw + 10px, 15px); }
 .btn.ghost {

--- a/zeus-web/src/util/use-keyboard-shortcuts.ts
+++ b/zeus-web/src/util/use-keyboard-shortcuts.ts
@@ -47,6 +47,7 @@ import {
   setMox,
   setVfo,
   setZoom,
+  zeroBeat,
   ZOOM_MAX,
   ZOOM_MIN,
   type ZoomLevel,
@@ -202,6 +203,18 @@ export function useKeyboardShortcuts() {
           e.preventDefault();
           bumpZoom(-1);
           break;
+        case 'z':
+        case 'Z': {
+          const mode = useConnectionStore.getState().mode;
+          if (mode !== 'CWL' && mode !== 'CWU') break;
+          e.preventDefault();
+          zeroBeat()
+            .then((next) => {
+              if (next) useConnectionStore.getState().applyState(next);
+            })
+            .catch(() => {});
+          break;
+        }
         case ' ':
         case 'Spacebar':
           // e.repeat filters native autorepeat so we fire MOX-on exactly


### PR DESCRIPTION
One-shot Zero Beat for CW. Tune near a signal, press the button (or
hit Z), the VFO snaps onto the carrier. Works at any sample rate
(tested on-air at 48 kHz and 192 kHz on an Anvelina PRO3, Protocol 2).

## How it works

Reads the raw 16384-bin FFT from the WDSP analyzer via a new
SnapSpectrumTimeout P/Invoke. Max-holds across ~1 s of frames to ride
through CW keying gaps, finds the peak in the current filter passband,
applies parabolic interpolation for sub-bin resolution, and retunes the
VFO so the carrier lands at the CW pitch.

A 6 dB SNR gate (scaled by sample rate) prevents the VFO from jumping
on noise. No toast on failure — the VFO not moving is the feedback,
matching standard rig convention.

## Future: WDSP native peak detector

WDSP has a built-in peak detector (SetupDetectMaxBin / GetDetectMaxBin)
that Thetis uses for its Zero Beat. Our approach works but the WDSP
detector would handle averaging and noise rejection internally, likely
with better results on weak signals. The endpoint and UI stay the same
either way — it's a backend-only swap.

## UI placement — @brianbruff

The 0 BEAT button lives inside the CW Keyer panel, which follows the
Thetis convention of a separate keyer/macro window. That's the right
home for macros, but Zero Beat is an operator action that should be as
accessible as RIT (which already has a transport-bar placeholder).
Brian, where would you want it? Transport bar next to RIT? VFO area?
Happy to move it wherever makes sense.

## Test plan

- [x] CWU + CWL: VFO snaps to carrier at both 48 kHz and 192 kHz
- [x] No signal: silent no-op, VFO stays put
- [x] Z keybind works in CW modes, ignored elsewhere
- [x] Button hidden outside CW modes
- [x] SNR gate rejects noise (6 dB threshold, scaled by sample rate)
- [x] `dotnet build Zeus.slnx` — 0 warnings, 0 errors
- [x] `dotnet test Zeus.slnx --filter ZeroBeat` — 15 tests pass