### PR TITLE
feat(tx): TX pre-key (MOX) delay for external-amp T/R sequencing (#630)

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -282,6 +282,19 @@ public sealed record StateDto(
     // would make pressing TUN appear to do nothing on first key.
     int TunePct = 10,
 
+    // ---- TX pre-key (MOX) delay ----
+    // Milliseconds to withhold modulated RF after a UI MOX/TUNE key-down so an
+    // external amplifier's T/R relay has time to settle before RF appears
+    // (Thetis "RF Delay" parity; issue #630). Zeus keys only via the software
+    // MOX bit — there is no hardware PTT-OUT line — so this is framed as a MOX
+    // delay. 0..500, default 0 = no behaviour change. The keying bit is still
+    // asserted immediately on key-down; only the IQ is muted (replaced with
+    // silence, never dropped — dropping starves the P2 DUC FIFO). Persisted to
+    // LiteDB via RadioStateStore, same pattern as DrivePct. The setter clamps
+    // this strictly below the PureSignal MOX hold-off so PS can never try to
+    // calibrate on muted RF — see RadioService.SetTxMoxPreKeyDelayMs.
+    int TxMoxPreKeyDelayMs = 0,
+
     // Hardware NCO frequency in Hz. Independent of VfoHz: the dial roams over
     // the sampled spectrum while the radio's hardware centre stays put.
     // Updated only by explicit calls to <c>POST /api/radio/lo</c> (or by the
@@ -358,6 +371,10 @@ public sealed record AttenuatorSetRequest(int Db);
 public sealed record MoxSetRequest(bool On);
 
 public sealed record DriveSetRequest(int Percent);
+
+/// <summary>TX pre-key (MOX) delay in milliseconds, 0..500. See
+/// <see cref="StateDto.TxMoxPreKeyDelayMs"/>.</summary>
+public sealed record TxPreKeyDelaySetRequest(int DelayMs);
 
 // TUN has its own drive % so the operator can pre-set a lower tune level
 // without touching the MOX drive. Same per-band PA gain compensates both,

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -103,6 +103,12 @@ public sealed class RadioService : IDisposable
     // the same per-band PA gain gives equal watts at equal percentages). piHPSDR
     // default is 10 — a 0 default would be "press TUN, nothing happens".
     private int _tunePct = 10;
+    // TX pre-key (MOX) delay ms (0..500). Authoritative copy read by TxService
+    // on the MOX rising edge to arm the IQ-mute window; the StateDto mirror is
+    // for the frontend. Always kept strictly below the PS MOX hold-off so PS
+    // never calibrates on muted RF — see SetTxMoxPreKeyDelayMs / ClampPreKeyToPs.
+    // Issue #630.
+    private int _txMoxPreKeyDelayMs;
     // Which drive % the next frame uses. Latched via NotifyTunActive from
     // TxService whenever the MOX/TUN keying state changes so a drag on either
     // slider during a live TX picks the right source without polling.
@@ -265,6 +271,11 @@ public sealed class RadioService : IDisposable
             _cwTxFilter = new(rsSnap.CwTxFilterLoAbs, rsSnap.CwTxFilterHiAbs);
             _drivePct = Math.Clamp(rsSnap.DrivePct, 0, 100);
             _tunePct = Math.Clamp(rsSnap.TunePct, 0, 100);
+            // Hydrate the TX pre-key delay, then clamp it below the persisted PS
+            // MOX hold-off so a hand-edited DB row can't break the invariant.
+            _txMoxPreKeyDelayMs = ClampPreKeyToPs(
+                Math.Clamp(rsSnap.TxMoxPreKeyDelayMs, 0, MaxPreKeyDelayMs),
+                ps?.MoxDelaySec ?? 0.2);
         }
 
         _state = new(
@@ -322,6 +333,7 @@ public sealed class RadioService : IDisposable
             // become the only path that puts these into the broadcast.
             DrivePct: Volatile.Read(ref _drivePct),
             TunePct: Volatile.Read(ref _tunePct),
+            TxMoxPreKeyDelayMs: Volatile.Read(ref _txMoxPreKeyDelayMs),
             // Hardware NCO — persisted in RadioStateStore so a restart resumes
             // on the same physical centre. RadioLoHz snaps to VfoHz on legacy
             // rows (RadioLoHz==0 — e.g. rows written by the old CTUN-off
@@ -1216,6 +1228,62 @@ public sealed class RadioService : IDisposable
         RecomputePaAndPush();
     }
 
+    // ---- TX pre-key (MOX) delay (issue #630) -----------------------------
+    // Max operator-settable pre-key delay. Thetis RF-Delay parity range.
+    internal const int MaxPreKeyDelayMs = 500;
+    // Safety margin the pre-key window must stay below the PS MOX hold-off by,
+    // so the IQ mute is fully open before WDSP calcc can leave LMOXDELAY and
+    // start binning feedback samples. A pre-key window that outlasts the PS
+    // hold-off would let PS collect zero-envelope samples → COLLECT never
+    // completes → the documented PS calibration stall. 50 ms is comfortably
+    // longer than one WDSP TX block at any supported rate.
+    private const int PsPreKeyMarginMs = 50;
+
+    // Clamp a requested pre-key delay to [0, MaxPreKeyDelayMs] AND strictly
+    // below (psMoxDelaySec*1000 - margin). With the default PS hold-off of
+    // 200 ms this caps the pre-key at 150 ms — ample for amp T/R sequencing
+    // (the #630 reporter needs ~30 ms) while keeping PS safe by construction.
+    private static int ClampPreKeyToPs(int requestedMs, double psMoxDelaySec)
+    {
+        int ceiling = (int)(psMoxDelaySec * 1000.0) - PsPreKeyMarginMs;
+        if (ceiling < 0) ceiling = 0;
+        if (ceiling > MaxPreKeyDelayMs) ceiling = MaxPreKeyDelayMs;
+        return Math.Clamp(requestedMs, 0, ceiling);
+    }
+
+    /// <summary>
+    /// Set the TX pre-key (MOX) delay in milliseconds. Clamped to
+    /// [0, <see cref="MaxPreKeyDelayMs"/>] and hard-clamped strictly below the
+    /// current PureSignal MOX hold-off (bidirectional invariant — the PS setter
+    /// re-clamps this downward too). Returns the updated snapshot so the caller
+    /// can surface the actually-applied value (which may be lower than asked).
+    /// </summary>
+    public StateDto SetTxMoxPreKeyDelayMs(int ms)
+    {
+        int clamped = ClampPreKeyToPs(ms, Snapshot().PsMoxDelaySec);
+        Interlocked.Exchange(ref _txMoxPreKeyDelayMs, clamped);
+        Mutate(s => s with { TxMoxPreKeyDelayMs = clamped });
+        return Snapshot();
+    }
+
+    /// <summary>Authoritative pre-key delay (ms) read by TxService on the MOX
+    /// rising edge. Already PS-clamped.</summary>
+    public int TxMoxPreKeyDelayMs => Volatile.Read(ref _txMoxPreKeyDelayMs);
+
+    // Re-clamp the stored pre-key delay after the PS MOX hold-off changed, so
+    // lowering PsMoxDelaySec can never leave a now-too-large pre-key window in
+    // place. Called from SetPsAdvanced after the PS mutate commits.
+    private void ReclampPreKeyToPs()
+    {
+        int current = Volatile.Read(ref _txMoxPreKeyDelayMs);
+        int reclamped = ClampPreKeyToPs(current, Snapshot().PsMoxDelaySec);
+        if (reclamped != current)
+        {
+            Interlocked.Exchange(ref _txMoxPreKeyDelayMs, reclamped);
+            Mutate(s => s with { TxMoxPreKeyDelayMs = reclamped });
+        }
+    }
+
     /// <summary>
     /// Forward the on-board CW keyer config (speed + mode) to the connected
     /// radio's C&amp;C register 0x0B, and remember it so a reconnect re-applies
@@ -1569,6 +1637,9 @@ public sealed class RadioService : IDisposable
             PsHwPeak = req.HwPeak ?? s.PsHwPeak,
             PsIntsSpiPreset = req.IntsSpiPreset ?? s.PsIntsSpiPreset,
         });
+        // If the PS MOX hold-off just dropped, shrink the pre-key window so the
+        // pre-key < PS-hold-off invariant holds regardless of setter ordering.
+        ReclampPreKeyToPs();
         PersistPsState();
         return Snapshot();
     }
@@ -1843,6 +1914,7 @@ public sealed class RadioService : IDisposable
                 CwTxFilterLoAbs = cwTx.LoAbs,   CwTxFilterHiAbs = cwTx.HiAbs,
                 DrivePct = snap.DrivePct,
                 TunePct = snap.TunePct,
+                TxMoxPreKeyDelayMs = snap.TxMoxPreKeyDelayMs,
                 RadioLoHz = snap.RadioLoHz,
                 UpdatedUtc = DateTime.UtcNow,
             });

--- a/Zeus.Server.Hosting/RadioStateStore.cs
+++ b/Zeus.Server.Hosting/RadioStateStore.cs
@@ -166,6 +166,8 @@ public sealed class RadioStateEntry
     // TUN drive slider % (0..100). Default 10 mirrors RadioService._tunePct seed —
     // a 0 default would make pressing TUN appear to do nothing.
     public int TunePct { get; set; } = 10;
+    // TX pre-key (MOX) delay ms (0..500). Default 0 = no delay. Issue #630.
+    public int TxMoxPreKeyDelayMs { get; set; }
     // Hardware NCO at last flush. Persisted so a restart retunes the radio
     // to the same physical centre the operator was last looking at. Zero on
     // legacy rows (pre-CTUN, or rows written by the old CTUN-off branch);

--- a/Zeus.Server.Hosting/TxAudioIngest.cs
+++ b/Zeus.Server.Hosting/TxAudioIngest.cs
@@ -90,6 +90,11 @@ public sealed class TxAudioIngest : IDisposable
     // (512 in / 4096 iq) profiles so we don't reallocate at protocol switch.
     private readonly float[] _scratchMic = new float[1024];
     private readonly float[] _scratchIq = new float[4096];
+    // All-zero IQ used to substitute silence during the pre-key (MOX) delay
+    // window (issue #630). Same size as _scratchIq, never written, so the
+    // modulated samples in _scratchIq stay intact for the peak diagnostic — we
+    // mute by writing FROM this buffer, not by zeroing _scratchIq in place.
+    private readonly float[] _muteIq = new float[4096];
 
     private long _totalMicSamples;
     private long _totalTxBlocks;
@@ -147,7 +152,8 @@ public sealed class TxAudioIngest : IDisposable
         ILogger<TxAudioIngest> log)
         : this(ring, () => pipeline.CurrentEngine, () => tx.IsMoxOn, hub, log,
                forwardP2: iq => pipeline.ForwardTxIqToP2(iq.Span),
-               txOwnedByTuneDriver: () => tx.IsTunOn || tx.IsTwoToneOn)
+               txOwnedByTuneDriver: () => tx.IsTunOn || tx.IsTwoToneOn,
+               preKeyOpenAtTicks: () => tx.PreKeyOpenAtTicks)
     {
     }
 
@@ -164,7 +170,8 @@ public sealed class TxAudioIngest : IDisposable
         ILogger<TxAudioIngest> log,
         Action<ReadOnlyMemory<float>>? forwardP2 = null,
         Action<int>? onWdspConsumed = null,
-        Func<bool>? txOwnedByTuneDriver = null)
+        Func<bool>? txOwnedByTuneDriver = null,
+        Func<long>? preKeyOpenAtTicks = null)
     {
         _ring = ring;
         _engineProvider = engineProvider;
@@ -172,6 +179,7 @@ public sealed class TxAudioIngest : IDisposable
         _forwardP2 = forwardP2;
         _onWdspConsumed = onWdspConsumed;
         _txOwnedByTuneDriver = txOwnedByTuneDriver ?? (static () => false);
+        _preKeyOpenAtTicks = preKeyOpenAtTicks ?? (static () => 0L);
         _hub = hub;
         _log = log;
         _handler = OnMicPcmBytesFromMic;
@@ -186,6 +194,13 @@ public sealed class TxAudioIngest : IDisposable
     // mic capture keeps feeding here during a two-tone; web has no native mic so
     // only TxTuneDriver drove it and it stayed clean.
     private readonly Func<bool> _txOwnedByTuneDriver;
+    // Pre-key (MOX) delay window deadline in Stopwatch ticks, supplied by
+    // TxService (issue #630). While Stopwatch.GetTimestamp() is below this
+    // value AND the block is genuine live-mic IQ (not WAV-over-air playback),
+    // we substitute silence for the modulated IQ so an external amp's T/R relay
+    // settles before RF appears. 0 = no window (the default-0 setting, CW, TUN,
+    // two-tone, TCI, hardware-PTT — all unset or cleared by TxService).
+    private readonly Func<long> _preKeyOpenAtTicks;
 
     // Cross-thread handoff: written from the TCI timer thread (Start/Stop of
     // the TX_CHRONO service), read every audio block from the WDSP worker.
@@ -372,12 +387,37 @@ public sealed class TxAudioIngest : IDisposable
                     // a monitor toggle would put the radio on the air.
                     if (moxNow)
                     {
+                        // Pre-key (MOX) delay window (issue #630): if still inside
+                        // the window, substitute silence for the modulated IQ so
+                        // the amp T/R relay settles before RF appears. We still
+                        // WRITE (a zero block of the same length) rather than drop
+                        // — dropping would starve the P2 DUC FIFO and produce the
+                        // exact bare/gappy carrier the feature exists to prevent.
+                        // WAV-over-air playback is exempt: the operator already
+                        // keyed and the clip head is position-locked, so muting it
+                        // would clip the intro.
+                        long openAt = _preKeyOpenAtTicks();
+                        bool wavRecent = false;
+                        if (openAt != 0L)
+                        {
+                            long lastWav = Volatile.Read(ref _lastWavTickMs);
+                            wavRecent = lastWav != 0
+                                && Environment.TickCount64 - lastWav < TciHysteresisMs;
+                        }
+                        bool mute = openAt != 0L
+                            && System.Diagnostics.Stopwatch.GetTimestamp() < openAt
+                            && !wavRecent;
+
                         // P1 path — EP2 packer in Protocol1Client drains the ring.
-                        _ring.Write(iqSpan);
+                        _ring.Write(mute
+                            ? new ReadOnlySpan<float>(_muteIq, 0, 2 * produced)
+                            : iqSpan);
                         // P2 path — Protocol2Client's 1029-port DUC sender. No-op
                         // when P2 isn't the active backend so both protocols share
                         // this seam cleanly. Mirrors TxTuneDriver's dual-write.
-                        _forwardP2?.Invoke(new ReadOnlyMemory<float>(_scratchIq, 0, 2 * produced));
+                        _forwardP2?.Invoke(mute
+                            ? new ReadOnlyMemory<float>(_muteIq, 0, 2 * produced)
+                            : new ReadOnlyMemory<float>(_scratchIq, 0, 2 * produced));
                     }
                     _totalTxBlocks++;
                     var onConsumed = Volatile.Read(ref _onWdspConsumed);

--- a/Zeus.Server.Hosting/TxService.cs
+++ b/Zeus.Server.Hosting/TxService.cs
@@ -63,6 +63,25 @@ public sealed class TxService
     // the owning source can drop MOX, except UI (master override) and
     // <see cref="TryTripForAlert"/> (always wins). Null when MOX is off.
     private MoxSource? _moxOwner;
+    // TX pre-key (MOX) delay window deadline, in Stopwatch ticks (issue #630).
+    // 0 = no active window. Armed on a UI MOX/TUNE rising edge in a voice mode
+    // when RadioService.TxMoxPreKeyDelayMs > 0; TxAudioIngest reads it on the
+    // audio thread and substitutes silence for modulated IQ until the deadline,
+    // so an external amp's T/R relay settles before RF appears. Cleared on every
+    // MOX-off, TUN-on, two-tone, and trip so a stale deadline can never bleed
+    // into a later transmission. Written under _sync, read lock-free via
+    // Interlocked elsewhere.
+    private long _preKeyOpenAtTicks;
+
+    /// <summary>Stopwatch-tick deadline until which modulated TX IQ should be
+    /// muted (silence substituted) after a UI MOX/TUNE key-down. 0 = no mute.
+    /// Read by <see cref="TxAudioIngest"/> on the audio thread.</summary>
+    public long PreKeyOpenAtTicks => Interlocked.Read(ref _preKeyOpenAtTicks);
+
+    // CW is excluded from the pre-key window: a blanket delay would clip the
+    // first dit, and Thetis's RF Delay is likewise non-CW. Mirrors
+    // ExternalPttService.IsCwMode.
+    private static bool IsCwMode(RxMode mode) => mode is RxMode.CWU or RxMode.CWL;
 
     public TxService(RadioService radio, DspPipelineService pipeline, StreamingHub hub, IBandPlanService bandPlan, ILogger<TxService> log)
     {
@@ -184,6 +203,17 @@ public sealed class TxService
 
         if (on && !CheckBandGuard(out error)) return false;
 
+        // Pre-key (MOX) delay arming inputs (issue #630). Read RadioService
+        // OUTSIDE _sync — Snapshot()/TxMoxPreKeyDelayMs take the RadioService
+        // lock and must never nest under _sync. Only a UI-sourced key-down in a
+        // voice (non-CW) mode arms the IQ-mute window; TCI / hardware-PTT / CWX /
+        // plugin keying never arm it.
+        int preKeyMs = on && source == MoxSource.UI ? _radio.TxMoxPreKeyDelayMs : 0;
+        bool armPreKey = preKeyMs > 0 && !IsCwMode(_radio.Snapshot().Mode);
+        long preKeyDelayTicks = armPreKey
+            ? (long)(preKeyMs / 1000.0 * System.Diagnostics.Stopwatch.Frequency)
+            : 0;
+
         bool wasTunOn;
         bool? txActiveCaptured;
         lock (_sync)
@@ -212,11 +242,15 @@ public sealed class TxService
                 _tunStartedAt = null;
                 _moxStartedAt = DateTime.UtcNow;
                 _moxOwner = source;
+                // Anchor the mute deadline at the same instant we stamp MOX-on.
+                Interlocked.Exchange(ref _preKeyOpenAtTicks,
+                    armPreKey ? System.Diagnostics.Stopwatch.GetTimestamp() + preKeyDelayTicks : 0);
             }
             else
             {
                 _moxStartedAt = null;
                 _moxOwner = null;
+                Interlocked.Exchange(ref _preKeyOpenAtTicks, 0);
             }
             _moxOn = on;
             txActiveCaptured = CaptureTxActiveChangeUnderLock();
@@ -290,6 +324,9 @@ public sealed class TxService
                 // gate in TrySetMox correctly rejects a foreign drop while
                 // the two-tone test is armed.
                 _moxOwner = MoxSource.UI;
+                // Two-tone excitation comes from TxTuneDriver/PostGen, not the
+                // mic seam, so it is never pre-key-muted; clear any window.
+                Interlocked.Exchange(ref _preKeyOpenAtTicks, 0);
             }
             else
             {
@@ -357,6 +394,9 @@ public sealed class TxService
                 _moxStartedAt = null;
                 // Whoever owned MOX just lost the channel — TUN took it.
                 _moxOwner = null;
+                // TUN IQ comes from TxTuneDriver, not the muted mic seam; clear
+                // any pending pre-key window so a stale deadline can't mute it.
+                Interlocked.Exchange(ref _preKeyOpenAtTicks, 0);
                 _tunStartedAt = DateTime.UtcNow;
             }
             else
@@ -413,6 +453,7 @@ public sealed class TxService
             // Trip always wins regardless of owner. Drop ownership so the
             // next rising edge starts from a clean source.
             _moxOwner = null;
+            Interlocked.Exchange(ref _preKeyOpenAtTicks, 0);
             txActiveCaptured = CaptureTxActiveChangeUnderLock();
         }
 

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -594,6 +594,20 @@ public static class ZeusEndpoints
             return Results.Ok(new { drivePercent = req.Percent });
         });
 
+        // TX pre-key (MOX) delay (issue #630). Withholds modulated RF for N ms
+        // after a UI MOX/TUNE key-down so an external amp's T/R relay settles
+        // before RF appears. A standalone TX-sequencing setting — deliberately
+        // NOT routed through /api/tx/ps/advanced. The server clamps below the PS
+        // MOX hold-off, so the echoed value may be lower than requested.
+        app.MapPost("/api/tx/prekey-delay", (TxPreKeyDelaySetRequest req, RadioService r) =>
+        {
+            log.LogInformation("api.tx.prekeyDelay ms={Ms}", req.DelayMs);
+            if (req.DelayMs < 0 || req.DelayMs > 500)
+                return Results.BadRequest(new { error = "delayMs must be 0..500" });
+            var state = r.SetTxMoxPreKeyDelayMs(req.DelayMs);
+            return Results.Ok(new { txMoxPreKeyDelayMs = state.TxMoxPreKeyDelayMs });
+        });
+
         // TUN drive %. Symmetric with /api/tx/drive; the same PA-gain math applies,
         // so equal slider positions emit equal watts. Backend selects between the
         // two sources based on whether TUN is keyed (TxService.TrySetTun →

--- a/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
+++ b/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
@@ -43,6 +43,7 @@
 // License for details.
 
 using System.Buffers.Binary;
+using System.Diagnostics;
 using Microsoft.Extensions.Logging.Abstractions;
 using Zeus.Contracts;
 using Zeus.Dsp;
@@ -285,5 +286,86 @@ public class TxAudioIngestTests
         ingest.OnMicPcmBytesFromMic(payload);   // gated — TCI just fed
         ingest.OnMicPcmBytesFromMic(payload);   // still gated
         Assert.Equal(afterTci, ingest.TotalMicSamples);
+    }
+
+    // ---- Pre-key (MOX) delay window — issue #630 ----------------------------
+
+    // A pre-key window that is still open substitutes silence for the modulated
+    // IQ, but MUST still process the block and write a same-length zero block to
+    // BOTH transports — dropping the write would starve the P2 DUC FIFO and emit
+    // the bare/gappy carrier the feature exists to prevent.
+    [Fact]
+    public void PreKeyWindowOpen_MutesWireIq_ButStillProcessesAndFeeds()
+    {
+        var engine = new StubEngine { BlockSize = 1024 };
+        var ring = new TxIqRing();
+        var hub = new StreamingHub(new NullLogger<StreamingHub>());
+        float[]? lastP2 = null;
+        // Deadline ~1 s in the future → window is open for the whole test.
+        long openAt = Stopwatch.GetTimestamp() + Stopwatch.Frequency;
+        using var ingest = new TxAudioIngest(
+            ring, () => engine, () => true, hub, new NullLogger<TxAudioIngest>(),
+            forwardP2: iq => lastP2 = iq.ToArray(),
+            preKeyOpenAtTicks: () => openAt);
+
+        var payload = BuildMicPcmPayload(_ => 0.5f);
+        ingest.OnMicPcmBytes(payload);     // 960 — accumulates, no block yet
+        ingest.OnMicPcmBytes(payload);     // ≥1024 — one block flushed
+
+        Assert.Equal(1, ingest.TotalTxBlocks);          // block still processed
+        Assert.Equal(1, engine.ProcessedBlocks);        // WDSP still ran
+        Assert.Equal(1024, ring.Count);                 // FIFO fed (zeros), not starved
+        Assert.NotNull(lastP2);
+        Assert.All(lastP2!, v => Assert.Equal(0f, v));  // wire IQ is silence
+    }
+
+    // With no window (deadline 0 — the default-0 setting, or after the window
+    // expired) the modulated IQ reaches the wire byte-for-byte as before.
+    [Fact]
+    public void NoPreKeyWindow_PassesModulatedIq()
+    {
+        var engine = new StubEngine { BlockSize = 1024 };
+        var ring = new TxIqRing();
+        var hub = new StreamingHub(new NullLogger<StreamingHub>());
+        float[]? lastP2 = null;
+        using var ingest = new TxAudioIngest(
+            ring, () => engine, () => true, hub, new NullLogger<TxAudioIngest>(),
+            forwardP2: iq => lastP2 = iq.ToArray(),
+            preKeyOpenAtTicks: () => 0L);   // no window
+
+        var payload = BuildMicPcmPayload(_ => 0.5f);
+        ingest.OnMicPcmBytes(payload);
+        ingest.OnMicPcmBytes(payload);
+
+        Assert.Equal(1, ingest.TotalTxBlocks);
+        Assert.NotNull(lastP2);
+        // StubEngine writes I = mic (0.5), Q = 0 — modulated samples present.
+        Assert.Contains(lastP2!, v => v == 0.5f);
+    }
+
+    // WAV-over-air playback is exempt from the mute even while the window is
+    // open: the operator already keyed and the clip head is position-locked, so
+    // muting it would clip the intro. The WAV source path sets the recency
+    // marker the mute branch checks.
+    [Fact]
+    public void PreKeyWindowOpen_DoesNotMuteWavOverAir()
+    {
+        var engine = new StubEngine { BlockSize = 1024 };
+        var ring = new TxIqRing();
+        var hub = new StreamingHub(new NullLogger<StreamingHub>());
+        float[]? lastP2 = null;
+        long openAt = Stopwatch.GetTimestamp() + Stopwatch.Frequency;
+        using var ingest = new TxAudioIngest(
+            ring, () => engine, () => true, hub, new NullLogger<TxAudioIngest>(),
+            forwardP2: iq => lastP2 = iq.ToArray(),
+            preKeyOpenAtTicks: () => openAt);
+
+        var payload = BuildMicPcmPayload(_ => 0.5f);
+        ingest.OnMicPcmBytesFromWav(payload);   // stamps WAV recency
+        ingest.OnMicPcmBytesFromWav(payload);   // flush — exempt from mute
+
+        Assert.Equal(1, ingest.TotalTxBlocks);
+        Assert.NotNull(lastP2);
+        Assert.Contains(lastP2!, v => v == 0.5f);   // not muted
     }
 }

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -223,6 +223,10 @@ export type RadioStateDto = {
   // persisted value on connect.
   drivePercent: number;
   tunePercent: number;
+  // TX pre-key (MOX) delay in ms (issue #630). Withholds RF after a UI MOX/TUNE
+  // key-down so an external amp's T/R relay settles before RF. Server-clamped
+  // below the PS MOX hold-off; hydrated on connect like the drive sliders.
+  txMoxPreKeyDelayMs: number;
   twoToneFreq1: number;
   twoToneFreq2: number;
   twoToneMag: number;
@@ -498,6 +502,8 @@ export function normalizeState(raw: unknown): RadioStateDto {
     // older server (no DrivePct/TunePct fields) deserialises cleanly.
     drivePercent: typeof r.drivePct === 'number' ? r.drivePct : 0,
     tunePercent: typeof r.tunePct === 'number' ? r.tunePct : 10,
+    txMoxPreKeyDelayMs:
+      typeof r.txMoxPreKeyDelayMs === 'number' ? r.txMoxPreKeyDelayMs : 0,
     twoToneFreq1: typeof r.twoToneFreq1 === 'number' ? r.twoToneFreq1 : 700,
     twoToneFreq2: typeof r.twoToneFreq2 === 'number' ? r.twoToneFreq2 : 1900,
     twoToneMag: typeof r.twoToneMag === 'number' ? r.twoToneMag : 0.49,
@@ -1173,6 +1179,28 @@ export function setDrive(
     (raw) => {
       const v = (raw as { drivePercent?: unknown }).drivePercent;
       return { drivePercent: typeof v === 'number' ? v : 0 };
+    },
+  );
+}
+
+// TX pre-key (MOX) delay: POST /api/tx/prekey-delay { delayMs }. Returns the
+// server-applied value, which may be lower than requested (clamped below the
+// PS MOX hold-off). Issue #630.
+export function setTxPreKeyDelay(
+  delayMs: number,
+  signal?: AbortSignal,
+): Promise<{ txMoxPreKeyDelayMs: number }> {
+  return jsonFetch(
+    '/api/tx/prekey-delay',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ delayMs: Math.round(delayMs) }),
+      signal,
+    },
+    (raw) => {
+      const v = (raw as { txMoxPreKeyDelayMs?: unknown }).txMoxPreKeyDelayMs;
+      return { txMoxPreKeyDelayMs: typeof v === 'number' ? v : 0 };
     },
   );
 }

--- a/zeus-web/src/components/PsSettingsPanel.tsx
+++ b/zeus-web/src/components/PsSettingsPanel.tsx
@@ -28,6 +28,7 @@ import {
   setPsMonitor,
   resetPs,
   setTwoTone,
+  setTxPreKeyDelay,
 } from '../api/client';
 import { useRadioStore } from '../state/radio-store';
 import { useTxStore } from '../state/tx-store';
@@ -77,6 +78,8 @@ export function PsSettingsPanel() {
   const psSingle = useTxStore((s) => s.psSingle);
   const psPtol = useTxStore((s) => s.psPtol);
   const psAutoAttenuate = useTxStore((s) => s.psAutoAttenuate);
+  const txMoxPreKeyDelayMs = useTxStore((s) => s.txMoxPreKeyDelayMs);
+  const setTxMoxPreKeyDelayMsLocal = useTxStore((s) => s.setTxMoxPreKeyDelayMs);
   const psMoxDelaySec = useTxStore((s) => s.psMoxDelaySec);
   const psLoopDelaySec = useTxStore((s) => s.psLoopDelaySec);
   const psAmpDelayNs = useTxStore((s) => s.psAmpDelayNs);
@@ -534,6 +537,27 @@ export function PsSettingsPanel() {
             Timing
             <span className="ps-card-hint">defaults assume your radio</span>
           </h4>
+
+          <FieldRow
+            label="TX delay"
+            help="Wait after key-down before RF (external amp T/R relay). 0 for CW/digital. Issue #630."
+          >
+            <NumberInput
+              value={txMoxPreKeyDelayMs}
+              min={0}
+              max={500}
+              step={5}
+              unit="ms"
+              onChange={(v) => {
+                // Optimistic local update; reconcile with the server-applied
+                // value, which may be clamped below the PS MOX hold-off below.
+                setTxMoxPreKeyDelayMsLocal(v);
+                setTxPreKeyDelay(v)
+                  .then((r) => setTxMoxPreKeyDelayMsLocal(r.txMoxPreKeyDelayMs))
+                  .catch(() => {});
+              }}
+            />
+          </FieldRow>
 
           <FieldRow
             label="MOX delay"

--- a/zeus-web/src/state/tx-store.ts
+++ b/zeus-web/src/state/tx-store.ts
@@ -204,6 +204,12 @@ export type TxState = {
   setPsPtol: (on: boolean) => void;
   psAutoAttenuate: boolean;
   setPsAutoAttenuate: (on: boolean) => void;
+  // TX pre-key (MOX) delay in ms (issue #630) — withholds RF after a UI
+  // MOX/TUNE key-down so an external amp's T/R relay settles before RF. Server
+  // is authoritative (clamped below the PS MOX hold-off); mirrored here so the
+  // input doesn't flicker on reload.
+  txMoxPreKeyDelayMs: number;
+  setTxMoxPreKeyDelayMs: (ms: number) => void;
   psMoxDelaySec: number;
   setPsMoxDelaySec: (s: number) => void;
   psLoopDelaySec: number;
@@ -383,6 +389,8 @@ export const useTxStore = create<TxState>()(
       setPsPtol: (on) => set({ psPtol: on }),
       psAutoAttenuate: true,
       setPsAutoAttenuate: (on) => set({ psAutoAttenuate: on }),
+      txMoxPreKeyDelayMs: 0,
+      setTxMoxPreKeyDelayMs: (ms) => set({ txMoxPreKeyDelayMs: ms }),
       psMoxDelaySec: 0.2,
       setPsMoxDelaySec: (s) => set({ psMoxDelaySec: s }),
       psLoopDelaySec: 0,
@@ -448,6 +456,7 @@ export const useTxStore = create<TxState>()(
           tunePercent: s.tunePercent,
           micGainDb: s.micGainDb,
           levelerMaxGainDb: s.levelerMaxGainDb,
+          txMoxPreKeyDelayMs: s.txMoxPreKeyDelayMs,
           psAuto: s.psAuto,
           psPtol: s.psPtol,
           psAutoAttenuate: s.psAutoAttenuate,
@@ -494,6 +503,7 @@ export const useTxStore = create<TxState>()(
       partialize: (s) => ({
         // PS tuning is persisted server-side too, but we mirror it here so
         // the slider seeks don't flicker on first paint after a reload.
+        txMoxPreKeyDelayMs: s.txMoxPreKeyDelayMs,
         psAuto: s.psAuto,
         psPtol: s.psPtol,
         psAutoAttenuate: s.psAutoAttenuate,


### PR DESCRIPTION
Closes the gap reported in #630 (Bob KC9RF): there is no way to delay RF after keying, so amps like the Flex PGL / FT-710 see RF before their T/R relay has switched ("RF early"). This adds a **TX pre-key delay** in parity with Thetis's *RF Delay*.

## What it does

When set non-zero, on a **MOX/TUNE key-down** Zeus asserts the keying line to the radio immediately (so the radio's own T/R relay flips right away), but **withholds the modulated RF for N milliseconds**, then lets it flow. That gives an external amp's relay time to settle before RF appears. Default is **0 ms = no change** from today.

Because Zeus keys only through the software MOX bit (there's no hardware PTT-OUT line yet), this is implemented as a **MOX delay**, which is the functional twin of Thetis's RF Delay.

## How it's kept safe (the #630 plan's hard requirement: don't break PureSignal or anything else)

A multi-agent design review drove these guards:

- **Silence is substituted, never dropped.** During the window we send a same-length block of zeros (no carrier), still pumped at full rate — dropping the IQ would starve the Protocol-2 FIFO on the G2 and *cause* a bare carrier, the very thing we're preventing.
- **Only the on-screen MOX/TUNE button arms it, and only in voice modes.** CW (would clip the first dit), TCI/digital (would truncate FT8), hardware footswitch, and CWX/plugin keying are all excluded. TUN/two-tone and protection trips clear the window. **WAV-over-air playback is exempt** so clip intros aren't clipped.
- **The delay is hard-clamped below the PureSignal MOX hold-off** (bidirectional — lowering the PS delay shrinks it too), so PS can never try to calibrate on muted RF and stall.

## Setting & UI

- Range 0–500 ms, persisted across restarts, hydrated from the server on connect (no localStorage clobber).
- New `POST /api/tx/prekey-delay` (standalone, deliberately not part of the PureSignal advanced endpoint).
- UI: a number input in the **PURESIGNAL panel → Timing** card (it groups with the other ms key-down timings).

## 🔴 Maintainer review (Brian / Doug) — design choices flagged

Per CLAUDE.md, these are red-light and want sign-off: the **default (0 ms)**, the **label/help wording**, the **placement** (Timing card), and whether the field should auto-disable in CW/digital modes.

## ⚠️ Not yet bench-tested

This touches the hot TX keying path. It builds clean and the full suite is green (722 server + 152 DSP tests, incl. 3 new pre-key tests), but it **needs G2 (Protocol 2) + HL2 (Protocol 1) bench verification before merge** — confirm no FIFO underrun / bare carrier during the window, PS still converges, and default-0 is byte-identical. **Do not merge** until that's done.

## Open questions for the reporter (Bob KC9RF)

- Your amp relay already follows the MOX bit (asserted immediately), so the relay is *already* early — please confirm the **30 ms RF-withhold** gives the protection you measured.
- v1 covers the **on-screen MOX/TUNE button** only; if you key via footswitch or a digital logger the delay won't apply by design.

Issue: #630
