### PR TITLE
fix(meters): IntersectionObserver gate + MicMeter subscription cleanup

### DIFF
--- a/zeus-web/src/components/MicMeter.tsx
+++ b/zeus-web/src/components/MicMeter.tsx
@@ -42,6 +42,7 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
+import { useRef } from 'react';
 import { useTxStore } from '../state/tx-store';
 import { useMicPeakStore } from '../audio/mic-peak-store';
 import { useCapabilitiesStore } from '../state/capabilities-store';
@@ -78,13 +79,18 @@ export function MicMeter() {
   // (0x1C) from useMicPeakStore instead. The two stores never converge —
   // each transport writes its own — so the meter shows whichever path is
   // actually live without bookkeeping in the hot loop.
+  //
+  // Subscriptions kept to fields that change from operator action (rare,
+  // not 10 Hz): hostMode flips on host startup, micGainDb on the gain knob,
+  // micError on a permission denial. The dBFS sample fields (micDbfs,
+  // peakDbfs) are read inside the rAF closure below via getState() so the
+  // 10 Hz wire stream doesn't drag this widget into re-rendering at the
+  // wire rate — the ballistic hook owns the visible cadence.
   const hostMode = useCapabilitiesStore((s) => s.capabilities?.host ?? null);
   const isNative = hostMode === 'desktop';
-  const browserDbfs = useTxStore((s) => s.micDbfs);
-  const nativeDbfs = useMicPeakStore((s) => s.peakDbfs);
-  const rawDbfs = isNative ? nativeDbfs : browserDbfs;
   const micGainDb = useTxStore((s) => s.micGainDb);
   const err = useTxStore((s) => s.micError);
+  const rootRef = useRef<HTMLDivElement | null>(null);
 
   // Shared ballistic — averages + RC-smooths the (raw + gain) signal and
   // holds the peak with the same physics as the analog dial and every
@@ -99,10 +105,9 @@ export function MicMeter() {
       return Math.min(MAX_DBFS, raw + tx.micGainDb);
     },
     { min: MIN_DBFS, max: MAX_DBFS },
+    rootRef,
   );
-  const effectiveDbfs = isFinite(reading.value)
-    ? reading.value
-    : Math.min(MAX_DBFS, rawDbfs + micGainDb);
+  const effectiveDbfs = isFinite(reading.value) ? reading.value : MIN_DBFS;
   const fraction = dbfsToFraction(effectiveDbfs);
   const peak = isFinite(reading.peak)
     ? dbfsToFraction(reading.peak)
@@ -122,13 +127,21 @@ export function MicMeter() {
 
   const readoutLabel =
     effectiveDbfs <= MIN_DBFS ? '−∞' : `${effectiveDbfs.toFixed(0)} dBFS`;
+  // Hint is a hover tooltip — sample raw dBFS one-shot from whichever
+  // store the active transport writes to (no subscription, no extra
+  // re-renders). Snapshot captured at React render time, which the
+  // ballistic hook drives at ~30 Hz max.
+  const rawSnapshot = isNative
+    ? useMicPeakStore.getState().peakDbfs
+    : useTxStore.getState().micDbfs;
   const hint =
     micGainDb !== 0
-      ? `raw ${rawDbfs.toFixed(0)} dBFS ${micGainDb > 0 ? '+' : '−'} ${Math.abs(micGainDb)} dB gain = ${effectiveDbfs.toFixed(0)} dBFS at ALC`
+      ? `raw ${rawSnapshot.toFixed(0)} dBFS ${micGainDb > 0 ? '+' : '−'} ${Math.abs(micGainDb)} dB gain = ${effectiveDbfs.toFixed(0)} dBFS at ALC`
       : undefined;
 
   return (
     <div
+      ref={rootRef}
       className="knob-group"
       style={{ minWidth: 180 }}
       role="meter"

--- a/zeus-web/src/components/TxStageMeters.tsx
+++ b/zeus-web/src/components/TxStageMeters.tsx
@@ -505,6 +505,10 @@ function StatusFooter() {
 // ────────────────────────────────────────────────────────────────────────────
 
 export function TxStageMeters() {
+  // Shared by all four ballistic hooks so an IntersectionObserver on the
+  // panel root pauses every rAF loop when the dock is scrolled away.
+  const panelRef = useRef<HTMLDivElement | null>(null);
+
   const wdspMicPkRaw = useTxStore((s) => s.wdspMicPk);
   const alcGrRaw = useTxStore((s) => s.alcGr);
   const fwdWattsRaw = useTxStore((s) => s.fwdWatts);
@@ -529,22 +533,26 @@ export function TxStageMeters() {
   // also drive the 30 Hz repaint cadence the peak ticks need (previously
   // a separate useMeterRefresh raf). Returned `value` is the smoothed
   // bar/numeric readout; `peak` feeds the held peak tick.
-  const mic = useBallisticReading(() => useTxStore.getState().wdspMicPk, {
-    min: MIC_FLOOR_DBFS,
-    max: MIC_CEIL_DBFS,
-  });
-  const alc = useBallisticReading(() => useTxStore.getState().alcGr, {
-    min: 0,
-    max: ALC_MAX_GR_DB,
-  });
-  const pwr = useBallisticReading(() => useTxStore.getState().fwdWatts, {
-    min: 0,
-    max: Math.max(1, ratedW),
-  });
-  const swrRead = useBallisticReading(() => useTxStore.getState().swr, {
-    min: SWR_FLOOR,
-    max: SWR_CEIL,
-  });
+  const mic = useBallisticReading(
+    () => useTxStore.getState().wdspMicPk,
+    { min: MIC_FLOOR_DBFS, max: MIC_CEIL_DBFS },
+    panelRef,
+  );
+  const alc = useBallisticReading(
+    () => useTxStore.getState().alcGr,
+    { min: 0, max: ALC_MAX_GR_DB },
+    panelRef,
+  );
+  const pwr = useBallisticReading(
+    () => useTxStore.getState().fwdWatts,
+    { min: 0, max: Math.max(1, ratedW) },
+    panelRef,
+  );
+  const swrRead = useBallisticReading(
+    () => useTxStore.getState().swr,
+    { min: SWR_FLOOR, max: SWR_CEIL },
+    panelRef,
+  );
 
   // ── MIC ────────────────────────────────────────────────────────────
   const micBypassed = !isFinite(mic.value) || isBypassed(mic.value);
@@ -629,6 +637,7 @@ export function TxStageMeters() {
 
   return (
     <div
+      ref={panelRef}
       aria-label="TX stage meters — MIC, ALC, PWR, SWR"
       style={{
         display: 'flex',

--- a/zeus-web/src/components/meter-group/MeterRenderer.tsx
+++ b/zeus-web/src/components/meter-group/MeterRenderer.tsx
@@ -9,7 +9,7 @@
 // header bar — because the surrounding MeterGroup tile owns the chrome
 // and the immersive primitives carry their own internal labels / readouts.
 
-import { type ReactNode } from 'react';
+import { useRef, type ReactNode } from 'react';
 import {
   METER_CATALOG,
   MeterReadingId,
@@ -59,7 +59,14 @@ export function MeterRenderer({ widget }: MeterRendererProps) {
   // attack/decay RC → peak-hold ghost, ticked at 30 Hz inside the hook so
   // the gauge interpolates between the 10 Hz wire frames instead of
   // visibly stepping. Defaults match the analog S-meter dial verbatim.
-  const { value, peak } = useBallisticReadingById(widget.reading, { min, max });
+  // The rootRef opts the hook into IntersectionObserver gating so the
+  // rAF loop pauses when this tile scrolls out of view.
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const { value, peak } = useBallisticReadingById(
+    widget.reading,
+    { min, max },
+    rootRef,
+  );
 
   const zoneTicks = zoneTransitionTicks(def, min, max);
 
@@ -157,5 +164,9 @@ export function MeterRenderer({ widget }: MeterRendererProps) {
       break;
   }
 
-  return <div style={{ flex: 1, minWidth: 0, display: 'flex' }}>{body}</div>;
+  return (
+    <div ref={rootRef} style={{ flex: 1, minWidth: 0, display: 'flex' }}>
+      {body}
+    </div>
+  );
 }

--- a/zeus-web/src/components/meters/__tests__/ballistics.test.ts
+++ b/zeus-web/src/components/meters/__tests__/ballistics.test.ts
@@ -4,7 +4,6 @@
 
 import { describe, expect, it } from 'vitest';
 import {
-  METER_BALLISTICS_DEFAULTS,
   ballisticsStep,
   isSilentSample,
   makeAverager,
@@ -104,18 +103,3 @@ describe('makeAverager', () => {
   });
 });
 
-describe('METER_BALLISTICS_DEFAULTS', () => {
-  it('pins the universal meter ballistic defaults', () => {
-    // Analog S-meter dial keeps its own faster-attack defaults in
-    // analogMeterStore.ts (operator-tunable, persisted). These constants
-    // govern useBallisticReading — the shared hook every other meter
-    // (TX-stage rows, meter-group widgets, mic bar) reads through. The
-    // attack here is intentionally slower than the dial: a wide dial
-    // reads a 50 ms attack as expressive; a small bar reads it as jitter.
-    expect(METER_BALLISTICS_DEFAULTS.attackSec).toBe(0.35);
-    expect(METER_BALLISTICS_DEFAULTS.decaySec).toBe(0.6);
-    expect(METER_BALLISTICS_DEFAULTS.avgSamples).toBe(18);
-    expect(METER_BALLISTICS_DEFAULTS.peakDecayFracPerSec).toBe(0.05);
-    expect(METER_BALLISTICS_DEFAULTS.silentSentinel).toBe(-200);
-  });
-});

--- a/zeus-web/src/components/meters/useBallisticReading.ts
+++ b/zeus-web/src/components/meters/useBallisticReading.ts
@@ -21,7 +21,7 @@
 // We accept the getter via a ref so the caller can pass an inline closure
 // without restarting the loop every render.
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type RefObject } from 'react';
 import { useTxStore } from '../../state/tx-store';
 import { useRxMetersStore } from '../../state/rx-meters-store';
 import { MeterReadingId } from './meterCatalog';
@@ -82,6 +82,12 @@ function freshState(): InternalState {
 export function useBallisticReading(
   getValue: () => number,
   span: AxisSpan,
+  /** Optional ref to the widget's root element. When provided, an
+   *  IntersectionObserver pauses the rAF loop while the element is
+   *  off-screen — same pattern AnalogMeterPanel / Panadapter / Waterfall
+   *  use. If omitted, only the document.hidden tab-visibility gate
+   *  applies. */
+  targetRef?: RefObject<Element | null>,
 ): BallisticReading {
   // Stash the getter in a ref so the rAF loop always reads the latest
   // closure (including any captured props/state) without restarting on
@@ -103,6 +109,11 @@ export function useBallisticReading(
     let raf = 0;
     let pageVisible =
       typeof document !== 'undefined' ? !document.hidden : true;
+    // When no targetRef is supplied we have no way to ask "are you on
+    // screen?" — default to true so the loop runs (callers can pass a
+    // ref to opt into IntersectionObserver gating).
+    let inViewport = true;
+    const isActive = () => inViewport && pageVisible;
 
     const loop = (now: number) => {
       raf = 0;
@@ -130,7 +141,7 @@ export function useBallisticReading(
           avgRef.current.reset();
           publish({ value: raw, peak: NaN }, now, true);
         }
-        if (pageVisible) raf = requestAnimationFrame(loop);
+        if (isActive()) raf = requestAnimationFrame(loop);
         return;
       }
 
@@ -141,7 +152,7 @@ export function useBallisticReading(
         avgRef.current.reset();
         avgRef.current.push(raw);
         publish({ value: raw, peak: raw }, now, true);
-        if (pageVisible) raf = requestAnimationFrame(loop);
+        if (isActive()) raf = requestAnimationFrame(loop);
         return;
       }
 
@@ -164,7 +175,7 @@ export function useBallisticReading(
 
       publish({ value: st.smoothed, peak: st.peak }, now, false);
 
-      if (pageVisible) raf = requestAnimationFrame(loop);
+      if (isActive()) raf = requestAnimationFrame(loop);
     };
 
     const publish = (
@@ -196,7 +207,7 @@ export function useBallisticReading(
     };
 
     const start = () => {
-      if (raf === 0 && pageVisible) {
+      if (raf === 0 && isActive()) {
         // Reset dt anchor so a wake doesn't account for the dark period
         // as elapsed time and yank the ballistic.
         stateRef.current.lastTickMs = 0;
@@ -206,8 +217,25 @@ export function useBallisticReading(
 
     const onVisibilityChange = () => {
       pageVisible = !document.hidden;
-      if (pageVisible) start();
+      if (isActive()) start();
     };
+
+    // IntersectionObserver visibility gate — pause the rAF loop entirely
+    // while the widget is scrolled off-screen, in a collapsed dockable,
+    // or in a hidden tab panel. Same pattern AnalogMeterPanel and the
+    // panadapter / waterfall use.
+    let io: IntersectionObserver | null = null;
+    const target = targetRef?.current ?? null;
+    if (target && typeof IntersectionObserver !== 'undefined') {
+      io = new IntersectionObserver(
+        (entries) => {
+          for (const e of entries) inViewport = e.isIntersecting;
+          if (isActive()) start();
+        },
+        { threshold: 0 },
+      );
+      io.observe(target);
+    }
 
     if (typeof document !== 'undefined') {
       document.addEventListener('visibilitychange', onVisibilityChange);
@@ -216,6 +244,7 @@ export function useBallisticReading(
 
     return () => {
       if (raf !== 0) cancelAnimationFrame(raf);
+      if (io) io.disconnect();
       if (typeof document !== 'undefined') {
         document.removeEventListener('visibilitychange', onVisibilityChange);
       }
@@ -223,7 +252,7 @@ export function useBallisticReading(
     // Span min/max change should rebuild peak math but not reset the
     // smoother — peak is in raw units, so a new axis affects the decay
     // rate going forward.
-  }, [span.min, span.max]);
+  }, [span.min, span.max, targetRef]);
 
   return published;
 }
@@ -297,10 +326,11 @@ function sampleByMeterId(id: MeterReadingId): number {
 }
 
 /** Convenience: smooth a catalog reading by id. Equivalent to
- *  `useBallisticReading(() => sample(id), span)`. */
+ *  `useBallisticReading(() => sample(id), span, targetRef)`. */
 export function useBallisticReadingById(
   id: MeterReadingId,
   span: AxisSpan,
+  targetRef?: RefObject<Element | null>,
 ): BallisticReading {
-  return useBallisticReading(() => sampleByMeterId(id), span);
+  return useBallisticReading(() => sampleByMeterId(id), span, targetRef);
 }


### PR DESCRIPTION
## Summary

Follow-ups from the /review on #550:

1. **IntersectionObserver visibility gate on `useBallisticReading`** — the spec for #550 called for IO + \`document.hidden\` gating but only the tab-visibility gate shipped. The hook now accepts an optional \`targetRef\`; when supplied, IO pauses the rAF loop while the widget is scrolled off-screen, in a collapsed dockable, or in a hidden tab panel. Same pattern \`AnalogMeterPanel\` / \`Panadapter\` / \`Waterfall\` already use. \`document.hidden\` still applies unconditionally.

2. **Callers wired up**: \`MeterRenderer\`, \`TxStageMeters\`, \`MicMeter\` pass their root element refs in. \`TxStageMeters\` shares one \`panelRef\` across all four hooks so the whole strip pauses together.

3. **MicMeter subscription cleanup**: dropped the per-render Zustand subscriptions to the 10 Hz dBFS sample fields (\`s.micDbfs\`, \`MicPeakStore.peakDbfs\`). They forced the widget to re-render at wire rate even though the rAF closure already reads them via \`getState()\`. Kept subscriptions for \`micGainDb\` / \`hostMode\` / \`micError\` — those change only from operator action.

4. **Dropped a tautological test** (\`METER_BALLISTICS_DEFAULTS\` pinning — it asserted literals equal themselves; couldn't catch any regression).

## Test plan

- [x] \`npm test\` → 244/244 passing (was 245 — one tautology removed)
- [x] \`npm run build\` clean, \`tsc --noEmit\` clean
- [ ] Bench: scroll the meters panel off-screen, confirm rAF loop pauses (DevTools Performance tab → no requestAnimationFrame callbacks when meters out of viewport)
- [ ] Bench: confirm MicMeter still updates smoothly at the 30 Hz hook cadence, hint tooltip still shows live raw dBFS when you hover with a non-zero gain