### PR TITLE
feat(ps): persist/restore PS feedback attenuation per board + manual control

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -234,6 +234,15 @@ public sealed record StateDto(
     // HardwareSpecific.PSDefaultPeak;` + clsHardwareSpecific.cs:303-328
     // PSDefaultPeak per-board switch.
     double PsHwPeakDefault = 0.4072,
+    // PS TX feedback attenuation (dB) currently applied to the radio's
+    // feedback path. Surfaced so the operator can set it directly — a manual
+    // alternative to AutoAttenuate for a fixed external-tap chain — and see
+    // the persisted value restored on connect. Written by the AutoAttenuate
+    // dance, the manual control, and the connect-time restore.
+    int PsTxFeedbackAttenuationDb = 0,
+    // Per-board minimum for the above. HL2's AD9866 TX PGA reaches -28 dB;
+    // the bare-HPSDR / P2 step attenuator floors at 0. Max is 31 everywhere.
+    int PsTxFeedbackAttenuationDbMin = 0,
     PsFeedbackSource PsFeedbackSource = PsFeedbackSource.Internal,
     string PsIntsSpiPreset = "16/256",
     double PsFeedbackLevel = 0.0,   // info[4] read-back, 0..256
@@ -725,6 +734,12 @@ public sealed record PsRestoreRequest(string Filename);
 // Sent from the PS settings panel. Affects only the radio-side ALEX bit;
 // the WDSP cal/iqc stages operate on whatever IQ arrives at DDC0/DDC1.
 public sealed record PsFeedbackSourceSetRequest(PsFeedbackSource Source);
+
+// Manual PS TX feedback attenuation (dB). Operator alternative to
+// AutoAttenuate for a fixed external-tap chain: set the value that lands the
+// feedback in calcc's range once, and it persists per board. Clamped
+// server-side to the connected board's range (P2 0..31, HL2 -28..31).
+public sealed record PsFeedbackAttenuationSetRequest(int Db);
 
 // "Monitor PA output" toggle (issue #121). Pure UI/source-routing flag —
 // no WDSP setter, no wire-format change. RadioService just stamps the

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -2191,11 +2191,11 @@ public sealed class WdspDspEngine : IDspEngine
         // causes: env climbing >1.0 = forward limiter escaping; fb railing
         // (toward ADC saturation, ideal ~152) = feedback path saturating
         // calcc's top bins; both bounded but info6=0x0040 spiking = fit
-        // destabilising on the top-skewed envelope PDF. Info-level so it
-        // shows in a normal run; remove once characterised (bd: ps-hot-audio).
+        // destabilising on the top-skewed envelope PDF. Debug-level: kept as a
+        // diagnostic but no longer spams ~1 Hz on every TX in a normal run.
         if (_psInfoLogCounter % 10 == 0)
         {
-            _log.LogInformation(
+            _log.LogDebug(
                 "wdsp.psHot env={Env:F3} fb={Fb} info6=0x{Sc:X4} cal={Cal} state={St} cor={Cor}",
                 maxTx, _psInfoBuf[4], _psInfoBuf[6], _psInfoBuf[5], _psInfoBuf[15], _psInfoBuf[14]);
         }

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -2183,6 +2183,23 @@ public sealed class WdspDspEngine : IDspEngine
                 _psInfoBuf[14], _psInfoBuf[15]);
         }
 
+        // Hot-audio robustness diagnostic. At ~1 Hz while PS is armed, surface
+        // the forward TX envelope PEAK (GetPSMaxTX, ~1.0 = at the ALC cap)
+        // next to the feedback level (info4), the scheck reject bitmask
+        // (info6), calcc fit count (info5), state and correcting flag. On a
+        // deliberately-hot over this separates the three candidate root
+        // causes: env climbing >1.0 = forward limiter escaping; fb railing
+        // (toward ADC saturation, ideal ~152) = feedback path saturating
+        // calcc's top bins; both bounded but info6=0x0040 spiking = fit
+        // destabilising on the top-skewed envelope PDF. Info-level so it
+        // shows in a normal run; remove once characterised (bd: ps-hot-audio).
+        if (_psInfoLogCounter % 10 == 0)
+        {
+            _log.LogInformation(
+                "wdsp.psHot env={Env:F3} fb={Fb} info6=0x{Sc:X4} cal={Cal} state={St} cor={Cor}",
+                maxTx, _psInfoBuf[4], _psInfoBuf[6], _psInfoBuf[5], _psInfoBuf[15], _psInfoBuf[14]);
+        }
+
         return new PsStageMeters(
             FeedbackLevel: feedback,
             CalState: calState,

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -483,6 +483,16 @@ public class DspPipelineService : BackgroundService,
         // is per-board (HL2 → 0.233, others → 0.4072) and only fires a
         // StateChanged when the value actually changes.
         _radio.ApplyPsHwPeakForConnection(isProtocol2: false, _radio.ConnectedBoardKind);
+        // Restore the persisted PS feedback attenuation so a hot external-tap
+        // chain isn't sitting at 0 dB on a fresh connect — at 0 dB the
+        // feedback ADC rails and calcc can never fit. HL2 only on the P1 side
+        // (it owns the AD9866 TX-PGA step attenuator). No-op when nothing was
+        // saved for this board yet.
+        if (_radio.ConnectedBoardKind == HpsdrBoardKind.HermesLite2
+            && _radio.GetPersistedPsTxAttnDb() is int hl2Attn)
+        {
+            _radio.ActiveClient?.SetHl2TxStepAttenuationDb(hl2Attn);
+        }
     }
 
     private void OnRadioDisconnected()
@@ -1083,6 +1093,15 @@ public class DspPipelineService : BackgroundService,
         // caller plumbed it through (issue #171); falls back to OrionMkII when
         // the byte wasn't supplied.
         _radio.ApplyPsHwPeakForConnection(isProtocol2: true, _radio.ConnectedBoardKind);
+        // Restore the persisted PS feedback attenuation (0..31 dB) before the
+        // operator arms PS, so a hot external-tap chain (e.g. RF2K-S −55 dB
+        // coupler) doesn't boot at 0 dB and rail the feedback ADC — the
+        // saturation that left calcc unable to fit on a fresh connect. No-op
+        // when nothing was saved for this board yet.
+        if (_radio.GetPersistedPsTxAttnDb() is int txAttn)
+        {
+            CurrentP2Client?.SetTxAttenuationDb((byte)Math.Clamp(txAttn, 0, 31));
+        }
         // Push current PA snapshot into the brand-new client so byte 345 /
         // byte 1401 / CmdGeneral[58] reflect PaSettingsStore from frame 1.
         _radio.ReplayPaSnapshot();

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -416,6 +416,31 @@ public class DspPipelineService : BackgroundService,
     /// and tests don't exercise it.</summary>
     public Zeus.Protocol2.Protocol2Client? CurrentP2Client => _p2Client;
 
+    /// <summary>
+    /// Manually set the PS TX feedback attenuation (operator alternative to
+    /// AutoAttenuate). Pushes the value to the connected radio — HL2 via the
+    /// AD9866 TX-PGA step, every other board via the P2 step attenuator — then
+    /// persists it per board and surfaces it in state via RadioService. This
+    /// is what lets an operator on a fixed external-tap chain dial the
+    /// feedback into calcc's range once and run with AutoAttenuate off.
+    /// Clamped to the connected board's range.
+    /// </summary>
+    public void SetPsFeedbackAttenuationDb(int db)
+    {
+        if (_radio.ConnectedBoardKind == HpsdrBoardKind.HermesLite2)
+        {
+            int clamped = Math.Clamp(db, -28, 31);
+            _radio.ActiveClient?.SetHl2TxStepAttenuationDb(clamped);
+            _radio.SetPsTxAttenuationDb(clamped);
+        }
+        else
+        {
+            int clamped = Math.Clamp(db, 0, 31);
+            _p2Client?.SetTxAttenuationDb((byte)clamped);
+            _radio.SetPsTxAttenuationDb(clamped);
+        }
+    }
+
     private void OpenSynthetic()
     {
         var engine = new SyntheticDspEngine();

--- a/Zeus.Server.Hosting/PsAutoAttenuateService.cs
+++ b/Zeus.Server.Hosting/PsAutoAttenuateService.cs
@@ -537,6 +537,10 @@ public sealed class PsAutoAttenuateService : BackgroundService
                         _currentAttnDb, newAttn);
                     _currentAttnDb = newAttn;
                     p1.SetHl2TxStepAttenuationDb(newAttn);
+                    // Persist per board so this converged value is restored on
+                    // the next connect (DspPipelineService) instead of booting
+                    // at 0 dB and re-saturating the feedback ADC.
+                    _radio.SetPsTxAttenuationDb(newAttn);
                     // mi0bot PSForm.cs:783 Thread.Sleep(100) — give the
                     // C4 frame time to land on the wire before the next
                     // tick re-enables PS in calcc.
@@ -668,6 +672,10 @@ public sealed class PsAutoAttenuateService : BackgroundService
                         _currentAttnDb, newAttn);
                     _currentAttnDb = newAttn;
                     p2.SetTxAttenuationDb((byte)newAttn);
+                    // Persist per board so this converged value is restored on
+                    // the next connect (DspPipelineService) instead of booting
+                    // at 0 dB and re-saturating the feedback ADC.
+                    _radio.SetPsTxAttenuationDb(newAttn);
                     // mi0bot PSForm.cs:783 Thread.Sleep(100) — give the
                     // wire byte time to land before the next tick re-enables
                     // PS in calcc.

--- a/Zeus.Server.Hosting/PsSettingsStore.cs
+++ b/Zeus.Server.Hosting/PsSettingsStore.cs
@@ -123,5 +123,14 @@ public sealed class PsSettingsEntry
     // the factory default from RadioService.ResolvePsHwPeak". See lengthy
     // header comment above for the why.
     public Dictionary<string, double> HwPeakByBoard { get; set; } = new();
+    // PS TX feedback attenuation (dB) per board, same key scheme as
+    // HwPeakByBoard. Keeps a hot external-tap feedback chain (e.g. an RF2K-S
+    // −55 dB coupler into G2 PS-IN) out of ADC saturation by restoring the
+    // converged attenuation on every connect, instead of booting at 0 dB
+    // where the feedback rails and calcc can never fit. Written by
+    // RadioService.PersistPsTxAttn when the auto-attenuate dance (or a manual
+    // control) changes it; consumed on connect by the DspPipelineService
+    // restore. Empty on first run — no entry means "leave the radio at 0".
+    public Dictionary<string, int> TxAttnByBoard { get; set; } = new();
     public DateTime UpdatedUtc { get; set; }
 }

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -410,6 +410,9 @@ public sealed class RadioService : IDisposable
     {
         _currentPsTxAttnDb = db;
         PersistPsState();
+        // Surface the live value so the PURESIGNAL panel's manual control and
+        // the "differs" hint track what's actually applied.
+        Mutate(s => s.PsTxFeedbackAttenuationDb == db ? s : s with { PsTxFeedbackAttenuationDb = db });
     }
 
     /// <summary>
@@ -1735,10 +1738,23 @@ public sealed class RadioService : IDisposable
         // Cache the board key so PersistPsState routes future SetPsAdvanced
         // writes into the right slot.
         _currentPsBoardKey = boardKey;
+        // Surface the TX feedback attenuation for the PURESIGNAL panel's manual
+        // control: the per-board floor (HL2 reaches -28, others 0) and the
+        // persisted value for this board (0 when none saved). GetPersistedPsTxAttnDb
+        // also seeds _currentPsTxAttnDb so PersistPsState keeps the slot.
+        int attnMin = board == HpsdrBoardKind.HermesLite2 ? -28 : 0;
+        int attn = GetPersistedPsTxAttnDb() ?? 0;
         Mutate(s =>
             s.PsHwPeak == peak && s.PsHwPeakDefault == factoryDefault
+            && s.PsTxFeedbackAttenuationDb == attn && s.PsTxFeedbackAttenuationDbMin == attnMin
                 ? s
-                : s with { PsHwPeak = peak, PsHwPeakDefault = factoryDefault });
+                : s with
+                {
+                    PsHwPeak = peak,
+                    PsHwPeakDefault = factoryDefault,
+                    PsTxFeedbackAttenuationDb = attn,
+                    PsTxFeedbackAttenuationDbMin = attnMin,
+                });
         _log.LogInformation(
             "radio.applyPsHwPeak proto={Proto} board={Board} variant={Variant} key={Key} peak={Peak:F4} default={Default:F4} source={Source}",
             isProtocol2 ? "P2" : "P1", board, variant, boardKey, peak, factoryDefault,

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -70,6 +70,14 @@ public sealed class RadioService : IDisposable
     // Empty when nothing is connected — PersistPsState skips HW Peak persistence
     // in that case (no board → no slot to write).
     private string _currentPsBoardKey = string.Empty;
+    // Mirror of the persisted PS TX feedback attenuation (dB) for the
+    // currently-connected board. Loaded from TxAttnByBoard on connect
+    // (GetPersistedPsTxAttnDb), updated by SetPsTxAttenuationDb when the
+    // auto-attenuate dance (or a manual control) settles on a value, and
+    // written back by PersistPsState. -1 = "no value for this board yet" →
+    // PersistPsState leaves the slot untouched so we never clobber a good
+    // saved value with a default.
+    private int _currentPsTxAttnDb = -1;
     // Debounced state flush. Set to true in every Mutate(); a 1 Hz timer
     // calls FlushState() which writes to LiteDB and clears the flag.
     // Avoids hammering LiteDB during rapid VFO scroll or filter drags.
@@ -361,6 +369,17 @@ public sealed class RadioService : IDisposable
         {
             hwPeakByBoard[_currentPsBoardKey] = snap.PsHwPeak;
         }
+        // Same per-board preserve-then-mutate as HW Peak. Only write the TX
+        // attenuation slot when we actually have a value for the connected
+        // board (>= 0); otherwise carry the existing map through untouched so
+        // a HW-Peak-triggered persist never wipes a saved attenuation.
+        var txAttnByBoard = existing?.TxAttnByBoard is { } amap
+            ? new Dictionary<string, int>(amap)
+            : new Dictionary<string, int>();
+        if (!string.IsNullOrEmpty(_currentPsBoardKey) && _currentPsTxAttnDb >= 0)
+        {
+            txAttnByBoard[_currentPsBoardKey] = _currentPsTxAttnDb;
+        }
         _psStore.Upsert(new PsSettingsEntry
         {
             Auto = snap.PsAuto,
@@ -375,7 +394,42 @@ public sealed class RadioService : IDisposable
             TwoToneFreq2 = snap.TwoToneFreq2,
             TwoToneMag = snap.TwoToneMag,
             HwPeakByBoard = hwPeakByBoard,
+            TxAttnByBoard = txAttnByBoard,
         });
+    }
+
+    /// <summary>
+    /// Record + persist the PS TX feedback attenuation the auto-attenuate
+    /// dance (or a manual operator control) settled on, for the currently-
+    /// connected board. Restored to the radio on the next connect by
+    /// DspPipelineService so a hot external-tap feedback chain doesn't boot
+    /// at 0 dB and re-saturate the feedback ADC. No-op persistence when no
+    /// board is connected (no slot to write).
+    /// </summary>
+    public void SetPsTxAttenuationDb(int db)
+    {
+        _currentPsTxAttnDb = db;
+        PersistPsState();
+    }
+
+    /// <summary>
+    /// Persisted PS TX feedback attenuation (dB) for the currently-connected
+    /// board, or null if none has been saved yet. Called on connect to
+    /// restore the radio's feedback attenuation before the operator arms PS.
+    /// Side effect: seeds <see cref="_currentPsTxAttnDb"/> so a later
+    /// PersistPsState preserves the slot rather than treating it as unset.
+    /// </summary>
+    public int? GetPersistedPsTxAttnDb()
+    {
+        if (string.IsNullOrEmpty(_currentPsBoardKey)) return null;
+        var persisted = _psStore?.Get();
+        if (persisted?.TxAttnByBoard is { } map
+            && map.TryGetValue(_currentPsBoardKey, out int db))
+        {
+            _currentPsTxAttnDb = db;
+            return db;
+        }
+        return null;
     }
 
     /// <summary>
@@ -598,6 +652,9 @@ public sealed class RadioService : IDisposable
         // disconnected) should NOT write into the previous radio's slot.
         // ApplyPsHwPeakForConnection sets it again on next connect.
         _currentPsBoardKey = string.Empty;
+        // Same for the TX-attn mirror — next connect re-seeds it from the
+        // persisted slot via GetPersistedPsTxAttnDb.
+        _currentPsTxAttnDb = -1;
         return Snapshot();
     }
 
@@ -1830,6 +1887,7 @@ public sealed class RadioService : IDisposable
         // disconnected SetPsAdvanced writes don't leak into the previous
         // radio's per-board HW Peak slot.
         _currentPsBoardKey = string.Empty;
+        _currentPsTxAttnDb = -1;
         P2Disconnected?.Invoke();
     }
 

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -619,6 +619,18 @@ public static class ZeusEndpoints
             return Results.Ok(r.SetPsFeedbackSource(req));
         });
 
+        // Manual PS TX feedback attenuation — routes through DspPipelineService
+        // (it owns both the P1 and P2 clients) to push the wire byte, then
+        // persists + surfaces it via RadioService. Operator alternative to
+        // AutoAttenuate for a fixed external-tap chain.
+        app.MapPost("/api/tx/ps/feedback-attenuation",
+            (PsFeedbackAttenuationSetRequest req, DspPipelineService pipe, RadioService r) =>
+        {
+            log.LogInformation("api.tx.ps.feedbackAttenuation db={Db}", req.Db);
+            pipe.SetPsFeedbackAttenuationDb(req.Db);
+            return Results.Ok(r.Snapshot());
+        });
+
         // PS-Monitor — operator-facing toggle that swaps the TX panadapter source
         // from the predistorted-IQ analyzer to the PS-feedback (post-PA) analyzer.
         // Pure UI/source-routing flag; no WDSP setter, no wire-format change.

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -205,6 +205,11 @@ export type RadioStateDto = {
   // HardwareSpecific.PSDefaultPeak;`.
   psHwPeak: number;
   psHwPeakDefault: number;
+  // Live PS TX feedback attenuation (dB) and the per-board floor (HL2 -28,
+  // others 0; max 31). Operator can set it directly as a manual alternative
+  // to AutoAttenuate; restored on connect.
+  psTxFeedbackAttenuationDb: number;
+  psTxFeedbackAttenuationDbMin: number;
   // Server raises this when calcc is alive (PS armed + keyed) for >5 s with
   // CalibrationAttempts pinned at 0 — almost always means hw_peak is set
   // higher than the actual TX envelope peak. Drives the HW-peak warning
@@ -479,6 +484,10 @@ export function normalizeState(raw: unknown): RadioStateDto {
     psHwPeak: typeof r.psHwPeak === 'number' ? r.psHwPeak : 0.4072,
     psHwPeakDefault:
       typeof r.psHwPeakDefault === 'number' ? r.psHwPeakDefault : 0.4072,
+    psTxFeedbackAttenuationDb:
+      typeof r.psTxFeedbackAttenuationDb === 'number' ? r.psTxFeedbackAttenuationDb : 0,
+    psTxFeedbackAttenuationDbMin:
+      typeof r.psTxFeedbackAttenuationDbMin === 'number' ? r.psTxFeedbackAttenuationDbMin : 0,
     psCalibrationStalled:
       typeof r.psCalibrationStalled === 'boolean' ? r.psCalibrationStalled : false,
     psIntsSpiPreset: typeof r.psIntsSpiPreset === 'string' ? r.psIntsSpiPreset : '16/256',
@@ -1371,6 +1380,26 @@ export async function setPsFeedbackSource(
       body: JSON.stringify({
         source: source === 'external' ? 'External' : 'Internal',
       }),
+      signal,
+    },
+    (raw) => raw as RadioStateDto,
+  );
+}
+
+// Manual PS TX feedback attenuation (dB). Operator alternative to
+// AutoAttenuate for a fixed external-tap chain — sets the value that lands
+// the feedback in calcc's range; server clamps to the board range and
+// persists per board.
+export async function setPsFeedbackAttenuation(
+  db: number,
+  signal?: AbortSignal,
+): Promise<RadioStateDto> {
+  return jsonFetch(
+    '/api/tx/ps/feedback-attenuation',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ db: Math.round(db) }),
       signal,
     },
     (raw) => raw as RadioStateDto,

--- a/zeus-web/src/components/PsSettingsPanel.tsx
+++ b/zeus-web/src/components/PsSettingsPanel.tsx
@@ -24,6 +24,7 @@ import {
   setPs,
   setPsAdvanced,
   setPsFeedbackSource,
+  setPsFeedbackAttenuation,
   setPsMonitor,
   resetPs,
   setTwoTone,
@@ -104,6 +105,9 @@ export function PsSettingsPanel() {
   const setPsLoopDelaySec = useTxStore((s) => s.setPsLoopDelaySec);
   const setPsAmpDelayNs = useTxStore((s) => s.setPsAmpDelayNs);
   const setPsHwPeak = useTxStore((s) => s.setPsHwPeak);
+  const psTxFeedbackAttenuationDb = useTxStore((s) => s.psTxFeedbackAttenuationDb);
+  const psTxFeedbackAttenuationDbMin = useTxStore((s) => s.psTxFeedbackAttenuationDbMin);
+  const setPsTxFeedbackAttenuationDb = useTxStore((s) => s.setPsTxFeedbackAttenuationDb);
   const setPsIntsSpiPreset = useTxStore((s) => s.setPsIntsSpiPreset);
   const setPsFeedbackSourceLocal = useTxStore((s) => s.setPsFeedbackSource);
 
@@ -645,6 +649,26 @@ export function PsSettingsPanel() {
                 Default
               </button>
             </span>
+          </FieldRow>
+
+          <FieldRow
+            label="Feedback atten"
+            help="Feedback attenuation (dB). Manual alternative to Auto-attenuate — dial it so Observed sits mid-scale, then it persists per band."
+          >
+            <NumberInput
+              value={psTxFeedbackAttenuationDb}
+              min={psTxFeedbackAttenuationDbMin}
+              max={31}
+              step={1}
+              onChange={(v) => {
+                setPsTxFeedbackAttenuationDb(v);
+                setPsFeedbackAttenuation(v).catch(() => {});
+              }}
+              onCommit={(v) => {
+                setPsTxFeedbackAttenuationDb(v);
+                setPsFeedbackAttenuation(v).catch(() => {});
+              }}
+            />
           </FieldRow>
 
           <FieldRow

--- a/zeus-web/src/state/tx-store.ts
+++ b/zeus-web/src/state/tx-store.ts
@@ -217,6 +217,13 @@ export type TxState = {
   // mi0bot ref: PSForm.cs:830 pbWarningSetPk.Visible = _PShwpeak !=
   // HardwareSpecific.PSDefaultPeak.
   psHwPeakDefault: number;
+  // Live PS TX feedback attenuation (dB) and the per-board floor (HL2 -28,
+  // others 0; max 31). Server-authoritative — NOT persisted to localStorage
+  // (restored from the prefs DB on connect; persisting it client-side would
+  // re-introduce the localStorage-clobbers-server bug).
+  psTxFeedbackAttenuationDb: number;
+  setPsTxFeedbackAttenuationDb: (db: number) => void;
+  psTxFeedbackAttenuationDbMin: number;
   psIntsSpiPreset: string;
   setPsIntsSpiPreset: (p: string) => void;
   // Feedback antenna source — Internal coupler (default) or External
@@ -388,6 +395,9 @@ export const useTxStore = create<TxState>()(
       // the server will push the per-board value into the StateDto, and
       // hydrateFromState below picks it up. mi0bot PSForm.cs:830 ref.
       psHwPeakDefault: 0.4072,
+      psTxFeedbackAttenuationDb: 0,
+      setPsTxFeedbackAttenuationDb: (db) => set({ psTxFeedbackAttenuationDb: db }),
+      psTxFeedbackAttenuationDbMin: 0,
       psIntsSpiPreset: '16/256',
       setPsIntsSpiPreset: (p) => set({ psIntsSpiPreset: p }),
       psFeedbackSource: 'internal',
@@ -451,6 +461,8 @@ export const useTxStore = create<TxState>()(
           // operator-tuned psHwPeak so the UI sees a coherent pair.
           psHwPeak: s.psHwPeak,
           psHwPeakDefault: s.psHwPeakDefault,
+          psTxFeedbackAttenuationDb: s.psTxFeedbackAttenuationDb,
+          psTxFeedbackAttenuationDbMin: s.psTxFeedbackAttenuationDbMin,
           psCalibrationStalled: s.psCalibrationStalled ?? false,
           twoToneFreq1: s.twoToneFreq1,
           twoToneFreq2: s.twoToneFreq2,


### PR DESCRIPTION
Builds on the AutoAttenuate baseline-sync fix. Three parts:

1. Persist the converged feedback attenuation per board (`PsSettingsEntry.TxAttnByBoard`) and restore it to the radio on connect (P2 + HL2), so a fresh connect no longer boots at 0 dB attn and saturates the feedback ADC (the 'wouldn't even correct' case — feedback railed ~410; with restore it lands ~157, cor=1, info6=0x0000).
2. Manual 'Feedback atten' control — `StateDto.PsTxFeedbackAttenuationDb`, POST `/api/tx/ps/feedback-attenuation`, NumberInput in PsSettingsPanel (Thetis parity; not localStorage-persisted).
3. Demote the `wdsp.psHot` diagnostic log to Debug (was ~1 Hz Info spam during TX).

On-air validated on KB2UKA's G2 ('working, very clean'). Composes with the baseline-sync PR (restore sets radio attn on connect → dance reads it on arm). Solution builds clean; tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)