### PR TITLE
fix(voyeur): engine min-size floor + CI engine build flags (zeus-la5)

### DIFF
--- a/.github/workflows/build-voyeur-engines.yml
+++ b/.github/workflows/build-voyeur-engines.yml
@@ -37,7 +37,10 @@ env:
   # Pinned upstream versions — bump deliberately, both are permissively licensed
   # (whisper.cpp + llama.cpp are MIT, GPL-compatible).
   WHISPER_REF: v1.7.4
-  LLAMA_REF: b4585
+  # b9610 is the build that ships the one-shot `llama-completion` tool the app
+  # invokes (matches the Homebrew build Voyeur was validated against). Older
+  # tags only have llama-cli (different one-shot flags).
+  LLAMA_REF: b9610
 
 jobs:
   # ----------------------------- macOS -------------------------------------
@@ -78,14 +81,19 @@ jobs:
         run: |
           set -eux
           git clone --depth 1 -b "${LLAMA_REF}" https://github.com/ggml-org/llama.cpp
+          # LLAMA_CURL/LLAMA_OPENSSL OFF: the completion tool otherwise links
+          # libcurl + OpenSSL (for -hf model downloads we never use), which on
+          # macOS pulls non-system Homebrew dylibs and breaks self-containment.
+          # We pass a local model path, so HTTPS isn't needed.
           cmake -S llama.cpp -B llama.cpp/build \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_SHARED_LIBS=OFF \
             -DGGML_OPENMP=OFF \
             -DGGML_METAL=ON \
             -DGGML_METAL_EMBED_LIBRARY=ON \
+            -DLLAMA_CURL=OFF \
+            -DLLAMA_OPENSSL=OFF \
             -DLLAMA_BUILD_TESTS=OFF \
-            -DLLAMA_BUILD_EXAMPLES=ON \
             -DLLAMA_BUILD_SERVER=OFF
           # Build the one-shot completion tool if this version has it, else the
           # classic llama-cli. The Zeus discovery accepts either name.
@@ -168,8 +176,8 @@ jobs:
           git clone --depth 1 -b "${LLAMA_REF}" https://github.com/ggml-org/llama.cpp
           cmake -S llama.cpp -B llama.cpp/build \
             -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF \
-            -DGGML_OPENMP=OFF -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_EXAMPLES=ON \
-            -DLLAMA_BUILD_SERVER=OFF ${CROSS:-}
+            -DGGML_OPENMP=OFF -DLLAMA_CURL=OFF -DLLAMA_OPENSSL=OFF \
+            -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_SERVER=OFF ${CROSS:-}
           cmake --build llama.cpp/build --config Release --target llama-completion --parallel || \
           cmake --build llama.cpp/build --config Release --target llama-cli --parallel
 
@@ -226,7 +234,8 @@ jobs:
           cmake -S llama.cpp -B llama.cpp/build -A ${{ matrix.arch }} `
             -DBUILD_SHARED_LIBS=OFF -DGGML_OPENMP=OFF `
             -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded `
-            -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_EXAMPLES=ON -DLLAMA_BUILD_SERVER=OFF
+            -DLLAMA_CURL=OFF -DLLAMA_OPENSSL=OFF `
+            -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_SERVER=OFF
           $built = cmake --build llama.cpp/build --config Release --target llama-completion --parallel 2>&1
           if ($LASTEXITCODE -ne 0) {
             cmake --build llama.cpp/build --config Release --target llama-cli --parallel

--- a/Zeus.Server.Hosting/Voyeur/VoyeurInstallService.cs
+++ b/Zeus.Server.Hosting/Voyeur/VoyeurInstallService.cs
@@ -83,10 +83,12 @@ public sealed class VoyeurInstallService
     private static readonly Dictionary<string, ModelDef> Models = new()
     {
         // --- engines (native binaries — required before models do anything) ---
+        // Min-size is a low floor to reject error pages, NOT a tight bound: a
+        // static whisper-cli zips to well under 1 MB, so keep this small.
         ["engine-whisper"] = new(EngineBase + "/whisper-{rid}.zip",
-            2_000_000, "Speech engine (whisper.cpp) — required for transcription", Kind.EngineWhisper, "whisper-engine.zip", Archive: true),
+            200_000, "Speech engine (whisper.cpp) — required for transcription", Kind.EngineWhisper, "whisper-engine.zip", Archive: true),
         ["engine-llama"] = new(EngineBase + "/llama-{rid}.zip",
-            2_000_000, "AI-summary engine (llama.cpp) — required for digests", Kind.EngineLlama, "llama-engine.zip", Archive: true),
+            200_000, "AI-summary engine (llama.cpp) — required for digests", Kind.EngineLlama, "llama-engine.zip", Archive: true),
         // --- transcription (whisper) ---
         ["medium.en"] = new("https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.en.bin",
             1_300_000_000, "Transcription: Medium (English) — ~1.5 GB, recommended", Kind.Whisper, "ggml-medium.en.bin"),


### PR DESCRIPTION
Follow-up fixes from verifying the button-download engine path end-to-end on osx-arm64 (bundles built locally, published to `voyeur-engines-v1`, downloaded via the API — both engines extract to `bin/` and run).

- Lower the engine min-size floor 2 MB → 200 KB (a static whisper-cli zips to ~690 KB and was being rejected).
- CI: pin `LLAMA_REF=b9610` (ships the `llama-completion` tool we call) and add `-DLLAMA_CURL=OFF -DLLAMA_OPENSSL=OFF` so the binary stays self-contained (no Homebrew OpenSSL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)