### PR TITLE
fix(cw): CW panel screens follow the light theme (zeus-22t)

### DIFF
--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -1806,7 +1806,13 @@
   gap: 10px;
   padding: 8px 10px;
   min-height: 44px;
-  background: var(--bg-inset);
+  /* Inset well one step darker than the panel base (--bg-1) so it reads as a
+     recessed display in BOTH themes — and crucially flips to a light grey in
+     the light theme instead of staying dark. --bg-inset / --bg-meter are
+     pinned dark in light theme (they're for the panadapter / LED wells), so
+     this panel — which is a text display, not a scope — uses --bg-0 to match
+     the VFO / TX-stage-meter treatment the operator expects (zeus-22t). */
+  background: var(--bg-0);
   border: 1px solid var(--line-strong);
   border-radius: var(--r-md);
   box-shadow:
@@ -1815,7 +1821,7 @@
   /* Subtle horizontal scanlines so the tape reads as a backlit display
      instead of a flat <div>. Stays under the text. */
   background-image:
-    var(--bg-inset, #060608),
+    var(--bg-0, #0a0a0c),
     repeating-linear-gradient(
       to bottom,
       rgba(255,255,255,0.012) 0px,
@@ -1930,7 +1936,9 @@
   justify-content: center;
   align-items: flex-start;
   padding: 4px 10px 4px 8px;
-  background: var(--bg-meter);
+  /* --bg-0 (inset, theme-flipping) rather than --bg-meter, which stays dark
+     in the light theme — see .cw-stream-hero note (zeus-22t). */
+  background: var(--bg-0);
   border: 1px solid var(--line-strong);
   border-radius: var(--r-md);
   box-shadow:
@@ -2091,7 +2099,9 @@
 .cw-macro-edit {
   font: 500 13px/1.2 var(--font-sans);
   padding: 7px 9px;
-  background: var(--bg-meter);
+  /* --bg-0 (inset, theme-flipping) rather than --bg-meter — see
+     .cw-stream-hero note (zeus-22t). */
+  background: var(--bg-0);
   color: var(--fg-0);
   border: 1px solid var(--accent-line);
   border-radius: var(--r-sm);


### PR DESCRIPTION
Fixes zeus-22t — in the light theme, parts of the CW panel stayed dark.

## Cause

The CW console's **stream-hero** (telegraph tape), **WPM readout** well, and inline **macro editor** used `--bg-inset` / `--bg-meter` for their backgrounds. Those two tokens are deliberately pinned dark in the light theme (they're the panadapter / LED-meter wells), so in light mode those areas stayed dark as large black blocks while the rest of the panel went light — reading as broken rather than as intentional instrument wells.

## Fix

Switch those three backgrounds to `--bg-0`, which is one step darker than the panel base (`--bg-1`) in **both** themes — so the elements still read as recessed wells, but now flip to a light grey (`#b8bcc3`) in the light theme. Text already uses the `--fg-*` tokens, so the readouts stay legible. Matches the VFO display / TX-stage-meter treatment the panel author expected. Dark theme is essentially unchanged (`#06`/`#05` → `#0a`).

Single-file change: `zeus-web/src/styles/layout.css` (3 background tokens). No TSX / logic changes.

## Verification

Bench-verified on a fresh local desktop build (light theme): stream-hero, WPM readout, and macro editor now render as light grey wells with legible text; dark theme unchanged.

## ⚠️ Visual change — maintainer review

Per CLAUDE.md, visual design is EI6LF's call. Filing for @-maintainer sign-off rather than auto-merge. The token choice (`--bg-0`) and the decision to treat these as theme-flipping wells (vs. intentional dark screens) need approval; happy to retune (`--bg-2`, or a VFO-style bordered well) if preferred.