### PR TITLE
revert(audio): undo #501 + add TX→RX resume timing probe to localise the 2s gap (#468)

### DIFF
--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -1416,32 +1416,12 @@ public sealed class WdspDspEngine : IDspEngine
         // stay running so fexchange2 keeps producing IQ for the monitor
         // demod path. We re-derive TXA target = (MOX || monitor) so the
         // monitor path doesn't go silent when the operator releases MOX.
-        // RX-resume warmth (issue #468, follow-up to #497): we deliberately
-        // leave the RXA channel at state=1 across the whole MOX cycle and do
-        // NOT damp it to state=0 on key-down. Damping the channel meant that
-        // on un-key the RXA pipeline had to walk its slew + AGC + overlap-add
-        // state back up from a flushed/quiescent state at the *same* moment the
-        // radio's RX front end was recovering from RX_GNDonTX un-grounding —
-        // the two stack into the operator-observed ~2 sec RX-resume ramp on G2
-        // (P2). Thetis avoids this by construction: in the common single-VFO
-        // case it leaves the WDSP RX channel running through TX and mutes the
-        // audio at the mixer (console.cs:29580 `RX1_shutdown` is conditional;
-        // Audio.cs MuteRX1), so its AGC stays converged and RX un-mutes
-        // instantly. We mirror that: keep RXA warm here, and mute the RX audio
-        // output while keyed in DspPipelineService (the `_keyed` gate), so the
-        // operator never hears band RX during TX while the DSP stays converged.
-        //
-        // The RX IQ fed to the warm channel during TX is the radio's grounded
-        // RX input (near-silence), so the channel demodulates near-silence and
-        // its AGC simply tracks the noise floor — no spurious audio leaks
-        // (it's muted downstream anyway) and the channel is hot the instant the
-        // real signal returns.
-        int txaPrior = -1;
+        int rxaPrior, txaPrior = -1;
         bool wantTxa = moxOn || _monitorRequested;
         if (moxOn)
         {
             _moxOn = true;
-            // NOTE: no SetChannelState(rxaId, 0, 1) — RXA stays at state=1.
+            rxaPrior = NativeMethods.SetChannelState(rxaId, 0, 1);
             if (!_txaRunning)
             {
                 txaPrior = NativeMethods.SetChannelState(txaId, 1, 0);
@@ -1469,20 +1449,19 @@ public sealed class WdspDspEngine : IDspEngine
                 txaPrior = NativeMethods.SetChannelState(txaId, 0, 1);
                 _txaRunning = false;
             }
-            // NOTE: no SetChannelState(rxaId, 1, 0) — RXA was never damped, so
-            // there is nothing to bring back up. The pipeline's `_keyed` gate
-            // un-mutes the already-converged RX audio on this same edge.
+            rxaPrior = NativeMethods.SetChannelState(rxaId, 1, 0);
             // Unkeying: clear the stage-meter snapshot so UI doesn't latch the
             // last-during-TX reading while idle. The next MOX-on will publish
             // fresh data on its first ProcessTxBlock.
             lock (_txMeterPublishLock) { _latestTxStageMeters = null; }
         }
-        // Diagnostic 2026-04-18: capture the prior-state return of the TXA
-        // SetChannelState call so we can detect a requested transition that was
-        // a no-op (prior == new). RXA is left warm so it has no prior to log.
+        // Diagnostic 2026-04-18: capture the prior-state return of every
+        // SetChannelState call so we can detect cases where the requested
+        // transition was a no-op (prior == new) — that's the failure mode that
+        // looks like "RX audio doesn't come back after MOX-off".
         _log.LogInformation(
-            "wdsp.setMox on={Mox} rxa={Rxa} (warm) txa={Txa} (prior {TxaPrior})",
-            moxOn, rxaId, txaId, txaPrior);
+            "wdsp.setMox on={Mox} rxa={Rxa} (prior {RxaPrior}) txa={Txa} (prior {TxaPrior})",
+            moxOn, rxaId, rxaPrior, txaId, txaPrior);
     }
 
     public TxStageMeters GetTxStageMeters()

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -225,6 +225,24 @@ public class DspPipelineService : BackgroundService,
     private volatile bool _rxFadeOutPending;        // first RX block after MOX↑
     private volatile bool _rxFadeInPending;         // first RX block after MOX↓
 
+    // TX→RX resume diagnostics (issue #468). The operator-confirmed symptom is
+    // ~2 s of RX-audio silence after un-key on BOTH P1 and P2, desktop native
+    // audio — and #494/#497/#501 did not fix it. Static analysis shows WDSP
+    // resumes audio ~50 ms after IQ flows and the publish path has no prefill,
+    // so the ~2 s must be a *runtime* gap somewhere on the un-key → first-
+    // audible-sample chain. These one-shot probes time-stamp that chain so the
+    // operator's next build logs EXACTLY which stage is late:
+    //   t0  = un-key edge observed (OnRadioMoxChanged(false))
+    //   t1  = first OnIqFrame after un-key (RX IQ actually flowing again)
+    //   t2  = first Tick where engine.ReadAudio returned > 0 after un-key
+    //   t3  = first PublishAudio after un-key (audio reaching NativeAudioSink)
+    // Each is a Stopwatch tick stamp; the deltas (ms) are logged at t1/t2/t3.
+    // volatile: written on the MOX-edge / RX-IQ / Tick threads, read on the
+    // same hot threads. -1 = "not yet seen this cycle".
+    private long _resumeUnkeyTicks = -1;
+    private volatile bool _resumeAwaitingIq;
+    private volatile bool _resumeAwaitingAudio;
+
     // ---- iter5 single-DSP-thread scaffolding -----------------------------
     // The pipeline now owns its hot path via IRxPacketSink: when a radio
     // connects we AttachRxSink to the protocol client and every IQ/PS-feedback
@@ -1102,6 +1120,16 @@ public class DspPipelineService : BackgroundService,
         // audio in so the dmp=0 RXA up doesn't pop through to the browser.
         if (on) _rxFadeOutPending = true;
         else _rxFadeInPending = true;
+        if (!on)
+        {
+            // Arm the TX→RX resume timing probe (issue #468). Stamp the un-key
+            // instant and flag the IQ / audio one-shots so the next OnIqFrame
+            // and first ReadAudio>0 / PublishAudio log their delta from here.
+            _resumeUnkeyTicks = Stopwatch.GetTimestamp();
+            _resumeAwaitingIq = true;
+            _resumeAwaitingAudio = true;
+            _log.LogInformation("rx.resume.probe t0 unkey ts={Ts}", _resumeUnkeyTicks);
+        }
         _p2Client?.SetMox(on);
         // Falling edge: pick up any PS knob changes that OnRadioStateChanged
         // deferred while we were keyed (HwPeak / Ptol / Advanced / Control).
@@ -1271,6 +1299,7 @@ public class DspPipelineService : BackgroundService,
             // full fence on AttachRxSink (Interlocked.Exchange) guarantees
             // the sink sees the freshly-installed engine. See _engineLock
             // doc on the field.
+            ResumeProbeOnIqFrame();
             var engine = Volatile.Read(ref _engine);
             int channel = Volatile.Read(ref _channelId);
             if (engine is not null)
@@ -1314,6 +1343,7 @@ public class DspPipelineService : BackgroundService,
     void Zeus.Protocol2.IRxPacketSink.OnIqFrame(in Zeus.Protocol2.IqFrame frame)
     {
         DrainDspCommands();
+        ResumeProbeOnIqFrame();
         var engine = Volatile.Read(ref _engine);
         int channel = Volatile.Read(ref _channelId);
         if (engine is not null)
@@ -1370,6 +1400,41 @@ public class DspPipelineService : BackgroundService,
         {
             _lastTickStopwatchTicks = now;
             Tick(_panBuf, _wfBuf, _audioBuf);
+        }
+    }
+
+    // TX→RX resume probe (issue #468). Called from the RX-IQ path (t1) and the
+    // Tick audio path (t2 first ReadAudio>0, t3 first PublishAudio) so the
+    // operator's log pinpoints which stage is late after un-key. Each stage is
+    // a one-shot per un-key cycle. Cheap: a couple of volatile reads on the hot
+    // path when not armed.
+    private void ResumeProbeOnIqFrame()
+    {
+        if (!_resumeAwaitingIq) return;
+        _resumeAwaitingIq = false;
+        long t0 = _resumeUnkeyTicks;
+        if (t0 <= 0) return;
+        double ms = (Stopwatch.GetTimestamp() - t0) * 1000.0 / Stopwatch.Frequency;
+        _log.LogInformation("rx.resume.probe t1 firstIq +{Ms:F1}ms", ms);
+    }
+
+    private void ResumeProbeFirstAudio(int audioSampleCount, bool published)
+    {
+        long t0 = _resumeUnkeyTicks;
+        if (t0 <= 0) return;
+        if (_resumeAwaitingAudio && audioSampleCount > 0)
+        {
+            // Disarm the t2 one-shot up front so this logs exactly once per
+            // un-key cycle even when the publish was suppressed (TX monitor).
+            _resumeAwaitingAudio = false;
+            double ms = (Stopwatch.GetTimestamp() - t0) * 1000.0 / Stopwatch.Frequency;
+            _log.LogInformation("rx.resume.probe t2 firstReadAudio>0 +{Ms:F1}ms samples={N} published={Pub}",
+                ms, audioSampleCount, published);
+            if (published)
+            {
+                _log.LogInformation("rx.resume.probe t3 firstPublish +{Ms:F1}ms", ms);
+            }
+            _resumeUnkeyTicks = -1;   // disarm cycle (t1 already fired or moot)
         }
     }
 
@@ -1614,32 +1679,8 @@ public class DspPipelineService : BackgroundService,
         // don't broadcast it. The VST RX seam still fires on the drained RX
         // so RX-side plugins keep running even while monitor is on.
         bool txMonitorOn = engine.IsTxMonitorOn;
-        // Always drain the WDSP RX audio ring, even while keyed. Issue #468
-        // follow-up: WdspDspEngine.SetMox now leaves the RXA channel warm
-        // (state=1) through the whole MOX cycle instead of damping it to
-        // state=0, so the DSP/AGC stay converged and RX resumes instantly on
-        // un-key (mirrors Thetis's MuteRX1-at-the-mixer approach). The cost is
-        // that ReadAudio now returns live band RX while keyed; we MUST NOT
-        // publish that (the operator would hear band RX while transmitting),
-        // but we still drain it so the WDSP audio ring doesn't back up and so
-        // the first post-un-key block is fresh rather than a stale TX-period
-        // backlog. The `_keyed` gate on PublishAudio below enforces the mute.
         int audioSampleCount = engine.ReadAudio(channel, audioBuf);
-        // RX audio is muted while keyed (MOX or TUN). The WDSP RX channel is
-        // kept warm, so this is a pure downstream mute — no DSP state is torn
-        // down and un-key resumes from a converged pipeline.
-        bool rxAudioMuted = _keyed;
-        if (rxAudioMuted)
-        {
-            // Consume the rising-edge fade-out one-shot here: with the mute in
-            // place the RX→TX transition is already silent (the operator hears
-            // TX, not band RX), so there's no click to ramp out — and leaving
-            // the flag armed would make it (as the leading `if` below) wrongly
-            // ramp DOWN the first un-keyed resume block instead of letting the
-            // fade-IN one-shot ramp it up.
-            _rxFadeOutPending = false;
-        }
-        if (audioSampleCount > 0 && !rxAudioMuted)
+        if (audioSampleCount > 0)
         {
             // MOX-edge fade envelope. Ramps the first ~5 ms of this block
             // either down (rising edge: last block before TX silence) or up
@@ -1693,6 +1734,14 @@ public class DspPipelineService : BackgroundService,
                     Samples: new ReadOnlyMemory<float>(audioBuf, 0, audioSampleCount));
                 PublishAudio(in audioFrame);
                 RxAudioAvailable?.Invoke(0, AudioOutputRateHz, new ReadOnlyMemory<float>(audioBuf, 0, audioSampleCount));
+                // Resume probe (issue #468): first published RX block after un-key.
+                ResumeProbeFirstAudio(audioSampleCount, published: true);
+            }
+            else
+            {
+                // ReadAudio produced samples but TX monitor suppressed the RX
+                // publish — still record that the RX pipeline is producing.
+                ResumeProbeFirstAudio(audioSampleCount, published: false);
             }
         }
         if (txMonitorOn)


### PR DESCRIPTION
## Summary

This is a **diagnostic + cleanup** PR, not a fourth blind fix. The ~2 sec TX→RX RX-audio gap is now confirmed to:
- affect **both P1 (HL2)** and **P2 (G2)**, desktop native audio;
- be **instant in Thetis on the same G2 + same Windows VM** (so it is a Zeus software bug, not radio/RX-ground hardware recovery);
- **pre-date** #494/#497/#501 — the original #468/#403 report was Ronnie on Hermes/P1. Those three were failed attempts.

Per the directive to stop stacking failed guesses, I did NOT ship a fourth speculative fix. Instead I (1) reverted #501 to get back to a clean, proven baseline, and (2) added a one-shot timing probe that will localise the ~2 sec on the operator's next build with a single un-key.

## What I verified (on Mac, real WDSP)

A real-WDSP probe (added during investigation, removed before this PR) fed IQ continuously across a full MOX cycle and measured demodulated-audio recovery: **the RXA channel resumes producing audio ~50–80 ms after the un-key state flip + IQ** — whether the channel is damped (baseline) or kept warm (#501). So **WDSP is not the 2 sec.**

I also traced the rest of the shared desktop chain end-to-end and found NO ~2 sec gate:
- `NativeAudioSink` / miniaudio (`native/miniaudio/zeus_miniaudio.c`): device runs continuously, fills silence on underrun, never auto-stops; **no prefill / buffer-target / start-threshold** (that lives only in the browser `audio-client.ts`, handled by #494).
- `_keyed` clears **synchronously** on the un-key call (`RadioService.SetMox` → `MoxChanged.Invoke` → `OnRadioMoxChanged`, all inline) — the #501 mute could not have been lingering 2 sec.
- `PublishAudio` writes straight to the sink ring — no scheduler, no prefill.
- P1/P2 RX IQ delivery has no batching pipe (`Protocol2Client.RxLoop` reads the socket directly; P1 likewise).

Conclusion: the ~2 sec is a **runtime** gap on the un-key → first-audible-sample chain that static analysis cannot pin down. That is exactly what the probe measures.

## What changed

1. **Revert #501** (`WdspDspEngine.SetMox`, `DspPipelineService.Tick`). #501 kept the RXA channel warm + added a `_keyed` publish-mute; it did not fix the gap, and the warm channel demodulates live band RX during TX (wasted hot-path CPU) while the mute is itself a resume-gating suspect. Reverting restores the simpler shipped baseline so the probe measures an unconfounded path. **#497's ring-drain is retained** — harmless, addresses a separate backlog case.
2. **Add a one-shot TX→RX resume timing probe** in `DspPipelineService` (pure logging, no behaviour change). On the un-key edge it stamps `t0`, then logs the delta to:
   - `t1` = first `OnIqFrame` after un-key (RX IQ flowing again),
   - `t2` = first Tick where `engine.ReadAudio` returned > 0,
   - `t3` = first `PublishAudio` (audio reaching `NativeAudioSink`).
   One line each, per un-key cycle — no flood. Wired into both the P1 and P2 `OnIqFrame` and the Tick audio path.

### How to read the probe (the operator's next build)

Key up, hold ~3 s, un-key, capture the `rx.resume.probe` lines:
- `t1 ≈ +2000 ms` → **RX IQ isn't reaching the engine for ~2 s** → the bug is in the protocol-client RX/keepalive resume path; chase there next.
- `t1` small but `t2`/`t3 ≈ +2000 ms` → **WDSP/pipeline holds audio after IQ resumes** → chase the engine/publish path.

That one log turns the remaining work into a targeted fix instead of another guess.

## Cross-platform impact (explicit)

- All changes are in the **shared P1/P2 desktop path**. The probe is pure logging; the revert restores previously-shipped behaviour. So **macOS, Linux, and Windows** behave identically, and **HL2/P1 + G2/P2** are affected the same way.
- **Browser path (#494) untouched.**
- No OS-specific conditionals introduced.

## Build / test (Mac)

- `dotnet build Zeus.slnx` → **0 warnings**, 0 errors.
- `dotnet test Zeus.slnx`: real-WDSP `SetMox`/`ReadAudio`/`ReadAudio_ResumesAfterMoxCycle` (7) pass — confirms the #501 revert restored a correct, audio-producing MOX cycle. `TxActiveChanged` (4) + MoxSource/TwoTone (21 total MOX-related) pass.
- 4 `ZeroBeat` tests fail — **pre-existing on the experimental baseline** (verified by stashing my changes), WDSP-timing-dependent, unrelated to this change. Not introduced here.

## ⚠️ RED-LIGHT note

Touches the realtime audio hot path. The probe is log-only and the revert restores shipped behaviour, so risk is low — but please run the operator's Windows-G2 (and ideally HL2) bench to **capture the `rx.resume.probe t0/t1/t2/t3` lines on one un-key** and post them back. That pinpoints the stage to fix. Acceptance for the eventual fix remains: instant key-up, instant un-key, no band-RX audible while keyed, both MOX and TUN, on every platform.

Refs #468, #497, #501.
