### PR TITLE
fix(ps): drop hot-path allocations + lift state-change P/Invokes out of _psLock (#559 slice 1)

### DIFF
--- a/Zeus.Dsp/Wdsp/NativeMethods.cs
+++ b/Zeus.Dsp/Wdsp/NativeMethods.cs
@@ -868,6 +868,21 @@ internal static partial class NativeMethods
                                        float[] Irxbuff, float[] Qrxbuff,
                                        int mox, int solidmox);
 
+    // Zero-allocation overload — used by FeedPsFeedbackBlock on the hot path
+    // so the engine doesn't have to .ToArray() its caller's spans on every
+    // 1024-sample block (~190 Hz @ 192 kHz, ~940 KB/sec of float allocations
+    // → GC pressure that freezes the same threads pumping feedback into
+    // calcc — see docs/rca/2026-05-28-ps-load-sensitivity.md). The native
+    // entry-point is identical; `ref float` lets P/Invoke pin the upstream
+    // buffer (typically rented from ArrayPool<float>.Shared) for the call
+    // duration without copying.
+    [LibraryImport(LibraryName, EntryPoint = "psccF")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void psccFSpan(int channel, int size,
+                                           ref float Itxbuff, ref float Qtxbuff,
+                                           ref float Irxbuff, ref float Qrxbuff,
+                                           int mox, int solidmox);
+
     [LibraryImport(LibraryName, StringMarshalling = StringMarshalling.Utf8)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial void PSSaveCorr(int channel, string filename);

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -1788,42 +1788,46 @@ public sealed class WdspDspEngine : IDspEngine
     {
         if (_disposed != 0) return;
         if (hwPeak <= 0.0 || hwPeak > 2.0) return;   // bogus value, ignore
+        int id;
         lock (_psLock)
         {
             _psHwPeak = hwPeak;
             int? txa;
             lock (_txaLock) txa = _txaChannelId;
-            if (txa is int id)
-            {
-                NativeMethods.SetPSHWPeak(id, hwPeak);
-            }
+            if (txa is not int channelId) return;
+            id = channelId;
         }
+        // P/Invoke outside _psLock — see docs/rca/2026-05-28-ps-load-sensitivity.md
+        // for why holding _psLock across native calls is the bidirectional-block
+        // pattern that lets state-change clicks stall FeedPsFeedbackBlock.
+        NativeMethods.SetPSHWPeak(id, hwPeak);
         _log.LogInformation("wdsp.setPsHwPeak peak={Peak:F4}", hwPeak);
     }
 
     public void SetPsControl(bool autoCal, bool singleCal)
     {
         if (_disposed != 0) return;
+        int id;
+        int reset, mancal, automode, turnon;
         lock (_psLock)
         {
             _psAuto = autoCal;
             _psSingle = singleCal;
             int? txa;
             lock (_txaLock) txa = _txaChannelId;
-            if (txa is not int id) return;
+            if (txa is not int channelId) return;
+            id = channelId;
             // (reset, mancal, automode, turnon) — see Thetis PSForm.cs.
             // Single takes precedence over auto when both true.
-            int reset = 0;
-            int mancal = singleCal ? 1 : 0;
-            int automode = (autoCal && !singleCal) ? 1 : 0;
-            int turnon = 0;
-            if (!autoCal && !singleCal)
-            {
-                // Both off → reset / idle.
-                reset = 1;
-            }
-            NativeMethods.SetPSControl(id, reset, mancal, automode, turnon);
+            mancal = singleCal ? 1 : 0;
+            automode = (autoCal && !singleCal) ? 1 : 0;
+            turnon = 0;
+            // Both off → reset / idle.
+            reset = (!autoCal && !singleCal) ? 1 : 0;
         }
+        // P/Invoke outside _psLock. SetPSControl in calcc.c is an atomic
+        // flag-store; safe to call concurrently with FeedPsFeedbackBlock.
+        NativeMethods.SetPSControl(id, reset, mancal, automode, turnon);
         _log.LogInformation("wdsp.setPsControl auto={Auto} single={Single}", autoCal, singleCal);
     }
 
@@ -1831,34 +1835,20 @@ public sealed class WdspDspEngine : IDspEngine
                               double ampDelayNs, double hwPeak, int ints, int spi)
     {
         if (_disposed != 0) return;
+        int id;
+        bool doPtol, doMoxDelay, doLoopDelay, doAmpDelay, doHwPeak, doIntsSpi;
         lock (_psLock)
         {
             int? txa;
             lock (_txaLock) txa = _txaChannelId;
-            int id = txa ?? -1;
+            id = txa ?? -1;
 
-            if (ptol != _psPtol)
-            {
-                _psPtol = ptol;
-                // ptol=true → relax 0.4; ptol=false → strict 0.8
-                // (pihpsdr transmitter.c:2517 / Thetis PSForm.cs).
-                if (id >= 0) NativeMethods.SetPSPtol(id, ptol ? 0.4 : 0.8);
-            }
-            if (moxDelaySec != _psMoxDelaySec)
-            {
-                _psMoxDelaySec = moxDelaySec;
-                if (id >= 0) NativeMethods.SetPSMoxDelay(id, moxDelaySec);
-            }
-            if (loopDelaySec != _psLoopDelaySec)
-            {
-                _psLoopDelaySec = loopDelaySec;
-                if (id >= 0) NativeMethods.SetPSLoopDelay(id, loopDelaySec);
-            }
-            if (ampDelayNs != _psAmpDelayNs)
-            {
-                _psAmpDelayNs = ampDelayNs;
-                if (id >= 0) _ = NativeMethods.SetPSTXDelay(id, ampDelayNs * 1e-9);
-            }
+            // ptol=true → relax 0.4; ptol=false → strict 0.8
+            // (pihpsdr transmitter.c:2517 / Thetis PSForm.cs).
+            doPtol = ptol != _psPtol;
+            doMoxDelay = moxDelaySec != _psMoxDelaySec;
+            doLoopDelay = loopDelaySec != _psLoopDelaySec;
+            doAmpDelay = ampDelayNs != _psAmpDelayNs;
             // mi0bot: PSForm.cs PSpeak_TextChanged calls
             // puresignal.SetPSHWPeak(_txachannel, _PShwpeak) unconditionally on
             // every TextChanged, with no equality guard against the prior
@@ -1866,19 +1856,29 @@ public sealed class WdspDspEngine : IDspEngine
             // value to clear an info[6]=0x0044 fault state without typing a
             // different value first. Range check stays (mi0bot stops the
             // operator at the WinForms NUD min/max).
-            if (hwPeak > 0.0 && hwPeak <= 2.0)
-            {
-                _psHwPeak = hwPeak;
-                if (id >= 0) NativeMethods.SetPSHWPeak(id, hwPeak);
-            }
+            doHwPeak = hwPeak > 0.0 && hwPeak <= 2.0;
             // Only call SetPSIntsAndSpi when the values actually changed —
             // it's a heavy restart inside calcc.c (allocates new buffers).
-            if (ints > 0 && spi > 0 && (ints != _psInts || spi != _psSpi))
-            {
-                _psInts = ints;
-                _psSpi = spi;
-                if (id >= 0) NativeMethods.SetPSIntsAndSpi(id, ints, spi);
-            }
+            doIntsSpi = ints > 0 && spi > 0 && (ints != _psInts || spi != _psSpi);
+
+            if (doPtol) _psPtol = ptol;
+            if (doMoxDelay) _psMoxDelaySec = moxDelaySec;
+            if (doLoopDelay) _psLoopDelaySec = loopDelaySec;
+            if (doAmpDelay) _psAmpDelayNs = ampDelayNs;
+            if (doHwPeak) _psHwPeak = hwPeak;
+            if (doIntsSpi) { _psInts = ints; _psSpi = spi; }
+        }
+        // P/Invokes outside _psLock — six independent native calls; holding
+        // _psLock across the chain blocks FeedPsFeedbackBlock for the full
+        // duration. None of these calls read or write _ps* fields.
+        if (id >= 0)
+        {
+            if (doPtol) NativeMethods.SetPSPtol(id, ptol ? 0.4 : 0.8);
+            if (doMoxDelay) NativeMethods.SetPSMoxDelay(id, moxDelaySec);
+            if (doLoopDelay) NativeMethods.SetPSLoopDelay(id, loopDelaySec);
+            if (doAmpDelay) _ = NativeMethods.SetPSTXDelay(id, ampDelayNs * 1e-9);
+            if (doHwPeak) NativeMethods.SetPSHWPeak(id, hwPeak);
+            if (doIntsSpi) NativeMethods.SetPSIntsAndSpi(id, ints, spi);
         }
         _log.LogInformation(
             "wdsp.setPsAdvanced ptol={Ptol} mox={Mox:F3}s loop={Loop:F3}s amp={Amp:F1}ns peak={Peak:F4} ints={Ints} spi={Spi}",
@@ -1888,15 +1888,19 @@ public sealed class WdspDspEngine : IDspEngine
     public void SetPsEnabled(bool enabled)
     {
         if (_disposed != 0) return;
+        int id;
+        int armMancal = 0, armAutomode = 0;
+        bool doDrain = false;
         lock (_psLock)
         {
             int? txa;
             lock (_txaLock) txa = _txaChannelId;
-            if (txa is not int id)
+            if (txa is not int channelId)
             {
                 _psEnabled = false;
                 return;
             }
+            id = channelId;
 
             if (enabled)
             {
@@ -1905,58 +1909,74 @@ public sealed class WdspDspEngine : IDspEngine
                 // and the first 100 pscc blocks log on every fresh arm.
                 _lastLoggedPsState = 255;
                 Interlocked.Exchange(ref _psFeedCount, 0);
-                NativeMethods.SetPSRunCal(id, 1);
-                int mancal = _psSingle ? 1 : 0;
-                int automode = (_psAuto && !_psSingle) ? 1 : 0;
-                // reset=1 forces a clean LRESET transit so a re-arm after a
-                // single-cal cycle (which can leave the SM in LSTAYON) starts
-                // a fresh fit (Thetis PSForm.cs:645,661).
-                NativeMethods.SetPSControl(id, 1, mancal, automode, 0);
-                // Open the PS-feedback display analyzer (issue #121). Inherits
-                // pixel width / zoom / matched RX rate from the TX analyzer so
-                // the PS-Monitor pan/wf frames slot into the same widget the
-                // TX analyzer is rendering into. Skipped when TX analyzer is
-                // off (no RXA, or P1 P2 rate-ratio mismatch) — the toggle
-                // becomes a no-op in that case and Tick keeps falling through
-                // to the existing TX/RX trace.
-                OpenPsFeedbackAnalyzer(id);
+                armMancal = _psSingle ? 1 : 0;
+                armAutomode = (_psAuto && !_psSingle) ? 1 : 0;
             }
             else
             {
                 _psEnabled = false;
-                // Tear down the PS-FB analyzer first so a stale GetPixels
-                // call from Tick doesn't race with WDSP cleaning up the slot.
-                ClosePsFeedbackAnalyzer();
-                // pihpsdr shutdown gotcha (transmitter.c:2422-2444): when
-                // disabling PS while NOT keyed, push 7 zero-IQ blocks through
-                // psccF so the calcc state machine advances to LRESET cleanly
-                // and doesn't latch a stale curve in iqc on re-arm.
-                //
-                // ONLY when not transmitting. Mid-MOX (operator aborting PS
-                // during a TX), the live feedback FB pump is still writing real
-                // samples into psccF; interleaving 7 manual zero blocks races
-                // that stream and can wedge calcc in LCALC. While keyed the
-                // live feedback advances calcc on its own, so the manual drain
-                // is both unnecessary and harmful — skip it.
-                if (!_moxOn)
-                {
-                    var zeros = new float[PsFeedbackBlockSize];
-                    for (int i = 0; i < 7; i++)
-                    {
-                        NativeMethods.psccF(id, PsFeedbackBlockSize, zeros, zeros, zeros, zeros, 0, 0);
-                    }
-                }
-                NativeMethods.SetPSRunCal(id, 0);
-                NativeMethods.SetPSControl(id, 1, 0, 0, 0);
+                // ONLY drain when not transmitting. Mid-MOX (operator aborting
+                // PS during a TX), the live feedback FB pump is still writing
+                // real samples into psccF; interleaving 7 manual zero blocks
+                // races that stream and can wedge calcc in LCALC. While keyed
+                // the live feedback advances calcc on its own, so the manual
+                // drain is both unnecessary and harmful — skip it.
+                doDrain = !_moxOn;
             }
+        }
+
+        // P/Invokes outside _psLock — the arm sequence (SetPSRunCal +
+        // SetPSControl + analyzer open) and the disarm sequence (analyzer
+        // close + zero-block drain + SetPSRunCal + SetPSControl) used to
+        // span the lock for hundreds of microseconds, blocking the
+        // FeedPsFeedbackBlock hot path. See docs/rca/2026-05-28-ps-load-
+        // sensitivity.md. The analyzer methods carry their own _psFbDispLock
+        // for the spectrum-slot races, so they're safe to call here.
+        if (enabled)
+        {
+            NativeMethods.SetPSRunCal(id, 1);
+            // reset=1 forces a clean LRESET transit so a re-arm after a
+            // single-cal cycle (which can leave the SM in LSTAYON) starts
+            // a fresh fit (Thetis PSForm.cs:645,661).
+            NativeMethods.SetPSControl(id, 1, armMancal, armAutomode, 0);
+            // Open the PS-feedback display analyzer (issue #121). Inherits
+            // pixel width / zoom / matched RX rate from the TX analyzer so
+            // the PS-Monitor pan/wf frames slot into the same widget the
+            // TX analyzer is rendering into. Skipped when TX analyzer is
+            // off (no RXA, or P1 P2 rate-ratio mismatch) — the toggle
+            // becomes a no-op in that case and Tick keeps falling through
+            // to the existing TX/RX trace.
+            OpenPsFeedbackAnalyzer(id);
+        }
+        else
+        {
+            // Tear down the PS-FB analyzer first so a stale GetPixels
+            // call from Tick doesn't race with WDSP cleaning up the slot.
+            ClosePsFeedbackAnalyzer();
+            // pihpsdr shutdown gotcha (transmitter.c:2422-2444): when
+            // disabling PS while NOT keyed, push 7 zero-IQ blocks through
+            // psccF so the calcc state machine advances to LRESET cleanly
+            // and doesn't latch a stale curve in iqc on re-arm.
+            if (doDrain)
+            {
+                var zeros = new float[PsFeedbackBlockSize];
+                for (int i = 0; i < 7; i++)
+                {
+                    NativeMethods.psccF(id, PsFeedbackBlockSize, zeros, zeros, zeros, zeros, 0, 0);
+                }
+            }
+            NativeMethods.SetPSRunCal(id, 0);
+            NativeMethods.SetPSControl(id, 1, 0, 0, 0);
         }
         _log.LogInformation("wdsp.setPsEnabled enabled={Enabled}", enabled);
     }
 
-    // Open / configure the PS-feedback display analyzer. Caller holds
-    // _psLock. Mirrors the TX analyzer's pixel width / zoom / matched RX
-    // sample rate so DspPipelineService.Tick can pick between TX-pixels and
-    // PS-FB-pixels per tick without a buffer resize.
+    // Open / configure the PS-feedback display analyzer. Protected internally
+    // by _psFbDispLock (the spectrum-slot lock). Mirrors the TX analyzer's
+    // pixel width / zoom / matched RX sample rate so DspPipelineService.Tick
+    // can pick between TX-pixels and PS-FB-pixels per tick without a buffer
+    // resize. Called from SetPsEnabled outside _psLock so the analyzer
+    // CreateAnalyzer/SetAnalyzer P/Invokes don't stall FeedPsFeedbackBlock.
     private void OpenPsFeedbackAnalyzer(int txaId)
     {
         // Snapshot TX-display geometry under its own lock — we need it whether
@@ -2018,10 +2038,11 @@ public sealed class WdspDspEngine : IDspEngine
         }
     }
 
-    // Tear down the PS-feedback display analyzer. Caller holds _psLock so
-    // FeedPsFeedbackBlock can't race in mid-Spectrum0; combined with
-    // _psFbDispLock around GetPixels / Spectrum0 this keeps the analyzer slot
-    // safe to destroy.
+    // Tear down the PS-feedback display analyzer. _psFbDispLock protects the
+    // analyzer slot itself (around GetPixels / Spectrum0 / DestroyAnalyzer);
+    // FeedPsFeedbackBlock's Spectrum0 hand-off is gated by an _psFbDispAlive
+    // check under the same lock, so a concurrent feed can't race through with
+    // a stale slot id. Called from SetPsEnabled outside _psLock.
     private void ClosePsFeedbackAnalyzer()
     {
         lock (_psFbDispLock)
@@ -2058,18 +2079,23 @@ public sealed class WdspDspEngine : IDspEngine
         lock (_txaLock) txa = _txaChannelId;
         if (txa is not int id) return;
 
-        // psccF takes float[] (not Span). Allocate fresh — caller may reuse
-        // its buffers immediately after this returns.
-        var bufTxI = txI.ToArray();
-        var bufTxQ = txQ.ToArray();
-        var bufRxI = rxI.ToArray();
-        var bufRxQ = rxQ.ToArray();
-
         lock (_psLock)
         {
             // mox/solidmox args are ignored by psccF (calcc.c:846); SetPSMox
             // is the source of truth and is driven from SetMox above.
-            NativeMethods.psccF(id, PsFeedbackBlockSize, bufTxI, bufTxQ, bufRxI, bufRxQ, 0, 0);
+            //
+            // Pin the upstream spans via `ref float` so P/Invoke pins for the
+            // call duration — no managed copy. The buffers belong to the
+            // upstream sink (Protocol{1,2}Client → DspPipelineService rents
+            // from ArrayPool<float>.Shared and returns post-call). See
+            // docs/rca/2026-05-28-ps-load-sensitivity.md for why the prior
+            // .ToArray() pattern was load-sensitive.
+            NativeMethods.psccFSpan(id, PsFeedbackBlockSize,
+                ref MemoryMarshal.GetReference(txI),
+                ref MemoryMarshal.GetReference(txQ),
+                ref MemoryMarshal.GetReference(rxI),
+                ref MemoryMarshal.GetReference(rxQ),
+                0, 0);
             long n = Interlocked.Increment(ref _psFeedCount);
             if (n % 100 == 1)
             {
@@ -2100,8 +2126,8 @@ public sealed class WdspDspEngine : IDspEngine
                 Span<double> psSpectrumIq = stackalloc double[2 * PsFeedbackBlockSize];
                 for (int i = 0; i < PsFeedbackBlockSize; i++)
                 {
-                    psSpectrumIq[2 * i] = bufRxI[i];
-                    psSpectrumIq[2 * i + 1] = -bufRxQ[i];
+                    psSpectrumIq[2 * i] = rxI[i];
+                    psSpectrumIq[2 * i + 1] = -rxQ[i];
                 }
                 lock (_psFbDispLock)
                 {
@@ -2130,28 +2156,38 @@ public sealed class WdspDspEngine : IDspEngine
         // the PsMeters frame.
         if (!_psEnabled) return PsStageMeters.Silent;
 
-        // Pin the int[16] buffer for the duration of the GetPSInfo call so
-        // WDSP can write into it. Re-using the same buffer between calls is
-        // fine because GetPSInfo writes synchronously.
+        // Pin a stack-local int[16] for the GetPSInfo write so we don't have to
+        // hold _psLock across the P/Invoke. The shared _psInfoBuf field is only
+        // updated under the lock from the freshly-read scratch values, so the
+        // per-call edge-triggered logs below still see a coherent snapshot.
+        // See docs/rca/2026-05-28-ps-load-sensitivity.md — the prior pattern
+        // held _psLock across both GetPSInfo and GetPSMaxTX, which on a hot
+        // meter cadence (~10 Hz) blocked FeedPsFeedbackBlock on every poll.
         int feedbackRaw;
         byte calState;
         bool correcting;
         double maxTx;
         int calibrationAttempts;
+        Span<int> infoScratch = stackalloc int[16];
+        unsafe
+        {
+            fixed (int* p = infoScratch)
+            {
+                NativeMethods.GetPSInfo(id, (IntPtr)p);
+            }
+        }
+        NativeMethods.GetPSMaxTX(id, out maxTx);
+        feedbackRaw = infoScratch[4];
+        correcting = infoScratch[14] != 0;
+        calState = (byte)Math.Clamp(infoScratch[15], 0, 255);
+        calibrationAttempts = infoScratch[5];
         lock (_psLock)
         {
-            unsafe
-            {
-                fixed (int* p = _psInfoBuf)
-                {
-                    NativeMethods.GetPSInfo(id, (IntPtr)p);
-                }
-            }
-            feedbackRaw = _psInfoBuf[4];
-            correcting = _psInfoBuf[14] != 0;
-            calState = (byte)Math.Clamp(_psInfoBuf[15], 0, 255);
-            calibrationAttempts = _psInfoBuf[5];
-            NativeMethods.GetPSMaxTX(id, out maxTx);
+            // Mirror the scratch read into _psInfoBuf so subsequent log
+            // statements that index by field name (info4..info15 below) see
+            // a consistent snapshot, and so _psMaxTxEnvelope publishes
+            // atomically. Pure memcpy + scalar store — no P/Invoke.
+            for (int i = 0; i < 16; i++) _psInfoBuf[i] = infoScratch[i];
             _psMaxTxEnvelope = maxTx;
         }
 
@@ -2225,23 +2261,33 @@ public sealed class WdspDspEngine : IDspEngine
         int? txa;
         lock (_txaLock) txa = _txaChannelId;
         if (txa is not int id) return;
+        int mancal, automode;
+        bool autoSnapshot, singleSnapshot;
         lock (_psLock)
         {
-            // Two-phase reset+restore — matches Thetis PSForm.cs:760-783
-            // (timer2code Monitor → SetNewValues → RestoreOperation) and
-            // pihpsdr's tx_ps_reset → tx_ps_resume pattern (transmitter.c
-            // :2478-2502). Phase 1 clears calcc to LRESET with mancal/
-            // automode zeroed (drops any in-flight fit). Phase 2 restores
-            // the saved Auto/Single mode so calcc autorestarts. Without
-            // phase 2, automode stays 0 and calcc parks at LRESET forever
-            // — which on a Patch-A-gated AutoAttenuate loop means info[5]
-            // never increments past 1 and the loop stalls after one step.
-            NativeMethods.SetPSControl(id, 1, 0, 0, 0);
-            int mancal = _psSingle ? 1 : 0;
-            int automode = (_psAuto && !_psSingle) ? 1 : 0;
-            NativeMethods.SetPSControl(id, 0, mancal, automode, 0);
+            // Snapshot the auto/single state under lock for both the P/Invoke
+            // args and the log line — keeps the two calls' view consistent
+            // even if SetPsControl races concurrently.
+            autoSnapshot = _psAuto;
+            singleSnapshot = _psSingle;
+            mancal = singleSnapshot ? 1 : 0;
+            automode = (autoSnapshot && !singleSnapshot) ? 1 : 0;
         }
-        _log.LogInformation("wdsp.resetPs auto={Auto} single={Single}", _psAuto, _psSingle);
+        // Two-phase reset+restore — matches Thetis PSForm.cs:760-783
+        // (timer2code Monitor → SetNewValues → RestoreOperation) and
+        // pihpsdr's tx_ps_reset → tx_ps_resume pattern (transmitter.c
+        // :2478-2502). Phase 1 clears calcc to LRESET with mancal/
+        // automode zeroed (drops any in-flight fit). Phase 2 restores
+        // the saved Auto/Single mode so calcc autorestarts. Without
+        // phase 2, automode stays 0 and calcc parks at LRESET forever
+        // — which on a Patch-A-gated AutoAttenuate loop means info[5]
+        // never increments past 1 and the loop stalls after one step.
+        //
+        // P/Invokes outside _psLock — calcc's SetPSControl is an atomic
+        // flag-store; safe with concurrent FeedPsFeedbackBlock.
+        NativeMethods.SetPSControl(id, 1, 0, 0, 0);
+        NativeMethods.SetPSControl(id, 0, mancal, automode, 0);
+        _log.LogInformation("wdsp.resetPs auto={Auto} single={Single}", autoSnapshot, singleSnapshot);
     }
 
     public void SavePsCorrection(string path)
@@ -2251,10 +2297,11 @@ public sealed class WdspDspEngine : IDspEngine
         int? txa;
         lock (_txaLock) txa = _txaChannelId;
         if (txa is not int id) return;
-        lock (_psLock)
-        {
-            NativeMethods.PSSaveCorr(id, path);
-        }
+        // PSSaveCorr does file I/O inside WDSP; holding _psLock across it
+        // blocks FeedPsFeedbackBlock for the full disk write. The save is
+        // a leaf operation — no shared state mutation — so the lock buys
+        // nothing here. See docs/rca/2026-05-28-ps-load-sensitivity.md.
+        NativeMethods.PSSaveCorr(id, path);
         _log.LogInformation("wdsp.savePsCorrection path={Path}", path);
     }
 
@@ -2265,12 +2312,12 @@ public sealed class WdspDspEngine : IDspEngine
         int? txa;
         lock (_txaLock) txa = _txaChannelId;
         if (txa is not int id) return;
-        lock (_psLock)
-        {
-            NativeMethods.PSRestoreCorr(id, path);
-            // Restore-and-go pattern from Thetis PSForm.cs:982-1162: turnon=1
-            NativeMethods.SetPSControl(id, 0, 0, 0, 1);
-        }
+        // P/Invokes outside _psLock — PSRestoreCorr reads from disk; the
+        // follow-up SetPSControl(turnon=1) is an atomic flag store. Neither
+        // touches _ps* fields, so the lock buys nothing here.
+        NativeMethods.PSRestoreCorr(id, path);
+        // Restore-and-go pattern from Thetis PSForm.cs:982-1162: turnon=1
+        NativeMethods.SetPSControl(id, 0, 0, 0, 1);
         _log.LogInformation("wdsp.restorePsCorrection path={Path}", path);
     }
 

--- a/Zeus.Protocol1/Protocol1Client.cs
+++ b/Zeus.Protocol1/Protocol1Client.cs
@@ -382,27 +382,40 @@ public sealed class Protocol1Client : IProtocol1Client
 
                 if (_psBlockFill >= PsFeedbackBlockSize)
                 {
-                    var txI = new float[PsFeedbackBlockSize];
-                    var txQ = new float[PsFeedbackBlockSize];
-                    var rxI = new float[PsFeedbackBlockSize];
-                    var rxQ = new float[PsFeedbackBlockSize];
+                    // Rent from ArrayPool so we don't allocate ~940 KB/sec of
+                    // float[] on the PS hot path. The sink (DspPipelineService.
+                    // OnPsFeedbackFrame) returns the four arrays to the pool
+                    // after the engine has consumed them — see
+                    // docs/rca/2026-05-28-ps-load-sensitivity.md for the
+                    // alloc-pressure ↔ GC ↔ feedback-thread-stall chain.
+                    var txI = ArrayPool<float>.Shared.Rent(PsFeedbackBlockSize);
+                    var txQ = ArrayPool<float>.Shared.Rent(PsFeedbackBlockSize);
+                    var rxI = ArrayPool<float>.Shared.Rent(PsFeedbackBlockSize);
+                    var rxQ = ArrayPool<float>.Shared.Rent(PsFeedbackBlockSize);
                     Array.Copy(_psTxI, txI, PsFeedbackBlockSize);
                     Array.Copy(_psTxQ, txQ, PsFeedbackBlockSize);
                     Array.Copy(_psRxI, rxI, PsFeedbackBlockSize);
                     Array.Copy(_psRxQ, rxQ, PsFeedbackBlockSize);
                     var psFrame = new PsFeedbackFrame(txI, txQ, rxI, rxQ, _psBlockStartSeq);
-                    // iter5: prefer the synchronous sink when attached. PS-feedback
-                    // buffers are plain float[] (not pooled), so a sink-throws path
-                    // just drops the block — no ArrayPool fallout.
+                    bool published = false;
                     var psSinkSnap = Volatile.Read(ref _rxSink);
                     if (psSinkSnap != null)
                     {
-                        try { psSinkSnap.OnPsFeedbackFrame(in psFrame); }
+                        try { psSinkSnap.OnPsFeedbackFrame(in psFrame); published = true; }
                         catch (Exception ex) { _log.LogError(ex, "p1.rx.sink_threw kind=psfb"); }
                     }
-                    else
+                    else if (_psFeedbackFrames.Writer.TryWrite(psFrame))
                     {
-                        _psFeedbackFrames.Writer.TryWrite(psFrame);
+                        published = true;
+                    }
+                    if (!published)
+                    {
+                        // No consumer took ownership — return the rentals so the
+                        // pool isn't bled by sink throws or full channels.
+                        ArrayPool<float>.Shared.Return(txI);
+                        ArrayPool<float>.Shared.Return(txQ);
+                        ArrayPool<float>.Shared.Return(rxI);
+                        ArrayPool<float>.Shared.Return(rxQ);
                     }
                     _psBlockFill = 0;
 

--- a/Zeus.Protocol1/PsFeedbackFrame.cs
+++ b/Zeus.Protocol1/PsFeedbackFrame.cs
@@ -38,10 +38,25 @@ namespace Zeus.Protocol1;
 /// SeqHint is the radio's EP6 sequence at the start of the block,
 /// useful for diagnostic logging when the cal converges slowly. Not
 /// used by WDSP.
+///
+/// <para><b>Buffer ownership:</b> <c>TxI/TxQ/RxI/RxQ</c> are rented from
+/// <see cref="System.Buffers.ArrayPool{T}"/>.Shared by Protocol1Client. The
+/// receiving sink (DspPipelineService.OnPsFeedbackFrame) owns the rentals
+/// once the frame is handed off and MUST return them to the pool after the
+/// engine has consumed them. The actual array length may exceed
+/// <c>PsFeedbackBlockSize</c> (1024) — ArrayPool's size guarantee is
+/// "at-least," so consumers must use a fixed 1024-sample view.</para>
 /// </summary>
 public readonly record struct PsFeedbackFrame(
     float[] TxI,
     float[] TxQ,
     float[] RxI,
     float[] RxQ,
-    ulong SeqHint);
+    ulong SeqHint)
+{
+    /// <summary>Wire-fixed block length WDSP <c>psccF</c> expects, per
+    /// pihpsdr <c>receiver.c:636</c>. The producer always fills exactly this
+    /// many samples; the rented arrays may be larger (ArrayPool size
+    /// guarantee is "at-least").</summary>
+    public const int BlockSize = 1024;
+}

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -42,6 +42,7 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Net;
@@ -1695,26 +1696,36 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
 
             if (_psBlockFill >= PsFeedbackBlockSize)
             {
-                // Copy out — caller may reuse the buffers immediately.
-                var txI = new float[PsFeedbackBlockSize];
-                var txQ = new float[PsFeedbackBlockSize];
-                var rxI = new float[PsFeedbackBlockSize];
-                var rxQ = new float[PsFeedbackBlockSize];
+                // Rent from ArrayPool — see Protocol1Client.HandlePs4DdcPacket
+                // for the rationale (and docs/rca/2026-05-28-ps-load-
+                // sensitivity.md). Sink returns the rentals to the pool after
+                // the engine has consumed them.
+                var txI = ArrayPool<float>.Shared.Rent(PsFeedbackBlockSize);
+                var txQ = ArrayPool<float>.Shared.Rent(PsFeedbackBlockSize);
+                var rxI = ArrayPool<float>.Shared.Rent(PsFeedbackBlockSize);
+                var rxQ = ArrayPool<float>.Shared.Rent(PsFeedbackBlockSize);
                 Array.Copy(_psTxI, txI, PsFeedbackBlockSize);
                 Array.Copy(_psTxQ, txQ, PsFeedbackBlockSize);
                 Array.Copy(_psRxI, rxI, PsFeedbackBlockSize);
                 Array.Copy(_psRxQ, rxQ, PsFeedbackBlockSize);
                 var psFrame = new PsFeedbackFrame(txI, txQ, rxI, rxQ, _psBlockStartSeq);
-                // iter5: prefer the synchronous sink when attached.
+                bool published = false;
                 var psSinkSnap = Volatile.Read(ref _rxSink);
                 if (psSinkSnap != null)
                 {
-                    try { psSinkSnap.OnPsFeedbackFrame(in psFrame); }
+                    try { psSinkSnap.OnPsFeedbackFrame(in psFrame); published = true; }
                     catch (Exception ex) { _log.LogError(ex, "p2.rx.sink_threw kind=psfb"); }
                 }
-                else
+                else if (_psFeedbackFrames.Writer.TryWrite(psFrame))
                 {
-                    _psFeedbackFrames.Writer.TryWrite(psFrame);
+                    published = true;
+                }
+                if (!published)
+                {
+                    ArrayPool<float>.Shared.Return(txI);
+                    ArrayPool<float>.Shared.Return(txQ);
+                    ArrayPool<float>.Shared.Return(rxI);
+                    ArrayPool<float>.Shared.Return(rxQ);
                 }
                 _psBlockFill = 0;
             }

--- a/Zeus.Protocol2/PsFeedbackFrame.cs
+++ b/Zeus.Protocol2/PsFeedbackFrame.cs
@@ -36,10 +36,25 @@ namespace Zeus.Protocol2;
 ///
 /// SeqHint is the radio's UDP sequence at the start of the block, useful
 /// for diagnostic logging when the cal converges slowly. Not used by WDSP.
+///
+/// <para><b>Buffer ownership:</b> <c>TxI/TxQ/RxI/RxQ</c> are rented from
+/// <see cref="System.Buffers.ArrayPool{T}"/>.Shared by Protocol2Client. The
+/// receiving sink (DspPipelineService.OnPsFeedbackFrame) owns the rentals
+/// once the frame is handed off and MUST return them to the pool after the
+/// engine has consumed them. The actual array length may exceed
+/// <c>PsFeedbackBlockSize</c> (1024) — ArrayPool's size guarantee is
+/// "at-least," so consumers must use a fixed 1024-sample view.</para>
 /// </summary>
 public readonly record struct PsFeedbackFrame(
     float[] TxI,
     float[] TxQ,
     float[] RxI,
     float[] RxQ,
-    ulong SeqHint);
+    ulong SeqHint)
+{
+    /// <summary>Wire-fixed block length WDSP <c>psccF</c> expects, per
+    /// pihpsdr <c>receiver.c:636</c>. The producer always fills exactly this
+    /// many samples; the rented arrays may be larger (ArrayPool size
+    /// guarantee is "at-least").</summary>
+    public const int BlockSize = 1024;
+}

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -151,6 +151,11 @@ public class DspPipelineService : BackgroundService,
     // so OnRadioStateChanged only fires the (possibly heavy)
     // SetPsIntsAndSpi / SetPsRunCal calls when the value actually moves.
     private bool _appliedPsEnabled;
+    // Generation counter for the non-blocking deferred PS arm — bumped on
+    // every PS-state transition so a scheduled arm that fires after the
+    // operator has flipped PS off (or off→on→off within 100 ms) compares
+    // generations and skips. See OnRadioStateChanged below.
+    private int _psArmGeneration;
     private bool _appliedPsAuto = true;
     private bool _appliedPsSingle;
     private bool _appliedPsPtol;
@@ -730,12 +735,20 @@ public class DspPipelineService : BackgroundService,
             // binfo[6], bs_count climbs to 2, calcc resets to LRESET — and
             // the loop sometimes thrashes instead of converging.
             //
-            // Disarm path stays engine-first: drop the engine run flag, then
-            // close the wire, then drain any in-flight paired frames so they
-            // don't arrive after PS has shut down.
+            // The settle is now non-blocking: we schedule the engine arm 100 ms
+            // out via Task.Delay continuation, so the state-change handler
+            // returns immediately and doesn't stall other state work (the
+            // previous blocking .Wait() was the symptom that froze RX audio +
+            // waterfall on the non-HL2 P1 stack — GH #426 — and contributed
+            // to the load-sensitive PS path documented in
+            // docs/rca/2026-05-28-ps-load-sensitivity.md). A generation
+            // counter (_psArmGeneration) lets any later PS-state transition
+            // cancel an in-flight deferred arm so a fast off→on→off (or PS-on
+            // followed by key-down) can't re-arm against operator intent.
             //
-            // Task.Delay(100).Wait() is acceptable here — OnRadioStateChanged
-            // runs on a state-change handler thread, not the request path.
+            // Disarm path stays engine-first AND synchronous: drop the engine
+            // run flag, then close the wire, then drain any in-flight paired
+            // frames so they don't arrive after PS has shut down.
             //
             // P1 sibling (issue #172): the active P1 client gets the same
             // arm/disarm sequencing — flip the wire bit (which also
@@ -768,22 +781,35 @@ public class DspPipelineService : BackgroundService,
                 // wire bump) and :1004 (4-DDC parser path) are both HL2-gated.
                 // On a non-HL2 P1 board WDSP arms with no possible feedback
                 // source, sits in COLLECT waiting on paired samples that
-                // never arrive, and the blocking 100 ms settle below stacks
-                // on the state-change thread — together that freezes RX
-                // audio + waterfall (GH #426). Skip the engine arm in that
-                // case; the wire calls above are no-ops on non-HL2 P1
-                // (board-gated in WriteAttenuatorPayload + SnapshotState).
+                // never arrive (GH #426). Skip the engine arm in that case;
+                // the wire calls above are no-ops on non-HL2 P1 (board-gated
+                // in WriteAttenuatorPayload + SnapshotState).
                 bool p1Connected = p1Active is not null;
                 bool psEngineSupported = !p1Connected
                     || _radio.ConnectedBoardKind == HpsdrBoardKind.HermesLite2;
                 if (psEngineSupported)
                 {
-                    try { Task.Delay(100).Wait(); } catch { /* ignore */ }
-                    engine.SetPsEnabled(true);
+                    int gen = Interlocked.Increment(ref _psArmGeneration);
+                    var engineCapture = engine;
+                    _ = Task.Delay(100).ContinueWith(_ =>
+                    {
+                        // Skip if a newer PS-state transition has been scheduled
+                        // (off, or off→on with a different gen). Also skip if
+                        // the operator keyed up during the settle — arm runs on
+                        // the falling-MOX edge re-apply instead.
+                        if (Volatile.Read(ref _psArmGeneration) != gen) return;
+                        if (_keyed) return;
+                        try { engineCapture.SetPsEnabled(true); }
+                        catch (Exception ex) { _log.LogWarning(ex, "deferred ps-arm threw"); }
+                    }, TaskScheduler.Default);
                 }
             }
             else
             {
+                // Bump the generation so any in-flight deferred arm from a
+                // prior off→on cycle within the last 100 ms self-cancels at
+                // fire time.
+                Interlocked.Increment(ref _psArmGeneration);
                 engine.SetPsEnabled(false);
                 _p2Client?.SetPsFeedbackEnabled(false);
                 p1Active?.SetPsEnabled(false);
@@ -1371,7 +1397,25 @@ public class DspPipelineService : BackgroundService,
     {
         DrainDspCommands();
         var engine = Volatile.Read(ref _engine);
-        engine?.FeedPsFeedbackBlock(frame.TxI, frame.TxQ, frame.RxI, frame.RxQ);
+        try
+        {
+            // Slice to the wire-fixed block size — ArrayPool may return larger
+            // arrays than requested. Engine validates Length == BlockSize.
+            engine?.FeedPsFeedbackBlock(
+                frame.TxI.AsSpan(0, Zeus.Protocol1.PsFeedbackFrame.BlockSize),
+                frame.TxQ.AsSpan(0, Zeus.Protocol1.PsFeedbackFrame.BlockSize),
+                frame.RxI.AsSpan(0, Zeus.Protocol1.PsFeedbackFrame.BlockSize),
+                frame.RxQ.AsSpan(0, Zeus.Protocol1.PsFeedbackFrame.BlockSize));
+        }
+        finally
+        {
+            // Return the rentals — the protocol client handed ownership to us
+            // (see Zeus.Protocol1.PsFeedbackFrame XML doc for the contract).
+            System.Buffers.ArrayPool<float>.Shared.Return(frame.TxI);
+            System.Buffers.ArrayPool<float>.Shared.Return(frame.TxQ);
+            System.Buffers.ArrayPool<float>.Shared.Return(frame.RxI);
+            System.Buffers.ArrayPool<float>.Shared.Return(frame.RxQ);
+        }
         // No Tick on PS-feedback — display cadence is paced by IQ frames.
     }
 
@@ -1396,7 +1440,23 @@ public class DspPipelineService : BackgroundService,
     {
         DrainDspCommands();
         var engine = Volatile.Read(ref _engine);
-        engine?.FeedPsFeedbackBlock(frame.TxI, frame.TxQ, frame.RxI, frame.RxQ);
+        try
+        {
+            engine?.FeedPsFeedbackBlock(
+                frame.TxI.AsSpan(0, Zeus.Protocol2.PsFeedbackFrame.BlockSize),
+                frame.TxQ.AsSpan(0, Zeus.Protocol2.PsFeedbackFrame.BlockSize),
+                frame.RxI.AsSpan(0, Zeus.Protocol2.PsFeedbackFrame.BlockSize),
+                frame.RxQ.AsSpan(0, Zeus.Protocol2.PsFeedbackFrame.BlockSize));
+        }
+        finally
+        {
+            // Return the rentals — the protocol client handed ownership to us
+            // (see Zeus.Protocol2.PsFeedbackFrame XML doc for the contract).
+            System.Buffers.ArrayPool<float>.Shared.Return(frame.TxI);
+            System.Buffers.ArrayPool<float>.Shared.Return(frame.TxQ);
+            System.Buffers.ArrayPool<float>.Shared.Return(frame.RxI);
+            System.Buffers.ArrayPool<float>.Shared.Return(frame.RxQ);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Addresses part 1 of #559 (the load-sensitivity issue where PureSignal in desktop mode produced a visibly dirtier signal than web mode on the same radio).

## What this changes

Three structural fixes to the PureSignal path — described in plain language, then the technical version.

### Plain language

1. **No more memory allocation on the PS hot path.** Every time the radio sent a block of PureSignal feedback samples, Zeus was allocating brand-new buffers (about 940 KB/sec of fresh memory at 192 kHz). That kept the garbage collector busy, and every garbage collection froze the same threads that were trying to feed PureSignal. Now those buffers are recycled from a pool — no allocation, no GC pauses on the PS path.

2. **PureSignal control changes (HW Peak, Auto/Single mode, Save/Restore, etc.) no longer block the PS feedback thread.** Previously, when the operator clicked anything in the PS panel, the engine held a lock for the full duration of the WDSP call — and the same lock was used by the thread feeding feedback samples into PureSignal. So a single click could briefly stall the correction loop. Now the lock is released before the WDSP call runs.

3. **The 100 ms blocking pause during PS arm is gone.** When arming PS, Zeus used to stop the state-change thread for 100 ms to give the radio time to switch into paired-DDC layout. That 100 ms is still respected, but it's now scheduled non-blocking so the rest of the radio (RX audio, waterfall, etc.) keeps working during the settle.

### Technical

1. **ArrayPool everywhere on the PS feedback path.** `Protocol1Client.HandlePs4DdcPacket` and `Protocol2Client.HandlePsPairedPacket` now rent the four `float[1024]` buffers from `ArrayPool<float>.Shared`. `DspPipelineService`'s two `OnPsFeedbackFrame` handlers return them after the engine consumes them. `PsFeedbackFrame` exposes a `BlockSize` constant (1024) so the sink can slice the pooled arrays exactly — `ArrayPool` only guarantees \"at-least\" the requested size. `WdspDspEngine.FeedPsFeedbackBlock` drops its four `.ToArray()` copies and uses a new `psccFSpan` P/Invoke overload (same `psccF` native entry, `ref float` parameters) so the upstream spans are pinned without a managed copy.

2. **State-change P/Invokes lifted out of `_psLock`.** All eight PS state methods (`SetPsHwPeak`, `SetPsControl`, `SetPsAdvanced`, `SetPsEnabled`, `GetPsCorrectionInfo`, `ResetPs`, `SavePsCorrection`, `RestorePsCorrection`) restructured to the snapshot-then-call pattern: lock for field mutation + id snapshot, release, then run the native calls. `FeedPsFeedbackBlock` keeps `_psLock` around its `psccF` call defensively but contends with nothing else. The `SetPsEnabled` shutdown drain and the analyzer open/close are also moved outside the lock — the analyzer methods carry their own `_psFbDispLock` for slot protection.

3. **`Task.Delay(100).Wait()` → non-blocking deferred arm.** `DspPipelineService` schedules the engine arm via `Task.Delay(100).ContinueWith` instead of blocking on `.Wait()`. A new `_psArmGeneration` counter is bumped on every PS-state transition; deferred arms compare generations at fire time and skip if a later transition has landed, so a fast off→on→off or PS-on-then-key-down within the window can't re-arm against operator intent.

## Bench test on the G2 — partial only

- **Web mode** (the case that was already cleaner pre-slice-1): worst case (mic gain + leveler maxed → highly distorted TX chain) was \"pretty clean, almost crystal clean.\" Normal levels were \"very clean.\"
- **Desktop mode** (the case #559 was actually about — the dirtier of the two pre-slice-1): **not yet tested**. Will be tested before merge.

The structural fixes in this PR apply to both modes; the desktop-mode test is what confirms whether slice 1 alone closes the gap that #559 originally documented.

Not yet bench-tested on HL2 either — flag for testing before this lands if anyone is running a HL2 setup.

## What's NOT in this PR

- **Slice 2** — per-platform thread priority for the PS feedback path (macOS QoS / Windows MMCSS / Linux `Thread.Priority.Highest`). Will be a separate PR; in progress on `fix/ps-slice-2-thread-priority`.

## Tests

`dotnet test Zeus.slnx` — all 7 test projects pass (1351 / 0 / skipped 107).