### PR TITLE
fix(audio): keep WDSP RXA warm across MOX so TX→RX audio resumes instantly

### DIFF
--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -1371,12 +1371,32 @@ public sealed class WdspDspEngine : IDspEngine
         // stay running so fexchange2 keeps producing IQ for the monitor
         // demod path. We re-derive TXA target = (MOX || monitor) so the
         // monitor path doesn't go silent when the operator releases MOX.
-        int rxaPrior, txaPrior = -1;
+        // RX-resume warmth (issue #468, follow-up to #497): we deliberately
+        // leave the RXA channel at state=1 across the whole MOX cycle and do
+        // NOT damp it to state=0 on key-down. Damping the channel meant that
+        // on un-key the RXA pipeline had to walk its slew + AGC + overlap-add
+        // state back up from a flushed/quiescent state at the *same* moment the
+        // radio's RX front end was recovering from RX_GNDonTX un-grounding —
+        // the two stack into the operator-observed ~2 sec RX-resume ramp on G2
+        // (P2). Thetis avoids this by construction: in the common single-VFO
+        // case it leaves the WDSP RX channel running through TX and mutes the
+        // audio at the mixer (console.cs:29580 `RX1_shutdown` is conditional;
+        // Audio.cs MuteRX1), so its AGC stays converged and RX un-mutes
+        // instantly. We mirror that: keep RXA warm here, and mute the RX audio
+        // output while keyed in DspPipelineService (the `_keyed` gate), so the
+        // operator never hears band RX during TX while the DSP stays converged.
+        //
+        // The RX IQ fed to the warm channel during TX is the radio's grounded
+        // RX input (near-silence), so the channel demodulates near-silence and
+        // its AGC simply tracks the noise floor — no spurious audio leaks
+        // (it's muted downstream anyway) and the channel is hot the instant the
+        // real signal returns.
+        int txaPrior = -1;
         bool wantTxa = moxOn || _monitorRequested;
         if (moxOn)
         {
             _moxOn = true;
-            rxaPrior = NativeMethods.SetChannelState(rxaId, 0, 1);
+            // NOTE: no SetChannelState(rxaId, 0, 1) — RXA stays at state=1.
             if (!_txaRunning)
             {
                 txaPrior = NativeMethods.SetChannelState(txaId, 1, 0);
@@ -1404,19 +1424,20 @@ public sealed class WdspDspEngine : IDspEngine
                 txaPrior = NativeMethods.SetChannelState(txaId, 0, 1);
                 _txaRunning = false;
             }
-            rxaPrior = NativeMethods.SetChannelState(rxaId, 1, 0);
+            // NOTE: no SetChannelState(rxaId, 1, 0) — RXA was never damped, so
+            // there is nothing to bring back up. The pipeline's `_keyed` gate
+            // un-mutes the already-converged RX audio on this same edge.
             // Unkeying: clear the stage-meter snapshot so UI doesn't latch the
             // last-during-TX reading while idle. The next MOX-on will publish
             // fresh data on its first ProcessTxBlock.
             lock (_txMeterPublishLock) { _latestTxStageMeters = null; }
         }
-        // Diagnostic 2026-04-18: capture the prior-state return of every
-        // SetChannelState call so we can detect cases where the requested
-        // transition was a no-op (prior == new) — that's the failure mode that
-        // looks like "RX audio doesn't come back after MOX-off".
+        // Diagnostic 2026-04-18: capture the prior-state return of the TXA
+        // SetChannelState call so we can detect a requested transition that was
+        // a no-op (prior == new). RXA is left warm so it has no prior to log.
         _log.LogInformation(
-            "wdsp.setMox on={Mox} rxa={Rxa} (prior {RxaPrior}) txa={Txa} (prior {TxaPrior})",
-            moxOn, rxaId, rxaPrior, txaId, txaPrior);
+            "wdsp.setMox on={Mox} rxa={Rxa} (warm) txa={Txa} (prior {TxaPrior})",
+            moxOn, rxaId, txaId, txaPrior);
     }
 
     public TxStageMeters GetTxStageMeters()

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -1614,8 +1614,32 @@ public class DspPipelineService : BackgroundService,
         // don't broadcast it. The VST RX seam still fires on the drained RX
         // so RX-side plugins keep running even while monitor is on.
         bool txMonitorOn = engine.IsTxMonitorOn;
+        // Always drain the WDSP RX audio ring, even while keyed. Issue #468
+        // follow-up: WdspDspEngine.SetMox now leaves the RXA channel warm
+        // (state=1) through the whole MOX cycle instead of damping it to
+        // state=0, so the DSP/AGC stay converged and RX resumes instantly on
+        // un-key (mirrors Thetis's MuteRX1-at-the-mixer approach). The cost is
+        // that ReadAudio now returns live band RX while keyed; we MUST NOT
+        // publish that (the operator would hear band RX while transmitting),
+        // but we still drain it so the WDSP audio ring doesn't back up and so
+        // the first post-un-key block is fresh rather than a stale TX-period
+        // backlog. The `_keyed` gate on PublishAudio below enforces the mute.
         int audioSampleCount = engine.ReadAudio(channel, audioBuf);
-        if (audioSampleCount > 0)
+        // RX audio is muted while keyed (MOX or TUN). The WDSP RX channel is
+        // kept warm, so this is a pure downstream mute — no DSP state is torn
+        // down and un-key resumes from a converged pipeline.
+        bool rxAudioMuted = _keyed;
+        if (rxAudioMuted)
+        {
+            // Consume the rising-edge fade-out one-shot here: with the mute in
+            // place the RX→TX transition is already silent (the operator hears
+            // TX, not band RX), so there's no click to ramp out — and leaving
+            // the flag armed would make it (as the leading `if` below) wrongly
+            // ramp DOWN the first un-keyed resume block instead of letting the
+            // fade-IN one-shot ramp it up.
+            _rxFadeOutPending = false;
+        }
+        if (audioSampleCount > 0 && !rxAudioMuted)
         {
             // MOX-edge fade envelope. Ramps the first ~5 ms of this block
             // either down (rising edge: last block before TX silence) or up


### PR DESCRIPTION
## Summary

Follow-up to #497. On-hardware, #497 (drain the desktop RX ring on both TX edges) was **confirmed merged and working but NOT sufficient**: the ~2 sec **TX → RX** delay persisted on **G2 / Protocol 2 / Windows desktop / native audio**, on both MOX and TUN. RX → TX stays instant.

The operator's log points away from buffered audio and at the **RX resume path itself**. After `wdsp.setMox on=False`:
- During TX the RX S-meter reads the `-400` sentinel (RXA parked — expected).
- After un-key the RX S-meter **ramps over ~2 sec** (`sAv` climbs −92 → −90 → −74 → −67 → −63) before real audio is present, while `agcGain` stays **pinned** at −48.5. So the RX pipeline isn't producing real audio yet — draining the ring can't help because there's nothing fresh to play.
- `audio.native.rx` underrun counter increments across the gap (device playing silence, waiting for RX audio).

### Root cause — the asymmetry vs Thetis

`WdspDspEngine.SetMox` damped the single RXA channel to **state=0** on key-down (`SetChannelState(rxaId, 0, 1)`, `Zeus.Dsp/Wdsp/WdspDspEngine.cs:1379` pre-change) and brought it back to **state=1** on un-key (`SetChannelState(rxaId, 1, 0)`). The state=0→1 transition re-arms `slew.upflag` + `ch_upslew`, clears `exec_bypass` and re-arms the `exchange` bit (`native/wdsp/channel.c:286-291`), so the RXA pipeline has to walk its slew / AGC / overlap-add state back up from quiescent — at the **same moment** the G2's RX front end is recovering from `RX_GNDonTX` un-grounding (`Zeus.Protocol2/Protocol2Client.cs:1207`). The two settles stack into the observed ~2 sec ramp.

Thetis avoids this by construction: in the common single-VFO case it leaves the WDSP RX channel **running** through TX and mutes the audio at the mixer (`console.cs:29580` — `RX1_shutdown` is conditional; `Audio.cs` `MuteRX1`), so its AGC stays converged and RX un-mutes instantly.

I ruled out (with file:line in the commit body): the audio ring (already #497), the IQ feed path (`DspPipelineService.OnIqFrame` — unconditional, no MOX gate), the P2 RX DDC stream (`Protocol2Client.SetMox` only re-emits HighPriority; DDC never stops), any deliberate desktop-side hold / `BUFFER_TARGET` re-anchor (none — `NativeAudioSink` has no buffer target; that lives only in the browser `audio-client.ts` handled by #494), the WDSP input slew (10 ms delay + 25 ms ramp, `WdspDspEngine.cs:372-373`), and AGC decay (250 ms MED, `wcpAGC.c:372`) / AGC lookahead (~4 ms). None is ~2 sec. The only ~2-sec-scale variable Zeus controls on this edge is the RXA channel reset stacking with the radio's RX-ground recovery.

## What changed

- **`Zeus.Dsp/Wdsp/WdspDspEngine.cs` (`SetMox`)** — leave RXA at **state=1 across the whole MOX cycle**; drop both `SetChannelState(rxaId, ...)` calls. The channel stays warm and converged. The IQ fed during TX is the grounded-RX input (near-silence), so it just tracks the noise floor and is hot the instant the real signal returns. TXA handling, PS `SetPSMox`, and the monitor path are unchanged.
- **`Zeus.Server.Hosting/DspPipelineService.cs` (`Tick`)** — `ReadAudio` now returns live band RX while keyed, so gate `PublishAudio` (and `RxAudioAvailable`) on `!_keyed` to mute it — the operator must not hear band RX during TX. The ring is still drained every tick (no backlog; the first post-un-key block is fresh). The rising-edge fade-out one-shot is consumed under the mute so it can't wrongly ramp DOWN the resume block; the falling-edge fade-IN one-shot still ramps the resume up.

No DSP state is torn down on key-down anymore, so un-key resumes from a converged pipeline. **HL2 / P1** (radio stops RX while MOX is asserted) is unaffected: no IQ arrives while keyed, `ReadAudio` returns 0, the mute is moot, and the warm RXA is ready on resume.

Minimal and focused — two methods touched, no pipeline refactor, no defaults an operator feels, no wire-format change, RX → TX path untouched.

## Build / test

- `dotnet build Zeus.slnx` → 0 warnings, 0 errors.
- `dotnet test Zeus.slnx` → all 7 projects pass, 0 failures. The real-WDSP `SetMox` / `ReadAudio` / post-MOX-resume tests (`WdspDspEngineTests`) **ran** (libwdsp present on the dev box, not skipped) and pass — they confirm RXA still produces audio across a MOX cycle with the warm-channel change.

## Test plan (Windows desktop bench — needs operator confirm)

1. G2 / P2 / Windows desktop. Connect, let RX run.
2. **Key up (MOX on):** RX should go silent **instantly** (no band RX bleeding through during TX), no change from current behaviour. Confirm you do NOT hear band RX while transmitting.
3. **Un-key (MOX off):** RX audio should resume **fast** (well under a second), not after the ~2 sec ramp. Watch the S-meter — it should snap back, not crawl up over 2 sec.
4. Repeat with **TUNE**. Same expectation on both edges.
5. Listen for dropouts / clicks on resume — there should be none beyond the normal brief post-MOX gap.
6. Re-check the `wdsp.setMox` log: it now reads `rxa=0 (warm) txa=1 (prior 1)` — the RXA channel is intentionally left at state=1, no `(prior N)` for RXA.
7. If a residual delay remains after this, it is the radio's RX-ground hardware recovery (not Zeus DSP) — capture the same S-meter ramp log so we can confirm.

## ⚠️ RED-LIGHT note

This touches the **realtime audio hot path** and WDSP RX channel state — a red-light area. The reasoning is grounded in the operator's on-hardware log and verified against Thetis source, the WDSP-side change is exercised by the real-WDSP unit tests, and the change is minimal — **but I developed it on macOS and cannot reproduce Windows audio timing.** Please get the operator's on-Windows G2 bench confirm (instant key-up with no band-RX bleed, fast un-key, no dropouts, on both MOX and TUN) **before promoting this to develop.** If any band RX is audible while transmitting, that is a mute regression to flag immediately.

Refs #468, #497.
