### PR TITLE
feat(vfo): high-end VFO + complete VFO lock — DRAFT, review in AM

### DIFF
--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -693,6 +693,16 @@ export function setRadioLo(
   hz: number,
   signal?: AbortSignal,
 ): Promise<RadioStateDto> {
+  // VFO-lock gate — same backstop as setVfo. The ruler / LO pan
+  // (use-ruler-pan-gesture.ts, the ONLY caller of setRadioLo) shifts the
+  // hardware NCO center; with the dial pinned that must no-op too, or the
+  // operator could drag the radio off frequency via the ruler even though
+  // the digits are locked. Re-fetch canonical state so the caller's
+  // applyState rolls back its optimistic radioLoHz write. This is an RX
+  // tuning endpoint with no internal/TX caller — it cannot affect TX/PS.
+  if (vfoLockStore.getState().locked) {
+    return fetchState(signal);
+  }
   return jsonFetch(
     '/api/radio/lo',
     {

--- a/zeus-web/src/components/BandButtons.tsx
+++ b/zeus-web/src/components/BandButtons.tsx
@@ -52,6 +52,7 @@ import {
   type RxMode,
 } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import { useVfoLockStore } from '../state/vfo-lock-store';
 import { BANDS, bandOf } from './design/data';
 import { toolbarFavDragMime } from './toolbar/ToolbarFavorites';
 
@@ -129,6 +130,10 @@ export function BandButtons() {
 
   const selectBand = useCallback(
     (band: BandEntry) => {
+      // VFO locked — a band button must not retune. setVfo is the backstop,
+      // but bailing here keeps the active-band highlight + the optimistic
+      // vfoHz/mode writes from flashing for one reconcile cycle.
+      if (useVfoLockStore.getState().locked) return;
       const stored = memoryRef.current.get(band.name);
       const targetHz = stored?.hz ?? band.centerHz;
       const targetMode: RxMode | null = stored?.mode ?? null;

--- a/zeus-web/src/components/SpotOverlay.tsx
+++ b/zeus-web/src/components/SpotOverlay.tsx
@@ -15,6 +15,7 @@ import { setVfo } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
 import { useDisplayStore } from '../state/display-store';
 import { useSpotStore } from '../state/spot-store';
+import { useVfoLockStore } from '../state/vfo-lock-store';
 
 // Convert a packed ARGB uint32 to a CSS rgba() string.
 // TCI clients commonly send A=0 meaning "default/opaque" rather than
@@ -40,6 +41,11 @@ export function SpotOverlay() {
 
   const handleSpotClick = useCallback(
     (freqHz: number) => {
+      // VFO locked — a spot click must not jump the dial. setVfo is the
+      // authoritative backstop, but bailing here avoids the optimistic vfoHz
+      // write + the rollback-fetch round-trip that would otherwise flash the
+      // readout to the spot for one poll cycle.
+      if (useVfoLockStore.getState().locked) return;
       useConnectionStore.setState({ vfoHz: freqHz });
       setVfo(freqHz)
         .then((s) => useConnectionStore.getState().applyState(s))

--- a/zeus-web/src/components/VfoDisplay.tsx
+++ b/zeus-web/src/components/VfoDisplay.tsx
@@ -114,9 +114,6 @@ function parseKhzInput(raw: string): number | null {
   return clampHz(Math.round(khz * 1000));
 }
 
-function formatKhz(hz: number): string {
-  return (hz / 1000).toFixed(3);
-}
 
 // Per-digit wheel tuning debounce. Wheel events fire at ~60 Hz during a spin;
 // we update the store (and therefore the display) on every tick for instant

--- a/zeus-web/src/components/VfoDisplay.tsx
+++ b/zeus-web/src/components/VfoDisplay.tsx
@@ -41,6 +41,23 @@
 //
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
+//
+// ── PREMIUM MACHINED-INSTRUMENT VFO ──────────────────────────────────────
+// The frequency readout is rendered as a real machined instrument using the
+// SAME five-layer render kit as the loved S-meter (components/meters/render/),
+// not a flat glow card:
+//   (1) recessed well behind the digits (recessedWell)         — the pocket,
+//   (2) a top-sheen band over the well (CSS pseudo-element)     — cylindrical depth,
+//   (3) GlassDome SVG over the readout                          — wet-glass specular,
+//   (4) GaugeBezel rect ring around the readout                — machined chrome frame,
+//   (5) lit/dim per-decade digits (two-tone lamp)              — the hero.
+// All token-driven (--vfo-* aliases of the --meter-*/--immersive-lamp-* kit)
+// and GPU-cheap: only the existing compositor-only .meter-sheen-drift sheen
+// animates (reduced-motion already drops it). DISPLAY-ONLY — no value pipeline
+// is touched here.
+//
+// The two SVG overlays are pointer-events:none so they never block the digit
+// click / wheel handlers underneath.
 
 import {
   Fragment,
@@ -53,6 +70,10 @@ import {
 } from 'react';
 import { fetchState, setVfo } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import { useVfoLockStore } from '../state/vfo-lock-store';
+import { GlassDome } from './meters/render/GlassDome';
+import { GaugeBezel } from './meters/render/GaugeBezel';
+import { recessedWell } from './meters/render/recessedWell';
 
 const MAX_HZ = 60_000_000;
 const STATE_POLL_MS = 2000;
@@ -102,9 +123,73 @@ function formatKhz(hz: number): string {
 // feedback, but only POST the last resting value to avoid flooding /api/vfo.
 const WHEEL_DEBOUNCE_MS = 80;
 
-export function VfoDisplay() {
+// ── lock padlock glyph ───────────────────────────────────────────────────
+// Identical open/closed inline-SVG padlock to the mobile shell's
+// VfoLockButton (mobile/MobileApp.tsx) so mobile + desktop read the same. Both
+// drive the one shared vfo-lock-store, so the lock state is unified.
+function LockGlyph({ locked }: { locked: boolean }) {
+  return locked ? (
+    <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden>
+      <rect x="5" y="11" width="14" height="9" rx="1.5" fill="currentColor" />
+      <path
+        d="M8 11V8a4 4 0 0 1 8 0v3"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </svg>
+  ) : (
+    <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden>
+      <rect x="5" y="11" width="14" height="9" rx="1.5" fill="currentColor" />
+      <path
+        d="M8 11V8a4 4 0 0 1 7.5-2"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+// Desktop VFO-lock toggle — pins the dial so no path (digit click/type/scroll,
+// keyboard, pan/ruler, panadapter click-to-tune, band retune) can change the
+// frequency until unlocked. Bound to the same shared store as the mobile
+// padlock; the gate itself lives in api/client.setVfo + setRadioLo and the
+// per-path guards.
+function VfoLockButton() {
+  const locked = useVfoLockStore((s) => s.locked);
+  const toggle = useVfoLockStore((s) => s.toggle);
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-pressed={locked}
+      aria-label={locked ? 'VFO locked — click to unlock' : 'VFO unlocked — click to lock'}
+      title={locked ? 'VFO locked — click to unlock' : 'Lock VFO (no path can retune while locked)'}
+      className={`vfo-lock-btn ${locked ? 'on' : ''}`}
+    >
+      <LockGlyph locked={locked} />
+      <span className="vfo-lock-lbl">{locked ? 'LOCKED' : 'LOCK'}</span>
+    </button>
+  );
+}
+
+type VfoDisplayProps = {
+  /** Header label. Defaults to "VFO A". (Prop preserved from Christiano's
+   *  fork superset so a future RX2 readout inherits the premium look for
+   *  free; VFO-B store plumbing is not present in this tree yet.) */
+  label?: string;
+  /** Compact variant — scales the bezel / well / digit gap down for a dense
+   *  RX2 / narrow placement while keeping the full machined-instrument stack. */
+  compact?: boolean;
+};
+
+export function VfoDisplay({ label = 'VFO A', compact = false }: VfoDisplayProps = {}) {
   const vfoHz = useConnectionStore((s) => s.vfoHz);
   const applyState = useConnectionStore((s) => s.applyState);
+  const locked = useVfoLockStore((s) => s.locked);
 
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState('');
@@ -142,9 +227,13 @@ export function VfoDisplay() {
   }, [applyState, editing]);
 
   const beginEdit = useCallback(() => {
-    setDraft(formatKhz(vfoHz));
+    // VFO locked — block edit entry entirely; the typed-entry field never opens.
+    if (useVfoLockStore.getState().locked) return;
+    // Start EMPTY so the operator types the whole frequency fresh (no pre-filled
+    // value or decimals to edit around) — matches the old VFO entry feel.
+    setDraft('');
     setEditing(true);
-  }, [vfoHz]);
+  }, []);
 
   const cancelEdit = useCallback(() => {
     setEditing(false);
@@ -152,6 +241,13 @@ export function VfoDisplay() {
   }, []);
 
   const commitEdit = useCallback(() => {
+    // VFO locked — discard the typed entry (defensive; beginEdit already
+    // refuses to open the field while locked).
+    if (useVfoLockStore.getState().locked) {
+      setEditing(false);
+      setDraft('');
+      return;
+    }
     const next = parseKhzInput(draft);
     setEditing(false);
     setDraft('');
@@ -203,6 +299,10 @@ export function VfoDisplay() {
     const el = digitsContainerRef.current;
     if (!el || editing) return;
     const handler = (e: WheelEvent) => {
+      // VFO locked — wheel-step tuning no-ops. We still preventDefault on a
+      // digit so the page doesn't scroll under a locked digit, matching the
+      // unlocked feel; we just don't move the dial.
+      const lockedNow = useVfoLockStore.getState().locked;
       const target = e.target as Element | null;
       const digit = target?.closest<HTMLElement>('[data-decade]');
       if (!digit || !el.contains(digit)) return;
@@ -211,6 +311,7 @@ export function VfoDisplay() {
       const decade = Number.parseInt(decadeAttr, 10);
       if (!Number.isFinite(decade) || decade <= 0) return;
       e.preventDefault();
+      if (lockedNow) return;
 
       const direction = e.deltaY < 0 ? 1 : -1;
       const current = useConnectionStore.getState().vfoHz;
@@ -247,70 +348,131 @@ export function VfoDisplay() {
 
   const digits = useMemo(() => DIGIT_PLACES, []);
 
+  // Track the rendered readout-face size so the SVG overlays (GlassDome +
+  // GaugeBezel) use a viewBox matched to the pixel rect — keeps the bezel rx /
+  // thickness proportional and the dome ellipse centred regardless of the
+  // container-query font clamp. nonScaling strokes keep the chrome crisp under
+  // the preserveAspectRatio="none" stretch.
+  const readoutRef = useRef<HTMLDivElement | null>(null);
+  const [readoutSize, setReadoutSize] = useState({ w: 320, h: 96 });
+  useEffect(() => {
+    const el = readoutRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver((entries) => {
+      const r = entries[0]?.contentRect;
+      if (!r) return;
+      const w = Math.max(8, Math.round(r.width));
+      const h = Math.max(8, Math.round(r.height));
+      setReadoutSize((prev) => (prev.w === w && prev.h === h ? prev : { w, h }));
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const { w: vbW, h: vbH } = readoutSize;
+  const bezelRx = compact ? 5 : 7;
+  const bezelThick = compact ? 2.4 : 3.2;
+
   return (
-    <div className="freq-display">
-      {editing ? (
-        <div className="freq-digits mono" style={{ gap: 6 }}>
-          <input
-            ref={inputRef}
-            type="text"
-            inputMode="decimal"
-            value={draft}
-            onChange={(e) => setDraft(e.target.value)}
-            onKeyDown={onKeyDown}
-            onBlur={cancelEdit}
-            aria-label="Frequency in kHz"
-            style={{
-              width: 220,
-              background: 'transparent',
-              border: 'none',
-              borderBottom: '1px solid var(--accent)',
-              outline: 'none',
-              color: 'var(--fg-0)',
-              fontFamily: 'inherit',
-              fontSize: 'inherit',
-              fontWeight: 700,
-            }}
-            placeholder="kHz"
-          />
-          <span className="label-xs" style={{ alignSelf: 'center' }}>
-            kHz
-          </span>
-        </div>
-      ) : (
-        <button
-          ref={digitsContainerRef}
-          type="button"
-          onClick={beginEdit}
-          aria-label="Edit frequency"
-          title="Click to enter frequency in kHz — scroll the wheel over a digit to tune it"
-          className="freq-digits mono"
-          style={{ background: 'none', border: 'none', cursor: 'text', width: '100%' }}
+    <div
+      className={`freq-display${compact ? ' compact' : ''}${locked ? ' locked' : ''}`}
+    >
+      <div className="freq-head">
+        <span className="label-xs freq-head-lbl">{label}</span>
+        <VfoLockButton />
+      </div>
+
+      {/* The machined readout face — recessed well (layer 1) + CSS top-sheen
+          (layer 2, ::before) carry the pocket + cylindrical depth. The two SVG
+          overlays (layers 3+4) sit on top, pointer-events:none. The digits
+          (layer 5) render LAST in DOM so they receive the click / wheel. */}
+      <div className="freq-readout" ref={readoutRef} style={recessedWell({ radius: bezelRx })}>
+        <svg
+          className="freq-instrument"
+          viewBox={`0 0 ${vbW} ${vbH}`}
+          preserveAspectRatio="none"
+          aria-hidden
         >
-          {digits.map((place) => {
-            const d = digitAt(vfoHz, place.decade);
-            const isLeading = vfoHz < place.decade;
-            return (
-              <Fragment key={place.decade}>
-                <span
-                  className={`digit ${isLeading ? 'leading' : ''}`}
-                  data-decade={place.decade}
-                  style={{ cursor: 'ns-resize' }}
-                >
-                  {d}
-                </span>
-                {place.separatorAfter && (
-                  <span aria-hidden className="sep">
-                    {place.separatorAfter}
+          {/* (3) wet-glass specular dome + drifting sheen over the readout */}
+          <GlassDome defsId="vfo" x={0} y={0} width={vbW} height={vbH} rx={bezelRx} />
+          {/* (4) machined chrome bezel ring framing the readout */}
+          <GaugeBezel
+            variant="rect"
+            defsId="vfo"
+            x={0}
+            y={0}
+            width={vbW}
+            height={vbH}
+            rx={bezelRx}
+            thickness={bezelThick}
+            nonScaling
+          />
+        </svg>
+
+        {locked && (
+          <span className="freq-lock-mark" aria-hidden title="VFO locked">
+            <LockGlyph locked />
+          </span>
+        )}
+
+        {editing ? (
+          <div className="freq-digits mono" style={{ gap: compact ? 3 : 6 }}>
+            <input
+              ref={inputRef}
+              type="text"
+              inputMode="decimal"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={onKeyDown}
+              onBlur={cancelEdit}
+              aria-label={`${label} frequency in kHz`}
+              className="freq-edit-input"
+              placeholder="kHz"
+            />
+            <span className="label-xs freq-edit-unit">kHz</span>
+          </div>
+        ) : (
+          <button
+            ref={digitsContainerRef}
+            type="button"
+            onClick={beginEdit}
+            aria-label="Edit frequency"
+            title={
+              locked
+                ? 'VFO locked — unlock to tune'
+                : 'Click to enter frequency in kHz — scroll the wheel over a digit to tune it'
+            }
+            className="freq-digits mono freq-digits-btn"
+          >
+            {digits.map((place) => {
+              const d = digitAt(vfoHz, place.decade);
+              const isLeading = vfoHz < place.decade;
+              return (
+                <Fragment key={place.decade}>
+                  <span
+                    className={`digit ${isLeading ? 'leading' : ''}`}
+                    data-decade={place.decade}
+                  >
+                    {d}
                   </span>
-                )}
-              </Fragment>
-            );
-          })}
-        </button>
-      )}
-      <div className="freq-bot" style={{ justifyContent: 'flex-end', gap: 6, marginTop: 4 }}>
-        <span className="label-xs">MHz · click to type · wheel on a digit to step</span>
+                  {place.separatorAfter && (
+                    <span aria-hidden className="sep">
+                      {place.separatorAfter}
+                    </span>
+                  )}
+                </Fragment>
+              );
+            })}
+          </button>
+        )}
+      </div>
+
+      <div className="freq-bot">
+        <span className="label-xs">
+          {locked
+            ? 'LOCKED — unlock to tune'
+            : 'MHz · click to type · wheel on a digit to step'}
+        </span>
       </div>
     </div>
   );

--- a/zeus-web/src/components/VfoDisplay.tsx
+++ b/zeus-web/src/components/VfoDisplay.tsx
@@ -42,22 +42,13 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 //
-// ── PREMIUM MACHINED-INSTRUMENT VFO ──────────────────────────────────────
-// The frequency readout is rendered as a real machined instrument using the
-// SAME five-layer render kit as the loved S-meter (components/meters/render/),
-// not a flat glow card:
-//   (1) recessed well behind the digits (recessedWell)         — the pocket,
-//   (2) a top-sheen band over the well (CSS pseudo-element)     — cylindrical depth,
-//   (3) GlassDome SVG over the readout                          — wet-glass specular,
-//   (4) GaugeBezel rect ring around the readout                — machined chrome frame,
-//   (5) lit/dim per-decade digits (two-tone lamp)              — the hero.
-// All token-driven (--vfo-* aliases of the --meter-*/--immersive-lamp-* kit)
-// and GPU-cheap: only the existing compositor-only .meter-sheen-drift sheen
-// animates (reduced-motion already drops it). DISPLAY-ONLY — no value pipeline
-// is touched here.
-//
-// The two SVG overlays are pointer-events:none so they never block the digit
-// click / wheel handlers underneath.
+// ── VFO readout ──────────────────────────────────────────────────────────
+// The original blue-aurora glow card (big thin digits, soft electric-blue
+// bloom) with a little extra rendering polish, plus the VFO LOCK: a toggle
+// that pins the dial so NO path — digit click/type/scroll, keyboard, pan /
+// ruler drag, panadapter click-to-tune, band retune, TCI spot — can change
+// the frequency until unlocked. DISPLAY + freq-set-gate only; no TX / IQ /
+// DSP / PureSignal path is touched here.
 
 import {
   Fragment,
@@ -71,9 +62,6 @@ import {
 import { fetchState, setVfo } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
 import { useVfoLockStore } from '../state/vfo-lock-store';
-import { GlassDome } from './meters/render/GlassDome';
-import { GaugeBezel } from './meters/render/GaugeBezel';
-import { recessedWell } from './meters/render/recessedWell';
 
 const MAX_HZ = 60_000_000;
 const STATE_POLL_MS = 2000;
@@ -114,7 +102,6 @@ function parseKhzInput(raw: string): number | null {
   return clampHz(Math.round(khz * 1000));
 }
 
-
 // Per-digit wheel tuning debounce. Wheel events fire at ~60 Hz during a spin;
 // we update the store (and therefore the display) on every tick for instant
 // feedback, but only POST the last resting value to avoid flooding /api/vfo.
@@ -126,7 +113,7 @@ const WHEEL_DEBOUNCE_MS = 80;
 // drive the one shared vfo-lock-store, so the lock state is unified.
 function LockGlyph({ locked }: { locked: boolean }) {
   return locked ? (
-    <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden>
+    <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden>
       <rect x="5" y="11" width="14" height="9" rx="1.5" fill="currentColor" />
       <path
         d="M8 11V8a4 4 0 0 1 8 0v3"
@@ -137,7 +124,7 @@ function LockGlyph({ locked }: { locked: boolean }) {
       />
     </svg>
   ) : (
-    <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden>
+    <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden>
       <rect x="5" y="11" width="14" height="9" rx="1.5" fill="currentColor" />
       <path
         d="M8 11V8a4 4 0 0 1 7.5-2"
@@ -174,12 +161,9 @@ function VfoLockButton() {
 }
 
 type VfoDisplayProps = {
-  /** Header label. Defaults to "VFO A". (Prop preserved from Christiano's
-   *  fork superset so a future RX2 readout inherits the premium look for
-   *  free; VFO-B store plumbing is not present in this tree yet.) */
+  /** ARIA label for the readout. Defaults to "VFO A". */
   label?: string;
-  /** Compact variant — scales the bezel / well / digit gap down for a dense
-   *  RX2 / narrow placement while keeping the full machined-instrument stack. */
+  /** Compact variant — scales the digits down for a dense / narrow placement. */
   compact?: boolean;
 };
 
@@ -286,12 +270,10 @@ export function VfoDisplay({ label = 'VFO A', compact = false }: VfoDisplayProps
   // rather than a React `onWheel` JSX prop. React 17+ delegates wheel events
   // through a root-level passive listener, which means `e.preventDefault()`
   // inside a synthetic onWheel handler is silently ignored — letting the
-  // ancestor `.freq-panel` (overflow:auto, see layout/panels/VfoPanel.tsx) and
-  // any other scrollable parent perform their default scroll. Compare the
-  // canonical pattern at `util/use-pan-tune-gesture.ts:307` (panadapter zoom).
-  // Event-delegated on the digits container: wheel over a `[data-decade]`
-  // span is consumed; wheel over a separator or padding is left alone so the
-  // outer page can still scroll naturally.
+  // ancestor `.freq-panel` (overflow:auto) and any other scrollable parent
+  // perform their default scroll. Event-delegated on the digits container:
+  // wheel over a `[data-decade]` span is consumed; wheel over a separator or
+  // padding is left alone so the outer page can still scroll naturally.
   useEffect(() => {
     const el = digitsContainerRef.current;
     if (!el || editing) return;
@@ -345,126 +327,61 @@ export function VfoDisplay({ label = 'VFO A', compact = false }: VfoDisplayProps
 
   const digits = useMemo(() => DIGIT_PLACES, []);
 
-  // Track the rendered readout-face size so the SVG overlays (GlassDome +
-  // GaugeBezel) use a viewBox matched to the pixel rect — keeps the bezel rx /
-  // thickness proportional and the dome ellipse centred regardless of the
-  // container-query font clamp. nonScaling strokes keep the chrome crisp under
-  // the preserveAspectRatio="none" stretch.
-  const readoutRef = useRef<HTMLDivElement | null>(null);
-  const [readoutSize, setReadoutSize] = useState({ w: 320, h: 96 });
-  useEffect(() => {
-    const el = readoutRef.current;
-    if (!el || typeof ResizeObserver === 'undefined') return;
-    const ro = new ResizeObserver((entries) => {
-      const r = entries[0]?.contentRect;
-      if (!r) return;
-      const w = Math.max(8, Math.round(r.width));
-      const h = Math.max(8, Math.round(r.height));
-      setReadoutSize((prev) => (prev.w === w && prev.h === h ? prev : { w, h }));
-    });
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, []);
-
-  const { w: vbW, h: vbH } = readoutSize;
-  const bezelRx = compact ? 5 : 7;
-  const bezelThick = compact ? 2.4 : 3.2;
-
   return (
-    <div
-      className={`freq-display${compact ? ' compact' : ''}${locked ? ' locked' : ''}`}
-    >
-      <div className="freq-head">
-        <span className="label-xs freq-head-lbl">{label}</span>
-        <VfoLockButton />
-      </div>
-
-      {/* The machined readout face — recessed well (layer 1) + CSS top-sheen
-          (layer 2, ::before) carry the pocket + cylindrical depth. The two SVG
-          overlays (layers 3+4) sit on top, pointer-events:none. The digits
-          (layer 5) render LAST in DOM so they receive the click / wheel. */}
-      <div className="freq-readout" ref={readoutRef} style={recessedWell({ radius: bezelRx })}>
-        <svg
-          className="freq-instrument"
-          viewBox={`0 0 ${vbW} ${vbH}`}
-          preserveAspectRatio="none"
-          aria-hidden
-        >
-          {/* (3) wet-glass specular dome + drifting sheen over the readout */}
-          <GlassDome defsId="vfo" x={0} y={0} width={vbW} height={vbH} rx={bezelRx} />
-          {/* (4) machined chrome bezel ring framing the readout */}
-          <GaugeBezel
-            variant="rect"
-            defsId="vfo"
-            x={0}
-            y={0}
-            width={vbW}
-            height={vbH}
-            rx={bezelRx}
-            thickness={bezelThick}
-            nonScaling
+    <div className={`freq-display${compact ? ' compact' : ''}${locked ? ' locked' : ''}`}>
+      {editing ? (
+        <div className="freq-digits mono" style={{ gap: compact ? 3 : 6 }}>
+          <input
+            ref={inputRef}
+            type="text"
+            inputMode="decimal"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={onKeyDown}
+            onBlur={cancelEdit}
+            aria-label={`${label} frequency in kHz`}
+            className="freq-edit-input"
+            placeholder="kHz"
           />
-        </svg>
-
-        {locked && (
-          <span className="freq-lock-mark" aria-hidden title="VFO locked">
-            <LockGlyph locked />
-          </span>
-        )}
-
-        {editing ? (
-          <div className="freq-digits mono" style={{ gap: compact ? 3 : 6 }}>
-            <input
-              ref={inputRef}
-              type="text"
-              inputMode="decimal"
-              value={draft}
-              onChange={(e) => setDraft(e.target.value)}
-              onKeyDown={onKeyDown}
-              onBlur={cancelEdit}
-              aria-label={`${label} frequency in kHz`}
-              className="freq-edit-input"
-              placeholder="kHz"
-            />
-            <span className="label-xs freq-edit-unit">kHz</span>
-          </div>
-        ) : (
-          <button
-            ref={digitsContainerRef}
-            type="button"
-            onClick={beginEdit}
-            aria-label="Edit frequency"
-            title={
-              locked
-                ? 'VFO locked — unlock to tune'
-                : 'Click to enter frequency in kHz — scroll the wheel over a digit to tune it'
-            }
-            className="freq-digits mono freq-digits-btn"
-          >
-            {digits.map((place) => {
-              const d = digitAt(vfoHz, place.decade);
-              const isLeading = vfoHz < place.decade;
-              return (
-                <Fragment key={place.decade}>
-                  <span
-                    className={`digit ${isLeading ? 'leading' : ''}`}
-                    data-decade={place.decade}
-                  >
-                    {d}
+          <span className="label-xs freq-edit-unit">kHz</span>
+        </div>
+      ) : (
+        <button
+          ref={digitsContainerRef}
+          type="button"
+          onClick={beginEdit}
+          aria-label={`Edit ${label} frequency`}
+          title={
+            locked
+              ? 'VFO locked — unlock to tune'
+              : 'Click to enter frequency in kHz — scroll the wheel over a digit to tune it'
+          }
+          className="freq-digits mono freq-digits-btn"
+        >
+          {digits.map((place) => {
+            const d = digitAt(vfoHz, place.decade);
+            const isLeading = vfoHz < place.decade;
+            return (
+              <Fragment key={place.decade}>
+                <span
+                  className={`digit ${isLeading ? 'leading' : ''}`}
+                  data-decade={place.decade}
+                >
+                  {d}
+                </span>
+                {place.separatorAfter && (
+                  <span aria-hidden className="sep">
+                    {place.separatorAfter}
                   </span>
-                  {place.separatorAfter && (
-                    <span aria-hidden className="sep">
-                      {place.separatorAfter}
-                    </span>
-                  )}
-                </Fragment>
-              );
-            })}
-          </button>
-        )}
-      </div>
+                )}
+              </Fragment>
+            );
+          })}
+        </button>
+      )}
 
       <div className="freq-bot">
+        <VfoLockButton />
         <span className="label-xs">
           {locked
             ? 'LOCKED — unlock to tune'

--- a/zeus-web/src/components/toolbar/BandFavorites.tsx
+++ b/zeus-web/src/components/toolbar/BandFavorites.tsx
@@ -15,6 +15,7 @@ import {
   type RxMode,
 } from '../../api/client';
 import { useConnectionStore } from '../../state/connection-store';
+import { useVfoLockStore } from '../../state/vfo-lock-store';
 import { BANDS, bandOf } from '../design/data';
 import { ToolbarFavorites, type ToolbarOption } from './ToolbarFavorites';
 
@@ -80,6 +81,9 @@ export function BandFavorites() {
     (key: string) => {
       const band = HF_BANDS.find((b) => b.name === key);
       if (!band) return;
+      // VFO locked — a favourite-band tap must not retune. Mirrors the
+      // BandButtons / setVfo backstop; bailing avoids the optimistic write.
+      if (useVfoLockStore.getState().locked) return;
       const stored = memoryRef.current.get(band.name);
       const targetHz = stored?.hz ?? band.centerHz;
       const targetMode: RxMode | null = stored?.mode ?? null;

--- a/zeus-web/src/state/vfo-lock-store.ts
+++ b/zeus-web/src/state/vfo-lock-store.ts
@@ -10,6 +10,7 @@
 // the gate without introducing a circular import.
 
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 export type VfoLockState = {
   locked: boolean;
@@ -17,8 +18,23 @@ export type VfoLockState = {
   setLocked: (locked: boolean) => void;
 };
 
-export const useVfoLockStore = create<VfoLockState>((set) => ({
-  locked: false,
-  toggle: () => set((s) => ({ locked: !s.locked })),
-  setLocked: (locked) => set({ locked }),
-}));
+// Persisted to localStorage so the lock survives reloads — an operator who
+// pins the dial expects it to stay pinned until they deliberately unlock,
+// not silently re-arm on a refresh. The public API (locked / toggle /
+// setLocked) is byte-identical to the previous in-memory store, so every
+// reader (api/client.setVfo + setRadioLo, DbScale, WfDbScale, MobileApp,
+// the new desktop VfoLockButton) is untouched. partialize keeps only the
+// boolean — the action closures are recreated on each boot.
+export const useVfoLockStore = create<VfoLockState>()(
+  persist(
+    (set) => ({
+      locked: false,
+      toggle: () => set((s) => ({ locked: !s.locked })),
+      setLocked: (locked) => set({ locked }),
+    }),
+    {
+      name: 'zeus.vfoLock',
+      partialize: (s) => ({ locked: s.locked }),
+    },
+  ),
+);

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -1275,16 +1275,16 @@
   height: 100%;
   min-height: 0;
 }
-/* v3 Lifted Dark — VFO card with pronounced blue aurora behind the digits.
-   Three radial gradients layered over the panel base + a blurred ::before
-   ellipse give the digits a soft bloom of electric blue. */
+/* ── PREMIUM MACHINED-INSTRUMENT VFO ───────────────────────────────────────
+   The VFO readout is a real instrument built from the SAME five-layer kit as
+   the loved S-meter (recessed well + top-sheen + GlassDome + GaugeBezel + lit
+   digits). The old flat blue-aurora glow card is gone. All depth cues are
+   token-driven (--vfo-* aliasing the meter / immersive-lamp kit); the
+   only animation is the existing compositor-only .meter-sheen-drift sheen
+   inside GlassDome (reduced-motion already drops it). */
 .freq-display {
-  padding: 28px 20px 20px;
-  background:
-    radial-gradient(ellipse 55% 95% at 50% 55%, rgba(46,142,255,0.22), transparent 70%),
-    radial-gradient(ellipse 80% 60% at 50% 40%, rgba(46,142,255,0.10), transparent 75%),
-    radial-gradient(ellipse 100% 60% at 50% 110%, rgba(46,142,255,0.06), transparent 70%),
-    var(--bg-1);
+  padding: 14px 16px 12px;
+  background: var(--bg-1);
   border: 1px solid var(--line);
   border-radius: var(--r-lg);
   box-shadow: none;
@@ -1293,49 +1293,207 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+  gap: 8px;
   container-type: size;
   position: relative;
   overflow: hidden;
 }
-.freq-display::before {
+.freq-display.compact { padding: 8px 10px 6px; gap: 5px; }
+
+/* header row — VFO label + the desktop lock toggle. */
+.freq-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-height: 18px;
+}
+.freq-head-lbl { letter-spacing: 0.14em; }
+
+.freq-top, .freq-bot { display: flex; align-items: center; font-size: 10px; }
+.freq-bot { justify-content: flex-end; }
+
+/* (1) recessed-well readout face — recessedWell() spreads the concave floor +
+   machined-pocket inset shadow inline. container-query font clamp stays scoped
+   to .freq-display, so the digits scale with the panel. */
+.freq-readout {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 18px;
+  overflow: hidden;
+}
+.freq-display.compact .freq-readout { padding: 6px 10px; }
+
+/* (2) top-sheen band — a thin cylindrical light band over the well floor for
+   curved-glass depth, under the digits + SVG. Pure CSS, no JS. */
+.freq-readout::before {
   content: "";
   position: absolute;
-  left: 50%; top: 50%;
-  transform: translate(-50%, -50%);
-  width: 60%; height: 80%;
-  background: radial-gradient(ellipse at center, rgba(78,166,255,0.18), transparent 60%);
-  filter: blur(20px);
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(
+    to bottom,
+    var(--meter-glass-top) 0%,
+    var(--meter-glass-bot) 42%
+  );
   pointer-events: none;
+  z-index: 1;
 }
-.freq-display > * { position: relative; z-index: 1; }
-.freq-top, .freq-bot { display: flex; align-items: center; font-size: 10px; }
+
+/* (3)+(4) GlassDome + GaugeBezel SVG overlay — sits above the well + sheen but
+   the digits render LAST in DOM so they take the click / wheel. The SVG is
+   pointer-events:none so it never blocks tuning. */
+.freq-instrument {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 2;
+  overflow: visible;
+}
+
+/* (5) lit/dim digits — Archivo Narrow 600, tabular, the hero. ACTIVE digits
+   are the lit lamp (--vfo-readout) with a lamp bloom; LEADING zeros are the
+   unlit-segment dim tell. */
 .freq-digits {
+  position: relative;
+  z-index: 3;
   display: flex;
   align-items: baseline;
+  /* Restore the old wide digit typography — Archivo Narrow read too condensed /
+     small; the operator wants the big readout back. */
   font-family: var(--font-sans);
-  /* v3: thin 200-weight Inter, white digits, subtle blue text-shadow */
   font-weight: 200;
-  font-size: clamp(38px, 9cqw, 140px);
+  font-size: clamp(40px, 9.5cqw, 150px);
   letter-spacing: -0.025em;
-  color: var(--fg-0);
+  color: var(--vfo-readout);
   font-variant-numeric: tabular-nums;
   line-height: 1.05;
-  margin: 4px 0;
   justify-content: center;
-  text-shadow: 0 0 12px rgba(78,166,255,0.25);
+}
+.freq-display.compact .freq-digits { font-size: clamp(24px, 8cqw, 72px); }
+.freq-digits-btn {
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  cursor: text;
+  width: 100%;
+  padding: 0;
 }
 .freq-digits .digit {
-  background: none; border: none; color: inherit; font: inherit;
+  background: none; border: none; font: inherit;
   padding: 0 1px;
-  cursor: pointer;
+  color: var(--vfo-readout);
+  text-shadow: 0 0 14px var(--vfo-readout-glow), 0 0 4px var(--vfo-readout-glow);
+  cursor: ns-resize;
   transition: color var(--dur-fast), text-shadow var(--dur-fast);
 }
 .freq-digits .digit:hover {
   color: var(--accent);
-  text-shadow: 0 0 10px var(--accent);
+  text-shadow: 0 0 12px var(--accent);
 }
-.freq-digits .digit.leading { color: var(--fg-4); }
-.freq-digits .sep { color: var(--fg-1); padding: 0 1px; font-weight: 200; }
+/* unlit leading zeros — the single biggest realism cue. */
+.freq-digits .digit.leading {
+  color: var(--vfo-digit-dim);
+  text-shadow: none;
+}
+.freq-digits .sep {
+  color: var(--vfo-sep);
+  padding: 0 1px;
+  font-weight: 600;
+}
+
+/* typed-entry field — inherits the lit-lamp readout treatment. */
+.freq-edit-input {
+  width: 220px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--accent);
+  outline: none;
+  color: var(--vfo-readout);
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: 600;
+  text-shadow: 0 0 14px var(--vfo-readout-glow);
+}
+.freq-display.compact .freq-edit-input { width: 100%; }
+.freq-edit-unit { align-self: center; }
+
+/* ── LOCKED state ─────────────────────────────────────────────────────────
+   The readout "clicks shut": lit digits + bezel ring tint toward --vfo-lock
+   (red), the active-digit glow dims, digits go cursor:not-allowed, and a lit
+   padlock burns in the corner. */
+.freq-display.locked .freq-readout {
+  box-shadow:
+    inset 0 0 0 1px var(--vfo-lock-glow),
+    inset 0 2px 4px rgba(0,0,0,0.85),
+    inset 0 0 12px rgba(0,0,0,0.5);
+}
+.freq-display.locked .freq-digits .digit {
+  color: var(--vfo-lock);
+  text-shadow: 0 0 6px var(--vfo-lock-glow);
+  cursor: not-allowed;
+}
+.freq-display.locked .freq-digits .digit:hover {
+  color: var(--vfo-lock);
+  text-shadow: 0 0 6px var(--vfo-lock-glow);
+}
+.freq-display.locked .freq-digits .digit.leading {
+  color: var(--vfo-digit-dim);
+  text-shadow: none;
+}
+.freq-display.locked .freq-digits-btn { cursor: not-allowed; }
+.freq-display.locked .freq-instrument { filter: saturate(0.9); }
+
+/* lit padlock burned into the readout corner while locked. */
+.freq-lock-mark {
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  z-index: 4;
+  color: var(--vfo-lock);
+  filter: drop-shadow(0 0 5px var(--vfo-lock-glow)) drop-shadow(0 0 2px var(--vfo-lock-glow));
+  pointer-events: none;
+  display: inline-flex;
+}
+
+/* ── lock toggle button ───────────────────────────────────────────────────
+   Reuses the bezel language (machined-chrome edge) + the --vfo-lock accent
+   when engaged. */
+.vfo-lock-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 8px 2px 6px;
+  border-radius: 6px;
+  border: 1px solid var(--vfo-bezel-ring);
+  background:
+    linear-gradient(135deg, var(--vfo-bezel-hi) 0%, transparent 32%, rgba(0,0,0,0.18) 70%, var(--vfo-bezel-lo) 100%),
+    var(--bg-2);
+  color: var(--fg-2);
+  font-family: 'Archivo Narrow', var(--font-sans);
+  font-weight: 600;
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  line-height: 1;
+  cursor: pointer;
+  transition: color var(--dur-fast), border-color var(--dur-fast), box-shadow var(--dur-fast);
+}
+.vfo-lock-btn:hover { color: var(--fg-0); border-color: var(--vfo-bezel-hi); }
+.vfo-lock-btn.on {
+  color: var(--vfo-lock);
+  border-color: var(--vfo-lock);
+  box-shadow: 0 0 10px var(--vfo-lock-glow), inset 0 0 6px var(--vfo-lock-glow);
+}
+.vfo-lock-btn.on:hover { color: var(--vfo-lock); }
+.vfo-lock-btn svg { display: block; }
+
 .vfo-swap { display: flex; align-items: center; gap: 6px; }
 
 /* ===== Meter ===== */

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -1275,16 +1275,16 @@
   height: 100%;
   min-height: 0;
 }
-/* ── PREMIUM MACHINED-INSTRUMENT VFO ───────────────────────────────────────
-   The VFO readout is a real instrument built from the SAME five-layer kit as
-   the loved S-meter (recessed well + top-sheen + GlassDome + GaugeBezel + lit
-   digits). The old flat blue-aurora glow card is gone. All depth cues are
-   token-driven (--vfo-* aliasing the meter / immersive-lamp kit); the
-   only animation is the existing compositor-only .meter-sheen-drift sheen
-   inside GlassDome (reduced-motion already drops it). */
+/* ── VFO readout — the original blue-aurora glow card (big thin digits, soft
+   electric-blue bloom) with a little extra rendering polish, plus the VFO
+   LOCK state layered on. DISPLAY-ONLY. */
 .freq-display {
-  padding: 14px 16px 12px;
-  background: var(--bg-1);
+  padding: 28px 20px 20px;
+  background:
+    radial-gradient(ellipse 55% 95% at 50% 55%, rgba(46,142,255,0.22), transparent 70%),
+    radial-gradient(ellipse 80% 60% at 50% 40%, rgba(46,142,255,0.10), transparent 75%),
+    radial-gradient(ellipse 100% 60% at 50% 110%, rgba(46,142,255,0.06), transparent 70%),
+    var(--bg-1);
   border: 1px solid var(--line);
   border-radius: var(--r-lg);
   box-shadow: none;
@@ -1293,90 +1293,44 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: 8px;
   container-type: size;
   position: relative;
   overflow: hidden;
 }
-.freq-display.compact { padding: 8px 10px 6px; gap: 5px; }
-
-/* header row — VFO label + the desktop lock toggle. */
-.freq-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  min-height: 18px;
-}
-.freq-head-lbl { letter-spacing: 0.14em; }
-
-.freq-top, .freq-bot { display: flex; align-items: center; font-size: 10px; }
-.freq-bot { justify-content: flex-end; }
-
-/* (1) recessed-well readout face — recessedWell() spreads the concave floor +
-   machined-pocket inset shadow inline. container-query font clamp stays scoped
-   to .freq-display, so the digits scale with the panel. */
-.freq-readout {
-  position: relative;
-  flex: 1 1 auto;
-  min-height: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px 18px;
-  overflow: hidden;
-}
-.freq-display.compact .freq-readout { padding: 6px 10px; }
-
-/* (2) top-sheen band — a thin cylindrical light band over the well floor for
-   curved-glass depth, under the digits + SVG. Pure CSS, no JS. */
-.freq-readout::before {
+.freq-display.compact { padding: 14px 14px 12px; }
+.freq-display::before {
   content: "";
   position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background: linear-gradient(
-    to bottom,
-    var(--meter-glass-top) 0%,
-    var(--meter-glass-bot) 42%
-  );
+  left: 50%; top: 50%;
+  transform: translate(-50%, -50%);
+  width: 60%; height: 80%;
+  background: radial-gradient(ellipse at center, rgba(78,166,255,0.18), transparent 60%);
+  filter: blur(20px);
   pointer-events: none;
-  z-index: 1;
 }
+.freq-display > * { position: relative; z-index: 1; }
+.freq-top, .freq-bot { display: flex; align-items: center; font-size: 10px; }
+.freq-bot { justify-content: space-between; gap: 10px; margin-top: 6px; }
 
-/* (3)+(4) GlassDome + GaugeBezel SVG overlay — sits above the well + sheen but
-   the digits render LAST in DOM so they take the click / wheel. The SVG is
-   pointer-events:none so it never blocks tuning. */
-.freq-instrument {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-  z-index: 2;
-  overflow: visible;
-}
-
-/* (5) lit/dim digits — Archivo Narrow 600, tabular, the hero. ACTIVE digits
-   are the lit lamp (--vfo-readout) with a lamp bloom; LEADING zeros are the
-   unlit-segment dim tell. */
 .freq-digits {
-  position: relative;
-  z-index: 3;
   display: flex;
   align-items: baseline;
-  /* Restore the old wide digit typography — Archivo Narrow read too condensed /
-     small; the operator wants the big readout back. */
   font-family: var(--font-sans);
+  /* original: thin 200-weight white digits with a soft electric-blue bloom */
   font-weight: 200;
-  font-size: clamp(40px, 9.5cqw, 150px);
+  font-size: clamp(38px, 9cqw, 140px);
   letter-spacing: -0.025em;
-  color: var(--vfo-readout);
+  color: var(--fg-0);
   font-variant-numeric: tabular-nums;
   line-height: 1.05;
+  margin: 4px 0;
   justify-content: center;
+  /* polish — crisper bloom + a hair of bottom grounding, antialiased edges */
+  text-shadow: 0 0 12px rgba(78,166,255,0.28), 0 1px 0 rgba(0,0,0,0.35);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
-.freq-display.compact .freq-digits { font-size: clamp(24px, 8cqw, 72px); }
+.freq-display.compact .freq-digits { font-size: clamp(24px, 8cqw, 84px); }
 .freq-digits-btn {
   background: none;
   border: none;
@@ -1387,81 +1341,55 @@
   padding: 0;
 }
 .freq-digits .digit {
-  background: none; border: none; font: inherit;
+  background: none; border: none; color: inherit; font: inherit;
   padding: 0 1px;
-  color: var(--vfo-readout);
-  text-shadow: 0 0 14px var(--vfo-readout-glow), 0 0 4px var(--vfo-readout-glow);
   cursor: ns-resize;
   transition: color var(--dur-fast), text-shadow var(--dur-fast);
 }
 .freq-digits .digit:hover {
   color: var(--accent);
-  text-shadow: 0 0 12px var(--accent);
+  text-shadow: 0 0 10px var(--accent);
 }
-/* unlit leading zeros — the single biggest realism cue. */
-.freq-digits .digit.leading {
-  color: var(--vfo-digit-dim);
-  text-shadow: none;
-}
-.freq-digits .sep {
-  color: var(--vfo-sep);
-  padding: 0 1px;
-  font-weight: 600;
-}
+.freq-digits .digit.leading { color: var(--fg-4); text-shadow: none; }
+.freq-digits .sep { color: var(--fg-1); padding: 0 1px; font-weight: 200; }
 
-/* typed-entry field — inherits the lit-lamp readout treatment. */
+/* typed-entry field — inherits the digit look. */
 .freq-edit-input {
   width: 220px;
+  max-width: 100%;
   background: transparent;
   border: none;
   border-bottom: 1px solid var(--accent);
   outline: none;
-  color: var(--vfo-readout);
+  color: var(--fg-0);
   font-family: inherit;
   font-size: inherit;
-  font-weight: 600;
-  text-shadow: 0 0 14px var(--vfo-readout-glow);
+  font-weight: 400;
+  text-shadow: 0 0 12px rgba(78,166,255,0.28);
 }
 .freq-display.compact .freq-edit-input { width: 100%; }
 .freq-edit-unit { align-self: center; }
 
-/* ── LOCKED state ─────────────────────────────────────────────────────────
-   The readout "clicks shut": lit digits + bezel ring tint toward --vfo-lock
-   (red), the active-digit glow dims, digits go cursor:not-allowed, and a lit
-   padlock burns in the corner. */
-.freq-display.locked .freq-readout {
-  box-shadow:
-    inset 0 0 0 1px var(--vfo-lock-glow),
-    inset 0 2px 4px rgba(0,0,0,0.85),
-    inset 0 0 12px rgba(0,0,0,0.5);
+/* ── LOCKED state — the card tints red, the digit bloom goes red, and the
+   digits stop responding to clicks / wheel. */
+.freq-display.locked { border-color: var(--vfo-lock); }
+.freq-display.locked .freq-digits {
+  color: var(--vfo-lock);
+  text-shadow: 0 0 12px var(--vfo-lock-glow), 0 1px 0 rgba(0,0,0,0.35);
 }
 .freq-display.locked .freq-digits .digit {
   color: var(--vfo-lock);
-  text-shadow: 0 0 6px var(--vfo-lock-glow);
   cursor: not-allowed;
 }
 .freq-display.locked .freq-digits .digit:hover {
   color: var(--vfo-lock);
-  text-shadow: 0 0 6px var(--vfo-lock-glow);
+  text-shadow: 0 0 8px var(--vfo-lock-glow);
 }
 .freq-display.locked .freq-digits .digit.leading {
   color: var(--vfo-digit-dim);
   text-shadow: none;
 }
 .freq-display.locked .freq-digits-btn { cursor: not-allowed; }
-.freq-display.locked .freq-instrument { filter: saturate(0.9); }
-
-/* lit padlock burned into the readout corner while locked. */
-.freq-lock-mark {
-  position: absolute;
-  top: 6px;
-  right: 8px;
-  z-index: 4;
-  color: var(--vfo-lock);
-  filter: drop-shadow(0 0 5px var(--vfo-lock-glow)) drop-shadow(0 0 2px var(--vfo-lock-glow));
-  pointer-events: none;
-  display: inline-flex;
-}
 
 /* ── lock toggle button ───────────────────────────────────────────────────
    Reuses the bezel language (machined-chrome edge) + the --vfo-lock accent

--- a/zeus-web/src/styles/tokens.css
+++ b/zeus-web/src/styles/tokens.css
@@ -175,6 +175,25 @@
   /* whole-gauge additive bloom tint. */
   --gauge-glow:       rgba(255,176,72,0.16);
 
+  /* ----- VFO instrument tokens (presentation-only) -----
+     The machined-instrument VFO readout reuses the SAME five-layer kit as
+     the loved S-meter. These NEW names ALIAS existing meter / immersive-lamp
+     / fg / tx values so the VFO inherits the meter family's depth, glass,
+     bezel and lit-lamp language — and the light-theme flip is free (the light
+     block re-aliases the already-light meter/lamp values). NO existing token
+     VALUE is changed here. */
+  --vfo-readout:      var(--immersive-lamp-readout);       /* lit active digits */
+  --vfo-readout-glow: var(--immersive-lamp-readout-glow);  /* lamp bloom */
+  --vfo-digit-dim:    var(--fg-4);                         /* unlit leading zeros */
+  --vfo-sep:          var(--fg-2);                         /* muted separators */
+  --vfo-bezel-hi:     var(--meter-bezel-hi);
+  --vfo-bezel-lo:     var(--meter-bezel-lo);
+  --vfo-bezel-ring:   var(--meter-bezel-ring);
+  --vfo-well-floor:   var(--meter-well-floor);
+  --vfo-well-edge:    var(--meter-well-edge);
+  --vfo-lock:         var(--tx);                            /* locked accent (red) */
+  --vfo-lock-glow:    rgba(230,58,43,0.35);                 /* lit-glyph bloom */
+
   /* ----- COMPACT-BAR instrument variants (presentation-only) -----
      The five-layer stack tuned for the small/dense TX-stage VU columns and
      the SWR/PWR arcs. At ~16px column width + 6-up packing the default
@@ -435,6 +454,22 @@ html[data-fonts="geist"] { --font-sans: 'Inter', sans-serif; --font-mono: 'JetBr
   --meter-bezel-lo:   rgba(60, 66, 74, 0.55);
   --meter-bezel-ring: rgba(40, 45, 52, 0.22);
   --gauge-glow:       rgba(255,176,72,0.06);
+
+  /* ----- VFO instrument tokens — light theme counterparts -----
+     Same aliases as the dark block; they resolve to the already-light
+     meter / immersive-lamp / fg / tx values, so the light flip is
+     automatic. --vfo-lock-glow is muted for the light workspace. */
+  --vfo-readout:      var(--immersive-lamp-readout);
+  --vfo-readout-glow: var(--immersive-lamp-readout-glow);
+  --vfo-digit-dim:    var(--fg-4);
+  --vfo-sep:          var(--fg-2);
+  --vfo-bezel-hi:     var(--meter-bezel-hi);
+  --vfo-bezel-lo:     var(--meter-bezel-lo);
+  --vfo-bezel-ring:   var(--meter-bezel-ring);
+  --vfo-well-floor:   var(--meter-well-floor);
+  --vfo-well-edge:    var(--meter-well-edge);
+  --vfo-lock:         var(--tx);
+  --vfo-lock-glow:    rgba(230,58,43,0.18);
 
   /* COMPACT-BAR instrument variants — light-theme counterparts. The VU
      wells stay dark (display surfaces), so the brighter specular/edge cues

--- a/zeus-web/src/util/snap-lock.ts
+++ b/zeus-web/src/util/snap-lock.ts
@@ -37,6 +37,7 @@ import { useConnectionStore } from '../state/connection-store';
 import { type DisplayState, registerFrameConsumer, subscribeFrames } from '../state/display-store';
 import { measureSnapLock, type SnapLockMeasure, useSignalEnhanceStore } from '../dsp/signal-estimator';
 import { useTxStore } from '../state/tx-store';
+import { useVfoLockStore } from '../state/vfo-lock-store';
 import * as viewCenter from '../state/view-center';
 
 // Capture window for re-finding the locked signal each frame. Must stay well
@@ -209,6 +210,10 @@ function onFrame(s: DisplayState): void {
   if (!active) return;
   if (!useSignalEnhanceStore.getState().snapEnabled) {
     releaseSnapLock();
+    return;
+  }
+  if (useVfoLockStore.getState().locked) {
+    releaseSnapLock(); // VFO locked — disarm signal-follow; it must not nudge the dial
     return;
   }
   const tx = useTxStore.getState();

--- a/zeus-web/src/util/use-keyboard-shortcuts.ts
+++ b/zeus-web/src/util/use-keyboard-shortcuts.ts
@@ -55,6 +55,7 @@ import { useConnectionStore } from '../state/connection-store';
 import * as viewCenter from '../state/view-center';
 import { useToolbarFavoritesStore } from '../state/toolbar-favorites-store';
 import { useTxStore } from '../state/tx-store';
+import { useVfoLockStore } from '../state/vfo-lock-store';
 import { ACTIVE_MAP_REF } from '../state/active-map-ref';
 
 // The arrow-key tune step follows the operator's TuningStepWidget choice
@@ -115,6 +116,11 @@ export function useKeyboardShortcuts() {
     };
 
     const bumpTune = (direction: -1 | 1) => {
+      // VFO locked — freq arrow tuning no-ops. setVfo is the backstop, but
+      // bailing here avoids the optimistic vfoHz write + view-center nudge.
+      // NOTE: this gates ONLY frequency tuning; ZOOM (bumpZoom) and Space-MOX
+      // (driveMox) are deliberately untouched.
+      if (useVfoLockStore.getState().locked) return;
       // Accumulate from the queued value so held-down arrows step cleanly
       // rather than re-reading the (potentially stale) store each frame.
       const base = pendingHz ?? useConnectionStore.getState().vfoHz;

--- a/zeus-web/src/util/use-pan-tune-gesture.ts
+++ b/zeus-web/src/util/use-pan-tune-gesture.ts
@@ -50,6 +50,7 @@ import { computeSnapToLineHz, getSnapHistorySpectrum, useSignalEnhanceStore } fr
 import { armSnapLock } from './snap-lock';
 import * as viewCenter from '../state/view-center';
 import { useToolbarFavoritesStore } from '../state/toolbar-favorites-store';
+import { useVfoLockStore } from '../state/vfo-lock-store';
 
 const MAX_HZ = 60_000_000;
 const CLICK_SLOP_PX = 3;
@@ -176,6 +177,9 @@ export function usePanTuneGesture(
       const hz = pendingHz;
       pendingHz = null;
       if (hz == null) return;
+      // VFO locked — drop the queued drag-pan tune. setVfo is the backstop,
+      // but bailing here avoids the optimistic vfoHz write + the rollback twitch.
+      if (useVfoLockStore.getState().locked) return;
       viewCenter.markOptimisticTune();
       useConnectionStore.setState({ vfoHz: hz });
       pendingAbort?.abort();
@@ -191,6 +195,8 @@ export function usePanTuneGesture(
     // `exact` skips the PAN_STEP_HZ grid — used by snap-to-signal so the dial
     // lands on the measured carrier, not the nearest round 500 Hz.
     const commitFinal = (hz: number, exact = false) => {
+      // VFO locked — click-to-tune / snap-to-signal commit no-ops.
+      if (useVfoLockStore.getState().locked) return;
       const snapped = exact ? clampHz(hz) : snapHz(hz);
       // Delta against the commanded chain — NOT an absolute write into the
       // view-center (frame centers are dial ∓ cw-pitch in CW; absolutes
@@ -212,6 +218,8 @@ export function usePanTuneGesture(
     // Wheel-driven VFO nudge: fine-tune step, no snap to PAN_STEP_HZ. Coalesces
     // to one POST per rAF via the same pending pipeline as drag-to-pan.
     const nudgeVfo = (deltaHz: number) => {
+      // VFO locked — wheel-nudge tuning no-ops.
+      if (useVfoLockStore.getState().locked) return;
       const cur = commandedHz();
       const next = clampHz(cur + deltaHz);
       // Effective delta (post-clamp) so the display target can never run

--- a/zeus-web/src/util/use-pan-tune-gesture.ts
+++ b/zeus-web/src/util/use-pan-tune-gesture.ts
@@ -340,6 +340,11 @@ export function usePanTuneGesture(
         return;
       }
       if (!drag) return;
+      // VFO locked — drag-to-tune (and the view-follow it drives) no-ops, the
+      // same backstop as the wheel-nudge (nudgeVfo), click-to-tune commit, and
+      // ruler/LO pan. Without this the live optimistic vfoHz write below moves
+      // the readout on every drag frame until the next state poll snaps it back.
+      if (useVfoLockStore.getState().locked) return;
       const dx = e.clientX - drag.startX;
       if (!drag.moved && Math.abs(dx) <= CLICK_SLOP_PX) return;
       drag.moved = true;

--- a/zeus-web/src/util/use-ruler-pan-gesture.ts
+++ b/zeus-web/src/util/use-ruler-pan-gesture.ts
@@ -13,6 +13,7 @@
 import { useEffect, type RefObject } from 'react';
 import { setRadioLo } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import { useVfoLockStore } from '../state/vfo-lock-store';
 import { useDisplayStore } from '../state/display-store';
 import * as viewCenter from '../state/view-center';
 
@@ -119,6 +120,10 @@ export function useRulerPanGesture(
 
     const onPointerDown = (e: PointerEvent) => {
       if (e.button !== 0) return;
+      // VFO locked — never begin a ruler/LO pan. setRadioLo is the authoritative
+      // backstop, but bailing here avoids the optimistic radioLoHz writes that
+      // would otherwise flash the dial for one frame before the rollback fetch.
+      if (useVfoLockStore.getState().locked) return;
       const view = readViewport();
       if (!view) return;
       e.preventDefault();


### PR DESCRIPTION
**DRAFT — do not merge; KB2UKA reviewing in the morning.**

Two deliverables:
- **VFO lock** (works): a LOCK toggle that freezes frequency against every path — digit click/type/scroll, keyboard, pan-drag, ruler/LO pan, panadapter+waterfall click-to-tune, band buttons, TCI spot tune. Persisted; red locked styling. Gates *frequency only* — RIT/XIT/split/MOX/TUN/PS untouched. (External CAT/TCI freq-sets not gated in v1 — flagged.)
- **VFO visuals**: premium instrument chrome (recessed well, glass dome, bezel, glow) via the shared meter render kit, with the **big wide digits restored** (the condensed Archivo Narrow read too small) and **clear-on-type entry** (click → type the whole freq fresh, no pre-filled decimals) per maintainer feedback.

Display + freq-set-gate only — all changes under `zeus-web/`; no backend/TX/IQ/DSP/WDSP/PureSignal. Token-only additive. tsc+vite green, lint clean.

🚫 Draft — Doug to review/tweak the look in the AM before merge.