### PR TITLE
fix(p2-tx): hard-gate TX-IQ shut on un-key (+ fix false un-key arming)

### DIFF
--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -240,6 +240,12 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     private int _postUnkeySends;    // TX-IQ packets sent to the radio since un-key
     private double _postUnkeySendLogMs;     // last rate-limited sender log (ms since un-key)
     private double _postUnkeyProducerLogMs; // last rate-limited producer log (ms since un-key)
+    // Closed on a true un-key, reopened on the next key-down. While closed,
+    // SendTxIq drops blocks so no TX-IQ trickles to the radio after release —
+    // the radio can keep T/R engaged while it's still receiving TX-IQ, and the
+    // mic-buffer drain / TUN-driver tick can otherwise dribble IQ for ~1s
+    // past un-key. pihpsdr likewise sends no TX-IQ when not transmitting.
+    private volatile bool _txIqGateClosed;
 
     // ---- PureSignal feedback (DDC0 + DDC1 paired on UDP 1035) ----
     // PS feedback decoder: when armed, packets on port 1035 carry interleaved
@@ -642,7 +648,8 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // clock mid-transmit.
     private void BeginTxIqMeasure()
     {
-        // New key-down: stop watching the previous un-key tail.
+        // New key-down: open the TX-IQ gate and stop watching the previous tail.
+        _txIqGateClosed = false;
         Interlocked.Exchange(ref _unkeyTicks, 0);
         if (Interlocked.Read(ref _txIqStartTicks) != 0) return;
         Interlocked.Exchange(ref _txIqSentSamples, 0);
@@ -715,9 +722,14 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
             if (ms <= 3000.0 && ms >= _postUnkeyProducerLogMs + 100.0)
             {
                 _postUnkeyProducerLogMs = ms;
-                _log.LogInformation("p2.unkey.producer +{Ms:F0}ms still PRODUCING TX-IQ after un-key ({N} samples this block)", ms, iqInterleaved.Length / 2);
+                _log.LogInformation("p2.unkey.producer +{Ms:F0}ms upstream still calling SendTxIq after un-key — DROPPED by gate ({N} samples)", ms, iqInterleaved.Length / 2);
             }
         }
+
+        // Gate closed by a true un-key: drop any straggler IQ (mic-buffer
+        // drain, late TUN-driver tick) so the radio stops receiving TX-IQ the
+        // instant the operator releases, instead of up to ~1s later.
+        if (_txIqGateClosed) return;
 
         lock (_txIqGate)
         {
@@ -745,6 +757,17 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         // the previous transmission's IQ when PTT re-engages.
         int flushed = 0;
         while (_txIqQueue.Reader.TryRead(out _)) { flushed++; }
+
+        // ResetTxIq also fires on redundant SetTune(false)/SetMox(false) calls
+        // that happen WHILE the other path is keying (e.g. a tune-off emitted
+        // as part of engaging MOX). Only treat it as a true un-key — closing
+        // the IQ gate and arming the tail watcher — when we're genuinely no
+        // longer transmitting. Otherwise we'd gate IQ mid-transmit and the
+        // watcher would count legitimate TX as a post-un-key tail.
+        if (_moxOn || _tuneActive) return;
+
+        // True un-key: close the gate so no further TX-IQ reaches the radio.
+        _txIqGateClosed = true;
 
         // Stamp the un-key instant and start watching the tail. The producer
         // (SendTxIq) and sender (TxIqSenderLoop) log, rate-limited, how long


### PR DESCRIPTION
## Data-driven follow-up to #527/#529

The diagnostic proved:
- ✅ The command path is correct — every **real** un-key flips the high-priority TX bit to `mox=False tun=False` (`p[1401]=0x00`) **immediately**, and the 100ms keepalive re-sends it.
- 🔴 But on a genuine un-key, the **producer kept feeding TX-IQ to +1236ms** after release (mic-buffer drain / TUN-driver tick latency). The radio can stay keyed (T/R engaged) while it's still receiving TX-IQ, so that ~1s IQ tail holds the relay past un-key.
- ⚠️ The scary `3s+ keeping the radio keyed` alarm was a **false positive** — the watcher armed during MOX *engage* (a redundant `SetTune(false)`) and counted legitimate 8.8W TX as a tail.

## Fix
- **`_txIqGateClosed`** — closed on a true un-key, reopened on next key-down. `SendTxIq` drops blocks while closed, so no straggler IQ reaches the radio after release; it stops the instant you un-key (pihpsdr sends no TX-IQ when not transmitting).
- **False-arming fix** — gate-close + watcher only arm when genuinely no longer transmitting (`!_moxOn && !_tuneActive`), so a tune-off during MOX-engage no longer misfires.

⚠️ RED-LIGHT P2 TX timing, builds clean, **not bench-tested**. If a real un-key still hangs ~2s with the gate showing IQ stopped at +0ms, the hold is radio-side → next step is a Thetis-vs-Zeus wire capture.