### PR TITLE
chore(wdsp): demote PS bring-up diagnostics to Debug

### DIFF
--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -2468,13 +2468,15 @@ public sealed class WdspDspEngine : IDspEngine
         // outPeak≈1.0 = post-iqc IQ clipping the Int24 wire (splatter). alcGain
         // (meter 14, dB) should go NEGATIVE under overdrive = ALC reducing gain
         // (limiting); ~0 dB while the mic clips = ALC NOT limiting (the bug).
-        // ~1 Hz while keyed.
-        if (++_txOverdriveLogCounter % 50 == 0)
+        // Debug-level: kept as a diagnostic but no longer spams ~1 Hz on every
+        // TX in a normal run — the meter reads are skipped entirely when the
+        // log level isn't enabled.
+        if (++_txOverdriveLogCounter % 50 == 0 && _log.IsEnabled(LogLevel.Debug))
         {
             double alcGainDb = NativeMethods.GetTXAMeter(txa, 14);
             double alcPkDb = NativeMethods.GetTXAMeter(txa, 12);
             double micPkDb = NativeMethods.GetTXAMeter(txa, 0);
-            _log.LogInformation(
+            _log.LogDebug(
                 "wdsp.txOverdrive micPk={Mic:F1}dB alcGain={Alc:F1}dB alcPk={AlcPk:F1}dB outPeak={Out:F3}{Clip}",
                 micPkDb, alcGainDb, alcPkDb, Math.Sqrt(txOutPeak),
                 txOutPeak >= 0.998 * 0.998 ? " RAIL!" : "");


### PR DESCRIPTION
Quiet the TX-path diagnostics left over from the PureSignal desktop-parity work (#559, merged via #566). They fired ~1 Hz on every transmit at Info level during bring-up and are no longer needed in a normal run.

## What changed
- **`wdsp.txOverdrive`** — demoted Info → Debug, and gated the whole block (including its three `GetTXAMeter` P/Invokes) behind `_log.IsEnabled(LogLevel.Debug)` so it's a genuine no-op unless someone turns Debug on to chase an overdrive issue.
- **`wdsp.psInfo`** / **`wdsp.psHot`** — already at Debug; no change (noted here for completeness).

## What was deliberately left alone
- **`wdsp.tx.stage`** — pre-existing per-stage TXA meter dump (the `peak=0` tell from the #324 IQ-gate work). Not part of this cleanup.
- **`wdsp.setMode` / `setAgcTop` / `setTxTune` / `setPsControl`** etc. — config-change one-shots (fire on a click, not per TX block). Useful, not noisy.

No behaviour change on the air; logging only. Builds clean (Zeus.Dsp, 0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)