### PR TITLE
ci: retry fftw3 vcpkg install (survive transient fftw.org flakes)

### DIFF
--- a/.github/workflows/build-native-libs.yml
+++ b/.github/workflows/build-native-libs.yml
@@ -57,7 +57,18 @@ jobs:
           } else {
             "x64-windows-static-md"
           }
-          vcpkg install fftw3:$triplet
+          # Retry the fftw3 install: vcpkg fetches fftw-3.3.11.tar.gz from
+          # www.fftw.org, which occasionally throws a transient SSL/connect error
+          # (curl 35) with no retry of its own. 3x with backoff so a momentary
+          # blip can't fail the native build. See the matching note in release.yml.
+          $ok = $false
+          for ($i = 1; $i -le 3; $i++) {
+            vcpkg install fftw3:$triplet
+            if ($LASTEXITCODE -eq 0) { $ok = $true; break }
+            Write-Host "::warning::vcpkg install fftw3 attempt $i failed (likely a transient fftw.org download error) — retrying..."
+            Start-Sleep -Seconds (15 * $i)
+          }
+          if (-not $ok) { Write-Error "vcpkg install fftw3 failed after 3 attempts."; exit 1 }
           echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" >> $env:GITHUB_ENV
 
       - name: Configure CMake

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,19 @@ jobs:
           } else {
             "x64-windows-static-md"
           }
-          vcpkg install fftw3:$triplet
+          # vcpkg pulls fftw-3.3.11.tar.gz from www.fftw.org, which intermittently
+          # throws a transient SSL/connect error (curl 35) and has no retry of its
+          # own — a single blip would fail the whole native build and skip every
+          # installer. Retry up to 3x with backoff so a momentary fftw.org hiccup
+          # can't red the build. vcpkg caches partial progress between attempts.
+          $ok = $false
+          for ($i = 1; $i -le 3; $i++) {
+            vcpkg install fftw3:$triplet
+            if ($LASTEXITCODE -eq 0) { $ok = $true; break }
+            Write-Host "::warning::vcpkg install fftw3 attempt $i failed (likely a transient fftw.org download error) — retrying..."
+            Start-Sleep -Seconds (15 * $i)
+          }
+          if (-not $ok) { Write-Error "vcpkg install fftw3 failed after 3 attempts."; exit 1 }
           echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" >> $env:GITHUB_ENV
 
       - name: Configure CMake


### PR DESCRIPTION
vcpkg fetches `fftw-3.3.11.tar.gz` from www.fftw.org with no retry of its own. A momentary SSL/connect error (curl 35) fails the Windows native-WDSP build and — because the installer jobs `needs` all native libs — skips **every** installer. Hit this on a #657 mac-arm dry-run today; a re-run cleared it, but it'll recur randomly on nightlies/releases.

Wraps `vcpkg install fftw3:$triplet` in a 3× backoff retry in both `release.yml` and `build-native-libs.yml`. Infra-only, no app code.

Note: nightly cron runs from main's workflow file, so this fully covers nightlies once it rides develop→main at the next release merge; it covers develop dry-runs immediately.