### PR TITLE
feat(plugins): expose RX receiver index to audio taps

### DIFF
--- a/Zeus.Plugins.Contracts/AbiVersion.cs
+++ b/Zeus.Plugins.Contracts/AbiVersion.cs
@@ -18,5 +18,5 @@ public static class AbiVersion
     /// change (default-interface methods, new optional manifest fields).
     /// Bump major in lockstep with <see cref="Current"/>.
     /// </summary>
-    public const string SdkVersion = "1.0.0";
+    public const string SdkVersion = "1.1.0";
 }

--- a/Zeus.Plugins.Contracts/Audio/AudioBlockContext.cs
+++ b/Zeus.Plugins.Contracts/Audio/AudioBlockContext.cs
@@ -6,13 +6,14 @@ namespace Zeus.Plugins.Contracts.Audio;
 /// </summary>
 public readonly ref struct AudioBlockContext
 {
-    public AudioBlockContext(int sampleRate, int channels, int frames, long sampleTime, bool mox)
+    public AudioBlockContext(int sampleRate, int channels, int frames, long sampleTime, bool mox, int receiver = 0)
     {
         SampleRate = sampleRate;
         Channels = channels;
         Frames = frames;
         SampleTime = sampleTime;
         Mox = mox;
+        Receiver = receiver;
     }
 
     public int SampleRate { get; }
@@ -33,6 +34,16 @@ public readonly ref struct AudioBlockContext
     /// of assuming every Process call is on-air.
     /// </summary>
     public bool Mox { get; }
+
+    /// <summary>
+    /// Zero-based hardware receiver index this block came from: 0 = main RX,
+    /// 1+ = SubRX / diversity / additional DDCs. Lets an <see
+    /// cref="Extensions.IRxAudioTapPlugin"/> filter to a single receiver — a
+    /// net monitor that only wants the main RX drops blocks where
+    /// <c>Receiver != 0</c>, exactly as in-core RX consumers do. Meaningful
+    /// only on the RX path; always 0 on TX mic/air blocks (no receiver).
+    /// </summary>
+    public int Receiver { get; }
 }
 
 /// <summary>

--- a/Zeus.Server.Hosting/AudioTapBridge.cs
+++ b/Zeus.Server.Hosting/AudioTapBridge.cs
@@ -85,7 +85,7 @@ public sealed class AudioTapBridge : IHostedService
         var taps = _rxTaps;
         if (taps.Length == 0) return;
         var span = block.Span;
-        var ctx = new AudioBlockContext(sampleRate, 1, span.Length, 0, mox: false);
+        var ctx = new AudioBlockContext(sampleRate, 1, span.Length, 0, mox: false, receiver: receiver);
         for (int i = 0; i < taps.Length; i++)
         {
             try { taps[i].OnRxAudio(span, ctx); } catch { /* a tap must never break audio */ }

--- a/tests/Zeus.Plugins.Host.Tests/ManifestValidatorTests.cs
+++ b/tests/Zeus.Plugins.Host.Tests/ManifestValidatorTests.cs
@@ -80,7 +80,10 @@ public class ManifestValidatorTests
     [Fact]
     public void IsAbiCompatible_ExactMatch_True()
     {
-        Assert.True(ManifestValidator.IsAbiCompatible(Make(), 1, "1.0.0"));
+        // Host at the current SDK version vs a plugin built for it (Make() defaults
+        // sdkMin to AbiVersion.SdkVersion) — reference the constant, not a frozen
+        // literal, so this stays correct across additive SDK minor bumps.
+        Assert.True(ManifestValidator.IsAbiCompatible(Make(), 1, AbiVersion.SdkVersion));
     }
 
     [Fact]


### PR DESCRIPTION
**Phase 0 (1 of 2) for the Voyeur-Mode plugin extraction.**

The RX audio tap (`AudioTapBridge` → `IRxAudioTapPlugin.OnRxAudio`) dropped the receiver index that `DspPipelineService.RxAudioAvailable` carries. In-core Voyeur filters `if (receiver != 0) return` to take only the main RX; a tap plugin couldn't, so on any multi-RX config (SubRX / diversity / dual-RX G2) it would ingest interleaved audio from every receiver and garble transcription.

- `AudioBlockContext` gains a `Receiver` property via a **trailing optional ctor param** (`receiver = 0`) — additive; all 10 existing call sites compile unchanged. RX path passes the real receiver; TX mic/air leave 0 (no receiver on TX).
- `AbiVersion.SdkVersion` 1.0.0 → 1.1.0 (additive; ABI `Current` stays 1, so existing plugins still load).
- Test fix: the ABI exact-match test now references `AbiVersion.SdkVersion` instead of a frozen `"1.0.0"` literal.

Build green, `Zeus.Plugins.Host.Tests` 79 passed, server audio/tap tests 72 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)