### PR TITLE
fix(ps): stop arming/disarming PS mid-TX from wedging calcc

### DIFF
--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -1931,10 +1931,20 @@ public sealed class WdspDspEngine : IDspEngine
                 // disabling PS while NOT keyed, push 7 zero-IQ blocks through
                 // psccF so the calcc state machine advances to LRESET cleanly
                 // and doesn't latch a stale curve in iqc on re-arm.
-                var zeros = new float[PsFeedbackBlockSize];
-                for (int i = 0; i < 7; i++)
+                //
+                // ONLY when not transmitting. Mid-MOX (operator aborting PS
+                // during a TX), the live feedback FB pump is still writing real
+                // samples into psccF; interleaving 7 manual zero blocks races
+                // that stream and can wedge calcc in LCALC. While keyed the
+                // live feedback advances calcc on its own, so the manual drain
+                // is both unnecessary and harmful — skip it.
+                if (!_moxOn)
                 {
-                    NativeMethods.psccF(id, PsFeedbackBlockSize, zeros, zeros, zeros, zeros, 0, 0);
+                    var zeros = new float[PsFeedbackBlockSize];
+                    for (int i = 0; i < 7; i++)
+                    {
+                        NativeMethods.psccF(id, PsFeedbackBlockSize, zeros, zeros, zeros, zeros, 0, 0);
+                    }
                 }
                 NativeMethods.SetPSRunCal(id, 0);
                 NativeMethods.SetPSControl(id, 1, 0, 0, 0);

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -711,7 +711,18 @@ public class DspPipelineService : BackgroundService,
             // flag locally and the C0=0x14 wire byte is unaffected
             // (board-gated in WriteAttenuatorPayload).
             var p1Active = _radio.ActiveClient;
-            if (s.PsEnabled)
+            if (s.PsEnabled && _keyed)
+            {
+                // Defer the ARM while transmitting. Arming mid-MOX fires
+                // calcc's SetPSControl(reset) into a live fit, which races the
+                // feedback stream and wedges calcc in LCALC on a stale curve
+                // (the mid-TX arm/disarm wedge — frozen info5, cor=1 but never
+                // updating → splatter). Re-arming mid-over isn't a real need;
+                // leaving _appliedPsEnabled stale here makes the
+                // OnRadioMoxChanged falling-edge re-apply arm it cleanly on
+                // key-up. Disarm (abort) below stays immediate.
+            }
+            else if (s.PsEnabled)
             {
                 _p2Client?.SetPsFeedbackEnabled(true);
                 p1Active?.SetPsEnabled(true);
@@ -743,7 +754,11 @@ public class DspPipelineService : BackgroundService,
                 p1Active?.SetPsEnabled(false);
                 DrainPsFeedback();
             }
-            _appliedPsEnabled = s.PsEnabled;
+            // Mark applied only when we actually armed or disarmed. A deferred
+            // (keyed) arm leaves _appliedPsEnabled stale on purpose so the
+            // MOX-off re-apply re-enters this block and arms.
+            if (!(s.PsEnabled && _keyed))
+                _appliedPsEnabled = s.PsEnabled;
         }
         if (resync || s.PsFeedbackSource != _appliedPsFeedbackSource)
         {

--- a/Zeus.Server.Hosting/PsAutoAttenuateService.cs
+++ b/Zeus.Server.Hosting/PsAutoAttenuateService.cs
@@ -152,6 +152,17 @@ public sealed class PsAutoAttenuateService : BackgroundService
     private bool _stallWarned;
     private static readonly TimeSpan StallThreshold = TimeSpan.FromSeconds(5);
 
+    // Wedge watchdog — distinct from the cal==0 stall above. Here calcc fit
+    // fine, then FROZE at a non-zero info5 while keyed in auto mode (the
+    // mid-TX arm/disarm wedge: stuck in LCALC, cor=1 on a stale curve →
+    // splatter). Auto mode re-fits continuously, so info5 frozen for
+    // >StallThreshold = wedged; recover with a clean calcc reset, rate-limited
+    // so a persistent wedge can't reset-storm. (Single-cal / manual hold
+    // legitimately freezes info5, so this is gated on auto mode only.)
+    private int _lastWedgeCal = -1;
+    private long _lastWedgeCalChangeMs;
+    private long _lastWedgeResetMs;
+
     // *** DEVIATION FROM mi0bot ***
     // Silent server-side auto-cal of WDSP hw_peak from observed TX envelope.
     // mi0bot exposes PSForm.cs txtPSpeak as a hand-dialed operator value
@@ -360,6 +371,34 @@ public sealed class PsAutoAttenuateService : BackgroundService
                 _radio.SetPsCalibrationStalled(false);
                 _log.LogInformation("psAutoAttn.stall.cleared info5={Cal}", stallPsm.CalibrationAttempts);
             }
+        }
+
+        // Wedge watchdog — info5 frozen at a NON-zero value while keyed in
+        // auto mode = calcc stalled in LCALC on a stale curve (see field
+        // comment). Reset calcc to recover; rate-limited to one reset per
+        // window so a hard wedge can't reset-storm. Gated on auto mode because
+        // single-cal / manual hold freezes info5 by design.
+        if (s.PsAuto && !s.PsSingle && stallPsm.CalibrationAttempts > 0)
+        {
+            long now = Environment.TickCount64;
+            if (stallPsm.CalibrationAttempts != _lastWedgeCal)
+            {
+                _lastWedgeCal = stallPsm.CalibrationAttempts;
+                _lastWedgeCalChangeMs = now;
+            }
+            else if (now - _lastWedgeCalChangeMs >= (long)StallThreshold.TotalMilliseconds
+                     && now - _lastWedgeResetMs >= (long)StallThreshold.TotalMilliseconds)
+            {
+                _lastWedgeResetMs = now;
+                _log.LogWarning(
+                    "psAutoAttn.wedge info5 frozen at {Cal} state={State} for {ElapsedMs}ms — calcc stalled (e.g. PS toggled mid-TX); resetting calcc.",
+                    stallPsm.CalibrationAttempts, stallPsm.CalState, now - _lastWedgeCalChangeMs);
+                engine.ResetPs();
+            }
+        }
+        else
+        {
+            _lastWedgeCal = -1;
         }
 
         // Auto-cal hw_peak from observed envelope. Independent of HL2/P2 path


### PR DESCRIPTION
Arming or disarming PureSignal mid-transmit could wedge WDSP calcc: info5 froze non-zero and cor=1 on a stale correction curve → splatter, recoverable only by unkey + clean re-arm.

Three layers: defer ARM while keyed (abort/disarm stay immediate); skip the not-keyed-only 7-zero psccF drain when MOX is on; extend the stall watchdog to catch a frozen non-zero info5 in auto mode → rate-limited `engine.ResetPs()`.

Built + tests green (711 server / 90 contracts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)