### PR TITLE
docs: trim CLAUDE.md beads section → .beads/README

### DIFF
--- a/.beads/README.md
+++ b/.beads/README.md
@@ -78,4 +78,40 @@ bd create "Try out Beads"
 
 ---
 
+## Zeus team sync (project-specific)
+
+> Moved here from `CLAUDE.md` to keep the agent context file lean. This is the
+> authoritative Zeus-specific bd setup; `CLAUDE.md` carries only a pointer.
+
+Zeus does **not** use the `refs/dolt/data`-on-git-remote sync path that bd's
+default integration block mentions. Zeus syncs its bd Dolt database to a
+dedicated public DoltHub repo:
+
+> **DoltHub:** https://www.dolthub.com/repositories/kb2uka/openhpsdr-zeus
+
+### One-time teammate setup
+
+```bash
+dolt login                                                                   # browser flow → associate a key
+bd dolt remote add origin https://doltremoteapi.dolthub.com/kb2uka/openhpsdr-zeus
+bd dolt pull origin main                                                     # fetch the team's issues
+```
+
+### Day-to-day
+
+```bash
+bd dolt pull origin main      # before starting work
+# ... bd create / bd update / bd close ...
+bd dolt push origin main      # after edits, before signing off
+```
+
+### What's tracked in git vs. DoltHub
+
+- **`.beads/config.yaml`** (in git) — team-wide bd config including `sync.remote`. Edit here for team-wide defaults.
+- **`.beads/issues.jsonl`** / **`interactions.jsonl`** (in git) — passive exports for human grep and zero-dependency reading. **Do not edit by hand** — bd regenerates them. **Do not commit them inside a feature-branch PR** — the merge-conflict tax is real once more than one person uses bd. Snapshot commits to `develop` are fine.
+- **`.beads/metadata.json`** (gitignored) — per-clone `project_id` + local `dolt_database` name. Local state, never committed.
+- **`.beads/embeddeddolt/`** (gitignored) — the actual Dolt DB. Never committed; this is what `bd dolt push` ships.
+
+---
+
 *Beads: Issue tracking that moves at the speed of thought* ⚡

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,29 +148,4 @@ bd close <id>         # Complete work
 
 ## Beads — Team Sync (Zeus-specific)
 
-The auto-generated block above mentions `refs/dolt/data` on the git remote as the default sync path. **Zeus does NOT use that.** Zeus syncs its bd Dolt database to a dedicated public DoltHub repo:
-
-> **DoltHub:** https://www.dolthub.com/repositories/kb2uka/openhpsdr-zeus
-
-### One-time teammate setup
-
-```bash
-dolt login                                                                   # browser flow → associate a key
-bd dolt remote add origin https://doltremoteapi.dolthub.com/kb2uka/openhpsdr-zeus
-bd dolt pull origin main                                                     # fetch the team's issues
-```
-
-### Day-to-day
-
-```bash
-bd dolt pull origin main      # before starting work
-# ... bd create / bd update / bd close ...
-bd dolt push origin main      # after edits, before signing off
-```
-
-### What's tracked in git vs. DoltHub
-
-- **`.beads/config.yaml`** (in git) — team-wide bd config including `sync.remote`. Edit here for team-wide defaults.
-- **`.beads/issues.jsonl`** / **`interactions.jsonl`** (in git) — passive exports for human grep and zero-dependency reading. **Do not edit by hand** — bd regenerates them. **Do not commit them inside a feature-branch PR** — the merge-conflict tax is real once more than one person uses bd. Snapshot commits to `develop` are fine.
-- **`.beads/metadata.json`** (gitignored) — per-clone `project_id` + local `dolt_database` name. Local state, never committed.
-- **`.beads/embeddeddolt/`** (gitignored) — the actual Dolt DB. Never committed; this is what `bd dolt push` ships.
+Zeus does **not** use the `refs/dolt/data`-on-git-remote sync path the auto-generated block above mentions — it syncs the bd Dolt DB to a dedicated public DoltHub repo (**https://www.dolthub.com/repositories/kb2uka/openhpsdr-zeus**). The one-time teammate setup, the `bd dolt pull/push origin main` day-to-day loop, and the git-vs-DoltHub tracking rules (what's committed vs. gitignored) live in **[`.beads/README.md`](.beads/README.md) → "Zeus team sync"**. Read it before your first `bd dolt push`.


### PR DESCRIPTION
## What

Moves the hand-written **"Beads — Team Sync (Zeus-specific)"** section out of `CLAUDE.md` and into `.beads/README.md`, leaving a one-paragraph pointer.

## Why

`CLAUDE.md` is loaded into agent context **every session, every turn** — it's recurring token rent, so low-value-per-token content should live elsewhere. The Zeus bd setup/sync detail (DoltHub remote, one-time teammate setup, git-vs-DoltHub tracking rules) is reference material you read once, not per-session guidance.

## Result

- `CLAUDE.md`: **176 → 151 lines** (~3,880 → ~3,620 tokens).
- The load-bearing sections (Load-Bearing Invariants, Radio-Specific Behaviour, Debugging Discipline, Autonomous-Agent Boundaries) are untouched.
- The **bd auto-generated block** (`<!-- BEGIN/END BEADS INTEGRATION -->`, incl. the session-push mandate) is left exactly as-is — it's tool-managed, and hand-edits get regenerated.

Docs-only. No code, no build impact.