### PR TITLE
Auto-fit dropped workspace panels

### DIFF
--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -30,6 +30,7 @@ import {
   ResponsiveGridLayout,
   useContainerWidth,
   type Layout,
+  type LayoutItem,
 } from 'react-grid-layout';
 import { absoluteStrategy } from 'react-grid-layout/core';
 import { Plus, Puzzle, Settings } from 'lucide-react';
@@ -39,6 +40,7 @@ import { getPanelDef } from './panels';
 import {
   WORKSPACE_DRAG_COMPACTOR,
   WORKSPACE_RESIZE_COMPACTOR,
+  autoFitDroppedPanel,
 } from './workspaceGrid';
 import { usePluginPanels } from '../plugins/runtime/usePluginPanels';
 import {
@@ -233,6 +235,7 @@ function WorkspaceCanvas({
   const [containerHeight, setContainerHeight] = useState(0);
   const [gridInteraction, setGridInteraction] =
     useState<GridInteraction>(null);
+  const autoFitNextDropRef = useRef(false);
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
@@ -315,7 +318,34 @@ function WorkspaceCanvas({
 
   const onDragStart = useCallback(() => setGridInteraction('drag'), []);
   const onResizeStart = useCallback(() => setGridInteraction('resize'), []);
-  const onInteractionStop = useCallback(() => setGridInteraction(null), []);
+  const onDragStop = useCallback((
+    _layout: Layout,
+    oldItem: LayoutItem | null,
+    newItem: LayoutItem | null,
+  ) => {
+    autoFitNextDropRef.current = !!(
+      oldItem &&
+      newItem &&
+      (oldItem.x !== newItem.x || oldItem.y !== newItem.y)
+    );
+    setGridInteraction(null);
+  }, []);
+  const onResizeStop = useCallback(() => {
+    autoFitNextDropRef.current = false;
+    setGridInteraction(null);
+  }, []);
+  const handleLayoutChange = useCallback(
+    (next: Layout) => {
+      const shouldAutoFit = autoFitNextDropRef.current;
+      autoFitNextDropRef.current = false;
+      onLayoutChange(
+        shouldAutoFit
+          ? autoFitDroppedPanel(next, WORKSPACE_GRID_COLS)
+          : next,
+      );
+    },
+    [onLayoutChange],
+  );
 
   // RGL needs a stable per-render layouts.lg array. Memoise against the
   // tile list identity so we don't push a new prop on every parent render.
@@ -395,10 +425,10 @@ function WorkspaceCanvas({
             bounded: false,
           }}
           onDragStart={onDragStart}
-          onDragStop={onInteractionStop}
+          onDragStop={onDragStop}
           onResizeStart={onResizeStart}
-          onResizeStop={onInteractionStop}
-          onLayoutChange={onLayoutChange}
+          onResizeStop={onResizeStop}
+          onLayoutChange={handleLayoutChange}
           layouts={rglLayouts}
         >
           {tiles.map((tile) => (

--- a/zeus-web/src/layout/workspaceGrid.test.ts
+++ b/zeus-web/src/layout/workspaceGrid.test.ts
@@ -7,10 +7,26 @@ import type { Layout } from 'react-grid-layout';
 import {
   WORKSPACE_DRAG_COMPACTOR,
   WORKSPACE_RESIZE_COMPACTOR,
+  autoFitDroppedPanel,
 } from './workspaceGrid';
 
 function cloneLayout(layout: Layout): Layout {
   return layout.map((item) => ({ ...item }));
+}
+
+function expectNoCollisions(layout: Layout) {
+  for (let i = 0; i < layout.length; i += 1) {
+    const a = layout[i]!;
+    for (let j = i + 1; j < layout.length; j += 1) {
+      const b = layout[j]!;
+      expect(
+        a.x + a.w <= b.x ||
+          a.x >= b.x + b.w ||
+          a.y + a.h <= b.y ||
+          a.y >= b.y + b.h,
+      ).toBe(true);
+    }
+  }
 }
 
 describe('workspace grid collision policy', () => {
@@ -19,23 +35,124 @@ describe('workspace grid collision policy', () => {
     { i: 'below', x: 0, y: 2, w: 6, h: 2 },
   ];
 
-  it('does not push another panel down when the dragged panel hits it', () => {
+  it('pushes a colliding neighbor sideways when the dragged panel hits it', () => {
     const layout = cloneLayout(baseLayout);
     const dragged = layout[0]!;
 
-    const next = moveElement(
-      layout,
-      dragged,
-      undefined,
-      2,
-      true,
-      WORKSPACE_DRAG_COMPACTOR.preventCollision,
-      WORKSPACE_DRAG_COMPACTOR.type,
+    const next = autoFitDroppedPanel(
+      moveElement(
+        layout,
+        dragged,
+        undefined,
+        2,
+        true,
+        WORKSPACE_DRAG_COMPACTOR.preventCollision,
+        WORKSPACE_DRAG_COMPACTOR.type,
+        24,
+        WORKSPACE_DRAG_COMPACTOR.allowOverlap,
+      ),
       24,
-      WORKSPACE_DRAG_COMPACTOR.allowOverlap,
     );
 
-    expect(next.find((item) => item.i === 'dragged')?.y).toBe(0);
+    expect(next.find((item) => item.i === 'dragged')).toMatchObject({
+      x: 0,
+      y: 2,
+      w: 6,
+      h: 2,
+    });
+    expect(next.find((item) => item.i === 'below')).toMatchObject({
+      x: 6,
+      y: 2,
+    });
+  });
+
+  it('shrinks the dragged panel to the available grid gap', () => {
+    const layout: Layout = cloneLayout([
+      { i: 'dragged', x: 0, y: 0, w: 10, h: 2, minW: 2, minH: 2 },
+      { i: 'right', x: 14, y: 0, w: 10, h: 2 },
+    ]);
+    const dragged = layout[0]!;
+
+    const next = autoFitDroppedPanel(
+      moveElement(
+        layout,
+        dragged,
+        8,
+        0,
+        true,
+        WORKSPACE_DRAG_COMPACTOR.preventCollision,
+        WORKSPACE_DRAG_COMPACTOR.type,
+        24,
+        WORKSPACE_DRAG_COMPACTOR.allowOverlap,
+      ),
+      24,
+    );
+
+    expect(next.find((item) => item.i === 'dragged')).toMatchObject({
+      x: 8,
+      y: 0,
+      w: 6,
+      h: 2,
+    });
+    expect(next.find((item) => item.i === 'right')).toMatchObject({
+      x: 14,
+      y: 0,
+      w: 10,
+      h: 2,
+    });
+  });
+
+  it('moves and shrinks the dropped panel into a free rectangle inside the drop footprint', () => {
+    const layout: Layout = cloneLayout([
+      { i: 'dragged', x: 0, y: 0, w: 12, h: 8, minW: 4, minH: 2 },
+      { i: 'left-block', x: 0, y: 0, w: 8, h: 6 },
+      { i: 'right-block', x: 8, y: 2, w: 16, h: 4 },
+    ]);
+    const dragged = layout[0]!;
+
+    const next = autoFitDroppedPanel(
+      moveElement(
+        layout,
+        dragged,
+        2,
+        2,
+        true,
+        WORKSPACE_DRAG_COMPACTOR.preventCollision,
+        WORKSPACE_DRAG_COMPACTOR.type,
+        24,
+        WORKSPACE_DRAG_COMPACTOR.allowOverlap,
+      ),
+      24,
+    );
+
+    expect(next.find((item) => item.i === 'dragged')).toMatchObject({
+      x: 2,
+      y: 6,
+      w: 12,
+      h: 4,
+    });
+    expectNoCollisions(next);
+  });
+
+  it('does not push another panel down during drag auto-fit', () => {
+    const layout = cloneLayout(baseLayout);
+    const dragged = layout[0]!;
+
+    const next = autoFitDroppedPanel(
+      moveElement(
+        layout,
+        dragged,
+        undefined,
+        2,
+        true,
+        WORKSPACE_DRAG_COMPACTOR.preventCollision,
+        WORKSPACE_DRAG_COMPACTOR.type,
+        24,
+        WORKSPACE_DRAG_COMPACTOR.allowOverlap,
+      ),
+      24,
+    );
+
     expect(next.find((item) => item.i === 'below')?.y).toBe(2);
   });
 
@@ -43,16 +160,19 @@ describe('workspace grid collision policy', () => {
     const layout = cloneLayout(baseLayout);
     const dragged = layout[0]!;
 
-    const next = moveElement(
-      layout,
-      dragged,
-      undefined,
-      4,
-      true,
-      WORKSPACE_DRAG_COMPACTOR.preventCollision,
-      WORKSPACE_DRAG_COMPACTOR.type,
+    const next = autoFitDroppedPanel(
+      moveElement(
+        layout,
+        dragged,
+        undefined,
+        4,
+        true,
+        WORKSPACE_DRAG_COMPACTOR.preventCollision,
+        WORKSPACE_DRAG_COMPACTOR.type,
+        24,
+        WORKSPACE_DRAG_COMPACTOR.allowOverlap,
+      ),
       24,
-      WORKSPACE_DRAG_COMPACTOR.allowOverlap,
     );
 
     expect(next.find((item) => item.i === 'dragged')?.y).toBe(4);

--- a/zeus-web/src/layout/workspaceGrid.ts
+++ b/zeus-web/src/layout/workspaceGrid.ts
@@ -3,9 +3,11 @@
 import { getCompactor } from 'react-grid-layout/core';
 import type { Compactor, Layout, LayoutItem } from 'react-grid-layout';
 
-// Keep the workspace sparse (no automatic gap-filling), but do not let RGL
-// resolve drag collisions by moving neighboring panels down the stack.
-export const WORKSPACE_DRAG_COMPACTOR = getCompactor(null, false, true);
+// Keep the workspace sparse (no automatic gap-filling). Dragging temporarily
+// allows overlap so the operator can drop a panel where they mean it; the
+// final drag-stop layout is normalized by autoFitDroppedPanel below before it
+// is persisted.
+export const WORKSPACE_DRAG_COMPACTOR = getCompactor(null, true, false);
 
 export const WORKSPACE_RESIZE_COMPACTOR: Compactor = {
   type: null,
@@ -13,14 +15,102 @@ export const WORKSPACE_RESIZE_COMPACTOR: Compactor = {
   compact: compactResizePushDown,
 };
 
+export function autoFitDroppedPanel(layout: Layout, cols: number): Layout {
+  const dropped = findDroppedItem(layout);
+  if (!dropped) return cloneLayout(layout);
+
+  const base = cloneLayout(layout);
+  const target = base.find((item) => item.i === dropped.i);
+  if (!target) return base;
+
+  const minW = boundedMin(target.minW, 1, cols);
+  const maxW = boundedMax(target.maxW, minW, cols);
+  const minH = boundedMin(target.minH, 1, Number.MAX_SAFE_INTEGER);
+  const maxH = boundedMax(target.maxH, minH, Number.MAX_SAFE_INTEGER);
+  const startW = clamp(target.w, minW, maxW);
+  const startH = clamp(target.h, minH, maxH);
+
+  const footprintX = clamp(target.x, 0, Math.max(0, cols - startW));
+  const footprintY = Math.max(0, Math.round(target.y));
+  const footprintRight = Math.min(cols, footprintX + startW);
+  const footprintBottom = footprintY + startH;
+
+  let best: {
+    layout: LayoutItem[];
+    area: number;
+    originDistance: number;
+    movement: number;
+  } | null = null;
+
+  for (let y = footprintY; y <= footprintBottom - minH; y += 1) {
+    const maxCandidateH = Math.min(maxH, footprintBottom - y);
+    for (let x = footprintX; x <= footprintRight - minW; x += 1) {
+      const maxCandidateW = Math.min(maxW, footprintRight - x);
+      for (let w = maxCandidateW; w >= minW; w -= 1) {
+        for (let h = maxCandidateH; h >= minH; h -= 1) {
+          const trial = cloneLayout(base);
+          const trialTarget = trial.find((item) => item.i === target.i);
+          if (!trialTarget) continue;
+          trialTarget.x = x;
+          trialTarget.y = y;
+          trialTarget.w = w;
+          trialTarget.h = h;
+
+          const resolved = resolveAnchorCollisionsHorizontally(
+            trial,
+            target.i,
+            cols,
+          );
+          if (!resolved) continue;
+
+          const area = w * h;
+          const originDistance =
+            Math.abs(x - footprintX) + Math.abs(y - footprintY);
+          const movement = horizontalMovement(base, resolved.layout, target.i);
+          if (
+            !best ||
+            originDistance < best.originDistance ||
+            (originDistance === best.originDistance && area > best.area) ||
+            (originDistance === best.originDistance &&
+              area === best.area &&
+              movement < best.movement)
+          ) {
+            best = { layout: resolved.layout, area, originDistance, movement };
+          }
+        }
+      }
+    }
+  }
+
+  if (best) return best.layout;
+
+  const fallback = cloneLayout(base);
+  const fallbackTarget = fallback.find((item) => item.i === target.i);
+  if (!fallbackTarget) return fallback;
+  fallbackTarget.w = minW;
+  fallbackTarget.h = minH;
+  fallbackTarget.x = clamp(fallbackTarget.x, 0, Math.max(0, cols - minW));
+  fallbackTarget.y = Math.max(0, fallbackTarget.y);
+  return compactPushDownWithPriority(fallback, target.i);
+}
+
 function compactResizePushDown(layout: Layout): Layout {
+  return compactPushDownWithPriority(layout);
+}
+
+function compactPushDownWithPriority(
+  layout: Layout,
+  priorityId?: string,
+): Layout {
   const next = layout.map((item) => ({ ...item }));
   const originalOrder = new Map(next.map((item, index) => [item.i, index]));
   const maxPasses = Math.max(1, next.length * next.length);
 
   for (let pass = 0; pass < maxPasses; pass += 1) {
     let moved = false;
-    const ordered = [...next].sort((a, b) => compareItems(a, b, originalOrder));
+    const ordered = [...next].sort((a, b) =>
+      compareItems(a, b, originalOrder, priorityId),
+    );
 
     for (let i = 0; i < ordered.length; i += 1) {
       const anchor = ordered[i]!;
@@ -42,16 +132,125 @@ function compactResizePushDown(layout: Layout): Layout {
   return next;
 }
 
+function resolveAnchorCollisionsHorizontally(
+  layout: Layout,
+  anchorId: string,
+  cols: number,
+): { layout: LayoutItem[] } | null {
+  const next = cloneLayout(layout);
+  const originalX = new Map(next.map((item) => [item.i, item.x]));
+  const maxPasses = Math.max(1, next.length);
+
+  for (let pass = 0; pass < maxPasses; pass += 1) {
+    const anchor = next.find((item) => item.i === anchorId);
+    if (!anchor) return null;
+
+    const collisions = next
+      .filter((item) => item.i !== anchorId && collides(anchor, item))
+      .sort((a, b) => Math.abs(a.x - anchor.x) - Math.abs(b.x - anchor.x));
+
+    if (collisions.length === 0) {
+      return anyCollision(next) ? null : { layout: next };
+    }
+
+    let moved = false;
+    for (const item of collisions) {
+      const x = nearestHorizontalSlot(
+        next,
+        item,
+        anchor,
+        cols,
+        originalX.get(item.i) ?? item.x,
+      );
+      if (x === null) return null;
+      if (x !== item.x) {
+        item.x = x;
+        moved = true;
+      }
+    }
+
+    if (!moved) return null;
+  }
+
+  return anyCollision(next) ? null : { layout: next };
+}
+
+function nearestHorizontalSlot(
+  layout: LayoutItem[],
+  item: LayoutItem,
+  anchor: LayoutItem,
+  cols: number,
+  originalX: number,
+): number | null {
+  const maxX = cols - item.w;
+  if (maxX < 0) return null;
+
+  let best: { x: number; distance: number } | null = null;
+  for (let x = 0; x <= maxX; x += 1) {
+    const candidate = { ...item, x };
+    if (collides(candidate, anchor)) continue;
+    if (
+      layout.some((other) => {
+        if (other.i === item.i || other.i === anchor.i) return false;
+        return collides(candidate, other);
+      })
+    ) {
+      continue;
+    }
+
+    const distance = Math.abs(x - originalX);
+    if (!best || distance < best.distance) best = { x, distance };
+  }
+
+  return best?.x ?? null;
+}
+
+function findDroppedItem(layout: Layout): LayoutItem | undefined {
+  const moved = layout.filter((item) => item.moved);
+  return moved[moved.length - 1];
+}
+
 function compareItems(
   a: LayoutItem,
   b: LayoutItem,
   originalOrder: Map<string, number>,
+  priorityId?: string,
 ) {
+  if (priorityId) {
+    if (a.i === priorityId && b.i !== priorityId) return -1;
+    if (b.i === priorityId && a.i !== priorityId) return 1;
+  }
   return (
     a.y - b.y ||
     a.x - b.x ||
     (originalOrder.get(a.i) ?? 0) - (originalOrder.get(b.i) ?? 0)
   );
+}
+
+function cloneLayout(layout: Layout): LayoutItem[] {
+  return layout.map((item) => ({ ...item }));
+}
+
+function horizontalMovement(
+  before: Layout,
+  after: Layout,
+  excludeId: string,
+): number {
+  const beforeX = new Map(before.map((item) => [item.i, item.x]));
+  return after.reduce((sum, item) => {
+    if (item.i === excludeId) return sum;
+    return sum + Math.abs(item.x - (beforeX.get(item.i) ?? item.x));
+  }, 0);
+}
+
+function anyCollision(layout: Layout): boolean {
+  for (let i = 0; i < layout.length; i += 1) {
+    const a = layout[i]!;
+    for (let j = i + 1; j < layout.length; j += 1) {
+      if (collides(a, layout[j]!)) return true;
+    }
+  }
+  return false;
 }
 
 function collides(a: LayoutItem, b: LayoutItem) {
@@ -61,4 +260,18 @@ function collides(a: LayoutItem, b: LayoutItem) {
   if (a.y + a.h <= b.y) return false;
   if (a.y >= b.y + b.h) return false;
   return true;
+}
+
+function boundedMin(value: number | undefined, fallback: number, ceiling: number) {
+  const min = Number.isFinite(value) ? value! : fallback;
+  return clamp(Math.round(min), fallback, ceiling);
+}
+
+function boundedMax(value: number | undefined, floor: number, ceiling: number) {
+  const max = Number.isFinite(value) ? value! : ceiling;
+  return Math.max(floor, clamp(Math.round(max), floor, ceiling));
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, Math.round(value)));
 }


### PR DESCRIPTION
## Summary
- auto-fit dropped workspace panels so newly placed panels size to their content
- keeps the existing workspace drop flow while avoiding oversized initial panels

## Verification
- Not rerun during org-branch migration; branch already matches current develop plus one commit.