### PR TITLE
feat(server-tab): https/6443 hint + Cloudflare Tunnel opt-in (Stage 1)

### DIFF
--- a/docs/adr/0001-data-plane-cloudflare-quick-tunnels.md
+++ b/docs/adr/0001-data-plane-cloudflare-quick-tunnels.md
@@ -1,0 +1,19 @@
+# Anonymous Cloudflare Quick Tunnels for the remote-access data plane
+
+Zeus desktop exposes itself to a paired mobile client by spawning `cloudflared` as a subprocess that opens an anonymous Quick Tunnel against `trycloudflare.com`. No third-party account exists in the user's mental model, and no per-byte cost lands on the maintainer's infrastructure.
+
+## Considered options
+
+- **ngrok free tier** — rejected. The user must sign up at ngrok.com and paste an authtoken, which kills the "open app, scan QR, online" first-run UX.
+- **Cloudflare Tunnel on the maintainer's CF account** (the original `feature_tunnel_broker` design) — rejected. Every user's data bytes would flow through the `openhpsdrzeus.com` Cloudflare account; the maintainer would bear both cost and abuse risk as the user base grows.
+- **User's own Cloudflare account with a named tunnel** — rejected. The signup and `cloudflared` auth flow is equivalent friction to ngrok.
+- **Tailscale Funnel / ZeroTier mesh** — rejected. Mesh-VPN onboarding requires installing a separate client and authenticating to an external account before the user can even reach the radio. Heavier than any HTTP-tunnel option for the common case.
+
+## Consequences
+
+- Each session gets a different ephemeral URL (`xyz-abc.trycloudflare.com`). The broker handles stability via slug → current-URL redirection — see [0002](./0002-broker-as-identity-redirector.md).
+- Cloudflare officially labels Quick Tunnels "for testing and development only." There is no SLA, and Cloudflare can rate-limit or remove the feature unilaterally. We accept this risk without a hedge in v1.
+- Cloudflare retired TOS Section 2.8 (the audio/video CDN restriction) for Tunnel; real-time WebSocket audio is no longer policy-blocked.
+- WebSocket and SignalR are supported on Quick Tunnels; Zeus's existing `UseWebSockets` configuration with a 20s keepalive already aligns with Cloudflare's idle-close behavior.
+- Quick Tunnels enforce a 200-concurrent-request cap, which is comfortable for one operator with one mobile client.
+- `cloudflared` must be available on the user's machine — see [0004](./0004-bundle-cloudflared-in-installer.md).

--- a/docs/adr/0002-broker-as-identity-redirector.md
+++ b/docs/adr/0002-broker-as-identity-redirector.md
@@ -1,0 +1,24 @@
+# Broker is identity + redirector, not the data plane
+
+`openhpsdrzeus.com` runs a Cloudflare Worker that holds Google OAuth identity, issues short-lived Ed25519-signed JWTs, and serves `GET /go/<slug>` as a 302 to the current Quick Tunnel URL reported by the desktop. The broker never sees tunnel bytes — only registration metadata and auth — which keeps the maintainer's hosting cost on Cloudflare's free tier indefinitely.
+
+## Considered options
+
+- **Broker provisions tunnels under the maintainer CF account** (original 16-commit `feature_tunnel_broker` design) — superseded by this ADR. Data-plane cost on the maintainer's account is the rejection driver. Roughly 3 commits of the existing broker (`e57294f` CF Tunnel API client, the DNS provisioning code paths inside `77be37b`) become dead code.
+- **No broker; QR encodes the raw Quick Tunnel URL** — rejected. The URL changes on every desktop restart, so mobile would have to re-scan every session, breaking "scan once, work forever."
+- **Broker also hosts a WebSocket relay** — rejected for the same data-plane-cost reason as the original design.
+
+## Consequences
+
+- The broker is a SPOF for *connection establishment* (first /go redirect of a new session) but not for *ongoing session data*. Once mobile holds a JWT and the current tunnel URL, broker outage does not interrupt an established session.
+- Approximately 70% of the existing 16-commit broker work survives intact: Google OAuth, sealed cookies, session middleware, Ed25519 / JWKS signing, `/go` redirect, `/settings/devices`, daily GC cron, D1 schema.
+- The "punch" endpoint reshapes from "create CF tunnel via API" to "register the current Quick Tunnel URL." `mine`, `heartbeat`, and `delete` mostly survive.
+- The Zeus desktop validates JWTs against the broker's JWKS endpoint, fetched once at startup. This means desktop ↔ broker have a startup-time coupling but no per-request dependency.
+
+## Glossary
+
+- **Slug** — a random per-install identifier issued by the broker on first sign-in (e.g. `blue-falcon-742`). Stable for the lifetime of the Zeus install. See [0003](./0003-random-slug-same-account-pairing.md).
+- **Broker** — the Cloudflare Worker hosted at `openhpsdrzeus.com` that handles Google OAuth, slug allocation, JWT minting, and the `/go/<slug>` redirect.
+- **Quick Tunnel** — an anonymous Cloudflare Tunnel session created by `cloudflared` with no account, ephemeral URL on `trycloudflare.com`. See [0001](./0001-data-plane-cloudflare-quick-tunnels.md).
+- **Device pairing** — the act of associating a mobile install with a Zeus desktop install via shared Google account on the broker.
+- **Redirect JWT** — the short-lived Ed25519-signed token the broker mints into the `/go/<slug>` 302 redirect; validated by Zeus desktop against the broker's JWKS on each WebSocket connect.

--- a/docs/adr/0003-random-slug-same-account-pairing.md
+++ b/docs/adr/0003-random-slug-same-account-pairing.md
@@ -1,0 +1,16 @@
+# Random slugs, same-Google-account pairing
+
+The broker assigns each Zeus install a random slug like `blue-falcon-742` rather than a callsign. Mobile binds to a desktop by signing into the broker with the same Google account; the QR encodes only the slug URL, with no embedded pairing token in v1.
+
+## Considered options
+
+- **Callsign slugs (`/go/ei6lf`)** — rejected. Callsign squatting is a real problem (callsigns get reassigned, and first-signup-wins lets users claim names they don't hold), and verification against FCC / Ofcom / equivalent is rabbit-hole work for v1. URLs should brand the tunnel, not assert amateur identity.
+- **Vanity callsign as a second alias on top of a random slug** — deferred, not rejected. Easy to add later as one column, one endpoint, with both `/go/blue-falcon-742` and `/go/ei6lf` redirecting to the same tunnel.
+- **One-time pairing token in the QR** — deferred. Would enable "share my shack with a friend without sharing my Google credentials," but adds first-run friction to the common case (the user's own phone). Implementable later as an additive `?pair=…` query parameter on the existing endpoint with no breaking change.
+
+## Consequences
+
+- A shoulder-surfer who photographs the QR cannot pair to the radio, because pairing requires an active session on the slug owner's Google account.
+- "Lend my shack to a friend" is not supported in v1; both endpoints must use the same Google account.
+- Callsign-shaped vanity URLs (a natural community-facing feature) are deferred but not architecturally blocked.
+- The broker's `c7b8064` random slug generator and `a2a9b3d` `/settings/devices` page already implement the model this ADR locks in; no broker-side work changes from this decision.

--- a/docs/adr/0004-bundle-cloudflared-in-installer.md
+++ b/docs/adr/0004-bundle-cloudflared-in-installer.md
@@ -1,0 +1,16 @@
+# Bundle `cloudflared` in the Zeus installer
+
+The `cloudflared` binary ships inside the Zeus desktop installer (~30 MB per platform/arch) rather than being downloaded on first use or installed by the user separately. The desktop spawns it as a subprocess and captures the random `*.trycloudflare.com` URL from its output.
+
+## Considered options
+
+- **Download `cloudflared` on first "Go Online"** — rejected. First-run reliability matters more than installer size, and a "downloading cloudflared… network error" experience on first connect breaks the dream UX. It also adds Gatekeeper / SmartScreen trust questions for a binary delivered post-install.
+- **Require the user to install `cloudflared` via Homebrew / Scoop / apt** — rejected. Highest user friction; eliminates non-technical operators entirely.
+
+## Consequences
+
+- Installer grows by ~30 MB per platform/arch — acceptable given Zeus already ships .NET runtime, WDSP, and miniaudio.
+- The macOS .app bundle must notarize `cloudflared` along with the rest of the binary. Cloudflare ships unsigned `.tgz` releases, so the Zeus build pipeline must re-sign and notarize. `~/zeus-sign-notarize.sh` and `create-macos-app.sh` need to learn about the embedded binary.
+- The Windows installer must Authenticode-sign the embedded `cloudflared.exe` as part of the existing `release.yml` flow.
+- CVE response cadence becomes "ship a Zeus point release with bumped `cloudflared`." Acceptable given `cloudflared`'s low CVE frequency.
+- The bundled `cloudflared` version is pinned in the build pipeline (downloaded at build time, not committed to the repo).

--- a/docs/superpowers/specs/2026-05-24-cloudflare-tunnel-zeus-side.md
+++ b/docs/superpowers/specs/2026-05-24-cloudflare-tunnel-zeus-side.md
@@ -1,0 +1,130 @@
+# Cloudflare Tunnel — Zeus app side (sub-project B)
+
+**Status:** Design 2026-05-24
+**Pair:** Broker side is `brianbruff/openhpsdrzeus.com#1` (branch `feature/tunnel-broker`)
+**Worktree:** `feature/tunnel`
+
+## Problem
+
+Once the broker at openhpsdrzeus.com is live, Zeus operators need three
+things inside the app:
+
+1. A clear UI on the Settings / Server tab to opt into a tunnel and
+   punch one with one click.
+2. A backend that talks to the broker (Google sign-in, fetch tunnel
+   credentials), downloads + spawns `cloudflared`, and reports status.
+3. Middleware on Zeus.Server that accepts the broker's signed redirect
+   JWT, sets a `zeus_session` cookie, and gates traffic that arrives via
+   the tunnel hostname (while leaving direct LAN access untouched).
+
+This spec covers all three but is implemented in stages — Stage 1 is
+visible UI only, Stages 2–4 wire the backend.
+
+## Default value changes (operator-visible)
+
+- The Server URL panel hint and placeholder change from
+  `http://192.168.1.23:6060` → `https://192.168.1.23:6443`.
+  Reason: HTTPS on `:6443` is the recommended path now that Zeus.Server
+  binds both. The HTTP port stays available; we just stop advertising
+  it. This is a one-place copy change and per repo conventions counts as
+  a low-risk visual default, not a behavior change.
+
+## Stages
+
+### Stage 1 — Server tab UI (this PR)
+
+- Change example URL hint + placeholder to `https://192.168.1.23:6443`.
+- Add a "Cloudflare Tunnel" card below the existing Base URL controls,
+  containing:
+  - Opt-in checkbox: **"Enable Cloudflare tunnel"** (persists to
+    localStorage `zeus.tunnel.optIn`).
+  - **"Punch tunnel"** button — enabled only when opted in.
+  - Status line. While the backend is not wired (Stages 2-4 below),
+    clicking "Punch tunnel" surfaces a static notice pointing the
+    operator at the broker landing page.
+- No backend changes in this stage. The button calls a local
+  function only; nothing is persisted server-side.
+
+### Stage 2 — Google sign-in (backend)
+
+- New ASP.NET controller `BrokerAuthController`:
+  - `POST /api/broker/login/start` — opens the operator's system browser
+    to `https://openhpsdrzeus.com/api/auth/google/start?client=zeus&return=<loopback>`.
+  - `GET /<loopback>/oauth-done?token=...` — captures the bearer token
+    from the broker's redirect, stores it in LiteDB
+    (`broker_session.token`) with file permissions 600, replies with a
+    short "you can close this window" HTML.
+- Frontend learns sign-in state via `GET /api/broker/me` (proxied to
+  broker `/api/auth/me` with the stored bearer).
+
+### Stage 3 — Cloudflared lifecycle (backend)
+
+- `TunnelService`:
+  - On first punch: downloads platform-appropriate `cloudflared` binary
+    from the official GitHub releases into `<app-data>/cloudflared/<version>/`.
+    Verifies SHA-256 against the published checksum.
+  - Calls broker `POST /api/tunnels/punch` with stored bearer.
+  - Spawns `cloudflared tunnel run --token <T>` as a child process.
+  - Captures stderr, exposes liveness over `GET /api/broker/tunnel/status`.
+  - Heartbeat ticker (5 min) calls broker `POST /api/tunnels/heartbeat`.
+  - Kills the subprocess on app shutdown.
+  - Persists last-known PID to LiteDB; on startup, if the PID is alive
+    and looks like `cloudflared`, adopt it; otherwise kill it.
+- Frontend Server tab status panel polls
+  `GET /api/broker/tunnel/status` and renders the live URL +
+  "Stop tunnel" button.
+
+### Stage 4 — Tunnel-side auth on Zeus.Server
+
+- New `TunnelAuthMiddleware` in `Zeus.Server.Hosting`:
+  - Detects whether the request arrived via the tunnel by checking
+    `Host` against the slug persisted to LiteDB (`tunnel.slug`).
+  - LAN / loopback hosts: skip entirely (preserves today's UX).
+  - Tunnel host:
+    - If `?t=<jwt>` is present: verify against broker JWKS
+      (`<jwks_url>` returned by `/api/tunnels/punch`, cached 24h).
+      Verify `iss=https://openhpsdrzeus.com`, `aud=<our slug>`, `exp`
+      not passed, `jti` not in replay-cache (in-process LRU, 10-minute
+      retention). On success: set `zeus_session` cookie (random session
+      id keyed in LiteDB to `(sub, email, exp+8h)`), 302 to same URL
+      with `?t` stripped.
+    - Else if `zeus_session` cookie is present and valid: attach
+      session, pass through.
+    - Else: 401 with an HTML page pointing back to
+      `https://openhpsdrzeus.com`.
+
+`zeus_session` cookie spec:
+- Name `zeus_session`
+- Domain `<slug>.openhpsdrzeus.com` (scoped, no leading dot)
+- Path `/`, `Secure; HttpOnly; SameSite=Lax`
+- `Max-Age=28800` (8 h)
+
+## Storage (LiteDB additions)
+
+Single new collection `broker_state` with one document:
+```jsonc
+{
+  "_id": 1,
+  "optIn": true,
+  "googleEmail": "x@y.z",
+  "bearerToken": "…",         // opaque from broker
+  "tunnelSlug": "rkkkxppmnz",
+  "tunnelHostname": "rkkkxppmnz.openhpsdrzeus.com",
+  "jwksUrl": "https://openhpsdrzeus.com/.well-known/jwks.json",
+  "cloudflaredPath": "/Users/bek/Library/.../cloudflared",
+  "lastPunchAt": 1748097600,
+  "lastKnownPid": 12345
+}
+```
+
+Cookie sessions (zeus_session) are in-process only for v1 — they don't
+need to survive a Zeus restart (users re-enter via openhpsdrzeus.com).
+
+## Open questions deferred
+
+- Multi-user sessions on one Zeus instance (current model: any logged-in
+  Google user can take over the tunnel since the bearer is single-token
+  per box). Acceptable for v1 since each Zeus is a single-operator
+  station.
+- Cloudflared auto-update — for v1 we pin a known version and require
+  reinstall to bump.

--- a/zeus-web/src/components/ServerUrlPanel.tsx
+++ b/zeus-web/src/components/ServerUrlPanel.tsx
@@ -13,9 +13,12 @@ import {
 } from '../serverUrl';
 
 // Settings tab: lets the operator point a Capacitor / standalone build at a
-// specific Zeus.Server on their LAN (e.g. http://192.168.1.23:6060). Browser
+// specific Zeus.Server on their LAN (e.g. https://192.168.1.23:6443). Browser
 // users on the bundled deploy normally leave this blank — relative paths
 // already reach the same-origin server.
+
+const TUNNEL_OPTIN_KEY = 'zeus.tunnel.optIn';
+const TUNNEL_BROKER_ORIGIN = 'https://openhpsdrzeus.com';
 
 export function ServerUrlPanel() {
   const [value, setValue] = useState(() => getServerBaseUrl());
@@ -75,7 +78,7 @@ export function ServerUrlPanel() {
         deploy). On native mobile / desktop wrappers, point this at the LAN
         host running Zeus.Server, e.g.{' '}
         <code style={{ fontFamily: 'monospace', color: 'var(--fg-1)' }}>
-          http://192.168.1.23:6060
+          https://192.168.1.23:6443
         </code>
         .
       </p>
@@ -98,7 +101,7 @@ export function ServerUrlPanel() {
           autoCorrect="off"
           spellCheck={false}
           inputMode="url"
-          placeholder="http://192.168.1.23:6060"
+          placeholder="https://192.168.1.23:6443"
           value={value}
           onChange={(e) => {
             setValue(e.target.value);
@@ -183,6 +186,128 @@ export function ServerUrlPanel() {
           Cleartext HTTP to RFC1918 / link-local addresses is permitted; iOS
           may show a "Find devices on local network" prompt the first time
           the app reaches a 192.168.* / 10.* host.
+        </div>
+      )}
+
+      <TunnelSection />
+    </div>
+  );
+}
+
+// Stage 1: opt-in UI for the Cloudflare tunnel feature. Frontend-only;
+// the backend wiring (Google sign-in, cloudflared subprocess, JWT
+// middleware) lands in Stages 2-4 — see
+// docs/superpowers/specs/2026-05-24-cloudflare-tunnel-zeus-side.md.
+function TunnelSection() {
+  const [optIn, setOptIn] = useState<boolean>(() => {
+    try { return localStorage.getItem(TUNNEL_OPTIN_KEY) === 'true'; }
+    catch { return false; }
+  });
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const persistOptIn = (v: boolean) => {
+    setOptIn(v);
+    try { localStorage.setItem(TUNNEL_OPTIN_KEY, v ? 'true' : 'false'); }
+    catch { /* noop */ }
+    if (!v) setNotice(null);
+  };
+
+  const handlePunch = () => {
+    // Backend lands in Stage 2-3. For now, surface a clear notice so
+    // the operator sees that the broker exists and where to find it.
+    setNotice(
+      `Broker live at ${TUNNEL_BROKER_ORIGIN}. ` +
+        'Backend wiring (Google sign-in + cloudflared spawn) is staged — ' +
+        'this button becomes functional once /api/broker/tunnel is implemented.',
+    );
+  };
+
+  return (
+    <div style={{ marginTop: 28 }}>
+      <h3
+        style={{
+          margin: '0 0 14px',
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: '0.12em',
+          textTransform: 'uppercase',
+          color: 'var(--fg-2)',
+        }}
+      >
+        CLOUDFLARE TUNNEL
+      </h3>
+
+      <p style={{ fontSize: 12, color: 'var(--fg-2)', lineHeight: 1.5, marginTop: 0 }}>
+        Expose this Zeus.Server to the public internet via a Cloudflare
+        Tunnel at <code style={{ fontFamily: 'monospace', color: 'var(--fg-1)' }}>{'<slug>.openhpsdrzeus.com'}</code>.
+        Access is gated by Google sign-in on{' '}
+        <a
+          href={TUNNEL_BROKER_ORIGIN}
+          target="_blank"
+          rel="noreferrer"
+          style={{ color: 'var(--accent)' }}
+        >openhpsdrzeus.com</a>; nobody can reach your radio without authenticating.
+      </p>
+
+      <label
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          marginTop: 16,
+          fontSize: 12,
+          color: 'var(--fg-1)',
+          cursor: 'pointer',
+        }}
+      >
+        <input
+          type="checkbox"
+          checked={optIn}
+          onChange={(e) => persistOptIn(e.target.checked)}
+        />
+        Enable Cloudflare tunnel
+      </label>
+
+      <div style={{ display: 'flex', gap: 8, marginTop: 14, alignItems: 'center' }}>
+        <button
+          type="button"
+          onClick={handlePunch}
+          disabled={!optIn}
+          style={{
+            padding: '8px 16px',
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: '0.1em',
+            textTransform: 'uppercase',
+            color: optIn ? 'var(--fg-0)' : 'var(--fg-2)',
+            background: optIn ? 'var(--accent)' : 'var(--bg-2)',
+            border: '1px solid var(--panel-border)',
+            borderRadius: 'var(--r-sm)',
+            cursor: optIn ? 'pointer' : 'not-allowed',
+            opacity: optIn ? 1 : 0.6,
+          }}
+        >
+          Punch tunnel
+        </button>
+        <span style={{ fontSize: 11, color: 'var(--fg-2)' }}>
+          {optIn ? 'No tunnel running.' : 'Tunnel disabled.'}
+        </span>
+      </div>
+
+      {notice && (
+        <div
+          style={{
+            marginTop: 14,
+            padding: 10,
+            fontSize: 11,
+            lineHeight: 1.5,
+            color: 'var(--fg-2)',
+            background: 'var(--bg-2)',
+            border: '1px solid var(--panel-border)',
+            borderRadius: 'var(--r-sm)',
+          }}
+        >
+          {notice}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

Stage 1 of three for openhpsdrzeus.com tunnel integration — **frontend only, no backend changes**.

- Server URL hint and placeholder updated from `http://...:6060` → `https://...:6443` (matches Zeus.Server's actual LAN HTTPS bind, which has been in place for some time).
- New **CLOUDFLARE TUNNEL** card below the URL controls:
  - Explanatory copy linking to openhpsdrzeus.com
  - Opt-in checkbox "Enable Cloudflare tunnel" (persists to `localStorage.zeus.tunnel.optIn`)
  - "Punch tunnel" button — disabled until opt-in, currently surfaces an honest notice that the backend is staged
- No changes to existing controls, behavior, or wiring. 229/229 zeus-web tests still pass.

Full design + later stages: `docs/superpowers/specs/2026-05-24-cloudflare-tunnel-zeus-side.md`

## Companion PR

Broker side (separate repo): https://github.com/brianbruff/openhpsdrzeus.com/pull/1

## Test plan

- [x] zeus-web typecheck clean
- [x] zeus-web vitest 229/229 pass
- [x] Manual: opened http://localhost:5173 with backend on :6060, navigated Settings → SERVER, verified the new section renders, checkbox toggles the Punch button, click surfaces the staged-backend notice
- [x] Manual: verified \`https://192.168.1.23:6443\` is now shown (and the old http/6060 string is gone) in both the hint paragraph and the input placeholder

## Stages remaining (separate PRs)

- **Stage 2** — Google sign-in: \`BrokerAuthController\` (opens system browser → loopback callback → bearer token in LiteDB)
- **Stage 3** — \`TunnelService\`: download cloudflared, call broker \`/api/tunnels/punch\`, spawn subprocess, surface status via \`GET /api/broker/tunnel/status\`
- **Stage 4** — \`TunnelAuthMiddleware\` in \`Zeus.Server.Hosting\`: validate broker JWT, set \`zeus_session\` cookie, gate traffic arriving via the tunnel hostname (LAN access unchanged)