### PR TITLE
fix(ci): pin Windows native-lib jobs to windows-2022 runner (develop mirror)

### DIFF
--- a/.github/workflows/build-native-libs.yml
+++ b/.github/workflows/build-native-libs.yml
@@ -14,7 +14,10 @@ on:
 jobs:
   build-windows:
     name: Build Windows Native Libraries
-    runs-on: windows-latest
+    # Pinned: windows-latest rolled past the VS 2022 image ~2026-06-10 and the
+    # 'Visual Studio 17 2022' generator below stopped resolving. Keep runner +
+    # generator in lockstep; bump both together.
+    runs-on: windows-2022
     strategy:
       matrix:
         # arm64 enabled: the _MM_SET_FLUSH_ZERO_MODE SSE-intrinsic block in

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,10 @@ jobs:
   build-native-windows:
     name: Build native WDSP (windows-${{ matrix.arch }})
     needs: determine-version
-    runs-on: windows-latest
+    # Pinned: windows-latest rolled past the VS 2022 image ~2026-06-10 and the
+    # 'Visual Studio 17 2022' generator below stopped resolving, killing every
+    # nightly. Keep runner + generator in lockstep; bump both together.
+    runs-on: windows-2022
     strategy:
       matrix:
         arch: [x64, arm64]


### PR DESCRIPTION
Mirror of #595 (merged to main) onto develop. The scheduled nightly resolves workflows from main, so #595 fixed that — but manual `workflow_dispatch` dry-runs and `release/**` branch builds resolve from the dispatched branch, and develop's copy still says `windows-latest` (no VS 2022 → CMake generator failure). Same two-line pin, keeps the branches from drifting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)