### PR TITLE
Issue #426 bundle: Hermes RX codec + meter cal + waterfall brightness + PTT race

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,3 +1,3 @@
 no-git-ops: true
 
-sync.remote: "https://doltremoteapi.dolthub.com/brianbruff/openhpsdr-zeus"
+sync.remote: "https://doltremoteapi.dolthub.com/kb2uka/openhpsdr-zeus"

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,3 +1,3 @@
 no-git-ops: true
 
-sync.remote: "https://doltremoteapi.dolthub.com/brianbruff/openhpsdr-zeus"
+# sync.remote: "https://doltremoteapi.dolthub.com/kb2uka/openhpsdr-zeus"

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,3 +1,3 @@
 no-git-ops: true
 
-# sync.remote: "https://doltremoteapi.dolthub.com/kb2uka/openhpsdr-zeus"
+sync.remote: "https://doltremoteapi.dolthub.com/kb2uka/openhpsdr-zeus"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,9 +2,9 @@ name: Build and Test
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, experimental]
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, experimental]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -596,12 +596,218 @@ jobs:
           path: installers/output/OpenhpsdrZeus*-${{ steps.version.outputs.version }}-linux-x86_64.AppImage
           if-no-files-found: error
 
+      # ---------- macOS code-signing + notarization ------------------------
+      #
+      # Five steps gated on (is-release || is-nightly): import the Developer
+      # ID cert into an ephemeral keychain, run the existing builder with
+      # CODESIGN_IDENTITY exported (the script signs apps + DMG inside-out
+      # hardened-runtime, see installers/create-macos-app.sh), submit to
+      # Apple notary, staple the ticket into the DMG, and verify Gatekeeper
+      # acceptance. The dry-run path falls through to the original
+      # unsigned-build step further down.
+      #
+      # Why gated:
+      #   - Notarization burns 2-15 min of macos-latest runner time (10x
+      #     Linux cost) and counts against Apple's API submission quota.
+      #     dry-run builds don't need either.
+      #   - Apple's API key (.p8) only exists as a secret in the repo; PRs
+      #     from forks running release.yml as a dry-run would otherwise hit
+      #     a "secret missing" error mid-job.
+      #
+      # The ephemeral keychain name embeds run_id + run_attempt so two
+      # concurrent dispatches (e.g. nightly cron racing with a maintainer's
+      # manual run) never collide on /Users/runner/Library/Keychains.
+      - name: macOS — dry-run notice (signing/notarization skipped)
+        if: ${{ startsWith(matrix.config.os, 'macos') && needs.determine-version.outputs.is-release != 'true' && needs.determine-version.outputs.is-nightly != 'true' }}
+        run: |
+          echo "::notice::macOS DMG will NOT be signed or notarized in dry-run mode. The artifact will require xattr -cr on first launch."
+
+      - name: macOS — import Developer ID certificate
+        if: ${{ startsWith(matrix.config.os, 'macos') && (needs.determine-version.outputs.is-release == 'true' || needs.determine-version.outputs.is-nightly == 'true') }}
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN_PATH="$RUNNER_TEMP/build-${{ github.run_id }}-${{ github.run_attempt }}.keychain-db"
+          CERT_PATH="$RUNNER_TEMP/macos-cert.p12"
+          INTERMEDIATE_PATH="$RUNNER_TEMP/DeveloperIDG2CA.cer"
+
+          # Decode the base64-encoded .p12 to a temp file. `security import`
+          # cannot read from stdin so we have to materialize it; we shred it
+          # below once it's in the keychain.
+          echo "$MACOS_CERTIFICATE" | base64 --decode > "$CERT_PATH"
+
+          # Download Apple's Developer ID Certification Authority (G2)
+          # intermediate cert. A .p12 exported from Keychain Access ships
+          # only the leaf + private key, NOT the intermediate. On a dev
+          # Mac the intermediate is already in login.keychain from prior
+          # Xcode use, so the chain validates fine — but a fresh GitHub
+          # Actions runner only has Apple Root CA in its trust store, so
+          # codesign warns "unable to build chain to self-signed root"
+          # and notarytool rejects the resulting bundle. URL is Apple's
+          # stable publication endpoint; cert is valid through 2031.
+          curl -fsSL --retry 3 \
+              https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer \
+              -o "$INTERMEDIATE_PATH"
+
+          # Per-run ephemeral keychain so concurrent dispatches don't trample
+          # each other and so cleanup is just `security delete-keychain`.
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          # 6h timeout — comfortably longer than any release build wall clock.
+          # Default is 5 minutes auto-lock which would break a slow notarization.
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Import the intermediate FIRST so chain validation works the
+          # moment the leaf .p12 lands in the keychain.
+          security import "$INTERMEDIATE_PATH" \
+              -k "$KEYCHAIN_PATH" \
+              -T /usr/bin/codesign
+
+          # -A allows all apps to use the key without prompting (no GUI on CI).
+          # -T whitelists specific tools so set-key-partition-list below can
+          # set a durable ACL — without it codesign would still prompt for
+          # the keychain password on first private-key access.
+          security import "$CERT_PATH" \
+              -P "$MACOS_CERTIFICATE_PWD" \
+              -A -t cert -f pkcs12 \
+              -k "$KEYCHAIN_PATH" \
+              -T /usr/bin/codesign \
+              -T /usr/bin/security
+
+          # Make the codesign ACL durable. Without this codesign hangs on
+          # CI waiting for a human to acknowledge the keychain prompt.
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+              -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" >/dev/null
+
+          # Prepend the temp keychain to the user search list. codesign
+          # defaults to login.keychain otherwise and never finds our cert.
+          # Capture the existing list into a bash array — string-mangling
+          # via tr corrupts paths in edge cases (we saw a local-test run
+          # end up with the search list set to a single mangled entry
+          # containing literal "-d -db" fragments).
+          ORIGINAL_KEYCHAINS=()
+          while IFS= read -r line; do
+              clean=$(echo "$line" | sed -E 's/^[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/')
+              [ -n "$clean" ] && ORIGINAL_KEYCHAINS+=("$clean")
+          done < <(security list-keychains -d user)
+          security list-keychains -d user -s "$KEYCHAIN_PATH" "${ORIGINAL_KEYCHAINS[@]}"
+
+          # Shred the on-disk cert files — both are safely in the keychain
+          # now. macOS `rm -P` overwrites with 0xff/0x00/0xff before unlink.
+          # The intermediate is public so shredding it is paranoia, but
+          # cheap and keeps the cleanup symmetric.
+          rm -P "$CERT_PATH" 2>/dev/null || rm -f "$CERT_PATH"
+          rm -P "$INTERMEDIATE_PATH" 2>/dev/null || rm -f "$INTERMEDIATE_PATH"
+
+          # Propagate KEYCHAIN_PATH to subsequent steps. create-macos-app.sh
+          # picks this up as the --keychain arg for every codesign call.
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+
+          # Sanity check: the identity must be findable, otherwise the build
+          # step will fail mid-way through codesign with a less helpful error.
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
       - name: Build macOS Package
         if: startsWith(matrix.config.os, 'macos')
+        env:
+          # Ternary: signed only when is-release || is-nightly. In dry-run
+          # the value is the empty string regardless of whether
+          # MACOS_SIGNING_IDENTITY is configured — keeps an accidentally-set
+          # secret from sneaking signing into a dry-run build.
+          CODESIGN_IDENTITY: ${{ (needs.determine-version.outputs.is-release == 'true' || needs.determine-version.outputs.is-nightly == 'true') && secrets.MACOS_SIGNING_IDENTITY || '' }}
+          ENTITLEMENTS_PATH: ${{ github.workspace }}/installers/zeus-macos.entitlements
+          # KEYCHAIN_PATH flows in via $GITHUB_ENV from the import step above.
         run: |
+          set -e
           chmod +x installers/create-macos-app.sh
           ARCH="${{ matrix.config.rid == 'osx-arm64' && 'arm64' || 'x64' }}"
           installers/create-macos-app.sh ${{ steps.version.outputs.version }} $ARCH
+
+      - name: macOS — notarize DMG
+        if: ${{ startsWith(matrix.config.os, 'macos') && (needs.determine-version.outputs.is-release == 'true' || needs.determine-version.outputs.is-nightly == 'true') }}
+        env:
+          APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
+          APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+          APPSTORE_API_KEY_P8: ${{ secrets.APPSTORE_API_KEY_P8 }}
+        run: |
+          set -euo pipefail
+          ARCH="${{ matrix.config.rid == 'osx-arm64' && 'arm64' || 'x64' }}"
+          DMG_PATH="installers/output/OpenhpsdrZeus-${{ steps.version.outputs.version }}-macos-${ARCH}.dmg"
+          KEY_PATH="$RUNNER_TEMP/AuthKey.p8"
+
+          # The .p8 secret is stored base64-encoded to avoid newline mangling
+          # in GitHub's secret editor. If you ever rotate the key, paste the
+          # `base64 < AuthKey_XXXXXX.p8` output as the secret value.
+          echo "$APPSTORE_API_KEY_P8" | base64 --decode > "$KEY_PATH"
+
+          # notarytool submit blocks until accepted/invalid (~2-15 min). We
+          # capture stdout to parse the submission ID, then drive the
+          # accept/reject branch from --output-format json status field.
+          # Don't use `set -e` around the submit itself — we want to fetch
+          # the log on rejection before exiting.
+          set +e
+          SUBMIT_OUT=$(xcrun notarytool submit "$DMG_PATH" \
+              --key "$KEY_PATH" \
+              --key-id "$APPSTORE_KEY_ID" \
+              --issuer "$APPSTORE_ISSUER_ID" \
+              --wait \
+              --output-format json)
+          SUBMIT_RC=$?
+          set -e
+          echo "$SUBMIT_OUT"
+
+          # Parse with python3 (preinstalled on macos-latest) rather than jq
+          # to avoid an extra brew install.
+          SUBMISSION_ID=$(echo "$SUBMIT_OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('id',''))" 2>/dev/null || true)
+          STATUS=$(echo "$SUBMIT_OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('status',''))" 2>/dev/null || true)
+
+          if [ "$STATUS" != "Accepted" ] || [ "$SUBMIT_RC" -ne 0 ]; then
+              echo "::error::Notarization failed (status=$STATUS, rc=$SUBMIT_RC, id=$SUBMISSION_ID)"
+              if [ -n "$SUBMISSION_ID" ]; then
+                  echo "::group::notarytool log $SUBMISSION_ID"
+                  xcrun notarytool log "$SUBMISSION_ID" \
+                      --key "$KEY_PATH" \
+                      --key-id "$APPSTORE_KEY_ID" \
+                      --issuer "$APPSTORE_ISSUER_ID" || true
+                  echo "::endgroup::"
+              else
+                  echo "::error::No submission ID returned — submit failed before Apple accepted it. Check network / quota / cert validity."
+              fi
+              rm -P "$KEY_PATH" 2>/dev/null || rm -f "$KEY_PATH"
+              exit 1
+          fi
+
+          rm -P "$KEY_PATH" 2>/dev/null || rm -f "$KEY_PATH"
+          echo "Notarization accepted (id=$SUBMISSION_ID)"
+
+      - name: macOS — staple notarization ticket
+        if: ${{ startsWith(matrix.config.os, 'macos') && (needs.determine-version.outputs.is-release == 'true' || needs.determine-version.outputs.is-nightly == 'true') }}
+        run: |
+          set -euo pipefail
+          ARCH="${{ matrix.config.rid == 'osx-arm64' && 'arm64' || 'x64' }}"
+          DMG_PATH="installers/output/OpenhpsdrZeus-${{ steps.version.outputs.version }}-macos-${ARCH}.dmg"
+          # Stapling embeds the ticket into the DMG so first launch works
+          # offline. Without staple, Gatekeeper has to call out to Apple to
+          # verify notarization on every first launch — which fails for
+          # users behind firewalls / on planes.
+          xcrun stapler staple "$DMG_PATH"
+          xcrun stapler validate "$DMG_PATH"
+
+      - name: macOS — Gatekeeper assess
+        if: ${{ startsWith(matrix.config.os, 'macos') && (needs.determine-version.outputs.is-release == 'true' || needs.determine-version.outputs.is-nightly == 'true') }}
+        run: |
+          set -euo pipefail
+          ARCH="${{ matrix.config.rid == 'osx-arm64' && 'arm64' || 'x64' }}"
+          DMG_PATH="installers/output/OpenhpsdrZeus-${{ steps.version.outputs.version }}-macos-${ARCH}.dmg"
+          # `--type open` is the context Gatekeeper uses when the user
+          # double-clicks the DMG to mount it. Primary-signature context
+          # forces it to read the DMG's own signature, not anything cached.
+          # Any rejection here (e.g. stale notarization, wrong identity)
+          # would fail before users see a broken download.
+          spctl --assess --type open --context context:primary-signature --verbose=2 "$DMG_PATH"
 
       - name: Upload macOS Package
         if: startsWith(matrix.config.os, 'macos')
@@ -610,6 +816,24 @@ jobs:
           name: ${{ matrix.config.artifact }}
           path: installers/output/OpenhpsdrZeus-${{ steps.version.outputs.version }}-macos-*.dmg
           if-no-files-found: error
+
+      # Defensive cleanup — the macos-latest runner is ephemeral and gets
+      # torn down after the job, but explicit removal of the temp keychain
+      # + any leftover .p8/.p12 means a `if: always()` run on a future
+      # runner image that caches $RUNNER_TEMP between jobs won't leak.
+      - name: macOS — clean up signing material
+        if: ${{ always() && startsWith(matrix.config.os, 'macos') && (needs.determine-version.outputs.is-release == 'true' || needs.determine-version.outputs.is-nightly == 'true') }}
+        run: |
+          set +e
+          if [ -n "${KEYCHAIN_PATH:-}" ] && [ -f "$KEYCHAIN_PATH" ]; then
+              security delete-keychain "$KEYCHAIN_PATH"
+          fi
+          rm -P "$RUNNER_TEMP/macos-cert.p12"        2>/dev/null || rm -f "$RUNNER_TEMP/macos-cert.p12"
+          rm -P "$RUNNER_TEMP/AuthKey.p8"            2>/dev/null || rm -f "$RUNNER_TEMP/AuthKey.p8"
+          rm -P "$RUNNER_TEMP/DeveloperIDG2CA.cer"   2>/dev/null || rm -f "$RUNNER_TEMP/DeveloperIDG2CA.cer"
+          # Restore the default user keychain search list to login only.
+          security list-keychains -d user -s login.keychain-db || true
+          true
 
   create-release:
     name: Create GitHub Release
@@ -693,16 +917,9 @@ jobs:
           on GitHub-hosted Actions is too slow to be practical. Build from source
           if you need one.
 
-          **IMPORTANT for macOS users**: After installation, clear the quarantine
-          attribute so Gatekeeper lets Zeus launch:
-
-          ```bash
-          xattr -cr "/Applications/OpenHPSDR Zeus.app"
-          xattr -cr "/Applications/OpenHPSDR Zeus Server.app"
-          ```
-
-          This is required because Zeus is not signed by a registered Apple
-          Developer.
+          The DMG and both `.app` bundles are signed with a Developer ID
+          Application certificate and notarized by Apple, so Gatekeeper
+          accepts them directly — no `xattr -cr` workaround needed.
 
           ### Linux (x64)
           - **openhpsdr-zeus-${{ steps.version.outputs.version }}-linux-x64.tar.gz**
@@ -826,9 +1043,9 @@ jobs:
           - **OpenhpsdrZeus-Server-${{ steps.version.outputs.version }}-linux-x86_64.AppImage** — Linux server AppImage
           - **OpenhpsdrZeus-${{ steps.version.outputs.version }}-macos-arm64.dmg** — macOS Apple Silicon DMG
 
-          macOS users still need to clear the quarantine attribute after
-          install — see the latest tagged release notes for the \`xattr -cr\`
-          command and Linux AppImage dependencies.
+          The macOS DMG is signed and notarized — no \`xattr -cr\` workaround
+          needed even on nightlies. Linux AppImage dependencies are listed
+          in the latest tagged release notes.
 
           ## Changes since ${{ steps.commits.outputs.last-tag }}
           EOF

--- a/.github/workflows/sync-develop-to-experimental.yml
+++ b/.github/workflows/sync-develop-to-experimental.yml
@@ -1,0 +1,153 @@
+name: Sync develop → experimental
+
+# Architectural context: Kb2uka/openhpsdr-zeus uses three long-lived
+# branches with distinct trust levels:
+#
+#   main         — tagged releases only. Code-owner approval required.
+#   develop      — humans (Doug/Brian/Ramón) PR + merge here. Code-owner
+#                  approval required. The "trusted" canonical branch.
+#   experimental — the kb2uka-agent autonomous coding agent commits +
+#                  PRs + auto-merges here. No human approval required
+#                  per-PR. Doug reviews the batch later and promotes
+#                  experimental → develop via a separate PR.
+#
+# experimental must stay a strict superset of develop at all times:
+#   experimental = develop + AI's pending work
+#
+# This workflow keeps them in parity. Every push to develop (a human-
+# reviewed merge, by definition) automatically merges develop INTO
+# experimental so the AI is always working from the latest reviewed
+# baseline.
+#
+# Conflicts are rare — they only happen when the AI and a human both
+# touched the same lines in overlapping work. When that does happen,
+# the workflow doesn't try to be clever — it just opens a PR with the
+# conflict markers visible so Doug can resolve by hand.
+
+on:
+  push:
+    branches: [develop]
+  # Also allow manual trigger from the Actions tab — useful for "I
+  # cherry-picked something onto experimental and now want to re-sync"
+  # or for re-running after a transient failure.
+  workflow_dispatch:
+
+permissions:
+  # The actual write happens via the kb2uka-agent App installation
+  # token (see steps below). These permissions are for any operations
+  # the default GITHUB_TOKEN does — currently just metadata reads.
+  contents: read
+
+concurrency:
+  # Serialise sync attempts so two rapid pushes to develop don't fight
+  # over experimental's tip. Cancel-in-progress=false because the
+  # second push's content needs to land too; we just want to queue.
+  group: sync-develop-experimental
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Merge develop → experimental
+    runs-on: ubuntu-latest
+    steps:
+      # Generate a kb2uka-agent App installation token. Cleaner than a
+      # human-account PAT: rotates every hour, attributed to the bot,
+      # no expiration management. App ID + private key live in repo
+      # secrets (configured 2026-05-13).
+      - name: Generate kb2uka-agent installation token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.KB2UKA_AGENT_APP_ID }}
+          private-key: ${{ secrets.KB2UKA_AGENT_PRIVATE_KEY }}
+
+      # Check out experimental with the App token. Full history needed
+      # so the merge sees both branches' commit graphs.
+      - name: Checkout experimental
+        uses: actions/checkout@v4
+        with:
+          ref: experimental
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      # Attempt the merge. continue-on-error so we can catch conflicts
+      # in the next step rather than failing the whole job opaquely.
+      - name: Merge develop into experimental
+        id: merge
+        continue-on-error: true
+        run: |
+          git config user.name "kb2uka-agent[bot]"
+          git config user.email "kb2uka-agent[bot]@users.noreply.github.com"
+          git fetch origin develop
+
+          # --no-ff so we keep a merge commit in experimental's history
+          # marking each develop sync. Makes the "what came in from
+          # develop on date X" audit trail easy to grep.
+          if git merge --no-edit --no-ff origin/develop -m "chore(sync): merge develop → experimental"; then
+            git push origin experimental
+            echo "result=clean" >> "$GITHUB_OUTPUT"
+            echo "::notice::develop → experimental sync clean ($(git rev-parse --short HEAD))"
+          else
+            echo "result=conflict" >> "$GITHUB_OUTPUT"
+            echo "::warning::develop → experimental sync conflicted; opening PR for manual resolution"
+          fi
+
+      # Conflict path: abort the merge, create a branch with the
+      # conflict markers committed, push it, open a PR. Doug resolves
+      # the PR locally and merges; that merge resolves the conflict
+      # and re-establishes parity.
+      - name: Open conflict PR if merge failed
+        if: steps.merge.outputs.result == 'conflict'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git merge --abort
+          BRANCH="chore/sync-develop-experimental-conflict-${{ github.run_id }}"
+          git checkout -b "$BRANCH"
+
+          # Re-trigger the conflict so the markers land in working
+          # tree, then stage everything including the conflict-marked
+          # files. This creates a commit that the PR diff makes
+          # visually obvious.
+          git merge origin/develop || true
+          git add -A
+          git commit -m "WIP: develop → experimental sync conflict ($(date -Iseconds))" --no-verify || true
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --base experimental \
+            --head "$BRANCH" \
+            --title "chore: sync develop → experimental — CONFLICT (manual resolve required)" \
+            --body "$(cat <<EOF
+          The automated \`develop → experimental\` sync workflow could not merge cleanly. This PR contains the conflicting state as the workflow last saw it — files with merge markers are visible in the diff.
+
+          ## To resolve
+
+          1. Check out this branch locally: \`gh pr checkout <this-pr-number>\`
+          2. Edit each conflict-marked file: pick the correct content, remove the \`<<<<<<<\`/\`=======\`/\`>>>>>>>\` markers
+          3. Commit the resolution: \`git add -A && git commit --amend --no-edit\`
+          4. Force-push to this branch: \`git push --force-with-lease\`
+          5. Merge this PR into experimental (admin merge OK — experimental's protection allows it)
+          6. Auto-sync will resume normally on the next push to develop
+
+          ## Context
+
+          - Triggered by: ${{ github.event_name }}
+          - Run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          - Develop tip at conflict time: \`${{ github.sha }}\`
+
+          🤖 Generated by the \`sync-develop-to-experimental\` workflow.
+          EOF
+          )"
+
+      # Final job status — if merge was clean, we already pushed.
+      # If conflict, we opened a PR. Either way the job exits success
+      # (Doug gets a notification via the PR rather than a workflow
+      # failure email).
+      - name: Summary
+        run: |
+          if [[ "${{ steps.merge.outputs.result }}" == "clean" ]]; then
+            echo "✅ develop → experimental sync clean"
+          else
+            echo "⚠️  develop → experimental sync had conflicts; PR opened for manual resolution"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,13 +149,13 @@ bd close <id>         # Complete work
 
 The auto-generated block above mentions `refs/dolt/data` on the git remote as the default sync path. **Zeus does NOT use that.** Zeus syncs its bd Dolt database to a dedicated public DoltHub repo:
 
-> **DoltHub:** https://www.dolthub.com/repositories/brianbruff/openhpsdr-zeus
+> **DoltHub:** https://www.dolthub.com/repositories/kb2uka/openhpsdr-zeus
 
 ### One-time teammate setup
 
 ```bash
 dolt login                                                                   # browser flow → associate a key
-bd dolt remote add origin https://doltremoteapi.dolthub.com/brianbruff/openhpsdr-zeus
+bd dolt remote add origin https://doltremoteapi.dolthub.com/kb2uka/openhpsdr-zeus
 bd dolt pull origin main                                                     # fetch the team's issues
 ```
 

--- a/Zeus.Contracts/BoardCapabilities.cs
+++ b/Zeus.Contracts/BoardCapabilities.cs
@@ -88,7 +88,15 @@ public sealed record BoardCapabilities(
     /// disabled when this flag is false, so operators can see the
     /// feature exists without being able to drive a non-supporting
     /// board.</summary>
-    bool SupportsAnvelinaDxOc = false)
+    bool SupportsAnvelinaDxOc = false,
+    /// <summary>True when the radio has an on-board audio codec with
+    /// front-panel headphone + microphone jacks (Hermes / Mercury+Penelope
+    /// / ANAN-10/10E/100/100B/100D/200D / OrionMkII family / Anan-G2E).
+    /// When true, demodulated RX audio is routed back to the radio's EP2
+    /// L/R bytes so the operator hears it on the front-panel headphones;
+    /// inbound EP6 mic bytes feed WDSP TXA. False on HermesLite2 (no
+    /// codec — host audio path only). Issue #426.</summary>
+    bool HasOnboardCodec = false)
 {
     /// <summary>Safe defaults for an unrecognised / disconnected board.
     /// Single ADC, no extras — minimum-surprise capability set so a

--- a/Zeus.Contracts/CwEngineStatus.cs
+++ b/Zeus.Contracts/CwEngineStatus.cs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+
+namespace Zeus.Contracts;
+
+/// <summary>
+/// Top-level state of the host-side CW engine. Reported on
+/// <c>CwEngine.Status</c> events and (in a follow-up PR) broadcast over the
+/// streaming hub so the UI macro pad can show queue / playback state.
+/// </summary>
+public enum CwEngineState : byte
+{
+    /// <summary>No message in flight, queue empty.</summary>
+    Idle = 0,
+    /// <summary>Actively playing out a message. MOX is held by Cwx.</summary>
+    Sending = 1,
+    /// <summary>Graceful stop requested — current symbol finishes, then unkey.</summary>
+    Stopping = 2,
+    /// <summary>Hard abort requested — drop immediately, queue cleared.</summary>
+    Aborting = 3,
+}
+
+/// <summary>
+/// Snapshot of the CW engine that <c>CwEngine.SendAsync</c> / completion /
+/// abort transitions emit on the <c>Status</c> event. <see cref="Text"/> is
+/// the message currently being sent (empty when <see cref="State"/> is
+/// <see cref="CwEngineState.Idle"/>); <see cref="Wpm"/> is the requested
+/// speed of that message. <see cref="QueueDepth"/> counts messages still
+/// waiting after the current one.
+/// </summary>
+/// <remarks>
+/// Reason field is optional and only populated on error / abort transitions
+/// (e.g. "not in CW mode", "operator abort", "UI override dropped MOX"). It
+/// surfaces in server logs and — once the streaming-hub frame lands in
+/// PR 2 — in the UI status pill.
+/// </remarks>
+public sealed record CwEngineStatus(
+    CwEngineState State,
+    string Text,
+    int Wpm,
+    int QueueDepth,
+    string? Reason = null);

--- a/Zeus.Contracts/CwEngineStatusFrame.cs
+++ b/Zeus.Contracts/CwEngineStatusFrame.cs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Text;
+
+namespace Zeus.Contracts;
+
+/// <summary>
+/// Wire frame for <see cref="CwEngineStatus"/>. Broadcast on every state
+/// edge of the host-side CW engine so the macro pad can show in-flight
+/// text + queue depth without polling. Format:
+///
+/// <code>
+/// [type:1=0x30][state:u8][wpm:u16 LE][queueDepth:u16 LE]
+/// [textLen:u16 LE][text:UTF-8 textLen bytes]
+/// </code>
+///
+/// 9-byte fixed header + variable text payload. Text is capped at
+/// <see cref="MaxTextBytes"/> so a runaway macro can't blow the wire — the
+/// frontend reconstructs per-character position from <see cref="Wpm"/> +
+/// the local-arrival timestamp (cheap to do client-side; no need to push
+/// per-character progress frames at audio rate).
+///
+/// Wire-frozen: state is <see cref="CwEngineState"/> as a byte; future
+/// additions append-only at the tail.
+/// </summary>
+public readonly record struct CwEngineStatusFrame(
+    CwEngineState State,
+    int Wpm,
+    int QueueDepth,
+    string Text)
+{
+    /// <summary>Hard cap on the text payload — well above any realistic CW
+    /// macro length. Senders that hand us a longer string get truncated to
+    /// this size; the frame stays under one MTU on a typical LAN.</summary>
+    public const int MaxTextBytes = 512;
+
+    public const int HeaderByteLength = 9;
+
+    public void Serialize(IBufferWriter<byte> writer)
+    {
+        // Encode text first so we know the actual byte count (UTF-8 may be
+        // longer than .Length for non-ASCII macros).
+        var rawBytes = Encoding.UTF8.GetBytes(Text ?? string.Empty);
+        int textBytes = Math.Min(rawBytes.Length, MaxTextBytes);
+        int total = HeaderByteLength + textBytes;
+        var span = writer.GetSpan(total);
+        span[0] = (byte)MsgType.CwEngineStatus;
+        span[1] = (byte)State;
+        // Clamp Wpm / QueueDepth to u16 so a logic bug upstream can't write
+        // a wider integer and silently truncate at the bit boundary.
+        ushort wpmU16 = (ushort)Math.Clamp(Wpm, 0, ushort.MaxValue);
+        ushort depthU16 = (ushort)Math.Clamp(QueueDepth, 0, ushort.MaxValue);
+        BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(2, 2), wpmU16);
+        BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(4, 2), depthU16);
+        BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(6, 2), (ushort)textBytes);
+        if (textBytes > 0)
+            rawBytes.AsSpan(0, textBytes).CopyTo(span.Slice(HeaderByteLength, textBytes));
+        writer.Advance(total);
+    }
+
+    public static CwEngineStatusFrame Deserialize(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length < HeaderByteLength)
+            throw new InvalidDataException(
+                $"CwEngineStatusFrame requires ≥{HeaderByteLength} bytes, got {bytes.Length}");
+        if (bytes[0] != (byte)MsgType.CwEngineStatus)
+            throw new InvalidDataException(
+                $"expected CwEngineStatus (0x{(byte)MsgType.CwEngineStatus:X2}), got 0x{bytes[0]:X2}");
+        var state = (CwEngineState)bytes[1];
+        int wpm = BinaryPrimitives.ReadUInt16LittleEndian(bytes.Slice(2, 2));
+        int depth = BinaryPrimitives.ReadUInt16LittleEndian(bytes.Slice(4, 2));
+        int textLen = BinaryPrimitives.ReadUInt16LittleEndian(bytes.Slice(6, 2));
+        if (HeaderByteLength + textLen > bytes.Length)
+            throw new InvalidDataException(
+                $"CwEngineStatusFrame textLen {textLen} exceeds payload");
+        string text = textLen == 0
+            ? string.Empty
+            : Encoding.UTF8.GetString(bytes.Slice(HeaderByteLength, textLen));
+        return new CwEngineStatusFrame(state, wpm, depth, text);
+    }
+
+    /// <summary>Lift a <see cref="CwEngineStatus"/> into the wire shape.</summary>
+    public static CwEngineStatusFrame FromStatus(CwEngineStatus s) =>
+        new(s.State, s.Wpm, s.QueueDepth, s.Text ?? string.Empty);
+}

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -404,10 +404,34 @@ public sealed record TunSetRequest(bool On);
 
 // /api/cw/send body. Text is the ASCII transcript to key out; Wpm is the
 // playback speed (PARIS-method words per minute, clamped to 5..50 at the
-// engine seam). Wpm null means "use the operator's stored default" — at the
-// moment that's a fixed engine default; PR 2 hooks it into a persisted
-// CwSettingsStore.
+// engine seam). Wpm null means "use the operator's stored CwSettings.Wpm
+// default" (CwSettingsStore — written by /api/cw/settings).
 public sealed record CwSendRequest(string Text, int? Wpm = null);
+
+// Persisted CW operator settings. Wpm is the default speed for new sends
+// when /api/cw/send is called without an explicit wpm. FarnsworthWpm is
+// the character-rate floor for Farnsworth spacing (null = pure WPM, no
+// Farnsworth). Macros is exactly six slots — the macro pad is a fixed
+// 2×3 grid; empty strings are valid (renders a "(empty)" button). The
+// sidetone fields are surfaced here so the UI sliders persist alongside
+// the macros, even though sidetone audio routing itself lands later
+// (zeus-5ue) — keeps the wire shape stable across the epic.
+public sealed record CwSettingsDto(
+    int Wpm,
+    int? FarnsworthWpm,
+    string[] Macros,
+    double SidetoneGainDb,
+    int SidetoneHz);
+
+// PATCH-shaped: every field nullable so the frontend can save one slider
+// (or one macro) without re-sending the whole record. Server merges on top
+// of the persisted row before applying.
+public sealed record CwSettingsSetRequest(
+    int? Wpm = null,
+    int? FarnsworthWpm = null,
+    string[]? Macros = null,
+    double? SidetoneGainDb = null,
+    int? SidetoneHz = null);
 
 public sealed record MicGainSetRequest(int Db);
 

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -577,21 +577,41 @@ public sealed record Hl2OptionsSetRequest(bool BandVolts);
 // "image"; Fit is one of "fit" | "fill" | "stretch". Image bytes are NOT
 // shipped in this DTO; HasImage signals whether GET /api/display-settings/image
 // will return content. RxTraceColor is the panadapter signal trace colour
-// as #RRGGBB (default "#FFA028"). All fields persisted server-side so the
-// settings follow the operator across browsers / devices — Photino desktop
-// mode in particular binds the webview to a fresh random loopback port on
-// every launch, which orphans any per-origin localStorage value.
+// as #RRGGBB (default "#FFA028"). Db* fields are the panadapter/waterfall dB
+// window bounds persisted so the operator's scale survives a backend restart.
+// Null means the server has never stored that field; the frontend falls back
+// to its built-in defaults (FIXED_DB_MIN / TX_FIXED_DB_MIN etc.) and pushes
+// the current value up on next interaction. All fields persisted server-side
+// so the settings follow the operator across browsers / devices — Photino
+// desktop mode in particular binds the webview to a fresh random loopback
+// port on every launch, which orphans any per-origin localStorage value.
 public sealed record DisplaySettingsDto(
     string Mode,
     string Fit,
     bool HasImage,
     string? ImageMime,
-    string RxTraceColor);
+    string RxTraceColor,
+    double? DbMin,
+    double? DbMax,
+    double? TxDbMin,
+    double? TxDbMax,
+    double? WfDbMin,
+    double? WfDbMax,
+    double? WfTxDbMin,
+    double? WfTxDbMax);
 
 public sealed record DisplaySettingsSetRequest(
     string Mode,
     string Fit,
-    string RxTraceColor);
+    string RxTraceColor,
+    double? DbMin = null,
+    double? DbMax = null,
+    double? TxDbMin = null,
+    double? TxDbMax = null,
+    double? WfDbMin = null,
+    double? WfDbMax = null,
+    double? WfTxDbMin = null,
+    double? WfTxDbMax = null);
 
 // Per-mode disclosure state for the inline NR settings accordion that hangs
 // below the DSP NR toggle row. Three independent booleans — one per NR

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -162,6 +162,23 @@ public sealed record StateDto(
     // yet; when multi-RX lands this becomes the master and the per-RX
     // values layer on top.
     double RxAfGainDb = 0.0,
+    // TX mic gain in dB. WDSP applies via SetTXAPanelGain1(10^(db/20)); the
+    // server stores the operator-friendly dB and converts at the engine seam.
+    // Range matches the /api/mic-gain endpoint clamp ([-40, +10]) which in
+    // turn matches Thetis's MicGainMin/Max defaults (console.cs:19151/19163).
+    // Persisted server-side via RadioStateStore so a fresh frontend connect
+    // (or a desktop relaunch that wiped localStorage) lands on the last
+    // operator value instead of the engine's 0 dB seed. Wire name omits the
+    // Tx prefix to match the existing /api/mic-gain endpoint POST response.
+    int MicGainDb = 0,
+    // TX Leveler max-gain ceiling in dB. Range [0, 15] — 0 disables the
+    // headroom entirely, 15 matches Thetis's stock ceiling
+    // (radio.cs:2979 tx_leveler_max_gain = 15.0). Default 8.0 matches
+    // WdspDspEngine.DefaultLevelerMaxGainDb (Brian's HL2 starting point;
+    // softer than Thetis stock). Persisted server-side; previously
+    // localStorage-only on the client and reverted on every restart. Wire
+    // name matches the existing /api/tx/leveler-max-gain endpoint response.
+    double LevelerMaxGainDb = 8.0,
     // Auto-AGC control loop. When on, the server automatically adjusts
     // AgcTopDb based on signal conditions. Similar to Auto-ATT but for AGC.
     // Default is OFF — operator must explicitly enable. The control loop

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -256,21 +256,15 @@ public sealed record StateDto(
     // would make pressing TUN appear to do nothing on first key.
     int TunePct = 10,
 
-    // ---- CTUN (Click-Tune) — issue #427 ----
-    // When CtunEnabled is false (default), VfoHz drives both the radio's
-    // hardware NCO and the panadapter centre — clicking the spectrum retunes
-    // the radio. When true, the hardware NCO is frozen at RadioLoHz and
-    // clicking only moves VfoHz around within the displayed bandwidth; WDSP's
-    // RX bandpass is shifted by (VfoHz - RadioLoHz) so the audio still
-    // resolves the operator's tuned signal. Mirrors Thetis chkFWCATU /
-    // ClickTuneDisplay (console.cs:43143-43170, 10857-10867).
-    bool CtunEnabled = false,
-    // Hardware NCO frequency in Hz. Tracks VfoHz when CTUN is OFF; frozen at
-    // the value VfoHz had when CTUN was toggled ON. RadioService is
+    // Hardware NCO frequency in Hz. Independent of VfoHz: the dial roams over
+    // the sampled spectrum while the radio's hardware centre stays put.
+    // Updated only by explicit calls to <c>POST /api/radio/lo</c> (or by the
+    // band-change / reconnect paths inside RadioService). RadioService is
     // authoritative; persisted to LiteDB so the radio re-tunes to the same
-    // hardware centre on reconnect when CTUN was on. Zero on a fresh server
-    // before the first state hydration; RadioService snaps it to VfoHz at
-    // construction so the displayed centre is never zero.
+    // hardware centre on reconnect. Zero on a fresh server before the first
+    // state hydration; RadioService snaps it to VfoHz at construction so the
+    // displayed centre is never zero. Mirrors Thetis CTUN's frozen-NCO model
+    // (console.cs:43143-43170), now Zeus's only tuning model.
     long RadioLoHz = 0);
 
 public sealed record RadioInfo(
@@ -295,7 +289,11 @@ public sealed record ConnectRequest(
 
 public sealed record VfoSetRequest(long Hz);
 
-public sealed record CtunSetRequest(bool Enabled);
+/// <summary>Set the hardware NCO (radio LO) frequency in Hz. Does not move
+/// the operator's tuned frequency (VfoHz). Used by the panadapter pure-pan
+/// gesture when a drag would otherwise carry the viewport outside the IQ
+/// capture window. Out-of-range values are rejected with 400.</summary>
+public sealed record RadioLoSetRequest(long Hz);
 
 public sealed record ModeSetRequest(RxMode Mode);
 

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -635,6 +635,15 @@ public sealed record BottomPinSetRequest(
     bool Logbook,
     bool TxMeters);
 
+// Vertical split between the panadapter and the waterfall in the Hero
+// panel. PanPercent is the panadapter share, clamped 10..90; the
+// waterfall takes the remainder. Single global value for now. Persisted
+// server-side in zeus-prefs.db (same pattern as BottomPinDto) so the
+// choice follows the operator across browsers / devices.
+public sealed record PanWfSplitDto(double PanPercent);
+
+public sealed record PanWfSplitSetRequest(double PanPercent);
+
 // ---- PureSignal request records ----
 // PsControlSetRequest = master arm (Enabled) + mode (Auto vs Single).
 // PsAdvancedSetRequest = nullable so partial updates from the settings

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -282,7 +282,22 @@ public sealed record StateDto(
     // state hydration; RadioService snaps it to VfoHz at construction so the
     // displayed centre is never zero. Mirrors Thetis CTUN's frozen-NCO model
     // (console.cs:43143-43170), now Zeus's only tuning model.
-    long RadioLoHz = 0);
+    long RadioLoHz = 0,
+
+    // CW sidetone pitch in Hz. Currently a baked-in constant
+    // (CwDefaults.PitchHz); will become a user-settable preference
+    // (Thetis: Setup → DSP → Keyer → CW Pitch). On the wire now so
+    // the frontend already consumes the live value — when the setting
+    // lands, only the server-side source changes.
+    int CwPitchHz = CwDefaults.PitchHz);
+
+/// <summary>Canonical CW constants shared between backend and wire DTOs.
+/// Single source of truth — CwOffset (server-side) and StateDto both
+/// reference these instead of duplicating magic numbers.</summary>
+public static class CwDefaults
+{
+    public const int PitchHz = 600;
+}
 
 public sealed record RadioInfo(
     string MacAddress,

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -402,6 +402,13 @@ public sealed record AutoAgcSetRequest(bool Enabled);
 
 public sealed record TunSetRequest(bool On);
 
+// /api/cw/send body. Text is the ASCII transcript to key out; Wpm is the
+// playback speed (PARIS-method words per minute, clamped to 5..50 at the
+// engine seam). Wpm null means "use the operator's stored default" — at the
+// moment that's a fixed engine default; PR 2 hooks it into a persisted
+// CwSettingsStore.
+public sealed record CwSendRequest(string Text, int? Wpm = null);
+
 public sealed record MicGainSetRequest(int Db);
 
 // Leveler max-gain ceiling in dB. Server clamps to [0, 15]; outside that is

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -670,12 +670,21 @@ public sealed record PanWfSplitSetRequest(double PanPercent);
 //     value. Trim for real-world antenna / coax / preamp combinations
 //     that shift the WDSP-internal reading. Clamped ±20 dB on the
 //     server. Display-only — does not touch WDSP or the radio.
+//   * MaxDisplayedWatts — operator override for the TX forward-power
+//     meter full scale, in Watts. Lets an operator set e.g. 25 W on
+//     a 100 W bracket so the indication fills the bar. Clamped
+//     [1, 1000] W when non-zero. 0 = "no override, use the radio's
+//     MaxWatts as the bar's full scale" (the historical behaviour).
 //
-// Persisted server-side in zeus-prefs.db (single-row pattern). Default
-// is 0.0 dB.
-public sealed record MeterDisplaySettingsDto(double SMeterOffsetDb);
+// Persisted server-side in zeus-prefs.db (single-row pattern).
+// Defaults: SMeterOffsetDb=0.0, MaxDisplayedWatts=0.0 (no override).
+public sealed record MeterDisplaySettingsDto(
+    double SMeterOffsetDb,
+    double MaxDisplayedWatts);
 
 public sealed record SMeterOffsetSetRequest(double OffsetDb);
+
+public sealed record MaxDisplayedWattsSetRequest(double MaxWatts);
 
 // ---- PureSignal request records ----
 // PsControlSetRequest = master arm (Enabled) + mode (Auto vs Single).

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -664,6 +664,19 @@ public sealed record PanWfSplitDto(double PanPercent);
 
 public sealed record PanWfSplitSetRequest(double PanPercent);
 
+// Per-operator display-side meter calibration knobs (GitHub #426).
+//
+//   * SMeterOffsetDb — signed dB offset added to the displayed RX dBm
+//     value. Trim for real-world antenna / coax / preamp combinations
+//     that shift the WDSP-internal reading. Clamped ±20 dB on the
+//     server. Display-only — does not touch WDSP or the radio.
+//
+// Persisted server-side in zeus-prefs.db (single-row pattern). Default
+// is 0.0 dB.
+public sealed record MeterDisplaySettingsDto(double SMeterOffsetDb);
+
+public sealed record SMeterOffsetSetRequest(double OffsetDb);
+
 // ---- PureSignal request records ----
 // PsControlSetRequest = master arm (Enabled) + mode (Auto vs Single).
 // PsAdvancedSetRequest = nullable so partial updates from the settings

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -585,6 +585,12 @@ public sealed record Hl2OptionsSetRequest(bool BandVolts);
 // so the settings follow the operator across browsers / devices — Photino
 // desktop mode in particular binds the webview to a fresh random loopback
 // port on every launch, which orphans any per-origin localStorage value.
+// WfBrightness is an operator-tunable multiplier applied to the colormap
+// input in the waterfall fragment shader (gl/shaders.ts WF_FS). 1.0 = no
+// change, < 1.0 darkens, > 1.0 brightens. Null means the server has never
+// stored a value; the frontend uses its built-in default (WF_BRIGHTNESS_DEFAULT
+// in display-settings-store.ts) and pushes the current value up on next
+// interaction. See issue #426 / bd zeus-lez.
 public sealed record DisplaySettingsDto(
     string Mode,
     string Fit,
@@ -598,7 +604,8 @@ public sealed record DisplaySettingsDto(
     double? WfDbMin,
     double? WfDbMax,
     double? WfTxDbMin,
-    double? WfTxDbMax);
+    double? WfTxDbMax,
+    double? WfBrightness);
 
 public sealed record DisplaySettingsSetRequest(
     string Mode,
@@ -611,7 +618,8 @@ public sealed record DisplaySettingsSetRequest(
     double? WfDbMin = null,
     double? WfDbMax = null,
     double? WfTxDbMin = null,
-    double? WfTxDbMax = null);
+    double? WfTxDbMax = null,
+    double? WfBrightness = null);
 
 // Per-mode disclosure state for the inline NR settings accordion that hangs
 // below the DSP NR toggle row. Three independent booleans — one per NR

--- a/Zeus.Contracts/MoxSource.cs
+++ b/Zeus.Contracts/MoxSource.cs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+
+namespace Zeus.Contracts;
+
+/// <summary>
+/// Identifies who keyed MOX so the release path can refuse to drop the
+/// transmitter on behalf of a different source. Without this tag, a TCI
+/// peer's "trx false" while the CW engine is mid-message would silently
+/// truncate the transmission, and a hardware-PTT falling edge while a UI
+/// click is holding MOX would do the same in the other direction.
+///
+/// Release rule (enforced in <c>TxService.TrySetMox</c>):
+/// <list type="bullet">
+///   <item><c>UI</c> always wins — the operator's on-screen button is the
+///         master override and can release MOX no matter who claimed it.</item>
+///   <item>Any other source can release only what it itself claimed.</item>
+///   <item><c>TxService.TryTripForAlert</c> bypasses the check entirely —
+///         SWR / timeout trips must always cut RF.</item>
+/// </list>
+///
+/// Wire-stable byte values — appending only. Callers that don't care about
+/// the source path may pass <see cref="UI"/> and get the legacy behaviour.
+/// </summary>
+public enum MoxSource : byte
+{
+    /// <summary>The on-screen MOX button, REST <c>/api/tx/mox</c>, or any
+    /// in-process default. Master override.</summary>
+    UI = 0,
+    /// <summary>A TCI peer (MSHV, JTDX, …) keyed via <c>trx:true</c>.</summary>
+    Tci = 1,
+    /// <summary>Hardware PTT input (foot switch, mic PTT, hand key) read
+    /// through the radio's protocol C&amp;C status path.</summary>
+    Hardware = 2,
+    /// <summary>The host-side CW engine driving keying from
+    /// <c>/api/cw/send</c>.</summary>
+    Cwx = 3,
+}

--- a/Zeus.Contracts/MsgType.cs
+++ b/Zeus.Contracts/MsgType.cs
@@ -153,4 +153,14 @@ public enum MsgType : byte
     // Payload: [type:1][bypassed:u8] = 2 bytes total. See
     // AudioMasterBypassFrame.cs.
     AudioMasterBypass = 0x1F,
+
+    // Server → client (CW engine status). Broadcast on every state edge of
+    // the host-side CW keyer (Idle ↔ Sending, Stopping, Aborting). Carries
+    // enough context for the UI macro pad to show what's in flight and how
+    // much queue is left without polling. Payload: [type:1][state:u8]
+    // [wpm:u16 LE][queueDepth:u16 LE][textLen:u16 LE][text:UTF-8…].
+    // See CwEngineStatusFrame.cs. New nibble 0x3x for control-plane
+    // feedback frames (0x1x is full); UI ignores unknown types so older
+    // builds tolerate this cleanly.
+    CwEngineStatus = 0x30,
 }

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -1176,11 +1176,12 @@ public sealed class WdspDspEngine : IDspEngine
             // enabled here to match that default — a disabled Leveler stage
             // also leaves GetTXAMeter(LVLR_PK) stuck at WDSP's -400 silence
             // sentinel, which made the frontend LVLR bar look broken. Other
-            // stages (Compressor, CFC, PHROT, osctrl, EQ, AMSQ) remain OFF
+            // optional stages (Compressor, CFC, PHROT, EQ, AMSQ) remain OFF
             // until they're wired to operator UI and tuned — enabling them
             // with library-default parameters can mask or create distortion.
             // ALC stays on (see SetTXAALCSt below; never 0). AMSQ is the mic
-            // noise gate and shouldn't shape SSB audio.
+            // noise gate and shouldn't shape SSB audio. CESSB (osctrl) is
+            // unconditionally ON — see SetTXAosctrlRun below.
             NativeMethods.SetTXALevelerSt(id, 1);
             // Leveler max-gain default. WDSP's create_wcpagc ships with
             // max_gain = 1.778 linear (≈ +5 dB) at TXA.c:169; we assert the
@@ -1193,7 +1194,16 @@ public sealed class WdspDspEngine : IDspEngine
             NativeMethods.SetTXACompressorRun(id, 0);
             NativeMethods.SetTXACFCOMPRun(id, 0);
             NativeMethods.SetTXAPHROTRun(id, 0);
-            NativeMethods.SetTXAosctrlRun(id, 0);
+            // CESSB (Controlled Envelope SSB) — unconditionally ON. Mirrors
+            // Thetis's WDSP entry point (dsp.cs:240 SetTXAosctrlRun) but
+            // without a user toggle: KISS, always on. WDSP's create_osctrl
+            // (TXA.c) ships sensible defaults (bandpass overshoot control on
+            // the SSB envelope) and no further setters are required —
+            // Thetis itself only ever calls SetTXAosctrlRun. Leaving CESSB
+            // off costs ~1–1.5 dB of average power on voice SSB; there is
+            // no operator scenario in which off is preferable, so no prefs
+            // key, no REST endpoint, no UI control. See bd zeus-5cg.
+            NativeMethods.SetTXAosctrlRun(id, 1);
             NativeMethods.SetTXAEQRun(id, 0);
             NativeMethods.SetTXAAMSQRun(id, 0);
             NativeMethods.SetTXAALCSt(id, 1);
@@ -1324,7 +1334,7 @@ public sealed class WdspDspEngine : IDspEngine
             }
 
             _log.LogInformation(
-                "wdsp.openTxChannel id={Id} rates={InRate}/{DspRate}/{OutRate} sizes={InSz}/{OutSz} cfir={Cfir} chain=[alc=1 lvlr=1 lvlrMax={LvlrMax:F1}dB cpdr=0 cfc=0 phrot=0 osctrl=0 eq=0 amsq=0] bp=150..2850 panelGain=1.0 txDisp={TxDisp}(pix={Pix} rxRate={RxRate} txRate={TxRate} zoom={Zoom})",
+                "wdsp.openTxChannel id={Id} rates={InRate}/{DspRate}/{OutRate} sizes={InSz}/{OutSz} cfir={Cfir} chain=[alc=1 lvlr=1 lvlrMax={LvlrMax:F1}dB cpdr=0 cfc=0 phrot=0 osctrl=1 eq=0 amsq=0] bp=150..2850 panelGain=1.0 txDisp={TxDisp}(pix={Pix} rxRate={RxRate} txRate={TxRate} zoom={Zoom})",
                 id, _txaInputRateHz, _txaDspRateHz, _txaOutputRateHz,
                 _txaInSize, _txaOutSize, _txaCfirRun ? 1 : 0, DefaultLevelerMaxGainDb,
                 _txDispAlive ? "on" : "off", _txDispPixelWidth, _txDispRxSampleRateHz, _txaOutputRateHz, _txDispZoomLevel);

--- a/Zeus.Protocol1/ControlFrame.cs
+++ b/Zeus.Protocol1/ControlFrame.cs
@@ -465,7 +465,8 @@ internal static class ControlFrame
         CcRegister evenRegister,
         CcRegister oddRegister,
         in CcState state,
-        ITxIqSource? iqSource = null)
+        ITxIqSource? iqSource = null,
+        IRxCodecAudioSource? audioSource = null)
     {
         if (packet.Length != PacketLength)
             throw new ArgumentException("packet span must be 1032 bytes", nameof(packet));
@@ -479,8 +480,8 @@ internal static class ControlFrame
         packet[3] = 0x02;
         BinaryPrimitives.WriteUInt32BigEndian(packet[4..8], sendSequence);
 
-        WriteUsbFrame(packet.Slice(8, UsbFrameLength), evenRegister, in state, iqSource);
-        WriteUsbFrame(packet.Slice(8 + UsbFrameLength, UsbFrameLength), oddRegister, in state, iqSource);
+        WriteUsbFrame(packet.Slice(8, UsbFrameLength), evenRegister, in state, iqSource, audioSource);
+        WriteUsbFrame(packet.Slice(8 + UsbFrameLength, UsbFrameLength), oddRegister, in state, iqSource, audioSource);
     }
 
     /// <summary>
@@ -499,7 +500,12 @@ internal static class ControlFrame
     /// <summary>Number of IQ samples per 504-byte EP2 USB-frame payload (63 × 8 bytes).</summary>
     internal const int IqSamplesPerUsbFrame = 63;
 
-    private static void WriteUsbFrame(Span<byte> frame, CcRegister register, in CcState state, ITxIqSource? source)
+    private static void WriteUsbFrame(
+        Span<byte> frame,
+        CcRegister register,
+        in CcState state,
+        ITxIqSource? iqSource,
+        IRxCodecAudioSource? audioSource)
     {
         frame[0] = 0x7F;
         frame[1] = 0x7F;
@@ -514,19 +520,26 @@ internal static class ControlFrame
         LastDriveByte = state.DriveLevel;
 
         // EP2 504-byte payload = 63 groups × 8 bytes, each group =
-        // [L_audio s16 BE][R_audio s16 BE][I s16 BE][Q s16 BE]
-        // (both the audio ring fill and the IQ ring fill write into the same
-        // 8-byte slot). HL2 has no audio codec in the MVP target, so audio
-        // bytes stay zero. The LSB of I and Q low bytes is masked off
-        // (`isample & 0xFE`) — originally an HL2 CWX workaround; harmless
-        // ≤1 LSB precision loss on other Protocol-1 boards.
+        // [L_audio s16 BE][R_audio s16 BE][I s16 BE][Q s16 BE].
+        // The wire format is identical across every Protocol-1 board (HL2,
+        // Hermes, ANAN-class, Orion-MkII). HL2 has no on-board audio codec
+        // so its L/R bytes are ignored by the firmware; every other P1 board
+        // routes them to the front-panel headphone jack via the on-board
+        // codec. The IQ LSB mask (`isample & 0xFE`) is an HL2 CWX workaround
+        // — harmless ≤1 LSB precision loss on other P1 boards. PA enable is
+        // driven by the C0 MOX bit + board-specific DriveFilter C2 bits in
+        // WriteCcBytes — see issue #294.
         //
-        // Pre-conditions for writing a non-zero payload: MOX engaged and an IQ
-        // source is plumbed through. The wire format (L/R audio + I/Q s16 BE)
-        // is identical across all Protocol-1 boards (HL2, Hermes, ANAN-class,
-        // Orion-MkII). PA enable is driven by the C0 MOX bit + board-specific
-        // DriveFilter C2 bits in WriteCcBytes — see issue #294.
-        if (source is null || !state.Mox)
+        // Pre-conditions:
+        //   IQ payload writes  → MOX engaged AND iqSource non-null AND DriveLevel > 0
+        //   Audio L/R writes   → audioSource non-null (any MOX state; the source
+        //                        returns (0,0) when its ring is empty — same as
+        //                        leaving the bytes zero, but lets RX audio reach
+        //                        the radio's headphone jack on Hermes / ANAN
+        //                        / OrionMkII boards). Issue #426.
+        bool writeIq    = iqSource is not null && state.Mox && state.DriveLevel > 0;
+        bool writeAudio = audioSource is not null;
+        if (!writeIq && !writeAudio)
         {
             // frame[8..] was cleared by BuildDataPacket; leave zero.
             return;
@@ -537,12 +550,7 @@ internal static class ControlFrame
         // (drive⁴ power response). Send at unity — WDSP's ALC already clamps
         // the TXA output to ≤ 0 dBFS and the TUN post-gen tone is a
         // fixed-amplitude single-tone carrier, so neither source can overshoot
-        // +1.0 here. The prior 0.85 factor cost ~1.4 dB of achievable output
-        // and was observed to leave HL2 at 1.2 W when deskHPSDR hit 6.6 W on
-        // the same antenna/band; it was belt-and-suspenders on top of ALC.
-        // At DriveLevel=0 the HL2 TXG is already 0 (silent), but zero the IQ
-        // too so the wire bytes are silent regardless of board.
-        if (state.DriveLevel == 0) return;
+        // +1.0 here.
         const double amplitude = 1.0;
 
         var payload = frame[8..];
@@ -551,24 +559,37 @@ internal static class ControlFrame
         int firstI = 0, firstQ = 0;
         for (int s = 0; s < IqSamplesPerUsbFrame; s++)
         {
-            var (iSample, qSample) = source.Next(amplitude);
-            if (s == 0) { firstI = iSample; firstQ = qSample; }
-            int ai = Math.Abs((int)iSample);
-            int aq = Math.Abs((int)qSample);
-            if (ai > peak) peak = ai;
-            if (aq > peak) peak = aq;
-            sumAbs += ai + aq;
             int off = s * 8;
-            // Audio L/R stay zero (payload was cleared).
-            payload[off + 4] = (byte)((iSample >> 8) & 0xFF);
-            payload[off + 5] = (byte)(iSample & 0xFE);
-            payload[off + 6] = (byte)((qSample >> 8) & 0xFF);
-            payload[off + 7] = (byte)(qSample & 0xFE);
+            if (writeAudio)
+            {
+                var (l, r) = audioSource!.Next();
+                payload[off + 0] = (byte)((l >> 8) & 0xFF);
+                payload[off + 1] = (byte)(l & 0xFF);
+                payload[off + 2] = (byte)((r >> 8) & 0xFF);
+                payload[off + 3] = (byte)(r & 0xFF);
+            }
+            if (writeIq)
+            {
+                var (iSample, qSample) = iqSource!.Next(amplitude);
+                if (s == 0) { firstI = iSample; firstQ = qSample; }
+                int ai = Math.Abs((int)iSample);
+                int aq = Math.Abs((int)qSample);
+                if (ai > peak) peak = ai;
+                if (aq > peak) peak = aq;
+                sumAbs += ai + aq;
+                payload[off + 4] = (byte)((iSample >> 8) & 0xFF);
+                payload[off + 5] = (byte)(iSample & 0xFE);
+                payload[off + 6] = (byte)((qSample >> 8) & 0xFF);
+                payload[off + 7] = (byte)(qSample & 0xFE);
+            }
         }
-        LastPeakAbs = peak;
-        LastMeanAbs = (int)(sumAbs / (2 * IqSamplesPerUsbFrame));
-        LastFirstI = firstI;
-        LastFirstQ = firstQ;
+        if (writeIq)
+        {
+            LastPeakAbs = peak;
+            LastMeanAbs = (int)(sumAbs / (2 * IqSamplesPerUsbFrame));
+            LastFirstI = firstI;
+            LastFirstQ = firstQ;
+        }
     }
 
     // Diagnostic tap — read by Protocol1Client.TxLoopAsync to log what's

--- a/Zeus.Protocol1/IProtocol1Client.cs
+++ b/Zeus.Protocol1/IProtocol1Client.cs
@@ -128,6 +128,24 @@ public interface IProtocol1Client : IDisposable
     event Action<AdcOverloadStatus>? AdcOverloadObserved;
 
     /// <summary>
+    /// Raised on a level change of the hardware-PTT echo bit (C0[0]) coming
+    /// back from the radio. On HL2 the gateware ORs in the rear KEY tip and
+    /// the external PTT line, so this rises whenever the operator keys the
+    /// radio directly without going through the host. It ALSO rises as a
+    /// loopback of any host-issued <see cref="SetMox(bool)"/>, so consumers
+    /// must check the host's current MOX/TUN state to disambiguate.
+    /// Edge-triggered: handler is called once per change. Fires on the RX
+    /// thread; handlers must not block.
+    /// </summary>
+    event Action<bool>? HardwarePttChanged;
+
+    /// <summary>
+    /// Latest hardware-PTT echo level. Volatile; safe to read from any
+    /// thread. Updated from the RX loop on every received EP6 packet.
+    /// </summary>
+    bool HardwarePtt { get; }
+
+    /// <summary>
     /// Select the radio's wire-level board family. Affects the extended
     /// attenuator byte layout (HL2 vs bare HPSDR) and the N2ADR filter-board
     /// OC pin encoding. Defaults to <see cref="HpsdrBoardKind.HermesLite2"/>.

--- a/Zeus.Protocol1/IRxCodecAudioSource.cs
+++ b/Zeus.Protocol1/IRxCodecAudioSource.cs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.Protocol1;
+
+/// <summary>
+/// Supplies one (L, R) s16 audio sample pair per call for the EP2
+/// outbound 8-byte slot's L/R audio bytes (offsets 0..3). Used on boards
+/// with an on-board audio codec (Hermes / Mercury / ANAN-class / OrionMkII
+/// / G2E) so the operator can plug headphones into the radio's front-panel
+/// jack and hear demodulated RX audio.
+///
+/// HermesLite2 has no on-board codec — these bytes are ignored by the radio.
+/// On HL2 we simply don't register a source and the EP2 audio bytes stay
+/// zero (the existing pre-#426 behaviour).
+///
+/// Implementations must be safe for the single reader (the Protocol1 TX
+/// loop) — they're polled 63 times per USB frame, twice per Metis packet,
+/// ~1500 calls/sec at the 750 packet/sec EP2 rate. Cross-thread writes
+/// (from the DSP audio sink) need to be safe relative to that reader.
+/// </summary>
+public interface IRxCodecAudioSource
+{
+    /// <summary>
+    /// Return the next (L, R) audio sample pair. Implementations that have
+    /// no data return (0, 0); the wire bytes go out as silence, matching
+    /// HL2 / pre-codec behaviour.
+    /// </summary>
+    (short L, short R) Next();
+}

--- a/Zeus.Protocol1/PacketParser.cs
+++ b/Zeus.Protocol1/PacketParser.cs
@@ -98,6 +98,28 @@ internal static class PacketParser
     private const double Int24Scale = 1.0 / 8_388_608.0; // 1 / 2^23
 
     /// <summary>
+    /// Extract the hardware-PTT echo bit from a parsed EP6 packet — C0[0] of
+    /// each USB frame OR'd together. The HL2 gateware sets this whenever the
+    /// rear KEY tip is grounded or an external PTT line is asserted (HL2
+    /// protocol doc §"Hermes Lite 2-specific behaviour", line 200): "When the
+    /// tip is grounded, both C0[0] and C0[2] are sent as one." Same wire bit
+    /// also echoes a host-driven MOX request, so consumers MUST gate on the
+    /// host's current MOX state to disambiguate "external key" from "echo of
+    /// our own outbound MOX".
+    /// </summary>
+    /// <returns>true if either USB frame's C0[0] is set, false otherwise.
+    /// Returns false for packets shorter than expected (the only caller has
+    /// already validated length via <see cref="TryParsePacket(System.ReadOnlySpan{byte},System.Span{double},out uint,out int)"/>).</returns>
+    public static bool ExtractHardwarePtt(ReadOnlySpan<byte> packet)
+    {
+        if (packet.Length < PacketLength) return false;
+        // usb[3] is c0; bit 0 is the PTT/MOX echo.
+        byte c0Frame0 = packet[MetisHeaderLength + 3];
+        byte c0Frame1 = packet[MetisHeaderLength + UsbFrameLength + 3];
+        return ((c0Frame0 | c0Frame1) & 0x01) != 0;
+    }
+
+    /// <summary>
     /// Read a 24-bit big-endian signed integer with sign-extension to int32.
     /// </summary>
     public static int ReadInt24BigEndian(ReadOnlySpan<byte> b)

--- a/Zeus.Protocol1/Protocol1Client.cs
+++ b/Zeus.Protocol1/Protocol1Client.cs
@@ -132,10 +132,21 @@ public sealed class Protocol1Client : IProtocol1Client
     // the tone so legacy callers (tests, tools/zeus-dump) keep working.
     private readonly ITxIqSource _txIqSource;
 
-    public Protocol1Client(ILogger<Protocol1Client>? logger = null, ITxIqSource? iqSource = null)
+    // RX-codec audio source: WDSP demodulated audio routed back to the
+    // radio's on-board codec so operators can plug headphones into the
+    // radio's front-panel jack and hear receive audio (issue #426).
+    // Null on HL2 / discovery-only callers; the EP2 L/R audio bytes stay
+    // zero and the radio ignores them, matching pre-#426 behaviour.
+    private readonly IRxCodecAudioSource? _rxCodecAudioSource;
+
+    public Protocol1Client(
+        ILogger<Protocol1Client>? logger = null,
+        ITxIqSource? iqSource = null,
+        IRxCodecAudioSource? rxCodecAudioSource = null)
     {
         _log = logger ?? NullLogger<Protocol1Client>.Instance;
         _txIqSource = iqSource ?? new TestToneGenerator();
+        _rxCodecAudioSource = rxCodecAudioSource;
         _channel = Channel.CreateBounded<IqFrame>(new BoundedChannelOptions(DefaultFrameChannelCapacity)
         {
             FullMode = BoundedChannelFullMode.DropOldest,
@@ -998,7 +1009,7 @@ public sealed class Protocol1Client : IProtocol1Client
                 bool psArmed = state.PsEnabled && state.Board == HpsdrBoardKind.HermesLite2;
                 var (first, second) = PhaseRegisters(phase, state.Mox, psArmed);
                 phase = (phase + 1) & (psArmed ? 0xF : 0x3);
-                ControlFrame.BuildDataPacket(buf, sendSeq++, first, second, in state, _txIqSource);
+                ControlFrame.BuildDataPacket(buf, sendSeq++, first, second, in state, _txIqSource, _rxCodecAudioSource);
                 rateWindowPkts++;
                 var nowUtc = DateTime.UtcNow;
                 var elapsed = nowUtc - rateWindowStart;

--- a/Zeus.Protocol1/Protocol1Client.cs
+++ b/Zeus.Protocol1/Protocol1Client.cs
@@ -974,10 +974,12 @@ public sealed class Protocol1Client : IProtocol1Client
                 if (elapsed >= TimeSpan.FromSeconds(1))
                 {
                     _log.LogInformation(
-                        "p1.tx.rate pkts={Pkts} in {Ms:F0}ms = {Rate:F0} pkt/s (target 381) | wire: peak={Peak}/32767 mean={Mean} firstI={I} firstQ={Q} drv={Drv}",
+                        "p1.tx.rate pkts={Pkts} in {Ms:F0}ms = {Rate:F0} pkt/s (target 381) | wire: peak={Peak}/32767 mean={Mean} firstI={I} firstQ={Q} drv={Drv} ocTx=0x{OcTx:X2} ocRx=0x{OcRx:X2} mox={Mox}",
                         rateWindowPkts, elapsed.TotalMilliseconds, rateWindowPkts / elapsed.TotalSeconds,
                         ControlFrame.LastPeakAbs, ControlFrame.LastMeanAbs,
-                        ControlFrame.LastFirstI, ControlFrame.LastFirstQ, ControlFrame.LastDriveByte);
+                        ControlFrame.LastFirstI, ControlFrame.LastFirstQ, ControlFrame.LastDriveByte,
+                        (byte)Volatile.Read(ref _ocTxMask), (byte)Volatile.Read(ref _ocRxMask),
+                        Volatile.Read(ref _mox) != 0);
                     rateWindowStart = nowUtc;
                     rateWindowPkts = 0;
                 }

--- a/Zeus.Protocol1/Protocol1Client.cs
+++ b/Zeus.Protocol1/Protocol1Client.cs
@@ -169,6 +169,18 @@ public sealed class Protocol1Client : IProtocol1Client
         int next = ptt ? 1 : 0;
         if (prev == next) return;
         Volatile.Write(ref _hardwarePtt, next);
+        // GH #426 / bd zeus-7uo + zeus-0aq diagnostic. Emit a single line per
+        // hardware-PTT edge capturing both the reported (radio C0[0] echo)
+        // level and the commanded (host) MOX state. The two diverge across
+        // the takeover/release latency we're chasing — anyone bench-testing
+        // can grep for `p1.mox.transition` and read the gap between
+        // reported-edge and host-applied edge (matching
+        // `externalPtt.takeover.applied dtUs=...` or
+        // `tx.mox.{on,off}.recv ts=...`).
+        _log.LogInformation(
+            "p1.mox.transition reportedPtt={Reported} commandedMox={Commanded} ts={Ts}",
+            ptt, Volatile.Read(ref _mox) != 0,
+            System.Diagnostics.Stopwatch.GetTimestamp());
         try { HardwarePttChanged?.Invoke(ptt); }
         catch (Exception ex) { _log.LogWarning(ex, "HardwarePttChanged handler threw"); }
     }

--- a/Zeus.Protocol1/Protocol1Client.cs
+++ b/Zeus.Protocol1/Protocol1Client.cs
@@ -150,6 +150,28 @@ public sealed class Protocol1Client : IProtocol1Client
 
     public event Action<TelemetryReading>? TelemetryReceived;
     public event Action<AdcOverloadStatus>? AdcOverloadObserved;
+    public event Action<bool>? HardwarePttChanged;
+
+    // 0/1; Volatile so the property read on any thread sees the latest value
+    // without needing a lock.
+    private int _hardwarePtt;
+    public bool HardwarePtt => Volatile.Read(ref _hardwarePtt) != 0;
+
+    /// <summary>
+    /// Update the cached hardware-PTT level from a freshly-parsed packet and
+    /// fire <see cref="HardwarePttChanged"/> if the level flipped. Called
+    /// exclusively from the RX loop (single writer) so a CAS isn't needed —
+    /// a plain Volatile.Write + compare is correct.
+    /// </summary>
+    private void UpdateHardwarePtt(bool ptt)
+    {
+        int prev = Volatile.Read(ref _hardwarePtt);
+        int next = ptt ? 1 : 0;
+        if (prev == next) return;
+        Volatile.Write(ref _hardwarePtt, next);
+        try { HardwarePttChanged?.Invoke(ptt); }
+        catch (Exception ex) { _log.LogWarning(ex, "HardwarePttChanged handler threw"); }
+    }
 
     // ---- PureSignal feedback (HL2-only, P1) -------------------------
     // 1024-sample paired blocks fed to WDSP `psccF`. Mirrors P2's
@@ -270,6 +292,10 @@ public sealed class Protocol1Client : IProtocol1Client
             }
             try { AdcOverloadObserved?.Invoke(AdcOverloadStatus.FromBits(overloadBits)); }
             catch (Exception ex) { _log.LogWarning(ex, "AdcOverloadObserved handler threw"); }
+
+            // Mirror the standard-path hardware-PTT level update so an
+            // external key released during PS+TX still propagates the edge.
+            UpdateHardwarePtt(PacketParser.ExtractHardwarePtt(packet));
 
             // DDC0 → IqFrame channel — keeps panadapter / audio alive during PS+TX.
             // Use a fresh rented buffer the channel can own; the ddc0 rental is
@@ -762,6 +788,11 @@ public sealed class Protocol1Client : IProtocol1Client
                 // needs cleared-frame signals as well as set ones to decay the offset.
                 try { AdcOverloadObserved?.Invoke(AdcOverloadStatus.FromBits(overloadBits)); }
                 catch (Exception ex) { _log.LogWarning(ex, "AdcOverloadObserved handler threw"); }
+
+                // Hardware-PTT (C0[0]) echo from the radio. Fires on edge so
+                // ExternalPttService can lift the host MOX when the operator
+                // keys the rear KEY jack or an external PTT line.
+                UpdateHardwarePtt(PacketParser.ExtractHardwarePtt(buffer.AsSpan(0, n)));
 
                 var rateHz = (HpsdrSampleRate)Volatile.Read(ref _rate) switch
                 {

--- a/Zeus.Protocol1/RxCodecAudioRing.cs
+++ b/Zeus.Protocol1/RxCodecAudioRing.cs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.Protocol1;
+
+/// <summary>
+/// Bounded mono int16 ring buffer feeding the EP2 outbound L/R audio bytes
+/// (issue #426). The DSP audio sink writes float32 [-1, +1] samples; the
+/// EP2 packer reads (L, R) int16 pairs at 63 samples per USB frame. Mono
+/// in → both L and R read the same sample.
+///
+/// Capacity sized for ~170 ms @ 48 kHz so a brief DSP-tick stall doesn't
+/// underflow the wire. On overflow (radio sample clock slow vs DSP) the
+/// oldest samples are dropped — that bounds latency on long sessions
+/// where the two clocks drift apart, matching the rationale in
+/// <see cref="Zeus.Server.NativeAudioSink"/>'s clock-drift handling.
+///
+/// Thread safety: a single object lock serialises Write / Next / Clear.
+/// The contention window is tiny (one short array index per call) and the
+/// read rate is ~1500 Hz at EP2 packet rate — well below where lock
+/// overhead matters.
+/// </summary>
+public sealed class RxCodecAudioRing : IRxCodecAudioSource
+{
+    /// <summary>Default 8192-sample capacity ≈ 170 ms @ 48 kHz mono.</summary>
+    public const int DefaultCapacitySamples = 8192;
+
+    private readonly short[] _buf;
+    private readonly object _sync = new();
+    private int _head;
+    private int _tail;
+    private int _count;
+    private long _droppedSamples;
+
+    public RxCodecAudioRing(int capacitySamples = DefaultCapacitySamples)
+    {
+        if (capacitySamples <= 0) throw new ArgumentOutOfRangeException(nameof(capacitySamples));
+        _buf = new short[capacitySamples];
+    }
+
+    /// <summary>
+    /// Append mono float samples in [-1, +1]. Saturating-clamps to int16.
+    /// On overflow (full ring) the oldest sample is dropped — bounds latency
+    /// at the cost of a tiny audible glitch on sustained overruns.
+    /// </summary>
+    public void Write(ReadOnlySpan<float> monoSamples)
+    {
+        if (monoSamples.IsEmpty) return;
+        lock (_sync)
+        {
+            int cap = _buf.Length;
+            for (int i = 0; i < monoSamples.Length; i++)
+            {
+                float s = monoSamples[i];
+                if (s > 1f) s = 1f;
+                else if (s < -1f) s = -1f;
+                short v = (short)(s * 32767f);
+                _buf[_tail] = v;
+                _tail++;
+                if (_tail == cap) _tail = 0;
+                if (_count == cap)
+                {
+                    _head++;
+                    if (_head == cap) _head = 0;
+                    _droppedSamples++;
+                }
+                else
+                {
+                    _count++;
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public (short L, short R) Next()
+    {
+        lock (_sync)
+        {
+            if (_count == 0) return (0, 0);
+            short v = _buf[_head];
+            _head++;
+            if (_head == _buf.Length) _head = 0;
+            _count--;
+            return (v, v);
+        }
+    }
+
+    /// <summary>Drop every queued sample. Used on disconnect.</summary>
+    public void Clear()
+    {
+        lock (_sync)
+        {
+            _head = 0;
+            _tail = 0;
+            _count = 0;
+        }
+    }
+
+    /// <summary>Sample count currently queued. Read-only snapshot.</summary>
+    public int Count { get { lock (_sync) return _count; } }
+
+    /// <summary>Cumulative samples dropped due to overflow since construction.</summary>
+    public long DroppedSamples { get { lock (_sync) return _droppedSamples; } }
+}

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -1225,6 +1225,12 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         WriteBeU32(p, 1428, alex1);
         WriteBeU32(p, 1432, alex0);
         _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1027));
+
+        _log.LogInformation(
+            "p2.cmd_hp.tx run={Run} mox={Mox} tun={Tun} board={Board} variant={Variant} ocTx=0x{OcTx:X2} ocRx=0x{OcRx:X2} ocDxTx=0x{OcDxTx:X2} ocDxRx=0x{OcDxRx:X2} -> p[1401]=0x{B1401:X2} p[1397]=0x{B1397:X2}",
+            run, _moxOn, _tuneActive, _boardKind, _variant,
+            _ocTxMask, _ocRxMask, _ocDxTxMask, _ocDxRxMask,
+            p[1401], p[1397]);
     }
 
     // ANAN-7000 / Orion-II / Saturn (G2 MkII) BPF board constants. Copied

--- a/Zeus.Server.Hosting/BoardCapabilitiesTable.cs
+++ b/Zeus.Server.Hosting/BoardCapabilitiesTable.cs
@@ -101,6 +101,11 @@ internal static class BoardCapabilitiesTable
     // 0-31 dB on RX1 only) matches the row exactly; see Zeus issue #171.
     // MaxPowerWatts=10 is conservative for Brick2 (rated 15 W); operator
     // overrides per-rig in the PA panel.
+    // HasOnboardCodec: every original-protocol board EXCEPT HermesLite2
+    // routes EP2 L/R bytes to a front-panel headphone jack and EP6 mic
+    // bytes from a front-panel mic jack via its on-board AK4951 / TLV320
+    // codec. HL2 has no such codec — host audio path only. Issue #426.
+
     private static readonly BoardCapabilities HermesClass = new(
         RxAdcCount: 1,
         MkiiBpf: false,
@@ -111,7 +116,8 @@ internal static class BoardCapabilitiesTable
         HasAudioAmplifier: false,
         HasSteppedAttenuationRx2: false, // single-RX: RX2 doesn't exist
         SupportsPathIllustrator: true,
-        MaxPowerWatts: 10);
+        MaxPowerWatts: 10,
+        HasOnboardCodec: true);
 
     // ANAN-10E (HermesII firmware) — same Hermes-class fingerprint but the
     // 10E hardware is rated to ~30 W, so its meter axis gets the bigger top.
@@ -125,7 +131,8 @@ internal static class BoardCapabilitiesTable
         HasAudioAmplifier: false,
         HasSteppedAttenuationRx2: false,
         SupportsPathIllustrator: true,
-        MaxPowerWatts: 30);
+        MaxPowerWatts: 30,
+        HasOnboardCodec: true);
 
     // ANAN-100D — 100 W class. Meter axis 120 W gives some headroom past
     // the rated rail without truncating PEP overshoots.
@@ -139,7 +146,8 @@ internal static class BoardCapabilitiesTable
         HasAudioAmplifier: false,
         HasSteppedAttenuationRx2: true,
         SupportsPathIllustrator: true,
-        MaxPowerWatts: 120);
+        MaxPowerWatts: 120,
+        HasOnboardCodec: true);
 
     // ANAN-200D — 200 W class but axis matches the 100/200/G2 family at
     // 120 W: half-axis at 100 W is the natural reading point.
@@ -153,7 +161,8 @@ internal static class BoardCapabilitiesTable
         HasAudioAmplifier: false,
         HasSteppedAttenuationRx2: true,
         SupportsPathIllustrator: true,
-        MaxPowerWatts: 120);
+        MaxPowerWatts: 120,
+        HasOnboardCodec: true);
 
     // 0x0A family default (G2 / 7000DLE / OrionMkII / ANVELINA-PRO3 /
     // Red Pitaya). Saturn-class facts. 100–200 W typical → 120 W axis.
@@ -167,7 +176,8 @@ internal static class BoardCapabilitiesTable
         HasAudioAmplifier: true,
         HasSteppedAttenuationRx2: true,
         SupportsPathIllustrator: false,
-        MaxPowerWatts: 120);
+        MaxPowerWatts: 120,
+        HasOnboardCodec: true);
 
     // ANAN-8000DLE — 250 W per Apache spec; axis snaps to that.
     private static readonly BoardCapabilities Saturn8000DLE = Saturn with
@@ -201,7 +211,8 @@ internal static class BoardCapabilitiesTable
         HasAudioAmplifier: true,
         HasSteppedAttenuationRx2: false, // single-RX: RX2 doesn't exist
         SupportsPathIllustrator: false,
-        MaxPowerWatts: 120);
+        MaxPowerWatts: 120,
+        HasOnboardCodec: true);
 
     // Apache OrionMkII original (Orion-MkII firmware, 100 W) — Saturn-class
     // hardware fingerprint but without on-board telemetry / audio amp per

--- a/Zeus.Server.Hosting/CwEngine.cs
+++ b/Zeus.Server.Hosting/CwEngine.cs
@@ -63,6 +63,8 @@ public sealed class CwEngine : BackgroundService
     private readonly TxService _tx;
     private readonly RadioService _radio;
     private readonly TxIqRing _ring;
+    private readonly StreamingHub _hub;
+    private readonly CwSettingsStore _settings;
     private readonly ILogger<CwEngine> _log;
     private readonly Channel<CwJob> _jobs = Channel.CreateUnbounded<CwJob>(
         new UnboundedChannelOptions { SingleReader = true, SingleWriter = false });
@@ -83,29 +85,44 @@ public sealed class CwEngine : BackgroundService
     /// fired from the playback worker thread.</summary>
     public event Action<CwEngineStatus>? Status;
 
-    public CwEngine(TxService tx, RadioService radio, TxIqRing ring, ILogger<CwEngine> log)
+    public CwEngine(TxService tx, RadioService radio, TxIqRing ring, StreamingHub hub, CwSettingsStore settings, ILogger<CwEngine> log)
     {
         _tx = tx;
         _radio = radio;
         _ring = ring;
+        _hub = hub;
+        _settings = settings;
         _log = log;
         // Drop the current send if the operator overrides MOX from the UI
         // (or a trip happens). Owner==null on the falling edge means MOX
         // was just released; if it wasn't us doing the release, cancel.
         _tx.TxActiveChanged += OnTxActiveChanged;
+        // Bridge the in-process Status event onto the wire so connected
+        // clients (the React macro pad) see state edges without polling.
+        Status += BroadcastStatus;
     }
 
     /// <summary>
-    /// Enqueue <paramref name="text"/> for transmission at <paramref name="wpm"/>
-    /// (null = engine default, currently 20). Returns immediately; actual
-    /// keying happens on the worker thread.
+    /// Enqueue <paramref name="text"/> for transmission at <paramref name="wpm"/>.
+    /// When <paramref name="wpm"/> is null the engine reads the operator's
+    /// persisted default from <see cref="CwSettingsStore"/>; if the store
+    /// hasn't been initialised yet (test seam) it falls back to
+    /// <see cref="WpmDefault"/>. Returns immediately; keying happens on
+    /// the worker thread.
     /// </summary>
     public ValueTask SendAsync(string text, int? wpm, CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(text);
-        int effective = Math.Clamp(wpm ?? WpmDefault, WpmMin, WpmMax);
+        int requested = wpm ?? _settings?.Get().Wpm ?? WpmDefault;
+        int effective = Math.Clamp(requested, WpmMin, WpmMax);
         Interlocked.Increment(ref _pendingJobs);
         return _jobs.Writer.WriteAsync(new CwJob(text, effective), ct);
+    }
+
+    private void BroadcastStatus(CwEngineStatus s)
+    {
+        try { _hub.Broadcast(CwEngineStatusFrame.FromStatus(s)); }
+        catch (Exception ex) { _log.LogWarning(ex, "cw.status hub broadcast failed"); }
     }
 
     /// <summary>Hard cancel. Drains the queue and signals the in-flight

--- a/Zeus.Server.Hosting/CwEngine.cs
+++ b/Zeus.Server.Hosting/CwEngine.cs
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// Host-side CW keyer. WDSP's CWX module is not exported by the libwdsp
+// binaries we ship today (verified 2026-05-24: `nm -D libwdsp.so | grep -i
+// CWX` is empty on linux-x64 and osx-arm64), so we generate the IQ here
+// instead and push it straight into the protocol-1 TX ring. The shape we
+// produce — a single tone at the CW pitch with raised-cosine rise/fall —
+// is what piHPSDR's `transmitter_send_cw` ends up emitting on the wire
+// anyway, so this is a wire-compatible substitute, not a fallback.
+//
+// PR 1 of zeus-4np epic: validates the end-to-end keying path (encoder →
+// engine → TxIqRing → EP2 → RF). UI, macros, TCI keyer, and sidetone
+// monitor land in subsequent PRs.
+
+using System.Threading.Channels;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Zeus.Contracts;
+using Zeus.Protocol1;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Queues text-to-CW jobs and drives them out as host-generated IQ. One
+/// instance per process — registered as a singleton hosted service. The
+/// engine claims MOX as <see cref="MoxSource.Cwx"/> for the life of each
+/// message and releases it on completion; <see cref="AbortAsync"/> is the
+/// hard cut for operator override, <see cref="StopAsync(CancellationToken)"/>
+/// is the graceful shutdown path used by host shutdown.
+///
+/// Audio shape: a 600 Hz tone (sign-flipped for CWL) at 48 kHz, envelope
+/// shaped with a 5 ms raised-cosine on each edge to keep the on-air signal
+/// inside the CW passband. Amplitude is full-scale (operator drives PA
+/// power via the normal drive % slider, not here).
+/// </summary>
+public sealed class CwEngine : BackgroundService
+{
+    // TX-side ring sample rate. Both P1 and P2 backends pull from TxIqRing
+    // at 48 kHz; see Zeus.Protocol1.TxIqRing class doc.
+    public const int SampleRateHz = 48_000;
+    // Raised-cosine ramp on each key edge. 5 ms ≈ ±100 Hz of skirt energy at
+    // the CW pitch — well under the WDSP RX CW bandpass (250 Hz wide). Below
+    // 2 ms produces audible clicks on the air; above 10 ms starts to round
+    // off short dits at 30+ WPM.
+    private const int RampMs = 5;
+    // Speed bounds. 5 WPM = 240 ms dit (very slow CW); 50 WPM = 24 ms dit
+    // (faster than most hand keys can copy). Clamping at ingest keeps the
+    // ramp/dit math sane and prevents divide-by-tiny artefacts.
+    private const int WpmMin = 5;
+    private const int WpmMax = 50;
+    private const int WpmDefault = 20;
+
+    // Chunk size used by the playback loop. 480 samples = 10 ms at 48 kHz —
+    // small enough that the ring stays well under its 340 ms drop-oldest
+    // threshold, large enough that the loop only wakes 100 times per second
+    // of TX (negligible CPU). Stay coherent with the ring's `Write(span)`
+    // path which is per-block.
+    private const int ChunkSamples = 480;
+
+    private readonly TxService _tx;
+    private readonly RadioService _radio;
+    private readonly TxIqRing _ring;
+    private readonly ILogger<CwEngine> _log;
+    private readonly Channel<CwJob> _jobs = Channel.CreateUnbounded<CwJob>(
+        new UnboundedChannelOptions { SingleReader = true, SingleWriter = false });
+    // .NET's default unbounded channel does NOT implement Reader.Count
+    // (CanCount=false), so calling _jobs.Reader.Count throws
+    // NotSupportedException. We need the depth for status reporting and
+    // idle gating, so track it ourselves via Interlocked. Incremented at
+    // the writer (SendAsync, Abort no-op), decremented after a successful
+    // worker read.
+    private int _pendingJobs;
+
+    // Aborts the currently-playing job. Recreated on each new job so abort
+    // doesn't poison the next send.
+    private CancellationTokenSource? _currentAbort;
+    private readonly object _abortLock = new();
+
+    /// <summary>Raised on every state transition. Subscribers must not block;
+    /// fired from the playback worker thread.</summary>
+    public event Action<CwEngineStatus>? Status;
+
+    public CwEngine(TxService tx, RadioService radio, TxIqRing ring, ILogger<CwEngine> log)
+    {
+        _tx = tx;
+        _radio = radio;
+        _ring = ring;
+        _log = log;
+        // Drop the current send if the operator overrides MOX from the UI
+        // (or a trip happens). Owner==null on the falling edge means MOX
+        // was just released; if it wasn't us doing the release, cancel.
+        _tx.TxActiveChanged += OnTxActiveChanged;
+    }
+
+    /// <summary>
+    /// Enqueue <paramref name="text"/> for transmission at <paramref name="wpm"/>
+    /// (null = engine default, currently 20). Returns immediately; actual
+    /// keying happens on the worker thread.
+    /// </summary>
+    public ValueTask SendAsync(string text, int? wpm, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        int effective = Math.Clamp(wpm ?? WpmDefault, WpmMin, WpmMax);
+        Interlocked.Increment(ref _pendingJobs);
+        return _jobs.Writer.WriteAsync(new CwJob(text, effective), ct);
+    }
+
+    /// <summary>Hard cancel. Drains the queue and signals the in-flight
+    /// playback to drop the rest of the symbols. MOX falls on the next
+    /// playback tick.</summary>
+    public void Abort(string reason = "operator abort")
+    {
+        // Drain queue first so cancelled jobs don't get picked up. Decrement
+        // the depth counter for every job we discard so the in-flight Status
+        // reports stay accurate.
+        while (_jobs.Reader.TryRead(out _)) Interlocked.Decrement(ref _pendingJobs);
+        CancellationTokenSource? cts;
+        lock (_abortLock) cts = _currentAbort;
+        try { cts?.Cancel(); }
+        catch (ObjectDisposedException) { /* race with worker disposal */ }
+        _log.LogInformation("cw.abort reason={Reason}", reason);
+    }
+
+    /// <summary>Tests only: snapshot queue depth without taking work.</summary>
+    internal int PendingJobCount => Volatile.Read(ref _pendingJobs);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            CwJob job;
+            try { job = await _jobs.Reader.ReadAsync(stoppingToken).ConfigureAwait(false); }
+            catch (OperationCanceledException) { return; }
+            // Decrement BEFORE the job runs so QueueDepth reported in the
+            // Sending status reflects "jobs still waiting after me", not
+            // "jobs including me".
+            int remaining = Interlocked.Decrement(ref _pendingJobs);
+
+            var jobCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+            lock (_abortLock) _currentAbort = jobCts;
+            try
+            {
+                await PlayJobAsync(job, remaining, jobCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Either operator abort or host shutdown. Either way, unkey
+                // and re-emit Idle if MOX is still ours.
+                Notify(new CwEngineStatus(
+                    CwEngineState.Aborting, job.Text, job.Wpm,
+                    Volatile.Read(ref _pendingJobs),
+                    Reason: "aborted"));
+                TryReleaseMox("aborted");
+            }
+            catch (Exception ex)
+            {
+                _log.LogWarning(ex, "cw.play failed text={Text} wpm={Wpm}", Truncate(job.Text), job.Wpm);
+                TryReleaseMox("error");
+            }
+            finally
+            {
+                lock (_abortLock)
+                {
+                    if (ReferenceEquals(_currentAbort, jobCts)) _currentAbort = null;
+                }
+                jobCts.Dispose();
+            }
+
+            // Emit Idle once the queue actually drains. Mid-queue jobs roll
+            // into the next iteration without a flicker.
+            if (Volatile.Read(ref _pendingJobs) == 0)
+                Notify(new CwEngineStatus(CwEngineState.Idle, string.Empty, 0, 0));
+        }
+    }
+
+    private async Task PlayJobAsync(CwJob job, int queueDepth, CancellationToken ct)
+    {
+        // Before keying, force the hardware LO to the canonical CW offset
+        // of the dial — eliminates CTUN drift so the carrier lands on the
+        // operator's displayed VFO. No-op when CTUN wasn't in play; when it
+        // was, the panadapter view recenters, which matches Thetis CW-TX
+        // behaviour (the CTUN convenience is RX-only).
+        bool loRealigned = _radio.AlignLoForCwTx();
+
+        var snap = _radio.Snapshot();
+        // Baseband offset = RadioLo − VFO. After AlignLoForCwTx this is
+        // exactly ∓ CwPitchHz (negative for CWU, positive for CWL) and the
+        // carrier lands at the dial. The formula is kept rather than
+        // hard-coding ±pitch so a future caller that skips AlignLoForCwTx
+        // (e.g. an operator who genuinely wants to TX off-centre under
+        // CTUN) still gets correct baseband math.
+        //
+        // Sign note (HL2 IQ convention): the HL2 emits the RF carrier at
+        // (LO − baseband_hz), not (LO + baseband_hz) — i.e. the "I − jQ"
+        // complex-baseband convention. Verified on a live HL2 2026-05-24
+        // (EA5IUE bench test).
+        int basebandHz = (int)(snap.RadioLoHz - snap.VfoHz);
+
+        if (!_tx.TrySetMox(true, MoxSource.Cwx, out var err))
+        {
+            _log.LogWarning("cw.mox.refused text={Text} reason={Err}", Truncate(job.Text), err);
+            Notify(new CwEngineStatus(
+                CwEngineState.Idle, job.Text, job.Wpm, queueDepth,
+                Reason: err ?? "MOX refused"));
+            return;
+        }
+        Notify(new CwEngineStatus(CwEngineState.Sending, job.Text, job.Wpm, queueDepth));
+        _log.LogInformation(
+            "cw.send text={Text} wpm={Wpm} mode={Mode} vfo={Vfo}Hz lo={Lo}Hz baseband={Bb}Hz loRealigned={LoRealigned}",
+            Truncate(job.Text), job.Wpm, snap.Mode, snap.VfoHz, snap.RadioLoHz, basebandHz, loRealigned);
+
+        // Phase accumulator runs continuously across symbols so the tone
+        // stays coherent through inter-element gaps (no phase pop on
+        // each dit-onset). Reset per-job.
+        double phase = 0.0;
+        double phaseStep = 2.0 * Math.PI * basebandHz / SampleRateHz;
+        // Scratch buffer for chunked IQ writes. 2 floats per sample.
+        var iq = new float[ChunkSamples * 2];
+
+        foreach (var symbol in MorseEncoder.Encode(job.Text, job.Wpm))
+        {
+            ct.ThrowIfCancellationRequested();
+            int totalSamples = (int)((long)symbol.DurationMs * SampleRateHz / 1000);
+            int rampSamples = Math.Min(
+                (int)((long)RampMs * SampleRateHz / 1000),
+                totalSamples / 2);
+
+            int written = 0;
+            while (written < totalSamples)
+            {
+                ct.ThrowIfCancellationRequested();
+                int n = Math.Min(ChunkSamples, totalSamples - written);
+                for (int i = 0; i < n; i++)
+                {
+                    double env = symbol.KeyDown
+                        ? RaisedCosineEnvelope(written + i, totalSamples, rampSamples)
+                        : 0.0;
+                    iq[2 * i] = (float)(env * Math.Cos(phase));
+                    iq[2 * i + 1] = (float)(env * Math.Sin(phase));
+                    phase += phaseStep;
+                    // Keep phase bounded so cos/sin stays numerically clean
+                    // over multi-minute transmissions.
+                    if (phase > 2.0 * Math.PI) phase -= 2.0 * Math.PI;
+                }
+                _ring.Write(new ReadOnlySpan<float>(iq, 0, 2 * n));
+                written += n;
+                // Pace ourselves to the ring drain rate so the ring stays
+                // well below its 16384-pair drop-oldest threshold. EP2 drains
+                // ~42k pairs/s; we write at the same average rate, so a
+                // (chunk/rate) sleep keeps the ring at ~one-chunk depth.
+                int sleepMs = Math.Max(1, (n * 1000) / SampleRateHz - 1);
+                try { await Task.Delay(sleepMs, ct).ConfigureAwait(false); }
+                catch (OperationCanceledException) { throw; }
+            }
+        }
+
+        // Drop MOX after the final symbol. The ring still has up to ~10 ms
+        // of envelope tail queued; wait that long so the radio actually
+        // transmits the tail before MOX falls. (Shorter than the natural
+        // ring depth — we deliberately keep the ring shallow above.)
+        try { await Task.Delay(20, ct).ConfigureAwait(false); }
+        catch (OperationCanceledException) { throw; }
+        TryReleaseMox("done");
+    }
+
+    private void TryReleaseMox(string reason)
+    {
+        // Only release MOX if we still own it — UI or trip may have already
+        // dropped it under us. Idempotent at the TxService layer either way.
+        if (_tx.MoxOwner == MoxSource.Cwx)
+        {
+            _tx.TrySetMox(false, MoxSource.Cwx, out _);
+            _log.LogInformation("cw.mox.released reason={Reason}", reason);
+        }
+    }
+
+    private void OnTxActiveChanged(bool active)
+    {
+        if (active) return;
+        // MOX just fell. If we have a job in flight and the falling edge
+        // wasn't initiated by us (TryReleaseMox above), the operator hit
+        // the UI override or a trip fired — cancel the playback so the
+        // remaining symbols don't queue up against a closed transmitter.
+        CancellationTokenSource? cts;
+        lock (_abortLock) cts = _currentAbort;
+        if (cts is null) return;
+        // MoxOwner is null after the falling edge regardless of who caused
+        // it, so we can't disambiguate "we released" from "UI overrode" by
+        // owner alone. We don't need to: the worker's own release path
+        // tolerates a redundant cancel (the linked-token CTS is one-shot
+        // and the worker's loop tail finishes the next iteration silently).
+        try { cts.Cancel(); } catch (ObjectDisposedException) { }
+    }
+
+    /// <summary>Test seam: precompute the IQ stream for <paramref name="text"/>
+    /// at <paramref name="wpm"/>. <paramref name="basebandHz"/> is the live
+    /// engine's <c>(VfoHz − RadioLoHz)</c> — pass +600 for CWU without CTUN,
+    /// -600 for CWL without CTUN, or any signed offset to exercise CTUN.</summary>
+    internal static float[] RenderForTest(string text, int wpm, int basebandHz)
+    {
+        double phase = 0.0;
+        double phaseStep = 2.0 * Math.PI * basebandHz / SampleRateHz;
+        var buf = new System.Collections.Generic.List<float>();
+        foreach (var sym in MorseEncoder.Encode(text, wpm))
+        {
+            int total = (int)((long)sym.DurationMs * SampleRateHz / 1000);
+            int ramp = Math.Min((int)((long)RampMs * SampleRateHz / 1000), total / 2);
+            for (int i = 0; i < total; i++)
+            {
+                double env = sym.KeyDown ? RaisedCosineEnvelope(i, total, ramp) : 0.0;
+                buf.Add((float)(env * Math.Cos(phase)));
+                buf.Add((float)(env * Math.Sin(phase)));
+                phase += phaseStep;
+                if (phase > 2.0 * Math.PI) phase -= 2.0 * Math.PI;
+            }
+        }
+        return buf.ToArray();
+    }
+
+    private void Notify(CwEngineStatus status)
+    {
+        try { Status?.Invoke(status); }
+        catch (Exception ex) { _log.LogWarning(ex, "cw.status subscriber threw"); }
+    }
+
+    private static double RaisedCosineEnvelope(int sample, int total, int ramp)
+    {
+        // Plateau region.
+        if (sample >= ramp && sample < total - ramp) return 1.0;
+        // Rising edge: 0.5 (1 - cos(π·t/ramp)) — Tukey window's leading half.
+        if (sample < ramp)
+            return 0.5 * (1.0 - Math.Cos(Math.PI * sample / ramp));
+        // Falling edge: same curve mirrored.
+        int into = sample - (total - ramp);
+        return 0.5 * (1.0 - Math.Cos(Math.PI * (ramp - into) / ramp));
+    }
+
+    private static string Truncate(string s) => s.Length <= 40 ? s : s[..40] + "…";
+
+    private readonly record struct CwJob(string Text, int Wpm);
+}

--- a/Zeus.Server.Hosting/CwOffset.cs
+++ b/Zeus.Server.Hosting/CwOffset.cs
@@ -21,7 +21,7 @@ namespace Zeus.Server;
 // 600 Hz off the signal to hear it.
 internal static class CwOffset
 {
-    public const int CwPitchHz = 600;
+    public const int CwPitchHz = CwDefaults.PitchHz;
 
     // Effective hardware LO for the supplied dial frequency. Non-CW modes
     // pass through unchanged so SSB / AM / FM / DIG behaviour is bit-for-bit

--- a/Zeus.Server.Hosting/CwSettingsStore.cs
+++ b/Zeus.Server.Hosting/CwSettingsStore.cs
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+
+using LiteDB;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Persists the CW operator's preferences (WPM, Farnsworth split, 6 macro
+/// slots, sidetone gain/pitch) so the macro pad and slider state survive
+/// server restarts. Shares <c>zeus-prefs.db</c> with the other Stores —
+/// CW settings aren't sensitive.
+///
+/// Single-row schema (one operator per backend). Macros is stored as a
+/// fixed-length string[6]; absent / shorter persisted arrays are padded
+/// to 6 with the seeded defaults on read, so legacy DBs hydrate cleanly.
+/// </summary>
+public sealed class CwSettingsStore : IDisposable
+{
+    /// <summary>Default macros — match the previously-hardcoded list in
+    /// <c>zeus-web/src/components/design/CwKeyer.tsx</c> so a fresh install
+    /// shows the same six buttons the UI used pre-persistence.</summary>
+    public static readonly string[] DefaultMacros =
+        { "CQ CQ CQ", "TU 73", "QRZ?", "AGN?", "5NN TU", "UR RST" };
+
+    public const int DefaultWpm = 22;
+    public const double DefaultSidetoneGainDb = -10.0;
+    public const int DefaultSidetoneHz = 600;
+    /// <summary>Hard cap on the total number of macros — keeps the UI
+    /// list manageable and bounds the broadcast frame size. Operators can
+    /// add up to this many slots; <see cref="DefaultMacros"/> seeds the
+    /// first six on a fresh install.</summary>
+    public const int MaxMacros = 32;
+    /// <summary>Hard cap on a single macro to keep wire frames small and
+    /// reject runaway paste / accidental long strings at the API edge.</summary>
+    public const int MaxMacroChars = 200;
+
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<CwSettingsEntry> _docs;
+    private readonly ILogger<CwSettingsStore> _log;
+    private readonly object _sync = new();
+
+    public CwSettingsStore(ILogger<CwSettingsStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _docs = _db.GetCollection<CwSettingsEntry>("cw_settings");
+
+        _log.LogInformation("CwSettingsStore initialized at {Path}", dbPath);
+    }
+
+    public CwSettingsDto Get()
+    {
+        lock (_sync)
+        {
+            var e = _docs.FindAll().FirstOrDefault();
+            if (e is null)
+                return new CwSettingsDto(
+                    Wpm: DefaultWpm,
+                    FarnsworthWpm: null,
+                    Macros: (string[])DefaultMacros.Clone(),
+                    SidetoneGainDb: DefaultSidetoneGainDb,
+                    SidetoneHz: DefaultSidetoneHz);
+
+            return new CwSettingsDto(
+                Wpm: e.Wpm,
+                FarnsworthWpm: e.FarnsworthWpm,
+                Macros: SanitizeStored(e.Macros),
+                SidetoneGainDb: e.SidetoneGainDb,
+                SidetoneHz: e.SidetoneHz);
+        }
+    }
+
+    /// <summary>
+    /// Merge a PATCH-shaped request on top of the persisted row. Null
+    /// fields preserve their current value; non-null fields are validated
+    /// (Wpm clamped 5..50, sidetone clamped to sane ranges, macros padded /
+    /// truncated to <see cref="MacroSlotCount"/> with per-string length cap).
+    /// Returns the post-merge snapshot.
+    /// </summary>
+    public CwSettingsDto Save(CwSettingsSetRequest req)
+    {
+        ArgumentNullException.ThrowIfNull(req);
+        lock (_sync)
+        {
+            var existing = _docs.FindAll().FirstOrDefault();
+            var entry = existing ?? SeedDefaultsEntry();
+
+            if (req.Wpm is int w)
+                entry.Wpm = Math.Clamp(w, 5, 50);
+            if (req.FarnsworthWpm is int fw)
+                entry.FarnsworthWpm = fw <= 0 ? null : Math.Clamp(fw, 5, 50);
+            else if (req.FarnsworthWpm is null && existing is not null)
+            {
+                // Null in the request keeps the existing value (PATCH semantics).
+                // No-op here, just being explicit about the contract.
+            }
+            if (req.Macros is { } macros)
+                entry.Macros = NormalizeMacros(macros);
+            if (req.SidetoneGainDb is double g)
+                // Operator-safe sidetone band: -60..+0 dB. Above 0 risks
+                // hard-clipping; below -60 is effectively silent.
+                entry.SidetoneGainDb = Math.Clamp(g, -60.0, 0.0);
+            if (req.SidetoneHz is int hz)
+                // CW pitch operator preference range. Below 200 is sub-bass
+                // and below the WDSP RX bandpass; above 1200 is uncomfortable.
+                entry.SidetoneHz = Math.Clamp(hz, 200, 1200);
+
+            entry.UpdatedUtc = DateTime.UtcNow;
+            if (existing is null) _docs.Insert(entry);
+            else _docs.Update(entry);
+
+            return new CwSettingsDto(
+                Wpm: entry.Wpm,
+                FarnsworthWpm: entry.FarnsworthWpm,
+                Macros: SanitizeStored(entry.Macros),
+                SidetoneGainDb: entry.SidetoneGainDb,
+                SidetoneHz: entry.SidetoneHz);
+        }
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private static CwSettingsEntry SeedDefaultsEntry() => new()
+    {
+        Wpm = DefaultWpm,
+        FarnsworthWpm = null,
+        Macros = (string[])DefaultMacros.Clone(),
+        SidetoneGainDb = DefaultSidetoneGainDb,
+        SidetoneHz = DefaultSidetoneHz,
+    };
+
+    /// <summary>Normalise a persisted Macros array on read. LiteDB
+    /// serialises empty strings as null on the round-trip — translate
+    /// back to empty so the wire shape is consistent. Variable length:
+    /// honours whatever the operator saved, up to <see cref="MaxMacros"/>.</summary>
+    private static string[] SanitizeStored(string[]? persisted)
+    {
+        if (persisted is null || persisted.Length == 0) return Array.Empty<string>();
+        int n = Math.Min(persisted.Length, MaxMacros);
+        var result = new string[n];
+        for (int i = 0; i < n; i++) result[i] = persisted[i] ?? string.Empty;
+        return result;
+    }
+
+    /// <summary>Validate + length-cap a user-supplied Macros array. The
+    /// length is preserved (operator chooses how many macros to keep —
+    /// add and delete are first-class operations) but capped at
+    /// <see cref="MaxMacros"/>; per-string content is capped at
+    /// <see cref="MaxMacroChars"/>. Null entries become empty strings.</summary>
+    private static string[] NormalizeMacros(string[] macros)
+    {
+        int n = Math.Min(macros.Length, MaxMacros);
+        var result = new string[n];
+        for (int i = 0; i < n; i++)
+        {
+            string raw = macros[i] ?? string.Empty;
+            result[i] = raw.Length > MaxMacroChars ? raw[..MaxMacroChars] : raw;
+        }
+        return result;
+    }
+}
+
+public sealed class CwSettingsEntry
+{
+    public int Id { get; set; }
+    public int Wpm { get; set; } = CwSettingsStore.DefaultWpm;
+    public int? FarnsworthWpm { get; set; }
+    public string[] Macros { get; set; } = (string[])CwSettingsStore.DefaultMacros.Clone();
+    public double SidetoneGainDb { get; set; } = CwSettingsStore.DefaultSidetoneGainDb;
+    public int SidetoneHz { get; set; } = CwSettingsStore.DefaultSidetoneHz;
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/DisplaySettingsStore.cs
+++ b/Zeus.Server.Hosting/DisplaySettingsStore.cs
@@ -57,18 +57,41 @@ public sealed class DisplaySettingsStore : IDisposable
                     Fit: "fill",
                     HasImage: false,
                     ImageMime: null,
-                    RxTraceColor: DefaultRxTraceColor);
+                    RxTraceColor: DefaultRxTraceColor,
+                    DbMin: null,
+                    DbMax: null,
+                    TxDbMin: null,
+                    TxDbMax: null,
+                    WfDbMin: null,
+                    WfDbMax: null,
+                    WfTxDbMin: null,
+                    WfTxDbMax: null);
             }
             return new DisplaySettingsDto(
                 Mode: NormalizeMode(e.Mode),
                 Fit: NormalizeFit(e.Fit),
                 HasImage: e.ImageBytes is { Length: > 0 },
                 ImageMime: string.IsNullOrEmpty(e.ImageMime) ? null : e.ImageMime,
-                RxTraceColor: NormalizeHexColor(e.RxTraceColor));
+                RxTraceColor: NormalizeHexColor(e.RxTraceColor),
+                DbMin: e.DbMin,
+                DbMax: e.DbMax,
+                TxDbMin: e.TxDbMin,
+                TxDbMax: e.TxDbMax,
+                WfDbMin: e.WfDbMin,
+                WfDbMax: e.WfDbMax,
+                WfTxDbMin: e.WfTxDbMin,
+                WfTxDbMax: e.WfTxDbMax);
         }
     }
 
-    public void SaveMode(string mode, string fit, string rxTraceColor)
+    // Null dB range values are treated as "not provided" — the existing
+    // stored value is kept unchanged. This lets callers updating only
+    // mode/fit/color leave the operator's dB scale untouched.
+    public void SaveMode(string mode, string fit, string rxTraceColor,
+        double? dbMin = null, double? dbMax = null,
+        double? txDbMin = null, double? txDbMax = null,
+        double? wfDbMin = null, double? wfDbMax = null,
+        double? wfTxDbMin = null, double? wfTxDbMax = null)
     {
         lock (_sync)
         {
@@ -76,6 +99,14 @@ public sealed class DisplaySettingsStore : IDisposable
             e.Mode = NormalizeMode(mode);
             e.Fit = NormalizeFit(fit);
             e.RxTraceColor = NormalizeHexColor(rxTraceColor);
+            if (dbMin.HasValue) e.DbMin = dbMin;
+            if (dbMax.HasValue) e.DbMax = dbMax;
+            if (txDbMin.HasValue) e.TxDbMin = txDbMin;
+            if (txDbMax.HasValue) e.TxDbMax = txDbMax;
+            if (wfDbMin.HasValue) e.WfDbMin = wfDbMin;
+            if (wfDbMax.HasValue) e.WfDbMax = wfDbMax;
+            if (wfTxDbMin.HasValue) e.WfTxDbMin = wfTxDbMin;
+            if (wfTxDbMax.HasValue) e.WfTxDbMax = wfTxDbMax;
             e.UpdatedUtc = DateTime.UtcNow;
             if (e.Id == 0) _docs.Insert(e);
             else _docs.Update(e);
@@ -169,5 +200,17 @@ public sealed class DisplaySettingsEntry
     // Panadapter signal trace colour as #RRGGBB. Null on legacy rows written
     // before this field existed — Get() normalises null → DefaultRxTraceColor.
     public string? RxTraceColor { get; set; }
+    // Panadapter and waterfall dB window bounds. Null on rows written before
+    // this field existed — Get() returns null to the frontend, which then
+    // falls back to its built-in FIXED_DB_MIN / TX_FIXED_DB_MIN constants and
+    // pushes the localStorage-saved (or default) value up on first interaction.
+    public double? DbMin { get; set; }
+    public double? DbMax { get; set; }
+    public double? TxDbMin { get; set; }
+    public double? TxDbMax { get; set; }
+    public double? WfDbMin { get; set; }
+    public double? WfDbMax { get; set; }
+    public double? WfTxDbMin { get; set; }
+    public double? WfTxDbMax { get; set; }
     public DateTime UpdatedUtc { get; set; }
 }

--- a/Zeus.Server.Hosting/DisplaySettingsStore.cs
+++ b/Zeus.Server.Hosting/DisplaySettingsStore.cs
@@ -65,7 +65,8 @@ public sealed class DisplaySettingsStore : IDisposable
                     WfDbMin: null,
                     WfDbMax: null,
                     WfTxDbMin: null,
-                    WfTxDbMax: null);
+                    WfTxDbMax: null,
+                    WfBrightness: null);
             }
             return new DisplaySettingsDto(
                 Mode: NormalizeMode(e.Mode),
@@ -80,18 +81,21 @@ public sealed class DisplaySettingsStore : IDisposable
                 WfDbMin: e.WfDbMin,
                 WfDbMax: e.WfDbMax,
                 WfTxDbMin: e.WfTxDbMin,
-                WfTxDbMax: e.WfTxDbMax);
+                WfTxDbMax: e.WfTxDbMax,
+                WfBrightness: e.WfBrightness);
         }
     }
 
-    // Null dB range values are treated as "not provided" — the existing
-    // stored value is kept unchanged. This lets callers updating only
-    // mode/fit/color leave the operator's dB scale untouched.
+    // Null dB range / brightness values are treated as "not provided" — the
+    // existing stored value is kept unchanged. This lets callers updating only
+    // mode/fit/color leave the operator's dB scale and waterfall brightness
+    // untouched.
     public void SaveMode(string mode, string fit, string rxTraceColor,
         double? dbMin = null, double? dbMax = null,
         double? txDbMin = null, double? txDbMax = null,
         double? wfDbMin = null, double? wfDbMax = null,
-        double? wfTxDbMin = null, double? wfTxDbMax = null)
+        double? wfTxDbMin = null, double? wfTxDbMax = null,
+        double? wfBrightness = null)
     {
         lock (_sync)
         {
@@ -107,6 +111,7 @@ public sealed class DisplaySettingsStore : IDisposable
             if (wfDbMax.HasValue) e.WfDbMax = wfDbMax;
             if (wfTxDbMin.HasValue) e.WfTxDbMin = wfTxDbMin;
             if (wfTxDbMax.HasValue) e.WfTxDbMax = wfTxDbMax;
+            if (wfBrightness.HasValue) e.WfBrightness = NormalizeBrightness(wfBrightness.Value);
             e.UpdatedUtc = DateTime.UtcNow;
             if (e.Id == 0) _docs.Insert(e);
             else _docs.Update(e);
@@ -171,6 +176,20 @@ public sealed class DisplaySettingsStore : IDisposable
     // and the original hard-coded #FFA028 in gl/panadapter.ts.
     public const string DefaultRxTraceColor = "#FFA028";
 
+    // Waterfall brightness slider bounds — must stay in lockstep with
+    // WF_BRIGHTNESS_MIN / WF_BRIGHTNESS_MAX in display-settings-store.ts so
+    // the server-side clamp matches what the UI slider can produce.
+    private const double WfBrightnessMin = 0.25;
+    private const double WfBrightnessMax = 4.0;
+
+    private static double NormalizeBrightness(double raw)
+    {
+        if (double.IsNaN(raw) || double.IsInfinity(raw)) return 1.0;
+        if (raw < WfBrightnessMin) return WfBrightnessMin;
+        if (raw > WfBrightnessMax) return WfBrightnessMax;
+        return raw;
+    }
+
     private static string NormalizeHexColor(string? raw)
     {
         if (string.IsNullOrEmpty(raw)) return DefaultRxTraceColor;
@@ -212,5 +231,10 @@ public sealed class DisplaySettingsEntry
     public double? WfDbMax { get; set; }
     public double? WfTxDbMin { get; set; }
     public double? WfTxDbMax { get; set; }
+    // Waterfall colormap brightness multiplier. Null on rows written before
+    // this field existed — Get() returns null, the frontend defaults to 1.0
+    // (no change) and pushes the value up on first interaction. See
+    // gl/shaders.ts WF_FS for how this is applied. Issue #426.
+    public double? WfBrightness { get; set; }
     public DateTime UpdatedUtc { get; set; }
 }

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -137,6 +137,14 @@ public class DspPipelineService : BackgroundService,
     private double _appliedAgcTopDb;
     private double _appliedAgcOffsetDb;
     private double _appliedRxAfGainDb;
+    // TX mic gain change-detect cache. NaN sentinel forces the first apply
+    // even when the persisted value happens to equal 0 dB (the engine seam
+    // expects an explicit unity SetTxPanelGain call so the TX chain leaves
+    // its uninitialised state in a known place after channel-open).
+    private double _appliedTxMicGainLinear = double.NaN;
+    // Same NaN-first-apply sentinel for the Leveler ceiling so a channel-open
+    // with the persisted value matching the 8 dB default still re-pushes it.
+    private double _appliedTxLevelerMaxGainDb = double.NaN;
     private NrConfig _appliedNr = new();
     private int _appliedZoomLevel = 1;
     // PureSignal latched values — same change-detect pattern as the others
@@ -566,6 +574,20 @@ public class DspPipelineService : BackgroundService,
             engine.SetRxAfGainDb(channel, s.RxAfGainDb);
             _appliedRxAfGainDb = s.RxAfGainDb;
         }
+        // TX mic gain: dB → linear (10^(db/20)) at the engine seam. Conversion
+        // matches the historical /api/mic-gain inline (Math.Pow(10.0, db/20.0));
+        // moved here so the operator-friendly dB is what gets stored and broadcast.
+        double micLinear = Math.Pow(10.0, s.MicGainDb / 20.0);
+        if (micLinear != _appliedTxMicGainLinear)
+        {
+            engine.SetTxPanelGain(micLinear);
+            _appliedTxMicGainLinear = micLinear;
+        }
+        if (s.LevelerMaxGainDb != _appliedTxLevelerMaxGainDb)
+        {
+            engine.SetTxLevelerMaxGain(s.LevelerMaxGainDb);
+            _appliedTxLevelerMaxGainDb = s.LevelerMaxGainDb;
+        }
         var nr = s.Nr ?? new NrConfig();
         if (!nr.Equals(_appliedNr))
         {
@@ -841,6 +863,14 @@ public class DspPipelineService : BackgroundService,
         double effectiveAgc = s.AgcTopDb + s.AgcOffsetDb;
         engine.SetAgcTop(channelId, effectiveAgc);
         engine.SetRxAfGainDb(channelId, s.RxAfGainDb);
+        // Re-push TX mic gain + Leveler on every fresh engine so the channel
+        // doesn't sit at the WDSP open-time defaults when the operator's last
+        // values differ. The engine's TXA reopen path resets PanelGain1=1.0 and
+        // LevelerTop=8.0 internally; without this re-push, a relaunch would
+        // ignore the just-hydrated StateDto values.
+        double micLinearInit = Math.Pow(10.0, s.MicGainDb / 20.0);
+        engine.SetTxPanelGain(micLinearInit);
+        engine.SetTxLevelerMaxGain(s.LevelerMaxGainDb);
         engine.SetNoiseReduction(channelId, nr);
         engine.SetZoom(channelId, s.ZoomLevel);
         _appliedMode = s.Mode;
@@ -852,6 +882,8 @@ public class DspPipelineService : BackgroundService,
         _appliedAgcTopDb = s.AgcTopDb;
         _appliedAgcOffsetDb = s.AgcOffsetDb;
         _appliedRxAfGainDb = s.RxAfGainDb;
+        _appliedTxMicGainLinear = micLinearInit;
+        _appliedTxLevelerMaxGainDb = s.LevelerMaxGainDb;
         _appliedNr = nr;
         _appliedZoomLevel = s.ZoomLevel;
     }

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -126,12 +126,11 @@ public class DspPipelineService : BackgroundService,
     private RxMode _appliedMode = RxMode.USB;
     private int _appliedLowHz;
     private int _appliedHighHz;
-    // CTUN bandpass shift currently applied to the WDSP RX filter (Hz). Equals
-    // (EffectiveLoHz(VfoHz) - RadioLoHz) when CtunEnabled, 0 otherwise. The
-    // filter low/high pushed to WDSP is the operator-set passband + this
-    // offset. Tracked separately from FilterLowHz/HighHz so re-pushing the
-    // filter when CTUN moves the dial doesn't require Mutate-ing the StateDto.
-    // Issue #427.
+    // WDSP RX filter shift currently applied (Hz). Equals
+    // (EffectiveLoHz(VfoHz) - RadioLoHz) — the always-frozen-NCO model.
+    // Tracked separately from FilterLowHz/HighHz so re-pushing the filter
+    // when the dial moves doesn't require Mutate-ing the StateDto.
+    // See docs/prd/panfall_behavior.md.
     private int _appliedCtunOffsetHz;
     private int _appliedTxLowHz;
     private int _appliedTxHighHz;
@@ -505,13 +504,12 @@ public class DspPipelineService : BackgroundService,
         // about tune changes without this forward. Sample rate / mode follow
         // here too when P2-side support is added.
         //
-        // CTUN — issue #427. When CTUN is on the hardware NCO is frozen at
-        // RadioLoHz: every state change must push that frozen value (not the
-        // operator's roaming dial) so dial movements stay confined to the
-        // WDSP filter-shift path and don't physically retune the radio.
+        // Frozen-NCO model: the hardware always sits at RadioLoHz; dial
+        // movements stay confined to the WDSP filter-shift path. Push
+        // RadioLoHz to the P2 client (the P1 client gets the same push from
+        // RadioService.SetRadioLo). See docs/prd/panfall_behavior.md.
         var p2 = _p2Client;
-        long p2TargetHz = s.CtunEnabled ? s.RadioLoHz : CwOffset.EffectiveLoHz(s);
-        p2?.SetVfoAHz(p2TargetHz);
+        p2?.SetVfoAHz(s.RadioLoHz);
 
         // iter5 pass-2: lock-free engine pointer read. The lock previously
         // here only provided pointer atomicity (the engine.* calls below
@@ -537,17 +535,14 @@ public class DspPipelineService : BackgroundService,
             _appliedLowHz = s.FilterLowHz;
             _appliedHighHz = s.FilterHighHz;
         }
-        // CTUN frequency shift — issue #427. When CtunEnabled, the operator's
-        // dial sits off-centre on the WDSP IF (the radio's NCO is frozen at
-        // RadioLoHz). WDSP's `shift` stage moves the IF by shiftHz before
-        // demodulation, so the unmodified bandpass filter sees the tuned
-        // signal at baseband. Disabled (shiftHz=0) when CtunEnabled is false,
-        // which collapses to legacy behaviour. This is the seam Thetis uses
-        // (radio.cs:1419-1420); shifting SetRXABandpassFreqs directly broke
-        // SSB demod because the nbp0 stage rejects sign-inverted ranges.
-        int ctunShiftHz = s.CtunEnabled
-            ? (int)(CwOffset.EffectiveLoHz(s.Mode, s.VfoHz) - s.RadioLoHz)
-            : 0;
+        // Frozen-NCO frequency shift. The dial sits off-centre on the WDSP
+        // IF (the radio's NCO is frozen at RadioLoHz); WDSP's `shift` stage
+        // moves the IF by shiftHz before demodulation so the unmodified
+        // bandpass filter sees the tuned signal at baseband. This is the
+        // seam Thetis uses (radio.cs:1419-1420); shifting SetRXABandpassFreqs
+        // directly broke SSB demod because the nbp0 stage rejects
+        // sign-inverted ranges. See docs/prd/panfall_behavior.md.
+        int ctunShiftHz = (int)(CwOffset.EffectiveLoHz(s.Mode, s.VfoHz) - s.RadioLoHz);
         if (ctunShiftHz != _appliedCtunOffsetHz)
         {
             engine.SetCtunShift(channel, ctunShiftHz);
@@ -837,13 +832,11 @@ public class DspPipelineService : BackgroundService,
         engine.SetFilter(channelId, s.FilterLowHz, s.FilterHighHz);
         engine.SetTxFilter(s.TxFilterLowHz, s.TxFilterHighHz);
         engine.SetVfoHz(channelId, s.VfoHz);
-        // Replay any CTUN shift on fresh-channel open so a connect landing
-        // with CtunEnabled already true (persisted across restart) is
-        // demodulating the same dial the operator saw last session.
-        // Issue #427.
-        int ctunShiftHz = s.CtunEnabled
-            ? (int)(CwOffset.EffectiveLoHz(s.Mode, s.VfoHz) - s.RadioLoHz)
-            : 0;
+        // Replay the WDSP shift on fresh-channel open so a connect landing
+        // with VfoHz != RadioLoHz (persisted across restart) is demodulating
+        // the same dial the operator saw last session.
+        // See docs/prd/panfall_behavior.md.
+        int ctunShiftHz = (int)(CwOffset.EffectiveLoHz(s.Mode, s.VfoHz) - s.RadioLoHz);
         engine.SetCtunShift(channelId, ctunShiftHz);
         double effectiveAgc = s.AgcTopDb + s.AgcOffsetDb;
         engine.SetAgcTop(channelId, effectiveAgc);
@@ -1532,15 +1525,12 @@ public class DspPipelineService : BackgroundService,
             // extra contract field needed, per task #7 scope note.
             int zoomLevel = Math.Max(1, state.ZoomLevel);
             float hzPerPixel = (float)((double)sampleRate / zoomLevel / Width);
-            // Panadapter centre = the radio's actual NCO. When CTUN is off this
-            // equals EffectiveLoHz(dial) (legacy behaviour). When CTUN is on the
-            // hardware is frozen at RadioLoHz while the dial roams, so the
-            // pan/waterfall must not follow the dial — they stay anchored to
-            // RadioLoHz so the spectrum doesn't slide under the operator on
-            // every click. Issue #427.
-            long centerHz = state.CtunEnabled
-                ? state.RadioLoHz
-                : CwOffset.EffectiveLoHz(state);
+            // Panadapter centre = the radio's actual NCO. The hardware is
+            // always frozen at RadioLoHz while the dial roams, so the
+            // pan/waterfall stay anchored to RadioLoHz and don't slide under
+            // the operator when only VfoHz moves.
+            // See docs/prd/panfall_behavior.md.
+            long centerHz = state.RadioLoHz;
 
             // Cache for the frequency-calibration service (issue #325). The
             // cal reads from this cache to avoid racing for WDSP's "fresh

--- a/Zeus.Server.Hosting/ExternalPttService.cs
+++ b/Zeus.Server.Hosting/ExternalPttService.cs
@@ -14,6 +14,7 @@
 // statement and per-component attribution.
 
 using Microsoft.Extensions.Hosting;
+using Zeus.Contracts;
 using Zeus.Protocol1;
 
 namespace Zeus.Server;
@@ -132,23 +133,37 @@ public sealed class ExternalPttService : IHostedService, IDisposable
             _owned = true;
         }
 
-        // TxService.TrySetMox locks, broadcasts via the hub, and pokes WDSP
-        // through DspPipelineService — work we don't want on the RX thread.
-        // The fire-and-forget Task.Run is OK because OnHardwarePttChanged is
-        // already edge-triggered (single rise per external press) and a
-        // subsequent fall is handled by HandleFalling regardless of ordering.
-        _ = Task.Run(() =>
+        // GH #426 / bd zeus-7uo — promote MOX synchronously on the RX thread.
+        // The prior fire-and-forget Task.Run let several EP6 IQ frames flow
+        // into WDSP RXA between the radio's first PTT echo and the ThreadPool
+        // scheduling the takeover. With RXA still running while the radio is
+        // already radiating, the panadapter / waterfall briefly paint the
+        // operator's own signal on top of received band noise — the
+        // "simultaneous RX+TX" artefact linoobs reported.
+        //
+        // TrySetMox is safe to invoke from the RX thread: it locks TxService
+        // briefly, flips WDSP RXA→TXA under _engineLock (uncontended — engine
+        // swaps happen on connect/disconnect, not the hot path), and fans out
+        // a hub broadcast (SignalR is internally async). No long-running I/O.
+        //
+        // Tag the rise with MoxSource.Hardware so the release rule in
+        // TxService correctly refuses to drop a CWX-driven transmission via
+        // a stray hardware-PTT release — MoxSourceOwnershipTests already
+        // pins this contract.
+        long t0 = System.Diagnostics.Stopwatch.GetTimestamp();
+        bool ok = _tx.TrySetMox(true, MoxSource.Hardware, out var err);
+        long t1 = System.Diagnostics.Stopwatch.GetTimestamp();
+        if (ok)
         {
-            if (_tx.TrySetMox(true, out var err))
-            {
-                _log.LogInformation("externalPtt.takeover.applied");
-            }
-            else
-            {
-                _log.LogWarning("externalPtt.takeover.rejected reason={Reason}", err);
-                lock (_sync) _owned = false;
-            }
-        });
+            _log.LogInformation(
+                "externalPtt.takeover.applied dtUs={DtUs}",
+                (t1 - t0) * 1_000_000L / System.Diagnostics.Stopwatch.Frequency);
+        }
+        else
+        {
+            _log.LogWarning("externalPtt.takeover.rejected reason={Reason}", err);
+            lock (_sync) _owned = false;
+        }
     }
 
     private void HandleFalling()
@@ -178,9 +193,17 @@ public sealed class ExternalPttService : IHostedService, IDisposable
         lock (_sync) { releaseNow = _owned; _owned = false; }
         if (!releaseNow) return;
 
-        if (_tx.TrySetMox(false, out var err))
+        // Tag the release with the same source that raised it. UI master
+        // override is reserved for an explicit operator click — see
+        // MoxSource.Hardware contract + MoxSourceOwnershipTests.
+        long t0 = System.Diagnostics.Stopwatch.GetTimestamp();
+        bool ok = _tx.TrySetMox(false, MoxSource.Hardware, out var err);
+        long t1 = System.Diagnostics.Stopwatch.GetTimestamp();
+        if (ok)
         {
-            _log.LogInformation("externalPtt.release.applied");
+            _log.LogInformation(
+                "externalPtt.release.applied dtUs={DtUs}",
+                (t1 - t0) * 1_000_000L / System.Diagnostics.Stopwatch.Frequency);
         }
         else
         {

--- a/Zeus.Server.Hosting/ExternalPttService.cs
+++ b/Zeus.Server.Hosting/ExternalPttService.cs
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Microsoft.Extensions.Hosting;
+using Zeus.Protocol1;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Promotes the radio's hardware-PTT echo (C0[0] of every inbound EP6 frame)
+/// into a host-side MOX request. The HL2 gateware generates a shaped CW
+/// envelope on its own whenever the rear KEY tip is grounded — protocol doc
+/// line 200 — so the radio transmits without any host involvement. Without
+/// this service the host stays unkeyed: the MOX UI indicator never lights,
+/// TX meters stay at idle cadence, PsAutoAttenuate doesn't engage, and the
+/// FR-6 120 s TX-timeout never arms.
+///
+/// State machine (per-connection):
+///   • inbound rising AND host MOX/TUN/TwoTone off → claim MOX via
+///     <c>TxService.TrySetMox(true)</c>, mark <c>_owned</c>.
+///   • inbound falling → arm a hang timer (<see cref="HangTime"/>). A rising
+///     edge inside the window cancels it (inter-character CW spaces).
+///   • hang elapsed AND inbound still low AND <c>_owned</c> → release MOX.
+///   • UI/TCI/trip drops MOX externally → <c>_owned</c> clears so the next
+///     hang timer doesn't re-release what someone else changed.
+///
+/// Inbound echo of host-initiated MOX (operator clicks the UI button) lands
+/// here too, but the <c>IsMoxOn || IsTunOn || IsTwoToneOn</c> gate ignores
+/// it because the host is already the source of truth.
+/// </summary>
+public sealed class ExternalPttService : IHostedService, IDisposable
+{
+    // CW operators expect TX to bridge inter-character spaces. 250 ms matches
+    // Thetis's default CW hang — long enough for a ~25 wpm character gap
+    // (~80 ms) plus margin, short enough that releasing a straight key feels
+    // immediate. Not configurable yet; if operators ask for a knob it lives
+    // on the per-mode DSP settings panel alongside the CW pitch.
+    private static readonly TimeSpan HangTime = TimeSpan.FromMilliseconds(250);
+
+    private readonly RadioService _radio;
+    private readonly TxService _tx;
+    private readonly ILogger<ExternalPttService> _log;
+
+    private readonly object _sync = new();
+    private IProtocol1Client? _client;
+    // True iff the most recent MOX-on we caused has not been released yet.
+    // Cleared by the hang-release path, by TxActiveChanged(false) from any
+    // other source, and by disconnect.
+    private bool _owned;
+    // Single-shot timer used to debounce falling edges. Created lazily and
+    // re-armed via Change(); the underlying System.Threading.Timer is thread
+    // safe so cancellation from the RX thread and fire-and-handle on the
+    // ThreadPool coexist cleanly.
+    private Timer? _hangTimer;
+
+    public ExternalPttService(RadioService radio, TxService tx, ILogger<ExternalPttService> log)
+    {
+        _radio = radio;
+        _tx = tx;
+        _log = log;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _radio.Connected += OnConnected;
+        _radio.Disconnected += OnDisconnected;
+        _tx.TxActiveChanged += OnTxActiveChanged;
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _radio.Connected -= OnConnected;
+        _radio.Disconnected -= OnDisconnected;
+        _tx.TxActiveChanged -= OnTxActiveChanged;
+        IProtocol1Client? client;
+        lock (_sync) { client = _client; _client = null; _owned = false; }
+        if (client is not null) client.HardwarePttChanged -= OnHardwarePttChanged;
+        _hangTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+        return Task.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _hangTimer?.Dispose();
+    }
+
+    private void OnConnected(IProtocol1Client client)
+    {
+        lock (_sync) { _client = client; _owned = false; }
+        client.HardwarePttChanged += OnHardwarePttChanged;
+    }
+
+    private void OnDisconnected()
+    {
+        IProtocol1Client? client;
+        lock (_sync) { client = _client; _client = null; _owned = false; }
+        if (client is not null) client.HardwarePttChanged -= OnHardwarePttChanged;
+        _hangTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+    }
+
+    private void OnHardwarePttChanged(bool on)
+    {
+        if (on) HandleRising();
+        else HandleFalling();
+    }
+
+    private void HandleRising()
+    {
+        // Cancel any pending hang-release — operator re-keyed before the
+        // window expired (inter-character CW gap).
+        _hangTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+
+        // Host is already the source of truth. Ignore the echo.
+        if (_tx.IsMoxOn || _tx.IsTunOn || _tx.IsTwoToneOn) return;
+
+        lock (_sync)
+        {
+            if (_owned) return;
+            _owned = true;
+        }
+
+        // TxService.TrySetMox locks, broadcasts via the hub, and pokes WDSP
+        // through DspPipelineService — work we don't want on the RX thread.
+        // The fire-and-forget Task.Run is OK because OnHardwarePttChanged is
+        // already edge-triggered (single rise per external press) and a
+        // subsequent fall is handled by HandleFalling regardless of ordering.
+        _ = Task.Run(() =>
+        {
+            if (_tx.TrySetMox(true, out var err))
+            {
+                _log.LogInformation("externalPtt.takeover.applied");
+            }
+            else
+            {
+                _log.LogWarning("externalPtt.takeover.rejected reason={Reason}", err);
+                lock (_sync) _owned = false;
+            }
+        });
+    }
+
+    private void HandleFalling()
+    {
+        // Arm or re-arm the single-shot hang timer. If we don't own the MOX
+        // (UI is driving) the eventual fire will short-circuit via _owned=false
+        // — but we still arm so a subsequent UI-release after the external key
+        // returns to the steady "external is low, _owned is false" state.
+        var timer = _hangTimer;
+        if (timer is null)
+        {
+            timer = new Timer(OnHangElapsed, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+            _hangTimer = timer;
+        }
+        timer.Change(HangTime, Timeout.InfiniteTimeSpan);
+    }
+
+    private void OnHangElapsed(object? _)
+    {
+        // Race guard: a rising edge inside the hang window cancels the timer,
+        // but the timer can already be in-flight on the ThreadPool when the
+        // cancel arrives. Re-check the latest level before acting.
+        var client = _client;
+        if (client is not null && client.HardwarePtt) return;
+
+        bool releaseNow;
+        lock (_sync) { releaseNow = _owned; _owned = false; }
+        if (!releaseNow) return;
+
+        if (_tx.TrySetMox(false, out var err))
+        {
+            _log.LogInformation("externalPtt.release.applied");
+        }
+        else
+        {
+            _log.LogWarning("externalPtt.release.rejected reason={Reason}", err);
+        }
+    }
+
+    private void OnTxActiveChanged(bool active)
+    {
+        // Any drop of TX-active state from outside our control (UI release,
+        // SWR trip, TCI ZZTX0, …) invalidates our ownership claim. The next
+        // external rise will re-acquire; the next external fall will no-op.
+        if (active) return;
+        lock (_sync) _owned = false;
+    }
+}

--- a/Zeus.Server.Hosting/FrequencyCalibrationService.cs
+++ b/Zeus.Server.Hosting/FrequencyCalibrationService.cs
@@ -135,7 +135,8 @@ public sealed class FrequencyCalibrationService
                 _radio.SetFilter(100, 2700);
                 _radio.SetZoom(CalZoomLevel);
                 long commandedLoHz = (long)(referenceFrequencyHz + IntentionalLoOffsetHz);
-                _radio.SetVfo(commandedLoHz);
+                // Calibration drives the LO absolutely; CTUN must not interpose.
+                _radio.SetVfo(commandedLoHz, fromExternal: true);
 
                 await Task.Delay(SettleMs, ct).ConfigureAwait(false);
 
@@ -203,7 +204,7 @@ public sealed class FrequencyCalibrationService
                 try { _radio.SetMode(origMode); } catch (Exception ex) { _log.LogWarning(ex, "freqcal.restore mode"); }
                 try { _radio.SetFilter(origFilterLo, origFilterHi); } catch (Exception ex) { _log.LogWarning(ex, "freqcal.restore filter"); }
                 try { _radio.SetZoom(origZoom); } catch (Exception ex) { _log.LogWarning(ex, "freqcal.restore zoom"); }
-                try { _radio.SetVfo(origVfoHz); } catch (Exception ex) { _log.LogWarning(ex, "freqcal.restore vfo"); }
+                try { _radio.SetVfo(origVfoHz, fromExternal: true); } catch (Exception ex) { _log.LogWarning(ex, "freqcal.restore vfo"); }
             }
         }
         finally

--- a/Zeus.Server.Hosting/FrequencyCalibrationService.cs
+++ b/Zeus.Server.Hosting/FrequencyCalibrationService.cs
@@ -135,7 +135,9 @@ public sealed class FrequencyCalibrationService
                 _radio.SetFilter(100, 2700);
                 _radio.SetZoom(CalZoomLevel);
                 long commandedLoHz = (long)(referenceFrequencyHz + IntentionalLoOffsetHz);
-                // Calibration drives the LO absolutely; CTUN must not interpose.
+                // Calibration drives the LO absolutely; bypass the frozen-NCO
+                // auto-recenter heuristic so the hardware lands at exactly the
+                // commanded freq.
                 _radio.SetVfo(commandedLoHz, fromExternal: true);
 
                 await Task.Delay(SettleMs, ct).ConfigureAwait(false);

--- a/Zeus.Server.Hosting/LogService.cs
+++ b/Zeus.Server.Hosting/LogService.cs
@@ -207,11 +207,24 @@ public sealed class LogService : IDisposable
         QrzLogId: doc.QrzLogId,
         QrzUploadedUtc: doc.QrzUploadedUtc);
 
-    private static void AppendAdifRecord(StringBuilder sb, LogEntryDocument doc)
+    /// <summary>Internal so AdifUtcTimezoneTests can pin the
+    /// <see cref="DateTime.Kind"/> behaviour without standing up a LiteDB
+    /// round-trip. The method itself remains a private detail of the ADIF
+    /// export path.</summary>
+    internal static void AppendAdifRecord(StringBuilder sb, LogEntryDocument doc)
     {
         AppendAdifField(sb, "CALL", doc.Callsign);
-        AppendAdifField(sb, "QSO_DATE", doc.QsoDateTimeUtc.ToString("yyyyMMdd"));
-        AppendAdifField(sb, "TIME_ON", doc.QsoDateTimeUtc.ToString("HHmmss"));
+        // .ToUniversalTime() is defensive: LiteDB's default BsonMapper
+        // serialises DateTime as Local on write and returns Kind=Local on
+        // read, so `doc.QsoDateTimeUtc` round-trips through the store with
+        // the wrong Kind even though we wrote DateTime.UtcNow at creation
+        // time. .ToString() doesn't do timezone conversion — it just
+        // formats whatever value the DateTime holds. Without the explicit
+        // ToUniversalTime() ADIF would emit local-time clocks, which broke
+        // the QRZ.com upload (the field name is qsoDateTimeUtc precisely
+        // because callers downstream rely on it being UTC).
+        AppendAdifField(sb, "QSO_DATE", doc.QsoDateTimeUtc.ToUniversalTime().ToString("yyyyMMdd"));
+        AppendAdifField(sb, "TIME_ON", doc.QsoDateTimeUtc.ToUniversalTime().ToString("HHmmss"));
         AppendAdifField(sb, "FREQ", doc.FrequencyMhz.ToString("F6", CultureInfo.InvariantCulture));
         AppendAdifField(sb, "BAND", doc.Band);
         AppendAdifField(sb, "MODE", doc.Mode);

--- a/Zeus.Server.Hosting/MeterDisplaySettingsStore.cs
+++ b/Zeus.Server.Hosting/MeterDisplaySettingsStore.cs
@@ -12,22 +12,30 @@ using Zeus.Contracts;
 namespace Zeus.Server;
 
 // Per-operator display-side meter calibration knobs (GitHub #426).
-//
-// Currently surfaces one knob; the entry record carries one extra
-// reserved field for the second knob (max displayed watts) which
-// lands in a follow-up commit. Same single-row LiteDB pattern as
-// PanWfSplitStore / BottomPinStore.
+// Same single-row LiteDB pattern as PanWfSplitStore / BottomPinStore.
 //
 //   * SMeterOffsetDb — signed dB offset added to the displayed RX dBm
 //     value. Trim for real-world antenna / coax / preamp combinations
 //     that shift the WDSP-internal reading by a few dB. Clamped ±20 dB.
-//     Default 0. Display-only — the underlying WDSP / radio physics
-//     are untouched.
+//     Default 0.
+//   * MaxDisplayedWatts — operator override for the TX forward-power
+//     meter full-scale, in Watts. Lets an operator set e.g. 25 W on
+//     a 100 W bracket so the indication fills the bar. Clamped
+//     1..1000 W. 0 means "no override, use radio's MaxWatts as full
+//     scale" (the historical behaviour). Default 0.
+//
+// Display-only — the underlying WDSP / radio physics are untouched.
 public sealed class MeterDisplaySettingsStore : IDisposable
 {
     public const double SMeterOffsetMinDb = -20.0;
     public const double SMeterOffsetMaxDb = 20.0;
     public const double SMeterOffsetDefaultDb = 0.0;
+
+    public const double MaxDisplayedWattsMin = 1.0;
+    public const double MaxDisplayedWattsMax = 1000.0;
+    // 0 = "no override, use the radio's rated MaxWatts" — same value
+    // the wire DTO surfaces to the frontend.
+    public const double MaxDisplayedWattsDefault = 0.0;
 
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<MeterDisplaySettingsEntry> _docs;
@@ -59,9 +67,13 @@ public sealed class MeterDisplaySettingsStore : IDisposable
             var e = _docs.FindAll().FirstOrDefault();
             if (e is null)
             {
-                return new MeterDisplaySettingsDto(SMeterOffsetDb: SMeterOffsetDefaultDb);
+                return new MeterDisplaySettingsDto(
+                    SMeterOffsetDb: SMeterOffsetDefaultDb,
+                    MaxDisplayedWatts: MaxDisplayedWattsDefault);
             }
-            return new MeterDisplaySettingsDto(SMeterOffsetDb: ClampOffset(e.SMeterOffsetDb));
+            return new MeterDisplaySettingsDto(
+                SMeterOffsetDb: ClampOffset(e.SMeterOffsetDb),
+                MaxDisplayedWatts: ClampMaxWatts(e.MaxDisplayedWatts));
         }
     }
 
@@ -80,11 +92,37 @@ public sealed class MeterDisplaySettingsStore : IDisposable
         return Get();
     }
 
+    public MeterDisplaySettingsDto SetMaxDisplayedWatts(double maxWatts)
+    {
+        var clamped = ClampMaxWatts(maxWatts);
+        lock (_sync)
+        {
+            var e = _docs.FindAll().FirstOrDefault() ?? new MeterDisplaySettingsEntry();
+            e.MaxDisplayedWatts = clamped;
+            e.UpdatedUtc = DateTime.UtcNow;
+            if (e.Id == 0) _docs.Insert(e);
+            else _docs.Update(e);
+        }
+        Changed?.Invoke();
+        return Get();
+    }
+
     private static double ClampOffset(double v)
     {
         if (double.IsNaN(v) || double.IsInfinity(v)) return SMeterOffsetDefaultDb;
         if (v < SMeterOffsetMinDb) return SMeterOffsetMinDb;
         if (v > SMeterOffsetMaxDb) return SMeterOffsetMaxDb;
+        return v;
+    }
+
+    private static double ClampMaxWatts(double v)
+    {
+        if (double.IsNaN(v) || double.IsInfinity(v)) return MaxDisplayedWattsDefault;
+        // 0 (or any non-positive value) = "no override". Accept verbatim.
+        // Anything else gets clamped into the legal [1, 1000] range.
+        if (v <= 0) return MaxDisplayedWattsDefault;
+        if (v < MaxDisplayedWattsMin) return MaxDisplayedWattsMin;
+        if (v > MaxDisplayedWattsMax) return MaxDisplayedWattsMax;
         return v;
     }
 
@@ -98,5 +136,11 @@ public sealed class MeterDisplaySettingsEntry
     /// Clamped ±20 dB on read/write. LiteDB hydrates as 0.0 for older
     /// rows that pre-date this field, which matches the default.</summary>
     public double SMeterOffsetDb { get; set; }
+    /// <summary>Operator override for the TX forward-power meter full
+    /// scale, in Watts. 0 = "no override, use the radio's rated
+    /// MaxWatts". Clamped [1, 1000] when non-zero. LiteDB hydrates as
+    /// 0.0 for older rows that pre-date this field, which matches the
+    /// default (no override).</summary>
+    public double MaxDisplayedWatts { get; set; }
     public DateTime UpdatedUtc { get; set; }
 }

--- a/Zeus.Server.Hosting/MeterDisplaySettingsStore.cs
+++ b/Zeus.Server.Hosting/MeterDisplaySettingsStore.cs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using LiteDB;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+// Per-operator display-side meter calibration knobs (GitHub #426).
+//
+// Currently surfaces one knob; the entry record carries one extra
+// reserved field for the second knob (max displayed watts) which
+// lands in a follow-up commit. Same single-row LiteDB pattern as
+// PanWfSplitStore / BottomPinStore.
+//
+//   * SMeterOffsetDb — signed dB offset added to the displayed RX dBm
+//     value. Trim for real-world antenna / coax / preamp combinations
+//     that shift the WDSP-internal reading by a few dB. Clamped ±20 dB.
+//     Default 0. Display-only — the underlying WDSP / radio physics
+//     are untouched.
+public sealed class MeterDisplaySettingsStore : IDisposable
+{
+    public const double SMeterOffsetMinDb = -20.0;
+    public const double SMeterOffsetMaxDb = 20.0;
+    public const double SMeterOffsetDefaultDb = 0.0;
+
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<MeterDisplaySettingsEntry> _docs;
+    private readonly ILogger<MeterDisplaySettingsStore> _log;
+    private readonly object _sync = new();
+
+    public event Action? Changed;
+
+    public MeterDisplaySettingsStore(ILogger<MeterDisplaySettingsStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _docs = _db.GetCollection<MeterDisplaySettingsEntry>("meter_display_settings");
+
+        _log.LogInformation("MeterDisplaySettingsStore initialized at {Path}", dbPath);
+    }
+
+    public MeterDisplaySettingsDto Get()
+    {
+        lock (_sync)
+        {
+            var e = _docs.FindAll().FirstOrDefault();
+            if (e is null)
+            {
+                return new MeterDisplaySettingsDto(SMeterOffsetDb: SMeterOffsetDefaultDb);
+            }
+            return new MeterDisplaySettingsDto(SMeterOffsetDb: ClampOffset(e.SMeterOffsetDb));
+        }
+    }
+
+    public MeterDisplaySettingsDto SetSMeterOffsetDb(double offsetDb)
+    {
+        var clamped = ClampOffset(offsetDb);
+        lock (_sync)
+        {
+            var e = _docs.FindAll().FirstOrDefault() ?? new MeterDisplaySettingsEntry();
+            e.SMeterOffsetDb = clamped;
+            e.UpdatedUtc = DateTime.UtcNow;
+            if (e.Id == 0) _docs.Insert(e);
+            else _docs.Update(e);
+        }
+        Changed?.Invoke();
+        return Get();
+    }
+
+    private static double ClampOffset(double v)
+    {
+        if (double.IsNaN(v) || double.IsInfinity(v)) return SMeterOffsetDefaultDb;
+        if (v < SMeterOffsetMinDb) return SMeterOffsetMinDb;
+        if (v > SMeterOffsetMaxDb) return SMeterOffsetMaxDb;
+        return v;
+    }
+
+    public void Dispose() => _db.Dispose();
+}
+
+public sealed class MeterDisplaySettingsEntry
+{
+    public int Id { get; set; }
+    /// <summary>Signed dB offset applied to the displayed RX dBm.
+    /// Clamped ±20 dB on read/write. LiteDB hydrates as 0.0 for older
+    /// rows that pre-date this field, which matches the default.</summary>
+    public double SMeterOffsetDb { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/MorseEncoder.cs
+++ b/Zeus.Server.Hosting/MorseEncoder.cs
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution. Morse table seeded from the
+// Thetis CWX defaults (Project Files/Source/Console/cwx.cs, load_alpha at
+// the morsedef.txt boot). Thetis is GPL-2.0+; preserving the lineage.
+
+namespace Zeus.Server;
+
+/// <summary>
+/// One emitted CW timing symbol: a stretch of key-down (carrier on) or
+/// key-up (silence). Durations are in milliseconds at the active WPM.
+/// Concatenating the durations yields the full transmission timeline.
+/// </summary>
+public readonly record struct CwSymbol(bool KeyDown, int DurationMs);
+
+/// <summary>
+/// Pure ASCII-text → key-down/key-up timing stream. No side effects, no IO,
+/// no allocation past the returned iterator's local state — safe to call
+/// from any thread.
+///
+/// Timing follows the PARIS-method standard: unit = 1200 / WPM ms.
+/// <list type="bullet">
+///   <item>dit = 1 unit on</item>
+///   <item>dah = 3 units on</item>
+///   <item>intra-element gap (between elements of a char) = 1 unit off</item>
+///   <item>inter-character gap = 3 units off</item>
+///   <item>inter-word gap = 7 units off (absorbs the would-be inter-char gap)</item>
+/// </list>
+///
+/// Inputs are case-folded to upper. Characters not present in the table
+/// (and the Thetis-only macro escapes <c>" # $ &amp;</c>) are silently
+/// skipped — same as Thetis treats undefined entries in morsedef.txt.
+/// </summary>
+public static class MorseEncoder
+{
+    /// <summary>One PARIS dit-unit in ms at <paramref name="wpm"/> WPM.</summary>
+    public static int DitMs(int wpm) => 1200 / wpm;
+
+    // ASCII 32..95, seeded from Thetis morsedef.txt defaults. Entries with
+    // no defined pattern (slot is empty / whitespace-only) and the Thetis
+    // macro escapes (loop ", long-dash #, long-space $, multi-digit &,
+    // reserved _) are absent on purpose — we want a clean "skip unknown"
+    // contract, not a partial port of Thetis's CWX special-char DSL.
+    private static readonly Dictionary<char, string> Table = new()
+    {
+        // Punctuation + special procedural signals
+        ['!'] = "...-.",   // [SN]
+        ['%'] = ".-...",   // [AS]
+        ['('] = "-.--.",   // [KN]
+        ['*'] = "...-.-",  // [SK]
+        ['+'] = ".-.-.",   // [AR]
+        [','] = "--..--",
+        ['-'] = "-....-",
+        ['.'] = ".-.-.-",
+        ['/'] = "-..-.",
+        [':'] = "---...",
+        [';'] = "-.-.-.",
+        ['='] = "-...-",   // [BT]
+        ['?'] = "..--..",
+        ['@'] = ".--.-.",
+        ['\\'] = "-...-.-", // [BK]
+
+        // Digits
+        ['0'] = "-----",
+        ['1'] = ".----",
+        ['2'] = "..---",
+        ['3'] = "...--",
+        ['4'] = "....-",
+        ['5'] = ".....",
+        ['6'] = "-....",
+        ['7'] = "--...",
+        ['8'] = "---..",
+        ['9'] = "----.",
+
+        // Letters
+        ['A'] = ".-",
+        ['B'] = "-...",
+        ['C'] = "-.-.",
+        ['D'] = "-..",
+        ['E'] = ".",
+        ['F'] = "..-.",
+        ['G'] = "--.",
+        ['H'] = "....",
+        ['I'] = "..",
+        ['J'] = ".---",
+        ['K'] = "-.-",
+        ['L'] = ".-..",
+        ['M'] = "--",
+        ['N'] = "-.",
+        ['O'] = "---",
+        ['P'] = ".--.",
+        ['Q'] = "--.-",
+        ['R'] = ".-.",
+        ['S'] = "...",
+        ['T'] = "-",
+        ['U'] = "..-",
+        ['V'] = "...-",
+        ['W'] = ".--",
+        ['X'] = "-..-",
+        ['Y'] = "-.--",
+        ['Z'] = "--..",
+    };
+
+    /// <summary>
+    /// Lazily emit timing symbols for <paramref name="text"/> at
+    /// <paramref name="wpm"/>. Iterating to the end is allocation-light:
+    /// one tiny struct per dit/dah/gap.
+    /// </summary>
+    /// <param name="text">ASCII text. Lowercase is upcased; SPACE / TAB /
+    /// LF / CR all collapse to a single word gap.</param>
+    /// <param name="wpm">Words per minute. Must be ≥ 1; clamp at the call
+    /// site if your UI permits zero/negative.</param>
+    public static IEnumerable<CwSymbol> Encode(string text, int wpm)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        if (wpm < 1) throw new ArgumentOutOfRangeException(nameof(wpm), wpm, "WPM must be ≥ 1");
+
+        int unit = DitMs(wpm);
+        bool atWordStart = true;  // suppresses the leading inter-character gap
+
+        foreach (char raw in text)
+        {
+            char c = char.ToUpperInvariant(raw);
+
+            if (c is ' ' or '\t' or '\n' or '\r')
+            {
+                // Word gap absorbs the inter-character gap that would
+                // otherwise precede the next char, so we mark atWordStart.
+                // Suppress at the very start of the buffer — no point
+                // emitting 7 units of silence before the first character.
+                if (!atWordStart) yield return new CwSymbol(false, unit * 7);
+                atWordStart = true;
+                continue;
+            }
+
+            if (!Table.TryGetValue(c, out var pattern)) continue;
+
+            // Inter-character gap. Skipped when this is the first
+            // character of the buffer or of a fresh word (atWordStart).
+            if (!atWordStart) yield return new CwSymbol(false, unit * 3);
+            atWordStart = false;
+
+            for (int i = 0; i < pattern.Length; i++)
+            {
+                if (i > 0) yield return new CwSymbol(false, unit); // intra-element gap
+                yield return new CwSymbol(true, pattern[i] == '.' ? unit : unit * 3);
+            }
+        }
+    }
+}

--- a/Zeus.Server.Hosting/PanWfSplitStore.cs
+++ b/Zeus.Server.Hosting/PanWfSplitStore.cs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using LiteDB;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+// Persists the vertical split between the panadapter and the waterfall
+// inside the Hero panel. Value is the panadapter share as a percentage
+// (10..90); the waterfall takes the remainder. Single global value for
+// now — if multi-RX panadapters land we can key per-receiver later.
+//
+// Lives in zeus-prefs.db alongside the other UI prefs (BottomPin,
+// NrUiPrefs, ThemeSettings, …) so the choice follows the operator across
+// browsers / devices. Same pattern as BottomPinStore — server-side, not
+// localStorage, per project_litedb_tx_filter_persistence /
+// project_rotator_resume lessons.
+public sealed class PanWfSplitStore : IDisposable
+{
+    public const double DefaultPanPercent = 50.0;
+    public const double MinPanPercent = 10.0;
+    public const double MaxPanPercent = 90.0;
+
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<PanWfSplitEntry> _docs;
+    private readonly ILogger<PanWfSplitStore> _log;
+    private readonly object _sync = new();
+
+    public PanWfSplitStore(ILogger<PanWfSplitStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _docs = _db.GetCollection<PanWfSplitEntry>("pan_wf_split");
+
+        _log.LogInformation("PanWfSplitStore initialized at {Path}", dbPath);
+    }
+
+    public PanWfSplitDto Get()
+    {
+        lock (_sync)
+        {
+            var e = _docs.FindAll().FirstOrDefault();
+            if (e is null) return new PanWfSplitDto(PanPercent: DefaultPanPercent);
+            return new PanWfSplitDto(PanPercent: Clamp(e.PanPercent));
+        }
+    }
+
+    public PanWfSplitDto Save(double panPercent)
+    {
+        var clamped = Clamp(panPercent);
+        lock (_sync)
+        {
+            var e = _docs.FindAll().FirstOrDefault() ?? new PanWfSplitEntry();
+            e.PanPercent = clamped;
+            e.UpdatedUtc = DateTime.UtcNow;
+            if (e.Id == 0) _docs.Insert(e);
+            else _docs.Update(e);
+        }
+        return new PanWfSplitDto(PanPercent: clamped);
+    }
+
+    private static double Clamp(double v)
+    {
+        if (double.IsNaN(v) || double.IsInfinity(v)) return DefaultPanPercent;
+        if (v < MinPanPercent) return MinPanPercent;
+        if (v > MaxPanPercent) return MaxPanPercent;
+        return v;
+    }
+
+    public void Dispose() => _db.Dispose();
+}
+
+public sealed class PanWfSplitEntry
+{
+    public int Id { get; set; }
+    public double PanPercent { get; set; } = PanWfSplitStore.DefaultPanPercent;
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/QrzService.cs
+++ b/Zeus.Server.Hosting/QrzService.cs
@@ -399,14 +399,23 @@ public sealed class QrzService
         return (false, null, reason ?? "Unknown error");
     }
 
-    private static string ConvertLogEntryToAdif(LogEntry entry)
+    /// <summary>Internal so AdifUtcTimezoneTests can verify the QRZ upload
+    /// path emits UTC clock values regardless of the incoming entry's
+    /// <see cref="DateTime.Kind"/>. The method is otherwise a private
+    /// detail of the publish path.</summary>
+    internal static string ConvertLogEntryToAdif(LogEntry entry)
     {
         var sb = new System.Text.StringBuilder();
 
         // Required fields
         AppendAdifField(sb, "CALL", entry.Callsign);
-        AppendAdifField(sb, "QSO_DATE", entry.QsoDateTimeUtc.ToString("yyyyMMdd"));
-        AppendAdifField(sb, "TIME_ON", entry.QsoDateTimeUtc.ToString("HHmmss"));
+        // .ToUniversalTime() guards against the LiteDB round-trip stripping
+        // the UTC kind off QsoDateTimeUtc — see LogService.AppendAdifRecord
+        // for the full story. Without it QRZ.com receives local-clock times
+        // and stamps the QSOs at the operator's wall-clock hour, breaking
+        // award credit and DXCC matching for anyone outside UTC.
+        AppendAdifField(sb, "QSO_DATE", entry.QsoDateTimeUtc.ToUniversalTime().ToString("yyyyMMdd"));
+        AppendAdifField(sb, "TIME_ON", entry.QsoDateTimeUtc.ToUniversalTime().ToString("HHmmss"));
         AppendAdifField(sb, "FREQ", entry.FrequencyMhz.ToString("F6", System.Globalization.CultureInfo.InvariantCulture));
         AppendAdifField(sb, "BAND", entry.Band);
         AppendAdifField(sb, "MODE", entry.Mode);

--- a/Zeus.Server.Hosting/RadioCodecAudioSink.cs
+++ b/Zeus.Server.Hosting/RadioCodecAudioSink.cs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Microsoft.Extensions.Logging;
+using Zeus.Contracts;
+using Zeus.Protocol1;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// <see cref="IRxAudioSink"/> that routes demodulated RX audio (mono float32
+/// 48 kHz) back to the radio's on-board audio codec via EP2 outbound L/R
+/// bytes. Operators on Hermes / ANAN-class / OrionMkII boards plug
+/// headphones into the radio's front-panel jack and hear receive audio
+/// without any host-audio plumbing. Issue #426.
+///
+/// Joins the existing <c>IRxAudioSink</c> fan-out collection consumed by
+/// <see cref="DspPipelineService"/> — sits alongside <see cref="WebSocketAudioSink"/>
+/// / <see cref="NativeAudioSink"/> so the operator can hear audio in the
+/// browser / desktop speakers AND on the radio's headphone jack
+/// simultaneously.
+///
+/// Gating is by-board: this sink only writes to the ring when the
+/// connected radio actually has a codec (i.e. <see cref="BoardCapabilities.HasOnboardCodec"/>
+/// is true). HermesLite2 has no codec — the wire bytes are ignored by the
+/// firmware either way, so skipping the work saves a few cycles. The
+/// no-board (synthetic / pre-connect) case also short-circuits via
+/// <c>UnknownDefaults</c>.
+/// </summary>
+internal sealed class RadioCodecAudioSink : IRxAudioSink
+{
+    private const int FrameRateHz = 48_000;
+
+    private readonly RxCodecAudioRing _ring;
+    private readonly RadioService _radio;
+    private readonly ILogger<RadioCodecAudioSink> _log;
+
+    public RadioCodecAudioSink(
+        RxCodecAudioRing ring,
+        RadioService radio,
+        ILogger<RadioCodecAudioSink> log)
+    {
+        _ring = ring;
+        _radio = radio;
+        _log = log;
+    }
+
+    public void Publish(in AudioFrame frame)
+    {
+        // Skip the cost when the connected board has no codec to receive
+        // these bytes. ConnectedBoardKind defaults to Unknown pre-connect,
+        // and HL2 has HasOnboardCodec=false — both short-circuit here.
+        var caps = BoardCapabilitiesTable.For(_radio.ConnectedBoardKind, _radio.EffectiveOrionMkIIVariant);
+        if (!caps.HasOnboardCodec) return;
+
+        // The DSP tick produces mono float32 @ 48 kHz. Anything else (e.g.
+        // a future RX2 stereo path) is dropped silently — the codec is mono
+        // anyway, so the right answer is for whoever owns that path to
+        // downmix before publishing.
+        if (frame.Channels != 1 || frame.SampleRateHz != FrameRateHz) return;
+
+        _ring.Write(frame.Samples.Span);
+    }
+}

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -179,7 +179,16 @@ public sealed class RadioService : IDisposable
     // to its internal test-tone generator (dev / tests without a hub).
     private readonly Zeus.Protocol1.ITxIqSource? _txIqSource;
 
-    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, FilterPresetStore? filterPresetStore = null, Zeus.Protocol1.ITxIqSource? txIqSource = null, PreferredRadioStore? preferredRadioStore = null, PsSettingsStore? psStore = null, RadioStateStore? radioStateStore = null)
+    // Shared RX-codec audio source — WDSP RX output routed back to the
+    // radio's on-board codec so operators on Hermes / ANAN-class / OrionMkII
+    // boards can plug headphones into the radio's front-panel jack and hear
+    // demodulated audio. Issue #426. RadioCodecAudioSink writes float samples
+    // into this ring; Protocol1Client drains it into EP2 L/R bytes.
+    // Null on the synthetic / discovery-only path; the radio sees zero
+    // audio bytes (matching pre-#426 HL2-only behaviour).
+    private readonly Zeus.Protocol1.IRxCodecAudioSource? _rxCodecAudioSource;
+
+    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, FilterPresetStore? filterPresetStore = null, Zeus.Protocol1.ITxIqSource? txIqSource = null, PreferredRadioStore? preferredRadioStore = null, PsSettingsStore? psStore = null, RadioStateStore? radioStateStore = null, Zeus.Protocol1.IRxCodecAudioSource? rxCodecAudioSource = null)
     {
         _loggerFactory = loggerFactory;
         _log = loggerFactory.CreateLogger<RadioService>();
@@ -193,6 +202,7 @@ public sealed class RadioService : IDisposable
         if (_preferredRadioStore is not null)
             _preferredRadioStore.Changed += RecomputePaAndPush;
         _txIqSource = txIqSource;
+        _rxCodecAudioSource = rxCodecAudioSource;
 
         // Load persisted DSP settings from the store, or use defaults if not found
         var persistedNr = _dspSettingsStore.Get() ?? new NrConfig();
@@ -441,7 +451,8 @@ public sealed class RadioService : IDisposable
 
             client = new Protocol1Client(
                 _loggerFactory.CreateLogger<Protocol1Client>(),
-                _txIqSource);
+                _txIqSource,
+                _rxCodecAudioSource);
             client.AdcOverloadObserved += OnAdcOverload;
             _activeClient = client;
             _state = _state with
@@ -561,6 +572,11 @@ public sealed class RadioService : IDisposable
             client.AdcOverloadObserved -= OnAdcOverload;
             Disconnected?.Invoke();
             await TearDownClientAsync(client, ct).ConfigureAwait(false);
+            // Drop any queued RX-codec audio so the next connect starts
+            // clean — otherwise on a quick disconnect/reconnect the operator
+            // hears a fraction of a second of stale audio in the radio's
+            // headphone jack. Issue #426.
+            (_rxCodecAudioSource as Zeus.Protocol1.RxCodecAudioRing)?.Clear();
             _log.LogInformation("radio.disconnected");
         }
 

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -267,6 +267,11 @@ public sealed class RadioService : IDisposable
             TxFilterLowHz: rsSnap?.TxFilterLowHz ?? 150,
             TxFilterHighHz: rsSnap?.TxFilterHighHz ?? 2850,
             RxAfGainDb: rsSnap?.RxAfGainDb ?? 0.0,
+            // 0 dB unity matches the engine's TXA fresh-open default; legacy
+            // rows missing the field hydrate to that same default.
+            MicGainDb: Math.Clamp(rsSnap?.MicGainDb ?? 0, -40, 10),
+            // 8.0 dB matches WdspDspEngine.DefaultLevelerMaxGainDb.
+            LevelerMaxGainDb: Math.Clamp(rsSnap?.LevelerMaxGainDb ?? 8.0, 0.0, 15.0),
             AutoAgcEnabled: rsSnap?.AutoAgcEnabled ?? false,
             AgcOffsetDb: 0.0,       // always reset — control-loop accumulator
             // PS persisted fields (or DTO defaults when not persisted yet).
@@ -1310,6 +1315,26 @@ public sealed class RadioService : IDisposable
         return Snapshot();
     }
 
+    // TX mic gain in dB. Server-clamped to [-40, +10] to match the endpoint
+    // contract and Thetis's MicGainMin/Max defaults. The dB → linear (10^(db/20))
+    // conversion happens at the engine seam in DspPipelineService so the wire
+    // and persisted form is the operator-friendly integer.
+    public StateDto SetTxMicGain(int db)
+    {
+        int clamped = Math.Clamp(db, -40, 10);
+        Mutate(s => s with { MicGainDb = clamped });
+        return Snapshot();
+    }
+
+    // TX Leveler max-gain ceiling in dB. Server-clamped to [0, 15]; same
+    // operator-safe band the endpoint already enforced.
+    public StateDto SetTxLevelerMaxGain(double db)
+    {
+        double clamped = Math.Clamp(db, 0.0, 15.0);
+        Mutate(s => s with { LevelerMaxGainDb = clamped });
+        return Snapshot();
+    }
+
     public StateDto SetNr(NrConfig cfg)
     {
         ArgumentNullException.ThrowIfNull(cfg);
@@ -1685,6 +1710,8 @@ public sealed class RadioService : IDisposable
                 AttenDb = snap.AttenDb,
                 AutoAgcEnabled = snap.AutoAgcEnabled,
                 RxAfGainDb = snap.RxAfGainDb,
+                MicGainDb = snap.MicGainDb,
+                LevelerMaxGainDb = snap.LevelerMaxGainDb,
                 ZoomLevel = snap.ZoomLevel,
                 SsbFilterLoAbs = ssb.LoAbs,   SsbFilterHiAbs = ssb.HiAbs,
                 AmFilterLoAbs = am.LoAbs,     AmFilterHiAbs = am.HiAbs,

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -573,22 +573,85 @@ public sealed class RadioService : IDisposable
         return Snapshot();
     }
 
-    public StateDto SetVfo(long hz)
+    public StateDto SetVfo(long hz) => SetVfo(hz, fromExternal: false);
+
+    /// <summary>
+    /// Set the VFO frequency. <paramref name="fromExternal"/> tags the source
+    /// as a CAT/TCI/calibration caller (vs. UI / panadapter click). External
+    /// callers bypass the CTUN auto-recenter heuristics and always retune the
+    /// hardware — matching Thetis's <c>CATChangesCenterFreq=true</c> default
+    /// (console.cs:32082, CATCommands.cs:2690). Without this, a 5–10 kHz FT8
+    /// → FT4 hop via TCI would stay inside the IF, leave CTUN's WDSP shift in
+    /// place, and the radio would TX on the wrong frequency.
+    /// </summary>
+    public StateDto SetVfo(long hz, bool fromExternal)
     {
         long clamped = Math.Clamp(hz, 0L, 60_000_000L);
         long previous;
+        long radioLo;
         RxMode currentMode;
         bool ctun;
-        lock (_sync) { previous = _state.VfoHz; currentMode = _state.Mode; ctun = _state.CtunEnabled; }
-        // CTUN ON: don't retune the hardware NCO. The radio stays at RadioLoHz
-        // and WDSP's RX bandpass is shifted by DspPipelineService so the
-        // operator's tuned signal still lands inside the passband. Issue #427.
-        // CTUN OFF: legacy behaviour — RadioLoHz tracks VfoHz so the radio is
-        // re-tuned to the clamped dial.
-        Mutate(s => ctun
-            ? s with { VfoHz = clamped }
-            : s with { VfoHz = clamped, RadioLoHz = clamped });
-        if (!ctun)
+        int sampleRate;
+        int zoomLevel;
+        int filterLow;
+        int filterHigh;
+        lock (_sync)
+        {
+            previous = _state.VfoHz;
+            currentMode = _state.Mode;
+            ctun = _state.CtunEnabled;
+            radioLo = _state.RadioLoHz;
+            sampleRate = _state.SampleRate;
+            zoomLevel = Math.Max(1, _state.ZoomLevel);
+            filterLow = _state.FilterLowHz;
+            filterHigh = _state.FilterHighHz;
+        }
+        // CTUN auto-recenter — mirrors Thetis txtVFOAFreq_LostFocus
+        // (console.cs:32189-32257) for UI-sourced changes. With CTUN on, two
+        // conditions force a hardware retune so the radio doesn't get "stuck":
+        //   (a) the resulting WDSP shift would push the filter edge outside
+        //       the visible panadapter span (Thetis dispMargin = 5% inset),
+        //   (b) the shift exceeds the IF capacity (Thetis uses
+        //       sample_rate * 0.92 / 2 — mirrored as sampleRate * 0.46).
+        // CAT / TCI / calibration callers (fromExternal=true) bypass both
+        // checks: those sources are expected to drive the radio absolutely
+        // (digital-mode workflows, memory recall, etc.) and CTUN should not
+        // hold the LO behind. Mirrors Thetis CATChangesCenterFreq=true default
+        // (console.cs:32082, CATCommands.cs:2690 ZZFA / 2741 ZZFB).
+        // Either way, when retune fires the CTUN state stays on; the NCO just
+        // snaps to the new dial and ctunShiftHz returns to 0 until the next
+        // panadapter-local movement. Issue #461.
+        bool retune;
+        if (ctun && !fromExternal)
+        {
+            long effectiveLoNew = CwOffset.EffectiveLoHz(currentMode, clamped);
+            long proposedShift = effectiveLoNew - radioLo;
+            long lMargin = Math.Max(0, -filterLow);
+            long hMargin = Math.Max(0, filterHigh);
+            double dispWidth = (double)sampleRate / zoomLevel;
+            double dispMarginHz = dispWidth * 0.05;
+            double lDisp = -dispWidth / 2.0 + dispMarginHz;
+            double hDisp = dispWidth / 2.0 - dispMarginHz;
+            bool outsideVisible = (proposedShift - lMargin) < lDisp
+                               || (proposedShift + hMargin) > hDisp;
+            long ifCapacity = (long)(sampleRate * 0.46);
+            bool outsideIf = Math.Abs(proposedShift) > ifCapacity;
+            retune = outsideVisible || outsideIf;
+        }
+        else
+        {
+            retune = true;
+        }
+        // CTUN-off path stores the raw dial in RadioLoHz (panadapter centre
+        // and P2 push both re-derive via EffectiveLoHz). CTUN-on auto-recenter
+        // path freezes the post-cw_pitch NCO so ctunShiftHz settles at 0.
+        long radioLoNew = ctun
+            ? CwOffset.EffectiveLoHz(currentMode, clamped)
+            : clamped;
+        Mutate(s => retune
+            ? s with { VfoHz = clamped, RadioLoHz = radioLoNew }
+            : s with { VfoHz = clamped });
+        if (retune)
         {
             // CW retunes the LO cw_pitch below/above the dial so the listening
             // freq lands on the +cw_pitch / -cw_pitch audio passband. In SSB /

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -305,7 +305,8 @@ public sealed class RadioService : IDisposable
             // unconditional — see docs/prd/panfall_behavior.md.
             RadioLoHz: (rsSnap?.RadioLoHz ?? 0L) != 0L
                 ? rsSnap!.RadioLoHz
-                : (rsSnap?.VfoHz ?? 14_200_000));
+                : (rsSnap?.VfoHz ?? 14_200_000),
+            CwPitchHz: CwOffset.CwPitchHz);
 
         // Kick off the debounce flush timer. Fires every 1 s; only writes to
         // LiteDB when _stateDirty is set (i.e., at least one Mutate() has fired

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -602,54 +602,26 @@ public sealed class RadioService : IDisposable
     {
         long clamped = Math.Clamp(hz, 0L, 60_000_000L);
         long previous;
-        long radioLo;
         RxMode currentMode;
-        int sampleRate;
-        int zoomLevel;
-        int filterLow;
-        int filterHigh;
         lock (_sync)
         {
             previous = _state.VfoHz;
             currentMode = _state.Mode;
-            radioLo = _state.RadioLoHz;
-            sampleRate = _state.SampleRate;
-            zoomLevel = Math.Max(1, _state.ZoomLevel);
-            filterLow = _state.FilterLowHz;
-            filterHigh = _state.FilterHighHz;
         }
-        bool retune;
-        if (!fromExternal)
-        {
-            long effectiveLoNew = CwOffset.EffectiveLoHz(currentMode, clamped);
-            long proposedShift = effectiveLoNew - radioLo;
-            long lMargin = Math.Max(0, -filterLow);
-            long hMargin = Math.Max(0, filterHigh);
-            double dispWidth = (double)sampleRate / zoomLevel;
-            double dispMarginHz = dispWidth * 0.05;
-            double lDisp = -dispWidth / 2.0 + dispMarginHz;
-            double hDisp = dispWidth / 2.0 - dispMarginHz;
-            bool outsideVisible = (proposedShift - lMargin) < lDisp
-                               || (proposedShift + hMargin) > hDisp;
-            long ifCapacity = (long)(sampleRate * 0.46);
-            bool outsideIf = Math.Abs(proposedShift) > ifCapacity;
-            retune = outsideVisible || outsideIf;
-        }
-        else
-        {
-            retune = true;
-        }
+        // Classic "radio follows the dial" tuning. The CTUN frozen-NCO model
+        // (#470) was reverted: it pinned the hardware NCO at the panadapter
+        // centre and offset RX in WDSP, but neither protocol client has a
+        // separate TX VFO (ControlFrame writes one VfoAHz to every freq
+        // register), so TX transmitted on the frozen centre instead of the
+        // dial. Every tune now retunes the radio so RX *and* TX track the dial;
+        // RadioLoHz follows the dial's effective LO (CW: dial ∓ pitch), which
+        // leaves the WDSP CTUN-shift stage at zero. The fromExternal flag is
+        // kept for API compatibility but no longer changes behaviour — all
+        // tunes retune now.
+        _ = fromExternal;
         long radioLoNew = CwOffset.EffectiveLoHz(currentMode, clamped);
-        Mutate(s => retune
-            ? s with { VfoHz = clamped, RadioLoHz = radioLoNew }
-            : s with { VfoHz = clamped });
-        if (retune)
-        {
-            // CW retunes the LO cw_pitch below/above the dial so the listening
-            // freq lands on the +cw_pitch / -cw_pitch audio passband. In SSB /
-            // AM / FM / DIG modes EffectiveLoHz returns the dial unchanged.
-            ActiveClient?.SetVfoAHz(radioLoNew);
-        }
+        Mutate(s => s with { VfoHz = clamped, RadioLoHz = radioLoNew });
+        ActiveClient?.SetVfoAHz(radioLoNew);
         // Band edge crossed? Per-band PA gain / OC bits may have swapped — push
         // the new snapshot before the next TX frame ships. Cheap when no
         // crossing occurred (same bytes re-pushed).

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -1227,8 +1227,9 @@ public sealed class RadioService : IDisposable
         bool paEnabled = cfg.Global.PaEnabled && !bandCfg.DisablePa;
 
         _log.LogInformation(
-            "pa.recompute tunActive={Tun} pct={Pct} band={Band} gainDb={Gain:F2} maxW={Max} profile={Profile} -> byte={Byte} paEn={PaEn}",
-            tunActive, activePct, bandName ?? "?", bandCfg.PaGainDb, cfg.Global.PaMaxPowerWatts, driveProfile.BoardLabel, driveByte, paEnabled);
+            "pa.recompute tunActive={Tun} pct={Pct} band={Band} gainDb={Gain:F2} maxW={Max} profile={Profile} -> byte={Byte} paEn={PaEn} ocTx=0x{OcTx:X2} ocRx=0x{OcRx:X2} ocDxTx=0x{OcDxTx:X2} ocDxRx=0x{OcDxRx:X2}",
+            tunActive, activePct, bandName ?? "?", bandCfg.PaGainDb, cfg.Global.PaMaxPowerWatts, driveProfile.BoardLabel, driveByte, paEnabled,
+            bandCfg.OcTx, bandCfg.OcRx, bandCfg.OcDxTx, bandCfg.OcDxRx);
 
         ActiveClient?.SetDriveByte(driveByte);
         ActiveClient?.SetOcMasks(bandCfg.OcTx, bandCfg.OcRx);

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -292,11 +292,12 @@ public sealed class RadioService : IDisposable
             // become the only path that puts these into the broadcast.
             DrivePct: Volatile.Read(ref _drivePct),
             TunePct: Volatile.Read(ref _tunePct),
-            // CTUN — issue #427. Persisted in RadioStateStore so the operator's
-            // last click-tune mode survives restart. RadioLoHz snaps to VfoHz
-            // on legacy rows (RadioLoHz==0) so the panadapter centre is never
-            // zero on a fresh row written by an older build.
-            CtunEnabled: rsSnap?.CtunEnabled ?? false,
+            // Hardware NCO — persisted in RadioStateStore so a restart resumes
+            // on the same physical centre. RadioLoHz snaps to VfoHz on legacy
+            // rows (RadioLoHz==0 — e.g. rows written by the old CTUN-off
+            // branch) so the panadapter centre is never zero on a fresh
+            // hydration. CTUN behaviour (frozen NCO, dial roams) is now
+            // unconditional — see docs/prd/panfall_behavior.md.
             RadioLoHz: (rsSnap?.RadioLoHz ?? 0L) != 0L
                 ? rsSnap!.RadioLoHz
                 : (rsSnap?.VfoHz ?? 14_200_000));
@@ -478,14 +479,13 @@ public sealed class RadioService : IDisposable
                 }
             }
             await client.StartAsync(new StreamConfig(hpsdrRate, _preampOn, _atten), ct).ConfigureAwait(false);
-            // CTUN-on across restart: retune the radio to the persisted hardware
-            // NCO (RadioLoHz), not to EffectiveLoHz(dial), so the operator's
-            // last frozen centre is restored. Issue #427.
+            // Retune the radio to the persisted hardware NCO (RadioLoHz). The
+            // dial (VfoHz) may sit elsewhere; WDSP's shift stage covers the
+            // gap. Hydration above already guarantees RadioLoHz != 0 by
+            // snapping to VfoHz on legacy rows, so a plain SetVfoAHz here is
+            // always valid. See docs/prd/panfall_behavior.md.
             var connectSnap = Snapshot();
-            long connectLoHz = connectSnap.CtunEnabled
-                ? connectSnap.RadioLoHz
-                : CwOffset.EffectiveLoHz(connectSnap);
-            client.SetVfoAHz(connectLoHz);
+            client.SetVfoAHz(connectSnap.RadioLoHz);
 
             // Default-on the N2ADR 7-relay filter board for HL2 — mirrors
             // Thetis's HERCULES preset (setup.cs:14642). Most HL2 deployments
@@ -576,13 +576,21 @@ public sealed class RadioService : IDisposable
     public StateDto SetVfo(long hz) => SetVfo(hz, fromExternal: false);
 
     /// <summary>
-    /// Set the VFO frequency. <paramref name="fromExternal"/> tags the source
-    /// as a CAT/TCI/calibration caller (vs. UI / panadapter click). External
-    /// callers bypass the CTUN auto-recenter heuristics and always retune the
-    /// hardware — matching Thetis's <c>CATChangesCenterFreq=true</c> default
-    /// (console.cs:32082, CATCommands.cs:2690). Without this, a 5–10 kHz FT8
-    /// → FT4 hop via TCI would stay inside the IF, leave CTUN's WDSP shift in
-    /// place, and the radio would TX on the wrong frequency.
+    /// Set the VFO (dial) frequency. The frozen-NCO model prefers to leave the
+    /// hardware alone — DspPipelineService recomputes the WDSP shift stage so
+    /// the tuned signal still lands at baseband. Two cases force a hardware
+    /// auto-retune anyway so the radio doesn't get "stuck": (a) the resulting
+    /// shift would push the filter edge outside the visible panadapter span
+    /// (Thetis dispMargin = 5% inset), or (b) the shift exceeds the IF
+    /// capacity (sample_rate * 0.46). External sources (CAT/TCI/calibration,
+    /// <paramref name="fromExternal"/>=true) bypass the heuristics and always
+    /// retune — mirrors Thetis <c>CATChangesCenterFreq=true</c> (console.cs:
+    /// 32082, CATCommands.cs:2690). Without this, a 5–10 kHz FT8 → FT4 hop
+    /// via TCI would stay inside the IF and the radio would TX on the wrong
+    /// frequency. Issues #461 and zeus-nnc — see docs/prd/panfall_behavior.md.
+    /// Operator-driven "pure pan" movements (panadapter drag release past
+    /// the IQ window edge) take the explicit POST /api/radio/lo path
+    /// instead, leaving VfoHz untouched.
     /// </summary>
     public StateDto SetVfo(long hz, bool fromExternal)
     {
@@ -590,7 +598,6 @@ public sealed class RadioService : IDisposable
         long previous;
         long radioLo;
         RxMode currentMode;
-        bool ctun;
         int sampleRate;
         int zoomLevel;
         int filterLow;
@@ -599,30 +606,14 @@ public sealed class RadioService : IDisposable
         {
             previous = _state.VfoHz;
             currentMode = _state.Mode;
-            ctun = _state.CtunEnabled;
             radioLo = _state.RadioLoHz;
             sampleRate = _state.SampleRate;
             zoomLevel = Math.Max(1, _state.ZoomLevel);
             filterLow = _state.FilterLowHz;
             filterHigh = _state.FilterHighHz;
         }
-        // CTUN auto-recenter — mirrors Thetis txtVFOAFreq_LostFocus
-        // (console.cs:32189-32257) for UI-sourced changes. With CTUN on, two
-        // conditions force a hardware retune so the radio doesn't get "stuck":
-        //   (a) the resulting WDSP shift would push the filter edge outside
-        //       the visible panadapter span (Thetis dispMargin = 5% inset),
-        //   (b) the shift exceeds the IF capacity (Thetis uses
-        //       sample_rate * 0.92 / 2 — mirrored as sampleRate * 0.46).
-        // CAT / TCI / calibration callers (fromExternal=true) bypass both
-        // checks: those sources are expected to drive the radio absolutely
-        // (digital-mode workflows, memory recall, etc.) and CTUN should not
-        // hold the LO behind. Mirrors Thetis CATChangesCenterFreq=true default
-        // (console.cs:32082, CATCommands.cs:2690 ZZFA / 2741 ZZFB).
-        // Either way, when retune fires the CTUN state stays on; the NCO just
-        // snaps to the new dial and ctunShiftHz returns to 0 until the next
-        // panadapter-local movement. Issue #461.
         bool retune;
-        if (ctun && !fromExternal)
+        if (!fromExternal)
         {
             long effectiveLoNew = CwOffset.EffectiveLoHz(currentMode, clamped);
             long proposedShift = effectiveLoNew - radioLo;
@@ -642,12 +633,7 @@ public sealed class RadioService : IDisposable
         {
             retune = true;
         }
-        // CTUN-off path stores the raw dial in RadioLoHz (panadapter centre
-        // and P2 push both re-derive via EffectiveLoHz). CTUN-on auto-recenter
-        // path freezes the post-cw_pitch NCO so ctunShiftHz settles at 0.
-        long radioLoNew = ctun
-            ? CwOffset.EffectiveLoHz(currentMode, clamped)
-            : clamped;
+        long radioLoNew = CwOffset.EffectiveLoHz(currentMode, clamped);
         Mutate(s => retune
             ? s with { VfoHz = clamped, RadioLoHz = radioLoNew }
             : s with { VfoHz = clamped });
@@ -655,9 +641,8 @@ public sealed class RadioService : IDisposable
         {
             // CW retunes the LO cw_pitch below/above the dial so the listening
             // freq lands on the +cw_pitch / -cw_pitch audio passband. In SSB /
-            // AM / FM / DIG modes EffectiveLoHz returns the dial value
-            // unchanged, preserving prior behaviour.
-            ActiveClient?.SetVfoAHz(CwOffset.EffectiveLoHz(currentMode, clamped));
+            // AM / FM / DIG modes EffectiveLoHz returns the dial unchanged.
+            ActiveClient?.SetVfoAHz(radioLoNew);
         }
         // Band edge crossed? Per-band PA gain / OC bits may have swapped — push
         // the new snapshot before the next TX frame ships. Cheap when no
@@ -670,45 +655,26 @@ public sealed class RadioService : IDisposable
     }
 
     /// <summary>
-    /// Toggle CTUN (Click-Tune) mode. On enable, the hardware NCO is frozen at
-    /// the current VfoHz — subsequent SetVfo calls update the dial without
-    /// retuning the radio, and the DSP pipeline shifts the RX bandpass to keep
-    /// the operator's tuned signal demodulated. On disable, RadioLoHz snaps
-    /// back to VfoHz and the radio is re-tuned to the current dial so the
-    /// hardware centre matches what the operator sees again. Mirrors Thetis
-    /// chkFWCATU_CheckedChanged (console.cs:43143-43170). Issue #427.
+    /// Set the radio's hardware NCO (LO) centre frequency in Hz, leaving
+    /// VfoHz untouched. Returns the updated <see cref="StateDto"/>.
+    /// Out-of-range values are clamped to [0, 60_000_000]; callers wanting
+    /// strict rejection should validate before calling. Triggers a P1 client
+    /// SetVfoAHz (and the P2 path via DspPipelineService.OnRadioStateChanged
+    /// reading the new RadioLoHz), and a PA recompute if the LO crossed a
+    /// band edge. WDSP's shift stage is updated by DspPipelineService so the
+    /// dial-relative demodulation remains correct.
     /// </summary>
-    public StateDto SetCtun(bool enabled)
+    public StateDto SetRadioLo(long hz)
     {
-        long retuneTo = 0;
-        RxMode currentMode = RxMode.USB;
-        bool retune = false;
-        Mutate(s =>
+        long clamped = Math.Clamp(hz, 0L, 60_000_000L);
+        long previous;
+        lock (_sync) { previous = _state.RadioLoHz; }
+        Mutate(s => s with { RadioLoHz = clamped });
+        ActiveClient?.SetVfoAHz(clamped);
+        if (BandUtils.FreqToBand(previous) != BandUtils.FreqToBand(clamped))
         {
-            if (s.CtunEnabled == enabled) return s;
-            currentMode = s.Mode;
-            if (enabled)
-            {
-                // Freeze the hardware NCO at its CURRENT value — which equals
-                // EffectiveLoHz(dial), accounting for cw_pitch in CWU/CWL. Using
-                // s.VfoHz directly would be wrong on CW: the hardware is at
-                // dial ± cw_pitch, not at the dial itself.
-                return s with
-                {
-                    CtunEnabled = true,
-                    RadioLoHz = CwOffset.EffectiveLoHz(s.Mode, s.VfoHz),
-                };
-            }
-            // Re-snap the hardware NCO to the operator's current dial and
-            // retune the radio to match below, outside the lock. RadioLoHz
-            // tracks the dial when CTUN is off so SetVfo's CTUN-off branch
-            // can keep RadioLoHz == VfoHz invariant.
-            retune = true;
-            retuneTo = s.VfoHz;
-            return s with { CtunEnabled = false, RadioLoHz = s.VfoHz };
-        });
-        if (retune)
-            ActiveClient?.SetVfoAHz(CwOffset.EffectiveLoHz(currentMode, retuneTo));
+            RecomputePaAndPush();
+        }
         return Snapshot();
     }
 
@@ -1730,7 +1696,6 @@ public sealed class RadioService : IDisposable
                 CwTxFilterLoAbs = cwTx.LoAbs,   CwTxFilterHiAbs = cwTx.HiAbs,
                 DrivePct = snap.DrivePct,
                 TunePct = snap.TunePct,
-                CtunEnabled = snap.CtunEnabled,
                 RadioLoHz = snap.RadioLoHz,
                 UpdatedUtc = DateTime.UtcNow,
             });

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -684,6 +684,44 @@ public sealed class RadioService : IDisposable
         return Snapshot();
     }
 
+    /// <summary>
+    /// Force the hardware LO to the canonical CW-mode offset of the
+    /// displayed VFO (LO = VFO − pitch for CWU, LO = VFO + pitch for CWL)
+    /// so a CW transmission lands the carrier on the dial. No-op for non-CW
+    /// modes and when the LO is already aligned.
+    ///
+    /// Background: CTUN (centred tuning) lets the operator click-tune the
+    /// panadapter without moving the hardware LO; <see cref="SetVfo"/>
+    /// updates only the displayed VFO and lets WDSP's shift stage move the
+    /// signal to baseband. That trick works fine for RX, but TX shares the
+    /// same physical NCO — if we keyed the radio while CTUN was active, the
+    /// carrier would land at <c>LO ± pitch</c> in real RF, not at the dial.
+    /// The host-side CW engine calls this before each transmission to
+    /// guarantee the operator-tuned freq is what reaches the antenna; the
+    /// pattern is the TCI-equivalent of "external retune" — see issue
+    /// <c>zeus-drf</c> bench notes (2026-05-24).
+    ///
+    /// Returns true when the LO was actually moved (caller may want to
+    /// log it for diagnostics), false on no-op.
+    /// </summary>
+    public bool AlignLoForCwTx()
+    {
+        long vfo;
+        RxMode mode;
+        long currentLo;
+        lock (_sync)
+        {
+            vfo = _state.VfoHz;
+            mode = _state.Mode;
+            currentLo = _state.RadioLoHz;
+        }
+        if (mode != RxMode.CWU && mode != RxMode.CWL) return false;
+        long targetLo = CwOffset.EffectiveLoHz(mode, vfo);
+        if (targetLo == currentLo) return false;
+        SetRadioLo(targetLo);
+        return true;
+    }
+
     // Per-mode-family remembered filter magnitudes. Mode switching snapshots
     // the current abs-filter into the departing family's slot and restores the
     // target family's slot on entry — so FM→USB brings back the SSB width

--- a/Zeus.Server.Hosting/RadioStateStore.cs
+++ b/Zeus.Server.Hosting/RadioStateStore.cs
@@ -13,9 +13,10 @@ using Zeus.Contracts;
 namespace Zeus.Server;
 
 // Persists the subset of RadioService state that no dedicated store covers:
-// active mode/VFO, RX/TX filter bounds, master volume, display zoom,
-// auto-ATT/AGC toggles, user-baseline attenuator, and the eight per-mode-
-// family filter memory slots (SSB/AM/FM/CW × RX/TX).
+// active mode/VFO, RX/TX filter bounds, master volume, TX mic gain, TX
+// Leveler max gain, display zoom, auto-ATT/AGC toggles, user-baseline
+// attenuator, and the eight per-mode-family filter memory slots
+// (SSB/AM/FM/CW × RX/TX).
 //
 // Not persisted here — handled elsewhere or intentionally ephemeral:
 //   AgcTopDb, Nr, Cfc       → DspSettingsStore
@@ -148,6 +149,17 @@ public sealed class RadioStateEntry
     public int AttenDb { get; set; }
     public bool AutoAgcEnabled { get; set; }
     public double RxAfGainDb { get; set; }
+    // TX mic gain in dB, range [-40, +10]. Default 0 ≡ unity panel-gain (mirrors
+    // WdspDspEngine TXA fresh-open). The endpoint accepted this value but didn't
+    // save it; lived only in frontend localStorage and reverted on every restart
+    // when the desktop webview's storage was wiped.
+    public int MicGainDb { get; set; }
+    // TX Leveler max-gain ceiling in dB, range [0, 15]. Default 8.0 matches
+    // WdspDspEngine.DefaultLevelerMaxGainDb so legacy rows missing the field
+    // hydrate with the same ceiling the engine has always opened with. Like
+    // MicGainDb, this used to live only in localStorage and reverted on
+    // restart.
+    public double LevelerMaxGainDb { get; set; } = 8.0;
     public int ZoomLevel { get; set; } = 1;
     // Drive slider % (0..100). Default 0 mirrors RadioService._drivePct seed.
     public int DrivePct { get; set; }

--- a/Zeus.Server.Hosting/RadioStateStore.cs
+++ b/Zeus.Server.Hosting/RadioStateStore.cs
@@ -154,15 +154,13 @@ public sealed class RadioStateEntry
     // TUN drive slider % (0..100). Default 10 mirrors RadioService._tunePct seed —
     // a 0 default would make pressing TUN appear to do nothing.
     public int TunePct { get; set; } = 10;
-    // CTUN — issue #427. When true, RadioLoHz is frozen and clicking the
-    // panadapter moves VfoHz instead of the radio. Persisted so the operator's
-    // last click-tune mode survives restart; missing on legacy rows defaults
-    // to false (Thetis parity).
-    public bool CtunEnabled { get; set; }
-    // Hardware NCO at last flush. Persisted alongside CtunEnabled so a
-    // restart-while-CTUN-on retunes the radio to the same physical centre.
-    // Zero on legacy rows; RadioService snaps it to VfoHz on hydration in
-    // that case.
+    // Hardware NCO at last flush. Persisted so a restart retunes the radio
+    // to the same physical centre the operator was last looking at. Zero on
+    // legacy rows (pre-CTUN, or rows written by the old CTUN-off branch);
+    // RadioService snaps it to VfoHz on hydration in that case. The
+    // <c>CtunEnabled</c> field was removed when the CTUN toggle was retired —
+    // see <c>docs/prd/panfall_behavior.md</c>. Any stale <c>CtunEnabled</c>
+    // value left in older rows by LiteDB is silently ignored.
     public long RadioLoHz { get; set; }
     // Per-mode-family RX filter memory (abs values, always positive)
     public int SsbFilterLoAbs { get; set; } = 150;

--- a/Zeus.Server.Hosting/RotctldService.cs
+++ b/Zeus.Server.Hosting/RotctldService.cs
@@ -53,7 +53,11 @@ namespace Zeus.Server;
 /// Persistent TCP client for hamlib's rotctld. Holds a single socket,
 /// sends commands, polls position at <see cref="RotctldConfig.PollingIntervalMs"/>,
 /// and reconnects with 5-second backoff on failure. Shape mirrors Log4YM's
-/// RotatorService but keeps state in-memory (single-operator).
+/// RotatorService. Config (host / port / enabled flag / polling interval) is
+/// persisted by <see cref="RotctldConfigStore"/> in zeus-prefs.db and hydrated
+/// at construction so a clean exit with Enabled=true reconnects automatically
+/// on next startup. Live socket state (current azimuth, target, error) is
+/// in-memory only.
 /// </summary>
 public sealed class RotctldService : BackgroundService
 {
@@ -91,6 +95,10 @@ public sealed class RotctldService : BackgroundService
         // ExecuteAsync's first tick will pick up Enabled=true and reconnect.
         _config = _store.Get();
     }
+
+    /// <summary>Returns the live config snapshot (host / port / enabled / polling interval).
+    /// Hydrated from <see cref="RotctldConfigStore"/> at construction; updated by <see cref="SetConfigAsync"/>.</summary>
+    public RotctldConfig GetConfig() => _config;
 
     public RotctldStatus GetStatus()
     {

--- a/Zeus.Server.Hosting/StreamingHub.cs
+++ b/Zeus.Server.Hosting/StreamingHub.cs
@@ -334,6 +334,24 @@ public sealed class StreamingHub
         }
     }
 
+    public void Broadcast(in CwEngineStatusFrame frame)
+    {
+        if (_clients.IsEmpty) return;
+        // Variable-length: 9-byte header + UTF-8 text bytes (capped at
+        // MaxTextBytes). Compute exact size up front so the broadcast
+        // payload allocates once — same shape as AlertFrame above.
+        int textBytes = System.Text.Encoding.UTF8.GetByteCount(frame.Text ?? string.Empty);
+        if (textBytes > CwEngineStatusFrame.MaxTextBytes) textBytes = CwEngineStatusFrame.MaxTextBytes;
+        int total = CwEngineStatusFrame.HeaderByteLength + textBytes;
+        var payload = new byte[total];
+        var writer = new FixedBufferWriter(payload, total);
+        frame.Serialize(writer);
+        foreach (var client in _clients.Values)
+        {
+            if (!client.TryEnqueue(payload)) System.Threading.Interlocked.Increment(ref _dropsOther);
+        }
+    }
+
     public void Broadcast(in WisdomStatusFrame frame)
     {
         SetWisdomPhase(frame.Phase);

--- a/Zeus.Server.Hosting/Tci/TciSession.cs
+++ b/Zeus.Server.Hosting/Tci/TciSession.cs
@@ -817,7 +817,9 @@ public sealed class TciSession : IDisposable
             // Spec §8.5: vfo:trx,vfo,0 is invalid — never set a VFO to 0 Hz.
             // Reject silently rather than driving the radio to an out-of-range freq.
             if (hz <= 0) return;
-            _radio.SetVfo(hz);
+            // TCI is a CAT-like external source — bypass CTUN auto-recenter.
+            // Mirrors Thetis CATChangesCenterFreq default. Issue #461.
+            _radio.SetVfo(hz, fromExternal: true);
             // Don't echo back immediately — the StateChanged event will broadcast it
         }
     }
@@ -836,8 +838,8 @@ public sealed class TciSession : IDisposable
         }
         else if (args.Length >= 2 && TciProtocol.TryParseLong(args[1], out long hz))
         {
-            // Set DDS (same as VFO for single-RX)
-            _radio.SetVfo(hz);
+            // Set DDS (same as VFO for single-RX). External source — see HandleVfo.
+            _radio.SetVfo(hz, fromExternal: true);
         }
     }
 

--- a/Zeus.Server.Hosting/Tci/TciSession.cs
+++ b/Zeus.Server.Hosting/Tci/TciSession.cs
@@ -947,7 +947,7 @@ public sealed class TciSession : IDisposable
         // state, TrySetMox is a no-op and lying to MSHV/WSJT-X causes the
         // client to think MOX is on when it isn't. MSHV tolerates redundant
         // echoes — it does not tolerate desynchronised state.
-        _tx.TrySetMox(on, out _);
+        _tx.TrySetMox(on, MoxSource.Tci, out _);
         Send(TciProtocol.Command("trx", rx, _tx.IsMoxOn));
     }
 
@@ -1458,7 +1458,11 @@ public sealed class TciSession : IDisposable
                 break;
             case "ZZTX0":
                 _log.LogInformation("tci.run_cat_ex ZZTX0 → force-unkey");
-                _tx.TrySetMox(false, out _);
+                // Source-tagged: a remote CAT command can drop MOX it itself
+                // claimed via trx:true, but cannot truncate a Cwx- or
+                // Hardware-driven transmission. The operator's UI button is
+                // still the master override.
+                _tx.TrySetMox(false, MoxSource.Tci, out _);
                 break;
             default:
                 _log.LogDebug("tci.run_cat_ex unhandled cmd={Cmd}", cmd);

--- a/Zeus.Server.Hosting/Tci/TciSession.cs
+++ b/Zeus.Server.Hosting/Tci/TciSession.cs
@@ -817,8 +817,10 @@ public sealed class TciSession : IDisposable
             // Spec §8.5: vfo:trx,vfo,0 is invalid — never set a VFO to 0 Hz.
             // Reject silently rather than driving the radio to an out-of-range freq.
             if (hz <= 0) return;
-            // TCI is a CAT-like external source — bypass CTUN auto-recenter.
-            // Mirrors Thetis CATChangesCenterFreq default. Issue #461.
+            // TCI is a CAT-like external source — bypass the frozen-NCO
+            // auto-recenter heuristic so the hardware tracks the commanded
+            // frequency absolutely. Mirrors Thetis CATChangesCenterFreq
+            // default. Issue #461.
             _radio.SetVfo(hz, fromExternal: true);
             // Don't echo back immediately — the StateChanged event will broadcast it
         }

--- a/Zeus.Server.Hosting/TxService.cs
+++ b/Zeus.Server.Hosting/TxService.cs
@@ -58,6 +58,11 @@ public sealed class TxService
     private bool _tunOn;
     private DateTime? _moxStartedAt;
     private DateTime? _tunStartedAt;
+    // Who currently owns MOX, set on the rising edge and cleared on the
+    // falling one. See <see cref="MoxSource"/> for the release rule: only
+    // the owning source can drop MOX, except UI (master override) and
+    // <see cref="TryTripForAlert"/> (always wins). Null when MOX is off.
+    private MoxSource? _moxOwner;
 
     public TxService(RadioService radio, DspPipelineService pipeline, StreamingHub hub, IBandPlanService bandPlan, ILogger<TxService> log)
     {
@@ -70,6 +75,11 @@ public sealed class TxService
 
     public bool IsMoxOn { get { lock (_sync) return _moxOn; } }
     public bool IsTunOn { get { lock (_sync) return _tunOn; } }
+    /// <summary>Source that currently holds MOX, or null when MOX is off.
+    /// Subscribers (e.g. <c>CwEngine</c>) read this on the
+    /// <see cref="TxActiveChanged"/> falling edge to tell apart "I dropped
+    /// MOX myself" from "the operator overrode me from the UI".</summary>
+    public MoxSource? MoxOwner { get { lock (_sync) return _moxOwner; } }
 
     /// <summary>
     /// Fires on every change to combined TX-active state
@@ -155,7 +165,19 @@ public sealed class TxService
         return false;
     }
 
+    /// <summary>Back-compat shim: callers that don't tag a source get
+    /// <see cref="MoxSource.UI"/>, the master override. New callers should
+    /// pass an explicit source so the release path can reject foreign drops.</summary>
     public bool TrySetMox(bool on, out string? error)
+        => TrySetMox(on, MoxSource.UI, out error);
+
+    /// <summary>
+    /// Source-aware MOX setter. The <paramref name="source"/> tag determines
+    /// whether the call is allowed when MOX is already held by another
+    /// source — see <see cref="MoxSource"/> for the rule. UI always wins;
+    /// any other source can only drop MOX it itself raised.
+    /// </summary>
+    public bool TrySetMox(bool on, MoxSource source, out string? error)
     {
         // FR-1 interlock: no TX unless connected.
         if (on && !_radio.IsConnected) { error = "not connected"; return false; }
@@ -166,17 +188,35 @@ public sealed class TxService
         bool? txActiveCaptured;
         lock (_sync)
         {
-            if (_moxOn == on) { error = null; return true; }
+            if (_moxOn == on)
+            {
+                // No-op edge. Don't reseat ownership on a redundant key-on
+                // (first-claim semantics — whoever raised the rising edge owns
+                // it for the life of the transmission). Drops are rejected
+                // here too so a foreign source can't even silently match the
+                // current state, since that would let a hardware-PTT release
+                // race a UI-driven send.
+                error = null;
+                return true;
+            }
+            if (!on && source != MoxSource.UI && _moxOwner is not null && _moxOwner != source)
+            {
+                // Foreign source trying to release someone else's MOX. Refuse.
+                error = $"MOX held by {_moxOwner}; only UI can override";
+                return false;
+            }
             wasTunOn = _tunOn;
             if (on)
             {
                 _tunOn = false;  // MOX-on preempts TUN (PRD FR-7 mutual-exclusion)
                 _tunStartedAt = null;
                 _moxStartedAt = DateTime.UtcNow;
+                _moxOwner = source;
             }
             else
             {
                 _moxStartedAt = null;
+                _moxOwner = null;
             }
             _moxOn = on;
             txActiveCaptured = CaptureTxActiveChangeUnderLock();
@@ -246,11 +286,16 @@ public sealed class TxService
                 _tunStartedAt = null;
                 _moxOn = true;
                 _moxStartedAt = DateTime.UtcNow;
+                // TwoTone is a UI-driven feature; tag the owner so the source
+                // gate in TrySetMox correctly rejects a foreign drop while
+                // the two-tone test is armed.
+                _moxOwner = MoxSource.UI;
             }
             else
             {
                 _moxOn = false;
                 _moxStartedAt = null;
+                _moxOwner = null;
             }
             txActiveCaptured = CaptureTxActiveChangeUnderLock();
         }
@@ -310,6 +355,8 @@ public sealed class TxService
             {
                 _moxOn = false;  // TUN-on preempts MOX (PRD FR-7)
                 _moxStartedAt = null;
+                // Whoever owned MOX just lost the channel — TUN took it.
+                _moxOwner = null;
                 _tunStartedAt = DateTime.UtcNow;
             }
             else
@@ -362,6 +409,9 @@ public sealed class TxService
             // would keep re-firing against the stale start time after the trip.
             _moxStartedAt = null;
             _tunStartedAt = null;
+            // Trip always wins regardless of owner. Drop ownership so the
+            // next rising edge starts from a clean source.
+            _moxOwner = null;
             txActiveCaptured = CaptureTxActiveChangeUnderLock();
         }
 

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -845,7 +845,9 @@ public static class ZeusEndpoints
         {
             if (string.IsNullOrWhiteSpace(req.Mode) || string.IsNullOrWhiteSpace(req.Fit))
                 return Results.BadRequest(new { error = "mode and fit required" });
-            store.SaveMode(req.Mode, req.Fit, req.RxTraceColor);
+            store.SaveMode(req.Mode, req.Fit, req.RxTraceColor,
+                req.DbMin, req.DbMax, req.TxDbMin, req.TxDbMax,
+                req.WfDbMin, req.WfDbMax, req.WfTxDbMin, req.WfTxDbMax);
             return Results.Ok(store.Get());
         });
 

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -469,6 +469,18 @@ public static class ZeusEndpoints
             return Results.Ok();
         });
 
+        // Persisted CW operator settings (WPM, Farnsworth, 6 macros,
+        // sidetone gain/pitch). PATCH-shaped PUT: every field nullable so
+        // the UI can save one slider or one macro without round-tripping
+        // the whole record. Returns the post-merge snapshot so the client
+        // can reconcile its store with what the server actually stored
+        // (e.g. clamped values).
+        app.MapGet("/api/cw/settings", (CwSettingsStore store) =>
+            Results.Ok(store.Get()));
+
+        app.MapPut("/api/cw/settings", (CwSettingsSetRequest req, CwSettingsStore store) =>
+            Results.Ok(store.Save(req)));
+
         // Mic-gain: N dB in [-40, +10], scales WDSP TXA panel-gain-1 the same
         // way Thetis does (console.cs:28805 setAudioMicGain → Audio.MicPreamp =
         // 10^(db/20) → cmaster.CMSetTXAPanelGain1). The negative range is the

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -457,28 +457,29 @@ public static class ZeusEndpoints
         // -10..-15 dBFS, which over-drives WDSP TXA + ALC and prints as
         // splatter on the air; without an attenuator the operator has nowhere
         // to back off. Range matches Thetis's MicGainMin/Max defaults
-        // (console.cs:19151 = -40, :19163 = +10).
-        app.MapPost("/api/mic-gain", (MicGainSetRequest req, DspPipelineService pipe) =>
+        // (console.cs:19151 = -40, :19163 = +10). RadioService persists the dB
+        // value via RadioStateStore; the dB → linear (10^(db/20)) conversion
+        // happens at the engine seam in DspPipelineService.
+        app.MapPost("/api/mic-gain", (MicGainSetRequest req, RadioService r) =>
         {
-            int db = Math.Clamp(req.Db, -40, 10);
-            double gain = Math.Pow(10.0, db / 20.0);
-            pipe.CurrentEngine?.SetTxPanelGain(gain);
-            return Results.Ok(new { micGainDb = db });
+            var snap = r.SetTxMicGain(req.Db);
+            return Results.Ok(new { micGainDb = snap.MicGainDb });
         });
 
         // Leveler max-gain ceiling in dB. Operator-safe band is 0..15 dB: 0 disables
         // the headroom entirely (unity-cap Leveler) and 15 matches Thetis's stock
         // ceiling (radio.cs:2979 tx_leveler_max_gain = 15.0). Anything outside is a
         // 400 so a misbehaving client can't hand WDSP a value that'd saturate on
-        // the first voiced sample. The server is stateless for this setting —
-        // frontend re-POSTs on WS reconnect to re-sync after a server restart.
-        app.MapPost("/api/tx/leveler-max-gain", (LevelerMaxGainSetRequest req, DspPipelineService pipe) =>
+        // the first voiced sample. RadioService persists via RadioStateStore so
+        // the operator's ceiling survives backend restart; the frontend no
+        // longer needs to re-POST on WS reconnect.
+        app.MapPost("/api/tx/leveler-max-gain", (LevelerMaxGainSetRequest req, RadioService r) =>
         {
             if (req.Gain < 0.0 || req.Gain > 15.0 || double.IsNaN(req.Gain))
                 return Results.BadRequest(new { error = "gain must be 0..15 dB" });
             log.LogInformation("api.tx.levelerMaxGain dB={Db:F1}", req.Gain);
-            pipe.CurrentEngine?.SetTxLevelerMaxGain(req.Gain);
-            return Results.Ok(new { levelerMaxGainDb = req.Gain });
+            var snap = r.SetTxLevelerMaxGain(req.Gain);
+            return Results.Ok(new { levelerMaxGainDb = snap.LevelerMaxGainDb });
         });
 
         // TUN: internal-tune carrier. Flips SetTXAPostGenRun on WDSP; server-side is

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -1222,6 +1222,8 @@ public static class ZeusEndpoints
 
         app.MapGet("/api/rotator/status", (RotctldService rot) => rot.GetStatus());
 
+        app.MapGet("/api/rotator/config", (RotctldService rot) => rot.GetConfig());
+
         app.MapPost("/api/rotator/config", async (RotctldConfig req, RotctldService rot, HttpContext ctx) =>
         {
             log.LogInformation("api.rotator.config enabled={En} host={Host} port={Port}", req.Enabled, req.Host, req.Port);

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -896,6 +896,20 @@ public static class ZeusEndpoints
             return Results.Ok(store.Get());
         });
 
+        // Vertical split between the panadapter and the waterfall in the
+        // Hero panel. PanPercent (10..90) is the panadapter share; the
+        // waterfall fills the remainder. Persisted in zeus-prefs.db so the
+        // choice follows the operator across browsers / devices, same
+        // pattern as /api/bottom-pin. Frontend reads on mount and PUTs
+        // debounced on drag-end.
+        app.MapGet("/api/pan-wf-split", (PanWfSplitStore store) => Results.Ok(store.Get()));
+
+        app.MapPut("/api/pan-wf-split", (PanWfSplitSetRequest req, PanWfSplitStore store) =>
+        {
+            var saved = store.Save(req.PanPercent);
+            return Results.Ok(saved);
+        });
+
         // Inline NR settings accordion disclosure state (NR1 / NR2 / NR4).
         // PUT writes all three flags atomically. Persisted in zeus-prefs.db
         // so the chevron-open preference follows the operator across

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -306,14 +306,19 @@ public static class ZeusEndpoints
             return r.SetVfo(req.Hz);
         });
 
-        // CTUN (Click-Tune) — issue #427. When enabled the hardware NCO is
-        // frozen at the current VfoHz so subsequent SetVfo calls move only the
-        // dial / WDSP filter offset, not the radio. RadioService.SetCtun
-        // handles the radio retune on disable.
-        app.MapPost("/api/ctun", (CtunSetRequest req, RadioService r) =>
+        // Set the radio's hardware NCO (LO) frequency directly. Does not
+        // move VfoHz — used by the panadapter pure-pan gesture when a drag
+        // would carry the viewport outside the IQ capture window.
+        // See docs/prd/panfall_behavior.md.
+        app.MapPost("/api/radio/lo", (RadioLoSetRequest req, RadioService r) =>
         {
-            log.LogInformation("api.ctun enabled={Enabled}", req.Enabled);
-            return r.SetCtun(req.Enabled);
+            if (req.Hz < 0 || req.Hz > 60_000_000)
+            {
+                log.LogInformation("api.radio.lo rejected hz={Hz}", req.Hz);
+                return Results.BadRequest(new { error = "hz out of range [0, 60000000]" });
+            }
+            log.LogInformation("api.radio.lo hz={Hz}", req.Hz);
+            return Results.Ok(r.SetRadioLo(req.Hz));
         });
 
         app.MapPost("/api/mode", (ModeSetRequest req, RadioService r) =>

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -450,6 +450,25 @@ public static class ZeusEndpoints
             return Results.Ok(new { moxOn = tx.IsMoxOn });
         });
 
+        // CW keyer (zeus-drf). Body: { text, wpm? }. Returns 202 immediately;
+        // playback happens on the engine's worker. WPM null = engine default
+        // (currently 20); the engine clamps to 5..50. Empty text is allowed —
+        // produces no symbols and resolves to Idle without keying.
+        app.MapPost("/api/cw/send", async (CwSendRequest req, CwEngine cw) =>
+        {
+            await cw.SendAsync(req.Text ?? string.Empty, req.Wpm, default).ConfigureAwait(false);
+            return Results.Accepted();
+        });
+
+        // Hard abort. Drops the queue and signals the in-flight playback to
+        // cancel. MOX falls on the next playback tick (≤ ChunkSamples / SR ≈
+        // 10 ms). Returns 200 unconditionally — abort is best-effort.
+        app.MapPost("/api/cw/abort", (CwEngine cw) =>
+        {
+            cw.Abort("api.cw.abort");
+            return Results.Ok();
+        });
+
         // Mic-gain: N dB in [-40, +10], scales WDSP TXA panel-gain-1 the same
         // way Thetis does (console.cs:28805 setAudioMicGain → Audio.MicPreamp =
         // 10^(db/20) → cmaster.CMSetTXAPanelGain1). The negative range is the

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -926,6 +926,16 @@ public static class ZeusEndpoints
                 return Results.Ok(saved);
             });
 
+        // Operator override for the TX forward-power meter's full scale.
+        // Clamped server-side; 0 means "no override, use the radio's
+        // rated MaxWatts" (historical behaviour).
+        app.MapPut("/api/meters/max-displayed-watts",
+            (MaxDisplayedWattsSetRequest req, MeterDisplaySettingsStore store) =>
+            {
+                var saved = store.SetMaxDisplayedWatts(req.MaxWatts);
+                return Results.Ok(saved);
+            });
+
         // Inline NR settings accordion disclosure state (NR1 / NR2 / NR4).
         // PUT writes all three flags atomically. Persisted in zeus-prefs.db
         // so the chevron-open preference follows the operator across

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -912,6 +912,20 @@ public static class ZeusEndpoints
             return Results.Ok(saved);
         });
 
+        // Display-side meter calibration knobs (GitHub #426). Currently
+        // surfaces the S-meter dB offset trim; signed value clamped ±20 dB
+        // on the server. Display-only — the underlying WDSP / radio
+        // physics are untouched. Persisted in zeus-prefs.db.
+        app.MapGet("/api/meters/display-settings",
+            (MeterDisplaySettingsStore store) => Results.Ok(store.Get()));
+
+        app.MapPut("/api/meters/smeter-offset-db",
+            (SMeterOffsetSetRequest req, MeterDisplaySettingsStore store) =>
+            {
+                var saved = store.SetSMeterOffsetDb(req.OffsetDb);
+                return Results.Ok(saved);
+            });
+
         // Inline NR settings accordion disclosure state (NR1 / NR2 / NR4).
         // PUT writes all three flags atomically. Persisted in zeus-prefs.db
         // so the chevron-open preference follows the operator across

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -847,7 +847,8 @@ public static class ZeusEndpoints
                 return Results.BadRequest(new { error = "mode and fit required" });
             store.SaveMode(req.Mode, req.Fit, req.RxTraceColor,
                 req.DbMin, req.DbMax, req.TxDbMin, req.TxDbMax,
-                req.WfDbMin, req.WfDbMax, req.WfTxDbMin, req.WfTxDbMax);
+                req.WfDbMin, req.WfDbMax, req.WfTxDbMin, req.WfTxDbMax,
+                req.WfBrightness);
             return Results.Ok(store.Get());
         });
 

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -246,6 +246,7 @@ public static class ZeusHost
         // Host-side CW keyer (zeus-drf). Single instance, drains a job queue
         // and pushes envelope-shaped IQ directly into TxIqRing while holding
         // MOX as MoxSource.Cwx.
+        builder.Services.AddSingleton<CwSettingsStore>();
         builder.Services.AddSingleton<CwEngine>();
         builder.Services.AddHostedService(sp => sp.GetRequiredService<CwEngine>());
         // PS auto-attenuate timer2code-equivalent: ramps the radio's TX step

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -159,6 +159,15 @@ public static class ZeusHost
         builder.Services.AddSingleton<Zeus.Protocol1.TxIqRing>();
         builder.Services.AddSingleton<Zeus.Protocol1.ITxIqSource>(sp =>
             sp.GetRequiredService<Zeus.Protocol1.TxIqRing>());
+        // RxCodecAudioRing is shared: RadioCodecAudioSink writes WDSP RX
+        // audio into it; Protocol1Client (constructed inside RadioService)
+        // drains it into the EP2 outbound L/R bytes so operators on
+        // Hermes / ANAN-class / OrionMkII boards hear audio on the radio's
+        // front-panel headphone jack. Empty ring = silent wire bytes,
+        // matching pre-#426 HL2-only behaviour. Issue #426.
+        builder.Services.AddSingleton<Zeus.Protocol1.RxCodecAudioRing>();
+        builder.Services.AddSingleton<Zeus.Protocol1.IRxCodecAudioSource>(sp =>
+            sp.GetRequiredService<Zeus.Protocol1.RxCodecAudioRing>());
         builder.Services.AddSingleton<RadioService>();
         builder.Services.AddSingleton<StreamingHub>();
         // RX audio publish seam (Phase 1). DspPipelineService.PublishAudio
@@ -223,6 +232,12 @@ public static class ZeusHost
             // mix client-side.
             builder.Services.AddSingleton<IAuditionAudioSink, NoOpAuditionAudioSink>();
         }
+        // Radio on-board codec sink — joins the IRxAudioSink fan-out so RX
+        // audio is duplicated to the radio's EP2 outbound L/R bytes whenever
+        // the connected board has an on-board codec (Hermes / ANAN-class /
+        // OrionMkII family / G2E). HL2 / synthetic / pre-connect short-
+        // circuit inside the sink. Issue #426.
+        builder.Services.AddSingleton<IRxAudioSink, RadioCodecAudioSink>();
         // WDSPwisdom bootstrap: run FFTW plan caching on a worker at app start so the
         // first /api/connect isn't blocked for ~2 min while WDSP plans FFTs 64..262144.
         // Clients are told to keep Connect disabled until phase=Ready.

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -243,6 +243,11 @@ public static class ZeusHost
         // TxTuneDriver pumps silent mic blocks through WDSP TXA while TUN is on so
         // the post-gen tone actually reaches the ring (no mic uplink during TUN).
         builder.Services.AddHostedService<TxTuneDriver>();
+        // Host-side CW keyer (zeus-drf). Single instance, drains a job queue
+        // and pushes envelope-shaped IQ directly into TxIqRing while holding
+        // MOX as MoxSource.Cwx.
+        builder.Services.AddSingleton<CwEngine>();
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<CwEngine>());
         // PS auto-attenuate timer2code-equivalent: ramps the radio's TX step
         // attenuator (Protocol2 only today) when calcc feedback level lands outside
         // the 128..181 ideal window, so PS has a recovery path on first arm. Idle

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -275,6 +275,7 @@ public static class ZeusHost
         builder.Services.AddSingleton<NrUiPrefsStore>();
         builder.Services.AddSingleton<ThemeSettingsStore>();
         builder.Services.AddSingleton<BottomPinStore>();
+        builder.Services.AddSingleton<PanWfSplitStore>();
         builder.Services.AddSingleton<RadioStateStore>();
         builder.Services.AddSingleton<QrzService>();
         builder.Services.AddSingleton<LogService>();

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -248,6 +248,11 @@ public static class ZeusHost
         // the 128..181 ideal window, so PS has a recovery path on first arm. Idle
         // when PS is off or AutoAttenuate is off — no wire, no engine pokes.
         builder.Services.AddHostedService<PsAutoAttenuateService>();
+        // Promote the radio's hardware-PTT echo (HL2 rear KEY tip, external
+        // PTT line) into a host MOX request — without it the gateware-driven
+        // CW carrier transmits while Zeus stays unkeyed (UI off, meters at
+        // idle cadence, FR-6 timeout disarmed).
+        builder.Services.AddHostedService<ExternalPttService>();
 
         // QRZ.com XML client. HttpClient default timeout is 100 s — cap at 10 s so a
         // hung login surfaces quickly in the UI.

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -276,6 +276,7 @@ public static class ZeusHost
         builder.Services.AddSingleton<ThemeSettingsStore>();
         builder.Services.AddSingleton<BottomPinStore>();
         builder.Services.AddSingleton<PanWfSplitStore>();
+        builder.Services.AddSingleton<MeterDisplaySettingsStore>();
         builder.Services.AddSingleton<RadioStateStore>();
         builder.Services.AddSingleton<QrzService>();
         builder.Services.AddSingleton<LogService>();

--- a/docs/prd/panfall_behavior.md
+++ b/docs/prd/panfall_behavior.md
@@ -1,0 +1,179 @@
+# Panadapter / Waterfall Behavior — PRD
+
+**Beads issue:** zeus-nnc
+**Status:** spec, awaiting implementation
+**Author:** Brian Keating (EI6LF), drafted 2026-05-23
+**Supersedes UX from:** issue #427 (CTUN toggle introduced), commit 4491ad9 (#461 — band-change retune)
+
+---
+
+## Goal
+
+Collapse Zeus's panadapter/waterfall tuning model into a single, intuitive interaction:
+
+1. CTUN behavior (frozen hardware NCO, dial roams) becomes the **only** mode. The toggle button and all `CtunEnabled` plumbing is removed.
+2. Press-and-drag horizontally on the panadapter or waterfall pans the view across the radio's already-sampled bandwidth. The radio retunes only when a drag would otherwise extend the viewport beyond the IQ capture window.
+
+Single tuning model, no operator-visible mode switch, no hidden state.
+
+## Background
+
+Today Zeus has two tuning modes selected by a CTUN button in the bottom transport bar:
+
+- **CTUN OFF (legacy):** panadapter clicks call `setVfo`, which retunes the hardware NCO so the clicked frequency becomes the new center. The view always centers on `RadioLoHz == vfoHz`.
+- **CTUN ON (`#427`):** the hardware NCO is frozen at the value `vfoHz` had when CTUN was toggled on (`RadioLoHz`). Subsequent `setVfo` calls move only the dial; WDSP's `shift` stage relocates the IF so the operator's tuned signal still demodulates. The dial cursor visually roams across a stationary spectrum.
+
+The existing drag handler in `zeus-web/src/util/use-pan-tune-gesture.ts:309` interprets a drag as repeated `setVfo` calls (i.e. dial tuning). Combined with CTUN-on, drag-to-tune lets the dial roam within the frozen viewport but cannot bring new spectrum into view — the visible window is locked to `RadioLoHz`.
+
+The desired interaction (this PRD) is the inverse: drag moves the **view** through the IQ capture window, and the dial stays anchored to its true frequency.
+
+## Definitions
+
+- **`vfoHz`** — the operator's tuned frequency. Where the dial cursor sits; what gets demodulated.
+- **`RadioLoHz`** — the radio's hardware NCO center frequency. Defines the center of the IQ stream the radio is capturing.
+- **Sample bandwidth (`sampleBw`)** — the width of the IQ window the radio is capturing, equal to the radio's sample rate in Hz (e.g. 192_000 on a 192 ksps configuration). Brian's default working setup uses ~19.2 kHz at low sample rate; the spec is rate-agnostic.
+- **Viewport span (`viewportSpan`)** — the frequency width currently displayed on the panadapter, set by the zoom level. Always `≤ sampleBw`.
+- **Viewport center** — the frequency at the horizontal center of the visible panel. Equals `RadioLoHz + viewportOffsetHz`.
+- **`viewportOffsetHz`** — frontend-only state introduced by this PRD. Hz offset of the viewport center from `RadioLoHz`. Range constrained so the viewport stays inside the IQ window; outside that range triggers a retune.
+
+## Part 1 — Remove the CTUN toggle
+
+CTUN behavior becomes implicit and unconditional. The toggle, its persisted flag, and all conditional code paths are deleted.
+
+### Backend changes
+
+**`Zeus.Contracts/Dtos.cs:259`** — remove `CtunEnabled`. Keep `RadioLoHz` (still needed; now always reflects the hardware NCO center, which is independent of `vfoHz` except at hydration).
+
+**`Zeus.Server.Hosting/RadioStateStore.cs:157`** — drop the persisted `CtunEnabled` field from the LiteDB schema. On hydrating an older prefs DB, ignore any stale `CtunEnabled` value (treat as always-on). `RadioLoHz` continues to be persisted so the operator's frozen NCO survives restart.
+
+**`Zeus.Server.Hosting/RadioService.cs`** —
+- Delete the `ToggleCtun` method and remove all `_state.CtunEnabled` reads.
+- `SetVfo` keeps the auto-recenter heuristic from #461 but drops the `if (ctun)` gate so it applies unconditionally. Small dial movements (resulting shift stays inside both the visible panadapter span minus a 5 % inset, and inside ±0.46×sample_rate IF capacity) leave `RadioLoHz` alone — the frozen-NCO ideal. Large dial movements (band-button jumps, CAT/TCI external sources) trigger an auto-retune: `RadioLoHz := EffectiveLoHz(mode, newDial)` plus a P1 `SetVfoAHz`. External callers (`fromExternal=true`) always retune regardless of geometry, matching Thetis `CATChangesCenterFreq=true`.
+- Operator-driven "pure pan" movements (panadapter drag-release past the IQ window edge) take the explicit `POST /api/radio/lo` path instead, leaving `VfoHz` untouched.
+- On reconnect / hydration, if the persisted `RadioLoHz == 0` (fresh DB or migrated-from-CTUN-off DB), initialize `RadioLoHz := vfoHz`. Otherwise restore the persisted value as today.
+
+**`Zeus.Server.Hosting/DspPipelineService.cs`** —
+- The conditional WDSP `shift` stage setup (around `:540`) becomes unconditional. The shift always equals `vfoHz − RadioLoHz`.
+- The fresh-channel-open replay at `:840` keeps the same behavior.
+
+**`Zeus.Server.Hosting/ZeusEndpoints.cs`** — delete the `/api/radio/ctun` endpoint at `:309`. Add a new endpoint:
+
+- `POST /api/radio/lo` with body `{ hz: number }` → calls a new `RadioService.SetRadioLo(hz)` that updates `RadioLoHz` directly (hardware retune + WDSP shift adjusted to keep `vfoHz` audible). Returns the updated `StateDto`. Returns 400 if `hz` is out of range for the connected radio.
+
+### Frontend changes
+
+**`zeus-web/src/App.tsx:775-793`** — delete the CTUN `<button>`.
+
+**`zeus-web/src/state/connection-store.ts:66`** — remove `ctunEnabled` from the store state and from `applyState`'s destructuring. Keep `radioLoHz`.
+
+**`zeus-web/src/api/client.ts:222`** — remove `setCtun`. Remove the `CtunEnabled` field from any DTO interfaces. Add `setRadioLo(hz: number)` calling `POST /api/radio/lo`.
+
+**`zeus-web/src/api/client.ts:482`** — drop the legacy-server fallback that defaulted `CtunEnabled` to false. The frontend assumes CTUN-style behavior unconditionally.
+
+**`Panadapter.tsx`, `Waterfall.tsx`, `PassbandOverlay.tsx`, `gl/panadapter.ts`, `gl/shaders.ts`** — comments mentioning "when CTUN is on/off" updated to reflect the unconditional model. The rendering math already handles the dial-roams case; nothing functional changes here in Part 1.
+
+### Tests
+
+- `tests/Zeus.Server.Tests/TxAudioIngestTests.cs`, `MicGainEndpointTests.cs`, and any other test that toggles CTUN or asserts on `CtunEnabled` — rewritten to assume CTUN-on semantics or deleted.
+- Add a new test for `POST /api/radio/lo` covering: in-range set, out-of-range rejection, and the invariant that `vfoHz` is unchanged when only `RadioLoHz` moves.
+
+## Part 2 — Drag = pure viewport pan
+
+The drag handler in `zeus-web/src/util/use-pan-tune-gesture.ts` is rewritten to pan the viewport visually, not to tune the dial. Click-without-drag (movement ≤ `CLICK_SLOP_PX = 3`) continues to tune the dial via `setVfo`.
+
+### State
+
+A new frontend-only piece of state, `viewportOffsetHz`, lives in the display store (or panadapter view state — exact location decided at plan time, but it is **not** persisted and **not** sent to the server during the drag).
+
+The panadapter and waterfall render the spectrum centered on `RadioLoHz + viewportOffsetHz`. The dial cursor X position is computed from `(vfoHz − (RadioLoHz + viewportOffsetHz)) / viewportSpan`; if `|vfoHz − viewportCenter| > viewportSpan / 2` the cursor is clipped off-screen but the dial frequency is unchanged.
+
+### Drag lifecycle
+
+**Pointer down:**
+- Capture `startX`, `startViewportCenterHz = RadioLoHz + viewportOffsetHz`, `viewportSpan`.
+- No state change yet.
+
+**Pointer move:**
+- If `|x − startX| ≤ CLICK_SLOP_PX`, do nothing (preserve click-to-tune).
+- Otherwise: `viewportOffsetHz := (startViewportCenterHz − RadioLoHz) − (dx / canvasWidth) × viewportSpan`
+  - Polarity matches the existing grab-and-pull idiom (drag right → see lower freqs).
+- No POST. No `setVfo`, no `setRadioLo`.
+- The panadapter and waterfall repaint with the new offset; the dial cursor visually slides off the edge if dragged past it.
+
+**Pointer up:**
+
+Determine whether the dragged viewport sits entirely inside the IQ capture window:
+
+```
+viewportLowerEdge = (RadioLoHz + viewportOffsetHz) − viewportSpan / 2
+viewportUpperEdge = (RadioLoHz + viewportOffsetHz) + viewportSpan / 2
+sampleLowerEdge   = RadioLoHz − sampleBw / 2
+sampleUpperEdge   = RadioLoHz + sampleBw / 2
+
+inside = viewportLowerEdge ≥ sampleLowerEdge AND viewportUpperEdge ≤ sampleUpperEdge
+```
+
+- **If `inside` (the common case):** leave `viewportOffsetHz` as-is. The radio keeps capturing the same IQ window; the panadapter continues to render the offset view. The dial may be off-screen but still audibly demodulating (it's inside the IQ capture).
+
+- **If not inside:** retune `RadioLoHz` so the new sample window adjoins the released viewport in the pan direction:
+  - Pan up (`viewportOffsetHz > 0`): `newRadioLoHz = viewportLowerEdge + sampleBw / 2` — new IQ window's bottom edge = current viewport's bottom edge.
+  - Pan down (`viewportOffsetHz < 0`): `newRadioLoHz = viewportUpperEdge − sampleBw / 2` — new IQ window's top edge = current viewport's top edge.
+
+  Then, **before** the round-trip to the server completes:
+  - Optimistically update `RadioLoHz` in the store to `newRadioLoHz`.
+  - Recompute `viewportOffsetHz := (RadioLoHz_old + viewportOffsetHz_old) − newRadioLoHz`. This preserves the on-screen position of every frequency across the retune — no visual jump.
+  - Call `POST /api/radio/lo {hz: newRadioLoHz}`; reconcile the returned `StateDto` on response.
+
+- **`vfoHz` is never modified by a drag**, on any code path. The dial stays at its true Hz throughout — even if the resulting `RadioLoHz` after a retune places `vfoHz` outside the new IQ window. In that case the signal goes silent and the dial cursor is hidden off-screen; the operator regains hearing by click-to-tuning somewhere inside the new visible window or by a band/preset change.
+
+### Click-without-drag
+
+Unchanged from today: a pointer release with `|dx| ≤ CLICK_SLOP_PX` calls `setVfo` with the clicked frequency (resolved through the current viewport center + offset). The dial moves to the click point; `RadioLoHz` is not affected.
+
+### Wheel, pinch, alt-drag
+
+Unchanged. Wheel tunes the dial (`nudgeVfo`); shift-wheel zooms; alt-drag pans the background map. Multi-touch pinch zooms the spectrum.
+
+### Mobile / touch parity
+
+Already handled by PointerEvents. No new code needed beyond keeping the existing pointer-capture + multi-touch branches in `use-pan-tune-gesture.ts` working with the new offset-based drag.
+
+## Edge cases & invariants
+
+- **Drag past the radio's overall tunable range** — `setRadioLo` rejects with 400; frontend reverts the optimistic `RadioLoHz` and snaps `viewportOffsetHz` back to the last valid offset.
+- **Zoom changes during a drag** — interrupted: the in-flight drag is cancelled (pointer capture released) and the offset is preserved. Re-press to continue panning.
+- **Band button / preset selection while a non-zero `viewportOffsetHz` is held** — reset `viewportOffsetHz := 0` when the user invokes any explicit tune-to-frequency action (band buttons, preset clicks, typed frequency, click-to-tune). Existing behavior is preserved — the new state just gets cleared on those paths.
+- **Frame reconnect / hub re-handshake** — `viewportOffsetHz` is frontend-only and resets to 0 on disconnect. No persistence.
+- **Multiple receivers** — out of scope for v1. Multi-panadapter support (see `project_multipanadapter_resume`) will require per-RX offsets when revived.
+
+## Migration
+
+- Existing prefs DBs with `CtunEnabled = false` and `RadioLoHz = 0`: on first hydrate, set `RadioLoHz := vfoHz` so the radio resumes at the previously tuned frequency with the new always-CTUN model.
+- Existing prefs DBs with `CtunEnabled = true` and a non-zero `RadioLoHz`: behave exactly as before — `RadioLoHz` restored from persistence, dial restored to `vfoHz`.
+- No web-frontend cache to clear; the removed `CtunEnabled` field is silently ignored if a stale DTO arrives during a rolling deploy.
+
+## Acceptance criteria
+
+- CTUN button no longer appears in the UI.
+- No `CtunEnabled` field on the wire; no `/api/radio/ctun` endpoint.
+- `POST /api/radio/lo` works, moves `RadioLoHz` without touching `vfoHz`, and returns the updated `StateDto`.
+- Click on panadapter → dial moves to the clicked frequency (existing behavior, unchanged).
+- Press-and-drag on panadapter or waterfall pans the visible window; dial stays at its true frequency throughout the drag and after release.
+- Drag entirely within the sample bandwidth → no retune, no POST during or after the drag.
+- Drag past the edge of the sample bandwidth → on release, exactly one `POST /api/radio/lo` fires with the directional landing per the formulas above; on-screen frequencies do not visually jump across the retune.
+- Touch drag behaves identically on mobile/tablet.
+- Build green (`dotnet build Zeus.slnx`, `npm --prefix zeus-web run build`, all existing tests).
+- HL2 bench-tested with the radio tuned to 28400 (10 m, Brian's only resonant antenna). RX-only — no MOX needed for this change.
+
+## Out of scope
+
+- Inertia / momentum on drag release.
+- Snap-to-band-edge or snap-to-bookmark while panning.
+- Vertical drag interactions (dB-range adjust via drag remains where it is in `Waterfall.tsx:195`).
+- Multi-RX viewport offsets — deferred to the multi-panadapter revival (#155).
+
+## Risks
+
+- **Operator muscle memory**: anyone who currently uses drag-to-tune within the frozen CTUN view loses that gesture. This is explicitly intended; click-to-tune covers the same use case more naturally.
+- **WDSP shift large excursions**: when the dial is well outside the sample window, the WDSP `shift` value is large in absolute terms — needs verification that the shift stage handles `|shift| > sampleBw` cleanly (it should, because the result simply produces no signal; but worth a smoke test).
+- **Cross-radio**: P1 and P2 both expose `RadioLoHz` updates through `RadioService`. The new `SetRadioLo` path needs to fire the same retune sequence on both, including any P2 DDC re-program. HL2 (P1) is the primary bench target; ANAN-class (P2) verification deferred to whoever has the hardware.

--- a/docs/references/protocol-1/thetis-board-matrix.md
+++ b/docs/references/protocol-1/thetis-board-matrix.md
@@ -285,3 +285,52 @@ loaded settings.
 | `HasVolts` / `HasAmps` / `HasAudioAmplifier` / `HasSteppedAttenuationRx2` / `SupportsPathIllustrator` | `Zeus.Contracts.BoardCapabilities` + `BoardCapabilitiesTable.For` | ✅ Phase 2 (`b0afe62`); fetched by frontend via `/api/radio/capabilities` (Phase 5) — UI panel gating is for future panels to consume |
 | `HPSDRModel.ANAN_G2E` (HermesC10) | `HpsdrBoardKind.HermesC10` | ✅ recognised on discovery (`83364ec`) and dispatched (`1bcbd7d`) |
 | 0x0A wire-byte alias family disambiguation | `Zeus.Contracts.OrionMkIIVariant` | ✅ Phase 3 (`d807611`); operator-selectable per-radio, persisted in `PreferredRadioStore`, surfaced via `/api/radio/variant` and the `RadioSelector` dropdown |
+
+## 7000DLE MKIII vs MKII (bd zeus-pqp, #218 follow-up)
+
+kw4ex on #218 asked whether the ANAN-7000DLE MKIII needs its own
+`OrionMkIIVariant` bucket distinct from MKII. Audit result: **no — all
+three reference codebases treat 7000DLE / 7000DLE MKII / (hypothetical)
+MKIII as the same hardware**, dispatched through the OrionMKII bucket.
+
+Refs (read 2026-05-24):
+
+- **ramdor / MW0LGE Thetis** (`/Users/bek/Data/Repo/github/Thetis`, tip
+  `3759d096` v2.10.3.15) —
+  - `Project Files/Source/Console/enums.cs:396` — single comment lumps
+    `AMAM-7000DLE 7000DLEMkII ANAN-8000DLE OrionMkII Anvelina-Pro3 RedPitaya`
+    into `OrionMKII = 5`.
+  - `clsHardwareSpecific.cs:343` — `"ANAN-7000DLE"` is the only model
+    string; there is no `"ANAN-7000DLE MKIII"` / `"MK3"` arm in
+    `StringToEnumModel` (the `case "ANAN-…"` block runs 330-360).
+  - `console.cs:8568`, `console.cs:8653` — both PA / TX paths switch on
+    `HPSDRHW.OrionMKII` with the same membership comment; no MKIII branch.
+  - Repo-wide `grep -rni "mkiii\|mk3\|7000DLEMkIII"` returns zero hits
+    against radio code (the only `MK3` hits in `display.cs` / `console.cs`
+    are `MMK3`, the memory-spot count).
+- **mi0bot / OpenHPSDR-Thetis** (HL2 fork,
+  `/Users/bek/Data/Repo/github/OpenHPSDR-Thetis`) —
+  - `enums.cs:393` carries the identical OrionMKII comment.
+  - `clsHardwareSpecific.cs:351` matches MW0LGE's `"ANAN-7000DLE"` arm;
+    no MKIII case.
+- **dl1bz / deskhpsdr** (`/Users/bek/Data/Repo/github/deskhpsdr`) —
+  - `src/discovered.h:33` — "ANAN 7000DLE and 8000DLE uses 10 as the
+    device type in old protocol" (single device-type value, no MKIII
+    sub-disambiguation).
+  - `src/saturnregisters.c:728` — single "7000DLE RF board" IC map; no
+    MKIII variant.
+  - Repo-wide `grep -rni "mkiii\|mk3\|7000DLEMkIII"` returns zero hits.
+- **piHPSDR** — not cloned locally on this machine (checked
+  `/Users/bek/Data/Repo` exhaustively); deskhpsdr is a piHPSDR descendant
+  and inherits the same device-type 10 model, so the piHPSDR codebase
+  behaviour is covered transitively.
+
+Conclusion: **MKIII == MKII at the protocol / DSP / calibration layer for
+all three reference implementations.** Apache Labs hardware revisions of
+the 7000DLE chassis do not change the protocol-1 wire fingerprint or PA
+gain bracket that Thetis / deskhpsdr / piHPSDR care about. **Zeus needs
+no `Anan7000DLE_MkIII` bucket.** Operators with a physical MKIII should
+select `Anan7000DLE` and report any forward-power discrepancy on a known
+dummy load — if a real difference shows up at the bench, the variant
+seam in `Zeus.Contracts.OrionMkIIVariant` is the place to add it then,
+not now on speculation.

--- a/installers/create-macos-app.sh
+++ b/installers/create-macos-app.sh
@@ -300,31 +300,92 @@ chmod +x "${SERVER_APP_BUNDLE}/Contents/MacOS/launch.sh"
 
 echo "Server wrapper bundle created at ${SERVER_APP_BUNDLE}"
 
-# --- Codesigning hook (opt-in) ------------------------------------------
+# --- Codesigning (opt-in via env) ---------------------------------------
 #
-# Ad-hoc signing or Developer ID signing happens here. Default behaviour
-# is to do nothing — the bundle ships unsigned and the user clears the
-# quarantine xattr on first launch (see DMG README).
+# Hardened-runtime, Developer-ID signing for notarization. Triggered when
+# CODESIGN_IDENTITY is set in the environment. CI populates it from the
+# MACOS_SIGNING_IDENTITY secret; a developer can export it locally for
+# off-the-cuff signed builds.
 #
-# To produce a Developer ID Application signed bundle:
-#   export APPLE_DEVELOPER_ID="Developer ID Application: Brian Keating (TEAMID)"
-#   ./create-macos-app.sh 0.4.1 arm64
-# Notarisation is a separate step (notarytool submit ... --wait) once the
-# Apple ID + app-specific password is configured locally — keep that out
-# of the script for now so the unsigned path stays the default and CI
-# doesn't trip over missing secrets.
-if [ -n "${APPLE_DEVELOPER_ID:-}" ]; then
-    echo "Codesigning with: ${APPLE_DEVELOPER_ID}"
-    codesign --force --deep --options runtime --timestamp \
-        --sign "${APPLE_DEVELOPER_ID}" "${APP_BUNDLE}"
-    codesign --verify --verbose=2 "${APP_BUNDLE}"
-    # Sign Zeus Server.app too — Gatekeeper otherwise pops a separate
-    # "unidentified developer" prompt for the wrapper.
-    codesign --force --deep --options runtime --timestamp \
-        --sign "${APPLE_DEVELOPER_ID}" "${SERVER_APP_BUNDLE}"
-    codesign --verify --verbose=2 "${SERVER_APP_BUNDLE}"
+#   CODESIGN_IDENTITY   "Developer ID Application: Name (TEAMID)"
+#                       (empty/unset → unsigned ad-hoc build, original
+#                       behaviour, user clears xattr on first launch.)
+#   KEYCHAIN_PATH       Optional path to a temp keychain (CI uses a
+#                       per-run keychain). Empty → codesign uses the
+#                       default keychain search list (dev-local).
+#   ENTITLEMENTS_PATH   Path to the hardened-runtime entitlements plist.
+#                       Defaults to installers/zeus-macos.entitlements.
+#
+# Why --deep (Apple-deprecated but unavoidable here):
+#
+# Apple's bundle convention says Contents/MacOS/ holds only code (Mach-O)
+# and Contents/Resources/ holds everything else. A .NET self-contained
+# publish dumps the entire payload alongside the main binary in
+# Contents/MacOS/: ~300 managed .dlls, runtime configs, web assets
+# (wwwroot/), BandPlans/*.json, etc. Without --deep, codesign refuses to
+# sign the outer bundle with "code object is not signed at all / In
+# subcomponent: <first-non-MachO-it-finds>" — it treats every file under
+# MacOS/ as a sub-bundle that must be pre-signed.
+#
+# --deep walks the bundle once and signs every nested Mach-O with the
+# outer flags (--options runtime + --entitlements + --timestamp). The
+# result is bit-equivalent to a per-item signing pass:
+#   - every dylib (libwdsp, libminiaudio, Photino.Native, .NET runtime)
+#     gets hardened runtime + timestamp + Team ID signature
+#   - the main exec (OpenhpsdrZeus) gets the same plus entitlements
+#   - non-MachO files (JSON, dll, png) are hashed into CodeResources
+#     as data and stop tripping the "subcomponent unsigned" check
+# Notarization accepts --deep-signed .NET bundles (every Mach-O has the
+# right flags; the deprecation warning is about ergonomics, not validity).
+#
+# --options runtime  enables hardened runtime (required for notarization).
+# --timestamp        embeds a trusted Apple timestamp so the signature
+#                    stays valid after the cert expires AND because
+#                    notarization rejects untimestamped signatures.
+if [ -n "${CODESIGN_IDENTITY:-}" ]; then
+    set -e
+    if [ -z "${ENTITLEMENTS_PATH:-}" ]; then
+        ENTITLEMENTS_PATH="${SCRIPT_DIR}/zeus-macos.entitlements"
+    fi
+    if [ ! -f "${ENTITLEMENTS_PATH}" ]; then
+        echo "ERROR: ENTITLEMENTS_PATH '${ENTITLEMENTS_PATH}' not found" >&2
+        exit 1
+    fi
+    echo "Codesigning with: ${CODESIGN_IDENTITY}"
+    echo "Entitlements:     ${ENTITLEMENTS_PATH}"
+    if [ -n "${KEYCHAIN_PATH:-}" ]; then
+        echo "Keychain:         ${KEYCHAIN_PATH}"
+    fi
+
+    # Pass --keychain only when KEYCHAIN_PATH is set; codesign default
+    # search list otherwise. Done via an array so we can splat or skip.
+    KEYCHAIN_FLAG=()
+    if [ -n "${KEYCHAIN_PATH:-}" ]; then
+        KEYCHAIN_FLAG=(--keychain "${KEYCHAIN_PATH}")
+    fi
+
+    sign_bundle() {
+        local bundle="$1"
+        echo "  → ${bundle}"
+
+        codesign --force --deep --options runtime --timestamp \
+            "${KEYCHAIN_FLAG[@]}" \
+            --entitlements "${ENTITLEMENTS_PATH}" \
+            --sign "${CODESIGN_IDENTITY}" \
+            "${bundle}"
+
+        # Verify the bundle and every nested Mach-O. --strict catches
+        # bad signature flags / missing hardened runtime / unsigned
+        # subcomponents that codesign --sign wouldn't have noticed.
+        codesign --verify --deep --strict "${bundle}"
+    }
+
+    sign_bundle "${APP_BUNDLE}"
+    sign_bundle "${SERVER_APP_BUNDLE}"
+    WILL_SIGN=1
 else
-    echo "(unsigned — set APPLE_DEVELOPER_ID to enable codesigning)"
+    echo "(unsigned — set CODESIGN_IDENTITY to enable codesigning)"
+    WILL_SIGN=0
 fi
 
 # --- DMG ----------------------------------------------------------------
@@ -347,7 +408,15 @@ cp -R "${APP_BUNDLE}" "${DMG_TEMP}/"
 cp -R "${SERVER_APP_BUNDLE}" "${DMG_TEMP}/"
 ln -s /Applications "${DMG_TEMP}/Applications"
 
-cat > "${DMG_TEMP}/README.txt" << 'EOF'
+# README inside the DMG. Two flavours, picked from WILL_SIGN above:
+#   - signed/notarized   → drag-to-Applications + first-run notes only.
+#                          No xattr; Gatekeeper accepts the .app directly.
+#   - unsigned (dryrun)  → original README with the xattr -cr workaround,
+#                          which is the only way to launch an unsigned
+#                          .app on modern macOS without right-click +
+#                          Open Anyway acrobatics.
+if [ "${WILL_SIGN}" -eq 1 ]; then
+    cat > "${DMG_TEMP}/README.txt" << 'EOF'
 OpenHPSDR Zeus for macOS
 ========================
 
@@ -360,19 +429,8 @@ INSTALL
   If you only want the desktop app, dragging "OpenHPSDR Zeus.app" alone
   is fine.
 
-FIRST LAUNCH (important — Zeus is not signed)
-  Zeus is distributed without an Apple Developer ID, so macOS Gatekeeper
-  will block it on first launch. To clear the quarantine flag, open
-  Terminal and run:
-
-      xattr -cr "/Applications/OpenHPSDR Zeus.app"
-      xattr -cr "/Applications/OpenHPSDR Zeus Server.app"
-
-  Then launch from Applications.
-
-  If you still see a security warning, go to:
-      System Settings -> Privacy & Security
-  and click "Open Anyway".
+  Then launch from Applications normally — Zeus is signed and notarized,
+  so Gatekeeper lets it open without any xattr workaround.
 
 THE TWO ICONS
 
@@ -391,7 +449,7 @@ THE TWO ICONS
                          warning on first connect.
 
 HEADLESS / CLI USE
-  If you're running Zeus on a headless Mac (no display, e.g. an mac mini
+  If you're running Zeus on a headless Mac (no display, e.g. a mac mini
   in a closet), use Terminal:
 
       "/Applications/OpenHPSDR Zeus.app/Contents/MacOS/OpenhpsdrZeus"
@@ -407,6 +465,71 @@ FIRST RUN — WDSP WISDOM
 
 More info: https://github.com/Kb2uka/openhpsdr-zeus
 EOF
+else
+    cat > "${DMG_TEMP}/README.txt" << 'EOF'
+OpenHPSDR Zeus for macOS  (UNSIGNED DEV BUILD)
+==============================================
+
+INSTALL
+  Drag BOTH "OpenHPSDR Zeus.app" and "OpenHPSDR Zeus Server.app" onto
+  the Applications shortcut in this window. "OpenHPSDR Zeus Server.app"
+  is a small wrapper around "OpenHPSDR Zeus.app" and won't work without
+  "OpenHPSDR Zeus.app" installed.
+
+  If you only want the desktop app, dragging "OpenHPSDR Zeus.app" alone
+  is fine.
+
+FIRST LAUNCH (important — this is an unsigned dev build)
+  This DMG is a dry-run / preview build and is NOT signed by an Apple
+  Developer ID. macOS Gatekeeper will block it on first launch. To clear
+  the quarantine flag, open Terminal and run:
+
+      xattr -cr "/Applications/OpenHPSDR Zeus.app"
+      xattr -cr "/Applications/OpenHPSDR Zeus Server.app"
+
+  Then launch from Applications.
+
+  If you still see a security warning, go to:
+      System Settings -> Privacy & Security
+  and click "Open Anyway".
+
+  Tagged release and nightly builds are signed + notarized and do NOT
+  need this step.
+
+THE TWO ICONS
+
+  OpenHPSDR Zeus         Full native window. The radio backend runs
+                         in-process inside the same window. Closing the
+                         window stops Zeus completely. This is the right
+                         choice for most operators.
+
+  OpenHPSDR Zeus Server  Backend-only mode for LAN / remote / phone
+                         access. Opens a small status window showing
+                         the URLs to connect to from a browser, with a
+                         Stop Zeus button. Connect from this Mac at
+                         http://localhost:6060 or from another device
+                         at http://<your-mac>:6060. HTTPS uses a
+                         self-signed certificate — accept the browser
+                         warning on first connect.
+
+HEADLESS / CLI USE
+  If you're running Zeus on a headless Mac (no display, e.g. a mac mini
+  in a closet), use Terminal:
+
+      "/Applications/OpenHPSDR Zeus.app/Contents/MacOS/OpenhpsdrZeus"
+
+  This is the no-window service mode. Identical to OpenHPSDR Zeus
+  Server's backend but without the status window. Closing the Terminal
+  (or Ctrl-C) stops the server.
+
+FIRST RUN — WDSP WISDOM
+  The first launch builds an FFTW "wisdom" cache and can take 1-3
+  minutes. The window will load, but do NOT click Discover/Connect
+  until the wisdom build settles. Subsequent launches are instant.
+
+More info: https://github.com/Kb2uka/openhpsdr-zeus
+EOF
+fi
 
 hdiutil create -volname "Openhpsdr Zeus v${VERSION}" \
     -srcfolder "${DMG_TEMP}" \
@@ -415,8 +538,31 @@ hdiutil create -volname "Openhpsdr Zeus v${VERSION}" \
 
 rm -rf "${DMG_TEMP}"
 
+# Sign the DMG itself when WILL_SIGN=1. The DMG is a separate signed
+# container from the .app bundles inside it — Gatekeeper's "open" assess
+# context (mounting a DMG) reads the DMG signature, not the nested app
+# signatures. notarize+staple in the CI workflow operate on this signed
+# DMG. DMGs don't take entitlements or --options runtime (those are
+# Mach-O concepts), just --sign + --timestamp.
+if [ "${WILL_SIGN}" -eq 1 ]; then
+    KEYCHAIN_FLAG=()
+    if [ -n "${KEYCHAIN_PATH:-}" ]; then
+        KEYCHAIN_FLAG=(--keychain "${KEYCHAIN_PATH}")
+    fi
+    echo "Signing DMG..."
+    codesign --force --timestamp \
+        "${KEYCHAIN_FLAG[@]}" \
+        --sign "${CODESIGN_IDENTITY}" \
+        "${DMG_PATH}"
+    codesign --verify --verbose=2 "${DMG_PATH}"
+fi
+
 echo "DMG created at ${DMG_PATH}"
-echo
-echo "NOTE: users must clear the quarantine flag on first launch:"
-echo "  xattr -cr \"/Applications/OpenHPSDR Zeus.app\""
-echo "  xattr -cr \"/Applications/OpenHPSDR Zeus Server.app\""
+if [ "${WILL_SIGN}" -eq 1 ]; then
+    echo "DMG is signed; CI will run notarytool submit + stapler staple as follow-up steps."
+else
+    echo
+    echo "NOTE: this is an unsigned dev build — users must clear the quarantine flag on first launch:"
+    echo "  xattr -cr \"/Applications/OpenHPSDR Zeus.app\""
+    echo "  xattr -cr \"/Applications/OpenHPSDR Zeus Server.app\""
+fi

--- a/installers/zeus-macos.entitlements
+++ b/installers/zeus-macos.entitlements
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Hardened-runtime entitlements for OpenHPSDR Zeus.app and OpenHPSDR Zeus Server.app.
+
+  Distribution: Developer ID + notarization (outside the App Store, NOT sandboxed).
+
+  Each flag below exists for a concrete reason in this codebase. Do not trim without
+  reading the matching code path first:
+
+  - allow-jit                          Photino hosts WKWebView, which JITs JavaScript;
+                                       .NET (the OpenhpsdrZeus self-contained publish)
+                                       falls back to tiered JIT for hot methods even
+                                       though we publish with ReadyToRun.
+  - allow-unsigned-executable-memory   Defensive companion to allow-jit: WebKit and
+                                       .NET RyuJIT both rely on RWX pages that the
+                                       hardened-runtime baseline forbids. Without this
+                                       the .NET runtime SIGKILLs at first JIT.
+  - disable-library-validation         libwdsp.dylib and libminiaudio.dylib live under
+                                       Contents/MacOS/runtimes/osx-*/native/ and are
+                                       loaded via P/Invoke at runtime. We DO sign them
+                                       with the same Team ID during the inside-out
+                                       codesign pass, so in theory this could be
+                                       removed — keep it on defensively so a single
+                                       missed dylib doesn't brick the app.
+  - allow-dyld-environment-variables   LOAD-BEARING. Contents/MacOS/launch.sh exports
+                                       DYLD_LIBRARY_PATH to pin the bundled
+                                       libwdsp.dylib ahead of any stale system copy
+                                       from /opt/homebrew/lib or /usr/local/lib
+                                       (piHPSDR / DeskHPSDR installs leave one). The
+                                       hardened runtime strips DYLD_* env vars by
+                                       default — without this flag the pin silently
+                                       fails and P/Invoke can bind against a stale
+                                       wdsp that pre-dates symbols Zeus needs (e.g.
+                                       SetRXAEMNRpost2*). See create-macos-app.sh
+                                       launch.sh block + docs/lessons/dev-conventions.md.
+
+  Microphone / camera access is NOT declared here: those entitlements only apply
+  inside the App Sandbox. Outside the sandbox the TCC prompt is driven by
+  NSMicrophoneUsageDescription / NSCameraUsageDescription in each bundle's Info.plist
+  (set by create-macos-app.sh). Adding sandbox-only entitlements to a non-sandboxed
+  app is silently ignored, but adds noise — keep this file tight.
+-->
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+</dict>
+</plist>

--- a/tests/Zeus.Contracts.Tests/CwEngineStatusFrameTests.cs
+++ b/tests/Zeus.Contracts.Tests/CwEngineStatusFrameTests.cs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+
+using System.Buffers;
+using Zeus.Contracts;
+using Xunit;
+
+namespace Zeus.Contracts.Tests;
+
+public class CwEngineStatusFrameTests
+{
+    [Fact]
+    public void SerializeDeserialize_RoundTrip()
+    {
+        var frame = new CwEngineStatusFrame(
+            State: CwEngineState.Sending,
+            Wpm: 22,
+            QueueDepth: 3,
+            Text: "CQ CQ CQ DE EA5IUE");
+        var writer = new ArrayBufferWriter<byte>();
+        frame.Serialize(writer);
+
+        var decoded = CwEngineStatusFrame.Deserialize(writer.WrittenSpan);
+
+        Assert.Equal(CwEngineState.Sending, decoded.State);
+        Assert.Equal(22, decoded.Wpm);
+        Assert.Equal(3, decoded.QueueDepth);
+        Assert.Equal("CQ CQ CQ DE EA5IUE", decoded.Text);
+    }
+
+    [Fact]
+    public void Serialize_WritesCorrectMsgType()
+    {
+        var frame = new CwEngineStatusFrame(CwEngineState.Idle, 20, 0, "");
+        var writer = new ArrayBufferWriter<byte>();
+        frame.Serialize(writer);
+
+        Assert.Equal((byte)MsgType.CwEngineStatus, writer.WrittenSpan[0]);
+    }
+
+    [Fact]
+    public void Serialize_EmptyText_Produces9ByteFrame()
+    {
+        var frame = new CwEngineStatusFrame(CwEngineState.Idle, 0, 0, "");
+        var writer = new ArrayBufferWriter<byte>();
+        frame.Serialize(writer);
+
+        // 1 byte type + 1 state + 2 wpm + 2 depth + 2 textLen + 0 text = 9.
+        Assert.Equal(CwEngineStatusFrame.HeaderByteLength, writer.WrittenSpan.Length);
+    }
+
+    [Fact]
+    public void Serialize_Utf8Text_RoundTripsCleanly()
+    {
+        // UTF-8-encoded macro lengths can exceed .Length; the frame must
+        // round-trip the bytes, not the char count.
+        var frame = new CwEngineStatusFrame(CwEngineState.Sending, 18, 1, "73 — gud QSO");
+        var writer = new ArrayBufferWriter<byte>();
+        frame.Serialize(writer);
+        var decoded = CwEngineStatusFrame.Deserialize(writer.WrittenSpan);
+
+        Assert.Equal("73 — gud QSO", decoded.Text);
+    }
+
+    [Fact]
+    public void Serialize_OversizedText_TruncatesToMax()
+    {
+        // Defensive cap so a runaway macro can't blow a single broadcast
+        // frame. Truncation happens silently at the serializer; deserialize
+        // sees only the truncated text and is still well-formed.
+        var huge = new string('X', CwEngineStatusFrame.MaxTextBytes * 2);
+        var frame = new CwEngineStatusFrame(CwEngineState.Sending, 20, 0, huge);
+        var writer = new ArrayBufferWriter<byte>();
+        frame.Serialize(writer);
+
+        var decoded = CwEngineStatusFrame.Deserialize(writer.WrittenSpan);
+        Assert.Equal(CwEngineStatusFrame.MaxTextBytes, decoded.Text.Length);
+    }
+
+    [Fact]
+    public void Deserialize_RejectsWrongMsgType()
+    {
+        var bytes = new byte[CwEngineStatusFrame.HeaderByteLength];
+        bytes[0] = (byte)MsgType.Alert;       // wrong type
+        Assert.Throws<InvalidDataException>(() => CwEngineStatusFrame.Deserialize(bytes));
+    }
+
+    [Fact]
+    public void Deserialize_RejectsTruncatedHeader()
+    {
+        var bytes = new byte[CwEngineStatusFrame.HeaderByteLength - 1];
+        bytes[0] = (byte)MsgType.CwEngineStatus;
+        Assert.Throws<InvalidDataException>(() => CwEngineStatusFrame.Deserialize(bytes));
+    }
+
+    [Fact]
+    public void Deserialize_RejectsTruncatedText()
+    {
+        // Header claims 50 bytes of text but only 10 follow — the frame
+        // is malformed and must be rejected rather than silently returning
+        // a short string.
+        var frame = new CwEngineStatusFrame(CwEngineState.Sending, 20, 0, new string('A', 50));
+        var writer = new ArrayBufferWriter<byte>();
+        frame.Serialize(writer);
+        var truncated = writer.WrittenSpan.Slice(0, CwEngineStatusFrame.HeaderByteLength + 10).ToArray();
+
+        Assert.Throws<InvalidDataException>(() => CwEngineStatusFrame.Deserialize(truncated));
+    }
+
+    [Fact]
+    public void FromStatus_LiftsDtoFieldsOntoWire()
+    {
+        var status = new CwEngineStatus(
+            State: CwEngineState.Stopping,
+            Text: "AGN?",
+            Wpm: 25,
+            QueueDepth: 7,
+            Reason: "operator request");
+
+        var frame = CwEngineStatusFrame.FromStatus(status);
+
+        Assert.Equal(CwEngineState.Stopping, frame.State);
+        Assert.Equal(25, frame.Wpm);
+        Assert.Equal(7, frame.QueueDepth);
+        Assert.Equal("AGN?", frame.Text);
+        // Reason is intentionally not in the wire frame — frontend doesn't
+        // need it; logged server-side only. Just sanity-check the lift
+        // didn't crash on the nullable.
+    }
+}

--- a/tests/Zeus.Protocol1.Tests/ControlFrameTests.cs
+++ b/tests/Zeus.Protocol1.Tests/ControlFrameTests.cs
@@ -613,6 +613,117 @@ public class ControlFrameTests
         Assert.Equal(0, peak);
     }
 
+    private sealed class ConstAudioSource : IRxCodecAudioSource
+    {
+        private readonly short _l;
+        private readonly short _r;
+        public ConstAudioSource(short l, short r) { _l = l; _r = r; }
+        public (short L, short R) Next() => (_l, _r);
+    }
+
+    [Fact]
+    public void BuildDataPacket_AudioSource_WritesLrBytes_MoxOff()
+    {
+        // Issue #426 — RX audio path. Operator on Hermes is receiving (MOX
+        // off); WDSP demodulated audio flows through the audio source into
+        // EP2 L/R bytes so the radio's front-panel headphone codec sees
+        // real data. IQ bytes stay zero (no TX during RX).
+        var buf = new byte[1032];
+        var state = BaseState() with
+        {
+            Board = HpsdrBoardKind.Hermes,
+            Mox = false,
+            DriveLevel = 0,
+        };
+        var audio = new ConstAudioSource(l: 0x4321, r: unchecked((short)0xABCD));
+
+        ControlFrame.BuildDataPacket(
+            buf, 1,
+            ControlFrame.CcRegister.Config,
+            ControlFrame.CcRegister.RxFreq,
+            state,
+            iqSource: null,
+            audioSource: audio);
+
+        // First USB-frame payload begins at byte 16 (8-byte Metis + 8-byte USB header).
+        const int payload = 16;
+        // L s16 BE in bytes 0..1
+        Assert.Equal(0x43, buf[payload + 0]);
+        Assert.Equal(0x21, buf[payload + 1]);
+        // R s16 BE in bytes 2..3
+        Assert.Equal(0xAB, buf[payload + 2]);
+        Assert.Equal(0xCD, buf[payload + 3]);
+        // IQ stays zero — MOX off / no IQ source.
+        Assert.Equal(0, buf[payload + 4]);
+        Assert.Equal(0, buf[payload + 5]);
+        Assert.Equal(0, buf[payload + 6]);
+        Assert.Equal(0, buf[payload + 7]);
+    }
+
+    [Fact]
+    public void BuildDataPacket_AudioAndIqSources_BothWriteIntoSameGroup()
+    {
+        // Hermes during TX: WDSP RX-OUT still feeds the codec L/R bytes (the
+        // radio mutes its headphone hardware on MOX anyway) and TXA IQ feeds
+        // the I/Q bytes. They share the 8-byte group but write to disjoint
+        // offsets — no clobbering.
+        var buf = new byte[1032];
+        var state = BaseState() with
+        {
+            Board = HpsdrBoardKind.Hermes,
+            Mox = true,
+            DriveLevel = 0x80,
+        };
+        var iq = new ConstIqSource(i: 0x2000, q: -0x2000);
+        var audio = new ConstAudioSource(l: 0x1234, r: 0x5678);
+
+        ControlFrame.BuildDataPacket(
+            buf, 1,
+            ControlFrame.CcRegister.Config,
+            ControlFrame.CcRegister.RxFreq,
+            state,
+            iqSource: iq,
+            audioSource: audio);
+
+        const int payload = 16;
+        Assert.Equal(0x12, buf[payload + 0]);
+        Assert.Equal(0x34, buf[payload + 1]);
+        Assert.Equal(0x56, buf[payload + 2]);
+        Assert.Equal(0x78, buf[payload + 3]);
+        // IQ unchanged from the existing all-boards test.
+        var (peak, firstI, firstQ) = FirstFrameIqStats(buf);
+        Assert.True(peak > 0);
+        Assert.Equal(0x2000, firstI);
+        Assert.Equal(unchecked((short)-0x2000), firstQ);
+    }
+
+    [Fact]
+    public void BuildDataPacket_NoAudioSource_KeepsLrBytesZero()
+    {
+        // HL2 / pre-#426 behaviour: no audio source supplied → L/R bytes
+        // stay zero (the radio firmware ignores them anyway, and any other
+        // P1 board with a codec will be plumbed via the optional argument).
+        var buf = new byte[1032];
+        var state = BaseState() with
+        {
+            Board = HpsdrBoardKind.HermesLite2,
+            Mox = false,
+            DriveLevel = 0,
+        };
+
+        ControlFrame.BuildDataPacket(
+            buf, 1,
+            ControlFrame.CcRegister.Config,
+            ControlFrame.CcRegister.RxFreq,
+            state);
+
+        const int payload = 16;
+        Assert.Equal(0, buf[payload + 0]);
+        Assert.Equal(0, buf[payload + 1]);
+        Assert.Equal(0, buf[payload + 2]);
+        Assert.Equal(0, buf[payload + 3]);
+    }
+
     [Fact]
     public void BuildDataPacket_IqPayload_MasksLsbAcrossAllBoards()
     {

--- a/tests/Zeus.Protocol1.Tests/PacketParserTests.cs
+++ b/tests/Zeus.Protocol1.Tests/PacketParserTests.cs
@@ -376,4 +376,51 @@ public class PacketParserTests
             out _, out _, out _, out _, out byte bits));
         Assert.Equal(0x03, bits);
     }
+
+    // ---- ExtractHardwarePtt -------------------------------------------------
+    // C0[0] is the PTT/MOX echo set by the HL2 gateware whenever the radio is
+    // keying — host-driven MOX, rear KEY tip grounded, or external PTT line
+    // asserted (HL2 protocol doc line 200). ExternalPttService consumes this
+    // edge to follow hardware-initiated TX.
+
+    [Fact]
+    public void ExtractHardwarePtt_BothFramesClear_ReturnsFalse()
+    {
+        byte[] packet = FramingTests.BuildValidPacket(1, new (int, int)[PacketParser.ComplexSamplesPerPacket]);
+        Assert.False(PacketParser.ExtractHardwarePtt(packet));
+    }
+
+    [Fact]
+    public void ExtractHardwarePtt_FirstFrameC0Bit0_ReturnsTrue()
+    {
+        byte[] packet = FramingTests.BuildValidPacket(1, new (int, int)[PacketParser.ComplexSamplesPerPacket]);
+        packet[8 + 3] |= 0x01;
+        Assert.True(PacketParser.ExtractHardwarePtt(packet));
+    }
+
+    [Fact]
+    public void ExtractHardwarePtt_SecondFrameC0Bit0_ReturnsTrue()
+    {
+        byte[] packet = FramingTests.BuildValidPacket(1, new (int, int)[PacketParser.ComplexSamplesPerPacket]);
+        packet[8 + 512 + 3] |= 0x01;
+        Assert.True(PacketParser.ExtractHardwarePtt(packet));
+    }
+
+    [Fact]
+    public void ExtractHardwarePtt_IgnoresOtherC0Bits()
+    {
+        // Bits 7:1 of C0 carry the address; only bit 0 is the PTT echo. Set
+        // every other bit on both frames and expect false.
+        byte[] packet = FramingTests.BuildValidPacket(1, new (int, int)[PacketParser.ComplexSamplesPerPacket]);
+        packet[8 + 3] = 0xFE;
+        packet[8 + 512 + 3] = 0xFE;
+        Assert.False(PacketParser.ExtractHardwarePtt(packet));
+    }
+
+    [Fact]
+    public void ExtractHardwarePtt_ShortPacket_ReturnsFalse()
+    {
+        // Defensive guard for callers that don't pre-validate length.
+        Assert.False(PacketParser.ExtractHardwarePtt(new byte[10]));
+    }
 }

--- a/tests/Zeus.Protocol1.Tests/Protocol1Client_HardwarePttEventTests.cs
+++ b/tests/Zeus.Protocol1.Tests/Protocol1Client_HardwarePttEventTests.cs
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using Xunit;
+using Zeus.Contracts;
+
+namespace Zeus.Protocol1.Tests;
+
+/// <summary>
+/// End-to-end test for the HardwarePttChanged event. Spins up a real
+/// Protocol1Client against a loopback UDP socket pretending to be a radio,
+/// sends EP6 packets with C0[0] toggled, and asserts the client raises the
+/// event exactly once per level change (edge-triggered, ignores no-op
+/// packets that keep the level the same).
+/// </summary>
+public class Protocol1Client_HardwarePttEventTests
+{
+    [Fact]
+    public async Task HardwarePttChanged_FiresOncePerLevelChange()
+    {
+        using var fakeRadio = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        fakeRadio.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        fakeRadio.ReceiveTimeout = 500;
+        var fakeRadioEp = (IPEndPoint)fakeRadio.LocalEndPoint!;
+
+        using var client = new Protocol1Client();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var observed = new List<bool>();
+        var firstEdgeGate = new TaskCompletionSource();
+        client.HardwarePttChanged += level =>
+        {
+            lock (observed)
+            {
+                observed.Add(level);
+                if (observed.Count == 1) firstEdgeGate.TrySetResult();
+            }
+        };
+
+        await client.ConnectAsync(fakeRadioEp, cts.Token);
+        await client.StartAsync(
+            new StreamConfig(HpsdrSampleRate.Rate192k, PreampOn: false, Atten: HpsdrAtten.Zero),
+            cts.Token);
+
+        // Drain Metis-start to learn the client's local port.
+        IPEndPoint clientEp = ReceiveFirstFromClient(fakeRadio);
+
+        // Send: off, off, on, on, off, on — expect events at levels 3, 5, 6
+        // (positions where the level *changed*). The initial run of "off"
+        // matches the client's startup state (_hardwarePtt=0) so the first
+        // event is the rise to "on".
+        var sequence = new[] { false, false, true, true, false, true };
+        for (uint seq = 0; seq < sequence.Length; seq++)
+        {
+            var packet = BuildEp6Packet(seq, hardwarePtt: sequence[seq]);
+            fakeRadio.SendTo(packet, clientEp);
+        }
+
+        await firstEdgeGate.Task.WaitAsync(TimeSpan.FromSeconds(2), cts.Token);
+        // Grace for the remaining packets to be drained by the RX loop.
+        await Task.Delay(200, cts.Token);
+
+        await client.StopAsync(CancellationToken.None);
+        await client.DisconnectAsync(CancellationToken.None);
+
+        List<bool> captured;
+        lock (observed) captured = new(observed);
+
+        // Exactly three edges from the input sequence.
+        Assert.Equal(new[] { true, false, true }, captured);
+        Assert.True(client.HardwarePtt, "final level read should match the last packet (PTT on)");
+    }
+
+    [Fact]
+    public async Task HardwarePttChanged_FiresOnEitherUsbFrameSettingTheBit()
+    {
+        using var fakeRadio = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        fakeRadio.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        fakeRadio.ReceiveTimeout = 500;
+        var fakeRadioEp = (IPEndPoint)fakeRadio.LocalEndPoint!;
+
+        using var client = new Protocol1Client();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var gate = new TaskCompletionSource<bool>();
+        client.HardwarePttChanged += level => gate.TrySetResult(level);
+
+        await client.ConnectAsync(fakeRadioEp, cts.Token);
+        await client.StartAsync(
+            new StreamConfig(HpsdrSampleRate.Rate192k, PreampOn: false, Atten: HpsdrAtten.Zero),
+            cts.Token);
+
+        IPEndPoint clientEp = ReceiveFirstFromClient(fakeRadio);
+
+        // First USB frame clear, second carries the PTT bit — combined OR
+        // should still raise the rising-edge event.
+        var packet = new byte[1032];
+        packet[0] = 0xEF; packet[1] = 0xFE; packet[2] = 0x01; packet[3] = 0x06;
+        BinaryPrimitives.WriteUInt32BigEndian(packet.AsSpan(4, 4), 0u);
+        for (int f = 0; f < 2; f++)
+        {
+            int fs = 8 + f * 512;
+            packet[fs + 0] = 0x7F; packet[fs + 1] = 0x7F; packet[fs + 2] = 0x7F;
+            packet[fs + 3] = 0x00;
+        }
+        // Set C0[0] on the second USB frame only.
+        packet[8 + 512 + 3] = 0x01;
+        fakeRadio.SendTo(packet, clientEp);
+
+        var observed = await gate.Task.WaitAsync(TimeSpan.FromSeconds(2), cts.Token);
+
+        await client.StopAsync(CancellationToken.None);
+        await client.DisconnectAsync(CancellationToken.None);
+
+        Assert.True(observed);
+    }
+
+    private static IPEndPoint ReceiveFirstFromClient(Socket fakeRadio)
+    {
+        var buf = new byte[2048];
+        EndPoint remote = new IPEndPoint(IPAddress.Any, 0);
+        fakeRadio.ReceiveFrom(buf, ref remote);
+        return (IPEndPoint)remote;
+    }
+
+    private static byte[] BuildEp6Packet(uint seq, bool hardwarePtt)
+    {
+        var packet = new byte[1032];
+        packet[0] = 0xEF; packet[1] = 0xFE; packet[2] = 0x01; packet[3] = 0x06;
+        BinaryPrimitives.WriteUInt32BigEndian(packet.AsSpan(4, 4), seq);
+
+        byte c0 = hardwarePtt ? (byte)0x01 : (byte)0x00;
+        for (int f = 0; f < 2; f++)
+        {
+            int fs = 8 + f * 512;
+            packet[fs + 0] = 0x7F; packet[fs + 1] = 0x7F; packet[fs + 2] = 0x7F;
+            packet[fs + 3] = c0; // C0[0] = PTT echo (bits 7:3 = 0 → non-AIN address)
+        }
+        return packet;
+    }
+}

--- a/tests/Zeus.Protocol1.Tests/RxCodecAudioRingTests.cs
+++ b/tests/Zeus.Protocol1.Tests/RxCodecAudioRingTests.cs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Issue #426 — RX audio routed to the radio's on-board codec via the
+// EP2 outbound L/R bytes. The ring is a tiny SPSC-ish buffer between
+// WDSP's audio sink and the EP2 packer; this test pins its core
+// semantics so a future refactor doesn't silently break Hermes audio.
+
+using Xunit;
+using Zeus.Protocol1;
+
+namespace Zeus.Protocol1.Tests;
+
+public class RxCodecAudioRingTests
+{
+    [Fact]
+    public void Next_EmptyRing_ReturnsZeroPair()
+    {
+        var ring = new RxCodecAudioRing(capacitySamples: 16);
+        var (l, r) = ring.Next();
+        Assert.Equal(0, l);
+        Assert.Equal(0, r);
+        Assert.Equal(0, ring.Count);
+    }
+
+    [Fact]
+    public void Write_MonoFloat_ReadsBackAsDuplicatedLrInt16()
+    {
+        var ring = new RxCodecAudioRing(capacitySamples: 32);
+        // 0.5f → ~16383.5 → int16 16383 after truncation toward zero.
+        ring.Write(new float[] { 0.5f, -0.5f, 1.0f, -1.0f });
+
+        Assert.Equal(4, ring.Count);
+
+        var (l0, r0) = ring.Next();
+        Assert.Equal(16383, l0);
+        Assert.Equal(l0, r0); // mono in → L == R out
+
+        var (l1, _) = ring.Next();
+        Assert.Equal(-16383, l1);
+
+        var (l2, _) = ring.Next();
+        Assert.Equal(short.MaxValue, l2);
+
+        var (l3, _) = ring.Next();
+        // -1.0 * 32767 = -32767, clamped to int16 range.
+        Assert.Equal(-short.MaxValue, l3);
+
+        Assert.Equal(0, ring.Count);
+    }
+
+    [Fact]
+    public void Write_SaturatesPastUnity()
+    {
+        var ring = new RxCodecAudioRing(capacitySamples: 8);
+        ring.Write(new float[] { 2.5f, -2.5f, 1.0001f });
+
+        var (l0, _) = ring.Next();
+        Assert.Equal(short.MaxValue, l0);
+        var (l1, _) = ring.Next();
+        Assert.Equal(-short.MaxValue, l1);
+        var (l2, _) = ring.Next();
+        Assert.Equal(short.MaxValue, l2);
+    }
+
+    [Fact]
+    public void Write_PastCapacity_DropsOldestAndCountsDrops()
+    {
+        var ring = new RxCodecAudioRing(capacitySamples: 4);
+        ring.Write(new float[] { 0.1f, 0.2f, 0.3f, 0.4f });
+        Assert.Equal(4, ring.Count);
+        Assert.Equal(0, ring.DroppedSamples);
+
+        // Overflow by 2 — oldest two get evicted.
+        ring.Write(new float[] { 0.5f, 0.6f });
+        Assert.Equal(4, ring.Count);
+        Assert.Equal(2, ring.DroppedSamples);
+
+        // FIFO from the surviving samples.
+        var (l0, _) = ring.Next();
+        var (l1, _) = ring.Next();
+        var (l2, _) = ring.Next();
+        var (l3, _) = ring.Next();
+        // 0.3, 0.4, 0.5, 0.6 — strictly increasing.
+        Assert.True(l0 < l1 && l1 < l2 && l2 < l3);
+    }
+
+    [Fact]
+    public void Clear_DrainsRingWithoutResettingDropCounter()
+    {
+        var ring = new RxCodecAudioRing(capacitySamples: 2);
+        ring.Write(new float[] { 0.1f, 0.2f, 0.3f }); // drops 1
+        Assert.Equal(2, ring.Count);
+        Assert.Equal(1, ring.DroppedSamples);
+
+        ring.Clear();
+        Assert.Equal(0, ring.Count);
+        // DroppedSamples is a session counter and reflects history, not
+        // current depth — Clear() doesn't reset it.
+        Assert.Equal(1, ring.DroppedSamples);
+
+        var (l, r) = ring.Next();
+        Assert.Equal(0, l);
+        Assert.Equal(0, r);
+    }
+
+    [Fact]
+    public void IRxCodecAudioSource_Polymorphism()
+    {
+        // Trivial — but ensures the contract surface the EP2 packer talks
+        // to is the same one the ring implements, so a future "swap the
+        // ring for a different source" refactor can't drift the interface.
+        IRxCodecAudioSource src = new RxCodecAudioRing(capacitySamples: 4);
+        var (l, r) = src.Next();
+        Assert.Equal(0, l);
+        Assert.Equal(0, r);
+    }
+}

--- a/tests/Zeus.Server.Tests/AdifUtcTimezoneTests.cs
+++ b/tests/Zeus.Server.Tests/AdifUtcTimezoneTests.cs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// Regression for issue #486 (zeus-1sc): QRZ.com uploads (and ADIF
+// exports) used to emit local-clock times because LiteDB's default
+// BsonMapper round-trips DateTime with Kind=Local on read — even
+// when the field was DateTime.UtcNow at write time. .ToString()
+// formats the stored value without timezone conversion, so the
+// local-kinded value reached QRZ as if it were UTC and stamped
+// every QSO at the operator's wall-clock hour. Award credit and
+// DXCC matching for anyone outside UTC was wrong.
+//
+// The fix is a defensive .ToUniversalTime() at both ADIF format
+// sites. These tests pin the behaviour by passing a DateTime that
+// has Kind=Local but represents a known UTC moment — exactly what
+// LiteDB returns — and asserting the ADIF still carries UTC.
+
+using System.Text;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class AdifUtcTimezoneTests
+{
+    // 19:30:00 UTC on 2026-05-24. Pick a wall-clock hour high enough that
+    // a CET-summer browser (UTC+2) shifts it into the next day — without
+    // the fix, ToString("yyyyMMdd") on a Local-kinded version would emit
+    // either 20260524 or 20260525 depending on the test box's TZ, but
+    // never the right value consistently. With the fix it's always
+    // 20260524 / 193000.
+    private static readonly DateTime QsoUtc =
+        new(2026, 5, 24, 19, 30, 0, DateTimeKind.Utc);
+    private const string ExpectedDate = "20260524";
+    private const string ExpectedTime = "193000";
+
+    /// <summary>Build a Kind=Local DateTime that represents <see cref="QsoUtc"/>
+    /// in the test host's local zone. This is exactly what LiteDB's default
+    /// BsonMapper hands back to <c>LogService</c> after the round-trip:
+    /// the moment in time is right, but the <see cref="DateTime.Kind"/>
+    /// is wrong. A naive <c>.ToString("HHmmss")</c> on this value would
+    /// format the LOCAL clock, not the UTC clock.</summary>
+    private static DateTime QsoSeenAsLocal => QsoUtc.ToLocalTime();
+
+    [Fact]
+    public void LogService_AdifRecord_EmitsUtcClock_EvenWhenKindIsLocal()
+    {
+        var doc = new LogEntryDocument
+        {
+            Id = "test-id",
+            QsoDateTimeUtc = QsoSeenAsLocal,    // ← LiteDB shape
+            Callsign = "EA5IUE",
+            FrequencyMhz = 21.065,
+            Band = "15m",
+            Mode = "CW",
+            RstSent = "599",
+            RstRcvd = "599",
+        };
+        var sb = new StringBuilder();
+
+        LogService.AppendAdifRecord(sb, doc);
+
+        var adif = sb.ToString();
+        Assert.Contains($"<QSO_DATE:8>{ExpectedDate}", adif);
+        Assert.Contains($"<TIME_ON:6>{ExpectedTime}", adif);
+    }
+
+    [Fact]
+    public void QrzService_AdifConversion_EmitsUtcClock_EvenWhenKindIsLocal()
+    {
+        // Same shape, but exercising the QRZ publish path which converts a
+        // LogEntry DTO (not the LiteDB doc) — the DTO is built by
+        // LogService.MapDocumentToDto which copies QsoDateTimeUtc through
+        // unchanged, so the wrong Kind reaches QRZ the same way.
+        var entry = new LogEntry(
+            Id: "test-id",
+            QsoDateTimeUtc: QsoSeenAsLocal,
+            Callsign: "EA5IUE",
+            Name: null,
+            FrequencyMhz: 21.065,
+            Band: "15m",
+            Mode: "CW",
+            RstSent: "599",
+            RstRcvd: "599",
+            Grid: null,
+            Country: null,
+            Dxcc: null,
+            CqZone: null,
+            ItuZone: null,
+            State: null,
+            Comment: null,
+            CreatedUtc: DateTime.UtcNow);
+
+        var adif = QrzService.ConvertLogEntryToAdif(entry);
+
+        Assert.Contains($"<QSO_DATE:8>{ExpectedDate}", adif);
+        Assert.Contains($"<TIME_ON:6>{ExpectedTime}", adif);
+    }
+
+    [Fact]
+    public void LogService_AdifRecord_AlsoCorrectForActuallyUtcKind()
+    {
+        // Sanity check: when the DateTime ALREADY has Kind=Utc (which is
+        // the case for freshly-created entries before any LiteDB
+        // round-trip — see LogService.CreateLogEntryAsync setting
+        // QsoDateTimeUtc = DateTime.UtcNow), the .ToUniversalTime() call
+        // is a no-op and the output is still correct. This guards against
+        // a future "optimisation" that strips the ToUniversalTime() call
+        // believing it's redundant.
+        var doc = new LogEntryDocument
+        {
+            Id = "test-id",
+            QsoDateTimeUtc = QsoUtc,
+            Callsign = "EA5IUE",
+            FrequencyMhz = 21.065,
+            Band = "15m",
+            Mode = "CW",
+            RstSent = "599",
+            RstRcvd = "599",
+        };
+        var sb = new StringBuilder();
+
+        LogService.AppendAdifRecord(sb, doc);
+
+        var adif = sb.ToString();
+        Assert.Contains($"<QSO_DATE:8>{ExpectedDate}", adif);
+        Assert.Contains($"<TIME_ON:6>{ExpectedTime}", adif);
+    }
+}

--- a/tests/Zeus.Server.Tests/CwEngineTests.cs
+++ b/tests/Zeus.Server.Tests/CwEngineTests.cs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// CwEngine — host-side CW IQ generator. The encoder's correctness is
+// covered by MorseEncoderTests; this file covers the *render path*: that
+// the engine produces the right number of samples for a given message at
+// a given WPM, and that the carrier sideband flips between CWU and CWL.
+
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class CwEngineTests
+{
+    private const int Sr = CwEngine.SampleRateHz;   // 48 000
+
+    // RenderForTest takes a SIGNED baseband Hz that matches the engine's
+    // live (RadioLoHz − VfoHz) computation. The sign reflects the HL2's
+    // "I − jQ" IQ convention: positive baseband puts the carrier BELOW the
+    // LO, negative baseband puts it above. So for CWU without CTUN the
+    // RadioService programs LO = VFO − 600, giving LO − VFO = −600 (carrier
+    // at LO + 600 = VFO). For CWL the LO is VFO + 600, giving +600 (carrier
+    // at LO − 600 = VFO).
+    private const int CwuNoCtun = -600;
+    private const int CwlNoCtun = +600;
+
+    [Fact]
+    public void Render_E_At20Wpm_ProducesOneDitOfSamples()
+    {
+        // 'E' = dit. At 20 WPM the PARIS unit is 1200/20 = 60 ms.
+        // No leading or trailing inter-char gap (single char, single
+        // character of buffer), so the IQ stream is exactly 60 ms long.
+        var iq = CwEngine.RenderForTest("E", wpm: 20, basebandHz: CwuNoCtun);
+
+        int expectedSamples = 60 * Sr / 1000;     // 2880 samples
+        Assert.Equal(2 * expectedSamples, iq.Length);
+    }
+
+    [Fact]
+    public void Render_T_At20Wpm_ProducesOneDahOfSamples()
+    {
+        // 'T' = dah. 3 units × 60 ms = 180 ms.
+        var iq = CwEngine.RenderForTest("T", wpm: 20, basebandHz: CwuNoCtun);
+
+        int expectedSamples = 180 * Sr / 1000;    // 8640
+        Assert.Equal(2 * expectedSamples, iq.Length);
+    }
+
+    [Fact]
+    public void Render_CQ_At20Wpm_ProducesExpectedTotalDuration()
+    {
+        // 'CQ' at 20 WPM:
+        //   C = -.-.  → 3 + 1 + 1 + 1 + 3 + 1 + 1 = 11 units
+        //   inter-char gap                          =  3 units
+        //   Q = --.-  → 3 + 1 + 3 + 1 + 1 + 1 + 3 = 13 units
+        //   ------------------------------------------
+        //   total                                  = 27 units = 1620 ms
+        var iq = CwEngine.RenderForTest("CQ", wpm: 20, basebandHz: CwuNoCtun);
+
+        int expectedSamples = 1620 * Sr / 1000;   // 77 760
+        Assert.Equal(2 * expectedSamples, iq.Length);
+    }
+
+    [Fact]
+    public void Render_CWU_vs_CWL_FlipsQSign_OnTheCarrier()
+    {
+        // The baseband sign distinguishes the sideband: CWU without CTUN
+        // emits +600 Hz, CWL emits -600 Hz. At the carrier peak (envelope =
+        // 1, phase past the ramp), I[n]/Q[n] for CWU and CWL should have
+        // the same I value and equal-and-opposite Q.
+        var u = CwEngine.RenderForTest("T", wpm: 20, basebandHz: CwuNoCtun);
+        var l = CwEngine.RenderForTest("T", wpm: 20, basebandHz: CwlNoCtun);
+
+        Assert.Equal(u.Length, l.Length);
+
+        // Sample at the midpoint of the dah — well past the 5 ms ramp,
+        // envelope is 1.0, so I/Q reflect the raw carrier.
+        int sampleIdx = (u.Length / 2) & ~1;   // even (I-position)
+        float iU = u[sampleIdx], qU = u[sampleIdx + 1];
+        float iL = l[sampleIdx], qL = l[sampleIdx + 1];
+
+        // I matches because cos(±θ) = cos(θ).
+        Assert.Equal(iU, iL, precision: 4);
+        // Q is opposite-signed: sin(-θ) = -sin(θ).
+        Assert.Equal(qU, -qL, precision: 4);
+        // And the carrier has real amplitude (sanity: not all zero).
+        Assert.True(Math.Abs(iU) > 0.5f || Math.Abs(qU) > 0.5f,
+            $"expected envelope near 1.0 at sample {sampleIdx}, got I={iU} Q={qU}");
+    }
+
+    [Fact]
+    public void Render_CtunOffset_ShiftsCarrierBaseband()
+    {
+        // Regression for the 2026-05-24 EA5IUE bench-test bug: with CTUN
+        // active the HL2 LO sits independent of the dial, and the engine
+        // must compensate so the carrier still lands at the operator's
+        // dial freq. Verify by comparing two renders that differ only in
+        // baseband Hz — the carrier-phase rate at the midpoint of the dah
+        // should match the supplied frequency.
+        var slow = CwEngine.RenderForTest("T", wpm: 20, basebandHz: 600);
+        var fast = CwEngine.RenderForTest("T", wpm: 20, basebandHz: 9600);
+
+        Assert.Equal(slow.Length, fast.Length);
+
+        // Count zero-crossings of I[n] in the steady-state region of the
+        // dah (skip the 5 ms ramp at start and end). At 600 Hz over an
+        // 80 ms window we expect ~48 crossings; at 9600 Hz, ~768.
+        int rampSamples = 5 * Sr / 1000;
+        int windowStart = rampSamples;
+        int windowEnd = (slow.Length / 2) - rampSamples;
+        int slowCrossings = CountZeroCrossingsI(slow, windowStart, windowEnd);
+        int fastCrossings = CountZeroCrossingsI(fast, windowStart, windowEnd);
+
+        // 9600 Hz is 16× the 600 Hz rate, so we expect ~16× the crossings.
+        // Allow ±5% slack for boundary effects at the window edges.
+        double ratio = (double)fastCrossings / slowCrossings;
+        Assert.InRange(ratio, 16.0 * 0.95, 16.0 * 1.05);
+    }
+
+    private static int CountZeroCrossingsI(float[] iq, int sampleStart, int sampleEnd)
+    {
+        int n = 0;
+        float prev = iq[2 * sampleStart];
+        for (int s = sampleStart + 1; s < sampleEnd; s++)
+        {
+            float cur = iq[2 * s];
+            if ((prev <= 0f && cur > 0f) || (prev >= 0f && cur < 0f)) n++;
+            prev = cur;
+        }
+        return n;
+    }
+
+    [Fact]
+    public void Render_KeyUpGaps_AreSilent()
+    {
+        // 'EE' at 20 WPM: dit, 3-unit inter-char gap, dit.
+        // Inter-char gap is samples [dit..dit+gap] of the stream — pure zeros.
+        var iq = CwEngine.RenderForTest("EE", wpm: 20, basebandHz: CwuNoCtun);
+
+        int ditSamples = 60 * Sr / 1000;
+        int gapSamples = 3 * 60 * Sr / 1000;
+
+        // Inspect a sample comfortably inside the gap (skip the very first
+        // sample at the boundary in case of rounding). 1000 samples in.
+        int probe = ditSamples + 1000;
+        Assert.True(probe < ditSamples + gapSamples, "probe must land inside the gap");
+
+        Assert.Equal(0f, iq[2 * probe]);
+        Assert.Equal(0f, iq[2 * probe + 1]);
+    }
+
+    [Fact]
+    public void Render_HasRaisedCosineRiseEdge_NoHardClick()
+    {
+        // The first key-down sample should be near zero (start of the raised-
+        // cosine ramp), not a hard step to full scale. This guards against
+        // accidentally removing the envelope shaper.
+        var iq = CwEngine.RenderForTest("E", wpm: 20, basebandHz: CwuNoCtun);
+
+        // Sample 0: I = cos(0) × env(0) = 1 × 0 = 0. Q = sin(0) × env(0) = 0.
+        // Both must be effectively zero — the envelope IS the click suppressor.
+        Assert.Equal(0f, iq[0], precision: 5);
+        Assert.Equal(0f, iq[1], precision: 5);
+
+        // Mid-ramp (sample 120 = 2.5 ms in, half-way through the 5 ms / 240-
+        // sample ramp): envelope is 0.5(1 - cos(π/2)) = 0.5, so combined
+        // amplitude sqrt(I² + Q²) ≈ 0.5.
+        int mid = 120;
+        float mag = MathF.Sqrt(iq[2 * mid] * iq[2 * mid] + iq[2 * mid + 1] * iq[2 * mid + 1]);
+        Assert.InRange(mag, 0.3f, 0.7f);
+    }
+}

--- a/tests/Zeus.Server.Tests/CwSettingsStoreTests.cs
+++ b/tests/Zeus.Server.Tests/CwSettingsStoreTests.cs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class CwSettingsStoreTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-cwset-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+    }
+
+    private CwSettingsStore Build() =>
+        new(NullLogger<CwSettingsStore>.Instance, _dbPath);
+
+    [Fact]
+    public void Get_OnFreshDb_ReturnsSeededDefaults()
+    {
+        using var store = Build();
+
+        var s = store.Get();
+
+        Assert.Equal(CwSettingsStore.DefaultWpm, s.Wpm);
+        Assert.Null(s.FarnsworthWpm);
+        Assert.Equal(CwSettingsStore.DefaultSidetoneGainDb, s.SidetoneGainDb);
+        Assert.Equal(CwSettingsStore.DefaultSidetoneHz, s.SidetoneHz);
+        // Fresh install gets the six seeded defaults — operator can grow
+        // the list to MaxMacros via PATCH.
+        Assert.Equal(CwSettingsStore.DefaultMacros.Length, s.Macros.Length);
+        Assert.Equal(CwSettingsStore.DefaultMacros, s.Macros);
+    }
+
+    [Fact]
+    public void Save_RoundtripsSingleField_LeavesOthersUntouched()
+    {
+        // PATCH semantics — saving Wpm alone must not wipe the macros.
+        using var store = Build();
+
+        var after = store.Save(new CwSettingsSetRequest(Wpm: 30));
+
+        Assert.Equal(30, after.Wpm);
+        Assert.Equal(CwSettingsStore.DefaultMacros, after.Macros);
+        Assert.Equal(CwSettingsStore.DefaultSidetoneGainDb, after.SidetoneGainDb);
+    }
+
+    [Fact]
+    public void Save_ClampsOutOfRangeFields()
+    {
+        // The store is the last line of defence before LiteDB persists —
+        // any pathological value (UI bug, hand-rolled curl) must clamp
+        // rather than write garbage that survives restarts.
+        using var store = Build();
+
+        var after = store.Save(new CwSettingsSetRequest(
+            Wpm: 999,
+            FarnsworthWpm: 999,
+            SidetoneGainDb: +10.0,
+            SidetoneHz: 50));
+
+        Assert.Equal(50, after.Wpm);                  // clamped to WpmMax
+        Assert.Equal(50, after.FarnsworthWpm);
+        Assert.Equal(0.0, after.SidetoneGainDb);      // clamped to ≤ 0
+        Assert.Equal(200, after.SidetoneHz);          // clamped to ≥ 200
+    }
+
+    [Fact]
+    public void Save_PreservesMacroLength_AndDoesNotPad()
+    {
+        // Variable-length: if the operator saves two macros, only two are
+        // persisted (add/delete are first-class operations from the UI).
+        // The previous fixed-6 padding behaviour would have hidden a
+        // genuine "user deleted 4 of 6 macros" intent behind invisible
+        // empty slots that the macro pad would still render.
+        using var store = Build();
+
+        var raw = new[] { "ONE", "TWO" };
+        var after = store.Save(new CwSettingsSetRequest(Macros: raw));
+
+        Assert.Equal(2, after.Macros.Length);
+        Assert.Equal("ONE", after.Macros[0]);
+        Assert.Equal("TWO", after.Macros[1]);
+    }
+
+    [Fact]
+    public void Save_CapsMacroCount_AtMaxMacros()
+    {
+        // Defensive upper bound — a programmatic mass-save (or a bug in
+        // an upcoming "import macros" feature) can't blow past the cap.
+        using var store = Build();
+        var huge = Enumerable.Range(0, CwSettingsStore.MaxMacros * 2)
+            .Select(i => $"M{i}")
+            .ToArray();
+
+        var after = store.Save(new CwSettingsSetRequest(Macros: huge));
+
+        Assert.Equal(CwSettingsStore.MaxMacros, after.Macros.Length);
+    }
+
+    [Fact]
+    public void Save_CapsMacroLength()
+    {
+        using var store = Build();
+        string huge = new string('A', CwSettingsStore.MaxMacroChars * 3);
+
+        var after = store.Save(new CwSettingsSetRequest(Macros: new[] { huge }));
+
+        Assert.Equal(CwSettingsStore.MaxMacroChars, after.Macros[0].Length);
+    }
+
+    [Fact]
+    public void Get_AfterDispose_AndReopen_ReturnsPersistedValues()
+    {
+        // Survives a backend restart — the whole point of the store.
+        // Empty-string slots in the middle of the list are preserved
+        // (LiteDB serialises "" as null; SanitizeStored maps back).
+        using (var store = Build())
+        {
+            store.Save(new CwSettingsSetRequest(
+                Wpm: 28,
+                Macros: new[] { "X", "Y", "Z", "", "M5" }));
+        }
+
+        using var reopened = Build();
+        var s = reopened.Get();
+
+        Assert.Equal(28, s.Wpm);
+        Assert.Equal(5, s.Macros.Length);
+        Assert.Equal("X", s.Macros[0]);
+        Assert.Equal("Y", s.Macros[1]);
+        Assert.Equal("Z", s.Macros[2]);
+        Assert.Equal(string.Empty, s.Macros[3]);
+        Assert.Equal("M5", s.Macros[4]);
+    }
+}

--- a/tests/Zeus.Server.Tests/DisplaySettingsPersistenceTests.cs
+++ b/tests/Zeus.Server.Tests/DisplaySettingsPersistenceTests.cs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// Persistence coverage for issue #478 — panadapter dB scale now survives a
+// backend restart. Verifies that all eight dB range fields round-trip through
+// LiteDB and that a fresh (or legacy) row returns null so the frontend knows
+// to fall back to its built-in defaults and push the localStorage value up.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Zeus.Server.Tests;
+
+public class DisplaySettingsPersistenceTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-display-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+    }
+
+    private DisplaySettingsStore BuildStore() =>
+        new(NullLogger<DisplaySettingsStore>.Instance, _dbPath);
+
+    [Fact]
+    public void FreshDb_ReturnsNullForAllDbRangeFields()
+    {
+        using var store = BuildStore();
+        var dto = store.Get();
+
+        Assert.Null(dto.DbMin);
+        Assert.Null(dto.DbMax);
+        Assert.Null(dto.TxDbMin);
+        Assert.Null(dto.TxDbMax);
+        Assert.Null(dto.WfDbMin);
+        Assert.Null(dto.WfDbMax);
+        Assert.Null(dto.WfTxDbMin);
+        Assert.Null(dto.WfTxDbMax);
+    }
+
+    [Fact]
+    public void SaveMode_WithDbRanges_PersistsAllFields()
+    {
+        using (var store = BuildStore())
+        {
+            store.SaveMode("basic", "fill", "#FFA028",
+                dbMin: -130, dbMax: -60,
+                txDbMin: -75, txDbMax: 15,
+                wfDbMin: -125, wfDbMax: -55,
+                wfTxDbMin: -70, wfTxDbMax: 10);
+        }
+
+        // Reopen to prove the values survived the LiteDB file round-trip.
+        using var fresh = BuildStore();
+        var dto = fresh.Get();
+
+        Assert.Equal(-130, dto.DbMin);
+        Assert.Equal(-60, dto.DbMax);
+        Assert.Equal(-75, dto.TxDbMin);
+        Assert.Equal(15, dto.TxDbMax);
+        Assert.Equal(-125, dto.WfDbMin);
+        Assert.Equal(-55, dto.WfDbMax);
+        Assert.Equal(-70, dto.WfTxDbMin);
+        Assert.Equal(10, dto.WfTxDbMax);
+    }
+
+    [Fact]
+    public void SaveMode_NullDbRanges_DoNotOverwriteExistingValues()
+    {
+        // Write concrete dB values first.
+        using (var store = BuildStore())
+        {
+            store.SaveMode("basic", "fill", "#FFA028",
+                dbMin: -130, dbMax: -60,
+                txDbMin: -75, txDbMax: 15,
+                wfDbMin: -125, wfDbMax: -55,
+                wfTxDbMin: -70, wfTxDbMax: 10);
+        }
+
+        // Update mode/fit/color only — no dB range args (default null).
+        using (var update = BuildStore())
+        {
+            update.SaveMode("beam-map", "fill", "#FF8800");
+        }
+
+        // dB values must still be the originals.
+        using var check = BuildStore();
+        var dto = check.Get();
+
+        Assert.Equal("beam-map", dto.Mode);
+        Assert.Equal(-130, dto.DbMin);
+        Assert.Equal(-60, dto.DbMax);
+        Assert.Equal(-75, dto.TxDbMin);
+        Assert.Equal(15, dto.TxDbMax);
+    }
+
+    [Fact]
+    public void SaveMode_UpdateDbRanges_OverwritesExistingValues()
+    {
+        using var store = BuildStore();
+        store.SaveMode("basic", "fill", "#FFA028",
+            dbMin: -140, dbMax: -50);
+        store.SaveMode("basic", "fill", "#FFA028",
+            dbMin: -120, dbMax: -40);
+
+        var dto = store.Get();
+        Assert.Equal(-120, dto.DbMin);
+        Assert.Equal(-40, dto.DbMax);
+    }
+}

--- a/tests/Zeus.Server.Tests/DisplaySettingsPersistenceTests.cs
+++ b/tests/Zeus.Server.Tests/DisplaySettingsPersistenceTests.cs
@@ -121,4 +121,48 @@ public class DisplaySettingsPersistenceTests : IDisposable
         Assert.Equal(-120, dto.DbMin);
         Assert.Equal(-40, dto.DbMax);
     }
+
+    // Issue #426 — waterfall brightness is the same persisted-double pattern
+    // as the dB ranges. Cover the three round-trip behaviours so a future
+    // refactor that breaks any one of them is caught here.
+
+    [Fact]
+    public void FreshDb_ReturnsNullForWfBrightness()
+    {
+        using var store = BuildStore();
+        Assert.Null(store.Get().WfBrightness);
+    }
+
+    [Fact]
+    public void SaveMode_WithWfBrightness_PersistsAcrossReopen()
+    {
+        using (var store = BuildStore())
+        {
+            store.SaveMode("basic", "fill", "#FFA028", wfBrightness: 1.75);
+        }
+        using var fresh = BuildStore();
+        Assert.Equal(1.75, fresh.Get().WfBrightness);
+    }
+
+    [Fact]
+    public void SaveMode_NullWfBrightness_PreservesExistingValue()
+    {
+        using var store = BuildStore();
+        store.SaveMode("basic", "fill", "#FFA028", wfBrightness: 2.0);
+        // Subsequent save that doesn't touch brightness must not zero it.
+        store.SaveMode("beam-map", "fit", "#FFA028");
+        Assert.Equal(2.0, store.Get().WfBrightness);
+    }
+
+    [Fact]
+    public void SaveMode_ClampsWfBrightnessToSliderBounds()
+    {
+        using var store = BuildStore();
+        // Below WF_BRIGHTNESS_MIN (0.25) clamps up.
+        store.SaveMode("basic", "fill", "#FFA028", wfBrightness: 0.01);
+        Assert.Equal(0.25, store.Get().WfBrightness);
+        // Above WF_BRIGHTNESS_MAX (4.0) clamps down.
+        store.SaveMode("basic", "fill", "#FFA028", wfBrightness: 99.0);
+        Assert.Equal(4.0, store.Get().WfBrightness);
+    }
 }

--- a/tests/Zeus.Server.Tests/LevelerMaxGainEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/LevelerMaxGainEndpointTests.cs
@@ -60,13 +60,16 @@ namespace Zeus.Server.Tests;
 /// <summary>
 /// End-to-end endpoint test for <c>POST /api/tx/leveler-max-gain</c>: drives
 /// the real handler via <see cref="WebApplicationFactory{TEntryPoint}"/>,
-/// asserting a JSON <c>{gain}</c> body reaches
-/// <see cref="IDspEngine.SetTxLevelerMaxGain"/> on the current engine, and
-/// that out-of-range values are rejected with a 400.
+/// asserting that a JSON <c>{gain}</c> body updates the persisted
+/// <see cref="StateDto.LevelerMaxGainDb"/>, and that out-of-range values
+/// are rejected with a 400.
 ///
-/// Frontend re-POSTs this on every slider move and on WS reconnect (task
-/// #19), so the handler's range check is the only thing between a rogue
-/// client and WDSP's Leveler ceiling.
+/// Post-persistence migration the endpoint routes through
+/// <c>RadioService.SetTxLevelerMaxGain</c> → <c>Mutate</c> → the StateChanged
+/// listener that pushes WDSP's <c>SetTXALevelerTop</c>. The HTTP test pins
+/// the request/response contract and the state-mutation hop; the engine-seam
+/// behaviour is covered by <see cref="DspPipelineService"/>'s broadcast path
+/// (no engine open in this test factory so the seam is intentionally inert).
 /// </summary>
 public class LevelerMaxGainEndpointTests : IClassFixture<LevelerMaxGainEndpointTests.Factory>
 {
@@ -77,33 +80,34 @@ public class LevelerMaxGainEndpointTests : IClassFixture<LevelerMaxGainEndpointT
     [InlineData(0.0)]   // band floor
     [InlineData(5.0)]   // W1AEX / softerhardware default
     [InlineData(15.0)]  // band ceiling (Thetis stock)
-    public async Task PostInRange_CallsEngineWithSameValue(double gain)
+    public async Task PostInRange_UpdatesRadioServiceState(double gain)
     {
-        _factory.TestEngine.LevelerMaxGainCalls.Clear();
+        using var scope = _factory.Services.CreateScope();
+        var radio = scope.ServiceProvider.GetRequiredService<RadioService>();
         using var client = _factory.CreateClient();
 
         var resp = await client.PostAsJsonAsync("/api/tx/leveler-max-gain", new { gain });
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
-
-        var call = Assert.Single(_factory.TestEngine.LevelerMaxGainCalls);
-        Assert.Equal(gain, call, precision: 6);
+        Assert.Equal(gain, radio.Snapshot().LevelerMaxGainDb, precision: 6);
     }
 
     [Theory]
     [InlineData(-0.1)]
     [InlineData(15.1)]
-    public async Task PostOutOfRange_Returns400_AndDoesNotCallEngine(double gain)
+    public async Task PostOutOfRange_Returns400_AndDoesNotMutateState(double gain)
     {
-        _factory.TestEngine.LevelerMaxGainCalls.Clear();
+        using var scope = _factory.Services.CreateScope();
+        var radio = scope.ServiceProvider.GetRequiredService<RadioService>();
+        double before = radio.Snapshot().LevelerMaxGainDb;
         using var client = _factory.CreateClient();
 
         var resp = await client.PostAsJsonAsync("/api/tx/leveler-max-gain", new { gain });
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
-        Assert.Empty(_factory.TestEngine.LevelerMaxGainCalls);
+        Assert.Equal(before, radio.Snapshot().LevelerMaxGainDb, precision: 6);
     }
 
     [Fact]
-    public async Task PostNaN_Returns400_AndDoesNotCallEngine()
+    public async Task PostNaN_Returns400_AndDoesNotMutateState()
     {
         // System.Text.Json refuses to serialize NaN via PostAsJsonAsync, so
         // simulate a rogue client sending the JavaScript literal `NaN` by
@@ -111,15 +115,18 @@ public class LevelerMaxGainEndpointTests : IClassFixture<LevelerMaxGainEndpointT
         // (double.IsNaN(req.Gain)) is defensive belt-and-braces against a
         // deserializer that later enables AllowNamedFloatingPointLiterals —
         // the test pins the rejection shape in place now.
-        _factory.TestEngine.LevelerMaxGainCalls.Clear();
+        using var scope = _factory.Services.CreateScope();
+        var radio = scope.ServiceProvider.GetRequiredService<RadioService>();
+        double before = radio.Snapshot().LevelerMaxGainDb;
         using var client = _factory.CreateClient();
         using var content = new StringContent(
             "{\"gain\":NaN}", Encoding.UTF8, "application/json");
 
         var resp = await client.PostAsync("/api/tx/leveler-max-gain", content);
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
-        Assert.Empty(_factory.TestEngine.LevelerMaxGainCalls);
+        Assert.Equal(before, radio.Snapshot().LevelerMaxGainDb, precision: 6);
     }
+
 
     public sealed class Factory : WebApplicationFactory<Program>
     {

--- a/tests/Zeus.Server.Tests/MeterDisplaySettingsStoreTests.cs
+++ b/tests/Zeus.Server.Tests/MeterDisplaySettingsStoreTests.cs
@@ -94,4 +94,84 @@ public class MeterDisplaySettingsStoreTests : IDisposable
         store.SetSMeterOffsetDb(-2.0);
         Assert.Equal(2, fired);
     }
+
+    // ---- MaxDisplayedWatts knob (GitHub #426 follow-up) ----
+
+    [Fact]
+    public void Empty_Store_Returns_Zero_MaxDisplayedWatts_Meaning_NoOverride()
+    {
+        using var store = new MeterDisplaySettingsStore(
+            NullLogger<MeterDisplaySettingsStore>.Instance, _dbPath);
+        // 0 = "no override, fall back to the radio's rated MaxWatts".
+        Assert.Equal(0.0, store.Get().MaxDisplayedWatts);
+    }
+
+    [Theory]
+    [InlineData(1.0)]      // lower bound
+    [InlineData(25.0)]     // common HL2-on-100W-bracket use case
+    [InlineData(50.0)]
+    [InlineData(1000.0)]   // upper bound
+    public void SetMaxDisplayedWatts_In_Range_Round_Trips(double w)
+    {
+        using var store = new MeterDisplaySettingsStore(
+            NullLogger<MeterDisplaySettingsStore>.Instance, _dbPath);
+        store.SetMaxDisplayedWatts(w);
+        Assert.Equal(w, store.Get().MaxDisplayedWatts, precision: 6);
+    }
+
+    [Theory]
+    [InlineData(0.0, 0.0)]        // 0 stays 0 (no override)
+    [InlineData(-5.0, 0.0)]       // negative is "clear the override"
+    [InlineData(0.5, 1.0)]        // sub-min positive clamps up to 1
+    [InlineData(5000.0, 1000.0)]  // huge value clamps to ceiling
+    public void SetMaxDisplayedWatts_Out_Of_Range_Clamps(double input, double expected)
+    {
+        using var store = new MeterDisplaySettingsStore(
+            NullLogger<MeterDisplaySettingsStore>.Instance, _dbPath);
+        store.SetMaxDisplayedWatts(input);
+        Assert.Equal(expected, store.Get().MaxDisplayedWatts, precision: 6);
+    }
+
+    [Fact]
+    public void MaxDisplayedWatts_Non_Finite_Resets_To_Default()
+    {
+        using var store = new MeterDisplaySettingsStore(
+            NullLogger<MeterDisplaySettingsStore>.Instance, _dbPath);
+        store.SetMaxDisplayedWatts(double.NaN);
+        Assert.Equal(0.0, store.Get().MaxDisplayedWatts);
+        store.SetMaxDisplayedWatts(double.PositiveInfinity);
+        Assert.Equal(0.0, store.Get().MaxDisplayedWatts);
+    }
+
+    [Fact]
+    public void MaxDisplayedWatts_Persists_Across_Instances()
+    {
+        using (var s1 = new MeterDisplaySettingsStore(
+                   NullLogger<MeterDisplaySettingsStore>.Instance, _dbPath))
+        {
+            s1.SetMaxDisplayedWatts(25.0);
+        }
+        using var s2 = new MeterDisplaySettingsStore(
+            NullLogger<MeterDisplaySettingsStore>.Instance, _dbPath);
+        Assert.Equal(25.0, s2.Get().MaxDisplayedWatts, precision: 6);
+    }
+
+    [Fact]
+    public void Two_Knobs_Are_Independent()
+    {
+        // Persisting one knob must not stomp the other.
+        using var store = new MeterDisplaySettingsStore(
+            NullLogger<MeterDisplaySettingsStore>.Instance, _dbPath);
+        store.SetSMeterOffsetDb(-4.0);
+        store.SetMaxDisplayedWatts(50.0);
+        var dto = store.Get();
+        Assert.Equal(-4.0, dto.SMeterOffsetDb, precision: 6);
+        Assert.Equal(50.0, dto.MaxDisplayedWatts, precision: 6);
+
+        // Update one, verify the other survives.
+        store.SetSMeterOffsetDb(7.5);
+        dto = store.Get();
+        Assert.Equal(7.5, dto.SMeterOffsetDb, precision: 6);
+        Assert.Equal(50.0, dto.MaxDisplayedWatts, precision: 6);
+    }
 }

--- a/tests/Zeus.Server.Tests/MeterDisplaySettingsStoreTests.cs
+++ b/tests/Zeus.Server.Tests/MeterDisplaySettingsStoreTests.cs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+// Round-trip the display-side meter calibration knobs (GitHub #426).
+// Tests use a per-test tmp DB path so the production zeus-prefs.db isn't
+// mutated.
+public class MeterDisplaySettingsStoreTests : IDisposable
+{
+    private readonly string _dbPath;
+
+    public MeterDisplaySettingsStoreTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"zeus-prefs-meterdisp-{Guid.NewGuid():N}.db");
+    }
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { /* test-only cleanup */ }
+    }
+
+    [Fact]
+    public void Empty_Store_Returns_Default_Zero_Offset()
+    {
+        using var store = new MeterDisplaySettingsStore(
+            NullLogger<MeterDisplaySettingsStore>.Instance, _dbPath);
+        Assert.Equal(0.0, store.Get().SMeterOffsetDb);
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(-7.5)]
+    [InlineData(12.0)]
+    [InlineData(20.0)]   // upper bound
+    [InlineData(-20.0)]  // lower bound
+    public void Set_In_Range_Round_Trips(double dB)
+    {
+        using var store = new MeterDisplaySettingsStore(
+            NullLogger<MeterDisplaySettingsStore>.Instance, _dbPath);
+        store.SetSMeterOffsetDb(dB);
+        Assert.Equal(dB, store.Get().SMeterOffsetDb, precision: 6);
+    }
+
+    [Theory]
+    [InlineData(50.0, 20.0)]
+    [InlineData(-100.0, -20.0)]
+    public void Set_Out_Of_Range_Clamps(double input, double expected)
+    {
+        using var store = new MeterDisplaySettingsStore(
+            NullLogger<MeterDisplaySettingsStore>.Instance, _dbPath);
+        store.SetSMeterOffsetDb(input);
+        Assert.Equal(expected, store.Get().SMeterOffsetDb, precision: 6);
+    }
+
+    [Fact]
+    public void Non_Finite_Resets_To_Default()
+    {
+        using var store = new MeterDisplaySettingsStore(
+            NullLogger<MeterDisplaySettingsStore>.Instance, _dbPath);
+        store.SetSMeterOffsetDb(double.NaN);
+        Assert.Equal(0.0, store.Get().SMeterOffsetDb);
+        store.SetSMeterOffsetDb(double.PositiveInfinity);
+        Assert.Equal(0.0, store.Get().SMeterOffsetDb);
+    }
+
+    [Fact]
+    public void Persists_Across_Instances()
+    {
+        using (var s1 = new MeterDisplaySettingsStore(
+                   NullLogger<MeterDisplaySettingsStore>.Instance, _dbPath))
+        {
+            s1.SetSMeterOffsetDb(-3.5);
+        }
+        using var s2 = new MeterDisplaySettingsStore(
+            NullLogger<MeterDisplaySettingsStore>.Instance, _dbPath);
+        Assert.Equal(-3.5, s2.Get().SMeterOffsetDb, precision: 6);
+    }
+
+    [Fact]
+    public void Changed_Fires_On_Set()
+    {
+        using var store = new MeterDisplaySettingsStore(
+            NullLogger<MeterDisplaySettingsStore>.Instance, _dbPath);
+        int fired = 0;
+        store.Changed += () => fired++;
+        store.SetSMeterOffsetDb(5.0);
+        Assert.Equal(1, fired);
+        store.SetSMeterOffsetDb(-2.0);
+        Assert.Equal(2, fired);
+    }
+}

--- a/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
@@ -58,14 +58,16 @@ namespace Zeus.Server.Tests;
 
 /// <summary>
 /// End-to-end endpoint test for <c>POST /api/mic-gain</c>: drives the real
-/// endpoint via <see cref="WebApplicationFactory{TEntryPoint}"/>, asserting
-/// that a request body of <c>{db}</c> reaches the DspPipelineService's
-/// current engine as <c>SetTxPanelGain(10^(db/20))</c>.
+/// endpoint via <see cref="WebApplicationFactory{TEntryPoint}"/> and asserts
+/// that <c>{db}</c> ends up in <see cref="StateDto.MicGainDb"/>, clamped to
+/// the endpoint's <c>[-40, +10]</c> range.
 ///
-/// PRD FR-3 (<c>docs/prd/12-tx-feature.md</c>) requires db → linear gain via
-/// <c>10^(db/20)</c>; this test exercises that path through Program.cs so
-/// the Math.Clamp + Math.Pow inlined on the handler can't drift from the
-/// spec without a failing test.
+/// PRD FR-3 (<c>docs/prd/12-tx-feature.md</c>) still requires db → linear
+/// gain via <c>10^(db/20)</c>; that conversion now lives at the engine seam
+/// in <see cref="DspPipelineService"/> so the persisted form stays in
+/// operator-friendly dB. The seam's dB → linear math is exercised inline in
+/// <see cref="DspPipelineService"/>'s broadcast path (no engine open in this
+/// test factory, so the seam stays intentionally dormant here).
 /// </summary>
 public class MicGainEndpointTests : IClassFixture<MicGainEndpointTests.Factory>
 {
@@ -73,62 +75,59 @@ public class MicGainEndpointTests : IClassFixture<MicGainEndpointTests.Factory>
     public MicGainEndpointTests(Factory factory) => _factory = factory;
 
     [Fact]
-    public async Task Post0db_SetsLinearGainOf1()
+    public async Task Post0db_PersistsZeroOnState()
     {
-        _factory.TestEngine.GainCalls.Clear();
+        using var scope = _factory.Services.CreateScope();
+        var radio = scope.ServiceProvider.GetRequiredService<RadioService>();
         using var client = _factory.CreateClient();
 
         var resp = await client.PostAsJsonAsync("/api/mic-gain", new { db = 0 });
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
-
-        var call = Assert.Single(_factory.TestEngine.GainCalls);
-        Assert.Equal(1.0, call, precision: 6);
+        Assert.Equal(0, radio.Snapshot().MicGainDb);
     }
 
     [Fact]
-    public async Task PostPlus10db_SetsLinearGainOfRoughly3point16()
+    public async Task PostPlus10db_PersistsPlus10()
     {
-        _factory.TestEngine.GainCalls.Clear();
+        using var scope = _factory.Services.CreateScope();
+        var radio = scope.ServiceProvider.GetRequiredService<RadioService>();
         using var client = _factory.CreateClient();
 
         var resp = await client.PostAsJsonAsync("/api/mic-gain", new { db = 10 });
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
-
-        var call = Assert.Single(_factory.TestEngine.GainCalls);
-        Assert.Equal(Math.Pow(10.0, 0.5), call, precision: 6);
+        Assert.Equal(10, radio.Snapshot().MicGainDb);
     }
 
     [Fact]
-    public async Task PostMinus20db_AttenuatesByLinearGainOfRoughly0point1()
+    public async Task PostMinus20db_PersistsMinus20()
     {
-        _factory.TestEngine.GainCalls.Clear();
+        // -20 dB lands in the negative half (attenuation) — verifies the range
+        // doesn't get clamped to 0 / unity by an off-by-one in the endpoint.
+        using var scope = _factory.Services.CreateScope();
+        var radio = scope.ServiceProvider.GetRequiredService<RadioService>();
         using var client = _factory.CreateClient();
 
-        // -20 dB → linear gain 0.1 — verifies the negative half of the range
-        // actually attenuates, not just clamps to 0 / unity.
         var resp = await client.PostAsJsonAsync("/api/mic-gain", new { db = -20 });
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
-
-        var call = Assert.Single(_factory.TestEngine.GainCalls);
-        Assert.Equal(0.1, call, precision: 6);
+        Assert.Equal(-20, radio.Snapshot().MicGainDb);
     }
 
     [Fact]
     public async Task PostOutOfRange_ClampsToMinus40AndPlus10()
     {
-        _factory.TestEngine.GainCalls.Clear();
+        using var scope = _factory.Services.CreateScope();
+        var radio = scope.ServiceProvider.GetRequiredService<RadioService>();
         using var client = _factory.CreateClient();
 
-        // db=-100 clamps to -40 → gain 10^(-2) = 0.01
+        // db=-100 clamps to -40.
         Assert.Equal(HttpStatusCode.OK,
             (await client.PostAsJsonAsync("/api/mic-gain", new { db = -100 })).StatusCode);
-        // db=50 clamps to +10 → gain 10^(0.5) ≈ 3.1623
+        Assert.Equal(-40, radio.Snapshot().MicGainDb);
+
+        // db=50 clamps to +10.
         Assert.Equal(HttpStatusCode.OK,
             (await client.PostAsJsonAsync("/api/mic-gain", new { db = 50 })).StatusCode);
-
-        Assert.Collection(_factory.TestEngine.GainCalls,
-            v => Assert.Equal(0.01, v, precision: 6),
-            v => Assert.Equal(Math.Pow(10.0, 0.5), v, precision: 6));
+        Assert.Equal(10, radio.Snapshot().MicGainDb);
     }
 
     public sealed class Factory : WebApplicationFactory<Program>

--- a/tests/Zeus.Server.Tests/MorseEncoderTests.cs
+++ b/tests/Zeus.Server.Tests/MorseEncoderTests.cs
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using Xunit;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class MorseEncoderTests
+{
+    // PARIS-method: 20 wpm → 60 ms per dit unit. Picked because the
+    // resulting timings stay whole-millisecond (1200/20 = 60) so the
+    // asserts read like a Morse-code primer.
+    private const int Wpm20Unit = 60;
+
+    [Theory]
+    [InlineData(20, 60)]
+    [InlineData(12, 100)]
+    [InlineData(40, 30)]
+    [InlineData(5, 240)]
+    public void DitMs_FollowsPARIS(int wpm, int expected)
+    {
+        Assert.Equal(expected, MorseEncoder.DitMs(wpm));
+    }
+
+    [Fact]
+    public void Encode_EmptyString_NoSymbols()
+    {
+        Assert.Empty(MorseEncoder.Encode(string.Empty, 20));
+    }
+
+    [Fact]
+    public void Encode_SingleE_OneDit()
+    {
+        // 'E' is a single dit. No surrounding gaps — leading
+        // inter-character gap is suppressed at the buffer start.
+        var sym = MorseEncoder.Encode("E", 20).ToList();
+        Assert.Single(sym);
+        Assert.True(sym[0].KeyDown);
+        Assert.Equal(Wpm20Unit, sym[0].DurationMs);
+    }
+
+    [Fact]
+    public void Encode_SingleT_OneDah()
+    {
+        // 'T' is a single dah (3 units on).
+        var sym = MorseEncoder.Encode("T", 20).ToList();
+        Assert.Single(sym);
+        Assert.True(sym[0].KeyDown);
+        Assert.Equal(Wpm20Unit * 3, sym[0].DurationMs);
+    }
+
+    [Fact]
+    public void Encode_LetterA_DitGapDah()
+    {
+        // 'A' = .- → dit, intra-element gap, dah.
+        var sym = MorseEncoder.Encode("A", 20).ToList();
+        Assert.Equal(3, sym.Count);
+        Assert.Equal(new CwSymbol(true, Wpm20Unit),     sym[0]); // dit
+        Assert.Equal(new CwSymbol(false, Wpm20Unit),    sym[1]); // intra gap
+        Assert.Equal(new CwSymbol(true, Wpm20Unit * 3), sym[2]); // dah
+    }
+
+    [Fact]
+    public void Encode_LowercaseFoldsToUpper()
+    {
+        Assert.Equal(MorseEncoder.Encode("A", 20), MorseEncoder.Encode("a", 20));
+        Assert.Equal(MorseEncoder.Encode("CQ", 20), MorseEncoder.Encode("cq", 20));
+    }
+
+    [Fact]
+    public void Encode_TwoLetters_HasInterCharGap()
+    {
+        // "EE" = dit, inter-char gap (3 units), dit.
+        var sym = MorseEncoder.Encode("EE", 20).ToList();
+        Assert.Equal(3, sym.Count);
+        Assert.Equal(new CwSymbol(true, Wpm20Unit),     sym[0]);
+        Assert.Equal(new CwSymbol(false, Wpm20Unit * 3), sym[1]);
+        Assert.Equal(new CwSymbol(true, Wpm20Unit),     sym[2]);
+    }
+
+    [Fact]
+    public void Encode_SpaceBetweenWords_EmitsSevenUnitGap()
+    {
+        // "E E" = dit, word gap (7 units, not 3+7), dit. The word gap
+        // absorbs the would-be inter-character gap, so we should see
+        // exactly one off-period between the two dits at 7 units total.
+        var sym = MorseEncoder.Encode("E E", 20).ToList();
+        Assert.Equal(3, sym.Count);
+        Assert.Equal(new CwSymbol(true, Wpm20Unit),     sym[0]);
+        Assert.Equal(new CwSymbol(false, Wpm20Unit * 7), sym[1]);
+        Assert.Equal(new CwSymbol(true, Wpm20Unit),     sym[2]);
+    }
+
+    [Fact]
+    public void Encode_LeadingSpaces_AreElided()
+    {
+        // Leading spaces shouldn't burn 7 units of silence before the
+        // first dit. Trailing spaces are NOT trimmed — they're harmless
+        // (silence after the last element) and dropping them would
+        // require a buffered emit. Documented here so the next reader
+        // knows it's deliberate, not a bug.
+        var sym = MorseEncoder.Encode("   E", 20).ToList();
+        Assert.Single(sym);
+        Assert.Equal(new CwSymbol(true, Wpm20Unit), sym[0]);
+    }
+
+    [Fact]
+    public void Encode_TrailingSpaces_EmitOneWordGap()
+    {
+        // Documents the deliberate "trailing word gap is not trimmed"
+        // behaviour. Any number of trailing whitespace chars collapse
+        // to a single 7-unit gap (the same word-gap collapsing rule
+        // that runs for inter-word spacing).
+        var sym = MorseEncoder.Encode("E    ", 20).ToList();
+        Assert.Equal(2, sym.Count);
+        Assert.Equal(new CwSymbol(true, Wpm20Unit), sym[0]);
+        Assert.Equal(new CwSymbol(false, Wpm20Unit * 7), sym[1]);
+    }
+
+    [Fact]
+    public void Encode_MultipleConsecutiveSpaces_CollapseToOneWordGap()
+    {
+        // Two spaces in a row should still emit only one 7-unit gap, not
+        // two. Same principle as Thetis: a word boundary is a word
+        // boundary regardless of how many spaces the operator typed.
+        var sym = MorseEncoder.Encode("E    E", 20).ToList();
+        var gaps = sym.Where(s => !s.KeyDown).ToList();
+        Assert.Single(gaps);
+        Assert.Equal(Wpm20Unit * 7, gaps[0].DurationMs);
+    }
+
+    [Theory]
+    [InlineData('\t')]
+    [InlineData('\n')]
+    [InlineData('\r')]
+    public void Encode_WhitespaceCharactersCountAsSpace(char ws)
+    {
+        var sym = MorseEncoder.Encode($"E{ws}E", 20).ToList();
+        Assert.Equal(3, sym.Count);
+        Assert.Equal(new CwSymbol(false, Wpm20Unit * 7), sym[1]);
+    }
+
+    [Fact]
+    public void Encode_UnknownCharsAreSilentlySkipped()
+    {
+        // '~' isn't in the table — it should disappear entirely, not
+        // synthesize a word gap or a "?" prosign. (Thetis treats unknown
+        // entries the same way: silently skip when morsedef.txt has no
+        // pattern for a slot.)
+        var direct = MorseEncoder.Encode("EE", 20).ToList();
+        var withTilde = MorseEncoder.Encode("E~E", 20).ToList();
+        Assert.Equal(direct, withTilde);
+    }
+
+    [Fact]
+    public void Encode_LoopAndLongDashMacros_AreSkippedAsUnknown()
+    {
+        // Thetis's `"` (loop), `#` (long-dash), `$` (long-space), `&`
+        // (digit macro), `_` (reserved) are deliberately absent from
+        // our table — they should behave like any other unmapped char
+        // and skip cleanly without producing weird timings.
+        foreach (char macro in new[] { '"', '#', '$', '&', '_' })
+        {
+            var sym = MorseEncoder.Encode($"E{macro}E", 20).ToList();
+            Assert.Equal(MorseEncoder.Encode("EE", 20), sym);
+        }
+    }
+
+    [Fact]
+    public void Encode_CQDE_ProducesExpectedSequence()
+    {
+        // Real-world phrase: "CQ DE" at 20 wpm.
+        // C = -.-. ; Q = --.- ; (word gap 7u) ; D = -.. ; E = .
+        // Expected total elements (key-down + gap) easy to sanity-check.
+        var sym = MorseEncoder.Encode("CQ DE", 20).ToList();
+        var keyDownCount = sym.Count(s => s.KeyDown);
+        // C=4 + Q=4 + D=3 + E=1 = 12 key-down events.
+        Assert.Equal(12, keyDownCount);
+
+        // Total transmission time at 20 wpm:
+        //   C(-.-.) = 3+1+1+1+3+1+1 = 11 units
+        //   inter-char = 3
+        //   Q(--.-) = 3+1+3+1+1+1+3 = 13 units
+        //   word gap = 7
+        //   D(-..)  = 3+1+1+1+1 = 7 units
+        //   inter-char = 3
+        //   E(.)    = 1 unit
+        // Total = 11+3+13+7+7+3+1 = 45 units = 45 * 60 = 2700 ms.
+        long totalMs = sym.Sum(s => (long)s.DurationMs);
+        Assert.Equal(45 * Wpm20Unit, totalMs);
+    }
+
+    [Fact]
+    public void Encode_LeadsAlternatesKeyDownAndKeyUp()
+    {
+        // A well-formed CW stream must never have two consecutive
+        // key-down or key-up symbols — that would mean we forgot a gap
+        // or fused two pulses. Spot-check on a substantial sample.
+        var sym = MorseEncoder.Encode("CQ CQ DE EI6LF EI6LF K", 20).ToList();
+        Assert.NotEmpty(sym);
+        for (int i = 1; i < sym.Count; i++)
+        {
+            Assert.NotEqual(sym[i - 1].KeyDown, sym[i].KeyDown);
+        }
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Encode_RejectsNonPositiveWpm(int wpm)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => MorseEncoder.Encode("E", wpm).ToList());
+    }
+
+    [Fact]
+    public void Encode_NullText_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => MorseEncoder.Encode(null!, 20).ToList());
+    }
+}

--- a/tests/Zeus.Server.Tests/MoxSourceOwnershipTests.cs
+++ b/tests/Zeus.Server.Tests/MoxSourceOwnershipTests.cs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// Ownership rules on TxService.TrySetMox(bool, MoxSource, …). The release
+// path must refuse to drop MOX on behalf of a foreign source, with two
+// exceptions: UI is a master override, and TryTripForAlert always wins.
+// Without these rules a TCI peer's `trx:false` could truncate a host-side
+// CW message, and a hardware-PTT falling edge could drop a UI-keyed TX.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class MoxSourceOwnershipTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-moxsrc-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+        try { if (File.Exists(_dbPath + ".pa")) File.Delete(_dbPath + ".pa"); } catch { }
+    }
+
+    private (RadioService radio, TxService tx) BuildConnectedRadioAndTx()
+    {
+        var loggerFactory = NullLoggerFactory.Instance;
+        var dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance, _dbPath);
+        var paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, _dbPath + ".pa");
+        var radio = new RadioService(loggerFactory, dspStore, paStore);
+        radio.MarkProtocol2Connected("127.0.0.1:1024", 48_000);
+        var hub = new StreamingHub(new NullLogger<StreamingHub>());
+        var pipeline = new DspPipelineService(radio, hub, Array.Empty<IRxAudioSink>(), loggerFactory);
+        var tx = new TxService(radio, pipeline, hub, NullBandPlanService.Instance, new NullLogger<TxService>());
+        return (radio, tx);
+    }
+
+    [Fact]
+    public void Hardware_CannotRelease_CwxOwnedMox()
+    {
+        var (_, tx) = BuildConnectedRadioAndTx();
+
+        Assert.True(tx.TrySetMox(true, MoxSource.Cwx, out _));
+        Assert.True(tx.IsMoxOn);
+        Assert.Equal(MoxSource.Cwx, tx.MoxOwner);
+
+        // External PTT falling edge — must NOT drop a CW-driven transmission.
+        bool ok = tx.TrySetMox(false, MoxSource.Hardware, out var err);
+
+        Assert.False(ok);
+        Assert.NotNull(err);
+        Assert.Contains("Cwx", err);
+        Assert.True(tx.IsMoxOn);
+        Assert.Equal(MoxSource.Cwx, tx.MoxOwner);
+    }
+
+    [Fact]
+    public void Cwx_CannotRelease_HardwareOwnedMox()
+    {
+        // Mirror of the above so the rule holds symmetrically — a stray
+        // /api/cw/abort while a hardware key is held shouldn't kill the
+        // operator's hand-keyed CW.
+        var (_, tx) = BuildConnectedRadioAndTx();
+
+        Assert.True(tx.TrySetMox(true, MoxSource.Hardware, out _));
+        Assert.Equal(MoxSource.Hardware, tx.MoxOwner);
+
+        bool ok = tx.TrySetMox(false, MoxSource.Cwx, out var err);
+
+        Assert.False(ok);
+        Assert.NotNull(err);
+        Assert.Contains("Hardware", err);
+        Assert.True(tx.IsMoxOn);
+    }
+
+    [Fact]
+    public void UI_AlwaysReleases_NoMatterWhoOwns()
+    {
+        // The operator's on-screen MOX button is the master override:
+        // pressing it must drop MOX no matter who claimed it.
+        foreach (var owner in new[] { MoxSource.Cwx, MoxSource.Hardware, MoxSource.Tci })
+        {
+            var (_, tx) = BuildConnectedRadioAndTx();
+
+            Assert.True(tx.TrySetMox(true, owner, out _));
+            Assert.Equal(owner, tx.MoxOwner);
+
+            bool ok = tx.TrySetMox(false, MoxSource.UI, out var err);
+
+            Assert.True(ok);
+            Assert.Null(err);
+            Assert.False(tx.IsMoxOn);
+            Assert.Null(tx.MoxOwner);
+        }
+    }
+
+    [Fact]
+    public void OwningSource_CanReleaseItsOwnMox()
+    {
+        var (_, tx) = BuildConnectedRadioAndTx();
+
+        Assert.True(tx.TrySetMox(true, MoxSource.Tci, out _));
+        Assert.Equal(MoxSource.Tci, tx.MoxOwner);
+
+        bool ok = tx.TrySetMox(false, MoxSource.Tci, out var err);
+
+        Assert.True(ok);
+        Assert.Null(err);
+        Assert.False(tx.IsMoxOn);
+    }
+
+    [Fact]
+    public void TripForAlert_AlwaysWins_RegardlessOfOwner()
+    {
+        // SWR / TX-timeout trips bypass the source rule completely — RF must
+        // cut even if the owning source isn't around to release voluntarily.
+        var (_, tx) = BuildConnectedRadioAndTx();
+
+        Assert.True(tx.TrySetMox(true, MoxSource.Cwx, out _));
+        Assert.True(tx.IsMoxOn);
+
+        tx.TryTripForAlert(AlertKind.SwrTrip, "test");
+
+        Assert.False(tx.IsMoxOn);
+        Assert.Null(tx.MoxOwner);
+    }
+
+    [Fact]
+    public void Owner_LatchesOnFirstClaim_RedundantKeyOnDoesNotReseat()
+    {
+        // First-claim semantics: if Cwx keys MOX and then UI also calls
+        // TrySetMox(true), ownership stays with Cwx. (UI hasn't actually
+        // changed state; the call is a no-op edge.) Without this, a UI poll
+        // that touches MOX while CW is running would convert the message's
+        // owner to UI and let foreign sources drop it.
+        var (_, tx) = BuildConnectedRadioAndTx();
+
+        Assert.True(tx.TrySetMox(true, MoxSource.Cwx, out _));
+        Assert.Equal(MoxSource.Cwx, tx.MoxOwner);
+
+        Assert.True(tx.TrySetMox(true, MoxSource.UI, out _));
+        Assert.Equal(MoxSource.Cwx, tx.MoxOwner);
+
+        // And a foreign drop is still rejected.
+        Assert.False(tx.TrySetMox(false, MoxSource.Tci, out _));
+        Assert.True(tx.IsMoxOn);
+    }
+
+    [Fact]
+    public void BackCompatOverload_DefaultsToUiSource()
+    {
+        // Callers that use the old 2-arg TrySetMox get MoxSource.UI behaviour
+        // implicitly. This keeps every existing test and call site working
+        // unchanged after the source-tag addition.
+        var (_, tx) = BuildConnectedRadioAndTx();
+
+        Assert.True(tx.TrySetMox(true, out _));
+        Assert.Equal(MoxSource.UI, tx.MoxOwner);
+
+        // Foreign drop still rejected (UI owns now).
+        Assert.False(tx.TrySetMox(false, MoxSource.Cwx, out _));
+        Assert.True(tx.IsMoxOn);
+
+        // UI can release its own MOX via the back-compat overload too.
+        Assert.True(tx.TrySetMox(false, out _));
+        Assert.False(tx.IsMoxOn);
+    }
+}

--- a/tests/Zeus.Server.Tests/NativeAudioSinkRegistrationTests.cs
+++ b/tests/Zeus.Server.Tests/NativeAudioSinkRegistrationTests.cs
@@ -34,10 +34,13 @@ public class NativeAudioSinkRegistrationTests
         var app = ZeusHost.Build(Array.Empty<string>(), opts);
 
         var sinks = app.Services.GetServices<IRxAudioSink>().ToArray();
-        Assert.Single(sinks);
-        // Server mode keeps the WS sink — bit-for-bit equivalent of the
-        // pre-seam direct hub broadcast.
-        Assert.Equal("WebSocketAudioSink", sinks[0].GetType().Name);
+        // Server mode keeps the WS sink (host-audio path) and additionally
+        // registers RadioCodecAudioSink so RX audio is also routed to the
+        // radio's on-board codec on Hermes / ANAN-class / OrionMkII boards
+        // (issue #426). HL2 short-circuits inside the codec sink.
+        Assert.Equal(2, sinks.Length);
+        Assert.Contains(sinks, s => s.GetType().Name == "WebSocketAudioSink");
+        Assert.Contains(sinks, s => s.GetType().Name == "RadioCodecAudioSink");
 
         // Native capture must never be registered in server mode.
         var hosted = app.Services.GetServices<IHostedService>().ToArray();
@@ -61,10 +64,12 @@ public class NativeAudioSinkRegistrationTests
         var app = ZeusHost.Build(Array.Empty<string>(), opts);
 
         var sinks = app.Services.GetServices<IRxAudioSink>().ToArray();
-        Assert.Single(sinks);
-        // Desktop mode swaps in the native sink so RX audio goes straight to
-        // the OS default output device (Phase 2b).
-        Assert.Equal("NativeAudioSink", sinks[0].GetType().Name);
+        // Desktop mode swaps the WS path for the native sink, plus the new
+        // radio-codec sink (#426). With ShareOverLan=false (default) the
+        // total is exactly two: native + codec.
+        Assert.Equal(2, sinks.Length);
+        Assert.Contains(sinks, s => s.GetType().Name == "NativeAudioSink");
+        Assert.Contains(sinks, s => s.GetType().Name == "RadioCodecAudioSink");
 
         // Same NativeAudioSink instance must also be wired as a hosted
         // service so its StartAsync opens the playback device.

--- a/tests/Zeus.Server.Tests/RadioServiceSetRadioLoTests.cs
+++ b/tests/Zeus.Server.Tests/RadioServiceSetRadioLoTests.cs
@@ -13,10 +13,12 @@ using Zeus.Server;
 namespace Zeus.Server.Tests;
 
 /// <summary>
-/// Unit-test the frozen-NCO invariants the panadapter pure-pan PRD
-/// (<c>docs/prd/panfall_behavior.md</c>) bakes into <see cref="RadioService"/>:
+/// Unit-test the tuning invariants in <see cref="RadioService"/> after the
+/// CTUN frozen-NCO model was reverted to classic "radio follows the dial":
 ///
-///   1. <c>SetVfo</c> only moves the dial; <c>RadioLoHz</c> is untouched.
+///   1. <c>SetVfo</c> retunes the radio — <c>RadioLoHz</c> tracks the dial's
+///      effective LO (== dial for SSB/AM/FM/DIG, dial ∓ pitch for CW) so RX
+///      and TX both land on the dial. (Was frozen under the old CTUN model.)
 ///   2. <c>SetRadioLo</c> only moves the hardware NCO; <c>VfoHz</c> is untouched.
 ///   3. Out-of-range inputs to <c>SetRadioLo</c> clamp into the legal HPSDR
 ///      tunable range [0, 60_000_000] Hz (matching <c>SetVfo</c>); the
@@ -82,16 +84,22 @@ public sealed class RadioServiceSetRadioLoTests : IDisposable
     }
 
     [Fact]
-    public void SetVfo_DoesNotMoveRadioLoHz()
+    public void SetVfo_MovesRadioLoToTrackDial()
     {
         using var radio = BuildRadio();
-        var seed = radio.SetRadioLo(28_400_000);
-        long loBefore = seed.RadioLoHz;
+        radio.SetRadioLo(28_400_000);
 
         var after = radio.SetVfo(28_410_500);
 
-        Assert.Equal(loBefore, after.RadioLoHz);
+        // Classic "radio follows the dial" (CTUN frozen-NCO reverted): SetVfo
+        // now retunes the LO to the dial's effective LO so RX and TX track the
+        // dial, instead of leaving it frozen at the old centre (28_400_000).
         Assert.Equal(28_410_500, after.VfoHz);
+        Assert.NotEqual(28_400_000, after.RadioLoHz);
+        // RadioLoHz lands on the dial (± CW pitch, which is well under 2 kHz),
+        // mode-agnostic so the test doesn't depend on the default RxMode.
+        Assert.True(Math.Abs(after.RadioLoHz - 28_410_500) <= 2_000,
+            $"RadioLoHz {after.RadioLoHz} should track dial 28410500 within CW pitch");
     }
 
     [Fact]

--- a/tests/Zeus.Server.Tests/RadioServiceSetRadioLoTests.cs
+++ b/tests/Zeus.Server.Tests/RadioServiceSetRadioLoTests.cs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Unit-test the frozen-NCO invariants the panadapter pure-pan PRD
+/// (<c>docs/prd/panfall_behavior.md</c>) bakes into <see cref="RadioService"/>:
+///
+///   1. <c>SetVfo</c> only moves the dial; <c>RadioLoHz</c> is untouched.
+///   2. <c>SetRadioLo</c> only moves the hardware NCO; <c>VfoHz</c> is untouched.
+///   3. Out-of-range inputs to <c>SetRadioLo</c> clamp into the legal HPSDR
+///      tunable range [0, 60_000_000] Hz (matching <c>SetVfo</c>); the
+///      endpoint layer rejects with 400, but the service layer clamps for
+///      safety so an internal caller can't park the NCO at a nonsense Hz.
+///
+/// We exercise the service directly rather than via the HTTP host — every
+/// behaviour worth pinning lives in <see cref="RadioService"/> and the
+/// service-level tests stay fast.
+/// </summary>
+public sealed class RadioServiceSetRadioLoTests : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly PaSettingsStore _paStore;
+    private readonly DspSettingsStore _dspStore;
+
+    public RadioServiceSetRadioLoTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"zeus-prefs-lo-{Guid.NewGuid():N}.db");
+        _paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, _dbPath + ".pa");
+        _dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance, _dbPath + ".dsp");
+    }
+
+    public void Dispose()
+    {
+        _paStore.Dispose();
+        _dspStore.Dispose();
+        foreach (var suffix in new[] { "", ".pa", ".dsp" })
+        {
+            try { if (File.Exists(_dbPath + suffix)) File.Delete(_dbPath + suffix); } catch { }
+        }
+    }
+
+    private RadioService BuildRadio() =>
+        new RadioService(NullLoggerFactory.Instance, _dspStore, _paStore);
+
+    [Fact]
+    public void SetRadioLo_InRange_UpdatesOnlyRadioLoHz()
+    {
+        using var radio = BuildRadio();
+        // Park the dial somewhere far from the LO so the invariant is visible.
+        var initial = radio.SetVfo(14_074_000);
+        long dialBefore = initial.VfoHz;
+
+        var after = radio.SetRadioLo(14_100_000);
+
+        Assert.Equal(14_100_000, after.RadioLoHz);
+        Assert.Equal(dialBefore, after.VfoHz);
+    }
+
+    [Fact]
+    public void SetRadioLo_DoesNotMoveVfo_AcrossMultipleCalls()
+    {
+        using var radio = BuildRadio();
+        var dial = radio.SetVfo(7_074_000).VfoHz;
+
+        radio.SetRadioLo(7_000_000);
+        radio.SetRadioLo(7_200_000);
+        var snap = radio.SetRadioLo(7_300_000);
+
+        Assert.Equal(dial, snap.VfoHz);
+        Assert.Equal(7_300_000, snap.RadioLoHz);
+    }
+
+    [Fact]
+    public void SetVfo_DoesNotMoveRadioLoHz()
+    {
+        using var radio = BuildRadio();
+        var seed = radio.SetRadioLo(28_400_000);
+        long loBefore = seed.RadioLoHz;
+
+        var after = radio.SetVfo(28_410_500);
+
+        Assert.Equal(loBefore, after.RadioLoHz);
+        Assert.Equal(28_410_500, after.VfoHz);
+    }
+
+    [Fact]
+    public void SetRadioLo_NegativeInput_ClampsToZero()
+    {
+        using var radio = BuildRadio();
+        var snap = radio.SetRadioLo(-1_000);
+        Assert.Equal(0, snap.RadioLoHz);
+    }
+
+    [Fact]
+    public void SetRadioLo_AboveMax_ClampsTo60MHz()
+    {
+        using var radio = BuildRadio();
+        var snap = radio.SetRadioLo(75_000_000);
+        Assert.Equal(60_000_000, snap.RadioLoHz);
+    }
+}

--- a/tests/Zeus.Server.Tests/RadioStateStoreTests.cs
+++ b/tests/Zeus.Server.Tests/RadioStateStoreTests.cs
@@ -60,6 +60,8 @@ public class RadioStateStoreTests : IDisposable
                 AttenDb = 12,
                 AutoAgcEnabled = true,
                 RxAfGainDb = -6.5,
+                MicGainDb = -7,
+                LevelerMaxGainDb = 12.5,
                 ZoomLevel = 4,
                 SsbFilterLoAbs = 300, SsbFilterHiAbs = 2400,
                 CwFilterLoAbs = 400, CwFilterHiAbs = 800,
@@ -85,6 +87,8 @@ public class RadioStateStoreTests : IDisposable
         Assert.Equal(12, got.AttenDb);
         Assert.True(got.AutoAgcEnabled);
         Assert.Equal(-6.5, got.RxAfGainDb);
+        Assert.Equal(-7, got.MicGainDb);
+        Assert.Equal(12.5, got.LevelerMaxGainDb);
         Assert.Equal(4, got.ZoomLevel);
         Assert.Equal(300, got.SsbFilterLoAbs);
         Assert.Equal(2400, got.SsbFilterHiAbs);
@@ -105,6 +109,18 @@ public class RadioStateStoreTests : IDisposable
         var entry = new RadioStateEntry();
         Assert.Equal(0, entry.DrivePct);
         Assert.Equal(10, entry.TunePct);
+    }
+
+    // Older rows written before the TX mic-gain / Leveler-max-gain fields
+    // existed must hydrate with the engine's open-time defaults so a build
+    // upgrade doesn't surprise the operator with a 0 dB Leveler ceiling (no
+    // headroom at all) on the first key after restart.
+    [Fact]
+    public void MicAndLevelerMaxGain_HaveCorrectDefaults_OnNewEntry()
+    {
+        var entry = new RadioStateEntry();
+        Assert.Equal(0, entry.MicGainDb);
+        Assert.Equal(8.0, entry.LevelerMaxGainDb);
     }
 
     // Snapshot is a single global row — saving twice should update, not insert.

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -400,7 +400,8 @@ export default function App() {
     setCallsign('');
   }, [setCallsign]);
 
-  const [wpm, setWpm] = useState(22);
+  // CW WPM is now persisted server-side via /api/cw/settings and read
+  // through useCwStore — no longer threaded through the workspace context.
   const nrState = useConnectionStore((s) => s.nr);
   const dspActive =
     nrState.nrMode !== 'Off' ||
@@ -628,8 +629,6 @@ export default function App() {
     handleLogQso,
     handleClearQrz,
     dspActive,
-    wpm,
-    setWpm,
     logbookTitle,
     logbookActions,
   }), [
@@ -641,7 +640,7 @@ export default function App() {
     beamOverrideDeg, beamInputStr, rotLiveAz, sp, lp, dist,
     // heroTitle and logbookActions are ReactNodes (new objects each render);
     // their underlying primitive deps are already above, so omit them here.
-    dspActive, wpm, logbookTitle,
+    dspActive, logbookTitle,
     handleLogQso, handleClearQrz, runQrzLookup,
   ]);
 

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -77,7 +77,7 @@ import { getServerBaseUrl, isCapacitorRuntime } from './serverUrl';
 import { getAudioClient } from './audio/audio-client';
 import { setAudioHostMode } from './audio/host-mode';
 import { useMicUplink } from './audio/use-mic-uplink';
-import { fetchState, setCtun } from './api/client';
+import { fetchState } from './api/client';
 import { useConnectionStore } from './state/connection-store';
 import { useRadioStore } from './state/radio-store';
 import { useQrzStore } from './state/qrz-store';
@@ -114,8 +114,6 @@ export default function App() {
   const vfoHz = useConnectionStore((s) => s.vfoHz);
   const mode = useConnectionStore((s) => s.mode);
   const preampOn = useConnectionStore((s) => s.preampOn);
-  const ctunEnabled = useConnectionStore((s) => s.ctunEnabled);
-  const applyState = useConnectionStore((s) => s.applyState);
   const moxOn = useTxStore((s) => s.moxOn);
   const tunOn = useTxStore((s) => s.tunOn);
   const endpoint = useConnectionStore((s) => s.endpoint);
@@ -772,25 +770,6 @@ export default function App() {
         <button type="button" className="btn ghost hide-mobile">SPLIT</button>
         <button type="button" className="btn ghost hide-mobile">RIT</button>
         <button type="button" className="btn ghost hide-mobile">SAVE MEM</button>
-        <button
-          type="button"
-          className={`btn ghost hide-mobile ${ctunEnabled ? 'active' : ''}`}
-          aria-pressed={ctunEnabled}
-          title={
-            ctunEnabled
-              ? 'CTUN ON — panadapter clicks move the dial; radio NCO stays put'
-              : 'CTUN OFF — panadapter clicks retune the radio. Click to enable.'
-          }
-          onClick={() => {
-            setCtun(!ctunEnabled)
-              .then(applyState)
-              .catch(() => {
-                /* next poll reconciles */
-              });
-          }}
-        >
-          CTUN
-        </button>
         <div className="spacer" style={{ flex: 1 }} />
         <PaTempChip />
         <div className="chip hide-mobile">

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -176,6 +176,12 @@ export type RadioStateDto = {
   autoAgcEnabled: boolean;
   agcOffsetDb: number;
   rxAfGainDb: number;
+  // TX mic gain in dB ([-40, +10]) and TX Leveler max-gain ceiling in dB
+  // ([0, 15]). Server is authoritative; hydrated into tx-store on every fresh
+  // RadioStateDto. Previously localStorage-only and reverted on every restart
+  // when the desktop webview wiped its storage.
+  micGainDb: number;
+  levelerMaxGainDb: number;
   attenDb: number;
   autoAttEnabled: boolean;
   attOffsetDb: number;
@@ -436,6 +442,12 @@ export function normalizeState(raw: unknown): RadioStateDto {
     autoAgcEnabled: typeof r.autoAgcEnabled === 'boolean' ? r.autoAgcEnabled : false,
     agcOffsetDb: typeof r.agcOffsetDb === 'number' ? r.agcOffsetDb : 0,
     rxAfGainDb: typeof r.rxAfGainDb === 'number' ? r.rxAfGainDb : 0,
+    // 0 dB = unity panel-gain (WDSP TXA open-time default).
+    micGainDb: typeof r.micGainDb === 'number' ? r.micGainDb : 0,
+    // 8 dB matches WdspDspEngine.DefaultLevelerMaxGainDb so older servers
+    // without the field hydrate to the same ceiling the engine opens with.
+    levelerMaxGainDb:
+      typeof r.levelerMaxGainDb === 'number' ? r.levelerMaxGainDb : 8,
     // Attenuator value in dB, range 0..31 (HpsdrAtten.MaxDb). 4-button UI
     // sends 0/10/20/30 today; #23 will unlock the full fine-grained range.
     attenDb: typeof r.attenDb === 'number' ? r.attenDb : 0,

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -219,12 +219,11 @@ export type RadioStateDto = {
   // after normalisation; falls back to CFC_CONFIG_DEFAULT when the server
   // omits it (legacy state frames).
   cfc: CfcConfigDto;
-  // CTUN (Click-Tune) — issue #427. When true, panadapter clicks move the
-  // dial (vfoHz) without retuning the radio; the WDSP RX filter is shifted
-  // by (vfoHz - radioLoHz) on the server so the audio still demodulates the
-  // operator's tuned signal. radioLoHz is the actual hardware NCO and is
-  // what the panadapter centres on.
-  ctunEnabled: boolean;
+  // Hardware NCO. Independent of vfoHz — the panadapter centres on radioLoHz
+  // and WDSP's shift stage relocates the operator's tuned signal so it still
+  // demodulates. Moves only on explicit retune (/api/radio/lo, band change,
+  // external CAT). The legacy CTUN toggle was removed in the pure-pan rework
+  // (PRD: docs/prd/panfall_behavior.md); this is now the only tuning model.
   radioLoHz: number;
 };
 
@@ -479,9 +478,9 @@ export function normalizeState(raw: unknown): RadioStateDto {
     twoToneFreq2: typeof r.twoToneFreq2 === 'number' ? r.twoToneFreq2 : 1900,
     twoToneMag: typeof r.twoToneMag === 'number' ? r.twoToneMag : 0.49,
     cfc: normalizeCfc(r.cfc),
-    // CTUN — issue #427. Legacy server without the fields → CTUN off and
-    // radioLoHz falls back to vfoHz so the panadapter centre stays sensible.
-    ctunEnabled: typeof r.ctunEnabled === 'boolean' ? r.ctunEnabled : false,
+    // Hardware NCO. Legacy server without the field → fall back to vfoHz so
+    // the panadapter centre stays sensible during a rolling deploy. Any
+    // stale ctunEnabled field from an old payload is ignored.
     radioLoHz:
       typeof r.radioLoHz === 'number' && r.radioLoHz > 0
         ? r.radioLoHz
@@ -655,16 +654,20 @@ export function disconnectP2(signal?: AbortSignal): Promise<unknown> {
   );
 }
 
-export function setCtun(
-  enabled: boolean,
+// Move the hardware NCO center frequency without touching vfoHz. Called by
+// the panadapter pan gesture (use-pan-tune-gesture.ts) when a drag releases
+// past the edge of the current IQ capture window. Server returns the full
+// updated StateDto; 400 if hz is out of range for the connected radio.
+export function setRadioLo(
+  hz: number,
   signal?: AbortSignal,
 ): Promise<RadioStateDto> {
   return jsonFetch(
-    '/api/ctun',
+    '/api/radio/lo',
     {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ enabled }),
+      body: JSON.stringify({ hz }),
       signal,
     },
     normalizeState,

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -231,6 +231,9 @@ export type RadioStateDto = {
   // external CAT). The legacy CTUN toggle was removed in the pure-pan rework
   // (PRD: docs/prd/panfall_behavior.md); this is now the only tuning model.
   radioLoHz: number;
+  // CW sidetone pitch in Hz. Today a baked-in constant (600); exposed so
+  // the frontend doesn't duplicate it. Will become configurable later.
+  cwPitchHz: number;
 };
 
 // CFC mirrors Zeus.Contracts.CfcConfig. Bands array is fixed at 10 entries
@@ -499,6 +502,7 @@ export function normalizeState(raw: unknown): RadioStateDto {
         : typeof r.vfoHz === 'number'
         ? r.vfoHz
         : 0,
+    cwPitchHz: typeof r.cwPitchHz === 'number' ? r.cwPitchHz : 600,
   };
 }
 

--- a/zeus-web/src/api/cw.ts
+++ b/zeus-web/src/api/cw.ts
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+
+// CW endpoints: /api/cw/send, /api/cw/abort, /api/cw/settings.
+// Backend lives in Zeus.Server.Hosting/CwEngine.cs (engine) +
+// CwSettingsStore.cs (persistence). Status feedback for in-flight
+// playback arrives over WebSocket as MsgType.CwEngineStatus (0x30) —
+// consumed in realtime/ws-client.ts and pushed into useCwStore.
+
+export type CwSettings = {
+  wpm: number;
+  // Farnsworth char-rate floor (slower than wpm). null = pure WPM, no
+  // Farnsworth — current default.
+  farnsworthWpm: number | null;
+  // Exactly 6 slots; empty strings are valid (renders the slot as an
+  // unlabelled placeholder button in the 2×3 grid).
+  macros: string[];
+  sidetoneGainDb: number;
+  sidetoneHz: number;
+};
+
+type CwSettingsDtoRaw = {
+  wpm?: number;
+  farnsworthWpm?: number | null;
+  macros?: string[];
+  sidetoneGainDb?: number;
+  sidetoneHz?: number;
+};
+
+const DEFAULT_MACROS = ['CQ CQ CQ', 'TU 73', 'QRZ?', 'AGN?', '5NN TU', 'UR RST'];
+
+// Single source of truth for the fallback shape — used when the backend
+// is unreachable on first load so the UI still renders a sensible macro
+// pad. Server has the authoritative defaults; this just mirrors them so
+// the UI doesn't flicker through "empty" on slow networks.
+export const DEFAULT_CW_SETTINGS: CwSettings = {
+  wpm: 22,
+  farnsworthWpm: null,
+  macros: [...DEFAULT_MACROS],
+  sidetoneGainDb: -10,
+  sidetoneHz: 600,
+};
+
+function normalize(raw: CwSettingsDtoRaw): CwSettings {
+  // Variable-length: pass through whatever the server sent (operator
+  // chose the count). Map non-string entries to empty strings defensively
+  // so a malformed wire payload never crashes the renderer.
+  const macros = (raw.macros ?? []).map((m) => (typeof m === 'string' ? m : ''));
+  return {
+    wpm: typeof raw.wpm === 'number' ? raw.wpm : DEFAULT_CW_SETTINGS.wpm,
+    farnsworthWpm:
+      typeof raw.farnsworthWpm === 'number' ? raw.farnsworthWpm : null,
+    macros,
+    sidetoneGainDb:
+      typeof raw.sidetoneGainDb === 'number'
+        ? raw.sidetoneGainDb
+        : DEFAULT_CW_SETTINGS.sidetoneGainDb,
+    sidetoneHz:
+      typeof raw.sidetoneHz === 'number'
+        ? raw.sidetoneHz
+        : DEFAULT_CW_SETTINGS.sidetoneHz,
+  };
+}
+
+export async function fetchCwSettings(signal?: AbortSignal): Promise<CwSettings> {
+  const res = await fetch('/api/cw/settings', { signal });
+  if (!res.ok) throw new Error(`GET /api/cw/settings → ${res.status}`);
+  return normalize((await res.json()) as CwSettingsDtoRaw);
+}
+
+/** PATCH-shaped PUT — only the fields you pass are sent. */
+export async function saveCwSettings(
+  patch: Partial<CwSettings>,
+  signal?: AbortSignal,
+): Promise<CwSettings> {
+  const body: CwSettingsDtoRaw = {};
+  if (patch.wpm !== undefined) body.wpm = patch.wpm;
+  if (patch.farnsworthWpm !== undefined) body.farnsworthWpm = patch.farnsworthWpm;
+  if (patch.macros !== undefined) body.macros = patch.macros;
+  if (patch.sidetoneGainDb !== undefined) body.sidetoneGainDb = patch.sidetoneGainDb;
+  if (patch.sidetoneHz !== undefined) body.sidetoneHz = patch.sidetoneHz;
+
+  const res = await fetch('/api/cw/settings', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+    signal,
+  });
+  if (!res.ok) throw new Error(`PUT /api/cw/settings → ${res.status}`);
+  return normalize((await res.json()) as CwSettingsDtoRaw);
+}
+
+/** Enqueue text for transmission. Returns when the server has accepted
+ * the job (HTTP 202) — playback happens on the engine worker. WPM omitted
+ * = use the persisted operator default (CwSettingsStore.Wpm). */
+export async function sendCw(text: string, wpm?: number, signal?: AbortSignal): Promise<void> {
+  const res = await fetch('/api/cw/send', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(wpm === undefined ? { text } : { text, wpm }),
+    signal,
+  });
+  if (!res.ok && res.status !== 202) {
+    throw new Error(`POST /api/cw/send → ${res.status}`);
+  }
+}
+
+/** Hard abort. Drops the queue + cancels in-flight playback. Best-effort
+ * — always returns OK (server-side too). */
+export async function abortCw(signal?: AbortSignal): Promise<void> {
+  await fetch('/api/cw/abort', { method: 'POST', signal });
+}

--- a/zeus-web/src/api/display.ts
+++ b/zeus-web/src/api/display.ts
@@ -12,6 +12,19 @@ export type DisplaySettings = {
   hasImage: boolean;
   imageMime: string | null;
   rxTraceColor: string;
+  // Panadapter and waterfall dB window bounds. null means the server has
+  // never stored a value; the frontend falls back to its built-in defaults
+  // (FIXED_DB_MIN / TX_FIXED_DB_MIN) and pushes the current value up on
+  // next interaction. Non-null values are used as-is (server wins over
+  // localStorage, surviving the Photino per-launch port shuffle).
+  dbMin: number | null;
+  dbMax: number | null;
+  txDbMin: number | null;
+  txDbMax: number | null;
+  wfDbMin: number | null;
+  wfDbMax: number | null;
+  wfTxDbMin: number | null;
+  wfTxDbMax: number | null;
 };
 
 // Matches backend DisplaySettingsStore.DefaultRxTraceColor.
@@ -23,11 +36,23 @@ type DisplaySettingsDtoRaw = {
   hasImage?: boolean;
   imageMime?: string | null;
   rxTraceColor?: string | null;
+  dbMin?: number | null;
+  dbMax?: number | null;
+  txDbMin?: number | null;
+  txDbMax?: number | null;
+  wfDbMin?: number | null;
+  wfDbMax?: number | null;
+  wfTxDbMin?: number | null;
+  wfTxDbMax?: number | null;
 };
 
 function normalizeRxTraceColor(raw: string | null | undefined): string {
   if (typeof raw !== 'string') return DEFAULT_RX_TRACE_COLOR;
   return /^#[0-9A-Fa-f]{6}$/.test(raw) ? raw.toUpperCase() : DEFAULT_RX_TRACE_COLOR;
+}
+
+function normalizeDbValue(raw: number | null | undefined): number | null {
+  return typeof raw === 'number' && Number.isFinite(raw) ? raw : null;
 }
 
 function normalize(raw: DisplaySettingsDtoRaw): DisplaySettings {
@@ -45,6 +70,14 @@ function normalize(raw: DisplaySettingsDtoRaw): DisplaySettings {
     hasImage: !!raw.hasImage,
     imageMime: raw.imageMime ?? null,
     rxTraceColor: normalizeRxTraceColor(raw.rxTraceColor),
+    dbMin: normalizeDbValue(raw.dbMin),
+    dbMax: normalizeDbValue(raw.dbMax),
+    txDbMin: normalizeDbValue(raw.txDbMin),
+    txDbMax: normalizeDbValue(raw.txDbMax),
+    wfDbMin: normalizeDbValue(raw.wfDbMin),
+    wfDbMax: normalizeDbValue(raw.wfDbMax),
+    wfTxDbMin: normalizeDbValue(raw.wfTxDbMin),
+    wfTxDbMax: normalizeDbValue(raw.wfTxDbMax),
   };
 }
 
@@ -58,12 +91,32 @@ export async function updateDisplaySettings(
   mode: DisplaySettings['mode'],
   fit: DisplaySettings['fit'],
   rxTraceColor: string,
+  dbMin?: number | null,
+  dbMax?: number | null,
+  txDbMin?: number | null,
+  txDbMax?: number | null,
+  wfDbMin?: number | null,
+  wfDbMax?: number | null,
+  wfTxDbMin?: number | null,
+  wfTxDbMax?: number | null,
   signal?: AbortSignal,
 ): Promise<DisplaySettings> {
   const res = await fetch('/api/display-settings', {
     method: 'PUT',
     headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ mode, fit, rxTraceColor }),
+    body: JSON.stringify({
+      mode,
+      fit,
+      rxTraceColor,
+      dbMin,
+      dbMax,
+      txDbMin,
+      txDbMax,
+      wfDbMin,
+      wfDbMax,
+      wfTxDbMin,
+      wfTxDbMax,
+    }),
     signal,
   });
   if (!res.ok) throw new Error(`PUT /api/display-settings → ${res.status}`);

--- a/zeus-web/src/api/display.ts
+++ b/zeus-web/src/api/display.ts
@@ -25,6 +25,10 @@ export type DisplaySettings = {
   wfDbMax: number | null;
   wfTxDbMin: number | null;
   wfTxDbMax: number | null;
+  // Operator-tunable waterfall colormap brightness multiplier (issue #426).
+  // null means the server has never stored a value; the frontend defaults to
+  // 1.0 (no change) and pushes the current value up on next interaction.
+  wfBrightness: number | null;
 };
 
 // Matches backend DisplaySettingsStore.DefaultRxTraceColor.
@@ -44,6 +48,7 @@ type DisplaySettingsDtoRaw = {
   wfDbMax?: number | null;
   wfTxDbMin?: number | null;
   wfTxDbMax?: number | null;
+  wfBrightness?: number | null;
 };
 
 function normalizeRxTraceColor(raw: string | null | undefined): string {
@@ -78,6 +83,7 @@ function normalize(raw: DisplaySettingsDtoRaw): DisplaySettings {
     wfDbMax: normalizeDbValue(raw.wfDbMax),
     wfTxDbMin: normalizeDbValue(raw.wfTxDbMin),
     wfTxDbMax: normalizeDbValue(raw.wfTxDbMax),
+    wfBrightness: normalizeDbValue(raw.wfBrightness),
   };
 }
 
@@ -99,6 +105,7 @@ export async function updateDisplaySettings(
   wfDbMax?: number | null,
   wfTxDbMin?: number | null,
   wfTxDbMax?: number | null,
+  wfBrightness?: number | null,
   signal?: AbortSignal,
 ): Promise<DisplaySettings> {
   const res = await fetch('/api/display-settings', {
@@ -116,6 +123,7 @@ export async function updateDisplaySettings(
       wfDbMax,
       wfTxDbMin,
       wfTxDbMax,
+      wfBrightness,
     }),
     signal,
   });

--- a/zeus-web/src/api/meter-display-settings.ts
+++ b/zeus-web/src/api/meter-display-settings.ts
@@ -6,19 +6,32 @@
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 
-// Display-side meter calibration knobs (GitHub #426). Currently surfaces
-// the S-meter dB offset trim. Persisted server-side in zeus-prefs.db.
+// Display-side meter calibration knobs (GitHub #426). Surfaces:
+//
+//   * S-meter dB offset trim (signed ±20 dB)
+//   * TX forward-power meter max-displayed-watts override
+//     (0 = no override, use radio's rated MaxWatts as full scale)
+//
+// Persisted server-side in zeus-prefs.db.
 
 export const SMETER_OFFSET_MIN_DB = -20;
 export const SMETER_OFFSET_MAX_DB = 20;
 export const SMETER_OFFSET_DEFAULT_DB = 0;
 
+export const MAX_DISPLAYED_WATTS_MIN = 1;
+export const MAX_DISPLAYED_WATTS_MAX = 1000;
+// 0 = "no override". Matches the server's MeterDisplaySettingsDto
+// shape; the meter component falls back to the radio's MaxWatts.
+export const MAX_DISPLAYED_WATTS_DEFAULT = 0;
+
 export type MeterDisplaySettings = {
   sMeterOffsetDb: number;
+  maxDisplayedWatts: number;
 };
 
 type RawDto = {
   sMeterOffsetDb?: number;
+  maxDisplayedWatts?: number;
 };
 
 function clampOffset(v: number): number {
@@ -28,10 +41,23 @@ function clampOffset(v: number): number {
   return v;
 }
 
+function clampMaxWatts(v: number): number {
+  if (!Number.isFinite(v)) return MAX_DISPLAYED_WATTS_DEFAULT;
+  if (v <= 0) return MAX_DISPLAYED_WATTS_DEFAULT;
+  if (v < MAX_DISPLAYED_WATTS_MIN) return MAX_DISPLAYED_WATTS_MIN;
+  if (v > MAX_DISPLAYED_WATTS_MAX) return MAX_DISPLAYED_WATTS_MAX;
+  return v;
+}
+
 function normalize(raw: RawDto): MeterDisplaySettings {
   return {
     sMeterOffsetDb: clampOffset(
       typeof raw.sMeterOffsetDb === 'number' ? raw.sMeterOffsetDb : SMETER_OFFSET_DEFAULT_DB,
+    ),
+    maxDisplayedWatts: clampMaxWatts(
+      typeof raw.maxDisplayedWatts === 'number'
+        ? raw.maxDisplayedWatts
+        : MAX_DISPLAYED_WATTS_DEFAULT,
     ),
   };
 }
@@ -55,5 +81,19 @@ export async function updateSMeterOffsetDb(
     signal,
   });
   if (!res.ok) throw new Error(`PUT /api/meters/smeter-offset-db → ${res.status}`);
+  return normalize((await res.json()) as RawDto);
+}
+
+export async function updateMaxDisplayedWatts(
+  maxWatts: number,
+  signal?: AbortSignal,
+): Promise<MeterDisplaySettings> {
+  const res = await fetch('/api/meters/max-displayed-watts', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ maxWatts: clampMaxWatts(maxWatts) }),
+    signal,
+  });
+  if (!res.ok) throw new Error(`PUT /api/meters/max-displayed-watts → ${res.status}`);
   return normalize((await res.json()) as RawDto);
 }

--- a/zeus-web/src/api/meter-display-settings.ts
+++ b/zeus-web/src/api/meter-display-settings.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+// Display-side meter calibration knobs (GitHub #426). Currently surfaces
+// the S-meter dB offset trim. Persisted server-side in zeus-prefs.db.
+
+export const SMETER_OFFSET_MIN_DB = -20;
+export const SMETER_OFFSET_MAX_DB = 20;
+export const SMETER_OFFSET_DEFAULT_DB = 0;
+
+export type MeterDisplaySettings = {
+  sMeterOffsetDb: number;
+};
+
+type RawDto = {
+  sMeterOffsetDb?: number;
+};
+
+function clampOffset(v: number): number {
+  if (!Number.isFinite(v)) return SMETER_OFFSET_DEFAULT_DB;
+  if (v < SMETER_OFFSET_MIN_DB) return SMETER_OFFSET_MIN_DB;
+  if (v > SMETER_OFFSET_MAX_DB) return SMETER_OFFSET_MAX_DB;
+  return v;
+}
+
+function normalize(raw: RawDto): MeterDisplaySettings {
+  return {
+    sMeterOffsetDb: clampOffset(
+      typeof raw.sMeterOffsetDb === 'number' ? raw.sMeterOffsetDb : SMETER_OFFSET_DEFAULT_DB,
+    ),
+  };
+}
+
+export async function fetchMeterDisplaySettings(
+  signal?: AbortSignal,
+): Promise<MeterDisplaySettings> {
+  const res = await fetch('/api/meters/display-settings', { signal });
+  if (!res.ok) throw new Error(`GET /api/meters/display-settings → ${res.status}`);
+  return normalize((await res.json()) as RawDto);
+}
+
+export async function updateSMeterOffsetDb(
+  offsetDb: number,
+  signal?: AbortSignal,
+): Promise<MeterDisplaySettings> {
+  const res = await fetch('/api/meters/smeter-offset-db', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ offsetDb: clampOffset(offsetDb) }),
+    signal,
+  });
+  if (!res.ok) throw new Error(`PUT /api/meters/smeter-offset-db → ${res.status}`);
+  return normalize((await res.json()) as RawDto);
+}

--- a/zeus-web/src/api/pan-wf-split.ts
+++ b/zeus-web/src/api/pan-wf-split.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+// Hero-panel vertical split between the panadapter (top) and the
+// waterfall (bottom). panPercent is the panadapter share, clamped
+// 10..90; the waterfall takes the remainder. Persisted server-side in
+// zeus-prefs.db, same pattern as /api/bottom-pin.
+
+export const PAN_WF_DEFAULT_PERCENT = 50;
+export const PAN_WF_MIN_PERCENT = 10;
+export const PAN_WF_MAX_PERCENT = 90;
+
+export type PanWfSplit = {
+  panPercent: number;
+};
+
+type PanWfSplitDtoRaw = {
+  panPercent?: number;
+};
+
+function clamp(v: number): number {
+  if (!Number.isFinite(v)) return PAN_WF_DEFAULT_PERCENT;
+  if (v < PAN_WF_MIN_PERCENT) return PAN_WF_MIN_PERCENT;
+  if (v > PAN_WF_MAX_PERCENT) return PAN_WF_MAX_PERCENT;
+  return v;
+}
+
+function normalize(raw: PanWfSplitDtoRaw): PanWfSplit {
+  const v = typeof raw.panPercent === 'number' ? raw.panPercent : PAN_WF_DEFAULT_PERCENT;
+  return { panPercent: clamp(v) };
+}
+
+export async function fetchPanWfSplit(signal?: AbortSignal): Promise<PanWfSplit> {
+  const res = await fetch('/api/pan-wf-split', { signal });
+  if (!res.ok) throw new Error(`GET /api/pan-wf-split → ${res.status}`);
+  return normalize((await res.json()) as PanWfSplitDtoRaw);
+}
+
+export async function updatePanWfSplit(
+  next: PanWfSplit,
+  signal?: AbortSignal,
+): Promise<PanWfSplit> {
+  const res = await fetch('/api/pan-wf-split', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ panPercent: clamp(next.panPercent) }),
+    signal,
+  });
+  if (!res.ok) throw new Error(`PUT /api/pan-wf-split → ${res.status}`);
+  return normalize((await res.json()) as PanWfSplitDtoRaw);
+}

--- a/zeus-web/src/api/rotator.ts
+++ b/zeus-web/src/api/rotator.ts
@@ -104,6 +104,23 @@ export function getRotatorStatus(signal?: AbortSignal): Promise<RotctldStatus> {
   return jsonFetch('/api/rotator/status', { signal }, normalizeStatus);
 }
 
+function normalizeConfig(raw: unknown): RotctldConfig {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  return {
+    enabled: Boolean(r.enabled),
+    host: typeof r.host === 'string' && r.host ? r.host : '127.0.0.1',
+    port: typeof r.port === 'number' && r.port > 0 ? r.port : 4533,
+    pollingIntervalMs:
+      typeof r.pollingIntervalMs === 'number' && r.pollingIntervalMs > 0
+        ? r.pollingIntervalMs
+        : 500,
+  };
+}
+
+export function getRotatorConfig(signal?: AbortSignal): Promise<RotctldConfig> {
+  return jsonFetch('/api/rotator/config', { signal }, normalizeConfig);
+}
+
 export function postRotatorConfig(cfg: RotctldConfig, signal?: AbortSignal): Promise<RotctldStatus> {
   return jsonFetch(
     '/api/rotator/config',

--- a/zeus-web/src/components/AfGainSlider.tsx
+++ b/zeus-web/src/components/AfGainSlider.tsx
@@ -42,9 +42,10 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { setRxAfGain } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import { useLiveSlider } from '../hooks/useLiveSlider';
 
 // Master RX AF gain in dB. Drives WDSP's SetRXAPanelGain1(linear) server-side
 // after a dB→linear conversion; the browser audio GainNode stays at 1.0 so
@@ -63,49 +64,23 @@ export function AfGainSlider() {
   const [dragValue, setDragValue] = useState<number | null>(null);
   const value = dragValue ?? serverAf;
 
-  const inflightAbort = useRef<AbortController | null>(null);
-  const latestSent = useRef<number>(serverAf);
-
-  const sendValue = useCallback(
-    (v: number) => {
-      if (v === latestSent.current) return;
-      latestSent.current = v;
-      inflightAbort.current?.abort();
-      const ac = new AbortController();
-      inflightAbort.current = ac;
-      setRxAfGain(v, ac.signal)
-        .then((next) => {
-          if (!ac.signal.aborted) applyState(next);
-        })
-        .catch(() => {
-          /* next poll will reconcile; don't noisily log on abort */
-        });
-    },
-    [applyState],
-  );
-
-  // Debounced send while dragging — 100ms is fast enough to feel immediate
-  // but prevents excessive API calls during a quick slider sweep.
-  const debounceTimer = useRef<number | null>(null);
-  const sendDebounced = useCallback(
-    (v: number) => {
-      if (debounceTimer.current !== null) {
-        clearTimeout(debounceTimer.current);
-      }
-      debounceTimer.current = window.setTimeout(() => {
-        sendValue(v);
-        debounceTimer.current = null;
-      }, 100);
-    },
-    [sendValue],
-  );
-
-  useEffect(() => () => {
-    inflightAbort.current?.abort();
-    if (debounceTimer.current !== null) {
-      clearTimeout(debounceTimer.current);
-    }
-  }, []);
+  // Stream during drag (rAF coalesced — ~16 ms at 60 Hz), flush on release.
+  // The previous 100 ms debounce was perceptible as a lag in the audible AF
+  // response on a fast sweep; rAF is fast enough to feel instant while still
+  // capping the wire rate to one POST per paint.
+  const liveSlider = useLiveSlider<number>({
+    send: useCallback(
+      (v: number, signal: AbortSignal) =>
+        setRxAfGain(v, signal)
+          .then((next) => {
+            if (!signal.aborted) applyState(next);
+          })
+          .catch(() => {
+            /* next poll will reconcile; don't noisily log on abort */
+          }),
+      [applyState],
+    ),
+  });
 
   return (
     <label className="knob-group" style={{ minWidth: 170 }}>
@@ -120,36 +95,18 @@ export function AfGainSlider() {
         onChange={(e) => {
           const newValue = Number(e.currentTarget.value);
           setDragValue(newValue);
-          sendDebounced(newValue);
+          liveSlider.push(newValue);
         }}
         onMouseUp={() => {
-          if (dragValue !== null) {
-            if (debounceTimer.current !== null) {
-              clearTimeout(debounceTimer.current);
-              debounceTimer.current = null;
-            }
-            sendValue(dragValue);
-          }
+          liveSlider.flush();
           setDragValue(null);
         }}
         onTouchEnd={() => {
-          if (dragValue !== null) {
-            if (debounceTimer.current !== null) {
-              clearTimeout(debounceTimer.current);
-              debounceTimer.current = null;
-            }
-            sendValue(dragValue);
-          }
+          liveSlider.flush();
           setDragValue(null);
         }}
         onKeyUp={() => {
-          if (dragValue !== null) {
-            if (debounceTimer.current !== null) {
-              clearTimeout(debounceTimer.current);
-              debounceTimer.current = null;
-            }
-            sendValue(dragValue);
-          }
+          liveSlider.flush();
           setDragValue(null);
         }}
         style={{ flex: 1, cursor: 'pointer', accentColor: 'var(--accent)' }}

--- a/zeus-web/src/components/AgcSlider.tsx
+++ b/zeus-web/src/components/AgcSlider.tsx
@@ -45,6 +45,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { setAgcTop, setAutoAgc } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import { useLiveSlider } from '../hooks/useLiveSlider';
 
 // AGC top (max gain) in dB. 80 is the Thetis AGC_MEDIUM default; the WDSP
 // docs call this the upper gain limit before compression kicks in.
@@ -67,27 +68,23 @@ export function AgcSlider() {
   const sliderValue = dragValue ?? userAgc;
   const effective = Math.round(Math.max(MIN, Math.min(MAX, sliderValue + offsetDb)));
 
-  const inflightAbort = useRef<AbortController | null>(null);
-  const latestSent = useRef<number>(userAgc);
   const autoAbort = useRef<AbortController | null>(null);
 
-  const sendValue = useCallback(
-    (v: number) => {
-      if (v === latestSent.current) return;
-      latestSent.current = v;
-      inflightAbort.current?.abort();
-      const ac = new AbortController();
-      inflightAbort.current = ac;
-      setAgcTop(v, ac.signal)
-        .then((next) => {
-          if (!ac.signal.aborted) applyState(next);
-        })
-        .catch(() => {
-          /* next poll will reconcile; don't noisily log on abort */
-        });
-    },
-    [applyState],
-  );
+  // Stream during drag (rAF coalesced), flush on release. The hook owns
+  // abort-on-supersede so a fast drag doesn't queue stale POSTs.
+  const liveSlider = useLiveSlider<number>({
+    send: useCallback(
+      (v: number, signal: AbortSignal) =>
+        setAgcTop(v, signal)
+          .then((next) => {
+            if (!signal.aborted) applyState(next);
+          })
+          .catch(() => {
+            /* next poll will reconcile; don't noisily log on abort */
+          }),
+      [applyState],
+    ),
+  });
 
   const toggleAuto = useCallback(() => {
     if (!connected) return;
@@ -105,7 +102,6 @@ export function AgcSlider() {
 
   useEffect(
     () => () => {
-      inflightAbort.current?.abort();
       autoAbort.current?.abort();
     },
     [],
@@ -136,17 +132,21 @@ export function AgcSlider() {
         step={1}
         value={sliderValue}
         disabled={!connected || autoEnabled}
-        onChange={(e) => setDragValue(Number(e.currentTarget.value))}
+        onChange={(e) => {
+          const v = Number(e.currentTarget.value);
+          setDragValue(v);
+          liveSlider.push(v);
+        }}
         onMouseUp={() => {
-          if (dragValue !== null) sendValue(dragValue);
+          liveSlider.flush();
           setDragValue(null);
         }}
         onTouchEnd={() => {
-          if (dragValue !== null) sendValue(dragValue);
+          liveSlider.flush();
           setDragValue(null);
         }}
         onKeyUp={() => {
-          if (dragValue !== null) sendValue(dragValue);
+          liveSlider.flush();
           setDragValue(null);
         }}
         style={{ flex: 1, cursor: 'pointer', accentColor: 'var(--accent)' }}

--- a/zeus-web/src/components/AttenuatorSlider.tsx
+++ b/zeus-web/src/components/AttenuatorSlider.tsx
@@ -45,6 +45,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { setAttenuator, setAutoAtt } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import { useLiveSlider } from '../hooks/useLiveSlider';
 
 // HpsdrAtten range — the server clamps to [MIN, MAX], but pinning the UI
 // to the same bounds avoids a round-trip that would visually snap the thumb.
@@ -65,27 +66,25 @@ export function AttenuatorSlider() {
   const sliderValue = dragValue ?? userAtten;
   const effective = Math.min(MAX, sliderValue + offsetDb);
 
-  const attenAbort = useRef<AbortController | null>(null);
-  const latestSent = useRef<number>(userAtten);
   const autoAbort = useRef<AbortController | null>(null);
 
-  const sendValue = useCallback(
-    (v: number) => {
-      if (v === latestSent.current) return;
-      latestSent.current = v;
-      attenAbort.current?.abort();
-      const ac = new AbortController();
-      attenAbort.current = ac;
-      setAttenuator(v, ac.signal)
-        .then((next) => {
-          if (!ac.signal.aborted) applyState(next);
-        })
-        .catch(() => {
-          /* next poll will reconcile; don't noisily log on abort */
-        });
-    },
-    [applyState],
-  );
+  // Stream during drag (rAF coalesced), flush on release — see useLiveSlider
+  // notes in hooks/useLiveSlider.ts. Previously the wire POST only fired on
+  // mouseUp / touchEnd / keyUp so the attenuator didn't change audibly until
+  // release; now it tracks the thumb in real time.
+  const liveSlider = useLiveSlider<number>({
+    send: useCallback(
+      (v: number, signal: AbortSignal) =>
+        setAttenuator(v, signal)
+          .then((next) => {
+            if (!signal.aborted) applyState(next);
+          })
+          .catch(() => {
+            /* next poll will reconcile; don't noisily log on abort */
+          }),
+      [applyState],
+    ),
+  });
 
   const toggleAuto = useCallback(() => {
     if (!connected) return;
@@ -103,7 +102,6 @@ export function AttenuatorSlider() {
 
   useEffect(
     () => () => {
-      attenAbort.current?.abort();
       autoAbort.current?.abort();
     },
     [],
@@ -138,17 +136,21 @@ export function AttenuatorSlider() {
         step={1}
         value={sliderValue}
         disabled={!connected || autoEnabled}
-        onChange={(e) => setDragValue(Number(e.currentTarget.value))}
+        onChange={(e) => {
+          const v = Number(e.currentTarget.value);
+          setDragValue(v);
+          liveSlider.push(v);
+        }}
         onMouseUp={() => {
-          if (dragValue !== null) sendValue(dragValue);
+          liveSlider.flush();
           setDragValue(null);
         }}
         onTouchEnd={() => {
-          if (dragValue !== null) sendValue(dragValue);
+          liveSlider.flush();
           setDragValue(null);
         }}
         onKeyUp={() => {
-          if (dragValue !== null) sendValue(dragValue);
+          liveSlider.flush();
           setDragValue(null);
         }}
         style={{ flex: 1, cursor: 'pointer', accentColor: 'var(--accent)' }}

--- a/zeus-web/src/components/BandButtons.tsx
+++ b/zeus-web/src/components/BandButtons.tsx
@@ -52,6 +52,7 @@ import {
   type RxMode,
 } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import { useDisplayStore } from '../state/display-store';
 import { BANDS, bandOf } from './design/data';
 import { toolbarFavDragMime } from './toolbar/ToolbarFavorites';
 
@@ -134,6 +135,10 @@ export function BandButtons() {
       const targetMode: RxMode | null = stored?.mode ?? null;
 
       useConnectionStore.setState({ vfoHz: targetHz });
+      // Band switch is an explicit tune-to-frequency action per the pure-pan
+      // PRD; reset any held viewport offset so the dial snaps back to centre
+      // on the new band.
+      useDisplayStore.getState().setViewportOffsetHz(0);
       setVfo(targetHz)
         .then(applyState)
         .catch(() => {

--- a/zeus-web/src/components/ConnectPanel.tsx
+++ b/zeus-web/src/components/ConnectPanel.tsx
@@ -50,8 +50,6 @@ import {
   disconnectP2 as apiDisconnectP2,
   fetchRadios,
   fetchState,
-  setLevelerMaxGain,
-  setMicGain,
   type RadioInfoDto,
 } from '../api/client';
 import {
@@ -116,21 +114,16 @@ function parseRawBoardId(raw: string | undefined): number | null {
 
 // Post-connect side-effects shared by discover-click and manual-connect.
 //
-// Drive / TUN drive are now authoritative on the server (StateDto.DrivePct /
-// TunePct, persisted via RadioStateStore). The connect-time response already
-// carries the hydrated values; tx-store.hydrateFromState picks them up from
-// the RadioStateDto returned by /api/connect. Pushing the localStorage mirror
-// back here would clobber the server's just-hydrated values, which is exactly
-// the bug reported for relaunches that didn't restore drive.
-//
-// micGainDb / levelerMaxGainDb don't have a server-authoritative path yet, so
-// they continue to push from localStorage. Migrating them to the same
-// StateDto pattern is the natural follow-up.
+// Drive / TUN drive, mic gain, and Leveler max-gain are all authoritative on
+// the server (StateDto.DrivePct / TunePct / MicGainDb / LevelerMaxGainDb,
+// persisted via RadioStateStore). The connect-time response carries the
+// hydrated values and tx-store.hydrateFromState picks them up; pushing the
+// localStorage mirror back here would clobber the server's just-hydrated
+// values, which is the bug reported for relaunches that didn't restore drive
+// (and the same bug that left mic gain + Leveler reverting on every desktop
+// launch when Photino wiped its storage).
 function applyPostConnectEffects() {
   void getAudioClient().start();
-  const tx = useTxStore.getState();
-  void setMicGain(tx.micGainDb).catch(() => {});
-  void setLevelerMaxGain(tx.levelerMaxGainDb).catch(() => {});
 }
 
 export interface ConnectPanelProps {

--- a/zeus-web/src/components/DriveSlider.tsx
+++ b/zeus-web/src/components/DriveSlider.tsx
@@ -42,18 +42,19 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import { setDrive } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
 import { useTxStore } from '../state/tx-store';
 import { usePaStore } from '../state/pa-store';
+import { useLiveSlider } from '../hooks/useLiveSlider';
 
-// PRD FR-4 drive range: 0..100 percent. Per-pixel POSTs would flood the
-// server during a drag — trailing-edge debounce keeps the wire quiet while
-// still giving a responsive thumb because the store updates optimistically.
+// PRD FR-4 drive range: 0..100 percent. Stream during drag via rAF coalesce
+// (one POST per paint at most) so the radio's drive byte tracks the thumb in
+// real time during MOX — previously a 100 ms trailing-edge debounce caused
+// audible lag on a fast sweep.
 const MIN = 0;
 const MAX = 100;
-const DEBOUNCE_MS = 100;
 
 export function DriveSlider() {
   const connected = useConnectionStore((s) => s.status === 'Connected');
@@ -66,40 +67,29 @@ export function DriveSlider() {
   const paMaxWatts = usePaStore((s) => s.settings.global.paMaxPowerWatts);
   const targetWatts = paMaxWatts > 0 ? Math.round((paMaxWatts * drivePercent) / 100) : null;
 
-  const inflightAbort = useRef<AbortController | null>(null);
-  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const lastSent = useRef<number>(drivePercent);
+  // Tracks the most recently acknowledged value so we can roll back on error.
   const previousOnError = useRef<number>(drivePercent);
 
-  const sendDebounced = useCallback((v: number) => {
-    if (debounceTimer.current != null) clearTimeout(debounceTimer.current);
-    debounceTimer.current = setTimeout(() => {
-      if (v === lastSent.current) return;
-      inflightAbort.current?.abort();
-      const ac = new AbortController();
-      inflightAbort.current = ac;
-      const prevValue = lastSent.current;
-      lastSent.current = v;
-      previousOnError.current = prevValue;
-      setDrive(v, ac.signal)
-        .then((r) => {
-          if (ac.signal.aborted) return;
-          if (r.drivePercent !== v) setDrivePercent(r.drivePercent);
-        })
-        .catch((err) => {
-          if (ac.signal.aborted) return;
-          if (err instanceof DOMException && err.name === 'AbortError') return;
-          // Roll back the optimistic update so the user sees the real state.
-          setDrivePercent(previousOnError.current);
-          lastSent.current = previousOnError.current;
-        });
-    }, DEBOUNCE_MS);
-  }, [setDrivePercent]);
-
-  useEffect(() => () => {
-    inflightAbort.current?.abort();
-    if (debounceTimer.current != null) clearTimeout(debounceTimer.current);
-  }, []);
+  const liveSlider = useLiveSlider<number>({
+    send: useCallback(
+      (v: number, signal: AbortSignal) => {
+        const prevValue = previousOnError.current;
+        return setDrive(v, signal)
+          .then((r) => {
+            if (signal.aborted) return;
+            previousOnError.current = r.drivePercent;
+            if (r.drivePercent !== v) setDrivePercent(r.drivePercent);
+          })
+          .catch((err) => {
+            if (signal.aborted) return;
+            if (err instanceof DOMException && err.name === 'AbortError') return;
+            // Roll back the optimistic update so the user sees the real state.
+            setDrivePercent(prevValue);
+          });
+      },
+      [setDrivePercent],
+    ),
+  });
 
   // Server is now authoritative for drivePercent (StateDto.DrivePct, persisted
   // via RadioStateStore, hydrated into tx-store by tx-store.hydrateFromState
@@ -110,7 +100,7 @@ export function DriveSlider() {
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const v = Number(e.currentTarget.value);
     setDrivePercent(v);
-    sendDebounced(v);
+    liveSlider.push(v);
   };
 
   return (
@@ -124,6 +114,9 @@ export function DriveSlider() {
         value={drivePercent}
         disabled={!connected}
         onChange={onChange}
+        onMouseUp={() => liveSlider.flush()}
+        onTouchEnd={() => liveSlider.flush()}
+        onKeyUp={() => liveSlider.flush()}
         style={{ flex: 1, cursor: 'pointer', accentColor: 'var(--accent)' }}
       />
       <span className="mono" style={{ width: 40, textAlign: 'right', color: 'var(--power)', fontSize: 11, fontWeight: 700 }}>

--- a/zeus-web/src/components/FreqAxis.tsx
+++ b/zeus-web/src/components/FreqAxis.tsx
@@ -77,13 +77,17 @@ export function FreqAxis() {
   const centerHz = useDisplayStore((s) => s.centerHz);
   const hzPerPixel = useDisplayStore((s) => s.hzPerPixel);
   const width = useDisplayStore((s) => s.panDb?.length ?? 0);
+  // Pure-pan viewport offset shifts the rendered window relative to the
+  // hardware NCO; tick labels and the dial-position marker recompute from
+  // the offset viewport centre.
+  const viewportOffsetHz = useDisplayStore((s) => s.viewportOffsetHz);
   const vfoHz = useConnectionStore((s) => s.vfoHz);
 
   if (!width || hzPerPixel <= 0) return null;
 
   const spanHz = width * hzPerPixel;
   const stride = pickStrideHz(spanHz, 6);
-  const center = Number(centerHz);
+  const center = Number(centerHz) + viewportOffsetHz;
   const startHz = center - spanHz / 2;
   const endHz = center + spanHz / 2;
   const dialPct = ((vfoHz - startHz) / spanHz) * 100;

--- a/zeus-web/src/components/LevelerMaxGainSlider.tsx
+++ b/zeus-web/src/components/LevelerMaxGainSlider.tsx
@@ -10,9 +10,10 @@
 // option) any later version. See the LICENSE file at the root of this
 // repository for the full text, or https://www.gnu.org/licenses/.
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import { setLevelerMaxGain } from '../api/client';
 import { useTxStore } from '../state/tx-store';
+import { useLiveSlider } from '../hooks/useLiveSlider';
 
 // Leveler max-gain (TX): how much the WDSP TXA Leveler can boost quiet
 // speech before the ALC catches it. Default +5 dB matches the W1AEX /
@@ -25,7 +26,6 @@ import { useTxStore } from '../state/tx-store';
 const MIN = 0;
 const MAX = 15;
 const STEP = 0.5;
-const DEBOUNCE_MS = 100;
 
 function quantize(v: number): number {
   const snapped = Math.round(v / STEP) * STEP;
@@ -37,44 +37,32 @@ export function LevelerMaxGainSlider() {
   const value = useTxStore((s) => s.levelerMaxGainDb);
   const setValue = useTxStore((s) => s.setLevelerMaxGainDb);
 
-  const inflightAbort = useRef<AbortController | null>(null);
-  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const lastSent = useRef<number>(value);
   const previousOnError = useRef<number>(value);
 
-  const sendDebounced = useCallback((v: number) => {
-    if (debounceTimer.current != null) clearTimeout(debounceTimer.current);
-    debounceTimer.current = setTimeout(() => {
-      if (v === lastSent.current) return;
-      inflightAbort.current?.abort();
-      const ac = new AbortController();
-      inflightAbort.current = ac;
-      const prevValue = lastSent.current;
-      lastSent.current = v;
-      previousOnError.current = prevValue;
-      setLevelerMaxGain(v, ac.signal)
-        .then((r) => {
-          if (ac.signal.aborted) return;
-          if (r.levelerMaxGainDb !== v) setValue(r.levelerMaxGainDb);
-        })
-        .catch((err) => {
-          if (ac.signal.aborted) return;
-          if (err instanceof DOMException && err.name === 'AbortError') return;
-          setValue(previousOnError.current);
-          lastSent.current = previousOnError.current;
-        });
-    }, DEBOUNCE_MS);
-  }, [setValue]);
-
-  useEffect(() => () => {
-    inflightAbort.current?.abort();
-    if (debounceTimer.current != null) clearTimeout(debounceTimer.current);
-  }, []);
+  const liveSlider = useLiveSlider<number>({
+    send: useCallback(
+      (v: number, signal: AbortSignal) => {
+        const prevValue = previousOnError.current;
+        return setLevelerMaxGain(v, signal)
+          .then((r) => {
+            if (signal.aborted) return;
+            previousOnError.current = r.levelerMaxGainDb;
+            if (r.levelerMaxGainDb !== v) setValue(r.levelerMaxGainDb);
+          })
+          .catch((err) => {
+            if (signal.aborted) return;
+            if (err instanceof DOMException && err.name === 'AbortError') return;
+            setValue(prevValue);
+          });
+      },
+      [setValue],
+    ),
+  });
 
   const onInput = (e: React.FormEvent<HTMLInputElement>) => {
     const q = quantize(Number(e.currentTarget.value));
     setValue(q);
-    sendDebounced(q);
+    liveSlider.push(q);
   };
 
   return (
@@ -91,6 +79,9 @@ export function LevelerMaxGainSlider() {
         value={value}
         onInput={onInput}
         onChange={onInput}
+        onMouseUp={() => liveSlider.flush()}
+        onTouchEnd={() => liveSlider.flush()}
+        onKeyUp={() => liveSlider.flush()}
         style={{ flex: 1, cursor: 'pointer', accentColor: 'var(--accent)' }}
       />
       <span

--- a/zeus-web/src/components/MicGainSlider.tsx
+++ b/zeus-web/src/components/MicGainSlider.tsx
@@ -42,9 +42,10 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import { setMicGain } from '../api/client';
 import { useTxStore } from '../state/tx-store';
+import { useLiveSlider } from '../hooks/useLiveSlider';
 
 // Mic-gain range: −40..+10 dB, default 0 dB (= unity, no behaviour change
 // for operators who never moved the slider). Matches Thetis's defaults at
@@ -60,45 +61,32 @@ import { useTxStore } from '../state/tx-store';
 // operator can dial in level against the live mic meter before keying.
 const MIN = -40;
 const MAX = 10;
-const DEBOUNCE_MS = 100;
 
 export function MicGainSlider() {
   const micGainDb = useTxStore((s) => s.micGainDb);
   const setMicGainDb = useTxStore((s) => s.setMicGainDb);
 
-  const inflightAbort = useRef<AbortController | null>(null);
-  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const lastSent = useRef<number>(micGainDb);
   const previousOnError = useRef<number>(micGainDb);
 
-  const sendDebounced = useCallback((v: number) => {
-    if (debounceTimer.current != null) clearTimeout(debounceTimer.current);
-    debounceTimer.current = setTimeout(() => {
-      if (v === lastSent.current) return;
-      inflightAbort.current?.abort();
-      const ac = new AbortController();
-      inflightAbort.current = ac;
-      const prevValue = lastSent.current;
-      lastSent.current = v;
-      previousOnError.current = prevValue;
-      setMicGain(v, ac.signal)
-        .then((r) => {
-          if (ac.signal.aborted) return;
-          if (r.micGainDb !== v) setMicGainDb(r.micGainDb);
-        })
-        .catch((err) => {
-          if (ac.signal.aborted) return;
-          if (err instanceof DOMException && err.name === 'AbortError') return;
-          setMicGainDb(previousOnError.current);
-          lastSent.current = previousOnError.current;
-        });
-    }, DEBOUNCE_MS);
-  }, [setMicGainDb]);
-
-  useEffect(() => () => {
-    inflightAbort.current?.abort();
-    if (debounceTimer.current != null) clearTimeout(debounceTimer.current);
-  }, []);
+  const liveSlider = useLiveSlider<number>({
+    send: useCallback(
+      (v: number, signal: AbortSignal) => {
+        const prevValue = previousOnError.current;
+        return setMicGain(v, signal)
+          .then((r) => {
+            if (signal.aborted) return;
+            previousOnError.current = r.micGainDb;
+            if (r.micGainDb !== v) setMicGainDb(r.micGainDb);
+          })
+          .catch((err) => {
+            if (signal.aborted) return;
+            if (err instanceof DOMException && err.name === 'AbortError') return;
+            setMicGainDb(prevValue);
+          });
+      },
+      [setMicGainDb],
+    ),
+  });
 
   // Rounded on send / display so the wire contract stays integer dB, but the
   // slider itself uses 0.5-step so micro-drags cross a step boundary on the
@@ -109,7 +97,7 @@ export function MicGainSlider() {
   const onInput = (e: React.FormEvent<HTMLInputElement>) => {
     const v = Number(e.currentTarget.value);
     setMicGainDb(v);
-    sendDebounced(Math.round(v));
+    liveSlider.push(Math.round(v));
   };
 
   return (
@@ -123,6 +111,9 @@ export function MicGainSlider() {
         value={micGainDb}
         onInput={onInput}
         onChange={onInput}
+        onMouseUp={() => liveSlider.flush()}
+        onTouchEnd={() => liveSlider.flush()}
+        onKeyUp={() => liveSlider.flush()}
         style={{ flex: 1, cursor: 'pointer', accentColor: 'var(--accent)' }}
       />
       <span className="mono" style={{ width: 52, textAlign: 'right', color: 'var(--fg-1)', fontSize: 11 }}>

--- a/zeus-web/src/components/MobileZoomSlider.tsx
+++ b/zeus-web/src/components/MobileZoomSlider.tsx
@@ -42,9 +42,10 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback } from 'react';
 import { setZoom, ZOOM_MAX, ZOOM_MIN, type ZoomLevel } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import { useLiveSlider } from '../hooks/useLiveSlider';
 
 /**
  * Vertical zoom slider pinned to the right edge of the panadapter on mobile.
@@ -62,29 +63,28 @@ export function MobileZoomSlider() {
   const applyState = useConnectionStore((s) => s.applyState);
   const connected = useConnectionStore((s) => s.status === 'Connected');
 
-  const inflightAbort = useRef<AbortController | null>(null);
-  const latestSent = useRef<ZoomLevel>(serverZoom);
+  // rAF-coalesced live stream — see ZoomControl for rationale.
+  const liveSlider = useLiveSlider<ZoomLevel>({
+    send: useCallback(
+      (v: ZoomLevel, signal: AbortSignal) =>
+        setZoom(v, signal)
+          .then((next) => {
+            if (!signal.aborted) applyState(next);
+          })
+          .catch(() => {
+            /* next state poll will reconcile */
+          }),
+      [applyState],
+    ),
+  });
 
-  const sendValue = useCallback(
+  const onSlide = useCallback(
     (v: ZoomLevel) => {
-      if (v === latestSent.current) return;
-      latestSent.current = v;
       setLocalZoom(v);
-      inflightAbort.current?.abort();
-      const ac = new AbortController();
-      inflightAbort.current = ac;
-      setZoom(v, ac.signal)
-        .then((next) => {
-          if (!ac.signal.aborted) applyState(next);
-        })
-        .catch(() => {
-          /* next state poll will reconcile */
-        });
+      liveSlider.push(v);
     },
-    [applyState, setLocalZoom],
+    [liveSlider, setLocalZoom],
   );
-
-  useEffect(() => () => inflightAbort.current?.abort(), []);
 
   return (
     <div
@@ -111,7 +111,10 @@ export function MobileZoomSlider() {
         step={1}
         value={serverZoom}
         disabled={!connected}
-        onChange={(e) => sendValue(Number(e.currentTarget.value) as ZoomLevel)}
+        onChange={(e) => onSlide(Number(e.currentTarget.value) as ZoomLevel)}
+        onMouseUp={() => liveSlider.flush()}
+        onTouchEnd={() => liveSlider.flush()}
+        onKeyUp={() => liveSlider.flush()}
         style={{
           writingMode: 'vertical-lr',
           direction: 'rtl',

--- a/zeus-web/src/components/Panadapter.tsx
+++ b/zeus-web/src/components/Panadapter.tsx
@@ -108,22 +108,37 @@ export function Panadapter() {
       const dbMax = keyed ? s.txDbMax : s.dbMax;
       const { r, g, b } = hexToRgbFloats(s.rxTraceColor);
       renderer.setTraceColor(r, g, b);
-      // CTUN cursor X offset — issue #427. The orange dial cursor in
-      // panadapter.ts is drawn in clip space; default x=0 = panadapter
-      // centre. When CTUN is on and the dial has roamed off the (frozen)
-      // hardware NCO, shift the cursor by (vfoHz - centerHz) / (spanHz/2)
-      // so it tracks the operator's tuned frequency. When CTUN is off
-      // vfoHz == centerHz and the offset stays 0, matching legacy behaviour.
+      // Dial cursor X offset. The orange dial cursor in panadapter.ts is
+      // drawn in clip space; default x=0 = panadapter centre = viewport
+      // centre. Shift the cursor by (vfoHz - viewportCenter) / (spanHz/2)
+      // where viewportCenter = centerHz (hardware NCO) + viewportOffsetHz
+      // (pure-pan offset, see docs/prd/panfall_behavior.md). The trace
+      // shifts together with viewportOffsetHz via the PAN_VS uOffsetPx
+      // uniform; cursor stays glued to the real dial frequency.
       const display = useDisplayStore.getState();
       const cn = useConnectionStore.getState();
       let cursorXOffset = 0;
+      let viewportPxOffset = 0;
       const panLen = display.panDb?.length ?? 0;
       if (panLen > 0 && display.hzPerPixel > 0) {
         const spanHz = panLen * display.hzPerPixel;
         const centerHz = Number(display.centerHz);
-        cursorXOffset = (cn.vfoHz - centerHz) / (spanHz / 2);
+        const viewportCenter = centerHz + display.viewportOffsetHz;
+        cursorXOffset = (cn.vfoHz - viewportCenter) / (spanHz / 2);
+        // PAN_VS treats positive uOffsetPx as a right-shift of the trace
+        // (x = (i + 0.5 + uOffsetPx) / width). Dragging right moves the
+        // viewport centre to a lower frequency (viewportOffsetHz < 0); the
+        // trace data must visually shift right by the same Hz, so px offset
+        // is -viewportOffsetHz / hzPerPixel.
+        viewportPxOffset = -display.viewportOffsetHz / display.hzPerPixel;
       }
-      renderer.draw(drawPan, dbMin, dbMax, drawOffsetPx, cursorXOffset);
+      renderer.draw(
+        drawPan,
+        dbMin,
+        dbMax,
+        drawOffsetPx + viewportPxOffset,
+        cursorXOffset,
+      );
     };
     const requestRedraw = () => {
       if (!isActive()) return;
@@ -250,14 +265,23 @@ export function Panadapter() {
       }
     });
 
-    // CTUN — issue #427. When CTUN is on the spectrum stays anchored on the
-    // frozen radio LO but the operator's dial (vfoHz) roams independently;
-    // the cursor X-offset is recomputed inside redraw() from vfoHz, so we
-    // need a repaint whenever vfoHz moves even though no fresh pan frame
-    // arrives. ctunEnabled also matters: toggling it off must reset the
-    // cursor back to centre immediately.
+    // The spectrum stays anchored on the hardware LO while the operator's
+    // dial (vfoHz) roams independently; the cursor X-offset is recomputed
+    // inside redraw() from vfoHz, so we need a repaint whenever vfoHz moves
+    // even though no fresh pan frame arrives.
     const unsubConn = useConnectionStore.subscribe((state, prev) => {
-      if (state.vfoHz !== prev.vfoHz || state.ctunEnabled !== prev.ctunEnabled) {
+      if (state.vfoHz !== prev.vfoHz) {
+        requestRedraw();
+      }
+    });
+
+    // viewportOffsetHz (pure-pan drag) lives outside the frame-decoded data
+    // path — the operator can drag for several seconds between spectrum
+    // ticks, and we want the trace to follow the finger at rAF rate. A
+    // separate diff'd subscription keeps the noisy unsub above from firing on
+    // every store mutation.
+    const unsubViewport = useDisplayStore.subscribe((state, prev) => {
+      if (state.viewportOffsetHz !== prev.viewportOffsetHz) {
         requestRedraw();
       }
     });
@@ -267,6 +291,7 @@ export function Panadapter() {
       unsubSettings();
       unsubTx();
       unsubConn();
+      unsubViewport();
       ro.disconnect();
       io.disconnect();
       document.removeEventListener('visibilitychange', onVisibilityChange);

--- a/zeus-web/src/components/PassbandOverlay.tsx
+++ b/zeus-web/src/components/PassbandOverlay.tsx
@@ -56,6 +56,12 @@ import { useConnectionStore } from '../state/connection-store';
 // independently. Anchoring the passband to vfoHz — not centerHz — keeps the
 // filter overlay glued to the operator's tuned signal so clicking the
 // spectrum visibly slides the passband around the (stationary) waterfall.
+//
+// CW fix (issue #429): filter edges are baseband Hz relative to the LO,
+// not the dial. In CW the LO sits ±cw_pitch from the dial, so we anchor
+// at loHz = vfoHz − cwPitch instead of vfoHz. cwPitchHz comes from the
+// server (StateDto.CwPitchHz → CwDefaults.PitchHz). Mirrors Thetis
+// PanDisplay.cs:1213.
 export function PassbandOverlay() {
   const centerHz = useDisplayStore((s) => s.centerHz);
   const hzPerPixel = useDisplayStore((s) => s.hzPerPixel);
@@ -67,6 +73,8 @@ export function PassbandOverlay() {
   const filterLowHz = useConnectionStore((s) => s.filterLowHz);
   const filterHighHz = useConnectionStore((s) => s.filterHighHz);
   const vfoHz = useConnectionStore((s) => s.vfoHz);
+  const mode = useConnectionStore((s) => s.mode);
+  const cwPitchHz = useConnectionStore((s) => s.cwPitchHz);
 
   if (!width || hzPerPixel <= 0) return null;
 
@@ -74,8 +82,14 @@ export function PassbandOverlay() {
   const center = Number(centerHz) + viewportOffsetHz;
   const startHz = center - spanHz / 2;
 
-  const passLowHz = vfoHz + filterLowHz;
-  const passHighHz = vfoHz + filterHighHz;
+  // Anchor the filter overlay at the LO, not at the dial. In CW the LO
+  // sits cw_pitch below (CWU) or above (CWL) the dial; in all other
+  // modes LO == dial. Mirrors Thetis PanDisplay.cs:1213-1214 which
+  // positions filter edges relative to Low (the LO-based display edge).
+  const cwOffset = mode === 'CWU' ? cwPitchHz : mode === 'CWL' ? -cwPitchHz : 0;
+  const loHz = vfoHz - cwOffset;
+  const passLowHz = loHz + filterLowHz;
+  const passHighHz = loHz + filterHighHz;
   const leftPct = ((passLowHz - startHz) / spanHz) * 100;
   const rightPct = ((passHighHz - startHz) / spanHz) * 100;
   const widthPct = rightPct - leftPct;

--- a/zeus-web/src/components/PassbandOverlay.tsx
+++ b/zeus-web/src/components/PassbandOverlay.tsx
@@ -52,16 +52,18 @@ import { useConnectionStore } from '../state/connection-store';
 // Positioned by percentage of the total span so it tracks resize and tune
 // without measuring DOM width.
 //
-// CTUN (issue #427): when CTUN is on, the panadapter centres on radioLoHz
-// (the frozen hardware NCO) while vfoHz roams independently. Anchoring the
-// passband to vfoHz — not centerHz — keeps the filter overlay glued to the
-// operator's tuned signal so clicking the spectrum visibly slides the
-// passband around the (stationary) waterfall. When CTUN is off vfoHz equals
-// centerHz so this collapses to legacy behaviour.
+// The panadapter centres on the hardware NCO (radioLoHz) while vfoHz roams
+// independently. Anchoring the passband to vfoHz — not centerHz — keeps the
+// filter overlay glued to the operator's tuned signal so clicking the
+// spectrum visibly slides the passband around the (stationary) waterfall.
 export function PassbandOverlay() {
   const centerHz = useDisplayStore((s) => s.centerHz);
   const hzPerPixel = useDisplayStore((s) => s.hzPerPixel);
   const width = useDisplayStore((s) => s.panDb?.length ?? 0);
+  // Pure-pan viewport offset shifts the rendered window relative to the
+  // hardware NCO; the passband must shift with it so it stays glued to the
+  // dial frequency on-screen.
+  const viewportOffsetHz = useDisplayStore((s) => s.viewportOffsetHz);
   const filterLowHz = useConnectionStore((s) => s.filterLowHz);
   const filterHighHz = useConnectionStore((s) => s.filterHighHz);
   const vfoHz = useConnectionStore((s) => s.vfoHz);
@@ -69,7 +71,7 @@ export function PassbandOverlay() {
   if (!width || hzPerPixel <= 0) return null;
 
   const spanHz = width * hzPerPixel;
-  const center = Number(centerHz);
+  const center = Number(centerHz) + viewportOffsetHz;
   const startHz = center - spanHz / 2;
 
   const passLowHz = vfoHz + filterLowHz;

--- a/zeus-web/src/components/RotatorSettingsPanel.tsx
+++ b/zeus-web/src/components/RotatorSettingsPanel.tsx
@@ -241,8 +241,9 @@ export function RotatorSettingsPanel() {
           <span style={{ fontFamily: 'monospace' }}>
             rotctld -m 2 -r /dev/ttyUSB0 -s 9600 -t 4533
           </span>{' '}
-          (model 2 = dummy rotor for testing). Settings are remembered locally; the backend holds no
-          persistent state across restarts.
+          (model 2 = dummy rotor for testing). Settings are saved server-side in zeus-prefs.db and
+          shared across browsers and sessions; Zeus only auto-connects on startup if Enabled was
+          checked at last clean exit.
         </div>
       </form>
     </div>

--- a/zeus-web/src/components/SMeterLive.tsx
+++ b/zeus-web/src/components/SMeterLive.tsx
@@ -42,11 +42,15 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
-import { useRef, useState } from 'react';
+import type { CSSProperties } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { SMeter } from './SMeter';
 import { useTxStore } from '../state/tx-store';
+import { useRadioStore } from '../state/radio-store';
 import { useMeterDisplaySettingsStore } from '../state/meter-display-settings-store';
 import {
+  MAX_DISPLAYED_WATTS_MAX,
+  MAX_DISPLAYED_WATTS_MIN,
   SMETER_OFFSET_MIN_DB,
   SMETER_OFFSET_MAX_DB,
 } from '../api/meter-display-settings';
@@ -72,6 +76,8 @@ export function SMeterLive({ hideChips = false }: { hideChips?: boolean } = {}) 
   const micDbfs = useTxStore((s) => s.micDbfs);
   const rxDbm = useTxStore((s) => s.rxDbm);
   const sMeterOffsetDb = useMeterDisplaySettingsStore((s) => s.sMeterOffsetDb);
+  const maxDisplayedWatts = useMeterDisplaySettingsStore((s) => s.maxDisplayedWatts);
+  const boardMaxWatts = useRadioStore((s) => s.capabilities.maxPowerWatts);
   const transmitting = moxOn || tunOn;
 
   const swrColor = swr >= 3 ? 'var(--tx)' : swr >= 2 ? 'var(--power)' : 'var(--fg-0)';
@@ -81,6 +87,16 @@ export function SMeterLive({ hideChips = false }: { hideChips?: boolean } = {}) 
   // calibration popover already mutate the store value, so this single
   // sum is the only place the offset enters the render path.
   const displayedDbm = rxDbm + sMeterOffsetDb;
+
+  // TX meter full scale: operator override wins; otherwise fall back to
+  // the radio's rated MaxWatts (via /api/capabilities); 100 W is the
+  // historical fallback when neither is available.
+  const ratedMaxWatts =
+    maxDisplayedWatts > 0
+      ? maxDisplayedWatts
+      : boardMaxWatts > 0
+      ? boardMaxWatts
+      : 100;
 
   return (
     <div
@@ -94,7 +110,7 @@ export function SMeterLive({ hideChips = false }: { hideChips?: boolean } = {}) 
     >
       <div>
         {transmitting ? (
-          <SMeter mode="tx" watts={fwdWatts} maxWatts={100} />
+          <SMeter mode="tx" watts={fwdWatts} maxWatts={ratedMaxWatts} />
         ) : (
           <SMeter mode="rx" dbm={displayedDbm} />
         )}
@@ -125,9 +141,27 @@ export function SMeterLive({ hideChips = false }: { hideChips?: boolean } = {}) 
 function SMeterCalibrationGear() {
   const [open, setOpen] = useState(false);
   const sMeterOffsetDb = useMeterDisplaySettingsStore((s) => s.sMeterOffsetDb);
-  const setLocal = useMeterDisplaySettingsStore((s) => s.setSMeterOffsetDbLocal);
-  const persist = useMeterDisplaySettingsStore((s) => s.persistSMeterOffsetDb);
-  const inputRef = useRef<HTMLInputElement | null>(null);
+  const setOffsetLocal = useMeterDisplaySettingsStore((s) => s.setSMeterOffsetDbLocal);
+  const persistOffset = useMeterDisplaySettingsStore((s) => s.persistSMeterOffsetDb);
+  const maxDisplayedWatts = useMeterDisplaySettingsStore((s) => s.maxDisplayedWatts);
+  const setMaxWattsLocal = useMeterDisplaySettingsStore((s) => s.setMaxDisplayedWattsLocal);
+  const persistMaxWatts = useMeterDisplaySettingsStore((s) => s.persistMaxDisplayedWatts);
+  const boardMaxWatts = useRadioStore((s) => s.capabilities.maxPowerWatts);
+  const offsetRef = useRef<HTMLInputElement | null>(null);
+  const maxWattsRef = useRef<HTMLInputElement | null>(null);
+  // Inputs show empty when "no override" — keeps the placeholder
+  // (the radio's rated MaxWatts) visible until the operator types.
+  const [maxWattsDraft, setMaxWattsDraft] = useState<string>(
+    maxDisplayedWatts > 0 ? String(maxDisplayedWatts) : '',
+  );
+
+  // Keep the draft in sync with hydration / external changes (e.g. another
+  // device updates the store). Skip resync while the input is focused so
+  // we don't yank what the operator is typing.
+  useEffect(() => {
+    if (document.activeElement === maxWattsRef.current) return;
+    setMaxWattsDraft(maxDisplayedWatts > 0 ? String(maxDisplayedWatts) : '');
+  }, [maxDisplayedWatts]);
 
   return (
     <>
@@ -197,7 +231,7 @@ function SMeterCalibrationGear() {
           >
             <span>Offset (dB)</span>
             <input
-              ref={inputRef}
+              ref={offsetRef}
               type="number"
               step={0.5}
               min={SMETER_OFFSET_MIN_DB}
@@ -205,39 +239,107 @@ function SMeterCalibrationGear() {
               value={sMeterOffsetDb}
               onChange={(e) => {
                 const v = parseFloat(e.target.value);
-                if (Number.isFinite(v)) setLocal(v);
+                if (Number.isFinite(v)) setOffsetLocal(v);
               }}
               onBlur={() => {
-                void persist(sMeterOffsetDb);
+                void persistOffset(sMeterOffsetDb);
               }}
               onKeyDown={(e) => {
                 if (e.key === 'Enter') {
                   e.preventDefault();
-                  inputRef.current?.blur();
+                  offsetRef.current?.blur();
                   setOpen(false);
                 } else if (e.key === 'Escape') {
                   setOpen(false);
                 }
               }}
-              style={{
-                width: 70,
-                background: 'var(--bg-0)',
-                color: 'var(--fg-0)',
-                border: '1px solid var(--line-strong)',
-                borderRadius: 3,
-                padding: '2px 6px',
-                fontFamily: 'inherit',
-                fontSize: 11,
-                textAlign: 'right',
-              }}
+              style={inputStyle}
             />
           </label>
-          <div style={{ color: 'var(--fg-3)', fontSize: 10, lineHeight: 1.3 }}>
+          <div style={hintStyle}>
             Trim ±{SMETER_OFFSET_MAX_DB} dB on the displayed RX signal.
             Does not affect the radio.
+          </div>
+
+          <div style={{ height: 1, background: 'var(--line-soft)', margin: '4px 0' }} />
+
+          <div
+            style={{
+              color: 'var(--fg-2)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.08em',
+              fontSize: 10,
+            }}
+          >
+            TX meter full scale
+          </div>
+          <label
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 8,
+              color: 'var(--fg-1)',
+            }}
+          >
+            <span>Max watts</span>
+            <input
+              ref={maxWattsRef}
+              type="number"
+              step={1}
+              min={MAX_DISPLAYED_WATTS_MIN}
+              max={MAX_DISPLAYED_WATTS_MAX}
+              value={maxWattsDraft}
+              placeholder={boardMaxWatts > 0 ? String(boardMaxWatts) : '100'}
+              onChange={(e) => {
+                const raw = e.target.value;
+                setMaxWattsDraft(raw);
+                if (raw === '') {
+                  setMaxWattsLocal(0);
+                  return;
+                }
+                const v = parseFloat(raw);
+                if (Number.isFinite(v)) setMaxWattsLocal(v);
+              }}
+              onBlur={() => {
+                void persistMaxWatts(maxDisplayedWatts);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  maxWattsRef.current?.blur();
+                  setOpen(false);
+                } else if (e.key === 'Escape') {
+                  setOpen(false);
+                }
+              }}
+              style={inputStyle}
+            />
+          </label>
+          <div style={hintStyle}>
+            Empty = use the radio's rated power. Set lower (e.g. 25 W
+            on a 100 W radio) to fill the bar.
           </div>
         </div>
       )}
     </>
   );
 }
+
+const inputStyle: CSSProperties = {
+  width: 70,
+  background: 'var(--bg-0)',
+  color: 'var(--fg-0)',
+  border: '1px solid var(--line-strong)',
+  borderRadius: 3,
+  padding: '2px 6px',
+  fontFamily: 'inherit',
+  fontSize: 11,
+  textAlign: 'right',
+};
+
+const hintStyle: CSSProperties = {
+  color: 'var(--fg-3)',
+  fontSize: 10,
+  lineHeight: 1.3,
+};

--- a/zeus-web/src/components/SMeterLive.tsx
+++ b/zeus-web/src/components/SMeterLive.tsx
@@ -42,8 +42,14 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
+import { useRef, useState } from 'react';
 import { SMeter } from './SMeter';
 import { useTxStore } from '../state/tx-store';
+import { useMeterDisplaySettingsStore } from '../state/meter-display-settings-store';
+import {
+  SMETER_OFFSET_MIN_DB,
+  SMETER_OFFSET_MAX_DB,
+} from '../api/meter-display-settings';
 
 // Replaces SMeterDemo's animated harness with real tx-store telemetry. The
 // SMeter component itself is unchanged (discriminated-union presentation
@@ -65,19 +71,35 @@ export function SMeterLive({ hideChips = false }: { hideChips?: boolean } = {}) 
   const swr = useTxStore((s) => s.swr);
   const micDbfs = useTxStore((s) => s.micDbfs);
   const rxDbm = useTxStore((s) => s.rxDbm);
+  const sMeterOffsetDb = useMeterDisplaySettingsStore((s) => s.sMeterOffsetDb);
   const transmitting = moxOn || tunOn;
 
   const swrColor = swr >= 3 ? 'var(--tx)' : swr >= 2 ? 'var(--power)' : 'var(--fg-0)';
 
+  // S-meter offset is a pure display trim — added on top of the dBm the
+  // server pushes. It does not touch WDSP or the radio. Live edits in the
+  // calibration popover already mutate the store value, so this single
+  // sum is the only place the offset enters the render path.
+  const displayedDbm = rxDbm + sMeterOffsetDb;
+
   return (
-    <div style={{ padding: 10, display: 'flex', flexDirection: 'column', gap: 8 }}>
+    <div
+      style={{
+        padding: 10,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+        position: 'relative',
+      }}
+    >
       <div>
         {transmitting ? (
           <SMeter mode="tx" watts={fwdWatts} maxWatts={100} />
         ) : (
-          <SMeter mode="rx" dbm={rxDbm} />
+          <SMeter mode="rx" dbm={displayedDbm} />
         )}
       </div>
+      <SMeterCalibrationGear />
       {transmitting && !hideChips && (
         <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end' }}>
           <span className="chip mono">
@@ -93,5 +115,129 @@ export function SMeterLive({ hideChips = false }: { hideChips?: boolean } = {}) 
         </div>
       )}
     </div>
+  );
+}
+
+// Discreet calibration affordance — a gear glyph in the meter panel's
+// top-right corner. Click to reveal a single numeric trim. Aesthetic
+// follows existing chip / popover patterns: muted text, panel-bg fill,
+// `--line` border, `--accent` ring on focus. No bespoke palette.
+function SMeterCalibrationGear() {
+  const [open, setOpen] = useState(false);
+  const sMeterOffsetDb = useMeterDisplaySettingsStore((s) => s.sMeterOffsetDb);
+  const setLocal = useMeterDisplaySettingsStore((s) => s.setSMeterOffsetDbLocal);
+  const persist = useMeterDisplaySettingsStore((s) => s.persistSMeterOffsetDb);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label="Meter calibration"
+        title="Meter calibration"
+        onClick={() => setOpen((v) => !v)}
+        style={{
+          position: 'absolute',
+          top: 4,
+          right: 4,
+          width: 18,
+          height: 18,
+          padding: 0,
+          background: 'transparent',
+          border: 'none',
+          color: open ? 'var(--accent-bright)' : 'var(--fg-3)',
+          cursor: 'pointer',
+          fontSize: 12,
+          lineHeight: '18px',
+          textAlign: 'center',
+        }}
+      >
+        {/* unicode gear — discreet, no SVG asset needed */}
+        {'⚙'}
+      </button>
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Meter calibration"
+          style={{
+            position: 'absolute',
+            top: 24,
+            right: 4,
+            zIndex: 20,
+            background: 'var(--bg-1)',
+            border: '1px solid var(--line)',
+            borderRadius: 4,
+            padding: '8px 10px',
+            boxShadow: '0 4px 12px rgba(0,0,0,0.45)',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 6,
+            minWidth: 180,
+            fontSize: 11,
+          }}
+        >
+          <div
+            style={{
+              color: 'var(--fg-2)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.08em',
+              fontSize: 10,
+            }}
+          >
+            S-Meter calibration
+          </div>
+          <label
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 8,
+              color: 'var(--fg-1)',
+            }}
+          >
+            <span>Offset (dB)</span>
+            <input
+              ref={inputRef}
+              type="number"
+              step={0.5}
+              min={SMETER_OFFSET_MIN_DB}
+              max={SMETER_OFFSET_MAX_DB}
+              value={sMeterOffsetDb}
+              onChange={(e) => {
+                const v = parseFloat(e.target.value);
+                if (Number.isFinite(v)) setLocal(v);
+              }}
+              onBlur={() => {
+                void persist(sMeterOffsetDb);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  inputRef.current?.blur();
+                  setOpen(false);
+                } else if (e.key === 'Escape') {
+                  setOpen(false);
+                }
+              }}
+              style={{
+                width: 70,
+                background: 'var(--bg-0)',
+                color: 'var(--fg-0)',
+                border: '1px solid var(--line-strong)',
+                borderRadius: 3,
+                padding: '2px 6px',
+                fontFamily: 'inherit',
+                fontSize: 11,
+                textAlign: 'right',
+              }}
+            />
+          </label>
+          <div style={{ color: 'var(--fg-3)', fontSize: 10, lineHeight: 1.3 }}>
+            Trim ±{SMETER_OFFSET_MAX_DB} dB on the displayed RX signal.
+            Does not affect the radio.
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/zeus-web/src/components/TunePowerSlider.tsx
+++ b/zeus-web/src/components/TunePowerSlider.tsx
@@ -19,18 +19,18 @@
 // (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
 // Both are GPL-2.0-or-later.
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import { setTuneDrive } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
 import { useTxStore } from '../state/tx-store';
 import { usePaStore } from '../state/pa-store';
+import { useLiveSlider } from '../hooks/useLiveSlider';
 
-// Same 0..100 range and debounce shape as DriveSlider; the backend picks
-// between the two sources based on TUN keying state so the UX/wire are
+// Same 0..100 range and stream-during-drag shape as DriveSlider; the backend
+// picks between the two sources based on TUN keying state so the UX/wire are
 // symmetric.
 const MIN = 0;
 const MAX = 100;
-const DEBOUNCE_MS = 100;
 
 export function TunePowerSlider() {
   const connected = useConnectionStore((s) => s.status === 'Connected');
@@ -40,39 +40,27 @@ export function TunePowerSlider() {
   const paMaxWatts = usePaStore((s) => s.settings.global.paMaxPowerWatts);
   const targetWatts = paMaxWatts > 0 ? Math.round((paMaxWatts * tunePercent) / 100) : null;
 
-  const inflightAbort = useRef<AbortController | null>(null);
-  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const lastSent = useRef<number>(tunePercent);
   const previousOnError = useRef<number>(tunePercent);
 
-  const sendDebounced = useCallback((v: number) => {
-    if (debounceTimer.current != null) clearTimeout(debounceTimer.current);
-    debounceTimer.current = setTimeout(() => {
-      if (v === lastSent.current) return;
-      inflightAbort.current?.abort();
-      const ac = new AbortController();
-      inflightAbort.current = ac;
-      const prevValue = lastSent.current;
-      lastSent.current = v;
-      previousOnError.current = prevValue;
-      setTuneDrive(v, ac.signal)
-        .then((r) => {
-          if (ac.signal.aborted) return;
-          if (r.tunePercent !== v) setTunePercent(r.tunePercent);
-        })
-        .catch((err) => {
-          if (ac.signal.aborted) return;
-          if (err instanceof DOMException && err.name === 'AbortError') return;
-          setTunePercent(previousOnError.current);
-          lastSent.current = previousOnError.current;
-        });
-    }, DEBOUNCE_MS);
-  }, [setTunePercent]);
-
-  useEffect(() => () => {
-    inflightAbort.current?.abort();
-    if (debounceTimer.current != null) clearTimeout(debounceTimer.current);
-  }, []);
+  const liveSlider = useLiveSlider<number>({
+    send: useCallback(
+      (v: number, signal: AbortSignal) => {
+        const prevValue = previousOnError.current;
+        return setTuneDrive(v, signal)
+          .then((r) => {
+            if (signal.aborted) return;
+            previousOnError.current = r.tunePercent;
+            if (r.tunePercent !== v) setTunePercent(r.tunePercent);
+          })
+          .catch((err) => {
+            if (signal.aborted) return;
+            if (err instanceof DOMException && err.name === 'AbortError') return;
+            setTunePercent(prevValue);
+          });
+      },
+      [setTunePercent],
+    ),
+  });
 
   // Server is authoritative for tunePercent (StateDto.TunePct, persisted via
   // RadioStateStore, hydrated into tx-store on every fresh RadioStateDto).
@@ -82,7 +70,7 @@ export function TunePowerSlider() {
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const v = Number(e.currentTarget.value);
     setTunePercent(v);
-    sendDebounced(v);
+    liveSlider.push(v);
   };
 
   return (
@@ -96,6 +84,9 @@ export function TunePowerSlider() {
         value={tunePercent}
         disabled={!connected}
         onChange={onChange}
+        onMouseUp={() => liveSlider.flush()}
+        onTouchEnd={() => liveSlider.flush()}
+        onKeyUp={() => liveSlider.flush()}
         style={{ flex: 1, cursor: 'pointer', accentColor: 'var(--accent)' }}
       />
       <span

--- a/zeus-web/src/components/VfoDisplay.tsx
+++ b/zeus-web/src/components/VfoDisplay.tsx
@@ -53,6 +53,7 @@ import {
 } from 'react';
 import { fetchState, setVfo } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import { useDisplayStore } from '../state/display-store';
 
 const MAX_HZ = 60_000_000;
 const STATE_POLL_MS = 2000;
@@ -157,6 +158,9 @@ export function VfoDisplay() {
     setDraft('');
     if (next == null || next === vfoHz) return;
     useConnectionStore.setState({ vfoHz: next });
+    // Typed-frequency commit is an explicit tune-to-frequency action per
+    // the pure-pan PRD; reset any held viewport offset.
+    useDisplayStore.getState().setViewportOffsetHz(0);
     setVfo(next)
       .then(applyState)
       .catch(() => {

--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -74,20 +74,23 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
   const colormap = useDisplaySettingsStore((s) => s.colormap);
   const setColormap = useDisplaySettingsStore((s) => s.setColormap);
   // Tuning-cursor position. The waterfall canvas centres on the radio's
-  // hardware NCO (centerHz) which equals VfoHz outside CTUN — so on the
-  // legacy path the cursor sits at 50%. With CTUN on the hardware stays
-  // frozen at RadioLoHz while VfoHz roams; the cursor must track the dial
-  // (VfoHz) so the operator can see where they're listening, not where the
-  // radio is anchored. Computed off panDb width × hzPerPixel for span,
-  // identical math to FreqAxis's dial marker. Issue #427.
+  // hardware NCO (centerHz / radioLoHz) while VfoHz roams independently; the
+  // cursor must track the dial (VfoHz) so the operator can see where they're
+  // listening, not where the radio is anchored. Computed off panDb width ×
+  // hzPerPixel for span, identical math to FreqAxis's dial marker.
   const cursorCenterHz = useDisplayStore((s) => s.centerHz);
   const cursorHzPerPixel = useDisplayStore((s) => s.hzPerPixel);
   const cursorWidth = useDisplayStore((s) => s.panDb?.length ?? 0);
+  const cursorViewportOffsetHz = useDisplayStore((s) => s.viewportOffsetHz);
   const cursorVfoHz = useConnectionStore((s) => s.vfoHz);
   const cursorPct = (() => {
     if (!cursorWidth || cursorHzPerPixel <= 0) return 50;
     const span = cursorWidth * cursorHzPerPixel;
-    const start = Number(cursorCenterHz) - span / 2;
+    // Viewport centre = hardware NCO + pure-pan offset; cursor sits at the
+    // dial's position relative to the shifted viewport, so a drag-right
+    // (negative offset) slides the cursor right with the rest of the
+    // spectrum.
+    const start = Number(cursorCenterHz) + cursorViewportOffsetHz - span / 2;
     return ((cursorVfoHz - start) / span) * 100;
   })();
 
@@ -131,7 +134,14 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       // window so the operator's RX noise-floor view stays put.
       const dbMin = keyed ? wfTxDbMin : wfDbMin;
       const dbMax = keyed ? wfTxDbMax : wfDbMax;
-      renderer.draw(dbMin, dbMax);
+      // Translate the viewport-offset Hz into the shader's UV space. Inside
+      // the IQ window (offset bounded by spanHz/2) WF_FS samples normally;
+      // past the edge the seed-dB fallback fills the unsampled columns.
+      const display = useDisplayStore.getState();
+      const width = display.panDb?.length ?? 0;
+      const spanHz = width > 0 ? width * display.hzPerPixel : 0;
+      const viewportOffsetUv = spanHz > 0 ? display.viewportOffsetHz / spanHz : 0;
+      renderer.draw(dbMin, dbMax, viewportOffsetUv);
     };
     const requestRedraw = () => {
       if (!isActive()) return;
@@ -227,10 +237,20 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       }
     });
 
+    // Repaint when the operator drags the panadapter/waterfall viewport. A
+    // pure-pan drag mutates viewportOffsetHz at rAF rate; redraw the shader
+    // each tick so the texture sample window slides under the finger.
+    const unsubViewport = useDisplayStore.subscribe((state, prev) => {
+      if (state.viewportOffsetHz !== prev.viewportOffsetHz) {
+        requestRedraw();
+      }
+    });
+
     return () => {
       unsub();
       unsubSettings();
       unsubTx();
+      unsubViewport();
       ro.disconnect();
       io.disconnect();
       document.removeEventListener('visibilitychange', onVisibilityChange);

--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -42,13 +42,18 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { COLORMAPS } from '../gl/colormap';
 import { createWfRenderer } from '../gl/waterfall';
 import { cancelDrawBusFrame, requestDrawBusFrame } from '../realtime/draw-bus';
 import { useConnectionStore } from '../state/connection-store';
 import { registerFrameConsumer, useDisplayStore } from '../state/display-store';
-import { useDisplaySettingsStore } from '../state/display-settings-store';
+import {
+  useDisplaySettingsStore,
+  WF_BRIGHTNESS_DEFAULT,
+  WF_BRIGHTNESS_MAX,
+  WF_BRIGHTNESS_MIN,
+} from '../state/display-settings-store';
 import { useTxStore } from '../state/tx-store';
 import { usePanTuneGesture } from '../util/use-pan-tune-gesture';
 import { WfDbScale } from './WfDbScale';
@@ -69,10 +74,28 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const rendererRef = useRef<ReturnType<typeof createWfRenderer> | null>(null);
+  // Live brightness ref — read by the WebGL draw closure each frame. We
+  // can't put dragBrightness in the render closure directly because the
+  // useEffect that builds the closure runs once on mount; instead we mutate
+  // a ref so the closure always sees the current value (committed store
+  // value while idle, in-flight drag value while the slider is moving).
+  const liveBrightnessRef = useRef<number>(WF_BRIGHTNESS_DEFAULT);
+  const requestRedrawRef = useRef<() => void>(() => {});
   const autoRange = useDisplaySettingsStore((s) => s.autoRange);
   const setAutoRange = useDisplaySettingsStore((s) => s.setAutoRange);
   const colormap = useDisplaySettingsStore((s) => s.colormap);
   const setColormap = useDisplaySettingsStore((s) => s.setColormap);
+  // Brightness slider state. Live drag value is held locally so the input
+  // remains responsive at native HTMLInputElement update rate; the committed
+  // store value is set on release (mouseup / touchend / keyup) at which
+  // point the store schedules a debounced PUT. Mirrors AfGainSlider's
+  // "stream during drag, flush on release" pattern but for a non-realtime
+  // (purely-cosmetic) setting where streaming to the server would just churn
+  // writes; we only commit once.
+  const committedBrightness = useDisplaySettingsStore((s) => s.wfBrightness);
+  const setWfBrightness = useDisplaySettingsStore((s) => s.setWfBrightness);
+  const [dragBrightness, setDragBrightness] = useState<number | null>(null);
+  const brightnessValue = dragBrightness ?? committedBrightness;
   // Tuning-cursor position. The waterfall canvas centres on the radio's
   // hardware NCO (centerHz / radioLoHz) while VfoHz roams independently; the
   // cursor must track the dial (VfoHz) so the operator can see where they're
@@ -141,7 +164,7 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       const width = display.panDb?.length ?? 0;
       const spanHz = width > 0 ? width * display.hzPerPixel : 0;
       const viewportOffsetUv = spanHz > 0 ? display.viewportOffsetHz / spanHz : 0;
-      renderer.draw(dbMin, dbMax, viewportOffsetUv);
+      renderer.draw(dbMin, dbMax, viewportOffsetUv, liveBrightnessRef.current);
     };
     const requestRedraw = () => {
       if (!isActive()) return;
@@ -150,6 +173,9 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       // matching the prior `if (rafHandle === 0)` gate.
       requestDrawBusFrame(redraw);
     };
+    // Expose requestRedraw so the brightness-drag effect outside this
+    // useEffect can ask for a repaint without rebuilding the GL closure.
+    requestRedrawRef.current = requestRedraw;
 
     const resize = () => {
       const { width, height } = container.getBoundingClientRect();
@@ -223,6 +249,14 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       ) {
         requestRedraw();
       }
+      if (state.wfBrightness !== prev.wfBrightness) {
+        // Drag-time updates flow via liveBrightnessRef + the dragBrightness
+        // effect below. This branch catches store-level commits — late
+        // hydration from the server, restoring a non-default value on
+        // first paint, etc.
+        liveBrightnessRef.current = state.wfBrightness;
+        requestRedraw();
+      }
     });
 
     // Repaint when MOX/TUN flips so the RX↔TX waterfall window swap lands
@@ -267,6 +301,16 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
   useEffect(() => {
     rendererRef.current?.setTransparent(transparent);
   }, [transparent]);
+
+  // Live-preview drag: whenever the local drag value moves, push it into the
+  // ref the WebGL closure reads and ask for a redraw. On release the slider
+  // commits to the store and the existing subscription above takes over —
+  // this effect quiets once dragBrightness goes back to null because
+  // brightnessValue then equals the committed store value (no change).
+  useEffect(() => {
+    liveBrightnessRef.current = brightnessValue;
+    requestRedrawRef.current();
+  }, [brightnessValue]);
 
   usePanTuneGesture(canvasRef);
 
@@ -320,6 +364,73 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
         >
           {autoRange ? 'dB: AUTO' : 'dB: FIXED'}
         </button>
+        {/* Brightness slider — issue #426. Live drag previews (the
+            dragBrightness effect repaints each input change) but only the
+            release commits to the store + persists. Double-click resets to
+            1.0 (no change). */}
+        <label
+          className="knob-group"
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 4,
+            background: 'rgba(0,0,0,0.45)',
+            border: '1px solid var(--line)',
+            borderRadius: 'var(--r-sm)',
+            padding: '2px 6px',
+            height: 22,
+          }}
+          title="Waterfall brightness (double-click to reset)"
+        >
+          <span
+            className="label-xs"
+            style={{
+              fontSize: 9,
+              letterSpacing: '0.12em',
+              color: 'var(--fg-2)',
+              textTransform: 'uppercase',
+            }}
+          >
+            BRT
+          </span>
+          <input
+            type="range"
+            min={WF_BRIGHTNESS_MIN}
+            max={WF_BRIGHTNESS_MAX}
+            step={0.05}
+            value={brightnessValue}
+            aria-label="Waterfall brightness"
+            onChange={(e) => setDragBrightness(Number(e.currentTarget.value))}
+            onMouseUp={() => {
+              if (dragBrightness !== null) setWfBrightness(dragBrightness);
+              setDragBrightness(null);
+            }}
+            onTouchEnd={() => {
+              if (dragBrightness !== null) setWfBrightness(dragBrightness);
+              setDragBrightness(null);
+            }}
+            onKeyUp={() => {
+              if (dragBrightness !== null) setWfBrightness(dragBrightness);
+              setDragBrightness(null);
+            }}
+            onDoubleClick={() => {
+              setDragBrightness(null);
+              setWfBrightness(WF_BRIGHTNESS_DEFAULT);
+            }}
+            style={{ width: 70, cursor: 'pointer', accentColor: 'var(--accent)' }}
+          />
+          <span
+            className="mono"
+            style={{
+              width: 30,
+              textAlign: 'right',
+              color: 'var(--fg-1)',
+              fontSize: 10,
+            }}
+          >
+            {brightnessValue.toFixed(2)}
+          </span>
+        </label>
       </div>
     </div>
   );

--- a/zeus-web/src/components/ZoomControl.tsx
+++ b/zeus-web/src/components/ZoomControl.tsx
@@ -42,9 +42,10 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback } from 'react';
 import { setZoom, ZOOM_MAX, ZOOM_MIN, type ZoomLevel } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import { useLiveSlider } from '../hooks/useLiveSlider';
 
 // Compact zoom slider styled as a panel-head chip. Lives in the hero
 // tile header (above the panadapter) so the operator always sees the
@@ -63,29 +64,31 @@ export function ZoomControl() {
   const applyState = useConnectionStore((s) => s.applyState);
   const connected = useConnectionStore((s) => s.status === 'Connected');
 
-  const inflightAbort = useRef<AbortController | null>(null);
-  const latestSent = useRef<ZoomLevel>(serverZoom);
+  // rAF-coalesced live stream — keeps the panadapter zoom tracking the thumb
+  // during a fast drag while capping POSTs to one per paint (zoom triggers a
+  // backend panadapter recompute, so flooding is real if onChange ever fires
+  // faster than rAF).
+  const liveSlider = useLiveSlider<ZoomLevel>({
+    send: useCallback(
+      (v: ZoomLevel, signal: AbortSignal) =>
+        setZoom(v, signal)
+          .then((next) => {
+            if (!signal.aborted) applyState(next);
+          })
+          .catch(() => {
+            /* next state poll will reconcile */
+          }),
+      [applyState],
+    ),
+  });
 
-  const sendValue = useCallback(
+  const onSlide = useCallback(
     (v: ZoomLevel) => {
-      if (v === latestSent.current) return;
-      latestSent.current = v;
       setLocalZoom(v);
-      inflightAbort.current?.abort();
-      const ac = new AbortController();
-      inflightAbort.current = ac;
-      setZoom(v, ac.signal)
-        .then((next) => {
-          if (!ac.signal.aborted) applyState(next);
-        })
-        .catch(() => {
-          /* next state poll will reconcile */
-        });
+      liveSlider.push(v);
     },
-    [applyState, setLocalZoom],
+    [liveSlider, setLocalZoom],
   );
-
-  useEffect(() => () => inflightAbort.current?.abort(), []);
 
   return (
     <label
@@ -109,7 +112,10 @@ export function ZoomControl() {
         step={1}
         value={serverZoom}
         disabled={!connected}
-        onChange={(e) => sendValue(Number(e.currentTarget.value) as ZoomLevel)}
+        onChange={(e) => onSlide(Number(e.currentTarget.value) as ZoomLevel)}
+        onMouseUp={() => liveSlider.flush()}
+        onTouchEnd={() => liveSlider.flush()}
+        onKeyUp={() => liveSlider.flush()}
         aria-label="Zoom level"
         style={{
           width: 90,

--- a/zeus-web/src/components/design/CwKeyer.tsx
+++ b/zeus-web/src/components/design/CwKeyer.tsx
@@ -1,74 +1,253 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 //
 // Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
-// Copyright (C) 2025-2026 Brian Keating (EI6LF),
-//                         Douglas J. Cerrato (KB2UKA), and contributors.
-//
-// This program is free software: you can redistribute it and/or modify it
-// under the terms of the GNU General Public License as published by the
-// Free Software Foundation, either version 2 of the License, or (at your
-// option) any later version. See the LICENSE file at the root of this
-// repository for the full text, or https://www.gnu.org/licenses/.
-//
-// Zeus is an independent reimplementation in .NET — not a fork. Its
-// Protocol-1 / Protocol-2 framing, WDSP integration, meter pipelines, and
-// TX behaviour were informed by studying the Thetis project
-// (https://github.com/ramdor/Thetis), the authoritative reference
-// implementation in the OpenHPSDR ecosystem. Zeus gratefully acknowledges
-// the Thetis contributors whose work made this possible:
-//
-//   Richard Samphire (MW0LGE), Warren Pratt (NR0V),
-//   Laurence Barker (G8NJJ),   Rick Koch (N1GP),
-//   Bryan Rambo (W4WMT),       Chris Codella (W2PA),
-//   Doug Wigley (W5WC),        FlexRadio Systems,
-//   Richard Allen (W5SD),      Joe Torrey (WD5Y),
-//   Andrew Mansfield (M0YGG),  Reid Campbell (MI0BOT),
-//   Sigi Jetzlsperger (DH1KLM).
-//
-// Thetis itself continues the GPL-governed lineage of FlexRadio PowerSDR
-// and the OpenHPSDR (TAPR/OpenHPSDR) ecosystem; that lineage is preserved
-// here. See ATTRIBUTIONS.md at the repository root for the full provenance
-// statement and per-component attribution.
-//
-// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
-// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
-// Wüllen (DL1YCF); and by DeskHPSDR
-// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
-// Both are GPL-2.0-or-later.
-//
-// WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
-// (NR0V), distributed under GPL v2 or later.
-//
-// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
-// License for details.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
 
-import { Slider } from './Slider';
+import { useState } from 'react';
+import type { CwEngineStatus } from '../../state/cw-store';
 
-type CwKeyerProps = {
+export type CwKeyerProps = {
   wpm: number;
-  setWpm: (v: number) => void;
-  onSend?: (macro: string) => void;
+  /** Tracks the slider while dragging — local-only, no PUT. */
+  setWpmLocal: (v: number) => void;
+  /** Schedules the server save after the operator stops moving. */
+  setWpmCommit: (v: number) => void;
+  macros: string[];
+  onSend: (macro: string) => void;
+  onAbort: () => void;
+  onMacroEdit: (index: number, value: string) => void;
+  onMacroDelete: (index: number) => void;
+  onMacroAdd: () => void;
+  /** Hard cap from the backend — disables the Add button at the limit. */
+  maxMacros: number;
+  /** Live engine status from the WS hub. Idle when nothing in flight. */
+  status: CwEngineStatus;
 };
 
-const MACROS = ['CQ CQ CQ', 'TU 73', 'QRZ?', 'AGN?', '5NN TU', 'UR RST'];
+const WPM_MIN = 5;
+const WPM_MAX = 40;
 
-export function CwKeyer({ wpm, setWpm, onSend }: CwKeyerProps) {
+export function CwKeyer({
+  wpm,
+  setWpmLocal,
+  setWpmCommit,
+  macros,
+  onSend,
+  onAbort,
+  onMacroEdit,
+  onMacroDelete,
+  onMacroAdd,
+  maxMacros,
+  status,
+}: CwKeyerProps) {
+  // Index of the macro slot currently in edit mode. null = no inline
+  // editor open. The editor is opened by clicking the ✎ icon next to a
+  // slot; click elsewhere or press Enter/Esc to close.
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  const [editDraft, setEditDraft] = useState<string>('');
+
+  const isSending = status.state === 'sending' || status.state === 'stopping';
+  const atMacroLimit = macros.length >= maxMacros;
+
+  const startEditing = (index: number, current: string) => {
+    setEditDraft(current);
+    setEditingIndex(index);
+  };
+
+  const commitEdit = (index: number) => {
+    if (editDraft !== macros[index]) onMacroEdit(index, editDraft);
+    setEditingIndex(null);
+  };
+
   return (
-    <div className="cw">
-      <div className="cw-row">
-        <Slider label="WPM" value={wpm} onChange={setWpm} min={5} max={40} />
+    <div className="cw cw-console">
+      <CwStream status={status} />
+
+      <div className="cw-control-strip">
+        <div className={`cw-wpm-readout ${isSending ? 'is-active' : ''}`}>
+          <span className="cw-wpm-label">WPM</span>
+          <span className="cw-wpm-value mono">{wpm}</span>
+        </div>
+        <div className="cw-wpm-track">
+          <input
+            type="range"
+            min={WPM_MIN}
+            max={WPM_MAX}
+            step={1}
+            value={wpm}
+            onChange={(e) => {
+              const v = Number(e.currentTarget.value);
+              setWpmLocal(v);
+              setWpmCommit(v);
+            }}
+            aria-label="Words per minute"
+          />
+          <div className="cw-wpm-scale">
+            <span>{WPM_MIN}</span>
+            <span>{WPM_MAX}</span>
+          </div>
+        </div>
+        <button
+          type="button"
+          className={`cw-stop ${isSending ? 'is-armed' : ''}`}
+          onClick={onAbort}
+          disabled={!isSending}
+          title="Abort current transmission and drain queue"
+          aria-label="STOP"
+        >
+          STOP
+        </button>
       </div>
-      <div className="cw-macros">
-        {MACROS.map((m) => (
-          <button key={m} type="button" className="btn sm" onClick={() => onSend?.(m)}>
-            {m}
-          </button>
+
+      <div className="cw-macro-list" role="list">
+        {macros.map((m, i) => (
+          <div key={i} className="cw-macro-row" role="listitem">
+            <span className="cw-macro-num mono" aria-hidden="true">
+              {String(i + 1).padStart(2, '0')}
+            </span>
+            {editingIndex === i ? (
+              <input
+                className="cw-macro-edit"
+                autoFocus
+                value={editDraft}
+                onChange={(e) => setEditDraft(e.target.value)}
+                onBlur={() => commitEdit(i)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') e.currentTarget.blur();
+                  else if (e.key === 'Escape') setEditingIndex(null);
+                }}
+              />
+            ) : (
+              <button
+                type="button"
+                className={`cw-macro-send ${m === '' ? 'is-empty' : ''}`}
+                onClick={() => m !== '' && onSend(m)}
+                disabled={m === ''}
+                title={m === '' ? 'Empty slot — edit to set' : `Send "${m}"`}
+              >
+                {m === '' ? <em>empty — edit me</em> : m}
+              </button>
+            )}
+            <button
+              type="button"
+              className="cw-macro-icon"
+              onClick={() => startEditing(i, m)}
+              title="Edit macro"
+              aria-label={`Edit macro ${i + 1}`}
+            >
+              <EditGlyph />
+            </button>
+            <button
+              type="button"
+              className="cw-macro-icon is-danger"
+              onClick={() => onMacroDelete(i)}
+              title="Delete macro"
+              aria-label={`Delete macro ${i + 1}`}
+            >
+              <DeleteGlyph />
+            </button>
+          </div>
         ))}
-      </div>
-      <div className="cw-stream mono">
-        <span className="cw-cursor">▮</span>
-        <span style={{ color: 'var(--fg-2)' }}>·  — ·  — · — ·  · — · ·  — — —</span>
+        <button
+          type="button"
+          className="cw-macro-add"
+          onClick={onMacroAdd}
+          disabled={atMacroLimit}
+          title={atMacroLimit ? `Maximum ${maxMacros} macros reached` : 'Add a new macro slot'}
+        >
+          <span className="cw-macro-add-plus" aria-hidden="true">+</span>
+          <span className="cw-macro-add-label">
+            {atMacroLimit ? `LIMIT — ${maxMacros} macros` : 'ADD MACRO'}
+          </span>
+        </button>
       </div>
     </div>
+  );
+}
+
+/* ---- Stream display (HERO) ----
+ * Renders what's being keyed right now as a "telegraph tape" across the
+ * top of the panel. Always present (no layout shift on idle ↔ sending);
+ * a small LED + state label on the left and a queue-depth chip on the
+ * right; the centre carries the live text with a JetBrains-Mono cursor
+ * estimated from elapsed-time × WPM. Server only emits status frames on
+ * state edges, so per-character animation has to be reconstructed
+ * client-side.
+ */
+function CwStream({ status }: { status: CwEngineStatus }) {
+  const [nowMs, setNowMs] = useState<number>(() => Date.now());
+  const active = status.state === 'sending' || status.state === 'stopping';
+  if (active) {
+    requestAnimationFrame(() => setNowMs(Date.now()));
+  }
+
+  const unitMs = status.wpm > 0 ? 1200 / status.wpm : 60;
+  const elapsedMs = Math.max(0, nowMs - status.receivedAtMs);
+  const charIdx = active
+    ? Math.min(status.text.length, Math.floor(elapsedMs / (10 * unitMs)))
+    : 0;
+
+  const stateLabel: Record<CwEngineStatus['state'], string> = {
+    idle: 'READY',
+    sending: 'SENDING',
+    stopping: 'STOPPING',
+    aborting: 'ABORTING',
+  };
+
+  return (
+    <div
+      className={`cw-stream-hero ${active ? 'is-active' : 'is-idle'}`}
+      data-state={status.state}
+    >
+      <div className="cw-stream-tag">
+        <span className="cw-stream-led" aria-hidden="true" />
+        <span className="cw-stream-label">{stateLabel[status.state]}</span>
+      </div>
+      <div className="cw-stream-tape mono">
+        {active ? (
+          <>
+            <span className="cw-stream-sent">{status.text.slice(0, charIdx)}</span>
+            <span className="cw-stream-cursor">
+              {status.text.charAt(charIdx) || '▮'}
+            </span>
+            <span className="cw-stream-pending">{status.text.slice(charIdx + 1)}</span>
+          </>
+        ) : (
+          <span className="cw-stream-placeholder">—— STAND BY ——</span>
+        )}
+      </div>
+      <div className="cw-stream-queue mono" aria-live="polite">
+        {status.queueDepth > 0 ? `+${status.queueDepth}` : '·'}
+      </div>
+    </div>
+  );
+}
+
+/* ---- Glyphs ----
+ * Inline SVGs so the icon weight matches Inter at the panel's text size
+ * (Unicode pencil / ✕ were inconsistent across platforms — heavy on macOS,
+ * thin on Linux). 12 px viewport, currentColor stroke so they pick up the
+ * button's text colour for free.
+ */
+function EditGlyph() {
+  return (
+    <svg viewBox="0 0 12 12" width="12" height="12" aria-hidden="true">
+      <path
+        d="M1.5 9.5 L8.5 2.5 L10 4 L3 11 L1 11 L1.5 9.5 Z"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1"
+        strokeLinejoin="round"
+      />
+      <path d="M7.5 3.5 L9 5" fill="none" stroke="currentColor" strokeWidth="1" />
+    </svg>
+  );
+}
+
+function DeleteGlyph() {
+  return (
+    <svg viewBox="0 0 12 12" width="12" height="12" aria-hidden="true">
+      <path d="M2 2 L10 10 M10 2 L2 10" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" />
+    </svg>
   );
 }

--- a/zeus-web/src/components/design/LogbookLive.formatters.test.ts
+++ b/zeus-web/src/components/design/LogbookLive.formatters.test.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// Regression for issue #486: the logbook used to render QSO timestamps
+// in the browser's local timezone, drifting the clock by the user's
+// offset. Ham-radio convention is UTC always — both formatters must pin
+// timeZone:'UTC' regardless of where the operator's browser thinks it
+// is, otherwise an operator in CET would see an 19:30Z QSO logged at
+// "21:30" on a 21:30-wall-clock summer evening.
+
+import { describe, expect, it } from 'vitest';
+import { formatQsoDateUtc, formatQsoTimeUtc } from './LogbookLive';
+
+describe('LogbookLive formatters', () => {
+  // Pick a timestamp where UTC and any plausible local timezone clearly
+  // disagree on the calendar day, so a missing timeZone:'UTC' option
+  // would obviously land on the wrong date and hour.
+  const ISO_LATE_NIGHT_UTC = '2026-05-24T23:30:00Z';
+  const ISO_EARLY_MORNING_UTC = '2026-05-25T01:15:00Z';
+
+  it('formats time as the UTC clock value regardless of the browser TZ', () => {
+    // 23:30 UTC must render as "23:30" everywhere. A CET-summer browser
+    // (UTC+2) would render "01:30" if timeZone:'UTC' were missing.
+    // Time format is digit-only (24h) so this assertion is locale-stable.
+    expect(formatQsoTimeUtc(ISO_LATE_NIGHT_UTC)).toBe('23:30');
+    // Sanity-check a second value to catch a transposed hour/minute fix.
+    expect(formatQsoTimeUtc(ISO_EARLY_MORNING_UTC)).toBe('01:15');
+  });
+
+  it('formats date as the UTC calendar day, not the browser day', () => {
+    // The localised month name differs by environment ("May 24" in en-US,
+    // "24 may" in es-ES, "24 May" in en-GB, …) so we assert against the
+    // reference UTC formatter rather than a hard-coded string. The key
+    // property: format(localTz) === format(UTC) for THIS input only if
+    // the formatter pinned timeZone:'UTC'. The day-number check on top
+    // catches the "shifted to next day" failure mode that timezone bugs
+    // produce on late-night-UTC timestamps.
+    const refLateNight = new Date(ISO_LATE_NIGHT_UTC).toLocaleDateString([], {
+      month: 'short',
+      day: 'numeric',
+      timeZone: 'UTC',
+    });
+    const refEarlyMorning = new Date(ISO_EARLY_MORNING_UTC).toLocaleDateString([], {
+      month: 'short',
+      day: 'numeric',
+      timeZone: 'UTC',
+    });
+    expect(formatQsoDateUtc(ISO_LATE_NIGHT_UTC)).toBe(refLateNight);
+    expect(formatQsoDateUtc(ISO_EARLY_MORNING_UTC)).toBe(refEarlyMorning);
+
+    // Day-number must be 24 (the UTC day) — not 25, which is what a
+    // CET-summer browser would render without timeZone:'UTC'.
+    expect(formatQsoDateUtc(ISO_LATE_NIGHT_UTC)).toMatch(/\b24\b/);
+    expect(formatQsoDateUtc(ISO_EARLY_MORNING_UTC)).toMatch(/\b25\b/);
+  });
+});

--- a/zeus-web/src/components/design/LogbookLive.tsx
+++ b/zeus-web/src/components/design/LogbookLive.tsx
@@ -45,6 +45,37 @@
 import { useEffect } from 'react';
 import { useLoggerStore } from '../../state/logger-store';
 
+// QSO timestamps are stored / exported / uploaded to QRZ in UTC throughout
+// the server stack (Zeus.Server.Hosting/LogService.cs writes DateTime.UtcNow
+// when the client omits a value; QrzService.cs and the ADIF export both
+// pull QsoDateTimeUtc directly). The renderer used to drop into
+// browser-local time via Date.toLocale*String() with no timezone option —
+// which silently shifted the displayed clock for any operator outside
+// UTC. Ham-radio convention is to log + display QSO times in UTC always,
+// so both formatters pin timeZone:'UTC' and the column label carries a
+// "UTC" tag so the operator never has to guess.
+//
+// Exported so the test (LogbookLive.formatters.test.ts) can assert the
+// timezone behaviour without rendering the whole component.
+export function formatQsoTimeUtc(isoString: string): string {
+  const date = new Date(isoString);
+  return date.toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+    timeZone: 'UTC',
+  });
+}
+
+export function formatQsoDateUtc(isoString: string): string {
+  const date = new Date(isoString);
+  return date.toLocaleDateString([], {
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
 export function LogbookLive() {
   const entries = useLoggerStore((s) => s.entries);
   const totalCount = useLoggerStore((s) => s.totalCount);
@@ -64,16 +95,6 @@ export function LogbookLive() {
       return () => clearTimeout(timer);
     }
   }, [lastPublishResult, publishError, clearPublishResult]);
-
-  const formatTime = (isoString: string) => {
-    const date = new Date(isoString);
-    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
-  };
-
-  const formatDate = (isoString: string) => {
-    const date = new Date(isoString);
-    return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
-  };
 
   if (loading && entries.length === 0) {
     return (
@@ -99,8 +120,8 @@ export function LogbookLive() {
     <div className="logbook">
       <div className="log-head mono">
         <span style={{ width: '2rem' }}>✓</span>
-        <span>Date</span>
-        <span>Time</span>
+        <span title="QSO date in UTC">Date·UTC</span>
+        <span title="QSO time in UTC">Time·UTC</span>
         <span>Call</span>
         <span>Freq</span>
         <span>Mode</span>
@@ -124,8 +145,12 @@ export function LogbookLive() {
                 style={{ cursor: 'pointer', pointerEvents: 'none' }}
               />
             </span>
-            <span className="t-date">{formatDate(entry.qsoDateTimeUtc)}</span>
-            <span className="t-time">{formatTime(entry.qsoDateTimeUtc)}</span>
+            <span className="t-date" title={entry.qsoDateTimeUtc}>
+              {formatQsoDateUtc(entry.qsoDateTimeUtc)}
+            </span>
+            <span className="t-time" title={entry.qsoDateTimeUtc}>
+              {formatQsoTimeUtc(entry.qsoDateTimeUtc)}
+            </span>
             <span className="t-call">{entry.callsign}</span>
             <span>{entry.frequencyMhz.toFixed(3)}</span>
             <span className="t-mode">{entry.mode}</span>

--- a/zeus-web/src/components/meter-group/MeterGroupPanel.tsx
+++ b/zeus-web/src/components/meter-group/MeterGroupPanel.tsx
@@ -28,6 +28,7 @@ import {
   Trash2,
 } from 'lucide-react';
 import {
+  effectiveKind,
   EMPTY_METER_GROUP_CONFIG,
   newWidgetUid,
   type MeterGroupConfig,
@@ -40,6 +41,19 @@ import {
   MeterReadingId,
   type MeterDefaultKind,
 } from '../meters/meterCatalog';
+
+// Per-kind intrinsic main-axis size (px). The panel body sizes each
+// widget to its own natural footprint and `justify-content: flex-start`
+// packs them to the leading edge — no stretch, no centering. That keeps
+// a single vertical VU bar at bar-width even when the tile is wider, and
+// makes additional bars line up to the left rather than spreading to
+// fill the row.
+const KIND_INTRINSIC_PX: Record<MeterDefaultKind, number> = {
+  vucolumn: 70,   // 60-unit viewBox + lamp-card padding
+  bigarc: 200,    // 240×150 viewBox arc, modest display size
+  pulldown: 230,  // 280×150 viewBox arc
+  hbar: 240,      // wide horizontal bar reads better with room
+};
 
 interface MeterGroupPanelProps {
   /** Per-instance config blob from the workspace store. */
@@ -386,7 +400,16 @@ export function MeterGroupPanel({
             Empty group — tap + to add a meter.
           </div>
         ) : (
-          config.widgets.map((w) => (
+          config.widgets.map((w) => {
+            const intrinsic = KIND_INTRINSIC_PX[effectiveKind(w)];
+            // Main axis = direction; cross axis stretches via the parent's
+            // `alignItems: 'stretch'`. `flex: 0 0 <px>` blocks both grow
+            // and shrink so each widget always reads at its natural size.
+            const sizeAxis =
+              config.direction === 'row'
+                ? { width: intrinsic, flex: `0 0 ${intrinsic}px` as const }
+                : { height: intrinsic, flex: `0 0 ${intrinsic}px` as const };
+            return (
             <div
               key={w.uid}
               data-widget-uid={w.uid}
@@ -396,7 +419,7 @@ export function MeterGroupPanel({
               }
               style={{
                 position: 'relative',
-                flex: '1 1 0',
+                ...sizeAxis,
                 minWidth: 0,
                 minHeight: 0,
                 display: 'flex',
@@ -428,7 +451,8 @@ export function MeterGroupPanel({
                 <Trash2 size={11} />
               </button>
             </div>
-          ))
+            );
+          })
         )}
       </div>
 

--- a/zeus-web/src/components/toolbar/BandFavorites.tsx
+++ b/zeus-web/src/components/toolbar/BandFavorites.tsx
@@ -15,6 +15,7 @@ import {
   type RxMode,
 } from '../../api/client';
 import { useConnectionStore } from '../../state/connection-store';
+import { useDisplayStore } from '../../state/display-store';
 import { BANDS, bandOf } from '../design/data';
 import { ToolbarFavorites, type ToolbarOption } from './ToolbarFavorites';
 
@@ -85,6 +86,9 @@ export function BandFavorites() {
       const targetMode: RxMode | null = stored?.mode ?? null;
 
       useConnectionStore.setState({ vfoHz: targetHz });
+      // Band-favorite tap is an explicit tune-to-frequency action per the
+      // pure-pan PRD; reset any held viewport offset.
+      useDisplayStore.getState().setViewportOffsetHz(0);
       setVfo(targetHz).then(applyState).catch(() => { /* next state poll reconciles */ });
 
       if (targetMode && targetMode !== mode) {

--- a/zeus-web/src/gl/panadapter.ts
+++ b/zeus-web/src/gl/panadapter.ts
@@ -59,10 +59,10 @@ export type PanRenderer = {
     dbMin: number,
     dbMax: number,
     offsetPx: number,
-    // CTUN cursor X offset in clip space (range [-1, +1]). 0 = dead centre
-    // (the default; CTUN off or dial == frozen radio LO). When non-zero the
-    // orange tuning-cursor line shifts horizontally to follow the dial while
-    // the spectrum stays anchored on the hardware NCO. Issue #427.
+    // Dial cursor X offset in clip space (range [-1, +1]). 0 = dead centre
+    // (dial aligned with the hardware NCO). When non-zero the orange
+    // tuning-cursor line shifts horizontally to follow the dial while the
+    // spectrum stays anchored on the hardware NCO.
     cursorXOffset?: number,
   ) => void;
   // Update the trace + fill colour. Components 0..1, premultiplied alpha is

--- a/zeus-web/src/gl/shaders.ts
+++ b/zeus-web/src/gl/shaders.ts
@@ -94,9 +94,9 @@ void main() { fragColor = vec4(uColor * v_alpha, v_alpha); }`;
 export const CURSOR_VS = /* glsl */ `#version 300 es
 layout(location = 0) in vec2 aPos;
 // uXOffset = clip-space X shift, range [-1, +1]. 0 = panadapter centre
-// (CTUN off, or CTUN on with the dial at the frozen radio LO). Non-zero
-// when CTUN is on and the operator's dial has roamed away from the frozen
-// hardware NCO — caller computes (vfoHz - centerHz) / (spanHz/2). Issue #427.
+// (dial aligned with the hardware NCO). Non-zero when the operator's dial
+// has roamed away from the NCO — caller computes
+// (vfoHz - centerHz) / (spanHz/2).
 uniform float uXOffset;
 void main() { gl_Position = vec4(aPos.x + uXOffset, aPos.y, 0.0, 1.0); }`;
 
@@ -126,13 +126,23 @@ uniform float uDbMax;
 uniform float uWriteRow;
 uniform float uH;
 uniform float uBgAlpha;
+// Pure-pan viewport offset in normalized [0,1] UV space (see docs/prd/
+// panfall_behavior.md). Positive = sample to the right of the canvas X (so
+// the displayed history slides left); negative = sample to the left (history
+// slides right with the operator's finger). Caller computes
+// uViewportOffsetUv = viewportOffsetHz / spanHz.
+uniform float uViewportOffsetUv;
+uniform float uSeedDb;
 out vec4 fragColor;
 void main() {
   // vUv.y == 1.0 at top of canvas; newest row sits at the top.
   // row = (writeRow - (1 - vUv.y) * H) mod H, normalised.
   float agePx = (1.0 - vUv.y) * uH;
   float row = mod(uWriteRow - agePx + uH, uH);
-  float v = texture(uHistory, vec2(vUv.x, (row + 0.5) / uH)).r;
+  float srcX = vUv.x + uViewportOffsetUv;
+  float v = (srcX < 0.0 || srcX > 1.0)
+    ? uSeedDb
+    : texture(uHistory, vec2(srcX, (row + 0.5) / uH)).r;
   float n = clamp((v - uDbMin) / (uDbMax - uDbMin), 0.0, 1.0);
   vec4 c = texture(uLut, vec2(n, 0.5));
   // uBgAlpha=1 → fully opaque (normal mode). uBgAlpha=0 → noise floor is

--- a/zeus-web/src/gl/shaders.ts
+++ b/zeus-web/src/gl/shaders.ts
@@ -133,6 +133,14 @@ uniform float uBgAlpha;
 // uViewportOffsetUv = viewportOffsetHz / spanHz.
 uniform float uViewportOffsetUv;
 uniform float uSeedDb;
+// Operator-tunable colormap brightness (issue #426). Multiplies the
+// normalised dB position before the LUT lookup so the lookup index — and
+// therefore the colour — shifts brighter (>1) or darker (<1). 1.0 = no
+// change. The pre-clamp multiply preserves dynamic range: values that would
+// have indexed off the top of the LUT still saturate at the brightest
+// colour, but mid-noise rows that previously sat near the dark end of the
+// gradient slide up into more visible territory.
+uniform float uBrightness;
 out vec4 fragColor;
 void main() {
   // vUv.y == 1.0 at top of canvas; newest row sits at the top.
@@ -143,7 +151,7 @@ void main() {
   float v = (srcX < 0.0 || srcX > 1.0)
     ? uSeedDb
     : texture(uHistory, vec2(srcX, (row + 0.5) / uH)).r;
-  float n = clamp((v - uDbMin) / (uDbMax - uDbMin), 0.0, 1.0);
+  float n = clamp(((v - uDbMin) / (uDbMax - uDbMin)) * uBrightness, 0.0, 1.0);
   vec4 c = texture(uLut, vec2(n, 0.5));
   // uBgAlpha=1 → fully opaque (normal mode). uBgAlpha=0 → noise floor is
   // fully transparent and signal peaks fade in proportionally; map/background

--- a/zeus-web/src/gl/waterfall.ts
+++ b/zeus-web/src/gl/waterfall.ts
@@ -82,7 +82,7 @@ export type WfRenderer = {
     hzPerPixel: number,
     options?: PushOptions,
   ) => void;
-  draw: (dbMin: number, dbMax: number) => void;
+  draw: (dbMin: number, dbMax: number, viewportOffsetUv?: number) => void;
   setColormap: (id: ColormapId) => void;
   /** 1.0 = opaque (default). 0.0 = noise floor fades to transparent so a
    *  background layer (e.g. the QRZ-mode Leaflet map) shows through. */
@@ -107,6 +107,8 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
   const uWriteRow = gl.getUniformLocation(drawProg, 'uWriteRow');
   const uH = gl.getUniformLocation(drawProg, 'uH');
   const uBgAlpha = gl.getUniformLocation(drawProg, 'uBgAlpha');
+  const uViewportOffsetUv = gl.getUniformLocation(drawProg, 'uViewportOffsetUv');
+  const uDrawSeed = gl.getUniformLocation(drawProg, 'uSeedDb');
   let bgAlpha = 1;
 
   const shiftProg = buildProgram(gl, WF_VS, WF_SHIFT_FS);
@@ -283,7 +285,7 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
     setTransparent(transparent) {
       bgAlpha = transparent ? 0 : 1;
     },
-    draw(dbMin, dbMax) {
+    draw(dbMin, dbMax, viewportOffsetUv = 0) {
       gl.viewport(0, 0, canvasW, canvasH);
       gl.clearColor(0, 0, 0, 0);
       gl.clear(gl.COLOR_BUFFER_BIT);
@@ -304,6 +306,8 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
       gl.uniform1f(uWriteRow, writeRow);
       gl.uniform1f(uH, HISTORY_ROWS);
       gl.uniform1f(uBgAlpha, bgAlpha);
+      gl.uniform1f(uViewportOffsetUv, viewportOffsetUv);
+      gl.uniform1f(uDrawSeed, SEED_DB);
       gl.bindVertexArray(vao);
       gl.drawArrays(gl.TRIANGLES, 0, 3);
       gl.bindVertexArray(null);

--- a/zeus-web/src/gl/waterfall.ts
+++ b/zeus-web/src/gl/waterfall.ts
@@ -82,7 +82,12 @@ export type WfRenderer = {
     hzPerPixel: number,
     options?: PushOptions,
   ) => void;
-  draw: (dbMin: number, dbMax: number, viewportOffsetUv?: number) => void;
+  draw: (
+    dbMin: number,
+    dbMax: number,
+    viewportOffsetUv?: number,
+    brightness?: number,
+  ) => void;
   setColormap: (id: ColormapId) => void;
   /** 1.0 = opaque (default). 0.0 = noise floor fades to transparent so a
    *  background layer (e.g. the QRZ-mode Leaflet map) shows through. */
@@ -109,6 +114,7 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
   const uBgAlpha = gl.getUniformLocation(drawProg, 'uBgAlpha');
   const uViewportOffsetUv = gl.getUniformLocation(drawProg, 'uViewportOffsetUv');
   const uDrawSeed = gl.getUniformLocation(drawProg, 'uSeedDb');
+  const uBrightness = gl.getUniformLocation(drawProg, 'uBrightness');
   let bgAlpha = 1;
 
   const shiftProg = buildProgram(gl, WF_VS, WF_SHIFT_FS);
@@ -285,7 +291,7 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
     setTransparent(transparent) {
       bgAlpha = transparent ? 0 : 1;
     },
-    draw(dbMin, dbMax, viewportOffsetUv = 0) {
+    draw(dbMin, dbMax, viewportOffsetUv = 0, brightness = 1) {
       gl.viewport(0, 0, canvasW, canvasH);
       gl.clearColor(0, 0, 0, 0);
       gl.clear(gl.COLOR_BUFFER_BIT);
@@ -308,6 +314,7 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
       gl.uniform1f(uBgAlpha, bgAlpha);
       gl.uniform1f(uViewportOffsetUv, viewportOffsetUv);
       gl.uniform1f(uDrawSeed, SEED_DB);
+      gl.uniform1f(uBrightness, brightness);
       gl.bindVertexArray(vao);
       gl.drawArrays(gl.TRIANGLES, 0, 3);
       gl.bindVertexArray(null);

--- a/zeus-web/src/hooks/useLiveSlider.test.tsx
+++ b/zeus-web/src/hooks/useLiveSlider.test.tsx
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Unit tests for useLiveSlider — the shared "stream during drag, commit
+// on release" helper used by every slider component (issue zeus-5k0).
+//
+// What we lock down here:
+//   * push() coalesces multiple values per animation frame so we POST at
+//     most once per paint (no endpoint flooding from a wild drag).
+//   * flush() dispatches the latest pending value immediately and is a
+//     no-op when nothing is pending (safe to wire to pointerUp blindly).
+//   * Successive dispatches abort the previous request's AbortSignal so
+//     stale acknowledgements don't yank the slider back.
+//   * Cleanup on unmount cancels pending rAF and aborts in-flight.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useLiveSlider, type LiveSliderSender } from './useLiveSlider';
+
+// rAF in jsdom is unreliable; the hook falls back to setTimeout(0) when
+// requestAnimationFrame isn't a function. We force that path so vi.runAllTimers()
+// gives us deterministic flush points.
+function stubRafAsTimers() {
+  // Make typeof window.requestAnimationFrame !== 'function' to trigger the
+  // setTimeout fallback. We can't delete it on the global, so reassign.
+  (window as unknown as { requestAnimationFrame?: unknown }).requestAnimationFrame = undefined;
+  (window as unknown as { cancelAnimationFrame?: unknown }).cancelAnimationFrame = undefined;
+}
+
+interface Harness<T> {
+  push: (v: T) => void;
+  flush: () => void;
+  unmount: () => void;
+}
+
+function mount<T>(send: LiveSliderSender<T>): Harness<T> {
+  const captured: { push: (v: T) => void; flush: () => void } = {
+    push: () => {},
+    flush: () => {},
+  };
+  function Probe() {
+    const api = useLiveSlider<T>({ send });
+    captured.push = api.push;
+    captured.flush = api.flush;
+    return null;
+  }
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+  act(() => {
+    root.render(<Probe />);
+  });
+  return {
+    push: (v) => captured.push(v),
+    flush: () => captured.flush(),
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+describe('useLiveSlider', () => {
+  beforeEach(() => {
+    stubRafAsTimers();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('coalesces multiple push() calls within one frame into a single dispatch', () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const h = mount<number>(send);
+    h.push(1);
+    h.push(2);
+    h.push(3);
+    expect(send).not.toHaveBeenCalled();
+    act(() => {
+      vi.runAllTimers();
+    });
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0]?.[0]).toBe(3);
+    h.unmount();
+  });
+
+  it('flush() dispatches the latest pending value immediately', () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const h = mount<number>(send);
+    h.push(7);
+    h.push(8);
+    expect(send).not.toHaveBeenCalled();
+    act(() => h.flush());
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0]?.[0]).toBe(8);
+    h.unmount();
+  });
+
+  it('flush() is a no-op when nothing is pending', () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const h = mount<number>(send);
+    act(() => h.flush());
+    expect(send).not.toHaveBeenCalled();
+    h.unmount();
+  });
+
+  it('does not redispatch the same value back-to-back', () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const h = mount<number>(send);
+    h.push(5);
+    act(() => vi.runAllTimers());
+    h.push(5);
+    act(() => vi.runAllTimers());
+    expect(send).toHaveBeenCalledTimes(1);
+    h.unmount();
+  });
+
+  it('aborts the previous in-flight request when a newer value supersedes it', async () => {
+    const signals: AbortSignal[] = [];
+    const send = vi.fn().mockImplementation((_v: number, signal: AbortSignal) => {
+      signals.push(signal);
+      return new Promise<void>(() => { /* never resolves */ });
+    });
+    const h = mount<number>(send);
+    h.push(1);
+    act(() => vi.runAllTimers());
+    h.push(2);
+    act(() => vi.runAllTimers());
+    expect(signals).toHaveLength(2);
+    expect(signals[0]?.aborted).toBe(true);
+    expect(signals[1]?.aborted).toBe(false);
+    h.unmount();
+  });
+
+  it('aborts in-flight on unmount', () => {
+    const signals: AbortSignal[] = [];
+    const send = vi.fn().mockImplementation((_v: number, signal: AbortSignal) => {
+      signals.push(signal);
+      return new Promise<void>(() => {});
+    });
+    const h = mount<number>(send);
+    h.push(42);
+    act(() => vi.runAllTimers());
+    expect(signals[0]?.aborted).toBe(false);
+    h.unmount();
+    expect(signals[0]?.aborted).toBe(true);
+  });
+});

--- a/zeus-web/src/hooks/useLiveSlider.ts
+++ b/zeus-web/src/hooks/useLiveSlider.ts
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Shared "stream during drag, commit on release" helper for slider inputs.
+//
+// Background (issue zeus-5k0): every slider in Zeus should feel live —
+// the operator hears / sees the change as the thumb moves, not just on
+// mouseUp. Previously some sliders (AGC-T, S-ATT) only POSTed on release;
+// others (AF, DRV, TUN, MIC, LVLR) debounced 100 ms which is noticeable
+// on a fast drag.
+//
+// This hook standardises the contract:
+//   * Intermediate values are coalesced via requestAnimationFrame so we
+//     post at most once per paint (~16 ms at 60 Hz) — feels instant to
+//     the operator while preventing endpoint flooding from a wild drag.
+//   * In-flight requests are aborted when a newer value supersedes them
+//     so the backend always sees the latest intent (and the slider isn't
+//     yanked back by a stale echo).
+//   * flush() commits the latest pending value immediately — call from
+//     pointerUp / mouseUp / touchEnd / keyUp / blur so the final value is
+//     guaranteed to land regardless of throttle alignment.
+//
+// Optimistic store updates remain the caller's responsibility (every
+// existing slider does this in its own onChange — we don't want to bake
+// the store shape into a generic hook).
+
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * Callback shape every slider already has: take a value, return a promise
+ * that resolves when the server has acknowledged. The hook passes an
+ * AbortSignal so the caller can plumb it through fetch().
+ */
+export type LiveSliderSender<T> = (value: T, signal: AbortSignal) => Promise<void>;
+
+export interface UseLiveSliderOptions<T> {
+  /**
+   * Send the value to the backend. The hook calls this with the latest
+   * pending value at most once per animation frame; older calls are
+   * superseded (their AbortSignals are aborted).
+   */
+  send: LiveSliderSender<T>;
+
+  /**
+   * Equality check — by default `Object.is`. Override for slider values
+   * that are objects (rare; most are numbers).
+   */
+  equals?: (a: T, b: T) => boolean;
+}
+
+export interface UseLiveSliderApi<T> {
+  /**
+   * Queue a value to be sent on the next animation frame, coalescing
+   * with any later push() calls that arrive in the same frame.
+   */
+  push: (value: T) => void;
+  /**
+   * Send the latest pending value immediately (no rAF wait). Safe to
+   * call from pointerUp / mouseUp / touchEnd / keyUp / blur handlers
+   * even if no value is pending — it no-ops in that case.
+   */
+  flush: () => void;
+}
+
+/**
+ * Stream slider values during drag, commit on release.
+ *
+ * Cleanup (cancel rAF + abort in-flight) happens automatically on unmount.
+ */
+export function useLiveSlider<T>(opts: UseLiveSliderOptions<T>): UseLiveSliderApi<T> {
+  const { send, equals = Object.is } = opts;
+
+  // Keep the latest send in a ref so callers don't have to memoise it —
+  // we only ever read it inside the rAF tick, where stale closures would
+  // otherwise be a footgun (an old `send` would post to the wrong store).
+  const sendRef = useRef(send);
+  sendRef.current = send;
+  const equalsRef = useRef(equals);
+  equalsRef.current = equals;
+
+  // Pending value waiting for the next rAF tick. `hasPending` is needed
+  // (vs. just checking pendingRef.current) because T might legitimately
+  // be 0 / null / undefined and we still want to fire.
+  const pendingRef = useRef<T | undefined>(undefined);
+  const hasPendingRef = useRef(false);
+
+  // rAF handle so we can cancel on flush / unmount.
+  const rafRef = useRef<number | null>(null);
+
+  // Last value actually dispatched to send() — used to short-circuit
+  // duplicate posts (operator drags away and back to the same value).
+  const lastDispatchedRef = useRef<T | undefined>(undefined);
+  const hasDispatchedRef = useRef(false);
+
+  // In-flight AbortController — aborted when a newer value comes in.
+  const inflightRef = useRef<AbortController | null>(null);
+
+  const dispatch = useCallback((value: T) => {
+    if (hasDispatchedRef.current && equalsRef.current(value, lastDispatchedRef.current as T)) {
+      return;
+    }
+    lastDispatchedRef.current = value;
+    hasDispatchedRef.current = true;
+    inflightRef.current?.abort();
+    const ac = new AbortController();
+    inflightRef.current = ac;
+    // Fire-and-forget — error handling is the sender's responsibility
+    // (every existing slider already does rollback / silent ignore on
+    // AbortError, and we don't want to swallow those decisions here).
+    void sendRef.current(value, ac.signal).catch(() => {
+      /* sender owns error handling */
+    });
+  }, []);
+
+  const push = useCallback((value: T) => {
+    pendingRef.current = value;
+    hasPendingRef.current = true;
+    if (rafRef.current != null) return;
+    // Use rAF when available, fall back to setTimeout(0) for non-browser
+    // (jsdom) test environments where rAF is stubbed or absent.
+    const schedule: (cb: () => void) => number =
+      typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function'
+        ? (cb) => window.requestAnimationFrame(cb)
+        : (cb) => setTimeout(cb, 0) as unknown as number;
+    rafRef.current = schedule(() => {
+      rafRef.current = null;
+      if (!hasPendingRef.current) return;
+      const v = pendingRef.current as T;
+      hasPendingRef.current = false;
+      pendingRef.current = undefined;
+      dispatch(v);
+    });
+  }, [dispatch]);
+
+  const flush = useCallback(() => {
+    if (rafRef.current != null) {
+      if (typeof window !== 'undefined' && typeof window.cancelAnimationFrame === 'function') {
+        window.cancelAnimationFrame(rafRef.current);
+      } else {
+        clearTimeout(rafRef.current as unknown as ReturnType<typeof setTimeout>);
+      }
+      rafRef.current = null;
+    }
+    if (!hasPendingRef.current) return;
+    const v = pendingRef.current as T;
+    hasPendingRef.current = false;
+    pendingRef.current = undefined;
+    dispatch(v);
+  }, [dispatch]);
+
+  useEffect(() => () => {
+    if (rafRef.current != null) {
+      if (typeof window !== 'undefined' && typeof window.cancelAnimationFrame === 'function') {
+        window.cancelAnimationFrame(rafRef.current);
+      } else {
+        clearTimeout(rafRef.current as unknown as ReturnType<typeof setTimeout>);
+      }
+      rafRef.current = null;
+    }
+    inflightRef.current?.abort();
+  }, []);
+
+  return { push, flush };
+}

--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -17,7 +17,7 @@
 //   - "+ Add Panel" is a single workspace-level button at the top-right,
 //     opening the categorized AddPanelModal.
 
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ResponsiveGridLayout,
   useContainerWidth,
@@ -320,6 +320,7 @@ function MeterGroupTileBody({
   const updateTileInstanceConfig = useLayoutStore(
     (s) => s.updateTileInstanceConfig,
   );
+  const updateTilePlacement = useLayoutStore((s) => s.updateTilePlacement);
   const config: MeterGroupConfig = useMemo(
     () => parseMeterGroupConfig(tile.instanceConfig),
     [tile.instanceConfig],
@@ -330,6 +331,33 @@ function MeterGroupTileBody({
     },
     [tile.uid, updateTileInstanceConfig],
   );
+
+  // Auto-fit the tile to its widget set. Operators add a Meter Group, drop
+  // in two vertical bars, and expect the tile to snap to bar-width — not
+  // to leave four grid columns of empty space waiting to be filled. The
+  // effect deps are widget count + direction only (live tile geometry is
+  // read through a ref) so an operator can still drag-resize the cross
+  // axis without the effect snapping it back on every render.
+  const tileRef = useRef(tile);
+  tileRef.current = tile;
+  useEffect(() => {
+    const t = tileRef.current;
+    const widgetCount = Math.max(1, config.widgets.length);
+    // Row: one grid col per widget on the main axis. Column: ~3 grid rows
+    // per widget so vertical bars get enough vertical span to read.
+    const targetW = config.direction === 'row' ? widgetCount : t.w;
+    const targetH =
+      config.direction === 'column' ? Math.max(3, widgetCount * 3) : t.h;
+    if (targetW !== t.w || targetH !== t.h) {
+      updateTilePlacement(t.uid, {
+        x: t.x,
+        y: t.y,
+        w: targetW,
+        h: targetH,
+      });
+    }
+  }, [config.widgets.length, config.direction, updateTilePlacement]);
+
   return (
     <MeterGroupPanel config={config} setConfig={setConfig} onRemove={onRemove} />
   );

--- a/zeus-web/src/layout/WorkspaceContext.tsx
+++ b/zeus-web/src/layout/WorkspaceContext.tsx
@@ -106,9 +106,8 @@ export interface WorkspaceCtx {
   // DSP
   dspActive: boolean;
 
-  // CW
-  wpm: number;
-  setWpm: (v: number) => void;
+  // CW state lives in src/state/cw-store.ts (persisted server-side via
+  // /api/cw/settings) — no longer threaded through the workspace context.
 
   // Logbook
   logbookTitle: string;

--- a/zeus-web/src/layout/panels/CwPanel.tsx
+++ b/zeus-web/src/layout/panels/CwPanel.tsx
@@ -1,56 +1,49 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 //
 // Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
-// Copyright (C) 2025-2026 Brian Keating (EI6LF),
-//                         Douglas J. Cerrato (KB2UKA), and contributors.
-//
-// This program is free software: you can redistribute it and/or modify it
-// under the terms of the GNU General Public License as published by the
-// Free Software Foundation, either version 2 of the License, or (at your
-// option) any later version. See the LICENSE file at the root of this
-// repository for the full text, or https://www.gnu.org/licenses/.
-//
-// Zeus is an independent reimplementation in .NET — not a fork. Its
-// Protocol-1 / Protocol-2 framing, WDSP integration, meter pipelines, and
-// TX behaviour were informed by studying the Thetis project
-// (https://github.com/ramdor/Thetis), the authoritative reference
-// implementation in the OpenHPSDR ecosystem. Zeus gratefully acknowledges
-// the Thetis contributors whose work made this possible:
-//
-//   Richard Samphire (MW0LGE), Warren Pratt (NR0V),
-//   Laurence Barker (G8NJJ),   Rick Koch (N1GP),
-//   Bryan Rambo (W4WMT),       Chris Codella (W2PA),
-//   Doug Wigley (W5WC),        FlexRadio Systems,
-//   Richard Allen (W5SD),      Joe Torrey (WD5Y),
-//   Andrew Mansfield (M0YGG),  Reid Campbell (MI0BOT),
-//   Sigi Jetzlsperger (DH1KLM).
-//
-// Thetis itself continues the GPL-governed lineage of FlexRadio PowerSDR
-// and the OpenHPSDR (TAPR/OpenHPSDR) ecosystem; that lineage is preserved
-// here. See ATTRIBUTIONS.md at the repository root for the full provenance
-// statement and per-component attribution.
-//
-// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
-// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
-// Wüllen (DL1YCF); and by DeskHPSDR
-// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
-// Both are GPL-2.0-or-later.
-//
-// WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
-// (NR0V), distributed under GPL v2 or later.
-//
-// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
-// License for details.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
 
 import { CwKeyer } from '../../components/design/CwKeyer';
-import { useWorkspace } from '../WorkspaceContext';
+import { abortCw, sendCw } from '../../api/cw';
+import { useCwStore } from '../../state/cw-store';
+
+// Hard cap mirrors Zeus.Server.Hosting/CwSettingsStore.cs MaxMacros. If
+// the server bumps the cap, also bump this so the UI's "Add" button
+// matches. (We could fetch it dynamically, but a constant is cheaper
+// and only changes during epic-scale revisits.)
+const MAX_MACROS = 32;
 
 export function CwPanel() {
-  const { wpm, setWpm } = useWorkspace();
+  const settings = useCwStore((s) => s.settings);
+  const status = useCwStore((s) => s.status);
+  const setSettingsLocal = useCwStore((s) => s.setSettingsLocal);
+  const commitDebounced = useCwStore((s) => s.commitDebounced);
+  const setMacro = useCwStore((s) => s.setMacro);
+  const addMacro = useCwStore((s) => s.addMacro);
+  const removeMacro = useCwStore((s) => s.removeMacro);
 
   return (
     <div style={{ flex: 1, overflow: 'auto' }}>
-      <CwKeyer wpm={wpm} setWpm={setWpm} />
+      <CwKeyer
+        wpm={settings.wpm}
+        // Split-write pattern fixes the "slider snaps back" race. The
+        // local setter updates the store immediately so the slider
+        // tracks the pointer; the debounced commit schedules a single
+        // PUT after the operator stops dragging.
+        setWpmLocal={(v) => setSettingsLocal({ wpm: v })}
+        setWpmCommit={(v) => commitDebounced({ wpm: v })}
+        macros={settings.macros}
+        // Pass the current WPM explicitly so a slider change that hasn't
+        // round-tripped to the server yet still keys at the operator's
+        // intended speed.
+        onSend={(macro) => void sendCw(macro, settings.wpm)}
+        onAbort={() => void abortCw()}
+        onMacroEdit={(i, v) => void setMacro(i, v)}
+        onMacroDelete={(i) => void removeMacro(i)}
+        onMacroAdd={() => void addMacro()}
+        maxMacros={MAX_MACROS}
+        status={status}
+      />
     </div>
   );
 }

--- a/zeus-web/src/layout/panels/HeroPanel.tsx
+++ b/zeus-web/src/layout/panels/HeroPanel.tsx
@@ -42,6 +42,7 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
+import { useCallback, useRef } from 'react';
 import type { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from 'react';
 import { GripVertical, X } from 'lucide-react';
 import { Panadapter } from '../../components/Panadapter';
@@ -51,6 +52,8 @@ import { LeafletWorldMap } from '../../components/design/LeafletWorldMap';
 import { LeafletMapErrorBoundary } from '../../components/design/LeafletMapErrorBoundary';
 import { useConnectionStore } from '../../state/connection-store';
 import { useRotatorStore } from '../../state/rotator-store';
+import { usePanWfSplitStore } from '../../state/pan-wf-split-store';
+import { PAN_WF_MAX_PERCENT, PAN_WF_MIN_PERCENT } from '../../api/pan-wf-split';
 import { useWorkspace } from '../WorkspaceContext';
 
 // Hero panel: Panadapter + Waterfall with optional Leaflet world-map overlay.
@@ -85,6 +88,70 @@ export function HeroPanel({ onRemove }: { onRemove?: () => void } = {}) {
     submitBeam,
   } = useWorkspace();
   const connected = useConnectionStore((s) => s.status === 'Connected');
+  const panPercent = usePanWfSplitStore((s) => s.panPercent);
+  const setPanPercentLive = usePanWfSplitStore((s) => s.setPanPercentLive);
+  const persistPanPercent = usePanWfSplitStore((s) => s.persistPanPercent);
+
+  // Drag state for the pan/wf splitter. We measure the spectrum-stack box
+  // on pointerdown and translate pointer Y → panadapter share (%). The
+  // store update is cheap (CSS grid template), so we run it at pointer
+  // rate; persistence happens once on pointerup via the debounced
+  // persistPanPercent action.
+  const spectrumStackRef = useRef<HTMLDivElement | null>(null);
+  const dragRectRef = useRef<DOMRect | null>(null);
+  const draggingPctRef = useRef<number>(panPercent);
+
+  const clampPct = (v: number) =>
+    Math.max(PAN_WF_MIN_PERCENT, Math.min(PAN_WF_MAX_PERCENT, v));
+
+  const onSplitPointerMove = useCallback(
+    (ev: PointerEvent) => {
+      const rect = dragRectRef.current;
+      if (!rect || rect.height <= 0) return;
+      const pct = clampPct(((ev.clientY - rect.top) / rect.height) * 100);
+      draggingPctRef.current = pct;
+      setPanPercentLive(pct);
+    },
+    [setPanPercentLive],
+  );
+
+  const onSplitPointerUp = useCallback(
+    (ev: PointerEvent) => {
+      window.removeEventListener('pointermove', onSplitPointerMove);
+      window.removeEventListener('pointerup', onSplitPointerUp);
+      window.removeEventListener('pointercancel', onSplitPointerUp);
+      try {
+        (ev.target as Element | null)?.releasePointerCapture?.(ev.pointerId);
+      } catch {
+        /* not all targets support release; ignore */
+      }
+      dragRectRef.current = null;
+      document.body.style.cursor = '';
+      void persistPanPercent(draggingPctRef.current);
+    },
+    [onSplitPointerMove, persistPanPercent],
+  );
+
+  const onSplitPointerDown = useCallback(
+    (ev: ReactPointerEvent<HTMLDivElement>) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      const stack = spectrumStackRef.current;
+      if (!stack) return;
+      dragRectRef.current = stack.getBoundingClientRect();
+      draggingPctRef.current = panPercent;
+      try {
+        (ev.target as Element).setPointerCapture?.(ev.pointerId);
+      } catch {
+        /* fallback to window listeners below */
+      }
+      document.body.style.cursor = 'row-resize';
+      window.addEventListener('pointermove', onSplitPointerMove);
+      window.addEventListener('pointerup', onSplitPointerUp);
+      window.addEventListener('pointercancel', onSplitPointerUp);
+    },
+    [panPercent, onSplitPointerMove, onSplitPointerUp],
+  );
 
   const handleRotateToBearing = (brg: number) => {
     const rot = useRotatorStore.getState();
@@ -240,17 +307,52 @@ export function HeroPanel({ onRemove }: { onRemove?: () => void } = {}) {
           </LeafletMapErrorBoundary>
         </div>
         <div
+          ref={spectrumStackRef}
           data-spectrum-stack
           style={{
             position: 'absolute',
             inset: 0,
             display: 'grid',
-            gridTemplateRows: '1fr 1fr',
+            // panPercent is the panadapter share (10..90); waterfall fills
+            // the remainder. fr units so the canvases naturally absorb the
+            // remaining height when the splitter moves.
+            gridTemplateRows: `${panPercent}fr ${100 - panPercent}fr`,
             zIndex: 1,
           }}
         >
           {connected && <Panadapter />}
           {connected && <Waterfall transparent={bgActive} />}
+          {/* Splitter — sits on the panadapter/waterfall boundary. The
+              parent grid is two rows; we position the handle at the
+              boundary with an absolutely-placed strip whose top tracks
+              panPercent. Hairline default, brighter on hover/active.
+              Pointer events on the strip don't propagate to the tile
+              drag (workspace-tile-header is the RGL drag handle). */}
+          <div
+            className="pan-wf-split-handle"
+            role="separator"
+            aria-orientation="horizontal"
+            aria-label="Resize panadapter / waterfall split"
+            aria-valuemin={PAN_WF_MIN_PERCENT}
+            aria-valuemax={PAN_WF_MAX_PERCENT}
+            aria-valuenow={Math.round(panPercent)}
+            title="Drag to resize panadapter / waterfall"
+            style={{
+              position: 'absolute',
+              left: 0,
+              right: 0,
+              top: `${panPercent}%`,
+              transform: 'translateY(-50%)',
+              height: 8,
+              cursor: 'row-resize',
+              zIndex: 5,
+              touchAction: 'none',
+            }}
+            onPointerDown={onSplitPointerDown}
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            <div className="pan-wf-split-handle__line" />
+          </div>
         </div>
       </div>
     </div>

--- a/zeus-web/src/layout/workspace.ts
+++ b/zeus-web/src/layout/workspace.ts
@@ -85,6 +85,11 @@ export const DEFAULT_TILE_SPAN: Record<string, { w: number; h: number }> = {
   band: { w: 6, h: 2 },
   mode: { w: 4, h: 2 },
   meters: { w: 6, h: 8 },
+  // Meter Group auto-fits to its widget set (see MeterGroupTileBody in
+  // FlexWorkspace.tsx) — start at the smallest grid footprint so the
+  // freshly-added tile shows just the empty-state hint, not 4 columns of
+  // blank space waiting for widgets.
+  metergroup: { w: 1, h: 6 },
 };
 
 const FALLBACK_SPAN = { w: 4, h: 4 };

--- a/zeus-web/src/main.tsx
+++ b/zeus-web/src/main.tsx
@@ -111,6 +111,20 @@ try {
   /* private mode — falls back to dark, the default. */
 }
 
+// ?desktop=1 — operator wants the desktop layout preserved in a narrow
+// window (e.g. a small touchscreen as a secondary control surface).
+// Set the attribute synchronously so the ≤900px media block in layout.css
+// (which is scoped to html:not([data-force-desktop="1"])) never applies.
+// useIsMobileViewport() in mobile/MobileApp.tsx honours the same param to
+// suppress the shell swap.
+try {
+  if (new URLSearchParams(window.location.search).get('desktop') === '1') {
+    document.documentElement.setAttribute('data-force-desktop', '1');
+  }
+} catch {
+  /* no-op */
+}
+
 // PERF_PASS_3_DEBUG: window debug helpers for playwright-driven validation.
 (window as unknown as Record<string, unknown>).__zeusPerf3 = {
   txStore: useTxStore,

--- a/zeus-web/src/mobile/MobileApp.tsx
+++ b/zeus-web/src/mobile/MobileApp.tsx
@@ -45,12 +45,15 @@ const MODES: readonly RxMode[] = ['LSB', 'USB', 'CWL', 'CWU', 'AM', 'FM', 'DIGU'
 const MOBILE_QUERY = '(max-width: 900px)';
 
 // Reactive viewport check. `?mobile=1` forces the mobile shell on for desktop
-// previews; everything else honours the matchMedia breakpoint and updates
-// when the window is resized or the device rotates.
+// previews; `?desktop=1` forces it off so the desktop layout survives narrow
+// windows (e.g. a small touchscreen used as a secondary control surface).
+// `?desktop=1` wins when both are present. Otherwise honours the matchMedia
+// breakpoint and updates on resize / device rotation.
 export function useIsMobileViewport(): boolean {
   const [mobile, setMobile] = useState<boolean>(() => {
     if (typeof window === 'undefined') return false;
     const params = new URLSearchParams(window.location.search);
+    if (params.get('desktop') === '1') return false;
     if (params.get('mobile') === '1') return true;
     return window.matchMedia(MOBILE_QUERY).matches;
   });
@@ -58,7 +61,8 @@ export function useIsMobileViewport(): boolean {
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const params = new URLSearchParams(window.location.search);
-    if (params.get('mobile') === '1') return; // forced — no listener needed
+    if (params.get('desktop') === '1') return; // forced off — no listener needed
+    if (params.get('mobile') === '1') return; // forced on — no listener needed
     const mq = window.matchMedia(MOBILE_QUERY);
     const onChange = (e: MediaQueryListEvent) => setMobile(e.matches);
     mq.addEventListener('change', onChange);

--- a/zeus-web/src/realtime/ws-client.ts
+++ b/zeus-web/src/realtime/ws-client.ts
@@ -163,6 +163,19 @@ export const MSG_TYPE_AUDIO_CHAIN_ORDER = 0x1e;
 export const MSG_TYPE_AUDIO_MASTER_BYPASS = 0x1f;
 const AUDIO_MASTER_BYPASS_BYTES = 2;
 
+// CW engine status — broadcast on every state edge of the host-side CW
+// keyer so the macro pad can render in-flight text + queue depth without
+// polling. Variable-length frame: 9-byte header + UTF-8 text. Contract:
+// Zeus.Contracts/CwEngineStatusFrame.cs.
+//
+// Wire shape:
+//   [0x30][state:u8][wpm:u16 LE][queueDepth:u16 LE][textLen:u16 LE][text:utf8…]
+//
+// 0x3x is the new "control-plane feedback" nibble (0x1x exhausted as of
+// AudioMasterBypass).
+export const MSG_TYPE_CW_ENGINE_STATUS = 0x30;
+const CW_ENGINE_STATUS_HEADER_BYTES = 9;
+
 // Shared by startRealtime / sendMicPcm. Single WS instance at a time; writes
 // are no-ops when the socket isn't open.
 let activeWs: WebSocket | null = null;
@@ -342,6 +355,49 @@ export function startRealtime(path = '/ws'): () => void {
           // window (e.g. the no-plugins-installed first-run experience).
           void import('../state/audio-suite-store').then((m) => {
             m.useAudioSuiteStore.getState().setChainOrderFromServer(ids);
+          });
+          return;
+        }
+        if (peekType === MSG_TYPE_CW_ENGINE_STATUS) {
+          if (ev.data.byteLength < CW_ENGINE_STATUS_HEADER_BYTES) {
+            warnOnce(
+              'ws-cw-status-short',
+              `cw status frame too short: ${ev.data.byteLength}`,
+            );
+            return;
+          }
+          const dv = new DataView(ev.data);
+          const stateByte = dv.getUint8(1);
+          const wpm = dv.getUint16(2, true);
+          const queueDepth = dv.getUint16(4, true);
+          const textLen = dv.getUint16(6, true);
+          if (ev.data.byteLength < CW_ENGINE_STATUS_HEADER_BYTES + textLen) {
+            warnOnce(
+              'ws-cw-status-truncated',
+              `cw status text claims ${textLen} bytes but only ${
+                ev.data.byteLength - CW_ENGINE_STATUS_HEADER_BYTES
+              } follow`,
+            );
+            return;
+          }
+          const text =
+            textLen === 0
+              ? ''
+              : new TextDecoder('utf-8').decode(
+                  new Uint8Array(ev.data, CW_ENGINE_STATUS_HEADER_BYTES, textLen),
+                );
+          // Lazy import keeps the cw-store off the critical path for
+          // clients that never open the CW panel (the macro pad is
+          // typically closed by default).
+          void import('../state/cw-store').then((m) => {
+            const state = m.CW_STATE_FROM_BYTE[stateByte] ?? 'idle';
+            m.useCwStore.getState().setStatusFromServer({
+              state,
+              text,
+              wpm,
+              queueDepth,
+              receivedAtMs: Date.now(),
+            });
           });
           return;
         }

--- a/zeus-web/src/state/connection-store.ts
+++ b/zeus-web/src/state/connection-store.ts
@@ -63,13 +63,11 @@ export type ConnectionState = {
   status: ConnectionStatus;
   endpoint: string | null;
   vfoHz: number;
-  // CTUN (Click-Tune) — issue #427. When true, panadapter clicks move vfoHz
-  // without retuning the radio; the hardware stays at radioLoHz and WDSP's RX
-  // filter is shifted to keep the operator's tuned signal in the passband.
-  ctunEnabled: boolean;
-  // Hardware NCO. Tracks vfoHz when ctunEnabled is false; frozen otherwise.
-  // The panadapter centres on radioLoHz so the spectrum doesn't slide on
-  // every click while CTUN is on.
+  // Hardware NCO frequency. Independent of vfoHz — the panadapter centres on
+  // radioLoHz and WDSP's shift stage relocates the operator's tuned signal
+  // (vfoHz) within the IQ window. Updated by /api/radio/lo and by band-change
+  // / external-CAT retunes; never by panadapter drags (those just move the
+  // viewport visually until released past the IQ window edge).
   radioLoHz: number;
   mode: RxMode;
   filterLowHz: number;
@@ -127,7 +125,6 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
   status: 'Disconnected',
   endpoint: null,
   vfoHz: 14_200_000,
-  ctunEnabled: false,
   radioLoHz: 14_200_000,
   mode: 'USB',
   filterLowHz: 150,
@@ -161,7 +158,6 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
       status: s.status,
       endpoint: s.endpoint,
       vfoHz: s.vfoHz,
-      ctunEnabled: s.ctunEnabled,
       radioLoHz: s.radioLoHz,
       mode: s.mode,
       filterLowHz: s.filterLowHz,

--- a/zeus-web/src/state/connection-store.ts
+++ b/zeus-web/src/state/connection-store.ts
@@ -69,6 +69,7 @@ export type ConnectionState = {
   // / external-CAT retunes; never by panadapter drags (those just move the
   // viewport visually until released past the IQ window edge).
   radioLoHz: number;
+  cwPitchHz: number;
   mode: RxMode;
   filterLowHz: number;
   filterHighHz: number;
@@ -126,6 +127,7 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
   endpoint: null,
   vfoHz: 14_200_000,
   radioLoHz: 14_200_000,
+  cwPitchHz: 600,
   mode: 'USB',
   filterLowHz: 150,
   filterHighHz: 2850,
@@ -159,6 +161,7 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
       endpoint: s.endpoint,
       vfoHz: s.vfoHz,
       radioLoHz: s.radioLoHz,
+      cwPitchHz: s.cwPitchHz,
       mode: s.mode,
       filterLowHz: s.filterLowHz,
       filterHighHz: s.filterHighHz,

--- a/zeus-web/src/state/cw-store.test.ts
+++ b/zeus-web/src/state/cw-store.test.ts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_CW_SETTINGS } from '../api/cw';
+import { useCwStore } from './cw-store';
+
+// The store hydrates on module load via a fetch — stub it to a no-op
+// before each test so we're always working from the API defaults.
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  useCwStore.setState({
+    settings: { ...DEFAULT_CW_SETTINGS, macros: [...DEFAULT_CW_SETTINGS.macros] },
+    status: {
+      state: 'idle',
+      text: '',
+      wpm: 0,
+      queueDepth: 0,
+      receivedAtMs: 0,
+    },
+  });
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('cw-store', () => {
+  it('seeds the default settings', () => {
+    const { settings } = useCwStore.getState();
+    expect(settings.wpm).toBe(22);
+    expect(settings.macros).toHaveLength(6);
+    expect(settings.macros[0]).toBe('CQ CQ CQ');
+  });
+
+  it('patchSettings PUTs once and applies the server response', async () => {
+    // Server normalises the wpm to a clamped value — store must re-apply.
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ...DEFAULT_CW_SETTINGS,
+        wpm: 40,  // server clamped from a hypothetical 999
+      }),
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    await useCwStore.getState().patchSettings({ wpm: 999 });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const call = fetchSpy.mock.calls[0]!;
+    expect(call[0]).toBe('/api/cw/settings');
+    expect(call[1]).toMatchObject({ method: 'PUT' });
+    const body = JSON.parse(call[1].body as string);
+    expect(body).toEqual({ wpm: 999 });
+    // Re-applied with server-normalised value.
+    expect(useCwStore.getState().settings.wpm).toBe(40);
+  });
+
+  it('patchSettings reverts the optimistic update on network failure', async () => {
+    globalThis.fetch = (() => Promise.reject(new Error('offline'))) as unknown as typeof fetch;
+
+    await useCwStore.getState().patchSettings({ wpm: 30 });
+
+    // Reverted to the seeded default — the operator sees their edit roll
+    // back, which is the honest signal that the save failed.
+    expect(useCwStore.getState().settings.wpm).toBe(22);
+  });
+
+  it('setMacro PATCHes only the macros field', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ...DEFAULT_CW_SETTINGS,
+        macros: ['HELLO', 'TU 73', 'QRZ?', 'AGN?', '5NN TU', 'UR RST'],
+      }),
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    await useCwStore.getState().setMacro(0, 'HELLO');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1].body as string);
+    // Only macros is in the body — wpm, sidetone etc. stay server-side.
+    expect(Object.keys(body)).toEqual(['macros']);
+    expect(body.macros[0]).toBe('HELLO');
+    expect(body.macros).toHaveLength(6);
+    expect(useCwStore.getState().settings.macros[0]).toBe('HELLO');
+  });
+
+  it('addMacro appends an empty slot and PUTs', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ...DEFAULT_CW_SETTINGS,
+        macros: [...DEFAULT_CW_SETTINGS.macros, ''],
+      }),
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    await useCwStore.getState().addMacro();
+
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1].body as string);
+    expect(body.macros).toHaveLength(DEFAULT_CW_SETTINGS.macros.length + 1);
+    expect(body.macros[DEFAULT_CW_SETTINGS.macros.length]).toBe('');
+    expect(useCwStore.getState().settings.macros).toHaveLength(
+      DEFAULT_CW_SETTINGS.macros.length + 1,
+    );
+  });
+
+  it('removeMacro drops the named index and PUTs', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ...DEFAULT_CW_SETTINGS,
+        macros: DEFAULT_CW_SETTINGS.macros.filter((_, i) => i !== 2),
+      }),
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    await useCwStore.getState().removeMacro(2);
+
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1].body as string);
+    expect(body.macros).toHaveLength(DEFAULT_CW_SETTINGS.macros.length - 1);
+    expect(body.macros).not.toContain(DEFAULT_CW_SETTINGS.macros[2]);
+  });
+
+  it('commitDebounced only PUTs once for a burst of calls', async () => {
+    // Regression for the "slider snaps back" bug: rapid pointer moves
+    // used to fire one PUT per tick, and out-of-order responses could
+    // clobber the operator's final value. commitDebounced coalesces.
+    vi.useFakeTimers();
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ...DEFAULT_CW_SETTINGS, wpm: 35 }),
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { commitDebounced } = useCwStore.getState();
+    commitDebounced({ wpm: 30 });
+    commitDebounced({ wpm: 31 });
+    commitDebounced({ wpm: 35 });
+    expect(fetchSpy).toHaveBeenCalledTimes(0);
+
+    vi.advanceTimersByTime(300);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1].body as string);
+    expect(body.wpm).toBe(35);
+
+    vi.useRealTimers();
+  });
+
+  it('setStatusFromServer replaces the in-flight status', () => {
+    useCwStore.getState().setStatusFromServer({
+      state: 'sending',
+      text: 'CQ CQ CQ',
+      wpm: 22,
+      queueDepth: 2,
+      receivedAtMs: 123456,
+    });
+
+    const { status } = useCwStore.getState();
+    expect(status.state).toBe('sending');
+    expect(status.text).toBe('CQ CQ CQ');
+    expect(status.wpm).toBe(22);
+    expect(status.queueDepth).toBe(2);
+    expect(status.receivedAtMs).toBe(123456);
+  });
+});

--- a/zeus-web/src/state/cw-store.ts
+++ b/zeus-web/src/state/cw-store.ts
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+
+import { create } from 'zustand';
+import {
+  DEFAULT_CW_SETTINGS,
+  fetchCwSettings,
+  saveCwSettings,
+  type CwSettings,
+} from '../api/cw';
+
+// CW engine state — must match the byte values of the C# CwEngineState
+// enum (Zeus.Contracts/CwEngineStatus.cs). Idle is the resting state with
+// no MOX; Sending is mid-playback; Stopping/Aborting are transitional.
+export type CwEngineState = 'idle' | 'sending' | 'stopping' | 'aborting';
+
+export const CW_STATE_FROM_BYTE: Record<number, CwEngineState> = {
+  0: 'idle',
+  1: 'sending',
+  2: 'stopping',
+  3: 'aborting',
+};
+
+export type CwEngineStatus = {
+  state: CwEngineState;
+  /** Text currently being keyed out (empty when state is idle). */
+  text: string;
+  /** Playback WPM for the current message — needed by the macro pad to
+   * estimate per-character progress without polling. */
+  wpm: number;
+  /** Jobs still waiting in the queue after the current one. 0 when idle. */
+  queueDepth: number;
+  /** Local timestamp (ms) when the most recent status frame arrived.
+   * Used by the panel to highlight the active character based on elapsed
+   * time × WPM — server only emits frames on state edges, so the per-
+   * character animation is reconstructed client-side. */
+  receivedAtMs: number;
+};
+
+const IDLE_STATUS: CwEngineStatus = {
+  state: 'idle',
+  text: '',
+  wpm: 0,
+  queueDepth: 0,
+  receivedAtMs: 0,
+};
+
+type CwStore = {
+  settings: CwSettings;
+  /** Optimistic save: caller mutates the store immediately, then the PUT
+   * either succeeds (server may normalise — re-apply the response) or
+   * fails (revert). Use this for one-shot saves (macro edit, slider
+   * release). For high-frequency updates (slider drag) use
+   * <see cref="setSettingsLocal"/> + <see cref="commitDebounced"/>. */
+  patchSettings: (patch: Partial<CwSettings>) => Promise<void>;
+  /** Update settings in-memory only; does NOT round-trip to the server.
+   * Used by the WPM slider during drag so the UI tracks the pointer
+   * without a 100-PUT thundering herd. Pair with <see cref="commitDebounced"/>
+   * to schedule the final save. */
+  setSettingsLocal: (patch: Partial<CwSettings>) => void;
+  /** Schedule a server PUT for the named field after a quiet period.
+   * The latest scheduled value wins — earlier scheduled PUTs are
+   * cancelled. Fixes the "slider snaps back" race where rapid PUTs
+   * from drag could complete out of order. */
+  commitDebounced: (patch: Partial<CwSettings>) => void;
+  setMacro: (index: number, value: string) => Promise<void>;
+  /** Append a new empty macro slot. The operator typically clicks edit
+   * on the freshly-added slot to fill it in. */
+  addMacro: () => Promise<void>;
+  removeMacro: (index: number) => Promise<void>;
+  status: CwEngineStatus;
+  /** Called by the WS dispatcher on every CwEngineStatus frame. */
+  setStatusFromServer: (s: CwEngineStatus) => void;
+};
+
+// Debounce timer for commitDebounced. Lives at module scope so a re-render
+// of CwPanel doesn't reset it; we only ever want one PUT in flight per
+// "burst" of operator input.
+const DEBOUNCE_MS = 250;
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+export const useCwStore = create<CwStore>((set, get) => ({
+  // Mirror the API's defaults — backend Get() ships the same values on
+  // a fresh install, so the UI doesn't flicker through "empty" while the
+  // hydrate fetch is in flight.
+  settings: DEFAULT_CW_SETTINGS,
+  patchSettings: async (patch) => {
+    const prev = get().settings;
+    const next = { ...prev, ...patch };
+    set({ settings: next });
+    try {
+      const server = await saveCwSettings(patch);
+      // Server may normalise (clamp WPM, truncate a long macro, etc.).
+      // Re-apply only if it actually changed something, to avoid an extra
+      // render on the common no-op-normalisation path.
+      if (!shallowEqualCwSettings(server, next)) {
+        set({ settings: server });
+      }
+    } catch {
+      // Roll back the optimistic update so the UI stays consistent with
+      // what the server actually persisted. The user will see their edit
+      // revert, which is the honest signal that the save failed.
+      set({ settings: prev });
+    }
+  },
+  setSettingsLocal: (patch) => {
+    set((s) => ({ settings: { ...s.settings, ...patch } }));
+  },
+  commitDebounced: (patch) => {
+    if (debounceTimer !== null) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      // Don't roll back on debounced saves — the operator has moved on,
+      // and a stale rollback that flips the slider back mid-typing would
+      // be more disorienting than a silent failure. The next save will
+      // retry; if the backend is truly down, the operator's next page
+      // load will resync from the persisted state.
+      void saveCwSettings(patch).catch(() => undefined);
+    }, DEBOUNCE_MS);
+  },
+  setMacro: async (index, value) => {
+    const macros = [...get().settings.macros];
+    macros[index] = value;
+    await get().patchSettings({ macros });
+  },
+  addMacro: async () => {
+    const macros = [...get().settings.macros, ''];
+    await get().patchSettings({ macros });
+  },
+  removeMacro: async (index) => {
+    const macros = get().settings.macros.filter((_, i) => i !== index);
+    await get().patchSettings({ macros });
+  },
+  status: IDLE_STATUS,
+  setStatusFromServer: (s) => set({ status: s }),
+}));
+
+function shallowEqualCwSettings(a: CwSettings, b: CwSettings): boolean {
+  if (
+    a.wpm !== b.wpm ||
+    a.farnsworthWpm !== b.farnsworthWpm ||
+    a.sidetoneGainDb !== b.sidetoneGainDb ||
+    a.sidetoneHz !== b.sidetoneHz
+  )
+    return false;
+  if (a.macros.length !== b.macros.length) return false;
+  for (let i = 0; i < a.macros.length; i++) {
+    if (a.macros[i] !== b.macros[i]) return false;
+  }
+  return true;
+}
+
+// Hydrate on module load. Same pattern as bottom-pin-store; tolerates a
+// failed fetch by leaving the defaults in place — subsequent patchSettings
+// will retry via PUT.
+export async function hydrateCwSettings(): Promise<void> {
+  try {
+    const server = await fetchCwSettings();
+    useCwStore.setState({ settings: server });
+  } catch {
+    /* network failure — keep defaults */
+  }
+}
+
+void hydrateCwSettings();

--- a/zeus-web/src/state/display-settings-store.ts
+++ b/zeus-web/src/state/display-settings-store.ts
@@ -219,6 +219,32 @@ function writeSavedWfTxRange(wfTxDbMin: number, wfTxDbMax: number): void {
   }
 }
 
+// Debounced server save for dB range changes. The drag gesture fires many
+// small shiftDbRange calls per second; we batch them into a single PUT after
+// the operator lifts their finger (1 s quiet period), the same pattern used
+// by layout-store.ts for tile position saves.
+let dbRangeTimer: ReturnType<typeof setTimeout> | null = null;
+
+function scheduleDbRangeSave(): void {
+  if (dbRangeTimer) clearTimeout(dbRangeTimer);
+  dbRangeTimer = setTimeout(() => {
+    const s = useDisplaySettingsStore.getState();
+    void updateDisplaySettings(
+      s.panBackground,
+      s.backgroundImageFit,
+      s.rxTraceColor,
+      s.dbMin,
+      s.dbMax,
+      s.txDbMin,
+      s.txDbMax,
+      s.wfDbMin,
+      s.wfDbMax,
+      s.wfTxDbMin,
+      s.wfTxDbMax,
+    );
+  }, 1000);
+}
+
 // Exponential smoothing constant for the auto-range tracker. 0.1 trades
 // flicker resistance for responsiveness — band-change artifacts fade over
 // ~30 frames at 30 Hz (~1 s).
@@ -418,6 +444,7 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
     const nextMax = Math.max(-DB_ABS_LIMIT, Math.min(DB_ABS_LIMIT, baseMax + deltaDb));
     set({ autoRange: false, dbMin: nextMin, dbMax: nextMax });
     writeSavedRange(nextMin, nextMax);
+    scheduleDbRangeSave();
   },
   shiftTxDbRange: (deltaDb) => {
     const { txDbMin, txDbMax } = get();
@@ -425,6 +452,7 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
     const nextMax = Math.max(-DB_ABS_LIMIT, Math.min(DB_ABS_LIMIT, txDbMax + deltaDb));
     set({ txDbMin: nextMin, txDbMax: nextMax });
     writeSavedTxRange(nextMin, nextMax);
+    scheduleDbRangeSave();
   },
   shiftWfDbRange: (deltaDb) => {
     const { wfDbMin, wfDbMax } = get();
@@ -432,6 +460,7 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
     const nextMax = Math.max(-DB_ABS_LIMIT, Math.min(DB_ABS_LIMIT, wfDbMax + deltaDb));
     set({ wfDbMin: nextMin, wfDbMax: nextMax });
     writeSavedWfRange(nextMin, nextMax);
+    scheduleDbRangeSave();
   },
   shiftWfTxDbRange: (deltaDb) => {
     const { wfTxDbMin, wfTxDbMax } = get();
@@ -439,6 +468,7 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
     const nextMax = Math.max(-DB_ABS_LIMIT, Math.min(DB_ABS_LIMIT, wfTxDbMax + deltaDb));
     set({ wfTxDbMin: nextMin, wfTxDbMax: nextMax });
     writeSavedWfTxRange(nextMin, nextMax);
+    scheduleDbRangeSave();
   },
   updateAutoRange: (wfDb) => {
     if (!get().autoRange || wfDb.length === 0) return;
@@ -522,12 +552,37 @@ async function hydrateFromServer(): Promise<void> {
 
   clearLegacyLocalStorage();
 
+  // Server dB values of null mean the field was never stored (fresh install
+  // or first run after upgrading to a version that added server persistence).
+  // Use server values when present; otherwise keep the localStorage-initialized
+  // state and push it up so the server has it for next restart.
+  const serverHasDbRange = server.dbMin !== null;
+
   useDisplaySettingsStore.setState({
     panBackground: server.mode,
     backgroundImage: server.hasImage ? displayImageUrl(Date.now()) : null,
     backgroundImageFit: server.fit,
     rxTraceColor: server.rxTraceColor,
+    ...(serverHasDbRange
+      ? {
+          dbMin: server.dbMin!,
+          dbMax: server.dbMax!,
+          txDbMin: server.txDbMin!,
+          txDbMax: server.txDbMax!,
+          wfDbMin: server.wfDbMin!,
+          wfDbMax: server.wfDbMax!,
+          wfTxDbMin: server.wfTxDbMin!,
+          wfTxDbMax: server.wfTxDbMax!,
+        }
+      : {}),
   });
+
+  if (!serverHasDbRange) {
+    // Push the current in-memory values (from localStorage or defaults) up
+    // to the server so subsequent restarts find them persisted. This is the
+    // one-time migration for operators upgrading from localStorage-only storage.
+    scheduleDbRangeSave();
+  }
 }
 
 function readLegacyLocalStorage(): { mode: PanBackgroundMode | null; fit: BackgroundImageFit | null; image: string | null } | null {

--- a/zeus-web/src/state/display-settings-store.ts
+++ b/zeus-web/src/state/display-settings-store.ts
@@ -86,6 +86,14 @@ const LEGACY_RX_TRACE_COLOR_KEY = 'zeus.display.rxTraceColor';
 // DisplaySettingsStore.DefaultRxTraceColor.
 export const DEFAULT_RX_TRACE_COLOR = '#FFA028';
 
+// Waterfall colormap brightness multiplier (issue #426). 1.0 = neutral
+// (shader applies no change), < 1.0 darkens, > 1.0 brightens. Bounds and
+// default must stay in lockstep with WfBrightnessMin / WfBrightnessMax /
+// the server-side NormalizeBrightness clamp in DisplaySettingsStore.cs.
+export const WF_BRIGHTNESS_DEFAULT = 1.0;
+export const WF_BRIGHTNESS_MIN = 0.25;
+export const WF_BRIGHTNESS_MAX = 4.0;
+
 function isHexColor(v: unknown): v is string {
   return typeof v === 'string' && /^#[0-9A-Fa-f]{6}$/.test(v);
 }
@@ -241,6 +249,7 @@ function scheduleDbRangeSave(): void {
       s.wfDbMax,
       s.wfTxDbMin,
       s.wfTxDbMax,
+      s.wfBrightness,
     );
   }, 1000);
 }
@@ -279,6 +288,13 @@ export type DisplaySettingsState = {
   // parity — see TX_FIXED_DB_MIN/MAX constants.
   txDbMin: number;
   txDbMax: number;
+  // Waterfall colormap brightness multiplier (issue #426). Applied in
+  // gl/shaders.ts WF_FS before the LUT lookup. 1.0 = no change. Persisted
+  // server-side via the same debounced /api/display-settings PUT used by
+  // the dB-range fields. Hydrated from server on load — null means the
+  // server has never stored a value, in which case the default 1.0 is used
+  // and pushed up on next interaction.
+  wfBrightness: number;
   colormap: ColormapId;
   // Panadapter background overlay mode + (optional) user image. See the
   // PanBackgroundMode and BackgroundImageFit types above. Persisted on the
@@ -314,6 +330,13 @@ export type DisplaySettingsState = {
   shiftWfDbRange: (deltaDb: number) => void;
   // Same as shiftWfDbRange but for the TX-specific waterfall range.
   shiftWfTxDbRange: (deltaDb: number) => void;
+  // Set the waterfall brightness multiplier. Clamps to
+  // WF_BRIGHTNESS_MIN..WF_BRIGHTNESS_MAX and schedules a debounced server
+  // save (callers stream updates live during the drag and the debounce
+  // collapses them into a single PUT after the operator releases the
+  // slider, matching the panadapter-dB-scale pattern). Non-finite input is
+  // ignored.
+  setWfBrightness: (v: number) => void;
 };
 
 const DB_ABS_LIMIT = 200;
@@ -333,6 +356,7 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
   wfTxDbMax: initialWfTxRange.wfTxDbMax,
   txDbMin: initialTxRange.txDbMin,
   txDbMax: initialTxRange.txDbMax,
+  wfBrightness: WF_BRIGHTNESS_DEFAULT,
   colormap: 'blue',
   // Defaults until the server-side fetch lands (see hydrateFromServer at the
   // bottom of this file). The operator briefly sees a plain panadapter on
@@ -470,6 +494,13 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
     writeSavedWfTxRange(nextMin, nextMax);
     scheduleDbRangeSave();
   },
+  setWfBrightness: (v) => {
+    if (!Number.isFinite(v)) return;
+    const clamped = Math.max(WF_BRIGHTNESS_MIN, Math.min(WF_BRIGHTNESS_MAX, v));
+    if (clamped === get().wfBrightness) return;
+    set({ wfBrightness: clamped });
+    scheduleDbRangeSave();
+  },
   updateAutoRange: (wfDb) => {
     if (!get().autoRange || wfDb.length === 0) return;
     const [p5, p95] = percentiles(wfDb);
@@ -575,12 +606,17 @@ async function hydrateFromServer(): Promise<void> {
           wfTxDbMax: server.wfTxDbMax!,
         }
       : {}),
+    // Brightness is independent of the dB-range fields — a fresh install
+    // without dB persistence can still have a stored brightness if the
+    // operator only touched that slider. Apply whenever the server has it.
+    ...(server.wfBrightness !== null ? { wfBrightness: server.wfBrightness } : {}),
   });
 
-  if (!serverHasDbRange) {
-    // Push the current in-memory values (from localStorage or defaults) up
-    // to the server so subsequent restarts find them persisted. This is the
-    // one-time migration for operators upgrading from localStorage-only storage.
+  if (!serverHasDbRange || server.wfBrightness === null) {
+    // Push the current in-memory values (from localStorage / defaults) up
+    // to the server so subsequent restarts find them persisted. One-time
+    // migration for operators upgrading from a build that didn't persist
+    // the dB scale or brightness.
     scheduleDbRangeSave();
   }
 }

--- a/zeus-web/src/state/display-store.ts
+++ b/zeus-web/src/state/display-store.ts
@@ -55,7 +55,20 @@ export type DisplayState = {
   panValid: boolean;
   wfValid: boolean;
   lastSeq: number;
+  // Pure-pan viewport offset (docs/prd/panfall_behavior.md). Hz offset of the
+  // panadapter/waterfall viewport centre from the radio's hardware NCO
+  // (radioLoHz, which is what the incoming frames' `centerHz` reflects). 0 =
+  // viewport centred on the radio LO; negative = panned right (showing lower
+  // freqs at centre); positive = panned left. Frontend-only — never sent to
+  // the server during the drag. Reset to 0 on disconnect and on any explicit
+  // tune-to-frequency action (band buttons, presets, typed freq, click-to-
+  // tune). Pointer-down captures the value, pointer-move mutates it, and
+  // pointer-up either leaves it (if the viewport sits inside the IQ window)
+  // or triggers a /api/radio/lo retune and rebases the offset so on-screen
+  // frequencies stay put across the LO move.
+  viewportOffsetHz: number;
   setConnected: (c: boolean) => void;
+  setViewportOffsetHz: (hz: number) => void;
   pushFrame: (f: DecodedFrame) => void;
 };
 
@@ -69,7 +82,10 @@ export const useDisplayStore = create<DisplayState>((set) => ({
   panValid: false,
   wfValid: false,
   lastSeq: 0,
-  setConnected: (connected) => set({ connected }),
+  viewportOffsetHz: 0,
+  setConnected: (connected) =>
+    set(connected ? { connected } : { connected, viewportOffsetHz: 0 }),
+  setViewportOffsetHz: (viewportOffsetHz) => set({ viewportOffsetHz }),
   pushFrame: (f) =>
     set({
       width: f.width,

--- a/zeus-web/src/state/meter-display-settings-store.ts
+++ b/zeus-web/src/state/meter-display-settings-store.ts
@@ -9,7 +9,11 @@
 import { create } from 'zustand';
 import {
   fetchMeterDisplaySettings,
+  updateMaxDisplayedWatts,
   updateSMeterOffsetDb,
+  MAX_DISPLAYED_WATTS_DEFAULT,
+  MAX_DISPLAYED_WATTS_MAX,
+  MAX_DISPLAYED_WATTS_MIN,
   SMETER_OFFSET_DEFAULT_DB,
   SMETER_OFFSET_MIN_DB,
   SMETER_OFFSET_MAX_DB,
@@ -26,9 +30,13 @@ import {
 
 type MeterDisplaySettingsState = {
   sMeterOffsetDb: number;
+  // 0 = "no override, use radio's MaxWatts as the meter full scale".
+  maxDisplayedWatts: number;
   hydrated: boolean;
   setSMeterOffsetDbLocal: (dB: number) => void;
   persistSMeterOffsetDb: (dB: number) => Promise<void>;
+  setMaxDisplayedWattsLocal: (w: number) => void;
+  persistMaxDisplayedWatts: (w: number) => Promise<void>;
 };
 
 function clampOffset(v: number): number {
@@ -38,8 +46,17 @@ function clampOffset(v: number): number {
   return v;
 }
 
+function clampMaxWatts(v: number): number {
+  if (!Number.isFinite(v)) return MAX_DISPLAYED_WATTS_DEFAULT;
+  if (v <= 0) return MAX_DISPLAYED_WATTS_DEFAULT;
+  if (v < MAX_DISPLAYED_WATTS_MIN) return MAX_DISPLAYED_WATTS_MIN;
+  if (v > MAX_DISPLAYED_WATTS_MAX) return MAX_DISPLAYED_WATTS_MAX;
+  return v;
+}
+
 export const useMeterDisplaySettingsStore = create<MeterDisplaySettingsState>((set) => ({
   sMeterOffsetDb: SMETER_OFFSET_DEFAULT_DB,
+  maxDisplayedWatts: MAX_DISPLAYED_WATTS_DEFAULT,
   hydrated: false,
   setSMeterOffsetDbLocal: (dB) => {
     set({ sMeterOffsetDb: clampOffset(dB) });
@@ -49,11 +66,30 @@ export const useMeterDisplaySettingsStore = create<MeterDisplaySettingsState>((s
     set({ sMeterOffsetDb: next });
     try {
       const result = await updateSMeterOffsetDb(next);
-      set({ sMeterOffsetDb: result.sMeterOffsetDb });
+      set({
+        sMeterOffsetDb: result.sMeterOffsetDb,
+        maxDisplayedWatts: result.maxDisplayedWatts,
+      });
     } catch {
       // Network / server failure — keep the local value. Next commit
       // will retry. We deliberately do NOT roll back: the operator's
       // intent is the value they just dialed in.
+    }
+  },
+  setMaxDisplayedWattsLocal: (w) => {
+    set({ maxDisplayedWatts: clampMaxWatts(w) });
+  },
+  persistMaxDisplayedWatts: async (w) => {
+    const next = clampMaxWatts(w);
+    set({ maxDisplayedWatts: next });
+    try {
+      const result = await updateMaxDisplayedWatts(next);
+      set({
+        sMeterOffsetDb: result.sMeterOffsetDb,
+        maxDisplayedWatts: result.maxDisplayedWatts,
+      });
+    } catch {
+      // See above — keep the local value on failure.
     }
   },
 }));
@@ -63,10 +99,11 @@ async function hydrateFromServer(): Promise<void> {
     const server = await fetchMeterDisplaySettings();
     useMeterDisplaySettingsStore.setState({
       sMeterOffsetDb: server.sMeterOffsetDb,
+      maxDisplayedWatts: server.maxDisplayedWatts,
       hydrated: true,
     });
   } catch {
-    // Backend unreachable — keep the default. Stay unhydrated so the
+    // Backend unreachable — keep the defaults. Stay unhydrated so the
     // next successful fetch (or a PUT) populates the store.
     useMeterDisplaySettingsStore.setState({ hydrated: false });
   }

--- a/zeus-web/src/state/meter-display-settings-store.ts
+++ b/zeus-web/src/state/meter-display-settings-store.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+import { create } from 'zustand';
+import {
+  fetchMeterDisplaySettings,
+  updateSMeterOffsetDb,
+  SMETER_OFFSET_DEFAULT_DB,
+  SMETER_OFFSET_MIN_DB,
+  SMETER_OFFSET_MAX_DB,
+} from '../api/meter-display-settings';
+
+// Display-side meter calibration knobs (GitHub #426). Persisted server-side
+// in zeus-prefs.db (LiteDB) so the calibration follows the operator across
+// browsers / devices. NO localStorage mirror per project_litedb_tx_filter
+// _persistence / project_rotator_resume lessons.
+//
+// The component should call setSMeterOffsetDbLocal(...) on every keystroke
+// (responsive display) and persistSMeterOffsetDb(...) on blur / Enter so
+// the server only sees the committed value.
+
+type MeterDisplaySettingsState = {
+  sMeterOffsetDb: number;
+  hydrated: boolean;
+  setSMeterOffsetDbLocal: (dB: number) => void;
+  persistSMeterOffsetDb: (dB: number) => Promise<void>;
+};
+
+function clampOffset(v: number): number {
+  if (!Number.isFinite(v)) return SMETER_OFFSET_DEFAULT_DB;
+  if (v < SMETER_OFFSET_MIN_DB) return SMETER_OFFSET_MIN_DB;
+  if (v > SMETER_OFFSET_MAX_DB) return SMETER_OFFSET_MAX_DB;
+  return v;
+}
+
+export const useMeterDisplaySettingsStore = create<MeterDisplaySettingsState>((set) => ({
+  sMeterOffsetDb: SMETER_OFFSET_DEFAULT_DB,
+  hydrated: false,
+  setSMeterOffsetDbLocal: (dB) => {
+    set({ sMeterOffsetDb: clampOffset(dB) });
+  },
+  persistSMeterOffsetDb: async (dB) => {
+    const next = clampOffset(dB);
+    set({ sMeterOffsetDb: next });
+    try {
+      const result = await updateSMeterOffsetDb(next);
+      set({ sMeterOffsetDb: result.sMeterOffsetDb });
+    } catch {
+      // Network / server failure — keep the local value. Next commit
+      // will retry. We deliberately do NOT roll back: the operator's
+      // intent is the value they just dialed in.
+    }
+  },
+}));
+
+async function hydrateFromServer(): Promise<void> {
+  try {
+    const server = await fetchMeterDisplaySettings();
+    useMeterDisplaySettingsStore.setState({
+      sMeterOffsetDb: server.sMeterOffsetDb,
+      hydrated: true,
+    });
+  } catch {
+    // Backend unreachable — keep the default. Stay unhydrated so the
+    // next successful fetch (or a PUT) populates the store.
+    useMeterDisplaySettingsStore.setState({ hydrated: false });
+  }
+}
+
+void hydrateFromServer();

--- a/zeus-web/src/state/pan-wf-split-store.ts
+++ b/zeus-web/src/state/pan-wf-split-store.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+// See LICENSE for the full GPL text.
+
+import { create } from 'zustand';
+import {
+  fetchPanWfSplit,
+  updatePanWfSplit,
+  PAN_WF_DEFAULT_PERCENT,
+  PAN_WF_MIN_PERCENT,
+  PAN_WF_MAX_PERCENT,
+} from '../api/pan-wf-split';
+
+// Vertical pan/wf split (panadapter share, 10..90). Persisted server-side
+// in zeus-prefs.db (LiteDB) so the choice follows the operator across
+// browsers / devices — same pattern as BottomPin. NO localStorage mirror
+// per project_litedb_tx_filter_persistence / project_rotator_resume.
+//
+// Live drag: setPanPercentLive() updates the in-memory value at pointer
+// rate so the canvases reflow immediately. Persistence is a debounced
+// (~300 ms after drag-end) PUT via persistPanPercent(); we send a final
+// PUT when the operator releases. The store never mirrors to
+// localStorage.
+
+type PanWfSplitState = {
+  panPercent: number;
+  hydrated: boolean;
+  setPanPercentLive: (pct: number) => void;
+  persistPanPercent: (pct: number) => Promise<void>;
+};
+
+function clamp(v: number): number {
+  if (!Number.isFinite(v)) return PAN_WF_DEFAULT_PERCENT;
+  if (v < PAN_WF_MIN_PERCENT) return PAN_WF_MIN_PERCENT;
+  if (v > PAN_WF_MAX_PERCENT) return PAN_WF_MAX_PERCENT;
+  return v;
+}
+
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+export const usePanWfSplitStore = create<PanWfSplitState>((set) => ({
+  panPercent: PAN_WF_DEFAULT_PERCENT,
+  hydrated: false,
+  setPanPercentLive: (pct) => {
+    set({ panPercent: clamp(pct) });
+  },
+  persistPanPercent: async (pct) => {
+    const next = clamp(pct);
+    set({ panPercent: next });
+    if (debounceTimer !== null) {
+      clearTimeout(debounceTimer);
+      debounceTimer = null;
+    }
+    await new Promise<void>((resolve) => {
+      debounceTimer = setTimeout(async () => {
+        debounceTimer = null;
+        try {
+          const result = await updatePanWfSplit({ panPercent: next });
+          set({ panPercent: result.panPercent });
+        } catch {
+          // Network / server failure — keep the live value; next drag will
+          // try again. We deliberately do NOT roll back because the
+          // operator's intent is the local value they just dragged to.
+        }
+        resolve();
+      }, 300);
+    });
+  },
+}));
+
+async function hydrateFromServer(): Promise<void> {
+  try {
+    const server = await fetchPanWfSplit();
+    usePanWfSplitStore.setState({ panPercent: server.panPercent, hydrated: true });
+  } catch {
+    // Backend unreachable — keep the default 50%. The store stays unhydrated
+    // so the next successful fetch (or a drag-end PUT) can populate it.
+    usePanWfSplitStore.setState({ hydrated: false });
+  }
+}
+
+void hydrateFromServer();

--- a/zeus-web/src/state/rotator-store.ts
+++ b/zeus-web/src/state/rotator-store.ts
@@ -44,6 +44,7 @@
 
 import { create } from 'zustand';
 import {
+  getRotatorConfig,
   getRotatorStatus,
   postRotatorConfig,
   setRotatorAz,
@@ -54,10 +55,9 @@ import {
   type RotctldTestResult,
 } from '../api/rotator';
 
-// Persist the host/port/enabled/interval the user has chosen so the pill
-// stays usable across reloads. The backend is the source of truth while
-// connected; this is just the form-default memory.
-const CONFIG_STORAGE_KEY = 'zeus.rotator.config';
+// Defaults match the backend record so the form has sensible values until the
+// first /api/rotator/config response lands. The backend is the sole source of
+// truth — config is persisted server-side in zeus-prefs.db, not in localStorage.
 const DEFAULT_CONFIG: RotctldConfig = {
   enabled: false,
   host: '127.0.0.1',
@@ -65,41 +65,13 @@ const DEFAULT_CONFIG: RotctldConfig = {
   pollingIntervalMs: 500,
 };
 
-function readSavedConfig(): RotctldConfig {
-  try {
-    if (typeof localStorage === 'undefined') return DEFAULT_CONFIG;
-    const raw = localStorage.getItem(CONFIG_STORAGE_KEY);
-    if (!raw) return DEFAULT_CONFIG;
-    const parsed = JSON.parse(raw) as Partial<RotctldConfig>;
-    return {
-      enabled: Boolean(parsed.enabled),
-      host: typeof parsed.host === 'string' && parsed.host ? parsed.host : DEFAULT_CONFIG.host,
-      port: typeof parsed.port === 'number' && parsed.port > 0 ? parsed.port : DEFAULT_CONFIG.port,
-      pollingIntervalMs:
-        typeof parsed.pollingIntervalMs === 'number' && parsed.pollingIntervalMs > 0
-          ? parsed.pollingIntervalMs
-          : DEFAULT_CONFIG.pollingIntervalMs,
-    };
-  } catch {
-    return DEFAULT_CONFIG;
-  }
-}
-
-function writeSavedConfig(cfg: RotctldConfig): void {
-  try {
-    if (typeof localStorage === 'undefined') return;
-    localStorage.setItem(CONFIG_STORAGE_KEY, JSON.stringify(cfg));
-  } catch {
-    /* quota — silent */
-  }
-}
-
 export type RotatorStoreState = {
   config: RotctldConfig;
   status: RotctldStatus | null;
   testInFlight: boolean;
   lastTestResult: RotctldTestResult | null;
 
+  refreshConfig: () => Promise<void>;
   refreshStatus: () => Promise<void>;
   saveConfig: (cfg: RotctldConfig) => Promise<RotctldStatus>;
   setAzimuth: (az: number) => Promise<RotctldStatus | null>;
@@ -108,10 +80,19 @@ export type RotatorStoreState = {
 };
 
 export const useRotatorStore = create<RotatorStoreState>((set) => ({
-  config: readSavedConfig(),
+  config: DEFAULT_CONFIG,
   status: null,
   testInFlight: false,
   lastTestResult: null,
+
+  refreshConfig: async () => {
+    try {
+      const config = await getRotatorConfig();
+      set({ config });
+    } catch {
+      /* transient — leave defaults in place */
+    }
+  },
 
   refreshStatus: async () => {
     try {
@@ -123,7 +104,6 @@ export const useRotatorStore = create<RotatorStoreState>((set) => ({
   },
 
   saveConfig: async (cfg) => {
-    writeSavedConfig(cfg);
     const status = await postRotatorConfig(cfg);
     set({ config: cfg, status });
     return status;
@@ -156,22 +136,18 @@ export const useRotatorStore = create<RotatorStoreState>((set) => ({
   },
 }));
 
-// Kick off an initial status probe at module load, then poll at 1 s while the
-// page is alive AND rotctld is enabled. When disabled there's nothing to
-// reconcile — skip the fetch to avoid an idle-RX HTTP wakeup the user can't
-// see anyway.
+// Hydrate config + status from the backend at module load, then poll status at
+// 1 s while the page is alive AND rotctld is enabled. When disabled there's
+// nothing to reconcile — skip the fetch to avoid an idle-RX HTTP wakeup.
+//
+// Note: we deliberately do NOT POST anything on load. The backend hydrates its
+// own config from LiteDB at startup; pushing a cached client copy here would
+// race that hydration and re-enable a rotator the operator already turned off.
 if (typeof window !== 'undefined') {
+  void useRotatorStore.getState().refreshConfig();
   void useRotatorStore.getState().refreshStatus();
   window.setInterval(() => {
     if (!useRotatorStore.getState().config.enabled) return;
     void useRotatorStore.getState().refreshStatus();
   }, 1000);
-
-  // Push the saved config to the backend on first load so the service is in the
-  // same state the UI will render (Enabled flag, host/port). Backend state is
-  // in-memory only — a restart resets to defaults.
-  const initial = useRotatorStore.getState().config;
-  if (initial.enabled) {
-    void useRotatorStore.getState().saveConfig(initial);
-  }
 }

--- a/zeus-web/src/state/tx-store.ts
+++ b/zeus-web/src/state/tx-store.ts
@@ -429,6 +429,10 @@ export const useTxStore = create<TxState>()(
           // a first-paint flicker before this hydrate runs.
           drivePercent: s.drivePercent,
           tunePercent: s.tunePercent,
+          // Mic gain + Leveler max-gain — server-authoritative (RadioStateStore).
+          // Previously localStorage-only and reverted on every desktop relaunch.
+          micGainDb: s.micGainDb,
+          levelerMaxGainDb: s.levelerMaxGainDb,
           psAuto: s.psAuto,
           psPtol: s.psPtol,
           psAutoAttenuate: s.psAutoAttenuate,

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -1773,26 +1773,392 @@
   box-shadow: 0 0 0 1px rgba(0,0,0,0.5), 0 1px 4px rgba(0,0,0,0.5);
 }
 
-/* ===== CW ===== */
-.cw { padding: 10px; display: flex; flex-direction: column; gap: 10px; background: var(--bg-1); }
-.cw-macros { display: grid; grid-template-columns: repeat(3, 1fr); gap: 4px; }
-.cw-stream {
+/* ===== CW — Telegraph Console layout =====
+   Three regions stacked top-down:
+     1. Stream HERO   — the always-on telegraph tape with state LED + queue chip
+     2. Control strip — chunky WPM readout, dial, and STOP kill-switch
+     3. Macro list    — numbered tiles + dashed Add tile
+   Designed around the 280–360 px-wide dockable panel; the column-flex
+   structure copes with both ends of that range without media queries.
+
+   Aesthetic: "lit instruments on a black bench" — the existing Zeus
+   immersive direction. Stream and STOP are the only places with semantic
+   colour (accent blue when sending, TX red when armed); everything else
+   stays in the neutral grey palette so a glance at the panel reads the
+   transmit state without parsing text. */
+
+.cw.cw-console {
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: var(--bg-1);
+}
+
+/* ---- Stream HERO -------------------------------------------------- */
+/* Inset well across the top — same depth treatment as the panadapter
+   and immersive meter wells (var(--bg-inset)), so the stream reads as
+   a screen embedded in the panel chrome rather than a regular row. */
+.cw-stream-hero {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 10px;
   padding: 8px 10px;
-  background: #000;
-  border: 1px solid rgba(0,0,0,0.8);
-  border-radius: 0;
-  font-size: 14px;
-  color: var(--accent);
-  letter-spacing: 0.2em;
-  min-height: 32px;
+  min-height: 44px;
+  background: var(--bg-inset);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-md);
+  box-shadow:
+    inset 0 1px 0 rgba(0,0,0,0.6),
+    inset 0 -1px 0 rgba(255,255,255,0.02);
+  /* Subtle horizontal scanlines so the tape reads as a backlit display
+     instead of a flat <div>. Stays under the text. */
+  background-image:
+    var(--bg-inset, #060608),
+    repeating-linear-gradient(
+      to bottom,
+      rgba(255,255,255,0.012) 0px,
+      rgba(255,255,255,0.012) 1px,
+      transparent 1px,
+      transparent 3px
+    );
+}
+.cw-stream-tag {
   display: flex;
   align-items: center;
   gap: 6px;
-  box-shadow: inset 0 1px 3px rgba(0,0,0,0.8);
-  text-shadow: 0 0 6px var(--accent);
+  /* Width-stable across state changes so the tape doesn't reflow on
+     idle → sending transitions. "ABORTING" (8 chars) is the widest. */
+  min-width: 78px;
 }
-.cw-cursor { animation: blink 1s steps(2) infinite; color: var(--accent); }
-@keyframes blink { 50% { opacity: 0.2; } }
+.cw-stream-led {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--fg-4);
+  box-shadow: inset 0 0 2px rgba(0,0,0,0.6);
+  transition: background var(--dur-fast) var(--ease-out),
+              box-shadow var(--dur-fast) var(--ease-out);
+}
+.cw-stream-label {
+  font: 500 10px/1 var(--font-sans);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--fg-2);
+  transition: color var(--dur-fast) var(--ease-out);
+}
+.cw-stream-hero.is-active .cw-stream-led {
+  background: var(--accent-bright);
+  box-shadow:
+    0 0 6px var(--accent-bright),
+    0 0 12px var(--accent-soft);
+  animation: cwLedPulse 1.2s ease-in-out infinite;
+}
+.cw-stream-hero.is-active .cw-stream-label { color: var(--accent-bright); }
+.cw-stream-hero[data-state="aborting"] .cw-stream-led {
+  background: var(--tx);
+  box-shadow: 0 0 6px var(--tx), 0 0 12px var(--tx-soft);
+}
+.cw-stream-hero[data-state="aborting"] .cw-stream-label { color: var(--tx); }
+@keyframes cwLedPulse {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50%      { transform: scale(1.15); opacity: 0.75; }
+}
+
+.cw-stream-tape {
+  font: 500 14px/1.25 var(--font-mono);
+  letter-spacing: 0.08em;
+  color: var(--fg-1);
+  min-width: 0;       /* let the flexbox shrink for ellipsis */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cw-stream-sent { color: var(--fg-3); }      /* already-keyed = dim */
+.cw-stream-pending { color: var(--fg-2); }   /* upcoming = medium */
+.cw-stream-cursor {
+  color: var(--accent-bright);
+  text-shadow: 0 0 6px var(--accent-soft);
+  animation: cwCursorBlink 1s steps(2) infinite;
+}
+@keyframes cwCursorBlink { 50% { opacity: 0.25; } }
+.cw-stream-placeholder {
+  color: var(--fg-3);
+  letter-spacing: 0.3em;
+  font-size: 11px;
+}
+
+.cw-stream-queue {
+  font: 600 11px/1 var(--font-mono);
+  color: var(--fg-2);
+  padding: 3px 6px;
+  min-width: 28px;
+  text-align: center;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-sm);
+  background: rgba(0,0,0,0.3);
+}
+.cw-stream-hero.is-active .cw-stream-queue {
+  color: var(--accent-bright);
+  border-color: var(--accent-line);
+}
+
+/* ---- Control strip — WPM readout + dial + STOP ------------------- */
+.cw-control-strip {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: stretch;
+  gap: 8px;
+}
+/* "Readout well" — a sunken digital chip that pairs with the stream's
+   inset treatment. The big numeric value is the chunky front-panel
+   element the operator's eye finds first; the small WPM label sits
+   above-left like the units printed on a piece of test equipment. */
+.cw-wpm-readout {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 4px 10px 4px 8px;
+  background: var(--bg-meter);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-md);
+  box-shadow:
+    inset 0 1px 0 rgba(0,0,0,0.7),
+    inset 0 -1px 0 rgba(255,255,255,0.03);
+  min-width: 72px;
+}
+.cw-wpm-label {
+  font: 600 9px/1 var(--font-sans);
+  letter-spacing: 0.22em;
+  color: var(--fg-3);
+  text-transform: uppercase;
+}
+.cw-wpm-value {
+  font: 700 26px/1 var(--font-mono);
+  color: var(--fg-0);
+  letter-spacing: -0.01em;
+  margin-top: 2px;
+  /* Faint accent halo so the readout looks "lit" against the well */
+  text-shadow: 0 0 8px rgba(78, 166, 255, 0.18);
+  font-variant-numeric: tabular-nums;
+}
+.cw-wpm-readout.is-active .cw-wpm-value {
+  color: var(--accent-bright);
+  text-shadow: 0 0 10px var(--accent-soft);
+}
+
+.cw-wpm-track {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+  min-width: 0;
+}
+.cw-wpm-track input[type="range"] { width: 100%; }
+.cw-wpm-scale {
+  display: flex;
+  justify-content: space-between;
+  font: 500 9px/1 var(--font-mono);
+  letter-spacing: 0.08em;
+  color: var(--fg-3);
+}
+
+/* STOP — kill-switch styling. Dim and locked when nothing to abort;
+   hot red with a soft halo when sending so the operator can find it
+   with peripheral vision without parsing text. Matches the visual
+   weight of the WPM readout so the strip reads as two paired controls
+   with a thin "dial" between. */
+.cw-stop {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 14px;
+  min-width: 60px;
+  font: 700 11px/1 var(--font-sans);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  background: var(--bg-2);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-md);
+  cursor: not-allowed;
+  transition: background var(--dur-fast) var(--ease-out),
+              color var(--dur-fast) var(--ease-out),
+              border-color var(--dur-fast) var(--ease-out),
+              box-shadow var(--dur-fast) var(--ease-out);
+}
+.cw-stop.is-armed {
+  color: #fff;
+  background: var(--tx);
+  border-color: var(--tx);
+  cursor: pointer;
+  box-shadow:
+    0 0 0 1px rgba(255,255,255,0.05) inset,
+    0 0 12px var(--tx-soft);
+  animation: cwStopArm 1.6s ease-in-out infinite;
+}
+.cw-stop.is-armed:hover { background: #ff5e6c; }
+.cw-stop.is-armed:active { transform: translateY(1px); }
+@keyframes cwStopArm {
+  0%, 100% { box-shadow: 0 0 0 1px rgba(255,255,255,0.05) inset, 0 0 12px var(--tx-soft); }
+  50%      { box-shadow: 0 0 0 1px rgba(255,255,255,0.10) inset, 0 0 18px rgba(255,74,89,0.30); }
+}
+
+/* ---- Macro list -------------------------------------------------- */
+.cw-macro-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* Each row: [00 index][primary send button][edit][delete].
+   The icons sit in dedicated columns at 32 px so they never crowd the
+   text and the click target is always thumb-friendly. */
+.cw-macro-row {
+  display: grid;
+  grid-template-columns: 28px 1fr 32px 32px;
+  align-items: stretch;
+  gap: 2px;
+  /* Mid-grey divider line under each row, dropping the last one. The
+     numbered prefix + dividers give the list the feel of a logbook
+     page rather than a stack of buttons. */
+  border-bottom: 1px solid var(--line-soft);
+}
+.cw-macro-list > .cw-macro-row:last-of-type { border-bottom: 0; }
+
+.cw-macro-num {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font: 600 10px/1 var(--font-mono);
+  color: var(--fg-3);
+  letter-spacing: 0.04em;
+}
+
+/* Send button — full-width text tile. Default state is calm and
+   typographic; on hover the left edge picks up an accent line to
+   advertise "this is the action target." Empty slots are dimmed and
+   italicised, click-disabled. */
+.cw-macro-send {
+  display: flex;
+  align-items: center;
+  padding: 8px 10px;
+  font: 500 13px/1.2 var(--font-sans);
+  color: var(--fg-1);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out),
+              border-color var(--dur-fast) var(--ease-out),
+              color var(--dur-fast) var(--ease-out);
+  /* Left accent rail when hovered — appears via box-shadow so the
+     layout doesn't shift. */
+  box-shadow: inset 2px 0 0 transparent;
+}
+.cw-macro-send:not(:disabled):hover {
+  background: var(--bg-2);
+  color: var(--fg-0);
+  box-shadow: inset 2px 0 0 var(--accent-bright);
+}
+.cw-macro-send:not(:disabled):active {
+  background: var(--bg-3);
+}
+.cw-macro-send.is-empty {
+  color: var(--fg-3);
+  cursor: not-allowed;
+}
+.cw-macro-send.is-empty em {
+  font-style: italic;
+  font-weight: 400;
+  letter-spacing: 0.02em;
+}
+
+/* Inline macro editor — overlays the send cell. Border matches the
+   accent rail so the field looks like the send tile lit up for input. */
+.cw-macro-edit {
+  font: 500 13px/1.2 var(--font-sans);
+  padding: 7px 9px;
+  background: var(--bg-meter);
+  color: var(--fg-0);
+  border: 1px solid var(--accent-line);
+  border-radius: var(--r-sm);
+  outline: none;
+  box-shadow: inset 2px 0 0 var(--accent-bright);
+}
+.cw-macro-edit:focus { border-color: var(--accent-bright); }
+
+/* Icon buttons — sit in their own 32 px columns so they never crowd
+   the macro text. Dim by default, accent / TX on hover, with a subtle
+   tile background that appears on hover only (no fixed chrome at rest
+   keeps the row visually quiet). */
+.cw-macro-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  width: 32px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  color: var(--fg-3);
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out),
+              color var(--dur-fast) var(--ease-out),
+              border-color var(--dur-fast) var(--ease-out);
+}
+.cw-macro-icon:hover {
+  background: var(--bg-2);
+  color: var(--accent-bright);
+  border-color: var(--line-strong);
+}
+.cw-macro-icon.is-danger:hover {
+  color: var(--tx);
+}
+.cw-macro-icon:active { transform: translateY(1px); }
+
+/* Add tile — dashed border so it advertises "this is empty space waiting
+   for content" rather than "this is another macro." Matches the height
+   of a macro row so the bottom of the list doesn't ramp down. */
+.cw-macro-add {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin-top: 6px;
+  padding: 10px 12px;
+  background: transparent;
+  border: 1px dashed var(--line-strong);
+  border-radius: var(--r-md);
+  color: var(--fg-2);
+  font: 600 10px/1 var(--font-sans);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out),
+              border-color var(--dur-fast) var(--ease-out),
+              color var(--dur-fast) var(--ease-out);
+}
+.cw-macro-add:not(:disabled):hover {
+  background: var(--bg-2);
+  border-color: var(--accent-line);
+  border-style: solid;
+  color: var(--accent-bright);
+}
+.cw-macro-add:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+.cw-macro-add-plus {
+  font: 600 14px/1 var(--font-mono);
+  letter-spacing: 0;
+}
+.cw-macro-add-label { letter-spacing: 0.22em; }
+
+/* ===== End CW — Telegraph Console ===== */
 
 /* ===== Transport bar — v3 Lifted Dark: flat near-black ===== */
 .transport {

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -1026,6 +1026,35 @@
 .hero.bg-active .spectrum-canvas { background: transparent !important; }
 .hero.bg-active .waterfall-canvas { background: transparent !important; }
 
+/* Pan / waterfall split drag handle. The handle strip is 8 px tall (easy
+ * pointer target) but renders only a 1 px hairline by default so the
+ * boundary stays visually quiet. Hover/active brighten the hairline with
+ * --accent-line so the operator can see the affordance, but no chrome /
+ * tokens change. Hidden when the map layer is interactive (same gate as
+ * spectrum-stack pointer-events). */
+.pan-wf-split-handle {
+  /* Touch / pointer target — invisible padding above and below the
+   * hairline so a pointer doesn't need pixel-perfect aim. */
+  display: flex;
+  align-items: center;
+  justify-content: stretch;
+}
+.pan-wf-split-handle__line {
+  width: 100%;
+  height: 1px;
+  background: var(--line);
+  opacity: 0.7;
+  transition: background 120ms ease, opacity 120ms ease, height 120ms ease;
+  pointer-events: none;
+}
+.pan-wf-split-handle:hover .pan-wf-split-handle__line,
+.pan-wf-split-handle:active .pan-wf-split-handle__line {
+  background: var(--accent-line, var(--accent));
+  opacity: 1;
+  height: 2px;
+}
+.hero.map-mode .pan-wf-split-handle { display: none; }
+
 /* User-supplied still image rendered behind the panadapter when
    panBackground === 'image'. Sized via the variant class set by
    backgroundImageFit. */

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -2047,19 +2047,25 @@
 }
 .mobile-ptt-btn.tx .mobile-ptt-hint { color: rgba(255,255,255,0.85); }
 
-/* ===== Mobile responsive layout (≤640 px) =====
+/* ===== Mobile responsive layout (≤900 px) =====
    Shows only frequency (VFO), signal (S-meter), mic level, power level (drive),
    the panadapter/waterfall stack, and a big hold-to-talk PTT button where the
    logbook sits on desktop. Everything else — QRZ, azimuth map, DSP, CW keyer,
    logbook, TX stage meters, mode/bandwidth, front-end, AGC, zoom, status chips,
-   tweaks panel — is hidden via the .hide-mobile utility. */
+   tweaks panel — is hidden via the .hide-mobile utility.
+
+   Every rule is scoped to html:not([data-force-desktop="1"]) so that the
+   `?desktop=1` query-param override (set in main.tsx) preserves the full
+   desktop layout in a narrow window — used when a small touchscreen is
+   docked as a secondary control surface. */
 @media (max-width: 900px) {
-  .hide-mobile { display: none !important; }
-  .show-mobile { display: flex; }
+  html:not([data-force-desktop="1"]) .hide-mobile { display: none !important; }
+  html:not([data-force-desktop="1"]) .show-mobile { display: flex; }
 
-  html, body { overflow-x: hidden; }
+  html:not([data-force-desktop="1"]),
+  html:not([data-force-desktop="1"]) body { overflow-x: hidden; }
 
-  .app {
+  html:not([data-force-desktop="1"]) .app {
     grid-template-rows: 44px 52px auto 1fr 44px;
     width: 100%;
     padding: 4px;
@@ -2067,20 +2073,20 @@
     overflow-x: hidden;
   }
 
-  .topbar {
+  html:not([data-force-desktop="1"]) .topbar {
     height: 44px;
     padding: 0 8px;
     gap: 6px;
     min-width: 0;
   }
-  .brand { padding: 0 4px; gap: 6px; }
-  .brand-mark { width: 22px; height: 22px; }
-  .brand-name { font-size: 13px; }
+  html:not([data-force-desktop="1"]) .brand { padding: 0 4px; gap: 6px; }
+  html:not([data-force-desktop="1"]) .brand-mark { width: 22px; height: 22px; }
+  html:not([data-force-desktop="1"]) .brand-name { font-size: 13px; }
   /* Compact the connected "RADIO x.x.x.x:pppp" chip — the mono IP overflows
      a 390 px viewport when the Disconnect button sits next to it. */
-  .topbar .chip.accent .v { max-width: 100px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: inline-block; }
+  html:not([data-force-desktop="1"]) .topbar .chip.accent .v { max-width: 100px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: inline-block; }
 
-  .control-strip {
+  html:not([data-force-desktop="1"]) .control-strip {
     height: 52px;
     padding: 2px 6px;
     gap: 8px;
@@ -2089,17 +2095,17 @@
   }
   /* Override inline min-width on the visible ZOOM ctrl-group so it shrinks
      to fit narrow viewports. */
-  .control-strip .ctrl-group { min-width: 0 !important; }
-  .control-strip .btn-row { min-width: 0; flex: 1; }
-  .control-strip .knob-group { min-width: 0; flex: 1; }
+  html:not([data-force-desktop="1"]) .control-strip .ctrl-group { min-width: 0 !important; }
+  html:not([data-force-desktop="1"]) .control-strip .btn-row { min-width: 0; flex: 1; }
+  html:not([data-force-desktop="1"]) .control-strip .knob-group { min-width: 0; flex: 1; }
 
-  .workspace {
+  html:not([data-force-desktop="1"]) .workspace {
     grid-template-columns: 1fr;
     grid-template-rows: minmax(0, 1.4fr) minmax(0, 0.85fr) auto;
     gap: 4px;
   }
-  .workspace .hero { grid-column: 1; grid-row: 1; }
-  .workspace .side-stack {
+  html:not([data-force-desktop="1"]) .workspace .hero { grid-column: 1; grid-row: 1; }
+  html:not([data-force-desktop="1"]) .workspace .side-stack {
     grid-column: 1;
     grid-row: 2;
     flex-direction: column;
@@ -2107,44 +2113,45 @@
     overflow-x: hidden;
     gap: 4px;
   }
-  .workspace .side-stack .side-slot {
+  html:not([data-force-desktop="1"]) .workspace .side-stack .side-slot {
     flex: 0 0 auto;
     min-width: 0;
   }
-  .workspace .side-stack .side-slot.grow {
+  html:not([data-force-desktop="1"]) .workspace .side-stack .side-slot.grow {
     flex: 0 0 auto;
     min-height: 0;
   }
-  .workspace .bottom-row {
+  html:not([data-force-desktop="1"]) .workspace .bottom-row {
     grid-column: 1;
     grid-row: 3;
     grid-template-columns: 1fr;
     min-height: 72px;
   }
 
-  .freq-digits { font-size: 26px; margin: 2px 0; }
-  .freq-panel { padding: 6px; gap: 4px; }
-  .smeter { padding: 6px 8px; gap: 4px; }
-  .smeter-scale { height: 40px; padding: 4px; }
+  html:not([data-force-desktop="1"]) .freq-digits { font-size: 26px; margin: 2px 0; }
+  html:not([data-force-desktop="1"]) .freq-panel { padding: 6px; gap: 4px; }
+  html:not([data-force-desktop="1"]) .smeter { padding: 6px 8px; gap: 4px; }
+  html:not([data-force-desktop="1"]) .smeter-scale { height: 40px; padding: 4px; }
 
-  .transport {
+  html:not([data-force-desktop="1"]) .transport {
     height: 44px;
     padding: 0 6px;
     gap: 4px;
     min-width: 0;
     overflow-x: hidden;
   }
-  .transport .knob-group { min-width: 0; flex: 1; }
+  html:not([data-force-desktop="1"]) .transport .knob-group { min-width: 0; flex: 1; }
 
-  .tweaks-fab,
-  .tweaks-panel { display: none !important; }
+  html:not([data-force-desktop="1"]) .tweaks-fab,
+  html:not([data-force-desktop="1"]) .tweaks-panel { display: none !important; }
 }
 
 /* Touch-target floor for coarse pointers (phones, tablets). Keyed off pointer
    type rather than width so a narrow desktop window doesn't inherit the
-   bigger tap zones. Apple HIG: 44 px minimum for primary targets. */
+   bigger tap zones. Apple HIG: 44 px minimum for primary targets.
+   Scoped the same way so ?desktop=1 keeps the desktop click targets. */
 @media (pointer: coarse) and (max-width: 900px) {
-  .btn     { min-height: 36px; }
-  .btn.lg  { min-height: 44px; }
-  .btn-row { gap: 6px; }
+  html:not([data-force-desktop="1"]) .btn     { min-height: 36px; }
+  html:not([data-force-desktop="1"]) .btn.lg  { min-height: 44px; }
+  html:not([data-force-desktop="1"]) .btn-row { gap: 6px; }
 }

--- a/zeus-web/src/util/use-pan-tune-gesture.ts
+++ b/zeus-web/src/util/use-pan-tune-gesture.ts
@@ -43,7 +43,7 @@
 // License for details.
 
 import { createContext, useContext, useEffect, type RefObject } from 'react';
-import { setRadioLo, setVfo, setZoom, ZOOM_MAX, ZOOM_MIN, type ZoomLevel } from '../api/client';
+import { setVfo, setZoom, ZOOM_MAX, ZOOM_MIN, type ZoomLevel } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
 import { useDisplayStore } from '../state/display-store';
 import { useToolbarFavoritesStore } from '../state/toolbar-favorites-store';
@@ -333,15 +333,17 @@ export function usePanTuneGesture(
       drag.moved = true;
       const rect = canvas.getBoundingClientRect();
       if (rect.width <= 0) return;
-      // Pure-pan: drag right → viewport centre slides to a lower Hz so the
-      // grabbed content moves right with the finger. No setVfo, no POST —
-      // we just mutate the frontend-only viewportOffsetHz. The panadapter +
-      // waterfall redraw subscribers in Panadapter.tsx / Waterfall.tsx pick
-      // this up and slide the trace + texture under the cursor at rAF rate.
-      const newViewportCenter =
-        drag.startViewportCenterHz - (dx / rect.width) * drag.spanHz;
-      const radioLoHz = useConnectionStore.getState().radioLoHz;
-      useDisplayStore.getState().setViewportOffsetHz(newViewportCenter - radioLoHz);
+      // Drag-to-tune (classic, CTUN pure-pan reverted): the frequency under the
+      // cursor becomes the dial, streamed through the coalesced setVfo pipeline
+      // so the radio retunes live as you drag. No viewport offset — RadioLoHz
+      // follows the dial server-side, RX and TX both track it.
+      const view = readView();
+      if (!view) return;
+      const frac = (e.clientX - rect.left) / rect.width;
+      pendingHz = clampHz(
+        Math.round(view.centerHz + view.viewportOffsetHz + (frac - 0.5) * view.spanHz),
+      );
+      scheduleFlush();
     };
 
     const onPointerUp = (e: PointerEvent) => {
@@ -374,64 +376,13 @@ export function usePanTuneGesture(
       }
       const rect = canvas.getBoundingClientRect();
       if (rect.width <= 0) return;
-      if (d.moved) {
-        // Drag release — decide whether the panned viewport still sits inside
-        // the IQ capture window. If yes, leave viewportOffsetHz as-is; the
-        // dial keeps demodulating its tuned signal (potentially off-screen)
-        // and the operator can keep panning visually. If no, retune the
-        // hardware NCO so the new sample window adjoins the released viewport
-        // in the pan direction; we optimistically rebase the offset so
-        // on-screen frequencies don't visually jump across the retune.
-        const display = useDisplayStore.getState();
-        const cn = useConnectionStore.getState();
-        const viewportOffsetHz = display.viewportOffsetHz;
-        const sampleBw = cn.sampleRate;
-        const viewportLowerEdge =
-          cn.radioLoHz + viewportOffsetHz - d.spanHz / 2;
-        const viewportUpperEdge =
-          cn.radioLoHz + viewportOffsetHz + d.spanHz / 2;
-        const sampleLowerEdge = cn.radioLoHz - sampleBw / 2;
-        const sampleUpperEdge = cn.radioLoHz + sampleBw / 2;
-        const inside =
-          viewportLowerEdge >= sampleLowerEdge &&
-          viewportUpperEdge <= sampleUpperEdge;
-        if (inside) return;
-        // Land the fresh IQ window adjacent to the released viewport in the
-        // pan direction. Panning up (offset > 0) puts the sample window's
-        // bottom at the current viewport bottom; panning down does the
-        // mirror.
-        const newRadioLoHz =
-          viewportOffsetHz > 0
-            ? Math.round(viewportLowerEdge + sampleBw / 2)
-            : Math.round(viewportUpperEdge - sampleBw / 2);
-        const clampedNewRadioLoHz = clampHz(newRadioLoHz);
-        const oldRadioLoHz = cn.radioLoHz;
-        // Optimistic update: move radioLoHz now, rebase the offset so the
-        // absolute frequency at every screen pixel is preserved across the
-        // retune. The /api/radio/lo response will reconcile both values.
-        useConnectionStore.setState({ radioLoHz: clampedNewRadioLoHz });
-        display.setViewportOffsetHz(
-          oldRadioLoHz + viewportOffsetHz - clampedNewRadioLoHz,
-        );
-        setRadioLo(clampedNewRadioLoHz)
-          .then((s) => useConnectionStore.getState().applyState(s))
-          .catch(() => {
-            // Server rejected the retune (e.g. out of band for this radio).
-            // Roll back to the pre-release state so the operator sees the
-            // viewport snap back to the last valid offset.
-            useConnectionStore.setState({ radioLoHz: oldRadioLoHz });
-            display.setViewportOffsetHz(viewportOffsetHz);
-          });
-      } else {
-        // click-to-tune: resolve the clicked frequency against the live
-        // viewport (centre = radioLoHz + viewportOffsetHz).
-        const view = readView();
-        if (!view) return;
-        const frac = (e.clientX - rect.left) / rect.width;
-        commitFinal(
-          view.centerHz + view.viewportOffsetHz + (frac - 0.5) * view.spanHz,
-        );
-      }
+      // Drag or click — both tune to the frequency at the release point. CTUN
+      // pure-pan (leave-offset / retune-NCO-on-release) is gone: a release
+      // always commits a dial tune so RX and TX track where you let go.
+      const view = readView();
+      if (!view) return;
+      const frac = (e.clientX - rect.left) / rect.width;
+      commitFinal(view.centerHz + view.viewportOffsetHz + (frac - 0.5) * view.spanHz);
     };
 
     const onWheel = (e: WheelEvent) => {

--- a/zeus-web/src/util/use-pan-tune-gesture.ts
+++ b/zeus-web/src/util/use-pan-tune-gesture.ts
@@ -43,7 +43,7 @@
 // License for details.
 
 import { createContext, useContext, useEffect, type RefObject } from 'react';
-import { setVfo, setZoom, ZOOM_MAX, ZOOM_MIN, type ZoomLevel } from '../api/client';
+import { setRadioLo, setVfo, setZoom, ZOOM_MAX, ZOOM_MIN, type ZoomLevel } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
 import { useDisplayStore } from '../state/display-store';
 import { useToolbarFavoritesStore } from '../state/toolbar-favorites-store';
@@ -87,12 +87,16 @@ export type SpectrumWheelActions = {
 
 export const SpectrumWheelActionsContext = createContext<SpectrumWheelActions>({});
 
-function readView(): { centerHz: number; spanHz: number } | null {
+function readView(): { centerHz: number; spanHz: number; viewportOffsetHz: number } | null {
   const s = useDisplayStore.getState();
   if (!s.panDb || s.hzPerPixel <= 0) return null;
   return {
+    // centerHz here is the radio's hardware NCO (== RadioLoHz) — that's what
+    // the incoming frames are anchored to. The visible viewport centre is
+    // centerHz + viewportOffsetHz.
     centerHz: Number(s.centerHz),
     spanHz: s.panDb.length * s.hzPerPixel,
+    viewportOffsetHz: s.viewportOffsetHz,
   };
 }
 
@@ -111,7 +115,22 @@ export function usePanTuneGesture(
     const canvas = canvasRef.current;
     if (!canvas) return;
 
-    type Drag = { startX: number; startHz: number; spanHz: number; moved: boolean };
+    // Pure-pan drag (docs/prd/panfall_behavior.md): pointer-down captures
+    // the viewport centre at gesture start, pointer-move slides the
+    // viewportOffsetHz (no setVfo, no POST), pointer-up either leaves the
+    // offset (drag stayed inside the IQ window) or POSTs /api/radio/lo to
+    // adjoin a fresh sample window in the pan direction. vfoHz is NEVER
+    // mutated by a drag.
+    type Drag = {
+      startX: number;
+      // Viewport centre at gesture start (Hz). The new viewportOffsetHz on
+      // every move is derived from this anchor — not from radioLoHz at the
+      // current tick — so an in-flight band-change retune that fires during
+      // a drag can't yank the spectrum out from under the finger.
+      startViewportCenterHz: number;
+      spanHz: number;
+      moved: boolean;
+    };
     type MapDrag = { lastX: number; lastY: number };
     type Pinch = {
       baseDist: number;     // pointer separation when the pinch began (px)
@@ -174,6 +193,10 @@ export function usePanTuneGesture(
     const commitFinal = (hz: number) => {
       const snapped = snapHz(hz);
       useConnectionStore.setState({ vfoHz: snapped });
+      // Click-to-tune is an explicit tune-to-frequency action; per the PRD
+      // it resets any held viewportOffsetHz so the dial visibly snaps back
+      // to the panadapter centre.
+      useDisplayStore.getState().setViewportOffsetHz(0);
       pendingAbort?.abort();
       pendingAbort = null;
       if (pendingRaf !== 0) {
@@ -251,7 +274,11 @@ export function usePanTuneGesture(
       }
       drag = {
         startX: e.clientX,
-        startHz: view.centerHz,
+        // Capture the viewport centre at gesture start (radioLoHz + any
+        // existing offset). Anchoring to this absolute Hz makes the pan feel
+        // stable even if radioLoHz changes mid-drag (band-change retune,
+        // CAT, etc.).
+        startViewportCenterHz: view.centerHz + view.viewportOffsetHz,
         spanHz: view.spanHz,
         moved: false,
       };
@@ -306,9 +333,15 @@ export function usePanTuneGesture(
       drag.moved = true;
       const rect = canvas.getBoundingClientRect();
       if (rect.width <= 0) return;
-      const newHz = snapHz(drag.startHz - (dx / rect.width) * drag.spanHz);
-      pendingHz = newHz;
-      scheduleFlush();
+      // Pure-pan: drag right → viewport centre slides to a lower Hz so the
+      // grabbed content moves right with the finger. No setVfo, no POST —
+      // we just mutate the frontend-only viewportOffsetHz. The panadapter +
+      // waterfall redraw subscribers in Panadapter.tsx / Waterfall.tsx pick
+      // this up and slide the trace + texture under the cursor at rAF rate.
+      const newViewportCenter =
+        drag.startViewportCenterHz - (dx / rect.width) * drag.spanHz;
+      const radioLoHz = useConnectionStore.getState().radioLoHz;
+      useDisplayStore.getState().setViewportOffsetHz(newViewportCenter - radioLoHz);
     };
 
     const onPointerUp = (e: PointerEvent) => {
@@ -342,14 +375,62 @@ export function usePanTuneGesture(
       const rect = canvas.getBoundingClientRect();
       if (rect.width <= 0) return;
       if (d.moved) {
-        const dx = e.clientX - d.startX;
-        commitFinal(d.startHz - (dx / rect.width) * d.spanHz);
+        // Drag release — decide whether the panned viewport still sits inside
+        // the IQ capture window. If yes, leave viewportOffsetHz as-is; the
+        // dial keeps demodulating its tuned signal (potentially off-screen)
+        // and the operator can keep panning visually. If no, retune the
+        // hardware NCO so the new sample window adjoins the released viewport
+        // in the pan direction; we optimistically rebase the offset so
+        // on-screen frequencies don't visually jump across the retune.
+        const display = useDisplayStore.getState();
+        const cn = useConnectionStore.getState();
+        const viewportOffsetHz = display.viewportOffsetHz;
+        const sampleBw = cn.sampleRate;
+        const viewportLowerEdge =
+          cn.radioLoHz + viewportOffsetHz - d.spanHz / 2;
+        const viewportUpperEdge =
+          cn.radioLoHz + viewportOffsetHz + d.spanHz / 2;
+        const sampleLowerEdge = cn.radioLoHz - sampleBw / 2;
+        const sampleUpperEdge = cn.radioLoHz + sampleBw / 2;
+        const inside =
+          viewportLowerEdge >= sampleLowerEdge &&
+          viewportUpperEdge <= sampleUpperEdge;
+        if (inside) return;
+        // Land the fresh IQ window adjacent to the released viewport in the
+        // pan direction. Panning up (offset > 0) puts the sample window's
+        // bottom at the current viewport bottom; panning down does the
+        // mirror.
+        const newRadioLoHz =
+          viewportOffsetHz > 0
+            ? Math.round(viewportLowerEdge + sampleBw / 2)
+            : Math.round(viewportUpperEdge - sampleBw / 2);
+        const clampedNewRadioLoHz = clampHz(newRadioLoHz);
+        const oldRadioLoHz = cn.radioLoHz;
+        // Optimistic update: move radioLoHz now, rebase the offset so the
+        // absolute frequency at every screen pixel is preserved across the
+        // retune. The /api/radio/lo response will reconcile both values.
+        useConnectionStore.setState({ radioLoHz: clampedNewRadioLoHz });
+        display.setViewportOffsetHz(
+          oldRadioLoHz + viewportOffsetHz - clampedNewRadioLoHz,
+        );
+        setRadioLo(clampedNewRadioLoHz)
+          .then((s) => useConnectionStore.getState().applyState(s))
+          .catch(() => {
+            // Server rejected the retune (e.g. out of band for this radio).
+            // Roll back to the pre-release state so the operator sees the
+            // viewport snap back to the last valid offset.
+            useConnectionStore.setState({ radioLoHz: oldRadioLoHz });
+            display.setViewportOffsetHz(viewportOffsetHz);
+          });
       } else {
-        // click-to-tune: resolve the clicked frequency against the live view.
+        // click-to-tune: resolve the clicked frequency against the live
+        // viewport (centre = radioLoHz + viewportOffsetHz).
         const view = readView();
         if (!view) return;
         const frac = (e.clientX - rect.left) / rect.width;
-        commitFinal(view.centerHz + (frac - 0.5) * view.spanHz);
+        commitFinal(
+          view.centerHz + view.viewportOffsetHz + (frac - 0.5) * view.spanHz,
+        );
       }
     };
 


### PR DESCRIPTION
Bundle of fixes/features for #426 (Brick2 codec issue + features) — Brian asked me to take all of them in one pass; per his instruction they're integrated on a single branch with a merge commit per concern so review can isolate each.

## What's in the bundle

| GH/bd | Title | Commit | Status |
|---|---|---|---|
| #426 bug 1 (zeus-hn5) | **Onboard codec — RX audio to radio headphones** (Phase A) | `77646ab` | Code complete; needs Hermes bench |
| #426 bug 2 (zeus-d0v) | PS freeze on non-HL2 P1 | — | Already merged in #435 |
| #426 bug 3 (zeus-0aq) | MOX/TUN release delay | (diagnostic in `adb855a`) | Diagnostic only — needs HL2 bench measurement |
| #426 bug 4 (zeus-7uo) | Simultaneous RX+TX on MIC PTT | `adb855a` | Race collapsed (synchronous handoff + Hardware MoxSource tag) |
| #426 feat 1 (zeus-58a) | S-meter dB-offset calibration | `1571b7f` | Shipped — ±20 dB, LiteDB-persisted, ⚙ popover |
| #426 feat 2 (zeus-ems) | Configurable max TX power scale | `5faee0a` | Shipped — null = falls back to `BoardCapabilities.MaxPowerWatts` |
| #426 feat 3 (zeus-lez) | Waterfall brightness | `d7cc5ad` | Shipped — 0.25..4.0, live preview during drag, persisted |

## Codec — Phase A only

`Zeus.Protocol1` learned to write EP2 L/R audio bytes from an optional `IRxCodecAudioSource`. New `RxCodecAudioRing` + `RadioCodecAudioSink` (joins the existing `IRxAudioSink` fan-out) bridge WDSP RX audio onto the wire. Gated by `BoardCapabilities.HasOnboardCodec` — true for Hermes / Mercury / ANAN-class / OrionMkII / G2E, false for HermesLite2 (no codec hardware). HL2 path is bit-for-bit unchanged (sink short-circuits, ring stays empty, EP2 L/R remain zero — same as pre-#426).

Phase B (radio mic → WDSP TXA) is filed as a follow-up bd item — it requires an operator-facing source-selection UI which is a separate UX decision.

## PureSignal freeze

Bug 2 in the original report was already fixed in PR #435 (merged 2026-05-21). Closing the bd item accordingly.

## What needs maintainer attention

- **Hermes bench test** — none of the codec / PTT changes can be HL2-tested locally. linoobs's Brick2 is the natural test bed.
- **Meter / waterfall UI placement** — agents chose a discreet ⚙ popover for both meter knobs and an inline `BRT` slider for the waterfall (using existing `tokens.css` colors only, no palette additions). Worth a glance before merge.
- **Bug 3 (UI MOX release delay)** is the only red item — the agent walked the un-key path and could not identify a code-path delay, so it shipped a `p1.mox.transition` + `externalPtt.{takeover,release}.applied dtUs=` log instead. Next bench cycle on HL2 should be conclusive.

## Test plan

- [x] `dotnet build Zeus.slnx` — 0 warnings, 0 errors
- [x] `dotnet test Zeus.slnx` — 1289 passed, 0 failed, 107 skipped (added 6 codec + 16 meter + 4 waterfall + 0 PTT tests; PTT change is covered by existing `MoxSourceOwnershipTests`)
- [x] `npm --prefix zeus-web run build` — clean (tsc + vite + PWA precache)
- [x] `npm --prefix zeus-web test` — 229 passed
- [ ] **HL2 bench**: PS-on regression (already covered by #435 but worth re-checking after this bundle); MOX/PTT race + delay diagnostic capture; meter knobs render and persist; waterfall slider feels right.
- [ ] **Hermes bench** (linoobs / maintainer): RX audio audible on radio front-panel headphone jack; HL2 mode operators see no behaviour change.

bd items closed: zeus-d0v, zeus-7uo, zeus-58a, zeus-ems, zeus-lez. Kept open: zeus-hn5 (Phase B), zeus-0aq (needs measurement). New: P1 onboard-codec Phase B item.