### PR TITLE
fix(ci): inherit secrets in nightly so macOS signing works (zeus-22l)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,5 +37,12 @@ jobs:
     with:
       mode: nightly
       ref: develop
+    # Reusable-workflow calls do NOT pass repo secrets unless the caller
+    # inherits them. release.yml's macOS signing step (gated on
+    # is-nightly=='true') reads secrets.MACOS_CERTIFICATE / _PWD /
+    # KEYCHAIN_PASSWORD and the notarization keys; without this they arrive
+    # empty and `security import` dies on the empty .p12 ("Unable to decode
+    # the provided data"). See zeus-22l.
+    secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
Backport of #519 (originally merged to `main`) onto `develop`.

The reusable-workflow call in `nightly.yml` did not pass repo secrets, so release.yml's macOS signing step (gated on `is-nightly=='true'`) read empty `MACOS_CERTIFICATE` / `_PWD` / `KEYCHAIN_PASSWORD` + notarization keys and `security import` died on the empty `.p12` ("Unable to decode the provided data").

Adds `secrets: inherit` to the nightly caller.

`develop` builds nightly from itself (`ref: develop`), so it needs the same fix `main` already has. Content is identical to `main`'s 7-line hunk, so a future develop↔main reconcile resolves cleanly.

See zeus-22l.