### PR TITLE
chore(agent): stop the agent escalating for `workflows` permission

### DIFF
--- a/.github/workflows/kb2uka-agent.yml
+++ b/.github/workflows/kb2uka-agent.yml
@@ -186,8 +186,17 @@ jobs:
             ## Rules (hard)
 
             - **Never push directly to `develop` or `main`.** Always go through a PR.
-            - **Never edit `.github/workflows/*.yml`.** The App doesn't have
-              workflow write permission anyway — but don't try.
+            - **Never edit `.github/workflows/*.yml`, and never ask for the
+              `workflows` permission to be granted.** The App deliberately
+              lacks workflow-write scope — this is a fixed security boundary,
+              not a blocker to escalate. The repo's CI secrets include the
+              macOS / App Store signing keys, so the App must never be able to
+              rewrite the workflows that can read them. When a fix genuinely
+              requires a workflow change, do the full diagnosis and **post the
+              exact diff in your comment for a human to apply by hand**, then
+              carry on with any non-workflow parts you *can* do. Treat the
+              missing scope as permanent — never frame it as something KB2UKA
+              needs to fix or "unblock" for next time.
             - **Never mention Anthropic or Claude in commit messages** (CLAUDE.md hard rule).
             - **Never skip git hooks** (`--no-verify`) or bypass signing.
             - **Respect CLAUDE.md red-light items** — visual design, UX behavior,


### PR DESCRIPTION
On #421 the KB2UKA-Agent diagnosed a CI fix correctly but then stalled and asked for the GitHub App to be **granted `workflows` write** so it could push the change itself.

That scope is a deliberate, **permanent** security boundary, not a blocker to escalate: the repo's CI secrets include the macOS / App Store signing keys (`MACOS_CERTIFICATE`, `APPSTORE_API_KEY_P8`, `KEYCHAIN_PASSWORD`, …), and a workflow file is arbitrary code-execution with reach to those secrets. The App must never be able to rewrite the workflows that can read them — especially since it ingests untrusted public issue text.

The agent prompt already said *"never edit `.github/workflows/*.yml`"* but didn't say what to do **instead**, so it defaulted to "ask Doug to grant the permission." This reframes the rule: when a fix needs a workflow change, diagnose fully and **post the exact diff for a human to apply by hand**, then continue with any non-workflow parts. Never frame the missing scope as something to "unblock."

Prompt-only change to `kb2uka-agent.yml`. No behavior change to the build.