### PR TITLE
feat(rit-xit): RIT/XIT incremental tuning — dogfood, do not merge

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,5 +22,16 @@
         "matcher": ""
       }
     ]
+  },
+  "enabledPlugins": {
+    "superpowers@claude-plugins-official": true,
+    "frontend-design@claude-plugins-official": true,
+    "context7@claude-plugins-official": true,
+    "chrome-devtools-mcp@claude-plugins-official": true,
+    "csharp-lsp@claude-plugins-official": true,
+    "claude-md-management@claude-plugins-official": true,
+    "claude-code-setup@claude-plugins-official": true,
+    "code-simplifier@claude-plugins-official": true,
+    "claude-hud@claude-hud": true
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ AI agents opening PRs against this repo may autonomously fix:
 - **Architecture** — new threads, new dependencies, new NuGet/npm packages, changes to the Zeus.Contracts wire format, signal-routing restructures.
 - **Default values** — anything an operator will notice on first connect: TX power, filter widths, AGC, meter calibration, default band/mode, color palette. One bug report is not evidence that the default is wrong for everyone.
 - **Feature scope creep** — if the issue says "fix meter," fix the meter. Don't add a new meter, refactor the meter pipeline, or rename the meter types.
+- **`.claude/settings.json`** — contributor-local plugin/hook configuration. Committed to the fork for dev-environment consistency but must NOT be included in upstream PRs.
 
 When uncertain, implement the minimal fix and note in the PR description that design decisions need maintainer review. The maintainer (Brian, EI6LF) is the sole authority on visual design, UX, and defaults.
 

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -58,6 +58,8 @@ public enum PsFeedbackSource : byte { Internal = 0, External = 1 }
 
 public enum ConnectionStatus { Disconnected, Connecting, Connected, Error }
 
+public enum IncrementalTuningMode : byte { Off = 0, Rit = 1, Xit = 2 }
+
 // Thetis NR-button state: Off = no spectral NR, Anr = NR1 (time-domain LMS),
 // Emnr = NR2 (Ephraim–Malah spectral), Sbnr = NR4 (libspecbleach spectral
 // bleaching — issue #79). NR3 (RNNR) is intentionally absent: training data
@@ -289,7 +291,16 @@ public sealed record StateDto(
     // (Thetis: Setup → DSP → Keyer → CW Pitch). On the wire now so
     // the frontend already consumes the live value — when the setting
     // lands, only the server-side source changes.
-    int CwPitchHz = CwDefaults.PitchHz);
+    int CwPitchHz = CwDefaults.PitchHz,
+
+    // ---- Incremental tuning (RIT / XIT) ----
+    // Runtime-only state, not persisted to LiteDB. Auto-cleared on band
+    // change, mode change, and disconnect. Offset values are preserved
+    // across cycle transitions (Off→Rit→Xit→Off) so the operator can
+    // park RIT, try XIT, and come back to find their RIT value intact.
+    IncrementalTuningMode ItMode = IncrementalTuningMode.Off,
+    int RitOffsetHz = 0,
+    int XitOffsetHz = 0);
 
 /// <summary>Canonical CW constants shared between backend and wire DTOs.
 /// Single source of truth — CwOffset (server-side) and StateDto both
@@ -397,6 +408,8 @@ public sealed record Nr2CoreConfigSetRequest(
 public sealed record ZoomSetRequest(int Level);
 
 public sealed record AutoAttSetRequest(bool Enabled);
+
+public sealed record IncrementalTuningSetRequest(IncrementalTuningMode Mode, int OffsetHz, bool Clear = false);
 
 public sealed record AutoAgcSetRequest(bool Enabled);
 

--- a/Zeus.Protocol1/ControlFrame.cs
+++ b/Zeus.Protocol1/ControlFrame.cs
@@ -73,7 +73,7 @@ internal static class ControlFrame
         // : adcpipe[1]`), so DDC1 ends up demodulating the pre-PA DAC
         // samples at whatever NCO we set here. Zeus has no split-VFO
         // and consumes DDC1 only as audio (when PS is off), so this
-        // just mirrors VfoAHz; the demodulated stream during PS+MOX is
+        // just mirrors RxFreqAHz; the demodulated stream during PS+MOX is
         // ignored (DDC3 is the canonical TX reference for pscc).
         RxFreq2 = 0x06,
         // RX3 NCO (DDC2). HL2-doc address 0x04 → wire byte 0x08. DDC2
@@ -187,7 +187,8 @@ internal static class ControlFrame
     /// thread copies a snapshot each tick.
     /// </summary>
     public readonly record struct CcState(
-        long VfoAHz,
+        long RxFreqAHz,
+        long TxFreqAHz,
         HpsdrSampleRate Rate,
         bool PreampOn,
         HpsdrAtten Atten,
@@ -268,18 +269,15 @@ internal static class ControlFrame
                 WriteConfigPayload(cc[1..], in state);
                 break;
 
-            case CcRegister.RxFreq:
             case CcRegister.TxFreq:
+                BinaryPrimitives.WriteUInt32BigEndian(cc[1..5], (uint)state.TxFreqAHz);
+                break;
+
+            case CcRegister.RxFreq:
             case CcRegister.RxFreq2:
             case CcRegister.RxFreq3:
             case CcRegister.RxFreq4:
-                // Frequency payload is a BE uint32 in C1..C4 (doc 02 §4 "Frequency payload").
-                // All five frequency registers (TxFreq + four RX NCOs) carry the
-                // same VfoAHz here — Zeus has no separate TX VFO. During HL2
-                // PS+MOX, mi0bot tunes DDC2 and DDC3 to TX freq, which is the
-                // operator-tuned freq for SSB; for CW, EffectiveLoHz is already
-                // baked into VfoAHz upstream in RadioService.SetVfo.
-                BinaryPrimitives.WriteUInt32BigEndian(cc[1..5], (uint)state.VfoAHz);
+                BinaryPrimitives.WriteUInt32BigEndian(cc[1..5], (uint)state.RxFreqAHz);
                 break;
 
             case CcRegister.DriveFilter:
@@ -469,7 +467,7 @@ internal static class ControlFrame
         byte ocPins = 0;
         if (s.Board == HpsdrBoardKind.HermesLite2 && s.HasN2adr)
         {
-            ocPins |= N2adrBands.RxOcMask(s.VfoAHz);
+            ocPins |= N2adrBands.RxOcMask(s.RxFreqAHz);
         }
         ocPins |= (byte)((s.Mox ? s.UserOcTxMask : s.UserOcRxMask) & 0x7F);
         byte c2 = (byte)(ocPins << 1);

--- a/Zeus.Protocol1/IProtocol1Client.cs
+++ b/Zeus.Protocol1/IProtocol1Client.cs
@@ -76,7 +76,7 @@ public interface IProtocol1Client : IDisposable
     /// <summary>Monotonic count of valid RX packets parsed since Start.</summary>
     long TotalFrames { get; }
 
-    void SetVfoAHz(long hz);
+    void SetFreqs(long rxHz, long txHz);
     void SetSampleRate(HpsdrSampleRate rate);
     void SetPreamp(bool on);
     void SetAttenuator(HpsdrAtten atten);

--- a/Zeus.Protocol1/Protocol1Client.cs
+++ b/Zeus.Protocol1/Protocol1Client.cs
@@ -75,9 +75,10 @@ public sealed class Protocol1Client : IProtocol1Client
 
     // Mutation state written from any thread, read from the TX thread.
     // 64-bit fields are written atomically on 64-bit .NET (Interlocked.Exchange used for safety).
-    private long _vfoAHz = 7_100_000;
+    private long _rxFreqAHz = 7_100_000;
+    private long _txFreqAHz = 7_100_000;
     // Frequency-correction factor (issue #325) — dimensionless multiplier
-    // near 1.0 applied to the incoming dial Hz before _vfoAHz is updated,
+    // near 1.0 applied to the incoming dial Hz before the freq slots are updated,
     // matching piHPSDR / Thetis. Stored as int64 bits for atomic
     // Interlocked.Exchange access from arbitrary threads. 1.0 = factory
     // default (no correction).
@@ -263,10 +264,10 @@ public sealed class Protocol1Client : IProtocol1Client
     /// cmaster.cs:8511-8550 FOUR_DDC routing). Stream assignment, cross-
     /// checked against the upstream HL2 gateware (rtl/radio_openhpsdr1/
     /// radio.sv:484-540, mix2_0 + mix2_2 + pure_signal switch):
-    ///   DDC0 = RX1 audio. mix2_0+adcpipe[0] at VfoAHz → operator's
+    ///   DDC0 = RX1 audio. mix2_0+adcpipe[0] at RxFreqAHz → operator's
     ///          listening freq, panadapter and audio chain stay alive
     ///          even while PS is keying. Published to IqFrame channel.
-    ///   DDC1 = mix2_2 input (shared with DDC3) at VfoAHz NCO. During
+    ///   DDC1 = mix2_2 input (shared with DDC3) at RxFreqAHz NCO. During
     ///          MOX+PS that input is `tx_data_dac`, so this DDC carries
     ///          a wrong-NCO copy of the DAC samples; functionally
     ///          useless, discarded.
@@ -540,20 +541,19 @@ public sealed class Protocol1Client : IProtocol1Client
         return Task.CompletedTask;
     }
 
-    public void SetVfoAHz(long hz)
+    public void SetFreqs(long rxHz, long txHz)
     {
         double factor = BitConverter.Int64BitsToDouble(Interlocked.Read(ref _freqCorrectionBits));
-        // host-side multiplicative correction, applied right before the
-        // wire-bound _vfoAHz slot (matches piHPSDR src/old_protocol.c:1040,
-        // Thetis NetworkIO.VFOfreq, deskHPSDR src/old_protocol.c:1629).
-        long corrected = (long)Math.Round(hz * factor, MidpointRounding.AwayFromZero);
-        Interlocked.Exchange(ref _vfoAHz, corrected);
+        long correctedRx = (long)Math.Round(rxHz * factor, MidpointRounding.AwayFromZero);
+        long correctedTx = (long)Math.Round(txHz * factor, MidpointRounding.AwayFromZero);
+        Interlocked.Exchange(ref _rxFreqAHz, correctedRx);
+        Interlocked.Exchange(ref _txFreqAHz, correctedTx);
     }
 
     /// <summary>
     /// Sets the per-radio frequency-correction factor (issue #325). The
     /// caller is responsible for re-pushing the current dial Hz via
-    /// <see cref="SetVfoAHz"/> after this so the new factor reaches the
+    /// <see cref="SetFreqs"/> after this so the new factor reaches the
     /// wire — this method on its own only mutates the multiplier used by
     /// the next tune-write.
     /// </summary>
@@ -662,8 +662,8 @@ public sealed class Protocol1Client : IProtocol1Client
         // Number of receivers requested in the Config payload (`(N-1) << 3`
         // in C4 bits [5:3]). mi0bot's HL2 path (Thetis console.cs:8186-8265)
         // uses **4 DDCs** during PS+MOX:
-        //   DDC0 → RX1 audio (mix2_0+adcpipe[0] at VfoAHz) — stays alive!
-        //   DDC1 → mix2_2 input at VfoAHz, demods to junk during MOX+PS
+        //   DDC0 → RX1 audio (mix2_0+adcpipe[0] at RxFreqAHz) — stays alive!
+        //   DDC1 → mix2_2 input at RxFreqAHz, demods to junk during MOX+PS
         //          (mix2_2.adc is forced to tx_data_dac then) — discarded.
         //   DDC2 → mix2_0+adcpipe[0] at TX freq → pscc "rx". On HL2 this
         //          is RF leakage of the radiated TX (no coupler hardware).
@@ -674,7 +674,8 @@ public sealed class Protocol1Client : IProtocol1Client
         byte numRxMinus1 = (byte)(psOn && isHl2 && moxOn ? 3 : 0);
 
         return new(
-            VfoAHz: Interlocked.Read(ref _vfoAHz),
+            RxFreqAHz: Interlocked.Read(ref _rxFreqAHz),
+            TxFreqAHz: Interlocked.Read(ref _txFreqAHz),
             Rate: (HpsdrSampleRate)Volatile.Read(ref _rate),
             PreampOn: Volatile.Read(ref _preamp) != 0,
             Atten: new HpsdrAtten(Volatile.Read(ref _attenDb)),

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -397,16 +397,14 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         _log.LogInformation("p2.stop totalFrames={Total} dropped={Drop}", _totalFrames, _droppedFrames);
     }
 
-    public void SetVfoAHz(long hz)
+    public void SetFreqs(long rxHz, long txHz)
     {
         double factor = BitConverter.Int64BitsToDouble(Interlocked.Read(ref _freqCorrectionBits));
-        // Host-side multiplicative correction, applied right before the
-        // phase-word feed slot (matches piHPSDR src/new_protocol.c:765,824,
-        // Thetis NetworkIO.VFOfreq, deskHPSDR src/new_protocol.c:909,967).
-        // _rxFreqHz then feeds the NCO phase-word at line 951
-        // (`rxPhase = _rxFreqHz * HzToPhase`).
-        long corrected = (long)Math.Round(hz * factor, MidpointRounding.AwayFromZero);
+        long corrected = (long)Math.Round(rxHz * factor, MidpointRounding.AwayFromZero);
         _rxFreqHz = (uint)Math.Clamp(corrected, 0L, uint.MaxValue);
+        // P2 TX freq routing is DDC-based; txHz is accepted for API
+        // symmetry with P1 but not yet wired to a separate NCO.
+        _ = txHz;
         var running = _rxTask is not null;
         _log.LogInformation("p2.tune hz={Hz} running={Running} hpSeq={Seq}",
             _rxFreqHz, running, _seqCmdHp);
@@ -416,7 +414,7 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     /// <summary>
     /// Sets the per-radio frequency-correction factor (issue #325). The
     /// caller is responsible for re-pushing the current dial Hz via
-    /// <see cref="SetVfoAHz"/> after this so the new factor reaches the
+    /// <see cref="SetFreqs"/> after this so the new factor reaches the
     /// wire — this method on its own only mutates the multiplier used by
     /// the next tune-write.
     /// </summary>
@@ -429,7 +427,7 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     /// <summary>
     /// Test seam (issue #325): the corrected NCO frequency that would be
     /// written to the wire on the next CmdHighPriority. Equals the last
-    /// <see cref="SetVfoAHz"/> argument multiplied by
+    /// <see cref="SetFreqs"/> argument multiplied by
     /// <see cref="FrequencyCorrectionFactor"/>.
     /// </summary>
     internal uint CorrectedRxFreqHzForTesting => _rxFreqHz;
@@ -751,12 +749,6 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         double fifoSamples = 0.0;
         long lastTicks = Stopwatch.GetTimestamp();
         double ticksPerSecond = Stopwatch.Frequency;
-        // 1 Hz TX-IQ rate log (mirrors P1's p1.tx.rate). The radio's DUC needs
-        // 192 kHz = 800 packets/s of 240 samples. On Windows a coarse timer
-        // floors Task.Delay-paced sends near ~380/s (the relay-hang symptom);
-        // this line is how we confirm the timeBeginPeriod(1) fix restores 800/s.
-        int rateCount = 0;
-        long lastRateTicks = lastTicks;
         try
         {
             while (!ct.IsCancellationRequested)
@@ -788,28 +780,11 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
                 }
 
                 fifoSamples += TxIqSamplesPerPacket;
-                try { _sock!.SendTo(packet, ep); rateCount++; }
+                try { _sock!.SendTo(packet, ep); }
                 catch (ObjectDisposedException) { break; }
                 catch (SocketException ex)
                 {
                     _log.LogWarning(ex, "p2.txiq send failed");
-                }
-
-                if (now - lastRateTicks >= ticksPerSecond)
-                {
-                    // Diagnostics must NEVER take down the TX-IQ sender — the
-                    // outer catch exits the loop on any exception, so a bad log
-                    // call here silently stops all TX. (It did: ChannelReader.Count
-                    // throws NotSupportedException on an unbounded channel, which
-                    // killed the sender 24ms into key-down — no TX output at all.)
-                    try
-                    {
-                        _log.LogInformation("p2.tx.rate pkts/s={Pps} fifoModel={Fifo:F0}",
-                            rateCount, fifoSamples);
-                    }
-                    catch { /* never let a diagnostic kill TX */ }
-                    rateCount = 0;
-                    lastRateTicks = now;
                 }
             }
         }

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -516,7 +516,7 @@ public class DspPipelineService : BackgroundService,
     private void OnRadioStateChanged(StateDto s)
     {
         // Forward VFO changes to the P2 client when it's active. RadioService
-        // does this for P1 via ActiveClient?.SetVfoAHz() inside SetVfo, but
+        // does this for P1 via ActiveClient?.SetFreqs() inside SetVfo, but
         // ActiveClient is null for P2 connections, so the radio never learns
         // about tune changes without this forward. Sample rate / mode follow
         // here too when P2-side support is added.
@@ -526,7 +526,8 @@ public class DspPipelineService : BackgroundService,
         // RadioLoHz to the P2 client (the P1 client gets the same push from
         // RadioService.SetRadioLo). See docs/prd/panfall_behavior.md.
         var p2 = _p2Client;
-        p2?.SetVfoAHz(s.RadioLoHz);
+        var (rxHz, txHz) = RitXitMath.WireFreqs(s.Mode, s.VfoHz, s.ItMode, s.RitOffsetHz, s.XitOffsetHz);
+        p2?.SetFreqs(rxHz, txHz);
 
         // iter5 pass-2: lock-free engine pointer read. The lock previously
         // here only provided pointer atomicity (the engine.* calls below
@@ -862,11 +863,9 @@ public class DspPipelineService : BackgroundService,
         engine.SetTxMode(s.Mode);
         engine.SetFilter(channelId, s.FilterLowHz, s.FilterHighHz);
         engine.SetTxFilter(s.TxFilterLowHz, s.TxFilterHighHz);
-        engine.SetVfoHz(channelId, s.VfoHz);
-        // Replay the WDSP shift on fresh-channel open so a connect landing
-        // with VfoHz != RadioLoHz (persisted across restart) is demodulating
-        // the same dial the operator saw last session.
-        // See docs/prd/panfall_behavior.md.
+        var (initRxWire, _) = RitXitMath.WireFreqs(
+            s.Mode, s.VfoHz, s.ItMode, s.RitOffsetHz, s.XitOffsetHz);
+        engine.SetVfoHz(channelId, (long)initRxWire);
         int ctunShiftHz = (int)(CwOffset.EffectiveLoHz(s.Mode, s.VfoHz) - s.RadioLoHz);
         engine.SetCtunShift(channelId, ctunShiftHz);
         double effectiveAgc = s.AgcTopDb + s.AgcOffsetDb;
@@ -1473,7 +1472,9 @@ public class DspPipelineService : BackgroundService,
         // real-radio data, so suppressing it unconditionally is correct.
         if (engine is SyntheticDspEngine) return;
 
-        engine.SetVfoHz(channel, state.VfoHz);
+        var (rxWire, _) = RitXitMath.WireFreqs(
+            state.Mode, state.VfoHz, state.ItMode, state.RitOffsetHz, state.XitOffsetHz);
+        engine.SetVfoHz(channel, (long)rxWire);
 
         // perf3 iter4: skip the entire display pipeline when no client is
         // subscribed. Saves: 2× engine.TryGet*DisplayPixels P/Invoke per tick
@@ -1566,12 +1567,12 @@ public class DspPipelineService : BackgroundService,
             // extra contract field needed, per task #7 scope note.
             int zoomLevel = Math.Max(1, state.ZoomLevel);
             float hzPerPixel = (float)((double)sampleRate / zoomLevel / Width);
-            // Panadapter centre = the radio's actual NCO. The hardware is
-            // always frozen at RadioLoHz while the dial roams, so the
-            // pan/waterfall stay anchored to RadioLoHz and don't slide under
-            // the operator when only VfoHz moves.
-            // See docs/prd/panfall_behavior.md.
-            long centerHz = state.RadioLoHz;
+            // Panadapter centre = the RX wire frequency (includes RIT when
+            // active). WDSP's analyzer processes IQ from the hardware NCO
+            // which sits at rxWire, so the FFT data is centred there. The
+            // display must match so signals, passband overlay, and audio
+            // stay in the same coordinate frame.
+            long centerHz = rxWire;
 
             // Cache for the frequency-calibration service (issue #325). The
             // cal reads from this cache to avoid racing for WDSP's "fresh

--- a/Zeus.Server.Hosting/FrequencyCalibrationService.cs
+++ b/Zeus.Server.Hosting/FrequencyCalibrationService.cs
@@ -39,7 +39,7 @@ namespace Zeus.Server;
 // mi0bot HL2 fork) use the same multiplicative-correction-at-tune-write
 // model; the per-board variation is in *where* the factor is applied
 // (host-side, never on a clock register), which is what Zeus already
-// does at `Protocol1Client.SetVfoAHz` + `Protocol2Client.SetVfoAHz`.
+// does at `Protocol1Client.SetFreqs` + `Protocol2Client.SetFreqs`.
 public sealed class FrequencyCalibrationService
 {
     public const double DefaultReferenceFrequencyHz = 10_000_000.0;

--- a/Zeus.Server.Hosting/PreferredRadioStore.cs
+++ b/Zeus.Server.Hosting/PreferredRadioStore.cs
@@ -233,7 +233,7 @@ public sealed class PreferredRadioStore : IDisposable
     /// <summary>
     /// Per-radio frequency-correction factor for crystal/clock drift
     /// (issue #325). Dimensionless multiplier near 1.0 applied host-side
-    /// at the Protocol-1 and Protocol-2 SetVfoAHz seams before the value
+    /// at the Protocol-1 and Protocol-2 SetFreqs seams before the value
     /// reaches the radio's NCO. 1.0 = uncalibrated (factory default).
     ///
     /// Models the Thetis "Correction Factor" approach

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -505,10 +505,10 @@ public sealed class RadioService : IDisposable
             // Retune the radio to the persisted hardware NCO (RadioLoHz). The
             // dial (VfoHz) may sit elsewhere; WDSP's shift stage covers the
             // gap. Hydration above already guarantees RadioLoHz != 0 by
-            // snapping to VfoHz on legacy rows, so a plain SetVfoAHz here is
+            // snapping to VfoHz on legacy rows, so a plain SetFreqs here is
             // always valid. See docs/prd/panfall_behavior.md.
             var connectSnap = Snapshot();
-            client.SetVfoAHz(connectSnap.RadioLoHz);
+            client.SetFreqs(connectSnap.RadioLoHz, connectSnap.RadioLoHz);
 
             // Default-on the N2ADR 7-relay filter board for HL2 — mirrors
             // Thetis's HERCULES preset (setup.cs:14642). Most HL2 deployments
@@ -592,6 +592,9 @@ public sealed class RadioService : IDisposable
             Endpoint = null,
             AttOffsetDb = 0,
             AdcOverloadWarning = false,
+            ItMode = IncrementalTuningMode.Off,
+            RitOffsetHz = 0,
+            XitOffsetHz = 0,
         });
         // Drop the PS board key — any SetPsAdvanced call between now and the
         // next connect (e.g. operator dialling in the panel while
@@ -632,10 +635,11 @@ public sealed class RadioService : IDisposable
         }
         // Classic "radio follows the dial" tuning. The CTUN frozen-NCO model
         // (#470) was reverted: it pinned the hardware NCO at the panadapter
-        // centre and offset RX in WDSP, but neither protocol client has a
-        // separate TX VFO (ControlFrame writes one VfoAHz to every freq
-        // register), so TX transmitted on the frozen centre instead of the
-        // dial. Every tune now retunes the radio so RX *and* TX track the dial;
+        // centre and offset RX in WDSP, but the protocol clients had no
+        // separate TX VFO, so TX transmitted on the frozen centre instead of
+        // the dial. The RIT/XIT wire-split (RxFreqAHz + TxFreqAHz) now
+        // enables independent RX/TX frequencies; PushWireFreqs applies IT
+        // offsets. Every tune retunes the radio so RX *and* TX track the dial;
         // RadioLoHz follows the dial's effective LO (CW: dial ∓ pitch), which
         // leaves the WDSP CTUN-shift stage at zero. The fromExternal flag is
         // kept for API compatibility but no longer changes behaviour — all
@@ -643,13 +647,14 @@ public sealed class RadioService : IDisposable
         _ = fromExternal;
         long radioLoNew = CwOffset.EffectiveLoHz(currentMode, clamped);
         Mutate(s => s with { VfoHz = clamped, RadioLoHz = radioLoNew });
-        ActiveClient?.SetVfoAHz(radioLoNew);
+        PushWireFreqs(currentMode, clamped);
         // Band edge crossed? Per-band PA gain / OC bits may have swapped — push
         // the new snapshot before the next TX frame ships. Cheap when no
         // crossing occurred (same bytes re-pushed).
         if (BandUtils.FreqToBand(previous) != BandUtils.FreqToBand(clamped))
         {
             RecomputePaAndPush();
+            ClearIncrementalTuning();
         }
         return Snapshot();
     }
@@ -659,7 +664,7 @@ public sealed class RadioService : IDisposable
     /// VfoHz untouched. Returns the updated <see cref="StateDto"/>.
     /// Out-of-range values are clamped to [0, 60_000_000]; callers wanting
     /// strict rejection should validate before calling. Triggers a P1 client
-    /// SetVfoAHz (and the P2 path via DspPipelineService.OnRadioStateChanged
+    /// SetFreqs (and the P2 path via DspPipelineService.OnRadioStateChanged
     /// reading the new RadioLoHz), and a PA recompute if the LO crossed a
     /// band edge. WDSP's shift stage is updated by DspPipelineService so the
     /// dial-relative demodulation remains correct.
@@ -670,11 +675,40 @@ public sealed class RadioService : IDisposable
         long previous;
         lock (_sync) { previous = _state.RadioLoHz; }
         Mutate(s => s with { RadioLoHz = clamped });
-        ActiveClient?.SetVfoAHz(clamped);
+        // Bypass PushWireFreqs intentionally: this is a low-level NCO setter
+        // (AlignLoForCwTx, direct REST override), not a VFO tune. IT offsets
+        // are not applied — callers know exactly what Hz they want on the wire.
+        ActiveClient?.SetFreqs(clamped, clamped);
         if (BandUtils.FreqToBand(previous) != BandUtils.FreqToBand(clamped))
         {
             RecomputePaAndPush();
         }
+        return Snapshot();
+    }
+
+    public StateDto SetIncrementalTuning(IncrementalTuningMode mode, int offsetHz, bool clear = false)
+    {
+        int clamped = RitXitMath.ClampOffset(offsetHz);
+        long vfo;
+        RxMode rxMode;
+        lock (_sync)
+        {
+            vfo = _state.VfoHz;
+            rxMode = _state.Mode;
+        }
+        Mutate(s => mode switch
+        {
+            IncrementalTuningMode.Rit => s with { ItMode = mode, RitOffsetHz = clamped },
+            IncrementalTuningMode.Xit => s with { ItMode = mode, XitOffsetHz = clamped },
+            _ when clear => s.ItMode switch
+            {
+                IncrementalTuningMode.Rit => s with { ItMode = IncrementalTuningMode.Off, RitOffsetHz = 0 },
+                IncrementalTuningMode.Xit => s with { ItMode = IncrementalTuningMode.Off, XitOffsetHz = 0 },
+                _ => s with { ItMode = IncrementalTuningMode.Off },
+            },
+            _ => s with { ItMode = IncrementalTuningMode.Off },
+        });
+        PushWireFreqs(rxMode, vfo);
         return Snapshot();
     }
 
@@ -793,6 +827,9 @@ public sealed class RadioService : IDisposable
                 FilterLowHz = lo, FilterHighHz = hi,
                 TxFilterLowHz = txLo, TxFilterHighHz = txHi,
                 FilterPresetName = restoredPreset,
+                ItMode = IncrementalTuningMode.Off,
+                RitOffsetHz = 0,
+                XitOffsetHz = 0,
             };
         });
 
@@ -804,7 +841,9 @@ public sealed class RadioService : IDisposable
         // into/out of CW changes EffectiveLoHz by ±cw_pitch and the radio
         // needs the new tuning before the next IQ block arrives. P2 is
         // pushed via DspPipelineService.OnRadioStateChanged.
-        ActiveClient?.SetVfoAHz(CwOffset.EffectiveLoHz(mode, newVfoHz));
+        // IT was cleared in the Mutate above, so both freqs are identical.
+        long lo = CwOffset.EffectiveLoHz(mode, newVfoHz);
+        ActiveClient?.SetFreqs(lo, lo);
 
         return Snapshot();
     }
@@ -1711,6 +1750,23 @@ public sealed class RadioService : IDisposable
         // Final flush so the last operator actions survive a clean shutdown.
         _stateDirty = true;
         FlushState();
+    }
+
+    private void ClearIncrementalTuning() =>
+        Mutate(s => s with { ItMode = IncrementalTuningMode.Off, RitOffsetHz = 0, XitOffsetHz = 0 });
+
+    private void PushWireFreqs(RxMode mode, long dialHz)
+    {
+        IncrementalTuningMode itMode;
+        int ritHz, xitHz;
+        lock (_sync)
+        {
+            itMode = _state.ItMode;
+            ritHz = _state.RitOffsetHz;
+            xitHz = _state.XitOffsetHz;
+        }
+        var (rx, tx) = RitXitMath.WireFreqs(mode, dialHz, itMode, ritHz, xitHz);
+        ActiveClient?.SetFreqs(rx, tx);
     }
 
     private void Mutate(Func<StateDto, StateDto> fn)

--- a/Zeus.Server.Hosting/RitXitMath.cs
+++ b/Zeus.Server.Hosting/RitXitMath.cs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Simone Fabris (IU3QEZ), and contributors.
+
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+internal static class RitXitMath
+{
+    public const int MaxOffsetHz = 3000;
+
+    public static int ClampOffset(int hz) =>
+        Math.Clamp(hz, -MaxOffsetHz, MaxOffsetHz);
+
+    public static int FilterAwareStepHz(int filterBandwidthHz) =>
+        filterBandwidthHz <= 250 ? 5 : 10;
+
+    public static (long RxHz, long TxHz) WireFreqs(RxMode mode, long dialHz,
+        IncrementalTuningMode itMode, int ritOffsetHz, int xitOffsetHz)
+    {
+        int ritDelta = itMode == IncrementalTuningMode.Rit ? ritOffsetHz : 0;
+        int xitDelta = itMode == IncrementalTuningMode.Xit ? xitOffsetHz : 0;
+        return (
+            CwOffset.EffectiveLoHz(mode, dialHz + ritDelta),
+            CwOffset.EffectiveLoHz(mode, dialHz + xitDelta));
+    }
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -321,6 +321,13 @@ public static class ZeusEndpoints
             return Results.Ok(r.SetRadioLo(req.Hz));
         });
 
+        app.MapPost("/api/rx/incremental-tuning",
+            (IncrementalTuningSetRequest req, RadioService r) =>
+        {
+            log.LogInformation("api.rx.it mode={Mode} offset={Hz} clear={Clear}", req.Mode, req.OffsetHz, req.Clear);
+            return Results.Ok(r.SetIncrementalTuning(req.Mode, req.OffsetHz, req.Clear));
+        });
+
         app.MapPost("/api/mode", (ModeSetRequest req, RadioService r) =>
         {
             log.LogInformation("api.mode mode={Mode}", req.Mode);

--- a/docs/designs/rit-xit-plumbing.md
+++ b/docs/designs/rit-xit-plumbing.md
@@ -1,0 +1,635 @@
+# RIT / XIT plumbing — design
+
+**Status:** IMPLEMENTED — pending operator smoke test + on-air validation,
+then maintainer review. Wire rename, backend, frontend, and panadapter
+marker are all landed; TCI handlers are still stubs (follow-up PR).
+**Date:** 2026-05-16 (revised 2026-05-25 — implementation complete).
+**Author:** Simone Fabris (IU3QEZ).
+**Upstream issue:** relates to #96 (Split VFO) — the `RxFreqAHz` +
+`TxFreqAHz` wire rename is the substrate that #96 will build on.
+**Branch:** `claude/kind-keller-hygeb` on `iu3qez/openhpsdr-zeus`.
+**Pairs with:** Zero Beat (issue #300 — landed as #499, reverted in #510,
+pending re-implementation).
+
+## TL;DR
+
+Zeus had a placeholder `RIT` button in the transport bar (`App.tsx:770`)
+that did nothing, and TCI stubs (`TciSession.cs:1095-1134`) that ignore
+RIT and XIT set-commands. This PR replaced the placeholder with a real
+feature: a single cycle button drives a 3-state machine
+(OFF → RIT → XIT → OFF), an offset sub-row appears under the VFO display
+with ▲/▼ spinners and a Clear button, and the existing host-side
+frequency-offset pipeline (CwOffset, freq-correction #325) grows a second
+branch so RX and TX wire frequencies can diverge.
+
+**CTUN history note (2026-05-25).** A prior draft (2026-05-22) added a
+§"Interaction with CTUN" section after upstream landed the frozen-NCO CTUN
+model (issue #427, commit `893b94e`). That model was subsequently **fully
+reverted** in commits `d25e32a` (#495, "revert CTUN frozen-NCO — radio
+follows the dial again") and `dcd414b` (#511, "restore pre-CTUN behavior")
+because the single-VFO wire model (`ControlFrame` writes `VfoAHz` to all
+five freq registers) caused TX to transmit on the frozen NCO instead of
+the dial. This is exactly the gap RIT/XIT fills — the `VfoAHz` →
+`RxFreqAHz` + `TxFreqAHz` rename that this design proposes. The CTUN
+interaction section has been removed; the wire formula below is the
+original v1 two-field model with no CTUN branch.
+
+`RadioLoHz` still exists in `StateDto` and `RadioService` but now tracks
+the dial's effective LO unconditionally (CW pitch baked in). It is used
+for panadapter centering. RIT/XIT do not interact with it — both operate
+on the wire-frequency formula only.
+
+This PR is the **substrate** that makes RIT-aware Zero Beat possible — a
+follow-up PR will extend `RadioService.ZeroBeat` to target the RIT register
+when RIT is active. The two PRs are independent: this one stands on its own
+as a feature ham operators actually want.
+
+## Goal
+
+Match the standard ham-radio RIT/XIT workflow: operator engages RIT, dials a
+small offset (±3 kHz max), the RX is shifted while TX stays on the dial.
+XIT mirrors that for TX. One offset active at a time, single cycle button to
+switch between RIT and XIT and back to OFF, per-mode offset preserved across
+the cycle so the operator can park RIT, try XIT, and come back to find their
+RIT value still there.
+
+Operating model and constants come from Thetis (the canonical reference for
+Zeus), with one deliberate divergence: Zeus enforces RIT and XIT to be
+mutually exclusive (one mode active at a time). Thetis allows both flags on
+simultaneously because RIT applies during RX and XIT during TX, so they don't
+fight each other. Zeus prefers the simpler UI — one cycle button, one offset
+visible at a time. Documented in §"Open questions for the maintainer" below
+because it's worth Doug's call.
+
+## Tech stack
+
+.NET 10 / C# 12 backend, React 19 + Vite frontend, xUnit 2.9 (backend tests),
+Vitest 2.1 (frontend tests). No new runtime dependencies; the work fits in
+the existing project layout.
+
+## Background
+
+### Why this is not just a UI wiring change
+
+You'd think wiring up the placeholder `RIT` button is a one-day job — just
+add an event handler, send the offset to the radio, done. It isn't, because
+of how Zeus currently models radio frequency.
+
+**Before this PR**, the wire format treated RX and TX freq as the same
+number. `ControlFrame.WriteCcBytes` (line 265) wrote `state.VfoAHz` to all
+five frequency registers. **This PR split** `CcState.VfoAHz` into
+`RxFreqAHz` + `TxFreqAHz`, and `WriteCcBytes` now routes `TxFreq` (0x02) to
+`TxFreqAHz` while the four RX registers use `RxFreqAHz`
+(`ControlFrame.cs:272-281`). `SetVfoAHz(long)` became `SetFreqs(long rxHz,
+long txHz)` on both protocol clients, and `RadioService.PushWireFreqs()`
+applies the RIT/XIT formula before calling `SetFreqs`.
+
+### Why RIT separately from SPLIT
+
+RIT and SPLIT serve overlapping use cases — both let the operator listen on
+one frequency and transmit on another — but they're mechanically different,
+and conflating them causes confusion in the codebase and the UI.
+
+- **RIT/XIT** = a small signed offset (±3 kHz in Zeus, ±9.999 on some
+  commercial rigs) added to one register. Use case: a caller is slightly
+  off-frequency, drift, fine alignment in pile-ups.
+- **SPLIT** = two independent VFOs (A and B), arbitrarily far apart. Use
+  case: a DX station on 14.220 listening up 5–10 kHz at 14.225–14.230.
+
+Most commercial rigs implement both, and they compose (you can RIT on top
+of SPLIT). Zeus has a `SPLIT` placeholder in `App.tsx:769` next to the `RIT`
+one; that's a separate feature deserving its own PR.
+
+### Why not just inherit from frequency-correction #325 / #334
+
+Doug's frequency-correction PR uses host-side injection at the
+`Protocol1Client.SetVfoAHz` / `Protocol2Client.SetVfoAHz` seam: the operator
+sets a calibration factor, and the client multiplies before writing to the
+wire. We could mirror that pattern for RIT/XIT — keep `SetVfoAHz`'s single
+parameter, add `client.SetRitOffset(hz)` / `SetXitOffset(hz)` setters,
+combine inside the client.
+
+We didn't. Two reasons:
+
+1. The freq-correction factor is conceptually one global multiplier applied
+   to every freq the client sees. RIT/XIT are different: they're additive,
+   they vary by mode (off / rit / xit), and the *math is different for RX
+   vs TX*. Treating them as "yet another client-side adjustment" buries
+   the rx-vs-tx split inside two protocol clients instead of in
+   `RadioService` where the operator state lives.
+
+2. The `ControlFrame.cs` comment is an invitation: *"Zeus has no separate
+   TX VFO yet"*. The codebase is ready for the rename; the comment was
+   left by whoever drew the line and stopped just short.
+
+The Thetis reference (`console.cs:31773-31787`, see receipts) calculates
+`rx_freq` and `tx_freq` independently in the orchestrator and pushes both
+to the wire. We follow that pattern.
+
+## Design
+
+### Server-side state model
+
+Three new fields on `StateDto` (`Zeus.Contracts/Dtos.cs:297-300`),
+runtime-only (not persisted to LiteDB):
+
+```csharp
+// Zeus.Contracts/Dtos.cs
+public enum IncrementalTuningMode : byte { Off = 0, Rit = 1, Xit = 2 }
+
+// on StateDto (default Off / 0 / 0):
+IncrementalTuningMode ItMode,
+int RitOffsetHz,   // ±3000, preserved across cycle transitions
+int XitOffsetHz    // ±3000, preserved across cycle transitions
+```
+
+The `enum` makes mutual exclusion structural — you cannot represent
+`RitOn && XitOn`. Three states, three states only.
+
+`RadioService.SetIncrementalTuning(mode, offsetHz)` (`RadioService.cs:685`)
+validates + clamps via `RitXitMath.ClampOffset` (`RitXitMath.cs:13`), then
+mutates state and calls `PushWireFreqs` to push the split frequencies to
+the protocol client.
+
+### Effective wire-frequency formula
+
+The single load-bearing piece of math, implemented in
+`RadioService.PushWireFreqs` (`RadioService.cs:1748-1759`):
+
+```csharp
+// RadioService.PushWireFreqs(RxMode mode, long dialHz)
+ritDelta = (ItMode == Rit) ? RitOffsetHz : 0;
+xitDelta = (ItMode == Xit) ? XitOffsetHz : 0;
+rxWireHz = CwOffset.EffectiveLoHz(mode, dialHz + ritDelta);
+txWireHz = CwOffset.EffectiveLoHz(mode, dialHz + xitDelta);
+ActiveClient?.SetFreqs(rxWireHz, txWireHz);
+```
+
+Note: CwOffset is applied to `dial + delta`, not added after. This is
+correct: `EffectiveLoHz(CWU, f) = f − pitch`, so
+`EffectiveLoHz(CWU, dial + rit) = (dial + rit) − pitch`.
+
+Worked example: dial 14.050.000, CWU mode (pitch 600 Hz), RIT engaged at
++250 Hz →
+- `rxWireHz = EffectiveLoHz(CWU, 14_050_250) = 14_049_650`
+- `txWireHz = EffectiveLoHz(CWU, 14_050_000) = 14_049_400` (XIT off)
+
+The CwOffset baking is inherited from existing CW handling (`CwOffset.cs`).
+RIT/XIT layer on top.
+
+### Wire-layer changes — the rename
+
+**Done.** The rename touched 21 files (74 occurrences). Summary:
+
+- `CcState.VfoAHz` → `RxFreqAHz` + `TxFreqAHz` (`ControlFrame.cs:190-191`)
+- `WriteCcBytes` switch (`ControlFrame.cs:272-281`):
+  ```csharp
+  case CcRegister.TxFreq:
+      BinaryPrimitives.WriteUInt32BigEndian(cc[1..5], (uint)state.TxFreqAHz);
+      break;
+  case CcRegister.RxFreq:
+  case CcRegister.RxFreq2:
+  case CcRegister.RxFreq3:
+  case CcRegister.RxFreq4:
+      BinaryPrimitives.WriteUInt32BigEndian(cc[1..5], (uint)state.RxFreqAHz);
+      break;
+  ```
+- `IProtocol1Client.SetVfoAHz(long)` → `SetFreqs(long rxHz, long txHz)`
+  (`IProtocol1Client.cs:79`)
+- `Protocol1Client`: `_vfoAHz` → `_rxFreqAHz` + `_txFreqAHz`
+  (`Protocol1Client.cs:78-79`), freq correction applied independently
+  (`Protocol1Client.cs:544-551`)
+- `Protocol2Client.SetFreqs`: accepts `txHz` for API symmetry, not yet
+  wired to a separate P2 NCO (`Protocol2Client.cs:400-414`)
+- N2ADR OC mask uses `RxFreqAHz` (`ControlFrame.cs:470`) — BPF follows RX
+- Backward compat: when IT is Off, `rxWireHz == txWireHz`. Same wire bytes.
+
+### REST endpoint
+
+One endpoint, replace-semantics:
+
+```http
+POST /api/rx/incremental-tuning
+Content-Type: application/json
+
+{ "mode": "off" | "rit" | "xit",
+  "offsetHz": -3000..3000 }
+```
+
+Whole-state set, not PATCH. The operator's edit (cycle a mode, dial an
+offset) is always a "this is the new state" decision, not a partial diff.
+Response body: the post-clamp state (200 OK), so the frontend can pick up
+the clamped value if the input was out of range.
+
+400 Bad Request for malformed payloads (mode not in the enum, offsetHz not
+an integer). Out-of-range `offsetHz` is silently clamped — operationally
+nicer than rejecting, and matches Thetis's `Math.Min`/`Math.Max` pattern.
+
+`GET /api/state` (existing) returns the runtime snapshot, extended with
+`itMode`, `ritOffsetHz`, `xitOffsetHz`. Frontend already broadcasts state
+via SignalR `StreamingHub` — the new fields ride along.
+
+### Frontend UI surface
+
+Four new components, two existing components touched:
+
+**`IncrementalTuningButton.tsx`** (new — replaces `App.tsx:770` placeholder)
+- Renders as a single button in the transport bar (`App.tsx:771`).
+- Single click cycles: OFF → RIT → XIT → OFF.
+- Label changes per state: dim "RIT/XIT" when OFF, lit "RIT" or "XIT" with
+  `accent` class when active.
+
+**`RitXitOffsetRow.tsx`** (new — sub-row under VfoDisplay)
+- Renders only when `itMode != 'Off'` (`VfoDisplay.tsx:316`).
+- Layout: `[ RIT  ▼  +0250 Hz  ▲  Clr ]`
+- ▲ / ▼ spinners: increment / decrement by **filter-aware step** (10 Hz
+  default, 5 Hz when current filter bandwidth ≤ 250 Hz — matches Thetis at
+  console.cs:7624-7633).
+- `Clr` button: sends `{ mode: "Off", offsetHz: 0 }` → sub-row disappears.
+- Debounced POSTs: 100 ms after the last ▲/▼ click.
+
+**`RitXitMarker.tsx`** (new — panadapter frequency indicator)
+- DOM overlay inside Panadapter container (`Panadapter.tsx:266`), same
+  coordinate system as `PassbandOverlay` (percentage of frequency span).
+- When RIT active: red (`--tx`) vertical line + "RX" label at `dial + ritOffset`.
+- When XIT active: red vertical line + "TX" label at `dial + xitOffset`.
+- Hidden when offset is 0 or IT mode is Off.
+- z-index 15 (same as dial marker), label with dark background for contrast.
+
+**`VfoDisplay.tsx`** (modified)
+- Imports and renders `<RitXitOffsetRow />` after the frequency hint
+  (`VfoDisplay.tsx:316`). The row conditionally renders itself.
+
+**`connection-store.ts`** (modified)
+- `itMode`, `ritOffsetHz`, `xitOffsetHz` fields added to `ConnectionState`
+  type, initial values, and `applyState` hydration.
+
+**`client.ts`** (modified)
+- `IncrementalTuningMode` type, `normalizeItMode`, fields on
+  `RadioStateDto`, `setIncrementalTuning()` API function.
+
+### Auto-clear events
+
+| Event | `_itMode` | `_itRitHz` | `_itXitHz` |
+|---|---|---|---|
+| Cycle button (any transition) | changes | preserved | preserved |
+| `Clr` button (mode = Rit) | Off | **0** | preserved |
+| `Clr` button (mode = Xit) | Off | preserved | **0** |
+| Band change | Off | **0** | **0** |
+| Mode change (CWU/CWL/USB/...) | Off | **0** | **0** |
+| Radio disconnect / reconnect | Off | **0** | **0** |
+| (future) SPLIT engaged | Off | **0** | **0** |
+| (future) Memory recall | overwritten | overwritten | overwritten |
+
+"Preserved" means the value sits in `RadioService` state but is not applied
+to the wire while `_itMode = Off`. Cycle back to the same mode → the value
+reappears in the sub-row and lands on the wire.
+
+### TCI handling
+
+The existing TCI stubs at `Tci/TciSession.cs:1095-1134` get real handlers,
+mapped to the Thetis CAT command names (canonical reference: Thetis
+`CATCommands.cs`):
+
+- `ZZRT` — RIT on/off (set/query)
+- `ZZRF` — RIT offset frequency (Hz, signed, 5 digits, e.g. `ZZRF+00250;`)
+- `ZZRU` / `ZZRD` — RIT step up/down (uses the filter-aware step)
+- `ZZXS` — XIT on/off (note: not `ZZXT`)
+- `ZZXF` — XIT offset
+- `ZZXU` / `ZZXD` — XIT step up/down
+
+Each command routes into the same `RadioService.SetIncrementalTuning(...)`
+the REST endpoint uses, so wire side-effects and state broadcast are
+identical regardless of source.
+
+**Mutual-exclusion divergence from Thetis.** If a TCI client (WSJT-X,
+N1MM+, etc.) sends `ZZRT1;` while XIT was already on, our backend cleanly
+transitions: `_itMode = Rit`, `_itXitHz` is preserved in memory (so cycling
+back to XIT restores it), but XIT is no longer applied to the wire. Thetis
+would leave both flags on. The operator's `_xitHz` is not lost — only its
+application is suspended while `_itMode != Xit`. Worth flagging to Doug;
+see §"Open questions for the maintainer".
+
+If Doug prefers, this TCI block can split into a follow-up PR to make this
+one atomic on the substrate alone.
+
+## Data flow
+
+**Operator clicks the cycle button (OFF → RIT):**
+
+```
+IncrementalTuningButton click
+  → client.ts setIncrementalTuning({ mode: "rit", offsetHz: lastRitHz })
+  → POST /api/rx/incremental-tuning
+  → ZeusEndpoints → RadioService.SetIncrementalTuning(...)
+       1. validate + clamp via RitXitMath
+       2. _itMode := Rit, _itRitHz := offsetHz
+       3. PushWireFreqs(mode, dialHz) computes rxWireHz, txWireHz
+       4. ActiveClient.SetFreqs(rxWireHz, txWireHz)
+       5. Mutate snapshot, SignalR broadcast
+  → Protocol1Client.SetFreqs
+       6. apply freq-correction to each field
+       7. update _rxFreqAHz, _txFreqAHz
+       8. rotation 4-phase carries new values on next tx packet (~3 ms)
+  → Frontend store updates, RitXitOffsetRow appears
+```
+
+**Operator clicks ▲ on sub-row:**
+
+Same path from step 1, debounced 100 ms. Offset becomes
+`current + filterAwareStep(currentFilterBw)`, clamped, sent.
+
+**Operator clicks `Clr` on sub-row:**
+
+```
+POST { mode: "off", offsetHz: 0 }  →  ... → 
+  _itMode := Off
+  if previousMode == Rit: _itRitHz := 0
+  else if previousMode == Xit: _itXitHz := 0
+  // the other mode's offset is left untouched
+  rxWireHz = txWireHz = dial + cwOffset(mode)
+  push to wire, broadcast
+  → sub-row disappears
+```
+
+**Auto-clear on band change:**
+
+```
+RadioService.SetBand(newBand)  →  if newBand != _band:
+  _itMode := Off, _itRitHz := 0, _itXitHz := 0
+  ... (recompute + push, exactly as a manual clear)
+```
+
+Same shape in `SetMode` and on disconnect.
+
+## Error handling
+
+### Input validation
+
+| Input | Behavior |
+|---|---|
+| `offsetHz` out of range (±50_000 etc.) | Silent clamp to ±3000. Response body carries the clamped value so frontend sees the truth. |
+| `offsetHz` not an integer / NaN | 400 Bad Request, no state change |
+| `mode` not in `{off, rit, xit}` | 400 Bad Request |
+| TCI `ZZRF+09999;` (would clamp to 3000) | Accept, clamp, store. Subsequent `ZZRF;` query returns the clamped form |
+| TCI command malformed | Ignored (matches Zeus's existing stub-permissive pattern) |
+
+Pure helper `Zeus.Server.Hosting.RitXitMath.ClampOffset(int hz)`
+(`RitXitMath.cs:13`) centralises this; `MaxOffsetHz = 3000`.
+
+### Wire-layer failures
+
+- **`_activeClient == null`** (disconnected): state is mutated, snapshot
+  broadcast, but no wire write. On reconnect the disconnect-clear rule
+  fires, so the rehydrated state is clean — no stale offset reaches the
+  fresh client.
+- **UDP write fails**: fire-and-forget, no retry (matches every other Zeus
+  wire write). The rotation schedule re-sends the register within ~3 ms
+  regardless.
+- **Race between `SetIncrementalTuning` and MOX edge**: `RadioService`
+  serialises mutations through the existing `Mutate(...)` lock; the MOX
+  edge re-reads the snapshot after each mutation completes, so no torn
+  state can reach the rotation.
+
+### Band-edge clamping
+
+Thetis clamps the post-offset wire frequency to band limits *after* adding
+the offset (`console.cs:31781`, `31788`). Example: dial 14.349.000 (top of
+20 m) + RIT +500 → `rxWireHz` would be 14.349.500, out of band; Thetis
+forces it to 14.350.000 (band edge), silently. The displayed offset stays
+at +500 but the effective offset is +1000.
+
+We follow Thetis exactly. This means rare drift between displayed offset
+and effective offset right at band edges. Worth flagging to Doug because
+the alternative (reject the set, or allow out-of-band) is also defensible.
+
+### TCI forced-mode transition
+
+Already covered in §"TCI handling". Recapping: an external TCI client can
+switch `_itMode` without operator input. The operator's offset *data* in
+the inactive mode is preserved in memory. Only application changes.
+
+Mitigation: an info log entry on the mode-switch (`tci.it.mode-transition
+from={x} to={y} source=tci`). No user-facing toast — TCI is machine-to-
+machine and the operator shouldn't have to dismiss notifications from it.
+Frontend learns about the switch through the normal state broadcast.
+
+## Testing strategy
+
+Six buckets — five automated, one manual, plus a light on-air pass.
+**Current totals: 1047 backend (210 P1 + 101 P2 + 736 Server) + 229
+frontend = 1276 tests, 0 failed.**
+
+### Pure unit tests (`Zeus.Server.Tests/RitXitMathTests.cs`) — DONE
+
+16 parametric tests covering `ClampOffset` (±3000 clamp) and
+`FilterAwareStepHz` (10 Hz / 5 Hz threshold at 250 Hz BW).
+
+### Orchestrator tests (`Zeus.Server.Tests/RadioServiceRitXitTests.cs`) — DONE
+
+10 tests exercising `RadioService` directly (same pattern as
+`RadioServiceSetRadioLoTests`). Cases:
+
+1. `SetIncrementalTuning(Rit, +250)` with dial 14_050_000, CWU, pitch 600
+   → pushed `rxWireHz=14_049_650, txWireHz=14_049_400`.
+2. Cycle Off → Rit (+250) → Xit (preserve rit) → Off (preserve both).
+   Final offsets equal initial dialled values, mode is Off.
+3. Band change with active mode → true clear.
+4. Mode change → true clear.
+5. Reconnect after a disconnect → true clear.
+6. Race: 100 concurrent `SetIncrementalTuning` from N threads → terminal
+   state matches the final caller's args, no torn `_itMode`.
+7. MOX edge with `_itMode = Xit` → `_txFreqHz = dial + xit`, `_rxFreqHz =
+   dial`. The two fields differ on the wire as expected.
+
+### Wire-layer tests (`Zeus.Protocol1.Tests/ControlFrameRxTxSplitTests.cs`) — DONE
+
+4 tests. Direct assertions on `WriteCcBytes` output bytes:
+
+1. `state.RxFreqAHz = X, state.TxFreqAHz = Y, register = RxFreq` → BE32
+   payload = `X`.
+2. Same state, `register = TxFreq` → payload = `Y`.
+3. `RxFreq2 / RxFreq3 / RxFreq4` → always `RxFreqAHz`, never `TxFreqAHz`.
+4. `state.Mox = true` → cc[0] bit 0 = 1, freq payload unchanged.
+
+### REST endpoint integration (`Zeus.Server.Tests/RitXitEndpointTests.cs`)
+
+`WebApplicationFactory<Program>`-based, hits the endpoint as HTTP.
+
+1. Valid POST → 200 + echoed state in body.
+2. Out-of-range `offsetHz` → 200 + clamped value in body.
+3. Bad `mode` enum → 400.
+4. `GET /api/state` reflects the new fields.
+
+### TCI handler tests (`Zeus.Server.Tests/TciRitXitTests.cs`)
+
+Test the new handlers in `TciSession`:
+
+1. `ZZRT1;` enables RIT mode in `RadioService`.
+2. `ZZRF+00250;` sets RIT offset to 250.
+3. `ZZRU;` steps up by the current filter-aware step.
+4. Mutex divergence: `ZZRT1;` then `ZZXS1;` → terminal `_itMode = Xit`,
+   `ZZRT;` query returns `ZZRT0;`. (Documents the divergence in test
+   form.)
+5. Query forms (no argument) reply with current state in Thetis-compatible
+   formatting.
+
+### Frontend (Vitest)
+
+- `IncrementalTuningButton.test.tsx`: state cycle, label changes, accent
+  border on active.
+- `RitXitOffsetRow.test.tsx`: render gating (only when `mode != Off`),
+  spinner clicks issue POSTs with correct payload, `Clr` POSTs `mode:
+  "off"`, click-to-edit numeric input commits on Enter.
+
+### Manual smoke test
+
+Pre-merge gate. With the dev stack up and a synthetic engine connected:
+
+1. Cycle button visible in transport bar. Click → label "RIT", accent
+   border lit. Sub-row appears under VFO with "RIT 0 Hz".
+2. Click ▲ three times → "RIT +30" (or +15 if a narrow filter is active).
+3. Click ▼ once → "RIT +20" / "+10".
+4. Click `Clr` → sub-row disappears, button label back to "RIT/XIT" dim.
+5. Cycle to RIT again → "RIT 0" (last Clr wiped this mode's offset).
+6. Cycle to XIT → "XIT 0", RIT preserved in `/api/state` if you check.
+7. Change band → sub-row gone, `/api/state` shows offsets 0.
+8. Disconnect / reconnect → same.
+
+### On-air validation
+
+This is a **lighter envelope** than the Zero Beat merge gate. Zero Beat is
+DSP — three baked-in constants whose correctness only shows on-air. RIT/XIT
+is wire plumbing. The algorithm is `dial + offset`; the constants are
+clamped at known bounds. What on-air checks is whether the operator's
+hands-and-ears reality matches the design intent.
+
+Minimum on-air pass (with a real HL2 or ANAN class radio):
+
+1. Real CW signal slightly off the dial — engage RIT, walk it to bring the
+   carrier to the correct pitch. Audio follows.
+2. Real SSB station off-frequency — engage RIT, align by ear.
+3. XIT in a QSO with a friend — dial-shift TX by some hundreds of Hz,
+   confirm they receive on the original dial frequency while you continue
+   to hear them on `dial + 0`.
+4. Mode change in the middle of an active RIT — sub-row vanishes, dial
+   frequency unchanged.
+5. Disconnect / reconnect with RIT active — comes back clean.
+
+If any of these surface a UX surprise (the `Clr` button is buried, the
+cycle through XIT-to-get-back-to-OFF is awkward, the filter-aware step
+feels wrong), flag it; we may need to add the `Esc` global hotkey or `×`
+inline reset button after the smoke pass.
+
+## Out of scope / future
+
+These are deliberately not in PR-A. Each gets its own design discussion
+when its turn comes.
+
+- **RIT-aware Zero Beat (PR-B).** This PR is the substrate; the follow-up
+  small PR teaches `RadioService.ZeroBeat` to target `_itRitHz` (when
+  `_itMode == Rit`) instead of the main VFO. The existing `ZeroBeatRequest`
+  DTO already has a `byte? RxId` forward-compatible parameter; we add a
+  sibling `target: "vfo" | "rit"`.
+- **SPLIT.** Independent feature, separate PR. The `SPLIT` placeholder
+  in `App.tsx:769` becomes its own button when that work happens.
+- **Memory recall.** Not implemented today (the `SAVE MEM` button at
+  `App.tsx:771` is also a placeholder). When memory cells arrive, recall
+  will overwrite `_itMode` / `_itRitHz` / `_itXitHz` from the stored
+  cell. The clear-rule table above already lists this as a hook.
+- **Configurable keyboard shortcuts.** Zeus has no hotkey-preferences UI
+  today. Hardcoded defaults in this PR (Shift+ArrowUp/Down for step,
+  Shift+Backspace for Clear). When a hotkey-prefs panel lands, RIT/XIT
+  hotkeys join it.
+- **~~Panadapter dual-marker for RIT/XIT visualisation.~~** DONE —
+  `RitXitMarker.tsx` renders a red (`--tx`) vertical line with "RX" or "TX"
+  label on the panadapter at the offset frequency. DOM overlay, same
+  coordinate system as `PassbandOverlay`.
+- **`Esc` global hotkey and `×` inline reset.** Provisional alternatives
+  to the on-row `Clr` button. Skipped from v1; on-air smoke may surface
+  the need.
+
+## Open questions for the maintainer
+
+This section is the "design notes" we'd quote in the PR description to
+Doug. Each item is a judgement call we made; happy to revise on his read.
+
+1. **~~Rename `VfoAHz` → `RxFreqAHz` + `TxFreqAHz` everywhere.~~**
+   RESOLVED — done. 21 files, 74 occurrences renamed.
+
+2. **~~`SetVfoAHz(long)` → `SetFreqs(long rxHz, long txHz)`.~~**
+   RESOLVED — done. Combined setter, both freqs pushed atomically.
+   5 call sites updated (4 in RadioService, 1 in DspPipelineService).
+
+3. **REST replace-semantics, not PATCH.** The endpoint takes
+   `{ mode, offsetHz }` as one indivisible state. We considered separate
+   `/enable` and `/offset` paths, or PATCH with optional fields. The
+   single replace endpoint is simpler and the operator action is always
+   "this is the new combined state" (you don't typically toggle the mode
+   without also implying what offset is in effect). Open to splitting if
+   you prefer two narrower endpoints.
+
+4. **Mutual exclusion (Zeus) vs both-on (Thetis).** This is the loudest
+   divergence. Thetis allows RIT and XIT to both be on, since they apply
+   in opposite MOX phases. We force a single-mode-active model so the UX
+   is one cycle button and one sub-row display. The operator's *data*
+   isn't lost (both `_itRitHz` and `_itXitHz` persist across cycling),
+   only application. If you'd rather we keep Thetis parity here — two
+   independent flags, two sub-rows, more UI — we'll redesign.
+
+5. **TCI in this PR vs split-out.** The TCI handlers replace ignore-
+   stubs and are ~12 commands (~15-20 lines each). Could ship in this PR
+   or as a small follow-up to keep PR-A "substrate only". Your call.
+
+6. **Band-edge clamping Thetis-strict.** When RIT pushes `rxWireHz` past
+   the band edge, we clamp silently and let the displayed offset diverge
+   from the effective offset (Thetis behavior). Alternatives: reject the
+   offset set (cleaner state) or allow out-of-band (some radios cope,
+   most don't). We picked Thetis-strict because it never blocks an
+   operator action.
+
+7. **Reset UX = on-row `Clr` only.** No `Esc` global hotkey, no `×`
+   inline mini-button. Provisional; on-air smoke may say this is too
+   buried in a fast QSO. Both alternatives are a few lines of code on
+   top of the substrate — happy to add either if the smoke surfaces it.
+
+8. **On-air validation envelope is lighter than Zero Beat's.** Zero Beat
+   needed slow/fast/weak/fading because three baked-in constants gate
+   real-radio correctness. RIT/XIT is wire plumbing — the math is
+   `dial + offset`. The smoke checklist above plus 5 reality-checks
+   feels right. If you'd rather we run a fuller envelope, name it.
+
+## Notes / receipts
+
+- **CTUN retired upstream (2026-05-25).** The frozen-NCO CTUN model
+  (issue #427, commit `893b94e`) was reverted in `d25e32a` (#495) and
+  `dcd414b` (#511). Root cause: `ControlFrame` writes a single `VfoAHz`
+  to all five freq registers, so TX transmitted on the frozen NCO instead
+  of the dial. `CtunEnabled` is gone from the contracts; `RadioLoHz`
+  persists but tracks the dial unconditionally. The `VfoAHz` →
+  `RxFreqAHz` + `TxFreqAHz` rename proposed by this design would have
+  unblocked CTUN's TX problem — should CTUN return in the future, it
+  can build on the two-field wire model RIT/XIT introduces.
+- **Thetis reference**: `console.cs:31773-31787` for the canonical
+  `rx_freq` / `tx_freq` independent calculation, `console.cs:7624-7633`
+  for the filter-aware step (10 / 5 Hz), `console.cs:36052` for
+  `btnRITReset_Click` (the canonical "clear value + turn off"),
+  `console.Designer.cs:2522-2531` for the original ±99.999 kHz range,
+  `CATCommands.cs:5904+` for the ZZRF wire format.
+- **Range choice**: ±3 kHz — tighter than the original ±9.999 kHz draft
+  and far narrower than Thetis's ±99.999. Beyond ±3 kHz, the operator
+  really wants SPLIT (issue #96, separate PR). `RitXitMath.MaxOffsetHz`
+  is a single constant to adjust if operator feedback surfaces the need.
+- **Upstream SPLIT VFO**: issue
+  [#96](https://github.com/Kb2uka/openhpsdr-zeus/issues/96) (open, P3,
+  by Brian). The `RxFreqAHz` + `TxFreqAHz` wire rename is the substrate
+  that #96 will build on — SPLIT just means `TxFreqAHz` can diverge
+  arbitrarily from `RxFreqAHz`, not just by ±3 kHz.
+- **Step choice**: 10 Hz default, 5 Hz when current filter bandwidth ≤
+  250 Hz. Lifted verbatim from Thetis. Provisional pending on-air.
+- **Cycle-button UX precedent**: not Thetis (which has two independent
+  toggles); more like Yaesu's CLAR button on some FT-series radios.
+  Documented as a deliberate divergence above.
+- **Personal operating experience**: Simo (iu3qez) on CW / SSB DX work.
+  Source of the "operator wants the Clr at hand" and "Esc/× as fallback
+  if Clr is buried" intuitions.

--- a/tests/Zeus.Protocol1.Tests/ControlFrameOcMaskTests.cs
+++ b/tests/Zeus.Protocol1.Tests/ControlFrameOcMaskTests.cs
@@ -32,7 +32,7 @@ public class ControlFrameOcMaskTests
 {
     private static ControlFrame.CcState BaseState(byte userTx = 0, byte userRx = 0, bool mox = false) =>
         new(
-            VfoAHz: 7_100_000, // 40m — N2adrBands.RxOcMask returns 0x44 (pins 3+7)
+            RxFreqAHz: 7_100_000, TxFreqAHz: 7_100_000, // 40m — N2adrBands.RxOcMask returns 0x44 (pins 3+7)
             Rate: HpsdrSampleRate.Rate48k,
             PreampOn: false,
             Atten: HpsdrAtten.Zero,
@@ -93,7 +93,7 @@ public class ControlFrameOcMaskTests
     {
         // Hermes without N2ADR → no auto mask. User bits stand alone.
         var state = new ControlFrame.CcState(
-            VfoAHz: 7_100_000,
+            RxFreqAHz: 7_100_000, TxFreqAHz: 7_100_000,
             Rate: HpsdrSampleRate.Rate48k,
             PreampOn: false,
             Atten: HpsdrAtten.Zero,

--- a/tests/Zeus.Protocol1.Tests/ControlFramePsEncoderTests.cs
+++ b/tests/Zeus.Protocol1.Tests/ControlFramePsEncoderTests.cs
@@ -31,7 +31,7 @@ namespace Zeus.Protocol1.Tests;
 public class ControlFramePsEncoderTests
 {
     private static ControlFrame.CcState BaseHl2(bool psEnabled = false) => new(
-        VfoAHz: 14_200_000,
+        RxFreqAHz: 14_200_000, TxFreqAHz: 14_200_000,
         Rate: HpsdrSampleRate.Rate48k,
         PreampOn: false,
         Atten: HpsdrAtten.Zero,

--- a/tests/Zeus.Protocol1.Tests/ControlFrameRxTxSplitTests.cs
+++ b/tests/Zeus.Protocol1.Tests/ControlFrameRxTxSplitTests.cs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Simone Fabris (IU3QEZ), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Buffers.Binary;
+using Zeus.Contracts;
+
+namespace Zeus.Protocol1.Tests;
+
+public class ControlFrameRxTxSplitTests
+{
+    private static ControlFrame.CcState SplitState(long rxHz, long txHz) => new(
+        RxFreqAHz: rxHz,
+        TxFreqAHz: txHz,
+        Rate: HpsdrSampleRate.Rate48k,
+        PreampOn: false,
+        Atten: HpsdrAtten.Zero,
+        RxAntenna: HpsdrAntenna.Ant1,
+        Mox: false,
+        EnableHl2BandVolts: false,
+        Board: HpsdrBoardKind.HermesLite2);
+
+    [Fact]
+    public void RxFreq_EncodesSplitRxFrequency()
+    {
+        var state = SplitState(rxHz: 14_050_250, txHz: 14_050_000);
+        Span<byte> cc = stackalloc byte[5];
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.RxFreq, state);
+        Assert.Equal(14_050_250u, BinaryPrimitives.ReadUInt32BigEndian(cc[1..5]));
+    }
+
+    [Fact]
+    public void TxFreq_EncodesSplitTxFrequency()
+    {
+        var state = SplitState(rxHz: 14_050_250, txHz: 14_050_000);
+        Span<byte> cc = stackalloc byte[5];
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.TxFreq, state);
+        Assert.Equal(14_050_000u, BinaryPrimitives.ReadUInt32BigEndian(cc[1..5]));
+    }
+
+    [Fact]
+    public void RxFreq2_FollowsRxFreq()
+    {
+        var state = SplitState(rxHz: 7_074_250, txHz: 7_074_000);
+        Span<byte> cc = stackalloc byte[5];
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.RxFreq2, state);
+        Assert.Equal(7_074_250u, BinaryPrimitives.ReadUInt32BigEndian(cc[1..5]));
+    }
+
+    [Fact]
+    public void WhenEqual_AllRegistersMatchOriginalBehavior()
+    {
+        var state = SplitState(rxHz: 14_200_000, txHz: 14_200_000);
+        Span<byte> cc = stackalloc byte[5];
+
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.TxFreq, state);
+        uint txVal = BinaryPrimitives.ReadUInt32BigEndian(cc[1..5]);
+
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.RxFreq, state);
+        uint rxVal = BinaryPrimitives.ReadUInt32BigEndian(cc[1..5]);
+
+        Assert.Equal(txVal, rxVal);
+        Assert.Equal(14_200_000u, txVal);
+    }
+}

--- a/tests/Zeus.Protocol1.Tests/ControlFrameTests.cs
+++ b/tests/Zeus.Protocol1.Tests/ControlFrameTests.cs
@@ -51,7 +51,7 @@ namespace Zeus.Protocol1.Tests;
 public class ControlFrameTests
 {
     private static ControlFrame.CcState BaseState() => new(
-        VfoAHz: 14_200_000,
+        RxFreqAHz: 14_200_000, TxFreqAHz: 14_200_000,
         Rate: HpsdrSampleRate.Rate48k,
         PreampOn: false,
         Atten: HpsdrAtten.Zero,
@@ -461,15 +461,13 @@ public class ControlFrameTests
     }
 
     [Fact]
-    public void PhaseTable_MoxOn_TxFreqPayloadIsVfoA()
+    public void PhaseTable_MoxOn_TxFreqPayloadMatchesTxFreqAHz()
     {
-        // Protocol-1 uses channel_freq(-1) (which resolves to the TX VFO) for
-        // the 0x02 payload. We don't have a split TX VFO yet, so TxFreq should
-        // encode VfoAHz — same VFO used for RxFreq. Pinning this so a future
-        // split-VFO implementation changes the phase-table registers together
-        // with the CcState field.
+        // TxFreq register (0x02) now encodes TxFreqAHz independently from
+        // the RX registers. When both are equal, wire output is unchanged
+        // from the pre-split single-VFO model.
         var state = new ControlFrame.CcState(
-            VfoAHz: 7_074_000,
+            RxFreqAHz: 7_074_000, TxFreqAHz: 7_074_000,
             Rate: HpsdrSampleRate.Rate48k,
             PreampOn: false,
             Atten: HpsdrAtten.Zero,

--- a/tests/Zeus.Protocol1.Tests/FrequencyCorrectionTests.cs
+++ b/tests/Zeus.Protocol1.Tests/FrequencyCorrectionTests.cs
@@ -11,7 +11,7 @@ namespace Zeus.Protocol1.Tests;
 /// <summary>
 /// Per-radio frequency-correction factor (issue #325). The correction is
 /// a single multiplicative scalar applied inside
-/// <see cref="Protocol1Client.SetVfoAHz"/> right before the wire-bound
+/// <see cref="Protocol1Client.SetFreqs"/> right before the wire-bound
 /// <c>_vfoAHz</c> slot. These tests pin down the math against the
 /// piHPSDR / Thetis / deskHPSDR reference convention:
 ///
@@ -29,9 +29,9 @@ public class FrequencyCorrectionTests
     {
         using var client = new Protocol1Client();
         client.SetFrequencyCorrectionFactor(1.0);
-        client.SetVfoAHz(14_250_000);
+        client.SetFreqs(14_250_000, 14_250_000);
 
-        Assert.Equal(14_250_000L, client.SnapshotState().VfoAHz);
+        Assert.Equal(14_250_000L, client.SnapshotState().RxFreqAHz);
     }
 
     [Fact]
@@ -40,8 +40,8 @@ public class FrequencyCorrectionTests
         using var client = new Protocol1Client();
         Assert.Equal(1.0, client.FrequencyCorrectionFactor);
 
-        client.SetVfoAHz(7_100_000);
-        Assert.Equal(7_100_000L, client.SnapshotState().VfoAHz);
+        client.SetFreqs(7_100_000, 7_100_000);
+        Assert.Equal(7_100_000L, client.SnapshotState().RxFreqAHz);
     }
 
     [Fact]
@@ -49,9 +49,9 @@ public class FrequencyCorrectionTests
     {
         using var client = new Protocol1Client();
         client.SetFrequencyCorrectionFactor(1.000001);
-        client.SetVfoAHz(10_000_000);
+        client.SetFreqs(10_000_000, 10_000_000);
 
-        Assert.Equal(10_000_010L, client.SnapshotState().VfoAHz);
+        Assert.Equal(10_000_010L, client.SnapshotState().RxFreqAHz);
     }
 
     [Fact]
@@ -59,9 +59,9 @@ public class FrequencyCorrectionTests
     {
         using var client = new Protocol1Client();
         client.SetFrequencyCorrectionFactor(0.999999);
-        client.SetVfoAHz(10_000_000);
+        client.SetFreqs(10_000_000, 10_000_000);
 
-        Assert.Equal(9_999_990L, client.SnapshotState().VfoAHz);
+        Assert.Equal(9_999_990L, client.SnapshotState().RxFreqAHz);
     }
 
     [Fact]
@@ -75,14 +75,14 @@ public class FrequencyCorrectionTests
         // multiplication of these gives a result comfortably on one side
         // of the midpoint, so the AwayFromZero rounding direction is not
         // implementation-defined here.
-        client.SetVfoAHz(1_000_000);
-        Assert.Equal(1_000_001L, client.SnapshotState().VfoAHz);
+        client.SetFreqs(1_000_000, 1_000_000);
+        Assert.Equal(1_000_001L, client.SnapshotState().RxFreqAHz);
 
-        client.SetVfoAHz(14_250_000);
-        Assert.Equal(14_250_014L, client.SnapshotState().VfoAHz);
+        client.SetFreqs(14_250_000, 14_250_000);
+        Assert.Equal(14_250_014L, client.SnapshotState().RxFreqAHz);
 
-        client.SetVfoAHz(50_000_000);
-        Assert.Equal(50_000_050L, client.SnapshotState().VfoAHz);
+        client.SetFreqs(50_000_000, 50_000_000);
+        Assert.Equal(50_000_050L, client.SnapshotState().RxFreqAHz);
     }
 
     [Fact]
@@ -95,15 +95,15 @@ public class FrequencyCorrectionTests
         // alone is non-destructive.
         using var client = new Protocol1Client();
         client.SetFrequencyCorrectionFactor(1.0);
-        client.SetVfoAHz(14_250_000);
-        Assert.Equal(14_250_000L, client.SnapshotState().VfoAHz);
+        client.SetFreqs(14_250_000, 14_250_000);
+        Assert.Equal(14_250_000L, client.SnapshotState().RxFreqAHz);
 
         client.SetFrequencyCorrectionFactor(1.000001);
-        // _vfoAHz wasn't touched — still the value written under factor=1.
-        Assert.Equal(14_250_000L, client.SnapshotState().VfoAHz);
+        // freq slots weren't touched — still the value written under factor=1.
+        Assert.Equal(14_250_000L, client.SnapshotState().RxFreqAHz);
 
         // Re-tune with same dial: now the new factor is applied.
-        client.SetVfoAHz(14_250_000);
-        Assert.Equal(14_250_014L, client.SnapshotState().VfoAHz);
+        client.SetFreqs(14_250_000, 14_250_000);
+        Assert.Equal(14_250_014L, client.SnapshotState().RxFreqAHz);
     }
 }

--- a/tests/Zeus.Protocol1.Tests/N2adrBandsTests.cs
+++ b/tests/Zeus.Protocol1.Tests/N2adrBandsTests.cs
@@ -89,7 +89,7 @@ public class N2adrBandsTests
         // Verify the final wire byte for a 20m park.
         Span<byte> cc = stackalloc byte[5];
         var state = new ControlFrame.CcState(
-            VfoAHz: 14_200_000,
+            RxFreqAHz: 14_200_000, TxFreqAHz: 14_200_000,
             Rate: HpsdrSampleRate.Rate192k,
             PreampOn: false,
             Atten: HpsdrAtten.Zero,
@@ -109,7 +109,7 @@ public class N2adrBandsTests
     {
         Span<byte> cc = stackalloc byte[5];
         var state = new ControlFrame.CcState(
-            VfoAHz: 14_200_000,
+            RxFreqAHz: 14_200_000, TxFreqAHz: 14_200_000,
             Rate: HpsdrSampleRate.Rate192k,
             PreampOn: false,
             Atten: HpsdrAtten.Zero,
@@ -152,7 +152,7 @@ public class N2adrBandsTests
         // Hermes must not emit any OC pin bits.
         Span<byte> cc = stackalloc byte[5];
         var state = new ControlFrame.CcState(
-            VfoAHz: 14_200_000,
+            RxFreqAHz: 14_200_000, TxFreqAHz: 14_200_000,
             Rate: HpsdrSampleRate.Rate192k,
             PreampOn: false,
             Atten: HpsdrAtten.Zero,

--- a/tests/Zeus.Protocol1.Tests/TestToneGeneratorTests.cs
+++ b/tests/Zeus.Protocol1.Tests/TestToneGeneratorTests.cs
@@ -50,7 +50,7 @@ namespace Zeus.Protocol1.Tests;
 public class TestToneGeneratorTests
 {
     private static ControlFrame.CcState Hl2Tx(byte driveLevel = 255, bool mox = true) => new(
-        VfoAHz: 14_200_000,
+        RxFreqAHz: 14_200_000, TxFreqAHz: 14_200_000,
         Rate: HpsdrSampleRate.Rate48k,
         PreampOn: false,
         Atten: HpsdrAtten.Zero,

--- a/tests/Zeus.Protocol2.Tests/FrequencyCorrectionTests.cs
+++ b/tests/Zeus.Protocol2.Tests/FrequencyCorrectionTests.cs
@@ -13,7 +13,7 @@ namespace Zeus.Protocol2.Tests;
 /// Per-radio frequency-correction factor (issue #325). Same math as the
 /// Protocol-1 path — verifies the Protocol-2 client (which feeds the DUC
 /// / DDC NCO phase-word) applies the same multiplicative correction
-/// inside <see cref="Protocol2Client.SetVfoAHz"/>. Without this gate,
+/// inside <see cref="Protocol2Client.SetFreqs"/>. Without this gate,
 /// G2 / OrionMkII / Saturn-class radios would calibrate the dial but the
 /// NCO phase-word at <c>line 951</c> would still drift.
 /// </summary>
@@ -26,7 +26,7 @@ public class FrequencyCorrectionTests
     {
         var client = NewClient();
         client.SetFrequencyCorrectionFactor(1.0);
-        client.SetVfoAHz(14_250_000);
+        client.SetFreqs(14_250_000, 14_250_000);
         Assert.Equal((uint)14_250_000, client.CorrectedRxFreqHzForTesting);
     }
 
@@ -36,7 +36,7 @@ public class FrequencyCorrectionTests
         var client = NewClient();
         Assert.Equal(1.0, client.FrequencyCorrectionFactor);
 
-        client.SetVfoAHz(7_100_000);
+        client.SetFreqs(7_100_000, 7_100_000);
         Assert.Equal((uint)7_100_000, client.CorrectedRxFreqHzForTesting);
     }
 
@@ -45,7 +45,7 @@ public class FrequencyCorrectionTests
     {
         var client = NewClient();
         client.SetFrequencyCorrectionFactor(1.000001);
-        client.SetVfoAHz(10_000_000);
+        client.SetFreqs(10_000_000, 10_000_000);
         Assert.Equal((uint)10_000_010, client.CorrectedRxFreqHzForTesting);
     }
 
@@ -54,7 +54,7 @@ public class FrequencyCorrectionTests
     {
         var client = NewClient();
         client.SetFrequencyCorrectionFactor(0.999999);
-        client.SetVfoAHz(10_000_000);
+        client.SetFreqs(10_000_000, 10_000_000);
         Assert.Equal((uint)9_999_990, client.CorrectedRxFreqHzForTesting);
     }
 
@@ -67,13 +67,13 @@ public class FrequencyCorrectionTests
         // +1 Hz per MHz at cardinal HF anchors. Inputs chosen so the
         // mathematical product isn't a half-integer — keeps the result
         // robust against double-precision rounding direction.
-        client.SetVfoAHz(1_000_000);
+        client.SetFreqs(1_000_000, 1_000_000);
         Assert.Equal((uint)1_000_001, client.CorrectedRxFreqHzForTesting);
 
-        client.SetVfoAHz(14_250_000);
+        client.SetFreqs(14_250_000, 14_250_000);
         Assert.Equal((uint)14_250_014, client.CorrectedRxFreqHzForTesting);
 
-        client.SetVfoAHz(50_000_000);
+        client.SetFreqs(50_000_000, 50_000_000);
         Assert.Equal((uint)50_000_050, client.CorrectedRxFreqHzForTesting);
     }
 
@@ -82,14 +82,14 @@ public class FrequencyCorrectionTests
     {
         var client = NewClient();
         client.SetFrequencyCorrectionFactor(1.0);
-        client.SetVfoAHz(14_250_000);
+        client.SetFreqs(14_250_000, 14_250_000);
         Assert.Equal((uint)14_250_000, client.CorrectedRxFreqHzForTesting);
 
         client.SetFrequencyCorrectionFactor(1.000001);
         // _rxFreqHz unchanged — RadioService is responsible for the re-tune.
         Assert.Equal((uint)14_250_000, client.CorrectedRxFreqHzForTesting);
 
-        client.SetVfoAHz(14_250_000);
+        client.SetFreqs(14_250_000, 14_250_000);
         Assert.Equal((uint)14_250_014, client.CorrectedRxFreqHzForTesting);
     }
 }

--- a/tests/Zeus.Server.Tests/RadioServiceRitXitTests.cs
+++ b/tests/Zeus.Server.Tests/RadioServiceRitXitTests.cs
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Simone Fabris (IU3QEZ), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public sealed class RadioServiceRitXitTests : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly PaSettingsStore _paStore;
+    private readonly DspSettingsStore _dspStore;
+
+    public RadioServiceRitXitTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"zeus-prefs-rit-{Guid.NewGuid():N}.db");
+        _paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, _dbPath + ".pa");
+        _dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance, _dbPath + ".dsp");
+    }
+
+    public void Dispose()
+    {
+        _paStore.Dispose();
+        _dspStore.Dispose();
+        foreach (var suffix in new[] { "", ".pa", ".dsp" })
+        {
+            try { if (File.Exists(_dbPath + suffix)) File.Delete(_dbPath + suffix); } catch { }
+        }
+    }
+
+    private RadioService BuildRadio() =>
+        new RadioService(NullLoggerFactory.Instance, _dspStore, _paStore);
+
+    // ---- Basic state transitions ----
+
+    [Fact]
+    public void SetIncrementalTuning_Rit_SetsMode()
+    {
+        using var radio = BuildRadio();
+        var snap = radio.SetIncrementalTuning(IncrementalTuningMode.Rit, 250);
+        Assert.Equal(IncrementalTuningMode.Rit, snap.ItMode);
+        Assert.Equal(250, snap.RitOffsetHz);
+    }
+
+    [Fact]
+    public void SetIncrementalTuning_Xit_SetsMode()
+    {
+        using var radio = BuildRadio();
+        var snap = radio.SetIncrementalTuning(IncrementalTuningMode.Xit, -300);
+        Assert.Equal(IncrementalTuningMode.Xit, snap.ItMode);
+        Assert.Equal(-300, snap.XitOffsetHz);
+    }
+
+    [Fact]
+    public void SetIncrementalTuning_Off_PreservesOffsets()
+    {
+        using var radio = BuildRadio();
+        radio.SetIncrementalTuning(IncrementalTuningMode.Rit, 250);
+        var snap = radio.SetIncrementalTuning(IncrementalTuningMode.Off, 0);
+        Assert.Equal(IncrementalTuningMode.Off, snap.ItMode);
+        Assert.Equal(250, snap.RitOffsetHz);
+    }
+
+    // ---- clear flag zeroes only the departing mode ----
+
+    [Fact]
+    public void Clear_From_Rit_ZerosRitOnly()
+    {
+        using var radio = BuildRadio();
+        radio.SetIncrementalTuning(IncrementalTuningMode.Rit, 250);
+        radio.SetIncrementalTuning(IncrementalTuningMode.Xit, -300);
+        radio.SetIncrementalTuning(IncrementalTuningMode.Rit, 250);
+        var snap = radio.SetIncrementalTuning(IncrementalTuningMode.Off, 0, clear: true);
+        Assert.Equal(IncrementalTuningMode.Off, snap.ItMode);
+        Assert.Equal(0, snap.RitOffsetHz);
+        Assert.Equal(-300, snap.XitOffsetHz);
+    }
+
+    [Fact]
+    public void Clear_From_Xit_ZerosXitOnly()
+    {
+        using var radio = BuildRadio();
+        radio.SetIncrementalTuning(IncrementalTuningMode.Xit, -300);
+        var snap = radio.SetIncrementalTuning(IncrementalTuningMode.Off, 0, clear: true);
+        Assert.Equal(IncrementalTuningMode.Off, snap.ItMode);
+        Assert.Equal(0, snap.XitOffsetHz);
+    }
+
+    // ---- Cycle preserves both offsets ----
+
+    [Fact]
+    public void Cycle_Rit_Xit_Off_Rit_PreservesOffsets()
+    {
+        using var radio = BuildRadio();
+        radio.SetIncrementalTuning(IncrementalTuningMode.Rit, 250);
+        radio.SetIncrementalTuning(IncrementalTuningMode.Xit, -300);
+        radio.SetIncrementalTuning(IncrementalTuningMode.Off, 0);
+        var snap = radio.SetIncrementalTuning(IncrementalTuningMode.Rit, 250);
+        Assert.Equal(250, snap.RitOffsetHz);
+        Assert.Equal(-300, snap.XitOffsetHz);
+    }
+
+    // ---- Clamp ----
+
+    [Fact]
+    public void SetIncrementalTuning_ClampsToMaxOffset()
+    {
+        using var radio = BuildRadio();
+        var snap = radio.SetIncrementalTuning(IncrementalTuningMode.Rit, 50_000);
+        Assert.Equal(3000, snap.RitOffsetHz);
+    }
+
+    [Fact]
+    public void SetIncrementalTuning_ClampsNegative()
+    {
+        using var radio = BuildRadio();
+        var snap = radio.SetIncrementalTuning(IncrementalTuningMode.Xit, -50_000);
+        Assert.Equal(-3000, snap.XitOffsetHz);
+    }
+
+    // ---- Auto-clear on mode change ----
+
+    [Fact]
+    public void ModeChange_ClearsIncrementalTuning()
+    {
+        using var radio = BuildRadio();
+        radio.SetIncrementalTuning(IncrementalTuningMode.Rit, 250);
+        var snap = radio.SetMode(RxMode.CWU);
+        Assert.Equal(IncrementalTuningMode.Off, snap.ItMode);
+        Assert.Equal(0, snap.RitOffsetHz);
+        Assert.Equal(0, snap.XitOffsetHz);
+    }
+
+    // ---- Auto-clear on band change (via SetVfo crossing band edge) ----
+
+    [Fact]
+    public void BandChange_ClearsIncrementalTuning()
+    {
+        using var radio = BuildRadio();
+        radio.SetVfo(14_074_000); // 20m
+        radio.SetIncrementalTuning(IncrementalTuningMode.Rit, 250);
+        var snap = radio.SetVfo(7_074_000); // 40m — band changed
+        Assert.Equal(IncrementalTuningMode.Off, snap.ItMode);
+        Assert.Equal(0, snap.RitOffsetHz);
+        Assert.Equal(0, snap.XitOffsetHz);
+    }
+
+    [Fact]
+    public void SameBandTune_PreservesIncrementalTuning()
+    {
+        using var radio = BuildRadio();
+        radio.SetVfo(14_074_000);
+        radio.SetIncrementalTuning(IncrementalTuningMode.Rit, 250);
+        var snap = radio.SetVfo(14_076_000); // same band
+        Assert.Equal(IncrementalTuningMode.Rit, snap.ItMode);
+        Assert.Equal(250, snap.RitOffsetHz);
+    }
+
+    // ---- Auto-clear on disconnect ----
+
+    [Fact]
+    public async Task Disconnect_ClearsIncrementalTuning()
+    {
+        using var radio = BuildRadio();
+        radio.SetIncrementalTuning(IncrementalTuningMode.Rit, 250);
+        var snap = await radio.DisconnectAsync();
+        Assert.Equal(IncrementalTuningMode.Off, snap.ItMode);
+        Assert.Equal(0, snap.RitOffsetHz);
+        Assert.Equal(0, snap.XitOffsetHz);
+    }
+}

--- a/tests/Zeus.Server.Tests/RitXitMathTests.cs
+++ b/tests/Zeus.Server.Tests/RitXitMathTests.cs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Simone Fabris (IU3QEZ), and contributors.
+
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class RitXitMathTests
+{
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(2000, 2000)]
+    [InlineData(-2000, -2000)]
+    [InlineData(3000, 3000)]
+    [InlineData(-3000, -3000)]
+    [InlineData(3001, 3000)]
+    [InlineData(-3001, -3000)]
+    [InlineData(50000, 3000)]
+    [InlineData(-50000, -3000)]
+    public void ClampOffset_clamps_to_max(int input, int expected)
+    {
+        Assert.Equal(expected, RitXitMath.ClampOffset(input));
+    }
+
+    [Theory]
+    [InlineData(2800, 10)]
+    [InlineData(500, 10)]
+    [InlineData(251, 10)]
+    [InlineData(250, 5)]
+    [InlineData(200, 5)]
+    [InlineData(100, 5)]
+    [InlineData(50, 5)]
+    public void FilterAwareStepHz_returns_5_for_narrow_filters(int bwHz, int expected)
+    {
+        Assert.Equal(expected, RitXitMath.FilterAwareStepHz(bwHz));
+    }
+
+    [Fact]
+    public void WireFreqs_Rit_shifts_rx_leaves_tx()
+    {
+        var (rx, tx) = RitXitMath.WireFreqs(
+            RxMode.CWU, 14_050_000,
+            IncrementalTuningMode.Rit, 250, 0);
+
+        Assert.Equal(CwOffset.EffectiveLoHz(RxMode.CWU, 14_050_250), rx);
+        Assert.Equal(CwOffset.EffectiveLoHz(RxMode.CWU, 14_050_000), tx);
+    }
+
+    [Fact]
+    public void WireFreqs_Xit_shifts_tx_leaves_rx()
+    {
+        var (rx, tx) = RitXitMath.WireFreqs(
+            RxMode.CWU, 14_050_000,
+            IncrementalTuningMode.Xit, 0, -300);
+
+        Assert.Equal(CwOffset.EffectiveLoHz(RxMode.CWU, 14_050_000), rx);
+        Assert.Equal(CwOffset.EffectiveLoHz(RxMode.CWU, 14_049_700), tx);
+    }
+
+    [Fact]
+    public void WireFreqs_Off_both_equal()
+    {
+        var (rx, tx) = RitXitMath.WireFreqs(
+            RxMode.USB, 7_050_000,
+            IncrementalTuningMode.Off, 500, -200);
+
+        long expected = CwOffset.EffectiveLoHz(RxMode.USB, 7_050_000);
+        Assert.Equal(expected, rx);
+        Assert.Equal(expected, tx);
+    }
+
+    [Fact]
+    public void WireFreqs_non_CW_mode_passes_through()
+    {
+        var (rx, tx) = RitXitMath.WireFreqs(
+            RxMode.USB, 14_200_000,
+            IncrementalTuningMode.Rit, 1000, 0);
+
+        Assert.Equal(14_201_000, rx);
+        Assert.Equal(14_200_000, tx);
+    }
+}

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -54,6 +54,7 @@ import { AudioToggle } from './components/AudioToggle';
 import { BandFavorites } from './components/toolbar/BandFavorites';
 import { ConnectPanel } from './components/ConnectPanel';
 import { FilterPanel } from './components/filter/FilterPanel';
+import { IncrementalTuningButton } from './components/IncrementalTuningButton';
 import { LeftLayoutBar } from './components/LeftLayoutBar';
 import { MicMeter } from './components/MicMeter';
 import { ModeFavorites } from './components/toolbar/ModeFavorites';
@@ -767,7 +768,7 @@ export default function App() {
         <MicMeter />
         <div className="transport-sep hide-mobile" />
         <button type="button" className="btn ghost hide-mobile">SPLIT</button>
-        <button type="button" className="btn ghost hide-mobile">RIT</button>
+        <IncrementalTuningButton />
         <button type="button" className="btn ghost hide-mobile">SAVE MEM</button>
         <div className="spacer" style={{ flex: 1 }} />
         <PaTempChip />

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -234,6 +234,11 @@ export type RadioStateDto = {
   // CW sidetone pitch in Hz. Today a baked-in constant (600); exposed so
   // the frontend doesn't duplicate it. Will become configurable later.
   cwPitchHz: number;
+  // Incremental tuning (RIT/XIT). Runtime-only, auto-cleared on band/mode
+  // change and disconnect. itMode is 'Off'|'Rit'|'Xit'.
+  itMode: 'Off' | 'Rit' | 'Xit';
+  ritOffsetHz: number;
+  xitOffsetHz: number;
 };
 
 // CFC mirrors Zeus.Contracts.CfcConfig. Bands array is fixed at 10 entries
@@ -352,6 +357,21 @@ export function normalizeMode(v: unknown): RxMode {
     return MODE_ORDER[v] ?? 'USB';
   }
   return 'USB';
+}
+
+export type IncrementalTuningMode = 'Off' | 'Rit' | 'Xit';
+const IT_MODES: readonly IncrementalTuningMode[] = ['Off', 'Rit', 'Xit'];
+
+export function normalizeItMode(v: unknown): IncrementalTuningMode {
+  if (typeof v === 'string') {
+    return (IT_MODES as readonly string[]).includes(v)
+      ? (v as IncrementalTuningMode)
+      : 'Off';
+  }
+  if (typeof v === 'number' && Number.isInteger(v)) {
+    return IT_MODES[v] ?? 'Off';
+  }
+  return 'Off';
 }
 
 export function normalizeNrMode(v: unknown): NrMode {
@@ -503,6 +523,9 @@ export function normalizeState(raw: unknown): RadioStateDto {
         ? r.vfoHz
         : 0,
     cwPitchHz: typeof r.cwPitchHz === 'number' ? r.cwPitchHz : 600,
+    itMode: normalizeItMode(r.itMode),
+    ritOffsetHz: typeof r.ritOffsetHz === 'number' ? r.ritOffsetHz : 0,
+    xitOffsetHz: typeof r.xitOffsetHz === 'number' ? r.xitOffsetHz : 0,
   };
 }
 
@@ -684,6 +707,24 @@ export function setRadioLo(
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ hz }),
+      signal,
+    },
+    normalizeState,
+  );
+}
+
+export function setIncrementalTuning(
+  mode: IncrementalTuningMode,
+  offsetHz: number,
+  clear?: boolean,
+  signal?: AbortSignal,
+): Promise<RadioStateDto> {
+  return jsonFetch(
+    '/api/rx/incremental-tuning',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ mode: IT_MODES.indexOf(mode), offsetHz, clear: clear ?? false }),
       signal,
     },
     normalizeState,

--- a/zeus-web/src/components/IncrementalTuningButton.tsx
+++ b/zeus-web/src/components/IncrementalTuningButton.tsx
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Simone Fabris (IU3QEZ), and contributors.
+
+import { useCallback } from 'react';
+import {
+  setIncrementalTuning,
+  type IncrementalTuningMode,
+} from '../api/client';
+import { useConnectionStore } from '../state/connection-store';
+
+const CYCLE: IncrementalTuningMode[] = ['Off', 'Rit', 'Xit'];
+
+export function IncrementalTuningButton() {
+  const itMode = useConnectionStore((s) => s.itMode);
+  const ritOffsetHz = useConnectionStore((s) => s.ritOffsetHz);
+  const xitOffsetHz = useConnectionStore((s) => s.xitOffsetHz);
+  const applyState = useConnectionStore((s) => s.applyState);
+
+  const cycle = useCallback(() => {
+    const idx = CYCLE.indexOf(itMode);
+    const next = CYCLE[(idx + 1) % CYCLE.length] ?? 'Off';
+    const offset =
+      next === 'Rit' ? ritOffsetHz : next === 'Xit' ? xitOffsetHz : 0;
+    setIncrementalTuning(next, offset).then(applyState).catch(() => {});
+  }, [itMode, ritOffsetHz, xitOffsetHz, applyState]);
+
+  const active = itMode !== 'Off';
+  const label = active ? itMode.toUpperCase() : 'RIT/XIT';
+
+  return (
+    <button
+      type="button"
+      className={`btn ghost hide-mobile${active ? ' accent' : ''}`}
+      onClick={cycle}
+      title="Cycle: Off → RIT → XIT → Off"
+    >
+      <span className={`led${active ? ' on' : ''}`} style={{ marginRight: 6 }} />
+      {label}
+    </button>
+  );
+}

--- a/zeus-web/src/components/Panadapter.tsx
+++ b/zeus-web/src/components/Panadapter.tsx
@@ -52,6 +52,7 @@ import { useTxStore } from '../state/tx-store';
 import { usePanTuneGesture } from '../util/use-pan-tune-gesture';
 import { FreqAxis } from './FreqAxis';
 import { PassbandOverlay } from './PassbandOverlay';
+import { RitXitMarker } from './RitXitMarker';
 import { DbScale } from './DbScale';
 
 export function Panadapter() {
@@ -263,6 +264,7 @@ export function Panadapter() {
     >
       <canvas ref={canvasRef} style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }} />
       <PassbandOverlay />
+      <RitXitMarker />
       <FreqAxis />
       <DbScale />
     </div>

--- a/zeus-web/src/components/RitXitMarker.tsx
+++ b/zeus-web/src/components/RitXitMarker.tsx
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Simone Fabris (IU3QEZ), and contributors.
+
+import { useDisplayStore } from '../state/display-store';
+import { useConnectionStore } from '../state/connection-store';
+
+export function RitXitMarker() {
+  const centerHz = useDisplayStore((s) => s.centerHz);
+  const hzPerPixel = useDisplayStore((s) => s.hzPerPixel);
+  const width = useDisplayStore((s) => s.panDb?.length ?? 0);
+  const vfoHz = useConnectionStore((s) => s.vfoHz);
+  const itMode = useConnectionStore((s) => s.itMode);
+  const ritOffsetHz = useConnectionStore((s) => s.ritOffsetHz);
+  const xitOffsetHz = useConnectionStore((s) => s.xitOffsetHz);
+
+  if (itMode === 'Off' || !width || hzPerPixel <= 0) return null;
+
+  const offsetHz = itMode === 'Rit' ? ritOffsetHz : xitOffsetHz;
+  if (offsetHz === 0) return null;
+
+  const label = itMode === 'Rit' ? 'RX' : 'TX';
+  const markerHz = vfoHz + offsetHz;
+
+  const spanHz = width * hzPerPixel;
+  const center = Number(centerHz);
+  const startHz = center - spanHz / 2;
+  const pct = ((markerHz - startHz) / spanHz) * 100;
+
+  if (pct < 0 || pct > 100) return null;
+
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none absolute inset-y-0 z-[15] -translate-x-1/2"
+      style={{ left: `${pct}%`, width: 2, background: 'var(--tx)', opacity: 0.85 }}
+    >
+      <span
+        style={{
+          position: 'absolute',
+          top: 22,
+          left: '50%',
+          transform: 'translateX(-50%)',
+          fontSize: '9px',
+          fontWeight: 700,
+          fontFamily: 'var(--font-mono, monospace)',
+          color: 'var(--tx)',
+          background: 'rgba(0,0,0,0.7)',
+          padding: '1px 3px',
+          borderRadius: 2,
+          whiteSpace: 'nowrap',
+          lineHeight: 1,
+        }}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}

--- a/zeus-web/src/components/RitXitOffsetRow.tsx
+++ b/zeus-web/src/components/RitXitOffsetRow.tsx
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Simone Fabris (IU3QEZ), and contributors.
+
+import { useCallback, useRef } from 'react';
+import {
+  setIncrementalTuning,
+  type IncrementalTuningMode,
+} from '../api/client';
+import { useConnectionStore } from '../state/connection-store';
+
+const DEBOUNCE_MS = 100;
+
+function filterAwareStep(bwHz: number): number {
+  return bwHz <= 250 ? 5 : 10;
+}
+
+export function RitXitOffsetRow() {
+  const itMode = useConnectionStore((s) => s.itMode);
+  const ritOffsetHz = useConnectionStore((s) => s.ritOffsetHz);
+  const xitOffsetHz = useConnectionStore((s) => s.xitOffsetHz);
+  const applyState = useConnectionStore((s) => s.applyState);
+
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const post = useCallback(
+    (mode: IncrementalTuningMode, newOffset: number) => {
+      if (timer.current != null) clearTimeout(timer.current);
+      timer.current = setTimeout(() => {
+        timer.current = null;
+        setIncrementalTuning(mode, newOffset)
+          .then(applyState)
+          .catch(() => {});
+      }, DEBOUNCE_MS);
+    },
+    [applyState],
+  );
+
+  const nudge = useCallback(
+    (dir: 1 | -1) => {
+      const s = useConnectionStore.getState();
+      const mode = s.itMode;
+      const curOffset = mode === 'Rit' ? s.ritOffsetHz : s.xitOffsetHz;
+      const bw = Math.abs(s.filterHighHz - s.filterLowHz);
+      const stp = filterAwareStep(bw);
+      const next = Math.max(-3000, Math.min(3000, curOffset + dir * stp));
+      useConnectionStore.setState(
+        mode === 'Rit' ? { ritOffsetHz: next } : { xitOffsetHz: next },
+      );
+      post(mode, next);
+    },
+    [post],
+  );
+
+  const clear = useCallback(() => {
+    setIncrementalTuning('Off', 0, true).then(applyState).catch(() => {});
+  }, [applyState]);
+
+  if (itMode === 'Off') return null;
+
+  const offset = itMode === 'Rit' ? ritOffsetHz : xitOffsetHz;
+  const { filterLowHz, filterHighHz } = useConnectionStore.getState();
+  const bw = Math.abs(filterHighHz - filterLowHz);
+  const step = filterAwareStep(bw);
+  const sign = offset >= 0 ? '+' : '';
+
+  return (
+    <div
+      className="freq-bot mono"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 6,
+        marginTop: 2,
+        fontSize: '0.8rem',
+        color: 'var(--fg-1)',
+      }}
+    >
+      <span
+        style={{ color: 'var(--accent)', fontWeight: 700, minWidth: 24 }}
+      >
+        {itMode.toUpperCase()}
+      </span>
+      <button
+        type="button"
+        className="btn ghost"
+        style={{ padding: '0 4px', fontSize: '0.75rem', lineHeight: 1 }}
+        onClick={() => nudge(-1)}
+        title={`−${step} Hz`}
+      >
+        ▼
+      </button>
+      <span style={{ minWidth: 60, textAlign: 'center' }}>
+        {sign}{offset} Hz
+      </span>
+      <button
+        type="button"
+        className="btn ghost"
+        style={{ padding: '0 4px', fontSize: '0.75rem', lineHeight: 1 }}
+        onClick={() => nudge(1)}
+        title={`+${step} Hz`}
+      >
+        ▲
+      </button>
+      <button
+        type="button"
+        className="btn ghost"
+        style={{ padding: '0 4px', fontSize: '0.7rem' }}
+        onClick={clear}
+        title="Clear offset and turn off"
+      >
+        Clr
+      </button>
+    </div>
+  );
+}

--- a/zeus-web/src/components/VfoDisplay.tsx
+++ b/zeus-web/src/components/VfoDisplay.tsx
@@ -53,6 +53,7 @@ import {
 } from 'react';
 import { fetchState, setVfo } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import { RitXitOffsetRow } from './RitXitOffsetRow';
 
 const MAX_HZ = 60_000_000;
 const STATE_POLL_MS = 2000;
@@ -312,6 +313,7 @@ export function VfoDisplay() {
       <div className="freq-bot" style={{ justifyContent: 'flex-end', gap: 6, marginTop: 4 }}>
         <span className="label-xs">MHz · click to type · wheel on a digit to step</span>
       </div>
+      <RitXitOffsetRow />
     </div>
   );
 }

--- a/zeus-web/src/state/connection-store.ts
+++ b/zeus-web/src/state/connection-store.ts
@@ -79,6 +79,9 @@ export type ConnectionState = {
   autoAttEnabled: boolean;
   attOffsetDb: number;
   adcOverloadWarning: boolean;
+  itMode: 'Off' | 'Rit' | 'Xit';
+  ritOffsetHz: number;
+  xitOffsetHz: number;
   // Board kind only known from the discovery list at connect time — StateDto
   // doesn't echo it. Null after a page reload while already connected; the
   // preamp guard treats null as "show", which is the safe default (an HL2
@@ -135,6 +138,9 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
   autoAttEnabled: true,
   attOffsetDb: 0,
   adcOverloadWarning: false,
+  itMode: 'Off',
+  ritOffsetHz: 0,
+  xitOffsetHz: 0,
   boardId: null,
   connectedProtocol: null,
   preampOn: false,
@@ -167,6 +173,9 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
       autoAttEnabled: s.autoAttEnabled,
       attOffsetDb: s.attOffsetDb,
       adcOverloadWarning: s.adcOverloadWarning,
+      itMode: s.itMode,
+      ritOffsetHz: s.ritOffsetHz,
+      xitOffsetHz: s.xitOffsetHz,
       nr: s.nr,
       zoomLevel: s.zoomLevel,
     }),


### PR DESCRIPTION
## ⚠️ Dogfood — not merge-ready

Needs validation before merge:

- **P1 untested.** Wire path (`ActiveClient.SetFreqs`) is structurally correct but not validated on P1 hardware (Hermes, ANAN-class). WDSP `SetVfoHz` fix verified on P2 (HL2) only.
- **Pre-existing display bugs surfaced during testing.** CWU↔CWL mode transition causes panadapter jump; FilterMiniPan passband walls are misaligned with spectrum in CW modes (#429). Neither introduced by this PR.
- **Zero Beat interaction.** Zero Beat was reverted from develop (#510) due to operator-reported issues. This PR's `RxFreqAHz + TxFreqAHz` wire split is the substrate Zero Beat needs — the two features should be tested together before upstream merge.

## Summary

Full RIT/XIT incremental tuning — server state machine, protocol wire layer, WDSP integration, frontend UI, and panadapter visualization.

**Wire-layer split:** `CcState.VfoAHz` → `RxFreqAHz` + `TxFreqAHz`. `WriteCcBytes` routes `TxFreq` (0x02) to `TxFreqAHz` and all 4 RX registers to `RxFreqAHz`. `SetVfoAHz(long)` → `SetFreqs(long rxHz, long txHz)` on both protocol clients.

**Server state machine:** `IncrementalTuningMode` enum (Off/Rit/Xit), `SetIncrementalTuning(mode, offsetHz, clear)` on `RadioService`. Auto-clear on band change, mode change, and disconnect. Cycle preserves offsets; `clear` flag (Clr button) zeros only the departing mode's offset.

**WDSP integration (P2):** `DspPipelineService` Tick loop (30 Hz) and channel-init feed `RitXitMath.WireFreqs` to `engine.SetVfoHz` so WDSP demodulates at the RIT-shifted centre. `centerHz` in the display frame follows `rxWire` so panadapter and audio stay in the same coordinate frame.

**`RitXitMath.WireFreqs`:** shared pure function used by `RadioService.PushWireFreqs` (P1), `DspPipelineService` (P2 + display), and channel-init. Single source of truth for the wire-frequency formula.

**REST endpoint:** `POST /api/rx/incremental-tuning { mode, offsetHz, clear }`, replace semantics, silent clamp to ±3000 Hz.

**Frontend:** cycle button with green LED (Off→RIT→XIT→Off), offset sub-row under VFO with ▲/▼ filter-aware spinners + Clr, red "RX"/"TX" marker on panadapter.

Relates to #96 (Split VFO) — the `RxFreqAHz` + `TxFreqAHz` wire rename is the substrate that SPLIT will build on.

## Test results

| Suite | Passed | Skipped | Failed |
|-------|--------|---------|--------|
| Zeus.Server.Tests | 742 | 6 | 0 |
| Zeus.Protocol1.Tests | 210 | 1 | 0 |
| Zeus.Protocol2.Tests | 101 | 0 | 0 |
| Zeus.Contracts.Tests | 84 | 0 | 0 |
| Zeus.Plugins.Host.Tests | 79 | 5 | 0 |
| Zeus.Plugins.Contracts.Tests | 11 | 0 | 0 |
| Zeus.Dsp.Tests | 152 | 96 | 0 |
| **Frontend (Vitest)** | **229** | 0 | 0 |
| `tsc --noEmit` | clean | | |

**On-air P2 (HL2):** RIT engage/disengage, nudge ±3000 Hz, auto-clear on band/mode change, audio tracks correctly at all offsets. Verified by IU3QEZ.

**P1: not tested** — needs validation on Hermes/ANAN hardware.

## Known pre-existing issues surfaced during testing

1. **FilterMiniPan misalignment (#429)** — passband walls don't match spectrum position in CW modes, with or without RIT.
2. **CWU↔CWL display jump** — panadapter jumps on mode transition due to `DialBumpForModeTransition` changing `RadioLoHz`.

## What's next

1. P1 on-air validation (contributor with ANAN/Hermes hardware)
2. Re-land Zero Beat on top of this wire split
3. FilterMiniPan CW alignment fix (#429, separate PR)