### PR TITLE
fix(server): guard prefs DB so a corrupt zeus-prefs.db can't stop Zeus launching (#637)

### DIFF
--- a/Zeus.Server.Hosting/PrefsDbPath.cs
+++ b/Zeus.Server.Hosting/PrefsDbPath.cs
@@ -7,6 +7,9 @@
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 
+using LiteDB;
+using Microsoft.Extensions.Logging;
+
 namespace Zeus.Server;
 
 // Central database-path resolver for all zeus-prefs.db stores.
@@ -25,5 +28,153 @@ public static class PrefsDbPath
             Environment.SpecialFolder.LocalApplicationData,
             Environment.SpecialFolderOption.Create);
         return Path.Combine(appDataDir, "Zeus", "zeus-prefs.db");
+    }
+
+    // ---- Startup corruption guard (#637) --------------------------------
+    //
+    // ~20 preference stores share ONE physical zeus-prefs.db, and each opens
+    // it directly in its constructor. If that file is corrupt — most often an
+    // interrupted write (power loss, a network/IP change that knocked the app
+    // over mid-flush) — the FIRST store's open throws a LiteException during DI
+    // build, the host fails to start, and on the desktop the window just
+    // flashes and closes (#635). A saved-settings file must never be able to
+    // stop the app from launching.
+    //
+    // EnsureUsable runs ONCE, before any store opens the file, and disposes its
+    // own handle before returning — so it can move a corrupt file aside without
+    // racing a live store handle. By the time any store constructor runs the
+    // file is guaranteed openable. The 20-odd `new LiteDatabase(...)` call sites
+    // are deliberately left unchanged.
+
+    private const string SharedConn = ";Connection=shared";
+    private enum ProbeResult { Ok, Transient, Corrupt }
+
+    /// <summary>
+    /// Probe the shared prefs DB and recover a corrupt one. Returns true when
+    /// the path is usable afterwards (it was fine, fresh, busy, or successfully
+    /// moved aside and will be recreated); false only when the file is corrupt
+    /// AND could not be moved (e.g. still locked) — the caller must then fall
+    /// back to a throwaway path so the app still launches.
+    ///
+    /// A merely BUSY/locked file (second instance, antivirus) is left untouched.
+    /// Corruption is judged only after it reproduces across several probes, so a
+    /// torn read from a concurrent writer is never mistaken for a corrupt file.
+    /// </summary>
+    public static bool EnsureUsable(string dbPath, ILogger? log = null)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(dbPath);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+
+            if (!File.Exists(dbPath))
+                return true; // fresh install / fresh DB — nothing to validate
+
+            const int attempts = 3;
+            const int backoffMs = 150;
+            for (int i = 0; i < attempts; i++)
+            {
+                var result = Probe(dbPath, log);
+                if (result is ProbeResult.Ok or ProbeResult.Transient)
+                    return true; // valid, or busy → leave it alone
+                if (i < attempts - 1)
+                    System.Threading.Thread.Sleep(backoffMs);
+            }
+
+            Warn(log, $"prefs DB at '{dbPath}' is corrupt across {attempts} probes — moving it aside.");
+            return MoveCorruptAside(dbPath, log);
+        }
+        catch (Exception ex)
+        {
+            // Never let the guard itself crash startup — worst case the caller
+            // falls back to a temp path.
+            Error(log, $"prefs DB EnsureUsable failed unexpectedly for '{dbPath}'", ex);
+            return false;
+        }
+    }
+
+    private static ProbeResult Probe(string dbPath, ILogger? log)
+    {
+        try
+        {
+            using var db = new LiteDatabase($"Filename={dbPath}{SharedConn}");
+            // Page 0 / collection dictionary.
+            var names = db.GetCollectionNames().ToList();
+            // Force a DATA-page read on every collection. Interrupted writes most
+            // often damage a data page, not the header — a header-only probe would
+            // sail past that and let a store crash later. These prefs tables are
+            // tiny single-row stores, so the scan costs a few ms.
+            foreach (var name in names)
+                _ = db.GetCollection(name).FindAll().FirstOrDefault();
+            return ProbeResult.Ok;
+        }
+        catch (IOException)
+        {
+            // Raw OS file lock (another instance, antivirus) — never corruption.
+            return ProbeResult.Transient;
+        }
+        catch (Exception ex) when (ex.InnerException is IOException)
+        {
+            // Lock surfaced wrapped in a LiteException (or similar).
+            return ProbeResult.Transient;
+        }
+        catch (Exception ex)
+        {
+            // Any other failure to open/read the file is corruption: a bad
+            // header, a torn/truncated data page, or garbage where a DB should
+            // be. LiteDB raises several exception types here (LiteException,
+            // end-of-stream, format errors) — all mean "this file won't open".
+            // The caller retries before judging, so a torn read from a live
+            // writer mid-flush is never mistaken for a corrupt file.
+            Warn(log, $"prefs DB probe failed: {ex.GetType().Name}: {ex.Message}", ex);
+            return ProbeResult.Corrupt;
+        }
+    }
+
+    private static bool MoveCorruptAside(string dbPath, ILogger? log)
+    {
+        var stamp = DateTime.UtcNow.ToString("yyyyMMddTHHmmssZ");
+        var bak = $"{dbPath}.corrupt-{stamp}.bak";
+        try
+        {
+            // Move the DB and any LiteDB sidecar (the -log transaction file) so a
+            // half-checkpointed pair can't re-corrupt the fresh DB. Best-effort
+            // per file; only move what exists.
+            foreach (var (src, dst) in new[]
+            {
+                (dbPath, bak),
+                (dbPath + "-log", bak + "-log"),
+            })
+            {
+                if (File.Exists(src)) File.Move(src, dst);
+            }
+            Warn(log,
+                $"prefs DB moved aside to '{bak}'; a fresh one will be created. " +
+                "Prior settings (including TX/PA calibration) were lost — the moved " +
+                "file is preserved for developer diagnosis only and cannot be auto-restored.");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Error(log, $"prefs DB move-aside failed (still locked?) for '{dbPath}'", ex);
+            return false;
+        }
+    }
+
+    // Dual sink: ILogger when one is available (it usually isn't — the guard runs
+    // before the DI container exists) AND Console.Error, because the desktop app
+    // calls FreeConsole() and would otherwise swallow the message entirely.
+    private static void Warn(ILogger? log, string msg, Exception? ex = null)
+    {
+        if (ex is null) log?.LogWarning("{Msg}", msg);
+        else log?.LogWarning(ex, "{Msg}", msg);
+        Console.Error.WriteLine(ex is null ? $"prefs.guard {msg}" : $"prefs.guard {msg} :: {ex.GetType().Name}: {ex.Message}");
+    }
+
+    private static void Error(ILogger? log, string msg, Exception ex)
+    {
+        log?.LogError(ex, "{Msg}", msg);
+        Console.Error.WriteLine($"prefs.guard {msg} :: {ex.GetType().Name}: {ex.Message}");
     }
 }

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -77,6 +77,40 @@ public static class ZeusHost
         var tciBindAddress = tciSection.GetValue<string?>("BindAddress") ?? "0.0.0.0";
         var tciPort = tciSection.GetValue<int?>("Port") ?? 40001;
 
+        // Prefs-DB integrity guard (#637). Probe the shared zeus-prefs.db ONCE
+        // before any store opens it (the bootstrap TciConfigStore below is the
+        // first). A corrupt file — typically an interrupted write after a power
+        // loss or network change — would otherwise throw out of a store
+        // constructor during DI build and the app would fail to launch (the
+        // window just flashes and closes, #635). EnsureUsable moves a genuinely
+        // corrupt file aside so the stores recreate a fresh one; a merely
+        // busy/locked file is left untouched.
+        var prefsPath = PrefsDbPath.Get();
+        if (!PrefsDbPath.EnsureUsable(prefsPath))
+        {
+            // Corrupt AND un-moveable (still locked — e.g. another instance has
+            // it). Don't let the natural store open throw silently out of Main
+            // under the desktop's detached console: record it to a persistent
+            // file and fall back to a throwaway prefs DB so the app still
+            // launches (degraded — settings won't persist this session).
+            var fatalLog = Path.Combine(
+                Path.GetDirectoryName(prefsPath) ?? ".", "zeus-prefs-fatal.log");
+            try
+            {
+                File.AppendAllText(fatalLog,
+                    $"{DateTime.UtcNow:o} prefs DB corrupt and locked at {prefsPath}; " +
+                    "close any other Zeus instance or delete the file. " +
+                    "Running on temporary settings for this session.\n");
+            }
+            catch { /* best effort — never block launch on the log write */ }
+
+            var tmpPrefs = Path.Combine(
+                Path.GetTempPath(), $"zeus-prefs-fallback-{Guid.NewGuid():N}.db");
+            Environment.SetEnvironmentVariable("ZEUS_PREFS_PATH", tmpPrefs);
+            Console.Error.WriteLine(
+                $"prefs.guard falling back to temporary prefs DB at {tmpPrefs}; settings will not persist this session.");
+        }
+
         // Persisted runtime override (LiteDB). The TCI management API queues changes
         // here because Kestrel's listener can only be wired before host build; we
         // pick those changes up on the next start. Falls back to appsettings when

--- a/tests/Zeus.Server.Tests/PrefsDbPathTests.cs
+++ b/tests/Zeus.Server.Tests/PrefsDbPathTests.cs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using LiteDB;
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+// Startup corruption guard for the shared zeus-prefs.db (#637 / #635).
+public class PrefsDbPathTests : IDisposable
+{
+    private readonly string _dbPath;
+
+    public PrefsDbPathTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"zeus-prefs-guard-{Guid.NewGuid():N}.db");
+    }
+
+    public void Dispose()
+    {
+        var dir = Path.GetDirectoryName(_dbPath)!;
+        var stem = Path.GetFileName(_dbPath);
+        foreach (var f in Directory.GetFiles(dir, stem + "*"))
+        {
+            try { File.Delete(f); } catch { /* best effort */ }
+        }
+    }
+
+    private static void WriteValidDb(string path)
+    {
+        using var db = new LiteDatabase($"Filename={path};Connection=shared");
+        var col = db.GetCollection("prefs");
+        col.Insert(new BsonDocument { ["_id"] = 1, ["value"] = "hello" });
+        col.Insert(new BsonDocument { ["_id"] = 2, ["value"] = "world" });
+    }
+
+    private string[] CorruptBackups()
+    {
+        var dir = Path.GetDirectoryName(_dbPath)!;
+        return Directory.GetFiles(dir, Path.GetFileName(_dbPath) + ".corrupt-*.bak");
+    }
+
+    [Fact]
+    public void MissingFile_ReturnsTrue_AndCreatesNothing()
+    {
+        Assert.False(File.Exists(_dbPath));
+        Assert.True(PrefsDbPath.EnsureUsable(_dbPath, NullLogger.Instance));
+        // A fresh install has no DB to validate; the guard must not fabricate one.
+        Assert.False(File.Exists(_dbPath));
+        Assert.Empty(CorruptBackups());
+    }
+
+    [Fact]
+    public void ValidDb_ReturnsTrue_AndLeavesItUntouched()
+    {
+        WriteValidDb(_dbPath);
+        var before = File.ReadAllBytes(_dbPath);
+
+        Assert.True(PrefsDbPath.EnsureUsable(_dbPath, NullLogger.Instance));
+
+        Assert.True(File.Exists(_dbPath));
+        Assert.Empty(CorruptBackups());
+        // Untouched — the guard must not rewrite a healthy DB.
+        Assert.Equal(before, File.ReadAllBytes(_dbPath));
+    }
+
+    [Fact]
+    public void CorruptFile_IsMovedAside_AndPathBecomesUsable()
+    {
+        // Not a valid LiteDB file at all — opening it throws a LiteException.
+        File.WriteAllBytes(_dbPath, Enumerable.Repeat((byte)0xAB, 9000).ToArray());
+
+        Assert.True(PrefsDbPath.EnsureUsable(_dbPath, NullLogger.Instance));
+
+        // The corrupt file was moved aside (preserved for diagnosis)...
+        Assert.False(File.Exists(_dbPath));
+        Assert.Single(CorruptBackups());
+        // ...and a store can now open a fresh DB at the original path.
+        using var db = new LiteDatabase($"Filename={_dbPath};Connection=shared");
+        Assert.Empty(db.GetCollection("prefs").FindAll());
+    }
+
+    [Fact]
+    public void LockedFile_IsNotWiped()
+    {
+        // A healthy DB that is exclusively locked (another instance / antivirus)
+        // must be treated as transient and left ALONE — never moved aside.
+        WriteValidDb(_dbPath);
+        using (var hold = new FileStream(_dbPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+        {
+            Assert.True(PrefsDbPath.EnsureUsable(_dbPath, NullLogger.Instance));
+        }
+
+        Assert.True(File.Exists(_dbPath));
+        Assert.Empty(CorruptBackups()); // load-bearing: a busy DB is NEVER wiped
+    }
+}


### PR DESCRIPTION
Fixes #637 — a corrupt `zeus-prefs.db` made Zeus fail to **launch entirely** (window flashes and closes, #635). An engineering team investigated the kb2uka-agent's proposed fix and tightened it before implementation.

## Root cause (confirmed)

~20 preference stores each open the shared `zeus-prefs.db` **directly in their constructor**. If the file is corrupt — an interrupted write (power loss, or a network/IP change that knocked the app over mid-flush) — the **first** store throws a `LiteException` during DI build, the host never starts, and on the desktop the window just closes.

Verified it is **corruption-at-open, not stale-value consumption**: persisted values hydrate via null-coalescing and no IP/endpoint is re-parsed at startup, so no IP-revalidation is needed (that would be scope creep against a non-existent bug).

## The fix

A single pre-DI integrity pass — `PrefsDbPath.EnsureUsable()` — runs **once** in `ZeusHost.Build` before any store opens the file, and disposes its own handle before returning. By the time any store constructor runs, the file is guaranteed openable. **The ~20 store call sites are unchanged** (one atomic pre-flight beats threading a guard through 20 files — and avoids the agent's original per-store design, which could rename the file out from under an already-open store mid-DI-build).

How the team hardened the agent's draft:
- **Data-page walk, not header-only.** The probe forces a row read on every collection — interrupted writes usually damage a data page, not page 0, which Ed's case (#635) hits and a header-only probe would miss.
- **Never wipe a healthy-but-busy DB.** A locked file (second instance, antivirus → `IOException`) is classified *transient* and left untouched. The agent's broad `catch (Exception)` would have renamed-and-wiped it. Corruption is judged only after it **reproduces across 3 probes with backoff**, so a torn read from a concurrent writer isn't mistaken for corruption.
- **Recovery preserves the bad file** at `<path>.corrupt-<utc>.bak` (diagnosis only — LiteDB can't rebuild a file it can't open) and lets the stores create a fresh DB.
- **Loud, not silent, when recovery itself fails.** If the corrupt file can't be moved (still locked), `ZeusHost` writes a persistent `zeus-prefs-fatal.log` (the desktop console is detached via `FreeConsole`) and falls back to a temp prefs DB so the app **still launches** (degraded) instead of the same silent crash.

## Tests
Missing → no-op · valid → byte-identical untouched · corrupt/garbage → moved aside + fresh DB usable · **exclusively-locked → NOT wiped** (the load-bearing safety test). Full server suite green (731). Backend + frontend build clean.

## 🟡 Recommended fast-follow (deliberately NOT in this PR)
Operators currently learn about a settings reset only from the log. A nicer touch is an **in-UI banner** ("Saved settings were corrupted and reset to defaults — re-check TX power/PA/calibration before transmitting"). The seam is already mapped: add `AlertKind.PrefsReset` to `Zeus.Contracts/AlertFrame.cs` (+ the frontend `tx-store` enum — the `AlertBanner` already renders any kind's message generically), latch the event in `ZeusHost.Build`, and replay it in `StreamingHub.AttachClientAsync` (same pattern as the wisdom/spot priming). I kept it out because it touches **`Zeus.Contracts`** (red-light per CLAUDE.md) — wanted your sign-off before adding a wire enum value. Say the word and I'll send it.

🔒 Per project rules: **not merging** — your call. Leave #637 open until the develop→main release merge.

Issue: #637
