### PR TITLE
fix(tx): raise Windows timer resolution to 1ms — fixes the Windows-only TX→RX / MOX / relay delay

### DIFF
--- a/OpenhpsdrZeus/Program.cs
+++ b/OpenhpsdrZeus/Program.cs
@@ -97,9 +97,36 @@ public partial class Program
         }
     }
 
+    // Windows' default system timer resolution is ~15.6 ms, which floors every
+    // Task.Delay / Thread.Sleep the .NET runtime issues. The Protocol-2 TX-IQ
+    // sender paces packets to the radio with sub-millisecond Task.Delay waits;
+    // at 15.6 ms granularity it can only feed the DUC at ~380 packets/s instead
+    // of the required 800 (192 kHz), starving the radio's TX FIFO so it holds
+    // its T/R relay ~2 s after un-key. macOS / Linux already run a ~1 ms timer
+    // so the identical code paces correctly there — which is why the symptom is
+    // Windows-only. timeBeginPeriod(1) raises the process-wide timer resolution
+    // to 1 ms for the lifetime of the process (the same thing Thetis gets via
+    // its multimedia-timer / "Pro Audio" thread), so Task.Delay-based TX pacing
+    // hits the full rate on Windows too. The matching timeEndPeriod is omitted
+    // deliberately — we want 1 ms resolution for the whole process lifetime and
+    // Windows restores the default on exit.
+    [System.Runtime.InteropServices.DllImport("winmm.dll", EntryPoint = "timeBeginPeriod")]
+    private static extern uint TimeBeginPeriod(uint uMilliseconds);
+
+    private static void RaiseTimerResolutionOnWindows()
+    {
+        if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
+        {
+            TimeBeginPeriod(1);
+        }
+    }
+
     [STAThread]
     public static int Main(string[] args)
     {
+        // Must run before any TX pacing starts — see RaiseTimerResolutionOnWindows.
+        RaiseTimerResolutionOnWindows();
+
         if (args.Contains("--desktop"))
         {
             HideConsoleOnWindows();

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -751,6 +751,12 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         double fifoSamples = 0.0;
         long lastTicks = Stopwatch.GetTimestamp();
         double ticksPerSecond = Stopwatch.Frequency;
+        // 1 Hz TX-IQ rate log (mirrors P1's p1.tx.rate). The radio's DUC needs
+        // 192 kHz = 800 packets/s of 240 samples. On Windows a coarse timer
+        // floors Task.Delay-paced sends near ~380/s (the relay-hang symptom);
+        // this line is how we confirm the timeBeginPeriod(1) fix restores 800/s.
+        int rateCount = 0;
+        long lastRateTicks = lastTicks;
         try
         {
             while (!ct.IsCancellationRequested)
@@ -782,11 +788,28 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
                 }
 
                 fifoSamples += TxIqSamplesPerPacket;
-                try { _sock!.SendTo(packet, ep); }
+                try { _sock!.SendTo(packet, ep); rateCount++; }
                 catch (ObjectDisposedException) { break; }
                 catch (SocketException ex)
                 {
                     _log.LogWarning(ex, "p2.txiq send failed");
+                }
+
+                if (now - lastRateTicks >= ticksPerSecond)
+                {
+                    // Diagnostics must NEVER take down the TX-IQ sender — the
+                    // outer catch exits the loop on any exception, so a bad log
+                    // call here silently stops all TX. (It did: ChannelReader.Count
+                    // throws NotSupportedException on an unbounded channel, which
+                    // killed the sender 24ms into key-down — no TX output at all.)
+                    try
+                    {
+                        _log.LogInformation("p2.tx.rate pkts/s={Pps} fifoModel={Fifo:F0}",
+                            rateCount, fifoSamples);
+                    }
+                    catch { /* never let a diagnostic kill TX */ }
+                    rateCount = 0;
+                    lastRateTicks = now;
                 }
             }
         }


### PR DESCRIPTION
## The Windows-only TX→RX / MOX / relay delay — root-caused and fixed

This is the fix for the long-standing **~2-second T/R relay hang on un-key** that multiple Windows operators have reported (and the slow/robotic TX audio that travels with it). After a long hunt that ruled out the audio buffer, the high-priority command path, and the TX-IQ stream itself, the actual cause turned out to be one thing:

### Root cause: Windows' system timer resolution

Windows' default timer quantum is **~15.6 ms**, and it floors every `Task.Delay` the .NET runtime issues. The Protocol-2 TX-IQ sender (`Protocol2Client.TxIqSenderLoop`) paces packets to the radio's DUC with **~1 ms `Task.Delay`** waits. On Windows each of those "1 ms" waits is really ~15.6 ms, so the sender:

- could only feed the radio at **~380 packets/s** instead of the required **800** (192 kHz, 240 samples/packet), and
- delivered them in **coarse bursts** rather than a smooth stream.

The radio's TX DAC FIFO was therefore chronically **starved and lumpy**. Two consequences:

1. **On un-key the radio held its T/R relay ~2 s** before returning to RX (the "MOX delay" / "RX-resume delay" / "amp delay").
2. **During TX the half-rate feed played voice back slow and robotic** (#444).

### Why it was Windows-only

**macOS and Linux already run a ~1 ms timer**, so the identical code paces correctly there — which is exactly why this never reproduced on Mac/Linux despite being trivially reproducible on Windows. Thetis sidesteps it on Windows by running its TX-IQ thread under the multimedia-timer / "Pro Audio" scheduling, which raises the timer resolution.

### The fix

One call: **`timeBeginPeriod(1)` (winmm.dll)** at process start on Windows, raising the process-wide timer resolution to 1 ms for the lifetime of the run — so every `Task.Delay`-paced TX path on Windows behaves like it already does on Mac/Linux. Guarded by an OS check, so it's a no-op on macOS/Linux. No matching `timeEndPeriod` by design (we want 1 ms for the whole process; Windows restores the default on exit). This is the standard approach audio/real-time apps take on Windows.

Also adds a 1 Hz `p2.tx.rate` log (mirrors the existing `p1.tx.rate`), wrapped in try/catch so a diagnostic can never take down the TX-IQ sender — it's how the feed rate was measured and how this stays debuggable.

### Scope / risk

**Timing only.** No change to drive, PA gain, calibration, filter widths, or any operator-facing default. The fix also benefits the **Windows P1 / Hermes-Lite-2 TX path**, which shares the same `Task.Delay` pacing. Slightly higher timer-interrupt rate while running, which is expected and standard for an audio application.

### Verification

- **ANAN-G2 (Protocol 2) from a Windows host:** T/R relay now releases **instantly on both TUNE and MOX**, TX power correct, and `p2.tx.rate` reads a steady **~800/s** (was ~380).
- **macOS:** sanity-swept (RX, panadapter, TUNE, MOX, TCI, audio) — no regression; the call is a Windows-only no-op.

### Issues this addresses

Addresses #468 (MOX delay still in 0.8.3), #336 (RX-resume delay after MOX-off), #444 (TX audio slow/robotic — the half-rate feed), and #518 (amp delay — knock-on of the T/R timing). Continues the lineage of #403 (earlier MOX-delay report, since closed). These stay open until the fix actually ships.

**This fix is in the next release** — the long-running Windows TX→RX delay is finally resolved.

### One known loose end (separate, not a blocker)

On the **test VM**, voice/MOX still feeds ~380/s while TUNE is now 800/s. The mic path is event-driven by mic-frame arrival (not `Task.Delay`-paced), so the timer fix doesn't touch it — this is almost certainly the VM's **RDP "Remote Audio"** virtual mic delivering at half real-time, not a code bug. The relay is prompt on MOX regardless. To be confirmed on real hardware; if a real mic also reads ~380/s we'll chase the mic-capture rate separately.
