### PR TITLE
ci(voyeur): drop osx-x64 (Intel/macos-13) from engine-bundle matrix

### DIFF
--- a/.github/workflows/build-voyeur-engines.yml
+++ b/.github/workflows/build-voyeur-engines.yml
@@ -52,8 +52,9 @@ jobs:
         include:
           - rid: osx-arm64
             runner: macos-14   # Apple Silicon
-          - rid: osx-x64
-            runner: macos-13   # Intel
+          # osx-x64 (Intel / macos-13) dropped: GitHub's Intel-Mac runner pool
+          # is being wound down and jobs sit queued for 14h+. Apple-Silicon
+          # covers current Macs; re-add this row if an Intel-Mac user needs it.
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Install build tools


### PR DESCRIPTION
## What

Drops the `osx-x64` / `macos-13` row from the Build Voyeur Engines matrix.

## Why

GitHub's Intel-Mac (`macos-13`) hosted-runner pool is being wound down. The `osx-x64` engine-bundle job sat **queued 14h+** across four overnight dispatches while every other RID built in minutes:

| RID | Status |
|---|---|
| linux-x64 | ✓ ~3m |
| linux-arm64 | ✓ ~3m |
| win-x64 | ✓ ~5m |
| win-arm64 | ✓ ~4m |
| osx-arm64 | ✓ |
| **osx-x64** | **⏳ wedged 14h+** |

Apple-Silicon (`osx-arm64`) covers current Macs. Re-add the Intel row if a Voyeur user on an Intel Mac actually needs it.

Once merged, re-dispatch a clean Build Voyeur Engines run from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)