### PR TITLE
feat(display): fast-attack RX display averaging on retune (#597 Phase 0)

### DIFF
--- a/Zeus.Dsp/IDspEngine.cs
+++ b/Zeus.Dsp/IDspEngine.cs
@@ -74,6 +74,19 @@ public interface IDspEngine : IDisposable
     void SetCtunShift(int channelId, int shiftHz);
     void SetAgcTop(int channelId, double topDb);
 
+    /// <summary>
+    /// Briefly tighten the RX display's averaging time-constant after a
+    /// retune so the spectrum settles at the new frequency in ~100 ms
+    /// instead of melting over ~300-400 ms (issue #597; Thetis parity —
+    /// display.cs fast-attacks its averaging after a center change). RX
+    /// display channel ONLY: the TX and PS-feedback analyzers keep their
+    /// own configured tau (TxAvgTauSec) untouched, so tuning while keyed
+    /// never disturbs the TX trace or the PureSignal monitor. Restoring
+    /// (<paramref name="fast"/> = false) re-applies the RX channel's
+    /// configured default tau. No-op on Synthetic.
+    /// </summary>
+    void SetRxDisplayFastAttack(int channelId, bool fast);
+
     /// <summary>Set the RX master AF gain in dB. Drives WDSP's
     /// <c>SetRXAPanelGain1</c> (linear) after a dB→linear conversion. 0 dB
     /// equals the engine's open-time default (linear 1.0). No-op on

--- a/Zeus.Dsp/SyntheticDspEngine.cs
+++ b/Zeus.Dsp/SyntheticDspEngine.cs
@@ -102,6 +102,8 @@ public sealed class SyntheticDspEngine : IDspEngine
 
     public void SetAgcTop(int channelId, double topDb) { /* synthetic has no AGC */ }
 
+    public void SetRxDisplayFastAttack(int channelId, bool fast) { /* synthetic has no display averaging */ }
+
     public void SetRxAfGainDb(int channelId, double db) { /* synthetic has no audio path */ }
 
     public void SetNoiseReduction(int channelId, NrConfig cfg)

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -538,6 +538,21 @@ public sealed class WdspDspEngine : IDspEngine
         NativeMethods.SetRXAShiftRun(channelId, shiftHz != 0 ? 1 : 0);
     }
 
+    public void SetRxDisplayFastAttack(int channelId, bool fast)
+    {
+        if (!_channels.TryGetValue(channelId, out var state)) return;
+        // RX display ONLY — channelId is the RXA channel whose analyzer was
+        // created in OpenChannel (XCreateAnalyzer(id, ...)). The TX analyzer
+        // (_txaChannelId) and PS-feedback analyzer keep TxAvgTauSec untouched,
+        // so a retune while keyed never disturbs the TX trace or PS monitor.
+        // AnalyzerLock mirrors SetZoom: SetDisplayAvBackmult races Spectrum0
+        // (worker) and GetPixels (pipeline tick) otherwise.
+        lock (state.AnalyzerLock)
+        {
+            ConfigureDisplayAveragingTau(channelId, fast ? FastAttackTauSec : DefaultAvgTauSec);
+        }
+    }
+
     public void SetAgcTop(int channelId, double topDb)
     {
         if (!_channels.TryGetValue(channelId, out var state)) return;
@@ -2657,6 +2672,12 @@ public sealed class WdspDspEngine : IDspEngine
     // Thetis-style smoothed envelope so the operator sees signal shape, not
     // every voiced/unvoiced transition.
     private const double TxAvgTauSec = 0.175;
+    // Issue #597 Phase 0: retune fast-attack tau. ~20 ms at 30 fps gives
+    // backmult ≈ exp(-1/(30·0.02)) ≈ 0.19 — the newest frame dominates, so
+    // post-retune content settles in ~3 ticks (~100 ms) instead of the
+    // 300-400 ms melt the 100 ms default produces. Mirrors Thetis's
+    // fast-attack after a display center change (display.cs:6360-6383).
+    private const double FastAttackTauSec = 0.020;
     private const int LogRecursiveMode = 3;
 
     private static void ConfigureDisplayAveraging(int disp)

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -289,6 +289,22 @@ public class DspPipelineService : BackgroundService,
     // see issue #81. volatile because MoxChanged fires on the caller's thread
     // and Tick reads from the pipeline thread.
     private volatile bool _keyed;
+    // Issue #597 Phase 0: display-EMA fast-attack latch. OnRadioStateChanged
+    // arms it when RadioLoHz moves (the operator is tuning) and Tick restores
+    // the default tau once the LO has been quiet for FastAttackRestoreMs.
+    // Debounced by design: one arm P/Invoke at gesture start, one restore
+    // P/Invoke at gesture end — NOT per wheel notch. Skipped entirely while
+    // _keyed so the TX display path is never touched (PS safety; the engine
+    // method is additionally scoped to the RX analyzer). long.MinValue
+    // sentinel suppresses the arm on the first state callback after connect.
+    // _fastAttackLastLoHz is only touched on the state-handler thread;
+    // _fastAttackLoChangedAt crosses to the RX thread via Interlocked.
+    private long _fastAttackLastLoHz = long.MinValue;
+    private long _fastAttackLoChangedAt;
+    private volatile bool _fastAttackActive;
+    private const int FastAttackRestoreMs = 250;
+    private static readonly long FastAttackRestoreTicks =
+        (long)(FastAttackRestoreMs / 1000.0 * Stopwatch.Frequency);
     // RX S-meter broadcast throttle. Pipeline ticks at 30 Hz; broadcasting
     // every 6 ticks = 5 Hz gives a smoother meter than Thetis's 4 Hz baseline
     // without spamming the WS (30 Hz dBm readouts add nothing a UI can use).
@@ -644,6 +660,24 @@ public class DspPipelineService : BackgroundService,
         // RadioService.SetRadioLo). See docs/prd/panfall_behavior.md.
         var p2 = _p2Client;
         p2?.SetVfoAHz(s.RadioLoHz);
+
+        // Issue #597 Phase 0: arm the RX display fast-attack when the LO
+        // moves. First callback after construction only records the LO
+        // (sentinel) so connect itself doesn't trigger a pointless arm.
+        if (_fastAttackLastLoHz == long.MinValue)
+        {
+            _fastAttackLastLoHz = s.RadioLoHz;
+        }
+        else if (s.RadioLoHz != _fastAttackLastLoHz)
+        {
+            _fastAttackLastLoHz = s.RadioLoHz;
+            Interlocked.Exchange(ref _fastAttackLoChangedAt, Stopwatch.GetTimestamp());
+            if (!_keyed && !_fastAttackActive)
+            {
+                Volatile.Read(ref _engine)?.SetRxDisplayFastAttack(Volatile.Read(ref _channelId), fast: true);
+                _fastAttackActive = true;
+            }
+        }
 
         // iter5 pass-2: lock-free engine pointer read. The lock previously
         // here only provided pointer atomicity (the engine.* calls below
@@ -1613,6 +1647,18 @@ public class DspPipelineService : BackgroundService,
         // when the user clicked Connect. The synthetic engine never produces
         // real-radio data, so suppressing it unconditionally is correct.
         if (engine is SyntheticDspEngine) return;
+
+        // Issue #597 Phase 0: restore the default display tau once the LO has
+        // been quiet for FastAttackRestoreMs. Runs on the RX/pipeline thread;
+        // the engine call is idempotent and channel-guarded, so a race with a
+        // simultaneous re-arm on the state thread is harmless (the re-arm
+        // refreshes _fastAttackLoChangedAt and the restore simply fires later).
+        if (_fastAttackActive &&
+            Stopwatch.GetTimestamp() - Interlocked.Read(ref _fastAttackLoChangedAt) >= FastAttackRestoreTicks)
+        {
+            engine.SetRxDisplayFastAttack(channel, fast: false);
+            _fastAttackActive = false;
+        }
 
         engine.SetVfoHz(channel, state.VfoHz);
 

--- a/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
@@ -179,6 +179,7 @@ public class MicGainEndpointTests : IClassFixture<MicGainEndpointTests.Factory>
         public void SetVfoHz(int channelId, long vfoHz) { }
         public void SetCtunShift(int channelId, int shiftHz) { }
         public void SetAgcTop(int channelId, double topDb) { }
+    public void SetRxDisplayFastAttack(int channelId, bool fast) { }
         public void SetRxAfGainDb(int channelId, double db) { }
         public void SetNoiseReduction(int channelId, NrConfig cfg) { }
         public void SetZoom(int channelId, int level) { }

--- a/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
+++ b/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
@@ -88,6 +88,7 @@ public class TxAudioIngestTests
         public void SetVfoHz(int channelId, long vfoHz) { }
         public void SetCtunShift(int channelId, int shiftHz) { }
         public void SetAgcTop(int channelId, double topDb) { }
+    public void SetRxDisplayFastAttack(int channelId, bool fast) { }
         public void SetRxAfGainDb(int channelId, double db) { }
         public void SetNoiseReduction(int channelId, NrConfig cfg) { }
         public void SetZoom(int channelId, int level) { }


### PR DESCRIPTION
Phase 0 of the #597 smooth-tuning stack (research findings: https://github.com/Kb2uka/openhpsdr-zeus/issues/597#issuecomment-4691893191). Ships independently of Phases 1-2.

## What

After a retune, the WDSP display averaging (100 ms EMA, never reset on LO change) keeps blending old-frequency energy into new pixel positions for ~300-400 ms — the visible "melt" after every tune step. Thetis fast-attacks its display averaging after a center change; Zeus had no equivalent.

- **`IDspEngine.SetRxDisplayFastAttack(channelId, fast)`** — WDSP impl re-runs `ConfigureDisplayAveragingTau` on the **RX analyzer only** with a 20 ms tau; restore re-applies the 100 ms default. Channel `AnalyzerLock` held (same rationale as `SetZoom`).
- **`DspPipelineService`** — arms when `RadioLoHz` moves, restores in `Tick` after 250 ms of LO quiet. Two P/Invokes per tuning gesture (debounced), not per wheel notch.

## PureSignal / TX safety

- Engine method is scoped to the RX display channel — the TX analyzer and PS-feedback analyzer keep `TxAvgTauSec` (0.175) untouched.
- The arm is **skipped entirely while keyed** (`_keyed`), so MOX/TUN tuning never even reaches the engine call.
- No changes on the PS cc/feedback path; the only Tick addition is a flag check + one stopwatch compare.

## Visible effect

Noise floor is livelier for ~250 ms after each tune (same as Thetis). Signals settle at the new frequency in ~100 ms instead of melting in over ~300-400 ms.

## Testing

- `dotnet test`: 865 passed, 0 failed
- Bench checklist before merge (KB2UKA): wheel-tune on G2 (P2) + HL2 (P1); tune-while-MOX'd on G2 — confirm TX trace texture unchanged

Part 1/3. Do not merge until the full stack is on-air tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)