### PR TITLE
fix(ci): inherit secrets in nightly so macOS signing works (zeus-22l)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,5 +37,12 @@ jobs:
     with:
       mode: nightly
       ref: develop
+    # Reusable-workflow calls do NOT pass repo secrets unless the caller
+    # inherits them. release.yml's macOS signing step (gated on
+    # is-nightly=='true') reads secrets.MACOS_CERTIFICATE / _PWD /
+    # KEYCHAIN_PASSWORD and the notarization keys; without this they arrive
+    # empty and `security import` dies on the empty .p12 ("Unable to decode
+    # the provided data"). See zeus-22l.
+    secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
## Problem

The Nightly run failed at **macOS — import Developer ID certificate** ([run 26388557106, job 77673178545](https://github.com/Kb2uka/openhpsdr-zeus/actions/runs/26388557106/job/77673178545)):

```
1 certificate imported.                                        ← Apple's public intermediate (curl)
security: SecKeychainItemImport: Unable to decode the provided data.   ← the leaf .p12
##[error]Process completed with exit code 1.
```

The job env showed the signing secrets empty:

```
MACOS_CERTIFICATE:
MACOS_CERTIFICATE_PWD:
KEYCHAIN_PASSWORD:
```

## Root cause

`nightly.yml` calls `release.yml` as a reusable workflow (`uses:`) but never passed `secrets: inherit`. release.yml's macOS signing step is gated on `is-nightly == 'true'` (the `dry-run notice` step explicitly excludes nightly), so the nightly build **intentionally** does a real Developer ID sign + notarize. But a reusable-workflow call receives **no** repo secrets unless the caller inherits them — so `secrets.MACOS_CERTIFICATE` et al. arrived empty, the base64 decode produced an empty file, and `security import` of the leaf `.p12` failed.

Repo-level secrets confirmed present (`MACOS_CERTIFICATE`, `MACOS_CERTIFICATE_PWD`, `KEYCHAIN_PASSWORD`, `MACOS_SIGNING_IDENTITY`, `APPSTORE_*`). Tagged releases sign fine because they run release.yml directly and see secrets natively.

## Fix

Add `secrets: inherit` to the nightly job. One line (plus a comment). The signing path for nightly is by design, so this passes the secrets through rather than gating signing off.

## Notes

- Must land on `main` — `schedule:` only fires from the default branch, and that's where the failing run originates.
- No way to fully dry-run a reusable-workflow secret inheritance without merging; YAML validated locally (ruby `YAML.load_file`), no tabs.