### PR TITLE
fix(toolbar): persist tuning step + favorites server-side

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -664,6 +664,27 @@ public sealed record PanWfSplitDto(double PanPercent);
 
 public sealed record PanWfSplitSetRequest(double PanPercent);
 
+// Toolbar Mode/Band/Step favorite-slot pins plus the currently-selected
+// tuning step. Each favorite array holds exactly three slot keys; StepHz is
+// the live tuning step in Hz. Persisted server-side in zeus-prefs.db so the
+// settings follow the operator across browsers / devices — Photino desktop
+// mode binds the webview to a fresh random loopback port on every launch,
+// which orphans any per-origin localStorage value (the bug this fixes). Null
+// arrays / StepHz mean the server has never stored a value; the frontend
+// falls back to its built-in defaults and pushes the current value up on the
+// next interaction.
+public sealed record ToolbarSettingsDto(
+    IReadOnlyList<string>? Mode,
+    IReadOnlyList<string>? Band,
+    IReadOnlyList<string>? Step,
+    int? StepHz);
+
+public sealed record ToolbarSettingsSetRequest(
+    IReadOnlyList<string>? Mode = null,
+    IReadOnlyList<string>? Band = null,
+    IReadOnlyList<string>? Step = null,
+    int? StepHz = null);
+
 // ---- PureSignal request records ----
 // PsControlSetRequest = master arm (Enabled) + mode (Auto vs Single).
 // PsAdvancedSetRequest = nullable so partial updates from the settings

--- a/Zeus.Server.Hosting/ToolbarSettingsStore.cs
+++ b/Zeus.Server.Hosting/ToolbarSettingsStore.cs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using LiteDB;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+// Persists the toolbar Mode/Band/Step favorite-slot pins and the currently-
+// selected tuning step (StepHz). Lives in the same zeus-prefs.db as PA /
+// band-memory / layout / display settings — none of these values are
+// sensitive.
+//
+// Why server-side: the previous implementation stored these in browser
+// localStorage via zustand's persist middleware. localStorage is keyed by
+// origin, and the Photino desktop backend binds the webview to a fresh
+// OS-assigned random loopback port on every launch — so each launch was a
+// new origin with empty localStorage, resetting the tuning step to its
+// 500 Hz default every time. Moving it to LiteDB lets the setting survive a
+// backend restart and follow the operator across every browser pointed at the
+// Zeus instance. Same pattern as DisplaySettingsStore.
+public sealed class ToolbarSettingsStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<ToolbarSettingsEntry> _docs;
+    private readonly ILogger<ToolbarSettingsStore> _log;
+    private readonly object _sync = new();
+
+    public ToolbarSettingsStore(ILogger<ToolbarSettingsStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _docs = _db.GetCollection<ToolbarSettingsEntry>("toolbar_settings");
+
+        _log.LogInformation("ToolbarSettingsStore initialized at {Path}", dbPath);
+    }
+
+    public ToolbarSettingsDto Get()
+    {
+        lock (_sync)
+        {
+            var e = _docs.FindAll().FirstOrDefault();
+            if (e is null)
+            {
+                // Null fields tell the frontend the server has never stored a
+                // value, so it keeps its built-in defaults and pushes them up.
+                return new ToolbarSettingsDto(Mode: null, Band: null, Step: null, StepHz: null);
+            }
+            return new ToolbarSettingsDto(
+                Mode: NormalizeSlots(e.Mode),
+                Band: NormalizeSlots(e.Band),
+                Step: NormalizeSlots(e.Step),
+                StepHz: e.StepHz);
+        }
+    }
+
+    // Null arguments are treated as "not provided" — the existing stored value
+    // is kept unchanged. This lets a caller update only StepHz (the common
+    // case) without disturbing the favorite-slot pins, and vice-versa.
+    public void Save(
+        IReadOnlyList<string>? mode = null,
+        IReadOnlyList<string>? band = null,
+        IReadOnlyList<string>? step = null,
+        int? stepHz = null)
+    {
+        lock (_sync)
+        {
+            var e = _docs.FindAll().FirstOrDefault() ?? new ToolbarSettingsEntry();
+            if (mode is not null) e.Mode = NormalizeSlots(mode);
+            if (band is not null) e.Band = NormalizeSlots(band);
+            if (step is not null) e.Step = NormalizeSlots(step);
+            if (stepHz.HasValue) e.StepHz = stepHz;
+            e.UpdatedUtc = DateTime.UtcNow;
+            if (e.Id == 0) _docs.Insert(e);
+            else _docs.Update(e);
+        }
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    // Favorite slots are always exactly three keys. A malformed array (wrong
+    // length, null entries) is rejected as null so the frontend falls back to
+    // its defaults rather than rendering a broken picker.
+    private static List<string>? NormalizeSlots(IReadOnlyList<string>? raw)
+    {
+        if (raw is null || raw.Count != 3) return null;
+        var copy = new List<string>(3);
+        foreach (var s in raw)
+        {
+            if (string.IsNullOrWhiteSpace(s)) return null;
+            copy.Add(s);
+        }
+        return copy;
+    }
+}
+
+public sealed class ToolbarSettingsEntry
+{
+    public int Id { get; set; }
+    // Three favorite-slot keys per picker. Null on legacy / fresh rows — Get()
+    // returns null to the frontend, which then keeps its built-in defaults.
+    public List<string>? Mode { get; set; }
+    public List<string>? Band { get; set; }
+    public List<string>? Step { get; set; }
+    // Currently-selected tuning step in Hz. Null on rows written before this
+    // field existed — Get() returns null and the frontend falls back to its
+    // 500 Hz default.
+    public int? StepHz { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -912,6 +912,20 @@ public static class ZeusEndpoints
             return Results.Ok(saved);
         });
 
+        // Toolbar Mode/Band/Step favorite-slot pins + the live tuning step
+        // (StepHz). POST patches only the fields supplied — null fields leave
+        // the stored value untouched — so a step-change doesn't reset the
+        // favorite pins. Persisted in zeus-prefs.db so the tuning step and
+        // favorites survive a backend restart, fixing the Photino desktop
+        // per-launch-random-port localStorage reset.
+        app.MapGet("/api/toolbar-settings", (ToolbarSettingsStore store) => Results.Ok(store.Get()));
+
+        app.MapPost("/api/toolbar-settings", (ToolbarSettingsSetRequest req, ToolbarSettingsStore store) =>
+        {
+            store.Save(req.Mode, req.Band, req.Step, req.StepHz);
+            return Results.Ok(store.Get());
+        });
+
         // Inline NR settings accordion disclosure state (NR1 / NR2 / NR4).
         // PUT writes all three flags atomically. Persisted in zeus-prefs.db
         // so the chevron-open preference follows the operator across

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -272,6 +272,7 @@ public static class ZeusHost
         builder.Services.AddSingleton<PsSettingsStore>();
         builder.Services.AddSingleton<FilterPresetStore>();
         builder.Services.AddSingleton<DisplaySettingsStore>();
+        builder.Services.AddSingleton<ToolbarSettingsStore>();
         builder.Services.AddSingleton<NrUiPrefsStore>();
         builder.Services.AddSingleton<ThemeSettingsStore>();
         builder.Services.AddSingleton<BottomPinStore>();

--- a/tests/Zeus.Server.Tests/ToolbarSettingsPersistenceTests.cs
+++ b/tests/Zeus.Server.Tests/ToolbarSettingsPersistenceTests.cs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// Persistence coverage for the toolbar tuning-step / favorites bug — the
+// tuning step and Mode/Band/Step favorite pins now survive a backend restart
+// instead of resetting to 500 Hz every Photino desktop launch (per-launch
+// random loopback port orphaned the old localStorage value). Verifies the
+// fields round-trip through LiteDB, that a fresh row returns null so the
+// frontend keeps its defaults, and that a partial save leaves untouched
+// fields intact.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Zeus.Server.Tests;
+
+public class ToolbarSettingsPersistenceTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-toolbar-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+    }
+
+    private ToolbarSettingsStore BuildStore() =>
+        new(NullLogger<ToolbarSettingsStore>.Instance, _dbPath);
+
+    [Fact]
+    public void FreshDb_ReturnsNullForAllFields()
+    {
+        using var store = BuildStore();
+        var dto = store.Get();
+
+        Assert.Null(dto.Mode);
+        Assert.Null(dto.Band);
+        Assert.Null(dto.Step);
+        Assert.Null(dto.StepHz);
+    }
+
+    [Fact]
+    public void Save_AllFields_PersistsAcrossReopen()
+    {
+        using (var store = BuildStore())
+        {
+            store.Save(
+                mode: new[] { "USB", "LSB", "AM" },
+                band: new[] { "80m", "40m", "20m" },
+                step: new[] { "10", "100", "1000" },
+                stepHz: 1000);
+        }
+
+        // Reopen to prove the values survived the LiteDB file round-trip.
+        using var fresh = BuildStore();
+        var dto = fresh.Get();
+
+        Assert.Equal(new[] { "USB", "LSB", "AM" }, dto.Mode);
+        Assert.Equal(new[] { "80m", "40m", "20m" }, dto.Band);
+        Assert.Equal(new[] { "10", "100", "1000" }, dto.Step);
+        Assert.Equal(1000, dto.StepHz);
+    }
+
+    [Fact]
+    public void Save_NullFields_DoNotOverwriteExistingValues()
+    {
+        using (var store = BuildStore())
+        {
+            store.Save(
+                mode: new[] { "USB", "LSB", "AM" },
+                band: new[] { "80m", "40m", "20m" },
+                step: new[] { "10", "100", "1000" },
+                stepHz: 1000);
+        }
+
+        // Update only StepHz — favorites left as null (the common case: the
+        // operator spins the step without touching the pins).
+        using (var update = BuildStore())
+        {
+            update.Save(stepHz: 250);
+        }
+
+        using var check = BuildStore();
+        var dto = check.Get();
+
+        Assert.Equal(250, dto.StepHz);
+        Assert.Equal(new[] { "USB", "LSB", "AM" }, dto.Mode);
+        Assert.Equal(new[] { "80m", "40m", "20m" }, dto.Band);
+        Assert.Equal(new[] { "10", "100", "1000" }, dto.Step);
+    }
+
+    [Fact]
+    public void Save_UpdateStepHz_OverwritesExistingValue()
+    {
+        using var store = BuildStore();
+        store.Save(stepHz: 500);
+        store.Save(stepHz: 1000);
+
+        var dto = store.Get();
+        Assert.Equal(1000, dto.StepHz);
+    }
+
+    [Fact]
+    public void Save_MalformedSlots_StoredAsNull()
+    {
+        using var store = BuildStore();
+        // Wrong length and a blank entry — both rejected so the frontend
+        // falls back to its built-in defaults rather than a broken picker.
+        store.Save(mode: new[] { "USB", "LSB" }, band: new[] { "80m", "", "20m" }, stepHz: 500);
+
+        var dto = store.Get();
+        Assert.Null(dto.Mode);
+        Assert.Null(dto.Band);
+        Assert.Equal(500, dto.StepHz);
+    }
+}

--- a/zeus-web/src/api/toolbar-settings.ts
+++ b/zeus-web/src/api/toolbar-settings.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// REST client for the server-side toolbar settings (Mode/Band/Step favorite
+// pins + the live tuning step). Mirrors api/display.ts. Persisting these on
+// the backend instead of localStorage fixes the Photino desktop bug where the
+// webview binds a fresh random loopback port every launch, orphaning the
+// per-origin localStorage and resetting the tuning step to 500 Hz.
+
+export type ToolbarSettings = {
+  // Three favorite-slot keys per picker, or null when the server has never
+  // stored a value (fresh install / first run after upgrade). The frontend
+  // keeps its built-in defaults and pushes them up on next interaction.
+  mode: string[] | null;
+  band: string[] | null;
+  step: string[] | null;
+  // Live tuning step in Hz, or null when never stored.
+  stepHz: number | null;
+};
+
+type ToolbarSettingsDtoRaw = {
+  mode?: string[] | null;
+  band?: string[] | null;
+  step?: string[] | null;
+  stepHz?: number | null;
+};
+
+function normalizeSlots(raw: string[] | null | undefined): string[] | null {
+  if (!Array.isArray(raw) || raw.length !== 3) return null;
+  if (!raw.every((s) => typeof s === 'string' && s.length > 0)) return null;
+  return raw;
+}
+
+function normalizeStepHz(raw: number | null | undefined): number | null {
+  return typeof raw === 'number' && Number.isFinite(raw) && raw > 0 ? raw : null;
+}
+
+function normalize(raw: ToolbarSettingsDtoRaw): ToolbarSettings {
+  return {
+    mode: normalizeSlots(raw.mode),
+    band: normalizeSlots(raw.band),
+    step: normalizeSlots(raw.step),
+    stepHz: normalizeStepHz(raw.stepHz),
+  };
+}
+
+export async function fetchToolbarSettings(signal?: AbortSignal): Promise<ToolbarSettings> {
+  const res = await fetch('/api/toolbar-settings', { signal });
+  if (!res.ok) throw new Error(`GET /api/toolbar-settings → ${res.status}`);
+  return normalize((await res.json()) as ToolbarSettingsDtoRaw);
+}
+
+// Patch only the supplied fields — null/undefined fields leave the stored
+// value untouched on the server, so a step change doesn't reset the favorite
+// pins and vice-versa.
+export async function updateToolbarSettings(
+  patch: Partial<{
+    mode: string[];
+    band: string[];
+    step: string[];
+    stepHz: number;
+  }>,
+  signal?: AbortSignal,
+): Promise<ToolbarSettings> {
+  const res = await fetch('/api/toolbar-settings', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(patch),
+    signal,
+  });
+  if (!res.ok) throw new Error(`POST /api/toolbar-settings → ${res.status}`);
+  return normalize((await res.json()) as ToolbarSettingsDtoRaw);
+}

--- a/zeus-web/src/state/toolbar-favorites-store.ts
+++ b/zeus-web/src/state/toolbar-favorites-store.ts
@@ -5,9 +5,17 @@
 // dropdown lets the operator drag any option onto a slot to pin it. Step
 // also stores the currently-selected step value so the toolbar widget and
 // the side-stack widget agree on a single tuning step.
+//
+// Persistence lives on the BACKEND (zeus-prefs.db via /api/toolbar-settings),
+// not browser localStorage. The Photino desktop webview binds a fresh
+// OS-assigned random loopback port on every launch, so a per-origin
+// localStorage value was orphaned each launch and the tuning step reset to
+// its 500 Hz default. Server-side storage survives the port shuffle and a
+// backend restart, and follows the operator across every browser pointed at
+// the Zeus instance. Same pattern as display-settings-store.ts.
 
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { fetchToolbarSettings, updateToolbarSettings } from '../api/toolbar-settings';
 
 export type ToolbarFavKind = 'mode' | 'band' | 'step';
 
@@ -25,21 +33,75 @@ type ToolbarFavoritesState = {
   setStepHz: (hz: number) => void;
 };
 
-export const useToolbarFavoritesStore = create<ToolbarFavoritesState>()(
-  persist(
-    (set) => ({
-      mode: [...DEFAULT_MODE],
-      band: [...DEFAULT_BAND],
-      step: [...DEFAULT_STEP],
-      stepHz: DEFAULT_STEP_HZ,
-      setFavorites: (kind, slots) => {
-        if (slots.length !== 3) return;
-        if (kind === 'mode') set({ mode: slots });
-        else if (kind === 'band') set({ band: slots });
-        else if (kind === 'step') set({ step: slots });
-      },
-      setStepHz: (hz) => set({ stepHz: hz }),
-    }),
-    { name: 'zeus.toolbar.favorites' },
-  ),
-);
+// Debounced server save. setStepHz / setFavorites can fire several times in
+// quick succession (e.g. spinning the step picker); batch into a single POST
+// after a 1 s quiet period, the same debounce display-settings-store.ts uses
+// for dB-range saves.
+let saveTimer: ReturnType<typeof setTimeout> | null = null;
+
+function scheduleSave(): void {
+  if (saveTimer) clearTimeout(saveTimer);
+  saveTimer = setTimeout(() => {
+    const s = useToolbarFavoritesStore.getState();
+    void updateToolbarSettings({
+      mode: s.mode,
+      band: s.band,
+      step: s.step,
+      stepHz: s.stepHz,
+    });
+  }, 1000);
+}
+
+export const useToolbarFavoritesStore = create<ToolbarFavoritesState>()((set) => ({
+  // Defaults until the server-side fetch lands (see hydrateFromServer at the
+  // bottom of this file). On first interaction before hydration completes the
+  // operator briefly sees the defaults — acceptable, same first-paint
+  // trade-off as display-settings-store.ts.
+  mode: [...DEFAULT_MODE],
+  band: [...DEFAULT_BAND],
+  step: [...DEFAULT_STEP],
+  stepHz: DEFAULT_STEP_HZ,
+  setFavorites: (kind, slots) => {
+    if (slots.length !== 3) return;
+    if (kind === 'mode') set({ mode: slots });
+    else if (kind === 'band') set({ band: slots });
+    else if (kind === 'step') set({ step: slots });
+    scheduleSave();
+  },
+  setStepHz: (hz) => {
+    set({ stepHz: hz });
+    scheduleSave();
+  },
+}));
+
+// One-shot hydration from the backend at module load. Server values of null
+// mean the field was never stored (fresh install / first run after upgrade);
+// keep the in-memory defaults in that case. When the server has nothing at
+// all, push the current defaults up once so subsequent restarts find them
+// persisted.
+async function hydrateFromServer(): Promise<void> {
+  let server: Awaited<ReturnType<typeof fetchToolbarSettings>>;
+  try {
+    server = await fetchToolbarSettings();
+  } catch {
+    // Backend unreachable; leave defaults in place. The next setStepHz /
+    // setFavorites will POST to the server.
+    return;
+  }
+
+  useToolbarFavoritesStore.setState({
+    ...(server.mode ? { mode: server.mode } : {}),
+    ...(server.band ? { band: server.band } : {}),
+    ...(server.step ? { step: server.step } : {}),
+    ...(server.stepHz !== null ? { stepHz: server.stepHz } : {}),
+  });
+
+  // Nothing stored server-side yet — push the current values (server's or our
+  // defaults) up so the next restart finds them persisted. One-time migration
+  // for operators upgrading from localStorage-only storage.
+  if (server.stepHz === null) {
+    scheduleSave();
+  }
+}
+
+void hydrateFromServer();


### PR DESCRIPTION
The tuning **step** (and Mode/Band/Step favorite pins) didn't survive a desktop restart — reset to the 500 Hz default every launch. Root cause: `toolbar-favorites-store.ts` persisted to **localStorage**, which the Photino desktop's **per-launch random loopback port** orphans (new origin → empty localStorage → defaults). Same bug #480 fixed for the panadapter dB scale.

**Fix (mirrors #480's server-side pattern):** new `ToolbarSettingsStore` (LiteDB via PrefsDbPath) + `ToolbarSettingsDto` + GET/POST `/api/toolbar-settings` + DI; frontend store drops the localStorage `persist`, hydrates from the server on load + debounced-saves on change. Store shape unchanged (no caller changes). Partial save (null = not-provided) so a step change doesn't clobber favorite pins.

Build 0 warnings; `dotnet test` green (685 incl 5 new `ToolbarSettingsPersistenceTests`); frontend clean. **Bench-confirmed on G2 desktop: set step → restart → persists.**