### PR TITLE
fix(macos): add device.audio-input entitlement so signed builds can use the mic

### DIFF
--- a/installers/zeus-macos.entitlements
+++ b/installers/zeus-macos.entitlements
@@ -35,11 +35,23 @@
                                        SetRXAEMNRpost2*). See create-macos-app.sh
                                        launch.sh block + docs/lessons/dev-conventions.md.
 
-  Microphone / camera access is NOT declared here: those entitlements only apply
-  inside the App Sandbox. Outside the sandbox the TCC prompt is driven by
-  NSMicrophoneUsageDescription / NSCameraUsageDescription in each bundle's Info.plist
-  (set by create-macos-app.sh). Adding sandbox-only entitlements to a non-sandboxed
-  app is silently ignored, but adds noise — keep this file tight.
+  - device.audio-input                 REQUIRED for desktop-mode mic TX uplink
+                                       (NativeMicCapture → miniaudio). Under the
+                                       Hardened Runtime a non-sandboxed app needs
+                                       `com.apple.security.device.audio-input` to
+                                       open the microphone — the TCC Privacy →
+                                       Microphone grant alone is NOT enough; the
+                                       system blocks capture without this entitlement
+                                       even with the toggle on. This is the Hardened-
+                                       Runtime capability and IS honoured outside the
+                                       sandbox — distinct from the App-Sandbox
+                                       `com.apple.security.device.microphone` key,
+                                       which would be ignored here. Missing this is
+                                       why signed/notarized builds couldn't hear the
+                                       mic while `dotnet run` (un-hardened, inherits
+                                       Terminal's grant) could. The TCC prompt itself
+                                       is still driven by NSMicrophoneUsageDescription
+                                       in each bundle's Info.plist (create-macos-app.sh).
 -->
 <plist version="1.0">
 <dict>
@@ -50,6 +62,8 @@
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
     <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
     <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Problem
On macOS, signed + notarized builds (release **and** nightly) couldn't use the microphone for the desktop-mode TX uplink — even with **Privacy → Microphone toggled ON** for the app. `dotnet run` builds worked, which masked it.

## Cause
Signed builds run under the **Hardened Runtime**. A non-sandboxed hardened app needs the **`com.apple.security.device.audio-input`** entitlement to open the mic; the TCC grant alone is not enough — the system blocks capture without the entitlement. The entitlements file omitted it on the (wrong) premise that mic entitlements are App-Sandbox-only. That holds for the sandbox key `com.apple.security.device.microphone`, but `device.audio-input` is the Hardened-Runtime capability and **is** required outside the sandbox.

`dotnet run` worked because it's un-hardened and inherits Terminal's mic grant — so this was latent in every signed build and only surfaced once desktop mic TX from a signed app was exercised.

## Fix
Add `com.apple.security.device.audio-input` to `installers/zeus-macos.entitlements` (and correct the misleading comment). Embeds at sign time → takes effect in the next signed **nightly/release**; a currently-installed build won't pick it up without a rebuild.

## Verification
- Built an **ad-hoc-signed hardened bundle** locally with the patched entitlements (`CODESIGN_IDENTITY=- create-macos-app.sh`) — builds + signs clean, entitlement embeds in the apphost + bundle.
- Reproduces standard Apple Hardened-Runtime behavior; the missing entitlement is the documented requirement for mic access on a notarized non-sandboxed app.