### PR TITLE
📊 Spectrum Scale settings (per-display dB windows) — DRAFT, bench test

### DIFF
--- a/zeus-web/src/components/DisplayPanel.tsx
+++ b/zeus-web/src/components/DisplayPanel.tsx
@@ -15,6 +15,7 @@
 
 import { BackgroundSettingsPanel } from './BackgroundSettingsPanel';
 import { SignalEnhancePanel } from './SignalEnhancePanel';
+import { SpectrumScaleSettingsPanel } from './SpectrumScaleSettingsPanel';
 import { ThemeSettingsPanel } from './ThemeSettingsPanel';
 import { TraceColorPanel } from './TraceColorPanel';
 import { WaterfallColormapPanel } from './WaterfallColormapPanel';
@@ -25,6 +26,7 @@ export function DisplayPanel() {
       <ThemeSettingsPanel />
       <BackgroundSettingsPanel />
       <TraceColorPanel />
+      <SpectrumScaleSettingsPanel />
       <SignalEnhancePanel />
       <WaterfallColormapPanel />
     </div>

--- a/zeus-web/src/components/SpectrumScaleSettingsPanel.tsx
+++ b/zeus-web/src/components/SpectrumScaleSettingsPanel.tsx
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+import type { CSSProperties } from 'react';
+import {
+  FIXED_DB_MAX,
+  FIXED_DB_MIN,
+  TX_FIXED_DB_MAX,
+  TX_FIXED_DB_MIN,
+  useDisplaySettingsStore,
+} from '../state/display-settings-store';
+
+const ABS_DB_MIN = -200;
+const ABS_DB_MAX = 200;
+const MIN_SPAN_DB = 20;
+
+type RangeRowProps = {
+  title: string;
+  detail: string;
+  minValue: number;
+  maxValue: number;
+  defaultMin: number;
+  defaultMax: number;
+  onChange: (min: number, max: number) => void;
+};
+
+function clamp(v: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, v));
+}
+
+function readNumber(raw: string): number | null {
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+function RangeRow({
+  title,
+  detail,
+  minValue,
+  maxValue,
+  defaultMin,
+  defaultMax,
+  onChange,
+}: RangeRowProps) {
+  const setMin = (raw: string) => {
+    const n = readNumber(raw);
+    if (n === null) return;
+    onChange(clamp(n, ABS_DB_MIN, maxValue - MIN_SPAN_DB), maxValue);
+  };
+  const setMax = (raw: string) => {
+    const n = readNumber(raw);
+    if (n === null) return;
+    onChange(minValue, clamp(n, minValue + MIN_SPAN_DB, ABS_DB_MAX));
+  };
+
+  return (
+    <div style={rangeRow}>
+      <div style={rangeText}>
+        <span style={rangeTitle}>{title}</span>
+        <span style={rangeDetail}>{detail}</span>
+      </div>
+      <label style={rangeLabel}>
+        Min
+        <input
+          type="number"
+          min={ABS_DB_MIN}
+          max={maxValue - MIN_SPAN_DB}
+          step={1}
+          value={Math.round(minValue)}
+          onChange={(event) => setMin(event.currentTarget.value)}
+          style={numberInput}
+        />
+      </label>
+      <label style={rangeLabel}>
+        Max
+        <input
+          type="number"
+          min={minValue + MIN_SPAN_DB}
+          max={ABS_DB_MAX}
+          step={1}
+          value={Math.round(maxValue)}
+          onChange={(event) => setMax(event.currentTarget.value)}
+          style={numberInput}
+        />
+      </label>
+      <button
+        type="button"
+        className="btn sm"
+        onClick={() => onChange(defaultMin, defaultMax)}
+        title={`Reset ${title} to ${defaultMin}..${defaultMax} dB`}
+        style={resetButton}
+      >
+        Reset
+      </button>
+    </div>
+  );
+}
+
+export function SpectrumScaleSettingsPanel() {
+  const autoRange = useDisplaySettingsStore((s) => s.autoRange);
+  const dbMin = useDisplaySettingsStore((s) => s.dbMin);
+  const dbMax = useDisplaySettingsStore((s) => s.dbMax);
+  const txDbMin = useDisplaySettingsStore((s) => s.txDbMin);
+  const txDbMax = useDisplaySettingsStore((s) => s.txDbMax);
+  const wfDbMin = useDisplaySettingsStore((s) => s.wfDbMin);
+  const wfDbMax = useDisplaySettingsStore((s) => s.wfDbMax);
+  const wfTxDbMin = useDisplaySettingsStore((s) => s.wfTxDbMin);
+  const wfTxDbMax = useDisplaySettingsStore((s) => s.wfTxDbMax);
+  const setAutoRange = useDisplaySettingsStore((s) => s.setAutoRange);
+  const setDbRange = useDisplaySettingsStore((s) => s.setDbRange);
+  const setTxDbRange = useDisplaySettingsStore((s) => s.setTxDbRange);
+  const setWfDbRange = useDisplaySettingsStore((s) => s.setWfDbRange);
+  const setWfTxDbRange = useDisplaySettingsStore((s) => s.setWfTxDbRange);
+  const resetDbRanges = useDisplaySettingsStore((s) => s.resetDbRanges);
+
+  return (
+    <section>
+      <div style={sectionHead}>
+        <h3 style={sectionH3}>Spectrum Scale</h3>
+        <p style={sectionP}>
+          Persisted dB windows for RX/TX panadapter and waterfall rendering.
+        </p>
+        <button type="button" className="btn sm" onClick={resetDbRanges} style={allResetButton}>
+          Reset All
+        </button>
+      </div>
+
+      <div style={card}>
+        <div style={autoRow}>
+          <label style={switchLabel}>
+            <input
+              type="checkbox"
+              checked={autoRange}
+              onChange={(event) => setAutoRange(event.currentTarget.checked)}
+              style={{ accentColor: 'var(--accent)' }}
+            />
+            Auto RX Panadapter Range
+          </label>
+          <span style={autoHint}>
+            Tracks live spectrum percentiles while enabled; any manual range edit returns to fixed mode.
+          </span>
+        </div>
+
+        <RangeRow
+          title="RX Panadapter"
+          detail="Trace window used while receiving."
+          minValue={dbMin}
+          maxValue={dbMax}
+          defaultMin={FIXED_DB_MIN}
+          defaultMax={FIXED_DB_MAX}
+          onChange={setDbRange}
+        />
+        <RangeRow
+          title="TX Panadapter"
+          detail="Trace window used while MOX or TUN is keyed."
+          minValue={txDbMin}
+          maxValue={txDbMax}
+          defaultMin={TX_FIXED_DB_MIN}
+          defaultMax={TX_FIXED_DB_MAX}
+          onChange={setTxDbRange}
+        />
+        <RangeRow
+          title="RX Waterfall"
+          detail="Colour-map dB window for receive waterfall rows."
+          minValue={wfDbMin}
+          maxValue={wfDbMax}
+          defaultMin={FIXED_DB_MIN}
+          defaultMax={FIXED_DB_MAX}
+          onChange={setWfDbRange}
+        />
+        <RangeRow
+          title="TX Waterfall"
+          detail="Colour-map dB window for keyed waterfall rows."
+          minValue={wfTxDbMin}
+          maxValue={wfTxDbMax}
+          defaultMin={TX_FIXED_DB_MIN}
+          defaultMax={TX_FIXED_DB_MAX}
+          onChange={setWfTxDbRange}
+        />
+      </div>
+    </section>
+  );
+}
+
+const sectionHead: CSSProperties = {
+  display: 'flex',
+  alignItems: 'baseline',
+  flexWrap: 'wrap',
+  gap: 10,
+  marginBottom: 10,
+};
+
+const sectionH3: CSSProperties = {
+  margin: 0,
+  fontSize: 11,
+  fontWeight: 700,
+  letterSpacing: '0.18em',
+  textTransform: 'uppercase',
+  color: 'var(--fg-0)',
+};
+
+const sectionP: CSSProperties = {
+  margin: 0,
+  flex: '1 1 260px',
+  fontSize: 12,
+  lineHeight: 1.5,
+  color: 'var(--fg-2)',
+};
+
+const card: CSSProperties = {
+  display: 'grid',
+  gap: 8,
+  padding: 10,
+  border: '1px solid var(--line)',
+  borderRadius: 'var(--r-md)',
+  background: 'linear-gradient(180deg, var(--bg-1), var(--bg-0))',
+};
+
+const autoRow: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: 10,
+  flexWrap: 'wrap',
+  padding: '4px 0 7px',
+  borderBottom: '1px solid var(--line)',
+};
+
+const switchLabel: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 8,
+  fontSize: 11,
+  fontWeight: 800,
+  letterSpacing: '0.08em',
+  textTransform: 'uppercase',
+  color: 'var(--fg-0)',
+};
+
+const autoHint: CSSProperties = {
+  flex: '1 1 260px',
+  fontSize: 11,
+  lineHeight: 1.35,
+  color: 'var(--fg-3)',
+};
+
+const rangeRow: CSSProperties = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: 8,
+  alignItems: 'center',
+};
+
+const rangeText: CSSProperties = {
+  display: 'grid',
+  gap: 2,
+  flex: '1 1 220px',
+  minWidth: 0,
+};
+
+const rangeTitle: CSSProperties = {
+  fontSize: 12,
+  fontWeight: 800,
+  color: 'var(--fg-0)',
+};
+
+const rangeDetail: CSSProperties = {
+  fontSize: 11,
+  lineHeight: 1.35,
+  color: 'var(--fg-3)',
+};
+
+const rangeLabel: CSSProperties = {
+  display: 'grid',
+  gap: 2,
+  flex: '0 0 88px',
+  minWidth: 0,
+  fontSize: 9,
+  fontWeight: 800,
+  letterSpacing: '0.08em',
+  textTransform: 'uppercase',
+  color: 'var(--fg-3)',
+};
+
+const numberInput: CSSProperties = {
+  width: '100%',
+  minWidth: 0,
+  height: 26,
+  boxSizing: 'border-box',
+  border: '1px solid var(--line)',
+  borderRadius: 4,
+  background: 'var(--bg-0)',
+  color: 'var(--fg-0)',
+  fontFamily: 'var(--font-mono, JetBrains Mono, ui-monospace, monospace)',
+  fontSize: 11,
+  fontWeight: 800,
+  padding: '0 6px',
+};
+
+const resetButton: CSSProperties = {
+  flex: '0 0 auto',
+  height: 26,
+  minWidth: 58,
+};
+
+const allResetButton: CSSProperties = {
+  height: 26,
+};

--- a/zeus-web/src/state/display-settings-store.ts
+++ b/zeus-web/src/state/display-settings-store.ts
@@ -347,6 +347,14 @@ export type DisplaySettingsState = {
   shiftWfDbRange: (deltaDb: number) => void;
   // Same as shiftWfDbRange but for the TX-specific waterfall range.
   shiftWfTxDbRange: (deltaDb: number) => void;
+  // Absolute (min, max) setters used by the Spectrum Scale settings panel.
+  // Distinct from the delta-based shift* family above: these set the window
+  // directly from typed numeric inputs and sanitize/persist like a drag edit.
+  setDbRange: (dbMin: number, dbMax: number) => void;
+  setTxDbRange: (txDbMin: number, txDbMax: number) => void;
+  setWfDbRange: (wfDbMin: number, wfDbMax: number) => void;
+  setWfTxDbRange: (wfTxDbMin: number, wfTxDbMax: number) => void;
+  resetDbRanges: () => void;
 };
 
 const DB_ABS_LIMIT = 200;
@@ -535,6 +543,50 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
     const { min: nextMin, max: nextMax } = clampShift(wfTxDbMin, wfTxDbMax, deltaDb);
     set({ wfTxDbMin: nextMin, wfTxDbMax: nextMax });
     writeSavedWfTxRange(nextMin, nextMax);
+    scheduleDbRangeSave();
+  },
+  setDbRange: (dbMin, dbMax) => {
+    const next = sanitizeRange(dbMin, dbMax, FIXED_DB_MIN, FIXED_DB_MAX);
+    // A manual range edit returns the RX panadapter to fixed mode (mirrors
+    // shiftDbRange) — AUTO is a temporary override the operator just left.
+    set({ autoRange: false, dbMin: next.min, dbMax: next.max });
+    writeSavedRange(next.min, next.max);
+    scheduleDbRangeSave();
+  },
+  setTxDbRange: (txDbMin, txDbMax) => {
+    const next = sanitizeRange(txDbMin, txDbMax, TX_FIXED_DB_MIN, TX_FIXED_DB_MAX);
+    set({ txDbMin: next.min, txDbMax: next.max });
+    writeSavedTxRange(next.min, next.max);
+    scheduleDbRangeSave();
+  },
+  setWfDbRange: (wfDbMin, wfDbMax) => {
+    const next = sanitizeRange(wfDbMin, wfDbMax, FIXED_DB_MIN, FIXED_DB_MAX);
+    set({ wfDbMin: next.min, wfDbMax: next.max });
+    writeSavedWfRange(next.min, next.max);
+    scheduleDbRangeSave();
+  },
+  setWfTxDbRange: (wfTxDbMin, wfTxDbMax) => {
+    const next = sanitizeRange(wfTxDbMin, wfTxDbMax, TX_FIXED_DB_MIN, TX_FIXED_DB_MAX);
+    set({ wfTxDbMin: next.min, wfTxDbMax: next.max });
+    writeSavedWfTxRange(next.min, next.max);
+    scheduleDbRangeSave();
+  },
+  resetDbRanges: () => {
+    set({
+      autoRange: false,
+      dbMin: FIXED_DB_MIN,
+      dbMax: FIXED_DB_MAX,
+      txDbMin: TX_FIXED_DB_MIN,
+      txDbMax: TX_FIXED_DB_MAX,
+      wfDbMin: FIXED_DB_MIN,
+      wfDbMax: FIXED_DB_MAX,
+      wfTxDbMin: TX_FIXED_DB_MIN,
+      wfTxDbMax: TX_FIXED_DB_MAX,
+    });
+    writeSavedRange(FIXED_DB_MIN, FIXED_DB_MAX);
+    writeSavedTxRange(TX_FIXED_DB_MIN, TX_FIXED_DB_MAX);
+    writeSavedWfRange(FIXED_DB_MIN, FIXED_DB_MAX);
+    writeSavedWfTxRange(TX_FIXED_DB_MIN, TX_FIXED_DB_MAX);
     scheduleDbRangeSave();
   },
   updateAutoRange: (wfDb) => {


### PR DESCRIPTION
## 📊 Spectrum Scale settings — DRAFT for bench testing (do not merge)

Christiano's (N9WAR) **Spectrum Scale** panel, ported clean into **Settings → Display**. Typed numeric **min/max dB-window** fields letting you set the render scale of each spectrum display independently:

| Category | fields |
|---|---|
| **RX Panadapter** | min / max dB (+ per-row Reset) |
| **TX Panadapter** | min / max dB |
| **RX Waterfall** | min / max dB colour-map window |
| **TX Waterfall** | min / max dB colour-map window |

\+ **Auto RX Panadapter Range** toggle and a **Reset All** button. Two-layer clamping (panel enforces ±200 dB with a 20 dB min span; the store re-validates). Manual edits return that display to fixed (non-auto) mode.

### Why it's a clean port
develop **already** tracked these per-display dB windows and the panadapter/waterfall renderers already consume them (they were drag-adjustable). The gap was just the explicit absolute setters + the typed-field UI + the Display-menu mount — so edits reach the display immediately.

### Safety
- ✅ **Display-only** — 3 frontend files (+371 lines): the new panel, 5 store setters (`setDbRange`/`setTxDbRange`/`setWfDbRange`/`setWfTxDbRange`/`resetDbRanges`, reusing develop's `sanitizeRange`/`writeSaved*`/`autoRange`), and the DisplayPanel mount.
- ✅ **Zero DSP brought over** — excluded NR5, smart-NR, squelch, AGC, SignalIntelligence, VST, RX2, relief/pop sliders.
- ✅ **PureSignal / AGC / volume / estimator untouched** — `signal-estimator.ts` byte-untouched; no `.cs`/server/WDSP/TX. PS byte-identical at defaults.
- Kept our `SignalEnhancePanel` (did **not** adopt his fork's swap-out that pulls in the estimator).

**Build:** tsc + vite + `dotnet build` all green; display-settings-store tests 8/8 pass.
**Authorship:** panel = N9WAR; integration = KB2UKA.

🚫 **Draft — not for merge.** Bench-test first.
