### PR TITLE
feat(tci): render TCI spots on panadapter + honest iq_samplerate echo

### DIFF
--- a/Zeus.Contracts/MsgType.cs
+++ b/Zeus.Contracts/MsgType.cs
@@ -172,4 +172,14 @@ public enum MsgType : byte
     // audio. Payload: [type:1][wpm:u16 LE][snrDb:f32 LE][confidence:f32 LE]
     // [textLen:u16 LE][text:UTF-8…]. See CwDecodedTextFrame.cs.
     CwDecodedText = 0x31,
+
+    // Server → client (TCI spot list snapshot). Broadcast by SpotBroadcastService
+    // whenever SpotManager changes (add / remove / clear), and pushed once per
+    // client on WS connect. Carries the full list so the frontend can replace
+    // its store in one atomic update. Variable-length binary frame; see
+    // SpotListFrame.cs for the per-spot layout.
+    // Payload: [type:1][count:u16 LE][spot…] — each spot: freqHz:i64 LE,
+    // argb:u32 LE, callsignLen:u8, callsign:UTF-8, modeLen:u8, mode:UTF-8,
+    // commentLen:u16 LE, comment:UTF-8.
+    SpotList = 0x32,
 }

--- a/Zeus.Contracts/SpotListFrame.cs
+++ b/Zeus.Contracts/SpotListFrame.cs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is an independent reimplementation in .NET — not a fork. Its
+// Protocol-1 / Protocol-2 framing, WDSP integration, meter pipelines, and
+// TX behaviour were informed by studying the Thetis project
+// (https://github.com/ramdor/Thetis), the authoritative reference
+// implementation in the OpenHPSDR ecosystem. Zeus gratefully acknowledges
+// the Thetis contributors whose work made this possible:
+//
+//   Richard Samphire (MW0LGE), Warren Pratt (NR0V),
+//   Laurence Barker (G8NJJ),   Rick Koch (N1GP),
+//   Bryan Rambo (W4WMT),       Chris Codella (W2PA),
+//   Doug Wigley (W5WC),        FlexRadio Systems,
+//   Richard Allen (W5SD),      Joe Torrey (WD5Y),
+//   Andrew Mansfield (M0YGG),  Reid Campbell (MI0BOT),
+//   Sigi Jetzlsperger (DH1KLM).
+//
+// Thetis itself continues the GPL-governed lineage of FlexRadio PowerSDR
+// and the OpenHPSDR (TAPR/OpenHPSDR) ecosystem; that lineage is preserved
+// here. See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-contribution attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
+// WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
+// (NR0V), distributed under GPL v2 or later.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Text;
+
+namespace Zeus.Contracts;
+
+/// <summary>
+/// Full spot-list snapshot frame. Broadcast by SpotBroadcastService whenever
+/// SpotManager changes (add / remove / clear), and pushed once to each new
+/// WS client on connect. Wire format:
+///
+/// <code>
+/// [type:u8=0x32][count:u16 LE]
+/// [for each spot:]
+///   [freqHz:i64 LE][argb:u32 LE]
+///   [callsignLen:u8][callsign:UTF-8]
+///   [modeLen:u8][mode:UTF-8]
+///   [commentLen:u16 LE][comment:UTF-8]
+/// </code>
+///
+/// String fields are capped: callsign ≤ <see cref="MaxCallsignBytes"/>,
+/// mode ≤ <see cref="MaxModeBytes"/>, comment ≤ <see cref="MaxCommentBytes"/>.
+/// Spot count is capped at <see cref="MaxSpots"/>. Wire-frozen: future fields
+/// append after the variable-length comment of each spot.
+/// </summary>
+public readonly record struct SpotListFrame(IReadOnlyList<SpotListFrame.SpotEntry> Spots)
+{
+    public const int MaxSpots = 2000;
+    public const int MaxCallsignBytes = 32;
+    public const int MaxModeBytes = 8;
+    public const int MaxCommentBytes = 256;
+
+    // Fixed per-spot overhead: freqHz(8) + argb(4) + callsignLen(1) + modeLen(1) + commentLen(2) = 16
+    private const int PerSpotFixed = 16;
+    // Frame header: type(1) + count(2) = 3
+    private const int FrameHeaderBytes = 3;
+
+    public readonly record struct SpotEntry(
+        long FreqHz,
+        uint Argb,
+        string Callsign,
+        string Mode,
+        string? Comment);
+
+    public void Serialize(IBufferWriter<byte> writer)
+    {
+        int count = Math.Min(Spots.Count, MaxSpots);
+
+        // Pre-encode strings to know exact byte lengths.
+        var entries = new (byte[] cs, byte[] md, byte[] cm)[count];
+        int totalBytes = FrameHeaderBytes;
+        for (int i = 0; i < count; i++)
+        {
+            var spot = Spots[i];
+            var cs = Clip(Encoding.UTF8.GetBytes(spot.Callsign ?? string.Empty), MaxCallsignBytes);
+            var md = Clip(Encoding.UTF8.GetBytes(spot.Mode ?? string.Empty), MaxModeBytes);
+            var cm = Clip(Encoding.UTF8.GetBytes(spot.Comment ?? string.Empty), MaxCommentBytes);
+            entries[i] = (cs, md, cm);
+            totalBytes += PerSpotFixed + cs.Length + md.Length + cm.Length;
+        }
+
+        var span = writer.GetSpan(totalBytes);
+        int pos = 0;
+
+        span[pos++] = (byte)MsgType.SpotList;
+        BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(pos, 2), (ushort)count); pos += 2;
+
+        for (int i = 0; i < count; i++)
+        {
+            var spot = Spots[i];
+            var (cs, md, cm) = entries[i];
+
+            BinaryPrimitives.WriteInt64LittleEndian(span.Slice(pos, 8), spot.FreqHz); pos += 8;
+            BinaryPrimitives.WriteUInt32LittleEndian(span.Slice(pos, 4), spot.Argb); pos += 4;
+
+            span[pos++] = (byte)cs.Length;
+            cs.CopyTo(span.Slice(pos, cs.Length)); pos += cs.Length;
+
+            span[pos++] = (byte)md.Length;
+            md.CopyTo(span.Slice(pos, md.Length)); pos += md.Length;
+
+            BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(pos, 2), (ushort)cm.Length); pos += 2;
+            cm.CopyTo(span.Slice(pos, cm.Length)); pos += cm.Length;
+        }
+
+        writer.Advance(pos);
+    }
+
+    private static byte[] Clip(byte[] src, int maxBytes) =>
+        src.Length <= maxBytes ? src : src[..maxBytes];
+}

--- a/Zeus.Server.Hosting/SpotBroadcastService.cs
+++ b/Zeus.Server.Hosting/SpotBroadcastService.cs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+
+using System.Buffers;
+using Microsoft.Extensions.Hosting;
+using Zeus.Contracts;
+using Zeus.Server.Tci;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Watches <see cref="SpotManager.SpotsChanged"/> and broadcasts a fresh
+/// <see cref="SpotListFrame"/> to all WS clients whenever the TCI spot list
+/// changes. No background loop — entirely event-driven.
+/// </summary>
+public sealed class SpotBroadcastService : BackgroundService
+{
+    private readonly SpotManager _spots;
+    private readonly StreamingHub _hub;
+
+    public SpotBroadcastService(SpotManager spots, StreamingHub hub)
+    {
+        _spots = spots;
+        _hub = hub;
+        _spots.SpotsChanged += OnSpotsChanged;
+    }
+
+    // ExecuteAsync is a no-op; all work happens in the SpotsChanged handler.
+    protected override Task ExecuteAsync(CancellationToken stoppingToken) => Task.CompletedTask;
+
+    private void OnSpotsChanged()
+    {
+        var all = _spots.GetAll();
+        var entries = all.Select(s => new SpotListFrame.SpotEntry(
+            s.FreqHz, s.Argb, s.Callsign, s.Mode, s.Comment)).ToList();
+        var frame = new SpotListFrame(entries);
+
+        // Estimate payload size: header(3) + per-spot fixed(16) + ~30 bytes avg strings.
+        var buf = new ArrayBufferWriter<byte>(3 + all.Length * 48);
+        frame.Serialize(buf);
+        _hub.BroadcastSpots(buf.WrittenMemory.ToArray());
+    }
+
+    public override void Dispose()
+    {
+        _spots.SpotsChanged -= OnSpotsChanged;
+        base.Dispose();
+    }
+}

--- a/Zeus.Server.Hosting/StreamingHub.cs
+++ b/Zeus.Server.Hosting/StreamingHub.cs
@@ -73,6 +73,11 @@ public sealed class StreamingHub
     private volatile byte _wisdomPhase;
     private volatile string _wisdomStatus = string.Empty;
 
+    // Latest serialised SpotList payload. Set by BroadcastSpots whenever the
+    // spot list changes; pushed to each new WS client in AttachClientAsync so
+    // they see the current spots without waiting for the next TCI spot event.
+    private volatile byte[]? _spotPayload;
+
     // ---- Step 1 drop-counter probe for issue #299 -----------------------
     // Each per-client send queue is bounded to MaxBacklogPerClient=4 with
     // FullMode=DropOldest (lines 318-324). When the producer outruns
@@ -164,6 +169,11 @@ public sealed class StreamingHub
         // joining mid-build needs both the phase byte and any status string
         // already accumulated so the body shows the current step.
         session.TryEnqueue(BuildWisdomPayload((Zeus.Contracts.WisdomPhase)_wisdomPhase, _wisdomStatus));
+
+        // Push the current spot list so the client renders any spots that
+        // arrived before it connected (e.g. a skimmer that was already running).
+        var spotSnap = _spotPayload;
+        if (spotSnap is not null) session.TryEnqueue(spotSnap);
 
         try
         {
@@ -481,6 +491,20 @@ public sealed class StreamingHub
         var payload = new byte[1 + regionBytes.Length];
         payload[0] = (byte)MsgType.BandPlanChanged;
         regionBytes.CopyTo(payload, 1);
+        foreach (var client in _clients.Values)
+        {
+            if (!client.TryEnqueue(payload)) System.Threading.Interlocked.Increment(ref _dropsOther);
+        }
+    }
+
+    /// <summary>
+    /// Serialises <paramref name="payload"/> as the current spot snapshot and
+    /// broadcasts it to all connected clients. Also caches the payload so new
+    /// clients receive it in <see cref="AttachClientAsync"/>.
+    /// </summary>
+    public void BroadcastSpots(byte[] payload)
+    {
+        _spotPayload = payload;
         foreach (var client in _clients.Values)
         {
             if (!client.TryEnqueue(payload)) System.Threading.Interlocked.Increment(ref _dropsOther);

--- a/Zeus.Server.Hosting/Tci/SpotManager.cs
+++ b/Zeus.Server.Hosting/Tci/SpotManager.cs
@@ -46,13 +46,20 @@ namespace Zeus.Server.Tci;
 
 /// <summary>
 /// In-memory storage for DX cluster spots received via TCI.
-/// Phase 1: stub implementation stores spots but doesn't render them on the
-/// panadapter. Rendering is a follow-up issue (requires panadapter overlay).
+/// Fires <see cref="SpotsChanged"/> after every mutation so
+/// SpotBroadcastService can push a fresh snapshot to all WS clients.
 /// </summary>
 public sealed class SpotManager
 {
     private readonly object _sync = new();
     private readonly Dictionary<string, Spot> _spots = new();
+
+    /// <summary>
+    /// Raised after any mutation (add, remove, or clear). Fired while the
+    /// lock is NOT held so subscribers can call <see cref="GetAll"/> safely.
+    /// The event fires on whatever thread called the mutating method.
+    /// </summary>
+    public event Action? SpotsChanged;
 
     /// <summary>
     /// Add or update a spot.
@@ -63,6 +70,7 @@ public sealed class SpotManager
         {
             _spots[callsign] = new Spot(callsign, mode, freqHz, argb, comment);
         }
+        SpotsChanged?.Invoke();
     }
 
     /// <summary>
@@ -74,6 +82,7 @@ public sealed class SpotManager
         {
             _spots.Remove(callsign);
         }
+        SpotsChanged?.Invoke();
     }
 
     /// <summary>
@@ -85,6 +94,7 @@ public sealed class SpotManager
         {
             _spots.Clear();
         }
+        SpotsChanged?.Invoke();
     }
 
     /// <summary>

--- a/Zeus.Server.Hosting/Tci/TciSession.cs
+++ b/Zeus.Server.Hosting/Tci/TciSession.cs
@@ -125,7 +125,12 @@ public sealed class TciSession : IDisposable
         lock (_streamLock) return _iqStreamEnabled.Count > 0;
     }
 
-    /// <summary>Last client-requested IQ sample rate, clamped to [48000, 384000].</summary>
+    /// <summary>
+    /// Last client-requested IQ sample rate, clamped to [48000, 384000].
+    /// Reserved for Path B per-session decimation. The actual delivery rate is
+    /// always the hardware rate (<c>_radio.Snapshot().SampleRate</c>); this
+    /// stored value is NOT echoed back to the client.
+    /// </summary>
     public int IqSampleRate
     {
         get { lock (_streamLock) return _iqSampleRate; }
@@ -1345,19 +1350,25 @@ public sealed class TciSession : IDisposable
     private void HandleIqSampleRate(string[] args)
     {
         // iq_samplerate:<rate>  or  iq_samplerate (query)
-        // Range matches Thetis: [48000, 384000]. Stored on the session; the
-        // actual rate of published frames is the radio's native rate, echoed
-        // back to the client when streaming starts.
+        // Range matches Thetis: [48000, 384000].
+        //
+        // Always echo the hardware delivery rate, NOT the requested rate.
+        // IQ frames are published at the radio's native sample rate regardless
+        // of what the client requests (per-session decimation is Path B, not
+        // yet implemented). Echoing the requested value would silently mislead
+        // clients that size their DSP pipeline on the negotiated rate.
+        int hwRate = _radio.Snapshot().SampleRate;
         if (args.Length == 0)
         {
-            Send(TciProtocol.Command("iq_samplerate", IqSampleRate));
+            Send(TciProtocol.Command("iq_samplerate", hwRate));
             return;
         }
         if (TciProtocol.TryParseInt(args[0], out int rate))
         {
+            // Store for future Path B decimation; echo what will actually arrive.
             rate = Math.Clamp(rate, 48000, 384000);
             lock (_streamLock) _iqSampleRate = rate;
-            Send(TciProtocol.Command("iq_samplerate", rate));
+            Send(TciProtocol.Command("iq_samplerate", hwRate));
         }
     }
 
@@ -1393,18 +1404,20 @@ public sealed class TciSession : IDisposable
     private void HandleAudioSampleRate(string[] args)
     {
         // audio_samplerate:<rate>  or  audio_samplerate (query)
-        // Range: [8000, 48000]. Zeus emits audio at 48 kHz; the requested rate
-        // is stored and echoed. Down-sampling is not yet implemented.
+        // Range: [8000, 48000]. Zeus always delivers audio at 48 kHz (the DSP
+        // pipeline output rate). Down-sampling to the requested rate is not yet
+        // implemented, so always echo 48000 — same honesty rule as IQ above.
+        const int deliveryRate = 48000;
         if (args.Length == 0)
         {
-            Send(TciProtocol.Command("audio_samplerate", AudioSampleRate));
+            Send(TciProtocol.Command("audio_samplerate", deliveryRate));
             return;
         }
         if (TciProtocol.TryParseInt(args[0], out int rate))
         {
             rate = Math.Clamp(rate, 8000, 48000);
             lock (_streamLock) _audioSampleRate = rate;
-            Send(TciProtocol.Command("audio_samplerate", rate));
+            Send(TciProtocol.Command("audio_samplerate", deliveryRate));
         }
     }
 

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -386,6 +386,8 @@ public static class ZeusHost
         builder.Services.AddSingleton<SpotManager>();
         builder.Services.AddSingleton<TciServer>();
         builder.Services.AddHostedService(sp => sp.GetRequiredService<TciServer>());
+        builder.Services.AddSingleton<SpotBroadcastService>();
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<SpotBroadcastService>());
         builder.Services.AddSingleton<TciManagementService>();
 
         var app = builder.Build();

--- a/docs/wiki/TCI.md
+++ b/docs/wiki/TCI.md
@@ -75,7 +75,7 @@ TCI server status and pending configuration are exposed over the standard Zeus R
 | **TX_CHRONO pacing emitter** | ✅ **New in this branch** |
 | NR / NB / ANF / ANC | ✅ Wired |
 | Preamp / attenuator | ✅ Complete |
-| DX cluster spots (in/out) | ✅ Stored, not rendered on panadapter yet |
+| DX cluster spots (in/out) | ✅ Stored and rendered on panadapter as click-to-QSY overlays |
 | `RX_SENSORS_ENABLE` / `TX_SENSORS_ENABLE` | ✅ Spec-correct shape `bool[,interval]` |
 | `RX_CHANNEL_SENSORS` (TCI 2.0) | ✅ Sent to opted-in clients |
 | `VFO_LOCK` (TCI 2.0) | 🟡 Echo-only stub |
@@ -177,6 +177,32 @@ Legend: ✅ working · 🟡 partial / stub-only · ❌ missing
 | LINE_OUT | S→C | 4 | ❌ Not implemented |
 
 Header layout matches TCI v1.x §7.1 (64-byte little-endian); dispatch keys off `type` at offset 24 per markdown spec quirk #7.
+
+#### IQ stream: `channels` and `length` fields for external implementors
+
+The 64-byte header has **no `channels` word**. The full field map is:
+
+| Offset | Size | Field |
+|--------|------|-------|
+| 0 | 4 | receiver index |
+| 4 | 4 | sample_rate (Hz) |
+| 8 | 4 | sample type (0 = float32) |
+| 12 | 4 | codec id (0 = uncompressed PCM) |
+| 16 | 4 | crc32 of payload (0 = skipped) |
+| 20 | 4 | **length** — total float32 scalar count |
+| 24 | 4 | stream type (0 = IQ, 1 = audio, 2 = TX audio, 3 = TX_CHRONO) |
+| 28–63 | 36 | reserved zeros (9 × uint32) |
+| 64… | — | sample payload |
+
+Clients that parse the header as 16 × uint32 and treat index 7 (offset 28) as `channels` will always read **0** — that is a reserved word, not a channel count.
+
+For **IQ frames** (stream type 0): `length` is the count of individual float32 scalars in the payload, interleaved as I₀ Q₀ I₁ Q₁ …. Complex sample count = `length / 2`. There is no separate `channels` negotiation; the interleave is fixed.
+
+For **RX audio frames** (stream type 1): `length` is likewise total float32 scalars in the stereo (L=R) payload. Frame count = `length / 2`.
+
+#### `iq_samplerate` negotiation
+
+Zeus does not yet decimate the IQ stream to a client-requested rate (Path B). `iq_samplerate:<hz>;` stores the requested value for future use but always echoes back the **hardware delivery rate** (e.g. `iq_samplerate:192000;`), so clients that inspect the echoed value will correctly size their pipeline. Sending `iq_samplerate:96000;` and receiving `iq_samplerate:192000;` in reply means the request was not granted — the stream will arrive at 192000.
 
 ---
 

--- a/zeus-web/src/components/Panadapter.tsx
+++ b/zeus-web/src/components/Panadapter.tsx
@@ -54,6 +54,7 @@ import { FreqAxis } from './FreqAxis';
 import { PassbandOverlay } from './PassbandOverlay';
 import { ImdReadings } from './ImdReadings';
 import { DbScale } from './DbScale';
+import { SpotOverlay } from './SpotOverlay';
 
 export function Panadapter() {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -264,6 +265,7 @@ export function Panadapter() {
     >
       <canvas ref={canvasRef} style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }} />
       <PassbandOverlay />
+      <SpotOverlay />
       <ImdReadings />
       <FreqAxis />
       <DbScale />

--- a/zeus-web/src/components/SpotOverlay.tsx
+++ b/zeus-web/src/components/SpotOverlay.tsx
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+import { useCallback } from 'react';
+import { setVfo } from '../api/client';
+import { useConnectionStore } from '../state/connection-store';
+import { useDisplayStore } from '../state/display-store';
+import { useSpotStore } from '../state/spot-store';
+
+// Convert a packed ARGB uint32 to a CSS rgba() string.
+// TCI clients commonly send A=0 meaning "default/opaque" rather than
+// transparent, so A=0 is treated as fully opaque.
+function argbToRgba(argb: number, opacity = 0.9): string {
+  const a = (argb >>> 24) & 0xff;
+  const r = (argb >>> 16) & 0xff;
+  const g = (argb >>> 8) & 0xff;
+  const b = argb & 0xff;
+  const alpha = a === 0 ? opacity : (a / 255) * opacity;
+  return `rgba(${r},${g},${b},${alpha})`;
+}
+
+// Thin vertical line + callsign label overlay for each in-view TCI spot.
+// Positioned by percentage of the total span, identical to PassbandOverlay
+// and FreqAxis, so no DOM measurement is needed on resize.
+export function SpotOverlay() {
+  const centerHz = useDisplayStore((s) => s.centerHz);
+  const hzPerPixel = useDisplayStore((s) => s.hzPerPixel);
+  const width = useDisplayStore((s) => s.panDb?.length ?? 0);
+  const spots = useSpotStore((s) => s.spots);
+  const vfoHz = useConnectionStore((s) => s.vfoHz);
+
+  const handleSpotClick = useCallback(
+    (freqHz: number) => {
+      useConnectionStore.setState({ vfoHz: freqHz });
+      setVfo(freqHz)
+        .then((s) => useConnectionStore.getState().applyState(s))
+        .catch(() => {});
+    },
+    [],
+  );
+
+  if (!width || hzPerPixel <= 0 || spots.length === 0) return null;
+
+  const spanHz = width * hzPerPixel;
+  const center = Number(centerHz);
+  const startHz = center - spanHz / 2;
+
+  const visible = spots.filter((s) => {
+    const pct = ((s.freqHz - startHz) / spanHz) * 100;
+    return pct >= -2 && pct <= 102;
+  });
+
+  if (visible.length === 0) return null;
+
+  return (
+    <>
+      {visible.map((spot) => {
+        const pct = ((spot.freqHz - startHz) / spanHz) * 100;
+        const color = argbToRgba(spot.argb);
+        const isNearVfo = Math.abs(spot.freqHz - vfoHz) < hzPerPixel * 4;
+        return (
+          <div
+            key={spot.callsign}
+            title={`${spot.callsign} ${spot.mode}${spot.comment ? ` — ${spot.comment}` : ''}`}
+            onClick={() => handleSpotClick(spot.freqHz)}
+            className="absolute inset-y-0 z-[8] -translate-x-1/2 cursor-pointer"
+            style={{ left: `${pct}%` }}
+          >
+            {/* vertical marker line */}
+            <div
+              className="absolute inset-y-0 w-px"
+              style={{
+                background: color,
+                opacity: isNearVfo ? 1 : 0.75,
+              }}
+            />
+            {/* callsign label at top */}
+            <div
+              className="absolute top-5 -translate-x-1/2 select-none whitespace-nowrap font-mono text-[9px] leading-none px-0.5"
+              style={{
+                color,
+                textShadow: '0 0 3px rgba(0,0,0,0.8)',
+              }}
+            >
+              {spot.callsign}
+            </div>
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/zeus-web/src/realtime/ws-client.ts
+++ b/zeus-web/src/realtime/ws-client.ts
@@ -187,6 +187,19 @@ const CW_ENGINE_STATUS_HEADER_BYTES = 9;
 export const MSG_TYPE_CW_DECODED_TEXT = 0x31;
 const CW_DECODED_TEXT_HEADER_BYTES = 13;
 
+// TCI spot list snapshot — broadcast by SpotBroadcastService whenever the
+// spot list changes (add / remove / clear), and pushed once on WS connect.
+// Variable-length binary frame; see Zeus.Contracts/SpotListFrame.cs.
+//
+// Wire shape:
+//   [0x32][count:u16 LE]
+//   [for each spot: freqHz:i64 LE, argb:u32 LE,
+//     callsignLen:u8, callsign:utf8,
+//     modeLen:u8, mode:utf8,
+//     commentLen:u16 LE, comment:utf8]
+export const MSG_TYPE_SPOT_LIST = 0x32;
+const SPOT_LIST_MIN_BYTES = 3; // type + count
+
 // Shared by startRealtime / sendMicPcm. Single WS instance at a time; writes
 // are no-ops when the socket isn't open.
 let activeWs: WebSocket | null = null;
@@ -594,6 +607,38 @@ export function startRealtime(path = '/ws'): () => void {
             // localMicArmed (only local interaction does — see issue #346).
             if (txStore.localMicArmed) txStore.setLocalMicArmed(false);
           }
+          return;
+        }
+        if (peekType === MSG_TYPE_SPOT_LIST) {
+          if (ev.data.byteLength < SPOT_LIST_MIN_BYTES) {
+            warnOnce('ws-spot-list-short', `spot list frame too short: ${ev.data.byteLength}`);
+            return;
+          }
+          const dv = new DataView(ev.data);
+          const count = dv.getUint16(1, true);
+          const spots: { callsign: string; mode: string; freqHz: number; argb: number; comment?: string }[] = [];
+          let offset = 3;
+          const td = new TextDecoder('utf-8');
+          for (let i = 0; i < count; i++) {
+            if (offset + 16 > ev.data.byteLength) break; // minimum per-spot fixed bytes
+            const freqHz = Number(dv.getBigInt64(offset, true)); offset += 8;
+            const argb = dv.getUint32(offset, true); offset += 4;
+            const callsignLen = dv.getUint8(offset); offset += 1;
+            if (offset + callsignLen > ev.data.byteLength) break;
+            const callsign = td.decode(new Uint8Array(ev.data, offset, callsignLen)); offset += callsignLen;
+            const modeLen = dv.getUint8(offset); offset += 1;
+            if (offset + modeLen > ev.data.byteLength) break;
+            const mode = td.decode(new Uint8Array(ev.data, offset, modeLen)); offset += modeLen;
+            if (offset + 2 > ev.data.byteLength) break;
+            const commentLen = dv.getUint16(offset, true); offset += 2;
+            if (offset + commentLen > ev.data.byteLength) break;
+            const comment = commentLen > 0 ? td.decode(new Uint8Array(ev.data, offset, commentLen)) : undefined;
+            offset += commentLen;
+            spots.push({ callsign, mode, freqHz, argb, comment });
+          }
+          void import('../state/spot-store').then((m) => {
+            m.useSpotStore.getState().setSpots(spots);
+          });
           return;
         }
         warnOnce(

--- a/zeus-web/src/state/spot-store.ts
+++ b/zeus-web/src/state/spot-store.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+import { create } from 'zustand';
+
+export type SpotData = {
+  callsign: string;
+  mode: string;
+  freqHz: number;
+  argb: number;
+  comment?: string;
+};
+
+type SpotStore = {
+  spots: SpotData[];
+  setSpots: (spots: SpotData[]) => void;
+};
+
+export const useSpotStore = create<SpotStore>()((set) => ({
+  spots: [],
+  setSpots: (spots) => set({ spots }),
+}));


### PR DESCRIPTION
Fixes #571 and #570.

## Spot rendering on panadapter (#571)

`SpotManager` already stored TCI `SPOT:`/`SPOT_DELETE:`/`SPOT_CLEAR:` commands (Phase 1). This adds the complete rendering path.

**Backend:**
- `SpotListFrame` (`MsgType 0x32`): binary snapshot pushed on every change and on each new WS client connect. Per-spot payload: `freqHz:i64`, `argb:u32`, variable-length UTF-8 callsign / mode / comment.
- `SpotManager`: fires a `SpotsChanged` event after every mutation (outside the lock).
- `SpotBroadcastService`: subscribes to `SpotsChanged`, serialises the full list, calls `hub.BroadcastSpots()`. Cached payload is pushed to late-joining clients in `AttachClientAsync`.

**Frontend:**
- `spot-store.ts` — Zustand store: `spots: SpotData[]` + `setSpots`.
- `ws-client.ts` — decodes the `0x32` binary frame (lazy import).
- `SpotOverlay.tsx` — absolute overlay inside the panadapter container; renders each in-view spot as a coloured vertical line + callsign label. Colour from the ARGB field; `A=0` treated as opaque. Clicking a spot tunes the VFO via `setVfo`.
- `Panadapter.tsx` — mounts `<SpotOverlay />`.

## Honest `iq_samplerate` echo (#570)

`HandleIqSampleRate` was echoing the client-requested rate verbatim even though the IQ stream is always delivered at the hardware sample rate. Clients that sized their DSP pipeline on the echoed value silently received the wrong data.

**Fix (Path A):** both query and set branches now echo `_radio.Snapshot().SampleRate`. The requested rate is stored in `_iqSampleRate` for future per-session decimation (Path B). Same fix applied to `HandleAudioSampleRate` (always 48 kHz).

`docs/wiki/TCI.md` updated: spot status, IQ header field table, `length` semantics, `iq_samplerate` negotiation behaviour.

## Test plan

- [x] `dotnet test Zeus.slnx` — all pass
- [x] `npm --prefix zeus-web run test` — all pass
- [x] `iq_samplerate:96000;` → echoes `iq_samplerate:192000;` (verified on HL2)
- [x] TCI `SPOT:` → marker on panadapter at correct frequency
- [x] `SPOT_DELETE:` / `SPOT_CLEAR:` → markers removed
- [x] Click spot marker → VFO tunes to spot frequency
- [x] Late WS client receives current spot list on connect