### PR TITLE
feat(hamclock): bundle Node in the macOS app — works on any Mac (#657)

### DIFF
--- a/Zeus.Server.Hosting/HamClockService.cs
+++ b/Zeus.Server.Hosting/HamClockService.cs
@@ -422,7 +422,14 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
     private (bool ok, string? version) GetNodeInfoCached()
     {
         lock (_nodeGate) { if (_nodeProbed) return _nodeInfo; }
+        // Adopt the app-bundled Node first (always present in packaged builds).
+        if (_nodeDir is null)
+        {
+            var bundled = FindBundledNodeBinDir();
+            if (bundled is not null) { _nodeDir = bundled; _nodeBundled = true; }
+        }
         var info = DetectNode();
+        if (!info.ok && _nodeBundled) { _nodeDir = null; _nodeBundled = false; info = DetectNode(); }
         if (!info.ok && _nodeDir is null)
         {
             var portable = FindPortableNodeBinDir();
@@ -444,12 +451,35 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
 
     /// <summary>
     /// Ensure a usable Node is resolved into <see cref="_nodeDir"/>. Order:
-    /// (1) system Node on PATH, (2) a private copy from a prior install,
-    /// (3) download a pinned portable Node from nodejs.org (checksum-verified).
-    /// Returns false (and calls Fail) only if the download/extract fails.
+    /// (0) a Node bundled inside the app payload, (1) system Node on PATH,
+    /// (2) a private copy from a prior install, (3) download a pinned portable
+    /// Node from nodejs.org (checksum-verified). Returns false (and calls Fail)
+    /// only if the download/extract fails.
     /// </summary>
     private async Task<bool> EnsureNodeAsync()
     {
+        // (0) Node bundled inside the app payload — deterministic, always present
+        // in packaged builds (sealed as a signed resource), needs no system Node
+        // and no runtime download. Preferred so HamClock "just works" on any Mac,
+        // including ones with no Node installed at all. (#657)
+        if (_nodeDir is null)
+        {
+            var bundled = FindBundledNodeBinDir();
+            if (bundled is not null)
+            {
+                _nodeDir = bundled;
+                var b = DetectNode();
+                if (b.ok)
+                {
+                    _nodeBundled = true;
+                    Append($"Using app-bundled Node {b.version}.");
+                    SetNodeInfo((true, b.version));
+                    return true;
+                }
+                _nodeDir = null; // bundled didn't run; fall through to system/download
+            }
+        }
+
         // (1) Whatever's already resolved (system, or a _nodeDir set earlier).
         var (ok, ver) = DetectNode();
         if (ok)
@@ -496,6 +526,30 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
     /// <summary>The PATH-prependable bin dir of a previously downloaded private
     /// Node, or null. Windows: the extracted folder (node.exe + npm.cmd at root);
     /// Unix: its <c>bin/</c> subdir.</summary>
+    /// <summary>Locate a Node runtime bundled inside the app payload (shipped at
+    /// build time under &lt;BaseDirectory&gt;/node — on macOS that is
+    /// Contents/Resources/app/node, sealed as a signed resource). Accepts either
+    /// node/bin/node or node/&lt;dist&gt;/bin/node. Returns the PATH-prependable bin
+    /// dir, or null when no bundled Node is present.</summary>
+    private static string? FindBundledNodeBinDir()
+    {
+        try
+        {
+            var root = Path.Combine(AppContext.BaseDirectory, "node");
+            if (!Directory.Exists(root)) return null;
+            var exeName = OperatingSystem.IsWindows() ? "node.exe" : "node";
+            var direct = OperatingSystem.IsWindows() ? root : Path.Combine(root, "bin");
+            if (File.Exists(Path.Combine(direct, exeName))) return direct;
+            foreach (var dir in Directory.GetDirectories(root))
+            {
+                var binDir = OperatingSystem.IsWindows() ? dir : Path.Combine(dir, "bin");
+                if (File.Exists(Path.Combine(binDir, exeName))) return binDir;
+            }
+        }
+        catch { /* best effort */ }
+        return null;
+    }
+
     private static string? FindPortableNodeBinDir()
     {
         try

--- a/installers/create-macos-app.sh
+++ b/installers/create-macos-app.sh
@@ -91,6 +91,31 @@ mkdir -p "${APP_PAYLOAD}"
 echo "Copying published files into Contents/Resources/app ..."
 cp -r "${PUBLISH_DIR}"/* "${APP_PAYLOAD}/"
 
+# Bundle a pinned Node runtime inside the app so the embedded HamClock works on
+# ANY Mac — including ones with no system Node — and never depends on the
+# stripped GUI-launch PATH. HamClockService.FindBundledNodeBinDir() looks for
+# <BaseDirectory>/node (= Contents/Resources/app/node here), which is sealed as
+# an ordinary signed resource (Node's own Developer-ID signature is preserved).
+# Keep NODE_BUNDLE_VERSION in sync with HamClockService.PortableNodeVersion. (#657)
+NODE_BUNDLE_VERSION="v22.11.0"
+NODE_DIST="node-${NODE_BUNDLE_VERSION}-darwin-${ARCH}"   # ARCH is arm64 | x64
+NODE_URL="https://nodejs.org/dist/${NODE_BUNDLE_VERSION}/${NODE_DIST}.tar.gz"
+echo "Bundling Node ${NODE_BUNDLE_VERSION} (darwin-${ARCH}) into the app payload..."
+NODE_TMP="$(mktemp -d)"
+if curl -fsSL "${NODE_URL}" -o "${NODE_TMP}/node.tar.gz"; then
+    mkdir -p "${APP_PAYLOAD}/node"
+    tar -xzf "${NODE_TMP}/node.tar.gz" -C "${APP_PAYLOAD}/node"
+    # Result: Contents/Resources/app/node/${NODE_DIST}/bin/node (+ npm).
+    if [ -x "${APP_PAYLOAD}/node/${NODE_DIST}/bin/node" ]; then
+        echo "  bundled node: $("${APP_PAYLOAD}/node/${NODE_DIST}/bin/node" --version 2>/dev/null || echo '?')"
+    else
+        echo "::warning::Bundled Node binary missing after extract — HamClock will fall back to download."
+    fi
+else
+    echo "::warning::Could not download Node ${NODE_BUNDLE_VERSION} for bundling — HamClock will fall back to system/download node."
+fi
+rm -rf "${NODE_TMP}"
+
 # Generate Zeus.icns from docs/pics/zeus.png so Finder, Dock, and Cmd-Tab
 # show the Zeus artwork. iconutil + sips ship with Xcode CLT (present on
 # every GitHub macos-latest runner and any dev box that has built native


### PR DESCRIPTION
Follow-up to #660. Ships a pinned **Node v22.11.0 inside the macOS .app** (`Contents/Resources/app/node/`, sealed as a signed resource — Node's Developer-ID signature preserved). `HamClockService` resolves the bundled Node **first** (before system PATH / before any download), so HamClock starts on Macs with **no Node installed, offline, zero setup**.

- `HamClockService`: `FindBundledNodeBinDir()` as step (0) in `EnsureNodeAsync` + the status probe; falls through to system/download when absent (Win/Linux unaffected).
- `create-macos-app.sh`: downloads `node-vX-darwin-$ARCH` into the payload at package time.

Resolution order now: **bundled → system (via #660 PATH prepend) → prior download → fresh download.** Infra-only, no TX/PS/DSP. Adds ~90 MB to the macOS app (the reliability tradeoff you asked for).