### PR TITLE
feat(web): animated view-center — butter-smooth panadapter tuning (#597 Phase 1)

### DIFF
--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -195,7 +195,9 @@ export default function App() {
       try {
         const next = await fetchState(ctrl.signal);
         if (!cancelled) {
-          useConnectionStore.getState().applyState(next);
+          // trustVfo:false — a poll response generated before the operator's
+          // latest tune must not rewind the dial mid-gesture (issue #597).
+          useConnectionStore.getState().applyState(next, { trustVfo: false });
           // Hydrate persistable PS / TwoTone fields from the server's StateDto
           // so server-persisted edits (e.g. operator changed MOX delay on
           // another tab) reach this tab even after the initial connect-time

--- a/zeus-web/src/components/FreqAxis.tsx
+++ b/zeus-web/src/components/FreqAxis.tsx
@@ -112,9 +112,17 @@ export function FreqAxis() {
       }
       const marker = markerRef.current;
       if (marker) {
+        // The marker's distance from the zero line is the dial's settled
+        // offset from the display center: 0 outside CW, ±cw_pitch in
+        // CWU/CWL. Computing it as (vfo − commanded target) keeps the
+        // marker PINNED to the zero line during a glide (vfo and target
+        // move in lockstep at input time) instead of leading off it and
+        // easing back (operator feedback, 2026-06-12).
         const vfoHz = useConnectionStore.getState().vfoHz;
-        const startHz = view - spanHz / 2;
-        marker.style.left = `${((vfoHz - startHz) / spanHz) * 100}%`;
+        const dialOffsetHz = viewCenter.isInitialized()
+          ? vfoHz - viewCenter.getTargetCenterHz()
+          : vfoHz - layoutCenter;
+        marker.style.left = `${((spanHz / 2 + dialOffsetHz) / spanHz) * 100}%`;
       }
     };
     const schedule = () => requestDrawBusFrame(update);

--- a/zeus-web/src/components/FreqAxis.tsx
+++ b/zeus-web/src/components/FreqAxis.tsx
@@ -42,8 +42,11 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
+import { useEffect, useRef } from 'react';
 import { useDisplayStore } from '../state/display-store';
 import { useConnectionStore } from '../state/connection-store';
+import { cancelDrawBusFrame, requestDrawBusFrame } from '../realtime/draw-bus';
+import * as viewCenter from '../state/view-center';
 
 function pickStrideHz(spanHz: number, targetTicks: number): number {
   if (spanHz <= 0) return 1;
@@ -67,17 +70,69 @@ function formatMHz(hz: number, strideHz: number): string {
   return mhz.toFixed(6);
 }
 
-// Overlay rendered inside Panadapter's container. Positions ticks by
-// percentage of the total span so it stays aligned without measuring DOM
-// width: spanHz = panDb.length * hzPerPixel; centerHz is the radio's
-// physical LO and lands at 50%. The amber dial-marker line tracks
-// VfoHz, which equals centerHz outside CW and sits ±cw_pitch from
-// centre in CWU/CWL — in non-CW the marker stays at 50% (zero offset).
+// Overlay rendered inside Panadapter's container. Tick LABELS are laid out
+// by React at the 30 Hz frame rate (percentage of span around the frame's
+// centerHz, exactly as before); smooth horizontal MOTION between frames is
+// applied imperatively — a draw-bus callback translates the tick strip and
+// repositions the dial marker against the animated view-center
+// (state/view-center.ts), so motion runs at display rate with ZERO React
+// commits per display frame (issue #597; ticks are rigid under a pure pan).
+// The amber dial-marker line tracks VfoHz, which equals centerHz outside CW
+// and sits ±cw_pitch from centre in CWU/CWL.
 export function FreqAxis() {
   const centerHz = useDisplayStore((s) => s.centerHz);
   const hzPerPixel = useDisplayStore((s) => s.hzPerPixel);
-  const width = useDisplayStore((s) => s.panDb?.length ?? 0);
-  const vfoHz = useConnectionStore((s) => s.vfoHz);
+  // Header width — present even on frames whose pan payload is invalid, so
+  // the axis doesn't unmount during a brief invalid-frame run.
+  const width = useDisplayStore((s) => s.width);
+  // NOTE deliberately NO vfoHz selector: during a tuning gesture vfoHz
+  // updates at input rate and a selector here would re-render this
+  // component at display rate. The draw-bus callback reads it directly.
+
+  const tickStripRef = useRef<HTMLDivElement | null>(null);
+  const markerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const update = () => {
+      const s = useDisplayStore.getState();
+      if (!s.width || s.hzPerPixel <= 0) return;
+      const spanHz = s.width * s.hzPerPixel;
+      const layoutCenter = Number(s.centerHz);
+      const view = viewCenter.isInitialized()
+        ? viewCenter.getViewCenterHz()
+        : layoutCenter;
+      // Ticks were laid out around layoutCenter; sliding the strip by the
+      // layout→view fraction of its own width keeps every label at its true
+      // frequency. translateX(%) is relative to the element's own width,
+      // which equals the container width (inset-x-0).
+      const strip = tickStripRef.current;
+      if (strip) {
+        const fracPct = ((layoutCenter - view) / spanHz) * 100;
+        strip.style.transform = `translateX(${fracPct}%)`;
+      }
+      const marker = markerRef.current;
+      if (marker) {
+        const vfoHz = useConnectionStore.getState().vfoHz;
+        const startHz = view - spanHz / 2;
+        marker.style.left = `${((vfoHz - startHz) / spanHz) * 100}%`;
+      }
+    };
+    const schedule = () => requestDrawBusFrame(update);
+    const unsubVc = viewCenter.subscribe(schedule);
+    const unsubVfo = useConnectionStore.subscribe((s, prev) => {
+      if (s.vfoHz !== prev.vfoHz) schedule();
+    });
+    const unsubFrame = useDisplayStore.subscribe((s, prev) => {
+      if (s.lastSeq !== prev.lastSeq) schedule();
+    });
+    schedule();
+    return () => {
+      unsubVc();
+      unsubVfo();
+      unsubFrame();
+      cancelDrawBusFrame(update);
+    };
+  }, []);
 
   if (!width || hzPerPixel <= 0) return null;
 
@@ -86,10 +141,15 @@ export function FreqAxis() {
   const center = Number(centerHz);
   const startHz = center - spanHz / 2;
   const endHz = center + spanHz / 2;
-  const dialPct = ((vfoHz - startHz) / spanHz) * 100;
+  // Initial (pre-draw-bus) marker position; the callback refines it against
+  // the animated view-center on the next frame.
+  const dialPct =
+    ((useConnectionStore.getState().vfoHz - startHz) / spanHz) * 100;
 
-  const firstIdx = Math.ceil(startHz / stride);
-  const lastIdx = Math.floor(endHz / stride);
+  // Lay ticks out one full stride beyond each edge so a glide can't expose
+  // a label-less gap before the next 30 Hz relayout catches up.
+  const firstIdx = Math.ceil((startHz - stride) / stride);
+  const lastIdx = Math.floor((endHz + stride) / stride);
   const ticks: { hz: number; pct: number }[] = [];
   for (let i = firstIdx; i <= lastIdx; i++) {
     const hz = i * stride;
@@ -98,19 +158,24 @@ export function FreqAxis() {
 
   return (
     <>
-      <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-5 bg-neutral-950/70">
-        {ticks.map((t) => (
-          <div
-            key={t.hz}
-            className="absolute top-0 -translate-x-1/2 font-mono text-[10px] leading-none text-neutral-300"
-            style={{ left: `${t.pct}%` }}
-          >
-            <div className="mx-auto h-1.5 w-px bg-neutral-400" />
-            <div className="mt-0.5 px-1 whitespace-nowrap">
-              {formatMHz(t.hz, stride)}
+      {/* Outer strip: fixed background + overflow clip. Inner strip: the
+          tick content, slid by the draw-bus callback — so the background
+          never moves and overscanned ticks scroll in from the edges. */}
+      <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-5 overflow-hidden bg-neutral-950/70">
+        <div ref={tickStripRef} className="absolute inset-0">
+          {ticks.map((t) => (
+            <div
+              key={t.hz}
+              className="absolute top-0 -translate-x-1/2 font-mono text-[10px] leading-none text-neutral-300"
+              style={{ left: `${t.pct}%` }}
+            >
+              <div className="mx-auto h-1.5 w-px bg-neutral-400" />
+              <div className="mt-0.5 px-1 whitespace-nowrap">
+                {formatMHz(t.hz, stride)}
+              </div>
             </div>
-          </div>
-        ))}
+          ))}
+        </div>
       </div>
       {/*
         Dial-position marker — sits at VfoHz, which equals centerHz outside
@@ -119,6 +184,7 @@ export function FreqAxis() {
         accent blue + a 2px width to read clearly against the amber fill.
        */}
       <div
+        ref={markerRef}
         className="pointer-events-none absolute inset-y-0 z-[15] -translate-x-1/2"
         style={{ left: `${dialPct}%`, width: 2, background: 'var(--accent)' }}
       />

--- a/zeus-web/src/components/Panadapter.tsx
+++ b/zeus-web/src/components/Panadapter.tsx
@@ -44,10 +44,12 @@
 
 import { useEffect, useRef } from 'react';
 import { createPanRenderer, hexToRgbFloats } from '../gl/panadapter';
-import { planWaterfallUpdate } from '../gl/wf-shift';
+import { planForFrame } from '../gl/frame-plan';
 import { cancelDrawBusFrame, requestDrawBusFrame } from '../realtime/draw-bus';
 import { registerFrameConsumer, useDisplayStore } from '../state/display-store';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
+import { useConnectionStore } from '../state/connection-store';
+import * as viewCenter from '../state/view-center';
 import { useTxStore } from '../state/tx-store';
 import { usePanTuneGesture } from '../util/use-pan-tune-gesture';
 import { FreqAxis } from './FreqAxis';
@@ -77,17 +79,16 @@ export function Panadapter() {
     const releaseFrameConsumer = registerFrameConsumer();
 
     const renderer = createPanRenderer(gl);
-    // Mirror the waterfall's shift state so pan and wf agree on what a VFO
-    // retune does to the spectrum. On a 'shift' tick the waterfall suppresses
-    // its new row and shifts the old history (doc 08 §5); the panadapter
-    // shows the prior trace with the same x-offset so the two views line up.
-    // On 'push'/'reset' the offset is 0 and the freshest trace is drawn.
-    let lastPan: Float32Array | null = null;
-    let lastCenterHz: bigint | null = null;
-    let lastHzPerPixel = 0;
-    let lastWidth = 0;
-    let drawPan: Float32Array | null = null;
-    let drawOffsetPx = 0;
+    // Anchor model (issue #597): the adopted trace is pinned to the center
+    // frequency it was captured at; every draw renders it offset by
+    // (anchorCenterHz − viewCenterHz) in FRACTIONAL pixels. Server frames
+    // refresh the anchor content (outside the refill hold); the animated
+    // view-center — not frame arrival — drives all horizontal motion. The
+    // shift decision itself comes from the shared planner (gl/frame-plan.ts)
+    // so the waterfall can never disagree with the trace by a frame.
+    let anchorPan: Float32Array | null = null;
+    let anchorCenterHz = 0;
+    let anchorHzPerPixel = 0;
     // Visibility gating: don't burn rAF cycles when the tile is scrolled
     // off-screen, the tab is hidden, or the operator switched to a layout
     // where the panadapter isn't mounted-but-visible. Both signals are
@@ -97,7 +98,7 @@ export function Panadapter() {
     const isActive = () => inViewport && pageVisible;
 
     const redraw = () => {
-      if (!drawPan) return;
+      if (!anchorPan) return;
       const s = useDisplaySettingsStore.getState();
       // While keyed (MOX or TUN — server already feeds TX pixels via
       // DspPipelineService.Tick) use the TX-specific dB range so the
@@ -109,7 +110,13 @@ export function Panadapter() {
       const dbMax = keyed ? s.txDbMax : s.dbMax;
       const { r, g, b } = hexToRgbFloats(s.rxTraceColor);
       renderer.setTraceColor(r, g, b);
-      renderer.draw(drawPan, dbMin, dbMax, drawOffsetPx);
+      // Fractional offset — the shaders take a float uOffsetPx, so the
+      // glide is sub-pixel-smooth for free (issue #597).
+      const offsetPx =
+        anchorHzPerPixel > 0 && viewCenter.isInitialized()
+          ? (anchorCenterHz - viewCenter.getViewCenterHz()) / anchorHzPerPixel
+          : 0;
+      renderer.draw(anchorPan, dbMin, dbMax, offsetPx);
     };
     const requestRedraw = () => {
       if (!isActive()) return;
@@ -166,46 +173,57 @@ export function Panadapter() {
     const unsub = useDisplayStore.subscribe((state) => {
       if (state.lastSeq === lastSeqDrawn) return;
       lastSeqDrawn = state.lastSeq;
-      if (!state.panValid || !state.panDb) return;
-
-      const decision = planWaterfallUpdate({
-        lastCenterHz,
-        lastHzPerPixel,
-        lastWidth,
-        nextCenterHz: state.centerHz,
-        nextHzPerPixel: state.hzPerPixel,
-        nextWidth: state.panDb.length,
+      // The planner must see EVERY frame — including ones whose pan payload
+      // is invalid — so its tracker can never drift against the waterfall's
+      // view of the same stream (issue #597 dual-tracker divergence fix).
+      const decision = planForFrame({
+        seq: state.lastSeq,
+        centerHz: state.centerHz,
+        hzPerPixel: state.hzPerPixel,
+        width: state.width,
       });
+      const frameCenter = Number(state.centerHz);
 
-      switch (decision.kind) {
-        case 'reset':
-          drawPan = state.panDb;
-          drawOffsetPx = 0;
-          lastPan = state.panDb;
-          lastCenterHz = state.centerHz;
-          lastHzPerPixel = state.hzPerPixel;
-          lastWidth = state.panDb.length;
-          break;
-        case 'push':
-          drawPan = state.panDb;
-          drawOffsetPx = 0;
-          lastPan = state.panDb;
-          // lastCenterHz unchanged so sub-pixel retunes accumulate.
-          break;
-        case 'shift':
-          // Show the last pushed frame with the accumulated integer-pixel
-          // offset the waterfall has applied to its history — the post-shift
-          // top row and this trace land the same carriers in the same
-          // columns. Offset accumulates across consecutive shift ticks and
-          // resets on the next push (which updates lastPan to fresh data).
-          drawPan = lastPan ?? state.panDb;
-          drawOffsetPx += decision.shiftPx;
-          lastCenterHz = decision.residualCenterHz;
-          break;
+      if (decision.kind === 'reset') {
+        // Geometry changed (first frame / zoom / sample rate / width): the
+        // old anchor is meaningless. Snap the view — no glide — and adopt
+        // immediately; the refill hold doesn't apply across a reset.
+        viewCenter.snapTo(frameCenter, state.hzPerPixel);
+        if (state.panValid && state.panDb) {
+          anchorPan = state.panDb;
+          anchorCenterHz = frameCenter;
+          anchorHzPerPixel = state.hzPerPixel;
+        }
+      } else {
+        // push/shift: feed the frame center back to the view-center. With no
+        // recent operator gesture this recognises external tunes (CAT/TCI,
+        // band buttons, typed entry, mode changes) and glides there — which
+        // also arms the refill hold via the target-change stamp.
+        viewCenter.reconcileFrame(frameCenter, state.hzPerPixel);
+        // Adopt fresh trace content only once the analyzer has refilled with
+        // post-retune IQ. Inside the hold the previous anchor keeps gliding
+        // at its own (correct) frequency — old signals never get redrawn at
+        // the new axis, which was the snap-back half of the judder.
+        const holdMs = viewCenter.refillHoldMsForSampleRate(
+          useConnectionStore.getState().sampleRate,
+        );
+        if (
+          state.panValid &&
+          state.panDb &&
+          !viewCenter.isWithinRefillHold(holdMs)
+        ) {
+          anchorPan = state.panDb;
+          anchorCenterHz = frameCenter;
+          anchorHzPerPixel = state.hzPerPixel;
+        }
       }
 
       requestRedraw();
     });
+
+    // View-center motion → redraw at display rate while gliding. The
+    // subscription is silent when the tween loop is parked (zero idle cost).
+    const unsubViewCenter = viewCenter.subscribe(requestRedraw);
 
     // Repaint on dB-range / trace-color updates so auto-range and the Display
     // settings panel apply without waiting for the next server frame. The
@@ -238,6 +256,7 @@ export function Panadapter() {
 
     return () => {
       unsub();
+      unsubViewCenter();
       unsubSettings();
       unsubTx();
       ro.disconnect();

--- a/zeus-web/src/components/PassbandOverlay.tsx
+++ b/zeus-web/src/components/PassbandOverlay.tsx
@@ -80,11 +80,13 @@ export function PassbandOverlay() {
       const view = viewCenter.isInitialized()
         ? viewCenter.getViewCenterHz()
         : Number(s.centerHz);
-      // The passband hangs off the COMMANDED center (where the radio is
-      // heading), drawn in view-space: it glides exactly with the trace.
-      const passCenter = viewCenter.isInitialized()
-        ? viewCenter.getTargetCenterHz()
-        : Number(s.centerHz);
+      // The passband hangs off the VIEW center — which is, by definition,
+      // always rendered at the screen center (the orange zero line). So
+      // during a tuning glide the filter stays PINNED to the line while the
+      // spectrum slides underneath it; anchoring to the commanded target
+      // instead made it lead off the line and ease back (operator feedback,
+      // 2026-06-12).
+      const passCenter = view;
       const conn = useConnectionStore.getState();
       const startHz = view - spanHz / 2;
       const leftPct = ((passCenter + conn.filterLowHz - startHz) / spanHz) * 100;

--- a/zeus-web/src/components/PassbandOverlay.tsx
+++ b/zeus-web/src/components/PassbandOverlay.tsx
@@ -42,8 +42,11 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
+import { useEffect, useRef } from 'react';
 import { useDisplayStore } from '../state/display-store';
 import { useConnectionStore } from '../state/connection-store';
+import { cancelDrawBusFrame, requestDrawBusFrame } from '../realtime/draw-bus';
+import * as viewCenter from '../state/view-center';
 
 // Translucent rectangle drawn inside the panadapter container to show the
 // active receive filter passband, mapped from [filterLowHz, filterHighHz]
@@ -54,9 +57,68 @@ import { useConnectionStore } from '../state/connection-store';
 export function PassbandOverlay() {
   const centerHz = useDisplayStore((s) => s.centerHz);
   const hzPerPixel = useDisplayStore((s) => s.hzPerPixel);
-  const width = useDisplayStore((s) => s.panDb?.length ?? 0);
+  // Header width — survives frames whose pan payload is invalid.
+  const width = useDisplayStore((s) => s.width);
   const filterLowHz = useConnectionStore((s) => s.filterLowHz);
   const filterHighHz = useConnectionStore((s) => s.filterHighHz);
+
+  const rectRef = useRef<HTMLDivElement | null>(null);
+
+  // Smooth motion (issue #597): the rect is positioned against the animated
+  // view-center by a draw-bus callback — same clock as the trace, waterfall,
+  // dial marker, and tick strip, zero React commits at display rate. The
+  // passband rides the radio's center (filter edges are center-relative),
+  // so during a glide it eases with the spectrum instead of teleporting at
+  // 30 Hz frame arrival.
+  useEffect(() => {
+    const update = () => {
+      const rect = rectRef.current;
+      if (!rect) return;
+      const s = useDisplayStore.getState();
+      if (!s.width || s.hzPerPixel <= 0) return;
+      const spanHz = s.width * s.hzPerPixel;
+      const view = viewCenter.isInitialized()
+        ? viewCenter.getViewCenterHz()
+        : Number(s.centerHz);
+      // The passband hangs off the COMMANDED center (where the radio is
+      // heading), drawn in view-space: it glides exactly with the trace.
+      const passCenter = viewCenter.isInitialized()
+        ? viewCenter.getTargetCenterHz()
+        : Number(s.centerHz);
+      const conn = useConnectionStore.getState();
+      const startHz = view - spanHz / 2;
+      const leftPct = ((passCenter + conn.filterLowHz - startHz) / spanHz) * 100;
+      const rightPct = ((passCenter + conn.filterHighHz - startHz) / spanHz) * 100;
+      const widthPct = rightPct - leftPct;
+      const visible = widthPct > 0 && leftPct <= 100 && rightPct >= 0;
+      rect.style.display = visible ? '' : 'none';
+      if (visible) {
+        rect.style.left = `${leftPct}%`;
+        rect.style.width = `${widthPct}%`;
+      }
+    };
+    const schedule = () => requestDrawBusFrame(update);
+    const unsubVc = viewCenter.subscribe(schedule);
+    const unsubConn = useConnectionStore.subscribe((s, prev) => {
+      if (
+        s.filterLowHz !== prev.filterLowHz ||
+        s.filterHighHz !== prev.filterHighHz ||
+        s.vfoHz !== prev.vfoHz
+      ) {
+        schedule();
+      }
+    });
+    const unsubFrame = useDisplayStore.subscribe((s, prev) => {
+      if (s.lastSeq !== prev.lastSeq) schedule();
+    });
+    schedule();
+    return () => {
+      unsubVc();
+      unsubConn();
+      unsubFrame();
+      cancelDrawBusFrame(update);
+    };
+  }, []);
 
   if (!width || hzPerPixel <= 0) return null;
 
@@ -64,16 +126,18 @@ export function PassbandOverlay() {
   const center = Number(centerHz);
   const startHz = center - spanHz / 2;
 
+  // Initial (pre-draw-bus) geometry; the callback refines it next frame.
   const passLowHz = center + filterLowHz;
   const passHighHz = center + filterHighHz;
   const leftPct = ((passLowHz - startHz) / spanHz) * 100;
   const rightPct = ((passHighHz - startHz) / spanHz) * 100;
   const widthPct = rightPct - leftPct;
 
-  if (widthPct <= 0 || leftPct > 100 || rightPct < 0) return null;
+  if (widthPct <= 0) return null;
 
   return (
     <div
+      ref={rectRef}
       aria-hidden
       className="pointer-events-none absolute inset-y-0 z-[5]"
       style={{

--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -45,9 +45,12 @@
 import { useEffect, useRef } from 'react';
 import { COLORMAPS } from '../gl/colormap';
 import { createWfRenderer } from '../gl/waterfall';
+import { planForFrame } from '../gl/frame-plan';
 import { cancelDrawBusFrame, requestDrawBusFrame } from '../realtime/draw-bus';
 import { registerFrameConsumer, useDisplayStore } from '../state/display-store';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
+import { useConnectionStore } from '../state/connection-store';
+import * as viewCenter from '../state/view-center';
 import { useTxStore } from '../state/tx-store';
 import { usePanTuneGesture } from '../util/use-pan-tune-gesture';
 import { WfDbScale } from './WfDbScale';
@@ -58,6 +61,13 @@ import { WfDbScale } from './WfDbScale';
 // retunes stay synchronised with the panadapter's offset.
 // TODO(phase-3.1): expose as a UI setting.
 const WF_PUSH_EVERY_N = 2;
+// During the post-retune refill hold, fresh rows are partly computed from
+// pre-retune IQ and would smear old-frequency energy across the new axis —
+// suppress them. BUT a sustained drag restarts the hold forever, and a
+// frozen waterfall reads as broken; cap the withhold so at most this much
+// time passes between rows (rows-only cap — the pan trace stays clean and
+// frozen until the gesture pauses; adversary #3, issue #597).
+const WF_ROW_MAX_WITHHOLD_MS = 200;
 
 type WaterfallProps = {
   /** When true, noise floor fades to transparent so the QRZ-mode map shows through. */
@@ -113,7 +123,11 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       // window so the operator's RX noise-floor view stays put.
       const dbMin = keyed ? wfTxDbMin : wfDbMin;
       const dbMax = keyed ? wfTxDbMax : wfDbMax;
-      renderer.draw(dbMin, dbMax);
+      renderer.draw(
+        dbMin,
+        dbMax,
+        viewCenter.isInitialized() ? viewCenter.getViewCenterHz() : null,
+      );
     };
     const requestRedraw = () => {
       if (!isActive()) return;
@@ -159,20 +173,53 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
     };
     document.addEventListener('visibilitychange', onVisibilityChange);
 
+    let lastRowUploadAtMs = 0;
     const unsub = useDisplayStore.subscribe((state) => {
       if (state.lastSeq === lastSeqDrawn) return;
       lastSeqDrawn = state.lastSeq;
-      if (state.wfValid && state.wfDb) {
+      // Shared per-frame plan (issue #597): identical decision to the
+      // panadapter's, computed once per seq — and the geometry (shift/reset)
+      // applies even on frames whose wf payload is invalid, so the history
+      // can never drift against the trace.
+      const decision = planForFrame({
+        seq: state.lastSeq,
+        centerHz: state.centerHz,
+        hzPerPixel: state.hzPerPixel,
+        width: state.width,
+      });
+      const wfDb = state.wfValid && state.wfDb ? state.wfDb : null;
+      let skipRowUpload = false;
+      if (wfDb) {
         tickCounter++;
-        const skipRowUpload = tickCounter % WF_PUSH_EVERY_N !== 0;
-        renderer.pushFrame(state.wfDb, state.centerHz, state.hzPerPixel, {
-          skipRowUpload,
-        });
+        skipRowUpload = tickCounter % WF_PUSH_EVERY_N !== 0;
+        if (!skipRowUpload) {
+          // Refill hold: rows computed mid-retune carry old-frequency
+          // energy. Withhold them — but never longer than the cap, so a
+          // continuous drag keeps a (mildly smeared) waterfall flowing.
+          const holdMs = viewCenter.refillHoldMsForSampleRate(
+            useConnectionStore.getState().sampleRate,
+          );
+          const nowMs = performance.now();
+          if (
+            viewCenter.isWithinRefillHold(holdMs) &&
+            nowMs - lastRowUploadAtMs < WF_ROW_MAX_WITHHOLD_MS
+          ) {
+            skipRowUpload = true;
+          }
+          if (!skipRowUpload) lastRowUploadAtMs = nowMs;
+        }
         // Feed the auto-range tracker — it's a no-op when AUTO is off.
-        useDisplaySettingsStore.getState().updateAutoRange(state.wfDb);
+        useDisplaySettingsStore.getState().updateAutoRange(wfDb);
       }
+      renderer.pushFrame(decision, wfDb, state.centerHz, state.hzPerPixel, {
+        skipRowUpload,
+      });
       requestRedraw();
     });
+
+    // View-center motion → redraw at display rate while gliding (the
+    // fractional sampling offset in draw() moves the visible window).
+    const unsubViewCenter = viewCenter.subscribe(requestRedraw);
 
     // Repaint on dB-range or colormap changes so the WfDbScale drag and the
     // colormap swap land without waiting for the next server frame. Re-upload
@@ -211,6 +258,7 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
 
     return () => {
       unsub();
+      unsubViewCenter();
       unsubSettings();
       unsubTx();
       ro.disconnect();

--- a/zeus-web/src/gl/frame-plan.test.ts
+++ b/zeus-web/src/gl/frame-plan.test.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Unit tests for the shared per-frame shift planner (issue #597 Phase 1).
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { planForFrame, plannedDataCenterHz, _resetFramePlanForTest } from './frame-plan';
+
+const W = 2048;
+const HZPP = 93.75;
+
+beforeEach(() => {
+  _resetFramePlanForTest();
+});
+
+describe('frame-plan memoization', () => {
+  it('returns the identical decision object for repeat calls on one seq', () => {
+    const a = planForFrame({ seq: 1, centerHz: 14_200_000n, hzPerPixel: HZPP, width: W });
+    const b = planForFrame({ seq: 1, centerHz: 14_200_000n, hzPerPixel: HZPP, width: W });
+    expect(b).toBe(a); // reference equality — both surfaces see one decision
+  });
+
+  it('advances the tracker exactly once per seq', () => {
+    planForFrame({ seq: 1, centerHz: 14_200_000n, hzPerPixel: HZPP, width: W });
+    // Second consumer of seq 1 must not re-plan against the updated tracker.
+    planForFrame({ seq: 1, centerHz: 14_200_000n, hzPerPixel: HZPP, width: W });
+    const d = planForFrame({ seq: 2, centerHz: 14_200_500n, hzPerPixel: HZPP, width: W });
+    // 500 Hz / 93.75 ≈ 5.33 px → integer shift of 5
+    expect(d).toMatchObject({ kind: 'shift', shiftPx: -5 });
+  });
+});
+
+describe('frame-plan decision semantics (parity with the per-component trackers)', () => {
+  it('first frame is a reset and seeds the tracker', () => {
+    const d = planForFrame({ seq: 1, centerHz: 14_200_000n, hzPerPixel: HZPP, width: W });
+    expect(d.kind).toBe('reset');
+    expect(plannedDataCenterHz()).toBe(14_200_000n);
+  });
+
+  it('sub-pixel retunes accumulate across pushes (residual convention)', () => {
+    planForFrame({ seq: 1, centerHz: 14_200_000n, hzPerPixel: HZPP, width: W });
+    // +40 Hz: under half a pixel → push, tracker center unchanged
+    const d2 = planForFrame({ seq: 2, centerHz: 14_200_040n, hzPerPixel: HZPP, width: W });
+    expect(d2.kind).toBe('push');
+    expect(plannedDataCenterHz()).toBe(14_200_000n);
+    // another +40 Hz: now 80 Hz from the anchor ≈ 0.85 px → still push at
+    // round() < 1? 80/93.75 = 0.853 → round = 1 → shift of -1
+    const d3 = planForFrame({ seq: 3, centerHz: 14_200_080n, hzPerPixel: HZPP, width: W });
+    expect(d3.kind).toBe('shift');
+  });
+
+  it('geometry changes are resets', () => {
+    planForFrame({ seq: 1, centerHz: 14_200_000n, hzPerPixel: HZPP, width: W });
+    const dWidth = planForFrame({ seq: 2, centerHz: 14_200_000n, hzPerPixel: HZPP, width: W / 2 });
+    expect(dWidth.kind).toBe('reset');
+    const dZoom = planForFrame({ seq: 3, centerHz: 14_200_000n, hzPerPixel: HZPP / 2, width: W / 2 });
+    expect(dZoom.kind).toBe('reset');
+  });
+
+  it('a move ≥ the full span is a reset', () => {
+    planForFrame({ seq: 1, centerHz: 14_200_000n, hzPerPixel: HZPP, width: W });
+    const spanHz = BigInt(Math.round(W * HZPP));
+    const d = planForFrame({ seq: 2, centerHz: 14_200_000n + spanHz, hzPerPixel: HZPP, width: W });
+    expect(d.kind).toBe('reset');
+  });
+
+  it('the tracker advances on every seq — invalid-payload frames included', () => {
+    // The caller passes header fields regardless of pan/wf validity; two
+    // consumers calling in any order across valid/invalid frames see the
+    // same shift exactly once.
+    planForFrame({ seq: 1, centerHz: 14_200_000n, hzPerPixel: HZPP, width: W });
+    // "invalid" frame (no payload) still carries the retuned header:
+    const d2 = planForFrame({ seq: 2, centerHz: 14_201_000n, hzPerPixel: HZPP, width: W });
+    expect(d2.kind).toBe('shift');
+    // next frame at the same center: no double shift
+    const d3 = planForFrame({ seq: 3, centerHz: 14_201_000n, hzPerPixel: HZPP, width: W });
+    expect(d3.kind).toBe('push');
+  });
+});

--- a/zeus-web/src/gl/frame-plan.ts
+++ b/zeus-web/src/gl/frame-plan.ts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is an independent reimplementation in .NET — not a fork. Its
+// Protocol-1 / Protocol-2 framing, WDSP integration, meter pipelines, and
+// TX behaviour were informed by studying the Thetis project
+// (https://github.com/ramdor/Thetis), the authoritative reference
+// implementation in the OpenHPSDR ecosystem. Zeus gratefully acknowledges
+// the Thetis contributors whose work made this possible:
+//
+//   Richard Samphire (MW0LGE), Warren Pratt (NR0V),
+//   Laurence Barker (G8NJJ),   Rick Koch (N1GP),
+//   Bryan Rambo (W4WMT),       Chris Codella (W2PA),
+//   Doug Wigley (W5WC),        FlexRadio Systems,
+//   Richard Allen (W5SD),      Joe Torrey (WD5Y),
+//   Andrew Mansfield (M0YGG),  Reid Campbell (MI0BOT),
+//   Sigi Jetzlsperger (DH1KLM).
+//
+// Thetis itself continues the GPL-governed lineage of FlexRadio PowerSDR
+// and the OpenHPSDR (TAPR/OpenHPSDR) ecosystem; that lineage is preserved
+// here. See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
+// WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
+// (NR0V), distributed under GPL v2 or later.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+// Shared per-frame shift planner (issue #597 Phase 1).
+//
+// Before this module, Panadapter.tsx and createWfRenderer each kept their
+// own copy of the planner tracker (lastCenterHz / lastHzPerPixel /
+// lastWidth). The two copies were gated on DIFFERENT validity flags
+// (panValid vs wfValid), so when the flags disagreed across a retune tick
+// the two surfaces applied the same shift on different frames — a visible
+// one-frame horizontal disagreement between trace and waterfall.
+//
+// This module computes ONE decision per frame seq from the frame's header
+// fields (which are present regardless of pan/wf validity) and hands the
+// identical decision to every consumer. The tracker advances on every seq —
+// including frames whose payloads are invalid — so neither surface can
+// drift against the other.
+
+import { planWaterfallUpdate, type WfShiftDecision } from './wf-shift';
+
+let plannedSeq = -1;
+let plannedDecision: WfShiftDecision = { kind: 'reset', reason: 'first' };
+let lastCenterHz: bigint | null = null;
+let lastHzPerPixel = 0;
+let lastWidth = 0;
+
+export type FramePlanInput = {
+  seq: number;
+  centerHz: bigint;
+  hzPerPixel: number;
+  width: number;
+};
+
+/**
+ * Decision for frame `seq`. Memoized: the first caller for a given seq
+ * computes and advances the tracker; subsequent callers (same seq) get the
+ * identical decision back. Callers MUST invoke this for every frame they
+ * observe, in seq order — both spectrum components already subscribe to
+ * every store update, so this holds by construction.
+ */
+export function planForFrame(i: FramePlanInput): WfShiftDecision {
+  if (i.seq === plannedSeq) return plannedDecision;
+  const decision = planWaterfallUpdate({
+    lastCenterHz,
+    lastHzPerPixel,
+    lastWidth,
+    nextCenterHz: i.centerHz,
+    nextHzPerPixel: i.hzPerPixel,
+    nextWidth: i.width,
+  });
+  switch (decision.kind) {
+    case 'reset':
+      lastCenterHz = i.centerHz;
+      lastHzPerPixel = i.hzPerPixel;
+      lastWidth = i.width;
+      break;
+    case 'push':
+      // lastCenterHz intentionally unchanged so sub-pixel retunes accumulate
+      // (same convention as the original per-component trackers).
+      break;
+    case 'shift':
+      lastCenterHz = decision.residualCenterHz;
+      break;
+  }
+  plannedSeq = i.seq;
+  plannedDecision = decision;
+  return decision;
+}
+
+/** The center frequency the planner currently believes the on-screen data
+ *  is anchored at (post-shift residual). Null before the first frame. */
+export function plannedDataCenterHz(): bigint | null {
+  return lastCenterHz;
+}
+
+/** Test/reconnect hook — forget all tracker state so the next frame is a
+ *  clean 'reset'. */
+export function _resetFramePlanForTest(): void {
+  plannedSeq = -1;
+  plannedDecision = { kind: 'reset', reason: 'first' };
+  lastCenterHz = null;
+  lastHzPerPixel = 0;
+  lastWidth = 0;
+}

--- a/zeus-web/src/gl/panadapter.ts
+++ b/zeus-web/src/gl/panadapter.ts
@@ -132,6 +132,12 @@ export function createPanRenderer(gl: WebGL2RenderingContext): PanRenderer {
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
   let panTexWidth = 0;
+  // Issue #597: dataDirty elision. During a view-center glide the SAME
+  // adopted Float32Array is drawn many times with only the offset uniform
+  // changing — re-uploading the texture + VBO each tick is pure waste.
+  // Reference identity is the dirty signal: the component swaps the array
+  // reference only when it adopts fresh data.
+  let lastUploadedPan: Float32Array | null = null;
 
   const cursorProg = buildProgram(gl, CURSOR_VS, CURSOR_FS);
   const uCursorColor = gl.getUniformLocation(cursorProg, 'uColor');
@@ -157,34 +163,39 @@ export function createPanRenderer(gl: WebGL2RenderingContext): PanRenderer {
       gl.clear(gl.COLOR_BUFFER_BIT);
 
       // Upload pan dB into the 1-row R32F texture. texImage2D re-allocates on
-      // width change; texSubImage2D otherwise just streams the row.
+      // width change; texSubImage2D otherwise just streams the row. Skipped
+      // entirely when this exact array was already uploaded (motion-only
+      // redraw during a view-center glide — issue #597).
+      const dataDirty = panDb !== lastUploadedPan || panDb.length !== panTexWidth;
       gl.activeTexture(gl.TEXTURE0);
       gl.bindTexture(gl.TEXTURE_2D, panTex);
-      if (panDb.length !== panTexWidth) {
-        gl.texImage2D(
-          gl.TEXTURE_2D,
-          0,
-          gl.R32F,
-          panDb.length,
-          1,
-          0,
-          gl.RED,
-          gl.FLOAT,
-          panDb,
-        );
-        panTexWidth = panDb.length;
-      } else {
-        gl.texSubImage2D(
-          gl.TEXTURE_2D,
-          0,
-          0,
-          0,
-          panDb.length,
-          1,
-          gl.RED,
-          gl.FLOAT,
-          panDb,
-        );
+      if (dataDirty) {
+        if (panDb.length !== panTexWidth) {
+          gl.texImage2D(
+            gl.TEXTURE_2D,
+            0,
+            gl.R32F,
+            panDb.length,
+            1,
+            0,
+            gl.RED,
+            gl.FLOAT,
+            panDb,
+          );
+          panTexWidth = panDb.length;
+        } else {
+          gl.texSubImage2D(
+            gl.TEXTURE_2D,
+            0,
+            0,
+            0,
+            panDb.length,
+            1,
+            gl.RED,
+            gl.FLOAT,
+            panDb,
+          );
+        }
       }
 
       // Fill (premultiplied alpha to avoid halo on the glowing top edge).
@@ -210,8 +221,11 @@ export function createPanRenderer(gl: WebGL2RenderingContext): PanRenderer {
       if (traceBytes > traceCapacity) {
         gl.bufferData(gl.ARRAY_BUFFER, traceBytes, gl.STREAM_DRAW);
         traceCapacity = traceBytes;
+        gl.bufferSubData(gl.ARRAY_BUFFER, 0, panDb);
+      } else if (dataDirty) {
+        gl.bufferSubData(gl.ARRAY_BUFFER, 0, panDb);
       }
-      gl.bufferSubData(gl.ARRAY_BUFFER, 0, panDb);
+      lastUploadedPan = panDb;
       gl.uniform1f(uTraceWidth, panDb.length);
       gl.uniform1f(uTraceDbMin, dbMin);
       gl.uniform1f(uTraceDbMax, dbMax);

--- a/zeus-web/src/gl/shaders.ts
+++ b/zeus-web/src/gl/shaders.ts
@@ -121,13 +121,26 @@ uniform float uDbMax;
 uniform float uWriteRow;
 uniform float uH;
 uniform float uBgAlpha;
+// Issue #597: fractional view offset in UV units —
+// (historyCenterHz − viewCenterHz) / spanHz. The history texture itself is
+// only rebased in integer pixels (ping-pong shift); this term slides the
+// SAMPLING window fractionally so the waterfall glides with the animated
+// view-center between rebases. Same sign convention as WF_SHIFT_FS's
+// uShiftUv: positive slides displayed content right. Columns the slide
+// exposes fall back to uSeedDb (noise-floor colour), matching the shift
+// pass convention.
+uniform float uViewOffsetUv;
+uniform float uSeedDb;
 out vec4 fragColor;
 void main() {
   // vUv.y == 1.0 at top of canvas; newest row sits at the top.
   // row = (writeRow - (1 - vUv.y) * H) mod H, normalised.
   float agePx = (1.0 - vUv.y) * uH;
   float row = mod(uWriteRow - agePx + uH, uH);
-  float v = texture(uHistory, vec2(vUv.x, (row + 0.5) / uH)).r;
+  float srcX = vUv.x - uViewOffsetUv;
+  float v = (srcX < 0.0 || srcX > 1.0)
+    ? uSeedDb
+    : texture(uHistory, vec2(srcX, (row + 0.5) / uH)).r;
   float n = clamp((v - uDbMin) / (uDbMax - uDbMin), 0.0, 1.0);
   vec4 c = texture(uLut, vec2(n, 0.5));
   // uBgAlpha=1 → fully opaque (normal mode). uBgAlpha=0 → noise floor is

--- a/zeus-web/src/gl/waterfall.ts
+++ b/zeus-web/src/gl/waterfall.ts
@@ -62,7 +62,7 @@
 import { buildProgram } from './util';
 import { WF_VS, WF_FS, WF_SHIFT_FS } from './shaders';
 import { lutFor, type ColormapId } from './colormap';
-import { planWaterfallUpdate } from './wf-shift';
+import type { WfShiftDecision } from './wf-shift';
 
 const HISTORY_ROWS = 512;
 const SEED_DB = -200;
@@ -76,13 +76,23 @@ export type PushOptions = {
 
 export type WfRenderer = {
   resize: (w: number, h: number) => void;
+  /** Apply the shared per-frame plan (issue #597: the decision is computed
+   *  once in gl/frame-plan.ts and handed to both spectrum surfaces so they
+   *  can never disagree). `wfDb` may be null on frames whose waterfall
+   *  payload is invalid — geometry (shift/reset) still applies so the
+   *  history stays aligned with the panadapter. */
   pushFrame: (
-    wfDb: Float32Array,
+    decision: WfShiftDecision,
+    wfDb: Float32Array | null,
     centerHz: bigint,
     hzPerPixel: number,
     options?: PushOptions,
   ) => void;
-  draw: (dbMin: number, dbMax: number) => void;
+  /** Draw the history. `viewCenterHz` is the animated view-center; when
+   *  non-null the sampling window slides by the fractional offset between
+   *  the history's anchor center and the view (issue #597). Null renders
+   *  with zero offset (pre-first-frame / tests). */
+  draw: (dbMin: number, dbMax: number, viewCenterHz?: number | null) => void;
   setColormap: (id: ColormapId) => void;
   /** 1.0 = opaque (default). 0.0 = noise floor fades to transparent so a
    *  background layer (e.g. the QRZ-mode Leaflet map) shows through. */
@@ -107,6 +117,8 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
   const uWriteRow = gl.getUniformLocation(drawProg, 'uWriteRow');
   const uH = gl.getUniformLocation(drawProg, 'uH');
   const uBgAlpha = gl.getUniformLocation(drawProg, 'uBgAlpha');
+  const uViewOffsetUv = gl.getUniformLocation(drawProg, 'uViewOffsetUv');
+  const uSeedDbDraw = gl.getUniformLocation(drawProg, 'uSeedDb');
   let bgAlpha = 1;
 
   const shiftProg = buildProgram(gl, WF_VS, WF_SHIFT_FS);
@@ -244,32 +256,29 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
       canvasH = h;
       gl.viewport(0, 0, w, h);
     },
-    pushFrame(wfDb, centerHz, hzPerPixel, options) {
-      const width = wfDb.length;
-      const decision = planWaterfallUpdate({
-        lastCenterHz,
-        lastHzPerPixel,
-        lastWidth: texWidth,
-        nextCenterHz: centerHz,
-        nextHzPerPixel: hzPerPixel,
-        nextWidth: width,
-      });
+    pushFrame(decision, wfDb, centerHz, hzPerPixel, options) {
       switch (decision.kind) {
-        case 'reset':
-          // Reset must always upload so the freshly-seeded history has a
-          // real top row; skipping it would leave the whole texture at -200.
-          resetTextures(width);
-          uploadRow(wfDb);
+        case 'reset': {
+          // Reset re-seeds both textures; when this frame carries valid wf
+          // data also upload it so the history has a real top row. A reset
+          // on an invalid-wf frame leaves the seed only — the next valid
+          // frame pushes the first real row.
+          const width = wfDb?.length ?? texWidth;
+          if (width > 0) resetTextures(width);
+          if (wfDb) uploadRow(wfDb);
           lastCenterHz = centerHz;
           lastHzPerPixel = hzPerPixel;
           break;
+        }
         case 'push':
-          if (!options?.skipRowUpload) uploadRow(wfDb);
+          if (wfDb && !options?.skipRowUpload) uploadRow(wfDb);
           // lastCenterHz unchanged so sub-pixel retunes accumulate.
           break;
         case 'shift':
           // Shift always runs — throttling it would let the history drift
-          // out of sync with the panadapter's VFO-accumulated offset.
+          // out of sync with the panadapter's anchor offset. This is a
+          // REBASE of the texture in integer pixels; the fractional
+          // remainder is rendered at draw time from the view-center.
           performShift(decision.shiftPx);
           // Suppress the new-row blit this tick per doc 08 §5 so we don't
           // overlay a post-retune row on top of a just-shifted frame.
@@ -283,11 +292,23 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
     setTransparent(transparent) {
       bgAlpha = transparent ? 0 : 1;
     },
-    draw(dbMin, dbMax) {
+    draw(dbMin, dbMax, viewCenterHz = null) {
       gl.viewport(0, 0, canvasW, canvasH);
       gl.clearColor(0, 0, 0, 0);
       gl.clear(gl.COLOR_BUFFER_BIT);
       if (texWidth === 0) return;
+      // Fractional glide between integer rebases (issue #597). Number()
+      // on the bigint anchor is exact to 2^53 — fine for 0..60 MHz.
+      let viewOffsetUv = 0;
+      if (viewCenterHz !== null && lastCenterHz !== null && lastHzPerPixel > 0) {
+        const offsetHz = Number(lastCenterHz) - viewCenterHz;
+        viewOffsetUv = offsetHz / (lastHzPerPixel * texWidth);
+        // A whole-span offset means the view ran away from the history
+        // (mid-glide band jump); clamp so sampling math stays sane — the
+        // shader's seed fallback paints the exposed region anyway.
+        if (!Number.isFinite(viewOffsetUv)) viewOffsetUv = 0;
+        viewOffsetUv = Math.max(-1, Math.min(1, viewOffsetUv));
+      }
       // Premultiplied-alpha blending — matches the fragment output so the
       // noise floor fades cleanly into whatever is behind the canvas.
       gl.enable(gl.BLEND);
@@ -304,6 +325,8 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
       gl.uniform1f(uWriteRow, writeRow);
       gl.uniform1f(uH, HISTORY_ROWS);
       gl.uniform1f(uBgAlpha, bgAlpha);
+      gl.uniform1f(uViewOffsetUv, viewOffsetUv);
+      gl.uniform1f(uSeedDbDraw, SEED_DB);
       gl.bindVertexArray(vao);
       gl.drawArrays(gl.TRIANGLES, 0, 3);
       gl.bindVertexArray(null);

--- a/zeus-web/src/state/connection-store.ts
+++ b/zeus-web/src/state/connection-store.ts
@@ -43,6 +43,7 @@
 // License for details.
 
 import { create } from 'zustand';
+import { msSinceOptimisticTune } from './view-center';
 import {
   NR_CONFIG_DEFAULT,
   type ConnectionStatus,
@@ -103,7 +104,15 @@ export type ConnectionState = {
   // Live WDSP wisdom_get_status() text streamed by the server while
   // wisdomPhase === 'building'. Empty otherwise.
   wisdomStatus: string;
-  applyState: (s: RadioStateDto) => void;
+  /** Apply a server StateDto. `opts.trustVfo` (default true) marks the
+   *  caller as an explicit command echo whose vfoHz must always apply
+   *  (drag release, keyboard flush, zoom/mode/band responses — clamps and
+   *  server-side corrections included). The 1 Hz App.tsx poll passes
+   *  trustVfo:false: a poll response generated just before the operator's
+   *  latest tune would otherwise rewind the dial mid-gesture (issue #597
+   *  rubber-band). Suppression is time-boxed to the optimistic-tune window
+   *  so a quiet dial always reconverges to server truth. */
+  applyState: (s: RadioStateDto, opts?: { trustVfo?: boolean }) => void;
   setInflight: (v: boolean) => void;
   setBoardId: (id: string | null) => void;
   setConnectedProtocol: (p: 'P1' | 'P2' | null) => void;
@@ -146,11 +155,14 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
   // pulse spuriously. The server overrides on attach with the real phase.
   wisdomPhase: 'ready',
   wisdomStatus: '',
-  applyState: (s) =>
-    set({
+  applyState: (s, opts) =>
+    set((prev) => ({
       status: s.status,
       endpoint: s.endpoint,
-      vfoHz: s.vfoHz,
+      vfoHz:
+        (opts?.trustVfo ?? true) || msSinceOptimisticTune() >= 1500
+          ? s.vfoHz
+          : prev.vfoHz,
       mode: s.mode,
       filterLowHz: s.filterLowHz,
       filterHighHz: s.filterHighHz,
@@ -169,7 +181,7 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
       adcOverloadWarning: s.adcOverloadWarning,
       nr: s.nr,
       zoomLevel: s.zoomLevel,
-    }),
+    })),
   setInflight: (inflight) => set({ inflight }),
   setBoardId: (boardId) => set({ boardId }),
   setConnectedProtocol: (connectedProtocol) => set({ connectedProtocol }),

--- a/zeus-web/src/state/view-center.test.ts
+++ b/zeus-web/src/state/view-center.test.ts
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Unit tests for the animated view-center (issue #597 Phase 1). Uses the
+// injectable clock/raf so the tween is driven deterministically — no
+// browser, no real time.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as vc from './view-center';
+
+// Manual clock + rAF harness.
+let nowMs = 0;
+let scheduled: ((t: number) => void) | null = null;
+let nextHandle = 1;
+
+function stepFrame(dtMs: number): void {
+  nowMs += dtMs;
+  const cb = scheduled;
+  scheduled = null;
+  cb?.(nowMs);
+}
+
+function drainFrames(dtMs: number, maxFrames = 1000): number {
+  let frames = 0;
+  while (scheduled && frames < maxFrames) {
+    stepFrame(dtMs);
+    frames++;
+  }
+  return frames;
+}
+
+beforeEach(() => {
+  nowMs = 0;
+  scheduled = null;
+  vc._resetForTest();
+  vc._setClockForTest(
+    () => nowMs,
+    (cb) => {
+      scheduled = cb;
+      return nextHandle++;
+    },
+    () => {
+      scheduled = null;
+    },
+  );
+});
+
+afterEach(() => {
+  vc._resetForTest();
+});
+
+describe('view-center tween', () => {
+  it('starts parked with zero cost (no rAF scheduled)', () => {
+    expect(vc._isLoopRunningForTest()).toBe(false);
+    expect(scheduled).toBeNull();
+  });
+
+  it('initialises from the first frame without a glide', () => {
+    vc.reconcileFrame(14_200_000, 93.75);
+    expect(vc.getViewCenterHz()).toBe(14_200_000);
+    expect(vc.getTargetCenterHz()).toBe(14_200_000);
+    expect(vc.isInitialized()).toBe(true);
+    expect(scheduled).toBeNull(); // snap, not tween
+  });
+
+  it('converges to the target and self-parks', () => {
+    vc.snapTo(14_200_000, 93.75);
+    vc.nudgeTargetHz(500);
+    expect(scheduled).not.toBeNull(); // loop armed
+    const frames = drainFrames(16.7);
+    expect(frames).toBeLessThan(60); // converges well under a second
+    expect(vc.getViewCenterHz()).toBe(14_200_500);
+    expect(scheduled).toBeNull(); // parked again — zero idle cost
+  });
+
+  it('moves monotonically toward the target (no overshoot, no reversal)', () => {
+    vc.snapTo(14_200_000, 93.75);
+    vc.nudgeTargetHz(500);
+    let prev = vc.getViewCenterHz();
+    while (scheduled) {
+      stepFrame(16.7);
+      const cur = vc.getViewCenterHz();
+      expect(cur).toBeGreaterThanOrEqual(prev); // the reversal-counter invariant
+      expect(cur).toBeLessThanOrEqual(14_200_500);
+      prev = cur;
+    }
+  });
+
+  it('accumulates bursty wheel notches into one continuous glide', () => {
+    vc.snapTo(14_200_000, 93.75);
+    // 10 notches over ~500 ms, mid-glide
+    for (let i = 0; i < 10; i++) {
+      vc.nudgeTargetHz(500);
+      stepFrame(50);
+    }
+    expect(vc.getTargetCenterHz()).toBe(14_205_000);
+    drainFrames(16.7);
+    expect(vc.getViewCenterHz()).toBe(14_205_000);
+  });
+
+  it('clamps dt across a GC pause instead of teleporting', () => {
+    vc.snapTo(14_200_000, 93.75);
+    vc.nudgeTargetHz(10_000);
+    // A 500 ms stall — the integrator must treat it as MAX_DT (50 ms), so
+    // the view moves at most 1 - e^(-50/70) ≈ 51% of the gap, not 99.9%.
+    stepFrame(500);
+    const moved = vc.getViewCenterHz() - 14_200_000;
+    expect(moved).toBeLessThan(10_000 * 0.55);
+    expect(moved).toBeGreaterThan(0);
+  });
+
+  it('notifies subscribers per tick and stops when parked', () => {
+    vc.snapTo(14_200_000, 93.75);
+    let calls = 0;
+    const unsub = vc.subscribe(() => calls++);
+    vc.nudgeTargetHz(500);
+    drainFrames(16.7);
+    const callsAtPark = calls;
+    expect(callsAtPark).toBeGreaterThan(0);
+    nowMs += 1000; // idle time — no frames, no notifications
+    expect(calls).toBe(callsAtPark);
+    unsub();
+  });
+});
+
+describe('reconcileFrame vs optimistic tuning', () => {
+  it('ignores lagging frame centers during an active gesture', () => {
+    vc.snapTo(14_200_000, 93.75);
+    vc.nudgeTargetHz(500); // operator just tuned
+    // A frame stamped at the OLD center arrives 100 ms later — must not
+    // drag the target backward.
+    nowMs += 100;
+    const external = vc.reconcileFrame(14_200_000, 93.75);
+    expect(external).toBe(false);
+    expect(vc.getTargetCenterHz()).toBe(14_200_500);
+  });
+
+  it('recognises an external tune when the dial has been quiet', () => {
+    vc.snapTo(14_200_000, 93.75);
+    nowMs += 5_000; // long quiet
+    const external = vc.reconcileFrame(14_350_000, 93.75);
+    expect(external).toBe(true);
+    expect(vc.getTargetCenterHz()).toBe(14_350_000);
+    expect(scheduled).not.toBeNull(); // glides there
+    // ...and the external retune armed the refill hold.
+    expect(vc.isWithinRefillHold(500)).toBe(true);
+  });
+
+  it('treats settled frames as agreement (no retarget churn)', () => {
+    vc.snapTo(14_200_000, 93.75);
+    nowMs += 5_000;
+    const external = vc.reconcileFrame(14_200_000, 93.75);
+    expect(external).toBe(false);
+    expect(scheduled).toBeNull();
+  });
+});
+
+describe('refill hold', () => {
+  it('opens on a tune and expires after holdMs', () => {
+    vc.snapTo(14_200_000, 93.75);
+    vc.nudgeTargetHz(500);
+    expect(vc.isWithinRefillHold(240)).toBe(true);
+    nowMs += 239;
+    expect(vc.isWithinRefillHold(240)).toBe(true);
+    nowMs += 2;
+    expect(vc.isWithinRefillHold(240)).toBe(false);
+  });
+
+  it('restarts on every target change (sustained drag keeps it open)', () => {
+    vc.snapTo(14_200_000, 93.75);
+    for (let i = 0; i < 5; i++) {
+      vc.nudgeTargetHz(500);
+      nowMs += 100;
+      expect(vc.isWithinRefillHold(240)).toBe(true);
+    }
+  });
+
+  it('is cleared by snapTo (reset path — zoom / sample-rate change)', () => {
+    vc.snapTo(14_200_000, 93.75);
+    vc.nudgeTargetHz(500);
+    expect(vc.isWithinRefillHold(240)).toBe(true);
+    vc.snapTo(14_200_500, 93.75);
+    expect(vc.isWithinRefillHold(240)).toBe(false);
+  });
+
+  it('derives holdMs from the sample rate, clamped to the radio range', () => {
+    // 16384-pt FFT: 192 kHz ≈ 85 ms fill → ~240 ms hold; 48 kHz ≈ 341 ms
+    // fill → ~508 ms hold.
+    const hold192 = vc.refillHoldMsForSampleRate(192_000);
+    const hold48 = vc.refillHoldMsForSampleRate(48_000);
+    expect(hold192).toBeGreaterThan(200);
+    expect(hold192).toBeLessThan(300);
+    expect(hold48).toBeGreaterThan(450);
+    expect(hold48).toBeLessThan(560);
+    // Bogus rates clamp instead of producing multi-second holds.
+    expect(vc.refillHoldMsForSampleRate(0)).toBe(vc.refillHoldMsForSampleRate(192_000));
+    expect(vc.refillHoldMsForSampleRate(1)).toBe(vc.refillHoldMsForSampleRate(48_000));
+  });
+});
+
+describe('delta-form semantics (CW safety)', () => {
+  it('a wheel-then-drag interleave never feeds an absolute into the center', () => {
+    // Frame center is dial − 700 (CWU pitch). The view tracks frame space;
+    // deltas keep it there.
+    const pitch = 700;
+    const dial = 7_030_000;
+    vc.snapTo(dial - pitch, 93.75);
+    // wheel +500 (dial space delta == center space delta)
+    vc.nudgeTargetHz(500);
+    // drag commit: snapped dial-space value minus commanded dial-space value
+    const commanded = dial + 500;
+    const snapped = dial + 1_000;
+    vc.nudgeTargetHz(snapped - commanded);
+    drainFrames(16.7);
+    // view ends at (dial + 1000) − pitch: pitch never leaked in.
+    expect(vc.getViewCenterHz()).toBe(dial + 1_000 - pitch);
+  });
+
+  it('zero-delta nudges only stamp the optimistic clock', () => {
+    vc.snapTo(14_200_000, 93.75);
+    nowMs += 5_000;
+    vc.nudgeTargetHz(0);
+    expect(vc.getTargetCenterHz()).toBe(14_200_000);
+    expect(scheduled).toBeNull();
+    expect(vc.msSinceOptimisticTune()).toBe(0);
+  });
+});

--- a/zeus-web/src/state/view-center.ts
+++ b/zeus-web/src/state/view-center.ts
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is an independent reimplementation in .NET — not a fork. Its
+// Protocol-1 / Protocol-2 framing, WDSP integration, meter pipelines, and
+// TX behaviour were informed by studying the Thetis project
+// (https://github.com/ramdor/Thetis), the authoritative reference
+// implementation in the OpenHPSDR ecosystem. Zeus gratefully acknowledges
+// the Thetis contributors whose work made this possible:
+//
+//   Richard Samphire (MW0LGE), Warren Pratt (NR0V),
+//   Laurence Barker (G8NJJ),   Rick Koch (N1GP),
+//   Bryan Rambo (W4WMT),       Chris Codella (W2PA),
+//   Doug Wigley (W5WC),        FlexRadio Systems,
+//   Richard Allen (W5SD),      Joe Torrey (WD5Y),
+//   Andrew Mansfield (M0YGG),  Reid Campbell (MI0BOT),
+//   Sigi Jetzlsperger (DH1KLM).
+//
+// Thetis itself continues the GPL-governed lineage of FlexRadio PowerSDR
+// and the OpenHPSDR (TAPR/OpenHPSDR) ecosystem; that lineage is preserved
+// here. See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
+// WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
+// (NR0V), distributed under GPL v2 or later.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+// Animated view-center for the spectrum surfaces (issue #597 Phase 1).
+//
+// One smoothly-tweened center frequency drives the panadapter trace, the
+// waterfall, the dial marker, the passband rect, and the freq-axis ticks as
+// a single rigid body at display rate. Server frames (30 Hz) no longer drive
+// horizontal motion — they only refresh content; every surface renders its
+// data anchored at the frequency it was captured at, offset by
+// (anchorHz − viewCenterHz) in fractional pixels.
+//
+// Model
+// -----
+// - `targetHz` is the *commanded* display center. Input handlers advance it
+//   by DELTA (`nudgeTargetHz`) — delta-form is load-bearing: in CW the frame
+//   center is the dial ∓ cw-pitch, and feeding any dial-space absolute value
+//   in here would oscillate the display by ±pitch on every commit. Deltas
+//   cancel the pitch term (constant while mode/pitch are unchanged).
+// - `viewHz` eases toward `targetHz` with an exponential tween
+//   (τ = TAU_MS), ticked on this module's own rAF loop. The loop self-parks
+//   when |target − view| < SNAP_EPS_HZ — ZERO idle cost: no rAF, no
+//   listeners firing, nothing. perf_pass_3 red-line respected.
+// - `reconcileFrame` feeds every server frame's centerHz back in. While the
+//   operator is actively tuning (recent optimistic stamp) frames lag the
+//   command and are ignored. With no recent gesture, a frame-center move is
+//   an EXTERNAL tune (CAT/TCI, band button, typed entry, mode change) — we
+//   retarget and glide there, which also arms the refill hold so mislabeled
+//   mid-retune frames are not adopted (see Panadapter.tsx).
+// - `snapTo` is the 'reset' path (zoom/sample-rate/width change): no glide,
+//   no hold — geometry changed, the next frame is authoritative.
+//
+// Kill switch: set VIEW_CENTER_TWEEN_ENABLED = false (or TAU_MS = 0) to
+// snap-to-target every tick — restores today's stepping feel while keeping
+// the anchor-model correctness fixes.
+
+export const VIEW_CENTER_TWEEN_ENABLED = true;
+
+// Tween time-constant. ~70 ms reads as "glides with the wheel" without
+// feeling laggy; the display sits ~τ behind the commanded freq during a
+// gesture and converges within ~3τ after the last input.
+const TAU_MS = 70;
+// Clamp dt so a GC pause / background-tab wakeup doesn't integrate one huge
+// step (the tween would visibly teleport). 50 ms ≈ 3 missed vsyncs.
+const MAX_DT_MS = 50;
+// Park threshold. Converted to Hz via the live hzPerPixel so "0.05 px" is
+// the actual sub-pixel invisibility bound at any zoom; falls back to 1 Hz
+// when no frame geometry is known yet.
+const SNAP_EPS_PX = 0.05;
+// reconcileFrame treats a frame-center move as an external tune only when
+// there has been no optimistic (operator) tune within this window. Frames
+// lag commands by FFT-window + EMA + transport (~100-400 ms worst case).
+const OPTIMISTIC_WINDOW_MS = 400;
+
+type Listener = () => void;
+
+// Injectable clock/raf so the tween is unit-testable without a browser.
+type Clock = () => number;
+type Raf = (cb: (t: number) => void) => number;
+type CancelRaf = (h: number) => void;
+
+let now: Clock = () => performance.now();
+let raf: Raf = (cb) => requestAnimationFrame(cb);
+let cancelRaf: CancelRaf = (h) => cancelAnimationFrame(h);
+
+let initialized = false;
+let targetHz = 0;
+let viewHz = 0;
+let hzPerPixel = 0;
+let lastOptimisticTuneAtMs = -Infinity;
+let lastTargetChangeAtMs = -Infinity;
+let rafHandle = 0;
+let lastTickMs = 0;
+const listeners = new Set<Listener>();
+
+function epsHz(): number {
+  return hzPerPixel > 0 ? hzPerPixel * SNAP_EPS_PX : 1;
+}
+
+function notify(): void {
+  for (const cb of listeners) {
+    try {
+      cb();
+    } catch (err) {
+      // One bad listener must not stall the tween loop.
+      // eslint-disable-next-line no-console
+      console.error('view-center listener threw', err);
+    }
+  }
+}
+
+function tick(tMs: number): void {
+  rafHandle = 0;
+  const dt = Math.min(MAX_DT_MS, Math.max(0, tMs - lastTickMs));
+  lastTickMs = tMs;
+  const gap = targetHz - viewHz;
+  if (!VIEW_CENTER_TWEEN_ENABLED || TAU_MS <= 0 || Math.abs(gap) < epsHz()) {
+    viewHz = targetHz; // converged (or kill switch) — park the loop.
+    notify();
+    return;
+  }
+  viewHz += gap * (1 - Math.exp(-dt / TAU_MS));
+  notify();
+  rafHandle = raf(tick);
+}
+
+function ensureRunning(): void {
+  if (rafHandle !== 0) return;
+  lastTickMs = now();
+  rafHandle = raf(tick);
+}
+
+/** Advance the commanded display center by a delta (Hz). Delta-form only —
+ *  see the module comment for why absolute dial values must never land here.
+ *  Also stamps the optimistic-tune clock used by reconcileFrame and the
+ *  App.tsx poll guard. */
+export function nudgeTargetHz(deltaHz: number): void {
+  if (!Number.isFinite(deltaHz) || deltaHz === 0) {
+    if (deltaHz === 0) markOptimisticTune();
+    return;
+  }
+  targetHz += deltaHz;
+  const t = now();
+  lastOptimisticTuneAtMs = t;
+  lastTargetChangeAtMs = t;
+  ensureRunning();
+}
+
+/** Stamp the optimistic-tune clock without moving the target (e.g. a POST
+ *  flush of an already-applied pending value). */
+export function markOptimisticTune(): void {
+  lastOptimisticTuneAtMs = now();
+}
+
+/** Hard-set view == target == centerHz with no glide. The 'reset' path:
+ *  zoom / sample-rate / width changed, so the previous geometry (and any
+ *  in-flight tween) is meaningless. Clears the refill hold. */
+export function snapTo(centerHz: number, nextHzPerPixel?: number): void {
+  targetHz = centerHz;
+  viewHz = centerHz;
+  if (nextHzPerPixel !== undefined && nextHzPerPixel > 0) hzPerPixel = nextHzPerPixel;
+  initialized = true;
+  lastTargetChangeAtMs = -Infinity;
+  notify();
+}
+
+/**
+ * Feed a server frame's center back in. Returns true when this frame was
+ * recognised as an EXTERNAL tune (no recent operator gesture) — the caller
+ * uses that to arm the refill hold for paths no gesture hook can see
+ * (CAT/TCI, band buttons, typed entry, mode changes, arrow keys missed by
+ * a stale build, …).
+ */
+export function reconcileFrame(centerHz: number, nextHzPerPixel: number): boolean {
+  if (nextHzPerPixel > 0) hzPerPixel = nextHzPerPixel;
+  if (!initialized) {
+    snapTo(centerHz);
+    return false;
+  }
+  const gapHz = Math.abs(centerHz - targetHz);
+  if (gapHz <= Math.max(epsHz(), 1)) return false;
+  const sinceOptimistic = now() - lastOptimisticTuneAtMs;
+  if (sinceOptimistic < OPTIMISTIC_WINDOW_MS) {
+    // Operator is tuning; frames lag the command. Ignore the mismatch.
+    return false;
+  }
+  // External tune: glide to where the radio actually went.
+  targetHz = centerHz;
+  lastTargetChangeAtMs = now();
+  ensureRunning();
+  return true;
+}
+
+/** The animated center the surfaces should render against, in Hz. */
+export function getViewCenterHz(): number {
+  return viewHz;
+}
+
+/** False until the first frame/snap establishes a center. Surfaces render
+ *  with zero offset until then. */
+export function isInitialized(): boolean {
+  return initialized;
+}
+
+// WDSP analyzer FFT size (WdspDspEngine.AnalyzerFftSize). The refill hold
+// must outlast the FFT fill window — the span of old-frequency IQ still
+// inside the analyzer after a retune — plus the EMA settle margin.
+const ANALYZER_FFT_SIZE = 16384;
+const HOLD_MARGIN_MS = 150;
+
+/** Refill-hold duration for the current sample rate: 1.05 × FFT fill time
+ *  + 150 ms (Thetis display.cs:6360 uses fftFillTime*1.05+2 frames; our
+ *  margin also covers Phase 0's 100 ms fast-attack settle). Rate is clamped
+ *  to the radio's real range so a transient bogus StateDto can't produce a
+ *  multi-second hold (adversary: zoom-transition mis-derivation). */
+export function refillHoldMsForSampleRate(sampleRateHz: number): number {
+  const rate = Math.min(384_000, Math.max(48_000, sampleRateHz || 192_000));
+  return (ANALYZER_FFT_SIZE / rate) * 1000 * 1.05 + HOLD_MARGIN_MS;
+}
+
+/** The commanded center (where the view is heading), in Hz. */
+export function getTargetCenterHz(): number {
+  return targetHz;
+}
+
+/** True while inside the post-retune refill hold: fresh server frames are
+ *  still (partly) computed from pre-retune IQ and must not be adopted as
+ *  trace content. holdMs is derived by the caller from the sample rate
+ *  (FFT fill time) — see Panadapter.tsx. */
+export function isWithinRefillHold(holdMs: number): boolean {
+  return now() - lastTargetChangeAtMs < holdMs;
+}
+
+/** Milliseconds since the last operator-initiated tune. Used by the
+ *  connection-store poll guard to suppress vfoHz rubber-banding from the
+ *  1 Hz /api/state poll. */
+export function msSinceOptimisticTune(): number {
+  return now() - lastOptimisticTuneAtMs;
+}
+
+/** Subscribe to view-center motion. Fires once per tween tick (display
+ *  rate while gliding; silent when parked). Returns the unsubscribe fn. */
+export function subscribe(cb: Listener): () => void {
+  listeners.add(cb);
+  return () => listeners.delete(cb);
+}
+
+// ---------------------------------------------------------------------------
+// Test hooks — not part of the public surface.
+
+export function _setClockForTest(clock: Clock, rafImpl: Raf, cancelImpl: CancelRaf): void {
+  now = clock;
+  raf = rafImpl;
+  cancelRaf = cancelImpl;
+}
+
+export function _resetForTest(): void {
+  if (rafHandle !== 0) cancelRaf(rafHandle);
+  rafHandle = 0;
+  initialized = false;
+  targetHz = 0;
+  viewHz = 0;
+  hzPerPixel = 0;
+  lastOptimisticTuneAtMs = -Infinity;
+  lastTargetChangeAtMs = -Infinity;
+  lastTickMs = 0;
+  listeners.clear();
+}
+
+export function _isLoopRunningForTest(): boolean {
+  return rafHandle !== 0;
+}

--- a/zeus-web/src/util/use-keyboard-shortcuts.ts
+++ b/zeus-web/src/util/use-keyboard-shortcuts.ts
@@ -52,6 +52,7 @@ import {
   type ZoomLevel,
 } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import * as viewCenter from '../state/view-center';
 import { useToolbarFavoritesStore } from '../state/toolbar-favorites-store';
 import { useTxStore } from '../state/tx-store';
 import { ACTIVE_MAP_REF } from '../state/active-map-ref';
@@ -102,6 +103,7 @@ export function useKeyboardShortcuts() {
       const hz = pendingHz;
       pendingHz = null;
       if (hz == null) return;
+      viewCenter.markOptimisticTune();
       tuneAbort?.abort();
       const ctrl = new AbortController();
       tuneAbort = ctrl;
@@ -118,6 +120,12 @@ export function useKeyboardShortcuts() {
       const base = pendingHz ?? useConnectionStore.getState().vfoHz;
       const step = useToolbarFavoritesStore.getState().stepHz;
       const next = snapHz(base + direction * step, step);
+      // Glide the spectrum with arrow-key tuning too (issue #597 adversary
+      // #1: without this the fix is "smooth for mouse, juddery for
+      // keyboard", and arrows are a primary CW workflow). Delta-form —
+      // dial-space deltas equal frame-center deltas while mode/pitch are
+      // unchanged.
+      viewCenter.nudgeTargetHz(next - base);
       useConnectionStore.setState({ vfoHz: next });
       pendingHz = next;
       if (pendingRaf === 0) pendingRaf = requestAnimationFrame(flushTune);

--- a/zeus-web/src/util/use-pan-tune-gesture.ts
+++ b/zeus-web/src/util/use-pan-tune-gesture.ts
@@ -206,8 +206,12 @@ export function usePanTuneGesture(
       const cur = commandedHz();
       const next = clampHz(cur + deltaHz);
       // Effective delta (post-clamp) so the display target can never run
-      // past a band edge the command was clamped at.
+      // past a band edge the command was clamped at. The optimistic store
+      // write happens in the SAME synchronous block as the target nudge so
+      // the dial marker's (vfo − target) offset is never transiently stale
+      // (it is pinned to the center line during glides).
       viewCenter.nudgeTargetHz(next - cur);
+      useConnectionStore.setState({ vfoHz: next });
       pendingHz = next;
       scheduleFlush();
     };
@@ -333,6 +337,9 @@ export function usePanTuneGesture(
       // glides between the unchanged 500 Hz snap points.
       if (newHz !== pendingHz) {
         viewCenter.nudgeTargetHz(newHz - commandedHz());
+        // Atomic with the nudge — keeps the marker's (vfo − target) offset
+        // consistent within the frame (see nudgeVfo).
+        useConnectionStore.setState({ vfoHz: newHz });
         pendingHz = newHz;
         scheduleFlush();
       }

--- a/zeus-web/src/util/use-pan-tune-gesture.ts
+++ b/zeus-web/src/util/use-pan-tune-gesture.ts
@@ -46,6 +46,7 @@ import { createContext, useContext, useEffect, type RefObject } from 'react';
 import { setVfo, setZoom, ZOOM_MAX, ZOOM_MIN, type ZoomLevel } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
 import { useDisplayStore } from '../state/display-store';
+import * as viewCenter from '../state/view-center';
 import { useToolbarFavoritesStore } from '../state/toolbar-favorites-store';
 
 const MAX_HZ = 60_000_000;
@@ -155,11 +156,20 @@ export function usePanTuneGesture(
     let wheelAccum = 0;
     let zoomInflight: AbortController | null = null;
 
+    // The commanded-frequency chain: pendingHz when a POST is queued, else
+    // the optimistic store value. All view-center nudges are DELTAS against
+    // this chain (never against the lagging frame center), so the display
+    // target always mirrors exactly what was commanded — including clamp
+    // effects at the band edges — and CW pitch offsets cancel (issue #597
+    // adversary #2/#12).
+    const commandedHz = () => pendingHz ?? useConnectionStore.getState().vfoHz;
+
     const flushPending = () => {
       pendingRaf = 0;
       const hz = pendingHz;
       pendingHz = null;
       if (hz == null) return;
+      viewCenter.markOptimisticTune();
       useConnectionStore.setState({ vfoHz: hz });
       pendingAbort?.abort();
       const ctrl = new AbortController();
@@ -173,6 +183,10 @@ export function usePanTuneGesture(
 
     const commitFinal = (hz: number) => {
       const snapped = snapHz(hz);
+      // Delta against the commanded chain — NOT an absolute write into the
+      // view-center (frame centers are dial ∓ cw-pitch in CW; absolutes
+      // would oscillate the display by ±pitch on every CW commit).
+      viewCenter.nudgeTargetHz(snapped - commandedHz());
       useConnectionStore.setState({ vfoHz: snapped });
       pendingAbort?.abort();
       pendingAbort = null;
@@ -189,8 +203,12 @@ export function usePanTuneGesture(
     // Wheel-driven VFO nudge: fine-tune step, no snap to PAN_STEP_HZ. Coalesces
     // to one POST per rAF via the same pending pipeline as drag-to-pan.
     const nudgeVfo = (deltaHz: number) => {
-      const cur = pendingHz ?? useConnectionStore.getState().vfoHz;
-      pendingHz = clampHz(cur + deltaHz);
+      const cur = commandedHz();
+      const next = clampHz(cur + deltaHz);
+      // Effective delta (post-clamp) so the display target can never run
+      // past a band edge the command was clamped at.
+      viewCenter.nudgeTargetHz(next - cur);
+      pendingHz = next;
       scheduleFlush();
     };
 
@@ -307,8 +325,17 @@ export function usePanTuneGesture(
       const rect = canvas.getBoundingClientRect();
       if (rect.width <= 0) return;
       const newHz = snapHz(drag.startHz - (dx / rect.width) * drag.spanHz);
-      pendingHz = newHz;
-      scheduleFlush();
+      // Pixel→Hz mapping stays display-relative (drag.startHz is the frame
+      // center at grab — unchanged semantics); the view-center moves by the
+      // COMMANDED delta, initialised from the live commanded value, never
+      // from the lagging frame center (adversary #12: prevents a one-time
+      // backward jump when a drag starts mid-wheel-glide). The display then
+      // glides between the unchanged 500 Hz snap points.
+      if (newHz !== pendingHz) {
+        viewCenter.nudgeTargetHz(newHz - commandedHz());
+        pendingHz = newHz;
+        scheduleFlush();
+      }
     };
 
     const onPointerUp = (e: PointerEvent) => {


### PR DESCRIPTION
Phase 1 (the main PR) of the #597 smooth-tuning stack. **Base is the Phase 0 branch** so this diff shows only Phase 1; retarget to develop after #598 merges. Full design + adversarial review: https://github.com/Kb2uka/openhpsdr-zeus/issues/597#issuecomment-4691893191

## The mechanism

One client-side **animated view-center** (`state/view-center.ts`, τ=70 ms exponential tween on its own self-parking rAF loop) drives the trace, waterfall, dial marker, passband rect, and freq-axis ticks as a single rigid body at display rate. Server frames stop driving motion — they only refresh content:

- **Anchor model**: the adopted trace renders at the center it was captured at, offset by `(anchorHz − viewHz)/hzPerPixel` in *fractional* pixels (the shaders already took float offsets — now it's used)
- **Refill hold** (Thetis-style): post-retune frames carrying pre-retune IQ are never adopted, killing the snap-back. Waterfall rows get a 200 ms rows-only cap so sustained drags keep flowing
- **Shared frame planner** (`gl/frame-plan.ts`): one shift decision per seq for both surfaces; tracker advances on invalid frames — the pan/wf one-frame divergence is structurally dead
- **One clock for overlays**: FreqAxis/PassbandOverlay motion is `ref.style.transform` writes in draw-bus callbacks — zero React commits at display rate (previously the vfoHz selector re-rendered them at gesture rate)
- **Poll guard**: `applyState(s, {trustVfo:false})` for the 1 Hz poll only — no more mid-gesture dial rewind; command echoes (incl. server clamps) always apply

## All 7 adversary mitigations folded in

arrow-key tuning drives the view (#1) · delta-form everywhere, CW pitch cancels (#2) · rows-only cap under sustained drag (#3) · caller-aware poll guard (#4) · tick container on the draw-bus, not React (#9) · drag target chain initialized from commanded value, not frame center (#12) · holdMs from StateDto sampleRate, clamped (#zoom-transition)

## What does NOT change

Tuning semantics byte-identical: same wheel steps, same 500 Hz drag snap, same POSTs/REST shapes, **no NCO/TX-path changes, nothing CTUN-shaped** (the #511 failure mode cannot recur). No new dependencies. Zero idle CPU (loop parks, uploads elided via dataDirty). Kill switch: `VIEW_CENTER_TWEEN_ENABLED = false` restores stepping while keeping the correctness fixes.

## Tests

23 new unit tests (`view-center.test.ts`, `frame-plan.test.ts`): tween convergence + **no-reversal invariant**, GC-pause dt clamp, optimistic-vs-external reconcile, hold windowing/restart/clear, CW wheel-then-drag interleave, planner memoization/parity. vitest 271 passed; `vite build` clean.

On-air checklist (KB2UKA, G2 + HL2): wheel CW at 500 Hz (no snap-back), 5 s SSB band drag (glide + flowing waterfall), arrow keys in CWU, tune-while-MOX'd, zoom mid-gesture, 1 Hz poll mid-gesture.

Part 2/3 — do not merge until the stack is on-air tested. τ lives in one constant for feel tuning (maintainer sign-off per CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)