### PR TITLE
fix(p2-tx): re-send RX-spec (CmdRx) on un-key so the G2 drops T/R

### DIFF
--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -633,15 +633,33 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     {
         _moxOn = on;
         if (on) BeginTxIqMeasure(); else ResetTxIq();
-        if (_rxTask is not null) SendCmdHighPriority(run: true);
+        if (_rxTask is not null)
+        {
+            SendCmdHighPriority(run: true);
+            if (!on) SendCmdRx(); // UnkeyToRx — see note below
+        }
     }
 
     public void SetTune(bool on)
     {
         _tuneActive = on;
         if (on) BeginTxIqMeasure(); else ResetTxIq();
-        if (_rxTask is not null) SendCmdHighPriority(run: true);
+        if (_rxTask is not null)
+        {
+            SendCmdHighPriority(run: true);
+            if (!on) SendCmdRx(); // UnkeyToRx — see note below
+        }
     }
+
+    // UnkeyToRx: on the TX→RX edge, re-send the RX-spec (port 1025) right after
+    // clearing PTT/relay, mirroring Thetis's turnaround (console.cs UpdateDDCs
+    // → CmdRx() at the un-key edge). Thetis explicitly tells the G2/Saturn to
+    // reconfigure its DDCs back to receive at the moment of un-key; Zeus
+    // previously only cleared the high-priority PTT bit and let the radio coast
+    // on the ~200 ms keepalive CmdRx. The Saturn firmware appears to gate its
+    // T/R relay turnaround on this RX-spec rather than solely on byte-4 bit-1,
+    // which matches the observed ~2 s relay hang that is independent of the
+    // TX-IQ stream.
 
     // Mark the start of a TX session for the un-key backlog diagnostic. Only
     // arms on the first rising edge so a TUN→MOX hand-off doesn't reset the


### PR DESCRIPTION
## The one packet Thetis sends on un-key that Zeus didn't

The ~2s relay hang is **independent of the TX-IQ stream** (confirmed: relay hangs even when the radio gets ~0 TX-IQ). A byte-for-byte source comparison vs Thetis found the gap: on the un-key edge Thetis does **TX-off(flush) -> CmdRx/UpdateDDCs -> SetPttOut(0)+SetTRXrelay(0) -> RX-on**, explicitly re-sending the **RX-spec (port 1025)** to reconfigure the G2's DDCs back to receive. **Zeus only cleared the high-priority PTT bit and never sent CmdRx on the edge** — the Saturn firmware appears to gate its T/R turnaround on that RX-spec, not solely on byte-4 bit-1 (matches a hang independent of TX-IQ).

## Fix
On the MOX/TUN falling edge, after clearing PTT/relay, send CmdRx (port 1025) — a per-edge RX-spec, mirroring Thetis.

## Honest caveat
The keepalive already re-sends CmdRx ~every 200ms, so if the radio gated purely on CmdRx presence the relay would drop in <200ms, not 2s. This bets that the per-edge timing (CmdRx at the un-key instant, right after the PTT/relay clear) is what the firmware needs. If it doesn't land, a Thetis-vs-Zeus wire capture is the definitive next step.

RED-LIGHT P2 TX path, builds clean, not bench-tested. Low-risk (CmdRx already sent at connect + keepalive).
