### PR TITLE
fix(ps): promote protocol RxLoop threads to pro-audio class (#559 slice 2)

### DIFF
--- a/Zeus.Protocol1/Protocol1Client.cs
+++ b/Zeus.Protocol1/Protocol1Client.cs
@@ -713,6 +713,17 @@ public sealed class Protocol1Client : IProtocol1Client
 
     private void RxLoop()
     {
+        // Pump RX (including PureSignal feedback paired-DDC packets, which
+        // arrive via the same socket and dispatch into FeedPsFeedbackBlock
+        // synchronously on this thread) at the platform's pro-audio class.
+        // Thetis runs the equivalent path off the ASIO driver's real-time
+        // thread; without an explicit promotion we'd be at default OS
+        // priority — the same priority as Photino render, SignalR fan-out,
+        // and general .NET ThreadPool work. See
+        // docs/rca/2026-05-28-ps-load-sensitivity.md for the load
+        // sensitivity this addresses.
+        RealtimeThreadPriority.PromoteCallingThreadToProAudio(_log);
+
         var sock = _socket!;
         var ct = _loopCts!.Token;
         var buffer = new byte[PacketParser.PacketLength];

--- a/Zeus.Protocol1/RealtimeThreadPriority.cs
+++ b/Zeus.Protocol1/RealtimeThreadPriority.cs
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Protocol1;
+
+/// <summary>
+/// Promotes the calling thread to the platform's pro-audio / low-latency
+/// thread class. Used at the top of the protocol RxLoop so PureSignal
+/// feedback samples and RX IQ frames are pumped at a priority that doesn't
+/// have to fight Photino render / SignalR fan-out / general .NET ThreadPool
+/// work for cycles. Mirrors the discipline Thetis gets by running the same
+/// path off the ASIO driver's real-time-class thread — see
+/// <c>docs/rca/2026-05-28-ps-load-sensitivity.md</c>.
+/// </summary>
+/// <remarks>
+/// All P/Invoke failures are non-fatal: the thread keeps running at
+/// whatever priority the OS will grant. We log at warning level so an
+/// operator chasing a perf issue can confirm the promotion landed (or didn't).
+///
+/// Per-platform mapping:
+/// <list type="bullet">
+/// <item><b>macOS</b> — <c>pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0)</c>.
+/// The high QoS tier for user-driven low-latency work. Doesn't need
+/// entitlements or the mach real-time ceremony.</item>
+/// <item><b>Windows</b> — <c>AvSetMmThreadCharacteristicsW("Pro Audio")</c>.
+/// MMCSS Pro Audio task class — the same one DAWs and Thetis (via ASIO)
+/// request. The returned handle is intentionally not reverted; the RX
+/// thread runs for the lifetime of the protocol session.</item>
+/// <item><b>Linux / other</b> — <c>Thread.CurrentThread.Priority = ThreadPriority.Highest</c>.
+/// <c>SCHED_FIFO</c> needs <c>CAP_SYS_NICE</c> which an operator process
+/// typically lacks; the .NET fallback maps to an elevated nice value, which
+/// is the best we can do without privileged setup.</item>
+/// </list>
+/// </remarks>
+internal static partial class RealtimeThreadPriority
+{
+    /// <summary>
+    /// Promote the calling thread to the platform's pro-audio class. Safe
+    /// to call once per long-running thread (e.g. at the top of an RxLoop).
+    /// </summary>
+    public static void PromoteCallingThreadToProAudio(ILogger log)
+    {
+        try
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                PromoteMacOs(log);
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                PromoteWindows(log);
+            else
+                PromoteFallback(log);
+        }
+        catch (DllNotFoundException ex)
+        {
+            // Library missing — e.g. WSL stub w/o avrt.dll, or a stripped
+            // libSystem build. Fall back without crashing.
+            log.LogWarning(ex, "thread.priority native library not found — leaving thread at default priority");
+        }
+        catch (Exception ex)
+        {
+            log.LogWarning(ex, "thread.priority promotion threw — leaving thread at default priority");
+        }
+    }
+
+    // ---- macOS -------------------------------------------------------------
+    // QOS_CLASS_USER_INTERACTIVE = 0x21 per <pthread/qos.h>.
+    private const int QOS_CLASS_USER_INTERACTIVE = 0x21;
+
+    [LibraryImport("libSystem.dylib", EntryPoint = "pthread_set_qos_class_self_np")]
+    private static partial int pthread_set_qos_class_self_np(int qos_class, int relative_priority);
+
+    private static void PromoteMacOs(ILogger log)
+    {
+        int rc = pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
+        if (rc == 0)
+            log.LogInformation("thread.priority promoted to QOS_CLASS_USER_INTERACTIVE (macOS)");
+        else
+            log.LogWarning("thread.priority pthread_set_qos_class_self_np rc={Rc} — staying at default", rc);
+    }
+
+    // ---- Windows -----------------------------------------------------------
+    // AvSetMmThreadCharacteristicsW — avrt.dll. Returns NULL on failure;
+    // GetLastWin32Error explains. The returned handle should normally be
+    // passed to AvRevertMmThreadCharacteristics on cleanup, but the RX
+    // thread runs for the entire protocol session and exits with the
+    // process, so we intentionally leak the handle — the kernel cleans up
+    // task scheduler state at process exit.
+    [LibraryImport("avrt.dll", EntryPoint = "AvSetMmThreadCharacteristicsW",
+                   StringMarshalling = StringMarshalling.Utf16, SetLastError = true)]
+    private static partial IntPtr AvSetMmThreadCharacteristicsW(string TaskName, out uint TaskIndex);
+
+    private static void PromoteWindows(ILogger log)
+    {
+        uint taskIdx = 0;
+        IntPtr handle;
+        try
+        {
+            handle = AvSetMmThreadCharacteristicsW("Pro Audio", out taskIdx);
+        }
+        catch (DllNotFoundException)
+        {
+            // Some stripped Windows containers don't ship avrt.dll. Fall
+            // back without spamming the warning twice.
+            log.LogWarning("thread.priority avrt.dll not available — falling back to ThreadPriority.Highest");
+            TrySetThreadPriorityHighest(log);
+            return;
+        }
+
+        if (handle != IntPtr.Zero)
+        {
+            log.LogInformation("thread.priority promoted to MMCSS Pro Audio (Windows, taskIdx={Idx})", taskIdx);
+        }
+        else
+        {
+            int err = Marshal.GetLastPInvokeError();
+            log.LogWarning("thread.priority AvSetMmThreadCharacteristicsW err={Err} — falling back to ThreadPriority.Highest", err);
+            TrySetThreadPriorityHighest(log);
+        }
+    }
+
+    // ---- Linux / other -----------------------------------------------------
+    private static void PromoteFallback(ILogger log)
+    {
+        if (TrySetThreadPriorityHighest(log))
+            log.LogInformation("thread.priority set to ThreadPriority.Highest (Linux/other)");
+    }
+
+    private static bool TrySetThreadPriorityHighest(ILogger log)
+    {
+        try
+        {
+            Thread.CurrentThread.Priority = ThreadPriority.Highest;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            log.LogWarning(ex, "thread.priority Thread.Priority.Highest threw");
+            return false;
+        }
+    }
+}

--- a/Zeus.Protocol1/Zeus.Protocol1.csproj
+++ b/Zeus.Protocol1/Zeus.Protocol1.csproj
@@ -12,6 +12,11 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <!-- LibraryImport source generator emits unsafe code (used by
+         RealtimeThreadPriority for pthread / MMCSS P/Invoke). Matches the
+         setting on Zeus.Dsp and Zeus.Server.Hosting which also use
+         LibraryImport. -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
 </Project>

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -360,7 +360,17 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         SendCmdHighPriority(run: true);
 
         _rxCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        _rxTask = Task.Run(() => RxLoop(_rxCts.Token));
+        // LongRunning hint → dedicated thread instead of a ThreadPool worker.
+        // The RX loop runs for the entire protocol session and we promote its
+        // thread to MMCSS Pro Audio / macOS USER_INTERACTIVE QoS inside
+        // RxLoop — both promotions are per-thread, so we need ownership of a
+        // dedicated thread that isn't going to be recycled back into the pool
+        // with the elevated priority still attached.
+        _rxTask = Task.Factory.StartNew(
+            () => RxLoop(_rxCts.Token),
+            _rxCts.Token,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
         _keepaliveTask = Task.Run(() => KeepaliveLoop(_rxCts.Token));
         // Paced TX IQ sender — drains the queue FlushTxIqLocked fills and
         // holds the radio's DUC FIFO at a steady level.
@@ -1453,6 +1463,14 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
 
     private void RxLoop(CancellationToken ct)
     {
+        // Pump RX (including PureSignal paired-DDC packets on port 1035) at
+        // the platform's pro-audio class. Thetis runs the equivalent path
+        // off the ASIO driver's real-time thread; without an explicit
+        // promotion we'd be at default OS priority and contend with Photino
+        // render, SignalR fan-out, and general .NET ThreadPool work. See
+        // docs/rca/2026-05-28-ps-load-sensitivity.md.
+        RealtimeThreadPriority.PromoteCallingThreadToProAudio(_log);
+
         var buf = new byte[2048];
         var sock = _sock!;
         sock.ReceiveTimeout = 500;

--- a/Zeus.Protocol2/RealtimeThreadPriority.cs
+++ b/Zeus.Protocol2/RealtimeThreadPriority.cs
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Protocol2;
+
+/// <summary>
+/// Promotes the calling thread to the platform's pro-audio / low-latency
+/// thread class. Used at the top of the protocol RxLoop so PureSignal
+/// feedback samples and RX IQ frames are pumped at a priority that doesn't
+/// have to fight Photino render / SignalR fan-out / general .NET ThreadPool
+/// work for cycles. Mirrors the discipline Thetis gets by running the same
+/// path off the ASIO driver's real-time-class thread — see
+/// <c>docs/rca/2026-05-28-ps-load-sensitivity.md</c>.
+/// </summary>
+/// <remarks>
+/// All P/Invoke failures are non-fatal: the thread keeps running at
+/// whatever priority the OS will grant. We log at warning level so an
+/// operator chasing a perf issue can confirm the promotion landed (or didn't).
+///
+/// Per-platform mapping:
+/// <list type="bullet">
+/// <item><b>macOS</b> — <c>pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0)</c>.
+/// The high QoS tier for user-driven low-latency work. Doesn't need
+/// entitlements or the mach real-time ceremony.</item>
+/// <item><b>Windows</b> — <c>AvSetMmThreadCharacteristicsW("Pro Audio")</c>.
+/// MMCSS Pro Audio task class — the same one DAWs and Thetis (via ASIO)
+/// request. The returned handle is intentionally not reverted; the RX
+/// thread runs for the lifetime of the protocol session.</item>
+/// <item><b>Linux / other</b> — <c>Thread.CurrentThread.Priority = ThreadPriority.Highest</c>.
+/// <c>SCHED_FIFO</c> needs <c>CAP_SYS_NICE</c> which an operator process
+/// typically lacks; the .NET fallback maps to an elevated nice value, which
+/// is the best we can do without privileged setup.</item>
+/// </list>
+///
+/// This file is intentionally duplicated in <c>Zeus.Protocol1</c>; the two
+/// protocol projects don't share a utility assembly. Keep the two copies in
+/// sync — if you fix one, fix the other.
+/// </remarks>
+internal static partial class RealtimeThreadPriority
+{
+    /// <summary>
+    /// Promote the calling thread to the platform's pro-audio class. Safe
+    /// to call once per long-running thread (e.g. at the top of an RxLoop).
+    /// </summary>
+    public static void PromoteCallingThreadToProAudio(ILogger log)
+    {
+        try
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                PromoteMacOs(log);
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                PromoteWindows(log);
+            else
+                PromoteFallback(log);
+        }
+        catch (DllNotFoundException ex)
+        {
+            log.LogWarning(ex, "thread.priority native library not found — leaving thread at default priority");
+        }
+        catch (Exception ex)
+        {
+            log.LogWarning(ex, "thread.priority promotion threw — leaving thread at default priority");
+        }
+    }
+
+    // ---- macOS -------------------------------------------------------------
+    private const int QOS_CLASS_USER_INTERACTIVE = 0x21;
+
+    [LibraryImport("libSystem.dylib", EntryPoint = "pthread_set_qos_class_self_np")]
+    private static partial int pthread_set_qos_class_self_np(int qos_class, int relative_priority);
+
+    private static void PromoteMacOs(ILogger log)
+    {
+        int rc = pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
+        if (rc == 0)
+            log.LogInformation("thread.priority promoted to QOS_CLASS_USER_INTERACTIVE (macOS)");
+        else
+            log.LogWarning("thread.priority pthread_set_qos_class_self_np rc={Rc} — staying at default", rc);
+    }
+
+    // ---- Windows -----------------------------------------------------------
+    [LibraryImport("avrt.dll", EntryPoint = "AvSetMmThreadCharacteristicsW",
+                   StringMarshalling = StringMarshalling.Utf16, SetLastError = true)]
+    private static partial IntPtr AvSetMmThreadCharacteristicsW(string TaskName, out uint TaskIndex);
+
+    private static void PromoteWindows(ILogger log)
+    {
+        uint taskIdx = 0;
+        IntPtr handle;
+        try
+        {
+            handle = AvSetMmThreadCharacteristicsW("Pro Audio", out taskIdx);
+        }
+        catch (DllNotFoundException)
+        {
+            log.LogWarning("thread.priority avrt.dll not available — falling back to ThreadPriority.Highest");
+            TrySetThreadPriorityHighest(log);
+            return;
+        }
+
+        if (handle != IntPtr.Zero)
+        {
+            log.LogInformation("thread.priority promoted to MMCSS Pro Audio (Windows, taskIdx={Idx})", taskIdx);
+        }
+        else
+        {
+            int err = Marshal.GetLastPInvokeError();
+            log.LogWarning("thread.priority AvSetMmThreadCharacteristicsW err={Err} — falling back to ThreadPriority.Highest", err);
+            TrySetThreadPriorityHighest(log);
+        }
+    }
+
+    // ---- Linux / other -----------------------------------------------------
+    private static void PromoteFallback(ILogger log)
+    {
+        if (TrySetThreadPriorityHighest(log))
+            log.LogInformation("thread.priority set to ThreadPriority.Highest (Linux/other)");
+    }
+
+    private static bool TrySetThreadPriorityHighest(ILogger log)
+    {
+        try
+        {
+            Thread.CurrentThread.Priority = ThreadPriority.Highest;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            log.LogWarning(ex, "thread.priority Thread.Priority.Highest threw");
+            return false;
+        }
+    }
+}

--- a/Zeus.Protocol2/Zeus.Protocol2.csproj
+++ b/Zeus.Protocol2/Zeus.Protocol2.csproj
@@ -12,6 +12,11 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <!-- LibraryImport source generator emits unsafe code (used by
+         RealtimeThreadPriority for pthread / MMCSS P/Invoke). Matches the
+         setting on Zeus.Dsp and Zeus.Server.Hosting which also use
+         LibraryImport. -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Addresses part 2 of #559, building on slice 1 (#560).

## What this changes

### Plain language

The two protocol clients each run their own \"RX loop\" thread that pulls UDP packets from the radio. That thread is also where PureSignal feedback samples flow into WDSP — under slice 1's plumbing, every PS feedback block runs synchronously on the same thread that pulls the packet off the wire. At default OS priority, that thread competes equally with the UI rendering thread (Photino), the SignalR fan-out that pushes data to the browser, and every other piece of background .NET work in the process. On a quiet machine that's fine; under load (heavy OBS recording, browser tab spikes, background apps) it's why the desktop-mode PS path was visibly dirtier than web mode in #559.

This PR promotes the RX thread to the platform's \"pro-audio\" priority class — the same class DAWs and Thetis (via ASIO) request — so PureSignal feedback gets the cycles it needs even when the rest of the process is busy. The promotion is per-platform:

- **macOS** — `pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0)`
- **Windows** — `AvSetMmThreadCharacteristicsW(\"Pro Audio\")` via `avrt.dll`
- **Linux** — `Thread.CurrentThread.Priority = ThreadPriority.Highest`. (Real `SCHED_FIFO` needs the `CAP_SYS_NICE` capability, which an operator user typically doesn't have. `ThreadPriority.Highest` maps to an elevated nice value, which is the best we can do without privileged setup.)

If any of the promotions fail (missing library, denied permission), the thread keeps running at default priority and a warning is logged — nothing breaks.

### Technical

- New helper `RealtimeThreadPriority` (duplicated in `Zeus.Protocol1` and `Zeus.Protocol2` — neither project has a shared utility assembly; if you edit one copy, edit the other). Single public entry point `PromoteCallingThreadToProAudio(ILogger)`. All P/Invoke failures are non-fatal and log at warning.
- `Protocol1Client.RxLoop` and `Protocol2Client.RxLoop` call the promotion as the first statement, so every RX packet — including PS paired-DDC frames — is handled at the elevated priority.
- `Protocol2Client.StartAsync` now starts the RX loop via `Task.Factory.StartNew(..., TaskCreationOptions.LongRunning, ...)` instead of `Task.Run(...)`. Thread-priority promotion only makes sense on a thread we'll own for the lifetime of the session; the LongRunning hint gives us a dedicated thread instead of borrowing a ThreadPool worker that could be recycled with the elevated priority still attached. `Protocol1Client` was already using `new Thread`.
- `Zeus.Protocol1.csproj` and `Zeus.Protocol2.csproj` enable `<AllowUnsafeBlocks>true</AllowUnsafeBlocks>` because the `LibraryImport` source generator emits unsafe code internally. Matches the setting already present on `Zeus.Dsp` and `Zeus.Server.Hosting`.

## How to verify

After connecting to a radio, the backend log should show one of these lines for each of the P1 and P2 RX threads:

```
thread.priority promoted to QOS_CLASS_USER_INTERACTIVE (macOS)
thread.priority promoted to MMCSS Pro Audio (Windows, taskIdx=...)
thread.priority set to ThreadPriority.Highest (Linux/other)
```

If the line says \"falling back\" or \"staying at default,\" the OS denied the promotion — surface the log and we can dig in.

## Sequencing with #560

This PR depends on the slice-1 plumbing in #560 only in spirit (the slice-1 fixes are what made the RX thread a hot enough path to be worth promoting). The two PRs touch different files and can land in either order, but merging slice 1 first is the natural sequence so any bisection bisects each structural concern independently.

## Bench test on the G2 — pending

Both modes pending — to be tested when at the shack:
- Web mode (the case slice-1 was tested against — should still be clean; the promotion shouldn't degrade)
- Desktop mode (the actual #559 symptom — this is where slice 2 has the bigger marginal effect)

## Tests

`dotnet test Zeus.slnx` — all 7 test projects pass (1351 / 0 / skipped 107).