### PR TITLE
fix(p2): blank panadapter + discovery on Windows multi-NIC hosts (#574)

### DIFF
--- a/Zeus.Protocol1/Discovery/RadioDiscoveryService.cs
+++ b/Zeus.Protocol1/Discovery/RadioDiscoveryService.cs
@@ -79,6 +79,7 @@ public sealed class RadioDiscoveryService : IRadioDiscovery
         {
             EnableBroadcast = true,
         };
+        DisableUdpConnReset(socket);
         socket.Bind(new IPEndPoint(IPAddress.Any, 0));
 
         var packet = BuildDiscoveryPacket();
@@ -107,6 +108,12 @@ public sealed class RadioDiscoveryService : IRadioDiscovery
                 catch (OperationCanceledException)
                 {
                     break;
+                }
+                catch (SocketException ex) when (ex.SocketErrorCode == SocketError.ConnectionReset)
+                {
+                    // Windows WSAECONNRESET (10054): stray ICMP port-unreachable.
+                    // Keep collecting replies until the timeout fires.
+                    continue;
                 }
                 catch (SocketException ex)
                 {
@@ -256,5 +263,17 @@ public sealed class RadioDiscoveryService : IRadioDiscovery
         var bytes = r.Ip.GetAddressBytes();
         if (bytes.Length != 4) return uint.MaxValue;
         return BinaryPrimitives.ReadUInt32BigEndian(bytes);
+    }
+
+    // Private copy — Protocol1 is a separate assembly from Protocol2.
+    // Windows surfaces ICMP port-unreachable as SocketError 10054 on the next recv;
+    // this ioctl disables that behaviour at the OS level.
+    private const int SIO_UDP_CONNRESET = -1744830452; // 0x9800000C
+
+    private static void DisableUdpConnReset(Socket s)
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        try { s.IOControl(SIO_UDP_CONNRESET, new byte[4], null); }
+        catch (SocketException) { /* best effort */ }
     }
 }

--- a/Zeus.Protocol2/Discovery/RadioDiscoveryService.cs
+++ b/Zeus.Protocol2/Discovery/RadioDiscoveryService.cs
@@ -47,6 +47,7 @@ using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using Microsoft.Extensions.Logging;
+using Zeus.Protocol2;
 
 namespace Zeus.Protocol2.Discovery;
 
@@ -79,6 +80,7 @@ public sealed class RadioDiscoveryService : IRadioDiscovery
         {
             EnableBroadcast = true,
         };
+        Protocol2Client.DisableUdpConnReset(socket);
         socket.Bind(new IPEndPoint(IPAddress.Any, 0));
 
         var packet = BuildDiscoveryPacket();
@@ -107,6 +109,12 @@ public sealed class RadioDiscoveryService : IRadioDiscovery
                 catch (OperationCanceledException)
                 {
                     break;
+                }
+                catch (SocketException ex) when (ex.SocketErrorCode == SocketError.ConnectionReset)
+                {
+                    // Windows WSAECONNRESET (10054): stray ICMP port-unreachable.
+                    // Keep collecting replies until the timeout fires.
+                    continue;
                 }
                 catch (SocketException ex)
                 {

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -314,12 +314,17 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
 
         _radioEndpoint = new IPEndPoint(radioEndpoint.Address, 1024);
         var sock = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        DisableUdpConnReset(sock);
+        var localBind = FindLocalAddressForSubnet(radioEndpoint.Address) ?? IPAddress.Any;
         // Matched port convention — PC binds 1025, radio sends back with source
         // ports 1025/1026/1027/1035.. which we demux by fromaddr.
-        sock.Bind(new IPEndPoint(IPAddress.Any, 1025));
+        sock.Bind(new IPEndPoint(localBind, 1025));
         sock.ReceiveBufferSize = 1 << 20;
         _sock = sock;
-        _log.LogInformation("p2.connect radio={Radio} localPort=1025", radioEndpoint.Address);
+        _log.LogInformation(
+            "p2.connect radio={Radio} localBind={Local} localPort=1025",
+            radioEndpoint.Address,
+            localBind.Equals(IPAddress.Any) ? "ANY (no subnet match)" : localBind.ToString());
         return Task.CompletedTask;
     }
 
@@ -991,6 +996,45 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         return 0;
     }
 
+    // Windows surfaces ICMP port-unreachable as SocketError 10054 on the next recv.
+    // Disabling it at the ioctl level keeps the socket clean; the ConnectionReset
+    // catch in RxLoop is a belt-and-suspenders fallback if the ioctl is unavailable.
+    private const int SIO_UDP_CONNRESET = -1744830452; // 0x9800000C
+
+    internal static void DisableUdpConnReset(Socket s)
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        try { s.IOControl(SIO_UDP_CONNRESET, new byte[4], null); }
+        catch (SocketException) { /* best effort — some Windows editions block the ioctl */ }
+    }
+
+    // Returns the local IPv4 address of the first NIC whose subnet contains radioIp.
+    // Returns null when no subnet match is found (single-NIC host, radio behind a
+    // router, etc.) — the caller falls back to IPAddress.Any in that case.
+    internal static IPAddress? FindLocalAddressForSubnet(IPAddress radioIp)
+    {
+        if (radioIp.AddressFamily != AddressFamily.InterNetwork) return null;
+        var radioBytes = radioIp.GetAddressBytes();
+        foreach (var iface in NetworkInterface.GetAllNetworkInterfaces())
+        {
+            if (iface.OperationalStatus != OperationalStatus.Up) continue;
+            if (iface.NetworkInterfaceType == NetworkInterfaceType.Loopback) continue;
+            foreach (var ua in iface.GetIPProperties().UnicastAddresses)
+            {
+                if (ua.Address.AddressFamily != AddressFamily.InterNetwork) continue;
+                var mask = ua.IPv4Mask;
+                if (mask is null || mask.Equals(IPAddress.Any)) continue;
+                var local = ua.Address.GetAddressBytes();
+                var m = mask.GetAddressBytes();
+                bool same = true;
+                for (int i = 0; i < 4; i++)
+                    if ((local[i] & m[i]) != (radioBytes[i] & m[i])) { same = false; break; }
+                if (same) return ua.Address;
+            }
+        }
+        return null;
+    }
+
     /// <summary>
     /// Per-board base DDC index for the user-visible RX. OrionMkII/Saturn/G2
     /// family reserves DDC0/DDC1 for PureSignal feedback so the operator's RX
@@ -1501,6 +1545,14 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
                 }
                 catch (SocketException ex) when (ex.SocketErrorCode == SocketError.TimedOut)
                 {
+                    continue;
+                }
+                catch (SocketException ex) when (ex.SocketErrorCode == SocketError.ConnectionReset)
+                {
+                    // Windows WSAECONNRESET (10054): a prior SendTo provoked an ICMP
+                    // port-unreachable and Windows surfaces it on the next recv.
+                    // Linux silently discards this; without the catch here the IQ
+                    // loop dies on the first stray ICMP → frozen panadapter.
                     continue;
                 }
                 catch (SocketException ex) when (ex.SocketErrorCode == SocketError.Interrupted


### PR DESCRIPTION
Brings the Windows multi-NIC fix that Ramon merged to **experimental** (#576) up against **develop** so it can ride the normal release path.

This is a cherry-pick of the single fix commit from #576 onto a clean branch off develop — it carries **only** the multi-NIC fix, none of experimental's other divergence.

## What it fixes

On a Windows host with multiple network adapters (VPN, Hyper-V/WSL vEthernet, Wi-Fi + Ethernet), the P2 data socket bound to `IPAddress.Any` would let Windows route outbound command packets through the wrong NIC, so the radio streamed DDC IQ back to an address nobody was listening on — **blank panadapter**. Windows also converts ICMP port-unreachable replies into `SocketException` 10054 on the next `ReceiveFrom`, which was silently killing the IQ receive loop and the discovery loops.

**Bug 1 — wrong bind address:** `ConnectAsync` now uses `FindLocalAddressForSubnet` to bind to the local IPv4 of the NIC whose subnet contains the radio IP, falling back to `IPAddress.Any` when there's no subnet match (single-NIC hosts, radio behind a router).

**Bug 2 — WSAECONNRESET 10054:** `DisableUdpConnReset` calls the `SIO_UDP_CONNRESET` ioctl (Windows-only, best-effort) on every UDP socket after creation, plus a `ConnectionReset` catch in the P2 IQ receive loop and both discovery loops as belt-and-suspenders.

## Scope

- `Zeus.Protocol2/Protocol2Client.cs` — bind fix, ioctl helper, `FindLocalAddressForSubnet`
- `Zeus.Protocol2/Discovery/RadioDiscoveryService.cs` — `ConnectionReset` fallback
- `Zeus.Protocol1/Discovery/RadioDiscoveryService.cs` — `ConnectionReset` fallback

## Notes

- Mac/Linux paths are unaffected (the ioctl is Windows-only and gated; the bind change is a no-op when there's no subnet match).
- Original work: #574 / #576 (kb2uka-agent), merged to experimental by @rampa069.
- Builds clean against develop (`dotnet build Zeus.slnx`).

Per repo convention this is **left open for KB2UKA's review/merge** — do not merge without confirmation.