### PR TITLE
feat(voyeur): Phase 2 — whisper ASR + callsign/QRZ enrichment + setup UI (zeus-la5)

### DIFF
--- a/Zeus.Server.Hosting/Voyeur/CallsignExtractor.cs
+++ b/Zeus.Server.Hosting/Voyeur/CallsignExtractor.cs
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see ATTRIBUTIONS.md for provenance.
+
+using System.Text.RegularExpressions;
+
+namespace Zeus.Server.Voyeur;
+
+/// <summary>
+/// Extracts candidate amateur callsigns from an ASR transcript of an HF SSB
+/// "over" (Voyeur Mode, zeus-la5 Phase 2). Decodes spoken NATO phonetics
+/// ("Whiskey Alpha 2 Delta Victor" → WA2DV) and digit words, tolerating the
+/// specific mis-hearings Whisper produces on noisy HF voice (validated against
+/// the Phase-0 spike on real eCARS audio: foxtrot→"foxtrops", india→"indi",
+/// uniform→"unites/united", already-collapsed "wa2", etc.).
+///
+/// Output is candidates ranked by occurrence. The DOWNSTREAM step (QRZ
+/// validation) is what separates a confirmed callsign from phonetic-decode
+/// noise — see the Phase-0 finding that truncated decodes (WA2D vs WA2DV) can
+/// both be real calls, so the caller prefers the longest QRZ-validated
+/// candidate and cross-checks the operator's spoken name.
+/// </summary>
+public static partial class CallsignExtractor
+{
+    private static readonly Dictionary<string, char> Phon = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["alpha"] = 'A', ["bravo"] = 'B', ["charlie"] = 'C', ["delta"] = 'D',
+        ["echo"] = 'E', ["foxtrot"] = 'F', ["foxtrops"] = 'F', ["foxtrop"] = 'F',
+        ["golf"] = 'G', ["hotel"] = 'H', ["india"] = 'I', ["indi"] = 'I',
+        ["indy"] = 'I', ["juliet"] = 'J', ["juliett"] = 'J', ["kilo"] = 'K',
+        ["lima"] = 'L', ["mike"] = 'M', ["november"] = 'N', ["oscar"] = 'O',
+        ["papa"] = 'P', ["papas"] = 'P', ["quebec"] = 'Q', ["romeo"] = 'R',
+        ["sierra"] = 'S', ["tango"] = 'T', ["uniform"] = 'U', ["unites"] = 'U',
+        ["united"] = 'U', ["victor"] = 'V', ["whiskey"] = 'W', ["xray"] = 'X',
+        ["yankee"] = 'Y', ["zulu"] = 'Z',
+    };
+
+    private static readonly Dictionary<string, char> Digit = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["zero"] = '0', ["one"] = '1', ["two"] = '2', ["three"] = '3',
+        ["four"] = '4', ["five"] = '5', ["six"] = '6', ["seven"] = '7',
+        ["eight"] = '8', ["nine"] = '9', ["niner"] = '9',
+    };
+
+    [GeneratedRegex(@"[a-z0-9]+", RegexOptions.IgnoreCase)]
+    private static partial Regex TokenRegex();
+
+    // Callsign anchor: 1-2 prefix letters + 1-2 digits. The suffix (1-4 letters)
+    // is taken from the run after the anchor.
+    [GeneratedRegex(@"[A-Z]{1,2}[0-9]{1,2}")]
+    private static partial Regex AnchorRegex();
+
+    // "X-ray" / "x ray" is the phonetic for X but Whisper writes it as two
+    // words; collapse to "xray" so it stays one run character. Same for the
+    // rarely-split "x-ray" in callsign readbacks.
+    [GeneratedRegex(@"\bx[\s\-]?ray\b", RegexOptions.IgnoreCase)]
+    private static partial Regex XrayRegex();
+
+    /// <summary>
+    /// Candidate callsigns from a transcript, ordered LONGEST-first then by
+    /// occurrence. Longest-first is deliberate: each decoded run emits every
+    /// valid-length truncation (WA2D, WA2DV, WA2DVU, WA2DVUE…), and the caller
+    /// (QRZ validation) prefers the longest candidate that resolves to a real
+    /// licensee — which is how the Phase-0 fragment-collision (WA2D vs WA2DVU
+    /// both being real calls) is resolved correctly.
+    /// </summary>
+    public static IReadOnlyList<string> Extract(string? transcript)
+    {
+        if (string.IsNullOrWhiteSpace(transcript)) return Array.Empty<string>();
+        transcript = XrayRegex().Replace(transcript, "xray");
+
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var run in DecodeRuns(transcript))
+            foreach (var cand in CandidatesFromRun(run))
+                counts[cand] = counts.TryGetValue(cand, out var n) ? n + 1 : 1;
+
+        return counts.Keys
+            .OrderByDescending(c => c.Length)
+            .ThenByDescending(c => counts[c])
+            .ThenBy(c => c, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    // For one decoded run, emit the valid-length truncations rooted at each
+    // prefix+digit anchor: anchor + 1..4 of the immediately-following letters.
+    private static IEnumerable<string> CandidatesFromRun(string run)
+    {
+        foreach (Match a in AnchorRegex().Matches(run))
+        {
+            int i = a.Index + a.Length;
+            int letters = 0;
+            while (i + letters < run.Length && char.IsLetter(run[i + letters]) && letters < 4)
+                letters++;
+            for (int L = 1; L <= letters; L++)
+                yield return run.Substring(a.Index, a.Length + L);
+        }
+    }
+
+    // Build maximal runs of decodable callsign characters: phonetic words →
+    // letters, digit words → digits, bare single letters and bare digits pass
+    // through, and an already-collapsed "wa2"/"n2zkn"-style token is kept.
+    // A non-callsign word OR a sentence terminator (. ! ? ;) between tokens
+    // breaks the run — the latter so two calls spoken back-to-back across a
+    // sentence boundary don't merge into one. Commas and hyphens do NOT break
+    // (they appear mid-callsign in net-control readbacks).
+    private static IEnumerable<string> DecodeRuns(string text)
+    {
+        var run = new System.Text.StringBuilder();
+        int prevEnd = -1;
+        foreach (Match tok in TokenRegex().Matches(text))
+        {
+            if (run.Length > 0 && prevEnd >= 0)
+            {
+                var gap = text.AsSpan(prevEnd, tok.Index - prevEnd);
+                if (gap.IndexOfAny('.', '!', '?') >= 0 || gap.IndexOf(';') >= 0)
+                {
+                    yield return run.ToString();
+                    run.Clear();
+                }
+            }
+            prevEnd = tok.Index + tok.Length;
+
+            var t = tok.Value;
+            string? piece = null;
+            if (Phon.TryGetValue(t, out var pc)) piece = pc.ToString();
+            else if (Digit.TryGetValue(t, out var dc)) piece = dc.ToString();
+            else if (t.Length == 1 && char.IsLetter(t[0])) piece = char.ToUpperInvariant(t[0]).ToString();
+            else if (t.Length == 1 && char.IsDigit(t[0])) piece = t;
+            else if (IsCollapsedPrefix(t)) piece = t.ToUpperInvariant();
+
+            if (piece is not null)
+            {
+                run.Append(piece);
+            }
+            else if (run.Length > 0)
+            {
+                yield return run.ToString();
+                run.Clear();
+            }
+        }
+        if (run.Length > 0) yield return run.ToString();
+    }
+
+    // "wa2", "k4", "n2zkn"-style already-spelled token: 1-2 letters then a
+    // digit, optionally more letters (Whisper occasionally emits the whole
+    // call as one token). Pure letter words are NOT collapsed prefixes (they'd
+    // swallow ordinary words), so require an embedded digit.
+    private static bool IsCollapsedPrefix(string t)
+    {
+        bool sawDigit = false;
+        foreach (var c in t)
+        {
+            if (!char.IsLetterOrDigit(c)) return false;
+            if (char.IsDigit(c)) sawDigit = true;
+        }
+        return sawDigit && t.Length >= 2 && t.Length <= 8 && char.IsLetter(t[0]);
+    }
+}

--- a/Zeus.Server.Hosting/Voyeur/CallsignExtractor.cs
+++ b/Zeus.Server.Hosting/Voyeur/CallsignExtractor.cs
@@ -106,17 +106,27 @@ public static partial class CallsignExtractor
         }
     }
 
-    // Build maximal runs of decodable callsign characters: phonetic words →
-    // letters, digit words → digits, bare single letters and bare digits pass
-    // through, and an already-collapsed "wa2"/"n2zkn"-style token is kept.
-    // A non-callsign word OR a sentence terminator (. ! ? ;) between tokens
-    // breaks the run — the latter so two calls spoken back-to-back across a
-    // sentence boundary don't merge into one. Commas and hyphens do NOT break
-    // (they appear mid-callsign in net-control readbacks).
+    // Longest a decoded run can grow before we flush it — caps weak-word
+    // absorption so a callsign readback can't swallow the rest of a sentence.
+    // (2 prefix + 2 digit + 4 suffix + slack.)
+    private const int MaxRunLength = 9;
+
+    // Build runs of decodable callsign characters. STRONG tokens — exact NATO
+    // phonetic words, digit words, bare single letters/digits, already-collapsed
+    // "wa2"/"n2zkn" tokens — always contribute. WEAK tokens (any other spoken
+    // word) contribute their FIRST LETTER, but ONLY once the run already holds a
+    // real NATO phonetic: that's how hams' CUSTOM phonetics are handled
+    // ("Kilo Echo 8 Jolly Shikers" → KE8 + J + S = KE8JS), since a custom
+    // phonetic always starts with the letter it stands for. Requiring a real
+    // phonetic first keeps ordinary conversation ("I got 8 of them") from
+    // manufacturing callsigns — and QRZ validation filters whatever slips
+    // through. A sentence terminator (. ! ? ;) or the length cap flushes the run.
     private static IEnumerable<string> DecodeRuns(string text)
     {
         var run = new System.Text.StringBuilder();
+        bool strong = false; // run contains ≥1 exact NATO phonetic word
         int prevEnd = -1;
+
         foreach (Match tok in TokenRegex().Matches(text))
         {
             if (run.Length > 0 && prevEnd >= 0)
@@ -126,26 +136,40 @@ public static partial class CallsignExtractor
                 {
                     yield return run.ToString();
                     run.Clear();
+                    strong = false;
                 }
             }
             prevEnd = tok.Index + tok.Length;
 
             var t = tok.Value;
             string? piece = null;
-            if (Phon.TryGetValue(t, out var pc)) piece = pc.ToString();
+            bool isPhonetic = false;
+            if (Phon.TryGetValue(t, out var pc)) { piece = pc.ToString(); isPhonetic = true; }
             else if (Digit.TryGetValue(t, out var dc)) piece = dc.ToString();
             else if (t.Length == 1 && char.IsLetter(t[0])) piece = char.ToUpperInvariant(t[0]).ToString();
             else if (t.Length == 1 && char.IsDigit(t[0])) piece = t;
-            else if (IsCollapsedPrefix(t)) piece = t.ToUpperInvariant();
+            else if (IsCollapsedPrefix(t)) { piece = t.ToUpperInvariant(); isPhonetic = true; }
+            else if (run.Length > 0 && strong && char.IsLetter(t[0]))
+                // WEAK word inside an active callsign readback → custom phonetic,
+                // take its first letter.
+                piece = char.ToUpperInvariant(t[0]).ToString();
 
             if (piece is not null)
             {
                 run.Append(piece);
+                if (isPhonetic) strong = true;
+                if (run.Length >= MaxRunLength)
+                {
+                    yield return run.ToString();
+                    run.Clear();
+                    strong = false;
+                }
             }
             else if (run.Length > 0)
             {
                 yield return run.ToString();
                 run.Clear();
+                strong = false;
             }
         }
         if (run.Length > 0) yield return run.ToString();

--- a/Zeus.Server.Hosting/Voyeur/VoyeurInstallService.cs
+++ b/Zeus.Server.Hosting/Voyeur/VoyeurInstallService.cs
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see ATTRIBUTIONS.md for provenance.
+
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Server.Voyeur;
+
+/// <summary>
+/// In-app, terminal-free setup for Voyeur Mode transcription (zeus-la5) —
+/// cross-platform (macOS / Linux / Windows). Downloads the whisper speech model
+/// (the large, license-/choice-dependent file that can't ship in the installer)
+/// into the Zeus app-data <c>whisper/</c> folder, with live progress, so the
+/// operator never has to run a command. Discovery is dynamic, so the model is
+/// picked up the moment the download finishes — no restart.
+///
+/// The whisper-cli BINARY is intended to ship bundled with Zeus per-platform
+/// (built in CI alongside libwdsp); when a hosted per-RID binary URL is
+/// configured here, this service will fetch it the same way. Until then, the
+/// binary status is surfaced so the panel can show exactly what's missing.
+/// </summary>
+public sealed class VoyeurInstallService
+{
+    public enum Phase { Idle, Downloading, Done, Error }
+
+    public sealed record Progress(
+        Phase Phase, int Percent, string Message, string? Item,
+        bool ModelPresent, bool BinaryPresent, string Rid);
+
+    private readonly ILogger<VoyeurInstallService> _log;
+    private readonly IHttpClientFactory _httpFactory;
+    private readonly WhisperTranscriber _whisper;
+
+    private readonly object _gate = new();
+    private Phase _phase = Phase.Idle;
+    private int _percent;
+    private string _message = "";
+    private string? _item;
+    private CancellationTokenSource? _cts;
+
+    // Models offered in-app. Stable Hugging Face URLs (whisper.cpp, MIT).
+    // small.en is the lighter default; medium.en is the Phase-0 accuracy pick.
+    private static readonly Dictionary<string, (string Url, long MinBytes, string Label)> Models = new()
+    {
+        ["small.en"] = ("https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.en.bin",
+                        400_000_000, "Small (English) — ~0.5 GB, fast"),
+        ["medium.en"] = ("https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.en.bin",
+                         1_300_000_000, "Medium (English) — ~1.5 GB, most accurate"),
+    };
+
+    public VoyeurInstallService(
+        ILogger<VoyeurInstallService> log,
+        IHttpClientFactory httpFactory,
+        WhisperTranscriber whisper)
+    {
+        _log = log;
+        _httpFactory = httpFactory;
+        _whisper = whisper;
+    }
+
+    public static IEnumerable<object> AvailableModels =>
+        Models.Select(m => new { id = m.Key, label = m.Value.Label });
+
+    public Progress Status()
+    {
+        lock (_gate)
+        {
+            return new Progress(
+                _phase, _percent, _message, _item,
+                ModelPresent: _whisper.ModelPath is not null,
+                BinaryPresent: _whisper.CliPath is not null,
+                Rid: Rid());
+        }
+    }
+
+    /// <summary>Begin downloading <paramref name="modelId"/>. Returns the current
+    /// status immediately; progress is polled via <see cref="Status"/>. No-op if
+    /// a download is already running.</summary>
+    public Progress InstallModel(string modelId)
+    {
+        lock (_gate)
+        {
+            if (_phase == Phase.Downloading) return Status();
+            if (!Models.ContainsKey(modelId))
+            {
+                _phase = Phase.Error;
+                _message = $"unknown model '{modelId}'";
+                return Status();
+            }
+            _phase = Phase.Downloading;
+            _percent = 0;
+            _item = modelId;
+            _message = "starting…";
+            _cts = new CancellationTokenSource();
+        }
+        var ct = _cts!.Token;
+        _ = Task.Run(() => DownloadModelAsync(modelId, ct), ct);
+        return Status();
+    }
+
+    /// <summary>Cancel an in-flight download.</summary>
+    public void Cancel() { lock (_gate) { _cts?.Cancel(); } }
+
+    private async Task DownloadModelAsync(string modelId, CancellationToken ct)
+    {
+        var (url, minBytes, _) = Models[modelId];
+        Directory.CreateDirectory(WhisperTranscriber.ModelDir);
+        var finalPath = Path.Combine(WhisperTranscriber.ModelDir, $"ggml-{modelId}.bin");
+        var tmpPath = finalPath + ".part";
+
+        try
+        {
+            var http = _httpFactory.CreateClient("voyeur-install");
+            http.Timeout = Timeout.InfiniteTimeSpan; // large file; we cap via ct, not a fixed timeout
+
+            using var resp = await http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct);
+            resp.EnsureSuccessStatusCode();
+            long? total = resp.Content.Headers.ContentLength;
+
+            await using (var src = await resp.Content.ReadAsStreamAsync(ct))
+            await using (var dst = File.Create(tmpPath))
+            {
+                var buf = new byte[1 << 20];
+                long read = 0;
+                int n;
+                while ((n = await src.ReadAsync(buf, ct)) > 0)
+                {
+                    await dst.WriteAsync(buf.AsMemory(0, n), ct);
+                    read += n;
+                    if (total is > 0)
+                        SetProgress((int)(read * 100 / total.Value),
+                            $"downloading {modelId} — {read / 1_000_000} / {total / 1_000_000} MB");
+                    else
+                        SetProgress(0, $"downloading {modelId} — {read / 1_000_000} MB");
+                }
+            }
+
+            var size = new FileInfo(tmpPath).Length;
+            if (size < minBytes)
+                throw new InvalidOperationException(
+                    $"download too small ({size} bytes) — likely an error page, not the model");
+
+            // Atomic publish: only a fully-downloaded, sane-sized file becomes
+            // the live model. A crash mid-download leaves only the .part.
+            File.Move(tmpPath, finalPath, overwrite: true);
+
+            lock (_gate)
+            {
+                _phase = Phase.Done;
+                _percent = 100;
+                _message = $"{modelId} ready";
+            }
+            _log.LogInformation("voyeur.install model {Model} done ({Mb} MB)", modelId, size / 1_000_000);
+        }
+        catch (OperationCanceledException)
+        {
+            TryDelete(tmpPath);
+            lock (_gate) { _phase = Phase.Idle; _percent = 0; _message = "cancelled"; }
+        }
+        catch (Exception ex)
+        {
+            TryDelete(tmpPath);
+            lock (_gate) { _phase = Phase.Error; _message = ex.Message; }
+            _log.LogWarning(ex, "voyeur.install model {Model} failed", modelId);
+        }
+    }
+
+    private void SetProgress(int percent, string message)
+    {
+        lock (_gate) { _percent = percent; _message = message; }
+    }
+
+    private static void TryDelete(string path)
+    {
+        try { if (File.Exists(path)) File.Delete(path); } catch { /* ignore */ }
+    }
+
+    private static string Rid()
+    {
+        string os = OperatingSystem.IsWindows() ? "win"
+            : OperatingSystem.IsMacOS() ? "osx"
+            : OperatingSystem.IsLinux() ? "linux" : "unknown";
+        string arch = RuntimeInformation.OSArchitecture switch
+        {
+            Architecture.Arm64 => "arm64",
+            Architecture.X64 => "x64",
+            _ => RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant(),
+        };
+        return $"{os}-{arch}";
+    }
+}

--- a/Zeus.Server.Hosting/Voyeur/VoyeurInstallService.cs
+++ b/Zeus.Server.Hosting/Voyeur/VoyeurInstallService.cs
@@ -53,10 +53,12 @@ public sealed class VoyeurInstallService
     // small.en is the lighter default; medium.en is the Phase-0 accuracy pick.
     private static readonly Dictionary<string, (string Url, long MinBytes, string Label)> Models = new()
     {
-        ["small.en"] = ("https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.en.bin",
-                        400_000_000, "Small (English) — ~0.5 GB, fast"),
+        // Medium first = the recommended default (Phase-0 spike: small misses
+        // a lot on noisy SSB; medium is the accuracy pick).
         ["medium.en"] = ("https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.en.bin",
-                         1_300_000_000, "Medium (English) — ~1.5 GB, most accurate"),
+                         1_300_000_000, "Medium (English) — ~1.5 GB, recommended (best accuracy)"),
+        ["small.en"] = ("https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.en.bin",
+                        400_000_000, "Small (English) — ~0.5 GB, faster download, less accurate"),
     };
 
     public VoyeurInstallService(

--- a/Zeus.Server.Hosting/Voyeur/VoyeurModels.cs
+++ b/Zeus.Server.Hosting/Voyeur/VoyeurModels.cs
@@ -61,6 +61,8 @@ public sealed class VoyeurSegmentDocument
     public string? Callsign { get; set; }
     /// <summary>"confirmed" | "tentative" | "unknown" — QRZ-validation state.</summary>
     public string? CallsignState { get; set; }
+    /// <summary>QRZ operator name when the callsign was confirmed (roster enrichment).</summary>
+    public string? CallsignName { get; set; }
 }
 
 // ---- DTOs (wire shape for the REST API) ----
@@ -75,7 +77,8 @@ public sealed record VoyeurStatusDto(
     double CapturedSeconds,
     long DroppedSamples,
     int RingFillPct,
-    bool Degraded);
+    bool Degraded,
+    bool TranscriptionAvailable);
 
 public sealed record VoyeurSessionDto(
     string Id,
@@ -99,7 +102,8 @@ public sealed record VoyeurSegmentDto(
     bool HasAudio,
     string? Transcript,
     string? Callsign,
-    string? CallsignState);
+    string? CallsignState,
+    string? CallsignName);
 
 public sealed record VoyeurSessionDetailDto(
     VoyeurSessionDto Session,

--- a/Zeus.Server.Hosting/Voyeur/VoyeurMonitorService.cs
+++ b/Zeus.Server.Hosting/Voyeur/VoyeurMonitorService.cs
@@ -51,6 +51,7 @@ public sealed class VoyeurMonitorService : BackgroundService, IDisposable
     private readonly DspPipelineService _pipeline;
     private readonly RadioService _radio;
     private readonly VoyeurStore _store;
+    private readonly Zeus.Server.Voyeur.VoyeurTranscriptionService _transcription;
     private readonly ILogger<VoyeurMonitorService> _log;
 
     // Ring sized for ~6 s at 48 kHz — far more than the drain thread ever needs,
@@ -76,11 +77,13 @@ public sealed class VoyeurMonitorService : BackgroundService, IDisposable
         DspPipelineService pipeline,
         RadioService radio,
         VoyeurStore store,
+        Zeus.Server.Voyeur.VoyeurTranscriptionService transcription,
         ILogger<VoyeurMonitorService> log)
     {
         _pipeline = pipeline;
         _radio = radio;
         _store = store;
+        _transcription = transcription;
         _log = log;
     }
 
@@ -178,7 +181,8 @@ public sealed class VoyeurMonitorService : BackgroundService, IDisposable
             CapturedSeconds: Interlocked.Read(ref _capturedMs) / 1000.0,
             DroppedSamples: ring?.DroppedSamples ?? 0,
             RingFillPct: fill,
-            Degraded: _degraded);
+            Degraded: _degraded,
+            TranscriptionAvailable: _transcription.Available);
     }
 
     // ---- PRODUCER (DSP/RX thread) — keep this trivially cheap and crash-proof ----
@@ -241,6 +245,14 @@ public sealed class VoyeurMonitorService : BackgroundService, IDisposable
             Interlocked.Increment(ref _segmentCount);
             Interlocked.Add(ref _capturedMs, r.DurationMs);
             _store.AddSegment(doc, r.DurationMs / 1000.0, ring.DroppedSamples);
+            // Phase 2: hand the saved over to the transcription pipeline (off
+            // this thread, off the audio path). No-op when whisper isn't
+            // installed (capture-only) or the over had no audio file.
+            if (file is not null && audioDir is not null)
+            {
+                _transcription.Enqueue(new Zeus.Server.Voyeur.VoyeurTranscriptionService.Job(
+                    session.Id, doc.Id, Path.Combine(audioDir, file), r.DurationMs));
+            }
             _log.LogDebug("voyeur: captured over {Dur}ms peak={Peak:F1}dBFS", r.DurationMs, r.PeakDbfs);
         }
 

--- a/Zeus.Server.Hosting/Voyeur/VoyeurStore.cs
+++ b/Zeus.Server.Hosting/Voyeur/VoyeurStore.cs
@@ -256,7 +256,26 @@ public sealed class VoyeurStore : IDisposable
     private static VoyeurSegmentDto ToSegDto(VoyeurSegmentDocument x) => new(
         x.Id, x.StartedUtc, x.DurationMs, x.PeakDbfs,
         HasAudio: x.AudioFile is not null,
-        x.Transcript, x.Callsign, x.CallsignState);
+        x.Transcript, x.Callsign, x.CallsignState, x.CallsignName);
+
+    /// <summary>Phase 2: write back the ASR transcript + the QRZ-validated
+    /// callsign attribution for a captured over. No-op if the segment is gone
+    /// (its session was deleted while transcription was in flight).</summary>
+    public void UpdateSegmentTranscript(
+        string segmentId, string? transcript, string? callsign,
+        string? callsignState, string? callsignName)
+    {
+        lock (_gate)
+        {
+            var seg = _segments.FindById(segmentId);
+            if (seg is null) return;
+            seg.Transcript = transcript;
+            seg.Callsign = callsign;
+            seg.CallsignState = callsignState;
+            seg.CallsignName = callsignName;
+            _segments.Update(seg);
+        }
+    }
 
     public void Dispose() => _db.Dispose();
 }

--- a/Zeus.Server.Hosting/Voyeur/VoyeurTranscriptionService.cs
+++ b/Zeus.Server.Hosting/Voyeur/VoyeurTranscriptionService.cs
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see ATTRIBUTIONS.md for provenance.
+
+using System.Threading.Channels;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Zeus.Contracts;
+
+namespace Zeus.Server.Voyeur;
+
+/// <summary>
+/// Voyeur Mode (zeus-la5) Phase 2 — the transcription + enrichment pipeline.
+/// Captured "overs" (Phase 1) are enqueued here; a SINGLE background worker
+/// pulls each one, runs whisper.cpp (in a supervised child process — see
+/// <see cref="WhisperTranscriber"/>), extracts candidate callsigns, validates
+/// them against QRZ, and writes the transcript + the best attribution back to
+/// the segment record.
+///
+/// This runs entirely OFF the audio/DSP path — it consumes already-saved WAV
+/// files, never the live ring — so nothing here can affect RX/PS/TX. A single
+/// worker bounds CPU/RAM (whisper at ~20× realtime keeps up with a net easily);
+/// the queue is bounded and drops oldest on overflow so a slow run can't grow
+/// memory without limit. QRZ lookups are de-duplicated per session and rate-
+/// limited, because <c>QrzService.LookupAsync</c> serializes every caller on a
+/// single gate — an unthrottled roster storm would starve the operator's own
+/// manual lookups.
+/// </summary>
+public sealed class VoyeurTranscriptionService : BackgroundService
+{
+    public readonly record struct Job(string SessionId, string SegmentId, string WavPath, int DurationMs);
+
+    private readonly WhisperTranscriber _whisper;
+    private readonly VoyeurStore _store;
+    private readonly QrzService _qrz;
+    private readonly ILogger<VoyeurTranscriptionService> _log;
+
+    private readonly Channel<Job> _queue = Channel.CreateBounded<Job>(
+        new BoundedChannelOptions(256)
+        {
+            FullMode = BoundedChannelFullMode.DropOldest,
+            SingleReader = true,
+        });
+
+    // Per-callsign QRZ cache + a min interval between live lookups. The worker
+    // is single-threaded so this needs no locking.
+    private readonly Dictionary<string, (QrzStation? Station, bool Valid)> _qrzCache = new(StringComparer.Ordinal);
+    private DateTime _lastQrzLookup = DateTime.MinValue;
+    private static readonly TimeSpan QrzMinInterval = TimeSpan.FromMilliseconds(600);
+
+    public VoyeurTranscriptionService(
+        WhisperTranscriber whisper,
+        VoyeurStore store,
+        QrzService qrz,
+        ILogger<VoyeurTranscriptionService> log)
+    {
+        _whisper = whisper;
+        _store = store;
+        _qrz = qrz;
+        _log = log;
+    }
+
+    public bool Available => _whisper.Available;
+
+    /// <summary>Queue a captured over for transcription. Non-blocking; drops
+    /// silently if transcription is unavailable (capture-only mode).</summary>
+    public void Enqueue(Job job)
+    {
+        if (!_whisper.Available) return;
+        _queue.Writer.TryWrite(job);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await foreach (var job in _queue.Reader.ReadAllAsync(stoppingToken))
+        {
+            try
+            {
+                await ProcessAsync(job, stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                // A failed transcription must never take the worker down — the
+                // over just stays untranscribed.
+                _log.LogWarning(ex, "voyeur.transcribe job failed seg={Seg}", job.SegmentId);
+            }
+        }
+    }
+
+    private async Task ProcessAsync(Job job, CancellationToken ct)
+    {
+        // Generous timeout: whisper runs ~20× realtime, so even a long over
+        // finishes in seconds. Cap at the larger of 60 s or 2× the over length
+        // and kill+drop past that (a wedged child must never block the queue).
+        var timeout = TimeSpan.FromMilliseconds(Math.Max(60_000, job.DurationMs * 2));
+        var transcript = await _whisper.TranscribeAsync(job.WavPath, timeout, ct);
+
+        if (string.IsNullOrWhiteSpace(transcript))
+        {
+            // Whisper found no speech (quiet/garbled over) — record nothing to
+            // attribute; leave the segment as captured-only.
+            _store.UpdateSegmentTranscript(job.SegmentId, transcript: null,
+                callsign: null, callsignState: "unknown", callsignName: null);
+            return;
+        }
+
+        var (callsign, state, name) = await AttributeAsync(transcript, ct);
+        _store.UpdateSegmentTranscript(job.SegmentId, transcript, callsign, state, name);
+        _log.LogDebug("voyeur.transcribe seg={Seg} call={Call} state={State}", job.SegmentId, callsign, state);
+    }
+
+    // Pick the best callsign from the transcript and validate it against QRZ.
+    // confirmed = QRZ resolves it (real licensee); tentative = well-formed but
+    // QRZ has no record (DX/foreign/unlisted); unknown = nothing decodable.
+    private async Task<(string? callsign, string state, string? name)> AttributeAsync(
+        string transcript, CancellationToken ct)
+    {
+        var candidates = CallsignExtractor.Extract(transcript);
+        if (candidates.Count == 0) return (null, "unknown", null);
+
+        // Try candidates in rank order; the first QRZ-confirmed one wins
+        // (longest-validated, per the Phase-0 fragment-collision finding).
+        foreach (var cand in candidates.Take(5))
+        {
+            var (station, valid) = await QrzLookupAsync(cand, ct);
+            if (valid)
+            {
+                var name = station?.FirstName ?? station?.Name;
+                return (cand, "confirmed", name);
+            }
+        }
+
+        // None confirmed — surface the top candidate as tentative so the
+        // operator sees a best-guess they can verify, clearly marked.
+        return (candidates[0], "tentative", null);
+    }
+
+    private async Task<(QrzStation? station, bool valid)> QrzLookupAsync(string callsign, CancellationToken ct)
+    {
+        if (_qrzCache.TryGetValue(callsign, out var cached)) return (cached.Station, cached.Valid);
+
+        // Rate-limit: never hammer QRZ's shared gate and starve manual lookups.
+        var since = DateTime.UtcNow - _lastQrzLookup;
+        if (since < QrzMinInterval)
+            await Task.Delay(QrzMinInterval - since, ct);
+        _lastQrzLookup = DateTime.UtcNow;
+
+        QrzStation? station = null;
+        try { station = await _qrz.LookupAsync(callsign, ct); }
+        catch (Exception ex) { _log.LogDebug(ex, "voyeur.qrz lookup failed {Call}", callsign); }
+
+        bool valid = station is not null;
+        _qrzCache[callsign] = (station, valid);
+        return (station, valid);
+    }
+}

--- a/Zeus.Server.Hosting/Voyeur/WhisperTranscriber.cs
+++ b/Zeus.Server.Hosting/Voyeur/WhisperTranscriber.cs
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see ATTRIBUTIONS.md for provenance.
+
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Server.Voyeur;
+
+/// <summary>
+/// Runs whisper.cpp as a SEPARATE, SUPERVISED OS CHILD PROCESS to transcribe a
+/// captured "over" (Voyeur Mode, zeus-la5 Phase 2). The child-process boundary
+/// is load-bearing safety, not a convenience: whisper.cpp is native code, and
+/// a segfault / access-violation / OOM there must kill only the child, never
+/// the Zeus host (which carries the realtime RX/DSP/PureSignal/TX threads).
+/// We therefore NEVER P/Invoke whisper — we shell out to <c>whisper-cli</c>,
+/// feed it the over's WAV, read the text it writes, and bound it with a hard
+/// timeout (kill + drop the segment) so a wedged child can never stall the
+/// pipeline.
+///
+/// Graceful absence: if the binary or model isn't installed, transcription is
+/// simply OFF — Voyeur Mode still captures overs (Phase 1), and the panel tells
+/// the operator how to enable ASR. Discovery is env-overridable
+/// (<c>ZEUS_WHISPER_CLI</c> / <c>ZEUS_WHISPER_MODEL</c>) and otherwise probes
+/// the usual Homebrew / system locations plus the Zeus app-data
+/// <c>whisper/</c> folder for a <c>ggml-*.en.bin</c> model.
+/// </summary>
+public sealed class WhisperTranscriber
+{
+    private readonly ILogger<WhisperTranscriber> _log;
+    private readonly string? _cliPath;
+    private readonly string? _modelPath;
+
+    // Ham-context prompt — biases decoding toward phonetics / Q-codes /
+    // callsign shapes. Proven on the Phase-0 spike against real eCARS audio.
+    private const string HamPrompt =
+        "Amateur radio HF SSB net. Operators identify by callsign using the NATO " +
+        "phonetic alphabet: Alpha Bravo Charlie Delta Echo Foxtrot Golf Hotel India " +
+        "Juliet Kilo Lima Mike November Oscar Papa Quebec Romeo Sierra Tango Uniform " +
+        "Victor Whiskey X-ray Yankee Zulu. Callsigns look like W1ABC, KB2UKA, VE3XYZ, " +
+        "G4ABC. Common terms: QSL, QRZ, QSO, QTH, QRM, QRN, QSB, roger, copy, over, " +
+        "standing by, this is, back to net control, signal report five nine, " +
+        "seventy-three, handle, grid square, rig, antenna, beam, dipole, watts.";
+
+    public WhisperTranscriber(ILogger<WhisperTranscriber> log)
+    {
+        _log = log;
+        _cliPath = LocateCli();
+        _modelPath = LocateModel();
+        if (Available)
+            _log.LogInformation("voyeur.whisper ready cli={Cli} model={Model}", _cliPath, _modelPath);
+        else
+            _log.LogInformation(
+                "voyeur.whisper not configured (cli={Cli} model={Model}) — capture-only until installed",
+                _cliPath ?? "missing", _modelPath ?? "missing");
+    }
+
+    /// <summary>True when both the binary and a model are present.</summary>
+    public bool Available => _cliPath is not null && _modelPath is not null;
+
+    /// <summary>Where the model is expected to live, for the panel's setup
+    /// instructions even when one isn't present yet.</summary>
+    public static string ModelDir => Path.Combine(ZeusAppData(), "whisper");
+
+    /// <summary>
+    /// Transcribe a WAV (any sample rate — whisper-cli resamples to 16 kHz
+    /// internally). Returns the transcript text, or null if transcription is
+    /// unavailable, timed out, or failed. NEVER throws into the caller, and
+    /// NEVER blocks past <paramref name="timeout"/> — a wedged child is killed.
+    /// </summary>
+    public async Task<string?> TranscribeAsync(string wavPath, TimeSpan timeout, CancellationToken ct)
+    {
+        if (!Available || !File.Exists(wavPath)) return null;
+
+        var outBase = Path.Combine(Path.GetTempPath(), "zeus-voyeur-" + Guid.NewGuid().ToString("N"));
+        var txtPath = outBase + ".txt";
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = _cliPath!,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            psi.ArgumentList.Add("-m"); psi.ArgumentList.Add(_modelPath!);
+            psi.ArgumentList.Add("-f"); psi.ArgumentList.Add(wavPath);
+            psi.ArgumentList.Add("--prompt"); psi.ArgumentList.Add(HamPrompt);
+            psi.ArgumentList.Add("-otxt");
+            psi.ArgumentList.Add("-of"); psi.ArgumentList.Add(outBase);
+            psi.ArgumentList.Add("-np"); // no per-segment progress prints
+
+            using var proc = new Process { StartInfo = psi };
+            if (!proc.Start()) return null;
+
+            // Below-normal priority so ASR bursts never preempt realtime threads.
+            try { proc.PriorityClass = ProcessPriorityClass.BelowNormal; } catch { /* best effort */ }
+
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timeoutCts.CancelAfter(timeout);
+            try
+            {
+                await proc.WaitForExitAsync(timeoutCts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // Timeout or shutdown — kill the whole child tree and drop the
+                // segment. Never let a wedged child hold the pipeline.
+                try { proc.Kill(entireProcessTree: true); } catch { /* ignore */ }
+                _log.LogWarning("voyeur.whisper timed out after {Sec:F0}s — segment dropped", timeout.TotalSeconds);
+                return null;
+            }
+
+            if (proc.ExitCode != 0)
+            {
+                _log.LogWarning("voyeur.whisper exit={Code}", proc.ExitCode);
+                return null;
+            }
+
+            if (!File.Exists(txtPath)) return null;
+            var text = (await File.ReadAllTextAsync(txtPath, ct)).Trim();
+            return string.IsNullOrWhiteSpace(text) ? null : Clean(text);
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "voyeur.whisper transcribe failed — segment left untranscribed");
+            return null;
+        }
+        finally
+        {
+            try { if (File.Exists(txtPath)) File.Delete(txtPath); } catch { /* ignore */ }
+        }
+    }
+
+    // whisper tags non-speech as [BLANK_AUDIO] / (noise) etc.; collapse those
+    // and whitespace so a quiet over yields an empty (=> dropped) transcript.
+    private static string Clean(string text)
+    {
+        var lines = text.Split('\n')
+            .Select(l => l.Trim())
+            .Where(l => l.Length > 0 && !l.StartsWith('[') && !l.StartsWith('('))
+            .ToList();
+        return string.Join(' ', lines).Trim();
+    }
+
+    private static string? LocateCli()
+    {
+        var env = Environment.GetEnvironmentVariable("ZEUS_WHISPER_CLI");
+        if (!string.IsNullOrWhiteSpace(env) && File.Exists(env)) return env;
+        // GUI/desktop processes often lack /opt/homebrew/bin on PATH, so probe
+        // the usual install locations explicitly.
+        string[] names = { "whisper-cli", "whisper", "main" };
+        string[] dirs =
+        {
+            "/opt/homebrew/bin", "/usr/local/bin", "/usr/bin",
+        };
+        foreach (var d in dirs)
+            foreach (var n in names)
+            {
+                var p = Path.Combine(d, n);
+                if (File.Exists(p)) return p;
+            }
+        // Fall back to PATH search.
+        var pathVar = Environment.GetEnvironmentVariable("PATH") ?? "";
+        foreach (var d in pathVar.Split(Path.PathSeparator))
+            foreach (var n in names)
+            {
+                try { var p = Path.Combine(d, n); if (File.Exists(p)) return p; }
+                catch { /* malformed PATH entry */ }
+            }
+        return null;
+    }
+
+    private static string? LocateModel()
+    {
+        var env = Environment.GetEnvironmentVariable("ZEUS_WHISPER_MODEL");
+        if (!string.IsNullOrWhiteSpace(env) && File.Exists(env)) return env;
+        var dir = ModelDir;
+        if (!Directory.Exists(dir)) return null;
+        // Prefer medium.en (Phase-0 recommended default) > small.en > anything.
+        string[] prefs = { "ggml-medium.en.bin", "ggml-small.en.bin", "ggml-base.en.bin" };
+        foreach (var pref in prefs)
+        {
+            var p = Path.Combine(dir, pref);
+            if (File.Exists(p)) return p;
+        }
+        return Directory.EnumerateFiles(dir, "ggml-*.bin").FirstOrDefault();
+    }
+
+    private static string ZeusAppData()
+    {
+        var appData = Environment.GetFolderPath(
+            Environment.SpecialFolder.LocalApplicationData,
+            Environment.SpecialFolderOption.Create);
+        return Path.Combine(appData, "Zeus");
+    }
+}

--- a/Zeus.Server.Hosting/Voyeur/WhisperTranscriber.cs
+++ b/Zeus.Server.Hosting/Voyeur/WhisperTranscriber.cs
@@ -38,8 +38,6 @@ namespace Zeus.Server.Voyeur;
 public sealed class WhisperTranscriber
 {
     private readonly ILogger<WhisperTranscriber> _log;
-    private readonly string? _cliPath;
-    private readonly string? _modelPath;
 
     // Ham-context prompt — biases decoding toward phonetics / Q-codes /
     // callsign shapes. Proven on the Phase-0 spike against real eCARS audio.
@@ -55,18 +53,23 @@ public sealed class WhisperTranscriber
     public WhisperTranscriber(ILogger<WhisperTranscriber> log)
     {
         _log = log;
-        _cliPath = LocateCli();
-        _modelPath = LocateModel();
-        if (Available)
-            _log.LogInformation("voyeur.whisper ready cli={Cli} model={Model}", _cliPath, _modelPath);
-        else
-            _log.LogInformation(
-                "voyeur.whisper not configured (cli={Cli} model={Model}) — capture-only until installed",
-                _cliPath ?? "missing", _modelPath ?? "missing");
+        _log.LogInformation(
+            "voyeur.whisper init cli={Cli} model={Model}",
+            LocateCli() ?? "missing", LocateModel() ?? "missing");
     }
 
-    /// <summary>True when both the binary and a model are present.</summary>
-    public bool Available => _cliPath is not null && _modelPath is not null;
+    // Discovery is DYNAMIC (re-resolved on each check), not cached at startup —
+    // so a binary/model installed via the in-app button is picked up
+    // immediately, with no Zeus restart. File-existence probes are cheap.
+
+    /// <summary>True when both the binary and a model are present right now.</summary>
+    public bool Available => LocateCli() is not null && LocateModel() is not null;
+
+    /// <summary>The whisper-cli binary path, or null if not found.</summary>
+    public string? CliPath => LocateCli();
+
+    /// <summary>The model path, or null if none present.</summary>
+    public string? ModelPath => LocateModel();
 
     /// <summary>Where the model is expected to live, for the panel's setup
     /// instructions even when one isn't present yet.</summary>
@@ -80,7 +83,9 @@ public sealed class WhisperTranscriber
     /// </summary>
     public async Task<string?> TranscribeAsync(string wavPath, TimeSpan timeout, CancellationToken ct)
     {
-        if (!Available || !File.Exists(wavPath)) return null;
+        var cliPath = LocateCli();
+        var modelPath = LocateModel();
+        if (cliPath is null || modelPath is null || !File.Exists(wavPath)) return null;
 
         var outBase = Path.Combine(Path.GetTempPath(), "zeus-voyeur-" + Guid.NewGuid().ToString("N"));
         var txtPath = outBase + ".txt";
@@ -88,13 +93,13 @@ public sealed class WhisperTranscriber
         {
             var psi = new ProcessStartInfo
             {
-                FileName = _cliPath!,
+                FileName = cliPath,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = true,
             };
-            psi.ArgumentList.Add("-m"); psi.ArgumentList.Add(_modelPath!);
+            psi.ArgumentList.Add("-m"); psi.ArgumentList.Add(modelPath);
             psi.ArgumentList.Add("-f"); psi.ArgumentList.Add(wavPath);
             psi.ArgumentList.Add("--prompt"); psi.ArgumentList.Add(HamPrompt);
             psi.ArgumentList.Add("-otxt");
@@ -158,20 +163,37 @@ public sealed class WhisperTranscriber
     {
         var env = Environment.GetEnvironmentVariable("ZEUS_WHISPER_CLI");
         if (!string.IsNullOrWhiteSpace(env) && File.Exists(env)) return env;
-        // GUI/desktop processes often lack /opt/homebrew/bin on PATH, so probe
-        // the usual install locations explicitly.
-        string[] names = { "whisper-cli", "whisper", "main" };
-        string[] dirs =
+
+        bool win = OperatingSystem.IsWindows();
+        string[] names = win
+            ? new[] { "whisper-cli.exe", "whisper.exe", "main.exe" }
+            : new[] { "whisper-cli", "whisper", "main" };
+
+        // 1) The in-app install dir (where the button drops a downloaded binary)
+        //    and the app's bundled-native dir (where CI would ship whisper-cli
+        //    alongside Zeus, exactly like libwdsp). Checked first so a managed
+        //    install always wins over a stray system copy.
+        var dirs = new List<string>
         {
-            "/opt/homebrew/bin", "/usr/local/bin", "/usr/bin",
+            BinDir,
+            AppContext.BaseDirectory,
+            Path.Combine(AppContext.BaseDirectory, "whisper"),
         };
+        // 2) Platform package-manager locations (GUI processes often lack these
+        //    on PATH, so probe explicitly).
+        if (!win)
+        {
+            dirs.Add("/opt/homebrew/bin");
+            dirs.Add("/usr/local/bin");
+            dirs.Add("/usr/bin");
+        }
         foreach (var d in dirs)
             foreach (var n in names)
             {
-                var p = Path.Combine(d, n);
-                if (File.Exists(p)) return p;
+                try { var p = Path.Combine(d, n); if (File.Exists(p)) return p; }
+                catch { /* ignore */ }
             }
-        // Fall back to PATH search.
+        // 3) PATH fallback.
         var pathVar = Environment.GetEnvironmentVariable("PATH") ?? "";
         foreach (var d in pathVar.Split(Path.PathSeparator))
             foreach (var n in names)
@@ -181,6 +203,9 @@ public sealed class WhisperTranscriber
             }
         return null;
     }
+
+    /// <summary>Where the in-app installer drops the whisper-cli binary.</summary>
+    public static string BinDir => Path.Combine(ZeusAppData(), "whisper", "bin");
 
     private static string? LocateModel()
     {

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -172,6 +172,18 @@ public static class ZeusEndpoints
         // Transcription readiness + setup hint for the panel (Phase 2).
         app.MapGet("/api/voyeur/transcription", (Zeus.Server.Voyeur.WhisperTranscriber w) =>
             Results.Ok(new { available = w.Available, modelDir = Zeus.Server.Voyeur.WhisperTranscriber.ModelDir }));
+        // In-app, terminal-free transcription setup (cross-platform model download).
+        app.MapGet("/api/voyeur/install/models", () =>
+            Results.Ok(Zeus.Server.Voyeur.VoyeurInstallService.AvailableModels));
+        app.MapGet("/api/voyeur/install/status", (Zeus.Server.Voyeur.VoyeurInstallService i) =>
+            Results.Ok(i.Status()));
+        app.MapPost("/api/voyeur/install/model", (VoyeurInstallRequest body, Zeus.Server.Voyeur.VoyeurInstallService i) =>
+            Results.Ok(i.InstallModel(body?.Model ?? "small.en")));
+        app.MapPost("/api/voyeur/install/cancel", (Zeus.Server.Voyeur.VoyeurInstallService i) =>
+        {
+            i.Cancel();
+            return Results.Ok(i.Status());
+        });
         app.MapPost("/api/voyeur/start", (VoyeurStartRequest? body, VoyeurMonitorService v) =>
             Results.Ok(v.Start(keepAudio: body?.KeepAudio ?? true)));
         app.MapPost("/api/voyeur/stop", (VoyeurMonitorService v) => Results.Ok(v.Stop()));
@@ -1524,3 +1536,4 @@ internal sealed record MasterBypassSetRequest(bool Bypassed);
 internal sealed record WavRecordStartRequest(string? Source);
 internal sealed record WavPlayRequest(string? File);
 internal sealed record VoyeurStartRequest(bool? KeepAudio);
+internal sealed record VoyeurInstallRequest(string? Model);

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -169,6 +169,9 @@ public static class ZeusEndpoints
 
         // ---- Voyeur Mode (zeus-la5) — unattended net monitor + log mgmt ----
         app.MapGet("/api/voyeur/status", (VoyeurMonitorService v) => Results.Ok(v.Status()));
+        // Transcription readiness + setup hint for the panel (Phase 2).
+        app.MapGet("/api/voyeur/transcription", (Zeus.Server.Voyeur.WhisperTranscriber w) =>
+            Results.Ok(new { available = w.Available, modelDir = Zeus.Server.Voyeur.WhisperTranscriber.ModelDir }));
         app.MapPost("/api/voyeur/start", (VoyeurStartRequest? body, VoyeurMonitorService v) =>
             Results.Ok(v.Start(keepAudio: body?.KeepAudio ?? true)));
         app.MapPost("/api/voyeur/stop", (VoyeurMonitorService v) => Results.Ok(v.Stop()));

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -284,6 +284,11 @@ public static class ZeusHost
         // callsign extraction + QRZ enrichment. Runs entirely off the audio
         // path; degrades to capture-only when whisper isn't installed.
         builder.Services.AddSingleton<Zeus.Server.Voyeur.WhisperTranscriber>();
+        // In-app, terminal-free model download (cross-platform). Needs an
+        // HttpClientFactory — already registered below via AddHttpClient, but
+        // ensure the default factory exists for this service.
+        builder.Services.AddHttpClient();
+        builder.Services.AddSingleton<Zeus.Server.Voyeur.VoyeurInstallService>();
         builder.Services.AddSingleton<Zeus.Server.Voyeur.VoyeurTranscriptionService>();
         builder.Services.AddHostedService(sp =>
             sp.GetRequiredService<Zeus.Server.Voyeur.VoyeurTranscriptionService>());

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -280,6 +280,13 @@ public static class ZeusHost
         // "cannot break anything" notes). VoyeurStore owns the LiteDB log +
         // segment-audio files (the save/delete surface).
         builder.Services.AddSingleton<Zeus.Server.Voyeur.VoyeurStore>();
+        // Phase 2: whisper.cpp transcription (supervised child process) +
+        // callsign extraction + QRZ enrichment. Runs entirely off the audio
+        // path; degrades to capture-only when whisper isn't installed.
+        builder.Services.AddSingleton<Zeus.Server.Voyeur.WhisperTranscriber>();
+        builder.Services.AddSingleton<Zeus.Server.Voyeur.VoyeurTranscriptionService>();
+        builder.Services.AddHostedService(sp =>
+            sp.GetRequiredService<Zeus.Server.Voyeur.VoyeurTranscriptionService>());
         builder.Services.AddSingleton<VoyeurMonitorService>();
         builder.Services.AddHostedService(sp => sp.GetRequiredService<VoyeurMonitorService>());
         // WAV recorder/player: taps DspPipelineService RX + TX-monitor audio to

--- a/tests/Zeus.Server.Tests/CallsignExtractorTests.cs
+++ b/tests/Zeus.Server.Tests/CallsignExtractorTests.cs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Tests for the Voyeur Mode callsign extractor (zeus-la5 Phase 2). The phrases
+// are the ACTUAL whisper.cpp output from the Phase-0 spike on real eCARS
+// (7255 kHz) audio, so this pins the C# decoder to the behavior validated end
+// to end against live HF SSB — including Whisper's specific mis-hearings.
+
+using System.Linq;
+using Xunit;
+using Zeus.Server.Voyeur;
+
+namespace Zeus.Server.Tests;
+
+public class CallsignExtractorTests
+{
+    [Theory]
+    // Net control, spelled in full NATO — the canonical case.
+    [InlineData("This is Whiskey Alpha 2 Delta Victor United E-Corps 7255, check ins", "WA2DVU")]
+    // VE3 with Whisper's "Foxtrops" mis-hearing of Foxtrot.
+    [InlineData("Victor Echo 3, Hotel X-ray, fox drop", "VE3HX")]
+    [InlineData("The Victor Echo 3 Hotel X-ray Foxtrops", "VE3HXF")]
+    // Clearly-worked check-ins from the spike.
+    [InlineData("Kilo Bravo 1, Hotel Romeo Lima", "KB1HRL")]
+    [InlineData("Kilo One, Papa November", "K1PN")]
+    [InlineData("Kilo Delta Two, Oscar Alpha Mike, mobile", "KD2OAM")]
+    [InlineData("Absolutely, this is K-4-U-E-K, standing by", "K4UEK")]
+    public void DecodesSpokenCallsign(string transcript, string expected)
+    {
+        var calls = CallsignExtractor.Extract(transcript);
+        Assert.Contains(expected, calls);
+    }
+
+    [Fact]
+    public void EmptyAndNonCallsignText_YieldNoCandidates()
+    {
+        Assert.Empty(CallsignExtractor.Extract(null));
+        Assert.Empty(CallsignExtractor.Extract(""));
+        Assert.Empty(CallsignExtractor.Extract(
+            "the band really sucks today, heavy QSB, can really only hear every other word"));
+    }
+
+    [Fact]
+    public void EmitsTruncations_LongestFirst_ForQrzToDisambiguate()
+    {
+        // The full call and its fragments are all candidates (QRZ picks the
+        // longest that validates — the Phase-0 fragment-collision fix). They're
+        // ordered longest-first, so the full call precedes its shorter fragment.
+        var calls = CallsignExtractor.Extract(
+            "This is Whiskey Alpha 2 Delta Victor. WA2 Delta Victor United, check ins.");
+        Assert.Contains("WA2DVU", calls);
+        Assert.Contains("WA2DV", calls);
+        Assert.True(
+            calls.ToList().IndexOf("WA2DVU") < calls.ToList().IndexOf("WA2DV"),
+            "longer call should rank before its fragment");
+    }
+
+    [Fact]
+    public void SentenceBoundaryBreaksRuns()
+    {
+        // "Victor. WA2" must not merge into one impossible run across the period.
+        var calls = CallsignExtractor.Extract("Whiskey Alpha 2 Delta Victor. Kilo One Papa November");
+        Assert.Contains("K1PN", calls);
+        Assert.DoesNotContain(calls, c => c.Contains("VK", System.StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void HandlesAlreadyCollapsedTokens()
+    {
+        // Whisper sometimes emits the whole call (or prefix+digit) as one token.
+        Assert.Contains("N2ZKN", CallsignExtractor.Extract("This is N2ZKN, net control for eCARS"));
+        Assert.Contains("N2BK", CallsignExtractor.Extract("Okay, this is N2BK and net control"));
+    }
+
+    [Fact]
+    public void DoesNotInventCallsFromOrdinaryWords()
+    {
+        // "one" / "two" are digit words but with no surrounding letters they
+        // can't form a callsign; plain prose must not yield a candidate.
+        var calls = CallsignExtractor.Extract("I worked one or two stations, nothing in close");
+        Assert.Empty(calls);
+    }
+}

--- a/tests/Zeus.Server.Tests/CallsignExtractorTests.cs
+++ b/tests/Zeus.Server.Tests/CallsignExtractorTests.cs
@@ -83,4 +83,24 @@ public class CallsignExtractorTests
         var calls = CallsignExtractor.Extract("I worked one or two stations, nothing in close");
         Assert.Empty(calls);
     }
+
+    [Theory]
+    // Custom / non-NATO phonetics — common in ham nets. The first letter of each
+    // spoken word is the callsign character; the real NATO words ("Kilo Echo")
+    // mark it as a readback so the custom words get absorbed.
+    [InlineData("this is Kilo Echo 8 Jolly Whiskers, looking for check-ins", "KE8JW")]
+    [InlineData("Whiskey Alpha 2 Denver Victor", "WA2DV")]
+    public void DecodesCustomPhonetics(string transcript, string expected)
+    {
+        Assert.Contains(expected, CallsignExtractor.Extract(transcript));
+    }
+
+    [Fact]
+    public void ConversationWithDigitsButNoPhonetics_YieldsNoConfidentCall()
+    {
+        // No NATO phonetic present → weak first-letter absorption is NOT armed,
+        // so ordinary talk around a number doesn't manufacture a callsign.
+        var calls = CallsignExtractor.Extract("I got 8 of them in the log, nothing much else going on");
+        Assert.Empty(calls);
+    }
 }

--- a/zeus-web/src/api/voyeur.ts
+++ b/zeus-web/src/api/voyeur.ts
@@ -27,6 +27,7 @@ export type VoyeurStatus = {
   droppedSamples: number;
   ringFillPct: number;
   degraded: boolean;
+  transcriptionAvailable: boolean;
 };
 
 export type VoyeurSession = {
@@ -54,6 +55,8 @@ export type VoyeurSegment = {
   callsign: string | null;
   // "confirmed" | "tentative" | "unknown" (Phase 2 — null in Phase 1)
   callsignState: string | null;
+  // QRZ operator name when confirmed (roster enrichment).
+  callsignName: string | null;
 };
 
 export type VoyeurSessionDetail = {
@@ -76,8 +79,13 @@ async function json<T>(input: string, init?: RequestInit): Promise<T> {
   return (await res.json()) as T;
 }
 
+export type VoyeurTranscription = { available: boolean; modelDir: string };
+
 export const getVoyeurStatus = (signal?: AbortSignal) =>
   json<VoyeurStatus>('/api/voyeur/status', { signal });
+
+export const getVoyeurTranscription = (signal?: AbortSignal) =>
+  json<VoyeurTranscription>('/api/voyeur/transcription', { signal });
 
 export const startVoyeur = (keepAudio = true) =>
   json<VoyeurStatus>('/api/voyeur/start', {

--- a/zeus-web/src/api/voyeur.ts
+++ b/zeus-web/src/api/voyeur.ts
@@ -87,6 +87,34 @@ export const getVoyeurStatus = (signal?: AbortSignal) =>
 export const getVoyeurTranscription = (signal?: AbortSignal) =>
   json<VoyeurTranscription>('/api/voyeur/transcription', { signal });
 
+export type VoyeurModel = { id: string; label: string };
+
+export type VoyeurInstall = {
+  phase: 'Idle' | 'Downloading' | 'Done' | 'Error';
+  percent: number;
+  message: string;
+  item: string | null;
+  modelPresent: boolean;
+  binaryPresent: boolean;
+  rid: string;
+};
+
+export const getVoyeurModels = (signal?: AbortSignal) =>
+  json<VoyeurModel[]>('/api/voyeur/install/models', { signal });
+
+export const getVoyeurInstallStatus = (signal?: AbortSignal) =>
+  json<VoyeurInstall>('/api/voyeur/install/status', { signal });
+
+export const installVoyeurModel = (model: string) =>
+  json<VoyeurInstall>('/api/voyeur/install/model', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ model }),
+  });
+
+export const cancelVoyeurInstall = () =>
+  json<VoyeurInstall>('/api/voyeur/install/cancel', { method: 'POST' });
+
 export const startVoyeur = (keepAudio = true) =>
   json<VoyeurStatus>('/api/voyeur/start', {
     method: 'POST',

--- a/zeus-web/src/layout/panels/VoyeurPanel.tsx
+++ b/zeus-web/src/layout/panels/VoyeurPanel.tsx
@@ -18,12 +18,18 @@ import type { PanelComponentProps } from '../panels';
 import {
   deleteVoyeurSession,
   getVoyeurSession,
+  cancelVoyeurInstall,
+  getVoyeurInstallStatus,
+  getVoyeurModels,
   getVoyeurStatus,
   getVoyeurTranscription,
+  installVoyeurModel,
   listVoyeurSessions,
   startVoyeur,
   stopVoyeur,
   updateVoyeurSession,
+  type VoyeurInstall,
+  type VoyeurModel,
   type VoyeurSession,
   type VoyeurSessionDetail,
   type VoyeurStatus,
@@ -66,6 +72,9 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
   const [asrReady, setAsrReady] = useState<boolean | null>(null);
   const [modelDir, setModelDir] = useState<string>('');
   const [showHelp, setShowHelp] = useState(false);
+  const [models, setModels] = useState<VoyeurModel[]>([]);
+  const [chosenModel, setChosenModel] = useState('small.en');
+  const [install, setInstall] = useState<VoyeurInstall | null>(null);
   const editingRef = useRef<HTMLInputElement | null>(null);
 
   const refreshSessions = useCallback(async () => {
@@ -100,20 +109,52 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
     void refreshSessions();
   }, [refreshSessions]);
 
-  useEffect(() => {
-    let alive = true;
-    void getVoyeurTranscription()
-      .then((t) => {
-        if (alive) {
-          setAsrReady(t.available);
-          setModelDir(t.modelDir);
-        }
-      })
-      .catch(() => {});
-    return () => {
-      alive = false;
-    };
+  const refreshAsr = useCallback(async () => {
+    try {
+      const t = await getVoyeurTranscription();
+      setAsrReady(t.available);
+      setModelDir(t.modelDir);
+    } catch {
+      /* ignore */
+    }
   }, []);
+
+  useEffect(() => {
+    void refreshAsr();
+    void getVoyeurModels().then(setModels).catch(() => {});
+    void getVoyeurInstallStatus().then(setInstall).catch(() => {});
+  }, [refreshAsr]);
+
+  // Poll install progress while a download is running; refresh ASR readiness
+  // when it finishes (discovery is dynamic, so no restart needed).
+  useEffect(() => {
+    if (install?.phase !== 'Downloading') return;
+    const h = setInterval(async () => {
+      try {
+        const s = await getVoyeurInstallStatus();
+        setInstall(s);
+        if (s.phase === 'Done') void refreshAsr();
+      } catch {
+        /* ignore */
+      }
+    }, 1000);
+    return () => clearInterval(h);
+  }, [install?.phase, refreshAsr]);
+
+  const onInstall = async () => {
+    try {
+      setInstall(await installVoyeurModel(chosenModel));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+  const onCancelInstall = async () => {
+    try {
+      setInstall(await cancelVoyeurInstall());
+    } catch {
+      /* ignore */
+    }
+  };
 
   // When a session is active, refresh the list as its segment count grows.
   useEffect(() => {
@@ -313,33 +354,79 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
             <div style={{ fontWeight: 600, margin: '8px 0 4px' }}>
               Enable transcription (one-time, optional)
             </div>
-            Transcription runs locally — audio never leaves your computer.
-            <ol style={{ margin: '4px 0 0', paddingLeft: 18 }}>
-              <li>
-                Install whisper:{' '}
-                <code style={{ background: 'var(--panel-top)', padding: '0 4px' }}>
-                  brew install whisper-cpp
-                </code>{' '}
-                (macOS) — or put the <code>whisper-cli</code> binary on your PATH.
-              </li>
-              <li>
-                Download a model and drop it here:
+            Transcription runs locally — audio never leaves your computer. Pick a
+            speech model and click Download; no terminal needed. The bigger model
+            is more accurate on noisy SSB; the smaller one downloads faster.
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, margin: '6px 0' }}>
+              <select
+                value={chosenModel}
+                onChange={(e) => setChosenModel(e.target.value)}
+                disabled={install?.phase === 'Downloading'}
+                aria-label="Speech model"
+                style={{ flex: 1, minWidth: 0 }}
+              >
+                {(models.length
+                  ? models
+                  : [
+                      { id: 'small.en', label: 'Small (English) — fast' },
+                      { id: 'medium.en', label: 'Medium (English) — most accurate' },
+                    ]
+                ).map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.label}
+                  </option>
+                ))}
+              </select>
+              {install?.phase === 'Downloading' ? (
+                <button type="button" className="btn sm tx" onClick={onCancelInstall}>
+                  Cancel
+                </button>
+              ) : (
+                <button type="button" className="btn sm accent" onClick={onInstall}>
+                  Download
+                </button>
+              )}
+            </div>
+            {install?.phase === 'Downloading' && (
+              <div style={{ margin: '4px 0' }}>
                 <div
                   style={{
-                    margin: '2px 0',
-                    padding: '2px 4px',
+                    height: 6,
+                    borderRadius: 3,
                     background: 'var(--panel-top)',
-                    wordBreak: 'break-all',
+                    overflow: 'hidden',
                   }}
                 >
-                  {modelDir || '…/Zeus/whisper/'}
+                  <div
+                    style={{
+                      width: `${install.percent}%`,
+                      height: '100%',
+                      background: 'var(--accent)',
+                      transition: 'width 0.4s',
+                    }}
+                  />
                 </div>
-                Recommended: <code>ggml-medium.en.bin</code> (best accuracy on
-                noisy SSB) or <code>ggml-small.en.bin</code> (lighter). Get them
-                from the whisper.cpp model page on Hugging Face.
-              </li>
-              <li>Restart Zeus. The indicator above turns green when it’s found.</li>
-            </ol>
+                <div style={{ fontSize: 10, opacity: 0.7, marginTop: 2 }}>{install.message}</div>
+              </div>
+            )}
+            {install?.phase === 'Done' && (
+              <div style={{ color: 'var(--accent)', fontSize: 11 }}>✓ {install.message}</div>
+            )}
+            {install?.phase === 'Error' && (
+              <div style={{ color: 'var(--tx)', fontSize: 11 }}>Download failed: {install.message}</div>
+            )}
+            {install && !install.binaryPresent && (
+              <div style={{ fontSize: 10, opacity: 0.7, marginTop: 4 }}>
+                Note: the whisper engine for your platform ({install.rid}) ships
+                with Zeus. If transcription stays off after the model downloads,
+                the engine isn’t bundled in this build yet — advanced users can
+                place a <code>whisper-cli</code> binary in{' '}
+                <code style={{ wordBreak: 'break-all' }}>
+                  {modelDir ? `${modelDir}/bin` : '…/Zeus/whisper/bin'}
+                </code>
+                .
+              </div>
+            )}
             <div style={{ fontWeight: 600, margin: '8px 0 4px' }}>
               Reading the roster
             </div>

--- a/zeus-web/src/layout/panels/VoyeurPanel.tsx
+++ b/zeus-web/src/layout/panels/VoyeurPanel.tsx
@@ -15,6 +15,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { TileChrome } from '../TileChrome';
 import type { PanelComponentProps } from '../panels';
+import './voyeur.css';
 import {
   deleteVoyeurSession,
   getVoyeurSession,
@@ -257,371 +258,268 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
           </button>
         }
       />
-      <div style={{ padding: '8px 10px', overflow: 'auto', fontSize: 12 }}>
-        {/* Live status */}
-        <div
-          style={{
-            display: 'flex',
-            gap: 12,
-            flexWrap: 'wrap',
-            padding: '6px 8px',
-            borderRadius: 4,
-            background: 'var(--panel-bot)',
-            marginBottom: 8,
-          }}
-        >
-          {active && status ? (
-            <>
-              <span>
-                <strong style={{ color: 'var(--accent)' }}>● listening</strong>{' '}
-                {fmtFreq(status.freqHz)} {status.mode} {status.band}
-              </span>
-              <span>overs: {status.segmentCount}</span>
-              <span>captured: {fmtDur(status.capturedSeconds)}</span>
-              {status.droppedSamples > 0 && (
-                <span title="Samples dropped because the CPU briefly fell behind. RX is unaffected — this is just a capture gap.">
-                  dropped: {status.droppedSamples}
-                </span>
-              )}
-              {status.degraded && (
-                <span style={{ color: 'var(--tx)' }} title="The monitor faulted and detached. RX is unaffected.">
-                  degraded
-                </span>
-              )}
-            </>
-          ) : (
-            <span style={{ opacity: 0.7 }}>
-              Idle — press LISTEN to log the current frequency. Phase 1 captures each
-              transmission; transcription + callsigns arrive in Phase 2.
-            </span>
-          )}
-        </div>
-
-        {/* Transcription readiness + setup */}
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 8,
-            marginBottom: 6,
-            fontSize: 11,
-          }}
-        >
-          <span
-            style={{ color: asrReady ? 'var(--accent)' : 'var(--power)' }}
-            title="Transcription needs whisper.cpp + a model. Without it, Voyeur Mode still captures overs; it just won't transcribe or identify callsigns."
-          >
-            {asrReady === null
-              ? 'transcription: checking…'
-              : asrReady
-                ? '● transcription ready'
-                : '○ transcription off (capture-only)'}
-          </span>
-          <button
-            type="button"
-            className="btn sm"
-            onClick={() => setShowHelp((v) => !v)}
-            aria-expanded={showHelp}
-          >
-            {showHelp ? 'Hide setup' : 'How to set up & use'}
-          </button>
-        </div>
-
-        {/* Prominent model-download control whenever transcription is off — so
-            the primary setup action isn't buried in the help disclosure. */}
-        {asrReady === false && (
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 6,
-              padding: '6px 8px',
-              marginBottom: 8,
-              borderRadius: 4,
-              background: 'var(--panel-bot)',
-              border: '1px solid var(--panel-top)',
-              fontSize: 11,
-            }}
-          >
-            {install?.phase === 'Downloading' ? (
+      <div className="voyeur">
+        <div className="voyeur__controls">
+          {/* Live receiver bar */}
+          <div className={`voyeur-live ${active ? 'voyeur-live--on' : ''}`}>
+            {active && status ? (
               <>
-                <div style={{ flex: 1, minWidth: 0 }}>
-                  <div
-                    style={{
-                      height: 6,
-                      borderRadius: 3,
-                      background: 'var(--panel-top)',
-                      overflow: 'hidden',
-                    }}
-                  >
-                    <div
-                      style={{
-                        width: `${install.percent}%`,
-                        height: '100%',
-                        background: 'var(--accent)',
-                        transition: 'width 0.4s',
-                      }}
-                    />
-                  </div>
-                  <div style={{ fontSize: 10, opacity: 0.7, marginTop: 2 }}>
-                    {install.message}
-                  </div>
-                </div>
-                <button type="button" className="btn sm tx" onClick={onCancelInstall}>
-                  Cancel
-                </button>
+                <span className="voyeur-rec">
+                  <span className="voyeur-rec__dot" />
+                  Listening
+                </span>
+                <span className="voyeur-freq">{fmtFreq(status.freqHz)}</span>
+                <span className="voyeur-mode">
+                  {status.mode} · {status.band}
+                </span>
+                <span className="status-chips" style={{ marginLeft: 'auto' }}>
+                  <span className="chip mono">
+                    <span className="k">overs</span>
+                    <span className="v">{status.segmentCount}</span>
+                  </span>
+                  <span className="chip mono">
+                    <span className="k">cap</span>
+                    <span className="v">{fmtDur(status.capturedSeconds)}</span>
+                  </span>
+                  {status.droppedSamples > 0 && (
+                    <span
+                      className="chip mono"
+                      title="Samples dropped because the CPU briefly fell behind. RX is unaffected — just a capture gap."
+                    >
+                      <span className="k">drop</span>
+                      <span className="v">{status.droppedSamples}</span>
+                    </span>
+                  )}
+                  {status.degraded && (
+                    <span className="chip tx" title="The monitor faulted and detached. RX is unaffected.">
+                      <span className="v">degraded</span>
+                    </span>
+                  )}
+                </span>
               </>
             ) : (
-              <>
-                <span style={{ opacity: 0.8 }}>Download a speech model to enable transcription:</span>
-                <select
-                  value={chosenModel}
-                  onChange={(e) => setChosenModel(e.target.value)}
-                  aria-label="Speech model"
-                  style={{ flex: 1, minWidth: 0 }}
-                >
-                  {(models.length
-                    ? models
-                    : [
-                        { id: 'medium.en', label: 'Medium — recommended' },
-                        { id: 'small.en', label: 'Small — faster download' },
-                      ]
-                  ).map((m) => (
-                    <option key={m.id} value={m.id}>
-                      {m.label}
-                    </option>
-                  ))}
-                </select>
-                <button type="button" className="btn sm accent" onClick={onInstall}>
-                  Download
-                </button>
-              </>
+              <span className="voyeur-idle">
+                Idle — tune to a busy frequency and press <strong>LISTEN</strong> to
+                log who’s on and what’s said.
+              </span>
             )}
           </div>
-        )}
 
-        {showHelp && (
-          <div
-            style={{
-              fontSize: 11,
-              lineHeight: 1.5,
-              padding: '8px 10px',
-              marginBottom: 8,
-              borderRadius: 4,
-              background: 'var(--panel-bot)',
-              border: '1px solid var(--panel-top)',
-            }}
-          >
-            <div style={{ fontWeight: 600, marginBottom: 4 }}>What it does</div>
-            Park the radio on a busy frequency (a net, a rag-chew) and press
-            LISTEN. Voyeur Mode records each transmission, then — if transcription
-            is set up — writes out what was said and who said it. Walk away; come
-            back to a log of the activity.
-            <div style={{ fontWeight: 600, margin: '8px 0 4px' }}>Using it</div>
-            <ol style={{ margin: 0, paddingLeft: 18 }}>
-              <li>Tune to the frequency you want to monitor (USB/LSB as normal).</li>
-              <li>Press <strong>LISTEN</strong>. The status line shows overs being captured.</li>
-              <li>Leave it running. Open a log anytime to read the transcript and roster.</li>
-              <li>★ <strong>saves</strong> a log (protects it from auto-cleanup); ✕ <strong>deletes</strong> it and its audio. Click a name to rename.</li>
-            </ol>
-            <div style={{ fontWeight: 600, margin: '8px 0 4px' }}>
-              Enable transcription (one-time, optional)
-            </div>
-            Transcription runs locally — audio never leaves your computer. Pick a
-            speech model and click Download; no terminal needed. The bigger model
-            is more accurate on noisy SSB; the smaller one downloads faster.
-            <div style={{ display: 'flex', alignItems: 'center', gap: 6, margin: '6px 0' }}>
-              <select
-                value={chosenModel}
-                onChange={(e) => setChosenModel(e.target.value)}
-                disabled={install?.phase === 'Downloading'}
-                aria-label="Speech model"
-                style={{ flex: 1, minWidth: 0 }}
-              >
-                {(models.length
-                  ? models
-                  : [
-                      { id: 'small.en', label: 'Small (English) — fast' },
-                      { id: 'medium.en', label: 'Medium (English) — most accurate' },
-                    ]
-                ).map((m) => (
-                  <option key={m.id} value={m.id}>
-                    {m.label}
-                  </option>
-                ))}
-              </select>
+          {/* Transcription status + setup toggle */}
+          <div className="voyeur-row">
+            <span
+              className={`voyeur-asr ${asrReady ? 'voyeur-asr--on' : 'voyeur-asr--off'}`}
+              title="Transcription runs locally via whisper. Without it, Voyeur Mode still captures overs; it just won't transcribe or identify callsigns."
+            >
+              <span className="voyeur-asr__dot" />
+              {asrReady === null ? 'checking…' : asrReady ? 'transcription on' : 'transcription off'}
+            </span>
+            <span style={{ flex: 1 }} />
+            <button
+              type="button"
+              className="btn sm"
+              onClick={() => setShowHelp((v) => !v)}
+              aria-expanded={showHelp}
+            >
+              {showHelp ? 'Hide setup' : 'How to set up & use'}
+            </button>
+          </div>
+
+          {/* Prominent model-download control whenever transcription is off */}
+          {asrReady === false && (
+            <div className="voyeur-dl">
               {install?.phase === 'Downloading' ? (
-                <button type="button" className="btn sm tx" onClick={onCancelInstall}>
-                  Cancel
-                </button>
+                <>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div className="voyeur-bar">
+                      <div className="voyeur-bar__fill" style={{ width: `${install.percent}%` }} />
+                    </div>
+                    <div className="voyeur-dl__msg">{install.message}</div>
+                  </div>
+                  <button type="button" className="btn sm tx" onClick={onCancelInstall}>
+                    Cancel
+                  </button>
+                </>
               ) : (
-                <button type="button" className="btn sm accent" onClick={onInstall}>
-                  Download
-                </button>
+                <>
+                  <span className="voyeur-dl__label">Speech model:</span>
+                  <select
+                    value={chosenModel}
+                    onChange={(e) => setChosenModel(e.target.value)}
+                    aria-label="Speech model"
+                    style={{ flex: 1, minWidth: 0 }}
+                  >
+                    {(models.length
+                      ? models
+                      : [
+                          { id: 'medium.en', label: 'Medium — recommended' },
+                          { id: 'small.en', label: 'Small — faster download' },
+                        ]
+                    ).map((m) => (
+                      <option key={m.id} value={m.id}>
+                        {m.label}
+                      </option>
+                    ))}
+                  </select>
+                  <button type="button" className="btn sm accent" onClick={onInstall}>
+                    Download
+                  </button>
+                </>
               )}
             </div>
-            {install?.phase === 'Downloading' && (
-              <div style={{ margin: '4px 0' }}>
-                <div
-                  style={{
-                    height: 6,
-                    borderRadius: 3,
-                    background: 'var(--panel-top)',
-                    overflow: 'hidden',
-                  }}
-                >
-                  <div
-                    style={{
-                      width: `${install.percent}%`,
-                      height: '100%',
-                      background: 'var(--accent)',
-                      transition: 'width 0.4s',
-                    }}
-                  />
+          )}
+
+          {showHelp && (
+            <div className="voyeur-help">
+              <h4>What it does</h4>
+              Park the radio on a busy frequency (a net, a rag-chew) and press
+              LISTEN. Voyeur Mode records each transmission, then — if transcription
+              is set up — writes out what was said and who said it. Walk away; come
+              back to a log of the activity.
+              <h4>Using it</h4>
+              <ol>
+                <li>Tune to the frequency you want to monitor (USB/LSB as normal).</li>
+                <li>
+                  Press <strong>LISTEN</strong>. The live bar shows overs being captured.
+                </li>
+                <li>Leave it running. Open a log anytime to read the transcript and roster.</li>
+                <li>
+                  ★ <strong>saves</strong> a log (protects it from auto-cleanup); ✕{' '}
+                  <strong>deletes</strong> it and its audio. Click a name to rename.
+                </li>
+              </ol>
+              <h4>Transcription (one-time, optional)</h4>
+              Runs locally — audio never leaves your computer. Pick a model above and
+              click Download (no terminal). The bigger model is more accurate on noisy
+              SSB; the smaller one downloads faster. You only download once.
+              {install?.phase === 'Done' && (
+                <div style={{ color: 'var(--green-soft)', marginTop: 4 }}>✓ {install.message}</div>
+              )}
+              {install?.phase === 'Error' && (
+                <div className="voyeur-error" style={{ marginTop: 4 }}>
+                  Download failed: {install.message}
                 </div>
-                <div style={{ fontSize: 10, opacity: 0.7, marginTop: 2 }}>{install.message}</div>
-              </div>
-            )}
-            {install?.phase === 'Done' && (
-              <div style={{ color: 'var(--accent)', fontSize: 11 }}>✓ {install.message}</div>
-            )}
-            {install?.phase === 'Error' && (
-              <div style={{ color: 'var(--tx)', fontSize: 11 }}>Download failed: {install.message}</div>
-            )}
-            {install && !install.binaryPresent && (
-              <div style={{ fontSize: 10, opacity: 0.7, marginTop: 4 }}>
-                Note: the whisper engine for your platform ({install.rid}) ships
-                with Zeus. If transcription stays off after the model downloads,
-                the engine isn’t bundled in this build yet — advanced users can
-                place a <code>whisper-cli</code> binary in{' '}
-                <code style={{ wordBreak: 'break-all' }}>
-                  {modelDir ? `${modelDir}/bin` : '…/Zeus/whisper/bin'}
-                </code>
-                .
-              </div>
-            )}
-            <div style={{ fontWeight: 600, margin: '8px 0 4px' }}>
-              Reading the roster
+              )}
+              {install && !install.binaryPresent && (
+                <div style={{ fontSize: 10, color: 'var(--fg-3)', marginTop: 6 }}>
+                  Note: the whisper engine for your platform ({install.rid}) ships with
+                  Zeus. If transcription stays off after the model downloads, the engine
+                  isn’t bundled in this build yet — advanced users can place a{' '}
+                  <code>whisper-cli</code> binary in{' '}
+                  <code>{modelDir ? `${modelDir}/bin` : '…/Zeus/whisper/bin'}</code>.
+                </div>
+              )}
+              <h4>Reading the roster</h4>
+              <span style={{ color: 'var(--accent)' }}>Blue</span> = QRZ-confirmed (real
+              licensee, name shown). <span style={{ color: 'var(--power)' }}>Amber</span> =
+              heard but unverified. Grey = no decodable callsign. HF voice is noisy, so
+              expect a useful gist — not a perfect transcript.
             </div>
-            <span style={{ color: 'var(--accent)' }}>Blue</span> callsign = QRZ-confirmed
-            (real licensee, name shown). <span style={{ color: 'var(--power)' }}>Amber</span>{' '}
-            = heard but unverified. Grey “callsign unknown” = an over with no
-            decodable ID. HF voice is noisy, so expect a useful gist — not a
-            perfect transcript.
-          </div>
-        )}
+          )}
 
-        {error && (
-          <div style={{ color: 'var(--tx)', marginBottom: 6 }}>{error}</div>
-        )}
-
-        {/* Saved logs */}
-        <div style={{ fontWeight: 600, margin: '4px 0', opacity: 0.8 }}>
-          Logs ({sessions.length})
+          {error && <div className="voyeur-error">{error}</div>}
         </div>
-        {sessions.length === 0 && (
-          <div style={{ opacity: 0.6 }}>No logs yet.</div>
-        )}
-        {sessions.map((s) => (
-          <div
-            key={s.id}
-            style={{
-              borderTop: '1px solid var(--panel-top)',
-              padding: '4px 0',
-            }}
-          >
-            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-              <button
-                type="button"
-                className="btn sm"
-                title={s.pinned ? 'Saved (won’t be auto-pruned). Click to unsave.' : 'Save this log'}
-                onClick={() => onTogglePin(s)}
-                style={{ color: s.pinned ? 'var(--power)' : undefined }}
-              >
-                {s.pinned ? '★' : '☆'}
-              </button>
-              <input
-                ref={editingRef}
-                defaultValue={s.label}
-                onBlur={(e) => onRename(s, e.currentTarget.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') e.currentTarget.blur();
-                }}
-                style={{
-                  flex: 1,
-                  minWidth: 0,
-                  background: 'transparent',
-                  border: 'none',
-                  color: 'inherit',
-                  font: 'inherit',
-                }}
-                aria-label="Log name"
-              />
-              <button type="button" className="btn sm" onClick={() => openSession(s.id)}>
-                {openId === s.id ? 'Hide' : 'Open'}
-              </button>
-              <button
-                type="button"
-                className="btn sm tx"
-                title="Delete this log and its audio"
-                onClick={() => onDelete(s)}
-              >
-                ✕
-              </button>
-            </div>
-            <div style={{ opacity: 0.65, fontSize: 11, paddingLeft: 30 }}>
-              {fmtWhen(s.startedUtc)} · {fmtFreq(s.freqHz)} {s.mode} · {s.segmentCount} overs ·{' '}
-              {fmtDur(s.capturedSeconds)}
-              {s.hasAudio ? ' · audio' : ''}
-            </div>
 
-            {openId === s.id && (
-              <div style={{ paddingLeft: 30, marginTop: 4 }}>
-                {!detail && <div style={{ opacity: 0.6 }}>Loading…</div>}
-                {detail && detail.segments.length === 0 && (
-                  <div style={{ opacity: 0.6 }}>No overs captured.</div>
-                )}
-                {detail &&
-                  detail.segments.map((seg, i) => (
-                    <div
-                      key={seg.id}
-                      style={{
-                        display: 'grid',
-                        gridTemplateColumns: 'auto 1fr',
-                        gap: 8,
-                        padding: '2px 0',
-                        borderTop: i === 0 ? 'none' : '1px dotted var(--panel-top)',
-                      }}
-                    >
-                      <span style={{ opacity: 0.7, fontVariantNumeric: 'tabular-nums' }}>
-                        {new Date(seg.startedUtc).toLocaleTimeString()} ·{' '}
-                        {(seg.durationMs / 1000).toFixed(1)}s
-                      </span>
-                      <span>
-                        {/* Phase 2: callsign + transcript. Phase 1: the over
-                            with no attribution yet. */}
-                        <strong
-                          style={{
-                            color:
-                              seg.callsignState === 'confirmed'
-                                ? 'var(--accent)'
-                                : seg.callsignState === 'tentative'
-                                  ? 'var(--power)'
-                                  : 'inherit',
-                            opacity: seg.callsign ? 1 : 0.5,
-                          }}
-                        >
-                          {seg.callsign ?? 'callsign unknown'}
-                          {seg.callsignName ? ` (${seg.callsignName})` : ''}
-                        </strong>
-                        {seg.transcript ? ` — ${seg.transcript}` : ''}
-                      </span>
-                    </div>
-                  ))}
+        {/* The intercepted-comms log */}
+        <div className="voyeur__log">
+          <div className="voyeur-loghdr">Logs · {sessions.length}</div>
+          {sessions.length === 0 && <div className="voyeur-empty">No logs yet — press LISTEN.</div>}
+          {sessions.map((s) => (
+            <div className="voyeur-card" key={s.id}>
+              <div className="voyeur-card__head">
+                <button
+                  type="button"
+                  className={`voyeur-pin ${s.pinned ? 'voyeur-pin--on' : ''}`}
+                  title={s.pinned ? 'Saved (won’t be auto-pruned). Click to unsave.' : 'Save this log'}
+                  onClick={() => onTogglePin(s)}
+                >
+                  {s.pinned ? '★' : '☆'}
+                </button>
+                <input
+                  ref={editingRef}
+                  className="voyeur-card__name"
+                  defaultValue={s.label}
+                  onBlur={(e) => onRename(s, e.currentTarget.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') e.currentTarget.blur();
+                  }}
+                  aria-label="Log name"
+                />
+                <button type="button" className="btn sm" onClick={() => openSession(s.id)}>
+                  {openId === s.id ? 'Hide' : 'Open'}
+                </button>
+                <button
+                  type="button"
+                  className="btn sm tx"
+                  title="Delete this log and its audio"
+                  onClick={() => onDelete(s)}
+                >
+                  ✕
+                </button>
               </div>
-            )}
-          </div>
-        ))}
+              <div className="voyeur-card__meta">
+                <span className="chip mono">
+                  <span className="v">{fmtFreq(s.freqHz)}</span>
+                </span>
+                <span className="chip">
+                  <span className="v">{s.mode}</span>
+                </span>
+                <span className="chip mono">
+                  <span className="k">overs</span>
+                  <span className="v">{s.segmentCount}</span>
+                </span>
+                <span className="chip mono">
+                  <span className="k">when</span>
+                  <span className="v">{fmtWhen(s.startedUtc)}</span>
+                </span>
+                {s.hasAudio && (
+                  <span className="chip">
+                    <span className="v">audio</span>
+                  </span>
+                )}
+              </div>
+
+              {openId === s.id && (
+                <div className="voyeur-overs">
+                  {!detail && <div className="voyeur-empty" style={{ padding: '6px 10px' }}>Loading…</div>}
+                  {detail && detail.segments.length === 0 && (
+                    <div className="voyeur-empty" style={{ padding: '6px 10px' }}>No overs captured.</div>
+                  )}
+                  {detail &&
+                    detail.segments.map((seg) => {
+                      const state = seg.callsignState ?? 'unknown';
+                      return (
+                        <div key={seg.id} className={`voyeur-over voyeur-over--${state}`}>
+                          <span className="voyeur-over__time">
+                            {new Date(seg.startedUtc).toLocaleTimeString([], {
+                              hour: '2-digit',
+                              minute: '2-digit',
+                              second: '2-digit',
+                            })}
+                            <br />
+                            {(seg.durationMs / 1000).toFixed(0)}s
+                          </span>
+                          <span className="voyeur-over__body">
+                            <span className={`voyeur-call voyeur-call--${state}`}>
+                              {seg.callsign ?? 'unknown'}
+                            </span>
+                            {seg.callsignName && <span className="voyeur-name">{seg.callsignName}</span>}
+                            {seg.transcript ? (
+                              <span className="voyeur-text">{seg.transcript}</span>
+                            ) : (
+                              <span className="voyeur-text voyeur-text--pending">
+                                {asrReady ? 'transcribing…' : 'audio captured'}
+                              </span>
+                            )}
+                          </span>
+                        </div>
+                      );
+                    })}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
       </div>
     </>
   );

--- a/zeus-web/src/layout/panels/VoyeurPanel.tsx
+++ b/zeus-web/src/layout/panels/VoyeurPanel.tsx
@@ -73,7 +73,7 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
   const [modelDir, setModelDir] = useState<string>('');
   const [showHelp, setShowHelp] = useState(false);
   const [models, setModels] = useState<VoyeurModel[]>([]);
-  const [chosenModel, setChosenModel] = useState('small.en');
+  const [chosenModel, setChosenModel] = useState('medium.en');
   const [install, setInstall] = useState<VoyeurInstall | null>(null);
   const editingRef = useRef<HTMLInputElement | null>(null);
 
@@ -326,6 +326,79 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
             {showHelp ? 'Hide setup' : 'How to set up & use'}
           </button>
         </div>
+
+        {/* Prominent model-download control whenever transcription is off — so
+            the primary setup action isn't buried in the help disclosure. */}
+        {asrReady === false && (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+              padding: '6px 8px',
+              marginBottom: 8,
+              borderRadius: 4,
+              background: 'var(--panel-bot)',
+              border: '1px solid var(--panel-top)',
+              fontSize: 11,
+            }}
+          >
+            {install?.phase === 'Downloading' ? (
+              <>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div
+                    style={{
+                      height: 6,
+                      borderRadius: 3,
+                      background: 'var(--panel-top)',
+                      overflow: 'hidden',
+                    }}
+                  >
+                    <div
+                      style={{
+                        width: `${install.percent}%`,
+                        height: '100%',
+                        background: 'var(--accent)',
+                        transition: 'width 0.4s',
+                      }}
+                    />
+                  </div>
+                  <div style={{ fontSize: 10, opacity: 0.7, marginTop: 2 }}>
+                    {install.message}
+                  </div>
+                </div>
+                <button type="button" className="btn sm tx" onClick={onCancelInstall}>
+                  Cancel
+                </button>
+              </>
+            ) : (
+              <>
+                <span style={{ opacity: 0.8 }}>Download a speech model to enable transcription:</span>
+                <select
+                  value={chosenModel}
+                  onChange={(e) => setChosenModel(e.target.value)}
+                  aria-label="Speech model"
+                  style={{ flex: 1, minWidth: 0 }}
+                >
+                  {(models.length
+                    ? models
+                    : [
+                        { id: 'medium.en', label: 'Medium — recommended' },
+                        { id: 'small.en', label: 'Small — faster download' },
+                      ]
+                  ).map((m) => (
+                    <option key={m.id} value={m.id}>
+                      {m.label}
+                    </option>
+                  ))}
+                </select>
+                <button type="button" className="btn sm accent" onClick={onInstall}>
+                  Download
+                </button>
+              </>
+            )}
+          </div>
+        )}
 
         {showHelp && (
           <div

--- a/zeus-web/src/layout/panels/VoyeurPanel.tsx
+++ b/zeus-web/src/layout/panels/VoyeurPanel.tsx
@@ -19,6 +19,7 @@ import {
   deleteVoyeurSession,
   getVoyeurSession,
   getVoyeurStatus,
+  getVoyeurTranscription,
   listVoyeurSessions,
   startVoyeur,
   stopVoyeur,
@@ -62,6 +63,9 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
   const [detail, setDetail] = useState<VoyeurSessionDetail | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [asrReady, setAsrReady] = useState<boolean | null>(null);
+  const [modelDir, setModelDir] = useState<string>('');
+  const [showHelp, setShowHelp] = useState(false);
   const editingRef = useRef<HTMLInputElement | null>(null);
 
   const refreshSessions = useCallback(async () => {
@@ -95,6 +99,21 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
   useEffect(() => {
     void refreshSessions();
   }, [refreshSessions]);
+
+  useEffect(() => {
+    let alive = true;
+    void getVoyeurTranscription()
+      .then((t) => {
+        if (alive) {
+          setAsrReady(t.available);
+          setModelDir(t.modelDir);
+        }
+      })
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, []);
 
   // When a session is active, refresh the list as its segment count grows.
   useEffect(() => {
@@ -237,6 +256,101 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
           )}
         </div>
 
+        {/* Transcription readiness + setup */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            marginBottom: 6,
+            fontSize: 11,
+          }}
+        >
+          <span
+            style={{ color: asrReady ? 'var(--accent)' : 'var(--power)' }}
+            title="Transcription needs whisper.cpp + a model. Without it, Voyeur Mode still captures overs; it just won't transcribe or identify callsigns."
+          >
+            {asrReady === null
+              ? 'transcription: checking…'
+              : asrReady
+                ? '● transcription ready'
+                : '○ transcription off (capture-only)'}
+          </span>
+          <button
+            type="button"
+            className="btn sm"
+            onClick={() => setShowHelp((v) => !v)}
+            aria-expanded={showHelp}
+          >
+            {showHelp ? 'Hide setup' : 'How to set up & use'}
+          </button>
+        </div>
+
+        {showHelp && (
+          <div
+            style={{
+              fontSize: 11,
+              lineHeight: 1.5,
+              padding: '8px 10px',
+              marginBottom: 8,
+              borderRadius: 4,
+              background: 'var(--panel-bot)',
+              border: '1px solid var(--panel-top)',
+            }}
+          >
+            <div style={{ fontWeight: 600, marginBottom: 4 }}>What it does</div>
+            Park the radio on a busy frequency (a net, a rag-chew) and press
+            LISTEN. Voyeur Mode records each transmission, then — if transcription
+            is set up — writes out what was said and who said it. Walk away; come
+            back to a log of the activity.
+            <div style={{ fontWeight: 600, margin: '8px 0 4px' }}>Using it</div>
+            <ol style={{ margin: 0, paddingLeft: 18 }}>
+              <li>Tune to the frequency you want to monitor (USB/LSB as normal).</li>
+              <li>Press <strong>LISTEN</strong>. The status line shows overs being captured.</li>
+              <li>Leave it running. Open a log anytime to read the transcript and roster.</li>
+              <li>★ <strong>saves</strong> a log (protects it from auto-cleanup); ✕ <strong>deletes</strong> it and its audio. Click a name to rename.</li>
+            </ol>
+            <div style={{ fontWeight: 600, margin: '8px 0 4px' }}>
+              Enable transcription (one-time, optional)
+            </div>
+            Transcription runs locally — audio never leaves your computer.
+            <ol style={{ margin: '4px 0 0', paddingLeft: 18 }}>
+              <li>
+                Install whisper:{' '}
+                <code style={{ background: 'var(--panel-top)', padding: '0 4px' }}>
+                  brew install whisper-cpp
+                </code>{' '}
+                (macOS) — or put the <code>whisper-cli</code> binary on your PATH.
+              </li>
+              <li>
+                Download a model and drop it here:
+                <div
+                  style={{
+                    margin: '2px 0',
+                    padding: '2px 4px',
+                    background: 'var(--panel-top)',
+                    wordBreak: 'break-all',
+                  }}
+                >
+                  {modelDir || '…/Zeus/whisper/'}
+                </div>
+                Recommended: <code>ggml-medium.en.bin</code> (best accuracy on
+                noisy SSB) or <code>ggml-small.en.bin</code> (lighter). Get them
+                from the whisper.cpp model page on Hugging Face.
+              </li>
+              <li>Restart Zeus. The indicator above turns green when it’s found.</li>
+            </ol>
+            <div style={{ fontWeight: 600, margin: '8px 0 4px' }}>
+              Reading the roster
+            </div>
+            <span style={{ color: 'var(--accent)' }}>Blue</span> callsign = QRZ-confirmed
+            (real licensee, name shown). <span style={{ color: 'var(--power)' }}>Amber</span>{' '}
+            = heard but unverified. Grey “callsign unknown” = an over with no
+            decodable ID. HF voice is noisy, so expect a useful gist — not a
+            perfect transcript.
+          </div>
+        )}
+
         {error && (
           <div style={{ color: 'var(--tx)', marginBottom: 6 }}>{error}</div>
         )}
@@ -338,6 +452,7 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
                           }}
                         >
                           {seg.callsign ?? 'callsign unknown'}
+                          {seg.callsignName ? ` (${seg.callsignName})` : ''}
                         </strong>
                         {seg.transcript ? ` — ${seg.transcript}` : ''}
                       </span>

--- a/zeus-web/src/layout/panels/voyeur.css
+++ b/zeus-web/src/layout/panels/voyeur.css
@@ -1,0 +1,326 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later
+ * Voyeur Mode panel (zeus-la5) — "intercepted comms log" styling, built on the
+ * Zeus design tokens. Dark console well for the roster/transcript; the live
+ * bar reads like a receiver readout. Token-only colors. */
+
+.voyeur {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.voyeur__controls {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px 10px;
+}
+
+/* ---- live receiver bar ---- */
+.voyeur-live {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 7px 10px;
+  border-radius: var(--r-xs);
+  background: var(--bg-2);
+  border: 1px solid var(--fg-4);
+}
+.voyeur-live--on {
+  background: linear-gradient(180deg, var(--accent-soft), transparent);
+  border-color: var(--accent-line);
+}
+.voyeur-rec {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--font-display);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 11px;
+  color: var(--fg-0);
+}
+.voyeur-rec__dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--tx);
+  box-shadow: 0 0 7px var(--tx);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+.voyeur-freq {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--fg-0);
+}
+.voyeur-mode {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--fg-2);
+}
+.voyeur-idle {
+  color: var(--fg-3);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+/* ---- transcription status pill ---- */
+.voyeur-asr {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--fg-4);
+}
+.voyeur-asr__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+.voyeur-asr--on {
+  color: var(--green-soft);
+  border-color: color-mix(in srgb, var(--green-soft) 45%, transparent);
+}
+.voyeur-asr--off {
+  color: var(--power);
+  border-color: color-mix(in srgb, var(--power) 40%, transparent);
+}
+.voyeur-asr--off .voyeur-asr__dot {
+  background: transparent;
+  border: 1px solid currentColor;
+}
+
+.voyeur-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* ---- download / setup ---- */
+.voyeur-dl {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 9px;
+  border-radius: var(--r-xs);
+  background: var(--bg-2);
+  border: 1px solid var(--accent-line);
+  font-size: 11px;
+}
+.voyeur-dl__label {
+  color: var(--fg-2);
+}
+.voyeur-bar {
+  height: 6px;
+  border-radius: 3px;
+  background: var(--bg-inset);
+  border: 1px solid var(--fg-4);
+  overflow: hidden;
+}
+.voyeur-bar__fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent), var(--accent-bright));
+  box-shadow: 0 0 8px var(--accent);
+  transition: width 0.4s var(--ease-out);
+}
+.voyeur-dl__msg {
+  font-size: 10px;
+  color: var(--fg-3);
+  margin-top: 3px;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---- help disclosure ---- */
+.voyeur-help {
+  font-size: 11px;
+  line-height: 1.5;
+  padding: 9px 11px;
+  border-radius: var(--r-xs);
+  background: var(--bg-1);
+  border: 1px solid var(--fg-4);
+  color: var(--fg-1);
+}
+.voyeur-help h4 {
+  margin: 8px 0 4px;
+  font-family: var(--font-display);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--fg-2);
+}
+.voyeur-help h4:first-child {
+  margin-top: 0;
+}
+.voyeur-help ol {
+  margin: 0;
+  padding-left: 18px;
+}
+.voyeur-help code {
+  background: var(--bg-inset);
+  border: 1px solid var(--fg-4);
+  border-radius: 3px;
+  padding: 0 4px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  word-break: break-all;
+}
+
+/* ---- log list (the dark console well) ---- */
+.voyeur__log {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 8px 10px 12px;
+  background: var(--bg-inset);
+  border-top: 1px solid var(--fg-4);
+}
+.voyeur-loghdr {
+  font-family: var(--font-display);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  margin-bottom: 6px;
+}
+.voyeur-empty {
+  color: var(--fg-4);
+  font-size: 11px;
+  font-style: italic;
+}
+
+.voyeur-card {
+  border: 1px solid var(--fg-4);
+  border-radius: var(--r-xs);
+  margin-bottom: 7px;
+  overflow: hidden;
+  background: var(--bg-1);
+}
+.voyeur-card__head {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 6px 5px 8px;
+}
+.voyeur-card__name {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  color: var(--fg-0);
+  font: inherit;
+  font-weight: 600;
+  padding: 2px 0;
+}
+.voyeur-card__name:focus {
+  outline: none;
+  border-bottom: 1px solid var(--accent);
+}
+.voyeur-pin {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1;
+  color: var(--fg-3);
+  padding: 2px 3px;
+}
+.voyeur-pin--on {
+  color: var(--power);
+  text-shadow: 0 0 6px color-mix(in srgb, var(--power) 60%, transparent);
+}
+.voyeur-card__meta {
+  display: flex;
+  gap: 5px;
+  flex-wrap: wrap;
+  padding: 0 8px 7px 8px;
+}
+
+/* ---- per-over rows: the intercepted-comms log ---- */
+.voyeur-overs {
+  padding: 2px 0 2px 0;
+  background: var(--bg-inset);
+  border-top: 1px solid var(--fg-4);
+}
+.voyeur-over {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 9px;
+  padding: 6px 10px 6px 8px;
+  border-left: 2px solid transparent;
+}
+.voyeur-over + .voyeur-over {
+  border-top: 1px solid color-mix(in srgb, var(--fg-4) 50%, transparent);
+}
+.voyeur-over--confirmed {
+  border-left-color: var(--accent);
+}
+.voyeur-over--tentative {
+  border-left-color: var(--power);
+}
+.voyeur-over__time {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--fg-3);
+  white-space: nowrap;
+  padding-top: 2px;
+  font-variant-numeric: tabular-nums;
+}
+.voyeur-over__body {
+  min-width: 0;
+}
+.voyeur-call {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  padding: 1px 7px;
+  border-radius: var(--r-xs);
+  vertical-align: middle;
+}
+.voyeur-call--confirmed {
+  color: var(--fg-0);
+  background: var(--accent);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--accent) 55%, transparent);
+}
+.voyeur-call--tentative {
+  color: var(--power);
+  border: 1px solid color-mix(in srgb, var(--power) 70%, transparent);
+}
+.voyeur-call--unknown {
+  color: var(--fg-4);
+  border: 1px dashed var(--fg-4);
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+.voyeur-name {
+  color: var(--fg-2);
+  font-size: 10px;
+  margin-left: 6px;
+}
+.voyeur-text {
+  display: block;
+  margin-top: 3px;
+  color: var(--fg-1);
+  font-size: 11px;
+  line-height: 1.45;
+}
+.voyeur-text--pending {
+  color: var(--fg-3);
+  font-style: italic;
+}
+
+.voyeur-error {
+  color: var(--tx);
+  font-size: 11px;
+}


### PR DESCRIPTION
Turns Phase 1's captured "overs" into an **attributed transcript** — each over transcribed locally by whisper.cpp, its callsign decoded and QRZ-validated, written back to the log. Plus the operator-facing **setup instructions**. **Base is the Phase 1 branch** (#601); retarget to develop after #601 lands.

## Crash isolation — the load-bearing safety fact
whisper.cpp runs as a **separate, supervised OS child process** (`WhisperTranscriber` shells out to `whisper-cli`), **never P/Invoked** — a native segfault/OOM kills only the child, never the Zeus host carrying the realtime RX/DSP/PS/TX threads. Hard timeout kills + drops a wedged child; below-normal child priority; the whole pipeline runs **off the audio path** (consumes saved WAVs, never the live ring). **Graceful absence:** no whisper installed ⇒ capture-only (Phase 1), and the panel explains how to enable it.

## Pipeline
- **`WhisperTranscriber`** — discovers `whisper-cli` (env `ZEUS_WHISPER_CLI` / PATH / Homebrew) + a ggml model (env `ZEUS_WHISPER_MODEL` or `<appdata>/Zeus/whisper/`, prefers `medium.en` per Phase 0); ham-context prompt; feeds the 48k WAV directly (whisper-cli resamples internally — verified, no C# resampler).
- **`CallsignExtractor`** — decodes spoken NATO phonetics tolerating Whisper's real HF mis-hearings (foxtrot→"foxtrops", X-ray→x+ray, collapsed "n2zkn"); emits valid-length truncations **longest-first** so QRZ picks the longest that resolves (the Phase-0 WA2D-vs-WA2DVU fragment fix); breaks runs on sentence boundaries.
- **`VoyeurTranscriptionService`** — single-worker bounded queue; whisper → extract → QRZ-validate (per-session cache + min-interval throttle so the roster never starves manual QRZ lookups) → write back. **confirmed** = QRZ resolves it (name enriched) · **tentative** = well-formed but unlisted/DX · **unknown** = no decodable ID.

## Frontend (your design call — built on tokens)
- **"How to set up & use"** section: what it does, 4-step usage, the one-time whisper+model install with the exact model dir, and the confirmed/tentative/unknown legend.
- Transcription-ready indicator; per-over rows show the confirmed callsign + **operator name** next to the transcript.

## Verified end-to-end
The C# `CallsignExtractor` run over the **real Phase-0 medium.en eCARS transcript** reproduces the validated roster (WA2DVU, KD2OAM, KB1HRL, K4UEK, K1PN, N2ZKN, N2BK…); Whisper-noise candidates don't QRZ-validate and are filtered. `CallsignExtractorTests` pin the decoder to the real spike phrases. **dotnet test 753 pass · vitest 271 pass · both builds clean.** Live smoke: whisper child-process discovery resolves, `/api/voyeur/transcription` returns `available=true`.

Part 2 of zeus-la5. Stacks on #601. Merge order: #601 → retarget this → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)