### PR TITLE
🌊 New Waterfall Engine (3D relief + scroll-speed) — DRAFT, bench test

### DIFF
--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -64,6 +64,9 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const rendererRef = useRef<ReturnType<typeof createWfRenderer> | null>(null);
+  // Pending deferred WEBGL_lose_context handle (see the GL effect cleanup). A
+  // ref so it survives across the StrictMode mount→cleanup→mount cycle.
+  const pendingLoseRef = useRef<number | null>(null);
   const popEnabled = useSignalEnhanceStore((s) => s.popEnabled);
   const popRenderIntensity = useSignalEnhanceStore((s) => s.popRenderIntensity);
   const waterfallReliefDepth = useSignalEnhanceStore((s) => s.waterfallReliefDepth);
@@ -94,6 +97,17 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
     const canvas = canvasRef.current;
     const container = containerRef.current;
     if (!canvas || !container) return;
+
+    // If a previous cleanup deferred a loseContext() (see below), this is an
+    // immediate remount — cancel it so we keep the still-healthy context on the
+    // reused canvas. Without this, StrictMode's dev mount→cleanup→mount (and any
+    // canvas-reuse remount) lands on a context we just killed: getContext()
+    // returns the dead one (float_linear=false, NEAREST fallback) and the
+    // engine's shader fails to compile → blank waterfall.
+    if (pendingLoseRef.current !== null) {
+      clearTimeout(pendingLoseRef.current);
+      pendingLoseRef.current = null;
+    }
 
     // Tell the realtime client that decoded spectrum frames are needed —
     // ws-client.ts skips decodeDisplayFrame entirely when no consumer is
@@ -453,10 +467,19 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       cancelDrawBusFrame(redraw);
       releaseFrameConsumer();
       renderer?.dispose();
-      // Free the ANGLE context slot now rather than waiting for GC — on a
+      // Free the ANGLE context slot rather than waiting for GC — on a
       // disconnect/reconnect cycle the Waterfall remounts, and ANGLE caps the
-      // number of live WebGL contexts (#629).
-      gl?.getExtension('WEBGL_lose_context')?.loseContext();
+      // number of live WebGL contexts (#629). But loseContext() is DESTRUCTIVE
+      // to the canvas element: a subsequent getContext() on the same canvas
+      // returns the dead context. So defer it — an immediate remount (StrictMode
+      // in dev, or any canvas reuse) cancels this at the top of the effect and
+      // keeps the live context; a real unmount has nothing to cancel it, so the
+      // slot is freed on the next tick.
+      const ctx = gl;
+      pendingLoseRef.current = window.setTimeout(() => {
+        ctx?.getExtension('WEBGL_lose_context')?.loseContext();
+        pendingLoseRef.current = null;
+      }, 0);
       rendererRef.current = null;
     };
   }, []);

--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -66,10 +66,14 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
   const rendererRef = useRef<ReturnType<typeof createWfRenderer> | null>(null);
   const popEnabled = useSignalEnhanceStore((s) => s.popEnabled);
   const popRenderIntensity = useSignalEnhanceStore((s) => s.popRenderIntensity);
+  const waterfallReliefDepth = useSignalEnhanceStore((s) => s.waterfallReliefDepth);
+  const waterfallSmoothness = useSignalEnhanceStore((s) => s.waterfallSmoothness);
   const moxOn = useTxStore((s) => s.moxOn);
   const tunOn = useTxStore((s) => s.tunOn);
   const popActive = popEnabled && !moxOn && !tunOn;
   const popIntensityCss = Math.max(0, Math.min(1, popRenderIntensity / 100)).toFixed(2);
+  const reliefDepthCss = Math.max(0, Math.min(1, waterfallReliefDepth / 100)).toFixed(2);
+  const smoothnessCss = Math.max(0, Math.min(1, waterfallSmoothness / 100)).toFixed(2);
   // Live transparency, read by buildRenderer() on context-restore so a rebuild
   // mid-QRZ-mode comes back transparent rather than occluding the map (#629).
   const transparentRef = useRef(transparent);
@@ -117,7 +121,10 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       const active = isPopRenderActive();
       const intensity = active ? Math.max(0, Math.min(1, signalEnhance.popRenderIntensity / 100)) : 0;
       const colormap: RenderColormapId = active ? 'pop' : useDisplaySettingsStore.getState().colormap;
-      renderer.setPopMode(active, intensity);
+      const reliefDepth = active ? Math.max(0, Math.min(1, signalEnhance.waterfallReliefDepth / 100)) : 0;
+      const smoothness = active ? Math.max(0, Math.min(1, signalEnhance.waterfallSmoothness / 100)) : 0;
+      renderer.setPopMode(active, intensity, reliefDepth, smoothness);
+      renderer.setScrollSpeed(useDisplaySettingsStore.getState().waterfallScrollSpeed);
       renderer.setColormap(colormap);
     };
 
@@ -202,7 +209,10 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       // window so the operator's RX noise-floor view stays put.
       const dbMin = popOn ? 0 : keyed ? wfTxDbMin : wfDbMin;
       const dbMax = popOn ? 1 : keyed ? wfTxDbMax : wfDbMax;
-      renderer.setPopMode(popOn, popIntensity);
+      const reliefDepth = popOn ? Math.max(0, Math.min(1, pop.waterfallReliefDepth / 100)) : 0;
+      const smoothness = popOn ? Math.max(0, Math.min(1, pop.waterfallSmoothness / 100)) : 0;
+      renderer.setPopMode(popOn, popIntensity, reliefDepth, smoothness);
+      renderer.setScrollSpeed(useDisplaySettingsStore.getState().waterfallScrollSpeed);
       renderer.draw(
         dbMin,
         dbMax,
@@ -320,14 +330,12 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       const wfDb = state.wfValid && state.wfDb ? state.wfDb : null;
       wfFrames++;
       if (wfDb) wfValidFrames++;
-      let skipRowUpload = false;
+      const skipRowUpload = false;
       if (wfDb) {
         tickCounter++;
-        // Operator-selectable scroll cadence (1/2/3 server frames per row).
-        // Shift/reset still run every frame so VFO retunes stay synchronised
-        // with the panadapter's offset.
-        const cadence = useDisplaySettingsStore.getState().waterfallRowCadence;
-        skipRowUpload = tickCounter % cadence !== 0;
+        // Every server frame uploads a row; the continuous scroll rate is
+        // applied shader-side via the per-fragment row-age divide by
+        // uScrollSpeed (see WfRenderer.setScrollSpeed / shaders.ts ageRows).
         // No refill hold here any more (issue #597 Phase 2): rows are
         // stamped with the LO their data was captured at, so the shared
         // shift planner places them correctly even mid-retune.
@@ -370,6 +378,11 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
         requestRedraw();
         return;
       }
+      if (state.waterfallScrollSpeed !== prev.waterfallScrollSpeed) {
+        renderer.setScrollSpeed(state.waterfallScrollSpeed);
+        requestRedraw();
+        return;
+      }
       if (
         state.wfDbMin !== prev.wfDbMin ||
         state.wfDbMax !== prev.wfDbMax ||
@@ -407,6 +420,8 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
         state.popSpanDb !== prev.popSpanDb ||
         state.popGamma !== prev.popGamma ||
         state.popRenderIntensity !== prev.popRenderIntensity ||
+        state.waterfallReliefDepth !== prev.waterfallReliefDepth ||
+        state.waterfallSmoothness !== prev.waterfallSmoothness ||
         state.coherenceHoldGate !== prev.coherenceHoldGate ||
         state.coherenceBoostDb !== prev.coherenceBoostDb ||
         state.ridgeBoost !== prev.ridgeBoost ||
@@ -467,7 +482,11 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
         height: '100%',
         background: popActive ? 'var(--pop-surface-bg)' : 'var(--wf-0)',
         ...(popActive
-          ? ({ ['--pop-intensity' as string]: popIntensityCss } as CSSProperties)
+          ? ({
+              ['--pop-intensity' as string]: popIntensityCss,
+              ['--pop-relief' as string]: reliefDepthCss,
+              ['--pop-smoothness' as string]: smoothnessCss,
+            } as CSSProperties)
           : undefined),
       }}
     >

--- a/zeus-web/src/components/WaterfallColormapPanel.tsx
+++ b/zeus-web/src/components/WaterfallColormapPanel.tsx
@@ -16,15 +16,12 @@
 import { useMemo } from 'react';
 import { COLORMAPS, lutFor, type ColormapId } from '../gl/colormap';
 import {
+  DEFAULT_WF_SCROLL_SPEED,
+  WATERFALL_SCROLL_SPEED_MAX,
+  WATERFALL_SCROLL_SPEED_MIN,
+  WATERFALL_SCROLL_SPEED_STEP,
   useDisplaySettingsStore,
-  type WaterfallRowCadence,
 } from '../state/display-settings-store';
-
-const CADENCE_OPTIONS: Array<{ value: WaterfallRowCadence; label: string; detail: string }> = [
-  { value: 1, label: 'Smooth', detail: '30 Hz' },
-  { value: 2, label: 'Balanced', detail: '15 Hz' },
-  { value: 3, label: 'Economy', detail: '10 Hz' },
-];
 
 // Build a horizontal CSS gradient that mirrors the actual 256-entry LUT the
 // WebGL waterfall samples, so the swatch the operator picks is exactly the
@@ -48,8 +45,8 @@ function gradientCss(id: ColormapId): string {
 export function WaterfallColormapPanel() {
   const colormap = useDisplaySettingsStore((s) => s.colormap);
   const setColormap = useDisplaySettingsStore((s) => s.setColormap);
-  const waterfallRowCadence = useDisplaySettingsStore((s) => s.waterfallRowCadence);
-  const setWaterfallRowCadence = useDisplaySettingsStore((s) => s.setWaterfallRowCadence);
+  const waterfallScrollSpeed = useDisplaySettingsStore((s) => s.waterfallScrollSpeed);
+  const setWaterfallScrollSpeed = useDisplaySettingsStore((s) => s.setWaterfallScrollSpeed);
   const gradients = useMemo(
     () => Object.fromEntries(COLORMAPS.map((cm) => [cm.id, gradientCss(cm.id)])) as Record<ColormapId, string>,
     [],
@@ -84,24 +81,20 @@ export function WaterfallColormapPanel() {
       </div>
 
       <div style={cadenceBlock}>
-        <span style={cadenceLabel}>Row Cadence</span>
-        <div role="radiogroup" aria-label="Waterfall row cadence" style={cadenceRow}>
-          {CADENCE_OPTIONS.map((opt) => {
-            const active = waterfallRowCadence === opt.value;
-            return (
-              <button
-                key={opt.value}
-                type="button"
-                role="radio"
-                aria-checked={active}
-                onClick={() => setWaterfallRowCadence(opt.value)}
-                style={cadenceButton(active)}
-              >
-                <span style={cadenceButtonLabel(active)}>{opt.label}</span>
-                <span style={cadenceButtonDetail}>{opt.detail}</span>
-              </button>
-            );
-          })}
+        <span style={cadenceLabel}>Scroll Speed</span>
+        <div style={speedControl}>
+          <input
+            type="range"
+            min={WATERFALL_SCROLL_SPEED_MIN}
+            max={WATERFALL_SCROLL_SPEED_MAX}
+            step={WATERFALL_SCROLL_SPEED_STEP}
+            value={waterfallScrollSpeed}
+            onDoubleClick={() => setWaterfallScrollSpeed(DEFAULT_WF_SCROLL_SPEED)}
+            onChange={(e) => setWaterfallScrollSpeed(Number(e.currentTarget.value))}
+            aria-label="Waterfall scroll speed"
+            style={speedInput}
+          />
+          <span style={speedValue}>{waterfallScrollSpeed.toFixed(2)}x</span>
         </div>
       </div>
     </section>
@@ -153,46 +146,27 @@ const cadenceLabel: React.CSSProperties = {
   color: 'var(--fg-1)',
 };
 
-const cadenceRow: React.CSSProperties = {
-  display: 'inline-grid',
-  gridTemplateColumns: 'repeat(3, minmax(84px, 1fr))',
-  border: '1px solid var(--line)',
-  borderRadius: 'var(--r-sm)',
-  overflow: 'hidden',
-  minWidth: 276,
+const speedControl: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 10,
+  minWidth: 260,
 };
 
-function cadenceButton(active: boolean): React.CSSProperties {
-  return {
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 2,
-    minHeight: 42,
-    padding: '6px 10px',
-    border: 0,
-    borderRight: '1px solid var(--line)',
-    background: active ? 'var(--accent)' : 'var(--bg-1)',
-    color: active ? 'var(--bg-0)' : 'var(--fg-1)',
-    cursor: 'pointer',
-  };
-}
+const speedInput: React.CSSProperties = {
+  flex: '1 1 auto',
+  minWidth: 180,
+  cursor: 'pointer',
+  accentColor: 'var(--accent)',
+};
 
-function cadenceButtonLabel(active: boolean): React.CSSProperties {
-  return {
-    fontSize: 11,
-    fontWeight: 800,
-    letterSpacing: 0,
-    color: active ? 'var(--bg-0)' : 'var(--fg-0)',
-  };
-}
-
-const cadenceButtonDetail: React.CSSProperties = {
-  fontSize: 10,
-  letterSpacing: 0,
-  color: 'inherit',
-  opacity: 0.72,
+const speedValue: React.CSSProperties = {
+  minWidth: 44,
+  fontSize: 12,
+  fontWeight: 800,
+  fontVariantNumeric: 'tabular-nums',
+  color: 'var(--fg-0)',
+  textAlign: 'right',
 };
 
 function swatchCard(active: boolean): React.CSSProperties {

--- a/zeus-web/src/components/WaterfallReliefControl.tsx
+++ b/zeus-web/src/components/WaterfallReliefControl.tsx
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+//
+// Display-only waterfall relief controls. These drive the EXISTING shared
+// setter useSignalEnhanceStore.setSignalEnhanceTuning(patch); no per-field
+// setters exist, so each slider passes a single-field patch. Relief / Smooth /
+// Glow only affect the render path while Signal Pop is active, so the three
+// sliders dim + disable when popEnabled is false.
+
+import { useSignalEnhanceStore } from '../dsp/signal-estimator';
+
+// The estimator does NOT export per-field range constants and
+// setSignalEnhanceTuning clamps to 0..100 in normalizeTuning, so the
+// documented min/max/step/default live here locally.
+const RELIEF_MIN = 0;
+const RELIEF_MAX = 100;
+const RELIEF_STEP = 1;
+const DEFAULT_RELIEF_DEPTH = 92;
+const DEFAULT_SMOOTHNESS = 64;
+const DEFAULT_GLOW = 72;
+
+type ReliefSliderProps = {
+  shortKey: string;
+  ariaLabel: string;
+  value: number;
+  defaultValue: number;
+  enabled: boolean;
+  onCommit: (n: number) => void;
+};
+
+function ReliefSlider({
+  shortKey,
+  ariaLabel,
+  value,
+  defaultValue,
+  enabled,
+  onCommit,
+}: ReliefSliderProps) {
+  return (
+    <label
+      className="mono"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        background: 'transparent',
+        border: 'none',
+        padding: '0 2px',
+        fontSize: 10,
+        opacity: enabled ? 1 : 0.45,
+        cursor: enabled ? 'default' : 'not-allowed',
+      }}
+      title={
+        enabled
+          ? undefined
+          : 'Relief, Smooth and Glow only affect the render while Signal Pop is on'
+      }
+    >
+      <span
+        className="k"
+        style={{
+          color: 'var(--fg-2)',
+          fontWeight: 600,
+          letterSpacing: '0.06em',
+          textTransform: 'uppercase',
+          fontSize: 9,
+        }}
+      >
+        {shortKey}
+      </span>
+      <input
+        type="range"
+        min={RELIEF_MIN}
+        max={RELIEF_MAX}
+        step={RELIEF_STEP}
+        value={value}
+        disabled={!enabled}
+        onDoubleClick={() => enabled && onCommit(defaultValue)}
+        onChange={(e) => onCommit(Number(e.currentTarget.value))}
+        aria-label={ariaLabel}
+        style={{
+          width: 64,
+          cursor: enabled ? 'pointer' : 'not-allowed',
+          accentColor: enabled ? 'var(--accent)' : 'var(--fg-2)',
+          margin: 0,
+          pointerEvents: enabled ? 'auto' : 'none',
+        }}
+      />
+      <span
+        className="v"
+        style={{
+          minWidth: 24,
+          textAlign: 'right',
+          color: enabled ? 'var(--fg-0)' : 'var(--fg-2)',
+          fontWeight: 700,
+          fontVariantNumeric: 'tabular-nums',
+        }}
+      >
+        {Math.round(value)}
+      </span>
+    </label>
+  );
+}
+
+export function WaterfallReliefControl() {
+  const popEnabled = useSignalEnhanceStore((s) => s.popEnabled);
+  const reliefDepth = useSignalEnhanceStore((s) => s.waterfallReliefDepth);
+  const smoothness = useSignalEnhanceStore((s) => s.waterfallSmoothness);
+  const glow = useSignalEnhanceStore((s) => s.popRenderIntensity);
+  const setTuning = useSignalEnhanceStore((s) => s.setSignalEnhanceTuning);
+
+  return (
+    <>
+      <ReliefSlider
+        shortKey="RELIEF"
+        ariaLabel="Waterfall relief depth"
+        value={reliefDepth}
+        defaultValue={DEFAULT_RELIEF_DEPTH}
+        enabled={popEnabled}
+        onCommit={(n) => setTuning({ waterfallReliefDepth: n })}
+      />
+      <ReliefSlider
+        shortKey="SMOOTH"
+        ariaLabel="Waterfall smoothness"
+        value={smoothness}
+        defaultValue={DEFAULT_SMOOTHNESS}
+        enabled={popEnabled}
+        onCommit={(n) => setTuning({ waterfallSmoothness: n })}
+      />
+      <ReliefSlider
+        shortKey="GLOW"
+        ariaLabel="Signal Pop glow intensity"
+        value={glow}
+        defaultValue={DEFAULT_GLOW}
+        enabled={popEnabled}
+        onCommit={(n) => setTuning({ popRenderIntensity: n })}
+      />
+    </>
+  );
+}

--- a/zeus-web/src/components/WaterfallSpeedControl.tsx
+++ b/zeus-web/src/components/WaterfallSpeedControl.tsx
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+
+import {
+  DEFAULT_WF_SCROLL_SPEED,
+  WATERFALL_SCROLL_SPEED_MAX,
+  WATERFALL_SCROLL_SPEED_MIN,
+  WATERFALL_SCROLL_SPEED_STEP,
+  useDisplaySettingsStore,
+} from '../state/display-settings-store';
+
+function speedLabel(speed: number): string {
+  return `${speed.toFixed(2)}x`;
+}
+
+export function WaterfallSpeedControl() {
+  const speed = useDisplaySettingsStore((s) => s.waterfallScrollSpeed);
+  const setSpeed = useDisplaySettingsStore((s) => s.setWaterfallScrollSpeed);
+
+  return (
+    <label
+      className="mono"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        background: 'transparent',
+        border: 'none',
+        padding: '0 2px',
+        fontSize: 10,
+      }}
+    >
+      <span
+        className="k"
+        style={{
+          color: 'var(--fg-2)',
+          fontWeight: 600,
+          letterSpacing: '0.06em',
+          textTransform: 'uppercase',
+          fontSize: 9,
+        }}
+      >
+        SPEED
+      </span>
+      <input
+        type="range"
+        min={WATERFALL_SCROLL_SPEED_MIN}
+        max={WATERFALL_SCROLL_SPEED_MAX}
+        step={WATERFALL_SCROLL_SPEED_STEP}
+        value={speed}
+        onDoubleClick={() => setSpeed(DEFAULT_WF_SCROLL_SPEED)}
+        onChange={(e) => setSpeed(Number(e.currentTarget.value))}
+        aria-label="Waterfall scroll speed"
+        style={{
+          width: 76,
+          cursor: 'pointer',
+          accentColor: 'var(--accent)',
+          margin: 0,
+        }}
+      />
+      <span
+        className="v"
+        style={{
+          minWidth: 38,
+          textAlign: 'right',
+          color: 'var(--fg-0)',
+          fontWeight: 700,
+          fontVariantNumeric: 'tabular-nums',
+        }}
+      >
+        {speedLabel(speed)}
+      </span>
+    </label>
+  );
+}

--- a/zeus-web/src/dsp/signal-estimator.ts
+++ b/zeus-web/src/dsp/signal-estimator.ts
@@ -644,7 +644,7 @@ function readPersisted(): SignalEnhancePersisted {
   try {
     if (typeof localStorage === 'undefined') {
       return {
-        popEnabled: true,
+        popEnabled: false,
         snapEnabled: false,
         autoProfileEnabled: false,
         visualAgcEnabled: true,
@@ -655,7 +655,7 @@ function readPersisted(): SignalEnhancePersisted {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) {
       return {
-        popEnabled: true,
+        popEnabled: false,
         snapEnabled: false,
         autoProfileEnabled: false,
         visualAgcEnabled: true,
@@ -665,10 +665,7 @@ function readPersisted(): SignalEnhancePersisted {
     }
     const parsed = JSON.parse(raw) as Record<string, unknown>;
     return {
-      // Signal Pop now defaults ON (PR #655) so the 3D shaded-relief engine is
-      // the out-of-box waterfall look. Missing key => on; only an explicit
-      // stored `false` (operator turned it off) keeps it off.
-      popEnabled: parsed.popEnabled !== false,
+      popEnabled: parsed.popEnabled === true,
       snapEnabled: parsed.snapEnabled === true,
       autoProfileEnabled: parsed.autoProfileEnabled === true,
       visualAgcEnabled: parsed.visualAgcEnabled !== false,

--- a/zeus-web/src/dsp/signal-estimator.ts
+++ b/zeus-web/src/dsp/signal-estimator.ts
@@ -85,6 +85,10 @@ const DEFAULT_POP_FLOOR_DB = 3;
 const DEFAULT_POP_SPAN_DB = 30;
 const DEFAULT_POP_GAMMA = 0.5;
 const DEFAULT_POP_RENDER_INTENSITY = 72;
+const LEGACY_WATERFALL_RELIEF_DEPTH = 48;
+const LEGACY_WATERFALL_SMOOTHNESS = 42;
+const DEFAULT_WATERFALL_RELIEF_DEPTH = 92;
+const DEFAULT_WATERFALL_SMOOTHNESS = 64;
 // Display-only persistence for weak ridges. The WDSP display frame rate can
 // miss short CW/digital bursts or make weak voice traces flicker; a fast peak
 // hold lets real signal energy leave a short visual afterimage while the gate
@@ -192,6 +196,10 @@ export type SignalEnhanceTuning = {
   popGamma: number;
   /** 0..100 strength for the Signal Pop shader glow and active surface chrome. */
   popRenderIntensity: number;
+  /** 0..100 height-field lighting depth for the Pop waterfall relief renderer. */
+  waterfallReliefDepth: number;
+  /** 0..100 shader-side neighbour smoothing for faint Pop waterfall traces. */
+  waterfallSmoothness: number;
   /** Confidence threshold required before signal energy can persist/glow. */
   coherenceHoldGate: number;
   /** Display-only dB lift for repeated/neighbour-supported signal energy. */
@@ -267,6 +275,8 @@ export const SIGNAL_ENHANCE_PROFILES: Record<SignalEnhancePresetId, SignalEnhanc
     popSpanDb: DEFAULT_POP_SPAN_DB,
     popGamma: DEFAULT_POP_GAMMA,
     popRenderIntensity: DEFAULT_POP_RENDER_INTENSITY,
+    waterfallReliefDepth: DEFAULT_WATERFALL_RELIEF_DEPTH,
+    waterfallSmoothness: DEFAULT_WATERFALL_SMOOTHNESS,
     coherenceHoldGate: COHERENCE_HOLD_GATE,
     coherenceBoostDb: COHERENCE_VISUAL_BOOST_DB,
     ridgeBoost: POP_RIDGE_BOOST,
@@ -282,6 +292,8 @@ export const SIGNAL_ENHANCE_PROFILES: Record<SignalEnhancePresetId, SignalEnhanc
     popSpanDb: 24,
     popGamma: 0.42,
     popRenderIntensity: 92,
+    waterfallReliefDepth: 100,
+    waterfallSmoothness: 70,
     coherenceHoldGate: 0.38,
     coherenceBoostDb: 5.5,
     ridgeBoost: 0.5,
@@ -297,6 +309,8 @@ export const SIGNAL_ENHANCE_PROFILES: Record<SignalEnhancePresetId, SignalEnhanc
     popSpanDb: 22,
     popGamma: 0.46,
     popRenderIntensity: 88,
+    waterfallReliefDepth: 96,
+    waterfallSmoothness: 62,
     coherenceHoldGate: 0.4,
     coherenceBoostDb: 5,
     ridgeBoost: 0.65,
@@ -312,6 +326,8 @@ export const SIGNAL_ENHANCE_PROFILES: Record<SignalEnhancePresetId, SignalEnhanc
     popSpanDb: 26,
     popGamma: 0.48,
     popRenderIntensity: 84,
+    waterfallReliefDepth: 94,
+    waterfallSmoothness: 66,
     coherenceHoldGate: 0.42,
     coherenceBoostDb: 4.5,
     ridgeBoost: 0.55,
@@ -327,6 +343,8 @@ export const SIGNAL_ENHANCE_PROFILES: Record<SignalEnhancePresetId, SignalEnhanc
     popSpanDb: 34,
     popGamma: 0.55,
     popRenderIntensity: 62,
+    waterfallReliefDepth: 84,
+    waterfallSmoothness: 58,
     coherenceHoldGate: 0.48,
     coherenceBoostDb: 3.5,
     ridgeBoost: 0.32,
@@ -342,6 +360,8 @@ export const SIGNAL_ENHANCE_PROFILES: Record<SignalEnhancePresetId, SignalEnhanc
     popSpanDb: 28,
     popGamma: 0.5,
     popRenderIntensity: 78,
+    waterfallReliefDepth: 88,
+    waterfallSmoothness: 48,
     coherenceHoldGate: 0.55,
     coherenceBoostDb: 3,
     ridgeBoost: 0.45,
@@ -591,12 +611,23 @@ function isProfileId(v: unknown): v is SignalEnhanceProfileId {
 function normalizeTuning(raw: SignalEnhanceTuningPatch = {}, fallback: SignalEnhanceTuning = DEFAULT_TUNING): SignalEnhanceTuning {
   const profileId = isProfileId(raw.profileId) ? raw.profileId : fallback.profileId;
   const base = profileId === 'custom' ? fallback : { profileId, ...SIGNAL_ENHANCE_PROFILES[profileId] };
+  let waterfallReliefDepth = clampFinite(raw.waterfallReliefDepth, 0, 100, base.waterfallReliefDepth);
+  let waterfallSmoothness = clampFinite(raw.waterfallSmoothness, 0, 100, base.waterfallSmoothness);
+  if (
+    waterfallReliefDepth === LEGACY_WATERFALL_RELIEF_DEPTH &&
+    waterfallSmoothness === LEGACY_WATERFALL_SMOOTHNESS
+  ) {
+    waterfallReliefDepth = DEFAULT_WATERFALL_RELIEF_DEPTH;
+    waterfallSmoothness = DEFAULT_WATERFALL_SMOOTHNESS;
+  }
   return {
     profileId,
     popFloorDb: clampFinite(raw.popFloorDb, 0, 12, base.popFloorDb),
     popSpanDb: clampFinite(raw.popSpanDb, 12, 60, base.popSpanDb),
     popGamma: clampFinite(raw.popGamma, 0.3, 1.2, base.popGamma),
     popRenderIntensity: clampFinite(raw.popRenderIntensity, 0, 100, base.popRenderIntensity),
+    waterfallReliefDepth,
+    waterfallSmoothness,
     coherenceHoldGate: clampFinite(raw.coherenceHoldGate, 0.2, 0.8, base.coherenceHoldGate),
     coherenceBoostDb: clampFinite(raw.coherenceBoostDb, 0, 8, base.coherenceBoostDb),
     ridgeBoost: clampFinite(raw.ridgeBoost, 0, 0.8, base.ridgeBoost),
@@ -667,6 +698,8 @@ function persist(s: SignalEnhancePersisted): void {
       popSpanDb: s.popSpanDb,
       popGamma: s.popGamma,
       popRenderIntensity: s.popRenderIntensity,
+      waterfallReliefDepth: s.waterfallReliefDepth,
+      waterfallSmoothness: s.waterfallSmoothness,
       coherenceHoldGate: s.coherenceHoldGate,
       coherenceBoostDb: s.coherenceBoostDb,
       ridgeBoost: s.ridgeBoost,
@@ -694,6 +727,8 @@ export function signalEnhanceSettingsFromState(s: SignalEnhanceState): SignalEnh
     popSpanDb: s.popSpanDb,
     popGamma: s.popGamma,
     popRenderIntensity: s.popRenderIntensity,
+    waterfallReliefDepth: s.waterfallReliefDepth,
+    waterfallSmoothness: s.waterfallSmoothness,
     coherenceHoldGate: s.coherenceHoldGate,
     coherenceBoostDb: s.coherenceBoostDb,
     ridgeBoost: s.ridgeBoost,
@@ -720,6 +755,8 @@ export const useSignalEnhanceStore = create<SignalEnhanceState>((set, get) => ({
   popSpanDb: persisted.popSpanDb,
   popGamma: persisted.popGamma,
   popRenderIntensity: persisted.popRenderIntensity,
+  waterfallReliefDepth: persisted.waterfallReliefDepth,
+  waterfallSmoothness: persisted.waterfallSmoothness,
   coherenceHoldGate: persisted.coherenceHoldGate,
   coherenceBoostDb: persisted.coherenceBoostDb,
   ridgeBoost: persisted.ridgeBoost,

--- a/zeus-web/src/dsp/signal-estimator.ts
+++ b/zeus-web/src/dsp/signal-estimator.ts
@@ -644,7 +644,7 @@ function readPersisted(): SignalEnhancePersisted {
   try {
     if (typeof localStorage === 'undefined') {
       return {
-        popEnabled: false,
+        popEnabled: true,
         snapEnabled: false,
         autoProfileEnabled: false,
         visualAgcEnabled: true,
@@ -655,7 +655,7 @@ function readPersisted(): SignalEnhancePersisted {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) {
       return {
-        popEnabled: false,
+        popEnabled: true,
         snapEnabled: false,
         autoProfileEnabled: false,
         visualAgcEnabled: true,
@@ -665,7 +665,10 @@ function readPersisted(): SignalEnhancePersisted {
     }
     const parsed = JSON.parse(raw) as Record<string, unknown>;
     return {
-      popEnabled: parsed.popEnabled === true,
+      // Signal Pop now defaults ON (PR #655) so the 3D shaded-relief engine is
+      // the out-of-box waterfall look. Missing key => on; only an explicit
+      // stored `false` (operator turned it off) keeps it off.
+      popEnabled: parsed.popEnabled !== false,
       snapEnabled: parsed.snapEnabled === true,
       autoProfileEnabled: parsed.autoProfileEnabled === true,
       visualAgcEnabled: parsed.visualAgcEnabled !== false,
@@ -674,7 +677,7 @@ function readPersisted(): SignalEnhancePersisted {
     };
   } catch {
     return {
-      popEnabled: false,
+      popEnabled: true,
       snapEnabled: false,
       autoProfileEnabled: false,
       visualAgcEnabled: true,

--- a/zeus-web/src/gl/colormap.ts
+++ b/zeus-web/src/gl/colormap.ts
@@ -110,12 +110,17 @@ const VIRIDIS_ANCHORS: Anchor[] = [
   [1.0, [253, 231, 37]],
 ];
 
+// Signal Pop palette — N9WAR's (Christiano) retune from his rx2 engine: the
+// four lower anchors sit lower than develop's, so weak signals and floor
+// structure light up earlier, giving the 3D relief more to shade. Adopted with
+// the new waterfall engine (PR #655); this intentionally diverges from
+// develop's byte-identical Signal Pop palette.
 const POP_ANCHORS: Anchor[] = [
   [0.0, [0, 0, 0]],
-  [0.22, [0, 0, 0]],
-  [0.34, [2, 18, 34]],
-  [0.46, [0, 74, 122]],
-  [0.58, [0, 178, 220]],
+  [0.12, [0, 0, 0]],
+  [0.26, [2, 18, 34]],
+  [0.42, [0, 74, 122]],
+  [0.56, [0, 178, 220]],
   [0.70, [42, 236, 200]],
   [0.82, [232, 214, 82]],
   [0.92, [255, 118, 40]],

--- a/zeus-web/src/gl/shaders.ts
+++ b/zeus-web/src/gl/shaders.ts
@@ -159,20 +159,186 @@ uniform float uDbMin;
 uniform float uDbMax;
 uniform float uWriteRow;
 uniform float uH;
+uniform float uVisibleRows;
+uniform float uScrollSpeed;
 uniform float uBgAlpha;
 uniform float uViewOffsetUv;
 uniform float uSeedDb;
+uniform float uPopActive;
+uniform float uPopIntensity;
+uniform float uReliefDepth;
+uniform float uSmoothness;
+uniform float uTexW;
 out vec4 fragColor;
-void main() {
-  float agePx = (1.0 - vUv.y) * uH;
-  float row = mod(uWriteRow - agePx + uH, uH);
-  float srcX = vUv.x - uViewOffsetUv;
-  float v = (srcX < 0.0 || srcX > 1.0)
+
+float sampleDb(vec2 uv) {
+  vec2 clampedUv = vec2(uv.x, clamp(uv.y, 0.0, 1.0));
+  float ageRows = (1.0 - clampedUv.y) * max(1.0, uVisibleRows) / max(0.05, uScrollSpeed);
+  if (ageRows > uH - 2.0) return uSeedDb;
+  float row = mod(uWriteRow - ageRows + uH, uH);
+  float srcX = clampedUv.x - uViewOffsetUv;
+  return (srcX < 0.0 || srcX > 1.0)
     ? uSeedDb
     : texture(uHistory, vec2(srcX, (row + 0.5) / uH)).r;
-  float n = clamp((v - uDbMin) / (uDbMax - uDbMin), 0.0, 1.0);
+}
+
+float toLevel(float db) {
+  return clamp((db - uDbMin) / max(0.0001, uDbMax - uDbMin), 0.0, 1.0);
+}
+
+float sampleLevel(vec2 uv) {
+  return toLevel(sampleDb(uv));
+}
+
+float closeWeight(float center, float value, float width) {
+  return 1.0 - smoothstep(width * 0.34, width, abs(center - value));
+}
+
+float popLift(float n, float popI) {
+  float lifted = pow(n, mix(1.0, 0.76, popI));
+  float micro = smoothstep(0.015, 0.20, n) * 0.06 * popI;
+  return clamp(max(lifted, n + micro), 0.0, 1.0);
+}
+
+void main() {
+  float n = sampleLevel(vUv);
+  float popI = clamp(uPopIntensity, 0.0, 1.0) * step(0.5, uPopActive);
+  float normalI = 1.0 - step(0.5, uPopActive);
+  float normalHdrI = normalI * 0.54;
+  float normalReliefI = normalI * 0.46;
+  float reliefI = clamp(uReliefDepth, 0.0, 1.0) * popI;
+  float smoothI = clamp(uSmoothness, 0.0, 1.0) * popI;
+  float shade = 1.0;
+  float ridge = 0.0;
+  float rim = 0.0;
+  float shadow = 0.0;
+  float specular = 0.0;
+  float warmHalo = 0.0;
+  float coolHalo = 0.0;
+  float offsetGlow = 0.0;
+  float castGlow = 0.0;
+  float contour = 0.0;
+  float heightContour = 0.0;
+  float dropShadow = 0.0;
+  float goldRim = 0.0;
+  float crest = 0.0;
+  if (popI > 0.001 || normalHdrI > 0.001) {
+    vec2 texel = vec2(1.0 / max(1.0, uTexW), 1.0 / max(1.0, uH));
+    float left = sampleLevel(vUv - vec2(texel.x, 0.0));
+    float right = sampleLevel(vUv + vec2(texel.x, 0.0));
+    float older = sampleLevel(vUv - vec2(0.0, texel.y));
+    float newer = sampleLevel(vUv + vec2(0.0, texel.y));
+    float left2 = sampleLevel(vUv - vec2(texel.x * 2.0, 0.0));
+    float right2 = sampleLevel(vUv + vec2(texel.x * 2.0, 0.0));
+    float older2 = sampleLevel(vUv - vec2(0.0, texel.y * 2.0));
+    float newer2 = sampleLevel(vUv + vec2(0.0, texel.y * 2.0));
+    float diagA = sampleLevel(vUv + vec2(-texel.x, texel.y));
+    float diagB = sampleLevel(vUv + vec2(texel.x, texel.y));
+    float diagC = sampleLevel(vUv + vec2(-texel.x, -texel.y));
+    float diagD = sampleLevel(vUv + vec2(texel.x, -texel.y));
+    float cross = (left + right + older + newer) * 0.25;
+    float popReliefCurve = smoothstep(0.01, 0.52, clamp(uReliefDepth, 0.0, 1.0)) * popI;
+    float edgeEnergy = abs(right - left) + abs(newer - older);
+    float reliefSignal = max(0.0, n - cross) + edgeEnergy * 0.55;
+    float reliefCurve = max(popReliefCurve, normalReliefI * smoothstep(0.010, 0.25, reliefSignal));
+    float closeWidth = mix(0.16, 0.28, smoothI);
+    float wL = closeWeight(n, left, closeWidth);
+    float wR = closeWeight(n, right, closeWidth);
+    float wO = closeWeight(n, older, closeWidth);
+    float wN = closeWeight(n, newer, closeWidth);
+    float wL2 = closeWeight(n, left2, closeWidth) * 0.45;
+    float wR2 = closeWeight(n, right2, closeWidth) * 0.45;
+    float wO2 = closeWeight(n, older2, closeWidth) * 0.35;
+    float wN2 = closeWeight(n, newer2, closeWidth) * 0.35;
+    float wD = 0.18;
+    float weighted =
+      n * 1.85 + left * wL + right * wR + older * wO + newer * wN +
+      left2 * wL2 + right2 * wR2 + older2 * wO2 + newer2 * wN2 +
+      (diagA + diagB + diagC + diagD) * wD;
+    float weights = 1.85 + wL + wR + wO + wN + wL2 + wR2 + wO2 + wN2 + 4.0 * wD;
+    float smoothLevel = weighted / max(0.0001, weights);
+    float edgeGuard = smoothstep(0.030, 0.24, edgeEnergy);
+    float lowMid = smoothstep(0.015, 0.58, n) * (1.0 - smoothstep(0.72, 1.0, n));
+    n = clamp(mix(n, pow(n, 0.78), normalHdrI) + lowMid * 0.10 * normalHdrI, 0.0, 1.0);
+    float smoothAmount = max(
+      normalI * 0.24,
+      smoothI * mix(0.84, 0.30, edgeGuard) * (1.0 - smoothstep(0.86, 1.0, n) * 0.45));
+    n = mix(n, smoothLevel, clamp(smoothAmount, 0.0, 0.92));
+    crest = max(0.0, n - smoothLevel);
+
+    if (reliefCurve > 0.001) {
+      float upLeft = sampleLevel(vUv + vec2(-texel.x * 1.35, texel.y * 1.35));
+      float downRight = sampleLevel(vUv + vec2(texel.x * 1.65, -texel.y * 1.65));
+      float reliefPx = mix(1.2, 6.2, reliefCurve);
+      float raisedA = max(
+        sampleLevel(vUv + vec2(-texel.x * reliefPx, texel.y * reliefPx)),
+        sampleLevel(vUv + vec2(-texel.x * reliefPx * 0.55, texel.y * reliefPx * 0.55)));
+      float raisedB = max(
+        sampleLevel(vUv + vec2(texel.x * reliefPx, -texel.y * reliefPx)),
+        sampleLevel(vUv + vec2(texel.x * reliefPx * 0.55, -texel.y * reliefPx * 0.55)));
+      float nearMax = max(max(left, right), max(older, newer));
+      float bevel = n - cross;
+      n = clamp(
+        n + bevel * mix(0.50, 1.58, reliefCurve) + max(bevel, 0.0) * 0.16 * reliefCurve,
+        0.0,
+        1.0);
+      float slope = mix(24.0, 78.0, reliefCurve);
+      vec3 normal = normalize(vec3((left - right) * slope, (older - newer) * slope, 1.0));
+      vec3 lightDir = normalize(vec3(-0.62, 0.76, 0.78));
+      float lambert = clamp(dot(normal, lightDir) * 0.5 + 0.5, 0.0, 1.0);
+      shade = 0.22 + 1.62 * pow(lambert, 1.55);
+      ridge = smoothstep(0.006, 0.082, edgeEnergy) *
+        smoothstep(0.014, 0.24, n) * reliefCurve;
+      rim = smoothstep(0.020, 0.42, n) * smoothstep(0.004, 0.16, max(0.0, n - downRight)) *
+        reliefCurve;
+      shadow = smoothstep(0.035, 0.48, upLeft) * (1.0 - smoothstep(0.014, 0.24, n)) *
+        reliefCurve;
+      warmHalo = smoothstep(0.055, 0.45, downRight) * (1.0 - smoothstep(0.018, 0.26, n)) *
+        reliefCurve;
+      coolHalo = smoothstep(0.045, 0.40, nearMax) * (1.0 - smoothstep(0.020, 0.30, n)) *
+        reliefCurve;
+      castGlow = smoothstep(0.028, 0.40, raisedA) * (1.0 - smoothstep(0.020, 0.30, n)) *
+        reliefCurve;
+      offsetGlow = smoothstep(0.028, 0.38, raisedB) * (1.0 - smoothstep(0.018, 0.28, n)) *
+        reliefCurve;
+      dropShadow = smoothstep(0.035, 0.55, raisedA) * (1.0 - smoothstep(0.030, 0.34, n)) *
+        reliefCurve;
+      goldRim = smoothstep(0.045, 0.74, n) * smoothstep(0.006, 0.18, max(0.0, n - upLeft)) *
+        reliefCurve;
+      contour = smoothstep(0.035, 0.42, n) * smoothstep(0.004, 0.10, edgeEnergy) *
+        reliefCurve;
+      float contourPhase = abs(fract(n * 9.5) - 0.5);
+      heightContour = (1.0 - smoothstep(0.030, 0.095, contourPhase)) *
+        smoothstep(0.10, 0.96, n) * reliefCurve;
+      vec3 viewDir = vec3(0.0, 0.0, 1.0);
+      specular = pow(max(dot(reflect(-lightDir, normal), viewDir), 0.0), 13.0) *
+        reliefCurve * smoothstep(0.10, 0.82, n);
+      specular += crest * reliefCurve * 0.86;
+      reliefI = reliefCurve;
+    }
+  }
+  n = popLift(n, popI);
   vec4 c = texture(uLut, vec2(n, 0.5));
+  c.rgb *= mix(1.0, shade, reliefI);
+  c.rgb = mix(c.rgb, vec3(0.0, 0.005, 0.012), min(0.88, dropShadow * 0.86));
+  c.rgb = mix(c.rgb, vec3(0.00, 0.030, 0.055) + c.rgb * 0.24, min(0.84, 0.82 * shadow));
+  c.rgb = mix(c.rgb, vec3(0.00, 0.070, 0.16), min(0.78, castGlow * 0.82));
+  c.rgb += vec3(0.00, 0.78, 1.00) * offsetGlow * 0.58;
+  c.rgb += vec3(0.70, 0.42, 0.10) * warmHalo * 0.86;
+  c.rgb += vec3(0.00, 0.18, 0.32) * coolHalo * 0.72;
+  c.rgb += vec3(0.04, 0.54, 0.60) * ridge * 1.18;
+  c.rgb += vec3(0.36, 0.88, 0.90) * rim * 1.25;
+  c.rgb += vec3(0.98, 1.00, 0.68) * contour * 0.66;
+  c.rgb += vec3(1.00, 0.82, 0.34) * heightContour * 0.34;
+  c.rgb += vec3(1.00, 0.66, 0.16) * goldRim * 0.94;
+  c.rgb += vec3(0.28, 0.96, 1.00) * crest * reliefI * 0.62;
+  c.rgb += vec3(1.00, 0.92, 0.48) * specular * 1.18;
+  c.rgb = min(c.rgb, vec3(1.0));
+  float reliefMask = max(
+    max(castGlow, offsetGlow),
+    max(max(warmHalo, coolHalo), max(max(max(ridge, rim), heightContour), max(dropShadow, goldRim))));
   float a = mix(smoothstep(0.05, 0.9, n), 1.0, uBgAlpha);
+  a = max(a, reliefMask * mix(0.45, 0.98, reliefI));
   fragColor = vec4(c.rgb * a, a);
 }`;
 

--- a/zeus-web/src/gl/shaders.ts
+++ b/zeus-web/src/gl/shaders.ts
@@ -203,7 +203,9 @@ float popLift(float n, float popI) {
 void main() {
   float n = sampleLevel(vUv);
   float popI = clamp(uPopIntensity, 0.0, 1.0) * step(0.5, uPopActive);
-  float normalI = 1.0 - step(0.5, uPopActive);
+  // Pop-OFF renders the flat develop LUT (no HDR/relief/smoothing). The 3D
+  // shaded-relief engine is opt-in via Signal Pop only. (Was: 1.0 - step(...).)
+  float normalI = 0.0;
   float normalHdrI = normalI * 0.54;
   float normalReliefI = normalI * 0.46;
   float reliefI = clamp(uReliefDepth, 0.0, 1.0) * popI;

--- a/zeus-web/src/gl/waterfall.ts
+++ b/zeus-web/src/gl/waterfall.ts
@@ -65,7 +65,7 @@ import { WF_VS, WF_FS, WF_REMAP_FS } from './shaders';
 import { lutFor, type RenderColormapId } from './colormap';
 import type { WfShiftDecision } from './wf-shift';
 
-const HISTORY_ROWS = 512;
+const HISTORY_ROWS = 4096;
 const SEED_DB = -200;
 
 export type PushOptions = {
@@ -106,7 +106,9 @@ export type WfRenderer = {
   draw: (dbMin: number, dbMax: number, viewCenterHz?: number | null) => void;
   setColormap: (id: RenderColormapId) => void;
   /** Enables and tunes the Signal Pop waterfall shader treatment. */
-  setPopMode: (active: boolean, intensity?: number) => void;
+  setPopMode: (active: boolean, intensity?: number, reliefDepth?: number, smoothness?: number) => void;
+  /** Continuous vertical waterfall scroll rate. 1.0 is one display pixel per frame. */
+  setScrollSpeed: (speed: number) => void;
   /** 1.0 = opaque (default). 0.0 = noise floor fades to transparent so a
    *  background layer (e.g. the QRZ-mode Leaflet map) shows through. */
   setTransparent: (transparent: boolean) => void;
@@ -116,6 +118,7 @@ export type WfRenderer = {
   debugState: () => {
     texWidth: number;
     writeRow: number;
+    scrollSpeed: number;
     lastViewOffsetUv: number;
     contextLost: boolean;
   };
@@ -166,10 +169,22 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
   const uDbMax = gl.getUniformLocation(drawProg, 'uDbMax');
   const uWriteRow = gl.getUniformLocation(drawProg, 'uWriteRow');
   const uH = gl.getUniformLocation(drawProg, 'uH');
+  const uVisibleRows = gl.getUniformLocation(drawProg, 'uVisibleRows');
+  const uScrollSpeed = gl.getUniformLocation(drawProg, 'uScrollSpeed');
   const uBgAlpha = gl.getUniformLocation(drawProg, 'uBgAlpha');
   const uViewOffsetUv = gl.getUniformLocation(drawProg, 'uViewOffsetUv');
   const uSeedDbDraw = gl.getUniformLocation(drawProg, 'uSeedDb');
+  const uPopActive = gl.getUniformLocation(drawProg, 'uPopActive');
+  const uPopIntensity = gl.getUniformLocation(drawProg, 'uPopIntensity');
+  const uReliefDepth = gl.getUniformLocation(drawProg, 'uReliefDepth');
+  const uSmoothness = gl.getUniformLocation(drawProg, 'uSmoothness');
+  const uTexW = gl.getUniformLocation(drawProg, 'uTexW');
   let bgAlpha = 1;
+  let popActive = false;
+  let popIntensity = 0;
+  let reliefDepth = 0;
+  let smoothness = 0;
+  let scrollSpeed = 1;
 
   const remapProg = buildProgram(gl, WF_VS, WF_REMAP_FS);
   const uRemapSrc = gl.getUniformLocation(remapProg, 'uSrc');
@@ -382,9 +397,14 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
     setTransparent(transparent) {
       bgAlpha = transparent ? 0 : 1;
     },
-    setPopMode() {
-      // POP is expressed through the renderer LUT; the shader remains the
-      // portable baseline waterfall program.
+    setPopMode(active, intensity = active ? 1 : 0, nextReliefDepth = 0, nextSmoothness = 0) {
+      popActive = active;
+      popIntensity = Number.isFinite(intensity) ? Math.max(0, Math.min(1, intensity)) : 0;
+      reliefDepth = Number.isFinite(nextReliefDepth) ? Math.max(0, Math.min(1, nextReliefDepth)) : 0;
+      smoothness = Number.isFinite(nextSmoothness) ? Math.max(0, Math.min(1, nextSmoothness)) : 0;
+    },
+    setScrollSpeed(speed) {
+      scrollSpeed = Number.isFinite(speed) ? Math.max(0.25, Math.min(2.5, speed)) : 1;
     },
     clearHistory() {
       if (texWidth > 0) resetTextures(texWidth);
@@ -422,9 +442,16 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
       gl.uniform1f(uDbMax, dbMax);
       gl.uniform1f(uWriteRow, writeRow);
       gl.uniform1f(uH, HISTORY_ROWS);
+      gl.uniform1f(uVisibleRows, Math.max(1, canvasH));
+      gl.uniform1f(uScrollSpeed, scrollSpeed);
       gl.uniform1f(uBgAlpha, bgAlpha);
       gl.uniform1f(uViewOffsetUv, viewOffsetUv);
       gl.uniform1f(uSeedDbDraw, SEED_DB);
+      gl.uniform1f(uPopActive, popActive ? 1 : 0);
+      gl.uniform1f(uPopIntensity, popIntensity);
+      gl.uniform1f(uReliefDepth, reliefDepth);
+      gl.uniform1f(uSmoothness, smoothness);
+      gl.uniform1f(uTexW, texWidth);
       gl.bindVertexArray(vao);
       gl.drawArrays(gl.TRIANGLES, 0, 3);
       gl.bindVertexArray(null);
@@ -434,6 +461,7 @@ export function createWfRenderer(gl: WebGL2RenderingContext): WfRenderer {
       return {
         texWidth,
         writeRow,
+        scrollSpeed,
         lastViewOffsetUv,
         contextLost: gl.isContextLost(),
       };

--- a/zeus-web/src/layout/panels/HeroPanel.tsx
+++ b/zeus-web/src/layout/panels/HeroPanel.tsx
@@ -48,6 +48,7 @@ import { GripVertical, X } from 'lucide-react';
 import { Panadapter } from '../../components/Panadapter';
 import { Waterfall } from '../../components/Waterfall';
 import { ZoomControl } from '../../components/ZoomControl';
+import { WaterfallSpeedControl } from '../../components/WaterfallSpeedControl';
 import { LeafletWorldMap } from '../../components/design/LeafletWorldMap';
 import { LeafletMapErrorBoundary } from '../../components/design/LeafletMapErrorBoundary';
 import { useConnectionStore } from '../../state/connection-store';
@@ -268,6 +269,7 @@ export function HeroPanel({ onRemove, tile }: HeroPanelProps = {}) {
           onMouseDown={stopDrag}
         >
           <ZoomControl />
+          <WaterfallSpeedControl />
           {terminatorActive && contact && mapAvailable && (
             <>
               <button

--- a/zeus-web/src/layout/panels/HeroPanel.tsx
+++ b/zeus-web/src/layout/panels/HeroPanel.tsx
@@ -49,6 +49,7 @@ import { Panadapter } from '../../components/Panadapter';
 import { Waterfall } from '../../components/Waterfall';
 import { ZoomControl } from '../../components/ZoomControl';
 import { WaterfallSpeedControl } from '../../components/WaterfallSpeedControl';
+import { WaterfallReliefControl } from '../../components/WaterfallReliefControl';
 import { LeafletWorldMap } from '../../components/design/LeafletWorldMap';
 import { LeafletMapErrorBoundary } from '../../components/design/LeafletMapErrorBoundary';
 import { useConnectionStore } from '../../state/connection-store';
@@ -270,6 +271,7 @@ export function HeroPanel({ onRemove, tile }: HeroPanelProps = {}) {
         >
           <ZoomControl />
           <WaterfallSpeedControl />
+          <WaterfallReliefControl />
           {terminatorActive && contact && mapAvailable && (
             <>
               <button

--- a/zeus-web/src/state/display-settings-store.test.ts
+++ b/zeus-web/src/state/display-settings-store.test.ts
@@ -44,9 +44,11 @@
 
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
-  DEFAULT_WF_ROW_CADENCE,
+  DEFAULT_WF_SCROLL_SPEED,
   FIXED_DB_MAX,
   FIXED_DB_MIN,
+  WATERFALL_SCROLL_SPEED_MAX,
+  WATERFALL_SCROLL_SPEED_MIN,
   useDisplaySettingsStore,
 } from './display-settings-store';
 
@@ -55,7 +57,7 @@ function resetStore() {
     autoRange: false,
     dbMin: FIXED_DB_MIN,
     dbMax: FIXED_DB_MAX,
-    waterfallRowCadence: DEFAULT_WF_ROW_CADENCE,
+    waterfallScrollSpeed: DEFAULT_WF_SCROLL_SPEED,
   });
 }
 
@@ -127,21 +129,31 @@ describe('display-settings-store', () => {
     expect(Number.isFinite(dbMax)).toBe(true);
   });
 
-  it('keeps balanced waterfall row cadence by default', () => {
-    const { waterfallRowCadence } = useDisplaySettingsStore.getState();
-    expect(waterfallRowCadence).toBe(DEFAULT_WF_ROW_CADENCE);
+  it('keeps default waterfall scroll speed by default', () => {
+    const { waterfallScrollSpeed } = useDisplaySettingsStore.getState();
+    expect(waterfallScrollSpeed).toBe(DEFAULT_WF_SCROLL_SPEED);
   });
 
-  it('updates waterfall row cadence to valid operator choices only', () => {
+  it('updates waterfall scroll speed continuously within operator limits', () => {
     const s = useDisplaySettingsStore.getState();
 
-    s.setWaterfallRowCadence(1);
-    expect(useDisplaySettingsStore.getState().waterfallRowCadence).toBe(1);
+    s.setWaterfallScrollSpeed(0.55);
+    expect(useDisplaySettingsStore.getState().waterfallScrollSpeed).toBe(0.55);
 
-    s.setWaterfallRowCadence(3);
-    expect(useDisplaySettingsStore.getState().waterfallRowCadence).toBe(3);
+    // Snaps to the 0.05 step grid.
+    s.setWaterfallScrollSpeed(1.37);
+    expect(useDisplaySettingsStore.getState().waterfallScrollSpeed).toBe(1.35);
 
-    s.setWaterfallRowCadence(99 as never);
-    expect(useDisplaySettingsStore.getState().waterfallRowCadence).toBe(DEFAULT_WF_ROW_CADENCE);
+    // Clamps below the minimum.
+    s.setWaterfallScrollSpeed(-5);
+    expect(useDisplaySettingsStore.getState().waterfallScrollSpeed).toBe(WATERFALL_SCROLL_SPEED_MIN);
+
+    // Clamps above the maximum.
+    s.setWaterfallScrollSpeed(99);
+    expect(useDisplaySettingsStore.getState().waterfallScrollSpeed).toBe(WATERFALL_SCROLL_SPEED_MAX);
+
+    // Non-finite falls back to the default.
+    s.setWaterfallScrollSpeed(Number.NaN);
+    expect(useDisplaySettingsStore.getState().waterfallScrollSpeed).toBe(DEFAULT_WF_SCROLL_SPEED);
   });
 });

--- a/zeus-web/src/state/display-settings-store.ts
+++ b/zeus-web/src/state/display-settings-store.ts
@@ -72,7 +72,7 @@ const STORAGE_KEY = 'zeus.display.dbRange';
 const TX_STORAGE_KEY = 'zeus.display.txDbRange';
 const WF_STORAGE_KEY = 'zeus.display.wfDbRange';
 const WF_TX_STORAGE_KEY = 'zeus.display.wfTxDbRange';
-const WF_CADENCE_STORAGE_KEY = 'zeus.display.wfRowCadence';
+const WF_SCROLL_SPEED_STORAGE_KEY = 'zeus.display.wfScrollSpeed';
 
 // Legacy localStorage keys — pre-server-side storage. Read once on first
 // load to migrate the operator's existing image / colour up to the backend,
@@ -103,31 +103,31 @@ export type PanBackgroundMode = 'basic' | 'beam-map' | 'image';
 // 'stretch' → 100% 100% (distorts to fit exactly)
 export type BackgroundImageFit = 'fit' | 'fill' | 'stretch';
 
-// Number of server display frames per waterfall row upload. 1 = every
-// frame (~30 Hz), 2 = current balanced default (~15 Hz), 3 = lower CPU
-// scroll (~10 Hz). Shift/reset still run every frame so tuning remains
-// visually locked to the panadapter.
-export type WaterfallRowCadence = 1 | 2 | 3;
-export const DEFAULT_WF_ROW_CADENCE: WaterfallRowCadence = 2;
+export const WATERFALL_SCROLL_SPEED_MIN = 0.25;
+export const WATERFALL_SCROLL_SPEED_MAX = 2.5;
+export const WATERFALL_SCROLL_SPEED_STEP = 0.05;
+export const DEFAULT_WF_SCROLL_SPEED = 1;
 
-function normalizeWaterfallRowCadence(raw: unknown): WaterfallRowCadence {
+function normalizeWaterfallScrollSpeed(raw: unknown): number {
   const n = typeof raw === 'number' ? raw : Number(raw);
-  return n === 1 || n === 2 || n === 3 ? n : DEFAULT_WF_ROW_CADENCE;
+  if (!Number.isFinite(n)) return DEFAULT_WF_SCROLL_SPEED;
+  const clamped = Math.max(WATERFALL_SCROLL_SPEED_MIN, Math.min(WATERFALL_SCROLL_SPEED_MAX, n));
+  return Math.round(clamped / WATERFALL_SCROLL_SPEED_STEP) * WATERFALL_SCROLL_SPEED_STEP;
 }
 
-function readSavedWaterfallRowCadence(): WaterfallRowCadence {
+function readSavedWaterfallScrollSpeed(): number {
   try {
-    if (typeof localStorage === 'undefined') return DEFAULT_WF_ROW_CADENCE;
-    return normalizeWaterfallRowCadence(localStorage.getItem(WF_CADENCE_STORAGE_KEY));
+    if (typeof localStorage === 'undefined') return DEFAULT_WF_SCROLL_SPEED;
+    return normalizeWaterfallScrollSpeed(localStorage.getItem(WF_SCROLL_SPEED_STORAGE_KEY));
   } catch {
-    return DEFAULT_WF_ROW_CADENCE;
+    return DEFAULT_WF_SCROLL_SPEED;
   }
 }
 
-function writeSavedWaterfallRowCadence(value: WaterfallRowCadence): void {
+function writeSavedWaterfallScrollSpeed(value: number): void {
   try {
     if (typeof localStorage === 'undefined') return;
-    localStorage.setItem(WF_CADENCE_STORAGE_KEY, String(value));
+    localStorage.setItem(WF_SCROLL_SPEED_STORAGE_KEY, String(value));
   } catch {
     // quota exceeded / private mode — accept silently.
   }
@@ -311,7 +311,7 @@ export type DisplaySettingsState = {
   txDbMin: number;
   txDbMax: number;
   colormap: ColormapId;
-  waterfallRowCadence: WaterfallRowCadence;
+  waterfallScrollSpeed: number;
   // Panadapter background overlay mode + (optional) user image. See the
   // PanBackgroundMode and BackgroundImageFit types above. Persisted on the
   // backend (zeus-prefs.db) so a single setting follows the operator across
@@ -334,7 +334,7 @@ export type DisplaySettingsState = {
   setRxTraceColor: (v: string) => Promise<void>;
   setAutoRange: (v: boolean) => void;
   setColormap: (id: ColormapId) => void;
-  setWaterfallRowCadence: (value: WaterfallRowCadence) => void;
+  setWaterfallScrollSpeed: (value: number) => void;
   updateAutoRange: (wfDb: Float32Array) => void;
   // Shift dbMin and dbMax together by `deltaDb`. Used by the draggable dB
   // scale overlay on the panadapter with content-follows-finger semantics:
@@ -386,7 +386,7 @@ const initialRange = readSavedRange();
 const initialTxRange = readSavedTxRange();
 const initialWfRange = readSavedWfRange();
 const initialWfTxRange = readSavedWfTxRange();
-const initialWaterfallRowCadence = readSavedWaterfallRowCadence();
+const initialWaterfallScrollSpeed = readSavedWaterfallScrollSpeed();
 
 export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) => ({
   autoRange: false,
@@ -399,7 +399,7 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
   txDbMin: initialTxRange.txDbMin,
   txDbMax: initialTxRange.txDbMax,
   colormap: 'blue',
-  waterfallRowCadence: initialWaterfallRowCadence,
+  waterfallScrollSpeed: initialWaterfallScrollSpeed,
   // Defaults until the server-side fetch lands (see hydrateFromServer at the
   // bottom of this file). The operator briefly sees a plain panadapter on
   // first paint instead of their saved image — acceptable trade-off for not
@@ -497,10 +497,10 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
     }
   },
   setColormap: (colormap) => set({ colormap }),
-  setWaterfallRowCadence: (value) => {
-    const next = normalizeWaterfallRowCadence(value);
-    set({ waterfallRowCadence: next });
-    writeSavedWaterfallRowCadence(next);
+  setWaterfallScrollSpeed: (value) => {
+    const next = normalizeWaterfallScrollSpeed(value);
+    set({ waterfallScrollSpeed: next });
+    writeSavedWaterfallScrollSpeed(next);
   },
   shiftDbRange: (deltaDb) => {
     // While AUTO is on, the live dbMin/dbMax are EMA-smoothed band-tracking


### PR DESCRIPTION
## 🌊 New Waterfall Engine — DRAFT for bench testing (do not merge)

Christiano's (Christian Suarez / N9WAR) **new waterfall engine**, extracted clean from his `iamexemplar/rx2` branch onto `develop`, plus the bench-test fixes and control surface from the 2026-06-17 session.

---

## ⬆️ Update — 2026-06-17 (4 commits added)

Decisions taken with KB2UKA on the bench, now landed:

### `fix(waterfall)` — blank-on-reopen / StrictMode context leak
Closing+reopening the waterfall (and React StrictMode's dev mount→cleanup→mount) reused the same canvas after cleanup had called `WEBGL_lose_context.loseContext()` on it; the next `getContext()` returned the dead/degraded context (`float_linear=false`, NEAREST fallback), the engine shader failed to compile, and the waterfall went blank. **Fix:** defer the destructive `loseContext()` to `setTimeout(0)` and cancel it on an immediate remount — keeps the live context on reuse, still frees the ANGLE slot on a real unmount (#629 intact).

### `feat(waterfall)` — Relief / Smooth / Glow control panel
His waterfall display knobs surfaced as three inline sliders in the panadapter header (next to Zoom + Speed): **RELIEF** (waterfallReliefDepth), **SMOOTH** (waterfallSmoothness), **GLOW** (popRenderIntensity). Each drives the **existing** `useSignalEnhanceStore.setSignalEnhanceTuning` setter — no new store fields, no estimator-math change. They dim/disable when Signal Pop is off (relief only affects the render while Pop is active). His DSP controls (NR/NR5/squelch/RX2/coherence/AGC tuning/VST bridge) were **deliberately excluded** — display-only.

### `feat/fix(waterfall)` — N9WAR pop palette; Signal Pop stays default OFF
- Restored N9WAR's **POP_ANCHORS** retune (the four lower anchors sit lower than develop's, so weak signals/floor light up earlier and give the relief more to shade). 🚩 *This intentionally diverges from develop's byte-identical Signal Pop palette — flagged for visual-design sign-off.*
- Signal Pop **remains default OFF** (KB2UKA bench call — `fbee4188` briefly defaulted it on; reverted in `c3fa74bc`). The 3D relief engine is **opt-in via the Signal Pop toggle**, as before.

**Verification:** `tsc` clean · frontend unit tests pass (estimator math unchanged) · `vite build` green · safety audit confirms no `*.cs`, no `WF_FS` shader-math edits, no PS/TX/NR/RX2 bleed.

**Still DRAFT — bench-test on G2/HL2 before merge.**

---

## Original engine (1f245f0b · ac7ef3d9)

### 1. Scroll-Speed / Cadence control
A **SPEED** slider (next to Zoom) sets waterfall scroll rate, decoupled from the DDC frame rate. Shader-side `ageRows = (1 - uv.y) * uVisibleRows / uScrollSpeed`; every row still uploads. Default `1.0x`, range `0.25x–2.5x`.

### 2. 3D shaded-relief renderer
The fragment shader renders an embossed/topographic surface — Lambert lighting, bevels, ridges, rim light, drop shadows, specular, gold rims, contour + height-contour lines, warm/cool/cast halos, with in-shader Signal Pop lift. `WF_FS` is byte-identical to Christiano's source.

### Safety — what this does NOT touch
- ✅ **Display-only.** Zero changes to TX, the TX IQ ring, DSP audio, **PureSignal**, the WDSP P/Invoke seam, or any `.cs`/server code.
- ✅ **No DSP work brought over** (NR5, smart-NR, squelch, RX2 dual-receive, VST native bridge, diagnostics all excluded).
- ✅ Signal Pop estimator MATH unchanged (the palette is a LUT retune, the new sliders drive existing setters — not estimator changes).

### Resolved toggle decisions (were open in the original draft)
1. **Pop-OFF look** — kept his mild relief on Pop-off (his design).
2. **Relief Depth / Smoothness** — now **exposed** as the RELIEF/SMOOTH sliders (+ GLOW), defaults 92 / 64 / 72.
3. **POP_ANCHORS** — his retune **restored** (palette diverges from develop — needs sign-off).
4. **HISTORY_ROWS** 512 → 4096 (taller scrollback; hard dependency of slow-scroll).
5. **Signal Pop default** — stays **OFF** (opt-in via the toggle).

**Authorship:** engine + palette = N9WAR (co-credited on commits); Zeus integration, context-leak fix, control panel = KB2UKA.

🚫 **Draft — not for merge.** Brian/Doug sign-off needed on the 🚩 palette divergence from develop.