### PR TITLE
fix(tx): raise Windows timer resolution to 1ms — the Windows-only ~2s relay-hang root cause

### DIFF
--- a/OpenhpsdrZeus/Program.cs
+++ b/OpenhpsdrZeus/Program.cs
@@ -97,9 +97,36 @@ public partial class Program
         }
     }
 
+    // Windows' default system timer resolution is ~15.6 ms, which floors every
+    // Task.Delay / Thread.Sleep the .NET runtime issues. The Protocol-2 TX-IQ
+    // sender paces packets to the radio with sub-millisecond Task.Delay waits;
+    // at 15.6 ms granularity it can only feed the DUC at ~380 packets/s instead
+    // of the required 800 (192 kHz), starving the radio's TX FIFO so it holds
+    // its T/R relay ~2 s after un-key. macOS / Linux already run a ~1 ms timer
+    // so the identical code paces correctly there — which is why the symptom is
+    // Windows-only. timeBeginPeriod(1) raises the process-wide timer resolution
+    // to 1 ms for the lifetime of the process (the same thing Thetis gets via
+    // its multimedia-timer / "Pro Audio" thread), so Task.Delay-based TX pacing
+    // hits the full rate on Windows too. The matching timeEndPeriod is omitted
+    // deliberately — we want 1 ms resolution for the whole process lifetime and
+    // Windows restores the default on exit.
+    [System.Runtime.InteropServices.DllImport("winmm.dll", EntryPoint = "timeBeginPeriod")]
+    private static extern uint TimeBeginPeriod(uint uMilliseconds);
+
+    private static void RaiseTimerResolutionOnWindows()
+    {
+        if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
+        {
+            TimeBeginPeriod(1);
+        }
+    }
+
     [STAThread]
     public static int Main(string[] args)
     {
+        // Must run before any TX pacing starts — see RaiseTimerResolutionOnWindows.
+        RaiseTimerResolutionOnWindows();
+
         if (args.Contains("--desktop"))
         {
             HideConsoleOnWindows();

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -751,6 +751,12 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         double fifoSamples = 0.0;
         long lastTicks = Stopwatch.GetTimestamp();
         double ticksPerSecond = Stopwatch.Frequency;
+        // 1 Hz TX-IQ rate log (mirrors P1's p1.tx.rate). The radio's DUC needs
+        // 192 kHz = 800 packets/s of 240 samples. On Windows a coarse timer
+        // floors Task.Delay-paced sends near ~380/s (the relay-hang symptom);
+        // this line is how we confirm the timeBeginPeriod(1) fix restores 800/s.
+        int rateCount = 0;
+        long lastRateTicks = lastTicks;
         try
         {
             while (!ct.IsCancellationRequested)
@@ -782,11 +788,19 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
                 }
 
                 fifoSamples += TxIqSamplesPerPacket;
-                try { _sock!.SendTo(packet, ep); }
+                try { _sock!.SendTo(packet, ep); rateCount++; }
                 catch (ObjectDisposedException) { break; }
                 catch (SocketException ex)
                 {
                     _log.LogWarning(ex, "p2.txiq send failed");
+                }
+
+                if (now - lastRateTicks >= ticksPerSecond)
+                {
+                    _log.LogInformation("p2.tx.rate pkts/s={Pps} queue={Queue} fifoModel={Fifo:F0}",
+                        rateCount, _txIqQueue.Reader.Count, fifoSamples);
+                    rateCount = 0;
+                    lastRateTicks = now;
                 }
             }
         }


### PR DESCRIPTION
## The Windows-only root cause

The ~2s T/R relay hang after un-key is **Windows' default ~15.6ms timer resolution**.

The P2 TX-IQ sender paces packets to the radio's DUC with ~1ms `Task.Delay` waits. On Windows, every "1ms" delay is really ~15.6ms, so the sender can only push **~380 packets/s** instead of the required **800** (192kHz). The radio's TX FIFO is chronically starved → it holds T/R ~2s on un-key.

**macOS/Linux already run a ~1ms timer, so the identical code paces correctly there — which is exactly why this never reproduced on Mac/Linux.** Thetis avoids it on Windows via multimedia-timer / "Pro Audio" thread scheduling.

This explains everything we measured:
- Windows-only ✓
- the consistent ~380/s feed (the math falls right out of 15.6ms) ✓
- why the producer-side fix (#534) couldn't help — the *sender's* delay was the cap ✓

## Fix
`timeBeginPeriod(1)` at process start on Windows → 1ms process-wide timer resolution for the whole run, so Task.Delay-paced TX behaves like it does on Mac/Linux. No-op on Mac/Linux.

Plus a 1Hz `p2.tx.rate` log (mirrors `p1.tx.rate`) to confirm the feed: should read **~800/s** now vs the ~380/s measured before.

## This is the only change on experimental
Experimental was fully reset to develop; this is the sole delta. (PR #536 remains open/unmerged against experimental separately.)

⚠️ Process-wide timer change (slightly higher interrupt rate, standard for audio apps). Builds clean. Needs G2 bench confirmation: relay drops promptly on un-key + `p2.tx.rate` reads ~800/s.
