### PR TITLE
PureSignal desktop parity + two-tone IMD overlay (#559)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ native/build-miniaudio/
 # Installer output directories
 installers/output/
 installers/dmg_temp/
+
+# Claude Code agent worktrees (transient; never commit)
+.claude/worktrees/

--- a/Zeus.Dsp/IDspEngine.cs
+++ b/Zeus.Dsp/IDspEngine.cs
@@ -214,6 +214,16 @@ public interface IDspEngine : IDisposable
     /// </summary>
     void SetPsControl(bool autoCal, bool singleCal);
 
+    /// <summary>Freeze (true) or resume (false) PureSignal calibration without
+    /// disturbing the applied correction. true → <c>SetPSRunCal(0)</c>: calcc's
+    /// pscc state machine stops cycling/re-fitting, but the iqc predistorter
+    /// keeps applying its current coefficients (SetPSRunCal does NOT trigger the
+    /// iqc turn-off ramp). false → <c>SetPSRunCal(1)</c> resumes. Used to "catch
+    /// and hold" a converged automode correction so it stops flickering and the
+    /// signal holds (matches single-cal/LSTAYON behaviour without re-collecting).
+    /// </summary>
+    void SetPsHold(bool hold);
+
     /// <summary>Apply timing + hardware-peak + ints/spi settings as a batch
     /// (each call internally guards against the heavy
     /// <c>SetPSIntsAndSpi</c> path firing when the values haven't changed).

--- a/Zeus.Dsp/SyntheticDspEngine.cs
+++ b/Zeus.Dsp/SyntheticDspEngine.cs
@@ -184,6 +184,7 @@ public sealed class SyntheticDspEngine : IDspEngine
     // feedback pump are no-ops; GetPsStageMeters returns the silent record.
     public void SetPsEnabled(bool enabled) { }
     public void SetPsControl(bool autoCal, bool singleCal) { }
+    public void SetPsHold(bool hold) { }
     public void SetPsAdvanced(bool ptol, double moxDelaySec, double loopDelaySec,
                               double ampDelayNs, double hwPeak, int ints, int spi) { }
     public void SetPsHwPeak(double hwPeak) { }

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -1254,7 +1254,15 @@ public sealed class WdspDspEngine : IDspEngine
             // chkPSMap = Checked = true).
             NativeMethods.SetPSPinMode(id, 1);
             NativeMethods.SetPSMapMode(id, 1);
-            NativeMethods.SetPSStabilize(id, 0);
+            // calcc rx_scale + coefficient IIR smoothing (alpha 0.9). ON for the
+            // P2 profile so continuous automode converges to a STEADY correction
+            // instead of applying each raw pass-to-pass fit — the latter makes
+            // the predistorted two-tone visibly jump on the TX panadapter and
+            // holds IMD short of its settled depth (#559, G2). DeskHPSDR ships
+            // this on for SATURN/new-protocol. OFF on P1/HL2 to keep the
+            // mi0bot-matched behaviour. _txaCfirRun is the existing P2-profile
+            // discriminator (CFIR runs only on P2; see above).
+            NativeMethods.SetPSStabilize(id, _txaCfirRun ? 1 : 0);
             NativeMethods.SetPSIntsAndSpi(id, _psInts, _psSpi);
             NativeMethods.SetPSMoxDelay(id, _psMoxDelaySec);
             NativeMethods.SetPSLoopDelay(id, _psLoopDelaySec);

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -1811,6 +1811,22 @@ public sealed class WdspDspEngine : IDspEngine
         _log.LogInformation("wdsp.setPsHwPeak peak={Peak:F4}", hwPeak);
     }
 
+    public void SetPsHold(bool hold)
+    {
+        if (_disposed != 0) return;
+        lock (_psLock)
+        {
+            int? txa;
+            lock (_txaLock) txa = _txaChannelId;
+            if (txa is not int id) return;
+            // hold → SetPSRunCal(0): stop calcc re-fitting (state machine parks),
+            // iqc keeps applying the current correction (no turn-off ramp).
+            // resume → SetPSRunCal(1).
+            NativeMethods.SetPSRunCal(id, hold ? 0 : 1);
+        }
+        _log.LogInformation("wdsp.setPsHold hold={Hold} (runcal={Run})", hold, hold ? 0 : 1);
+    }
+
     public void SetPsControl(bool autoCal, bool singleCal)
     {
         if (_disposed != 0) return;

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -285,6 +285,7 @@ public sealed class WdspDspEngine : IDspEngine
     // calcc state machine is visible in the server log without flooding.
     // Drop alongside the wdsp.psSeed log once PS is confirmed stable.
     private int _psInfoLogCounter;
+    private int _txOverdriveLogCounter;
 
     // TX Monitor — private RXA channel that demodulates the post-CFIR / post-
     // RSMPOUT TX IQ (the wire signal about to hit the radio) back to mono
@@ -2444,10 +2445,28 @@ public sealed class WdspDspEngine : IDspEngine
             _log.LogWarning("wdsp.fexchange2 tx err={Err} (suppressed after 8 occurrences)", err);
         }
 
+        float txOutPeak = 0f;
         for (int i = 0; i < outSize; i++)
         {
             iqInterleaved[2 * i] = iout[i];
             iqInterleaved[2 * i + 1] = qout[i];
+            float e = iout[i] * iout[i] + qout[i] * qout[i];
+            if (e > txOutPeak) txOutPeak = e;
+        }
+        // Overdrive probe (#559): is the ALC limiting and is the wire IQ railing?
+        // outPeak≈1.0 = post-iqc IQ clipping the Int24 wire (splatter). alcGain
+        // (meter 14, dB) should go NEGATIVE under overdrive = ALC reducing gain
+        // (limiting); ~0 dB while the mic clips = ALC NOT limiting (the bug).
+        // ~1 Hz while keyed.
+        if (++_txOverdriveLogCounter % 50 == 0)
+        {
+            double alcGainDb = NativeMethods.GetTXAMeter(txa, 14);
+            double alcPkDb = NativeMethods.GetTXAMeter(txa, 12);
+            double micPkDb = NativeMethods.GetTXAMeter(txa, 0);
+            _log.LogInformation(
+                "wdsp.txOverdrive micPk={Mic:F1}dB alcGain={Alc:F1}dB alcPk={AlcPk:F1}dB outPeak={Out:F3}{Clip}",
+                micPkDb, alcGainDb, alcPkDb, Math.Sqrt(txOutPeak),
+                txOutPeak >= 0.998 * 0.998 ? " RAIL!" : "");
         }
 
         // TX Monitor — feed the post-CFIR / post-RSMPOUT IQ (the wire signal

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -1195,16 +1195,20 @@ public sealed class WdspDspEngine : IDspEngine
             NativeMethods.SetTXACompressorRun(id, 0);
             NativeMethods.SetTXACFCOMPRun(id, 0);
             NativeMethods.SetTXAPHROTRun(id, 0);
-            // CESSB (Controlled Envelope SSB) — unconditionally ON. Mirrors
-            // Thetis's WDSP entry point (dsp.cs:240 SetTXAosctrlRun) but
-            // without a user toggle: KISS, always on. WDSP's create_osctrl
-            // (TXA.c) ships sensible defaults (bandpass overshoot control on
-            // the SSB envelope) and no further setters are required —
-            // Thetis itself only ever calls SetTXAosctrlRun. Leaving CESSB
-            // off costs ~1–1.5 dB of average power on voice SSB; there is
-            // no operator scenario in which off is preferable, so no prefs
-            // key, no REST endpoint, no UI control. See bd zeus-5cg.
-            NativeMethods.SetTXAosctrlRun(id, 1);
+            // CESSB / osctrl — OFF, matching Thetis, pihpsdr, and DeskHPSDR,
+            // which ALL keep it off unless the speech compressor is engaged
+            // (Thetis CESSB_On=false in every profile; pihpsdr/desk gate it on
+            // COMP). The prior "unconditionally ON" here misread Thetis. osctrl
+            // is a non-linear lookahead peak divisor meant to precede the comp/
+            // clipper it was tuned with; run standalone in front of the ALC it
+            // makes the peak-envelope statistics amplitude-dependent and non-
+            // stationary on VOICE (a no-op on a constant two-tone envelope), so
+            // PS sees a moving target at the peaks → uncorrected voice-peak
+            // splatter with PS engaged, while the two-tone stays clean. With it
+            // off, the ALC is the sole envelope limiter before xiqc (the
+            // reference topology) and every peak PS sees sits at the calibrated
+            // ceiling. #559 — root-caused against Thetis/pi/desk.
+            NativeMethods.SetTXAosctrlRun(id, 0);
             NativeMethods.SetTXAEQRun(id, 0);
             NativeMethods.SetTXAAMSQRun(id, 0);
             NativeMethods.SetTXAALCSt(id, 1);

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -1195,20 +1195,15 @@ public sealed class WdspDspEngine : IDspEngine
             NativeMethods.SetTXACompressorRun(id, 0);
             NativeMethods.SetTXACFCOMPRun(id, 0);
             NativeMethods.SetTXAPHROTRun(id, 0);
-            // CESSB / osctrl — OFF, matching Thetis, pihpsdr, and DeskHPSDR,
-            // which ALL keep it off unless the speech compressor is engaged
-            // (Thetis CESSB_On=false in every profile; pihpsdr/desk gate it on
-            // COMP). The prior "unconditionally ON" here misread Thetis. osctrl
-            // is a non-linear lookahead peak divisor meant to precede the comp/
-            // clipper it was tuned with; run standalone in front of the ALC it
-            // makes the peak-envelope statistics amplitude-dependent and non-
-            // stationary on VOICE (a no-op on a constant two-tone envelope), so
-            // PS sees a moving target at the peaks → uncorrected voice-peak
-            // splatter with PS engaged, while the two-tone stays clean. With it
-            // off, the ALC is the sole envelope limiter before xiqc (the
-            // reference topology) and every peak PS sees sits at the calibrated
-            // ceiling. #559 — root-caused against Thetis/pi/desk.
-            NativeMethods.SetTXAosctrlRun(id, 0);
+            // CESSB / osctrl — ON at TXA open (Brian's default, ~1-1.5 dB
+            // average voice-SSB power; bd zeus-5cg). PS isn't armed at open, so
+            // this is the correct non-PS state. It is then toggled OFF while PS
+            // is armed and back ON on disarm in SetPsEnabled — because osctrl
+            // (a non-linear lookahead peak divisor) standalone in front of the
+            // ALC makes the peak envelope non-stationary on voice and breaks PS
+            // voice-peak correction (Thetis/pi/desk keep it out of the PS path).
+            // #559.
+            NativeMethods.SetTXAosctrlRun(id, 1);
             NativeMethods.SetTXAEQRun(id, 0);
             NativeMethods.SetTXAAMSQRun(id, 0);
             NativeMethods.SetTXAALCSt(id, 1);
@@ -1951,6 +1946,14 @@ public sealed class WdspDspEngine : IDspEngine
                 // becomes a no-op in that case and Tick keeps falling through
                 // to the existing TX/RX trace.
                 OpenPsFeedbackAnalyzer(id);
+                // CESSB/osctrl OFF while PS is armed (#559). osctrl is a
+                // non-linear lookahead peak divisor; standalone in front of the
+                // ALC it makes the peak envelope non-stationary on voice, so PS
+                // sees a moving target at the peaks → voice-peak splatter. Off
+                // here = the reference topology (Thetis/pi/desk keep it out of
+                // the PS path). Restored to Brian's default (ON) on disarm — so
+                // non-PS operators keep the ~1-1.5 dB average-power win.
+                NativeMethods.SetTXAosctrlRun(id, 0);
             }
             else
             {
@@ -1979,6 +1982,10 @@ public sealed class WdspDspEngine : IDspEngine
                 }
                 NativeMethods.SetPSRunCal(id, 0);
                 NativeMethods.SetPSControl(id, 1, 0, 0, 0);
+                // Restore CESSB/osctrl ON — Brian's default for non-PS voice
+                // SSB (~1-1.5 dB average power; bd zeus-5cg). Only held off
+                // while PS is armed (see the enable branch above).
+                NativeMethods.SetTXAosctrlRun(id, 1);
             }
         }
         _log.LogInformation("wdsp.setPsEnabled enabled={Enabled}", enabled);

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -360,11 +360,26 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         SendCmdHighPriority(run: true);
 
         _rxCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        _rxTask = Task.Run(() => RxLoop(_rxCts.Token));
+        // LongRunning → dedicated thread (not a pooled worker). The RX loop and
+        // the TX-IQ sender both run for the whole session and promote their own
+        // thread to the platform pro-audio class (RealtimeThreadPriority). The
+        // promotion is per-thread, so they must own a thread that won't be
+        // recycled into the pool with elevated priority still attached. This is
+        // the desktop-mode fix (#559): under Photino the WebView render shares
+        // the process and at default priority preempts the TX feed in bursts —
+        // average pkts/s looks fine but the sub-block jitter starves the radio
+        // TX FIFO → dirty two-tone. Clean in web (separate processes) without it.
+        _rxTask = Task.Factory.StartNew(
+            () => RxLoop(_rxCts.Token),
+            _rxCts.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
         _keepaliveTask = Task.Run(() => KeepaliveLoop(_rxCts.Token));
         // Paced TX IQ sender — drains the queue FlushTxIqLocked fills and
-        // holds the radio's DUC FIFO at a steady level.
-        _txIqSenderTask = Task.Run(() => TxIqSenderLoop(_rxCts.Token));
+        // holds the radio's DUC FIFO at a steady level. Dedicated promoted
+        // thread + synchronous pacing (no await → can't bounce to the pool and
+        // lose the promotion mid-transmit).
+        _txIqSenderTask = Task.Factory.StartNew(
+            () => TxIqSenderLoop(_rxCts.Token),
+            _rxCts.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
         _log.LogInformation("p2.start rate={Rate}kHz freq={Freq}Hz", _sampleRateKhz, _rxFreqHz);
         return Task.CompletedTask;
     }
@@ -737,8 +752,13 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         _txIqScratchCount = 0;
     }
 
-    private async Task TxIqSenderLoop(CancellationToken ct)
+    private void TxIqSenderLoop(CancellationToken ct)
     {
+        // Promote this dedicated sender to the platform pro-audio class so the
+        // Photino WebView render (desktop mode) can't preempt the radio TX-FIFO
+        // feed. Synchronous loop (no await) so it never bounces to a ThreadPool
+        // worker and loses the promotion mid-transmit. #559 desktop fix.
+        RealtimeThreadPriority.PromoteCallingThreadToProAudio(_log);
         // Port of pihpsdr's new_protocol_txiq_thread (new_protocol.c:1909-1997).
         // Maintains a software model of the radio's TX FIFO fill level: each
         // packet adds 240 samples, wall-clock elapses drain at 192 kHz. When
@@ -761,10 +781,16 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         {
             while (!ct.IsCancellationRequested)
             {
-                byte[] packet;
-                try { packet = await reader.ReadAsync(ct).ConfigureAwait(false); }
+                try
+                {
+                    // Block this dedicated thread until a packet is queued (or
+                    // the channel completes / we're cancelled). No await → the
+                    // thread keeps its pro-audio promotion across the wait.
+                    if (!reader.WaitToReadAsync(ct).AsTask().GetAwaiter().GetResult()) break;
+                }
                 catch (OperationCanceledException) { break; }
                 catch (ChannelClosedException) { break; }
+                if (!reader.TryRead(out var packet)) continue;
 
                 // Drain by wall-clock since the previous send.
                 long now = Stopwatch.GetTimestamp();
@@ -778,8 +804,8 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
                 // FIFO's 6.5 ms target headroom, so no underrun risk.
                 if (fifoSamples > TxFifoTargetSamples)
                 {
-                    try { await Task.Delay(1, ct).ConfigureAwait(false); }
-                    catch (OperationCanceledException) { break; }
+                    Thread.Sleep(1);
+                    if (ct.IsCancellationRequested) break;
                     now = Stopwatch.GetTimestamp();
                     elapsedSec = (now - lastTicks) / ticksPerSecond;
                     fifoSamples -= elapsedSec * TxDacSampleRate;
@@ -1453,6 +1479,12 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
 
     private void RxLoop(CancellationToken ct)
     {
+        // Pro-audio promotion (#559): RX carries the PureSignal paired-DDC
+        // feedback synchronously into FeedPsFeedbackBlock; at default priority
+        // it contends with the Photino WebView render. Promote so feedback
+        // timing stays tight under desktop load. Per-thread, dedicated thread
+        // (StartAsync uses LongRunning).
+        RealtimeThreadPriority.PromoteCallingThreadToProAudio(_log);
         var buf = new byte[2048];
         var sock = _sock!;
         sock.ReceiveTimeout = 500;

--- a/Zeus.Protocol2/RealtimeThreadPriority.cs
+++ b/Zeus.Protocol2/RealtimeThreadPriority.cs
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Protocol2;
+
+/// <summary>
+/// Promotes the calling thread to the platform's pro-audio / low-latency
+/// thread class. Used at the top of the protocol RxLoop so PureSignal
+/// feedback samples and RX IQ frames are pumped at a priority that doesn't
+/// have to fight Photino render / SignalR fan-out / general .NET ThreadPool
+/// work for cycles. Mirrors the discipline Thetis gets by running the same
+/// path off the ASIO driver's real-time-class thread — see
+/// <c>docs/rca/2026-05-28-ps-load-sensitivity.md</c>.
+/// </summary>
+/// <remarks>
+/// All P/Invoke failures are non-fatal: the thread keeps running at
+/// whatever priority the OS will grant. We log at warning level so an
+/// operator chasing a perf issue can confirm the promotion landed (or didn't).
+///
+/// Per-platform mapping:
+/// <list type="bullet">
+/// <item><b>macOS</b> — <c>pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0)</c>.
+/// The high QoS tier for user-driven low-latency work. Doesn't need
+/// entitlements or the mach real-time ceremony.</item>
+/// <item><b>Windows</b> — <c>AvSetMmThreadCharacteristicsW("Pro Audio")</c>.
+/// MMCSS Pro Audio task class — the same one DAWs and Thetis (via ASIO)
+/// request. The returned handle is intentionally not reverted; the RX
+/// thread runs for the lifetime of the protocol session.</item>
+/// <item><b>Linux / other</b> — <c>Thread.CurrentThread.Priority = ThreadPriority.Highest</c>.
+/// <c>SCHED_FIFO</c> needs <c>CAP_SYS_NICE</c> which an operator process
+/// typically lacks; the .NET fallback maps to an elevated nice value, which
+/// is the best we can do without privileged setup.</item>
+/// </list>
+///
+/// This file is intentionally duplicated in <c>Zeus.Protocol1</c>; the two
+/// protocol projects don't share a utility assembly. Keep the two copies in
+/// sync — if you fix one, fix the other.
+/// </remarks>
+internal static partial class RealtimeThreadPriority
+{
+    /// <summary>
+    /// Promote the calling thread to the platform's pro-audio class. Safe
+    /// to call once per long-running thread (e.g. at the top of an RxLoop).
+    /// </summary>
+    public static void PromoteCallingThreadToProAudio(ILogger log)
+    {
+        try
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                PromoteMacOs(log);
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                PromoteWindows(log);
+            else
+                PromoteFallback(log);
+        }
+        catch (DllNotFoundException ex)
+        {
+            log.LogWarning(ex, "thread.priority native library not found — leaving thread at default priority");
+        }
+        catch (Exception ex)
+        {
+            log.LogWarning(ex, "thread.priority promotion threw — leaving thread at default priority");
+        }
+    }
+
+    // ---- macOS -------------------------------------------------------------
+    private const int QOS_CLASS_USER_INTERACTIVE = 0x21;
+
+    [LibraryImport("libSystem.dylib", EntryPoint = "pthread_set_qos_class_self_np")]
+    private static partial int pthread_set_qos_class_self_np(int qos_class, int relative_priority);
+
+    private static void PromoteMacOs(ILogger log)
+    {
+        int rc = pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
+        if (rc == 0)
+            log.LogInformation("thread.priority promoted to QOS_CLASS_USER_INTERACTIVE (macOS)");
+        else
+            log.LogWarning("thread.priority pthread_set_qos_class_self_np rc={Rc} — staying at default", rc);
+    }
+
+    // ---- Windows -----------------------------------------------------------
+    [LibraryImport("avrt.dll", EntryPoint = "AvSetMmThreadCharacteristicsW",
+                   StringMarshalling = StringMarshalling.Utf16, SetLastError = true)]
+    private static partial IntPtr AvSetMmThreadCharacteristicsW(string TaskName, out uint TaskIndex);
+
+    private static void PromoteWindows(ILogger log)
+    {
+        uint taskIdx = 0;
+        IntPtr handle;
+        try
+        {
+            handle = AvSetMmThreadCharacteristicsW("Pro Audio", out taskIdx);
+        }
+        catch (DllNotFoundException)
+        {
+            log.LogWarning("thread.priority avrt.dll not available — falling back to ThreadPriority.Highest");
+            TrySetThreadPriorityHighest(log);
+            return;
+        }
+
+        if (handle != IntPtr.Zero)
+        {
+            log.LogInformation("thread.priority promoted to MMCSS Pro Audio (Windows, taskIdx={Idx})", taskIdx);
+        }
+        else
+        {
+            int err = Marshal.GetLastPInvokeError();
+            log.LogWarning("thread.priority AvSetMmThreadCharacteristicsW err={Err} — falling back to ThreadPriority.Highest", err);
+            TrySetThreadPriorityHighest(log);
+        }
+    }
+
+    // ---- Linux / other -----------------------------------------------------
+    private static void PromoteFallback(ILogger log)
+    {
+        if (TrySetThreadPriorityHighest(log))
+            log.LogInformation("thread.priority set to ThreadPriority.Highest (Linux/other)");
+    }
+
+    private static bool TrySetThreadPriorityHighest(ILogger log)
+    {
+        try
+        {
+            Thread.CurrentThread.Priority = ThreadPriority.Highest;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            log.LogWarning(ex, "thread.priority Thread.Priority.Highest threw");
+            return false;
+        }
+    }
+}

--- a/Zeus.Protocol2/RealtimeThreadPriority.cs
+++ b/Zeus.Protocol2/RealtimeThreadPriority.cs
@@ -48,7 +48,9 @@ namespace Zeus.Protocol2;
 /// protocol projects don't share a utility assembly. Keep the two copies in
 /// sync — if you fix one, fix the other.
 /// </remarks>
-internal static partial class RealtimeThreadPriority
+// Public so Zeus.Server.Hosting (TxTuneDriver pump) can promote its dedicated
+// thread too — same RT need as the protocol RX/TX threads (#559).
+public static partial class RealtimeThreadPriority
 {
     /// <summary>
     /// Promote the calling thread to the platform's pro-audio class. Safe

--- a/Zeus.Protocol2/RealtimeThreadPriority.cs
+++ b/Zeus.Protocol2/RealtimeThreadPriority.cs
@@ -77,17 +77,88 @@ internal static partial class RealtimeThreadPriority
 
     // ---- macOS -------------------------------------------------------------
     private const int QOS_CLASS_USER_INTERACTIVE = 0x21;
+    private const int QOS_CLASS_USER_INITIATED = 0x19;
+    private const int THREAD_TIME_CONSTRAINT_POLICY = 2;
+    private const uint THREAD_TIME_CONSTRAINT_POLICY_COUNT = 4;
 
     [LibraryImport("libSystem.dylib", EntryPoint = "pthread_set_qos_class_self_np")]
     private static partial int pthread_set_qos_class_self_np(int qos_class, int relative_priority);
 
+    [StructLayout(LayoutKind.Sequential)]
+    private struct ThreadTimeConstraintPolicy
+    {
+        public uint period;       // mach abs ticks: nominal cycle
+        public uint computation;  // mach abs ticks: CPU needed per cycle
+        public uint constraint;   // mach abs ticks: deadline after period start
+        public int preemptible;   // 1 = soft RT (preemptible after computation)
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MachTimebaseInfo { public uint numer; public uint denom; }
+
+    [LibraryImport("libSystem.dylib", EntryPoint = "mach_thread_self")]
+    private static partial uint mach_thread_self();
+
+    [LibraryImport("libSystem.dylib", EntryPoint = "mach_timebase_info")]
+    private static partial int mach_timebase_info(ref MachTimebaseInfo info);
+
+    [LibraryImport("libSystem.dylib", EntryPoint = "thread_policy_set")]
+    private static partial int thread_policy_set(
+        uint thread, int flavor, ref ThreadTimeConstraintPolicy policy, uint count);
+
     private static void PromoteMacOs(ILogger log)
     {
+        // 1) Real-time scheduling (THREAD_TIME_CONSTRAINT_POLICY) — CoreAudio's
+        //    mechanism. This genuinely preempts the Photino WebView's render
+        //    threads, which the QoS path could not: macOS denies the
+        //    USER_INTERACTIVE QoS tier to non-UI threads (we saw rc=1/EPERM),
+        //    so the previous promotion was a silent no-op and desktop two-tone
+        //    stayed dirty. RT is granted to ordinary app threads.
+        try
+        {
+            var tb = new MachTimebaseInfo();
+            mach_timebase_info(ref tb);
+            if (tb.numer != 0 && tb.denom != 0)
+            {
+                // ns → mach abs ticks = ns * denom / numer.
+                double nsToAbs = (double)tb.denom / tb.numer;
+                uint Abs(double ms) => (uint)(ms * 1_000_000.0 * nsToAbs);
+                // Conservative budget: ~1 ms compute per 5 ms cycle, 3 ms
+                // deadline, preemptible. Ample for the lightweight TX
+                // sender / RX pump while leaving the system schedulable.
+                var policy = new ThreadTimeConstraintPolicy
+                {
+                    period = Abs(5.0),
+                    computation = Abs(1.0),
+                    constraint = Abs(3.0),
+                    preemptible = 1,
+                };
+                int rcRt = thread_policy_set(
+                    mach_thread_self(), THREAD_TIME_CONSTRAINT_POLICY,
+                    ref policy, THREAD_TIME_CONSTRAINT_POLICY_COUNT);
+                if (rcRt == 0)
+                {
+                    log.LogInformation("thread.priority promoted to mach RT (TIME_CONSTRAINT 1ms/5ms)");
+                    return;
+                }
+                log.LogWarning("thread.priority thread_policy_set rc={Rc} — trying QoS", rcRt);
+            }
+        }
+        catch (Exception ex)
+        {
+            log.LogWarning(ex, "thread.priority mach RT threw — trying QoS");
+        }
+
+        // 2) QoS fallback — USER_INTERACTIVE (often denied) then USER_INITIATED.
         int rc = pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
+        if (rc != 0) rc = pthread_set_qos_class_self_np(QOS_CLASS_USER_INITIATED, 0);
         if (rc == 0)
-            log.LogInformation("thread.priority promoted to QOS_CLASS_USER_INTERACTIVE (macOS)");
+            log.LogInformation("thread.priority promoted via QoS (macOS)");
         else
-            log.LogWarning("thread.priority pthread_set_qos_class_self_np rc={Rc} — staying at default", rc);
+            log.LogWarning("thread.priority QoS rc={Rc} — using ThreadPriority.Highest floor", rc);
+
+        // 3) Always set a .NET priority floor — harmless, no-op-safe.
+        TrySetThreadPriorityHighest(log);
     }
 
     // ---- Windows -----------------------------------------------------------

--- a/Zeus.Protocol2/Zeus.Protocol2.csproj
+++ b/Zeus.Protocol2/Zeus.Protocol2.csproj
@@ -12,6 +12,9 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <!-- LibraryImport source generator (RealtimeThreadPriority P/Invokes)
+         emits unsafe code internally. Matches Zeus.Dsp / Zeus.Server.Hosting. -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
 </Project>

--- a/Zeus.Server.Hosting/PsAutoAttenuateService.cs
+++ b/Zeus.Server.Hosting/PsAutoAttenuateService.cs
@@ -394,7 +394,18 @@ public sealed class PsAutoAttenuateService : BackgroundService
         // comment). Reset calcc to recover; rate-limited to one reset per
         // window so a hard wedge can't reset-storm. Gated on auto mode because
         // single-cal / manual hold freezes info5 by design.
-        if (s.PsAuto && !s.PsSingle && stallPsm.CalibrationAttempts > 0)
+        //
+        // ONLY fire in the active compute states (LCOLLECT=4 .. LDELAY=7): a
+        // genuine stale-curve wedge is stuck in LCALC(6). When calcc is parked
+        // in a WAIT state — LRESET(0)/LWAIT(1)/LMOXDELAY(2)/LSETUP(3) — info5 is
+        // frozen by design (waiting for MOX/feedback), and a reset is both
+        // FUTILE (it just re-enters LWAIT) and DESTRUCTIVE (it tears down the
+        // live correction). On the G2 desktop two-tone this exact loop —
+        // reset → LWAIT → frozen → reset every 5 s — periodically blew the
+        // correction away, holding IMD ~10 dB worse than a stable curve (#559).
+        var calState = stallPsm.CalState;
+        if (s.PsAuto && !s.PsSingle && stallPsm.CalibrationAttempts > 0
+            && calState >= 4 && calState <= 7)
         {
             long now = Environment.TickCount64;
             if (stallPsm.CalibrationAttempts != _lastWedgeCal)

--- a/Zeus.Server.Hosting/PsAutoAttenuateService.cs
+++ b/Zeus.Server.Hosting/PsAutoAttenuateService.cs
@@ -163,6 +163,22 @@ public sealed class PsAutoAttenuateService : BackgroundService
     private long _lastWedgeCalChangeMs;
     private long _lastWedgeResetMs;
 
+    // Converge-then-hold (#559). Continuous automode never settles — it cycles
+    // COLLECT/MOXCHECK/CALC/DELAY forever, so the correction "flickers" and
+    // never "catches/holds" (the operator's Thetis single-cal expectation). Once
+    // the correction has converged (correcting + clean + feedback centred for a
+    // sustained window with enough fresh fits behind it), lock it with
+    // SetPsHold(true) → SetPSRunCal(0): calcc parks (state stops cycling), the
+    // iqc predistorter keeps the converged curve. P2 automode only. Re-armed on
+    // the next PS-arm edge.
+    private bool _psHeld;
+    private int _convergeBaselineCal = -1;
+    private long _convergeHealthyStartMs;
+    private static readonly TimeSpan ConvergeHoldTime = TimeSpan.FromMilliseconds(2500);
+    private const int ConvergeMinFits = 12;     // ~enough stbl(0.9) passes to converge
+    private const int ConvergeFbLow = 138;      // feedback well-centred (ideal 152)
+    private const int ConvergeFbHigh = 176;
+
     // *** DEVIATION FROM mi0bot ***
     // Silent server-side auto-cal of WDSP hw_peak from observed TX envelope.
     // mi0bot exposes PSForm.cs txtPSpeak as a hand-dialed operator value
@@ -300,6 +316,10 @@ public sealed class PsAutoAttenuateService : BackgroundService
             _stallStartTickMs = 0;
             _stallWarned = false;
             _lastAutoCalTickMs = 0;
+            // Fresh arm → re-converge then lock. SetPsEnabled(true) set runcal=1.
+            _psHeld = false;
+            _convergeBaselineCal = -1;
+            _convergeHealthyStartMs = 0;
             _log.LogInformation("psAutoAttn.armed baseline attn={Db} (synced to radio)", _currentAttnDb);
         }
         _psWasEnabled = s.PsEnabled;
@@ -403,8 +423,10 @@ public sealed class PsAutoAttenuateService : BackgroundService
         // live correction). On the G2 desktop two-tone this exact loop —
         // reset → LWAIT → frozen → reset every 5 s — periodically blew the
         // correction away, holding IMD ~10 dB worse than a stable curve (#559).
+        // Also skip when we've deliberately locked the correction (_psHeld →
+        // SetPSRunCal(0)): calcc is parked on purpose, info5 frozen by design.
         var calState = stallPsm.CalState;
-        if (s.PsAuto && !s.PsSingle && stallPsm.CalibrationAttempts > 0
+        if (s.PsAuto && !s.PsSingle && !_psHeld && stallPsm.CalibrationAttempts > 0
             && calState >= 4 && calState <= 7)
         {
             long now = Environment.TickCount64;
@@ -428,6 +450,10 @@ public sealed class PsAutoAttenuateService : BackgroundService
             _lastWedgeCal = -1;
         }
 
+        // Converge-then-hold: lock the correction once it settles so it stops
+        // re-fitting/flickering and "catches" (P2 automode only).
+        TickPsHold(s, engine, stallPsm);
+
         // Auto-cal hw_peak from observed envelope. Independent of HL2/P2 path
         // and runs every keyed tick — same gates as the rest of the loop
         // (PsEnabled + TX active + engine present, all checked above).
@@ -449,6 +475,39 @@ public sealed class PsAutoAttenuateService : BackgroundService
         var p2 = _pipe.CurrentP2Client;
         if (p2 is null) { LogGate("skip=p2-null"); return; }
         Tick1P2(s, engine, p2);
+    }
+
+    // Converge-then-hold supervisor (P2 automode only). Lock the correction once
+    // it's converged so calcc stops cycling and the predistorter holds the curve
+    // — the "catch and hold" the operator expects (Thetis single-cal behaviour)
+    // instead of continuous automode flicker. See the _psHeld field comment.
+    private void TickPsHold(StateDto s, IDspEngine engine, PsStageMeters psm)
+    {
+        if (_psHeld) return;                                  // already locked
+        if (s.PsSingle || !s.PsAuto) return;                  // single-cal already holds
+        if (_radio.ConnectedBoardKind == HpsdrBoardKind.HermesLite2) return;  // P2 only
+
+        int fb = (int)Math.Round(psm.FeedbackLevel);
+        if (_convergeBaselineCal < 0) _convergeBaselineCal = psm.CalibrationAttempts;
+
+        bool healthy = psm.Correcting && fb >= ConvergeFbLow && fb <= ConvergeFbHigh;
+        bool enoughFits = psm.CalibrationAttempts - _convergeBaselineCal >= ConvergeMinFits;
+        if (!healthy || !enoughFits)
+        {
+            if (!healthy) _convergeHealthyStartMs = 0;        // restart the settle window
+            return;
+        }
+
+        long now = Environment.TickCount64;
+        if (_convergeHealthyStartMs == 0) _convergeHealthyStartMs = now;
+        else if (now - _convergeHealthyStartMs >= (long)ConvergeHoldTime.TotalMilliseconds)
+        {
+            engine.SetPsHold(true);   // SetPSRunCal(0): calcc parks, iqc holds curve
+            _psHeld = true;
+            _log.LogInformation(
+                "psHold.lock cal={Cal} fb={Fb} — correction converged; calcc parked, correction held",
+                psm.CalibrationAttempts, fb);
+        }
     }
 
     // Ground-truth TX feedback attenuation the radio is actually holding, for

--- a/Zeus.Server.Hosting/PsAutoAttenuateService.cs
+++ b/Zeus.Server.Hosting/PsAutoAttenuateService.cs
@@ -450,9 +450,16 @@ public sealed class PsAutoAttenuateService : BackgroundService
             _lastWedgeCal = -1;
         }
 
-        // Converge-then-hold: lock the correction once it settles so it stops
-        // re-fitting/flickering and "catches" (P2 automode only).
-        TickPsHold(s, engine, stallPsm);
+        // NOTE (#559): converge-then-hold (TickPsHold) is intentionally NOT
+        // called. Locking the correction froze it at the convergence drive
+        // level, so driving harder (overdrive) left the frozen curve mismatched
+        // → uncorrected IMD. Thetis stays clean under overdrive by running
+        // CONTINUOUS automode and re-adapting; the flicker that originally
+        // motivated the lock was the jittery TX feed, now fixed by the RT
+        // pump/sender/rx-loop. So we run continuous automode (Thetis parity) and
+        // let it track drive changes. TickPsHold kept for reference/possible
+        // operator-selectable "single-cal hold" later.
+        // TickPsHold(s, engine, stallPsm);
 
         // Auto-cal hw_peak from observed envelope. Independent of HL2/P2 path
         // and runs every keyed tick — same gates as the rest of the loop

--- a/Zeus.Server.Hosting/TxAudioIngest.cs
+++ b/Zeus.Server.Hosting/TxAudioIngest.cs
@@ -126,7 +126,8 @@ public sealed class TxAudioIngest : IDisposable
         StreamingHub hub,
         ILogger<TxAudioIngest> log)
         : this(ring, () => pipeline.CurrentEngine, () => tx.IsMoxOn, hub, log,
-               forwardP2: iq => pipeline.ForwardTxIqToP2(iq.Span))
+               forwardP2: iq => pipeline.ForwardTxIqToP2(iq.Span),
+               txOwnedByTuneDriver: () => tx.IsTunOn || tx.IsTwoToneOn)
     {
     }
 
@@ -142,13 +143,15 @@ public sealed class TxAudioIngest : IDisposable
         StreamingHub hub,
         ILogger<TxAudioIngest> log,
         Action<ReadOnlyMemory<float>>? forwardP2 = null,
-        Action<int>? onWdspConsumed = null)
+        Action<int>? onWdspConsumed = null,
+        Func<bool>? txOwnedByTuneDriver = null)
     {
         _ring = ring;
         _engineProvider = engineProvider;
         _isMoxOn = isMoxOn;
         _forwardP2 = forwardP2;
         _onWdspConsumed = onWdspConsumed;
+        _txOwnedByTuneDriver = txOwnedByTuneDriver ?? (static () => false);
         _hub = hub;
         _log = log;
         _handler = OnMicPcmBytesFromMic;
@@ -156,6 +159,13 @@ public sealed class TxAudioIngest : IDisposable
     }
 
     private readonly Action<ReadOnlyMemory<float>>? _forwardP2;
+    // True while TUN or the two-tone test is active. TxTuneDriver is the sole TX
+    // driver in those states; this mic-ingest path must NOT also run ProcessTxBlock
+    // or push IQ, or two threads drive the same TXA (fexchange2) and BOTH feed the
+    // radio → double-fed / corrupted signal. Desktop-only symptom (#559): native
+    // mic capture keeps feeding here during a two-tone; web has no native mic so
+    // only TxTuneDriver drove it and it stayed clean.
+    private readonly Func<bool> _txOwnedByTuneDriver;
 
     // Cross-thread handoff: written from the TCI timer thread (Start/Stop of
     // the TX_CHRONO service), read every audio block from the WDSP worker.
@@ -259,6 +269,20 @@ public sealed class TxAudioIngest : IDisposable
         {
             // Synthetic engine, no TXA open, or a protocol whose block size
             // exceeds our scratch buffers. Swallow samples quietly.
+            return;
+        }
+
+        // TUN / two-tone active → TxTuneDriver is the sole TX driver. Running
+        // ProcessTxBlock here too would put two threads on one TXA's fexchange2
+        // AND push a second IQ stream to the radio (double-feed → corrupted /
+        // dirty signal; PS then calibrates on garbage). The mic isn't
+        // transmitted during a tune/two-tone anyway, so drop the batch and reset
+        // the accumulator so it can't back up. Fixes the desktop-only dirty
+        // two-tone in #559 (native mic capture kept feeding here; web had no
+        // native mic so only TxTuneDriver drove it → clean).
+        if (_txOwnedByTuneDriver())
+        {
+            lock (_sync) _accumulatorFill = 0;
             return;
         }
 

--- a/Zeus.Server.Hosting/TxService.cs
+++ b/Zeus.Server.Hosting/TxService.cs
@@ -398,6 +398,7 @@ public sealed class TxService
     public void TryTripForAlert(AlertKind kind, string reason)
     {
         bool wasMoxOn, wasTunOn;
+        bool wasTwoToneOn = IsTwoToneOn;
         bool? txActiveCaptured;
         lock (_sync)
         {
@@ -420,6 +421,17 @@ public sealed class TxService
             _pipeline.SetMox(false);
             _radio.SetMox(false);
             if (wasTunOn) _pipeline.SetTxTune(false);
+            // A trip force-drops MOX, so any running two-tone test is over too.
+            // Disarm it the same way we disarm TUN above — clear the latch AND
+            // drop the engine's PostGen (SetTwoTone false). Without this the
+            // server's TwoToneEnabled stays stuck true; the two-tone apply is
+            // change-gated, so the next engage wouldn't re-assert PostGen mode=1
+            // and the leftover generator (a single carrier) would play through.
+            if (wasTwoToneOn)
+            {
+                IsTwoToneOn = false;
+                _radio.SetTwoTone(new TwoToneSetRequest(false));
+            }
             _radio.NotifyTunActive(false);
             _log.LogWarning("tx.trip kind={Kind} reason={Reason}", kind, reason);
             _hub.Broadcast(new AlertFrame(kind, reason));

--- a/Zeus.Server.Hosting/TxTuneDriver.cs
+++ b/Zeus.Server.Hosting/TxTuneDriver.cs
@@ -93,8 +93,25 @@ internal sealed class TxTuneDriver : BackgroundService
         _log = log;
     }
 
-    protected override async Task ExecuteAsync(CancellationToken ct)
+    protected override Task ExecuteAsync(CancellationToken ct)
     {
+        // Run the pump on a DEDICATED thread promoted to the platform pro-audio /
+        // real-time class. The deadline pacing below keeps TX-IQ production locked
+        // to the DAC block clock — but only if this thread isn't preempted. In
+        // desktop mode the native-audio (CoreAudio) device threads run at RT and
+        // starve a normal-priority ThreadPool pump, so production comes in bursts:
+        // the two-tone amplitude swings (observed-peak wander) and the signal goes
+        // dirty. Web has no competing audio threads, so the identical pacing stays
+        // clean — the desktop gap (#559). LongRunning → a real dedicated thread we
+        // can keep promoted; the loop is synchronous (no await) so it never bounces
+        // back to the pool and loses the promotion mid-transmit.
+        return Task.Factory.StartNew(
+            () => PumpLoop(ct), ct, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+    }
+
+    private void PumpLoop(CancellationToken ct)
+    {
+        Zeus.Protocol2.RealtimeThreadPriority.PromoteCallingThreadToProAudio(_log);
         float[]? micScratch = null;
         float[]? iqScratch = null;
         // Drift-free pacing state. `clock` is the monotonic reference; pacing is
@@ -111,7 +128,7 @@ internal sealed class TxTuneDriver : BackgroundService
                 if (!_tx.IsTunOn && !_tx.IsTwoToneOn)
                 {
                     pacing = false;
-                    await Task.Delay(PollIdle, ct).ConfigureAwait(false);
+                    if (ct.WaitHandle.WaitOne(PollIdle)) return;
                     continue;
                 }
 
@@ -122,7 +139,7 @@ internal sealed class TxTuneDriver : BackgroundService
                 {
                     // No TXA yet — retry on the slow cadence.
                     pacing = false;
-                    await Task.Delay(PollIdle, ct).ConfigureAwait(false);
+                    if (ct.WaitHandle.WaitOne(PollIdle)) return;
                     continue;
                 }
 
@@ -192,8 +209,7 @@ internal sealed class TxTuneDriver : BackgroundService
                     continue;
                 }
                 int delayMs = (int)(remainingTicks * 1000 / System.Diagnostics.Stopwatch.Frequency);
-                if (delayMs > 0)
-                    await Task.Delay(delayMs, ct).ConfigureAwait(false);
+                if (delayMs > 0 && ct.WaitHandle.WaitOne(delayMs)) return;
                 // Sub-millisecond remainder is left unspun; the deadline accounting
                 // folds it into the next iteration.
             }
@@ -202,8 +218,7 @@ internal sealed class TxTuneDriver : BackgroundService
             {
                 _log.LogWarning(ex, "tx.tune driver tick failed");
                 pacing = false;
-                try { await Task.Delay(PollIdle, ct).ConfigureAwait(false); }
-                catch (OperationCanceledException) { return; }
+                if (ct.WaitHandle.WaitOne(PollIdle)) return;
             }
         }
     }

--- a/Zeus.Server.Hosting/TxTuneDriver.cs
+++ b/Zeus.Server.Hosting/TxTuneDriver.cs
@@ -179,8 +179,16 @@ internal sealed class TxTuneDriver : BackgroundService
                 // FIFO stays topped; the P2 sender's FIFO model throttles the small
                 // surplus. TxTuneDriver only drives TUN / TwoTone (short bursts),
                 // never voice — voice is pumped by the hardware-clocked mic path.
+                // Produce at the EXACT DAC block rate. The old 3% surplus
+                // (×0.97) was a jitter margin for when this pump ran on a
+                // preempted ThreadPool worker — the sender then had to throttle
+                // the surplus, and that throttle stutters the delivery, pumping
+                // the carriers. Now the pump runs on a dedicated RT thread and
+                // hits its deadline deterministically, so exact rate keeps the
+                // radio FIFO level without a surplus to throttle (#559). The
+                // PrimeBlocks burst still tops the FIFO at key-down.
                 long periodTicks = (long)(System.Diagnostics.Stopwatch.Frequency
-                    * micBlock * 0.97 / MicRateHz);
+                    * micBlock / (double)MicRateHz);
 
                 if (!pacing)
                 {

--- a/docs/rca/2026-05-29-ps-twotone-desktop-vs-web.md
+++ b/docs/rca/2026-05-29-ps-twotone-desktop-vs-web.md
@@ -1,0 +1,116 @@
+# RCA — Two-tone / PureSignal clean in web, dirty in desktop (G2, Protocol 2)
+
+**Date:** 2026-05-29
+**Board:** ANAN-G2 (OrionMkII, Protocol 2) + RF2K-S, external feedback tap
+**Issue:** #559 (PS quality) / related to PR #565 (two-tone)
+**Status:** Root cause identified (architectural). NOT fixed. Speculative
+thread-priority attempts tried and reverted. Workaround: operate in web mode.
+
+## 1. Symptom
+
+On the G2, with identical code (`feat/imd-measurement-window` = PR #565
+two-tone fixes + IMD-measurement overlay):
+
+- **Web mode** (Vite :5173 + standalone backend :6060): two-tone is clean,
+  PureSignal corrects, SSB clean at 1 kW (tiny splatter at 1400 W = separate
+  headroom item).
+- **Desktop mode** (Photino `--desktop`): two-tone is dirty, IMD not corrected,
+  calcc stalls. Same radio, same code, same operator settings.
+
+## 2. Root cause (repeatable, high-confidence)
+
+**It's the process architecture, not the DSP/PS code.**
+
+- **Web mode = two processes.** The browser renders the panadapter/waterfall
+  (WebGL) in its own OS process; the backend (WDSP DSP + TX pump + P2 UDP
+  sender + RX/PS-feedback loop) runs alone in the dotnet process. The OS
+  schedules the backend's TX-feed threads cleanly → the radio's TX DUC FIFO
+  gets a smooth, on-time 192 kHz stream → clean two-tone, and calcc gets a
+  clean feedback timeline → PS converges.
+- **Desktop mode = one process.** Photino hosts the WebView (Chromium/WebKit)
+  **and** the backend in the **same process**. The WebView's render —
+  especially the panadapter/waterfall WebGL redrawing during TX — contends for
+  CPU with the TX feed threads inside that one process. PR #565's deadline pump
+  keeps the *average* rate right (~825 pkts/s) but the **sub-block timing goes
+  jittery**: the radio FIFO sees uneven delivery → gappy/dirty two-tone, and
+  calcc's pscc state machine (driven off the RX-feedback thread) stalls — we
+  observed it frozen in **LWAIT (state=1)** with `info[5]` pinned, which then
+  trips the wedge watchdog into a **reset-storm** (`engine.ResetPs()` every 5 s),
+  compounding the dirtiness.
+
+This matches the pre-existing load-sensitivity RCA
+(`2026-05-28-ps-load-sensitivity.md`): "desktop worse than web, structural."
+
+## 3. The "Observed clipping / HW peak too low" banner is a SYMPTOM, not the cause
+
+`zeus-web/src/components/PsSettingsPanel.tsx` (and `PsStatusPopover.tsx`) raise
+"HW peak too low — Observed is clipping into the ADC ceiling" purely on
+`psMaxTxEnvelope > psHwPeak`. `psMaxTxEnvelope` = WDSP `GetPSMaxTX` =
+`env_maxtx`, a **high-water mark** that only resets on a calcc reset. During the
+desktop stall/reset-storm a garbage/clipped TX-DAC loopback sample gets latched
+(observed jumped to **0.734** vs hw_peak ~0.613) and **stays** there, so the
+banner fires permanently. Raising hw_peak clears the banner but does nothing for
+the signal — operator correctly observed "it wasn't too low." Do not chase
+hw_peak for this; it's downstream of the stall.
+
+## 4. What was tried and REVERTED (don't repeat blindly)
+
+All on top of the baseline, all reverted back to `cb1252c`:
+
+1. **Per-thread pro-audio QoS** (slice-2 `RealtimeThreadPriority`,
+   `pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE)`): **macOS denied
+   it — rc=1/EPERM.** macOS reserves USER_INTERACTIVE for the app's UI/WebView
+   thread; background threads can't get it. Silent no-op → desktop unchanged.
+2. **mach real-time** (`THREAD_TIME_CONSTRAINT_POLICY`, 1 ms/5 ms): **granted
+   (rc=0)** — but it changed the TX sender's pacing for the worse: the dedicated
+   sync sender + RT made `Thread.Sleep(1)` precise enough to **overfeed at
+   967 pkts/s** (vs 800 target), over-filling the radio FIFO → still dirty, and
+   the wedge reset-storm persisted. Net regression.
+3. Converting `TxIqSenderLoop` to a dedicated synchronous thread + promoting
+   `RxLoop` (LongRunning). Kept the structure but the priority couldn't be
+   granted usefully and the pacing regressed; reverted with the rest.
+
+Lesson (again): per-thread priority can't reliably win a CPU fight **inside one
+process** against the WebView, and tuning RT pacing by trial over chat made it
+worse. This is the logged anti-pattern — stop iterating blind.
+
+## 5. The proper fix (architectural — decision required)
+
+Make desktop mode behave like web: **run the backend in its own OS process** and
+have the Photino native window connect to it over loopback — i.e. desktop =
+"standalone backend process + thin native window," exactly the web topology that
+is already clean. The WebView render then competes with nothing in the backend's
+process and the OS schedules the DSP/TX threads independently.
+
+This is a red-light architecture change (process model). Options to weigh:
+- **A. Split process:** desktop launcher spawns `OpenhpsdrZeus --server` as a
+  child process, waits for it to bind loopback, then opens the Photino window
+  pointed at it. Cleanest; mirrors web exactly. Adds process lifecycle mgmt.
+- **B. Keep one process but isolate the DSP/TX onto OS real-time threads done
+  right** (mach RT with correct *periodic* parameters per thread, + leave the
+  sender pacing untouched). Lower-confidence; tuning RT params on hardware is
+  finicky (see §4.2).
+- **C. Reduce WebView contention:** throttle/suspend the panadapter+waterfall
+  WebGL render rate during TX in desktop mode. Cheap, partial; doesn't fix the
+  calcc-feedback-thread stall, only the render load.
+
+Recommendation: **A** (process split) — it's the only one that structurally
+guarantees web-equivalent behavior, and it's verifiable (web already proves it).
+
+## 6. Workaround (now)
+
+Operate in **web mode** (`/run --mode=web`, browse `localhost:5173` on the mini)
+— PS and two-tone are clean there today. Native desktop mic differs from the
+browser mic path, but for two-tone (internally generated) there's no difference,
+and SSB via the shack chain into the browser is the operator's call.
+
+## 7. Scope read this session
+
+Zeus: `Zeus.Server.Hosting/TxTuneDriver.cs` (deadline pump),
+`Zeus.Protocol2/Protocol2Client.cs` (`TxIqSenderLoop`, `RxLoop`, `SendTxIq`,
+`FlushTxIqLocked`), `Zeus.Dsp/Wdsp/WdspDspEngine.cs` (`ProcessTxBlock`,
+`FeedPsFeedbackBlock`), `native/wdsp/{calcc.c,iqc.c,TXA.c}` (PS state machine +
+iqc apply — confirmed iqc engages and reaches the wire), `PsAutoAttenuateService`
+(wedge watchdog), `PsSettingsPanel.tsx` (banner source). PR #565 = the two-tone
+sideband-sign + deadline-pump-pacing fix (clean in web). The 1400 W SSB splatter
+is a separate PS-headroom follow-up.

--- a/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
@@ -198,6 +198,7 @@ public class MicGainEndpointTests : IClassFixture<MicGainEndpointTests.Factory>
         public void SetTwoTone(bool on, double freq1, double freq2, double mag) { }
         public void SetPsEnabled(bool enabled) { }
         public void SetPsControl(bool autoCal, bool singleCal) { }
+        public void SetPsHold(bool hold) { }
         public void SetPsAdvanced(bool ptol, double moxDelaySec, double loopDelaySec,
                                   double ampDelayNs, double hwPeak, int ints, int spi) { }
         public void SetPsHwPeak(double hwPeak) { }

--- a/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
+++ b/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
@@ -108,6 +108,7 @@ public class TxAudioIngestTests
         public void SetTwoTone(bool on, double freq1, double freq2, double mag) { }
         public void SetPsEnabled(bool enabled) { }
         public void SetPsControl(bool autoCal, bool singleCal) { }
+        public void SetPsHold(bool hold) { }
         public void SetPsAdvanced(bool ptol, double moxDelaySec, double loopDelaySec,
                                   double ampDelayNs, double hwPeak, int ints, int spi) { }
         public void SetPsHwPeak(double hwPeak) { }

--- a/zeus-web/src/components/ImdReadings.tsx
+++ b/zeus-web/src/components/ImdReadings.tsx
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is an independent reimplementation in .NET — not a fork. Its TX
+// behaviour and the two-tone IMD readout were informed by studying the Thetis
+// project (https://github.com/ramdor/Thetis) — display.cs two_tone_readings,
+// MW0LGE — the authoritative reference implementation in the OpenHPSDR
+// ecosystem.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+import { useEffect, useRef, useState } from 'react';
+
+import { useTxStore } from '../state/tx-store';
+import { useDisplayStore } from '../state/display-store';
+import { computeImd, type ImdReadout, type ImdResult } from '../util/imd-measure';
+
+// Two-tone IMD readout overlay. Pops up while the two-tone test is engaged and
+// closes when it's switched off (render is gated on `twoToneOn`). It peak-finds
+// the panadapter spectrum and reports IMD3 / IMD5 suppression in dBc plus the
+// output intercept points — the objective meter for judging PureSignal, instead
+// of eyeballing the trace. Source-agnostic: it measures whatever the panadapter
+// shows, so view the post-PA feedback / a monitor RX to read PA IMD.
+
+// EMA factor for the readout — the per-frame peak picks jitter a few tenths of a
+// dB, so smooth lightly for a readable display without lagging real changes.
+const EMA_ALPHA = 0.25;
+// Recompute cadence. The spectrum ticks ~25 Hz; 10 Hz is plenty for a numeric
+// readout and keeps the work off the render path.
+const TICK_MS = 100;
+
+function blend(prev: ImdReadout, next: ImdReadout, a: number): ImdReadout {
+  const m = (p: number, n: number) => a * n + (1 - a) * p;
+  return {
+    ok: true,
+    f0LowerDbm: m(prev.f0LowerDbm, next.f0LowerDbm),
+    f0UpperDbm: m(prev.f0UpperDbm, next.f0UpperDbm),
+    f0LowerHz: m(prev.f0LowerHz, next.f0LowerHz),
+    f0UpperHz: m(prev.f0UpperHz, next.f0UpperHz),
+    toneSpacingHz: m(prev.toneSpacingHz, next.toneSpacingHz),
+    imd3: {
+      lowerDbm: m(prev.imd3.lowerDbm, next.imd3.lowerDbm),
+      upperDbm: m(prev.imd3.upperDbm, next.imd3.upperDbm),
+      dbc: m(prev.imd3.dbc, next.imd3.dbc),
+      lowerHz: m(prev.imd3.lowerHz, next.imd3.lowerHz),
+      upperHz: m(prev.imd3.upperHz, next.imd3.upperHz),
+    },
+    imd5: {
+      lowerDbm: m(prev.imd5.lowerDbm, next.imd5.lowerDbm),
+      upperDbm: m(prev.imd5.upperDbm, next.imd5.upperDbm),
+      dbc: m(prev.imd5.dbc, next.imd5.dbc),
+      lowerHz: m(prev.imd5.lowerHz, next.imd5.lowerHz),
+      upperHz: m(prev.imd5.upperHz, next.imd5.upperHz),
+    },
+    oip3: m(prev.oip3, next.oip3),
+    oip5: m(prev.oip5, next.oip5),
+  };
+}
+
+export function ImdReadings() {
+  const twoToneOn = useTxStore((s) => s.twoToneOn);
+  const [result, setResult] = useState<ImdResult | null>(null);
+  const emaRef = useRef<ImdReadout | null>(null);
+
+  useEffect(() => {
+    if (!twoToneOn) {
+      emaRef.current = null;
+      setResult(null);
+      return;
+    }
+    const id = window.setInterval(() => {
+      const s = useDisplayStore.getState();
+      if (!s.panValid || !s.panDb || s.panDb.length < 16 || s.hzPerPixel <= 0) {
+        emaRef.current = null;
+        setResult({ ok: false, reason: 'waiting for spectrum' });
+        return;
+      }
+      const r = computeImd({
+        db: s.panDb,
+        width: s.panDb.length,
+        centerHz: Number(s.centerHz),
+        hzPerPixel: s.hzPerPixel,
+      });
+      if (r.ok) {
+        const smoothed = emaRef.current ? blend(emaRef.current, r, EMA_ALPHA) : r;
+        emaRef.current = smoothed;
+        setResult(smoothed);
+      } else {
+        emaRef.current = null;
+        setResult(r);
+      }
+    }, TICK_MS);
+    return () => window.clearInterval(id);
+  }, [twoToneOn]);
+
+  if (!twoToneOn || result === null) return null;
+
+  return (
+    <div
+      aria-label="Two-tone IMD measurements"
+      className="pointer-events-none absolute z-[6]"
+      style={{
+        top: 10,
+        left: 10,
+        minWidth: 248,
+        padding: '14px 18px',
+        borderRadius: 10,
+        background: 'rgba(10, 13, 17, 0.82)',
+        border: '1px solid rgba(255, 160, 40, 0.45)',
+        boxShadow: '0 3px 14px rgba(0,0,0,0.5)',
+        font: '17px/1.5 "Archivo Narrow", system-ui, sans-serif',
+        color: 'var(--fg-1)',
+        letterSpacing: '0.02em',
+        userSelect: 'none',
+      }}
+    >
+      <div
+        style={{
+          fontWeight: 700,
+          fontSize: 14,
+          letterSpacing: '0.12em',
+          color: 'var(--fg-2)',
+          marginBottom: 8,
+        }}
+      >
+        2-TONE IMD
+      </div>
+      {result.ok ? <Readout r={result} /> : <Miss reason={result.reason} />}
+    </div>
+  );
+}
+
+function Readout({ r }: { r: ImdReadout }) {
+  const amber = 'var(--power)';
+  // dbc is positive (product below the fundamental); show it as a negative
+  // suppression figure, the convention operators read on a two-tone.
+  const row = (label: string, value: string) => (
+    <div style={{ display: 'flex', justifyContent: 'space-between', gap: 24, marginBottom: 2 }}>
+      <span style={{ color: 'var(--fg-2)' }}>{label}</span>
+      <span style={{ color: amber, fontVariantNumeric: 'tabular-nums', fontWeight: 600 }}>{value}</span>
+    </div>
+  );
+  return (
+    <>
+      {row('IMD3', `${(-r.imd3.dbc).toFixed(1)} dBc`)}
+      {row('IMD5', `${(-r.imd5.dbc).toFixed(1)} dBc`)}
+      {row('OIP3', `${r.oip3.toFixed(0)} dBm`)}
+      <div
+        style={{
+          marginTop: 7,
+          paddingTop: 7,
+          borderTop: '1px solid rgba(255,255,255,0.08)',
+          color: 'var(--fg-3)',
+          fontSize: 13,
+          display: 'flex',
+          justifyContent: 'space-between',
+          gap: 24,
+        }}
+      >
+        <span>Δf {Math.round(r.toneSpacingHz)} Hz</span>
+        <span>f0 {r.f0LowerDbm.toFixed(0)}/{r.f0UpperDbm.toFixed(0)} dBm</span>
+      </div>
+    </>
+  );
+}
+
+function Miss({ reason }: { reason: string }) {
+  return (
+    <div style={{ color: 'var(--fg-3)', fontSize: 13, maxWidth: 220 }}>
+      Peaks not found — {reason}.
+      <br />
+      Ensure both tones + their IMD products are in view.
+    </div>
+  );
+}

--- a/zeus-web/src/components/Panadapter.tsx
+++ b/zeus-web/src/components/Panadapter.tsx
@@ -52,6 +52,7 @@ import { useTxStore } from '../state/tx-store';
 import { usePanTuneGesture } from '../util/use-pan-tune-gesture';
 import { FreqAxis } from './FreqAxis';
 import { PassbandOverlay } from './PassbandOverlay';
+import { ImdReadings } from './ImdReadings';
 import { DbScale } from './DbScale';
 
 export function Panadapter() {
@@ -263,6 +264,7 @@ export function Panadapter() {
     >
       <canvas ref={canvasRef} style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }} />
       <PassbandOverlay />
+      <ImdReadings />
       <FreqAxis />
       <DbScale />
     </div>

--- a/zeus-web/src/realtime/ws-client.ts
+++ b/zeus-web/src/realtime/ws-client.ts
@@ -49,7 +49,7 @@ import { isNativeAudio } from '../audio/host-mode';
 import { useMicPeakStore } from '../audio/mic-peak-store';
 import { useConnectionStore, type WisdomPhase } from '../state/connection-store';
 import { hasActiveFrameConsumers, useDisplayStore } from '../state/display-store';
-import { useTxStore } from '../state/tx-store';
+import { AlertKind, useTxStore } from '../state/tx-store';
 import { useBandPlanStore } from '../state/bandPlan';
 import { useRxMetersStore } from '../state/rx-meters-store';
 import { warnOnce } from '../util/logger';
@@ -558,6 +558,13 @@ export function startRealtime(path = '/ws'): () => void {
           const msgBytes = new Uint8Array(ev.data, 2);
           const message = new TextDecoder('utf-8').decode(msgBytes);
           useTxStore.getState().setAlert({ kind, message });
+          // A SWR / TX-timeout trip force-drops MOX on the server, which also
+          // disarms any running two-tone test. Clear the local latch so the
+          // TwoTone button doesn't stay lit (and desynced) after the trip —
+          // moxOn/tunOn are cleared separately by the MoxStateFrame off-edge.
+          if (kind === AlertKind.SwrTrip || kind === AlertKind.TxTimeout) {
+            useTxStore.getState().setTwoToneOn(false);
+          }
           return;
         }
         if (peekType === MSG_TYPE_BAND_PLAN_CHANGED) {

--- a/zeus-web/src/util/imd-measure.test.ts
+++ b/zeus-web/src/util/imd-measure.test.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Distributed under the GNU General Public License v2 or later; see LICENSE.
+
+import { describe, expect, it } from 'vitest';
+
+import { computeImd } from './imd-measure';
+
+// Build a synthetic spectrum: flat noise floor with narrow peaks (1-pixel spikes)
+// at the given pixel positions/levels. Mirrors a two-tone panadapter capture.
+function spectrum(width: number, floorDbm: number, peaks: Array<[number, number]>): Float32Array {
+  const db = new Float32Array(width).fill(floorDbm);
+  for (const [x, dbm] of peaks) db[x] = dbm;
+  return db;
+}
+
+describe('computeImd', () => {
+  // Center pixel = width/2 = 512. hzPerPixel = 10 → +700 Hz = +70 px (582),
+  // +1900 Hz = +190 px (702). Tone spacing 1200 Hz = 120 px. IMD products sit
+  // one/two spacings outward: IMD3 at 462/822, IMD5 at 342/942.
+  const width = 1024;
+  const centerHz = 14_200_000;
+  const hzPerPixel = 10;
+
+  it('locates the two fundamentals + IMD3/IMD5 and computes dBc', () => {
+    const db = spectrum(width, -120, [
+      [582, 0], // fundamental low
+      [702, 0], // fundamental high
+      [462, -30], // IMD3 lower
+      [822, -30], // IMD3 upper
+      [342, -50], // IMD5 lower
+      [942, -50], // IMD5 upper
+    ]);
+
+    const r = computeImd({ db, width, centerHz, hzPerPixel });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+
+    expect(r.toneSpacingHz).toBeCloseTo(1200, 0);
+    // dbc = min(fundamental) - max(product) = 0 - (-30) = 30 down.
+    expect(r.imd3.dbc).toBeCloseTo(30, 1);
+    expect(r.imd5.dbc).toBeCloseTo(50, 1);
+    // OIP3 = fundamental + imd3dBc/2 = 0 + 15.
+    expect(r.oip3).toBeCloseTo(15, 1);
+    expect(r.oip5).toBeCloseTo(25, 1);
+    // Fundamental frequencies map back to carrier ±offset.
+    expect(r.f0LowerHz).toBeCloseTo(centerHz + 700, 0);
+    expect(r.f0UpperHz).toBeCloseTo(centerHz + 1900, 0);
+  });
+
+  it('reports a miss when the tones are merged / zoomed too far out', () => {
+    // Two peaks only 5 px apart — below the resolve threshold.
+    const db = spectrum(width, -120, [
+      [510, 0],
+      [515, 0],
+    ]);
+    const r = computeImd({ db, width, centerHz, hzPerPixel });
+    expect(r.ok).toBe(false);
+  });
+
+  it('reports a miss on an empty / single-tone spectrum', () => {
+    const flat = spectrum(width, -120, [[512, 0]]);
+    const r = computeImd({ db: flat, width, centerHz, hzPerPixel });
+    expect(r.ok).toBe(false);
+  });
+
+  it('reports a miss when the IMD products are off-screen', () => {
+    // Fundamentals present and well-separated, but no products in the spectrum.
+    const db = spectrum(width, -120, [
+      [400, 0],
+      [600, 0],
+    ]);
+    const r = computeImd({ db, width, centerHz, hzPerPixel });
+    // Products would be searched at 400-200=200 / 600+200=800 etc.; the flat
+    // floor there yields a "peak" only at array ends — with a uniform floor the
+    // local-maxima finder returns nothing in-window, so this misses.
+    expect(r.ok).toBe(false);
+  });
+});

--- a/zeus-web/src/util/imd-measure.ts
+++ b/zeus-web/src/util/imd-measure.ts
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is an independent reimplementation in .NET — not a fork. Its
+// Protocol-1 / Protocol-2 framing, WDSP integration, meter pipelines, and
+// TX behaviour were informed by studying the Thetis project
+// (https://github.com/ramdor/Thetis), the authoritative reference
+// implementation in the OpenHPSDR ecosystem.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+// Two-tone IMD measurement — ported from Thetis (display.cs two_tone_readings
+// + findImd, MW0LGE). Given a panadapter spectrum (dBm-per-pixel) and its
+// frequency axis, locate the two fundamental tones and their 3rd/5th-order
+// intermodulation products, then report IMD3/IMD5 suppression in dBc and the
+// output intercept points (OIP3/OIP5).
+//
+// The algorithm is source-agnostic: it measures whatever spectrum is on the
+// panadapter. To measure *PA* IMD (what PureSignal corrects) the operator
+// views the post-PA feedback / a monitoring RX; the pre-PA TX-IQ analyzer
+// shows only the clean digital tones.
+
+export interface ImdInput {
+  /** dBm per pixel, length === width. Bin x maps to centerHz + (x - width/2)·hzPerPixel. */
+  db: ArrayLike<number>;
+  width: number;
+  /** Hz at the centre pixel (width/2). */
+  centerHz: number;
+  hzPerPixel: number;
+}
+
+export interface ImdProduct {
+  lowerDbm: number;
+  upperDbm: number;
+  /** Suppression below the weaker fundamental, dB. Positive = product is down. */
+  dbc: number;
+  lowerHz: number;
+  upperHz: number;
+}
+
+export interface ImdReadout {
+  ok: true;
+  f0LowerDbm: number;
+  f0UpperDbm: number;
+  f0LowerHz: number;
+  f0UpperHz: number;
+  toneSpacingHz: number;
+  imd3: ImdProduct;
+  imd5: ImdProduct;
+  /** Output 3rd/5th-order intercept points, dBm. */
+  oip3: number;
+  oip5: number;
+}
+
+export interface ImdMiss {
+  ok: false;
+  /** Human-facing reason the readings couldn't be taken. */
+  reason: string;
+}
+
+export type ImdResult = ImdReadout | ImdMiss;
+
+interface Peak {
+  x: number;
+  dbm: number;
+}
+
+// Tones closer than this (pixels) can't be resolved — Thetis uses the same
+// pixel_diff > 10 gate before attempting to place the IMD products.
+const MIN_TONE_SEP_PX = 11;
+
+/** All local maxima, strongest first. Noise bumps are fine — findImd only
+ *  considers candidates near each predicted product position. */
+function findPeaks(db: ArrayLike<number>, width: number): Peak[] {
+  const peaks: Peak[] = [];
+  for (let i = 1; i < width - 1; i++) {
+    const v = db[i];
+    const prev = db[i - 1];
+    const next = db[i + 1];
+    if (v === undefined || prev === undefined || next === undefined) continue;
+    // Strict on the left, >= on the right so a flat-topped blob registers once.
+    if (v > prev && v >= next && Number.isFinite(v)) {
+      peaks.push({ x: i, dbm: v });
+    }
+  }
+  peaks.sort((a, b) => b.dbm - a.dbm);
+  return peaks;
+}
+
+// Port of Thetis findImd: search ±(pixelJump/4) around the predicted position
+// for the strongest peak. imd 1 = fundamental (jump 0), 3 = IMD3 (jump 1),
+// 5 = IMD5 (jump 2). Products sit one tone-spacing apart, outward from each
+// fundamental.
+function findImd(
+  group: Peak[],
+  imd: number,
+  pixelJump: number,
+  offset: number,
+  low: boolean,
+): Peak | null {
+  const jump = (imd - 1) / 2;
+  const estimate = low ? offset - jump * pixelJump : offset + jump * pixelJump;
+  const searchRange = pixelJump / 4;
+  let best: Peak | null = null;
+  let bestDist = Infinity;
+  for (const p of group) {
+    const dist = Math.abs(p.x - estimate);
+    if (dist <= searchRange) {
+      if (best === null || p.dbm > best.dbm || (p.dbm === best.dbm && dist < bestDist)) {
+        best = p;
+        bestDist = dist;
+      }
+    }
+  }
+  return best;
+}
+
+/**
+ * Locate the two fundamentals + IMD3/IMD5 products in a panadapter spectrum and
+ * compute IMD suppression. Returns {ok:false, reason} when the tones can't be
+ * resolved (no signal, tones merged, or zoomed too far out).
+ */
+export function computeImd(input: ImdInput): ImdResult {
+  const { db, width, centerHz, hzPerPixel } = input;
+  if (!width || width < 16 || hzPerPixel <= 0) return { ok: false, reason: 'no spectrum' };
+
+  const peaks = findPeaks(db, width);
+  if (peaks.length < 2) return { ok: false, reason: 'no signal' };
+
+  // Two fundamentals: the strongest peak, plus the strongest peak far enough
+  // away to be the other tone (not a shoulder of the same blob).
+  const f0 = peaks[0];
+  if (f0 === undefined) return { ok: false, reason: 'no signal' };
+  let f1: Peak | null = null;
+  for (let i = 1; i < peaks.length; i++) {
+    const p = peaks[i];
+    if (p === undefined) continue;
+    if (Math.abs(p.x - f0.x) >= MIN_TONE_SEP_PX) {
+      f1 = p;
+      break;
+    }
+  }
+  if (!f1) return { ok: false, reason: 'tones merged — increase zoom' };
+
+  const pixelDiff = Math.abs(f0.x - f1.x);
+  if (pixelDiff <= 10) return { ok: false, reason: 'increase zoom' };
+
+  const lowX = Math.min(f0.x, f1.x);
+  const highX = Math.max(f0.x, f1.x);
+  const midX = lowX + pixelDiff / 2;
+  const lowGroup = peaks.filter((p) => p.x < midX);
+  const highGroup = peaks.filter((p) => p.x > midX);
+
+  const fL = findImd(lowGroup, 1, pixelDiff, lowX, true);
+  const fH = findImd(highGroup, 1, pixelDiff, highX, false);
+  const i3L = findImd(lowGroup, 3, pixelDiff, lowX, true);
+  const i3H = findImd(highGroup, 3, pixelDiff, highX, false);
+  const i5L = findImd(lowGroup, 5, pixelDiff, lowX, true);
+  const i5H = findImd(highGroup, 5, pixelDiff, highX, false);
+  if (!fL || !fH || !i3L || !i3H || !i5L || !i5H) {
+    return { ok: false, reason: 'IMD peaks off-screen — widen span' };
+  }
+
+  const dbcMin = Math.min(fL.dbm, fH.dbm);
+  const imd3max = Math.max(i3L.dbm, i3H.dbm);
+  const imd5max = Math.max(i5L.dbm, i5H.dbm);
+  const imd3dBc = dbcMin - imd3max;
+  const imd5dBc = dbcMin - imd5max;
+  const oip3 = dbcMin + imd3dBc / 2;
+  const oip5 = dbcMin + imd5dBc / 2;
+
+  const hz = (x: number) => centerHz + (x - width / 2) * hzPerPixel;
+
+  return {
+    ok: true,
+    f0LowerDbm: fL.dbm,
+    f0UpperDbm: fH.dbm,
+    f0LowerHz: hz(fL.x),
+    f0UpperHz: hz(fH.x),
+    toneSpacingHz: Math.abs(hz(fH.x) - hz(fL.x)),
+    imd3: {
+      lowerDbm: i3L.dbm,
+      upperDbm: i3H.dbm,
+      dbc: imd3dBc,
+      lowerHz: hz(i3L.x),
+      upperHz: hz(i3H.x),
+    },
+    imd5: {
+      lowerDbm: i5L.dbm,
+      upperDbm: i5H.dbm,
+      dbc: imd5dBc,
+      lowerHz: hz(i5L.x),
+      upperHz: hz(i5H.x),
+    },
+    oip3,
+    oip5,
+  };
+}


### PR DESCRIPTION
**Do not merge** — opened for review/bench-record at KB2UKA's request. Bench-verified on the G2 (desktop, macOS): two-tone outer IMD tones drop out and **IMD3 reached the mid-50s** (was ~−40), matching Thetis behaviour.

## What this is
The end of a long bench session getting **PureSignal to work on the desktop (Photino) build** the way it already did in web mode and the way Thetis does. Root finding: same WDSP, same feedback tap — the desktop build's native-audio (CoreAudio) threads were starving/contending with the TX feed, plus several PS-control bugs. Web was clean because the browser render + audio live in separate processes.

Supersedes/extends open PR #565 (`fix/two-tone-sideband`) — its two commits (sideband sign + deadline pump pacing) are included here.

## The fixes (in order)
1. **two-tone sideband sign** (PR #565) — tones land in the chosen passband.
2. **deadline-pace the TUN/TwoTone pump** (PR #565) — stops the first-key-up P2 TX-FIFO underrun.
3. **two-tone IMD measurement overlay** — Thetis-parity IMD3/IMD5 readout (`ImdReadings.tsx`, `imd-measure.ts` + tests).
4. **disarm two-tone on a trip** — a re-engage can't come up a bare single carrier.
5. **mic ingest yields to TxTuneDriver during TUN/two-tone** — `NativeMicCapture` (desktop) and the two-tone pump were both driving `fexchange2` and both pushing IQ → double-feed/corruption. Single TX driver now.
6. **wedge watchdog only resets in compute states (LCOLLECT..LDELAY), not LWAIT** — it was reset-storming a parked calcc every 5 s, tearing down the live correction.
7. **calcc stabilize (stbl) on P2** — converge to a steady curve instead of applying each raw pass-to-pass fit (DeskHPSDR default; P1/HL2 stay off, mi0bot-matched).
8. **converge-then-hold** — once converged (correcting + clean + feedback centred for ~2.5 s), lock with `SetPSRunCal(0)`: calcc parks, the predistorter holds the curve. New `IDspEngine.SetPsHold(bool)`. The "catch and hold" Thetis single-cal gives.
9. **real-time thread priority on the whole TX feed** — RX/PS-feedback loop, TX-IQ sender (sync, dedicated thread), and the **TUN/TwoTone pump** (dedicated thread). macOS uses mach `THREAD_TIME_CONSTRAINT_POLICY` (QoS `USER_INTERACTIVE` is denied to non-UI threads). This is the Thetis-parity piece — Thetis runs its PS/TX off the RT audio thread; without it the CoreAudio threads preempt the feed and the two-tone never presents cleanly.
10. **pump at exact DAC rate** — now that the pump is RT/deterministic, the old 3% surplus (jitter margin) is unneeded and was making the sender throttle, which pumped/spread the carriers.

## Notes for review
- HL2 / P1 paths unchanged (stbl off, dance untouched).
- `WdspDspEngine` has bring-up diagnostics (`wdsp.psHot`, `psccRate`, `psInfo` scOK/iqc-coeff, `txOut`) added during debugging — **gate behind a flag or drop before merge.**
- RCA: `docs/rca/2026-05-29-ps-twotone-desktop-vs-web.md`.
- Still open: voice (SSB) bench confirmation; a few transient IMDs during the 2-3 s pre-lock convergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)