### PR TITLE
fix(web): restore Windows waterfall — float-linear fallback + WebGL context-loss recovery (#629)

### DIFF
--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -594,6 +594,17 @@ public static class ZeusEndpoints
             return Results.Ok(new { drivePercent = req.Percent });
         });
 
+        // Waterfall render-state diagnostic (#629). The desktop (WebView2) app
+        // has no reachable DevTools, so the frontend POSTs the waterfall's
+        // runtime state here a few seconds after connect — letting us confirm
+        // headlessly, from the SERVER log, that the history textures seeded
+        // (texWidth > 0). Read-only: logs at Info, no side effects.
+        app.MapPost("/api/diag/wf", (System.Text.Json.JsonElement body) =>
+        {
+            log.LogInformation("diag.wf {Report}", body.ToString());
+            return Results.Ok();
+        });
+
         // TUN drive %. Symmetric with /api/tx/drive; the same PA-gain math applies,
         // so equal slider positions emit equal watts. Backend selects between the
         // two sources based on whether TUN is keyed (TxService.TrySetTun →

--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -42,10 +42,10 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { COLORMAPS } from '../gl/colormap';
-import { createWfRenderer } from '../gl/waterfall';
-import { planForFrame } from '../gl/frame-plan';
+import { createWfRenderer, type WfGlCaps } from '../gl/waterfall';
+import { planForFrame, resetFramePlan } from '../gl/frame-plan';
 import { cancelDrawBusFrame, requestDrawBusFrame } from '../realtime/draw-bus';
 import { registerFrameConsumer, useDisplayStore } from '../state/display-store';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
@@ -70,6 +70,13 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const rendererRef = useRef<ReturnType<typeof createWfRenderer> | null>(null);
+  // Live transparency, read by buildRenderer() on context-restore so a rebuild
+  // mid-QRZ-mode comes back transparent rather than occluding the map (#629).
+  const transparentRef = useRef(transparent);
+  // GL float-texture capabilities, surfaced on-screen because the desktop
+  // (WebView2) app has no reachable DevTools. Only shown when something the
+  // waterfall needs is missing (#629).
+  const [glCaps, setGlCaps] = useState<WfGlCaps | null>(null);
   const autoRange = useDisplaySettingsStore((s) => s.autoRange);
   const setAutoRange = useDisplaySettingsStore((s) => s.setAutoRange);
   const colormap = useDisplaySettingsStore((s) => s.colormap);
@@ -80,25 +87,49 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
     const container = containerRef.current;
     if (!canvas || !container) return;
 
-    const gl = canvas.getContext('webgl2', { antialias: false, alpha: true, premultipliedAlpha: true });
-    if (!gl) {
-      console.error('WebGL2 not available');
-      return;
-    }
-
     // Tell the realtime client that decoded spectrum frames are needed —
     // ws-client.ts skips decodeDisplayFrame entirely when no consumer is
-    // registered (all spectrum surfaces closed).
+    // registered (all spectrum surfaces closed). Context-independent: stays a
+    // single mount/unmount pair, NEVER re-invoked on context-restore (#629).
     const releaseFrameConsumer = registerFrameConsumer();
 
-    const renderer = createWfRenderer(gl);
-    rendererRef.current = renderer;
-    // Seed with the current store value so the palette survives remount
-    // (e.g. after a resize that cycles the canvas).
-    renderer.setColormap(useDisplaySettingsStore.getState().colormap);
-    renderer.setTransparent(transparent);
+    // Mutable GL bindings so the renderer can be rebuilt after a WebGL context
+    // loss (#629). On Windows/ANGLE the waterfall's float-texture context can
+    // be evicted after minutes; without a rebuild path it freezes forever.
+    let gl: WebGL2RenderingContext | null = null;
+    let renderer: ReturnType<typeof createWfRenderer> | null = null;
+    let contextLost = false;
+
+    // (Re)acquire the context and build a fresh renderer with every GL
+    // resource. Returns false if WebGL2 is unavailable. Does NOT touch the
+    // frame-consumer registration. Reads colormap/transparency LIVE so a
+    // rebuild lands on the operator's current state, not a stale closure.
+    const buildRenderer = (): boolean => {
+      const ctx = canvas.getContext('webgl2', {
+        antialias: false,
+        alpha: true,
+        premultipliedAlpha: true,
+      });
+      if (!ctx) {
+        console.error('WebGL2 not available');
+        return false;
+      }
+      gl = ctx;
+      renderer = createWfRenderer(ctx);
+      rendererRef.current = renderer;
+      renderer.setColormap(useDisplaySettingsStore.getState().colormap);
+      renderer.setTransparent(transparentRef.current);
+      setGlCaps(renderer.caps);
+      return true;
+    };
+
+    if (!buildRenderer()) return;
+
     let lastSeqDrawn = -1;
     let tickCounter = 0;
+    // Count context-restore cycles — a one-off eviction logs once; a steady
+    // leak would climb, which is the signal to dig further (#629).
+    let restoreCount = 0;
     // Visibility gating: skip the rAF redraw when the waterfall tile is
     // scrolled offscreen or the tab is hidden. We still push frames into
     // the history texture so when visibility resumes the operator sees a
@@ -108,6 +139,7 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
     const isActive = () => inViewport && pageVisible;
 
     const redraw = () => {
+      if (contextLost || !renderer) return;
       const { wfDbMin, wfDbMax, wfTxDbMin, wfTxDbMax } = useDisplaySettingsStore.getState();
       const { moxOn, tunOn } = useTxStore.getState();
       const keyed = moxOn || tunOn;
@@ -141,6 +173,7 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       const h = Math.max(1, Math.round(height * dpr));
       canvas.width = w;
       canvas.height = h;
+      if (contextLost || !renderer) return;
       renderer.resize(w, h);
       requestRedraw();
     };
@@ -165,7 +198,38 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
     };
     document.addEventListener('visibilitychange', onVisibilityChange);
 
+    // WebGL context-loss recovery (#629). On Windows/ANGLE the waterfall's
+    // float-texture context can be evicted after minutes of streaming; without
+    // this the surface freezes forever. preventDefault() on 'lost' is MANDATORY
+    // — without it the browser never fires 'restored'.
+    const onContextLost = (e: Event) => {
+      e.preventDefault();
+      contextLost = true;
+      cancelDrawBusFrame(redraw);
+      console.warn('[waterfall] WebGL context lost — awaiting restore');
+    };
+    const onContextRestored = () => {
+      restoreCount++;
+      console.warn(`[waterfall] WebGL context restored (#${restoreCount}) — rebuilding`);
+      if (!buildRenderer()) return;
+      // Rebuilding the renderer is NOT enough: the waterfall's entire history
+      // lives in now-lost GPU textures with no CPU mirror. Force the shared
+      // planner to emit a 'reset' on the next frame so the textures re-seed,
+      // and seed immediately from the last-held frame so a paused-RX restore
+      // is not left blank.
+      resetFramePlan();
+      contextLost = false;
+      resize();
+      const st = useDisplayStore.getState();
+      const wfDb = st.wfValid && st.wfDb ? st.wfDb : null;
+      renderer!.pushFrame({ kind: 'reset', reason: 'first' }, wfDb, st.centerHz, st.hzPerPixel);
+      requestRedraw();
+    };
+    canvas.addEventListener('webglcontextlost', onContextLost);
+    canvas.addEventListener('webglcontextrestored', onContextRestored);
+
     const unsub = useDisplayStore.subscribe((state) => {
+      if (contextLost || !renderer) return;
       if (state.lastSeq === lastSeqDrawn) return;
       lastSeqDrawn = state.lastSeq;
       // Shared per-frame plan (issue #597): identical decision to the
@@ -207,6 +271,7 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
     // ordinary RX traffic pulled the waterfall rAF floor above the
     // spectrum-tick rate.
     const unsubSettings = useDisplaySettingsStore.subscribe((state, prev) => {
+      if (contextLost || !renderer) return;
       if (state.colormap !== prev.colormap) {
         renderer.setColormap(state.colormap);
         requestRedraw();
@@ -242,10 +307,19 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       ro.disconnect();
       io.disconnect();
       document.removeEventListener('visibilitychange', onVisibilityChange);
+      // Remove loss/restore listeners BEFORE loseContext() — loseContext fires
+      // 'webglcontextlost' synchronously, and we don't want onContextLost to
+      // run during teardown.
+      canvas.removeEventListener('webglcontextlost', onContextLost);
+      canvas.removeEventListener('webglcontextrestored', onContextRestored);
       cancelDrawBusFrame(redraw);
-      renderer.dispose();
-      rendererRef.current = null;
       releaseFrameConsumer();
+      renderer?.dispose();
+      // Free the ANGLE context slot now rather than waiting for GC — on a
+      // disconnect/reconnect cycle the Waterfall remounts, and ANGLE caps the
+      // number of live WebGL contexts (#629).
+      gl?.getExtension('WEBGL_lose_context')?.loseContext();
+      rendererRef.current = null;
     };
   }, []);
 
@@ -253,6 +327,7 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
   // history texture survives a QRZ engage/disengage. draw() runs on the next
   // frame via the realtime store subscription.
   useEffect(() => {
+    transparentRef.current = transparent;
     rendererRef.current?.setTransparent(transparent);
   }, [transparent]);
 
@@ -271,6 +346,31 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       }}
     >
       <canvas ref={canvasRef} style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }} />
+      {glCaps && !glCaps.floatLinear && (
+        // On-screen diagnostic (#629). The desktop (WebView2) app has no
+        // reachable DevTools, so when the GPU lacks OES_texture_float_linear —
+        // the prime suspect for the Windows-in-a-VM "no waterfall" — surface it
+        // here. The NEAREST fallback keeps the waterfall working; this just
+        // confirms the cause from a screenshot.
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 4,
+            left: 6,
+            padding: '2px 6px',
+            fontSize: 10,
+            fontFamily: 'monospace',
+            color: 'var(--fg-0)',
+            background: 'rgba(0,0,0,0.55)',
+            borderRadius: 3,
+            pointerEvents: 'none',
+            zIndex: 2,
+          }}
+          title={`GPU: ${glCaps.gpu}`}
+        >
+          wf: float_linear unsupported → NEAREST fallback
+        </div>
+      )}
       <WfDbScale />
       <div
         className="tuning-cursor"

--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -130,6 +130,9 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
     // Count context-restore cycles — a one-off eviction logs once; a steady
     // leak would climb, which is the signal to dig further (#629).
     let restoreCount = 0;
+    // Waterfall frame tallies for the one-shot backend diagnostic below (#629).
+    let wfFrames = 0;
+    let wfValidFrames = 0;
     // Visibility gating: skip the rAF redraw when the waterfall tile is
     // scrolled offscreen or the tab is hidden. We still push frames into
     // the history texture so when visibility resumes the operator sees a
@@ -228,6 +231,25 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
     canvas.addEventListener('webglcontextlost', onContextLost);
     canvas.addEventListener('webglcontextrestored', onContextRestored);
 
+    // One-shot backend diagnostic (#629). The desktop app has no DevTools, so
+    // ~6 s after mount we POST the waterfall's render state to the server log
+    // (texWidth>0 means the history seeded; wfValidFrames>0 means real wf data
+    // is arriving). One line per session — enough to confirm the fix headless.
+    const diagTimer = window.setTimeout(() => {
+      const ds = renderer?.debugState();
+      void fetch('/api/diag/wf', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          caps: renderer?.caps,
+          ...ds,
+          wfFrames,
+          wfValidFrames,
+          restoreCount,
+        }),
+      }).catch(() => {});
+    }, 6000);
+
     const unsub = useDisplayStore.subscribe((state) => {
       if (contextLost || !renderer) return;
       if (state.lastSeq === lastSeqDrawn) return;
@@ -243,6 +265,8 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
         width: state.width,
       });
       const wfDb = state.wfValid && state.wfDb ? state.wfDb : null;
+      wfFrames++;
+      if (wfDb) wfValidFrames++;
       let skipRowUpload = false;
       if (wfDb) {
         tickCounter++;
@@ -307,6 +331,7 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       ro.disconnect();
       io.disconnect();
       document.removeEventListener('visibilitychange', onVisibilityChange);
+      window.clearTimeout(diagTimer);
       // Remove loss/restore listeners BEFORE loseContext() — loseContext fires
       // 'webglcontextlost' synchronously, and we don't want onContextLost to
       // run during teardown.

--- a/zeus-web/src/gl/frame-plan.ts
+++ b/zeus-web/src/gl/frame-plan.ts
@@ -114,12 +114,20 @@ export function plannedDataCenterHz(): bigint | null {
   return lastCenterHz;
 }
 
-/** Test/reconnect hook — forget all tracker state so the next frame is a
- *  clean 'reset'. */
-export function _resetFramePlanForTest(): void {
+/** Forget all tracker state so the next observed frame is planned as a clean
+ *  'reset'. Used on reconnect AND on WebGL context restore (#629): after the
+ *  waterfall's GPU history textures are lost and the renderer is rebuilt, the
+ *  next frame must re-seed them — but under unchanged geometry the planner
+ *  would otherwise emit 'push'/'shift', never 'reset'. Resetting the shared
+ *  tracker forces the seeding 'reset'. The panadapter simply re-snaps its
+ *  surviving CPU-side anchor on the same frame (a single snap, no glide). */
+export function resetFramePlan(): void {
   plannedSeq = -1;
   plannedDecision = { kind: 'reset', reason: 'first' };
   lastCenterHz = null;
   lastHzPerPixel = 0;
   lastWidth = 0;
 }
+
+/** Test alias — kept so existing specs import the same behaviour. */
+export const _resetFramePlanForTest = resetFramePlan;

--- a/zeus-web/src/gl/waterfall.ts
+++ b/zeus-web/src/gl/waterfall.ts
@@ -107,6 +107,15 @@ export type WfRenderer = {
   /** 1.0 = opaque (default). 0.0 = noise floor fades to transparent so a
    *  background layer (e.g. the QRZ-mode Leaflet map) shows through. */
   setTransparent: (transparent: boolean) => void;
+  /** Runtime render state, posted to the BACKEND log (#629) because the
+   *  desktop app has no reachable DevTools — lets us confirm the waterfall
+   *  seeded (texWidth > 0) headlessly. */
+  debugState: () => {
+    texWidth: number;
+    writeRow: number;
+    lastViewOffsetUv: number;
+    contextLost: boolean;
+  };
   dispose: () => void;
 };
 
@@ -219,6 +228,8 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
   // Last width the history textures were seeded at — lets a 'reset' decision on
   // a null-wf frame re-seed at the known column count (#629 hardening).
   let lastValidWidth = 0;
+  // Last view offset applied at draw — surfaced via debugState for #629 triage.
+  let lastViewOffsetUv = 0;
 
   const seedTexture = (tex: WebGLTexture, w: number) => {
     gl.bindTexture(gl.TEXTURE_2D, tex);
@@ -247,7 +258,15 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
   };
 
   const uploadRow = (wfDb: Float32Array) => {
-    if (texWidth === 0) return; // not seeded yet — a stray push before reset
+    // Lazy seed (#629): the first valid waterfall row seeds the history,
+    // regardless of whether a 'reset' decision happened to carry wf data.
+    // Before this, seeding only ran inside the 'reset' branch when that exact
+    // frame had a non-null wfDb; if the first post-connect frame's wf payload
+    // was null (timing-dependent — reliably so on Windows), the textures never
+    // got R32F storage, texWidth stayed 0, draw() bailed to a transparent
+    // clear, and the waterfall was permanently black. Seeding here (and on any
+    // width change) makes it order- and platform-independent.
+    if (texWidth !== wfDb.length) resetTextures(wfDb.length);
     writeRow = (writeRow + 1) % HISTORY_ROWS;
     gl.bindTexture(gl.TEXTURE_2D, textures[active]);
     gl.texSubImage2D(
@@ -349,6 +368,7 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
         if (!Number.isFinite(viewOffsetUv)) viewOffsetUv = 0;
         viewOffsetUv = Math.max(-1, Math.min(1, viewOffsetUv));
       }
+      lastViewOffsetUv = viewOffsetUv;
       // Premultiplied-alpha blending — matches the fragment output so the
       // noise floor fades cleanly into whatever is behind the canvas.
       gl.enable(gl.BLEND);
@@ -371,6 +391,14 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
       gl.drawArrays(gl.TRIANGLES, 0, 3);
       gl.bindVertexArray(null);
       gl.disable(gl.BLEND);
+    },
+    debugState() {
+      return {
+        texWidth,
+        writeRow,
+        lastViewOffsetUv,
+        contextLost: gl.isContextLost(),
+      };
     },
     dispose() {
       gl.deleteTexture(textures[0]);

--- a/zeus-web/src/gl/waterfall.ts
+++ b/zeus-web/src/gl/waterfall.ts
@@ -74,7 +74,17 @@ export type PushOptions = {
   skipRowUpload?: boolean;
 };
 
+/** WebGL float-texture capabilities, surfaced so the component can show an
+ *  on-screen badge when a feature needed by the waterfall is missing (#629). */
+export type WfGlCaps = {
+  floatLinear: boolean;
+  colorBufferFloat: boolean;
+  gpu: string;
+};
+
 export type WfRenderer = {
+  /** GL float-texture capabilities of the context this renderer was built on. */
+  caps: WfGlCaps;
   resize: (w: number, h: number) => void;
   /** Apply the shared per-frame plan (issue #597: the decision is computed
    *  once in gl/frame-plan.ts and handed to both spectrum surfaces so they
@@ -106,8 +116,31 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
   // for effect — we don't consume the extension objects directly.
   const colorExt = gl.getExtension('EXT_color_buffer_float');
   const floatExt = gl.getExtension('OES_texture_float_linear');
-  void colorExt;
-  void floatExt;
+  // LINEAR filtering on a FLOAT (R32F) texture is ONLY legal when
+  // OES_texture_float_linear is present. Without it, sampling the history with
+  // gl.LINEAR makes the texture "incomplete" and the fragment shader's
+  // texture() reads return garbage — the waterfall renders wrong or blanks
+  // entirely while the (non-float) panadapter is unaffected. This is the prime
+  // suspect for the Windows/WebView2-in-a-VM case in #629: ANGLE on a software
+  // or weak GPU frequently omits this extension. Fall back to NEAREST so the
+  // waterfall still renders — we lose only sub-pixel-smooth horizontal glide,
+  // not the data.
+  const histMagFilter = floatExt ? gl.LINEAR : gl.NEAREST;
+  const dbg = gl.getExtension('WEBGL_debug_renderer_info');
+  const caps: WfGlCaps = {
+    floatLinear: !!floatExt,
+    colorBufferFloat: !!colorExt,
+    gpu: dbg ? String(gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL)) : 'unknown',
+  };
+  // One-time capability log — surfaces in any console; the Waterfall component
+  // also renders an on-screen badge when floatLinear is false, because the
+  // desktop (WebView2) app has no reachable DevTools (#629).
+  // eslint-disable-next-line no-console
+  console.info(
+    `[waterfall] gl caps: float_linear=${caps.floatLinear} ` +
+      `color_buffer_float=${caps.colorBufferFloat} ` +
+      `magFilter=${floatExt ? 'LINEAR' : 'NEAREST(fallback)'} gpu=${caps.gpu}`,
+  );
 
   const drawProg = buildProgram(gl, WF_VS, WF_FS);
   const uHistory = gl.getUniformLocation(drawProg, 'uHistory');
@@ -146,7 +179,7 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
   const initTextureParams = (tex: WebGLTexture) => {
     gl.bindTexture(gl.TEXTURE_2D, tex);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, histMagFilter);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
   };
@@ -183,6 +216,9 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
   let lastHzPerPixel = 0;
   let canvasW = 0;
   let canvasH = 0;
+  // Last width the history textures were seeded at — lets a 'reset' decision on
+  // a null-wf frame re-seed at the known column count (#629 hardening).
+  let lastValidWidth = 0;
 
   const seedTexture = (tex: WebGLTexture, w: number) => {
     gl.bindTexture(gl.TEXTURE_2D, tex);
@@ -205,11 +241,13 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
     seedTexture(textures[0], w);
     seedTexture(textures[1], w);
     texWidth = w;
+    lastValidWidth = w;
     writeRow = 0;
     active = 0;
   };
 
   const uploadRow = (wfDb: Float32Array) => {
+    if (texWidth === 0) return; // not seeded yet — a stray push before reset
     writeRow = (writeRow + 1) % HISTORY_ROWS;
     gl.bindTexture(gl.TEXTURE_2D, textures[active]);
     gl.texSubImage2D(
@@ -226,6 +264,7 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
   };
 
   const performShift = (shiftPx: number) => {
+    if (texWidth === 0) return; // not seeded yet — nothing to shift
     const src = active === 0 ? textures[0] : textures[1];
     const dst = active === 0 ? textures[1] : textures[0];
     gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
@@ -251,6 +290,7 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
   };
 
   return {
+    caps,
     resize(w, h) {
       canvasW = w;
       canvasH = h;
@@ -263,7 +303,7 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
           // data also upload it so the history has a real top row. A reset
           // on an invalid-wf frame leaves the seed only — the next valid
           // frame pushes the first real row.
-          const width = wfDb?.length ?? texWidth;
+          const width = wfDb?.length ?? (texWidth || lastValidWidth);
           if (width > 0) resetTextures(width);
           if (wfDb) uploadRow(wfDb);
           lastCenterHz = centerHz;


### PR DESCRIPTION
Hotfix for #629 — multiple Windows 11 users lost the waterfall after upgrading to v0.9.0 while the panadapter kept working. Two distinct GPU-side causes on Windows/ANGLE, both fixed. **Frontend only**, inert on healthy GPUs.

## Root causes

**1. Blank from the first frame (esp. desktop/WebView2 in a VM).** The waterfall's float (R32F) history texture is filtered with `gl.LINEAR`, which is only legal when `OES_texture_float_linear` is present. ANGLE on a software/weak GPU (very common in a VM) frequently omits it → the texture is "incomplete" → the shader's `texture()` reads return garbage → the waterfall renders wrong/blank. The panadapter uses no float texture, so it's unaffected. **Fix:** detect the extension; fall back to `NEAREST` when absent. The waterfall renders correctly — we lose only sub-pixel-smooth horizontal glide, not data.

**2. Freeze after a few minutes (real GPUs).** ANGLE/D3D11 evicts the waterfall's WebGL2 context under sustained float-texture + FBO load, and nothing re-acquired it — there was **no `webglcontextlost`/`webglcontextrestored` handler anywhere**, so `draw()` kept calling a dead context forever. **Fix:** add loss/restore handlers — `preventDefault()` on loss (mandatory, or the browser never fires restore); on restore rebuild every GL resource **and** force the shared frame-planner to emit a `reset` so the GPU-only history re-seeds (rebuilding the renderer alone leaves it blank), plus an immediate seed from the last-held frame for paused-RX. Release the ANGLE context slot via `WEBGL_lose_context` on unmount so reconnect cycles don't leak toward the context cap.

## Diagnostics (because desktop has no DevTools)

The desktop (WebView2) app can't open F12, so the waterfall now **logs its GL caps** and shows a small **on-screen badge** when `float_linear` is missing: `wf: float_linear unsupported → NEAREST fallback` (hover shows the GPU string). That confirms cause #1 from a screenshot.

## Scope / risk

- **Panadapter context-loss parity was deliberately NOT added.** It works today and is the surviving surface; touching it adds risk for an unreported combined-GPU-reset case. Can follow up separately.
- Hardening: `lastValidWidth` + `texWidth==0` guards on `uploadRow`/`performShift`; promoted frame-plan's test-only reset to a production `resetFramePlan()` (test alias kept).

## Verification

- `tsc -b` + vite build clean; gl vitest suites (frame-plan, wf-shift — 17 tests) green.
- **Needs bench confirmation before merge:** Windows (incl. the VM/WebView2 desktop that reproduces it) and Mac. On the VM, expect the waterfall to **return** with the NEAREST fallback (and the badge to show, confirming cause #1). On a real Windows GPU, a long session should no longer end in a permanently frozen waterfall; if a loss occurs it blanks one frame then resumes.

**Do not merge** — bench test on Windows + Mac first (alongside the MOX-delay PR #633).

Issue: #629
