### PR TITLE
feat(plugins): register IRadioStateReader host adapter

### DIFF
--- a/Zeus.Server.Hosting/RadioStateReader.cs
+++ b/Zeus.Server.Hosting/RadioStateReader.cs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// RadioStateReader — host implementation of the plugin-facing IRadioStateReader
+// (read-only). Surfaces the operator's current VFO frequency, mode, band, and
+// MOX state to plugins holding the ReadRadioState capability, wrapping the same
+// RadioService snapshot + change events the UI uses. Band is derived from the
+// VFO with BandUtils.FreqToBand, exactly as the in-core Voyeur session metadata
+// did. Registered as a singleton and surfaced via IPluginContext.Radio (gated
+// on the capability in PluginManager). Copyright (C) 2026 contributors.
+
+using Zeus.Contracts;
+using Zeus.Plugins.Contracts;
+
+namespace Zeus.Server;
+
+internal sealed class RadioStateReader : IRadioStateReader, IDisposable
+{
+    private readonly RadioService _radio;
+    private long _lastFreq;
+    private string _lastMode;
+    private volatile bool _mox;
+
+    public RadioStateReader(RadioService radio)
+    {
+        _radio = radio;
+        var s = _radio.Snapshot();
+        _lastFreq = s.VfoHz;
+        _lastMode = s.Mode.ToString();
+        _radio.StateChanged += OnStateChanged;
+        _radio.MoxChanged += OnMoxChanged;
+    }
+
+    public long FrequencyHz => _radio.Snapshot().VfoHz;
+    public string Mode => _radio.Snapshot().Mode.ToString();
+    public string Band => BandUtils.FreqToBand(_radio.Snapshot().VfoHz) ?? "";
+    public bool Mox => _mox;
+
+    public event Action<long>? FrequencyChanged;
+    public event Action<string>? ModeChanged;
+    public event Action<bool>? MoxChanged;
+
+    private void OnStateChanged(StateDto s)
+    {
+        if (s.VfoHz != _lastFreq)
+        {
+            _lastFreq = s.VfoHz;
+            FrequencyChanged?.Invoke(s.VfoHz);
+        }
+        var mode = s.Mode.ToString();
+        if (!string.Equals(mode, _lastMode, StringComparison.Ordinal))
+        {
+            _lastMode = mode;
+            ModeChanged?.Invoke(mode);
+        }
+    }
+
+    private void OnMoxChanged(bool on)
+    {
+        _mox = on;
+        MoxChanged?.Invoke(on);
+    }
+
+    public void Dispose()
+    {
+        _radio.StateChanged -= OnStateChanged;
+        _radio.MoxChanged -= OnMoxChanged;
+    }
+}

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -398,6 +398,12 @@ public static class ZeusHost
         // the capability in PluginManager). Enables plugin keyers (RTTY/voice).
         builder.Services.AddSingleton<Zeus.Plugins.Contracts.IRadioController, RadioController>();
 
+        // RadioStateReader gives a plugin holding ReadRadioState the operator's
+        // current VFO / mode / band / MOX (read-only), wrapping RadioService.
+        // Surfaced via IPluginContext.Radio (gated on the capability in
+        // PluginManager). Voyeur uses it for per-session frequency/band metadata.
+        builder.Services.AddSingleton<Zeus.Plugins.Contracts.IRadioStateReader, RadioStateReader>();
+
         // PluginQrzLookup surfaces the core QrzService to plugins (gated on the
         // NetworkAccess capability in PluginManager) so a plugin reuses the
         // operator's stored QRZ credentials + rate-limit gate instead of asking


### PR DESCRIPTION
**Phase 1 prerequisite for the Voyeur extraction** (the gap found during Phase 0).

`PluginManager` resolves `IRadioStateReader` from DI to populate `IPluginContext.Radio` (gated on `ReadRadioState`), but **no host adapter was ever registered** — so `IPluginContext.Radio` resolved `null`. The Voyeur plugin needs current VFO/mode/band for session metadata (in-core it read `RadioService.Snapshot()` + `BandUtils.FreqToBand`).

- New `RadioStateReader` wraps `RadioService`: `FrequencyHz`/`Mode`/`Band`/`Mox` from `Snapshot()`, band via `BandUtils.FreqToBand` (matches the in-core value), and `FrequencyChanged`/`ModeChanged`/`MoxChanged` raised off `RadioService.StateChanged` + `MoxChanged`.
- Registered as a singleton alongside `RadioController`/`PluginQrzLookup`.

Build green, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)