### PR TITLE
feat(cw): sidetone on TCI raw-key (keyer:1) path (zeus-cix)

### DIFF
--- a/Zeus.Server.Hosting/CwEngine.cs
+++ b/Zeus.Server.Hosting/CwEngine.cs
@@ -391,31 +391,43 @@ public sealed class CwEngine : BackgroundService
 
         int written = 0;
         bool releasedByCancel = false;
-        while (!totalSamples.HasValue || written < totalSamples.Value)
+        // Sidetone follows the raw key for its whole held duration. Down here,
+        // Up in the finally so a cancel / duration-expiry / error all release
+        // the monitor tone; the DSP-thread mixer runs its own 5 ms fade so the
+        // Up lands in lockstep with the carrier release tail below.
+        _sidetone?.Down();
+        try
         {
-            if (ct.IsCancellationRequested) { releasedByCancel = true; break; }
-            int n = totalSamples.HasValue
-                ? Math.Min(ChunkSamples, totalSamples.Value - written)
-                : ChunkSamples;
-            for (int i = 0; i < n; i++)
+            while (!totalSamples.HasValue || written < totalSamples.Value)
             {
-                int pos = written + i;
-                // Attack region only — once past rampSamples we plateau at 1.0
-                // until release. The release tail is rendered after this loop
-                // exits so it always sees the steady-state amplitude.
-                double env = pos < rampSamples
-                    ? 0.5 * (1.0 - Math.Cos(Math.PI * pos / rampSamples))
-                    : 1.0;
-                iq[2 * i] = (float)(env * Math.Cos(phase));
-                iq[2 * i + 1] = (float)(env * Math.Sin(phase));
-                phase += phaseStep;
-                if (phase > 2.0 * Math.PI) phase -= 2.0 * Math.PI;
+                if (ct.IsCancellationRequested) { releasedByCancel = true; break; }
+                int n = totalSamples.HasValue
+                    ? Math.Min(ChunkSamples, totalSamples.Value - written)
+                    : ChunkSamples;
+                for (int i = 0; i < n; i++)
+                {
+                    int pos = written + i;
+                    // Attack region only — once past rampSamples we plateau at 1.0
+                    // until release. The release tail is rendered after this loop
+                    // exits so it always sees the steady-state amplitude.
+                    double env = pos < rampSamples
+                        ? 0.5 * (1.0 - Math.Cos(Math.PI * pos / rampSamples))
+                        : 1.0;
+                    iq[2 * i] = (float)(env * Math.Cos(phase));
+                    iq[2 * i + 1] = (float)(env * Math.Sin(phase));
+                    phase += phaseStep;
+                    if (phase > 2.0 * Math.PI) phase -= 2.0 * Math.PI;
+                }
+                _ring.Write(new ReadOnlySpan<float>(iq, 0, 2 * n));
+                written += n;
+                int sleepMs = Math.Max(1, (n * 1000) / SampleRateHz - 1);
+                try { await Task.Delay(sleepMs, ct).ConfigureAwait(false); }
+                catch (OperationCanceledException) { releasedByCancel = true; break; }
             }
-            _ring.Write(new ReadOnlySpan<float>(iq, 0, 2 * n));
-            written += n;
-            int sleepMs = Math.Max(1, (n * 1000) / SampleRateHz - 1);
-            try { await Task.Delay(sleepMs, ct).ConfigureAwait(false); }
-            catch (OperationCanceledException) { releasedByCancel = true; break; }
+        }
+        finally
+        {
+            _sidetone?.Up();
         }
 
         // Release tail — raised-cosine fall from 1.0 to 0. Use a non-cancellable


### PR DESCRIPTION
Follow-up after #504 (zeus-j3t) and #508 (zeus-5ue) both merged. Closes the last keying path without host-side sidetone.

## Summary

`CwEngine.PlayRawKeyAsync` (the TCI `keyer:1` manual key-down path) now drives `CwSidetoneSource` — `Down()` after the MOX claim, `Up()` in a `finally` around the carrier loop so a `keyer:0`, a duration expiry, or an error all release the monitor tone. The DSP mixer's own 5 ms fade lands the release in lockstep with the carrier release tail, mirroring the already-shipped `PlayJobAsync` pattern.

Before this, sidetone covered macro / `cw_msg` (PlayJobAsync) and the hardware key (ExternalPttService); the TCI raw-key path transmitted but produced no monitor tone.

## Test plan

- [x] `dotnet build Zeus.slnx` — 0 warnings, 0 errors
- [x] `dotnet test Zeus.slnx` — CW suite green (24 CwEngine/CwSidetone cases)
- [x] Bench: `keyer:0,true;` / `keyer:0,false;` and the timed `keyer:0,true,800;` form all produce audible sidetone with a clean release; `cw.keyer.down` / `cw.mox.released reason=keyer.up|keyer.duration` confirmed in the log.

No new test: `CwSidetoneSource` is unit-tested (12 cases) and the wiring is identical to the tested `PlayJobAsync` path (integration would need full-engine scaffolding, which the codebase doesn't do for the text path either).