### PR TITLE
fix(test): bump AddPanelModal panel count 20 → 21 after WAV recorder

### DIFF
--- a/zeus-web/src/layout/__tests__/AddPanelModal.test.tsx
+++ b/zeus-web/src/layout/__tests__/AddPanelModal.test.tsx
@@ -55,9 +55,10 @@ describe('AddPanelModal', () => {
     const cards = container.querySelectorAll(
       '[data-testid="add-panel-cards"] .add-panel-card',
     );
-    // 20 panels in registry (CW Decoder added in zeus-cdn; RF-2K panel was
-    // extracted to a plugin; Rotator Dial was added in #385).
-    expect(cards.length).toBe(20);
+    // 21 panels in registry (CW Decoder added in zeus-cdn; RF-2K panel was
+    // extracted to a plugin; Rotator Dial was added in #385; WAV recorder
+    // added in #579).
+    expect(cards.length).toBe(21);
     unmount();
   });
 


### PR DESCRIPTION
`develop` is red on the frontend test suite. PR #579 (WAV recorder + player) added the recorder panel to the registry but did not update the hard-coded count assertion in `AddPanelModal.test.tsx`, which still expected 20:

```
AssertionError: expected 21 to be 20
❯ src/layout/__tests__/AddPanelModal.test.tsx:60:26
```

One-line fix: bump the expected count to 21 to match the registry. Comment updated to record the WAV recorder addition.

Verified locally:
```
✓ src/layout/__tests__/AddPanelModal.test.tsx (7 tests)
Test Files  1 passed (1)
```

Unblocks every open PR targeting `develop` (including #580 linux-arm64).