### PR TITLE
feat(voyeur): Phase 3 — report/roster/search/replay + local-LLM digest + button-download engines (zeus-la5)

### DIFF
--- a/.github/workflows/build-voyeur-engines.yml
+++ b/.github/workflows/build-voyeur-engines.yml
@@ -1,0 +1,280 @@
+name: Build Voyeur Engines
+
+# Builds the Voyeur Mode (zeus-la5) speech + AI-summary engines as static,
+# self-contained, single-binary executables per platform, zips them per-RID,
+# and (optionally) publishes them as release assets under a stable tag that the
+# in-app installer fetches.
+#
+# WHY STATIC / SINGLE-BINARY: whisper.cpp and llama.cpp normally link a
+# constellation of dylibs (libwhisper, libggml, libggml-base, libllama, …).
+# Building with BUILD_SHARED_LIBS=OFF + CPU-only + OpenMP off folds everything
+# into ONE binary that depends only on the platform's system libraries. That
+# makes the download bundle a single file, removes all @rpath surgery, and
+# keeps the macOS story trivial (see below).
+#
+# WHY NO NOTARIZATION: the Zeus app downloads these via HttpClient and extracts
+# them with .NET's ZipFile — neither applies the com.apple.quarantine xattr, so
+# Gatekeeper never gates them. Apple Silicon still requires a *valid* signature
+# to exec, but the macOS linker applies an ad-hoc signature automatically and
+# zip/unzip preserves it. So no Developer ID, no notarytool, no stapling here —
+# that burden only existed in the rejected bake-into-the-app path.
+#
+# This is manual-trigger only. After a successful run, download the per-RID
+# artifacts (or let the publish job attach them) and they become available to
+# the installer under the tag below. Bump ENGINE_TAG when the engines change
+# and keep it in sync with VoyeurInstallService.EngineTag.
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Attach the built bundles to the engine release tag"
+        type: boolean
+        default: false
+
+env:
+  ENGINE_TAG: voyeur-engines-v1
+  # Pinned upstream versions — bump deliberately, both are permissively licensed
+  # (whisper.cpp + llama.cpp are MIT, GPL-compatible).
+  WHISPER_REF: v1.7.4
+  LLAMA_REF: b4585
+
+jobs:
+  # ----------------------------- macOS -------------------------------------
+  macos:
+    name: macOS ${{ matrix.rid }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rid: osx-arm64
+            runner: macos-14   # Apple Silicon
+          - rid: osx-x64
+            runner: macos-13   # Intel
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Install build tools
+        run: brew install cmake git
+
+      # whisper.cpp — Metal stays ON but is EMBEDDED, and Metal/Accelerate are
+      # system frameworks, so the binary is still self-contained (no external
+      # dylibs). CPU fallback is built in.
+      - name: Build whisper-cli
+        run: |
+          set -eux
+          git clone --depth 1 -b "${WHISPER_REF}" https://github.com/ggml-org/whisper.cpp
+          cmake -S whisper.cpp -B whisper.cpp/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DGGML_OPENMP=OFF \
+            -DGGML_METAL=ON \
+            -DGGML_METAL_EMBED_LIBRARY=ON \
+            -DWHISPER_BUILD_TESTS=OFF \
+            -DWHISPER_BUILD_EXAMPLES=ON
+          cmake --build whisper.cpp/build --config Release --target whisper-cli --parallel
+          find whisper.cpp/build -name whisper-cli -type f
+
+      - name: Build llama completion tool
+        run: |
+          set -eux
+          git clone --depth 1 -b "${LLAMA_REF}" https://github.com/ggml-org/llama.cpp
+          cmake -S llama.cpp -B llama.cpp/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DGGML_OPENMP=OFF \
+            -DGGML_METAL=ON \
+            -DGGML_METAL_EMBED_LIBRARY=ON \
+            -DLLAMA_BUILD_TESTS=OFF \
+            -DLLAMA_BUILD_EXAMPLES=ON \
+            -DLLAMA_BUILD_SERVER=OFF
+          # Build the one-shot completion tool if this version has it, else the
+          # classic llama-cli. The Zeus discovery accepts either name.
+          cmake --build llama.cpp/build --config Release --target llama-completion --parallel || \
+          cmake --build llama.cpp/build --config Release --target llama-cli --parallel
+          find llama.cpp/build -name 'llama-completion' -o -name 'llama-cli' | grep -E 'llama-(completion|cli)$'
+
+      - name: Stage + verify self-contained + zip
+        run: |
+          set -eux
+          mkdir -p out/whisper out/llama
+          cp "$(find whisper.cpp/build -name whisper-cli -type f | head -1)" out/whisper/whisper-cli
+          llama_bin="$(find llama.cpp/build -type f \( -name llama-completion -o -name llama-cli \) | head -1)"
+          cp "$llama_bin" "out/llama/$(basename "$llama_bin")"
+
+          # Fail loudly if anything links a non-system dylib (i.e. not under
+          # /usr/lib or /System) — that would mean the bundle isn't actually
+          # self-contained.
+          for b in out/whisper/whisper-cli out/llama/*; do
+            echo "== otool -L $b =="
+            otool -L "$b"
+            bad=$(otool -L "$b" | tail -n +2 | awk '{print $1}' \
+                  | grep -vE '^/usr/lib/|^/System/' || true)
+            if [ -n "$bad" ]; then echo "ERROR: non-system deps in $b:"; echo "$bad"; exit 1; fi
+            codesign -dv "$b" 2>&1 | grep -i 'Signature' || true
+          done
+
+          ( cd out/whisper && zip -X "../../whisper-${{ matrix.rid }}.zip" whisper-cli )
+          ( cd out/llama && zip -X "../../llama-${{ matrix.rid }}.zip" * )
+          ls -lh whisper-${{ matrix.rid }}.zip llama-${{ matrix.rid }}.zip
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: voyeur-engines-${{ matrix.rid }}
+          path: |
+            whisper-${{ matrix.rid }}.zip
+            llama-${{ matrix.rid }}.zip
+
+  # ----------------------------- Linux -------------------------------------
+  # Pinned to ubuntu-22.04 (glibc 2.35) for the same broad-distro-compat reason
+  # as build-native-libs.yml. arm64 is a cross-compile.
+  linux:
+    name: Linux ${{ matrix.rid }}
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        rid: [linux-x64, linux-arm64]
+    steps:
+      - name: Install build tools (x64)
+        if: matrix.rid == 'linux-x64'
+        run: sudo apt-get update && sudo apt-get install -y cmake git build-essential
+
+      - name: Install cross toolchain (arm64)
+        if: matrix.rid == 'linux-arm64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake git gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+      - name: Set cross flags (arm64)
+        if: matrix.rid == 'linux-arm64'
+        run: |
+          {
+            echo "CROSS=-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DGGML_NATIVE=OFF"
+          } >> "$GITHUB_ENV"
+
+      - name: Build whisper-cli
+        run: |
+          set -eux
+          git clone --depth 1 -b "${WHISPER_REF}" https://github.com/ggml-org/whisper.cpp
+          cmake -S whisper.cpp -B whisper.cpp/build \
+            -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF \
+            -DGGML_OPENMP=OFF -DWHISPER_BUILD_TESTS=OFF -DWHISPER_BUILD_EXAMPLES=ON \
+            ${CROSS:-}
+          cmake --build whisper.cpp/build --config Release --target whisper-cli --parallel
+
+      - name: Build llama completion tool
+        run: |
+          set -eux
+          git clone --depth 1 -b "${LLAMA_REF}" https://github.com/ggml-org/llama.cpp
+          cmake -S llama.cpp -B llama.cpp/build \
+            -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF \
+            -DGGML_OPENMP=OFF -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_EXAMPLES=ON \
+            -DLLAMA_BUILD_SERVER=OFF ${CROSS:-}
+          cmake --build llama.cpp/build --config Release --target llama-completion --parallel || \
+          cmake --build llama.cpp/build --config Release --target llama-cli --parallel
+
+      - name: Stage + zip
+        run: |
+          set -eux
+          mkdir -p out/whisper out/llama
+          cp "$(find whisper.cpp/build -name whisper-cli -type f | head -1)" out/whisper/whisper-cli
+          llama_bin="$(find llama.cpp/build -type f \( -name llama-completion -o -name llama-cli \) | head -1)"
+          cp "$llama_bin" "out/llama/$(basename "$llama_bin")"
+          # On native x64 we can sanity-check deps; the cross arm64 binary can't
+          # be ldd'd on the x64 host, so only print file type there.
+          if [ "${{ matrix.rid }}" = "linux-x64" ]; then ldd out/whisper/whisper-cli || true; fi
+          file out/whisper/whisper-cli out/llama/*
+          ( cd out/whisper && zip -X "../../whisper-${{ matrix.rid }}.zip" whisper-cli )
+          ( cd out/llama && zip -X "../../llama-${{ matrix.rid }}.zip" * )
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: voyeur-engines-${{ matrix.rid }}
+          path: |
+            whisper-${{ matrix.rid }}.zip
+            llama-${{ matrix.rid }}.zip
+
+  # ---------------------------- Windows ------------------------------------
+  windows:
+    name: Windows ${{ matrix.rid }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rid: win-x64
+            arch: x64
+          - rid: win-arm64
+            arch: ARM64
+    steps:
+      - name: Build whisper-cli
+        shell: pwsh
+        run: |
+          git clone --depth 1 -b "$env:WHISPER_REF" https://github.com/ggml-org/whisper.cpp
+          # Static CRT (/MT) so the .exe needs no VC++ redistributable — same
+          # rationale as the arm64 wdsp.dll in build-native-libs.yml.
+          cmake -S whisper.cpp -B whisper.cpp/build -A ${{ matrix.arch }} `
+            -DBUILD_SHARED_LIBS=OFF -DGGML_OPENMP=OFF `
+            -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded `
+            -DWHISPER_BUILD_TESTS=OFF -DWHISPER_BUILD_EXAMPLES=ON
+          cmake --build whisper.cpp/build --config Release --target whisper-cli --parallel
+
+      - name: Build llama completion tool
+        shell: pwsh
+        run: |
+          git clone --depth 1 -b "$env:LLAMA_REF" https://github.com/ggml-org/llama.cpp
+          cmake -S llama.cpp -B llama.cpp/build -A ${{ matrix.arch }} `
+            -DBUILD_SHARED_LIBS=OFF -DGGML_OPENMP=OFF `
+            -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded `
+            -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_EXAMPLES=ON -DLLAMA_BUILD_SERVER=OFF
+          $built = cmake --build llama.cpp/build --config Release --target llama-completion --parallel 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            cmake --build llama.cpp/build --config Release --target llama-cli --parallel
+          }
+
+      - name: Stage + zip
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force out\whisper, out\llama | Out-Null
+          $w = Get-ChildItem -Recurse whisper.cpp\build -Filter whisper-cli.exe | Select-Object -First 1
+          Copy-Item $w.FullName out\whisper\whisper-cli.exe
+          $l = Get-ChildItem -Recurse llama.cpp\build -Include llama-completion.exe,llama-cli.exe |
+               Select-Object -First 1
+          Copy-Item $l.FullName "out\llama\$($l.Name)"
+          Compress-Archive -Path out\whisper\* -DestinationPath "whisper-${{ matrix.rid }}.zip" -Force
+          Compress-Archive -Path out\llama\*   -DestinationPath "llama-${{ matrix.rid }}.zip" -Force
+          Get-ChildItem *.zip
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: voyeur-engines-${{ matrix.rid }}
+          path: |
+            whisper-${{ matrix.rid }}.zip
+            llama-${{ matrix.rid }}.zip
+
+  # ---------------------- Publish to the engine tag ------------------------
+  publish:
+    name: Publish engine bundles
+    if: ${{ inputs.publish }}
+    needs: [macos, linux, windows]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Create/refresh the engine release and upload assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -eux
+          ls -lh dist
+          # Idempotent: create the tag/release if missing, then overwrite assets.
+          gh release view "$ENGINE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 || \
+            gh release create "$ENGINE_TAG" --repo "$GITHUB_REPOSITORY" \
+              --title "Voyeur Mode engines ($ENGINE_TAG)" \
+              --notes "Static, self-contained whisper.cpp + llama.cpp engine binaries fetched by Zeus' Voyeur Mode in-app setup. Built by build-voyeur-engines.yml." \
+              --prerelease
+          gh release upload "$ENGINE_TAG" dist/*.zip --repo "$GITHUB_REPOSITORY" --clobber

--- a/Zeus.Server.Hosting/Voyeur/LlamaSummarizer.cs
+++ b/Zeus.Server.Hosting/Voyeur/LlamaSummarizer.cs
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see ATTRIBUTIONS.md for provenance.
+
+using System.Diagnostics;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Server.Voyeur;
+
+/// <summary>
+/// Local LLM digest for Voyeur Mode (zeus-la5 Phase 3B). Summarizes a session's
+/// transcript into a "what was discussed" paragraph using llama.cpp, run as a
+/// SEPARATE, SUPERVISED OS CHILD PROCESS — never P/Invoked — for exactly the
+/// same crash-isolation reason as <see cref="WhisperTranscriber"/>: a native
+/// fault must kill only the child, never the Zeus host. Everything runs OFF the
+/// audio/DSP path (it reads stored transcript text), and the digest is
+/// on-demand only, so it never adds steady load.
+///
+/// Local-only by design — the transcript never leaves the machine, $0, no API
+/// key. Graceful absence: no binary/model ⇒ digest is simply unavailable and
+/// the panel offers to download the model. The one-shot tool is
+/// <c>llama-completion</c> (modern llama.cpp; <c>llama-cli</c> is the
+/// interactive fallback). Discovery is dynamic + cross-platform, mirroring the
+/// whisper transcriber (env <c>ZEUS_LLAMA_CLI</c> / <c>ZEUS_LLAMA_MODEL</c>,
+/// PATH, Homebrew, the app's bundled dir, .exe on Windows).
+/// </summary>
+public sealed class LlamaSummarizer
+{
+    private readonly ILogger<LlamaSummarizer> _log;
+
+    private const string SystemPrompt =
+        "You are a ham-radio net assistant. You are given a rough, noisy speech-to-text " +
+        "transcript of an amateur-radio HF net (callsigns and words may be imperfect). " +
+        "Write a brief plain-English summary in 2-4 sentences: who appeared to run the net, " +
+        "roughly who checked in, and what was discussed (band/propagation, weather, equipment, " +
+        "topics). Do not invent specific callsigns or facts not present. Be concise and factual.";
+
+    public LlamaSummarizer(ILogger<LlamaSummarizer> log)
+    {
+        _log = log;
+        _log.LogInformation(
+            "voyeur.llama init cli={Cli} model={Model}",
+            LocateCli() ?? "missing", LocateModel() ?? "missing");
+    }
+
+    /// <summary>True when both a llama binary and a model are present right now.</summary>
+    public bool Available => LocateCli() is not null && LocateModel() is not null;
+
+    public string? CliPath => LocateCli();
+    public string? ModelPath => LocateModel();
+
+    /// <summary>Where the in-app installer drops the LLM model + binary.</summary>
+    public static string ModelDir => Path.Combine(ZeusAppData(), "llama");
+    public static string BinDir => Path.Combine(ModelDir, "bin");
+
+    /// <summary>
+    /// Summarize a transcript. Returns the digest text, or null if the LLM is
+    /// unavailable, timed out, or produced nothing. NEVER throws to the caller;
+    /// NEVER blocks past <paramref name="timeout"/> (a wedged child is killed).
+    /// </summary>
+    public async Task<string?> SummarizeAsync(string transcript, TimeSpan timeout, CancellationToken ct)
+    {
+        var cli = LocateCli();
+        var model = LocateModel();
+        if (cli is null || model is null || string.IsNullOrWhiteSpace(transcript)) return null;
+
+        // Keep the prompt bounded — a multi-hour net can be long; the head +
+        // tail carries the structure (who opened, who closed) without blowing
+        // the context window of a small local model.
+        var text = Trim(transcript, 6000);
+
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = cli,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            psi.ArgumentList.Add("-m"); psi.ArgumentList.Add(model);
+            psi.ArgumentList.Add("-sys"); psi.ArgumentList.Add(SystemPrompt);
+            psi.ArgumentList.Add("-p"); psi.ArgumentList.Add(text);
+            psi.ArgumentList.Add("-n"); psi.ArgumentList.Add("220");      // max new tokens
+            psi.ArgumentList.Add("-c"); psi.ArgumentList.Add("8192");     // context
+            psi.ArgumentList.Add("--no-display-prompt");
+
+            using var proc = new Process { StartInfo = psi };
+            var sb = new StringBuilder();
+            proc.OutputDataReceived += (_, e) => { if (e.Data is not null) sb.AppendLine(e.Data); };
+            if (!proc.Start()) return null;
+            proc.BeginOutputReadLine();
+            try { proc.PriorityClass = ProcessPriorityClass.BelowNormal; } catch { /* best effort */ }
+
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timeoutCts.CancelAfter(timeout);
+            try
+            {
+                await proc.WaitForExitAsync(timeoutCts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                try { proc.Kill(entireProcessTree: true); } catch { /* ignore */ }
+                _log.LogWarning("voyeur.llama timed out after {Sec:F0}s", timeout.TotalSeconds);
+                return null;
+            }
+
+            return Clean(sb.ToString());
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "voyeur.llama summarize failed");
+            return null;
+        }
+    }
+
+    // Strip llama-cli/completion interactive artifacts ("> EOF by user", the
+    // "[ Prompt: … ]" stats line, leading "> " prompts) and collapse whitespace.
+    private static string? Clean(string raw)
+    {
+        var lines = raw.Split('\n')
+            .Select(l => l.TrimEnd())
+            .Where(l =>
+            {
+                var t = l.TrimStart();
+                if (t.Length == 0) return false;
+                if (t.StartsWith('>')) return false;           // interactive prompt echo
+                if (t.StartsWith('[') && t.Contains("t/s")) return false; // stats line
+                return true;
+            })
+            .ToList();
+        var text = string.Join(' ', lines).Trim();
+        return string.IsNullOrWhiteSpace(text) ? null : text;
+    }
+
+    private static string Trim(string s, int max)
+    {
+        if (s.Length <= max) return s;
+        // Head + tail: the net's open and close carry the most structure.
+        int half = max / 2;
+        return s[..half] + "\n…\n" + s[^half..];
+    }
+
+    private static string? LocateCli()
+    {
+        var env = Environment.GetEnvironmentVariable("ZEUS_LLAMA_CLI");
+        if (!string.IsNullOrWhiteSpace(env) && File.Exists(env)) return env;
+
+        bool win = OperatingSystem.IsWindows();
+        // Prefer the one-shot completion tool; fall back to llama-cli.
+        string[] names = win
+            ? new[] { "llama-completion.exe", "llama-cli.exe" }
+            : new[] { "llama-completion", "llama-cli" };
+
+        var dirs = new List<string>
+        {
+            BinDir,
+            AppContext.BaseDirectory,
+            Path.Combine(AppContext.BaseDirectory, "llama"),
+        };
+        if (!win)
+        {
+            dirs.Add("/opt/homebrew/bin");
+            dirs.Add("/usr/local/bin");
+            dirs.Add("/usr/bin");
+        }
+        foreach (var n in names)
+            foreach (var d in dirs)
+            {
+                try { var p = Path.Combine(d, n); if (File.Exists(p)) return p; }
+                catch { /* ignore */ }
+            }
+        var pathVar = Environment.GetEnvironmentVariable("PATH") ?? "";
+        foreach (var n in names)
+            foreach (var d in pathVar.Split(Path.PathSeparator))
+            {
+                try { var p = Path.Combine(d, n); if (File.Exists(p)) return p; }
+                catch { /* ignore */ }
+            }
+        return null;
+    }
+
+    private static string? LocateModel()
+    {
+        var env = Environment.GetEnvironmentVariable("ZEUS_LLAMA_MODEL");
+        if (!string.IsNullOrWhiteSpace(env) && File.Exists(env)) return env;
+        if (!Directory.Exists(ModelDir)) return null;
+        return Directory.EnumerateFiles(ModelDir, "*.gguf").FirstOrDefault();
+    }
+
+    private static string ZeusAppData()
+    {
+        var appData = Environment.GetFolderPath(
+            Environment.SpecialFolder.LocalApplicationData,
+            Environment.SpecialFolderOption.Create);
+        return Path.Combine(appData, "Zeus");
+    }
+}

--- a/Zeus.Server.Hosting/Voyeur/VoyeurInstallService.cs
+++ b/Zeus.Server.Hosting/Voyeur/VoyeurInstallService.cs
@@ -12,23 +12,32 @@
 //
 // Zeus is distributed WITHOUT ANY WARRANTY; see ATTRIBUTIONS.md for provenance.
 
+using System.IO.Compression;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
 
 namespace Zeus.Server.Voyeur;
 
 /// <summary>
-/// In-app, terminal-free setup for Voyeur Mode transcription (zeus-la5) —
-/// cross-platform (macOS / Linux / Windows). Downloads the whisper speech model
-/// (the large, license-/choice-dependent file that can't ship in the installer)
-/// into the Zeus app-data <c>whisper/</c> folder, with live progress, so the
-/// operator never has to run a command. Discovery is dynamic, so the model is
-/// picked up the moment the download finishes — no restart.
+/// In-app, terminal-free setup for Voyeur Mode (zeus-la5) — cross-platform
+/// (macOS / Linux / Windows). The operator never runs a command: this service
+/// downloads, with live progress, everything the AI features need into the Zeus
+/// app-data folders, and discovery is dynamic so each piece is picked up the
+/// moment its download finishes — no restart.
 ///
-/// The whisper-cli BINARY is intended to ship bundled with Zeus per-platform
-/// (built in CI alongside libwdsp); when a hosted per-RID binary URL is
-/// configured here, this service will fetch it the same way. Until then, the
-/// binary status is surfaced so the panel can show exactly what's missing.
+/// Two kinds of payload:
+///  • MODELS — the large, license-/choice-dependent speech (whisper.cpp) and
+///    digest (Qwen GGUF) files, streamed from Hugging Face into <c>whisper/</c>
+///    and <c>llama/</c>.
+///  • ENGINES — the native binaries (whisper-cli, llama completion tool), shipped
+///    as a per-RID zip built by <c>build-voyeur-engines.yml</c> and published as
+///    a Zeus release asset, extracted into each engine's <c>bin/</c> dir. They
+///    are static/self-contained and run without notarization because an
+///    app-download applies no macOS quarantine xattr (see EngineTag below).
+///
+/// Keeping engines OUT of the base Zeus download (button-fetched on demand)
+/// keeps the install lean for the majority who never use Voyeur, and confines
+/// the native-binary footprint to those who opt in.
 /// </summary>
 public sealed class VoyeurInstallService
 {
@@ -51,13 +60,33 @@ public sealed class VoyeurInstallService
     private string? _item;
     private CancellationTokenSource? _cts;
 
-    // Models offered in-app. Stable Hugging Face URLs (whisper.cpp, MIT).
-    // small.en is the lighter default; medium.en is the Phase-0 accuracy pick.
-    private enum Kind { Whisper, Llama }
-    private sealed record ModelDef(string Url, long MinBytes, string Label, Kind Kind, string FileName);
+    // Per-RID engine bundles, built + notarized in CI and published as Zeus
+    // release assets under a stable tag. Asset names are <engine>-<rid>.zip
+    // (rid = osx-arm64 | osx-x64 | win-x64 | win-arm64 | linux-x64 |
+    // linux-arm64). The "{rid}" token is resolved at download time. Bumping
+    // the engine build = bump this tag (and re-publish the assets); the app
+    // re-fetches the matching bundle. Keep the tag in sync with
+    // .github/workflows/build-voyeur-engines.yml.
+    private const string EngineTag = "voyeur-engines-v1";
+    private const string EngineBase =
+        "https://github.com/Kb2uka/openhpsdr-zeus/releases/download/" + EngineTag;
+
+    // Models + engines offered in-app. Speech/digest MODELS are stable Hugging
+    // Face files (whisper.cpp + Qwen GGUF, both permissively licensed). ENGINES
+    // are the native binaries + their dylibs, shipped as a per-RID zip that we
+    // extract into the engine's bin/ dir (where discovery already looks).
+    private enum Kind { Whisper, Llama, EngineWhisper, EngineLlama }
+    // Archive=true ⇒ payload is a zip to extract into DestDir; else a single
+    // file moved into place atomically.
+    private sealed record ModelDef(string Url, long MinBytes, string Label, Kind Kind, string FileName, bool Archive = false);
 
     private static readonly Dictionary<string, ModelDef> Models = new()
     {
+        // --- engines (native binaries — required before models do anything) ---
+        ["engine-whisper"] = new(EngineBase + "/whisper-{rid}.zip",
+            2_000_000, "Speech engine (whisper.cpp) — required for transcription", Kind.EngineWhisper, "whisper-engine.zip", Archive: true),
+        ["engine-llama"] = new(EngineBase + "/llama-{rid}.zip",
+            2_000_000, "AI-summary engine (llama.cpp) — required for digests", Kind.EngineLlama, "llama-engine.zip", Archive: true),
         // --- transcription (whisper) ---
         ["medium.en"] = new("https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.en.bin",
             1_300_000_000, "Transcription: Medium (English) — ~1.5 GB, recommended", Kind.Whisper, "ggml-medium.en.bin"),
@@ -70,7 +99,14 @@ public sealed class VoyeurInstallService
             900_000_000, "Digest LLM: Medium — ~1 GB, better summaries", Kind.Llama, "qwen2.5-1.5b-instruct-q4_k_m.gguf"),
     };
 
-    private static string DestDir(Kind k) => k == Kind.Llama ? LlamaSummarizer.ModelDir : WhisperTranscriber.ModelDir;
+    private static string DestDir(Kind k) => k switch
+    {
+        Kind.Llama => LlamaSummarizer.ModelDir,
+        Kind.Whisper => WhisperTranscriber.ModelDir,
+        Kind.EngineLlama => LlamaSummarizer.BinDir,
+        Kind.EngineWhisper => WhisperTranscriber.BinDir,
+        _ => WhisperTranscriber.ModelDir,
+    };
 
     public VoyeurInstallService(
         ILogger<VoyeurInstallService> log,
@@ -85,8 +121,15 @@ public sealed class VoyeurInstallService
     }
 
     public static IEnumerable<object> AvailableModels =>
-        Models.Select(m => new { id = m.Key, label = m.Value.Label,
-            kind = m.Value.Kind == Kind.Llama ? "digest" : "transcription" });
+        Models.Select(m => new { id = m.Key, label = m.Value.Label, kind = KindTag(m.Value.Kind) });
+
+    private static string KindTag(Kind k) => k switch
+    {
+        Kind.EngineWhisper => "engine-whisper",
+        Kind.EngineLlama => "engine-llama",
+        Kind.Llama => "digest",
+        _ => "transcription",
+    };
 
     public Progress Status()
     {
@@ -138,7 +181,7 @@ public sealed class VoyeurInstallService
         var finalPath = Path.Combine(destDir, def.FileName);
         var tmpPath = finalPath + ".part";
         long minBytes = def.MinBytes;
-        var url = def.Url;
+        var url = def.Url.Replace("{rid}", Rid());
 
         try
         {
@@ -172,9 +215,24 @@ public sealed class VoyeurInstallService
                 throw new InvalidOperationException(
                     $"download too small ({size} bytes) — likely an error page, not the model");
 
-            // Atomic publish: only a fully-downloaded, sane-sized file becomes
-            // the live model. A crash mid-download leaves only the .part.
-            File.Move(tmpPath, finalPath, overwrite: true);
+            if (def.Archive)
+            {
+                // Engine bundle: extract the binary + its dylibs into the
+                // engine's bin/ dir (where discovery looks), then mark them
+                // executable on Unix. The bundle is signed/notarized in CI, and
+                // an HttpClient download applies no quarantine xattr, so the
+                // binaries run without a Gatekeeper prompt.
+                SetProgress(100, $"installing {modelId}…");
+                ExtractEngine(tmpPath, destDir);
+                TryDelete(tmpPath);
+            }
+            else
+            {
+                // Atomic publish: only a fully-downloaded, sane-sized file
+                // becomes the live model. A crash mid-download leaves only the
+                // .part.
+                File.Move(tmpPath, finalPath, overwrite: true);
+            }
 
             lock (_gate)
             {
@@ -182,7 +240,7 @@ public sealed class VoyeurInstallService
                 _percent = 100;
                 _message = $"{modelId} ready";
             }
-            _log.LogInformation("voyeur.install model {Model} done ({Mb} MB)", modelId, size / 1_000_000);
+            _log.LogInformation("voyeur.install {Model} done ({Mb} MB)", modelId, size / 1_000_000);
         }
         catch (OperationCanceledException)
         {
@@ -205,6 +263,44 @@ public sealed class VoyeurInstallService
     private static void TryDelete(string path)
     {
         try { if (File.Exists(path)) File.Delete(path); } catch { /* ignore */ }
+    }
+
+    // Extract an engine zip into binDir (flattening any single top-level folder
+    // the archiver may have added), overwriting prior copies, then add the
+    // executable bit on Unix so the binary can be launched. Dylibs/DLLs are
+    // harmless to mark +x.
+    internal static void ExtractEngine(string zipPath, string binDir)
+    {
+        Directory.CreateDirectory(binDir);
+        using (var zip = ZipFile.OpenRead(zipPath))
+        {
+            foreach (var entry in zip.Entries)
+            {
+                if (string.IsNullOrEmpty(entry.Name)) continue; // directory entry
+                // Flatten a leading "<something>/" so files land directly in binDir.
+                var rel = entry.FullName.Replace('\\', '/');
+                var slash = rel.IndexOf('/');
+                var name = slash >= 0 ? rel[(slash + 1)..] : rel;
+                if (string.IsNullOrEmpty(name)) name = entry.Name;
+                var target = Path.GetFullPath(Path.Combine(binDir, name));
+                // Guard against zip-slip: never write outside binDir.
+                if (!target.StartsWith(Path.GetFullPath(binDir) + Path.DirectorySeparatorChar, StringComparison.Ordinal)
+                    && !string.Equals(target, Path.Combine(Path.GetFullPath(binDir), name), StringComparison.Ordinal))
+                    continue;
+                Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+                entry.ExtractToFile(target, overwrite: true);
+                if (!OperatingSystem.IsWindows())
+                {
+                    try
+                    {
+                        var mode = File.GetUnixFileMode(target);
+                        File.SetUnixFileMode(target,
+                            mode | UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute);
+                    }
+                    catch { /* best effort */ }
+                }
+            }
+        }
     }
 
     private static string Rid()

--- a/Zeus.Server.Hosting/Voyeur/VoyeurInstallService.cs
+++ b/Zeus.Server.Hosting/Voyeur/VoyeurInstallService.cs
@@ -36,11 +36,13 @@ public sealed class VoyeurInstallService
 
     public sealed record Progress(
         Phase Phase, int Percent, string Message, string? Item,
-        bool ModelPresent, bool BinaryPresent, string Rid);
+        bool ModelPresent, bool BinaryPresent,
+        bool DigestModelPresent, bool DigestBinaryPresent, string Rid);
 
     private readonly ILogger<VoyeurInstallService> _log;
     private readonly IHttpClientFactory _httpFactory;
     private readonly WhisperTranscriber _whisper;
+    private readonly LlamaSummarizer _llama;
 
     private readonly object _gate = new();
     private Phase _phase = Phase.Idle;
@@ -51,28 +53,40 @@ public sealed class VoyeurInstallService
 
     // Models offered in-app. Stable Hugging Face URLs (whisper.cpp, MIT).
     // small.en is the lighter default; medium.en is the Phase-0 accuracy pick.
-    private static readonly Dictionary<string, (string Url, long MinBytes, string Label)> Models = new()
+    private enum Kind { Whisper, Llama }
+    private sealed record ModelDef(string Url, long MinBytes, string Label, Kind Kind, string FileName);
+
+    private static readonly Dictionary<string, ModelDef> Models = new()
     {
-        // Medium first = the recommended default (Phase-0 spike: small misses
-        // a lot on noisy SSB; medium is the accuracy pick).
-        ["medium.en"] = ("https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.en.bin",
-                         1_300_000_000, "Medium (English) — ~1.5 GB, recommended (best accuracy)"),
-        ["small.en"] = ("https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.en.bin",
-                        400_000_000, "Small (English) — ~0.5 GB, faster download, less accurate"),
+        // --- transcription (whisper) ---
+        ["medium.en"] = new("https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.en.bin",
+            1_300_000_000, "Transcription: Medium (English) — ~1.5 GB, recommended", Kind.Whisper, "ggml-medium.en.bin"),
+        ["small.en"] = new("https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.en.bin",
+            400_000_000, "Transcription: Small (English) — ~0.5 GB, faster", Kind.Whisper, "ggml-small.en.bin"),
+        // --- digest (local LLM) ---
+        ["digest-small"] = new("https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/main/qwen2.5-0.5b-instruct-q4_k_m.gguf",
+            300_000_000, "Digest LLM: Small — ~0.5 GB, fast", Kind.Llama, "qwen2.5-0.5b-instruct-q4_k_m.gguf"),
+        ["digest-medium"] = new("https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/main/qwen2.5-1.5b-instruct-q4_k_m.gguf",
+            900_000_000, "Digest LLM: Medium — ~1 GB, better summaries", Kind.Llama, "qwen2.5-1.5b-instruct-q4_k_m.gguf"),
     };
+
+    private static string DestDir(Kind k) => k == Kind.Llama ? LlamaSummarizer.ModelDir : WhisperTranscriber.ModelDir;
 
     public VoyeurInstallService(
         ILogger<VoyeurInstallService> log,
         IHttpClientFactory httpFactory,
-        WhisperTranscriber whisper)
+        WhisperTranscriber whisper,
+        LlamaSummarizer llama)
     {
         _log = log;
         _httpFactory = httpFactory;
         _whisper = whisper;
+        _llama = llama;
     }
 
     public static IEnumerable<object> AvailableModels =>
-        Models.Select(m => new { id = m.Key, label = m.Value.Label });
+        Models.Select(m => new { id = m.Key, label = m.Value.Label,
+            kind = m.Value.Kind == Kind.Llama ? "digest" : "transcription" });
 
     public Progress Status()
     {
@@ -82,6 +96,8 @@ public sealed class VoyeurInstallService
                 _phase, _percent, _message, _item,
                 ModelPresent: _whisper.ModelPath is not null,
                 BinaryPresent: _whisper.CliPath is not null,
+                DigestModelPresent: _llama.ModelPath is not null,
+                DigestBinaryPresent: _llama.CliPath is not null,
                 Rid: Rid());
         }
     }
@@ -116,10 +132,13 @@ public sealed class VoyeurInstallService
 
     private async Task DownloadModelAsync(string modelId, CancellationToken ct)
     {
-        var (url, minBytes, _) = Models[modelId];
-        Directory.CreateDirectory(WhisperTranscriber.ModelDir);
-        var finalPath = Path.Combine(WhisperTranscriber.ModelDir, $"ggml-{modelId}.bin");
+        var def = Models[modelId];
+        var destDir = DestDir(def.Kind);
+        Directory.CreateDirectory(destDir);
+        var finalPath = Path.Combine(destDir, def.FileName);
         var tmpPath = finalPath + ".part";
+        long minBytes = def.MinBytes;
+        var url = def.Url;
 
         try
         {

--- a/Zeus.Server.Hosting/Voyeur/VoyeurModels.cs
+++ b/Zeus.Server.Hosting/Voyeur/VoyeurModels.cs
@@ -43,6 +43,9 @@ public sealed class VoyeurSessionDocument
     /// <summary>Relative directory (under the Voyeur root) holding this
     /// session's segment WAVs. Null when audio retention is off.</summary>
     public string? AudioDir { get; set; }
+    /// <summary>Phase 3: LLM-generated topic digest ("what was discussed").
+    /// Null until the operator generates it.</summary>
+    public string? Digest { get; set; }
 }
 
 /// <summary>One captured transmission ("over"). Phase 2 fills Transcript /
@@ -110,3 +113,29 @@ public sealed record VoyeurSessionDetailDto(
     IReadOnlyList<VoyeurSegmentDto> Segments);
 
 public sealed record VoyeurUpdateRequest(string? Label, bool? Pinned);
+
+// ---- Phase 3: report / roster / search ----
+
+public sealed record VoyeurRosterEntry(
+    string Callsign,
+    string? Name,
+    string State,          // confirmed | tentative
+    int OverCount,
+    DateTime FirstHeardUtc,
+    DateTime LastHeardUtc);
+
+public sealed record VoyeurReportDto(
+    VoyeurSessionDto Session,
+    IReadOnlyList<VoyeurRosterEntry> Roster,
+    int UniqueStations,
+    int ConfirmedStations,
+    int TranscribedOvers,
+    // LLM topic digest (Stage B); null until generated.
+    string? Digest);
+
+public sealed record VoyeurSearchHit(
+    string SessionId,
+    string SessionLabel,
+    long FreqHz,
+    DateTime StartedUtc,
+    IReadOnlyList<VoyeurSegmentDto> Matches);

--- a/Zeus.Server.Hosting/Voyeur/VoyeurStore.cs
+++ b/Zeus.Server.Hosting/Voyeur/VoyeurStore.cs
@@ -258,6 +258,133 @@ public sealed class VoyeurStore : IDisposable
         HasAudio: x.AudioFile is not null,
         x.Transcript, x.Callsign, x.CallsignState, x.CallsignName);
 
+    /// <summary>Phase 3: aggregate a session into a roster (who was on) + stats.
+    /// The roster dedups by callsign, counts overs, and keeps confirmed ahead of
+    /// tentative. Pure aggregation — no LLM. <paramref name="digest"/> carries an
+    /// optional pre-computed topic summary (Stage B).</summary>
+    public VoyeurReportDto? GetReport(string id, string? digest = null)
+    {
+        lock (_gate)
+        {
+            var s = _sessions.FindById(id);
+            if (s is null) return null;
+            var segs = _segments.Query().Where(x => x.SessionId == id).ToList();
+
+            var byCall = new Dictionary<string, (string? Name, string State, int Count, DateTime First, DateTime Last)>(StringComparer.Ordinal);
+            int transcribed = 0;
+            foreach (var seg in segs)
+            {
+                if (!string.IsNullOrWhiteSpace(seg.Transcript)) transcribed++;
+                if (string.IsNullOrWhiteSpace(seg.Callsign)) continue;
+                if (seg.CallsignState is not ("confirmed" or "tentative")) continue;
+                var key = seg.Callsign!;
+                if (byCall.TryGetValue(key, out var e))
+                {
+                    // Prefer the strongest state + a real name we've seen.
+                    var state = e.State == "confirmed" || seg.CallsignState == "confirmed" ? "confirmed" : "tentative";
+                    byCall[key] = (e.Name ?? seg.CallsignName, state, e.Count + 1,
+                        seg.StartedUtc < e.First ? seg.StartedUtc : e.First,
+                        seg.StartedUtc > e.Last ? seg.StartedUtc : e.Last);
+                }
+                else
+                {
+                    byCall[key] = (seg.CallsignName, seg.CallsignState!, 1, seg.StartedUtc, seg.StartedUtc);
+                }
+            }
+
+            var roster = byCall
+                .Select(kv => new VoyeurRosterEntry(kv.Key, kv.Value.Name, kv.Value.State,
+                    kv.Value.Count, kv.Value.First, kv.Value.Last))
+                .OrderByDescending(r => r.State == "confirmed")
+                .ThenByDescending(r => r.OverCount)
+                .ThenBy(r => r.Callsign, StringComparer.Ordinal)
+                .ToList();
+
+            return new VoyeurReportDto(
+                ToDto(s), roster,
+                UniqueStations: roster.Count,
+                ConfirmedStations: roster.Count(r => r.State == "confirmed"),
+                TranscribedOvers: transcribed,
+                Digest: digest ?? s.Digest);
+        }
+    }
+
+    /// <summary>Persist a generated topic digest on the session (Stage B).</summary>
+    public void SetDigest(string sessionId, string digest)
+    {
+        lock (_gate)
+        {
+            var s = _sessions.FindById(sessionId);
+            if (s is null) return;
+            s.Digest = digest;
+            _sessions.Update(s);
+        }
+    }
+
+    /// <summary>The whole concatenated transcript of a session, oldest over
+    /// first — input for the digest summarizer.</summary>
+    public string SessionTranscript(string id)
+    {
+        lock (_gate)
+        {
+            return string.Join("\n", _segments.Query()
+                .Where(x => x.SessionId == id)
+                .ToList()
+                .OrderBy(x => x.StartedUtc)
+                .Select(x => x.Transcript)
+                .Where(t => !string.IsNullOrWhiteSpace(t)));
+        }
+    }
+
+    /// <summary>Search every session's overs by callsign or transcript text.
+    /// Returns sessions with their matching overs, newest session first.</summary>
+    public IReadOnlyList<VoyeurSearchHit> Search(string query)
+    {
+        var q = query.Trim();
+        if (q.Length == 0) return Array.Empty<VoyeurSearchHit>();
+        lock (_gate)
+        {
+            var hits = new List<VoyeurSearchHit>();
+            foreach (var s in _sessions.Query().OrderByDescending(x => x.StartedUtc).ToList())
+            {
+                var matches = _segments.Query()
+                    .Where(x => x.SessionId == s.Id)
+                    .ToList()
+                    .Where(x =>
+                        (x.Callsign?.Contains(q, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                        (x.Transcript?.Contains(q, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                        (x.CallsignName?.Contains(q, StringComparison.OrdinalIgnoreCase) ?? false))
+                    .OrderBy(x => x.StartedUtc)
+                    .Select(ToSegDto)
+                    .ToList();
+                if (matches.Count > 0)
+                    hits.Add(new VoyeurSearchHit(s.Id, s.Label, s.FreqHz, s.StartedUtc, matches));
+            }
+            return hits;
+        }
+    }
+
+    /// <summary>Resolve a segment's on-disk WAV path for audio replay,
+    /// traversal-guarded. Null if the segment, its audio, or the file is gone.</summary>
+    public string? GetSegmentAudioPath(string segmentId)
+    {
+        lock (_gate)
+        {
+            var seg = _segments.FindById(segmentId);
+            if (seg?.AudioFile is null) return null;
+            var session = _sessions.FindById(seg.SessionId);
+            if (session?.AudioDir is null) return null;
+            var dir = Path.GetFullPath(Path.Combine(_audioRoot, session.AudioDir));
+            var rootFull = Path.GetFullPath(_audioRoot);
+            if (!dir.StartsWith(rootFull, StringComparison.Ordinal)) return null;
+            // Audio file name is server-generated (over-<ts>.wav); guard anyway.
+            var name = Path.GetFileName(seg.AudioFile);
+            var path = Path.GetFullPath(Path.Combine(dir, name));
+            if (!path.StartsWith(rootFull, StringComparison.Ordinal)) return null;
+            return File.Exists(path) ? path : null;
+        }
+    }
+
     /// <summary>Phase 2: write back the ASR transcript + the QRZ-validated
     /// callsign attribution for a captured over. No-op if the segment is gone
     /// (its session was deleted while transcription was in flight).</summary>

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -206,6 +206,23 @@ public static class ZeusEndpoints
             store.Delete(id)
                 ? Results.Ok(new { deleted = id })
                 : Results.NotFound(new { error = "session not found" }));
+        // Phase 3: report (roster who-was-on + stats + any saved digest).
+        app.MapGet("/api/voyeur/sessions/{id}/report", (string id, Zeus.Server.Voyeur.VoyeurStore store) =>
+        {
+            var r = store.GetReport(id);
+            return r is null ? Results.NotFound(new { error = "session not found" }) : Results.Ok(r);
+        });
+        // Phase 3: search every log's overs by callsign / name / transcript text.
+        app.MapGet("/api/voyeur/search", (string? q, Zeus.Server.Voyeur.VoyeurStore store) =>
+            Results.Ok(store.Search(q ?? "")));
+        // Phase 3: stream a captured over's audio for in-panel replay.
+        app.MapGet("/api/voyeur/segments/{segId}/audio", (string segId, Zeus.Server.Voyeur.VoyeurStore store) =>
+        {
+            var path = store.GetSegmentAudioPath(segId);
+            return path is null
+                ? Results.NotFound(new { error = "audio not found" })
+                : Results.File(path, "audio/wav", enableRangeProcessing: true);
+        });
 
         app.MapGet("/api/state", (RadioService r) => r.Snapshot());
 

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -170,8 +170,14 @@ public static class ZeusEndpoints
         // ---- Voyeur Mode (zeus-la5) — unattended net monitor + log mgmt ----
         app.MapGet("/api/voyeur/status", (VoyeurMonitorService v) => Results.Ok(v.Status()));
         // Transcription readiness + setup hint for the panel (Phase 2).
-        app.MapGet("/api/voyeur/transcription", (Zeus.Server.Voyeur.WhisperTranscriber w) =>
-            Results.Ok(new { available = w.Available, modelDir = Zeus.Server.Voyeur.WhisperTranscriber.ModelDir }));
+        app.MapGet("/api/voyeur/transcription",
+            (Zeus.Server.Voyeur.WhisperTranscriber w, Zeus.Server.Voyeur.LlamaSummarizer l) =>
+            Results.Ok(new
+            {
+                available = w.Available,
+                modelDir = Zeus.Server.Voyeur.WhisperTranscriber.ModelDir,
+                digestAvailable = l.Available,
+            }));
         // In-app, terminal-free transcription setup (cross-platform model download).
         app.MapGet("/api/voyeur/install/models", () =>
             Results.Ok(Zeus.Server.Voyeur.VoyeurInstallService.AvailableModels));
@@ -215,6 +221,21 @@ public static class ZeusEndpoints
         // Phase 3: search every log's overs by callsign / name / transcript text.
         app.MapGet("/api/voyeur/search", (string? q, Zeus.Server.Voyeur.VoyeurStore store) =>
             Results.Ok(store.Search(q ?? "")));
+        // Phase 3B: generate the local-LLM topic digest for a session, on demand.
+        app.MapPost("/api/voyeur/sessions/{id}/digest",
+            async (string id, Zeus.Server.Voyeur.VoyeurStore store, Zeus.Server.Voyeur.LlamaSummarizer llama, CancellationToken ct) =>
+        {
+            if (!llama.Available)
+                return Results.BadRequest(new { error = "digest model not installed" });
+            var transcript = store.SessionTranscript(id);
+            if (string.IsNullOrWhiteSpace(transcript))
+                return Results.BadRequest(new { error = "no transcript to summarize yet" });
+            var digest = await llama.SummarizeAsync(transcript, TimeSpan.FromSeconds(120), ct);
+            if (digest is null)
+                return Results.StatusCode(503);
+            store.SetDigest(id, digest);
+            return Results.Ok(store.GetReport(id));
+        });
         // Phase 3: stream a captured over's audio for in-panel replay.
         app.MapGet("/api/voyeur/segments/{segId}/audio", (string segId, Zeus.Server.Voyeur.VoyeurStore store) =>
         {

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -284,6 +284,7 @@ public static class ZeusHost
         // callsign extraction + QRZ enrichment. Runs entirely off the audio
         // path; degrades to capture-only when whisper isn't installed.
         builder.Services.AddSingleton<Zeus.Server.Voyeur.WhisperTranscriber>();
+        builder.Services.AddSingleton<Zeus.Server.Voyeur.LlamaSummarizer>();
         // In-app, terminal-free model download (cross-platform). Needs an
         // HttpClientFactory — already registered below via AddHttpClient, but
         // ensure the default factory exists for this service.

--- a/tests/Zeus.Server.Tests/VoyeurEngineExtractTests.cs
+++ b/tests/Zeus.Server.Tests/VoyeurEngineExtractTests.cs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+
+using System.IO.Compression;
+using Zeus.Server.Voyeur;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Covers VoyeurInstallService.ExtractEngine — the new engine-bundle unzip path
+/// (zeus-la5 Phase 3C). The engines are button-downloaded as a per-RID zip and
+/// extracted into the engine's bin/ dir; these tests pin the behaviour that
+/// matters: files land flattened in the target, a malicious "zip-slip" entry
+/// cannot escape the target, and on Unix the extracted files are executable.
+/// </summary>
+public sealed class VoyeurEngineExtractTests
+{
+    private static string NewTempDir()
+    {
+        var d = Path.Combine(Path.GetTempPath(), "zeus-voyeur-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(d);
+        return d;
+    }
+
+    [Fact]
+    public void Extract_FlattensLeadingFolder_AndDropsFilesInBinDir()
+    {
+        var work = NewTempDir();
+        try
+        {
+            var zipPath = Path.Combine(work, "whisper-osx-arm64.zip");
+            using (var zip = ZipFile.Open(zipPath, ZipArchiveMode.Create))
+            {
+                // Archivers commonly wrap everything in a top-level folder.
+                AddEntry(zip, "whisper-osx-arm64/whisper-cli", "binary");
+                AddEntry(zip, "whisper-osx-arm64/libfoo.dylib", "lib");
+            }
+
+            var binDir = Path.Combine(work, "bin");
+            VoyeurInstallService.ExtractEngine(zipPath, binDir);
+
+            Assert.True(File.Exists(Path.Combine(binDir, "whisper-cli")));
+            Assert.True(File.Exists(Path.Combine(binDir, "libfoo.dylib")));
+            // The wrapping folder must NOT survive.
+            Assert.False(Directory.Exists(Path.Combine(binDir, "whisper-osx-arm64")));
+        }
+        finally { Directory.Delete(work, true); }
+    }
+
+    [Fact]
+    public void Extract_BlocksZipSlip_OutsideBinDir()
+    {
+        var work = NewTempDir();
+        try
+        {
+            var zipPath = Path.Combine(work, "evil.zip");
+            using (var zip = ZipFile.Open(zipPath, ZipArchiveMode.Create))
+            {
+                AddEntry(zip, "whisper-cli", "ok");
+                // Attempt to write a sibling of binDir via path traversal.
+                AddEntry(zip, "../escaped.txt", "pwned");
+            }
+
+            var binDir = Path.Combine(work, "bin");
+            VoyeurInstallService.ExtractEngine(zipPath, binDir);
+
+            Assert.True(File.Exists(Path.Combine(binDir, "whisper-cli")));
+            // The traversal entry must never have escaped binDir.
+            Assert.False(File.Exists(Path.Combine(work, "escaped.txt")));
+        }
+        finally { Directory.Delete(work, true); }
+    }
+
+    [Fact]
+    public void Extract_OverwritesPriorCopy()
+    {
+        var work = NewTempDir();
+        try
+        {
+            var binDir = Path.Combine(work, "bin");
+            Directory.CreateDirectory(binDir);
+            File.WriteAllText(Path.Combine(binDir, "whisper-cli"), "OLD");
+
+            var zipPath = Path.Combine(work, "whisper.zip");
+            using (var zip = ZipFile.Open(zipPath, ZipArchiveMode.Create))
+                AddEntry(zip, "whisper-cli", "NEW");
+
+            VoyeurInstallService.ExtractEngine(zipPath, binDir);
+
+            Assert.Equal("NEW", File.ReadAllText(Path.Combine(binDir, "whisper-cli")));
+        }
+        finally { Directory.Delete(work, true); }
+    }
+
+    [Fact]
+    public void Extract_SetsExecutableBit_OnUnix()
+    {
+        if (OperatingSystem.IsWindows()) return; // no Unix file mode on Windows
+
+        var work = NewTempDir();
+        try
+        {
+            var zipPath = Path.Combine(work, "whisper.zip");
+            using (var zip = ZipFile.Open(zipPath, ZipArchiveMode.Create))
+                AddEntry(zip, "whisper-cli", "binary");
+
+            var binDir = Path.Combine(work, "bin");
+            VoyeurInstallService.ExtractEngine(zipPath, binDir);
+
+            var mode = File.GetUnixFileMode(Path.Combine(binDir, "whisper-cli"));
+            Assert.True(mode.HasFlag(UnixFileMode.UserExecute));
+        }
+        finally { Directory.Delete(work, true); }
+    }
+
+    private static void AddEntry(ZipArchive zip, string name, string content)
+    {
+        var entry = zip.CreateEntry(name);
+        using var s = entry.Open();
+        using var w = new StreamWriter(s);
+        w.Write(content);
+    }
+}

--- a/zeus-web/src/api/voyeur.ts
+++ b/zeus-web/src/api/voyeur.ts
@@ -145,3 +145,40 @@ export const deleteVoyeurSession = (id: string) =>
   json<{ deleted: string }>(`/api/voyeur/sessions/${encodeURIComponent(id)}`, {
     method: 'DELETE',
   });
+
+// ---- Phase 3: report / search / audio replay ----
+
+export type VoyeurRosterEntry = {
+  callsign: string;
+  name: string | null;
+  state: 'confirmed' | 'tentative';
+  overCount: number;
+  firstHeardUtc: string;
+  lastHeardUtc: string;
+};
+
+export type VoyeurReport = {
+  session: VoyeurSession;
+  roster: VoyeurRosterEntry[];
+  uniqueStations: number;
+  confirmedStations: number;
+  transcribedOvers: number;
+  digest: string | null;
+};
+
+export type VoyeurSearchHit = {
+  sessionId: string;
+  sessionLabel: string;
+  freqHz: number;
+  startedUtc: string;
+  matches: VoyeurSegment[];
+};
+
+export const getVoyeurReport = (id: string, signal?: AbortSignal) =>
+  json<VoyeurReport>(`/api/voyeur/sessions/${encodeURIComponent(id)}/report`, { signal });
+
+export const searchVoyeur = (q: string, signal?: AbortSignal) =>
+  json<VoyeurSearchHit[]>(`/api/voyeur/search?q=${encodeURIComponent(q)}`, { signal });
+
+export const voyeurSegmentAudioUrl = (segmentId: string) =>
+  `/api/voyeur/segments/${encodeURIComponent(segmentId)}/audio`;

--- a/zeus-web/src/api/voyeur.ts
+++ b/zeus-web/src/api/voyeur.ts
@@ -79,7 +79,7 @@ async function json<T>(input: string, init?: RequestInit): Promise<T> {
   return (await res.json()) as T;
 }
 
-export type VoyeurTranscription = { available: boolean; modelDir: string };
+export type VoyeurTranscription = { available: boolean; modelDir: string; digestAvailable: boolean };
 
 export const getVoyeurStatus = (signal?: AbortSignal) =>
   json<VoyeurStatus>('/api/voyeur/status', { signal });
@@ -176,6 +176,9 @@ export type VoyeurSearchHit = {
 
 export const getVoyeurReport = (id: string, signal?: AbortSignal) =>
   json<VoyeurReport>(`/api/voyeur/sessions/${encodeURIComponent(id)}/report`, { signal });
+
+export const generateVoyeurDigest = (id: string) =>
+  json<VoyeurReport>(`/api/voyeur/sessions/${encodeURIComponent(id)}/digest`, { method: 'POST' });
 
 export const searchVoyeur = (q: string, signal?: AbortSignal) =>
   json<VoyeurSearchHit[]>(`/api/voyeur/search?q=${encodeURIComponent(q)}`, { signal });

--- a/zeus-web/src/api/voyeur.ts
+++ b/zeus-web/src/api/voyeur.ts
@@ -96,6 +96,8 @@ export type VoyeurInstall = {
   item: string | null;
   modelPresent: boolean;
   binaryPresent: boolean;
+  digestModelPresent: boolean;
+  digestBinaryPresent: boolean;
   rid: string;
 };
 

--- a/zeus-web/src/layout/panels/VoyeurPanel.tsx
+++ b/zeus-web/src/layout/panels/VoyeurPanel.tsx
@@ -22,6 +22,7 @@ import {
   cancelVoyeurInstall,
   getVoyeurInstallStatus,
   getVoyeurModels,
+  generateVoyeurDigest,
   getVoyeurReport,
   getVoyeurStatus,
   getVoyeurTranscription,
@@ -77,6 +78,8 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [asrReady, setAsrReady] = useState<boolean | null>(null);
+  const [digestReady, setDigestReady] = useState(false);
+  const [digestBusy, setDigestBusy] = useState<string | null>(null);
   const [modelDir, setModelDir] = useState<string>('');
   const [showHelp, setShowHelp] = useState(false);
   const [models, setModels] = useState<VoyeurModel[]>([]);
@@ -126,6 +129,7 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
     try {
       const t = await getVoyeurTranscription();
       setAsrReady(t.available);
+      setDigestReady(t.digestAvailable);
       setModelDir(t.modelDir);
     } catch {
       /* ignore */
@@ -284,6 +288,19 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
     if (mode === 'roster' && !reports[id]) void loadReport(id);
   };
 
+  const onGenerateDigest = async (id: string) => {
+    setDigestBusy(id);
+    setError(null);
+    try {
+      const r = await generateVoyeurDigest(id);
+      setReports((m) => ({ ...m, [id]: r }));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setDigestBusy(null);
+    }
+  };
+
   const playSegment = (segId: string) => {
     let el = audioRef.current;
     if (!el) {
@@ -349,6 +366,23 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
           <span className="chip mono"><span className="k">confirmed</span><span className="v">{r.confirmedStations}</span></span>
           <span className="chip mono"><span className="k">overs</span><span className="v">{r.session.segmentCount}</span></span>
           <span className="chip mono"><span className="k">cap</span><span className="v">{fmtDur(r.session.capturedSeconds)}</span></span>
+        </div>
+        <div className="voyeur-digestbar">
+          <span className="voyeur-digestbar__label">Digest</span>
+          {digestReady ? (
+            <button
+              type="button"
+              className="btn sm accent"
+              disabled={digestBusy === id}
+              onClick={() => onGenerateDigest(id)}
+            >
+              {digestBusy === id ? 'Summarizing…' : r.digest ? 'Regenerate' : 'Generate'}
+            </button>
+          ) : (
+            <span className="voyeur-digestbar__hint">
+              install the digest model in “How to set up & use” to enable
+            </span>
+          )}
         </div>
         {r.digest && <div className="voyeur-digest">{r.digest}</div>}
         {r.roster.length === 0 && (

--- a/zeus-web/src/layout/panels/VoyeurPanel.tsx
+++ b/zeus-web/src/layout/panels/VoyeurPanel.tsx
@@ -214,6 +214,9 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
     }
     setOpenId(id);
     setDetail(null);
+    // Load the report too so the AI Summary bar (with any existing digest) is
+    // available in the Log view, not just behind the Roster toggle.
+    if (!reports[id]) void loadReport(id);
     try {
       setDetail(await getVoyeurSession(id));
     } catch (e) {
@@ -356,17 +359,14 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
     );
   };
 
-  const renderRoster = (id: string) => {
-    const r = reports[id];
-    if (!r) return <div className="voyeur-empty" style={{ padding: '6px 10px' }}>Loading…</div>;
+  // AI Summary bar — surfaced whenever a log is open (both Log and Roster
+  // views), so it's never hidden behind the Roster toggle. The digest text (if
+  // any) comes from the loaded report; the button works even before the report
+  // loads.
+  const renderSummary = (id: string) => {
+    const digest = reports[id]?.digest;
     return (
-      <div className="voyeur-roster">
-        <div className="voyeur-roster__stats">
-          <span className="chip mono"><span className="k">stations</span><span className="v">{r.uniqueStations}</span></span>
-          <span className="chip mono"><span className="k">confirmed</span><span className="v">{r.confirmedStations}</span></span>
-          <span className="chip mono"><span className="k">overs</span><span className="v">{r.session.segmentCount}</span></span>
-          <span className="chip mono"><span className="k">cap</span><span className="v">{fmtDur(r.session.capturedSeconds)}</span></span>
-        </div>
+      <div className="voyeur-summary">
         <div className="voyeur-digestbar">
           <div className="voyeur-digestbar__text">
             <span className="voyeur-digestbar__label">AI Summary</span>
@@ -385,7 +385,7 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
             >
               {digestBusy === id
                 ? 'Summarizing…'
-                : r.digest
+                : digest
                   ? 'Regenerate summary'
                   : 'Summarize this net'}
             </button>
@@ -395,7 +395,22 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
             </span>
           )}
         </div>
-        {r.digest && <div className="voyeur-digest">{r.digest}</div>}
+        {digest && <div className="voyeur-digest">{digest}</div>}
+      </div>
+    );
+  };
+
+  const renderRoster = (id: string) => {
+    const r = reports[id];
+    if (!r) return <div className="voyeur-empty" style={{ padding: '6px 10px' }}>Loading…</div>;
+    return (
+      <div className="voyeur-roster">
+        <div className="voyeur-roster__stats">
+          <span className="chip mono"><span className="k">stations</span><span className="v">{r.uniqueStations}</span></span>
+          <span className="chip mono"><span className="k">confirmed</span><span className="v">{r.confirmedStations}</span></span>
+          <span className="chip mono"><span className="k">overs</span><span className="v">{r.session.segmentCount}</span></span>
+          <span className="chip mono"><span className="k">cap</span><span className="v">{fmtDur(r.session.capturedSeconds)}</span></span>
+        </div>
         {r.roster.length === 0 && (
           <div className="voyeur-empty" style={{ padding: '4px 10px' }}>No callsigns identified.</div>
         )}
@@ -713,17 +728,22 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
                 )}
               </div>
 
-              {openId === s.id && (view[s.id] === 'roster' ? (
-                renderRoster(s.id)
-              ) : (
-                <div className="voyeur-overs">
-                  {!detail && <div className="voyeur-empty" style={{ padding: '6px 10px' }}>Loading…</div>}
-                  {detail && detail.segments.length === 0 && (
-                    <div className="voyeur-empty" style={{ padding: '6px 10px' }}>No overs captured.</div>
+              {openId === s.id && (
+                <>
+                  {renderSummary(s.id)}
+                  {view[s.id] === 'roster' ? (
+                    renderRoster(s.id)
+                  ) : (
+                    <div className="voyeur-overs">
+                      {!detail && <div className="voyeur-empty" style={{ padding: '6px 10px' }}>Loading…</div>}
+                      {detail && detail.segments.length === 0 && (
+                        <div className="voyeur-empty" style={{ padding: '6px 10px' }}>No overs captured.</div>
+                      )}
+                      {detail && detail.segments.map(renderOver)}
+                    </div>
                   )}
-                  {detail && detail.segments.map(renderOver)}
-                </div>
-              ))}
+                </>
+              )}
             </div>
           ))}
         </div>

--- a/zeus-web/src/layout/panels/VoyeurPanel.tsx
+++ b/zeus-web/src/layout/panels/VoyeurPanel.tsx
@@ -368,15 +368,26 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
           <span className="chip mono"><span className="k">cap</span><span className="v">{fmtDur(r.session.capturedSeconds)}</span></span>
         </div>
         <div className="voyeur-digestbar">
-          <span className="voyeur-digestbar__label">Digest</span>
+          <div className="voyeur-digestbar__text">
+            <span className="voyeur-digestbar__label">AI Summary</span>
+            <span className="voyeur-digestbar__sub">
+              Plain-English recap of who ran the net and what was discussed —
+              written locally on your machine from this log’s transcript.
+            </span>
+          </div>
           {digestReady ? (
             <button
               type="button"
               className="btn sm accent"
               disabled={digestBusy === id}
               onClick={() => onGenerateDigest(id)}
+              title="Summarize this net’s transcript into a short recap (runs locally, nothing leaves your machine)"
             >
-              {digestBusy === id ? 'Summarizing…' : r.digest ? 'Regenerate' : 'Generate'}
+              {digestBusy === id
+                ? 'Summarizing…'
+                : r.digest
+                  ? 'Regenerate summary'
+                  : 'Summarize this net'}
             </button>
           ) : (
             <span className="voyeur-digestbar__hint">

--- a/zeus-web/src/layout/panels/VoyeurPanel.tsx
+++ b/zeus-web/src/layout/panels/VoyeurPanel.tsx
@@ -22,15 +22,21 @@ import {
   cancelVoyeurInstall,
   getVoyeurInstallStatus,
   getVoyeurModels,
+  getVoyeurReport,
   getVoyeurStatus,
   getVoyeurTranscription,
   installVoyeurModel,
   listVoyeurSessions,
+  searchVoyeur,
+  voyeurSegmentAudioUrl,
   startVoyeur,
   stopVoyeur,
   updateVoyeurSession,
   type VoyeurInstall,
   type VoyeurModel,
+  type VoyeurReport,
+  type VoyeurSearchHit,
+  type VoyeurSegment,
   type VoyeurSession,
   type VoyeurSessionDetail,
   type VoyeurStatus,
@@ -76,7 +82,13 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
   const [models, setModels] = useState<VoyeurModel[]>([]);
   const [chosenModel, setChosenModel] = useState('medium.en');
   const [install, setInstall] = useState<VoyeurInstall | null>(null);
+  const [query, setQuery] = useState('');
+  const [hits, setHits] = useState<VoyeurSearchHit[] | null>(null);
+  const [reports, setReports] = useState<Record<string, VoyeurReport>>({});
+  const [view, setView] = useState<Record<string, 'log' | 'roster'>>({});
+  const [playing, setPlaying] = useState<string | null>(null);
   const editingRef = useRef<HTMLInputElement | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
 
   const refreshSessions = useCallback(async () => {
     try {
@@ -237,6 +249,122 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     }
+  };
+
+  // Search across all logs (debounced). Empty query → normal session list.
+  useEffect(() => {
+    const q = query.trim();
+    if (!q) {
+      setHits(null);
+      return;
+    }
+    const ctrl = new AbortController();
+    const h = setTimeout(() => {
+      void searchVoyeur(q, ctrl.signal)
+        .then(setHits)
+        .catch(() => {});
+    }, 250);
+    return () => {
+      clearTimeout(h);
+      ctrl.abort();
+    };
+  }, [query]);
+
+  const loadReport = useCallback(async (id: string) => {
+    try {
+      const r = await getVoyeurReport(id);
+      setReports((m) => ({ ...m, [id]: r }));
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  const setSessionView = (id: string, mode: 'log' | 'roster') => {
+    setView((v) => ({ ...v, [id]: mode }));
+    if (mode === 'roster' && !reports[id]) void loadReport(id);
+  };
+
+  const playSegment = (segId: string) => {
+    let el = audioRef.current;
+    if (!el) {
+      el = new Audio();
+      el.onended = () => setPlaying(null);
+      audioRef.current = el;
+    }
+    if (playing === segId) {
+      el.pause();
+      setPlaying(null);
+      return;
+    }
+    el.src = voyeurSegmentAudioUrl(segId);
+    void el.play().then(() => setPlaying(segId)).catch(() => setPlaying(null));
+  };
+
+  const renderOver = (seg: VoyeurSegment) => {
+    const state = seg.callsignState ?? 'unknown';
+    return (
+      <div key={seg.id} className={`voyeur-over voyeur-over--${state}`}>
+        <span className="voyeur-over__time">
+          {new Date(seg.startedUtc).toLocaleTimeString([], {
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+          })}
+          <br />
+          {(seg.durationMs / 1000).toFixed(0)}s
+        </span>
+        <span className="voyeur-over__body">
+          {seg.hasAudio && (
+            <button
+              type="button"
+              className={`voyeur-play ${playing === seg.id ? 'voyeur-play--on' : ''}`}
+              onClick={() => playSegment(seg.id)}
+              title="Play this over"
+              aria-label="Play this over"
+            >
+              {playing === seg.id ? '⏸' : '▶'}
+            </button>
+          )}
+          <span className={`voyeur-call voyeur-call--${state}`}>{seg.callsign ?? 'unknown'}</span>
+          {seg.callsignName && <span className="voyeur-name">{seg.callsignName}</span>}
+          {seg.transcript ? (
+            <span className="voyeur-text">{seg.transcript}</span>
+          ) : (
+            <span className="voyeur-text voyeur-text--pending">
+              {asrReady ? 'transcribing…' : 'audio captured'}
+            </span>
+          )}
+        </span>
+      </div>
+    );
+  };
+
+  const renderRoster = (id: string) => {
+    const r = reports[id];
+    if (!r) return <div className="voyeur-empty" style={{ padding: '6px 10px' }}>Loading…</div>;
+    return (
+      <div className="voyeur-roster">
+        <div className="voyeur-roster__stats">
+          <span className="chip mono"><span className="k">stations</span><span className="v">{r.uniqueStations}</span></span>
+          <span className="chip mono"><span className="k">confirmed</span><span className="v">{r.confirmedStations}</span></span>
+          <span className="chip mono"><span className="k">overs</span><span className="v">{r.session.segmentCount}</span></span>
+          <span className="chip mono"><span className="k">cap</span><span className="v">{fmtDur(r.session.capturedSeconds)}</span></span>
+        </div>
+        {r.digest && <div className="voyeur-digest">{r.digest}</div>}
+        {r.roster.length === 0 && (
+          <div className="voyeur-empty" style={{ padding: '4px 10px' }}>No callsigns identified.</div>
+        )}
+        {r.roster.map((e) => (
+          <div key={e.callsign} className="voyeur-rosteritem">
+            <span className={`voyeur-call voyeur-call--${e.state}`}>{e.callsign}</span>
+            {e.name && <span className="voyeur-name">{e.name}</span>}
+            <span className="voyeur-rosteritem__count">
+              {e.overCount} {e.overCount === 1 ? 'over' : 'overs'}
+            </span>
+          </div>
+        ))}
+      </div>
+    );
   };
 
   const active = status?.active ?? false;
@@ -422,9 +550,52 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
 
         {/* The intercepted-comms log */}
         <div className="voyeur__log">
-          <div className="voyeur-loghdr">Logs · {sessions.length}</div>
-          {sessions.length === 0 && <div className="voyeur-empty">No logs yet — press LISTEN.</div>}
-          {sessions.map((s) => (
+          <div className="voyeur-loghdr">
+            <span>Logs · {sessions.length}</span>
+            <input
+              className="voyeur-search"
+              type="search"
+              placeholder="search callsign or text…"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              aria-label="Search logs"
+            />
+          </div>
+
+          {hits !== null && (
+            <>
+              {hits.length === 0 && (
+                <div className="voyeur-empty">No matches for “{query}”.</div>
+              )}
+              {hits.map((hit) => (
+                <div className="voyeur-card" key={hit.sessionId}>
+                  <div className="voyeur-card__meta" style={{ paddingTop: 6 }}>
+                    <span className="chip mono"><span className="v">{fmtFreq(hit.freqHz)}</span></span>
+                    <span className="chip mono"><span className="k">when</span><span className="v">{fmtWhen(hit.startedUtc)}</span></span>
+                    <span className="chip mono"><span className="k">hits</span><span className="v">{hit.matches.length}</span></span>
+                    <span style={{ flex: 1 }} />
+                    <button
+                      type="button"
+                      className="btn sm"
+                      onClick={() => {
+                        setQuery('');
+                        void openSession(hit.sessionId);
+                      }}
+                    >
+                      Open log
+                    </button>
+                  </div>
+                  <div className="voyeur-overs">{hit.matches.map(renderOver)}</div>
+                </div>
+              ))}
+            </>
+          )}
+
+          {hits === null && sessions.length === 0 && (
+            <div className="voyeur-empty">No logs yet — press LISTEN.</div>
+          )}
+          {hits === null &&
+            sessions.map((s) => (
             <div className="voyeur-card" key={s.id}>
               <div className="voyeur-card__head">
                 <button
@@ -445,6 +616,24 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
                   }}
                   aria-label="Log name"
                 />
+                {openId === s.id && (
+                  <div className="voyeur-viewtoggle">
+                    <button
+                      type="button"
+                      className={`btn sm ${(view[s.id] ?? 'log') === 'log' ? 'active' : ''}`}
+                      onClick={() => setSessionView(s.id, 'log')}
+                    >
+                      Log
+                    </button>
+                    <button
+                      type="button"
+                      className={`btn sm ${view[s.id] === 'roster' ? 'active' : ''}`}
+                      onClick={() => setSessionView(s.id, 'roster')}
+                    >
+                      Roster
+                    </button>
+                  </div>
+                )}
                 <button type="button" className="btn sm" onClick={() => openSession(s.id)}>
                   {openId === s.id ? 'Hide' : 'Open'}
                 </button>
@@ -479,44 +668,17 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
                 )}
               </div>
 
-              {openId === s.id && (
+              {openId === s.id && (view[s.id] === 'roster' ? (
+                renderRoster(s.id)
+              ) : (
                 <div className="voyeur-overs">
                   {!detail && <div className="voyeur-empty" style={{ padding: '6px 10px' }}>Loading…</div>}
                   {detail && detail.segments.length === 0 && (
                     <div className="voyeur-empty" style={{ padding: '6px 10px' }}>No overs captured.</div>
                   )}
-                  {detail &&
-                    detail.segments.map((seg) => {
-                      const state = seg.callsignState ?? 'unknown';
-                      return (
-                        <div key={seg.id} className={`voyeur-over voyeur-over--${state}`}>
-                          <span className="voyeur-over__time">
-                            {new Date(seg.startedUtc).toLocaleTimeString([], {
-                              hour: '2-digit',
-                              minute: '2-digit',
-                              second: '2-digit',
-                            })}
-                            <br />
-                            {(seg.durationMs / 1000).toFixed(0)}s
-                          </span>
-                          <span className="voyeur-over__body">
-                            <span className={`voyeur-call voyeur-call--${state}`}>
-                              {seg.callsign ?? 'unknown'}
-                            </span>
-                            {seg.callsignName && <span className="voyeur-name">{seg.callsignName}</span>}
-                            {seg.transcript ? (
-                              <span className="voyeur-text">{seg.transcript}</span>
-                            ) : (
-                              <span className="voyeur-text voyeur-text--pending">
-                                {asrReady ? 'transcribing…' : 'audio captured'}
-                              </span>
-                            )}
-                          </span>
-                        </div>
-                      );
-                    })}
+                  {detail && detail.segments.map(renderOver)}
                 </div>
-              )}
+              ))}
             </div>
           ))}
         </div>

--- a/zeus-web/src/layout/panels/VoyeurPanel.tsx
+++ b/zeus-web/src/layout/panels/VoyeurPanel.tsx
@@ -21,7 +21,6 @@ import {
   getVoyeurSession,
   cancelVoyeurInstall,
   getVoyeurInstallStatus,
-  getVoyeurModels,
   generateVoyeurDigest,
   getVoyeurReport,
   getVoyeurStatus,
@@ -34,7 +33,6 @@ import {
   stopVoyeur,
   updateVoyeurSession,
   type VoyeurInstall,
-  type VoyeurModel,
   type VoyeurReport,
   type VoyeurSearchHit,
   type VoyeurSegment,
@@ -80,9 +78,7 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
   const [asrReady, setAsrReady] = useState<boolean | null>(null);
   const [digestReady, setDigestReady] = useState(false);
   const [digestBusy, setDigestBusy] = useState<string | null>(null);
-  const [modelDir, setModelDir] = useState<string>('');
   const [showHelp, setShowHelp] = useState(false);
-  const [models, setModels] = useState<VoyeurModel[]>([]);
   const [chosenModel, setChosenModel] = useState('medium.en');
   const [install, setInstall] = useState<VoyeurInstall | null>(null);
   const [query, setQuery] = useState('');
@@ -130,7 +126,6 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
       const t = await getVoyeurTranscription();
       setAsrReady(t.available);
       setDigestReady(t.digestAvailable);
-      setModelDir(t.modelDir);
     } catch {
       /* ignore */
     }
@@ -138,7 +133,6 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
 
   useEffect(() => {
     void refreshAsr();
-    void getVoyeurModels().then(setModels).catch(() => {});
     void getVoyeurInstallStatus().then(setInstall).catch(() => {});
   }, [refreshAsr]);
 
@@ -158,9 +152,9 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
     return () => clearInterval(h);
   }, [install?.phase, refreshAsr]);
 
-  const onInstall = async () => {
+  const onInstall = async (id?: string) => {
     try {
-      setInstall(await installVoyeurModel(chosenModel));
+      setInstall(await installVoyeurModel(id ?? chosenModel));
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     }
@@ -513,7 +507,8 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
             </button>
           </div>
 
-          {/* Prominent model-download control whenever transcription is off */}
+          {/* Prominent setup control whenever transcription is off. Two
+              one-time downloads: the speech engine, then a speech model. */}
           {asrReady === false && (
             <div className="voyeur-dl">
               {install?.phase === 'Downloading' ? (
@@ -529,30 +524,58 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
                   </button>
                 </>
               ) : (
-                <>
-                  <span className="voyeur-dl__label">Speech model:</span>
-                  <select
-                    value={chosenModel}
-                    onChange={(e) => setChosenModel(e.target.value)}
-                    aria-label="Speech model"
-                    style={{ flex: 1, minWidth: 0 }}
-                  >
-                    {(models.length
-                      ? models
-                      : [
-                          { id: 'medium.en', label: 'Medium — recommended' },
-                          { id: 'small.en', label: 'Small — faster download' },
-                        ]
-                    ).map((m) => (
-                      <option key={m.id} value={m.id}>
-                        {m.label}
-                      </option>
-                    ))}
-                  </select>
-                  <button type="button" className="btn sm accent" onClick={onInstall}>
-                    Download
-                  </button>
-                </>
+                <div className="voyeur-setup">
+                  <div className="voyeur-setup__hdr">
+                    Set up transcription — two one-time downloads, no terminal:
+                  </div>
+                  {/* Step 1 — speech engine */}
+                  <div className="voyeur-setup__row">
+                    <span className="voyeur-setup__step">
+                      {install?.binaryPresent ? '✓' : '1'}
+                    </span>
+                    <span className="voyeur-setup__name">Speech engine</span>
+                    {install?.binaryPresent ? (
+                      <span className="voyeur-setup__done">installed</span>
+                    ) : (
+                      <button
+                        type="button"
+                        className="btn sm accent"
+                        onClick={() => onInstall('engine-whisper')}
+                        title="Download the whisper.cpp speech engine for your platform (one-time)"
+                      >
+                        Download engine
+                      </button>
+                    )}
+                  </div>
+                  {/* Step 2 — speech model */}
+                  <div className="voyeur-setup__row">
+                    <span className="voyeur-setup__step">
+                      {install?.modelPresent ? '✓' : '2'}
+                    </span>
+                    <span className="voyeur-setup__name">Speech model</span>
+                    {install?.modelPresent ? (
+                      <span className="voyeur-setup__done">installed</span>
+                    ) : (
+                      <>
+                        <select
+                          value={chosenModel}
+                          onChange={(e) => setChosenModel(e.target.value)}
+                          aria-label="Speech model"
+                        >
+                          <option value="medium.en">Medium — recommended</option>
+                          <option value="small.en">Small — faster download</option>
+                        </select>
+                        <button
+                          type="button"
+                          className="btn sm accent"
+                          onClick={() => onInstall(chosenModel)}
+                        >
+                          Download
+                        </button>
+                      </>
+                    )}
+                  </div>
+                </div>
               )}
             </div>
           )}
@@ -577,9 +600,12 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
                 </li>
               </ol>
               <h4>Transcription (one-time, optional)</h4>
-              Runs locally — audio never leaves your computer. Pick a model above and
-              click Download (no terminal). The bigger model is more accurate on noisy
-              SSB; the smaller one downloads faster. You only download once.
+              Runs locally — audio never leaves your computer. It needs two
+              one-time downloads (no terminal): the <strong>speech engine</strong>{' '}
+              for your platform ({install?.rid ?? 'your OS'}) and a{' '}
+              <strong>speech model</strong>. Use the two-step panel above; the
+              bigger model is more accurate on noisy SSB, the smaller one downloads
+              faster. You only download once.
               {install?.phase === 'Done' && (
                 <div style={{ color: 'var(--green-soft)', marginTop: 4 }}>✓ {install.message}</div>
               )}
@@ -588,15 +614,47 @@ export function VoyeurPanel({ onRemove }: PanelComponentProps) {
                   Download failed: {install.message}
                 </div>
               )}
-              {install && !install.binaryPresent && (
-                <div style={{ fontSize: 10, color: 'var(--fg-3)', marginTop: 6 }}>
-                  Note: the whisper engine for your platform ({install.rid}) ships with
-                  Zeus. If transcription stays off after the model downloads, the engine
-                  isn’t bundled in this build yet — advanced users can place a{' '}
-                  <code>whisper-cli</code> binary in{' '}
-                  <code>{modelDir ? `${modelDir}/bin` : '…/Zeus/whisper/bin'}</code>.
+              <h4>AI summaries (optional)</h4>
+              A plain-English recap of each net, written locally by a small
+              language model — also two one-time downloads, both optional.
+              <div className="voyeur-setup" style={{ marginTop: 6 }}>
+                <div className="voyeur-setup__row">
+                  <span className="voyeur-setup__step">
+                    {install?.digestBinaryPresent ? '✓' : '·'}
+                  </span>
+                  <span className="voyeur-setup__name">Summary engine</span>
+                  {install?.digestBinaryPresent ? (
+                    <span className="voyeur-setup__done">installed</span>
+                  ) : (
+                    <button
+                      type="button"
+                      className="btn sm"
+                      disabled={install?.phase === 'Downloading'}
+                      onClick={() => onInstall('engine-llama')}
+                    >
+                      Download engine
+                    </button>
+                  )}
                 </div>
-              )}
+                <div className="voyeur-setup__row">
+                  <span className="voyeur-setup__step">
+                    {install?.digestModelPresent ? '✓' : '·'}
+                  </span>
+                  <span className="voyeur-setup__name">Summary model</span>
+                  {install?.digestModelPresent ? (
+                    <span className="voyeur-setup__done">installed</span>
+                  ) : (
+                    <button
+                      type="button"
+                      className="btn sm"
+                      disabled={install?.phase === 'Downloading'}
+                      onClick={() => onInstall('digest-small')}
+                    >
+                      Download
+                    </button>
+                  )}
+                </div>
+              </div>
               <h4>Reading the roster</h4>
               <span style={{ color: 'var(--accent)' }}>Blue</span> = QRZ-confirmed (real
               licensee, name shown). <span style={{ color: 'var(--power)' }}>Amber</span> =

--- a/zeus-web/src/layout/panels/voyeur.css
+++ b/zeus-web/src/layout/panels/voyeur.css
@@ -324,3 +324,85 @@
   color: var(--tx);
   font-size: 11px;
 }
+
+/* ---- Phase 3: search, roster, digest, replay ---- */
+.voyeur-loghdr {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.voyeur-search {
+  margin-left: auto;
+  min-width: 0;
+  flex: 0 1 180px;
+  background: var(--bg-1);
+  border: 1px solid var(--fg-4);
+  border-radius: var(--r-xs);
+  color: var(--fg-0);
+  font: inherit;
+  font-size: 11px;
+  padding: 2px 7px;
+}
+.voyeur-search:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.voyeur-viewtoggle {
+  display: inline-flex;
+  gap: 2px;
+  margin-right: 4px;
+}
+.voyeur-play {
+  background: none;
+  border: 1px solid var(--fg-4);
+  border-radius: var(--r-xs);
+  color: var(--accent-bright);
+  cursor: pointer;
+  font-size: 9px;
+  line-height: 1;
+  padding: 2px 5px;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+.voyeur-play--on {
+  color: var(--fg-0);
+  background: var(--accent);
+  border-color: var(--accent);
+}
+.voyeur-roster {
+  padding: 8px 10px;
+  background: var(--bg-inset);
+  border-top: 1px solid var(--fg-4);
+}
+.voyeur-roster__stats {
+  display: flex;
+  gap: 5px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+.voyeur-digest {
+  padding: 8px 10px;
+  margin-bottom: 8px;
+  border-radius: var(--r-xs);
+  background: var(--bg-1);
+  border: 1px solid var(--accent-line);
+  border-left: 3px solid var(--accent);
+  color: var(--fg-1);
+  font-size: 11px;
+  line-height: 1.5;
+}
+.voyeur-rosteritem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 2px;
+}
+.voyeur-rosteritem + .voyeur-rosteritem {
+  border-top: 1px solid color-mix(in srgb, var(--fg-4) 50%, transparent);
+}
+.voyeur-rosteritem__count {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--fg-3);
+}

--- a/zeus-web/src/layout/panels/voyeur.css
+++ b/zeus-web/src/layout/panels/voyeur.css
@@ -406,3 +406,22 @@
   font-size: 10px;
   color: var(--fg-3);
 }
+
+.voyeur-digestbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.voyeur-digestbar__label {
+  font-family: var(--font-display);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+}
+.voyeur-digestbar__hint {
+  font-size: 10px;
+  color: var(--fg-3);
+  font-style: italic;
+}

--- a/zeus-web/src/layout/panels/voyeur.css
+++ b/zeus-web/src/layout/panels/voyeur.css
@@ -407,11 +407,19 @@
   color: var(--fg-3);
 }
 
+/* AI Summary bar — shown above both Log and Roster views when a log is open. */
+.voyeur-summary {
+  padding: 8px 10px;
+  background: var(--bg-inset);
+  border-top: 1px solid var(--fg-4);
+}
+.voyeur-summary .voyeur-digest {
+  margin: 8px 0 0;
+}
 .voyeur-digestbar {
   display: flex;
   align-items: center;
   gap: 10px;
-  margin-bottom: 8px;
 }
 .voyeur-digestbar__text {
   display: flex;

--- a/zeus-web/src/layout/panels/voyeur.css
+++ b/zeus-web/src/layout/panels/voyeur.css
@@ -140,6 +140,57 @@
   font-variant-numeric: tabular-nums;
 }
 
+/* ---- setup checklist (engine + model, one-time) ---- */
+.voyeur-setup {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+}
+.voyeur-setup__hdr {
+  font-size: 11px;
+  color: var(--fg-2);
+}
+.voyeur-setup__row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.voyeur-setup__step {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  font-size: 10px;
+  font-weight: 700;
+  font-family: var(--font-mono);
+  color: var(--fg-0);
+  background: var(--accent);
+  flex: 0 0 auto;
+}
+.voyeur-setup__name {
+  font-size: 11px;
+  color: var(--fg-1);
+  flex: 1;
+  min-width: 0;
+}
+.voyeur-setup__done {
+  font-size: 10px;
+  color: var(--green-soft);
+  font-weight: 600;
+}
+.voyeur-setup select {
+  background: var(--bg-1);
+  border: 1px solid var(--fg-4);
+  border-radius: var(--r-xs);
+  color: var(--fg-0);
+  font: inherit;
+  font-size: 11px;
+  padding: 1px 4px;
+}
+
 /* ---- help disclosure ---- */
 .voyeur-help {
   font-size: 11px;

--- a/zeus-web/src/layout/panels/voyeur.css
+++ b/zeus-web/src/layout/panels/voyeur.css
@@ -410,15 +410,31 @@
 .voyeur-digestbar {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
   margin-bottom: 8px;
+}
+.voyeur-digestbar__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
 }
 .voyeur-digestbar__label {
   font-family: var(--font-display);
   font-size: 10px;
   letter-spacing: 0.06em;
   text-transform: uppercase;
+  color: var(--fg-2);
+}
+.voyeur-digestbar__sub {
+  font-size: 10px;
+  line-height: 1.4;
   color: var(--fg-3);
+}
+.voyeur-digestbar .btn {
+  flex: 0 0 auto;
+  white-space: nowrap;
 }
 .voyeur-digestbar__hint {
   font-size: 10px;


### PR DESCRIPTION
Phase 3 of Voyeur Mode (zeus-la5). Stacks on #601 (Phase 1) + #602 (Phase 2), both now merged to develop.

## What's in it
- **3A — Report / Roster / Search / Replay:** per-session roster (deduped callsign + QRZ name + over-count + first/last heard), full-text search across every log's overs, per-over audio replay (range-enabled). Endpoints: `/sessions/{id}/report`, `/search`, `/segments/{id}/audio`.
- **3B — Local-LLM digest** ("what was discussed"): `LlamaSummarizer` runs `llama-completion` as a supervised child process (never P/Invoked — same crash-isolation as whisper), reads the stored transcript only (off the audio/DSP path), $0/offline. "AI Summary" bar shown in both Log and Roster views. `POST /sessions/{id}/digest`.
- **3C — Button-download engine bundles:** the in-app setup now also fetches the native engines (per-RID static single-binary zips published by `build-voyeur-engines.yml`) into each engine's `bin/`, with a zip-slip-guarded extractor. Keeps the engines out of the base Zeus download; only Voyeur users pull them. No notarization needed (app-downloaded ⇒ un-quarantined ⇒ ad-hoc sig suffices).

## Safety
Prime directive intact: the RX tap still does only a lock-free ring copy on the DSP thread, self-wrapped + detach-on-fault, default OFF. Digest/engine work is on-demand and off the realtime path.

## Tests
757 backend + 271 frontend green, incl. 4 new `ExtractEngine` cases (flatten / zip-slip block / overwrite / exec-bit).

## Notes
- Engine **buttons 404 until `voyeur-engines-v1` is populated** by the new workflow (infra landed on main via #603).
- HL2 RX-unaffected bench proof still owed (verified on G2 with a live net).

🤖 Generated with [Claude Code](https://claude.com/claude-code)