### PR TITLE
fix(ps): wedge watchdog recovers in ~5s, not ~37s

### DIFF
--- a/Zeus.Server.Hosting/PsAutoAttenuateService.cs
+++ b/Zeus.Server.Hosting/PsAutoAttenuateService.cs
@@ -260,6 +260,10 @@ public sealed class PsAutoAttenuateService : BackgroundService
     private void ClearStallFlag()
     {
         _stallStartTickMs = 0;
+        // Clear wedge-watchdog tracking on every idle/disarm/unkey exit so the
+        // freeze clock starts fresh on the next key-up — a frozen info5 from a
+        // prior over must not count toward a wedge against the new transmission.
+        _lastWedgeCal = -1;
         if (_stallWarned)
         {
             _stallWarned = false;
@@ -425,29 +429,35 @@ public sealed class PsAutoAttenuateService : BackgroundService
         // correction away, holding IMD ~10 dB worse than a stable curve (#559).
         // Also skip when we've deliberately locked the correction (_psHeld →
         // SetPSRunCal(0)): calcc is parked on purpose, info5 frozen by design.
+        // Run the info5 freeze CLOCK on every armed+keyed tick, INDEPENDENT of
+        // CalState. Previously the clock lived inside the `calState in 4..7`
+        // gate with an `else { _lastWedgeCal = -1; }`, so a wedged calcc that
+        // flickered between LCALC(6) and a transient WAIT state reset the clock
+        // on every re-entry to the compute states — the freeze never accumulated
+        // StallThreshold and recovery dragged out (~37 s observed instead of ~5).
         var calState = stallPsm.CalState;
-        if (s.PsAuto && !s.PsSingle && !_psHeld && stallPsm.CalibrationAttempts > 0
-            && calState >= 4 && calState <= 7)
+        long nowW = Environment.TickCount64;
+        if (stallPsm.CalibrationAttempts != _lastWedgeCal)
         {
-            long now = Environment.TickCount64;
-            if (stallPsm.CalibrationAttempts != _lastWedgeCal)
-            {
-                _lastWedgeCal = stallPsm.CalibrationAttempts;
-                _lastWedgeCalChangeMs = now;
-            }
-            else if (now - _lastWedgeCalChangeMs >= (long)StallThreshold.TotalMilliseconds
-                     && now - _lastWedgeResetMs >= (long)StallThreshold.TotalMilliseconds)
-            {
-                _lastWedgeResetMs = now;
-                _log.LogWarning(
-                    "psAutoAttn.wedge info5 frozen at {Cal} state={State} for {ElapsedMs}ms — calcc stalled (e.g. PS toggled mid-TX); resetting calcc.",
-                    stallPsm.CalibrationAttempts, stallPsm.CalState, now - _lastWedgeCalChangeMs);
-                engine.ResetPs();
-            }
+            _lastWedgeCal = stallPsm.CalibrationAttempts;
+            _lastWedgeCalChangeMs = nowW;
         }
-        else
+        // FIRE only in the active compute states (LCOLLECT=4..LDELAY=7). Per
+        // #559, resetting while calcc is parked in a WAIT state (0..3) is futile
+        // (it just re-enters LWAIT) and destructive (tears down the live
+        // correction) — so the clock runs always, but the reset stays gated to
+        // compute states, in auto mode, on a non-zero frozen info5, rate-limited.
+        else if (s.PsAuto && !s.PsSingle && !_psHeld
+                 && stallPsm.CalibrationAttempts > 0
+                 && calState >= 4 && calState <= 7
+                 && nowW - _lastWedgeCalChangeMs >= (long)StallThreshold.TotalMilliseconds
+                 && nowW - _lastWedgeResetMs >= (long)StallThreshold.TotalMilliseconds)
         {
-            _lastWedgeCal = -1;
+            _lastWedgeResetMs = nowW;
+            _log.LogWarning(
+                "psAutoAttn.wedge info5 frozen at {Cal} state={State} for {ElapsedMs}ms — calcc stalled (e.g. PS toggled mid-TX); resetting calcc.",
+                stallPsm.CalibrationAttempts, stallPsm.CalState, nowW - _lastWedgeCalChangeMs);
+            engine.ResetPs();
         }
 
         // NOTE (#559): converge-then-hold (TickPsHold) is intentionally NOT


### PR DESCRIPTION
## Problem
On a PS off→on re-arm followed by key-up, calcc came up wedged (`info5` frozen, state 4) and the wedge watchdog took **~37 s** to reset it — the TX was dirty/splattering that whole window. Observed on the G2 (P2) this session.

## Root cause
The info5 freeze-clock was tracked *inside* the `calState in 4..7` gate, with an `else { _lastWedgeCal = -1; }`. A wedged calcc that flickers between LCALC(6) and a transient WAIT state reset the freeze clock on every re-entry to the compute states, so the freeze never accumulated `StallThreshold` (5 s) and recovery dragged out.

## Fix
- Run the info5 freeze clock on **every armed+keyed tick, independent of CalState** — flicker can't reset it.
- Keep the **reset gated to compute states 4..7** (auto mode, non-zero frozen info5, rate-limited), so the #559 protection — never reset while calcc is parked in a WAIT state (futile + destructive) — is fully preserved.
- Clear wedge tracking in `ClearStallFlag` (called on every idle/disarm/unkey exit) so a frozen info5 from a prior over can't count against the next key-up.

Recovery window drops from ~37 s to ~5 s. Does not address *why* calcc stalls on re-arm (the root cause) — that's a separate follow-up; this shrinks the dirty window the watchdog leaves behind.

## Testing
- `dotnet build Zeus.slnx` clean.
- **Bench-verified on the ANAN-G2 (KB2UKA):** reproduced the off→on→key-up stall; watchdog now recovers quickly, dirty window brief.