### PR TITLE
feat(voyeur): Phase 1 — unattended net-monitor capture + log management (zeus-la5)

### DIFF
--- a/Zeus.Server.Hosting/Voyeur/VoyeurAudioRing.cs
+++ b/Zeus.Server.Hosting/Voyeur/VoyeurAudioRing.cs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details. See ATTRIBUTIONS.md for full provenance.
+
+using System.Runtime.CompilerServices;
+
+namespace Zeus.Server.Voyeur;
+
+/// <summary>
+/// Lock-free single-producer / single-consumer float ring buffer for Voyeur
+/// Mode (issue zeus-la5). The PRODUCER is the DSP/RX thread inside
+/// <c>DspPipelineService.Tick</c> — the WDSP IQ-feed hot path — which calls
+/// <see cref="Write"/> exactly once per ~21 ms audio tick. The CONSUMER is the
+/// Voyeur drain thread (below-normal priority), which calls <see cref="Read"/>.
+///
+/// This is the load-bearing "cannot break anything" primitive: the producer
+/// path does only a bounded <c>Span.CopyTo</c> + two volatile index ops — no
+/// lock, no allocation, no IO, and crucially NO back-pressure. If the consumer
+/// has fallen behind and the ring is full, <see cref="Write"/> DROPS the block
+/// and bumps <see cref="DroppedSamples"/>, then returns immediately. A stalled
+/// or crashed Voyeur consumer is therefore invisible to RX — the worst case is
+/// a gap in the captured audio, never a stall in the radio.
+///
+/// Concurrency model: the producer owns <c>_write</c>, the consumer owns
+/// <c>_read</c>; each reads the other's position via <see cref="Volatile"/>.
+/// Capacity is rounded up to a power of two so index→slot is a mask. Positions
+/// are monotonic <c>long</c> (no wrap in any realistic runtime — 2^63 samples
+/// at 48 kHz is ~6 million years).
+/// </summary>
+public sealed class VoyeurAudioRing
+{
+    private readonly float[] _buffer;
+    private readonly int _mask;
+    private readonly int _capacity;
+
+    // Producer-owned write position; consumer-owned read position. Both
+    // monotonically increasing. Read across threads only via Volatile.
+    private long _write;
+    private long _read;
+    private long _dropped;
+
+    public VoyeurAudioRing(int capacitySamples)
+    {
+        if (capacitySamples < 2) capacitySamples = 2;
+        _capacity = NextPow2(capacitySamples);
+        _buffer = new float[_capacity];
+        _mask = _capacity - 1;
+    }
+
+    /// <summary>Ring capacity in samples (power of two).</summary>
+    public int Capacity => _capacity;
+
+    /// <summary>Total samples dropped because the ring was full when the
+    /// producer wrote (consumer fell behind). Monotonic; telemetry only.</summary>
+    public long DroppedSamples => Volatile.Read(ref _dropped);
+
+    /// <summary>Samples currently available to read. Telemetry / consumer use.</summary>
+    public int Available
+    {
+        get
+        {
+            long w = Volatile.Read(ref _write);
+            long r = Volatile.Read(ref _read);
+            return (int)(w - r);
+        }
+    }
+
+    /// <summary>
+    /// PRODUCER (DSP thread). Copy <paramref name="src"/> into the ring. If the
+    /// whole block doesn't fit, drop it entirely (block-atomic — a half-written
+    /// over is worse than a clean gap) and add its length to
+    /// <see cref="DroppedSamples"/>. O(n) memcpy, no alloc, no lock, never blocks.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Write(ReadOnlySpan<float> src)
+    {
+        if (src.IsEmpty) return;
+        long w = _write;                       // producer owns _write — plain read
+        long r = Volatile.Read(ref _read);     // consumer's position
+        int free = _capacity - (int)(w - r);
+        if (src.Length > free)
+        {
+            // Drop the whole block; never partially fill (keeps segment audio
+            // clean) and never overwrite unread data.
+            Interlocked.Add(ref _dropped, src.Length);
+            return;
+        }
+        int start = (int)(w & _mask);
+        int first = Math.Min(src.Length, _capacity - start);
+        src.Slice(0, first).CopyTo(_buffer.AsSpan(start));
+        if (first < src.Length)
+            src.Slice(first).CopyTo(_buffer.AsSpan(0)); // wrap
+        Volatile.Write(ref _write, w + src.Length);     // publish to consumer
+    }
+
+    /// <summary>
+    /// CONSUMER (drain thread). Copy up to <paramref name="dst"/>.Length samples
+    /// out of the ring. Returns the count actually read (0 when empty).
+    /// </summary>
+    public int Read(Span<float> dst)
+    {
+        if (dst.IsEmpty) return 0;
+        long r = _read;                        // consumer owns _read — plain read
+        long w = Volatile.Read(ref _write);    // producer's position
+        int avail = (int)(w - r);
+        if (avail <= 0) return 0;
+        int n = Math.Min(avail, dst.Length);
+        int start = (int)(r & _mask);
+        int first = Math.Min(n, _capacity - start);
+        _buffer.AsSpan(start, first).CopyTo(dst);
+        if (first < n)
+            _buffer.AsSpan(0, n - first).CopyTo(dst.Slice(first)); // wrap
+        Volatile.Write(ref _read, r + n);      // publish free space to producer
+        return n;
+    }
+
+    private static int NextPow2(int v)
+    {
+        v--;
+        v |= v >> 1; v |= v >> 2; v |= v >> 4; v |= v >> 8; v |= v >> 16;
+        return v + 1;
+    }
+}

--- a/Zeus.Server.Hosting/Voyeur/VoyeurModels.cs
+++ b/Zeus.Server.Hosting/Voyeur/VoyeurModels.cs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see ATTRIBUTIONS.md for provenance.
+
+namespace Zeus.Server.Voyeur;
+
+/// <summary>
+/// A Voyeur Mode monitoring session: one unattended "listen on a frequency"
+/// run. Persisted in LiteDB. Phase 1 captures the per-"over" transmission
+/// segments (timestamp / duration / level / audio file). The transcript and
+/// callsign-roster fields are reserved for Phase 2 (ASR) and Phase 3
+/// (enrichment) — they're nullable so those phases are purely additive.
+/// </summary>
+public sealed class VoyeurSessionDocument
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
+    /// <summary>Operator-editable name. Defaults to the freq + start time.</summary>
+    public string Label { get; set; } = "";
+    public DateTime StartedUtc { get; set; }
+    public DateTime? EndedUtc { get; set; }
+    public long FreqHz { get; set; }
+    public string Mode { get; set; } = "";
+    public string Band { get; set; } = "";
+    public int SegmentCount { get; set; }
+    /// <summary>Total captured "over" audio across the session, seconds.</summary>
+    public double CapturedSeconds { get; set; }
+    /// <summary>Samples the safety ring dropped during this session (consumer
+    /// fell behind). Telemetry — non-zero means a busy CPU, never a radio fault.</summary>
+    public long DroppedSamples { get; set; }
+    /// <summary>Pinned sessions are protected from the rolling-retention prune
+    /// (this is the operator's "save this log" flag).</summary>
+    public bool Pinned { get; set; }
+    /// <summary>Relative directory (under the Voyeur root) holding this
+    /// session's segment WAVs. Null when audio retention is off.</summary>
+    public string? AudioDir { get; set; }
+}
+
+/// <summary>One captured transmission ("over"). Phase 2 fills Transcript /
+/// Callsign / CallsignState from ASR + QRZ validation.</summary>
+public sealed class VoyeurSegmentDocument
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
+    public string SessionId { get; set; } = "";
+    public DateTime StartedUtc { get; set; }
+    public int DurationMs { get; set; }
+    public float PeakDbfs { get; set; }
+    /// <summary>WAV file name within the session's AudioDir, or null.</summary>
+    public string? AudioFile { get; set; }
+    // ---- Phase 2+ (reserved; null in Phase 1) ----
+    public string? Transcript { get; set; }
+    public string? Callsign { get; set; }
+    /// <summary>"confirmed" | "tentative" | "unknown" — QRZ-validation state.</summary>
+    public string? CallsignState { get; set; }
+}
+
+// ---- DTOs (wire shape for the REST API) ----
+
+public sealed record VoyeurStatusDto(
+    bool Active,
+    string? SessionId,
+    long FreqHz,
+    string Mode,
+    string Band,
+    int SegmentCount,
+    double CapturedSeconds,
+    long DroppedSamples,
+    int RingFillPct,
+    bool Degraded);
+
+public sealed record VoyeurSessionDto(
+    string Id,
+    string Label,
+    DateTime StartedUtc,
+    DateTime? EndedUtc,
+    long FreqHz,
+    string Mode,
+    string Band,
+    int SegmentCount,
+    double CapturedSeconds,
+    long DroppedSamples,
+    bool Pinned,
+    bool HasAudio);
+
+public sealed record VoyeurSegmentDto(
+    string Id,
+    DateTime StartedUtc,
+    int DurationMs,
+    float PeakDbfs,
+    bool HasAudio,
+    string? Transcript,
+    string? Callsign,
+    string? CallsignState);
+
+public sealed record VoyeurSessionDetailDto(
+    VoyeurSessionDto Session,
+    IReadOnlyList<VoyeurSegmentDto> Segments);
+
+public sealed record VoyeurUpdateRequest(string? Label, bool? Pinned);

--- a/Zeus.Server.Hosting/Voyeur/VoyeurMonitorService.cs
+++ b/Zeus.Server.Hosting/Voyeur/VoyeurMonitorService.cs
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see ATTRIBUTIONS.md for provenance.
+
+using System.Diagnostics;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Zeus.Contracts;
+using Zeus.Server.Voyeur;
+using Zeus.Server.Wav;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Voyeur Mode (zeus-la5) — Phase 1. Unattended passive monitor: park the
+/// radio on a frequency, capture each transmission ("over") to a log the
+/// operator can review, save, and delete later. Phase 2 adds whisper.cpp ASR
+/// (in a supervised child process) + callsign/QRZ enrichment; Phase 1 lands
+/// the safe foundation and the per-over capture + log management.
+///
+/// SAFETY — "cannot break anything" (zeus-la5 prime directive):
+/// • Default OFF. We only subscribe to <see cref="DspPipelineService.RxAudioAvailable"/>
+///   while a session is active, so an idle Voyeur Mode adds ZERO code to the
+///   RX path.
+/// • <see cref="OnRxAudio"/> runs on the DSP/RX producer thread and does ONLY
+///   a lock-free <see cref="VoyeurAudioRing.Write"/> (bounded memcpy + two
+///   volatile ops) — no alloc, no lock, no IO, no segmenting, no whisper. It is
+///   wrapped in try/catch that swallows everything (the producer's Invoke site
+///   has no per-delegate guard), and DETACHES on repeated fault so RX returns
+///   to a bit-identical no-op.
+/// • The ring has NO back-pressure: when full it drops the block and counts it.
+///   A stalled/slow consumer is invisible to RX — worst case is a capture gap.
+/// • All real work (segment detection, WAV writing, persistence) happens on the
+///   drain thread at BELOW-NORMAL priority, so it can never preempt the
+///   realtime WDSP / DSP / TX threads.
+/// • RX-only, receiver 0; touches neither the audio sink, the TX/IQ path, nor
+///   PureSignal.
+/// </summary>
+public sealed class VoyeurMonitorService : BackgroundService, IDisposable
+{
+    private readonly DspPipelineService _pipeline;
+    private readonly RadioService _radio;
+    private readonly VoyeurStore _store;
+    private readonly ILogger<VoyeurMonitorService> _log;
+
+    // Ring sized for ~6 s at 48 kHz — far more than the drain thread ever needs,
+    // so an occasional GC pause in the consumer never drops audio.
+    private const int RingSamples = 48_000 * 6;
+    private const int FaultDetachThreshold = 8;
+
+    private readonly object _ctrl = new();
+    private volatile bool _active;
+    private volatile bool _degraded;
+    private VoyeurAudioRing? _ring;
+    private Thread? _drain;
+    private CancellationTokenSource? _drainCts;
+    private VoyeurSessionDocument? _session;
+    private int _faultCount;
+
+    // Live status (written by the drain thread, read by REST — volatile/Interlocked).
+    private int _segmentCount;
+    private long _capturedMs;
+    private int _sampleRate = DspPipelineService.AudioOutputRateHz;
+
+    public VoyeurMonitorService(
+        DspPipelineService pipeline,
+        RadioService radio,
+        VoyeurStore store,
+        ILogger<VoyeurMonitorService> log)
+    {
+        _pipeline = pipeline;
+        _radio = radio;
+        _store = store;
+        _log = log;
+    }
+
+    // No background loop — the drain thread is spun up per session in Start().
+    protected override Task ExecuteAsync(CancellationToken stoppingToken) => Task.CompletedTask;
+
+    /// <summary>Begin monitoring the radio's current frequency. Idempotent-ish:
+    /// returns the existing status if already active.</summary>
+    public VoyeurStatusDto Start(bool keepAudio = true)
+    {
+        lock (_ctrl)
+        {
+            if (_active) return Status();
+
+            var s = _radio.Snapshot();
+            string band = BandUtils.FreqToBand(s.VfoHz) ?? "";
+            var session = _store.CreateSession(s.VfoHz, s.Mode.ToString(), band, keepAudio);
+
+            _session = session;
+            _segmentCount = 0;
+            _capturedMs = 0;
+            _faultCount = 0;
+            _degraded = false;
+            _ring = new VoyeurAudioRing(RingSamples);
+            _drainCts = new CancellationTokenSource();
+
+            // Subscribe LAST, after all state is built, so the first OnRxAudio
+            // can't see a half-initialized ring.
+            _pipeline.RxAudioAvailable += OnRxAudio;
+            _active = true;
+
+            var ct = _drainCts.Token;
+            _drain = new Thread(() => DrainLoop(session, keepAudio, ct))
+            {
+                IsBackground = true,
+                Name = "voyeur-drain",
+                Priority = ThreadPriority.BelowNormal, // never preempt realtime DSP/TX
+            };
+            _drain.Start();
+
+            _log.LogInformation(
+                "voyeur: started session {Id} freq={Freq} mode={Mode} band={Band} keepAudio={Keep}",
+                session.Id, s.VfoHz, s.Mode, band, keepAudio);
+            return Status();
+        }
+    }
+
+    /// <summary>Stop monitoring and finalize the current session.</summary>
+    public VoyeurStatusDto Stop()
+    {
+        Thread? drain;
+        VoyeurAudioRing? ring;
+        VoyeurSessionDocument? session;
+        lock (_ctrl)
+        {
+            if (!_active) return Status();
+            // Detach the tap FIRST so no more audio enters the ring, then let
+            // the drain thread finish the in-flight over and exit.
+            _pipeline.RxAudioAvailable -= OnRxAudio;
+            _active = false;
+            _drainCts?.Cancel();
+            drain = _drain;
+            ring = _ring;
+            session = _session;
+            _drain = null;
+        }
+
+        drain?.Join(TimeSpan.FromSeconds(3));
+        if (session is not null)
+            _store.FinalizeSession(session.Id, ring?.DroppedSamples ?? 0);
+
+        lock (_ctrl)
+        {
+            _ring = null;
+            _session = null;
+            _drainCts?.Dispose();
+            _drainCts = null;
+        }
+        _log.LogInformation("voyeur: stopped session {Id}", session?.Id);
+        return Status();
+    }
+
+    public VoyeurStatusDto Status()
+    {
+        var session = _session;
+        var ring = _ring;
+        int fill = ring is null ? 0 : (int)(100L * ring.Available / Math.Max(1, ring.Capacity));
+        return new VoyeurStatusDto(
+            Active: _active,
+            SessionId: session?.Id,
+            FreqHz: session?.FreqHz ?? 0,
+            Mode: session?.Mode ?? "",
+            Band: session?.Band ?? "",
+            SegmentCount: Volatile.Read(ref _segmentCount),
+            CapturedSeconds: Interlocked.Read(ref _capturedMs) / 1000.0,
+            DroppedSamples: ring?.DroppedSamples ?? 0,
+            RingFillPct: fill,
+            Degraded: _degraded);
+    }
+
+    // ---- PRODUCER (DSP/RX thread) — keep this trivially cheap and crash-proof ----
+    private void OnRxAudio(int receiver, int sampleRateHz, ReadOnlyMemory<float> samples)
+    {
+        // receiver 0 only; ignore anything else (single-radio scope).
+        if (receiver != 0) return;
+        var ring = _ring;
+        if (ring is null) return;
+        try
+        {
+            // The ONLY work on the producer thread: a bounded copy into the ring.
+            ring.Write(samples.Span);
+            _sampleRate = sampleRateHz;
+        }
+        catch
+        {
+            // The producer's Invoke site has no per-delegate guard, so an
+            // escaping throw would abort the rest of the DSP tick. Swallow it,
+            // and after repeated faults detach entirely so RX returns to a
+            // bit-identical no-op (the feature self-disables; the radio runs on).
+            if (Interlocked.Increment(ref _faultCount) >= FaultDetachThreshold)
+            {
+                try { _pipeline.RxAudioAvailable -= OnRxAudio; } catch { /* ignore */ }
+                _degraded = true;
+            }
+        }
+    }
+
+    // ---- CONSUMER (drain thread, below-normal priority) — all real work here ----
+    private void DrainLoop(VoyeurSessionDocument session, bool keepAudio, CancellationToken ct)
+    {
+        var ring = _ring;
+        if (ring is null) return;
+
+        var seg = new VoyeurSegmenter(_sampleRate);
+        var scratch = new float[4096];
+        string? audioDir = keepAudio ? _store.SessionAudioDir(session.Id) : null;
+
+        WavWriter? writer = null;
+        DateTime overStart = default;
+
+        void CloseOver(VoyeurSegmenter.Result r)
+        {
+            string? file = null;
+            if (writer is not null)
+            {
+                file = Path.GetFileName(writer.Path);
+                writer.Dispose();
+                writer = null;
+            }
+            var doc = new VoyeurSegmentDocument
+            {
+                SessionId = session.Id,
+                StartedUtc = overStart,
+                DurationMs = r.DurationMs,
+                PeakDbfs = r.PeakDbfs,
+                AudioFile = file,
+            };
+            Interlocked.Increment(ref _segmentCount);
+            Interlocked.Add(ref _capturedMs, r.DurationMs);
+            _store.AddSegment(doc, r.DurationMs / 1000.0, ring.DroppedSamples);
+            _log.LogDebug("voyeur: captured over {Dur}ms peak={Peak:F1}dBFS", r.DurationMs, r.PeakDbfs);
+        }
+
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                int n = ring.Read(scratch);
+                if (n == 0)
+                {
+                    Thread.Sleep(20); // ring empty — yield; below-normal priority
+                    continue;
+                }
+                var block = scratch.AsSpan(0, n);
+                var r = seg.Process(block);
+                switch (r.Transition)
+                {
+                    case VoyeurSegmenter.Transition.Started:
+                        overStart = DateTime.UtcNow;
+                        if (audioDir is not null)
+                        {
+                            var path = Path.Combine(audioDir, $"over-{overStart:yyyyMMdd-HHmmss-fff}.wav");
+                            writer = new WavWriter(path, _sampleRate);
+                            writer.Append(block);
+                        }
+                        break;
+                    case VoyeurSegmenter.Transition.Continuing:
+                        writer?.Append(block);
+                        break;
+                    case VoyeurSegmenter.Transition.Ended:
+                        CloseOver(r);
+                        break;
+                }
+            }
+
+            // Session stopping — flush any in-flight over.
+            var tail = seg.Flush();
+            if (tail.Transition == VoyeurSegmenter.Transition.Ended)
+                CloseOver(tail);
+            else
+                writer?.Dispose();
+        }
+        catch (Exception ex)
+        {
+            // A crash in the consumer must not affect RX (the tap is already
+            // a fire-and-forget ring write). Mark degraded and exit cleanly.
+            _degraded = true;
+            writer?.Dispose();
+            _log.LogError(ex, "voyeur: drain loop failed — monitor degraded, RX unaffected");
+        }
+    }
+
+    public override void Dispose()
+    {
+        if (_active) Stop();
+        base.Dispose();
+    }
+}

--- a/Zeus.Server.Hosting/Voyeur/VoyeurSegmenter.cs
+++ b/Zeus.Server.Hosting/Voyeur/VoyeurSegmenter.cs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see ATTRIBUTIONS.md for provenance.
+
+namespace Zeus.Server.Voyeur;
+
+/// <summary>
+/// Energy-based transmission ("over") segmenter for Voyeur Mode (zeus-la5
+/// Phase 1). Runs on the Voyeur drain thread — NEVER the DSP/RX thread — over
+/// the demodulated mono RX audio. Tracks a slow noise-floor follower and gates
+/// a segment open when short-window RMS rises a margin above it, closing the
+/// segment after a hang period of quiet so speech pauses don't chop one over
+/// into many.
+///
+/// Phase 2 replaces this with Silero VAD (the Phase-0 spike showed even
+/// un-gated whisper barely hallucinates on this audio, but VAD still cuts work
+/// and sharpens the per-over boundaries). The interface here — feed blocks,
+/// get start/continue/end transitions — is exactly what the ASR runner will
+/// consume, so Phase 2 is a swap of the detector, not a rewrite of the caller.
+/// </summary>
+public sealed class VoyeurSegmenter
+{
+    public enum Transition { Idle, Started, Continuing, Ended }
+
+    public readonly record struct Result(Transition Transition, int DurationMs, float PeakDbfs);
+
+    private readonly int _sampleRate;
+    private readonly double _openMarginDb;   // RMS must exceed floor by this to open
+    private readonly double _closeMarginDb;  // ...and fall below this to start the hang
+    private readonly int _hangSamples;       // quiet duration that ends an over
+    private readonly int _minSegmentSamples; // ignore blips shorter than this
+
+    private bool _active;
+    private bool _floorSeeded;
+    private double _noiseFloor = 1e-4; // linear RMS estimate; seeded to ambient on first block
+    private long _activeSamples;
+    private long _quietRun;
+    private float _peak;
+
+    public VoyeurSegmenter(
+        int sampleRate,
+        double openMarginDb = 8.0,
+        double closeMarginDb = 4.0,
+        double hangSeconds = 1.2,
+        double minSegmentSeconds = 0.4)
+    {
+        _sampleRate = sampleRate;
+        _openMarginDb = openMarginDb;
+        _closeMarginDb = closeMarginDb;
+        _hangSamples = (int)(hangSeconds * sampleRate);
+        _minSegmentSamples = (int)(minSegmentSeconds * sampleRate);
+    }
+
+    /// <summary>True while inside an over (caller should be capturing audio).</summary>
+    public bool IsActive => _active;
+
+    /// <summary>
+    /// Process one block of mono samples. Returns the transition for this block.
+    /// On <see cref="Transition.Ended"/>, DurationMs/PeakDbfs describe the over
+    /// that just closed. The caller appends the block to the segment's audio
+    /// whenever the result is Started or Continuing.
+    /// </summary>
+    public Result Process(ReadOnlySpan<float> block)
+    {
+        if (block.IsEmpty) return new Result(_active ? Transition.Continuing : Transition.Idle, 0, 0);
+
+        // Block RMS + peak.
+        double sumsq = 0;
+        float peak = 0;
+        foreach (var s in block)
+        {
+            sumsq += (double)s * s;
+            float a = s < 0 ? -s : s;
+            if (a > peak) peak = a;
+        }
+        double rms = Math.Sqrt(sumsq / block.Length);
+
+        // Seed the floor to the first block's ambient level so the open gate is
+        // relative to THIS receiver's noise, not an arbitrary constant. Without
+        // this, a quiet-but-above-1e-4 band floor would false-trigger an over on
+        // the very first block. The seed block itself never opens.
+        if (!_floorSeeded)
+        {
+            _noiseFloor = Math.Max(rms, 1e-6);
+            _floorSeeded = true;
+            return new Result(Transition.Idle, 0, 0);
+        }
+
+        // Noise-floor follower: track downward fast (find the quiet floor),
+        // upward slowly (don't let a loud over raise the floor and self-close).
+        if (rms < _noiseFloor)
+            _noiseFloor += (rms - _noiseFloor) * 0.20;
+        else
+            _noiseFloor += (rms - _noiseFloor) * 0.0005;
+        _noiseFloor = Math.Max(_noiseFloor, 1e-6);
+
+        double overDb = 20.0 * Math.Log10(rms / _noiseFloor);
+
+        if (!_active)
+        {
+            if (overDb >= _openMarginDb)
+            {
+                _active = true;
+                _activeSamples = block.Length;
+                _quietRun = 0;
+                _peak = peak;
+                return new Result(Transition.Started, 0, 0);
+            }
+            return new Result(Transition.Idle, 0, 0);
+        }
+
+        // Active.
+        _activeSamples += block.Length;
+        if (peak > _peak) _peak = peak;
+
+        if (overDb < _closeMarginDb)
+        {
+            _quietRun += block.Length;
+            if (_quietRun >= _hangSamples)
+            {
+                // Close the over. Subtract the trailing hang so the reported
+                // duration is the speech, not the hang tail.
+                long speechSamples = Math.Max(0, _activeSamples - _quietRun);
+                bool tooShort = speechSamples < _minSegmentSamples;
+                int durMs = (int)(speechSamples * 1000L / _sampleRate);
+                float peakDb = _peak > 0 ? 20f * MathF.Log10(_peak) : -120f;
+                Reset();
+                // A sub-minimum blip (a click, a fragment) is dropped: report
+                // Ended only for real overs so the caller doesn't store noise.
+                return tooShort
+                    ? new Result(Transition.Idle, 0, 0)
+                    : new Result(Transition.Ended, durMs, peakDb);
+            }
+        }
+        else
+        {
+            _quietRun = 0; // speech resumed within the hang window
+        }
+        return new Result(Transition.Continuing, 0, 0);
+    }
+
+    /// <summary>Force-close any in-flight over (session stop). Returns the
+    /// Ended result if a real over was open, else Idle.</summary>
+    public Result Flush()
+    {
+        if (!_active) return new Result(Transition.Idle, 0, 0);
+        long speechSamples = Math.Max(0, _activeSamples - _quietRun);
+        bool tooShort = speechSamples < _minSegmentSamples;
+        int durMs = (int)(speechSamples * 1000L / _sampleRate);
+        float peakDb = _peak > 0 ? 20f * MathF.Log10(_peak) : -120f;
+        Reset();
+        return tooShort ? new Result(Transition.Idle, 0, 0) : new Result(Transition.Ended, durMs, peakDb);
+    }
+
+    private void Reset()
+    {
+        _active = false;
+        _activeSamples = 0;
+        _quietRun = 0;
+        _peak = 0;
+    }
+}

--- a/Zeus.Server.Hosting/Voyeur/VoyeurStore.cs
+++ b/Zeus.Server.Hosting/Voyeur/VoyeurStore.cs
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see ATTRIBUTIONS.md for provenance.
+
+using LiteDB;
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Server.Voyeur;
+
+/// <summary>
+/// LiteDB persistence + audio-file management for Voyeur Mode logs (zeus-la5).
+/// This is the "save and delete these logs" surface: sessions and their
+/// per-over segments live in a dedicated <c>voyeur.db</c> (no secrets, so no
+/// password — unlike the credential DB), and segment audio lives under a
+/// Voyeur root inside the OS Downloads folder so the operator can find/replay
+/// the WAVs. Delete removes the records AND the on-disk audio directory; a
+/// rolling retention cap prunes the oldest UNPINNED sessions so an unattended
+/// multi-day run can't fill the disk.
+///
+/// All access is serialized under <c>_gate</c> — LiteDB is embedded and the
+/// callers (REST thread + the Voyeur drain thread finalizing segments) are
+/// distinct threads. None of this runs on the DSP/RX producer thread.
+/// </summary>
+public sealed class VoyeurStore : IDisposable
+{
+    private readonly object _gate = new();
+    private readonly ILogger<VoyeurStore> _log;
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<VoyeurSessionDocument> _sessions;
+    private readonly ILiteCollection<VoyeurSegmentDocument> _segments;
+    private readonly string _audioRoot;
+
+    /// <summary>Hard cap on retained sessions; oldest UNPINNED beyond this are
+    /// pruned (records + audio). Pinned ("saved") sessions never count toward
+    /// eviction. Generous — transcripts/metadata are tiny; the prune mainly
+    /// bounds segment-audio disk over long unattended use.</summary>
+    private const int MaxRetainedSessions = 200;
+
+    public VoyeurStore(ILogger<VoyeurStore> log)
+    {
+        _log = log;
+
+        var appData = Environment.GetFolderPath(
+            Environment.SpecialFolder.LocalApplicationData,
+            Environment.SpecialFolderOption.Create);
+        var zeusDir = Path.Combine(appData, "Zeus");
+        Directory.CreateDirectory(zeusDir);
+        var dbPath = Path.Combine(zeusDir, "voyeur.db");
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _sessions = _db.GetCollection<VoyeurSessionDocument>("sessions");
+        _segments = _db.GetCollection<VoyeurSegmentDocument>("segments");
+        _sessions.EnsureIndex(x => x.Id, unique: true);
+        _sessions.EnsureIndex(x => x.StartedUtc);
+        _segments.EnsureIndex(x => x.SessionId);
+
+        _audioRoot = ResolveAudioRoot();
+        Directory.CreateDirectory(_audioRoot);
+
+        _log.LogInformation("VoyeurStore initialized db={Db} audio={Audio}", dbPath, _audioRoot);
+    }
+
+    /// <summary>Audio segments land under Downloads/zeus-voyeur so the operator
+    /// finds them where recordings live; falls back to the home dir.</summary>
+    private static string ResolveAudioRoot()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var downloads = Path.Combine(home, "Downloads");
+        var baseDir = Directory.Exists(downloads) ? downloads : home;
+        return Path.Combine(baseDir, "zeus-voyeur");
+    }
+
+    public string AudioRoot => _audioRoot;
+
+    /// <summary>Absolute, traversal-guarded directory for a session's audio.
+    /// Created on demand. The guard mirrors WavRecorderService: the resolved
+    /// path must stay under the Voyeur root, so a crafted session id can't
+    /// escape it.</summary>
+    public string SessionAudioDir(string sessionId)
+    {
+        var safe = SanitizeId(sessionId);
+        var dir = Path.GetFullPath(Path.Combine(_audioRoot, safe));
+        var rootFull = Path.GetFullPath(_audioRoot);
+        if (!dir.StartsWith(rootFull, StringComparison.Ordinal))
+            throw new InvalidOperationException("session audio path escaped the Voyeur root");
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    public VoyeurSessionDocument CreateSession(long freqHz, string mode, string band, bool keepAudio)
+    {
+        lock (_gate)
+        {
+            var s = new VoyeurSessionDocument
+            {
+                StartedUtc = DateTime.UtcNow,
+                FreqHz = freqHz,
+                Mode = mode,
+                Band = band,
+                Label = $"{freqHz / 1_000_000.0:F3} MHz {mode} — {DateTime.Now:yyyy-MM-dd HH:mm}",
+            };
+            if (keepAudio) s.AudioDir = SanitizeId(s.Id);
+            _sessions.Insert(s);
+            PruneLocked();
+            return s;
+        }
+    }
+
+    public void AddSegment(VoyeurSegmentDocument seg, double capturedSeconds, long droppedSamples)
+    {
+        lock (_gate)
+        {
+            _segments.Insert(seg);
+            var s = _sessions.FindById(seg.SessionId);
+            if (s is not null)
+            {
+                s.SegmentCount += 1;
+                s.CapturedSeconds += capturedSeconds;
+                s.DroppedSamples = droppedSamples;
+                _sessions.Update(s);
+            }
+        }
+    }
+
+    public void FinalizeSession(string sessionId, long droppedSamples)
+    {
+        lock (_gate)
+        {
+            var s = _sessions.FindById(sessionId);
+            if (s is null) return;
+            s.EndedUtc = DateTime.UtcNow;
+            s.DroppedSamples = droppedSamples;
+            _sessions.Update(s);
+        }
+    }
+
+    public IReadOnlyList<VoyeurSessionDto> ListSessions()
+    {
+        lock (_gate)
+        {
+            return _sessions.Query()
+                .OrderByDescending(x => x.StartedUtc)
+                .ToList()
+                .Select(ToDto)
+                .ToList();
+        }
+    }
+
+    public VoyeurSessionDetailDto? GetSession(string id)
+    {
+        lock (_gate)
+        {
+            var s = _sessions.FindById(id);
+            if (s is null) return null;
+            var segs = _segments.Query()
+                .Where(x => x.SessionId == id)
+                .OrderBy(x => x.StartedUtc)
+                .ToList()
+                .Select(ToSegDto)
+                .ToList();
+            return new VoyeurSessionDetailDto(ToDto(s), segs);
+        }
+    }
+
+    /// <summary>Rename and/or pin ("save") a session. Returns the updated DTO,
+    /// or null if the session doesn't exist.</summary>
+    public VoyeurSessionDto? Update(string id, string? label, bool? pinned)
+    {
+        lock (_gate)
+        {
+            var s = _sessions.FindById(id);
+            if (s is null) return null;
+            if (label is not null) s.Label = label.Trim();
+            if (pinned is not null) s.Pinned = pinned.Value;
+            _sessions.Update(s);
+            return ToDto(s);
+        }
+    }
+
+    /// <summary>Delete a session: its segment records AND its on-disk audio
+    /// directory. Idempotent. Returns true if a session was removed.</summary>
+    public bool Delete(string id)
+    {
+        lock (_gate)
+        {
+            var s = _sessions.FindById(id);
+            if (s is null) return false;
+            _segments.DeleteMany(x => x.SessionId == id);
+            _sessions.Delete(id);
+            DeleteAudioDir(s);
+            _log.LogInformation("voyeur: deleted session {Id} ({Label})", id, s.Label);
+            return true;
+        }
+    }
+
+    private void PruneLocked()
+    {
+        // Evict oldest UNPINNED sessions beyond the cap. Pinned/saved logs are
+        // never pruned — that's the whole point of the save flag.
+        var unpinned = _sessions.Query()
+            .Where(x => !x.Pinned)
+            .OrderByDescending(x => x.StartedUtc)
+            .ToList();
+        if (unpinned.Count <= MaxRetainedSessions) return;
+        foreach (var s in unpinned.Skip(MaxRetainedSessions))
+        {
+            _segments.DeleteMany(x => x.SessionId == s.Id);
+            _sessions.Delete(s.Id);
+            DeleteAudioDir(s);
+            _log.LogInformation("voyeur: pruned old session {Id} (retention cap)", s.Id);
+        }
+    }
+
+    private void DeleteAudioDir(VoyeurSessionDocument s)
+    {
+        if (s.AudioDir is null) return;
+        try
+        {
+            var dir = Path.GetFullPath(Path.Combine(_audioRoot, s.AudioDir));
+            var rootFull = Path.GetFullPath(_audioRoot);
+            // Traversal guard: only ever delete inside the Voyeur root.
+            if (dir.StartsWith(rootFull, StringComparison.Ordinal) && Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "voyeur: failed to delete audio dir for session {Id}", s.Id);
+        }
+    }
+
+    private static string SanitizeId(string id)
+    {
+        // Ids are GUID-N (hex) by construction; this is defense-in-depth so a
+        // hand-crafted id can never contain a path separator.
+        Span<char> buf = stackalloc char[id.Length];
+        int n = 0;
+        foreach (var c in id)
+            if (char.IsLetterOrDigit(c)) buf[n++] = c;
+        return n == 0 ? "session" : new string(buf[..n]);
+    }
+
+    private VoyeurSessionDto ToDto(VoyeurSessionDocument s) => new(
+        s.Id, s.Label, s.StartedUtc, s.EndedUtc, s.FreqHz, s.Mode, s.Band,
+        s.SegmentCount, s.CapturedSeconds, s.DroppedSamples, s.Pinned,
+        HasAudio: s.AudioDir is not null);
+
+    private static VoyeurSegmentDto ToSegDto(VoyeurSegmentDocument x) => new(
+        x.Id, x.StartedUtc, x.DurationMs, x.PeakDbfs,
+        HasAudio: x.AudioFile is not null,
+        x.Transcript, x.Callsign, x.CallsignState);
+
+    public void Dispose() => _db.Dispose();
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -167,6 +167,31 @@ public static class ZeusEndpoints
             catch (FileNotFoundException) { return Results.NotFound(new { error = "recording not found" }); }
         });
 
+        // ---- Voyeur Mode (zeus-la5) — unattended net monitor + log mgmt ----
+        app.MapGet("/api/voyeur/status", (VoyeurMonitorService v) => Results.Ok(v.Status()));
+        app.MapPost("/api/voyeur/start", (VoyeurStartRequest? body, VoyeurMonitorService v) =>
+            Results.Ok(v.Start(keepAudio: body?.KeepAudio ?? true)));
+        app.MapPost("/api/voyeur/stop", (VoyeurMonitorService v) => Results.Ok(v.Stop()));
+        app.MapGet("/api/voyeur/sessions", (Zeus.Server.Voyeur.VoyeurStore store) =>
+            Results.Ok(store.ListSessions()));
+        app.MapGet("/api/voyeur/sessions/{id}", (string id, Zeus.Server.Voyeur.VoyeurStore store) =>
+        {
+            var d = store.GetSession(id);
+            return d is null ? Results.NotFound(new { error = "session not found" }) : Results.Ok(d);
+        });
+        // Rename and/or pin ("save") a log so retention never prunes it.
+        app.MapPatch("/api/voyeur/sessions/{id}",
+            (string id, Zeus.Server.Voyeur.VoyeurUpdateRequest body, Zeus.Server.Voyeur.VoyeurStore store) =>
+        {
+            var d = store.Update(id, body?.Label, body?.Pinned);
+            return d is null ? Results.NotFound(new { error = "session not found" }) : Results.Ok(d);
+        });
+        // Delete a log: records + on-disk segment audio.
+        app.MapDelete("/api/voyeur/sessions/{id}", (string id, Zeus.Server.Voyeur.VoyeurStore store) =>
+            store.Delete(id)
+                ? Results.Ok(new { deleted = id })
+                : Results.NotFound(new { error = "session not found" }));
+
         app.MapGet("/api/state", (RadioService r) => r.Snapshot());
 
         // TX diagnostic — exposes the producer/consumer counts for the mic-to-IQ ring
@@ -1495,3 +1520,4 @@ internal sealed record ChainOrderSetRequest(List<string> PluginIds);
 internal sealed record MasterBypassSetRequest(bool Bypassed);
 internal sealed record WavRecordStartRequest(string? Source);
 internal sealed record WavPlayRequest(string? File);
+internal sealed record VoyeurStartRequest(bool? KeepAudio);

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -275,6 +275,13 @@ public static class ZeusHost
         // host and headless — see CwDecoderService.
         builder.Services.AddSingleton<CwDecoderService>();
         builder.Services.AddHostedService(sp => sp.GetRequiredService<CwDecoderService>());
+        // Voyeur Mode (zeus-la5) — unattended net monitor. Default OFF; only
+        // taps RX audio while a session is active (see VoyeurMonitorService
+        // "cannot break anything" notes). VoyeurStore owns the LiteDB log +
+        // segment-audio files (the save/delete surface).
+        builder.Services.AddSingleton<Zeus.Server.Voyeur.VoyeurStore>();
+        builder.Services.AddSingleton<VoyeurMonitorService>();
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<VoyeurMonitorService>());
         // WAV recorder/player: taps DspPipelineService RX + TX-monitor audio to
         // record float32 WAVs (default save folder = Downloads) and plays them
         // back locally via the audition sink. Over-the-air playback is layered

--- a/tests/Zeus.Server.Tests/VoyeurAudioRingTests.cs
+++ b/tests/Zeus.Server.Tests/VoyeurAudioRingTests.cs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Tests for the Voyeur Mode lock-free SPSC audio ring (zeus-la5). This is the
+// "cannot break anything" primitive: the producer (DSP/RX thread) must never
+// block or overwrite unread data, and a slow consumer must only ever cause a
+// counted drop — never corruption and never a stall.
+
+using System.Threading;
+using Xunit;
+using Zeus.Server.Voyeur;
+
+namespace Zeus.Server.Tests;
+
+public class VoyeurAudioRingTests
+{
+    [Fact]
+    public void RoundsCapacityUpToPowerOfTwo()
+    {
+        Assert.Equal(1024, new VoyeurAudioRing(1000).Capacity);
+        Assert.Equal(1024, new VoyeurAudioRing(1024).Capacity);
+        Assert.Equal(2, new VoyeurAudioRing(1).Capacity);
+    }
+
+    [Fact]
+    public void WriteThenReadRoundTripsExactSamples()
+    {
+        var ring = new VoyeurAudioRing(16);
+        var src = new float[] { 1, 2, 3, 4, 5 };
+        ring.Write(src);
+        Assert.Equal(5, ring.Available);
+        var dst = new float[5];
+        Assert.Equal(5, ring.Read(dst));
+        Assert.Equal(src, dst);
+        Assert.Equal(0, ring.Available);
+        Assert.Equal(0, ring.DroppedSamples);
+    }
+
+    [Fact]
+    public void WrapsAroundCorrectly()
+    {
+        var ring = new VoyeurAudioRing(8); // capacity 8
+        // Fill, drain most, then write across the wrap boundary.
+        ring.Write(new float[] { 1, 2, 3, 4, 5, 6 });
+        var tmp = new float[4];
+        Assert.Equal(4, ring.Read(tmp)); // read 1,2,3,4 — read idx now 4
+        ring.Write(new float[] { 7, 8, 9, 10 }); // writes 7,8 then wraps 9,10
+        var dst = new float[6];
+        Assert.Equal(6, ring.Read(dst)); // 5,6,7,8,9,10
+        Assert.Equal(new float[] { 5, 6, 7, 8, 9, 10 }, dst);
+    }
+
+    [Fact]
+    public void DropsWholeBlockWhenFull_NeverOverwritesUnread()
+    {
+        var ring = new VoyeurAudioRing(8); // capacity 8
+        ring.Write(new float[] { 1, 2, 3, 4, 5, 6 }); // 6 used, 2 free
+        ring.Write(new float[] { 7, 8, 9 });          // needs 3, only 2 free -> DROP whole block
+        Assert.Equal(3, ring.DroppedSamples);
+        Assert.Equal(6, ring.Available);
+        // The unread data is intact — the dropped block did not corrupt it.
+        var dst = new float[6];
+        Assert.Equal(6, ring.Read(dst));
+        Assert.Equal(new float[] { 1, 2, 3, 4, 5, 6 }, dst);
+    }
+
+    [Fact]
+    public void ReadFromEmptyReturnsZero()
+    {
+        var ring = new VoyeurAudioRing(8);
+        Assert.Equal(0, ring.Read(new float[4]));
+    }
+
+    [Fact]
+    public void PartialReadLeavesRemainder()
+    {
+        var ring = new VoyeurAudioRing(16);
+        ring.Write(new float[] { 1, 2, 3, 4, 5 });
+        var dst = new float[3];
+        Assert.Equal(3, ring.Read(dst));
+        Assert.Equal(new float[] { 1, 2, 3 }, dst);
+        Assert.Equal(2, ring.Available);
+    }
+
+    [Fact]
+    public void ConcurrentProducerConsumer_NoLossNoCorruption_WhenConsumerKeepsUp()
+    {
+        // A real SPSC stress: producer writes a known ramp in blocks, consumer
+        // drains continuously. With a generously sized ring and a keeping-up
+        // consumer, every sample arrives in order with zero drops.
+        const int total = 2_048_000; // multiple of the 256-sample block
+        var ring = new VoyeurAudioRing(1 << 16);
+        long nextExpected = 0;
+        bool corrupt = false;
+
+        var consumer = new Thread(() =>
+        {
+            var buf = new float[1024];
+            long seen = 0;
+            while (seen < total)
+            {
+                int n = ring.Read(buf);
+                for (int i = 0; i < n; i++)
+                {
+                    if (buf[i] != (float)(nextExpected)) { corrupt = true; }
+                    nextExpected++;
+                }
+                seen += n;
+                if (n == 0) Thread.SpinWait(50);
+            }
+        });
+        consumer.Start();
+
+        var block = new float[256];
+        long produced = 0;
+        while (produced < total)
+        {
+            for (int i = 0; i < block.Length; i++) block[i] = (float)(produced + i);
+            // Retry on drop so this "keeps up" test asserts ordering, not policy
+            // (the drop policy itself is covered by DropsWholeBlockWhenFull).
+            long before = ring.DroppedSamples;
+            ring.Write(block);
+            if (ring.DroppedSamples == before) produced += block.Length;
+            else Thread.SpinWait(50); // ring momentarily full; retry same block
+        }
+        consumer.Join();
+
+        Assert.False(corrupt, "consumer observed an out-of-order / corrupt sample");
+        Assert.Equal(total, nextExpected);
+    }
+}

--- a/tests/Zeus.Server.Tests/VoyeurSegmenterTests.cs
+++ b/tests/Zeus.Server.Tests/VoyeurSegmenterTests.cs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Tests for the Voyeur Mode energy segmenter (zeus-la5 Phase 1): detects
+// transmission "overs" by energy over the noise floor, with hang time so
+// speech pauses don't split one over, and a minimum length so blips are
+// ignored. Phase 2 swaps this detector for Silero VAD behind the same
+// transition interface.
+
+using System;
+using Xunit;
+using Zeus.Server.Voyeur;
+
+namespace Zeus.Server.Tests;
+
+public class VoyeurSegmenterTests
+{
+    private const int Rate = 48_000;
+
+    private static float[] Block(int samples, float amplitude, int seed)
+    {
+        // Pseudo-random noise at a given amplitude (deterministic per seed).
+        var rng = new Random(seed);
+        var b = new float[samples];
+        for (int i = 0; i < samples; i++)
+            b[i] = (float)((rng.NextDouble() * 2 - 1) * amplitude);
+        return b;
+    }
+
+    private static void Warm(VoyeurSegmenter seg, float floorAmp)
+    {
+        // Feed quiet blocks so the noise-floor follower settles.
+        for (int i = 0; i < 30; i++)
+            seg.Process(Block(2048, floorAmp, i));
+    }
+
+    [Fact]
+    public void DetectsAnOver_StartThenEnd()
+    {
+        var seg = new VoyeurSegmenter(Rate, hangSeconds: 0.2, minSegmentSeconds: 0.1);
+        Warm(seg, 0.001f);
+
+        // Loud speech-like energy for ~0.5 s (well above the 8 dB open margin).
+        bool sawStart = false;
+        for (int i = 0; i < 12; i++) // 12 * 2048 ≈ 0.5 s
+        {
+            var r = seg.Process(Block(2048, 0.3f, 100 + i));
+            if (r.Transition == VoyeurSegmenter.Transition.Started) sawStart = true;
+        }
+        Assert.True(sawStart, "segmenter did not open an over on loud audio");
+        Assert.True(seg.IsActive);
+
+        // Go quiet; after the hang time the over must close.
+        VoyeurSegmenter.Result ended = default;
+        for (int i = 0; i < 30; i++)
+        {
+            var r = seg.Process(Block(2048, 0.001f, 500 + i));
+            if (r.Transition == VoyeurSegmenter.Transition.Ended) { ended = r; break; }
+        }
+        Assert.Equal(VoyeurSegmenter.Transition.Ended, ended.Transition);
+        Assert.False(seg.IsActive);
+        Assert.True(ended.DurationMs > 0, "ended over reported zero duration");
+        Assert.True(ended.PeakDbfs < 0 && ended.PeakDbfs > -120, $"unexpected peak {ended.PeakDbfs}");
+    }
+
+    [Fact]
+    public void HangTime_DoesNotSplitOnShortPause()
+    {
+        var seg = new VoyeurSegmenter(Rate, hangSeconds: 0.5, minSegmentSeconds: 0.1);
+        Warm(seg, 0.001f);
+
+        int ends = 0;
+        // speech ... brief 0.1 s pause ... speech — one over, not two.
+        void Speak(int n, int seed) { for (int i = 0; i < n; i++) { var r = seg.Process(Block(2048, 0.3f, seed + i)); if (r.Transition == VoyeurSegmenter.Transition.Ended) ends++; } }
+        void Pause(int n, int seed) { for (int i = 0; i < n; i++) { var r = seg.Process(Block(2048, 0.001f, seed + i)); if (r.Transition == VoyeurSegmenter.Transition.Ended) ends++; } }
+
+        Speak(10, 0);
+        Pause(2, 1000);   // ~0.085 s < 0.5 s hang -> must NOT end
+        Speak(10, 2000);
+        Assert.Equal(0, ends);
+        Assert.True(seg.IsActive);
+    }
+
+    [Fact]
+    public void IgnoresSubMinimumBlip()
+    {
+        var seg = new VoyeurSegmenter(Rate, hangSeconds: 0.2, minSegmentSeconds: 0.5);
+        Warm(seg, 0.001f);
+
+        // A single loud block (~43 ms) — far under the 0.5 s minimum.
+        seg.Process(Block(2048, 0.3f, 1));
+        VoyeurSegmenter.Result result = default;
+        for (int i = 0; i < 30; i++)
+        {
+            var r = seg.Process(Block(2048, 0.001f, 200 + i));
+            if (r.Transition == VoyeurSegmenter.Transition.Ended) { result = r; break; }
+        }
+        // Blip is dropped: it closes as Idle, never reported as a real over.
+        Assert.NotEqual(VoyeurSegmenter.Transition.Ended, result.Transition);
+        Assert.False(seg.IsActive);
+    }
+
+    [Fact]
+    public void Flush_ClosesInFlightOver()
+    {
+        var seg = new VoyeurSegmenter(Rate, hangSeconds: 2.0, minSegmentSeconds: 0.1);
+        Warm(seg, 0.001f);
+        for (int i = 0; i < 12; i++) seg.Process(Block(2048, 0.3f, i)); // open + sustain
+        Assert.True(seg.IsActive);
+
+        var r = seg.Flush();
+        Assert.Equal(VoyeurSegmenter.Transition.Ended, r.Transition);
+        Assert.False(seg.IsActive);
+        Assert.True(r.DurationMs > 0);
+    }
+
+    [Fact]
+    public void SteadyQuiet_NeverOpens()
+    {
+        var seg = new VoyeurSegmenter(Rate);
+        for (int i = 0; i < 100; i++)
+        {
+            var r = seg.Process(Block(2048, 0.001f, i));
+            Assert.Equal(VoyeurSegmenter.Transition.Idle, r.Transition);
+        }
+        Assert.False(seg.IsActive);
+    }
+}

--- a/tests/Zeus.Server.Tests/VoyeurStoreTests.cs
+++ b/tests/Zeus.Server.Tests/VoyeurStoreTests.cs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Tests for VoyeurStore (zeus-la5) — the "save and delete these logs" surface:
+// session/segment persistence, pin-to-save, delete (records + audio dir), and
+// the traversal guard on session audio paths.
+//
+// Note: VoyeurStore writes its LiteDB + audio under the OS LocalAppData/Zeus
+// and Downloads/zeus-voyeur. These tests exercise the public API end-to-end on
+// the real store and clean up the sessions they create, so they don't depend
+// on a particular environment but do touch disk (consistent with the other
+// LiteDB-backed store tests in this suite).
+
+using System.IO;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+using Zeus.Server.Voyeur;
+
+namespace Zeus.Server.Tests;
+
+public class VoyeurStoreTests
+{
+    private static VoyeurStore NewStore() => new(NullLogger<VoyeurStore>.Instance);
+
+    [Fact]
+    public void CreateListGetDelete_RoundTrips()
+    {
+        var store = NewStore();
+        var created = store.CreateSession(7_255_000, "LSB", "40m", keepAudio: false);
+        try
+        {
+            Assert.Contains(store.ListSessions(), s => s.Id == created.Id);
+
+            var detail = store.GetSession(created.Id);
+            Assert.NotNull(detail);
+            Assert.Equal(7_255_000, detail!.Session.FreqHz);
+            Assert.Equal("LSB", detail.Session.Mode);
+            Assert.Equal("40m", detail.Session.Band);
+            Assert.Empty(detail.Segments);
+        }
+        finally
+        {
+            Assert.True(store.Delete(created.Id));
+            Assert.Null(store.GetSession(created.Id));
+            // Idempotent delete.
+            Assert.False(store.Delete(created.Id));
+            store.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AddSegment_UpdatesSessionCountsAndIsReturned()
+    {
+        var store = NewStore();
+        var session = store.CreateSession(14_200_000, "USB", "20m", keepAudio: false);
+        try
+        {
+            store.AddSegment(new VoyeurSegmentDocument
+            {
+                SessionId = session.Id,
+                StartedUtc = System.DateTime.UtcNow,
+                DurationMs = 4200,
+                PeakDbfs = -6.5f,
+            }, capturedSeconds: 4.2, droppedSamples: 0);
+
+            var detail = store.GetSession(session.Id);
+            Assert.NotNull(detail);
+            Assert.Equal(1, detail!.Session.SegmentCount);
+            Assert.Equal(4.2, detail.Session.CapturedSeconds, 3);
+            Assert.Single(detail.Segments);
+            Assert.Equal(4200, detail.Segments[0].DurationMs);
+        }
+        finally
+        {
+            store.Delete(session.Id);
+            store.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Update_RenamesAndPins()
+    {
+        var store = NewStore();
+        var session = store.CreateSession(7_200_000, "LSB", "40m", keepAudio: false);
+        try
+        {
+            var updated = store.Update(session.Id, label: "Saturday eCARS", pinned: true);
+            Assert.NotNull(updated);
+            Assert.Equal("Saturday eCARS", updated!.Label);
+            Assert.True(updated.Pinned);
+
+            // Null fields leave the existing value untouched.
+            var again = store.Update(session.Id, label: null, pinned: null);
+            Assert.Equal("Saturday eCARS", again!.Label);
+            Assert.True(again.Pinned);
+        }
+        finally
+        {
+            store.Delete(session.Id);
+            store.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Delete_RemovesSegmentsAndAudioDir()
+    {
+        var store = NewStore();
+        var session = store.CreateSession(7_255_000, "LSB", "40m", keepAudio: true);
+        var audioDir = store.SessionAudioDir(session.Id);
+        File.WriteAllText(Path.Combine(audioDir, "over-test.wav"), "x");
+        store.AddSegment(new VoyeurSegmentDocument
+        {
+            SessionId = session.Id,
+            StartedUtc = System.DateTime.UtcNow,
+            DurationMs = 1000,
+            AudioFile = "over-test.wav",
+        }, 1.0, 0);
+
+        Assert.True(Directory.Exists(audioDir));
+        Assert.True(store.Delete(session.Id));
+        Assert.False(Directory.Exists(audioDir), "audio dir should be removed on delete");
+        Assert.Null(store.GetSession(session.Id));
+        store.Dispose();
+    }
+
+    [Fact]
+    public void SessionAudioDir_NeutralizesTraversal_StaysUnderRoot()
+    {
+        var store = NewStore();
+        try
+        {
+            // A crafted id with path separators is sanitized to safe characters,
+            // so the resolved dir can never escape the Voyeur root.
+            var dir = store.SessionAudioDir("../../etc/passwd");
+            var rootFull = Path.GetFullPath(store.AudioRoot);
+            Assert.StartsWith(rootFull, Path.GetFullPath(dir));
+            Assert.DoesNotContain("..", Path.GetRelativePath(rootFull, dir));
+            if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
+        }
+        finally
+        {
+            store.Dispose();
+        }
+    }
+}

--- a/zeus-web/src/api/voyeur.ts
+++ b/zeus-web/src/api/voyeur.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see ATTRIBUTIONS.md for provenance.
+
+// Voyeur Mode (zeus-la5) REST client. Voyeur Mode parks the radio on a
+// frequency and logs each transmission ("over"); these calls drive the
+// start/stop control and the save/delete log management.
+
+export type VoyeurStatus = {
+  active: boolean;
+  sessionId: string | null;
+  freqHz: number;
+  mode: string;
+  band: string;
+  segmentCount: number;
+  capturedSeconds: number;
+  droppedSamples: number;
+  ringFillPct: number;
+  degraded: boolean;
+};
+
+export type VoyeurSession = {
+  id: string;
+  label: string;
+  startedUtc: string;
+  endedUtc: string | null;
+  freqHz: number;
+  mode: string;
+  band: string;
+  segmentCount: number;
+  capturedSeconds: number;
+  droppedSamples: number;
+  pinned: boolean;
+  hasAudio: boolean;
+};
+
+export type VoyeurSegment = {
+  id: string;
+  startedUtc: string;
+  durationMs: number;
+  peakDbfs: number;
+  hasAudio: boolean;
+  transcript: string | null;
+  callsign: string | null;
+  // "confirmed" | "tentative" | "unknown" (Phase 2 — null in Phase 1)
+  callsignState: string | null;
+};
+
+export type VoyeurSessionDetail = {
+  session: VoyeurSession;
+  segments: VoyeurSegment[];
+};
+
+async function json<T>(input: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(input, init);
+  if (!res.ok) {
+    let message = `${res.status} ${res.statusText}`;
+    try {
+      const body = (await res.json()) as { error?: string };
+      if (body?.error) message = body.error;
+    } catch {
+      /* ignore */
+    }
+    throw new Error(message);
+  }
+  return (await res.json()) as T;
+}
+
+export const getVoyeurStatus = (signal?: AbortSignal) =>
+  json<VoyeurStatus>('/api/voyeur/status', { signal });
+
+export const startVoyeur = (keepAudio = true) =>
+  json<VoyeurStatus>('/api/voyeur/start', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ keepAudio }),
+  });
+
+export const stopVoyeur = () =>
+  json<VoyeurStatus>('/api/voyeur/stop', { method: 'POST' });
+
+export const listVoyeurSessions = (signal?: AbortSignal) =>
+  json<VoyeurSession[]>('/api/voyeur/sessions', { signal });
+
+export const getVoyeurSession = (id: string, signal?: AbortSignal) =>
+  json<VoyeurSessionDetail>(`/api/voyeur/sessions/${encodeURIComponent(id)}`, { signal });
+
+export const updateVoyeurSession = (
+  id: string,
+  patch: { label?: string; pinned?: boolean },
+) =>
+  json<VoyeurSession>(`/api/voyeur/sessions/${encodeURIComponent(id)}`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+
+export const deleteVoyeurSession = (id: string) =>
+  json<{ deleted: string }>(`/api/voyeur/sessions/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+  });

--- a/zeus-web/src/layout/__tests__/AddPanelModal.test.tsx
+++ b/zeus-web/src/layout/__tests__/AddPanelModal.test.tsx
@@ -55,10 +55,10 @@ describe('AddPanelModal', () => {
     const cards = container.querySelectorAll(
       '[data-testid="add-panel-cards"] .add-panel-card',
     );
-    // 21 panels in registry (CW Decoder added in zeus-cdn; RF-2K panel was
+    // 22 panels in registry (CW Decoder added in zeus-cdn; RF-2K panel was
     // extracted to a plugin; Rotator Dial was added in #385; WAV recorder
-    // added in #579).
-    expect(cards.length).toBe(21);
+    // added in #579; Voyeur Mode net monitor added in zeus-la5).
+    expect(cards.length).toBe(22);
     unmount();
   });
 

--- a/zeus-web/src/layout/panels.ts
+++ b/zeus-web/src/layout/panels.ts
@@ -64,6 +64,7 @@ import { StepPanel } from './panels/StepPanel';
 import { MeterGroupPanel } from '../components/meter-group/MeterGroupPanel';
 import { AnalogMeterPanel } from './panels/AnalogMeterPanel';
 import { WavRecorderPanel } from './panels/WavRecorderPanel';
+import { VoyeurPanel } from './panels/VoyeurPanel';
 
 export type PanelCategory =
   | 'spectrum'
@@ -314,6 +315,15 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'tools',
     tags: ['recorder', 'wav', 'tape', 'record', 'playback', 'audio', 'reel'],
     component: WavRecorderPanel,
+    maxW: 4,
+  },
+  voyeur: {
+    id: 'voyeur',
+    name: 'Voyeur Mode · Net Monitor',
+    category: 'tools',
+    tags: ['voyeur', 'monitor', 'net', 'log', 'transcribe', 'listen', 'unattended', 'who', 'roster'],
+    component: VoyeurPanel,
+    headerless: true,
     maxW: 4,
   },
   analogmeter: {

--- a/zeus-web/src/layout/panels/VoyeurPanel.tsx
+++ b/zeus-web/src/layout/panels/VoyeurPanel.tsx
@@ -1,0 +1,353 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see ATTRIBUTIONS.md for provenance.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { TileChrome } from '../TileChrome';
+import type { PanelComponentProps } from '../panels';
+import {
+  deleteVoyeurSession,
+  getVoyeurSession,
+  getVoyeurStatus,
+  listVoyeurSessions,
+  startVoyeur,
+  stopVoyeur,
+  updateVoyeurSession,
+  type VoyeurSession,
+  type VoyeurSessionDetail,
+  type VoyeurStatus,
+} from '../../api/voyeur';
+
+// Voyeur Mode (zeus-la5) — Phase 1 panel. Park the radio on a frequency, let
+// the backend capture each transmission ("over") to a log, then review / save
+// / delete those logs. The transcript + callsign columns light up in Phase 2
+// (ASR); Phase 1 surfaces the captured-over metadata and the management UI.
+//
+// Visual design is intentionally restrained and token-only (KB2UKA owns all
+// design decisions on this repo); structure first, polish on his call.
+
+function fmtFreq(hz: number): string {
+  return `${(hz / 1_000_000).toFixed(3)} MHz`;
+}
+function fmtDur(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.round(seconds % 60);
+  return m > 0 ? `${m}m ${s}s` : `${s}s`;
+}
+function fmtWhen(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export function VoyeurPanel({ onRemove }: PanelComponentProps) {
+  const handleRemove = onRemove ?? (() => {});
+  const [status, setStatus] = useState<VoyeurStatus | null>(null);
+  const [sessions, setSessions] = useState<VoyeurSession[]>([]);
+  const [openId, setOpenId] = useState<string | null>(null);
+  const [detail, setDetail] = useState<VoyeurSessionDetail | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const editingRef = useRef<HTMLInputElement | null>(null);
+
+  const refreshSessions = useCallback(async () => {
+    try {
+      setSessions(await listVoyeurSessions());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, []);
+
+  // Poll status while mounted (1 Hz — cheap, and shows the live segment count
+  // and the safety drop counter climbing during a session).
+  useEffect(() => {
+    let alive = true;
+    const tick = async () => {
+      try {
+        const s = await getVoyeurStatus();
+        if (alive) setStatus(s);
+      } catch {
+        /* transient */
+      }
+    };
+    void tick();
+    const h = setInterval(tick, 1000);
+    return () => {
+      alive = false;
+      clearInterval(h);
+    };
+  }, []);
+
+  useEffect(() => {
+    void refreshSessions();
+  }, [refreshSessions]);
+
+  // When a session is active, refresh the list as its segment count grows.
+  useEffect(() => {
+    if (!status?.active) return;
+    const h = setInterval(() => void refreshSessions(), 3000);
+    return () => clearInterval(h);
+  }, [status?.active, refreshSessions]);
+
+  const onStart = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      setStatus(await startVoyeur(true));
+      await refreshSessions();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onStop = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      setStatus(await stopVoyeur());
+      await refreshSessions();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const openSession = async (id: string) => {
+    if (openId === id) {
+      setOpenId(null);
+      setDetail(null);
+      return;
+    }
+    setOpenId(id);
+    setDetail(null);
+    try {
+      setDetail(await getVoyeurSession(id));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const onTogglePin = async (s: VoyeurSession) => {
+    try {
+      await updateVoyeurSession(s.id, { pinned: !s.pinned });
+      await refreshSessions();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const onRename = async (s: VoyeurSession, label: string) => {
+    const trimmed = label.trim();
+    if (!trimmed || trimmed === s.label) return;
+    try {
+      await updateVoyeurSession(s.id, { label: trimmed });
+      await refreshSessions();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const onDelete = async (s: VoyeurSession) => {
+    if (!window.confirm(`Delete log "${s.label}"? This removes its captured audio too.`)) return;
+    try {
+      await deleteVoyeurSession(s.id);
+      if (openId === s.id) {
+        setOpenId(null);
+        setDetail(null);
+      }
+      await refreshSessions();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const active = status?.active ?? false;
+
+  return (
+    <>
+      <TileChrome
+        title="Voyeur Mode"
+        onRemove={handleRemove}
+        rightSlot={
+          <button
+            type="button"
+            className={`btn ${active ? 'tx' : 'accent'}`}
+            disabled={busy}
+            onClick={active ? onStop : onStart}
+            aria-label={active ? 'Stop monitoring' : 'Start monitoring'}
+          >
+            {active ? 'STOP' : 'LISTEN'}
+          </button>
+        }
+      />
+      <div style={{ padding: '8px 10px', overflow: 'auto', fontSize: 12 }}>
+        {/* Live status */}
+        <div
+          style={{
+            display: 'flex',
+            gap: 12,
+            flexWrap: 'wrap',
+            padding: '6px 8px',
+            borderRadius: 4,
+            background: 'var(--panel-bot)',
+            marginBottom: 8,
+          }}
+        >
+          {active && status ? (
+            <>
+              <span>
+                <strong style={{ color: 'var(--accent)' }}>● listening</strong>{' '}
+                {fmtFreq(status.freqHz)} {status.mode} {status.band}
+              </span>
+              <span>overs: {status.segmentCount}</span>
+              <span>captured: {fmtDur(status.capturedSeconds)}</span>
+              {status.droppedSamples > 0 && (
+                <span title="Samples dropped because the CPU briefly fell behind. RX is unaffected — this is just a capture gap.">
+                  dropped: {status.droppedSamples}
+                </span>
+              )}
+              {status.degraded && (
+                <span style={{ color: 'var(--tx)' }} title="The monitor faulted and detached. RX is unaffected.">
+                  degraded
+                </span>
+              )}
+            </>
+          ) : (
+            <span style={{ opacity: 0.7 }}>
+              Idle — press LISTEN to log the current frequency. Phase 1 captures each
+              transmission; transcription + callsigns arrive in Phase 2.
+            </span>
+          )}
+        </div>
+
+        {error && (
+          <div style={{ color: 'var(--tx)', marginBottom: 6 }}>{error}</div>
+        )}
+
+        {/* Saved logs */}
+        <div style={{ fontWeight: 600, margin: '4px 0', opacity: 0.8 }}>
+          Logs ({sessions.length})
+        </div>
+        {sessions.length === 0 && (
+          <div style={{ opacity: 0.6 }}>No logs yet.</div>
+        )}
+        {sessions.map((s) => (
+          <div
+            key={s.id}
+            style={{
+              borderTop: '1px solid var(--panel-top)',
+              padding: '4px 0',
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <button
+                type="button"
+                className="btn sm"
+                title={s.pinned ? 'Saved (won’t be auto-pruned). Click to unsave.' : 'Save this log'}
+                onClick={() => onTogglePin(s)}
+                style={{ color: s.pinned ? 'var(--power)' : undefined }}
+              >
+                {s.pinned ? '★' : '☆'}
+              </button>
+              <input
+                ref={editingRef}
+                defaultValue={s.label}
+                onBlur={(e) => onRename(s, e.currentTarget.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') e.currentTarget.blur();
+                }}
+                style={{
+                  flex: 1,
+                  minWidth: 0,
+                  background: 'transparent',
+                  border: 'none',
+                  color: 'inherit',
+                  font: 'inherit',
+                }}
+                aria-label="Log name"
+              />
+              <button type="button" className="btn sm" onClick={() => openSession(s.id)}>
+                {openId === s.id ? 'Hide' : 'Open'}
+              </button>
+              <button
+                type="button"
+                className="btn sm tx"
+                title="Delete this log and its audio"
+                onClick={() => onDelete(s)}
+              >
+                ✕
+              </button>
+            </div>
+            <div style={{ opacity: 0.65, fontSize: 11, paddingLeft: 30 }}>
+              {fmtWhen(s.startedUtc)} · {fmtFreq(s.freqHz)} {s.mode} · {s.segmentCount} overs ·{' '}
+              {fmtDur(s.capturedSeconds)}
+              {s.hasAudio ? ' · audio' : ''}
+            </div>
+
+            {openId === s.id && (
+              <div style={{ paddingLeft: 30, marginTop: 4 }}>
+                {!detail && <div style={{ opacity: 0.6 }}>Loading…</div>}
+                {detail && detail.segments.length === 0 && (
+                  <div style={{ opacity: 0.6 }}>No overs captured.</div>
+                )}
+                {detail &&
+                  detail.segments.map((seg, i) => (
+                    <div
+                      key={seg.id}
+                      style={{
+                        display: 'grid',
+                        gridTemplateColumns: 'auto 1fr',
+                        gap: 8,
+                        padding: '2px 0',
+                        borderTop: i === 0 ? 'none' : '1px dotted var(--panel-top)',
+                      }}
+                    >
+                      <span style={{ opacity: 0.7, fontVariantNumeric: 'tabular-nums' }}>
+                        {new Date(seg.startedUtc).toLocaleTimeString()} ·{' '}
+                        {(seg.durationMs / 1000).toFixed(1)}s
+                      </span>
+                      <span>
+                        {/* Phase 2: callsign + transcript. Phase 1: the over
+                            with no attribution yet. */}
+                        <strong
+                          style={{
+                            color:
+                              seg.callsignState === 'confirmed'
+                                ? 'var(--accent)'
+                                : seg.callsignState === 'tentative'
+                                  ? 'var(--power)'
+                                  : 'inherit',
+                            opacity: seg.callsign ? 1 : 0.5,
+                          }}
+                        >
+                          {seg.callsign ?? 'callsign unknown'}
+                        </strong>
+                        {seg.transcript ? ` — ${seg.transcript}` : ''}
+                      </span>
+                    </div>
+                  ))}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
**Voyeur Mode** (zeus-la5): park the radio on a frequency, walk away, and come back to a log of what happened on the air. This PR is **Phase 1** — the safe in-tree foundation, per-transmission ("over") capture, and the **save/delete log management**. Whisper ASR + callsign/QRZ enrichment are Phase 2 (the segment schema already carries nullable `Transcript`/`Callsign`/`CallsignState`, so Phase 2 is additive).

Phase 0 (the ASR GO/NO-GO spike) **passed** on real KiwiSDR eCARS audio — see the issue for the scorecard.

## "Cannot break anything" — RX/DSP/PS/TX untouched (verified by design + test)
- **Default OFF.** Subscribes to `DspPipelineService.RxAudioAvailable` only while a session is active — idle Voyeur Mode adds zero RX-path code.
- **`OnRxAudio` (DSP/RX thread) does only a lock-free `VoyeurAudioRing.Write`** — bounded memcpy + two volatile ops, no alloc/lock/IO. Self-wrapped in try/catch (the producer Invoke site has no per-delegate guard) and **detaches on repeated fault** → RX returns bit-identical.
- **Ring has no back-pressure** — full ⇒ drop block + count it. A slow/crashed consumer is invisible to RX (worst case: capture gap).
- All real work (segmentation, WAV writing, persistence) on a **below-normal-priority drain thread**. RX-only, receiver 0; never touches the audio sink, TX/IQ, or PureSignal.

## What's here
| Piece | |
|---|---|
| `VoyeurAudioRing` | lock-free SPSC float ring, drop-on-full + dropped counter |
| `VoyeurSegmenter` | energy/noise-floor "over" detector (Phase 2 swaps for Silero VAD behind the same API) |
| `VoyeurStore` | LiteDB sessions+segments; segment audio under `Downloads/zeus-voyeur` (traversal-guarded); **pin-to-save** + rolling prune of unpinned logs |
| `VoyeurMonitorService` | `BackgroundService` — start/stop, safe tap, drain loop |
| REST | `/api/voyeur/{status,start,stop}` + `/sessions[/{id}]` GET/PATCH/DELETE |
| Panel | **Voyeur Mode** — LISTEN/STOP, live status (segment count + safety drop counter), saved-logs list with rename / ★save / delete; per-over rows show the confirmed/tentative/unknown callsign slot ("callsign unknown" until Phase 2) and transcript slot |

## Tests
- `VoyeurAudioRingTests` — SPSC round-trip, wrap, drop-on-full-no-corruption, concurrent producer/consumer ordering
- `VoyeurSegmenterTests` — open/close, hang-doesn't-split, blip-ignored, flush, steady-quiet-never-opens
- `VoyeurStoreTests` — CRUD, pin, delete-removes-audio-dir, traversal neutralized
- `dotnet test`: 741 server tests pass · `vitest`: 271 pass · both builds clean
- **Live smoke test** on a running backend: start/stop/list/rename/pin/delete all verified; audio dir cleaned on delete

Part 1 of zeus-la5. Phase 2 (whisper.cpp sidecar child process + QRZ enrichment) next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)