### PR TITLE
ci(voyeur): restore osx-x64 via x86_64 cross-build on macos-14

### DIFF
--- a/.github/workflows/build-voyeur-engines.yml
+++ b/.github/workflows/build-voyeur-engines.yml
@@ -51,11 +51,15 @@ jobs:
       matrix:
         include:
           - rid: osx-arm64
-            runner: macos-14   # Apple Silicon
-          # osx-x64 (Intel / macos-13) dropped: GitHub's Intel-Mac runner pool
-          # is being wound down and jobs sit queued for 14h+. Apple-Silicon
-          # covers current Macs; re-add this row if an Intel-Mac user needs it.
-    runs-on: ${{ matrix.runner }}
+            arch: arm64    # Apple Silicon — native on the macos-14 runner
+          - rid: osx-x64
+            arch: x86_64   # Intel — cross-compiled on the SAME macos-14 runner.
+                           # GitHub's macos-13 (Intel) hosted pool is being wound
+                           # down (jobs queued 14h+). GGML_NATIVE=OFF means no
+                           # -march=native, so the x86_64 slice builds portably
+                           # here; CMAKE_OSX_ARCHITECTURES picks the slice and the
+                           # otool self-containment check below is arch-agnostic.
+    runs-on: macos-14
     steps:
       - name: Install build tools
         run: brew install cmake git
@@ -69,6 +73,7 @@ jobs:
           git clone --depth 1 -b "${WHISPER_REF}" https://github.com/ggml-org/whisper.cpp
           cmake -S whisper.cpp -B whisper.cpp/build \
             -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch }} \
             -DBUILD_SHARED_LIBS=OFF \
             -DGGML_OPENMP=OFF \
             -DGGML_NATIVE=OFF \
@@ -89,6 +94,7 @@ jobs:
           # We pass a local model path, so HTTPS isn't needed.
           cmake -S llama.cpp -B llama.cpp/build \
             -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch }} \
             -DBUILD_SHARED_LIBS=OFF \
             -DGGML_OPENMP=OFF \
             -DGGML_NATIVE=OFF \
@@ -121,6 +127,14 @@ jobs:
             bad=$(otool -L "$b" | tail -n +2 | awk '{print $1}' \
                   | grep -vE '^/usr/lib/|^/System/' || true)
             if [ -n "$bad" ]; then echo "ERROR: non-system deps in $b:"; echo "$bad"; exit 1; fi
+            # Assert the cross-compile actually produced the requested slice — a
+            # silent fall-back to the host arch (arm64) would ship a binary that
+            # won't run on Intel Macs while still passing every other check.
+            echo "== lipo -archs $b =="
+            got=$(lipo -archs "$b")
+            if [ "$got" != "${{ matrix.arch }}" ]; then
+              echo "ERROR: $b is '$got', expected '${{ matrix.arch }}'"; exit 1
+            fi
             codesign -dv "$b" 2>&1 | grep -i 'Signature' || true
           done
 


### PR DESCRIPTION
## What

Restores Intel-Mac (`osx-x64`) Voyeur engine bundles by **cross-compiling the x86_64 slice on the `macos-14` (Apple Silicon) runner**, instead of GitHub's deprecated `macos-13` Intel pool.

## Why

PR #611 dropped `osx-x64` because the `macos-13` hosted-runner pool wedged jobs for 14h+. Rather than lose Intel-Mac coverage, build both Mac slices on the healthy `macos-14` runner.

## How

- Matrix carries `arch` (`arm64` / `x86_64`), passed to `-DCMAKE_OSX_ARCHITECTURES`.
- Works because `GGML_NATIVE=OFF` is already set (no `-march=native`), so the x86_64 slice builds portably on an arm64 host.
- The `otool -L` self-containment check is arch-agnostic and still applies.
- Added a **`lipo -archs` assertion**: fails the build if the cross-compile silently falls back to the host arch (which would otherwise ship an arm64 binary mislabeled `osx-x64`).

## Risk

Independent of the 5-platform release publish already in flight. If the x86_64 build ever hiccups, it only affects a *separate* re-dispatch — the publish step is idempotent (`--clobber`) and just adds the 2 Intel zips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)