### PR TITLE
fix(display): clamp dB-range shifts so dragging can't collapse the span

### DIFF
--- a/Zeus.Server.Hosting/DisplaySettingsStore.cs
+++ b/Zeus.Server.Hosting/DisplaySettingsStore.cs
@@ -24,6 +24,25 @@ namespace Zeus.Server;
 // pointed at the Zeus instance.
 public sealed class DisplaySettingsStore : IDisposable
 {
+    // Defensive bounds for any persisted dB window. Mirrors DB_ABS_LIMIT /
+    // MIN_SPAN_DB in zeus-web's display-settings-store.ts. A range outside
+    // these bounds (or with span < MIN_SPAN_DB) would render the panadapter
+    // or waterfall as a single flat colour, so we drop the write instead of
+    // poisoning zeus-prefs.db. Either endpoint being null means "field not
+    // provided in this PUT" and is handled by the caller.
+    private const double DbAbsLimit = 200;
+    private const double MinSpanDb = 20;
+
+    private static bool IsValidRange(double? min, double? max)
+    {
+        if (!min.HasValue || !max.HasValue) return false;
+        if (double.IsNaN(min.Value) || double.IsNaN(max.Value)) return false;
+        if (double.IsInfinity(min.Value) || double.IsInfinity(max.Value)) return false;
+        if (min.Value < -DbAbsLimit || max.Value > DbAbsLimit) return false;
+        if (max.Value - min.Value < MinSpanDb) return false;
+        return true;
+    }
+
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<DisplaySettingsEntry> _docs;
     private readonly ILogger<DisplaySettingsStore> _log;
@@ -99,14 +118,15 @@ public sealed class DisplaySettingsStore : IDisposable
             e.Mode = NormalizeMode(mode);
             e.Fit = NormalizeFit(fit);
             e.RxTraceColor = NormalizeHexColor(rxTraceColor);
-            if (dbMin.HasValue) e.DbMin = dbMin;
-            if (dbMax.HasValue) e.DbMax = dbMax;
-            if (txDbMin.HasValue) e.TxDbMin = txDbMin;
-            if (txDbMax.HasValue) e.TxDbMax = txDbMax;
-            if (wfDbMin.HasValue) e.WfDbMin = wfDbMin;
-            if (wfDbMax.HasValue) e.WfDbMax = wfDbMax;
-            if (wfTxDbMin.HasValue) e.WfTxDbMin = wfTxDbMin;
-            if (wfTxDbMax.HasValue) e.WfTxDbMax = wfTxDbMax;
+            // Accept a (min, max) pair only when it's a non-degenerate window.
+            // The old code wrote whatever the client sent, so a dB drag that
+            // hit the abs-limit on both endpoints persisted min == max == -200
+            // and the next page load rendered a solid colour. See zeus-web's
+            // sanitizeRange + clampShift for the matching client-side guard.
+            if (IsValidRange(dbMin, dbMax)) { e.DbMin = dbMin; e.DbMax = dbMax; }
+            if (IsValidRange(txDbMin, txDbMax)) { e.TxDbMin = txDbMin; e.TxDbMax = txDbMax; }
+            if (IsValidRange(wfDbMin, wfDbMax)) { e.WfDbMin = wfDbMin; e.WfDbMax = wfDbMax; }
+            if (IsValidRange(wfTxDbMin, wfTxDbMax)) { e.WfTxDbMin = wfTxDbMin; e.WfTxDbMax = wfTxDbMax; }
             e.UpdatedUtc = DateTime.UtcNow;
             if (e.Id == 0) _docs.Insert(e);
             else _docs.Update(e);

--- a/tests/Zeus.Server.Tests/DisplaySettingsPersistenceTests.cs
+++ b/tests/Zeus.Server.Tests/DisplaySettingsPersistenceTests.cs
@@ -121,4 +121,50 @@ public class DisplaySettingsPersistenceTests : IDisposable
         Assert.Equal(-120, dto.DbMin);
         Assert.Equal(-40, dto.DbMax);
     }
+
+    // Regression for the "white waterfall" symptom: dragging the waterfall dB
+    // scale far enough used to push both endpoints to the same ±DB_ABS_LIMIT
+    // wall, persisting min == max. Next page load mapped the entire colormap
+    // input to one colour. The store now drops degenerate writes so a buggy
+    // client (or a stray API call) can't leave the DB in that state.
+    [Theory]
+    [InlineData(-200, -200)] // both at -DbAbsLimit (the original symptom)
+    [InlineData(-50, -50)]   // min == max anywhere
+    [InlineData(-60, -50)]   // span (10) below MinSpanDb (20)
+    [InlineData(-50, -60)]   // inverted
+    [InlineData(-300, -50)]  // min outside abs limit
+    [InlineData(-50, 300)]   // max outside abs limit
+    public void SaveMode_DegenerateWfRange_IsRejectedAndPriorValueKept(double badMin, double badMax)
+    {
+        using var store = BuildStore();
+        store.SaveMode("basic", "fill", "#FFA028",
+            wfDbMin: -125, wfDbMax: -55);
+
+        store.SaveMode("basic", "fill", "#FFA028",
+            wfDbMin: badMin, wfDbMax: badMax);
+
+        var dto = store.Get();
+        Assert.Equal(-125, dto.WfDbMin);
+        Assert.Equal(-55, dto.WfDbMax);
+    }
+
+    [Fact]
+    public void SaveMode_PartialDegenerateRange_OnlyAffectedPairIsRejected()
+    {
+        using var store = BuildStore();
+        store.SaveMode("basic", "fill", "#FFA028",
+            dbMin: -130, dbMax: -60,
+            wfDbMin: -125, wfDbMax: -55);
+
+        // Valid pan update, but degenerate wf update in the same call.
+        store.SaveMode("basic", "fill", "#FFA028",
+            dbMin: -120, dbMax: -50,
+            wfDbMin: -200, wfDbMax: -200);
+
+        var dto = store.Get();
+        Assert.Equal(-120, dto.DbMin);
+        Assert.Equal(-50, dto.DbMax);
+        Assert.Equal(-125, dto.WfDbMin);
+        Assert.Equal(-55, dto.WfDbMax);
+    }
 }

--- a/zeus-web/src/state/display-settings-store.ts
+++ b/zeus-web/src/state/display-settings-store.ts
@@ -318,6 +318,37 @@ export type DisplaySettingsState = {
 
 const DB_ABS_LIMIT = 200;
 
+// Clamp a shift delta so neither endpoint crosses ±DB_ABS_LIMIT while
+// preserving the span. The pre-fix code clamped each endpoint independently,
+// so a far-enough drag let both endpoints pile up against the same wall and
+// the span collapsed to zero — at which point the colormap maps everything
+// to one colour and the panadapter/waterfall renders a solid block.
+function clampShift(min: number, max: number, delta: number): { min: number; max: number } {
+  const lo = -DB_ABS_LIMIT;
+  const hi = DB_ABS_LIMIT;
+  const maxDown = lo - min; // ≤ 0
+  const maxUp = hi - max; // ≥ 0
+  const d = Math.max(maxDown, Math.min(maxUp, delta));
+  return { min: min + d, max: max + d };
+}
+
+// Validate a (min, max) pair coming from persisted state (server or
+// localStorage). Falls back to defaults if either value is non-finite,
+// outside [-DB_ABS_LIMIT, DB_ABS_LIMIT], or the span is below MIN_SPAN_DB
+// (which would render the trace/waterfall as a single flat colour).
+function sanitizeRange(
+  min: number | null | undefined,
+  max: number | null | undefined,
+  defaultMin: number,
+  defaultMax: number,
+): { min: number; max: number } {
+  if (typeof min !== 'number' || typeof max !== 'number') return { min: defaultMin, max: defaultMax };
+  if (!Number.isFinite(min) || !Number.isFinite(max)) return { min: defaultMin, max: defaultMax };
+  if (min < -DB_ABS_LIMIT || max > DB_ABS_LIMIT) return { min: defaultMin, max: defaultMax };
+  if (max - min < MIN_SPAN_DB) return { min: defaultMin, max: defaultMax };
+  return { min, max };
+}
+
 const initialRange = readSavedRange();
 const initialTxRange = readSavedTxRange();
 const initialWfRange = readSavedWfRange();
@@ -440,32 +471,28 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
     const { autoRange, dbMin, dbMax } = get();
     const baseMin = autoRange ? readSavedRange().dbMin : dbMin;
     const baseMax = autoRange ? readSavedRange().dbMax : dbMax;
-    const nextMin = Math.max(-DB_ABS_LIMIT, Math.min(DB_ABS_LIMIT, baseMin + deltaDb));
-    const nextMax = Math.max(-DB_ABS_LIMIT, Math.min(DB_ABS_LIMIT, baseMax + deltaDb));
+    const { min: nextMin, max: nextMax } = clampShift(baseMin, baseMax, deltaDb);
     set({ autoRange: false, dbMin: nextMin, dbMax: nextMax });
     writeSavedRange(nextMin, nextMax);
     scheduleDbRangeSave();
   },
   shiftTxDbRange: (deltaDb) => {
     const { txDbMin, txDbMax } = get();
-    const nextMin = Math.max(-DB_ABS_LIMIT, Math.min(DB_ABS_LIMIT, txDbMin + deltaDb));
-    const nextMax = Math.max(-DB_ABS_LIMIT, Math.min(DB_ABS_LIMIT, txDbMax + deltaDb));
+    const { min: nextMin, max: nextMax } = clampShift(txDbMin, txDbMax, deltaDb);
     set({ txDbMin: nextMin, txDbMax: nextMax });
     writeSavedTxRange(nextMin, nextMax);
     scheduleDbRangeSave();
   },
   shiftWfDbRange: (deltaDb) => {
     const { wfDbMin, wfDbMax } = get();
-    const nextMin = Math.max(-DB_ABS_LIMIT, Math.min(DB_ABS_LIMIT, wfDbMin + deltaDb));
-    const nextMax = Math.max(-DB_ABS_LIMIT, Math.min(DB_ABS_LIMIT, wfDbMax + deltaDb));
+    const { min: nextMin, max: nextMax } = clampShift(wfDbMin, wfDbMax, deltaDb);
     set({ wfDbMin: nextMin, wfDbMax: nextMax });
     writeSavedWfRange(nextMin, nextMax);
     scheduleDbRangeSave();
   },
   shiftWfTxDbRange: (deltaDb) => {
     const { wfTxDbMin, wfTxDbMax } = get();
-    const nextMin = Math.max(-DB_ABS_LIMIT, Math.min(DB_ABS_LIMIT, wfTxDbMin + deltaDb));
-    const nextMax = Math.max(-DB_ABS_LIMIT, Math.min(DB_ABS_LIMIT, wfTxDbMax + deltaDb));
+    const { min: nextMin, max: nextMax } = clampShift(wfTxDbMin, wfTxDbMax, deltaDb);
     set({ wfTxDbMin: nextMin, wfTxDbMax: nextMax });
     writeSavedWfTxRange(nextMin, nextMax);
     scheduleDbRangeSave();
@@ -558,6 +585,34 @@ async function hydrateFromServer(): Promise<void> {
   // state and push it up so the server has it for next restart.
   const serverHasDbRange = server.dbMin !== null;
 
+  // Sanitize server-provided ranges so a corrupt or pre-validation row in
+  // zeus-prefs.db (e.g. wfDbMin == wfDbMax from earlier builds) can't render
+  // the panadapter/waterfall as a single flat colour on next load. If the
+  // server value is invalid we fall back to defaults and let scheduleDbRangeSave
+  // push the corrected value back up.
+  const panRange = serverHasDbRange
+    ? sanitizeRange(server.dbMin, server.dbMax, FIXED_DB_MIN, FIXED_DB_MAX)
+    : null;
+  const panTxRange = serverHasDbRange
+    ? sanitizeRange(server.txDbMin, server.txDbMax, TX_FIXED_DB_MIN, TX_FIXED_DB_MAX)
+    : null;
+  const wfRange = serverHasDbRange
+    ? sanitizeRange(server.wfDbMin, server.wfDbMax, FIXED_DB_MIN, FIXED_DB_MAX)
+    : null;
+  const wfTxRange = serverHasDbRange
+    ? sanitizeRange(server.wfTxDbMin, server.wfTxDbMax, TX_FIXED_DB_MIN, TX_FIXED_DB_MAX)
+    : null;
+  const serverRangeWasCorrupt =
+    serverHasDbRange &&
+    (panRange!.min !== server.dbMin ||
+      panRange!.max !== server.dbMax ||
+      panTxRange!.min !== server.txDbMin ||
+      panTxRange!.max !== server.txDbMax ||
+      wfRange!.min !== server.wfDbMin ||
+      wfRange!.max !== server.wfDbMax ||
+      wfTxRange!.min !== server.wfTxDbMin ||
+      wfTxRange!.max !== server.wfTxDbMax);
+
   useDisplaySettingsStore.setState({
     panBackground: server.mode,
     backgroundImage: server.hasImage ? displayImageUrl(Date.now()) : null,
@@ -565,19 +620,19 @@ async function hydrateFromServer(): Promise<void> {
     rxTraceColor: server.rxTraceColor,
     ...(serverHasDbRange
       ? {
-          dbMin: server.dbMin!,
-          dbMax: server.dbMax!,
-          txDbMin: server.txDbMin!,
-          txDbMax: server.txDbMax!,
-          wfDbMin: server.wfDbMin!,
-          wfDbMax: server.wfDbMax!,
-          wfTxDbMin: server.wfTxDbMin!,
-          wfTxDbMax: server.wfTxDbMax!,
+          dbMin: panRange!.min,
+          dbMax: panRange!.max,
+          txDbMin: panTxRange!.min,
+          txDbMax: panTxRange!.max,
+          wfDbMin: wfRange!.min,
+          wfDbMax: wfRange!.max,
+          wfTxDbMin: wfTxRange!.min,
+          wfTxDbMax: wfTxRange!.max,
         }
       : {}),
   });
 
-  if (!serverHasDbRange) {
+  if (!serverHasDbRange || serverRangeWasCorrupt) {
     // Push the current in-memory values (from localStorage or defaults) up
     // to the server so subsequent restarts find them persisted. This is the
     // one-time migration for operators upgrading from localStorage-only storage.


### PR DESCRIPTION
## Symptom

Drag the waterfall (or panadapter) dB scale far enough and you get a solid-colour block where the spectrum used to be. The slider, AUTO/FIXED button, and palette buttons are now hidden behind that block, and the operator can't click their way out. Setting persists to \`zeus-prefs.db\`, so a page reload brings the block back. Hit on develop today with \`wfDbMin == wfDbMax == -200\`.

## Root cause

\`shiftWfDbRange\` (and the three sibling shifters) clamped \`min\` and \`max\` *independently* to \`±DB_ABS_LIMIT\`:

\`\`\`ts
const nextMin = Math.max(-DB_ABS_LIMIT, Math.min(DB_ABS_LIMIT, wfDbMin + deltaDb));
const nextMax = Math.max(-DB_ABS_LIMIT, Math.min(DB_ABS_LIMIT, wfDbMax + deltaDb));
\`\`\`

Drag down repeatedly: \`min\` hits the floor first, then \`max\` catches up. Once \`max == min == -DB_ABS_LIMIT\`, the colormap input range is zero — every sample maps to the same colour. There's no client- or server-side guard, so the broken pair persists to LiteDB and survives reload.

## Fix — three guards, defence in depth

1. **Client shift (`clampShift`)** — clamps the *delta*, not each endpoint, so the span is preserved no matter how hard the operator drags.
2. **Client hydrate (`sanitizeRange`)** — every value read from the server is checked against \`±DB_ABS_LIMIT\` and \`MIN_SPAN_DB (20)\`. Degenerate stored values fall back to \`FIXED_DB_MIN/MAX\` and are pushed back up so the corrupt row gets healed on next load.
3. **Server write (`IsValidRange`)** — \`DisplaySettingsStore.SaveMode\` now drops any (min, max) pair that's NaN/infinite/inverted/outside ±200/span < 20 dB. The prior stored value is kept, so a buggy client or stray API call can't poison \`zeus-prefs.db\`.

All four shifters covered: RX pan, TX pan, RX wf, TX wf.

## Tests

- New theory cases in \`DisplaySettingsPersistenceTests\` for the original symptom (\`-200, -200\`), \`min == max\`, \`span < MinSpanDb\`, inverted, and outside-abs-limit pairs.
- New mixed-validity case proves a valid pan update lands while a degenerate wf update in the same call is dropped.
- Full suite: **687 passed, 0 failed, 5 skipped** (no regressions).

## Test plan

- [ ] Drag the panadapter dB scale to the floor — span never collapses; visualisation still readable.
- [ ] Drag the waterfall dB scale to the floor — same.
- [ ] Reload — server-stored ranges round-trip; if the existing DB still has a degenerate row, it self-heals to defaults.
- [ ] \`curl -X PUT /api/display-settings -d '{"mode":"image","fit":"fill","wfDbMin":-200,"wfDbMax":-200}'\` — write is rejected, prior value retained.