### PR TITLE
test(cw): fix ZeroBeat test fixtures to unblock develop CI (#499, #300)

### DIFF
--- a/tests/Zeus.Server.Tests/RadioServiceZeroBeatTests.cs
+++ b/tests/Zeus.Server.Tests/RadioServiceZeroBeatTests.cs
@@ -30,32 +30,30 @@ namespace Zeus.Server.Tests;
 
 public class RadioServiceZeroBeatTests
 {
-    // Number of frames in phase 1 (mirrors RadioService.ZeroBeatPhase1Frames).
-    private const int Phase1Frames = 15;
-
     /// <summary>
     /// Engine stub that returns a synthetic FFT with a single peak at a
-    /// chosen offset from DC for every snap call.
+    /// chosen bin for every snap call.
     ///
-    /// <para>For tests that need phase 2 to be a silent no-op (so the
-    /// assertion only measures the phase-1 move), set
-    /// <see cref="Phase2PeakDb"/> to a value less than
-    /// <see cref="FloorDb"/> + 6 so the SNR gate blocks the second
-    /// refinement step.</para>
+    /// <para>ZeroBeat collects <c>ZeroBeatPhase1Frames</c> (30) frames and
+    /// max-holds per bin before measuring the peak. To simulate a signal that
+    /// only appears partway through the accumulation window, give the first
+    /// half (calls 1..15) and the second half (calls 16..30) different
+    /// peak bins / levels via the <c>Phase2*</c> properties; max-hold keeps
+    /// whichever is louder per bin.</para>
     /// </summary>
     private sealed class PeakAtBinEngine : IDspEngine
     {
-        // Phase 1 (first ZeroBeatPhase1Frames calls = 15)
+        // First half of the peak-hold window (calls 1..15)
         public int Phase1PeakBin { get; init; } = 8192;
         public double Phase1PeakDb { get; init; } = -30;
 
-        // Phase 2 (calls 16..60 = next 45)
-        public int? Phase2PeakBin { get; init; } = null;   // null = same as phase 1
-        public double? Phase2PeakDb { get; init; } = null; // null = same as phase 1
+        // Second half of the peak-hold window (calls 16..30)
+        public int? Phase2PeakBin { get; init; } = null;   // null = same as first half
+        public double? Phase2PeakDb { get; init; } = null; // null = same as first half
 
         public double FloorDb { get; init; } = -90;
 
-        // Phase boundary at 15 frames (matches RadioService.ZeroBeatPhase1Frames).
+        // Halfway through the 30-frame ZeroBeat peak-hold window.
         private const int Phase1Boundary = 15;
         private int _callCount;
 
@@ -124,53 +122,56 @@ public class RadioServiceZeroBeatTests
     }
 
     // -------------------------------------------------------------------------
-    // Test 1: Peak exactly at DC — no VFO movement expected.
+    // Test 1: Carrier already at the CW pitch — no meaningful VFO movement.
     //
-    // With PeakBin = ZeroBeatDcBin (8192), deltaHz = (8192 + 0 - 8192) * hzPerBin = 0.
-    // After both phases the VFO must be unchanged and ZeroBeat must return
-    // a non-null StateDto (the "phase 1 SNR gate passed but delta=0" branch
-    // returns Snapshot() at the end rather than null).
+    // The zero-beat target is NOT DC (bin 8192). In CW the LO is offset by the
+    // CW pitch (600 Hz) from the dial, so a carrier the operator is already
+    // perfectly zero-beat on lands at +cw_pitch in the baseband FFT, which on
+    // the inverted analyzer axis is bin 8192 − round(600 / 2.93) = 7987.
+    // deltaHz = rawOffsetHz − cw_pitch ≈ 600.6 − 600 = 0.6 Hz → rounds to a
+    // sub-bin residual of at most a couple Hz (2.93 Hz/bin grid at 48 kHz).
+    // ZeroBeat must return a non-null StateDto (gate passed) and leave the VFO
+    // effectively where it was.
     // -------------------------------------------------------------------------
     [Fact]
     public void ZeroBeat_in_CWU_with_on_frequency_peak_does_not_move_VFO()
     {
-        var engine = new PeakAtBinEngine { Phase1PeakBin = 8192, Phase2PeakBin = 8192 };
+        // Bin nearest +600 Hz on the inverted axis (8192 − round(600/2.93) = 7987).
+        var engine = new PeakAtBinEngine { Phase1PeakBin = 7987, Phase2PeakBin = 7987 };
         using var radio = TestRadioServiceFactory.WithEngine(engine, mode: RxMode.CWU, vfoHz: 14_060_000);
 
         long before = radio.Snapshot().VfoHz;
         var result = radio.ZeroBeat();
         long after = radio.Snapshot().VfoHz;
 
-        Assert.Equal(before, after);   // peak already at DC → zero delta
+        // Carrier already at the CW pitch → only the ±1-bin grid residual.
+        Assert.InRange(after - before, -2, 2);
         Assert.NotNull(result);
     }
 
     // -------------------------------------------------------------------------
-    // Test 2: Peak 10 bins above DC → coarse tune of ~+29 Hz.
+    // Test 2: Carrier ~30 Hz above the CW pitch → VFO tunes up ~+30 Hz.
     //
-    // 48 kHz / 16 384 bins → hzPerBin ≈ 2.93 Hz.  10 bins × 2.93 ≈ 29.3 Hz.
-    // Phase 1 fires (SNR 60 dB >> 6 dB gate) and moves VFO by round(29.3) = 29 Hz.
-    // Phase 2 is silenced by the PeakAtBinEngine returning floor-level after the
-    // first Phase1Frames calls, so the SNR gate blocks the second refinement step
-    // and the net delta is just the phase-1 move.
-    //
-    // Allow ±2 Hz tolerance for floating-point rounding (2.93 Hz/bin is
-    // irrational at exactly 48000/16384).
+    // 48 kHz / 16 384 bins → hzPerBin ≈ 2.93 Hz. The zero-beat target is at
+    // +cw_pitch (600 Hz). A peak at bin 7977 sits at rawOffsetHz =
+    // (8192 − 7977) × 2.93 ≈ 629.9 Hz, so deltaHz = 629.9 − 600 ≈ +29.9 Hz →
+    // the dial moves UP onto the carrier. SNR 60 dB ≫ 6 dB gate, so the move
+    // fires. ±2 Hz tolerance for the 2.93 Hz/bin grid quantisation.
     // -------------------------------------------------------------------------
     [Fact]
     public void ZeroBeat_with_peak_above_DC_moves_VFO_up()
     {
-        // Phase 2: carrier has shifted to DC after phase-1 tune; SNR gate blocks second move.
-        var engine = new PeakAtBinEngine { Phase1PeakBin = 8202, Phase2PeakBin = 8192, Phase2PeakDb = -30 };
+        // Bin 7977 ≈ +630 Hz on the inverted axis = 30 Hz above the 600 Hz pitch.
+        var engine = new PeakAtBinEngine { Phase1PeakBin = 7977, Phase2PeakBin = 7977 };
         using var radio = TestRadioServiceFactory.WithEngine(engine, mode: RxMode.CWU, vfoHz: 14_060_000);
 
         radio.ZeroBeat();
         long after = radio.Snapshot().VfoHz;
         long delta = after - 14_060_000;
 
-        // 10 bins × (48000/16384) ≈ 29.3 Hz → rounds to 29.
-        // ±2 Hz tolerance accounts for floating-point imprecision.
-        Assert.InRange(delta, 27, 31);
+        // (8192 − 7977) × (48000/16384) − 600 ≈ +29.9 Hz → rounds to +30.
+        // ±2 Hz tolerance accounts for floating-point / grid imprecision.
+        Assert.InRange(delta, 28, 32);
     }
 
     // -------------------------------------------------------------------------
@@ -194,8 +195,9 @@ public class RadioServiceZeroBeatTests
     // -------------------------------------------------------------------------
     // Test 4: Flat noise floor (peak − floor < 6 dB SNR gate) → no VFO move.
     //
-    // Both phases see peak − floor = 2 dB which is below the 6 dB threshold.
-    // Neither phase moves the VFO and ZeroBeat returns null (no-signal path).
+    // The passband peak − floor = 2 dB, below the 6 dB threshold for the whole
+    // peak-hold window. ZeroBeat never moves the VFO and returns null (no-signal
+    // path). Bin 8500 is inside the (-1000, +1000) test filter at 48 kHz.
     // -------------------------------------------------------------------------
     [Fact]
     public void ZeroBeat_with_flat_noise_floor_does_not_move_VFO()
@@ -204,7 +206,7 @@ public class RadioServiceZeroBeatTests
         {
             Phase1PeakBin = 8500,
             Phase1PeakDb  = -88,   // peak − floor = −88 − (−90) = 2 dB < 6 dB SNR gate
-            Phase2PeakDb  = -88,   // phase 2 also below threshold
+            Phase2PeakDb  = -88,   // still below threshold in the second half
             FloorDb       = -90,
         };
         using var radio = TestRadioServiceFactory.WithEngine(engine, mode: RxMode.CWU, vfoHz: 14_060_000);
@@ -216,24 +218,25 @@ public class RadioServiceZeroBeatTests
     }
 
     // -------------------------------------------------------------------------
-    // Test 5: Phase 1 quiet, phase 2 has a real carrier.
+    // Test 5: Quiet start, carrier appears partway through the peak-hold window.
     //
-    // Phase 1: only noise (peak = floor → SNR 0 dB, gate fails → no Δ₁).
-    // Phase 2: carrier appears 10 bins above DC (Δ₂ ≈ +29 Hz at 48 kHz).
-    // Expected: VFO moves +29 Hz from phase 2 alone, despite phase 1's failure.
-    // This exercises the previously-unreachable fall-through path.
+    // The first half of the accumulation window is only noise (peak = floor),
+    // then a real carrier shows up ~30 Hz above the CW pitch. Because ZeroBeat
+    // max-holds per bin across the whole window, the late carrier is still
+    // captured and clears the SNR gate. Expected: VFO tunes up ~+30 Hz onto it.
+    // This exercises the "signal that wasn't there at button-press" path.
     // -------------------------------------------------------------------------
     [Fact]
     public void ZeroBeat_phase1_quiet_phase2_signal_moves_VFO_from_phase2_only()
     {
-        // Phase 1: only noise (peak = floor, SNR = 0 dB, gate fails → no Δ₁).
-        // Phase 2: a real carrier appears 10 bins above DC (Δ₂ ≈ +29 Hz at 48 kHz).
-        // Expected: VFO moves +29 Hz from phase 2 alone, despite phase 1's failure.
+        // First half: only noise (peak = floor, SNR 0 dB, nothing to lock onto).
+        // Second half: a real carrier at bin 7977 ≈ +630 Hz = 30 Hz above the
+        // 600 Hz pitch. Max-hold preserves it → VFO moves up ~+30 Hz.
         var engine = new PeakAtBinEngine
         {
-            Phase1PeakBin = 8192,
-            Phase1PeakDb  = -90,   // = FloorDb → SNR 0 dB → phase 1 gate fails
-            Phase2PeakBin = 8202,  // 10 bins above DC ≈ +29 Hz
+            Phase1PeakBin = 7987,  // bin at the pitch but at floor level (no signal yet)
+            Phase1PeakDb  = -90,   // = FloorDb → SNR 0 dB → nothing in the first half
+            Phase2PeakBin = 7977,  // carrier 30 Hz above the pitch
             Phase2PeakDb  = -30,   // strong signal
             FloorDb       = -90,
         };
@@ -243,7 +246,7 @@ public class RadioServiceZeroBeatTests
         long after = radio.Snapshot().VfoHz;
 
         Assert.NotNull(result);
-        Assert.InRange(after - 14_060_000, 27, 31);
+        Assert.InRange(after - 14_060_000, 28, 32);
     }
 }
 
@@ -274,8 +277,9 @@ public class ZeroBeatEndpointTests : IClassFixture<ZeroBeatEndpointTests.NoSigna
     }
 
     // -------------------------------------------------------------------------
-    // 422 path: mode CWU, wide filter, flat noise floor (SNR 2 dB < 6 dB gate).
-    // Both phases fail the SNR gate → ZeroBeat returns null → 422.
+    // 422 path: mode CWU, wide filter, near-flat noise floor (SNR 1 dB, below
+    // the 2 dB effective gate at 192 kHz). The peak in the passband never
+    // clears the SNR gate → ZeroBeat returns null → endpoint 422.
     // -------------------------------------------------------------------------
     [Fact]
     public async Task Post_returns_422_when_no_signal()
@@ -287,9 +291,10 @@ public class ZeroBeatEndpointTests : IClassFixture<ZeroBeatEndpointTests.NoSigna
         var modeResp = await client.PostAsJsonAsync("/api/mode", new { mode = "CWU" });
         Assert.Equal(HttpStatusCode.OK, modeResp.StatusCode);
 
-        // Set a wide CWU filter so the peak at bin 8300 is inside the passband
-        // regardless of the default CW pitch / family-filter stored state.
-        // FilterLowHz=0 → lo = DC; FilterHighHz=3000 → hi ≈ DC+255 bins at 192 kHz.
+        // Set a wide CWU filter so the peak at bin 8100 is inside the passband.
+        // No radio is connected, so the snapshot sample rate is the 192 kHz
+        // default → hzPerBin ≈ 11.72 Hz. Filter (0, 3000) maps to passband bins
+        // [DC − round(3000/11.72), DC] = [7936, 8192]; bin 8100 sits inside it.
         var bwResp = await client.PostAsJsonAsync("/api/bandwidth", new { low = 0, high = 3000 });
         Assert.Equal(HttpStatusCode.OK, bwResp.StatusCode);
 
@@ -313,7 +318,8 @@ public class ZeroBeatEndpointTests : IClassFixture<ZeroBeatEndpointTests.NoSigna
         var modeResp = await client.PostAsJsonAsync("/api/mode", new { mode = "CWU" });
         Assert.Equal(HttpStatusCode.OK, modeResp.StatusCode);
 
-        // Set a wide CWU filter so the peak at bin 8300 is inside the passband.
+        // Set a wide CWU filter so the peak at bin 8100 is inside the passband
+        // ([7936, 8192] at the 192 kHz default sample rate).
         var bwResp = await client.PostAsJsonAsync("/api/bandwidth", new { low = 0, high = 3000 });
         Assert.Equal(HttpStatusCode.OK, bwResp.StatusCode);
 
@@ -330,16 +336,20 @@ public class ZeroBeatEndpointTests : IClassFixture<ZeroBeatEndpointTests.NoSigna
     // Test factories
     // -------------------------------------------------------------------------
 
-    // Flat noise. Peak bin 8300 inside the wide CWU filter (0..3000 Hz) set by
-    // the test. peakDb -88 dB, FloorDb -90 dB → SNR 2 dB < 6 dB gate →
-    // ZeroBeat returns null → endpoint 422.
+    // Flat noise. Peak bin 8100 inside the wide CWU filter (0..3000 Hz =
+    // passband bins [7936, 8192] at 192 kHz) set by the test, so the SNR gate
+    // — not a passband miss — is what's exercised. peakDb -89 dB, FloorDb
+    // -90 dB → SNR 1 dB. At 192 kHz the gate floors at 2 dB (6 dB − 10·log10(4)
+    // ≈ −0.02 dB → clamped to 2.0), so 1 dB < 2.0 → ZeroBeat returns null →
+    // endpoint 422.
     public sealed class NoSignalFactory : WebApplicationFactory<Program>
     {
         private static readonly PeakAtBinEngine _engine = new()
         {
-            Phase1PeakBin = 8300,
-            Phase1PeakDb  = -88,
-            Phase2PeakDb  = -88,
+            Phase1PeakBin = 8100,
+            Phase1PeakDb  = -89,
+            Phase2PeakBin = 8100,
+            Phase2PeakDb  = -89,
             FloorDb       = -90,
         };
 
@@ -360,15 +370,16 @@ public class ZeroBeatEndpointTests : IClassFixture<ZeroBeatEndpointTests.NoSigna
         }
     }
 
-    // Strong carrier. Peak bin 8300 inside the wide CWU filter (0..3000 Hz) set
-    // by the test. Phase1PeakDb -30 dB, FloorDb -90 dB → SNR 60 dB >> 6 dB
-    // gate → ZeroBeat returns non-null → endpoint 200.
+    // Strong carrier. Peak bin 8100 inside the wide CWU filter (0..3000 Hz =
+    // passband bins [7936, 8192] at 192 kHz) set by the test. Phase1PeakDb
+    // -30 dB, FloorDb -90 dB → SNR 60 dB >> 6 dB gate → ZeroBeat returns
+    // non-null → endpoint 200.
     public sealed class StrongSignalFactory : WebApplicationFactory<Program>
     {
         private static readonly PeakAtBinEngine _engine = new()
         {
-            Phase1PeakBin = 8300,   // inside the wide CWU filter set by the test
-            Phase2PeakBin = 8300,
+            Phase1PeakBin = 8100,   // inside the passband [7936, 8192] at 192 kHz
+            Phase2PeakBin = 8100,
             Phase1PeakDb  = -30,
             FloorDb       = -90,
         };


### PR DESCRIPTION
## What

Fixes the 4 RED ZeroBeat unit/endpoint tests that #499 (Zero Beat — snap VFO to strongest CW carrier, issue #300) merged with. They fail on every PR targeting `develop`, currently blocking #503 and #504.

**Verdict: it's the TESTS, not the feature.** iu3qez's implementation is correct and matches `docs/designs/cw-zero-beat.md`. No feature code was touched.

## Root cause

The merged tests encoded a wrong premise about where the zero-beat target sits in the FFT:

- The tests placed synthetic carrier peaks at / around the **DC bin (8192)** and asserted "on-frequency → no VFO move".
- But the implementation (and the design doc, §"After unpacking…") measures the tune delta from the **+cw_pitch target**, i.e. DC ± 600 Hz — *not* from DC. A carrier the operator is already perfectly zero-beat on lands at the +cw_pitch bin, not at DC.

So every signal-present fixture computed `deltaHz = rawOffsetHz − 600`, moving the VFO ~−600 Hz where the test expected `0` or `+29`. The runtime `zero-beat.exit reason=snr-gate-failed` logs were a second, related fixture bug:

- The endpoint **200** fixture placed its peak at bin **8300**, which is *outside* the `(0, 3000 Hz)` passband at the 192 kHz default sample rate (passband = bins `[7936, 8192]`). Peak outside passband → floor-only → SNR 0 → gate fails → 422 instead of 200.

## The change (tests only)

`tests/Zeus.Server.Tests/RadioServiceZeroBeatTests.cs`:

- **on-frequency test** — peak at the +600 Hz pitch bin (7987); assert ≤ ±2 Hz sub-bin grid residual instead of exact-equal (the 2.93 Hz/bin grid at 48 kHz can't land exactly on 600 Hz).
- **moves-up test** and **phase-2-signal test** — peak at bin 7977 (≈ +30 Hz above the pitch); assert `+30 ±2 Hz` (a real "carrier is 30 Hz high, snap up onto it" scenario).
- **endpoint 200 / 422 fixtures** — peaks moved inside the 192 kHz passband (bin 8100). The 422 fixture's SNR lowered to 1 dB so it genuinely trips the gate (the gate **floors at 2 dB** at 192 kHz via `6 − 10·log10(4)`, so the old 2 dB no longer rejected).
- refreshed the stub doc + comments to describe the actual single-window max-hold (the merged implementation has no two-phase split; the stub's mid-window switch is repurposed to simulate "a carrier that appears partway through the peak-hold window").

The tests still verify the real intended behaviour — Zero Beat moves / does-not-move / no-ops the VFO as designed — they're not weakened into pass-anything checks.

## Verification

- `dotnet build Zeus.slnx` → **0 Warning(s), 0 Error(s)**
- `dotnet test Zeus.slnx` → **fully green** (Server 653 passed, Dsp 161, Protocol1 191, Protocol2 101, Contracts 84, Plugins.Host 79, Plugins.Contracts 11; 0 failed across all assemblies)
- The 4 originally-failing tests now pass; the 3 previously-passing ZeroBeat tests still pass.

Refs #499, #300. Do not merge without maintainer go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)