### PR TITLE
ci: port windows-2022 build pins onto develop

### DIFF
--- a/.github/workflows/build-native-libs.yml
+++ b/.github/workflows/build-native-libs.yml
@@ -14,7 +14,10 @@ on:
 jobs:
   build-windows:
     name: Build Windows Native Libraries
-    runs-on: windows-latest
+    # Pinned: windows-latest rolled past the VS 2022 image ~2026-06-10 and the
+    # 'Visual Studio 17 2022' generator below stopped resolving. Keep runner +
+    # generator in lockstep; bump both together.
+    runs-on: windows-2022
     strategy:
       matrix:
         # arm64 enabled: the _MM_SET_FLUSH_ZERO_MODE SSE-intrinsic block in

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,10 @@ jobs:
   build-native-windows:
     name: Build native WDSP (windows-${{ matrix.arch }})
     needs: determine-version
-    runs-on: windows-latest
+    # Pinned: windows-latest rolled past the VS 2022 image ~2026-06-10 and the
+    # 'Visual Studio 17 2022' generator below stopped resolving, killing every
+    # nightly. Keep runner + generator in lockstep; bump both together.
+    runs-on: windows-2022
     strategy:
       matrix:
         arch: [x64, arm64]


### PR DESCRIPTION
Cherry-picks KB2UKA's `e9de2639` (windows-2022 runner pins for build-native-libs.yml + release.yml) onto develop.

These pins existed only on `main`; without them the Windows native-lib / release builds fail (windows-latest rolled past the VS 2022 image ~2026-06-10). develop already had the macOS FFTW bundling that main lacked — this brings both infra fixes onto develop so it's the complete, correct basis for the 0.9.0 `main`.

Prereq for reconciling `main` to develop (dropping the stranded #502 features) ahead of the 0.9.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)