### PR TITLE
fix(dsp): stop filter-drag double-free (serialize WDSP/FFTW bandpass recompute)

### DIFF
--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -170,6 +170,13 @@ public sealed class WdspDspEngine : IDspEngine
     // so we don't register it in _channels. _txaLock serializes OpenTxChannel
     // vs SetMox vs teardown — all three are rare, so a plain lock is fine.
     private readonly object _txaLock = new();
+    // FFTW plan create/destroy is NOT thread-safe (bundled libfftw3 built without
+    // --enable-threads). Every bandpass setter below rebuilds a plan; concurrent
+    // HTTP-worker filter updates double-free without this. Static = process-wide:
+    // RXA, TXA, and TXA-monitor channels all share one FFTW planner.
+    // LEAF LOCK: never acquire any other lock while holding this; safe to hold
+    // _txaLock/_monitorLock around it (one-way nesting, no cycle).
+    private static readonly object _fftwPlannerGate = new();
     // Counter throttles fexchange2-error logging so a persistent wire-protocol
     // mismatch doesn't flood the log. First 8 errors are visible then suppressed.
     private int _txFexchangeErrLogged;
@@ -387,9 +394,12 @@ public sealed class WdspDspEngine : IDspEngine
         NativeMethods.SetRXAPanelBinaural(id, 0);
         NativeMethods.SetRXAPanelGain1(id, 1.0);
         NativeMethods.SetRXAMode(id, (int)RxaMode.USB);
-        NativeMethods.SetRXABandpassFreqs(id, 150.0, 2850.0);
-        NativeMethods.RXANBPSetFreqs(id, 150.0, 2850.0);
-        NativeMethods.SetRXASNBAOutputBandwidth(id, 150.0, 2850.0);
+        lock (_fftwPlannerGate)
+        {
+            NativeMethods.SetRXABandpassFreqs(id, 150.0, 2850.0);
+            NativeMethods.RXANBPSetFreqs(id, 150.0, 2850.0);
+            NativeMethods.SetRXASNBAOutputBandwidth(id, 150.0, 2850.0);
+        }
 
         ApplyAgcDefaults(id);
 
@@ -533,9 +543,16 @@ public sealed class WdspDspEngine : IDspEngine
         // an `rx_osc = -(dial - centre)` then calls SetRXAShiftFreq(-osc), so
         // the net argument is (dial - centre) = our shiftHz. Same goes to
         // the nbp0 stage that enforces SSB sideband.
-        NativeMethods.SetRXAShiftFreq(channelId, shiftHz);
-        NativeMethods.RXANBPSetShiftFrequency(channelId, shiftHz);
-        NativeMethods.SetRXAShiftRun(channelId, shiftHz != 0 ? 1 : 0);
+        // RXANBPSetShiftFrequency rebuilds the nbp0 FIR (calc_nbp_lightweight),
+        // so it must share _fftwPlannerGate with the bandpass setters — a CTUN
+        // shift on tune can otherwise race a concurrent filter recompute and
+        // double-free the FFTW plan. Same leaf lock, no value/order change.
+        lock (_fftwPlannerGate)
+        {
+            NativeMethods.SetRXAShiftFreq(channelId, shiftHz);
+            NativeMethods.RXANBPSetShiftFrequency(channelId, shiftHz);
+            NativeMethods.SetRXAShiftRun(channelId, shiftHz != 0 ? 1 : 0);
+        }
     }
 
     public void SetRxDisplayFastAttack(int channelId, bool fast)
@@ -1153,7 +1170,10 @@ public sealed class WdspDspEngine : IDspEngine
             // re-asserts this from the live StateDto (TxFilterLowHz/HighHz)
             // immediately after OpenTxChannel so operator-edited widths survive
             // a protocol switch / engine reopen.
-            NativeMethods.SetTXABandpassFreqs(id, 150.0, 2850.0);
+            lock (_fftwPlannerGate)
+            {
+                NativeMethods.SetTXABandpassFreqs(id, 150.0, 2850.0);
+            }
             NativeMethods.SetTXABandpassWindow(id, 1);
             // Intentionally NOT calling SetTXABandpassRun(id, 1): despite the
             // name it sets bp1.run (the compressor-only aux bandpass), not bp0,
@@ -1605,7 +1625,10 @@ public sealed class WdspDspEngine : IDspEngine
         lock (_txaLock)
         {
             if (_txaChannelId is not int txa) return;
-            NativeMethods.SetTXABandpassFreqs(txa, lowHz, highHz);
+            lock (_fftwPlannerGate)
+            {
+                NativeMethods.SetTXABandpassFreqs(txa, lowHz, highHz);
+            }
         }
         // Mirror the filter onto the monitor channel so the audition stays at
         // the same bandwidth as the on-air signal. Stash the values regardless
@@ -2898,9 +2921,12 @@ public sealed class WdspDspEngine : IDspEngine
         // Thetis rxa.cs:110-124: every filter change updates all three stages.
         // SetRXABandpassFreqs alone only affects bp1, which is bypassed for SSB.
         // nbp0 (RXANBPSetFreqs) is what actually carries the SSB passband.
-        NativeMethods.SetRXABandpassFreqs(state.Id, low, high);
-        NativeMethods.RXANBPSetFreqs(state.Id, low, high);
-        NativeMethods.SetRXASNBAOutputBandwidth(state.Id, low, high);
+        lock (_fftwPlannerGate)
+        {
+            NativeMethods.SetRXABandpassFreqs(state.Id, low, high);
+            NativeMethods.RXANBPSetFreqs(state.Id, low, high);
+            NativeMethods.SetRXASNBAOutputBandwidth(state.Id, low, high);
+        }
     }
 
     private static RxaMode MapMode(RxMode mode) => mode switch

--- a/tests/Zeus.Dsp.Tests/WdspDspEngineBandpassConcurrencyTests.cs
+++ b/tests/Zeus.Dsp.Tests/WdspDspEngineBandpassConcurrencyTests.cs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using Zeus.Contracts;
+using Zeus.Dsp;
+using Zeus.Dsp.Wdsp;
+
+namespace Zeus.Dsp.Tests;
+
+// Regression guard for fix/filter-drag-double-free. Dragging the RX filter
+// edge very fast floods POST /api/filter; the minimal-API handler runs on
+// ASP.NET thread-pool workers, so two filter updates land on two threads and
+// both rebuild an FFTW plan via SetRXABandpassFreqs / RXANBPSetFreqs /
+// SetRXASNBAOutputBandwidth (and the TX leg via SetTXABandpassFreqs). The
+// bundled libfftw3 is built WITHOUT --enable-threads, so concurrent plan
+// create/destroy double-frees. On macOS libmalloc aborts with
+// POINTER_BEING_FREED_WAS_NOT_ALLOCATED; on Linux/Windows it corrupts silently.
+//
+// WdspDspEngine._fftwPlannerGate serializes every plan-mutating bandpass call.
+// This test pounds those entry points from many threads at once. With the gate
+// in place it completes cleanly; REMOVE the gate and on the macOS bench this
+// aborts with SIGABRT — that hard abort is the regression sentinel (it cannot
+// be caught as a managed exception, so the test process dies, which is exactly
+// the failure mode the bug filed).
+//
+// Requires the real native WDSP + libfftw3 — the synthetic engine never
+// touches FFTW. Gated like every other WDSP-backed test so CI without the
+// dylib stays green and this runs on the macOS bench where the crash repros.
+[Collection("Wdsp")]
+public class WdspDspEngineBandpassConcurrencyTests
+{
+    private static bool WdspAvailable()
+    {
+        try { return WdspNativeLoader.TryProbe(); }
+        catch { return false; }
+    }
+
+    [SkippableFact]
+    public void ConcurrentFilterAndModeChanges_DoNotDoubleFreeFftwPlans()
+    {
+        Skip.IfNot(WdspAvailable(), "libwdsp not available — builder has not dropped the .dylib yet");
+
+        const int SampleRate = 192_000;
+        const int Width = 2048;
+        const int IterationsPerThread = 2_000;
+        const int RxFilterThreads = 8;
+
+        using var engine = new WdspDspEngine();
+        int rx = engine.OpenChannel(SampleRate, Width);
+        try
+        {
+            engine.OpenTxChannel();
+            engine.SetMode(rx, RxMode.USB);
+
+            using var start = new ManualResetEventSlim(false);
+            var threads = new List<Thread>();
+            Exception? firstError = null;
+            var errorLock = new object();
+
+            void Guard(Action body)
+            {
+                start.Wait();
+                try { body(); }
+                catch (Exception ex)
+                {
+                    lock (errorLock) { firstError ??= ex; }
+                }
+            }
+
+            // RX filter flood — the confirmed crash entry point. Each tick
+            // rebuilds three FFTW plans (bp1 / nbp0 / snba) with a rapidly
+            // varying passband, exactly like a fast edge drag.
+            for (int t = 0; t < RxFilterThreads; t++)
+            {
+                int seed = t;
+                threads.Add(new Thread(() => Guard(() =>
+                {
+                    var rng = new Random(seed);
+                    for (int i = 0; i < IterationsPerThread; i++)
+                    {
+                        int lo = 50 + rng.Next(0, 400);
+                        int hi = lo + 200 + rng.Next(0, 2600);
+                        engine.SetFilter(rx, lo, hi);
+                    }
+                })));
+            }
+
+            // TX filter flood — same plan-rebuild path on the TXA channel,
+            // sharing the one process-wide FFTW planner with the RX threads.
+            threads.Add(new Thread(() => Guard(() =>
+            {
+                var rng = new Random(1001);
+                for (int i = 0; i < IterationsPerThread; i++)
+                {
+                    int lo = 50 + rng.Next(0, 400);
+                    int hi = lo + 200 + rng.Next(0, 2600);
+                    engine.SetTxFilter(lo, hi);
+                }
+            })));
+
+            // Mode flipper — drives the SetMode → ApplyBandpassForMode entry
+            // (the other reachable create/destroy path during a drag).
+            threads.Add(new Thread(() => Guard(() =>
+            {
+                var modes = new[] { RxMode.USB, RxMode.LSB, RxMode.AM, RxMode.CWU };
+                for (int i = 0; i < IterationsPerThread; i++)
+                    engine.SetMode(rx, modes[i % modes.Length]);
+            })));
+
+            foreach (var th in threads) th.Start();
+            start.Set();
+            foreach (var th in threads)
+                Assert.True(th.Join(TimeSpan.FromSeconds(60)), "a bandpass-hammer thread hung");
+
+            Assert.Null(firstError);
+        }
+        finally
+        {
+            engine.CloseChannel(rx);
+        }
+    }
+}

--- a/zeus-web/src/components/filter/FilterMiniPan.tsx
+++ b/zeus-web/src/components/filter/FilterMiniPan.tsx
@@ -64,6 +64,8 @@ export function FilterMiniPan() {
     lastWriteAt: number;
     flushTimer: number | null;
     pointerId: number;
+    inFlight: boolean;
+    dirty: boolean;
   } | null>(null);
 
   useEffect(() => {
@@ -332,8 +334,17 @@ export function FilterMiniPan() {
     const d = dragRef.current;
     if (!d) return;
     d.flushTimer = null;
+    if (d.inFlight) { d.dirty = true; return; }   // coalesce: one POST at a time
+    d.inFlight = true;
     d.lastWriteAt = performance.now();
-    setFilter(d.pendingLo, d.pendingHi, d.activeSlot).catch(() => {});
+    setFilter(d.pendingLo, d.pendingHi, d.activeSlot)
+      .catch(() => {})
+      .finally(() => {
+        const dd = dragRef.current;
+        if (!dd) return;
+        dd.inFlight = false;
+        if (dd.dirty) { dd.dirty = false; flushPending(); }  // send the latest
+      });
   };
 
   const schedule = () => {
@@ -383,6 +394,8 @@ export function FilterMiniPan() {
       lastWriteAt: 0,
       flushTimer: null,
       pointerId: e.pointerId,
+      inFlight: false,
+      dirty: false,
     };
 
     if (activeSlot !== c.filterPresetName) {

--- a/zeus-web/src/components/filter/__tests__/FilterMiniPan.throttle.test.ts
+++ b/zeus-web/src/components/filter/__tests__/FilterMiniPan.throttle.test.ts
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Regression guard for fix/filter-drag-double-free (frontend half). Dragging
+// the RX filter edge fast used to fire one POST /api/filter per mouse-move; a
+// slow request could still be in flight when the next fired, piling concurrent
+// POSTs onto the ASP.NET thread pool and racing the (now-serialized) FFTW
+// planner. FilterMiniPan now coalesces: at most one /api/filter POST is in
+// flight at a time, and the most-recent pending value is sent when it returns.
+// These tests prove (a) only one setFilter is outstanding during a fast drag,
+// and (b) the terminal POST on pointer-up always carries the final drag value.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { createElement } from 'react';
+
+// Mock setFilter so we control when it resolves. A deferred lets us hold a
+// request "in flight" while we fire more pointer-moves. Partial-mock so the
+// rest of the client (NR_CONFIG_DEFAULT, etc., pulled in transitively by the
+// connection store) keeps its real exports.
+const setFilterMock = vi.fn();
+vi.mock('../../../api/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../api/client')>();
+  return {
+    ...actual,
+    setFilter: (...args: unknown[]) => setFilterMock(...args),
+  };
+});
+
+import { FilterMiniPan } from '../FilterMiniPan';
+import { useConnectionStore } from '../../../state/connection-store';
+
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((res) => { resolve = res; });
+  return { promise, resolve };
+}
+
+const RIBBON_SPAN_HZ = 12_000;
+const RECT = { left: 0, top: 0, width: 600, height: 110, right: 600, bottom: 110, x: 0, y: 0 } as DOMRect;
+
+// Convert a passband-edge Hz value to the clientX a pointer would have on a
+// 600px-wide ribbon spanning ±6 kHz — mirrors FilterMiniPan's own mapping.
+function hzToClientX(hz: number): number {
+  return ((hz + RIBBON_SPAN_HZ / 2) / RIBBON_SPAN_HZ) * RECT.width;
+}
+
+function makePointerEvent(type: string, clientX: number): Event {
+  // jsdom lacks PointerEvent; synthesize one carrying the fields the handlers
+  // read (pointerId, button, clientX). React listens for these DOM events.
+  const ev = new Event(type, { bubbles: true, cancelable: true });
+  Object.assign(ev, { pointerId: 1, button: 0, clientX });
+  return ev;
+}
+
+describe('FilterMiniPan drag coalescing', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let canvas: HTMLCanvasElement;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setFilterMock.mockReset();
+
+    // jsdom canvas has no 2D context and no pointer capture / RAF — stub the
+    // bits FilterMiniPan's effect and handlers touch so the component mounts.
+    HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
+      clearRect: vi.fn(), fillRect: vi.fn(), beginPath: vi.fn(), moveTo: vi.fn(),
+      lineTo: vi.fn(), stroke: vi.fn(), fill: vi.fn(), save: vi.fn(),
+      restore: vi.fn(), fillText: vi.fn(), setLineDash: vi.fn(), arc: vi.fn(),
+      closePath: vi.fn(), rect: vi.fn(), clip: vi.fn(), translate: vi.fn(),
+      scale: vi.fn(), measureText: vi.fn(() => ({ width: 0 })),
+    })) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+    HTMLCanvasElement.prototype.setPointerCapture = vi.fn();
+    HTMLCanvasElement.prototype.releasePointerCapture = vi.fn();
+    HTMLCanvasElement.prototype.hasPointerCapture = vi.fn(() => true);
+    HTMLCanvasElement.prototype.getBoundingClientRect = () => RECT;
+    vi.stubGlobal('requestAnimationFrame', () => 0);
+    vi.stubGlobal('cancelAnimationFrame', () => {});
+    vi.stubGlobal('ResizeObserver', class {
+      observe() {} unobserve() {} disconnect() {}
+    });
+    vi.stubGlobal('performance', { now: () => Date.now() });
+
+    useConnectionStore.setState({
+      filterLowHz: 150,
+      filterHighHz: 2850,
+      filterPresetName: 'VAR1',
+    });
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    act(() => {
+      root = createRoot(container);
+      root.render(createElement(FilterMiniPan));
+    });
+    canvas = container.querySelector('canvas')!;
+  });
+
+  afterEach(() => {
+    act(() => { root.unmount(); });
+    container.remove();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps at most one setFilter POST in flight during a fast drag', async () => {
+    const d1 = deferred<unknown>();
+    setFilterMock.mockReturnValueOnce(d1.promise);
+    // Every subsequent (coalesced re-flush) call returns a resolved promise so
+    // the component's .catch()/.finally() chain has something to attach to.
+    setFilterMock.mockReturnValue(Promise.resolve(useConnectionStore.getState()));
+
+    // Grab the HIGH edge (2850 Hz) and drag it fast — many moves inside the
+    // 50ms throttle window while the first POST is unresolved.
+    act(() => {
+      canvas.dispatchEvent(makePointerEvent('pointerdown', hzToClientX(2850)));
+    });
+
+    // First move triggers the immediate flush (elapsed >= interval since
+    // lastWriteAt started at 0) → exactly one setFilter in flight.
+    act(() => {
+      canvas.dispatchEvent(makePointerEvent('pointermove', hzToClientX(2700)));
+    });
+    expect(setFilterMock).toHaveBeenCalledTimes(1);
+
+    // Flood more moves while d1 is still pending and advance fake time past the
+    // throttle interval each time. The coalescing guard must NOT start a second
+    // POST until d1 resolves — they collapse into a single pending "dirty".
+    for (let hz = 2650; hz >= 2300; hz -= 50) {
+      act(() => {
+        vi.advanceTimersByTime(60);
+        canvas.dispatchEvent(makePointerEvent('pointermove', hzToClientX(hz)));
+      });
+    }
+    // Let any queued throttle timers fire — still only the one in-flight POST.
+    act(() => { vi.advanceTimersByTime(200); });
+    expect(setFilterMock).toHaveBeenCalledTimes(1);
+
+    // Resolve the in-flight POST: the coalesced "dirty" value flushes as the
+    // second call, carrying the most-recent drag position.
+    await act(async () => {
+      d1.resolve(undefined);
+      await Promise.resolve();
+    });
+    expect(setFilterMock).toHaveBeenCalledTimes(2);
+    // Latest dragged HIGH edge was 2300 Hz → second POST sends (150, 2300).
+    expect(setFilterMock.mock.calls[1]![0]).toBe(150);
+    expect(setFilterMock.mock.calls[1]![1]).toBe(2300);
+  });
+
+  it('sends the final drag value as the terminal POST on pointer-up', async () => {
+    const d1 = deferred<unknown>();
+    setFilterMock.mockReturnValueOnce(d1.promise);
+    setFilterMock.mockReturnValue(Promise.resolve(useConnectionStore.getState()));
+
+    act(() => {
+      canvas.dispatchEvent(makePointerEvent('pointerdown', hzToClientX(2850)));
+      canvas.dispatchEvent(makePointerEvent('pointermove', hzToClientX(2700)));
+    });
+    expect(setFilterMock).toHaveBeenCalledTimes(1);
+
+    // More fast moves while in flight — coalesced, not sent yet.
+    for (let hz = 2600; hz >= 2400; hz -= 100) {
+      act(() => {
+        vi.advanceTimersByTime(60);
+        canvas.dispatchEvent(makePointerEvent('pointermove', hzToClientX(hz)));
+      });
+    }
+
+    // Resolve the in-flight POST, then move once more and release.
+    await act(async () => { d1.resolve(undefined); await Promise.resolve(); });
+    act(() => {
+      vi.advanceTimersByTime(60);
+      canvas.dispatchEvent(makePointerEvent('pointermove', hzToClientX(2200)));
+    });
+    await act(async () => {
+      canvas.dispatchEvent(makePointerEvent('pointerup', hzToClientX(2200)));
+      await Promise.resolve();
+    });
+
+    // The LAST setFilter invocation must carry the final drag position (2200),
+    // never a stale intermediate value.
+    const last = setFilterMock.mock.calls[setFilterMock.mock.calls.length - 1]!;
+    expect(last[0]).toBe(150);
+    expect(last[1]).toBe(2200);
+  });
+});


### PR DESCRIPTION
## Fixes a filter-drag crash (native double-free) — develop bug, surfaced on macOS

**Symptom:** dragging a filter edge **very fast** crashes Zeus on macOS — `SIGABRT` / `POINTER_BEING_FREED_WAS_NOT_ALLOCATED`. Bench-reproduced on a G2, 3× (his fork *and* plain develop crash identically — this is a develop bug, not branch-specific).

**Root cause:** a fast drag fires a flood of `POST /api/filter` updates. The minimal-API handler runs on ASP.NET thread-pool workers, so two updates land on two threads at once and both call the WDSP bandpass setters (`SetRXABandpassFreqs`/`RXANBPSetFreqs`/`SetRXASNBAOutputBandwidth`), each rebuilding an **FFTW plan**. The bundled `libfftw3` is built **without** `--enable-threads`, so concurrent plan create/destroy double-frees. macOS libmalloc aborts hard; Windows/Linux heaps corrupt silently — which is why it stayed latent and unreported.

**Fix (surgical, no behavior change):**
- **Backend** — a process-wide static **leaf lock** (`_fftwPlannerGate`) around every plan-mutating bandpass/shift call: RX filter+mode, TX filter, RX/TX open-time seeds, and CTUN shift. **No DSP value, frequency, sign, or call-order change**, so PureSignal is byte-identical. The audio/DSP hot path (`fexchange`) is untouched — it only *executes* plans, so it stays lock-free (no deadlock, no underrun).
- **Frontend** — coalesce `/api/filter` during a drag so at most one POST is in flight; the final pointer-up value is always sent. Feel unchanged.

**Verification (independently re-run):**
- Native concurrency sentinel (8 RX + TX + mode-flip threads × 2000 iters) — **aborts without the gate, passes with it.**
- PS goldens: **112 (server) + 18 (P2 wire) green** → PureSignal preserved.
- Full backend build + suites green; frontend `tsc -b` + vite + vitest green.

**How to test:** on develop with this branch, drag the filter edge as fast as you can — it should no longer crash. (Built by an engineering-team workflow; adversarially reviewed for deadlock / PS byte-identity / completeness.)

🚫 Draft — only @Kb2uka merges. Bench-test on the G2 first.
