### PR TITLE
fix(p2-tx): p2.tx.rate log crashed the TX-IQ sender (.Count on unbounded channel)

### DIFF
--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -797,8 +797,17 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
 
                 if (now - lastRateTicks >= ticksPerSecond)
                 {
-                    _log.LogInformation("p2.tx.rate pkts/s={Pps} queue={Queue} fifoModel={Fifo:F0}",
-                        rateCount, _txIqQueue.Reader.Count, fifoSamples);
+                    // Diagnostics must NEVER take down the TX-IQ sender — the
+                    // outer catch exits the loop on any exception, so a bad log
+                    // call here silently stops all TX. (It did: ChannelReader.Count
+                    // throws NotSupportedException on an unbounded channel, which
+                    // killed the sender 24ms into key-down — no TX output at all.)
+                    try
+                    {
+                        _log.LogInformation("p2.tx.rate pkts/s={Pps} fifoModel={Fifo:F0}",
+                            rateCount, fifoSamples);
+                    }
+                    catch { /* never let a diagnostic kill TX */ }
                     rateCount = 0;
                     lastRateTicks = now;
                 }


### PR DESCRIPTION
The `p2.tx.rate` log added in #537 called `_txIqQueue.Reader.Count` — which **throws `NotSupportedException` on an unbounded `Channel`**. `TxIqSenderLoop`'s outer catch treats any exception as fatal and exits, so the TX-IQ sender **died ~24ms into the first key-down** → the radio got no TX-IQ (TUN = no output power, MOX = no mic spectrum).

This **invalidated the #537 timer-fix test**: the relay clicked instantly only because nothing was being transmitted (dead sender, empty radio FIFO).

Fix: drop `.Count` (log `pkts/s` + `fifoModel` only) and wrap the rate log in try/catch so a diagnostic can never take down the TX-IQ sender again. Now we can actually get a valid `p2.tx.rate` reading **with TX flowing** and see whether the timer fix puts it at ~800/s.
