### PR TITLE
feat(logbook): add search filter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,14 @@ bd close <id>         # Complete work
 bd dolt push          # Push beads data to remote
 ```
 
+## Git Workflow
+
+- For each new feature, bug fix, or similarly scoped development task, create a separate git worktree from `develop`.
+- Use a branch name such as `feature/<short-descriptive-name>` or `fix/<short-descriptive-name>` in that worktree.
+- Keep simultaneous work in separate worktree folders so switching branches for one task does not disturb another.
+- Open pull requests from the worktree branch into `develop` on `OpenHPSDR-Zeus-org/openhpsdr-zeus`.
+- Do not commit development work directly to `develop` or `main`.
+
 ## Non-Interactive Shell Commands
 
 **ALWAYS use non-interactive flags** with file operations to avoid hanging on confirmation prompts.

--- a/zeus-web/src/components/design/LogbookLive.tsx
+++ b/zeus-web/src/components/design/LogbookLive.tsx
@@ -42,10 +42,12 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Search, X } from 'lucide-react';
 import { useLoggerStore } from '../../state/logger-store';
 import type { LogEntry } from '../../api/log';
 import { formatQsoDateUtc, formatQsoTimeUtc } from './logbook-formatters';
+import { filterLogEntries } from './logbook-search';
 
 function compactList(parts: Array<string | null | undefined>): string {
   return parts.filter((p): p is string => !!p).join(' · ');
@@ -88,11 +90,15 @@ export function LogbookLive() {
   const toggleSelected = useLoggerStore((s) => s.toggleSelected);
   const setSelectedIds = useLoggerStore((s) => s.setSelectedIds);
   const selectAllRef = useRef<HTMLInputElement>(null);
-  const selectedVisibleCount = entries.reduce(
+  const [searchText, setSearchText] = useState('');
+  const query = searchText.trim();
+  const filteredEntries = useMemo(() => filterLogEntries(entries, searchText), [entries, searchText]);
+  const visibleIds = useMemo(() => new Set(filteredEntries.map((entry) => entry.id)), [filteredEntries]);
+  const selectedVisibleCount = filteredEntries.reduce(
     (count, entry) => count + (selectedIds.has(entry.id) ? 1 : 0),
     0,
   );
-  const allVisibleSelected = entries.length > 0 && selectedVisibleCount === entries.length;
+  const allVisibleSelected = filteredEntries.length > 0 && selectedVisibleCount === filteredEntries.length;
   const someVisibleSelected = selectedVisibleCount > 0 && !allVisibleSelected;
 
   useEffect(() => {
@@ -133,17 +139,44 @@ export function LogbookLive() {
 
   return (
     <div className="logbook">
+      <div className="log-search">
+        <Search size={14} strokeWidth={2} aria-hidden="true" />
+        <input
+          type="search"
+          value={searchText}
+          onChange={(event) => setSearchText(event.target.value)}
+          placeholder="Search logbook"
+          aria-label="Search logbook"
+          spellCheck={false}
+        />
+        {query && (
+          <button
+            type="button"
+            className="log-search-clear"
+            onClick={() => setSearchText('')}
+            aria-label="Clear logbook search"
+            title="Clear search"
+          >
+            <X size={13} strokeWidth={2.2} aria-hidden="true" />
+          </button>
+        )}
+      </div>
       <div className="log-head mono">
         <span className="log-select-cell">
           <input
             ref={selectAllRef}
             type="checkbox"
             checked={allVisibleSelected}
+            disabled={filteredEntries.length === 0}
             onChange={() => {
-              setSelectedIds(allVisibleSelected ? [] : entries.map((entry) => entry.id));
+              setSelectedIds(
+                allVisibleSelected
+                  ? [...selectedIds].filter((id) => !visibleIds.has(id))
+                  : [...selectedIds, ...filteredEntries.map((entry) => entry.id)],
+              );
             }}
-            aria-label={allVisibleSelected ? 'Clear selected log entries' : 'Select all log entries'}
-            title={allVisibleSelected ? 'Clear selected log entries' : 'Select all log entries'}
+            aria-label={allVisibleSelected ? 'Clear selected visible log entries' : 'Select visible log entries'}
+            title={allVisibleSelected ? 'Clear selected visible log entries' : 'Select visible log entries'}
           />
         </span>
         <span title="QSO date in UTC">Date·UTC</span>
@@ -155,7 +188,12 @@ export function LogbookLive() {
         <span>Name · QTH · Notes</span>
       </div>
       <div className="log-rows">
-        {entries.map((entry) => (
+        {filteredEntries.length === 0 && (
+          <div className="log-empty">
+            No log entries match "{query}".
+          </div>
+        )}
+        {filteredEntries.map((entry) => (
           <button
             key={entry.id}
             type="button"
@@ -204,7 +242,11 @@ export function LogbookLive() {
       </div>
       <div className="log-foot">
         <span style={{ flex: 1 }} />
-        <span className="label-xs">{entries.length} of {totalCount}</span>
+        <span className="label-xs">
+          {query
+            ? `${filteredEntries.length} of ${entries.length} visible · ${totalCount} total`
+            : `${entries.length} of ${totalCount}`}
+        </span>
       </div>
     </div>
   );

--- a/zeus-web/src/components/design/logbook-search.test.ts
+++ b/zeus-web/src/components/design/logbook-search.test.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, expect, it } from 'vitest';
+import type { LogEntry } from '../../api/log';
+import { filterLogEntries, logEntrySearchText } from './logbook-search';
+
+function entry(overrides: Partial<LogEntry>): LogEntry {
+  return {
+    id: 'base',
+    qsoDateTimeUtc: '2026-06-19T14:22:00Z',
+    callsign: 'N0CALL',
+    name: null,
+    frequencyMhz: 14.074,
+    band: '20m',
+    mode: 'FT8',
+    rstSent: '599',
+    rstRcvd: '579',
+    grid: null,
+    country: null,
+    dxcc: null,
+    cqZone: null,
+    ituZone: null,
+    state: null,
+    comment: null,
+    createdUtc: '2026-06-19T14:23:00Z',
+    qrzLogId: null,
+    qrzUploadedUtc: null,
+    ...overrides,
+  };
+}
+
+describe('logbook search', () => {
+  const entries = [
+    entry({
+      id: 'a',
+      callsign: 'N9WAR',
+      name: 'Christian',
+      frequencyMhz: 7.185,
+      band: '40m',
+      mode: 'LSB',
+      grid: 'EN61',
+      country: 'United States',
+      state: 'IL',
+      comment: 'net control',
+      qrzLogId: 'QRZ-123',
+    }),
+    entry({
+      id: 'b',
+      callsign: 'EI6LF',
+      name: 'Brian',
+      frequencyMhz: 14.250,
+      band: '20m',
+      mode: 'USB',
+      grid: 'IO63',
+      country: 'Ireland',
+      comment: 'long path',
+    }),
+  ];
+
+  it('matches callsigns case-insensitively', () => {
+    expect(filterLogEntries(entries, 'n9war').map((qso) => qso.id)).toEqual(['a']);
+  });
+
+  it('matches multiple terms across displayed fields', () => {
+    expect(filterLogEntries(entries, '20m brian usb').map((qso) => qso.id)).toEqual(['b']);
+  });
+
+  it('matches location, comments, frequency, and QRZ sync text', () => {
+    expect(filterLogEntries(entries, '7.185 net QRZ-123').map((qso) => qso.id)).toEqual(['a']);
+  });
+
+  it('returns all entries for blank queries', () => {
+    expect(filterLogEntries(entries, '   ')).toBe(entries);
+  });
+
+  it('includes UTC date and time in the searchable text', () => {
+    expect(logEntrySearchText(entries[0]!)).toContain('14:22');
+    expect(filterLogEntries(entries, '2026 14:22').map((qso) => qso.id)).toEqual(['a', 'b']);
+  });
+});

--- a/zeus-web/src/components/design/logbook-search.ts
+++ b/zeus-web/src/components/design/logbook-search.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import type { LogEntry } from '../../api/log';
+import { formatQsoDateUtc, formatQsoTimeUtc } from './logbook-formatters';
+
+function normalizeSearchText(value: string): string {
+  return value.trim().toLocaleLowerCase();
+}
+
+function compactSearchParts(parts: Array<string | number | null | undefined>): string {
+  return parts
+    .filter((part): part is string | number => part !== null && part !== undefined && part !== '')
+    .join(' ')
+    .toLocaleLowerCase();
+}
+
+export function logEntrySearchText(entry: LogEntry): string {
+  return compactSearchParts([
+    entry.callsign,
+    formatQsoDateUtc(entry.qsoDateTimeUtc),
+    formatQsoTimeUtc(entry.qsoDateTimeUtc),
+    entry.qsoDateTimeUtc,
+    entry.frequencyMhz.toFixed(3),
+    entry.frequencyMhz.toString(),
+    entry.band,
+    entry.mode,
+    entry.rstSent,
+    entry.rstRcvd,
+    entry.name,
+    entry.grid,
+    entry.country,
+    entry.dxcc,
+    entry.cqZone,
+    entry.ituZone,
+    entry.state,
+    entry.comment,
+    entry.qrzLogId,
+  ]);
+}
+
+export function filterLogEntries(entries: LogEntry[], query: string): LogEntry[] {
+  const terms = normalizeSearchText(query).split(/\s+/).filter(Boolean);
+  if (terms.length === 0) return entries;
+
+  return entries.filter((entry) => {
+    const haystack = logEntrySearchText(entry);
+    return terms.every((term) => haystack.includes(term));
+  });
+}

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -2826,6 +2826,50 @@
 
 /* ===== Logbook ===== */
 .logbook { display: flex; flex-direction: column; height: 100%; min-height: 0; background: var(--bg-1); }
+.log-search {
+  flex: 0 0 auto;
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr) 22px;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 8px;
+  color: var(--fg-2);
+  background: var(--bg-2);
+  border-bottom: 1px solid rgba(0,0,0,0.35);
+}
+.log-search input {
+  min-width: 0;
+  height: 22px;
+  padding: 2px 6px;
+  color: var(--fg-0);
+  background: var(--bg-0);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-xs);
+  font: 600 11px/1.2 var(--font-sans);
+  outline: none;
+}
+.log-search input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent-line);
+}
+.log-search-clear {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  color: var(--fg-2);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--r-xs);
+  cursor: pointer;
+}
+.log-search-clear:hover {
+  color: var(--fg-0);
+  background: var(--bg-0);
+  border-color: var(--line-strong);
+}
 .log-head {
   display: grid;
   grid-template-columns: 2rem 60px 55px 85px 70px 50px 70px 1fr;
@@ -2849,6 +2893,13 @@
   cursor: pointer;
 }
 .log-rows { flex: 1; overflow-y: auto; min-height: 0; }
+.log-empty {
+  padding: 2rem 1rem;
+  color: var(--fg-2);
+  font-size: 12px;
+  font-weight: 600;
+  text-align: center;
+}
 .log-row {
   display: grid;
   grid-template-columns: 2rem 60px 55px 85px 70px 50px 70px 1fr;


### PR DESCRIPTION
## Summary
- add a Logbook search field with clear button and empty-match state
- filter visible QSO rows client-side across callsign, UTC date/time, frequency, band, mode, RST, name, location, notes, and QRZ ID
- document the new worktree-per-feature workflow in AGENTS.md

## Verification
- npm --prefix zeus-web run test -- logbook
- npm --prefix zeus-web run typecheck
- npm --prefix zeus-web run build
- npm --prefix zeus-web run test
- Browser smoke: http://localhost:5183 search filtered XE1RK to 1 row, clear restored 6 rows, NOPE123 showed empty state

## Notes
- dotnet test Zeus.slnx was attempted but timed out after 5 minutes; this branch changes frontend/docs only.