### PR TITLE
feat(display): delay-compensated CenterHz stamp — honest frames (#597 Phase 2)

### DIFF
--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -305,6 +305,33 @@ public class DspPipelineService : BackgroundService,
     private const int FastAttackRestoreMs = 250;
     private static readonly long FastAttackRestoreTicks =
         (long)(FastAttackRestoreMs / 1000.0 * Stopwatch.Frequency);
+    // Issue #597 Phase 2: delay-compensated CenterHz stamp (Thetis pixel_ref
+    // emulation). The display pixels broadcast at tick time were computed
+    // from IQ captured ~D earlier; stamping them with the LO from
+    // LookupAt(now − D) makes frames self-describing — the client renders
+    // data where it actually belongs, killing the mislabeled-frame
+    // snap-back at the root (no wire change: same CenterHz field).
+    // D = ½·FFT-fill + display-EMA lag + per-protocol transport. Override
+    // the transport+EMA constant with ZEUS_CENTER_STAMP_LAG_MS for bench
+    // tuning at 48/96/192/384 kHz on P1 (HL2) and P2 (G2). When the LO is
+    // stable longer than D the stamp equals live RadioLoHz — WWV cal
+    // (#325) and every stable-LO consumer is byte-identical (see
+    // LoHistoryRingTests regression).
+    private readonly LoHistoryRing _loHistory = new();
+    private const int AnalyzerFftSizeForStamp = 16_384; // WdspDspEngine.AnalyzerFftSize
+    private const double CenterStampEmaLagMs = 20.0;    // fast-attack tau during gestures (Phase 0)
+    private const double CenterStampTransportP1Ms = 40.0;
+    private const double CenterStampTransportP2Ms = 15.0;
+    private static readonly double? CenterStampLagOverrideMs = ReadCenterStampLagOverrideMs();
+
+    private static double? ReadCenterStampLagOverrideMs()
+    {
+        var raw = Environment.GetEnvironmentVariable("ZEUS_CENTER_STAMP_LAG_MS");
+        return double.TryParse(raw, System.Globalization.NumberStyles.Float,
+            System.Globalization.CultureInfo.InvariantCulture, out var ms) && ms >= 0
+            ? ms
+            : null;
+    }
     // RX S-meter broadcast throttle. Pipeline ticks at 30 Hz; broadcasting
     // every 6 ticks = 5 Hz gives a smoother meter than Thetis's 4 Hz baseline
     // without spamming the WS (30 Hz dBm readouts add nothing a UI can use).
@@ -671,7 +698,11 @@ public class DspPipelineService : BackgroundService,
         else if (s.RadioLoHz != _fastAttackLastLoHz)
         {
             _fastAttackLastLoHz = s.RadioLoHz;
-            Interlocked.Exchange(ref _fastAttackLoChangedAt, Stopwatch.GetTimestamp());
+            long nowTicks = Stopwatch.GetTimestamp();
+            // Issue #597 Phase 2: the LO history feeding the delay-compensated
+            // CenterHz stamp. O(1) append, LO changes only.
+            _loHistory.Append(nowTicks, s.RadioLoHz);
+            Interlocked.Exchange(ref _fastAttackLoChangedAt, nowTicks);
             if (!_keyed && !_fastAttackActive)
             {
                 Volatile.Read(ref _engine)?.SetRxDisplayFastAttack(Volatile.Read(ref _channelId), fast: true);
@@ -1753,12 +1784,24 @@ public class DspPipelineService : BackgroundService,
             // extra contract field needed, per task #7 scope note.
             int zoomLevel = Math.Max(1, state.ZoomLevel);
             float hzPerPixel = (float)((double)sampleRate / zoomLevel / Width);
-            // Panadapter centre = the radio's actual NCO. The hardware is
-            // always frozen at RadioLoHz while the dial roams, so the
-            // pan/waterfall stay anchored to RadioLoHz and don't slide under
-            // the operator when only VfoHz moves.
-            // See docs/prd/panfall_behavior.md.
-            long centerHz = state.RadioLoHz;
+            // Panadapter centre: the LO the pixels were actually computed
+            // at (issue #597 Phase 2). The analyzer output broadcast this
+            // tick reflects IQ captured ~stampLag earlier; LookupAt rewinds
+            // the LO history by that much so mid-retune frames carry the
+            // frequency their data belongs to instead of the live NCO.
+            // Stable LO (≥ stampLag with no tune) ⇒ identical to the old
+            // `state.RadioLoHz` stamp, byte for byte.
+            double fftFillMs = sampleRate > 0
+                ? AnalyzerFftSizeForStamp / (double)sampleRate * 1000.0
+                : 0.0;
+            double stampLagMs = 0.5 * fftFillMs
+                + (CenterStampLagOverrideMs
+                   ?? (CenterStampEmaLagMs
+                       + (_p2Client is not null ? CenterStampTransportP2Ms : CenterStampTransportP1Ms)));
+            long stampLagTicks = (long)(stampLagMs / 1000.0 * Stopwatch.Frequency);
+            long centerHz = _loHistory.LookupAt(
+                Stopwatch.GetTimestamp() - stampLagTicks,
+                fallbackLoHz: state.RadioLoHz);
 
             // Cache for the frequency-calibration service (issue #325). The
             // cal reads from this cache to avoid racing for WDSP's "fresh

--- a/Zeus.Server.Hosting/LoHistoryRing.cs
+++ b/Zeus.Server.Hosting/LoHistoryRing.cs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is an independent reimplementation in .NET — not a fork. Its
+// Protocol-1 / Protocol-2 framing, WDSP integration, meter pipelines, and
+// TX behaviour were informed by studying the Thetis project
+// (https://github.com/ramdor/Thetis), the authoritative reference
+// implementation in the OpenHPSDR ecosystem. See ATTRIBUTIONS.md at the
+// repository root for the full provenance statement.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Fixed-size history of (timestamp, RadioLoHz) pairs for the
+/// delay-compensated panadapter CenterHz stamp (issue #597 Phase 2 — the
+/// Thetis <c>pixel_ref</c> emulation). The display pixels broadcast at
+/// time T were computed from IQ captured roughly D earlier (half the FFT
+/// fill window + display-EMA lag + protocol transport), so stamping them
+/// with the LO from <c>LookupAt(T − D)</c> makes every frame
+/// self-describing: the client renders data at the frequency it actually
+/// belongs to, regardless of arrival timing.
+///
+/// Concurrency: appends come from the radio state-handler thread (LO
+/// changes only — at most input rate, ~60/s during a drag), lookups from
+/// the RX/pipeline thread (30 Hz). A plain lock is held for nanoseconds;
+/// no allocation after construction.
+///
+/// When the LO has been stable longer than the lookback delay, LookupAt
+/// returns the current LO — i.e. the stamp is BYTE-IDENTICAL to the old
+/// <c>state.RadioLoHz</c> behaviour. WWV frequency calibration (#325) and
+/// every other consumer that runs at stable LO sees no change; the
+/// regression test asserts this.
+/// </summary>
+public sealed class LoHistoryRing
+{
+    private readonly object _lock = new();
+    private readonly long[] _timestamps;
+    private readonly long[] _loHz;
+    private int _count;
+    private int _head; // index of the NEWEST entry when _count > 0
+
+    public LoHistoryRing(int capacity = 64)
+    {
+        if (capacity < 2) capacity = 2;
+        _timestamps = new long[capacity];
+        _loHz = new long[capacity];
+    }
+
+    /// <summary>Record that the LO changed to <paramref name="loHz"/> at
+    /// <paramref name="timestamp"/> (Stopwatch ticks). Out-of-order or
+    /// duplicate timestamps are tolerated (last write wins on lookup ties).</summary>
+    public void Append(long timestamp, long loHz)
+    {
+        lock (_lock)
+        {
+            _head = _count == 0 ? 0 : (_head + 1) % _timestamps.Length;
+            _timestamps[_head] = timestamp;
+            _loHz[_head] = loHz;
+            if (_count < _timestamps.Length) _count++;
+        }
+    }
+
+    /// <summary>
+    /// The LO that was in effect at <paramref name="timestamp"/>: the newest
+    /// entry whose timestamp is ≤ the query. Falls back to the oldest known
+    /// entry when the query predates the whole ring (best effort — the ring
+    /// only needs to span the lookback delay, ≤ ~400 ms), and to
+    /// <paramref name="fallbackLoHz"/> when the ring is empty (pre-connect /
+    /// first frames).
+    /// </summary>
+    public long LookupAt(long timestamp, long fallbackLoHz)
+    {
+        lock (_lock)
+        {
+            if (_count == 0) return fallbackLoHz;
+            // Walk newest → oldest; the ring is tiny (≤64) and during a
+            // gesture the answer is almost always within the first few
+            // entries, so a linear scan beats anything fancier.
+            int idx = _head;
+            for (int i = 0; i < _count; i++)
+            {
+                if (_timestamps[idx] <= timestamp) return _loHz[idx];
+                idx = (idx - 1 + _timestamps.Length) % _timestamps.Length;
+            }
+            // Query predates everything we remember — oldest known value.
+            int oldest = (_head - (_count - 1) + _timestamps.Length) % _timestamps.Length;
+            return _loHz[oldest];
+        }
+    }
+
+    /// <summary>Forget all history (disconnect/reconnect).</summary>
+    public void Clear()
+    {
+        lock (_lock)
+        {
+            _count = 0;
+            _head = 0;
+        }
+    }
+}

--- a/tests/Zeus.Server.Tests/LoHistoryRingTests.cs
+++ b/tests/Zeus.Server.Tests/LoHistoryRingTests.cs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Tests for the delay-compensated CenterHz stamp's LO history
+// (issue #597 Phase 2). The stable-LO regression is load-bearing: WWV
+// frequency calibration (#325) and every other consumer that reads frame
+// CenterHz at a quiet dial must see EXACTLY the live RadioLoHz — this
+// radio has a prior spurious-calibration incident, so that equivalence is
+// pinned by test, not by inspection.
+
+using Xunit;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class LoHistoryRingTests
+{
+    [Fact]
+    public void EmptyRing_ReturnsFallback()
+    {
+        var ring = new LoHistoryRing();
+        Assert.Equal(14_200_000L, ring.LookupAt(1_000, fallbackLoHz: 14_200_000L));
+    }
+
+    [Fact]
+    public void StableLo_StampEqualsLiveRadioLo_Regression325()
+    {
+        // The LO tuned once, long ago. ANY query after that change — i.e.
+        // every tick at a stable dial, which is where WWV cal runs — must
+        // return the live LO, byte-identical to the pre-Phase-2 stamp.
+        var ring = new LoHistoryRing();
+        ring.Append(timestamp: 1_000, loHz: 14_200_000L);
+        for (long t = 1_000; t < 1_000_000; t += 33_333)
+        {
+            Assert.Equal(14_200_000L, ring.LookupAt(t, fallbackLoHz: -1L));
+        }
+    }
+
+    [Fact]
+    public void MidGesture_LookbackReturnsTheLoAtCaptureTime()
+    {
+        var ring = new LoHistoryRing();
+        ring.Append(1_000, 14_200_000L);
+        ring.Append(2_000, 14_200_500L);
+        ring.Append(3_000, 14_201_000L);
+        // A tick at t=3_100 whose pixels were captured at t=2_500 must be
+        // stamped with the LO in effect at 2_500 — the middle entry.
+        Assert.Equal(14_200_500L, ring.LookupAt(2_500, fallbackLoHz: -1L));
+        // Exactly on a boundary: the entry at that timestamp wins.
+        Assert.Equal(14_200_500L, ring.LookupAt(2_000, fallbackLoHz: -1L));
+        // Just before the first entry: best-effort oldest.
+        Assert.Equal(14_200_000L, ring.LookupAt(500, fallbackLoHz: -1L));
+    }
+
+    [Fact]
+    public void Wraparound_KeepsTheNewestCapacityEntries()
+    {
+        var ring = new LoHistoryRing(capacity: 4);
+        for (int i = 0; i < 10; i++)
+        {
+            ring.Append(timestamp: i * 100, loHz: 7_000_000L + i);
+        }
+        // Newest entry (t=900) serves late queries…
+        Assert.Equal(7_000_009L, ring.LookupAt(10_000, fallbackLoHz: -1L));
+        // …entries 6..9 survive (capacity 4); a query inside the window
+        // resolves correctly…
+        Assert.Equal(7_000_007L, ring.LookupAt(750, fallbackLoHz: -1L));
+        // …and a query older than the whole ring degrades to the oldest
+        // surviving value (bounded error, never a wild stamp).
+        Assert.Equal(7_000_006L, ring.LookupAt(0, fallbackLoHz: -1L));
+    }
+
+    [Fact]
+    public void Clear_ForgetsHistory()
+    {
+        var ring = new LoHistoryRing();
+        ring.Append(1_000, 14_200_000L);
+        ring.Clear();
+        Assert.Equal(-1L, ring.LookupAt(2_000, fallbackLoHz: -1L));
+    }
+
+    [Fact]
+    public void WheelGestureProfile_StampsAreMonotonicAndLagBounded()
+    {
+        // Simulate a 10-notch wheel burst at 50 ms spacing (500 Hz steps),
+        // then verify a 30 Hz tick sequence with an 85 ms lookback never
+        // produces a stamp that moves BACKWARD — the reversal-counter
+        // invariant from the #597 verification plan, applied server-side.
+        var ring = new LoHistoryRing();
+        const long tickHz = 10_000; // fake stopwatch resolution: 10 kHz
+        for (int i = 0; i < 10; i++)
+        {
+            ring.Append(timestamp: i * 50 * tickHz / 1000, loHz: 14_200_000L + i * 500);
+        }
+        long lookback = 85 * tickHz / 1000;
+        long prev = long.MinValue;
+        for (long t = 0; t < 1_000 * tickHz / 1000; t += 33 * tickHz / 1000)
+        {
+            long stamp = ring.LookupAt(t - lookback, fallbackLoHz: 14_200_000L);
+            Assert.True(stamp >= prev, $"stamp went backward at t={t}: {stamp} < {prev}");
+            prev = stamp;
+        }
+        // And the final settled stamp is the final LO.
+        Assert.Equal(14_204_500L, ring.LookupAt(long.MaxValue, fallbackLoHz: -1L));
+    }
+}

--- a/zeus-web/src/components/Panadapter.tsx
+++ b/zeus-web/src/components/Panadapter.tsx
@@ -48,7 +48,6 @@ import { planForFrame } from '../gl/frame-plan';
 import { cancelDrawBusFrame, requestDrawBusFrame } from '../realtime/draw-bus';
 import { registerFrameConsumer, useDisplayStore } from '../state/display-store';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
-import { useConnectionStore } from '../state/connection-store';
 import * as viewCenter from '../state/view-center';
 import { useTxStore } from '../state/tx-store';
 import { usePanTuneGesture } from '../util/use-pan-tune-gesture';
@@ -200,18 +199,12 @@ export function Panadapter() {
         // band buttons, typed entry, mode changes) and glides there — which
         // also arms the refill hold via the target-change stamp.
         viewCenter.reconcileFrame(frameCenter, state.hzPerPixel);
-        // Adopt fresh trace content only once the analyzer has refilled with
-        // post-retune IQ. Inside the hold the previous anchor keeps gliding
-        // at its own (correct) frequency — old signals never get redrawn at
-        // the new axis, which was the snap-back half of the judder.
-        const holdMs = viewCenter.refillHoldMsForSampleRate(
-          useConnectionStore.getState().sampleRate,
-        );
-        if (
-          state.panValid &&
-          state.panDb &&
-          !viewCenter.isWithinRefillHold(holdMs)
-        ) {
+        // Adoption is unconditional (issue #597 Phase 2): the backend now
+        // stamps CenterHz with the LO the pixels were actually computed at
+        // (delay-compensated LO-history lookup), so mid-retune frames are
+        // self-describing — the anchor model draws them where their data
+        // belongs and the old refill-hold heuristic is unnecessary.
+        if (state.panValid && state.panDb) {
           anchorPan = state.panDb;
           anchorCenterHz = frameCenter;
           anchorHzPerPixel = state.hzPerPixel;

--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -49,7 +49,6 @@ import { planForFrame } from '../gl/frame-plan';
 import { cancelDrawBusFrame, requestDrawBusFrame } from '../realtime/draw-bus';
 import { registerFrameConsumer, useDisplayStore } from '../state/display-store';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
-import { useConnectionStore } from '../state/connection-store';
 import * as viewCenter from '../state/view-center';
 import { useTxStore } from '../state/tx-store';
 import { usePanTuneGesture } from '../util/use-pan-tune-gesture';
@@ -61,13 +60,6 @@ import { WfDbScale } from './WfDbScale';
 // retunes stay synchronised with the panadapter's offset.
 // TODO(phase-3.1): expose as a UI setting.
 const WF_PUSH_EVERY_N = 2;
-// During the post-retune refill hold, fresh rows are partly computed from
-// pre-retune IQ and would smear old-frequency energy across the new axis —
-// suppress them. BUT a sustained drag restarts the hold forever, and a
-// frozen waterfall reads as broken; cap the withhold so at most this much
-// time passes between rows (rows-only cap — the pan trace stays clean and
-// frozen until the gesture pauses; adversary #3, issue #597).
-const WF_ROW_MAX_WITHHOLD_MS = 200;
 
 type WaterfallProps = {
   /** When true, noise floor fades to transparent so the QRZ-mode map shows through. */
@@ -173,7 +165,6 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
     };
     document.addEventListener('visibilitychange', onVisibilityChange);
 
-    let lastRowUploadAtMs = 0;
     const unsub = useDisplayStore.subscribe((state) => {
       if (state.lastSeq === lastSeqDrawn) return;
       lastSeqDrawn = state.lastSeq;
@@ -192,22 +183,9 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       if (wfDb) {
         tickCounter++;
         skipRowUpload = tickCounter % WF_PUSH_EVERY_N !== 0;
-        if (!skipRowUpload) {
-          // Refill hold: rows computed mid-retune carry old-frequency
-          // energy. Withhold them — but never longer than the cap, so a
-          // continuous drag keeps a (mildly smeared) waterfall flowing.
-          const holdMs = viewCenter.refillHoldMsForSampleRate(
-            useConnectionStore.getState().sampleRate,
-          );
-          const nowMs = performance.now();
-          if (
-            viewCenter.isWithinRefillHold(holdMs) &&
-            nowMs - lastRowUploadAtMs < WF_ROW_MAX_WITHHOLD_MS
-          ) {
-            skipRowUpload = true;
-          }
-          if (!skipRowUpload) lastRowUploadAtMs = nowMs;
-        }
+        // No refill hold here any more (issue #597 Phase 2): rows are
+        // stamped with the LO their data was captured at, so the shared
+        // shift planner places them correctly even mid-retune.
         // Feed the auto-range tracker — it's a no-op when AUTO is off.
         useDisplaySettingsStore.getState().updateAutoRange(wfDb);
       }


### PR DESCRIPTION
Phase 2 (final) of the #597 smooth-tuning stack. **Base is the Phase 1 branch** — this diff is Phase 2 only; retarget after #599 merges. Design: https://github.com/Kb2uka/openhpsdr-zeus/issues/597#issuecomment-4691893191

## What

Frames were stamped with the live `RadioLoHz` but their pixels came from IQ captured ~85-340 ms earlier — the root ambiguity behind the tuning snap-back. Now `Tick` stamps `CenterHz` from a small LO-history ring rewound by the capture delay (`D = ½·FFT-fill + EMA lag + per-protocol transport`) — the Thetis `pixel_ref` idea, **reusing the existing CenterHz field: no wire/contract change**.

With self-describing frames, Phase 1's refill-hold heuristic is **deleted**: trace adoption is unconditional, the waterfall rows cap goes away, and sustained drags show fresh correctly-placed content throughout.

## Safety / consumer audit (from the adversary review)

- **Stable-LO byte-identity pinned by regression test**: quiet dial ⇒ stamp == live `RadioLoHz` exactly. WWV auto-cal (#325 — prior spurious-cal incident) and `_calPanCenterHz` consumers run at stable LO and see no change.
- **Mis-tuned D degrades gracefully**: bounded, monotone lag — never a direction reversal (pinned by a wheel-burst sweep test).
- SpotOverlay/FreqAxis see ≤ ~100 ms extra label lag *mid-tune only* — intended (labels follow the data).
- PS untouched: one O(1) ring lookup added to Tick; nothing on the cc/feedback/TX path.
- `ZEUS_CENTER_STAMP_LAG_MS` overrides the EMA+transport term for bench tuning — sweep 48/96/192/384 kHz on **G2 (P2) and HL2 (P1)** before merge.

## Tests

`LoHistoryRingTests` (6): stable-LO regression, mid-gesture lookback, wraparound, clear, monotonic wheel-burst sweep. dotnet 1,466 passed · vitest 271 passed · both builds clean.

## Merge order for the stack

#598 (Phase 0) → retarget #599 → #599 (Phase 1) → retarget this → this. **Test the tip of this branch = the whole feature.** Do not merge until on-air tested on G2 + HL2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)