### PR TITLE
fix(ci): pin Windows native-lib jobs to windows-2022 runner

### DIFF
--- a/.github/workflows/build-native-libs.yml
+++ b/.github/workflows/build-native-libs.yml
@@ -14,7 +14,10 @@ on:
 jobs:
   build-windows:
     name: Build Windows Native Libraries
-    runs-on: windows-latest
+    # Pinned: windows-latest rolled past the VS 2022 image ~2026-06-10 and the
+    # 'Visual Studio 17 2022' generator below stopped resolving. Keep runner +
+    # generator in lockstep; bump both together.
+    runs-on: windows-2022
     strategy:
       matrix:
         # arm64 enabled: the _MM_SET_FLUSH_ZERO_MODE SSE-intrinsic block in

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,10 @@ jobs:
   build-native-windows:
     name: Build native WDSP (windows-${{ matrix.arch }})
     needs: determine-version
-    runs-on: windows-latest
+    # Pinned: windows-latest rolled past the VS 2022 image ~2026-06-10 and the
+    # 'Visual Studio 17 2022' generator below stopped resolving, killing every
+    # nightly. Keep runner + generator in lockstep; bump both together.
+    runs-on: windows-2022
     strategy:
       matrix:
         arch: [x64, arm64]


### PR DESCRIPTION
## What broke

Every nightly since **2026-06-10** has failed in `Build native WDSP (windows-x64)` → Configure CMake:

```
CMake Error at CMakeLists.txt:23 (project):
  Generator "Visual Studio 17 2022" could not find any instance of Visual Studio.
```

The `windows-latest` runner image rolled past VS 2022 (~06-10); our CMake invocations hardcode the `Visual Studio 17 2022` generator. Last good nightly: 2026-06-09 — built just before the image flip. Nothing merged since (incl. the in-tree FFTW fix #593) has shipped in a nightly.

## Fix

Pin `runs-on: windows-2022` in `release.yml` (build-native-windows) and `build-native-libs.yml` — restores exactly the environment that built clean on 06-09, keeping runner image and generator in lockstep. Comments at both sites say to bump them together.

Migrating to the new image's VS generator (and revalidating ClangCL + the static-CRT arm64 path there) can be a deliberate follow-up rather than a forced fire-drill.

Targets `main` because the scheduled nightly resolves `nightly.yml` → reusable `release.yml` from the default branch.

## Verification

Will manually dispatch the nightly after merge and confirm it goes green end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)