### PR TITLE
fix(discovery): reclassify ANAN-10E wire byte 0x06 + low code version as HermesII (#493)

### DIFF
--- a/Zeus.Protocol1/Discovery/ReplyParser.cs
+++ b/Zeus.Protocol1/Discovery/ReplyParser.cs
@@ -84,6 +84,16 @@ public static class ReplyParser
         var board = MapBoard(rawBoardId);
         var isHl2 = board == HpsdrBoardKind.HermesLite2 && codeVersion >= HermesLite2CodeVersionThreshold;
 
+        // Wire byte 0x06 is shared by genuine Hermes Lite 2 units AND by the
+        // Hermes-II / ANAN-10E firmware family (e.g. Hermes10E_v1.5.rbf).
+        // Genuine HL2 units always report code versions >= HermesLite2CodeVersionThreshold (40).
+        // A board that sent 0x06 with a version below that threshold is a Hermes-II / ANAN-10E;
+        // reclassify so downstream drive-model and calibration dispatch select the correct
+        // 8-bit full-byte profile instead of HL2's 4-bit nibble/percentage model.
+        // Issue #493: ANAN-10E with Hermes10E_v1.5.rbf sends byte 0x06, version 15.
+        if (!isHl2 && board == HpsdrBoardKind.HermesLite2)
+            board = HpsdrBoardKind.HermesII;
+
         var fixedIp = isHl2 && (hl2Flags & Hl2FixedIpBit) != 0;
         var fixedIpOverridesDhcp = isHl2 && (hl2Flags & (Hl2FixedIpBit | Hl2DhcpOverrideBit)) == (Hl2FixedIpBit | Hl2DhcpOverrideBit);
         var macModified = isHl2 && (hl2Flags & Hl2MacModifiedBit) != 0;

--- a/docs/rca/2026-05-25-anan10e-wire-0x06-reclassify.md
+++ b/docs/rca/2026-05-25-anan10e-wire-0x06-reclassify.md
@@ -1,0 +1,121 @@
+# RCA — ANAN-10E detected as Hermes Lite 2 in 0.8.3 (issue #493)
+
+**Date:** 2026-05-25  
+**Reported by:** Ronnie C (RonnieC82)  
+**Fixed in:** PR targeting `experimental`
+
+---
+
+## Symptom
+
+ANAN-10E with `Hermes10E_v1.5.rbf` firmware discovered and connected as **Hermes Lite 2**
+in Zeus 0.8.3-nightly. The PA drive model applied was the HL2 nibble/percentage model instead
+of the 8-bit byte model, producing incorrect TX power levels. The Discover list already showed
+"Hermes Lite 2" before Connect was clicked, confirming the mis-classification happened at
+discovery parse time, not during connect.
+
+Server log confirming the mis-classification:
+
+```
+radio.applyPsHwPeak proto=P1 board=HermesLite2 ...
+pa.recompute ... profile=HermesLite2 (%-scale, 4-bit) -> byte=96
+```
+
+---
+
+## Root Cause
+
+### Wire byte 0x06 is ambiguous
+
+The OpenHPSDR Protocol 1 discovery reply places the board-ID byte at offset 10.
+`Zeus.Protocol1/Discovery/ReplyParser.cs` maps byte `0x06` to
+`HpsdrBoardKind.HermesLite2` in `MapBoard()` -- correct per the protocol spec.
+
+However, `Hermes10E_v1.5.rbf` (Apache Labs ANAN-10E firmware) also reports byte `0x06`.
+This is a firmware quirk: the ANAN-10E uses a Hermes-II / Griffin derivative gateware that
+was tagged with board-ID 0x06 in some firmware versions rather than the expected 0x02 (HermesII).
+
+### The version-threshold guard was already present -- but incomplete
+
+The parser already contained a discriminator:
+
+```csharp
+// ReplyParser.cs:85
+var isHl2 = board == HpsdrBoardKind.HermesLite2 && codeVersion >= HermesLite2CodeVersionThreshold;
+//                                                                  ^^ threshold = 40
+```
+
+Genuine HL2 units always report code versions >= 40. The ANAN-10E reports version 15
+(`Hermes10E_v1.5.rbf`), so `isHl2` correctly evaluates to **false**.
+
+The bug: although `isHl2` was false, `board` was never corrected. It remained
+`HermesLite2` (from the raw `MapBoard` result) and that stale value flowed into
+`DiscoveredRadio.Board`, which is the source of truth for all downstream dispatch:
+PA drive profile, calibration tables, and log labels.
+
+---
+
+## Fix
+
+`Zeus.Protocol1/Discovery/ReplyParser.cs` -- one guard added immediately after `isHl2`:
+
+```csharp
+if (!isHl2 && board == HpsdrBoardKind.HermesLite2)
+    board = HpsdrBoardKind.HermesII;
+```
+
+If the raw wire byte was `0x06` but the code version is below the threshold (not a genuine HL2),
+reclassify `board` to `HermesII` (Hermes-II / ANAN-10E / 100B family). This causes downstream
+dispatch to select the correct 8-bit full-byte drive profile and the correct ANAN PA calibration table.
+
+`RawBoardId` in `DiscoveryDetails` continues to store the raw wire byte (`0x06`) for diagnostic
+purposes; the firmware string is formatted as `"1.5"` (not the HL2 `major.minor` format) because
+`isHl2` remains false.
+
+---
+
+## Tests
+
+`tests/Zeus.Protocol1.Tests/DiscoveryTests.cs`:
+
+- `WireByte_0x06_BelowHl2CodeThreshold_ReclassifiesAsHermesII` -- regression test:
+  version 15 + byte 0x06 -> `HermesII`, firmware string `"1.5"`, no HL2 extras.
+- `Maps_Every_Recognised_WireByte_To_BoardKind` -- updated: `0x06` InlineData now uses
+  code version 73 (>= 40) to continue asserting `HermesLite2` for genuine HL2 units;
+  method signature gains a `codeVersion` parameter.
+
+---
+
+## Why the previous fix (#294) did not cover this
+
+Issue #294 addressed the case where `RadioService.ConnectAsync` was not calling `SetBoardKind`
+on the fresh `Protocol1Client`, leaving the client's `_boardKind` at its `HermesLite2`
+constructor default even after a correctly-classified discovery. That fix ensured the discovered
+`Board` was propagated to the client at connect time.
+
+Issue #493 is upstream of that: the discovery parser itself was returning `HermesLite2` as
+`DiscoveredRadio.Board` for the ANAN-10E firmware variant. Once the parser returns the wrong
+board, there is nothing in the connect path to correct it -- the connect path trusts
+`DiscoveredRadio.Board` as the authoritative classification.
+
+---
+
+## Timeline
+
+| Date       | Event |
+|------------|-------|
+| 2026-05-24 | Ronnie reports issue #493 -- ANAN-10E shows as HL2 in 0.8.3-nightly |
+| 2026-05-25 | Log analysis confirms `board=HermesLite2` in `radio.applyPsHwPeak` |
+| 2026-05-25 | Ronnie reports `Hermes10E_v1.5.rbf` firmware version |
+| 2026-05-25 | Manual override confirmed working; code fix implemented |
+
+---
+
+## Prevention
+
+Any future firmware that reports byte `0x06` with code version < 40 will automatically be
+classified as `HermesII`. The version-threshold logic was already the right design; the single
+missing reassignment was the gap.
+
+If future ANAN hardware reports a genuinely new byte (e.g. a next-generation Apache board),
+add it to `MapBoard()` and `HpsdrBoardKind.cs` explicitly rather than reusing the HL2 byte.

--- a/tests/Zeus.Protocol1.Tests/DiscoveryTests.cs
+++ b/tests/Zeus.Protocol1.Tests/DiscoveryTests.cs
@@ -95,23 +95,25 @@ public class DiscoveryTests
     }
 
     [Theory]
-    [InlineData((byte)0x00, HpsdrBoardKind.Metis)]      // original HPSDR Mercury+Penelope+Metis
-    [InlineData((byte)0x01, HpsdrBoardKind.Hermes)]
-    [InlineData((byte)0x02, HpsdrBoardKind.HermesII)]    // ANAN-10E / 100B / Hermes-II firmware
-    [InlineData((byte)0x04, HpsdrBoardKind.Angelia)]    // ANAN-100D
-    [InlineData((byte)0x05, HpsdrBoardKind.Orion)]      // ANAN-200D
-    [InlineData((byte)0x06, HpsdrBoardKind.HermesLite2)]
-    [InlineData((byte)0x0A, HpsdrBoardKind.OrionMkII)]  // 0x0A alias family — see issue #218
-    [InlineData((byte)0x14, HpsdrBoardKind.HermesC10)]  // ANAN-G2E (N1GP firmware)
-    public void Maps_Every_Recognised_WireByte_To_BoardKind(byte boardId, HpsdrBoardKind expected)
+    [InlineData((byte)0x00, HpsdrBoardKind.Metis, (byte)31)]      // original HPSDR Mercury+Penelope+Metis
+    [InlineData((byte)0x01, HpsdrBoardKind.Hermes, (byte)31)]
+    [InlineData((byte)0x02, HpsdrBoardKind.HermesII, (byte)31)]    // ANAN-10E / 100B / Hermes-II firmware
+    [InlineData((byte)0x04, HpsdrBoardKind.Angelia, (byte)31)]    // ANAN-100D
+    [InlineData((byte)0x05, HpsdrBoardKind.Orion, (byte)31)]      // ANAN-200D
+    [InlineData((byte)0x06, HpsdrBoardKind.HermesLite2, (byte)73)] // version >= 40 -> genuine HL2
+    [InlineData((byte)0x0A, HpsdrBoardKind.OrionMkII, (byte)31)]  // 0x0A alias family — see issue #218
+    [InlineData((byte)0x14, HpsdrBoardKind.HermesC10, (byte)31)]  // ANAN-G2E (N1GP firmware)
+    public void Maps_Every_Recognised_WireByte_To_BoardKind(byte boardId, HpsdrBoardKind expected, byte codeVersion)
     {
         // Pin every wire byte that ramdor/Thetis (MW0LGE) recognises in
         // HPSDRHW (enums.cs:389-402) so a regression in MapBoard cannot
         // silently land. Cross-references docs/references/protocol-1/thetis-board-matrix.md.
+        // codeVersion is parameterised: 0x06 needs version >= 40 to stay classified as
+        // HermesLite2 after the issue #493 reclassification guard.
         var reply = BuildReply(new ReplyFields(
             Status: 0x02,
             Mac: new byte[] { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55 },
-            CodeVersion: 31,
+            CodeVersion: codeVersion,
             BoardId: boardId,
             GatewareBuild: 0));
 
@@ -205,6 +207,29 @@ public class DiscoveryTests
             BoardId: 0x01));
 
         Assert.False(ReplyParser.TryParse(reply, FromIp, out _));
+    }
+
+
+    [Fact]
+    public void WireByte_0x06_BelowHl2CodeThreshold_ReclassifiesAsHermesII()
+    {
+        // Regression for issue #493: ANAN-10E with Hermes10E_v1.5.rbf firmware
+        // reports board byte 0x06 (same as Hermes Lite 2) but code version 15,
+        // which is well below the HL2 threshold (40). The parser must reclassify
+        // to HermesII so downstream drive-model / calibration dispatch selects the
+        // correct 8-bit full-byte profile instead of HL2's nibble/percentage model.
+        var reply = BuildReply(new ReplyFields(
+            Status: 0x02,
+            Mac: new byte[] { 0xAA, 0xBB, 0xCC, 0x00, 0x01, 0x02 },
+            CodeVersion: 15,       // Hermes10E_v1.5.rbf -> version 15
+            BoardId: 0x06,
+            GatewareBuild: 0));
+
+        Assert.True(ReplyParser.TryParse(reply, FromIp, out var radio));
+        Assert.Equal(HpsdrBoardKind.HermesII, radio.Board);
+        Assert.Equal((byte)0x06, radio.Details.RawBoardId);         // raw wire byte preserved
+        Assert.Equal("1.5", radio.FirmwareString);                  // version formatted as X.Y
+        Assert.Null(radio.Details.HermesLite2MinorVersion);          // no HL2-specific extras
     }
 
     [Fact]


### PR DESCRIPTION
Clean re-land of the ANAN-10E discovery fix for #493 onto `develop`.

## Why a fresh PR
The original fix (PR #536) was branched off the old `experimental` tip and its diff was entangled with unrelated relay-experiment files; `experimental` has since been reset multiple times, so it isn't a trustworthy source. This PR cherry-picks **only the clean commit** (`22908431`) — 3 files, nothing else.

## The fix
ANAN-10E units running `Hermes10E_v1.5.rbf` report board-ID byte `0x06` on the discovery wire (same byte as a genuine Hermes Lite 2) but code version 15, well below the HL2 threshold of 40. The parser computed `isHl2 = false` but never corrected the `board` variable, so downstream drive-model / calibration dispatch picked the HL2 4-bit percentage profile instead of the 8-bit ANAN model.

One-line guard in `ReplyParser.cs` after `isHl2` is computed:
```
if (!isHl2 && board == HpsdrBoardKind.HermesLite2)
    board = HpsdrBoardKind.HermesII;
```

## Changes
- `Zeus.Protocol1/Discovery/ReplyParser.cs` — the guard
- `tests/Zeus.Protocol1.Tests/DiscoveryTests.cs` — new regression `WireByte_0x06_BelowHl2CodeThreshold_ReclassifiesAsHermesII`; `Maps_Every_Recognised_WireByte_To_BoardKind` updated so genuine HL2 still maps via codeVersion 73
- `docs/rca/2026-05-25-anan10e-wire-0x06-reclassify.md` — RCA

## Verification
Confirmed working on @RonnieC82's actual ANAN-10E hardware via the `test-anan10e-493` prerelease (0.8.3 + this commit).

Leaving #493 open until the release carrying this ships.