### PR TITLE
fix(audio): keep RX output device warm through TX so un-key resumes instantly (#468)

### DIFF
--- a/Zeus.Server.Hosting/AudioResumeProbe.cs
+++ b/Zeus.Server.Hosting/AudioResumeProbe.cs
@@ -84,12 +84,25 @@ internal static class AudioResumeProbe
     }
 
     /// <summary>t4 — first non-silent samples written to the OS playback
-    /// device after un-key. Logs the probe line and disarms. Called on the
-    /// miniaudio playback worker thread; keeps work to the single log call
-    /// only when this thread wins the t4 CAS.</summary>
+    /// device after un-key that belong to FRESH post-un-key RX audio. Logs the
+    /// probe line and disarms. Called on the miniaudio playback worker thread;
+    /// keeps work to the single log call only when this thread wins the t4 CAS.
+    ///
+    /// PROVENANCE GATE (issue #468): t4 is stamped only after t3 (firstPublish)
+    /// has fired. The keep-warm feed continuously pushes silence to the ring
+    /// during TX, and the falling-edge drain can leave a residual tail of stale
+    /// pre-un-key audio. Without this gate the playback worker could stamp t4
+    /// on that stale/silence content before the fresh-audio pipeline (t1/t2/t3)
+    /// ran — the misleading "t4=0.9ms, t1..t3=n/a" reading. Requiring t3 first
+    /// guarantees t4 measures the first FRESH audible output, so t1→t4 and the
+    /// t3→t4 buffer-drain are meaningful.</summary>
     public static void MarkFirstAudibleOutput()
     {
         if (!_armed) return;
+        // Fresh RX audio must have been published before we attribute audible
+        // output to this resume. If t3 hasn't fired yet, the samples the sink
+        // sees are stale residual ring content, not the post-un-key resume.
+        if (Volatile.Read(ref _t3FirstPublish) == 0) return;
         if (Interlocked.CompareExchange(ref _t4FirstAudible, Stopwatch.GetTimestamp(), 0) != 0)
             return; // already captured this resume
 

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -266,6 +266,10 @@ public class DspPipelineService : BackgroundService,
     private readonly float[] _panBuf = new float[Width];
     private readonly float[] _wfBuf = new float[Width];
     private readonly float[] _audioBuf = new float[AudioDrainCapacity];
+    // Dedicated scratch for the timer-thread keep-warm fallback (issue #468)
+    // so it never races the RX-thread Tick over _audioBuf. Only ever touched
+    // on the ExecuteAsync PeriodicTimer thread.
+    private readonly float[] _keepWarmBuf = new float[AudioDrainCapacity];
 
     // Cached panadapter snapshot for the frequency-calibration service
     // (issue #325). Tick fills this every cycle that produced a valid
@@ -308,6 +312,36 @@ public class DspPipelineService : BackgroundService,
             _audioSinks[i].Publish(in frame);
     }
 
+    // Publish one tick's worth of silence to the RX audio sinks to keep the
+    // output device endpoint warm during TX / RX-idle periods (issue #468).
+    // Sized to 48 kHz / 30 Hz = 1600 samples (capped to the scratch buffer) so
+    // the silence-feed rate matches the device's consumption rate and the ring
+    // neither starves nor backs up over a long key-down. This is the half of
+    // the fix that #521 unblocked: with the WASAPI output buffer now ~20 ms
+    // (was the ~1.7 s shared-mode default) the feed tracks consumption and no
+    // longer accumulates a backlog the way it did on the old deep buffer.
+    // No-op when there are no sinks. internal for unit-test coverage of the
+    // keep-warm behaviour; `scratch` is the caller's reusable audio buffer
+    // (zeroed here). These frames deliberately do NOT mark the resume probe's
+    // t3 (firstPublish) — t3 is reserved for fresh post-un-key RX audio, so
+    // the keep-warm silence can't make t4 fire early (see AudioResumeProbe).
+    internal void PublishKeepWarmSilence(float[] scratch, double nowMs)
+    {
+        if (_audioSinks.Length == 0) return;
+        int keepWarm = Math.Min(AudioOutputRateHz / 30, scratch.Length);
+        if (keepWarm <= 0) return;
+        Array.Clear(scratch, 0, keepWarm);
+        var silenceFrame = new AudioFrame(
+            Seq: ++_audioSeq,
+            TsUnixMs: nowMs,
+            RxId: 0,
+            Channels: 1,
+            SampleRateHz: (uint)AudioOutputRateHz,
+            SampleCount: (ushort)keepWarm,
+            Samples: new ReadOnlyMemory<float>(scratch, 0, keepWarm));
+        PublishAudio(in silenceFrame);
+    }
+
     protected override async Task ExecuteAsync(CancellationToken ct)
     {
         OpenSynthetic();
@@ -337,7 +371,32 @@ public class DspPipelineService : BackgroundService,
                 // a double-tick and keep WDSP truly single-thread-owned on
                 // the hot path. The "no sink attached" branch keeps the
                 // synthetic-mode display alive when there's no radio.
-                if (_rxSinkAttached) continue;
+                if (_rxSinkAttached)
+                {
+                    // Keep-warm fallback (issue #468). When a sink is attached
+                    // the inline RX-thread Tick normally drives audio, so we
+                    // skip the timer-driven Tick to avoid double-ticking WDSP.
+                    // BUT on radios that STOP RX during TX (HL2 / P1 non-PS),
+                    // RX IQ — and therefore the inline Tick and its keep-warm
+                    // silence feed — stop for the whole key-down. Without a
+                    // fallback the output ring drains and the endpoint idles,
+                    // re-introducing the un-key gap on those radios (and, over
+                    // RDP Remote Audio, the ~2 s wake-from-silence that #521's
+                    // tiny output buffer alone does NOT fix). So if no inline
+                    // Tick has run for ~2 tick periods, feed keep-warm silence
+                    // from here. This touches only the sink + a dedicated
+                    // buffer (never WDSP), so it's safe off the RX thread. On
+                    // radios that keep RX flowing during TX (G2 / P2) the
+                    // inline Tick keeps _lastTickStopwatchTicks fresh and this
+                    // branch never fires — no double-feed.
+                    long now = Stopwatch.GetTimestamp();
+                    long last = _lastTickStopwatchTicks;
+                    if (last != 0 && (now - last) >= 2 * TickPeriodStopwatchTicks)
+                    {
+                        PublishKeepWarmSilence(_keepWarmBuf, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+                    }
+                    continue;
+                }
                 // Drain any cross-thread commands posted while no sink was
                 // attached (rare — most commands arrive while a radio is
                 // connected and the sink is the consumer).
@@ -1699,6 +1758,29 @@ public class DspPipelineService : BackgroundService,
                 PublishAudio(in audioFrame);
                 RxAudioAvailable?.Invoke(0, AudioOutputRateHz, new ReadOnlyMemory<float>(audioBuf, 0, audioSampleCount));
             }
+        }
+        else if (!txMonitorOn)
+        {
+            // KEEP THE OUTPUT DEVICE WARM (issue #468). When the RXA produced
+            // no audio this tick — which is exactly the case throughout TX
+            // (RXA is damped while keyed) — publish a block of SILENCE instead
+            // of publishing nothing. Without this the producer side stops
+            // feeding NativeAudioSink's ring entirely during TX; the ring runs
+            // dry and the OS output endpoint idles. Over RDP "Remote Audio"
+            // the channel then takes ~2 s to wake from silence on un-key, even
+            // though #521 already shrank the WASAPI output buffer to ~20 ms and
+            // the backend has fresh RX audio ready in ~13 ms (proven by the
+            // t1/t2/t3 resume probe) — that is the remaining TX→RX gap. Thetis
+            // avoids it by keeping its RX audio mixer fed continuously through
+            // TX; this is the Zeus equivalent. Gated to the no-TX-monitor path
+            // (the monitor path feeds the same ring from ReadTxMonitorAudio
+            // below). macOS / Linux share this path and benefit identically;
+            // CoreAudio / ALSA also prefer an unbroken stream, and a steady
+            // 48 kHz silence feed is platform-agnostic — no OS conditionals.
+            // The silence is inaudible, so RX→TX stays instant: the rising
+            // edge still drains the ring (#497) and keep-warm then holds it at
+            // silence, which is exactly what the operator should hear keyed.
+            PublishKeepWarmSilence(audioBuf, nowMs);
         }
         if (txMonitorOn)
         {

--- a/Zeus.Server.Hosting/NativeAudioSink.cs
+++ b/Zeus.Server.Hosting/NativeAudioSink.cs
@@ -307,10 +307,24 @@ internal sealed class NativeAudioSink : IRxAudioSink, IAuditionAudioSink, IHoste
         int read = _ring.Read(mono);
         if (read > 0)
         {
-            // t4 — first non-silent RX samples reach the OS playback device
-            // after un-key. The probe captures only the first occurrence per
-            // armed resume, so this is cheap on every subsequent callback.
-            AudioResumeProbe.MarkFirstAudibleOutput();
+            // t4 — first NON-SILENT RX samples reach the OS playback device
+            // after un-key. The keep-warm feed (issue #468) now keeps the ring
+            // continuously fed with SILENCE through TX, so "read > 0" alone is
+            // true on every post-un-key callback and would stamp t4 on stale
+            // or silence content before the fresh-audio stages (t1/t2/t3) ran —
+            // exactly the misleading "t4=0.9ms while t1..t3=n/a" reading. So we
+            // only mark t4 once the buffer actually carries audible (non-zero)
+            // samples. AudioResumeProbe additionally gates t4 on t3 having been
+            // published, so this measures the first FRESH post-un-key audio.
+            // The probe captures only the first occurrence per armed resume, so
+            // this scan is cheap once the line has logged.
+            bool nonZero = false;
+            for (int i = 0; i < read; i++)
+            {
+                if (mono[i] != 0f) { nonZero = true; break; }
+            }
+            if (nonZero)
+                AudioResumeProbe.MarkFirstAudibleOutput();
         }
         if (read < totalFrames)
         {

--- a/tests/Zeus.Server.Tests/AudioResumeProbeTests.cs
+++ b/tests/Zeus.Server.Tests/AudioResumeProbeTests.cs
@@ -119,19 +119,53 @@ public class AudioResumeProbeTests
 
         // Operator double-taps the key: arm, partial progress, then arm again
         // before audible output. The second arm clears t1–t4 so the measured
-        // window reflects the second resume only.
+        // window reflects the second resume only. After the re-arm only t3 is
+        // re-marked (the provenance gate requires a fresh publish before t4),
+        // so t1/t2 read n/a but t3/t4 reflect the second resume.
         AudioResumeProbe.ArmUnkey(log);
         AudioResumeProbe.MarkFirstIq();
         AudioResumeProbe.MarkFirstReadAudio();
 
         AudioResumeProbe.ArmUnkey(log);   // re-arm
+        AudioResumeProbe.MarkFirstPublish();          // fresh t3 for the 2nd resume
         AudioResumeProbe.MarkFirstAudibleOutput();
 
         var lines = log.Messages.ToArray();
         Assert.Single(lines);
-        // After re-arm, t1/t2/t3 were never re-marked, so they read n/a.
+        // After re-arm, t1/t2 were never re-marked, so they read n/a.
         Assert.Contains("t1=n/a", lines[0]);
         Assert.Contains("t2=n/a", lines[0]);
-        Assert.Contains("t3=n/a", lines[0]);
+        // t3 fired after the re-arm, so it is NOT n/a.
+        Assert.DoesNotContain("t3=n/a", lines[0]);
+    }
+
+    [Fact]
+    public void AudibleOutput_BeforePublish_DoesNotLog()
+    {
+        var log = new CapturingLogger();
+
+        // The provenance gate (issue #468): the keep-warm silence feed keeps
+        // the output ring fed during TX, and the falling-edge drain can leave a
+        // stale residual tail. If audible output is reported before t3 (fresh
+        // publish) has fired, that output is NOT the post-un-key resume — t4
+        // must not stamp and the line must not log yet.
+        AudioResumeProbe.ArmUnkey(log);
+        AudioResumeProbe.MarkFirstIq();
+        AudioResumeProbe.MarkFirstReadAudio();
+        // (no MarkFirstPublish — t3 has not fired)
+        AudioResumeProbe.MarkFirstAudibleOutput();   // stale/residual output
+
+        Assert.Empty(log.Messages);
+
+        // Once fresh audio is actually published, the NEXT audible output is
+        // the real resume and the line logs with a meaningful t4.
+        AudioResumeProbe.MarkFirstPublish();
+        AudioResumeProbe.MarkFirstAudibleOutput();
+
+        var lines = log.Messages.ToArray();
+        Assert.Single(lines);
+        Assert.DoesNotContain("t3=n/a", lines[0]);
+        Assert.Contains("t4=", lines[0]);
+        Assert.DoesNotContain("t4=n/a", lines[0]);
     }
 }

--- a/tests/Zeus.Server.Tests/RxAudioKeepWarmTests.cs
+++ b/tests/Zeus.Server.Tests/RxAudioKeepWarmTests.cs
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Regression tests for the TX→RX RX-audio resume fix (issue #468, revived on
+// top of the #521 WASAPI low-latency fix).
+//
+// Root cause: during TX the WDSP RXA is damped, so DspPipelineService.Tick
+// read 0 audio samples and published NOTHING. The producer side stopped
+// feeding NativeAudioSink's ring entirely for the whole key-down; the ring
+// ran dry and the OS output endpoint idled. On un-key the backend had fresh
+// RX audio in ~13 ms (proven by the rx.resume.probe t1/t2/t3 timings) but the
+// starved output endpoint — especially an RDP "Remote Audio" channel — took
+// ~2 s to wake from silence, which is the whole perceived gap. #521 shrank the
+// WASAPI output buffer to ~20 ms but did NOT fix the wake-from-silence.
+//
+// Fix: DspPipelineService.PublishKeepWarmSilence feeds one tick's worth of
+// silence to the RX sinks whenever the RX channel produced no audio (and TX
+// monitor is off), so the ring stays non-empty and the endpoint never idles —
+// mirroring Thetis keeping its RX audio mixer fed continuously through TX. The
+// feed rate matches device consumption so on #521's tiny buffer it tracks the
+// drain and does not accumulate a backlog.
+//
+// These tests pin the keep-warm behaviour against a real NativeAudioSink so a
+// future change that stops feeding the ring during TX fails here. They also
+// pin the "both edges" contract: the rising edge (RX→TX) still drains the ring
+// to instant silence, and throughout TX the keep-warm feed keeps it warm.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class RxAudioKeepWarmTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-keepwarm-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+        try { if (File.Exists(_dbPath + ".pa")) File.Delete(_dbPath + ".pa"); } catch { }
+    }
+
+    private DspPipelineService BuildPipeline(params IRxAudioSink[] sinks)
+    {
+        var loggerFactory = NullLoggerFactory.Instance;
+        var dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance, _dbPath);
+        var paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, _dbPath + ".pa");
+        var radio = new RadioService(loggerFactory, dspStore, paStore);
+        var hub = new StreamingHub(new NullLogger<StreamingHub>());
+        return new DspPipelineService(radio, hub, sinks, loggerFactory);
+    }
+
+    // Minimal sink that records the total samples published — lets us assert
+    // the keep-warm feed actually reached the sink without standing up a real
+    // miniaudio device. Captures the last block so we can confirm it's silence.
+    private sealed class CountingSink : IRxAudioSink
+    {
+        public long TotalSamples;
+        public int Frames;
+        public float MaxAbsLastFrame;
+        public void Publish(in AudioFrame frame)
+        {
+            TotalSamples += frame.SampleCount;
+            Frames++;
+            float max = 0f;
+            var span = frame.Samples.Span;
+            for (int i = 0; i < span.Length; i++)
+            {
+                float a = Math.Abs(span[i]);
+                if (a > max) max = a;
+            }
+            MaxAbsLastFrame = max;
+        }
+    }
+
+    [Fact]
+    public void PublishKeepWarmSilence_FeedsOneTickOfSilence_ToSink()
+    {
+        var sink = new CountingSink();
+        var pipeline = BuildPipeline(sink);
+        var scratch = new float[2048];
+        // Pre-fill with a non-zero pattern so we can confirm the published
+        // block is actually silence (zeroed), not stale audio.
+        for (int i = 0; i < scratch.Length; i++) scratch[i] = 0.5f;
+
+        pipeline.PublishKeepWarmSilence(scratch, nowMs: 0);
+
+        // 48 kHz / 30 Hz = 1600 samples per tick — matches device consumption.
+        Assert.Equal(1, sink.Frames);
+        Assert.Equal(1600, sink.TotalSamples);
+        // The published block must be silence (all samples zeroed before send).
+        Assert.Equal(0f, sink.MaxAbsLastFrame);
+        // ...and the first 1600 scratch samples must have been zeroed in place.
+        for (int i = 0; i < 1600; i++)
+            Assert.Equal(0f, scratch[i]);
+    }
+
+    [Fact]
+    public void PublishKeepWarmSilence_KeepsNativeSinkRingWarm()
+    {
+        // The load-bearing invariant: feeding keep-warm silence leaves the
+        // NativeAudioSink ring NON-EMPTY, so the miniaudio playback callback
+        // reads real data instead of underrunning the device into an idle
+        // state. This is the consumer-side guarantee the resume fix depends on.
+        var sink = new NativeAudioSink(NullLogger<NativeAudioSink>.Instance);
+        var pipeline = BuildPipeline(sink);
+        var scratch = new float[2048];
+
+        Assert.Equal(0, sink.CurrentRingDepth);   // starts dry
+
+        pipeline.PublishKeepWarmSilence(scratch, nowMs: 0);
+
+        // Ring now holds the silence block — the device will not starve.
+        Assert.Equal(1600, sink.CurrentRingDepth);
+    }
+
+    [Fact]
+    public void PublishKeepWarmSilence_NoSinks_IsNoOp()
+    {
+        // With no audio sinks (web mode), keep-warm must be a cheap no-op —
+        // no allocation churn, no throw.
+        var pipeline = BuildPipeline(); // no sinks
+        var scratch = new float[2048];
+        var ex = Record.Exception(() => pipeline.PublishKeepWarmSilence(scratch, nowMs: 0));
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void PublishKeepWarmSilence_RepeatedFeeds_AccumulateInRing()
+    {
+        // Repeated ticks (a sustained key-down) keep topping the ring up so it
+        // never drains — the steady-state behaviour during a long TX.
+        var sink = new NativeAudioSink(NullLogger<NativeAudioSink>.Instance);
+        var pipeline = BuildPipeline(sink);
+        var scratch = new float[2048];
+
+        pipeline.PublishKeepWarmSilence(scratch, nowMs: 0);
+        pipeline.PublishKeepWarmSilence(scratch, nowMs: 33);
+        pipeline.PublishKeepWarmSilence(scratch, nowMs: 66);
+
+        // Three ticks × 1600 = 4800 samples, all still queued (well under the
+        // 65 536 ring capacity, nothing consuming in the test).
+        Assert.Equal(4800, sink.CurrentRingDepth);
+    }
+
+    [Fact]
+    public void BothEdges_RisingDrains_ThenKeepWarmRefillsThroughTx()
+    {
+        // The "both edges" contract for the resume fix:
+        //   1. RISING edge (RX→TX): OnTxActiveChanged(true) drains the ring so
+        //      the operator hears instant silence (RX→TX stays instant).
+        //   2. THROUGHOUT TX: keep-warm silence refills the ring every tick so
+        //      the output endpoint never idles and the un-key wake-from-silence
+        //      gap is gone.
+        var sink = new NativeAudioSink(NullLogger<NativeAudioSink>.Instance);
+        var pipeline = BuildPipeline(sink);
+        var scratch = new float[2048];
+
+        // Pre-TX: some band RX audio queued in the ring.
+        var rx = new float[1600];
+        for (int i = 0; i < rx.Length; i++) rx[i] = 0.25f;
+        sink.Publish(new AudioFrame(
+            Seq: 1, TsUnixMs: 0, RxId: 0, Channels: 1,
+            SampleRateHz: 48_000, SampleCount: (ushort)rx.Length,
+            Samples: rx));
+        Assert.True(sink.CurrentRingDepth > 0);
+
+        // Rising edge: ring drains to instant silence (RX→TX instant).
+        sink.OnTxActiveChanged(true);
+        Assert.Equal(0, sink.CurrentRingDepth);
+
+        // Throughout TX (RXA damped → no RX audio): keep-warm feeds silence
+        // every tick, so the ring stays non-empty and the endpoint stays warm.
+        pipeline.PublishKeepWarmSilence(scratch, nowMs: 33);
+        pipeline.PublishKeepWarmSilence(scratch, nowMs: 66);
+        Assert.Equal(3200, sink.CurrentRingDepth);
+    }
+}
+
+// Regression tests for the resume-probe provenance gate (issue #468). The
+// probe must NOT stamp t4 on stale/keep-warm content before fresh RX audio
+// has been published (t3) — otherwise it logs a misleading "t4=0.9ms while
+// t1..t3=n/a" line and the real fresh-RX resume timing is lost. These live
+// in the AudioResumeProbe collection so they serialise against the shared
+// process-wide probe state.
+[Collection("AudioResumeProbe")]
+public class RxResumeProbeProvenanceTests
+{
+    public RxResumeProbeProvenanceTests() => AudioResumeProbe.ResetForTest();
+
+    private sealed class CapturingLogger : Microsoft.Extensions.Logging.ILogger
+    {
+        public System.Collections.Concurrent.ConcurrentQueue<string> Messages { get; } = new();
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) => true;
+        public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel,
+            Microsoft.Extensions.Logging.EventId eventId, TState state,
+            Exception? exception, Func<TState, Exception?, string> formatter)
+            => Messages.Enqueue(formatter(state, exception));
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+
+    [Fact]
+    public void KeepWarmSilenceBeforePublish_DoesNotStampT4()
+    {
+        // Models the exact failure: after un-key, the keep-warm feed keeps the
+        // ring fed and the playback worker reports audible output BEFORE the
+        // fresh-audio pipeline has published (t3). t4 must not stamp; no line.
+        var log = new CapturingLogger();
+        AudioResumeProbe.ArmUnkey(log);
+        AudioResumeProbe.MarkFirstIq();           // t1
+        AudioResumeProbe.MarkFirstReadAudio();    // t2
+        // (no t3 yet — only stale/keep-warm content has reached the device)
+        AudioResumeProbe.MarkFirstAudibleOutput();
+
+        Assert.Empty(log.Messages);
+
+        // Now fresh RX audio is published and the next audible output is real.
+        AudioResumeProbe.MarkFirstPublish();      // t3
+        AudioResumeProbe.MarkFirstAudibleOutput();
+
+        var lines = log.Messages.ToArray();
+        Assert.Single(lines);
+        // Every reachable stage fired, so the line carries meaningful timings.
+        Assert.DoesNotContain("t1=n/a", lines[0]);
+        Assert.DoesNotContain("t2=n/a", lines[0]);
+        Assert.DoesNotContain("t3=n/a", lines[0]);
+        Assert.DoesNotContain("t4=n/a", lines[0]);
+        Assert.Contains("buffer-drain=", lines[0]);
+    }
+}


### PR DESCRIPTION
## What this fixes

A real Windows-VM test of the #521 WASAPI low-latency fix confirmed the fix engaged — the output buffer is now ~20 ms:

```
audio.native.rx open backend=WASAPI bufFrames=485 periods=2 bufferMs=20.2
```

(was the ~1.7 s WASAPI shared-mode default). **But the operator on RDP "Remote Audio" STILL perceived ~2 s of TX→RX lag**, while **Thetis is instant on that exact same device**.

## Diagnosis

With the buffer now tiny *and* Thetis instant on the identical Remote Audio endpoint, the remaining cause is **stream continuity**. During TX the WDSP RXA is damped → `DspPipelineService.Tick` reads 0 audio samples → it publishes **nothing** → `NativeAudioSink`'s RX ring drains → the WASAPI/RDP output stream goes idle. The **RDP Remote Audio channel takes ~2 s to wake from silence** on un-key. Thetis keeps its output stream continuously fed (silence during TX) so its endpoint never idles — that is the whole Zeus-vs-Thetis delta on this setup.

## The fix

### Task 1 (primary) — keep-warm silence during TX (revives #506, now viable on #521's tiny buffer)

`Zeus.Server.Hosting/DspPipelineService.cs`
- **`PublishKeepWarmSilence()`** publishes one tick's worth (48 kHz / 30 Hz = 1600 samples) of SILENCE to the RX sinks. The feed rate matches device consumption, so the ring neither starves nor backs up over a long key-down. This is what #521 unblocked — on the old ~1.7 s buffer the silence accumulated a backlog (why #506 failed); on the ~20 ms buffer it tracks the drain.
- **Inline `Tick`:** when the RXA produced no audio AND TX monitor is off (i.e. throughout TX), publish keep-warm silence instead of nothing.
- **Timer-thread fallback** for radios that STOP RX during TX (HL2 / P1 non-PS): if no inline Tick has run for ~2 tick periods, feed keep-warm silence from the `PeriodicTimer` thread (touches only the sink + a dedicated buffer, never WDSP). Covers **BOTH P1 (HL2) and P2 (G2)** on the shared output path. On G2 / P2 (RX flows through TX) the inline Tick stays fresh and this never fires — no double-feed.

Gated so **no band RX audio is audible during TX** (the silence is inaudible) and **RX→TX stays instant** — the rising edge still drains the ring (#497) and keep-warm then holds it at silence. **No OS conditionals**; a steady 48 kHz silence feed is platform-agnostic (CoreAudio / ALSA prefer an unbroken stream too). **No regression to #521** — the output buffer stays ~20 ms.

### Task 2 (secondary) — trustworthy resume probe

The probe's `t4` (first audible output) fired on **stale ring content** before `t1`/`t2`/`t3` ran, producing the misleading `t0=0 t1=n/a t2=n/a t3=n/a t4=0.9ms` line — the real fresh-RX timing was never captured. With keep-warm silence now feeding the ring continuously, `read > 0` is true on every callback, so the old `t4` would fire on silence immediately. Fixed both ends:
- `Zeus.Server.Hosting/NativeAudioSink.cs` — only report audible output when the read buffer carries a **non-zero** sample (keep-warm silence / a drained ring no longer trip `t4`).
- `Zeus.Server.Hosting/AudioResumeProbe.cs` — **gate `t4` on `t3` (firstPublish) having fired**, so `t4` measures the first FRESH post-un-key RX audio. `t1→t4` and the `t3→t4` buffer-drain are now meaningful; truly-skipped stages still render `n/a`.

## Tests

- `RxAudioKeepWarmTests` — keep-warm feed against a real `NativeAudioSink` (one tick = 1600 silent samples; ring stays warm; no-sink no-op; repeated feeds accumulate) **plus a both-edges test** (rising edge drains to instant silence, keep-warm refills through TX).
- `RxResumeProbeProvenanceTests` + updated `AudioResumeProbeTests` — pin the `t4`-after-`t3` provenance gate (no stamp on stale/keep-warm content before fresh publish).

## Gates

- `dotnet build Zeus.slnx -warnaserror` → **0 warnings**.
- `dotnet test Zeus.slnx` → **green** across all 7 assemblies.
- macOS dylib rebuilt via `native/build.sh Release miniaudio` — **byte-identical** (this is a C#-only change; the miniaudio C source is untouched), so there's nothing to commit there.
- **Windows / Linux native libs must be regenerated via the "Build Native Libraries" workflow** (coordinator triggers it) — though this change does not touch native code, so they are also expected to be unchanged.
- Frontend untouched.

Refs #468, #506, #509, #521, #497.

> [!NOTE]
> Do **not** merge — coordinator merges. Base is `experimental`.