### PR TITLE
fix(tx): persist mic gain + leveler max-gain across desktop restart

### DIFF
--- a/tests/Zeus.Server.Tests/MicGainPersistenceTests.cs
+++ b/tests/Zeus.Server.Tests/MicGainPersistenceTests.cs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server;
+using Xunit;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Full TX mic-gain + Leveler max-gain persistence round-trip — guards the
+/// desktop-relaunch bug where the slider reverted to 0 dB on every launch.
+///
+/// The existing <c>MicGainEndpointTests</c> assert the HTTP handler updates
+/// the live <see cref="StateDto"/>; <c>RadioStateStoreTests</c> assert the
+/// LiteDB row round-trips. Neither covered the *seam between them*: that
+/// <see cref="RadioService.SetTxMicGain"/> rides the debounce flush into the
+/// store AND that a freshly-reconstructed <see cref="RadioService"/> (the
+/// relaunch path) hydrates the operator's value back into its first
+/// <see cref="StateDto"/> rather than the 0 dB / 8 dB seeds.
+///
+/// Disposing the first RadioService forces its final flush (same hook the
+/// desktop window-close StopAsync / host-dispose drives), so this exercises
+/// exactly the save→restart→restore cycle the operator hits.
+/// </summary>
+public class MicGainPersistenceTests : IDisposable
+{
+    private readonly string _dbPath;
+
+    public MicGainPersistenceTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"zeus-prefs-micgaintest-{Guid.NewGuid():N}.db");
+    }
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+    }
+
+    private (RadioService radio, RadioStateStore store) BuildRadioWithStore()
+    {
+        var loggerFactory = NullLoggerFactory.Instance;
+        var dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance);
+        var paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, _dbPath);
+        var stateStore = new RadioStateStore(NullLogger<RadioStateStore>.Instance, _dbPath);
+        var radio = new RadioService(
+            loggerFactory, dspStore, paStore,
+            filterPresetStore: null, txIqSource: null,
+            preferredRadioStore: null, psStore: null,
+            radioStateStore: stateStore);
+        return (radio, stateStore);
+    }
+
+    [Fact]
+    public void SetTxMicGain_FlushesToStore()
+    {
+        var (radio, store) = BuildRadioWithStore();
+
+        radio.SetTxMicGain(-12);
+        // Force the debounce flush deterministically — same write the 1 s
+        // timer / Dispose hook performs, without waiting on wall-clock.
+        radio.Dispose();
+
+        var entry = store.Get();
+        Assert.NotNull(entry);
+        Assert.Equal(-12, entry!.MicGainDb);
+    }
+
+    [Fact]
+    public void SetTxLevelerMaxGain_FlushesToStore()
+    {
+        var (radio, store) = BuildRadioWithStore();
+
+        radio.SetTxLevelerMaxGain(15.0);
+        radio.Dispose();
+
+        var entry = store.Get();
+        Assert.NotNull(entry);
+        Assert.Equal(15.0, entry!.LevelerMaxGainDb);
+    }
+
+    [Fact]
+    public void MicGain_SurvivesRadioServiceReconstruction()
+    {
+        // Session 1: operator drops mic gain to -18 dB, then the app closes.
+        var (radio1, _) = BuildRadioWithStore();
+        radio1.SetTxMicGain(-18);
+        radio1.Dispose();   // final flush — mirrors desktop window-close shutdown
+
+        // Session 2: a fresh RadioService reads the same prefs DB on relaunch.
+        var (radio2, _) = BuildRadioWithStore();
+        try
+        {
+            // The very first StateDto the frontend hydrates from must already
+            // carry the operator's value, NOT the 0 dB seed.
+            Assert.Equal(-18, radio2.Snapshot().MicGainDb);
+        }
+        finally
+        {
+            radio2.Dispose();
+        }
+    }
+
+    [Fact]
+    public void LevelerMaxGain_SurvivesRadioServiceReconstruction()
+    {
+        var (radio1, _) = BuildRadioWithStore();
+        radio1.SetTxLevelerMaxGain(3.5);
+        radio1.Dispose();
+
+        var (radio2, _) = BuildRadioWithStore();
+        try
+        {
+            Assert.Equal(3.5, radio2.Snapshot().LevelerMaxGainDb);
+        }
+        finally
+        {
+            radio2.Dispose();
+        }
+    }
+
+    [Fact]
+    public void MicGainAndLeveler_PersistTogether_WithDriveAndVolume()
+    {
+        // The control fields share one radio_state row. This guards against a
+        // future Save() that drops MicGainDb while still writing DrivePct /
+        // RxAfGainDb — the exact asymmetry seen in the field (drive + leveler
+        // persisted, mic reverted to 0) would resurface as a failing assert.
+        var (radio1, _) = BuildRadioWithStore();
+        radio1.SetDrive(33);
+        radio1.SetRxAfGain(-9.0);
+        radio1.SetTxLevelerMaxGain(11.0);
+        radio1.SetTxMicGain(-7);
+        radio1.Dispose();
+
+        var (radio2, _) = BuildRadioWithStore();
+        try
+        {
+            var snap = radio2.Snapshot();
+            Assert.Equal(33, snap.DrivePct);
+            Assert.Equal(-9.0, snap.RxAfGainDb);
+            Assert.Equal(11.0, snap.LevelerMaxGainDb);
+            Assert.Equal(-7, snap.MicGainDb);
+        }
+        finally
+        {
+            radio2.Dispose();
+        }
+    }
+}

--- a/zeus-web/src/state/tx-store.ts
+++ b/zeus-web/src/state/tx-store.ts
@@ -302,7 +302,13 @@ export const useTxStore = create<TxState>()(
       setTunePercent: (p) => set({ tunePercent: p }),
       micGainDb: 0,
       setMicGainDb: (db) => set({ micGainDb: db }),
-      levelerMaxGainDb: 5,
+      // 8 dB matches the server-authoritative default everywhere else —
+      // StateDto.LevelerMaxGainDb, RadioStateStore, RadioService restore, and
+      // the client.ts parseState fallback all open at 8.0 (WdspDspEngine
+      // .DefaultLevelerMaxGainDb). The store previously defaulted to 5, so the
+      // pre-hydration paint disagreed with the value the server reports a beat
+      // later — a needless flash. Keep this in lock-step with the server seed.
+      levelerMaxGainDb: 8,
       setLevelerMaxGainDb: (db) =>
         set({ levelerMaxGainDb: Math.max(0, Math.min(15, db)) }),
       fwdWatts: 0,
@@ -422,15 +428,14 @@ export const useTxStore = create<TxState>()(
 
       hydrateFromState: (s) =>
         set({
-          // Drive sliders — server is the source of truth. Persisted via
-          // RadioStateStore and broadcast on every SetDrive/SetTuneDrive so
-          // the operator's last-set values come back on relaunch. The
-          // localStorage mirror in `partialize` below exists only to avoid
-          // a first-paint flicker before this hydrate runs.
+          // Drive / TUN drive / mic gain / Leveler max-gain — server is the
+          // sole source of truth. Persisted via RadioStateStore and broadcast
+          // on every Set* so the operator's last-set values come back on
+          // relaunch via this hydrate (connect + every state poll). These are
+          // deliberately NOT mirrored to localStorage — see the partialize note
+          // below for why a mirror is harmful on the Photino desktop.
           drivePercent: s.drivePercent,
           tunePercent: s.tunePercent,
-          // Mic gain + Leveler max-gain — server-authoritative (RadioStateStore).
-          // Previously localStorage-only and reverted on every desktop relaunch.
           micGainDb: s.micGainDb,
           levelerMaxGainDb: s.levelerMaxGainDb,
           psAuto: s.psAuto,
@@ -457,11 +462,24 @@ export const useTxStore = create<TxState>()(
       name: 'zeus-tx',
       // Persist only operator-tuning fields. Master arm bits (psEnabled,
       // twoToneOn, mox/tun) are transient per-session.
+      //
+      // Drive / TUN drive / mic gain / Leveler max-gain are deliberately NOT
+      // mirrored here. They are server-authoritative (StateDto.{DrivePct,
+      // TunePct,MicGainDb,LevelerMaxGainDb}, persisted in zeus-prefs.db) and
+      // are rehydrated by hydrateFromState on connect + every state poll. A
+      // localStorage mirror is actively harmful for them on the desktop: the
+      // Photino webview binds a fresh OS-assigned loopback port on every
+      // launch, so localStorage is a new (empty) origin each time. zustand's
+      // persist rehydrates that empty origin over the store defaults
+      // (micGainDb=0, etc.) synchronously at store-creation — before the
+      // server hydrate lands — and any read in that window (or a later store
+      // re-creation) flashes the default back. Worse, the partialize write
+      // then re-seeds the empty origin with that 0, which a connect-time
+      // re-POST used to push to the server, clobbering the persisted value.
+      // The connect-time re-POST was removed (ConnectPanel) and now the mirror
+      // is too, so the server is the single source of truth — same pattern the
+      // toolbar-favorites + display-settings stores already follow.
       partialize: (s) => ({
-        drivePercent: s.drivePercent,
-        tunePercent: s.tunePercent,
-        micGainDb: s.micGainDb,
-        levelerMaxGainDb: s.levelerMaxGainDb,
         // PS tuning is persisted server-side too, but we mirror it here so
         // the slider seeks don't flicker on first paint after a reload.
         psAuto: s.psAuto,


### PR DESCRIPTION
MIC gain (and Leveler max-gain) reverted to defaults on every desktop restart. Root cause: `tx-store.ts` mirrored the four **server-authoritative** TX fields (drive/tune/mic/leveler) into **localStorage** via zustand `partialize`; the Photino desktop binds a fresh random loopback port each launch → new empty localStorage origin → zustand re-seeds defaults over the store synchronously, before the server hydrate. Same class as the toolbar fix #515. (Backend save/restore was always correct — verified across SIGINT + SIGKILL; confirmed via the live prefs DB showing leveler/drive persisted but `MicGainDb=0`.)

**Fix:** removed drive/tune/mic/leveler from the localStorage `partialize` mirror so the server (`RadioStateStore` → StateDto → `hydrateFromState` on connect + 1 Hz poll) is the single source of truth; aligned the `levelerMaxGainDb` store default 5→8 to match every other layer (no pre-hydration flash).

Build 0 warnings; `dotnet test` green (709 incl 5 new `MicGainPersistenceTests`); frontend clean. **Bench-confirmed on G2 desktop: set MIC + LVLR → restart → both persist.**