### PR TITLE
chore: org governance — code owners KB2UKA + N9WAR; credit Christian Suarez

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,21 +1,22 @@
 # OpenHPSDR Zeus — Code Owners
 #
-# Every path is co-owned by @Kb2uka, @brianbruff, @rampa069, and @dl1bz.
-# Combined with branch protection on `develop` and `main` (require
-# approving review from a code owner), this means any one of the four
-# can approve + merge a PR — but GitHub still blocks self-approval, so
-# the PR author always needs an approval from one of the others.
+# Every path is co-owned by @Kb2uka and @iamexemplar. Combined with branch
+# protection on `develop` and `main` (require approving review from a code
+# owner), this means either one can approve + merge a PR — but GitHub still
+# blocks self-approval, so the PR author always needs an approval from the
+# other owner.
 #
-# Roles are still defined per CLAUDE.md; this file isn't about who
-# decides what merges:
+# Roles are still defined per CLAUDE.md; this file isn't about who decides
+# what merges:
+#   - Kb2uka (@Kb2uka, KB2UKA / Douglas J. Cerrato) — maintainer/owner;
+#     backend/DSP/protocol architecture + audio-chain content owner
+#     (block choices, algorithm picks, defaults).
+#   - Christian Suarez (@iamexemplar, N9WAR) — maintainer/owner.
 #   - Brian (@brianbruff, EI6LF) — visual design, UX, architecture
-#     authority. Plugin SDK / VST3 / contracts owner.
+#     authority; Plugin SDK / VST3 / contracts owner. Write contributor.
 #   - Ramón (@rampa069, EA5IUE) — protocol + radio-state contributor.
-#   - Heiko (@dl1bz, DL1BZ) — maintainer of upstream DeskHPSDR; one of
-#     Zeus's Protocol-2 / PureSignal / Saturn-class references.
-#   - Kb2uka (@Kb2uka, KB2UKA) — maintainer + audio-chain content
-#     owner (block choices, algorithm picks, defaults).
+#     Write contributor.
 #
 # Format reference: https://docs.github.com/en/repositories/managing-your-repositories-settings-and-security/customizing-your-repository/about-code-owners
 
-*       @Kb2uka @brianbruff @rampa069 @dl1bz
+*       @Kb2uka @iamexemplar

--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -32,7 +32,8 @@ GPL v3 works.
 Zeus is maintained by:
 
 - **Brian Keating (EI6LF)** — project lead
-- **Douglas J. Cerrato (KB2UKA)** — contributor
+- **Douglas J. Cerrato (KB2UKA)** — maintainer
+- **Christian Suarez (N9WAR)** — maintainer
 - **Ramón Martínez (EA5IUE)** — contributor
 
 Additional contributions are visible in `git log` and in the repository's

--- a/zeus-web/src/components/SignalEnhancePanel.tsx
+++ b/zeus-web/src/components/SignalEnhancePanel.tsx
@@ -13,7 +13,7 @@
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
-// Display-tab surface for the signal-enhance engine (Christian Suarez N9WAR's
+// Display-tab surface for the signal-enhance engine (Christian Suarez (N9WAR)'s
 // pop / snap / peak-marker work, commit 8d949e2e). Only **Signal Pop** is
 // exposed: it toggles `popEnabled` on the same store the GL pop-remap reads.
 //

--- a/zeus-web/src/gl/colormap.ts
+++ b/zeus-web/src/gl/colormap.ts
@@ -110,7 +110,7 @@ const VIRIDIS_ANCHORS: Anchor[] = [
   [1.0, [253, 231, 37]],
 ];
 
-// Signal Pop palette — N9WAR's (Christiano) retune from his rx2 engine: the
+// Signal Pop palette — Christian Suarez (N9WAR)'s retune from his rx2 engine: the
 // four lower anchors sit lower than develop's, so weak signals and floor
 // structure light up earlier, giving the 3D relief more to shade. Adopted with
 // the new waterfall engine (PR #655); this intentionally diverges from


### PR DESCRIPTION
Post-transfer governance setup for the new org repo:
- **CODEOWNERS** → `* @Kb2uka @iamexemplar` (Doug + Christian are the merge approvers; Brian/Ramón remain write contributors; dl1bz dropped).
- Christian's full name **Christian Suarez (N9WAR)** in code comments (drop the 'Christiano' nickname).
- **ATTRIBUTIONS.md**: Christian added as maintainer.

Docs/comments + CODEOWNERS only — no code logic.