### PR TITLE
feat(display): Christiano's panadapter + waterfall work (height/colormap/cadence/pan/snap)

### DIFF
--- a/zeus-web/src/components/DisplayPanel.tsx
+++ b/zeus-web/src/components/DisplayPanel.tsx
@@ -16,6 +16,7 @@
 import { BackgroundSettingsPanel } from './BackgroundSettingsPanel';
 import { ThemeSettingsPanel } from './ThemeSettingsPanel';
 import { TraceColorPanel } from './TraceColorPanel';
+import { WaterfallColormapPanel } from './WaterfallColormapPanel';
 
 export function DisplayPanel() {
   return (
@@ -23,6 +24,7 @@ export function DisplayPanel() {
       <ThemeSettingsPanel />
       <BackgroundSettingsPanel />
       <TraceColorPanel />
+      <WaterfallColormapPanel />
     </div>
   );
 }

--- a/zeus-web/src/components/FreqAxis.tsx
+++ b/zeus-web/src/components/FreqAxis.tsx
@@ -47,6 +47,7 @@ import { useDisplayStore } from '../state/display-store';
 import { useConnectionStore } from '../state/connection-store';
 import { cancelDrawBusFrame, requestDrawBusFrame } from '../realtime/draw-bus';
 import * as viewCenter from '../state/view-center';
+import { useRulerPanGesture } from '../util/use-ruler-pan-gesture';
 
 function pickStrideHz(spanHz: number, targetTicks: number): number {
   if (spanHz <= 0) return 1;
@@ -91,6 +92,9 @@ export function FreqAxis() {
 
   const tickStripRef = useRef<HTMLDivElement | null>(null);
   const markerRef = useRef<HTMLDivElement | null>(null);
+  const rulerRef = useRef<HTMLDivElement | null>(null);
+
+  useRulerPanGesture(rulerRef, !!width && hzPerPixel > 0);
 
   useEffect(() => {
     const update = () => {
@@ -169,8 +173,13 @@ export function FreqAxis() {
       {/* Outer strip: fixed background + overflow clip. Inner strip: the
           tick content, slid by the draw-bus callback — so the background
           never moves and overscanned ticks scroll in from the edges. */}
-      <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-5 overflow-hidden bg-neutral-950/70">
-        <div ref={tickStripRef} className="absolute inset-0">
+      <div
+        ref={rulerRef}
+        className="pointer-events-auto absolute inset-x-0 top-0 z-10 h-5 overflow-hidden bg-neutral-950/70"
+        style={{ touchAction: 'none', userSelect: 'none' }}
+        title="Drag to pan the frequency view"
+      >
+        <div ref={tickStripRef} className="pointer-events-none absolute inset-0">
           {ticks.map((t) => (
             <div
               key={t.hz}

--- a/zeus-web/src/components/Panadapter.tsx
+++ b/zeus-web/src/components/Panadapter.tsx
@@ -42,12 +42,13 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, type CSSProperties } from 'react';
 import { createPanRenderer, hexToRgbFloats } from '../gl/panadapter';
 import { planForFrame } from '../gl/frame-plan';
 import { cancelDrawBusFrame, requestDrawBusFrame } from '../realtime/draw-bus';
 import { registerFrameConsumer, useDisplayStore } from '../state/display-store';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
+import { enhanceInto, useSignalEnhanceStore } from '../dsp/signal-estimator';
 import * as viewCenter from '../state/view-center';
 import { useTxStore } from '../state/tx-store';
 import { usePanTuneGesture } from '../util/use-pan-tune-gesture';
@@ -56,10 +57,17 @@ import { PassbandOverlay } from './PassbandOverlay';
 import { ImdReadings } from './ImdReadings';
 import { DbScale } from './DbScale';
 import { SpotOverlay } from './SpotOverlay';
+import { PeakMarkerOverlay } from './PeakMarkerOverlay';
 
 export function Panadapter() {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const popEnabled = useSignalEnhanceStore((s) => s.popEnabled);
+  const popRenderIntensity = useSignalEnhanceStore((s) => s.popRenderIntensity);
+  const moxOn = useTxStore((s) => s.moxOn);
+  const tunOn = useTxStore((s) => s.tunOn);
+  const popActive = popEnabled && !moxOn && !tunOn;
+  const popIntensityCss = Math.max(0, Math.min(1, popRenderIntensity / 100)).toFixed(2);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -88,6 +96,31 @@ export function Panadapter() {
     let anchorPan: Float32Array | null = null;
     let anchorCenterHz = 0;
     let anchorHzPerPixel = 0;
+    // Signal Pop. The adopted anchor is the raw server trace UNLESS Pop is on,
+    // in which case it's the per-bin floor-subtracted trace. We keep the last
+    // RAW trace around so a Pop toggle (or a parameter change) can rebuild the
+    // anchor without waiting for the next frame. Enhanced output is
+    // double-buffered so each adoption presents a NEW Float32Array reference —
+    // the renderer's dataDirty check (issue #597) keys on reference identity,
+    // so mutating one buffer in place would be silently dropped during a glide.
+    let lastRawPan: Float32Array | null = null;
+    const enhScratch: Array<Float32Array | null> = [null, null];
+    let enhSlot = 0;
+    const buildAnchor = (raw: Float32Array): Float32Array => {
+      const { popEnabled } = useSignalEnhanceStore.getState();
+      const { moxOn, tunOn } = useTxStore.getState();
+      // Pop is an RX weak-signal aid; the TX trace lives in a different dB
+      // domain (speech against a calibrated scale), so leave it raw while keyed.
+      if (!popEnabled || moxOn || tunOn) return raw;
+      let buf = enhScratch[enhSlot];
+      if (!buf || buf.length !== raw.length) {
+        buf = new Float32Array(raw.length);
+        enhScratch[enhSlot] = buf;
+      }
+      enhanceInto(raw, buf);
+      enhSlot ^= 1;
+      return buf;
+    };
     // Visibility gating: don't burn rAF cycles when the tile is scrolled
     // off-screen, the tab is hidden, or the operator switched to a layout
     // where the panadapter isn't mounted-but-visible. Both signals are
@@ -105,10 +138,17 @@ export function Panadapter() {
       // TX_FIXED_DB_MIN/MAX in display-settings-store.
       const { moxOn, tunOn } = useTxStore.getState();
       const keyed = moxOn || tunOn;
-      const dbMin = keyed ? s.txDbMin : s.dbMin;
-      const dbMax = keyed ? s.txDbMax : s.dbMax;
+      const pop = useSignalEnhanceStore.getState();
+      // Signal Pop (RX only): the anchor now holds gated/compressed 0..1 display
+      // values (enhanceInto), so the colormap maps [0,1] directly. Keyed/TX
+      // keeps the absolute dB window.
+      const popOn = pop.popEnabled && !keyed;
+      const popIntensity = popOn ? Math.max(0, Math.min(1, pop.popRenderIntensity / 100)) : 0;
+      const dbMin = popOn ? 0 : keyed ? s.txDbMin : s.dbMin;
+      const dbMax = popOn ? 1 : keyed ? s.txDbMax : s.dbMax;
       const { r, g, b } = hexToRgbFloats(s.rxTraceColor);
       renderer.setTraceColor(r, g, b);
+      renderer.setPopMode(popOn, popIntensity);
       // Fractional offset — the shaders take a float uOffsetPx, so the
       // glide is sub-pixel-smooth for free (issue #597).
       const offsetPx =
@@ -189,7 +229,8 @@ export function Panadapter() {
         // immediately; the refill hold doesn't apply across a reset.
         viewCenter.snapTo(frameCenter, state.hzPerPixel);
         if (state.panValid && state.panDb) {
-          anchorPan = state.panDb;
+          lastRawPan = state.panDb;
+          anchorPan = buildAnchor(state.panDb);
           anchorCenterHz = frameCenter;
           anchorHzPerPixel = state.hzPerPixel;
         }
@@ -205,13 +246,37 @@ export function Panadapter() {
         // self-describing — the anchor model draws them where their data
         // belongs and the old refill-hold heuristic is unnecessary.
         if (state.panValid && state.panDb) {
-          anchorPan = state.panDb;
+          lastRawPan = state.panDb;
+          anchorPan = buildAnchor(state.panDb);
           anchorCenterHz = frameCenter;
           anchorHzPerPixel = state.hzPerPixel;
         }
       }
 
       requestRedraw();
+    });
+
+    // Signal Pop toggle / tuning change: rebuild the anchor from the last raw
+    // trace and repaint now, instead of waiting for the next server frame.
+    const unsubEnhance = useSignalEnhanceStore.subscribe((state, prev) => {
+      if (
+        state.popEnabled !== prev.popEnabled ||
+        state.popFloorDb !== prev.popFloorDb ||
+        state.popSpanDb !== prev.popSpanDb ||
+        state.popGamma !== prev.popGamma ||
+        state.popRenderIntensity !== prev.popRenderIntensity ||
+        state.coherenceHoldGate !== prev.coherenceHoldGate ||
+        state.coherenceBoostDb !== prev.coherenceBoostDb ||
+        state.ridgeBoost !== prev.ridgeBoost ||
+        state.ridgeMaxBoostDb !== prev.ridgeMaxBoostDb ||
+        state.visualAgcEnabled !== prev.visualAgcEnabled ||
+        state.visualAgcStrength !== prev.visualAgcStrength ||
+        state.impulseRejectEnabled !== prev.impulseRejectEnabled ||
+        state.impulseRejectDb !== prev.impulseRejectDb
+      ) {
+        if (lastRawPan) anchorPan = buildAnchor(lastRawPan);
+        requestRedraw();
+      }
     });
 
     // View-center motion → redraw at display rate while gliding. The
@@ -243,6 +308,10 @@ export function Panadapter() {
     // raises the floor on the redraw rate above the spectrum-tick rate.
     const unsubTx = useTxStore.subscribe((state, prev) => {
       if (state.moxOn !== prev.moxOn || state.tunOn !== prev.tunOn) {
+        // buildAnchor gates Pop off while keyed, so rebuild from the last raw
+        // trace on the MOX/TUN edge to avoid a one-frame enhanced-vs-TX-range
+        // mismap before the first TX frame adopts.
+        if (lastRawPan) anchorPan = buildAnchor(lastRawPan);
         requestRedraw();
       }
     });
@@ -252,6 +321,7 @@ export function Panadapter() {
       unsubViewCenter();
       unsubSettings();
       unsubTx();
+      unsubEnhance();
       ro.disconnect();
       io.disconnect();
       document.removeEventListener('visibilitychange', onVisibilityChange);
@@ -266,18 +336,22 @@ export function Panadapter() {
   return (
     <div
       ref={containerRef}
-      className="spectrum-canvas"
+      className={`spectrum-canvas${popActive ? ' pop-enhanced' : ''}`}
       style={{
         position: 'relative',
         minHeight: 0,
         width: '100%',
         height: '100%',
-        background: 'var(--spec-bg)',
+        background: popActive ? 'var(--pop-surface-bg)' : 'var(--spec-bg)',
+        ...(popActive
+          ? ({ ['--pop-intensity' as string]: popIntensityCss } as CSSProperties)
+          : undefined),
       }}
     >
       <canvas ref={canvasRef} style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }} />
       <PassbandOverlay />
       <SpotOverlay />
+      <PeakMarkerOverlay />
       <ImdReadings />
       <FreqAxis />
       <DbScale />

--- a/zeus-web/src/components/PeakMarkerOverlay.tsx
+++ b/zeus-web/src/components/PeakMarkerOverlay.tsx
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+import { useEffect, useState } from 'react';
+import { detectPeaks, peakAlpha, useSignalEnhanceStore, type DetectedPeak } from '../dsp/signal-estimator';
+import { useDisplayStore } from '../state/display-store';
+import { useDisplaySettingsStore } from '../state/display-settings-store';
+
+// Snap-target markers: short ticks rising from the noise-floor baseline at each
+// detected carrier, so the operator can see exactly where a snap click will
+// land. Shown only while SNAP is engaged. Coloured to match the operator's RX
+// trace colour (sanctioned amber peak-tick by default — signal-strength
+// visualisation, varying alpha; see dev-conventions.md), with opacity scaled by
+// the peak's SNR above the noise floor.
+//
+// Recompute is throttled to ~8 Hz: markers don't need the 30 Hz frame rate, and
+// the spectrum surfaces deliberately keep React out of the per-frame path. The
+// number of marker divs is bounded by PEAK_MAX_COUNT in the estimator.
+const RECOMPUTE_MIN_INTERVAL_MS = 120;
+
+type Snapshot = { peaks: DetectedPeak[]; centerHz: number; spanHz: number };
+
+const EMPTY: Snapshot = { peaks: [], centerHz: 0, spanHz: 0 };
+
+export function PeakMarkerOverlay() {
+  const snapEnabled = useSignalEnhanceStore((s) => s.snapEnabled);
+  const peakMinSnrDb = useSignalEnhanceStore((s) => s.peakMinSnrDb);
+  const traceColor = useDisplaySettingsStore((s) => s.rxTraceColor);
+  const [snap, setSnap] = useState<Snapshot>(EMPTY);
+
+  useEffect(() => {
+    if (!snapEnabled) {
+      setSnap(EMPTY);
+      return;
+    }
+    let lastAt = 0;
+    const recompute = () => {
+      const s = useDisplayStore.getState();
+      if (!s.panDb || s.hzPerPixel <= 0) {
+        setSnap(EMPTY);
+        return;
+      }
+      const centerHz = Number(s.centerHz);
+      const spanHz = s.panDb.length * s.hzPerPixel;
+      setSnap({ peaks: detectPeaks(s.panDb, centerHz, s.hzPerPixel), centerHz, spanHz });
+    };
+    const unsub = useDisplayStore.subscribe((state, prev) => {
+      if (state.lastSeq === prev.lastSeq) return;
+      const now = performance.now();
+      if (now - lastAt < RECOMPUTE_MIN_INTERVAL_MS) return;
+      lastAt = now;
+      recompute();
+    });
+    recompute();
+    return unsub;
+  }, [snapEnabled, peakMinSnrDb]);
+
+  if (!snapEnabled || snap.peaks.length === 0 || snap.spanHz <= 0) return null;
+
+  const startHz = snap.centerHz - snap.spanHz / 2;
+
+  return (
+    <>
+      {snap.peaks.map((p) => {
+        const pct = ((p.hz - startHz) / snap.spanHz) * 100;
+        if (pct < -1 || pct > 101) return null;
+        return (
+          <div
+            key={p.hz}
+            className="pointer-events-none absolute bottom-0 z-[7] h-4 w-0.5 -translate-x-1/2"
+            style={{
+              left: `${pct}%`,
+              background: traceColor,
+              opacity: peakAlpha(p.snrDb),
+              boxShadow: '0 0 3px rgba(0,0,0,0.9)',
+            }}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/zeus-web/src/components/Waterfall.test.tsx
+++ b/zeus-web/src/components/Waterfall.test.tsx
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/** @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createElement } from 'react';
+
+import { render } from './meters/__tests__/harness';
+import { Waterfall } from './Waterfall';
+
+const releaseFrameConsumerMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../gl/waterfall', () => ({
+  createWfRenderer: vi.fn(() => {
+    throw new Error('shader compile failed (vertex): no compiler log');
+  }),
+}));
+
+vi.mock('../state/display-store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../state/display-store')>();
+  return {
+    ...actual,
+    registerFrameConsumer: vi.fn(() => releaseFrameConsumerMock),
+  };
+});
+
+vi.mock('./WfDbScale', () => ({
+  WfDbScale: () => null,
+}));
+
+vi.mock('../util/use-pan-tune-gesture', () => ({
+  usePanTuneGesture: () => undefined,
+}));
+
+describe('Waterfall', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+      configurable: true,
+      value: vi.fn(() => ({})),
+    });
+    releaseFrameConsumerMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('degrades instead of crashing when the WebGL renderer fails to build', () => {
+    const { container, unmount } = render(createElement(Waterfall));
+
+    expect(container.textContent).toContain('Waterfall renderer unavailable');
+
+    unmount();
+
+    expect(releaseFrameConsumerMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -42,24 +42,18 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
-import { useEffect, useRef, useState } from 'react';
-import { COLORMAPS } from '../gl/colormap';
+import { useEffect, useRef, useState, type CSSProperties } from 'react';
+import { COLORMAPS, type RenderColormapId } from '../gl/colormap';
 import { createWfRenderer, type WfGlCaps } from '../gl/waterfall';
 import { planForFrame, resetFramePlan } from '../gl/frame-plan';
 import { cancelDrawBusFrame, requestDrawBusFrame } from '../realtime/draw-bus';
 import { registerFrameConsumer, useDisplayStore } from '../state/display-store';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
+import { enhanceInto, useSignalEnhanceStore } from '../dsp/signal-estimator';
 import * as viewCenter from '../state/view-center';
 import { useTxStore } from '../state/tx-store';
 import { usePanTuneGesture } from '../util/use-pan-tune-gesture';
 import { WfDbScale } from './WfDbScale';
-
-// Throttle row uploads so the waterfall scrolls at ~(server tick / N).
-// With a 30 Hz server tick N=2 gives ~15 Hz, which is a comfortable scroll
-// speed without costing much CPU. Shift/reset still run every frame so VFO
-// retunes stay synchronised with the panadapter's offset.
-// TODO(phase-3.1): expose as a UI setting.
-const WF_PUSH_EVERY_N = 2;
 
 type WaterfallProps = {
   /** When true, noise floor fades to transparent so the QRZ-mode map shows through. */
@@ -70,6 +64,12 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const rendererRef = useRef<ReturnType<typeof createWfRenderer> | null>(null);
+  const popEnabled = useSignalEnhanceStore((s) => s.popEnabled);
+  const popRenderIntensity = useSignalEnhanceStore((s) => s.popRenderIntensity);
+  const moxOn = useTxStore((s) => s.moxOn);
+  const tunOn = useTxStore((s) => s.tunOn);
+  const popActive = popEnabled && !moxOn && !tunOn;
+  const popIntensityCss = Math.max(0, Math.min(1, popRenderIntensity / 100)).toFixed(2);
   // Live transparency, read by buildRenderer() on context-restore so a rebuild
   // mid-QRZ-mode comes back transparent rather than occluding the map (#629).
   const transparentRef = useRef(transparent);
@@ -77,6 +77,10 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
   // (WebView2) app has no reachable DevTools. Only shown when something the
   // waterfall needs is missing (#629).
   const [glCaps, setGlCaps] = useState<WfGlCaps | null>(null);
+  // Last renderer-build failure message, surfaced on-screen (desktop has no
+  // DevTools). When set, the waterfall degrades to a notice instead of a frozen
+  // black surface — e.g. an ANGLE shader-compile failure after context loss.
+  const [glError, setGlError] = useState<string | null>(null);
   const autoRange = useDisplaySettingsStore((s) => s.autoRange);
   const setAutoRange = useDisplaySettingsStore((s) => s.setAutoRange);
   const colormap = useDisplaySettingsStore((s) => s.colormap);
@@ -99,31 +103,69 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
     let gl: WebGL2RenderingContext | null = null;
     let renderer: ReturnType<typeof createWfRenderer> | null = null;
     let contextLost = false;
+    const isPopRenderActive = () => {
+      const { popEnabled } = useSignalEnhanceStore.getState();
+      const { moxOn, tunOn } = useTxStore.getState();
+      return popEnabled && !moxOn && !tunOn;
+    };
+    // Apply the active value-scale look: the synthetic 'pop' LUT + pop blend
+    // intensity while Signal Pop is engaged (RX only), otherwise the operator's
+    // chosen colormap with pop blend off.
+    const applyRenderLook = () => {
+      if (!renderer) return;
+      const signalEnhance = useSignalEnhanceStore.getState();
+      const active = isPopRenderActive();
+      const intensity = active ? Math.max(0, Math.min(1, signalEnhance.popRenderIntensity / 100)) : 0;
+      const colormap: RenderColormapId = active ? 'pop' : useDisplaySettingsStore.getState().colormap;
+      renderer.setPopMode(active, intensity);
+      renderer.setColormap(colormap);
+    };
 
     // (Re)acquire the context and build a fresh renderer with every GL
     // resource. Returns false if WebGL2 is unavailable. Does NOT touch the
     // frame-consumer registration. Reads colormap/transparency LIVE so a
     // rebuild lands on the operator's current state, not a stale closure.
     const buildRenderer = (): boolean => {
-      const ctx = canvas.getContext('webgl2', {
-        antialias: false,
-        alpha: true,
-        premultipliedAlpha: true,
-      });
-      if (!ctx) {
-        console.error('WebGL2 not available');
+      try {
+        const ctx = canvas.getContext('webgl2', {
+          antialias: false,
+          alpha: true,
+          premultipliedAlpha: true,
+        });
+        if (!ctx) {
+          console.error('WebGL2 not available');
+          setGlCaps(null);
+          setGlError('WebGL2 not available');
+          return false;
+        }
+        gl = ctx;
+        renderer = createWfRenderer(ctx);
+        rendererRef.current = renderer;
+        renderer.setTransparent(transparentRef.current);
+        applyRenderLook();
+        setGlCaps(renderer.caps);
+        setGlError(null);
+        return true;
+      } catch (err) {
+        // createWfRenderer can throw on an ANGLE shader-compile failure after a
+        // context-loss/restore race. Degrade to a notice instead of crashing
+        // the whole workspace tree (#629).
+        const message = err instanceof Error ? err.message : String(err);
+        console.error('[waterfall] renderer unavailable', err);
+        renderer = null;
+        rendererRef.current = null;
+        setGlCaps(null);
+        setGlError(message);
         return false;
       }
-      gl = ctx;
-      renderer = createWfRenderer(ctx);
-      rendererRef.current = renderer;
-      renderer.setColormap(useDisplaySettingsStore.getState().colormap);
-      renderer.setTransparent(transparentRef.current);
-      setGlCaps(renderer.caps);
-      return true;
     };
 
-    if (!buildRenderer()) return;
+    if (!buildRenderer()) {
+      return () => {
+        releaseFrameConsumer();
+        rendererRef.current = null;
+      };
+    }
 
     let lastSeqDrawn = -1;
     let tickCounter = 0;
@@ -133,6 +175,10 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
     // Waterfall frame tallies for the one-shot backend diagnostic below (#629).
     let wfFrames = 0;
     let wfValidFrames = 0;
+    // Scratch buffer for Signal Pop. uploadRow() copies immediately
+    // (texSubImage2D), so unlike the panadapter texture a single reused buffer
+    // is safe — there's no deferred reference-identity dirty check here.
+    let enhBuf: Float32Array | null = null;
     // Visibility gating: skip the rAF redraw when the waterfall tile is
     // scrolled offscreen or the tab is hidden. We still push frames into
     // the history texture so when visibility resumes the operator sees a
@@ -146,10 +192,17 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       const { wfDbMin, wfDbMax, wfTxDbMin, wfTxDbMax } = useDisplaySettingsStore.getState();
       const { moxOn, tunOn } = useTxStore.getState();
       const keyed = moxOn || tunOn;
+      const pop = useSignalEnhanceStore.getState();
+      // Signal Pop (RX only): history rows hold gated/compressed 0..1 display
+      // values (enhanceInto), so the colormap maps [0,1] directly. Keyed/TX
+      // keeps the absolute dB window.
+      const popOn = pop.popEnabled && !keyed;
+      const popIntensity = popOn ? Math.max(0, Math.min(1, pop.popRenderIntensity / 100)) : 0;
       // Mirror DbScale.tsx — keyed (MOX/TUN) renders the TX waterfall
       // window so the operator's RX noise-floor view stays put.
-      const dbMin = keyed ? wfTxDbMin : wfDbMin;
-      const dbMax = keyed ? wfTxDbMax : wfDbMax;
+      const dbMin = popOn ? 0 : keyed ? wfTxDbMin : wfDbMin;
+      const dbMax = popOn ? 1 : keyed ? wfTxDbMax : wfDbMax;
+      renderer.setPopMode(popOn, popIntensity);
       renderer.draw(
         dbMin,
         dbMax,
@@ -270,14 +323,30 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       let skipRowUpload = false;
       if (wfDb) {
         tickCounter++;
-        skipRowUpload = tickCounter % WF_PUSH_EVERY_N !== 0;
+        // Operator-selectable scroll cadence (1/2/3 server frames per row).
+        // Shift/reset still run every frame so VFO retunes stay synchronised
+        // with the panadapter's offset.
+        const cadence = useDisplaySettingsStore.getState().waterfallRowCadence;
+        skipRowUpload = tickCounter % cadence !== 0;
         // No refill hold here any more (issue #597 Phase 2): rows are
         // stamped with the LO their data was captured at, so the shared
         // shift planner places them correctly even mid-retune.
         // Feed the auto-range tracker — it's a no-op when AUTO is off.
         useDisplaySettingsStore.getState().updateAutoRange(wfDb);
       }
-      renderer.pushFrame(decision, wfDb, state.centerHz, state.hzPerPixel, {
+      // Signal Pop (RX only): substitute the per-bin floor-subtracted row so
+      // weak carriers leap off a flattened baseline. Gated off while keyed —
+      // TX pixels are a different dB domain.
+      let wfForPush = wfDb;
+      if (wfDb) {
+        const { moxOn, tunOn } = useTxStore.getState();
+        if (useSignalEnhanceStore.getState().popEnabled && !moxOn && !tunOn) {
+          if (!enhBuf || enhBuf.length !== wfDb.length) enhBuf = new Float32Array(wfDb.length);
+          enhanceInto(wfDb, enhBuf);
+          wfForPush = enhBuf;
+        }
+      }
+      renderer.pushFrame(decision, wfForPush, state.centerHz, state.hzPerPixel, {
         skipRowUpload,
       });
       requestRedraw();
@@ -297,7 +366,7 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
     const unsubSettings = useDisplaySettingsStore.subscribe((state, prev) => {
       if (contextLost || !renderer) return;
       if (state.colormap !== prev.colormap) {
-        renderer.setColormap(state.colormap);
+        applyRenderLook();
         requestRedraw();
         return;
       }
@@ -319,6 +388,34 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
     // spectrum-tick rate.
     const unsubTx = useTxStore.subscribe((state, prev) => {
       if (state.moxOn !== prev.moxOn || state.tunOn !== prev.tunOn) {
+        applyRenderLook();
+        requestRedraw();
+      }
+    });
+
+    // Signal Pop toggle: the value scale flips wholesale (absolute dB ↔
+    // dB-above-floor). Re-seed the history so pre-toggle rows don't render as a
+    // clipped band against the new range. New rows fill in from the top.
+    const unsubEnhance = useSignalEnhanceStore.subscribe((state, prev) => {
+      if (contextLost || !renderer) return;
+      if (state.popEnabled !== prev.popEnabled) {
+        applyRenderLook();
+        renderer.clearHistory();
+        requestRedraw();
+      } else if (
+        state.popFloorDb !== prev.popFloorDb ||
+        state.popSpanDb !== prev.popSpanDb ||
+        state.popGamma !== prev.popGamma ||
+        state.popRenderIntensity !== prev.popRenderIntensity ||
+        state.coherenceHoldGate !== prev.coherenceHoldGate ||
+        state.coherenceBoostDb !== prev.coherenceBoostDb ||
+        state.ridgeBoost !== prev.ridgeBoost ||
+        state.ridgeMaxBoostDb !== prev.ridgeMaxBoostDb ||
+        state.visualAgcEnabled !== prev.visualAgcEnabled ||
+        state.visualAgcStrength !== prev.visualAgcStrength ||
+        state.impulseRejectEnabled !== prev.impulseRejectEnabled ||
+        state.impulseRejectDb !== prev.impulseRejectDb
+      ) {
         requestRedraw();
       }
     });
@@ -328,6 +425,7 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       unsubViewCenter();
       unsubSettings();
       unsubTx();
+      unsubEnhance();
       ro.disconnect();
       io.disconnect();
       document.removeEventListener('visibilitychange', onVisibilityChange);
@@ -361,13 +459,16 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
   return (
     <div
       ref={containerRef}
-      className="waterfall-canvas"
+      className={`waterfall-canvas${popActive ? ' pop-enhanced' : ''}`}
       style={{
         position: 'relative',
         minHeight: 0,
         width: '100%',
         height: '100%',
-        background: 'var(--wf-0)',
+        background: popActive ? 'var(--pop-surface-bg)' : 'var(--wf-0)',
+        ...(popActive
+          ? ({ ['--pop-intensity' as string]: popIntensityCss } as CSSProperties)
+          : undefined),
       }}
     >
       <canvas ref={canvasRef} style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }} />
@@ -394,6 +495,29 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
           title={`GPU: ${glCaps.gpu}`}
         >
           wf: float_linear unsupported → NEAREST fallback
+        </div>
+      )}
+      {glError && (
+        <div
+          role="status"
+          style={{
+            position: 'absolute',
+            top: 6,
+            left: 6,
+            right: 6,
+            padding: '4px 6px',
+            fontSize: 10,
+            fontFamily: 'monospace',
+            color: 'var(--fg-0)',
+            background: 'rgba(0,0,0,0.62)',
+            border: '1px solid rgba(255,255,255,0.22)',
+            borderRadius: 3,
+            pointerEvents: 'none',
+            zIndex: 3,
+          }}
+          title={glError}
+        >
+          Waterfall renderer unavailable
         </div>
       )}
       <WfDbScale />

--- a/zeus-web/src/components/WaterfallColormapPanel.tsx
+++ b/zeus-web/src/components/WaterfallColormapPanel.tsx
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+import { useMemo } from 'react';
+import { COLORMAPS, lutFor, type ColormapId } from '../gl/colormap';
+import {
+  useDisplaySettingsStore,
+  type WaterfallRowCadence,
+} from '../state/display-settings-store';
+
+const CADENCE_OPTIONS: Array<{ value: WaterfallRowCadence; label: string; detail: string }> = [
+  { value: 1, label: 'Smooth', detail: '30 Hz' },
+  { value: 2, label: 'Balanced', detail: '15 Hz' },
+  { value: 3, label: 'Economy', detail: '10 Hz' },
+];
+
+// Build a horizontal CSS gradient that mirrors the actual 256-entry LUT the
+// WebGL waterfall samples, so the swatch the operator picks is exactly the
+// palette they get. Sampled at 16 stops — dense enough that the eye can't tell
+// it from the continuous LUT.
+function gradientCss(id: ColormapId): string {
+  const lut = lutFor(id);
+  const stops: string[] = [];
+  const N = 16;
+  for (let i = 0; i <= N; i++) {
+    const t = i / N;
+    const base = Math.round(t * 255) * 4;
+    const r = lut[base];
+    const g = lut[base + 1];
+    const b = lut[base + 2];
+    stops.push(`rgb(${r}, ${g}, ${b}) ${((t * 100) | 0)}%`);
+  }
+  return `linear-gradient(90deg, ${stops.join(', ')})`;
+}
+
+export function WaterfallColormapPanel() {
+  const colormap = useDisplaySettingsStore((s) => s.colormap);
+  const setColormap = useDisplaySettingsStore((s) => s.setColormap);
+  const waterfallRowCadence = useDisplaySettingsStore((s) => s.waterfallRowCadence);
+  const setWaterfallRowCadence = useDisplaySettingsStore((s) => s.setWaterfallRowCadence);
+  const gradients = useMemo(
+    () => Object.fromEntries(COLORMAPS.map((cm) => [cm.id, gradientCss(cm.id)])) as Record<ColormapId, string>,
+    [],
+  );
+
+  return (
+    <section>
+      <div style={sectionHead}>
+        <h3 style={sectionH3}>Waterfall Colormap</h3>
+        <p style={sectionP}>
+          The palette the waterfall maps signal strength to — low power on the left, peaks on the right.
+        </p>
+      </div>
+
+      <div role="radiogroup" aria-label="Waterfall colormap" style={cardGrid}>
+        {COLORMAPS.map((cm) => {
+          const active = colormap === cm.id;
+          return (
+            <button
+              key={cm.id}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              onClick={() => setColormap(cm.id)}
+              style={swatchCard(active)}
+            >
+              <div style={{ ...gradientStrip, background: gradients[cm.id] }} aria-hidden />
+              <span style={swatchLabel(active)}>{cm.label}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div style={cadenceBlock}>
+        <span style={cadenceLabel}>Row Cadence</span>
+        <div role="radiogroup" aria-label="Waterfall row cadence" style={cadenceRow}>
+          {CADENCE_OPTIONS.map((opt) => {
+            const active = waterfallRowCadence === opt.value;
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                role="radio"
+                aria-checked={active}
+                onClick={() => setWaterfallRowCadence(opt.value)}
+                style={cadenceButton(active)}
+              >
+                <span style={cadenceButtonLabel(active)}>{opt.label}</span>
+                <span style={cadenceButtonDetail}>{opt.detail}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+const sectionHead: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'baseline',
+  flexWrap: 'wrap',
+  gap: 10,
+  marginBottom: 10,
+};
+const sectionH3: React.CSSProperties = {
+  margin: 0,
+  fontSize: 11,
+  fontWeight: 700,
+  letterSpacing: '0.18em',
+  textTransform: 'uppercase',
+  color: 'var(--fg-0)',
+};
+const sectionP: React.CSSProperties = {
+  margin: 0,
+  fontSize: 12,
+  lineHeight: 1.5,
+  color: 'var(--fg-2)',
+};
+
+const cardGrid: React.CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))',
+  gap: 10,
+};
+
+const cadenceBlock: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: 12,
+  marginTop: 14,
+  flexWrap: 'wrap',
+};
+
+const cadenceLabel: React.CSSProperties = {
+  fontSize: 11,
+  fontWeight: 700,
+  letterSpacing: '0.14em',
+  textTransform: 'uppercase',
+  color: 'var(--fg-1)',
+};
+
+const cadenceRow: React.CSSProperties = {
+  display: 'inline-grid',
+  gridTemplateColumns: 'repeat(3, minmax(84px, 1fr))',
+  border: '1px solid var(--line)',
+  borderRadius: 'var(--r-sm)',
+  overflow: 'hidden',
+  minWidth: 276,
+};
+
+function cadenceButton(active: boolean): React.CSSProperties {
+  return {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 2,
+    minHeight: 42,
+    padding: '6px 10px',
+    border: 0,
+    borderRight: '1px solid var(--line)',
+    background: active ? 'var(--accent)' : 'var(--bg-1)',
+    color: active ? 'var(--bg-0)' : 'var(--fg-1)',
+    cursor: 'pointer',
+  };
+}
+
+function cadenceButtonLabel(active: boolean): React.CSSProperties {
+  return {
+    fontSize: 11,
+    fontWeight: 800,
+    letterSpacing: 0,
+    color: active ? 'var(--bg-0)' : 'var(--fg-0)',
+  };
+}
+
+const cadenceButtonDetail: React.CSSProperties = {
+  fontSize: 10,
+  letterSpacing: 0,
+  color: 'inherit',
+  opacity: 0.72,
+};
+
+function swatchCard(active: boolean): React.CSSProperties {
+  return {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 8,
+    padding: 10,
+    textAlign: 'left',
+    background: 'linear-gradient(180deg, var(--bg-1), var(--bg-0))',
+    border: active ? '1.5px solid var(--accent)' : '1.5px solid var(--line)',
+    borderRadius: 'var(--r-md)',
+    boxShadow: active ? '0 0 0 1px var(--accent)' : 'none',
+    cursor: 'pointer',
+    transition: 'border-color var(--dur-fast), box-shadow var(--dur-fast)',
+  };
+}
+
+const gradientStrip: React.CSSProperties = {
+  width: '100%',
+  height: 40,
+  borderRadius: 'var(--r-sm)',
+  border: '1px solid rgba(0, 0, 0, 0.5)',
+  boxShadow: 'inset 0 0 0 1px rgba(255, 255, 255, 0.06)',
+};
+
+function swatchLabel(active: boolean): React.CSSProperties {
+  return {
+    fontSize: 11,
+    fontWeight: 700,
+    letterSpacing: '0.06em',
+    textTransform: 'uppercase',
+    color: active ? 'var(--fg-0)' : 'var(--fg-1)',
+  };
+}

--- a/zeus-web/src/dsp/signal-estimator.test.ts
+++ b/zeus-web/src/dsp/signal-estimator.test.ts
@@ -1,0 +1,1069 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License v2 or later. See the
+// LICENSE file at the repository root, or https://www.gnu.org/licenses/.
+
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  computeSnapToLineHz,
+  computeSnapTuneHz,
+  detectPeaks,
+  enhanceInto,
+  findNearestPeakHz,
+  findPeakHz,
+  getNoiseFloor,
+  getSignalConfidence,
+  getSnapHistorySpectrum,
+  maybeUpdateEstimator,
+  measureOccupiedBandwidth,
+  measureSignalExtent,
+  measureSnapLock,
+  peakAlpha,
+  resetEstimator,
+  SIGNAL_ENHANCE_PROFILES,
+  recommendSignalEnhanceScene,
+  signalExtentHz,
+  signalEnhanceProfileForMode,
+  useSignalEnhanceStore,
+} from './signal-estimator';
+
+const WIDTH = 256;
+const HZ_PER_PX = 100;
+const CENTER = 14_200_000;
+const NOISE_DB = -110;
+const CARRIER_BIN = 150;
+const CARRIER_DB = -50;
+
+// Flat noise floor with a single one-bin carrier spike at CARRIER_BIN.
+function spectrumWithCarrier(): Float32Array {
+  const spec = new Float32Array(WIDTH).fill(NOISE_DB);
+  spec[CARRIER_BIN] = CARRIER_DB;
+  return spec;
+}
+
+// Sloped (band-tilt) noise floor: -90 at the left edge down to -120 at the
+// right, plus the same carrier spike.
+function spectrumWithTilt(): Float32Array {
+  const spec = new Float32Array(WIDTH);
+  for (let i = 0; i < WIDTH; i++) spec[i] = -90 + (-30 * i) / WIDTH;
+  spec[CARRIER_BIN] = CARRIER_DB;
+  return spec;
+}
+
+function pushFrame(spec: Float32Array): void {
+  maybeUpdateEstimator({ panDb: spec, panValid: true, width: WIDTH, hzPerPixel: HZ_PER_PX });
+}
+
+afterEach(() => {
+  resetEstimator();
+  useSignalEnhanceStore.setState({
+    popEnabled: false,
+    snapEnabled: false,
+    visualAgcEnabled: true,
+    impulseRejectEnabled: true,
+  });
+  useSignalEnhanceStore.getState().resetSignalEnhanceTuning();
+});
+
+describe('signal estimator — spatial floor', () => {
+  it('applies operator profiles and clamps custom signal-intelligence tuning', () => {
+    const store = useSignalEnhanceStore.getState();
+
+    store.applySignalEnhanceProfile('dx');
+    expect(useSignalEnhanceStore.getState().profileId).toBe('dx');
+    expect(useSignalEnhanceStore.getState().popSpanDb).toBe(SIGNAL_ENHANCE_PROFILES.dx.popSpanDb);
+
+    store.setSignalEnhanceTuning({
+      popFloorDb: -10,
+      popGamma: 2,
+      popRenderIntensity: 250,
+      snapRadiusHz: 99_999,
+    });
+    const tuned = useSignalEnhanceStore.getState();
+    expect(tuned.profileId).toBe('custom');
+    expect(tuned.popFloorDb).toBe(0);
+    expect(tuned.popGamma).toBe(1.2);
+    expect(tuned.popRenderIntensity).toBe(100);
+    expect(tuned.snapRadiusHz).toBe(12_000);
+  });
+
+  it('maps RX modes to signal-intelligence profiles and lets manual tuning leave auto mode', () => {
+    expect(signalEnhanceProfileForMode('CWU')).toBe('cw');
+    expect(signalEnhanceProfileForMode('CWL')).toBe('cw');
+    expect(signalEnhanceProfileForMode('DIGU')).toBe('digital');
+    expect(signalEnhanceProfileForMode('DIGL')).toBe('digital');
+    expect(signalEnhanceProfileForMode('USB')).toBe('voice');
+    expect(signalEnhanceProfileForMode('AM')).toBe('voice');
+
+    const store = useSignalEnhanceStore.getState();
+    store.setSignalEnhanceAutoProfile(true, 'DIGU');
+    expect(useSignalEnhanceStore.getState().autoProfileEnabled).toBe(true);
+    expect(useSignalEnhanceStore.getState().profileId).toBe('digital');
+
+    useSignalEnhanceStore.getState().applySignalEnhanceModeProfile('CWU');
+    expect(useSignalEnhanceStore.getState().autoProfileEnabled).toBe(true);
+    expect(useSignalEnhanceStore.getState().profileId).toBe('cw');
+
+    useSignalEnhanceStore.getState().applySignalEnhanceProfile('dx');
+    expect(useSignalEnhanceStore.getState().autoProfileEnabled).toBe(false);
+    expect(useSignalEnhanceStore.getState().profileId).toBe('dx');
+  });
+
+  it('recommends DX for sparse weak voice-like signals and Contest for crowded spans', () => {
+    const floor = new Float32Array(WIDTH).fill(NOISE_DB);
+    const sparseWeak = new Float32Array(WIDTH).fill(NOISE_DB);
+    sparseWeak[140] = NOISE_DB + 15;
+    expect(recommendSignalEnhanceScene({
+      mode: 'USB',
+      spectrum: sparseWeak,
+      floor,
+      hzPerPixel: HZ_PER_PX,
+    }).profileId).toBe('dx');
+
+    const strongVoice = new Float32Array(WIDTH).fill(NOISE_DB);
+    strongVoice[140] = NOISE_DB + 38;
+    expect(recommendSignalEnhanceScene({
+      mode: 'USB',
+      spectrum: strongVoice,
+      floor,
+      hzPerPixel: HZ_PER_PX,
+    }).profileId).toBe('voice');
+
+    const crowded = new Float32Array(WIDTH).fill(NOISE_DB);
+    for (let i = 20; i < WIDTH - 20; i += 8) crowded[i] = NOISE_DB + 30;
+    const busyScene = recommendSignalEnhanceScene({
+      mode: 'USB',
+      spectrum: crowded,
+      floor,
+      hzPerPixel: HZ_PER_PX,
+    });
+    expect(busyScene.profileId).toBe('contest');
+    expect(busyScene.peaksPer10Khz).toBeGreaterThan(3.5);
+  });
+
+  it('uses temporal confidence to reject impulsive scene changes', () => {
+    const floor = new Float32Array(WIDTH).fill(NOISE_DB);
+    const lowConfidence = new Float32Array(WIDTH);
+
+    const sparseImpulse = new Float32Array(WIDTH).fill(NOISE_DB);
+    sparseImpulse[140] = NOISE_DB + 15;
+    const impulseScene = recommendSignalEnhanceScene({
+      mode: 'USB',
+      spectrum: sparseImpulse,
+      floor,
+      confidence: lowConfidence,
+      hzPerPixel: HZ_PER_PX,
+    });
+    expect(impulseScene.profileId).toBe('voice');
+    expect(impulseScene.peakCount).toBe(1);
+    expect(impulseScene.coherentPeakCount).toBe(0);
+    expect(impulseScene.impulsiveOccupiedRatio).toBeGreaterThan(0);
+
+    const sparseCoherent = new Float32Array(WIDTH).fill(NOISE_DB);
+    const coherentConfidence = new Float32Array(WIDTH);
+    sparseCoherent[140] = NOISE_DB + 15;
+    coherentConfidence[140] = 0.8;
+    const dxScene = recommendSignalEnhanceScene({
+      mode: 'USB',
+      spectrum: sparseCoherent,
+      floor,
+      confidence: coherentConfidence,
+      hzPerPixel: HZ_PER_PX,
+    });
+    expect(dxScene.profileId).toBe('dx');
+    expect(dxScene.coherentPeakCount).toBe(1);
+    expect(dxScene.coherentMaxSnrDb).toBeCloseTo(15, 5);
+  });
+
+  it('requires coherent crowding before selecting the Contest profile', () => {
+    const floor = new Float32Array(WIDTH).fill(NOISE_DB);
+    const crowded = new Float32Array(WIDTH).fill(NOISE_DB);
+    for (let i = 20; i < WIDTH - 20; i += 8) crowded[i] = NOISE_DB + 30;
+
+    const nonCoherentScene = recommendSignalEnhanceScene({
+      mode: 'USB',
+      spectrum: crowded,
+      floor,
+      confidence: new Float32Array(WIDTH),
+      hzPerPixel: HZ_PER_PX,
+    });
+    expect(nonCoherentScene.profileId).toBe('voice');
+    expect(nonCoherentScene.peakCount).toBeGreaterThan(10);
+    expect(nonCoherentScene.coherentPeakCount).toBe(0);
+
+    const coherentConfidence = new Float32Array(WIDTH);
+    for (let i = 20; i < WIDTH - 20; i += 8) coherentConfidence[i] = 0.8;
+    const coherentScene = recommendSignalEnhanceScene({
+      mode: 'USB',
+      spectrum: crowded,
+      floor,
+      confidence: coherentConfidence,
+      hzPerPixel: HZ_PER_PX,
+    });
+    expect(coherentScene.profileId).toBe('contest');
+    expect(coherentScene.coherentPeaksPer10Khz).toBeGreaterThan(3.5);
+  });
+
+  it('keeps mode-specific CW and digital profiles even on busy scenes', () => {
+    const floor = new Float32Array(WIDTH).fill(NOISE_DB);
+    const crowded = new Float32Array(WIDTH).fill(NOISE_DB);
+    for (let i = 20; i < WIDTH - 20; i += 8) crowded[i] = NOISE_DB + 30;
+
+    expect(recommendSignalEnhanceScene({
+      mode: 'CWU',
+      spectrum: crowded,
+      floor,
+      hzPerPixel: HZ_PER_PX,
+    }).profileId).toBe('cw');
+    expect(recommendSignalEnhanceScene({
+      mode: 'DIGU',
+      spectrum: crowded,
+      floor,
+      hzPerPixel: HZ_PER_PX,
+    }).profileId).toBe('digital');
+  });
+
+  it('ignores non-finite bins when recommending scene profiles', () => {
+    const floor = new Float32Array(WIDTH).fill(NOISE_DB);
+    const spec = new Float32Array(WIDTH).fill(NOISE_DB);
+    const confidence = new Float32Array(WIDTH).fill(0.8);
+    spec[80] = Infinity;
+    spec[90] = NaN;
+    spec[100] = -Infinity;
+    floor[110] = NaN;
+    confidence[80] = Infinity;
+
+    const scene = recommendSignalEnhanceScene({
+      mode: 'USB',
+      spectrum: spec,
+      floor,
+      confidence,
+      hzPerPixel: HZ_PER_PX,
+    });
+
+    expect(scene.profileId).toBe('voice');
+    expect(scene.peakCount).toBe(0);
+    expect(scene.coherentPeakCount).toBe(0);
+    expect(scene.maxSnrDb).toBe(0);
+    expect(scene.coherentMaxSnrDb).toBe(0);
+    expect(scene.impulsiveOccupiedRatio).toBe(0);
+  });
+
+  it('fails closed on invalid scene geometry without emitting NaN metrics', () => {
+    const floor = new Float32Array(WIDTH).fill(NOISE_DB);
+    const spec = spectrumWithCarrier();
+
+    for (const hzPerPixel of [Number.NaN, Infinity, 0, -1]) {
+      const scene = recommendSignalEnhanceScene({
+        mode: 'USB',
+        spectrum: spec,
+        floor,
+        hzPerPixel,
+      });
+
+      expect(scene.profileId).toBe('voice');
+      expect(scene.peakCount).toBe(0);
+      expect(scene.peaksPer10Khz).toBe(0);
+      expect(scene.occupiedRatio).toBe(0);
+      expect(scene.maxSnrDb).toBe(0);
+      expect(Number.isFinite(scene.peaksPer10Khz)).toBe(true);
+      expect(Number.isFinite(scene.coherentPeaksPer10Khz)).toBe(true);
+    }
+  });
+
+  it('stays cold (no floor, zero cost) when both Pop and Snap are off', () => {
+    pushFrame(spectrumWithCarrier());
+    expect(getNoiseFloor()).toBeNull();
+  });
+
+  it('keeps the floor estimator live while auto-profile analysis is enabled', () => {
+    useSignalEnhanceStore.setState({ autoProfileEnabled: true, popEnabled: false, snapEnabled: false });
+    pushFrame(spectrumWithCarrier());
+    expect(getNoiseFloor()).not.toBeNull();
+  });
+
+  it('does not warm the estimator from invalid frame geometry', () => {
+    useSignalEnhanceStore.setState({ popEnabled: true });
+    maybeUpdateEstimator({
+      panDb: spectrumWithCarrier(),
+      panValid: true,
+      width: WIDTH + 1,
+      hzPerPixel: HZ_PER_PX,
+    });
+    expect(getNoiseFloor()).toBeNull();
+
+    maybeUpdateEstimator({
+      panDb: spectrumWithCarrier(),
+      panValid: true,
+      width: WIDTH,
+      hzPerPixel: Number.NaN,
+    });
+    expect(getNoiseFloor()).toBeNull();
+  });
+
+  it('estimates the floor from neighbours — a steady carrier does NOT raise its own floor', () => {
+    useSignalEnhanceStore.setState({ popEnabled: true });
+    // Many identical frames: a temporal tracker would creep the carrier bin's
+    // floor up to the carrier. The spatial estimate must keep it at the noise.
+    for (let k = 0; k < 30; k++) pushFrame(spectrumWithCarrier());
+    const floor = getNoiseFloor()!;
+    expect(floor).not.toBeNull();
+    // Floor at the carrier bin tracks the surrounding noise (+ a few dB offset),
+    // nowhere near the −50 dB carrier.
+    expect(floor[CARRIER_BIN]!).toBeLessThan(NOISE_DB + 12);
+    expect(floor[CARRIER_BIN]!).toBeGreaterThan(NOISE_DB - 2);
+  });
+
+  it('maps the carrier near full brightness and the noise to black (0..1)', () => {
+    useSignalEnhanceStore.setState({ popEnabled: true });
+    for (let k = 0; k < 5; k++) pushFrame(spectrumWithCarrier());
+    const spec = spectrumWithCarrier();
+    const out = new Float32Array(WIDTH);
+    enhanceInto(spec, out);
+    // Output is a 0..1 display value: the strong carrier clips to ~1, gated
+    // noise sits at 0.
+    expect(out[CARRIER_BIN]!).toBeGreaterThan(0.9);
+    expect(out[CARRIER_BIN]!).toBeLessThanOrEqual(1);
+    expect(out[0]!).toBe(0);
+  });
+
+  it('gamma lifts a weak signal well clear of the gate', () => {
+    useSignalEnhanceStore.setState({ popEnabled: true });
+    // ~15 dB-over-noise signal: with span 30 + gamma 0.5 it should read as a
+    // bright mid value, not buried — this is the "pull weak out" behaviour.
+    const spec = new Float32Array(WIDTH).fill(NOISE_DB);
+    spec[150] = NOISE_DB + 15;
+    for (let k = 0; k < 5; k++) pushFrame(spec);
+    const out = new Float32Array(WIDTH);
+    enhanceInto(spec, out);
+    expect(out[150]!).toBeGreaterThan(0.45);
+    expect(out[0]!).toBe(0);
+  });
+
+  it('visual AGC gives sparse weak signals more of the colour ramp', () => {
+    useSignalEnhanceStore.setState({
+      popEnabled: true,
+      visualAgcEnabled: false,
+      visualAgcStrength: 0,
+    });
+    const spec = new Float32Array(WIDTH).fill(NOISE_DB);
+    spec[150] = NOISE_DB + 10;
+    for (let k = 0; k < 5; k++) pushFrame(spec);
+
+    const fixed = new Float32Array(WIDTH);
+    enhanceInto(spec, fixed);
+
+    useSignalEnhanceStore.setState({
+      visualAgcEnabled: true,
+      visualAgcStrength: 100,
+    });
+    const agc = new Float32Array(WIDTH);
+    enhanceInto(spec, agc);
+
+    expect(agc[150]!).toBeGreaterThan(fixed[150]! + 0.15);
+    expect(agc[0]!).toBe(0);
+  });
+
+  it('builds temporal confidence for a persistent weak signal', () => {
+    useSignalEnhanceStore.setState({ popEnabled: true });
+    const spec = new Float32Array(WIDTH).fill(NOISE_DB);
+    spec[150] = NOISE_DB + 15;
+    for (let k = 0; k < 5; k++) pushFrame(spec);
+
+    const confidence = getSignalConfidence()!;
+    expect(confidence[150]!).toBeGreaterThan(0.5);
+    expect(confidence[0]!).toBeLessThan(0.05);
+  });
+
+  it('builds temporal confidence for automation consumers when Signal Pop is off', () => {
+    useSignalEnhanceStore.setState({ popEnabled: false, autoProfileEnabled: true });
+    const spec = new Float32Array(WIDTH).fill(NOISE_DB);
+    spec[150] = NOISE_DB + 15;
+    for (let k = 0; k < 5; k++) pushFrame(spec);
+
+    const confidence = getSignalConfidence()!;
+    expect(confidence).not.toBeNull();
+    expect(confidence[150]!).toBeGreaterThan(0.5);
+    expect(confidence[0]!).toBeLessThan(0.05);
+  });
+
+  it('rejects one-frame auto-profile impulses even when Signal Pop is off', () => {
+    useSignalEnhanceStore.setState({ popEnabled: false, autoProfileEnabled: true });
+    const noise = new Float32Array(WIDTH).fill(NOISE_DB);
+    for (let k = 0; k < 5; k++) pushFrame(noise);
+
+    const impulse = new Float32Array(WIDTH).fill(NOISE_DB);
+    impulse[150] = NOISE_DB + 15;
+    pushFrame(impulse);
+
+    const confidence = getSignalConfidence()!;
+    const scene = recommendSignalEnhanceScene({
+      mode: 'USB',
+      spectrum: impulse,
+      floor: getNoiseFloor(),
+      confidence,
+      hzPerPixel: HZ_PER_PX,
+    });
+
+    expect(confidence[150]!).toBeLessThan(useSignalEnhanceStore.getState().coherenceHoldGate);
+    expect(scene.peakCount).toBe(1);
+    expect(scene.coherentPeakCount).toBe(0);
+    expect(scene.impulsiveOccupiedRatio).toBeGreaterThan(0);
+    expect(scene.profileId).toBe('voice');
+  });
+
+  it('does not give a one-frame isolated impulse a persistent trail', () => {
+    useSignalEnhanceStore.setState({ popEnabled: true });
+    const noise = new Float32Array(WIDTH).fill(NOISE_DB);
+    for (let k = 0; k < 5; k++) pushFrame(noise);
+
+    const impulse = new Float32Array(WIDTH).fill(NOISE_DB);
+    impulse[150] = NOISE_DB + 45;
+    pushFrame(impulse);
+    pushFrame(noise);
+
+    const out = new Float32Array(WIDTH);
+    enhanceInto(noise, out);
+    expect(out[150]!).toBe(0);
+  });
+
+  it('display-clamps isolated one-frame spikes but preserves coherent signals', () => {
+    useSignalEnhanceStore.setState({
+      popEnabled: true,
+      visualAgcEnabled: false,
+      impulseRejectEnabled: true,
+      impulseRejectDb: 18,
+    });
+    const noise = new Float32Array(WIDTH).fill(NOISE_DB);
+    for (let k = 0; k < 5; k++) pushFrame(noise);
+
+    const impulse = new Float32Array(WIDTH).fill(NOISE_DB);
+    impulse[150] = NOISE_DB + 45;
+    pushFrame(impulse);
+    const impulseOut = new Float32Array(WIDTH);
+    enhanceInto(impulse, impulseOut);
+
+    expect(impulseOut[150]!).toBeLessThan(0.55);
+
+    resetEstimator();
+    const coherent = new Float32Array(WIDTH).fill(NOISE_DB);
+    coherent[150] = NOISE_DB + 45;
+    for (let k = 0; k < 5; k++) pushFrame(coherent);
+    const coherentOut = new Float32Array(WIDTH);
+    enhanceInto(coherent, coherentOut);
+
+    expect(coherentOut[150]!).toBeGreaterThan(0.9);
+  });
+
+  it('boosts a narrow weak ridge above a broad raised neighbourhood at the same SNR', () => {
+    useSignalEnhanceStore.setState({ popEnabled: true });
+    const narrow = new Float32Array(WIDTH).fill(NOISE_DB);
+    narrow[150] = NOISE_DB + 15;
+    for (let k = 0; k < 5; k++) pushFrame(narrow);
+    const narrowOut = new Float32Array(WIDTH);
+    enhanceInto(narrow, narrowOut);
+
+    resetEstimator();
+
+    const broad = new Float32Array(WIDTH).fill(NOISE_DB);
+    for (let i = 140; i <= 160; i++) broad[i] = NOISE_DB + 15;
+    for (let k = 0; k < 5; k++) pushFrame(broad);
+    const broadOut = new Float32Array(WIDTH);
+    enhanceInto(broad, broadOut);
+
+    expect(narrowOut[150]!).toBeGreaterThan(broadOut[150]! + 0.08);
+  });
+
+  it('flattens band tilt — gated noise is uniformly dark across the span', () => {
+    useSignalEnhanceStore.setState({ popEnabled: true });
+    for (let k = 0; k < 5; k++) pushFrame(spectrumWithTilt());
+    const spec = spectrumWithTilt();
+    const out = new Float32Array(WIDTH);
+    enhanceInto(spec, out);
+    // Left edge (−90) and right edge (−120) differ by 30 dB raw; after floor
+    // subtraction + gate both are noise and land at 0.
+    expect(out[5]!).toBe(0);
+    expect(out[WIDTH - 5]!).toBe(0);
+  });
+
+  it('does not let one deep spectral null light nearby noise', () => {
+    useSignalEnhanceStore.setState({ popEnabled: true });
+    const spec = new Float32Array(WIDTH).fill(NOISE_DB);
+    spec[80] = NOISE_DB - 40;
+    spec[90] = NOISE_DB;
+    spec[150] = NOISE_DB + 15;
+    for (let k = 0; k < 5; k++) pushFrame(spec);
+
+    const out = new Float32Array(WIDTH);
+    enhanceInto(spec, out);
+
+    expect(out[90]!).toBe(0);
+    expect(out[150]!).toBeGreaterThan(0.45);
+  });
+
+  it('holds a weak signal ridge briefly, then decays back to black', () => {
+    useSignalEnhanceStore.setState({ popEnabled: true });
+    const weak = new Float32Array(WIDTH).fill(NOISE_DB);
+    weak[150] = NOISE_DB + 15;
+    for (let k = 0; k < 5; k++) pushFrame(weak);
+
+    const noise = new Float32Array(WIDTH).fill(NOISE_DB);
+    pushFrame(noise);
+    const held = new Float32Array(WIDTH);
+    enhanceInto(noise, held);
+
+    expect(held[150]!).toBeGreaterThan(0.35);
+    expect(held[0]!).toBe(0);
+
+    for (let k = 0; k < 20; k++) pushFrame(noise);
+    const faded = new Float32Array(WIDTH);
+    enhanceInto(noise, faded);
+
+    expect(faded[150]!).toBe(0);
+  });
+
+  it('enhanceInto outputs all-zero before any floor exists', () => {
+    const spec = spectrumWithCarrier();
+    const out = new Float32Array(WIDTH).fill(0.5);
+    enhanceInto(spec, out); // no floor yet
+    expect(Array.from(out).every((v) => v === 0)).toBe(true);
+  });
+
+  it('keeps non-finite estimator samples dark and out of confidence memory', () => {
+    useSignalEnhanceStore.setState({ popEnabled: true });
+    const noise = new Float32Array(WIDTH).fill(NOISE_DB);
+    for (let k = 0; k < 5; k++) pushFrame(noise);
+
+    const bad = new Float32Array(WIDTH).fill(NOISE_DB);
+    bad[149] = Infinity;
+    bad[150] = NaN;
+    bad[151] = -Infinity;
+    pushFrame(bad);
+
+    const out = new Float32Array(WIDTH).fill(0.5);
+    enhanceInto(bad, out);
+    const confidence = getSignalConfidence()!;
+
+    expect(Array.from(out).every(Number.isFinite)).toBe(true);
+    expect(out[149]).toBe(0);
+    expect(out[150]).toBe(0);
+    expect(out[151]).toBe(0);
+    expect(confidence[149]).toBe(0);
+    expect(confidence[150]).toBe(0);
+    expect(confidence[151]).toBe(0);
+  });
+});
+
+describe('signal estimator — snap-to-signal', () => {
+  it('snaps a near-carrier click onto the exact carrier bin frequency', () => {
+    useSignalEnhanceStore.setState({ popEnabled: true });
+    for (let k = 0; k < 5; k++) pushFrame(spectrumWithCarrier());
+    const spec = spectrumWithCarrier();
+    // Click 1.8 kHz away from the carrier (carrier is at +2200 Hz from center).
+    const clickHz = CENTER + 2000;
+    const peak = findPeakHz(spec, CENTER, HZ_PER_PX, clickHz);
+    const carrierHz = CENTER + (CARRIER_BIN - WIDTH / 2) * HZ_PER_PX;
+    expect(peak).toBe(carrierHz);
+  });
+
+  it('returns null over bare noise (nothing rises above the floor)', () => {
+    useSignalEnhanceStore.setState({ popEnabled: true });
+    for (let k = 0; k < 5; k++) pushFrame(spectrumWithCarrier());
+    const spec = spectrumWithCarrier();
+    // Click far from the carrier, on flat noise.
+    const peak = findPeakHz(spec, CENTER, HZ_PER_PX, CENTER - 5000);
+    expect(peak).toBeNull();
+  });
+});
+
+describe('signal estimator — peak markers (CFAR)', () => {
+  it('detects the carrier and nothing else on a flat-noise span', () => {
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    for (let k = 0; k < 5; k++) pushFrame(spectrumWithCarrier());
+    const peaks = detectPeaks(spectrumWithCarrier(), CENTER, HZ_PER_PX);
+    expect(peaks).toHaveLength(1);
+    expect(peaks[0]!.hz).toBe(CENTER + (CARRIER_BIN - WIDTH / 2) * HZ_PER_PX);
+    expect(peaks[0]!.snrDb).toBeGreaterThan(45);
+  });
+
+  it('collapses a multi-bin signal to a single strongest marker', () => {
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    const spec = new Float32Array(WIDTH).fill(NOISE_DB);
+    // A 3-bin-wide signal cresting at the middle bin.
+    spec[120] = -70;
+    spec[121] = -55;
+    spec[122] = -68;
+    for (let k = 0; k < 5; k++) pushFrame(spec);
+    const peaks = detectPeaks(spec, CENTER, HZ_PER_PX);
+    expect(peaks).toHaveLength(1);
+    expect(peaks[0]!.hz).toBe(CENTER + (121 - WIDTH / 2) * HZ_PER_PX);
+  });
+
+  it('uses the configured marker SNR threshold for peak detection', () => {
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    const weak = new Float32Array(WIDTH).fill(NOISE_DB);
+    weak[CARRIER_BIN] = NOISE_DB + 12;
+    for (let k = 0; k < 5; k++) pushFrame(weak);
+
+    useSignalEnhanceStore.getState().setSignalEnhanceTuning({ peakMinSnrDb: 4 });
+    expect(detectPeaks(weak, CENTER, HZ_PER_PX)).toHaveLength(1);
+
+    useSignalEnhanceStore.getState().setSignalEnhanceTuning({ peakMinSnrDb: 12 });
+    expect(detectPeaks(weak, CENTER, HZ_PER_PX)).toHaveLength(0);
+  });
+
+  it('returns nothing before a floor exists', () => {
+    expect(detectPeaks(spectrumWithCarrier(), CENTER, HZ_PER_PX)).toEqual([]);
+  });
+
+  it('does not treat non-finite bins as snap peaks or signal extents', () => {
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    const noise = new Float32Array(WIDTH).fill(NOISE_DB);
+    for (let k = 0; k < 5; k++) pushFrame(noise);
+
+    const bad = new Float32Array(WIDTH).fill(NOISE_DB);
+    bad[149] = Infinity;
+    bad[150] = NaN;
+    bad[151] = -Infinity;
+    const clickHz = CENTER + (150 - WIDTH / 2) * HZ_PER_PX;
+
+    expect(detectPeaks(bad, CENTER, HZ_PER_PX)).toEqual([]);
+    expect(findPeakHz(bad, CENTER, HZ_PER_PX, clickHz)).toBeNull();
+    expect(computeSnapTuneHz(bad, CENTER, HZ_PER_PX, clickHz, 5000, 'USB')).toBeNull();
+    expect(computeSnapToLineHz(bad, CENTER, HZ_PER_PX, 'USB', clickHz, 5000)).toBeNull();
+    expect(signalExtentHz(bad, CENTER, HZ_PER_PX, clickHz, 5000)).toBeNull();
+  });
+
+  it('fails closed when snap and marker geometry is non-finite', () => {
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    for (let k = 0; k < 5; k++) pushFrame(spectrumWithCarrier());
+    const spec = spectrumWithCarrier();
+    const clickHz = CENTER + (CARRIER_BIN - WIDTH / 2) * HZ_PER_PX;
+
+    for (const centerHz of [Number.NaN, Infinity]) {
+      expect(detectPeaks(spec, centerHz, HZ_PER_PX)).toEqual([]);
+      expect(findPeakHz(spec, centerHz, HZ_PER_PX, clickHz)).toBeNull();
+      expect(findNearestPeakHz(spec, centerHz, HZ_PER_PX, clickHz, 5000)).toBeNull();
+      expect(computeSnapTuneHz(spec, centerHz, HZ_PER_PX, clickHz, 5000, 'USB')).toBeNull();
+      expect(computeSnapToLineHz(spec, centerHz, HZ_PER_PX, 'USB', clickHz, 5000)).toBeNull();
+      expect(signalExtentHz(spec, centerHz, HZ_PER_PX, clickHz, 5000)).toBeNull();
+      expect(measureSnapLock(spec, centerHz, HZ_PER_PX, 'USB', clickHz, 500)).toBeNull();
+    }
+
+    for (const hzPerPixel of [Number.NaN, Infinity, 0, -1]) {
+      expect(detectPeaks(spec, CENTER, hzPerPixel)).toEqual([]);
+      expect(findPeakHz(spec, CENTER, hzPerPixel, clickHz)).toBeNull();
+      expect(findNearestPeakHz(spec, CENTER, hzPerPixel, clickHz, 5000)).toBeNull();
+      expect(computeSnapTuneHz(spec, CENTER, hzPerPixel, clickHz, 5000, 'USB')).toBeNull();
+      expect(computeSnapToLineHz(spec, CENTER, hzPerPixel, 'USB', clickHz, 5000)).toBeNull();
+      expect(signalExtentHz(spec, CENTER, hzPerPixel, clickHz, 5000)).toBeNull();
+      expect(measureSnapLock(spec, CENTER, hzPerPixel, 'USB', clickHz, 500)).toBeNull();
+    }
+
+    expect(findNearestPeakHz(spec, CENTER, HZ_PER_PX, clickHz, Number.NaN)).toBeNull();
+    expect(computeSnapTuneHz(spec, CENTER, HZ_PER_PX, clickHz, Infinity, 'USB')).toBeNull();
+    expect(computeSnapToLineHz(spec, CENTER, HZ_PER_PX, 'USB', clickHz, -1)).toBeNull();
+    expect(signalExtentHz(spec, CENTER, HZ_PER_PX, clickHz, Number.NaN)).toBeNull();
+    expect(measureSnapLock(spec, CENTER, HZ_PER_PX, 'USB', clickHz, -1)).toBeNull();
+  });
+
+  it('peakAlpha scales with SNR and stays within [0.45, 1]', () => {
+    expect(peakAlpha(0)).toBe(0.45);
+    expect(peakAlpha(1000)).toBe(1);
+    expect(peakAlpha(NaN)).toBe(0.45);
+    expect(peakAlpha(30)).toBeGreaterThan(0.45);
+    expect(peakAlpha(30)).toBeLessThan(1);
+  });
+});
+
+describe('signal estimator — findNearestPeakHz (snap)', () => {
+  const carrierHz = CENTER + (CARRIER_BIN - WIDTH / 2) * HZ_PER_PX;
+
+  it('snaps a nearby click onto the carrier within the radius', () => {
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    for (let k = 0; k < 5; k++) pushFrame(spectrumWithCarrier());
+    const spec = spectrumWithCarrier();
+    // Click 1.5 kHz off the carrier, radius 5 kHz → snaps.
+    const got = findNearestPeakHz(spec, CENTER, HZ_PER_PX, carrierHz - 1500, 5000);
+    expect(got).toBe(carrierHz);
+  });
+
+  it('returns null when the nearest carrier is outside the radius', () => {
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    for (let k = 0; k < 5; k++) pushFrame(spectrumWithCarrier());
+    const spec = spectrumWithCarrier();
+    // Click 8 kHz off the carrier, radius 3 kHz → no snap.
+    const got = findNearestPeakHz(spec, CENTER, HZ_PER_PX, carrierHz - 8000, 3000);
+    expect(got).toBeNull();
+  });
+
+  it('picks the closer of two carriers', () => {
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    const spec = new Float32Array(WIDTH).fill(NOISE_DB);
+    spec[110] = -55;
+    spec[150] = -55;
+    for (let k = 0; k < 5; k++) pushFrame(spec);
+    const hz110 = CENTER + (110 - WIDTH / 2) * HZ_PER_PX;
+    const hz150 = CENTER + (150 - WIDTH / 2) * HZ_PER_PX;
+    // Click just left of bin 150 → should grab 150, not 110.
+    const got = findNearestPeakHz(spec, CENTER, HZ_PER_PX, hz150 - 500, 1_000_000);
+    expect(got).toBe(hz150);
+    expect(got).not.toBe(hz110);
+  });
+});
+
+describe('signal estimator — computeSnapTuneHz (mode-aware tune)', () => {
+  const carrierHz = CENTER + (CARRIER_BIN - WIDTH / 2) * HZ_PER_PX; // bin 150
+  const binHz = (b: number) => CENTER + (b - WIDTH / 2) * HZ_PER_PX;
+
+  // A ~20-bin voice channel cresting at bin 150 (formant), energy 140..160.
+  function voiceBlock(): Float32Array {
+    const spec = new Float32Array(WIDTH).fill(NOISE_DB);
+    for (let i = 140; i <= 160; i++) spec[i] = -60 - Math.abs(i - 150);
+    return spec;
+  }
+
+  it('CW: dials the carrier itself (sub-bin), backend adds the pitch', () => {
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    for (let k = 0; k < 5; k++) pushFrame(spectrumWithCarrier());
+    const got = computeSnapTuneHz(spectrumWithCarrier(), CENTER, HZ_PER_PX, carrierHz - 800, 5000, 'CWU');
+    // Symmetric single-bin carrier → parabolic peak lands exactly on the bin.
+    expect(got).toBeCloseTo(carrierHz, 3);
+  });
+
+  it('USB: dials the LOW energy edge (suppressed carrier)', () => {
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    const spec = voiceBlock();
+    for (let k = 0; k < 5; k++) pushFrame(spec);
+    const got = computeSnapTuneHz(spec, CENTER, HZ_PER_PX, carrierHz, 5000, 'USB');
+    expect(got).toBe(binHz(140));
+  });
+
+  it('USB: clicking the MIDDLE/RIGHT of a signal still snaps to the LOW edge', () => {
+    // The reported bug: click inside a signal (not on its crest) and it stayed
+    // put. With anchor-on-strongest-nearby-bin it must still reach the low edge.
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    const spec = voiceBlock(); // energy 140..160, crest 150
+    for (let k = 0; k < 5; k++) pushFrame(spec);
+    // Click at bin 156 (right of crest, well inside the signal).
+    const got = computeSnapTuneHz(spec, CENTER, HZ_PER_PX, binHz(156), 5000, 'USB');
+    expect(got).toBe(binHz(140));
+    expect(got!).toBeLessThan(binHz(156)); // moved LEFT, didn't stay put
+  });
+
+  it('LSB: dials the HIGH energy edge', () => {
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    const spec = voiceBlock();
+    for (let k = 0; k < 5; k++) pushFrame(spec);
+    const got = computeSnapTuneHz(spec, CENTER, HZ_PER_PX, carrierHz, 5000, 'LSB');
+    expect(got).toBe(binHz(160));
+  });
+
+  it('AM: dials the carrier centre (energy centroid)', () => {
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    const spec = voiceBlock();
+    for (let k = 0; k < 5; k++) pushFrame(spec);
+    const got = computeSnapTuneHz(spec, CENTER, HZ_PER_PX, carrierHz, 5000, 'AM')!;
+    // Symmetric hump → centroid within a bin of the centre.
+    expect(Math.abs(got - carrierHz)).toBeLessThan(HZ_PER_PX);
+  });
+
+  it('returns null when no signal is within the radius', () => {
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    for (let k = 0; k < 5; k++) pushFrame(spectrumWithCarrier());
+    const got = computeSnapTuneHz(spectrumWithCarrier(), CENTER, HZ_PER_PX, CENTER - 5000, 1000, 'USB');
+    expect(got).toBeNull();
+  });
+});
+
+describe('signal estimator — computeSnapToLineHz (favour the clicked line)', () => {
+  const binHz = (b: number) => CENTER + (b - WIDTH / 2) * HZ_PER_PX;
+  const WIDE = 1_000_000; // radius wide enough to reach any on-screen signal
+
+  // Two voice channels: A near the centre (energy 118..128, crest 123),
+  // B well to the right (energy 180..200, crest 190). CENTER maps to bin 128.
+  function twoBlocks(): Float32Array {
+    const spec = new Float32Array(WIDTH).fill(NOISE_DB);
+    for (let i = 118; i <= 128; i++) spec[i] = -60 - Math.abs(i - 123);
+    for (let i = 180; i <= 200; i++) spec[i] = -60 - Math.abs(i - 190);
+    return spec;
+  }
+
+  it('USB: snaps to the LOW edge of the signal nearest the clicked line', () => {
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    const spec = twoBlocks();
+    for (let k = 0; k < 5; k++) pushFrame(spec);
+    // Click on A → A's low edge (118), which is far closer than B's edge (180).
+    const got = computeSnapToLineHz(spec, CENTER, HZ_PER_PX, 'USB', binHz(123), WIDE);
+    expect(got).toBe(binHz(118));
+  });
+
+  it('honours WHERE you click — a click by the far signal snaps to IT, not the one near centre', () => {
+    // Regression for the "always snaps to centre" bug: clicking next to the
+    // far-right signal must grab IT, even though A sits closer to the display
+    // centre. The reference line is the cursor, not the display centre.
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    const spec = twoBlocks();
+    for (let k = 0; k < 5; k++) pushFrame(spec);
+    // Click on B (crest 190) → USB low edge of B is 180; A is left untouched.
+    const got = computeSnapToLineHz(spec, CENTER, HZ_PER_PX, 'USB', binHz(190), WIDE);
+    expect(got).toBe(binHz(180));
+  });
+
+  it('picks the edge closest to the clicked line, not the nearest signal body', () => {
+    // A spans 100..118 (USB low edge 100, FAR from the click at bin 128);
+    // B spans 135..160 (low edge 135, only 7 bins from the click). USB must dial
+    // B's low edge — that EDGE is closest to the clicked line. The 16-bin gap
+    // keeps them as distinct clusters (walkEdge merges ≤3-bin gaps).
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    const spec = new Float32Array(WIDTH).fill(NOISE_DB);
+    for (let i = 100; i <= 118; i++) spec[i] = -60 - Math.abs(i - 109);
+    for (let i = 135; i <= 160; i++) spec[i] = -60 - Math.abs(i - 147);
+    for (let k = 0; k < 5; k++) pushFrame(spec);
+    const got = computeSnapToLineHz(spec, CENTER, HZ_PER_PX, 'USB', binHz(128), WIDE);
+    expect(got).toBe(binHz(135));
+  });
+
+  it('CW: snaps to the carrier crest nearest the clicked line', () => {
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    const spec = twoBlocks();
+    for (let k = 0; k < 5; k++) pushFrame(spec);
+    const got = computeSnapToLineHz(spec, CENTER, HZ_PER_PX, 'CWU', binHz(128), WIDE)!;
+    // A's crest (bin 123) is the nearest crest to the clicked line (bin 128).
+    expect(Math.abs(got - binHz(123))).toBeLessThan(HZ_PER_PX);
+  });
+
+  it('LSB: clicking the LOW side of a wide channel still snaps to its HIGH edge', () => {
+    // The live-G2 case: a ~3 kHz LSB channel (energy 120..150, 30 bins). Click
+    // the low side (bin 122); the tuning HIGH edge (bin 150) is 2.8 kHz away —
+    // beyond a tight 1.5 kHz grab radius. Body-distance selection still grabs the
+    // signal (the click is INSIDE it) and dials the high edge. An edge-distance
+    // rule would have missed the very signal under the cursor.
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    const spec = new Float32Array(WIDTH).fill(NOISE_DB);
+    for (let i = 120; i <= 150; i++) spec[i] = -60 - Math.abs(i - 135) * 0.3;
+    for (let k = 0; k < 5; k++) pushFrame(spec);
+    const got = computeSnapToLineHz(spec, CENTER, HZ_PER_PX, 'LSB', binHz(122), 1500);
+    expect(got).toBe(binHz(150));
+  });
+
+  it('returns null when no signal is within the snap radius (click tunes normally)', () => {
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    const spec = twoBlocks();
+    for (let k = 0; k < 5; k++) pushFrame(spec);
+    // Click at bin 60, far from both signals; a tight 1 kHz radius → no snap.
+    const got = computeSnapToLineHz(spec, CENTER, HZ_PER_PX, 'USB', binHz(60), 1000);
+    expect(got).toBeNull();
+  });
+
+  it('returns null on bare noise (caller then tunes normally)', () => {
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    const noise = new Float32Array(WIDTH).fill(NOISE_DB);
+    for (let k = 0; k < 5; k++) pushFrame(noise);
+    expect(computeSnapToLineHz(noise, CENTER, HZ_PER_PX, 'USB', CENTER, WIDE)).toBeNull();
+  });
+});
+
+describe('signal estimator — snap history (waterfall memory)', () => {
+  const binHz = (b: number) => CENTER + (b - WIDTH / 2) * HZ_PER_PX;
+  const WIDE = 1_000_000;
+
+  // A voice channel, energy 140..160, crest 150.
+  function voiceBlock(): Float32Array {
+    const spec = new Float32Array(WIDTH).fill(NOISE_DB);
+    for (let i = 140; i <= 160; i++) spec[i] = -60 - Math.abs(i - 150);
+    return spec;
+  }
+
+  it('only accumulates while Snap is on (Pop alone leaves it empty)', () => {
+    useSignalEnhanceStore.setState({ popEnabled: true, snapEnabled: false });
+    for (let k = 0; k < 6; k++) pushFrame(voiceBlock());
+    expect(getSnapHistorySpectrum()).toBeNull();
+  });
+
+  it('never remembers bare noise (no false history clusters)', () => {
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    const noise = new Float32Array(WIDTH).fill(NOISE_DB);
+    for (let k = 0; k < 10; k++) pushFrame(noise);
+    expect(getSnapHistorySpectrum()).toBeNull();
+  });
+
+  it('remembers a signal that has left the live frame, then snaps to it', () => {
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    for (let k = 0; k < 6; k++) pushFrame(voiceBlock()); // build the memory
+    // The signal is gone now — one live noise frame keeps the floor sane.
+    const noise = new Float32Array(WIDTH).fill(NOISE_DB);
+    pushFrame(noise);
+    // Live snap finds nothing where the signal used to be...
+    expect(computeSnapToLineHz(noise, CENTER, HZ_PER_PX, 'USB', binHz(150), WIDE)).toBeNull();
+    // ...but the waterfall memory still has it, edge-aligned for the mode.
+    const history = getSnapHistorySpectrum();
+    expect(history).not.toBeNull();
+    const got = computeSnapToLineHz(history!, CENTER, HZ_PER_PX, 'USB', binHz(150), WIDE);
+    expect(got).toBe(binHz(140)); // USB low edge of the remembered channel
+  });
+
+  it('a remembered signal fades below the snap threshold after enough quiet frames', () => {
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    for (let k = 0; k < 6; k++) pushFrame(voiceBlock());
+    const noise = new Float32Array(WIDTH).fill(NOISE_DB);
+    // Crest SNR starts ~50 dB; at 0.4 dB/frame it needs >100 quiet frames to
+    // fade under the 6 dB cluster gate. 200 is comfortably past that.
+    for (let k = 0; k < 200; k++) pushFrame(noise);
+    const history = getSnapHistorySpectrum();
+    if (history) {
+      expect(computeSnapToLineHz(history, CENTER, HZ_PER_PX, 'USB', binHz(150), WIDE)).toBeNull();
+    } else {
+      expect(history).toBeNull();
+    }
+  });
+});
+
+describe('signal estimator — measureSnapLock (self-correcting lock, neighbour-safe)', () => {
+  const binHz = (b: number) => CENTER + (b - WIDTH / 2) * HZ_PER_PX;
+  const CAPTURE_HZ = 300; // ±3 bins at 100 Hz/px
+
+  // Weak channel (120..130, crest 125) sitting near a MUCH louder neighbour
+  // (145..160, crest 152) — the operator's exact worry.
+  function weakNearStrong(): Float32Array {
+    const spec = new Float32Array(WIDTH).fill(NOISE_DB);
+    for (let i = 120; i <= 130; i++) spec[i] = -92 - Math.abs(i - 125) * 0.5;
+    for (let i = 145; i <= 160; i++) spec[i] = -55 - Math.abs(i - 152) * 0.3;
+    return spec;
+  }
+
+  it('follows the WEAK signal and never grabs the loud neighbour', () => {
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    const spec = weakNearStrong();
+    for (let k = 0; k < 5; k++) pushFrame(spec);
+    // Anchor on the weak signal; the strong one is ~27 bins away, far outside ±3.
+    const m = measureSnapLock(spec, CENTER, HZ_PER_PX, 'USB', binHz(125), CAPTURE_HZ)!;
+    expect(m).not.toBeNull();
+    expect(m.dialHz).toBe(binHz(120)); // USB low edge of the WEAK channel
+    expect(Math.abs(m.bodyHz - binHz(125))).toBeLessThan(2 * HZ_PER_PX);
+    expect(m.dialHz).toBeLessThan(binHz(140)); // nowhere near the neighbour (145+)
+  });
+
+  it('HOLDS (returns null) when the locked signal fades — does NOT jump to the neighbour', () => {
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    // Only the strong neighbour remains; the weak one we locked is gone.
+    const spec = new Float32Array(WIDTH).fill(NOISE_DB);
+    for (let i = 145; i <= 160; i++) spec[i] = -55 - Math.abs(i - 152) * 0.3;
+    for (let k = 0; k < 5; k++) pushFrame(spec);
+    // Anchored on the (now-empty) weak slot: nothing in the ±3-bin window.
+    expect(measureSnapLock(spec, CENTER, HZ_PER_PX, 'USB', binHz(125), CAPTURE_HZ)).toBeNull();
+  });
+
+  it('ignores a signal outside the capture window', () => {
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    const spec = new Float32Array(WIDTH).fill(NOISE_DB);
+    for (let i = 138; i <= 146; i++) spec[i] = -60 - Math.abs(i - 142); // ~17 bins from anchor
+    for (let k = 0; k < 5; k++) pushFrame(spec);
+    expect(measureSnapLock(spec, CENTER, HZ_PER_PX, 'USB', binHz(125), CAPTURE_HZ)).toBeNull();
+  });
+
+  it('tracks the signal as it drifts within the window', () => {
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    // Signal shifted +3 bins to 123..133 (crest 128) since the lock anchored at
+    // bin 125; the crest is still inside the ±3-bin window.
+    const spec = new Float32Array(WIDTH).fill(NOISE_DB);
+    for (let i = 123; i <= 133; i++) spec[i] = -90 - Math.abs(i - 128) * 0.5;
+    for (let k = 0; k < 5; k++) pushFrame(spec);
+    const m = measureSnapLock(spec, CENTER, HZ_PER_PX, 'USB', binHz(125), CAPTURE_HZ)!;
+    expect(m).not.toBeNull();
+    expect(m.dialHz).toBe(binHz(123)); // followed the drift to the new low edge
+  });
+
+  // The close-neighbour hole the capture window alone can't close: a loud signal
+  // spaced INSIDE the window once our weak lock dips into the noise. The identity
+  // gate (tracked level) is what rejects it.
+  function loudNeighbourInWindow(): Float32Array {
+    const spec = new Float32Array(WIDTH).fill(NOISE_DB);
+    // Our weak signal is gone; a strong carrier crests at bin 127 — 2 bins from
+    // the anchor at 125, well inside the ±3-bin window.
+    for (let i = 124; i <= 130; i++) spec[i] = -55 - Math.abs(i - 127) * 2;
+    return spec;
+  }
+
+  it('without a tracked level, grabs the close loud neighbour (the hole)', () => {
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    const spec = loudNeighbourInWindow();
+    for (let k = 0; k < 5; k++) pushFrame(spec);
+    // No anchorLevelDb supplied ⇒ gate inert ⇒ nearest-peak grabs the neighbour.
+    const m = measureSnapLock(spec, CENTER, HZ_PER_PX, 'USB', binHz(125), CAPTURE_HZ);
+    expect(m).not.toBeNull();
+    expect(Math.abs(m!.bodyHz - binHz(127))).toBeLessThan(2 * HZ_PER_PX);
+  });
+
+  it('identity gate HOLDS when a displaced louder neighbour invades the window', () => {
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    const spec = loudNeighbourInWindow();
+    for (let k = 0; k < 5; k++) pushFrame(spec);
+    // We have been tracking a weak (~-92 dB) signal; the in-window candidate is
+    // ~+37 dB louder AND displaced ⇒ a foreign carrier ⇒ hold, don't jump.
+    expect(measureSnapLock(spec, CENTER, HZ_PER_PX, 'USB', binHz(125), CAPTURE_HZ, -92)).toBeNull();
+  });
+
+  it('identity gate KEEPS a signal that merely brightens in place (QSB lift)', () => {
+    useSignalEnhanceStore.setState({ snapEnabled: true });
+    // Our signal at the anchor (crest 125) jumps from ~-92 to -70 dB but does NOT
+    // move — that is our lock getting louder, not a neighbour, so it is kept.
+    const spec = new Float32Array(WIDTH).fill(NOISE_DB);
+    for (let i = 121; i <= 129; i++) spec[i] = -70 - Math.abs(i - 125) * 2;
+    for (let k = 0; k < 5; k++) pushFrame(spec);
+    const m = measureSnapLock(spec, CENTER, HZ_PER_PX, 'USB', binHz(125), CAPTURE_HZ, -92);
+    expect(m).not.toBeNull();
+    expect(Math.abs(m!.bodyHz - binHz(125))).toBeLessThan(2 * HZ_PER_PX);
+  });
+});
+
+describe('measureOccupiedBandwidth', () => {
+  it('finds the −6 dB edges of a triangular carrier', () => {
+    // Crest at bin 120 (−40 dB), sloping 1 dB/bin → −6 dB points are ±6 bins.
+    const spec = new Float32Array(WIDTH).fill(NOISE_DB);
+    for (let i = 100; i <= 140; i++) spec[i] = -40 - Math.abs(i - 120);
+    const [lo, hi] = measureOccupiedBandwidth(spec, 120, 6, 40);
+    expect(lo).toBe(114);
+    expect(hi).toBe(126);
+  });
+
+  it('stops at the valley between two adjacent carriers', () => {
+    // Two crests (bin 110 and 140) with a deep notch between them: the walk from
+    // the left carrier must not leak across the valley into the right one.
+    const spec = new Float32Array(WIDTH).fill(NOISE_DB);
+    for (let i = 100; i <= 120; i++) spec[i] = -50 - Math.abs(i - 110);
+    for (let i = 130; i <= 150; i++) spec[i] = -50 - Math.abs(i - 140);
+    const [, hi] = measureOccupiedBandwidth(spec, 110, 6, 60);
+    expect(hi).toBeLessThan(130);
+  });
+
+  it('respects the max-radius bound', () => {
+    const spec = new Float32Array(WIDTH).fill(-40); // flat-topped, never drops
+    const [lo, hi] = measureOccupiedBandwidth(spec, 128, 6, 5);
+    expect(lo).toBe(123);
+    expect(hi).toBe(133);
+  });
+
+  it('keeps non-finite bandwidth and extent measurements bounded', () => {
+    const badCrest = new Float32Array(WIDTH).fill(NOISE_DB);
+    badCrest[120] = NaN;
+    expect(measureOccupiedBandwidth(badCrest, 120, 6, 40)).toEqual([120, 120]);
+    expect(measureSignalExtent(badCrest, null, 120, 3, 40)).toEqual([120, 120]);
+    expect(measureOccupiedBandwidth(badCrest, NaN, 6, 40)).toEqual([0, 0]);
+    expect(measureSignalExtent(badCrest, null, NaN, 3, 40)).toEqual([0, 0]);
+
+    const spec = new Float32Array(WIDTH).fill(NOISE_DB);
+    const floor = new Float32Array(WIDTH).fill(NOISE_DB - 5);
+    for (let i = 116; i <= 124; i++) spec[i] = -55 - Math.abs(i - 120);
+    floor[119] = NaN;
+
+    const [lo, hi] = measureSignalExtent(spec, floor, 120, 3, 40);
+    expect(lo).toBe(120);
+    expect(hi).toBeGreaterThan(120);
+  });
+});

--- a/zeus-web/src/dsp/signal-estimator.ts
+++ b/zeus-web/src/dsp/signal-estimator.ts
@@ -1,0 +1,1873 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+// Shared spectrum signal estimator.
+//
+// One per-bin noise-floor estimate feeds TWO operator features that both need
+// to know "where is the noise and where are the signals":
+//
+//   • Signal Pop  — subtract the per-bin floor before the colormap so weak
+//                   carriers leap off a flattened baseline (band tilt removed).
+//   • Snap-to     — on click, search the bins near the cursor for the strongest
+//                   carrier above the floor and tune exactly onto it.
+//
+// This is classical DSP, not ML. The floor is estimated SPATIALLY (across
+// frequency) — an ordered-statistic CFAR estimate over nearby bins, lifted
+// toward the noise mean and lightly smoothed in time. Spatial CFAR is the
+// right model here: a bin's noise is read from its frequency neighbours, so
+// even a STEADY carrier pops against the noise around it. A purely temporal
+// per-bin tracker would instead converge up to a steady carrier and suppress
+// it. It runs on the existing display pixels (panDb), so there is NO backend,
+// native, or protocol change — and it is gated entirely off (zero per-frame
+// cost) unless the operator turns Pop or Snap on.
+//
+// All of this is OPT-IN and OFF BY DEFAULT: first-connect behaviour is byte-for
+// -byte the current panadapter/waterfall. The Pop dB window and snap tuning are
+// display/UX surface — final values are the maintainer's call (CLAUDE.md).
+
+import { create } from 'zustand';
+import type { RxMode } from '../api/client';
+import { clampFinite } from '../util/number';
+
+// ── Floor-estimator tuning ──────────────────────────────────────────────────
+// Spatial reference window, in Hz. A low percentile is taken over roughly
+// ±(window/2) around each bin, so the window must be wider than the widest
+// signal we want to pop (an SSB channel ≈ 2.7 kHz) to read the noise beside it.
+// Unlike a true minimum, a low percentile is robust against one deep spectral
+// null or notch dragging the whole local floor down and lighting nearby noise.
+// Converted to bins per-frame using the live Hz/pixel, then clamped so extreme
+// zoom levels stay sane.
+const FLOOR_WINDOW_HZ = 6000;
+const FLOOR_MIN_RADIUS_BINS = 6;
+const FLOOR_MAX_RADIUS_BINS = 160;
+const FLOOR_QUIET_PERCENTILE = 0.2;
+const FLOOR_HIST_MIN_DB = -200;
+const FLOOR_HIST_MAX_DB = 20;
+const FLOOR_HIST_STEP_DB = 0.5;
+const FLOOR_HIST_BINS = Math.round((FLOOR_HIST_MAX_DB - FLOOR_HIST_MIN_DB) / FLOOR_HIST_STEP_DB) + 1;
+// The quiet percentile sits in the lower tail of the noise; lift it toward
+// the noise mean so `raw − floor` centres noise near 0 dB rather than several
+// dB up.
+const NOISE_OFFSET_DB = 3;
+// Light temporal smoothing of the spatial floor — kills frame-to-frame jitter
+// in the minimum without lagging real noise-floor changes. 1.0 on a geometry
+// reset so the first frame is already converged (no flat opening frame).
+const FLOOR_TIME_EMA = 0.3;
+
+// ── Pop display mapping (gate → compress → normalise) ───────────────────────
+// enhanceInto turns `snr = raw − floor` (dB above the noise floor) into a 0..1
+// display value the colormap maps directly (the renderers pass dbMin=0,dbMax=1
+// while Pop is on):
+//
+//   1. GATE  — snr below popFloorDb is noise → 0 (dark).
+//   2. SPAN  — popSpanDb is the snr that reaches full brightness; anything
+//              stronger clips to 1. A SMALL span makes weak signals bright.
+//   3. GAMMA — popGamma < 1 compresses the range so a 15 dB signal and a 70 dB
+//              signal can BOTH read as bright at once. This is what stops two
+//              strong carriers from owning the whole colour scale and burying
+//              everything weaker in black.
+//
+// Defaults want on-air tuning by the maintainer; exposed in the store so the
+// Settings > DSP "Signal Intelligence" surface can tune them live.
+const DEFAULT_POP_FLOOR_DB = 3;
+const DEFAULT_POP_SPAN_DB = 30;
+const DEFAULT_POP_GAMMA = 0.5;
+const DEFAULT_POP_RENDER_INTENSITY = 72;
+// Display-only persistence for weak ridges. The WDSP display frame rate can
+// miss short CW/digital bursts or make weak voice traces flicker; a fast peak
+// hold lets real signal energy leave a short visual afterimage while the gate
+// still drives ordinary noise to black. This never feeds snap/peak detection.
+const POP_PERSIST_DECAY = 0.82;
+// Local contrast/ridge boost. After floor subtraction, narrow carriers and
+// digital/CW traces are often only a few bins wide. Compare each bin's SNR
+// with a short local positive-SNR mean; bins that stand above their immediate
+// neighbourhood get a capped dB lift before the gamma map. Broad noise and
+// wide raised baselines get little or no lift.
+const POP_RIDGE_WINDOW_HZ = 1200;
+const POP_RIDGE_MIN_RADIUS_BINS = 2;
+const POP_RIDGE_MAX_RADIUS_BINS = 18;
+const POP_RIDGE_BOOST = 0.35;
+const POP_RIDGE_MAX_BOOST_DB = 8;
+// Temporal coherence: real signals tend to persist in the same bin neighbourhood
+// for multiple display frames, while random FFT speckles and single-row QRN
+// hits do not. Track a 0..1 confidence per bin and let it drive persistence
+// and a small display boost. Current-frame energy still shows immediately;
+// coherence mostly decides whether that energy should linger and glow.
+const COHERENCE_SNR_FULL_DB = 22;
+const COHERENCE_DECAY = 0.88;
+const COHERENCE_HOLD_GATE = 0.45;
+const COHERENCE_VISUAL_BOOST_DB = 4;
+// Display-domain visual AGC. After local-floor subtraction/ridge/coherence,
+// sparse weak scenes can still under-use the 0..1 colormap because a fixed
+// Pop span must also tolerate strong stations. Visual AGC estimates the active
+// SNR percentile per frame and blends the effective span toward it, so weak DX
+// traces fill more of the colour ramp while strong signals still clip cleanly.
+const DEFAULT_VISUAL_AGC_STRENGTH = 45;
+const VISUAL_AGC_PERCENTILE = 0.92;
+const VISUAL_AGC_HEADROOM_DB = 3;
+const VISUAL_AGC_MIN_SPAN_DB = 8;
+const VISUAL_AGC_MAX_SPAN_DB = 72;
+const VISUAL_AGC_HIST_STEP_DB = 1;
+const VISUAL_AGC_HIST_MAX_DB = 96;
+const VISUAL_AGC_HIST_BINS = Math.round(VISUAL_AGC_HIST_MAX_DB / VISUAL_AGC_HIST_STEP_DB) + 1;
+const VISUAL_AGC_MIN_ACTIVE_BINS = 1;
+// Single-frame isolated QRN/ADC sparks can look like "signals" in a waterfall
+// even though they have no neighbour or temporal support. This display-only
+// clamp reduces those bins before colour mapping; detection/snap still read the
+// raw spectrum, so it cannot hide real RF from DSP decisions.
+const DEFAULT_IMPULSE_REJECT_DB = 18;
+const IMPULSE_REJECT_CONFIDENCE_MAX = 0.42;
+const IMPULSE_REJECT_KEEP_FRACTION = 0.35;
+
+// ── Snap search ─────────────────────────────────────────────────────────────
+// Look this far either side of the click for a carrier, and only snap to bins
+// at least this many dB above the local floor (else there's nothing to grab).
+const SNAP_RADIUS_HZ = 4000;
+const SNAP_MIN_SNR_DB = 6;
+// Mode-aware tune placement: walk out from the carrier peak while the spectrum
+// stays this far above the floor to find the signal's energy extent (its
+// "transmitted bandwidth"). A few sub-threshold bins are tolerated so intra-
+// voice dips don't truncate the channel; the walk is capped so it can't run
+// across the whole band on a noisy day.
+const SNAP_EDGE_SNR_DB = 6;
+const SNAP_EDGE_GAP_BINS = 3;
+const SNAP_MAX_SIGNAL_HZ = 8000;
+// Snap history (waterfall memory): when no LIVE signal sits near the click,
+// snap consults a slow-decaying max-hold of recent signal energy — the same
+// persistent/intermittent carriers the operator sees streaking down the
+// waterfall. A bin only enters the memory once it crosses SNAP_HISTORY_GATE_DB
+// (a real-carrier gate, so noise speckle never pollutes history); it then fades
+// by SNAP_HISTORY_DROP_DB per frame, lingering for the few seconds it stays
+// visible on the waterfall before dropping back below the snap threshold.
+const SNAP_HISTORY_GATE_DB = 8;
+const SNAP_HISTORY_DROP_DB = 0.4;
+// Self-correcting-lock identity gate (close-neighbour safety). When the tracker
+// supplies the level it has been following, a candidate peak inside the capture
+// window is rejected as a FOREIGN signal — not our locked one — when it is both
+// much louder than what we've been tracking AND displaced from the anchor. This
+// closes the one hole the capture window can't: a loud neighbour spaced closer
+// than the window, which would otherwise be grabbed the instant our weak signal
+// dips into the noise. The displacement clause keeps a signal that merely
+// BRIGHTENS in place (QSB lift, operator pulling it in) from being rejected —
+// only a louder peak that has ALSO moved looks like a different carrier.
+const SNAP_LOCK_IDENTITY_REJECT_DB = 12;
+const SNAP_LOCK_IDENTITY_MIN_DISP_HZ = 80;
+
+// ── Peak detection (CFAR-style markers) ─────────────────────────────────────
+// A bin is a marked peak when it is a local maximum at least this many dB above
+// its spatial floor. A little stricter than the snap threshold so the markers
+// flag real carriers, not every noise bump. Near-duplicates inside the spacing
+// (skirts of one wide signal) collapse to the strongest; total markers capped.
+const PEAK_MIN_SNR_DB = 8;
+const PEAK_MIN_SPACING_BINS = 4;
+const PEAK_MAX_COUNT = 48;
+// SNR at which a marker reaches full opacity (alpha scales 0..1 up to this).
+const PEAK_FULL_SNR_DB = 40;
+
+const STORAGE_KEY = 'zeus.enhance';
+
+export type SignalEnhanceProfileId = 'balanced' | 'dx' | 'cw' | 'digital' | 'voice' | 'contest' | 'custom';
+export type SignalEnhancePresetId = Exclude<SignalEnhanceProfileId, 'custom'>;
+
+export type SignalEnhanceTuning = {
+  /** Operator-facing profile label. `custom` means at least one tunable moved. */
+  profileId: SignalEnhanceProfileId;
+  /** Pop noise gate: snr (dB above floor) below this maps to black. */
+  popFloorDb: number;
+  /** Pop full-brightness snr (dB above floor); stronger signals clip. */
+  popSpanDb: number;
+  /** Pop compression exponent (<1 lifts weak signals relative to strong). */
+  popGamma: number;
+  /** 0..100 strength for the Signal Pop shader glow and active surface chrome. */
+  popRenderIntensity: number;
+  /** Confidence threshold required before signal energy can persist/glow. */
+  coherenceHoldGate: number;
+  /** Display-only dB lift for repeated/neighbour-supported signal energy. */
+  coherenceBoostDb: number;
+  /** Local narrow-ridge contrast gain for CW/digital/carrier traces. */
+  ridgeBoost: number;
+  /** Cap for ridge contrast gain, in dB. */
+  ridgeMaxBoostDb: number;
+  /** Blend strength for per-frame visual AGC over the Pop colormap. */
+  visualAgcStrength: number;
+  /** dB isolation required before a one-frame spike is display-clamped. */
+  impulseRejectDb: number;
+  /** Default carrier search radius used by direct snap helpers. */
+  snapRadiusHz: number;
+  /** Minimum dB over local floor required for snap-to-signal grabs. */
+  snapMinSnrDb: number;
+  /** Minimum dB over local floor required for snap marker peaks. */
+  peakMinSnrDb: number;
+};
+
+export type SignalEnhanceTuningPatch = Partial<SignalEnhanceTuning>;
+
+export type SignalEnhanceState = SignalEnhanceTuning & {
+  /** Per-bin noise-floor subtraction on the panadapter + waterfall. */
+  popEnabled: boolean;
+  /** Snap-to-signal on panadapter/waterfall click. */
+  snapEnabled: boolean;
+  /** Follow the receiver mode with the matching profile (CW, digital, voice). */
+  autoProfileEnabled: boolean;
+  /** Per-frame Pop span adaptation for sparse/weak scenes. */
+  visualAgcEnabled: boolean;
+  /** Display-only clamp for isolated one-frame spectral spikes. */
+  impulseRejectEnabled: boolean;
+  /** Latest scene analysis used by auto-profile and diagnostics UI. */
+  sceneStatus: SignalEnhanceSceneStatus | null;
+  setPopEnabled: (v: boolean) => void;
+  setSnapEnabled: (v: boolean) => void;
+  setVisualAgcEnabled: (v: boolean) => void;
+  setImpulseRejectEnabled: (v: boolean) => void;
+  setSignalEnhanceSceneStatus: (status: SignalEnhanceSceneStatus | null) => void;
+  togglePop: () => void;
+  toggleSnap: () => void;
+  setSignalEnhanceTuning: (patch: SignalEnhanceTuningPatch) => void;
+  applySignalEnhanceProfile: (profileId: SignalEnhancePresetId) => void;
+  applySignalEnhanceAutoProfile: (profileId: SignalEnhancePresetId) => void;
+  applySignalEnhanceModeProfile: (mode: RxMode) => void;
+  applySignalEnhanceSettings: (settings: SignalEnhancePersisted) => void;
+  setSignalEnhanceAutoProfile: (enabled: boolean, mode?: RxMode) => void;
+  resetSignalEnhanceTuning: () => void;
+};
+
+export type SignalEnhancePersisted = {
+  popEnabled: boolean;
+  snapEnabled: boolean;
+  autoProfileEnabled: boolean;
+  visualAgcEnabled: boolean;
+  impulseRejectEnabled: boolean;
+} & SignalEnhanceTuning;
+type SignalEnhanceTuningValues = Omit<SignalEnhanceTuning, 'profileId'>;
+
+export const SIGNAL_ENHANCE_PROFILE_ORDER: readonly SignalEnhancePresetId[] = [
+  'balanced',
+  'dx',
+  'cw',
+  'digital',
+  'voice',
+  'contest',
+];
+
+export const SIGNAL_ENHANCE_PROFILES: Record<SignalEnhancePresetId, SignalEnhanceTuningValues> = {
+  balanced: {
+    popFloorDb: DEFAULT_POP_FLOOR_DB,
+    popSpanDb: DEFAULT_POP_SPAN_DB,
+    popGamma: DEFAULT_POP_GAMMA,
+    popRenderIntensity: DEFAULT_POP_RENDER_INTENSITY,
+    coherenceHoldGate: COHERENCE_HOLD_GATE,
+    coherenceBoostDb: COHERENCE_VISUAL_BOOST_DB,
+    ridgeBoost: POP_RIDGE_BOOST,
+    ridgeMaxBoostDb: POP_RIDGE_MAX_BOOST_DB,
+    visualAgcStrength: DEFAULT_VISUAL_AGC_STRENGTH,
+    impulseRejectDb: DEFAULT_IMPULSE_REJECT_DB,
+    snapRadiusHz: SNAP_RADIUS_HZ,
+    snapMinSnrDb: SNAP_MIN_SNR_DB,
+    peakMinSnrDb: PEAK_MIN_SNR_DB,
+  },
+  dx: {
+    popFloorDb: 2,
+    popSpanDb: 24,
+    popGamma: 0.42,
+    popRenderIntensity: 92,
+    coherenceHoldGate: 0.38,
+    coherenceBoostDb: 5.5,
+    ridgeBoost: 0.5,
+    ridgeMaxBoostDb: 10,
+    visualAgcStrength: 70,
+    impulseRejectDb: 16,
+    snapRadiusHz: 5000,
+    snapMinSnrDb: 5,
+    peakMinSnrDb: 7,
+  },
+  cw: {
+    popFloorDb: 2.5,
+    popSpanDb: 22,
+    popGamma: 0.46,
+    popRenderIntensity: 88,
+    coherenceHoldGate: 0.4,
+    coherenceBoostDb: 5,
+    ridgeBoost: 0.65,
+    ridgeMaxBoostDb: 11,
+    visualAgcStrength: 62,
+    impulseRejectDb: 14,
+    snapRadiusHz: 2500,
+    snapMinSnrDb: 5,
+    peakMinSnrDb: 6.5,
+  },
+  digital: {
+    popFloorDb: 2.5,
+    popSpanDb: 26,
+    popGamma: 0.48,
+    popRenderIntensity: 84,
+    coherenceHoldGate: 0.42,
+    coherenceBoostDb: 4.5,
+    ridgeBoost: 0.55,
+    ridgeMaxBoostDb: 10,
+    visualAgcStrength: 58,
+    impulseRejectDb: 15,
+    snapRadiusHz: 3500,
+    snapMinSnrDb: 5.5,
+    peakMinSnrDb: 7,
+  },
+  voice: {
+    popFloorDb: 3.5,
+    popSpanDb: 34,
+    popGamma: 0.55,
+    popRenderIntensity: 62,
+    coherenceHoldGate: 0.48,
+    coherenceBoostDb: 3.5,
+    ridgeBoost: 0.32,
+    ridgeMaxBoostDb: 7,
+    visualAgcStrength: 42,
+    impulseRejectDb: 20,
+    snapRadiusHz: 5000,
+    snapMinSnrDb: 6.5,
+    peakMinSnrDb: 8.5,
+  },
+  contest: {
+    popFloorDb: 4,
+    popSpanDb: 28,
+    popGamma: 0.5,
+    popRenderIntensity: 78,
+    coherenceHoldGate: 0.55,
+    coherenceBoostDb: 3,
+    ridgeBoost: 0.45,
+    ridgeMaxBoostDb: 8,
+    visualAgcStrength: 35,
+    impulseRejectDb: 22,
+    snapRadiusHz: 2200,
+    snapMinSnrDb: 7,
+    peakMinSnrDb: 9,
+  },
+};
+
+const DEFAULT_TUNING: SignalEnhanceTuning = {
+  profileId: 'balanced',
+  ...SIGNAL_ENHANCE_PROFILES.balanced,
+};
+
+export function signalEnhanceProfileForMode(mode: RxMode): SignalEnhancePresetId {
+  switch (mode) {
+    case 'CWU':
+    case 'CWL':
+      return 'cw';
+    case 'DIGU':
+    case 'DIGL':
+      return 'digital';
+    case 'LSB':
+    case 'USB':
+    case 'AM':
+    case 'SAM':
+    case 'DSB':
+    case 'FM':
+      return 'voice';
+    default:
+      return 'balanced';
+  }
+}
+
+export type SignalEnhanceSceneInput = {
+  mode: RxMode;
+  spectrum: Float32Array | null;
+  floor: Float32Array | null;
+  confidence?: Float32Array | null;
+  hzPerPixel: number;
+};
+
+export type SignalEnhanceScene = {
+  profileId: SignalEnhancePresetId;
+  baseProfileId: SignalEnhancePresetId;
+  peakCount: number;
+  coherentPeakCount: number;
+  peaksPer10Khz: number;
+  coherentPeaksPer10Khz: number;
+  occupiedRatio: number;
+  coherentOccupiedRatio: number;
+  impulsiveOccupiedRatio: number;
+  maxSnrDb: number;
+  coherentMaxSnrDb: number;
+};
+
+export type SignalEnhanceSceneStatus = {
+  atUtc: string;
+  profileId: SignalEnhancePresetId;
+  baseProfileId: SignalEnhancePresetId;
+  reason: string;
+  peakCount: number;
+  coherentPeakCount: number;
+  peaksPer10Khz: number;
+  occupiedPct: number;
+  coherentOccupiedPct: number;
+  impulsivePct: number;
+  maxSnrDb: number;
+  coherentMaxSnrDb: number;
+};
+
+const SCENE_PEAK_GATE_DB = 8;
+const SCENE_BUSY_PEAKS_PER_10KHZ = 3.5;
+const SCENE_BUSY_OCCUPIED_RATIO = 0.14;
+const SCENE_DX_MAX_PEAKS_PER_10KHZ = 1.6;
+const SCENE_DX_MAX_SNR_DB = 24;
+const SCENE_IMPULSE_GATE_DB = 12;
+const SCENE_IMPULSE_CONFIDENCE_CEILING = 0.25;
+const FALLBACK_FLOOR_DB = -200;
+
+function finiteSample(arr: Float32Array, index: number): number | null {
+  const v = arr[index]!;
+  return Number.isFinite(v) ? v : null;
+}
+
+function optionalFloorDb(f: Float32Array | null, n: number, index: number): number | null {
+  if (f === null || f.length !== n) return FALLBACK_FLOOR_DB;
+  const floorDb = f[index]!;
+  return Number.isFinite(floorDb) ? floorDb : null;
+}
+
+function optionalSnr(spec: Float32Array, f: Float32Array | null, n: number, index: number): number | null {
+  const sample = finiteSample(spec, index);
+  const floorDb = optionalFloorDb(f, n, index);
+  return sample !== null && floorDb !== null ? sample - floorDb : null;
+}
+
+function finiteConfidenceValue(conf: Float32Array | null, n: number, index: number): number {
+  if (conf === null || conf.length !== n) return 0;
+  const c = conf[index]!;
+  return Number.isFinite(c) ? Math.max(0, Math.min(1, c)) : 0;
+}
+
+function finiteLinearPowerWeight(snrDb: number): number {
+  return Math.pow(10, Math.min(120, Math.max(0, snrDb)) / 10);
+}
+
+function validHzPerPixel(hzPerPixel: number): boolean {
+  return Number.isFinite(hzPerPixel) && hzPerPixel > 0;
+}
+
+function validSpectrumGeometry(centerHz: number, hzPerPixel: number): boolean {
+  return Number.isFinite(centerHz) && validHzPerPixel(hzPerPixel);
+}
+
+function validSearchRadiusHz(radiusHz: number): boolean {
+  return Number.isFinite(radiusHz) && radiusHz >= 0;
+}
+
+function sceneSnr(spec: Float32Array, f: Float32Array, index: number): number | null {
+  return optionalSnr(spec, f, spec.length, index);
+}
+
+function sceneConfidence(confidence: Float32Array | null | undefined, index: number, useConfidence: boolean): number {
+  if (!useConfidence) return 1;
+  const c = confidence![index]!;
+  return Number.isFinite(c) ? Math.max(0, Math.min(1, c)) : 0;
+}
+
+/** Recommend a Signal Intelligence profile from current mode + spectrum scene.
+ *  The mode remains the primary constraint: CW and digital keep their narrow
+ *  ridge-heavy profiles. Voice-like modes can adapt between Voice, DX, and
+ *  Contest by looking at CFAR SNR peaks and occupied-bin density. When the
+ *  temporal confidence map is available, scene changes require coherent
+ *  repeated-bin evidence so one-frame QRN/FFT speckles do not trigger DX or
+ *  Contest profiles. */
+export function recommendSignalEnhanceScene(input: SignalEnhanceSceneInput): SignalEnhanceScene {
+  const baseProfileId = signalEnhanceProfileForMode(input.mode);
+  const spec = input.spectrum;
+  const f = input.floor;
+  const confidence = input.confidence;
+  if (spec === null || f === null || spec.length < 3 || f.length !== spec.length || !validHzPerPixel(input.hzPerPixel)) {
+    return {
+      profileId: baseProfileId,
+      baseProfileId,
+      peakCount: 0,
+      coherentPeakCount: 0,
+      peaksPer10Khz: 0,
+      coherentPeaksPer10Khz: 0,
+      occupiedRatio: 0,
+      coherentOccupiedRatio: 0,
+      impulsiveOccupiedRatio: 0,
+      maxSnrDb: 0,
+      coherentMaxSnrDb: 0,
+    };
+  }
+
+  const useConfidence = confidence !== null && confidence !== undefined && confidence.length === spec.length;
+  let peakCount = 0;
+  let coherentPeakCount = 0;
+  let occupied = 0;
+  let coherentOccupied = 0;
+  let impulsiveOccupied = 0;
+  let maxSnrDb = 0;
+  let coherentMaxSnrDb = 0;
+  for (let i = 1; i < spec.length - 1; i++) {
+    const snr = sceneSnr(spec, f, i);
+    if (snr === null) continue;
+    const c = sceneConfidence(confidence, i, useConfidence);
+    const coherent = c >= COHERENCE_HOLD_GATE;
+    if (snr >= SCENE_PEAK_GATE_DB) occupied++;
+    if (snr >= SCENE_PEAK_GATE_DB && coherent) coherentOccupied++;
+    if (useConfidence && snr >= SCENE_IMPULSE_GATE_DB && c < SCENE_IMPULSE_CONFIDENCE_CEILING) {
+      impulsiveOccupied++;
+    }
+    if (snr > maxSnrDb) maxSnrDb = snr;
+    if (coherent && snr > coherentMaxSnrDb) coherentMaxSnrDb = snr;
+    const center = spec[i]!;
+    const left = spec[i - 1]!;
+    const right = spec[i + 1]!;
+    if (
+      snr >= SCENE_PEAK_GATE_DB &&
+      Number.isFinite(center) &&
+      Number.isFinite(left) &&
+      Number.isFinite(right) &&
+      center >= left &&
+      center > right
+    ) {
+      peakCount++;
+      if (coherent) coherentPeakCount++;
+    }
+  }
+  const span10Khz = Math.max(1, (spec.length * input.hzPerPixel) / 10_000);
+  const peaksPer10Khz = peakCount / span10Khz;
+  const coherentPeaksPer10Khz = coherentPeakCount / span10Khz;
+  const occupiedRatio = occupied / spec.length;
+  const coherentOccupiedRatio = coherentOccupied / spec.length;
+  const impulsiveOccupiedRatio = impulsiveOccupied / spec.length;
+  const scenePeaksPer10Khz = useConfidence ? coherentPeaksPer10Khz : peaksPer10Khz;
+  const scenePeakCount = useConfidence ? coherentPeakCount : peakCount;
+  const sceneOccupiedRatio = useConfidence ? coherentOccupiedRatio : occupiedRatio;
+  const sceneMaxSnrDb = useConfidence ? coherentMaxSnrDb : maxSnrDb;
+
+  let profileId = baseProfileId;
+  if (baseProfileId === 'voice') {
+    if (scenePeaksPer10Khz >= SCENE_BUSY_PEAKS_PER_10KHZ || sceneOccupiedRatio >= SCENE_BUSY_OCCUPIED_RATIO) {
+      profileId = 'contest';
+    } else if (
+      scenePeakCount > 0 &&
+      scenePeaksPer10Khz <= SCENE_DX_MAX_PEAKS_PER_10KHZ &&
+      sceneMaxSnrDb <= SCENE_DX_MAX_SNR_DB
+    ) {
+      profileId = 'dx';
+    }
+  }
+
+  return {
+    profileId,
+    baseProfileId,
+    peakCount,
+    coherentPeakCount,
+    peaksPer10Khz,
+    coherentPeaksPer10Khz,
+    occupiedRatio,
+    coherentOccupiedRatio,
+    impulsiveOccupiedRatio,
+    maxSnrDb,
+    coherentMaxSnrDb,
+  };
+}
+
+function isProfileId(v: unknown): v is SignalEnhanceProfileId {
+  return (
+    v === 'balanced' ||
+    v === 'dx' ||
+    v === 'cw' ||
+    v === 'digital' ||
+    v === 'voice' ||
+    v === 'contest' ||
+    v === 'custom'
+  );
+}
+
+function normalizeTuning(raw: SignalEnhanceTuningPatch = {}, fallback: SignalEnhanceTuning = DEFAULT_TUNING): SignalEnhanceTuning {
+  const profileId = isProfileId(raw.profileId) ? raw.profileId : fallback.profileId;
+  const base = profileId === 'custom' ? fallback : { profileId, ...SIGNAL_ENHANCE_PROFILES[profileId] };
+  return {
+    profileId,
+    popFloorDb: clampFinite(raw.popFloorDb, 0, 12, base.popFloorDb),
+    popSpanDb: clampFinite(raw.popSpanDb, 12, 60, base.popSpanDb),
+    popGamma: clampFinite(raw.popGamma, 0.3, 1.2, base.popGamma),
+    popRenderIntensity: clampFinite(raw.popRenderIntensity, 0, 100, base.popRenderIntensity),
+    coherenceHoldGate: clampFinite(raw.coherenceHoldGate, 0.2, 0.8, base.coherenceHoldGate),
+    coherenceBoostDb: clampFinite(raw.coherenceBoostDb, 0, 8, base.coherenceBoostDb),
+    ridgeBoost: clampFinite(raw.ridgeBoost, 0, 0.8, base.ridgeBoost),
+    ridgeMaxBoostDb: clampFinite(raw.ridgeMaxBoostDb, 0, 12, base.ridgeMaxBoostDb),
+    visualAgcStrength: clampFinite(raw.visualAgcStrength, 0, 100, base.visualAgcStrength),
+    impulseRejectDb: clampFinite(raw.impulseRejectDb, 8, 32, base.impulseRejectDb),
+    snapRadiusHz: clampFinite(raw.snapRadiusHz, 500, 12_000, base.snapRadiusHz),
+    snapMinSnrDb: clampFinite(raw.snapMinSnrDb, 3, 16, base.snapMinSnrDb),
+    peakMinSnrDb: clampFinite(raw.peakMinSnrDb, 4, 20, base.peakMinSnrDb),
+  };
+}
+
+function readPersisted(): SignalEnhancePersisted {
+  try {
+    if (typeof localStorage === 'undefined') {
+      return {
+        popEnabled: false,
+        snapEnabled: false,
+        autoProfileEnabled: false,
+        visualAgcEnabled: true,
+        impulseRejectEnabled: true,
+        ...DEFAULT_TUNING,
+      };
+    }
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return {
+        popEnabled: false,
+        snapEnabled: false,
+        autoProfileEnabled: false,
+        visualAgcEnabled: true,
+        impulseRejectEnabled: true,
+        ...DEFAULT_TUNING,
+      };
+    }
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    return {
+      popEnabled: parsed.popEnabled === true,
+      snapEnabled: parsed.snapEnabled === true,
+      autoProfileEnabled: parsed.autoProfileEnabled === true,
+      visualAgcEnabled: parsed.visualAgcEnabled !== false,
+      impulseRejectEnabled: parsed.impulseRejectEnabled !== false,
+      ...normalizeTuning(parsed as SignalEnhanceTuningPatch),
+    };
+  } catch {
+    return {
+      popEnabled: false,
+      snapEnabled: false,
+      autoProfileEnabled: false,
+      visualAgcEnabled: true,
+      impulseRejectEnabled: true,
+      ...DEFAULT_TUNING,
+    };
+  }
+}
+
+function persist(s: SignalEnhancePersisted): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      popEnabled: s.popEnabled,
+      snapEnabled: s.snapEnabled,
+      autoProfileEnabled: s.autoProfileEnabled,
+      visualAgcEnabled: s.visualAgcEnabled,
+      impulseRejectEnabled: s.impulseRejectEnabled,
+      profileId: s.profileId,
+      popFloorDb: s.popFloorDb,
+      popSpanDb: s.popSpanDb,
+      popGamma: s.popGamma,
+      popRenderIntensity: s.popRenderIntensity,
+      coherenceHoldGate: s.coherenceHoldGate,
+      coherenceBoostDb: s.coherenceBoostDb,
+      ridgeBoost: s.ridgeBoost,
+      ridgeMaxBoostDb: s.ridgeMaxBoostDb,
+      visualAgcStrength: s.visualAgcStrength,
+      impulseRejectDb: s.impulseRejectDb,
+      snapRadiusHz: s.snapRadiusHz,
+      snapMinSnrDb: s.snapMinSnrDb,
+      peakMinSnrDb: s.peakMinSnrDb,
+    }));
+  } catch {
+    // quota / private mode — in-memory state is still the source of truth.
+  }
+}
+
+export function signalEnhanceSettingsFromState(s: SignalEnhanceState): SignalEnhancePersisted {
+  return {
+    popEnabled: s.popEnabled,
+    snapEnabled: s.snapEnabled,
+    autoProfileEnabled: s.autoProfileEnabled,
+    visualAgcEnabled: s.visualAgcEnabled,
+    impulseRejectEnabled: s.impulseRejectEnabled,
+    profileId: s.profileId,
+    popFloorDb: s.popFloorDb,
+    popSpanDb: s.popSpanDb,
+    popGamma: s.popGamma,
+    popRenderIntensity: s.popRenderIntensity,
+    coherenceHoldGate: s.coherenceHoldGate,
+    coherenceBoostDb: s.coherenceBoostDb,
+    ridgeBoost: s.ridgeBoost,
+    ridgeMaxBoostDb: s.ridgeMaxBoostDb,
+    visualAgcStrength: s.visualAgcStrength,
+    impulseRejectDb: s.impulseRejectDb,
+    snapRadiusHz: s.snapRadiusHz,
+    snapMinSnrDb: s.snapMinSnrDb,
+    peakMinSnrDb: s.peakMinSnrDb,
+  };
+}
+
+const persisted = readPersisted();
+
+export const useSignalEnhanceStore = create<SignalEnhanceState>((set, get) => ({
+  popEnabled: persisted.popEnabled,
+  snapEnabled: persisted.snapEnabled,
+  autoProfileEnabled: persisted.autoProfileEnabled,
+  visualAgcEnabled: persisted.visualAgcEnabled,
+  impulseRejectEnabled: persisted.impulseRejectEnabled,
+  sceneStatus: null,
+  profileId: persisted.profileId,
+  popFloorDb: persisted.popFloorDb,
+  popSpanDb: persisted.popSpanDb,
+  popGamma: persisted.popGamma,
+  popRenderIntensity: persisted.popRenderIntensity,
+  coherenceHoldGate: persisted.coherenceHoldGate,
+  coherenceBoostDb: persisted.coherenceBoostDb,
+  ridgeBoost: persisted.ridgeBoost,
+  ridgeMaxBoostDb: persisted.ridgeMaxBoostDb,
+  visualAgcStrength: persisted.visualAgcStrength,
+  impulseRejectDb: persisted.impulseRejectDb,
+  snapRadiusHz: persisted.snapRadiusHz,
+  snapMinSnrDb: persisted.snapMinSnrDb,
+  peakMinSnrDb: persisted.peakMinSnrDb,
+  setPopEnabled: (popEnabled) => {
+    set({ popEnabled });
+    if (!popEnabled) resetSignalHold();
+    persist(get());
+  },
+  setSnapEnabled: (snapEnabled) => {
+    set({ snapEnabled });
+    persist(get());
+  },
+  setVisualAgcEnabled: (visualAgcEnabled) => {
+    set({ visualAgcEnabled });
+    persist(get());
+  },
+  setImpulseRejectEnabled: (impulseRejectEnabled) => {
+    set({ impulseRejectEnabled });
+    persist(get());
+  },
+  setSignalEnhanceSceneStatus: (sceneStatus) => set({ sceneStatus }),
+  togglePop: () => {
+    const popEnabled = !get().popEnabled;
+    set({ popEnabled });
+    if (!popEnabled) resetSignalHold();
+    persist(get());
+  },
+  toggleSnap: () => {
+    const snapEnabled = !get().snapEnabled;
+    set({ snapEnabled });
+    persist(get());
+  },
+  setSignalEnhanceTuning: (patch) => {
+    const current = get();
+    const next = normalizeTuning({ ...current, ...patch, profileId: patch.profileId ?? 'custom' }, current);
+    set({ ...next, autoProfileEnabled: false });
+    resetSignalState();
+    persist(get());
+  },
+  applySignalEnhanceProfile: (profileId) => {
+    const next = normalizeTuning({ profileId, ...SIGNAL_ENHANCE_PROFILES[profileId] });
+    set({ ...next, autoProfileEnabled: false });
+    resetSignalState();
+    persist(get());
+  },
+  applySignalEnhanceAutoProfile: (profileId) => {
+    const next = normalizeTuning({ profileId, ...SIGNAL_ENHANCE_PROFILES[profileId] });
+    set({ ...next, autoProfileEnabled: true });
+    resetSignalState();
+    persist(get());
+  },
+  applySignalEnhanceModeProfile: (mode) => {
+    const profileId = signalEnhanceProfileForMode(mode);
+    get().applySignalEnhanceAutoProfile(profileId);
+  },
+  applySignalEnhanceSettings: (settings) => {
+    const next = {
+      popEnabled: settings.popEnabled,
+      snapEnabled: settings.snapEnabled,
+      autoProfileEnabled: settings.autoProfileEnabled,
+      visualAgcEnabled: settings.visualAgcEnabled,
+      impulseRejectEnabled: settings.impulseRejectEnabled,
+      ...normalizeTuning(settings),
+    };
+    set(next);
+    if (!next.popEnabled) resetSignalHold();
+    resetSignalState();
+    persist(get());
+  },
+  setSignalEnhanceAutoProfile: (autoProfileEnabled, mode) => {
+    if (autoProfileEnabled && mode) {
+      const profileId = signalEnhanceProfileForMode(mode);
+      get().applySignalEnhanceAutoProfile(profileId);
+    } else {
+      set({ autoProfileEnabled });
+      resetSignalState();
+      persist(get());
+    }
+  },
+  resetSignalEnhanceTuning: () => {
+    const next = normalizeTuning({ profileId: 'balanced', ...SIGNAL_ENHANCE_PROFILES.balanced });
+    set({ ...next, autoProfileEnabled: false });
+    resetSignalState();
+    persist(get());
+  },
+}));
+
+// ── Per-bin floor estimator (module singleton) ──────────────────────────────
+// Singleton, not per-component: the panadapter and waterfall must enhance off
+// the SAME floor, and a click handler needs it on demand. Driven once per frame
+// from display-store.pushFrame so both surfaces see an already-updated floor.
+
+let floor: Float32Array | null = null; // published, time-smoothed floor
+let quietRef: Float32Array | null = null; // per-frame low-percentile spatial reference
+let signalHold: Float32Array | null = null; // display-only SNR peak hold
+let signalConfidence: Float32Array | null = null; // 0..1 temporal/neighbour confidence
+let previousSnr: Float32Array | null = null; // previous-frame SNR for coherence
+let ridgeMean: Float32Array | null = null; // display-only local positive-SNR mean
+let visualAgcHist: Int32Array | null = null; // SNR histogram for display-domain visual AGC
+let snapHistorySnr: Float32Array | null = null; // slow-decay SNR max-hold for snap history
+let snapHistorySpec: Float32Array | null = null; // reusable floor+history reconstruction
+let hist: Int32Array | null = null; // quantized dB histogram for ordered-statistic CFAR
+let geomKey = '';
+let lastHzPerPixel = 0;
+
+/** A floor estimate is only valid for the geometry it was built on. Width and
+ *  Hz/pixel changes (zoom, sample rate) re-scale the window and bin layout, so
+ *  re-converge in one frame (EMA=1). A plain retune does NOT reset — the
+ *  spatial estimate is frame-local and needs no per-bin history. */
+function makeGeomKey(width: number, hzPerPixel: number): string {
+  return `${width}:${hzPerPixel}`;
+}
+
+type EstimatorFrame = {
+  panDb: Float32Array | null;
+  panValid: boolean;
+  width: number;
+  hzPerPixel: number;
+};
+
+// Ref-counted estimator consumers. A surface that needs the floor/detection
+// while global Pop and Snap are both off (e.g. the Bandwidth Filter panel, which
+// wants live signal awareness whenever it is open) registers one. The estimator
+// runs while any consumer is active; closing the panel (and Pop/Snap off) drops
+// the count back to zero and the per-frame cost disappears.
+let estimatorConsumers = 0;
+
+/** Keep the floor estimator running while this consumer is registered, even if
+ *  global Pop/Snap are off. Returns a release function (idempotent). */
+export function registerEstimatorConsumer(): () => void {
+  estimatorConsumers += 1;
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    estimatorConsumers = Math.max(0, estimatorConsumers - 1);
+  };
+}
+
+/** Update the floor estimate for this frame — but only when an operator feature
+ *  needs it. When Pop, Snap, and all registered consumers are absent this
+ *  returns immediately, so the feature carries no cost until switched on. Call
+ *  before notifying subscribers so the same-frame enhance sees this frame's
+ *  floor. */
+export function maybeUpdateEstimator(f: EstimatorFrame): void {
+  const st = useSignalEnhanceStore.getState();
+  if (!st.popEnabled && !st.snapEnabled && !st.autoProfileEnabled && estimatorConsumers === 0) return;
+  if (!f.panValid || !f.panDb || f.panDb.length === 0) return;
+  if (f.panDb.length !== f.width || !validHzPerPixel(f.hzPerPixel)) return;
+  updateFloor(f.panDb, f.hzPerPixel, makeGeomKey(f.width, f.hzPerPixel));
+}
+
+function histIndex(db: number): number {
+  if (!Number.isFinite(db)) return 0;
+  const idx = Math.round((db - FLOOR_HIST_MIN_DB) / FLOOR_HIST_STEP_DB);
+  return idx < 0 ? 0 : idx >= FLOOR_HIST_BINS ? FLOOR_HIST_BINS - 1 : idx;
+}
+
+function histDb(idx: number): number {
+  return FLOOR_HIST_MIN_DB + idx * FLOOR_HIST_STEP_DB;
+}
+
+/** Ordered-statistic CFAR floor over ±radius bins, written into `out`.
+ *  The low percentile behaves like a quiet-neighbour detector but is much less
+ *  sensitive than a raw minimum to deep spectral holes, notches, and one-bin
+ *  FFT outliers. Histogram quantisation keeps the per-frame cost linear in
+ *  width and stable at high zoom. */
+function quietPercentile(src: Float32Array, radius: number, out: Float32Array): void {
+  const n = src.length;
+  if (hist === null) hist = new Int32Array(FLOOR_HIST_BINS);
+  const h = hist;
+  h.fill(0);
+  let lo = 0;
+  let hi = -1;
+  let count = 0;
+
+  const add = (i: number) => {
+    const idx = histIndex(src[i]!);
+    h[idx] = h[idx]! + 1;
+    count++;
+  };
+  const remove = (i: number) => {
+    const idx = histIndex(src[i]!);
+    h[idx] = h[idx]! - 1;
+    count--;
+  };
+  const percentile = () => {
+    const rank = Math.max(1, Math.ceil(count * FLOOR_QUIET_PERCENTILE));
+    let seen = 0;
+    for (let b = 0; b < FLOOR_HIST_BINS; b++) {
+      seen += h[b]!;
+      if (seen >= rank) return histDb(b);
+    }
+    return histDb(FLOOR_HIST_BINS - 1);
+  };
+
+  for (let i = 0; i < n; i++) {
+    const nextLo = Math.max(0, i - radius);
+    const nextHi = Math.min(n - 1, i + radius);
+    while (hi < nextHi) add(++hi);
+    while (lo < nextLo) remove(lo++);
+    out[i] = percentile();
+  }
+}
+
+function updateFloor(spec: Float32Array, hzPerPixel: number, key: string): void {
+  const n = spec.length;
+  const reset = floor === null || floor.length !== n || key !== geomKey;
+  if (floor === null || floor.length !== n) floor = new Float32Array(n);
+  if (quietRef === null || quietRef.length !== n) quietRef = new Float32Array(n);
+  if (reset) {
+    resetSignalState();
+    resetSnapHistory();
+  }
+
+  let radius = validHzPerPixel(hzPerPixel) ? Math.round(FLOOR_WINDOW_HZ / hzPerPixel / 2) : FLOOR_MIN_RADIUS_BINS;
+  radius = Math.max(FLOOR_MIN_RADIUS_BINS, Math.min(FLOOR_MAX_RADIUS_BINS, radius));
+  quietPercentile(spec, radius, quietRef);
+
+  const f = floor;
+  const ref = quietRef;
+  const a = reset ? 1 : FLOOR_TIME_EMA;
+  for (let i = 0; i < n; i++) {
+    const target = ref[i]! + NOISE_OFFSET_DB;
+    f[i] = reset ? target : f[i]! + a * (target - f[i]!);
+  }
+  geomKey = key;
+  lastHzPerPixel = hzPerPixel;
+  updateSignalState(spec);
+  updateSnapHistory(spec);
+}
+
+function updateSignalState(spec: Float32Array): void {
+  const st = useSignalEnhanceStore.getState();
+  const f = floor;
+  const n = spec.length;
+  const needsConfidence =
+    st.popEnabled || st.snapEnabled || st.autoProfileEnabled || estimatorConsumers > 0;
+  if (!needsConfidence || f === null || f.length !== n) {
+    resetSignalState();
+    return;
+  }
+  if (signalConfidence === null || signalConfidence.length !== n) signalConfidence = new Float32Array(n);
+  if (previousSnr === null || previousSnr.length !== n) previousSnr = new Float32Array(n);
+  const conf = signalConfidence;
+  const prev = previousSnr;
+  const gate = st.popFloorDb;
+  const coherenceHoldGate = st.coherenceHoldGate;
+  if (!st.popEnabled) signalHold = null;
+  else if (signalHold === null || signalHold.length !== n) signalHold = new Float32Array(n);
+  const hold = signalHold;
+  for (let i = 0; i < n; i++) {
+    const snr = optionalSnr(spec, f, n, i) ?? 0;
+    const leftSnr = i > 0 ? optionalSnr(spec, f, n, i - 1) ?? -Infinity : -Infinity;
+    const rightSnr = i + 1 < n ? optionalSnr(spec, f, n, i + 1) ?? -Infinity : -Infinity;
+    const neighbourSupported = leftSnr >= gate || rightSnr >= gate;
+    const prevSnr = Number.isFinite(prev[i]!) ? prev[i]! : 0;
+    const previousSupported = prevSnr >= gate;
+    const stable = previousSupported && Math.abs(snr - prevSnr) <= 10;
+    const snrNorm = Math.max(0, Math.min(1, (snr - gate) / COHERENCE_SNR_FULL_DB));
+    const targetConfidence = snr >= gate
+      ? Math.min(
+        1,
+        0.10 + 0.30 * snrNorm +
+        (neighbourSupported ? 0.24 : 0) +
+        (previousSupported ? 0.20 : 0) +
+        (stable ? 0.10 : 0),
+      )
+      : 0;
+    const decayedConfidence = finiteConfidenceValue(conf, n, i) * COHERENCE_DECAY;
+    conf[i] = targetConfidence > decayedConfidence
+      ? targetConfidence
+      : decayedConfidence;
+
+    if (hold !== null) {
+      const target = snr >= gate ? snr : 0;
+      const holdDecay = conf[i]! >= coherenceHoldGate
+        ? POP_PERSIST_DECAY
+        : POP_PERSIST_DECAY * 0.55;
+      const held = Number.isFinite(hold[i]!) ? hold[i]! : 0;
+      const decayed = held * holdDecay;
+      const next = target > decayed ? target : decayed;
+      hold[i] = next >= gate && conf[i]! >= coherenceHoldGate ? next : 0;
+    }
+    prev[i] = snr;
+  }
+}
+
+function resetSignalState(): void {
+  signalHold = null;
+  signalConfidence = null;
+  previousSnr = null;
+}
+
+function resetSignalHold(): void {
+  signalHold = null;
+}
+
+/** Per-frame waterfall memory for snap. Runs only while Snap is enabled (it is
+ *  independent of Pop, which owns signalHold). Each bin that crosses the
+ *  real-carrier gate is remembered at its current SNR; bins below the gate fade
+ *  by a fixed dB per frame, so a carrier that scrolls off the live FFT but is
+ *  still visible on the waterfall stays grabbable for a few seconds. */
+function updateSnapHistory(spec: Float32Array): void {
+  const st = useSignalEnhanceStore.getState();
+  const f = floor;
+  const n = spec.length;
+  if (!st.snapEnabled || f === null || f.length !== n) {
+    resetSnapHistory();
+    return;
+  }
+  if (snapHistorySnr === null || snapHistorySnr.length !== n) snapHistorySnr = new Float32Array(n);
+  const h = snapHistorySnr;
+  for (let i = 0; i < n; i++) {
+    const snr = optionalSnr(spec, f, n, i);
+    if (snr !== null && snr >= SNAP_HISTORY_GATE_DB) {
+      h[i] = snr;
+    } else {
+      const held = Number.isFinite(h[i]!) ? h[i]! : 0;
+      const decayed = held - SNAP_HISTORY_DROP_DB;
+      h[i] = decayed > 0 ? decayed : 0;
+    }
+  }
+}
+
+function resetSnapHistory(): void {
+  snapHistorySnr = null;
+  snapHistorySpec = null;
+}
+
+/** A pseudo-spectrum (live floor + remembered SNR) for the snap history fallback,
+ *  or null when nothing has been remembered yet. Reuses the snap cluster/edge
+ *  logic: bins with held energy read above the floor exactly as a live signal
+ *  would, so computeSnapToLineHz finds and edge-aligns them. Read-only. */
+export function getSnapHistorySpectrum(): Float32Array | null {
+  const f = floor;
+  const h = snapHistorySnr;
+  if (f === null || h === null || h.length !== f.length) return null;
+  const n = f.length;
+  if (snapHistorySpec === null || snapHistorySpec.length !== n) snapHistorySpec = new Float32Array(n);
+  const out = snapHistorySpec;
+  let any = false;
+  for (let i = 0; i < n; i++) {
+    const floorDb = Number.isFinite(f[i]!) ? f[i]! : FALLBACK_FLOOR_DB;
+    const held = Number.isFinite(h[i]!) ? h[i]! : 0;
+    out[i] = floorDb + held;
+    if (held > 0) any = true;
+  }
+  return any ? out : null;
+}
+
+/** Current per-bin floor, or null before the first frame. Read-only — callers
+ *  must not mutate it. */
+export function getNoiseFloor(): Float32Array | null {
+  return floor;
+}
+
+/** Current 0..1 signal confidence map, or null before Pop has accumulated it.
+ *  Read-only. Values near 1 mean the bin has repeated/neighbour-supported
+ *  signal energy; values near 0 are noise or one-frame speckles. */
+export function getSignalConfidence(): Float32Array | null {
+  return signalConfidence;
+}
+
+/** Reset the estimator (e.g. on disconnect). Next frame re-seeds. */
+export function resetEstimator(): void {
+  floor = null;
+  quietRef = null;
+  signalHold = null;
+  signalConfidence = null;
+  previousSnr = null;
+  ridgeMean = null;
+  visualAgcHist = null;
+  snapHistorySnr = null;
+  snapHistorySpec = null;
+  geomKey = '';
+  lastHzPerPixel = 0;
+}
+
+function computeLocalMeanPositiveSnr(raw: Float32Array, f: Float32Array, hold: Float32Array | null, out: Float32Array): void {
+  const n = raw.length;
+  let radius = validHzPerPixel(lastHzPerPixel) ? Math.round(POP_RIDGE_WINDOW_HZ / lastHzPerPixel / 2) : POP_RIDGE_MIN_RADIUS_BINS;
+  radius = Math.max(POP_RIDGE_MIN_RADIUS_BINS, Math.min(POP_RIDGE_MAX_RADIUS_BINS, radius));
+
+  const snrAt = (i: number): number => {
+    const live = optionalSnr(raw, f, n, i) ?? 0;
+    const held = hold && Number.isFinite(hold[i]!) ? hold[i]! : 0;
+    const snr = live > held ? live : held;
+    return snr > 0 ? snr : 0;
+  };
+
+  let lo = 0;
+  let hi = -1;
+  let sum = 0;
+  for (let i = 0; i < n; i++) {
+    const nextLo = Math.max(0, i - radius);
+    const nextHi = Math.min(n - 1, i + radius);
+    while (hi < nextHi) sum += snrAt(++hi);
+    while (lo < nextLo) sum -= snrAt(lo++);
+    out[i] = sum / (hi - lo + 1);
+  }
+}
+
+function visualAgcHistIndex(snrDb: number): number {
+  if (!Number.isFinite(snrDb) || snrDb <= 0) return 0;
+  const idx = Math.round(snrDb / VISUAL_AGC_HIST_STEP_DB);
+  return idx >= VISUAL_AGC_HIST_BINS ? VISUAL_AGC_HIST_BINS - 1 : idx;
+}
+
+function maybeClampImpulseSnr(
+  raw: Float32Array,
+  f: Float32Array,
+  st: SignalEnhanceState,
+  i: number,
+  liveSnr: number,
+  confidence: number,
+  snr: number,
+): number {
+  if (!st.impulseRejectEnabled) return snr;
+  if (confidence >= IMPULSE_REJECT_CONFIDENCE_MAX) return snr;
+  if (liveSnr < st.popFloorDb + st.impulseRejectDb) return snr;
+
+  const n = raw.length;
+  const leftSnr = i > 0 ? optionalSnr(raw, f, n, i - 1) ?? -Infinity : -Infinity;
+  const rightSnr = i + 1 < n ? optionalSnr(raw, f, n, i + 1) ?? -Infinity : -Infinity;
+  const neighbourSnr = Math.max(leftSnr, rightSnr, 0);
+  if (liveSnr - neighbourSnr < st.impulseRejectDb) return snr;
+
+  const cap = Math.max(st.popFloorDb, neighbourSnr + st.impulseRejectDb * IMPULSE_REJECT_KEEP_FRACTION);
+  return snr > cap ? cap : snr;
+}
+
+function displaySnrForBin(
+  raw: Float32Array,
+  f: Float32Array,
+  hold: Float32Array | null,
+  conf: Float32Array | null,
+  mean: Float32Array,
+  st: SignalEnhanceState,
+  i: number,
+  clampImpulse: boolean,
+): number {
+  const liveSnr = optionalSnr(raw, f, raw.length, i) ?? 0;
+  const confidence = finiteConfidenceValue(conf, raw.length, i);
+  const held = hold && Number.isFinite(hold[i]!) ? hold[i]! : 0;
+  const heldSnr = hold && confidence >= st.coherenceHoldGate
+    ? held * (0.45 + 0.55 * confidence)
+    : 0;
+  let snr = heldSnr > liveSnr ? heldSnr : liveSnr;
+  const localMean = Number.isFinite(mean[i]!) ? mean[i]! : 0;
+  const contrast = snr - localMean;
+  if (contrast > 0) snr += Math.min(st.ridgeMaxBoostDb, contrast * st.ridgeBoost);
+  if (snr >= st.popFloorDb) {
+    const ridgeWeight = contrast <= 0 ? 0.15 : Math.min(1, contrast / 12);
+    snr += confidence * st.coherenceBoostDb * ridgeWeight;
+  }
+  return clampImpulse ? maybeClampImpulseSnr(raw, f, st, i, liveSnr, confidence, snr) : snr;
+}
+
+function estimateVisualAgcSpan(
+  raw: Float32Array,
+  f: Float32Array,
+  hold: Float32Array | null,
+  conf: Float32Array | null,
+  mean: Float32Array,
+  st: SignalEnhanceState,
+  baseSpan: number,
+): number {
+  if (!st.visualAgcEnabled || st.visualAgcStrength <= 0) return baseSpan;
+  if (visualAgcHist === null) visualAgcHist = new Int32Array(VISUAL_AGC_HIST_BINS);
+  const histAgc = visualAgcHist;
+  histAgc.fill(0);
+
+  let active = 0;
+  for (let i = 0; i < raw.length; i++) {
+    const snr = displaySnrForBin(raw, f, hold, conf, mean, st, i, false);
+    if (snr < st.popFloorDb) continue;
+    const idx = visualAgcHistIndex(snr);
+    histAgc[idx] = histAgc[idx]! + 1;
+    active++;
+  }
+  if (active < VISUAL_AGC_MIN_ACTIVE_BINS) return baseSpan;
+
+  const rank = Math.max(1, Math.ceil(active * VISUAL_AGC_PERCENTILE));
+  let seen = 0;
+  let pSnr = st.popFloorDb + baseSpan;
+  for (let b = 0; b < VISUAL_AGC_HIST_BINS; b++) {
+    seen += histAgc[b]!;
+    if (seen >= rank) {
+      pSnr = b * VISUAL_AGC_HIST_STEP_DB;
+      break;
+    }
+  }
+
+  const targetSpan = Math.max(
+    VISUAL_AGC_MIN_SPAN_DB,
+    Math.min(VISUAL_AGC_MAX_SPAN_DB, pSnr - st.popFloorDb + VISUAL_AGC_HEADROOM_DB),
+  );
+  const strength = Math.max(0, Math.min(1, st.visualAgcStrength / 100));
+  return baseSpan * (1 - strength) + targetSpan * strength;
+}
+
+/** Map the spectrum to a 0..1 Pop display value per bin: subtract the floor,
+ *  gate the noise, then compress so weak and strong signals are both visible
+ *  (see the "Pop display mapping" notes above). The renderers pass dbMin=0,
+ *  dbMax=1 while Pop is on, so the colormap consumes this directly. Outputs 0
+ *  (dark) when no floor exists yet — only the first frame after a reset, which
+ *  the estimator seeds before subscribers run. `out` must match `raw`'s length. */
+export function enhanceInto(raw: Float32Array, out: Float32Array): void {
+  const n = raw.length;
+  const f = floor;
+  if (f === null || f.length !== n) {
+    out.fill(0);
+    return;
+  }
+  const st = useSignalEnhanceStore.getState();
+  const gate = st.popFloorDb;
+  const baseSpan = st.popSpanDb > 1 ? st.popSpanDb : 1;
+  const gamma = st.popGamma;
+  const hold = signalHold && signalHold.length === n ? signalHold : null;
+  const conf = signalConfidence && signalConfidence.length === n ? signalConfidence : null;
+  if (ridgeMean === null || ridgeMean.length !== n) ridgeMean = new Float32Array(n);
+  computeLocalMeanPositiveSnr(raw, f, hold, ridgeMean);
+  const mean = ridgeMean;
+  const span = estimateVisualAgcSpan(raw, f, hold, conf, mean, st, baseSpan);
+  for (let i = 0; i < n; i++) {
+    const snr = displaySnrForBin(raw, f, hold, conf, mean, st, i, true);
+    let v = (snr - gate) / span;
+    v = v < 0 ? 0 : v > 1 ? 1 : v;
+    out[i] = gamma === 1 ? v : Math.pow(v, gamma);
+  }
+}
+
+/** Find the strongest carrier near a clicked frequency and return its exact
+ *  bin-center frequency, or null if nothing rises far enough above the floor.
+ *
+ *  Pure: caller supplies the live spectrum + geometry (panadapter store) and we
+ *  use the shared floor. Bypasses the 500 Hz tune grid — snap lands on the real
+ *  carrier, not the nearest round number. */
+export function findPeakHz(
+  spec: Float32Array,
+  centerHz: number,
+  hzPerPixel: number,
+  clickHz: number,
+): number | null {
+  const n = spec.length;
+  if (
+    n < 3 ||
+    !validSpectrumGeometry(centerHz, hzPerPixel) ||
+    !Number.isFinite(clickHz)
+  ) return null;
+  const f = floor;
+  const st = useSignalEnhanceStore.getState();
+  const half = n / 2;
+  const clickBin = Math.round((clickHz - centerHz) / hzPerPixel + half);
+  const radius = Math.max(2, Math.round(st.snapRadiusHz / hzPerPixel));
+  const lo = Math.max(1, clickBin - radius);
+  const hi = Math.min(n - 2, clickBin + radius);
+  let bestBin = -1;
+  let bestVal = -Infinity;
+  for (let i = lo; i <= hi; i++) {
+    const v = finiteSample(spec, i);
+    if (v === null) continue;
+    const snr = optionalSnr(spec, f, n, i);
+    if (snr === null || snr < coherentThreshold(st.snapMinSnrDb, i, n)) continue;
+    const left = finiteSample(spec, i - 1);
+    const right = finiteSample(spec, i + 1);
+    if (left === null || right === null) continue;
+    // Local maximum so we land on the carrier crest, not its skirt.
+    if (v >= left && v >= right && v > bestVal) {
+      bestVal = v;
+      bestBin = i;
+    }
+  }
+  if (bestBin < 0) return null;
+  return centerHz + (bestBin - half) * hzPerPixel;
+}
+
+export type DetectedPeak = {
+  /** Absolute bin-centre frequency of the peak. */
+  hz: number;
+  /** dB above the local noise floor (used for marker opacity). */
+  snrDb: number;
+};
+
+function confidenceAt(index: number, n: number): number {
+  return finiteConfidenceValue(signalConfidence, n, index);
+}
+
+function coherentThreshold(baseDb: number, index: number, n: number): number {
+  const confidence = confidenceAt(index, n);
+  return confidence >= 0.65 ? baseDb - 2 : baseDb;
+}
+
+/** Detect carriers across the whole span for the snap-target markers. Returns
+ *  local maxima at least PEAK_MIN_SNR_DB above their spatial floor, de-duplicated
+ *  to the strongest within PEAK_MIN_SPACING_BINS and capped at PEAK_MAX_COUNT
+ *  (strongest first). Empty until a floor exists. Pure: caller passes the live
+ *  spectrum + geometry. */
+export function detectPeaks(spec: Float32Array, centerHz: number, hzPerPixel: number): DetectedPeak[] {
+  const n = spec.length;
+  const f = floor;
+  if (n < 3 || !validSpectrumGeometry(centerHz, hzPerPixel) || f === null || f.length !== n) return [];
+  const st = useSignalEnhanceStore.getState();
+  const half = n / 2;
+  const found: Array<{ bin: number; snrDb: number }> = [];
+  for (let i = 1; i < n - 1; i++) {
+    const v = finiteSample(spec, i);
+    if (v === null) continue;
+    const snr = optionalSnr(spec, f, n, i);
+    if (snr === null) continue;
+    if (snr < coherentThreshold(st.peakMinSnrDb, i, n)) continue;
+    const left = finiteSample(spec, i - 1);
+    const right = finiteSample(spec, i + 1);
+    if (left === null || right === null) continue;
+    // `>=` left / `>` right accepts a flat top once (at its right edge) rather
+    // than emitting a marker for every bin of the plateau.
+    if (v >= left && v > right) {
+      found.push({ bin: i, snrDb: snr + confidenceAt(i, n) * 2 });
+    }
+  }
+  // Strongest first, then greedily accept peaks that clear the spacing — so the
+  // skirts of one wide signal collapse onto its crest.
+  found.sort((a, b) => b.snrDb - a.snrDb);
+  const accepted: Array<{ bin: number; snrDb: number }> = [];
+  for (const p of found) {
+    if (accepted.length >= PEAK_MAX_COUNT) break;
+    let clear = true;
+    for (const q of accepted) {
+      if (Math.abs(q.bin - p.bin) < PEAK_MIN_SPACING_BINS) {
+        clear = false;
+        break;
+      }
+    }
+    if (clear) accepted.push(p);
+  }
+  return accepted.map((p) => ({ hz: centerHz + (p.bin - half) * hzPerPixel, snrDb: p.snrDb }));
+}
+
+/** Normalised marker opacity (0..1) for a peak SNR, for the amber tick alpha. */
+export function peakAlpha(snrDb: number): number {
+  if (!Number.isFinite(snrDb)) return 0.45;
+  return Math.max(0.45, Math.min(1, snrDb / PEAK_FULL_SNR_DB));
+}
+
+/** Measure a carrier's occupied bandwidth: walk outward from the crest bin until
+ *  the level falls `dropDb` below the crest (the −6 dB / −26 dB edges), bounded
+ *  to ±maxRadiusBins and stopping early at a rising edge (valley) so an adjacent
+ *  signal is not swallowed. Returns inclusive [loBin, hiBin]. Pure — caller
+ *  supplies the live spectrum. */
+export function measureOccupiedBandwidth(
+  spec: Float32Array,
+  centerBin: number,
+  dropDb: number,
+  maxRadiusBins: number,
+): [number, number] {
+  const n = spec.length;
+  if (n === 0) return [0, 0];
+  if (!Number.isFinite(centerBin)) return [0, 0];
+  const radiusBins = Number.isFinite(maxRadiusBins) && maxRadiusBins > 0 ? Math.round(maxRadiusBins) : 0;
+  const cb = Math.max(0, Math.min(n - 1, Math.round(centerBin)));
+  const crest = finiteSample(spec, cb);
+  if (crest === null || !Number.isFinite(dropDb)) return [cb, cb];
+  const thresh = crest - dropDb;
+  let lo = cb;
+  let prev = crest;
+  for (let i = cb - 1, stop = Math.max(0, cb - radiusBins); i >= stop; i--) {
+    const v = finiteSample(spec, i);
+    if (v === null) break;
+    if (v < thresh) break; // dropped past the edge
+    if (v > prev + 3) break; // rising again → into an adjacent signal
+    prev = v;
+    lo = i;
+  }
+  prev = crest;
+  let hi = cb;
+  for (let i = cb + 1, stop = Math.min(n - 1, cb + radiusBins); i <= stop; i++) {
+    const v = finiteSample(spec, i);
+    if (v === null) break;
+    if (v < thresh) break;
+    if (v > prev + 3) break;
+    prev = v;
+    hi = i;
+  }
+  return [lo, hi];
+}
+
+/** Measure a signal's VISIBLE extent: walk outward from the crest until the
+ *  level sinks to within `edgeMarginDb` of the LOCAL noise floor (i.e. the
+ *  signal has dropped into the noise) — the edge the eye reads as "where the
+ *  signal ends". More faithful than a fixed crest-relative drop because it
+ *  adapts to each signal's SNR. Stops early at a rising edge (adjacent signal)
+ *  and is bounded to ±maxRadiusBins. Returns inclusive [loBin, hiBin]. Pure. */
+export function measureSignalExtent(
+  spec: Float32Array,
+  floorArr: Float32Array | null,
+  centerBin: number,
+  edgeMarginDb: number,
+  maxRadiusBins: number,
+): [number, number] {
+  const n = spec.length;
+  if (n === 0) return [0, 0];
+  if (!Number.isFinite(centerBin)) return [0, 0];
+  const radiusBins = Number.isFinite(maxRadiusBins) && maxRadiusBins > 0 ? Math.round(maxRadiusBins) : 0;
+  const haveFloor = floorArr !== null && floorArr.length === n;
+  const cb = Math.max(0, Math.min(n - 1, Math.round(centerBin)));
+  const crest = finiteSample(spec, cb);
+  if (crest === null || !Number.isFinite(edgeMarginDb)) return [cb, cb];
+  const edgeOf = (i: number) => {
+    if (!haveFloor) return FALLBACK_FLOOR_DB + edgeMarginDb;
+    const floorDb = floorArr![i]!;
+    return Number.isFinite(floorDb) ? floorDb + edgeMarginDb : Infinity;
+  };
+  let lo = cb;
+  let prev = crest;
+  for (let i = cb - 1, stop = Math.max(0, cb - radiusBins); i >= stop; i--) {
+    const v = finiteSample(spec, i);
+    if (v === null) break;
+    if (v <= edgeOf(i)) break; // sank into the noise
+    if (v > prev + 3) break; // rising again → adjacent signal
+    prev = v;
+    lo = i;
+  }
+  prev = crest;
+  let hi = cb;
+  for (let i = cb + 1, stop = Math.min(n - 1, cb + radiusBins); i <= stop; i++) {
+    const v = finiteSample(spec, i);
+    if (v === null) break;
+    if (v <= edgeOf(i)) break;
+    if (v > prev + 3) break;
+    prev = v;
+    hi = i;
+  }
+  return [lo, hi];
+}
+
+/** Snap target for a click: the detected peak (same set the markers draw)
+ *  nearest to `clickHz`, within `maxRadiusHz`. Returns its exact bin-centre
+ *  frequency, or null if no carrier is close enough — so a click over bare
+ *  spectrum tunes normally. The radius is supplied by the caller (derived from
+ *  a screen-pixel distance) so snapping feels the same at every zoom. */
+export function findNearestPeakHz(
+  spec: Float32Array,
+  centerHz: number,
+  hzPerPixel: number,
+  clickHz: number,
+  maxRadiusHz: number,
+): number | null {
+  if (!validSpectrumGeometry(centerHz, hzPerPixel) || !Number.isFinite(clickHz) || !validSearchRadiusHz(maxRadiusHz)) return null;
+  const peaks = detectPeaks(spec, centerHz, hzPerPixel);
+  let best: number | null = null;
+  let bestDist = Infinity;
+  for (const p of peaks) {
+    const d = Math.abs(p.hz - clickHz);
+    if (d <= maxRadiusHz && d < bestDist) {
+      bestDist = d;
+      best = p.hz;
+    }
+  }
+  return best;
+}
+
+// Parabolic interpolation around `bin` (dB domain) → sub-bin peak position, for
+// carrier precision finer than one FFT bin. Returns a fractional bin index.
+function refinePeakBin(spec: Float32Array, bin: number): number {
+  const n = spec.length;
+  if (bin <= 0 || bin >= n - 1) return bin;
+  const l = finiteSample(spec, bin - 1);
+  const c = finiteSample(spec, bin);
+  const r = finiteSample(spec, bin + 1);
+  if (l === null || c === null || r === null) return bin;
+  const denom = l - 2 * c + r;
+  if (denom === 0 || !Number.isFinite(denom)) return bin;
+  let delta = (0.5 * (l - r)) / denom;
+  if (!Number.isFinite(delta)) return bin;
+  if (delta < -1) delta = -1;
+  else if (delta > 1) delta = 1;
+  return bin + delta;
+}
+
+// Walk out from `startBin` in `dir` (±1) while the spectrum stays above the
+// floor, tolerating a few sub-threshold bins, and return the last in-signal bin
+// — the signal's energy edge on that side. Capped at `maxBins`.
+function walkEdgeBin(spec: Float32Array, startBin: number, dir: number, maxBins: number): number {
+  const n = spec.length;
+  const f = floor;
+  let edge = startBin;
+  let gap = 0;
+  let i = startBin;
+  for (let steps = 0; steps < maxBins; steps++) {
+    const j = i + dir;
+    if (j < 0 || j >= n) break;
+    const snr = optionalSnr(spec, f, n, j);
+    if (snr !== null && snr > coherentThreshold(SNAP_EDGE_SNR_DB, j, n)) {
+      edge = j;
+      gap = 0;
+    } else if (++gap > SNAP_EDGE_GAP_BINS) {
+      break;
+    }
+    i = j;
+  }
+  return edge;
+}
+
+/** Power-weighted centroid bin over [lo, hi] (carrier centre for AM/FM/DSB). */
+function centroidBin(spec: Float32Array, lo: number, hi: number): number {
+  const n = spec.length;
+  const f = floor;
+  let wsum = 0;
+  let bsum = 0;
+  for (let i = lo; i <= hi; i++) {
+    const snr = optionalSnr(spec, f, n, i);
+    if (snr === null || snr <= 0) continue;
+    const w = finiteLinearPowerWeight(snr); // dB → bounded linear power
+    wsum += w;
+    bsum += w * i;
+  }
+  return wsum > 0 ? bsum / wsum : 0.5 * (lo + hi);
+}
+
+function strongestFiniteBin(spec: Float32Array, lo: number, hi: number, fallback: number): number {
+  let bestBin = fallback;
+  let best = finiteSample(spec, fallback) ?? -Infinity;
+  for (let i = lo; i <= hi; i++) {
+    const sample = finiteSample(spec, i);
+    if (sample !== null && sample > best) {
+      best = sample;
+      bestBin = i;
+    }
+  }
+  return bestBin;
+}
+
+/** Mode-aware "tune in perfectly" target for a snap click. Anchors on the
+ *  strongest bin near the click (not a pre-detected peak — so clicking anywhere
+ *  ON a signal works, not just on its crest), walks out to that signal's full
+ *  extent, then returns the DIAL frequency to POST so it demodulates correctly:
+ *
+ *    • CW (CWU/CWL) — dial = carrier crest (sub-bin). The backend offsets the
+ *      LO by the sidetone pitch (CwOffset.EffectiveLoHz) → zero-beat.
+ *    • USB / DIGU   — dial = LOW edge of the signal (suppressed carrier), so the
+ *      whole voice channel sits inside the passband.
+ *    • LSB / DIGL   — dial = HIGH edge.
+ *    • AM/SAM/DSB/FM — dial = energy centroid (carrier centre).
+ *
+ *  Returns null only when the click is over bare noise (no bin within
+ *  `maxRadiusHz` rises above the floor). */
+export function computeSnapTuneHz(
+  spec: Float32Array,
+  centerHz: number,
+  hzPerPixel: number,
+  clickHz: number,
+  maxRadiusHz: number,
+  mode: RxMode,
+): number | null {
+  const n = spec.length;
+  if (
+    n < 3 ||
+    !validSpectrumGeometry(centerHz, hzPerPixel) ||
+    !Number.isFinite(clickHz) ||
+    !validSearchRadiusHz(maxRadiusHz)
+  ) return null;
+  const f = floor;
+  const half = n / 2;
+  const st = useSignalEnhanceStore.getState();
+
+  // Anchor: the strongest bin within the search radius that clears the floor.
+  // This is what makes "click in the middle of a signal" work — we don't
+  // require the click to land on a detected peak.
+  const clickBin = Math.round((clickHz - centerHz) / hzPerPixel + half);
+  const radius = Math.max(2, Math.round(maxRadiusHz / hzPerPixel));
+  const lo = Math.max(1, clickBin - radius);
+  const hi = Math.min(n - 2, clickBin + radius);
+  let anchor = -1;
+  let anchorVal = -Infinity;
+  for (let i = lo; i <= hi; i++) {
+    const sample = finiteSample(spec, i);
+    if (sample === null) continue;
+    const snr = optionalSnr(spec, f, n, i);
+    if (snr === null || snr < coherentThreshold(st.snapMinSnrDb, i, n)) continue;
+    if (sample > anchorVal) {
+      anchorVal = sample;
+      anchor = i;
+    }
+  }
+  if (anchor < 0) return null; // clicked on bare noise — tune normally.
+
+  const binToHz = (b: number): number => centerHz + (b - half) * hzPerPixel;
+  const maxBins = Math.max(2, Math.round(SNAP_MAX_SIGNAL_HZ / hzPerPixel));
+  const loEdge = walkEdgeBin(spec, anchor, -1, maxBins);
+  const hiEdge = walkEdgeBin(spec, anchor, +1, maxBins);
+
+  switch (mode) {
+    case 'CWU':
+    case 'CWL': {
+      // Narrow carrier: the crest of the blob, sub-bin. Backend adds the pitch.
+      const pk = strongestFiniteBin(spec, loEdge, hiEdge, anchor);
+      return binToHz(refinePeakBin(spec, pk));
+    }
+    case 'USB':
+    case 'DIGU':
+      return binToHz(loEdge);
+    case 'LSB':
+    case 'DIGL':
+      return binToHz(hiEdge);
+    default:
+      // AM / SAM / DSB / FM: centre the dial on the carrier (energy centroid).
+      return binToHz(centroidBin(spec, loEdge, hiEdge));
+  }
+}
+
+/** The dial frequency that demodulates a signal cluster [loEdge, hiEdge]
+ *  correctly for `mode` — the same placement rule computeSnapTuneHz uses, but
+ *  factored out so the line-favouring snap can evaluate every candidate. */
+function modeTuneHz(
+  spec: Float32Array,
+  loEdge: number,
+  hiEdge: number,
+  mode: RxMode,
+  binToHz: (b: number) => number,
+): number {
+  switch (mode) {
+    case 'CWU':
+    case 'CWL': {
+      const pk = strongestFiniteBin(spec, loEdge, hiEdge, loEdge);
+      return binToHz(refinePeakBin(spec, pk));
+    }
+    case 'USB':
+    case 'DIGU':
+      return binToHz(loEdge);
+    case 'LSB':
+    case 'DIGL':
+      return binToHz(hiEdge);
+    default:
+      return binToHz(centroidBin(spec, loEdge, hiEdge));
+  }
+}
+
+/** Snap that FAVOURS THE LINE UNDER THE CURSOR. Scans the visible spectrum for
+ *  signal clusters, picks the one nearest the clicked line `lineHz`, and returns
+ *  that signal's mode-aware tuning edge — the dial freq that demodulates it
+ *  correctly (USB low edge, LSB high edge, CW zero-beat, AM centroid). So a
+ *  click locks onto the signal you clicked, edge-aligned for the mode, instead
+ *  of the exact sub-Hz pixel under the cursor — and it tracks WHERE you clicked
+ *  rather than collapsing to the display centre.
+ *
+ *  Selection is by distance to the signal's BODY [loEdge, hiEdge] (zero when the
+ *  click lands inside the signal), NOT to its tuning edge. That matters for wide
+ *  SSB: clicking the low side of a 3 kHz LSB channel must still grab it even
+ *  though its tuning (high) edge is kilohertz away — the dial then lands on that
+ *  high edge. Clusters whose body is more than `maxRadiusHz` from the click are
+ *  ignored, so a click over bare spectrum returns null and the caller tunes
+ *  normally at the click point. */
+export function computeSnapToLineHz(
+  spec: Float32Array,
+  centerHz: number,
+  hzPerPixel: number,
+  mode: RxMode,
+  lineHz: number,
+  maxRadiusHz: number,
+): number | null {
+  const n = spec.length;
+  if (
+    n < 3 ||
+    !validSpectrumGeometry(centerHz, hzPerPixel) ||
+    !Number.isFinite(lineHz) ||
+    !validSearchRadiusHz(maxRadiusHz)
+  ) return null;
+  const f = floor;
+  const half = n / 2;
+  const st = useSignalEnhanceStore.getState();
+  const binToHz = (b: number): number => centerHz + (b - half) * hzPerPixel;
+  const maxBins = Math.max(2, Math.round(SNAP_MAX_SIGNAL_HZ / hzPerPixel));
+
+  let best: number | null = null;
+  let bestDist = Infinity;
+  let i = 1;
+  const end = n - 2;
+  while (i <= end) {
+    const snr = optionalSnr(spec, f, n, i);
+    if (snr === null || snr < coherentThreshold(st.snapMinSnrDb, i, n)) {
+      i++;
+      continue;
+    }
+    // Found a cluster — measure its full energy extent, then score it by how
+    // close the click sits to the signal BODY (0 when the click is inside it),
+    // so clicking any part of a wide signal grabs it; the dial still lands on
+    // the mode-tuning edge.
+    const loEdge = walkEdgeBin(spec, i, -1, maxBins);
+    const hiEdge = walkEdgeBin(spec, i, +1, maxBins);
+    const loHz = binToHz(loEdge);
+    const hiHz = binToHz(hiEdge);
+    const dist = lineHz < loHz ? loHz - lineHz : lineHz > hiHz ? lineHz - hiHz : 0;
+    if (dist <= maxRadiusHz && dist < bestDist) {
+      bestDist = dist;
+      best = modeTuneHz(spec, loEdge, hiEdge, mode, binToHz);
+    }
+    i = Math.max(i + 1, hiEdge + 1);
+  }
+  return best;
+}
+
+/** The energy extent of the signal cluster nearest `nearHz`, using the SAME
+ *  confidence-aware, gap-tolerant edge walk the snap tuner uses (walkEdgeBin) —
+ *  so a panel that DRAWS these edges shows exactly where a snap click would tune.
+ *  Anchors on the strongest bin within `maxRadiusHz` of nearHz (so it locks onto
+ *  the carrier even if nearHz is a few Hz off), walks both energy edges, and
+ *  returns absolute { loHz, hiHz, crestHz } with a sub-bin crest. Null over bare
+ *  noise (nothing within radius clears the floor). Pure: caller supplies the live
+ *  spectrum + geometry; the shared floor must already be populated. */
+export function signalExtentHz(
+  spec: Float32Array,
+  centerHz: number,
+  hzPerPixel: number,
+  nearHz: number,
+  maxRadiusHz: number,
+): { loHz: number; hiHz: number; crestHz: number } | null {
+  const n = spec.length;
+  if (
+    n < 3 ||
+    !validSpectrumGeometry(centerHz, hzPerPixel) ||
+    !Number.isFinite(nearHz) ||
+    !validSearchRadiusHz(maxRadiusHz)
+  ) return null;
+  const f = floor;
+  const half = n / 2;
+  const st = useSignalEnhanceStore.getState();
+  const binToHz = (b: number): number => centerHz + (b - half) * hzPerPixel;
+  const clickBin = Math.round((nearHz - centerHz) / hzPerPixel + half);
+  const radius = Math.max(2, Math.round(maxRadiusHz / hzPerPixel));
+  const lo = Math.max(1, clickBin - radius);
+  const hi = Math.min(n - 2, clickBin + radius);
+  let anchor = -1;
+  let anchorVal = -Infinity;
+  for (let i = lo; i <= hi; i++) {
+    const sample = finiteSample(spec, i);
+    if (sample === null) continue;
+    const snr = optionalSnr(spec, f, n, i);
+    if (snr === null || snr < coherentThreshold(st.snapMinSnrDb, i, n)) continue;
+    if (sample > anchorVal) {
+      anchorVal = sample;
+      anchor = i;
+    }
+  }
+  if (anchor < 0) return null;
+  const maxBins = Math.max(2, Math.round(SNAP_MAX_SIGNAL_HZ / hzPerPixel));
+  const loEdge = walkEdgeBin(spec, anchor, -1, maxBins);
+  const hiEdge = walkEdgeBin(spec, anchor, +1, maxBins);
+  const pk = strongestFiniteBin(spec, loEdge, hiEdge, anchor);
+  return { loHz: binToHz(loEdge), hiHz: binToHz(hiEdge), crestHz: binToHz(refinePeakBin(spec, pk)) };
+}
+
+export type SnapLockMeasure = {
+  /** Mode-tuning dial for the locked signal this frame (USB low edge, etc.). */
+  dialHz: number;
+  /** Energy-centroid of the locked signal — the anchor to track frame to frame. */
+  bodyHz: number;
+  /** Crest level (dB) of the chosen signal — fed back as the next frame's
+   *  `anchorLevelDb` so the identity gate can reject a louder foreign neighbour. */
+  levelDb: number;
+};
+
+/** Re-measure a LOCKED signal for the self-correcting snap tracker. Searches a
+ *  DELIBERATELY NARROW window (±captureHz) around `anchorBodyHz` for the local
+ *  peak NEAREST the anchor — not the strongest in view — then walks that signal's
+ *  own energy extent and returns its mode-tuning dial plus its centroid body.
+ *
+ *  This is the whole answer to "don't get confused by a loud neighbour while
+ *  pulling in a weak one": the search never looks past ±captureHz, and the
+ *  caller keeps captureHz far smaller than the spacing to the neighbour and
+ *  clamps how far the anchor may ever roam — so a stronger signal outside the
+ *  window can NEVER steal the lock. Returns null when the locked signal has sunk
+ *  into the noise inside the window, so the caller HOLDS rather than jumping to
+ *  whatever else is on the band. Pure: caller supplies the live spectrum; the
+ *  shared floor must already be populated. */
+export function measureSnapLock(
+  spec: Float32Array,
+  centerHz: number,
+  hzPerPixel: number,
+  mode: RxMode,
+  anchorBodyHz: number,
+  captureHz: number,
+  anchorLevelDb?: number,
+): SnapLockMeasure | null {
+  const n = spec.length;
+  if (
+    n < 3 ||
+    !validSpectrumGeometry(centerHz, hzPerPixel) ||
+    !Number.isFinite(anchorBodyHz) ||
+    !validSearchRadiusHz(captureHz)
+  ) return null;
+  const f = floor;
+  const half = n / 2;
+  const st = useSignalEnhanceStore.getState();
+  const binToHz = (b: number): number => centerHz + (b - half) * hzPerPixel;
+  const anchorBin = Math.round((anchorBodyHz - centerHz) / hzPerPixel + half);
+  const capBins = Math.max(1, Math.round(captureHz / hzPerPixel));
+  const lo = Math.max(1, anchorBin - capBins);
+  const hi = Math.min(n - 2, anchorBin + capBins);
+  const dispBins = Math.max(1, Math.round(SNAP_LOCK_IDENTITY_MIN_DISP_HZ / hzPerPixel));
+
+  // The peak NEAREST the anchor that clears the floor — continuity keeps us on
+  // OUR signal frame to frame instead of hopping to a louder bin in the window.
+  // The identity gate rejects a candidate that is both much louder than the
+  // level we've been tracking AND displaced from the anchor: that is a foreign
+  // neighbour, not our (possibly faded) signal. Without a tracked level the gate
+  // is inert, so first-frame and unlocked callers behave exactly as before.
+  let bestBin = -1;
+  let bestDist = Infinity;
+  let bestLevelDb = -Infinity;
+  for (let i = lo; i <= hi; i++) {
+    const sample = finiteSample(spec, i);
+    if (sample === null) continue;
+    const snr = optionalSnr(spec, f, n, i);
+    if (snr === null || snr < coherentThreshold(st.snapMinSnrDb, i, n)) continue;
+    const left = finiteSample(spec, i - 1);
+    const right = finiteSample(spec, i + 1);
+    if (left !== null && right !== null && sample >= left && sample >= right) {
+      if (
+        anchorLevelDb !== undefined &&
+        Number.isFinite(anchorLevelDb) &&
+        sample - anchorLevelDb > SNAP_LOCK_IDENTITY_REJECT_DB &&
+        Math.abs(i - anchorBin) >= dispBins
+      ) {
+        continue; // displaced + much louder ⇒ a different carrier, not our lock.
+      }
+      const d = Math.abs(i - anchorBin);
+      if (d < bestDist) {
+        bestDist = d;
+        bestBin = i;
+        bestLevelDb = sample;
+      }
+    }
+  }
+  if (bestBin < 0) return null; // locked signal is in the noise this frame — hold.
+
+  const maxBins = Math.max(2, Math.round(SNAP_MAX_SIGNAL_HZ / hzPerPixel));
+  const loEdge = walkEdgeBin(spec, bestBin, -1, maxBins);
+  const hiEdge = walkEdgeBin(spec, bestBin, +1, maxBins);
+  return {
+    dialHz: modeTuneHz(spec, loEdge, hiEdge, mode, binToHz),
+    bodyHz: binToHz(centroidBin(spec, loEdge, hiEdge)),
+    levelDb: bestLevelDb,
+  };
+}

--- a/zeus-web/src/gl/colormap.ts
+++ b/zeus-web/src/gl/colormap.ts
@@ -59,6 +59,7 @@
 // continuous form for our use case.
 
 export type ColormapId = 'blue' | 'inferno' | 'viridis';
+export type RenderColormapId = ColormapId | 'pop';
 
 export type ColormapSpec = {
   id: ColormapId;
@@ -109,6 +110,18 @@ const VIRIDIS_ANCHORS: Anchor[] = [
   [1.0, [253, 231, 37]],
 ];
 
+const POP_ANCHORS: Anchor[] = [
+  [0.0, [0, 0, 0]],
+  [0.22, [0, 0, 0]],
+  [0.34, [2, 18, 34]],
+  [0.46, [0, 74, 122]],
+  [0.58, [0, 178, 220]],
+  [0.70, [42, 236, 200]],
+  [0.82, [232, 214, 82]],
+  [0.92, [255, 118, 40]],
+  [1.0, [255, 248, 214]],
+];
+
 function sampleAnchors(anchors: Anchor[], t: number): [number, number, number] {
   let lo = anchors[0]!;
   let hi = anchors[anchors.length - 1]!;
@@ -143,13 +156,15 @@ function buildLut(anchors: Anchor[]): Uint8Array {
 }
 
 // Lazy-cached so palette swaps at runtime don't re-interpolate each time.
-const CACHE: Partial<Record<ColormapId, Uint8Array>> = {};
+const CACHE: Partial<Record<RenderColormapId, Uint8Array>> = {};
 
-export function lutFor(id: ColormapId): Uint8Array {
+export function lutFor(id: RenderColormapId): Uint8Array {
   const cached = CACHE[id];
   if (cached) return cached;
   const anchors =
-    id === 'inferno'
+    id === 'pop'
+      ? POP_ANCHORS
+      : id === 'inferno'
       ? INFERNO_ANCHORS
       : id === 'viridis'
         ? VIRIDIS_ANCHORS

--- a/zeus-web/src/gl/frame-plan.test.ts
+++ b/zeus-web/src/gl/frame-plan.test.ts
@@ -48,12 +48,13 @@ describe('frame-plan decision semantics (parity with the per-component trackers)
     expect(d3.kind).toBe('shift');
   });
 
-  it('geometry changes are resets', () => {
+  it('width changes reset but zoom changes rescale overlapping history', () => {
     planForFrame({ seq: 1, centerHz: 14_200_000n, hzPerPixel: HZPP, width: W });
     const dWidth = planForFrame({ seq: 2, centerHz: 14_200_000n, hzPerPixel: HZPP, width: W / 2 });
     expect(dWidth.kind).toBe('reset');
     const dZoom = planForFrame({ seq: 3, centerHz: 14_200_000n, hzPerPixel: HZPP / 2, width: W / 2 });
-    expect(dZoom.kind).toBe('reset');
+    expect(dZoom).toMatchObject({ kind: 'rescale', srcXScale: 0.5 });
+    expect(plannedDataCenterHz()).toBe(14_200_000n);
   });
 
   it('a move ≥ the full span is a reset', () => {

--- a/zeus-web/src/gl/frame-plan.ts
+++ b/zeus-web/src/gl/frame-plan.ts
@@ -102,6 +102,11 @@ export function planForFrame(i: FramePlanInput): WfShiftDecision {
     case 'shift':
       lastCenterHz = decision.residualCenterHz;
       break;
+    case 'rescale':
+      lastCenterHz = i.centerHz;
+      lastHzPerPixel = i.hzPerPixel;
+      lastWidth = i.width;
+      break;
   }
   plannedSeq = i.seq;
   plannedDecision = decision;

--- a/zeus-web/src/gl/panadapter.ts
+++ b/zeus-web/src/gl/panadapter.ts
@@ -64,6 +64,8 @@ export type PanRenderer = {
   // applied inside draw via the FILL_ALPHA_TOP uniform; callers pass plain
   // RGB. No GL re-init — the next draw picks up the new uniform values.
   setTraceColor: (r: number, g: number, b: number) => void;
+  /** Enables and tunes the high-contrast Signal Pop visual treatment. */
+  setPopMode: (active: boolean, intensity?: number) => void;
   dispose: () => void;
 };
 
@@ -91,6 +93,7 @@ export function createPanRenderer(gl: WebGL2RenderingContext): PanRenderer {
   let traceR = 1.0;
   let traceG = 0.627;
   let traceB = 0.157;
+  let popIntensity = 1;
 
   const traceProg = buildProgram(gl, PAN_VS, PAN_FS);
   const uTraceWidth = gl.getUniformLocation(traceProg, 'uWidth');
@@ -98,6 +101,7 @@ export function createPanRenderer(gl: WebGL2RenderingContext): PanRenderer {
   const uTraceDbMax = gl.getUniformLocation(traceProg, 'uDbMax');
   const uTraceOffsetPx = gl.getUniformLocation(traceProg, 'uOffsetPx');
   const uTraceColor = gl.getUniformLocation(traceProg, 'uColor');
+  const uTracePopIntensity = gl.getUniformLocation(traceProg, 'uPopIntensity');
 
   const fillProg = buildProgram(gl, PAN_FILL_VS, PAN_FILL_FS);
   const uFillWidth = gl.getUniformLocation(fillProg, 'uWidth');
@@ -107,6 +111,7 @@ export function createPanRenderer(gl: WebGL2RenderingContext): PanRenderer {
   const uFillColor = gl.getUniformLocation(fillProg, 'uColor');
   const uFillAlphaTop = gl.getUniformLocation(fillProg, 'uFillAlphaTop');
   const uFillPan = gl.getUniformLocation(fillProg, 'uPan');
+  const uFillPopIntensity = gl.getUniformLocation(fillProg, 'uPopIntensity');
 
   // Trace VBO: one float per bin, rendered as LINE_STRIP for the sharp
   // top edge. Fill reuses the same data via a 1-row R32F texture sampled
@@ -210,6 +215,7 @@ export function createPanRenderer(gl: WebGL2RenderingContext): PanRenderer {
       gl.uniform1f(uFillOffsetPx, offsetPx);
       gl.uniform3f(uFillColor, traceR, traceG, traceB);
       gl.uniform1f(uFillAlphaTop, FILL_ALPHA_TOP);
+      gl.uniform1f(uFillPopIntensity, popIntensity);
       gl.drawArrays(gl.TRIANGLE_STRIP, 0, panDb.length * 2);
 
       // Sharp trace line on top.
@@ -231,6 +237,7 @@ export function createPanRenderer(gl: WebGL2RenderingContext): PanRenderer {
       gl.uniform1f(uTraceDbMax, dbMax);
       gl.uniform1f(uTraceOffsetPx, offsetPx);
       gl.uniform3f(uTraceColor, traceR, traceG, traceB);
+      gl.uniform1f(uTracePopIntensity, popIntensity);
       gl.drawArrays(gl.LINE_STRIP, 0, panDb.length);
 
       gl.useProgram(cursorProg);
@@ -244,6 +251,9 @@ export function createPanRenderer(gl: WebGL2RenderingContext): PanRenderer {
       traceR = r;
       traceG = g;
       traceB = b;
+    },
+    setPopMode(active, intensity = active ? 1 : 0) {
+      popIntensity = Math.max(0, Math.min(1, intensity));
     },
     dispose() {
       gl.deleteBuffer(traceVbo);

--- a/zeus-web/src/gl/shaders.ts
+++ b/zeus-web/src/gl/shaders.ts
@@ -48,17 +48,36 @@ uniform float uWidth;
 uniform float uDbMin;
 uniform float uDbMax;
 uniform float uOffsetPx;
+out float vLevel;
 void main() {
   float x = (float(gl_VertexID) + 0.5 + uOffsetPx) / uWidth;
   float n = clamp((aDb - uDbMin) / (uDbMax - uDbMin), 0.0, 1.0);
+  vLevel = n;
   gl_Position = vec4(x * 2.0 - 1.0, n * 2.0 - 1.0, 0.0, 1.0);
 }`;
 
 export const PAN_FS = /* glsl */ `#version 300 es
 precision highp float;
+in float vLevel;
 uniform vec3 uColor;
+uniform float uPopIntensity;
 out vec4 fragColor;
-void main() { fragColor = vec4(uColor, 1.0); }`;
+vec3 popRamp(float n) {
+  vec3 low = vec3(0.02, 0.20, 0.34);
+  vec3 mid = vec3(0.00, 0.86, 1.00);
+  vec3 hot = vec3(1.00, 0.72, 0.26);
+  vec3 peak = vec3(1.00, 0.97, 0.82);
+  vec3 c = mix(low, mid, smoothstep(0.04, 0.48, n));
+  c = mix(c, hot, smoothstep(0.46, 0.82, n));
+  return mix(c, peak, smoothstep(0.82, 1.0, n));
+}
+void main() {
+  float popI = clamp(uPopIntensity, 0.0, 1.0);
+  vec3 c = mix(uColor, popRamp(vLevel), popI);
+  c += vec3(0.08, 0.12, 0.06) * smoothstep(0.58, 1.0, vLevel) * popI;
+  c = min(c, vec3(1.0));
+  fragColor = vec4(c, 1.0);
+}`;
 
 // Fill under the trace. Pan dB values live in a 1-row R32F texture; vertex
 // IDs map 2i → bottom vertex for bin i, 2i+1 → top, so texelFetch at
@@ -73,6 +92,7 @@ uniform float uDbMax;
 uniform float uOffsetPx;
 uniform float uFillAlphaTop;
 out float v_alpha;
+out float v_level;
 void main() {
   int binIdx = gl_VertexID >> 1;
   bool isTop = (gl_VertexID & 1) == 1;
@@ -81,15 +101,34 @@ void main() {
   float n = clamp((aDb - uDbMin) / (uDbMax - uDbMin), 0.0, 1.0);
   float y = isTop ? (n * 2.0 - 1.0) : -1.0;
   v_alpha = isTop ? uFillAlphaTop : 0.0;
+  v_level = n;
   gl_Position = vec4(x * 2.0 - 1.0, y, 0.0, 1.0);
 }`;
 
 export const PAN_FILL_FS = /* glsl */ `#version 300 es
 precision highp float;
 in float v_alpha;
+in float v_level;
 uniform vec3 uColor;
+uniform float uPopIntensity;
 out vec4 fragColor;
-void main() { fragColor = vec4(uColor * v_alpha, v_alpha); }`;
+vec3 popRamp(float n) {
+  vec3 floorGlow = vec3(0.00, 0.10, 0.18);
+  vec3 weak = vec3(0.00, 0.52, 0.78);
+  vec3 strong = vec3(0.14, 0.96, 0.92);
+  vec3 peak = vec3(1.00, 0.72, 0.30);
+  vec3 c = mix(floorGlow, weak, smoothstep(0.02, 0.34, n));
+  c = mix(c, strong, smoothstep(0.30, 0.70, n));
+  return mix(c, peak, smoothstep(0.72, 1.0, n));
+}
+void main() {
+  vec4 base = vec4(uColor * v_alpha, v_alpha);
+  float popI = clamp(uPopIntensity, 0.0, 1.0);
+  float lift = smoothstep(0.04, 0.92, v_level);
+  float alpha = v_alpha * mix(0.42, 0.86, lift);
+  vec3 c = popRamp(v_level) * alpha;
+  fragColor = mix(base, vec4(c, alpha), popI);
+}`;
 
 export const CURSOR_VS = /* glsl */ `#version 300 es
 layout(location = 0) in vec2 aPos;
@@ -121,20 +160,10 @@ uniform float uDbMax;
 uniform float uWriteRow;
 uniform float uH;
 uniform float uBgAlpha;
-// Issue #597: fractional view offset in UV units —
-// (historyCenterHz − viewCenterHz) / spanHz. The history texture itself is
-// only rebased in integer pixels (ping-pong shift); this term slides the
-// SAMPLING window fractionally so the waterfall glides with the animated
-// view-center between rebases. Same sign convention as WF_SHIFT_FS's
-// uShiftUv: positive slides displayed content right. Columns the slide
-// exposes fall back to uSeedDb (noise-floor colour), matching the shift
-// pass convention.
 uniform float uViewOffsetUv;
 uniform float uSeedDb;
 out vec4 fragColor;
 void main() {
-  // vUv.y == 1.0 at top of canvas; newest row sits at the top.
-  // row = (writeRow - (1 - vUv.y) * H) mod H, normalised.
   float agePx = (1.0 - vUv.y) * uH;
   float row = mod(uWriteRow - agePx + uH, uH);
   float srcX = vUv.x - uViewOffsetUv;
@@ -143,27 +172,26 @@ void main() {
     : texture(uHistory, vec2(srcX, (row + 0.5) / uH)).r;
   float n = clamp((v - uDbMin) / (uDbMax - uDbMin), 0.0, 1.0);
   vec4 c = texture(uLut, vec2(n, 0.5));
-  // uBgAlpha=1 → fully opaque (normal mode). uBgAlpha=0 → noise floor is
-  // fully transparent and signal peaks fade in proportionally; map/background
-  // shows through between carriers. Smoothstep widens the signal-visible band
-  // a touch so weaker activity still registers.
   float a = mix(smoothstep(0.05, 0.9, n), 1.0, uBgAlpha);
   fragColor = vec4(c.rgb * a, a);
 }`;
 
-// Horizontal-shift pass for doc 08 §5 ping-pong: sample the previous history
-// at vUv.x - shiftUv, fall back to a background-noise seed dB where the shift
-// exposes fresh columns. Rendered into the inactive R32F texture; the main
-// WF_FS then reads from the now-active texture next draw.
-export const WF_SHIFT_FS = /* glsl */ `#version 300 es
+// Horizontal remap pass for doc 08 §5 ping-pong: sample the previous history
+// at the absolute-frequency equivalent of the destination x. Plain retunes
+// use scale=1 and an offset; zoom changes use scale=nextHzPerPixel/oldHzPerPixel
+// so the old waterfall history narrows/widens around the new center instead
+// of being wiped. Rendered into the inactive R32F texture; the main WF_FS then
+// reads from the now-active texture next draw.
+export const WF_REMAP_FS = /* glsl */ `#version 300 es
 precision highp float;
 in vec2 vUv;
 uniform sampler2D uSrc;
-uniform float uShiftUv;
+uniform float uSrcXScale;
+uniform float uSrcCenterOffsetUv;
 uniform float uSeedDb;
 layout(location = 0) out vec4 fragColor;
 void main() {
-  float srcX = vUv.x - uShiftUv;
+  float srcX = 0.5 + uSrcCenterOffsetUv + (vUv.x - 0.5) * uSrcXScale;
   float v = (srcX < 0.0 || srcX > 1.0)
     ? uSeedDb
     : texture(uSrc, vec2(srcX, vUv.y)).r;

--- a/zeus-web/src/gl/util.ts
+++ b/zeus-web/src/gl/util.ts
@@ -49,8 +49,14 @@ export function compile(gl: WebGL2RenderingContext, type: number, src: string): 
   gl.compileShader(sh);
   if (!gl.getShaderParameter(sh, gl.COMPILE_STATUS)) {
     const log = gl.getShaderInfoLog(sh) ?? '';
+    const stage =
+      type === gl.VERTEX_SHADER
+        ? 'vertex'
+        : type === gl.FRAGMENT_SHADER
+          ? 'fragment'
+          : String(type);
     gl.deleteShader(sh);
-    throw new Error(`shader compile failed: ${log}`);
+    throw new Error(`shader compile failed (${stage}): ${log || 'no compiler log'}`);
   }
   return sh;
 }

--- a/zeus-web/src/gl/waterfall.ts
+++ b/zeus-web/src/gl/waterfall.ts
@@ -55,13 +55,14 @@
 // shift tick avoids a discontinuity between the just-shifted top row and the
 // pre-retune frame underneath.
 //
-// Reset conditions (|shift| ≥ width, width change, hzPerPixel change) re-
-// seed both textures at -200 dB so uninitialised columns render as the
-// noise-floor colour rather than a 0 dB yellow band.
+// Reset conditions (|shift| ≥ width or width change) re-seed both textures
+// at -200 dB so uninitialised columns render as the noise-floor colour rather
+// than a 0 dB yellow band. Hz-per-pixel changes are resampled in-place when
+// the old and new spans overlap, so zooming preserves waterfall history.
 
 import { buildProgram } from './util';
-import { WF_VS, WF_FS, WF_SHIFT_FS } from './shaders';
-import { lutFor, type ColormapId } from './colormap';
+import { WF_VS, WF_FS, WF_REMAP_FS } from './shaders';
+import { lutFor, type RenderColormapId } from './colormap';
 import type { WfShiftDecision } from './wf-shift';
 
 const HISTORY_ROWS = 512;
@@ -103,7 +104,9 @@ export type WfRenderer = {
    *  the history's anchor center and the view (issue #597). Null renders
    *  with zero offset (pre-first-frame / tests). */
   draw: (dbMin: number, dbMax: number, viewCenterHz?: number | null) => void;
-  setColormap: (id: ColormapId) => void;
+  setColormap: (id: RenderColormapId) => void;
+  /** Enables and tunes the Signal Pop waterfall shader treatment. */
+  setPopMode: (active: boolean, intensity?: number) => void;
   /** 1.0 = opaque (default). 0.0 = noise floor fades to transparent so a
    *  background layer (e.g. the QRZ-mode Leaflet map) shows through. */
   setTransparent: (transparent: boolean) => void;
@@ -116,6 +119,11 @@ export type WfRenderer = {
     lastViewOffsetUv: number;
     contextLost: boolean;
   };
+  /** Re-seed the history to the noise-floor colour. Used when the value scale
+   *  changes wholesale (Signal Pop toggle) so pre-toggle rows in the old dB
+   *  domain don't render as a clipped band against the new range. No-op before
+   *  the first frame (nothing allocated yet). */
+  clearHistory: () => void;
   dispose: () => void;
 };
 
@@ -163,10 +171,11 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
   const uSeedDbDraw = gl.getUniformLocation(drawProg, 'uSeedDb');
   let bgAlpha = 1;
 
-  const shiftProg = buildProgram(gl, WF_VS, WF_SHIFT_FS);
-  const uShiftSrc = gl.getUniformLocation(shiftProg, 'uSrc');
-  const uShiftUv = gl.getUniformLocation(shiftProg, 'uShiftUv');
-  const uShiftSeed = gl.getUniformLocation(shiftProg, 'uSeedDb');
+  const remapProg = buildProgram(gl, WF_VS, WF_REMAP_FS);
+  const uRemapSrc = gl.getUniformLocation(remapProg, 'uSrc');
+  const uRemapSrcXScale = gl.getUniformLocation(remapProg, 'uSrcXScale');
+  const uRemapSrcCenterOffsetUv = gl.getUniformLocation(remapProg, 'uSrcCenterOffsetUv');
+  const uRemapSeed = gl.getUniformLocation(remapProg, 'uSeedDb');
 
   const vao = gl.createVertexArray()!;
   const vbo = gl.createBuffer()!;
@@ -198,7 +207,7 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
   const fbo = gl.createFramebuffer()!;
 
   const lutTex = gl.createTexture()!;
-  const uploadLut = (id: ColormapId) => {
+  const uploadLut = (id: RenderColormapId) => {
     gl.bindTexture(gl.TEXTURE_2D, lutTex);
     gl.texImage2D(
       gl.TEXTURE_2D,
@@ -266,6 +275,7 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
     // got R32F storage, texWidth stayed 0, draw() bailed to a transparent
     // clear, and the waterfall was permanently black. Seeding here (and on any
     // width change) makes it order- and platform-independent.
+    if (wfDb.length === 0) return;
     if (texWidth !== wfDb.length) resetTextures(wfDb.length);
     writeRow = (writeRow + 1) % HISTORY_ROWS;
     gl.bindTexture(gl.TEXTURE_2D, textures[active]);
@@ -282,8 +292,8 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
     );
   };
 
-  const performShift = (shiftPx: number) => {
-    if (texWidth === 0) return; // not seeded yet — nothing to shift
+  const performRemap = (srcCenterOffsetUv: number, srcXScale: number) => {
+    if (texWidth === 0) return; // not seeded yet — nothing to remap
     const src = active === 0 ? textures[0] : textures[1];
     const dst = active === 0 ? textures[1] : textures[0];
     gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
@@ -295,17 +305,23 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
       0,
     );
     gl.viewport(0, 0, texWidth, HISTORY_ROWS);
-    gl.useProgram(shiftProg);
+    gl.useProgram(remapProg);
     gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, src);
-    gl.uniform1i(uShiftSrc, 0);
-    gl.uniform1f(uShiftUv, shiftPx / texWidth);
-    gl.uniform1f(uShiftSeed, SEED_DB);
+    gl.uniform1i(uRemapSrc, 0);
+    gl.uniform1f(uRemapSrcXScale, srcXScale);
+    gl.uniform1f(uRemapSrcCenterOffsetUv, srcCenterOffsetUv);
+    gl.uniform1f(uRemapSeed, SEED_DB);
     gl.bindVertexArray(vao);
     gl.drawArrays(gl.TRIANGLES, 0, 3);
     gl.bindVertexArray(null);
     gl.bindFramebuffer(gl.FRAMEBUFFER, null);
     active = (1 - active) as 0 | 1;
+  };
+
+  const performShift = (shiftPx: number) => {
+    if (texWidth === 0) return;
+    performRemap(-shiftPx / texWidth, 1);
   };
 
   return {
@@ -334,6 +350,12 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
           // lastCenterHz unchanged so sub-pixel retunes accumulate.
           break;
         case 'shift':
+          // A shift on an unseeded renderer (texWidth === 0, e.g. the first
+          // frame this surface observes after a remount happens to be a
+          // retune) has no history to rebase and would bind a level-0 store
+          // that texImage2D never allocated. Skip it; the next valid frame
+          // seeds via uploadRow.
+          if (texWidth === 0) break;
           // Shift always runs — throttling it would let the history drift
           // out of sync with the panadapter's anchor offset. This is a
           // REBASE of the texture in integer pixels; the fractional
@@ -343,6 +365,15 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
           // overlay a post-retune row on top of a just-shifted frame.
           lastCenterHz = decision.residualCenterHz;
           break;
+        case 'rescale':
+          // Remap each historical column to the equivalent absolute-frequency
+          // column under the new hz/px. This keeps zoom changes continuous:
+          // zoom-in crops around the center; zoom-out exposes seeded edges.
+          performRemap(decision.srcCenterOffsetUv, decision.srcXScale);
+          if (wfDb && !options?.skipRowUpload) uploadRow(wfDb);
+          lastCenterHz = centerHz;
+          lastHzPerPixel = hzPerPixel;
+          break;
       }
     },
     setColormap(id) {
@@ -350,6 +381,13 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
     },
     setTransparent(transparent) {
       bgAlpha = transparent ? 0 : 1;
+    },
+    setPopMode() {
+      // POP is expressed through the renderer LUT; the shader remains the
+      // portable baseline waterfall program.
+    },
+    clearHistory() {
+      if (texWidth > 0) resetTextures(texWidth);
     },
     draw(dbMin, dbMax, viewCenterHz = null) {
       gl.viewport(0, 0, canvasW, canvasH);
@@ -408,7 +446,7 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
       gl.deleteBuffer(vbo);
       gl.deleteVertexArray(vao);
       gl.deleteProgram(drawProg);
-      gl.deleteProgram(shiftProg);
+      gl.deleteProgram(remapProg);
     },
   };
 }

--- a/zeus-web/src/gl/wf-shift.test.ts
+++ b/zeus-web/src/gl/wf-shift.test.ts
@@ -67,10 +67,36 @@ describe('planWaterfallUpdate', () => {
     ).toEqual({ kind: 'reset', reason: 'width' });
   });
 
-  it('resets when hzPerPixel changes (sampleRate or span change)', () => {
+  it('rescales when hzPerPixel changes and spans overlap', () => {
     expect(
       planWaterfallUpdate({ ...base, nextHzPerPixel: 50 }),
-    ).toEqual({ kind: 'reset', reason: 'hzPerPixel' });
+    ).toEqual({
+      kind: 'rescale',
+      srcXScale: 0.5,
+      srcCenterOffsetUv: 0,
+    });
+  });
+
+  it('includes center offset when rescaling during a tune', () => {
+    const d = planWaterfallUpdate({
+      ...base,
+      nextCenterHz: 14_201_000n,
+      nextHzPerPixel: 50,
+    });
+    expect(d).toMatchObject({
+      kind: 'rescale',
+      srcXScale: 0.5,
+    });
+    expect(d.kind === 'rescale' ? d.srcCenterOffsetUv : 0).toBeCloseTo(1000 / (1024 * 100));
+  });
+
+  it('resets when a zoomed span no longer overlaps old history', () => {
+    const d = planWaterfallUpdate({
+      ...base,
+      nextCenterHz: 14_400_000n,
+      nextHzPerPixel: 50,
+    });
+    expect(d).toEqual({ kind: 'reset', reason: 'span' });
   });
 
   it('pushes a row when center is unchanged', () => {

--- a/zeus-web/src/gl/wf-shift.ts
+++ b/zeus-web/src/gl/wf-shift.ts
@@ -47,12 +47,14 @@
 //
 // Input is the "last-seen" frame geometry (width, hzPerPixel, centerHz) and
 // the incoming frame's same fields. Output tells the renderer what to do:
-//   - reset: wipe history (first frame, width or hzPerPixel changed, or
-//     the LO moved far enough that the whole visible span is new data)
+//   - reset: wipe history (first frame, width changed, or the LO moved far
+//     enough that the whole visible span is new data)
 //   - push:  no translation needed, upload the new row normally
 //   - shift: ping-pong horizontal shift by `shiftPx` columns; suppress
 //     this tick's row blit and remember the residual sub-pixel delta so
 //     subsequent fine retunes accumulate instead of being dropped
+//   - rescale: hzPerPixel changed but the old/new spans overlap, so resample
+//     the existing history around the new center instead of throwing it away
 //
 // Sign convention: shiftPx = round((oldCenter − newCenter) / hzPerPixel).
 // The server emits `wfDb` with low freq on the left / high
@@ -69,9 +71,10 @@ export type WfShiftInput = {
 };
 
 export type WfShiftDecision =
-  | { kind: 'reset'; reason: 'first' | 'width' | 'hzPerPixel' | 'span' }
+  | { kind: 'reset'; reason: 'first' | 'width' | 'span' }
   | { kind: 'push' }
-  | { kind: 'shift'; shiftPx: number; residualCenterHz: bigint };
+  | { kind: 'shift'; shiftPx: number; residualCenterHz: bigint }
+  | { kind: 'rescale'; srcXScale: number; srcCenterOffsetUv: number };
 
 export function planWaterfallUpdate(i: WfShiftInput): WfShiftDecision {
   if (i.lastWidth === 0 || i.lastCenterHz === null) {
@@ -79,7 +82,22 @@ export function planWaterfallUpdate(i: WfShiftInput): WfShiftDecision {
   }
   if (i.lastWidth !== i.nextWidth) return { kind: 'reset', reason: 'width' };
   if (i.lastHzPerPixel !== i.nextHzPerPixel) {
-    return { kind: 'reset', reason: 'hzPerPixel' };
+    const oldSpanHz = i.lastWidth * i.lastHzPerPixel;
+    const newSpanHz = i.nextWidth * i.nextHzPerPixel;
+    const oldCenterHz = Number(i.lastCenterHz);
+    const newCenterHz = Number(i.nextCenterHz);
+    const oldLo = oldCenterHz - oldSpanHz / 2;
+    const oldHi = oldCenterHz + oldSpanHz / 2;
+    const newLo = newCenterHz - newSpanHz / 2;
+    const newHi = newCenterHz + newSpanHz / 2;
+    if (Math.max(oldLo, newLo) >= Math.min(oldHi, newHi)) {
+      return { kind: 'reset', reason: 'span' };
+    }
+    return {
+      kind: 'rescale',
+      srcXScale: i.nextHzPerPixel / i.lastHzPerPixel,
+      srcCenterOffsetUv: (newCenterHz - oldCenterHz) / oldSpanHz,
+    };
   }
   const deltaHz = Number(i.lastCenterHz - i.nextCenterHz);
   const shiftPx = Math.round(deltaHz / i.nextHzPerPixel);

--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -305,9 +305,9 @@ function PanelBody({
   // onRemove so their close button can drop the tile (matches the meter
   // group special-case above without pulling in its per-tile config).
   if (def.headerless && onRemove) {
-    return <Component onRemove={onRemove} />;
+    return <Component onRemove={onRemove} tile={tile} />;
   }
-  return <Component />;
+  return <Component tile={tile} />;
 }
 
 function MeterGroupTileBody({

--- a/zeus-web/src/layout/panels.ts
+++ b/zeus-web/src/layout/panels.ts
@@ -43,6 +43,7 @@
 // License for details.
 
 import type { ComponentType } from 'react';
+import type { WorkspaceTile } from './workspace';
 import { HeroPanel } from './panels/HeroPanel';
 import { VfoPanel } from './panels/VfoPanel';
 import { SMeterPanel } from './panels/SMeterPanel';
@@ -114,8 +115,10 @@ const VALID_PANEL_CATEGORIES = new Set<string>(PANEL_CATEGORIES);
  *  `<def.component />`. Multi-instance panels with per-instance config
  *  (just `meters` today) take a typed prop pair instead; `PanelTile` knows
  *  to switch on `def.id === 'meters'` for that wiring. Headerless panels
- *  receive `onRemove` so the close button they own can drop the tile. */
-export type PanelComponentProps = { onRemove?: () => void };
+ *  receive `onRemove` so the close button they own can drop the tile. The
+ *  optional `tile` lets a headerless panel persist per-tile UI state (e.g.
+ *  HeroPanel's panadapter/waterfall split) into the workspace layout config. */
+export type PanelComponentProps = { onRemove?: () => void; tile?: WorkspaceTile };
 
 export interface PanelDef {
   id: string;

--- a/zeus-web/src/layout/panels/HeroPanel.tsx
+++ b/zeus-web/src/layout/panels/HeroPanel.tsx
@@ -42,6 +42,7 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from 'react';
 import { GripVertical, X } from 'lucide-react';
 import { Panadapter } from '../../components/Panadapter';
@@ -51,7 +52,74 @@ import { LeafletWorldMap } from '../../components/design/LeafletWorldMap';
 import { LeafletMapErrorBoundary } from '../../components/design/LeafletMapErrorBoundary';
 import { useConnectionStore } from '../../state/connection-store';
 import { useRotatorStore } from '../../state/rotator-store';
+import { useLayoutStore } from '../../state/layout-store';
 import { useWorkspace } from '../WorkspaceContext';
+import type { WorkspaceTile } from '../workspace';
+
+// Persisted spectrum/waterfall split: fraction of the stack height given to
+// the panadapter (the waterfall gets the remainder). Default 0.4 so the
+// waterfall is the larger of the two out of the box; the operator can drag
+// the divider to rebalance and the choice survives reloads via localStorage
+// (and the server-backed workspace layout when a tile is provided).
+const SPLIT_STORAGE_KEY = 'zeus.layout.spectrumSplit';
+const SPLIT_CONFIG_KEY = 'spectrumSplit';
+const DEFAULT_SPLIT = 0.4;
+const MIN_SPLIT = 0.15;
+const MAX_SPLIT = 0.85;
+
+function clampSplit(v: number): number {
+  return Math.min(MAX_SPLIT, Math.max(MIN_SPLIT, v));
+}
+
+function isValidSplit(v: number): boolean {
+  return Number.isFinite(v) && v >= MIN_SPLIT && v <= MAX_SPLIT;
+}
+
+function readInstanceSplit(raw: unknown): number | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const v = (raw as Record<string, unknown>)[SPLIT_CONFIG_KEY];
+  return typeof v === 'number' && isValidSplit(v) ? v : null;
+}
+
+function mergeInstanceSplit(raw: unknown, split: number): Record<string, unknown> {
+  const base =
+    raw && typeof raw === 'object' && !Array.isArray(raw)
+      ? { ...(raw as Record<string, unknown>) }
+      : {};
+  base[SPLIT_CONFIG_KEY] = clampSplit(split);
+  return base;
+}
+
+function readLegacySplit(): number | null {
+  try {
+    if (typeof localStorage === 'undefined') return null;
+    const raw = localStorage.getItem(SPLIT_STORAGE_KEY);
+    if (raw === null) return null;
+    const v = Number.parseFloat(raw);
+    if (!isValidSplit(v)) return null;
+    return v;
+  } catch {
+    return null;
+  }
+}
+
+function readInitialSplit(raw: unknown): number {
+  return readInstanceSplit(raw) ?? readLegacySplit() ?? DEFAULT_SPLIT;
+}
+
+function writeLegacySplit(v: number): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(SPLIT_STORAGE_KEY, String(clampSplit(v)));
+  } catch {
+    // quota exceeded / private mode — in-memory state still holds for this session.
+  }
+}
+
+interface HeroPanelProps {
+  onRemove?: () => void;
+  tile?: WorkspaceTile;
+}
 
 // Hero panel: Panadapter + Waterfall with optional Leaflet world-map overlay.
 // Registered as headerless in panels.ts — this component owns the single
@@ -60,7 +128,7 @@ import { useWorkspace } from '../WorkspaceContext';
 // the ⌥ map-mode hint, the HZ/PX readout, and the close X. Interactive
 // controls inside stop mousedown propagation so a click on a chip / slider /
 // input doesn't initiate a tile drag (mirrors the MetersPanel pattern).
-export function HeroPanel({ onRemove }: { onRemove?: () => void } = {}) {
+export function HeroPanel({ onRemove, tile }: HeroPanelProps = {}) {
   const {
     terminatorActive,
     imageMode,
@@ -85,6 +153,81 @@ export function HeroPanel({ onRemove }: { onRemove?: () => void } = {}) {
     submitBeam,
   } = useWorkspace();
   const connected = useConnectionStore((s) => s.status === 'Connected');
+  const updateTileInstanceConfig = useLayoutStore((s) => s.updateTileInstanceConfig);
+  const layoutLoaded = useLayoutStore((s) => s.isLoaded);
+  const layoutRadioKey = useLayoutStore((s) => s.radioKey);
+  const activeLayoutId = useLayoutStore((s) => s.activeLayoutId);
+
+  const stackRef = useRef<HTMLDivElement | null>(null);
+  const [split, setSplit] = useState(() => readInitialSplit(tile?.instanceConfig));
+  const [splitDragging, setSplitDragging] = useState(false);
+
+  useEffect(() => {
+    const persisted = readInstanceSplit(tile?.instanceConfig);
+    if (persisted === null) return;
+    setSplit((current) => (Math.abs(current - persisted) < 0.001 ? current : persisted));
+  }, [tile?.uid, tile?.instanceConfig]);
+
+  // One-time migration from the previous localStorage-only split into the
+  // server-backed workspace layout config. The localStorage mirror remains as
+  // an immediate fallback, but the tile config is the restart-safe source.
+  useEffect(() => {
+    if (!layoutLoaded) return;
+    if (!tile) return;
+    if (readInstanceSplit(tile.instanceConfig) !== null) return;
+    const legacy = readLegacySplit();
+    if (legacy === null) return;
+    updateTileInstanceConfig(tile.uid, mergeInstanceSplit(tile.instanceConfig, legacy));
+  }, [
+    activeLayoutId,
+    layoutLoaded,
+    layoutRadioKey,
+    tile?.uid,
+    tile?.instanceConfig,
+    updateTileInstanceConfig,
+  ]);
+
+  const persistSplit = useCallback(
+    (next: number) => {
+      const clamped = clampSplit(next);
+      writeLegacySplit(clamped);
+      if (tile) {
+        updateTileInstanceConfig(tile.uid, mergeInstanceSplit(tile.instanceConfig, clamped));
+      }
+    },
+    [tile, updateTileInstanceConfig],
+  );
+
+  // Drag the divider to rebalance the panadapter/waterfall split. We attach
+  // window-level move/up listeners (rather than relying on the divider's own
+  // pointer events) so the drag keeps tracking even when the cursor outruns
+  // the slim hit area. stopPropagation keeps RGL from treating it as a tile
+  // drag; preventDefault suppresses text selection during the gesture.
+  const onSplitterPointerDown = (e: ReactPointerEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const stack = stackRef.current;
+    if (!stack) return;
+    const rect = stack.getBoundingClientRect();
+    if (rect.height <= 0) return;
+    setSplitDragging(true);
+    let latest = split;
+    const onMove = (ev: PointerEvent) => {
+      const frac = (ev.clientY - rect.top) / rect.height;
+      latest = clampSplit(frac);
+      setSplit(latest);
+    };
+    const onEnd = () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onEnd);
+      window.removeEventListener('pointercancel', onEnd);
+      setSplitDragging(false);
+      persistSplit(latest);
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onEnd);
+    window.addEventListener('pointercancel', onEnd);
+  };
 
   const handleRotateToBearing = (brg: number) => {
     const rot = useRotatorStore.getState();
@@ -240,16 +383,25 @@ export function HeroPanel({ onRemove }: { onRemove?: () => void } = {}) {
           </LeafletMapErrorBoundary>
         </div>
         <div
+          ref={stackRef}
           data-spectrum-stack
           style={{
             position: 'absolute',
             inset: 0,
             display: 'grid',
-            gridTemplateRows: '1fr 1fr',
+            gridTemplateRows: `${split}fr 8px ${1 - split}fr`,
             zIndex: 1,
           }}
         >
           {connected && <Panadapter />}
+          <div
+            className={`spectrum-splitter ${splitDragging ? 'dragging' : ''}`}
+            role="separator"
+            aria-orientation="horizontal"
+            aria-label="Resize panadapter and waterfall"
+            title="Drag to resize panadapter / waterfall"
+            onPointerDown={onSplitterPointerDown}
+          />
           {connected && <Waterfall transparent={bgActive} />}
         </div>
       </div>

--- a/zeus-web/src/state/connection-store.ts
+++ b/zeus-web/src/state/connection-store.ts
@@ -93,6 +93,9 @@ export type ConnectionState = {
   // PS-toggle disabled branch.
   connectedProtocol: 'P1' | 'P2' | null;
   preampOn: boolean;
+  // Hardware NCO / panadapter centre. The frequency-axis ruler drag moves this
+  // without touching vfoHz so the operator can pan to off-screen spectrum.
+  radioLoHz: number;
   nr: NrConfigDto;
   zoomLevel: ZoomLevel;
   inflight: boolean;
@@ -147,6 +150,7 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
   boardId: null,
   connectedProtocol: null,
   preampOn: false,
+  radioLoHz: 14_200_000,
   nr: { ...NR_CONFIG_DEFAULT },
   zoomLevel: 1,
   inflight: false,
@@ -179,6 +183,7 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
       autoAttEnabled: s.autoAttEnabled,
       attOffsetDb: s.attOffsetDb,
       adcOverloadWarning: s.adcOverloadWarning,
+      radioLoHz: s.radioLoHz > 0 ? s.radioLoHz : prev.radioLoHz,
       nr: s.nr,
       zoomLevel: s.zoomLevel,
     })),

--- a/zeus-web/src/state/display-settings-store.test.ts
+++ b/zeus-web/src/state/display-settings-store.test.ts
@@ -44,6 +44,7 @@
 
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
+  DEFAULT_WF_ROW_CADENCE,
   FIXED_DB_MAX,
   FIXED_DB_MIN,
   useDisplaySettingsStore,
@@ -54,6 +55,7 @@ function resetStore() {
     autoRange: false,
     dbMin: FIXED_DB_MIN,
     dbMax: FIXED_DB_MAX,
+    waterfallRowCadence: DEFAULT_WF_ROW_CADENCE,
   });
 }
 
@@ -123,5 +125,23 @@ describe('display-settings-store', () => {
     const { dbMin, dbMax } = useDisplaySettingsStore.getState();
     expect(Number.isFinite(dbMin)).toBe(true);
     expect(Number.isFinite(dbMax)).toBe(true);
+  });
+
+  it('keeps balanced waterfall row cadence by default', () => {
+    const { waterfallRowCadence } = useDisplaySettingsStore.getState();
+    expect(waterfallRowCadence).toBe(DEFAULT_WF_ROW_CADENCE);
+  });
+
+  it('updates waterfall row cadence to valid operator choices only', () => {
+    const s = useDisplaySettingsStore.getState();
+
+    s.setWaterfallRowCadence(1);
+    expect(useDisplaySettingsStore.getState().waterfallRowCadence).toBe(1);
+
+    s.setWaterfallRowCadence(3);
+    expect(useDisplaySettingsStore.getState().waterfallRowCadence).toBe(3);
+
+    s.setWaterfallRowCadence(99 as never);
+    expect(useDisplaySettingsStore.getState().waterfallRowCadence).toBe(DEFAULT_WF_ROW_CADENCE);
   });
 });

--- a/zeus-web/src/state/display-settings-store.ts
+++ b/zeus-web/src/state/display-settings-store.ts
@@ -72,6 +72,7 @@ const STORAGE_KEY = 'zeus.display.dbRange';
 const TX_STORAGE_KEY = 'zeus.display.txDbRange';
 const WF_STORAGE_KEY = 'zeus.display.wfDbRange';
 const WF_TX_STORAGE_KEY = 'zeus.display.wfTxDbRange';
+const WF_CADENCE_STORAGE_KEY = 'zeus.display.wfRowCadence';
 
 // Legacy localStorage keys — pre-server-side storage. Read once on first
 // load to migrate the operator's existing image / colour up to the backend,
@@ -101,6 +102,36 @@ export type PanBackgroundMode = 'basic' | 'beam-map' | 'image';
 // 'fill' → cover (fills the panel, may crop)
 // 'stretch' → 100% 100% (distorts to fit exactly)
 export type BackgroundImageFit = 'fit' | 'fill' | 'stretch';
+
+// Number of server display frames per waterfall row upload. 1 = every
+// frame (~30 Hz), 2 = current balanced default (~15 Hz), 3 = lower CPU
+// scroll (~10 Hz). Shift/reset still run every frame so tuning remains
+// visually locked to the panadapter.
+export type WaterfallRowCadence = 1 | 2 | 3;
+export const DEFAULT_WF_ROW_CADENCE: WaterfallRowCadence = 2;
+
+function normalizeWaterfallRowCadence(raw: unknown): WaterfallRowCadence {
+  const n = typeof raw === 'number' ? raw : Number(raw);
+  return n === 1 || n === 2 || n === 3 ? n : DEFAULT_WF_ROW_CADENCE;
+}
+
+function readSavedWaterfallRowCadence(): WaterfallRowCadence {
+  try {
+    if (typeof localStorage === 'undefined') return DEFAULT_WF_ROW_CADENCE;
+    return normalizeWaterfallRowCadence(localStorage.getItem(WF_CADENCE_STORAGE_KEY));
+  } catch {
+    return DEFAULT_WF_ROW_CADENCE;
+  }
+}
+
+function writeSavedWaterfallRowCadence(value: WaterfallRowCadence): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(WF_CADENCE_STORAGE_KEY, String(value));
+  } catch {
+    // quota exceeded / private mode — accept silently.
+  }
+}
 
 function readLegacyRxTraceColor(): string | null {
   try {
@@ -280,6 +311,7 @@ export type DisplaySettingsState = {
   txDbMin: number;
   txDbMax: number;
   colormap: ColormapId;
+  waterfallRowCadence: WaterfallRowCadence;
   // Panadapter background overlay mode + (optional) user image. See the
   // PanBackgroundMode and BackgroundImageFit types above. Persisted on the
   // backend (zeus-prefs.db) so a single setting follows the operator across
@@ -302,6 +334,7 @@ export type DisplaySettingsState = {
   setRxTraceColor: (v: string) => Promise<void>;
   setAutoRange: (v: boolean) => void;
   setColormap: (id: ColormapId) => void;
+  setWaterfallRowCadence: (value: WaterfallRowCadence) => void;
   updateAutoRange: (wfDb: Float32Array) => void;
   // Shift dbMin and dbMax together by `deltaDb`. Used by the draggable dB
   // scale overlay on the panadapter with content-follows-finger semantics:
@@ -353,6 +386,7 @@ const initialRange = readSavedRange();
 const initialTxRange = readSavedTxRange();
 const initialWfRange = readSavedWfRange();
 const initialWfTxRange = readSavedWfTxRange();
+const initialWaterfallRowCadence = readSavedWaterfallRowCadence();
 
 export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) => ({
   autoRange: false,
@@ -365,6 +399,7 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
   txDbMin: initialTxRange.txDbMin,
   txDbMax: initialTxRange.txDbMax,
   colormap: 'blue',
+  waterfallRowCadence: initialWaterfallRowCadence,
   // Defaults until the server-side fetch lands (see hydrateFromServer at the
   // bottom of this file). The operator briefly sees a plain panadapter on
   // first paint instead of their saved image — acceptable trade-off for not
@@ -462,6 +497,11 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
     }
   },
   setColormap: (colormap) => set({ colormap }),
+  setWaterfallRowCadence: (value) => {
+    const next = normalizeWaterfallRowCadence(value);
+    set({ waterfallRowCadence: next });
+    writeSavedWaterfallRowCadence(next);
+  },
   shiftDbRange: (deltaDb) => {
     // While AUTO is on, the live dbMin/dbMax are EMA-smoothed band-tracking
     // outputs (often messy floats and a tighter span than the user's saved

--- a/zeus-web/src/state/display-store.ts
+++ b/zeus-web/src/state/display-store.ts
@@ -44,6 +44,9 @@
 
 import { create } from 'zustand';
 import type { DecodedFrame } from '../realtime/frame';
+import { maybeUpdateEstimator } from '../dsp/signal-estimator';
+
+const DISPLAY_INVALID_BIN_DB = -200;
 
 export type DisplayState = {
   connected: boolean;
@@ -59,6 +62,41 @@ export type DisplayState = {
   pushFrame: (f: DecodedFrame) => void;
 };
 
+export function sanitizeDisplayBins(bins: Float32Array): Float32Array {
+  let firstBad = -1;
+  for (let i = 0; i < bins.length; i++) {
+    if (!Number.isFinite(bins[i])) {
+      firstBad = i;
+      break;
+    }
+  }
+  if (firstBad < 0) return bins;
+
+  const sanitized = new Float32Array(bins);
+  for (let i = firstBad; i < sanitized.length; i++) {
+    if (!Number.isFinite(sanitized[i])) sanitized[i] = DISPLAY_INVALID_BIN_DB;
+  }
+  return sanitized;
+}
+
+function validFrameGeometry(width: number, hzPerPixel: number): boolean {
+  return (
+    Number.isInteger(width) &&
+    width > 0 &&
+    Number.isFinite(hzPerPixel) &&
+    hzPerPixel > 0
+  );
+}
+
+function validPayload(
+  enabled: boolean,
+  bins: Float32Array,
+  width: number,
+  geometryValid: boolean,
+): boolean {
+  return enabled && geometryValid && bins.length === width;
+}
+
 export const useDisplayStore = create<DisplayState>((set) => ({
   connected: false,
   width: 0,
@@ -70,17 +108,39 @@ export const useDisplayStore = create<DisplayState>((set) => ({
   wfValid: false,
   lastSeq: 0,
   setConnected: (connected) => set({ connected }),
-  pushFrame: (f) =>
+  pushFrame: (f) => {
+    const geometryValid = validFrameGeometry(f.width, f.hzPerPixel);
+    const width = geometryValid ? f.width : 0;
+    const hzPerPixel = geometryValid ? f.hzPerPixel : 0;
+    const panValid = validPayload(f.panValid, f.panDb, width, geometryValid);
+    const wfValid = validPayload(f.wfValid, f.wfDb, width, geometryValid);
+    const panDb = panValid ? sanitizeDisplayBins(f.panDb) : f.panDb;
+    const wfDb = wfValid ? sanitizeDisplayBins(f.wfDb) : f.wfDb;
+    const cleanFrame =
+      panDb === f.panDb &&
+      wfDb === f.wfDb &&
+      panValid === f.panValid &&
+      wfValid === f.wfValid &&
+      width === f.width &&
+      hzPerPixel === f.hzPerPixel
+      ? f
+      : { ...f, width, hzPerPixel, panValid, wfValid, panDb, wfDb };
+
+    // Advance the shared noise-floor tracker BEFORE notifying subscribers, so
+    // the panadapter/waterfall enhance this frame against this frame's floor.
+    // No-op (zero cost) unless Signal Pop or Snap is enabled.
+    maybeUpdateEstimator(cleanFrame);
     set({
-      width: f.width,
-      centerHz: f.centerHz,
-      hzPerPixel: f.hzPerPixel,
-      panDb: f.panDb,
-      wfDb: f.wfDb,
-      panValid: f.panValid,
-      wfValid: f.wfValid,
-      lastSeq: f.seq,
-    }),
+      width: cleanFrame.width,
+      centerHz: cleanFrame.centerHz,
+      hzPerPixel: cleanFrame.hzPerPixel,
+      panDb: cleanFrame.panValid ? cleanFrame.panDb : null,
+      wfDb: cleanFrame.wfValid ? cleanFrame.wfDb : null,
+      panValid: cleanFrame.panValid,
+      wfValid: cleanFrame.wfValid,
+      lastSeq: cleanFrame.seq,
+    });
+  },
 }));
 
 export function subscribeFrames(cb: (s: DisplayState) => void): () => void {

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -2698,3 +2698,86 @@
   white-space: pre-wrap;
   word-break: break-word;
 }
+
+/* ===== Signal Pop display-enhance surface =====
+   Opt-in (snap/pop) RX visualisation. The .pop-enhanced class is set by
+   Panadapter/Waterfall only while Pop is engaged and not keyed; base
+   .spectrum-canvas / .waterfall-canvas rules above are untouched. The
+   --pop-intensity custom property (0..1) is written inline by the component
+   from the operator's render-intensity slider. */
+.spectrum-canvas,
+.waterfall-canvas {
+  --pop-surface-bg:
+    radial-gradient(ellipse at 50% 0%, rgba(0, 206, 255, 0.12), transparent 52%),
+    linear-gradient(180deg, #071016 0%, #020304 100%);
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+}
+.spectrum-canvas > canvas,
+.waterfall-canvas > canvas {
+  position: relative;
+  z-index: 0;
+}
+.spectrum-canvas.pop-enhanced,
+.waterfall-canvas.pop-enhanced {
+  background: var(--pop-surface-bg);
+}
+.spectrum-canvas.pop-enhanced::before,
+.waterfall-canvas.pop-enhanced::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+  background:
+    linear-gradient(90deg, rgba(95, 226, 255, 0.11) 0 1px, transparent 1px 100%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.055) 0 1px, transparent 1px 100%),
+    linear-gradient(180deg, transparent 0 48%, rgba(255, 255, 255, 0.045) 50%, transparent 52% 100%);
+  background-size: 72px 100%, 100% 28px, 100% 6px;
+  opacity: calc(0.08 + var(--pop-intensity, 1) * 0.24);
+  mix-blend-mode: screen;
+}
+.waterfall-canvas.pop-enhanced::before {
+  background-size: 64px 100%, 100% 24px, 100% 5px;
+  opacity: calc(0.06 + var(--pop-intensity, 1) * 0.18);
+}
+.spectrum-canvas.pop-enhanced::after,
+.waterfall-canvas.pop-enhanced::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 2;
+  box-shadow:
+    inset 0 0 0 1px rgba(96, 226, 255, 0.18),
+    inset 0 18px 28px rgba(0, 214, 255, 0.08),
+    inset 0 -20px 36px rgba(0, 0, 0, 0.58);
+}
+
+/* Draggable divider between the panadapter and waterfall rows of the
+   spectrum stack. Sits in its own grid row so it never overlaps either
+   canvas; a centred grip line gives it visible affordance. */
+.spectrum-splitter {
+  position: relative;
+  z-index: 6;
+  cursor: row-resize;
+  touch-action: none;
+  background: transparent;
+}
+.spectrum-splitter::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  height: 1px;
+  transform: translateY(-50%);
+  background: var(--line);
+  transition: background 120ms ease, height 120ms ease;
+}
+.spectrum-splitter:hover::before,
+.spectrum-splitter.dragging::before {
+  height: 3px;
+  background: var(--accent);
+}

--- a/zeus-web/src/util/number.ts
+++ b/zeus-web/src/util/number.ts
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+export function clampFinite(value: unknown, min: number, max: number, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.max(min, Math.min(max, value))
+    : fallback;
+}

--- a/zeus-web/src/util/snap-lock.test.ts
+++ b/zeus-web/src/util/snap-lock.test.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License v2 or later. See the
+// LICENSE file at the repository root, or https://www.gnu.org/licenses/.
+
+import { describe, expect, it } from 'vitest';
+import type { SnapLockMeasure } from '../dsp/signal-estimator';
+import { snapLockStep, type SnapLockCfg, type SnapLockState } from './snap-lock';
+
+const CFG: SnapLockCfg = { maxDriftHz: 500, deadbandHz: 40, maxStepHz: 80, releaseMissFrames: 25 };
+
+function lockedAt(hz: number): SnapLockState {
+  return { dialHz: hz, bodyHz: hz, originDialHz: hz, originBodyHz: hz, missFrames: 0 };
+}
+
+// snapLockStep ignores levelDb (the identity gate lives in measureSnapLock); a
+// placeholder keeps these decision-core cases readable.
+function meas(dialHz: number, bodyHz: number): SnapLockMeasure {
+  return { dialHz, bodyHz, levelDb: -80 };
+}
+
+describe('snapLockStep — self-correcting decision core', () => {
+  it('does nothing inside the deadband (no chatter)', () => {
+    const r = snapLockStep(lockedAt(1000), meas(1020, 1020), CFG);
+    expect(r.commitHz).toBeNull(); // 20 Hz < 40 Hz deadband
+    expect(r.dialHz).toBe(1000);
+    expect(r.release).toBe(false);
+    expect(r.bodyHz).toBe(1020); // body still tracked silently
+  });
+
+  it('corrects past the deadband but clamps the per-frame step', () => {
+    const r = snapLockStep(lockedAt(1000), meas(1300, 1300), CFG);
+    // err 300 → clamped to +80; the dial creeps, never lurches.
+    expect(r.dialHz).toBe(1080);
+    expect(r.commitHz).toBe(1080);
+  });
+
+  it('clamps the target to ±maxDrift of the snap point (can never reach a far neighbour)', () => {
+    // A measurement 1 kHz away (e.g. a momentary mis-measure toward a neighbour)
+    // is clamped to origin+500 before the step is even taken.
+    const r = snapLockStep(lockedAt(1000), meas(2000, 2000), CFG);
+    expect(r.dialHz).toBe(1080); // still only +80 this frame, toward the 1500 cap
+    expect(r.bodyHz).toBe(1500); // body anchor clamped to origin+maxDrift
+  });
+
+  it('counts a miss when the signal is gone, holding the dial', () => {
+    const r = snapLockStep(lockedAt(1000), null, CFG);
+    expect(r.missFrames).toBe(1);
+    expect(r.commitHz).toBeNull();
+    expect(r.dialHz).toBe(1000); // held, not moved
+    expect(r.release).toBe(false);
+  });
+
+  it('releases after too many consecutive misses', () => {
+    const r = snapLockStep({ ...lockedAt(1000), missFrames: 24 }, null, CFG);
+    expect(r.missFrames).toBe(25);
+    expect(r.release).toBe(true);
+  });
+
+  it('a fresh measurement resets the miss counter', () => {
+    const r = snapLockStep({ ...lockedAt(1000), missFrames: 10 }, meas(1005, 1005), CFG);
+    expect(r.missFrames).toBe(0);
+  });
+});

--- a/zeus-web/src/util/snap-lock.ts
+++ b/zeus-web/src/util/snap-lock.ts
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+// Self-correcting snap lock ("stay tuned"). After a snap-to-signal click, this
+// singleton keeps the dial aligned to THAT signal as it drifts — re-measuring
+// it every display frame and nudging the dial back onto its mode-tuning edge.
+//
+// The load-bearing design constraint (operator's words): "don't get confused
+// with signals that are close to a weak signal we are trying to pull in." So the
+// tracker never re-acquires "the nearest/strongest signal." It follows the ONE
+// signal it locked, inside a capture window far narrower than the spacing to any
+// neighbour (measureSnapLock), and clamps how far the anchor and dial may ever
+// roam from the snap point. A louder neighbour OUTSIDE that window can never
+// pull the dial; if the locked signal fades, the tracker HOLDS, then releases —
+// it never jumps to whatever else is on the band.
+//
+// Everything here is gated behind Snap being on, an armed lock, RX (never during
+// MOX/TUN), and an unchanged mode — and it disengages the instant the operator
+// tunes by hand. Corrections are deadbanded, rate-limited, and step-limited, so
+// the dial creeps rather than chases. Snap is display/UX surface — the engage
+// model and these constants are the maintainer's call (CLAUDE.md).
+
+import { setVfo } from '../api/client';
+import { useConnectionStore } from '../state/connection-store';
+import { type DisplayState, registerFrameConsumer, subscribeFrames } from '../state/display-store';
+import { measureSnapLock, type SnapLockMeasure, useSignalEnhanceStore } from '../dsp/signal-estimator';
+import { useTxStore } from '../state/tx-store';
+import * as viewCenter from '../state/view-center';
+
+// Capture window for re-finding the locked signal each frame. Must stay well
+// under the spacing to the neighbour you're trying not to grab.
+const SNAP_LOCK_CAPTURE_HZ = 300;
+// Hard bound on how far the dial/anchor may roam from the snap point — the
+// ultimate "can't walk to the neighbour" guard, independent of the window.
+const SNAP_LOCK_MAX_DRIFT_HZ = 500;
+// Misalignment below this is ignored (no retune) — kills frame-to-frame chatter
+// as the estimated edge breathes with the noise floor.
+const SNAP_LOCK_DEADBAND_HZ = 40;
+// Largest single correction, so the dial creeps onto the signal and can never
+// lurch across a gap to an adjacent carrier.
+const SNAP_LOCK_MAX_STEP_HZ = 80;
+// Minimum spacing between committed retunes.
+const SNAP_LOCK_COMMIT_INTERVAL_MS = 250;
+// Consecutive frames with the locked signal in the noise before we let go.
+const SNAP_LOCK_RELEASE_MISS_FRAMES = 25;
+// A vfo change larger than this that the tracker didn't command = the operator
+// (or another control) tuned → release. Above a fine-tune step, below a band hop.
+const SNAP_LOCK_MANUAL_EPS_HZ = 60;
+// Smoothing for the tracked signal level fed to measureSnapLock's identity gate.
+// Slow enough to ride out QSB without chasing a single-frame neighbour spike.
+const SNAP_LOCK_LEVEL_EMA = 0.25;
+
+export type SnapLockState = {
+  dialHz: number;
+  bodyHz: number;
+  originDialHz: number;
+  originBodyHz: number;
+  missFrames: number;
+};
+
+export type SnapLockCfg = {
+  maxDriftHz: number;
+  deadbandHz: number;
+  maxStepHz: number;
+  releaseMissFrames: number;
+};
+
+export type SnapLockStepResult = {
+  dialHz: number;
+  bodyHz: number;
+  missFrames: number;
+  /** Dial to retune to this frame, or null to hold (deadband / rate-limited / miss). */
+  commitHz: number | null;
+  /** True when the lock should be dropped (signal gone too long). */
+  release: boolean;
+};
+
+const DEFAULT_CFG: SnapLockCfg = {
+  maxDriftHz: SNAP_LOCK_MAX_DRIFT_HZ,
+  deadbandHz: SNAP_LOCK_DEADBAND_HZ,
+  maxStepHz: SNAP_LOCK_MAX_STEP_HZ,
+  releaseMissFrames: SNAP_LOCK_RELEASE_MISS_FRAMES,
+};
+
+function clamp(v: number, lo: number, hi: number): number {
+  return v < lo ? lo : v > hi ? hi : v;
+}
+
+/** Pure decision core for one tracker frame. Given the lock state and this
+ *  frame's measurement (or null when the signal wasn't found in the capture
+ *  window), decide the next anchor, whether to retune, and whether to release.
+ *  Side-effect free so the neighbour-safety guarantees are unit-testable. */
+export function snapLockStep(
+  state: SnapLockState,
+  measure: SnapLockMeasure | null,
+  cfg: SnapLockCfg = DEFAULT_CFG,
+): SnapLockStepResult {
+  if (measure === null) {
+    const missFrames = state.missFrames + 1;
+    return {
+      dialHz: state.dialHz,
+      bodyHz: state.bodyHz,
+      missFrames,
+      commitHz: null,
+      release: missFrames >= cfg.releaseMissFrames,
+    };
+  }
+
+  // Clamp the tracked anchor and target to ±maxDrift of the snap point so the
+  // window can never creep onto a neighbour even over many frames.
+  const bodyHz = clamp(measure.bodyHz, state.originBodyHz - cfg.maxDriftHz, state.originBodyHz + cfg.maxDriftHz);
+  const target = clamp(measure.dialHz, state.originDialHz - cfg.maxDriftHz, state.originDialHz + cfg.maxDriftHz);
+  const err = target - state.dialHz;
+  if (Math.abs(err) < cfg.deadbandHz) {
+    // Aligned enough — track the body silently, leave the dial put.
+    return { dialHz: state.dialHz, bodyHz, missFrames: 0, commitHz: null, release: false };
+  }
+  const step = clamp(err, -cfg.maxStepHz, cfg.maxStepHz);
+  const dialHz = state.dialHz + step;
+  return { dialHz, bodyHz, missFrames: 0, commitHz: dialHz, release: false };
+}
+
+// ── Singleton controller ─────────────────────────────────────────────────────
+
+let active = false;
+let dialHz = 0;
+let bodyHz = 0;
+let originDialHz = 0;
+let originBodyHz = 0;
+let anchorLevelDb: number | undefined;
+let missFrames = 0;
+let commandedHz = 0;
+let lastCommitMs = 0;
+let lockMode = useConnectionStore.getState().mode;
+let unsubFrames: (() => void) | null = null;
+let unsubVfo: (() => void) | null = null;
+let releaseFrameConsumer: (() => void) | null = null;
+
+function now(): number {
+  return typeof performance !== 'undefined' ? performance.now() : 0;
+}
+
+/** True while a self-correcting lock is engaged. */
+export function isSnapLocked(): boolean {
+  return active;
+}
+
+/** Drop the lock and stop tracking. Leaves the dial exactly where it is — it
+ *  never re-tunes on release. Idempotent. */
+export function releaseSnapLock(): void {
+  if (!active) return;
+  active = false;
+  unsubFrames?.();
+  unsubFrames = null;
+  unsubVfo?.();
+  unsubVfo = null;
+  releaseFrameConsumer?.();
+  releaseFrameConsumer = null;
+}
+
+/** Engage (or re-point) the lock onto the signal a snap just tuned. `dialHz` is
+ *  the committed dial; `anchorBodyHz` is a frequency inside the signal (the
+ *  click point is ideal — it sits on the signal body). No-op unless Snap is on. */
+export function armSnapLock(p: { dialHz: number; anchorBodyHz: number; mode: ReturnType<typeof useConnectionStore.getState>['mode'] }): void {
+  if (!useSignalEnhanceStore.getState().snapEnabled) return;
+  dialHz = p.dialHz;
+  originDialHz = p.dialHz;
+  bodyHz = p.anchorBodyHz;
+  originBodyHz = p.anchorBodyHz;
+  anchorLevelDb = undefined; // seeded from the first good measurement
+  lockMode = p.mode;
+  missFrames = 0;
+  commandedHz = p.dialHz;
+  lastCommitMs = now();
+  if (!active) {
+    active = true;
+    releaseFrameConsumer = registerFrameConsumer();
+    unsubFrames = subscribeFrames(onFrame);
+    unsubVfo = useConnectionStore.subscribe(onVfoMaybeManual);
+  }
+}
+
+function applyTune(hz: number): void {
+  const conn = useConnectionStore.getState();
+  const prevVfo = conn.vfoHz;
+  // Mirror the click-tune commit: nudge the view-centre target by the delta so
+  // the dial stays put and the display follows. Record the commanded value
+  // BEFORE the store write so the manual-override watcher sees our own change
+  // as a match.
+  viewCenter.nudgeTargetHz(hz - prevVfo);
+  commandedHz = hz;
+  useConnectionStore.setState({ vfoHz: hz });
+  setVfo(hz).catch(() => {});
+}
+
+function onFrame(s: DisplayState): void {
+  if (!active) return;
+  if (!useSignalEnhanceStore.getState().snapEnabled) {
+    releaseSnapLock();
+    return;
+  }
+  const tx = useTxStore.getState();
+  if (tx.moxOn || tx.tunOn) {
+    releaseSnapLock(); // never auto-tune during TX
+    return;
+  }
+  const conn = useConnectionStore.getState();
+  if (conn.status !== 'Connected' || conn.mode !== lockMode) {
+    releaseSnapLock();
+    return;
+  }
+  if (!s.panValid || !s.panDb || s.hzPerPixel <= 0) return;
+
+  const measure = measureSnapLock(
+    s.panDb,
+    Number(s.centerHz),
+    s.hzPerPixel,
+    lockMode,
+    bodyHz,
+    SNAP_LOCK_CAPTURE_HZ,
+    anchorLevelDb,
+  );
+  if (measure) {
+    // Track the locked signal's level so the identity gate can tell it apart
+    // from a louder neighbour drifting into the window. Seed on first sight,
+    // then ride QSB slowly.
+    anchorLevelDb =
+      anchorLevelDb === undefined
+        ? measure.levelDb
+        : anchorLevelDb + SNAP_LOCK_LEVEL_EMA * (measure.levelDb - anchorLevelDb);
+  }
+  const res = snapLockStep({ dialHz, bodyHz, originDialHz, originBodyHz, missFrames }, measure);
+  missFrames = res.missFrames;
+  bodyHz = res.bodyHz;
+  if (res.release) {
+    releaseSnapLock();
+    return;
+  }
+  if (res.commitHz !== null && now() - lastCommitMs >= SNAP_LOCK_COMMIT_INTERVAL_MS) {
+    applyTune(res.commitHz);
+    dialHz = res.commitHz;
+    lastCommitMs = now();
+  }
+}
+
+function onVfoMaybeManual(s: { vfoHz: number }, prev: { vfoHz: number }): void {
+  if (!active) return;
+  if (s.vfoHz === prev.vfoHz) return;
+  // A vfo move we didn't command = operator/keyboard/band/typed tune → let go.
+  if (Math.abs(s.vfoHz - commandedHz) > SNAP_LOCK_MANUAL_EPS_HZ) releaseSnapLock();
+}
+
+/** Test-only: reset all controller state without touching subscriptions. */
+export function _resetSnapLockForTest(): void {
+  releaseSnapLock();
+  dialHz = bodyHz = originDialHz = originBodyHz = missFrames = commandedHz = lastCommitMs = 0;
+  anchorLevelDb = undefined;
+}

--- a/zeus-web/src/util/use-pan-tune-gesture.ts
+++ b/zeus-web/src/util/use-pan-tune-gesture.ts
@@ -46,6 +46,8 @@ import { createContext, useContext, useEffect, type RefObject } from 'react';
 import { setVfo, setZoom, ZOOM_MAX, ZOOM_MIN, type ZoomLevel } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
 import { useDisplayStore } from '../state/display-store';
+import { computeSnapToLineHz, getSnapHistorySpectrum, useSignalEnhanceStore } from '../dsp/signal-estimator';
+import { armSnapLock } from './snap-lock';
 import * as viewCenter from '../state/view-center';
 import { useToolbarFavoritesStore } from '../state/toolbar-favorites-store';
 
@@ -55,6 +57,11 @@ const CLICK_SLOP_PX = 3;
 // and band presets bypass it. Ham-friendly default; becomes user-settable
 // once the UX exists.
 const PAN_STEP_HZ = 500;
+// Snap-to-signal reach: a click in snap mode grabs the nearest signal whose
+// mode-aware tuning edge sits within this many screen pixels of the cursor
+// (converted to Hz at the live scale). Past it, the click tunes normally — so
+// clicking empty spectrum still lands where you clicked.
+const SNAP_RADIUS_PX = 80;
 // Wheel tune step now follows the operator's TuningStepWidget choice
 // (toolbar-favorites-store.stepHz). Read at event time inside the wheel
 // handler so the latest value applies on every notch. Arrow-key tuning
@@ -181,8 +188,10 @@ export function usePanTuneGesture(
       if (pendingRaf === 0) pendingRaf = requestAnimationFrame(flushPending);
     };
 
-    const commitFinal = (hz: number) => {
-      const snapped = snapHz(hz);
+    // `exact` skips the PAN_STEP_HZ grid — used by snap-to-signal so the dial
+    // lands on the measured carrier, not the nearest round 500 Hz.
+    const commitFinal = (hz: number, exact = false) => {
+      const snapped = exact ? clampHz(hz) : snapHz(hz);
       // Delta against the commanded chain — NOT an absolute write into the
       // view-center (frame centers are dial ∓ cw-pitch in CW; absolutes
       // would oscillate the display by ±pitch on every CW commit).
@@ -383,7 +392,61 @@ export function usePanTuneGesture(
         const view = readView();
         if (!view) return;
         const frac = (e.clientX - rect.left) / rect.width;
-        commitFinal(view.centerHz + (frac - 0.5) * view.spanHz);
+        const clickHz = view.centerHz + (frac - 0.5) * view.spanHz;
+        // Snap-to-signal: when enabled, a click FAVOURS THE LINE UNDER THE
+        // CURSOR — it scans the visible spectrum near the click and tunes to
+        // whichever signal has its mode-aware edge closest to where you clicked
+        // (USB low edge, LSB high edge, CW zero-beat, AM centroid). So the click
+        // locks onto the nearest signal, edge-aligned for the mode, while still
+        // honouring where you clicked. If the live frame has nothing near the
+        // click, fall back to the waterfall memory (recently-seen, now-faded
+        // signals); only if THAT is empty too does the click tune normally.
+        const enhance = useSignalEnhanceStore.getState();
+        if (enhance.snapEnabled) {
+          const ds = useDisplayStore.getState();
+          if (ds.panDb && ds.hzPerPixel > 0 && rect.width > 0) {
+            // Zoom-consistent grab distance with an operator/profile cap: the
+            // pixel reach keeps snap feel stable while Snap Radius stops a
+            // zoomed-out click from grabbing across too much spectrum.
+            const maxRadiusHz = Math.min(ds.hzPerPixel * SNAP_RADIUS_PX, enhance.snapRadiusHz);
+            const mode = useConnectionStore.getState().mode;
+            const centerHz = Number(ds.centerHz);
+            let tuneHz = computeSnapToLineHz(
+              ds.panDb,
+              centerHz,
+              ds.hzPerPixel,
+              mode,
+              clickHz,
+              maxRadiusHz,
+            );
+            // Only a LIVE signal can be tracked frame-to-frame; a waterfall-memory
+            // hit is by definition not on screen right now, so it tunes once but
+            // does not arm the self-correcting lock.
+            const fromLive = tuneHz != null;
+            if (tuneHz == null) {
+              // Nothing live near the click — consult the waterfall memory.
+              const history = getSnapHistorySpectrum();
+              if (history) {
+                tuneHz = computeSnapToLineHz(history, centerHz, ds.hzPerPixel, mode, clickHz, maxRadiusHz);
+              }
+            }
+            if (tuneHz != null) {
+              // Quantise to the operator's configured tuning step. The raw
+              // signal edge/peak shifts by tens of Hz frame-to-frame as the
+              // noise floor breathes; landing on the nearest step gives a
+              // stable, clean dial instead of a jittery sub-Hz frequency.
+              const step = useToolbarFavoritesStore.getState().stepHz;
+              const stepped = step > 0 ? Math.round(tuneHz / step) * step : tuneHz;
+              commitFinal(stepped, true);
+              // Engage the self-correcting lock so the dial follows this signal as
+              // it drifts. clickHz sits inside the signal body — the tracker's
+              // anchor. Disengages itself on manual tune / mode change / signal loss.
+              if (fromLive) armSnapLock({ dialHz: stepped, anchorBodyHz: clickHz, mode });
+              return;
+            }
+          }
+        }
+        commitFinal(clickHz);
       }
     };
 

--- a/zeus-web/src/util/use-ruler-pan-gesture.test.ts
+++ b/zeus-web/src/util/use-ruler-pan-gesture.test.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, expect, it } from 'vitest';
+import { rulerDragTargetHz } from './use-ruler-pan-gesture';
+
+describe('rulerDragTargetHz', () => {
+  it('moves content with the grab direction', () => {
+    expect(rulerDragTargetHz(28_000_000, 500, 600, 1000, 100_000)).toBe(27_990_000);
+    expect(rulerDragTargetHz(28_000_000, 500, 400, 1000, 100_000)).toBe(28_010_000);
+  });
+
+  it('can pan by more than the visible span', () => {
+    expect(rulerDragTargetHz(28_000_000, 500, 1700, 1000, 100_000)).toBe(27_880_000);
+    expect(rulerDragTargetHz(28_000_000, 500, -700, 1000, 100_000)).toBe(28_120_000);
+  });
+
+  it('clamps to the supported radio range', () => {
+    expect(rulerDragTargetHz(1000, 0, 100, 100, 10_000)).toBe(0);
+    expect(rulerDragTargetHz(59_999_000, 100, 0, 100, 10_000)).toBe(60_000_000);
+  });
+});

--- a/zeus-web/src/util/use-ruler-pan-gesture.ts
+++ b/zeus-web/src/util/use-ruler-pan-gesture.ts
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+import { useEffect, type RefObject } from 'react';
+import { setRadioLo } from '../api/client';
+import { useConnectionStore } from '../state/connection-store';
+import { useDisplayStore } from '../state/display-store';
+import * as viewCenter from '../state/view-center';
+
+const MAX_HZ = 60_000_000;
+const CLICK_SLOP_PX = 3;
+
+function clampHz(hz: number): number {
+  if (!Number.isFinite(hz)) return 0;
+  return Math.min(MAX_HZ, Math.max(0, Math.round(hz)));
+}
+
+export function rulerDragTargetHz(
+  startCenterHz: number,
+  startX: number,
+  currentX: number,
+  widthPx: number,
+  spanHz: number,
+): number {
+  if (!Number.isFinite(widthPx) || widthPx <= 0 || !Number.isFinite(spanHz) || spanHz <= 0) {
+    return clampHz(startCenterHz);
+  }
+  return clampHz(startCenterHz - ((currentX - startX) / widthPx) * spanHz);
+}
+
+function readViewport(): { centerHz: number; spanHz: number } | null {
+  const s = useDisplayStore.getState();
+  const width = s.width || s.panDb?.length || 0;
+  if (!width || s.hzPerPixel <= 0) return null;
+  return {
+    centerHz: viewCenter.isInitialized()
+      ? viewCenter.getTargetCenterHz()
+      : Number(s.centerHz),
+    spanHz: width * s.hzPerPixel,
+  };
+}
+
+export function useRulerPanGesture(
+  ref: RefObject<HTMLElement | null>,
+  active = true,
+) {
+  useEffect(() => {
+    if (!active) return;
+    const el = ref.current;
+    if (!el) return;
+
+    type Drag = {
+      pointerId: number;
+      startX: number;
+      startCenterHz: number;
+      spanHz: number;
+      moved: boolean;
+    };
+
+    let drag: Drag | null = null;
+    let pendingLoHz: number | null = null;
+    let pendingRaf = 0;
+    let pendingAbort: AbortController | null = null;
+
+    const commandedLoHz = () =>
+      pendingLoHz ?? (viewCenter.isInitialized()
+        ? viewCenter.getTargetCenterHz()
+        : Number(useDisplayStore.getState().centerHz));
+
+    const reconcileAppliedLo = (appliedLoHz: number) => {
+      const next = clampHz(appliedLoHz);
+      useConnectionStore.setState({ radioLoHz: next });
+      if (pendingLoHz !== null) return;
+      const delta = next - commandedLoHz();
+      if (delta !== 0) viewCenter.nudgeTargetHz(delta);
+    };
+
+    const flushPending = () => {
+      pendingRaf = 0;
+      const loHz = pendingLoHz;
+      pendingLoHz = null;
+      if (loHz == null) return;
+
+      viewCenter.markOptimisticTune();
+      useConnectionStore.setState({ radioLoHz: loHz });
+      pendingAbort?.abort();
+      const ctrl = new AbortController();
+      pendingAbort = ctrl;
+      setRadioLo(loHz, ctrl.signal)
+        .then((state) => {
+          if (ctrl.signal.aborted) return;
+          useConnectionStore.getState().applyState(state, { trustVfo: false });
+          reconcileAppliedLo(state.radioLoHz);
+        })
+        .catch(() => {});
+    };
+
+    const scheduleFlush = () => {
+      if (pendingRaf === 0) pendingRaf = requestAnimationFrame(flushPending);
+    };
+
+    const queueLo = (nextLoHz: number) => {
+      const loHz = clampHz(nextLoHz);
+      if (loHz === pendingLoHz) return;
+      viewCenter.nudgeTargetHz(loHz - commandedLoHz());
+      useConnectionStore.setState({ radioLoHz: loHz });
+      pendingLoHz = loHz;
+      scheduleFlush();
+    };
+
+    const onPointerDown = (e: PointerEvent) => {
+      if (e.button !== 0) return;
+      const view = readViewport();
+      if (!view) return;
+      e.preventDefault();
+      try { el.setPointerCapture(e.pointerId); } catch { /* ok */ }
+      drag = {
+        pointerId: e.pointerId,
+        startX: e.clientX,
+        startCenterHz: view.centerHz,
+        spanHz: view.spanHz,
+        moved: false,
+      };
+      el.style.cursor = 'grabbing';
+    };
+
+    const onPointerMove = (e: PointerEvent) => {
+      const d = drag;
+      if (!d || e.pointerId !== d.pointerId) return;
+      const dx = e.clientX - d.startX;
+      if (!d.moved && Math.abs(dx) <= CLICK_SLOP_PX) return;
+      d.moved = true;
+      const rect = el.getBoundingClientRect();
+      queueLo(rulerDragTargetHz(d.startCenterHz, d.startX, e.clientX, rect.width, d.spanHz));
+    };
+
+    const onPointerUp = (e: PointerEvent) => {
+      const d = drag;
+      if (!d || e.pointerId !== d.pointerId) return;
+      drag = null;
+      el.style.cursor = 'grab';
+      try { el.releasePointerCapture(e.pointerId); } catch { /* ok */ }
+      if (!d.moved) return;
+      const rect = el.getBoundingClientRect();
+      queueLo(rulerDragTargetHz(d.startCenterHz, d.startX, e.clientX, rect.width, d.spanHz));
+      if (pendingRaf !== 0) {
+        cancelAnimationFrame(pendingRaf);
+        flushPending();
+      }
+    };
+
+    el.style.cursor = 'grab';
+    el.addEventListener('pointerdown', onPointerDown);
+    el.addEventListener('pointermove', onPointerMove);
+    el.addEventListener('pointerup', onPointerUp);
+    el.addEventListener('pointercancel', onPointerUp);
+
+    return () => {
+      if (pendingRaf !== 0) cancelAnimationFrame(pendingRaf);
+      pendingAbort?.abort();
+      el.removeEventListener('pointerdown', onPointerDown);
+      el.removeEventListener('pointermove', onPointerMove);
+      el.removeEventListener('pointerup', onPointerUp);
+      el.removeEventListener('pointercancel', onPointerUp);
+    };
+  }, [ref, active]);
+}


### PR DESCRIPTION
## Christiano's panadapter / waterfall display work — extracted clean, his AGC/AF left out

Brings **Christian Suarez (N9WAR / @iamexemplar)**'s panadapter + waterfall display cluster onto develop, **without** the over-sensitive AGC/AF or any of his other rejected work. Frontend-only (zero `.cs`) — the TX/PS path is untouched.

### Features (all 4 requested)
1. **Signal Pop / snap-to-signal / peak markers** — CFAR noise-floor estimator, snap-lock, peak-marker overlay, GL "pop" shader + colormap.
2. **Ruler-drag LO pan** — drag the frequency axis to pan (reuses develop's existing `/api/radio/lo`).
3. **Resizable panadapter/waterfall split** — draggable divider to **adjust waterfall height**, persisted.
4. **Waterfall colormap picker + scroll-cadence control + renderer-fallback hardening.**

### How it was done (not a raw cherry-pick)
His display commits were layered on top of *excluded* mixed commits (smart-NR, notch-store, VST, TX-fidelity), and snap-to-signal even imported the excluded notch-store — so a `cherry-pick` stack was impossible. Instead this is **4 hand-assembled commits, each authored to Christian Suarez** (KB2UKA committer + Co-Authored-By, originating SHAs in each body for provenance). The notch-painting branch was surgically stripped from the snap gesture; the CTUN coupling was dropped (develop has no frontend CTUN).

### Excluded (verified absent from the diff)
AGC/AF/auto-AGC, adaptive squelch, Smart-NR + notch-store, filter rework (FilterMiniPan/WindowedSincKernel), TX-fidelity, VST, spots, HamClock, CTUN click-tune, diagnostics bloat. (The "Visual AGC" in `signal-estimator.ts` is display-brightness normalization, **not** the audio AGC loop.)

### Verification (independently re-run)
- Frontend-only: **32 files, 0 `.cs`** → TX/PS path untouched.
- **Zero leakage** — diff grep for AGC/notch/filter/VST/spots/HamClock/CTUN is empty.
- **tsc -b + vite clean; 353/353 vitest; 726 server tests green.**
- **#629** waterfall context-loss fix and **#597** smooth-tuning preserved.
- All 4 commits authored `Christian Suarez (N9WAR) <christiantsuarez@gmail.com>`.

🚫 Draft — only @Kb2uka merges. Bench-test on the G2 first (waterfall height, colormap, ruler-drag, snap/pop).
