### PR TITLE
fix(waterfall): remove dead tickCounter (lint) — un-break develop CI

### DIFF
--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -189,7 +189,6 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
     }
 
     let lastSeqDrawn = -1;
-    let tickCounter = 0;
     // Count context-restore cycles — a one-off eviction logs once; a steady
     // leak would climb, which is the signal to dig further (#629).
     let restoreCount = 0;
@@ -346,7 +345,6 @@ export function Waterfall({ transparent = false }: WaterfallProps = {}) {
       if (wfDb) wfValidFrames++;
       const skipRowUpload = false;
       if (wfDb) {
-        tickCounter++;
         // Every server frame uploads a row; the continuous scroll rate is
         // applied shader-side via the per-fragment row-age divide by
         // uScrollSpeed (see WfRenderer.setScrollSpeed / shaders.ts ageRows).


### PR DESCRIPTION
Dead-code-only lint fix. The scroll-speed engine (#655) dropped the JS cadence-skip but left `tickCounter` incremented and never read → `@typescript-eslint/no-unused-vars` error → develop's Build-and-Test went red. Removing the vestigial counter; zero runtime change. eslint clean (0 errors), tsc+vite green.