### PR TITLE
Update Protocol2Client.cs to allow connection to a G2, Zeus back end also running on the G2

### DIFF
--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -314,6 +314,7 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
 
         _radioEndpoint = new IPEndPoint(radioEndpoint.Address, 1024);
         var sock = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        sock.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
         // Matched port convention — PC binds 1025, radio sends back with source
         // ports 1025/1026/1027/1035.. which we demux by fromaddr.
         sock.Bind(new IPEndPoint(IPAddress.Any, 1025));


### PR DESCRIPTION
When both Zeus back end and p2app run native on a G2 as Linux host, the socket needs to be (re-)usable by both apps. This requires setting of option ReuseAddress. Without it an exception gets thrown of socket address already occupied.