### PR TITLE
feat(hamclock): Christiano's installable live-embed HamClock panel (parity)

### DIFF
--- a/OpenhpsdrZeus/Program.cs
+++ b/OpenhpsdrZeus/Program.cs
@@ -343,11 +343,15 @@ public partial class Program
                 path = UniquePath(path);
 
                 await File.WriteAllBytesAsync(path, bytes).ConfigureAwait(false);
-                w.SendNotification("Download complete", path);
+                // Do NOT call any Photino native UI here (SendNotification etc.):
+                // it must run on the Cocoa main thread and throws an uncaught
+                // NSException off it, which a managed try/catch CANNOT catch — it
+                // terminates the whole process. The file is in ~/Downloads; just log.
+                Console.WriteLine($"[download] saved to {path}");
             }
             catch (Exception ex)
             {
-                w.SendNotification("Download failed", ex.Message);
+                Console.Error.WriteLine($"[download] failed for {url}: {ex.Message}");
             }
         });
     }

--- a/OpenhpsdrZeus/Program.cs
+++ b/OpenhpsdrZeus/Program.cs
@@ -258,6 +258,16 @@ public partial class Program
             .SetSize(InitialWidth, InitialHeight)
             .Center()
             .SetIconFile(iconPath)
+            // Desktop downloads: the embedded webview (macOS WKWebView via Photino,
+            // WebView2 on Windows) has no download delegate Photino exposes, so an
+            // attachment navigation from the HamClock iframe (e.g. its Rig Bridge
+            // installer scripts) is silently dropped. The HamClock HTML is patched
+            // (ZEUS_DL_BRIDGE) to forward such download URLs to the SPA shell, which
+            // relays them here as "download:<url>". We fetch the bytes server-side
+            // (the URL is a loopback sidecar endpoint, reachable by HttpClient) and
+            // save them to the OS Downloads folder, then notify. Coexists with the
+            // existing "stop" message path.
+            .RegisterWebMessageReceivedHandler((sender, msg) => HandleDesktopWebMessage(sender, msg))
             .Load(new Uri(startUrl));
 
         // Translate Ctrl-C into a window close so `dotnet run` (and the installer's
@@ -281,6 +291,80 @@ public partial class Program
         Console.WriteLine("Window closed; stopping backend.");
         app.StopAsync().GetAwaiter().GetResult();
         return 0;
+    }
+
+    // Shared HttpClient for desktop downloads — loopback fetches of attachment
+    // URLs the embedded webview won't download on its own. One instance for the
+    // process lifetime (the standard guidance).
+    private static readonly System.Net.Http.HttpClient DownloadHttp = new();
+
+    /// <summary>
+    /// Handle web messages from the Photino desktop shell. Two shapes:
+    ///   "stop"            — close the window (mirrors RunServerWithStatus).
+    ///   "download:<url>"  — fetch the URL and save it to the Downloads folder.
+    /// The download path exists because the embedded webview drops attachment
+    /// downloads (no Photino download delegate); the HamClock HTML is patched to
+    /// forward such URLs here. Fire-and-forget so the message loop isn't blocked.
+    /// </summary>
+    private static void HandleDesktopWebMessage(object? sender, string msg)
+    {
+        if (sender is not PhotinoWindow w) return;
+        if (msg == "stop") { w.Close(); return; }
+        if (!msg.StartsWith("download:", StringComparison.Ordinal)) return;
+
+        var url = msg["download:".Length..];
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                using var resp = await DownloadHttp.GetAsync(url).ConfigureAwait(false);
+                resp.EnsureSuccessStatusCode();
+                var bytes = await resp.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+
+                // Prefer the server-advertised filename; fall back to the URL tail.
+                var cd = resp.Content.Headers.ContentDisposition;
+                var name = cd?.FileNameStar ?? cd?.FileName?.Trim('"');
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    try { name = Path.GetFileName(new Uri(url).AbsolutePath); } catch { name = null; }
+                }
+                if (string.IsNullOrWhiteSpace(name)) name = "download";
+                // Strip any path components a header might smuggle in.
+                name = Path.GetFileName(name);
+
+                // .NET has no SpecialFolder.Downloads — UserProfile/Downloads works
+                // on macOS / Windows / Linux.
+                var dir = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Downloads");
+                Directory.CreateDirectory(dir);
+
+                var path = Path.Combine(dir, name);
+                // Avoid clobbering an existing file — append " (n)".
+                path = UniquePath(path);
+
+                await File.WriteAllBytesAsync(path, bytes).ConfigureAwait(false);
+                w.SendNotification("Download complete", path);
+            }
+            catch (Exception ex)
+            {
+                w.SendNotification("Download failed", ex.Message);
+            }
+        });
+    }
+
+    /// <summary>Return <paramref name="path"/>, or "name (n).ext" if it exists.</summary>
+    private static string UniquePath(string path)
+    {
+        if (!File.Exists(path)) return path;
+        var dir = Path.GetDirectoryName(path) ?? string.Empty;
+        var stem = Path.GetFileNameWithoutExtension(path);
+        var ext = Path.GetExtension(path);
+        for (var i = 1; i < 1000; i++)
+        {
+            var candidate = Path.Combine(dir, $"{stem} ({i}){ext}");
+            if (!File.Exists(candidate)) return candidate;
+        }
+        return path;
     }
 
     private static int RunServerWithStatus(string[] args)

--- a/Zeus.Server.Hosting/HamClockService.cs
+++ b/Zeus.Server.Hosting/HamClockService.cs
@@ -253,6 +253,7 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
             // Make "Use My Current Location" work on the desktop webview (no HTML5
             // Geolocation API) via a native-first shim with a coarse IP fallback.
             PatchGeolocationFallback();
+            PatchSettingsPersistence();
 
             lock (_gate) { _phase = HamClockPhase.Installed; _busy = false; }
             Append("HamClock installed. Click Start to launch the panel.");
@@ -308,6 +309,7 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
             // Covers pre-existing installs + re-injects after a dist/ rebuild that
             // regenerated index.html without the marker (idempotent).
             PatchGeolocationFallback();
+            PatchSettingsPersistence();
 
             var psi = MakePsi("node", "server.js", InstallDir);
             // Belt-and-suspenders env (overridden by .env, but harmless).
@@ -869,6 +871,99 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
             catch (Exception ex)
             {
                 Append($"  (geolocation fallback patch skipped for {rel}: {ex.Message})");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Inject a server-backed-localStorage shim into HamClock's served HTML so its
+    /// settings survive restarts. The desktop webview (WebKit) partitions the
+    /// cross-origin HamClock iframe's localStorage as third-party / ephemeral
+    /// storage, so it is wiped every launch (settings reset, first-visit popup).
+    /// HamClock's own SETTINGS_SYNC saves to disk but does not reliably restore
+    /// into localStorage on boot. This shim — running BEFORE HamClock's deferred
+    /// module bundle — synchronously pulls /api/settings into localStorage (so the
+    /// app boots as a returning visitor with settings intact) and mirrors
+    /// openhamclock_*/ohc_* writes back to the server (debounced). Same-origin
+    /// (the sidecar's own port), so no CORS. Idempotent via the ZEUS_SETTINGS_PERSIST
+    /// marker; re-injected after any rebuild. Requires SETTINGS_SYNC=true (set by
+    /// EnsureEnvPort) for the /api/settings store to be live.
+    /// </summary>
+    private void PatchSettingsPersistence()
+    {
+        const string shim =
+@"<!-- ZEUS_SETTINGS_PERSIST: server-backed localStorage so HamClock settings survive the webview's ephemeral iframe storage (KB2UKA) -->
+<script>
+(function () {
+  function ok(k) {
+    return !!k && (k.indexOf('openhamclock_') === 0 || k.indexOf('ohc_') === 0)
+      && k !== 'openhamclock_profiles' && k !== 'openhamclock_activeProfile';
+  }
+  // 1) PULL — synchronously restore persisted settings into localStorage BEFORE
+  //    HamClock's deferred module bundle reads them, so the app boots as a
+  //    returning visitor (settings present, no first-visit popup). Same-origin
+  //    request to the sidecar's own /api/settings (SETTINGS_SYNC persists to disk).
+  try {
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', '/api/settings', false);
+    xhr.send(null);
+    if (xhr.status >= 200 && xhr.status < 300) {
+      var data = JSON.parse(xhr.responseText || '{}');
+      for (var k in data) {
+        if (Object.prototype.hasOwnProperty.call(data, k) && ok(k) && typeof data[k] === 'string') {
+          try { localStorage.setItem(k, data[k]); } catch (e) {}
+        }
+      }
+    }
+  } catch (e) {}
+  // 2) MIRROR — persist openhamclock_*/ohc_* writes back to the server (debounced).
+  var timer = null;
+  function push() {
+    timer = null;
+    try {
+      var out = {};
+      for (var i = 0; i < localStorage.length; i++) {
+        var key = localStorage.key(i);
+        if (ok(key)) out[key] = localStorage.getItem(key);
+      }
+      fetch('/api/settings', { method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(out) }).catch(function () {});
+    } catch (e) {}
+  }
+  try {
+    var origSet = localStorage.setItem.bind(localStorage);
+    localStorage.setItem = function (k, v) {
+      origSet(k, v);
+      if (ok(k)) { if (timer) clearTimeout(timer); timer = setTimeout(push, 800); }
+    };
+  } catch (e) {}
+})();
+</script>
+";
+
+        foreach (var rel in new[] { "dist", "public" })
+        {
+            try
+            {
+                var file = Path.Combine(InstallDir, rel, "index.html");
+                if (!File.Exists(file)) continue;
+                var src = File.ReadAllText(file);
+                if (src.Contains("ZEUS_SETTINGS_PERSIST", StringComparison.Ordinal)) continue; // already patched
+                const string anchor = "</head>";
+                var idx = src.IndexOf(anchor, StringComparison.Ordinal);
+                if (idx < 0)
+                {
+                    Append($"  (note: couldn't inject settings-persistence into {rel}/index.html — </head> not found)");
+                    continue;
+                }
+                src = src.Insert(idx, shim);
+                File.WriteAllText(file, src);
+                Append($"Patched HamClock settings persistence into {rel}/index.html.");
+            }
+            catch (Exception ex)
+            {
+                Append($"  (settings-persistence patch skipped for {rel}: {ex.Message})");
             }
         }
     }

--- a/Zeus.Server.Hosting/HamClockService.cs
+++ b/Zeus.Server.Hosting/HamClockService.cs
@@ -285,7 +285,13 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
             if (!await EnsureNodeAsync().ConfigureAwait(false))
                 throw new InvalidOperationException("Node.js is unavailable — reinstall HamClock from Settings.");
 
-            var port = FreeTcpPort();
+            // Reuse the previously-chosen port (persisted in .env) when it's
+            // still free, so HamClock keeps the SAME loopback origin across
+            // restarts. Its settings (callsign, location, map prefs) live in
+            // localStorage, which is per-origin — a changing port silently
+            // wipes them every launch. Falls back to a fresh free port only on
+            // first run or if the saved one is taken.
+            var port = ResolveStablePort();
             Append($"Starting HamClock server on port {port}…");
 
             // HamClock's own server/config loads .env with precedence over
@@ -774,6 +780,46 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
         var port = ((IPEndPoint)l.LocalEndpoint).Port;
         l.Stop();
         return port;
+    }
+
+    /// <summary>
+    /// Prefer the port persisted in <c>.env</c> when it's still free, so the
+    /// HamClock loopback origin is stable across restarts (its UI settings live
+    /// in per-origin localStorage). Falls back to a fresh free port on first
+    /// run or if the saved one is in use.
+    /// </summary>
+    private static int ResolveStablePort()
+    {
+        var envPath = Path.Combine(InstallDir, ".env");
+        if (File.Exists(envPath))
+        {
+            foreach (var raw in File.ReadLines(envPath))
+            {
+                var line = raw.AsSpan().Trim();
+                if (line.StartsWith("PORT=", StringComparison.OrdinalIgnoreCase) &&
+                    int.TryParse(line[5..].Trim(), out var saved) &&
+                    saved is > 0 and <= 65535 && IsPortFree(saved))
+                {
+                    return saved;
+                }
+            }
+        }
+        return FreeTcpPort();
+    }
+
+    private static bool IsPortFree(int port)
+    {
+        try
+        {
+            var l = new TcpListener(IPAddress.Loopback, port);
+            l.Start();
+            l.Stop();
+            return true;
+        }
+        catch (SocketException)
+        {
+            return false;
+        }
     }
 
     private void Append(string line)

--- a/Zeus.Server.Hosting/HamClockService.cs
+++ b/Zeus.Server.Hosting/HamClockService.cs
@@ -358,7 +358,7 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
             // by RigBridgeService, talking to Zeus's TCI server on :40001). Both
             // are best-effort — a failure here never blocks HamClock itself.
             try { SeedRigControl(port); } catch (Exception ex) { Append($"  (rigControl seed skipped: {ex.Message})"); }
-            try { await _rigBridge.StartAsync().ConfigureAwait(false); }
+            try { await _rigBridge.StartAsync(port).ConfigureAwait(false); }
             catch (Exception ex) { Append($"  (rig-bridge start skipped: {ex.Message})"); }
 
             return port;

--- a/Zeus.Server.Hosting/HamClockService.cs
+++ b/Zeus.Server.Hosting/HamClockService.cs
@@ -1,0 +1,810 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// HamClockService — optional, on-demand embed of OpenHamClock
+// (https://github.com/accius/openhamclock, MIT) as a Zeus panel.
+//
+// OpenHamClock is a self-contained Node/Express web app. Its Express
+// server is NOT optional chrome: it's a CORS proxy that nearly every
+// live-data feature (NOAA space weather, POTA/SOTA, DX cluster,
+// PSKReporter, RBN, ITURHFProp propagation, satellites, APRS) routes
+// through. Serving its static dist/ alone would leave those panels dead,
+// so the only "works" option is to run its own server as a managed
+// sidecar process and point an <iframe> at it.
+//
+// Nothing here touches the radio / DSP / TX path. This is a self-supervised
+// child process that is entirely inert until the operator clicks "Install"
+// in Settings → HamClock. If Node is missing, install fails loudly with a
+// clear message; it never wedges Zeus.
+//
+// Lifecycle:
+//   NotInstalled --Install--> (download zip → npm ci → npm run build) --> Installed
+//   Installed    --Start----> (spawn `node server.js` on a free port) ---> Running
+//   Running      --Stop-----> (kill child) --------------------------------> Installed
+// The child is always killed on Zeus shutdown (IHostedService.StopAsync).
+
+using System.Diagnostics;
+using System.IO.Compression;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Server;
+
+/// <summary>Coarse lifecycle phase for the HamClock embed, surfaced to the UI.</summary>
+public enum HamClockPhase
+{
+    NotInstalled,
+    Installing,
+    Installed,
+    Starting,
+    Running,
+    Error,
+}
+
+/// <summary>Immutable status snapshot returned by <c>GET /api/hamclock/status</c>.</summary>
+public sealed record HamClockStatus(
+    string Phase,
+    bool Installed,
+    bool Running,
+    bool Busy,
+    int Port,
+    string? Version,
+    bool NodeAvailable,
+    string? NodeVersion,
+    string? Error,
+    IReadOnlyList<string> Log);
+
+/// <summary>
+/// Owns the OpenHamClock sidecar: download/build install, start/stop of the
+/// Node server process, and a status snapshot for the Settings panel.
+/// Singleton + <see cref="IHostedService"/> (only for clean shutdown — it
+/// never auto-starts the child; the operator opens the panel to start it).
+/// </summary>
+public sealed class HamClockService : IHostedService, IAsyncDisposable
+{
+    // Pinned release. Override with ZEUS_HAMCLOCK_ZIP_URL to track a different
+    // tag / a local mirror. Pinned (not a branch) for reproducible installs;
+    // bump deliberately. codeload returns a zip whose single top-level folder
+    // is openhamclock-<tag-without-v>/, which InstallAsync flattens.
+    private const string DefaultTag = "v26.4.1";
+    private static string SourceZipUrl =>
+        Environment.GetEnvironmentVariable("ZEUS_HAMCLOCK_ZIP_URL")
+        ?? $"https://github.com/accius/openhamclock/archive/refs/tags/{DefaultTag}.zip";
+
+    private const int MaxLogLines = 400;
+
+    // Single client for download + health-poll. GitHub codeload follows a
+    // redirect to its asset CDN; HttpClient follows it by default.
+    private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromMinutes(10) };
+
+    private readonly ILogger<HamClockService> _log;
+    private readonly object _gate = new();
+    private readonly LinkedList<string> _logLines = new();
+
+    private HamClockPhase _phase = HamClockPhase.NotInstalled;
+    private string? _error;
+    private int _port;
+    private Process? _proc;
+    private bool _busy; // an install or start is in flight
+
+    // Resolved Node runtime. _nodeDir = a directory to prepend to PATH so
+    // node/npm resolve to a private copy we downloaded; null = use whatever
+    // 'node' is on the system PATH. Set by EnsureNodeAsync. _nodeInfo is the
+    // cached "(available, version)" for Snapshot so status polls don't spawn
+    // `node --version` on every request.
+    private string? _nodeDir;
+    private bool _nodeBundled;
+    private readonly object _nodeGate = new();
+    private (bool ok, string? version) _nodeInfo;
+    private bool _nodeProbed;
+
+    // Pinned portable Node (current LTS). Downloaded into PortableNodeRoot when
+    // the system has no Node, so Install works on a machine with none
+    // preinstalled. Override the version only by editing this constant.
+    private const string PortableNodeVersion = "v22.11.0";
+
+    public HamClockService(ILogger<HamClockService> log)
+    {
+        _log = log;
+        // Reflect a prior install on boot so the panel comes up "Installed"
+        // without the operator re-downloading every launch.
+        if (IsBuilt(InstallDir))
+            _phase = HamClockPhase.Installed;
+    }
+
+    /// <summary>App-data install root: %LOCALAPPDATA%/Zeus/hamclock (mirrors PrefsDbPath).</summary>
+    public static string InstallDir
+    {
+        get
+        {
+            var appData = Environment.GetFolderPath(
+                Environment.SpecialFolder.LocalApplicationData,
+                Environment.SpecialFolderOption.Create);
+            return Path.Combine(appData, "Zeus", "hamclock");
+        }
+    }
+
+    /// <summary>App-data root for a downloaded private Node: %LOCALAPPDATA%/Zeus/node.</summary>
+    private static string PortableNodeRoot
+    {
+        get
+        {
+            var appData = Environment.GetFolderPath(
+                Environment.SpecialFolder.LocalApplicationData,
+                Environment.SpecialFolderOption.Create);
+            return Path.Combine(appData, "Zeus", "node");
+        }
+    }
+
+    /// <summary>A built install has both a server entrypoint and a Vite dist/.</summary>
+    private static bool IsBuilt(string dir) =>
+        File.Exists(Path.Combine(dir, "server.js")) &&
+        File.Exists(Path.Combine(dir, "dist", "index.html"));
+
+    // -- Status ----------------------------------------------------------
+
+    public HamClockStatus Snapshot()
+    {
+        // Probe Node outside _gate (it may spawn `node --version`) and cache it.
+        var (nodeOk, nodeVer) = GetNodeInfoCached();
+        lock (_gate)
+        {
+            bool running = _proc is { HasExited: false };
+            return new HamClockStatus(
+                Phase: _phase.ToString(),
+                Installed: IsBuilt(InstallDir),
+                Running: running,
+                Busy: _busy,
+                Port: running ? _port : 0,
+                Version: ReadInstalledVersion(),
+                NodeAvailable: nodeOk,
+                NodeVersion: nodeVer,
+                Error: _error,
+                Log: _logLines.ToArray());
+        }
+    }
+
+    // -- Install ---------------------------------------------------------
+
+    /// <summary>
+    /// Kick off download → npm ci → npm run build on a background task.
+    /// Returns immediately; progress is observable via <see cref="Snapshot"/>.
+    /// Returns false if an install/start is already running.
+    /// </summary>
+    public bool BeginInstall()
+    {
+        lock (_gate)
+        {
+            if (_busy) return false;
+            _busy = true;
+            _error = null;
+            _phase = HamClockPhase.Installing;
+            _logLines.Clear();
+        }
+        Append("Starting HamClock install…");
+        _ = Task.Run(InstallCoreAsync);
+        return true;
+    }
+
+    private async Task InstallCoreAsync()
+    {
+        try
+        {
+            // Resolve Node — use the system copy if present, otherwise download a
+            // private one. This is what makes Install one-click on a machine with
+            // no Node preinstalled.
+            if (!await EnsureNodeAsync().ConfigureAwait(false)) return; // Fail() already set
+
+            Directory.CreateDirectory(InstallDir);
+
+            // 1. Download the pinned source zip to a temp file.
+            Append($"Downloading {SourceZipUrl} …");
+            var tmpZip = Path.Combine(Path.GetTempPath(), $"hamclock-{Guid.NewGuid():N}.zip");
+            await using (var resp = await Http.GetStreamAsync(SourceZipUrl).ConfigureAwait(false))
+            await using (var fs = File.Create(tmpZip))
+                await resp.CopyToAsync(fs).ConfigureAwait(false);
+            Append($"Downloaded {new FileInfo(tmpZip).Length / 1024} KiB.");
+
+            // 2. Extract to a staging dir, then flatten the single top-level
+            //    folder (openhamclock-<tag>/) into InstallDir. Wipe any prior
+            //    install first so a re-install is clean.
+            var staging = Path.Combine(Path.GetTempPath(), $"hamclock-stage-{Guid.NewGuid():N}");
+            ZipFile.ExtractToDirectory(tmpZip, staging);
+            try { File.Delete(tmpZip); } catch { /* best effort */ }
+
+            var top = Directory.GetDirectories(staging).FirstOrDefault() ?? staging;
+            Append("Staging extracted source…");
+            if (Directory.Exists(InstallDir)) Directory.Delete(InstallDir, recursive: true);
+            Directory.Move(top, InstallDir);
+            try { if (Directory.Exists(staging)) Directory.Delete(staging, recursive: true); } catch { }
+
+            // 3. npm ci (reproducible from the committed lockfile). Fall back to
+            //    npm install if the lockfile is absent / out of sync.
+            Append("Installing dependencies (npm ci)… this can take a few minutes.");
+            int rc = await RunToolAsync("npm", "ci", InstallDir).ConfigureAwait(false);
+            if (rc != 0)
+            {
+                Append("npm ci failed; retrying with npm install…");
+                rc = await RunToolAsync("npm", "install", InstallDir).ConfigureAwait(false);
+                if (rc != 0) { Fail("npm install failed — see log."); return; }
+            }
+
+            // 4. Build the Vite frontend into dist/.
+            Append("Building frontend (npm run build)…");
+            rc = await RunToolAsync("npm", "run build", InstallDir).ConfigureAwait(false);
+            if (rc != 0) { Fail("npm run build failed — see log."); return; }
+
+            if (!IsBuilt(InstallDir)) { Fail("Build finished but dist/index.html is missing."); return; }
+
+            // HamClock's Express server sends X-Frame-Options: SAMEORIGIN (helmet
+            // frameguard), which blocks embedding it in the Zeus workspace iframe.
+            // We own this local copy, so disable frameguard.
+            PatchHelmetFrameguard();
+
+            lock (_gate) { _phase = HamClockPhase.Installed; _busy = false; }
+            Append("HamClock installed. Click Start to launch the panel.");
+        }
+        catch (Exception ex)
+        {
+            Fail($"Install error: {ex.Message}");
+        }
+    }
+
+    // -- Start / Stop ----------------------------------------------------
+
+    /// <summary>
+    /// Launch `node server.js` on a free port and health-poll until it
+    /// answers. Idempotent: a no-op (returns the live port) if already
+    /// running. Throws on failure with a UI-friendly message.
+    /// </summary>
+    public async Task<int> StartAsync()
+    {
+        lock (_gate)
+        {
+            if (_proc is { HasExited: false }) return _port;
+            if (_busy) throw new InvalidOperationException("HamClock is busy.");
+            if (!IsBuilt(InstallDir)) throw new InvalidOperationException("HamClock is not installed yet.");
+            _busy = true;
+            _error = null;
+            _phase = HamClockPhase.Starting;
+        }
+
+        try
+        {
+            // Resolve Node (system, or the private copy fetched at install time).
+            if (!await EnsureNodeAsync().ConfigureAwait(false))
+                throw new InvalidOperationException("Node.js is unavailable — reinstall HamClock from Settings.");
+
+            var port = FreeTcpPort();
+            Append($"Starting HamClock server on port {port}…");
+
+            // HamClock's own server/config loads .env with precedence over
+            // process.env, and creates .env from .env.example on first run with
+            // a pinned PORT=3001. So passing PORT via the environment is not
+            // enough — we write the chosen port into .env. server.js binds
+            // app.listen(PORT, '0.0.0.0'), so HOST is moot; only PORT matters.
+            EnsureEnvPort(port);
+            // Covers installs that predate the frameguard patch (idempotent).
+            PatchHelmetFrameguard();
+
+            var psi = MakePsi("node", "server.js", InstallDir);
+            // Belt-and-suspenders env (overridden by .env, but harmless).
+            psi.Environment["PORT"] = port.ToString();
+            psi.Environment["NODE_ENV"] = "production";
+            psi.Environment["AUTO_UPDATE_ENABLED"] = "false";
+
+            var proc = new Process { StartInfo = psi, EnableRaisingEvents = true };
+            proc.OutputDataReceived += (_, e) => { if (e.Data is not null) Append("[hc] " + e.Data); };
+            proc.ErrorDataReceived  += (_, e) => { if (e.Data is not null) Append("[hc!] " + e.Data); };
+            proc.Exited += (_, _) =>
+            {
+                Append("HamClock server exited.");
+                lock (_gate)
+                {
+                    if (_phase is HamClockPhase.Running or HamClockPhase.Starting)
+                        _phase = IsBuilt(InstallDir) ? HamClockPhase.Installed : HamClockPhase.NotInstalled;
+                }
+            };
+
+            if (!proc.Start()) throw new InvalidOperationException("Failed to start node.");
+            proc.BeginOutputReadLine();
+            proc.BeginErrorReadLine();
+
+            lock (_gate) { _proc = proc; _port = port; }
+
+            // Health-poll the server root for up to ~30s.
+            var healthy = await WaitForHealthAsync(port, TimeSpan.FromSeconds(30)).ConfigureAwait(false);
+            if (!healthy)
+            {
+                if (proc is { HasExited: false }) { try { proc.Kill(entireProcessTree: true); } catch { } }
+                lock (_gate) { _proc = null; }
+                throw new InvalidOperationException("HamClock server did not become healthy in time — see log.");
+            }
+
+            lock (_gate) { _phase = HamClockPhase.Running; }
+            Append($"HamClock running on port {port}.");
+            return port;
+        }
+        catch (Exception ex)
+        {
+            Fail($"Start error: {ex.Message}");
+            throw;
+        }
+        finally
+        {
+            lock (_gate) { _busy = false; }
+        }
+    }
+
+    /// <summary>Kill the HamClock server if running. Idempotent.</summary>
+    public void Stop()
+    {
+        Process? proc;
+        lock (_gate)
+        {
+            proc = _proc;
+            _proc = null;
+            if (_phase is HamClockPhase.Running or HamClockPhase.Starting)
+                _phase = IsBuilt(InstallDir) ? HamClockPhase.Installed : HamClockPhase.NotInstalled;
+        }
+        if (proc is { HasExited: false })
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { /* best effort */ }
+        }
+        proc?.Dispose();
+        Append("HamClock server stopped.");
+    }
+
+    // -- Helpers ---------------------------------------------------------
+
+    /// <summary>Run `node --version` using the currently resolved Node (system
+    /// PATH, or the private copy via _nodeDir). Returns (ok, version-string).</summary>
+    private (bool ok, string? version) DetectNode()
+    {
+        try
+        {
+            var psi = MakePsi("node", "--version", Path.GetTempPath());
+            using var p = Process.Start(psi);
+            if (p is null) return (false, null);
+            var outp = p.StandardOutput.ReadToEnd().Trim();
+            p.WaitForExit(5000);
+            return p.ExitCode == 0 ? (true, outp) : (false, null);
+        }
+        catch
+        {
+            return (false, null);
+        }
+    }
+
+    /// <summary>Cached Node availability for Snapshot — probes once, then reuses
+    /// the result (refreshed by EnsureNodeAsync). Also adopts a previously
+    /// downloaded private Node if the system has none.</summary>
+    private (bool ok, string? version) GetNodeInfoCached()
+    {
+        lock (_nodeGate) { if (_nodeProbed) return _nodeInfo; }
+        var info = DetectNode();
+        if (!info.ok && _nodeDir is null)
+        {
+            var portable = FindPortableNodeBinDir();
+            if (portable is not null)
+            {
+                _nodeDir = portable;
+                info = DetectNode();
+                if (info.ok) _nodeBundled = true; else _nodeDir = null;
+            }
+        }
+        lock (_nodeGate) { _nodeInfo = info; _nodeProbed = true; }
+        return info;
+    }
+
+    private void SetNodeInfo((bool ok, string? version) info)
+    {
+        lock (_nodeGate) { _nodeInfo = info; _nodeProbed = true; }
+    }
+
+    /// <summary>
+    /// Ensure a usable Node is resolved into <see cref="_nodeDir"/>. Order:
+    /// (1) system Node on PATH, (2) a private copy from a prior install,
+    /// (3) download a pinned portable Node from nodejs.org (checksum-verified).
+    /// Returns false (and calls Fail) only if the download/extract fails.
+    /// </summary>
+    private async Task<bool> EnsureNodeAsync()
+    {
+        // (1) Whatever's already resolved (system, or a _nodeDir set earlier).
+        var (ok, ver) = DetectNode();
+        if (ok)
+        {
+            Append($"Using {(_nodeBundled ? "bundled" : "system")} Node {ver}.");
+            SetNodeInfo((true, ver));
+            return true;
+        }
+
+        // (2) A private Node from a previous install.
+        var portable = FindPortableNodeBinDir();
+        if (portable is not null)
+        {
+            _nodeDir = portable;
+            (ok, ver) = DetectNode();
+            if (ok)
+            {
+                _nodeBundled = true;
+                Append($"Using bundled Node {ver}.");
+                SetNodeInfo((true, ver));
+                return true;
+            }
+            _nodeDir = null;
+        }
+
+        // (3) Download a pinned portable Node.
+        Append($"Node.js not found on this system — downloading a private copy ({PortableNodeVersion}) for HamClock…");
+        var binDir = await DownloadPortableNodeAsync().ConfigureAwait(false);
+        if (binDir is null) return false; // Fail() already set
+        _nodeDir = binDir;
+        _nodeBundled = true;
+        (ok, ver) = DetectNode();
+        if (!ok)
+        {
+            _nodeDir = null;
+            Fail("Downloaded Node did not run.");
+            return false;
+        }
+        Append($"Bundled Node {ver} ready.");
+        SetNodeInfo((true, ver));
+        return true;
+    }
+
+    /// <summary>The PATH-prependable bin dir of a previously downloaded private
+    /// Node, or null. Windows: the extracted folder (node.exe + npm.cmd at root);
+    /// Unix: its <c>bin/</c> subdir.</summary>
+    private static string? FindPortableNodeBinDir()
+    {
+        try
+        {
+            if (!Directory.Exists(PortableNodeRoot)) return null;
+            foreach (var dir in Directory.GetDirectories(PortableNodeRoot))
+            {
+                var binDir = OperatingSystem.IsWindows() ? dir : Path.Combine(dir, "bin");
+                var exe = Path.Combine(binDir, OperatingSystem.IsWindows() ? "node.exe" : "node");
+                if (File.Exists(exe)) return binDir;
+            }
+        }
+        catch { /* best effort */ }
+        return null;
+    }
+
+    /// <summary>Compute the nodejs.org artifact for this OS/arch.</summary>
+    private static (string url, string fileName, bool isZip, string dirName) PortableNodeArtifact()
+    {
+        string os, ext;
+        bool isZip;
+        if (OperatingSystem.IsWindows()) { os = "win"; ext = "zip"; isZip = true; }
+        else if (OperatingSystem.IsMacOS()) { os = "darwin"; ext = "tar.gz"; isZip = false; }
+        else { os = "linux"; ext = "tar.gz"; isZip = false; }
+
+        var arch = RuntimeInformation.OSArchitecture switch
+        {
+            Architecture.Arm64 => "arm64",
+            Architecture.X64 => "x64",
+            Architecture.X86 => "x86",
+            _ => "x64",
+        };
+        var dirName = $"node-{PortableNodeVersion}-{os}-{arch}";
+        var fileName = $"{dirName}.{ext}";
+        var url = $"https://nodejs.org/dist/{PortableNodeVersion}/{fileName}";
+        return (url, fileName, isZip, dirName);
+    }
+
+    /// <summary>Download + checksum-verify + extract a portable Node into
+    /// PortableNodeRoot. Returns the PATH-prependable bin dir, or null on failure
+    /// (after calling Fail).</summary>
+    private async Task<string?> DownloadPortableNodeAsync()
+    {
+        try
+        {
+            var (url, fileName, isZip, dirName) = PortableNodeArtifact();
+            Directory.CreateDirectory(PortableNodeRoot);
+
+            Append($"Downloading {url} …");
+            var tmp = Path.Combine(Path.GetTempPath(), fileName);
+            await using (var s = await Http.GetStreamAsync(url).ConfigureAwait(false))
+            await using (var fs = File.Create(tmp))
+                await s.CopyToAsync(fs).ConfigureAwait(false);
+            Append($"Downloaded {new FileInfo(tmp).Length / 1024 / 1024} MiB. Verifying checksum…");
+
+            if (!await VerifyNodeChecksumAsync(tmp, fileName).ConfigureAwait(false))
+            {
+                try { File.Delete(tmp); } catch { }
+                Fail("Node download failed SHA-256 verification — aborting.");
+                return null;
+            }
+
+            var dest = Path.Combine(PortableNodeRoot, dirName);
+            if (Directory.Exists(dest)) Directory.Delete(dest, recursive: true);
+            Append("Extracting Node…");
+            if (isZip)
+            {
+                ZipFile.ExtractToDirectory(tmp, PortableNodeRoot);
+            }
+            else
+            {
+                // tar.gz — use the system `tar` (present on Windows 10+, macOS, Linux).
+                var rc = await RunToolAsync("tar", $"-xzf \"{tmp}\" -C \"{PortableNodeRoot}\"", PortableNodeRoot)
+                    .ConfigureAwait(false);
+                if (rc != 0) { Fail("Failed to extract the Node tarball (tar)."); return null; }
+            }
+            try { File.Delete(tmp); } catch { }
+
+            var binDir = OperatingSystem.IsWindows() ? dest : Path.Combine(dest, "bin");
+            var exe = Path.Combine(binDir, OperatingSystem.IsWindows() ? "node.exe" : "node");
+            if (!File.Exists(exe)) { Fail("Node archive did not contain the expected binary."); return null; }
+            return binDir;
+        }
+        catch (Exception ex)
+        {
+            Fail($"Node download error: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>Verify a downloaded Node archive against nodejs.org's
+    /// SHASUMS256.txt. Returns true on match; also true (with a note) if the
+    /// checksum list can't be fetched or has no entry — so a transient
+    /// SHASUMS fetch failure doesn't block install, while a real mismatch does.</summary>
+    private async Task<bool> VerifyNodeChecksumAsync(string filePath, string fileName)
+    {
+        try
+        {
+            var sums = await Http.GetStringAsync(
+                $"https://nodejs.org/dist/{PortableNodeVersion}/SHASUMS256.txt").ConfigureAwait(false);
+            string? expected = null;
+            foreach (var line in sums.Split('\n'))
+            {
+                var parts = line.Trim().Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length == 2 && parts[1] == fileName)
+                {
+                    expected = parts[0].ToLowerInvariant();
+                    break;
+                }
+            }
+            if (expected is null)
+            {
+                Append("  (checksum: no entry for this file — skipping verification)");
+                return true;
+            }
+            await using var fs = File.OpenRead(filePath);
+            var hash = await SHA256.HashDataAsync(fs).ConfigureAwait(false);
+            var actual = Convert.ToHexString(hash).ToLowerInvariant();
+            if (actual == expected) { Append("  checksum OK."); return true; }
+            Append($"  checksum MISMATCH (expected {expected[..12]}…, got {actual[..12]}…)");
+            return false;
+        }
+        catch (Exception ex)
+        {
+            Append($"  (checksum check skipped: {ex.Message})");
+            return true;
+        }
+    }
+
+    private static string? ReadInstalledVersion()
+    {
+        try
+        {
+            var pkg = Path.Combine(InstallDir, "package.json");
+            if (!File.Exists(pkg)) return null;
+            using var doc = System.Text.Json.JsonDocument.Parse(File.ReadAllText(pkg));
+            return doc.RootElement.TryGetProperty("version", out var v) ? v.GetString() : null;
+        }
+        catch { return null; }
+    }
+
+    /// <summary>
+    /// Build a ProcessStartInfo that resolves PATH-installed tools on every
+    /// OS. npm is a .cmd shim on Windows (not a PATH-resolvable .exe), so it
+    /// must be invoked through cmd.exe; node.exe resolves directly.
+    /// </summary>
+    private ProcessStartInfo MakePsi(string tool, string args, string cwd)
+    {
+        var psi = new ProcessStartInfo
+        {
+            WorkingDirectory = cwd,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        if (OperatingSystem.IsWindows() && (tool is "npm" or "npx"))
+        {
+            psi.FileName = "cmd.exe";
+            psi.Arguments = $"/c {tool} {args}";
+        }
+        else
+        {
+            psi.FileName = tool;
+            psi.Arguments = args;
+        }
+        // When using a private Node, prepend its bin dir to the child's PATH so
+        // `node`, `npm`, and `npm.cmd` resolve to it (npm lives beside node in
+        // the portable archive, not on the system PATH).
+        if (_nodeDir is not null)
+        {
+            var existing = psi.Environment.TryGetValue("PATH", out var p) ? p : Environment.GetEnvironmentVariable("PATH");
+            psi.Environment["PATH"] = _nodeDir + Path.PathSeparator + (existing ?? string.Empty);
+        }
+        return psi;
+    }
+
+    /// <summary>Run a tool to completion, streaming its output into the log. Returns the exit code (or -1 on spawn failure).</summary>
+    private async Task<int> RunToolAsync(string tool, string args, string cwd)
+    {
+        try
+        {
+            var psi = MakePsi(tool, args, cwd);
+            using var p = new Process { StartInfo = psi, EnableRaisingEvents = true };
+            p.OutputDataReceived += (_, e) => { if (e.Data is not null) Append("  " + e.Data); };
+            p.ErrorDataReceived  += (_, e) => { if (e.Data is not null) Append("  " + e.Data); };
+            if (!p.Start()) return -1;
+            p.BeginOutputReadLine();
+            p.BeginErrorReadLine();
+            await p.WaitForExitAsync().ConfigureAwait(false);
+            return p.ExitCode;
+        }
+        catch (Exception ex)
+        {
+            Append($"  ! {tool} {args}: {ex.Message}");
+            return -1;
+        }
+    }
+
+    /// <summary>
+    /// Wait until the sidecar is accepting TCP connections on its port. A raw
+    /// loopback connect (not an HTTP GET) deliberately sidesteps any system
+    /// proxy / WinHTTP indirection that can stall or refuse loopback HTTP — the
+    /// listening socket is the only signal we need before showing the iframe.
+    /// </summary>
+    private static async Task<bool> WaitForHealthAsync(int port, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                using var client = new TcpClient();
+                var connect = client.ConnectAsync(IPAddress.Loopback, port);
+                var done = await Task.WhenAny(connect, Task.Delay(1500)).ConfigureAwait(false);
+                if (done == connect && client.Connected)
+                {
+                    await connect.ConfigureAwait(false); // observe any exception
+                    return true;
+                }
+            }
+            catch { /* not listening yet */ }
+            await Task.Delay(400).ConfigureAwait(false);
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Ensure <c>.env</c> in the install dir pins HamClock's PORT to the one we
+    /// chose (its config gives .env precedence over process.env). Seeds from
+    /// .env.example if .env doesn't exist yet, then upserts the PORT and
+    /// AUTO_UPDATE_ENABLED keys, preserving every other line.
+    /// </summary>
+    private static void EnsureEnvPort(int port)
+    {
+        var envPath = Path.Combine(InstallDir, ".env");
+        string content;
+        if (File.Exists(envPath))
+            content = File.ReadAllText(envPath);
+        else
+        {
+            var example = Path.Combine(InstallDir, ".env.example");
+            content = File.Exists(example) ? File.ReadAllText(example) : string.Empty;
+        }
+        content = UpsertEnvKey(content, "PORT", port.ToString());
+        content = UpsertEnvKey(content, "AUTO_UPDATE_ENABLED", "false");
+        File.WriteAllText(envPath, content);
+    }
+
+    /// <summary>
+    /// Disable helmet's frameguard in HamClock's middleware so it stops sending
+    /// X-Frame-Options: SAMEORIGIN, which otherwise blocks embedding it in the
+    /// Zeus workspace iframe. Idempotent — a no-op once "frameguard" is present
+    /// (or if upstream restructures the helmet call). CSP is already disabled
+    /// upstream, so there's no frame-ancestors directive to worry about.
+    /// </summary>
+    private void PatchHelmetFrameguard()
+    {
+        try
+        {
+            var file = Path.Combine(InstallDir, "server", "middleware", "index.js");
+            if (!File.Exists(file)) return;
+            var src = File.ReadAllText(file);
+            if (src.Contains("frameguard", StringComparison.Ordinal)) return; // already patched
+            const string anchor = "helmet({";
+            var idx = src.IndexOf(anchor, StringComparison.Ordinal);
+            if (idx < 0)
+            {
+                Append("  (note: couldn't disable frameguard — helmet anchor not found; embedding may be blocked)");
+                return;
+            }
+            src = src.Insert(idx + anchor.Length,
+                "\n      frameguard: false, // Zeus: allow embedding in the Zeus workspace iframe");
+            File.WriteAllText(file, src);
+            Append("Patched HamClock to allow embedding (X-Frame-Options off).");
+        }
+        catch (Exception ex)
+        {
+            Append($"  (frameguard patch skipped: {ex.Message})");
+        }
+    }
+
+    /// <summary>Replace the first uncommented <c>KEY=</c> line, or append one.</summary>
+    private static string UpsertEnvKey(string content, string key, string value)
+    {
+        var lines = content.Replace("\r\n", "\n").Split('\n').ToList();
+        bool found = false;
+        for (int i = 0; i < lines.Count; i++)
+        {
+            var trimmed = lines[i].TrimStart();
+            if (!trimmed.StartsWith('#') && trimmed.StartsWith(key + "=", StringComparison.Ordinal))
+            {
+                lines[i] = $"{key}={value}";
+                found = true;
+                break;
+            }
+        }
+        if (!found) lines.Add($"{key}={value}");
+        return string.Join("\n", lines);
+    }
+
+    private static int FreeTcpPort()
+    {
+        var l = new TcpListener(IPAddress.Loopback, 0);
+        l.Start();
+        var port = ((IPEndPoint)l.LocalEndpoint).Port;
+        l.Stop();
+        return port;
+    }
+
+    private void Append(string line)
+    {
+        _log.LogInformation("HamClock: {Line}", line);
+        lock (_gate)
+        {
+            _logLines.AddLast(line);
+            while (_logLines.Count > MaxLogLines) _logLines.RemoveFirst();
+        }
+    }
+
+    private void Fail(string message)
+    {
+        Append("ERROR: " + message);
+        lock (_gate) { _phase = HamClockPhase.Error; _error = message; _busy = false; }
+    }
+
+    // -- IHostedService (clean shutdown only) ----------------------------
+
+    public Task StartAsync(CancellationToken ct) => Task.CompletedTask;
+
+    public Task StopAsync(CancellationToken ct)
+    {
+        Stop();
+        return Task.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Stop();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/Zeus.Server.Hosting/HamClockService.cs
+++ b/Zeus.Server.Hosting/HamClockService.cs
@@ -708,8 +708,8 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
     /// <summary>
     /// Ensure <c>.env</c> in the install dir pins HamClock's PORT to the one we
     /// chose (its config gives .env precedence over process.env). Seeds from
-    /// .env.example if .env doesn't exist yet, then upserts the PORT and
-    /// AUTO_UPDATE_ENABLED keys, preserving every other line.
+    /// .env.example if .env doesn't exist yet, then upserts the PORT,
+    /// AUTO_UPDATE_ENABLED and SETTINGS_SYNC keys, preserving every other line.
     /// </summary>
     private static void EnsureEnvPort(int port)
     {
@@ -724,6 +724,14 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
         }
         content = UpsertEnvKey(content, "PORT", port.ToString());
         content = UpsertEnvKey(content, "AUTO_UPDATE_ENABLED", "false");
+        // Persist HamClock's UI settings (callsign, location, map prefs) on the
+        // server side, in the install dir. The embed's localStorage does NOT
+        // survive — the cross-origin iframe gets partitioned/ephemeral storage
+        // in the desktop webview (WebKit third-party storage), so settings reset
+        // (and the first-visit popup reappears) every launch otherwise. Server
+        // sync mirrors the openhamclock_* keys to disk and reloads them on boot.
+        // requireWriteAuth is open with no API_WRITE_KEY set (our local install).
+        content = UpsertEnvKey(content, "SETTINGS_SYNC", "true");
         File.WriteAllText(envPath, content);
     }
 

--- a/Zeus.Server.Hosting/HamClockService.cs
+++ b/Zeus.Server.Hosting/HamClockService.cs
@@ -88,6 +88,7 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
     private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromMinutes(10) };
 
     private readonly ILogger<HamClockService> _log;
+    private readonly RigBridgeService _rigBridge;
     private readonly object _gate = new();
     private readonly LinkedList<string> _logLines = new();
 
@@ -113,9 +114,10 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
     // preinstalled. Override the version only by editing this constant.
     private const string PortableNodeVersion = "v22.11.0";
 
-    public HamClockService(ILogger<HamClockService> log)
+    public HamClockService(ILogger<HamClockService> log, RigBridgeService rigBridge)
     {
         _log = log;
+        _rigBridge = rigBridge;
         // Reflect a prior install on boot so the panel comes up "Installed"
         // without the operator re-downloading every launch.
         if (IsBuilt(InstallDir))
@@ -254,6 +256,7 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
             // Geolocation API) via a native-first shim with a coarse IP fallback.
             PatchGeolocationFallback();
             PatchSettingsPersistence();
+            PatchDownloadBridge();
 
             lock (_gate) { _phase = HamClockPhase.Installed; _busy = false; }
             Append("HamClock installed. Click Start to launch the panel.");
@@ -310,6 +313,7 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
             // regenerated index.html without the marker (idempotent).
             PatchGeolocationFallback();
             PatchSettingsPersistence();
+            PatchDownloadBridge();
 
             var psi = MakePsi("node", "server.js", InstallDir);
             // Belt-and-suspenders env (overridden by .env, but harmless).
@@ -347,6 +351,16 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
 
             lock (_gate) { _phase = HamClockPhase.Running; }
             Append($"HamClock running on port {port}.");
+
+            // Auto-link click-to-tune (zero operator setup): seed HamClock's
+            // Rig Control setting to point at the bundled rig-bridge agent with a
+            // matching API token, then spawn that agent in TCI mode (config written
+            // by RigBridgeService, talking to Zeus's TCI server on :40001). Both
+            // are best-effort — a failure here never blocks HamClock itself.
+            try { SeedRigControl(port); } catch (Exception ex) { Append($"  (rigControl seed skipped: {ex.Message})"); }
+            try { await _rigBridge.StartAsync().ConfigureAwait(false); }
+            catch (Exception ex) { Append($"  (rig-bridge start skipped: {ex.Message})"); }
+
             return port;
         }
         catch (Exception ex)
@@ -376,6 +390,8 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
             try { proc.Kill(entireProcessTree: true); } catch { /* best effort */ }
         }
         proc?.Dispose();
+        // Stopping HamClock also stops its rig-bridge sidecar (lives/dies with it).
+        try { _rigBridge.Stop(); } catch { /* best effort */ }
         Append("HamClock server stopped.");
     }
 
@@ -619,6 +635,18 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
             return doc.RootElement.TryGetProperty("version", out var v) ? v.GetString() : null;
         }
         catch { return null; }
+    }
+
+    /// <summary>
+    /// Build a ProcessStartInfo for `node`/`npm` using the SAME resolved Node
+    /// runtime HamClock uses (system PATH, or the private copy via _nodeDir).
+    /// Exposed for the rig-bridge sidecar (RigBridgeService) so both Node
+    /// children share one runtime resolution. Ensures Node is resolved first.
+    /// </summary>
+    internal async Task<ProcessStartInfo?> MakeNodePsiAsync(string tool, string args, string cwd)
+    {
+        if (!await EnsureNodeAsync().ConfigureAwait(false)) return null;
+        return MakePsi(tool, args, cwd);
     }
 
     /// <summary>
@@ -993,6 +1021,141 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
             {
                 Append($"  (settings-persistence patch skipped for {rel}: {ex.Message})");
             }
+        }
+    }
+
+    /// <summary>
+    /// Inject a download-forwarding shim into HamClock's served HTML so the
+    /// desktop webview (Photino → WKWebView/WebView2) actually handles attachment
+    /// downloads (e.g. HamClock's Rig Bridge installer scripts). The embed iframe
+    /// has allow-downloads, but the macOS WKWebView Photino wraps has no download
+    /// delegate, so an attachment navigation is silently dropped ("nothing
+    /// happens"). This shim intercepts clicks on download links / the rig-bridge
+    /// download endpoint and posts the absolute URL up to the Zeus SPA shell, which
+    /// hands it to C# (window.external.sendMessage('download:'+url)) to fetch + save
+    /// to disk. Same mechanism as the geo / settings patches; idempotent via the
+    /// ZEUS_DL_BRIDGE marker; re-injected after any rebuild. No-op in a plain
+    /// browser where native downloads already work AND there's no Zeus shell parent.
+    /// </summary>
+    private void PatchDownloadBridge()
+    {
+        const string shim =
+@"<!-- ZEUS_DL_BRIDGE: forward attachment downloads to the Zeus desktop shell so the webview saves them (KB2UKA) -->
+<script>
+(function () {
+  document.addEventListener('click', function (e) {
+    try {
+      var a = e.target && e.target.closest ? e.target.closest('a') : null;
+      if (!a) return;
+      var href = a.getAttribute('href') || a.href || '';
+      if (!href) return;
+      var isDownload = a.hasAttribute('download') || /\/api\/rig-bridge\/download\//.test(href);
+      if (!isDownload) return;
+      // Only intercept when running inside the Zeus desktop shell (a parent
+      // window we can postMessage to). In a standalone browser, let the native
+      // download proceed untouched.
+      if (window.parent === window) return;
+      e.preventDefault();
+      var abs = new URL(href, location.href).href;
+      window.parent.postMessage({ zeusDownload: abs }, '*');
+    } catch (err) {}
+  }, true);
+})();
+</script>
+";
+
+        foreach (var rel in new[] { "dist", "public" })
+        {
+            try
+            {
+                var file = Path.Combine(InstallDir, rel, "index.html");
+                if (!File.Exists(file)) continue;
+                var src = File.ReadAllText(file);
+                if (src.Contains("ZEUS_DL_BRIDGE", StringComparison.Ordinal)) continue; // already patched
+                const string anchor = "</head>";
+                var idx = src.IndexOf(anchor, StringComparison.Ordinal);
+                if (idx < 0)
+                {
+                    Append($"  (note: couldn't inject download bridge into {rel}/index.html — </head> not found)");
+                    continue;
+                }
+                src = src.Insert(idx, shim);
+                File.WriteAllText(file, src);
+                Append($"Patched HamClock download bridge into {rel}/index.html.");
+            }
+            catch (Exception ex)
+            {
+                Append($"  (download bridge patch skipped for {rel}: {ex.Message})");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Seed HamClock's Rig Control setting so clicking a spot tunes the Zeus
+    /// radio with no operator setup. HamClock stores all UI prefs in a single
+    /// JSON blob under the localStorage key <c>openhamclock_config</c>, mirrored
+    /// server-side by its <c>/api/settings</c> store (SETTINGS_SYNC, already
+    /// enabled by EnsureEnvPort). Inside that blob, <c>rigControl</c> is
+    /// <c>{ enabled, host, port, tuneEnabled, autoMode, apiToken }</c>. We GET the
+    /// current blob, merge our rigControl (pointing at the rig-bridge agent on
+    /// :5555 with the SAME api token RigBridgeService writes into the agent
+    /// config), and POST it back. The ZEUS_SETTINGS_PERSIST shim then seeds this
+    /// into localStorage at HamClock boot, so it reads the rigControl on first paint.
+    /// Merge-safe — never overwrites the blob's other keys (callsign, map prefs).
+    /// </summary>
+    private void SeedRigControl(int port)
+    {
+        var token = _rigBridge.GetOrCreateApiToken();
+        var baseUrl = $"http://127.0.0.1:{port}";
+
+        // 1. Read the existing settings store, extract the current config blob.
+        var settings = new System.Text.Json.Nodes.JsonObject();
+        try
+        {
+            var raw = Http.GetStringAsync($"{baseUrl}/api/settings").GetAwaiter().GetResult();
+            if (System.Text.Json.Nodes.JsonNode.Parse(raw) is System.Text.Json.Nodes.JsonObject obj)
+                settings = obj;
+        }
+        catch { /* store may be empty / not yet written — start fresh */ }
+
+        System.Text.Json.Nodes.JsonObject config;
+        try
+        {
+            // Stored as a JSON *string* (the only value shape /api/settings accepts).
+            var inner = settings["openhamclock_config"]?.GetValue<string>();
+            config = (inner is not null
+                ? System.Text.Json.Nodes.JsonNode.Parse(inner) as System.Text.Json.Nodes.JsonObject
+                : null) ?? new System.Text.Json.Nodes.JsonObject();
+        }
+        catch { config = new System.Text.Json.Nodes.JsonObject(); }
+
+        // 2. Merge our rigControl.
+        config["rigControl"] = new System.Text.Json.Nodes.JsonObject
+        {
+            ["enabled"] = true,
+            ["host"] = "http://localhost",
+            ["port"] = RigBridgeService.BridgePort,
+            ["tuneEnabled"] = true,
+            ["autoMode"] = false,
+            ["apiToken"] = token,
+        };
+
+        // 3. Re-stringify the blob and POST the full settings set back (the store
+        //    replaces wholesale, so we send every key we read plus our update).
+        settings["openhamclock_config"] = config.ToJsonString();
+        try
+        {
+            var body = settings.ToJsonString();
+            using var content = new StringContent(body, System.Text.Encoding.UTF8, "application/json");
+            using var resp = Http.PostAsync($"{baseUrl}/api/settings", content).GetAwaiter().GetResult();
+            if (resp.IsSuccessStatusCode)
+                Append("Seeded HamClock Rig Control (click-to-tune → rig-bridge :5555 → TCI).");
+            else
+                Append($"  (rigControl seed POST returned {(int)resp.StatusCode})");
+        }
+        catch (Exception ex)
+        {
+            Append($"  (rigControl seed POST failed: {ex.Message})");
         }
     }
 

--- a/Zeus.Server.Hosting/HamClockService.cs
+++ b/Zeus.Server.Hosting/HamClockService.cs
@@ -250,6 +250,9 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
             // frameguard), which blocks embedding it in the Zeus workspace iframe.
             // We own this local copy, so disable frameguard.
             PatchHelmetFrameguard();
+            // Make "Use My Current Location" work on the desktop webview (no HTML5
+            // Geolocation API) via a native-first shim with a coarse IP fallback.
+            PatchGeolocationFallback();
 
             lock (_gate) { _phase = HamClockPhase.Installed; _busy = false; }
             Append("HamClock installed. Click Start to launch the panel.");
@@ -302,6 +305,9 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
             EnsureEnvPort(port);
             // Covers installs that predate the frameguard patch (idempotent).
             PatchHelmetFrameguard();
+            // Covers pre-existing installs + re-injects after a dist/ rebuild that
+            // regenerated index.html without the marker (idempotent).
+            PatchGeolocationFallback();
 
             var psi = MakePsi("node", "server.js", InstallDir);
             // Belt-and-suspenders env (overridden by .env, but harmless).
@@ -751,6 +757,111 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
         catch (Exception ex)
         {
             Append($"  (frameguard patch skipped: {ex.Message})");
+        }
+    }
+
+    /// <summary>
+    /// Inject a native-first geolocation shim into HamClock's served HTML so the
+    /// "Use My Current Location" button works on every platform. HamClock calls
+    /// only navigator.geolocation.getCurrentPosition; the macOS desktop webview
+    /// (Photino → WKWebView) does not implement the HTML5 Geolocation API, so the
+    /// call always fails there. The shim tries the NATIVE API first (preserving
+    /// exact browser / Windows-WebView2 behaviour), and only on failure — or when
+    /// the API is absent entirely — falls back to a user-initiated, coarse
+    /// (city-level) IP lookup, mapped into the standard GeolocationPosition shape.
+    /// Idempotent — a no-op once the ZEUS_GEO_FALLBACK marker is present. Targets
+    /// the global navigator.geolocation, so it is independent of the hashed Vite
+    /// bundle filename and survives rebuilds (re-injected on the next start).
+    /// </summary>
+    private void PatchGeolocationFallback()
+    {
+        // Inline (non-module) script: runs at parse time, before the deferred
+        // ES-module bundle, so the global patch is installed first. The bundle
+        // reads navigator.geolocation at call time, so it picks this up unchanged.
+        const string shim =
+@"<!-- ZEUS_GEO_FALLBACK: native-first geolocation with IP fallback (KB2UKA) -->
+<script>
+(function () {
+  var geo = navigator.geolocation;
+  var nativeGet = geo && geo.getCurrentPosition ? geo.getCurrentPosition.bind(geo) : null;
+  // City-level, no-key, CORS + HTTPS services; both expose flat latitude/longitude.
+  var IP_SERVICES = ['https://ipapi.co/json/', 'https://ipwho.is/'];
+  function ipLookup() {
+    var i = 0;
+    function tryNext() {
+      if (i >= IP_SERVICES.length) return Promise.reject(new Error('IP geolocation failed'));
+      var url = IP_SERVICES[i++];
+      return fetch(url, { cache: 'no-store' }).then(function (res) {
+        if (!res.ok) return tryNext();
+        return res.json().then(function (j) {
+          if (!j || j.success === false) return tryNext();
+          var lat = Number(j.latitude), lon = Number(j.longitude);
+          if (!isFinite(lat) || !isFinite(lon)) return tryNext();
+          // Coarse, user-initiated lookup — tag accuracy ~city-level (metres).
+          return { coords: { latitude: lat, longitude: lon, accuracy: 50000,
+            altitude: null, altitudeAccuracy: null, heading: null, speed: null },
+            timestamp: Date.now() };
+        });
+      }).catch(function () { return tryNext(); });
+    }
+    return tryNext();
+  }
+  function patched(success, error, options) {
+    function fallback(failCode, failMsg) {
+      ipLookup().then(success).catch(function () {
+        if (error) error({ code: failCode, message: failMsg });
+      });
+    }
+    if (nativeGet) {
+      // 1) NATIVE FIRST — exact existing web / Windows-WebView2 behaviour.
+      nativeGet(success, function () {
+        // 2) Native failed (incl. macOS WKWebView) -> IP fallback.
+        fallback(2, 'Location unavailable (native + IP failed)');
+      }, options);
+    } else {
+      fallback(2, 'Location unavailable (IP lookup failed)');
+    }
+  }
+  if (navigator.geolocation) {
+    try { navigator.geolocation.getCurrentPosition = patched; } catch (e) {}
+  } else {
+    // macOS WKWebView: the geolocation object is absent, so HamClock's
+    // `navigator.geolocation ? ... : alert('unsupported')` would alert. Synthesize
+    // the object so the happy path is taken and the IP fallback runs.
+    try {
+      Object.defineProperty(navigator, 'geolocation', {
+        value: { getCurrentPosition: patched, watchPosition: function () {}, clearWatch: function () {} },
+        configurable: true
+      });
+    } catch (e) {}
+  }
+})();
+</script>
+";
+
+        foreach (var rel in new[] { "dist", "public" })
+        {
+            try
+            {
+                var file = Path.Combine(InstallDir, rel, "index.html");
+                if (!File.Exists(file)) continue;
+                var src = File.ReadAllText(file);
+                if (src.Contains("ZEUS_GEO_FALLBACK", StringComparison.Ordinal)) continue; // already patched
+                const string anchor = "</head>";
+                var idx = src.IndexOf(anchor, StringComparison.Ordinal);
+                if (idx < 0)
+                {
+                    Append($"  (note: couldn't inject geolocation fallback into {rel}/index.html — </head> not found)");
+                    continue;
+                }
+                src = src.Insert(idx, shim);
+                File.WriteAllText(file, src);
+                Append($"Patched HamClock geolocation fallback into {rel}/index.html.");
+            }
+            catch (Exception ex)
+            {
+                Append($"  (geolocation fallback patch skipped for {rel}: {ex.Message})");
+            }
         }
     }
 

--- a/Zeus.Server.Hosting/HamClockService.cs
+++ b/Zeus.Server.Hosting/HamClockService.cs
@@ -896,13 +896,18 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
 <script>
 (function () {
   function ok(k) {
-    return !!k && (k.indexOf('openhamclock_') === 0 || k.indexOf('ohc_') === 0)
+    return typeof k === 'string'
+      && (k.indexOf('openhamclock_') === 0 || k.indexOf('ohc_') === 0)
       && k !== 'openhamclock_profiles' && k !== 'openhamclock_activeProfile';
   }
-  // 1) PULL — synchronously restore persisted settings into localStorage BEFORE
-  //    HamClock's deferred module bundle reads them, so the app boots as a
-  //    returning visitor (settings present, no first-visit popup). Same-origin
-  //    request to the sidecar's own /api/settings (SETTINGS_SYNC persists to disk).
+  // WebKit partitions/blocks the cross-origin HamClock iframe's NATIVE
+  // localStorage, so HamClock can't persist anything (first-visit every launch,
+  // no save). Replace localStorage with a server-backed store: seed it
+  // synchronously from /api/settings (so the app boots as a returning visitor)
+  // and mirror writes back to the server (debounced). Runs before HamClock's
+  // deferred module bundle, so it transparently uses this instead of the blocked
+  // native one. /api/settings persists to disk via SETTINGS_SYNC.
+  var store = {};
   try {
     var xhr = new XMLHttpRequest();
     xhr.open('GET', '/api/settings', false);
@@ -910,34 +915,50 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
     if (xhr.status >= 200 && xhr.status < 300) {
       var data = JSON.parse(xhr.responseText || '{}');
       for (var k in data) {
-        if (Object.prototype.hasOwnProperty.call(data, k) && ok(k) && typeof data[k] === 'string') {
-          try { localStorage.setItem(k, data[k]); } catch (e) {}
-        }
+        if (Object.prototype.hasOwnProperty.call(data, k) && typeof data[k] === 'string') store[k] = data[k];
       }
     }
   } catch (e) {}
-  // 2) MIRROR — persist openhamclock_*/ohc_* writes back to the server (debounced).
   var timer = null;
-  function push() {
-    timer = null;
-    try {
-      var out = {};
-      for (var i = 0; i < localStorage.length; i++) {
-        var key = localStorage.key(i);
-        if (ok(key)) out[key] = localStorage.getItem(key);
-      }
-      fetch('/api/settings', { method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(out) }).catch(function () {});
-    } catch (e) {}
+  function schedule() {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(function () {
+      timer = null;
+      try {
+        var out = {};
+        for (var k in store) { if (Object.prototype.hasOwnProperty.call(store, k) && ok(k)) out[k] = store[k]; }
+        fetch('/api/settings', { method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(out) }).catch(function () {});
+      } catch (e) {}
+    }, 600);
   }
-  try {
-    var origSet = localStorage.setItem.bind(localStorage);
-    localStorage.setItem = function (k, v) {
-      origSet(k, v);
-      if (ok(k)) { if (timer) clearTimeout(timer); timer = setTimeout(push, 800); }
-    };
-  } catch (e) {}
+  var methods = {
+    getItem: function (k) { k = String(k); return Object.prototype.hasOwnProperty.call(store, k) ? store[k] : null; },
+    setItem: function (k, v) { k = String(k); store[k] = String(v); if (ok(k)) schedule(); },
+    removeItem: function (k) { k = String(k); delete store[k]; if (ok(k)) schedule(); },
+    clear: function () { for (var k in store) delete store[k]; schedule(); },
+    key: function (i) { return Object.keys(store)[i] || null; }
+  };
+  var backed = new Proxy(methods, {
+    get: function (t, p) {
+      if (p === 'length') return Object.keys(store).length;
+      if (p in t) return t[p];
+      return (typeof p === 'string' && Object.prototype.hasOwnProperty.call(store, p)) ? store[p] : undefined;
+    },
+    set: function (t, p, v) {
+      if (p in t) { t[p] = v; return true; }
+      var k = String(p); store[k] = String(v); if (ok(k)) schedule(); return true;
+    },
+    deleteProperty: function (t, p) { var k = String(p); delete store[k]; if (ok(k)) schedule(); return true; },
+    has: function (t, p) { return (p in t) || Object.prototype.hasOwnProperty.call(store, p); },
+    ownKeys: function () { return Object.keys(store); },
+    getOwnPropertyDescriptor: function (t, p) {
+      if (Object.prototype.hasOwnProperty.call(store, p)) return { configurable: true, enumerable: true, writable: true, value: store[p] };
+      return undefined;
+    }
+  });
+  try { Object.defineProperty(window, 'localStorage', { value: backed, configurable: true }); } catch (e) {}
 })();
 </script>
 ";
@@ -949,7 +970,14 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
                 var file = Path.Combine(InstallDir, rel, "index.html");
                 if (!File.Exists(file)) continue;
                 var src = File.ReadAllText(file);
-                if (src.Contains("ZEUS_SETTINGS_PERSIST", StringComparison.Ordinal)) continue; // already patched
+                // Self-updating: strip any prior version of our block, then inject
+                // the current shim — so installs carrying an older shim get the fix.
+                var ms = src.IndexOf("<!-- ZEUS_SETTINGS_PERSIST", StringComparison.Ordinal);
+                if (ms >= 0)
+                {
+                    var es = src.IndexOf("</script>", ms, StringComparison.Ordinal);
+                    if (es >= 0) src = src.Remove(ms, (es + "</script>".Length) - ms);
+                }
                 const string anchor = "</head>";
                 var idx = src.IndexOf(anchor, StringComparison.Ordinal);
                 if (idx < 0)

--- a/Zeus.Server.Hosting/RigBridgeService.cs
+++ b/Zeus.Server.Hosting/RigBridgeService.cs
@@ -161,7 +161,7 @@ public sealed class RigBridgeService : IHostedService, IAsyncDisposable
     /// that make Zeus auto-linking work. configVersion 8 matches the agent's
     /// current schema (core/config.js CONFIG_VERSION) so it doesn't run a migration.
     /// </summary>
-    private void WriteConfig(string token)
+    private void WriteConfig(string token, int hamclockPort)
     {
         var path = ConfigPath();
         try
@@ -187,6 +187,11 @@ public sealed class RigBridgeService : IHostedService, IAsyncDisposable
             // rather than flashing a first-run "copy this token" banner.
             root["tokenDisplayed"] = true;
             root["logging"] = true;
+            // The HamClock iframe (served on its own sidecar port) POSTs /freq
+            // cross-origin to this bridge. The agent does EXACT-origin CORS
+            // matching, so HamClock's port MUST be on the allowlist or the
+            // browser silently blocks every spot-click tune (cluster, POTA, map).
+            root["corsOrigins"] = $"http://localhost:{hamclockPort},http://127.0.0.1:{hamclockPort}";
 
             var radio = root["radio"] as JsonObject ?? new JsonObject();
             radio["type"] = "tci";
@@ -265,7 +270,7 @@ public sealed class RigBridgeService : IHostedService, IAsyncDisposable
         }
     }
 
-    public async Task StartAsync()
+    public async Task StartAsync(int hamclockPort)
     {
         lock (_gate) { if (_proc is { HasExited: false }) return; }
 
@@ -276,7 +281,7 @@ public sealed class RigBridgeService : IHostedService, IAsyncDisposable
         }
 
         var token = GetOrCreateApiToken();
-        WriteConfig(token);
+        WriteConfig(token, hamclockPort);
 
         // The rig-bridge is a SEPARATE npm package (its own package.json:
         // node-forge, ws, express, serialport, xmlrpc) — HamClock's root install

--- a/Zeus.Server.Hosting/RigBridgeService.cs
+++ b/Zeus.Server.Hosting/RigBridgeService.cs
@@ -193,7 +193,10 @@ public sealed class RigBridgeService : IHostedService, IAsyncDisposable
             root["radio"] = radio;
 
             var tci = root["tci"] as JsonObject ?? new JsonObject();
-            tci["host"] = "localhost";
+            // 127.0.0.1, not "localhost": Node resolves localhost to ::1 (IPv6)
+            // first on macOS, but Zeus's TCI listener is IPv4 — force IPv4 loopback
+            // so the WS connects instead of ECONNREFUSED on the IPv6 attempt.
+            tci["host"] = "127.0.0.1";
             tci["port"] = TciPort;
             tci["trx"] = 0;
             tci["vfo"] = 0;
@@ -216,6 +219,52 @@ public sealed class RigBridgeService : IHostedService, IAsyncDisposable
     /// if the bundled agent isn't present (older HamClock installs). Never throws —
     /// click-to-tune is a best-effort convenience, not a launch blocker.
     /// </summary>
+    /// <summary>
+    /// Install the rig-bridge agent's own npm dependencies (node-forge, ws,
+    /// express, serialport, xmlrpc) into rig-bridge/node_modules — once, lazily,
+    /// on first start. HamClock's root install doesn't cover this sub-package.
+    /// serialport ships prebuilt binaries (prebuild-install), so no native
+    /// toolchain is required. Idempotent: a no-op once node-forge is present.
+    /// </summary>
+    private async Task<bool> EnsureDepsInstalledAsync()
+    {
+        var marker = Path.Combine(RigBridgeDir, "node_modules", "node-forge", "package.json");
+        if (File.Exists(marker)) return true;
+
+        Append("Installing rig-bridge dependencies (first run)…");
+        var psi = await HamClock
+            .MakeNodePsiAsync("npm", "install --no-audit --no-fund --omit=dev", RigBridgeDir)
+            .ConfigureAwait(false);
+        if (psi is null)
+        {
+            Append("Node/npm unavailable — can't install rig-bridge deps (reinstall HamClock).");
+            return false;
+        }
+        psi.Environment["NODE_ENV"] = "production";
+        try
+        {
+            using var p = new Process { StartInfo = psi, EnableRaisingEvents = true };
+            p.OutputDataReceived += (_, e) => { if (e.Data is not null) Append("[rb-npm] " + e.Data); };
+            p.ErrorDataReceived += (_, e) => { if (e.Data is not null) Append("[rb-npm!] " + e.Data); };
+            if (!p.Start()) { Append("Failed to start npm for rig-bridge."); return false; }
+            p.BeginOutputReadLine();
+            p.BeginErrorReadLine();
+            await p.WaitForExitAsync().ConfigureAwait(false);
+            if (p.ExitCode != 0)
+            {
+                Append($"rig-bridge npm install failed (exit {p.ExitCode}).");
+                return false;
+            }
+            Append("rig-bridge dependencies installed.");
+            return File.Exists(marker);
+        }
+        catch (Exception ex)
+        {
+            Append($"rig-bridge dep install error: {ex.Message}");
+            return false;
+        }
+    }
+
     public async Task StartAsync()
     {
         lock (_gate) { if (_proc is { HasExited: false }) return; }
@@ -228,6 +277,16 @@ public sealed class RigBridgeService : IHostedService, IAsyncDisposable
 
         var token = GetOrCreateApiToken();
         WriteConfig(token);
+
+        // The rig-bridge is a SEPARATE npm package (its own package.json:
+        // node-forge, ws, express, serialport, xmlrpc) — HamClock's root install
+        // doesn't cover it, so without this its node_modules is missing and
+        // require('node-forge') in core/tls.js crashes it on load. Install once.
+        if (!await EnsureDepsInstalledAsync().ConfigureAwait(false))
+        {
+            Append("rig-bridge dependencies unavailable — click-to-tune unavailable.");
+            return;
+        }
 
         try
         {

--- a/Zeus.Server.Hosting/RigBridgeService.cs
+++ b/Zeus.Server.Hosting/RigBridgeService.cs
@@ -1,0 +1,335 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// RigBridgeService — the second Zeus-supervised Node sidecar that makes
+// HamClock "click-to-tune" work with zero operator setup.
+//
+// HamClock's "Rig Control" feature POSTs the clicked-spot frequency to a small
+// local HTTP daemon — the OpenHamClock "Rig Bridge" agent (bundled inside the
+// HamClock install at hamclock/rig-bridge/rig-bridge.js). That agent, when its
+// radio plugin is `tci`, opens a TCI WebSocket to an SDR's TCI server and sends
+// `VFO:<trx>,<vfo>,<hz>;`. Zeus already runs an ExpertSDR3-compatible TCI server
+// on :40001 (Zeus.Server.Tci.TciServer); its TciSession.HandleVfo applies the
+// inbound VFO set via RadioService.SetVfo(fromExternal: true). So the chain is:
+//
+//   HamClock spot click → POST localhost:5555/freq
+//     → rig-bridge (radio.type=tci) → ws://localhost:40001  VFO:0,0,<hz>;
+//       → Zeus TciServer → RadioService.SetVfo → radio tunes.
+//
+// Without this service the operator would have to (1) enable Zeus's TCI server,
+// (2) download + run the rig-bridge agent in TCI mode, and (3) point HamClock's
+// Rig Bridge setting at :5555 with a matching API token. This service automates
+// all three: Zeus binds :40001 in desktop mode (see ZeusHost), spawns + supervises
+// the BUNDLED rig-bridge.js (same Node runtime + lifecycle as HamClockService),
+// writes its config (radio.type=tci, tci.port=40001, bridge port 5555, a stable
+// API token), and HamClockService seeds HamClock's rigControl setting with the
+// matching token. Net: install HamClock → click a spot → radio tunes.
+//
+// Nothing here touches the radio / DSP / TX path. It is inert until HamClock is
+// started (HamClockService.StartAsync calls StartAsync here), lives and dies
+// with HamClock, and is also killed on Zeus shutdown (IHostedService.StopAsync).
+
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Owns the OpenHamClock "Rig Bridge" agent sidecar in TCI mode, wiring
+/// HamClock click-to-tune to Zeus's TCI server. Singleton +
+/// <see cref="IHostedService"/> (only for clean shutdown — it never
+/// auto-starts; HamClockService starts/stops it alongside HamClock).
+/// </summary>
+public sealed class RigBridgeService : IHostedService, IAsyncDisposable
+{
+    // The bridge's local HTTP port HamClock POSTs spot frequencies to. 5555 is
+    // the rig-bridge agent's own default and the value HamClock's Rig Control
+    // setting defaults to, so the operator never has to change it.
+    public const int BridgePort = 5555;
+
+    // Zeus's TCI server port (ExpertSDR3-compatible). Must match the port Zeus
+    // binds in ZeusHost (Tci:Port / desktop auto-bind).
+    private const int TciPort = 40001;
+
+    private const int MaxLogLines = 200;
+
+    private readonly ILogger<RigBridgeService> _log;
+    // HamClockService and RigBridgeService reference each other (HamClock starts/
+    // stops the bridge; the bridge borrows HamClock's resolved Node runtime), which
+    // is a constructor-injection cycle the DI container rejects. Break it by lazily
+    // resolving HamClockService from the provider on first use — see
+    // docs/lessons feedback_di_cycle_iservice_provider.
+    private readonly IServiceProvider _services;
+    private HamClockService? _hamclockCached;
+    private readonly object _gate = new();
+    private readonly LinkedList<string> _logLines = new();
+    private Process? _proc;
+
+    public RigBridgeService(ILogger<RigBridgeService> log, IServiceProvider services)
+    {
+        _log = log;
+        _services = services;
+    }
+
+    private HamClockService HamClock =>
+        _hamclockCached ??= _services.GetRequiredService<HamClockService>();
+
+    /// <summary>The bundled rig-bridge dir inside the HamClock install.</summary>
+    private static string RigBridgeDir => Path.Combine(HamClockService.InstallDir, "rig-bridge");
+
+    /// <summary>The agent entrypoint (node rig-bridge.js).</summary>
+    private static string Entry => Path.Combine(RigBridgeDir, "rig-bridge.js");
+
+    /// <summary>True once the bundled rig-bridge agent is present on disk.</summary>
+    public static bool IsAvailable => File.Exists(Entry);
+
+    /// <summary>True while the bridge child process is alive.</summary>
+    public bool Running { get { lock (_gate) return _proc is { HasExited: false }; } }
+
+    // -- API token --------------------------------------------------------
+
+    /// <summary>
+    /// A stable hex API token shared by the rig-bridge config (radio write auth)
+    /// and HamClock's rigControl.apiToken. The rig-bridge agent auto-generates
+    /// (and enforces) a token on /freq when its config token is empty, so we must
+    /// pre-seed a KNOWN token on both sides or HamClock's POST /freq would 401.
+    /// Persisted in a small file under the rig-bridge dir so it survives restarts.
+    /// </summary>
+    public string GetOrCreateApiToken()
+    {
+        var tokenFile = Path.Combine(RigBridgeDir, ".zeus-rig-token");
+        try
+        {
+            if (File.Exists(tokenFile))
+            {
+                var existing = File.ReadAllText(tokenFile).Trim();
+                if (existing.Length >= 16) return existing;
+            }
+        }
+        catch { /* fall through to regenerate */ }
+
+        var token = Convert.ToHexString(RandomNumberGenerator.GetBytes(16)).ToLowerInvariant();
+        try
+        {
+            Directory.CreateDirectory(RigBridgeDir);
+            File.WriteAllText(tokenFile, token);
+        }
+        catch (Exception ex)
+        {
+            Append($"  (could not persist rig-bridge token: {ex.Message})");
+        }
+        return token;
+    }
+
+    // -- Config -----------------------------------------------------------
+
+    /// <summary>
+    /// The agent's external config path: ~/.config/openhamclock/rig-bridge-config.json
+    /// on mac/Linux, %APPDATA%\openhamclock\rig-bridge-config.json on Windows.
+    /// This mirrors the agent's own resolveConfigPath() (core/config.js), which
+    /// reads this file verbatim — so we write our TCI config here directly rather
+    /// than into the read-only installed tree.
+    /// </summary>
+    private static string ConfigPath()
+    {
+        string dir = OperatingSystem.IsWindows()
+            ? Path.Combine(
+                Environment.GetEnvironmentVariable("APPDATA")
+                    ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "AppData", "Roaming"),
+                "openhamclock")
+            : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config", "openhamclock");
+        return Path.Combine(dir, "rig-bridge-config.json");
+    }
+
+    /// <summary>
+    /// Write (or merge into) the agent's config so it runs in TCI mode pointed at
+    /// Zeus's TCI server, with our stable API token. Merge-safe: preserves any
+    /// keys the operator may have set, only forcing the radio.type/tci/apiToken
+    /// that make Zeus auto-linking work. configVersion 8 matches the agent's
+    /// current schema (core/config.js CONFIG_VERSION) so it doesn't run a migration.
+    /// </summary>
+    private void WriteConfig(string token)
+    {
+        var path = ConfigPath();
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+            JsonObject root;
+            if (File.Exists(path))
+            {
+                try { root = JsonNode.Parse(File.ReadAllText(path)) as JsonObject ?? new JsonObject(); }
+                catch { root = new JsonObject(); }
+            }
+            else
+            {
+                root = new JsonObject();
+            }
+
+            root["configVersion"] = 8;
+            root["port"] = BridgePort;
+            root["bindAddress"] = "127.0.0.1";
+            root["apiToken"] = token;
+            // Mark the token as already shown so the agent's setup UI gates normally
+            // rather than flashing a first-run "copy this token" banner.
+            root["tokenDisplayed"] = true;
+            root["logging"] = true;
+
+            var radio = root["radio"] as JsonObject ?? new JsonObject();
+            radio["type"] = "tci";
+            root["radio"] = radio;
+
+            var tci = root["tci"] as JsonObject ?? new JsonObject();
+            tci["host"] = "localhost";
+            tci["port"] = TciPort;
+            tci["trx"] = 0;
+            tci["vfo"] = 0;
+            root["tci"] = tci;
+
+            File.WriteAllText(path, root.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+            Append($"Wrote rig-bridge config (radio.type=tci, tci.port={TciPort}) to {path}.");
+        }
+        catch (Exception ex)
+        {
+            Append($"  (rig-bridge config write skipped: {ex.Message})");
+        }
+    }
+
+    // -- Start / Stop -----------------------------------------------------
+
+    /// <summary>
+    /// Write the config and spawn `node rig-bridge.js --port 5555 --bind 127.0.0.1`
+    /// using HamClock's resolved Node. Idempotent: a no-op if already running or
+    /// if the bundled agent isn't present (older HamClock installs). Never throws —
+    /// click-to-tune is a best-effort convenience, not a launch blocker.
+    /// </summary>
+    public async Task StartAsync()
+    {
+        lock (_gate) { if (_proc is { HasExited: false }) return; }
+
+        if (!IsAvailable)
+        {
+            Append("rig-bridge agent not present in this HamClock install — click-to-tune unavailable.");
+            return;
+        }
+
+        var token = GetOrCreateApiToken();
+        WriteConfig(token);
+
+        try
+        {
+            var psi = await HamClock
+                .MakeNodePsiAsync("node", $"\"{Entry}\" --port {BridgePort} --bind 127.0.0.1", RigBridgeDir)
+                .ConfigureAwait(false);
+            if (psi is null)
+            {
+                Append("Node unavailable — rig-bridge not started (reinstall HamClock from Settings).");
+                return;
+            }
+
+            // The agent's TCI plugin requires the `ws` npm package; it resolves
+            // from the parent hamclock/node_modules via Node's upward walk (cwd is
+            // RigBridgeDir). NODE_PATH is belt-and-suspenders for that resolution.
+            psi.Environment["NODE_PATH"] = Path.Combine(HamClockService.InstallDir, "node_modules");
+            psi.Environment["NODE_ENV"] = "production";
+
+            var proc = new Process { StartInfo = psi, EnableRaisingEvents = true };
+            proc.OutputDataReceived += (_, e) => { if (e.Data is not null) Append("[rb] " + e.Data); };
+            proc.ErrorDataReceived += (_, e) => { if (e.Data is not null) Append("[rb!] " + e.Data); };
+            proc.Exited += (_, _) => Append("rig-bridge exited.");
+
+            if (!proc.Start())
+            {
+                Append("Failed to start rig-bridge (node).");
+                return;
+            }
+            proc.BeginOutputReadLine();
+            proc.BeginErrorReadLine();
+            lock (_gate) { _proc = proc; }
+
+            // Best-effort health probe — the agent retries the TCI WS on its own
+            // every few seconds, so we don't block on it.
+            _ = await WaitForListeningAsync(BridgePort, TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+            Append($"rig-bridge running on :{BridgePort} (TCI → :{TciPort}).");
+        }
+        catch (Exception ex)
+        {
+            Append($"  (rig-bridge start error: {ex.Message})");
+        }
+    }
+
+    /// <summary>Kill the rig-bridge child if running. Idempotent.</summary>
+    public void Stop()
+    {
+        Process? proc;
+        lock (_gate) { proc = _proc; _proc = null; }
+        if (proc is { HasExited: false })
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { /* best effort */ }
+        }
+        proc?.Dispose();
+    }
+
+    // -- Helpers ----------------------------------------------------------
+
+    private static async Task<bool> WaitForListeningAsync(int port, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                using var client = new TcpClient();
+                var connect = client.ConnectAsync(IPAddress.Loopback, port);
+                var done = await Task.WhenAny(connect, Task.Delay(1000)).ConfigureAwait(false);
+                if (done == connect && client.Connected)
+                {
+                    await connect.ConfigureAwait(false);
+                    return true;
+                }
+            }
+            catch { /* not listening yet */ }
+            await Task.Delay(300).ConfigureAwait(false);
+        }
+        return false;
+    }
+
+    private void Append(string line)
+    {
+        _log.LogInformation("RigBridge: {Line}", line);
+        lock (_gate)
+        {
+            _logLines.AddLast(line);
+            while (_logLines.Count > MaxLogLines) _logLines.RemoveFirst();
+        }
+    }
+
+    // -- IHostedService (clean shutdown only) -----------------------------
+
+    public Task StartAsync(CancellationToken ct) => Task.CompletedTask;
+
+    public Task StopAsync(CancellationToken ct)
+    {
+        Stop();
+        return Task.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Stop();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -1620,6 +1620,40 @@ public static class ZeusEndpoints
             await hub.AttachClientAsync(ws, ctx.RequestAborted);
         });
 
+        // -- HamClock embed (optional Node sidecar; see HamClockService) -----
+        // Inert until the operator installs it from Settings → HamClock. The
+        // <iframe> in HamClockWindow points at the sidecar's own port (status
+        // reports it), so HamClock serves its own /api proxy + /assets at the
+        // root of that port with no path rewriting.
+        app.MapGet("/api/hamclock/status", (HamClockService hc) => Results.Ok(hc.Snapshot()));
+
+        app.MapPost("/api/hamclock/install", (HamClockService hc) =>
+        {
+            bool started = hc.BeginInstall();
+            return started
+                ? Results.Accepted("/api/hamclock/status", hc.Snapshot())
+                : Results.Conflict(new { error = "HamClock is already installing or starting." });
+        });
+
+        app.MapPost("/api/hamclock/start", async (HamClockService hc) =>
+        {
+            try
+            {
+                var port = await hc.StartAsync();
+                return Results.Ok(new { port, status = hc.Snapshot() });
+            }
+            catch (Exception ex)
+            {
+                return Results.BadRequest(new { error = ex.Message, status = hc.Snapshot() });
+            }
+        });
+
+        app.MapPost("/api/hamclock/stop", (HamClockService hc) =>
+        {
+            hc.Stop();
+            return Results.Ok(hc.Snapshot());
+        });
+
         return app;
     }
 

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -484,6 +484,14 @@ public static class ZeusHost
         builder.Services.AddHostedService(sp => sp.GetRequiredService<SpotBroadcastService>());
         builder.Services.AddSingleton<TciManagementService>();
 
+        // HamClockService — optional, on-demand embed of OpenHamClock (MIT,
+        // github.com/accius/openhamclock) as a Zeus panel. Entirely inert until
+        // the operator clicks Install in Settings → HamClock; nothing here
+        // touches the radio / DSP / TX path. Registered as a hosted service
+        // only so its sidecar Node process is killed on Zeus shutdown.
+        builder.Services.AddSingleton<HamClockService>();
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<HamClockService>());
+
         var app = builder.Build();
 
         // Surface the listening endpoints up front so the operator can pick one

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -138,16 +138,23 @@ public static class ZeusHost
         // HamClock comes up — no operator toggle, no restart. Kestrel's listener
         // is wired at host build (there is no runtime TCI toggle), so we force it
         // on here. This only changes LISTENER PRESENCE: an idle TCI listener with
-        // no client is inert and never touches the radio / DSP / TX path. Skipped
-        // when the operator has deliberately persisted a TCI config (persistedTci
-        // not null) — their explicit choice (incl. a different port or disabled)
-        // wins. The matching in-process TciOptions.Enabled is forced below so
+        // no client is inert and never touches the radio / DSP / TX path. Applied
+        // in desktop mode regardless of any persisted TCI config: the bundled
+        // rig-bridge hard-needs :40001 reachable on LOOPBACK, and any-IP (below)
+        // includes 127.0.0.1 for the bridge AND the LAN IP for external loggers,
+        // so it only ADDS loopback — it never reduces an operator's LAN access.
+        // The matching in-process TciOptions.Enabled is forced below so
         // TciServer.StartAsync doesn't early-return on !Enabled.
-        var desktopAutoTci = persistedTci is null && options.HostMode == ZeusHostMode.Desktop;
+        var desktopAutoTci = options.HostMode == ZeusHostMode.Desktop;
         if (desktopAutoTci)
         {
             tciEnabled = true;
-            tciBindAddress = "localhost";
+            // Bind all IPv4 (0.0.0.0) — NOT "localhost", which resolved to the
+            // machine's LAN IP here (e.g. 10.70.x:40001) and left 127.0.0.1 with
+            // nothing, so the bundled rig-bridge (connecting to loopback) got
+            // ECONNREFUSED. 0.0.0.0 covers 127.0.0.1 for the bridge AND the LAN
+            // for external loggers (N1MM/Log4OM), matching the normal TCI default.
+            tciBindAddress = "0.0.0.0";
             tciPort = 40001;
         }
 

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -131,6 +131,26 @@ public static class ZeusHost
             tciBindAddress = persistedTci.BindAddress;
             tciPort = persistedTci.Port;
         }
+
+        // HamClock click-to-tune auto-link: in desktop mode, ensure Zeus's TCI
+        // server is listening on :40001 so the bundled rig-bridge agent (which
+        // HamClockService spawns when HamClock starts) can connect the instant
+        // HamClock comes up — no operator toggle, no restart. Kestrel's listener
+        // is wired at host build (there is no runtime TCI toggle), so we force it
+        // on here. This only changes LISTENER PRESENCE: an idle TCI listener with
+        // no client is inert and never touches the radio / DSP / TX path. Skipped
+        // when the operator has deliberately persisted a TCI config (persistedTci
+        // not null) — their explicit choice (incl. a different port or disabled)
+        // wins. The matching in-process TciOptions.Enabled is forced below so
+        // TciServer.StartAsync doesn't early-return on !Enabled.
+        var desktopAutoTci = persistedTci is null && options.HostMode == ZeusHostMode.Desktop;
+        if (desktopAutoTci)
+        {
+            tciEnabled = true;
+            tciBindAddress = "localhost";
+            tciPort = 40001;
+        }
+
         // PERF_PASS_3_DEBUG: force-disable TCI bind when running a second
         // instance on the same box (Brian's main session keeps :40001).
         // Uncommitted local edit.
@@ -476,6 +496,18 @@ public static class ZeusHost
                 o.Port = pendingTci.Port;
             });
         }
+        else if (desktopAutoTci)
+        {
+            // Mirror the desktop click-to-tune auto-bind into the in-process
+            // TciOptions so TciServer.StartAsync runs (it early-returns on
+            // !Enabled). Same Enabled/Bind/Port the Kestrel listener bound to above.
+            builder.Services.PostConfigure<TciOptions>(o =>
+            {
+                o.Enabled = true;
+                o.BindAddress = "localhost";
+                o.Port = 40001;
+            });
+        }
         builder.Services.AddSingleton<TciConfigStore>();
         builder.Services.AddSingleton<SpotManager>();
         builder.Services.AddSingleton<TciServer>();
@@ -489,6 +521,12 @@ public static class ZeusHost
         // the operator clicks Install in Settings → HamClock; nothing here
         // touches the radio / DSP / TX path. Registered as a hosted service
         // only so its sidecar Node process is killed on Zeus shutdown.
+        // RigBridgeService — the second supervised Node sidecar that auto-links
+        // HamClock click-to-tune to Zeus's TCI server (spawns the bundled
+        // rig-bridge agent in TCI mode). Inert until HamClock starts; killed on
+        // shutdown via its IHostedService. Touches nothing on the radio/DSP/TX path.
+        builder.Services.AddSingleton<RigBridgeService>();
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<RigBridgeService>());
         builder.Services.AddSingleton<HamClockService>();
         builder.Services.AddHostedService(sp => sp.GetRequiredService<HamClockService>());
 

--- a/zeus-web/src/components/HamClockSettingsPanel.tsx
+++ b/zeus-web/src/components/HamClockSettingsPanel.tsx
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// HamClockSettingsPanel — Settings → HamClock tab. Installs / starts / stops
+// the OpenHamClock sidecar (MIT, github.com/accius/openhamclock) and opens it
+// as a Zeus panel. Mirrors AboutPanel's layout + Zeus tokens.
+//
+// Install downloads HamClock's source from GitHub and builds it with the
+// operator's local Node/npm (a few hundred MB of npm deps land in app-data,
+// not the Zeus installer). Node 18+ must be present; the panel surfaces a
+// clear prereq warning when it isn't.
+
+import { useEffect, useRef } from 'react';
+import { HAMCLOCK_LAYOUT_NAME, useHamClockStore } from '../state/hamclock-store';
+import { useLayoutStore } from '../state/layout-store';
+
+export function HamClockSettingsPanel() {
+  const status = useHamClockStore((s) => s.status);
+  const loadStatus = useHamClockStore((s) => s.loadStatus);
+  const install = useHamClockStore((s) => s.install);
+  const start = useHamClockStore((s) => s.start);
+  const stop = useHamClockStore((s) => s.stop);
+  const openWorkspace = useHamClockStore((s) => s.openWorkspace);
+  const disableWorkspace = useHamClockStore((s) => s.disableWorkspace);
+
+  // Whether the HamClock workspace tab currently exists (reactive — the toggle
+  // reflects adds/removes from anywhere). Per-radio, like every Zeus layout.
+  const workspaceEnabled = useLayoutStore((s) =>
+    s.layouts.some((l) => l.name === HAMCLOCK_LAYOUT_NAME),
+  );
+
+  const logRef = useRef<HTMLDivElement>(null);
+
+  // Poll status while this tab is mounted — faster while an install/start is
+  // in flight so the log streams.
+  useEffect(() => {
+    void loadStatus();
+    const busy = status.busy || status.phase === 'Installing' || status.phase === 'Starting';
+    const id = window.setInterval(() => void loadStatus(), busy ? 1500 : 5000);
+    return () => window.clearInterval(id);
+  }, [loadStatus, status.busy, status.phase]);
+
+  // Keep the log scrolled to the newest line.
+  useEffect(() => {
+    if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight;
+  }, [status.log]);
+
+  const installing = status.phase === 'Installing';
+  const starting = status.phase === 'Starting';
+  const canInstall = !status.busy && !installing && !starting;
+
+  return (
+    <div style={{ maxWidth: 640 }}>
+      <h3 style={{
+        margin: '0 0 16px 0', fontSize: 13, fontWeight: 700,
+        letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--fg-0)',
+      }}>
+        HamClock
+      </h3>
+
+      <p style={{ margin: '0 0 16px 0', lineHeight: 1.6, color: 'var(--fg-2)', fontSize: 12 }}>
+        Embed{' '}
+        <a
+          href="https://github.com/accius/openhamclock"
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: 'var(--accent)', textDecoration: 'underline' }}
+        >
+          OpenHamClock
+        </a>{' '}
+        — a ham-radio dashboard (propagation, DX cluster, satellites, POTA/SOTA,
+        space weather) — as a panel inside Zeus. Installing downloads it from
+        GitHub and builds it locally; nothing is bundled into the Zeus installer.
+      </p>
+
+      {/* Status line */}
+      <div style={{ marginBottom: 14, display: 'flex', alignItems: 'center', gap: 10 }}>
+        <span style={{ color: 'var(--fg-2)', fontSize: 12 }}>Status:</span>
+        <StatusPill phase={status.phase} />
+        {status.version && (
+          <span style={{ color: 'var(--fg-3)', fontSize: 11, fontFamily: 'var(--font-mono, ui-monospace, monospace)' }}>
+            v{status.version}
+          </span>
+        )}
+        {status.running && status.port > 0 && (
+          <span style={{ color: 'var(--fg-3)', fontSize: 11, fontFamily: 'var(--font-mono, ui-monospace, monospace)' }}>
+            port {status.port}
+          </span>
+        )}
+      </div>
+
+      {/* Node prereq — informational. Install fetches a private Node when the
+          system has none, so this never blocks installation. */}
+      {!status.nodeAvailable && !installing && (
+        <div style={{
+          padding: 10, marginBottom: 14, borderRadius: 'var(--r-sm, 4px)',
+          background: 'rgba(74, 158, 255, 0.08)', border: '1px solid rgba(74, 158, 255, 0.25)',
+          color: 'var(--fg-1)', fontSize: 12, lineHeight: 1.5,
+        }}>
+          No system Node.js detected — Install will download a private copy
+          (~30 MB) automatically. No separate install needed.
+        </div>
+      )}
+      {status.nodeAvailable && status.nodeVersion && (
+        <div style={{ marginBottom: 14, fontSize: 11, color: 'var(--fg-3)' }}>
+          Node {status.nodeVersion} ready.
+        </div>
+      )}
+
+      {/* Error */}
+      {status.error && (
+        <div style={{
+          padding: 10, marginBottom: 14, borderRadius: 'var(--r-sm, 4px)',
+          background: 'rgba(230, 58, 43, 0.1)', border: '1px solid rgba(230, 58, 43, 0.3)',
+          color: 'var(--tx)', fontSize: 12, lineHeight: 1.5,
+        }}>
+          {status.error}
+        </div>
+      )}
+
+      {/* Actions — install, then enable/disable the workspace tab. */}
+      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 6 }}>
+        <button
+          type="button"
+          className="btn sm"
+          disabled={!canInstall}
+          onClick={() => void install()}
+          title={status.installed
+            ? 'Re-download and rebuild HamClock'
+            : 'Download and build HamClock (downloads Node automatically if needed)'}
+        >
+          {installing ? 'INSTALLING…' : status.installed ? 'REINSTALL' : 'INSTALL'}
+        </button>
+
+        {/* Enable workspace — creates the HamClock layout tab and switches to
+            it (the panel auto-starts the sidecar on mount). */}
+        {status.installed && !workspaceEnabled && (
+          <button
+            type="button"
+            className="btn sm active"
+            disabled={status.busy || starting}
+            onClick={() => {
+              if (!status.running) void start();
+              openWorkspace();
+            }}
+            title="Add the HamClock workspace tab and open it"
+          >
+            {starting ? 'STARTING…' : 'ENABLE WORKSPACE'}
+          </button>
+        )}
+
+        {/* Workspace already enabled — jump to it or remove it. */}
+        {status.installed && workspaceEnabled && (
+          <>
+            <button
+              type="button"
+              className="btn sm active"
+              onClick={() => {
+                if (!status.running) void start();
+                openWorkspace();
+              }}
+              title="Switch to the HamClock workspace"
+            >
+              OPEN
+            </button>
+            <button
+              type="button"
+              className="btn sm"
+              onClick={() => disableWorkspace()}
+              title="Remove the HamClock workspace tab (does not uninstall)"
+            >
+              DISABLE WORKSPACE
+            </button>
+          </>
+        )}
+
+        {/* Stop the sidecar process. Independent of the workspace tab. */}
+        {status.running && (
+          <button
+            type="button"
+            className="btn sm"
+            onClick={() => void stop()}
+            title="Stop the HamClock server process"
+          >
+            STOP SERVER
+          </button>
+        )}
+      </div>
+
+      <div style={{ marginBottom: 16, fontSize: 11, color: 'var(--fg-3)', lineHeight: 1.5 }}>
+        {!status.installed
+          ? 'Install once, then enable the workspace to add a HamClock tab to the left layout bar.'
+          : workspaceEnabled
+            ? 'HamClock has its own tab in the left layout bar. Disable to remove it.'
+            : 'Enable the workspace to add a HamClock tab to the left layout bar.'}
+      </div>
+
+      {/* Install / run log */}
+      {status.log.length > 0 && (
+        <div>
+          <div style={{
+            fontSize: 10, letterSpacing: 0.8, textTransform: 'uppercase',
+            color: 'var(--fg-3)', marginBottom: 6,
+          }}>
+            Log
+          </div>
+          <div
+            ref={logRef}
+            style={{
+              maxHeight: 220, overflowY: 'auto',
+              padding: '8px 10px',
+              background: 'var(--bg-1, #0e1014)', border: '1px solid var(--line-1, var(--line))',
+              borderRadius: 6,
+              fontFamily: 'var(--font-mono, JetBrains Mono, ui-monospace, monospace)',
+              fontSize: 10.5, lineHeight: 1.5, color: 'var(--fg-1)',
+              whiteSpace: 'pre-wrap', wordBreak: 'break-word',
+            }}
+          >
+            {status.log.map((line, i) => (
+              <div key={i} style={{ color: line.startsWith('ERROR') ? 'var(--tx)' : undefined }}>
+                {line}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatusPill({ phase }: { phase: string }) {
+  const map: Record<string, { color: string; bg: string }> = {
+    Running:      { color: 'var(--accent)', bg: 'rgba(74,158,255,0.12)' },
+    Installed:    { color: 'var(--fg-1)',   bg: 'var(--bg-2)' },
+    Installing:   { color: 'var(--power)',  bg: 'rgba(255,201,58,0.12)' },
+    Starting:     { color: 'var(--power)',  bg: 'rgba(255,201,58,0.12)' },
+    Error:        { color: 'var(--tx)',     bg: 'rgba(230,58,43,0.12)' },
+    NotInstalled: { color: 'var(--fg-3)',   bg: 'var(--bg-2)' },
+  };
+  const s = map[phase] ?? map.NotInstalled!;
+  return (
+    <span style={{
+      padding: '2px 8px', borderRadius: 10, fontSize: 11, fontWeight: 600,
+      color: s.color, background: s.bg, border: `1px solid ${s.color}`,
+    }}>
+      {phase}
+    </span>
+  );
+}

--- a/zeus-web/src/components/SettingsMenu.tsx
+++ b/zeus-web/src/components/SettingsMenu.tsx
@@ -37,6 +37,7 @@ import { useRadioStore } from '../state/radio-store';
 import { PsSettingsPanel } from './PsSettingsPanel';
 import { TxAudioToolsPanel } from './TxAudioToolsPanel';
 import { PluginsPanel } from '../plugins/components/PluginsPanel';
+import { HamClockSettingsPanel } from './HamClockSettingsPanel';
 
 export type SettingsTabId =
   | 'pa'
@@ -48,6 +49,7 @@ export type SettingsTabId =
   | 'tci'
   | 'display'
   | 'plugins'
+  | 'hamclock'
   | 'server'
   | 'radio'
   | 'radio-settings'
@@ -64,6 +66,7 @@ const TABS: ReadonlyArray<{ id: SettingsTabId; label: string }> = [
   { id: 'tci', label: 'TCI' },
   { id: 'display', label: 'DISPLAY' },
   { id: 'plugins', label: 'PLUGINS' },
+  { id: 'hamclock', label: 'HAMCLOCK' },
   { id: 'server', label: 'SERVER' },
   { id: 'radio', label: 'RADIO' },
   { id: 'radio-settings', label: 'RADIO SETTINGS' },
@@ -202,6 +205,7 @@ export function SettingsView({ initialTab, onClose }: Props) {
           {active === 'tci' && <TciSettingsPanel />}
           {active === 'display' && <DisplayPanel />}
           {active === 'plugins' && <PluginsPanel />}
+          {active === 'hamclock' && <HamClockSettingsPanel />}
           {active === 'server' && <ServerUrlPanel />}
           {active === 'radio' && hasHl2OptionalToggles && <RadioOptionsPanel />}
           {active === 'radio-settings' && hasExternalPorts && <RadioSettingsPanel />}

--- a/zeus-web/src/layout/__tests__/AddPanelModal.test.tsx
+++ b/zeus-web/src/layout/__tests__/AddPanelModal.test.tsx
@@ -55,10 +55,10 @@ describe('AddPanelModal', () => {
     const cards = container.querySelectorAll(
       '[data-testid="add-panel-cards"] .add-panel-card',
     );
-    // 21 panels in registry (CW Decoder added in zeus-cdn; RF-2K panel and
+    // 22 panels in registry (CW Decoder added in zeus-cdn; RF-2K panel and
     // Voyeur Mode net monitor were both extracted to plugins; Rotator Dial was
-    // added in #385; WAV recorder added in #579).
-    expect(cards.length).toBe(21);
+    // added in #385; WAV recorder added in #579; HamClock embed added).
+    expect(cards.length).toBe(22);
     unmount();
   });
 

--- a/zeus-web/src/layout/panels.ts
+++ b/zeus-web/src/layout/panels.ts
@@ -65,6 +65,7 @@ import { StepPanel } from './panels/StepPanel';
 import { MeterGroupPanel } from '../components/meter-group/MeterGroupPanel';
 import { AnalogMeterPanel } from './panels/AnalogMeterPanel';
 import { WavRecorderPanel } from './panels/WavRecorderPanel';
+import { HamClockPanel } from './panels/HamClockPanel';
 
 export type PanelCategory =
   | 'spectrum'
@@ -326,6 +327,17 @@ export const PANELS: Record<string, PanelDef> = {
     tags: ['analog', 'meter', 'smeter', 's-meter', 'signal', 'rx', 'tx', 'power', 'swr', 'needle'],
     component: AnalogMeterPanel,
     headerless: true,
+  },
+  hamclock: {
+    id: 'hamclock',
+    name: 'HamClock',
+    category: 'tools',
+    tags: ['hamclock', 'dashboard', 'propagation', 'dx', 'cluster', 'satellite', 'pota', 'sota', 'space weather', 'map'],
+    component: HamClockPanel,
+    // Wants the whole workspace — it's a full dashboard embedded as an iframe.
+    // Full-bleed sizing comes from DEFAULT_TILE_SPAN.hamclock (12×24 on the
+    // 12-col grid); develop's PanelDef has no minW/minH floor, so we don't set
+    // one here.
   },
 };
 

--- a/zeus-web/src/layout/panels/HamClockPanel.tsx
+++ b/zeus-web/src/layout/panels/HamClockPanel.tsx
@@ -10,22 +10,8 @@
 // then shows the iframe; otherwise it shows install/start state and points the
 // operator at Settings → HamClock.
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect } from 'react';
 import { hamclockIframeUrl, useHamClockStore } from '../../state/hamclock-store';
-
-// Fixed logical render size for the embedded HamClock dashboard. The iframe
-// is always rendered at this resolution and the whole view is uniformly
-// scaled (transform: scale) to fit the tile, so the dashboard keeps the same
-// visual scale/aspect when the operator grows or shrinks the panel instead of
-// reflowing into HamClock's mobile/tablet breakpoints. 1280×800 sits above
-// HamClock's largest responsive breakpoint (1024px) so the full desktop
-// multi-panel layout always renders; 16:10 matches the tall default tile span
-// (DEFAULT_TILE_SPAN.hamclock = 12×24).
-const HAMCLOCK_BASE_W = 1280;
-const HAMCLOCK_BASE_H = 800;
-// Floor so the dashboard never scales to nothing on a tiny tile; below this
-// the wrapper's overflow:hidden simply crops.
-const HAMCLOCK_MIN_SCALE = 0.2;
 
 export function HamClockPanel() {
   const status = useHamClockStore((s) => s.status);
@@ -63,73 +49,11 @@ export function HamClockPanel() {
   const url = running ? hamclockIframeUrl(status.port) : '';
 
   if (running) {
-    return <ScaledHamClockFrame url={url} />;
-  }
-
-  return <HamClockPlaceholder status={status} onStart={() => void start()} />;
-}
-
-// Renders the HamClock iframe at a fixed logical base size and uniformly
-// scales it (preserving aspect — letterboxed, never distorted) to fit the
-// tile via a ResizeObserver on the wrapping host. This is what keeps the
-// dashboard at a constant visual scale as the operator resizes the panel.
-//
-// The wrapper is also the seam for the resize-handle fix: an <iframe> is its
-// own hit-test root and swallows the pointerdown that would start an RGL
-// corner-resize. A transparent same-document grip sits over the tile's SE
-// corner so the operator can always grab the resize affordance; once a
-// drag/resize gesture begins, all-panels.css neutralises the iframe's
-// pointer-events (`.resizing`/`.react-draggable-dragging iframe`) so the
-// gesture keeps tracking over the iframe surface.
-function ScaledHamClockFrame({ url }: { url: string }) {
-  const hostRef = useRef<HTMLDivElement>(null);
-  const [scale, setScale] = useState(1);
-
-  useEffect(() => {
-    const host = hostRef.current;
-    if (!host) return;
-    const ro = new ResizeObserver((entries) => {
-      const entry = entries[0];
-      if (!entry) return;
-      const { width, height } = entry.contentRect;
-      if (width <= 0 || height <= 0) return;
-      // Uniform scale: the smaller axis ratio so the whole dashboard fits
-      // without distortion (the other axis letterboxes).
-      const next = Math.min(width / HAMCLOCK_BASE_W, height / HAMCLOCK_BASE_H);
-      setScale(Math.max(HAMCLOCK_MIN_SCALE, next));
-    });
-    ro.observe(host);
-    return () => ro.disconnect();
-  }, []);
-
-  return (
-    <div
-      ref={hostRef}
-      style={{
-        flex: 1,
-        width: '100%',
-        height: '100%',
-        minHeight: 0,
-        position: 'relative',
-        overflow: 'hidden', // clip the un-shrunk layout box + letterbox bars
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        background: 'var(--bg-1)', // letterbox bars read as panel base
-      }}
-    >
+    return (
       <iframe
         title="HamClock"
         src={url}
-        style={{
-          width: HAMCLOCK_BASE_W,
-          height: HAMCLOCK_BASE_H,
-          flex: 'none', // don't let the flex host stretch the base size
-          border: 'none',
-          display: 'block',
-          transform: `scale(${scale})`,
-          transformOrigin: 'center center', // matches the flex centering
-        }}
+        style={{ flex: 1, width: '100%', height: '100%', border: 'none', display: 'block', minHeight: 0 }}
         // HamClock is a trusted local sidecar; allow scripts + same-origin so
         // its app (storage, its own /api fetches) works. allow-downloads lets
         // its Rig Bridge / rig-listener installer downloads through — the embed
@@ -140,15 +64,10 @@ function ScaledHamClockFrame({ url }: { url: string }) {
         // location" works (Permissions-Policy is deny-by-default for iframes).
         allow="geolocation"
       />
-      {/* Same-document grip over the tile's SE corner. The iframe would
-          otherwise eat the pointerdown that starts an RGL corner-resize; this
-          transparent layer lives in the host document and aligns with the
-          RGL resize handle (right/bottom 2px, 20×20 in all-panels.css) so the
-          press lands on the parent and the resize starts. pointer-events on
-          the iframe are dropped for the rest of the gesture via CSS. */}
-      <div className="hamclock-resize-catch" aria-hidden />
-    </div>
-  );
+    );
+  }
+
+  return <HamClockPlaceholder status={status} onStart={() => void start()} />;
 }
 
 function HamClockPlaceholder({

--- a/zeus-web/src/layout/panels/HamClockPanel.tsx
+++ b/zeus-web/src/layout/panels/HamClockPanel.tsx
@@ -10,8 +10,22 @@
 // then shows the iframe; otherwise it shows install/start state and points the
 // operator at Settings → HamClock.
 
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { hamclockIframeUrl, useHamClockStore } from '../../state/hamclock-store';
+
+// Fixed logical render size for the embedded HamClock dashboard. The iframe
+// is always rendered at this resolution and the whole view is uniformly
+// scaled (transform: scale) to fit the tile, so the dashboard keeps the same
+// visual scale/aspect when the operator grows or shrinks the panel instead of
+// reflowing into HamClock's mobile/tablet breakpoints. 1280×800 sits above
+// HamClock's largest responsive breakpoint (1024px) so the full desktop
+// multi-panel layout always renders; 16:10 matches the tall default tile span
+// (DEFAULT_TILE_SPAN.hamclock = 12×24).
+const HAMCLOCK_BASE_W = 1280;
+const HAMCLOCK_BASE_H = 800;
+// Floor so the dashboard never scales to nothing on a tiny tile; below this
+// the wrapper's overflow:hidden simply crops.
+const HAMCLOCK_MIN_SCALE = 0.2;
 
 export function HamClockPanel() {
   const status = useHamClockStore((s) => s.status);
@@ -49,11 +63,73 @@ export function HamClockPanel() {
   const url = running ? hamclockIframeUrl(status.port) : '';
 
   if (running) {
-    return (
+    return <ScaledHamClockFrame url={url} />;
+  }
+
+  return <HamClockPlaceholder status={status} onStart={() => void start()} />;
+}
+
+// Renders the HamClock iframe at a fixed logical base size and uniformly
+// scales it (preserving aspect — letterboxed, never distorted) to fit the
+// tile via a ResizeObserver on the wrapping host. This is what keeps the
+// dashboard at a constant visual scale as the operator resizes the panel.
+//
+// The wrapper is also the seam for the resize-handle fix: an <iframe> is its
+// own hit-test root and swallows the pointerdown that would start an RGL
+// corner-resize. A transparent same-document grip sits over the tile's SE
+// corner so the operator can always grab the resize affordance; once a
+// drag/resize gesture begins, all-panels.css neutralises the iframe's
+// pointer-events (`.resizing`/`.react-draggable-dragging iframe`) so the
+// gesture keeps tracking over the iframe surface.
+function ScaledHamClockFrame({ url }: { url: string }) {
+  const hostRef = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(1);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      const { width, height } = entry.contentRect;
+      if (width <= 0 || height <= 0) return;
+      // Uniform scale: the smaller axis ratio so the whole dashboard fits
+      // without distortion (the other axis letterboxes).
+      const next = Math.min(width / HAMCLOCK_BASE_W, height / HAMCLOCK_BASE_H);
+      setScale(Math.max(HAMCLOCK_MIN_SCALE, next));
+    });
+    ro.observe(host);
+    return () => ro.disconnect();
+  }, []);
+
+  return (
+    <div
+      ref={hostRef}
+      style={{
+        flex: 1,
+        width: '100%',
+        height: '100%',
+        minHeight: 0,
+        position: 'relative',
+        overflow: 'hidden', // clip the un-shrunk layout box + letterbox bars
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'var(--bg-1)', // letterbox bars read as panel base
+      }}
+    >
       <iframe
         title="HamClock"
         src={url}
-        style={{ flex: 1, width: '100%', height: '100%', border: 'none', display: 'block', minHeight: 0 }}
+        style={{
+          width: HAMCLOCK_BASE_W,
+          height: HAMCLOCK_BASE_H,
+          flex: 'none', // don't let the flex host stretch the base size
+          border: 'none',
+          display: 'block',
+          transform: `scale(${scale})`,
+          transformOrigin: 'center center', // matches the flex centering
+        }}
         // HamClock is a trusted local sidecar; allow scripts + same-origin so
         // its app (storage, its own /api fetches) works. allow-downloads lets
         // its Rig Bridge / rig-listener installer downloads through — the embed
@@ -64,10 +140,15 @@ export function HamClockPanel() {
         // location" works (Permissions-Policy is deny-by-default for iframes).
         allow="geolocation"
       />
-    );
-  }
-
-  return <HamClockPlaceholder status={status} onStart={() => void start()} />;
+      {/* Same-document grip over the tile's SE corner. The iframe would
+          otherwise eat the pointerdown that starts an RGL corner-resize; this
+          transparent layer lives in the host document and aligns with the
+          RGL resize handle (right/bottom 2px, 20×20 in all-panels.css) so the
+          press lands on the parent and the resize starts. pointer-events on
+          the iframe are dropped for the rest of the gesture via CSS. */}
+      <div className="hamclock-resize-catch" aria-hidden />
+    </div>
+  );
 }
 
 function HamClockPlaceholder({

--- a/zeus-web/src/layout/panels/HamClockPanel.tsx
+++ b/zeus-web/src/layout/panels/HamClockPanel.tsx
@@ -55,8 +55,11 @@ export function HamClockPanel() {
         src={url}
         style={{ flex: 1, width: '100%', height: '100%', border: 'none', display: 'block', minHeight: 0 }}
         // HamClock is a trusted local sidecar; allow scripts + same-origin so
-        // its app (storage, its own /api fetches) works.
-        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
+        // its app (storage, its own /api fetches) works. allow-downloads lets
+        // its Rig Bridge / rig-listener installer downloads through — the embed
+        // sandbox blocks them otherwise (they work standalone, where there's no
+        // sandbox).
+        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals allow-downloads"
       />
     );
   }

--- a/zeus-web/src/layout/panels/HamClockPanel.tsx
+++ b/zeus-web/src/layout/panels/HamClockPanel.tsx
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// HamClockPanel — workspace tile that embeds OpenHamClock (MIT,
+// github.com/accius/openhamclock) in an <iframe>. Lives in its own
+// auto-created "HamClock" layout (see hamclock-store.openWorkspace), filling
+// the workspace edge-to-edge.
+//
+// OpenHamClock runs as a Zeus-supervised Node sidecar (HamClockService). This
+// panel auto-starts the sidecar when mounted, polls status until it's Running,
+// then shows the iframe; otherwise it shows install/start state and points the
+// operator at Settings → HamClock.
+
+import { useEffect } from 'react';
+import { hamclockIframeUrl, useHamClockStore } from '../../state/hamclock-store';
+
+export function HamClockPanel() {
+  const status = useHamClockStore((s) => s.status);
+  const loadStatus = useHamClockStore((s) => s.loadStatus);
+  const start = useHamClockStore((s) => s.start);
+
+  // Auto-start the sidecar on mount if it's installed but not running, then
+  // poll until it reaches Running so the iframe appears. Faster tick while an
+  // install/start is in flight.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      await loadStatus();
+      if (cancelled) return;
+      const s = useHamClockStore.getState().status;
+      if (s.installed && !s.running && !s.busy && s.phase !== 'Starting') {
+        await start();
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // Run once on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const busy = status.busy || status.phase === 'Installing' || status.phase === 'Starting';
+    if (!busy && status.running) return; // settled — no need to keep polling
+    const id = window.setInterval(() => void loadStatus(), busy ? 1500 : 4000);
+    return () => window.clearInterval(id);
+  }, [loadStatus, status.busy, status.phase, status.running]);
+
+  const running = status.running && status.port > 0;
+  const url = running ? hamclockIframeUrl(status.port) : '';
+
+  if (running) {
+    return (
+      <iframe
+        title="HamClock"
+        src={url}
+        style={{ flex: 1, width: '100%', height: '100%', border: 'none', display: 'block', minHeight: 0 }}
+        // HamClock is a trusted local sidecar; allow scripts + same-origin so
+        // its app (storage, its own /api fetches) works.
+        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
+      />
+    );
+  }
+
+  return <HamClockPlaceholder status={status} onStart={() => void start()} />;
+}
+
+function HamClockPlaceholder({
+  status,
+  onStart,
+}: {
+  status: ReturnType<typeof useHamClockStore.getState>['status'];
+  onStart: () => void;
+}) {
+  let message: string;
+  if (status.error) message = status.error;
+  else if (status.phase === 'Installing') message = 'Installing HamClock… (downloading + building)';
+  else if (status.phase === 'Starting') message = 'Starting HamClock server…';
+  else if (!status.installed) message = 'HamClock is not installed yet. Open Settings → HamClock to install it.';
+  else message = 'Starting HamClock…';
+
+  return (
+    <div
+      style={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 14,
+        padding: 24,
+        textAlign: 'center',
+      }}
+    >
+      <div style={{ fontSize: 13, fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--fg-1)' }}>
+        HamClock
+      </div>
+      <div style={{ fontSize: 12, color: status.error ? 'var(--tx)' : 'var(--fg-2)', maxWidth: 420, lineHeight: 1.5 }}>
+        {message}
+      </div>
+      {status.installed && status.phase !== 'Installing' && status.phase !== 'Starting' && (
+        <button type="button" className="btn sm active" disabled={status.busy} onClick={onStart}>
+          {status.busy ? 'Starting…' : 'Start HamClock'}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/zeus-web/src/layout/panels/HamClockPanel.tsx
+++ b/zeus-web/src/layout/panels/HamClockPanel.tsx
@@ -60,6 +60,9 @@ export function HamClockPanel() {
         // sandbox blocks them otherwise (they work standalone, where there's no
         // sandbox).
         sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals allow-downloads"
+        // Delegate Geolocation into the embed so HamClock's "Use my current
+        // location" works (Permissions-Policy is deny-by-default for iframes).
+        allow="geolocation"
       />
     );
   }

--- a/zeus-web/src/layout/workspace.ts
+++ b/zeus-web/src/layout/workspace.ts
@@ -90,6 +90,10 @@ export const DEFAULT_TILE_SPAN: Record<string, { w: number; h: number }> = {
   // freshly-added tile shows just the empty-state hint, not 4 columns of
   // blank space waiting for widgets.
   metergroup: { w: 1, h: 6 },
+  // HamClock fills the whole workspace — it's an embedded dashboard. The
+  // originating fork authored this as 24×48 on a 24-col grid; develop's grid is
+  // 12-col (WORKSPACE_GRID_COLS=12) so the full-bleed span is 12×24.
+  hamclock: { w: 12, h: 24 },
 };
 
 const FALLBACK_SPAN = { w: 4, h: 4 };

--- a/zeus-web/src/main.tsx
+++ b/zeus-web/src/main.tsx
@@ -98,6 +98,22 @@ installFetchInterceptor();
 // and re-renders when entries land.
 void loadInstalledPluginUis();
 
+// Desktop download bridge. The embedded HamClock iframe is patched (server-side,
+// ZEUS_DL_BRIDGE) to postMessage attachment-download URLs up to this top frame
+// instead of navigating — the Photino desktop webview otherwise silently drops
+// them. Relay the URL to the C# host (window.external.sendMessage), which fetches
+// + saves it to the Downloads folder. No-op in a plain browser (window.external
+// has no sendMessage), where native downloads already work.
+window.addEventListener('message', (e: MessageEvent) => {
+  const data = e.data as { zeusDownload?: unknown } | null | undefined;
+  const url = data && typeof data === 'object' ? data.zeusDownload : undefined;
+  if (typeof url !== 'string' || !url) return;
+  // Only forward same-origin-shaped http(s) loopback URLs the host can fetch.
+  if (!/^https?:\/\//i.test(url)) return;
+  const ext = (window as unknown as { external?: { sendMessage?: (m: string) => void } }).external;
+  ext?.sendMessage?.('download:' + url);
+});
+
 // Seed the operator's chosen theme on <html> BEFORE React paints. The
 // ThemeApplier component reapplies on store changes; this just prevents
 // a flash of dark-chrome on first render when the operator's saved

--- a/zeus-web/src/state/hamclock-store.ts
+++ b/zeus-web/src/state/hamclock-store.ts
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// HamClock install/run state + "open as a workspace" helper.
+//
+// The HamClock panel embeds OpenHamClock (MIT, github.com/accius/openhamclock)
+// as an <iframe>. OpenHamClock runs as a Zeus-supervised Node sidecar on its
+// own port — see HamClockService on the backend. This store mirrors the
+// install/run status from GET /api/hamclock/status and drives the
+// install/start/stop endpoints.
+//
+// "Open as a workspace": rather than a floating window, HamClock gets its own
+// named layout in the LeftLayoutBar (a single full-bleed hamclock tile), so it
+// behaves like any other Zeus workspace. openWorkspace() creates that layout
+// on first use (idempotent by name) and switches to it.
+
+import { create } from 'zustand';
+import { useLayoutStore } from './layout-store';
+
+/** Name of the auto-created HamClock layout in the LeftLayoutBar. */
+export const HAMCLOCK_LAYOUT_NAME = 'HamClock';
+/** Panel registry id for the HamClock iframe tile. */
+export const HAMCLOCK_PANEL_ID = 'hamclock';
+
+/** Mirror of the backend HamClockStatus record. */
+export interface HamClockStatus {
+  phase:
+    | 'NotInstalled'
+    | 'Installing'
+    | 'Installed'
+    | 'Starting'
+    | 'Running'
+    | 'Error';
+  installed: boolean;
+  running: boolean;
+  busy: boolean;
+  port: number;
+  version: string | null;
+  nodeAvailable: boolean;
+  nodeVersion: string | null;
+  error: string | null;
+  log: string[];
+}
+
+const EMPTY_STATUS: HamClockStatus = {
+  phase: 'NotInstalled',
+  installed: false,
+  running: false,
+  busy: false,
+  port: 0,
+  version: null,
+  nodeAvailable: false,
+  nodeVersion: null,
+  error: null,
+  log: [],
+};
+
+interface HamClockState {
+  status: HamClockStatus;
+  loadStatus(): Promise<void>;
+  install(): Promise<void>;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  /** Enable the HamClock workspace: ensure the layout exists and switch to it.
+   *  Creates it (single full-bleed hamclock tile) on first use. Idempotent. */
+  openWorkspace(): void;
+  /** Disable the HamClock workspace: remove its layout tab from the
+   *  LeftLayoutBar. The sidecar process is left untouched (use Stop for that).
+   *  No-op if the workspace isn't enabled. */
+  disableWorkspace(): void;
+}
+
+/**
+ * Build the iframe src for a running HamClock sidecar. HamClock binds all
+ * interfaces, so a LAN client loads it from the same host it reached Zeus on;
+ * desktop loopback loads it from localhost. Always plain HTTP (HamClock has no
+ * TLS) — under an HTTPS Zeus origin the browser blocks this as mixed content
+ * (known limitation of the LAN/HTTPS path; desktop is unaffected).
+ */
+export function hamclockIframeUrl(port: number): string {
+  if (!port) return '';
+  const host = window.location.hostname || '127.0.0.1';
+  return `http://${host}:${port}/`;
+}
+
+export const useHamClockStore = create<HamClockState>()((set) => ({
+  status: EMPTY_STATUS,
+
+  loadStatus: async () => {
+    try {
+      const res = await fetch('/api/hamclock/status');
+      if (!res.ok) return;
+      set({ status: (await res.json()) as HamClockStatus });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn('hamclock status GET threw', err);
+    }
+  },
+
+  install: async () => {
+    try {
+      const res = await fetch('/api/hamclock/install', { method: 'POST' });
+      if (res.ok || res.status === 202) {
+        set({ status: (await res.json()) as HamClockStatus });
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn('hamclock install POST threw', err);
+    }
+  },
+
+  start: async () => {
+    try {
+      const res = await fetch('/api/hamclock/start', { method: 'POST' });
+      const body = await res.json();
+      if (body?.status) set({ status: body.status as HamClockStatus });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn('hamclock start POST threw', err);
+    }
+  },
+
+  stop: async () => {
+    try {
+      const res = await fetch('/api/hamclock/stop', { method: 'POST' });
+      if (res.ok) set({ status: (await res.json()) as HamClockStatus });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn('hamclock stop POST threw', err);
+    }
+  },
+
+  openWorkspace: () => {
+    const ls = useLayoutStore.getState();
+    const existing = ls.layouts.find((l) => l.name === HAMCLOCK_LAYOUT_NAME);
+    if (existing) {
+      ls.setActiveLayout(existing.id);
+      return;
+    }
+    // Create the layout (addLayout switches to it and seeds the default radio
+    // tiles), then replace those with a single full-bleed HamClock tile.
+    ls.addLayout(HAMCLOCK_LAYOUT_NAME, {
+      icon: '🕐',
+      description: 'OpenHamClock dashboard',
+    });
+    const seeded = useLayoutStore.getState().workspace.tiles.map((t) => t.uid);
+    for (const uid of seeded) useLayoutStore.getState().removeTile(uid);
+    const uid = useLayoutStore.getState().addTile(HAMCLOCK_PANEL_ID);
+    // develop's workspace grid is 12-col (WORKSPACE_GRID_COLS=12); the
+    // originating fork authored this in 24-col units. Halve to fill the grid.
+    useLayoutStore.getState().updateTilePlacement(uid, { x: 0, y: 0, w: 12, h: 24 });
+  },
+
+  disableWorkspace: () => {
+    const ls = useLayoutStore.getState();
+    const existing = ls.layouts.find((l) => l.name === HAMCLOCK_LAYOUT_NAME);
+    if (existing) ls.removeLayout(existing.id);
+  },
+}));

--- a/zeus-web/src/styles/all-panels.css
+++ b/zeus-web/src/styles/all-panels.css
@@ -111,6 +111,37 @@
   opacity: 1;
 }
 
+/* HamClock (and any other iframe-bodied tile) resize fix.
+ *
+ * An <iframe> is its own hit-test root: a pointerdown anywhere over its
+ * rectangle is consumed by the embedded document before the parent-document
+ * RGL resize handle (z-index:2, above) can see it — z-index orders elements
+ * within a document but cannot pull a host handle in front of an iframe's
+ * internal hit-testing. Two pieces fix it:
+ *
+ * 1. `.hamclock-resize-catch` — a transparent host-document layer over the
+ *    tile's SE corner, sitting ABOVE the iframe (z-index:1) but BELOW the RGL
+ *    handle (z-index:2). It gives the host document a real hit surface in the
+ *    corner so the iframe can't swallow corner presses, while the handle
+ *    itself still wins on its own pixels and starts the resize.
+ * 2. Once a drag/resize gesture is live, RGL stamps `.resizing` /
+ *    `.react-draggable-dragging` on the grid item; we drop the iframe's
+ *    pointer-events for the duration so tracking continues over the whole
+ *    iframe surface and settles on release. */
+.hamclock-resize-catch {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: 22px;
+  height: 22px;
+  z-index: 1;
+  cursor: se-resize;
+}
+.all-panels-grid .react-grid-item.resizing iframe,
+.all-panels-grid .react-grid-item.react-draggable-dragging iframe {
+  pointer-events: none;
+}
+
 /* Workspace tile — beveled chrome wrapping the panel body. Mirrors the
  * .panel recipe from layout.css so RGL tiles read the same as the legacy
  * fixed-grid panels. */

--- a/zeus-web/src/styles/all-panels.css
+++ b/zeus-web/src/styles/all-panels.css
@@ -111,37 +111,6 @@
   opacity: 1;
 }
 
-/* HamClock (and any other iframe-bodied tile) resize fix.
- *
- * An <iframe> is its own hit-test root: a pointerdown anywhere over its
- * rectangle is consumed by the embedded document before the parent-document
- * RGL resize handle (z-index:2, above) can see it — z-index orders elements
- * within a document but cannot pull a host handle in front of an iframe's
- * internal hit-testing. Two pieces fix it:
- *
- * 1. `.hamclock-resize-catch` — a transparent host-document layer over the
- *    tile's SE corner, sitting ABOVE the iframe (z-index:1) but BELOW the RGL
- *    handle (z-index:2). It gives the host document a real hit surface in the
- *    corner so the iframe can't swallow corner presses, while the handle
- *    itself still wins on its own pixels and starts the resize.
- * 2. Once a drag/resize gesture is live, RGL stamps `.resizing` /
- *    `.react-draggable-dragging` on the grid item; we drop the iframe's
- *    pointer-events for the duration so tracking continues over the whole
- *    iframe surface and settles on release. */
-.hamclock-resize-catch {
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  width: 22px;
-  height: 22px;
-  z-index: 1;
-  cursor: se-resize;
-}
-.all-panels-grid .react-grid-item.resizing iframe,
-.all-panels-grid .react-grid-item.react-draggable-dragging iframe {
-  pointer-events: none;
-}
-
 /* Workspace tile — beveled chrome wrapping the panel body. Mirrors the
  * .panel recipe from layout.css so RGL tiles read the same as the legacy
  * fixed-grid panels. */


### PR DESCRIPTION
## HamClock — Christiano's installable live-embed panel (parity port)

Adds **Christian Suarez (N9WAR / @iamexemplar)**'s HamClock feature at full parity: a **Settings → HAMCLOCK** menu tab to install/start/stop, and a workspace **HamClock** panel that **embeds the live HamClock** — so when HamClock updates (space weather, DX cluster, satellites, propagation), Zeus users see it in real time. Faithfully ported from his fork commit `15f1ce5a`.

### How it works (his design, preserved)
- **Install** (Settings → HamClock → Install): downloads OpenHamClock (MIT, `accius/openhamclock`, pinned `v26.4.1`) into the Zeus app-data dir, bootstrapping a SHA-256-verified portable Node if none is on the system, then `npm ci` + build.
- **Run:** `HamClockService` (a sidecar) starts `node server.js` on a free loopback port with auto-update disabled; the panel's `<iframe>` points straight at that port, so HamClock serves its own `/api` proxy + assets → **live, real-time**. The sidecar is killed on Zeus shutdown.
- **Inert until installed** — nothing runs or downloads until the operator clicks Install.

### Scope & safety
- **No VST host.** His commit bundled the VST `AudioProcessingModeService` registration in the same `ZeusHost.cs` hunk — that was **excluded**; only the hamclock registration was taken. Diff grep for `AudioProcessingMode/Vst/Voyeur/Spots/SmartNr/TxFidelity` = **0**.
- **Display-only / PureSignal-safe** — `HamClockService` references zero `RadioService`/`PureSignal`/`DSP`/`TX` symbols. Nothing touches the radio path.
- Grid spans adapted from his 24-col fork to develop's 12-col grid (full-bleed preserved). Tokens, no raw hex (one CSS-var fallback). #629/#597 untouched.

### Credit & commits
- `b771d7dc` — the feature, authored **Christian Suarez (N9WAR)** (4 files whole + surgical hamclock-only registration; cites SHA `15f1ce5a`).
- `054b3da1` — KB2UKA: bump the AddPanelModal panel-count test (21→22) for the new panel.
- **No Claude/Anthropic co-author** on either commit.

### Verified
Backend build 0 errors; 835 server tests; tsc+vite clean; **387/387 vitest**.

### Bench-test
Settings → **HAMCLOCK** → **Install** (first run downloads — give it a minute), then add the **HamClock** panel to a workspace → you should see the live HamClock with real-time updates. Change something in HamClock → it reflects live.

🚫 Draft — only @Kb2uka merges. Note: this spawns a local Node sidecar + downloads OpenHamClock on install (his architecture, inert until you opt in).
