### PR TITLE
fix(ps): sync AutoAttenuate baseline to the radio's actual TX attenuation

### DIFF
--- a/Zeus.Protocol1/IProtocol1Client.cs
+++ b/Zeus.Protocol1/IProtocol1Client.cs
@@ -231,6 +231,16 @@ public interface IProtocol1Client : IDisposable
     void SetHl2TxStepAttenuationDb(int db);
 
     /// <summary>
+    /// Current HL2 TX-side step attenuation in dB — the value last written
+    /// via <see cref="SetHl2TxStepAttenuationDb"/>. Returns 0 when untouched
+    /// (the radio's power-on default), never the internal int.MinValue
+    /// sentinel. Read by <c>PsAutoAttenuateService</c> on a PS-arm edge so
+    /// the dance baselines its model to ground truth instead of assuming 0,
+    /// which would desync from the radio's sticky ATTOnTX value.
+    /// </summary>
+    int Hl2TxStepAttenuationDb { get; }
+
+    /// <summary>
     /// Push the on-board CW keyer config to C&amp;C register 0x0B: speed in
     /// WPM (clamped to the 6-bit 0..60 gateware field) and the keyer mode
     /// (straight / iambic A / iambic B). Sent via the register round-robin

--- a/Zeus.Protocol1/Protocol1Client.cs
+++ b/Zeus.Protocol1/Protocol1Client.cs
@@ -639,6 +639,18 @@ public sealed class Protocol1Client : IProtocol1Client
         Interlocked.Exchange(ref _hl2TxAttnDb, clamped);
     }
 
+    public int Hl2TxStepAttenuationDb
+    {
+        // int.MinValue is the "never written / radio default" sentinel (see
+        // _hl2TxAttnDb decl + SnapshotState). Surface it as 0 so the PS-arm
+        // baseline sync reads the radio's actual untouched 0 dB.
+        get
+        {
+            int v = Volatile.Read(ref _hl2TxAttnDb);
+            return v == int.MinValue ? 0 : v;
+        }
+    }
+
     public void Dispose()
     {
         if (_disposed) return;

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -1120,6 +1120,13 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     /// loop to ramp feedback level into the 128..181 window when calcc
     /// rejects fits because the loopback is too hot or too quiet.
     /// </summary>
+    /// <summary>Current TX feedback step attenuation in dB (the ATTOnTX value
+    /// last written via <see cref="SetTxAttenuationDb"/>). Sticky across
+    /// MOX/unkey — the radio holds it until changed — so the PureSignal
+    /// auto-attenuate dance can read ground truth on re-arm instead of
+    /// assuming 0 and desyncing its model from the radio.</summary>
+    public byte TxStepAttnDb => _txStepAttnDb;
+
     public void SetTxAttenuationDb(byte db)
     {
         if (db > 31) db = 31;

--- a/Zeus.Server.Hosting/PsAutoAttenuateService.cs
+++ b/Zeus.Server.Hosting/PsAutoAttenuateService.cs
@@ -257,23 +257,39 @@ public sealed class PsAutoAttenuateService : BackgroundService
     {
         var s = _radio.Snapshot();
 
-        // PS-arm edge: re-baseline _currentAttnDb on every false→true so a
-        // fresh arm starts at the radio's untouched 0 dB. The actual radio
-        // state may differ if the operator manually changed step-att between
-        // sessions; assume the radio holds 0 between arms (matches pihpsdr).
-        // Also reset the HL2 state machine so a fresh arm always starts in
+        // PS-arm edge: baseline _currentAttnDb to the radio's ACTUAL current
+        // TX step attenuation on every false→true.
+        //
+        // This used to force 0 on the premise that "the radio holds 0 between
+        // arms (matches pihpsdr)". That premise is false in Zeus: the ATTOnTX
+        // wire byte is sticky — nothing in the disarm/unkey path resets it —
+        // so the radio holds the *last dance value* (e.g. ~21 dB for a hot
+        // external-tap feedback chain). Forcing the model to 0 desynced it
+        // from the radio, with two on-air failures:
+        //   • first arm after a fresh connect (radio genuinely 0): the hot
+        //     feedback saturates the ADC, so the dance needs several slow
+        //     cycles to climb out — calcc can't fit and the signal splatters
+        //     during the climb;
+        //   • re-arm (radio still ~21, model says 0): the moment a voice peak
+        //     pushes feedback out of [128,181], the dance computes its step
+        //     from the phantom 0 baseline and slams a too-low attenuation onto
+        //     the radio → feedback blows out → "corrects but won't hold".
+        // Reading ground truth keeps every step anchored. (root-caused on a
+        // G2 + RF2K-S external tap 2026-05-27; AutoAttenuate-off was clean.)
+        //
+        // Also reset the state machines so a fresh arm always starts in
         // Monitor — if the prior session was disarmed mid-dance, we don't
         // want to fire RestoreOperation against a stale saved cal-mode.
         if (s.PsEnabled && !_psWasEnabled)
         {
-            _currentAttnDb = 0;
+            _currentAttnDb = ReadRadioTxAttnDb();
             _lastCalibrationAttempts = -1;
             _hl2State = Hl2AutoAttState.Monitor;
             _p2State = P2AutoAttState.Monitor;
             _stallStartTickMs = 0;
             _stallWarned = false;
             _lastAutoCalTickMs = 0;
-            _log.LogInformation("psAutoAttn.armed reset attn={Db}", _currentAttnDb);
+            _log.LogInformation("psAutoAttn.armed baseline attn={Db} (synced to radio)", _currentAttnDb);
         }
         _psWasEnabled = s.PsEnabled;
 
@@ -383,6 +399,23 @@ public sealed class PsAutoAttenuateService : BackgroundService
         var p2 = _pipe.CurrentP2Client;
         if (p2 is null) { LogGate("skip=p2-null"); return; }
         Tick1P2(s, engine, p2);
+    }
+
+    // Ground-truth TX feedback attenuation the radio is actually holding, for
+    // baselining the dance model on a PS-arm edge. HL2 reads its sticky AD9866
+    // PGA value (range -28..31); every other (P2) board reads the sticky
+    // ATTOnTX byte (0..31). Clamped to the per-board range; 0 when no client
+    // is connected. See the arm-edge comment in Tick1 for why this replaced
+    // the old assume-0.
+    private int ReadRadioTxAttnDb()
+    {
+        if (_radio.ConnectedBoardKind == HpsdrBoardKind.HermesLite2)
+        {
+            int hl2 = _radio.ActiveClient?.Hl2TxStepAttenuationDb ?? 0;
+            return Math.Clamp(hl2, Hl2TxAttnMinDb, Hl2TxAttnMaxDb);
+        }
+        int p2 = _pipe.CurrentP2Client?.TxStepAttnDb ?? 0;
+        return Math.Clamp(p2, TxAttnMinDb, TxAttnMaxDb);
     }
 
     // *** DEVIATION FROM mi0bot ***


### PR DESCRIPTION
Root cause of the G2 PureSignal blowouts (corrects-but-won't-hold): `PsAutoAttenuateService` reset its attenuation model to 0 on every PS-arm edge, but the radio's TX feedback attenuation is sticky. On a hot external-tap feedback chain (RF2K-S −55 dB) the model desyncs from the radio (model=0, radio≈21 dB) → the dance computes steps from the wrong baseline and slams a too-low attenuation onto the radio → feedback blows out.

Fix: on arm, baseline `_currentAttnDb` to the radio's *actual* current TX step attenuation via new read-only getters (`Protocol2Client.TxStepAttnDb`, `IProtocol1Client.Hl2TxStepAttenuationDb`) instead of forcing 0. No dance-logic, default, or wire-format change. P2 + HL2.

On-air validated on KB2UKA's G2. 207 Protocol1 + 711 Server tests green; full solution builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)