### PR TITLE
feat(meters): high-end premium meter rendering + 60Hz liquid motion

### DIFF
--- a/zeus-web/src/components/MicMeter.tsx
+++ b/zeus-web/src/components/MicMeter.tsx
@@ -47,6 +47,7 @@ import { useTxStore } from '../state/tx-store';
 import { useMicPeakStore } from '../audio/mic-peak-store';
 import { useCapabilitiesStore } from '../state/capabilities-store';
 import { useBallisticReading } from './meters/useBallisticReading';
+import { BloomFill, BloomFilter, PeakTick } from './meters/render/svgChrome';
 
 // Pre-TX mic level indicator. The worklet measures peak dBFS on the raw
 // browser capture *before* any gain; the server then applies
@@ -152,7 +153,7 @@ export function MicMeter() {
       title={hint}
     >
       <span className="label-xs">MIC</span>
-      <div className="meter-bar" style={{ flex: 1, height: 8 }}>
+      <div className="meter-bar meter-bar--lit" style={{ flex: 1, height: 8 }}>
         {/* Permanent red zone on the last 3 dB — always visible so peaks
             have a "target just below" reference, same as Thetis. */}
         <div
@@ -163,24 +164,62 @@ export function MicMeter() {
             bottom: 0,
             left: `${RED_ZONE_START * 100}%`,
             right: 0,
-            background: 'rgba(255,64,64,0.14)',
+            background: 'var(--tx-soft)',
           }}
         />
-        <div
-          className="meter-fill"
-          style={{
-            width: `${fraction * 100}%`,
-            background: clipping
-              ? 'linear-gradient(90deg, var(--power), var(--tx))'
-              : 'linear-gradient(90deg, #2e7a2e, var(--accent))',
-          }}
-        />
-        {/* Peak-hold marker, matches .meter-peak style */}
-        <div
+        {/* Bloom-behind-crisp fill — a blurred copy of the colored bar under
+            the crisp clip, giving the lit-trace halo that matches the
+            immersive gauges. preserveAspectRatio="none" stretches the SVG to
+            the bar; the bloom filter region is widened vertically to bleed. */}
+        <svg
           aria-hidden
-          className="meter-peak"
-          style={{ left: `${peak * 100}%` }}
-        />
+          viewBox="0 0 100 10"
+          preserveAspectRatio="none"
+          style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', display: 'block' }}
+        >
+          <defs>
+            <BloomFilter id="micmeter-blur" region={['-2%', '-60%', '104%', '220%']} />
+            <linearGradient id="micmeter-fill" x1="0" y1="0" x2="100" y2="0" gradientUnits="userSpaceOnUse">
+              {clipping ? (
+                <>
+                  <stop offset="0" stopColor="var(--power)" />
+                  <stop offset="1" stopColor="var(--tx)" />
+                </>
+              ) : (
+                <>
+                  <stop offset="0" stopColor="var(--ok)" />
+                  <stop offset="1" stopColor="var(--accent)" />
+                </>
+              )}
+            </linearGradient>
+            <linearGradient id="micmeter-glass" x1="0" y1="0" x2="0" y2="10" gradientUnits="userSpaceOnUse">
+              <stop offset="0" stopColor="var(--meter-glass-top)" />
+              <stop offset="1" stopColor="var(--meter-glass-bot)" />
+            </linearGradient>
+          </defs>
+          {fraction > 0 && (
+            <BloomFill
+              shape={{ kind: 'rect', x: 0, y: 0, width: fraction * 100, height: 10 }}
+              fill="url(#micmeter-fill)"
+              filterId="micmeter-blur"
+            />
+          )}
+          {/* faint top-to-bottom glass sheen over the fill */}
+          {fraction > 0 && (
+            <rect x={0} y={0} width={fraction * 100} height={4} fill="url(#micmeter-glass)" />
+          )}
+          {/* Peak-hold marker — glowing tick. */}
+          <PeakTick
+            x1={peak * 100}
+            y1={-1}
+            x2={peak * 100}
+            y2={11}
+            stroke="#fff"
+            strokeWidth={1.5}
+            opacity={0.85}
+            nonScaling
+          />
+        </svg>
       </div>
       <span
         className="mono"

--- a/zeus-web/src/components/SMeter.tsx
+++ b/zeus-web/src/components/SMeter.tsx
@@ -43,6 +43,11 @@
 // License for details.
 
 import { useEffect, useRef, useState } from 'react';
+import { BloomFill, BloomFilter, PeakTick } from './meters/render/svgChrome';
+import { GaugeBezel } from './meters/render/GaugeBezel';
+import { GlassDome } from './meters/render/GlassDome';
+import { recessedWell } from './meters/render/recessedWell';
+import { useGlidedFraction } from './meters/render/useGlidedDraw';
 
 // RX scale: amateur-radio S-units. S9 = -73 dBm on HF. Each S-unit = 6 dB.
 // Above S9 labelled in dB over S9 (+10, +20, +40, +60).
@@ -139,6 +144,20 @@ export function SMeter(props: SMeterProps) {
     };
   }, [fraction, peak]);
 
+  // 60 Hz display-side glide for the amber bar — the DRAWN width springs
+  // toward the live fraction on the shared draw-bus, written imperatively as a
+  // scaleX on the fill <g> (no setState in the hot path). The peak marker is
+  // NEVER glided — it stays on its own instant rAF latch above (#FFA028
+  // signal-amber semantics + alpha ramp are untouched).
+  const fillGroupRef = useRef<SVGGElement | null>(null);
+  const glide = useGlidedFraction(fraction, {
+    onDraw: (drawn) => {
+      const g = fillGroupRef.current;
+      if (g) g.setAttribute('transform', `scale(${Math.max(0, Math.min(1, drawn)).toFixed(4)} 1)`);
+    },
+  });
+  const initialScale = Math.max(0, Math.min(1, glide.read())).toFixed(4);
+
   const valueLabel = isTx
     ? `${props.watts.toFixed(1)} W`
     : formatRxLabel(props.dbm);
@@ -165,37 +184,97 @@ export function SMeter(props: SMeterProps) {
       </div>
 
       <div className="relative flex-1">
-        {/* Track */}
-        <div className="relative h-6 overflow-hidden rounded-sm bg-neutral-900 ring-1 ring-inset ring-neutral-800">
-          {/* Subtle grid backdrop evoking the reference mockup */}
-          <div
-            aria-hidden
-            className="absolute inset-0 opacity-40"
-            style={{
-              backgroundImage:
-                'linear-gradient(to right, rgba(255,255,255,0.04) 1px, transparent 1px)',
-              backgroundSize: '10% 100%',
-            }}
-          />
+        {/* Track — recessed machined well + warm amber halo, matching the
+            immersive gauges and the TX-stage rows. */}
+        <div
+          className="relative h-6 overflow-hidden"
+          style={recessedWell({ radius: 3, warmHalo: true, glow: true })}
+        >
           {/* Fill — single-hue amber ramp matching the panadapter trace
-              (#FFA028, see src/gl/panadapter.ts TRACE_R/G/B). Alpha rises
-              with signal: dim at S0, full-bright past S9. No hue shift. */}
-          <div
-            className="absolute inset-0 overflow-hidden transition-[clip-path] duration-75 ease-out"
-            style={{
-              clipPath: `inset(0 ${(1 - fraction) * 100}% 0 0)`,
-              boxShadow: 'inset 0 0 8px rgba(0,0,0,0.35)',
-            }}
+              (#FFA028, see src/gl/panadapter.ts TRACE_R/G/B; the sanctioned
+              signal amber). Rendered bloom-behind-crisp under a domed glass +
+              drifting sheen, framed by a machined bezel ring. Alpha rises with
+              signal: dim at S0, full-bright past S9 — no hue shift. The fill
+              width is driven at 60 Hz by an imperative scaleX on the fill <g>;
+              the PEAK tick latches instantly from `peak`. */}
+          <svg
+            aria-hidden
+            viewBox="0 0 100 24"
+            preserveAspectRatio="none"
+            className="absolute inset-0"
+            style={{ width: '100%', height: '100%', display: 'block' }}
           >
-            <div
-              aria-hidden
-              className="absolute inset-0"
-              style={{
-                background:
-                  'linear-gradient(90deg, rgba(255,160,40,0.18) 0%, rgba(255,160,40,0.55) 50%, rgba(255,160,40,1) 100%)',
-              }}
+            <defs>
+              <BloomFilter id="smeter-blur" region={['-2%', '-40%', '104%', '180%']} />
+              <linearGradient id="smeter-fill" x1="0" y1="0" x2="100" y2="0" gradientUnits="userSpaceOnUse">
+                <stop offset="0" stopColor="#FFA028" stopOpacity="0.18" />
+                <stop offset="0.5" stopColor="#FFA028" stopOpacity="0.55" />
+                <stop offset="1" stopColor="#FFA028" stopOpacity="1" />
+              </linearGradient>
+              {/* vertical volume gradient — cylindrical shading over the bar */}
+              <linearGradient id="smeter-vol" x1="0" y1="0" x2="0" y2="24" gradientUnits="userSpaceOnUse">
+                <stop offset="0" stopColor="var(--meter-fill-hot)" />
+                <stop offset="0.18" stopColor="rgba(255,255,255,0.10)" />
+                <stop offset="0.5" stopColor="rgba(0,0,0,0)" />
+                <stop offset="0.82" stopColor="rgba(0,0,0,0.18)" />
+                <stop offset="1" stopColor="var(--meter-fill-base)" />
+              </linearGradient>
+            </defs>
+
+            {/* LED-ladder ground behind the fill */}
+            <g opacity={0.45}>
+              {Array.from({ length: 9 }).map((_, i) => (
+                <line
+                  key={`smled-${i}`}
+                  x1={(i + 1) * 10}
+                  y1={0}
+                  x2={(i + 1) * 10}
+                  y2={24}
+                  stroke="rgba(255,255,255,0.05)"
+                  strokeWidth={0.6}
+                  vectorEffect="non-scaling-stroke"
+                />
+              ))}
+            </g>
+
+            {/* Live amber fill — unit-width, scaled in X by the glided draw. */}
+            <g ref={fillGroupRef} transform={`scale(${initialScale} 1)`}>
+              <BloomFill
+                shape={{ kind: 'rect', x: 0, y: 0, width: 100, height: 24 }}
+                fill="url(#smeter-fill)"
+                filterId="smeter-blur"
+              />
+              <rect x={0} y={0} width={100} height={24} fill="url(#smeter-vol)" />
+              {/* bright amber leading edge */}
+              <rect
+                x={97}
+                y={0}
+                width={3}
+                height={24}
+                fill="#FFA028"
+                opacity={0.9}
+                style={{ filter: 'drop-shadow(0 0 3px #FFA028)' }}
+              />
+            </g>
+
+            {/* domed glass + drifting sheen */}
+            <GlassDome defsId="smeter" x={0} y={0} width={100} height={24} rx={2} />
+
+            {/* Peak-hold marker — glowing tick, latched instantly. */}
+            <PeakTick
+              x1={peak * 100}
+              y1={-1}
+              x2={peak * 100}
+              y2={25}
+              stroke="#fff"
+              strokeWidth={2.2}
+              opacity={0.9}
+              nonScaling
             />
-          </div>
+
+            {/* machined bezel ring */}
+            <GaugeBezel variant="rect" defsId="smeter" x={0} y={0} width={100} height={24} rx={2} thickness={2.4} nonScaling />
+          </svg>
           {/* S9 reference marker for RX — thin amber line, not red. */}
           {!isTx && (
             <div
@@ -204,12 +283,6 @@ export function SMeter(props: SMeterProps) {
               style={{ left: `${rxFraction(S9_DBM) * 100}%` }}
             />
           )}
-          {/* Peak-hold marker */}
-          <div
-            aria-hidden
-            className="absolute inset-y-0 w-0.5 bg-white/80 mix-blend-screen"
-            style={{ left: `calc(${peak * 100}% - 1px)` }}
-          />
           {/* TX badge inside the track, top-right */}
           {badge && (
             <span className="absolute right-1 top-0.5 rounded-sm bg-red-500/20 px-1 text-[10px] font-bold tracking-wider text-red-300 ring-1 ring-red-400/40">

--- a/zeus-web/src/components/TxStageMeters.tsx
+++ b/zeus-web/src/components/TxStageMeters.tsx
@@ -25,6 +25,12 @@ import { useConnectionStore } from '../state/connection-store';
 import { usePaStore } from '../state/pa-store';
 import { useRadioStore } from '../state/radio-store';
 import { useBallisticReading } from './meters/useBallisticReading';
+import { BloomFill, BloomFilter, PeakTick, prefixDefs } from './meters/render/svgChrome';
+import { GaugeBezel } from './meters/render/GaugeBezel';
+import { GlassDome } from './meters/render/GlassDome';
+import { recessedWell } from './meters/render/recessedWell';
+import { volumeStops } from './meters/render/fillGradient';
+import { useGlidedFraction } from './meters/render/useGlidedDraw';
 
 // ────────────────────────────────────────────────────────────────────────────
 // Overdrive indicator (re-exported so App.tsx can keep wiring it as the
@@ -267,6 +273,8 @@ type MeterRowProps = {
   hot?: boolean;
   /** Hover-tooltip explaining what this meter shows. */
   hint: string;
+  /** Panel root for the shared draw-bus off-screen gate. */
+  hostRef?: React.RefObject<Element | null>;
 };
 
 function MeterRow({
@@ -278,6 +286,7 @@ function MeterRow({
   color,
   gradient,
   zones,
+  hostRef,
   readNow,
   readUnit,
   pkLabel,
@@ -286,6 +295,33 @@ function MeterRow({
   hint,
 }: MeterRowProps) {
   const heldVisible = peakPct > pct + 0.5;
+  // Per-row defs ids — namespaced so the four rows' blur/gradient filters
+  // never collide on a shared page.
+  const blurId = prefixDefs(`txrow-${id}`, 'blur');
+  const volId = prefixDefs(`txrow-${id}`, 'vol');
+  // PWR / SWR carry the healthy→hot gradient as an SVG paint; MIC / ALC fill
+  // with their flat token colour. `gradient` (the CSS string) only signals
+  // which rows want the SVG gradient — the SVG redefines the same stops.
+  const svgGradientId = gradient ? prefixDefs(`txrow-${id}`, 'grad') : null;
+
+  // 60 Hz display-side glide — the bar's DRAWN width springs toward the
+  // already-calibrated pct on the shared draw-bus. We write the width
+  // imperatively to a <g> scaleX transform (transform-origin at x=0) so no
+  // React setState runs in the 60 Hz path; reconciliation stays at the 30 Hz
+  // value cadence. The PEAK marker is NEVER glided — it latches off the raw
+  // peakPct below. Position math (micPctOf/…) is unchanged.
+  const fillGroupRef = useRef<SVGGElement | null>(null);
+  const glow = useGlidedFraction(pct / 100, {
+    hostRef,
+    onDraw: (drawn) => {
+      const g = fillGroupRef.current;
+      if (g) g.setAttribute('transform', `scale(${Math.max(0, Math.min(1, drawn)).toFixed(4)} 1)`);
+    },
+  });
+  // Seed the drawn width on first paint so a freshly-mounted row isn't blank
+  // for a frame before the bus ticks.
+  const initialScale = Math.max(0, Math.min(1, glow.read())).toFixed(4);
+  const TRACK_H = 24;
   return (
     <div
       data-id={id}
@@ -311,36 +347,17 @@ function MeterRow({
       </div>
       <div style={{ position: 'relative' }}>
         <TickLabels labels={ticks} />
+        {/* Recessed machined well — the concave pocket the lit fill sits
+            inside (layer 1). The warm amber halo + gauge bloom give the
+            "lit instrument on a black bench" glow. */}
         <div
           style={{
             position: 'relative',
-            height: 14,
-            background: 'var(--meter-bg)',
-            border: '1px solid var(--line)',
-            borderRadius: 2,
-            // v3 Lifted Dark: warm amber halo around the meter well — the
-            // "lit instruments on a black bench" look. Inner inset stays
-            // for depth; outer halos give the column a soft glow.
-            boxShadow:
-              'inset 0 1px 3px rgba(0,0,0,0.8),' +
-              ' inset 0 0 0 1px rgba(255,255,255,0.03),' +
-              ' 0 0 18px rgba(255,140,40,0.18),' +
-              ' 0 0 6px rgba(255,170,80,0.12)',
+            height: TRACK_H,
+            ...recessedWell({ radius: 3, warmHalo: true, glow: true }),
             overflow: 'hidden',
           }}
         >
-          {/* Subtle 10 % tick grid on the track itself — same trick as the
-              design HTML, gives the bar a "ruled" feel without adding hue. */}
-          <div
-            aria-hidden="true"
-            style={{
-              position: 'absolute',
-              inset: 0,
-              backgroundImage:
-                'repeating-linear-gradient(90deg, transparent 0 calc(10% - 1px), rgba(255,255,255,0.05) calc(10% - 1px) 10%)',
-              pointerEvents: 'none',
-            }}
-          />
           {/* Warning / danger zone bands behind the live fill. */}
           {zones?.map((z, i) => (
             <div
@@ -353,42 +370,108 @@ function MeterRow({
                 left: `${z.from}%`,
                 width: `${Math.max(0, z.to - z.from)}%`,
                 background: z.color,
-                opacity: 0.14,
+                opacity: 0.16,
                 pointerEvents: 'none',
               }}
             />
           ))}
-          {/* Live fill — flat color or gradient depending on the meter. */}
-          <div
+          {/* The full five-layer instrument stack drawn as one inline SVG so
+              the fill, LED ladder, volumetric shading, specular glass dome +
+              drifting sheen, and the machined bezel ring all share one
+              coordinate space. preserveAspectRatio="none" stretches the fixed
+              viewBox to the row width. The live fill width is driven at 60 Hz
+              by an imperative scaleX on the fill <g>; the PEAK tick latches
+              instantly from the raw peakPct. */}
+          <svg
             aria-hidden="true"
-            style={{
-              position: 'absolute',
-              left: 0,
-              top: 0,
-              bottom: 0,
-              width: `${pct}%`,
-              background: gradient ?? color,
-              transition: 'width 120ms linear, background 150ms',
-              pointerEvents: 'none',
-            }}
-          />
-          {/* Peak-hold tick. PWR/SWR use a neutral tick (the bar colour is
-              already a healthy→hot gradient); MIC/ALC use the meter colour. */}
-          {heldVisible && (
-            <div
-              aria-hidden="true"
-              style={{
-                position: 'absolute',
-                top: -1,
-                bottom: -1,
-                width: 2,
-                left: `calc(${peakPct}% - 1px)`,
-                background: gradient ? 'var(--fg-1)' : color,
-                transition: 'left 250ms cubic-bezier(.2,.7,.3,1)',
-                pointerEvents: 'none',
-              }}
-            />
-          )}
+            viewBox={`0 0 100 ${TRACK_H}`}
+            preserveAspectRatio="none"
+            style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', display: 'block', pointerEvents: 'none' }}
+          >
+            <defs>
+              <BloomFilter id={blurId} region={['-2%', '-50%', '104%', '200%']} />
+              {svgGradientId && (
+                <linearGradient id={svgGradientId} x1="0" y1="0" x2="100" y2="0" gradientUnits="userSpaceOnUse">
+                  {/* good floor brightened to --immersive-good so the lit
+                      fill GLOWS instead of sitting dark. */}
+                  <stop offset="0" stopColor="var(--immersive-good)" />
+                  <stop offset="0.55" stopColor="var(--immersive-good)" />
+                  <stop offset="0.70" stopColor="#7cd1a8" />
+                  <stop offset="0.82" stopColor="var(--power)" />
+                  <stop offset="1" stopColor="var(--tx)" />
+                </linearGradient>
+              )}
+              {/* (2) vertical volume gradient — makes the bar read cylindrical
+                  UNDER the horizontal hue ramp. */}
+              <linearGradient id={volId} x1="0" y1="0" x2="0" y2={TRACK_H} gradientUnits="userSpaceOnUse">
+                {volumeStops()}
+              </linearGradient>
+            </defs>
+
+            {/* LED-ladder ground — lit segment grid behind the fill so the
+                bar reads as a row of illuminated cells. */}
+            <g opacity={0.5}>
+              {Array.from({ length: 9 }).map((_, i) => (
+                <line
+                  key={`led-${i}`}
+                  x1={(i + 1) * 10}
+                  y1={0}
+                  x2={(i + 1) * 10}
+                  y2={TRACK_H}
+                  stroke="rgba(255,255,255,0.06)"
+                  strokeWidth={0.6}
+                  vectorEffect="non-scaling-stroke"
+                />
+              ))}
+            </g>
+
+            {/* Live fill — a unit-width (x=0..100) stack scaled in X by the
+                glided draw value. (a) bloom-behind-crisp hue fill via the
+                shared kit, then (b) the vertical volume gradient over it, then
+                (c) a bright leading-edge color-glow streak that lights up as
+                the bar rises. */}
+            <g ref={fillGroupRef} transform={`scale(${initialScale} 1)`}>
+              <BloomFill
+                shape={{ kind: 'rect', x: 0, y: 0, width: 100, height: TRACK_H }}
+                fill={svgGradientId ? `url(#${svgGradientId})` : color}
+                filterId={blurId}
+              />
+              {/* volumetric cylinder shading */}
+              <rect x={0} y={0} width={100} height={TRACK_H} fill={`url(#${volId})`} />
+              {/* leading-edge color-glow — a bright sliver at the fill tip */}
+              <rect
+                x={97}
+                y={0}
+                width={3}
+                height={TRACK_H}
+                fill={gradient ? 'var(--meter-fill-glow)' : color}
+                opacity={0.85}
+                style={{ filter: `drop-shadow(0 0 3px ${gradient ? 'var(--meter-fill-glow)' : color})` }}
+              />
+            </g>
+
+            {/* (3) specular glass dome + drifting sheen over the whole track */}
+            <GlassDome defsId={`txrow-${id}`} x={0} y={0} width={100} height={TRACK_H} rx={2} />
+
+            {/* (5) glowing peak marker — taller + brighter, latched INSTANTLY
+                from the raw peakPct (never the glided draw value). */}
+            {heldVisible && (
+              <PeakTick
+                x1={peakPct}
+                y1={-1}
+                x2={peakPct}
+                y2={TRACK_H + 1}
+                stroke={gradient ? 'var(--fg-0)' : color}
+                strokeWidth={2.6}
+                opacity={1}
+                nonScaling
+              />
+            )}
+
+            {/* (4) machined bezel ring — drawn LAST so the chrome frames the
+                whole instrument and it sits IN the panel. */}
+            <GaugeBezel variant="rect" defsId={`txrow-${id}`} x={0} y={0} width={100} height={TRACK_H} rx={2} thickness={2.4} nonScaling />
+          </svg>
         </div>
       </div>
       <div
@@ -658,6 +741,7 @@ export function TxStageMeters() {
         }}
       >
         <MeterRow
+          hostRef={panelRef}
           id="mic"
           label="MIC"
           ticks={MIC_TICKS}
@@ -671,6 +755,7 @@ export function TxStageMeters() {
           hint="Mic peak entering WDSP TXA, post-panel-gain (TXA_MIC_PK)"
         />
         <MeterRow
+          hostRef={panelRef}
           id="alc"
           label="ALC"
           ticks={ALC_TICKS}
@@ -685,6 +770,7 @@ export function TxStageMeters() {
           hint="ALC gain reduction. Healthy SSB compression sits in the 3–10 dB band; sustained > 10 dB means the input is over-driving the limiter."
         />
         <MeterRow
+          hostRef={panelRef}
           id="pwr"
           label="PWR"
           ticks={pwrTicks(ratedW)}
@@ -700,6 +786,7 @@ export function TxStageMeters() {
           hint={`Forward power. Axis 0..${ratedW} W (PA panel override → board default → 100 W fallback).`}
         />
         <MeterRow
+          hostRef={panelRef}
           id="swr"
           label="SWR"
           ticks={SWR_TICKS}

--- a/zeus-web/src/components/analog-meter/AnalogMeterFace.tsx
+++ b/zeus-web/src/components/analog-meter/AnalogMeterFace.tsx
@@ -11,7 +11,7 @@
 // adapted to the Zeus palette: the warm-red needle uses --tx, the active
 // arc + +dB region uses --accent, base chrome uses --fg-* / --bg-* / --line.
 
-import { Fragment } from 'react';
+import { Fragment, useRef } from 'react';
 import {
   FACE,
   pt,
@@ -21,6 +21,9 @@ import {
   type ScaleDef,
   type ScaleId,
 } from './analogMeterShared';
+import { BloomFilter, prefixDefs } from '../meters/render/svgChrome';
+import { GaugeBezel } from '../meters/render/GaugeBezel';
+import { useGlidedFraction } from '../meters/render/useGlidedDraw';
 
 interface ScaleArcProps {
   scale: ScaleDef;
@@ -46,9 +49,19 @@ function ScaleArc({ scale, radius, active, enabled, peakValueN }: ScaleArcProps)
   const tickAngle = (v: number) => normToDeg(scale.n(v));
   const peakDeg = active && peakValueN != null ? normToDeg(peakValueN) : null;
   const isS = scale.id === 's';
+  const arcBlurId = prefixDefs(`amface-${scale.id}`, 'arcblur');
 
   return (
     <g>
+      {/* inner-groove dark inset arc behind the lit track — a recessed
+          channel the illuminated tube sits inside. */}
+      <path
+        d={arcPath(FACE.cx, FACE.cy, radius, a0, a1)}
+        stroke="rgba(0,0,0,0.55)"
+        strokeWidth={active ? 12 : 7}
+        fill="none"
+        strokeLinecap="round"
+      />
       <path
         d={arcPath(FACE.cx, FACE.cy, radius, a0, a1)}
         stroke={trackColor}
@@ -57,26 +70,61 @@ function ScaleArc({ scale, radius, active, enabled, peakValueN }: ScaleArcProps)
         fill="none"
       />
 
+      {/* Illuminated active arc tube — a wide blurred copy under a crisp
+          --accent stroke (bloom-behind-crisp), so the active scale reads as a
+          lit channel instead of a 2px hairline. Drawn full-span at low alpha
+          as the "lit rail," brightest near the live end via the peak arc. */}
+      {active && (
+        <g opacity={0.9}>
+          <defs>
+            <BloomFilter id={arcBlurId} stdDeviation={5} region={['-30%', '-30%', '160%', '160%']} />
+          </defs>
+          {/* wide soft glow rail */}
+          <path
+            d={arcPath(FACE.cx, FACE.cy, radius, a0, a1)}
+            stroke="var(--accent)"
+            strokeOpacity={0.4}
+            strokeWidth={11}
+            fill="none"
+            strokeLinecap="round"
+            filter={`url(#${arcBlurId})`}
+          />
+          {/* crisp lit tube */}
+          <path
+            d={arcPath(FACE.cx, FACE.cy, radius, a0, a1)}
+            stroke="var(--accent)"
+            strokeOpacity={0.85}
+            strokeWidth={5}
+            fill="none"
+            strokeLinecap="round"
+          />
+        </g>
+      )}
+
       {peakDeg != null && (
         <path
           d={arcPath(FACE.cx, FACE.cy, radius, a0, peakDeg)}
           stroke="var(--accent)"
-          strokeOpacity={0.35}
-          strokeWidth={6}
+          strokeOpacity={0.5}
+          strokeWidth={9}
           fill="none"
           strokeLinecap="round"
+          style={{ filter: 'drop-shadow(0 0 6px var(--accent))' }}
         />
       )}
 
       {/* +dB region of the S-scale always reads in accent, even when not the
-          active scale, so the operator can see at a glance where they are. */}
+          active scale, so the operator can see at a glance where they are.
+          When active it glows harder — a bloomed copy under the crisp arc. */}
       {isS && (
         <path
           d={arcPath(FACE.cx, FACE.cy, radius, normToDeg(scale.n(9)), a1)}
           stroke="var(--accent)"
-          strokeOpacity={active ? 0.95 : 0.5}
-          strokeWidth={trackWidth + 0.5}
+          strokeOpacity={active ? 1 : 0.5}
+          strokeWidth={active ? 9 : trackWidth + 0.5}
           fill="none"
+          strokeLinecap="round"
+          style={active ? { filter: 'drop-shadow(0 0 7px var(--accent))' } : undefined}
         />
       )}
 
@@ -172,13 +220,25 @@ function ScaleArc({ scale, radius, active, enabled, peakValueN }: ScaleArcProps)
 interface NeedleProps {
   angleDeg: number;
   peakAngleDeg: number | null;
+  /** Ref to the rotating needle <g> so the 60 Hz glide can drive its rotate
+   *  transform imperatively (no setState in the hot path). */
+  needleGroupRef: React.RefObject<SVGGElement | null>;
 }
 
-function Needle({ angleDeg, peakAngleDeg }: NeedleProps) {
+function Needle({ angleDeg, peakAngleDeg, needleGroupRef }: NeedleProps) {
   const r = FACE.rOuter + 30;
   const tail = -55;
   const [tx, ty] = pt(FACE.cx, FACE.cy, r, 0);
   const [bx, by] = pt(FACE.cx, FACE.cy, tail, 0);
+
+  // Tapered metal blade as a filled polygon — wide at the hub, narrowing to
+  // a fine tip. ~9 user-units wide at the base (the SVG is 1000 wide so this
+  // reads as a chunky machined pointer, not a hairline).
+  const BASE_HALF = 4.5;
+  const blade = `M ${FACE.cx - BASE_HALF} ${FACE.cy} L ${tx} ${ty} L ${FACE.cx + BASE_HALF} ${FACE.cy} Z`;
+  const tipFrac = 0.55;
+  const tipX = FACE.cx + (tx - FACE.cx) * tipFrac;
+  const tipY = FACE.cy + (ty - FACE.cy) * tipFrac;
 
   return (
     <Fragment>
@@ -190,23 +250,15 @@ function Needle({ angleDeg, peakAngleDeg }: NeedleProps) {
             x2={tx}
             y2={ty}
             stroke="var(--accent)"
-            strokeOpacity={0.4}
-            strokeWidth={1.5}
+            strokeOpacity={0.45}
+            strokeWidth={2}
           />
         </g>
       )}
 
-      <g transform={`rotate(${angleDeg} ${FACE.cx} ${FACE.cy})`}>
-        {/* Soft shadow under the needle blade. */}
-        <line
-          x1={FACE.cx}
-          y1={FACE.cy + 2}
-          x2={tx}
-          y2={ty + 2}
-          stroke="#000"
-          strokeOpacity={0.45}
-          strokeWidth={3}
-        />
+      <g ref={needleGroupRef} transform={`rotate(${angleDeg} ${FACE.cx} ${FACE.cy})`}>
+        {/* Soft drop shadow under the blade. */}
+        <path d={`M ${FACE.cx - BASE_HALF} ${FACE.cy + 3} L ${tx} ${ty + 3} L ${FACE.cx + BASE_HALF} ${FACE.cy + 3} Z`} fill="#000" opacity={0.4} />
         {/* Counterweight below the pivot. */}
         <line
           x1={FACE.cx}
@@ -215,34 +267,48 @@ function Needle({ angleDeg, peakAngleDeg }: NeedleProps) {
           y2={by}
           stroke="var(--tx)"
           strokeOpacity={0.7}
-          strokeWidth={3}
+          strokeWidth={5}
           strokeLinecap="round"
         />
-        {/* Main blade. */}
-        <line
-          x1={FACE.cx}
-          y1={FACE.cy}
-          x2={tx}
-          y2={ty}
-          stroke="var(--tx)"
-          strokeWidth={2.4}
-          strokeLinecap="round"
+        {/* Main tapered blade. */}
+        <path d={blade} fill="var(--tx)" />
+        {/* Dark bevel along the trailing (right) edge — the Lambert shadow
+            side, scaled up to a real 1.6-unit edge. */}
+        <path
+          d={`M ${FACE.cx + BASE_HALF} ${FACE.cy} L ${tx} ${ty} L ${tx - 1.6} ${ty} L ${FACE.cx + BASE_HALF - 1.6} ${FACE.cy} Z`}
+          fill="var(--needle-bevel-lo)"
         />
-        {/* Bright tip. */}
+        {/* Bright bevel along the leading (left) edge — the highlight side. */}
+        <path
+          d={`M ${FACE.cx - BASE_HALF} ${FACE.cy} L ${tx} ${ty} L ${tx + 1.6} ${ty} L ${FACE.cx - BASE_HALF + 1.6} ${FACE.cy} Z`}
+          fill="var(--needle-bevel-hi)"
+          opacity={0.9}
+        />
+        {/* Bright glowing tip. */}
         <line
-          x1={FACE.cx + (tx - FACE.cx) * 0.55}
-          y1={FACE.cy + (ty - FACE.cy) * 0.55}
+          x1={tipX}
+          y1={tipY}
           x2={tx}
           y2={ty}
           stroke="var(--power)"
-          strokeWidth={2.6}
+          strokeWidth={4}
           strokeLinecap="round"
+          style={{ filter: 'drop-shadow(0 0 6px var(--power))' }}
         />
       </g>
 
-      {/* Pivot cap drawn last so it sits above the needle. */}
-      <circle cx={FACE.cx} cy={FACE.cy} r={9} fill="var(--bg-3)" stroke="var(--panel-edge)" strokeWidth={1.5} />
-      <circle cx={FACE.cx} cy={FACE.cy} r={4} fill="var(--tx)" />
+      {/* Lit jewel pivot — drawn last so it sits above the blade. A machined
+          chrome collar, a radial-gradient jewel cap, and a bright glowing
+          core (like BigArc's hub). */}
+      <circle cx={FACE.cx} cy={FACE.cy} r={14} fill="var(--bg-3)" stroke="var(--panel-edge)" strokeWidth={2} />
+      <circle cx={FACE.cx} cy={FACE.cy} r={11} fill="url(#analogMeterJewel)" />
+      <circle
+        cx={FACE.cx}
+        cy={FACE.cy}
+        r={5}
+        fill="var(--power)"
+        style={{ filter: 'drop-shadow(0 0 5px var(--power)) drop-shadow(0 0 9px var(--tx-soft))' }}
+      />
     </Fragment>
   );
 }
@@ -259,12 +325,14 @@ function NeedleShadow({ angleDeg }: NeedleShadowProps) {
   if (endA <= startA + 0.5) return null;
   const [x0, y0] = pt(FACE.cx, FACE.cy, r, startA);
   const [x1, y1] = pt(FACE.cx, FACE.cy, r, endA);
+  const d = `M ${FACE.cx} ${FACE.cy} L ${x0} ${y0} A ${r} ${r} 0 0 1 ${x1} ${y1} Z`;
   return (
-    <path
-      d={`M ${FACE.cx} ${FACE.cy} L ${x0} ${y0} A ${r} ${r} 0 0 1 ${x1} ${y1} Z`}
-      fill="url(#analogMeterSweepGrad)"
-      opacity={0.18}
-    />
+    <>
+      {/* Bloomed copy under the crisp wedge so the sweep glows like the arc
+          fills on the immersive gauges — brightened for the dramatic dial. */}
+      <path d={d} fill="url(#analogMeterSweepGrad)" opacity={0.22} filter="url(#analogMeterSweepBlur)" />
+      <path d={d} fill="url(#analogMeterSweepGrad)" opacity={0.30} />
+    </>
   );
 }
 
@@ -288,8 +356,27 @@ export function AnalogMeterFace({
   peakN,
   scales = SCALES,
 }: AnalogMeterFaceProps) {
-  const angle = normToDeg(Math.max(0, Math.min(1, needleN)));
+  const clampedN = Math.max(0, Math.min(1, needleN));
   const peakAngle = peakN != null ? normToDeg(Math.max(0, Math.min(1, peakN))) : null;
+
+  // 60 Hz display-side glide for the needle. We glide the already-normalised
+  // needleN (BEFORE normToDeg), then drive the needle <g> rotate transform
+  // imperatively so the sweep is liquid at up to 60 Hz between the 30 Hz
+  // value publishes — without re-rendering this subtree in the hot path. The
+  // peak ghost/arc stays INSTANT (driven by peakN, never glided). normToDeg
+  // and the needleN VALUE are unchanged — only the drawn rotation eases.
+  const needleGroupRef = useRef<SVGGElement | null>(null);
+  const needleGlide = useGlidedFraction(clampedN, {
+    onDraw: (drawn) => {
+      const g = needleGroupRef.current;
+      if (g) g.setAttribute('transform', `rotate(${normToDeg(drawn).toFixed(3)} ${FACE.cx} ${FACE.cy})`);
+    },
+  });
+  // The needle's React-rendered initial angle must track the GLIDED drawn
+  // value (not the raw target) so a 30 Hz re-render doesn't snap the needle
+  // ahead of the spring — the bus then continues easing from here. The sweep
+  // wedge shares this drawn angle. Peak stays on the raw target angle.
+  const drawnAngle = normToDeg(needleGlide.read());
 
   // Concentric radii: active scale takes the outermost slot; remaining enabled
   // scales render below it in a fixed display order (s, po, swr).
@@ -312,18 +399,68 @@ export function AnalogMeterFace({
         preserveAspectRatio="xMidYMid meet"
       >
         <defs>
-          <radialGradient id="analogMeterDialBg" cx="50%" cy="100%" r="80%">
-            <stop offset="0%" stopColor="var(--bg-2)" />
-            <stop offset="60%" stopColor="var(--bg-1)" />
-            <stop offset="100%" stopColor="var(--bg-0)" />
+          {/* Deep recessed dial well — a concave multi-stop radial floor
+              (--meter-well-edge rim → --meter-well-floor centre) so the dial
+              reads machined into the chassis, not a flat panel. Anchored at
+              the upper-left so the whole instrument is lit from one key. */}
+          <radialGradient id="analogMeterDialBg" cx="38%" cy="20%" r="95%">
+            <stop offset="0%" stopColor="var(--meter-well-edge)" />
+            <stop offset="55%" stopColor="var(--meter-well-floor)" />
+            <stop offset="100%" stopColor="var(--meter-well-floor)" />
           </radialGradient>
           <linearGradient id="analogMeterSweepGrad" x1="0" x2="0" y1="1" y2="0">
             <stop offset="0%" stopColor="var(--accent)" stopOpacity="0" />
-            <stop offset="100%" stopColor="var(--accent)" stopOpacity="0.6" />
+            <stop offset="100%" stopColor="var(--accent)" stopOpacity="0.85" />
           </linearGradient>
+          {/* Domed-glass specular — an upper-left radial hot-spot (the pow()
+              specular analogue) over the dial face so the instrument reads as
+              covered by curved glass. */}
+          <radialGradient id="analogMeterGlass" cx="30%" cy="14%" r="70%">
+            <stop offset="0%" stopColor="var(--meter-glass-dome)" />
+            <stop offset="40%" stopColor="var(--meter-glass-top)" />
+            <stop offset="100%" stopColor="var(--meter-glass-bot)" />
+          </radialGradient>
+          {/* moving-sheen band gradient — a soft bright vertical streak. */}
+          <linearGradient id="analogMeterSheen" x1="0" x2="1" y1="0" y2="0">
+            <stop offset="0%" stopColor="var(--meter-sheen-soft)" stopOpacity="0" />
+            <stop offset="50%" stopColor="var(--meter-sheen)" />
+            <stop offset="100%" stopColor="var(--meter-sheen-soft)" stopOpacity="0" />
+          </linearGradient>
+          {/* Lit jewel pivot cap — a domed gem catching the upper-left key. */}
+          <radialGradient id="analogMeterJewel" cx="38%" cy="30%" r="75%">
+            <stop offset="0%" stopColor="rgba(255,255,255,0.7)" />
+            <stop offset="35%" stopColor="var(--tx)" />
+            <stop offset="100%" stopColor="#3a0a06" />
+          </radialGradient>
+          {/* Soft blur for the colored sweep wedge so it glows like the arc
+              fills on the immersive gauges. */}
+          <BloomFilter id="analogMeterSweepBlur" stdDeviation={4} />
         </defs>
 
+        {/* Deep recessed dial floor. */}
         <rect x="0" y="0" width={FACE.w} height={FACE.h} fill="url(#analogMeterDialBg)" />
+        {/* Inner-shadow vignette around the rim so the floor reads concave. */}
+        <rect
+          x="0"
+          y="0"
+          width={FACE.w}
+          height={FACE.h}
+          fill="none"
+          stroke="rgba(0,0,0,0.6)"
+          strokeWidth={28}
+          opacity={0.5}
+          style={{ filter: 'blur(14px)' }}
+        />
+
+        {/* Thick anodised bezel arc — concentric chrome framing the dial.
+            Drawn along the outermost scale radius + a hair beyond so the dial
+            sits IN a machined ring. */}
+        <GaugeBezel
+          variant="arc"
+          defsId="amface-bezel"
+          d={arcPath(FACE.cx, FACE.cy, FACE.rOuter + 56, -FACE.sweep / 2 - 4, FACE.sweep / 2 + 4)}
+          thickness={10}
+        />
 
         {(['s', 'po', 'swr'] as const).map((id) => {
           const radius = radii[id];
@@ -340,8 +477,22 @@ export function AnalogMeterFace({
           );
         })}
 
-        <NeedleShadow angleDeg={angle} />
-        <Needle angleDeg={angle} peakAngleDeg={peakAngle} />
+        <NeedleShadow angleDeg={drawnAngle} />
+        <Needle angleDeg={drawnAngle} peakAngleDeg={peakAngle} needleGroupRef={needleGroupRef} />
+
+        {/* Domed glass cover drawn LAST so it reads as curved glass over the
+            whole instrument — an upper-left specular hot-spot plus a slow
+            drifting sheen band (compositor-only CSS, paused under reduced
+            motion). pointer-events:none so it never blocks interaction. */}
+        <g style={{ pointerEvents: 'none' }}>
+          <rect x="0" y="0" width={FACE.w} height={FACE.h * 0.62} fill="url(#analogMeterGlass)" />
+          <g
+            className="meter-sheen-drift"
+            style={{ ['--sheen-travel' as string]: `${FACE.w * 1.25}px` }}
+          >
+            <rect x={-FACE.w * 0.2} y="0" width={FACE.w * 0.16} height={FACE.h} fill="url(#analogMeterSheen)" />
+          </g>
+        </g>
       </svg>
     </div>
   );

--- a/zeus-web/src/components/immersive-meters/BigArc.tsx
+++ b/zeus-web/src/components/immersive-meters/BigArc.tsx
@@ -23,10 +23,15 @@
 // in viewBox units via SVG `transform="rotate(angle cx cy)"` — a CSS
 // transform-origin would mismatch once the SVG scales to the tile.
 
-import type { CSSProperties } from 'react';
+import { useRef, type CSSProperties } from 'react';
 import { dbToFrac, fmtDb, isSilent } from './dbScale';
 import { usePeakHoldFrac } from './usePeakHold';
 import { immersiveZoneTickColor, type ZoneTick } from '../meters/meterCatalog';
+import { BloomFilter, PeakPip, prefixDefs } from '../meters/render/svgChrome';
+import { GaugeBezel } from '../meters/render/GaugeBezel';
+import { GlassDome } from '../meters/render/GlassDome';
+import { lampCardStyle } from '../meters/render/lampCard';
+import { useGlidedFraction } from '../meters/render/useGlidedDraw';
 
 interface CommonProps {
   /** Section/label text — top-left chip. */
@@ -210,36 +215,68 @@ function resolveAxis(props: BigArcProps): ResolvedAxis {
   };
 }
 
+// Build the dash string for a given 0..1 fraction of the arc.
+function dashFor(frac: number): string {
+  const len = ARC_LEN * Math.max(0, Math.min(1, frac));
+  return `${len.toFixed(1)} ${(ARC_LEN + 5).toFixed(1)}`;
+}
+
 export function BigArc(props: BigArcProps) {
   const axis = resolveAxis(props);
   const peakFrac = usePeakHoldFrac(axis.rawValue, axis.toFrac);
 
-  const fillLen = ARC_LEN * axis.liveFrac;
-  const fillDash = `${fillLen.toFixed(1)} ${(ARC_LEN + 5).toFixed(1)}`;
-  const needleAngle = -90 + 180 * axis.liveFrac;
-  const peakPoint = pointAt(peakFrac, R);
+  // 60 Hz display-side glide for the live arc + needle. We glide liveFrac on
+  // the shared draw-bus and write the fill dash + needle rotation imperatively
+  // to element refs each frame, so the arc/needle move at up to 60 Hz between
+  // the ~30 Hz panel re-render cadence — without a setState in the hot path.
+  // Peak (peakFrac / peakPoint) is NEVER glided; it stays instant.
+  const fillCrispRef = useRef<SVGPathElement | null>(null);
+  const fillBloomRef = useRef<SVGPathElement | null>(null);
+  const needleRef = useRef<SVGGElement | null>(null);
+  const headRef = useRef<SVGCircleElement | null>(null);
+  const headGlowRef = useRef<SVGCircleElement | null>(null);
+  const glide = useGlidedFraction(axis.silent ? 0 : axis.liveFrac, {
+    onDraw: (drawn) => {
+      const dash = dashFor(drawn);
+      fillCrispRef.current?.setAttribute('stroke-dasharray', dash);
+      fillBloomRef.current?.setAttribute('stroke-dasharray', dash);
+      const ang = (-90 + 180 * Math.max(0, Math.min(1, drawn))).toFixed(2);
+      needleRef.current?.setAttribute('transform', `rotate(${ang} ${CX} ${CY})`);
+      // Glowing head pip rides the live arc tip.
+      const hp = pointAt(Math.max(0, Math.min(1, drawn)), R);
+      headRef.current?.setAttribute('cx', hp.x.toFixed(1));
+      headRef.current?.setAttribute('cy', hp.y.toFixed(1));
+      headGlowRef.current?.setAttribute('cx', hp.x.toFixed(1));
+      headGlowRef.current?.setAttribute('cy', hp.y.toFixed(1));
+    },
+  });
 
-  const fillGradId = `${props.defsId}-fill`;
-  const glowGradId = `${props.defsId}-glow`;
-  const blurFilterId = `${props.defsId}-blur`;
+  const drawn0 = axis.silent ? 0 : glide.read();
+  const fillDash = dashFor(drawn0);
+  const needleAngle = -90 + 180 * Math.max(0, Math.min(1, drawn0));
+  const headPoint0 = pointAt(Math.max(0, Math.min(1, drawn0)), R);
+  const peakPoint = pointAt(peakFrac, R);
+  const isSwr = props.mode === 'swr';
+
+  const fillGradId = prefixDefs(props.defsId, 'fill');
+  const glowGradId = prefixDefs(props.defsId, 'glow');
+  const blurFilterId = prefixDefs(props.defsId, 'blur');
+  const glassClipId = prefixDefs(props.defsId, 'glassclip');
   const units = props.units ?? axis.readoutUnit;
 
+  // Shared arc geometry path used by the track / bezel / channel strokes.
+  const arcPath = `M 28 ${CY} A ${R} ${R} 0 0 1 212 ${CY}`;
+
+  // Warm-cream "lamp glow" rising from the bottom of the gauge face —
+  // simulates an incandescent bulb illuminating the instrument from below.
+  // The illuminated-surface recipe (cream radials over a dark well + inset
+  // rim/vignette) now lives in the shared lampCard factory; this card just
+  // adds its own layout (aspect / position / overflow). The decorative
+  // bloom blob is painted via cardBloomStyle below the SVG.
   const cardStyle: CSSProperties = {
+    ...lampCardStyle('arc'),
     position: 'relative',
     aspectRatio: '1.55 / 1',
-    borderRadius: 7,
-    // Warm-cream "lamp glow" rising from the bottom of the gauge face —
-    // simulates an incandescent bulb illuminating the instrument from
-    // below. Layered: bottom-anchored cream radial → mid pale-yellow
-    // radial → dark linear panel base. The decorative bloom blob is
-    // painted via cardBloomStyle below the SVG.
-    background:
-      'radial-gradient(80% 95% at 50% 95%, var(--immersive-lamp-bloom-1), var(--immersive-lamp-bloom-2) 45%, transparent 72%),' +
-      ' radial-gradient(60% 60% at 50% 70%, var(--immersive-lamp-bloom-3), transparent 65%),' +
-      ' linear-gradient(180deg, var(--immersive-lamp-well-top) 0%, var(--immersive-lamp-well-bot) 100%)',
-    border: '1px solid var(--immersive-lamp-border)',
-    boxShadow:
-      'inset 0 1px 0 var(--immersive-lamp-rim), inset 0 -22px 40px rgba(255,240,180,0.05), inset 0 0 50px rgba(0,0,0,0.55)',
     overflow: 'hidden',
   };
   // Decorative bottom-blob bloom — sits behind the SVG and softens the
@@ -339,33 +376,65 @@ export function BigArc(props: BigArcProps) {
             <stop offset="0" stopColor="#ffffff" stopOpacity="0.10" />
             <stop offset="1" stopColor="#ffffff" stopOpacity="0" />
           </radialGradient>
-          <filter id={blurFilterId} x="-40%" y="-40%" width="180%" height="180%">
-            <feGaussianBlur stdDeviation="3" />
-          </filter>
+          <BloomFilter id={blurFilterId} />
+          {/* clip the glass dome to the dial bounding box so the specular
+              cover only sits over the instrument face, not the readout. */}
+          <clipPath id={glassClipId}>
+            <rect x={20} y={24} width={200} height={104} rx={10} />
+          </clipPath>
         </defs>
 
         {/* ambient ground glow — pale white over the warm-cream lamp wash */}
         <ellipse cx={CX} cy={135} rx={110} ry={40} fill={`url(#${glowGradId})`} />
 
-        {/* background arc — soft track. Rim + inset shadow are tokenised
-            so the light theme can flip both to a steel-grey inset on the
-            silver chassis (white@6% on silver disappears at idle). */}
+        {/* machined bezel ring framing the arc — the chrome edge that makes the
+            gauge sit IN the panel. Drawn first (widest) so the track + channel
+            nest inside it. */}
+        <GaugeBezel variant="arc" defsId={props.defsId} d={arcPath} thickness={16} />
+
+        {/* recessed track channel — a dark inset core stroked inside the bezel
+            so the arc reads as a machined groove, not a flat soft track. */}
         <path
-          d={`M 28 ${CY} A ${R} ${R} 0 0 1 212 ${CY}`}
+          d={arcPath}
           fill="none"
           stroke="var(--immersive-arc-track-rim)"
-          strokeWidth={14}
+          strokeWidth={11}
           strokeLinecap="round"
         />
         <path
-          d={`M 28 ${CY} A ${R} ${R} 0 0 1 212 ${CY}`}
+          d={arcPath}
+          fill="none"
+          stroke="var(--arc-channel-core)"
+          strokeWidth={9}
+          strokeLinecap="round"
+        />
+        <path
+          d={arcPath}
           fill="none"
           stroke="var(--immersive-arc-track-shadow)"
-          strokeWidth={10}
+          strokeWidth={7}
         />
 
-        {/* active fill — bloomed copy + crisp copy on top */}
+        {/* SWR danger-zone band — a low-alpha red arc painted UNDER the fill
+            from 2.0:1 → 3.0+ so a climbing SWR reads as entering an alarm
+            region even before the needle gets there. SWR mode only. */}
+        {isSwr && (
+          <path
+            d={arcPath}
+            fill="none"
+            stroke="var(--arc-danger-band)"
+            strokeWidth={9}
+            strokeLinecap="butt"
+            strokeDasharray={`${(ARC_LEN * 0.5).toFixed(1)} ${(ARC_LEN + 5).toFixed(1)}`}
+            strokeDashoffset={`-${(ARC_LEN * 0.5).toFixed(1)}`}
+          />
+        )}
+
+        {/* active fill — bloomed copy + crisp copy on top. Inlined (rather
+            than via the BloomFill kit) so the two paths can carry refs the
+            60 Hz glide writes stroke-dasharray to imperatively. */}
         <path
+          ref={fillBloomRef}
           d={`M 28 ${CY} A ${R} ${R} 0 0 1 212 ${CY}`}
           fill="none"
           stroke={`url(#${fillGradId})`}
@@ -376,6 +445,7 @@ export function BigArc(props: BigArcProps) {
           opacity={0.85}
         />
         <path
+          ref={fillCrispRef}
           d={`M 28 ${CY} A ${R} ${R} 0 0 1 212 ${CY}`}
           fill="none"
           stroke={`url(#${fillGradId})`}
@@ -383,6 +453,41 @@ export function BigArc(props: BigArcProps) {
           strokeLinecap="round"
           strokeDasharray={fillDash}
         />
+
+        {/* glowing leading-edge head pip — a bright lit bead riding the live
+            arc tip, hotter on SWR-over. Latches with the glide, not the peak. */}
+        {!axis.silent && (
+          <>
+            <circle
+              ref={headGlowRef}
+              cx={headPoint0.x.toFixed(1)}
+              cy={headPoint0.y.toFixed(1)}
+              r={6}
+              fill={axis.over ? 'var(--immersive-tx)' : 'var(--meter-fill-glow)'}
+              opacity={0.55}
+              style={{ filter: 'blur(2.5px)' }}
+            />
+            <circle
+              ref={headRef}
+              cx={headPoint0.x.toFixed(1)}
+              cy={headPoint0.y.toFixed(1)}
+              r={2.6}
+              fill="#fff"
+              opacity={0.95}
+              style={{
+                filter: `drop-shadow(0 0 4px ${axis.over ? 'var(--immersive-tx-glow)' : 'var(--meter-fill-glow)'})`,
+              }}
+            />
+          </>
+        )}
+
+        {/* specular glass cover over the dial face — wet-glass highlight +
+            drifting sheen, clipped to the dial bounding box. Sits over the
+            fill + ticks but below the needle/hub so the operator reads the
+            needle THROUGH the glass. */}
+        <g clipPath={`url(#${glassClipId})`}>
+          <GlassDome defsId={props.defsId} x={20} y={24} width={200} height={104} rx={10} sheenWidthFrac={0.14} />
+        </g>
 
         {/* zone-transition ticks — coloured perpendicular lines at the
             inner-rim band (R-12..R-6). Rendered before axis ticks so the
@@ -456,21 +561,13 @@ export function BigArc(props: BigArcProps) {
 
         {/* peak-hold pip on the rim — warm-cream pearl with cream halo */}
         {!axis.silent && peakFrac > 0 && (
-          <circle
-            cx={peakPoint.x.toFixed(1)}
-            cy={peakPoint.y.toFixed(1)}
-            r={3}
-            fill="#fff"
-            stroke="var(--immersive-lamp-pin)"
-            strokeWidth={1}
-            style={{ filter: 'drop-shadow(0 0 6px var(--immersive-lamp-pin))' }}
-          />
+          <PeakPip cx={peakPoint.x.toFixed(1)} cy={peakPoint.y.toFixed(1)} r={3} />
         )}
 
         {/* needle — warm-cream tapered ribbon over a pale-yellow centerline.
             Pivots around the hub centre (CX, CY) in viewBox units. */}
         {!axis.silent && (
-          <g transform={`rotate(${needleAngle.toFixed(2)} ${CX} ${CY})`}>
+          <g ref={needleRef} transform={`rotate(${needleAngle.toFixed(2)} ${CX} ${CY})`}>
             <line
               x1={CX}
               y1={CY}

--- a/zeus-web/src/components/immersive-meters/ImmersiveMetersPanel.tsx
+++ b/zeus-web/src/components/immersive-meters/ImmersiveMetersPanel.tsx
@@ -32,6 +32,7 @@ import { useTxStore } from '../../state/tx-store';
 import { useConnectionStore } from '../../state/connection-store';
 import { useRadioStore } from '../../state/radio-store';
 import { usePaStore } from '../../state/pa-store';
+import { subscribe } from '../meters/render/drawBus';
 
 /**
  * Track the per-keydown peak watts (PEP) and a 1-second exponential moving
@@ -72,22 +73,26 @@ function useFwdWattsStats(transmitting: boolean): { pep: number; avg: number } {
   return { pep: peakRef.current, avg: avgRef.current };
 }
 
-function useRafTick(targetHz: number = 30) {
+// Re-render tick that keeps the wall-clock peak-hold decay (usePeakHoldFrac,
+// recomputed on render) advancing between the 10 Hz wire frames. Now driven
+// by the SHARED draw-bus instead of a dedicated rAF — one module-level rAF for
+// the whole meter cluster — throttled to ~30 Hz so the panel reconcile stays
+// off the system frame rate while each widget's live fill/needle glides at up
+// to 60 Hz via useGlidedFraction's imperative writes (no setState in the hot
+// path). `hostRef` opts this subscriber into the bus's off-screen gate.
+function useBusTick(hostRef: React.RefObject<Element | null>, throttleMs = 33) {
   const [, setTick] = useState(0);
   useEffect(() => {
-    let raf = 0;
-    let last = 0;
-    const minMs = 1000 / targetHz;
-    const loop = (ts: number) => {
-      if (ts - last >= minMs) {
-        last = ts;
+    let acc = 0;
+    const step = (dt: number) => {
+      acc += dt * 1000;
+      if (acc >= throttleMs) {
+        acc = 0;
         setTick((n) => (n + 1) & 0xff);
       }
-      raf = requestAnimationFrame(loop);
     };
-    raf = requestAnimationFrame(loop);
-    return () => cancelAnimationFrame(raf);
-  }, [targetHz]);
+    return subscribe(step, hostRef.current ?? null);
+  }, [hostRef, throttleMs]);
 }
 
 interface SectionProps {
@@ -263,9 +268,11 @@ function StatusFooter({ pepWatts, ratedWatts }: { pepWatts: number; ratedWatts: 
 
 /* ─── Main panel ───────────────────────────────────────────────────── */
 export function ImmersiveMetersPanel() {
-  // ~30 Hz tick to drive peak-hold decay smoothly between the 10 Hz wire
-  // frames. Same recipe the legacy TxStageMeters used.
-  useRafTick(30);
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+  // ~30 Hz re-render tick (shared draw-bus) to advance peak-hold decay
+  // between the 10 Hz wire frames; the live fills/needles inside each widget
+  // glide at up to 60 Hz on the same bus via useGlidedFraction.
+  useBusTick(bodyRef, 33);
 
   const micPk = useTxStore((s) => s.wdspMicPk);
   const micAv = useTxStore((s) => s.micAv);
@@ -317,10 +324,30 @@ export function ImmersiveMetersPanel() {
     gridTemplateColumns: '1fr 1fr',
     gap: 10,
   };
+  // Three stage groups (MIC / LEV / ALC) side by side, each holding its own
+  // PK + AVG pair under a shared brass-plate header. Grouping (instead of a
+  // flat 6-up grid) is what de-busies the row — the eye reads three labelled
+  // instruments showing peak + average, not six identical strips.
   const vuClusterStyle: CSSProperties = {
     display: 'grid',
-    gridTemplateColumns: 'repeat(6, minmax(0, 1fr))',
-    gap: 6,
+    gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+    gap: 10,
+  };
+  const vuStageStyle: CSSProperties = {
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    gap: 4,
+  };
+  const vuStageHeaderStyle: CSSProperties = {
+    fontSize: 9,
+    letterSpacing: '0.18em',
+    textTransform: 'uppercase',
+    color: 'var(--immersive-lamp-label)',
+    fontWeight: 700,
+    textAlign: 'center',
+    marginBottom: 4,
+    paddingBottom: 3,
+    borderBottom: '1px solid var(--immersive-line)',
   };
   const grRowStyle: CSSProperties = {
     display: 'grid',
@@ -329,7 +356,7 @@ export function ImmersiveMetersPanel() {
   };
 
   return (
-    <div style={bodyStyle} aria-label="Immersive TX meters — final output, signal chain, gain reduction">
+    <div ref={bodyRef} style={bodyStyle} aria-label="Immersive TX meters — final output, signal chain, gain reduction">
       <Section
         title="Final Output"
         led="on"
@@ -359,12 +386,27 @@ export function ImmersiveMetersPanel() {
         meta={['PK / AVG', 'HOLD 1.2s', '−60 → +6 dBFS']}
       >
         <div style={vuClusterStyle}>
-          <VuColumn valueDb={micPk} name="MIC" sub="PK" defsId="immersive-vu-micpk" />
-          <VuColumn valueDb={micAv} name="MIC" sub="AVG" defsId="immersive-vu-micav" />
-          <VuColumn valueDb={lvlrPk} name="LEV" sub="PK" defsId="immersive-vu-lvlrpk" />
-          <VuColumn valueDb={lvlrAv} name="LEV" sub="AVG" defsId="immersive-vu-lvlrav" />
-          <VuColumn valueDb={alcPk} name="ALC" sub="PK" defsId="immersive-vu-alcpk" />
-          <VuColumn valueDb={alcAv} name="ALC" sub="AVG" defsId="immersive-vu-alcav" />
+          <div>
+            <div style={vuStageHeaderStyle}>Mic</div>
+            <div style={vuStageStyle}>
+              <VuColumn valueDb={micPk} name="" sub="PK" variant="pk" hostRef={bodyRef} defsId="immersive-vu-micpk" />
+              <VuColumn valueDb={micAv} name="" sub="AVG" variant="avg" hostRef={bodyRef} defsId="immersive-vu-micav" />
+            </div>
+          </div>
+          <div>
+            <div style={vuStageHeaderStyle}>Leveler</div>
+            <div style={vuStageStyle}>
+              <VuColumn valueDb={lvlrPk} name="" sub="PK" variant="pk" hostRef={bodyRef} defsId="immersive-vu-lvlrpk" />
+              <VuColumn valueDb={lvlrAv} name="" sub="AVG" variant="avg" hostRef={bodyRef} defsId="immersive-vu-lvlrav" />
+            </div>
+          </div>
+          <div>
+            <div style={vuStageHeaderStyle}>ALC</div>
+            <div style={vuStageStyle}>
+              <VuColumn valueDb={alcPk} name="" sub="PK" variant="pk" hostRef={bodyRef} defsId="immersive-vu-alcpk" />
+              <VuColumn valueDb={alcAv} name="" sub="AVG" variant="avg" hostRef={bodyRef} defsId="immersive-vu-alcav" />
+            </div>
+          </div>
         </div>
       </Section>
 

--- a/zeus-web/src/components/immersive-meters/PullDownArc.tsx
+++ b/zeus-web/src/components/immersive-meters/PullDownArc.tsx
@@ -16,6 +16,8 @@
 
 import type { CSSProperties } from 'react';
 import { immersiveZoneTickColor, type ZoneTick } from '../meters/meterCatalog';
+import { BloomFill, BloomFilter, PeakPip, prefixDefs } from '../meters/render/svgChrome';
+import { lampCardBackground } from '../meters/render/lampCard';
 
 // Arc geometry — kept at the design's R=118 so the gauge feels big and
 // dramatic, with the viewBox extended above y=0 to fit the entire half-
@@ -106,8 +108,8 @@ export function PullDownArc({
   const compressing = gainReductionDb > 10;
   const stateLabel = compressing ? 'Compressing' : active ? 'Active' : 'Idle';
 
-  const fillGradId = `${defsId}-fill`;
-  const blurFilterId = `${defsId}-blur`;
+  const fillGradId = prefixDefs(defsId, 'fill');
+  const blurFilterId = prefixDefs(defsId, 'blur');
 
   const cardStyle: CSSProperties = {
     position: 'relative',
@@ -121,14 +123,11 @@ export function PullDownArc({
     // aspect = 280/216 ≈ 1.30/1.
     aspectRatio: '280 / 216',
     borderRadius: 7,
-    // Warm-cream lamp glow matching BigArc / VuColumn — the GR cards
-    // sit alongside the hero arcs, so they share the same lit-instrument
-    // base. The pre-existing amber bias (0.07) was a leftover from when
-    // GR was the only warm-tinted card; the lamp wash now does that job.
-    background:
-      'radial-gradient(80% 95% at 50% 100%, var(--immersive-lamp-bloom-1), var(--immersive-lamp-bloom-2) 50%, transparent 75%),' +
-      ' radial-gradient(60% 60% at 50% 70%, var(--immersive-lamp-bloom-3), transparent 65%),' +
-      ' linear-gradient(180deg, var(--immersive-lamp-well-top) 0%, var(--immersive-lamp-well-bot) 100%)',
+    // Warm-cream lamp glow matching BigArc / VuColumn — the GR cards sit
+    // alongside the hero arcs, so they share the shared lampCard cream wash
+    // ('column' geometry: bottom-anchored bloom). The GR card keeps its own
+    // slightly shallower inset vignette (40px vs the arc's 50px).
+    background: lampCardBackground('column'),
     border: '1px solid var(--immersive-lamp-border)',
     boxShadow:
       'inset 0 1px 0 var(--immersive-lamp-rim), inset 0 -22px 40px rgba(255,240,180,0.05), inset 0 0 40px rgba(0,0,0,0.45)',
@@ -266,9 +265,7 @@ export function PullDownArc({
             <stop offset="0.6" stopColor="#f0a040" />
             <stop offset="1" stopColor="var(--immersive-tx)" />
           </linearGradient>
-          <filter id={blurFilterId} x="-40%" y="-40%" width="180%" height="180%">
-            <feGaussianBlur stdDeviation="2.5" />
-          </filter>
+          <BloomFilter id={blurFilterId} stdDeviation={2.5} />
         </defs>
 
         {/* background arc — top half. Endpoints derived from the radius
@@ -361,24 +358,19 @@ export function PullDownArc({
         </g>
 
         {/* fill — anchored at right (ARC_X_RIGHT, CY), drawn LEFTWARD via
-            reverse sweep flag. */}
-        <path
-          d={`M ${ARC_X_RIGHT} ${CY} A ${R} ${R} 0 0 0 ${ARC_X_LEFT} ${CY}`}
-          fill="none"
-          stroke={`url(#${fillGradId})`}
-          strokeWidth={9}
-          strokeLinecap="round"
-          strokeDasharray={fillDash}
-          filter={`url(#${blurFilterId})`}
-          opacity={0.9}
-        />
-        <path
-          d={`M ${ARC_X_RIGHT} ${CY} A ${R} ${R} 0 0 0 ${ARC_X_LEFT} ${CY}`}
-          fill="none"
-          stroke={`url(#${fillGradId})`}
+            reverse sweep flag. Bloom-behind-crisp via shared kit. */}
+        <BloomFill
+          shape={{
+            kind: 'path',
+            d: `M ${ARC_X_RIGHT} ${CY} A ${R} ${R} 0 0 0 ${ARC_X_LEFT} ${CY}`,
+          }}
+          fill={`url(#${fillGradId})`}
+          filterId={blurFilterId}
           strokeWidth={5.5}
+          bloomStrokeWidth={9}
           strokeLinecap="round"
           strokeDasharray={fillDash}
+          bloomOpacity={0.9}
         />
 
         {/* 0 dB anchor pin (right end of arc) — dark cap with cream rim */}
@@ -389,12 +381,13 @@ export function PullDownArc({
             (warn-glow remains intact so "compression is happening" still
             reads as the legacy amber cue). */}
         {grFrac > 0.001 && (
-          <circle
+          <PeakPip
             cx={headX.toFixed(1)}
             cy={headY.toFixed(1)}
             r={4.5}
             fill="var(--immersive-lamp-needle-bri)"
-            style={{ filter: 'drop-shadow(0 0 6px var(--immersive-warn))' }}
+            stroke="var(--immersive-lamp-needle-bri)"
+            glow="var(--immersive-warn)"
           />
         )}
       </svg>

--- a/zeus-web/src/components/immersive-meters/VuColumn.tsx
+++ b/zeus-web/src/components/immersive-meters/VuColumn.tsx
@@ -3,16 +3,29 @@
 // Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
 // Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
 //
-// Vertical VU column — LED-style segmented bar with a bloom layer behind a
-// crisp fill, ticks on both sides at 0/-3/-6/-10/-20/-40/-60 dB, dashed red
-// 0 dBFS reference, peak-hold tick. Lift-and-shift of the design
-// prototype's `.vu` SVG (Immersive Meters.html). Used for the six
-// signal-chain readings (MIC PK/AV, LVLR PK/AV, ALC PK/AV).
+// Vertical VU column — the full five-layer premium instrument stack (the same
+// recipe the loved S-meter uses), scaled UP for the small/dense TX-stage rows:
+//   (1) recessed machined well behind the track,
+//   (2) volumetric bloom-behind-crisp fill under a vertical cylinder gradient,
+//   (3) a bright glowing leading-edge sliver at the live fill tip,
+//   (4) a specular GlassDome (wet-glass + drifting sheen),
+//   (5) a machined GaugeBezel chrome ring framing each column.
+// The live fill height glides at up to 60 Hz on the shared draw-bus
+// (useGlidedFraction); the peak-hold tick latches INSTANTLY and is never
+// glided. Used for the six signal-chain readings (MIC PK/AVG, LEV PK/AVG,
+// ALC PK/AVG). Position math (dbToFrac) and the peak-hold hook are byte-
+// identical to the prior implementation — only HOW the value is drawn changed.
 
-import type { CSSProperties } from 'react';
+import { useRef, type CSSProperties } from 'react';
 import { dbToFrac, fmtDb, isSilent } from './dbScale';
 import { usePeakHoldFrac } from './usePeakHold';
 import { immersiveZoneTickColor, type ZoneTick } from '../meters/meterCatalog';
+import { BloomFilter, PeakTick, prefixDefs } from '../meters/render/svgChrome';
+import { GaugeBezel } from '../meters/render/GaugeBezel';
+import { GlassDome } from '../meters/render/GlassDome';
+import { recessedWell } from '../meters/render/recessedWell';
+import { useGlidedFraction } from '../meters/render/useGlidedDraw';
+import { lampCardStyle } from '../meters/render/lampCard';
 
 interface VuColumnProps {
   /** Live value in dBFS. */
@@ -23,6 +36,11 @@ interface VuColumnProps {
   sub: string;
   /** Stable id prefix for SVG `<defs>` — required to avoid collisions. */
   defsId: string;
+  /** Average partner of a PK column — drawn slightly dimmer/desaturated so the
+   *  eye reads peak-vs-average across a stage pair instead of six clones. */
+  variant?: 'pk' | 'avg';
+  /** Host element ref for the draw-bus off-screen gate (the panel body). */
+  hostRef?: React.RefObject<Element | null>;
   /** Optional green/amber/red tick marks at zone-level boundaries.
    *  Rendered as short horizontal lines on the right-hand side of the
    *  column (x=48..54). `frac` is the linear position 0..1 along the
@@ -38,40 +56,77 @@ const BOT_Y = 148;
 const COL_HEIGHT = BOT_Y - TOP_Y;
 const COL_X = 22;
 const COL_W = 16;
+const EDGE_H = 3; // bright leading-edge sliver height (viewBox units)
 const SIDE_TICKS = [0, -3, -6, -10, -20, -40, -60] as const;
 const SEG_COUNT = 17;
 
-export function VuColumn({ valueDb, name, sub, defsId, zoneTicks }: VuColumnProps) {
+export function VuColumn({ valueDb, name, sub, defsId, variant = 'pk', hostRef, zoneTicks }: VuColumnProps) {
   const silent = isSilent(valueDb);
   const liveFrac = silent ? 0 : dbToFrac(valueDb);
   const peakFrac = usePeakHoldFrac(valueDb, dbToFrac);
 
-  const fillH = COL_HEIGHT * liveFrac;
-  const fillY = BOT_Y - fillH;
   const peakY = BOT_Y - COL_HEIGHT * peakFrac;
   const zeroY = BOT_Y - COL_HEIGHT * dbToFrac(0);
 
-  const fillGradId = `${defsId}-fill`;
-  const bloomGradId = `${defsId}-bloom`;
-  const blurFilterId = `${defsId}-blur`;
-  const maskId = `${defsId}-mask`;
+  const isAvg = variant === 'avg';
+
+  // 60 Hz liquid glide for the live fill height. We glide `liveFrac` on the
+  // shared draw-bus and write the fill rect's y/height + the leading-edge
+  // sliver position imperatively each frame — NO setState in the hot path.
+  // The peak tick (peakFrac) is NEVER glided; it stays instant.
+  const fillCrispRef = useRef<SVGRectElement | null>(null);
+  const fillBloomRef = useRef<SVGRectElement | null>(null);
+  const fillVolRef = useRef<SVGRectElement | null>(null);
+  const edgeRef = useRef<SVGRectElement | null>(null);
+  const edgeGlowRef = useRef<SVGRectElement | null>(null);
+
+  const writeFill = (drawn: number) => {
+    const f = Math.max(0, Math.min(1, drawn));
+    const h = COL_HEIGHT * f;
+    const y = BOT_Y - h;
+    const hs = h.toFixed(1);
+    const ys = y.toFixed(1);
+    fillCrispRef.current?.setAttribute('y', ys);
+    fillCrispRef.current?.setAttribute('height', hs);
+    fillBloomRef.current?.setAttribute('y', ys);
+    fillBloomRef.current?.setAttribute('height', hs);
+    fillVolRef.current?.setAttribute('y', ys);
+    fillVolRef.current?.setAttribute('height', hs);
+    // Leading-edge sliver rides the fill top; hide it when the bar is empty.
+    const edgeY = Math.max(TOP_Y, y - EDGE_H * 0.5);
+    const visible = f > 0.001;
+    edgeRef.current?.setAttribute('y', edgeY.toFixed(1));
+    edgeRef.current?.setAttribute('opacity', visible ? '0.95' : '0');
+    edgeGlowRef.current?.setAttribute('y', edgeY.toFixed(1));
+    edgeGlowRef.current?.setAttribute('opacity', visible ? '0.9' : '0');
+  };
+
+  const glide = useGlidedFraction(liveFrac, { hostRef, onDraw: writeFill });
+  // Initial (pre-first-frame) geometry from the current drawn value so SSR /
+  // first paint is correct without waiting for the bus.
+  const drawn0 = Math.max(0, Math.min(1, glide.read()));
+  const fillH0 = COL_HEIGHT * drawn0;
+  const fillY0 = BOT_Y - fillH0;
+  const edgeY0 = Math.max(TOP_Y, fillY0 - EDGE_H * 0.5);
+  const edgeVisible0 = drawn0 > 0.001;
+
+  const fillGradId = prefixDefs(defsId, 'fill');
+  const bloomGradId = prefixDefs(defsId, 'bloom');
+  const volGradId = prefixDefs(defsId, 'vol');
+  const blurFilterId = prefixDefs(defsId, 'blur');
+  const maskId = prefixDefs(defsId, 'mask');
 
   const isOver = !silent && valueDb > 0;
 
+  // Recessed machined pocket behind the track — same warm-halo well the
+  // S-meter uses, applied as the SVG track backdrop via a foreignObject-free
+  // approach: we paint the concave floor + inset via a CSS box on the card,
+  // but for the SVG track itself we draw a dark recessed rect + inset edges.
+  // The card keeps the warm lamp wash so the cluster reads as one instrument.
   const cardStyle: CSSProperties = {
+    ...lampCardStyle('column'),
     position: 'relative',
-    // Same warm-cream lamp glow recipe as BigArc — three radial layers
-    // over a dark linear base, so the VU columns and the hero arcs read
-    // as a single illuminated instrument cluster.
-    background:
-      'radial-gradient(80% 95% at 50% 100%, var(--immersive-lamp-bloom-1), var(--immersive-lamp-bloom-2) 50%, transparent 75%),' +
-      ' radial-gradient(60% 60% at 50% 70%, var(--immersive-lamp-bloom-3), transparent 65%),' +
-      ' linear-gradient(180deg, var(--immersive-lamp-well-top) 0%, var(--immersive-lamp-well-bot) 100%)',
-    border: '1px solid var(--immersive-lamp-border)',
-    borderRadius: 7,
     padding: '10px 4px 10px',
-    boxShadow:
-      'inset 0 1px 0 var(--immersive-lamp-rim), inset 0 -18px 32px rgba(255,240,180,0.04), inset 0 0 22px rgba(0,0,0,0.40)',
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
@@ -89,8 +144,8 @@ export function VuColumn({ valueDb, name, sub, defsId, zoneTicks }: VuColumnProp
     fontSize: 8.5,
     letterSpacing: '0.14em',
     textTransform: 'uppercase',
-    color: 'var(--immersive-lamp-label)',
-    fontWeight: 600,
+    color: isAvg ? 'var(--immersive-lamp-corner)' : 'var(--immersive-lamp-label)',
+    fontWeight: isAvg ? 500 : 700,
   };
   const numStyle: CSSProperties = {
     fontFamily: 'var(--font-mono)',
@@ -110,159 +165,266 @@ export function VuColumn({ valueDb, name, sub, defsId, zoneTicks }: VuColumnProp
     marginLeft: 2,
   };
 
+  // The well CSS box sits behind the SVG, giving the column real concave
+  // machined depth (inset shadow stack + warm halo) instead of a flat rect.
+  // It is positioned to overlap exactly the SVG track region (COL_X..COL_X+W,
+  // TOP_Y..BOT_Y) within the 60×160 viewBox stretched to the SVG element box.
+  const wellBoxStyle: CSSProperties = {
+    ...recessedWell({ radius: 2, warmHalo: true, glow: true }),
+    position: 'absolute',
+    // map viewBox units → % of the 60-wide / 160-tall SVG box
+    left: `${(COL_X / 60) * 100}%`,
+    width: `${(COL_W / 60) * 100}%`,
+    top: `${(TOP_Y / 160) * 100}%`,
+    height: `${(COL_HEIGHT / 160) * 100}%`,
+    pointerEvents: 'none',
+  };
+
+  // Average columns read slightly softer so the eye groups each stage's
+  // PK (bright) + AVG (dim) pair into one peak-vs-average instrument.
+  const fillOpacity = isAvg ? 0.82 : 1;
+  const bloomOpacity = isAvg ? 0.55 : 0.85;
+
   return (
     <div style={cardStyle} aria-hidden="true">
-      <div style={nameStyle}>{name}</div>
+      {name ? <div style={nameStyle}>{name}</div> : null}
       <div style={subStyle}>{sub}</div>
-      <svg viewBox="0 0 60 160" preserveAspectRatio="none" style={{ width: '100%', height: 160, display: 'block' }}>
-        <defs>
-          <linearGradient id={fillGradId} x1="0" y1="148" x2="0" y2="12" gradientUnits="userSpaceOnUse">
-            <stop offset="0" stopColor="var(--immersive-good)" />
-            <stop offset="0.45" stopColor="var(--immersive-good)" />
-            <stop offset="0.62" stopColor="#7cd1a8" />
-            <stop offset="0.74" stopColor="var(--immersive-warn)" />
-            <stop offset="0.88" stopColor="var(--immersive-tx)" />
-            <stop offset="1" stopColor="var(--immersive-tx)" />
-          </linearGradient>
-          <linearGradient id={bloomGradId} x1="0" y1="148" x2="0" y2="12" gradientUnits="userSpaceOnUse">
-            <stop offset="0" stopColor="var(--immersive-good)" stopOpacity="0.5" />
-            <stop offset="0.74" stopColor="var(--immersive-warn)" stopOpacity="0.5" />
-            <stop offset="1" stopColor="var(--immersive-tx)" stopOpacity="0.5" />
-          </linearGradient>
-          <filter id={blurFilterId} x="-50%" y="-10%" width="200%" height="120%">
-            <feGaussianBlur stdDeviation="3" />
-          </filter>
-          <mask id={maskId}>
-            <rect x={COL_X} y={TOP_Y} width={COL_W} height={COL_HEIGHT} fill="white" />
-          </mask>
-        </defs>
-
-        {/* side ticks + numeric labels — warm-cream lamp tone, with the
-            0 dBFS ticks staying in tx-red as the "rail" cue. */}
-        <g
-          strokeWidth={0.6}
-          fontFamily="var(--font-mono)"
-          fontSize={6}
-          textAnchor="end"
+      <div style={{ position: 'relative', width: '100%', height: 160 }}>
+        {/* recessed machined well behind the SVG track */}
+        <div style={wellBoxStyle} />
+        <svg
+          viewBox="0 0 60 160"
+          preserveAspectRatio="none"
+          style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', display: 'block' }}
         >
-          {SIDE_TICKS.map((db) => {
-            const f = dbToFrac(db);
-            const y = BOT_Y - COL_HEIGHT * f;
-            const zero = db === 0;
-            const tickStroke = zero ? 'var(--immersive-tx)' : 'var(--immersive-lamp-tick)';
-            const tickWidth = zero ? 1 : 0.6;
-            return (
-              <g key={`vt-${db}`}>
-                <line x1={14} y1={y} x2={COL_X} y2={y} stroke={tickStroke} strokeWidth={tickWidth} />
-                <line x1={COL_X + COL_W} y1={y} x2={COL_X + COL_W + 8} y2={y} stroke={tickStroke} strokeWidth={tickWidth} />
-                <text x={13} y={y + 2} fill={zero ? 'var(--immersive-tx)' : 'var(--immersive-lamp-label)'}>
-                  {zero ? '0' : Math.abs(db)}
-                </text>
-              </g>
-            );
-          })}
-        </g>
+          <defs>
+            <linearGradient id={fillGradId} x1="0" y1="148" x2="0" y2="12" gradientUnits="userSpaceOnUse">
+              <stop offset="0" stopColor="var(--immersive-good)" />
+              <stop offset="0.45" stopColor="var(--immersive-good)" />
+              <stop offset="0.62" stopColor="#7cd1a8" />
+              <stop offset="0.74" stopColor="var(--immersive-warn)" />
+              <stop offset="0.88" stopColor="var(--immersive-tx)" />
+              <stop offset="1" stopColor="var(--immersive-tx)" />
+            </linearGradient>
+            <linearGradient id={bloomGradId} x1="0" y1="148" x2="0" y2="12" gradientUnits="userSpaceOnUse">
+              <stop offset="0" stopColor="var(--immersive-good)" stopOpacity="0.55" />
+              <stop offset="0.74" stopColor="var(--immersive-warn)" stopOpacity="0.55" />
+              <stop offset="1" stopColor="var(--immersive-tx)" stopOpacity="0.55" />
+            </linearGradient>
+            {/* horizontal cylinder shading across the column width + a soft
+                white-screen lift at the floor so a quiet bar still glows. */}
+            <linearGradient id={volGradId} x1={COL_X} y1="0" x2={COL_X + COL_W} y2="0" gradientUnits="userSpaceOnUse">
+              <stop offset="0" stopColor="var(--meter-fill-base)" />
+              <stop offset="0.32" stopColor="var(--vu-floor-lift)" />
+              <stop offset="0.5" stopColor="var(--meter-fill-hot)" />
+              <stop offset="0.68" stopColor="var(--vu-floor-lift)" />
+              <stop offset="1" stopColor="var(--meter-fill-base)" />
+            </linearGradient>
+            {/* taller vertical bloom region so the halo actually shows on the
+                thin column (was 120% → now 160% with extra side bleed). */}
+            <BloomFilter id={blurFilterId} region={['-60%', '-20%', '220%', '160%']} />
+            <mask id={maskId}>
+              <rect x={COL_X} y={TOP_Y} width={COL_W} height={COL_HEIGHT} fill="white" />
+            </mask>
+          </defs>
 
-        {/* track background */}
-        <rect
-          x={COL_X}
-          y={TOP_Y}
-          width={COL_W}
-          height={COL_HEIGHT}
-          rx={2}
-          fill="var(--immersive-vu-track)"
-          stroke="var(--immersive-rim)"
-          strokeWidth={0.6}
-        />
-        {/* inset top shadow */}
-        <rect x={COL_X + 0.5} y={TOP_Y + 0.5} width={COL_W - 1} height={2} fill="rgba(0,0,0,0.6)" />
+          {/* side ticks + numeric labels — warm-cream lamp tone, with the
+              0 dBFS ticks staying in tx-red as the "rail" cue. */}
+          <g
+            strokeWidth={0.6}
+            fontFamily="var(--font-mono)"
+            fontSize={6}
+            textAnchor="end"
+            vectorEffect="non-scaling-stroke"
+          >
+            {SIDE_TICKS.map((db) => {
+              const f = dbToFrac(db);
+              const y = BOT_Y - COL_HEIGHT * f;
+              const zero = db === 0;
+              const tickStroke = zero ? 'var(--immersive-tx)' : 'var(--immersive-lamp-tick)';
+              const tickWidth = zero ? 1 : 0.6;
+              return (
+                <g key={`vt-${db}`}>
+                  <line x1={14} y1={y} x2={COL_X} y2={y} stroke={tickStroke} strokeWidth={tickWidth} vectorEffect="non-scaling-stroke" />
+                  <line x1={COL_X + COL_W} y1={y} x2={COL_X + COL_W + 8} y2={y} stroke={tickStroke} strokeWidth={tickWidth} vectorEffect="non-scaling-stroke" />
+                  <text x={13} y={y + 2} fill={zero ? 'var(--immersive-tx)' : 'var(--immersive-lamp-label)'}>
+                    {zero ? '0' : Math.abs(db)}
+                  </text>
+                </g>
+              );
+            })}
+          </g>
 
-        {/* bloom (blurred) layer behind crisp fill */}
-        <rect
-          x={COL_X}
-          y={fillY.toFixed(1)}
-          width={COL_W}
-          height={fillH.toFixed(1)}
-          fill={`url(#${bloomGradId})`}
-          filter={`url(#${blurFilterId})`}
-          opacity={0.85}
-        />
-        {/* crisp fill */}
-        <rect
-          x={COL_X}
-          y={fillY.toFixed(1)}
-          width={COL_W}
-          height={fillH.toFixed(1)}
-          fill={`url(#${fillGradId})`}
-        />
-
-        {/* LED segment lines */}
-        <g mask={`url(#${maskId})`}>
-          {Array.from({ length: SEG_COUNT }).map((_, i) => {
-            const segY = TOP_Y + ((i + 1) * COL_HEIGHT) / 18;
-            return (
-              <line
-                key={`seg-${i}`}
-                x1={COL_X}
-                y1={segY.toFixed(1)}
-                x2={COL_X + COL_W}
-                y2={segY.toFixed(1)}
-                stroke="var(--immersive-bg)"
-                strokeWidth={1.2}
-              />
-            );
-          })}
-        </g>
-
-        {/* peak-hold tick — warm-cream pearl matching the BigArc peak pip */}
-        {!silent && peakFrac > 0 && (
-          <line
-            x1={20}
-            y1={peakY.toFixed(1)}
-            x2={40}
-            y2={peakY.toFixed(1)}
-            stroke="var(--immersive-lamp-needle-bri)"
-            strokeWidth={1.4}
-            opacity={0.92}
-            style={{ filter: 'drop-shadow(0 0 4px var(--immersive-lamp-pin))' }}
+          {/* translucent inner stage over the recessed well — darkens the
+              pocket for the fill to glow against while letting the CSS well's
+              concave floor + machined inset edges read through. */}
+          <rect
+            x={COL_X}
+            y={TOP_Y}
+            width={COL_W}
+            height={COL_HEIGHT}
+            rx={2}
+            fill="var(--immersive-vu-track)"
+            fillOpacity={0.55}
           />
-        )}
 
-        {/* dashed 0 dBFS reference */}
-        <line
-          x1={20}
-          y1={zeroY.toFixed(1)}
-          x2={40}
-          y2={zeroY.toFixed(1)}
-          stroke="var(--immersive-tx)"
-          strokeWidth={0.8}
-          strokeDasharray="2 2"
-          opacity={0.55}
-        />
+          {/* fill stack (bloom-behind-crisp + cylinder volume), masked to the
+              column so the bloom halo doesn't bleed past the well. */}
+          <g mask={`url(#${maskId})`}>
+            <rect
+              ref={fillBloomRef}
+              x={COL_X}
+              y={fillY0.toFixed(1)}
+              width={COL_W}
+              height={fillH0.toFixed(1)}
+              fill={`url(#${bloomGradId})`}
+              filter={`url(#${blurFilterId})`}
+              opacity={bloomOpacity}
+            />
+            <rect
+              ref={fillCrispRef}
+              x={COL_X}
+              y={fillY0.toFixed(1)}
+              width={COL_W}
+              height={fillH0.toFixed(1)}
+              fill={`url(#${fillGradId})`}
+              opacity={fillOpacity}
+            />
+            <rect
+              ref={fillVolRef}
+              x={COL_X}
+              y={fillY0.toFixed(1)}
+              width={COL_W}
+              height={fillH0.toFixed(1)}
+              fill={`url(#${volGradId})`}
+            />
+          </g>
 
-        {/* zone-transition ticks — short coloured horizontal lines on the
-            right of the column, away from the side-tick numeric labels.
-            Always visible at idle so the operator sees the sweet-spot
-            window even with no signal. */}
-        {zoneTicks && zoneTicks.length > 0 && (
-          <g strokeLinecap="round">
-            {zoneTicks.map((zt, i) => {
-              const y = BOT_Y - COL_HEIGHT * zt.frac;
+          {/* bright glowing leading-edge sliver at the live fill TOP — the tip
+              glows as the bar rises (mirrors the S-meter's leading edge). A
+              soft wide glow under a crisp bright cap. */}
+          <g mask={`url(#${maskId})`}>
+            <rect
+              ref={edgeGlowRef}
+              x={COL_X}
+              y={edgeY0.toFixed(1)}
+              width={COL_W}
+              height={EDGE_H * 2}
+              fill={isOver ? 'var(--vu-edge-hot)' : 'var(--meter-fill-glow)'}
+              opacity={edgeVisible0 ? 0.9 : 0}
+              style={{ filter: 'blur(2px)' }}
+            />
+            <rect
+              ref={edgeRef}
+              x={COL_X}
+              y={edgeY0.toFixed(1)}
+              width={COL_W}
+              height={EDGE_H}
+              fill={isOver ? 'var(--vu-edge-hot)' : 'var(--vu-edge-warn)'}
+              opacity={edgeVisible0 ? 0.95 : 0}
+              style={{ filter: `drop-shadow(0 0 3px ${isOver ? 'var(--vu-edge-hot)' : 'var(--meter-fill-glow)'})` }}
+            />
+          </g>
+
+          {/* LED segment lines — thin dark gaps to read as a stacked ladder. */}
+          <g mask={`url(#${maskId})`}>
+            {Array.from({ length: SEG_COUNT }).map((_, i) => {
+              const segY = TOP_Y + ((i + 1) * COL_HEIGHT) / 18;
               return (
                 <line
-                  key={`zt-${i}`}
-                  x1={48}
-                  y1={y.toFixed(1)}
-                  x2={54}
-                  y2={y.toFixed(1)}
-                  stroke={immersiveZoneTickColor(zt.level)}
-                  strokeWidth={1.6}
+                  key={`seg-${i}`}
+                  x1={COL_X}
+                  y1={segY.toFixed(1)}
+                  x2={COL_X + COL_W}
+                  y2={segY.toFixed(1)}
+                  stroke="var(--immersive-bg)"
+                  strokeWidth={1.2}
                 />
               );
             })}
           </g>
-        )}
-      </svg>
+
+          {/* specular glass dome + drifting sheen — brighter *-sm tokens so the
+              wet-glass tell survives at the thin column size. */}
+          <GlassDome
+            defsId={defsId}
+            x={COL_X}
+            y={TOP_Y}
+            width={COL_W}
+            height={COL_HEIGHT}
+            rx={2}
+            domeColor="var(--meter-glass-dome-sm)"
+            sheenColor="var(--meter-sheen-sm)"
+          />
+
+          {/* peak-hold tick — instant white double-bloom tick that pops like
+              the S-meter's, latched directly from the raw peak (never glided). */}
+          {!silent && peakFrac > 0 && (
+            <PeakTick
+              x1={COL_X - 1}
+              y1={peakY.toFixed(1)}
+              x2={COL_X + COL_W + 1}
+              y2={peakY.toFixed(1)}
+              stroke="#fff"
+              glow="var(--meter-fill-glow)"
+              strokeWidth={2.2}
+              opacity={0.95}
+              nonScaling
+            />
+          )}
+
+          {/* dashed 0 dBFS reference */}
+          <line
+            x1={COL_X}
+            y1={zeroY.toFixed(1)}
+            x2={COL_X + COL_W}
+            y2={zeroY.toFixed(1)}
+            stroke="var(--immersive-tx)"
+            strokeWidth={0.8}
+            strokeDasharray="2 2"
+            opacity={0.55}
+            vectorEffect="non-scaling-stroke"
+          />
+
+          {/* machined chrome bezel ring framing the column — brighter *-sm
+              highlight so the chrome reads at small bar size. LAST so it
+              frames the fill + glass. */}
+          <GaugeBezel
+            variant="rect"
+            defsId={defsId}
+            x={COL_X}
+            y={TOP_Y}
+            width={COL_W}
+            height={COL_HEIGHT}
+            rx={2}
+            thickness={2}
+            hiColor="var(--meter-bezel-hi-sm)"
+            nonScaling
+          />
+
+          {/* zone-transition ticks — short coloured horizontal lines on the
+              right of the column, away from the side-tick numeric labels. */}
+          {zoneTicks && zoneTicks.length > 0 && (
+            <g strokeLinecap="round">
+              {zoneTicks.map((zt, i) => {
+                const y = BOT_Y - COL_HEIGHT * zt.frac;
+                return (
+                  <line
+                    key={`zt-${i}`}
+                    x1={48}
+                    y1={y.toFixed(1)}
+                    x2={54}
+                    y2={y.toFixed(1)}
+                    stroke={immersiveZoneTickColor(zt.level)}
+                    strokeWidth={1.6}
+                    vectorEffect="non-scaling-stroke"
+                  />
+                );
+              })}
+            </g>
+          )}
+        </svg>
+      </div>
       <div style={numStyle}>
         {silent ? '−∞' : fmtDb(valueDb)}
         <span style={numUnitStyle}>dB</span>

--- a/zeus-web/src/components/meters/render/GaugeBezel.tsx
+++ b/zeus-web/src/components/meters/render/GaugeBezel.tsx
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// GaugeBezel — the machined chrome ring framing a gauge so it sits IN the
+// panel, not ON it. Layer (4) of the instrument stack and the single biggest
+// "whoa" tell. A 135° gradient runs a light edge top-left (--meter-bezel-hi)
+// into a dark edge bottom-right (--meter-bezel-lo); a thin inner rim
+// (--meter-bezel-ring) catches the key. SVG analogue of the WebGL shader's
+// rim/goldRim. Paint-once static art — never animates.
+//
+// rect | arc variants. All <defs> ids are namespaced via prefixDefs() since
+// 6-12 gauges share one page. DISPLAY-ONLY.
+
+import { prefixDefs } from './svgChrome';
+
+interface BezelGradientDef {
+  /** Resolved gradient id (already run through prefixDefs by the caller). */
+  id: string;
+}
+
+/** The shared 135° metallic edge gradient — light TL → dark BR. Drop this
+ *  inside the consuming SVG's <defs>. `hiColor` overrides the bright TL edge
+ *  stop (compact VU columns pass `--meter-bezel-hi-sm` so the chrome reads at
+ *  small bar size); defaults to the standard `--meter-bezel-hi`. */
+export function BezelGradient({ id, hiColor }: BezelGradientDef & { hiColor?: string }) {
+  return (
+    <linearGradient id={id} x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stopColor={hiColor ?? 'var(--meter-bezel-hi)'} />
+      <stop offset="0.32" stopColor="rgba(255,255,255,0.04)" />
+      <stop offset="0.68" stopColor="rgba(0,0,0,0.30)" />
+      <stop offset="1" stopColor="var(--meter-bezel-lo)" />
+    </linearGradient>
+  );
+}
+
+interface RectBezelProps {
+  variant: 'rect';
+  /** Defs prefix; ids namespaced under it. */
+  defsId: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  rx?: number;
+  /** Bezel ring thickness in viewBox units. Default 3. */
+  thickness?: number;
+  /** Keep stroke width constant under preserveAspectRatio="none" stretch so
+   *  the chrome doesn't smear (wide-and-short tracks). */
+  nonScaling?: boolean;
+  /** Override the bright TL bezel edge (compact bars pass
+   *  `--meter-bezel-hi-sm` so the chrome survives at small size). */
+  hiColor?: string;
+}
+
+interface ArcBezelProps {
+  variant: 'arc';
+  defsId: string;
+  /** Full SVG path `d` for the ring stroke (the caller draws the arc). */
+  d: string;
+  /** Bezel ring thickness. Default 6. */
+  thickness?: number;
+  /** Override the bright TL bezel edge. */
+  hiColor?: string;
+}
+
+export type GaugeBezelProps = RectBezelProps | ArcBezelProps;
+
+/**
+ * Machined metallic bezel ring. For `rect`, draws the chrome frame as a
+ * stroked rounded rect plus a thin inner rim. For `arc`, strokes the supplied
+ * path with the metallic gradient plus an inner-rim hairline. Render this
+ * ABOVE the well + glass so the chrome frames everything.
+ */
+export function GaugeBezel(props: GaugeBezelProps) {
+  const gradId = prefixDefs(props.defsId, 'bezelgrad');
+
+  if (props.variant === 'rect') {
+    const t = props.thickness ?? 3;
+    const half = t / 2;
+    const ve = props.nonScaling ? ('non-scaling-stroke' as const) : undefined;
+    return (
+      <>
+        <defs>
+          <BezelGradient id={gradId} hiColor={props.hiColor} />
+        </defs>
+        {/* outer machined frame — the thick chrome edge */}
+        <rect
+          x={props.x + half}
+          y={props.y + half}
+          width={Math.max(0, props.width - t)}
+          height={Math.max(0, props.height - t)}
+          rx={props.rx}
+          fill="none"
+          stroke={`url(#${gradId})`}
+          strokeWidth={t}
+          vectorEffect={ve}
+        />
+        {/* thin inner rim — the key-catching hairline just inside the frame */}
+        <rect
+          x={props.x + t}
+          y={props.y + t}
+          width={Math.max(0, props.width - 2 * t)}
+          height={Math.max(0, props.height - 2 * t)}
+          rx={props.rx ? Math.max(0, props.rx - half) : undefined}
+          fill="none"
+          stroke="var(--meter-bezel-ring)"
+          strokeWidth={0.75}
+          vectorEffect={ve}
+        />
+      </>
+    );
+  }
+
+  const t = props.thickness ?? 6;
+  return (
+    <>
+      <defs>
+        <BezelGradient id={gradId} hiColor={props.hiColor} />
+      </defs>
+      <path d={props.d} fill="none" stroke={`url(#${gradId})`} strokeWidth={t} strokeLinecap="round" />
+      <path
+        d={props.d}
+        fill="none"
+        stroke="var(--meter-bezel-ring)"
+        strokeWidth={0.85}
+        strokeLinecap="round"
+        opacity={0.9}
+      />
+    </>
+  );
+}

--- a/zeus-web/src/components/meters/render/GlassDome.tsx
+++ b/zeus-web/src/components/meters/render/GlassDome.tsx
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// GlassDome — the domed-glass specular layer that reads as light catching
+// curved glass over an instrument. Layer (3) of the instrument stack:
+//   • an upper-left-biased specular ellipse (--meter-glass-dome) — the SVG
+//     analogue of the WebGL shader's pow() specular hot-spot,
+//   • a thin edge-light along the top rim,
+//   • a slow horizontally-drifting narrow sheen band (--meter-sheen) — light
+//     sweeping across the glass on a multi-second loop.
+//
+// The drift is a compositor-only CSS @keyframes translateX (see
+// .meter-sheen-drift in layout.css) — no JS, no draw-bus cost — and is
+// PAUSED by prefers-reduced-motion (the animation is dropped) and when the
+// gauge is off-screen (animation-play-state via the parent). Paint-once defs;
+// only the sheen's transform animates. DISPLAY-ONLY, id-namespaced.
+
+import { prefixDefs } from './svgChrome';
+
+interface GlassDomeProps {
+  /** Defs prefix; ids namespaced under it. */
+  defsId: string;
+  /** Glass region in viewBox units (the area under the glass). */
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  /** Corner radius for the rounded glass rect. */
+  rx?: number;
+  /** Draw the drifting sheen band. Default true; set false to disable. */
+  sheen?: boolean;
+  /** Sheen band width as a fraction of `width`. Default 0.16. */
+  sheenWidthFrac?: number;
+  /** Specular-dome highlight colour. Defaults to the standard
+   *  `--meter-glass-dome`; the compact VU columns pass `--meter-glass-dome-sm`
+   *  so the wet-glass tell survives at small bar size. */
+  domeColor?: string;
+  /** Drifting-sheen band colour. Defaults to `--meter-sheen`; compact callers
+   *  pass `--meter-sheen-sm`. */
+  sheenColor?: string;
+}
+
+/**
+ * Specular glass cover. Renders ABOVE the well + fill but BELOW the bezel.
+ * The dome ellipse is biased to the upper-left so every gauge is lit from the
+ * same key direction as the rest of the instrument family.
+ */
+export function GlassDome({
+  defsId,
+  x,
+  y,
+  width,
+  height,
+  rx,
+  sheen = true,
+  sheenWidthFrac = 0.16,
+  domeColor = 'var(--meter-glass-dome)',
+  sheenColor = 'var(--meter-sheen)',
+}: GlassDomeProps) {
+  const domeId = prefixDefs(defsId, 'glassdome');
+  const sheenId = prefixDefs(defsId, 'glasssheen');
+  const sheenW = Math.max(2, width * sheenWidthFrac);
+
+  return (
+    <>
+      <defs>
+        {/* upper-left specular hot-spot — bright core fading out, the pow()
+            specular analogue. */}
+        <radialGradient id={domeId} cx="32%" cy="22%" r="62%">
+          <stop offset="0" stopColor={domeColor} />
+          <stop offset="0.45" stopColor="var(--meter-glass-top)" />
+          <stop offset="1" stopColor="var(--meter-glass-bot)" />
+        </radialGradient>
+        {/* the moving sheen band — a thin bright vertical streak, soft edges. */}
+        <linearGradient id={sheenId} x1="0" y1="0" x2="1" y2="0">
+          <stop offset="0" stopColor="var(--meter-sheen-soft)" stopOpacity="0" />
+          <stop offset="0.5" stopColor={sheenColor} />
+          <stop offset="1" stopColor="var(--meter-sheen-soft)" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+
+      {/* domed specular highlight over the whole glass */}
+      <rect x={x} y={y} width={width} height={height} rx={rx} fill={`url(#${domeId})`} />
+
+      {/* thin top edge-light rim */}
+      <rect
+        x={x}
+        y={y}
+        width={width}
+        height={Math.max(1, height * 0.06)}
+        rx={rx}
+        fill={domeColor}
+        opacity={0.5}
+      />
+
+      {/* drifting sheen band — the group carries the compositor-only CSS drift
+          animation. The band starts off the left edge and travels one glass-
+          width to the right (CSS var --sheen-travel, in SVG user units mapped
+          by translateX(<n>px)). prefers-reduced-motion drops the animation
+          (see layout.css). */}
+      {sheen && (
+        <g
+          className="meter-sheen-drift"
+          style={{ ['--sheen-travel' as string]: `${width + sheenW}px` }}
+        >
+          <rect x={x - sheenW} y={y} width={sheenW} height={height} rx={rx} fill={`url(#${sheenId})`} />
+        </g>
+      )}
+    </>
+  );
+}

--- a/zeus-web/src/components/meters/render/drawBus.ts
+++ b/zeus-web/src/components/meters/render/drawBus.ts
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Shared 60 Hz draw-bus for the meter cluster — ONE module-level
+// requestAnimationFrame that drives every presentation-layer glide for the
+// whole meter set. There is never a timer or rAF per meter: each meter
+// subscribes a per-frame step function; the bus runs rAF only while at least
+// one subscriber is registered and self-cancels when the set empties.
+//
+// DISPLAY-ONLY. This bus interpolates how a value is DRAWN — it does not
+// read, smooth, or publish any meter VALUE. The value pipeline
+// (useBallisticReading / ballistics.ts / peak-hold) is untouched; the glide
+// hooks that subscribe here consume the already-published value and only
+// decide the drawn position between updates.
+//
+// GATING — idle meters and hidden tabs cost zero frames, so the panadapter
+// is unaffected:
+//   • The whole tick is skipped while document.hidden.
+//   • Each subscriber may register its host element; an IntersectionObserver
+//     (same pattern as useBallisticReading.ts:218-238 / AnalogMeterPanel:
+//     334-346) marks it off-screen and the bus skips stepping it. When every
+//     live subscriber is off-screen the rAF still parks (no visible work).
+
+/** Per-frame step. `dt` is seconds since the last tick, clamped to 0.05 s
+ *  (matches the wake-protection clamps in the value pipeline) so a tab wake
+ *  or a long frame never yanks the spring. */
+export type DrawStep = (dt: number) => void;
+
+interface Subscriber {
+  step: DrawStep;
+  /** Host element for off-screen gating; null → always considered visible. */
+  host: Element | null;
+  /** Last IntersectionObserver verdict — true until told otherwise. */
+  visible: boolean;
+}
+
+const subscribers = new Set<Subscriber>();
+let raf = 0;
+let lastMs = 0;
+let observer: IntersectionObserver | null = null;
+// Map from observed element → subscriber so the IO callback can flip its flag.
+const byElement = new WeakMap<Element, Subscriber>();
+
+const DT_CLAMP_S = 0.05;
+
+function pageHidden(): boolean {
+  return typeof document !== 'undefined' && document.hidden;
+}
+
+function ensureObserver(): IntersectionObserver | null {
+  if (typeof IntersectionObserver === 'undefined') return null;
+  if (observer) return observer;
+  observer = new IntersectionObserver(
+    (entries) => {
+      for (const e of entries) {
+        const sub = byElement.get(e.target);
+        if (sub) sub.visible = e.isIntersecting;
+      }
+    },
+    { threshold: 0 },
+  );
+  return observer;
+}
+
+function tick(now: number) {
+  raf = 0;
+  if (subscribers.size === 0) return;
+
+  // Skip the whole tick on a hidden tab — but keep the loop alive so we
+  // resume instantly on un-hide. (The dt anchor is reset on the first
+  // visible frame via the lastMs==0 seed below.)
+  if (pageHidden()) {
+    lastMs = 0;
+    raf = requestAnimationFrame(tick);
+    return;
+  }
+
+  const dt = lastMs === 0 ? 0 : Math.min(DT_CLAMP_S, Math.max(0, (now - lastMs) / 1000));
+  lastMs = now;
+
+  for (const sub of subscribers) {
+    if (sub.host && !sub.visible) continue;
+    sub.step(dt);
+  }
+
+  if (subscribers.size > 0) raf = requestAnimationFrame(tick);
+}
+
+function start() {
+  if (raf === 0 && subscribers.size > 0) {
+    lastMs = 0; // reseed dt anchor so the first frame doesn't count the gap
+    raf = requestAnimationFrame(tick);
+  }
+}
+
+/**
+ * Register a per-frame step. Returns an unsubscribe fn. Pass `host` to opt
+ * the subscriber into off-screen gating (the bus skips stepping it while its
+ * element is not intersecting the viewport).
+ */
+export function subscribe(step: DrawStep, host?: Element | null): () => void {
+  const sub: Subscriber = { step, host: host ?? null, visible: true };
+  subscribers.add(sub);
+
+  if (sub.host) {
+    const io = ensureObserver();
+    if (io) {
+      byElement.set(sub.host, sub);
+      io.observe(sub.host);
+    }
+  }
+
+  start();
+
+  return () => {
+    subscribers.delete(sub);
+    if (sub.host && observer) {
+      observer.unobserve(sub.host);
+      byElement.delete(sub.host);
+    }
+    if (subscribers.size === 0 && raf !== 0) {
+      cancelAnimationFrame(raf);
+      raf = 0;
+      lastMs = 0;
+    }
+  };
+}

--- a/zeus-web/src/components/meters/render/fillGradient.tsx
+++ b/zeus-web/src/components/meters/render/fillGradient.tsx
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// fillGradient — the vertical "volume" gradient that makes a meter fill read
+// cylindrical: a dark floor (--meter-fill-base) → the live signal colour core
+// → a bright top crown (--meter-fill-hot). It layers UNDER the existing
+// horizontal good→warn→tx HUE ramp, so the bar gains depth while the hue ramp
+// keeps its semantic meaning untouched. Layer (2) of the instrument stack.
+//
+// Returned as <stop> children so callers can drop it into a vertical
+// <linearGradient> that's multiplied over (or composited under) their crisp
+// horizontal fill. DISPLAY-ONLY.
+
+import type { ReactNode } from 'react';
+
+export interface VolumeStopsOptions {
+  /** Base floor alpha-darken stop. Defaults to --meter-fill-base. */
+  base?: string;
+  /** Bright crown stop at the top. Defaults to --meter-fill-hot. */
+  hot?: string;
+}
+
+/**
+ * Vertical-volume gradient stops (top y=0 → bottom y=1 in a 0→1 gradient).
+ * The crown sits near the top, a clear mid lets the underlying hue show, and
+ * a dark floor anchors the bottom — the classic lit-cylinder shading.
+ *
+ * Use with a vertical <linearGradient> drawn over the crisp fill at a low/
+ * screen-ish composite so it shades rather than recolours.
+ */
+export function volumeStops(opts: VolumeStopsOptions = {}): ReactNode {
+  const base = opts.base ?? 'var(--meter-fill-base)';
+  const hot = opts.hot ?? 'var(--meter-fill-hot)';
+  return [
+    <stop key="crown" offset="0" stopColor={hot} />,
+    <stop key="hi" offset="0.18" stopColor="rgba(255,255,255,0.10)" />,
+    <stop key="mid" offset="0.5" stopColor="rgba(0,0,0,0)" />,
+    <stop key="lo" offset="0.82" stopColor="rgba(0,0,0,0.18)" />,
+    <stop key="floor" offset="1" stopColor={base} />,
+  ];
+}
+
+/** A CSS linear-gradient string equivalent for DOM-only callers. Vertical,
+ *  top→bottom, same crown/mid/floor shading as the SVG stops. */
+export function volumeGradientCss(opts: VolumeStopsOptions = {}): string {
+  const base = opts.base ?? 'var(--meter-fill-base)';
+  const hot = opts.hot ?? 'var(--meter-fill-hot)';
+  return (
+    `linear-gradient(180deg,` +
+    ` ${hot} 0%,` +
+    ` rgba(255,255,255,0.10) 18%,` +
+    ` rgba(0,0,0,0) 50%,` +
+    ` rgba(0,0,0,0.18) 82%,` +
+    ` ${base} 100%)`
+  );
+}

--- a/zeus-web/src/components/meters/render/lampCard.ts
+++ b/zeus-web/src/components/meters/render/lampCard.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// The warm-lamp card recipe — the three-radial cream-bloom background over a
+// dark linear well, plus the inset rim / under-glow / vignette boxShadow —
+// extracted from the verbatim copies in BigArc.cardStyle and
+// VuColumn.cardStyle. Centralised so the flat DOM meters (SMeter, MicMeter,
+// TxStageMeters rows) can opt into the same lit-instrument surface, and so a
+// future colour-temperature tweak lives in one place.
+//
+// Token-only. The light-theme flip already comes for free from the
+// --immersive-lamp-* token overrides (the warm blooms go transparent on the
+// silver chassis, the well flips to brushed silver). DISPLAY-ONLY.
+
+import type { CSSProperties } from 'react';
+
+export type LampCardVariant =
+  // Bottom-anchored bloom (an arc face lit from below — BigArc / PullDownArc).
+  | 'arc'
+  // Bottom-anchored bloom tuned for a tall column (VuColumn).
+  | 'column';
+
+interface LampCardOptions {
+  /** Corner radius. Defaults to 7 (the immersive card radius). */
+  radius?: number;
+  /** Override the inset depth shadow — column cards use a shallower well. */
+  insetShadow?: string;
+}
+
+/** The cream-bloom background stack for a lit gauge face. */
+export function lampCardBackground(variant: LampCardVariant): string {
+  const bloomGeom =
+    variant === 'column'
+      ? '80% 95% at 50% 100%'
+      : '80% 95% at 50% 95%';
+  return (
+    `radial-gradient(${bloomGeom}, var(--immersive-lamp-bloom-1), var(--immersive-lamp-bloom-2) ${
+      variant === 'column' ? '50%' : '45%'
+    }, transparent ${variant === 'column' ? '75%' : '72%'}),` +
+    ' radial-gradient(60% 60% at 50% 70%, var(--immersive-lamp-bloom-3), transparent 65%),' +
+    ' linear-gradient(180deg, var(--immersive-lamp-well-top) 0%, var(--immersive-lamp-well-bot) 100%)'
+  );
+}
+
+/** The inset rim + warm under-glow + vignette depth shadow for a lit card. */
+export function lampInsetShadow(variant: LampCardVariant): string {
+  return variant === 'column'
+    ? 'inset 0 1px 0 var(--immersive-lamp-rim), inset 0 -18px 32px rgba(255,240,180,0.04), inset 0 0 22px rgba(0,0,0,0.40)'
+    : 'inset 0 1px 0 var(--immersive-lamp-rim), inset 0 -22px 40px rgba(255,240,180,0.05), inset 0 0 50px rgba(0,0,0,0.55)';
+}
+
+/** Full lit-instrument card surface: background + border + depth shadow.
+ *  Layout (position / aspect / flex) stays the caller's job — this only owns
+ *  the illuminated-surface look so it can be spread into any card style. */
+export function lampCardStyle(
+  variant: LampCardVariant,
+  opts: LampCardOptions = {},
+): CSSProperties {
+  return {
+    background: lampCardBackground(variant),
+    border: '1px solid var(--immersive-lamp-border)',
+    borderRadius: opts.radius ?? 7,
+    boxShadow: opts.insetShadow ?? lampInsetShadow(variant),
+  };
+}
+
+/** A recessed-well inset shadow for a thin DOM meter track that wants the
+ *  lit-instrument depth without the full cream-bloom card behind it (SMeter
+ *  track, MicMeter bar). Keeps the warm amber halo the TxStageMeters rows
+ *  already use so every moving bar reads as the same lit channel. */
+export function meterWellShadow(): string {
+  return (
+    'inset 0 1px 3px rgba(0,0,0,0.8),' +
+    ' inset 0 0 0 1px rgba(255,255,255,0.03),' +
+    ' 0 0 18px rgba(255,140,40,0.18),' +
+    ' 0 0 6px rgba(255,170,80,0.12)'
+  );
+}

--- a/zeus-web/src/components/meters/render/recessedWell.ts
+++ b/zeus-web/src/components/meters/render/recessedWell.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// recessedWell — the concave "machined pocket" a meter fill sits inside.
+// Generalises lampCard.ts meterWellShadow() (a single flat inset) into a
+// real well: a concave radial floor gradient (--meter-well-floor centre →
+// --meter-well-edge rim) plus a multi-layer inset box-shadow stack so the
+// pocket reads as pressed into the metal chassis, lit from the upper-left.
+//
+// Token-only / DISPLAY-ONLY. This is layer (1) of the five-layer instrument
+// stack; the volumetric fill (fillGradient), specular glass (GlassDome) and
+// bezel ring (GaugeBezel) stack on top.
+
+import type { CSSProperties } from 'react';
+
+export interface RecessedWellOptions {
+  /** Corner radius. Defaults to 3. */
+  radius?: number;
+  /** Add the warm amber halo (signal bars want it; chrome wells don't). */
+  warmHalo?: boolean;
+  /** Add the whole-gauge outer additive bloom (--gauge-glow). */
+  glow?: boolean;
+}
+
+/** Background paint for a recessed well — a concave floor lit from the
+ *  upper-left so the centre reads deepest and the rim catches the key. */
+export function recessedWellBackground(): string {
+  return (
+    // Concave floor — dark centre rising to a slightly lighter rim, biased
+    // to the upper-left so the pocket reads as lit from the key light.
+    'radial-gradient(120% 140% at 35% 25%,' +
+    ' var(--meter-well-edge) 0%,' +
+    ' var(--meter-well-floor) 55%,' +
+    ' var(--meter-well-floor) 100%)'
+  );
+}
+
+/** The multi-layer inset shadow stack giving the pocket its machined depth.
+ *  Two crisp inner edges (dark top, faint light bottom-rim catch) over a
+ *  soft inner vignette. Optional warm amber halo + gauge bloom outside. */
+export function recessedWellShadow(opts: RecessedWellOptions = {}): string {
+  const layers: string[] = [
+    // hard top-edge shadow — the lip of the pocket
+    'inset 0 2px 4px rgba(0,0,0,0.85)',
+    // faint bottom-rim light catch — the far wall reflecting the key
+    'inset 0 -1px 1px rgba(255,255,255,0.06)',
+    // crisp inner hairline so the pocket edge stays defined
+    'inset 0 0 0 1px rgba(0,0,0,0.55)',
+    // soft inner vignette — depth
+    'inset 0 0 10px rgba(0,0,0,0.45)',
+  ];
+  if (opts.warmHalo) {
+    layers.push('0 0 18px rgba(255,140,40,0.18)');
+    layers.push('0 0 6px rgba(255,170,80,0.12)');
+  }
+  if (opts.glow) {
+    layers.push('0 0 22px var(--gauge-glow)');
+  }
+  return layers.join(', ');
+}
+
+/** Full recessed-well CSS — background + concave depth shadow + radius.
+ *  Spread into the track wrapper's style; the caller owns size / layout. */
+export function recessedWell(opts: RecessedWellOptions = {}): CSSProperties {
+  return {
+    background: recessedWellBackground(),
+    borderRadius: opts.radius ?? 3,
+    boxShadow: recessedWellShadow(opts),
+  };
+}

--- a/zeus-web/src/components/meters/render/svgChrome.tsx
+++ b/zeus-web/src/components/meters/render/svgChrome.tsx
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Shared SVG render kit for the meter cluster — the central, token-only
+// implementation of the "bloom-behind-crisp + glowing-peak" idiom that the
+// immersive primitives (BigArc / VuColumn / HBarMeter / PullDownArc) already
+// prove. Extracted here so the same lit-instrument look can be lifted onto
+// the flat DOM meters (SMeter, MicMeter, TxStageMeters) without copy-pasting
+// the blurred-copy + drop-shadow-pip code a fourth and fifth time.
+//
+// DISPLAY-ONLY: nothing here touches the meter value pipeline, ballistics,
+// or peak-hold physics. Callers compute every fraction/position from the
+// already-smoothed {value, peak}; this kit only decides how those are DRAWN.
+//
+// Per-instance id prefixing is MANDATORY — many gauges share one page, so a
+// shared <filter>/<gradient> id added by this kit must be namespaced via
+// `prefixDefs()` or one gauge's blur bleeds into another's.
+
+import type { ReactNode } from 'react';
+
+// ── id namespacing ──────────────────────────────────────────────────────
+// Sanitise a caller-supplied defs prefix into a DOM-safe id stem and join a
+// local part onto it. Mirrors the `def.id.replace(/\W/g, '_')` pattern
+// already in use across HBarMeter so existing ids are unchanged.
+export function prefixDefs(defsId: string, local: string): string {
+  const stem = defsId.replace(/\W/g, '_');
+  return `${stem}-${local}`;
+}
+
+// ── shared blur filter ──────────────────────────────────────────────────
+// The single feGaussianBlur every two-pass fill uses. stdDeviation kept at 3
+// (byte-identical to the value inlined in BigArc / VuColumn / HBarMeter) so
+// lifting these into the kit does not shift the rendered halo. `pad` widens
+// the filter region for callers that need extra bleed room (HBarMeter uses a
+// wide horizontal region; VuColumn a tall vertical one) — default covers the
+// common 180% box.
+interface BloomFilterProps {
+  /** Fully-resolved filter id (run the caller's prefix through prefixDefs). */
+  id: string;
+  /** Blur radius. Defaults to 3 — the established meter bloom radius. */
+  stdDeviation?: number;
+  /** Filter region as [x, y, width, height] in % strings. */
+  region?: readonly [string, string, string, string];
+}
+
+export function BloomFilter({
+  id,
+  stdDeviation = 3,
+  region = ['-40%', '-40%', '180%', '180%'],
+}: BloomFilterProps) {
+  const [x, y, width, height] = region;
+  return (
+    <filter id={id} x={x} y={y} width={width} height={height}>
+      <feGaussianBlur stdDeviation={stdDeviation} />
+    </filter>
+  );
+}
+
+// ── bloom-behind-crisp fill ─────────────────────────────────────────────
+// Draws an SVG shape twice: a blurred, wider, low-opacity copy UNDER a crisp
+// copy on top. This is the core "lit trace halo" tell shared by every
+// premium meter. Generalised over rect | path | line so all the gauges and
+// the DOM bars share ONE implementation instead of three near-identical
+// copies. The caller owns geometry + fill (gradient url or token); this owns
+// the two-pass stack and the blur wiring.
+type BloomShape =
+  | {
+      kind: 'rect';
+      x: number | string;
+      y: number | string;
+      width: number | string;
+      height: number | string;
+      rx?: number;
+    }
+  | { kind: 'path'; d: string }
+  | {
+      kind: 'line';
+      x1: number | string;
+      y1: number | string;
+      x2: number | string;
+      y2: number | string;
+    };
+
+interface BloomFillProps {
+  shape: BloomShape;
+  /** Crisp-copy paint — a gradient `url(#…)` or a token color string. */
+  fill: string;
+  /** Bloom-copy paint. Defaults to `fill`; pass a softer gradient when one
+   *  exists (VuColumn / HBarMeter keep a dedicated half-opacity bloom grad). */
+  bloomFill?: string;
+  /** Resolved id of the BloomFilter the blurred copy references. */
+  filterId: string;
+  /** Bloom-copy opacity. 0.85 matches the immersive primitives. */
+  bloomOpacity?: number;
+  /** For stroke-based shapes (path/line arcs): crisp + bloom stroke widths. */
+  strokeWidth?: number;
+  bloomStrokeWidth?: number;
+  /** strokeLinecap for stroked shapes. */
+  strokeLinecap?: 'butt' | 'round' | 'square';
+  /** strokeDasharray for partial-fill arcs. */
+  strokeDasharray?: string;
+}
+
+function renderShape(
+  shape: BloomShape,
+  paint: string,
+  stroked: boolean,
+  strokeWidth: number | undefined,
+  strokeLinecap: BloomFillProps['strokeLinecap'],
+  strokeDasharray: string | undefined,
+  filterId: string | null,
+  opacity: number | undefined,
+): ReactNode {
+  const strokeProps = stroked
+    ? {
+        fill: 'none' as const,
+        stroke: paint,
+        strokeWidth,
+        strokeLinecap,
+        strokeDasharray,
+      }
+    : { fill: paint };
+  const common = {
+    ...strokeProps,
+    ...(filterId ? { filter: `url(#${filterId})` } : {}),
+    ...(opacity != null ? { opacity } : {}),
+  };
+  switch (shape.kind) {
+    case 'rect':
+      return (
+        <rect
+          x={shape.x}
+          y={shape.y}
+          width={shape.width}
+          height={shape.height}
+          rx={shape.rx}
+          {...common}
+        />
+      );
+    case 'path':
+      return <path d={shape.d} {...common} />;
+    case 'line':
+      return <line x1={shape.x1} y1={shape.y1} x2={shape.x2} y2={shape.y2} {...common} />;
+  }
+}
+
+export function BloomFill({
+  shape,
+  fill,
+  bloomFill,
+  filterId,
+  bloomOpacity = 0.85,
+  strokeWidth,
+  bloomStrokeWidth,
+  strokeLinecap,
+  strokeDasharray,
+}: BloomFillProps) {
+  const stroked = shape.kind !== 'rect';
+  return (
+    <>
+      {renderShape(
+        shape,
+        bloomFill ?? fill,
+        stroked,
+        bloomStrokeWidth ?? strokeWidth,
+        strokeLinecap,
+        strokeDasharray,
+        filterId,
+        bloomOpacity,
+      )}
+      {renderShape(
+        shape,
+        fill,
+        stroked,
+        strokeWidth,
+        strokeLinecap,
+        strokeDasharray,
+        null,
+        undefined,
+      )}
+    </>
+  );
+}
+
+// ── glowing peak markers ────────────────────────────────────────────────
+// A warm-cream peak pip (BigArc rim pearl) and a peak tick (VuColumn /
+// HBarMeter / DOM bar). Both carry the established drop-shadow halo so the
+// peak reads as a lit indicator rather than a hairline. Geometry stays the
+// caller's job; this fixes the look.
+interface PeakPipProps {
+  cx: number | string;
+  cy: number | string;
+  r?: number;
+  /** Halo color token. Defaults to the warm lamp pin. */
+  glow?: string;
+  fill?: string;
+  stroke?: string;
+}
+
+export function PeakPip({
+  cx,
+  cy,
+  r = 3,
+  glow = 'var(--immersive-lamp-pin)',
+  fill = '#fff',
+  stroke = 'var(--immersive-lamp-pin)',
+}: PeakPipProps) {
+  return (
+    <circle
+      cx={cx}
+      cy={cy}
+      r={r}
+      fill={fill}
+      stroke={stroke}
+      strokeWidth={1}
+      // Brighter halo for the taller dramatic gauges — a tight bright core
+      // over a wider soft bloom so the peak pearl reads as a lit indicator.
+      style={{ filter: `drop-shadow(0 0 4px ${glow}) drop-shadow(0 0 9px ${glow})` }}
+    />
+  );
+}
+
+interface PeakTickProps {
+  x1: number | string;
+  y1: number | string;
+  x2: number | string;
+  y2: number | string;
+  stroke?: string;
+  strokeWidth?: number;
+  /** Halo color. Defaults to the stroke (so a white tick glows white). */
+  glow?: string;
+  opacity?: number;
+  /** Keep the tick crisp under SVG `preserveAspectRatio="none"` stretch. */
+  nonScaling?: boolean;
+}
+
+export function PeakTick({
+  x1,
+  y1,
+  x2,
+  y2,
+  stroke = '#fff',
+  strokeWidth = 1.8,
+  glow,
+  opacity = 0.95,
+  nonScaling = false,
+}: PeakTickProps) {
+  return (
+    <line
+      x1={x1}
+      y1={y1}
+      x2={x2}
+      y2={y2}
+      stroke={stroke}
+      strokeWidth={strokeWidth}
+      opacity={opacity}
+      vectorEffect={nonScaling ? 'non-scaling-stroke' : undefined}
+      // Stronger double-bloom halo so the latched peak marker reads as a lit
+      // indicator on the taller, brighter dramatic tracks.
+      style={{ filter: `drop-shadow(0 0 4px ${glow ?? stroke}) drop-shadow(0 0 8px ${glow ?? stroke})` }}
+    />
+  );
+}

--- a/zeus-web/src/components/meters/render/useGlidedDraw.ts
+++ b/zeus-web/src/components/meters/render/useGlidedDraw.ts
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// 60 Hz display-side interpolation — a pure presentation layer that glides
+// HOW a value is DRAWN, never WHAT value is read. It sits on top of the
+// already-published (~30 Hz) value from useBallisticReading and springs the
+// drawn position toward it on the shared draw-bus. It does NOT touch the
+// value pipeline (ballistics.ts, peakHoldStep, advancePeakHold,
+// PUBLISH_INTERVAL_MS). PS / calibration stay byte-identical because at
+// steady state the drawn value === the target exactly.
+//
+// SPRING — semi-implicit (symplectic Euler) critically-damped, per frame:
+//     accel = -k*(drawn - target) - c*vel
+//     vel  += accel*dt
+//     drawn += vel*dt
+//   • Stiffness k≈170 → settle ~80-120 ms at 60 Hz.
+//   • Damping ratio: FALLS use 1.0 (critical, smooth decay, no overshoot);
+//     RISES use ~0.86 (slight under-damp → the requested subtle
+//     overshoot-settle / momentum). c = 2*ratio*sqrt(k).
+//   • dt clamped to 0.05 s by the draw-bus.
+//   • PARK: when |drawn-target| < EPS and |vel| small, snap + go idle so the
+//     subscriber stops asking the bus to step it while steady.
+//
+// PEAK IS NEVER GLIDED. The peak fraction/tick passes through the raw latched
+// value untouched and latches on the same frame; callers wire peak straight
+// from the raw pkRef/peak, never from this hook's output.
+
+import { useEffect, useRef, type RefObject } from 'react';
+import { subscribe } from './drawBus';
+
+// Presentation-only timing constants (NOT tokens — these are motion, not
+// colour). Named here so a future feel tweak lives in one place.
+const STIFFNESS = 170; // k — settle in ~80-120 ms at 60 Hz
+const RISE_DAMPING = 0.86; // < 1 → subtle overshoot-settle on rises
+const FALL_DAMPING = 1.0; // critical → smooth decay, no overshoot
+const EPS_PARK = 5e-4; // park when within this of target …
+const VEL_PARK = 5e-3; // … and velocity below this
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+}
+
+export interface GlideOptions {
+  /** Host element for the draw-bus off-screen gate (the widget root). */
+  hostRef?: RefObject<Element | null>;
+  /**
+   * Imperative writer called every frame the drawn value moves, with the
+   * fresh 0..1 drawn fraction. Preferred path: write a transform straight to
+   * an element ref (scaleX / translateX for bars, rotate for the needle) so
+   * NO React setState runs in the 60 Hz path and reconciliation stays at the
+   * 30 Hz value cadence. If omitted the hook still glides internally and
+   * `read()` returns the live drawn value (for callers that sample at their
+   * own render cadence).
+   */
+  onDraw?: (drawn: number) => void;
+}
+
+export interface GlideHandle {
+  /** Current drawn fraction (0..1). Cheap synchronous read for callers that
+   *  compute geometry off the drawn value at their own paint cadence. */
+  read: () => number;
+}
+
+/**
+ * Glide a calibrated target fraction (or any already-normalised 0..1 scalar
+ * — angle/N work too) toward its latest value on the shared 60 Hz bus.
+ *
+ * The target is passed every render; the hook stashes it in a ref so the bus
+ * step always springs toward the freshest published value without
+ * re-subscribing. prefers-reduced-motion forces critical damping both
+ * directions (no overshoot) so motion is still smooth but never bounces.
+ */
+export function useGlidedFraction(target: number, opts: GlideOptions = {}): GlideHandle {
+  const targetRef = useRef(target);
+  targetRef.current = Number.isFinite(target) ? target : 0;
+
+  const drawnRef = useRef(targetRef.current);
+  const velRef = useRef(0);
+  const idleRef = useRef(false);
+
+  const onDrawRef = useRef(opts.onDraw);
+  onDrawRef.current = opts.onDraw;
+
+  const hostRef = opts.hostRef;
+
+  useEffect(() => {
+    const reduced = prefersReducedMotion();
+
+    const step = (dt: number) => {
+      const target = targetRef.current;
+      let drawn = drawnRef.current;
+      let vel = velRef.current;
+
+      const delta = drawn - target;
+
+      // Park check — snap exact and stop stepping while steady so a row of
+      // idle meters costs nothing. The first non-trivial target change wakes
+      // it again (see the wake below).
+      if (Math.abs(delta) < EPS_PARK && Math.abs(vel) < VEL_PARK) {
+        if (!idleRef.current) {
+          drawnRef.current = target; // byte-exact at rest → zero draw drift
+          velRef.current = 0;
+          idleRef.current = true;
+          onDrawRef.current?.(target);
+        }
+        return;
+      }
+      idleRef.current = false;
+
+      // Rises under-damp slightly (momentum/overshoot); falls critically
+      // damp (smooth decay). prefers-reduced-motion forces critical both ways.
+      const rising = target > drawn;
+      const ratio = reduced ? 1.0 : rising ? RISE_DAMPING : FALL_DAMPING;
+      const c = 2 * ratio * Math.sqrt(STIFFNESS);
+
+      const accel = -STIFFNESS * delta - c * vel;
+      vel += accel * dt;
+      drawn += vel * dt;
+
+      drawnRef.current = drawn;
+      velRef.current = vel;
+      onDrawRef.current?.(drawn);
+    };
+
+    // Wake the spring whenever React re-renders with a fresh target: the
+    // park-snap above marks idle, but a new published value must restart
+    // stepping. A 60 Hz subscriber that's parked simply returns early each
+    // frame (nearly free); we keep it subscribed so it picks up the next
+    // change instantly without a re-subscribe round-trip.
+    const unsub = subscribe(step, hostRef?.current ?? null);
+    return unsub;
+    // host element identity is stable for the widget's life; target changes
+    // flow through targetRef without re-subscribing.
+  }, [hostRef]);
+
+  // Re-arm out of park on every render where the target moved meaningfully.
+  if (idleRef.current && Math.abs(drawnRef.current - targetRef.current) >= EPS_PARK) {
+    idleRef.current = false;
+  }
+
+  return {
+    read: () => drawnRef.current,
+  };
+}

--- a/zeus-web/src/components/meters/widgets/HBarMeter.tsx
+++ b/zeus-web/src/components/meters/widgets/HBarMeter.tsx
@@ -25,6 +25,7 @@ import type { CSSProperties } from 'react';
 import type { MeterReadingDef, MeterUnit } from '../meterCatalog';
 import { immersiveZoneTickColor, type ZoneTick } from '../meterCatalog';
 import type { WidgetSettings } from '../widgetSettings';
+import { BloomFill, BloomFilter, PeakTick, prefixDefs } from '../render/svgChrome';
 
 interface HBarMeterProps {
   value: number;
@@ -188,10 +189,10 @@ export function HBarMeter({
 
   const scaleTicks = generateScaleTicks(def.unit, min, max);
 
-  const fillId = `hb-${def.id.replace(/\W/g, '_')}-fill`;
-  const bloomId = `hb-${def.id.replace(/\W/g, '_')}-bloom`;
-  const blurId = `hb-${def.id.replace(/\W/g, '_')}-blur`;
-  const maskId = `hb-${def.id.replace(/\W/g, '_')}-mask`;
+  const fillId = prefixDefs(`hb-${def.id}`, 'fill');
+  const bloomId = prefixDefs(`hb-${def.id}`, 'bloom');
+  const blurId = prefixDefs(`hb-${def.id}`, 'blur');
+  const maskId = prefixDefs(`hb-${def.id}`, 'mask');
 
   const fillW = VB_W * liveFrac;
   const peakX = peakFrac !== null ? VB_W * peakFrac : 0;
@@ -385,9 +386,7 @@ export function HBarMeter({
                 </>
               )}
             </linearGradient>
-            <filter id={blurId} x="-10%" y="-50%" width="120%" height="200%">
-              <feGaussianBlur stdDeviation="3" />
-            </filter>
+            <BloomFilter id={blurId} region={['-10%', '-50%', '120%', '200%']} />
             <mask id={maskId}>
               <rect x={0} y={BAR_Y} width={VB_W} height={BAR_H} fill="white" />
             </mask>
@@ -432,8 +431,8 @@ export function HBarMeter({
             width={VB_W}
             height={BAR_H}
             rx={2}
-            fill="#080a10"
-            stroke="rgba(255,255,255,0.08)"
+            fill="var(--immersive-vu-track)"
+            stroke="var(--immersive-rim)"
             strokeWidth={1}
             vectorEffect="non-scaling-stroke"
           />
@@ -446,26 +445,13 @@ export function HBarMeter({
             fill="rgba(0,0,0,0.6)"
           />
 
-          {/* bloom (blurred) layer behind crisp fill */}
+          {/* bloom-behind-crisp fill — shared kit */}
           {!silent && fillW > 0 && (
-            <rect
-              x={0}
-              y={BAR_Y}
-              width={fillW}
-              height={BAR_H}
-              fill={`url(#${bloomId})`}
-              filter={`url(#${blurId})`}
-              opacity={0.85}
-            />
-          )}
-          {/* crisp fill */}
-          {!silent && fillW > 0 && (
-            <rect
-              x={0}
-              y={BAR_Y}
-              width={fillW}
-              height={BAR_H}
+            <BloomFill
+              shape={{ kind: 'rect', x: 0, y: BAR_Y, width: fillW, height: BAR_H }}
               fill={`url(#${fillId})`}
+              bloomFill={`url(#${bloomId})`}
+              filterId={blurId}
             />
           )}
 
@@ -496,16 +482,12 @@ export function HBarMeter({
               2 px past each edge of the bar (same overhang VuColumn
               uses on its peak tick relative to the column edge). */}
           {showPeak && (
-            <line
+            <PeakTick
               x1={peakX.toFixed(2)}
               y1={BAR_Y - 2}
               x2={peakX.toFixed(2)}
               y2={BAR_Y + BAR_H + 2}
-              stroke="#fff"
-              strokeWidth={1.4}
-              opacity={0.9}
-              vectorEffect="non-scaling-stroke"
-              style={{ filter: 'drop-shadow(0 0 4px #fff)' }}
+              nonScaling
             />
           )}
 

--- a/zeus-web/src/styles/analog-meter.css
+++ b/zeus-web/src/styles/analog-meter.css
@@ -89,6 +89,12 @@
   align-items: stretch;
   justify-content: center;
   overflow: hidden;
+  /* Machined recess — a hard top-edge inset + soft inner vignette so the dial
+     reads as pressed into the chassis, plus a faint warm gauge bloom. */
+  box-shadow:
+    inset 0 3px 8px rgba(0,0,0,0.7),
+    inset 0 0 24px rgba(0,0,0,0.45),
+    0 0 26px var(--gauge-glow);
 }
 .am-tile .analog-meter-face {
   display: block;

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -1362,6 +1362,41 @@
 .meter-tick.danger { background: rgba(0,0,0,0.7); }
 .meter-peak { position: absolute; top: -1px; bottom: -1px; width: 2px; background: #fff; transform: translateX(-50%); opacity: 0.9; }
 
+/* High-end "lit instrument" variant of the meter track — recessed well with
+   a warm amber halo so the moving bar reads as the same lit channel as the
+   immersive gauges. The fill / sheen / glowing peak are drawn by an inline
+   SVG (bloom-behind-crisp via the shared render kit), so this only restyles
+   the surrounding well. Scoped to the modifier class to leave other
+   .meter-bar consumers untouched. */
+.meter-bar--lit {
+  background: var(--meter-bg);
+  border: 1px solid var(--line);
+  box-shadow:
+    inset 0 1px 3px rgba(0,0,0,0.8),
+    inset 0 0 0 1px rgba(255,255,255,0.03),
+    0 0 18px rgba(255,140,40,0.18),
+    0 0 6px rgba(255,170,80,0.12);
+}
+
+/* Moving-sheen drift for GlassDome — a slow compositor-only translateX loop
+   that reads as light sweeping across curved glass. The travel distance is
+   supplied per-gauge via the --sheen-travel custom property (SVG user units).
+   GPU-cheap: only `transform` animates. Dropped entirely under reduced
+   motion (the sheen rect is hidden). */
+@keyframes meter-sheen-drift-kf {
+  0%   { transform: translateX(0); opacity: 0; }
+  12%  { opacity: 1; }
+  88%  { opacity: 1; }
+  100% { transform: translateX(var(--sheen-travel, 100px)); opacity: 0; }
+}
+.meter-sheen-drift {
+  animation: meter-sheen-drift-kf 7s linear infinite;
+  will-change: transform;
+}
+@media (prefers-reduced-motion: reduce) {
+  .meter-sheen-drift { animation: none; opacity: 0; }
+}
+
 .power-panel { display: flex; flex-direction: column; gap: 4px; padding: 4px 0; }
 
 /* ===== S-Meter — horizontal bars with S-unit labels ===== */

--- a/zeus-web/src/styles/tokens.css
+++ b/zeus-web/src/styles/tokens.css
@@ -127,6 +127,79 @@
   --immersive-tx:        #ef6b54;
   --immersive-tx-glow:   rgba(239,107,84,0.45);
 
+  /* ----- High-end meter render surfaces (presentation-only) -----
+     Glow / glass / specular surfaces for the shared SVG meter render kit
+     (components/meters/render). These encode the "bloom-behind-crisp +
+     warm-lamp + glowing-peak" idiom so the flat DOM meters (SMeter,
+     MicMeter, TxStageMeters) and the analog dial read as the same lit
+     instrument cluster as BigArc / VuColumn. No existing token VALUE is
+     changed — palette meaning is preserved; these are new names so no raw
+     hex leaks into the components. Each has a light-theme counterpart in
+     the :root[data-theme="light"] block (the warm blooms must go
+     transparent on the silver chassis, the needle highlight must flip). */
+  /* Faint top-to-bottom glass sheen laid over a bar fill — a domed-glass
+     highlight that fades to nothing across the bar height. */
+  --meter-glass-top: rgba(255,255,255,0.16);
+  --meter-glass-bot: rgba(255,255,255,0.00);
+  /* Soft bloom alpha applied to the blurred under-copy of DOM bar fills,
+     mirroring the SVG BloomFill opacity used by the immersive gauges. */
+  --meter-fill-bloom: 0.85;
+  /* Analog-needle Lambert/specular vocabulary faked in SVG: a thin bright
+     hairline along one blade edge, a shadow on the other. */
+  --needle-spec:    rgba(255,250,220,0.85);
+  --needle-bevel-hi: rgba(255,252,236,0.55);
+  --needle-bevel-lo: rgba(0,0,0,0.42);
+
+  /* ----- DRAMATIC instrument stack (presentation-only) -----
+     The five-layer "lit instrument behind curved glass, machined into a
+     metal chassis" recipe — the SVG/CSS analogue of the WebGL waterfall's
+     upper-left light + Lambert + specular + rim + glow. New names only; NO
+     existing token VALUE changed and palette MEANING is preserved (amber
+     #FFA028 = signal-strength only, --accent = S-meter arc, --tx = needle,
+     --power = output/tip). Each has a light-theme counterpart below. */
+  /* (1) RECESSED METALLIC WELL — concave machined pocket floor → rim. */
+  --meter-well-floor: #07080a;
+  --meter-well-edge:  #1b1d22;
+  /* (2) VOLUMETRIC FILL — vertical cylinder gradient under the hue ramp. */
+  --meter-fill-base:  rgba(0,0,0,0.55);
+  --meter-fill-hot:   rgba(255,255,255,0.42);
+  --meter-fill-glow:  rgba(255,196,96,0.55);
+  /* (3) SPECULAR GLASS — domed highlight ellipse + drifting sheen band. */
+  --meter-glass-dome: rgba(255,255,255,0.28);
+  --meter-sheen:      rgba(255,255,255,0.30);
+  --meter-sheen-soft: rgba(255,255,255,0.10);
+  /* (4) BEVELED METALLIC BEZEL RING — chrome frame, TL light / BR dark. */
+  --meter-bezel-hi:   rgba(255,252,244,0.55);
+  --meter-bezel-lo:   rgba(0,0,0,0.72);
+  --meter-bezel-ring: rgba(255,255,255,0.10);
+  /* whole-gauge additive bloom tint. */
+  --gauge-glow:       rgba(255,176,72,0.16);
+
+  /* ----- COMPACT-BAR instrument variants (presentation-only) -----
+     The five-layer stack tuned for the small/dense TX-stage VU columns and
+     the SWR/PWR arcs. At ~16px column width + 6-up packing the default
+     --meter-* depth cues compress to subtlety, so these *-sm/* arc variants
+     push the glass specular, bezel highlight and fill glow brighter so the
+     instrument tells survive at small size. NEW names only — no existing
+     token VALUE is changed; light-theme counterparts live in the light block
+     below. */
+  /* Brighter domed-glass specular for the thin VU columns. */
+  --meter-glass-dome-sm: rgba(255,255,255,0.40);
+  --meter-sheen-sm:      rgba(255,255,255,0.42);
+  /* Stronger machined-chrome highlight for the small bezel ring. */
+  --meter-bezel-hi-sm:   rgba(255,253,247,0.78);
+  /* Vivid leading-edge glow on the live fill tip of a VU column. */
+  --vu-edge-good:        #6cf0b8;
+  --vu-edge-warn:        #ffd277;
+  --vu-edge-hot:         #ff7d63;
+  /* Soft white-screen lift over the green floor so a quiet bar still glows. */
+  --vu-floor-lift:       rgba(255,255,255,0.10);
+  /* SWR danger-zone band painted under the fill past 2.0:1. */
+  --arc-danger-band:     rgba(239,107,84,0.16);
+  --arc-danger-band-hot: rgba(239,107,84,0.34);
+  /* Recessed arc channel — a deeper inset core inside the track stroke. */
+  --arc-channel-core:    rgba(0,0,0,0.55);
+
   /* Warm "lamp glow" palette — pale-cream / soft-yellow tones used to
      light gauge faces, ticks, labels, needles, and active state pills
      on the immersive meters and the RF2K-S amplifier panel. The signal
@@ -333,6 +406,50 @@ html[data-fonts="geist"] { --font-sans: 'Inter', sans-serif; --font-mono: 'JetBr
      dark-theme white rim vanishes here — see comment in :root). */
   --immersive-arc-track-rim:    rgba(40, 45, 52, 0.18);
   --immersive-arc-track-shadow: rgba(40, 45, 52, 0.42);
+
+  /* High-end meter render surfaces — light-theme counterparts. The warm
+     blooms wash to muddy grey on silver, so the glass sheen stays subtle
+     and the needle highlight flips to a cool steel hairline + darker bevel
+     so it reads on the bright chassis. */
+  --meter-glass-top: rgba(255,255,255,0.45);
+  --meter-glass-bot: rgba(255,255,255,0.00);
+  --meter-fill-bloom: 0.55;
+  --needle-spec:    rgba(255,255,255,0.85);
+  --needle-bevel-hi: rgba(255,255,255,0.65);
+  --needle-bevel-lo: rgba(20, 24, 30, 0.30);
+
+  /* DRAMATIC instrument stack — light-theme counterparts. The wells stay
+     dark (display surfaces are dark even on the silver chassis), but the
+     bezel flips to a brushed-silver edge pair, the glass dome / sheen go
+     brighter white, and the gauge bloom washes nearly transparent so the
+     warm dark-tuned values don't read muddy on silver. */
+  --meter-well-floor: #14171c;
+  --meter-well-edge:  #2c3138;
+  --meter-fill-base:  rgba(0,0,0,0.45);
+  --meter-fill-hot:   rgba(255,255,255,0.55);
+  --meter-fill-glow:  rgba(255,196,96,0.40);
+  --meter-glass-dome: rgba(255,255,255,0.42);
+  --meter-sheen:      rgba(255,255,255,0.45);
+  --meter-sheen-soft: rgba(255,255,255,0.16);
+  --meter-bezel-hi:   rgba(255,255,255,0.85);
+  --meter-bezel-lo:   rgba(60, 66, 74, 0.55);
+  --meter-bezel-ring: rgba(40, 45, 52, 0.22);
+  --gauge-glow:       rgba(255,176,72,0.06);
+
+  /* COMPACT-BAR instrument variants — light-theme counterparts. The VU
+     wells stay dark (display surfaces), so the brighter specular/edge cues
+     carry over; only the bezel highlight cools to a brushed-silver edge and
+     the danger band softens slightly on the bright chassis. */
+  --meter-glass-dome-sm: rgba(255,255,255,0.50);
+  --meter-sheen-sm:      rgba(255,255,255,0.52);
+  --meter-bezel-hi-sm:   rgba(255,255,255,0.92);
+  --vu-edge-good:        #6cf0b8;
+  --vu-edge-warn:        #ffd277;
+  --vu-edge-hot:         #ff7d63;
+  --vu-floor-lift:       rgba(255,255,255,0.12);
+  --arc-danger-band:     rgba(239,107,84,0.14);
+  --arc-danger-band-hot: rgba(239,107,84,0.30);
+  --arc-channel-core:    rgba(0,0,0,0.45);
 }
 
 /* ===========================================================


### PR DESCRIPTION
Premium 'instrument' rendering across every moving meter (S-meter, TX immersive meters, analog dial, mic meter) + a shared **60Hz display-side glide** so needles/bars move liquid-smooth. Built via a 3-pass Opus team against Doug's 'blow me away' direction.

- **Look:** five-layer stack — recessed machined well, volumetric gradient fill, specular glass dome + drifting sheen, metallic bezel, glowing peak. TX panel: mic/lev/alc grouped as PK+AVG instruments; PWR/SWR arcs get chrome bezels, glass, a glowing head-pip, and an SWR danger band (2.0→3.0:1).
- **Motion:** one shared rAF, critically-damped spring (subtle rise-overshoot, smooth decay); **peak-hold stays INSTANT** (bypasses the glide); parks byte-exact.
- **Safety:** display-only — 20 files all under `zeus-web/`; position math + ballistics/value hooks byte-identical; **no backend/TX/IQ/DSP/WDSP/PureSignal**. Token-only (additive; no existing token value changed). eslint clean, tsc+vite green, 40/40 meter tests pass.

New shared render kit under `components/meters/render/`. Visuals approved by Doug (KB2UKA) live on G2.