### PR TITLE
feat(cw): add CW station panel — decode terminal + threshold scope + keyer

### DIFF
--- a/Zeus.Contracts/CwDecodedTextFrame.cs
+++ b/Zeus.Contracts/CwDecodedTextFrame.cs
@@ -16,14 +16,20 @@ namespace Zeus.Contracts;
 ///
 /// <code>
 /// [type:1=0x31][wpm:u16 LE][snrDb:f32 LE][confidence:f32 LE]
+/// [envelopeDb:f32 LE][noiseFloorDb:f32 LE]
 /// [textLen:u16 LE][text:UTF-8 textLen bytes]
 /// </code>
 ///
-/// 13-byte fixed header + variable text payload. <see cref="Text"/> is the
+/// 21-byte fixed header + variable text payload. <see cref="Text"/> is the
 /// chunk of characters decoded during one audio tick (usually 0–2 chars,
-/// including ' ' on a word gap); the client appends them in order. Decoding
-/// happens server-side so it works in the desktop/native-audio host and
-/// headless — see CwDecoderService. Text is capped at <see cref="MaxTextBytes"/>.
+/// including ' ' on a word gap); the client appends them in order.
+/// <see cref="EnvelopeDb"/> and <see cref="NoiseFloorDb"/> are the
+/// instantaneous envelope and tracked noise floor in dBFS — consumed by the
+/// frontend threshold scope to display the signal waveform and guide manual
+/// threshold placement. Emitted on every DSP tick (even with empty text) so
+/// the scope updates continuously. Decoding happens server-side so it works
+/// in the desktop/native-audio host and headless — see CwDecoderService.
+/// Text is capped at <see cref="MaxTextBytes"/>.
 ///
 /// Wire-frozen: future additions append-only at the tail.
 /// </summary>
@@ -31,29 +37,32 @@ public readonly record struct CwDecodedTextFrame(
     string Text,
     int Wpm,
     float SnrDb,
-    float Confidence)
+    float Confidence,
+    float EnvelopeDb,
+    float NoiseFloorDb)
 {
     /// <summary>Hard cap on the text payload. One tick decodes a handful of
     /// characters at most, so this is comfortably generous and keeps the
     /// frame well under one MTU.</summary>
     public const int MaxTextBytes = 256;
 
-    public const int HeaderByteLength = 13; // type(1) + wpm(2) + snr(4) + conf(4) + textLen(2)
+    // type(1) + wpm(2) + snr(4) + conf(4) + envelopeDb(4) + noiseFloorDb(4) + textLen(2)
+    public const int HeaderByteLength = 21;
 
     public void Serialize(IBufferWriter<byte> writer)
     {
-        // Encode text first so we know the actual UTF-8 byte count.
         var rawBytes = Encoding.UTF8.GetBytes(Text ?? string.Empty);
         int textBytes = Math.Min(rawBytes.Length, MaxTextBytes);
         int total = HeaderByteLength + textBytes;
         var span = writer.GetSpan(total);
         span[0] = (byte)MsgType.CwDecodedText;
-        // Clamp Wpm to u16 so an upstream logic bug can't silently truncate.
         ushort wpmU16 = (ushort)Math.Clamp(Wpm, 0, ushort.MaxValue);
         BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(1, 2), wpmU16);
         BinaryPrimitives.WriteSingleLittleEndian(span.Slice(3, 4), SnrDb);
         BinaryPrimitives.WriteSingleLittleEndian(span.Slice(7, 4), Confidence);
-        BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(11, 2), (ushort)textBytes);
+        BinaryPrimitives.WriteSingleLittleEndian(span.Slice(11, 4), EnvelopeDb);
+        BinaryPrimitives.WriteSingleLittleEndian(span.Slice(15, 4), NoiseFloorDb);
+        BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(19, 2), (ushort)textBytes);
         if (textBytes > 0)
             rawBytes.AsSpan(0, textBytes).CopyTo(span.Slice(HeaderByteLength, textBytes));
         writer.Advance(total);
@@ -67,16 +76,18 @@ public readonly record struct CwDecodedTextFrame(
         if (bytes[0] != (byte)MsgType.CwDecodedText)
             throw new InvalidDataException(
                 $"expected CwDecodedText (0x{(byte)MsgType.CwDecodedText:X2}), got 0x{bytes[0]:X2}");
-        int wpm = BinaryPrimitives.ReadUInt16LittleEndian(bytes.Slice(1, 2));
-        float snr = BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(3, 4));
+        int wpm    = BinaryPrimitives.ReadUInt16LittleEndian(bytes.Slice(1, 2));
+        float snr  = BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(3, 4));
         float conf = BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(7, 4));
-        int textLen = BinaryPrimitives.ReadUInt16LittleEndian(bytes.Slice(11, 2));
+        float env  = BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(11, 4));
+        float nf   = BinaryPrimitives.ReadSingleLittleEndian(bytes.Slice(15, 4));
+        int textLen = BinaryPrimitives.ReadUInt16LittleEndian(bytes.Slice(19, 2));
         if (HeaderByteLength + textLen > bytes.Length)
             throw new InvalidDataException(
                 $"CwDecodedTextFrame textLen {textLen} exceeds payload");
         string text = textLen == 0
             ? string.Empty
             : Encoding.UTF8.GetString(bytes.Slice(HeaderByteLength, textLen));
-        return new CwDecodedTextFrame(text, wpm, snr, conf);
+        return new CwDecodedTextFrame(text, wpm, snr, conf, env, nf);
     }
 }

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -444,6 +444,14 @@ public sealed record CwSettingsSetRequest(
     int? SidetoneHz = null,
     CwKeyerMode? KeyerMode = null);
 
+// PUT /api/cw/decoder/settings — set or clear the manual Schmitt-trigger
+// threshold for the CW receive decoder (zeus-yrq). IsManual=true + a
+// ThresholdDb value pins the detector at that level; IsManual=false resets
+// to the default adaptive mode. ThresholdDb is in dBFS (typically -60..0).
+public sealed record CwDecoderThresholdRequest(
+    bool? IsManual = null,
+    double? ThresholdDb = null);
+
 // Hermes-Lite 2 (and the wider openHPSDR family) on-board CW keyer mode,
 // written to C&C register 0x0B C3[7:6] (gateware rtl/cw_openhpsdr.sv:32).
 // Straight is the default-safe choice: in this mode the gateware passes the

--- a/Zeus.Server.Hosting/CwAudioDecoder.cs
+++ b/Zeus.Server.Hosting/CwAudioDecoder.cs
@@ -77,6 +77,28 @@ internal sealed class CwAudioDecoder
     public int Wpm => (int)Math.Round(1200.0 / (_ditMs * 2));
     public double SnrDb { get; private set; }
     public double Confidence { get; private set; }
+    /// <summary>Instantaneous envelope level in dBFS (≤ 0). Updated every
+    /// sample; useful as a real-time scope signal for threshold tuning.</summary>
+    public float EnvelopeDb => _env < 1e-10 ? -100f : (float)(20 * Math.Log10(_env));
+    /// <summary>Tracked noise-floor level in dBFS. The adaptive Schmitt
+    /// thresholds sit between this and the signal follower.</summary>
+    public float NoiseFloorDb => _noiseFloor < 1e-10 ? -100f : (float)(20 * Math.Log10(_noiseFloor));
+
+    // Manual threshold override. When non-null the adaptive Schmitt trigger is
+    // bypassed and a fixed hysteresis band is applied around this linear level.
+    // Set via CwDecoderService.SetManualThreshold(); null = adaptive (default).
+    private double? _manualThresholdLinear;
+
+    /// <summary>Pin the key-detect threshold at a fixed level expressed in
+    /// dBFS. The Schmitt hysteresis (±10 %) still applies so fast noise
+    /// transients don't jitter the detector.  Pass null to restore the
+    /// default adaptive behaviour.</summary>
+    public void SetManualThreshold(double? thresholdDb)
+    {
+        _manualThresholdLinear = thresholdDb.HasValue
+            ? Math.Pow(10.0, thresholdDb.Value / 20.0)
+            : null;
+    }
 
     public CwAudioDecoder(int sampleRate)
     {
@@ -152,21 +174,33 @@ internal sealed class CwAudioDecoder
         // Hold off deciding until the followers settle (no cold-start element).
         if (_warmup < _warmupSamples) { _warmup++; return false; }
 
-        // Activity gate: require the tracked signal to stand clearly above the
-        // noise floor before treating the channel as carrying CW at all. Pure
-        // band noise has signal ≈ noiseFloor (no keying structure), so this
-        // suppresses noise-only periods; a genuine CW tone sits well above it.
-        if (_signal < _noiseFloor * ActivityRatio)
+        double hi, lo;
+        if (_manualThresholdLinear.HasValue)
         {
-            _keyedEnv = false;
-            return false;
+            // Manual mode: operator-pinned threshold, tight ±10 % hysteresis.
+            // Bypass the activity gate so the operator's decision is honoured
+            // even in a pure-noise channel (they set it above the noise floor).
+            hi = _manualThresholdLinear.Value * 1.10;
+            lo = _manualThresholdLinear.Value * 0.90;
+        }
+        else
+        {
+            // Adaptive mode: require the signal to stand clearly above the
+            // noise floor. Pure band noise has signal ≈ noiseFloor (no keying
+            // structure) so this gate suppresses noise-only periods.
+            if (_signal < _noiseFloor * ActivityRatio)
+            {
+                _keyedEnv = false;
+                return false;
+            }
+
+            double span = _signal - _noiseFloor;
+            if (span <= 1e-6) { _keyedEnv = false; return false; }
+
+            hi = _noiseFloor + 0.62 * span;
+            lo = _noiseFloor + 0.40 * span;
         }
 
-        double span = _signal - _noiseFloor;
-        if (span <= 1e-6) { _keyedEnv = false; return false; }
-
-        double hi = _noiseFloor + 0.62 * span;
-        double lo = _noiseFloor + 0.4 * span;
         if (!_keyedEnv && _env > hi) _keyedEnv = true;
         else if (_keyedEnv && _env < lo) _keyedEnv = false;
         return _keyedEnv;

--- a/Zeus.Server.Hosting/CwDecoderService.cs
+++ b/Zeus.Server.Hosting/CwDecoderService.cs
@@ -28,23 +28,50 @@ public sealed class CwDecoderService : BackgroundService
     private readonly DspPipelineService _pipeline;
     private readonly StreamingHub _hub;
     private readonly RadioService _radio;
+    private readonly TxService _tx;
     private readonly ILogger<CwDecoderService> _log;
 
     // Touched only on the DSP pipeline thread (RxAudioAvailable is single-fire
-    // per tick from that thread), so no locking is needed.
+    // per tick from that thread), so no locking is needed for the decoder itself.
     private CwAudioDecoder? _decoder;
     private int _decoderRate;
     private readonly StringBuilder _pending = new();
+
+    // Manual threshold — written from the HTTP handler thread, read on the DSP
+    // thread. Volatile write/read is sufficient for a single nullable double.
+    private double? _manualThresholdDb;
+    private readonly object _thresholdSync = new();
+
+    /// <summary>Set or clear the manual decode threshold. Null restores the
+    /// default adaptive Schmitt trigger. Thread-safe: can be called from any
+    /// thread (e.g. an ASP.NET request handler).</summary>
+    public void SetManualThreshold(double? thresholdDb)
+    {
+        lock (_thresholdSync)
+        {
+            _manualThresholdDb = thresholdDb;
+            _decoder?.SetManualThreshold(thresholdDb);
+        }
+    }
+
+    /// <summary>Current threshold mode + value for GET /api/cw/decoder/settings.</summary>
+    public (bool IsManual, double? ThresholdDb) GetThresholdState()
+    {
+        lock (_thresholdSync)
+            return (_manualThresholdDb.HasValue, _manualThresholdDb);
+    }
 
     public CwDecoderService(
         DspPipelineService pipeline,
         StreamingHub hub,
         RadioService radio,
+        TxService tx,
         ILogger<CwDecoderService> log)
     {
         _pipeline = pipeline;
         _hub = hub;
         _radio = radio;
+        _tx = tx;
         _log = log;
         _pipeline.RxAudioAvailable += OnRxAudio;
     }
@@ -67,6 +94,9 @@ public sealed class CwDecoderService : BackgroundService
         {
             _decoder = new CwAudioDecoder(sampleRateHz);
             _decoderRate = sampleRateHz;
+            // Re-apply manual threshold to the freshly-constructed decoder.
+            lock (_thresholdSync)
+                _decoder.SetManualThreshold(_manualThresholdDb);
         }
 
         _pending.Clear();
@@ -80,14 +110,19 @@ public sealed class CwDecoderService : BackgroundService
             return;
         }
 
-        if (_pending.Length > 0)
-        {
-            _hub.Broadcast(new CwDecodedTextFrame(
-                _pending.ToString(),
-                _decoder.Wpm,
-                (float)_decoder.SnrDb,
-                (float)_decoder.Confidence));
-        }
+        // During TX (MOX active) the sidetone bleeds into the RX audio and the
+        // decoder would echo our own keying as spurious receive text — suppress
+        // the decoded characters while transmitting. The envelope + noise-floor
+        // telemetry is still emitted so the scope scope keeps updating and the
+        // operator can see the sidetone shape in the waveform display.
+        bool txActive = _tx.IsMoxOn;
+        _hub.Broadcast(new CwDecodedTextFrame(
+            txActive ? string.Empty : _pending.ToString(),
+            _decoder.Wpm,
+            (float)_decoder.SnrDb,
+            (float)_decoder.Confidence,
+            _decoder.EnvelopeDb,
+            _decoder.NoiseFloorDb));
     }
 
     public override void Dispose()

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -495,6 +495,28 @@ public static class ZeusEndpoints
             return Results.Ok(snapshot);
         });
 
+        // CW decoder threshold settings. GET returns current mode + value;
+        // PUT sets/clears the manual threshold that overrides the adaptive
+        // Schmitt trigger in CwAudioDecoder (zeus-yrq). Not persisted across
+        // restarts (ephemeral) — the operator re-pins it after connecting
+        // (consistent with how squelch / AGC thresholds work). Persisting it
+        // is a follow-up if operators find re-pinning inconvenient.
+        app.MapGet("/api/cw/decoder/settings", (CwDecoderService dec) =>
+        {
+            var (isManual, thresholdDb) = dec.GetThresholdState();
+            return Results.Ok(new { isManual, thresholdDb });
+        });
+
+        app.MapPut("/api/cw/decoder/settings", (CwDecoderThresholdRequest req, CwDecoderService dec) =>
+        {
+            double? thr = req.IsManual == true && req.ThresholdDb.HasValue
+                ? Math.Clamp(req.ThresholdDb.Value, -80.0, 0.0)
+                : null;
+            dec.SetManualThreshold(thr);
+            var (isManual, thresholdDb) = dec.GetThresholdState();
+            return Results.Ok(new { isManual, thresholdDb });
+        });
+
         // Mic-gain: N dB in [-40, +10], scales WDSP TXA panel-gain-1 the same
         // way Thetis does (console.cs:28805 setAudioMicGain → Audio.MicPreamp =
         // 10^(db/20) → cmaster.CMSetTXAPanelGain1). The negative range is the

--- a/tests/Zeus.Contracts.Tests/CwDecodedTextFrameTests.cs
+++ b/tests/Zeus.Contracts.Tests/CwDecodedTextFrameTests.cs
@@ -14,7 +14,7 @@ public class CwDecodedTextFrameTests
     [Fact]
     public void Serialize_EmptyText_ProducesHeaderOnlyFrame()
     {
-        var frame = new CwDecodedTextFrame("", 0, 0f, 0f);
+        var frame = new CwDecodedTextFrame("", 0, 0f, 0f, -60f, -60f);
         var writer = new ArrayBufferWriter<byte>();
         frame.Serialize(writer);
 
@@ -25,7 +25,7 @@ public class CwDecodedTextFrameTests
     [Fact]
     public void Serialize_RoundTripsAllFields()
     {
-        var frame = new CwDecodedTextFrame("CQ DE EA", 22, 9.5f, 0.8f);
+        var frame = new CwDecodedTextFrame("CQ DE EA", 22, 9.5f, 0.8f, -42.1f, -55.3f);
         var writer = new ArrayBufferWriter<byte>();
         frame.Serialize(writer);
         var decoded = CwDecodedTextFrame.Deserialize(writer.WrittenSpan);
@@ -34,13 +34,15 @@ public class CwDecodedTextFrameTests
         Assert.Equal(22, decoded.Wpm);
         Assert.Equal(9.5f, decoded.SnrDb);
         Assert.Equal(0.8f, decoded.Confidence);
+        Assert.Equal(-42.1f, decoded.EnvelopeDb, precision: 4);
+        Assert.Equal(-55.3f, decoded.NoiseFloorDb, precision: 4);
     }
 
     [Fact]
     public void Serialize_OversizedText_TruncatesToMax()
     {
         var huge = new string('X', CwDecodedTextFrame.MaxTextBytes * 2);
-        var frame = new CwDecodedTextFrame(huge, 20, 0f, 0f);
+        var frame = new CwDecodedTextFrame(huge, 20, 0f, 0f, -60f, -60f);
         var writer = new ArrayBufferWriter<byte>();
         frame.Serialize(writer);
 
@@ -67,7 +69,7 @@ public class CwDecodedTextFrameTests
     [Fact]
     public void Deserialize_RejectsTruncatedText()
     {
-        var frame = new CwDecodedTextFrame(new string('A', 50), 20, 0f, 0f);
+        var frame = new CwDecodedTextFrame(new string('A', 50), 20, 0f, 0f, -60f, -60f);
         var writer = new ArrayBufferWriter<byte>();
         frame.Serialize(writer);
         var truncated = writer.WrittenSpan

--- a/zeus-web/src/components/design/CwTerminal.tsx
+++ b/zeus-web/src/components/design/CwTerminal.tsx
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { useCwDecoderStore } from '../../state/cw-decoder-store';
+import { useCwStore, type CwEngineState } from '../../state/cw-store';
+import { sendCw } from '../../api/cw';
+
+type TerminalEntry =
+  | { kind: 'rx'; text: string }
+  | { kind: 'tx'; text: string };
+
+type CwTerminalProps = {
+  decoderEnabled: boolean;
+  onToggleDecoder: () => void;
+};
+
+export function CwTerminal({ decoderEnabled, onToggleDecoder }: CwTerminalProps) {
+  const { state: decoderState, text: rxText, wpm: rxWpm, snrDb, confidence, toggleHold, clear } =
+    useCwDecoderStore();
+  const wpm = useCwStore((s) => s.settings.wpm);
+
+  const [entries, setEntries] = useState<TerminalEntry[]>([]);
+  const prevRxLen = useRef(0);
+
+  // Track incoming RX text deltas and coalesce consecutive RX chunks.
+  useEffect(() => {
+    if (rxText.length > prevRxLen.current) {
+      const delta = rxText.slice(prevRxLen.current);
+      setEntries((e) => {
+        const last = e[e.length - 1];
+        if (last?.kind === 'rx') {
+          return [...e.slice(0, -1), { kind: 'rx', text: last.text + delta }];
+        }
+        return [...e, { kind: 'rx', text: delta }];
+      });
+    } else if (rxText.length < prevRxLen.current) {
+      setEntries([]);
+    }
+    prevRxLen.current = rxText.length;
+  }, [rxText]);
+
+  // Echo macros/engine-sent text into the terminal.
+  // Track the last engine state so we only add an entry when a new send starts.
+  const engineStatus = useCwStore((s) => s.status);
+  const prevEngineState = useRef<CwEngineState>('idle');
+  useEffect(() => {
+    const { state, text } = engineStatus;
+    const prev = prevEngineState.current;
+    // TX starts → blank line + TX text
+    if (state === 'sending' && prev !== 'sending' && text) {
+      setEntries((e) => [...e, { kind: 'tx', text: '\n' + text }]);
+    }
+    // TX ends → blank line so next RX text starts on a fresh line
+    if (prev === 'sending' && state !== 'sending') {
+      setEntries((e) => {
+        if (e.length === 0) return e;
+        // Append the trailing newline to the last TX entry rather than
+        // adding a new entry, so coalescing works correctly.
+        const last = e[e.length - 1];
+        if (last?.kind === 'tx') {
+          return [...e.slice(0, -1), { kind: 'tx', text: last.text + '\n' }];
+        }
+        return [...e, { kind: 'rx', text: '\n' }];
+      });
+    }
+    prevEngineState.current = state;
+  }, [engineStatus]);
+
+  const [txDraft, setTxDraft] = useState('');
+  const windowRef = useRef<HTMLDivElement>(null);
+
+  const handleSend = useCallback(async () => {
+    const text = txDraft.trim();
+    if (!text) return;
+    setTxDraft('');
+    // Do NOT add a manual echo here — the engine status useEffect above
+    // echoes the text when the backend confirms state='sending', which also
+    // covers macros sent from the keyer. A manual echo here caused duplicates.
+    try { await sendCw(text, wpm); } catch { /* silent */ }
+  }, [txDraft, wpm]);
+
+  useEffect(() => {
+    const el = windowRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [entries]);
+
+  const isListening = decoderState === 'listening';
+  const isHeld     = decoderState === 'held';
+  const isIdle     = decoderState === 'idle';
+  const active     = isListening || isHeld;
+
+  const confidenceColor =
+    confidence > 0.8 ? 'var(--accent-bright)' :
+    confidence > 0.5 ? 'var(--power)' :
+    'var(--tx)';
+  const confidenceLabel = confidence > 0.8 ? 'HI' : confidence > 0.5 ? 'MED' : 'LO';
+
+  const stateLabel = isHeld ? 'HELD' : isListening ? 'DECODE' : 'OFF';
+
+  return (
+    <div className="cw-terminal">
+
+      {/* Header row: state LED + label + decoder ON/OFF */}
+      <div className="cw-terminal-header">
+        <span className={`cw-stream-led${active ? ' cw-stream-led--active' : ''}`} aria-hidden="true" />
+        <span className="cw-terminal-state-label">{stateLabel}</span>
+        {active && (
+          <div className="cw-terminal-stats-inline">
+            <div className={`cw-terminal-stat${isListening ? ' is-active' : ''}`}>
+              <span className="cw-terminal-stat-label">WPM</span>
+              <span className="cw-terminal-stat-value mono">{rxWpm}</span>
+            </div>
+            <div className="cw-terminal-stat">
+              <span className="cw-terminal-stat-label">SNR</span>
+              <span className="cw-terminal-stat-value mono">{snrDb.toFixed(0)}dB</span>
+            </div>
+            <div className="cw-terminal-stat">
+              <span
+                className="cw-confidence-dot"
+                style={{ background: confidenceColor, width: 8, height: 8, borderRadius: '50%', display: 'inline-block', flexShrink: 0 }}
+                aria-label={`Confidence ${confidenceLabel}`}
+              />
+              <span className="cw-terminal-stat-label">{confidenceLabel}</span>
+            </div>
+          </div>
+        )}
+        <div className="cw-terminal-header-actions">
+          <button
+            type="button"
+            className={`cw-hold${isHeld ? ' is-armed' : ''}`}
+            onClick={toggleHold}
+            disabled={isIdle}
+            title="Hold — pause text display"
+          >HOLD</button>
+          <button
+            type="button"
+            className="cw-clear"
+            onClick={() => { clear(); setEntries([]); prevRxLen.current = 0; }}
+            disabled={entries.length === 0 && isIdle}
+            title="Clear terminal"
+          >CLEAR</button>
+          <button
+            type="button"
+            className={`btn${decoderEnabled ? ' accent' : ''}`}
+            onClick={onToggleDecoder}
+            aria-label={decoderEnabled ? 'Disable decoder' : 'Enable decoder'}
+          >{decoderEnabled ? 'ON' : 'OFF'}</button>
+        </div>
+      </div>
+
+      {/* Scrolling decode window */}
+      <div ref={windowRef} className="cw-terminal-window" role="log" aria-live="polite">
+        {entries.length === 0
+          ? <span className="cw-stream-placeholder">
+              {decoderEnabled ? '… waiting for signal …' : '—— DECODER OFF ——'}
+            </span>
+          : entries.map((e, i) =>
+              e.kind === 'rx'
+                ? <span key={i} className="cw-terminal-rx">{e.text}</span>
+                : <span key={i} className="cw-terminal-tx" title="Transmitted">{e.text} </span>
+            )
+        }
+      </div>
+
+      {/* TX free-text input */}
+      <div className="cw-terminal-input-row">
+        <span className="cw-terminal-prompt mono" aria-hidden="true">&gt;</span>
+        <input
+          type="text"
+          className="cw-terminal-input mono"
+          value={txDraft}
+          onChange={(e) => setTxDraft(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') void handleSend(); }}
+          placeholder="type and Enter to transmit…"
+          aria-label="CW text to transmit"
+          spellCheck={false}
+          autoCorrect="off"
+          autoCapitalize="characters"
+        />
+        <button
+          type="button"
+          className="cw-terminal-send-btn"
+          onClick={() => void handleSend()}
+          disabled={!txDraft.trim()}
+          title="Send"
+          aria-label="Send"
+        >↵</button>
+      </div>
+
+    </div>
+  );
+}

--- a/zeus-web/src/components/design/CwThresholdScope.tsx
+++ b/zeus-web/src/components/design/CwThresholdScope.tsx
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+
+import { useEffect, useRef, useCallback } from 'react';
+import {
+  useCwDecoderStore,
+  SCOPE_DB_MIN,
+  SCOPE_DB_MAX,
+} from '../../state/cw-decoder-store';
+
+const SCOPE_SAMPLES = 200;
+const LABEL_W = 28;  // px reserved for dB axis labels
+
+function dbToY(db: number, h: number): number {
+  const clamped = Math.max(SCOPE_DB_MIN, Math.min(SCOPE_DB_MAX, db));
+  const frac = (clamped - SCOPE_DB_MIN) / (SCOPE_DB_MAX - SCOPE_DB_MIN);
+  return h - frac * h;
+}
+
+function token(name: string, fallback: string): string {
+  const v = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  return v || fallback;
+}
+
+export function CwThresholdScope() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const rafRef = useRef<number>(0);
+
+  const envelopeDb   = useCwDecoderStore((s) => s.envelopeDb);
+  const noiseFloorDb = useCwDecoderStore((s) => s.noiseFloorDb);
+  const thresholdMode = useCwDecoderStore((s) => s.thresholdMode);
+  const thresholdDb   = useCwDecoderStore((s) => s.thresholdDb);
+  const setThreshold  = useCwDecoderStore((s) => s.setThreshold);
+  const resetThreshold = useCwDecoderStore((s) => s.resetThreshold);
+
+  // Ring buffer: real envelope samples from CwDecodedTextFrame
+  const ringBuf  = useRef<Float32Array>(new Float32Array(SCOPE_SAMPLES));
+  const ringHead = useRef(0);
+
+  // Push real envelope sample every time the store updates
+  useEffect(() => {
+    ringBuf.current[ringHead.current % SCOPE_SAMPLES] = envelopeDb;
+    ringHead.current++;
+  }, [envelopeDb]);
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const w = canvas.width;
+    const h = canvas.height;
+
+    const colBg      = token('--bg-meter',     '#050507');
+    const colLabel   = token('--fg-3',         '#5a5a60');
+    const colGrid    = token('--line-strong',  '#2c2c32');
+    const colSignal  = token('--accent-bright','#4ea6ff');
+    const colFill    = 'rgba(78,166,255,0.18)';
+    const colThresh  = token('--power',        '#ffb13c');
+    const colNoise   = token('--ok',           '#2dd566');
+    const colMono    = token('--font-mono',    'monospace');
+
+    ctx.clearRect(0, 0, w, h);
+    ctx.fillStyle = colBg;
+    ctx.fillRect(0, 0, w, h);
+
+    const plotW = w - LABEL_W;
+
+    // Grid lines + dB labels at 10 dB intervals
+    ctx.font = `500 8px ${colMono}`;
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'middle';
+    const step = 10;
+    for (let db = SCOPE_DB_MIN; db <= SCOPE_DB_MAX; db += step) {
+      const y = dbToY(db, h);
+      ctx.strokeStyle = colGrid;
+      ctx.lineWidth = db === SCOPE_DB_MIN ? 1 : 0.5;
+      ctx.setLineDash(db === SCOPE_DB_MIN ? [] : [3, 4]);
+      ctx.beginPath();
+      ctx.moveTo(LABEL_W, y);
+      ctx.lineTo(w, y);
+      ctx.stroke();
+      ctx.setLineDash([]);
+      ctx.fillStyle = colLabel;
+      ctx.fillText(`${db}`, LABEL_W - 3, y);
+    }
+
+    // Noise floor band — shade the region below the tracked noise floor
+    const nfY = dbToY(noiseFloorDb, h);
+    ctx.fillStyle = `${colNoise}18`;
+    ctx.fillRect(LABEL_W, nfY, plotW, h - nfY);
+
+    // Noise floor line
+    ctx.strokeStyle = colNoise;
+    ctx.lineWidth = 1;
+    ctx.setLineDash([3, 3]);
+    ctx.beginPath();
+    ctx.moveTo(LABEL_W, nfY);
+    ctx.lineTo(w, nfY);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    // Waveform (real envelope samples)
+    const total = Math.min(ringHead.current, SCOPE_SAMPLES);
+    if (total > 1) {
+      const start  = ringHead.current - total;
+      const xStep  = plotW / SCOPE_SAMPLES;
+
+      // Fill under curve
+      ctx.beginPath();
+      for (let i = 0; i < total; i++) {
+        const idx = (start + i) % SCOPE_SAMPLES;
+        const x = LABEL_W + i * xStep;
+        const y = dbToY(ringBuf.current[idx] ?? SCOPE_DB_MIN, h);
+        if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+      }
+      ctx.lineTo(LABEL_W + (total - 1) * xStep, h);
+      ctx.lineTo(LABEL_W, h);
+      ctx.closePath();
+      ctx.fillStyle = colFill;
+      ctx.fill();
+
+      // Envelope line
+      ctx.beginPath();
+      for (let i = 0; i < total; i++) {
+        const idx = (start + i) % SCOPE_SAMPLES;
+        const x = LABEL_W + i * xStep;
+        const y = dbToY(ringBuf.current[idx] ?? SCOPE_DB_MIN, h);
+        if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+      }
+      ctx.strokeStyle = colSignal;
+      ctx.lineWidth = 1.5;
+      ctx.stroke();
+    }
+
+    // Threshold line — position from store
+    const thrDb = thresholdMode === 'manual'
+      ? thresholdDb
+      : noiseFloorDb + 6; // auto: 6 dB above tracked noise floor as visual hint
+    const thrY = dbToY(thrDb, h);
+
+    ctx.strokeStyle = colThresh;
+    ctx.lineWidth = thresholdMode === 'manual' ? 2 : 1.5;
+    ctx.setLineDash(thresholdMode === 'manual' ? [] : [5, 3]);
+    ctx.beginPath();
+    ctx.moveTo(LABEL_W, thrY);
+    ctx.lineTo(w, thrY);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    // "THR" label
+    ctx.fillStyle = colThresh;
+    ctx.font = `600 8px ${colMono}`;
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'bottom';
+    ctx.fillText('THR', w - 2, thrY - 2);
+
+    // Left axis border
+    ctx.strokeStyle = colGrid;
+    ctx.lineWidth = 1;
+    ctx.setLineDash([]);
+    ctx.beginPath();
+    ctx.moveTo(LABEL_W, 0);
+    ctx.lineTo(LABEL_W, h);
+    ctx.stroke();
+
+    rafRef.current = requestAnimationFrame(draw);
+  }, [envelopeDb, noiseFloorDb, thresholdMode, thresholdDb]);
+
+  useEffect(() => {
+    rafRef.current = requestAnimationFrame(draw);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [draw]);
+
+  // Resize canvas to CSS size
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ro = new ResizeObserver((entries) => {
+      for (const e of entries) {
+        const { width, height } = e.contentRect;
+        if (width > 0 && height > 0) {
+          canvas.width = Math.round(width);
+          canvas.height = Math.round(height);
+        }
+      }
+    });
+    ro.observe(canvas);
+    return () => ro.disconnect();
+  }, []);
+
+  // Drag threshold
+  const isDragging = useRef(false);
+
+  const posToFraction = useCallback((clientY: number): number => {
+    const canvas = canvasRef.current;
+    if (!canvas) return 0;
+    const rect = canvas.getBoundingClientRect();
+    return Math.max(0, Math.min(1, 1 - (clientY - rect.top) / rect.height));
+  }, []);
+
+  const onMouseDown = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
+    isDragging.current = true;
+    setThreshold(posToFraction(e.clientY));
+  }, [posToFraction, setThreshold]);
+
+  const onMouseMove = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
+    if (!isDragging.current) return;
+    setThreshold(posToFraction(e.clientY));
+  }, [posToFraction, setThreshold]);
+
+  const stopDrag = useCallback(() => { isDragging.current = false; }, []);
+
+  return (
+    <div className="cw-scope">
+      <canvas
+        ref={canvasRef}
+        className={`cw-scope-canvas${thresholdMode === 'manual' ? ' is-manual' : ''}`}
+        onMouseDown={onMouseDown}
+        onMouseMove={onMouseMove}
+        onMouseUp={stopDrag}
+        onMouseLeave={stopDrag}
+        title="Drag to set decoder threshold — pin just above the noise floor (green) to stop WPM jitter"
+        aria-label="CW envelope scope"
+      />
+      <div className="cw-scope-controls">
+        <div className="cw-scope-mode-pill">
+          <span
+            className="cw-scope-mode-dot"
+            style={{ background: thresholdMode === 'auto' ? 'var(--fg-3)' : 'var(--accent-bright)' }}
+          />
+          <span>{thresholdMode === 'auto' ? 'AUTO' : 'MANUAL'}</span>
+        </div>
+        {thresholdMode === 'manual' && (
+          <>
+            <span className="cw-scope-thr-readout mono">THR {thresholdDb.toFixed(1)} dBFS</span>
+            <button type="button" className="cw-scope-reset" onClick={resetThreshold} title="Return to adaptive">
+              RESET
+            </button>
+          </>
+        )}
+        {thresholdMode === 'auto' && (
+          <span className="cw-scope-hint">drag THR line to pin above noise (green)</span>
+        )}
+        <span style={{ flex: 1 }} />
+        <span className="cw-scope-thr-readout mono" style={{ color: 'var(--fg-3)' }}>
+          NF {noiseFloorDb.toFixed(1)} dB
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/zeus-web/src/layout/__tests__/AddPanelModal.test.tsx
+++ b/zeus-web/src/layout/__tests__/AddPanelModal.test.tsx
@@ -55,9 +55,10 @@ describe('AddPanelModal', () => {
     const cards = container.querySelectorAll(
       '[data-testid="add-panel-cards"] .add-panel-card',
     );
-    // 20 panels in registry (CW Decoder added in zeus-cdn; RF-2K panel was
-    // extracted to a plugin; Rotator Dial was added in #385).
-    expect(cards.length).toBe(20);
+    // 21 panels in registry (CW Decoder added in zeus-cdn; RF-2K panel was
+    // extracted to a plugin; Rotator Dial was added in #385; CW station panel
+    // 'cw-station' added alongside the legacy 'cw'/'cwdecoder' tiles).
+    expect(cards.length).toBe(21);
     unmount();
   });
 

--- a/zeus-web/src/layout/panels.ts
+++ b/zeus-web/src/layout/panels.ts
@@ -53,6 +53,7 @@ import { RotatorDialPanel } from './panels/RotatorDialPanel';
 import { DspFlexPanel } from './panels/DspFlexPanel';
 import { CwPanel } from './panels/CwPanel';
 import { CwDecoderPanel } from './panels/CwDecoderPanel';
+import { CwStationPanel } from './panels/CwStationPanel';
 import { LogbookPanel } from './panels/LogbookPanel';
 import { TxMetersPanel } from './panels/TxMetersPanel';
 import { TxPanel } from './panels/TxPanel';
@@ -238,6 +239,19 @@ export const PANELS: Record<string, PanelDef> = {
     // a second default TileChrome on top, producing a duplicated window
     // header — and the panel's own close button goes dead because PanelTile
     // only injects onRemove to headerless panels.
+    headerless: true,
+  },
+  // CW station panel — terminal (RX decode + TX free-text), threshold scope,
+  // and keyer controls in one tile. The legacy 'cw' (keyer) and 'cwdecoder'
+  // (decoder) ids are kept above for backwards-compatibility with saved
+  // layouts (RED-LIGHT: layout migration policy needs maintainer sign-off
+  // before retiring the old ids).
+  'cw-station': {
+    id: 'cw-station',
+    name: 'CW',
+    category: 'tools',
+    tags: ['cw', 'morse', 'keyer', 'decoder', 'terminal'],
+    component: CwStationPanel,
     headerless: true,
   },
   logbook: {

--- a/zeus-web/src/layout/panels/CwStationPanel.tsx
+++ b/zeus-web/src/layout/panels/CwStationPanel.tsx
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+
+import { useCwStore } from '../../state/cw-store';
+import { useCwDecoderStore } from '../../state/cw-decoder-store';
+import { abortCw, sendCw } from '../../api/cw';
+import { TileChrome } from '../TileChrome';
+import { CwKeyer } from '../../components/design/CwKeyer';
+import { CwTerminal } from '../../components/design/CwTerminal';
+import { CwThresholdScope } from '../../components/design/CwThresholdScope';
+import type { PanelComponentProps } from '../panels';
+
+const MAX_MACROS = 32;
+
+export function CwStationPanel({ onRemove }: PanelComponentProps) {
+  const settings = useCwStore((s) => s.settings);
+  const status = useCwStore((s) => s.status);
+  const setSettingsLocal = useCwStore((s) => s.setSettingsLocal);
+  const commitDebounced = useCwStore((s) => s.commitDebounced);
+  const patchSettings = useCwStore((s) => s.patchSettings);
+  const setMacro = useCwStore((s) => s.setMacro);
+  const addMacro = useCwStore((s) => s.addMacro);
+  const removeMacro = useCwStore((s) => s.removeMacro);
+
+  const decoderState = useCwDecoderStore((s) => s.state);
+  const setEnabled = useCwDecoderStore((s) => s.setEnabled);
+
+  const decoderEnabled = decoderState !== 'idle';
+  const handleRemove = onRemove ?? (() => {});
+
+  return (
+    <>
+      <TileChrome title="CW" onRemove={handleRemove} />
+      <div className="workspace-tile-body cw-station">
+
+        {/* ── TERMINAL region ── */}
+        <div className="cw-station-section cw-station-section--terminal">
+          <CwTerminal
+            decoderEnabled={decoderEnabled}
+            onToggleDecoder={() => setEnabled(!decoderEnabled)}
+          />
+        </div>
+
+        <div className="cw-station-sep" role="separator" />
+
+        {/* ── SCOPE region ── */}
+        <div className="cw-station-section cw-station-section--scope">
+          <div className="cw-station-section-label">THRESHOLD SCOPE</div>
+          <CwThresholdScope />
+        </div>
+
+        <div className="cw-station-sep" role="separator" />
+
+        {/* ── KEYER region ── */}
+        <div className="cw-station-section cw-station-section--keyer">
+          <div className="cw-station-section-label">KEYER</div>
+          <CwKeyer
+            wpm={settings.wpm}
+            setWpmLocal={(v) => setSettingsLocal({ wpm: v })}
+            setWpmCommit={(v) => commitDebounced({ wpm: v })}
+            keyerMode={settings.keyerMode}
+            setKeyerMode={(m) => void patchSettings({ keyerMode: m })}
+            sidetoneHz={settings.sidetoneHz}
+            setSidetoneHzLocal={(v) => setSettingsLocal({ sidetoneHz: v })}
+            setSidetoneHzCommit={(v) => commitDebounced({ sidetoneHz: v })}
+            sidetoneGainDb={settings.sidetoneGainDb}
+            setSidetoneGainDbLocal={(v) => setSettingsLocal({ sidetoneGainDb: v })}
+            setSidetoneGainDbCommit={(v) => commitDebounced({ sidetoneGainDb: v })}
+            macros={settings.macros}
+            onSend={(macro) => void sendCw(macro, settings.wpm)}
+            onAbort={() => void abortCw()}
+            onMacroEdit={(i, v) => void setMacro(i, v)}
+            onMacroDelete={(i) => void removeMacro(i)}
+            onMacroAdd={() => void addMacro()}
+            maxMacros={MAX_MACROS}
+            status={status}
+          />
+        </div>
+
+      </div>
+    </>
+  );
+}

--- a/zeus-web/src/realtime/ws-client.ts
+++ b/zeus-web/src/realtime/ws-client.ts
@@ -182,10 +182,11 @@ const CW_ENGINE_STATUS_HEADER_BYTES = 9;
 // host and headless. Variable-length frame: 13-byte header + UTF-8 text.
 // Contract: Zeus.Contracts/CwDecodedTextFrame.cs.
 //
-// Wire shape:
-//   [0x31][wpm:u16 LE][snrDb:f32 LE][confidence:f32 LE][textLen:u16 LE][text:utf8…]
+// Wire shape (zeus-yrq extended):
+//   [0x31][wpm:u16 LE][snrDb:f32 LE][confidence:f32 LE]
+//   [envelopeDb:f32 LE][noiseFloorDb:f32 LE][textLen:u16 LE][text:utf8…]
 export const MSG_TYPE_CW_DECODED_TEXT = 0x31;
-const CW_DECODED_TEXT_HEADER_BYTES = 13;
+const CW_DECODED_TEXT_HEADER_BYTES = 21; // was 13; +8 for envelopeDb+noiseFloorDb
 
 // Shared by startRealtime / sendMicPcm. Single WS instance at a time; writes
 // are no-ops when the socket isn't open.
@@ -421,10 +422,12 @@ export function startRealtime(path = '/ws'): () => void {
             return;
           }
           const dv = new DataView(ev.data);
-          const wpm = dv.getUint16(1, true);
-          const snrDb = dv.getFloat32(3, true);
-          const confidence = dv.getFloat32(7, true);
-          const textLen = dv.getUint16(11, true);
+          const wpm          = dv.getUint16(1, true);
+          const snrDb        = dv.getFloat32(3, true);
+          const confidence   = dv.getFloat32(7, true);
+          const envelopeDb   = dv.getFloat32(11, true);
+          const noiseFloorDb = dv.getFloat32(15, true);
+          const textLen      = dv.getUint16(19, true);
           if (ev.data.byteLength < CW_DECODED_TEXT_HEADER_BYTES + textLen) {
             warnOnce(
               'ws-cw-decoded-truncated',
@@ -434,19 +437,22 @@ export function startRealtime(path = '/ws'): () => void {
             );
             return;
           }
-          if (textLen === 0) return;
-          const text = new TextDecoder('utf-8').decode(
-            new Uint8Array(ev.data, CW_DECODED_TEXT_HEADER_BYTES, textLen),
-          );
+          const text = textLen === 0
+            ? ''
+            : new TextDecoder('utf-8').decode(
+                new Uint8Array(ev.data, CW_DECODED_TEXT_HEADER_BYTES, textLen),
+              );
           // Lazy import keeps the cw-decoder-store off the critical path for
           // clients that never open the decoder panel.
           void import('../state/cw-decoder-store').then((m) => {
             const store = m.useCwDecoderStore.getState();
-            // The panel ON/OFF + HOLD are client-side display gates: the
-            // server always decodes in CW mode, but we only surface text
-            // while the operator has the panel actively listening.
-            if (store.state !== 'listening') return;
-            store.appendText(text, wpm, snrDb, confidence);
+            // Always push envelope telemetry so the scope updates even when
+            // the display is held or the decoder is idle.
+            store.pushEnvelope(envelopeDb, noiseFloorDb, snrDb, confidence, wpm);
+            // Text is only surfaced when the operator has the panel listening.
+            if (text && store.state === 'listening') {
+              store.appendText(text, wpm, snrDb, confidence);
+            }
           });
           return;
         }

--- a/zeus-web/src/state/cw-decoder-store.ts
+++ b/zeus-web/src/state/cw-decoder-store.ts
@@ -7,6 +7,8 @@ import { create } from 'zustand';
 
 export type CwDecoderState = 'idle' | 'listening' | 'held';
 
+export type CwThresholdMode = 'auto' | 'manual';
+
 export type CwDecoderStore = {
   state: CwDecoderState;
   // Continuous decoded stream. CW has no line structure (no carriage
@@ -18,15 +20,55 @@ export type CwDecoderStore = {
   snrDb: number;
   confidence: number;
 
+  // Real-time envelope telemetry from CwDecodedTextFrame (zeus-yrq Phase 2).
+  // Values are in dBFS (typically -100..0). Updated on every DSP tick (~48 Hz)
+  // via pushEnvelope() regardless of decoder state, so the scope is always live.
+  envelopeDb: number;
+  noiseFloorDb: number;
+
+  // Threshold scope.
+  // 'auto'   = adaptive Schmitt trigger (server default).
+  // 'manual' = operator-pinned; thresholdDb is in dBFS (sent to backend via
+  //            PUT /api/cw/decoder/settings). thresholdFraction is the
+  //            normalised 0..1 position on the scope canvas (for drag UI).
+  thresholdMode: CwThresholdMode;
+  thresholdDb: number;      // dBFS value sent to/from server
+  thresholdFraction: number; // 0..1 display position (derived from thresholdDb + scope range)
+
   // Actions
   setEnabled: (enabled: boolean) => void;
   toggleHold: () => void;
   clear: () => void;
   appendText: (chunk: string, wpm: number, snrDb: number, confidence: number) => void;
   updateStats: (wpm: number, snrDb: number, confidence: number) => void;
+  pushEnvelope: (envelopeDb: number, noiseFloorDb: number, snrDb: number, confidence: number, wpm: number) => void;
+  setThreshold: (fraction: number) => void;   // drag UI → computes dBFs + PUTs to server
+  resetThreshold: () => void;                 // → auto mode, PUTs to server
 };
 
 const MAX_CHARS = 4000;
+
+// dBFS range displayed on the scope canvas — maps linearly to Y position.
+const SCOPE_DB_MIN = -80;
+const SCOPE_DB_MAX = -20;
+
+function dbToFraction(db: number): number {
+  return Math.max(0, Math.min(1, (db - SCOPE_DB_MIN) / (SCOPE_DB_MAX - SCOPE_DB_MIN)));
+}
+
+function fractionToDb(f: number): number {
+  return SCOPE_DB_MIN + f * (SCOPE_DB_MAX - SCOPE_DB_MIN);
+}
+
+async function putThreshold(isManual: boolean, thresholdDb?: number): Promise<void> {
+  try {
+    await fetch('/api/cw/decoder/settings', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ isManual, thresholdDb }),
+    });
+  } catch { /* non-critical — scope still works visually */ }
+}
 
 export const useCwDecoderStore = create<CwDecoderStore>((set) => ({
   state: 'idle',
@@ -35,6 +77,11 @@ export const useCwDecoderStore = create<CwDecoderStore>((set) => ({
   wpm: 0,
   snrDb: 0,
   confidence: 0,
+  envelopeDb: -80,
+  noiseFloorDb: -80,
+  thresholdMode: 'auto',
+  thresholdDb: -50,
+  thresholdFraction: dbToFraction(-50),
 
   setEnabled: (enabled) =>
     set((s) => ({
@@ -63,9 +110,21 @@ export const useCwDecoderStore = create<CwDecoderStore>((set) => ({
     })),
 
   updateStats: (wpm, snrDb, confidence) =>
-    set({
-      wpm,
-      snrDb,
-      confidence,
-    }),
+    set({ wpm, snrDb, confidence }),
+
+  pushEnvelope: (envelopeDb, noiseFloorDb, snrDb, confidence, wpm) =>
+    set({ envelopeDb, noiseFloorDb, snrDb, confidence, wpm }),
+
+  setThreshold: (fraction) => {
+    const db = fractionToDb(Math.max(0, Math.min(1, fraction)));
+    set({ thresholdMode: 'manual', thresholdDb: db, thresholdFraction: fraction });
+    void putThreshold(true, db);
+  },
+
+  resetThreshold: () => {
+    set({ thresholdMode: 'auto', thresholdDb: -50, thresholdFraction: dbToFraction(-50) });
+    void putThreshold(false);
+  },
 }));
+
+export { dbToFraction, fractionToDb, SCOPE_DB_MIN, SCOPE_DB_MAX };

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -2698,3 +2698,313 @@
   white-space: pre-wrap;
   word-break: break-word;
 }
+
+/* ===========================================================
+   Unified CW Panel (zeus-yrq)
+   =========================================================== */
+
+/* Root layout — three stacked sections separated by hairlines */
+.cw-station {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+}
+
+.cw-station-sep {
+  height: 1px;
+  background: var(--line-soft);
+  flex-shrink: 0;
+}
+
+.cw-station-section {
+  padding: 8px 10px;
+}
+
+.cw-station-section--terminal {
+  /* min-height forces the terminal visible even when the keyer section
+     is long enough to push it out; flex: 1 picks up any extra space. */
+  flex: 1 1 220px;
+  min-height: 220px;
+  display: flex;
+  flex-direction: column;
+}
+
+.cw-station-section--scope {
+  flex-shrink: 0;
+  padding-top: 6px;
+}
+
+.cw-station-section--keyer {
+  /* Keyer section scrolls internally so it never crushes the terminal above */
+  flex-shrink: 0;
+  padding-top: 6px;
+  overflow-y: auto;
+}
+
+/* Small uppercase section label — one step dimmer than panel text */
+.cw-station-section-label {
+  font: 600 9px/1 var(--font-sans);
+  letter-spacing: 0.18em;
+  color: var(--fg-3);
+  text-transform: uppercase;
+  margin-bottom: 6px;
+}
+
+/* ---- CW Terminal ---- */
+.cw-terminal {
+  display: flex;
+  flex-direction: column;
+  /* height:100% fills the section; min-height 0 allows flex children to shrink */
+  height: 100%;
+  min-height: 0;
+  /* Use --bg-0 (not --bg-inset) so the terminal is readable in light theme:
+     dark=near-black+light-text, light=silver+dark-text. --bg-inset stays dark
+     in both themes and --fg-1 collapses against it in light mode. */
+  background: var(--bg-0);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-md);
+  overflow: hidden;
+}
+
+/* Header: state LED + label + optional inline stats + action buttons */
+.cw-terminal-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--line-strong);
+  flex-shrink: 0;
+  min-height: 36px;
+}
+
+/* State LED — reuses the keyer LED shape; active class applied via JS */
+.cw-stream-led--active {
+  background: var(--accent-bright) !important;
+  box-shadow: 0 0 6px var(--accent-soft);
+  animation: cwLedPulse 1.2s ease-in-out infinite;
+}
+
+/* State text label */
+.cw-terminal-state-label {
+  font: 600 10px/1 var(--font-sans);
+  letter-spacing: 0.14em;
+  color: var(--fg-3);
+  text-transform: uppercase;
+  min-width: 44px;
+}
+
+/* Inline stats cluster (WPM / SNR / confidence) shown when active */
+.cw-terminal-stats-inline {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+}
+
+.cw-terminal-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2px 8px;
+  background: var(--bg-0);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-sm);
+  min-width: 44px;
+}
+
+.cw-terminal-stat.is-active .cw-terminal-stat-value {
+  color: var(--accent-bright);
+}
+
+.cw-terminal-stat-label {
+  font: 500 8px/1 var(--font-sans);
+  letter-spacing: 0.1em;
+  color: var(--fg-3);
+  text-transform: uppercase;
+  margin-bottom: 2px;
+}
+
+.cw-terminal-stat-value {
+  font: 700 16px/1 var(--font-mono);
+  color: var(--fg-0);
+  letter-spacing: -0.01em;
+}
+
+/* Action buttons (HOLD / CLEAR / ON-OFF) pushed to the right */
+.cw-terminal-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+}
+
+/* Override .cw-hold / .cw-clear height for the header */
+.cw-terminal-header-actions .cw-hold,
+.cw-terminal-header-actions .cw-clear {
+  height: 28px;
+  min-width: 48px;
+  font-size: 10px;
+}
+
+/* Scrolling decode window — takes all available vertical space */
+.cw-terminal-window {
+  flex: 1 1 100px;
+  min-height: 100px;
+  overflow-y: auto;
+  padding: 10px 12px;
+  font: 500 13px/1.7 var(--font-mono);
+  letter-spacing: 0.06em;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--fg-1);
+}
+
+/* RX decoded text — default foreground */
+.cw-terminal-rx {
+  color: var(--fg-1);
+}
+
+/* TX echo — amber (--power) distinguishes from RX without alarm-red.
+   RED-LIGHT: colour choice needs Brian's sign-off. */
+.cw-terminal-tx {
+  color: var(--power);
+  opacity: 0.85;
+}
+
+/* TX free-text input row */
+.cw-terminal-input-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: var(--bg-1);
+  border-top: 1px solid var(--line-strong);
+  flex-shrink: 0;
+  min-height: 38px;
+}
+
+.cw-terminal-prompt {
+  color: var(--fg-3);
+  font: 600 12px/1 var(--font-mono);
+  flex-shrink: 0;
+  user-select: none;
+}
+
+.cw-terminal-input {
+  flex: 1;
+  min-width: 0;
+  background: var(--bg-0);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-sm);
+  color: var(--fg-0);
+  font: 500 12px/1 var(--font-mono);
+  padding: 5px 8px;
+  outline: none;
+  letter-spacing: 0.04em;
+  transition: border-color var(--dur-fast) var(--ease-out);
+}
+
+.cw-terminal-input::placeholder {
+  color: var(--fg-4);
+  font-style: italic;
+}
+
+.cw-terminal-input:focus {
+  border-color: var(--accent-line);
+}
+
+.cw-terminal-send-btn {
+  width: 30px;
+  height: 26px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font: 600 13px/1 var(--font-mono);
+  color: var(--fg-2);
+  background: var(--bg-2);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  transition: all var(--dur-fast) var(--ease-out);
+}
+
+.cw-terminal-send-btn:hover:not(:disabled) {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--fg-0);
+}
+
+.cw-terminal-send-btn:active:not(:disabled) { transform: translateY(1px); }
+.cw-terminal-send-btn:disabled { opacity: 0.3; cursor: not-allowed; }
+
+/* ---- CW Threshold Scope ---- */
+.cw-scope {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-inset);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-md);
+  overflow: hidden;
+}
+
+.cw-scope-canvas {
+  display: block;
+  width: 100%;
+  height: 80px;
+  cursor: ns-resize;
+  touch-action: none;
+}
+
+.cw-scope-canvas.is-manual { cursor: grab; }
+.cw-scope-canvas.is-manual:active { cursor: grabbing; }
+
+.cw-scope-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px 5px;
+  font: 500 9px/1 var(--font-mono);
+  color: var(--fg-3);
+  letter-spacing: 0.08em;
+  background: var(--bg-1);
+  border-top: 1px solid var(--line-soft);
+}
+
+.cw-scope-mode-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: var(--bg-2);
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  padding: 3px 7px;
+  letter-spacing: 0.12em;
+}
+
+.cw-scope-mode-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  transition: background var(--dur-fast) var(--ease-out);
+}
+
+.cw-scope-thr-readout { color: var(--fg-2); min-width: 64px; }
+
+.cw-scope-reset {
+  color: var(--fg-3);
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  font: 500 9px/1 var(--font-mono);
+  letter-spacing: 0.12em;
+  padding: 0;
+  text-transform: uppercase;
+  transition: color var(--dur-fast) var(--ease-out);
+}
+
+.cw-scope-reset:hover { color: var(--tx); }
+.cw-scope-hint { color: var(--fg-4); font-style: italic; }


### PR DESCRIPTION
## ⚠️ DO NOT MERGE WITHOUT VISUAL SIGN-OFF

This PR touches **two red-light areas** (per CONTRIBUTING.md): the
`Zeus.Contracts` wire format and visual design / layout. Please **do not merge
until @brianbruff has confirmed the panel visually on a running build.** I'm
opening it as a draft for review of the approach and a look at the layout, not
as ready-to-land.

My own reservation: **the panel feels too tall.** It works and I'm happy with
how it turned out functionally, but stacking terminal + scope + keyer in one
tile takes a lot of vertical space, especially on smaller screens. The sizing
is a starting point, not a final decision — happy to tune it however you want.

## What this does

Merges the former separate `cw` (keyer) and `cwdecoder` panels into a single
**CW** tile (id `cw-station`) with three stacked regions:

1. **Terminal** — RX-decoded text + TX free-text input, with state LED, WPM,
   SNR and confidence readouts.
2. **Threshold scope** — real-time envelope oscilloscope with a draggable
   threshold line and AUTO/MANUAL mode, plus a noise-floor readout.
3. **Keyer** — existing speed / sidetone / macro controls, unchanged.

The legacy `cw` and `cwdecoder` panel ids stay registered for
backwards-compatibility with saved layouts.

## Changes

**Backend**
- `CwDecodedTextFrame`: added `EnvelopeDb` and `NoiseFloorDb` to the frame so
  the frontend can render the threshold scope. **This is a wire-format change**
  (header grows) — flagging it as red-light per CONTRIBUTING.
- `CwAudioDecoder`: computes envelope / noise-floor metrics and populates the
  new fields.
- `CwDecoderService` + `ZeusEndpoints`: manual-vs-auto threshold handling and a
  settings endpoint.
- Frame round-trip tests updated.

**Frontend**
- New components `CwTerminal`, `CwThresholdScope`, and the `CwStationPanel`
  container.
- `cw-decoder-store`: envelope tracking + threshold state/actions.
- `ws-client`: deserialize the new frame fields.
- `panels.ts`: register `cw-station` (legacy ids retained).
- `layout.css`: styling for the new panel. Uses existing token variables only,
  no raw hex.

## Open questions for the maintainer

- [ ] **Overall height** — terminal is `min-height: 220px`, scope `80px`, keyer
      below. Too tall? Should the scope be collapsible, or the keyer move
      behind a toggle?
- [ ] Is merging the two panels into one tile the direction you want, or keep
      them separate?
- [ ] Retire the legacy `cw` / `cwdecoder` ids, or keep them indefinitely?
- [ ] Wire-format addition OK as-is, or would you prefer the metrics on a
      separate frame/channel?

## Testing

- `dotnet build Zeus.slnx` clean (0 warnings, 0 errors), `dotnet test Zeus.slnx`
  green (incl. the `CwDecodedTextFrame` round-trip tests for the new fields).
- `npm --prefix zeus-web run build` clean.
- Decoder + threshold scope exercised on a Hermes-Lite 2 (HL2).
- Not yet verified on other boards — please bench-test on ANAN-class before merge.

Follow-up: `zeus-6q9` — retire legacy `cw`/`cwdecoder` panels + migrate saved
layouts (after this lands).
