### PR TITLE
fix(tx): G2/P2 two-tone — correct sideband sign + stop the first-key-up TX FIFO underrun

### DIFF
--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -1545,18 +1545,18 @@ public sealed class WdspDspEngine : IDspEngine
             // asserts SetTxFilter after SetTxMode using the per-mode-family
             // memory in RadioService. No auto-apply here.
             //
-            // TwoTone is sideband-sensitive (gen.c xgen mode-1 emits e^(-jωt)
-            // which always lands LSB-side of carrier). If a TwoTone test is
-            // mid-flight when the operator changes mode, re-assert PostGen
-            // freqs with the new sign so the tones stay inside the displayed
-            // bandpass. Mag and run flag stay as last set.
+            // TwoTone is sideband-sensitive. If a TwoTone test is mid-flight
+            // when the operator changes mode, re-assert PostGen freqs with the
+            // new sign so the tones stay inside the displayed bandpass. Sign
+            // convention matches Thetis (Setup.cs:11096): negate for LSB-family,
+            // positive for USB-family. Mag and run flag stay as last set.
             if (_twoToneArmed)
             {
-                bool usbFamily = mapped == RxaMode.USB
-                              || mapped == RxaMode.CWU
-                              || mapped == RxaMode.DIGU;
-                double signedF1 = usbFamily ? -_twoToneF1Hz : _twoToneF1Hz;
-                double signedF2 = usbFamily ? -_twoToneF2Hz : _twoToneF2Hz;
+                bool lsbFamily = mapped == RxaMode.LSB
+                              || mapped == RxaMode.CWL
+                              || mapped == RxaMode.DIGL;
+                double signedF1 = lsbFamily ? -_twoToneF1Hz : _twoToneF1Hz;
+                double signedF2 = lsbFamily ? -_twoToneF2Hz : _twoToneF2Hz;
                 NativeMethods.SetTXAPostGenTTFreq(txa, signedF1, signedF2);
                 _log.LogInformation(
                     "wdsp.setTxMode twoTone re-signed f1={F1} f2={F2} signedF1={SF1} signedF2={SF2} mode={Mode}",
@@ -1745,17 +1745,19 @@ public sealed class WdspDspEngine : IDspEngine
             if (_txaChannelId is not int txa) return;
             if (on)
             {
-                // gen.c xgen mode-1 emits e^(-jωt): positive freq lands on
-                // the LSB-side of carrier in any TX mode. USB-family modes
-                // need a sign flip so the tones appear above carrier inside
-                // the displayed bandpass. Cache the operator-supplied
-                // (unsigned) freqs so SetTxMode can re-assert with the
-                // correct sign on a mid-test mode change.
-                bool usbFamily = _txCurrentMode == RxaMode.USB
-                              || _txCurrentMode == RxaMode.CWU
-                              || _txCurrentMode == RxaMode.DIGU;
-                double signedF1 = usbFamily ? -freq1 : freq1;
-                double signedF2 = usbFamily ? -freq2 : freq2;
+                // Sideband sign — matches Thetis (Setup.cs:11096, chkInvertTones
+                // default ON): USB-family takes positive freqs (tones above
+                // carrier), LSB-family takes negated freqs so the tones land in
+                // the displayed bandpass on the correct side. Zeus previously had
+                // this inverted (flipped USB instead of LSB), which put the tones
+                // on the wrong sideband — outside the visible passband on USB.
+                // Cache the operator-supplied (unsigned) freqs so SetTxMode can
+                // re-assert with the correct sign on a mid-test mode change.
+                bool lsbFamily = _txCurrentMode == RxaMode.LSB
+                              || _txCurrentMode == RxaMode.CWL
+                              || _txCurrentMode == RxaMode.DIGL;
+                double signedF1 = lsbFamily ? -freq1 : freq1;
+                double signedF2 = lsbFamily ? -freq2 : freq2;
                 _twoToneF1Hz = freq1;
                 _twoToneF2Hz = freq2;
                 _twoToneArmed = true;

--- a/Zeus.Server.Hosting/TxTuneDriver.cs
+++ b/Zeus.Server.Hosting/TxTuneDriver.cs
@@ -74,6 +74,11 @@ internal sealed class TxTuneDriver : BackgroundService
     // than WDSP's block clock). Fixed 20 ms fell behind on P2's 512-sample
     // block (10.67 ms) and starved the G2 DUC, producing close-in spurs.
     private const int MicRateHz = 48_000;
+    // Blocks delivered back-to-back at key-down to fill the radio's TX FIFO to
+    // its ~1250-sample target before steady pacing begins. One P2 block already
+    // carries ~2048 output samples, so a handful primes the FIFO well clear of
+    // the underrun floor without overshooting the sender's throttle headroom.
+    private const int PrimeBlocks = 4;
 
     private readonly TxService _tx;
     private readonly DspPipelineService _pipeline;
@@ -92,12 +97,20 @@ internal sealed class TxTuneDriver : BackgroundService
     {
         float[]? micScratch = null;
         float[]? iqScratch = null;
+        // Drift-free pacing state. `clock` is the monotonic reference; pacing is
+        // false whenever TUN/TwoTone is idle so the next key-down re-primes and
+        // re-anchors the schedule from scratch.
+        var clock = System.Diagnostics.Stopwatch.StartNew();
+        long nextDeadlineTicks = 0;
+        int primeRemaining = 0;
+        bool pacing = false;
         while (!ct.IsCancellationRequested)
         {
             try
             {
                 if (!_tx.IsTunOn && !_tx.IsTwoToneOn)
                 {
+                    pacing = false;
                     await Task.Delay(PollIdle, ct).ConfigureAwait(false);
                     continue;
                 }
@@ -108,6 +121,7 @@ internal sealed class TxTuneDriver : BackgroundService
                 if (engine is null || micBlock <= 0 || iqOut <= 0)
                 {
                     // No TXA yet — retry on the slow cadence.
+                    pacing = false;
                     await Task.Delay(PollIdle, ct).ConfigureAwait(false);
                     continue;
                 }
@@ -136,17 +150,58 @@ internal sealed class TxTuneDriver : BackgroundService
                     _pipeline.ForwardTxIqToP2(iqSpan);
                 }
 
-                // Tick at ~95 % of the mic-block duration so WDSP is nearly
-                // always ready for the next fexchange2 call (the 5 % margin
-                // keeps us ahead of the block clock without blowing a CPU
-                // spin on early wakeups).
-                int tickMs = Math.Max(1, (micBlock * 950) / (MicRateHz));
-                await Task.Delay(TimeSpan.FromMilliseconds(tickMs), ct).ConfigureAwait(false);
+                // Wall-clock deadline pacing. A fixed Task.Delay(tickMs) was
+                // overshot by the OS scheduler + ProcessTxBlock time, so the loop
+                // ran ~13 ms instead of the 10.67 ms real-time period of a P2
+                // 512-sample block — production fell ~6 % below the 192 kHz DAC
+                // rate (≈750 vs 800 pkts/s), draining the radio's TX FIFO and
+                // producing a gappy/dirty two-tone until a MOX cycle re-primed it.
+                // Pacing against a monotonic deadline borrows per-block jitter back
+                // on the next iteration, so the average production rate stays locked
+                // to the block clock. We aim a hair (~3 %) above real-time so the
+                // FIFO stays topped; the P2 sender's FIFO model throttles the small
+                // surplus. TxTuneDriver only drives TUN / TwoTone (short bursts),
+                // never voice — voice is pumped by the hardware-clocked mic path.
+                long periodTicks = (long)(System.Diagnostics.Stopwatch.Frequency
+                    * micBlock * 0.97 / MicRateHz);
+
+                if (!pacing)
+                {
+                    // First block of this key-down: prime the radio FIFO by
+                    // delivering a short burst back-to-back before steady pacing.
+                    pacing = true;
+                    primeRemaining = PrimeBlocks;
+                }
+
+                if (primeRemaining > 0)
+                {
+                    primeRemaining--;
+                    // Anchor the steady-state schedule to the moment priming ends.
+                    if (primeRemaining == 0) nextDeadlineTicks = clock.ElapsedTicks;
+                    continue;
+                }
+
+                nextDeadlineTicks += periodTicks;
+                long remainingTicks = nextDeadlineTicks - clock.ElapsedTicks;
+                if (remainingTicks <= 0)
+                {
+                    // Behind schedule (slow block / scheduler hiccup): skip the
+                    // delay and catch up. Re-anchor only if we've fallen badly
+                    // behind so a long stall can't trigger a runaway burst.
+                    if (-remainingTicks > periodTicks * 8) nextDeadlineTicks = clock.ElapsedTicks;
+                    continue;
+                }
+                int delayMs = (int)(remainingTicks * 1000 / System.Diagnostics.Stopwatch.Frequency);
+                if (delayMs > 0)
+                    await Task.Delay(delayMs, ct).ConfigureAwait(false);
+                // Sub-millisecond remainder is left unspun; the deadline accounting
+                // folds it into the next iteration.
             }
             catch (OperationCanceledException) { return; }
             catch (Exception ex)
             {
                 _log.LogWarning(ex, "tx.tune driver tick failed");
+                pacing = false;
                 try { await Task.Delay(PollIdle, ct).ConfigureAwait(false); }
                 catch (OperationCanceledException) { return; }
             }


### PR DESCRIPTION
Fixes the G2 / Protocol-2 two-tone test, which produced a **very dirty** signal on first arm and only cleaned up after a MOX off→on cycle. Two independent fixes, both verified on-air on the G2 (web mode). Refs #559.

This also explains — and removes — the long-standing "G2 two-tone always blows out" workaround and the recurring "PureSignal produces a dirty correction" reports: **PS was never the problem; it was being fed a gappy two-tone.**

## 1. Two-tone sideband sign matched to Thetis (`c1a378b`)
Zeus negated the PostGen tone frequencies for **USB**-family modes and left LSB positive — the inverse of Thetis (`Setup.cs:11096`, `chkInvertTones` default on), which negates **LSB**-family and leaves USB positive. With the same WDSP underneath, Zeus placed the tones on the wrong sideband (below carrier on USB), off the edge of the displayed passband. Flipped both sites (`SetTwoTone` and the mid-test `SetTxMode` re-assert) to negate on LSB-family.

**On-air:** tones now land inside the passband (`signedF1=-700 mode=LSB`).

## 2. Deadline-pace the TUN/TwoTone pump so the TX FIFO can't underrun (`2c8b929`)
`TxTuneDriver` feeds WDSP silent blocks to keep PostGen flowing when there's no mic, pacing with a fixed `Task.Delay(tickMs)`. The OS scheduler overshoots that delay and `ProcessTxBlock` time stacks on top, so each loop ran ~13 ms instead of a P2 512-sample block's 10.67 ms real-time period. Production landed **~750 pkts/s**, ~6 % under the 192 kHz DAC rate (800 pkts/s) — the radio's TX FIFO bled to its underrun floor and the two-tone came out gappy/dirty until a MOX cycle happened to re-prime it.

Fix: pace against a monotonic **wall-clock deadline** (per-block jitter is borrowed back on the next iteration so the average rate locks to the block clock), aimed ~3 % above real-time so the FIFO stays topped — the P2 sender's existing FIFO model throttles the small surplus. Added a short **prime burst** at key-down so the FIFO fills before steady pacing.

**On-air before:** `pkts/s≈750` sawtoothing `fifoModel` to the 240 floor → dirty.
**On-air after:** steady `pkts/s=800-801`, `fifoModel` parked `1250-1465` → **clean two-tone on the first arm, no MOX cycle**, and PureSignal corrects.

## Scope
- **Two-tone / TUN only.** `TxTuneDriver` is the no-mic pump. **SSB voice is pumped by the hardware-clocked mic path and is unaffected** by either change.
- No wire-format / Contracts changes. No DSP-algorithm changes (sign fix is a P/Invoke argument; pump fix is host-side cadence).

## Tests
`dotnet test` — Zeus.Dsp.Tests **152 passed**, Zeus.Server.Tests **711 passed**, 0 failures. No test asserted the old two-tone sign (it's a P/Invoke detail), so none needed updating.