### PR TITLE
ci: publish downloads to Cloudflare

### DIFF
--- a/.github/workflows/publish-downloads.yml
+++ b/.github/workflows/publish-downloads.yml
@@ -1,0 +1,107 @@
+name: Publish Website Downloads
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: website-downloads-main
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build main installers
+    uses: ./.github/workflows/release.yml
+    with:
+      mode: download-main
+      ref: main
+    secrets: inherit
+    permissions:
+      contents: read
+
+  publish:
+    name: Publish to downloads.openhpsdrzeus.com
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      DOWNLOAD_BASE_URL: https://downloads.openhpsdrzeus.com
+      ZEUS_DOWNLOAD_VERSION: ${{ needs.build.outputs.version }}
+      ZEUS_DOWNLOAD_CHANNEL: main
+      ZEUS_DOWNLOAD_BRANCH: main
+      WRANGLER_SEND_METRICS: "false"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-artifacts
+
+      - name: Display artifact structure
+        run: find release-artifacts -maxdepth 3 -type f -print | sort
+
+      - name: Fetch current download manifest
+        run: |
+          if ! curl -fsSL "$DOWNLOAD_BASE_URL/manifest.json" -o existing-manifest.json; then
+            printf '{ "schema": 1, "updatedAt": null, "latest": null, "versions": [] }\n' > existing-manifest.json
+          fi
+
+      - name: Generate download manifest
+        run: node tools/update-download-manifest.mjs release-artifacts existing-manifest.json manifest.json
+
+      - name: Upload installers to R2
+        run: |
+          set -euo pipefail
+          while IFS= read -r -d '' file; do
+            name="$(basename "$file")"
+            key="versions/${ZEUS_DOWNLOAD_VERSION}/${name}"
+            case "$name" in
+              *.exe) content_type="application/vnd.microsoft.portable-executable" ;;
+              *.dmg) content_type="application/x-apple-diskimage" ;;
+              *.tar.gz) content_type="application/gzip" ;;
+              *.AppImage) content_type="application/octet-stream" ;;
+              *) content_type="application/octet-stream" ;;
+            esac
+            npx --yes wrangler@4.103.0 r2 object put "openhpsdrzeus-downloads/${key}" \
+              --file "$file" \
+              --content-type "$content_type" \
+              --remote
+          done < <(find release-artifacts -type f \( -name '*.exe' -o -name '*.dmg' -o -name '*.tar.gz' -o -name '*.AppImage' \) -print0)
+
+      - name: Upload manifests to R2
+        run: |
+          npx --yes wrangler@4.103.0 r2 object put openhpsdrzeus-downloads/manifest.json \
+            --file manifest.json \
+            --content-type application/json \
+            --remote
+          npx --yes wrangler@4.103.0 r2 object put openhpsdrzeus-downloads/latest.json \
+            --file latest.json \
+            --content-type application/json \
+            --remote
+          npx --yes wrangler@4.103.0 r2 object put "openhpsdrzeus-downloads/versions/${ZEUS_DOWNLOAD_VERSION}/manifest.json" \
+            --file latest.json \
+            --content-type application/json \
+            --remote
+
+      - name: Verify public manifest
+        run: |
+          curl -fsSL "$DOWNLOAD_BASE_URL/manifest.json" | node -e "
+          const chunks = [];
+          process.stdin.on('data', c => chunks.push(c));
+          process.stdin.on('end', () => {
+            const manifest = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+            if (manifest.latest !== process.env.ZEUS_DOWNLOAD_VERSION) {
+              throw new Error(`latest mismatch: ${manifest.latest} !== ${process.env.ZEUS_DOWNLOAD_VERSION}`);
+            }
+            console.log(`Published ${manifest.latest} with ${manifest.versions[0].assets.length} assets`);
+          });
+          "

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ on:
   workflow_call:
     inputs:
       mode:
-        description: 'Build mode when invoked as a reusable workflow. Currently only `nightly` is consumed by the parse step; other values fall through to the dry-run path.'
+        description: 'Build mode when invoked as a reusable workflow. `nightly` builds develop for the rolling prerelease; `download-main` builds main for openhpsdrzeus.com downloads; other values fall through to the dry-run path.'
         type: string
         required: false
         default: dryrun
@@ -46,6 +46,16 @@ on:
         type: string
         required: false
         default: ''
+    outputs:
+      version:
+        description: 'Full SemVer string used in artifact filenames.'
+        value: ${{ jobs.determine-version.outputs.version }}
+      version-prefix:
+        description: 'Numeric MAJOR.MINOR.PATCH version prefix.'
+        value: ${{ jobs.determine-version.outputs.version-prefix }}
+      version-suffix:
+        description: 'Pre-release/build suffix, if any.'
+        value: ${{ jobs.determine-version.outputs.version-suffix }}
 
 jobs:
   determine-version:
@@ -63,6 +73,7 @@ jobs:
       is-release: ${{ steps.parse.outputs.is-release }}
       is-draft: ${{ steps.parse.outputs.is-draft }}
       is-nightly: ${{ steps.parse.outputs.is-nightly }}
+      sign-macos: ${{ steps.parse.outputs.sign-macos }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -81,6 +92,7 @@ jobs:
         run: |
           IS_DRAFT="false"
           IS_NIGHTLY="false"
+          SIGN_MACOS="false"
           if [[ "$INPUT_MODE" == "nightly" ]]; then
             # Nightly mode — caller (nightly.yml) has already pointed checkout
             # at develop via `inputs.ref`, so HEAD reflects develop tip rather
@@ -94,7 +106,22 @@ jobs:
             VERSION="${VERSION_PREFIX}-${VERSION_SUFFIX}"
             IS_RELEASE="false"
             IS_NIGHTLY="true"
+            SIGN_MACOS="true"
             echo "Nightly build (ref=$GITHUB_REF, head=$SHORT_SHA) → version $VERSION"
+          elif [[ "$INPUT_MODE" == "download-main" ]]; then
+            # Website download mode — build the current main branch and publish
+            # the artifacts to openhpsdrzeus.com via the caller workflow. Use a
+            # monotonic suffix so every main build can coexist in the download
+            # manifest, while the website marks only the newest one as latest.
+            VERSION_PREFIX=$(sed -n 's:.*<VersionPrefix[^>]*>\([^<]*\)</VersionPrefix>.*:\1:p' Directory.Build.props | head -1)
+            VERSION_PREFIX="${VERSION_PREFIX:-0.0.0}"
+            DATE_STAMP=$(date -u +%Y%m%d)
+            SHORT_SHA=$(git rev-parse --short=7 HEAD)
+            VERSION_SUFFIX="main.${DATE_STAMP}.${SHORT_SHA}"
+            VERSION="${VERSION_PREFIX}-${VERSION_SUFFIX}"
+            IS_RELEASE="false"
+            SIGN_MACOS="true"
+            echo "Download build (ref=$GITHUB_REF, head=$SHORT_SHA) → version $VERSION"
           elif [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
             # Tag push — strict release path.
             if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -111,6 +138,7 @@ jobs:
             VERSION_SUFFIX=""
             VERSION="$VERSION_PREFIX"
             IS_RELEASE="true"
+            SIGN_MACOS="true"
             echo "Tagged release $GITHUB_REF_NAME → version $VERSION"
           elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" && "$DISPATCH_DRAFT" == "true" ]]; then
             # Manual dispatch with draft=true — produce a DRAFT GitHub Release
@@ -124,6 +152,7 @@ jobs:
             VERSION="$VERSION_PREFIX"
             IS_RELEASE="true"
             IS_DRAFT="true"
+            SIGN_MACOS="true"
             echo "Draft release dispatch (ref=$GITHUB_REF) → version $VERSION (draft=true)"
           else
             # Branch push or manual dispatch (draft=false) — dry-run path. Read
@@ -144,6 +173,7 @@ jobs:
           echo "is-release=${IS_RELEASE}" >> "$GITHUB_OUTPUT"
           echo "is-draft=${IS_DRAFT}" >> "$GITHUB_OUTPUT"
           echo "is-nightly=${IS_NIGHTLY}" >> "$GITHUB_OUTPUT"
+          echo "sign-macos=${SIGN_MACOS}" >> "$GITHUB_OUTPUT"
 
   # ---------- Native WDSP rebuild (always-fresh natives in releases) -------
   #
@@ -785,7 +815,7 @@ jobs:
 
       # ---------- macOS code-signing + notarization ------------------------
       #
-      # Five steps gated on (is-release || is-nightly): import the Developer
+      # Five steps gated on sign-macos=true: import the Developer
       # ID cert into an ephemeral keychain, run the existing builder with
       # CODESIGN_IDENTITY exported (the script signs apps + DMG inside-out
       # hardened-runtime, see installers/create-macos-app.sh), submit to
@@ -805,12 +835,12 @@ jobs:
       # concurrent dispatches (e.g. nightly cron racing with a maintainer's
       # manual run) never collide on /Users/runner/Library/Keychains.
       - name: macOS — dry-run notice (signing/notarization skipped)
-        if: ${{ startsWith(matrix.config.os, 'macos') && needs.determine-version.outputs.is-release != 'true' && needs.determine-version.outputs.is-nightly != 'true' }}
+        if: ${{ startsWith(matrix.config.os, 'macos') && needs.determine-version.outputs.sign-macos != 'true' }}
         run: |
           echo "::notice::macOS DMG will NOT be signed or notarized in dry-run mode. The artifact will require xattr -cr on first launch."
 
       - name: macOS — import Developer ID certificate
-        if: ${{ startsWith(matrix.config.os, 'macos') && (needs.determine-version.outputs.is-release == 'true' || needs.determine-version.outputs.is-nightly == 'true') }}
+        if: ${{ startsWith(matrix.config.os, 'macos') && needs.determine-version.outputs.sign-macos == 'true' }}
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
@@ -900,11 +930,11 @@ jobs:
       - name: Build macOS Package
         if: startsWith(matrix.config.os, 'macos')
         env:
-          # Ternary: signed only when is-release || is-nightly. In dry-run
+          # Ternary: signed only when sign-macos=true. In dry-run
           # the value is the empty string regardless of whether
           # MACOS_SIGNING_IDENTITY is configured — keeps an accidentally-set
           # secret from sneaking signing into a dry-run build.
-          CODESIGN_IDENTITY: ${{ (needs.determine-version.outputs.is-release == 'true' || needs.determine-version.outputs.is-nightly == 'true') && secrets.MACOS_SIGNING_IDENTITY || '' }}
+          CODESIGN_IDENTITY: ${{ needs.determine-version.outputs.sign-macos == 'true' && secrets.MACOS_SIGNING_IDENTITY || '' }}
           ENTITLEMENTS_PATH: ${{ github.workspace }}/installers/zeus-macos.entitlements
           # KEYCHAIN_PATH flows in via $GITHUB_ENV from the import step above.
         run: |
@@ -914,7 +944,7 @@ jobs:
           installers/create-macos-app.sh ${{ steps.version.outputs.version }} $ARCH
 
       - name: macOS — notarize DMG
-        if: ${{ startsWith(matrix.config.os, 'macos') && (needs.determine-version.outputs.is-release == 'true' || needs.determine-version.outputs.is-nightly == 'true') }}
+        if: ${{ startsWith(matrix.config.os, 'macos') && needs.determine-version.outputs.sign-macos == 'true' }}
         env:
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
@@ -971,7 +1001,7 @@ jobs:
           echo "Notarization accepted (id=$SUBMISSION_ID)"
 
       - name: macOS — staple notarization ticket
-        if: ${{ startsWith(matrix.config.os, 'macos') && (needs.determine-version.outputs.is-release == 'true' || needs.determine-version.outputs.is-nightly == 'true') }}
+        if: ${{ startsWith(matrix.config.os, 'macos') && needs.determine-version.outputs.sign-macos == 'true' }}
         run: |
           set -euo pipefail
           ARCH="${{ matrix.config.rid == 'osx-arm64' && 'arm64' || 'x64' }}"
@@ -984,7 +1014,7 @@ jobs:
           xcrun stapler validate "$DMG_PATH"
 
       - name: macOS — Gatekeeper assess
-        if: ${{ startsWith(matrix.config.os, 'macos') && (needs.determine-version.outputs.is-release == 'true' || needs.determine-version.outputs.is-nightly == 'true') }}
+        if: ${{ startsWith(matrix.config.os, 'macos') && needs.determine-version.outputs.sign-macos == 'true' }}
         run: |
           set -euo pipefail
           ARCH="${{ matrix.config.rid == 'osx-arm64' && 'arm64' || 'x64' }}"
@@ -1009,7 +1039,7 @@ jobs:
       # + any leftover .p8/.p12 means a `if: always()` run on a future
       # runner image that caches $RUNNER_TEMP between jobs won't leak.
       - name: macOS — clean up signing material
-        if: ${{ always() && startsWith(matrix.config.os, 'macos') && (needs.determine-version.outputs.is-release == 'true' || needs.determine-version.outputs.is-nightly == 'true') }}
+        if: ${{ always() && startsWith(matrix.config.os, 'macos') && needs.determine-version.outputs.sign-macos == 'true' }}
         run: |
           set +e
           if [ -n "${KEYCHAIN_PATH:-}" ] && [ -f "$KEYCHAIN_PATH" ]; then
@@ -1148,7 +1178,7 @@ jobs:
           EOF
 
       - name: Create or Update Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: Openhpsdr Zeus v${{ steps.version.outputs.version }}

--- a/tools/update-download-manifest.mjs
+++ b/tools/update-download-manifest.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const [artifactRoot, existingPath, outputPath] = process.argv.slice(2);
+
+if (!artifactRoot || !existingPath || !outputPath) {
+  console.error("Usage: node tools/update-download-manifest.mjs <artifact-root> <existing-manifest.json> <output-manifest.json>");
+  process.exit(2);
+}
+
+const baseUrl = process.env.DOWNLOAD_BASE_URL || "https://downloads.openhpsdrzeus.com";
+const files = walk(artifactRoot).filter((file) => isDownload(file));
+if (files.length === 0) {
+  console.error(`No downloadable artifacts found under ${artifactRoot}`);
+  process.exit(1);
+}
+
+const version = process.env.ZEUS_DOWNLOAD_VERSION || inferVersion(files);
+if (!version) {
+  console.error("Could not infer Zeus version from artifact filenames.");
+  process.exit(1);
+}
+
+const manifest = loadManifest(existingPath);
+const assets = files
+  .map((file) => assetFor(file, version, baseUrl))
+  .filter(Boolean)
+  .sort(assetSort);
+
+if (assets.length === 0) {
+  console.error(`No recognized Zeus artifacts found for ${version}.`);
+  process.exit(1);
+}
+
+const versionEntry = {
+  version,
+  channel: process.env.ZEUS_DOWNLOAD_CHANNEL || "main",
+  publishedAt: new Date().toISOString(),
+  source: {
+    branch: process.env.ZEUS_DOWNLOAD_BRANCH || process.env.GITHUB_REF_NAME || "main",
+    commit: process.env.GITHUB_SHA || null,
+    runUrl: process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY && process.env.GITHUB_RUN_ID
+      ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+      : null,
+  },
+  assets,
+};
+
+const versions = [
+  versionEntry,
+  ...manifest.versions.filter((entry) => entry.version !== version),
+].sort((a, b) => String(b.publishedAt || "").localeCompare(String(a.publishedAt || "")));
+
+const nextManifest = {
+  schema: 1,
+  updatedAt: versionEntry.publishedAt,
+  latest: version,
+  versions,
+};
+
+writeFileSync(outputPath, `${JSON.stringify(nextManifest, null, 2)}\n`, "utf8");
+writeFileSync(path.join(path.dirname(outputPath), "latest.json"), `${JSON.stringify(versionEntry, null, 2)}\n`, "utf8");
+
+function walk(root) {
+  const result = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      result.push(...walk(fullPath));
+    } else if (entry.isFile()) {
+      result.push(fullPath);
+    }
+  }
+  return result;
+}
+
+function isDownload(file) {
+  const name = path.basename(file).toLowerCase();
+  return name.endsWith(".exe") || name.endsWith(".dmg") || name.endsWith(".tar.gz") || name.endsWith(".appimage");
+}
+
+function loadManifest(file) {
+  if (!existsSync(file)) {
+    return { schema: 1, versions: [] };
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(file, "utf8"));
+    return {
+      schema: 1,
+      versions: Array.isArray(parsed.versions) ? parsed.versions : [],
+    };
+  } catch {
+    return { schema: 1, versions: [] };
+  }
+}
+
+function inferVersion(filesToInspect) {
+  for (const file of filesToInspect) {
+    const name = path.basename(file);
+    const match =
+      name.match(/^openhpsdr-zeus-(.+)-win-(?:x64|arm64)-setup\.exe$/i) ||
+      name.match(/^openhpsdr-zeus-(.+)-linux-(?:x64|arm64)\.tar\.gz$/i) ||
+      name.match(/^OpenhpsdrZeus-(.+)-macos-arm64\.dmg$/) ||
+      name.match(/^OpenhpsdrZeus(?:-Server)?-(.+)-linux-(?:x86_64|aarch64)\.AppImage$/);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+function assetFor(file, versionValue, urlBase) {
+  const filename = path.basename(file);
+  const stats = statSync(file);
+  const sha256 = createHash("sha256").update(readFileSync(file)).digest("hex");
+  const common = {
+    filename,
+    url: `${urlBase}/versions/${encodeURIComponent(versionValue)}/${encodeURIComponent(filename)}`,
+    size: stats.size,
+    sha256,
+  };
+
+  let match = filename.match(/^openhpsdr-zeus-(.+)-win-(x64|arm64)-setup\.exe$/i);
+  if (match) {
+    return {
+      ...common,
+      platform: "windows",
+      arch: match[2],
+      kind: "installer",
+      label: `Windows ${match[2].toUpperCase()} installer`,
+    };
+  }
+
+  match = filename.match(/^OpenhpsdrZeus-(.+)-macos-(arm64)\.dmg$/);
+  if (match) {
+    return {
+      ...common,
+      platform: "macos",
+      arch: match[2],
+      kind: "dmg",
+      label: "macOS Apple Silicon DMG",
+    };
+  }
+
+  match = filename.match(/^openhpsdr-zeus-(.+)-linux-(x64|arm64)\.tar\.gz$/i);
+  if (match) {
+    return {
+      ...common,
+      platform: "linux",
+      arch: match[2],
+      kind: "tarball",
+      label: `Linux ${match[2]} tarball`,
+    };
+  }
+
+  match = filename.match(/^OpenhpsdrZeus(-Server)?-(.+)-linux-(x86_64|aarch64)\.AppImage$/);
+  if (match) {
+    const arch = match[3] === "x86_64" ? "x64" : "arm64";
+    const mode = match[1] ? "server" : "desktop";
+    return {
+      ...common,
+      platform: "linux",
+      arch,
+      kind: "appimage",
+      mode,
+      label: `Linux ${arch} ${mode} AppImage`,
+    };
+  }
+
+  return null;
+}
+
+function assetSort(a, b) {
+  const platformOrder = { windows: 0, macos: 1, linux: 2 };
+  const archOrder = { x64: 0, arm64: 1 };
+  const kindOrder = { installer: 0, dmg: 0, appimage: 1, tarball: 2 };
+  return (
+    (platformOrder[a.platform] ?? 9) - (platformOrder[b.platform] ?? 9) ||
+    (archOrder[a.arch] ?? 9) - (archOrder[b.arch] ?? 9) ||
+    (kindOrder[a.kind] ?? 9) - (kindOrder[b.kind] ?? 9) ||
+    a.filename.localeCompare(b.filename)
+  );
+}


### PR DESCRIPTION
## Summary
- add a main-branch download publishing workflow that builds installers and uploads them to the Cloudflare R2 downloads bucket
- generate the downloads manifest consumed by openhpsdrzeus.com, including all versions, latest build metadata, platform/arch labels, sizes, and SHA-256 hashes
- add a `download-main` release mode for signed/notarized main builds and update `softprops/action-gh-release` to v2 for current runner compatibility

## Verification
- `npx --yes github-actionlint .github/workflows/release.yml .github/workflows/publish-downloads.yml`
- `node --check tools/update-download-manifest.mjs`
- manifest smoke test with Windows x64/ARM64, macOS arm64, Linux x64/ARM64 tarballs, and Linux AppImage artifacts