### PR TITLE
Add release-aware update prompts

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -51,6 +51,10 @@ jobs:
         run: npm ci
         working-directory: zeus-web
 
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+        working-directory: zeus-web
+
       - name: Lint frontend
         run: npm run lint
         working-directory: zeus-web
@@ -62,6 +66,10 @@ jobs:
 
       - name: Run frontend tests
         run: npm test
+        working-directory: zeus-web
+
+      - name: Run frontend E2E tests
+        run: npm run test:e2e
         working-directory: zeus-web
 
       - name: Build frontend

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,8 @@ native/build-miniaudio/
 # Playwright-MCP accessibility snapshots and console logs — regenerated
 # on every browser-automation run; do not track.
 .playwright-mcp/
+zeus-web/test-results/
+zeus-web/playwright-report/
 
 # Ad-hoc screenshot captures (debug PNGs) in the repo root. Real docs
 # imagery lives under docs/ when we need it.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Wiki jump-off points for the most-asked things:
 
 ## Download
 
-Grab the latest installer from the **[Releases page](https://github.com/Kb2uka/openhpsdr-zeus/releases/latest)**
+Grab the latest installer from the **[Releases page](https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus/releases/latest)**
 — Windows x64 `.exe`, Windows on ARM (Snapdragon / Surface Pro X) `.exe`, macOS `.dmg`, Linux `.tar.gz`. Full install detail (PWA path,
 macOS Gatekeeper xattr step, first-run WDSP wisdom wait) is on the wiki's
 [Installation](https://github.com/Kb2uka/openhpsdr-zeus/wiki/Installation)
@@ -99,6 +99,11 @@ for prerequisites, the two-terminal dev loop, project layout, tests, and
 conventions.
 
 ## Updating
+
+Packaged installs check the OpenHPSDR-Zeus-org GitHub Releases feed on startup.
+When a newer tagged release is available, Zeus shows an update notice and
+**Settings → Updates** offers **Update now** for the matching installer, DMG, or
+AppImage for your platform.
 
 If you run Zeus from a git checkout, **Settings → Updates** shows how far behind
 the upstream repo you are and can fast-forward your checkout with one click.

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -1920,16 +1920,19 @@ public sealed record TxFidelityPolicyDto(
     string ProfileId,
     int TargetSpectralDensity);
 
-/// <summary>Status of the local git checkout relative to its configured
-/// upstream, for the Settings -> Updates panel (GET /api/system/update).
+/// <summary>Status of the local install relative to the latest available Zeus
+/// update, for the Settings -> Updates panel (GET /api/system/update).
 /// <para>When <see cref="IsGitRepo"/> is false the app is running from a
-/// non-git build and the UI falls back to manual-update guidance. All SHAs are
-/// short form. <see cref="Behind"/>/<see cref="Ahead"/> count commits relative
-/// to <see cref="UpstreamRef"/> (e.g. "upstream/main"). <see cref="CanFastForward"/>
+/// packaged build; release fields describe the matching GitHub Release asset
+/// when a network check has completed. All SHAs are short form.
+/// <see cref="Behind"/>/<see cref="Ahead"/> count commits relative to
+/// <see cref="UpstreamRef"/> (e.g. "upstream/main"). <see cref="CanFastForward"/>
 /// is true only when behind &gt; 0, HEAD is an ancestor of the upstream tip, and
-/// the working tree is clean. <see cref="Error"/> carries a human message when a
-/// git call failed (e.g. offline fetch); the rest of the fields hold the last
-/// locally-known values in that case.</para></summary>
+/// the working tree is clean. <see cref="UpdateAction"/> is "pull" for git
+/// checkouts, "download" for packaged builds with a matching asset,
+/// "openRelease" when only the release page is available, or "none".
+/// <see cref="Error"/> carries a human message when a git or release check
+/// failed; the rest of the fields hold the last locally-known values.</para></summary>
 public sealed record RepoUpdateStatus(
     bool IsGitRepo,
     string? Branch,
@@ -1945,7 +1948,23 @@ public sealed record RepoUpdateStatus(
     string? LatestRemoteSubject,
     string? RemoteUrl,
     string? CheckedUtc,
-    string? Error);
+    string? Error)
+{
+    public string InstalledVersion { get; init; } = "unknown";
+    public string RuntimePlatform { get; init; } = "unknown";
+    public string RuntimeArchitecture { get; init; } = "unknown";
+    public bool UpdateAvailable { get; init; }
+    public string UpdateAction { get; init; } = "none";
+    public string? LatestVersion { get; init; }
+    public string? ReleaseTag { get; init; }
+    public string? ReleaseName { get; init; }
+    public string? ReleaseUrl { get; init; }
+    public string? ReleasePublishedUtc { get; init; }
+    public string? ReleaseAssetName { get; init; }
+    public string? ReleaseDownloadUrl { get; init; }
+    public long? ReleaseAssetSizeBytes { get; init; }
+    public string? ReleaseAssetDigest { get; init; }
+}
 
 /// <summary>Result of a fast-forward pull (POST /api/system/update/pull).
 /// <see cref="RequiresRebuild"/> is true whenever source actually changed —

--- a/Zeus.Server.Hosting/RepoUpdateService.cs
+++ b/Zeus.Server.Hosting/RepoUpdateService.cs
@@ -8,34 +8,48 @@
 // statement and per-component attribution.
 //
 // RepoUpdateService — reports whether the running checkout is behind its
-// configured git upstream and performs a fast-forward pull on request. It is a
-// thin git-CLI wrapper (no new dependencies): every operation shells out to the
-// `git` already on PATH, scoped to the repo root with `git -C <root>`.
+// configured git upstream, or whether a packaged install is behind the latest
+// GitHub Release. The git path remains a thin CLI wrapper (no new dependencies):
+// every operation shells out to the `git` already on PATH, scoped to the repo
+// root with `git -C <root>`.
 //
-// This drives Settings -> Updates (/api/system/update). It deliberately does
-// NOT rebuild or restart — the running binaries are stale after a pull, so the
-// UI tells the operator to run scripts/update.* and restart. If the app is not
-// running from a git checkout (a packaged build) every call reports
-// IsGitRepo=false and the UI shows manual-update guidance instead.
+// This drives Settings -> Updates (/api/system/update). Git checkout updates
+// deliberately do NOT rebuild or restart — the running binaries are stale after
+// a pull, so the UI tells the operator to run scripts/update.* and restart.
+// Packaged builds surface the matching release asset download URL; replacing
+// the running executable is left to the installer / DMG / AppImage flow.
 
 using System.Diagnostics;
+using System.Net;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using Zeus.Contracts;
 
 namespace Zeus.Server;
 
 /// <summary>Git-checkout update helper backing the Settings -> Updates panel.
 /// Registered as a singleton in <c>ZeusHost</c>.</summary>
-public sealed class RepoUpdateService
+public sealed partial class RepoUpdateService
 {
+    internal const string LatestReleaseApi =
+        "https://api.github.com/repos/OpenHPSDR-Zeus-org/openhpsdr-zeus/releases/latest";
+
+    private static readonly JsonSerializerOptions GitHubJsonOptions = new(JsonSerializerDefaults.Web);
+
     private readonly ILogger<RepoUpdateService> _log;
+    private readonly IHttpClientFactory _httpClientFactory;
     private readonly string? _repoRoot;
 
-    public RepoUpdateService(ILogger<RepoUpdateService> log)
+    public RepoUpdateService(ILogger<RepoUpdateService> log, IHttpClientFactory httpClientFactory)
     {
         _log = log;
+        _httpClientFactory = httpClientFactory;
         _repoRoot = ResolveRepoRoot();
         if (_repoRoot is null)
-            _log.LogInformation("RepoUpdateService: not running from a git checkout; update checks disabled");
+            _log.LogInformation("RepoUpdateService: not running from a git checkout; release updates enabled");
         else
             _log.LogInformation("RepoUpdateService: repo root {Root}", _repoRoot);
     }
@@ -47,7 +61,7 @@ public sealed class RepoUpdateService
     public async Task<RepoUpdateStatus> GetStatusAsync(bool fetch, CancellationToken ct)
     {
         if (_repoRoot is null)
-            return NotAGitRepo();
+            return await AddReleaseStatusAsync(NotAGitRepo(), fetch, ct).ConfigureAwait(false);
 
         try
         {
@@ -113,7 +127,14 @@ public sealed class RepoUpdateService
                 LatestRemoteSubject: latestSubject,
                 RemoteUrl: remoteUrl,
                 CheckedUtc: DateTime.UtcNow.ToString("o"),
-                Error: note);
+                Error: note)
+            {
+                InstalledVersion = InstalledVersion(),
+                RuntimePlatform = RuntimePlatform(),
+                RuntimeArchitecture = RuntimeInformation.OSArchitecture.ToString(),
+                UpdateAvailable = behind > 0,
+                UpdateAction = canFf ? "pull" : "none",
+            };
         }
         catch (Exception ex)
         {
@@ -123,7 +144,12 @@ public sealed class RepoUpdateService
                 CurrentSubject: null, UpstreamRef: null, Behind: 0, Ahead: 0, Dirty: false,
                 CanFastForward: false, LatestRemoteSha: null, LatestRemoteSubject: null,
                 RemoteUrl: null, CheckedUtc: DateTime.UtcNow.ToString("o"),
-                Error: GitMissing(ex) ? "git is not installed or not on PATH" : ex.Message);
+                Error: GitMissing(ex) ? "git is not installed or not on PATH" : ex.Message)
+            {
+                InstalledVersion = InstalledVersion(),
+                RuntimePlatform = RuntimePlatform(),
+                RuntimeArchitecture = RuntimeInformation.OSArchitecture.ToString(),
+            };
         }
     }
 
@@ -133,7 +159,8 @@ public sealed class RepoUpdateService
     public async Task<RepoUpdateResult> PullAsync(CancellationToken ct)
     {
         if (_repoRoot is null)
-            return new RepoUpdateResult(false, null, false, "Not running from a git checkout — update manually.");
+            return new RepoUpdateResult(false, null, false,
+                "Not running from a git checkout — download the latest Zeus release.");
 
         try
         {
@@ -160,6 +187,86 @@ public sealed class RepoUpdateService
             _log.LogWarning(ex, "repo update pull failed");
             return new RepoUpdateResult(false, null, false,
                 GitMissing(ex) ? "git is not installed or not on PATH" : ex.Message);
+        }
+    }
+
+    private async Task<RepoUpdateStatus> AddReleaseStatusAsync(
+        RepoUpdateStatus status,
+        bool fetch,
+        CancellationToken ct)
+    {
+        if (!fetch)
+            return status;
+
+        try
+        {
+            using var response = await _httpClientFactory.CreateClient("ZeusUpdates")
+                .GetAsync(LatestReleaseApi, ct)
+                .ConfigureAwait(false);
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return status with
+                {
+                    CheckedUtc = DateTime.UtcNow.ToString("o"),
+                    Error = MergeNotes(status.Error, "No published Zeus release was found on GitHub."),
+                };
+            }
+
+            response.EnsureSuccessStatusCode();
+            var release = await response.Content
+                .ReadFromJsonAsync<GitHubRelease>(GitHubJsonOptions, ct)
+                .ConfigureAwait(false);
+            if (release is null || string.IsNullOrWhiteSpace(release.TagName))
+            {
+                return status with
+                {
+                    CheckedUtc = DateTime.UtcNow.ToString("o"),
+                    Error = MergeNotes(status.Error, "GitHub returned an empty release response."),
+                };
+            }
+
+            var asset = SelectReleaseAsset(
+                release.Assets,
+                RuntimePlatform(),
+                RuntimeInformation.OSArchitecture,
+                IsRunningFromAppImage(),
+                IsServerMode());
+            var latestVersion = NormalizeReleaseVersion(release.TagName);
+            var updateAvailable = IsReleaseNewer(latestVersion, status.InstalledVersion);
+            var updateAction = updateAvailable
+                ? asset?.BrowserDownloadUrl is { Length: > 0 }
+                    ? "download"
+                    : !string.IsNullOrWhiteSpace(release.HtmlUrl) ? "openRelease" : "none"
+                : "none";
+
+            return status with
+            {
+                CheckedUtc = DateTime.UtcNow.ToString("o"),
+                UpdateAvailable = updateAvailable,
+                UpdateAction = updateAction,
+                LatestVersion = latestVersion,
+                ReleaseTag = release.TagName,
+                ReleaseName = release.Name,
+                ReleaseUrl = release.HtmlUrl,
+                ReleasePublishedUtc = release.PublishedAt,
+                ReleaseAssetName = asset?.Name,
+                ReleaseDownloadUrl = asset?.BrowserDownloadUrl,
+                ReleaseAssetSizeBytes = asset?.Size,
+                ReleaseAssetDigest = asset?.Digest,
+            };
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _log.LogDebug(ex, "release update check failed");
+            return status with
+            {
+                CheckedUtc = DateTime.UtcNow.ToString("o"),
+                Error = MergeNotes(status.Error, $"release check failed (offline?): {Trunc(ex.Message)}"),
+            };
         }
     }
 
@@ -218,7 +325,12 @@ public sealed class RepoUpdateService
         IsGitRepo: false, Branch: null, CurrentSha: null, CurrentShortSha: null,
         CurrentSubject: null, UpstreamRef: null, Behind: 0, Ahead: 0, Dirty: false,
         CanFastForward: false, LatestRemoteSha: null, LatestRemoteSubject: null,
-        RemoteUrl: null, CheckedUtc: null, Error: "Not running from a git checkout.");
+        RemoteUrl: null, CheckedUtc: null, Error: null)
+    {
+        InstalledVersion = InstalledVersion(),
+        RuntimePlatform = RuntimePlatform(),
+        RuntimeArchitecture = RuntimeInformation.OSArchitecture.ToString(),
+    };
 
     private static string PreferErr((bool Ok, string Out, string Err) r)
         => !string.IsNullOrWhiteSpace(r.Err) ? r.Err : r.Out;
@@ -235,6 +347,109 @@ public sealed class RepoUpdateService
     private static string Trunc(string s, int max = 300)
         => s.Length <= max ? s : s[..max] + "…";
 
+    private static string MergeNotes(string? first, string second)
+        => string.IsNullOrWhiteSpace(first) ? second : $"{first}; {second}";
+
+    private static string InstalledVersion()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        var attr = assembly.GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false)
+            .FirstOrDefault() as AssemblyInformationalVersionAttribute;
+        return string.IsNullOrWhiteSpace(attr?.InformationalVersion)
+            ? "unknown"
+            : attr.InformationalVersion;
+    }
+
+    internal static string NormalizeReleaseVersion(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return string.Empty;
+        var m = VersionPattern().Match(value);
+        return m.Success ? m.Value.TrimStart('v', 'V') : value.Trim().TrimStart('v', 'V');
+    }
+
+    internal static bool IsReleaseNewer(string? latest, string? installed)
+    {
+        return TryParseReleaseVersion(latest, out var latestVersion)
+            && TryParseReleaseVersion(installed, out var installedVersion)
+            && latestVersion.CompareTo(installedVersion) > 0;
+    }
+
+    private static bool TryParseReleaseVersion(string? value, out Version version)
+    {
+        version = new Version(0, 0, 0);
+        if (string.IsNullOrWhiteSpace(value)) return false;
+        var m = VersionPattern().Match(value);
+        if (!m.Success) return false;
+        version = new Version(
+            int.Parse(m.Groups["major"].Value),
+            int.Parse(m.Groups["minor"].Value),
+            int.Parse(m.Groups["patch"].Value));
+        return true;
+    }
+
+    [GeneratedRegex(@"[vV]?(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)")]
+    private static partial Regex VersionPattern();
+
+    internal static GitHubReleaseAsset? SelectReleaseAsset(
+        IReadOnlyList<GitHubReleaseAsset>? assets,
+        string platform,
+        Architecture architecture,
+        bool runningFromAppImage,
+        bool serverMode)
+    {
+        if (assets is null || assets.Count == 0) return null;
+
+        var isArm64 = architecture == Architecture.Arm64;
+        if (string.Equals(platform, "windows", StringComparison.OrdinalIgnoreCase))
+        {
+            return FindAsset(assets, isArm64 ? "-win-arm64-setup.exe" : "-win-x64-setup.exe");
+        }
+
+        if (string.Equals(platform, "macos", StringComparison.OrdinalIgnoreCase))
+        {
+            return FindAsset(assets, isArm64 ? "-macos-arm64.dmg" : "-macos-x64.dmg");
+        }
+
+        if (string.Equals(platform, "linux", StringComparison.OrdinalIgnoreCase))
+        {
+            if (runningFromAppImage)
+            {
+                var appImageArch = isArm64 ? "aarch64" : "x86_64";
+                var suffix = $"-linux-{appImageArch}.AppImage";
+                var appImage = assets.FirstOrDefault(a =>
+                    a.Name.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)
+                    && (serverMode
+                        ? a.Name.StartsWith("OpenhpsdrZeus-Server-", StringComparison.OrdinalIgnoreCase)
+                        : !a.Name.StartsWith("OpenhpsdrZeus-Server-", StringComparison.OrdinalIgnoreCase)));
+                if (appImage is not null) return appImage;
+            }
+
+            return FindAsset(assets, isArm64 ? "-linux-arm64.tar.gz" : "-linux-x64.tar.gz");
+        }
+
+        return null;
+    }
+
+    private static GitHubReleaseAsset? FindAsset(
+        IReadOnlyList<GitHubReleaseAsset> assets,
+        string suffix)
+        => assets.FirstOrDefault(a => a.Name.EndsWith(suffix, StringComparison.OrdinalIgnoreCase));
+
+    private static string RuntimePlatform()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return "windows";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return "macos";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return "linux";
+        return "unknown";
+    }
+
+    private static bool IsRunningFromAppImage()
+        => !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("APPIMAGE"));
+
+    private static bool IsServerMode()
+        => Environment.GetCommandLineArgs()
+            .Any(a => string.Equals(a, "--server", StringComparison.OrdinalIgnoreCase));
+
     /// <summary>Walk up from the running binary's directory until a `.git` entry
     /// is found (directory for a normal clone, file for a worktree/submodule).</summary>
     private static string? ResolveRepoRoot()
@@ -249,4 +464,37 @@ public sealed class RepoUpdateService
         }
         return null;
     }
+}
+
+internal sealed class GitHubRelease
+{
+    [JsonPropertyName("tag_name")]
+    public string? TagName { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("html_url")]
+    public string? HtmlUrl { get; set; }
+
+    [JsonPropertyName("published_at")]
+    public string? PublishedAt { get; set; }
+
+    [JsonPropertyName("assets")]
+    public List<GitHubReleaseAsset> Assets { get; set; } = [];
+}
+
+internal sealed class GitHubReleaseAsset
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("browser_download_url")]
+    public string? BrowserDownloadUrl { get; set; }
+
+    [JsonPropertyName("size")]
+    public long Size { get; set; }
+
+    [JsonPropertyName("digest")]
+    public string? Digest { get; set; }
 }

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -69,11 +69,10 @@ public static class ZeusEndpoints
                 return Results.Ok(saved);
             });
 
-        // Self-update from the git checkout. GET reports how far behind the
-        // configured upstream the running source is (fetch=false skips the
-        // network and reports the last-known counts); POST fast-forwards. Neither
-        // rebuilds/restarts — the UI tells the operator to run scripts/update.*
-        // and restart. Backed by RepoUpdateService.
+        // Self-update status. Git checkouts report upstream fast-forward state;
+        // packaged builds report the latest GitHub Release asset for this
+        // platform. POST is git-checkout-only and fast-forwards source; packaged
+        // installs download their installer/DMG/AppImage from the GET response.
         app.MapGet("/api/system/update",
             async (RepoUpdateService updates, bool? fetch, CancellationToken ct) =>
                 Results.Ok(await updates.GetStatusAsync(fetch ?? true, ct)));

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -344,6 +344,14 @@ public static class ZeusHost
         // Localhost proxy to the HamClock sidecar's propagation engine. The first
         // P.533-14 prediction for a cold path can take ~20 s upstream; allow for it.
         builder.Services.AddHttpClient("Propagation", c => c.Timeout = TimeSpan.FromSeconds(25));
+        // Public GitHub release metadata for packaged-app update checks.
+        builder.Services.AddHttpClient("ZeusUpdates", c =>
+        {
+            c.Timeout = TimeSpan.FromSeconds(15);
+            c.DefaultRequestHeaders.UserAgent.ParseAdd("OpenHPSDR-Zeus-Updater/1.0");
+            c.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
+            c.DefaultRequestHeaders.Add("X-GitHub-Api-Version", "2022-11-28");
+        });
         builder.Services.AddSingleton<CredentialStore>();
         builder.Services.AddSingleton<BandMemoryStore>();
         builder.Services.AddSingleton<LayoutStore>();

--- a/tests/Zeus.Server.Tests/RepoUpdateServiceTests.cs
+++ b/tests/Zeus.Server.Tests/RepoUpdateServiceTests.cs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+
+using System.Runtime.InteropServices;
+
+namespace Zeus.Server.Tests;
+
+public class RepoUpdateServiceTests
+{
+    [Theory]
+    [InlineData("v0.9.1", "0.9.0", true)]
+    [InlineData("v0.9.1", "0.9.1", false)]
+    [InlineData("v0.9.1", "0.9.1-dev", false)]
+    [InlineData("v0.10.0", "0.9.9", true)]
+    [InlineData("bad", "0.9.1", false)]
+    public void IsReleaseNewer_UsesNumericReleaseVersion(string latest, string installed, bool expected)
+    {
+        Assert.Equal(expected, RepoUpdateService.IsReleaseNewer(latest, installed));
+    }
+
+    [Theory]
+    [InlineData("windows", Architecture.X64, false, false, "openhpsdr-zeus-0.9.1-win-x64-setup.exe")]
+    [InlineData("windows", Architecture.Arm64, false, false, "openhpsdr-zeus-0.9.1-win-arm64-setup.exe")]
+    [InlineData("macos", Architecture.Arm64, false, false, "OpenhpsdrZeus-0.9.1-macos-arm64.dmg")]
+    [InlineData("linux", Architecture.X64, false, false, "openhpsdr-zeus-0.9.1-linux-x64.tar.gz")]
+    [InlineData("linux", Architecture.Arm64, false, false, "openhpsdr-zeus-0.9.1-linux-arm64.tar.gz")]
+    [InlineData("linux", Architecture.X64, true, false, "OpenhpsdrZeus-0.9.1-linux-x86_64.AppImage")]
+    [InlineData("linux", Architecture.X64, true, true, "OpenhpsdrZeus-Server-0.9.1-linux-x86_64.AppImage")]
+    public void SelectReleaseAsset_PicksPlatformAsset(
+        string platform,
+        Architecture architecture,
+        bool appImage,
+        bool serverMode,
+        string expected)
+    {
+        var asset = RepoUpdateService.SelectReleaseAsset(
+            ReleaseAssets(),
+            platform,
+            architecture,
+            appImage,
+            serverMode);
+
+        Assert.NotNull(asset);
+        Assert.Equal(expected, asset.Name);
+    }
+
+    [Fact]
+    public void SelectReleaseAsset_FallsBackToTarballWhenArm64AppImageIsMissing()
+    {
+        var asset = RepoUpdateService.SelectReleaseAsset(
+            ReleaseAssets(),
+            "linux",
+            Architecture.Arm64,
+            runningFromAppImage: true,
+            serverMode: false);
+
+        Assert.NotNull(asset);
+        Assert.Equal("openhpsdr-zeus-0.9.1-linux-arm64.tar.gz", asset.Name);
+    }
+
+    private static List<GitHubReleaseAsset> ReleaseAssets() => new()
+    {
+        new() { Name = "openhpsdr-zeus-0.9.1-linux-arm64.tar.gz" },
+        new() { Name = "openhpsdr-zeus-0.9.1-linux-x64.tar.gz" },
+        new() { Name = "openhpsdr-zeus-0.9.1-win-arm64-setup.exe" },
+        new() { Name = "openhpsdr-zeus-0.9.1-win-x64-setup.exe" },
+        new() { Name = "OpenhpsdrZeus-0.9.1-linux-x86_64.AppImage" },
+        new() { Name = "OpenhpsdrZeus-0.9.1-macos-arm64.dmg" },
+        new() { Name = "OpenhpsdrZeus-Server-0.9.1-linux-x86_64.AppImage" },
+    };
+}

--- a/zeus-web/e2e/release-update-flow.spec.ts
+++ b/zeus-web/e2e/release-update-flow.spec.ts
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { expect, test, type Page, type Route } from '@playwright/test';
+
+const downloadUrl =
+  'https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus/releases/download/v0.9.2/OpenHPSDR-Zeus-v0.9.2-win-x64-setup.exe';
+
+const releaseUpdateStatus = {
+  isGitRepo: false,
+  branch: null,
+  currentSha: null,
+  currentShortSha: null,
+  currentSubject: null,
+  upstreamRef: null,
+  behind: 0,
+  ahead: 0,
+  dirty: false,
+  canFastForward: false,
+  latestRemoteSha: null,
+  latestRemoteSubject: null,
+  remoteUrl: null,
+  checkedUtc: '2026-06-19T13:48:38.990Z',
+  error: null,
+  installedVersion: '0.9.1',
+  runtimePlatform: 'windows',
+  runtimeArchitecture: 'X64',
+  updateAvailable: true,
+  updateAction: 'download',
+  latestVersion: '0.9.2',
+  releaseTag: 'v0.9.2',
+  releaseName: 'Zeus v0.9.2',
+  releaseUrl: 'https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus/releases/tag/v0.9.2',
+  releasePublishedUtc: '2026-06-19T12:00:00Z',
+  releaseAssetName: 'OpenHPSDR-Zeus-v0.9.2-win-x64-setup.exe',
+  releaseDownloadUrl: downloadUrl,
+  releaseAssetSizeBytes: 134_217_728,
+  releaseAssetDigest: 'sha256:0123456789abcdef',
+};
+
+async function fulfillJson(route: Route, body: unknown) {
+  await route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  });
+}
+
+async function stubZeusApi(page: Page) {
+  await page.addInitScript(() => {
+    const NativeWebSocket = window.WebSocket;
+    class MockZeusWebSocket extends EventTarget {
+      readonly url: string;
+      readonly protocol = '';
+      readonly extensions = '';
+      binaryType: BinaryType = 'blob';
+      bufferedAmount = 0;
+      readyState = NativeWebSocket.CONNECTING;
+      onopen: ((this: WebSocket, ev: Event) => unknown) | null = null;
+      onmessage: ((this: WebSocket, ev: MessageEvent) => unknown) | null = null;
+      onerror: ((this: WebSocket, ev: Event) => unknown) | null = null;
+      onclose: ((this: WebSocket, ev: CloseEvent) => unknown) | null = null;
+
+      constructor(url: string | URL) {
+        super();
+        this.url = String(url);
+        window.setTimeout(() => {
+          if (this.readyState !== NativeWebSocket.CONNECTING) return;
+          this.readyState = NativeWebSocket.OPEN;
+          const event = new Event('open');
+          this.onopen?.call(this as unknown as WebSocket, event);
+          this.dispatchEvent(event);
+        }, 0);
+      }
+
+      send() {
+        /* No realtime frames are needed for this update-flow test. */
+      }
+
+      close() {
+        if (this.readyState === NativeWebSocket.CLOSED) return;
+        this.readyState = NativeWebSocket.CLOSED;
+        const event = new CloseEvent('close');
+        this.onclose?.call(this as unknown as WebSocket, event);
+        this.dispatchEvent(event);
+      }
+    }
+
+    const PatchedWebSocket = function (
+      url: string | URL,
+      protocols?: string | string[],
+    ): WebSocket {
+      const parsed = new URL(String(url), window.location.href);
+      if (parsed.pathname === '/ws') {
+        return new MockZeusWebSocket(url) as unknown as WebSocket;
+      }
+      return protocols === undefined
+        ? new NativeWebSocket(url)
+        : new NativeWebSocket(url, protocols);
+    } as unknown as typeof WebSocket;
+    Object.assign(PatchedWebSocket, {
+      CONNECTING: NativeWebSocket.CONNECTING,
+      OPEN: NativeWebSocket.OPEN,
+      CLOSING: NativeWebSocket.CLOSING,
+      CLOSED: NativeWebSocket.CLOSED,
+    });
+    PatchedWebSocket.prototype = NativeWebSocket.prototype;
+    window.WebSocket = PatchedWebSocket;
+
+    const openedUrls: string[] = [];
+    Object.defineProperty(window, '__zeusOpenedUrls', {
+      value: openedUrls,
+      configurable: false,
+    });
+    window.open = ((url?: string | URL | null) => {
+      openedUrls.push(url == null ? '' : String(url));
+      return null;
+    }) as typeof window.open;
+  });
+
+  await page.route(/^https?:\/\/[^/]+\/api(?:\/|\?|$)/, async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const method = request.method();
+
+    if (url.pathname === '/api/system/update') {
+      await fulfillJson(route, releaseUpdateStatus);
+      return;
+    }
+
+    if (url.pathname === '/api/capabilities') {
+      await fulfillJson(route, {
+        host: 'server',
+        platform: 'windows',
+        architecture: 'X64',
+        version: '0.9.1',
+        lanHttpsUrls: [],
+        features: {},
+      });
+      return;
+    }
+
+    if (url.pathname === '/api/radio/selection') {
+      await fulfillJson(route, {
+        preferred: 'Auto',
+        connected: 'Unknown',
+        effective: 'Unknown',
+        overrideDetection: false,
+      });
+      return;
+    }
+
+    if (url.pathname === '/api/plugins') {
+      await fulfillJson(route, {
+        sdkAbi: 1,
+        sdkVersion: '0.9.1',
+        plugins: [],
+      });
+      return;
+    }
+
+    if (url.pathname === '/api/ui/layouts' && method === 'GET') {
+      await fulfillJson(route, {
+        radioKey: url.searchParams.get('radio') ?? 'default',
+        layouts: [],
+        activeLayoutId: 'default',
+      });
+      return;
+    }
+
+    if (url.pathname === '/api/ui/layouts') {
+      await route.fulfill({ status: 204, body: '' });
+      return;
+    }
+
+    await route.fulfill({
+      status: 404,
+      contentType: 'application/json',
+      body: '{}',
+    });
+  });
+}
+
+test('packaged startup update opens Settings and the selected release asset', async ({ page }) => {
+  const pageErrors: string[] = [];
+  page.on('pageerror', (err) => pageErrors.push(err.message));
+  await stubZeusApi(page);
+
+  await page.goto('/');
+
+  await expect(page.getByText('UPDATE AVAILABLE')).toBeVisible();
+  await expect(page.getByText('Zeus 0.9.2 is ready')).toBeVisible();
+  await expect(page.getByText(/Installed 0\.9\.1.*OpenHPSDR-Zeus-v0\.9\.2-win-x64-setup\.exe/)).toBeVisible();
+
+  await page.getByRole('button', { name: 'DETAILS' }).click();
+
+  await expect(page.getByRole('region', { name: 'Settings' })).toBeVisible();
+  await expect(page.getByRole('tab', { name: 'UPDATES' })).toHaveAttribute('aria-selected', 'true');
+  await expect(page.getByRole('heading', { name: 'SOFTWARE UPDATES' })).toBeVisible();
+  await expect(page.getByText('Version 0.9.2 available')).toBeVisible();
+  await expect(page.getByText('OpenHPSDR-Zeus-v0.9.2-win-x64-setup.exe')).toBeVisible();
+
+  await page.getByRole('button', { name: 'UPDATE NOW' }).click();
+
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        ((window as unknown as { __zeusOpenedUrls: string[] }).__zeusOpenedUrls),
+      ),
+    )
+    .toEqual([downloadUrl]);
+
+  expect(pageErrors).toEqual([]);
+});

--- a/zeus-web/package-lock.json
+++ b/zeus-web/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
+        "@playwright/test": "^1.61.0",
         "@tailwindcss/vite": "^4.0.0",
         "@types/leaflet": "^1.9.21",
         "@types/node": "^22.10.2",
@@ -2454,6 +2455,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -7196,6 +7213,53 @@
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",

--- a/zeus-web/package.json
+++ b/zeus-web/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint .",
     "typecheck": "tsc -b --noEmit",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "test:watch": "vitest",
     "smoke": "node scripts/smoke.mjs"
   },
@@ -25,6 +26,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.0.0",
     "@types/leaflet": "^1.9.21",
     "@types/node": "^22.10.2",

--- a/zeus-web/playwright.config.ts
+++ b/zeus-web/playwright.config.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { defineConfig, devices } from '@playwright/test';
+
+const port = Number(process.env.E2E_PORT ?? 5174);
+const baseURL = `http://127.0.0.1:${port}`;
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: `npm run dev -- --host 127.0.0.1 --port ${port}`,
+    url: baseURL,
+    timeout: 120_000,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -75,6 +75,7 @@ import { DspSceneDiagnosticsPublisher } from './components/DspSceneDiagnosticsPu
 import { AudioPlaybackDiagnosticsPublisher } from './components/AudioPlaybackDiagnosticsPublisher';
 import { ThemeApplier } from './components/ThemeApplier';
 import { TxStationProfileActivator } from './components/TxStationProfileActivator';
+import { StartupUpdatePrompt } from './components/StartupUpdatePrompt';
 import { StepFavorites } from './components/toolbar/StepFavorites';
 import { TunButton } from './components/TunButton';
 import { BOARD_LABELS } from './api/radio';
@@ -86,7 +87,7 @@ import { getServerBaseUrl, isCapacitorRuntime } from './serverUrl';
 import { getAudioClient } from './audio/audio-client';
 import { setAudioHostMode } from './audio/host-mode';
 import { useMicUplink } from './audio/use-mic-uplink';
-import { fetchState } from './api/client';
+import { fetchState, fetchUpdateStatus, type RepoUpdateStatus } from './api/client';
 import { useConnectionStore } from './state/connection-store';
 import { useRadioStore } from './state/radio-store';
 import { useQrzStore } from './state/qrz-store';
@@ -131,6 +132,8 @@ export default function App() {
   );
   const [updateAvailable, setUpdateAvailable] = useState(false);
   const [installUpdate, setInstallUpdate] = useState<(() => Promise<void>) | null>(null);
+  const [startupUpdate, setStartupUpdate] = useState<RepoUpdateStatus | null>(null);
+  const [startupUpdateDismissed, setStartupUpdateDismissed] = useState(false);
   const [confirmResetLayout, setConfirmResetLayout] = useState<{
     id: string;
     name: string;
@@ -231,6 +234,22 @@ export default function App() {
     if (install) {
       setInstallUpdate(() => install);
     }
+  }, []);
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    fetchUpdateStatus(true, ctrl.signal)
+      .then((next) => {
+        const actionableRelease =
+          !next.isGitRepo
+          && next.updateAvailable
+          && (next.updateAction === 'download' || next.updateAction === 'openRelease');
+        if (actionableRelease) setStartupUpdate(next);
+      })
+      .catch(() => {
+        /* Settings -> Updates exposes manual retry and detailed errors. */
+      });
+    return () => ctrl.abort();
   }, []);
 
   useEffect(() => {
@@ -335,6 +354,7 @@ export default function App() {
         hash === 'rotator' ||
         hash === 'pa' ||
         hash === 'server' ||
+        hash === 'updates' ||
         hash === 'about'
       ) {
         setSettingsView(true, hash as SettingsTabId);
@@ -1022,6 +1042,11 @@ export default function App() {
           <p>This keeps the layout tab but replaces its current panel positions.</p>
         </ConfirmDialog>
       )}
+      <StartupUpdatePrompt
+        status={!startupUpdateDismissed ? startupUpdate : null}
+        onDismiss={() => setStartupUpdateDismissed(true)}
+        onOpenSettings={() => setSettingsView(true, 'updates')}
+      />
       <UpdatePrompt show={updateAvailable} onUpdate={installUpdate} />
     </div>
     </SpectrumWheelActionsContext.Provider>

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -4908,7 +4908,9 @@ export function restartApp(
   );
 }
 
-/** Status of the local git checkout vs its configured upstream
+export type UpdateAction = 'none' | 'pull' | 'download' | 'openRelease';
+
+/** Status of the local install vs its configured update source
  *  (GET /api/system/update). Mirrors Zeus.Contracts.RepoUpdateStatus. */
 export interface RepoUpdateStatus {
   isGitRepo: boolean;
@@ -4926,6 +4928,20 @@ export interface RepoUpdateStatus {
   remoteUrl: string | null;
   checkedUtc: string | null;
   error: string | null;
+  installedVersion: string;
+  runtimePlatform: string;
+  runtimeArchitecture: string;
+  updateAvailable: boolean;
+  updateAction: UpdateAction;
+  latestVersion: string | null;
+  releaseTag: string | null;
+  releaseName: string | null;
+  releaseUrl: string | null;
+  releasePublishedUtc: string | null;
+  releaseAssetName: string | null;
+  releaseDownloadUrl: string | null;
+  releaseAssetSizeBytes: number | null;
+  releaseAssetDigest: string | null;
 }
 
 /** Result of POST /api/system/update/pull. Mirrors Zeus.Contracts.RepoUpdateResult. */

--- a/zeus-web/src/components/StartupUpdatePrompt.tsx
+++ b/zeus-web/src/components/StartupUpdatePrompt.tsx
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+import { useEffect, useState } from 'react';
+import type { RepoUpdateStatus } from '../api/client';
+
+type Props = {
+  status: RepoUpdateStatus | null;
+  onDismiss: () => void;
+  onOpenSettings: () => void;
+};
+
+function updateUrl(status: RepoUpdateStatus): string | null {
+  return status.releaseDownloadUrl ?? status.releaseUrl;
+}
+
+export function StartupUpdatePrompt({ status, onDismiss, onOpenSettings }: Props) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!status) return;
+    const timer = setTimeout(() => setVisible(true), 100);
+    return () => clearTimeout(timer);
+  }, [status]);
+
+  if (!status) return null;
+
+  const url = updateUrl(status);
+  const latest = status.latestVersion ?? status.releaseTag ?? 'latest';
+
+  const openUpdate = () => {
+    if (url) window.open(url, '_blank', 'noopener,noreferrer');
+    onDismiss();
+  };
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        position: 'fixed',
+        top: 16,
+        right: 16,
+        zIndex: 10000,
+        maxWidth: 420,
+        width: 'calc(100% - 32px)',
+        transform: `translateY(${visible ? '0' : '-120%'})`,
+        transition: 'transform 0.25s ease-out',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 10,
+          padding: 14,
+          borderRadius: 'var(--r-md)',
+          border: '1px solid var(--panel-border)',
+          background: 'var(--panel-top)',
+          color: 'var(--fg-1)',
+          boxShadow: '0 10px 28px rgba(0, 0, 0, 0.35)',
+        }}
+      >
+        <div>
+          <div
+            style={{
+              fontSize: 11,
+              fontWeight: 700,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color: 'var(--power)',
+              marginBottom: 4,
+            }}
+          >
+            UPDATE AVAILABLE
+          </div>
+          <div style={{ fontSize: 13, fontWeight: 700 }}>
+            Zeus {latest} is ready
+          </div>
+          <div style={{ fontSize: 11, color: 'var(--fg-3)', lineHeight: 1.4, marginTop: 3 }}>
+            Installed {status.installedVersion ?? 'unknown'}
+            {status.releaseAssetName ? ` - ${status.releaseAssetName}` : ''}
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, flexWrap: 'wrap' }}>
+          <button type="button" className="btn sm" onClick={onDismiss}>
+            LATER
+          </button>
+          <button
+            type="button"
+            className="btn sm"
+            onClick={() => {
+              onOpenSettings();
+              onDismiss();
+            }}
+          >
+            DETAILS
+          </button>
+          <button type="button" className="btn sm active" onClick={openUpdate} disabled={!url}>
+            UPDATE NOW
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/zeus-web/src/components/UpdatesPanel.tsx
+++ b/zeus-web/src/components/UpdatesPanel.tsx
@@ -7,13 +7,11 @@
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
-// UpdatesPanel — Settings → Updates. Shows how far the running git checkout is
-// behind its configured upstream and offers a one-click fast-forward pull
-// (GET/POST /api/system/update*, backed by RepoUpdateService). A pull updates
-// source only: the panel makes the required rebuild + restart explicit and
-// points at scripts/update.* rather than trying to rebuild a running binary.
+// UpdatesPanel — Settings -> Updates. Git checkouts can fast-forward their
+// configured upstream. Packaged builds check GitHub Releases and open the
+// matching installer / DMG / AppImage asset for this platform.
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, type CSSProperties, type ReactNode } from 'react';
 import {
   fetchUpdateStatus,
   pullUpdate,
@@ -21,11 +19,12 @@ import {
   type RepoUpdateResult,
 } from '../api/client';
 
-const labelStyle: React.CSSProperties = { fontSize: 11, fontWeight: 600, letterSpacing: '0.06em', color: 'var(--fg-2)' };
-const valueStyle: React.CSSProperties = { fontSize: 12, color: 'var(--fg-1)', fontFamily: 'monospace' };
-const hintStyle: React.CSSProperties = { fontSize: 10, lineHeight: 1.4, color: 'var(--fg-3)' };
+const labelStyle: CSSProperties = { fontSize: 11, fontWeight: 600, letterSpacing: '0.06em', color: 'var(--fg-2)' };
+const valueStyle: CSSProperties = { fontSize: 12, color: 'var(--fg-1)', fontFamily: 'monospace' };
+const hintStyle: CSSProperties = { fontSize: 10, lineHeight: 1.4, color: 'var(--fg-3)' };
+const linkStyle: CSSProperties = { color: 'var(--accent)', textDecoration: 'none' };
 
-function Row({ label, children }: { label: string; children: React.ReactNode }) {
+function Row({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div style={{ display: 'flex', gap: 10, alignItems: 'baseline' }}>
       <span style={{ ...labelStyle, minWidth: 92 }}>{label}</span>
@@ -42,6 +41,33 @@ function fmtChecked(iso: string | null): string {
   if (secs < 60) return `${secs}s ago`;
   const mins = Math.round(secs / 60);
   return mins < 60 ? `${mins}m ago` : `${Math.round(mins / 60)}h ago`;
+}
+
+function fmtBytes(bytes: number | null): string {
+  if (bytes == null || !Number.isFinite(bytes) || bytes <= 0) return '';
+  const mib = bytes / (1024 * 1024);
+  return `${mib.toFixed(mib >= 10 ? 0 : 1)} MB`;
+}
+
+function openExternal(url: string | null | undefined) {
+  if (!url) return;
+  window.open(url, '_blank', 'noopener,noreferrer');
+}
+
+function statusLabel(status: RepoUpdateStatus, updateAvailable: boolean): string {
+  if (updateAvailable && !status.isGitRepo && status.latestVersion) {
+    return `Version ${status.latestVersion} available`;
+  }
+  if (status.isGitRepo && status.behind > 0) {
+    return `${status.behind} update${status.behind === 1 ? '' : 's'} available`;
+  }
+  if (!status.isGitRepo && !status.latestVersion && !status.error) {
+    return 'Checking releases';
+  }
+  if (!status.error && (!status.isGitRepo || status.behind === 0)) {
+    return 'Up to date';
+  }
+  return 'Status unknown';
 }
 
 export function UpdatesPanel() {
@@ -64,7 +90,7 @@ export function UpdatesPanel() {
   }, []);
 
   // Quick local-only read on mount (no network), then a fetch in the background
-  // so the panel paints instantly but still reflects the real upstream state.
+  // so the panel paints instantly but still reflects the real upstream/release state.
   useEffect(() => {
     void (async () => {
       await check(false);
@@ -91,11 +117,38 @@ export function UpdatesPanel() {
     }
   };
 
-  const behind = status?.behind ?? 0;
-  const upToDate = status?.isGitRepo && behind === 0 && !status.error;
+  const doUpdate = async () => {
+    if (!status) return;
+    const action = status.updateAction ?? (status.canFastForward ? 'pull' : 'none');
+    if (action === 'pull') {
+      await doPull();
+      return;
+    }
+
+    const url = status.releaseDownloadUrl ?? status.releaseUrl;
+    openExternal(url);
+    setResult({
+      ok: Boolean(url),
+      newSha: null,
+      requiresRebuild: false,
+      message: url
+        ? status.releaseDownloadUrl
+          ? `Opened ${status.releaseAssetName ?? 'the latest Zeus download'}.`
+          : 'Opened the latest Zeus release page.'
+        : 'No release download is available for this platform.',
+    });
+  };
+
+  const action = status?.updateAction ?? (status?.canFastForward ? 'pull' : 'none');
+  const updateAvailable = status?.updateAvailable ?? (status?.isGitRepo ? status.behind > 0 : false);
+  const canUpdate = status != null
+    && (action === 'pull'
+      ? status.canFastForward
+      : action === 'download' || action === 'openRelease');
+  const assetSize = fmtBytes(status?.releaseAssetSizeBytes ?? null);
 
   return (
-    <div style={{ maxWidth: 600 }}>
+    <div style={{ maxWidth: 640 }}>
       <h3
         style={{
           margin: '0 0 14px',
@@ -113,33 +166,51 @@ export function UpdatesPanel() {
         <div style={{ fontSize: 12, color: 'var(--tx)', marginBottom: 12 }}>{loadError}</div>
       )}
 
-      {status && !status.isGitRepo && (
-        <div style={{ fontSize: 12, color: 'var(--fg-1)', lineHeight: 1.6 }}>
-          Zeus isn’t running from a git checkout, so in-app updates aren’t available. To update,
-          re-clone or pull the repository and rebuild — see the “Updating” section of the README.
-        </div>
-      )}
-
-      {status?.isGitRepo && (
+      {status && (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-          <section style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-            <Row label="Branch">{status.branch ?? '—'}</Row>
-            <Row label="Installed">
-              {status.currentShortSha ?? '—'}
-              {status.currentSubject ? (
-                <span style={{ color: 'var(--fg-3)', fontFamily: 'inherit' }}> · {status.currentSubject}</span>
-              ) : null}
-            </Row>
-            <Row label="Upstream">{status.upstreamRef ?? '—'}</Row>
-            {status.latestRemoteSha && (
-              <Row label="Available">
-                {status.latestRemoteSha}
-                {status.latestRemoteSubject ? (
-                  <span style={{ color: 'var(--fg-3)', fontFamily: 'inherit' }}> · {status.latestRemoteSubject}</span>
+          {status.isGitRepo ? (
+            <section style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              <Row label="Branch">{status.branch ?? '-'}</Row>
+              <Row label="Installed">
+                {status.currentShortSha ?? '-'}
+                {status.currentSubject ? (
+                  <span style={{ color: 'var(--fg-3)', fontFamily: 'inherit' }}> - {status.currentSubject}</span>
                 ) : null}
               </Row>
-            )}
-          </section>
+              <Row label="Upstream">{status.upstreamRef ?? '-'}</Row>
+              {status.latestRemoteSha && (
+                <Row label="Available">
+                  {status.latestRemoteSha}
+                  {status.latestRemoteSubject ? (
+                    <span style={{ color: 'var(--fg-3)', fontFamily: 'inherit' }}> - {status.latestRemoteSubject}</span>
+                  ) : null}
+                </Row>
+              )}
+            </section>
+          ) : (
+            <section style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              <Row label="Installed">{status.installedVersion ?? 'unknown'}</Row>
+              <Row label="Latest">{status.latestVersion ?? (checking ? 'checking...' : '-')}</Row>
+              <Row label="Platform">
+                {(status.runtimePlatform ?? 'unknown')}/{status.runtimeArchitecture ?? 'unknown'}
+              </Row>
+              {status.releaseUrl && (
+                <Row label="Release">
+                  <a href={status.releaseUrl} target="_blank" rel="noreferrer" style={linkStyle}>
+                    {status.releaseName ?? status.releaseTag ?? 'GitHub Releases'}
+                  </a>
+                </Row>
+              )}
+              {status.releaseAssetName && (
+                <Row label="Download">
+                  {status.releaseAssetName}
+                  {assetSize && (
+                    <span style={{ color: 'var(--fg-3)', fontFamily: 'inherit' }}> - {assetSize}</span>
+                  )}
+                </Row>
+              )}
+            </section>
+          )}
 
           <section
             style={{
@@ -156,17 +227,13 @@ export function UpdatesPanel() {
               style={{
                 fontSize: 13,
                 fontWeight: 700,
-                color: upToDate ? 'var(--fg-1)' : 'var(--power)',
+                color: updateAvailable ? 'var(--power)' : 'var(--fg-1)',
               }}
             >
-              {upToDate
-                ? 'Up to date'
-                : behind > 0
-                  ? `${behind} update${behind === 1 ? '' : 's'} available`
-                  : 'Status unknown'}
+              {statusLabel(status, updateAvailable)}
             </span>
-            {status.ahead > 0 && (
-              <span style={hintStyle}>· {status.ahead} local commit{status.ahead === 1 ? '' : 's'} ahead</span>
+            {status.isGitRepo && status.ahead > 0 && (
+              <span style={hintStyle}>- {status.ahead} local commit{status.ahead === 1 ? '' : 's'} ahead</span>
             )}
             {status.checkedUtc && (
               <span style={{ ...hintStyle, marginLeft: 'auto' }}>checked {fmtChecked(status.checkedUtc)}</span>
@@ -175,7 +242,7 @@ export function UpdatesPanel() {
 
           {status.dirty && (
             <div style={{ fontSize: 11, color: 'var(--tx)' }}>
-              Working tree has uncommitted changes — commit or stash them before updating.
+              Working tree has uncommitted changes. Commit or stash them before updating.
             </div>
           )}
           {status.error && (
@@ -189,24 +256,30 @@ export function UpdatesPanel() {
               disabled={checking || pulling}
               onClick={() => void check(true)}
             >
-              {checking ? 'CHECKING…' : 'CHECK FOR UPDATES'}
+              {checking ? 'CHECKING...' : 'CHECK FOR UPDATES'}
             </button>
             <button
               type="button"
               className="btn sm active"
-              disabled={!status.canFastForward || pulling || checking}
-              onClick={() => void doPull()}
+              disabled={!canUpdate || pulling || checking}
+              onClick={() => void doUpdate()}
               title={
-                status.canFastForward
-                  ? 'Fast-forward the checkout to the latest upstream commit'
-                  : status.dirty
-                    ? 'Commit or stash local changes first'
-                    : behind === 0
-                      ? 'Already up to date'
-                      : 'Cannot fast-forward (local commits diverge from upstream)'
+                action === 'pull'
+                  ? status.canFastForward
+                    ? 'Fast-forward the checkout to the latest upstream commit'
+                    : status.dirty
+                      ? 'Commit or stash local changes first'
+                      : status.behind === 0
+                        ? 'Already up to date'
+                        : 'Cannot fast-forward; local commits diverge from upstream'
+                  : action === 'download'
+                    ? 'Open the latest Zeus download for this platform'
+                    : action === 'openRelease'
+                      ? 'Open the latest Zeus release page'
+                      : 'Already up to date'
               }
             >
-              {pulling ? 'UPDATING…' : 'UPDATE NOW'}
+              {pulling ? 'UPDATING...' : 'UPDATE NOW'}
             </button>
           </div>
 
@@ -221,18 +294,18 @@ export function UpdatesPanel() {
               {result.message}
               {result.requiresRebuild && (
                 <div style={{ ...hintStyle, marginTop: 6 }}>
-                  Source updated — the running app is still on the old build. Rebuild and restart
-                  Zeus to apply: run <code>scripts/update.ps1</code> (Windows) or{' '}
-                  <code>scripts/update.sh</code> (macOS/Linux), then relaunch.
+                  Source updated. The running app is still on the old build. Rebuild and restart
+                  Zeus to apply: run <code>scripts/update.ps1</code> on Windows or{' '}
+                  <code>scripts/update.sh</code> on macOS/Linux, then relaunch.
                 </div>
               )}
             </div>
           )}
 
           <div style={hintStyle}>
-            “Update now” fast-forwards your local checkout to the latest upstream commit. It changes
-            source only — Zeus keeps running the previously-built binaries until you rebuild and
-            restart. The update script handles the rebuild for both the backend and the web UI.
+            {status.isGitRepo
+              ? 'Update now fast-forwards your checkout. Rebuild and restart Zeus to run the new source.'
+              : 'Update now opens the latest installer or package for this platform. Run the downloaded update and restart Zeus to apply it.'}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- Add release-aware update status fields and GitHub latest-release checks for packaged Zeus builds.
- Surface startup and Settings -> Updates prompts with Update now links to the matching platform asset.
- Keep existing git checkout update/pull behavior intact for development worktrees.
- Add Playwright E2E coverage for the packaged startup update and Settings -> Updates asset-opening flow.
- Wire the frontend E2E command into the main build-test workflow.

## Verification
- dotnet test tests\Zeus.Server.Tests\Zeus.Server.Tests.csproj --configuration Debug --filter RepoUpdateServiceTests
- dotnet test tests\Zeus.Contracts.Tests\Zeus.Contracts.Tests.csproj --configuration Debug
- npm --prefix zeus-web run lint
- npm --prefix zeus-web run typecheck
- npm --prefix zeus-web run test
- npm --prefix zeus-web run test:e2e
- npm --prefix zeus-web run build
- dotnet build Zeus.slnx --no-restore

Note: full dotnet test Zeus.slnx was attempted, but timed out after 10 minutes; the focused server/contracts/frontend gates above passed.