### PR TITLE
feat(rpi): headless deployment for Raspberry Pi 4 (arm64)

### DIFF
--- a/docs/lessons/raspberry-pi-deployment.md
+++ b/docs/lessons/raspberry-pi-deployment.md
@@ -1,0 +1,109 @@
+# Deploying Zeus headless on a Raspberry Pi 4
+
+Zeus runs on a Raspberry Pi 4 (arm64) as a headless radio server — .NET
+backend on one end, HL2 on the other, browser UI served over the LAN.
+The `libwdsp.so` ARM64 binary already ships in the repo
+(`Zeus.Dsp/runtimes/linux-arm64/native/`); no native compilation is needed.
+
+Verified on: **Raspberry Pi 4 (4 GB), Debian 13 (trixie) arm64**, kernel
+6.12, Ethernet, HL2 connected on the same LAN segment.
+
+---
+
+## One-command deploy (from your Mac/Linux dev machine)
+
+```bash
+# Full build + deploy to the Pi
+bash installers/deploy-rpi.sh emu-agon.local
+
+# Build locally only (produces publish-rpi/ in the repo root)
+bash installers/deploy-rpi.sh emu-agon.local --build-only
+
+# Re-deploy an existing bundle (skip publish step)
+bash installers/deploy-rpi.sh emu-agon.local --deploy-only
+```
+
+The script:
+1. Builds the frontend into `wwwroot` (`npm run build`)
+2. Runs `dotnet publish -r linux-arm64 --self-contained`
+3. Checks / installs `libfftw3-double3` on the Pi via SSH
+4. `rsync`s the bundle to `~/zeus-rpi/` on the Pi
+
+The bundle is **self-contained** — no `.NET` install needed on the Pi.
+
+---
+
+## Starting Zeus on the Pi
+
+```bash
+ssh rampa@emu-agon.local
+ZEUS_PORT=6060 ~/zeus-rpi/OpenhpsdrZeus
+```
+
+Then open `http://<pi-ip>:6060` in any browser on the LAN.
+
+First launch regenerates the WDSP FFTW wisdom cache (`~/.local/share/Zeus/`).
+This takes a few minutes; subsequent starts are instant.
+
+---
+
+## Pi OS requirements
+
+- **64-bit OS mandatory** — `linux-arm64` does not run on 32-bit Raspberry
+  Pi OS. Use Raspberry Pi OS 64-bit or Debian arm64 (trixie or later).
+- **`libfftw3-double3`** — the only runtime dependency not bundled.
+  On Debian 13 it is usually pre-installed; the deploy script installs it
+  if missing.
+
+```bash
+sudo apt-get install -y libfftw3-double3
+```
+
+---
+
+## HL2 discovery with multiple network interfaces (load-bearing)
+
+HPSDR Protocol 1 discovery sends a **UDP broadcast** to find the HL2.
+When the Pi has **both WiFi and Ethernet active**, the broadcast goes out
+whichever interface owns the default route — usually WiFi — and never
+reaches the HL2 if it's on the Ethernet segment.
+
+**Symptom:** the radio does not appear in Zeus's discovery list. Connecting
+manually (entering the HL2's IP directly) works because unicast routes
+correctly regardless of interface.
+
+**Fix — disable WiFi while using Ethernet:**
+
+```bash
+sudo ip link set wlan0 down    # discovery now goes out eth0
+```
+
+To restore:
+
+```bash
+sudo ip link set wlan0 up
+```
+
+To make it permanent across reboots, add to `/etc/network/interfaces` or
+disable WiFi via `raspi-config` → System Options → Wireless LAN → disable.
+
+---
+
+## Desktop (Photino) mode
+
+Photino on `linux-arm64` requires `libwebkit2gtk` and a display. On a
+headless Pi this is impractical. **Always run without the `--desktop` flag**
+(web/service mode). The browser is the UI.
+
+---
+
+## Performance notes (RPi 4 4 GB)
+
+| Scenario | CPU (observed) |
+|---|---|
+| Idle, no radio connected | < 5 % |
+| RX 48 kHz, 1 DDC, WDSP | ~15–25 % |
+| RX 192 kHz | ~30–40 % (estimate) |
+
+NR4 (libspecbleach / SBNR) is included in the prebuilt `libwdsp.so`.
+PureSignal at 192 kHz is untested on RPi 4 — likely marginal.

--- a/installers/deploy-rpi.sh
+++ b/installers/deploy-rpi.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# deploy-rpi.sh — build Zeus for Raspberry Pi 4 (linux-arm64) and deploy to the Pi.
+#
+# Usage:
+#   ./installers/deploy-rpi.sh <pi-host>             # e.g. emu-agon.local or 192.168.86.24
+#   ./installers/deploy-rpi.sh <pi-host> --build-only  # publish locally, skip rsync
+#   ./installers/deploy-rpi.sh <pi-host> --deploy-only # skip publish, rsync existing bundle
+#
+# Requirements:
+#   Local: .NET 10 SDK, npm
+#   Pi:    Debian/Raspberry Pi OS 64-bit (arm64), libfftw3-double3
+#          (installed automatically by this script on first run)
+#
+# The produced bundle is self-contained — .NET runtime is included, no dotnet
+# install needed on the Pi. Zeus runs headless (web mode); open a browser at
+# http://<pi-ip>:6060 to connect.
+#
+# Discovery gotcha: if the Pi has both WiFi and Ethernet active, HPSDR
+# UDP broadcast discovery goes out the default-route interface (usually WiFi).
+# The HL2 won't be found automatically. Fix:
+#   ssh rampa@<pi> "sudo ip link set wlan0 down"
+# Connect manually instead, or keep WiFi disabled while using Ethernet.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PUBLISH_DIR="${REPO_ROOT}/publish-rpi"
+PI_HOST="${1:-}"
+MODE="full"
+
+if [ -z "${PI_HOST}" ]; then
+    echo "Usage: $0 <pi-host> [--build-only|--deploy-only]"
+    exit 1
+fi
+
+for arg in "${@:2}"; do
+    case "${arg}" in
+        --build-only)  MODE=build  ;;
+        --deploy-only) MODE=deploy ;;
+    esac
+done
+
+# ── 1. Build frontend + dotnet publish ───────────────────────────────────────
+if [ "${MODE}" != "deploy" ]; then
+    echo "==> Building frontend..."
+    npm --prefix "${REPO_ROOT}/zeus-web" run build
+
+    echo "==> Publishing OpenhpsdrZeus for linux-arm64 (self-contained)..."
+    rm -rf "${PUBLISH_DIR}"
+    dotnet publish "${REPO_ROOT}/OpenhpsdrZeus" \
+        -c Release \
+        -r linux-arm64 \
+        --self-contained \
+        -o "${PUBLISH_DIR}"
+    echo "==> Bundle ready at ${PUBLISH_DIR} ($(du -sh "${PUBLISH_DIR}" | cut -f1))"
+fi
+
+if [ "${MODE}" = "build" ]; then
+    echo "Build-only mode — skipping deploy."
+    echo "Copy manually: rsync -az ${PUBLISH_DIR}/ rampa@<pi>:~/zeus-rpi/"
+    exit 0
+fi
+
+# ── 2. Ensure libfftw3-double3 on the Pi ─────────────────────────────────────
+echo "==> Checking Pi dependencies..."
+ssh "rampa@${PI_HOST}" \
+    "dpkg -s libfftw3-double3 &>/dev/null || sudo apt-get install -y libfftw3-double3" \
+    2>/dev/null && echo "    libfftw3-double3 OK"
+
+# ── 3. Rsync bundle to Pi ────────────────────────────────────────────────────
+echo "==> Deploying to rampa@${PI_HOST}:~/zeus-rpi/ ..."
+rsync -az --delete --progress \
+    "${PUBLISH_DIR}/" \
+    "rampa@${PI_HOST}:~/zeus-rpi/"
+
+# ── 4. Make executable ───────────────────────────────────────────────────────
+ssh "rampa@${PI_HOST}" "chmod +x ~/zeus-rpi/OpenhpsdrZeus"
+
+# ── Done ─────────────────────────────────────────────────────────────────────
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Deployed to ${PI_HOST}"
+echo ""
+echo "  To start Zeus on the Pi:"
+echo "    ssh rampa@${PI_HOST}"
+echo "    ZEUS_PORT=6060 ~/zeus-rpi/OpenhpsdrZeus"
+echo ""
+echo "  Then open: http://${PI_HOST}:6060"
+echo ""
+echo "  If discovery doesn't find the HL2 (WiFi+Ethernet active):"
+echo "    sudo ip link set wlan0 down"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
Adds a one-command deploy script and a deployment guide for running Zeus headless on a Raspberry Pi 4.

## What's included

**`installers/deploy-rpi.sh`**
- Builds frontend (`npm run build`) + `dotnet publish -r linux-arm64 --self-contained`
- Checks/installs `libfftw3-double3` on the Pi via SSH
- `rsync`s the bundle to `~/zeus-rpi/`
- Modes: full (default), `--build-only`, `--deploy-only`

**`docs/lessons/raspberry-pi-deployment.md`**
- OS requirements (64-bit mandatory)
- One-command deploy recipe
- First-run wisdom generation note
- **Load-bearing gotcha: WiFi + Ethernet discovery** — HPSDR UDP broadcast goes out the default-route interface (WiFi); disable `wlan0` for clean HL2 discovery on Ethernet

## Verified on

- Raspberry Pi 4 (4 GB), Debian 13 (trixie) arm64, kernel 6.12
- Hermes-Lite 2, Ethernet, ZEUS_PORT=6060 headless
- `libwdsp.so` arm64 already ships in `Zeus.Dsp/runtimes/linux-arm64/native/` — no native build needed on the Pi
- Self-contained bundle: no .NET install required on the Pi

No code changes — script + docs only.

Refs zeus-i4r.