### PR TITLE
fix(ci): bundle FFTW dylibs in the macOS .app (zeus-421)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -371,12 +371,39 @@ jobs:
             exit 1
           fi
 
-      - name: Stage dylib
+      - name: Stage dylib + bundled FFTW
         run: |
           set -eux
           destDir="staged/osx-arm64"
           mkdir -p "$destDir"
           cp native/build/libwdsp.dylib "$destDir/libwdsp.dylib"
+
+          # Bundle both FFTW precisions alongside libwdsp so the .app is
+          # self-contained on any Mac without Homebrew FFTW installed —
+          # mirrors what the Linux job already does for libfftw3.so.3.
+          fftw_lib="$(brew --prefix fftw)/lib"
+          cp "${fftw_lib}/libfftw3.3.dylib"  "$destDir/libfftw3.3.dylib"
+          cp "${fftw_lib}/libfftw3f.3.dylib" "$destDir/libfftw3f.3.dylib"
+
+          # Rewrite the absolute Homebrew LC_LOAD_DYLIB paths baked into
+          # libwdsp.dylib by the CI runner to @loader_path so the dylib
+          # resolves its FFTW deps relative to its own location, independent
+          # of DYLD_LIBRARY_PATH. Belt-and-suspenders alongside launch.sh's
+          # DYLD_LIBRARY_PATH export.
+          install_name_tool \
+            -change "${fftw_lib}/libfftw3.3.dylib"  @loader_path/libfftw3.3.dylib \
+            -change "${fftw_lib}/libfftw3f.3.dylib" @loader_path/libfftw3f.3.dylib \
+            "$destDir/libwdsp.dylib"
+
+          # Fail the build if any Homebrew absolute path survives — a leftover
+          # would ship a bundle broken on Macs without Homebrew FFTW installed.
+          if otool -L "$destDir/libwdsp.dylib" | grep -q '/opt/homebrew'; then
+            echo "ERROR: Homebrew absolute paths still present after install_name_tool rewrite"
+            otool -L "$destDir/libwdsp.dylib"
+            exit 1
+          fi
+          otool -L "$destDir/libwdsp.dylib"
+          ls -la "$destDir/"
 
       # ---------- miniaudio (desktop-mode RX sink + TX mic capture) -------
       #
@@ -395,7 +422,10 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          # Staged dir now contains libwdsp.dylib + libminiaudio.dylib.
+          # Staged dir now contains libwdsp.dylib + libfftw3.3.dylib +
+          # libfftw3f.3.dylib + libminiaudio.dylib. The downstream
+          # `download-artifact` extracts the whole directory into
+          # Zeus.Dsp/runtimes/osx-arm64/native/.
           name: wdsp-native-osx-arm64
           path: staged/osx-arm64/
 


### PR DESCRIPTION
## Problem

The macOS DMG crashes on **Connect** with a `DllNotFoundException` for `libwdsp.dylib` on any Mac that doesn't already have Homebrew FFTW installed — i.e. every normal end-user install. Reported on #421 by @M9KGS, with matching crash traces from Ian and ZigmundRat.

Root cause (confirmed from the workflow + the crash trace): the macOS "Stage dylib" step copied **only** `libwdsp.dylib`. That dylib has `/opt/homebrew/opt/fftw/lib/libfftw3.3.dylib` baked in as a hard `LC_LOAD_DYLIB` path by the CI runner, so dyld can't resolve it on a clean Mac:

```
Library not loaded: /opt/homebrew/opt/fftw/lib/libfftw3.3.dylib
  Referenced from: .../runtimes/osx-arm64/native/libwdsp.dylib
  Reason: tried: '.../runtimes/osx-arm64/native/libfftw3.3.dylib' (no such file)
```

The Linux job has bundled FFTW (`libfftw3.so.3` / `libfftw3f.so.3`) since day one; the macOS job never got the equivalent step. This still affects every shipped macOS DMG — develop's macOS staging has no FFTW bundling.

## Fix — `release.yml` only, no Zeus source changes

- Stage **both** FFTW precisions (`libfftw3.3.dylib` + `libfftw3f.3.dylib`) alongside `libwdsp.dylib`.
- Rewrite the absolute Homebrew `LC_LOAD_DYLIB` paths to `@loader_path` via `install_name_tool`, so the dylib resolves its FFTW deps relative to its own location independent of `DYLD_LIBRARY_PATH` (belt-and-suspenders alongside `launch.sh`'s export).
- **Guard:** the build fails if any `/opt/homebrew` path survives the rewrite, so a broken bundle can't ship silently again.

`create-macos-app.sh` already codesigns every `*.dylib` under the bundle, so the new FFTW dylibs are signed automatically — no other file changes.

## Provenance

Root-caused and drafted by @kb2uka-agent on #421 (branch `agent/issue-421`, commit `f01a51b`). Applied here manually by the maintainer rather than granting the App `workflows` write — same diff, no standing escalation of the App's CI access given the macOS signing/App-Store secrets reachable from this workflow.

## Test notes

CI-only change; can't be exercised by the local test suite. Verification is the release run itself: the new `otool -L` / `ls -la` output in the "Stage dylib + bundled FFTW" step should show no `/opt/homebrew` paths and all three dylibs staged. Worth a clean-Mac (no Homebrew FFTW) Connect smoke-test on the resulting DMG before the next release ships.

Relates to #421 (leave open until the fix ships in a release per release-hygiene).