### PR TITLE
feat(radio): external-port control (antenna/RX-aux/audio/GPIO) — all radios, both protocols

### DIFF
--- a/Zeus.Contracts/BoardCapabilities.cs
+++ b/Zeus.Contracts/BoardCapabilities.cs
@@ -10,6 +10,70 @@
 namespace Zeus.Contracts;
 
 /// <summary>
+/// RX auxiliary inputs a board's Alex / filter board exposes (external-ports
+/// plan, Phase 5). These are the receive-only feed paths in addition to the
+/// base ANT1/2/3 relays: an external transverter IF (<see cref="Xvtr"/>), two
+/// external receive-loop inputs (<see cref="Ext1"/> / <see cref="Ext2"/>), and
+/// the RX-bypass / K36 path (<see cref="Bypass"/>) that is BIT-IDENTICAL to the
+/// PureSignal external-feedback select on the wire (alex0 bit 11). A board can
+/// expose any subset; HL2 exposes <see cref="None"/> (the inputs do not
+/// physically exist). The flags gate the UI/REST/wire so an operator can only
+/// pick an input the connected board actually has.
+/// </summary>
+[Flags]
+public enum RxAuxInputs
+{
+    None  = 0,
+    Ext1  = 1 << 0,
+    Ext2  = 1 << 1,
+    Xvtr  = 1 << 2,
+    Bypass = 1 << 3,
+    /// <summary>Every aux input — the full Alex / Saturn-BPF set.</summary>
+    All = Ext1 | Ext2 | Xvtr | Bypass,
+}
+
+/// <summary>
+/// The selected RX antenna / aux input for one band (external-ports plan,
+/// Phase 5). Base relays (<see cref="Ant1"/>..<see cref="Ant3"/>) coexist with
+/// the aux feeds; this is a single enum because the radio routes ONE RX source
+/// at a time. Persisted as a byte in <c>antenna_bands</c>; default
+/// <see cref="Ant1"/> reproduces today's wire bit-for-bit.
+/// </summary>
+public enum RxSource : byte
+{
+    Ant1  = 0,
+    Ant2  = 1,
+    Ant3  = 2,
+    Ext1  = 10,
+    Ext2  = 11,
+    Xvtr  = 12,
+    Bypass = 13,
+}
+
+/// <summary>
+/// Alex / filter-board revision family, for the K36-BYPASS-direction branch
+/// (external-ports plan, §3.4(4)). On older Rev 15/16 Alex boards K36 switches
+/// an OUTPUT and PureSignal external feedback must route to EXT1/XVTR (selecting
+/// BYPASS breaks PS); on Rev 24+ boards K36 switches an INPUT and PS routes to
+/// BYPASS. THIS IS NOT WIRE-DISCOVERABLE — verified against pihpsdr (operator
+/// boolean <c>new_pa_board</c>, radio.c:221) and Thetis (model-derived
+/// <c>mkiibpf</c>); neither reads it from a discovery/status packet. Zeus
+/// therefore DEFAULTS CONSERVATIVELY to <see cref="Modern"/> (Rev 24+, BYPASS
+/// for PS) — the behaviour Zeus already ships (PS external feedback sets bit 11)
+/// — and treats the revision as an operator preference, never a guessed wire
+/// value that could mis-route PS. See the open-question note in the Phase 5 PR.
+/// </summary>
+public enum AlexRevision
+{
+    /// <summary>Rev 24+ — K36 is an input; PureSignal external feedback routes
+    /// to BYPASS (alex0 bit 11). The safe default.</summary>
+    Modern = 0,
+    /// <summary>Rev 15/16 — K36 is an output; PureSignal external feedback must
+    /// route to EXT1/XVTR, NOT BYPASS. Operator opt-in only.</summary>
+    Legacy15Or16 = 1,
+}
+
+/// <summary>
 /// Per-board capability fingerprint. Mirrors the facts Thetis MW0LGE
 /// special-cases in <c>clsHardwareSpecific.cs</c> — RX ADC count, MKII
 /// BPF support, ADC supply mV, LR audio swap, telemetry presence,
@@ -121,7 +185,32 @@ public sealed record BoardCapabilities(
     /// Distinct from <see cref="HasOnboardCodec"/> — HL2 has the mic front-end
     /// but not the stream codec. mic_bias defaults OFF (enabling it on a
     /// floating connector can hang PTT) and is guarded.</summary>
-    bool HermesLite2MicFrontEnd = false)
+    bool HermesLite2MicFrontEnd = false,
+    // ---- External-port control, Phase 5 -----------------------------------
+    /// <summary>The RX auxiliary inputs (EXT1/EXT2/XVTR/BYPASS) this board's
+    /// Alex / filter board exposes. <see cref="Contracts.RxAuxInputs.All"/> for
+    /// the Alex-class P1 boards and the 0x0A Saturn family;
+    /// <see cref="Contracts.RxAuxInputs.None"/> for Hermes-Lite 2 (the inputs do
+    /// not physically exist). Gates the RX-aux selector in the UI/REST and, at
+    /// the wire layer, whether the encoder emits any aux-relay bits. The
+    /// <see cref="Contracts.RxAuxInputs.Bypass"/> (K36) bit is bit-identical to
+    /// the PureSignal external-feedback select — PS owns it while armed
+    /// (§3.4(2)).</summary>
+    RxAuxInputs RxAuxInputs = RxAuxInputs.None,
+    /// <summary>Board has a second RX antenna path (dual-Alex / dual-RX). True
+    /// for the dual-ADC boards: ANAN-100D / 200D and the dual-RX 0x0A family.
+    /// Gates the RX2-antenna selector.</summary>
+    bool HasRx2AntennaPath = false,
+    /// <summary>Board has the 4-bit user GPIO (<c>user_dig_out</c>) on its
+    /// Protocol-1 register 0x0a (wire 0x14) C3[3:0] → MCP23008. Hermes-Lite 2
+    /// only (verified Thetis-mi0bot networkproto1.c:774). Gates the HL2 user
+    /// GPIO toggle group.</summary>
+    bool HasHl2UserGpio = false,
+    /// <summary>Alex / filter-board revision for the K36-BYPASS-direction
+    /// branch (§3.4(4)). NOT wire-discoverable — defaults
+    /// <see cref="Contracts.AlexRevision.Modern"/> (Rev 24+, PS routes to BYPASS,
+    /// matching Zeus's current behaviour). Operator preference only.</summary>
+    AlexRevision AlexRevision = AlexRevision.Modern)
 {
     /// <summary>Safe defaults for an unrecognised / disconnected board.
     /// Single ADC, no extras — minimum-surprise capability set so a

--- a/Zeus.Contracts/BoardCapabilities.cs
+++ b/Zeus.Contracts/BoardCapabilities.cs
@@ -88,7 +88,40 @@ public sealed record BoardCapabilities(
     /// disabled when this flag is false, so operators can see the
     /// feature exists without being able to drive a non-supporting
     /// board.</summary>
-    bool SupportsAnvelinaDxOc = false)
+    bool SupportsAnvelinaDxOc = false,
+    // ---- External-port control capabilities (external-ports plan) ---------
+    // Static per-board facts that gate the "Radio Settings" external-port
+    // controls (antenna select, audio front-end). Additive optional fields —
+    // the capabilities response is JSON, so older frontends ignore them and
+    // newer ones default the absent fields. Conservative defaults (false) so
+    // an unknown board never advertises a port it may not physically have.
+    /// <summary>Board has switchable TX antenna relays (ANT1/2/3). True only
+    /// for the 0x0A OrionMkII / Saturn family (G2 / 7000DLE / 8000DLE / G2-1K /
+    /// ANVELINA-PRO3 / Red Pitaya / Apache OrionMkII original). Every P1 board
+    /// (Hermes-class, ANAN-100D/200D, ANAN-G2E) and Hermes-Lite 2 are
+    /// ANT1-hardwired on transmit. Gates the TX-antenna selector and, at the
+    /// wire layer, whether the encoder emits TX-antenna relay bits.</summary>
+    bool HasTxAntennaRelays = false,
+    /// <summary>Board has switchable RX antenna relays (ANT1/2/3) via its
+    /// Alex/filter board. True for every ANAN board (Hermes-class through the
+    /// Saturn family and ANAN-G2E). False for Hermes-Lite 2 — HL2 has a single
+    /// antenna jack and its C3[5] bit drives the N2ADR antenna pad, not an
+    /// ANT1/2/3 relay, so RX-antenna selection MUST be clamped to ANT1 on HL2
+    /// at the wire layer.</summary>
+    bool HasRxAntennaRelays = false,
+    /// <summary>Board decodes the host→radio audio STREAM (TLV320 codec) — the
+    /// path that carries the Hermes-class mic / line-in front-end. True for
+    /// every ANAN board. False for Hermes-Lite 2, which has no stream codec.
+    /// STREAM codec only; does NOT gate the HL2 mic front-end (see
+    /// <see cref="HermesLite2MicFrontEnd"/>).</summary>
+    bool HasOnboardCodec = false,
+    /// <summary>Board has the Hermes-Lite 2 mic / PTT / line-in front-end on
+    /// register 0x0a (wire byte 0x14): mic_trs, mic_bias, mic_ptt and a 5-bit
+    /// line-in gain. True for <see cref="HpsdrBoardKind.HermesLite2"/> only.
+    /// Distinct from <see cref="HasOnboardCodec"/> — HL2 has the mic front-end
+    /// but not the stream codec. mic_bias defaults OFF (enabling it on a
+    /// floating connector can hang PTT) and is guarded.</summary>
+    bool HermesLite2MicFrontEnd = false)
 {
     /// <summary>Safe defaults for an unrecognised / disconnected board.
     /// Single ADC, no extras — minimum-surprise capability set so a

--- a/Zeus.Contracts/BoardCapabilities.cs
+++ b/Zeus.Contracts/BoardCapabilities.cs
@@ -186,6 +186,32 @@ public sealed record BoardCapabilities(
     /// but not the stream codec. mic_bias defaults OFF (enabling it on a
     /// floating connector can hang PTT) and is guarded.</summary>
     bool HermesLite2MicFrontEnd = false,
+    // ---- TX-audio source jacks (external-ports plan, §6) ------------------
+    // Static per-board facts gating which <see cref="Contracts.TxAudioSource"/>
+    // options the Radio Settings panel offers. Additive optional fields — older
+    // frontends ignore them; conservative defaults (false) so an unknown board
+    // never advertises a jack it may not physically have. Host is ALWAYS
+    // available regardless of these flags.
+    /// <summary>Board has an analog line-in jack the operator can select as the
+    /// TX-audio source (<see cref="Contracts.TxAudioSource.RadioLineIn"/>). True
+    /// for ANAN-200D (Orion) and the whole 0x0A Saturn family; false for pure
+    /// Hermes-class P1 boards (no P1 radio-mic receive path in v1 — §6),
+    /// ANAN-G2E, Metis, and Hermes-Lite 2.</summary>
+    bool HasRadioLineIn = false,
+    /// <summary>Board has a switchable balanced XLR microphone input
+    /// (<see cref="Contracts.TxAudioSource.RadioBalancedXlr"/>). True ONLY for
+    /// the Saturn-FPGA ANAN-G2 and ANAN-G2-1K; offered nowhere else (use this
+    /// flag, never <see cref="HasAudioAmplifier"/>, to gate XLR).</summary>
+    bool HasBalancedXlr = false,
+    /// <summary>Board exposes the Orion mic-bias enable on its mic jack. In
+    /// Thetis the bias control lives in <c>pnlGeneralHardwareORION</c> and is
+    /// Enabled for ANAN-200D, ANAN-7000DLE, ANAN-8000DLE, ANAN-G2, ANAN-G2-1K,
+    /// and ANVELINA-PRO3. FALSE for Red Pitaya (Thetis disables the panel
+    /// there), Hermes, ANAN-G2E, ANAN-10/10E/100/100B/100D, Metis, and HL2.
+    /// Do NOT derive this from <see cref="HasAudioAmplifier"/>. mic_bias
+    /// defaults OFF and is gated behind explicit operator confirmation on every
+    /// bias-capable board (floating-connector RF / PTT-hang risk).</summary>
+    bool HasMicBias = false,
     // ---- External-port control, Phase 5 -----------------------------------
     /// <summary>The RX auxiliary inputs (EXT1/EXT2/XVTR/BYPASS) this board's
     /// Alex / filter board exposes. <see cref="Contracts.RxAuxInputs.All"/> for

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -617,6 +617,31 @@ public sealed record AntennaSettingsDto(
 // request that targets a relay the connected board lacks with 409.
 public sealed record AntennaSetRequest(string Band, string TxAnt, string RxAnt);
 
+// Global (per-radio, NOT per-band) audio front-end selection (external-ports
+// plan, Phase 4). GET carries the capability gates so the panel renders the
+// right controls: HasOnboardCodec gates the Hermes-class mic-boost / line-in
+// controls; HermesLite2MicFrontEnd gates the HL2 mic_trs(balanced) / mic_bias /
+// line-in-gain controls. BalancedInput is the Saturn XLR / HL2 TRS select.
+// mic_bias defaults OFF (enabling it on a floating connector can hang PTT).
+public sealed record AudioFrontEndDto(
+    bool HasOnboardCodec,
+    bool HermesLite2MicFrontEnd,
+    bool LineIn,
+    bool MicBoost,
+    bool MicBias,
+    bool BalancedInput,
+    int LineInGain);
+
+// Mutating version — sets the whole global audio front-end. LineInGain is
+// clamped to 0..31 server-side. The server returns the persisted state plus
+// the live capability gates.
+public sealed record AudioFrontEndSetRequest(
+    bool LineIn,
+    bool MicBoost,
+    bool MicBias,
+    bool BalancedInput,
+    int LineInGain);
+
 // HL2-specific optional toggles surfaced via /api/radio/hl2-options.
 // Shape is an object (not a bare bool) so future mi0bot HL2 toggles can
 // slot in without breaking the contract. Currently carries Band Volts

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -642,6 +642,16 @@ public sealed record AntennaSetRequest(string Band, string TxAnt, string RxAnt, 
 public sealed record Hl2GpioDto(bool Supported, int Bits);
 public sealed record Hl2GpioSetRequest(int Bits);
 
+// Hardware-PTT-IN status + enable gate (external-ports plan, §4). Read-only
+// `Keyed` is the live footswitch / mic-PTT / rear-KEY level (per-protocol
+// source: P1 HardwarePttChanged, P2 UDP-1025 PttIn). `Enabled` gates MOX
+// promotion (defaults ON); when off the lamp still tracks the input but the
+// hardware edge is not lifted to MOX. `HangMs` is the fixed 250 ms release
+// hang, surfaced read-only for the UI label. Every board has a PTT-IN, so this
+// is ungated.
+public sealed record PttStatusDto(bool Keyed, bool Enabled, int HangMs);
+public sealed record PttEnableSetRequest(bool Enabled);
+
 // Global (per-radio, NOT per-band) TX-audio SOURCE selection (external-ports
 // plan, §2/§11). GET carries the per-board source-availability gates so the
 // single-select picker renders only the sources the connected board offers

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -600,6 +600,23 @@ public sealed record RadioSelectionSetRequest(
 // against the OrionMkIIVariant enum. Empty / unknown rejected with 400.
 public sealed record RadioVariantSetRequest(string Variant);
 
+// Per-band TX/RX antenna relay selection surfaced via /api/radio/antenna
+// (external-ports plan, Phase 2). Antenna strings are "Ant1" | "Ant2" |
+// "Ant3" (forward-compatible, parsed against HpsdrAntenna server-side). The
+// GET response carries the relay-capability gates so the frontend can render
+// the right selectors; the per-band rows let the panel show all HF bands.
+public sealed record AntennaBandDto(string Band, string TxAnt, string RxAnt);
+
+public sealed record AntennaSettingsDto(
+    bool HasTxAntennaRelays,
+    bool HasRxAntennaRelays,
+    IReadOnlyList<AntennaBandDto> Bands);
+
+// Mutating version — sets ONE band's antenna selection. Band must be a known
+// HF band; TxAnt/RxAnt must parse to HpsdrAntenna. The server rejects a
+// request that targets a relay the connected board lacks with 409.
+public sealed record AntennaSetRequest(string Band, string TxAnt, string RxAnt);
+
 // HL2-specific optional toggles surfaced via /api/radio/hl2-options.
 // Shape is an object (not a bare bool) so future mi0bot HL2 toggles can
 // slot in without breaking the contract. Currently carries Band Volts

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -605,17 +605,33 @@ public sealed record RadioVariantSetRequest(string Variant);
 // "Ant3" (forward-compatible, parsed against HpsdrAntenna server-side). The
 // GET response carries the relay-capability gates so the frontend can render
 // the right selectors; the per-band rows let the panel show all HF bands.
-public sealed record AntennaBandDto(string Band, string TxAnt, string RxAnt);
+// RxAux is the auxiliary RX input string: "None" | "Ext1" | "Ext2" | "Xvtr" |
+// "Bypass" (external-ports plan, Phase 5). "None" uses the base RX-antenna
+// relay. Forward-compatible: parsed against RxAuxInputSel server-side.
+public sealed record AntennaBandDto(string Band, string TxAnt, string RxAnt, string RxAux = "None");
 
+// AvailableRxAux is the set of aux-input strings the connected board's Alex /
+// filter board exposes (so the frontend renders only valid options). Empty on
+// boards with no aux inputs (HL2). AlexRevision is the (operator-set, NOT
+// wire-discoverable) K36-BYPASS-direction family: "Modern" (Rev 24+, PS routes
+// to BYPASS — the safe default) or "Legacy15Or16".
 public sealed record AntennaSettingsDto(
     bool HasTxAntennaRelays,
     bool HasRxAntennaRelays,
-    IReadOnlyList<AntennaBandDto> Bands);
+    IReadOnlyList<AntennaBandDto> Bands,
+    IReadOnlyList<string>? AvailableRxAux = null,
+    string AlexRevision = "Modern");
 
-// Mutating version — sets ONE band's antenna selection. Band must be a known
-// HF band; TxAnt/RxAnt must parse to HpsdrAntenna. The server rejects a
-// request that targets a relay the connected board lacks with 409.
-public sealed record AntennaSetRequest(string Band, string TxAnt, string RxAnt);
+// Mutating version — sets ONE band's antenna + RX-aux selection. Band must be a
+// known HF band; TxAnt/RxAnt must parse to HpsdrAntenna; RxAux to RxAuxInputSel.
+// The server rejects a request targeting a relay/aux the board lacks with 409.
+public sealed record AntennaSetRequest(string Band, string TxAnt, string RxAnt, string RxAux = "None");
+
+// HL2 user GPIO (external-ports plan, Phase 5). 4-bit user_dig_out → the
+// register 0x0a (wire 0x14) C3[3:0] MCP23008 lines. Bits is the low-nibble mask;
+// Supported gates the panel (HL2 only).
+public sealed record Hl2GpioDto(bool Supported, int Bits);
+public sealed record Hl2GpioSetRequest(int Bits);
 
 // Global (per-radio, NOT per-band) audio front-end selection (external-ports
 // plan, Phase 4). GET carries the capability gates so the panel renders the

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -311,7 +311,16 @@ public sealed record StateDto(
     // (Thetis: Setup → DSP → Keyer → CW Pitch). On the wire now so
     // the frontend already consumes the live value — when the setting
     // lands, only the server-side source changes.
-    int CwPitchHz = CwDefaults.PitchHz);
+    int CwPitchHz = CwDefaults.PitchHz,
+
+    // ---- TX-audio source (external-ports plan, §2/§8) ----
+    // The RESOLVED (board-clamped) TX-audio source the server is currently
+    // pushing. RadioService reads AudioSettingsStore, clamps the persisted
+    // selection against the connected board's capabilities (a jack the board
+    // lacks falls back to Host), and mirrors the resolved value here so the
+    // frontend HYDRATES from the server and never clobbers it on connect
+    // (the PR #359/#360 pattern). Default Host = 0 reproduces today's behaviour.
+    TxAudioSource TxAudioSource = TxAudioSource.Host);
 
 /// <summary>Canonical CW constants shared between backend and wire DTOs.
 /// Single source of truth — CwOffset (server-side) and StateDto both
@@ -633,29 +642,38 @@ public sealed record AntennaSetRequest(string Band, string TxAnt, string RxAnt, 
 public sealed record Hl2GpioDto(bool Supported, int Bits);
 public sealed record Hl2GpioSetRequest(int Bits);
 
-// Global (per-radio, NOT per-band) audio front-end selection (external-ports
-// plan, Phase 4). GET carries the capability gates so the panel renders the
-// right controls: HasOnboardCodec gates the Hermes-class mic-boost / line-in
-// controls; HermesLite2MicFrontEnd gates the HL2 mic_trs(balanced) / mic_bias /
-// line-in-gain controls. BalancedInput is the Saturn XLR / HL2 TRS select.
-// mic_bias defaults OFF (enabling it on a floating connector can hang PTT).
+// Global (per-radio, NOT per-band) TX-audio SOURCE selection (external-ports
+// plan, §2/§11). GET carries the per-board source-availability gates so the
+// single-select picker renders only the sources the connected board offers
+// (Host is always available): HasOnboardCodec gates RadioMic; HasRadioLineIn
+// gates RadioLineIn; HasBalancedXlr gates RadioBalancedXlr; HasMicBias gates the
+// mic-bias toggle. HermesLite2MicFrontEnd is carried so the panel can render the
+// HL2 "audio over USB/Ethernet" note (HL2 is Host-only).
+//
+// `Source` is the RESOLVED (board-clamped) source the server is pushing — the
+// frontend hydrates from it and never clobbers the server on connect. MicBoost /
+// MicBias / LineInGain are the parameters OF the selected source. The legacy
+// `LineIn` / `BalancedInput` fields are dropped — line-in / balanced are now
+// distinct `Source` values.
 public sealed record AudioFrontEndDto(
     bool HasOnboardCodec,
     bool HermesLite2MicFrontEnd,
-    bool LineIn,
+    bool HasRadioLineIn,
+    bool HasBalancedXlr,
+    bool HasMicBias,
+    TxAudioSource Source,
     bool MicBoost,
     bool MicBias,
-    bool BalancedInput,
     int LineInGain);
 
-// Mutating version — sets the whole global audio front-end. LineInGain is
-// clamped to 0..31 server-side. The server returns the persisted state plus
+// Mutating version — sets the whole global TX-audio source. LineInGain is
+// clamped to 0..31 server-side. The server clamps Source against the board's
+// capabilities (an unsupported jack → Host) and returns the resolved state plus
 // the live capability gates.
 public sealed record AudioFrontEndSetRequest(
-    bool LineIn,
+    TxAudioSource Source,
     bool MicBoost,
     bool MicBias,
-    bool BalancedInput,
     int LineInGain);
 
 // HL2-specific optional toggles surfaced via /api/radio/hl2-options.

--- a/Zeus.Contracts/MsgType.cs
+++ b/Zeus.Contracts/MsgType.cs
@@ -182,4 +182,15 @@ public enum MsgType : byte
     // argb:u32 LE, callsignLen:u8, callsign:UTF-8, modeLen:u8, mode:UTF-8,
     // commentLen:u16 LE, comment:UTF-8.
     SpotList = 0x32,
+
+    // Server → client (hardware PTT-IN status edge). Broadcast on every
+    // footswitch / mic-PTT / rear-KEY edge so the Radio Settings "PTT-IN:
+    // idle / keyed" lamp tracks the physical input regardless of protocol.
+    // The source is per-protocol (external-ports plan §4): P1 boards via the
+    // Protocol1Client HardwarePttChanged event, P2 boards via the UDP-1025
+    // hi-priority status PttIn bit. Read-only indicator — does NOT drive MOX
+    // (ExternalPttService promotes the same edges into MOX separately through
+    // the TxService.TrySetMox arbitration). Payload: [type:1][keyed:u8] = 2
+    // bytes total. See PttStatusFrame.cs.
+    PttStatus = 0x33,
 }

--- a/Zeus.Contracts/PttStatusFrame.cs
+++ b/Zeus.Contracts/PttStatusFrame.cs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Buffers;
+
+namespace Zeus.Contracts;
+
+// Hardware-PTT-IN (footswitch / mic PTT / rear KEY) status edge frame. 2 bytes:
+//   [0x33][keyed:u8]
+//
+// Read-only status for the Radio Settings "PTT-IN: idle / keyed" lamp. The
+// SOURCE of the edge is per-protocol (external-ports plan §4): P1 boards are
+// driven by the Protocol1Client HardwarePttChanged event (C0[0] / ptt_resp),
+// P2 boards by the UDP-1025 hi-priority status PttIn bit (byte0 bit0). This
+// is a pure indicator — it does NOT drive MOX (ExternalPttService promotes
+// the same edges into MOX separately, through TxService.TrySetMox arbitration).
+public readonly record struct PttStatusFrame(bool Keyed)
+{
+    public const int ByteLength = 2;
+
+    public void Serialize(IBufferWriter<byte> writer)
+    {
+        var span = writer.GetSpan(ByteLength);
+        span[0] = (byte)MsgType.PttStatus;
+        span[1] = Keyed ? (byte)1 : (byte)0;
+        writer.Advance(ByteLength);
+    }
+
+    public static PttStatusFrame Deserialize(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length < ByteLength)
+            throw new InvalidDataException($"PttStatusFrame requires {ByteLength} bytes, got {bytes.Length}");
+        if (bytes[0] != (byte)MsgType.PttStatus)
+            throw new InvalidDataException($"expected PttStatus (0x{(byte)MsgType.PttStatus:X2}), got 0x{bytes[0]:X2}");
+        return new PttStatusFrame(Keyed: bytes[1] != 0);
+    }
+}

--- a/Zeus.Contracts/TxAudioSource.cs
+++ b/Zeus.Contracts/TxAudioSource.cs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.Contracts;
+
+/// <summary>
+/// The single mutually-exclusive TX-audio SOURCE for a connected radio
+/// (external-ports plan, §2). Replaces the prior four-bool
+/// <c>AudioFrontEndSelection</c> mic-PARAMETER model, which only set codec wire
+/// bits and never switched the TX pipeline (host mic kept flowing regardless of
+/// the operator's pick) and allowed illegal combinations (line-in AND balanced,
+/// etc.). With this enum, illegal states are unrepresentable: exactly one source
+/// is active at a time.
+///
+/// <see cref="Host"/> = 0 is the default and the universal fallback. A persisted
+/// row that names a source the connected board can't honour (e.g. a balanced-XLR
+/// selection after a G2→Hermes swap) is clamped back to <see cref="Host"/> at
+/// connect, so the wire is never handed a source the hardware lacks.
+///
+/// MicBoost / MicBias / LineInGain are PARAMETERS OF a chosen source (carried
+/// alongside in <c>AudioSettingsStore</c>), never peer toggles — they apply only
+/// to whichever radio jack is selected and are suppressed entirely under
+/// <see cref="Host"/>.
+///
+/// RED-LIGHT but ADDITIVE and back-compatible: the underlying byte values are
+/// wire-stable and serialised into <c>zeus-prefs.db</c>; default 0 reproduces
+/// today's behaviour bit-for-bit on every board.
+/// </summary>
+public enum TxAudioSource : byte
+{
+    /// <summary>Host-supplied TX audio (USB/network mic, TCI, WAV playback —
+    /// whatever feeds the host TX pipeline today). The default and the only
+    /// option on boards with no radio-audio jack (Hermes-Lite 2). The radio's
+    /// own analog input is suppressed; the wire is byte-identical to today.</summary>
+    Host = 0,
+
+    /// <summary>The radio's analog 3.5 mm microphone jack. Honours the
+    /// per-source <c>MicBoost</c> parameter on every codec/P2 board and
+    /// <c>MicBias</c> on the bias-capable boards (200D / 7000DLE / 8000DLE /
+    /// G2 / G2-1K / ANVELINA-PRO3).</summary>
+    RadioMic = 1,
+
+    /// <summary>The radio's analog 3.5 mm line-in jack. Honours the per-source
+    /// 0..31 <c>LineInGain</c>. Offered on ANAN-200D and the 0x0A Saturn family
+    /// only (Zeus has no P1 radio-mic receive path in v1, so pure-P1 codec
+    /// boards do not expose it — §6 deviation note).</summary>
+    RadioLineIn = 2,
+
+    /// <summary>The radio's balanced XLR microphone input. Switchable on the
+    /// Saturn-FPGA G2 / G2-1K only (<c>HasBalancedXlr</c>). Implies the XLR wire
+    /// select; no separate "balanced" flag is persisted.</summary>
+    RadioBalancedXlr = 3,
+}

--- a/Zeus.Protocol1/AssemblyInfo.cs
+++ b/Zeus.Protocol1/AssemblyInfo.cs
@@ -45,3 +45,7 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Zeus.Protocol1.Tests")]
+// The external-port encoder seam (Zeus.Server.Hosting.IExternalPortEncoder)
+// delegates to ControlFrame's pure antenna-bit helpers so the firewall and the
+// wire path share one copy of the math — byte-identical by construction.
+[assembly: InternalsVisibleTo("Zeus.Server.Hosting")]

--- a/Zeus.Protocol1/ControlFrame.cs
+++ b/Zeus.Protocol1/ControlFrame.cs
@@ -274,7 +274,16 @@ internal static class ControlFrame
         bool MicLineIn = false,
         bool MicTrs = false,
         bool MicBias = false,
-        byte LineInGain = 0);
+        byte LineInGain = 0,
+        // ---- HL2 user GPIO (external-ports plan, Phase 5) -------------------
+        // 4-bit user_dig_out, emitted on this same 0x0a / wire-0x14 frame at
+        // C3[3:0] → MCP23008 (verified Thetis-mi0bot networkproto1.c:774:
+        // `C3 = prn->user_dig_out & 0b00001111;`). HL2 only. Default 0 →
+        // byte-identical to today (the frame's C3 was previously written 0).
+        // Written via read-modify-write in WriteAttenuatorPayload alongside the
+        // audio bits, PS bit, and C4 step-attenuator — none of which touch
+        // C3, so the four GPIO bits are independent.
+        byte UserDigOut = 0);
 
     /// <summary>
     /// Write the 5 C&amp;C bytes for <paramref name="register"/> given the current
@@ -393,8 +402,19 @@ internal static class ControlFrame
 
         c14[0] = 0;   // C1 — reserved on this register
         c14[1] = 0;   // C2
-        c14[2] = 0;   // C3
+        c14[2] = 0;   // C3 — HL2 user_dig_out [3:0] set below
         c14[3] = c4;
+
+        // HL2 user GPIO (external-ports plan, Phase 5). The 4-bit user_dig_out
+        // lands in C3[3:0] of this same 0x0a / wire-0x14 frame (Thetis-mi0bot
+        // networkproto1.c:774). Read-modify-write: OR ONLY the low nibble so the
+        // (currently unused) high C3 bits stay clear and the audio / PS / C4
+        // bytes — written below and above — are untouched. Default 0 → byte-
+        // identical to today. HL2 only; on other boards C3 stays 0.
+        if (s.Board == HpsdrBoardKind.HermesLite2)
+        {
+            c14[2] |= (byte)(s.UserDigOut & 0x0F);
+        }
 
         // HL2 mic front-end (external-ports plan, Phase 4). This C0=0x14 frame
         // is register 0x0a, which on HL2 carries the real mic/line-in front-

--- a/Zeus.Protocol1/ControlFrame.cs
+++ b/Zeus.Protocol1/ControlFrame.cs
@@ -248,7 +248,33 @@ internal static class ControlFrame
         // WriteCwKeyerConfigPayload. Default mode Straight makes the write a
         // no-op until the operator opts into iambic. See zeus-bks.
         int CwKeyerSpeedWpm = 0,
-        CwKeyerMode CwKeyerMode = CwKeyerMode.Straight);
+        CwKeyerMode CwKeyerMode = CwKeyerMode.Straight,
+        // ---- Audio front-end (external-ports plan, Phase 4) -----------------
+        // Two distinct P1 audio surfaces, both verified against ramdor Thetis
+        // networkproto1.c and piHPSDR old_protocol.c:
+        //
+        //  (a) Hermes-class codec boards — DriveFilter (0x12) frame:
+        //        C2[0] = mic_boost, C2[1] = mic_linein
+        //      (Thetis networkproto1.c:581; piHPSDR old_protocol.c:2154-2156.)
+        //      These default false → byte-identical to today's 0x12 frame.
+        //
+        //  (b) Hermes-Lite 2 — 0x0a / wire-0x14 frame (read-modify-write):
+        //        C1[4] = mic_trs, C1[5] = mic_bias, C2[4:0] = line_in_gain
+        //      (Thetis networkproto1.c:597-599 case 11; same in mi0bot.)
+        //      The SAME frame carries C2[6] = puresignal_run and the C4 PGA /
+        //      step-attenuator byte — those are written by the existing
+        //      WriteAttenuatorPayload logic and MUST survive. The audio fields
+        //      only set their own bits on top.
+        //
+        // mic_bias defaults OFF — enabling it on a floating connector can hang
+        // PTT (BoardCapabilities.HermesLite2MicFrontEnd guards the surface).
+        // mic_ptt routing is a PTT-IN concern (plan §2.7), not this phase, so
+        // it is intentionally not written here (stays 0, as today).
+        bool MicBoost = false,
+        bool MicLineIn = false,
+        bool MicTrs = false,
+        bool MicBias = false,
+        byte LineInGain = 0);
 
     /// <summary>
     /// Write the 5 C&amp;C bytes for <paramref name="register"/> given the current
@@ -296,6 +322,18 @@ internal static class ControlFrame
                 if (state.Board == HpsdrBoardKind.HermesLite2 && state.Mox)
                 {
                     cc[2] |= 0x08;
+                }
+                // Hermes-class codec boards carry mic_boost (C2[0]) and
+                // mic_linein (C2[1]) on this 0x12 frame — Thetis
+                // networkproto1.c:581, piHPSDR old_protocol.c:2154-2156. HL2
+                // has no stream codec and routes mic/line through the 0x14
+                // frame instead, so it is excluded here. Both default false so
+                // an operator who never touches the audio panel emits the same
+                // bytes as today (byte-identical default-unsent).
+                else if (state.Board != HpsdrBoardKind.HermesLite2)
+                {
+                    if (state.MicBoost) cc[2] |= 0x01;   // C2[0] mic_boost
+                    if (state.MicLineIn) cc[2] |= 0x02;  // C2[1] mic_linein
                 }
                 break;
 
@@ -358,6 +396,30 @@ internal static class ControlFrame
         c14[2] = 0;   // C3
         c14[3] = c4;
 
+        // HL2 mic front-end (external-ports plan, Phase 4). This C0=0x14 frame
+        // is register 0x0a, which on HL2 carries the real mic/line-in front-
+        // end ALONGSIDE puresignal_run and the C4 step-attenuator byte. The
+        // verified layout (Thetis networkproto1.c:597-599 case 11; identical in
+        // mi0bot):
+        //   C1[4] = mic_trs, C1[5] = mic_bias, C1[6] = mic_ptt
+        //   C2[4:0] = line_in_gain, C2[6] = puresignal_run
+        // We READ-MODIFY-WRITE: set ONLY the audio bits, leaving the C4 PGA /
+        // step-attenuator byte (already in c14[3]) and the C2[6] PS bit (set
+        // below) untouched. mic_ptt is a PTT-IN concern (plan §2.7), not this
+        // phase, so C1[6] is intentionally left 0 — same as today. mic_bias
+        // (C1[5]) defaults OFF: enabling it on a floating connector can hang
+        // PTT, so the operator must opt in explicitly via the audio panel.
+        if (s.Board == HpsdrBoardKind.HermesLite2)
+        {
+            byte c1 = 0;
+            if (s.MicTrs)  c1 |= 1 << 4;   // C1[4] mic_trs
+            if (s.MicBias) c1 |= 1 << 5;   // C1[5] mic_bias
+            c14[0] = c1;
+            // line_in_gain is the low 5 bits of C2; OR it in so the PS bit
+            // (set below) and the reserved high bits stay clear.
+            c14[1] |= (byte)(s.LineInGain & 0x1F);
+        }
+
         // HL2 PureSignal: register 0x0a bit 22 = puresignal_run. Bit 22 lives
         // in C2 bit 6 (22 - 16 = 6) of this same C0=0x14 frame. mi0bot
         // networkproto1.c:1102 — `C2 = (line_in_gain & 0b00011111) |
@@ -365,7 +427,8 @@ internal static class ControlFrame
         // have their PS-enable bit elsewhere on the wire (Protocol 2's
         // ALEX_PS_BIT) so we only flip C2[6] when we know we're talking to
         // an HL2. Issue #172. PR #119 placed this in C3 — that bug is the
-        // canonical regression to guard.
+        // canonical regression to guard. The audio OR above does NOT touch
+        // C2[6], so adding line_in_gain can never disturb puresignal_run.
         if (s.Board == HpsdrBoardKind.HermesLite2 && s.PsEnabled)
         {
             c14[1] |= 1 << 6;   // C2 bit 6 = puresignal_run

--- a/Zeus.Protocol1/ControlFrame.cs
+++ b/Zeus.Protocol1/ControlFrame.cs
@@ -491,9 +491,44 @@ internal static class ControlFrame
         // them, so the rename is purely client-side.
         if (s.EnableHl2BandVolts) c3 |= 1 << 3;
         if (s.PreampOn) c3 |= 1 << 4;             // Q#2: single global preamp bit for MVP.
-        c3 |= (byte)(((byte)s.RxAntenna & 0x07) << 5);
+        // RX-antenna relay bits C3[7:5]. Emitted through the external-port
+        // encoder seam (see Zeus.Server.Hosting.IExternalPortEncoder) so every
+        // antenna-relay bit on the wire flows through one board-branched
+        // firewall. This pure helper is the single source of the C3[7:5] math;
+        // the encoder calls it too, guaranteeing the bytes are identical.
+        c3 |= EncodeRxAntennaC3Bits(s.RxAntenna, s.Board);
         c14[2] = c3;
 
+        WriteC4DuplexAndRxCount(c14, in s);
+    }
+
+    /// <summary>
+    /// Pure encoder for the Protocol-1 Config-frame RX-antenna relay bits
+    /// (C3[7:5]). Single source of truth for the antenna-relay math: both the
+    /// inline Config-frame write and
+    /// <c>Zeus.Server.Hosting.Protocol1PortEncoder</c> call this, so the bytes
+    /// on the wire are identical regardless of who composed them.
+    ///
+    /// Phase-1 (external-ports plan) is BYTE-IDENTICAL — the wire-layer clamp
+    /// that forces ANT1 on relay-less boards (HL2's single jack drives the
+    /// N2ADR antenna pad off C3[5], not an ANT1/2/3 relay) is scaffolded here
+    /// but intentionally inert: it activates in Phase 2 together with its own
+    /// differential golden test. Until then this reproduces today's emission
+    /// exactly — including HL2's raw C3[7:5] value.
+    /// </summary>
+    internal static byte EncodeRxAntennaC3Bits(HpsdrAntenna rxAntenna, HpsdrBoardKind board)
+    {
+        // Phase 2 will clamp here: `if (!HasRxAntennaRelays(board)) rxAntenna =
+        // HpsdrAntenna.Ant1;`. Kept inert in Phase 1 so the refactor is
+        // byte-identical (the capability lives in Zeus.Server.Hosting, which
+        // this assembly cannot reference; the clamp moves to the encoder seam
+        // where the capability table is available).
+        _ = board;
+        return (byte)(((byte)rxAntenna & 0x07) << 5);
+    }
+
+    private static void WriteC4DuplexAndRxCount(Span<byte> c14, in CcState s)
+    {
         // C4: Alex TX antenna [1:0] = 0 (RX-only MVP), duplex [2] = 1 (always, per
         // old_protocol.c:2661), N-1 receivers at [5:3]. mi0bot
         // networkproto1.c:973 — `C4 |= (nddc - 1) << 3`. Single-RX default

--- a/Zeus.Protocol1/ControlFrame.cs
+++ b/Zeus.Protocol1/ControlFrame.cs
@@ -509,23 +509,35 @@ internal static class ControlFrame
     /// <c>Zeus.Server.Hosting.Protocol1PortEncoder</c> call this, so the bytes
     /// on the wire are identical regardless of who composed them.
     ///
-    /// Phase-1 (external-ports plan) is BYTE-IDENTICAL — the wire-layer clamp
-    /// that forces ANT1 on relay-less boards (HL2's single jack drives the
-    /// N2ADR antenna pad off C3[5], not an ANT1/2/3 relay) is scaffolded here
-    /// but intentionally inert: it activates in Phase 2 together with its own
-    /// differential golden test. Until then this reproduces today's emission
-    /// exactly — including HL2's raw C3[7:5] value.
+    /// Phase 2 (external-ports plan) ACTIVATES the wire-layer clamp: on a board
+    /// with no RX-antenna relay (HL2's single jack — C3[5] forwards to the
+    /// N2ADR antenna pad, it does NOT drive an ANT1/2/3 relay), the selection
+    /// is forced to ANT1 here so a stale per-band ANT2/3 value can never flip
+    /// the N2ADR pad. This is the wire layer of the three-layer defence (UI /
+    /// REST / wire); it holds even if an upstream layer is bypassed. For every
+    /// relay-capable board the bytes are unchanged — byte-identical to Phase 1
+    /// and to today, so the default-ANT1 golden tests stay green.
     /// </summary>
     internal static byte EncodeRxAntennaC3Bits(HpsdrAntenna rxAntenna, HpsdrBoardKind board)
     {
-        // Phase 2 will clamp here: `if (!HasRxAntennaRelays(board)) rxAntenna =
-        // HpsdrAntenna.Ant1;`. Kept inert in Phase 1 so the refactor is
-        // byte-identical (the capability lives in Zeus.Server.Hosting, which
-        // this assembly cannot reference; the clamp moves to the encoder seam
-        // where the capability table is available).
-        _ = board;
+        // Wire-layer clamp: relay-less boards (HL2) ignore an ANT2/3 request.
+        // The capability record proper lives in Zeus.Server.Hosting (which this
+        // assembly cannot reference), so the single relay-less P1 board is named
+        // directly here — see BoardCapabilities.HasRxAntennaRelays, false for HL2
+        // only across the P1 lineup.
+        if (!P1BoardHasRxAntennaRelays(board)) rxAntenna = HpsdrAntenna.Ant1;
         return (byte)(((byte)rxAntenna & 0x07) << 5);
     }
+
+    /// <summary>
+    /// Whether a Protocol-1 board has switchable RX-antenna relays (ANT1/2/3).
+    /// Mirrors <c>BoardCapabilities.HasRxAntennaRelays</c> for the P1 lineup:
+    /// every ANAN / Hermes-class board does; Hermes-Lite 2 does not (single
+    /// jack). Kept local to the protocol assembly so the wire-layer clamp does
+    /// not need a reference to Zeus.Server.Hosting.
+    /// </summary>
+    internal static bool P1BoardHasRxAntennaRelays(HpsdrBoardKind board) =>
+        board != HpsdrBoardKind.HermesLite2;
 
     private static void WriteC4DuplexAndRxCount(Span<byte> c14, in CcState s)
     {

--- a/Zeus.Protocol1/IProtocol1Client.cs
+++ b/Zeus.Protocol1/IProtocol1Client.cs
@@ -262,6 +262,15 @@ public interface IProtocol1Client : IDisposable
     void SetAudioFrontEnd(bool micBoost, bool micLineIn, bool micTrs, bool micBias, int lineInGain);
 
     /// <summary>
+    /// HL2 user GPIO (external-ports plan, Phase 5). Sets the 4-bit
+    /// <c>user_dig_out</c> mask emitted on the 0x14 frame C3[3:0] → MCP23008
+    /// (bits above the low nibble are masked off). HL2 only — on other boards
+    /// the value is stored but never reaches the wire (ControlFrame keeps C3 at
+    /// 0). Default 0 is byte-identical to today.
+    /// </summary>
+    void SetUserDigOut(int mask);
+
+    /// <summary>
     /// 1024-sample paired feedback blocks decoded from the EP6 stream when
     /// PS is armed. TX side comes from the in-flight TX-IQ ring (the
     /// samples we just wrote to the wire); RX side is DDC1, the dedicated

--- a/Zeus.Protocol1/IProtocol1Client.cs
+++ b/Zeus.Protocol1/IProtocol1Client.cs
@@ -250,6 +250,18 @@ public interface IProtocol1Client : IDisposable
     void SetCwKeyerConfig(int wpm, CwKeyerMode mode);
 
     /// <summary>
+    /// Set the audio front-end (external-ports plan, Phase 4). Global per-radio.
+    /// <paramref name="micBoost"/> / <paramref name="micLineIn"/> ride the 0x12
+    /// frame on Hermes-class codec boards; <paramref name="micTrs"/> /
+    /// <paramref name="micBias"/> / <paramref name="lineInGain"/> (0..31) ride
+    /// the 0x14 frame on HL2 via read-modify-write (PureSignal + step-att
+    /// preserved). Per-board gating lives in <see cref="ControlFrame"/>, so a
+    /// value for the wrong board is ignored on the wire. mic_bias defaults OFF
+    /// (floating-connector PTT-hang guard).
+    /// </summary>
+    void SetAudioFrontEnd(bool micBoost, bool micLineIn, bool micTrs, bool micBias, int lineInGain);
+
+    /// <summary>
     /// 1024-sample paired feedback blocks decoded from the EP6 stream when
     /// PS is armed. TX side comes from the in-flight TX-IQ ring (the
     /// samples we just wrote to the wire); RX side is DDC1, the dedicated

--- a/Zeus.Protocol1/Protocol1Client.cs
+++ b/Zeus.Protocol1/Protocol1Client.cs
@@ -86,6 +86,12 @@ public sealed class Protocol1Client : IProtocol1Client
     private int _preamp;       // 0 / 1
     private int _attenDb;      // 0..31 dB (HpsdrAtten value)
     private int _antenna = (int)HpsdrAntenna.Ant1;
+    // Antenna selection deferred while keyed (external-ports plan, Phase 2,
+    // §3.4(1)). The C&C TX loop reads _antenna every frame, so applying a new
+    // RX-antenna mid-key would hot-switch the relay under power. SetAntennaRx
+    // stashes here while MOX is active; SetMox(false) flushes it to _antenna on
+    // the unkey edge. -1 = nothing pending.
+    private int _pendingAntenna = -1;
     // HL2 Band Volts PWM enable. Wire encoding is C3 bit 3 of the Config
     // frame — same bit that legacy HPSDR boards used for ADC DITHER, which
     // HL2's AD9866 doesn't need (see hermes-lite2-protocol.md line 39 and
@@ -566,12 +572,36 @@ public sealed class Protocol1Client : IProtocol1Client
     public void SetSampleRate(HpsdrSampleRate rate) => Interlocked.Exchange(ref _rate, (int)rate);
     public void SetPreamp(bool on) => Interlocked.Exchange(ref _preamp, on ? 1 : 0);
     public void SetAttenuator(HpsdrAtten atten) => Interlocked.Exchange(ref _attenDb, atten.ClampedDb);
-    public void SetAntennaRx(HpsdrAntenna ant) => Interlocked.Exchange(ref _antenna, (int)ant);
+    public void SetAntennaRx(HpsdrAntenna ant)
+    {
+        // §3.4(1): never hot-switch the RX-antenna relay while keyed. Defer to
+        // the unkey edge (SetMox(false) flushes _pendingAntenna). Reads of _mox
+        // and the two writes don't need to be atomic w.r.t. each other — a
+        // change racing the MOX edge is resolved by SetMox's flush either way.
+        if (Volatile.Read(ref _mox) != 0)
+        {
+            Interlocked.Exchange(ref _pendingAntenna, (int)ant);
+            return;
+        }
+        Interlocked.Exchange(ref _pendingAntenna, -1);
+        Interlocked.Exchange(ref _antenna, (int)ant);
+    }
     public void SetBoardKind(HpsdrBoardKind board) => Interlocked.Exchange(ref _boardKind, (int)board);
 
     public HpsdrBoardKind BoardKind => (HpsdrBoardKind)Volatile.Read(ref _boardKind);
     public void SetHasN2adr(bool hasN2adr) => Interlocked.Exchange(ref _hasN2adr, hasN2adr ? 1 : 0);
-    public void SetMox(bool on) => Interlocked.Exchange(ref _mox, on ? 1 : 0);
+    public void SetMox(bool on)
+    {
+        Interlocked.Exchange(ref _mox, on ? 1 : 0);
+        // Unkey edge: apply any RX-antenna change deferred while keyed so the
+        // relay switches at idle, never under power (§3.4(1)). The next C&C
+        // frame then carries the operator's selection.
+        if (!on)
+        {
+            int pending = Interlocked.Exchange(ref _pendingAntenna, -1);
+            if (pending >= 0) Interlocked.Exchange(ref _antenna, pending);
+        }
+    }
     public void SetDrive(int percent) =>
         Interlocked.Exchange(ref _drivePct, Math.Clamp(percent, 0, 100));
 

--- a/Zeus.Protocol1/Protocol1Client.cs
+++ b/Zeus.Protocol1/Protocol1Client.cs
@@ -139,6 +139,9 @@ public sealed class Protocol1Client : IProtocol1Client
     private int _micTrs;       // 0 / 1
     private int _micBias;      // 0 / 1
     private int _lineInGain;   // 0..31 (5-bit HL2 line_in_gain)
+    // HL2 user GPIO (external-ports plan, Phase 5). 4-bit user_dig_out emitted
+    // on the 0x14 frame C3[3:0]. Default 0 → byte-identical to today.
+    private int _userDigOut;   // 0..15
     private long _droppedFrames;
     private long _totalFrames;
 
@@ -690,6 +693,18 @@ public sealed class Protocol1Client : IProtocol1Client
         Interlocked.Exchange(ref _lineInGain, Math.Clamp(lineInGain, 0, 31));
     }
 
+    /// <summary>
+    /// HL2 user GPIO (external-ports plan, Phase 5). 4-bit user_dig_out emitted
+    /// on the 0x14 frame C3[3:0] → MCP23008. Bits above the low nibble are
+    /// masked off. HL2 only — on other boards C3 stays 0 in ControlFrame, so
+    /// the value is stored but never reaches the wire. Default 0 (no bits set)
+    /// is byte-identical to today.
+    /// </summary>
+    public void SetUserDigOut(int mask)
+    {
+        Interlocked.Exchange(ref _userDigOut, mask & 0x0F);
+    }
+
     public void SetHl2TxStepAttenuationDb(int db)
     {
         // Range matches mi0bot console.cs:2084 (udTXStepAttData.Minimum=-28,
@@ -773,7 +788,8 @@ public sealed class Protocol1Client : IProtocol1Client
             MicLineIn: Volatile.Read(ref _micLineIn) != 0,
             MicTrs: Volatile.Read(ref _micTrs) != 0,
             MicBias: Volatile.Read(ref _micBias) != 0,
-            LineInGain: (byte)Volatile.Read(ref _lineInGain));
+            LineInGain: (byte)Volatile.Read(ref _lineInGain),
+            UserDigOut: (byte)Volatile.Read(ref _userDigOut));
     }
 
     private void RxLoop()

--- a/Zeus.Protocol1/Protocol1Client.cs
+++ b/Zeus.Protocol1/Protocol1Client.cs
@@ -129,6 +129,16 @@ public sealed class Protocol1Client : IProtocol1Client
     // a no-op until the operator opts into iambic. See zeus-bks.
     private int _cwKeyerSpeedWpm;
     private int _cwKeyerMode; // CwKeyerMode as int for Interlocked
+    // Audio front-end (external-ports plan, Phase 4). mic_boost / mic_linein
+    // ride the 0x12 frame on codec boards; mic_trs / mic_bias / line_in_gain
+    // ride the 0x14 frame on HL2 (read-modify-write — see ControlFrame). All
+    // default to the off / zero state so an untouched radio is byte-identical
+    // to today. mic_bias defaults OFF (floating-connector PTT-hang guard).
+    private int _micBoost;     // 0 / 1
+    private int _micLineIn;    // 0 / 1
+    private int _micTrs;       // 0 / 1
+    private int _micBias;      // 0 / 1
+    private int _lineInGain;   // 0..31 (5-bit HL2 line_in_gain)
     private long _droppedFrames;
     private long _totalFrames;
 
@@ -660,6 +670,26 @@ public sealed class Protocol1Client : IProtocol1Client
         Interlocked.Exchange(ref _cwKeyerMode, (int)mode);
     }
 
+    /// <summary>
+    /// Set the audio front-end state (external-ports plan, Phase 4). Global,
+    /// per-radio — not per-band. <paramref name="micBoost"/> /
+    /// <paramref name="micLineIn"/> ride the 0x12 frame on Hermes-class codec
+    /// boards; <paramref name="micTrs"/> / <paramref name="micBias"/> /
+    /// <paramref name="lineInGain"/> ride the 0x14 frame on HL2. Which fields
+    /// actually reach the wire is gated per-board in ControlFrame, so a value
+    /// for the wrong board is simply ignored. mic_bias defaults OFF and the
+    /// caller (RadioService / REST) guards the gate; passing it true is the
+    /// operator's explicit opt-in.
+    /// </summary>
+    public void SetAudioFrontEnd(bool micBoost, bool micLineIn, bool micTrs, bool micBias, int lineInGain)
+    {
+        Interlocked.Exchange(ref _micBoost, micBoost ? 1 : 0);
+        Interlocked.Exchange(ref _micLineIn, micLineIn ? 1 : 0);
+        Interlocked.Exchange(ref _micTrs, micTrs ? 1 : 0);
+        Interlocked.Exchange(ref _micBias, micBias ? 1 : 0);
+        Interlocked.Exchange(ref _lineInGain, Math.Clamp(lineInGain, 0, 31));
+    }
+
     public void SetHl2TxStepAttenuationDb(int db)
     {
         // Range matches mi0bot console.cs:2084 (udTXStepAttData.Minimum=-28,
@@ -738,7 +768,12 @@ public sealed class Protocol1Client : IProtocol1Client
             // untouched, fall through to the RX-side encoding above.
             Hl2TxAttnDb: Volatile.Read(ref _hl2TxAttnDb),
             CwKeyerSpeedWpm: Volatile.Read(ref _cwKeyerSpeedWpm),
-            CwKeyerMode: (CwKeyerMode)Volatile.Read(ref _cwKeyerMode));
+            CwKeyerMode: (CwKeyerMode)Volatile.Read(ref _cwKeyerMode),
+            MicBoost: Volatile.Read(ref _micBoost) != 0,
+            MicLineIn: Volatile.Read(ref _micLineIn) != 0,
+            MicTrs: Volatile.Read(ref _micTrs) != 0,
+            MicBias: Volatile.Read(ref _micBias) != 0,
+            LineInGain: (byte)Volatile.Read(ref _lineInGain));
     }
 
     private void RxLoop()

--- a/Zeus.Protocol2/AssemblyInfo.cs
+++ b/Zeus.Protocol2/AssemblyInfo.cs
@@ -45,3 +45,7 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Zeus.Protocol2.Tests")]
+// The external-port encoder seam (Zeus.Server.Hosting.IExternalPortEncoder)
+// delegates to Protocol2Client's pure Alex-word antenna-bit helpers so the
+// firewall and the wire path share one copy of the math — byte-identical.
+[assembly: InternalsVisibleTo("Zeus.Server.Hosting")]

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -202,6 +202,21 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     private int _pendingTxAntenna = -1;
     private int _pendingRxAntenna = -1;
     private bool _hasTxAntennaRelays;
+    // RX auxiliary input select (external-ports plan, Phase 5). Mirrors the
+    // RxSource enum (Zeus.Contracts) but as an int so this assembly needs no
+    // contracts-enum reference on the hot path: 0 = base ANT relay (no aux),
+    // 1 = EXT1, 2 = EXT2, 3 = XVTR, 4 = BYPASS (K36). When non-zero the alex0
+    // aux bits replace the base RX path. Defaults 0 → byte-identical to today.
+    // The K36/BYPASS pick can NEVER override PS feedback routing — PS arbitration
+    // runs AFTER the operator aux in SendCmdHighPriority (§3.4(2)). Deferred while
+    // keyed alongside the antennas (§3.4(1)).
+    private int _rxAuxInput;
+    private int _pendingRxAuxInput = -1;
+    // Whether the connected board's Alex/BPF board uses the ANAN-7000/Saturn
+    // master RX-select gating (bit 14 must accompany any aux selection). Set
+    // alongside the relay-population gate. MkII-BPF boards (0x0A / G2E) use it;
+    // classic-Alex boards do not.
+    private bool _mkiiBpfRxSelect;
     // Audio front-end (external-ports plan, Phase 4). Wire-encoded into the
     // TxSpecific (CmdTx, port 1026) packet byte 50 (mic_control flags) + byte
     // 51 (line_in_gain) — Thetis network.c:1234,1236. Both default 0, which is
@@ -662,24 +677,41 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     /// / MOX / OC / duplex bytes are untouched here.
     /// </summary>
     public void SetAntennas(int txAntWire, int rxAntWire, bool hasTxAntennaRelays)
+        => SetAntennas(txAntWire, rxAntWire, hasTxAntennaRelays, rxAuxInput: 0, mkiiBpfRxSelect: false);
+
+    /// <summary>
+    /// Phase-5 overload: also sets the RX auxiliary input
+    /// (<paramref name="rxAuxInput"/>: 0=base ANT, 1=EXT1, 2=EXT2, 3=XVTR,
+    /// 4=BYPASS) and the MkII-BPF master RX-select gate. The K36/BYPASS pick is
+    /// emitted on alex0 bit 11, but PureSignal external feedback OWNS that bit
+    /// while PS is armed — the arbitration runs in SendCmdHighPriority AFTER the
+    /// operator aux, so an aux=BYPASS choice can never steal the PS coupler
+    /// (§3.4(2)). Same mid-key deferral as the base antennas (§3.4(1)).
+    /// </summary>
+    public void SetAntennas(int txAntWire, int rxAntWire, bool hasTxAntennaRelays, int rxAuxInput, bool mkiiBpfRxSelect)
     {
         int tx = (txAntWire is 1 or 2 or 3) ? txAntWire : 1;
         int rx = (rxAntWire is 1 or 2 or 3) ? rxAntWire : 1;
+        int aux = (rxAuxInput is >= 0 and <= 4) ? rxAuxInput : 0;
         _hasTxAntennaRelays = hasTxAntennaRelays;
+        _mkiiBpfRxSelect = mkiiBpfRxSelect;
 
         if (_moxOn || _tuneActive)
         {
             // Keyed: stash the desired state, leave the live relay bits alone.
             _pendingTxAntenna = tx;
             _pendingRxAntenna = rx;
+            _pendingRxAuxInput = aux;
             return;
         }
 
-        bool changed = _txAntenna != tx || _rxAntenna != rx;
+        bool changed = _txAntenna != tx || _rxAntenna != rx || _rxAuxInput != aux;
         _txAntenna = tx;
         _rxAntenna = rx;
+        _rxAuxInput = aux;
         _pendingTxAntenna = -1;
         _pendingRxAntenna = -1;
+        _pendingRxAuxInput = -1;
         if (changed && _rxTask is not null) SendCmdHighPriority(run: true);
     }
 
@@ -689,14 +721,17 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // warranted (the caller's SendCmdHighPriority covers it).
     private bool FlushPendingAntennas()
     {
-        if (_pendingTxAntenna < 0 && _pendingRxAntenna < 0) return false;
+        if (_pendingTxAntenna < 0 && _pendingRxAntenna < 0 && _pendingRxAuxInput < 0) return false;
         int tx = _pendingTxAntenna >= 0 ? _pendingTxAntenna : _txAntenna;
         int rx = _pendingRxAntenna >= 0 ? _pendingRxAntenna : _rxAntenna;
-        bool changed = _txAntenna != tx || _rxAntenna != rx;
+        int aux = _pendingRxAuxInput >= 0 ? _pendingRxAuxInput : _rxAuxInput;
+        bool changed = _txAntenna != tx || _rxAntenna != rx || _rxAuxInput != aux;
         _txAntenna = tx;
         _rxAntenna = rx;
+        _rxAuxInput = aux;
         _pendingTxAntenna = -1;
         _pendingRxAntenna = -1;
+        _pendingRxAuxInput = -1;
         return changed;
     }
 
@@ -1431,6 +1466,18 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         uint alexCommon = ComputeAlexWord(_rxFreqHz, _rxFreqHz, txAnt: txAntWire, board: _boardKind);
         uint alex0 = alexCommon | (xmit ? ALEX_TX_RELAY : 0u);
         uint alex1 = alexCommon | (xmit ? ALEX_TX_RELAY | ALEX1_ANAN7000_RX_GNDonTX : 0u);
+
+        // RX auxiliary input select (external-ports plan, Phase 5). Emitted on
+        // alex0 — XVTR/EXT1/EXT2/BYPASS bits 8..11 (+ Saturn RX_SELECT bit 14).
+        // ORDER IS LOAD-BEARING (§3.4(2)): the operator aux bits are composed
+        // FIRST, then the PureSignal feedback routing is applied AFTER and
+        // OWNS the K36/BYPASS (bit 11) relay while PS is armed. This is the
+        // PS-K36 firewall — an operator aux=BYPASS choice can never steal the
+        // PS coupler. Computed via the shared pure helper so the golden test
+        // and the wire agree.
+        alex0 |= ComposeRxAuxBits(_rxAuxInput, _mkiiBpfRxSelect);
+
+        // ---- PureSignal feedback routing — applied AFTER operator aux (§3.4(2)) ----
         // ALEX_PS_BIT (0x00040000): pihpsdr new_protocol.c:994-998 ORs this
         // into alex0 (during xmit) and alex1 (always-on while PS armed). The
         // BPF board uses it to swap to the feedback-coupler tap on the TX
@@ -1443,7 +1490,12 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         // External (Bypass) feedback antenna — pihpsdr new_protocol.c:1284-
         // 1296 ORs ALEX_RX_ANTENNA_BYPASS into alex0 only during xmit when
         // PS is armed and the operator selected the external path. Internal
-        // coupler leaves this bit clear.
+        // coupler leaves this bit clear. PS OWNS the K36 relay here: this OR
+        // runs after the operator-aux OR above, so when PS is armed the coupler
+        // routing always lands regardless of the operator's aux pick. On a
+        // Legacy (Rev 15/16) Alex board PS external feedback must route to
+        // EXT1 (not BYPASS) — that branch lives in the encoder/capability layer
+        // (AlexRevision); the wire bit chosen here is the default modern BYPASS.
         if (_psFeedbackEnabled && _psFeedbackExternal && xmit)
         {
             alex0 |= AlexRxAntennaBypass;
@@ -1500,6 +1552,24 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // operator picks the external feedback path. Internal coupler leaves
     // this bit clear.
     internal const uint AlexRxAntennaBypass = 0x00000800;
+    // RX auxiliary input select bits (external-ports plan, Phase 5). Verified
+    // against pihpsdr src/alex.h:43-47 — the rx_only_antenna jacket relays in
+    // the alex0 word:
+    //   ALEX_RX_ANTENNA_XVTR   0x00000100  (bit 8)  XVTR-in   to RX1
+    //   ALEX_RX_ANTENNA_EXT1   0x00000200  (bit 9)  EXT1      to RX1
+    //   ALEX_RX_ANTENNA_EXT2   0x00000400  (bit 10) EXT2      to RX1
+    //   ALEX_RX_ANTENNA_BYPASS 0x00000800  (bit 11) BYPASS (K36) — SAME bit as
+    //                                       AlexRxAntennaBypass above (PS owns it
+    //                                       while armed; §3.4(2)).
+    // On the ANAN-7000/8000/G2 (Saturn-BPF) boards a master "RX select" bit
+    // additionally gates the aux jacks onto the RX (alex.h:122
+    // ALEX0_ANAN7000_RX_SELECT 0x00004000, bit 14). The aux bits are inert on
+    // those boards unless bit 14 is also set, so RX_SELECT is OR'd in alongside
+    // any non-base aux selection on MkII-BPF boards.
+    internal const uint AlexRxAntennaXvtr   = 0x00000100;
+    internal const uint AlexRxAntennaExt1   = 0x00000200;
+    internal const uint AlexRxAntennaExt2   = 0x00000400;
+    internal const uint Alex0Anan7000RxSelect = 0x00004000;
     // Alex1-only: grounds the RX input while keyed so the hot TX field doesn't
     // back-feed into the Mercury ADC (pihpsdr alex.h ANAN7000_RX_GNDonTX).
     private const uint ALEX1_ANAN7000_RX_GNDonTX = 0x00000100;
@@ -1530,15 +1600,22 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         bool psExternal,
         HpsdrBoardKind board = HpsdrBoardKind.OrionMkII,
         int txAntWire = 1,
-        bool hasTxAntennaRelays = false)
+        bool hasTxAntennaRelays = false,
+        int rxAuxInput = 0,
+        bool mkiiBpfRxSelect = false)
     {
-        // Mirrors the SendCmdHighPriority alex0 path including the Phase-2 TX-
-        // antenna gate: hasTxAntennaRelays false stays on ANT1, true threads
-        // the 1-based wire selector. Default args reproduce the pre-Phase-2
-        // hardcoded ANT1 word, so the original golden tests stay byte-identical.
+        // Mirrors the SendCmdHighPriority alex0 path EXACTLY, in the same order,
+        // so the golden test asserts real behaviour:
+        //   1. base BPF/LPF/TX-ant bits (Phase-2 TX-antenna gate)
+        //   2. TX_RELAY during xmit
+        //   3. operator RX-aux bits (Phase 5) — composed FIRST
+        //   4. PureSignal feedback routing — applied AFTER, owns K36 (§3.4(2))
+        // Default args reproduce the pre-Phase-5 word, so the older golden
+        // tests stay byte-identical.
         int wire = hasTxAntennaRelays ? txAntWire : 1;
         uint alexCommon = ComputeAlexWord(rxFreqHz, rxFreqHz, txAnt: wire, board: board);
         uint alex0 = alexCommon | (moxOn ? ALEX_TX_RELAY : 0u);
+        alex0 |= ComposeRxAuxBits(rxAuxInput, mkiiBpfRxSelect);
         if (psEnabled && moxOn) alex0 |= AlexPsBit;
         if (psEnabled && psExternal && moxOn) alex0 |= AlexRxAntennaBypass;
         return alex0;
@@ -1598,6 +1675,39 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         3 => ALEX_TX_ANTENNA_3,
         _ => ALEX_TX_ANTENNA_1,
     };
+
+    /// <summary>
+    /// Pure encoder for the Protocol-2 alex0 RX-auxiliary-input bits
+    /// (external-ports plan, Phase 5). Single source of truth for the aux-relay
+    /// math, shared by <see cref="SendCmdHighPriority"/> and the PS-K36
+    /// arbitration golden test.
+    ///
+    /// <paramref name="rxAux"/> selects the aux feed: 0=base ANT (no aux bits),
+    /// 1=EXT1, 2=EXT2, 3=XVTR, 4=BYPASS(K36). On MkII-BPF (Saturn) boards the
+    /// master RX-select bit (bit 14) is OR'd in alongside any non-base aux so
+    /// the jacks are actually gated onto the RX (alex.h:122); classic-Alex
+    /// boards leave bit 14 clear. Returns 0 for the base ANT path — byte-
+    /// identical to today's alex0 when no aux is selected.
+    ///
+    /// NOTE on the K36 (BYPASS) bit: this helper returns
+    /// <see cref="AlexRxAntennaBypass"/> for an operator BYPASS pick, but the
+    /// caller applies PureSignal feedback routing AFTER this, so PS owns the
+    /// relay while armed (§3.4(2)). This helper never inspects PS state — the
+    /// arbitration is purely "PS OR runs last".
+    /// </summary>
+    internal static uint ComposeRxAuxBits(int rxAux, bool mkiiBpfRxSelect)
+    {
+        uint bits = rxAux switch
+        {
+            1 => AlexRxAntennaExt1,
+            2 => AlexRxAntennaExt2,
+            3 => AlexRxAntennaXvtr,
+            4 => AlexRxAntennaBypass,
+            _ => 0u,
+        };
+        if (bits != 0 && mkiiBpfRxSelect) bits |= Alex0Anan7000RxSelect;
+        return bits;
+    }
 
     // RX BPF band splits lifted from pihpsdr new_protocol.c
     // (function new_protocol_high_priority, ADC0 BPFfreq selection).

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -1463,8 +1463,21 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         // is the 1-based wire selector and is only ever updated at idle (mid-key
         // changes defer — §3.4(1)), so the relay matrix is never hot-switched.
         int txAntWire = _hasTxAntennaRelays ? _txAntenna : 1;
+        // alex0 ANT1/2/3 bits [26:24] are STATE-MULTIPLEXED (pihpsdr
+        // new_protocol.c:1331-1357): during RX they reflect the RX antenna;
+        // during TX — or when RX is on an aux input (EXT/XVTR/BYPASS), where the
+        // ANT relay isn't used for RX — they reflect the TX antenna. alex1 ALWAYS
+        // reflects TX. Bench finding (G2): without this, changing the TX antenna
+        // also moved the RX path and the RX-antenna selector did nothing, because
+        // alex0 always carried the TX antenna.
+        int alex0AntWire = (xmit || _rxAuxInput != 0)
+            ? txAntWire
+            : ((_rxAntenna is 1 or 2 or 3) ? _rxAntenna : 1);
         uint alexCommon = ComputeAlexWord(_rxFreqHz, _rxFreqHz, txAnt: txAntWire, board: _boardKind);
-        uint alex0 = alexCommon | (xmit ? ALEX_TX_RELAY : 0u);
+        // alex1 keeps the TX antenna from alexCommon; alex0 swaps in the
+        // state-correct antenna (clear [26:24], re-OR via the shared encoder).
+        uint alex0 = (alexCommon & ~ALEX_TX_ANTENNA_MASK) | EncodeTxAntennaBits(alex0AntWire)
+                     | (xmit ? ALEX_TX_RELAY : 0u);
         uint alex1 = alexCommon | (xmit ? ALEX_TX_RELAY | ALEX1_ANAN7000_RX_GNDonTX : 0u);
 
         // RX auxiliary input select (external-ports plan, Phase 5). Emitted on
@@ -1539,6 +1552,7 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     private const uint ALEX_TX_ANTENNA_1   = 0x01000000;
     private const uint ALEX_TX_ANTENNA_2   = 0x02000000;
     private const uint ALEX_TX_ANTENNA_3   = 0x04000000;
+    private const uint ALEX_TX_ANTENNA_MASK = ALEX_TX_ANTENNA_1 | ALEX_TX_ANTENNA_2 | ALEX_TX_ANTENNA_3; // [26:24]
 
     // Flips the T/R relay on the LPF board so the TX path reaches the antenna
     // through the selected TX LPF instead of through the RX BPF path. OR'd
@@ -1602,19 +1616,25 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         int txAntWire = 1,
         bool hasTxAntennaRelays = false,
         int rxAuxInput = 0,
-        bool mkiiBpfRxSelect = false)
+        bool mkiiBpfRxSelect = false,
+        int rxAntWire = 1)
     {
         // Mirrors the SendCmdHighPriority alex0 path EXACTLY, in the same order,
         // so the golden test asserts real behaviour:
-        //   1. base BPF/LPF/TX-ant bits (Phase-2 TX-antenna gate)
+        //   1. base BPF/LPF bits + STATE-MULTIPLEXED ANT1/2/3 (RX ant on RX,
+        //      TX ant on xmit / RX-on-aux) — pihpsdr new_protocol.c:1331-1357
         //   2. TX_RELAY during xmit
         //   3. operator RX-aux bits (Phase 5) — composed FIRST
         //   4. PureSignal feedback routing — applied AFTER, owns K36 (§3.4(2))
-        // Default args reproduce the pre-Phase-5 word, so the older golden
-        // tests stay byte-identical.
+        // Default args (rx ant = tx ant = ANT1) reproduce the prior word, so the
+        // older golden tests stay byte-identical.
         int wire = hasTxAntennaRelays ? txAntWire : 1;
+        int alex0AntWire = (moxOn || rxAuxInput != 0)
+            ? wire
+            : ((rxAntWire is 1 or 2 or 3) ? rxAntWire : 1);
         uint alexCommon = ComputeAlexWord(rxFreqHz, rxFreqHz, txAnt: wire, board: board);
-        uint alex0 = alexCommon | (moxOn ? ALEX_TX_RELAY : 0u);
+        uint alex0 = (alexCommon & ~ALEX_TX_ANTENNA_MASK) | EncodeTxAntennaBits(alex0AntWire)
+                     | (moxOn ? ALEX_TX_RELAY : 0u);
         alex0 |= ComposeRxAuxBits(rxAuxInput, mkiiBpfRxSelect);
         if (psEnabled && moxOn) alex0 |= AlexPsBit;
         if (psEnabled && psExternal && moxOn) alex0 |= AlexRxAntennaBypass;

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -202,6 +202,15 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     private int _pendingTxAntenna = -1;
     private int _pendingRxAntenna = -1;
     private bool _hasTxAntennaRelays;
+    // Audio front-end (external-ports plan, Phase 4). Wire-encoded into the
+    // TxSpecific (CmdTx, port 1026) packet byte 50 (mic_control flags) + byte
+    // 51 (line_in_gain) — Thetis network.c:1234,1236. Both default 0, which is
+    // byte-identical to today's all-zero CmdTx tail. mic_control bit layout
+    // (Thetis network.c:1226-1233): bit0=line_in, bit1=mic_boost,
+    // bit4=mic_bias_enable, bit5=balanced(XLR) input. Composed in
+    // ComposeCmdTxBuffer; SetAudioFrontEnd re-pushes CmdTx so the change lands.
+    private byte _micControl;
+    private byte _lineInGain;
     private bool _moxOn;
     private bool _tuneActive;
     private long _totalFrames;
@@ -1204,8 +1213,35 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
 
     private void SendCmdTx()
     {
-        var p = ComposeCmdTxBuffer(_seqCmdTx++, (ushort)_sampleRateKhz, _txStepAttnDb, _paEnabled, _psFeedbackEnabled);
+        var p = ComposeCmdTxBuffer(_seqCmdTx++, (ushort)_sampleRateKhz, _txStepAttnDb, _paEnabled, _psFeedbackEnabled, _micControl, _lineInGain);
         _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1026));
+    }
+
+    // TxSpecific byte-50 mic_control bit flags (Thetis network.c:1226-1233).
+    internal const byte MicControlLineIn   = 0x01; // bit0 — line-in select
+    internal const byte MicControlMicBoost = 0x02; // bit1 — mic boost
+    internal const byte MicControlMicBias  = 0x10; // bit4 — enable Orion mic bias
+    internal const byte MicControlXlr      = 0x20; // bit5 — balanced (XLR) input (Saturn)
+
+    /// <summary>
+    /// Set the audio front-end (external-ports plan, Phase 4). Global per-radio.
+    /// Composes the TxSpecific byte-50 mic_control flags and byte-51
+    /// line_in_gain (Thetis network.c:1234,1236) and re-pushes CmdTx so the
+    /// radio honours them on the next TX cycle. Defaults (all false / 0) leave
+    /// the CmdTx tail byte-identical to today. Bits 2/3 (mic PTT enable / tip-
+    /// ring routing) are PTT-IN routing (plan §2.7), not this phase, so they
+    /// stay 0. mic_bias defaults OFF — the caller guards the gate.
+    /// </summary>
+    public void SetAudioFrontEnd(bool lineIn, bool micBoost, bool micBias, bool xlr, byte lineInGain)
+    {
+        byte ctl = 0;
+        if (lineIn)   ctl |= MicControlLineIn;
+        if (micBoost) ctl |= MicControlMicBoost;
+        if (micBias)  ctl |= MicControlMicBias;
+        if (xlr)      ctl |= MicControlXlr;
+        _micControl = ctl;
+        _lineInGain = lineInGain;
+        if (_rxTask is not null) SendCmdTx();
     }
 
     // Test-seamed Compose for the CmdTx (TxSpecific) packet. Layout per
@@ -1232,12 +1268,19 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // 57/58/59) — operator's normal voice TX has been validated working
     // with that wire form on G2 MkII, so we don't ship a wire change
     // beyond the PS-armed window in this patch.
-    internal static byte[] ComposeCmdTxBuffer(uint seq, ushort sampleRateKhz, byte txStepAttnDb, bool paEnabled, bool psEnabled)
+    internal static byte[] ComposeCmdTxBuffer(uint seq, ushort sampleRateKhz, byte txStepAttnDb, bool paEnabled, bool psEnabled, byte micControl = 0, byte lineInGain = 0)
     {
         var p = new byte[60];
         WriteBeU32(p, 0, seq);
         p[4] = 1;                 // num_dac
         WriteBeU16(p, 14, sampleRateKhz);
+
+        // Audio front-end (external-ports plan, Phase 4). Byte 50 = mic_control
+        // flags, byte 51 = line_in_gain — Thetis network.c:1234,1236. Both
+        // default 0, so an untouched audio front-end is byte-identical to the
+        // historical all-zero tail.
+        p[50] = micControl;
+        p[51] = lineInGain;
 
         if (psEnabled)
         {

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -186,6 +186,22 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // out as the reserved-bit safe default for non-Anvelina firmware.
     private byte _ocDxTxMask;
     private byte _ocDxRxMask;
+    // TX/RX antenna relay selection (external-ports plan, Phase 2). 1-based wire
+    // selector (1=ANT1, 2=ANT2, 3=ANT3) — same convention as
+    // EncodeTxAntennaBits, so this assembly needs no reference to the
+    // HpsdrAntenna enum (which lives in Zeus.Protocol1; P2 references only
+    // Zeus.Contracts). _txAntenna feeds alex0[26:24] via ComputeAlexWord;
+    // _rxAntenna is carried for the RX-antenna Alex path (Phase 5). These are
+    // the *applied* values — the wire reads them. While keyed, an operator
+    // setter stashes into _pending* and is flushed on the next unkey edge so
+    // the Alex relay matrix is never hot-switched under power (§3.4(1)). The
+    // [26:24] emission is additionally gated on _hasTxAntennaRelays so single-
+    // relay / non-relay boards never advertise ANT2/3. -1 = nothing pending.
+    private int _txAntenna = 1;
+    private int _rxAntenna = 1;
+    private int _pendingTxAntenna = -1;
+    private int _pendingRxAntenna = -1;
+    private bool _hasTxAntennaRelays;
     private bool _moxOn;
     private bool _tuneActive;
     private long _totalFrames;
@@ -620,6 +636,61 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         if (_rxTask is not null) SendCmdHighPriority(run: true);
     }
 
+    /// <summary>
+    /// Set the TX/RX antenna relay selection (external-ports plan, Phase 2).
+    /// <paramref name="txAntWire"/>/<paramref name="rxAntWire"/> are the 1-based
+    /// wire selectors (1=ANT1, 2=ANT2, 3=ANT3); out-of-range coerces to ANT1.
+    /// <paramref name="hasTxAntennaRelays"/> is the board/variant relay gate
+    /// (from <c>BoardCapabilities.HasTxAntennaRelays</c>) — when false the
+    /// alex0[26:24] TX-antenna bits stay on ANT1 regardless of selection, so a
+    /// single-relay / non-relay variant never advertises ANT2/3.
+    ///
+    /// SAFETY (§3.4(1)): the Alex relay matrix must never be hot-switched while
+    /// keyed. When MOX or TUNE is active this defers the new selection into
+    /// <see cref="_pendingTxAntenna"/>/<see cref="_pendingRxAntenna"/> and does
+    /// NOT re-push HighPriority; the deferred value is flushed and emitted on
+    /// the next unkey edge (<see cref="SetMox"/>/<see cref="SetTune"/> off). PS
+    /// / MOX / OC / duplex bytes are untouched here.
+    /// </summary>
+    public void SetAntennas(int txAntWire, int rxAntWire, bool hasTxAntennaRelays)
+    {
+        int tx = (txAntWire is 1 or 2 or 3) ? txAntWire : 1;
+        int rx = (rxAntWire is 1 or 2 or 3) ? rxAntWire : 1;
+        _hasTxAntennaRelays = hasTxAntennaRelays;
+
+        if (_moxOn || _tuneActive)
+        {
+            // Keyed: stash the desired state, leave the live relay bits alone.
+            _pendingTxAntenna = tx;
+            _pendingRxAntenna = rx;
+            return;
+        }
+
+        bool changed = _txAntenna != tx || _rxAntenna != rx;
+        _txAntenna = tx;
+        _rxAntenna = rx;
+        _pendingTxAntenna = -1;
+        _pendingRxAntenna = -1;
+        if (changed && _rxTask is not null) SendCmdHighPriority(run: true);
+    }
+
+    // Apply any antenna selection deferred while keyed. Called on the unkey
+    // edge from SetMox/SetTune AFTER the MOX/TUNE flag clears, so the relay
+    // re-push happens at idle, never under power. Returns true if a re-push is
+    // warranted (the caller's SendCmdHighPriority covers it).
+    private bool FlushPendingAntennas()
+    {
+        if (_pendingTxAntenna < 0 && _pendingRxAntenna < 0) return false;
+        int tx = _pendingTxAntenna >= 0 ? _pendingTxAntenna : _txAntenna;
+        int rx = _pendingRxAntenna >= 0 ? _pendingRxAntenna : _rxAntenna;
+        bool changed = _txAntenna != tx || _rxAntenna != rx;
+        _txAntenna = tx;
+        _rxAntenna = rx;
+        _pendingTxAntenna = -1;
+        _pendingRxAntenna = -1;
+        return changed;
+    }
+
     public void SetPaEnabled(bool enabled)
     {
         _paEnabled = enabled;
@@ -630,6 +701,11 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     {
         _moxOn = on;
         if (!on) ResetTxIq();
+        // Unkey edge: apply any antenna selection deferred while keyed (§3.4(1))
+        // before the HighPriority re-push, so the relay matrix switches at idle
+        // and the very next HP frame carries the operator's new antenna. Only
+        // flush when fully unkeyed (a TUNE could still be active).
+        if (!on && !_tuneActive) FlushPendingAntennas();
         if (_rxTask is not null) SendCmdHighPriority(run: true);
     }
 
@@ -637,6 +713,7 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     {
         _tuneActive = on;
         if (!on) ResetTxIq();
+        if (!on && !_moxOn) FlushPendingAntennas();
         if (_rxTask is not null) SendCmdHighPriority(run: true);
     }
 
@@ -1302,7 +1379,13 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         // harmonics. Alex1 additionally gets RX_GNDonTX to short the RX input
         // while keyed, protecting the ADC.
         bool xmit = _moxOn || _tuneActive;
-        uint alexCommon = ComputeAlexWord(_rxFreqHz, _rxFreqHz, txAnt: 1, board: _boardKind);
+        // TX-antenna relay select (external-ports plan, Phase 2). Gate the
+        // alex0[26:24] emission on the board/variant relay population: a non-
+        // relay variant stays on ANT1 and never advertises ANT2/3. _txAntenna
+        // is the 1-based wire selector and is only ever updated at idle (mid-key
+        // changes defer — §3.4(1)), so the relay matrix is never hot-switched.
+        int txAntWire = _hasTxAntennaRelays ? _txAntenna : 1;
+        uint alexCommon = ComputeAlexWord(_rxFreqHz, _rxFreqHz, txAnt: txAntWire, board: _boardKind);
         uint alex0 = alexCommon | (xmit ? ALEX_TX_RELAY : 0u);
         uint alex1 = alexCommon | (xmit ? ALEX_TX_RELAY | ALEX1_ANAN7000_RX_GNDonTX : 0u);
         // ALEX_PS_BIT (0x00040000): pihpsdr new_protocol.c:994-998 ORs this
@@ -1402,9 +1485,16 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         bool moxOn,
         bool psEnabled,
         bool psExternal,
-        HpsdrBoardKind board = HpsdrBoardKind.OrionMkII)
+        HpsdrBoardKind board = HpsdrBoardKind.OrionMkII,
+        int txAntWire = 1,
+        bool hasTxAntennaRelays = false)
     {
-        uint alexCommon = ComputeAlexWord(rxFreqHz, rxFreqHz, txAnt: 1, board: board);
+        // Mirrors the SendCmdHighPriority alex0 path including the Phase-2 TX-
+        // antenna gate: hasTxAntennaRelays false stays on ANT1, true threads
+        // the 1-based wire selector. Default args reproduce the pre-Phase-2
+        // hardcoded ANT1 word, so the original golden tests stay byte-identical.
+        int wire = hasTxAntennaRelays ? txAntWire : 1;
+        uint alexCommon = ComputeAlexWord(rxFreqHz, rxFreqHz, txAnt: wire, board: board);
         uint alex0 = alexCommon | (moxOn ? ALEX_TX_RELAY : 0u);
         if (psEnabled && moxOn) alex0 |= AlexPsBit;
         if (psEnabled && psExternal && moxOn) alex0 |= AlexRxAntennaBypass;

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -1411,6 +1411,25 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         return alex0;
     }
 
+    /// <summary>
+    /// Compose the alex1 word the way <see cref="SendCmdHighPriority"/> does,
+    /// exposed internal so wire-format tests can assert the alex1 (offset 1428)
+    /// PureSignal / TX-relay / RX-ground bits without standing up a socket.
+    /// Mirrors the in-line logic at SendCmdHighPriority &gt; alex1 calculation:
+    /// TX_RELAY + RX_GNDonTX during xmit; AlexPsBit always-on while PS armed.
+    /// </summary>
+    internal static uint ComposeAlex1ForTest(
+        uint rxFreqHz,
+        bool moxOn,
+        bool psEnabled,
+        HpsdrBoardKind board = HpsdrBoardKind.OrionMkII)
+    {
+        uint alexCommon = ComputeAlexWord(rxFreqHz, rxFreqHz, txAnt: 1, board: board);
+        uint alex1 = alexCommon | (moxOn ? ALEX_TX_RELAY | ALEX1_ANAN7000_RX_GNDonTX : 0u);
+        if (psEnabled) alex1 |= AlexPsBit;
+        return alex1;
+    }
+
     internal static uint ComputeAlexWord(uint rxFreqHz, uint txFreqHz, int txAnt, HpsdrBoardKind board = HpsdrBoardKind.OrionMkII)
     {
         uint word = 0;
@@ -1422,15 +1441,30 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         // ANAN-7000/Saturn BPF board) — confirmed against pihpsdr alex.h
         // and new_protocol.c. Same call for every board.
         word |= LpfBits(txFreqHz);
-        word |= txAnt switch
-        {
-            1 => ALEX_TX_ANTENNA_1,
-            2 => ALEX_TX_ANTENNA_2,
-            3 => ALEX_TX_ANTENNA_3,
-            _ => ALEX_TX_ANTENNA_1,
-        };
+        word |= EncodeTxAntennaBits(txAnt);
         return word;
     }
+
+    /// <summary>
+    /// Pure encoder for the Protocol-2 Alex-word TX-antenna relay bits
+    /// (alex0[26:24]). Single source of truth for the TX-antenna math: both
+    /// <see cref="ComputeAlexWord"/> and
+    /// <c>Zeus.Server.Hosting.Protocol2PortEncoder</c> call this, so the bits
+    /// on the wire are identical regardless of who composed them.
+    ///
+    /// <paramref name="txAnt"/> is the 1-based wire selector (1=ANT1, 2=ANT2,
+    /// 3=ANT3); out-of-range coerces to ANT1, matching the prior inline switch.
+    /// Phase-1 (external-ports plan) callers still pass a hardcoded 1, so this
+    /// emits ALEX_TX_ANTENNA_1 exactly as before — byte-identical. Phase 2
+    /// threads the real per-band TxAnt through.
+    /// </summary>
+    internal static uint EncodeTxAntennaBits(int txAnt) => txAnt switch
+    {
+        1 => ALEX_TX_ANTENNA_1,
+        2 => ALEX_TX_ANTENNA_2,
+        3 => ALEX_TX_ANTENNA_3,
+        _ => ALEX_TX_ANTENNA_1,
+    };
 
     // RX BPF band splits lifted from pihpsdr new_protocol.c
     // (function new_protocol_high_priority, ADC0 BPFfreq selection).

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -311,6 +311,40 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // per-protocol because the protocol projects do not reference each other.
     private IRxPacketSink? _rxSink;
 
+    // ---- Radio-mic stream (UDP 1026) — external-ports plan, §3 -------------
+    // The radio digitises its analog jack (mic / line-in / balanced-XLR) and
+    // ships it on source port 1026. We DROP it by default (the RX loop just
+    // skips it) — there is ZERO added RX cost unless a radio audio source is
+    // armed and a handler is attached via AttachRadioMicHandler. The handler is
+    // called SYNCHRONOUSLY on the RX loop thread with a span over the receive
+    // buffer; it must copy/consume before returning (RadioMicReceiver does, by
+    // re-blocking into its own accumulator). Set via Interlocked so the
+    // attach/detach on a source switch is a full fence against the RX thread.
+    private volatile RadioMicPacketHandler? _radioMicHandler;
+
+    /// <summary>
+    /// Synchronous handler for one decoded UDP-1026 radio-mic packet. Invoked on
+    /// the RX loop thread with a span over the live receive buffer — copy before
+    /// returning. The packet is the raw 132-byte 1026 payload (4-byte BE seq +
+    /// 64 × int16 BE @ 48 kHz); decoding/re-blocking is the handler's job.
+    /// </summary>
+    public delegate void RadioMicPacketHandler(ReadOnlySpan<byte> packet);
+
+    /// <summary>
+    /// Attach the radio-mic (UDP 1026) handler. Until this is set the 1026
+    /// stream is dropped with one cheap srcPort comparison — Host-default has no
+    /// added cost. Pass <c>null</c> (or call <see cref="DetachRadioMicHandler"/>)
+    /// on a switch back to Host.
+    /// </summary>
+    public void AttachRadioMicHandler(RadioMicPacketHandler handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        _radioMicHandler = handler;
+    }
+
+    /// <summary>Detach the radio-mic handler, reverting to drop-on-RX.</summary>
+    public void DetachRadioMicHandler() => _radioMicHandler = null;
+
     /// <summary>
     /// Attach a synchronous RX sink. While non-null, the RX loop calls the
     /// sink directly INSTEAD of writing to <see cref="IqFrames"/> /
@@ -1899,8 +1933,21 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
                     // because TxMetersService had no telemetry feed.
                     HandleHiPriStatusPacket(buf);
                 }
-                // mic samples (1026), wideband ADC0..7 (1027..1034)
-                // intentionally ignored for now — separate features.
+                else if (srcPort == 1026)
+                {
+                    // Radio-mic stream (external-ports plan, §3): the radio's
+                    // digitised analog jack (mic / line-in / balanced-XLR),
+                    // 4-byte BE seq + 64 × int16 BE @ 48 kHz = 132 bytes
+                    // (pihpsdr new_protocol.c process_mic_data). Dropped unless
+                    // a radio audio source is armed AND a handler is attached —
+                    // the volatile read is the only added cost under Host. The
+                    // handler decodes + re-blocks synchronously on this thread.
+                    var radioMic = _radioMicHandler;
+                    if (radioMic is not null && n >= 132)
+                        radioMic(new ReadOnlySpan<byte>(buf, 0, n));
+                }
+                // wideband ADC0..7 (1027..1034) intentionally ignored — a
+                // separate feature.
             }
         }
         finally

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -1274,7 +1274,23 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         if (micBoost) ctl |= MicControlMicBoost;
         if (micBias)  ctl |= MicControlMicBias;
         if (xlr)      ctl |= MicControlXlr;
-        _micControl = ctl;
+        SetAudioFrontEndBytes(ctl, lineInGain);
+    }
+
+    /// <summary>
+    /// Set the audio front-end from already-composed wire bytes (external-ports
+    /// plan, §2). The TX-audio source model resolves byte-50 mic_control and
+    /// byte-51 line_in_gain as pure functions of the selected
+    /// <c>TxAudioSource</c> upstream (RadioService / ExternalPortEncoder), so the
+    /// client just latches them and re-pushes CmdTx on the next TX cycle. With
+    /// <c>micControl == 0 &amp;&amp; lineInGain == 0</c> (the Host source) the CmdTx
+    /// tail is byte-identical to today. Verifying that SendCmdTx fires on every
+    /// change is load-bearing — the radio keeps its last-remembered input
+    /// otherwise (pihpsdr transmit_specific risk, §8).
+    /// </summary>
+    public void SetAudioFrontEndBytes(byte micControl, byte lineInGain)
+    {
+        _micControl = micControl;
         _lineInGain = lineInGain;
         if (_rxTask is not null) SendCmdTx();
     }

--- a/Zeus.Server.Hosting/AntennaSettingsStore.cs
+++ b/Zeus.Server.Hosting/AntennaSettingsStore.cs
@@ -63,8 +63,8 @@ public sealed class AntennaSettingsStore : IDisposable
         {
             var e = _bands.FindOne(x => x.Band == band);
             return e is null
-                ? new AntennaBandSelection(band, HpsdrAntenna.Ant1, HpsdrAntenna.Ant1)
-                : new AntennaBandSelection(band, ClampAnt(e.TxAnt), ClampAnt(e.RxAnt));
+                ? new AntennaBandSelection(band, HpsdrAntenna.Ant1, HpsdrAntenna.Ant1, RxAuxInputSel.None)
+                : new AntennaBandSelection(band, ClampAnt(e.TxAnt), ClampAnt(e.RxAnt), ClampAux(e.RxAux));
         }
     }
 
@@ -76,8 +76,8 @@ public sealed class AntennaSettingsStore : IDisposable
             var existing = _bands.FindAll().ToDictionary(e => e.Band, e => e);
             return BandUtils.HfBands
                 .Select(b => existing.TryGetValue(b, out var e)
-                    ? new AntennaBandSelection(b, ClampAnt(e.TxAnt), ClampAnt(e.RxAnt))
-                    : new AntennaBandSelection(b, HpsdrAntenna.Ant1, HpsdrAntenna.Ant1))
+                    ? new AntennaBandSelection(b, ClampAnt(e.TxAnt), ClampAnt(e.RxAnt), ClampAux(e.RxAux))
+                    : new AntennaBandSelection(b, HpsdrAntenna.Ant1, HpsdrAntenna.Ant1, RxAuxInputSel.None))
                 .ToArray();
         }
     }
@@ -85,6 +85,14 @@ public sealed class AntennaSettingsStore : IDisposable
     /// <summary>Upsert one band's antenna selection. Invalid band names are
     /// rejected by the caller; here we narrow to the HF set defensively.</summary>
     public void SetBand(string band, HpsdrAntenna txAnt, HpsdrAntenna rxAnt)
+        => SetBand(band, txAnt, rxAnt, RxAuxInputSel.None);
+
+    /// <summary>Upsert one band's antenna + RX-aux selection (external-ports
+    /// plan, Phase 5). <paramref name="rxAux"/> selects an auxiliary RX feed
+    /// (EXT1/EXT2/XVTR/BYPASS); <see cref="RxAuxInputSel.None"/> uses the base
+    /// RX-antenna relay. LiteDB is schema-less so rows written before Phase 5
+    /// hydrate RxAux as 0 = None.</summary>
+    public void SetBand(string band, HpsdrAntenna txAnt, HpsdrAntenna rxAnt, RxAuxInputSel rxAux)
     {
         if (!BandUtils.HfBands.Contains(band)) return;
         lock (_sync)
@@ -97,6 +105,7 @@ public sealed class AntennaSettingsStore : IDisposable
                     Band = band,
                     TxAnt = (byte)txAnt,
                     RxAnt = (byte)rxAnt,
+                    RxAux = (byte)rxAux,
                     UpdatedUtc = DateTime.UtcNow,
                 });
             }
@@ -104,6 +113,7 @@ public sealed class AntennaSettingsStore : IDisposable
             {
                 existing.TxAnt = (byte)txAnt;
                 existing.RxAnt = (byte)rxAnt;
+                existing.RxAux = (byte)rxAux;
                 existing.UpdatedUtc = DateTime.UtcNow;
                 _bands.Update(existing);
             }
@@ -116,11 +126,30 @@ public sealed class AntennaSettingsStore : IDisposable
     private static HpsdrAntenna ClampAnt(byte v) =>
         v <= (byte)HpsdrAntenna.Ant3 ? (HpsdrAntenna)v : HpsdrAntenna.Ant1;
 
+    private static RxAuxInputSel ClampAux(byte v) =>
+        v <= (byte)RxAuxInputSel.Bypass ? (RxAuxInputSel)v : RxAuxInputSel.None;
+
     public void Dispose() => _db.Dispose();
 }
 
-/// <summary>Resolved per-band antenna selection.</summary>
-public sealed record AntennaBandSelection(string Band, HpsdrAntenna TxAnt, HpsdrAntenna RxAnt);
+/// <summary>
+/// Per-band RX auxiliary input selection (external-ports plan, Phase 5).
+/// Persisted as a byte; <see cref="None"/> means "use the base RX-antenna
+/// relay" (today's behaviour). Maps 1:1 to the Protocol2Client aux selector
+/// (1=EXT1, 2=EXT2, 3=XVTR, 4=BYPASS), with 0 = no aux.
+/// </summary>
+public enum RxAuxInputSel : byte
+{
+    None  = 0,
+    Ext1  = 1,
+    Ext2  = 2,
+    Xvtr  = 3,
+    Bypass = 4,
+}
+
+/// <summary>Resolved per-band antenna + RX-aux selection.</summary>
+public sealed record AntennaBandSelection(
+    string Band, HpsdrAntenna TxAnt, HpsdrAntenna RxAnt, RxAuxInputSel RxAux);
 
 public sealed class AntennaBandEntry
 {
@@ -130,5 +159,8 @@ public sealed class AntennaBandEntry
     // before this feature hydrate these as 0 = ANT1, the correct legacy default.
     public byte TxAnt { get; set; }
     public byte RxAnt { get; set; }
+    // RX auxiliary input (RxAuxInputSel byte). Pre-Phase-5 rows hydrate as
+    // 0 = None, the byte-identical legacy default.
+    public byte RxAux { get; set; }
     public DateTime UpdatedUtc { get; set; }
 }

--- a/Zeus.Server.Hosting/AntennaSettingsStore.cs
+++ b/Zeus.Server.Hosting/AntennaSettingsStore.cs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// Per-band TX/RX antenna relay selection (external-ports plan, Phase 2).
+//
+// Reuses the band-keyed LiteDB pattern of PaSettingsStore (per-band entry in
+// the shared, unencrypted zeus-prefs.db) but keeps antenna out of the PA wire
+// DTO so the red-light Zeus.Contracts PA contract is untouched. The store is
+// deliberately band-only keyed — NO board/variant column. That is safe ONLY
+// because the wire layer gates emission: a per-band ANT3 persisted on a G2
+// rides into the same row an HL2 later reads, and HL2 is protected because its
+// encoder never emits TX-antenna bits and clamps RX-antenna to ANT1
+// (ControlFrame.EncodeRxAntennaC3Bits). All 0x0A variants share
+// HpsdrBoardKind.OrionMkII and identical antenna wire semantics, so a band row
+// round-trips across variants. Keep this wire-gate dependency in mind before
+// any refactor that drops the clamp.
+
+using LiteDB;
+using Zeus.Contracts;
+using Zeus.Protocol1;
+
+namespace Zeus.Server;
+
+public sealed class AntennaSettingsStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<AntennaBandEntry> _bands;
+    private readonly ILogger<AntennaSettingsStore> _log;
+    private readonly object _sync = new();
+
+    // Fired on any write so RadioService can re-push the active band's antenna
+    // to the live client on the next recompute, same pattern as PaSettingsStore.
+    public event Action? Changed;
+
+    public AntennaSettingsStore(ILogger<AntennaSettingsStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _bands = _db.GetCollection<AntennaBandEntry>("antenna_bands");
+        _bands.EnsureIndex(x => x.Band, unique: true);
+
+        _log.LogInformation("AntennaSettingsStore initialized at {Path}", dbPath);
+    }
+
+    /// <summary>
+    /// Per-band antenna selection. Missing rows (fresh install, legacy DB)
+    /// default to ANT1/ANT1 — the byte-identical "no relay change" state.
+    /// </summary>
+    public AntennaBandSelection GetBand(string band)
+    {
+        lock (_sync)
+        {
+            var e = _bands.FindOne(x => x.Band == band);
+            return e is null
+                ? new AntennaBandSelection(band, HpsdrAntenna.Ant1, HpsdrAntenna.Ant1)
+                : new AntennaBandSelection(band, ClampAnt(e.TxAnt), ClampAnt(e.RxAnt));
+        }
+    }
+
+    /// <summary>All HF bands, missing rows defaulting to ANT1/ANT1.</summary>
+    public IReadOnlyList<AntennaBandSelection> GetAll()
+    {
+        lock (_sync)
+        {
+            var existing = _bands.FindAll().ToDictionary(e => e.Band, e => e);
+            return BandUtils.HfBands
+                .Select(b => existing.TryGetValue(b, out var e)
+                    ? new AntennaBandSelection(b, ClampAnt(e.TxAnt), ClampAnt(e.RxAnt))
+                    : new AntennaBandSelection(b, HpsdrAntenna.Ant1, HpsdrAntenna.Ant1))
+                .ToArray();
+        }
+    }
+
+    /// <summary>Upsert one band's antenna selection. Invalid band names are
+    /// rejected by the caller; here we narrow to the HF set defensively.</summary>
+    public void SetBand(string band, HpsdrAntenna txAnt, HpsdrAntenna rxAnt)
+    {
+        if (!BandUtils.HfBands.Contains(band)) return;
+        lock (_sync)
+        {
+            var existing = _bands.FindOne(x => x.Band == band);
+            if (existing is null)
+            {
+                _bands.Insert(new AntennaBandEntry
+                {
+                    Band = band,
+                    TxAnt = (byte)txAnt,
+                    RxAnt = (byte)rxAnt,
+                    UpdatedUtc = DateTime.UtcNow,
+                });
+            }
+            else
+            {
+                existing.TxAnt = (byte)txAnt;
+                existing.RxAnt = (byte)rxAnt;
+                existing.UpdatedUtc = DateTime.UtcNow;
+                _bands.Update(existing);
+            }
+        }
+        Changed?.Invoke();
+    }
+
+    // Defensive clamp on read — a corrupt / out-of-range byte resolves to ANT1
+    // rather than throwing or producing a bogus enum value on the wire.
+    private static HpsdrAntenna ClampAnt(byte v) =>
+        v <= (byte)HpsdrAntenna.Ant3 ? (HpsdrAntenna)v : HpsdrAntenna.Ant1;
+
+    public void Dispose() => _db.Dispose();
+}
+
+/// <summary>Resolved per-band antenna selection.</summary>
+public sealed record AntennaBandSelection(string Band, HpsdrAntenna TxAnt, HpsdrAntenna RxAnt);
+
+public sealed class AntennaBandEntry
+{
+    public int Id { get; set; }
+    public string Band { get; set; } = string.Empty;
+    // 0-based HpsdrAntenna (Ant1=0). LiteDB is schema-less so rows persisted
+    // before this feature hydrate these as 0 = ANT1, the correct legacy default.
+    public byte TxAnt { get; set; }
+    public byte RxAnt { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/AudioSettingsStore.cs
+++ b/Zeus.Server.Hosting/AudioSettingsStore.cs
@@ -7,20 +7,29 @@
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
-// Global (per-radio, NOT per-band) audio front-end selection (external-ports
-// plan, Phase 4): mic-vs-line-in, mic boost, mic bias, line-in gain, and the
-// HL2 mic_trs / Saturn XLR balanced-input selects.
+// Global (per-radio, NOT per-band) TX-audio SOURCE selection (external-ports
+// plan, §2/§8). This REPLACES the prior four-bool AudioFrontEndSelection
+// (LineIn/MicBoost/MicBias/BalancedInput/LineInGain) — that model only set codec
+// mic-gain wire bits and never switched the TX pipeline, and it allowed illegal
+// combinations. The model is now a single mutually-exclusive
+// <see cref="Zeus.Contracts.TxAudioSource"/> selector PLUS the parameters that
+// apply to whichever radio jack is chosen (MicBoost, MicBias, LineInGain).
 //
-// Mirrors AntennaSettingsStore's LiteDB pattern but holds ONE global row
-// instead of a band-keyed collection — the audio front-end is a per-radio
-// front-panel state, not per-band. Upsert uses DeleteMany+Insert rather than
-// Update/Upsert to dodge the LiteDB `Id=0` bug (an Upsert with Id=0 always
-// inserts, never updates — PR #387). The store is deliberately board-agnostic;
-// which fields actually reach the wire is gated per-board at the encoder /
-// REST layer (HasOnboardCodec for Hermes-class, HermesLite2MicFrontEnd for
-// HL2), so a value stored on one radio is simply ignored on another.
+// Mirrors AntennaSettingsStore's LiteDB pattern but holds ONE global row instead
+// of a band-keyed collection — the audio source is a per-radio front-panel
+// state, not per-band. Upsert uses DeleteMany+Insert rather than Update/Upsert to
+// dodge the LiteDB `Id=0`-always-inserts bug (PR #387). The store is deliberately
+// board-agnostic; the persisted Source is clamped against the connected board's
+// capabilities at the RadioService push (a board that can't honour a jack falls
+// back to Host), so a value stored on one radio is simply ignored on another.
+//
+// LEGACY MIGRATION: a pre-rework DB carries an AudioFrontEndEntry row WITHOUT the
+// `Source` field. LiteDB is schema-less, so that row hydrates `Source` to its
+// default value 0 == TxAudioSource.Host — exactly the clean fallback the plan
+// requires (§8). The dropped `LineIn`/`BalancedInput` columns are simply ignored.
 
 using LiteDB;
+using Zeus.Contracts;
 
 namespace Zeus.Server;
 
@@ -50,45 +59,43 @@ public sealed class AudioSettingsStore : IDisposable
     }
 
     /// <summary>
-    /// The persisted global audio front-end state. A missing row (fresh
-    /// install / legacy DB) defaults to the radio's power-on state: mic input
-    /// (line-in off), no boost, mic bias OFF (floating-connector PTT-hang
-    /// guard), line-in gain 0, balanced input off. That default is
+    /// The persisted global TX-audio source state. A missing row (fresh install
+    /// / pre-feature DB) — AND a legacy four-bool row that has no
+    /// <c>Source</c> field — defaults to <see cref="TxAudioSource.Host"/>, the
+    /// radio's power-on state with the analog jacks suppressed. That default is
     /// byte-identical to today's wire output on every board.
     /// </summary>
-    public AudioFrontEndSelection Get()
+    public AudioSourceSelection Get()
     {
         lock (_sync)
         {
             var e = _rows.FindAll().FirstOrDefault();
             return e is null
-                ? AudioFrontEndSelection.Default
-                : new AudioFrontEndSelection(
-                    LineIn: e.LineIn,
+                ? AudioSourceSelection.Default
+                : new AudioSourceSelection(
+                    Source: ClampSource(e.Source),
                     MicBoost: e.MicBoost,
                     MicBias: e.MicBias,
-                    BalancedInput: e.BalancedInput,
                     LineInGain: ClampGain(e.LineInGain));
         }
     }
 
     /// <summary>
-    /// Replace the global audio front-end state. Uses DeleteMany+Insert so the
+    /// Replace the global TX-audio source state. Uses DeleteMany+Insert so the
     /// single global row is rewritten cleanly regardless of its Id (the LiteDB
     /// Id=0-always-inserts bug, PR #387). mic_bias is stored as-given; the
     /// REST / UI layer is responsible for the floating-connector guard.
     /// </summary>
-    public void Set(AudioFrontEndSelection sel)
+    public void Set(AudioSourceSelection sel)
     {
         lock (_sync)
         {
             _rows.DeleteMany(_ => true);
             _rows.Insert(new AudioFrontEndEntry
             {
-                LineIn = sel.LineIn,
+                Source = (byte)ClampSource((byte)sel.Source),
                 MicBoost = sel.MicBoost,
                 MicBias = sel.MicBias,
-                BalancedInput = sel.BalancedInput,
                 LineInGain = ClampGain(sel.LineInGain),
                 UpdatedUtc = DateTime.UtcNow,
             });
@@ -101,52 +108,63 @@ public sealed class AudioSettingsStore : IDisposable
     // can never overflow the wire field.
     private static byte ClampGain(int v) => (byte)Math.Clamp(v, 0, 31);
 
+    // An out-of-range persisted source byte (corruption / a future enum value an
+    // older build can't represent) falls back to Host rather than reaching the
+    // wire as an undefined selection.
+    private static TxAudioSource ClampSource(byte raw) =>
+        Enum.IsDefined(typeof(TxAudioSource), raw) ? (TxAudioSource)raw : TxAudioSource.Host;
+
     public void Dispose() => _db.Dispose();
 }
 
 /// <summary>
-/// Resolved global audio front-end selection. <see cref="LineIn"/> selects
-/// line-in vs mic. <see cref="MicBias"/> is the Orion/HL2 mic-bias enable —
-/// defaults OFF (enabling on a floating connector can hang PTT).
-/// <see cref="BalancedInput"/> is the Saturn XLR balanced-input select (P2
-/// only). <see cref="LineInGain"/> is the 0..31 line-in gain.
+/// Resolved global TX-audio source selection (external-ports plan, §2).
+/// <see cref="Source"/> is the single mutually-exclusive selector; the remaining
+/// fields are PARAMETERS OF that source and apply only when the matching radio
+/// jack is chosen: <see cref="MicBoost"/>/<see cref="MicBias"/> for
+/// <see cref="TxAudioSource.RadioMic"/> (and MicBoost optionally for XLR),
+/// <see cref="LineInGain"/> (0..31) for <see cref="TxAudioSource.RadioLineIn"/>.
+/// Under <see cref="TxAudioSource.Host"/> none of the params reach the wire — the
+/// encoder is a pure function of Source and returns literal zero for Host.
 /// </summary>
-public sealed record AudioFrontEndSelection(
-    bool LineIn,
+public sealed record AudioSourceSelection(
+    TxAudioSource Source,
     bool MicBoost,
     bool MicBias,
-    bool BalancedInput,
     byte LineInGain)
 {
-    /// <summary>Power-on default: mic input, no boost/bias, no balanced
-    /// input, gain 0 — byte-identical to today's wire output.</summary>
-    public static readonly AudioFrontEndSelection Default =
-        new(LineIn: false, MicBoost: false, MicBias: false, BalancedInput: false, LineInGain: 0);
+    /// <summary>Power-on default: Host audio (radio jacks suppressed), no
+    /// boost/bias, gain 0 — byte-identical to today's wire output.</summary>
+    public static readonly AudioSourceSelection Default =
+        new(Source: TxAudioSource.Host, MicBoost: false, MicBias: false, LineInGain: 0);
 }
 
 /// <summary>
-/// Runtime audio front-end push payload (external-ports plan, Phase 4).
-/// RadioService fires this on <c>AudioFrontEndChanged</c>; DspPipelineService
-/// forwards it into the live Protocol2Client (TxSpecific bytes 50/51). Already
-/// per-board-gated by the time it is raised — a non-audio board pushes the
-/// all-default (no-op) payload.
+/// Runtime audio front-end push payload (external-ports plan). RadioService fires
+/// this on <c>AudioFrontEndChanged</c>; DspPipelineService forwards it into the
+/// live Protocol2Client (TxSpecific bytes 50/51). The wire bytes are already
+/// resolved (board-clamped + Host-zeroed) by the time it is raised — the payload
+/// carries the literal byte-50 mic_control + byte-51 line_in_gain so the
+/// forwarder does no source interpretation of its own.
 /// </summary>
 public sealed record AudioFrontEndPush(
-    bool LineIn,
-    bool MicBoost,
-    bool MicBias,
-    bool BalancedInput,
+    TxAudioSource Source,
+    byte MicControlByte,
     byte LineInGain);
 
 public sealed class AudioFrontEndEntry
 {
     public int Id { get; set; }
-    public bool LineIn { get; set; }
+    // The persisted TX-audio source (TxAudioSource as byte). LiteDB is
+    // schema-less, so a legacy four-bool row that predates this field hydrates
+    // Source = 0 == TxAudioSource.Host — the correct migration default.
+    public byte Source { get; set; }
+    // Per-source parameters. MicBoost/MicBias apply to RadioMic; LineInGain to
+    // RadioLineIn. All ignored under Host.
     public bool MicBoost { get; set; }
     public bool MicBias { get; set; }
-    public bool BalancedInput { get; set; }
-    // 0..31 line-in gain. LiteDB is schema-less so rows written before this
-    // feature hydrate this as 0, the correct legacy default.
+    // 0..31 line-in gain. Rows written before this feature hydrate this as 0,
+    // the correct legacy default.
     public byte LineInGain { get; set; }
     public DateTime UpdatedUtc { get; set; }
 }

--- a/Zeus.Server.Hosting/AudioSettingsStore.cs
+++ b/Zeus.Server.Hosting/AudioSettingsStore.cs
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// Global (per-radio, NOT per-band) audio front-end selection (external-ports
+// plan, Phase 4): mic-vs-line-in, mic boost, mic bias, line-in gain, and the
+// HL2 mic_trs / Saturn XLR balanced-input selects.
+//
+// Mirrors AntennaSettingsStore's LiteDB pattern but holds ONE global row
+// instead of a band-keyed collection — the audio front-end is a per-radio
+// front-panel state, not per-band. Upsert uses DeleteMany+Insert rather than
+// Update/Upsert to dodge the LiteDB `Id=0` bug (an Upsert with Id=0 always
+// inserts, never updates — PR #387). The store is deliberately board-agnostic;
+// which fields actually reach the wire is gated per-board at the encoder /
+// REST layer (HasOnboardCodec for Hermes-class, HermesLite2MicFrontEnd for
+// HL2), so a value stored on one radio is simply ignored on another.
+
+using LiteDB;
+
+namespace Zeus.Server;
+
+public sealed class AudioSettingsStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<AudioFrontEndEntry> _rows;
+    private readonly ILogger<AudioSettingsStore> _log;
+    private readonly object _sync = new();
+
+    // Fired on any write so RadioService can re-push the audio state to the
+    // live client — same pattern as AntennaSettingsStore.Changed.
+    public event Action? Changed;
+
+    public AudioSettingsStore(ILogger<AudioSettingsStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _rows = _db.GetCollection<AudioFrontEndEntry>("audio_frontend");
+
+        _log.LogInformation("AudioSettingsStore initialized at {Path}", dbPath);
+    }
+
+    /// <summary>
+    /// The persisted global audio front-end state. A missing row (fresh
+    /// install / legacy DB) defaults to the radio's power-on state: mic input
+    /// (line-in off), no boost, mic bias OFF (floating-connector PTT-hang
+    /// guard), line-in gain 0, balanced input off. That default is
+    /// byte-identical to today's wire output on every board.
+    /// </summary>
+    public AudioFrontEndSelection Get()
+    {
+        lock (_sync)
+        {
+            var e = _rows.FindAll().FirstOrDefault();
+            return e is null
+                ? AudioFrontEndSelection.Default
+                : new AudioFrontEndSelection(
+                    LineIn: e.LineIn,
+                    MicBoost: e.MicBoost,
+                    MicBias: e.MicBias,
+                    BalancedInput: e.BalancedInput,
+                    LineInGain: ClampGain(e.LineInGain));
+        }
+    }
+
+    /// <summary>
+    /// Replace the global audio front-end state. Uses DeleteMany+Insert so the
+    /// single global row is rewritten cleanly regardless of its Id (the LiteDB
+    /// Id=0-always-inserts bug, PR #387). mic_bias is stored as-given; the
+    /// REST / UI layer is responsible for the floating-connector guard.
+    /// </summary>
+    public void Set(AudioFrontEndSelection sel)
+    {
+        lock (_sync)
+        {
+            _rows.DeleteMany(_ => true);
+            _rows.Insert(new AudioFrontEndEntry
+            {
+                LineIn = sel.LineIn,
+                MicBoost = sel.MicBoost,
+                MicBias = sel.MicBias,
+                BalancedInput = sel.BalancedInput,
+                LineInGain = ClampGain(sel.LineInGain),
+                UpdatedUtc = DateTime.UtcNow,
+            });
+        }
+        Changed?.Invoke();
+    }
+
+    // line_in_gain is a 5-bit field (0..31) on both the HL2 0x14 frame and the
+    // P2 TxSpecific byte 51. Clamp defensively on read/write so a stale value
+    // can never overflow the wire field.
+    private static byte ClampGain(int v) => (byte)Math.Clamp(v, 0, 31);
+
+    public void Dispose() => _db.Dispose();
+}
+
+/// <summary>
+/// Resolved global audio front-end selection. <see cref="LineIn"/> selects
+/// line-in vs mic. <see cref="MicBias"/> is the Orion/HL2 mic-bias enable —
+/// defaults OFF (enabling on a floating connector can hang PTT).
+/// <see cref="BalancedInput"/> is the Saturn XLR balanced-input select (P2
+/// only). <see cref="LineInGain"/> is the 0..31 line-in gain.
+/// </summary>
+public sealed record AudioFrontEndSelection(
+    bool LineIn,
+    bool MicBoost,
+    bool MicBias,
+    bool BalancedInput,
+    byte LineInGain)
+{
+    /// <summary>Power-on default: mic input, no boost/bias, no balanced
+    /// input, gain 0 — byte-identical to today's wire output.</summary>
+    public static readonly AudioFrontEndSelection Default =
+        new(LineIn: false, MicBoost: false, MicBias: false, BalancedInput: false, LineInGain: 0);
+}
+
+/// <summary>
+/// Runtime audio front-end push payload (external-ports plan, Phase 4).
+/// RadioService fires this on <c>AudioFrontEndChanged</c>; DspPipelineService
+/// forwards it into the live Protocol2Client (TxSpecific bytes 50/51). Already
+/// per-board-gated by the time it is raised — a non-audio board pushes the
+/// all-default (no-op) payload.
+/// </summary>
+public sealed record AudioFrontEndPush(
+    bool LineIn,
+    bool MicBoost,
+    bool MicBias,
+    bool BalancedInput,
+    byte LineInGain);
+
+public sealed class AudioFrontEndEntry
+{
+    public int Id { get; set; }
+    public bool LineIn { get; set; }
+    public bool MicBoost { get; set; }
+    public bool MicBias { get; set; }
+    public bool BalancedInput { get; set; }
+    // 0..31 line-in gain. LiteDB is schema-less so rows written before this
+    // feature hydrate this as 0, the correct legacy default.
+    public byte LineInGain { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/BoardCapabilitiesTable.cs
+++ b/Zeus.Server.Hosting/BoardCapabilitiesTable.cs
@@ -83,6 +83,14 @@ internal static class BoardCapabilitiesTable
             // keeps SupportsAnvelinaDxOc=false so the wire path stays
             // closed on G2 / 7000DLE / Apache OrionMkII original / etc.
             OrionMkIIVariant.AnvelinaPro3 => SaturnAnvelinaPro3,
+            // Red Pitaya — Saturn-class hardware but Thetis DISABLES the Orion
+            // mic-bias panel there (HasMicBias=false) and has no balanced XLR.
+            OrionMkIIVariant.RedPitaya    => SaturnRedPitaya,
+            // G2 / G2-1K (Saturn FPGA) get the balanced-XLR jack; G2-1K already
+            // fans out above for the kilowatt meter axis. The bare default (G2 /
+            // 7000DLE) lands on Saturn, which carries the XLR jack — narrowed
+            // for 7000DLE below if needed (7000DLE has no XLR).
+            OrionMkIIVariant.Anan7000DLE  => Saturn7000DLE,
             _                             => Saturn,
         },
         // --- ANAN-G2E (HermesC10, N1GP) ---
@@ -173,7 +181,12 @@ internal static class BoardCapabilitiesTable
         HasRxAntennaRelays: true,
         HasOnboardCodec: true,
         RxAuxInputs: RxAuxInputs.All,
-        HasRx2AntennaPath: true);
+        HasRx2AntennaPath: true,
+        // ANAN-200D (Orion): analog line-in jack + Orion mic bias (Thetis ORION
+        // bias panel Enabled). No balanced XLR. P1 — but it has the stream codec
+        // and the radio-controlled front-end, so line-in/bias are offered (§6).
+        HasRadioLineIn: true,
+        HasMicBias: true);
 
     // 0x0A family default (G2 / 7000DLE / OrionMkII / ANVELINA-PRO3 /
     // Red Pitaya). Saturn-class facts. 100–200 W typical → 120 W axis.
@@ -199,28 +212,54 @@ internal static class BoardCapabilitiesTable
         // BYPASS (bit 11) is bit-identical to PS external feedback — PS owns it
         // while armed (§3.4(2)).
         RxAuxInputs: RxAuxInputs.All,
-        HasRx2AntennaPath: true);
+        HasRx2AntennaPath: true,
+        // TX-audio jacks (§6). The bare Saturn fingerprint is ANAN-G2 (the 0x0A
+        // default variant): analog line-in jack + Orion mic-bias + switchable
+        // balanced XLR (Saturn FPGA). 7000DLE / 8000DLE / ANVELINA / Red Pitaya
+        // narrow these per their own fingerprints below.
+        HasRadioLineIn: true,
+        HasBalancedXlr: true,
+        HasMicBias: true);
 
-    // ANAN-8000DLE — 250 W per Apache spec; axis snaps to that.
+    // ANAN-8000DLE — 250 W per Apache spec; axis snaps to that. Line-in + mic
+    // bias, NO balanced XLR (XLR is G2 / G2-1K only).
     private static readonly BoardCapabilities Saturn8000DLE = Saturn with
     {
         MaxPowerWatts = 250,
+        HasBalancedXlr = false,
     };
 
-    // ANAN-G2-1K — kilowatt-class with internal 1 kW PA. Same Saturn fingerprint
-    // but the meter axis needs the room.
+    // ANAN-G2-1K — kilowatt-class with internal 1 kW PA. Saturn-FPGA, so it
+    // keeps the balanced-XLR jack + mic bias; only the meter axis differs.
     private static readonly BoardCapabilities SaturnG2_1K = Saturn with
     {
         MaxPowerWatts = 1000,
+    };
+
+    // ANAN-7000DLE — Saturn-class but no balanced XLR (G2 / G2-1K only).
+    // Keeps analog line-in + Orion mic bias (Thetis ORION bias panel Enabled).
+    private static readonly BoardCapabilities Saturn7000DLE = Saturn with
+    {
+        HasBalancedXlr = false,
     };
 
     // ANVELINA-PRO3 (EU2AV). Saturn-class fingerprint plus the DX OC
     // extension (USEROUT7..10) wired into P2 byte 1397 bits [4:1] —
     // issue #407, EU2AV's Open_Collector_Anvelina_DX for Thetis spec.
     // This is the only variant where SupportsAnvelinaDxOc flips true.
+    // Line-in + mic bias (Thetis ORION bias panel Enabled), NO balanced XLR.
     private static readonly BoardCapabilities SaturnAnvelinaPro3 = Saturn with
     {
         SupportsAnvelinaDxOc = true,
+        HasBalancedXlr = false,
+    };
+
+    // Red Pitaya (DH1KLM). Saturn-class hardware but Thetis DISABLES the Orion
+    // mic-bias panel for it, and there is no balanced XLR. Analog line-in only.
+    private static readonly BoardCapabilities SaturnRedPitaya = Saturn with
+    {
+        HasBalancedXlr = false,
+        HasMicBias = false,
     };
 
     private static readonly BoardCapabilities HermesC10 = new(
@@ -261,7 +300,12 @@ internal static class BoardCapabilitiesTable
         HasRxAntennaRelays: true,
         HasOnboardCodec: true,
         RxAuxInputs: RxAuxInputs.All,
-        HasRx2AntennaPath: true);
+        HasRx2AntennaPath: true,
+        // Apache OrionMkII original: analog line-in jack, NO balanced XLR
+        // (Saturn-FPGA G2 / G2-1K only). HasMicBias stays FALSE — the corrected
+        // §6 bias set is exactly {200D, 7000DLE, 8000DLE, G2, G2-1K, ANVELINA};
+        // the Apache OrionMkII original firmware is not in it.
+        HasRadioLineIn: true);
 
     // HermesLite2 — rated 5 W stock but operators routinely run to 10 W with
     // adequate cooling, so the meter axis is 10 W to cover the realistic

--- a/Zeus.Server.Hosting/BoardCapabilitiesTable.cs
+++ b/Zeus.Server.Hosting/BoardCapabilitiesTable.cs
@@ -113,9 +113,11 @@ internal static class BoardCapabilitiesTable
         SupportsPathIllustrator: true,
         MaxPowerWatts: 10,
         // Alex RX-antenna relays + stream codec (Hermes-class). ANT1-hardwired
-        // on TX (no TX relays).
+        // on TX (no TX relays). Alex board exposes the full RX-aux input set
+        // (EXT1/EXT2/XVTR/BYPASS) — Phase 5.
         HasRxAntennaRelays: true,
-        HasOnboardCodec: true);
+        HasOnboardCodec: true,
+        RxAuxInputs: RxAuxInputs.All);
 
     // ANAN-10E (HermesII firmware) — same Hermes-class fingerprint but the
     // 10E hardware is rated to ~30 W, so its meter axis gets the bigger top.
@@ -131,7 +133,8 @@ internal static class BoardCapabilitiesTable
         SupportsPathIllustrator: true,
         MaxPowerWatts: 30,
         HasRxAntennaRelays: true,
-        HasOnboardCodec: true);
+        HasOnboardCodec: true,
+        RxAuxInputs: RxAuxInputs.All);
 
     // ANAN-100D — 100 W class. Meter axis 120 W gives some headroom past
     // the rated rail without truncating PEP overshoots.
@@ -147,7 +150,12 @@ internal static class BoardCapabilitiesTable
         SupportsPathIllustrator: true,
         MaxPowerWatts: 120,
         HasRxAntennaRelays: true,
-        HasOnboardCodec: true);
+        HasOnboardCodec: true,
+        // Dual-RX dual-Alex 100D: full RX-aux set + a second RX antenna path.
+        // The dual-Alex (alex1) RX2 emission is scaffolded but flagged for
+        // bench — Zeus has no 100D/200D to verify against (Phase 5).
+        RxAuxInputs: RxAuxInputs.All,
+        HasRx2AntennaPath: true);
 
     // ANAN-200D — 200 W class but axis matches the 100/200/G2 family at
     // 120 W: half-axis at 100 W is the natural reading point.
@@ -163,7 +171,9 @@ internal static class BoardCapabilitiesTable
         SupportsPathIllustrator: true,
         MaxPowerWatts: 120,
         HasRxAntennaRelays: true,
-        HasOnboardCodec: true);
+        HasOnboardCodec: true,
+        RxAuxInputs: RxAuxInputs.All,
+        HasRx2AntennaPath: true);
 
     // 0x0A family default (G2 / 7000DLE / OrionMkII / ANVELINA-PRO3 /
     // Red Pitaya). Saturn-class facts. 100–200 W typical → 120 W axis.
@@ -183,7 +193,13 @@ internal static class BoardCapabilitiesTable
         // AnvelinaPro3 inherit these via `Saturn with {...}`.
         HasTxAntennaRelays: true,
         HasRxAntennaRelays: true,
-        HasOnboardCodec: true);
+        HasOnboardCodec: true,
+        // 0x0A Saturn-BPF family: full RX-aux input set (alex0 bits 8..11 +
+        // RX_SELECT bit 14) and a second RX antenna path (dual-RX). The K36
+        // BYPASS (bit 11) is bit-identical to PS external feedback — PS owns it
+        // while armed (§3.4(2)).
+        RxAuxInputs: RxAuxInputs.All,
+        HasRx2AntennaPath: true);
 
     // ANAN-8000DLE — 250 W per Apache spec; axis snaps to that.
     private static readonly BoardCapabilities Saturn8000DLE = Saturn with
@@ -219,8 +235,10 @@ internal static class BoardCapabilitiesTable
         SupportsPathIllustrator: false,
         MaxPowerWatts: 120,
         // ANAN-G2E: Alex BPF RX relays + codec; ANT1-hardwired on TX (P1).
+        // Single-RX, so no RX2 path. Full RX-aux input set on its BPF board.
         HasRxAntennaRelays: true,
-        HasOnboardCodec: true);
+        HasOnboardCodec: true,
+        RxAuxInputs: RxAuxInputs.All);
 
     // Apache OrionMkII original (Orion-MkII firmware, 100 W) — Saturn-class
     // hardware fingerprint but without on-board telemetry / audio amp per
@@ -241,7 +259,9 @@ internal static class BoardCapabilitiesTable
         // differ, handled above; port relays are present on all 0x0A boards).
         HasTxAntennaRelays: true,
         HasRxAntennaRelays: true,
-        HasOnboardCodec: true);
+        HasOnboardCodec: true,
+        RxAuxInputs: RxAuxInputs.All,
+        HasRx2AntennaPath: true);
 
     // HermesLite2 — rated 5 W stock but operators routinely run to 10 W with
     // adequate cooling, so the meter axis is 10 W to cover the realistic
@@ -267,6 +287,10 @@ internal static class BoardCapabilitiesTable
         // HL2: single antenna jack (no ANT1/2/3 relays), no stream codec — but
         // it DOES have a real mic/PTT/line-in front-end on register 0x14.
         // HasTxAntennaRelays / HasRxAntennaRelays / HasOnboardCodec all stay
-        // false (defaults); only the mic front-end flag flips true.
-        HermesLite2MicFrontEnd: true);
+        // false (defaults); only the mic front-end flag flips true. HL2 has NO
+        // RX-aux inputs (the EXT/XVTR/BYPASS jacks do not physically exist) so
+        // RxAuxInputs stays None — but it DOES have the 4-bit user GPIO on its
+        // register 0x0a / wire 0x14 C3[3:0] (Phase 5).
+        HermesLite2MicFrontEnd: true,
+        HasHl2UserGpio: true);
 }

--- a/Zeus.Server.Hosting/BoardCapabilitiesTable.cs
+++ b/Zeus.Server.Hosting/BoardCapabilitiesTable.cs
@@ -111,7 +111,11 @@ internal static class BoardCapabilitiesTable
         HasAudioAmplifier: false,
         HasSteppedAttenuationRx2: false, // single-RX: RX2 doesn't exist
         SupportsPathIllustrator: true,
-        MaxPowerWatts: 10);
+        MaxPowerWatts: 10,
+        // Alex RX-antenna relays + stream codec (Hermes-class). ANT1-hardwired
+        // on TX (no TX relays).
+        HasRxAntennaRelays: true,
+        HasOnboardCodec: true);
 
     // ANAN-10E (HermesII firmware) — same Hermes-class fingerprint but the
     // 10E hardware is rated to ~30 W, so its meter axis gets the bigger top.
@@ -125,7 +129,9 @@ internal static class BoardCapabilitiesTable
         HasAudioAmplifier: false,
         HasSteppedAttenuationRx2: false,
         SupportsPathIllustrator: true,
-        MaxPowerWatts: 30);
+        MaxPowerWatts: 30,
+        HasRxAntennaRelays: true,
+        HasOnboardCodec: true);
 
     // ANAN-100D — 100 W class. Meter axis 120 W gives some headroom past
     // the rated rail without truncating PEP overshoots.
@@ -139,7 +145,9 @@ internal static class BoardCapabilitiesTable
         HasAudioAmplifier: false,
         HasSteppedAttenuationRx2: true,
         SupportsPathIllustrator: true,
-        MaxPowerWatts: 120);
+        MaxPowerWatts: 120,
+        HasRxAntennaRelays: true,
+        HasOnboardCodec: true);
 
     // ANAN-200D — 200 W class but axis matches the 100/200/G2 family at
     // 120 W: half-axis at 100 W is the natural reading point.
@@ -153,7 +161,9 @@ internal static class BoardCapabilitiesTable
         HasAudioAmplifier: false,
         HasSteppedAttenuationRx2: true,
         SupportsPathIllustrator: true,
-        MaxPowerWatts: 120);
+        MaxPowerWatts: 120,
+        HasRxAntennaRelays: true,
+        HasOnboardCodec: true);
 
     // 0x0A family default (G2 / 7000DLE / OrionMkII / ANVELINA-PRO3 /
     // Red Pitaya). Saturn-class facts. 100–200 W typical → 120 W axis.
@@ -167,7 +177,13 @@ internal static class BoardCapabilitiesTable
         HasAudioAmplifier: true,
         HasSteppedAttenuationRx2: true,
         SupportsPathIllustrator: false,
-        MaxPowerWatts: 120);
+        MaxPowerWatts: 120,
+        // 0x0A/Saturn family — the only boards with switchable TX antenna
+        // relays (ANT1/2/3), plus RX relays + stream codec. 8000DLE/G2-1K/
+        // AnvelinaPro3 inherit these via `Saturn with {...}`.
+        HasTxAntennaRelays: true,
+        HasRxAntennaRelays: true,
+        HasOnboardCodec: true);
 
     // ANAN-8000DLE — 250 W per Apache spec; axis snaps to that.
     private static readonly BoardCapabilities Saturn8000DLE = Saturn with
@@ -201,7 +217,10 @@ internal static class BoardCapabilitiesTable
         HasAudioAmplifier: true,
         HasSteppedAttenuationRx2: false, // single-RX: RX2 doesn't exist
         SupportsPathIllustrator: false,
-        MaxPowerWatts: 120);
+        MaxPowerWatts: 120,
+        // ANAN-G2E: Alex BPF RX relays + codec; ANT1-hardwired on TX (P1).
+        HasRxAntennaRelays: true,
+        HasOnboardCodec: true);
 
     // Apache OrionMkII original (Orion-MkII firmware, 100 W) — Saturn-class
     // hardware fingerprint but without on-board telemetry / audio amp per
@@ -217,7 +236,12 @@ internal static class BoardCapabilitiesTable
         HasAudioAmplifier: false,
         HasSteppedAttenuationRx2: true,
         SupportsPathIllustrator: false,
-        MaxPowerWatts: 120);
+        MaxPowerWatts: 120,
+        // 0x0A family — TX + RX antenna relays + codec (telemetry/audio-amp
+        // differ, handled above; port relays are present on all 0x0A boards).
+        HasTxAntennaRelays: true,
+        HasRxAntennaRelays: true,
+        HasOnboardCodec: true);
 
     // HermesLite2 — rated 5 W stock but operators routinely run to 10 W with
     // adequate cooling, so the meter axis is 10 W to cover the realistic
@@ -239,5 +263,10 @@ internal static class BoardCapabilitiesTable
         HasSteppedAttenuationRx2: false,
         SupportsPathIllustrator: false,
         MaxPowerWatts: 10,
-        HasHl2OptionalToggles: true);
+        HasHl2OptionalToggles: true,
+        // HL2: single antenna jack (no ANT1/2/3 relays), no stream codec — but
+        // it DOES have a real mic/PTT/line-in front-end on register 0x14.
+        // HasTxAntennaRelays / HasRxAntennaRelays / HasOnboardCodec all stay
+        // false (defaults); only the mic front-end flag flips true.
+        HermesLite2MicFrontEnd: true);
 }

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -1337,7 +1337,16 @@ public class DspPipelineService : BackgroundService,
         // Alex path. Convert the 0-based HpsdrAntenna to the 1-based wire
         // selector the P2 client uses. Default ANT1 / no-relay reproduces
         // today's wire bit-for-bit.
-        p2.SetAntennas((int)snap.TxAntenna + 1, (int)snap.RxAntenna + 1, snap.HasTxAntennaRelays);
+        // Phase 5: also forward the RX-aux input + MkII-BPF RX-select gate. The
+        // P2 client emits the aux bits on alex0 (EXT1/EXT2/XVTR/BYPASS) and PS
+        // owns the K36/BYPASS relay while armed (§3.4(2), in SendCmdHighPriority).
+        // Default RxAuxInput=0 reproduces today's wire bit-for-bit.
+        p2.SetAntennas(
+            (int)snap.TxAntenna + 1,
+            (int)snap.RxAntenna + 1,
+            snap.HasTxAntennaRelays,
+            snap.RxAuxInput,
+            snap.MkiiBpfRxSelect);
         p2.SetPaEnabled(snap.PaEnabled);
     }
 

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -1308,16 +1308,11 @@ public class DspPipelineService : BackgroundService,
     {
         var p2 = _p2Client;
         if (p2 is null) return;
-        // TxSpecific byte 50 mic_control flags + byte 51 line_in_gain. The
-        // payload is already per-board-gated by RadioService.PushAudioFrontEnd,
-        // so a non-audio board forwards the all-default (no-op) state. On P2 the
-        // balanced-input select is the Saturn XLR bit (byte 50 bit 5).
-        p2.SetAudioFrontEnd(
-            lineIn: a.LineIn,
-            micBoost: a.MicBoost,
-            micBias: a.MicBias,
-            xlr: a.BalancedInput,
-            lineInGain: a.LineInGain);
+        // TxSpecific byte 50 mic_control flags + byte 51 line_in_gain, already
+        // RESOLVED (board-clamped + source-encoded, Host → 0) by
+        // RadioService.PushAudioFrontEnd. The forwarder pushes the literal bytes
+        // with no source interpretation of its own (external-ports plan, §2).
+        p2.SetAudioFrontEndBytes(a.MicControlByte, a.LineInGain);
     }
 
     private void OnPaSnapshotChanged(PaRuntimeSnapshot snap)

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -1305,6 +1305,13 @@ public class DspPipelineService : BackgroundService,
         // connected board+variant. Non-Anvelina P2 boards see byte 1397
         // stay at zero per EU2AV's reserved-bit rule.
         p2.SetOcDxMasks(snap.OcDxTxMask, snap.OcDxRxMask);
+        // Per-band antenna relay selection (external-ports plan, Phase 2). The
+        // P2 client gates alex0[26:24] on snap.HasTxAntennaRelays and defers the
+        // relay re-push if keyed (§3.4(1)); RX antenna rides for the Phase-5
+        // Alex path. Convert the 0-based HpsdrAntenna to the 1-based wire
+        // selector the P2 client uses. Default ANT1 / no-relay reproduces
+        // today's wire bit-for-bit.
+        p2.SetAntennas((int)snap.TxAntenna + 1, (int)snap.RxAntenna + 1, snap.HasTxAntennaRelays);
         p2.SetPaEnabled(snap.PaEnabled);
     }
 

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -205,6 +205,19 @@ public class DspPipelineService : BackgroundService,
     // keeping it isolated avoids touching any P1 behavior.
     private Zeus.Protocol2.Protocol2Client? _p2Client;
 
+    // Radio-mic (UDP 1026) routing — external-ports plan, §3 (Pass B). The
+    // re-blocker buffers 64-sample 1026 packets into the 960-sample mic blocks
+    // TxAudioIngest consumes; it forwards into OnMicPcmBytesFromRadioMic, whose
+    // in-lock _activeSource gate drops them unless a radio jack is armed. The
+    // 1026 handler is attached to the live P2 client ONLY while a radio source
+    // is selected, so Host-default has zero added RX cost. Both are lazily wired
+    // (TxAudioIngest depends on this service, so it's resolved through a factory
+    // to avoid a DI cycle — feedback_di_cycle_iservice_provider pattern).
+    private readonly Func<TxAudioIngest?>? _txIngestFactory;
+    private TxAudioIngest? _txIngest;
+    private RadioMicReceiver? _radioMicReceiver;
+    private bool _radioMicAttached;
+
     private RxMode _appliedMode = RxMode.USB;
     private int _appliedLowHz;
     private int _appliedHighHz;
@@ -415,7 +428,8 @@ public class DspPipelineService : BackgroundService,
         StreamingHub hub,
         IEnumerable<IRxAudioSink> audioSinks,
         ILoggerFactory loggerFactory,
-        CwSidetoneSource? sidetone = null)
+        CwSidetoneSource? sidetone = null,
+        Func<TxAudioIngest?>? txIngestFactory = null)
     {
         _radio = radio;
         _hub = hub;
@@ -425,6 +439,24 @@ public class DspPipelineService : BackgroundService,
         _sidetone = sidetone;
         _loggerFactory = loggerFactory;
         _log = loggerFactory.CreateLogger<DspPipelineService>();
+        _txIngestFactory = txIngestFactory;
+    }
+
+    // Lazily resolve TxAudioIngest (DI cycle avoidance — see field comment) and
+    // build the radio-mic re-blocker on first use. Returns null in tests that
+    // didn't supply a factory; the radio-mic path then simply no-ops.
+    private TxAudioIngest? ResolveTxIngest()
+    {
+        if (_txIngest is not null) return _txIngest;
+        _txIngest = _txIngestFactory?.Invoke();
+        if (_txIngest is not null && _radioMicReceiver is null)
+        {
+            var ingest = _txIngest;
+            _radioMicReceiver = new RadioMicReceiver(
+                block => ingest.OnMicPcmBytesFromRadioMic(block),
+                _loggerFactory.CreateLogger<RadioMicReceiver>());
+        }
+        return _txIngest;
     }
 
     private void PublishAudio(in AudioFrame frame)
@@ -1306,6 +1338,13 @@ public class DspPipelineService : BackgroundService,
 
     private void OnAudioFrontEndChanged(AudioFrontEndPush a)
     {
+        // PASS B — route the radio-mic STREAM (external-ports plan, §3). This
+        // runs on EVERY resolved-source push (store edit AND connect, via
+        // ReplayAudioFrontEnd) so the pipeline's active source tracks the wire
+        // bytes. Done BEFORE the byte forward and independent of _p2Client so a
+        // switch back to Host always quiesces the gate even mid-disconnect.
+        ApplyRadioMicRouting(a.Source);
+
         var p2 = _p2Client;
         if (p2 is null) return;
         // TxSpecific byte 50 mic_control flags + byte 51 line_in_gain, already
@@ -1313,6 +1352,51 @@ public class DspPipelineService : BackgroundService,
         // RadioService.PushAudioFrontEnd. The forwarder pushes the literal bytes
         // with no source interpretation of its own (external-ports plan, §2).
         p2.SetAudioFrontEndBytes(a.MicControlByte, a.LineInGain);
+    }
+
+    // Arm/disarm the radio-mic stream for a resolved TxAudioSource
+    // (external-ports plan, §3, atomic single-select). Idempotent and cheap on
+    // Host (the common case): it sets the in-lock _activeSource on TxAudioIngest
+    // (which quiesces its WDSP accumulator), resets the 1026 re-blocker so no
+    // pre-switch audio stitches onto the post-switch source, and attaches /
+    // detaches the UDP-1026 decode on the live P2 client so there is zero added
+    // RX cost while Host is selected. P1 radios have no 1026 stream — the handler
+    // simply never fires there; the _activeSource gate still arbitrates host vs
+    // (absent) radio harmlessly.
+    private void ApplyRadioMicRouting(TxAudioSource source)
+    {
+        var ingest = ResolveTxIngest();
+        if (ingest is null) return;
+
+        bool radioActive = source != TxAudioSource.Host;
+
+        // Arm the in-lock single-select gate FIRST. Under TxAudioIngest._sync
+        // this flips _activeSource and clears its half-written WDSP block, so the
+        // instant the gate is armed the host mic is dropped (radio armed) or the
+        // radio mic is dropped (Host armed) — no overlap window.
+        ingest.SetActiveSource(source);
+
+        // Always reset the re-blocker on any switch so a <960-sample remainder
+        // of the old source can't stitch onto the new one.
+        _radioMicReceiver?.Reset();
+
+        var p2 = _p2Client;
+        if (radioActive)
+        {
+            // Subscribe the 1026 decode only while a radio jack is armed. No-op
+            // if already attached or if P1 (no 1026 stream / null p2Client).
+            if (!_radioMicAttached && p2 is not null && _radioMicReceiver is not null)
+            {
+                var rb = _radioMicReceiver;
+                p2.AttachRadioMicHandler(rb.Accept);
+                _radioMicAttached = true;
+            }
+        }
+        else if (_radioMicAttached)
+        {
+            p2?.DetachRadioMicHandler();
+            _radioMicAttached = false;
+        }
     }
 
     private void OnPaSnapshotChanged(PaRuntimeSnapshot snap)
@@ -1414,6 +1498,12 @@ public class DspPipelineService : BackgroundService,
         // and no further callbacks land. client.StopAsync joins the RX task,
         // so by the time it returns the RX thread is gone.
         DetachRxSinkP2();
+        // The 1026 radio-mic handler is bound to this client instance; clear our
+        // attach latch so a reconnect (which re-fires ReplayAudioFrontEnd) re-
+        // attaches against the fresh client. The handler reference dies with the
+        // disposed client. Quiesce the re-blocker so no stale remainder survives.
+        _radioMicAttached = false;
+        _radioMicReceiver?.Reset();
         try { await client.StopAsync(ct).ConfigureAwait(false); } catch { }
         await client.DisposeAsync().ConfigureAwait(false);
 

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -440,6 +440,10 @@ public class DspPipelineService : BackgroundService,
         _radio.Disconnected += OnRadioDisconnected;
         _radio.StateChanged += OnRadioStateChanged;
         _radio.PaSnapshotChanged += OnPaSnapshotChanged;
+        // Audio front-end (external-ports plan, Phase 4) — global per-radio.
+        // RadioService can't reach the P2 client directly (ActiveClient is
+        // P1-only), so forward TxSpecific bytes 50/51 here.
+        _radio.AudioFrontEndChanged += OnAudioFrontEndChanged;
         _radio.MoxChanged += OnRadioMoxChanged;
         _radio.TunActiveChanged += OnRadioTunActiveChanged;
         _radio.PreampChanged += OnRadioPreampChanged;
@@ -478,6 +482,7 @@ public class DspPipelineService : BackgroundService,
             _radio.Disconnected -= OnRadioDisconnected;
             _radio.StateChanged -= OnRadioStateChanged;
             _radio.PaSnapshotChanged -= OnPaSnapshotChanged;
+            _radio.AudioFrontEndChanged -= OnAudioFrontEndChanged;
             _radio.MoxChanged -= OnRadioMoxChanged;
             _radio.TunActiveChanged -= OnRadioTunActiveChanged;
             _radio.PreampChanged -= OnRadioPreampChanged;
@@ -1292,6 +1297,27 @@ public class DspPipelineService : BackgroundService,
         // Push current PA snapshot into the brand-new client so byte 345 /
         // byte 1401 / CmdGeneral[58] reflect PaSettingsStore from frame 1.
         _radio.ReplayPaSnapshot();
+        // Push the persisted audio front-end (TxSpecific bytes 50/51) into the
+        // fresh P2 client so mic/line-in/boost/bias/gain are correct from the
+        // first CmdTx, not deferred until a store edit. No-op on boards without
+        // an audio front-end (gated + OFF defaults).
+        _radio.ReplayAudioFrontEnd();
+    }
+
+    private void OnAudioFrontEndChanged(AudioFrontEndPush a)
+    {
+        var p2 = _p2Client;
+        if (p2 is null) return;
+        // TxSpecific byte 50 mic_control flags + byte 51 line_in_gain. The
+        // payload is already per-board-gated by RadioService.PushAudioFrontEnd,
+        // so a non-audio board forwards the all-default (no-op) state. On P2 the
+        // balanced-input select is the Saturn XLR bit (byte 50 bit 5).
+        p2.SetAudioFrontEnd(
+            lineIn: a.LineIn,
+            micBoost: a.MicBoost,
+            micBias: a.MicBias,
+            xlr: a.BalancedInput,
+            lineInGain: a.LineInGain);
     }
 
     private void OnPaSnapshotChanged(PaRuntimeSnapshot snap)

--- a/Zeus.Server.Hosting/ExternalPortEncoder.cs
+++ b/Zeus.Server.Hosting/ExternalPortEncoder.cs
@@ -117,12 +117,13 @@ public sealed class Protocol1PortEncoder : IExternalPortEncoder
 
     public byte EncodeP1RxAntennaC3Bits(in ExternalPortState state)
     {
-        // Phase 1: byte-identical. The pure helper ControlFrame.
-        // EncodeRxAntennaC3Bits is the single source of the C3[7:5] math and
-        // is also called inline on the wire path. The relay-presence clamp is
-        // scaffolded (constructor captures _hasRxAntennaRelays) but applied in
-        // Phase 2, where it gets a differential golden test — applying it now
-        // would change HL2's bytes.
+        // The pure helper ControlFrame.EncodeRxAntennaC3Bits is the single
+        // source of the C3[7:5] math and is also called inline on the wire
+        // path. It applies the wire-layer relay-presence clamp itself (forcing
+        // ANT1 on relay-less boards), so a relay-capable P1 board emits the raw
+        // selection and HL2 is clamped — same bytes the inline path produces.
+        // _hasRxAntennaRelays stays available for the encoder's own gating.
+        _ = _hasRxAntennaRelays;
         return ControlFrame.EncodeRxAntennaC3Bits(state.RxAnt, _board);
     }
 
@@ -158,12 +159,13 @@ public sealed class Protocol2PortEncoder : IExternalPortEncoder
 
     public uint EncodeP2TxAntennaBits(in ExternalPortState state)
     {
-        // Phase 1: byte-identical. The wire path still passes a hardcoded
-        // txAnt:1 into ComputeAlexWord, so we mirror that here exactly. Phase 2
-        // threads state.TxAnt through (1-based wire selector) and gates the
-        // [26:24] emission on _hasTxAntennaRelays / variant relay population.
-        _ = _hasTxAntennaRelays;
-        return Protocol2Client.EncodeTxAntennaBits(txAnt: 1);
+        // Gate the alex0[26:24] TX-antenna emission on the variant's relay
+        // population: a board/variant without TX-antenna relays stays on ANT1
+        // regardless of the requested selection, so it can never advertise
+        // ANT2/3. Relay-capable variants thread the real per-band TxAnt through
+        // the shared pure helper (1-based wire selector).
+        int wire = _hasTxAntennaRelays ? (int)state.TxAnt + 1 : 1;
+        return Protocol2Client.EncodeTxAntennaBits(wire);
     }
 }
 
@@ -184,9 +186,10 @@ public sealed class HermesLite2PortEncoder : IExternalPortEncoder
 
     public byte EncodeP1RxAntennaC3Bits(in ExternalPortState state)
     {
-        // Phase 2 will clamp: `EncodeRxAntennaC3Bits(HpsdrAntenna.Ant1, ...)`.
-        // Phase 1 reproduces today's HL2 emission exactly via the shared pure
-        // helper so the golden bytes do not move.
+        // HL2 has no RX-antenna relay (C3[5] drives the N2ADR antenna pad). The
+        // shared pure helper applies the wire-layer clamp for HL2, so whatever
+        // RxAnt the operator persisted, the emitted bits are ANT1 — the N2ADR
+        // pad never flips off a stale per-band ANT2/3.
         return ControlFrame.EncodeRxAntennaC3Bits(state.RxAnt, HpsdrBoardKind.HermesLite2);
     }
 

--- a/Zeus.Server.Hosting/ExternalPortEncoder.cs
+++ b/Zeus.Server.Hosting/ExternalPortEncoder.cs
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// External-port encoder seam (external-ports plan, Phase 1).
+//
+// This is the FIREWALL described in the engineering plan §3.1: every
+// external-port relay bit on the wire — RX-antenna select, TX-antenna select,
+// open-collector masks — is composed behind one board-branched / protocol-
+// branched encoder, instead of scattered bit literals in the emission code.
+//
+// Phase 1 is BYTE-IDENTICAL. The encoders here delegate to the very same pure
+// helpers the wire path already uses (ControlFrame.EncodeRxAntennaC3Bits on
+// P1; Protocol2Client.EncodeTxAntennaBits / ComputeAlexWord on P2), so the
+// bits they produce are identical to today's emission for every supported
+// board. No OC / PS / MOX / duplex byte is touched here. The per-board wire-
+// layer clamp scaffolding (force ANT1 on relay-less boards) is present but
+// inert — it activates in Phase 2 with its own differential golden test.
+//
+// Dependency direction: Zeus.Server.Hosting references Zeus.Protocol1 /
+// Zeus.Protocol2 (not the reverse), so this seam consults the protocol layer's
+// pure helpers via InternalsVisibleTo. The protocol clients never call back
+// into this assembly — that would be a cycle.
+
+using Zeus.Contracts;
+using Zeus.Protocol1;
+using Zeus.Protocol2;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Immutable canonical desired external-port state. Protocol-agnostic — holds
+/// no wire bits, only the operator-meaningful selections. Phase 1 carries just
+/// antenna + OC (the controls whose emission this phase moves behind the
+/// encoder); audio front-end and RX-aux inputs join in later phases.
+///
+/// OC masks mirror the existing <c>CcState.UserOcTxMask</c>/<c>UserOcRxMask</c>
+/// (and the P2 <c>_ocTxMask</c>/<c>_ocRxMask</c>) — they are carried here so the
+/// canonical state is complete, NOT to introduce a second emission path. Phase 1
+/// does not re-route OC emission; the existing OC code is untouched.
+/// </summary>
+public readonly record struct ExternalPortState(
+    /// <summary>TX antenna relay select. Honoured only on boards with
+    /// <see cref="BoardCapabilities.HasTxAntennaRelays"/> (0x0A/Saturn family);
+    /// every other board is ANT1-hardwired on transmit. Phase 1 leaves the
+    /// wire emission at the hardcoded ANT1 — this field is wired through in
+    /// Phase 2.</summary>
+    HpsdrAntenna TxAnt = HpsdrAntenna.Ant1,
+    /// <summary>RX antenna relay select (C3[7:5] on P1; Alex select on P2).
+    /// Clamped to ANT1 at the wire layer on boards without
+    /// <see cref="BoardCapabilities.HasRxAntennaRelays"/> — scaffolded in
+    /// Phase 1, active in Phase 2.</summary>
+    HpsdrAntenna RxAnt = HpsdrAntenna.Ant1,
+    /// <summary>Open-collector TX mask (7-bit). Carried for completeness;
+    /// emission stays on the existing OC path in Phase 1.</summary>
+    byte OcTxMask = 0,
+    /// <summary>Open-collector RX mask (7-bit). Carried for completeness;
+    /// emission stays on the existing OC path in Phase 1.</summary>
+    byte OcRxMask = 0)
+{
+    /// <summary>Default state: ANT1 / ANT1 / no OC — reproduces today's wire
+    /// emission bit-for-bit on every board.</summary>
+    public static readonly ExternalPortState Default = new();
+}
+
+/// <summary>
+/// Per-board / per-protocol external-port bit encoder. Mirrors
+/// <see cref="IRadioDriveProfile"/>'s seam: a small strategy interface,
+/// concrete per-protocol implementations, and an
+/// <see cref="ExternalPortEncoders.For(HpsdrBoardKind, OrionMkIIVariant, RadioProtocol)"/>
+/// dispatch. This is the single place external-port relay math lives.
+/// </summary>
+public interface IExternalPortEncoder
+{
+    /// <summary>Diagnostic label for the encoder strategy.</summary>
+    string Label { get; }
+
+    /// <summary>
+    /// Encode the Protocol-1 Config-frame RX-antenna relay bits (C3[7:5]) for
+    /// the desired <paramref name="state"/>. Returns the byte to OR into C3.
+    /// Delegates to the wire path's own pure helper so the bytes match exactly.
+    /// </summary>
+    byte EncodeP1RxAntennaC3Bits(in ExternalPortState state);
+
+    /// <summary>
+    /// Encode the Protocol-2 Alex-word TX-antenna relay bits (alex0[26:24]) for
+    /// the desired <paramref name="state"/>. Returns the bits to OR into the
+    /// Alex word. Delegates to the wire path's own pure helper.
+    /// </summary>
+    uint EncodeP2TxAntennaBits(in ExternalPortState state);
+}
+
+/// <summary>
+/// Protocol-1 encoder for codec / Alex boards that DO have switchable RX
+/// antenna relays (Hermes-class, ANAN-100D/200D, ANAN-G2E). Emits C3[7:5]
+/// straight from the desired RX antenna. These boards are ANT1-hardwired on
+/// transmit (no P2 Alex word), so the P2 TX-antenna path returns ANT1.
+/// </summary>
+public sealed class Protocol1PortEncoder : IExternalPortEncoder
+{
+    /// <summary>Whether the target board has RX-antenna relays. False clamps
+    /// the RX-antenna selection to ANT1 at the wire layer (the HL2 case).
+    /// Phase 1 keeps this informational only (clamp inert); Phase 2 enforces
+    /// it.</summary>
+    private readonly bool _hasRxAntennaRelays;
+    private readonly HpsdrBoardKind _board;
+
+    public Protocol1PortEncoder(HpsdrBoardKind board, bool hasRxAntennaRelays)
+    {
+        _board = board;
+        _hasRxAntennaRelays = hasRxAntennaRelays;
+    }
+
+    public string Label => $"P1({_board}, rxRelays={_hasRxAntennaRelays})";
+
+    public byte EncodeP1RxAntennaC3Bits(in ExternalPortState state)
+    {
+        // Phase 1: byte-identical. The pure helper ControlFrame.
+        // EncodeRxAntennaC3Bits is the single source of the C3[7:5] math and
+        // is also called inline on the wire path. The relay-presence clamp is
+        // scaffolded (constructor captures _hasRxAntennaRelays) but applied in
+        // Phase 2, where it gets a differential golden test — applying it now
+        // would change HL2's bytes.
+        return ControlFrame.EncodeRxAntennaC3Bits(state.RxAnt, _board);
+    }
+
+    public uint EncodeP2TxAntennaBits(in ExternalPortState state)
+        // P1 boards do not emit a P2 Alex word; ANT1-hardwired on transmit.
+        => Protocol2Client.EncodeTxAntennaBits(txAnt: 1);
+}
+
+/// <summary>
+/// Protocol-2 encoder for the 0x0A / Saturn family (G2 / 7000DLE / 8000DLE /
+/// G2-1K / OrionMkII original / ANVELINA-PRO3 / Red Pitaya). These boards have
+/// switchable TX antenna relays (alex0[26:24]) and RX antenna relays.
+/// </summary>
+public sealed class Protocol2PortEncoder : IExternalPortEncoder
+{
+    private readonly HpsdrBoardKind _board;
+    private readonly OrionMkIIVariant _variant;
+    private readonly bool _hasTxAntennaRelays;
+
+    public Protocol2PortEncoder(HpsdrBoardKind board, OrionMkIIVariant variant, bool hasTxAntennaRelays)
+    {
+        _board = board;
+        _variant = variant;
+        _hasTxAntennaRelays = hasTxAntennaRelays;
+    }
+
+    public string Label => $"P2({_board}/{_variant}, txRelays={_hasTxAntennaRelays})";
+
+    public byte EncodeP1RxAntennaC3Bits(in ExternalPortState state)
+        // P2 boards do not use the P1 Config frame; the P2 RX-antenna select
+        // rides the Alex word (Phase 5). Phase 1 returns no C3 bits.
+        => 0;
+
+    public uint EncodeP2TxAntennaBits(in ExternalPortState state)
+    {
+        // Phase 1: byte-identical. The wire path still passes a hardcoded
+        // txAnt:1 into ComputeAlexWord, so we mirror that here exactly. Phase 2
+        // threads state.TxAnt through (1-based wire selector) and gates the
+        // [26:24] emission on _hasTxAntennaRelays / variant relay population.
+        _ = _hasTxAntennaRelays;
+        return Protocol2Client.EncodeTxAntennaBits(txAnt: 1);
+    }
+}
+
+/// <summary>
+/// Hermes-Lite 2 encoder. HL2 has a single antenna jack: C3[5] does NOT drive
+/// an ANT1/2/3 relay, it forwards to the N2ADR antenna pad. The RX-antenna
+/// selection MUST therefore be clamped to ANT1 at the wire layer
+/// (<see cref="BoardCapabilities.HasRxAntennaRelays"/> is false for HL2).
+///
+/// Phase 1 is BYTE-IDENTICAL: today's wire path emits HL2's raw C3[7:5] value
+/// unconditionally, so the clamp is scaffolded here but inert — it activates
+/// in Phase 2 with a differential golden test (raw ANT3 today → ANT1 after).
+/// HL2 has no P2 Alex word and is ANT1-hardwired on transmit.
+/// </summary>
+public sealed class HermesLite2PortEncoder : IExternalPortEncoder
+{
+    public string Label => "HL2(singleJack, rxClamp=Phase2)";
+
+    public byte EncodeP1RxAntennaC3Bits(in ExternalPortState state)
+    {
+        // Phase 2 will clamp: `EncodeRxAntennaC3Bits(HpsdrAntenna.Ant1, ...)`.
+        // Phase 1 reproduces today's HL2 emission exactly via the shared pure
+        // helper so the golden bytes do not move.
+        return ControlFrame.EncodeRxAntennaC3Bits(state.RxAnt, HpsdrBoardKind.HermesLite2);
+    }
+
+    public uint EncodeP2TxAntennaBits(in ExternalPortState state)
+        => Protocol2Client.EncodeTxAntennaBits(txAnt: 1);
+}
+
+/// <summary>
+/// Which transport a connected board uses, for encoder dispatch. The 0x0A
+/// family runs Protocol 2 in Zeus; every other supported board runs Protocol 1.
+/// </summary>
+public enum RadioProtocol
+{
+    Protocol1,
+    Protocol2,
+}
+
+/// <summary>
+/// Per-board / per-protocol dispatch for <see cref="IExternalPortEncoder"/>.
+/// Mirrors <see cref="RadioDriveProfiles.For"/>. Every <see cref="HpsdrBoardKind"/>
+/// maps to a non-null encoder (the board-coverage test asserts this).
+/// </summary>
+public static class ExternalPortEncoders
+{
+    /// <summary>
+    /// Resolve the external-port encoder for a connected board. The protocol is
+    /// derived from the board kind when not given explicitly: the 0x0A
+    /// OrionMkII family is Protocol 2, everything else Protocol 1.
+    /// </summary>
+    public static IExternalPortEncoder For(
+        HpsdrBoardKind board,
+        OrionMkIIVariant variant = OrionMkIIVariant.G2,
+        RadioProtocol? protocol = null)
+    {
+        var caps = BoardCapabilitiesTable.For(board, variant);
+        var p = protocol ?? DefaultProtocolFor(board);
+
+        // HL2 first — it is the single-jack special case (single P1 board with
+        // no RX-antenna relay), so its dedicated encoder owns the clamp.
+        if (board == HpsdrBoardKind.HermesLite2)
+            return new HermesLite2PortEncoder();
+
+        return p == RadioProtocol.Protocol2
+            ? new Protocol2PortEncoder(board, variant, caps.HasTxAntennaRelays)
+            : new Protocol1PortEncoder(board, caps.HasRxAntennaRelays);
+    }
+
+    /// <summary>The transport Zeus uses for a given board kind.</summary>
+    public static RadioProtocol DefaultProtocolFor(HpsdrBoardKind board) => board switch
+    {
+        HpsdrBoardKind.OrionMkII => RadioProtocol.Protocol2,
+        _                        => RadioProtocol.Protocol1,
+    };
+}

--- a/Zeus.Server.Hosting/ExternalPortEncoder.cs
+++ b/Zeus.Server.Hosting/ExternalPortEncoder.cs
@@ -59,27 +59,34 @@ public readonly record struct ExternalPortState(
     /// <summary>Open-collector RX mask (7-bit). Carried for completeness;
     /// emission stays on the existing OC path in Phase 1.</summary>
     byte OcRxMask = 0,
-    // ---- Audio front-end (external-ports plan, Phase 4) --------------------
-    // Global per-radio (NOT per-band). Verified byte layouts:
-    //   P1 Hermes-class codec (0x12 frame): C2[0]=MicBoost, C2[1]=LineIn.
-    //   P1 HL2 (0x14 frame, read-modify-write): C1[4]=BalancedInput (mic_trs),
-    //     C1[5]=MicBias, C2[4:0]=LineInGain (PS C2[6] + C4 PGA preserved).
-    //   P2 TxSpecific byte 50: bit0=LineIn, bit1=MicBoost, bit4=MicBias,
-    //     bit5=BalancedInput(XLR); byte 51=LineInGain.
-    // All default off / 0 → byte-identical to today on every board.
-    /// <summary>Line-in vs mic select (true = line-in).</summary>
-    bool LineIn = false,
-    /// <summary>Mic boost (Hermes-class codec / P2).</summary>
+    // ---- TX-audio source (external-ports plan, §2) ------------------------
+    // Global per-radio (NOT per-band). The wire bytes are PURE FUNCTIONS of
+    // Source (plus that source's params). Verified byte layouts:
+    //   P2 TxSpecific byte 50 mic_control:
+    //     Host=0x00; RadioMic=(boost?0x02)|(bias?0x10); RadioLineIn=0x01;
+    //     RadioBalancedXlr=0x20 (| opt boost/bias). byte 51 = LineInGain only
+    //     for RadioLineIn, else 0.
+    //   P1 Hermes-class codec (0x12 frame): C2[0]=mic_boost (RadioMic only),
+    //     C2[1]=mic_linein (unreachable on pure-P1 in v1 — no radio-mic RX path).
+    //   P1 HL2 (0x14 frame): Host-only — HL2 has no codec, audio bits stay clear
+    //     (PS C2[6] + C4 PGA preserved by the existing read-modify-write).
+    // Source==Host → every audio surface is literal zero, byte-identical to
+    // today; the encoder must NOT fall through to read the params under Host.
+    /// <summary>The single mutually-exclusive TX-audio source.</summary>
+    TxAudioSource Source = TxAudioSource.Host,
+    /// <summary>Mic boost — parameter of <see cref="TxAudioSource.RadioMic"/>
+    /// (and optionally XLR). Ignored under Host / RadioLineIn.</summary>
     bool MicBoost = false,
-    /// <summary>Mic bias enable. DEFAULTS OFF — enabling on a floating
-    /// connector can hang PTT; the gate guards it.</summary>
+    /// <summary>Mic bias enable — parameter of <see cref="TxAudioSource.RadioMic"/>
+    /// (and XLR). DEFAULTS OFF — enabling on a floating connector can hang PTT;
+    /// the gate guards it. Ignored under Host / RadioLineIn.</summary>
     bool MicBias = false,
-    /// <summary>Balanced / TRS input select (HL2 mic_trs / Saturn XLR).</summary>
-    bool BalancedInput = false,
-    /// <summary>Line-in gain, 0..31 (HL2 0x14 C2[4:0] / P2 byte 51).</summary>
+    /// <summary>Line-in gain, 0..31 — parameter of
+    /// <see cref="TxAudioSource.RadioLineIn"/>. Ignored under every other
+    /// source.</summary>
     byte LineInGain = 0)
 {
-    /// <summary>Default state: ANT1 / ANT1 / no OC / mic input, no boost/bias,
+    /// <summary>Default state: ANT1 / ANT1 / no OC / Host audio, no boost/bias,
     /// gain 0 — reproduces today's wire emission bit-for-bit on every board.</summary>
     public static readonly ExternalPortState Default = new();
 }
@@ -111,15 +118,37 @@ public interface IExternalPortEncoder
     uint EncodeP2TxAntennaBits(in ExternalPortState state);
 
     /// <summary>
-    /// Encode the Protocol-2 TxSpecific (port 1026) byte-50 mic_control flags
-    /// for the desired audio front-end state (external-ports plan, Phase 4).
-    /// Only emitted on codec boards; a board without
+    /// Encode the Protocol-2 TxSpecific (port 1026) byte-50 mic_control flags as
+    /// a PURE FUNCTION of <see cref="ExternalPortState.Source"/> (external-ports
+    /// plan, §2). Only emitted on codec boards; a board without
     /// <see cref="BoardCapabilities.HasOnboardCodec"/> returns 0 so its
     /// TxSpecific tail stays byte-identical to today. Bit layout (Thetis
     /// network.c:1226-1233): bit0=line_in, bit1=mic_boost, bit4=mic_bias,
-    /// bit5=balanced/XLR. Pairs with byte 51 = <c>LineInGain</c>.
+    /// bit5=balanced/XLR. <see cref="TxAudioSource.Host"/> returns LITERAL 0 with
+    /// NO fallthrough that reads the params, so a persisted non-zero
+    /// MicBoost/MicBias can never leak onto the wire after a revert to Host.
+    /// Pairs with <see cref="EncodeP2LineInGainByte"/> (byte 51).
     /// </summary>
     byte EncodeP2MicControlByte(in ExternalPortState state);
+
+    /// <summary>
+    /// Encode the Protocol-2 TxSpecific byte-51 line_in_gain (0..31). Non-zero
+    /// ONLY for <see cref="TxAudioSource.RadioLineIn"/>; every other source
+    /// (including Host) returns 0 so the radio's last-remembered gain is cleared
+    /// the moment line-in is deselected. Pure function of Source.
+    /// </summary>
+    byte EncodeP2LineInGainByte(in ExternalPortState state);
+
+    /// <summary>
+    /// Resolve the Protocol-1 codec (0x12 DriveFilter frame) audio bits as a
+    /// PURE FUNCTION of <see cref="ExternalPortState.Source"/>. C2[0]=mic_boost,
+    /// C2[1]=mic_linein. <see cref="TxAudioSource.RadioMic"/> drives mic_boost
+    /// from the param; every other source (Host included) returns
+    /// <c>(false,false)</c> — no param leak. RadioLineIn is intentionally
+    /// unreachable on pure-P1 codec boards in v1 (no P1 radio-mic RX path, §2/§6),
+    /// so mic_linein stays clear. HL2 is Host-only and never calls this.
+    /// </summary>
+    (bool MicBoost, bool MicLineIn) EncodeP1CodecAudioBits(in ExternalPortState state);
 }
 
 /// <summary>
@@ -165,6 +194,16 @@ public sealed class Protocol1PortEncoder : IExternalPortEncoder
         // P1 codec boards carry mic_boost/mic_linein on the 0x12 frame
         // (ControlFrame), not the P2 TxSpecific byte 50. No P2 byte here.
         => 0;
+
+    public byte EncodeP2LineInGainByte(in ExternalPortState state)
+        // P1 boards have no P2 TxSpecific byte 51.
+        => 0;
+
+    public (bool MicBoost, bool MicLineIn) EncodeP1CodecAudioBits(in ExternalPortState state)
+        // Pure function of Source: RadioMic → mic_boost; Host / everything else
+        // → all clear (no param leak). RadioLineIn is intentionally unreachable
+        // on pure-P1 codec boards in v1.
+        => ExternalPortAudio.P1CodecAudioBits(state.Source, state.MicBoost);
 }
 
 /// <summary>
@@ -209,42 +248,77 @@ public sealed class Protocol2PortEncoder : IExternalPortEncoder
     {
         // Gate on codec presence: a board without the stream codec gets the
         // zero byte, so its TxSpecific tail is byte-identical to today. The
-        // shared helper is the single source of the byte-50 bit math (the same
-        // constants Protocol2Client.SetAudioFrontEnd composes).
+        // shared helper is the single source of the byte-50 bit math, computed
+        // PURELY from the source — Host returns literal 0 with no param read.
         if (!_hasOnboardCodec) return 0;
-        return ExternalPortAudio.P2MicControlByte(
-            lineIn: state.LineIn,
-            micBoost: state.MicBoost,
-            micBias: state.MicBias,
-            balanced: state.BalancedInput);
+        return ExternalPortAudio.P2MicControlByte(state.Source, state.MicBoost, state.MicBias);
     }
+
+    public byte EncodeP2LineInGainByte(in ExternalPortState state)
+    {
+        // byte 51 is non-zero only for RadioLineIn; suppressed (0) for every
+        // other source so a deselected line-in jack drops its remembered gain.
+        if (!_hasOnboardCodec) return 0;
+        return ExternalPortAudio.P2LineInGainByte(state.Source, state.LineInGain);
+    }
+
+    public (bool MicBoost, bool MicLineIn) EncodeP1CodecAudioBits(in ExternalPortState state)
+        // P2 boards do not use the P1 0x12 codec frame.
+        => (false, false);
 }
 
 /// <summary>
-/// Shared pure helpers for the audio front-end bit math (external-ports plan,
-/// Phase 4). The single source of truth for the P2 TxSpecific byte-50
-/// mic_control flag layout (Thetis network.c:1226-1233), so the encoder seam
-/// and any test compute the same byte. The P1 audio bits (0x12 mic_boost/linein
-/// and 0x14 mic_trs/mic_bias/line_in_gain) live in ControlFrame, which owns the
-/// per-board gating for the Protocol-1 frames.
+/// Shared PURE audio-source bit math (external-ports plan, §2). Single source of
+/// truth for the P2 TxSpecific byte-50 mic_control / byte-51 line_in_gain layout
+/// (Thetis network.c:1226-1233) and the P1 0x12 codec bits, computed straight
+/// from <see cref="TxAudioSource"/> so the encoder seam and any test agree.
+///
+/// CRUCIAL PURITY INVARIANT: <see cref="TxAudioSource.Host"/> returns literal 0
+/// on every surface WITHOUT reading MicBoost/MicBias/LineInGain — a persisted
+/// non-zero param must never leak onto the wire after a revert to Host. The
+/// switch's Host arm short-circuits before any param is consulted.
 /// </summary>
 internal static class ExternalPortAudio
 {
     // TxSpecific byte-50 mic_control flags (Thetis network.c:1226-1233).
-    private const byte LineInBit   = 0x01; // bit0
-    private const byte MicBoostBit = 0x02; // bit1
-    private const byte MicBiasBit  = 0x10; // bit4 (enable Orion mic bias)
-    private const byte XlrBit       = 0x20; // bit5 (balanced/XLR input — Saturn)
+    private const byte LineInBit   = 0x01; // bit0 — line-in select
+    private const byte MicBoostBit = 0x02; // bit1 — mic boost
+    private const byte MicBiasBit  = 0x10; // bit4 — enable Orion mic bias
+    private const byte XlrBit       = 0x20; // bit5 — balanced/XLR input (Saturn)
 
-    public static byte P2MicControlByte(bool lineIn, bool micBoost, bool micBias, bool balanced)
+    /// <summary>P2 byte-50 mic_control as a pure function of the source.</summary>
+    public static byte P2MicControlByte(TxAudioSource source, bool micBoost, bool micBias) => source switch
     {
-        byte b = 0;
-        if (lineIn)   b |= LineInBit;
-        if (micBoost) b |= MicBoostBit;
-        if (micBias)  b |= MicBiasBit;
-        if (balanced) b |= XlrBit;
-        return b;
-    }
+        // Host: literal zero, no param read. The analog jacks are suppressed.
+        TxAudioSource.Host => 0,
+        // RadioMic: boost (bit1) + bias (bit4) from the params, mic jack implied
+        // (no line-in / XLR bit).
+        TxAudioSource.RadioMic =>
+            (byte)((micBoost ? MicBoostBit : 0) | (micBias ? MicBiasBit : 0)),
+        // RadioLineIn: line-in select (bit0); gain rides byte 51. Mic params do
+        // not apply.
+        TxAudioSource.RadioLineIn => LineInBit,
+        // RadioBalancedXlr: XLR select (bit5) | optional boost/bias (the XLR
+        // front-end still honours the Orion mic-bias / boost stage on G2).
+        TxAudioSource.RadioBalancedXlr =>
+            (byte)(XlrBit | (micBoost ? MicBoostBit : 0) | (micBias ? MicBiasBit : 0)),
+        _ => 0,
+    };
+
+    /// <summary>P2 byte-51 line_in_gain — non-zero ONLY for RadioLineIn.</summary>
+    public static byte P2LineInGainByte(TxAudioSource source, byte lineInGain) =>
+        source == TxAudioSource.RadioLineIn ? (byte)(lineInGain & 0x1F) : (byte)0;
+
+    /// <summary>P1 0x12 codec bits (mic_boost C2[0], mic_linein C2[1]) as a pure
+    /// function of the source. RadioMic drives mic_boost; everything else,
+    /// including Host, returns all-clear — no param leak.</summary>
+    public static (bool MicBoost, bool MicLineIn) P1CodecAudioBits(TxAudioSource source, bool micBoost) => source switch
+    {
+        TxAudioSource.RadioMic => (micBoost, false),
+        // RadioLineIn is unreachable on pure-P1 codec boards in v1 (no P1
+        // radio-mic RX path); Host/XLR are not P1-codec sources. All clear.
+        _ => (false, false),
+    };
 }
 
 /// <summary>
@@ -275,9 +349,18 @@ public sealed class HermesLite2PortEncoder : IExternalPortEncoder
         => Protocol2Client.EncodeTxAntennaBits(txAnt: 1);
 
     public byte EncodeP2MicControlByte(in ExternalPortState state)
-        // HL2 is Protocol 1 with no stream codec — its mic front-end rides the
-        // 0x14 frame (ControlFrame read-modify-write), not the P2 TxSpecific.
+        // HL2 has no stream codec and no P2 TxSpecific frame at all.
         => 0;
+
+    public byte EncodeP2LineInGainByte(in ExternalPortState state)
+        // HL2 has no P2 TxSpecific byte 51.
+        => 0;
+
+    public (bool MicBoost, bool MicLineIn) EncodeP1CodecAudioBits(in ExternalPortState state)
+        // HL2 is Host-only (no onboard codec — §2/§6). Its 0x14 audio bits stay
+        // clear and the existing ControlFrame read-modify-write preserves the
+        // C2[6] PureSignal bit + the C4 PGA byte. Never emit codec audio bits.
+        => (false, false);
 }
 
 /// <summary>

--- a/Zeus.Server.Hosting/ExternalPortEncoder.cs
+++ b/Zeus.Server.Hosting/ExternalPortEncoder.cs
@@ -58,10 +58,29 @@ public readonly record struct ExternalPortState(
     byte OcTxMask = 0,
     /// <summary>Open-collector RX mask (7-bit). Carried for completeness;
     /// emission stays on the existing OC path in Phase 1.</summary>
-    byte OcRxMask = 0)
+    byte OcRxMask = 0,
+    // ---- Audio front-end (external-ports plan, Phase 4) --------------------
+    // Global per-radio (NOT per-band). Verified byte layouts:
+    //   P1 Hermes-class codec (0x12 frame): C2[0]=MicBoost, C2[1]=LineIn.
+    //   P1 HL2 (0x14 frame, read-modify-write): C1[4]=BalancedInput (mic_trs),
+    //     C1[5]=MicBias, C2[4:0]=LineInGain (PS C2[6] + C4 PGA preserved).
+    //   P2 TxSpecific byte 50: bit0=LineIn, bit1=MicBoost, bit4=MicBias,
+    //     bit5=BalancedInput(XLR); byte 51=LineInGain.
+    // All default off / 0 → byte-identical to today on every board.
+    /// <summary>Line-in vs mic select (true = line-in).</summary>
+    bool LineIn = false,
+    /// <summary>Mic boost (Hermes-class codec / P2).</summary>
+    bool MicBoost = false,
+    /// <summary>Mic bias enable. DEFAULTS OFF — enabling on a floating
+    /// connector can hang PTT; the gate guards it.</summary>
+    bool MicBias = false,
+    /// <summary>Balanced / TRS input select (HL2 mic_trs / Saturn XLR).</summary>
+    bool BalancedInput = false,
+    /// <summary>Line-in gain, 0..31 (HL2 0x14 C2[4:0] / P2 byte 51).</summary>
+    byte LineInGain = 0)
 {
-    /// <summary>Default state: ANT1 / ANT1 / no OC — reproduces today's wire
-    /// emission bit-for-bit on every board.</summary>
+    /// <summary>Default state: ANT1 / ANT1 / no OC / mic input, no boost/bias,
+    /// gain 0 — reproduces today's wire emission bit-for-bit on every board.</summary>
     public static readonly ExternalPortState Default = new();
 }
 
@@ -90,6 +109,17 @@ public interface IExternalPortEncoder
     /// Alex word. Delegates to the wire path's own pure helper.
     /// </summary>
     uint EncodeP2TxAntennaBits(in ExternalPortState state);
+
+    /// <summary>
+    /// Encode the Protocol-2 TxSpecific (port 1026) byte-50 mic_control flags
+    /// for the desired audio front-end state (external-ports plan, Phase 4).
+    /// Only emitted on codec boards; a board without
+    /// <see cref="BoardCapabilities.HasOnboardCodec"/> returns 0 so its
+    /// TxSpecific tail stays byte-identical to today. Bit layout (Thetis
+    /// network.c:1226-1233): bit0=line_in, bit1=mic_boost, bit4=mic_bias,
+    /// bit5=balanced/XLR. Pairs with byte 51 = <c>LineInGain</c>.
+    /// </summary>
+    byte EncodeP2MicControlByte(in ExternalPortState state);
 }
 
 /// <summary>
@@ -130,6 +160,11 @@ public sealed class Protocol1PortEncoder : IExternalPortEncoder
     public uint EncodeP2TxAntennaBits(in ExternalPortState state)
         // P1 boards do not emit a P2 Alex word; ANT1-hardwired on transmit.
         => Protocol2Client.EncodeTxAntennaBits(txAnt: 1);
+
+    public byte EncodeP2MicControlByte(in ExternalPortState state)
+        // P1 codec boards carry mic_boost/mic_linein on the 0x12 frame
+        // (ControlFrame), not the P2 TxSpecific byte 50. No P2 byte here.
+        => 0;
 }
 
 /// <summary>
@@ -142,12 +177,14 @@ public sealed class Protocol2PortEncoder : IExternalPortEncoder
     private readonly HpsdrBoardKind _board;
     private readonly OrionMkIIVariant _variant;
     private readonly bool _hasTxAntennaRelays;
+    private readonly bool _hasOnboardCodec;
 
-    public Protocol2PortEncoder(HpsdrBoardKind board, OrionMkIIVariant variant, bool hasTxAntennaRelays)
+    public Protocol2PortEncoder(HpsdrBoardKind board, OrionMkIIVariant variant, bool hasTxAntennaRelays, bool hasOnboardCodec)
     {
         _board = board;
         _variant = variant;
         _hasTxAntennaRelays = hasTxAntennaRelays;
+        _hasOnboardCodec = hasOnboardCodec;
     }
 
     public string Label => $"P2({_board}/{_variant}, txRelays={_hasTxAntennaRelays})";
@@ -166,6 +203,47 @@ public sealed class Protocol2PortEncoder : IExternalPortEncoder
         // the shared pure helper (1-based wire selector).
         int wire = _hasTxAntennaRelays ? (int)state.TxAnt + 1 : 1;
         return Protocol2Client.EncodeTxAntennaBits(wire);
+    }
+
+    public byte EncodeP2MicControlByte(in ExternalPortState state)
+    {
+        // Gate on codec presence: a board without the stream codec gets the
+        // zero byte, so its TxSpecific tail is byte-identical to today. The
+        // shared helper is the single source of the byte-50 bit math (the same
+        // constants Protocol2Client.SetAudioFrontEnd composes).
+        if (!_hasOnboardCodec) return 0;
+        return ExternalPortAudio.P2MicControlByte(
+            lineIn: state.LineIn,
+            micBoost: state.MicBoost,
+            micBias: state.MicBias,
+            balanced: state.BalancedInput);
+    }
+}
+
+/// <summary>
+/// Shared pure helpers for the audio front-end bit math (external-ports plan,
+/// Phase 4). The single source of truth for the P2 TxSpecific byte-50
+/// mic_control flag layout (Thetis network.c:1226-1233), so the encoder seam
+/// and any test compute the same byte. The P1 audio bits (0x12 mic_boost/linein
+/// and 0x14 mic_trs/mic_bias/line_in_gain) live in ControlFrame, which owns the
+/// per-board gating for the Protocol-1 frames.
+/// </summary>
+internal static class ExternalPortAudio
+{
+    // TxSpecific byte-50 mic_control flags (Thetis network.c:1226-1233).
+    private const byte LineInBit   = 0x01; // bit0
+    private const byte MicBoostBit = 0x02; // bit1
+    private const byte MicBiasBit  = 0x10; // bit4 (enable Orion mic bias)
+    private const byte XlrBit       = 0x20; // bit5 (balanced/XLR input — Saturn)
+
+    public static byte P2MicControlByte(bool lineIn, bool micBoost, bool micBias, bool balanced)
+    {
+        byte b = 0;
+        if (lineIn)   b |= LineInBit;
+        if (micBoost) b |= MicBoostBit;
+        if (micBias)  b |= MicBiasBit;
+        if (balanced) b |= XlrBit;
+        return b;
     }
 }
 
@@ -195,6 +273,11 @@ public sealed class HermesLite2PortEncoder : IExternalPortEncoder
 
     public uint EncodeP2TxAntennaBits(in ExternalPortState state)
         => Protocol2Client.EncodeTxAntennaBits(txAnt: 1);
+
+    public byte EncodeP2MicControlByte(in ExternalPortState state)
+        // HL2 is Protocol 1 with no stream codec — its mic front-end rides the
+        // 0x14 frame (ControlFrame read-modify-write), not the P2 TxSpecific.
+        => 0;
 }
 
 /// <summary>
@@ -233,7 +316,7 @@ public static class ExternalPortEncoders
             return new HermesLite2PortEncoder();
 
         return p == RadioProtocol.Protocol2
-            ? new Protocol2PortEncoder(board, variant, caps.HasTxAntennaRelays)
+            ? new Protocol2PortEncoder(board, variant, caps.HasTxAntennaRelays, caps.HasOnboardCodec)
             : new Protocol1PortEncoder(board, caps.HasRxAntennaRelays);
     }
 

--- a/Zeus.Server.Hosting/ExternalPttService.cs
+++ b/Zeus.Server.Hosting/ExternalPttService.cs
@@ -14,31 +14,45 @@
 // statement and per-component attribution.
 
 using Microsoft.Extensions.Hosting;
+using Zeus.Contracts;
 using Zeus.Protocol1;
 
 namespace Zeus.Server;
 
 /// <summary>
-/// Promotes the radio's hardware-PTT echo (C0[0] of every inbound EP6 frame)
-/// into a host-side MOX request. The HL2 gateware generates a shaped CW
-/// envelope on its own whenever the rear KEY tip is grounded — protocol doc
-/// line 200 — so the radio transmits without any host involvement. Without
-/// this service the host stays unkeyed: the MOX UI indicator never lights,
-/// TX meters stay at idle cadence, PsAutoAttenuate doesn't engage, and the
-/// FR-6 120 s TX-timeout never arms.
+/// Promotes the radio's hardware-PTT echo into a host-side MOX request, on
+/// BOTH protocols (external-ports plan §4):
+///   • Protocol 1 — C0[0] of every inbound EP6 frame, surfaced as the
+///     <see cref="IProtocol1Client.HardwarePttChanged"/> edge event. The HL2
+///     gateware generates a shaped CW envelope on its own whenever the rear KEY
+///     tip is grounded (protocol doc line 200) so the radio transmits without
+///     any host involvement; this service lifts the host MOX to match.
+///   • Protocol 2 — the UDP-1025 hi-priority status PttIn bit (byte 0 bit 0),
+///     surfaced as the <see cref="Zeus.Protocol2.P2TelemetryReading.PttIn"/>
+///     level on every <see cref="Zeus.Protocol2.Protocol2Client.TelemetryReceived"/>.
+///     P2 telemetry is LEVEL-sampled (not edge-evented), so this service derives
+///     rising/falling edges by comparing against the previous level.
 ///
-/// State machine (per-connection):
-///   • inbound rising AND host MOX/TUN/TwoTone off → claim MOX via
-///     <c>TxService.TrySetMox(true)</c>, mark <c>_owned</c>.
-///   • inbound falling → arm a hang timer (<see cref="HangTime"/>). A rising
+/// Without this service the host stays unkeyed on a hardware press: the MOX UI
+/// indicator never lights, TX meters stay at idle cadence, PsAutoAttenuate
+/// doesn't engage, and the FR-6 120 s TX-timeout never arms. Before this pass
+/// the service was P1-only — a G2/P2 connect fired the separate P2Connected
+/// event and never reached here, so footswitch PTT was dead on the G2.
+///
+/// State machine (shared across both protocols, per-connection):
+///   • raw rising AND host MOX/TUN/TwoTone off → claim MOX via
+///     <c>TxService.TrySetMox(true, MoxSource.Hardware)</c>, mark <c>_owned</c>.
+///   • raw falling → arm a hang timer (<see cref="HangTime"/>). A rising
 ///     edge inside the window cancels it (inter-character CW spaces).
-///   • hang elapsed AND inbound still low AND <c>_owned</c> → release MOX.
+///   • hang elapsed AND raw still low AND <c>_owned</c> → release MOX.
 ///   • UI/TCI/trip drops MOX externally → <c>_owned</c> clears so the next
 ///     hang timer doesn't re-release what someone else changed.
 ///
-/// Inbound echo of host-initiated MOX (operator clicks the UI button) lands
-/// here too, but the <c>IsMoxOn || IsTunOn || IsTwoToneOn</c> gate ignores
-/// it because the host is already the source of truth.
+/// MOX/TUN/TwoTone arbitration and the <c>MoxSource.Hardware</c> ownership rule
+/// are EXACTLY the P1 behaviour — the P2 path reuses the same hang/owned engine,
+/// it does not fork it. The per-protocol PTT-IN status lamp is broadcast on
+/// every raw edge regardless of the Enable gate so the operator can see the
+/// physical input even when MOX promotion is disabled.
 /// </summary>
 public sealed class ExternalPttService : IHostedService, IDisposable
 {
@@ -49,27 +63,54 @@ public sealed class ExternalPttService : IHostedService, IDisposable
     // on the per-mode DSP settings panel alongside the CW pitch.
     private static readonly TimeSpan HangTime = TimeSpan.FromMilliseconds(250);
 
+    /// <summary>Read-only hang time surfaced to the UI ("Hang: 250 ms") and the
+    /// REST status endpoint. The knob itself is out of scope for this pass.</summary>
+    public static int HangMs => (int)HangTime.TotalMilliseconds;
+
+    /// <summary>Live PTT-IN level (lamp state) for the REST status snapshot.
+    /// Fed by both protocol edge sources; false when disconnected.</summary>
+    public bool IsKeyed => _rawHigh;
+
     private readonly RadioService _radio;
     private readonly TxService _tx;
+    private readonly StreamingHub _hub;
+    private readonly PttSettingsStore _settings;
     private readonly CwSidetoneSource? _sidetone;
     private readonly ILogger<ExternalPttService> _log;
 
     private readonly object _sync = new();
     private IProtocol1Client? _client;
+    private Zeus.Protocol2.Protocol2Client? _p2Client;
     // True iff the most recent MOX-on we caused has not been released yet.
     // Cleared by the hang-release path, by TxActiveChanged(false) from any
     // other source, and by disconnect.
     private bool _owned;
+    // Latest raw hardware-PTT level, fed by BOTH protocol edge sources. Used by
+    // the hang-release race-guard (protocol-agnostic replacement for the P1-only
+    // IProtocol1Client.HardwarePtt latched property) and surfaced as the lamp
+    // state. Volatile: written on the RX thread, read on the timer ThreadPool.
+    private volatile bool _rawHigh;
+    // Previous P2 PttIn level, for edge detection on the level-sampled P2
+    // telemetry stream. Owned by the P2 RX thread only.
+    private bool _p2PrevPtt;
     // Single-shot timer used to debounce falling edges. Created lazily and
     // re-armed via Change(); the underlying System.Threading.Timer is thread
     // safe so cancellation from the RX thread and fire-and-handle on the
     // ThreadPool coexist cleanly.
     private Timer? _hangTimer;
 
-    public ExternalPttService(RadioService radio, TxService tx, ILogger<ExternalPttService> log, CwSidetoneSource? sidetone = null)
+    public ExternalPttService(
+        RadioService radio,
+        TxService tx,
+        StreamingHub hub,
+        PttSettingsStore settings,
+        ILogger<ExternalPttService> log,
+        CwSidetoneSource? sidetone = null)
     {
         _radio = radio;
         _tx = tx;
+        _hub = hub;
+        _settings = settings;
         _sidetone = sidetone;
         _log = log;
     }
@@ -78,6 +119,8 @@ public sealed class ExternalPttService : IHostedService, IDisposable
     {
         _radio.Connected += OnConnected;
         _radio.Disconnected += OnDisconnected;
+        _radio.P2Connected += OnP2Connected;
+        _radio.P2Disconnected += OnP2Disconnected;
         _tx.TxActiveChanged += OnTxActiveChanged;
         return Task.CompletedTask;
     }
@@ -86,14 +129,18 @@ public sealed class ExternalPttService : IHostedService, IDisposable
     {
         _radio.Connected -= OnConnected;
         _radio.Disconnected -= OnDisconnected;
+        _radio.P2Connected -= OnP2Connected;
+        _radio.P2Disconnected -= OnP2Disconnected;
         _tx.TxActiveChanged -= OnTxActiveChanged;
         IProtocol1Client? client;
-        lock (_sync) { client = _client; _client = null; _owned = false; }
+        Zeus.Protocol2.Protocol2Client? p2;
+        lock (_sync) { client = _client; _client = null; p2 = _p2Client; _p2Client = null; _owned = false; }
         if (client is not null)
         {
             client.HardwarePttChanged -= OnHardwarePttChanged;
             client.CwKeyDownChanged -= OnCwKeyDownChanged;
         }
+        if (p2 is not null) p2.TelemetryReceived -= OnP2Telemetry;
         _hangTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
         return Task.CompletedTask;
     }
@@ -103,9 +150,11 @@ public sealed class ExternalPttService : IHostedService, IDisposable
         _hangTimer?.Dispose();
     }
 
+    // ---- Protocol 1 wiring (unchanged behaviour) -------------------------
+
     private void OnConnected(IProtocol1Client client)
     {
-        lock (_sync) { _client = client; _owned = false; }
+        lock (_sync) { _client = client; _owned = false; _rawHigh = false; }
         client.HardwarePttChanged += OnHardwarePttChanged;
         client.CwKeyDownChanged += OnCwKeyDownChanged;
     }
@@ -113,13 +162,14 @@ public sealed class ExternalPttService : IHostedService, IDisposable
     private void OnDisconnected()
     {
         IProtocol1Client? client;
-        lock (_sync) { client = _client; _client = null; _owned = false; }
+        lock (_sync) { client = _client; _client = null; _owned = false; _rawHigh = false; }
         if (client is not null)
         {
             client.HardwarePttChanged -= OnHardwarePttChanged;
             client.CwKeyDownChanged -= OnCwKeyDownChanged;
         }
         _hangTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+        BroadcastLamp(false);
     }
 
     // Sidetone follows the gateware's shaped keyer output (C0[2] /
@@ -136,14 +186,57 @@ public sealed class ExternalPttService : IHostedService, IDisposable
         else _sidetone.Up();
     }
 
-    private void OnHardwarePttChanged(bool on)
+    private void OnHardwarePttChanged(bool on) => HandleRawPtt(on);
+
+    // ---- Protocol 2 wiring (new — §4 P2 PTT-in → MOX) --------------------
+
+    private void OnP2Connected(Zeus.Protocol2.Protocol2Client client)
     {
+        lock (_sync) { _p2Client = client; _owned = false; _rawHigh = false; _p2PrevPtt = false; }
+        client.TelemetryReceived += OnP2Telemetry;
+    }
+
+    private void OnP2Disconnected()
+    {
+        Zeus.Protocol2.Protocol2Client? client;
+        lock (_sync) { client = _p2Client; _p2Client = null; _owned = false; _rawHigh = false; _p2PrevPtt = false; }
+        if (client is not null) client.TelemetryReceived -= OnP2Telemetry;
+        _hangTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+        BroadcastLamp(false);
+    }
+
+    // UDP-1025 hi-priority status is LEVEL-sampled at the P2 status cadence, not
+    // an edge event — derive rising/falling by comparing against the previous
+    // PttIn level. Runs on the Protocol2Client RX thread.
+    private void OnP2Telemetry(Zeus.Protocol2.P2TelemetryReading reading)
+    {
+        bool ptt = reading.PttIn;
+        if (ptt == _p2PrevPtt) return; // no edge
+        _p2PrevPtt = ptt;
+        HandleRawPtt(ptt);
+    }
+
+    // ---- Shared debounce / hang / ownership engine -----------------------
+
+    private static bool IsCwMode(Zeus.Contracts.RxMode mode) =>
+        mode is Zeus.Contracts.RxMode.CWU or Zeus.Contracts.RxMode.CWL;
+
+    // Single entry point for a raw hardware-PTT edge from EITHER protocol. The
+    // lamp always tracks the physical input; MOX promotion is gated by the
+    // operator Enable toggle.
+    private void HandleRawPtt(bool on)
+    {
+        _rawHigh = on;
+        BroadcastLamp(on);
+        // Enable gate: when off, the lamp still tracks the footswitch but we
+        // never promote it to MOX (UI-only keying). Checked on each edge so a
+        // toggle takes effect immediately without restart.
+        if (!_settings.Get()) return;
         if (on) HandleRising();
         else HandleFalling();
     }
 
-    private static bool IsCwMode(Zeus.Contracts.RxMode mode) =>
-        mode is Zeus.Contracts.RxMode.CWU or Zeus.Contracts.RxMode.CWL;
+    private void BroadcastLamp(bool keyed) => _hub.Broadcast(new PttStatusFrame(keyed));
 
     private void HandleRising()
     {
@@ -162,12 +255,13 @@ public sealed class ExternalPttService : IHostedService, IDisposable
 
         // TxService.TrySetMox locks, broadcasts via the hub, and pokes WDSP
         // through DspPipelineService — work we don't want on the RX thread.
-        // The fire-and-forget Task.Run is OK because OnHardwarePttChanged is
-        // already edge-triggered (single rise per external press) and a
-        // subsequent fall is handled by HandleFalling regardless of ordering.
+        // The fire-and-forget Task.Run is OK because the edge is single-shot
+        // (one rise per external press) and a subsequent fall is handled by
+        // HandleFalling regardless of ordering. MoxSource.Hardware routes
+        // through the EXISTING arbitration: it cannot drop a UI/TCI/CWX MOX.
         _ = Task.Run(() =>
         {
-            if (_tx.TrySetMox(true, out var err))
+            if (_tx.TrySetMox(true, MoxSource.Hardware, out var err))
             {
                 _log.LogInformation("externalPtt.takeover.applied");
             }
@@ -198,15 +292,16 @@ public sealed class ExternalPttService : IHostedService, IDisposable
     {
         // Race guard: a rising edge inside the hang window cancels the timer,
         // but the timer can already be in-flight on the ThreadPool when the
-        // cancel arrives. Re-check the latest level before acting.
-        var client = _client;
-        if (client is not null && client.HardwarePtt) return;
+        // cancel arrives. Re-check the latest raw level before acting. _rawHigh
+        // is fed by both protocols, so this is protocol-agnostic; on P1 it
+        // tracks the same C0[0] level the old IProtocol1Client.HardwarePtt did.
+        if (_rawHigh) return;
 
         bool releaseNow;
         lock (_sync) { releaseNow = _owned; _owned = false; }
         if (!releaseNow) return;
 
-        if (_tx.TrySetMox(false, out var err))
+        if (_tx.TrySetMox(false, MoxSource.Hardware, out var err))
         {
             _log.LogInformation("externalPtt.release.applied");
         }
@@ -224,4 +319,19 @@ public sealed class ExternalPttService : IHostedService, IDisposable
         if (active) return;
         lock (_sync) _owned = false;
     }
+
+    // ---- Test seams ------------------------------------------------------
+
+    /// <summary>Test seam: drive a raw P1-style hardware-PTT edge through the
+    /// full shared engine (lamp + MOX promotion). Mirrors what
+    /// <see cref="OnHardwarePttChanged"/> does for a live P1 client.</summary>
+    internal void TestRawPttP1(bool on) => OnHardwarePttChanged(on);
+
+    /// <summary>Test seam: feed a P2 hi-priority telemetry sample through the
+    /// level→edge derivation and the shared engine, exactly as a live
+    /// Protocol2Client TelemetryReceived would.</summary>
+    internal void TestP2Telemetry(Zeus.Protocol2.P2TelemetryReading reading) => OnP2Telemetry(reading);
+
+    /// <summary>Test seam: current latched raw PTT-IN (lamp) level.</summary>
+    internal bool TestRawHigh => _rawHigh;
 }

--- a/Zeus.Server.Hosting/Hl2GpioSettingsStore.cs
+++ b/Zeus.Server.Hosting/Hl2GpioSettingsStore.cs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// HL2 user GPIO (external-ports plan, Phase 5): the 4-bit user_dig_out mask
+// emitted on the Protocol-1 register 0x0a (wire 0x14) frame C3[3:0] → MCP23008
+// (verified Thetis-mi0bot networkproto1.c:774). Global per-radio (NOT per-band)
+// — it is a static front-panel control-line state, like the audio front-end.
+//
+// Mirrors AudioSettingsStore's single-global-row LiteDB pattern, including the
+// DeleteMany+Insert upsert that dodges the LiteDB Id=0-always-inserts bug
+// (PR #387). HL2-only; the value is stored board-agnostically and gated at the
+// REST / wire layer (HasHl2UserGpio), so it never reaches the wire on a non-HL2
+// board. Default 0 (no bits set) is byte-identical to today.
+
+using LiteDB;
+
+namespace Zeus.Server;
+
+public sealed class Hl2GpioSettingsStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<Hl2GpioEntry> _rows;
+    private readonly ILogger<Hl2GpioSettingsStore> _log;
+    private readonly object _sync = new();
+
+    public event Action? Changed;
+
+    public Hl2GpioSettingsStore(ILogger<Hl2GpioSettingsStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _rows = _db.GetCollection<Hl2GpioEntry>("hl2_gpio");
+
+        _log.LogInformation("Hl2GpioSettingsStore initialized at {Path}", dbPath);
+    }
+
+    /// <summary>The persisted 4-bit user GPIO mask. Missing row defaults to 0
+    /// (all GPIO lines low) — byte-identical to today.</summary>
+    public byte Get()
+    {
+        lock (_sync)
+        {
+            var e = _rows.FindAll().FirstOrDefault();
+            return e is null ? (byte)0 : (byte)(e.Mask & 0x0F);
+        }
+    }
+
+    /// <summary>Replace the global GPIO mask (low nibble only). DeleteMany+Insert
+    /// avoids the LiteDB Id=0 upsert bug.</summary>
+    public void Set(byte mask)
+    {
+        lock (_sync)
+        {
+            _rows.DeleteMany(_ => true);
+            _rows.Insert(new Hl2GpioEntry { Mask = (byte)(mask & 0x0F), UpdatedUtc = DateTime.UtcNow });
+        }
+        Changed?.Invoke();
+    }
+
+    public void Dispose() => _db.Dispose();
+}
+
+public sealed class Hl2GpioEntry
+{
+    public int Id { get; set; }
+    // 4-bit user_dig_out mask. LiteDB is schema-less; a missing/legacy row
+    // hydrates as 0 = all lines low, the correct byte-identical default.
+    public byte Mask { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/PaSettingsStore.cs
+++ b/Zeus.Server.Hosting/PaSettingsStore.cs
@@ -236,7 +236,14 @@ public sealed record PaRuntimeSnapshot(
     // ControlFrame.EncodeRxAntennaC3Bits (P1) and is independent of this.
     HpsdrAntenna TxAntenna = HpsdrAntenna.Ant1,
     HpsdrAntenna RxAntenna = HpsdrAntenna.Ant1,
-    bool HasTxAntennaRelays = false);
+    bool HasTxAntennaRelays = false,
+    // RX auxiliary input + MkII-BPF RX-select gate (external-ports plan,
+    // Phase 5). RxAuxInput is the 0-based selector (0=None/base ANT, 1=EXT1,
+    // 2=EXT2, 3=XVTR, 4=BYPASS) the Protocol2Client expects. MkiiBpfRxSelect
+    // tells the P2 client to OR in the Saturn master RX-select bit alongside
+    // any aux. Default 0 / false reproduces today's wire bit-for-bit.
+    int RxAuxInput = 0,
+    bool MkiiBpfRxSelect = false);
 
 public sealed class PaBandEntry
 {

--- a/Zeus.Server.Hosting/PaSettingsStore.cs
+++ b/Zeus.Server.Hosting/PaSettingsStore.cs
@@ -228,7 +228,15 @@ public sealed record PaRuntimeSnapshot(
     byte OcRxMask,
     bool PaEnabled,
     byte OcDxTxMask = 0,
-    byte OcDxRxMask = 0);
+    byte OcDxRxMask = 0,
+    // Per-band antenna relay selection (external-ports plan, Phase 2). Pushed
+    // to the Protocol2Client alongside OC. HasTxAntennaRelays is the board/
+    // variant gate so the P2 client only advertises ANT2/3 on a relay-capable
+    // board; the RX-antenna wire clamp for relay-less boards lives in
+    // ControlFrame.EncodeRxAntennaC3Bits (P1) and is independent of this.
+    HpsdrAntenna TxAntenna = HpsdrAntenna.Ant1,
+    HpsdrAntenna RxAntenna = HpsdrAntenna.Ant1,
+    bool HasTxAntennaRelays = false);
 
 public sealed class PaBandEntry
 {

--- a/Zeus.Server.Hosting/PttSettingsStore.cs
+++ b/Zeus.Server.Hosting/PttSettingsStore.cs
@@ -48,14 +48,14 @@ public sealed class PttSettingsStore : IDisposable
     }
 
     /// <summary>Whether hardware PTT-IN is promoted to MOX. Missing row (fresh
-    /// install / pre-feature DB) defaults to ON — the footswitch stays live,
-    /// byte-identical to prior behaviour.</summary>
+    /// install / pre-feature DB) defaults to OFF — hardware PTT-IN keying is
+    /// opt-in; the operator enables the footswitch gate in Radio Settings.</summary>
     public bool Get()
     {
         lock (_sync)
         {
             var e = _rows.FindAll().FirstOrDefault();
-            return e is null ? true : e.Enabled;
+            return e is null ? false : e.Enabled;
         }
     }
 

--- a/Zeus.Server.Hosting/PttSettingsStore.cs
+++ b/Zeus.Server.Hosting/PttSettingsStore.cs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// Global (per-install, NOT per-band/per-radio) hardware-PTT-IN enable gate
+// (external-ports plan §4). When OFF, ExternalPttService still drives the
+// per-protocol PTT-IN status lamp (so the operator sees the footswitch press)
+// but does NOT promote the hardware edge to MOX — keying is UI-only. Defaults
+// ON so a fresh install keeps the footswitch live, matching prior behaviour.
+//
+// Mirrors Hl2GpioSettingsStore's single-row LiteDB pattern. Upsert uses
+// DeleteMany+Insert rather than Update/Upsert to dodge the LiteDB
+// `Id=0`-always-inserts bug (PR #387). A missing/legacy row hydrates Enabled to
+// its default — handled in Get() (LiteDB defaults a missing bool to false, so
+// we store the row eagerly on first Set and treat "no row" as ON).
+
+using LiteDB;
+
+namespace Zeus.Server;
+
+public sealed class PttSettingsStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<PttSettingsEntry> _rows;
+    private readonly ILogger<PttSettingsStore> _log;
+    private readonly object _sync = new();
+
+    // Fired on any write so the UI / status endpoint re-reads the gate.
+    public event Action? Changed;
+
+    public PttSettingsStore(ILogger<PttSettingsStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _rows = _db.GetCollection<PttSettingsEntry>("ptt_settings");
+
+        _log.LogInformation("PttSettingsStore initialized at {Path}", dbPath);
+    }
+
+    /// <summary>Whether hardware PTT-IN is promoted to MOX. Missing row (fresh
+    /// install / pre-feature DB) defaults to ON — the footswitch stays live,
+    /// byte-identical to prior behaviour.</summary>
+    public bool Get()
+    {
+        lock (_sync)
+        {
+            var e = _rows.FindAll().FirstOrDefault();
+            return e is null ? true : e.Enabled;
+        }
+    }
+
+    /// <summary>Replace the global enable gate. DeleteMany+Insert avoids the
+    /// LiteDB Id=0 upsert bug.</summary>
+    public void Set(bool enabled)
+    {
+        lock (_sync)
+        {
+            _rows.DeleteMany(_ => true);
+            _rows.Insert(new PttSettingsEntry { Enabled = enabled, UpdatedUtc = DateTime.UtcNow });
+        }
+        Changed?.Invoke();
+    }
+
+    public void Dispose() => _db.Dispose();
+}
+
+public sealed class PttSettingsEntry
+{
+    public int Id { get; set; }
+    public bool Enabled { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/RadioMicReceiver.cs
+++ b/Zeus.Server.Hosting/RadioMicReceiver.cs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Distributed under the GNU General Public License v2 or later. See the
+// LICENSE file at the root of this repository for full text.
+
+using System.Buffers.Binary;
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Decoder + 960-sample re-blocker for the Saturn radio-mic stream (UDP 1026,
+/// external-ports plan, §3). The radio digitises its analog jack (mic / line-in
+/// / balanced-XLR) and ships 64 samples per packet at 48 kHz; downstream
+/// <see cref="TxAudioIngest.OnMicPcmBytesFromRadioMic"/> hard-rejects anything
+/// that isn't exactly 960 samples / 3840 bytes (<c>MicBlockBytes</c>). A raw
+/// 64-sample block would be counted as a dropped frame → dead air. So, exactly
+/// as <see cref="Zeus.Server.Tci.TciTxAudioReceiver"/> does for arbitrary TCI
+/// chunk sizes, this buffers the 64-sample/packet f32-mono stream and emits only
+/// full 3840-byte blocks, carrying the &lt;960-sample remainder across packets.
+/// No resampler — the 1026 stream is natively 48 kHz; only the block SIZE is
+/// repacked.
+///
+/// Packet format (verified against pihpsdr <c>src/new_protocol.c</c>
+/// <c>process_mic_data</c>, lines 2694-2714; <c>MIC_LINE_TO_HOST_PORT = 1026</c>,
+/// <c>MIC_SAMPLES = 64</c>):
+///   bytes 0..3  : 4-byte big-endian sequence number
+///   bytes 4..131: 64 × int16 BIG-ENDIAN samples → f32 mono via × (1 / 2^15)
+///   total = 4 + 64×2 = 132 bytes
+///
+/// Threading: <see cref="Accept"/> runs on the Protocol2Client RX loop thread.
+/// The mono accumulator is guarded by <see cref="_sync"/> so a <see cref="Reset"/>
+/// (issued on any source switch) doesn't tear a packet mid-decode. The forward
+/// delegate is invoked under the lock — it lands in
+/// <see cref="TxAudioIngest.OnMicPcmBytesFromRadioMic"/>, whose own _sync is a
+/// different object, so there is no lock nesting on a shared monitor.
+/// </summary>
+internal sealed class RadioMicReceiver
+{
+    /// <summary>Sample count carried in one 1026 packet (pihpsdr MIC_SAMPLES).</summary>
+    public const int PacketSamples = 64;
+    /// <summary>Header (4 B seq) + 64 × int16 = 132 bytes.</summary>
+    public const int PacketBytes = 4 + PacketSamples * 2;
+
+    /// <summary>Mic block size <see cref="TxAudioIngest"/> consumes (20 ms @ 48 kHz).</summary>
+    public const int OutputBlockSamples = 960;
+    private const int OutputBlockBytes = OutputBlockSamples * 4;
+
+    // Worst-case headroom: 960-sample block + one full 64-sample packet.
+    private const int AccumulatorCapacity = OutputBlockSamples + PacketSamples + 64;
+
+    // int16 full-scale → f32. Matches pihpsdr's literal 0.00003051 (≈ 1/32768).
+    private const float Int16ToFloat = 1.0f / 32768.0f;
+
+    private readonly Action<ReadOnlyMemory<byte>> _forward;
+    private readonly ILogger _log;
+
+    private readonly object _sync = new();
+    private readonly float[] _monoAccumulator = new float[AccumulatorCapacity];
+    private int _monoFill;
+    private readonly byte[] _outputBuffer = new byte[OutputBlockBytes];
+
+    private long _totalPacketsAccepted;
+    private long _totalPacketsDropped;
+    private long _totalBlocksForwarded;
+
+    public RadioMicReceiver(Action<ReadOnlyMemory<byte>> forwardF32leMicBlock, ILogger log)
+    {
+        _forward = forwardF32leMicBlock ?? throw new ArgumentNullException(nameof(forwardF32leMicBlock));
+        _log = log;
+    }
+
+    public long TotalPacketsAccepted { get { lock (_sync) return _totalPacketsAccepted; } }
+    public long TotalPacketsDropped { get { lock (_sync) return _totalPacketsDropped; } }
+    public long TotalBlocksForwarded { get { lock (_sync) return _totalBlocksForwarded; } }
+
+    /// <summary>
+    /// Decode one UDP-1026 packet (4-byte BE seq + 64 × int16 BE @ 48 kHz),
+    /// append the 64 mono samples to the re-block accumulator, and forward every
+    /// full 960-sample block. The sequence header is skipped — gap detection is
+    /// not needed for TX audio (a dropped packet is a 1.3 ms silence the
+    /// accumulator simply doesn't see).
+    /// </summary>
+    public void Accept(ReadOnlySpan<byte> packet)
+    {
+        if (packet.Length < PacketBytes)
+        {
+            lock (_sync) _totalPacketsDropped++;
+            return;
+        }
+
+        lock (_sync)
+        {
+            if (_monoFill + PacketSamples > _monoAccumulator.Length)
+            {
+                // Producer outran the WDSP consumer (shouldn't happen at 48 kHz
+                // / 64-sample cadence vs. WDSP block drain). Flush + drop.
+                _log.LogWarning("radiomic overflow fill={Fill} cap={Cap}", _monoFill, _monoAccumulator.Length);
+                _monoFill = 0;
+                _totalPacketsDropped++;
+                return;
+            }
+
+            int b = 4; // skip the 4-byte BE sequence header
+            for (int i = 0; i < PacketSamples; i++, b += 2)
+            {
+                short s = BinaryPrimitives.ReadInt16BigEndian(packet.Slice(b, 2));
+                _monoAccumulator[_monoFill + i] = s * Int16ToFloat;
+            }
+            _monoFill += PacketSamples;
+            _totalPacketsAccepted++;
+
+            int writeOffset = 0;
+            while (_monoFill - writeOffset >= OutputBlockSamples)
+            {
+                for (int i = 0; i < OutputBlockSamples; i++)
+                {
+                    BinaryPrimitives.WriteSingleLittleEndian(
+                        _outputBuffer.AsSpan(i * 4, 4),
+                        _monoAccumulator[writeOffset + i]);
+                }
+                _forward(_outputBuffer);
+                writeOffset += OutputBlockSamples;
+                _totalBlocksForwarded++;
+            }
+
+            // Shift the remainder (< 960 samples) to the head.
+            int remainder = _monoFill - writeOffset;
+            if (remainder > 0 && writeOffset > 0)
+                Array.Copy(_monoAccumulator, writeOffset, _monoAccumulator, 0, remainder);
+            _monoFill = remainder;
+        }
+    }
+
+    /// <summary>
+    /// Drop any in-flight (&lt; 960-sample) remainder. Called on ANY TX-audio
+    /// source switch so pre-switch radio audio is never stitched onto the
+    /// post-switch source (external-ports plan, §3: "clear/reset this
+    /// accumulator on any source switch").
+    /// </summary>
+    public void Reset()
+    {
+        lock (_sync) _monoFill = 0;
+    }
+}

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -62,6 +62,7 @@ public sealed class RadioService : IDisposable
     private readonly PaSettingsStore _paStore;
     private readonly AntennaSettingsStore? _antennaStore;
     private readonly AudioSettingsStore? _audioStore;
+    private readonly Hl2GpioSettingsStore? _hl2GpioStore;
     private readonly PreferredRadioStore? _preferredRadioStore;
     private readonly PsSettingsStore? _psStore;
     private readonly FilterPresetStore? _filterPresetStore;
@@ -208,7 +209,7 @@ public sealed class RadioService : IDisposable
     // to its internal test-tone generator (dev / tests without a hub).
     private readonly Zeus.Protocol1.ITxIqSource? _txIqSource;
 
-    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, FilterPresetStore? filterPresetStore = null, Zeus.Protocol1.ITxIqSource? txIqSource = null, PreferredRadioStore? preferredRadioStore = null, PsSettingsStore? psStore = null, RadioStateStore? radioStateStore = null, CwSettingsStore? cwSettingsStore = null, AntennaSettingsStore? antennaStore = null, AudioSettingsStore? audioStore = null)
+    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, FilterPresetStore? filterPresetStore = null, Zeus.Protocol1.ITxIqSource? txIqSource = null, PreferredRadioStore? preferredRadioStore = null, PsSettingsStore? psStore = null, RadioStateStore? radioStateStore = null, CwSettingsStore? cwSettingsStore = null, AntennaSettingsStore? antennaStore = null, AudioSettingsStore? audioStore = null, Hl2GpioSettingsStore? hl2GpioStore = null)
     {
         _loggerFactory = loggerFactory;
         _log = loggerFactory.CreateLogger<RadioService>();
@@ -216,6 +217,7 @@ public sealed class RadioService : IDisposable
         _paStore = paStore;
         _antennaStore = antennaStore;
         _audioStore = audioStore;
+        _hl2GpioStore = hl2GpioStore;
         _preferredRadioStore = preferredRadioStore;
         _psStore = psStore;
         _filterPresetStore = filterPresetStore;
@@ -228,6 +230,11 @@ public sealed class RadioService : IDisposable
         // edit so the operator's change reaches the live client immediately.
         if (_audioStore is not null)
             _audioStore.Changed += PushAudioFrontEnd;
+        // HL2 user GPIO is global per-radio (like the audio front-end) — its own
+        // push path. Re-push on edit so the operator's change reaches the live
+        // client immediately. HL2-only; gated in PushHl2Gpio.
+        if (_hl2GpioStore is not null)
+            _hl2GpioStore.Changed += PushHl2Gpio;
         if (_preferredRadioStore is not null)
             _preferredRadioStore.Changed += RecomputePaAndPush;
         _txIqSource = txIqSource;
@@ -651,6 +658,10 @@ public sealed class RadioService : IDisposable
             // Per-board gating + the OFF defaults make this a no-op on boards
             // without an audio front-end.
             PushAudioFrontEnd();
+            // Replay the HL2 user GPIO mask (external-ports plan, Phase 5) so a
+            // persisted GPIO state is on the first frame. Gated on HasHl2UserGpio
+            // (HL2 only); a no-op everywhere else.
+            PushHl2Gpio();
             return Snapshot();
         }
         catch
@@ -1395,6 +1406,29 @@ public sealed class RadioService : IDisposable
     // for a store edit. Public so the P2-connect hook can drive it.
     public void ReplayAudioFrontEnd() => PushAudioFrontEnd();
 
+    // HL2 user GPIO push (external-ports plan, Phase 5). Global per-radio. Gated
+    // on HasHl2UserGpio — a non-HL2 board gets mask 0 (no-op), so the GPIO bits
+    // never reach the wire on a board that doesn't have them. The P1 client
+    // stores the value board-agnostically; ControlFrame only emits it on HL2.
+    private void PushHl2Gpio()
+    {
+        var caps = BoardCapabilitiesTable.For(EffectiveBoardKind, EffectiveOrionMkIIVariant);
+        byte mask = (caps.HasHl2UserGpio && _hl2GpioStore is not null) ? _hl2GpioStore.Get() : (byte)0;
+        ActiveClient?.SetUserDigOut(mask);
+    }
+
+    // Called on connect so a fresh P1 client picks up the persisted GPIO mask.
+    public void ReplayHl2Gpio() => PushHl2Gpio();
+
+    /// <summary>Read the persisted HL2 user GPIO mask (low nibble). For the
+    /// REST GET; returns 0 when no store / not set.</summary>
+    public byte GetHl2GpioMask() => _hl2GpioStore?.Get() ?? 0;
+
+    /// <summary>Persist + push the HL2 user GPIO mask (low nibble). Fires the
+    /// store Changed → PushHl2Gpio so the live client updates. No-op when no
+    /// store is wired.</summary>
+    public void SetHl2GpioMask(byte mask) => _hl2GpioStore?.Set((byte)(mask & 0x0F));
+
     /// <summary>
     /// HL2 Band Volts PWM enable (issue #279). Updates the persisted
     /// per-radio preference AND any live Protocol-1 client so the next
@@ -1522,7 +1556,19 @@ public sealed class RadioService : IDisposable
         var caps = BoardCapabilitiesTable.For(EffectiveBoardKind, EffectiveOrionMkIIVariant);
         var ant = (_antennaStore is not null && bandName is not null)
             ? _antennaStore.GetBand(bandName)
-            : new AntennaBandSelection(bandName ?? "unknown", HpsdrAntenna.Ant1, HpsdrAntenna.Ant1);
+            : new AntennaBandSelection(bandName ?? "unknown", HpsdrAntenna.Ant1, HpsdrAntenna.Ant1, RxAuxInputSel.None);
+
+        // RX auxiliary input (external-ports plan, Phase 5). Only forwarded on
+        // boards whose Alex/BPF board actually exposes the requested aux input;
+        // a board with RxAuxInputs=None (HL2) always sends None. The selected
+        // aux is gated against the per-input capability flag so a stale per-band
+        // EXT2 (persisted on a board that had EXT2) can't drive an aux relay on
+        // a board that doesn't. The P1 RX-aux wire emission is NOT implemented
+        // (no ANAN P1 board to bench against) — RX-aux only reaches the wire on
+        // the P2/0x0A path via the snapshot below; on P1 it is a no-op.
+        var rxAuxSel = GateRxAux(ant.RxAux, caps.RxAuxInputs);
+        int rxAuxWire = (int)rxAuxSel;          // 0=None..4=BYPASS, P2 selector
+        bool mkiiRxSelect = caps.MkiiBpf;        // Saturn boards gate aux behind bit 14
 
         ActiveClient?.SetDriveByte(driveByte);
         ActiveClient?.SetOcMasks(bandCfg.OcTx, bandCfg.OcRx);
@@ -1545,8 +1591,25 @@ public sealed class RadioService : IDisposable
             OcDxRxMask: bandCfg.OcDxRx,
             TxAntenna: ant.TxAnt,
             RxAntenna: ant.RxAnt,
-            HasTxAntennaRelays: caps.HasTxAntennaRelays));
+            HasTxAntennaRelays: caps.HasTxAntennaRelays,
+            RxAuxInput: rxAuxWire,
+            MkiiBpfRxSelect: mkiiRxSelect));
     }
+
+    // Gate a persisted per-band RX-aux selection against the connected board's
+    // actual aux-input capability set (external-ports plan, Phase 5). A stale
+    // value for an input this board does not expose collapses to None — the
+    // wire-layer leg of the three-layer (UI/REST/wire) defence, independent of
+    // the REST 409. Keeps a per-band BYPASS persisted on a Saturn board from
+    // ever driving K36 on a board whose Alex revision routes PS differently.
+    private static RxAuxInputSel GateRxAux(RxAuxInputSel sel, RxAuxInputs caps) => sel switch
+    {
+        RxAuxInputSel.Ext1   => caps.HasFlag(RxAuxInputs.Ext1)   ? sel : RxAuxInputSel.None,
+        RxAuxInputSel.Ext2   => caps.HasFlag(RxAuxInputs.Ext2)   ? sel : RxAuxInputSel.None,
+        RxAuxInputSel.Xvtr   => caps.HasFlag(RxAuxInputs.Xvtr)   ? sel : RxAuxInputSel.None,
+        RxAuxInputSel.Bypass => caps.HasFlag(RxAuxInputs.Bypass) ? sel : RxAuxInputSel.None,
+        _                    => RxAuxInputSel.None,
+    };
 
     // Back-compat shim for callers/tests that predate IRadioDriveProfile.
     // Runtime RecomputePaAndPush no longer goes through here — it uses the
@@ -1944,6 +2007,8 @@ public sealed class RadioService : IDisposable
             _antennaStore.Changed -= RecomputePaAndPush;
         if (_audioStore is not null)
             _audioStore.Changed -= PushAudioFrontEnd;
+        if (_hl2GpioStore is not null)
+            _hl2GpioStore.Changed -= PushHl2Gpio;
         if (_preferredRadioStore is not null)
             _preferredRadioStore.Changed -= RecomputePaAndPush;
         try { DisconnectAsync(CancellationToken.None).GetAwaiter().GetResult(); }

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -61,6 +61,7 @@ public sealed class RadioService : IDisposable
     private readonly DspSettingsStore _dspSettingsStore;
     private readonly PaSettingsStore _paStore;
     private readonly AntennaSettingsStore? _antennaStore;
+    private readonly AudioSettingsStore? _audioStore;
     private readonly PreferredRadioStore? _preferredRadioStore;
     private readonly PsSettingsStore? _psStore;
     private readonly FilterPresetStore? _filterPresetStore;
@@ -180,6 +181,13 @@ public sealed class RadioService : IDisposable
     // CmdGeneral[58]). RadioService pushes to the P1 client directly because
     // it owns _activeClient.
     public event Action<PaRuntimeSnapshot>? PaSnapshotChanged;
+    // Fires whenever the global audio front-end state changes (store edit or
+    // connect rehydrate). The P1 side is pushed directly via ActiveClient in
+    // PushAudioFrontEnd; this event lets DspPipelineService forward the same
+    // state into a live Protocol2Client (TxSpecific bytes 50/51). Audio is
+    // global per-radio, so it is a distinct event from PaSnapshotChanged
+    // (which is per-band).
+    public event Action<AudioFrontEndPush>? AudioFrontEndChanged;
     // Fires on every MOX / TUN edge. P1 side is pushed directly via
     // ActiveClient?.SetMox; these events give DspPipelineService the hook it
     // needs to forward the same bit into a live Protocol2Client, which owns
@@ -200,13 +208,14 @@ public sealed class RadioService : IDisposable
     // to its internal test-tone generator (dev / tests without a hub).
     private readonly Zeus.Protocol1.ITxIqSource? _txIqSource;
 
-    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, FilterPresetStore? filterPresetStore = null, Zeus.Protocol1.ITxIqSource? txIqSource = null, PreferredRadioStore? preferredRadioStore = null, PsSettingsStore? psStore = null, RadioStateStore? radioStateStore = null, CwSettingsStore? cwSettingsStore = null, AntennaSettingsStore? antennaStore = null)
+    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, FilterPresetStore? filterPresetStore = null, Zeus.Protocol1.ITxIqSource? txIqSource = null, PreferredRadioStore? preferredRadioStore = null, PsSettingsStore? psStore = null, RadioStateStore? radioStateStore = null, CwSettingsStore? cwSettingsStore = null, AntennaSettingsStore? antennaStore = null, AudioSettingsStore? audioStore = null)
     {
         _loggerFactory = loggerFactory;
         _log = loggerFactory.CreateLogger<RadioService>();
         _dspSettingsStore = dspSettingsStore;
         _paStore = paStore;
         _antennaStore = antennaStore;
+        _audioStore = audioStore;
         _preferredRadioStore = preferredRadioStore;
         _psStore = psStore;
         _filterPresetStore = filterPresetStore;
@@ -214,6 +223,11 @@ public sealed class RadioService : IDisposable
         _paStore.Changed += RecomputePaAndPush;
         if (_antennaStore is not null)
             _antennaStore.Changed += RecomputePaAndPush;
+        // Audio front-end is global per-radio (not per-band), so it has its own
+        // push path rather than riding RecomputePaAndPush. Re-push on any store
+        // edit so the operator's change reaches the live client immediately.
+        if (_audioStore is not null)
+            _audioStore.Changed += PushAudioFrontEnd;
         if (_preferredRadioStore is not null)
             _preferredRadioStore.Changed += RecomputePaAndPush;
         _txIqSource = txIqSource;
@@ -631,6 +645,12 @@ public sealed class RadioService : IDisposable
             // at the protocol defaults (drive=0, OC=0) until something else
             // moves.
             RecomputePaAndPush();
+            // Replay the global audio front-end (external-ports plan, Phase 4)
+            // so the operator's mic/line-in/boost/bias/gain selection is on the
+            // first outgoing frame, not deferred until they touch the panel.
+            // Per-board gating + the OFF defaults make this a no-op on boards
+            // without an audio front-end.
+            PushAudioFrontEnd();
             return Snapshot();
         }
         catch
@@ -1327,6 +1347,54 @@ public sealed class RadioService : IDisposable
     // next state change.
     public void ReplayPaSnapshot() => RecomputePaAndPush();
 
+    // Global audio front-end push (external-ports plan, Phase 4). Server-
+    // authoritative: read AudioSettingsStore, gate per-board, push to the P1
+    // client directly and fire AudioFrontEndChanged for the P2 forwarder.
+    // Called on store edit and on connect (P1 + P2). Mirrors the OC/antenna
+    // RecomputePaAndPush discipline but for the GLOBAL (not per-band) audio
+    // state. Defaults (mic input, no boost/bias, gain 0) reproduce today's
+    // wire output bit-for-bit.
+    private void PushAudioFrontEnd()
+    {
+        var sel = _audioStore?.Get() ?? AudioFrontEndSelection.Default;
+        var caps = BoardCapabilitiesTable.For(EffectiveBoardKind, EffectiveOrionMkIIVariant);
+
+        // Per-board gating. A board with neither codec nor HL2 mic front-end
+        // gets the all-default (no-op) state, so nothing new ever reaches the
+        // wire. mic_bias is additionally guarded: only HL2 (HermesLite2MicFrontEnd)
+        // and codec boards (HasOnboardCodec) expose it, and it stays whatever
+        // the operator stored — defaulting OFF — but a non-audio board can never
+        // emit it.
+        bool audioCapable = caps.HasOnboardCodec || caps.HermesLite2MicFrontEnd;
+        var eff = audioCapable ? sel : AudioFrontEndSelection.Default;
+
+        // P1: codec boards carry mic_boost/mic_linein on the 0x12 frame; HL2
+        // carries mic_trs(=balanced) / mic_bias / line_in_gain on the 0x14
+        // frame. The ControlFrame writer gates which fields actually land per
+        // board, so passing the full set is safe — the wrong-board fields are
+        // ignored. On HL2 the "balanced input" select maps to mic_trs (the
+        // TRS/balanced front-end pin), so BalancedInput drives MicTrs there.
+        ActiveClient?.SetAudioFrontEnd(
+            micBoost: eff.MicBoost,
+            micLineIn: eff.LineIn,
+            micTrs: eff.BalancedInput,
+            micBias: eff.MicBias,
+            lineInGain: eff.LineInGain);
+
+        // P2: forward to the live Protocol2Client via DspPipelineService.
+        AudioFrontEndChanged?.Invoke(new AudioFrontEndPush(
+            LineIn: eff.LineIn,
+            MicBoost: eff.MicBoost,
+            MicBias: eff.MicBias,
+            BalancedInput: eff.BalancedInput,
+            LineInGain: eff.LineInGain));
+    }
+
+    // DspPipelineService calls this right after a P2 client is created so the
+    // fresh connection picks up the persisted audio front-end without waiting
+    // for a store edit. Public so the P2-connect hook can drive it.
+    public void ReplayAudioFrontEnd() => PushAudioFrontEnd();
+
     /// <summary>
     /// HL2 Band Volts PWM enable (issue #279). Updates the persisted
     /// per-radio preference AND any live Protocol-1 client so the next
@@ -1874,6 +1942,8 @@ public sealed class RadioService : IDisposable
         _paStore.Changed -= RecomputePaAndPush;
         if (_antennaStore is not null)
             _antennaStore.Changed -= RecomputePaAndPush;
+        if (_audioStore is not null)
+            _audioStore.Changed -= PushAudioFrontEnd;
         if (_preferredRadioStore is not null)
             _preferredRadioStore.Changed -= RecomputePaAndPush;
         try { DisconnectAsync(CancellationToken.None).GetAwaiter().GetResult(); }

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -1367,38 +1367,107 @@ public sealed class RadioService : IDisposable
     // wire output bit-for-bit.
     private void PushAudioFrontEnd()
     {
-        var sel = _audioStore?.Get() ?? AudioFrontEndSelection.Default;
-        var caps = BoardCapabilitiesTable.For(EffectiveBoardKind, EffectiveOrionMkIIVariant);
+        var sel = _audioStore?.Get() ?? AudioSourceSelection.Default;
+        var board = EffectiveBoardKind;
+        var variant = EffectiveOrionMkIIVariant;
+        var caps = BoardCapabilitiesTable.For(board, variant);
 
-        // Per-board gating. A board with neither codec nor HL2 mic front-end
-        // gets the all-default (no-op) state, so nothing new ever reaches the
-        // wire. mic_bias is additionally guarded: only HL2 (HermesLite2MicFrontEnd)
-        // and codec boards (HasOnboardCodec) expose it, and it stays whatever
-        // the operator stored — defaulting OFF — but a non-audio board can never
-        // emit it.
-        bool audioCapable = caps.HasOnboardCodec || caps.HermesLite2MicFrontEnd;
-        var eff = audioCapable ? sel : AudioFrontEndSelection.Default;
+        // CLAMP the persisted source against the connected board's capabilities
+        // (external-ports plan, §5/§8). Any source the board can't honour falls
+        // back to Host so the wire is never handed a jack the hardware lacks:
+        //   - HL2 (no onboard codec) is Host-only — any radio source → Host.
+        //   - RadioLineIn requires HasRadioLineIn (200D + 0x0A family).
+        //   - RadioBalancedXlr requires HasBalancedXlr (G2 / G2-1K only).
+        //   - RadioMic requires an audio front-end at all (codec OR HL2 mic —
+        //     but HL2's "mic front-end" is not a host-suppressing TX source in
+        //     v1, so RadioMic needs the codec).
+        // The mic-bias param is additionally suppressed on boards without
+        // HasMicBias, so a stale bias bit can never reach a non-bias board.
+        var resolved = ClampAudioSource(sel, caps);
 
-        // P1: codec boards carry mic_boost/mic_linein on the 0x12 frame; HL2
-        // carries mic_trs(=balanced) / mic_bias / line_in_gain on the 0x14
-        // frame. The ControlFrame writer gates which fields actually land per
-        // board, so passing the full set is safe — the wrong-board fields are
-        // ignored. On HL2 the "balanced input" select maps to mic_trs (the
-        // TRS/balanced front-end pin), so BalancedInput drives MicTrs there.
+        // Encode the wire bytes as PURE FUNCTIONS of the resolved source (§2).
+        // Host → literal zero on every surface, byte-identical to today; no
+        // param fallthrough.
+        var encoder = ExternalPortEncoders.For(board, variant);
+        var portState = new ExternalPortState(
+            Source: resolved.Source,
+            MicBoost: resolved.MicBoost,
+            MicBias: resolved.MicBias,
+            LineInGain: resolved.LineInGain);
+
+        // P1 codec boards (Hermes-class): mic_boost on the 0x12 frame. HL2 is
+        // Host-only — the encoder returns all-clear, and ControlFrame's
+        // read-modify-write keeps the PS bit + C4 PGA intact. mic_trs/mic_bias/
+        // line_in_gain are NOT host-suppressing TX sources on HL2 in v1, so they
+        // stay clear (Host). The P1 SetAudioFrontEnd signature is preserved.
+        var (p1Boost, p1LineIn) = encoder.EncodeP1CodecAudioBits(in portState);
         ActiveClient?.SetAudioFrontEnd(
-            micBoost: eff.MicBoost,
-            micLineIn: eff.LineIn,
-            micTrs: eff.BalancedInput,
-            micBias: eff.MicBias,
-            lineInGain: eff.LineInGain);
+            micBoost: p1Boost,
+            micLineIn: p1LineIn,
+            micTrs: false,
+            micBias: false,
+            lineInGain: 0);
 
-        // P2: forward to the live Protocol2Client via DspPipelineService.
+        // P2 (0x0A Saturn family): forward the resolved literal byte-50
+        // mic_control + byte-51 line_in_gain to the live Protocol2Client via
+        // DspPipelineService. The forwarder does no source interpretation.
+        byte micControl = encoder.EncodeP2MicControlByte(in portState);
+        byte lineInGain = encoder.EncodeP2LineInGainByte(in portState);
         AudioFrontEndChanged?.Invoke(new AudioFrontEndPush(
-            LineIn: eff.LineIn,
-            MicBoost: eff.MicBoost,
-            MicBias: eff.MicBias,
-            BalancedInput: eff.BalancedInput,
-            LineInGain: eff.LineInGain));
+            Source: resolved.Source,
+            MicControlByte: micControl,
+            LineInGain: lineInGain));
+
+        // Mirror the RESOLVED source into StateDto so the frontend hydrates from
+        // the server and never clobbers it on connect (PR #359/#360 pattern).
+        Mutate(s => s.TxAudioSource == resolved.Source ? s : s with { TxAudioSource = resolved.Source });
+
+        // PASS B SEAM: the actual radio-mic STREAM routing into the TX pipeline
+        // (1026 parse → 960-sample re-block → OnMicPcmBytesFromRadioMic) and the
+        // in-lock `_activeSource` single-select arbitration in TxAudioIngest are
+        // NOT wired here — Pass A only pushes the wire bytes + StateDto + clamp.
+        // Pass B reads `resolved.Source` (or StateDto.TxAudioSource) to set the
+        // pipeline's active source and suppress the host mic when a radio jack is
+        // chosen. Until then, host audio continues to flow regardless of Source.
+    }
+
+    /// <summary>
+    /// Clamp a persisted <see cref="AudioSourceSelection"/> against a board's
+    /// capabilities (external-ports plan, §5/§8). Returns Host (with no params)
+    /// whenever the board cannot honour the requested jack, and drops the
+    /// mic-bias param on boards without <c>HasMicBias</c>. Pure — no side
+    /// effects — so the endpoint and the push share one definition.
+    /// </summary>
+    internal static AudioSourceSelection ClampAudioSource(AudioSourceSelection sel, BoardCapabilities caps)
+    {
+        // A board with neither the stream codec nor the HL2 mic front-end has no
+        // audio jacks at all → Host.
+        bool audioCapable = caps.HasOnboardCodec || caps.HermesLite2MicFrontEnd;
+        if (!audioCapable) return AudioSourceSelection.Default;
+
+        switch (sel.Source)
+        {
+            case TxAudioSource.RadioMic:
+                // RadioMic needs the stream codec (HL2's mic front-end is not a
+                // host-suppressing TX source in v1). Drop bias on non-bias boards.
+                if (!caps.HasOnboardCodec) return AudioSourceSelection.Default;
+                return sel with { MicBias = sel.MicBias && caps.HasMicBias };
+
+            case TxAudioSource.RadioLineIn:
+                if (!caps.HasOnboardCodec || !caps.HasRadioLineIn)
+                    return AudioSourceSelection.Default;
+                // Line-in carries gain, not mic params.
+                return new AudioSourceSelection(TxAudioSource.RadioLineIn, MicBoost: false, MicBias: false, LineInGain: sel.LineInGain);
+
+            case TxAudioSource.RadioBalancedXlr:
+                if (!caps.HasOnboardCodec || !caps.HasBalancedXlr)
+                    return AudioSourceSelection.Default;
+                return sel with { MicBias = sel.MicBias && caps.HasMicBias, LineInGain = 0 };
+
+            case TxAudioSource.Host:
+            default:
+                return AudioSourceSelection.Default;
+        }
     }
 
     // DspPipelineService calls this right after a P2 client is created so the

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -60,6 +60,7 @@ public sealed class RadioService : IDisposable
     private readonly ILogger<RadioService> _log;
     private readonly DspSettingsStore _dspSettingsStore;
     private readonly PaSettingsStore _paStore;
+    private readonly AntennaSettingsStore? _antennaStore;
     private readonly PreferredRadioStore? _preferredRadioStore;
     private readonly PsSettingsStore? _psStore;
     private readonly FilterPresetStore? _filterPresetStore;
@@ -199,17 +200,20 @@ public sealed class RadioService : IDisposable
     // to its internal test-tone generator (dev / tests without a hub).
     private readonly Zeus.Protocol1.ITxIqSource? _txIqSource;
 
-    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, FilterPresetStore? filterPresetStore = null, Zeus.Protocol1.ITxIqSource? txIqSource = null, PreferredRadioStore? preferredRadioStore = null, PsSettingsStore? psStore = null, RadioStateStore? radioStateStore = null, CwSettingsStore? cwSettingsStore = null)
+    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, FilterPresetStore? filterPresetStore = null, Zeus.Protocol1.ITxIqSource? txIqSource = null, PreferredRadioStore? preferredRadioStore = null, PsSettingsStore? psStore = null, RadioStateStore? radioStateStore = null, CwSettingsStore? cwSettingsStore = null, AntennaSettingsStore? antennaStore = null)
     {
         _loggerFactory = loggerFactory;
         _log = loggerFactory.CreateLogger<RadioService>();
         _dspSettingsStore = dspSettingsStore;
         _paStore = paStore;
+        _antennaStore = antennaStore;
         _preferredRadioStore = preferredRadioStore;
         _psStore = psStore;
         _filterPresetStore = filterPresetStore;
         _radioStateStore = radioStateStore;
         _paStore.Changed += RecomputePaAndPush;
+        if (_antennaStore is not null)
+            _antennaStore.Changed += RecomputePaAndPush;
         if (_preferredRadioStore is not null)
             _preferredRadioStore.Changed += RecomputePaAndPush;
         _txIqSource = txIqSource;
@@ -1440,8 +1444,24 @@ public sealed class RadioService : IDisposable
             tunActive, activePct, bandName ?? "?", bandCfg.PaGainDb, cfg.Global.PaMaxPowerWatts, driveProfile.BoardLabel, driveByte, paEnabled,
             bandCfg.OcTx, bandCfg.OcRx, bandCfg.OcDxTx, bandCfg.OcDxRx);
 
+        // Per-band TX/RX antenna relay selection (external-ports plan, Phase 2).
+        // Server-authoritative: read from AntennaSettingsStore for the current
+        // band (NOT StateDto — avoids the frontend-clobbers-server-on-connect
+        // bug), and pushed through the SAME RecomputePaAndPush path OC uses.
+        // The relay-capability gate travels in the snapshot so the P2 client
+        // can gate alex0[26:24]; the P1 RX-antenna wire clamp lives in
+        // ControlFrame.EncodeRxAntennaC3Bits and protects HL2 regardless.
+        var caps = BoardCapabilitiesTable.For(EffectiveBoardKind, EffectiveOrionMkIIVariant);
+        var ant = (_antennaStore is not null && bandName is not null)
+            ? _antennaStore.GetBand(bandName)
+            : new AntennaBandSelection(bandName ?? "unknown", HpsdrAntenna.Ant1, HpsdrAntenna.Ant1);
+
         ActiveClient?.SetDriveByte(driveByte);
         ActiveClient?.SetOcMasks(bandCfg.OcTx, bandCfg.OcRx);
+        // P1 RX-antenna (TX is ANT1-hardwired on every P1 board). The wire-layer
+        // clamp in EncodeRxAntennaC3Bits forces ANT1 on HL2, so pushing the
+        // stored value here is safe even for the single-jack board.
+        ActiveClient?.SetAntennaRx(ant.RxAnt);
 
         PaSnapshotChanged?.Invoke(new PaRuntimeSnapshot(
             DriveByte: driveByte,
@@ -1454,7 +1474,10 @@ public sealed class RadioService : IDisposable
             // gated by board+variant, so non-Anvelina radios receive a
             // SetOcDxMasks call but the bytes never reach the wire.
             OcDxTxMask: bandCfg.OcDxTx,
-            OcDxRxMask: bandCfg.OcDxRx));
+            OcDxRxMask: bandCfg.OcDxRx,
+            TxAntenna: ant.TxAnt,
+            RxAntenna: ant.RxAnt,
+            HasTxAntennaRelays: caps.HasTxAntennaRelays));
     }
 
     // Back-compat shim for callers/tests that predate IRadioDriveProfile.
@@ -1849,6 +1872,10 @@ public sealed class RadioService : IDisposable
     public void Dispose()
     {
         _paStore.Changed -= RecomputePaAndPush;
+        if (_antennaStore is not null)
+            _antennaStore.Changed -= RecomputePaAndPush;
+        if (_preferredRadioStore is not null)
+            _preferredRadioStore.Changed -= RecomputePaAndPush;
         try { DisconnectAsync(CancellationToken.None).GetAwaiter().GetResult(); }
         catch { /* best-effort */ }
         _stateFlushTimer?.Dispose();

--- a/Zeus.Server.Hosting/StreamingHub.cs
+++ b/Zeus.Server.Hosting/StreamingHub.cs
@@ -433,6 +433,19 @@ public sealed class StreamingHub
         }
     }
 
+    public void Broadcast(in PttStatusFrame frame)
+    {
+        if (_clients.IsEmpty) return;
+
+        var payload = new byte[PttStatusFrame.ByteLength];
+        var writer = new FixedBufferWriter(payload, PttStatusFrame.ByteLength);
+        frame.Serialize(writer);
+        foreach (var client in _clients.Values)
+        {
+            if (!client.TryEnqueue(payload)) System.Threading.Interlocked.Increment(ref _dropsOther);
+        }
+    }
+
     public void Broadcast(in AudioMasterBypassFrame frame)
     {
         if (_clients.IsEmpty) return;

--- a/Zeus.Server.Hosting/TxAudioIngest.cs
+++ b/Zeus.Server.Hosting/TxAudioIngest.cs
@@ -44,10 +44,32 @@
 
 using System.Buffers.Binary;
 using Microsoft.Extensions.Logging;
+using Zeus.Contracts;
 using Zeus.Dsp;
 using Zeus.Protocol1;
 
 namespace Zeus.Server;
+
+/// <summary>
+/// Internal tag identifying which producer fed a TX-audio block into
+/// <see cref="TxAudioIngest.OnMicPcmBytes"/>. Carried explicitly (NOT inferred
+/// from recency) so the in-lock single-select gate can arbitrate the host mic
+/// against a radio jack deterministically across a source switch
+/// (external-ports plan, §3). TCI/WAV remain operator-explicit overrides and
+/// bypass the host/radio arbitration — their precedence is the existing
+/// recency hysteresis.
+/// </summary>
+internal enum MicBlockSource
+{
+    /// <summary>Browser / native host microphone (the default TX-audio source).</summary>
+    Host = 0,
+    /// <summary>Radio-digitised jack audio (Saturn mic/line-in/XLR via UDP 1026).</summary>
+    RadioMic,
+    /// <summary>TCI client TX audio (MSHV / WSJT-X …). Operator-explicit override.</summary>
+    Tci,
+    /// <summary>WAV-recording playback to the air. Operator-explicit override.</summary>
+    Wav,
+}
 
 /// <summary>
 /// Bridges browser-side mic audio to WDSP TXA and onward to the EP2 IQ
@@ -120,6 +142,51 @@ public sealed class TxAudioIngest : IDisposable
     // concurrent native-mic frame within TciHysteresisMs is suppressed — the
     // recording replaces the live mic on the air, they never mix.
     private long _lastWavTickMs;
+
+    // The currently-armed TX-audio source for HOST↔RADIO arbitration
+    // (external-ports plan, §3, "atomic single-select gate"). Read and written
+    // ONLY under _sync. OnMicPcmBytes rejects any Host- or RadioMic-tagged block
+    // whose tag != _activeSource, so when a radio jack is armed the host mic is
+    // dropped immediately by the in-lock compare (no overlap window) and vice
+    // versa. TCI/WAV-tagged blocks bypass this compare — they are operator-
+    // explicit overrides gated by their own recency hysteresis. Default Host so
+    // a fresh / un-switched ingest is byte/behaviour-identical to today.
+    private MicBlockSource _activeSource = MicBlockSource.Host;
+    // Source whose samples currently occupy the WDSP accumulator. Read/written
+    // ONLY under _sync. Used to enforce that a partially-filled accumulator is
+    // NEVER topped up by a different source: between the cheap top-of-method gate
+    // and the accumulation lock, _activeSource can flip, so the AUTHORITATIVE
+    // arbitration is re-done inside the accumulation lock against this owner.
+    private MicBlockSource _accumulatorSource = MicBlockSource.Host;
+
+    /// <summary>
+    /// Arm the TX-audio source for the HOST↔RADIO single-select gate
+    /// (external-ports plan, §3). Called by the pipeline when the resolved
+    /// <see cref="TxAudioSource"/> changes. Under <see cref="_sync"/> this sets
+    /// the new active source AND clears the WDSP accumulator so no half-block of
+    /// the old source survives onto the new source — the new source fills from
+    /// empty. The 1026 re-blocker (owned upstream) is reset by the same caller.
+    /// Maps every radio jack (Mic/Line-In/XLR) onto <see cref="MicBlockSource.RadioMic"/>
+    /// because they all arrive on the one UDP-1026 stream; only Host is distinct
+    /// here. TCI/WAV are not selectable sources — they override transiently.
+    /// </summary>
+    internal void SetActiveSource(TxAudioSource source)
+    {
+        var mapped = source == TxAudioSource.Host
+            ? MicBlockSource.Host
+            : MicBlockSource.RadioMic;
+        lock (_sync)
+        {
+            if (_activeSource == mapped) return;
+            _activeSource = mapped;
+            // Quiesce: drop any partially-accumulated old-source audio so it
+            // can't stitch onto the post-switch source mid-WDSP-block.
+            _accumulatorFill = 0;
+        }
+    }
+
+    /// <summary>Current armed source for the host/radio gate (test/diagnostic).</summary>
+    internal MicBlockSource ActiveSource { get { lock (_sync) return _activeSource; } }
 
     /// <summary>
     /// True when a TCI client is the authoritative source of TX audio right now
@@ -232,7 +299,7 @@ public sealed class TxAudioIngest : IDisposable
     internal void OnMicPcmBytesFromTci(ReadOnlyMemory<byte> f32lePayload)
     {
         Volatile.Write(ref _lastTciTickMs, Environment.TickCount64);
-        OnMicPcmBytes(f32lePayload);
+        OnMicPcmBytes(f32lePayload, MicBlockSource.Tci);
     }
 
     /// <summary>
@@ -249,7 +316,27 @@ public sealed class TxAudioIngest : IDisposable
         if (lastTci != 0 && now - lastTci < TciHysteresisMs) return;
         long lastWav = Volatile.Read(ref _lastWavTickMs);
         if (lastWav != 0 && now - lastWav < TciHysteresisMs) return;
-        OnMicPcmBytes(f32lePayload);
+        OnMicPcmBytes(f32lePayload, MicBlockSource.Host);
+    }
+
+    /// <summary>
+    /// Source-tagged entry point for radio-digitised jack audio (Saturn mic /
+    /// line-in / balanced-XLR, arriving on UDP 1026 and re-blocked to 960
+    /// samples upstream — external-ports plan, §3). Tagged
+    /// <see cref="MicBlockSource.RadioMic"/>; the in-lock <see cref="_activeSource"/>
+    /// compare in <see cref="OnMicPcmBytes"/> drops it unless a radio jack is the
+    /// armed source, so it can never leak onto the air under Host. Like the host
+    /// mic, it yields to a recent TCI/WAV override so a remote/playback source is
+    /// never mixed with radio-jack audio.
+    /// </summary>
+    internal void OnMicPcmBytesFromRadioMic(ReadOnlyMemory<byte> f32lePayload)
+    {
+        long now = Environment.TickCount64;
+        long lastTci = Volatile.Read(ref _lastTciTickMs);
+        if (lastTci != 0 && now - lastTci < TciHysteresisMs) return;
+        long lastWav = Volatile.Read(ref _lastWavTickMs);
+        if (lastWav != 0 && now - lastWav < TciHysteresisMs) return;
+        OnMicPcmBytes(f32lePayload, MicBlockSource.RadioMic);
     }
 
     /// <summary>Source-tagged entry point for WAV-recording playback to the
@@ -261,16 +348,37 @@ public sealed class TxAudioIngest : IDisposable
     internal void OnMicPcmBytesFromWav(ReadOnlyMemory<byte> f32lePayload)
     {
         Volatile.Write(ref _lastWavTickMs, Environment.TickCount64);
-        OnMicPcmBytes(f32lePayload);
+        OnMicPcmBytes(f32lePayload, MicBlockSource.Wav);
     }
 
     // Internal so tests can drive the ingest directly without standing up a WS.
+    // The source tag arbitrates the HOST↔RADIO single-select gate IN-LOCK (see
+    // _activeSource); TCI/WAV bypass that compare as operator-explicit overrides.
     internal void OnMicPcmBytes(ReadOnlyMemory<byte> f32lePayload)
+        => OnMicPcmBytes(f32lePayload, MicBlockSource.Host);
+
+    internal void OnMicPcmBytes(ReadOnlyMemory<byte> f32lePayload, MicBlockSource source)
     {
         if (f32lePayload.Length != MicBlockBytes)
         {
             lock (_sync) _droppedFrames++;
             return;
+        }
+
+        // Cheap early-out for the host/radio gate (external-ports plan, §3). This
+        // is NOT the hard gate — _activeSource can still flip between here and the
+        // accumulation lock below, so the AUTHORITATIVE single-select decision is
+        // re-checked atomically with the append (see "ATOMIC single-select gate"
+        // inside the accumulation lock). Doing the obvious reject here too avoids
+        // running the MOX-edge / tap / WDSP-sizing work for a block that the
+        // authoritative check will drop anyway. TCI/WAV bypass this compare — they
+        // are operator-explicit overrides gated by the recency hysteresis above.
+        if (source is MicBlockSource.Host or MicBlockSource.RadioMic)
+        {
+            lock (_sync)
+            {
+                if (source != _activeSource) { _droppedFrames++; return; }
+            }
         }
 
         // Non-destructive mic tap, fired BEFORE the MOX/monitor gate so a
@@ -350,6 +458,33 @@ public sealed class TxAudioIngest : IDisposable
 
         lock (_sync)
         {
+            // ATOMIC single-select gate (external-ports plan, §3, the crux).
+            // This is the AUTHORITATIVE host/radio arbitration: it runs in the
+            // SAME critical section as the accumulator append, so no flip of
+            // _activeSource (by SetActiveSource, also under _sync) can slip
+            // between "decide" and "append". A Host/RadioMic block whose tag no
+            // longer matches the armed source is dropped, so two producer threads
+            // straddling a switch resolve to exactly one contributor per WDSP
+            // block — no double-feed. TCI/WAV bypass this (operator-explicit
+            // overrides; recency-gated above). Under Host with a Host block this
+            // is a pure no-op → host path byte/behaviour-identical to today.
+            if (source is MicBlockSource.Host or MicBlockSource.RadioMic
+                && source != _activeSource)
+            {
+                _droppedFrames++;
+                return;
+            }
+            // Guard the accumulator owner: if a half-filled block belongs to a
+            // different source than the one now appending (possible when the
+            // active source flipped while data sat buffered), drop the stale
+            // remainder so the two sources never mix inside one WDSP block. For
+            // TCI/WAV the owner tracks them too so a TCI burst can't stitch onto a
+            // leftover host/radio remainder. SetActiveSource already clears on the
+            // host/radio switch; this covers the TCI/WAV interleave as well.
+            if (_accumulatorFill > 0 && _accumulatorSource != source)
+                _accumulatorFill = 0;
+            _accumulatorSource = source;
+
             // Decode f32le into accumulator. WDSP wants -1..+1 range; browser
             // ships the same convention.
             var src = f32lePayload.Span;

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -1202,6 +1202,61 @@ public static class ZeusEndpoints
             return Results.Ok(new AntennaSettingsDto(caps.HasTxAntennaRelays, caps.HasRxAntennaRelays, bands));
         });
 
+        // Global (per-radio) audio front-end (external-ports plan, Phase 4).
+        // GET returns the capability gates + the persisted selection. The
+        // frontend renders the Hermes-class controls (mic boost / line-in) when
+        // hasOnboardCodec, and the HL2 controls (mic_trs / mic_bias /
+        // line-in-gain) when hermesLite2MicFrontEnd. Always 200 — a board with
+        // neither reports both gates false and the panel shows nothing.
+        app.MapGet("/api/radio/audio", (RadioService radio, AudioSettingsStore store) =>
+        {
+            var caps = BoardCapabilitiesTable.For(radio.EffectiveBoardKind, radio.EffectiveOrionMkIIVariant);
+            var sel = store.Get();
+            return Results.Ok(new AudioFrontEndDto(
+                HasOnboardCodec: caps.HasOnboardCodec,
+                HermesLite2MicFrontEnd: caps.HermesLite2MicFrontEnd,
+                LineIn: sel.LineIn,
+                MicBoost: sel.MicBoost,
+                MicBias: sel.MicBias,
+                BalancedInput: sel.BalancedInput,
+                LineInGain: sel.LineInGain));
+        });
+
+        // PUT the whole global audio front-end. Capability-gated: 409 when the
+        // connected board has no audio front-end at all (neither codec nor HL2
+        // mic), so a non-audio board can never be handed audio bytes. LineInGain
+        // is clamped 0..31. The save fires AudioSettingsStore.Changed ->
+        // RadioService.PushAudioFrontEnd, which gates per-board and pushes
+        // server-authoritatively to the live client (P1 SetAudioFrontEnd / P2
+        // TxSpecific 50/51) — never via the frontend, so no clobber-on-connect.
+        app.MapPut("/api/radio/audio", (AudioFrontEndSetRequest req, RadioService radio, AudioSettingsStore store) =>
+        {
+            if (req is null)
+                return Results.BadRequest(new { error = "body required" });
+
+            var caps = BoardCapabilitiesTable.For(radio.EffectiveBoardKind, radio.EffectiveOrionMkIIVariant);
+            bool audioCapable = caps.HasOnboardCodec || caps.HermesLite2MicFrontEnd;
+            if (!audioCapable)
+                return Results.Conflict(new { error = $"board {radio.EffectiveBoardKind} has no audio front-end" });
+
+            store.Set(new AudioFrontEndSelection(
+                LineIn: req.LineIn,
+                MicBoost: req.MicBoost,
+                MicBias: req.MicBias,
+                BalancedInput: req.BalancedInput,
+                LineInGain: (byte)Math.Clamp(req.LineInGain, 0, 31)));
+
+            var sel = store.Get();
+            return Results.Ok(new AudioFrontEndDto(
+                caps.HasOnboardCodec,
+                caps.HermesLite2MicFrontEnd,
+                sel.LineIn,
+                sel.MicBoost,
+                sel.MicBias,
+                sel.BalancedInput,
+                sel.LineInGain));
+        });
+
         // Per-radio frequency calibration (issue #325). GET returns the
         // persisted correction factor + its ppm representation. POST
         // /calibrate runs the one-button auto-cal procedure (snapshot

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -1150,6 +1150,58 @@ public static class ZeusEndpoints
             return Results.Ok(new Hl2OptionsDto(BandVolts: effective));
         });
 
+        // Per-band TX/RX antenna relay selection (external-ports plan, Phase 2).
+        // GET returns the relay-capability gates + all HF bands' stored
+        // selections (defaulting to ANT1/ANT1). The frontend gates the TX/RX
+        // selectors on hasTxAntennaRelays / hasRxAntennaRelays. Always 200 —
+        // a non-relay board simply reports the gates false and ANT1 rows.
+        app.MapGet("/api/radio/antenna", (RadioService radio, AntennaSettingsStore store) =>
+        {
+            var caps = BoardCapabilitiesTable.For(radio.EffectiveBoardKind, radio.EffectiveOrionMkIIVariant);
+            var bands = store.GetAll()
+                .Select(b => new AntennaBandDto(b.Band, b.TxAnt.ToString(), b.RxAnt.ToString()))
+                .ToArray();
+            return Results.Ok(new AntennaSettingsDto(
+                HasTxAntennaRelays: caps.HasTxAntennaRelays,
+                HasRxAntennaRelays: caps.HasRxAntennaRelays,
+                Bands: bands));
+        });
+
+        // PUT one band's antenna selection. Capability-gated: 400 on a malformed
+        // body / unknown band / unparseable antenna; 409 when the request asks
+        // for a relay the connected board does not have (a non-ANT1 TX on a
+        // board without TX relays, or non-ANT1 RX on a board without RX relays).
+        // ANT1 is always accepted (it is the hardwired default on every board).
+        app.MapPut("/api/radio/antenna", (AntennaSetRequest req, RadioService radio, AntennaSettingsStore store) =>
+        {
+            if (req is null || string.IsNullOrWhiteSpace(req.Band))
+                return Results.BadRequest(new { error = "band required" });
+            if (!BandUtils.HfBands.Contains(req.Band))
+                return Results.BadRequest(new { error = $"unknown band '{req.Band}'" });
+            if (!Enum.TryParse<HpsdrAntenna>(req.TxAnt, ignoreCase: true, out var txAnt))
+                return Results.BadRequest(new { error = $"unknown txAnt '{req.TxAnt}'" });
+            if (!Enum.TryParse<HpsdrAntenna>(req.RxAnt, ignoreCase: true, out var rxAnt))
+                return Results.BadRequest(new { error = $"unknown rxAnt '{req.RxAnt}'" });
+
+            var caps = BoardCapabilitiesTable.For(radio.EffectiveBoardKind, radio.EffectiveOrionMkIIVariant);
+            if (txAnt != HpsdrAntenna.Ant1 && !caps.HasTxAntennaRelays)
+                return Results.Conflict(new { error = $"board {radio.EffectiveBoardKind} has no TX antenna relays; only Ant1 is valid" });
+            if (rxAnt != HpsdrAntenna.Ant1 && !caps.HasRxAntennaRelays)
+                return Results.Conflict(new { error = $"board {radio.EffectiveBoardKind} has no RX antenna relays; only Ant1 is valid" });
+
+            // Save fires Changed → RadioService.RecomputePaAndPush, which reads
+            // the new per-band selection and pushes it server-authoritatively to
+            // the live client (P1 SetAntennaRx / P2 SetAntennas) — never via the
+            // frontend, so no clobber-on-connect. The wire layer defers a mid-key
+            // relay change to the unkey edge.
+            store.SetBand(req.Band, txAnt, rxAnt);
+
+            var bands = store.GetAll()
+                .Select(b => new AntennaBandDto(b.Band, b.TxAnt.ToString(), b.RxAnt.ToString()))
+                .ToArray();
+            return Results.Ok(new AntennaSettingsDto(caps.HasTxAntennaRelays, caps.HasRxAntennaRelays, bands));
+        });
+
         // Per-radio frequency calibration (issue #325). GET returns the
         // persisted correction factor + its ppm representation. POST
         // /calibrate runs the one-button auto-cal procedure (snapshot

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -1159,12 +1159,14 @@ public static class ZeusEndpoints
         {
             var caps = BoardCapabilitiesTable.For(radio.EffectiveBoardKind, radio.EffectiveOrionMkIIVariant);
             var bands = store.GetAll()
-                .Select(b => new AntennaBandDto(b.Band, b.TxAnt.ToString(), b.RxAnt.ToString()))
+                .Select(b => new AntennaBandDto(b.Band, b.TxAnt.ToString(), b.RxAnt.ToString(), b.RxAux.ToString()))
                 .ToArray();
             return Results.Ok(new AntennaSettingsDto(
                 HasTxAntennaRelays: caps.HasTxAntennaRelays,
                 HasRxAntennaRelays: caps.HasRxAntennaRelays,
-                Bands: bands));
+                Bands: bands,
+                AvailableRxAux: AvailableRxAux(caps.RxAuxInputs),
+                AlexRevision: caps.AlexRevision.ToString()));
         });
 
         // PUT one band's antenna selection. Capability-gated: 400 on a malformed
@@ -1182,24 +1184,34 @@ public static class ZeusEndpoints
                 return Results.BadRequest(new { error = $"unknown txAnt '{req.TxAnt}'" });
             if (!Enum.TryParse<HpsdrAntenna>(req.RxAnt, ignoreCase: true, out var rxAnt))
                 return Results.BadRequest(new { error = $"unknown rxAnt '{req.RxAnt}'" });
+            var rxAuxStr = string.IsNullOrWhiteSpace(req.RxAux) ? "None" : req.RxAux;
+            if (!Enum.TryParse<RxAuxInputSel>(rxAuxStr, ignoreCase: true, out var rxAux))
+                return Results.BadRequest(new { error = $"unknown rxAux '{req.RxAux}'" });
 
             var caps = BoardCapabilitiesTable.For(radio.EffectiveBoardKind, radio.EffectiveOrionMkIIVariant);
             if (txAnt != HpsdrAntenna.Ant1 && !caps.HasTxAntennaRelays)
                 return Results.Conflict(new { error = $"board {radio.EffectiveBoardKind} has no TX antenna relays; only Ant1 is valid" });
             if (rxAnt != HpsdrAntenna.Ant1 && !caps.HasRxAntennaRelays)
                 return Results.Conflict(new { error = $"board {radio.EffectiveBoardKind} has no RX antenna relays; only Ant1 is valid" });
+            // RX-aux 409: reject an aux input the connected board's Alex/filter
+            // board does not expose (HL2 has none). None is always accepted.
+            if (rxAux != RxAuxInputSel.None && !RxAuxSupported(rxAux, caps.RxAuxInputs))
+                return Results.Conflict(new { error = $"board {radio.EffectiveBoardKind} does not expose RX-aux input {rxAux}" });
 
             // Save fires Changed → RadioService.RecomputePaAndPush, which reads
             // the new per-band selection and pushes it server-authoritatively to
             // the live client (P1 SetAntennaRx / P2 SetAntennas) — never via the
             // frontend, so no clobber-on-connect. The wire layer defers a mid-key
-            // relay change to the unkey edge.
-            store.SetBand(req.Band, txAnt, rxAnt);
+            // relay change to the unkey edge; PS owns the K36/BYPASS relay while
+            // armed regardless of an aux=BYPASS pick (§3.4(2)).
+            store.SetBand(req.Band, txAnt, rxAnt, rxAux);
 
             var bands = store.GetAll()
-                .Select(b => new AntennaBandDto(b.Band, b.TxAnt.ToString(), b.RxAnt.ToString()))
+                .Select(b => new AntennaBandDto(b.Band, b.TxAnt.ToString(), b.RxAnt.ToString(), b.RxAux.ToString()))
                 .ToArray();
-            return Results.Ok(new AntennaSettingsDto(caps.HasTxAntennaRelays, caps.HasRxAntennaRelays, bands));
+            return Results.Ok(new AntennaSettingsDto(
+                caps.HasTxAntennaRelays, caps.HasRxAntennaRelays, bands,
+                AvailableRxAux(caps.RxAuxInputs), caps.AlexRevision.ToString()));
         });
 
         // Global (per-radio) audio front-end (external-ports plan, Phase 4).
@@ -1255,6 +1267,26 @@ public static class ZeusEndpoints
                 sel.MicBias,
                 sel.BalancedInput,
                 sel.LineInGain));
+        });
+
+        // HL2 user GPIO (external-ports plan, Phase 5). 4-bit user_dig_out →
+        // register 0x0a (wire 0x14) C3[3:0] MCP23008. GET returns the gate +
+        // persisted mask; always 200. The frontend renders the toggle group
+        // only when supported (HL2). PUT 409s on a non-HL2 board so the GPIO
+        // bits can never reach the wire on a board without them.
+        app.MapGet("/api/radio/hl2-gpio", (RadioService radio) =>
+        {
+            var caps = BoardCapabilitiesTable.For(radio.EffectiveBoardKind, radio.EffectiveOrionMkIIVariant);
+            return Results.Ok(new Hl2GpioDto(caps.HasHl2UserGpio, radio.GetHl2GpioMask() & 0x0F));
+        });
+        app.MapPut("/api/radio/hl2-gpio", (Hl2GpioSetRequest req, RadioService radio) =>
+        {
+            if (req is null) return Results.BadRequest(new { error = "body required" });
+            var caps = BoardCapabilitiesTable.For(radio.EffectiveBoardKind, radio.EffectiveOrionMkIIVariant);
+            if (!caps.HasHl2UserGpio)
+                return Results.Conflict(new { error = $"board {radio.EffectiveBoardKind} has no user GPIO" });
+            radio.SetHl2GpioMask((byte)(req.Bits & 0x0F));
+            return Results.Ok(new Hl2GpioDto(true, radio.GetHl2GpioMask() & 0x0F));
         });
 
         // Per-radio frequency calibration (issue #325). GET returns the
@@ -1586,6 +1618,28 @@ public static class ZeusEndpoints
         0x0A => HpsdrBoardKind.OrionMkII,
         0x14 => HpsdrBoardKind.HermesC10,
         _    => HpsdrBoardKind.Unknown,
+    };
+
+    // Map the board's RxAuxInputs capability flags to the aux-input strings the
+    // frontend renders (external-ports plan, Phase 5). Order is fixed for a
+    // stable UI: EXT1, EXT2, XVTR, BYPASS. Empty on a board with no aux inputs.
+    static string[] AvailableRxAux(RxAuxInputs caps)
+    {
+        var list = new List<string>(4);
+        if (caps.HasFlag(RxAuxInputs.Ext1))  list.Add(nameof(RxAuxInputSel.Ext1));
+        if (caps.HasFlag(RxAuxInputs.Ext2))  list.Add(nameof(RxAuxInputSel.Ext2));
+        if (caps.HasFlag(RxAuxInputs.Xvtr))  list.Add(nameof(RxAuxInputSel.Xvtr));
+        if (caps.HasFlag(RxAuxInputs.Bypass)) list.Add(nameof(RxAuxInputSel.Bypass));
+        return list.ToArray();
+    }
+
+    static bool RxAuxSupported(RxAuxInputSel sel, RxAuxInputs caps) => sel switch
+    {
+        RxAuxInputSel.Ext1   => caps.HasFlag(RxAuxInputs.Ext1),
+        RxAuxInputSel.Ext2   => caps.HasFlag(RxAuxInputs.Ext2),
+        RxAuxInputSel.Xvtr   => caps.HasFlag(RxAuxInputs.Xvtr),
+        RxAuxInputSel.Bypass => caps.HasFlag(RxAuxInputs.Bypass),
+        _                    => true, // None always allowed
     };
 
     static HpsdrBoardKind? ParseBoardKind(string? raw)

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -1301,6 +1301,28 @@ public static class ZeusEndpoints
             return Results.Ok(new Hl2GpioDto(true, radio.GetHl2GpioMask() & 0x0F));
         });
 
+        // Hardware-PTT-IN status + enable gate (external-ports plan §4). GET
+        // returns the live footswitch/mic-PTT level (per-protocol source: P1
+        // HardwarePttChanged, P2 UDP-1025 PttIn), the MOX-promotion enable gate,
+        // and the fixed 250 ms hang. Ungated — every board has a PTT-IN. The
+        // lamp is also pushed live via the PttStatus (0x33) hub frame; this
+        // endpoint is for first-paint hydration. PUT toggles the enable gate.
+        app.MapGet("/api/radio/ptt-status", (ExternalPttService ptt, PttSettingsStore store) =>
+            Results.Ok(new PttStatusDto(
+                Keyed: ptt.IsKeyed,
+                Enabled: store.Get(),
+                HangMs: ExternalPttService.HangMs)));
+
+        app.MapPut("/api/radio/ptt-status", (PttEnableSetRequest req, ExternalPttService ptt, PttSettingsStore store) =>
+        {
+            if (req is null) return Results.BadRequest(new { error = "body required" });
+            store.Set(req.Enabled);
+            return Results.Ok(new PttStatusDto(
+                Keyed: ptt.IsKeyed,
+                Enabled: store.Get(),
+                HangMs: ExternalPttService.HangMs));
+        });
+
         // Per-radio frequency calibration (issue #325). GET returns the
         // persisted correction factor + its ppm representation. POST
         // /calibrate runs the one-button auto-cal procedure (snapshot

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -1223,24 +1223,32 @@ public static class ZeusEndpoints
         app.MapGet("/api/radio/audio", (RadioService radio, AudioSettingsStore store) =>
         {
             var caps = BoardCapabilitiesTable.For(radio.EffectiveBoardKind, radio.EffectiveOrionMkIIVariant);
-            var sel = store.Get();
+            // Surface the RESOLVED (board-clamped) source so the picker hydrates
+            // from what the server is actually pushing, not a stale persisted
+            // jack the current board can't honour.
+            var resolved = RadioService.ClampAudioSource(store.Get(), caps);
             return Results.Ok(new AudioFrontEndDto(
                 HasOnboardCodec: caps.HasOnboardCodec,
                 HermesLite2MicFrontEnd: caps.HermesLite2MicFrontEnd,
-                LineIn: sel.LineIn,
-                MicBoost: sel.MicBoost,
-                MicBias: sel.MicBias,
-                BalancedInput: sel.BalancedInput,
-                LineInGain: sel.LineInGain));
+                HasRadioLineIn: caps.HasRadioLineIn,
+                HasBalancedXlr: caps.HasBalancedXlr,
+                HasMicBias: caps.HasMicBias,
+                Source: resolved.Source,
+                MicBoost: resolved.MicBoost,
+                MicBias: resolved.MicBias,
+                LineInGain: resolved.LineInGain));
         });
 
-        // PUT the whole global audio front-end. Capability-gated: 409 when the
+        // PUT the whole global TX-audio source. Capability-gated: 409 when the
         // connected board has no audio front-end at all (neither codec nor HL2
-        // mic), so a non-audio board can never be handed audio bytes. LineInGain
-        // is clamped 0..31. The save fires AudioSettingsStore.Changed ->
-        // RadioService.PushAudioFrontEnd, which gates per-board and pushes
-        // server-authoritatively to the live client (P1 SetAudioFrontEnd / P2
-        // TxSpecific 50/51) — never via the frontend, so no clobber-on-connect.
+        // mic), so a non-audio board can never be handed audio bytes. The
+        // requested Source is CLAMPED against the board's capabilities (an
+        // unsupported jack → Host) before persisting, so the store never holds a
+        // source the wire can't emit on this board. LineInGain is clamped 0..31.
+        // The save fires AudioSettingsStore.Changed -> RadioService.PushAudioFrontEnd,
+        // which re-clamps + pushes server-authoritatively to the live client
+        // (P1 SetAudioFrontEnd / P2 TxSpecific 50/51) and mirrors the resolved
+        // source into StateDto — never via the frontend, so no clobber-on-connect.
         app.MapPut("/api/radio/audio", (AudioFrontEndSetRequest req, RadioService radio, AudioSettingsStore store) =>
         {
             if (req is null)
@@ -1251,22 +1259,26 @@ public static class ZeusEndpoints
             if (!audioCapable)
                 return Results.Conflict(new { error = $"board {radio.EffectiveBoardKind} has no audio front-end" });
 
-            store.Set(new AudioFrontEndSelection(
-                LineIn: req.LineIn,
+            var requested = new AudioSourceSelection(
+                Source: req.Source,
                 MicBoost: req.MicBoost,
                 MicBias: req.MicBias,
-                BalancedInput: req.BalancedInput,
-                LineInGain: (byte)Math.Clamp(req.LineInGain, 0, 31)));
+                LineInGain: (byte)Math.Clamp(req.LineInGain, 0, 31));
+            // Clamp to the board before persisting — a board that lacks the
+            // requested jack stores Host, never the illegal source.
+            store.Set(RadioService.ClampAudioSource(requested, caps));
 
-            var sel = store.Get();
+            var resolved = RadioService.ClampAudioSource(store.Get(), caps);
             return Results.Ok(new AudioFrontEndDto(
                 caps.HasOnboardCodec,
                 caps.HermesLite2MicFrontEnd,
-                sel.LineIn,
-                sel.MicBoost,
-                sel.MicBias,
-                sel.BalancedInput,
-                sel.LineInGain));
+                caps.HasRadioLineIn,
+                caps.HasBalancedXlr,
+                caps.HasMicBias,
+                resolved.Source,
+                resolved.MicBoost,
+                resolved.MicBias,
+                resolved.LineInGain));
         });
 
         // HL2 user GPIO (external-ports plan, Phase 5). 4-bit user_dig_out →

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -338,6 +338,7 @@ public static class ZeusHost
         builder.Services.AddSingleton<LayoutStore>();
         builder.Services.AddSingleton<DspSettingsStore>();
         builder.Services.AddSingleton<PaSettingsStore>();
+        builder.Services.AddSingleton<AntennaSettingsStore>();
         builder.Services.AddSingleton<PreferredRadioStore>();
         builder.Services.AddSingleton<PsSettingsStore>();
         builder.Services.AddSingleton<FilterPresetStore>();

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -270,7 +270,17 @@ public static class ZeusHost
         // Clients are told to keep Connect disabled until phase=Ready.
         builder.Services.AddSingleton<WdspWisdomInitializer>();
         builder.Services.AddHostedService<WisdomBootstrapService>();
-        builder.Services.AddSingleton<DspPipelineService>();
+        builder.Services.AddSingleton<DspPipelineService>(sp => new DspPipelineService(
+            sp.GetRequiredService<RadioService>(),
+            sp.GetRequiredService<StreamingHub>(),
+            sp.GetServices<IRxAudioSink>(),
+            sp.GetRequiredService<ILoggerFactory>(),
+            sp.GetService<CwSidetoneSource>(),
+            // Lazy factory: TxAudioIngest depends on DspPipelineService, so it
+            // MUST be resolved on demand (after both singletons exist) to avoid a
+            // DI cycle. Used only by the Pass-B radio-mic routing (external-ports
+            // §3), first invoked on the first audio-front-end push.
+            () => sp.GetRequiredService<TxAudioIngest>()));
         builder.Services.AddHostedService(sp => sp.GetRequiredService<DspPipelineService>());
         // Per-radio frequency calibration (issue #325). Stateless coordinator —
         // owns no resources, just a SemaphoreSlim to prevent re-entry.

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -339,6 +339,7 @@ public static class ZeusHost
         builder.Services.AddSingleton<DspSettingsStore>();
         builder.Services.AddSingleton<PaSettingsStore>();
         builder.Services.AddSingleton<AntennaSettingsStore>();
+        builder.Services.AddSingleton<AudioSettingsStore>();
         builder.Services.AddSingleton<PreferredRadioStore>();
         builder.Services.AddSingleton<PsSettingsStore>();
         builder.Services.AddSingleton<FilterPresetStore>();

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -335,10 +335,13 @@ public static class ZeusHost
         // when PS is off or AutoAttenuate is off — no wire, no engine pokes.
         builder.Services.AddHostedService<PsAutoAttenuateService>();
         // Promote the radio's hardware-PTT echo (HL2 rear KEY tip, external
-        // PTT line) into a host MOX request — without it the gateware-driven
-        // CW carrier transmits while Zeus stays unkeyed (UI off, meters at
-        // idle cadence, FR-6 timeout disarmed).
-        builder.Services.AddHostedService<ExternalPttService>();
+        // PTT line, P2 footswitch) into a host MOX request — without it the
+        // gateware-driven CW carrier transmits while Zeus stays unkeyed (UI off,
+        // meters at idle cadence, FR-6 timeout disarmed). Registered as a
+        // singleton AND as the hosted service so the /api/radio/ptt-status
+        // endpoint can read the live lamp level off the same instance.
+        builder.Services.AddSingleton<ExternalPttService>();
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<ExternalPttService>());
 
         // QRZ.com XML client. HttpClient default timeout is 100 s — cap at 10 s so a
         // hung login surfaces quickly in the UI.
@@ -351,6 +354,9 @@ public static class ZeusHost
         builder.Services.AddSingleton<AntennaSettingsStore>();
         builder.Services.AddSingleton<AudioSettingsStore>();
         builder.Services.AddSingleton<Hl2GpioSettingsStore>();
+        // Hardware-PTT-IN enable gate (external-ports plan §4). Read by
+        // ExternalPttService on every footswitch edge; defaults ON.
+        builder.Services.AddSingleton<PttSettingsStore>();
         builder.Services.AddSingleton<PreferredRadioStore>();
         builder.Services.AddSingleton<PsSettingsStore>();
         builder.Services.AddSingleton<FilterPresetStore>();

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -340,6 +340,7 @@ public static class ZeusHost
         builder.Services.AddSingleton<PaSettingsStore>();
         builder.Services.AddSingleton<AntennaSettingsStore>();
         builder.Services.AddSingleton<AudioSettingsStore>();
+        builder.Services.AddSingleton<Hl2GpioSettingsStore>();
         builder.Services.AddSingleton<PreferredRadioStore>();
         builder.Services.AddSingleton<PsSettingsStore>();
         builder.Services.AddSingleton<FilterPresetStore>();

--- a/tests/Zeus.Contracts.Tests/PttStatusFrameTests.cs
+++ b/tests/Zeus.Contracts.Tests/PttStatusFrameTests.cs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// External-ports plan §4 — PTT-IN status lamp wire frame (0x33).
+
+using System.Buffers;
+using Zeus.Contracts;
+using Xunit;
+
+namespace Zeus.Contracts.Tests;
+
+public class PttStatusFrameTests
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void RoundTrip_PreservesKeyed(bool keyed)
+    {
+        var frame = new PttStatusFrame(Keyed: keyed);
+
+        var writer = new ArrayBufferWriter<byte>();
+        frame.Serialize(writer);
+
+        Assert.Equal(PttStatusFrame.ByteLength, writer.WrittenCount);
+        Assert.Equal(2, writer.WrittenCount);
+
+        var bytes = writer.WrittenSpan;
+        Assert.Equal((byte)MsgType.PttStatus, bytes[0]);
+        Assert.Equal(keyed ? (byte)1 : (byte)0, bytes[1]);
+
+        var decoded = PttStatusFrame.Deserialize(bytes);
+        Assert.Equal(keyed, decoded.Keyed);
+    }
+
+    [Fact]
+    public void MsgType_PttStatus_Is0x33()
+    {
+        // Next free control-plane slot above SpotList (0x32).
+        Assert.Equal((byte)0x33, (byte)MsgType.PttStatus);
+    }
+
+    [Fact]
+    public void Deserialize_RejectsWrongMsgType()
+    {
+        var bogus = new byte[PttStatusFrame.ByteLength];
+        bogus[0] = (byte)MsgType.MoxState; // 0x1C, not 0x33
+        Assert.Throws<InvalidDataException>(() => PttStatusFrame.Deserialize(bogus));
+    }
+
+    [Fact]
+    public void Deserialize_RejectsTruncated()
+    {
+        var buf = new byte[PttStatusFrame.ByteLength - 1];
+        buf[0] = (byte)MsgType.PttStatus;
+        Assert.Throws<InvalidDataException>(() => PttStatusFrame.Deserialize(buf));
+    }
+}

--- a/tests/Zeus.Protocol1.Tests/ControlFrameAudioEncoderTests.cs
+++ b/tests/Zeus.Protocol1.Tests/ControlFrameAudioEncoderTests.cs
@@ -223,4 +223,61 @@ public class ControlFrameAudioEncoderTests
         Assert.Equal(0x00, cc[1]); // C1 — no mic bits
         Assert.Equal(0x00, cc[2] & 0x1F); // C2 — no line_in_gain
     }
+
+    // ---- HL2 user GPIO (external-ports plan, Phase 5) — 0x14 frame C3[3:0] ----
+    // Verified Thetis-mi0bot networkproto1.c:774 `C3 = user_dig_out & 0x0F`.
+    // C3 is cc[3] of the WriteCcBytes output (C0=cc[0], C1=cc[1], ... C4=cc[4]).
+
+    [Fact]
+    public void Attenuator_Hl2_DefaultGpio_C3IsZero_ByteIdentical()
+    {
+        // Default UserDigOut=0 → C3 stays 0, byte-identical to today.
+        var cc = Frame(ControlFrame.CcRegister.Attenuator, Hl2());
+        Assert.Equal(0x00, cc[3]);
+    }
+
+    [Theory]
+    [InlineData(0x0, 0x0)]
+    [InlineData(0x1, 0x1)]
+    [InlineData(0x5, 0x5)]
+    [InlineData(0xF, 0xF)]
+    [InlineData(0xFF, 0x0F)] // high bits masked off — only the low nibble lands
+    public void Attenuator_Hl2_UserGpio_LandsInC3LowNibble(byte mask, byte expectedC3)
+    {
+        var cc = Frame(ControlFrame.CcRegister.Attenuator, Hl2() with { UserDigOut = mask });
+        Assert.Equal(expectedC3, cc[3]);
+        // GPIO never touches the high C3 bits.
+        Assert.Equal(0x00, cc[3] & 0xF0);
+    }
+
+    [Fact]
+    public void Attenuator_Hl2_UserGpio_PreservesPsAndAudioAndStepAtten()
+    {
+        // CRUX: GPIO write must NOT disturb puresignal_run (C2[6]), the audio
+        // bits, or the C4 step-attenuator. GPIO is on C3 (cc[3]); none of those
+        // co-tenants live in C3, so the read-modify-write keeps them intact.
+        var s = Hl2(ps: true) with
+        {
+            Atten = new HpsdrAtten(20),
+            MicTrs = true,
+            MicBias = true,
+            LineInGain = 0x15,
+            UserDigOut = 0x0A,
+        };
+        var cc = Frame(ControlFrame.CcRegister.Attenuator, s);
+        Assert.Equal(0x0A, cc[3]);            // GPIO in C3
+        Assert.Equal(1 << 6, cc[2] & (1 << 6)); // puresignal_run survives
+        Assert.Equal(0x15, cc[2] & 0x1F);     // line_in_gain survives
+        Assert.Equal(0x30, cc[1]);            // mic_trs + mic_bias survive
+        Assert.Equal(0x68, cc[4]);            // C4 step-att = 0x40|(60-20)
+    }
+
+    [Fact]
+    public void Attenuator_NonHl2_UserGpio_DoesNotTouchC3()
+    {
+        // A non-HL2 board with UserDigOut set must NOT emit it — the GPIO surface
+        // is HL2-only. C3 on the 0x14 frame stays 0 for Hermes.
+        var cc = Frame(ControlFrame.CcRegister.Attenuator, Hermes() with { UserDigOut = 0x0F });
+        Assert.Equal(0x00, cc[3]);
+    }
 }

--- a/tests/Zeus.Protocol1.Tests/ControlFrameAudioEncoderTests.cs
+++ b/tests/Zeus.Protocol1.Tests/ControlFrameAudioEncoderTests.cs
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Contracts;
+using Zeus.Protocol1.Discovery;
+
+namespace Zeus.Protocol1.Tests;
+
+/// <summary>
+/// GOLDEN-BYTE tests for the Protocol-1 audio front-end (external-ports plan,
+/// Phase 4). Two verified surfaces:
+///
+///   (a) Hermes-class codec boards — DriveFilter (0x12) frame:
+///         C2[0] = mic_boost, C2[1] = mic_linein
+///       (ramdor Thetis networkproto1.c:581; piHPSDR old_protocol.c:2154-2156).
+///
+///   (b) Hermes-Lite 2 — 0x0a / wire-0x14 frame, READ-MODIFY-WRITE:
+///         C1[4] = mic_trs, C1[5] = mic_bias, C2[4:0] = line_in_gain
+///       (ramdor Thetis networkproto1.c:597-599 case 11; same in mi0bot).
+///       The SAME frame carries C2[6] = puresignal_run and the C4 PGA /
+///       step-attenuator byte — those MUST survive any audio write.
+///
+/// The CRUX safety assertion: setting an HL2 audio field must NOT disturb
+/// puresignal_run (C2[6]) or the C4 step-attenuator byte. PureSignal lives next
+/// to audio on this frame; a clobber here would silently break PS.
+/// </summary>
+public class ControlFrameAudioEncoderTests
+{
+    private static ControlFrame.CcState Hermes() => new(
+        VfoAHz: 14_200_000,
+        Rate: HpsdrSampleRate.Rate48k,
+        PreampOn: false,
+        Atten: HpsdrAtten.Zero,
+        RxAntenna: HpsdrAntenna.Ant1,
+        Mox: false,
+        EnableHl2BandVolts: false,
+        Board: HpsdrBoardKind.Hermes,
+        DriveLevel: 0x80);
+
+    private static ControlFrame.CcState Hl2(bool ps = false) => new(
+        VfoAHz: 14_200_000,
+        Rate: HpsdrSampleRate.Rate48k,
+        PreampOn: false,
+        Atten: HpsdrAtten.Zero,
+        RxAntenna: HpsdrAntenna.Ant1,
+        Mox: false,
+        EnableHl2BandVolts: false,
+        Board: HpsdrBoardKind.HermesLite2,
+        PsEnabled: ps);
+
+    private static byte[] Frame(ControlFrame.CcRegister reg, in ControlFrame.CcState s)
+    {
+        Span<byte> cc = stackalloc byte[5];
+        ControlFrame.WriteCcBytes(cc, reg, s);
+        return cc.ToArray();
+    }
+
+    // ---- (a) Hermes-class codec — 0x12 frame mic_boost / mic_linein --------
+
+    [Fact]
+    public void DriveFilter_Hermes_DefaultAudio_IsByteIdentical()
+    {
+        // No audio fields set → C2/C3/C4 all zero (the historical 0x12 tail).
+        var cc = Frame(ControlFrame.CcRegister.DriveFilter, Hermes());
+        Assert.Equal(0x12, cc[0]);
+        Assert.Equal(0x80, cc[1]); // drive byte
+        Assert.Equal(0x00, cc[2]);
+        Assert.Equal(0x00, cc[3]);
+        Assert.Equal(0x00, cc[4]);
+    }
+
+    [Theory]
+    [InlineData(false, false, 0x00)]
+    [InlineData(true,  false, 0x01)] // mic_boost → C2[0]
+    [InlineData(false, true,  0x02)] // mic_linein → C2[1]
+    [InlineData(true,  true,  0x03)] // both
+    public void DriveFilter_Hermes_MicBits_LandInC2(bool boost, bool lineIn, byte expectedC2)
+    {
+        var cc = Frame(ControlFrame.CcRegister.DriveFilter,
+            Hermes() with { MicBoost = boost, MicLineIn = lineIn });
+        Assert.Equal(expectedC2, cc[2]);
+        // Drive byte untouched.
+        Assert.Equal(0x80, cc[1]);
+    }
+
+    [Fact]
+    public void DriveFilter_Hl2_DoesNotEmitCodecMicBits()
+    {
+        // HL2 has no stream codec — mic_boost/linein must NOT bleed onto the
+        // 0x12 frame (they ride the 0x14 frame instead). C2 stays at the HL2
+        // baseline (PA-enable only when MOX; here RX so 0).
+        var cc = Frame(ControlFrame.CcRegister.DriveFilter,
+            Hl2() with { MicBoost = true, MicLineIn = true });
+        Assert.Equal(0x00, cc[2]);
+    }
+
+    [Fact]
+    public void DriveFilter_Hl2_PaEnableBit_StillSetOnMox()
+    {
+        // Regression guard: the HL2 PA-enable C2[3] path must keep working with
+        // the new codec-board branch added alongside it.
+        var cc = Frame(ControlFrame.CcRegister.DriveFilter, Hl2() with { Mox = true });
+        Assert.Equal(0x08, cc[2] & 0x08);
+    }
+
+    // ---- (b) HL2 0x14 frame — mic_trs / mic_bias / line_in_gain ------------
+
+    [Fact]
+    public void Attenuator_Hl2_DefaultAudio_IsByteIdentical()
+    {
+        // No audio set: C1=0, C2=0 (no PS), C3=0, C4 = 0x40 | (60-0) = 0x7C.
+        // This is exactly today's WriteAttenuatorPayload output.
+        var cc = Frame(ControlFrame.CcRegister.Attenuator, Hl2());
+        Assert.Equal(0x14, cc[0]);
+        Assert.Equal(0x00, cc[1]);
+        Assert.Equal(0x00, cc[2]);
+        Assert.Equal(0x00, cc[3]);
+        Assert.Equal(0x7C, cc[4]); // 0x40 | 60
+    }
+
+    [Theory]
+    [InlineData(false, false, 0x00)]
+    [InlineData(true,  false, 0x10)] // mic_trs (balanced) → C1[4]
+    [InlineData(false, true,  0x20)] // mic_bias → C1[5]
+    [InlineData(true,  true,  0x30)] // both
+    public void Attenuator_Hl2_MicTrsBias_LandInC1(bool trs, bool bias, byte expectedC1)
+    {
+        var cc = Frame(ControlFrame.CcRegister.Attenuator,
+            Hl2() with { MicTrs = trs, MicBias = bias });
+        Assert.Equal(expectedC1, cc[1]); // C1 = cc[1]
+        // mic_ptt (C1[6]) is a PTT-IN concern, never written here.
+        Assert.Equal(0x00, cc[1] & (1 << 6));
+    }
+
+    [Theory]
+    [InlineData(0, 0x00)]
+    [InlineData(1, 0x01)]
+    [InlineData(31, 0x1F)]
+    [InlineData(63, 0x1F)] // clamps to the 5-bit field
+    public void Attenuator_Hl2_LineInGain_LandsInC2LowFiveBits(int gain, byte expectedLow)
+    {
+        var cc = Frame(ControlFrame.CcRegister.Attenuator,
+            Hl2() with { LineInGain = (byte)gain });
+        Assert.Equal(expectedLow, (byte)(cc[2] & 0x1F));
+        // No PS → C2[6] stays clear; line_in_gain must not bleed into it.
+        Assert.Equal(0x00, cc[2] & (1 << 6));
+    }
+
+    // ---- CRUX: audio writes must NOT disturb PureSignal or step-atten ------
+
+    [Fact]
+    public void Attenuator_Hl2_AudioSet_PreservesPureSignalRun()
+    {
+        // PS armed + ALL audio fields set. puresignal_run (C2[6]) MUST survive
+        // — this is the load-bearing safety property of the read-modify-write.
+        var s = Hl2(ps: true) with
+        {
+            MicTrs = true,
+            MicBias = true,
+            LineInGain = 0x15, // 10101
+        };
+        var cc = Frame(ControlFrame.CcRegister.Attenuator, s);
+
+        // PS bit survives.
+        Assert.Equal(1 << 6, cc[2] & (1 << 6));
+        // line_in_gain occupies the low 5 bits alongside it.
+        Assert.Equal(0x15, cc[2] & 0x1F);
+        // Full C2 = line_in_gain | PS bit = 0x15 | 0x40 = 0x55.
+        Assert.Equal(0x55, cc[2]);
+        // mic_trs + mic_bias in C1.
+        Assert.Equal(0x30, cc[1]);
+    }
+
+    [Fact]
+    public void Attenuator_Hl2_AudioSet_PreservesStepAttenuatorByte()
+    {
+        // C4 step-attenuator byte (PGA select 0x40 | 60-Db) must be untouched
+        // by an audio write. 20 dB atten → 0x40 | (60-20) = 0x68.
+        var s = Hl2(ps: true) with
+        {
+            Atten = new HpsdrAtten(20),
+            MicTrs = true,
+            MicBias = true,
+            LineInGain = 0x1F,
+        };
+        var cc = Frame(ControlFrame.CcRegister.Attenuator, s);
+        Assert.Equal(0x68, cc[4]);
+    }
+
+    [Fact]
+    public void Attenuator_Hl2_AudioSet_PreservesPsTxStepAtten_DuringMox()
+    {
+        // The HL2 PS auto-attenuate path (C4 = (31 - txAttn) | 0x40 during MOX)
+        // must also survive an audio write. txAttn = 5 → 0x40 | (31-5) = 0x5A.
+        var s = Hl2(ps: true) with
+        {
+            Mox = true,
+            Hl2TxAttnDb = 5,
+            MicTrs = true,
+            LineInGain = 0x10,
+        };
+        var cc = Frame(ControlFrame.CcRegister.Attenuator, s);
+        Assert.Equal(0x5A, cc[4]);
+        // PS + audio still intact in C2.
+        Assert.Equal(1 << 6, cc[2] & (1 << 6));
+        Assert.Equal(0x10, cc[2] & 0x1F);
+    }
+
+    [Fact]
+    public void Attenuator_NonHl2_AudioFields_DoNotTouchTheFrame()
+    {
+        // A Hermes board with the 0x14-frame audio fields set must NOT emit
+        // mic_trs/bias/line_in_gain there — that frame's mic surface is HL2-
+        // only. (Hermes mic bits ride the 0x12 frame instead.)
+        var s = Hermes() with { MicTrs = true, MicBias = true, LineInGain = 0x1F };
+        var cc = Frame(ControlFrame.CcRegister.Attenuator, s);
+        Assert.Equal(0x00, cc[1]); // C1 — no mic bits
+        Assert.Equal(0x00, cc[2] & 0x1F); // C2 — no line_in_gain
+    }
+}

--- a/tests/Zeus.Protocol1.Tests/ControlFrameTests.cs
+++ b/tests/Zeus.Protocol1.Tests/ControlFrameTests.cs
@@ -228,11 +228,26 @@ public class ControlFrameTests
     [Fact]
     public void ControlFrame_AntennaSelection_Ant2_SetsC3UpperBits()
     {
+        // RX-antenna C3[7:5] is emitted only on relay-capable boards. BaseState
+        // is HL2 (single jack → clamped to ANT1, see the clamp test below), so
+        // use a relay board (Hermes) to exercise the antenna-select math itself.
         Span<byte> cc = stackalloc byte[5];
-        var s = BaseState() with { RxAntenna = HpsdrAntenna.Ant2 };
+        var s = BaseState() with { RxAntenna = HpsdrAntenna.Ant2, Board = HpsdrBoardKind.Hermes };
         ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Config, s);
         // C3 [7:5] = antenna select; ANT2 = 0b001 → value 0x20.
         Assert.Equal(0b001 << 5, cc[3] & 0b11100000);
+    }
+
+    [Fact]
+    public void ControlFrame_AntennaSelection_Hl2_ClampedToAnt1()
+    {
+        // External-ports plan, Phase 2: HL2 has a single antenna jack — C3[5]
+        // forwards to the N2ADR antenna pad, not an ANT1/2/3 relay — so a
+        // non-ANT1 RX-antenna selection MUST be clamped to ANT1 at the wire.
+        Span<byte> cc = stackalloc byte[5];
+        var s = BaseState() with { RxAntenna = HpsdrAntenna.Ant3 }; // HL2
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Config, s);
+        Assert.Equal(0x00, cc[3] & 0b11100000);
     }
 
     [Fact]

--- a/tests/Zeus.Protocol1.Tests/ExternalPortGoldenTests.cs
+++ b/tests/Zeus.Protocol1.Tests/ExternalPortGoldenTests.cs
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Contracts;
+using Zeus.Protocol1.Discovery;
+
+namespace Zeus.Protocol1.Tests;
+
+/// <summary>
+/// GOLDEN-BYTE CHARACTERIZATION tests for the Protocol-1 Config (0x00) frame
+/// (external-ports plan, Phase 1). These lock the *current* emitted C0..C4
+/// bytes for the external-port-relevant fields — RX antenna (C3[7:5]), OC
+/// masks (C2[7:1]), duplex (C4[2]), and RX-count (C4[5:3]) — across boards
+/// and MOX states.
+///
+/// These are the safety net for the IExternalPortEncoder refactor: the
+/// encoder must reproduce these bytes EXACTLY. A single byte diff means the
+/// refactor changed behaviour. Do not "fix" these to match new output —
+/// they ARE the contract.
+///
+/// Co-tenancy is the point: C3 carries RxAntenna[7:5] alongside HL2 band-volts
+/// [3] and preamp [4]; C4 carries duplex[2] + RX-count[5:3] and must NEVER pick
+/// up TX-antenna bits for any supported board. The asserts below pin every
+/// co-tenant so the refactor can't clobber one while moving another.
+/// </summary>
+public class ExternalPortGoldenTests
+{
+    // A clean ANAN-class (codec board, RX relays) state at 14.2 MHz, RX.
+    private static ControlFrame.CcState HermesState() => new(
+        VfoAHz: 14_200_000,
+        Rate: HpsdrSampleRate.Rate48k,
+        PreampOn: false,
+        Atten: HpsdrAtten.Zero,
+        RxAntenna: HpsdrAntenna.Ant1,
+        Mox: false,
+        EnableHl2BandVolts: false,
+        Board: HpsdrBoardKind.Hermes);
+
+    private static ControlFrame.CcState Hl2State() => new(
+        VfoAHz: 14_200_000,
+        Rate: HpsdrSampleRate.Rate48k,
+        PreampOn: false,
+        Atten: HpsdrAtten.Zero,
+        RxAntenna: HpsdrAntenna.Ant1,
+        Mox: false,
+        EnableHl2BandVolts: false,
+        Board: HpsdrBoardKind.HermesLite2);
+
+    private static byte[] Config(in ControlFrame.CcState s)
+    {
+        Span<byte> cc = stackalloc byte[5];
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Config, s);
+        return cc.ToArray();
+    }
+
+    // ---- RX antenna C3[7:5] across Ant1/Ant2/Ant3 (Hermes / codec board) ----
+
+    [Theory]
+    [InlineData(HpsdrAntenna.Ant1, 0x00)] // 0 << 5
+    [InlineData(HpsdrAntenna.Ant2, 0x20)] // 1 << 5
+    [InlineData(HpsdrAntenna.Ant3, 0x40)] // 2 << 5
+    public void Config_C3_RxAntenna_Bits_AreLocked(HpsdrAntenna ant, byte expectedC3)
+    {
+        var cc = Config(HermesState() with { RxAntenna = ant });
+
+        // C0 = Config wire byte, RX (MOX off).
+        Assert.Equal(0x00, cc[0]);
+        // C1 = sample rate (48k = 0).
+        Assert.Equal(0x00, cc[1]);
+        // C2 = OC pins (none) << 1 = 0.
+        Assert.Equal(0x00, cc[2]);
+        // C3 = preamp off, band-volts off → just the RX-antenna bits.
+        Assert.Equal(expectedC3, cc[3]);
+        // C4 = duplex(1<<2) | rx-count(0).
+        Assert.Equal(0x04, cc[4]);
+    }
+
+    // RxAntenna co-tenants C3 with preamp[4] and (HL2-only) band-volts[3].
+    // Pin that the antenna shift never clobbers the neighbours.
+    [Fact]
+    public void Config_C3_RxAntenna_CoTenants_Preamp_AreLocked()
+    {
+        var cc = Config(HermesState() with
+        {
+            RxAntenna = HpsdrAntenna.Ant3,
+            PreampOn = true,
+        });
+
+        // preamp[4]=0x10 | antenna Ant3 [7:5]=0x40 → 0x50.
+        Assert.Equal(0x50, cc[3]);
+        Assert.Equal(0x04, cc[4]);
+    }
+
+    [Fact]
+    public void Config_Hl2_C3_RxAntenna_CoTenants_BandVolts_AreLocked()
+    {
+        // HL2 today emits C3[7:5] unconditionally (the value flows to the
+        // N2ADR antenna pad). Lock TODAY's bytes; the Phase-2 clamp will
+        // change this on purpose, with its own test.
+        var cc = Config(Hl2State() with
+        {
+            RxAntenna = HpsdrAntenna.Ant2,
+            EnableHl2BandVolts = true,
+            PreampOn = true,
+        });
+
+        // band-volts[3]=0x08 | preamp[4]=0x10 | Ant2 [7:5]=0x20 → 0x38.
+        Assert.Equal(0x38, cc[3]);
+        Assert.Equal(0x04, cc[4]);
+    }
+
+    // ---- OC mask C2[7:1] — MOX selects TX vs RX mask ----
+
+    [Fact]
+    public void Config_C2_OcMask_Rx_IsShiftedLeftOne()
+    {
+        // UserOcRxMask 0x05 (7-bit) → C2 = 0x05 << 1 = 0x0A (RX, MOX off).
+        var cc = Config(HermesState() with { UserOcRxMask = 0x05, UserOcTxMask = 0x42 });
+        Assert.Equal(0x0A, cc[2]);
+    }
+
+    [Fact]
+    public void Config_C2_OcMask_Tx_IsSelectedWhenMox()
+    {
+        // MOX on → TX mask 0x42 << 1 = 0x84.
+        var cc = Config(HermesState() with
+        {
+            Mox = true,
+            UserOcRxMask = 0x05,
+            UserOcTxMask = 0x42,
+        });
+        Assert.Equal(0x01, cc[0]);    // Config + MOX bit
+        Assert.Equal(0x84, cc[2]);
+    }
+
+    [Fact]
+    public void Config_Hl2_C2_OcMask_OrsN2adrAutoMask()
+    {
+        // HL2 with N2ADR ORs the auto-filter mask first, then the user mask.
+        // 14.2 MHz lives in the 20m N2ADR bucket; lock whatever that resolves
+        // to today combined with a user RX bit.
+        byte n2adr = N2adrBands.RxOcMask(14_200_000);
+        var cc = Config(Hl2State() with { HasN2adr = true, UserOcRxMask = 0x01 });
+        byte expectedC2 = (byte)(((n2adr | 0x01) & 0x7F) << 1);
+        Assert.Equal(expectedC2, cc[2]);
+    }
+
+    // ---- C4 duplex + RX-count, never TX antenna ----
+
+    [Theory]
+    [InlineData((byte)0, 0x04)] // duplex only
+    [InlineData((byte)1, 0x0C)] // duplex | (1<<3)
+    [InlineData((byte)3, 0x1C)] // duplex | (3<<3)
+    public void Config_C4_Duplex_And_RxCount_AreLocked(byte rxMinusOne, byte expectedC4)
+    {
+        var cc = Config(HermesState() with { NumReceiversMinusOne = rxMinusOne });
+        Assert.Equal(expectedC4, cc[4]);
+        // Bit 2 (duplex) always set.
+        Assert.Equal(0x04, cc[4] & 0x04);
+        // Bits [1:0] (TX antenna on legacy Alex) always clear — Zeus emits no
+        // TX-antenna relay bits on the P1 Config frame for any board.
+        Assert.Equal(0x00, cc[4] & 0x03);
+    }
+
+    [Fact]
+    public void Config_C4_NeverCarriesTxAntenna_EvenWithRxAntennaSet()
+    {
+        // Selecting a non-default RX antenna must not bleed into C4.
+        var cc = Config(HermesState() with
+        {
+            RxAntenna = HpsdrAntenna.Ant3,
+            NumReceiversMinusOne = 1,
+        });
+        Assert.Equal(0x0C, cc[4]);          // duplex | rx-count, no TX-ant bits
+        Assert.Equal(0x00, cc[4] & 0x03);
+    }
+}

--- a/tests/Zeus.Protocol1.Tests/ExternalPortGoldenTests.cs
+++ b/tests/Zeus.Protocol1.Tests/ExternalPortGoldenTests.cs
@@ -97,22 +97,43 @@ public class ExternalPortGoldenTests
         Assert.Equal(0x04, cc[4]);
     }
 
-    [Fact]
-    public void Config_Hl2_C3_RxAntenna_CoTenants_BandVolts_AreLocked()
+    // DIFFERENTIAL (external-ports plan, Phase 2): the HL2 RX-antenna wire
+    // clamp. HL2 has a single jack — C3[5] drives the N2ADR antenna pad, not an
+    // ANT1/2/3 relay — so an operator (or a stale per-band) ANT2/3 MUST be
+    // forced to ANT1 at the wire layer. The co-tenant band-volts[3] / preamp[4]
+    // bits are preserved; only the [7:5] antenna field is zeroed.
+    [Theory]
+    [InlineData(HpsdrAntenna.Ant1)]
+    [InlineData(HpsdrAntenna.Ant2)]
+    [InlineData(HpsdrAntenna.Ant3)]
+    public void Config_Hl2_C3_RxAntenna_IsClampedToAnt1(HpsdrAntenna requested)
     {
-        // HL2 today emits C3[7:5] unconditionally (the value flows to the
-        // N2ADR antenna pad). Lock TODAY's bytes; the Phase-2 clamp will
-        // change this on purpose, with its own test.
         var cc = Config(Hl2State() with
         {
-            RxAntenna = HpsdrAntenna.Ant2,
+            RxAntenna = requested,
             EnableHl2BandVolts = true,
             PreampOn = true,
         });
 
-        // band-volts[3]=0x08 | preamp[4]=0x10 | Ant2 [7:5]=0x20 → 0x38.
-        Assert.Equal(0x38, cc[3]);
+        // band-volts[3]=0x08 | preamp[4]=0x10 | antenna [7:5]=0 (clamped) → 0x18,
+        // regardless of which antenna was requested.
+        Assert.Equal(0x18, cc[3]);
         Assert.Equal(0x04, cc[4]);
+        // Antenna field is hard-zero on HL2.
+        Assert.Equal(0x00, cc[3] & 0xE0);
+    }
+
+    // A relay-capable P1 board (Hermes) reflects the selection in C3[7:5] — the
+    // other side of the differential. This is the same lock as
+    // Config_C3_RxAntenna_Bits_AreLocked but stated as the HL2-clamp contrast.
+    [Theory]
+    [InlineData(HpsdrAntenna.Ant1, 0x00)]
+    [InlineData(HpsdrAntenna.Ant2, 0x20)]
+    [InlineData(HpsdrAntenna.Ant3, 0x40)]
+    public void Config_RelayBoard_C3_RxAntenna_ReflectsSelection(HpsdrAntenna ant, byte expectedC3)
+    {
+        var cc = Config(HermesState() with { RxAntenna = ant });
+        Assert.Equal(expectedC3, cc[3]);
     }
 
     // ---- OC mask C2[7:1] — MOX selects TX vs RX mask ----

--- a/tests/Zeus.Protocol2.Tests/CmdTxAudioFrontEndTests.cs
+++ b/tests/Zeus.Protocol2.Tests/CmdTxAudioFrontEndTests.cs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.Protocol2.Tests;
+
+/// <summary>
+/// GOLDEN-BYTE tests for the Protocol-2 audio front-end (external-ports plan,
+/// Phase 4). The TxSpecific (CmdTx, port 1026) packet carries the mic/line-in
+/// front-end at byte 50 (mic_control flags) + byte 51 (line_in_gain) — verified
+/// against ramdor Thetis network.c:1234,1236 with the byte-50 bit layout from
+/// network.c:1226-1233:
+///   bit0 = line_in, bit1 = mic_boost, bit2 = mic_ptt_disabled,
+///   bit3 = mic_ptt_tip, bit4 = mic_bias_enable, bit5 = balanced(XLR) input.
+///
+/// DEFAULT-UNSENT: with the audio front-end at defaults, bytes 50/51 stay 0,
+/// so the CmdTx tail is byte-identical to the pre-feature all-zero memset.
+/// </summary>
+public class CmdTxAudioFrontEndTests
+{
+    [Fact]
+    public void CmdTx_DefaultAudio_Bytes50And51AreZero()
+    {
+        // No mic_control / line_in_gain args → both bytes stay at the memset 0,
+        // byte-identical to today's CmdTx.
+        var p = Protocol2Client.ComposeCmdTxBuffer(
+            seq: 1, sampleRateKhz: 48, txStepAttnDb: 0, paEnabled: true, psEnabled: false);
+        Assert.Equal((byte)0, p[50]);
+        Assert.Equal((byte)0, p[51]);
+    }
+
+    [Theory]
+    [InlineData(false, false, false, false, 0x00)]
+    [InlineData(true,  false, false, false, 0x01)] // line_in → bit0
+    [InlineData(false, true,  false, false, 0x02)] // mic_boost → bit1
+    [InlineData(false, false, true,  false, 0x10)] // mic_bias → bit4
+    [InlineData(false, false, false, true,  0x20)] // balanced/XLR → bit5
+    [InlineData(true,  true,  true,  true,  0x33)] // all four
+    public void CmdTx_MicControl_FlagLayoutIsLocked(
+        bool lineIn, bool micBoost, bool micBias, bool xlr, byte expected)
+    {
+        byte ctl = 0;
+        if (lineIn)   ctl |= Protocol2Client.MicControlLineIn;
+        if (micBoost) ctl |= Protocol2Client.MicControlMicBoost;
+        if (micBias)  ctl |= Protocol2Client.MicControlMicBias;
+        if (xlr)      ctl |= Protocol2Client.MicControlXlr;
+
+        Assert.Equal(expected, ctl);
+
+        var p = Protocol2Client.ComposeCmdTxBuffer(
+            seq: 1, sampleRateKhz: 48, txStepAttnDb: 0, paEnabled: true, psEnabled: false,
+            micControl: ctl, lineInGain: 0);
+        Assert.Equal(expected, p[50]);
+    }
+
+    [Theory]
+    [InlineData((byte)0)]
+    [InlineData((byte)15)]
+    [InlineData((byte)31)]
+    public void CmdTx_LineInGain_LandsInByte51(byte gain)
+    {
+        var p = Protocol2Client.ComposeCmdTxBuffer(
+            seq: 1, sampleRateKhz: 48, txStepAttnDb: 0, paEnabled: true, psEnabled: false,
+            micControl: 0, lineInGain: gain);
+        Assert.Equal(gain, p[51]);
+    }
+
+    [Fact]
+    public void CmdTx_AudioSet_DoesNotDisturbStepAttenuatorBytes()
+    {
+        // The audio bytes (50/51) are disjoint from the PS / PA-protection
+        // bytes (57/58/59). Setting audio must not move them.
+        var p = Protocol2Client.ComposeCmdTxBuffer(
+            seq: 1, sampleRateKhz: 48, txStepAttnDb: 17, paEnabled: true, psEnabled: true,
+            micControl: 0x33, lineInGain: 31);
+        // PS-on asymmetry preserved.
+        Assert.Equal((byte)0, p[57]);
+        Assert.Equal((byte)31, p[58]);
+        Assert.Equal((byte)17, p[59]);
+        // Audio landed.
+        Assert.Equal((byte)0x33, p[50]);
+        Assert.Equal((byte)31, p[51]);
+    }
+}

--- a/tests/Zeus.Protocol2.Tests/CmdTxAudioFrontEndTests.cs
+++ b/tests/Zeus.Protocol2.Tests/CmdTxAudioFrontEndTests.cs
@@ -86,4 +86,30 @@ public class CmdTxAudioFrontEndTests
         Assert.Equal((byte)0x33, p[50]);
         Assert.Equal((byte)31, p[51]);
     }
+
+    // ---- HOST BYTE-IDENTICAL: FULL-BUFFER differential golden (regression guard) ----
+
+    [Theory]
+    [InlineData(false, false)] // PS off
+    [InlineData(true,  true)]  // PS on + PA
+    public void CmdTx_HostSource_Is_FullBuffer_ByteIdentical_To_PreFeatureEmission(
+        bool psEnabled, bool paEnabled)
+    {
+        // The TX-audio source model resolves Host → micControl=0, lineInGain=0
+        // (ExternalPortEncoder, verified in the server-test purity suite). With
+        // those literal zeros the WHOLE 60-byte CmdTx buffer must be identical to
+        // the pre-feature emission (the overload that omits the audio args — i.e.
+        // the historical all-zero tail). Asserting the full buffer, not just 50/51,
+        // is the regression guard the plan requires.
+        var baseline = Protocol2Client.ComposeCmdTxBuffer(
+            seq: 7, sampleRateKhz: 48, txStepAttnDb: 19, paEnabled: paEnabled, psEnabled: psEnabled);
+        var hostResolved = Protocol2Client.ComposeCmdTxBuffer(
+            seq: 7, sampleRateKhz: 48, txStepAttnDb: 19, paEnabled: paEnabled, psEnabled: psEnabled,
+            micControl: 0, lineInGain: 0);
+
+        Assert.Equal(baseline.Length, hostResolved.Length);
+        Assert.Equal(60, hostResolved.Length);
+        Assert.True(baseline.AsSpan().SequenceEqual(hostResolved),
+            "Host source must reproduce the pre-feature CmdTx buffer byte-for-byte.");
+    }
 }

--- a/tests/Zeus.Protocol2.Tests/ExternalPortAlexGoldenTests.cs
+++ b/tests/Zeus.Protocol2.Tests/ExternalPortAlexGoldenTests.cs
@@ -94,6 +94,71 @@ public class ExternalPortAlexGoldenTests
         Assert.Equal(AlexCommon, alex0);
     }
 
+    // ---- TX-antenna select alex0[26:24] (external-ports plan, Phase 2) ----
+
+    // The fixture's BPF+LPF bits without ANY TX-antenna bit (AlexCommon minus
+    // ALEX_TX_ANTENNA_1). Antenna bits are added on top per selection.
+    private const uint AlexNoAnt = 0x00100002u;
+    private const uint TxAnt1 = 0x01000000u;
+    private const uint TxAnt2 = 0x02000000u;
+    private const uint TxAnt3 = 0x04000000u;
+
+    // DIFFERENTIAL: on a relay-capable board (G2 / OrionMkII) the selected TX
+    // antenna flips alex0[26:24], and nothing else moves. PS / TX-relay / BPF /
+    // LPF bits are untouched.
+    [Theory]
+    [InlineData(1, TxAnt1)]
+    [InlineData(2, TxAnt2)]
+    [InlineData(3, TxAnt3)]
+    public void Alex0_Idle_TxAntenna_FlipsBits_OnRelayBoard(int txAntWire, uint expectedAntBits)
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: false, psEnabled: false, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII,
+            txAntWire: txAntWire, hasTxAntennaRelays: true);
+        Assert.Equal(AlexNoAnt | expectedAntBits, alex0);
+    }
+
+    // During xmit the TX-relay rides alongside the selected antenna — confirm
+    // the two are disjoint and both present.
+    [Fact]
+    public void Alex0_Xmit_TxAntenna2_AddsAntAndTxRelay()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: true, psEnabled: false, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII,
+            txAntWire: 2, hasTxAntennaRelays: true);
+        Assert.Equal(AlexNoAnt | TxAnt2 | TxRelay, alex0);
+    }
+
+    // PS armed + ANT3 mid-xmit: the PS bit and the antenna bits coexist; PS is
+    // never disturbed by the antenna selection.
+    [Fact]
+    public void Alex0_Xmit_TxAntenna3_PsInternal_KeepsPsBit()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: true, psEnabled: true, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII,
+            txAntWire: 3, hasTxAntennaRelays: true);
+        Assert.Equal(AlexNoAnt | TxAnt3 | TxRelay | PsBit, alex0);
+    }
+
+    // GATE: a board/variant WITHOUT TX-antenna relays must NOT advertise ANT2/3
+    // even when ANT2/3 is requested — it stays on ANT1. This is the single-relay
+    // / non-relay safety, and it keeps the ANT1 default byte-identical.
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    public void Alex0_Idle_NonRelayBoard_StaysOnAnt1(int txAntWire)
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: false, psEnabled: false, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII,
+            txAntWire: txAntWire, hasTxAntennaRelays: false);
+        Assert.Equal(AlexCommon, alex0); // AlexCommon already carries ANT1
+    }
+
     // ---- alex1 (offset 1428) ----
 
     [Fact]

--- a/tests/Zeus.Protocol2.Tests/ExternalPortAlexGoldenTests.cs
+++ b/tests/Zeus.Protocol2.Tests/ExternalPortAlexGoldenTests.cs
@@ -103,20 +103,46 @@ public class ExternalPortAlexGoldenTests
     private const uint TxAnt2 = 0x02000000u;
     private const uint TxAnt3 = 0x04000000u;
 
-    // DIFFERENTIAL: on a relay-capable board (G2 / OrionMkII) the selected TX
-    // antenna flips alex0[26:24], and nothing else moves. PS / TX-relay / BPF /
-    // LPF bits are untouched.
+    // DIFFERENTIAL: alex0 ANT1/2/3 [26:24] is STATE-MULTIPLEXED (pihpsdr
+    // new_protocol.c:1331-1357, bench-confirmed on G2). DURING XMIT alex0 carries
+    // the TX antenna (+ TX_RELAY); nothing else moves.
     [Theory]
     [InlineData(1, TxAnt1)]
     [InlineData(2, TxAnt2)]
     [InlineData(3, TxAnt3)]
-    public void Alex0_Idle_TxAntenna_FlipsBits_OnRelayBoard(int txAntWire, uint expectedAntBits)
+    public void Alex0_Xmit_CarriesTxAntenna_OnRelayBoard(int txAntWire, uint expectedAntBits)
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: true, psEnabled: false, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII,
+            txAntWire: txAntWire, hasTxAntennaRelays: true);
+        Assert.Equal(AlexNoAnt | expectedAntBits | TxRelay, alex0);
+    }
+
+    // AT IDLE (RX) alex0 carries the RX antenna, NOT the TX antenna.
+    [Theory]
+    [InlineData(1, TxAnt1)]
+    [InlineData(2, TxAnt2)]
+    [InlineData(3, TxAnt3)]
+    public void Alex0_Idle_CarriesRxAntenna_OnRelayBoard(int rxAntWire, uint expectedAntBits)
     {
         uint alex0 = Protocol2Client.ComposeAlex0ForTest(
             rxFreqHz: Rx, moxOn: false, psEnabled: false, psExternal: false,
             board: HpsdrBoardKind.OrionMkII,
-            txAntWire: txAntWire, hasTxAntennaRelays: true);
+            txAntWire: 1, hasTxAntennaRelays: true, rxAntWire: rxAntWire);
         Assert.Equal(AlexNoAnt | expectedAntBits, alex0);
+    }
+
+    // THE BENCH BUG: at idle, changing the TX antenna must NOT move the RX path.
+    // TX=ANT2 with RX=ANT1 → alex0 stays on ANT1 (RX), so RX doesn't go away.
+    [Fact]
+    public void Alex0_Idle_TxAntennaChange_DoesNotMoveRx()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: false, psEnabled: false, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII,
+            txAntWire: 2, hasTxAntennaRelays: true, rxAntWire: 1);
+        Assert.Equal(AlexNoAnt | TxAnt1, alex0);
     }
 
     // During xmit the TX-relay rides alongside the selected antenna — confirm

--- a/tests/Zeus.Protocol2.Tests/ExternalPortAlexGoldenTests.cs
+++ b/tests/Zeus.Protocol2.Tests/ExternalPortAlexGoldenTests.cs
@@ -197,4 +197,136 @@ public class ExternalPortAlexGoldenTests
             board: HpsdrBoardKind.OrionMkII);
         Assert.Equal(AlexCommon | TxRelay | Gnd0nTx | PsBit, alex1);
     }
+
+    // ============================================================
+    //  Phase 5 — RX-aux inputs (EXT1/EXT2/XVTR/BYPASS) + RX_SELECT
+    // ============================================================
+    // Verified against pihpsdr src/alex.h:43-47, 122.
+    private const uint AuxXvtr   = 0x00000100u; // bit 8
+    private const uint AuxExt1   = 0x00000200u; // bit 9
+    private const uint AuxExt2   = 0x00000400u; // bit 10
+    private const uint AuxBypass = 0x00000800u; // bit 11  (== Bypass / K36)
+    private const uint RxSelect  = 0x00004000u; // bit 14  Saturn master RX-select
+
+    // selector ints used by ComposeRxAuxBits / ComposeAlex0ForTest:
+    // 0=None, 1=EXT1, 2=EXT2, 3=XVTR, 4=BYPASS.
+
+    [Fact]
+    public void RxAux_None_IsByteIdentical()
+    {
+        // The default-unsent invariant: aux=None leaves alex0 exactly as the
+        // pre-Phase-5 word.
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: false, psEnabled: false, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII,
+            rxAuxInput: 0, mkiiBpfRxSelect: true);
+        Assert.Equal(AlexCommon, alex0);
+    }
+
+    [Theory]
+    [InlineData(1, AuxExt1)]
+    [InlineData(2, AuxExt2)]
+    [InlineData(3, AuxXvtr)]
+    [InlineData(4, AuxBypass)]
+    public void RxAux_ClassicAlex_SetsJustTheJacketBit(int aux, uint expected)
+    {
+        // Classic-Alex board (no MkII master RX-select): the aux jacket bit
+        // alone, RX_SELECT clear.
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: false, psEnabled: false, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII,
+            rxAuxInput: aux, mkiiBpfRxSelect: false);
+        Assert.Equal(AlexCommon | expected, alex0);
+        Assert.Equal(0u, alex0 & RxSelect);
+    }
+
+    [Theory]
+    [InlineData(1, AuxExt1)]
+    [InlineData(2, AuxExt2)]
+    [InlineData(3, AuxXvtr)]
+    [InlineData(4, AuxBypass)]
+    public void RxAux_SaturnBpf_AlsoSetsRxSelectBit14(int aux, uint expected)
+    {
+        // MkII / Saturn BPF board: the aux jacket bit AND the master RX-select
+        // (bit 14) so the jack is actually gated onto the RX (alex.h:122).
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: false, psEnabled: false, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII,
+            rxAuxInput: aux, mkiiBpfRxSelect: true);
+        Assert.Equal(AlexCommon | expected | RxSelect, alex0);
+    }
+
+    // ============================================================
+    //  Phase 5 — PS-K36 ARBITRATION (the load-bearing firewall, §3.4(2))
+    // ============================================================
+
+    // THE GOLDEN TEST. Operator selects aux=BYPASS AND PureSignal is armed
+    // (external feedback) during xmit: the wire MUST still carry the PS coupler
+    // routing. Because both the operator BYPASS and PS-external use bit 11, and
+    // PS routing is OR'd AFTER the operator aux, the PS coupler bit is present
+    // regardless — the operator pick can NEVER strip it. Encoded order:
+    // operator-aux first, PS last.
+    [Fact]
+    public void PsK36_AuxBypassPlusPsExternal_StillEmitsPsCoupler()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: true, psEnabled: true, psExternal: true,
+            board: HpsdrBoardKind.OrionMkII,
+            rxAuxInput: 4 /* BYPASS */, mkiiBpfRxSelect: true);
+
+        // PS coupler bit (K36 / bit 11) present, PS bit present, TX-relay present.
+        Assert.Equal(AuxBypass, alex0 & AuxBypass); // K36 set (== PS coupler)
+        Assert.Equal(PsBit, alex0 & PsBit);          // PS feedback-coupler enable
+        Assert.Equal(TxRelay, alex0 & TxRelay);
+        // The exact word: base + RX_SELECT (operator aux on Saturn) + K36 + PS + TX-relay.
+        Assert.Equal(AlexCommon | RxSelect | AuxBypass | PsBit | TxRelay, alex0);
+    }
+
+    // Even with a CONFLICTING aux (operator picks EXT1, not BYPASS) while PS is
+    // armed-external during xmit, the PS coupler (BYPASS/K36) is still asserted —
+    // PS owns the relay. The operator's EXT1 bit also rides (it is a different
+    // bit, bit 9) but it cannot suppress the PS coupler.
+    [Fact]
+    public void PsK36_AuxExt1PlusPsExternal_PsCouplerNotStolen()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: true, psEnabled: true, psExternal: true,
+            board: HpsdrBoardKind.OrionMkII,
+            rxAuxInput: 1 /* EXT1 */, mkiiBpfRxSelect: true);
+        Assert.Equal(AuxBypass, alex0 & AuxBypass); // PS coupler still set
+        Assert.Equal(PsBit, alex0 & PsBit);
+    }
+
+    // PS armed but INTERNAL coupler + operator aux=BYPASS during xmit: the K36
+    // bit comes purely from the operator's aux here (PS internal doesn't set it),
+    // which is the operator's prerogative when PS isn't using the external path.
+    // The PS bit is still present (feedback-coupler enable). This documents that
+    // the arbitration is "PS external OWNS K36"; PS internal leaves the operator
+    // aux in control of bit 11.
+    [Fact]
+    public void PsK36_AuxBypassPlusPsInternal_OperatorBypassRides()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: true, psEnabled: true, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII,
+            rxAuxInput: 4 /* BYPASS */, mkiiBpfRxSelect: true);
+        Assert.Equal(AuxBypass, alex0 & AuxBypass);
+        Assert.Equal(PsBit, alex0 & PsBit);
+        Assert.Equal(AlexCommon | RxSelect | AuxBypass | PsBit | TxRelay, alex0);
+    }
+
+    // Idle (not keyed), PS armed external, operator aux=BYPASS: alex0 carries the
+    // operator BYPASS (RX-time aux routing) but NOT the PS coupler/PS bit (those
+    // ride alex0 only during xmit). Confirms the aux path works at RX and the PS
+    // xmit-only gating is intact.
+    [Fact]
+    public void PsK36_Idle_AuxBypass_PsExternal_NoPsBitButAuxRides()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: false, psEnabled: true, psExternal: true,
+            board: HpsdrBoardKind.OrionMkII,
+            rxAuxInput: 4 /* BYPASS */, mkiiBpfRxSelect: true);
+        Assert.Equal(AlexCommon | RxSelect | AuxBypass, alex0);
+        Assert.Equal(0u, alex0 & PsBit);
+    }
 }

--- a/tests/Zeus.Protocol2.Tests/ExternalPortAlexGoldenTests.cs
+++ b/tests/Zeus.Protocol2.Tests/ExternalPortAlexGoldenTests.cs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Xunit;
+using Zeus.Contracts;
+
+namespace Zeus.Protocol2.Tests;
+
+/// <summary>
+/// GOLDEN-BYTE CHARACTERIZATION tests for the Protocol-2 Alex words on the
+/// Saturn / 0x0A (OrionMkII) path (external-ports plan, Phase 1). These lock
+/// the *current* 32-bit alex0 (HighPriority offset 1432) and alex1 (offset
+/// 1428) values for the antenna + TX-relay + PureSignal bits across idle/xmit
+/// and PS-armed/not.
+///
+/// This is the safety net for the IExternalPortEncoder refactor: moving the
+/// TX/RX antenna bits behind the encoder must reproduce these words EXACTLY.
+/// A single differing bit means the refactor changed behaviour — and the
+/// PureSignal bits (AlexPsBit 0x00040000, AlexRxAntennaBypass 0x00000800) and
+/// TX_RELAY (0x08000000) are pinned here precisely so a refactor cannot
+/// disturb them.
+///
+/// Canonical fixture: 14.1 MHz on the OrionMkII (Saturn BPF) board.
+///   BPF (20/15m bucket)      = 0x00000002
+///   LPF (30/20m bucket)      = 0x00100000
+///   TX antenna 1 (hardcoded) = 0x01000000
+///   => alexCommon            = 0x01100002
+/// </summary>
+public class ExternalPortAlexGoldenTests
+{
+    private const uint Rx = 14_100_000u;
+
+    // The composed base word (no TX-relay, no PS) for the canonical fixture.
+    private const uint AlexCommon = 0x01100002u;
+
+    // Live-path OR constants (must match Protocol2Client private consts).
+    private const uint TxRelay = 0x08000000u;
+    private const uint Gnd0nTx = 0x00000100u; // alex1-only RX-ground while keyed
+    private const uint PsBit = 0x00040000u;
+    private const uint Bypass = 0x00000800u;
+
+    // ---- alex0 (offset 1432) ----
+
+    [Fact]
+    public void Alex0_Idle_NoPs_IsAlexCommon()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: false, psEnabled: false, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII);
+        Assert.Equal(AlexCommon, alex0);
+    }
+
+    [Fact]
+    public void Alex0_Xmit_NoPs_AddsTxRelay()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: true, psEnabled: false, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII);
+        Assert.Equal(AlexCommon | TxRelay, alex0);
+    }
+
+    [Fact]
+    public void Alex0_Xmit_PsInternal_AddsTxRelayAndPsBit()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: true, psEnabled: true, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII);
+        Assert.Equal(AlexCommon | TxRelay | PsBit, alex0);
+    }
+
+    [Fact]
+    public void Alex0_Xmit_PsExternal_AddsBypassBit()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: true, psEnabled: true, psExternal: true,
+            board: HpsdrBoardKind.OrionMkII);
+        Assert.Equal(AlexCommon | TxRelay | PsBit | Bypass, alex0);
+    }
+
+    [Fact]
+    public void Alex0_Idle_PsArmed_DoesNotAddTxRelayOrPsOrBypass()
+    {
+        // PS armed but not keyed: alex0 stays at the base word (PS rides alex1
+        // always, alex0 only during xmit).
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: false, psEnabled: true, psExternal: true,
+            board: HpsdrBoardKind.OrionMkII);
+        Assert.Equal(AlexCommon, alex0);
+    }
+
+    // ---- alex1 (offset 1428) ----
+
+    [Fact]
+    public void Alex1_Idle_NoPs_IsAlexCommon()
+    {
+        uint alex1 = Protocol2Client.ComposeAlex1ForTest(
+            rxFreqHz: Rx, moxOn: false, psEnabled: false,
+            board: HpsdrBoardKind.OrionMkII);
+        Assert.Equal(AlexCommon, alex1);
+    }
+
+    [Fact]
+    public void Alex1_Xmit_NoPs_AddsTxRelayAndGndOnTx()
+    {
+        uint alex1 = Protocol2Client.ComposeAlex1ForTest(
+            rxFreqHz: Rx, moxOn: true, psEnabled: false,
+            board: HpsdrBoardKind.OrionMkII);
+        Assert.Equal(AlexCommon | TxRelay | Gnd0nTx, alex1);
+    }
+
+    [Fact]
+    public void Alex1_Idle_PsArmed_AddsPsBitAlways()
+    {
+        // PS rides alex1 whenever armed, regardless of MOX.
+        uint alex1 = Protocol2Client.ComposeAlex1ForTest(
+            rxFreqHz: Rx, moxOn: false, psEnabled: true,
+            board: HpsdrBoardKind.OrionMkII);
+        Assert.Equal(AlexCommon | PsBit, alex1);
+    }
+
+    [Fact]
+    public void Alex1_Xmit_PsArmed_AddsTxRelayGndAndPs()
+    {
+        uint alex1 = Protocol2Client.ComposeAlex1ForTest(
+            rxFreqHz: Rx, moxOn: true, psEnabled: true,
+            board: HpsdrBoardKind.OrionMkII);
+        Assert.Equal(AlexCommon | TxRelay | Gnd0nTx | PsBit, alex1);
+    }
+}

--- a/tests/Zeus.Server.Tests/AntennaEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/AntennaEndpointTests.cs
@@ -114,6 +114,60 @@ public class AntennaEndpointTests : IClassFixture<AntennaEndpointTests.Factory>
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
     }
 
+    // ---- RX-aux + HL2 GPIO (external-ports plan, Phase 5) ----
+
+    [Fact]
+    public async Task AuxBoard_Exposes_AvailableRxAux_And_Accepts_Bypass()
+    {
+        SetBoard(HpsdrBoardKind.OrionMkII); // RxAuxInputs.All
+        using var client = _factory.CreateClient();
+
+        var resp = await client.PutAsJsonAsync("/api/radio/antenna",
+            new { band = "20m", txAnt = "Ant1", rxAnt = "Ant1", rxAux = "Bypass" });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var dto = await resp.Content.ReadFromJsonAsync<AntennaSettingsDto>();
+        Assert.NotNull(dto);
+        Assert.Contains("Bypass", dto!.AvailableRxAux!);
+        Assert.Equal("Modern", dto.AlexRevision);
+        Assert.Equal("Bypass", dto.Bands.First(b => b.Band == "20m").RxAux);
+    }
+
+    [Fact]
+    public async Task Hl2_Rejects_RxAux_With_409()
+    {
+        SetBoard(HpsdrBoardKind.HermesLite2); // RxAuxInputs.None
+        using var client = _factory.CreateClient();
+
+        var resp = await client.PutAsJsonAsync("/api/radio/antenna",
+            new { band = "20m", txAnt = "Ant1", rxAnt = "Ant1", rxAux = "Ext1" });
+        Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+
+        // The GET advertises NO aux inputs on HL2.
+        var got = await client.GetFromJsonAsync<AntennaSettingsDto>("/api/radio/antenna");
+        Assert.Empty(got!.AvailableRxAux!);
+    }
+
+    [Fact]
+    public async Task Hl2_Gpio_Roundtrips_And_NonHl2_Is_409()
+    {
+        SetBoard(HpsdrBoardKind.HermesLite2);
+        using var client = _factory.CreateClient();
+
+        var put = await client.PutAsJsonAsync("/api/radio/hl2-gpio", new { bits = 0x0A });
+        Assert.Equal(HttpStatusCode.OK, put.StatusCode);
+        var dto = await put.Content.ReadFromJsonAsync<Hl2GpioDto>();
+        Assert.True(dto!.Supported);
+        Assert.Equal(0x0A, dto.Bits);
+
+        // Non-HL2 board: GPIO is gated off (409 on PUT, unsupported on GET).
+        SetBoard(HpsdrBoardKind.OrionMkII);
+        var put2 = await client.PutAsJsonAsync("/api/radio/hl2-gpio", new { bits = 0x01 });
+        Assert.Equal(HttpStatusCode.Conflict, put2.StatusCode);
+        var got = await client.GetFromJsonAsync<Hl2GpioDto>("/api/radio/hl2-gpio");
+        Assert.False(got!.Supported);
+    }
+
     public sealed class Factory : WebApplicationFactory<Program>
     {
         protected override void ConfigureWebHost(IWebHostBuilder builder)

--- a/tests/Zeus.Server.Tests/AntennaEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/AntennaEndpointTests.cs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// External-ports plan, Phase 2 — capability-gated /api/radio/antenna.
+
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Capability-gating + persistence of the per-band antenna endpoint. The
+/// connected board is simulated by writing the PreferredRadioStore override so
+/// RadioService.EffectiveBoardKind resolves without a live radio.
+/// </summary>
+public class AntennaEndpointTests : IClassFixture<AntennaEndpointTests.Factory>
+{
+    private readonly Factory _factory;
+    public AntennaEndpointTests(Factory factory) => _factory = factory;
+
+    private void SetBoard(HpsdrBoardKind board)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var prefs = scope.ServiceProvider.GetRequiredService<PreferredRadioStore>();
+        prefs.Set(board, overrideDetection: true);
+    }
+
+    [Fact]
+    public async Task RelayBoard_Accepts_Ant2_And_Persists()
+    {
+        SetBoard(HpsdrBoardKind.OrionMkII); // has TX + RX antenna relays
+        using var client = _factory.CreateClient();
+
+        var resp = await client.PutAsJsonAsync("/api/radio/antenna",
+            new { band = "20m", txAnt = "Ant2", rxAnt = "Ant3" });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var dto = await resp.Content.ReadFromJsonAsync<AntennaSettingsDto>();
+        Assert.NotNull(dto);
+        Assert.True(dto!.HasTxAntennaRelays);
+        Assert.True(dto.HasRxAntennaRelays);
+        var b20 = dto.Bands.First(b => b.Band == "20m");
+        Assert.Equal("Ant2", b20.TxAnt);
+        Assert.Equal("Ant3", b20.RxAnt);
+
+        // GET reflects the persisted selection.
+        var got = await client.GetFromJsonAsync<AntennaSettingsDto>("/api/radio/antenna");
+        Assert.Equal("Ant2", got!.Bands.First(b => b.Band == "20m").TxAnt);
+    }
+
+    [Fact]
+    public async Task NonRelayBoard_Rejects_TxAnt2_With_409()
+    {
+        SetBoard(HpsdrBoardKind.HermesLite2); // single jack: no TX/RX relays
+        using var client = _factory.CreateClient();
+
+        var resp = await client.PutAsJsonAsync("/api/radio/antenna",
+            new { band = "20m", txAnt = "Ant2", rxAnt = "Ant1" });
+        Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task NonRelayBoard_Rejects_RxAnt3_With_409()
+    {
+        SetBoard(HpsdrBoardKind.HermesLite2);
+        using var client = _factory.CreateClient();
+
+        var resp = await client.PutAsJsonAsync("/api/radio/antenna",
+            new { band = "20m", txAnt = "Ant1", rxAnt = "Ant3" });
+        Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task NonRelayBoard_Accepts_Ant1()
+    {
+        SetBoard(HpsdrBoardKind.HermesLite2);
+        using var client = _factory.CreateClient();
+
+        // ANT1 is the hardwired default on every board — always valid.
+        var resp = await client.PutAsJsonAsync("/api/radio/antenna",
+            new { band = "20m", txAnt = "Ant1", rxAnt = "Ant1" });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Unknown_Band_Is_400()
+    {
+        SetBoard(HpsdrBoardKind.OrionMkII);
+        using var client = _factory.CreateClient();
+
+        var resp = await client.PutAsJsonAsync("/api/radio/antenna",
+            new { band = "not-a-band", txAnt = "Ant1", rxAnt = "Ant1" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Unparseable_Antenna_Is_400()
+    {
+        SetBoard(HpsdrBoardKind.OrionMkII);
+        using var client = _factory.CreateClient();
+
+        var resp = await client.PutAsJsonAsync("/api/radio/antenna",
+            new { band = "20m", txAnt = "Ant9", rxAnt = "Ant1" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    public sealed class Factory : WebApplicationFactory<Program>
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Test");
+            // Only the HTTP handler is under test; keep the hosted pipeline out.
+            builder.ConfigureServices(services => services.RemoveAll<IHostedService>());
+        }
+    }
+}

--- a/tests/Zeus.Server.Tests/AntennaSettingsStoreTests.cs
+++ b/tests/Zeus.Server.Tests/AntennaSettingsStoreTests.cs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// External-ports plan, Phase 2 — per-band antenna persistence round-trip.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Protocol1;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class AntennaSettingsStoreTests : IDisposable
+{
+    private readonly string _dbPath;
+
+    public AntennaSettingsStoreTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"zeus-prefs-antenna-{Guid.NewGuid():N}.db");
+    }
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+    }
+
+    private AntennaSettingsStore NewStore() =>
+        new AntennaSettingsStore(NullLogger<AntennaSettingsStore>.Instance, _dbPath);
+
+    [Fact]
+    public void Unset_Band_Defaults_To_Ant1()
+    {
+        using var store = NewStore();
+        var sel = store.GetBand("20m");
+        Assert.Equal(HpsdrAntenna.Ant1, sel.TxAnt);
+        Assert.Equal(HpsdrAntenna.Ant1, sel.RxAnt);
+    }
+
+    [Fact]
+    public void SetBand_RoundTrips_PerBand()
+    {
+        using (var store = NewStore())
+        {
+            store.SetBand("20m", HpsdrAntenna.Ant2, HpsdrAntenna.Ant3);
+            store.SetBand("40m", HpsdrAntenna.Ant3, HpsdrAntenna.Ant1);
+        }
+
+        // Reopen to prove it survives a backend restart (the whole point of
+        // server-authoritative persistence).
+        using var reopened = NewStore();
+        var b20 = reopened.GetBand("20m");
+        Assert.Equal(HpsdrAntenna.Ant2, b20.TxAnt);
+        Assert.Equal(HpsdrAntenna.Ant3, b20.RxAnt);
+
+        var b40 = reopened.GetBand("40m");
+        Assert.Equal(HpsdrAntenna.Ant3, b40.TxAnt);
+        Assert.Equal(HpsdrAntenna.Ant1, b40.RxAnt);
+
+        // An untouched band is still ANT1 — selections are per-band, not global.
+        var b15 = reopened.GetBand("15m");
+        Assert.Equal(HpsdrAntenna.Ant1, b15.TxAnt);
+        Assert.Equal(HpsdrAntenna.Ant1, b15.RxAnt);
+    }
+
+    [Fact]
+    public void SetBand_Upsert_Updates_Existing()
+    {
+        using var store = NewStore();
+        store.SetBand("20m", HpsdrAntenna.Ant2, HpsdrAntenna.Ant2);
+        store.SetBand("20m", HpsdrAntenna.Ant3, HpsdrAntenna.Ant1);
+
+        var sel = store.GetBand("20m");
+        Assert.Equal(HpsdrAntenna.Ant3, sel.TxAnt);
+        Assert.Equal(HpsdrAntenna.Ant1, sel.RxAnt);
+    }
+
+    [Fact]
+    public void Changed_Fires_On_Save()
+    {
+        using var store = NewStore();
+        int fired = 0;
+        store.Changed += () => fired++;
+        store.SetBand("20m", HpsdrAntenna.Ant2, HpsdrAntenna.Ant1);
+        Assert.Equal(1, fired);
+    }
+
+    [Fact]
+    public void GetAll_Returns_Every_HfBand()
+    {
+        using var store = NewStore();
+        store.SetBand("20m", HpsdrAntenna.Ant2, HpsdrAntenna.Ant3);
+        var all = store.GetAll();
+        Assert.All(BandUtils.HfBands, b => Assert.Contains(all, x => x.Band == b));
+        var b20 = all.First(x => x.Band == "20m");
+        Assert.Equal(HpsdrAntenna.Ant2, b20.TxAnt);
+        Assert.Equal(HpsdrAntenna.Ant3, b20.RxAnt);
+    }
+}

--- a/tests/Zeus.Server.Tests/AntennaSettingsStoreTests.cs
+++ b/tests/Zeus.Server.Tests/AntennaSettingsStoreTests.cs
@@ -39,6 +39,22 @@ public class AntennaSettingsStoreTests : IDisposable
     }
 
     [Fact]
+    public void SetBand_RxAux_RoundTrips_PerBand()
+    {
+        // Phase 5: the RX-aux selection persists per band alongside the antennas.
+        using (var store = NewStore())
+        {
+            store.SetBand("20m", HpsdrAntenna.Ant1, HpsdrAntenna.Ant1, RxAuxInputSel.Bypass);
+            store.SetBand("40m", HpsdrAntenna.Ant2, HpsdrAntenna.Ant1, RxAuxInputSel.Ext1);
+        }
+        using var reopened = NewStore();
+        Assert.Equal(RxAuxInputSel.Bypass, reopened.GetBand("20m").RxAux);
+        var b40 = reopened.GetBand("40m");
+        Assert.Equal(HpsdrAntenna.Ant2, b40.TxAnt);
+        Assert.Equal(RxAuxInputSel.Ext1, b40.RxAux);
+    }
+
+    [Fact]
     public void SetBand_RoundTrips_PerBand()
     {
         using (var store = NewStore())
@@ -62,6 +78,9 @@ public class AntennaSettingsStoreTests : IDisposable
         var b15 = reopened.GetBand("15m");
         Assert.Equal(HpsdrAntenna.Ant1, b15.TxAnt);
         Assert.Equal(HpsdrAntenna.Ant1, b15.RxAnt);
+        // RX-aux defaults to None for pre-Phase-5 / untouched rows.
+        Assert.Equal(RxAuxInputSel.None, b15.RxAux);
+        Assert.Equal(RxAuxInputSel.None, b20.RxAux); // 3-arg SetBand → None
     }
 
     [Fact]

--- a/tests/Zeus.Server.Tests/AudioEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/AudioEndpointTests.cs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// External-ports plan, Phase 4 — capability-gated /api/radio/audio.
+
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Capability-gating + persistence of the global audio front-end endpoint. The
+/// connected board is simulated via the PreferredRadioStore override so
+/// RadioService.EffectiveBoardKind resolves without a live radio.
+/// </summary>
+public class AudioEndpointTests : IClassFixture<AudioEndpointTests.Factory>
+{
+    private readonly Factory _factory;
+    public AudioEndpointTests(Factory factory) => _factory = factory;
+
+    private void SetBoard(HpsdrBoardKind board)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var prefs = scope.ServiceProvider.GetRequiredService<PreferredRadioStore>();
+        prefs.Set(board, overrideDetection: true);
+    }
+
+    [Fact]
+    public async Task CodecBoard_GET_ReportsCodecGate()
+    {
+        SetBoard(HpsdrBoardKind.OrionMkII); // has onboard codec
+        using var client = _factory.CreateClient();
+
+        var dto = await client.GetFromJsonAsync<AudioFrontEndDto>("/api/radio/audio");
+        Assert.NotNull(dto);
+        Assert.True(dto!.HasOnboardCodec);
+        Assert.False(dto.HermesLite2MicFrontEnd);
+    }
+
+    [Fact]
+    public async Task Hl2_GET_ReportsMicFrontEndGate()
+    {
+        SetBoard(HpsdrBoardKind.HermesLite2);
+        using var client = _factory.CreateClient();
+
+        var dto = await client.GetFromJsonAsync<AudioFrontEndDto>("/api/radio/audio");
+        Assert.NotNull(dto);
+        Assert.False(dto!.HasOnboardCodec);     // HL2 has no stream codec
+        Assert.True(dto.HermesLite2MicFrontEnd); // but DOES have the mic front-end
+    }
+
+    [Fact]
+    public async Task CodecBoard_PUT_PersistsAndRoundTrips()
+    {
+        SetBoard(HpsdrBoardKind.OrionMkII);
+        using var client = _factory.CreateClient();
+
+        var resp = await client.PutAsJsonAsync("/api/radio/audio",
+            new { lineIn = true, micBoost = true, micBias = false, balancedInput = true, lineInGain = 18 });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var dto = await resp.Content.ReadFromJsonAsync<AudioFrontEndDto>();
+        Assert.NotNull(dto);
+        Assert.True(dto!.LineIn);
+        Assert.True(dto.MicBoost);
+        Assert.False(dto.MicBias);
+        Assert.True(dto.BalancedInput);
+        Assert.Equal(18, dto.LineInGain);
+
+        var got = await client.GetFromJsonAsync<AudioFrontEndDto>("/api/radio/audio");
+        Assert.Equal(18, got!.LineInGain);
+        Assert.True(got.LineIn);
+    }
+
+    [Fact]
+    public async Task LineInGain_ClampedTo31()
+    {
+        SetBoard(HpsdrBoardKind.HermesLite2);
+        using var client = _factory.CreateClient();
+
+        var resp = await client.PutAsJsonAsync("/api/radio/audio",
+            new { lineIn = false, micBoost = false, micBias = false, balancedInput = false, lineInGain = 200 });
+        var dto = await resp.Content.ReadFromJsonAsync<AudioFrontEndDto>();
+        Assert.Equal(31, dto!.LineInGain);
+    }
+
+    [Fact]
+    public async Task NonAudioBoard_PUT_Is409()
+    {
+        // A board with neither codec nor HL2 mic front-end is rejected — the
+        // wire never gets handed audio bytes. (UnknownDefaults has both false.)
+        SetBoard(HpsdrBoardKind.Unknown);
+        using var client = _factory.CreateClient();
+
+        var resp = await client.PutAsJsonAsync("/api/radio/audio",
+            new { lineIn = true, micBoost = false, micBias = false, balancedInput = false, lineInGain = 0 });
+        Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+    }
+
+    public sealed class Factory : WebApplicationFactory<Program>
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Test");
+            builder.ConfigureServices(services => services.RemoveAll<IHostedService>());
+        }
+    }
+}

--- a/tests/Zeus.Server.Tests/AudioEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/AudioEndpointTests.cs
@@ -8,6 +8,8 @@
 
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
@@ -28,6 +30,20 @@ public class AudioEndpointTests : IClassFixture<AudioEndpointTests.Factory>
     private readonly Factory _factory;
     public AudioEndpointTests(Factory factory) => _factory = factory;
 
+    // The server serializes enums as their member names (JsonStringEnumConverter
+    // is registered globally in ZeusHost). The default test deserializer can't
+    // read a string back into TxAudioSource, so mirror the server's converter.
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    private async Task<AudioFrontEndDto?> GetAudioAsync(HttpClient client) =>
+        await client.GetFromJsonAsync<AudioFrontEndDto>("/api/radio/audio", Json);
+
+    private static async Task<AudioFrontEndDto?> ReadAudioAsync(HttpResponseMessage resp) =>
+        await resp.Content.ReadFromJsonAsync<AudioFrontEndDto>(Json);
+
     private void SetBoard(HpsdrBoardKind board)
     {
         using var scope = _factory.Services.CreateScope();
@@ -41,7 +57,7 @@ public class AudioEndpointTests : IClassFixture<AudioEndpointTests.Factory>
         SetBoard(HpsdrBoardKind.OrionMkII); // has onboard codec
         using var client = _factory.CreateClient();
 
-        var dto = await client.GetFromJsonAsync<AudioFrontEndDto>("/api/radio/audio");
+        var dto = await GetAudioAsync(client);
         Assert.NotNull(dto);
         Assert.True(dto!.HasOnboardCodec);
         Assert.False(dto.HermesLite2MicFrontEnd);
@@ -53,44 +69,55 @@ public class AudioEndpointTests : IClassFixture<AudioEndpointTests.Factory>
         SetBoard(HpsdrBoardKind.HermesLite2);
         using var client = _factory.CreateClient();
 
-        var dto = await client.GetFromJsonAsync<AudioFrontEndDto>("/api/radio/audio");
+        var dto = await GetAudioAsync(client);
         Assert.NotNull(dto);
         Assert.False(dto!.HasOnboardCodec);     // HL2 has no stream codec
         Assert.True(dto.HermesLite2MicFrontEnd); // but DOES have the mic front-end
     }
 
     [Fact]
-    public async Task CodecBoard_PUT_PersistsAndRoundTrips()
+    public async Task CodecBoard_GET_ReportsSourceGates()
     {
+        // OrionMkII default variant is G2 (Saturn FPGA): line-in + bias + XLR.
         SetBoard(HpsdrBoardKind.OrionMkII);
         using var client = _factory.CreateClient();
 
+        var dto = await GetAudioAsync(client);
+        Assert.NotNull(dto);
+        Assert.True(dto!.HasRadioLineIn);
+        Assert.True(dto.HasBalancedXlr);
+        Assert.True(dto.HasMicBias);
+    }
+
+    [Fact]
+    public async Task CodecBoard_PUT_PersistsAndRoundTrips()
+    {
+        SetBoard(HpsdrBoardKind.OrionMkII); // G2 — supports RadioLineIn
+        using var client = _factory.CreateClient();
+
         var resp = await client.PutAsJsonAsync("/api/radio/audio",
-            new { lineIn = true, micBoost = true, micBias = false, balancedInput = true, lineInGain = 18 });
+            new { source = "RadioLineIn", micBoost = false, micBias = false, lineInGain = 18 });
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
 
-        var dto = await resp.Content.ReadFromJsonAsync<AudioFrontEndDto>();
+        var dto = await ReadAudioAsync(resp);
         Assert.NotNull(dto);
-        Assert.True(dto!.LineIn);
-        Assert.True(dto.MicBoost);
-        Assert.False(dto.MicBias);
-        Assert.True(dto.BalancedInput);
+        Assert.Equal(TxAudioSource.RadioLineIn, dto!.Source);
         Assert.Equal(18, dto.LineInGain);
 
-        var got = await client.GetFromJsonAsync<AudioFrontEndDto>("/api/radio/audio");
+        var got = await GetAudioAsync(client);
         Assert.Equal(18, got!.LineInGain);
-        Assert.True(got.LineIn);
+        Assert.Equal(TxAudioSource.RadioLineIn, got.Source);
     }
 
     [Fact]
     public async Task LineInGain_ClampedTo31()
     {
-        SetBoard(HpsdrBoardKind.HermesLite2);
+        SetBoard(HpsdrBoardKind.OrionMkII); // G2 — supports RadioLineIn
         using var client = _factory.CreateClient();
 
         var resp = await client.PutAsJsonAsync("/api/radio/audio",
-            new { lineIn = false, micBoost = false, micBias = false, balancedInput = false, lineInGain = 200 });
-        var dto = await resp.Content.ReadFromJsonAsync<AudioFrontEndDto>();
+            new { source = "RadioLineIn", micBoost = false, micBias = false, lineInGain = 200 });
+        var dto = await ReadAudioAsync(resp);
         Assert.Equal(31, dto!.LineInGain);
     }
 
@@ -103,8 +130,28 @@ public class AudioEndpointTests : IClassFixture<AudioEndpointTests.Factory>
         using var client = _factory.CreateClient();
 
         var resp = await client.PutAsJsonAsync("/api/radio/audio",
-            new { lineIn = true, micBoost = false, micBias = false, balancedInput = false, lineInGain = 0 });
+            new { source = "RadioMic", micBoost = false, micBias = false, lineInGain = 0 });
         Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnsupportedSource_OnBoard_ClampsToHost()
+    {
+        // HL2 has a mic front-end (so the PUT is accepted, not 409) but no
+        // onboard codec → it is Host-only. A RadioMic request must clamp back to
+        // Host rather than persist an illegal jack the wire can't emit.
+        SetBoard(HpsdrBoardKind.HermesLite2);
+        using var client = _factory.CreateClient();
+
+        var resp = await client.PutAsJsonAsync("/api/radio/audio",
+            new { source = "RadioMic", micBoost = true, micBias = true, lineInGain = 9 });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var dto = await ReadAudioAsync(resp);
+        Assert.Equal(TxAudioSource.Host, dto!.Source);
+        // Params dropped with the source.
+        Assert.False(dto.MicBoost);
+        Assert.False(dto.MicBias);
     }
 
     public sealed class Factory : WebApplicationFactory<Program>

--- a/tests/Zeus.Server.Tests/AudioSettingsStoreTests.cs
+++ b/tests/Zeus.Server.Tests/AudioSettingsStoreTests.cs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// External-ports plan, Phase 4 — global audio front-end persistence round-trip.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class AudioSettingsStoreTests : IDisposable
+{
+    private readonly string _dbPath;
+
+    public AudioSettingsStoreTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"zeus-prefs-audio-{Guid.NewGuid():N}.db");
+    }
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+    }
+
+    private AudioSettingsStore NewStore() =>
+        new AudioSettingsStore(NullLogger<AudioSettingsStore>.Instance, _dbPath);
+
+    [Fact]
+    public void Unset_Defaults_To_MicInput_NoBias()
+    {
+        using var store = NewStore();
+        var sel = store.Get();
+        Assert.False(sel.LineIn);
+        Assert.False(sel.MicBoost);
+        Assert.False(sel.MicBias); // mic_bias defaults OFF
+        Assert.False(sel.BalancedInput);
+        Assert.Equal(0, sel.LineInGain);
+    }
+
+    [Fact]
+    public void Set_RoundTrips_AcrossReopen()
+    {
+        using (var store = NewStore())
+        {
+            store.Set(new AudioFrontEndSelection(
+                LineIn: true, MicBoost: true, MicBias: true, BalancedInput: true, LineInGain: 21));
+        }
+
+        using var reopened = NewStore();
+        var sel = reopened.Get();
+        Assert.True(sel.LineIn);
+        Assert.True(sel.MicBoost);
+        Assert.True(sel.MicBias);
+        Assert.True(sel.BalancedInput);
+        Assert.Equal(21, sel.LineInGain);
+    }
+
+    [Fact]
+    public void Set_Twice_Updates_NotDuplicates_DeleteManyInsert()
+    {
+        // The DeleteMany+Insert upsert must replace the single global row, not
+        // accumulate rows (the LiteDB Id=0-always-inserts bug, PR #387).
+        using var store = NewStore();
+        store.Set(new AudioFrontEndSelection(true, false, false, false, 5));
+        store.Set(new AudioFrontEndSelection(false, true, true, false, 12));
+
+        var sel = store.Get();
+        Assert.False(sel.LineIn);
+        Assert.True(sel.MicBoost);
+        Assert.True(sel.MicBias);
+        Assert.Equal(12, sel.LineInGain);
+    }
+
+    [Fact]
+    public void LineInGain_ClampedTo31()
+    {
+        using var store = NewStore();
+        store.Set(new AudioFrontEndSelection(false, false, false, false, 99));
+        Assert.Equal(31, store.Get().LineInGain);
+    }
+
+    [Fact]
+    public void Changed_Fires_On_Set()
+    {
+        using var store = NewStore();
+        int fired = 0;
+        store.Changed += () => fired++;
+        store.Set(AudioFrontEndSelection.Default with { MicBoost = true });
+        Assert.Equal(1, fired);
+    }
+}

--- a/tests/Zeus.Server.Tests/AudioSettingsStoreTests.cs
+++ b/tests/Zeus.Server.Tests/AudioSettingsStoreTests.cs
@@ -4,9 +4,12 @@
 // Copyright (C) 2025-2026 Brian Keating (EI6LF),
 //                         Douglas J. Cerrato (KB2UKA), and contributors.
 //
-// External-ports plan, Phase 4 — global audio front-end persistence round-trip.
+// External-ports plan, §2/§8 — global TX-audio SOURCE persistence round-trip +
+// legacy four-bool row migration to Host.
 
+using LiteDB;
 using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
 using Zeus.Server;
 
 namespace Zeus.Server.Tests;
@@ -29,14 +32,13 @@ public class AudioSettingsStoreTests : IDisposable
         new AudioSettingsStore(NullLogger<AudioSettingsStore>.Instance, _dbPath);
 
     [Fact]
-    public void Unset_Defaults_To_MicInput_NoBias()
+    public void Unset_Defaults_To_Host_NoBias()
     {
         using var store = NewStore();
         var sel = store.Get();
-        Assert.False(sel.LineIn);
+        Assert.Equal(TxAudioSource.Host, sel.Source);
         Assert.False(sel.MicBoost);
         Assert.False(sel.MicBias); // mic_bias defaults OFF
-        Assert.False(sel.BalancedInput);
         Assert.Equal(0, sel.LineInGain);
     }
 
@@ -45,16 +47,15 @@ public class AudioSettingsStoreTests : IDisposable
     {
         using (var store = NewStore())
         {
-            store.Set(new AudioFrontEndSelection(
-                LineIn: true, MicBoost: true, MicBias: true, BalancedInput: true, LineInGain: 21));
+            store.Set(new AudioSourceSelection(
+                Source: TxAudioSource.RadioLineIn, MicBoost: true, MicBias: true, LineInGain: 21));
         }
 
         using var reopened = NewStore();
         var sel = reopened.Get();
-        Assert.True(sel.LineIn);
+        Assert.Equal(TxAudioSource.RadioLineIn, sel.Source);
         Assert.True(sel.MicBoost);
         Assert.True(sel.MicBias);
-        Assert.True(sel.BalancedInput);
         Assert.Equal(21, sel.LineInGain);
     }
 
@@ -64,11 +65,11 @@ public class AudioSettingsStoreTests : IDisposable
         // The DeleteMany+Insert upsert must replace the single global row, not
         // accumulate rows (the LiteDB Id=0-always-inserts bug, PR #387).
         using var store = NewStore();
-        store.Set(new AudioFrontEndSelection(true, false, false, false, 5));
-        store.Set(new AudioFrontEndSelection(false, true, true, false, 12));
+        store.Set(new AudioSourceSelection(TxAudioSource.RadioMic, false, false, 5));
+        store.Set(new AudioSourceSelection(TxAudioSource.RadioBalancedXlr, true, true, 12));
 
         var sel = store.Get();
-        Assert.False(sel.LineIn);
+        Assert.Equal(TxAudioSource.RadioBalancedXlr, sel.Source);
         Assert.True(sel.MicBoost);
         Assert.True(sel.MicBias);
         Assert.Equal(12, sel.LineInGain);
@@ -78,7 +79,7 @@ public class AudioSettingsStoreTests : IDisposable
     public void LineInGain_ClampedTo31()
     {
         using var store = NewStore();
-        store.Set(new AudioFrontEndSelection(false, false, false, false, 99));
+        store.Set(new AudioSourceSelection(TxAudioSource.RadioLineIn, false, false, 99));
         Assert.Equal(31, store.Get().LineInGain);
     }
 
@@ -88,7 +89,60 @@ public class AudioSettingsStoreTests : IDisposable
         using var store = NewStore();
         int fired = 0;
         store.Changed += () => fired++;
-        store.Set(AudioFrontEndSelection.Default with { MicBoost = true });
+        store.Set(AudioSourceSelection.Default with { MicBoost = true });
         Assert.Equal(1, fired);
+    }
+
+    [Fact]
+    public void LegacyFourBoolRow_MigratesTo_Host()
+    {
+        // Write a pre-rework row directly into the audio_frontend collection with
+        // the OLD four-bool schema (LineIn / MicBoost / MicBias / BalancedInput /
+        // LineInGain) and NO `Source` field. The new store must hydrate Source
+        // to Host (the schema-less LiteDB default 0) — the §8 migration contract.
+        using (var db = new LiteDatabase($"Filename={_dbPath};Connection=shared"))
+        {
+            var col = db.GetCollection("audio_frontend");
+            col.Insert(new BsonDocument
+            {
+                ["_id"] = 1,
+                ["LineIn"] = true,
+                ["MicBoost"] = true,
+                ["MicBias"] = true,
+                ["BalancedInput"] = true,
+                ["LineInGain"] = 17,
+                ["UpdatedUtc"] = DateTime.UtcNow,
+            });
+        }
+
+        using var store = NewStore();
+        var sel = store.Get();
+        // No `Source` field on the legacy row → Host (the clean fallback).
+        Assert.Equal(TxAudioSource.Host, sel.Source);
+        // The carried-over params survive as raw values (clamped at push time),
+        // but the SOURCE — the thing that actually drives the wire — is Host.
+        Assert.True(sel.MicBoost);
+        Assert.True(sel.MicBias);
+        Assert.Equal(17, sel.LineInGain);
+    }
+
+    [Fact]
+    public void CorruptSourceByte_FallsBackToHost()
+    {
+        using (var db = new LiteDatabase($"Filename={_dbPath};Connection=shared"))
+        {
+            var col = db.GetCollection("audio_frontend");
+            col.Insert(new BsonDocument
+            {
+                ["_id"] = 1,
+                ["Source"] = 99, // out of TxAudioSource range
+                ["MicBoost"] = false,
+                ["MicBias"] = false,
+                ["LineInGain"] = 0,
+            });
+        }
+
+        using var store = NewStore();
+        Assert.Equal(TxAudioSource.Host, store.Get().Source);
     }
 }

--- a/tests/Zeus.Server.Tests/BoardCapabilitiesTableTests.cs
+++ b/tests/Zeus.Server.Tests/BoardCapabilitiesTableTests.cs
@@ -203,4 +203,65 @@ public class BoardCapabilitiesTableTests
 
     public static IEnumerable<object[]> EveryBoardKind() =>
         Enum.GetValues<HpsdrBoardKind>().Select(b => new object[] { b });
+
+    // ---- External-port capability flags (external-ports plan, Phase 1) ----
+
+    [Fact]
+    public void TxAntennaRelays_Only_OrionMkII_0x0A_Family()
+    {
+        // Only the 0x0A / Saturn family has switchable TX antenna relays.
+        // Every variant in that family (incl. Apache OrionMkII original) does.
+        foreach (var variant in Enum.GetValues<OrionMkIIVariant>())
+            Assert.True(BoardCapabilitiesTable.For(HpsdrBoardKind.OrionMkII, variant).HasTxAntennaRelays);
+
+        // No P1 board and not HL2.
+        foreach (var board in new[] {
+            HpsdrBoardKind.Metis, HpsdrBoardKind.Hermes, HpsdrBoardKind.HermesII,
+            HpsdrBoardKind.Angelia, HpsdrBoardKind.Orion, HpsdrBoardKind.HermesC10,
+            HpsdrBoardKind.HermesLite2 })
+            Assert.False(BoardCapabilitiesTable.For(board).HasTxAntennaRelays);
+    }
+
+    [Fact]
+    public void RxAntennaRelays_And_Codec_Every_ANAN_Not_HL2()
+    {
+        // Every ANAN board has Alex RX-antenna relays and the stream codec;
+        // HL2 has neither (single jack, no stream codec).
+        foreach (var board in new[] {
+            HpsdrBoardKind.Metis, HpsdrBoardKind.Hermes, HpsdrBoardKind.HermesII,
+            HpsdrBoardKind.Angelia, HpsdrBoardKind.Orion, HpsdrBoardKind.OrionMkII,
+            HpsdrBoardKind.HermesC10 })
+        {
+            var caps = BoardCapabilitiesTable.For(board);
+            Assert.True(caps.HasRxAntennaRelays);
+            Assert.True(caps.HasOnboardCodec);
+        }
+
+        var hl2 = BoardCapabilitiesTable.For(HpsdrBoardKind.HermesLite2);
+        Assert.False(hl2.HasRxAntennaRelays);
+        Assert.False(hl2.HasOnboardCodec);
+    }
+
+    [Fact]
+    public void HermesLite2MicFrontEnd_Only_HL2()
+    {
+        // HL2 has the only register-0x14 mic/PTT/line-in front-end; no other
+        // board advertises it (they use the stream-codec path instead).
+        Assert.True(BoardCapabilitiesTable.For(HpsdrBoardKind.HermesLite2).HermesLite2MicFrontEnd);
+
+        foreach (var board in Enum.GetValues<HpsdrBoardKind>())
+            if (board != HpsdrBoardKind.HermesLite2)
+                Assert.False(BoardCapabilitiesTable.For(board).HermesLite2MicFrontEnd);
+    }
+
+    [Fact]
+    public void UnknownDefaults_Advertise_No_Ports()
+    {
+        // Conservative: an unrecognised board must not claim any external port.
+        var u = BoardCapabilities.UnknownDefaults;
+        Assert.False(u.HasTxAntennaRelays);
+        Assert.False(u.HasRxAntennaRelays);
+        Assert.False(u.HasOnboardCodec);
+        Assert.False(u.HermesLite2MicFrontEnd);
+    }
 }

--- a/tests/Zeus.Server.Tests/BoardCapabilitiesTableTests.cs
+++ b/tests/Zeus.Server.Tests/BoardCapabilitiesTableTests.cs
@@ -320,4 +320,65 @@ public class BoardCapabilitiesTableTests
         foreach (var board in Enum.GetValues<HpsdrBoardKind>())
             Assert.Equal(AlexRevision.Modern, BoardCapabilitiesTable.For(board).AlexRevision);
     }
+
+    // ---- TX-audio source jacks (external-ports plan, §6) — EXACT matrix ----
+
+    [Fact]
+    public void HasMicBias_Exactly_The_Six_BiasCapable_Boards()
+    {
+        // CRITICAL §6: bias TRUE only for ANAN-200D + 7000DLE + 8000DLE + G2 +
+        // G2-1K + ANVELINA-PRO3; FALSE for Red Pitaya + every Hermes-class + G2E
+        // + Metis + HL2 + Apache OrionMkII original.
+        Assert.True(BoardCapabilitiesTable.For(HpsdrBoardKind.Orion).HasMicBias); // 200D
+        Assert.True(BoardCapabilitiesTable.For(HpsdrBoardKind.OrionMkII, OrionMkIIVariant.Anan7000DLE).HasMicBias);
+        Assert.True(BoardCapabilitiesTable.For(HpsdrBoardKind.OrionMkII, OrionMkIIVariant.Anan8000DLE).HasMicBias);
+        Assert.True(BoardCapabilitiesTable.For(HpsdrBoardKind.OrionMkII, OrionMkIIVariant.G2).HasMicBias);
+        Assert.True(BoardCapabilitiesTable.For(HpsdrBoardKind.OrionMkII, OrionMkIIVariant.G2_1K).HasMicBias);
+        Assert.True(BoardCapabilitiesTable.For(HpsdrBoardKind.OrionMkII, OrionMkIIVariant.AnvelinaPro3).HasMicBias);
+
+        // FALSE set.
+        Assert.False(BoardCapabilitiesTable.For(HpsdrBoardKind.OrionMkII, OrionMkIIVariant.RedPitaya).HasMicBias);
+        Assert.False(BoardCapabilitiesTable.For(HpsdrBoardKind.OrionMkII, OrionMkIIVariant.OrionMkII).HasMicBias);
+        Assert.False(BoardCapabilitiesTable.For(HpsdrBoardKind.Metis).HasMicBias);
+        Assert.False(BoardCapabilitiesTable.For(HpsdrBoardKind.Hermes).HasMicBias);
+        Assert.False(BoardCapabilitiesTable.For(HpsdrBoardKind.HermesII).HasMicBias);
+        Assert.False(BoardCapabilitiesTable.For(HpsdrBoardKind.Angelia).HasMicBias); // 100D
+        Assert.False(BoardCapabilitiesTable.For(HpsdrBoardKind.HermesC10).HasMicBias); // G2E
+        Assert.False(BoardCapabilitiesTable.For(HpsdrBoardKind.HermesLite2).HasMicBias);
+    }
+
+    [Fact]
+    public void HasBalancedXlr_Only_G2_And_G2_1K()
+    {
+        // §6: balanced XLR is the Saturn-FPGA G2 / G2-1K only.
+        Assert.True(BoardCapabilitiesTable.For(HpsdrBoardKind.OrionMkII, OrionMkIIVariant.G2).HasBalancedXlr);
+        Assert.True(BoardCapabilitiesTable.For(HpsdrBoardKind.OrionMkII, OrionMkIIVariant.G2_1K).HasBalancedXlr);
+
+        foreach (var v in new[] {
+            OrionMkIIVariant.Anan7000DLE, OrionMkIIVariant.Anan8000DLE,
+            OrionMkIIVariant.OrionMkII, OrionMkIIVariant.AnvelinaPro3, OrionMkIIVariant.RedPitaya })
+            Assert.False(BoardCapabilitiesTable.For(HpsdrBoardKind.OrionMkII, v).HasBalancedXlr);
+
+        foreach (var board in new[] {
+            HpsdrBoardKind.Metis, HpsdrBoardKind.Hermes, HpsdrBoardKind.HermesII,
+            HpsdrBoardKind.Angelia, HpsdrBoardKind.Orion, HpsdrBoardKind.HermesC10,
+            HpsdrBoardKind.HermesLite2 })
+            Assert.False(BoardCapabilitiesTable.For(board).HasBalancedXlr);
+    }
+
+    [Fact]
+    public void HasRadioLineIn_On_200D_And_All_0x0A_Not_HermesClass_Or_HL2()
+    {
+        // §6: line-in on ANAN-200D + every 0x0A variant. NOT on pure Hermes-class
+        // P1 (no P1 radio-mic RX path in v1), ANAN-G2E, Metis, HL2.
+        Assert.True(BoardCapabilitiesTable.For(HpsdrBoardKind.Orion).HasRadioLineIn); // 200D
+        foreach (var v in Enum.GetValues<OrionMkIIVariant>())
+            Assert.True(BoardCapabilitiesTable.For(HpsdrBoardKind.OrionMkII, v).HasRadioLineIn);
+
+        foreach (var board in new[] {
+            HpsdrBoardKind.Metis, HpsdrBoardKind.Hermes, HpsdrBoardKind.HermesII,
+            HpsdrBoardKind.Angelia /* 100D */, HpsdrBoardKind.HermesC10 /* G2E */,
+            HpsdrBoardKind.HermesLite2 })
+            Assert.False(BoardCapabilitiesTable.For(board).HasRadioLineIn);
+    }
 }

--- a/tests/Zeus.Server.Tests/BoardCapabilitiesTableTests.cs
+++ b/tests/Zeus.Server.Tests/BoardCapabilitiesTableTests.cs
@@ -263,5 +263,61 @@ public class BoardCapabilitiesTableTests
         Assert.False(u.HasRxAntennaRelays);
         Assert.False(u.HasOnboardCodec);
         Assert.False(u.HermesLite2MicFrontEnd);
+        // Phase 5 ports also off by default.
+        Assert.Equal(RxAuxInputs.None, u.RxAuxInputs);
+        Assert.False(u.HasRx2AntennaPath);
+        Assert.False(u.HasHl2UserGpio);
+        Assert.Equal(AlexRevision.Modern, u.AlexRevision);
+    }
+
+    // ---- External-port capability flags (external-ports plan, Phase 5) ----
+
+    [Fact]
+    public void RxAuxInputs_All_On_Alex_Boards_None_On_HL2()
+    {
+        // Every Alex-class P1 board and the 0x0A family exposes the full RX-aux
+        // input set (EXT1/EXT2/XVTR/BYPASS). HL2 exposes NONE — the jacks don't
+        // physically exist.
+        foreach (var board in new[] {
+            HpsdrBoardKind.Metis, HpsdrBoardKind.Hermes, HpsdrBoardKind.HermesII,
+            HpsdrBoardKind.Angelia, HpsdrBoardKind.Orion, HpsdrBoardKind.OrionMkII,
+            HpsdrBoardKind.HermesC10 })
+            Assert.Equal(RxAuxInputs.All, BoardCapabilitiesTable.For(board).RxAuxInputs);
+
+        Assert.Equal(RxAuxInputs.None, BoardCapabilitiesTable.For(HpsdrBoardKind.HermesLite2).RxAuxInputs);
+    }
+
+    [Fact]
+    public void Rx2AntennaPath_Only_DualAdc_Boards()
+    {
+        // The dual-ADC boards (100D / 200D / 0x0A family) have a second RX
+        // antenna path; single-RX boards (Hermes-class, G2E, HL2) do not.
+        foreach (var board in new[] {
+            HpsdrBoardKind.Angelia, HpsdrBoardKind.Orion, HpsdrBoardKind.OrionMkII })
+            Assert.True(BoardCapabilitiesTable.For(board).HasRx2AntennaPath);
+
+        foreach (var board in new[] {
+            HpsdrBoardKind.Metis, HpsdrBoardKind.Hermes, HpsdrBoardKind.HermesII,
+            HpsdrBoardKind.HermesC10, HpsdrBoardKind.HermesLite2 })
+            Assert.False(BoardCapabilitiesTable.For(board).HasRx2AntennaPath);
+    }
+
+    [Fact]
+    public void Hl2UserGpio_Only_HL2()
+    {
+        Assert.True(BoardCapabilitiesTable.For(HpsdrBoardKind.HermesLite2).HasHl2UserGpio);
+        foreach (var board in Enum.GetValues<HpsdrBoardKind>())
+            if (board != HpsdrBoardKind.HermesLite2)
+                Assert.False(BoardCapabilitiesTable.For(board).HasHl2UserGpio);
+    }
+
+    [Fact]
+    public void AlexRevision_Defaults_Modern_Everywhere()
+    {
+        // The K36-BYPASS direction is NOT wire-discoverable; Zeus defaults
+        // conservatively to Modern (Rev 24+, PS routes to BYPASS — the current
+        // shipped behaviour) on every board. Legacy is operator opt-in only.
+        foreach (var board in Enum.GetValues<HpsdrBoardKind>())
+            Assert.Equal(AlexRevision.Modern, BoardCapabilitiesTable.For(board).AlexRevision);
     }
 }

--- a/tests/Zeus.Server.Tests/ExternalPortEncoderTests.cs
+++ b/tests/Zeus.Server.Tests/ExternalPortEncoderTests.cs
@@ -93,24 +93,30 @@ public class ExternalPortEncoderTests
         Assert.Equal(expected, bits);
     }
 
-    [Fact]
-    public void Hl2Encoder_RxAntennaC3Bits_StillRawInPhase1()
+    [Theory]
+    [InlineData(HpsdrAntenna.Ant1)]
+    [InlineData(HpsdrAntenna.Ant2)]
+    [InlineData(HpsdrAntenna.Ant3)]
+    public void Hl2Encoder_RxAntennaC3Bits_ClampedToAnt1(HpsdrAntenna requested)
     {
-        // Phase 1 is byte-identical: HL2 still emits the raw C3[7:5] value
-        // (the Phase-2 clamp to ANT1 is inert). This pins that the clamp has
-        // NOT activated early — if it had, Ant2 would encode as 0x00.
+        // Phase 2: HL2 has no RX-antenna relay — C3[7:5] is hard-clamped to
+        // ANT1 (0x00) at the wire layer regardless of the requested antenna,
+        // so a stale per-band ANT2/3 can never flip the N2ADR antenna pad.
         var encoder = ExternalPortEncoders.For(HpsdrBoardKind.HermesLite2);
-        byte bits = encoder.EncodeP1RxAntennaC3Bits(new ExternalPortState(RxAnt: HpsdrAntenna.Ant2));
-        Assert.Equal(0x20, bits);
+        byte bits = encoder.EncodeP1RxAntennaC3Bits(new ExternalPortState(RxAnt: requested));
+        Assert.Equal(0x00, bits);
     }
 
-    [Fact]
-    public void P2Encoder_TxAntennaBits_AreAnt1InPhase1()
+    [Theory]
+    [InlineData(HpsdrAntenna.Ant1, 0x01000000u)]
+    [InlineData(HpsdrAntenna.Ant2, 0x02000000u)]
+    [InlineData(HpsdrAntenna.Ant3, 0x04000000u)]
+    public void P2Encoder_TxAntennaBits_ThreadSelection_OnRelayBoard(HpsdrAntenna ant, uint expected)
     {
-        // Phase 1 keeps the hardcoded ANT1 (0x01000000) regardless of the
-        // desired TxAnt — the real per-band thread-through is Phase 2.
+        // Phase 2: a relay-capable variant (G2 / OrionMkII) threads the real
+        // per-band TX antenna into alex0[26:24].
         var encoder = ExternalPortEncoders.For(HpsdrBoardKind.OrionMkII);
-        uint bits = encoder.EncodeP2TxAntennaBits(new ExternalPortState(TxAnt: HpsdrAntenna.Ant3));
-        Assert.Equal(0x01000000u, bits);
+        uint bits = encoder.EncodeP2TxAntennaBits(new ExternalPortState(TxAnt: ant));
+        Assert.Equal(expected, bits);
     }
 }

--- a/tests/Zeus.Server.Tests/ExternalPortEncoderTests.cs
+++ b/tests/Zeus.Server.Tests/ExternalPortEncoderTests.cs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Contracts;
+using Zeus.Protocol1;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Coverage + byte-identity tests for the external-port encoder seam
+/// (external-ports plan, Phase 1).
+///
+/// 1. Every <see cref="HpsdrBoardKind"/> resolves to a non-null encoder.
+/// 2. The encoders produce the SAME antenna bits as today's wire path for the
+///    default (ANT1) state — these complement the golden-byte tests in the
+///    protocol test projects, asserting the firewall is byte-identical.
+/// </summary>
+public class ExternalPortEncoderTests
+{
+    [Theory]
+    [InlineData(HpsdrBoardKind.Metis)]
+    [InlineData(HpsdrBoardKind.Hermes)]
+    [InlineData(HpsdrBoardKind.HermesII)]
+    [InlineData(HpsdrBoardKind.Angelia)]
+    [InlineData(HpsdrBoardKind.Orion)]
+    [InlineData(HpsdrBoardKind.HermesLite2)]
+    [InlineData(HpsdrBoardKind.OrionMkII)]
+    [InlineData(HpsdrBoardKind.HermesC10)]
+    [InlineData(HpsdrBoardKind.Unknown)]
+    public void For_ReturnsNonNullEncoder_ForEveryBoardKind(HpsdrBoardKind board)
+    {
+        var encoder = ExternalPortEncoders.For(board);
+        Assert.NotNull(encoder);
+        Assert.False(string.IsNullOrWhiteSpace(encoder.Label));
+    }
+
+    [Fact]
+    public void For_ReturnsNonNullEncoder_ForEveryEnumeratedBoardKind()
+    {
+        foreach (HpsdrBoardKind board in Enum.GetValues<HpsdrBoardKind>())
+        {
+            Assert.NotNull(ExternalPortEncoders.For(board));
+        }
+    }
+
+    [Theory]
+    [InlineData(OrionMkIIVariant.G2)]
+    [InlineData(OrionMkIIVariant.G2_1K)]
+    [InlineData(OrionMkIIVariant.Anan7000DLE)]
+    [InlineData(OrionMkIIVariant.Anan8000DLE)]
+    [InlineData(OrionMkIIVariant.OrionMkII)]
+    [InlineData(OrionMkIIVariant.AnvelinaPro3)]
+    [InlineData(OrionMkIIVariant.RedPitaya)]
+    public void For_0x0A_RoutesToProtocol2Encoder_ForEveryVariant(OrionMkIIVariant variant)
+    {
+        var encoder = ExternalPortEncoders.For(HpsdrBoardKind.OrionMkII, variant);
+        Assert.IsType<Protocol2PortEncoder>(encoder);
+    }
+
+    [Fact]
+    public void For_Hermes_RoutesToProtocol1Encoder()
+        => Assert.IsType<Protocol1PortEncoder>(ExternalPortEncoders.For(HpsdrBoardKind.Hermes));
+
+    [Fact]
+    public void For_Hl2_RoutesToHl2Encoder()
+        => Assert.IsType<HermesLite2PortEncoder>(ExternalPortEncoders.For(HpsdrBoardKind.HermesLite2));
+
+    [Fact]
+    public void DefaultProtocolFor_0x0A_IsProtocol2_OthersProtocol1()
+    {
+        Assert.Equal(RadioProtocol.Protocol2, ExternalPortEncoders.DefaultProtocolFor(HpsdrBoardKind.OrionMkII));
+        Assert.Equal(RadioProtocol.Protocol1, ExternalPortEncoders.DefaultProtocolFor(HpsdrBoardKind.Hermes));
+        Assert.Equal(RadioProtocol.Protocol1, ExternalPortEncoders.DefaultProtocolFor(HpsdrBoardKind.HermesLite2));
+    }
+
+    // ---- byte-identity: encoder output == wire path for the default state ----
+
+    [Theory]
+    [InlineData(HpsdrAntenna.Ant1, 0x00)]
+    [InlineData(HpsdrAntenna.Ant2, 0x20)]
+    [InlineData(HpsdrAntenna.Ant3, 0x40)]
+    public void P1Encoder_RxAntennaC3Bits_MatchWirePath(HpsdrAntenna ant, byte expected)
+    {
+        var encoder = ExternalPortEncoders.For(HpsdrBoardKind.Hermes);
+        byte bits = encoder.EncodeP1RxAntennaC3Bits(new ExternalPortState(RxAnt: ant));
+        Assert.Equal(expected, bits);
+    }
+
+    [Fact]
+    public void Hl2Encoder_RxAntennaC3Bits_StillRawInPhase1()
+    {
+        // Phase 1 is byte-identical: HL2 still emits the raw C3[7:5] value
+        // (the Phase-2 clamp to ANT1 is inert). This pins that the clamp has
+        // NOT activated early — if it had, Ant2 would encode as 0x00.
+        var encoder = ExternalPortEncoders.For(HpsdrBoardKind.HermesLite2);
+        byte bits = encoder.EncodeP1RxAntennaC3Bits(new ExternalPortState(RxAnt: HpsdrAntenna.Ant2));
+        Assert.Equal(0x20, bits);
+    }
+
+    [Fact]
+    public void P2Encoder_TxAntennaBits_AreAnt1InPhase1()
+    {
+        // Phase 1 keeps the hardcoded ANT1 (0x01000000) regardless of the
+        // desired TxAnt — the real per-band thread-through is Phase 2.
+        var encoder = ExternalPortEncoders.For(HpsdrBoardKind.OrionMkII);
+        uint bits = encoder.EncodeP2TxAntennaBits(new ExternalPortState(TxAnt: HpsdrAntenna.Ant3));
+        Assert.Equal(0x01000000u, bits);
+    }
+}

--- a/tests/Zeus.Server.Tests/ExternalPortEncoderTests.cs
+++ b/tests/Zeus.Server.Tests/ExternalPortEncoderTests.cs
@@ -119,4 +119,148 @@ public class ExternalPortEncoderTests
         uint bits = encoder.EncodeP2TxAntennaBits(new ExternalPortState(TxAnt: ant));
         Assert.Equal(expected, bits);
     }
+
+    // ---- TX-audio source: P2 byte-50/51 PURE FUNCTIONS (external-ports §2) ----
+
+    [Theory]
+    // Host: literal 0 regardless of any persisted params.
+    [InlineData(TxAudioSource.Host, false, false, (byte)0x00)]
+    [InlineData(TxAudioSource.Host, true, true, (byte)0x00)]
+    // RadioMic: boost (bit1) + bias (bit4) from params, no line-in/XLR bits.
+    [InlineData(TxAudioSource.RadioMic, false, false, (byte)0x00)]
+    [InlineData(TxAudioSource.RadioMic, true, false, (byte)0x02)]
+    [InlineData(TxAudioSource.RadioMic, false, true, (byte)0x10)]
+    [InlineData(TxAudioSource.RadioMic, true, true, (byte)0x12)]
+    // RadioLineIn: line-in select (bit0); mic params ignored.
+    [InlineData(TxAudioSource.RadioLineIn, true, true, (byte)0x01)]
+    // RadioBalancedXlr: XLR (bit5) | opt boost/bias.
+    [InlineData(TxAudioSource.RadioBalancedXlr, false, false, (byte)0x20)]
+    [InlineData(TxAudioSource.RadioBalancedXlr, true, true, (byte)0x32)]
+    public void P2Encoder_MicControlByte_IsPureFunctionOfSource(
+        TxAudioSource source, bool micBoost, bool micBias, byte expected)
+    {
+        var encoder = ExternalPortEncoders.For(HpsdrBoardKind.OrionMkII);
+        var state = new ExternalPortState(Source: source, MicBoost: micBoost, MicBias: micBias);
+        Assert.Equal(expected, encoder.EncodeP2MicControlByte(in state));
+    }
+
+    [Fact]
+    public void P2Encoder_Host_ByteIsLiteralZero_DespitePersistedParams()
+    {
+        // PURITY: a stale non-zero MicBoost/MicBias/LineInGain must NOT leak onto
+        // the wire after a revert to Host. Host returns literal 0 on every surface.
+        var encoder = ExternalPortEncoders.For(HpsdrBoardKind.OrionMkII);
+        var leaky = new ExternalPortState(
+            Source: TxAudioSource.Host, MicBoost: true, MicBias: true, LineInGain: 31);
+        Assert.Equal((byte)0x00, encoder.EncodeP2MicControlByte(in leaky));
+        Assert.Equal((byte)0x00, encoder.EncodeP2LineInGainByte(in leaky));
+    }
+
+    [Theory]
+    // Gain rides byte 51 ONLY for RadioLineIn; every other source returns 0.
+    [InlineData(TxAudioSource.RadioLineIn, (byte)19, (byte)19)]
+    [InlineData(TxAudioSource.RadioLineIn, (byte)63, (byte)31)] // 5-bit clamp
+    [InlineData(TxAudioSource.RadioMic, (byte)19, (byte)0)]
+    [InlineData(TxAudioSource.RadioBalancedXlr, (byte)19, (byte)0)]
+    [InlineData(TxAudioSource.Host, (byte)19, (byte)0)]
+    public void P2Encoder_LineInGainByte_OnlyForLineIn(
+        TxAudioSource source, byte gain, byte expected)
+    {
+        var encoder = ExternalPortEncoders.For(HpsdrBoardKind.OrionMkII);
+        var state = new ExternalPortState(Source: source, LineInGain: gain);
+        Assert.Equal(expected, encoder.EncodeP2LineInGainByte(in state));
+    }
+
+    [Theory]
+    // P1 codec 0x12 bits (mic_boost C2[0], mic_linein C2[1]). RadioMic → boost
+    // from param; Host / everything else → all clear (no leak).
+    [InlineData(TxAudioSource.Host, true, false, false)]
+    [InlineData(TxAudioSource.RadioMic, false, false, false)]
+    [InlineData(TxAudioSource.RadioMic, true, true, false)]
+    public void P1Encoder_CodecAudioBits_IsPureFunctionOfSource(
+        TxAudioSource source, bool micBoost, bool expBoost, bool expLineIn)
+    {
+        var encoder = ExternalPortEncoders.For(HpsdrBoardKind.Hermes);
+        var state = new ExternalPortState(Source: source, MicBoost: micBoost);
+        var (boost, lineIn) = encoder.EncodeP1CodecAudioBits(in state);
+        Assert.Equal(expBoost, boost);
+        Assert.Equal(expLineIn, lineIn);
+    }
+
+    [Fact]
+    public void Hl2Encoder_AllAudioSurfaces_AreZero_HostOnly()
+    {
+        // HL2 is Host-only — no codec audio bits, no P2 bytes, ever.
+        var encoder = ExternalPortEncoders.For(HpsdrBoardKind.HermesLite2);
+        var hot = new ExternalPortState(
+            Source: TxAudioSource.RadioMic, MicBoost: true, MicBias: true, LineInGain: 31);
+        Assert.Equal((byte)0, encoder.EncodeP2MicControlByte(in hot));
+        Assert.Equal((byte)0, encoder.EncodeP2LineInGainByte(in hot));
+        var (boost, lineIn) = encoder.EncodeP1CodecAudioBits(in hot);
+        Assert.False(boost);
+        Assert.False(lineIn);
+    }
+
+    // ---- RadioService.ClampAudioSource against board capabilities (§5/§8) ----
+
+    [Fact]
+    public void Clamp_BalancedXlr_OnNonXlrBoard_FallsBackToHost()
+    {
+        // 7000DLE has line-in + bias but NO balanced XLR. A persisted XLR
+        // selection (e.g. after a G2→7000DLE swap) must clamp to Host.
+        var caps = BoardCapabilitiesTable.For(HpsdrBoardKind.OrionMkII, OrionMkIIVariant.Anan7000DLE);
+        var got = RadioService.ClampAudioSource(
+            new AudioSourceSelection(TxAudioSource.RadioBalancedXlr, true, true, 0), caps);
+        Assert.Equal(TxAudioSource.Host, got.Source);
+    }
+
+    [Fact]
+    public void Clamp_LineIn_OnBoardWithoutLineIn_FallsBackToHost()
+    {
+        // Hermes (pure P1 codec) has no RadioLineIn exposure in v1.
+        var caps = BoardCapabilitiesTable.For(HpsdrBoardKind.Hermes);
+        var got = RadioService.ClampAudioSource(
+            new AudioSourceSelection(TxAudioSource.RadioLineIn, false, false, 12), caps);
+        Assert.Equal(TxAudioSource.Host, got.Source);
+    }
+
+    [Fact]
+    public void Clamp_AnyRadioSource_OnHl2_FallsBackToHost()
+    {
+        // HL2 has the mic front-end (so not a 409) but no codec → Host-only.
+        var caps = BoardCapabilitiesTable.For(HpsdrBoardKind.HermesLite2);
+        foreach (var src in new[] { TxAudioSource.RadioMic, TxAudioSource.RadioLineIn, TxAudioSource.RadioBalancedXlr })
+        {
+            var got = RadioService.ClampAudioSource(
+                new AudioSourceSelection(src, true, true, 9), caps);
+            Assert.Equal(TxAudioSource.Host, got.Source);
+        }
+    }
+
+    [Fact]
+    public void Clamp_MicBias_DroppedOnNonBiasBoard()
+    {
+        // Red Pitaya has line-in but NOT mic bias. RadioMic survives; the bias
+        // param is dropped so a stale bias bit can never reach the wire.
+        var caps = BoardCapabilitiesTable.For(HpsdrBoardKind.OrionMkII, OrionMkIIVariant.RedPitaya);
+        var got = RadioService.ClampAudioSource(
+            new AudioSourceSelection(TxAudioSource.RadioMic, MicBoost: true, MicBias: true, LineInGain: 0), caps);
+        Assert.Equal(TxAudioSource.RadioMic, got.Source);
+        Assert.True(got.MicBoost);
+        Assert.False(got.MicBias); // dropped — Red Pitaya has no mic bias
+    }
+
+    [Fact]
+    public void Clamp_G2_KeepsAllSources()
+    {
+        // G2 (default OrionMkII variant) honours every radio source.
+        var caps = BoardCapabilitiesTable.For(HpsdrBoardKind.OrionMkII);
+        Assert.Equal(TxAudioSource.RadioBalancedXlr,
+            RadioService.ClampAudioSource(new AudioSourceSelection(TxAudioSource.RadioBalancedXlr, false, false, 0), caps).Source);
+        Assert.Equal(TxAudioSource.RadioLineIn,
+            RadioService.ClampAudioSource(new AudioSourceSelection(TxAudioSource.RadioLineIn, false, false, 7), caps).Source);
+        var mic = RadioService.ClampAudioSource(new AudioSourceSelection(TxAudioSource.RadioMic, true, true, 0), caps);
+        Assert.Equal(TxAudioSource.RadioMic, mic.Source);
+        Assert.True(mic.MicBias); // G2 has mic bias
+    }
 }

--- a/tests/Zeus.Server.Tests/ExternalPttServiceTests.cs
+++ b/tests/Zeus.Server.Tests/ExternalPttServiceTests.cs
@@ -64,7 +64,9 @@ public class ExternalPttServiceTests : IDisposable
             var pipeline = new DspPipelineService(Radio, Hub, Array.Empty<IRxAudioSink>(), loggerFactory);
             Tx = new TxService(Radio, pipeline, Hub, NullBandPlanService.Instance, new NullLogger<TxService>());
             Settings = new PttSettingsStore(NullLogger<PttSettingsStore>.Instance, pttDbPath);
-            if (!enabled) Settings.Set(false);
+            // Set explicitly (PTT-IN now defaults OFF / opt-in) so the harness is
+            // deterministic regardless of the store's power-on default.
+            Settings.Set(enabled);
             Service = new ExternalPttService(Radio, Tx, Hub, Settings, new NullLogger<ExternalPttService>());
         }
 
@@ -215,13 +217,13 @@ public class ExternalPttServiceTests : IDisposable
     }
 
     [Fact]
-    public void EnableGate_DefaultsOn()
+    public void EnableGate_DefaultsOff()
     {
         using var store = new PttSettingsStore(NullLogger<PttSettingsStore>.Instance, _pttDbPath);
-        Assert.True(store.Get());
-        store.Set(false);
         Assert.False(store.Get());
         store.Set(true);
         Assert.True(store.Get());
+        store.Set(false);
+        Assert.False(store.Get());
     }
 }

--- a/tests/Zeus.Server.Tests/ExternalPttServiceTests.cs
+++ b/tests/Zeus.Server.Tests/ExternalPttServiceTests.cs
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// External-ports plan §4 (PASS C): hardware PTT-IN → MOX, both protocols.
+//
+// PASS B added the radio-mic TX pipeline; PASS C adds the P2 hardware-PTT→MOX
+// promotion (which did NOT exist — ExternalPttService was P1-only and a G2/P2
+// connect never reached it) plus the per-protocol PTT-IN status lamp.
+//
+// These tests drive the SHARED debounce/hang/_owned engine through the P1 and
+// P2 entry-point seams and assert:
+//   • P2 PttIn rising → MOX-on with MoxSource.Hardware.
+//   • P2 PttIn falling → 250 ms hang → MOX-off.
+//   • P1 path behaviour unchanged (rising→MOX, falling→hang→off).
+//   • The lamp tracks the raw input per protocol (and the hub frame fires).
+//   • A re-key inside the hang window cancels the release (CW inter-char gap).
+//   • Hardware can never drop a UI/CWX-owned MOX (arbitration preserved → PS
+//     keying untouched).
+//   • The Enable gate stops MOX promotion but the lamp still tracks the input.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Protocol2;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class ExternalPttServiceTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-extptt-{Guid.NewGuid():N}.db");
+    private readonly string _pttDbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-extptt-ptt-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        foreach (var p in new[] { _dbPath, _dbPath + ".pa", _pttDbPath })
+        {
+            try { if (File.Exists(p)) File.Delete(p); } catch { }
+        }
+    }
+
+    private sealed class Harness : IDisposable
+    {
+        public RadioService Radio { get; }
+        public TxService Tx { get; }
+        public StreamingHub Hub { get; }
+        public PttSettingsStore Settings { get; }
+        public ExternalPttService Service { get; }
+
+        public Harness(string dbPath, string pttDbPath, bool enabled = true)
+        {
+            var loggerFactory = NullLoggerFactory.Instance;
+            var dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance, dbPath);
+            var paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, dbPath + ".pa");
+            Radio = new RadioService(loggerFactory, dspStore, paStore);
+            // Connect P2 so TrySetMox's FR-1 "not connected" interlock passes —
+            // exactly how a live G2 looks to the service.
+            Radio.MarkProtocol2Connected("127.0.0.1:1024", 48_000);
+            Hub = new StreamingHub(new NullLogger<StreamingHub>());
+            var pipeline = new DspPipelineService(Radio, Hub, Array.Empty<IRxAudioSink>(), loggerFactory);
+            Tx = new TxService(Radio, pipeline, Hub, NullBandPlanService.Instance, new NullLogger<TxService>());
+            Settings = new PttSettingsStore(NullLogger<PttSettingsStore>.Instance, pttDbPath);
+            if (!enabled) Settings.Set(false);
+            Service = new ExternalPttService(Radio, Tx, Hub, Settings, new NullLogger<ExternalPttService>());
+        }
+
+        public void Dispose()
+        {
+            Service.Dispose();
+            Settings.Dispose();
+        }
+    }
+
+    // The MOX takeover/release run on Task.Run; poll briefly for the expected
+    // state instead of racing the ThreadPool.
+    private static bool WaitFor(Func<bool> cond, int timeoutMs = 2000)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.ElapsedMilliseconds < timeoutMs)
+        {
+            if (cond()) return true;
+            Thread.Sleep(5);
+        }
+        return cond();
+    }
+
+    private static P2TelemetryReading Ptt(bool on) =>
+        new P2TelemetryReading(FwdAdc: 0, RevAdc: 0, ExciterAdc: 0, PttIn: on, PllLocked: true);
+
+    [Fact]
+    public void P2_PttInRising_KeysMox_WithHardwareSource()
+    {
+        using var h = new Harness(_dbPath, _pttDbPath);
+
+        h.Service.TestP2Telemetry(Ptt(true));
+
+        Assert.True(WaitFor(() => h.Tx.IsMoxOn));
+        Assert.Equal(MoxSource.Hardware, h.Tx.MoxOwner);
+        Assert.True(h.Service.IsKeyed);
+    }
+
+    [Fact]
+    public void P2_PttInFalling_HoldsForHang_ThenReleases()
+    {
+        using var h = new Harness(_dbPath, _pttDbPath);
+
+        h.Service.TestP2Telemetry(Ptt(true));
+        Assert.True(WaitFor(() => h.Tx.IsMoxOn));
+
+        h.Service.TestP2Telemetry(Ptt(false));
+        // Within the 250 ms hang MOX must still be up (bridges CW gaps).
+        Assert.True(h.Tx.IsMoxOn, "MOX dropped before the 250 ms hang elapsed");
+        Assert.False(h.Service.IsKeyed); // lamp tracks the raw input immediately
+
+        // After the hang the release fires (timer → Task on the ThreadPool).
+        Assert.True(WaitFor(() => !h.Tx.IsMoxOn, timeoutMs: 2000));
+        Assert.Null(h.Tx.MoxOwner);
+    }
+
+    [Fact]
+    public void P2_ReKeyInsideHang_CancelsRelease()
+    {
+        using var h = new Harness(_dbPath, _pttDbPath);
+
+        h.Service.TestP2Telemetry(Ptt(true));
+        Assert.True(WaitFor(() => h.Tx.IsMoxOn));
+
+        h.Service.TestP2Telemetry(Ptt(false)); // arm hang
+        Thread.Sleep(50);
+        h.Service.TestP2Telemetry(Ptt(true));  // re-key inside the window
+
+        // MOX must stay up well past the hang window — the release was cancelled.
+        Thread.Sleep(350);
+        Assert.True(h.Tx.IsMoxOn);
+        Assert.True(h.Service.IsKeyed);
+    }
+
+    [Fact]
+    public void P2_LevelSampled_NoEdge_DoesNotReKey()
+    {
+        // P2 telemetry is level-sampled at high rate; repeated identical levels
+        // must not be treated as edges (no MOX churn, no ownership reseat).
+        using var h = new Harness(_dbPath, _pttDbPath);
+
+        h.Service.TestP2Telemetry(Ptt(true));
+        Assert.True(WaitFor(() => h.Tx.IsMoxOn));
+
+        // Many redundant "still keyed" samples — must remain a single claim.
+        for (int i = 0; i < 20; i++) h.Service.TestP2Telemetry(Ptt(true));
+        Assert.True(h.Tx.IsMoxOn);
+        Assert.Equal(MoxSource.Hardware, h.Tx.MoxOwner);
+    }
+
+    [Fact]
+    public void P1_PttInRising_KeysMox_WithHardwareSource_Unchanged()
+    {
+        using var h = new Harness(_dbPath, _pttDbPath);
+
+        h.Service.TestRawPttP1(true);
+
+        Assert.True(WaitFor(() => h.Tx.IsMoxOn));
+        Assert.Equal(MoxSource.Hardware, h.Tx.MoxOwner);
+        Assert.True(h.Service.IsKeyed);
+
+        h.Service.TestRawPttP1(false);
+        Assert.True(h.Tx.IsMoxOn, "P1 MOX dropped before the hang elapsed");
+        Assert.True(WaitFor(() => !h.Tx.IsMoxOn, timeoutMs: 2000));
+    }
+
+    [Fact]
+    public void Hardware_CannotDrop_UiOwnedMox_ArbitrationPreserved()
+    {
+        // PURESIGNAL / UI keying is paramount: a footswitch release must never
+        // truncate a UI-keyed transmission. The hardware path goes through the
+        // EXISTING TrySetMox(MoxSource.Hardware) arbitration.
+        using var h = new Harness(_dbPath, _pttDbPath);
+
+        Assert.True(h.Tx.TrySetMox(true, MoxSource.UI, out _));
+        Assert.Equal(MoxSource.UI, h.Tx.MoxOwner);
+
+        // Hardware rising while UI owns: the IsMoxOn gate ignores the echo, so
+        // no takeover and ownership stays UI.
+        h.Service.TestP2Telemetry(Ptt(true));
+        Thread.Sleep(50);
+        Assert.True(h.Tx.IsMoxOn);
+        Assert.Equal(MoxSource.UI, h.Tx.MoxOwner);
+
+        // Hardware falling + full hang: the release is attempted but rejected by
+        // the arbitration (foreign source can't drop UI's MOX).
+        h.Service.TestP2Telemetry(Ptt(false));
+        Thread.Sleep(350);
+        Assert.True(h.Tx.IsMoxOn);
+        Assert.Equal(MoxSource.UI, h.Tx.MoxOwner);
+    }
+
+    [Fact]
+    public void EnableGate_Off_SuppressesMox_ButLampStillTracks()
+    {
+        using var h = new Harness(_dbPath, _pttDbPath, enabled: false);
+
+        h.Service.TestP2Telemetry(Ptt(true));
+        Thread.Sleep(50);
+
+        // No MOX promotion when the gate is off…
+        Assert.False(h.Tx.IsMoxOn);
+        // …but the lamp still reflects the physical footswitch press.
+        Assert.True(h.Service.IsKeyed);
+
+        h.Service.TestP2Telemetry(Ptt(false));
+        Assert.False(h.Service.IsKeyed);
+    }
+
+    [Fact]
+    public void EnableGate_DefaultsOn()
+    {
+        using var store = new PttSettingsStore(NullLogger<PttSettingsStore>.Instance, _pttDbPath);
+        Assert.True(store.Get());
+        store.Set(false);
+        Assert.False(store.Get());
+        store.Set(true);
+        Assert.True(store.Get());
+    }
+}

--- a/tests/Zeus.Server.Tests/RadioMicReceiverTests.cs
+++ b/tests/Zeus.Server.Tests/RadioMicReceiverTests.cs
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Distributed under the GNU General Public License v2 or later. See the
+// LICENSE file at the root of this repository for full text.
+
+using System.Buffers.Binary;
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Dsp;
+using Zeus.Protocol1;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+// Covers the Saturn radio-mic (UDP 1026) parse + 960-sample re-blocker
+// (external-ports plan, §3). The packet layout is verified against pihpsdr
+// src/new_protocol.c process_mic_data (4-byte BE seq + 64 × int16 BE @ 48 kHz).
+public class RadioMicReceiverTests
+{
+    // Build one 132-byte 1026 packet: 4-byte BE seq + 64 × int16 BE samples.
+    private static byte[] BuildPacket(uint seq, Func<int, short> sampleAt)
+    {
+        var buf = new byte[RadioMicReceiver.PacketBytes];
+        BinaryPrimitives.WriteUInt32BigEndian(buf.AsSpan(0, 4), seq);
+        int b = 4;
+        for (int i = 0; i < RadioMicReceiver.PacketSamples; i++, b += 2)
+            BinaryPrimitives.WriteInt16BigEndian(buf.AsSpan(b, 2), sampleAt(i));
+        return buf;
+    }
+
+    [Fact]
+    public void ReBlocks_SixtyFourSamplePackets_IntoNineSixtySampleBlocks()
+    {
+        var blocks = new List<byte[]>();
+        var rx = new RadioMicReceiver(b => blocks.Add(b.ToArray()), NullLogger.Instance);
+
+        // 15 packets × 64 = 960 samples → exactly one 960-sample block.
+        for (uint i = 0; i < 15; i++)
+            rx.Accept(BuildPacket(i, _ => 8192));   // 8192/32768 = 0.25
+
+        Assert.Single(blocks);
+        Assert.Equal(RadioMicReceiver.OutputBlockSamples * 4, blocks[0].Length);
+
+        // Verify the decode: int16 8192 → f32 0.25, little-endian on the wire out.
+        float first = BinaryPrimitives.ReadSingleLittleEndian(blocks[0].AsSpan(0, 4));
+        Assert.Equal(0.25f, first, 5);
+
+        // 14 packets (896 samples) → no further block; remainder carried.
+        for (uint i = 15; i < 29; i++)
+            rx.Accept(BuildPacket(i, _ => 8192));
+        Assert.Single(blocks);
+
+        // One more packet (960 total) → second block emitted.
+        rx.Accept(BuildPacket(29, _ => 8192));
+        Assert.Equal(2, blocks.Count);
+    }
+
+    [Fact]
+    public void Reset_DropsRemainder_NoStitchAcrossSwitch()
+    {
+        var blocks = new List<byte[]>();
+        var rx = new RadioMicReceiver(b => blocks.Add(b.ToArray()), NullLogger.Instance);
+
+        // 10 packets (640 samples) accumulate, no block yet.
+        for (uint i = 0; i < 10; i++) rx.Accept(BuildPacket(i, _ => 16384));
+        Assert.Empty(blocks);
+
+        rx.Reset();   // source switch — drop the 640-sample remainder
+
+        // 15 fresh packets (960). Were the 640 NOT dropped, 640+960=1600 would
+        // emit a block at 960 with stale audio in front. After Reset the first
+        // block is purely the new audio and arrives only once 960 new samples land.
+        for (uint i = 0; i < 15; i++) rx.Accept(BuildPacket(i, _ => 16384));
+        Assert.Single(blocks);
+    }
+
+    [Fact]
+    public void RejectsUndersizedPacket()
+    {
+        var blocks = new List<byte[]>();
+        var rx = new RadioMicReceiver(b => blocks.Add(b.ToArray()), NullLogger.Instance);
+
+        rx.Accept(new byte[100]);   // < 132
+        Assert.Empty(blocks);
+        Assert.Equal(1, rx.TotalPacketsDropped);
+    }
+
+    // END-TO-END: a synthetic 64-sample 1026 feed, after re-blocking, reaches
+    // ProcessTxBlock and produces NON-ZERO IQ (external-ports plan, §3 / §10
+    // test register). Wires RadioMicReceiver → TxAudioIngest.OnMicPcmBytesFromRadioMic
+    // with a radio source armed, MOX on, and a stub engine that copies mic → I.
+    [Fact]
+    public void SyntheticPacketFeed_ReachesProcessTxBlock_ProducesNonZeroIq()
+    {
+        var engine = new CopyEngine { BlockSize = 1024 };
+        var ring = new TxIqRing();
+        var hub = new StreamingHub(new NullLogger<StreamingHub>());
+        using var ingest = new TxAudioIngest(
+            ring, () => engine, () => true, hub, new NullLogger<TxAudioIngest>());
+        ingest.SetActiveSource(TxAudioSource.RadioMic);   // arm the radio jack
+
+        var rx = new RadioMicReceiver(
+            block => ingest.OnMicPcmBytesFromRadioMic(block), NullLogger.Instance);
+
+        // Feed enough 64-sample packets to flush at least one WDSP block: WDSP
+        // wants 1024 samples; 1024/64 = 16 packets cover the first 960-sample mic
+        // block (15 pkts) plus carry — push 32 packets (2048 samples) to be safe.
+        for (uint i = 0; i < 32; i++)
+            rx.Accept(BuildPacket(i, _ => 16384));   // 0.5 amplitude
+
+        Assert.True(ingest.TotalTxBlocks >= 1);       // re-block reached WDSP
+        Assert.True(ring.Count > 0);                  // IQ produced and ringed
+
+        // Drain the ring (pairs) and confirm non-zero IQ samples are present.
+        int pairs = ring.Count;
+        bool nonZero = false;
+        for (int i = 0; i < pairs; i++)
+        {
+            var (iv, qv) = ring.Next(1.0);
+            if (iv != 0 || qv != 0) { nonZero = true; break; }
+        }
+        Assert.True(nonZero, "re-blocked radio-mic feed produced all-zero IQ");
+    }
+
+    // Minimal engine: copies mic mono into I (Q=0) so non-zero mic → non-zero IQ.
+    private sealed class CopyEngine : IDspEngine
+    {
+        public int BlockSize { get; set; } = 1024;
+        public int TxBlockSamples => BlockSize;
+        public int TxOutputSamples => BlockSize;
+
+        public int ProcessTxBlock(ReadOnlySpan<float> micMono, Span<float> iqInterleaved)
+        {
+            for (int i = 0; i < BlockSize; i++) { iqInterleaved[2 * i] = micMono[i]; iqInterleaved[2 * i + 1] = 0f; }
+            return BlockSize;
+        }
+
+        public int OpenChannel(int sampleRateHz, int pixelWidth) => 0;
+        public void CloseChannel(int channelId) { }
+        public void FeedIq(int channelId, ReadOnlySpan<double> interleavedIqSamples) { }
+        public void SetMode(int channelId, RxMode mode) { }
+        public void SetFilter(int channelId, int lowHz, int highHz) { }
+        public void SetVfoHz(int channelId, long vfoHz) { }
+        public void SetCtunShift(int channelId, int shiftHz) { }
+        public void SetAgcTop(int channelId, double topDb) { }
+        public void SetRxDisplayFastAttack(int channelId, bool fast) { }
+        public void SetRxAfGainDb(int channelId, double db) { }
+        public void SetNoiseReduction(int channelId, NrConfig cfg) { }
+        public void SetZoom(int channelId, int level) { }
+        public int ReadAudio(int channelId, Span<float> output) => 0;
+        public bool TryGetDisplayPixels(int channelId, DisplayPixout which, Span<float> dbOut) => false;
+        public bool TryGetTxDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
+        public bool TryGetPsFeedbackDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
+        public int OpenTxChannel(int outputRateHz = 48_000) => 0;
+        public void SetMox(bool moxOn) { }
+        public double GetRxaSignalDbm(int channelId) => -140.0;
+        public RxStageMeters GetRxStageMeters(int channelId) => RxStageMeters.Silent;
+        public void SetTxMode(RxMode mode) { }
+        public void SetTxFilter(int lowHz, int highHz) { }
+        public void SetTxPanelGain(double linearGain) { }
+        public void SetTxLevelerMaxGain(double maxGainDb) { }
+        public void SetTxTune(bool on) { }
+        public TxStageMeters GetTxStageMeters() => TxStageMeters.Silent;
+        public void SetTwoTone(bool on, double freq1, double freq2, double mag) { }
+        public void SetPsEnabled(bool enabled) { }
+        public void SetPsControl(bool autoCal, bool singleCal) { }
+        public void SetPsHold(bool hold) { }
+        public void SetPsAdvanced(bool ptol, double moxDelaySec, double loopDelaySec,
+                                  double ampDelayNs, double hwPeak, int ints, int spi) { }
+        public void SetPsHwPeak(double hwPeak) { }
+        public void FeedPsFeedbackBlock(ReadOnlySpan<float> txI, ReadOnlySpan<float> txQ,
+                                        ReadOnlySpan<float> rxI, ReadOnlySpan<float> rxQ) { }
+        public PsStageMeters GetPsStageMeters() => PsStageMeters.Silent;
+        public void ResetPs() { }
+        public void SavePsCorrection(string path) { }
+        public void RestorePsCorrection(string path) { }
+        public void SetCfcConfig(CfcConfig cfg) { }
+        public void SetTxMonitorEnabled(bool enabled) { }
+        public int ReadTxMonitorAudio(Span<float> output) => 0;
+        public bool IsTxMonitorOn => false;
+        public void Dispose() { }
+    }
+}

--- a/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
+++ b/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
@@ -368,4 +368,205 @@ public class TxAudioIngestTests
         Assert.NotNull(lastP2);
         Assert.Contains(lastP2!, v => v == 0.5f);   // not muted
     }
+
+    // ---- Atomic single-select gate (external-ports plan, §3) ----------------
+
+    // Default _activeSource is Host, so a radio-mic-tagged block is dropped under
+    // Host without ever reaching WDSP — host audio is byte/behaviour-identical to
+    // today (the host block tag == _activeSource == Host).
+    [Fact]
+    public void RadioMic_DroppedUnderHost_HostPasses()
+    {
+        var engine = new StubEngine { BlockSize = 1024 };
+        var ring = new TxIqRing();
+        var hub = new StreamingHub(new NullLogger<StreamingHub>());
+        using var ingest = new TxAudioIngest(
+            ring, () => engine, () => true, hub, new NullLogger<TxAudioIngest>());
+
+        Assert.Equal(MicBlockSource.Host, ingest.ActiveSource);   // default
+
+        var payload = BuildMicPcmPayload(_ => 0.5f);
+        ingest.OnMicPcmBytesFromRadioMic(payload);    // tag=RadioMic, armed=Host → drop
+        ingest.OnMicPcmBytesFromRadioMic(payload);
+        Assert.Equal(0, ingest.TotalMicSamples);      // radio mic never accumulated
+        Assert.Equal(2, ingest.DroppedFrames);
+
+        ingest.OnMicPcmBytesFromMic(payload);         // host passes
+        Assert.Equal(MicBlockSamples, ingest.TotalMicSamples);
+    }
+
+    // Arm a radio jack: the host mic is dropped immediately by the in-lock tag
+    // compare (no overlap window), and the radio-mic stream flows.
+    [Fact]
+    public void HostSuppressedUnderRadioSource_RadioFlows()
+    {
+        var engine = new StubEngine { BlockSize = 1024 };
+        var ring = new TxIqRing();
+        var hub = new StreamingHub(new NullLogger<StreamingHub>());
+        using var ingest = new TxAudioIngest(
+            ring, () => engine, () => true, hub, new NullLogger<TxAudioIngest>());
+
+        ingest.SetActiveSource(TxAudioSource.RadioMic);
+        Assert.Equal(MicBlockSource.RadioMic, ingest.ActiveSource);
+
+        var payload = BuildMicPcmPayload(_ => 0.5f);
+        ingest.OnMicPcmBytesFromMic(payload);         // host tag, radio armed → drop
+        ingest.OnMicPcmBytesFromMic(payload);
+        Assert.Equal(0, ingest.TotalMicSamples);
+
+        ingest.OnMicPcmBytesFromRadioMic(payload);    // radio passes
+        Assert.Equal(MicBlockSamples, ingest.TotalMicSamples);
+    }
+
+    // SetActiveSource quiesces the WDSP accumulator on a switch so no half-block
+    // of the old source survives onto the new source.
+    [Fact]
+    public void SourceSwitch_ClearsAccumulator()
+    {
+        var engine = new StubEngine { BlockSize = 1024 };
+        var ring = new TxIqRing();
+        var hub = new StreamingHub(new NullLogger<StreamingHub>());
+        using var ingest = new TxAudioIngest(
+            ring, () => engine, () => true, hub, new NullLogger<TxAudioIngest>());
+
+        var payload = BuildMicPcmPayload(_ => 0.5f);
+        ingest.OnMicPcmBytesFromMic(payload);     // 960 host samples sit in accumulator (< 1024)
+        Assert.Equal(0, engine.ProcessedBlocks);  // no flush yet
+
+        ingest.SetActiveSource(TxAudioSource.RadioMic);   // switch → accumulator cleared
+
+        // Feed exactly one 960-sample radio block: were the 960 host samples NOT
+        // cleared, 960+960=1920 ≥ 1024 would flush a block. After the clear, a
+        // single radio block is still < 1024, so still no flush — proving the
+        // pre-switch host audio did not stitch onto the radio audio.
+        ingest.OnMicPcmBytesFromRadioMic(payload);
+        Assert.Equal(0, engine.ProcessedBlocks);
+    }
+
+    // CONCURRENCY DOUBLE-FEED (external-ports plan, §3, the crux test): two
+    // producer threads — one host-tagged, one radio-tagged — hammer the ingest
+    // while the active source is flipped repeatedly underneath them. For every
+    // WDSP block, exactly one source may have contributed, because the host/radio
+    // arbitration is decided IN-LOCK against a single _activeSource snapshot. We
+    // assert (a) no exceptions / torn state, and (b) the WDSP block count never
+    // exceeds the number of accepted-source blocks (i.e. the rejected source's
+    // blocks never reached the accumulator and contributed to a flush).
+    [Fact]
+    public void ConcurrentHostAndRadio_AcrossSourceFlips_ExactlyOneSourcePerBlock()
+    {
+        // Counting engine: every block it processes MUST be uniform (all samples
+        // equal), because host blocks are all 0.25 and radio blocks are all 0.75.
+        // If the in-lock gate ever let two sources straddle one WDSP block, the
+        // accumulator would contain a 0.25/0.75 boundary and the block would be
+        // non-uniform → the engine flags it.
+        var engine = new UniformAssertEngine { BlockSize = 1024 };
+        var ring = new TxIqRing();
+        var hub = new StreamingHub(new NullLogger<StreamingHub>());
+        using var ingest = new TxAudioIngest(
+            ring, () => engine, () => true, hub, new NullLogger<TxAudioIngest>());
+
+        var hostPayload = BuildMicPcmPayload(_ => 0.25f);
+        var radioPayload = BuildMicPcmPayload(_ => 0.75f);
+
+        const int iterations = 5000;
+        using var start = new ManualResetEventSlim(false);
+        Exception? failure = null;
+
+        var hostThread = new Thread(() =>
+        {
+            start.Wait();
+            try { for (int i = 0; i < iterations; i++) ingest.OnMicPcmBytesFromMic(hostPayload); }
+            catch (Exception ex) { Volatile.Write(ref failure, ex); }
+        });
+        var radioThread = new Thread(() =>
+        {
+            start.Wait();
+            try { for (int i = 0; i < iterations; i++) ingest.OnMicPcmBytesFromRadioMic(radioPayload); }
+            catch (Exception ex) { Volatile.Write(ref failure, ex); }
+        });
+        var flipThread = new Thread(() =>
+        {
+            start.Wait();
+            for (int i = 0; i < iterations; i++)
+                ingest.SetActiveSource((i & 1) == 0 ? TxAudioSource.RadioMic : TxAudioSource.Host);
+        });
+
+        hostThread.Start();
+        radioThread.Start();
+        flipThread.Start();
+        start.Set();
+        hostThread.Join();
+        radioThread.Join();
+        flipThread.Join();
+
+        Assert.Null(failure);                   // no torn block ever reached WDSP
+        Assert.False(engine.SawMixedBlock);     // no block straddled both sources
+        Assert.True(engine.ProcessedBlocks > 0);// the path actually ran
+    }
+
+    // Engine that asserts every WDSP block is uniform (single source). A mixed
+    // block (host 0.25 + radio 0.75 in the same 1024 samples) sets SawMixedBlock.
+    private sealed class UniformAssertEngine : IDspEngine
+    {
+        public int BlockSize { get; set; } = 1024;
+        public int TxBlockSamples => BlockSize;
+        public int TxOutputSamples => BlockSize;
+        public int ProcessedBlocks { get; private set; }
+        public bool SawMixedBlock { get; private set; }
+
+        public int ProcessTxBlock(ReadOnlySpan<float> micMono, Span<float> iqInterleaved)
+        {
+            float first = micMono[0];
+            for (int i = 1; i < micMono.Length; i++)
+                if (micMono[i] != first) { SawMixedBlock = true; break; }
+            for (int i = 0; i < BlockSize; i++) { iqInterleaved[2 * i] = micMono[i]; iqInterleaved[2 * i + 1] = 0f; }
+            ProcessedBlocks++;
+            return BlockSize;
+        }
+
+        public int OpenChannel(int sampleRateHz, int pixelWidth) => 0;
+        public void CloseChannel(int channelId) { }
+        public void FeedIq(int channelId, ReadOnlySpan<double> interleavedIqSamples) { }
+        public void SetMode(int channelId, RxMode mode) { }
+        public void SetFilter(int channelId, int lowHz, int highHz) { }
+        public void SetVfoHz(int channelId, long vfoHz) { }
+        public void SetCtunShift(int channelId, int shiftHz) { }
+        public void SetAgcTop(int channelId, double topDb) { }
+        public void SetRxDisplayFastAttack(int channelId, bool fast) { }
+        public void SetRxAfGainDb(int channelId, double db) { }
+        public void SetNoiseReduction(int channelId, NrConfig cfg) { }
+        public void SetZoom(int channelId, int level) { }
+        public int ReadAudio(int channelId, Span<float> output) => 0;
+        public bool TryGetDisplayPixels(int channelId, DisplayPixout which, Span<float> dbOut) => false;
+        public bool TryGetTxDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
+        public bool TryGetPsFeedbackDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
+        public int OpenTxChannel(int outputRateHz = 48_000) => 0;
+        public void SetMox(bool moxOn) { }
+        public double GetRxaSignalDbm(int channelId) => -140.0;
+        public RxStageMeters GetRxStageMeters(int channelId) => RxStageMeters.Silent;
+        public void SetTxMode(RxMode mode) { }
+        public void SetTxFilter(int lowHz, int highHz) { }
+        public void SetTxPanelGain(double linearGain) { }
+        public void SetTxLevelerMaxGain(double maxGainDb) { }
+        public void SetTxTune(bool on) { }
+        public TxStageMeters GetTxStageMeters() => TxStageMeters.Silent;
+        public void SetTwoTone(bool on, double freq1, double freq2, double mag) { }
+        public void SetPsEnabled(bool enabled) { }
+        public void SetPsControl(bool autoCal, bool singleCal) { }
+        public void SetPsHold(bool hold) { }
+        public void SetPsAdvanced(bool ptol, double moxDelaySec, double loopDelaySec,
+                                  double ampDelayNs, double hwPeak, int ints, int spi) { }
+        public void SetPsHwPeak(double hwPeak) { }
+        public void FeedPsFeedbackBlock(ReadOnlySpan<float> txI, ReadOnlySpan<float> txQ,
+                                        ReadOnlySpan<float> rxI, ReadOnlySpan<float> rxQ) { }
+        public PsStageMeters GetPsStageMeters() => PsStageMeters.Silent;
+        public void ResetPs() { }
+        public void SavePsCorrection(string path) { }
+        public void RestorePsCorrection(string path) { }
+        public void SetCfcConfig(CfcConfig cfg) { }
+        public void SetTxMonitorEnabled(bool enabled) { }
+        public int ReadTxMonitorAudio(Span<float> output) => 0;
+        public bool IsTxMonitorOn => false;
+        public void Dispose() { }
+    }
 }

--- a/zeus-web/src/api/board-capabilities.test.ts
+++ b/zeus-web/src/api/board-capabilities.test.ts
@@ -46,6 +46,18 @@ describe('parseBoardCapabilities', () => {
     expect(caps.adcSupplyMv).toBe(UNKNOWN_BOARD_CAPABILITIES.adcSupplyMv);
     expect(caps.hasVolts).toBe(false);
     expect(caps.maxPowerWatts).toBe(UNKNOWN_BOARD_CAPABILITIES.maxPowerWatts);
+    // Phase 5 flags default false when absent (old server).
+    expect(caps.hasRx2AntennaPath).toBe(false);
+    expect(caps.hasHl2UserGpio).toBe(false);
+  });
+
+  it('parses the Phase 5 capability flags', () => {
+    const caps = parseBoardCapabilities({
+      hasRx2AntennaPath: true,
+      hasHl2UserGpio: true,
+    });
+    expect(caps.hasRx2AntennaPath).toBe(true);
+    expect(caps.hasHl2UserGpio).toBe(true);
   });
 
   it('rejects non-positive maxPowerWatts and falls back to default', () => {

--- a/zeus-web/src/api/board-capabilities.ts
+++ b/zeus-web/src/api/board-capabilities.ts
@@ -53,6 +53,13 @@ export interface BoardCapabilities {
   /** Board has the Hermes-Lite 2 mic/PTT/line-in front-end (register 0x14).
    *  HL2 only. Gates the HL2 audio front-end controls. */
   hermesLite2MicFrontEnd: boolean;
+  // ---- External-port control (Phase 5) ----
+  /** Board has a second RX antenna path (dual-Alex / dual-RX). True for the
+   *  dual-ADC boards (100D/200D/0x0A family). Gates the RX2-antenna selector. */
+  hasRx2AntennaPath: boolean;
+  /** Board has the 4-bit HL2 user GPIO (user_dig_out on register 0x14 C3[3:0]).
+   *  HL2 only. Gates the user GPIO toggle group. */
+  hasHl2UserGpio: boolean;
 }
 
 // Safe defaults matching Zeus.Contracts.BoardCapabilities.UnknownDefaults —
@@ -76,6 +83,8 @@ export const UNKNOWN_BOARD_CAPABILITIES: BoardCapabilities = {
   hasRxAntennaRelays: false,
   hasOnboardCodec: false,
   hermesLite2MicFrontEnd: false,
+  hasRx2AntennaPath: false,
+  hasHl2UserGpio: false,
 };
 
 export function parseBoardCapabilities(raw: unknown): BoardCapabilities {
@@ -128,6 +137,14 @@ export function parseBoardCapabilities(raw: unknown): BoardCapabilities {
       typeof r.hermesLite2MicFrontEnd === 'boolean'
         ? r.hermesLite2MicFrontEnd
         : UNKNOWN_BOARD_CAPABILITIES.hermesLite2MicFrontEnd,
+    hasRx2AntennaPath:
+      typeof r.hasRx2AntennaPath === 'boolean'
+        ? r.hasRx2AntennaPath
+        : UNKNOWN_BOARD_CAPABILITIES.hasRx2AntennaPath,
+    hasHl2UserGpio:
+      typeof r.hasHl2UserGpio === 'boolean'
+        ? r.hasHl2UserGpio
+        : UNKNOWN_BOARD_CAPABILITIES.hasHl2UserGpio,
   };
 }
 

--- a/zeus-web/src/api/board-capabilities.ts
+++ b/zeus-web/src/api/board-capabilities.ts
@@ -37,6 +37,22 @@ export interface BoardCapabilities {
    *  PA Settings panel's DX OUT subsection renders unconditionally but
    *  disables itself when this flag is false. */
   supportsAnvelinaDxOc: boolean;
+  // ---- External-port control (external-ports plan) ----
+  /** Board has switchable TX antenna relays (ANT1/2/3) — 0x0A / Saturn family
+   *  only. Gates the TX-antenna selector in the Radio Settings menu. */
+  hasTxAntennaRelays: boolean;
+  /** Board has switchable RX antenna relays (ANT1/2/3) via its Alex board.
+   *  True for every ANAN board; false for Hermes-Lite 2 (single jack — its
+   *  selection is clamped to ANT1 at the wire layer). Gates the RX-antenna
+   *  selector. */
+  hasRxAntennaRelays: boolean;
+  /** Board decodes the host audio stream (TLV320 codec) carrying the
+   *  Hermes-class mic/line-in front-end. True for ANAN; false for HL2 (no
+   *  stream codec). Gates the Hermes-class audio front-end controls. */
+  hasOnboardCodec: boolean;
+  /** Board has the Hermes-Lite 2 mic/PTT/line-in front-end (register 0x14).
+   *  HL2 only. Gates the HL2 audio front-end controls. */
+  hermesLite2MicFrontEnd: boolean;
 }
 
 // Safe defaults matching Zeus.Contracts.BoardCapabilities.UnknownDefaults —
@@ -56,6 +72,10 @@ export const UNKNOWN_BOARD_CAPABILITIES: BoardCapabilities = {
   hasHl2OptionalToggles: false,
   maxPowerWatts: 100,
   supportsAnvelinaDxOc: false,
+  hasTxAntennaRelays: false,
+  hasRxAntennaRelays: false,
+  hasOnboardCodec: false,
+  hermesLite2MicFrontEnd: false,
 };
 
 export function parseBoardCapabilities(raw: unknown): BoardCapabilities {
@@ -92,6 +112,22 @@ export function parseBoardCapabilities(raw: unknown): BoardCapabilities {
       typeof r.supportsAnvelinaDxOc === 'boolean'
         ? r.supportsAnvelinaDxOc
         : UNKNOWN_BOARD_CAPABILITIES.supportsAnvelinaDxOc,
+    hasTxAntennaRelays:
+      typeof r.hasTxAntennaRelays === 'boolean'
+        ? r.hasTxAntennaRelays
+        : UNKNOWN_BOARD_CAPABILITIES.hasTxAntennaRelays,
+    hasRxAntennaRelays:
+      typeof r.hasRxAntennaRelays === 'boolean'
+        ? r.hasRxAntennaRelays
+        : UNKNOWN_BOARD_CAPABILITIES.hasRxAntennaRelays,
+    hasOnboardCodec:
+      typeof r.hasOnboardCodec === 'boolean'
+        ? r.hasOnboardCodec
+        : UNKNOWN_BOARD_CAPABILITIES.hasOnboardCodec,
+    hermesLite2MicFrontEnd:
+      typeof r.hermesLite2MicFrontEnd === 'boolean'
+        ? r.hermesLite2MicFrontEnd
+        : UNKNOWN_BOARD_CAPABILITIES.hermesLite2MicFrontEnd,
   };
 }
 

--- a/zeus-web/src/api/board-capabilities.ts
+++ b/zeus-web/src/api/board-capabilities.ts
@@ -53,6 +53,19 @@ export interface BoardCapabilities {
   /** Board has the Hermes-Lite 2 mic/PTT/line-in front-end (register 0x14).
    *  HL2 only. Gates the HL2 audio front-end controls. */
   hermesLite2MicFrontEnd: boolean;
+  /** Board has an analog line-in jack selectable as the TX-audio source
+   *  (TxAudioSource.RadioLineIn). True for ANAN-200D + the whole 0x0A Saturn
+   *  family; false for pure Hermes-class P1, ANAN-G2E, Metis, HL2. Gates the
+   *  Line-In source option + its gain slider. */
+  hasRadioLineIn: boolean;
+  /** Board has a switchable balanced XLR mic input (TxAudioSource.RadioBalancedXlr).
+   *  Saturn-FPGA ANAN-G2 / G2-1K only. Gates the Balanced-XLR source option. */
+  hasBalancedXlr: boolean;
+  /** Board exposes the Orion mic-bias enable on its mic jack. True for
+   *  ANAN-200D / 7000DLE / 8000DLE / G2 / G2-1K / ANVELINA-PRO3; false for
+   *  Red Pitaya, Hermes-class, ANAN-G2E, Metis, HL2. Gates the (confirmation-
+   *  guarded) mic-bias toggle that appears with RadioMic. */
+  hasMicBias: boolean;
   // ---- External-port control (Phase 5) ----
   /** Board has a second RX antenna path (dual-Alex / dual-RX). True for the
    *  dual-ADC boards (100D/200D/0x0A family). Gates the RX2-antenna selector. */
@@ -83,6 +96,9 @@ export const UNKNOWN_BOARD_CAPABILITIES: BoardCapabilities = {
   hasRxAntennaRelays: false,
   hasOnboardCodec: false,
   hermesLite2MicFrontEnd: false,
+  hasRadioLineIn: false,
+  hasBalancedXlr: false,
+  hasMicBias: false,
   hasRx2AntennaPath: false,
   hasHl2UserGpio: false,
 };
@@ -137,6 +153,18 @@ export function parseBoardCapabilities(raw: unknown): BoardCapabilities {
       typeof r.hermesLite2MicFrontEnd === 'boolean'
         ? r.hermesLite2MicFrontEnd
         : UNKNOWN_BOARD_CAPABILITIES.hermesLite2MicFrontEnd,
+    hasRadioLineIn:
+      typeof r.hasRadioLineIn === 'boolean'
+        ? r.hasRadioLineIn
+        : UNKNOWN_BOARD_CAPABILITIES.hasRadioLineIn,
+    hasBalancedXlr:
+      typeof r.hasBalancedXlr === 'boolean'
+        ? r.hasBalancedXlr
+        : UNKNOWN_BOARD_CAPABILITIES.hasBalancedXlr,
+    hasMicBias:
+      typeof r.hasMicBias === 'boolean'
+        ? r.hasMicBias
+        : UNKNOWN_BOARD_CAPABILITIES.hasMicBias,
     hasRx2AntennaPath:
       typeof r.hasRx2AntennaPath === 'boolean'
         ? r.hasRx2AntennaPath

--- a/zeus-web/src/components/RadioSettingsPanel.test.tsx
+++ b/zeus-web/src/components/RadioSettingsPanel.test.tsx
@@ -1,0 +1,320 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// RadioSettingsPanel — Pass D behavior gates (external-ports plan §6/§7/§8):
+//   1. TX-audio source is SINGLE-SELECT — a radio-button group where exactly
+//      one option is checked; selecting another deselects the prior (the old
+//      multi-checkbox bug is structurally impossible).
+//   2. DEFAULT-OFF — on first render with the server-authoritative store at its
+//      default, Host is selected and every param control (boost/bias/gain) is
+//      hidden / off. Nothing comes up engaged.
+//   3. Dependent params are visible ONLY for the active source.
+//   4. Board-gating — HL2 is Host-only (no Mic/Line/Balanced); Balanced renders
+//      only when hasBalancedXlr (G2 / G2-1K).
+//
+// Uses the project's createRoot + act idiom (see SettingsMenu.test.tsx); no RTL.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { RadioSettingsPanel } from './RadioSettingsPanel';
+import { useRadioStore } from '../state/radio-store';
+import { useAudioStore, type TxAudioSource } from '../state/audio-store';
+import { useAntennaStore } from '../state/antenna-store';
+import { usePttStore } from '../state/ptt-store';
+import { useHl2GpioStore } from '../state/hl2-gpio-store';
+import {
+  UNKNOWN_BOARD_CAPABILITIES,
+  type BoardCapabilities,
+} from '../api/board-capabilities';
+
+// A fully-featured Saturn-class fingerprint: codec + line-in + balanced XLR +
+// mic-bias. The board-gating tests trim flags off this.
+const G2_CAPS: Partial<BoardCapabilities> = {
+  hasOnboardCodec: true,
+  hasRadioLineIn: true,
+  hasBalancedXlr: true,
+  hasMicBias: true,
+};
+
+// HL2: no codec, no radio jacks — the mic front-end flag is set but
+// hasOnboardCodec is false, which is the Host-only collapse.
+const HL2_CAPS: Partial<BoardCapabilities> = {
+  hasOnboardCodec: false,
+  hermesLite2MicFrontEnd: true,
+};
+
+function seedCaps(overrides: Partial<BoardCapabilities>) {
+  useRadioStore.setState((s) => ({
+    ...s,
+    capabilities: { ...UNKNOWN_BOARD_CAPABILITIES, ...overrides },
+  }));
+}
+
+function seedAudio(
+  source: TxAudioSource,
+  params?: Partial<{ micBoost: boolean; micBias: boolean; lineInGain: number }>,
+) {
+  useAudioStore.setState((s) => ({
+    ...s,
+    settings: {
+      ...s.settings,
+      source,
+      micBoost: params?.micBoost ?? false,
+      micBias: params?.micBias ?? false,
+      lineInGain: params?.lineInGain ?? 0,
+    },
+    loaded: true,
+    inflight: false,
+  }));
+}
+
+// The panel's mount effect fires four GET loads (load/loadAudio/loadGpio/
+// loadPtt). Those flip `inflight` true and would clobber the directly-seeded
+// store state with the (empty) fetch response. Neutralize them to no-ops so the
+// test renders exactly the seeded server-authoritative state — which is also
+// the precise hydration path the panel relies on. We assert against the seeded
+// state, not a live fetch.
+function stubLoaders() {
+  vi.spyOn(useAntennaStore.getState(), 'load').mockResolvedValue();
+  vi.spyOn(useAudioStore.getState(), 'load').mockResolvedValue();
+  vi.spyOn(useHl2GpioStore.getState(), 'load').mockResolvedValue();
+  vi.spyOn(usePttStore.getState(), 'load').mockResolvedValue();
+  vi.stubGlobal(
+    'fetch',
+    vi.fn<typeof fetch>().mockResolvedValue(
+      new Response('{}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+}
+
+// Source radio buttons live in the role="radiogroup" labelled "TX audio source".
+function sourceButtons(container: HTMLElement): HTMLButtonElement[] {
+  const group = container.querySelector(
+    '[role="radiogroup"][aria-label="TX audio source"]',
+  );
+  if (!group) return [];
+  return Array.from(group.querySelectorAll<HTMLButtonElement>('button[role="radio"]'));
+}
+
+function labelOf(b: HTMLButtonElement): string {
+  return b.textContent?.trim() ?? '';
+}
+
+describe('RadioSettingsPanel — TX audio source (Pass D)', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    // Reset shared stores so order-independent.
+    useAntennaStore.setState((s) => ({ ...s, loaded: true, inflight: false }));
+    usePttStore.getState().__resetForTests();
+    useHl2GpioStore.setState((s) => ({ ...s, state: { supported: false, bits: 0 } }));
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    seedCaps({});
+    seedAudio('Host');
+  });
+
+  function render() {
+    stubLoaders();
+    act(() => {
+      root.render(<RadioSettingsPanel />);
+    });
+  }
+
+  it('single-select: exactly one source button is checked', () => {
+    seedCaps(G2_CAPS);
+    seedAudio('Host');
+    render();
+    const btns = sourceButtons(container);
+    expect(btns.length).toBeGreaterThan(1);
+    const checked = btns.filter((b) => b.getAttribute('aria-checked') === 'true');
+    expect(checked).toHaveLength(1);
+    expect(labelOf(checked[0]!)).toBe('Host');
+  });
+
+  it('selecting another source deselects the prior (mutual exclusion)', () => {
+    seedCaps(G2_CAPS);
+    seedAudio('RadioMic');
+    render();
+    const checked = sourceButtons(container).filter(
+      (b) => b.getAttribute('aria-checked') === 'true',
+    );
+    expect(checked).toHaveLength(1);
+    expect(labelOf(checked[0]!)).toBe('Radio Mic');
+    // Host is NOT also checked — single value, not independent toggles.
+    const host = sourceButtons(container).find((b) => labelOf(b) === 'Host')!;
+    expect(host.getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('clicking a source button calls the store update with the new source', () => {
+    seedCaps(G2_CAPS);
+    seedAudio('Host');
+    const spy = vi.spyOn(useAudioStore.getState(), 'update').mockResolvedValue();
+    render();
+    const lineIn = sourceButtons(container).find(
+      (b) => labelOf(b) === 'Radio Line In',
+    )!;
+    act(() => lineIn.click());
+    expect(spy).toHaveBeenCalledWith({ source: 'RadioLineIn' });
+    spy.mockRestore();
+  });
+
+  it('DEFAULT-OFF: Host selected, no param controls, nothing engaged on first render', () => {
+    seedCaps(G2_CAPS);
+    seedAudio('Host'); // the store default
+    render();
+    const checked = sourceButtons(container).filter(
+      (b) => b.getAttribute('aria-checked') === 'true',
+    );
+    expect(checked).toHaveLength(1);
+    expect(labelOf(checked[0]!)).toBe('Host');
+    // No dependent-param controls render under Host.
+    expect(container.textContent).not.toContain('Mic Boost');
+    expect(container.textContent).not.toContain('Mic Bias');
+    expect(container.textContent).not.toContain('Line-In Gain');
+    // No checkbox anywhere in the audio card comes up checked.
+    const audioChecks = Array.from(
+      container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
+    );
+    // PTT Enable defaults ON, so filter to the audio card by proximity to the
+    // audio labels — simplest: assert NONE of the audio param toggles exist.
+    expect(audioChecks.every((c) => c.checked === false || c.closest('.ps-card')))
+      .toBe(true);
+  });
+
+  it('dependent params: Mic Boost + Mic Bias show under RadioMic, gain hidden', () => {
+    seedCaps(G2_CAPS);
+    seedAudio('RadioMic');
+    render();
+    expect(container.textContent).toContain('Mic Boost');
+    expect(container.textContent).toContain('Mic Bias');
+    expect(container.textContent).not.toContain('Line-In Gain');
+  });
+
+  it('dependent params: Line-In Gain shows under RadioLineIn, mic params hidden', () => {
+    seedCaps(G2_CAPS);
+    seedAudio('RadioLineIn');
+    render();
+    expect(container.textContent).toContain('Line-In Gain');
+    expect(container.textContent).not.toContain('Mic Boost');
+    expect(container.textContent).not.toContain('Mic Bias');
+  });
+
+  it('mic-bias toggle only appears when hasMicBias is set', () => {
+    seedCaps({ ...G2_CAPS, hasMicBias: false });
+    seedAudio('RadioMic');
+    render();
+    expect(container.textContent).toContain('Mic Boost');
+    expect(container.textContent).not.toContain('Mic Bias');
+  });
+
+  it('mic-bias enable is gated behind a confirmation (declining keeps it off)', () => {
+    seedCaps(G2_CAPS);
+    seedAudio('RadioMic', { micBias: false });
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    const updateSpy = vi
+      .spyOn(useAudioStore.getState(), 'update')
+      .mockResolvedValue();
+    render();
+    const biasCheckbox = Array.from(
+      container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
+    ).find((c) => c.closest('.ps-field')?.textContent?.includes('Mic Bias'))!;
+    expect(biasCheckbox).toBeDefined();
+    act(() => biasCheckbox.click());
+    expect(confirmSpy).toHaveBeenCalled();
+    // Declined → no update pushed.
+    expect(updateSpy).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+    updateSpy.mockRestore();
+  });
+
+  it('mic-bias enable proceeds when the confirmation is accepted', () => {
+    seedCaps(G2_CAPS);
+    seedAudio('RadioMic', { micBias: false });
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const updateSpy = vi
+      .spyOn(useAudioStore.getState(), 'update')
+      .mockResolvedValue();
+    render();
+    const biasCheckbox = Array.from(
+      container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
+    ).find((c) => c.closest('.ps-field')?.textContent?.includes('Mic Bias'))!;
+    act(() => biasCheckbox.click());
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(updateSpy).toHaveBeenCalledWith({ micBias: true });
+    confirmSpy.mockRestore();
+    updateSpy.mockRestore();
+  });
+});
+
+describe('RadioSettingsPanel — board-gating (Pass D)', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAntennaStore.setState((s) => ({ ...s, loaded: true, inflight: false }));
+    usePttStore.getState().__resetForTests();
+    useHl2GpioStore.setState((s) => ({ ...s, state: { supported: false, bits: 0 } }));
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    seedCaps({});
+    seedAudio('Host');
+  });
+
+  function render() {
+    stubLoaders();
+    act(() => {
+      root.render(<RadioSettingsPanel />);
+    });
+  }
+
+  it('HL2: Host-only — no Mic / Line / Balanced source options', () => {
+    seedCaps(HL2_CAPS);
+    seedAudio('Host');
+    render();
+    // No segmented radio group at all on HL2; a "USB / Ethernet" note instead.
+    expect(sourceButtons(container)).toHaveLength(0);
+    expect(container.textContent).toContain('USB / Ethernet');
+    expect(container.textContent).not.toContain('Radio Mic');
+    expect(container.textContent).not.toContain('Radio Line In');
+    expect(container.textContent).not.toContain('Radio Balanced');
+  });
+
+  it('Balanced renders only when hasBalancedXlr (G2 / G2-1K)', () => {
+    seedCaps(G2_CAPS);
+    seedAudio('Host');
+    render();
+    const labels = sourceButtons(container).map(labelOf);
+    expect(labels).toEqual(['Host', 'Radio Mic', 'Radio Line In', 'Radio Balanced']);
+  });
+
+  it('non-Saturn codec board: no Balanced option', () => {
+    seedCaps({ hasOnboardCodec: true, hasBalancedXlr: false, hasRadioLineIn: false });
+    seedAudio('Host');
+    render();
+    const labels = sourceButtons(container).map(labelOf);
+    expect(labels).toEqual(['Host', 'Radio Mic']);
+    expect(labels).not.toContain('Radio Balanced');
+  });
+});

--- a/zeus-web/src/components/RadioSettingsPanel.tsx
+++ b/zeus-web/src/components/RadioSettingsPanel.tsx
@@ -28,6 +28,7 @@ import {
 } from '../state/antenna-store';
 import { useAudioStore } from '../state/audio-store';
 import { useHl2GpioStore } from '../state/hl2-gpio-store';
+import { usePttStore } from '../state/ptt-store';
 import { bandOf } from './design/data';
 
 const ANTENNAS: AntennaName[] = ['Ant1', 'Ant2', 'Ant3'];
@@ -70,11 +71,22 @@ export function RadioSettingsPanel() {
   const loadGpio = useHl2GpioStore((s) => s.load);
   const setGpioBit = useHl2GpioStore((s) => s.setBit);
 
+  // Hardware PTT-IN (footswitch / mic-PTT / rear-KEY). Every board has one, so
+  // this card is ungated. `keyed` is driven live by the PttStatusFrame WS edge
+  // (per-protocol source server-side); `enabled` / `hangMs` hydrate from REST.
+  const pttKeyed = usePttStore((s) => s.keyed);
+  const pttEnabled = usePttStore((s) => s.enabled);
+  const pttHangMs = usePttStore((s) => s.hangMs);
+  const pttInflight = usePttStore((s) => s.inflight);
+  const loadPtt = usePttStore((s) => s.load);
+  const setPttEnabled = usePttStore((s) => s.setEnabled);
+
   useEffect(() => {
     load();
     loadAudio();
     loadGpio();
-  }, [load, loadAudio, loadGpio]);
+    loadPtt();
+  }, [load, loadAudio, loadGpio, loadPtt]);
 
   const band = bandOf(vfoHz);
   const onBand = band !== '—';
@@ -360,6 +372,70 @@ export function RadioSettingsPanel() {
           )}
         </div>
       ) : null}
+
+      <div className="ps-card">
+        <h4>
+          <svg className="ps-ic-sm" viewBox="0 0 12 12">
+            <path d="M6 1v4M3.5 5h5v3a2.5 2.5 0 0 1-5 0z" />
+          </svg>
+          PTT-IN
+          <span className="ps-card-hint">footswitch / mic-PTT / rear KEY</span>
+        </h4>
+
+        <div className="ps-field">
+          <div className="ps-name">
+            Status
+            <em>
+              Live hardware PTT-IN level. Read-only — the radio drives this when
+              you press the footswitch / mic PTT (or ground the rear KEY).
+            </em>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <span
+              aria-hidden
+              style={{
+                width: '0.6rem',
+                height: '0.6rem',
+                borderRadius: '50%',
+                background: pttKeyed ? 'var(--tx)' : 'var(--fg-3)',
+                boxShadow: pttKeyed ? '0 0 6px var(--tx-soft)' : 'none',
+                transition: 'background 60ms linear',
+              }}
+            />
+            <span style={{ color: pttKeyed ? 'var(--tx)' : 'var(--fg-2)' }}>
+              {pttKeyed ? 'KEYED' : 'idle'}
+            </span>
+          </div>
+        </div>
+
+        <div className="ps-field">
+          <div className="ps-name">
+            Enable
+            <em>
+              When off, the footswitch is ignored for keying (UI-only TX). The
+              lamp above still shows the physical input.
+            </em>
+          </div>
+          <label className="ps-check">
+            <input
+              type="checkbox"
+              checked={pttEnabled}
+              disabled={pttInflight}
+              onChange={(e) => void setPttEnabled(e.target.checked)}
+            />
+            <span className="ps-check-box" />
+            <span>Hardware PTT → MOX</span>
+          </label>
+        </div>
+
+        <div className="ps-field">
+          <div className="ps-name">
+            Hang
+            <em>Release hang time — bridges CW inter-character gaps. Fixed for now.</em>
+          </div>
+          <span style={{ color: 'var(--fg-2)' }}>{pttHangMs} ms</span>
+        </div>
+      </div>
 
       {caps.hasHl2UserGpio && gpio.supported ? (
         <div className="ps-card">

--- a/zeus-web/src/components/RadioSettingsPanel.tsx
+++ b/zeus-web/src/components/RadioSettingsPanel.tsx
@@ -24,8 +24,10 @@ import { useRadioStore } from '../state/radio-store';
 import {
   useAntennaStore,
   type AntennaName,
+  type RxAuxName,
 } from '../state/antenna-store';
 import { useAudioStore } from '../state/audio-store';
+import { useHl2GpioStore } from '../state/hl2-gpio-store';
 import { bandOf } from './design/data';
 
 const ANTENNAS: AntennaName[] = ['Ant1', 'Ant2', 'Ant3'];
@@ -34,6 +36,17 @@ const ANTENNA_LABEL: Record<AntennaName, string> = {
   Ant2: 'ANT 2',
   Ant3: 'ANT 3',
 };
+
+const RX_AUX_LABEL: Record<RxAuxName, string> = {
+  None: 'Base ANT',
+  Ext1: 'EXT 1',
+  Ext2: 'EXT 2',
+  Xvtr: 'XVTR IN',
+  Bypass: 'RX BYPASS',
+};
+
+// HL2 user GPIO line labels (4-bit user_dig_out → MCP23008).
+const GPIO_LINES = [0, 1, 2, 3] as const;
 
 export function RadioSettingsPanel() {
   const vfoHz = useConnectionStore((s) => s.vfoHz);
@@ -52,24 +65,37 @@ export function RadioSettingsPanel() {
   const hasCodecAudio = caps.hasOnboardCodec;
   const hasHl2Audio = caps.hermesLite2MicFrontEnd;
 
+  const gpio = useHl2GpioStore((s) => s.state);
+  const gpioInflight = useHl2GpioStore((s) => s.inflight);
+  const loadGpio = useHl2GpioStore((s) => s.load);
+  const setGpioBit = useHl2GpioStore((s) => s.setBit);
+
   useEffect(() => {
     load();
     loadAudio();
-  }, [load, loadAudio]);
+    loadGpio();
+  }, [load, loadAudio, loadGpio]);
 
   const band = bandOf(vfoHz);
   const onBand = band !== '—';
   const current = settings.bands.find((b) => b.band === band);
   const txAnt: AntennaName = current?.txAnt ?? 'Ant1';
   const rxAnt: AntennaName = current?.rxAnt ?? 'Ant1';
+  const rxAux: RxAuxName = current?.rxAux ?? 'None';
+  const auxOptions: RxAuxName[] = ['None', ...settings.availableRxAux];
+  const showAux = settings.availableRxAux.length > 0;
 
   const onSetTx = (next: AntennaName) => {
     if (!onBand) return;
-    void setBand(band, next, rxAnt);
+    void setBand(band, next, rxAnt, rxAux);
   };
   const onSetRx = (next: AntennaName) => {
     if (!onBand) return;
-    void setBand(band, txAnt, next);
+    void setBand(band, txAnt, next, rxAux);
+  };
+  const onSetRxAux = (next: RxAuxName) => {
+    if (!onBand) return;
+    void setBand(band, txAnt, rxAnt, next);
   };
 
   const statusText = inflight
@@ -141,6 +167,47 @@ export function RadioSettingsPanel() {
                   {ANTENNA_LABEL[a]}
                 </option>
               ))}
+            </select>
+          </div>
+        ) : null}
+
+        {showAux ? (
+          <div className="ps-field">
+            <div className="ps-name">
+              RX Aux Input
+              <em>
+                Auxiliary receive feed (EXT / transverter / RX-bypass) for
+                {onBand ? ` ${band}` : ' the current band'}. While PureSignal is
+                armed it keeps control of the RX-bypass coupler.
+              </em>
+            </div>
+            <select
+              className="ps-select-mini"
+              value={rxAux}
+              disabled={!onBand || inflight}
+              onChange={(e) => onSetRxAux(e.target.value as RxAuxName)}
+            >
+              {auxOptions.map((a) => (
+                <option key={a} value={a}>
+                  {RX_AUX_LABEL[a]}
+                </option>
+              ))}
+            </select>
+          </div>
+        ) : null}
+
+        {caps.hasRx2AntennaPath ? (
+          <div className="ps-field">
+            <div className="ps-name">
+              RX2 Antenna
+              <em>
+                Second-receiver antenna path (dual-RX boards). Per-board wire
+                emission is pending bench verification on a 100D/200D — the
+                selector is not yet active.
+              </em>
+            </div>
+            <select className="ps-select-mini" value="Ant1" disabled>
+              <option value="Ant1">ANT 1</option>
             </select>
           </div>
         ) : null}
@@ -263,6 +330,44 @@ export function RadioSettingsPanel() {
                 }
               }}
             />
+          </div>
+        </div>
+      ) : null}
+
+      {caps.hasHl2UserGpio && gpio.supported ? (
+        <div className="ps-card">
+          <h4>
+            <svg className="ps-ic-sm" viewBox="0 0 12 12">
+              <path d="M2 6h2M8 6h2M6 2v2M6 8v2M4 4h4v4H4z" />
+            </svg>
+            User GPIO
+            <span className="ps-card-hint">HL2 — 4 digital outputs</span>
+          </h4>
+          <div className="ps-field">
+            <div className="ps-name">
+              Output Lines
+              <em>
+                The four user-controllable digital output pins (user_dig_out →
+                MCP23008). Operator-defined; wire to whatever your station needs.
+              </em>
+            </div>
+            <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+              {GPIO_LINES.map((bit) => {
+                const on = (gpio.bits & (1 << bit)) !== 0;
+                return (
+                  <label className="ps-check" key={bit}>
+                    <input
+                      type="checkbox"
+                      checked={on}
+                      disabled={gpioInflight}
+                      onChange={(e) => void setGpioBit(bit, e.target.checked)}
+                    />
+                    <span className="ps-check-box" />
+                    <span>OUT {bit}</span>
+                  </label>
+                );
+              })}
+            </div>
           </div>
         </div>
       ) : null}

--- a/zeus-web/src/components/RadioSettingsPanel.tsx
+++ b/zeus-web/src/components/RadioSettingsPanel.tsx
@@ -25,6 +25,7 @@ import {
   useAntennaStore,
   type AntennaName,
 } from '../state/antenna-store';
+import { useAudioStore } from '../state/audio-store';
 import { bandOf } from './design/data';
 
 const ANTENNAS: AntennaName[] = ['Ant1', 'Ant2', 'Ant3'];
@@ -44,9 +45,17 @@ export function RadioSettingsPanel() {
   const load = useAntennaStore((s) => s.load);
   const setBand = useAntennaStore((s) => s.setBand);
 
+  const audio = useAudioStore((s) => s.settings);
+  const audioInflight = useAudioStore((s) => s.inflight);
+  const loadAudio = useAudioStore((s) => s.load);
+  const updateAudio = useAudioStore((s) => s.update);
+  const hasCodecAudio = caps.hasOnboardCodec;
+  const hasHl2Audio = caps.hermesLite2MicFrontEnd;
+
   useEffect(() => {
     load();
-  }, [load]);
+    loadAudio();
+  }, [load, loadAudio]);
 
   const band = bandOf(vfoHz);
   const onBand = band !== '—';
@@ -136,6 +145,127 @@ export function RadioSettingsPanel() {
           </div>
         ) : null}
       </div>
+
+      {hasCodecAudio || hasHl2Audio ? (
+        <div className="ps-card">
+          <h4>
+            <svg className="ps-ic-sm" viewBox="0 0 12 12">
+              <path d="M6 1a2 2 0 0 1 2 2v3a2 2 0 0 1-4 0V3a2 2 0 0 1 2-2zM3 6a3 3 0 0 0 6 0M6 9v2" />
+            </svg>
+            Audio Input
+            <span className="ps-card-hint">
+              {hasHl2Audio ? 'mic / line front-end' : 'mic / line-in'}
+            </span>
+          </h4>
+
+          {/* Line-in vs mic select — present on both codec and HL2 paths. */}
+          <div className="ps-field">
+            <div className="ps-name">
+              Input Source
+              <em>
+                Select the line-in jack instead of the microphone input.
+              </em>
+            </div>
+            <label className="ps-check">
+              <input
+                type="checkbox"
+                checked={audio.lineIn}
+                disabled={audioInflight}
+                onChange={(e) => void updateAudio({ lineIn: e.target.checked })}
+              />
+              <span className="ps-check-box" />
+              <span>{audio.lineIn ? 'Line In' : 'Microphone'}</span>
+            </label>
+          </div>
+
+          {/* Mic boost — Hermes-class codec boards only. */}
+          {hasCodecAudio ? (
+            <div className="ps-field">
+              <div className="ps-name">
+                Mic Boost
+                <em>+20 dB microphone preamp boost.</em>
+              </div>
+              <label className="ps-check">
+                <input
+                  type="checkbox"
+                  checked={audio.micBoost}
+                  disabled={audioInflight}
+                  onChange={(e) => void updateAudio({ micBoost: e.target.checked })}
+                />
+                <span className="ps-check-box" />
+                <span>{audio.micBoost ? 'On' : 'Off'}</span>
+              </label>
+            </div>
+          ) : null}
+
+          {/* Balanced / TRS input — HL2 mic_trs (balanced) or Saturn XLR. */}
+          <div className="ps-field">
+            <div className="ps-name">
+              Balanced Input
+              <em>
+                {hasHl2Audio
+                  ? 'Use the TRS (balanced) mic pin on the HL2 front-end.'
+                  : 'Select the balanced (XLR) microphone input.'}
+              </em>
+            </div>
+            <label className="ps-check">
+              <input
+                type="checkbox"
+                checked={audio.balancedInput}
+                disabled={audioInflight}
+                onChange={(e) => void updateAudio({ balancedInput: e.target.checked })}
+              />
+              <span className="ps-check-box" />
+              <span>{audio.balancedInput ? 'Balanced' : 'Standard'}</span>
+            </label>
+          </div>
+
+          {/* Mic bias — DEFAULTS OFF, floating-connector PTT-hang guard. */}
+          <div className="ps-field">
+            <div className="ps-name">
+              Mic Bias
+              <em>
+                Supply bias voltage for electret microphones. Leave OFF unless
+                your mic needs it — enabling it on a floating / unconnected
+                connector can hang PTT.
+              </em>
+            </div>
+            <label className="ps-check">
+              <input
+                type="checkbox"
+                checked={audio.micBias}
+                disabled={audioInflight}
+                onChange={(e) => void updateAudio({ micBias: e.target.checked })}
+              />
+              <span className="ps-check-box" />
+              <span>{audio.micBias ? 'On' : 'Off (default)'}</span>
+            </label>
+          </div>
+
+          {/* Line-in gain 0..31 — present on both paths. */}
+          <div className="ps-field">
+            <div className="ps-name">
+              Line-In Gain
+              <em>Line-in input gain (0–31).</em>
+            </div>
+            <input
+              className="ps-select-mini"
+              type="number"
+              min={0}
+              max={31}
+              step={1}
+              value={audio.lineInGain}
+              disabled={audioInflight}
+              onChange={(e) => {
+                const n = Number.parseInt(e.target.value, 10);
+                if (!Number.isNaN(n)) {
+                  void updateAudio({ lineInGain: Math.min(31, Math.max(0, n)) });
+                }
+              }}
+            />
+          </div>
+        </div>
+      ) : null}
 
       <div className="ps-status-row">
         <div className="ps-status-left">

--- a/zeus-web/src/components/RadioSettingsPanel.tsx
+++ b/zeus-web/src/components/RadioSettingsPanel.tsx
@@ -225,112 +225,139 @@ export function RadioSettingsPanel() {
             </span>
           </h4>
 
-          {/* Line-in vs mic select — present on both codec and HL2 paths. */}
-          <div className="ps-field">
-            <div className="ps-name">
-              Input Source
-              <em>
-                Select the line-in jack instead of the microphone input.
-              </em>
-            </div>
-            <label className="ps-check">
-              <input
-                type="checkbox"
-                checked={audio.lineIn}
-                disabled={audioInflight}
-                onChange={(e) => void updateAudio({ lineIn: e.target.checked })}
-              />
-              <span className="ps-check-box" />
-              <span>{audio.lineIn ? 'Line In' : 'Microphone'}</span>
-            </label>
-          </div>
-
-          {/* Mic boost — Hermes-class codec boards only. */}
-          {hasCodecAudio ? (
+          {/* HL2 has no codec → Host-only; render a note, no picker. */}
+          {hasHl2Audio && !hasCodecAudio ? (
             <div className="ps-field">
               <div className="ps-name">
-                Mic Boost
-                <em>+20 dB microphone preamp boost.</em>
+                TX Audio Source
+                <em>
+                  Hermes-Lite 2 has no onboard audio codec — TX audio comes from
+                  the host (USB / Ethernet) only.
+                </em>
               </div>
-              <label className="ps-check">
-                <input
-                  type="checkbox"
-                  checked={audio.micBoost}
+              <select className="ps-select-mini" value="Host" disabled>
+                <option value="Host">Host</option>
+              </select>
+            </div>
+          ) : (
+            <>
+              {/* Single-select TX-audio source — board-gated, cannot
+                  double-pick. Host always present; radio jacks render only when
+                  the connected board exposes them. */}
+              <div className="ps-field">
+                <div className="ps-name">
+                  TX Audio Source
+                  <em>
+                    Which input feeds the transmitter. Host uses the computer
+                    mic / audio chain; the radio options digitize the rig's own
+                    analog jacks.
+                  </em>
+                </div>
+                <select
+                  className="ps-select-mini"
+                  value={audio.source}
                   disabled={audioInflight}
-                  onChange={(e) => void updateAudio({ micBoost: e.target.checked })}
-                />
-                <span className="ps-check-box" />
-                <span>{audio.micBoost ? 'On' : 'Off'}</span>
-              </label>
-            </div>
-          ) : null}
+                  onChange={(e) =>
+                    void updateAudio({
+                      source: e.target.value as typeof audio.source,
+                    })
+                  }
+                >
+                  <option value="Host">Host</option>
+                  {hasCodecAudio ? (
+                    <option value="RadioMic">Radio Mic</option>
+                  ) : null}
+                  {caps.hasRadioLineIn ? (
+                    <option value="RadioLineIn">Radio Line In</option>
+                  ) : null}
+                  {caps.hasBalancedXlr ? (
+                    <option value="RadioBalancedXlr">
+                      Radio Balanced (XLR)
+                    </option>
+                  ) : null}
+                </select>
+              </div>
 
-          {/* Balanced / TRS input — HL2 mic_trs (balanced) or Saturn XLR. */}
-          <div className="ps-field">
-            <div className="ps-name">
-              Balanced Input
-              <em>
-                {hasHl2Audio
-                  ? 'Use the TRS (balanced) mic pin on the HL2 front-end.'
-                  : 'Select the balanced (XLR) microphone input.'}
-              </em>
-            </div>
-            <label className="ps-check">
-              <input
-                type="checkbox"
-                checked={audio.balancedInput}
-                disabled={audioInflight}
-                onChange={(e) => void updateAudio({ balancedInput: e.target.checked })}
-              />
-              <span className="ps-check-box" />
-              <span>{audio.balancedInput ? 'Balanced' : 'Standard'}</span>
-            </label>
-          </div>
+              {/* Mic boost — parameter of Radio Mic / Balanced. */}
+              {audio.source === 'RadioMic' ||
+              audio.source === 'RadioBalancedXlr' ? (
+                <div className="ps-field">
+                  <div className="ps-name">
+                    Mic Boost
+                    <em>+20 dB microphone preamp boost.</em>
+                  </div>
+                  <label className="ps-check">
+                    <input
+                      type="checkbox"
+                      checked={audio.micBoost}
+                      disabled={audioInflight}
+                      onChange={(e) =>
+                        void updateAudio({ micBoost: e.target.checked })
+                      }
+                    />
+                    <span className="ps-check-box" />
+                    <span>{audio.micBoost ? 'On' : 'Off'}</span>
+                  </label>
+                </div>
+              ) : null}
 
-          {/* Mic bias — DEFAULTS OFF, floating-connector PTT-hang guard. */}
-          <div className="ps-field">
-            <div className="ps-name">
-              Mic Bias
-              <em>
-                Supply bias voltage for electret microphones. Leave OFF unless
-                your mic needs it — enabling it on a floating / unconnected
-                connector can hang PTT.
-              </em>
-            </div>
-            <label className="ps-check">
-              <input
-                type="checkbox"
-                checked={audio.micBias}
-                disabled={audioInflight}
-                onChange={(e) => void updateAudio({ micBias: e.target.checked })}
-              />
-              <span className="ps-check-box" />
-              <span>{audio.micBias ? 'On' : 'Off (default)'}</span>
-            </label>
-          </div>
+              {/* Mic bias — DEFAULTS OFF, floating-connector PTT-hang guard.
+                  Parameter of Radio Mic / Balanced, bias-capable boards only. */}
+              {caps.hasMicBias &&
+              (audio.source === 'RadioMic' ||
+                audio.source === 'RadioBalancedXlr') ? (
+                <div className="ps-field">
+                  <div className="ps-name">
+                    Mic Bias
+                    <em>
+                      Supply bias voltage for electret microphones. Leave OFF
+                      unless your mic needs it — enabling it on a floating /
+                      unconnected connector can hang PTT.
+                    </em>
+                  </div>
+                  <label className="ps-check">
+                    <input
+                      type="checkbox"
+                      checked={audio.micBias}
+                      disabled={audioInflight}
+                      onChange={(e) =>
+                        void updateAudio({ micBias: e.target.checked })
+                      }
+                    />
+                    <span className="ps-check-box" />
+                    <span>{audio.micBias ? 'On' : 'Off (default)'}</span>
+                  </label>
+                </div>
+              ) : null}
 
-          {/* Line-in gain 0..31 — present on both paths. */}
-          <div className="ps-field">
-            <div className="ps-name">
-              Line-In Gain
-              <em>Line-in input gain (0–31).</em>
-            </div>
-            <input
-              className="ps-select-mini"
-              type="number"
-              min={0}
-              max={31}
-              step={1}
-              value={audio.lineInGain}
-              disabled={audioInflight}
-              onChange={(e) => {
-                const n = Number.parseInt(e.target.value, 10);
-                if (!Number.isNaN(n)) {
-                  void updateAudio({ lineInGain: Math.min(31, Math.max(0, n)) });
-                }
-              }}
-            />
-          </div>
+              {/* Line-in gain 0..31 — parameter of Radio Line In. */}
+              {audio.source === 'RadioLineIn' ? (
+                <div className="ps-field">
+                  <div className="ps-name">
+                    Line-In Gain
+                    <em>Line-in input gain (0–31).</em>
+                  </div>
+                  <input
+                    className="ps-select-mini"
+                    type="number"
+                    min={0}
+                    max={31}
+                    step={1}
+                    value={audio.lineInGain}
+                    disabled={audioInflight}
+                    onChange={(e) => {
+                      const n = Number.parseInt(e.target.value, 10);
+                      if (!Number.isNaN(n)) {
+                        void updateAudio({
+                          lineInGain: Math.min(31, Math.max(0, n)),
+                        });
+                      }
+                    }}
+                  />
+                </div>
+              ) : null}
+            </>
+          )}
         </div>
       ) : null}
 

--- a/zeus-web/src/components/RadioSettingsPanel.tsx
+++ b/zeus-web/src/components/RadioSettingsPanel.tsx
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// RADIO SETTINGS tab — external-port controls (external-ports plan, Phase 2).
+// First control: per-band TX / RX antenna relay selection for the CURRENT
+// band, board-gated. The TX selector renders only when the board has TX
+// antenna relays (0x0A / Saturn family); the RX selector only when it has RX
+// antenna relays (every ANAN board; HL2's single jack is clamped to ANT1 on
+// the wire, so its RX selector is hidden). Persistence is per band and
+// server-authoritative — the panel loads + PUTs; the backend pushes the active
+// band to the live radio.
+//
+// Visual idiom reuses PsSettingsPanel's `.ps-shell` / `.ps-card` / `.ps-field`
+// surfaces and the `.ps-select-mini` select, so no new chrome / palette is
+// introduced (tokens only). Layout / visual specifics are the maintainer's
+// call — this stays clean and minimal.
+
+import { useEffect } from 'react';
+import { useConnectionStore } from '../state/connection-store';
+import { useRadioStore } from '../state/radio-store';
+import {
+  useAntennaStore,
+  type AntennaName,
+} from '../state/antenna-store';
+import { bandOf } from './design/data';
+
+const ANTENNAS: AntennaName[] = ['Ant1', 'Ant2', 'Ant3'];
+const ANTENNA_LABEL: Record<AntennaName, string> = {
+  Ant1: 'ANT 1',
+  Ant2: 'ANT 2',
+  Ant3: 'ANT 3',
+};
+
+export function RadioSettingsPanel() {
+  const vfoHz = useConnectionStore((s) => s.vfoHz);
+  const caps = useRadioStore((s) => s.capabilities);
+  const settings = useAntennaStore((s) => s.settings);
+  const loaded = useAntennaStore((s) => s.loaded);
+  const inflight = useAntennaStore((s) => s.inflight);
+  const error = useAntennaStore((s) => s.error);
+  const load = useAntennaStore((s) => s.load);
+  const setBand = useAntennaStore((s) => s.setBand);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const band = bandOf(vfoHz);
+  const onBand = band !== '—';
+  const current = settings.bands.find((b) => b.band === band);
+  const txAnt: AntennaName = current?.txAnt ?? 'Ant1';
+  const rxAnt: AntennaName = current?.rxAnt ?? 'Ant1';
+
+  const onSetTx = (next: AntennaName) => {
+    if (!onBand) return;
+    void setBand(band, next, rxAnt);
+  };
+  const onSetRx = (next: AntennaName) => {
+    if (!onBand) return;
+    void setBand(band, txAnt, next);
+  };
+
+  const statusText = inflight
+    ? 'Saving…'
+    : loaded
+      ? 'Loaded from server — changes apply immediately'
+      : 'Loading…';
+
+  return (
+    <div className="ps-shell">
+      <div className="ps-card">
+        <h4>
+          <svg className="ps-ic-sm" viewBox="0 0 12 12">
+            <path d="M6 1v7M3 4l3-3 3 3M3 10h6" />
+          </svg>
+          Antenna
+          <span className="ps-card-hint">
+            per band — {onBand ? band : 'no HF band'}
+          </span>
+        </h4>
+
+        {!caps.hasTxAntennaRelays && !caps.hasRxAntennaRelays ? (
+          <div className="ps-field">
+            <div className="ps-name">
+              No switchable antennas
+              <em>
+                The connected radio is hardwired to ANT 1 (no TX or RX antenna
+                relays). Nothing to select here.
+              </em>
+            </div>
+          </div>
+        ) : null}
+
+        {caps.hasTxAntennaRelays ? (
+          <div className="ps-field">
+            <div className="ps-name">
+              TX Antenna
+              <em>Transmit antenna relay for {onBand ? band : 'the current band'}.</em>
+            </div>
+            <select
+              className="ps-select-mini"
+              value={txAnt}
+              disabled={!onBand || inflight}
+              onChange={(e) => onSetTx(e.target.value as AntennaName)}
+            >
+              {ANTENNAS.map((a) => (
+                <option key={a} value={a}>
+                  {ANTENNA_LABEL[a]}
+                </option>
+              ))}
+            </select>
+          </div>
+        ) : null}
+
+        {caps.hasRxAntennaRelays ? (
+          <div className="ps-field">
+            <div className="ps-name">
+              RX Antenna
+              <em>Receive antenna relay for {onBand ? band : 'the current band'}.</em>
+            </div>
+            <select
+              className="ps-select-mini"
+              value={rxAnt}
+              disabled={!onBand || inflight}
+              onChange={(e) => onSetRx(e.target.value as AntennaName)}
+            >
+              {ANTENNAS.map((a) => (
+                <option key={a} value={a}>
+                  {ANTENNA_LABEL[a]}
+                </option>
+              ))}
+            </select>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="ps-status-row">
+        <div className="ps-status-left">
+          <span>Status</span>
+          <span className={inflight ? '' : 'saved'}>{statusText}</span>
+        </div>
+        {error ? (
+          <div className="ps-status-left" style={{ color: 'var(--tx)' }}>
+            <span>Error</span>
+            <span>{error}</span>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/zeus-web/src/components/RadioSettingsPanel.tsx
+++ b/zeus-web/src/components/RadioSettingsPanel.tsx
@@ -26,7 +26,7 @@ import {
   type AntennaName,
   type RxAuxName,
 } from '../state/antenna-store';
-import { useAudioStore } from '../state/audio-store';
+import { useAudioStore, type TxAudioSource } from '../state/audio-store';
 import { useHl2GpioStore } from '../state/hl2-gpio-store';
 import { usePttStore } from '../state/ptt-store';
 import { bandOf } from './design/data';
@@ -49,6 +49,28 @@ const RX_AUX_LABEL: Record<RxAuxName, string> = {
 // HL2 user GPIO line labels (4-bit user_dig_out → MCP23008).
 const GPIO_LINES = [0, 1, 2, 3] as const;
 
+// TX-audio source labels for the single-select segmented control. The control
+// is a radio-button group (role="radiogroup") bound to the ONE TxAudioSource
+// enum value — exactly one is active at a time, so the prior bug (independent
+// checkboxes that came up checked and let you pick more than one) is
+// structurally impossible. Host is always offered; the radio jacks render only
+// when the connected board exposes them (board-gated below).
+const AUDIO_SOURCE_LABEL: Record<TxAudioSource, string> = {
+  Host: 'Host',
+  RadioMic: 'Radio Mic',
+  RadioLineIn: 'Radio Line In',
+  RadioBalancedXlr: 'Radio Balanced',
+};
+
+// Explicit confirmation copy for enabling mic bias — the floating-connector
+// RF / PTT-hang risk (plan §7). Wording is a maintainer (Brian) call; kept
+// short and factual. Only gates turning bias ON; turning it OFF is unguarded.
+const MIC_BIAS_CONFIRM =
+  'Enable mic bias?\n\n' +
+  'This supplies DC bias voltage on the mic connector for electret ' +
+  'microphones. On a floating or unconnected mic jack it can hang PTT or ' +
+  'couple RF. Leave it OFF unless your microphone needs bias.';
+
 export function RadioSettingsPanel() {
   const vfoHz = useConnectionStore((s) => s.vfoHz);
   const caps = useRadioStore((s) => s.capabilities);
@@ -65,6 +87,30 @@ export function RadioSettingsPanel() {
   const updateAudio = useAudioStore((s) => s.update);
   const hasCodecAudio = caps.hasOnboardCodec;
   const hasHl2Audio = caps.hermesLite2MicFrontEnd;
+
+  // Board-gated single-select source list. Host is ALWAYS present and is the
+  // default; each radio jack appears only when its capability flag is set.
+  // HL2 (no codec, no radio jacks) collapses to Host-only — handled by the
+  // dedicated note branch below, so this list is for codec boards.
+  const audioSources: TxAudioSource[] = [
+    'Host',
+    ...(hasCodecAudio ? (['RadioMic'] as const) : []),
+    ...(caps.hasRadioLineIn ? (['RadioLineIn'] as const) : []),
+    ...(caps.hasBalancedXlr ? (['RadioBalancedXlr'] as const) : []),
+  ];
+
+  const onSelectSource = (next: TxAudioSource) => {
+    if (next === audio.source) return;
+    void updateAudio({ source: next });
+  };
+
+  // Mic bias is OFF by default and gated behind an explicit confirmation when
+  // turning it ON (floating-connector RF / PTT-hang risk, plan §7). Turning it
+  // off needs no confirmation.
+  const onToggleMicBias = (next: boolean) => {
+    if (next && !window.confirm(MIC_BIAS_CONFIRM)) return;
+    void updateAudio({ micBias: next });
+  };
 
   const gpio = useHl2GpioStore((s) => s.state);
   const gpioInflight = useHl2GpioStore((s) => s.inflight);
@@ -253,41 +299,42 @@ export function RadioSettingsPanel() {
             </div>
           ) : (
             <>
-              {/* Single-select TX-audio source — board-gated, cannot
-                  double-pick. Host always present; radio jacks render only when
-                  the connected board exposes them. */}
+              {/* Single-select TX-audio source — a radio-button group bound to
+                  the ONE TxAudioSource value, so it is physically impossible to
+                  pick more than one (illegal states unrepresentable). Board-
+                  gated: Host always present; radio jacks render only when the
+                  connected board exposes them. */}
               <div className="ps-field">
                 <div className="ps-name">
                   TX Audio Source
                   <em>
                     Which input feeds the transmitter. Host uses the computer
                     mic / audio chain; the radio options digitize the rig's own
-                    analog jacks.
+                    analog jacks. Exactly one is active at a time.
                   </em>
                 </div>
-                <select
-                  className="ps-select-mini"
-                  value={audio.source}
-                  disabled={audioInflight}
-                  onChange={(e) =>
-                    void updateAudio({
-                      source: e.target.value as typeof audio.source,
-                    })
-                  }
+                <div
+                  className="btn-row wrap"
+                  role="radiogroup"
+                  aria-label="TX audio source"
                 >
-                  <option value="Host">Host</option>
-                  {hasCodecAudio ? (
-                    <option value="RadioMic">Radio Mic</option>
-                  ) : null}
-                  {caps.hasRadioLineIn ? (
-                    <option value="RadioLineIn">Radio Line In</option>
-                  ) : null}
-                  {caps.hasBalancedXlr ? (
-                    <option value="RadioBalancedXlr">
-                      Radio Balanced (XLR)
-                    </option>
-                  ) : null}
-                </select>
+                  {audioSources.map((src) => {
+                    const active = audio.source === src;
+                    return (
+                      <button
+                        key={src}
+                        type="button"
+                        role="radio"
+                        aria-checked={active}
+                        className={`btn sm ${active ? 'active' : ''}`}
+                        disabled={audioInflight}
+                        onClick={() => onSelectSource(src)}
+                      >
+                        {AUDIO_SOURCE_LABEL[src]}
+                      </button>
+                    );
+                  })}
+                </div>
               </div>
 
               {/* Mic boost — parameter of Radio Mic / Balanced. */}
@@ -332,9 +379,7 @@ export function RadioSettingsPanel() {
                       type="checkbox"
                       checked={audio.micBias}
                       disabled={audioInflight}
-                      onChange={(e) =>
-                        void updateAudio({ micBias: e.target.checked })
-                      }
+                      onChange={(e) => onToggleMicBias(e.target.checked)}
                     />
                     <span className="ps-check-box" />
                     <span>{audio.micBias ? 'On' : 'Off (default)'}</span>

--- a/zeus-web/src/components/SettingsMenu.test.tsx
+++ b/zeus-web/src/components/SettingsMenu.test.tsx
@@ -114,7 +114,7 @@ describe('SettingsView — RADIO tab gating', () => {
     expect(tabs).not.toContain('RADIO');
   });
 
-  it('hides RADIO SETTINGS when the board has no antenna relays', () => {
+  it('hides RADIO SETTINGS when the board has no external ports at all', () => {
     seedRadioCaps({ hasTxAntennaRelays: false, hasRxAntennaRelays: false });
     act(() => {
       root.render(<SettingsView onClose={() => {}} />);
@@ -123,6 +123,25 @@ describe('SettingsView — RADIO tab gating', () => {
       container.querySelectorAll('[role="tablist"] button'),
     ).map((b) => b.textContent?.trim() ?? '');
     expect(tabs).not.toContain('RADIO SETTINGS');
+  });
+
+  it('shows RADIO SETTINGS on HL2 (no relays, but mic front-end + user GPIO)', () => {
+    // Phase 5 gate broadening: HL2 has no antenna relays but DOES have the
+    // register-0x14 mic front-end and the 4-bit user GPIO, so the tab — and
+    // therefore those HL2-only controls — must be reachable.
+    seedRadioCaps({
+      hasTxAntennaRelays: false,
+      hasRxAntennaRelays: false,
+      hermesLite2MicFrontEnd: true,
+      hasHl2UserGpio: true,
+    });
+    act(() => {
+      root.render(<SettingsView onClose={() => {}} />);
+    });
+    const tabs = Array.from(
+      container.querySelectorAll('[role="tablist"] button'),
+    ).map((b) => b.textContent?.trim() ?? '');
+    expect(tabs).toContain('RADIO SETTINGS');
   });
 
   it('shows RADIO SETTINGS and renders the antenna panel when the board has relays', () => {

--- a/zeus-web/src/components/SettingsMenu.test.tsx
+++ b/zeus-web/src/components/SettingsMenu.test.tsx
@@ -96,7 +96,11 @@ describe('SettingsView — RADIO tab gating', () => {
     container.remove();
     vi.unstubAllGlobals();
     // Restore the radio-store fixture so other test files start clean.
-    seedRadioCaps({ hasHl2OptionalToggles: false });
+    seedRadioCaps({
+      hasHl2OptionalToggles: false,
+      hasTxAntennaRelays: false,
+      hasRxAntennaRelays: false,
+    });
   });
 
   it('hides the RADIO tab when hasHl2OptionalToggles is false', () => {
@@ -108,6 +112,44 @@ describe('SettingsView — RADIO tab gating', () => {
       container.querySelectorAll('[role="tablist"] button'),
     ).map((b) => b.textContent?.trim() ?? '');
     expect(tabs).not.toContain('RADIO');
+  });
+
+  it('hides RADIO SETTINGS when the board has no antenna relays', () => {
+    seedRadioCaps({ hasTxAntennaRelays: false, hasRxAntennaRelays: false });
+    act(() => {
+      root.render(<SettingsView onClose={() => {}} />);
+    });
+    const tabs = Array.from(
+      container.querySelectorAll('[role="tablist"] button'),
+    ).map((b) => b.textContent?.trim() ?? '');
+    expect(tabs).not.toContain('RADIO SETTINGS');
+  });
+
+  it('shows RADIO SETTINGS and renders the antenna panel when the board has relays', () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            hasTxAntennaRelays: true,
+            hasRxAntennaRelays: true,
+            bands: [{ band: '20m', txAnt: 'Ant1', rxAnt: 'Ant1' }],
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      ),
+    );
+
+    seedRadioCaps({ hasTxAntennaRelays: true, hasRxAntennaRelays: true });
+    act(() => {
+      root.render(<SettingsView onClose={() => {}} initialTab="radio-settings" />);
+    });
+    const tabs = Array.from(
+      container.querySelectorAll('[role="tablist"] button'),
+    ).map((b) => b.textContent?.trim() ?? '');
+    expect(tabs).toContain('RADIO SETTINGS');
+    expect(container.textContent).toContain('TX Antenna');
+    expect(container.textContent).toContain('RX Antenna');
   });
 
   it('shows the RADIO tab and renders the panel on click when hasHl2OptionalToggles is true', () => {

--- a/zeus-web/src/components/SettingsMenu.tsx
+++ b/zeus-web/src/components/SettingsMenu.tsx
@@ -27,6 +27,7 @@ import { CalibrationPanel } from './CalibrationPanel';
 import { DisplayPanel } from './DisplayPanel';
 import { QrzSettingsPanel } from './QrzSettingsPanel';
 import { RadioOptionsPanel } from './RadioOptionsPanel';
+import { RadioSettingsPanel } from './RadioSettingsPanel';
 import { RotatorSettingsPanel } from './RotatorSettingsPanel';
 import { ServerUrlPanel } from './ServerUrlPanel';
 import { TciSettingsPanel } from './TciSettingsPanel';
@@ -49,6 +50,7 @@ export type SettingsTabId =
   | 'plugins'
   | 'server'
   | 'radio'
+  | 'radio-settings'
   | 'calibration'
   | 'about';
 
@@ -64,6 +66,7 @@ const TABS: ReadonlyArray<{ id: SettingsTabId; label: string }> = [
   { id: 'plugins', label: 'PLUGINS' },
   { id: 'server', label: 'SERVER' },
   { id: 'radio', label: 'RADIO' },
+  { id: 'radio-settings', label: 'RADIO SETTINGS' },
   { id: 'calibration', label: 'CALIBRATION' },
   { id: 'about', label: 'ABOUT' },
 ];
@@ -89,19 +92,35 @@ export function SettingsView({ initialTab, onClose }: Props) {
   const hasHl2OptionalToggles = useRadioStore(
     (s) => s.capabilities.hasHl2OptionalToggles,
   );
+  // RADIO SETTINGS tab (external-ports plan, Phase 2) appears when the board
+  // exposes at least one external port — currently antenna. Start with the
+  // antenna relay capabilities; future external ports (audio front-end, etc.)
+  // OR into this gate.
+  const hasExternalPorts = useRadioStore(
+    (s) =>
+      s.capabilities.hasTxAntennaRelays || s.capabilities.hasRxAntennaRelays,
+  );
   const visibleTabs = useMemo(
-    () => TABS.filter((t) => t.id !== 'radio' || hasHl2OptionalToggles),
-    [hasHl2OptionalToggles],
+    () =>
+      TABS.filter((t) => {
+        if (t.id === 'radio') return hasHl2OptionalToggles;
+        if (t.id === 'radio-settings') return hasExternalPorts;
+        return true;
+      }),
+    [hasHl2OptionalToggles, hasExternalPorts],
   );
 
-  // If the operator was sitting on the RADIO tab and the board changed
-  // (re-discovery now reports a non-HL2), bounce them back to PA so they
-  // don't get stuck on an empty tabpanel.
+  // If the operator was sitting on a board-gated tab and the board changed
+  // (re-discovery now reports a board without that capability), bounce them
+  // back to PA so they don't get stuck on an empty tabpanel.
   useEffect(() => {
     if (active === 'radio' && !hasHl2OptionalToggles) {
       setActive('pa');
     }
-  }, [active, hasHl2OptionalToggles]);
+    if (active === 'radio-settings' && !hasExternalPorts) {
+      setActive('pa');
+    }
+  }, [active, hasHl2OptionalToggles, hasExternalPorts]);
 
   useEffect(() => {
     if (initialTab) setActive(initialTab);
@@ -179,6 +198,7 @@ export function SettingsView({ initialTab, onClose }: Props) {
           {active === 'plugins' && <PluginsPanel />}
           {active === 'server' && <ServerUrlPanel />}
           {active === 'radio' && hasHl2OptionalToggles && <RadioOptionsPanel />}
+          {active === 'radio-settings' && hasExternalPorts && <RadioSettingsPanel />}
           {active === 'calibration' && <CalibrationPanel />}
           {active === 'about' && <AboutPanel />}
         </div>

--- a/zeus-web/src/components/SettingsMenu.tsx
+++ b/zeus-web/src/components/SettingsMenu.tsx
@@ -92,13 +92,19 @@ export function SettingsView({ initialTab, onClose }: Props) {
   const hasHl2OptionalToggles = useRadioStore(
     (s) => s.capabilities.hasHl2OptionalToggles,
   );
-  // RADIO SETTINGS tab (external-ports plan, Phase 2) appears when the board
-  // exposes at least one external port — currently antenna. Start with the
-  // antenna relay capabilities; future external ports (audio front-end, etc.)
-  // OR into this gate.
+  // RADIO SETTINGS tab appears when the board exposes ANY external port the
+  // panel can drive: antenna relays (Phase 2), the audio front-end (Phase 4),
+  // or the Phase-5 ports (RX-aux inputs, HL2 user GPIO). HL2 has no antenna
+  // relays but DOES have the mic front-end + user GPIO, so it must light the
+  // tab too — broadened here so those HL2 controls are reachable.
   const hasExternalPorts = useRadioStore(
     (s) =>
-      s.capabilities.hasTxAntennaRelays || s.capabilities.hasRxAntennaRelays,
+      s.capabilities.hasTxAntennaRelays ||
+      s.capabilities.hasRxAntennaRelays ||
+      s.capabilities.hasOnboardCodec ||
+      s.capabilities.hermesLite2MicFrontEnd ||
+      s.capabilities.hasHl2UserGpio ||
+      s.capabilities.hasRx2AntennaPath,
   );
   const visibleTabs = useMemo(
     () =>

--- a/zeus-web/src/realtime/ws-client.ts
+++ b/zeus-web/src/realtime/ws-client.ts
@@ -51,6 +51,7 @@ import { useConnectionStore, type WisdomPhase } from '../state/connection-store'
 import { hasActiveFrameConsumers, useDisplayStore } from '../state/display-store';
 import { AlertKind, useTxStore } from '../state/tx-store';
 import { useBandPlanStore } from '../state/bandPlan';
+import { usePttStore } from '../state/ptt-store';
 import { useRxMetersStore } from '../state/rx-meters-store';
 import { warnOnce } from '../util/logger';
 import { wsUrl as buildWsUrl } from '../serverUrl';
@@ -199,6 +200,15 @@ const CW_DECODED_TEXT_HEADER_BYTES = 13;
 //     commentLen:u16 LE, comment:utf8]
 export const MSG_TYPE_SPOT_LIST = 0x32;
 const SPOT_LIST_MIN_BYTES = 3; // type + count
+
+// Hardware-PTT-IN status edge: 1 type byte + keyed:u8 = 2 bytes. Broadcast on
+// every footswitch / mic-PTT / rear-KEY edge so the Radio Settings PTT-IN lamp
+// tracks the physical input regardless of protocol (server source is
+// per-protocol: P1 HardwarePttChanged, P2 UDP-1025 PttIn). Read-only indicator
+// — does NOT drive MOX (the server promotes the same edges to MOX separately).
+// Contract: Zeus.Contracts/PttStatusFrame.cs.
+export const MSG_TYPE_PTT_STATUS = 0x33;
+const PTT_STATUS_BYTES = 2;
 
 // Shared by startRealtime / sendMicPcm. Single WS instance at a time; writes
 // are no-ops when the socket isn't open.
@@ -607,6 +617,15 @@ export function startRealtime(path = '/ws'): () => void {
             // localMicArmed (only local interaction does — see issue #346).
             if (txStore.localMicArmed) txStore.setLocalMicArmed(false);
           }
+          return;
+        }
+        if (peekType === MSG_TYPE_PTT_STATUS) {
+          if (ev.data.byteLength < PTT_STATUS_BYTES) {
+            warnOnce('ws-ptt-status-short', `ptt status frame too short: ${ev.data.byteLength}`);
+            return;
+          }
+          const dv = new DataView(ev.data);
+          usePttStore.getState().setKeyed(dv.getUint8(1) !== 0);
           return;
         }
         if (peekType === MSG_TYPE_SPOT_LIST) {

--- a/zeus-web/src/state/antenna-store.test.ts
+++ b/zeus-web/src/state/antenna-store.test.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Antenna store — parse robustness + optimistic setBand round-trip
+// (external-ports plan, Phase 2).
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  fetchAntennaSettings,
+  updateAntennaBand,
+  useAntennaStore,
+} from './antenna-store';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  useAntennaStore.setState({
+    settings: { hasTxAntennaRelays: false, hasRxAntennaRelays: false, bands: [] },
+    loaded: false,
+    inflight: false,
+    error: null,
+  });
+});
+
+function stubFetch(body: unknown, status = 200) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+}
+
+describe('antenna-store parsing', () => {
+  it('coerces unknown antenna strings to Ant1', async () => {
+    stubFetch({
+      hasTxAntennaRelays: true,
+      hasRxAntennaRelays: true,
+      bands: [{ band: '20m', txAnt: 'Ant9', rxAnt: 'Ant2' }],
+    });
+    const s = await fetchAntennaSettings();
+    expect(s.bands[0].txAnt).toBe('Ant1');
+    expect(s.bands[0].rxAnt).toBe('Ant2');
+  });
+
+  it('defaults gates false and bands [] on garbage', async () => {
+    stubFetch(42);
+    const s = await fetchAntennaSettings();
+    expect(s.hasTxAntennaRelays).toBe(false);
+    expect(s.bands).toEqual([]);
+  });
+
+  it('throws on a 409 from the PUT', async () => {
+    stubFetch({ error: 'no relays' }, 409);
+    await expect(updateAntennaBand('20m', 'Ant2', 'Ant1')).rejects.toThrow();
+  });
+});
+
+describe('antenna-store setBand', () => {
+  it('optimistically updates then adopts the server response', async () => {
+    stubFetch({
+      hasTxAntennaRelays: true,
+      hasRxAntennaRelays: true,
+      bands: [{ band: '20m', txAnt: 'Ant3', rxAnt: 'Ant1' }],
+    });
+    await useAntennaStore.getState().setBand('20m', 'Ant3', 'Ant1');
+    const b = useAntennaStore.getState().settings.bands.find((x) => x.band === '20m');
+    expect(b?.txAnt).toBe('Ant3');
+  });
+
+  it('rolls back on PUT failure', async () => {
+    // Seed a known-good current state, then fail the PUT.
+    useAntennaStore.setState({
+      settings: {
+        hasTxAntennaRelays: true,
+        hasRxAntennaRelays: true,
+        bands: [{ band: '20m', txAnt: 'Ant1', rxAnt: 'Ant1' }],
+      },
+    });
+    stubFetch({ error: 'boom' }, 409);
+    await useAntennaStore.getState().setBand('20m', 'Ant2', 'Ant1');
+    const b = useAntennaStore.getState().settings.bands.find((x) => x.band === '20m');
+    expect(b?.txAnt).toBe('Ant1'); // rolled back
+    expect(useAntennaStore.getState().error).toBeTruthy();
+  });
+});

--- a/zeus-web/src/state/antenna-store.test.ts
+++ b/zeus-web/src/state/antenna-store.test.ts
@@ -13,7 +13,13 @@ import {
 afterEach(() => {
   vi.unstubAllGlobals();
   useAntennaStore.setState({
-    settings: { hasTxAntennaRelays: false, hasRxAntennaRelays: false, bands: [] },
+    settings: {
+      hasTxAntennaRelays: false,
+      hasRxAntennaRelays: false,
+      bands: [],
+      availableRxAux: [],
+      alexRevision: 'Modern',
+    },
     loaded: false,
     inflight: false,
     error: null,
@@ -53,7 +59,7 @@ describe('antenna-store parsing', () => {
 
   it('throws on a 409 from the PUT', async () => {
     stubFetch({ error: 'no relays' }, 409);
-    await expect(updateAntennaBand('20m', 'Ant2', 'Ant1')).rejects.toThrow();
+    await expect(updateAntennaBand('20m', 'Ant2', 'Ant1', 'None')).rejects.toThrow();
   });
 });
 
@@ -64,9 +70,23 @@ describe('antenna-store setBand', () => {
       hasRxAntennaRelays: true,
       bands: [{ band: '20m', txAnt: 'Ant3', rxAnt: 'Ant1' }],
     });
-    await useAntennaStore.getState().setBand('20m', 'Ant3', 'Ant1');
+    await useAntennaStore.getState().setBand('20m', 'Ant3', 'Ant1', 'None');
     const b = useAntennaStore.getState().settings.bands.find((x) => x.band === '20m');
     expect(b?.txAnt).toBe('Ant3');
+  });
+
+  it('round-trips a per-band RX-aux selection', async () => {
+    stubFetch({
+      hasTxAntennaRelays: true,
+      hasRxAntennaRelays: true,
+      bands: [{ band: '20m', txAnt: 'Ant1', rxAnt: 'Ant1', rxAux: 'Bypass' }],
+      availableRxAux: ['Ext1', 'Ext2', 'Xvtr', 'Bypass'],
+      alexRevision: 'Modern',
+    });
+    await useAntennaStore.getState().setBand('20m', 'Ant1', 'Ant1', 'Bypass');
+    const b = useAntennaStore.getState().settings.bands.find((x) => x.band === '20m');
+    expect(b?.rxAux).toBe('Bypass');
+    expect(useAntennaStore.getState().settings.availableRxAux).toContain('Bypass');
   });
 
   it('rolls back on PUT failure', async () => {
@@ -75,11 +95,13 @@ describe('antenna-store setBand', () => {
       settings: {
         hasTxAntennaRelays: true,
         hasRxAntennaRelays: true,
-        bands: [{ band: '20m', txAnt: 'Ant1', rxAnt: 'Ant1' }],
+        bands: [{ band: '20m', txAnt: 'Ant1', rxAnt: 'Ant1', rxAux: 'None' }],
+        availableRxAux: [],
+        alexRevision: 'Modern',
       },
     });
     stubFetch({ error: 'boom' }, 409);
-    await useAntennaStore.getState().setBand('20m', 'Ant2', 'Ant1');
+    await useAntennaStore.getState().setBand('20m', 'Ant2', 'Ant1', 'None');
     const b = useAntennaStore.getState().settings.bands.find((x) => x.band === '20m');
     expect(b?.txAnt).toBe('Ant1'); // rolled back
     expect(useAntennaStore.getState().error).toBeTruthy();

--- a/zeus-web/src/state/antenna-store.test.ts
+++ b/zeus-web/src/state/antenna-store.test.ts
@@ -40,8 +40,8 @@ describe('antenna-store parsing', () => {
       bands: [{ band: '20m', txAnt: 'Ant9', rxAnt: 'Ant2' }],
     });
     const s = await fetchAntennaSettings();
-    expect(s.bands[0].txAnt).toBe('Ant1');
-    expect(s.bands[0].rxAnt).toBe('Ant2');
+    expect(s.bands[0]?.txAnt).toBe('Ant1');
+    expect(s.bands[0]?.rxAnt).toBe('Ant2');
   });
 
   it('defaults gates false and bands [] on garbage', async () => {

--- a/zeus-web/src/state/antenna-store.ts
+++ b/zeus-web/src/state/antenna-store.ts
@@ -17,33 +17,53 @@
 import { create } from 'zustand';
 
 export type AntennaName = 'Ant1' | 'Ant2' | 'Ant3';
+// RX auxiliary input (external-ports plan, Phase 5). 'None' = use the base
+// RX-antenna relay; the rest are the Alex/filter-board aux feeds.
+export type RxAuxName = 'None' | 'Ext1' | 'Ext2' | 'Xvtr' | 'Bypass';
 
 export interface AntennaBand {
   band: string;
   txAnt: AntennaName;
   rxAnt: AntennaName;
+  rxAux: RxAuxName;
 }
 
 export interface AntennaSettings {
   hasTxAntennaRelays: boolean;
   hasRxAntennaRelays: boolean;
   bands: AntennaBand[];
+  /** Aux inputs the connected board's Alex/filter board exposes (Phase 5).
+   *  Empty on boards with no aux inputs (HL2). */
+  availableRxAux: RxAuxName[];
+  /** K36-BYPASS direction family (operator-set, NOT wire-discoverable):
+   *  'Modern' (Rev 24+, PS routes to BYPASS — safe default) or 'Legacy15Or16'. */
+  alexRevision: string;
 }
 
 const DEFAULT_SETTINGS: AntennaSettings = {
   hasTxAntennaRelays: false,
   hasRxAntennaRelays: false,
   bands: [],
+  availableRxAux: [],
+  alexRevision: 'Modern',
 };
 
 function parseAnt(v: unknown): AntennaName {
   return v === 'Ant2' || v === 'Ant3' ? v : 'Ant1';
 }
 
+const RX_AUX_NAMES: RxAuxName[] = ['None', 'Ext1', 'Ext2', 'Xvtr', 'Bypass'];
+function parseRxAux(v: unknown): RxAuxName {
+  return typeof v === 'string' && (RX_AUX_NAMES as string[]).includes(v)
+    ? (v as RxAuxName)
+    : 'None';
+}
+
 function parse(raw: unknown): AntennaSettings {
   if (!raw || typeof raw !== 'object') return DEFAULT_SETTINGS;
   const r = raw as Record<string, unknown>;
   const bandsRaw = Array.isArray(r.bands) ? r.bands : [];
+  const auxRaw = Array.isArray(r.availableRxAux) ? r.availableRxAux : [];
   return {
     hasTxAntennaRelays:
       typeof r.hasTxAntennaRelays === 'boolean' ? r.hasTxAntennaRelays : false,
@@ -55,8 +75,13 @@ function parse(raw: unknown): AntennaSettings {
         band: typeof e.band === 'string' ? e.band : '',
         txAnt: parseAnt(e.txAnt),
         rxAnt: parseAnt(e.rxAnt),
+        rxAux: parseRxAux(e.rxAux),
       };
     }),
+    availableRxAux: auxRaw
+      .map((a) => parseRxAux(a))
+      .filter((a) => a !== 'None'),
+    alexRevision: typeof r.alexRevision === 'string' ? r.alexRevision : 'Modern',
   };
 }
 
@@ -72,12 +97,13 @@ export async function updateAntennaBand(
   band: string,
   txAnt: AntennaName,
   rxAnt: AntennaName,
+  rxAux: RxAuxName,
   signal?: AbortSignal,
 ): Promise<AntennaSettings> {
   const res = await fetch('/api/radio/antenna', {
     method: 'PUT',
     headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ band, txAnt, rxAnt }),
+    body: JSON.stringify({ band, txAnt, rxAnt, rxAux }),
     signal,
   });
   if (!res.ok) throw new Error(`PUT /api/radio/antenna → ${res.status}`);
@@ -90,7 +116,12 @@ type AntennaStore = {
   inflight: boolean;
   error: string | null;
   load: () => Promise<void>;
-  setBand: (band: string, txAnt: AntennaName, rxAnt: AntennaName) => Promise<void>;
+  setBand: (
+    band: string,
+    txAnt: AntennaName,
+    rxAnt: AntennaName,
+    rxAux: RxAuxName,
+  ) => Promise<void>;
 };
 
 export const useAntennaStore = create<AntennaStore>((set, get) => ({
@@ -112,7 +143,7 @@ export const useAntennaStore = create<AntennaStore>((set, get) => ({
     }
   },
 
-  setBand: async (band, txAnt, rxAnt) => {
+  setBand: async (band, txAnt, rxAnt, rxAux) => {
     // Optimistic local update, rollback on error — same idiom as pa-store /
     // radio-options-store. The PUT returns the canonical settings which we
     // adopt so the local view stays in lockstep with the server.
@@ -121,14 +152,14 @@ export const useAntennaStore = create<AntennaStore>((set, get) => ({
       const found = prev.bands.some((b) => b.band === band);
       if (found) {
         return prev.bands.map((b) =>
-          b.band === band ? { ...b, txAnt, rxAnt } : b,
+          b.band === band ? { ...b, txAnt, rxAnt, rxAux } : b,
         );
       }
-      return [...prev.bands, { band, txAnt, rxAnt }];
+      return [...prev.bands, { band, txAnt, rxAnt, rxAux }];
     })();
     set({ settings: { ...prev, bands: nextBands }, inflight: true, error: null });
     try {
-      const s = await updateAntennaBand(band, txAnt, rxAnt);
+      const s = await updateAntennaBand(band, txAnt, rxAnt, rxAux);
       set({ settings: s, inflight: false });
     } catch (err) {
       set({

--- a/zeus-web/src/state/antenna-store.ts
+++ b/zeus-web/src/state/antenna-store.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Per-band TX/RX antenna relay selection (external-ports plan, Phase 2).
+// Mirrors /api/radio/antenna, which is server-authoritative: the backend reads
+// AntennaSettingsStore and pushes the active band's selection to the live radio
+// through RecomputePaAndPush (the same path OC uses), so the frontend never
+// clobbers the server on connect — it only loads + PUTs operator edits.
+//
+// The GET response carries the relay-capability gates so the panel can render
+// the right selectors; the per-band rows let the operator stage selections for
+// every band even when only the current band is shown.
+
+import { create } from 'zustand';
+
+export type AntennaName = 'Ant1' | 'Ant2' | 'Ant3';
+
+export interface AntennaBand {
+  band: string;
+  txAnt: AntennaName;
+  rxAnt: AntennaName;
+}
+
+export interface AntennaSettings {
+  hasTxAntennaRelays: boolean;
+  hasRxAntennaRelays: boolean;
+  bands: AntennaBand[];
+}
+
+const DEFAULT_SETTINGS: AntennaSettings = {
+  hasTxAntennaRelays: false,
+  hasRxAntennaRelays: false,
+  bands: [],
+};
+
+function parseAnt(v: unknown): AntennaName {
+  return v === 'Ant2' || v === 'Ant3' ? v : 'Ant1';
+}
+
+function parse(raw: unknown): AntennaSettings {
+  if (!raw || typeof raw !== 'object') return DEFAULT_SETTINGS;
+  const r = raw as Record<string, unknown>;
+  const bandsRaw = Array.isArray(r.bands) ? r.bands : [];
+  return {
+    hasTxAntennaRelays:
+      typeof r.hasTxAntennaRelays === 'boolean' ? r.hasTxAntennaRelays : false,
+    hasRxAntennaRelays:
+      typeof r.hasRxAntennaRelays === 'boolean' ? r.hasRxAntennaRelays : false,
+    bands: bandsRaw.map((b) => {
+      const e = (b ?? {}) as Record<string, unknown>;
+      return {
+        band: typeof e.band === 'string' ? e.band : '',
+        txAnt: parseAnt(e.txAnt),
+        rxAnt: parseAnt(e.rxAnt),
+      };
+    }),
+  };
+}
+
+export async function fetchAntennaSettings(
+  signal?: AbortSignal,
+): Promise<AntennaSettings> {
+  const res = await fetch('/api/radio/antenna', { signal });
+  if (!res.ok) throw new Error(`GET /api/radio/antenna → ${res.status}`);
+  return parse(await res.json());
+}
+
+export async function updateAntennaBand(
+  band: string,
+  txAnt: AntennaName,
+  rxAnt: AntennaName,
+  signal?: AbortSignal,
+): Promise<AntennaSettings> {
+  const res = await fetch('/api/radio/antenna', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ band, txAnt, rxAnt }),
+    signal,
+  });
+  if (!res.ok) throw new Error(`PUT /api/radio/antenna → ${res.status}`);
+  return parse(await res.json());
+}
+
+type AntennaStore = {
+  settings: AntennaSettings;
+  loaded: boolean;
+  inflight: boolean;
+  error: string | null;
+  load: () => Promise<void>;
+  setBand: (band: string, txAnt: AntennaName, rxAnt: AntennaName) => Promise<void>;
+};
+
+export const useAntennaStore = create<AntennaStore>((set, get) => ({
+  settings: DEFAULT_SETTINGS,
+  loaded: false,
+  inflight: false,
+  error: null,
+
+  load: async () => {
+    set({ inflight: true, error: null });
+    try {
+      const s = await fetchAntennaSettings();
+      set({ settings: s, loaded: true, inflight: false });
+    } catch (err) {
+      set({
+        error: err instanceof Error ? err.message : String(err),
+        inflight: false,
+      });
+    }
+  },
+
+  setBand: async (band, txAnt, rxAnt) => {
+    // Optimistic local update, rollback on error — same idiom as pa-store /
+    // radio-options-store. The PUT returns the canonical settings which we
+    // adopt so the local view stays in lockstep with the server.
+    const prev = get().settings;
+    const nextBands = (() => {
+      const found = prev.bands.some((b) => b.band === band);
+      if (found) {
+        return prev.bands.map((b) =>
+          b.band === band ? { ...b, txAnt, rxAnt } : b,
+        );
+      }
+      return [...prev.bands, { band, txAnt, rxAnt }];
+    })();
+    set({ settings: { ...prev, bands: nextBands }, inflight: true, error: null });
+    try {
+      const s = await updateAntennaBand(band, txAnt, rxAnt);
+      set({ settings: s, inflight: false });
+    } catch (err) {
+      set({
+        settings: prev,
+        error: err instanceof Error ? err.message : String(err),
+        inflight: false,
+      });
+    }
+  },
+}));

--- a/zeus-web/src/state/audio-store.test.ts
+++ b/zeus-web/src/state/audio-store.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 //
-// Audio front-end store — parse robustness + optimistic update round-trip
-// (external-ports plan, Phase 4).
+// TX-audio source store — parse robustness + optimistic update round-trip
+// (external-ports plan, §2/§11).
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -16,10 +16,12 @@ afterEach(() => {
     settings: {
       hasOnboardCodec: false,
       hermesLite2MicFrontEnd: false,
-      lineIn: false,
+      hasRadioLineIn: false,
+      hasBalancedXlr: false,
+      hasMicBias: false,
+      source: 'Host',
       micBoost: false,
       micBias: false,
-      balancedInput: false,
       lineInGain: 0,
     },
     loaded: false,
@@ -42,27 +44,39 @@ function stubFetch(body: unknown, status = 200) {
 
 describe('audio-store parsing', () => {
   it('clamps lineInGain into 0..31', async () => {
-    stubFetch({ hasOnboardCodec: true, lineInGain: 99 });
+    stubFetch({ hasOnboardCodec: true, source: 'RadioLineIn', lineInGain: 99 });
     const s = await fetchAudioFrontEnd();
     expect(s.lineInGain).toBe(31);
   });
 
-  it('defaults gates false on garbage', async () => {
+  it('defaults gates false + source Host on garbage', async () => {
     stubFetch(42);
     const s = await fetchAudioFrontEnd();
     expect(s.hasOnboardCodec).toBe(false);
     expect(s.hermesLite2MicFrontEnd).toBe(false);
+    expect(s.source).toBe('Host');
     expect(s.lineInGain).toBe(0);
+  });
+
+  it('parses the numeric enum form of source', async () => {
+    stubFetch({ source: 1 }); // RadioMic
+    const s = await fetchAudioFrontEnd();
+    expect(s.source).toBe('RadioMic');
+  });
+
+  it('falls back to Host on an unknown source string', async () => {
+    stubFetch({ source: 'Nonsense' });
+    const s = await fetchAudioFrontEnd();
+    expect(s.source).toBe('Host');
   });
 
   it('throws on a 409 from the PUT', async () => {
     stubFetch({ error: 'no audio' }, 409);
     await expect(
       updateAudioFrontEnd({
-        lineIn: true,
+        source: 'RadioMic',
         micBoost: false,
         micBias: false,
-        balancedInput: false,
         lineInGain: 0,
       }),
     ).rejects.toThrow();
@@ -74,15 +88,14 @@ describe('audio-store update', () => {
     stubFetch({
       hasOnboardCodec: true,
       hermesLite2MicFrontEnd: false,
-      lineIn: true,
+      source: 'RadioMic',
       micBoost: true,
       micBias: false,
-      balancedInput: false,
       lineInGain: 12,
     });
-    await useAudioStore.getState().update({ lineIn: true, micBoost: true });
+    await useAudioStore.getState().update({ source: 'RadioMic', micBoost: true });
     const s = useAudioStore.getState().settings;
-    expect(s.lineIn).toBe(true);
+    expect(s.source).toBe('RadioMic');
     expect(s.micBoost).toBe(true);
     expect(s.lineInGain).toBe(12);
   });
@@ -92,10 +105,12 @@ describe('audio-store update', () => {
       settings: {
         hasOnboardCodec: true,
         hermesLite2MicFrontEnd: false,
-        lineIn: false,
+        hasRadioLineIn: false,
+        hasBalancedXlr: false,
+        hasMicBias: true,
+        source: 'RadioMic',
         micBoost: false,
         micBias: false,
-        balancedInput: false,
         lineInGain: 3,
       },
     });

--- a/zeus-web/src/state/audio-store.test.ts
+++ b/zeus-web/src/state/audio-store.test.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Audio front-end store — parse robustness + optimistic update round-trip
+// (external-ports plan, Phase 4).
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  fetchAudioFrontEnd,
+  updateAudioFrontEnd,
+  useAudioStore,
+} from './audio-store';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  useAudioStore.setState({
+    settings: {
+      hasOnboardCodec: false,
+      hermesLite2MicFrontEnd: false,
+      lineIn: false,
+      micBoost: false,
+      micBias: false,
+      balancedInput: false,
+      lineInGain: 0,
+    },
+    loaded: false,
+    inflight: false,
+    error: null,
+  });
+});
+
+function stubFetch(body: unknown, status = 200) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+}
+
+describe('audio-store parsing', () => {
+  it('clamps lineInGain into 0..31', async () => {
+    stubFetch({ hasOnboardCodec: true, lineInGain: 99 });
+    const s = await fetchAudioFrontEnd();
+    expect(s.lineInGain).toBe(31);
+  });
+
+  it('defaults gates false on garbage', async () => {
+    stubFetch(42);
+    const s = await fetchAudioFrontEnd();
+    expect(s.hasOnboardCodec).toBe(false);
+    expect(s.hermesLite2MicFrontEnd).toBe(false);
+    expect(s.lineInGain).toBe(0);
+  });
+
+  it('throws on a 409 from the PUT', async () => {
+    stubFetch({ error: 'no audio' }, 409);
+    await expect(
+      updateAudioFrontEnd({
+        lineIn: true,
+        micBoost: false,
+        micBias: false,
+        balancedInput: false,
+        lineInGain: 0,
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('audio-store update', () => {
+  it('optimistically patches then adopts the server response', async () => {
+    stubFetch({
+      hasOnboardCodec: true,
+      hermesLite2MicFrontEnd: false,
+      lineIn: true,
+      micBoost: true,
+      micBias: false,
+      balancedInput: false,
+      lineInGain: 12,
+    });
+    await useAudioStore.getState().update({ lineIn: true, micBoost: true });
+    const s = useAudioStore.getState().settings;
+    expect(s.lineIn).toBe(true);
+    expect(s.micBoost).toBe(true);
+    expect(s.lineInGain).toBe(12);
+  });
+
+  it('rolls back on PUT failure', async () => {
+    useAudioStore.setState({
+      settings: {
+        hasOnboardCodec: true,
+        hermesLite2MicFrontEnd: false,
+        lineIn: false,
+        micBoost: false,
+        micBias: false,
+        balancedInput: false,
+        lineInGain: 3,
+      },
+    });
+    stubFetch({ error: 'boom' }, 409);
+    await useAudioStore.getState().update({ micBias: true });
+    const s = useAudioStore.getState().settings;
+    expect(s.micBias).toBe(false); // rolled back
+    expect(useAudioStore.getState().error).toBeTruthy();
+  });
+});

--- a/zeus-web/src/state/audio-store.ts
+++ b/zeus-web/src/state/audio-store.ts
@@ -4,41 +4,65 @@
 // Copyright (C) 2025-2026 Brian Keating (EI6LF),
 //                         Douglas J. Cerrato (KB2UKA), and contributors.
 //
-// Global (per-radio, NOT per-band) audio front-end (external-ports plan,
-// Phase 4). Mirrors /api/radio/audio, which is server-authoritative: the
-// backend reads AudioSettingsStore and pushes the selection to the live radio
-// through PushAudioFrontEnd, so the frontend never clobbers the server on
-// connect — it only loads + PUTs operator edits.
+// Global (per-radio, NOT per-band) TX-audio SOURCE (external-ports plan, §2/§11).
+// Mirrors /api/radio/audio, which is server-authoritative: the backend reads
+// AudioSettingsStore, CLAMPS the source against the connected board, and pushes
+// the resolved selection to the live radio through PushAudioFrontEnd, so the
+// frontend never clobbers the server on connect — it only loads + PUTs operator
+// edits. The GET response carries per-board source-availability gates so the
+// single-select picker offers only the sources the board has (Host is always
+// available).
 //
-// The GET response carries the capability gates (hasOnboardCodec for the
-// Hermes-class mic-boost / line-in controls; hermesLite2MicFrontEnd for the
-// HL2 mic_trs(balanced) / mic_bias / line-in-gain controls) so the panel can
-// render the right controls.
+// This replaces the prior four-bool model (lineIn/balancedInput peers); line-in
+// and balanced are now distinct `source` enum values.
 
 import { create } from 'zustand';
 
+// Must match Zeus.Contracts.TxAudioSource (string round-trips via STJ enum
+// names — the wire carries the member name, e.g. "RadioMic").
+export type TxAudioSource = 'Host' | 'RadioMic' | 'RadioLineIn' | 'RadioBalancedXlr';
+
+const SOURCES: readonly TxAudioSource[] = ['Host', 'RadioMic', 'RadioLineIn', 'RadioBalancedXlr'];
+
 export interface AudioFrontEnd {
+  // Per-board source-availability gates (read-only / server-set).
   hasOnboardCodec: boolean;
   hermesLite2MicFrontEnd: boolean;
-  lineIn: boolean;
+  hasRadioLineIn: boolean;
+  hasBalancedXlr: boolean;
+  hasMicBias: boolean;
+  // The resolved (board-clamped) source + its params.
+  source: TxAudioSource;
   micBoost: boolean;
   micBias: boolean;
-  balancedInput: boolean;
   lineInGain: number;
 }
 
 const DEFAULT_AUDIO: AudioFrontEnd = {
   hasOnboardCodec: false,
   hermesLite2MicFrontEnd: false,
-  lineIn: false,
+  hasRadioLineIn: false,
+  hasBalancedXlr: false,
+  hasMicBias: false,
+  source: 'Host',
   micBoost: false,
   micBias: false,
-  balancedInput: false,
   lineInGain: 0,
 };
 
 function parseBool(v: unknown, fallback: boolean): boolean {
   return typeof v === 'boolean' ? v : fallback;
+}
+
+function parseSource(v: unknown): TxAudioSource {
+  // Tolerate the numeric enum form (0..3) as well as the STJ member-name form.
+  if (typeof v === 'string' && (SOURCES as readonly string[]).includes(v)) {
+    return v as TxAudioSource;
+  }
+  if (typeof v === 'number' && Number.isInteger(v) && v >= 0 && v < SOURCES.length) {
+    return SOURCES[v] ?? 'Host';
+  }
+  return 'Host';
 }
 
 function parse(raw: unknown): AudioFrontEnd {
@@ -48,10 +72,12 @@ function parse(raw: unknown): AudioFrontEnd {
   return {
     hasOnboardCodec: parseBool(r.hasOnboardCodec, false),
     hermesLite2MicFrontEnd: parseBool(r.hermesLite2MicFrontEnd, false),
-    lineIn: parseBool(r.lineIn, false),
+    hasRadioLineIn: parseBool(r.hasRadioLineIn, false),
+    hasBalancedXlr: parseBool(r.hasBalancedXlr, false),
+    hasMicBias: parseBool(r.hasMicBias, false),
+    source: parseSource(r.source),
     micBoost: parseBool(r.micBoost, false),
     micBias: parseBool(r.micBias, false),
-    balancedInput: parseBool(r.balancedInput, false),
     lineInGain: Math.min(31, Math.max(0, Math.round(gain))),
   };
 }
@@ -59,7 +85,7 @@ function parse(raw: unknown): AudioFrontEnd {
 // The mutable subset an operator can PUT (the gates are read-only / server-set).
 export type AudioFrontEndEdit = Pick<
   AudioFrontEnd,
-  'lineIn' | 'micBoost' | 'micBias' | 'balancedInput' | 'lineInGain'
+  'source' | 'micBoost' | 'micBias' | 'lineInGain'
 >;
 
 export async function fetchAudioFrontEnd(
@@ -114,14 +140,14 @@ export const useAudioStore = create<AudioStore>((set, get) => ({
 
   update: async (patch) => {
     // Optimistic local update, rollback on error — same idiom as the antenna
-    // store. The PUT returns the canonical settings (incl. clamped gain) which
-    // we adopt so the local view stays in lockstep with the server.
+    // store. The PUT returns the canonical settings (incl. board-clamped source
+    // + clamped gain) which we adopt so the local view stays in lockstep with
+    // the server.
     const prev = get().settings;
     const edit: AudioFrontEndEdit = {
-      lineIn: patch.lineIn ?? prev.lineIn,
+      source: patch.source ?? prev.source,
       micBoost: patch.micBoost ?? prev.micBoost,
       micBias: patch.micBias ?? prev.micBias,
-      balancedInput: patch.balancedInput ?? prev.balancedInput,
       lineInGain: patch.lineInGain ?? prev.lineInGain,
     };
     set({ settings: { ...prev, ...edit }, inflight: true, error: null });

--- a/zeus-web/src/state/audio-store.ts
+++ b/zeus-web/src/state/audio-store.ts
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Global (per-radio, NOT per-band) audio front-end (external-ports plan,
+// Phase 4). Mirrors /api/radio/audio, which is server-authoritative: the
+// backend reads AudioSettingsStore and pushes the selection to the live radio
+// through PushAudioFrontEnd, so the frontend never clobbers the server on
+// connect — it only loads + PUTs operator edits.
+//
+// The GET response carries the capability gates (hasOnboardCodec for the
+// Hermes-class mic-boost / line-in controls; hermesLite2MicFrontEnd for the
+// HL2 mic_trs(balanced) / mic_bias / line-in-gain controls) so the panel can
+// render the right controls.
+
+import { create } from 'zustand';
+
+export interface AudioFrontEnd {
+  hasOnboardCodec: boolean;
+  hermesLite2MicFrontEnd: boolean;
+  lineIn: boolean;
+  micBoost: boolean;
+  micBias: boolean;
+  balancedInput: boolean;
+  lineInGain: number;
+}
+
+const DEFAULT_AUDIO: AudioFrontEnd = {
+  hasOnboardCodec: false,
+  hermesLite2MicFrontEnd: false,
+  lineIn: false,
+  micBoost: false,
+  micBias: false,
+  balancedInput: false,
+  lineInGain: 0,
+};
+
+function parseBool(v: unknown, fallback: boolean): boolean {
+  return typeof v === 'boolean' ? v : fallback;
+}
+
+function parse(raw: unknown): AudioFrontEnd {
+  if (!raw || typeof raw !== 'object') return DEFAULT_AUDIO;
+  const r = raw as Record<string, unknown>;
+  const gain = typeof r.lineInGain === 'number' ? r.lineInGain : 0;
+  return {
+    hasOnboardCodec: parseBool(r.hasOnboardCodec, false),
+    hermesLite2MicFrontEnd: parseBool(r.hermesLite2MicFrontEnd, false),
+    lineIn: parseBool(r.lineIn, false),
+    micBoost: parseBool(r.micBoost, false),
+    micBias: parseBool(r.micBias, false),
+    balancedInput: parseBool(r.balancedInput, false),
+    lineInGain: Math.min(31, Math.max(0, Math.round(gain))),
+  };
+}
+
+// The mutable subset an operator can PUT (the gates are read-only / server-set).
+export type AudioFrontEndEdit = Pick<
+  AudioFrontEnd,
+  'lineIn' | 'micBoost' | 'micBias' | 'balancedInput' | 'lineInGain'
+>;
+
+export async function fetchAudioFrontEnd(
+  signal?: AbortSignal,
+): Promise<AudioFrontEnd> {
+  const res = await fetch('/api/radio/audio', { signal });
+  if (!res.ok) throw new Error(`GET /api/radio/audio → ${res.status}`);
+  return parse(await res.json());
+}
+
+export async function updateAudioFrontEnd(
+  edit: AudioFrontEndEdit,
+  signal?: AbortSignal,
+): Promise<AudioFrontEnd> {
+  const res = await fetch('/api/radio/audio', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(edit),
+    signal,
+  });
+  if (!res.ok) throw new Error(`PUT /api/radio/audio → ${res.status}`);
+  return parse(await res.json());
+}
+
+type AudioStore = {
+  settings: AudioFrontEnd;
+  loaded: boolean;
+  inflight: boolean;
+  error: string | null;
+  load: () => Promise<void>;
+  update: (patch: Partial<AudioFrontEndEdit>) => Promise<void>;
+};
+
+export const useAudioStore = create<AudioStore>((set, get) => ({
+  settings: DEFAULT_AUDIO,
+  loaded: false,
+  inflight: false,
+  error: null,
+
+  load: async () => {
+    set({ inflight: true, error: null });
+    try {
+      const s = await fetchAudioFrontEnd();
+      set({ settings: s, loaded: true, inflight: false });
+    } catch (err) {
+      set({
+        error: err instanceof Error ? err.message : String(err),
+        inflight: false,
+      });
+    }
+  },
+
+  update: async (patch) => {
+    // Optimistic local update, rollback on error — same idiom as the antenna
+    // store. The PUT returns the canonical settings (incl. clamped gain) which
+    // we adopt so the local view stays in lockstep with the server.
+    const prev = get().settings;
+    const edit: AudioFrontEndEdit = {
+      lineIn: patch.lineIn ?? prev.lineIn,
+      micBoost: patch.micBoost ?? prev.micBoost,
+      micBias: patch.micBias ?? prev.micBias,
+      balancedInput: patch.balancedInput ?? prev.balancedInput,
+      lineInGain: patch.lineInGain ?? prev.lineInGain,
+    };
+    set({ settings: { ...prev, ...edit }, inflight: true, error: null });
+    try {
+      const s = await updateAudioFrontEnd(edit);
+      set({ settings: s, inflight: false });
+    } catch (err) {
+      set({
+        settings: prev,
+        error: err instanceof Error ? err.message : String(err),
+        inflight: false,
+      });
+    }
+  },
+}));

--- a/zeus-web/src/state/hl2-gpio-store.ts
+++ b/zeus-web/src/state/hl2-gpio-store.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// HL2 user GPIO (external-ports plan, Phase 5). Mirrors /api/radio/hl2-gpio:
+// the 4-bit user_dig_out mask → register 0x0a (wire 0x14) C3[3:0] MCP23008.
+// Server-authoritative (the backend pushes the persisted mask to the live
+// client on connect), so the frontend only loads + PUTs operator edits. HL2
+// only; `supported` gates the toggle group.
+
+import { create } from 'zustand';
+
+export interface Hl2Gpio {
+  supported: boolean;
+  bits: number; // 4-bit mask
+}
+
+const DEFAULT: Hl2Gpio = { supported: false, bits: 0 };
+
+function parse(raw: unknown): Hl2Gpio {
+  if (!raw || typeof raw !== 'object') return DEFAULT;
+  const r = raw as Record<string, unknown>;
+  return {
+    supported: typeof r.supported === 'boolean' ? r.supported : false,
+    bits: typeof r.bits === 'number' ? r.bits & 0x0f : 0,
+  };
+}
+
+export async function fetchHl2Gpio(signal?: AbortSignal): Promise<Hl2Gpio> {
+  const res = await fetch('/api/radio/hl2-gpio', { signal });
+  if (!res.ok) throw new Error(`GET /api/radio/hl2-gpio → ${res.status}`);
+  return parse(await res.json());
+}
+
+export async function updateHl2Gpio(
+  bits: number,
+  signal?: AbortSignal,
+): Promise<Hl2Gpio> {
+  const res = await fetch('/api/radio/hl2-gpio', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ bits: bits & 0x0f }),
+    signal,
+  });
+  if (!res.ok) throw new Error(`PUT /api/radio/hl2-gpio → ${res.status}`);
+  return parse(await res.json());
+}
+
+type Hl2GpioStore = {
+  state: Hl2Gpio;
+  inflight: boolean;
+  error: string | null;
+  load: () => Promise<void>;
+  setBit: (bit: number, on: boolean) => Promise<void>;
+};
+
+export const useHl2GpioStore = create<Hl2GpioStore>((set, get) => ({
+  state: DEFAULT,
+  inflight: false,
+  error: null,
+
+  load: async () => {
+    set({ inflight: true, error: null });
+    try {
+      const s = await fetchHl2Gpio();
+      set({ state: s, inflight: false });
+    } catch (err) {
+      set({
+        error: err instanceof Error ? err.message : String(err),
+        inflight: false,
+      });
+    }
+  },
+
+  setBit: async (bit, on) => {
+    const prev = get().state;
+    const mask = 1 << bit;
+    const nextBits = (on ? prev.bits | mask : prev.bits & ~mask) & 0x0f;
+    set({ state: { ...prev, bits: nextBits }, inflight: true, error: null });
+    try {
+      const s = await updateHl2Gpio(nextBits);
+      set({ state: s, inflight: false });
+    } catch (err) {
+      set({
+        state: prev,
+        error: err instanceof Error ? err.message : String(err),
+        inflight: false,
+      });
+    }
+  },
+}));

--- a/zeus-web/src/state/ptt-store.test.ts
+++ b/zeus-web/src/state/ptt-store.test.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// PTT-IN status store + wire decode (external-ports plan §4).
+//   1. setKeyed writes the live lamp level; reset clears.
+//   2. The 2-byte [0x33][keyed:u8] PttStatusFrame round-trips through the same
+//      decode the ws-client dispatcher does, into the store.
+
+import { describe, expect, it } from 'vitest';
+
+import { usePttStore } from './ptt-store';
+
+const MSG_TYPE_PTT_STATUS = 0x33;
+const PTT_STATUS_BYTES = 2;
+
+function encodePttStatusFrame(keyed: boolean): ArrayBuffer {
+  const buf = new ArrayBuffer(PTT_STATUS_BYTES);
+  const dv = new DataView(buf);
+  dv.setUint8(0, MSG_TYPE_PTT_STATUS);
+  dv.setUint8(1, keyed ? 1 : 0);
+  return buf;
+}
+
+// Mirrors the ws-client dispatcher branch for 0x33.
+function dispatchPttStatus(data: ArrayBuffer): void {
+  const dv = new DataView(data);
+  usePttStore.getState().setKeyed(dv.getUint8(1) !== 0);
+}
+
+describe('ptt-store', () => {
+  it('defaults: idle, enabled ON, hang 250 ms', () => {
+    usePttStore.getState().__resetForTests();
+    const s = usePttStore.getState();
+    expect(s.keyed).toBe(false);
+    expect(s.enabled).toBe(true);
+    expect(s.hangMs).toBe(250);
+  });
+
+  it('setKeyed toggles the lamp', () => {
+    usePttStore.getState().__resetForTests();
+    usePttStore.getState().setKeyed(true);
+    expect(usePttStore.getState().keyed).toBe(true);
+    usePttStore.getState().setKeyed(false);
+    expect(usePttStore.getState().keyed).toBe(false);
+  });
+});
+
+describe('ptt-status wire decode', () => {
+  it('byte-length is 2 (1 type + 1 keyed)', () => {
+    expect(encodePttStatusFrame(true).byteLength).toBe(2);
+  });
+
+  it('first byte is the PttStatus type (0x33)', () => {
+    expect(new DataView(encodePttStatusFrame(false)).getUint8(0)).toBe(MSG_TYPE_PTT_STATUS);
+  });
+
+  it('keyed edge dispatches into the store', () => {
+    usePttStore.getState().__resetForTests();
+    dispatchPttStatus(encodePttStatusFrame(true));
+    expect(usePttStore.getState().keyed).toBe(true);
+    dispatchPttStatus(encodePttStatusFrame(false));
+    expect(usePttStore.getState().keyed).toBe(false);
+  });
+});

--- a/zeus-web/src/state/ptt-store.ts
+++ b/zeus-web/src/state/ptt-store.ts
@@ -15,7 +15,7 @@ import { create } from 'zustand';
 export interface PttStatus {
   /** Live PTT-IN level — true while the hardware footswitch/mic-PTT is held. */
   keyed: boolean;
-  /** Whether hardware PTT is promoted to MOX. Defaults ON server-side. */
+  /** Whether hardware PTT is promoted to MOX. Defaults OFF server-side (opt-in). */
   enabled: boolean;
   /** Fixed release hang in ms (250). Read-only label; knob is out of scope. */
   hangMs: number;
@@ -25,7 +25,7 @@ function parse(raw: unknown): PttStatus {
   const r = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
   return {
     keyed: typeof r.keyed === 'boolean' ? r.keyed : false,
-    enabled: typeof r.enabled === 'boolean' ? r.enabled : true,
+    enabled: typeof r.enabled === 'boolean' ? r.enabled : false,
     hangMs: typeof r.hangMs === 'number' ? r.hangMs : 250,
   };
 }
@@ -62,7 +62,7 @@ interface PttState extends PttStatus {
 
 export const usePttStore = create<PttState>((set, get) => ({
   keyed: false,
-  enabled: true,
+  enabled: false,
   hangMs: 250,
   loaded: false,
   inflight: false,

--- a/zeus-web/src/state/ptt-store.ts
+++ b/zeus-web/src/state/ptt-store.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Hardware-PTT-IN status store (external-ports plan §4). Holds the live
+// footswitch / mic-PTT / rear-KEY level for the Radio Settings "PTT-IN:
+// idle / keyed" lamp, plus the MOX-promotion enable gate and the fixed hang.
+//
+// `keyed` is written from the WS dispatcher on every PttStatusFrame (0x33).
+// The frame source is per-protocol on the server (P1 HardwarePttChanged, P2
+// UDP-1025 PttIn) so the lamp tracks the physical input regardless of board.
+// `enabled` / `hangMs` hydrate from GET /api/radio/ptt-status on connect and
+// re-sync on a PUT toggle — server-authoritative, never clobbered on connect.
+
+import { create } from 'zustand';
+
+export interface PttStatus {
+  /** Live PTT-IN level — true while the hardware footswitch/mic-PTT is held. */
+  keyed: boolean;
+  /** Whether hardware PTT is promoted to MOX. Defaults ON server-side. */
+  enabled: boolean;
+  /** Fixed release hang in ms (250). Read-only label; knob is out of scope. */
+  hangMs: number;
+}
+
+function parse(raw: unknown): PttStatus {
+  const r = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+  return {
+    keyed: typeof r.keyed === 'boolean' ? r.keyed : false,
+    enabled: typeof r.enabled === 'boolean' ? r.enabled : true,
+    hangMs: typeof r.hangMs === 'number' ? r.hangMs : 250,
+  };
+}
+
+export async function fetchPttStatus(signal?: AbortSignal): Promise<PttStatus> {
+  const res = await fetch('/api/radio/ptt-status', { signal });
+  if (!res.ok) throw new Error(`GET /api/radio/ptt-status → ${res.status}`);
+  return parse(await res.json());
+}
+
+export async function updatePttEnable(enabled: boolean, signal?: AbortSignal): Promise<PttStatus> {
+  const res = await fetch('/api/radio/ptt-status', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ enabled }),
+    signal,
+  });
+  if (!res.ok) throw new Error(`PUT /api/radio/ptt-status → ${res.status}`);
+  return parse(await res.json());
+}
+
+interface PttState extends PttStatus {
+  loaded: boolean;
+  inflight: boolean;
+  error: string | null;
+  /** WS-driven live lamp update (PttStatusFrame). */
+  setKeyed: (keyed: boolean) => void;
+  /** Hydrate enable/hang from the REST snapshot. */
+  load: () => Promise<void>;
+  /** Toggle the MOX-promotion gate (optimistic, server-authoritative). */
+  setEnabled: (enabled: boolean) => Promise<void>;
+  __resetForTests: () => void;
+}
+
+export const usePttStore = create<PttState>((set, get) => ({
+  keyed: false,
+  enabled: true,
+  hangMs: 250,
+  loaded: false,
+  inflight: false,
+  error: null,
+
+  setKeyed: (keyed) => set({ keyed }),
+
+  load: async () => {
+    set({ inflight: true, error: null });
+    try {
+      const s = await fetchPttStatus();
+      // Don't clobber the live lamp with the REST snapshot's stale `keyed` —
+      // the WS frame is the authority for that field once connected.
+      set({ enabled: s.enabled, hangMs: s.hangMs, loaded: true, inflight: false });
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : String(err), inflight: false });
+    }
+  },
+
+  setEnabled: async (enabled) => {
+    const prev = get().enabled;
+    set({ enabled, inflight: true, error: null });
+    try {
+      const s = await updatePttEnable(enabled);
+      set({ enabled: s.enabled, hangMs: s.hangMs, inflight: false });
+    } catch (err) {
+      set({ enabled: prev, error: err instanceof Error ? err.message : String(err), inflight: false });
+    }
+  },
+
+  __resetForTests: () =>
+    set({ keyed: false, enabled: true, hangMs: 250, loaded: false, inflight: false, error: null }),
+}));


### PR DESCRIPTION
Complete **external-port control** across every ANAN radio + Hermes-Lite 2, both protocols, in a board-aware **"Radio Settings"** menu. Built and **bench-corrected** from real G2 testing. **DRAFT + do-not-merge — only KB2UKA merges, after the Discord tester group signs off.**

**PureSignal (P1 + P2) is preserved by construction** — every audio/antenna/PTT surface is byte-identical at its default, the HL2 `0x14` writes preserve `puresignal_run`, and the PS-K36 firewall holds. All PS golden tests green.

## Audio — TX source selection (the corrected model)
A **single-select source** (radio buttons, exactly one active): **Host (default = Zeus today, unchanged) · Radio Mic · Radio Line-In · Radio Balanced/XLR**. Selecting a radio jack actually **switches the TX source** — Zeus decodes the radio's mic stream (UDP 1026) through a 960-sample re-blocker and feeds it to TXA, suppressing host mic via an **in-lock atomic single-select gate** (no double-feed across a switch, proven by a 5000-iteration concurrency test). `mic boost / bias / line-gain` are **parameters of the active source**, not independent toggles; mic-bias is behind a PTT-hang confirmation. Per board: **G2 = all four**; most ANANs = **Host + Mic**; **HL2 = Host only** (no onboard codec). This **replaces a flawed first attempt** (4 checkboxes that only sent config bytes and never switched the source).

## Antenna
TX/RX ANT1/2/3 (state-multiplexed per piHPSDR — **fixes a bench bug where TX-antenna change moved RX**), RX-aux EXT/XVTR/BYPASS with the PS-K36 firewall, HL2 RX clamp. Per-band.

## PTT (footswitch)
**New P2 hardware-PTT→MOX path** — footswitch keying did **not** work on the G2 before (the service was P1-only); now `ExternalPttService` handles both protocols through one shared 250 ms-hang/arbitration engine. Per-protocol **PTT-IN status lamp** + `/api/radio/ptt-status` + Enable gate.

## Per-radio port matrix (from Thetis / mi0bot for HL2)
Audio jacks, PTT, CW, antenna grounded per board — most ANANs mic-only, line-in on 200D + 0x0A, balanced XLR on G2/G2-1K only, HL2 audio over USB/Ethernet.

## Verification
Backend **835 server / 253 P1 / 148 P2 / 95 contracts / 152 DSP** green; frontend **305** green; Release build 0 warnings; real `tsc -b` exit 0. Host-byte-identical full-buffer goldens, encoder purity (no Host param leak), concurrency double-feed, re-block→non-zero-IQ, P2 PTT edge→MOX, per-protocol lamp, default-off UI — all covered.

## 🔴 Bench checklist (KB2UKA + testers)
- **G2:** Host TX byte-identical → engage Radio Mic/Line/Balanced (radio audio transmits, host drops) → switch Host↔Radio & jack↔jack **mid-TX, no double-feed/dead-air/bare-carrier** → **PureSignal clean throughout** → footswitch keys MOX (lamp tracks) → antenna ANT2/3 + RX-aux.
- **HL2:** Host-only audio (no picker) → footswitch keys MOX (P1 path) → PS preserved.
- **Other boards:** flagged for owner bench — same wire path, unverified.

## 🟡 Maintainer flags
Additive `Zeus.Contracts` (TxAudioSource enum) — KB2UKA approved. Visual specifics (control type, wording, confirm copy) red-light for Brian. Deferred: HL2 dynamic I2C, L/R swap, hang-time knob, PTT-out.

🔒 Not merging — KB2UKA only, after testing. Ref: external-ports corrected plan.
