### PR TITLE
feat(plugins): host-mediated QRZ lookup for plugins (IPluginContext.Qrz)

### DIFF
--- a/Zeus.Plugins.Contracts/AbiVersion.cs
+++ b/Zeus.Plugins.Contracts/AbiVersion.cs
@@ -18,5 +18,5 @@ public static class AbiVersion
     /// change (default-interface methods, new optional manifest fields).
     /// Bump major in lockstep with <see cref="Current"/>.
     /// </summary>
-    public const string SdkVersion = "1.1.0";
+    public const string SdkVersion = "1.2.0";
 }

--- a/Zeus.Plugins.Contracts/IPluginContext.cs
+++ b/Zeus.Plugins.Contracts/IPluginContext.cs
@@ -55,6 +55,15 @@ public interface IPluginContext
     /// need no change.
     /// </summary>
     IAudioPlaybackSink? Playback => null;
+
+    /// <summary>
+    /// Host-mediated QRZ callsign lookup, reusing the operator's stored QRZ
+    /// credentials + session + rate-limit gate. Null unless
+    /// <see cref="PluginCapabilities.NetworkAccess"/> was granted and the host
+    /// has QRZ configured. Default implementation returns null so existing
+    /// hosts / test doubles need no change.
+    /// </summary>
+    IQrzLookup? Qrz => null;
 }
 
 /// <summary>Key/value persistence scoped to one plugin id.</summary>

--- a/Zeus.Plugins.Contracts/IQrzLookup.cs
+++ b/Zeus.Plugins.Contracts/IQrzLookup.cs
@@ -1,0 +1,37 @@
+namespace Zeus.Plugins.Contracts;
+
+/// <summary>
+/// Host-mediated QRZ.com callsign lookup, granted via
+/// <see cref="PluginCapabilities.NetworkAccess"/>. The host performs the
+/// lookup using the OPERATOR'S OWN stored QRZ credentials, session, and shared
+/// rate-limit gate — so a plugin never asks the user for QRZ credentials a
+/// second time, never stores keys, and can't stampede QRZ. Surfaced as
+/// <see cref="IPluginContext.Qrz"/>; null there when the capability wasn't
+/// granted or the host has no QRZ subscription configured.
+/// </summary>
+public interface IQrzLookup
+{
+    /// <summary>
+    /// Resolve a callsign against QRZ. Returns null if the callsign isn't
+    /// found, QRZ is unconfigured / unreachable, or the lookup failed — this
+    /// method NEVER throws. Subject to the host's shared QRZ rate limit.
+    /// </summary>
+    Task<QrzLookupResult?> LookupAsync(string callsign, CancellationToken ct = default);
+}
+
+/// <summary>
+/// A resolved QRZ station record — an SDK-stable subset of the host's internal
+/// QRZ model, mapped by the host adapter so the plugin contract stays decoupled
+/// from the app's wire format.
+/// </summary>
+public sealed record QrzLookupResult(
+    string Callsign,
+    string? Name,
+    string? FirstName,
+    string? Country,
+    string? State,
+    string? City,
+    string? Grid,
+    double? Lat,
+    double? Lon,
+    int? Dxcc);

--- a/Zeus.Plugins.Host/PluginContext.cs
+++ b/Zeus.Plugins.Host/PluginContext.cs
@@ -20,7 +20,8 @@ internal sealed class PluginContext : IPluginContext
         IPluginSettings settings,
         IRadioStateReader? radio,
         IRadioController? radioController,
-        IAudioPlaybackSink? playback = null)
+        IAudioPlaybackSink? playback = null,
+        IQrzLookup? qrz = null)
     {
         PluginId = pluginId;
         Manifest = manifest;
@@ -31,6 +32,7 @@ internal sealed class PluginContext : IPluginContext
         Radio = radio;
         RadioController = radioController;
         Playback = playback;
+        Qrz = qrz;
     }
 
     public string PluginId { get; }
@@ -42,4 +44,5 @@ internal sealed class PluginContext : IPluginContext
     public IRadioStateReader? Radio { get; }
     public IRadioController? RadioController { get; }
     public IAudioPlaybackSink? Playback { get; }
+    public IQrzLookup? Qrz { get; }
 }

--- a/Zeus.Plugins.Host/PluginManager.cs
+++ b/Zeus.Plugins.Host/PluginManager.cs
@@ -135,7 +135,12 @@ public sealed class PluginManager : IHostedService, IAsyncDisposable
             // Audio playback sink (local monitor + on-air TX inject). Provided
             // by the host when available; on-air only reaches the air under
             // operator MOX, so this is not capability-gated here.
-            playback: _services.GetService<IAudioPlaybackSink>());
+            playback: _services.GetService<IAudioPlaybackSink>(),
+            // QRZ callsign lookup, gated on NetworkAccess — the host reuses the
+            // operator's stored credentials + rate-limit gate (no second login).
+            qrz: granted.HasFlag(PluginCapabilities.NetworkAccess)
+                ? _services.GetService<IQrzLookup>()
+                : null);
 
         using (var initCts = CancellationTokenSource.CreateLinkedTokenSource(ct))
         {

--- a/Zeus.Server.Hosting/PluginQrzLookup.cs
+++ b/Zeus.Server.Hosting/PluginQrzLookup.cs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// PluginQrzLookup — host adapter that surfaces the core QrzService to plugins
+// via the IQrzLookup contract. Maps the internal Zeus.Contracts.QrzStation to
+// the SDK-stable Zeus.Plugins.Contracts.QrzLookupResult so the plugin contract
+// never depends on the app wire format. Plugins reach this through
+// IPluginContext.Qrz (gated on the NetworkAccess capability in PluginManager),
+// reusing the operator's stored QRZ credentials + the QrzService rate-limit
+// gate — no second login, no key handling in plugin code.
+
+using Microsoft.Extensions.Logging;
+using Zeus.Plugins.Contracts;
+
+namespace Zeus.Server;
+
+public sealed class PluginQrzLookup : IQrzLookup
+{
+    private readonly QrzService _qrz;
+    private readonly ILogger<PluginQrzLookup> _log;
+
+    public PluginQrzLookup(QrzService qrz, ILogger<PluginQrzLookup> log)
+    {
+        _qrz = qrz;
+        _log = log;
+    }
+
+    public async Task<QrzLookupResult?> LookupAsync(string callsign, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(callsign)) return null;
+        try
+        {
+            var s = await _qrz.LookupAsync(callsign, ct).ConfigureAwait(false);
+            if (s is null) return null;
+            return new QrzLookupResult(
+                s.Callsign, s.Name, s.FirstName, s.Country,
+                s.State, s.City, s.Grid, s.Lat, s.Lon, s.Dxcc);
+        }
+        catch (OperationCanceledException)
+        {
+            throw; // honour caller cancellation; not a lookup failure
+        }
+        catch (Exception ex)
+        {
+            // IQrzLookup contract: never throw on a failed lookup — return null.
+            _log.LogDebug(ex, "plugin QRZ lookup failed for {Call}", callsign);
+            return null;
+        }
+    }
+}

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -398,6 +398,12 @@ public static class ZeusHost
         // the capability in PluginManager). Enables plugin keyers (RTTY/voice).
         builder.Services.AddSingleton<Zeus.Plugins.Contracts.IRadioController, RadioController>();
 
+        // PluginQrzLookup surfaces the core QrzService to plugins (gated on the
+        // NetworkAccess capability in PluginManager) so a plugin reuses the
+        // operator's stored QRZ credentials + rate-limit gate instead of asking
+        // for them again. Surfaced via IPluginContext.Qrz.
+        builder.Services.AddSingleton<Zeus.Plugins.Contracts.IQrzLookup, PluginQrzLookup>();
+
         // AudioChainMasterBypassService — operator's "disengage the
         // whole Audio Suite" lever. Default is true (bypassed) on first
         // install so a brand-new operator's chain is inert until they


### PR DESCRIPTION
**Phase 0 (2 of 2) for the Voyeur-Mode plugin extraction.**

A plugin doing its own QRZ HTTP can't reach the operator's stored QRZ credentials (`QrzService` → `CredentialStore`) — that would force users to **re-enter QRZ creds in a second place**, a regression for Voyeur's callsign enrichment.

- New `IQrzLookup` + `QrzLookupResult` in the SDK; surfaced via `IPluginContext.Qrz` as a **default-interface member** (→ null), so existing hosts/test doubles need no change.
- Host adapter `PluginQrzLookup` wraps the core `QrzService`, maps `QrzStation` → the SDK-stable `QrzLookupResult` (keeps the plugin contract off the app wire format), and never throws (returns null on failure, honours cancellation).
- Gated on the **`NetworkAccess`** capability in `PluginManager` → reuses the operator's credentials + the existing QRZ rate-limit gate. No second login.
- `AbiVersion.SdkVersion` 1.1.0 → 1.2.0 (additive; ABI `Current` stays 1).

**Phase-1 note:** `IRadioStateReader` has no host adapter registered yet, so `IPluginContext.Radio` resolves null today — registering a `RadioService`-backed reader is a separate small Phase-1 shim for Voyeur's session metadata (freq/mode/band).

Build green; `Zeus.Plugins.Host.Tests` 79 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)