### PR TITLE
fix(cw): hardware-key sidetone follows cw_key_status not ptt_resp (zeus-cl2)

### DIFF
--- a/Zeus.Protocol1/IProtocol1Client.cs
+++ b/Zeus.Protocol1/IProtocol1Client.cs
@@ -146,6 +146,18 @@ public interface IProtocol1Client : IDisposable
     bool HardwarePtt { get; }
 
     /// <summary>
+    /// Edge-triggered CW key-down from the gateware's shaped keyer output
+    /// (C0[2] / cw_key_status) — toggles per dit/dah, distinct from the
+    /// held <see cref="HardwarePttChanged"/> (C0[0] / ptt_resp). Drives the
+    /// local CW sidetone. Fires on the RX thread; handlers must not block.
+    /// (zeus-cl2)
+    /// </summary>
+    event Action<bool>? CwKeyDownChanged;
+
+    /// <summary>Latest CW key-down level (C0[2]). Volatile; any thread.</summary>
+    bool CwKeyDown { get; }
+
+    /// <summary>
     /// Select the radio's wire-level board family. Affects the extended
     /// attenuator byte layout (HL2 vs bare HPSDR) and the N2ADR filter-board
     /// OC pin encoding. Defaults to <see cref="HpsdrBoardKind.HermesLite2"/>.

--- a/Zeus.Protocol1/PacketParser.cs
+++ b/Zeus.Protocol1/PacketParser.cs
@@ -120,6 +120,25 @@ internal static class PacketParser
     }
 
     /// <summary>
+    /// Extract the CW key-down state from a parsed EP6 packet — C0[2] of each
+    /// USB frame OR'd together. This is the gateware's *shaped keyer output*
+    /// (HL2 response slot: <c>{3'b000, resp_addr[1:0], cw_key_status, 1'b0,
+    /// ptt_resp}</c>, so <c>cw_key_status = C0[2]</c>), which toggles per
+    /// dit/dah — NOT the level-held <c>ptt_resp</c> at C0[0] that
+    /// <see cref="ExtractHardwarePtt"/> reads. Used to drive the local CW
+    /// sidetone so it follows individual elements instead of staying on for
+    /// the whole keyed period + hang time. HL2 protocol doc: "C0[2] follows
+    /// the signal at the tip, and a shaped CW signal is generated." (zeus-cl2)
+    /// </summary>
+    public static bool ExtractCwKeyDown(ReadOnlySpan<byte> packet)
+    {
+        if (packet.Length < PacketLength) return false;
+        byte c0Frame0 = packet[MetisHeaderLength + 3];
+        byte c0Frame1 = packet[MetisHeaderLength + UsbFrameLength + 3];
+        return ((c0Frame0 | c0Frame1) & 0x04) != 0;
+    }
+
+    /// <summary>
     /// Read a 24-bit big-endian signed integer with sign-extension to int32.
     /// </summary>
     public static int ReadInt24BigEndian(ReadOnlySpan<byte> b)

--- a/Zeus.Protocol1/Protocol1Client.cs
+++ b/Zeus.Protocol1/Protocol1Client.cs
@@ -151,11 +151,18 @@ public sealed class Protocol1Client : IProtocol1Client
     public event Action<TelemetryReading>? TelemetryReceived;
     public event Action<AdcOverloadStatus>? AdcOverloadObserved;
     public event Action<bool>? HardwarePttChanged;
+    /// <summary>Fires on the edge of the gateware's shaped CW keyer output
+    /// (C0[2] / cw_key_status), i.e. per dit/dah — distinct from
+    /// <see cref="HardwarePttChanged"/> (C0[0] / ptt_resp), which is held for
+    /// the whole keyed period. Drives the local sidetone. (zeus-cl2)</summary>
+    public event Action<bool>? CwKeyDownChanged;
 
     // 0/1; Volatile so the property read on any thread sees the latest value
     // without needing a lock.
     private int _hardwarePtt;
     public bool HardwarePtt => Volatile.Read(ref _hardwarePtt) != 0;
+    private int _cwKeyDown;
+    public bool CwKeyDown => Volatile.Read(ref _cwKeyDown) != 0;
 
     /// <summary>
     /// Update the cached hardware-PTT level from a freshly-parsed packet and
@@ -171,6 +178,21 @@ public sealed class Protocol1Client : IProtocol1Client
         Volatile.Write(ref _hardwarePtt, next);
         try { HardwarePttChanged?.Invoke(ptt); }
         catch (Exception ex) { _log.LogWarning(ex, "HardwarePttChanged handler threw"); }
+    }
+
+    /// <summary>
+    /// Update the cached CW key-down level (C0[2] / cw_key_status) and fire
+    /// <see cref="CwKeyDownChanged"/> on the edge. Single-writer (RX loop),
+    /// same contract as <see cref="UpdateHardwarePtt"/>. (zeus-cl2)
+    /// </summary>
+    private void UpdateCwKeyDown(bool down)
+    {
+        int prev = Volatile.Read(ref _cwKeyDown);
+        int next = down ? 1 : 0;
+        if (prev == next) return;
+        Volatile.Write(ref _cwKeyDown, next);
+        try { CwKeyDownChanged?.Invoke(down); }
+        catch (Exception ex) { _log.LogWarning(ex, "CwKeyDownChanged handler threw"); }
     }
 
     // ---- PureSignal feedback (HL2-only, P1) -------------------------
@@ -296,6 +318,7 @@ public sealed class Protocol1Client : IProtocol1Client
             // Mirror the standard-path hardware-PTT level update so an
             // external key released during PS+TX still propagates the edge.
             UpdateHardwarePtt(PacketParser.ExtractHardwarePtt(packet));
+            UpdateCwKeyDown(PacketParser.ExtractCwKeyDown(packet));
 
             // DDC0 → IqFrame channel — keeps panadapter / audio alive during PS+TX.
             // Use a fresh rented buffer the channel can own; the ddc0 rental is
@@ -793,6 +816,9 @@ public sealed class Protocol1Client : IProtocol1Client
                 // ExternalPttService can lift the host MOX when the operator
                 // keys the rear KEY jack or an external PTT line.
                 UpdateHardwarePtt(PacketParser.ExtractHardwarePtt(buffer.AsSpan(0, n)));
+                // CW key-down (C0[2], shaped keyer output) — drives the local
+                // sidetone per dit/dah, separate from the held PTT. (zeus-cl2)
+                UpdateCwKeyDown(PacketParser.ExtractCwKeyDown(buffer.AsSpan(0, n)));
 
                 var rateHz = (HpsdrSampleRate)Volatile.Read(ref _rate) switch
                 {

--- a/Zeus.Server.Hosting/ExternalPttService.cs
+++ b/Zeus.Server.Hosting/ExternalPttService.cs
@@ -89,7 +89,11 @@ public sealed class ExternalPttService : IHostedService, IDisposable
         _tx.TxActiveChanged -= OnTxActiveChanged;
         IProtocol1Client? client;
         lock (_sync) { client = _client; _client = null; _owned = false; }
-        if (client is not null) client.HardwarePttChanged -= OnHardwarePttChanged;
+        if (client is not null)
+        {
+            client.HardwarePttChanged -= OnHardwarePttChanged;
+            client.CwKeyDownChanged -= OnCwKeyDownChanged;
+        }
         _hangTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
         return Task.CompletedTask;
     }
@@ -103,29 +107,37 @@ public sealed class ExternalPttService : IHostedService, IDisposable
     {
         lock (_sync) { _client = client; _owned = false; }
         client.HardwarePttChanged += OnHardwarePttChanged;
+        client.CwKeyDownChanged += OnCwKeyDownChanged;
     }
 
     private void OnDisconnected()
     {
         IProtocol1Client? client;
         lock (_sync) { client = _client; _client = null; _owned = false; }
-        if (client is not null) client.HardwarePttChanged -= OnHardwarePttChanged;
+        if (client is not null)
+        {
+            client.HardwarePttChanged -= OnHardwarePttChanged;
+            client.CwKeyDownChanged -= OnCwKeyDownChanged;
+        }
         _hangTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+    }
+
+    // Sidetone follows the gateware's shaped keyer output (C0[2] /
+    // cw_key_status), which toggles per dit/dah — NOT the held PTT (C0[0] /
+    // ptt_resp) that drives MOX below. Reading PTT here would leave the tone
+    // on for the whole keyed period including inter-element gaps + hang time.
+    // Gated to CW modes so an SSB mic-PTT press doesn't inject a 600 Hz tone.
+    // (zeus-cl2)
+    private void OnCwKeyDownChanged(bool down)
+    {
+        if (_sidetone is null) return;
+        if (!IsCwMode(_radio.Snapshot().Mode)) return;
+        if (down) _sidetone.Down();
+        else _sidetone.Up();
     }
 
     private void OnHardwarePttChanged(bool on)
     {
-        // Sidetone tracks the hardware key directly, NOT the hang-held MOX
-        // state — the operator wants to hear their actual keying rhythm
-        // (including the brief inter-character spaces that the hang timer
-        // smooths over for the radio's TX). Only fire in CW modes; an SSB
-        // operator pressing mic PTT would otherwise hear a 600 Hz monitor
-        // tone competing with their voice.
-        if (_sidetone is not null && IsCwMode(_radio.Snapshot().Mode))
-        {
-            if (on) _sidetone.Down();
-            else _sidetone.Up();
-        }
         if (on) HandleRising();
         else HandleFalling();
     }

--- a/tests/Zeus.Protocol1.Tests/PacketParserTests.cs
+++ b/tests/Zeus.Protocol1.Tests/PacketParserTests.cs
@@ -423,4 +423,56 @@ public class PacketParserTests
         // Defensive guard for callers that don't pre-validate length.
         Assert.False(PacketParser.ExtractHardwarePtt(new byte[10]));
     }
+
+    // ---- ExtractCwKeyDown (zeus-cl2) ----------------------------------------
+    // C0[2] = cw_key_status, the gateware's shaped keyer OUTPUT (per dit/dah),
+    // distinct from C0[0] = ptt_resp (held for the whole keyed period). The
+    // sidetone follows C0[2]; MOX follows C0[0].
+
+    [Fact]
+    public void ExtractCwKeyDown_BothFramesClear_ReturnsFalse()
+    {
+        byte[] packet = FramingTests.BuildValidPacket(1, new (int, int)[PacketParser.ComplexSamplesPerPacket]);
+        Assert.False(PacketParser.ExtractCwKeyDown(packet));
+    }
+
+    [Fact]
+    public void ExtractCwKeyDown_FirstFrameC0Bit2_ReturnsTrue()
+    {
+        byte[] packet = FramingTests.BuildValidPacket(1, new (int, int)[PacketParser.ComplexSamplesPerPacket]);
+        packet[8 + 3] |= 0x04;
+        Assert.True(PacketParser.ExtractCwKeyDown(packet));
+    }
+
+    [Fact]
+    public void ExtractCwKeyDown_SecondFrameC0Bit2_ReturnsTrue()
+    {
+        byte[] packet = FramingTests.BuildValidPacket(1, new (int, int)[PacketParser.ComplexSamplesPerPacket]);
+        packet[8 + 512 + 3] |= 0x04;
+        Assert.True(PacketParser.ExtractCwKeyDown(packet));
+    }
+
+    [Fact]
+    public void ExtractCwKeyDown_IsIndependentOfPttBit()
+    {
+        // The whole point of the fix: PTT (C0[0]) and cw_key_status (C0[2])
+        // are separate. A held PTT with the keyer momentarily up (between
+        // dits) must read key-DOWN false even though PTT is true.
+        byte[] packet = FramingTests.BuildValidPacket(1, new (int, int)[PacketParser.ComplexSamplesPerPacket]);
+        packet[8 + 3] |= 0x01;          // ptt_resp set
+        Assert.False(PacketParser.ExtractCwKeyDown(packet));   // but key is up
+        Assert.True(PacketParser.ExtractHardwarePtt(packet));  // ptt still seen
+
+        // And the reverse: keyer down but PTT bit clear reads key-down true.
+        byte[] keyOnly = FramingTests.BuildValidPacket(1, new (int, int)[PacketParser.ComplexSamplesPerPacket]);
+        keyOnly[8 + 3] |= 0x04;         // cw_key_status set, ptt clear
+        Assert.True(PacketParser.ExtractCwKeyDown(keyOnly));
+        Assert.False(PacketParser.ExtractHardwarePtt(keyOnly));
+    }
+
+    [Fact]
+    public void ExtractCwKeyDown_ShortPacket_ReturnsFalse()
+    {
+        Assert.False(PacketParser.ExtractCwKeyDown(new byte[10]));
+    }
 }


### PR DESCRIPTION
## Problem

Keying the HL2 with a paddle, the local CW sidetone stayed **continuously on** instead of following the individual dits/dahs.

## Root cause

The sidetone was driven off **C0[0] = ptt_resp** (`cw_on | ext_ptt`), which the gateware holds HIGH for the whole keyed period — inter-element gaps and CW hang time included. The gateware emits the *shaped keyer output* separately at **C0[2] = cw_key_status** (HL2 response slot `{3'b000, resp_addr[1:0], cw_key_status, 1'b0, ptt_resp}`), which toggles per element. Confirmed with the HL2 gateware author; the upstream protocol doc already notes "C0[2] follows the signal at the tip, and a shaped CW signal is generated."

## Fix

- `PacketParser.ExtractCwKeyDown` reads **C0[2]** (`& 0x04`), OR'd across both USB frames.
- `Protocol1Client` gains a `CwKeyDownChanged` edge event alongside `HardwarePttChanged`.
- `ExternalPttService` drives the **sidetone** from `CwKeyDownChanged` (C0[2]); **MOX takeover** stays on `HardwarePttChanged` (C0[0]) — MOX must remain held through inter-element gaps + hang time, the sidetone must not.

Packet-rate sampling (~2.6 ms at 48k) is ample for 20-40 WPM dit envelopes; `CwSidetoneSource`'s own 5 ms raised-cosine smooths edges.

## Test plan

- [x] `dotnet build Zeus.slnx` — 0/0
- [x] `dotnet test Zeus.slnx` — Protocol1 + Server suites green; 5 new `ExtractCwKeyDown` tests incl. the PTT-vs-key independence case
- [x] Bench (HL2 + paddle, CWU/CWL): sidetone follows individual dits/dahs; MOX held across gaps + hang time

Follow-up to zeus-5ue. Independent of #517 (no UI/CSS).