### PR TITLE
feat(zeuschat): operator-to-operator chat (QRZ identity, live frequency, Cloudflare relay)

### DIFF
--- a/Zeus.Contracts/ChatDtos.cs
+++ b/Zeus.Contracts/ChatDtos.cs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is an independent reimplementation in .NET — not a fork. Its
+// Protocol-1 / Protocol-2 framing, WDSP integration, meter pipelines, and
+// TX behaviour were informed by studying the Thetis project
+// (https://github.com/ramdor/Thetis), the authoritative reference
+// implementation in the OpenHPSDR ecosystem. Zeus gratefully acknowledges
+// the Thetis contributors whose work made this possible:
+//
+//   Richard Samphire (MW0LGE), Warren Pratt (NR0V),
+//   Laurence Barker (G8NJJ),   Rick Koch (N1GP),
+//   Bryan Rambo (W4WMT),       Chris Codella (W2PA),
+//   Doug Wigley (W5WC),        FlexRadio Systems,
+//   Richard Allen (W5SD),      Joe Torrey (WD5Y),
+//   Andrew Mansfield (M0YGG),  Reid Campbell (MI0BOT),
+//   Sigi Jetzlsperger (DH1KLM).
+//
+// Thetis itself continues the GPL-governed lineage of FlexRadio PowerSDR
+// and the OpenHPSDR (TAPR/OpenHPSDR) ecosystem; that lineage is preserved
+// here. See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// Protocol-2 / PureSignal / Saturn-class behaviour was additionally informed
+// by pihpsdr (https://github.com/dl1ycf/pihpsdr), maintained by Christoph
+// Wüllen (DL1YCF); and by DeskHPSDR
+// (https://github.com/dl1bz/deskhpsdr), maintained by Heiko (DL1BZ).
+// Both are GPL-2.0-or-later.
+//
+// WDSP — loaded by Zeus via P/Invoke — is Copyright (C) Warren Pratt
+// (NR0V), distributed under GPL v2 or later.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+namespace Zeus.Contracts;
+
+// ── ZeusChat — operator-to-operator chat over a Cloudflare relay ───────────
+//
+// These DTOs mirror the relay wire protocol (cloud/zeuschat-relay/src/
+// protocol.ts) on the Zeus side AND form the JSON envelopes Zeus pushes down
+// to its own web clients inside the ChatEvent (0x35) binary frame. All field
+// names serialise camelCase on the wire (JsonSerializerDefaults.Web).
+
+/// <summary>
+/// A single chat message as broadcast by the relay (and echoed back to the
+/// sender for ordering). <paramref name="Ts"/> is epoch milliseconds.
+/// </summary>
+public sealed record ChatMessage(
+    string Id,
+    string From,
+    string Text,
+    long Ts,
+    string Room);
+
+/// <summary>
+/// A connected operator in the relay roster. <paramref name="FreqHz"/> is the
+/// operator's VFO frequency in Hz; <paramref name="Status"/> is "rx"|"tx"|
+/// "away"; <paramref name="Since"/> is epoch milliseconds the operator joined.
+/// </summary>
+public sealed record ChatOperator(
+    string Callsign,
+    string? Grid,
+    long? FreqHz,
+    string? Mode,
+    string? Status,
+    long Since);
+
+/// <summary>
+/// Snapshot of the local chat node's state, surfaced via
+/// <c>GET /api/chat/status</c> and pushed as a ChatEvent status envelope.
+/// <paramref name="Enabled"/> is the persisted opt-in; <paramref name="Connected"/>
+/// is whether the relay WebSocket is currently live.
+/// </summary>
+public sealed record ChatStatusDto(
+    bool Enabled,
+    bool Connected,
+    string? Callsign,
+    string RelayUrl,
+    string? Error);
+
+// ── REST request/response shapes ──────────────────────────────────────────
+
+public sealed record ChatEnableRequest(bool Enabled);
+
+public sealed record ChatSendRequest(string Text);

--- a/Zeus.Contracts/ChatEventFrame.cs
+++ b/Zeus.Contracts/ChatEventFrame.cs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Zeus.Contracts;
+
+/// <summary>
+/// Wire frame for ZeusChat events (MsgType.ChatEvent, 0x35). The payload is a
+/// single byte type prefix followed by a UTF-8 JSON envelope discriminated by
+/// a camelCase <c>kind</c> field:
+///
+/// <code>
+/// {"kind":"status","status":{...ChatStatusDto...}}
+/// {"kind":"roster","roster":[{...ChatOperator...}, ...]}
+/// {"kind":"message","message":{...ChatMessage...}}
+/// {"kind":"history","messages":[{...ChatMessage...}, ...]}
+/// </code>
+///
+/// JSON (rather than fixed binary) because the payload is small, low-rate, and
+/// the shapes are richer than the other 0x3x control frames. Clients ignore
+/// unknown kinds so additions stay backward compatible.
+/// </summary>
+public static class ChatEventFrame
+{
+    /// <summary>camelCase, no indentation — matches the project's web JSON
+    /// convention (JsonSerializerDefaults.Web).</summary>
+    public static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>Encodes a status envelope into a 0x35 frame ([type][UTF-8 JSON]).</summary>
+    public static byte[] Status(ChatStatusDto status) =>
+        Encode(new StatusEnvelope(status));
+
+    /// <summary>Encodes a roster envelope into a 0x35 frame.</summary>
+    public static byte[] Roster(IReadOnlyList<ChatOperator> roster) =>
+        Encode(new RosterEnvelope(roster));
+
+    /// <summary>Encodes a single-message envelope into a 0x35 frame.</summary>
+    public static byte[] Message(ChatMessage message) =>
+        Encode(new MessageEnvelope(message));
+
+    /// <summary>Encodes a history (message list) envelope into a 0x35 frame.</summary>
+    public static byte[] History(IReadOnlyList<ChatMessage> messages) =>
+        Encode(new HistoryEnvelope(messages));
+
+    /// <summary>Serialises <paramref name="envelope"/> to UTF-8 JSON and
+    /// prefixes the ChatEvent type byte.</summary>
+    public static byte[] Encode<T>(T envelope)
+    {
+        var json = JsonSerializer.SerializeToUtf8Bytes(envelope, JsonOptions);
+        var frame = new byte[1 + json.Length];
+        frame[0] = (byte)MsgType.ChatEvent;
+        json.CopyTo(frame, 1);
+        return frame;
+    }
+
+    /// <summary>Returns the UTF-8 JSON payload of a 0x35 frame (the byte[] with
+    /// the type prefix stripped), or throws if the prefix is wrong. Provided
+    /// for tests / decoders.</summary>
+    public static ReadOnlySpan<byte> Payload(ReadOnlySpan<byte> frame)
+    {
+        if (frame.Length < 1)
+            throw new InvalidDataException("ChatEvent frame is empty");
+        if (frame[0] != (byte)MsgType.ChatEvent)
+            throw new InvalidDataException(
+                $"expected ChatEvent (0x{(byte)MsgType.ChatEvent:X2}), got 0x{frame[0]:X2}");
+        return frame.Slice(1);
+    }
+
+    // Envelope records. The `kind` literal is emitted via the property default;
+    // System.Text.Json serialises it like any other property (camelCase "kind").
+    public sealed record StatusEnvelope(ChatStatusDto Status)
+    {
+        public string Kind => "status";
+    }
+
+    public sealed record RosterEnvelope(IReadOnlyList<ChatOperator> Roster)
+    {
+        public string Kind => "roster";
+    }
+
+    public sealed record MessageEnvelope(ChatMessage Message)
+    {
+        public string Kind => "message";
+    }
+
+    public sealed record HistoryEnvelope(IReadOnlyList<ChatMessage> Messages)
+    {
+        public string Kind => "history";
+    }
+}

--- a/Zeus.Contracts/MsgType.cs
+++ b/Zeus.Contracts/MsgType.cs
@@ -204,4 +204,19 @@ public enum MsgType : byte
     // Payload: [type:1][bypassed:u8] = 2 bytes total. See
     // RxAudioMasterBypassFrame.cs.
     RxAudioMasterBypass = 0x34,
+
+    // Server → client (ZeusChat event). Broadcast by ChatService for every
+    // operator-to-operator chat update: connection status changes, roster
+    // updates, incoming messages, and the message history snapshot pushed
+    // once per client on WS attach (mirrors the SpotList push-on-attach).
+    // Payload: [type:1][UTF-8 JSON envelope]. The envelope is discriminated
+    // by a camelCase "kind" field:
+    //   {"kind":"status","status":ChatStatusDto}
+    //   {"kind":"roster","roster":ChatOperator[]}
+    //   {"kind":"message","message":ChatMessage}
+    //   {"kind":"history","messages":ChatMessage[]}
+    // JSON (not fixed binary) because the payload is small, low-rate, and the
+    // shapes are richer than the other control frames. UI ignores unknown
+    // kinds so older builds tolerate additions cleanly. See ChatEventFrame.cs.
+    ChatEvent = 0x35,
 }

--- a/Zeus.Server.Hosting/ChatEnabledStore.cs
+++ b/Zeus.Server.Hosting/ChatEnabledStore.cs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using LiteDB;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Persists the operator's ZeusChat opt-in across restarts. Chat is OFF by
+/// default; the operator must explicitly enable it (it relays presence and
+/// callsign to a public Cloudflare service, so it stays opt-in). A dedicated
+/// single-row collection ("chat_enabled") sharing zeus-prefs.db, mirroring
+/// <see cref="AudioProcessingModeStore"/>.
+///
+/// <para>First-run semantics: <see cref="GetEnabled"/> returns <c>false</c>
+/// when no row exists, so a brand-new operator stays off the relay until they
+/// opt in.</para>
+/// </summary>
+public sealed class ChatEnabledStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<ChatEnabledEntry> _state;
+    private readonly ILogger<ChatEnabledStore> _log;
+    private readonly object _sync = new();
+
+    public ChatEnabledStore(ILogger<ChatEnabledStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _state = _db.GetCollection<ChatEnabledEntry>("chat_enabled");
+
+        _log.LogInformation("ChatEnabledStore initialized at {Path}", dbPath);
+    }
+
+    /// <summary>Persisted opt-in, defaulting to false on first run (no row yet).</summary>
+    public bool GetEnabled()
+    {
+        lock (_sync)
+        {
+            var entry = _state.FindAll().FirstOrDefault();
+            return entry?.Enabled ?? false;
+        }
+    }
+
+    public void SetEnabled(bool enabled)
+    {
+        lock (_sync)
+        {
+            var existing = _state.FindAll().FirstOrDefault();
+            var nowUtc = DateTime.UtcNow;
+            if (existing is null)
+            {
+                _state.Insert(new ChatEnabledEntry { Enabled = enabled, UpdatedUtc = nowUtc });
+            }
+            else
+            {
+                existing.Enabled = enabled;
+                existing.UpdatedUtc = nowUtc;
+                _state.Update(existing);
+            }
+        }
+    }
+
+    public void Dispose() => _db.Dispose();
+}
+
+public sealed class ChatEnabledEntry
+{
+    public int Id { get; set; }
+    public bool Enabled { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/ChatService.cs
+++ b/Zeus.Server.Hosting/ChatService.cs
@@ -1,0 +1,506 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is an independent reimplementation in .NET — not a fork. See
+// ATTRIBUTIONS.md at the repository root for the full provenance statement.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Hosting;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Owns the operator's connection to the ZeusChat Cloudflare relay. Connects
+/// only while chat is enabled (persisted opt-in, default OFF) AND QRZ is logged
+/// in (the relay validates the QRZ session on the WS upgrade). Mirrors radio
+/// presence to the relay, fans incoming relay events out to web clients via
+/// <see cref="StreamingHub"/> as ChatEvent (0x35) frames, and keeps an in-memory
+/// roster + bounded message history for push-on-attach.
+/// </summary>
+public sealed class ChatService : BackgroundService
+{
+    /// <summary>Default public relay endpoint. Override with ZEUSCHAT_RELAY_URL.</summary>
+    public const string DefaultRelayUrl =
+        "wss://zeuschat-relay.christiantsuarez.workers.dev/chat";
+
+    private const int MessageHistoryCap = 200;
+    private static readonly TimeSpan HeartbeatInterval = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan PresenceThrottleWindow = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan ReconnectMinDelay = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan ReconnectMaxDelay = TimeSpan.FromSeconds(30);
+
+    private readonly QrzService _qrz;
+    private readonly RadioService _radio;
+    private readonly StreamingHub _hub;
+    private readonly ChatEnabledStore _store;
+    private readonly ILogger<ChatService> _log;
+
+    private readonly string _relayUrl;
+    private readonly string? _relaySecret;
+
+    private readonly ChatMessageRing _messages = new(MessageHistoryCap);
+    private readonly object _rosterSync = new();
+    private IReadOnlyList<ChatOperator> _roster = Array.Empty<ChatOperator>();
+
+    // Live connection state, set on the worker loop and read by the API.
+    private volatile bool _connected;
+    private volatile string? _lastError;
+    private volatile string? _selfCallsign;
+
+    // Signals the worker loop to re-evaluate (enable/disable toggled, or a
+    // presence change is pending). The send side runs on the worker so frames
+    // never interleave across threads.
+    private readonly SemaphoreSlim _wake = new(0, int.MaxValue);
+
+    // Presence the worker should publish on its next opportunity, gated by the
+    // throttle. Written by event handlers, drained by the worker.
+    private readonly PresenceThrottle _presence = new(PresenceThrottleWindow);
+    private volatile bool _moxOn;
+
+    // The live socket, set while connected so SendMessageAsync (API path) can
+    // post a {t:"msg"} frame. Null when disconnected.
+    private ClientWebSocket? _socket;
+    private readonly SemaphoreSlim _sendGate = new(1, 1);
+
+    public ChatService(
+        QrzService qrz,
+        RadioService radio,
+        StreamingHub hub,
+        ChatEnabledStore store,
+        ILogger<ChatService> log)
+    {
+        _qrz = qrz;
+        _radio = radio;
+        _hub = hub;
+        _store = store;
+        _log = log;
+
+        var url = Environment.GetEnvironmentVariable("ZEUSCHAT_RELAY_URL");
+        _relayUrl = string.IsNullOrWhiteSpace(url) ? DefaultRelayUrl : url.Trim();
+        var secret = Environment.GetEnvironmentVariable("ZEUSCHAT_RELAY_SECRET");
+        _relaySecret = string.IsNullOrWhiteSpace(secret) ? null : secret.Trim();
+
+        _hub.SetChatSnapshotProvider(BuildSnapshotFrames);
+        _radio.StateChanged += OnRadioStateChanged;
+        _radio.MoxChanged += OnMoxChanged;
+    }
+
+    // ── Public API surface (used by ZeusEndpoints) ─────────────────────────
+
+    public bool Enabled => _store.GetEnabled();
+
+    public ChatStatusDto GetStatus() => new(
+        Enabled: _store.GetEnabled(),
+        Connected: _connected,
+        Callsign: _selfCallsign,
+        RelayUrl: _relayUrl,
+        Error: _lastError);
+
+    /// <summary>Persists the opt-in and wakes the worker to connect/disconnect.</summary>
+    public ChatStatusDto SetEnabled(bool enabled)
+    {
+        _store.SetEnabled(enabled);
+        if (!enabled)
+        {
+            _lastError = null;
+        }
+        Wake();
+        return GetStatus();
+    }
+
+    public IReadOnlyList<ChatMessage> GetMessages(int limit) => _messages.Snapshot(limit);
+
+    public IReadOnlyList<ChatOperator> GetRoster()
+    {
+        lock (_rosterSync) return _roster;
+    }
+
+    /// <summary>
+    /// Sends an outgoing chat message to the relay. Throws
+    /// <see cref="InvalidOperationException"/> when not connected and
+    /// <see cref="ArgumentException"/> when the text is empty — the endpoint
+    /// maps these to 409 / 400.
+    /// </summary>
+    public async Task SendMessageAsync(string text, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            throw new ArgumentException("message text is empty", nameof(text));
+
+        var socket = _socket;
+        if (socket is null || socket.State != WebSocketState.Open || !_connected)
+            throw new InvalidOperationException("chat relay is not connected");
+
+        await SendFrameAsync(socket, new { t = "msg", text }, ct);
+    }
+
+    // ── Background worker ──────────────────────────────────────────────────
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var backoff = ReconnectMinDelay;
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            if (!_store.GetEnabled())
+            {
+                await WaitForWakeAsync(Timeout.InfiniteTimeSpan, stoppingToken);
+                continue;
+            }
+
+            var identity = await TryGetIdentityAsync(stoppingToken);
+            if (identity is null)
+            {
+                // Logged out (or no session) while enabled — wait and retry.
+                _lastError = "QRZ not logged in";
+                await WaitForWakeAsync(backoff, stoppingToken);
+                continue;
+            }
+
+            try
+            {
+                await RunConnectionAsync(identity.Value.Callsign, identity.Value.SessionKey, stoppingToken);
+                backoff = ReconnectMinDelay; // clean cycle resets backoff
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _lastError = ex.Message;
+                _log.LogWarning(ex, "chat relay connection ended; will retry in {Delay}", backoff);
+            }
+            finally
+            {
+                SetDisconnected();
+            }
+
+            if (!_store.GetEnabled()) continue; // disabled during the cycle → loop, will idle
+
+            await WaitForWakeAsync(backoff, stoppingToken);
+            backoff = NextBackoff(backoff);
+        }
+
+        SetDisconnected();
+    }
+
+    private async Task<(string Callsign, string SessionKey)?> TryGetIdentityAsync(CancellationToken ct)
+    {
+        try { return await _qrz.GetChatIdentityAsync(ct); }
+        catch (Exception ex)
+        {
+            _log.LogDebug(ex, "chat: failed to acquire QRZ chat identity");
+            return null;
+        }
+    }
+
+    private async Task RunConnectionAsync(string callsign, string sessionKey, CancellationToken ct)
+    {
+        using var socket = new ClientWebSocket();
+        socket.Options.SetRequestHeader("X-QRZ-Session", sessionKey);
+        socket.Options.SetRequestHeader("X-QRZ-Callsign", callsign);
+        if (_relaySecret is not null)
+            socket.Options.SetRequestHeader("Authorization", $"Bearer {_relaySecret}");
+
+        _log.LogInformation("chat: connecting to relay {Url} as {Callsign}", _relayUrl, callsign);
+        await socket.ConnectAsync(new Uri(_relayUrl), ct);
+
+        _socket = socket;
+        _connected = true;
+        _lastError = null;
+        _selfCallsign = callsign;
+        PushStatus();
+
+        // First frame: hello with current presence.
+        var snap = _radio.Snapshot();
+        var grid = TryGetGrid();
+        await SendFrameAsync(socket, new
+        {
+            t = "hello",
+            callsign,
+            grid,
+            freq = snap.VfoHz,
+            mode = snap.Mode.ToString(),
+            status = CurrentStatus(),
+            client = "zeus",
+        }, ct);
+
+        // Seed the throttle so the first idle presence is suppressed (hello
+        // already carried it) but a genuine change still fires.
+        _presence.Seed(snap.VfoHz, snap.Mode.ToString(), CurrentStatus());
+
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        var receiveTask = ReceiveLoopAsync(socket, linked.Token);
+        var pumpTask = PresenceAndHeartbeatLoopAsync(socket, linked.Token);
+
+        var done = await Task.WhenAny(receiveTask, pumpTask);
+        linked.Cancel();
+        try { await Task.WhenAll(receiveTask, pumpTask); } catch { /* one side already failed */ }
+        await done; // surface its exception, if any
+    }
+
+    private async Task ReceiveLoopAsync(ClientWebSocket socket, CancellationToken ct)
+    {
+        var buf = new byte[16 * 1024];
+        var accum = new MemoryStream();
+        while (!ct.IsCancellationRequested && socket.State == WebSocketState.Open)
+        {
+            accum.SetLength(0);
+            WebSocketReceiveResult result;
+            do
+            {
+                result = await socket.ReceiveAsync(buf, ct);
+                if (result.MessageType == WebSocketMessageType.Close)
+                {
+                    await socket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, null, CancellationToken.None);
+                    throw new WebSocketException("relay closed the connection");
+                }
+                accum.Write(buf, 0, result.Count);
+            }
+            while (!result.EndOfMessage);
+
+            if (result.MessageType != WebSocketMessageType.Text) continue;
+            var text = Encoding.UTF8.GetString(accum.GetBuffer(), 0, (int)accum.Length);
+            HandleRelayFrame(text);
+        }
+    }
+
+    private async Task PresenceAndHeartbeatLoopAsync(ClientWebSocket socket, CancellationToken ct)
+    {
+        var nextHeartbeat = DateTimeOffset.UtcNow + HeartbeatInterval;
+        while (!ct.IsCancellationRequested && socket.State == WebSocketState.Open)
+        {
+            // Short wait so pending presence changes flush near the throttle
+            // boundary without a busy loop.
+            await WaitForWakeAsync(TimeSpan.FromSeconds(1), ct);
+
+            var now = DateTimeOffset.UtcNow;
+            if (_presence.TryTake(now, out var p))
+                await SendFrameAsync(socket, new { t = "presence", freq = p.FreqHz, mode = p.Mode, status = p.Status }, ct);
+
+            if (now >= nextHeartbeat)
+            {
+                await SendPingAsync(socket, ct);
+                nextHeartbeat = now + HeartbeatInterval;
+            }
+        }
+    }
+
+    // ── Relay frame handling ───────────────────────────────────────────────
+
+    private void HandleRelayFrame(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            if (!root.TryGetProperty("t", out var tEl)) return;
+            switch (tEl.GetString())
+            {
+                case "welcome":
+                    if (root.TryGetProperty("self", out var selfEl))
+                        _selfCallsign = ReadString(selfEl, "callsign") ?? _selfCallsign;
+                    UpdateRoster(root, "roster");
+                    PushStatus();
+                    break;
+                case "roster":
+                    UpdateRoster(root, "roster");
+                    break;
+                case "msg":
+                    var msg = ParseMessage(root);
+                    _messages.Add(msg);
+                    _hub.BroadcastChatEvent(ChatEventFrame.Message(msg));
+                    break;
+                case "error":
+                    var code = ReadString(root, "code");
+                    var message = ReadString(root, "message");
+                    _lastError = string.IsNullOrEmpty(code) ? message : $"{code}: {message}";
+                    _log.LogWarning("chat relay error {Code}: {Message}", code, message);
+                    PushStatus();
+                    break;
+                case "pong":
+                    break;
+            }
+        }
+        catch (JsonException ex)
+        {
+            _log.LogDebug(ex, "chat: failed to parse relay frame");
+        }
+    }
+
+    private void UpdateRoster(JsonElement root, string property)
+    {
+        var list = ParseRoster(root, property);
+        if (list is null) return;
+        lock (_rosterSync) _roster = list;
+        _hub.BroadcastChatEvent(ChatEventFrame.Roster(list));
+    }
+
+    /// <summary>
+    /// Parses a relay <c>{t:"msg",...}</c> frame into a <see cref="ChatMessage"/>.
+    /// Tolerant of missing fields (id/ts are synthesised; room defaults to
+    /// "lobby"). Internal for unit tests — no network needed.
+    /// </summary>
+    internal static ChatMessage ParseMessage(JsonElement root) => new(
+        Id: ReadString(root, "id") ?? Guid.NewGuid().ToString("N"),
+        From: ReadString(root, "from") ?? string.Empty,
+        Text: ReadString(root, "text") ?? string.Empty,
+        Ts: ReadLong(root, "ts") ?? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+        Room: ReadString(root, "room") ?? "lobby");
+
+    /// <summary>
+    /// Parses the <paramref name="property"/> roster array out of a relay
+    /// <c>welcome</c>/<c>roster</c> frame. Returns null when the property is
+    /// absent or not an array. Internal for unit tests.
+    /// </summary>
+    internal static IReadOnlyList<ChatOperator>? ParseRoster(JsonElement root, string property)
+    {
+        if (!root.TryGetProperty(property, out var arr) || arr.ValueKind != JsonValueKind.Array)
+            return null;
+
+        var list = new List<ChatOperator>(arr.GetArrayLength());
+        foreach (var op in arr.EnumerateArray())
+        {
+            list.Add(new ChatOperator(
+                Callsign: ReadString(op, "callsign") ?? string.Empty,
+                Grid: ReadString(op, "grid"),
+                FreqHz: ReadLong(op, "freq"),
+                Mode: ReadString(op, "mode"),
+                Status: ReadString(op, "status"),
+                Since: ReadLong(op, "since") ?? 0));
+        }
+        return list;
+    }
+
+    // ── Presence / status helpers ──────────────────────────────────────────
+
+    private void OnRadioStateChanged(StateDto state)
+    {
+        if (!_connected) return;
+        if (_presence.Offer(state.VfoHz, state.Mode.ToString(), CurrentStatus()))
+            Wake();
+    }
+
+    private void OnMoxChanged(bool on)
+    {
+        _moxOn = on;
+        if (!_connected) return;
+        var snap = _radio.Snapshot();
+        if (_presence.Offer(snap.VfoHz, snap.Mode.ToString(), CurrentStatus()))
+            Wake();
+    }
+
+    private string CurrentStatus() => _moxOn ? "tx" : "rx";
+
+    private string? TryGetGrid() => _qrz.GetStatus().Home?.Grid;
+
+    // ── Snapshot / push helpers ────────────────────────────────────────────
+
+    private IReadOnlyList<byte[]> BuildSnapshotFrames()
+    {
+        IReadOnlyList<ChatOperator> roster;
+        lock (_rosterSync) roster = _roster;
+        return new[]
+        {
+            ChatEventFrame.Status(GetStatus()),
+            ChatEventFrame.Roster(roster),
+            ChatEventFrame.History(_messages.Snapshot(MessageHistoryCap)),
+        };
+    }
+
+    private void PushStatus() => _hub.BroadcastChatEvent(ChatEventFrame.Status(GetStatus()));
+
+    private void SetDisconnected()
+    {
+        _socket = null;
+        if (_connected)
+        {
+            _connected = false;
+            PushStatus();
+        }
+        else
+        {
+            _connected = false;
+        }
+    }
+
+    // ── Low-level frame send ───────────────────────────────────────────────
+
+    private async Task SendFrameAsync(ClientWebSocket socket, object frame, CancellationToken ct)
+    {
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(frame, ChatEventFrame.JsonOptions);
+        await _sendGate.WaitAsync(ct);
+        try
+        {
+            await socket.SendAsync(bytes, WebSocketMessageType.Text, true, ct);
+        }
+        finally { _sendGate.Release(); }
+    }
+
+    // The relay auto-responds to the EXACT string {"t":"ping"} without waking
+    // the durable object — send it verbatim, not via the serializer (which
+    // might add spacing).
+    private async Task SendPingAsync(ClientWebSocket socket, CancellationToken ct)
+    {
+        var bytes = Encoding.UTF8.GetBytes("{\"t\":\"ping\"}");
+        await _sendGate.WaitAsync(ct);
+        try
+        {
+            await socket.SendAsync(bytes, WebSocketMessageType.Text, true, ct);
+        }
+        finally { _sendGate.Release(); }
+    }
+
+    // ── Wake / backoff plumbing ────────────────────────────────────────────
+
+    private void Wake()
+    {
+        try { _wake.Release(); } catch (SemaphoreFullException) { /* already pending */ }
+    }
+
+    private async Task WaitForWakeAsync(TimeSpan timeout, CancellationToken ct)
+    {
+        try { await _wake.WaitAsync(timeout, ct); }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
+    }
+
+    private static TimeSpan NextBackoff(TimeSpan current)
+    {
+        var doubled = TimeSpan.FromTicks(current.Ticks * 2);
+        return doubled > ReconnectMaxDelay ? ReconnectMaxDelay : doubled;
+    }
+
+    // ── JSON read helpers (tolerant of missing / mistyped fields) ───────────
+
+    private static string? ReadString(JsonElement el, string name) =>
+        el.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
+
+    private static long? ReadLong(JsonElement el, string name)
+    {
+        if (!el.TryGetProperty(name, out var v)) return null;
+        return v.ValueKind == JsonValueKind.Number && v.TryGetInt64(out var n) ? n : null;
+    }
+
+    public override void Dispose()
+    {
+        _radio.StateChanged -= OnRadioStateChanged;
+        _radio.MoxChanged -= OnMoxChanged;
+        _wake.Dispose();
+        _sendGate.Dispose();
+        base.Dispose();
+    }
+}

--- a/Zeus.Server.Hosting/ChatService.cs
+++ b/Zeus.Server.Hosting/ChatService.cs
@@ -36,7 +36,7 @@ public sealed class ChatService : BackgroundService
 {
     /// <summary>Default public relay endpoint. Override with ZEUSCHAT_RELAY_URL.</summary>
     public const string DefaultRelayUrl =
-        "wss://zeuschat-relay.christiantsuarez.workers.dev/chat";
+        "wss://chat.openhpsdrzeus.com/chat";
 
     private const int MessageHistoryCap = 200;
     private static readonly TimeSpan HeartbeatInterval = TimeSpan.FromSeconds(30);

--- a/Zeus.Server.Hosting/ChatSupport.cs
+++ b/Zeus.Server.Hosting/ChatSupport.cs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Bounded in-memory chat message history. Keeps at most <c>capacity</c>
+/// messages, evicting the oldest. Thread-safe. Factored out of
+/// <see cref="ChatService"/> so the cap behaviour is unit-testable in isolation.
+/// </summary>
+public sealed class ChatMessageRing
+{
+    private readonly int _capacity;
+    private readonly Queue<ChatMessage> _items;
+    private readonly object _sync = new();
+
+    public ChatMessageRing(int capacity)
+    {
+        if (capacity <= 0) throw new ArgumentOutOfRangeException(nameof(capacity));
+        _capacity = capacity;
+        _items = new Queue<ChatMessage>(capacity);
+    }
+
+    public int Count
+    {
+        get { lock (_sync) return _items.Count; }
+    }
+
+    public void Add(ChatMessage message)
+    {
+        lock (_sync)
+        {
+            _items.Enqueue(message);
+            while (_items.Count > _capacity) _items.Dequeue();
+        }
+    }
+
+    /// <summary>
+    /// Returns up to <paramref name="limit"/> of the most recent messages in
+    /// chronological (oldest-first) order. A non-positive limit returns all.
+    /// </summary>
+    public IReadOnlyList<ChatMessage> Snapshot(int limit)
+    {
+        lock (_sync)
+        {
+            if (limit <= 0 || limit >= _items.Count)
+                return _items.ToArray();
+            return _items.Skip(_items.Count - limit).ToArray();
+        }
+    }
+}
+
+/// <summary>
+/// Presence-update throttle for the relay. Coalesces frequency/mode/status
+/// changes so the relay sees at most one presence frame per
+/// <c>window</c>, but never suppresses a genuine change beyond the window.
+/// Factored out of <see cref="ChatService"/> for unit testing.
+///
+/// <para>Usage: event handlers call <see cref="Offer"/> with the latest
+/// presence; it returns true when the worker should wake. The worker calls
+/// <see cref="TryTake"/> on its tick; it yields a frame only when presence
+/// differs from the last sent value AND the window has elapsed.</para>
+/// </summary>
+public sealed class PresenceThrottle
+{
+    public readonly record struct Presence(long FreqHz, string Mode, string Status);
+
+    private readonly TimeSpan _window;
+    private readonly object _sync = new();
+
+    private Presence _lastSent;
+    private bool _hasSent;
+    private Presence _pending;
+    private bool _hasPending;
+    private DateTimeOffset _lastSentAt = DateTimeOffset.MinValue;
+
+    public PresenceThrottle(TimeSpan window)
+    {
+        _window = window;
+    }
+
+    /// <summary>
+    /// Seeds the last-sent presence without emitting (e.g. after a hello frame
+    /// already carried it) so the next identical idle tick is suppressed.
+    /// </summary>
+    public void Seed(long freqHz, string mode, string status)
+    {
+        lock (_sync)
+        {
+            _lastSent = new Presence(freqHz, mode, status);
+            _hasSent = true;
+            _lastSentAt = DateTimeOffset.MinValue; // allow an immediate change to flush
+            _hasPending = false;
+        }
+    }
+
+    /// <summary>
+    /// Records the latest presence. Returns true when this represents a change
+    /// from the last sent value (so the caller should wake the worker); false
+    /// when it's a no-op duplicate.
+    /// </summary>
+    public bool Offer(long freqHz, string mode, string status)
+    {
+        var p = new Presence(freqHz, mode, status);
+        lock (_sync)
+        {
+            if (_hasSent && p == _lastSent && !_hasPending)
+                return false;
+            _pending = p;
+            _hasPending = true;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// If a changed presence is pending and the throttle window has elapsed
+    /// since the last send, yields it and records it as sent. Otherwise returns
+    /// false.
+    /// </summary>
+    public bool TryTake(DateTimeOffset now, out Presence presence)
+    {
+        lock (_sync)
+        {
+            presence = default;
+            if (!_hasPending) return false;
+            if (_hasSent && _pending == _lastSent)
+            {
+                _hasPending = false;
+                return false;
+            }
+            if (now - _lastSentAt < _window) return false;
+
+            presence = _pending;
+            _lastSent = _pending;
+            _hasSent = true;
+            _hasPending = false;
+            _lastSentAt = now;
+            return true;
+        }
+    }
+}

--- a/Zeus.Server.Hosting/QrzService.cs
+++ b/Zeus.Server.Hosting/QrzService.cs
@@ -180,6 +180,33 @@ public sealed class QrzService
         }
     }
 
+    /// <summary>
+    /// Returns the operator's chat identity for the ZeusChat relay handshake:
+    /// the home callsign plus a currently-valid QRZ session key (the relay
+    /// validates the session on the WS upgrade). Returns null when the operator
+    /// is not logged in or no session key can be acquired. Reuses the same gate
+    /// and session-acquisition path as lookups so a refresh here doesn't race a
+    /// concurrent lookup.
+    /// </summary>
+    public async Task<(string Callsign, string SessionKey)?> GetChatIdentityAsync(CancellationToken ct)
+    {
+        await _gate.WaitAsync(ct);
+        try
+        {
+            var callsign = _home?.Callsign;
+            if (string.IsNullOrWhiteSpace(callsign)) return null;
+
+            var key = await AcquireSessionKeyAsync(ct);
+            if (string.IsNullOrWhiteSpace(key)) return null;
+
+            return (callsign!, key!);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
     public async Task LogoutAsync(CancellationToken ct = default)
     {
         _username = null;

--- a/Zeus.Server.Hosting/StreamingHub.cs
+++ b/Zeus.Server.Hosting/StreamingHub.cs
@@ -91,6 +91,14 @@ public sealed class StreamingHub
     // they see the current spots without waiting for the next TCI spot event.
     private volatile byte[]? _spotPayload;
 
+    // Supplies the ChatEvent (0x35) snapshot frames pushed to each new WS
+    // client on attach: current status, the live roster, and the message
+    // history. Set once by ChatService at startup (mirrors the SpotList
+    // push-on-attach, but chat has three distinct envelopes so a single
+    // cached payload won't do). Null until ChatService wires it up; absent
+    // chat support simply skips the push.
+    private volatile Func<IReadOnlyList<byte[]>>? _chatSnapshotProvider;
+
     // ---- Step 1 drop-counter probe for issue #299 -----------------------
     // Each per-client send queue is bounded to MaxBacklogPerClient=4 with
     // FullMode=DropOldest (lines 318-324). When the producer outruns
@@ -289,6 +297,16 @@ public sealed class StreamingHub
         // arrived before it connected (e.g. a skimmer that was already running).
         var spotSnap = _spotPayload;
         if (spotSnap is not null) session.TryEnqueue(spotSnap);
+
+        // Push the current chat snapshot (status + roster + history) so a
+        // late-joining client renders the conversation without waiting for the
+        // next relay event. Same push-on-attach pattern as the spot list.
+        var chatProvider = _chatSnapshotProvider;
+        if (chatProvider is not null)
+        {
+            foreach (var frame in chatProvider())
+                session.TryEnqueue(frame);
+        }
 
         try
         {
@@ -713,6 +731,33 @@ public sealed class StreamingHub
     public void BroadcastSpots(byte[] payload)
     {
         _spotPayload = payload;
+        foreach (var client in _clients.Values)
+        {
+            if (!client.TryEnqueue(payload)) System.Threading.Interlocked.Increment(ref _dropsOther);
+        }
+    }
+
+    /// <summary>
+    /// Registers the provider that yields the ChatEvent (0x35) snapshot frames
+    /// (status + roster + history) pushed to each new WS client on attach.
+    /// Called once by ChatService at startup. Mirrors how the spot list is
+    /// cached for push-on-attach, but chat has three distinct envelopes so a
+    /// provider is used instead of a single cached payload.
+    /// </summary>
+    public void SetChatSnapshotProvider(Func<IReadOnlyList<byte[]>> provider)
+    {
+        _chatSnapshotProvider = provider;
+    }
+
+    /// <summary>
+    /// Broadcasts a pre-encoded ChatEvent (0x35) frame ([type][UTF-8 JSON]) to
+    /// every connected client. ChatService builds the frame via
+    /// <see cref="Zeus.Contracts.ChatEventFrame"/> so the envelope shapes stay
+    /// in one place. Same fan-out shape as <see cref="BroadcastSpots"/>.
+    /// </summary>
+    public void BroadcastChatEvent(byte[] payload)
+    {
+        if (_clients.IsEmpty) return;
         foreach (var client in _clients.Values)
         {
             if (!client.TryEnqueue(payload)) System.Threading.Interlocked.Increment(ref _dropsOther);

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -2502,6 +2502,40 @@ public static class ZeusEndpoints
             return Results.Ok(qrz.GetStatus());
         });
 
+        // ── ZeusChat — operator-to-operator chat over the Cloudflare relay ──
+        app.MapGet("/api/chat/status", (ChatService chat) => chat.GetStatus());
+
+        app.MapPost("/api/chat/enable", (ChatEnableRequest req, ChatService chat) =>
+        {
+            log.LogInformation("api.chat.enable enabled={Enabled}", req.Enabled);
+            return Results.Ok(chat.SetEnabled(req.Enabled));
+        });
+
+        app.MapPost("/api/chat/send", async (ChatSendRequest req, ChatService chat, HttpContext ctx) =>
+        {
+            if (string.IsNullOrWhiteSpace(req.Text))
+                return Results.BadRequest(new { error = "message text required" });
+            try
+            {
+                await chat.SendMessageAsync(req.Text, ctx.RequestAborted);
+                return Results.Ok(new { ok = true });
+            }
+            catch (ArgumentException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status409Conflict);
+            }
+        });
+
+        app.MapGet("/api/chat/messages", (ChatService chat, int? limit) =>
+            Results.Ok(new { messages = chat.GetMessages(limit ?? 200) }));
+
+        app.MapGet("/api/chat/roster", (ChatService chat) =>
+            Results.Ok(new { operators = chat.GetRoster() }));
+
         // Point-to-point propagation (DE → DX). Proxies the HamClock sidecar's
         // ITU-R P.533-14 engine; always returns 200 with an {available:false}
         // payload when the engine is offline so the QRZ card can degrade quietly.

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -549,6 +549,14 @@ public static class ZeusHost
         builder.Services.AddHostedService(sp => sp.GetRequiredService<SpotBroadcastService>());
         builder.Services.AddSingleton<TciManagementService>();
 
+        // ZeusChat — operator-to-operator chat over the Cloudflare relay.
+        // Singleton (API surface) + hosted service (relay connection lifecycle),
+        // same shape as SpotBroadcastService above. Opt-in persisted via
+        // ChatEnabledStore; default OFF.
+        builder.Services.AddSingleton<ChatEnabledStore>();
+        builder.Services.AddSingleton<ChatService>();
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<ChatService>());
+
         var app = builder.Build();
 
         // Surface the listening endpoints up front so the operator can pick one

--- a/cloud/zeuschat-relay/.gitignore
+++ b/cloud/zeuschat-relay/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.wrangler/
+dist/
+*.log
+.dev.vars
+worker-configuration.d.ts

--- a/cloud/zeuschat-relay/README.md
+++ b/cloud/zeuschat-relay/README.md
@@ -33,9 +33,15 @@ side mirrors it.
 Backend → relay: `hello`, `presence`, `msg`, `ping`
 Relay → backend: `welcome`, `roster`, `msg`, `error`, `pong`
 
-Connect to `wss://<host>/chat`. If `RELAY_SHARED_SECRET` is set, present it as
-`Authorization: Bearer <secret>` or `?token=<secret>` on the upgrade. First
-frame must be `hello` with a callsign.
+Connect to `wss://<host>/chat`. Auth is at the HTTP upgrade via headers:
+
+- `Authorization: Bearer <secret>` (or `?token=<secret>`) if `RELAY_SHARED_SECRET` is set.
+- `X-QRZ-Session: <live QRZ session key>` and `X-QRZ-Callsign: <own callsign>`
+  when `QRZ_VERIFY` is on (the default). The relay validates the session against
+  the QRZ XML API and locks the verified callsign for the connection.
+
+The first frame is `hello` (presence: grid/freq/mode/status). Its `callsign` is
+only used in local dev where `QRZ_VERIFY=off`.
 
 ## Develop locally
 
@@ -75,12 +81,18 @@ npm run deploy
 `new_sqlite_classes` is used for the DO namespace, which is available on the
 free Workers plan.
 
-## Security notes (MVP)
+## Security notes
 
-- Callsign identity is **trust-on-assert**: it comes from the backend's
-  QRZ-authenticated session over TLS (not spoofable from a browser), but a
-  modified backend could assert a false callsign. Hardened in ZeusChat P4.
-- `RELAY_SHARED_SECRET` gates *who can connect at all*; set it in production so
-  the relay is not an open endpoint.
+- **QRZ-login required.** With `QRZ_VERIFY` on (default), every connection must
+  present a live QRZ session key, which the relay validates against the QRZ XML
+  API before admitting. Only operators logged into QRZ can use chat. Works for
+  any QRZ login tier (subscription not required). Fails closed if QRZ is
+  unreachable.
+- `RELAY_SHARED_SECRET` gates *who can reach the relay at all*; set it in
+  production so the relay is not an open endpoint.
+- **Callsign↔account binding is best-effort.** The QRZ session proves a valid
+  login; QRZ XML does not cleanly prove which callsign owns that session, so a
+  determined modified client could present a valid session under a different
+  callsign. Tightening this is tracked in ZeusChat P4.
 - Messages are capped at `MAX_MESSAGE_LEN` (2000 chars). Rate limiting lands in
   P3.

--- a/cloud/zeuschat-relay/README.md
+++ b/cloud/zeuschat-relay/README.md
@@ -74,25 +74,31 @@ Requires a Cloudflare account with Workers + Durable Objects.
 ```bash
 npm install
 wrangler login
-wrangler secret put RELAY_SHARED_SECRET   # optional but recommended
 npm run deploy
 ```
 
-`new_sqlite_classes` is used for the DO namespace, which is available on the
-free Workers plan.
+`new_sqlite_classes` is used for the DO namespaces, available on the free
+Workers plan. No secret is required — access is gated by QRZ verification, so
+shipped Zeus builds connect with no baked-in credential.
 
 ## Security notes
 
-- **QRZ-login required.** With `QRZ_VERIFY` on (default), every connection must
-  present a live QRZ session key, which the relay validates against the QRZ XML
-  API before admitting. Only operators logged into QRZ can use chat. Works for
-  any QRZ login tier (subscription not required). Fails closed if QRZ is
-  unreachable.
-- `RELAY_SHARED_SECRET` gates *who can reach the relay at all*; set it in
-  production so the relay is not an open endpoint.
-- **Callsign↔account binding is best-effort.** The QRZ session proves a valid
-  login; QRZ XML does not cleanly prove which callsign owns that session, so a
-  determined modified client could present a valid session under a different
-  callsign. Tightening this is tracked in ZeusChat P4.
-- Messages are capped at `MAX_MESSAGE_LEN` (2000 chars). Rate limiting lands in
-  P3.
+- **QRZ-login required (the access gate).** With `QRZ_VERIFY` on (default),
+  every connection must present a live QRZ session key, which the relay
+  validates against the QRZ XML API before admitting. Only operators logged
+  into QRZ can use chat. Works for any QRZ login tier (subscription not
+  required). Fails closed if QRZ is unreachable. Positive verdicts are cached
+  ~5 min (edge cache) to spare the QRZ API on reconnects.
+- **Rate limiting.** Per-IP connection limit (30 / 60s, via the `RateLimiter`
+  Durable Object) guards the QRZ-verify path from connection-spam; per-connection
+  message limit (6 / 5s, in `ChatRoom`) guards the room from message-spam.
+- `RELAY_SHARED_SECRET` is an *optional* extra gate (Bearer / `?token=`). Unset
+  in production — QRZ verification is the real gate, and requiring a secret
+  would mean shipping a key in every Zeus build.
+- **Callsign↔account binding is best-effort (known limitation).** The QRZ
+  session proves a valid login; QRZ XML does not cleanly expose which callsign
+  owns that session, so a determined *modified* client could present a valid
+  session under a different callsign. The UI discloses that chat broadcasts the
+  operator's callsign + frequency. Cryptographic ownership binding would require
+  QRZ support that doesn't currently exist.
+- Messages are capped at `MAX_MESSAGE_LEN` (2000 chars).

--- a/cloud/zeuschat-relay/README.md
+++ b/cloud/zeuschat-relay/README.md
@@ -1,0 +1,86 @@
+# zeuschat-relay
+
+Cloudflare Worker + Durable Object relay for **ZeusChat** — operator-to-operator
+chat for Zeus.
+
+Every operator runs their own local Zeus backend, so there is no shared server.
+This relay is the central meeting point: each Zeus backend opens one outbound
+WebSocket here, asserts its QRZ-verified callsign, publishes live presence
+(frequency / mode / status), and exchanges chat messages. The relay fans
+messages and roster updates out to all connected operators.
+
+It runs on the project's own Cloudflare account.
+
+## Design
+
+- **Backend is the chat node, not the browser.** The Zeus backend holds the
+  QRZ-verified callsign and the live VFO frequency, so the relay connection
+  stays server-side and the identity token never reaches a browser. The browser
+  ChatPanel talks to its own backend over the existing StreamingHub/REST.
+- **WebSocket Hibernation.** The `ChatRoom` Durable Object uses the hibernation
+  API (`acceptWebSocket` + `webSocket*` handlers), so it can be evicted from
+  memory while connections stay open. Roster is reconstructed from per-socket
+  attachments. Keepalive `ping`/`pong` is handled by `setWebSocketAutoResponse`
+  and does not wake the DO.
+- **One room in P0** (`lobby`). Band-derived rooms arrive in P3.
+
+## Wire protocol
+
+Text WebSocket frames, one JSON object per frame, discriminated by `t`. The
+authoritative definition lives in [`src/protocol.ts`](src/protocol.ts); the C#
+side mirrors it.
+
+Backend → relay: `hello`, `presence`, `msg`, `ping`
+Relay → backend: `welcome`, `roster`, `msg`, `error`, `pong`
+
+Connect to `wss://<host>/chat`. If `RELAY_SHARED_SECRET` is set, present it as
+`Authorization: Bearer <secret>` or `?token=<secret>` on the upgrade. First
+frame must be `hello` with a callsign.
+
+## Develop locally
+
+```bash
+cd cloud/zeuschat-relay
+npm install
+npm run typecheck      # tsc --noEmit
+npm run dev            # wrangler dev — serves on http://localhost:8787
+```
+
+Smoke test the health route:
+
+```bash
+curl http://localhost:8787/health      # -> "zeuschat-relay ok"
+```
+
+Smoke test the socket (any WS client), e.g. with `websocat`:
+
+```bash
+websocat ws://localhost:8787/chat
+> {"t":"hello","callsign":"W1ABC","freq":14074000,"mode":"FT8"}
+< {"t":"welcome", ...}
+< {"t":"roster", ...}
+```
+
+## Deploy (project owner)
+
+Requires a Cloudflare account with Workers + Durable Objects.
+
+```bash
+npm install
+wrangler login
+wrangler secret put RELAY_SHARED_SECRET   # optional but recommended
+npm run deploy
+```
+
+`new_sqlite_classes` is used for the DO namespace, which is available on the
+free Workers plan.
+
+## Security notes (MVP)
+
+- Callsign identity is **trust-on-assert**: it comes from the backend's
+  QRZ-authenticated session over TLS (not spoofable from a browser), but a
+  modified backend could assert a false callsign. Hardened in ZeusChat P4.
+- `RELAY_SHARED_SECRET` gates *who can connect at all*; set it in production so
+  the relay is not an open endpoint.
+- Messages are capped at `MAX_MESSAGE_LEN` (2000 chars). Rate limiting lands in
+  P3.

--- a/cloud/zeuschat-relay/package-lock.json
+++ b/cloud/zeuschat-relay/package-lock.json
@@ -1,0 +1,1576 @@
+{
+  "name": "zeuschat-relay",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "zeuschat-relay",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250109.0",
+        "typescript": "^5.7.0",
+        "wrangler": "^4.0.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260617.1.tgz",
+      "integrity": "sha512-jWwmgEVVWbsHNrLSNXzwjJaH90VzRxq1cWkQFUidxyeUPnMxemeNE8I9qFAfrpzGgE11e9sKDcE3ettJW08swQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260617.1.tgz",
+      "integrity": "sha512-LHH7b565g9znfCUOkwbec6FG2rmRbsgCy6aJiU9KN662mNheWl5sw/iKleiFSiljPKQQP3HkjnC/NSkdgi/aSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260617.1.tgz",
+      "integrity": "sha512-FMnaAKXe4Cfd8TQurCVd9fs2XQVBFRCsP+Id/SRdUv89MlwYu9zXfoyx6BxM+brPTIUK38SHbo8iaxiwzLi9JQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260617.1.tgz",
+      "integrity": "sha512-MRoifFYcqbxxIIQy7PqO5tFY/qPFSnjXzakWl0sO93l+HLyG35jRAgOi6jfqa4kBxc7gKKtH861DcewjxUfkjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260617.1.tgz",
+      "integrity": "sha512-rgBV9wQrv0OSKgCTTbhFUFY3sLGNANZ88aqaLvtmEn2gmbFVb1J4PDGochVUdB7NSEp4D/ghHva6/8SZmbONpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260619.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260619.1.tgz",
+      "integrity": "sha512-bprsNzG0DapQPFwU2AvQlQ6FUO7Y4bKWaPBzLNI7nBSqlHsK0P62xx2NaNT6i/htzAgQspKZm1D32y0RxofrRQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
+      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260617.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260617.0.tgz",
+      "integrity": "sha512-A+H5gcOCQZsKFg7/daZUtx8WHn4gGxwUfH1jnNDAisyAWSvvSZHe+GCeQWs16uthnUDcm72UQIQ1NXDJtnuo9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.34.5",
+        "undici": "7.28.0",
+        "workerd": "1.20260617.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260617.1.tgz",
+      "integrity": "sha512-Re5pl6pdowt3ZmWUzGlOuB7jbRIIPetgKalmo4cYmucQnVhpo7/3e4MfpekbhLi2EhZZz5EY9NWRu8zFzuEZew==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260617.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260617.1",
+        "@cloudflare/workerd-linux-64": "1.20260617.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260617.1",
+        "@cloudflare/workerd-windows-64": "1.20260617.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.102.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.102.0.tgz",
+      "integrity": "sha512-GPljlQs9a+/Ai2h0TdEUYaaWv9upK4fUteSWTPlruas7tdixiIwr74CZSWHcEPuRgZYkyYKHIBbT1w+BYPkPrw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "4.20260617.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260617.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260617.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/cloud/zeuschat-relay/package.json
+++ b/cloud/zeuschat-relay/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "zeuschat-relay",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Cloudflare Worker + Durable Object relay for ZeusChat operator-to-operator chat.",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit",
+    "cf-typegen": "wrangler types"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250109.0",
+    "typescript": "^5.7.0",
+    "wrangler": "^4.0.0"
+  }
+}

--- a/cloud/zeuschat-relay/src/chat-room.ts
+++ b/cloud/zeuschat-relay/src/chat-room.ts
@@ -42,15 +42,17 @@ export class ChatRoom extends DurableObject<Env> {
   }
 
   /** Upgrade an incoming request to a hibernatable WebSocket. */
-  override async fetch(_request: Request): Promise<Response> {
+  override async fetch(request: Request): Promise<Response> {
     const pair = new WebSocketPair();
     const client = pair[0];
     const server = pair[1];
 
     this.ctx.acceptWebSocket(server);
-    // Placeholder identity until the client sends `hello`. Connections without
-    // a callsign are excluded from the roster.
-    const initial: Attachment = { callsign: '', since: Date.now() };
+    // The Worker entry verifies the QRZ login and forwards the authoritative
+    // callsign here. When present it is locked in (hello cannot change it);
+    // when absent (local dev with QRZ_VERIFY=off) the callsign comes from hello.
+    const verified = (request.headers.get('X-Operator-Callsign') ?? '').trim().toUpperCase();
+    const initial: Attachment = { callsign: verified, since: Date.now() };
     server.serializeAttachment(initial);
 
     return new Response(null, { status: 101, webSocket: client });
@@ -73,7 +75,9 @@ export class ChatRoom extends DurableObject<Env> {
 
     switch (msg.t) {
       case 'hello': {
-        const callsign = (msg.callsign ?? '').trim().toUpperCase();
+        // Prefer the verified callsign locked in at connect; fall back to the
+        // hello-provided one only when the relay didn't verify one (local dev).
+        const callsign = att.callsign || (msg.callsign ?? '').trim().toUpperCase();
         if (!callsign) {
           this.send(ws, { t: 'error', code: 'no_callsign', message: 'callsign required' });
           return;

--- a/cloud/zeuschat-relay/src/chat-room.ts
+++ b/cloud/zeuschat-relay/src/chat-room.ts
@@ -1,0 +1,201 @@
+import { DurableObject } from 'cloudflare:workers';
+import type { Env } from './types';
+import {
+  type ClientToRelay,
+  type RelayToClient,
+  type Operator,
+  type PresenceStatus,
+  MAX_MESSAGE_LEN,
+  DEFAULT_ROOM,
+} from './protocol';
+
+/**
+ * Per-connection state, stored on the WebSocket via serializeAttachment so it
+ * survives Durable Object hibernation. Keep it small — it is persisted by the
+ * runtime for every accepted socket.
+ */
+interface Attachment {
+  callsign: string;
+  grid?: string;
+  freq?: number;
+  mode?: string;
+  status?: PresenceStatus;
+  since: number;
+}
+
+/**
+ * A single chat room. Each connected Zeus backend holds one WebSocket here.
+ * Uses the WebSocket Hibernation API so the DO can evict from memory while
+ * sockets stay open — presence/roster is reconstructed from socket attachments.
+ */
+export class ChatRoom extends DurableObject<Env> {
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+    // Auto-answer keepalives without waking the DO. Backends must send the
+    // exact request string for this to match.
+    this.ctx.setWebSocketAutoResponse(
+      new WebSocketRequestResponsePair(
+        JSON.stringify({ t: 'ping' }),
+        JSON.stringify({ t: 'pong' }),
+      ),
+    );
+  }
+
+  /** Upgrade an incoming request to a hibernatable WebSocket. */
+  override async fetch(_request: Request): Promise<Response> {
+    const pair = new WebSocketPair();
+    const client = pair[0];
+    const server = pair[1];
+
+    this.ctx.acceptWebSocket(server);
+    // Placeholder identity until the client sends `hello`. Connections without
+    // a callsign are excluded from the roster.
+    const initial: Attachment = { callsign: '', since: Date.now() };
+    server.serializeAttachment(initial);
+
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  override async webSocketMessage(ws: WebSocket, raw: string | ArrayBuffer): Promise<void> {
+    let msg: ClientToRelay;
+    try {
+      const text = typeof raw === 'string' ? raw : new TextDecoder().decode(raw);
+      msg = JSON.parse(text) as ClientToRelay;
+    } catch {
+      this.send(ws, { t: 'error', code: 'bad_json', message: 'invalid JSON' });
+      return;
+    }
+
+    const att = (ws.deserializeAttachment() as Attachment | null) ?? {
+      callsign: '',
+      since: Date.now(),
+    };
+
+    switch (msg.t) {
+      case 'hello': {
+        const callsign = (msg.callsign ?? '').trim().toUpperCase();
+        if (!callsign) {
+          this.send(ws, { t: 'error', code: 'no_callsign', message: 'callsign required' });
+          return;
+        }
+        const next: Attachment = {
+          callsign,
+          grid: msg.grid,
+          freq: msg.freq,
+          mode: msg.mode,
+          status: msg.status ?? 'rx',
+          since: att.since || Date.now(),
+        };
+        ws.serializeAttachment(next);
+        this.send(ws, { t: 'welcome', self: toOperator(next), roster: this.roster() });
+        this.broadcastRoster();
+        return;
+      }
+
+      case 'presence': {
+        if (!att.callsign) return; // ignore until identified
+        const next: Attachment = {
+          ...att,
+          freq: msg.freq ?? att.freq,
+          mode: msg.mode ?? att.mode,
+          status: msg.status ?? att.status,
+        };
+        ws.serializeAttachment(next);
+        this.broadcastRoster();
+        return;
+      }
+
+      case 'msg': {
+        if (!att.callsign) {
+          this.send(ws, { t: 'error', code: 'no_hello', message: 'send hello first' });
+          return;
+        }
+        const text = (msg.text ?? '').slice(0, MAX_MESSAGE_LEN);
+        if (!text.trim()) return;
+        this.broadcast({
+          t: 'msg',
+          id: crypto.randomUUID(),
+          from: att.callsign,
+          text,
+          ts: Date.now(),
+          room: msg.room ?? DEFAULT_ROOM,
+        });
+        return;
+      }
+
+      case 'ping': {
+        // Normally handled by auto-response; respond anyway if it reaches here.
+        this.send(ws, { t: 'pong' });
+        return;
+      }
+    }
+  }
+
+  override async webSocketClose(
+    ws: WebSocket,
+    code: number,
+    reason: string,
+    _wasClean: boolean,
+  ): Promise<void> {
+    try {
+      ws.close(code, reason);
+    } catch {
+      // already closing
+    }
+    this.broadcastRoster();
+  }
+
+  override async webSocketError(_ws: WebSocket, _error: unknown): Promise<void> {
+    this.broadcastRoster();
+  }
+
+  // --- helpers ---------------------------------------------------------------
+
+  private send(ws: WebSocket, msg: RelayToClient): void {
+    try {
+      ws.send(JSON.stringify(msg));
+    } catch {
+      // socket gone
+    }
+  }
+
+  private broadcast(msg: RelayToClient): void {
+    const payload = JSON.stringify(msg);
+    for (const ws of this.ctx.getWebSockets()) {
+      try {
+        ws.send(payload);
+      } catch {
+        // skip dead sockets
+      }
+    }
+  }
+
+  private roster(): Operator[] {
+    const seen = new Set<string>();
+    const out: Operator[] = [];
+    for (const ws of this.ctx.getWebSockets()) {
+      const att = ws.deserializeAttachment() as Attachment | null;
+      if (!att || !att.callsign) continue;
+      if (seen.has(att.callsign)) continue; // de-dup multi-tab/same call
+      seen.add(att.callsign);
+      out.push(toOperator(att));
+    }
+    out.sort((a, b) => a.callsign.localeCompare(b.callsign));
+    return out;
+  }
+
+  private broadcastRoster(): void {
+    this.broadcast({ t: 'roster', roster: this.roster() });
+  }
+}
+
+function toOperator(a: Attachment): Operator {
+  return {
+    callsign: a.callsign,
+    grid: a.grid,
+    freq: a.freq,
+    mode: a.mode,
+    status: a.status,
+    since: a.since,
+  };
+}

--- a/cloud/zeuschat-relay/src/chat-room.ts
+++ b/cloud/zeuschat-relay/src/chat-room.ts
@@ -21,7 +21,14 @@ interface Attachment {
   mode?: string;
   status?: PresenceStatus;
   since: number;
+  // Per-connection message rate-limit window (fixed window).
+  rlWindowStart?: number;
+  rlCount?: number;
 }
+
+/** Max messages a single connection may send per RL_WINDOW_MS. */
+const MSG_RATE_LIMIT = 6;
+const RL_WINDOW_MS = 5000;
 
 /**
  * A single chat room. Each connected Zeus backend holds one WebSocket here.
@@ -116,12 +123,27 @@ export class ChatRoom extends DurableObject<Env> {
         }
         const text = (msg.text ?? '').slice(0, MAX_MESSAGE_LEN);
         if (!text.trim()) return;
+
+        // Per-connection fixed-window message rate limit.
+        const now = Date.now();
+        const fresh = now - (att.rlWindowStart ?? 0) > RL_WINDOW_MS;
+        const count = fresh ? 0 : att.rlCount ?? 0;
+        if (count >= MSG_RATE_LIMIT) {
+          this.send(ws, { t: 'error', code: 'rate_limited', message: 'Slow down — too many messages' });
+          return;
+        }
+        ws.serializeAttachment({
+          ...att,
+          rlWindowStart: fresh ? now : att.rlWindowStart,
+          rlCount: count + 1,
+        });
+
         this.broadcast({
           t: 'msg',
           id: crypto.randomUUID(),
           from: att.callsign,
           text,
-          ts: Date.now(),
+          ts: now,
           room: msg.room ?? DEFAULT_ROOM,
         });
         return;

--- a/cloud/zeuschat-relay/src/index.ts
+++ b/cloud/zeuschat-relay/src/index.ts
@@ -15,7 +15,7 @@ export default {
     }
 
     if (url.pathname === '/chat') {
-      // Optional shared-secret gate (set RELAY_SHARED_SECRET to enable).
+      // 1. Shared-secret gate (set RELAY_SHARED_SECRET to enable).
       if (env.RELAY_SHARED_SECRET) {
         const header = request.headers.get('Authorization');
         const bearer = header?.startsWith('Bearer ') ? header.slice(7) : undefined;
@@ -25,16 +25,65 @@ export default {
         }
       }
 
+      // 2. QRZ-login gate. The backend proves the operator is logged into QRZ
+      //    by presenting its live QRZ session key + own callsign as headers; we
+      //    validate the session against QRZ before admitting. Disable with
+      //    QRZ_VERIFY="off" for local dev (browser WS clients can't set headers).
+      const verify = (env.QRZ_VERIFY ?? 'on').toLowerCase() !== 'off';
+      const callsign = (request.headers.get('X-QRZ-Callsign') ?? '').trim().toUpperCase();
+      if (verify) {
+        const sessionKey = request.headers.get('X-QRZ-Session') ?? '';
+        if (!sessionKey || !callsign) {
+          return new Response('qrz auth required', { status: 401 });
+        }
+        const ok = await verifyQrzSession(sessionKey, callsign);
+        if (!ok) {
+          return new Response('qrz session invalid or not logged in', { status: 403 });
+        }
+      }
+
+      // 3. WebSocket upgrade required.
       if (request.headers.get('Upgrade') !== 'websocket') {
         return new Response('expected websocket upgrade', { status: 426 });
       }
 
-      // P0: one global room. P3 introduces band-derived rooms keyed by name.
+      // 4. Route to the room DO, forwarding the (verified) callsign so the DO
+      //    treats it as authoritative. P0: one global room.
+      const headers = new Headers(request.headers);
+      if (callsign) headers.set('X-Operator-Callsign', callsign);
+      const forwarded = new Request(request, { headers });
+
       const id = env.CHAT_ROOM.idFromName(DEFAULT_ROOM);
       const stub = env.CHAT_ROOM.get(id);
-      return stub.fetch(request);
+      return stub.fetch(forwarded);
     }
 
     return new Response('not found', { status: 404 });
   },
 } satisfies ExportedHandler<Env>;
+
+/**
+ * Validates a QRZ XML session key by performing one lookup of the operator's
+ * own callsign. Per the QRZ XML spec, a live session returns a <Key> element;
+ * an expired/invalid session omits <Key> and returns <Error>Session Timeout</Error>.
+ * Non-subscribers still get a <Key> (plus a subscription <Message>), so this
+ * works for any QRZ login tier. Fails closed on any QRZ/network error.
+ */
+async function verifyQrzSession(sessionKey: string, callsign: string): Promise<boolean> {
+  const u =
+    'https://xmldata.qrz.com/xml/current/' +
+    `?s=${encodeURIComponent(sessionKey)}` +
+    `;callsign=${encodeURIComponent(callsign)}` +
+    ';agent=zeuschat';
+  try {
+    const res = await fetch(u, { cf: { cacheTtl: 0 } });
+    if (!res.ok) return false;
+    const xml = await res.text();
+    const hasKey = /<Key>\s*[^<\s][^<]*<\/Key>/i.test(xml);
+    const errText = /<Error>([^<]*)<\/Error>/i.exec(xml)?.[1] ?? '';
+    const badSession = /session timeout|invalid session|session expired|not logged/i.test(errText);
+    return hasKey && !badSession;
+  } catch {
+    return false; // fail closed: no proof of login => no access
+  }
+}

--- a/cloud/zeuschat-relay/src/index.ts
+++ b/cloud/zeuschat-relay/src/index.ts
@@ -2,9 +2,10 @@ import type { Env } from './types';
 import { DEFAULT_ROOM } from './protocol';
 
 export { ChatRoom } from './chat-room';
+export { RateLimiter } from './rate-limiter';
 
 export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
 
     if (url.pathname === '/' || url.pathname === '/health') {
@@ -15,7 +16,18 @@ export default {
     }
 
     if (url.pathname === '/chat') {
-      // 1. Shared-secret gate (set RELAY_SHARED_SECRET to enable).
+      const ip = request.headers.get('cf-connecting-ip') ?? 'unknown';
+
+      // 1. Per-IP connection rate limit (protects the QRZ-verify path from
+      //    connection-spam). Deterministic per-IP Durable Object counter.
+      const limiter = env.RATE_DO.get(env.RATE_DO.idFromName(ip));
+      const rlRes = await limiter.fetch('https://rl.internal/check');
+      if (rlRes.status === 429) {
+        return new Response('rate limited', { status: 429 });
+      }
+
+      // 2. Optional shared-secret gate (defense-in-depth; production relies on
+      //    QRZ verification, so this is normally unset).
       if (env.RELAY_SHARED_SECRET) {
         const header = request.headers.get('Authorization');
         const bearer = header?.startsWith('Bearer ') ? header.slice(7) : undefined;
@@ -25,10 +37,9 @@ export default {
         }
       }
 
-      // 2. QRZ-login gate. The backend proves the operator is logged into QRZ
-      //    by presenting its live QRZ session key + own callsign as headers; we
-      //    validate the session against QRZ before admitting. Disable with
-      //    QRZ_VERIFY="off" for local dev (browser WS clients can't set headers).
+      // 3. QRZ-login gate. The backend presents its live QRZ session key + own
+      //    callsign as headers; we validate the session against QRZ before
+      //    admitting. Disable with QRZ_VERIFY="off" for local dev only.
       const verify = (env.QRZ_VERIFY ?? 'on').toLowerCase() !== 'off';
       const callsign = (request.headers.get('X-QRZ-Callsign') ?? '').trim().toUpperCase();
       if (verify) {
@@ -36,19 +47,18 @@ export default {
         if (!sessionKey || !callsign) {
           return new Response('qrz auth required', { status: 401 });
         }
-        const ok = await verifyQrzSession(sessionKey, callsign);
+        const ok = await verifyQrzSessionCached(sessionKey, callsign, ctx);
         if (!ok) {
           return new Response('qrz session invalid or not logged in', { status: 403 });
         }
       }
 
-      // 3. WebSocket upgrade required.
+      // 4. WebSocket upgrade required.
       if (request.headers.get('Upgrade') !== 'websocket') {
         return new Response('expected websocket upgrade', { status: 426 });
       }
 
-      // 4. Route to the room DO, forwarding the (verified) callsign so the DO
-      //    treats it as authoritative. P0: one global room.
+      // 5. Route to the room DO, forwarding the (verified) callsign. P0: one room.
       const headers = new Headers(request.headers);
       if (callsign) headers.set('X-Operator-Callsign', callsign);
       const forwarded = new Request(request, { headers });
@@ -62,12 +72,44 @@ export default {
   },
 } satisfies ExportedHandler<Env>;
 
+/** TTL (seconds) for cached positive QRZ-session verdicts. */
+const QRZ_VERIFY_TTL = 300;
+
+/**
+ * QRZ verification with a short-lived positive-result cache (edge Cache API).
+ * Legit reconnects within the TTL don't re-hit QRZ; only valid verdicts are
+ * cached (never negative, so a freshly-logged-in operator is never locked out).
+ */
+async function verifyQrzSessionCached(
+  sessionKey: string,
+  callsign: string,
+  ctx: ExecutionContext,
+): Promise<boolean> {
+  const digest = await sha256Hex(`${sessionKey}|${callsign}`);
+  const cacheKey = new Request(`https://qrz-verify.zeuschat.internal/${digest}`);
+  const cache = caches.default;
+
+  const hit = await cache.match(cacheKey);
+  if (hit) return (await hit.text()) === '1';
+
+  const ok = await verifyQrzSession(sessionKey, callsign);
+  if (ok) {
+    ctx.waitUntil(
+      cache.put(
+        cacheKey,
+        new Response('1', { headers: { 'Cache-Control': `max-age=${QRZ_VERIFY_TTL}` } }),
+      ),
+    );
+  }
+  return ok;
+}
+
 /**
  * Validates a QRZ XML session key by performing one lookup of the operator's
  * own callsign. Per the QRZ XML spec, a live session returns a <Key> element;
  * an expired/invalid session omits <Key> and returns <Error>Session Timeout</Error>.
- * Non-subscribers still get a <Key> (plus a subscription <Message>), so this
- * works for any QRZ login tier. Fails closed on any QRZ/network error.
+ * Non-subscribers still get a <Key>, so this works for any QRZ login tier.
+ * Fails closed on any QRZ/network error.
  */
 async function verifyQrzSession(sessionKey: string, callsign: string): Promise<boolean> {
   const u =
@@ -86,4 +128,11 @@ async function verifyQrzSession(sessionKey: string, callsign: string): Promise<b
   } catch {
     return false; // fail closed: no proof of login => no access
   }
+}
+
+/** Hex SHA-256 of a string (for opaque cache keys; never logs the raw key). */
+async function sha256Hex(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input);
+  const buf = await crypto.subtle.digest('SHA-256', data);
+  return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, '0')).join('');
 }

--- a/cloud/zeuschat-relay/src/index.ts
+++ b/cloud/zeuschat-relay/src/index.ts
@@ -1,0 +1,40 @@
+import type { Env } from './types';
+import { DEFAULT_ROOM } from './protocol';
+
+export { ChatRoom } from './chat-room';
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname === '/' || url.pathname === '/health') {
+      return new Response('zeuschat-relay ok', {
+        status: 200,
+        headers: { 'content-type': 'text/plain' },
+      });
+    }
+
+    if (url.pathname === '/chat') {
+      // Optional shared-secret gate (set RELAY_SHARED_SECRET to enable).
+      if (env.RELAY_SHARED_SECRET) {
+        const header = request.headers.get('Authorization');
+        const bearer = header?.startsWith('Bearer ') ? header.slice(7) : undefined;
+        const token = bearer ?? url.searchParams.get('token') ?? undefined;
+        if (token !== env.RELAY_SHARED_SECRET) {
+          return new Response('unauthorized', { status: 401 });
+        }
+      }
+
+      if (request.headers.get('Upgrade') !== 'websocket') {
+        return new Response('expected websocket upgrade', { status: 426 });
+      }
+
+      // P0: one global room. P3 introduces band-derived rooms keyed by name.
+      const id = env.CHAT_ROOM.idFromName(DEFAULT_ROOM);
+      const stub = env.CHAT_ROOM.get(id);
+      return stub.fetch(request);
+    }
+
+    return new Response('not found', { status: 404 });
+  },
+} satisfies ExportedHandler<Env>;

--- a/cloud/zeuschat-relay/src/protocol.ts
+++ b/cloud/zeuschat-relay/src/protocol.ts
@@ -6,6 +6,14 @@
 //
 // Transport: text WebSocket frames, one JSON object per frame, discriminated by
 // the `t` (type) field.
+//
+// Connection auth happens at the HTTP upgrade (before any frame), via headers:
+//   Authorization: Bearer <RELAY_SHARED_SECRET>   (if the relay sets a secret)
+//   X-QRZ-Session:  <live QRZ session key>         (when QRZ_VERIFY != "off")
+//   X-QRZ-Callsign: <operator's own callsign>      (validated against QRZ)
+// The relay validates the QRZ session, then locks the verified callsign for the
+// connection. `hello` thereafter carries presence; its `callsign` is only used
+// as a fallback in local dev (QRZ_VERIFY=off), where header auth is unavailable.
 
 /** Operator presence/activity state. */
 export type PresenceStatus = 'rx' | 'tx' | 'away';

--- a/cloud/zeuschat-relay/src/protocol.ts
+++ b/cloud/zeuschat-relay/src/protocol.ts
@@ -1,0 +1,68 @@
+// ZeusChat relay wire protocol.
+//
+// This is the authoritative definition of the JSON messages exchanged over the
+// WebSocket between a Zeus backend (the "chat node") and the relay Durable
+// Object. The C# side (Zeus.Contracts / ChatService) mirrors these shapes.
+//
+// Transport: text WebSocket frames, one JSON object per frame, discriminated by
+// the `t` (type) field.
+
+/** Operator presence/activity state. */
+export type PresenceStatus = 'rx' | 'tx' | 'away';
+
+/** A connected operator as seen by everyone in the room. */
+export interface Operator {
+  /** Uppercased callsign (QRZ-verified on the backend that asserted it). */
+  callsign: string;
+  /** Maidenhead grid square, if known. */
+  grid?: string;
+  /** Current VFO frequency in Hz. */
+  freq?: number;
+  /** Current mode (e.g. "USB", "CW"). */
+  mode?: string;
+  /** Activity state. */
+  status?: PresenceStatus;
+  /** Epoch ms the operator connected. */
+  since: number;
+}
+
+/** Messages sent by a backend chat node TO the relay. */
+export type ClientToRelay =
+  // First frame after connect: declares identity + initial presence.
+  | {
+      t: 'hello';
+      callsign: string;
+      grid?: string;
+      freq?: number;
+      mode?: string;
+      status?: PresenceStatus;
+      /** Client identifier, e.g. "zeus/0.9.0". Informational. */
+      client?: string;
+    }
+  // Live presence update (frequency / mode / status changed).
+  | { t: 'presence'; freq?: number; mode?: string; status?: PresenceStatus }
+  // Outgoing chat message.
+  | { t: 'msg'; text: string; room?: string }
+  // Keepalive. The relay auto-responds with {t:"pong"} without waking (see
+  // setWebSocketAutoResponse in chat-room.ts) — send this EXACT string:
+  // '{"t":"ping"}'.
+  | { t: 'ping' };
+
+/** Messages sent by the relay TO a backend chat node. */
+export type RelayToClient =
+  // Acknowledges hello: echoes the caller's resolved operator + current roster.
+  | { t: 'welcome'; self: Operator; roster: Operator[] }
+  // Roster changed (someone joined/left or updated presence).
+  | { t: 'roster'; roster: Operator[] }
+  // A chat message (including the sender's own, for echo/ordering).
+  | { t: 'msg'; id: string; from: string; text: string; ts: number; room: string }
+  // Protocol/validation error. Non-fatal unless the socket is also closed.
+  | { t: 'error'; code: string; message: string }
+  // Keepalive response.
+  | { t: 'pong' };
+
+/** Max accepted chat message length (characters); longer is truncated. */
+export const MAX_MESSAGE_LEN = 2000;
+
+/** The single room used in P0. Band-derived rooms arrive in P3. */
+export const DEFAULT_ROOM = 'lobby';

--- a/cloud/zeuschat-relay/src/rate-limiter.ts
+++ b/cloud/zeuschat-relay/src/rate-limiter.ts
@@ -1,0 +1,28 @@
+import { DurableObject } from 'cloudflare:workers';
+import type { Env } from './types';
+
+/** Connection attempts allowed per IP per window. */
+const LIMIT = 30;
+const WINDOW_MS = 60_000;
+
+/**
+ * Per-IP connection rate limiter. One instance per IP (idFromName(ip)), so the
+ * fixed-window counter is strongly consistent for that IP (a DO is
+ * single-threaded). In-memory state is fine here: an actively-abused limiter
+ * stays warm and keeps counting; an idle one may evict and reset, but idle ==
+ * no abuse. Guards the QRZ-verification path from connection-spam.
+ */
+export class RateLimiter extends DurableObject<Env> {
+  private windowStart = 0;
+  private count = 0;
+
+  override async fetch(_request: Request): Promise<Response> {
+    const now = Date.now();
+    if (now - this.windowStart > WINDOW_MS) {
+      this.windowStart = now;
+      this.count = 0;
+    }
+    this.count += 1;
+    return new Response(null, { status: this.count <= LIMIT ? 204 : 429 });
+  }
+}

--- a/cloud/zeuschat-relay/src/types.ts
+++ b/cloud/zeuschat-relay/src/types.ts
@@ -11,4 +11,12 @@ export interface Env {
    * (local dev only).
    */
   RELAY_SHARED_SECRET?: string;
+
+  /**
+   * QRZ-login enforcement. Default "on": each connection must present a valid
+   * QRZ session (X-QRZ-Session + X-QRZ-Callsign headers) which the relay
+   * validates against the QRZ XML API. Set "off" for local dev only — browser
+   * WebSocket clients cannot set request headers.
+   */
+  QRZ_VERIFY?: string;
 }

--- a/cloud/zeuschat-relay/src/types.ts
+++ b/cloud/zeuschat-relay/src/types.ts
@@ -1,0 +1,14 @@
+import type { ChatRoom } from './chat-room';
+
+/** Worker environment bindings (see wrangler.toml). */
+export interface Env {
+  /** Durable Object namespace hosting chat rooms. */
+  CHAT_ROOM: DurableObjectNamespace<ChatRoom>;
+  /**
+   * Optional shared secret gating connections to the relay. When set (via
+   * `wrangler secret put RELAY_SHARED_SECRET`), backends must present it as a
+   * Bearer token or `?token=` query param on the WS upgrade. Unset = open
+   * (local dev only).
+   */
+  RELAY_SHARED_SECRET?: string;
+}

--- a/cloud/zeuschat-relay/src/types.ts
+++ b/cloud/zeuschat-relay/src/types.ts
@@ -1,9 +1,13 @@
 import type { ChatRoom } from './chat-room';
+import type { RateLimiter } from './rate-limiter';
 
 /** Worker environment bindings (see wrangler.toml). */
 export interface Env {
   /** Durable Object namespace hosting chat rooms. */
   CHAT_ROOM: DurableObjectNamespace<ChatRoom>;
+
+  /** Per-IP connection rate limiter Durable Object. */
+  RATE_DO: DurableObjectNamespace<RateLimiter>;
   /**
    * Optional shared secret gating connections to the relay. When set (via
    * `wrangler secret put RELAY_SHARED_SECRET`), backends must present it as a

--- a/cloud/zeuschat-relay/test/smoke.mjs
+++ b/cloud/zeuschat-relay/test/smoke.mjs
@@ -1,0 +1,35 @@
+// Minimal runtime smoke test for the ZeusChat relay.
+// Connects, sends `hello` + a `msg`, collects relay responses, prints them.
+// Usage: node test/smoke.mjs   (set CHAT_URL to override the endpoint)
+const url = process.env.CHAT_URL || 'ws://127.0.0.1:8787/chat';
+const token = process.env.RELAY_TOKEN;
+const target = token ? `${url}?token=${encodeURIComponent(token)}` : url;
+
+if (typeof WebSocket === 'undefined') {
+  console.error('FAIL: global WebSocket unavailable (need Node >= 21)');
+  process.exit(3);
+}
+
+const got = [];
+const ws = new WebSocket(target);
+
+ws.addEventListener('open', () => {
+  ws.send(JSON.stringify({ t: 'hello', callsign: 'w1abc', freq: 14074000, mode: 'FT8' }));
+  setTimeout(() => ws.send(JSON.stringify({ t: 'msg', text: 'hello world' })), 300);
+  setTimeout(() => {
+    const types = got.map((g) => { try { return JSON.parse(g).t; } catch { return '?'; } });
+    console.log('RECEIVED TYPES:', types.join(', '));
+    console.log('FRAMES:');
+    for (const g of got) console.log('  ' + g);
+    const ok = types.includes('welcome') && types.includes('roster') && types.includes('msg');
+    console.log(ok ? 'SMOKE: PASS' : 'SMOKE: FAIL');
+    ws.close();
+    process.exit(ok ? 0 : 1);
+  }, 900);
+});
+
+ws.addEventListener('message', (e) => got.push(typeof e.data === 'string' ? e.data : ''));
+ws.addEventListener('error', (e) => {
+  console.error('WS ERROR:', e?.message || String(e));
+  process.exit(2);
+});

--- a/cloud/zeuschat-relay/tsconfig.json
+++ b/cloud/zeuschat-relay/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "lib": ["es2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/cloud/zeuschat-relay/wrangler.toml
+++ b/cloud/zeuschat-relay/wrangler.toml
@@ -2,6 +2,11 @@ name = "zeuschat-relay"
 main = "src/index.ts"
 compatibility_date = "2025-01-01"
 
+# QRZ-login enforcement is on by default. For local `wrangler dev`, override
+# with: wrangler dev --var QRZ_VERIFY:off
+[vars]
+QRZ_VERIFY = "on"
+
 # Chat room Durable Object (WebSocket Hibernation).
 [[durable_objects.bindings]]
 name = "CHAT_ROOM"

--- a/cloud/zeuschat-relay/wrangler.toml
+++ b/cloud/zeuschat-relay/wrangler.toml
@@ -2,6 +2,16 @@ name = "zeuschat-relay"
 main = "src/index.ts"
 compatibility_date = "2025-01-01"
 
+# Branded custom domain (Cloudflare auto-creates the DNS record on deploy).
+# Requires the openhpsdrzeus.com zone to live on this Cloudflare account.
+# chat.openhpsdrzeus.com is the canonical relay endpoint (Zeus default).
+routes = [
+  { pattern = "chat.openhpsdrzeus.com", custom_domain = true },
+]
+
+# Keep the *.workers.dev URL alive too, as a fallback endpoint.
+workers_dev = true
+
 # QRZ-login enforcement is on by default. For local `wrangler dev`, override
 # with: wrangler dev --var QRZ_VERIFY:off
 [vars]

--- a/cloud/zeuschat-relay/wrangler.toml
+++ b/cloud/zeuschat-relay/wrangler.toml
@@ -22,10 +22,20 @@ QRZ_VERIFY = "on"
 name = "CHAT_ROOM"
 class_name = "ChatRoom"
 
-# SQLite-backed DO namespace (free-plan compatible).
+# Per-IP connection rate limiter Durable Object (protects the QRZ-verify path
+# from connection-spam; 30 attempts / 60s / IP).
+[[durable_objects.bindings]]
+name = "RATE_DO"
+class_name = "RateLimiter"
+
+# SQLite-backed DO namespaces (free-plan compatible).
 [[migrations]]
 tag = "v1"
 new_sqlite_classes = ["ChatRoom"]
+
+[[migrations]]
+tag = "v2"
+new_sqlite_classes = ["RateLimiter"]
 
 # RELAY_SHARED_SECRET is NOT set here. Provide it out-of-band so it stays out
 # of source control:

--- a/cloud/zeuschat-relay/wrangler.toml
+++ b/cloud/zeuschat-relay/wrangler.toml
@@ -1,0 +1,18 @@
+name = "zeuschat-relay"
+main = "src/index.ts"
+compatibility_date = "2025-01-01"
+
+# Chat room Durable Object (WebSocket Hibernation).
+[[durable_objects.bindings]]
+name = "CHAT_ROOM"
+class_name = "ChatRoom"
+
+# SQLite-backed DO namespace (free-plan compatible).
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["ChatRoom"]
+
+# RELAY_SHARED_SECRET is NOT set here. Provide it out-of-band so it stays out
+# of source control:
+#   wrangler secret put RELAY_SHARED_SECRET
+# Leave unset for local `wrangler dev` (open, no auth).

--- a/tests/Zeus.Server.Tests/ChatServiceTests.cs
+++ b/tests/Zeus.Server.Tests/ChatServiceTests.cs
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+
+using System.Net.Http;
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+// Backend coverage for ZeusChat: the message ring-buffer cap, the presence
+// throttle, the relay-frame JSON (de)serialization (both the inbound relay
+// frames and the outbound 0x35 ChatEvent envelopes the frontend consumes), and
+// the connect gating (no relay activity when disabled or logged out). All
+// network + real QRZ is avoided — the QrzService under test is simply never
+// logged in, so GetChatIdentityAsync returns null without any HTTP call.
+public class ChatServiceTests : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(), "zeus-chat-" + Guid.NewGuid().ToString("N"));
+
+    public ChatServiceTests() => Directory.CreateDirectory(_root);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    // ── Message ring-buffer cap ────────────────────────────────────────────
+
+    [Fact]
+    public void Ring_KeepsOnlyMostRecent_WhenOverCap()
+    {
+        var ring = new ChatMessageRing(200);
+        for (int i = 0; i < 250; i++) ring.Add(Msg(i));
+
+        Assert.Equal(200, ring.Count);
+        var all = ring.Snapshot(0); // 0 = all
+        Assert.Equal(200, all.Count);
+        // Oldest 50 evicted; the buffer holds 50..249 in order.
+        Assert.Equal("m50", all[0].Id);
+        Assert.Equal("m249", all[^1].Id);
+    }
+
+    [Fact]
+    public void Ring_Snapshot_RespectsLimit_AndReturnsNewest()
+    {
+        var ring = new ChatMessageRing(200);
+        for (int i = 0; i < 10; i++) ring.Add(Msg(i));
+
+        var last3 = ring.Snapshot(3);
+        Assert.Equal(3, last3.Count);
+        Assert.Equal("m7", last3[0].Id);
+        Assert.Equal("m9", last3[^1].Id);
+    }
+
+    // ── Presence throttle ──────────────────────────────────────────────────
+
+    [Fact]
+    public void Throttle_SuppressesDuplicates_AndCoalescesWithinWindow()
+    {
+        var t = new PresenceThrottle(TimeSpan.FromSeconds(2));
+        var t0 = DateTimeOffset.UnixEpoch;
+
+        // No-op offer of the same value as a fresh (unseeded) throttle still
+        // counts as a change the first time.
+        Assert.True(t.Offer(14_000_000, "USB", "rx"));
+        // First take flushes immediately (lastSentAt = MinValue).
+        Assert.True(t.TryTake(t0, out var p1));
+        Assert.Equal(14_000_000, p1.FreqHz);
+
+        // Re-offering the identical presence is a no-op.
+        Assert.False(t.Offer(14_000_000, "USB", "rx"));
+
+        // A change within the window is recorded but held back until the
+        // window elapses.
+        Assert.True(t.Offer(14_001_000, "USB", "rx"));
+        Assert.False(t.TryTake(t0 + TimeSpan.FromSeconds(1), out _)); // 1s < 2s window
+        Assert.True(t.TryTake(t0 + TimeSpan.FromSeconds(2), out var p2));
+        Assert.Equal(14_001_000, p2.FreqHz);
+    }
+
+    [Fact]
+    public void Throttle_Seed_SuppressesEqualPresence_ButAllowsImmediateChange()
+    {
+        var t = new PresenceThrottle(TimeSpan.FromSeconds(2));
+        t.Seed(7_000_000, "LSB", "rx");
+
+        // Same as seeded → no change to wake on.
+        Assert.False(t.Offer(7_000_000, "LSB", "rx"));
+
+        // A genuine change after seeding flushes immediately (seed left
+        // lastSentAt at MinValue so the window has already elapsed).
+        Assert.True(t.Offer(7_000_000, "LSB", "tx"));
+        Assert.True(t.TryTake(DateTimeOffset.UnixEpoch, out var p));
+        Assert.Equal("tx", p.Status);
+    }
+
+    // ── Relay-frame parsing (inbound) ──────────────────────────────────────
+
+    [Fact]
+    public void ParseMessage_ReadsAllFields()
+    {
+        using var doc = JsonDocument.Parse(
+            """{"t":"msg","id":"abc","from":"N9WAR","text":"hi there","ts":1700000000000,"room":"lobby"}""");
+        var msg = ChatService.ParseMessage(doc.RootElement);
+
+        Assert.Equal("abc", msg.Id);
+        Assert.Equal("N9WAR", msg.From);
+        Assert.Equal("hi there", msg.Text);
+        Assert.Equal(1700000000000, msg.Ts);
+        Assert.Equal("lobby", msg.Room);
+    }
+
+    [Fact]
+    public void ParseMessage_ToleratesMissingFields()
+    {
+        using var doc = JsonDocument.Parse("""{"t":"msg","from":"EI6LF","text":"hello"}""");
+        var msg = ChatService.ParseMessage(doc.RootElement);
+
+        Assert.False(string.IsNullOrEmpty(msg.Id)); // synthesised
+        Assert.Equal("EI6LF", msg.From);
+        Assert.Equal("hello", msg.Text);
+        Assert.True(msg.Ts > 0); // synthesised
+        Assert.Equal("lobby", msg.Room); // defaulted
+    }
+
+    [Fact]
+    public void ParseRoster_ReadsOperators_AndUsesFreqAsHz()
+    {
+        using var doc = JsonDocument.Parse(
+            """{"t":"roster","roster":[{"callsign":"N9WAR","grid":"EL96","freq":14250000,"mode":"USB","status":"rx","since":1700000000000},{"callsign":"EI6LF","status":"tx","since":1700000001000}]}""");
+
+        var roster = ChatService.ParseRoster(doc.RootElement, "roster");
+        Assert.NotNull(roster);
+        Assert.Equal(2, roster!.Count);
+
+        Assert.Equal("N9WAR", roster[0].Callsign);
+        Assert.Equal("EL96", roster[0].Grid);
+        Assert.Equal(14250000, roster[0].FreqHz);
+        Assert.Equal("USB", roster[0].Mode);
+        Assert.Equal("rx", roster[0].Status);
+        Assert.Equal(1700000000000, roster[0].Since);
+
+        Assert.Equal("EI6LF", roster[1].Callsign);
+        Assert.Null(roster[1].Grid);
+        Assert.Null(roster[1].FreqHz);
+        Assert.Equal("tx", roster[1].Status);
+    }
+
+    [Fact]
+    public void ParseRoster_ReturnsNull_WhenPropertyMissingOrNotArray()
+    {
+        using var doc = JsonDocument.Parse("""{"t":"welcome"}""");
+        Assert.Null(ChatService.ParseRoster(doc.RootElement, "roster"));
+    }
+
+    // ── ChatEvent (0x35) envelope serialization (outbound, frontend wire) ───
+
+    [Fact]
+    public void ChatEvent_StatusEnvelope_IsCamelCaseWithKind()
+    {
+        var status = new ChatStatusDto(
+            Enabled: true, Connected: false, Callsign: "N9WAR",
+            RelayUrl: "wss://relay/chat", Error: null);
+
+        var frame = ChatEventFrame.Status(status);
+        Assert.Equal((byte)MsgType.ChatEvent, frame[0]);
+
+        using var doc = JsonDocument.Parse(ChatEventFrame.Payload(frame).ToArray());
+        var root = doc.RootElement;
+        Assert.Equal("status", root.GetProperty("kind").GetString());
+        var s = root.GetProperty("status");
+        Assert.True(s.GetProperty("enabled").GetBoolean());
+        Assert.False(s.GetProperty("connected").GetBoolean());
+        Assert.Equal("N9WAR", s.GetProperty("callsign").GetString());
+        Assert.Equal("wss://relay/chat", s.GetProperty("relayUrl").GetString());
+        // Null error is omitted (WhenWritingNull).
+        Assert.False(s.TryGetProperty("error", out _));
+    }
+
+    [Fact]
+    public void ChatEvent_MessageEnvelope_RoundTripsFields()
+    {
+        var msg = new ChatMessage("id1", "EI6LF", "hi", 1700000000000, "lobby");
+        var frame = ChatEventFrame.Message(msg);
+
+        using var doc = JsonDocument.Parse(ChatEventFrame.Payload(frame).ToArray());
+        var root = doc.RootElement;
+        Assert.Equal("message", root.GetProperty("kind").GetString());
+        var m = root.GetProperty("message");
+        Assert.Equal("id1", m.GetProperty("id").GetString());
+        Assert.Equal("EI6LF", m.GetProperty("from").GetString());
+        Assert.Equal("hi", m.GetProperty("text").GetString());
+        Assert.Equal(1700000000000, m.GetProperty("ts").GetInt64());
+        Assert.Equal("lobby", m.GetProperty("room").GetString());
+    }
+
+    [Fact]
+    public void ChatEvent_RosterAndHistoryEnvelopes_UseCamelCaseArrays()
+    {
+        var op = new ChatOperator("N9WAR", "EL96", 14_250_000, "USB", "rx", 1700000000000);
+        var rosterFrame = ChatEventFrame.Roster(new[] { op });
+        using (var doc = JsonDocument.Parse(ChatEventFrame.Payload(rosterFrame).ToArray()))
+        {
+            var root = doc.RootElement;
+            Assert.Equal("roster", root.GetProperty("kind").GetString());
+            var first = root.GetProperty("roster")[0];
+            Assert.Equal("N9WAR", first.GetProperty("callsign").GetString());
+            Assert.Equal(14_250_000, first.GetProperty("freqHz").GetInt64());
+        }
+
+        var msg = new ChatMessage("id1", "EI6LF", "hi", 1700000000000, "lobby");
+        var historyFrame = ChatEventFrame.History(new[] { msg });
+        using (var doc = JsonDocument.Parse(ChatEventFrame.Payload(historyFrame).ToArray()))
+        {
+            var root = doc.RootElement;
+            Assert.Equal("history", root.GetProperty("kind").GetString());
+            Assert.Equal("id1", root.GetProperty("messages")[0].GetProperty("id").GetString());
+        }
+    }
+
+    [Fact]
+    public void ChatEventPayload_Throws_OnWrongPrefix()
+    {
+        Assert.Throws<InvalidDataException>(() => ChatEventFrame.Payload(new byte[] { 0x00, 0x01 }));
+    }
+
+    // ── Gating: no relay activity when disabled or logged out ──────────────
+
+    [Fact]
+    public async Task Disabled_ByDefault_AndNotConnected_NoSendPossible()
+    {
+        using var chat = BuildChat();
+
+        var status = chat.GetStatus();
+        Assert.False(status.Enabled);   // opt-in default OFF
+        Assert.False(status.Connected); // worker never ran a connection
+        Assert.Equal(ChatService.DefaultRelayUrl, status.RelayUrl);
+
+        // Send must fail with 409-mapped exception when not connected.
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => chat.SendMessageAsync("hello", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Enable_WhenLoggedOut_PersistsOptIn_ButCannotSend()
+    {
+        using var store = NewEnabledStore();
+        using var chat = BuildChat(store);
+
+        var status = chat.SetEnabled(true);
+        Assert.True(status.Enabled);
+        Assert.False(status.Connected); // QRZ logged out → no relay connection
+
+        // Persisted across a fresh store instance.
+        Assert.True(store.GetEnabled());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => chat.SendMessageAsync("hi", CancellationToken.None));
+
+        chat.SetEnabled(false);
+        Assert.False(store.GetEnabled());
+    }
+
+    [Fact]
+    public async Task EmptySend_Throws_ArgumentException()
+    {
+        using var chat = BuildChat();
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => chat.SendMessageAsync("   ", CancellationToken.None));
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────
+
+    private static ChatMessage Msg(int i) =>
+        new($"m{i}", "N9WAR", $"text {i}", 1700000000000 + i, "lobby");
+
+    private ChatEnabledStore NewEnabledStore() =>
+        new(NullLogger<ChatEnabledStore>.Instance, Path.Combine(_root, "chat.db"));
+
+    private QrzService NewLoggedOutQrz() =>
+        new(new SingleClientFactory(), NullLogger<QrzService>.Instance,
+            new CredentialStore(NullLogger<CredentialStore>.Instance, _root));
+
+    private RadioService NewRadio() =>
+        new(NullLoggerFactory.Instance,
+            new DspSettingsStore(NullLogger<DspSettingsStore>.Instance, Path.Combine(_root, "dsp.db")),
+            new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, Path.Combine(_root, "pa.db")));
+
+    private ChatService BuildChat(ChatEnabledStore? store = null) =>
+        new(NewLoggedOutQrz(), NewRadio(),
+            new StreamingHub(NullLogger<StreamingHub>.Instance),
+            store ?? NewEnabledStore(),
+            NullLogger<ChatService>.Instance);
+
+    // Minimal IHttpClientFactory so QrzService constructs without DI. It is
+    // never exercised — the QRZ service is never logged in, so no HTTP flows.
+    private sealed class SingleClientFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new();
+    }
+}

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -80,7 +80,7 @@ import { TunButton } from './components/TunButton';
 import { BOARD_LABELS } from './api/radio';
 import { useFilterRibbonOpenSync } from './components/filter/filterRibbonShared';
 import { CONTACTS, bandOf } from './components/design/data';
-import { bearingDeg, distanceKm, dayNightAt } from './components/design/geo';
+import { bearingDeg, distanceKm } from './components/design/geo';
 import { startRealtime } from './realtime/ws-client';
 import { getServerBaseUrl, isCapacitorRuntime } from './serverUrl';
 import { getAudioClient } from './audio/audio-client';
@@ -103,8 +103,8 @@ import { registerServiceWorker } from './service-worker/registerSW';
 import { UpdatePrompt } from './service-worker/UpdatePrompt';
 import { useDesktopViewportLock, useIsMobileViewport } from './mobile/use-mobile-viewport';
 import type L from 'leaflet';
-import type { QrzStation } from './api/qrz';
 import type { Contact } from './components/design/data';
+import { qrzStationToContact } from './components/design/qrz-contact';
 
 const SettingsView = lazy(async () => {
   const module = await import('./components/SettingsMenu');
@@ -1030,93 +1030,3 @@ export default function App() {
   );
 }
 
-// QRZ XML gives us a sparser record than the design-time Contact type; fill
-// the design-only fields ("local", "rig", "ant", "age"…) with em-dashes so
-// QrzCard still renders without needing a schema change.
-/** "2008-05-12" → 2008. Returns null for empty/unparseable values. */
-function licenseYear(efdate: string | null): number | null {
-  if (!efdate) return null;
-  const m = /(\d{4})/.exec(efdate);
-  if (!m) return null;
-  const y = Number(m[1]);
-  return y >= 1900 && y <= 2100 ? y : null;
-}
-
-/** Contact's wall-clock time from the QRZ GMT offset, e.g. "03:14". */
-function localTimeFromOffset(gmtOffset: number | null, tz: string | null): string {
-  if (gmtOffset == null) return '—';
-  const utcMs = Date.now() + new Date().getTimezoneOffset() * 60_000;
-  const d = new Date(utcMs + gmtOffset * 3_600_000);
-  const hh = String(d.getHours()).padStart(2, '0');
-  const mm = String(d.getMinutes()).padStart(2, '0');
-  return tz ? `${hh}:${mm} ${tz}` : `${hh}:${mm}`;
-}
-
-/** "LoTW · eQSL · Direct" summary, or "—" when nothing is known. */
-function qslSummary(s: QrzStation): string {
-  const parts: string[] = [];
-  if (s.acceptsLotw) parts.push('LoTW');
-  if (s.acceptsEqsl) parts.push('eQSL');
-  if (s.acceptsMailQsl) parts.push('Direct');
-  if (s.qslManager) parts.push(`via ${s.qslManager}`);
-  return parts.length ? parts.join(' · ') : '—';
-}
-
-function qrzStationToContact(s: QrzStation | null, home: QrzStation | null): Contact | null {
-  if (!s || s.lat == null || s.lon == null) return null;
-  const bearing = home?.lat != null && home?.lon != null
-    ? bearingDeg(home.lat, home.lon, s.lat, s.lon)
-    : 0;
-  const distance = home?.lat != null && home?.lon != null
-    ? distanceKm(home.lat, home.lon, s.lat, s.lon)
-    : 0;
-  const first = (s.firstName || s.name || '').trim().charAt(0).toUpperCase();
-  const last = (s.name || '').trim().split(/\s+/).pop()?.charAt(0).toUpperCase() ?? '';
-  const initials = (first + last) || s.callsign.slice(0, 2);
-  const location = [s.city, s.state, s.country].filter(Boolean).join(', ') || (s.country ?? '—');
-  const fullName = [s.firstName, s.name].filter(Boolean).join(' ') || '—';
-
-  const licYear = licenseYear(s.licenseEffectiveDate);
-  const licensedYears = licYear != null ? new Date().getFullYear() - licYear : null;
-  const distanceMi = distance * 0.621371;
-  const distanceLabel = distance > 0
-    ? `${Math.round(distance).toLocaleString()} km · ${Math.round(distanceMi).toLocaleString()} mi`
-    : null;
-
-  return {
-    callsign: s.callsign,
-    name: fullName,
-    location,
-    grid: s.grid ?? '—',
-    cq: s.cqZone != null ? String(s.cqZone).padStart(2, '0') : '—',
-    itu: s.ituZone != null ? String(s.ituZone).padStart(2, '0') : '—',
-    latlon: `${Math.abs(s.lat).toFixed(2)}°${s.lat >= 0 ? 'N' : 'S'} / ${Math.abs(s.lon).toFixed(2)}°${s.lon >= 0 ? 'E' : 'W'}`,
-    lat: s.lat,
-    lon: s.lon,
-    local: localTimeFromOffset(s.gmtOffset, s.timeZone),
-    qsl: qslSummary(s),
-    licensed: licYear != null ? String(licYear) : '—',
-    initials,
-    flag: '',
-    bearing,
-    distance,
-    age: 0,
-    class: s.licenseClass ?? '—',
-    rig: '—',
-    ant: '—',
-    power: '—',
-    qth: s.city ?? s.country ?? '—',
-    email: s.email ?? '—',
-    photoUrl: s.imageUrl ?? undefined,
-    qrzUrl: `https://www.qrz.com/db/${s.callsign}`,
-    // Enrichment
-    licenseCodes: s.licenseCodes,
-    licensedYears,
-    qslLotw: s.acceptsLotw,
-    qslEqsl: s.acceptsEqsl,
-    qslMail: s.acceptsMailQsl,
-    qslManager: s.qslManager,
-    dayNight: dayNightAt(s.lat, s.lon),
-    distanceLabel,
-  };
-}

--- a/zeus-web/src/api/chat.ts
+++ b/zeus-web/src/api/chat.ts
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+// Operator-to-operator chat REST surface. Live push frames arrive over the
+// existing WS (type byte 0x35, see realtime/ws-client.ts); these endpoints
+// cover status, enable/disable, send, and the initial history/roster hydrate.
+
+import { ApiError } from './client';
+
+export type ChatOperatorStatus = 'rx' | 'tx' | 'away';
+
+export type ChatOperator = {
+  callsign: string;
+  grid: string | null;
+  freqHz: number | null;
+  mode: string | null;
+  status: ChatOperatorStatus | null;
+  /** Epoch ms — when this operator joined / was last seen. */
+  since: number;
+};
+
+export type ChatMessage = {
+  id: string;
+  from: string;
+  text: string;
+  /** Epoch ms. */
+  ts: number;
+  room: string;
+};
+
+export type ChatStatus = {
+  enabled: boolean;
+  connected: boolean;
+  callsign: string | null;
+  relayUrl: string | null;
+  error: string | null;
+};
+
+function toStr(v: unknown): string | null {
+  return typeof v === 'string' && v.length > 0 ? v : null;
+}
+
+function toNum(v: unknown): number | null {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+
+function toStatus(v: unknown): ChatOperatorStatus | null {
+  return v === 'rx' || v === 'tx' || v === 'away' ? v : null;
+}
+
+export function normalizeStatus(raw: unknown): ChatStatus {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  return {
+    enabled: Boolean(r.enabled),
+    connected: Boolean(r.connected),
+    callsign: toStr(r.callsign),
+    relayUrl: toStr(r.relayUrl),
+    error: toStr(r.error),
+  };
+}
+
+export function normalizeOperator(raw: unknown): ChatOperator {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  return {
+    callsign: typeof r.callsign === 'string' ? r.callsign : '',
+    grid: toStr(r.grid),
+    freqHz: toNum(r.freqHz),
+    mode: toStr(r.mode),
+    status: toStatus(r.status),
+    since: toNum(r.since) ?? 0,
+  };
+}
+
+export function normalizeMessage(raw: unknown): ChatMessage {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  return {
+    id: typeof r.id === 'string' ? r.id : '',
+    from: typeof r.from === 'string' ? r.from : '',
+    text: typeof r.text === 'string' ? r.text : '',
+    ts: toNum(r.ts) ?? 0,
+    room: typeof r.room === 'string' ? r.room : '',
+  };
+}
+
+async function jsonFetch<T>(
+  input: RequestInfo,
+  init: RequestInit | undefined,
+  parse: (raw: unknown) => T,
+): Promise<T> {
+  const res = await fetch(input, init);
+  if (!res.ok) {
+    let message = `${res.status} ${res.statusText}`;
+    try {
+      const body = (await res.json()) as unknown;
+      if (
+        body &&
+        typeof body === 'object' &&
+        'error' in body &&
+        typeof (body as { error: unknown }).error === 'string'
+      ) {
+        message = (body as { error: string }).error;
+      }
+    } catch {
+      /* non-JSON body — keep status text */
+    }
+    throw new ApiError(res.status, message);
+  }
+  return parse((await res.json()) as unknown);
+}
+
+export function chatStatus(signal?: AbortSignal): Promise<ChatStatus> {
+  return jsonFetch('/api/chat/status', { signal }, normalizeStatus);
+}
+
+export function chatSetEnabled(enabled: boolean, signal?: AbortSignal): Promise<ChatStatus> {
+  return jsonFetch(
+    '/api/chat/enable',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ enabled }),
+      signal,
+    },
+    normalizeStatus,
+  );
+}
+
+export function chatSend(text: string, signal?: AbortSignal): Promise<{ ok: boolean }> {
+  return jsonFetch(
+    '/api/chat/send',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ text }),
+      signal,
+    },
+    (raw) => ({ ok: Boolean((raw as { ok?: unknown } | null)?.ok) }),
+  );
+}
+
+export function chatMessages(limit: number, signal?: AbortSignal): Promise<ChatMessage[]> {
+  return jsonFetch(
+    `/api/chat/messages?limit=${encodeURIComponent(limit)}`,
+    { signal },
+    (raw) => {
+      const arr = (raw as { messages?: unknown } | null)?.messages;
+      return Array.isArray(arr) ? arr.map(normalizeMessage) : [];
+    },
+  );
+}
+
+export function chatRoster(signal?: AbortSignal): Promise<ChatOperator[]> {
+  return jsonFetch('/api/chat/roster', { signal }, (raw) => {
+    const arr = (raw as { operators?: unknown } | null)?.operators;
+    return Array.isArray(arr) ? arr.map(normalizeOperator) : [];
+  });
+}

--- a/zeus-web/src/components/design/qrz-contact.ts
+++ b/zeus-web/src/components/design/qrz-contact.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+// QRZ XML gives us a sparser record than the design-time Contact type; fill
+// in the gaps so QrzCard renders the same whether the source is a panel
+// lookup (App) or a click-through from the operator chat roster.
+
+import type { QrzStation } from '../../api/qrz';
+import type { Contact } from './data';
+import { bearingDeg, distanceKm, dayNightAt } from './geo';
+
+function licenseYear(efdate: string | null): number | null {
+  if (!efdate) return null;
+  const m = /(\d{4})/.exec(efdate);
+  if (!m) return null;
+  const y = Number(m[1]);
+  return y >= 1900 && y <= 2100 ? y : null;
+}
+
+/** Contact's wall-clock time from the QRZ GMT offset, e.g. "03:14". */
+function localTimeFromOffset(gmtOffset: number | null, tz: string | null): string {
+  if (gmtOffset == null) return '—';
+  const utcMs = Date.now() + new Date().getTimezoneOffset() * 60_000;
+  const d = new Date(utcMs + gmtOffset * 3_600_000);
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  return tz ? `${hh}:${mm} ${tz}` : `${hh}:${mm}`;
+}
+
+/** "LoTW · eQSL · Direct" summary, or "—" when nothing is known. */
+function qslSummary(s: QrzStation): string {
+  const parts: string[] = [];
+  if (s.acceptsLotw) parts.push('LoTW');
+  if (s.acceptsEqsl) parts.push('eQSL');
+  if (s.acceptsMailQsl) parts.push('Direct');
+  if (s.qslManager) parts.push(`via ${s.qslManager}`);
+  return parts.length ? parts.join(' · ') : '—';
+}
+
+export function qrzStationToContact(s: QrzStation | null, home: QrzStation | null): Contact | null {
+  if (!s || s.lat == null || s.lon == null) return null;
+  const bearing = home?.lat != null && home?.lon != null
+    ? bearingDeg(home.lat, home.lon, s.lat, s.lon)
+    : 0;
+  const distance = home?.lat != null && home?.lon != null
+    ? distanceKm(home.lat, home.lon, s.lat, s.lon)
+    : 0;
+  const first = (s.firstName || s.name || '').trim().charAt(0).toUpperCase();
+  const last = (s.name || '').trim().split(/\s+/).pop()?.charAt(0).toUpperCase() ?? '';
+  const initials = (first + last) || s.callsign.slice(0, 2);
+  const location = [s.city, s.state, s.country].filter(Boolean).join(', ') || (s.country ?? '—');
+  const fullName = [s.firstName, s.name].filter(Boolean).join(' ') || '—';
+
+  const licYear = licenseYear(s.licenseEffectiveDate);
+  const licensedYears = licYear != null ? new Date().getFullYear() - licYear : null;
+  const distanceMi = distance * 0.621371;
+  const distanceLabel = distance > 0
+    ? `${Math.round(distance).toLocaleString()} km · ${Math.round(distanceMi).toLocaleString()} mi`
+    : null;
+
+  return {
+    callsign: s.callsign,
+    name: fullName,
+    location,
+    grid: s.grid ?? '—',
+    cq: s.cqZone != null ? String(s.cqZone).padStart(2, '0') : '—',
+    itu: s.ituZone != null ? String(s.ituZone).padStart(2, '0') : '—',
+    latlon: `${Math.abs(s.lat).toFixed(2)}°${s.lat >= 0 ? 'N' : 'S'} / ${Math.abs(s.lon).toFixed(2)}°${s.lon >= 0 ? 'E' : 'W'}`,
+    lat: s.lat,
+    lon: s.lon,
+    local: localTimeFromOffset(s.gmtOffset, s.timeZone),
+    qsl: qslSummary(s),
+    licensed: licYear != null ? String(licYear) : '—',
+    initials,
+    flag: '',
+    bearing,
+    distance,
+    age: 0,
+    class: s.licenseClass ?? '—',
+    rig: '—',
+    ant: '—',
+    power: '—',
+    qth: s.city ?? s.country ?? '—',
+    email: s.email ?? '—',
+    photoUrl: s.imageUrl ?? undefined,
+    qrzUrl: `https://www.qrz.com/db/${s.callsign}`,
+    // Enrichment
+    licenseCodes: s.licenseCodes,
+    licensedYears,
+    qslLotw: s.acceptsLotw,
+    qslEqsl: s.acceptsEqsl,
+    qslMail: s.acceptsMailQsl,
+    qslManager: s.qslManager,
+    dayNight: dayNightAt(s.lat, s.lon),
+    distanceLabel,
+  };
+}

--- a/zeus-web/src/layout/panels.ts
+++ b/zeus-web/src/layout/panels.ts
@@ -70,6 +70,7 @@ import { HamClockPanel } from './panels/HamClockPanel';
 import { SpotsPanel } from './panels/SpotsPanel';
 import { SpaceWeatherPanel } from './panels/SpaceWeatherPanel';
 import { UrlEmbedPanel } from './panels/UrlEmbedPanel';
+import { ChatPanel } from './panels/ChatPanel';
 
 export type PanelCategory =
   | 'spectrum'
@@ -407,6 +408,15 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'tools',
     tags: ['spots', 'pota', 'sota', 'activation', 'dx', 'cluster', 'tune', 'park', 'summit'],
     component: SpotsPanel,
+    minW: 6,
+    minH: 8,
+  },
+  chat: {
+    id: 'chat',
+    name: 'Chat',
+    category: 'tools',
+    tags: ['chat', 'message', 'operator', 'qrz', 'dx'],
+    component: ChatPanel,
     minW: 6,
     minH: 8,
   },

--- a/zeus-web/src/layout/panels/ChatPanel.tsx
+++ b/zeus-web/src/layout/panels/ChatPanel.tsx
@@ -522,6 +522,24 @@ export function ChatPanel() {
       </div>
 
       {/* Call-to-action banners */}
+      {!enabled ? (
+        <div
+          style={{
+            padding: '6px 10px',
+            borderBottom: '1px solid var(--panel-border)',
+            background: 'var(--bg-2)',
+            fontSize: 11.5,
+            color: 'var(--fg-2)',
+            lineHeight: 1.4,
+          }}
+        >
+          Enabling chat connects you to the public operator relay and{' '}
+          <strong style={{ color: 'var(--fg-1)' }}>
+            broadcasts your callsign and live VFO frequency
+          </strong>{' '}
+          to other logged-in operators.
+        </div>
+      ) : null}
       {enabled && !qrzConnected ? (
         <div
           style={{

--- a/zeus-web/src/layout/panels/ChatPanel.tsx
+++ b/zeus-web/src/layout/panels/ChatPanel.tsx
@@ -1,0 +1,651 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// ChatPanel — operator-to-operator chat tile. A roster of online operators
+// (live frequency + mode + rx/tx/away status), a scrollable message thread,
+// and a send box. Hydrated on mount via chat-store REST calls and kept live
+// by the 0x35 push frames decoded in realtime/ws-client.ts. Clicking any
+// callsign (roster or message) opens that operator's QRZ profile in an
+// overlay, reusing the QrzCard component and the qrz-store lookup cache so we
+// don't re-implement the profile card or burn QRZ quota.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useChatStore, type ChatMessage, type ChatOperator } from '../../state/chat-store';
+import { useQrzStore } from '../../state/qrz-store';
+import { QrzCard } from '../../components/design/QrzCard';
+import { qrzStationToContact } from '../../components/design/qrz-contact';
+import type { Contact } from '../../components/design/data';
+import type { QrzStation } from '../../api/qrz';
+
+const MAX_MESSAGE_CHARS = 2000;
+const CHAR_WARN_THRESHOLD = 1800;
+
+/** Hz → MHz with the operator-friendly "14.074.00" grouping. */
+function fmtFreqMhz(hz: number | null | undefined): string {
+  if (typeof hz !== 'number' || !Number.isFinite(hz) || hz <= 0) return '—';
+  const mhz = hz / 1_000_000;
+  // e.g. 14074000 → "14.074.00": MHz . kHz(3) . hHz(2)
+  const whole = Math.floor(mhz);
+  const frac = Math.round((mhz - whole) * 100_000); // 5 fractional digits
+  const khz = String(Math.floor(frac / 100)).padStart(3, '0');
+  const hhz = String(frac % 100).padStart(2, '0');
+  return `${whole}.${khz}.${hhz}`;
+}
+
+/** Clock time (HH:MM) from epoch ms, in the operator's local zone. */
+function fmtClock(ts: number): string {
+  if (!Number.isFinite(ts) || ts <= 0) return '';
+  return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+}
+
+/** Short relative age, e.g. "now", "3m", "2h", or a date for older stamps. */
+function fmtRelative(ts: number): string {
+  if (!Number.isFinite(ts) || ts <= 0) return '';
+  const deltaMs = Date.now() - ts;
+  const sec = Math.floor(deltaMs / 1000);
+  if (sec < 45) return 'now';
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h`;
+  const day = Math.floor(hr / 24);
+  if (day < 7) return `${day}d`;
+  return new Date(ts).toLocaleDateString([], { month: 'short', day: 'numeric' });
+}
+
+const STATUS_META: Record<string, { color: string; label: string }> = {
+  rx: { color: 'var(--ok)', label: 'Receiving' },
+  tx: { color: 'var(--tx)', label: 'Transmitting' },
+  away: { color: 'var(--fg-3)', label: 'Away' },
+};
+
+function StatusDot({ status }: { status: ChatOperator['status'] }) {
+  const meta = (status && STATUS_META[status]) || { color: 'var(--fg-4)', label: 'Unknown' };
+  return (
+    <span
+      title={meta.label}
+      aria-label={meta.label}
+      style={{
+        display: 'inline-block',
+        width: 8,
+        height: 8,
+        borderRadius: '50%',
+        background: meta.color,
+        boxShadow: status === 'tx' ? '0 0 6px var(--tx)' : 'none',
+        flexShrink: 0,
+      }}
+    />
+  );
+}
+
+/** A callsign that opens the QRZ profile overlay when clicked. */
+function CallsignButton({
+  callsign,
+  onOpen,
+  prominent,
+  own,
+}: {
+  callsign: string;
+  onOpen: (callsign: string) => void;
+  prominent?: boolean;
+  own?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      className="mono"
+      onClick={() => onOpen(callsign)}
+      title={`Open ${callsign} on QRZ`}
+      style={{
+        background: 'none',
+        border: 'none',
+        padding: 0,
+        cursor: 'pointer',
+        font: 'inherit',
+        fontWeight: prominent ? 700 : 600,
+        fontSize: prominent ? 13 : 12,
+        letterSpacing: '0.04em',
+        color: own ? 'var(--accent-bright)' : 'var(--fg-0)',
+        textAlign: 'left',
+      }}
+      onMouseEnter={(e) => (e.currentTarget.style.textDecoration = 'underline')}
+      onMouseLeave={(e) => (e.currentTarget.style.textDecoration = 'none')}
+    >
+      {callsign}
+    </button>
+  );
+}
+
+function RosterRow({
+  op,
+  onOpen,
+}: {
+  op: ChatOperator;
+  onOpen: (callsign: string) => void;
+}) {
+  const tip = [
+    STATUS_META[op.status ?? '']?.label,
+    op.grid ? `Grid ${op.grid}` : null,
+    op.mode ?? null,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+  return (
+    <div
+      title={tip || undefined}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        padding: '5px 8px',
+        borderRadius: 'var(--r-sm)',
+        transition: 'background var(--dur-fast) var(--ease-out)',
+      }}
+      onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--bg-3)')}
+      onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+    >
+      <StatusDot status={op.status} />
+      <div style={{ display: 'flex', flexDirection: 'column', minWidth: 0, flex: 1 }}>
+        <CallsignButton callsign={op.callsign} onOpen={onOpen} prominent />
+        <div
+          className="mono"
+          style={{
+            display: 'flex',
+            gap: 6,
+            alignItems: 'baseline',
+            fontSize: 10.5,
+            color: 'var(--fg-2)',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          <span style={{ color: 'var(--power)' }}>{fmtFreqMhz(op.freqHz)}</span>
+          {op.mode ? <span style={{ color: 'var(--fg-2)' }}>{op.mode}</span> : null}
+          {op.grid ? <span style={{ color: 'var(--fg-3)' }}>{op.grid}</span> : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MessageRow({
+  msg,
+  own,
+  onOpen,
+}: {
+  msg: ChatMessage;
+  own: boolean;
+  onOpen: (callsign: string) => void;
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: own ? 'flex-end' : 'flex-start',
+        gap: 2,
+        padding: '0 10px',
+      }}
+    >
+      <div style={{ display: 'flex', gap: 6, alignItems: 'baseline' }}>
+        <CallsignButton callsign={msg.from} onOpen={onOpen} own={own} />
+        <span className="mono" title={fmtClock(msg.ts)} style={{ fontSize: 10, color: 'var(--fg-3)' }}>
+          {fmtRelative(msg.ts)}
+        </span>
+      </div>
+      <div
+        style={{
+          maxWidth: '85%',
+          padding: '6px 10px',
+          borderRadius: 'var(--r-lg)',
+          background: own ? 'var(--accent-soft)' : 'var(--bg-2)',
+          border: own ? '1px solid var(--accent-line)' : '1px solid var(--line)',
+          color: 'var(--fg-1)',
+          fontSize: 12.5,
+          lineHeight: 1.45,
+          wordBreak: 'break-word',
+          whiteSpace: 'pre-wrap',
+        }}
+      >
+        {msg.text}
+      </div>
+    </div>
+  );
+}
+
+function ProfileOverlay({
+  callsign,
+  onClose,
+}: {
+  callsign: string;
+  onClose: () => void;
+}) {
+  const lookupCached = useQrzStore((s) => s.lookupCached);
+  const qrzConnected = useQrzStore((s) => s.connected);
+  const qrzHome = useQrzStore((s) => s.home);
+  const [station, setStation] = useState<QrzStation | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    setLoading(true);
+    setError(null);
+    void lookupCached(callsign)
+      .then((s) => {
+        if (!live) return;
+        if (s) setStation(s);
+        else setError(qrzConnected ? 'No QRZ record' : 'Log into QRZ to view profiles');
+      })
+      .finally(() => {
+        if (live) setLoading(false);
+      });
+    return () => {
+      live = false;
+    };
+  }, [callsign, lookupCached, qrzConnected]);
+
+  const contact: Contact | null = useMemo(
+    () => qrzStationToContact(station, qrzHome),
+    [station, qrzHome],
+  );
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'absolute',
+        inset: 0,
+        background: 'rgba(0,0,0,0.55)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 30,
+        padding: 16,
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: 'var(--panel-top)',
+          border: '1px solid var(--panel-border)',
+          borderRadius: 'var(--r-lg)',
+          boxShadow: '0 12px 40px rgba(0,0,0,0.6)',
+          width: 340,
+          maxWidth: '100%',
+          maxHeight: '90%',
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: '6px 10px',
+            borderBottom: '1px solid var(--panel-border)',
+          }}
+        >
+          <span
+            className="mono"
+            style={{ fontWeight: 700, letterSpacing: '0.06em', color: 'var(--fg-0)' }}
+          >
+            {callsign}
+          </span>
+          <button type="button" className="btn sm" onClick={onClose} title="Close">
+            ✕
+          </button>
+        </div>
+        <div style={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
+          <QrzCard
+            contact={contact}
+            enriching={loading}
+            lookupError={!loading && !contact ? (error ?? 'No QRZ record') : null}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ChatPanel() {
+  const enabled = useChatStore((s) => s.enabled);
+  const connected = useChatStore((s) => s.connected);
+  const ownCall = useChatStore((s) => s.callsign);
+  const relayError = useChatStore((s) => s.relayError);
+  const roster = useChatStore((s) => s.roster);
+  const messages = useChatStore((s) => s.messages);
+  const refreshStatus = useChatStore((s) => s.refreshStatus);
+  const setEnabled = useChatStore((s) => s.setEnabled);
+  const send = useChatStore((s) => s.send);
+  const loadHistory = useChatStore((s) => s.loadHistory);
+  const loadRoster = useChatStore((s) => s.loadRoster);
+
+  const qrzConnected = useQrzStore((s) => s.connected);
+
+  const [draft, setDraft] = useState('');
+  const [profileCall, setProfileCall] = useState<string | null>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  // Hydrate on mount; live 0x35 frames keep us current afterwards.
+  useEffect(() => {
+    void refreshStatus();
+    void loadHistory();
+    void loadRoster();
+  }, [refreshStatus, loadHistory, loadRoster]);
+
+  // Auto-scroll to newest message when the thread grows.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages.length]);
+
+  const openProfile = useCallback((callsign: string) => {
+    setProfileCall(callsign.trim().toUpperCase());
+  }, []);
+
+  const sortedRoster = useMemo(() => {
+    const rank: Record<string, number> = { tx: 0, rx: 1, away: 2 };
+    return [...roster].sort((a, b) => {
+      const ra = rank[a.status ?? ''] ?? 3;
+      const rb = rank[b.status ?? ''] ?? 3;
+      if (ra !== rb) return ra - rb;
+      return a.callsign.localeCompare(b.callsign);
+    });
+  }, [roster]);
+
+  const canSend = enabled && connected && draft.trim().length > 0 && draft.length <= MAX_MESSAGE_CHARS;
+
+  const doSend = useCallback(async () => {
+    const text = draft.trim();
+    if (!text || !connected || text.length > MAX_MESSAGE_CHARS) return;
+    setDraft('');
+    const ok = await send(text);
+    if (!ok) setDraft(text); // restore on failure so the operator can retry
+  }, [draft, connected, send]);
+
+  const statusPill = (() => {
+    if (!enabled) return { color: 'var(--fg-3)', bg: 'var(--bg-2)', label: 'Disabled' };
+    if (connected) return { color: 'var(--ok)', bg: 'var(--ok-soft)', label: 'Connected' };
+    return { color: 'var(--power)', bg: 'var(--power-soft)', label: 'Connecting…' };
+  })();
+
+  const remaining = MAX_MESSAGE_CHARS - draft.length;
+  const counterColor =
+    draft.length > MAX_MESSAGE_CHARS
+      ? 'var(--tx)'
+      : draft.length >= CHAR_WARN_THRESHOLD
+        ? 'var(--power)'
+        : 'var(--fg-3)';
+
+  return (
+    <div
+      style={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+        position: 'relative',
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          padding: '6px 10px',
+          borderBottom: '1px solid var(--panel-border)',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          flexWrap: 'wrap',
+        }}
+      >
+        <span
+          style={{
+            fontSize: 13,
+            fontWeight: 700,
+            letterSpacing: '0.14em',
+            textTransform: 'uppercase',
+            color: 'var(--fg-1)',
+          }}
+        >
+          Chat
+        </span>
+        <span
+          title={relayError ?? statusPill.label}
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 5,
+            padding: '2px 8px',
+            borderRadius: 'var(--r-lg)',
+            background: statusPill.bg,
+            color: statusPill.color,
+            fontSize: 10.5,
+            fontWeight: 600,
+            letterSpacing: '0.04em',
+          }}
+        >
+          <span
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: '50%',
+              background: statusPill.color,
+            }}
+          />
+          {statusPill.label}
+        </span>
+        {ownCall ? (
+          <span className="mono" style={{ fontSize: 11, color: 'var(--fg-2)' }}>
+            {ownCall}
+          </span>
+        ) : null}
+        <div style={{ flex: 1 }} />
+        {!enabled ? (
+          <button
+            type="button"
+            className="btn sm active"
+            onClick={() => void setEnabled(true)}
+            title="Connect to the operator chat relay"
+          >
+            Enable
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="btn sm"
+            onClick={() => void setEnabled(false)}
+            title="Disconnect from the operator chat relay"
+          >
+            Disable
+          </button>
+        )}
+      </div>
+
+      {/* Call-to-action banners */}
+      {enabled && !qrzConnected ? (
+        <div
+          style={{
+            padding: '6px 10px',
+            borderBottom: '1px solid var(--panel-border)',
+            background: 'var(--bg-2)',
+            fontSize: 11.5,
+            color: 'var(--fg-2)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+          }}
+        >
+          <span>Log into QRZ to chat and view operator profiles.</span>
+          <span style={{ color: 'var(--fg-3)' }}>(Settings → QRZ)</span>
+        </div>
+      ) : null}
+      {relayError ? (
+        <div
+          style={{
+            padding: '6px 10px',
+            borderBottom: '1px solid var(--panel-border)',
+            background: 'var(--tx-soft)',
+            fontSize: 11.5,
+            color: 'var(--tx)',
+          }}
+        >
+          {relayError}
+        </div>
+      ) : null}
+
+      {/* Body: roster column + message thread */}
+      <div style={{ flex: 1, display: 'flex', minHeight: 0, overflow: 'hidden' }}>
+        {/* Roster */}
+        <div
+          style={{
+            width: 150,
+            flexShrink: 0,
+            borderRight: '1px solid var(--panel-border)',
+            display: 'flex',
+            flexDirection: 'column',
+            minHeight: 0,
+          }}
+        >
+          <div
+            style={{
+              padding: '5px 8px 3px',
+              fontSize: 10,
+              fontWeight: 700,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color: 'var(--fg-3)',
+            }}
+          >
+            Online · {sortedRoster.length}
+          </div>
+          <div style={{ flex: 1, overflow: 'auto', minHeight: 0, padding: '0 4px 6px' }}>
+            {sortedRoster.length === 0 ? (
+              <div style={{ padding: '10px 8px', fontSize: 11, color: 'var(--fg-3)' }}>
+                No one here yet
+              </div>
+            ) : (
+              sortedRoster.map((op) => (
+                <RosterRow key={op.callsign} op={op} onOpen={openProfile} />
+              ))
+            )}
+          </div>
+        </div>
+
+        {/* Thread */}
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+          <div
+            ref={scrollRef}
+            style={{
+              flex: 1,
+              overflow: 'auto',
+              minHeight: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 8,
+              padding: '10px 0',
+            }}
+          >
+            {messages.length === 0 ? (
+              <div
+                style={{
+                  margin: 'auto',
+                  fontSize: 12,
+                  color: 'var(--fg-3)',
+                  textAlign: 'center',
+                  padding: 16,
+                }}
+              >
+                {enabled ? 'No messages' : 'Chat is disabled — enable it to join the conversation.'}
+              </div>
+            ) : (
+              messages.map((m) => {
+                const own = !!ownCall && m.from.toUpperCase() === ownCall.toUpperCase();
+                return <MessageRow key={m.id || `${m.from}-${m.ts}`} msg={m} own={own} onOpen={openProfile} />;
+              })
+            )}
+          </div>
+
+          {/* Input row */}
+          <div
+            style={{
+              borderTop: '1px solid var(--panel-border)',
+              padding: '6px 8px',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 4,
+            }}
+          >
+            <div style={{ display: 'flex', gap: 6, alignItems: 'flex-end' }}>
+              <textarea
+                className="mono"
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && !e.shiftKey) {
+                    e.preventDefault();
+                    void doSend();
+                  }
+                }}
+                placeholder={
+                  connected ? 'Message… (Enter to send, Shift+Enter for newline)' : 'Not connected'
+                }
+                disabled={!connected}
+                rows={1}
+                maxLength={MAX_MESSAGE_CHARS + 64}
+                style={{
+                  flex: 1,
+                  resize: 'none',
+                  maxHeight: 90,
+                  minHeight: 28,
+                  padding: '5px 8px',
+                  borderRadius: 'var(--r-sm)',
+                  border: '1px solid var(--line-strong)',
+                  background: connected ? '#0c0c10' : 'var(--bg-1)',
+                  color: '#d8d8dc',
+                  fontSize: 12.5,
+                  lineHeight: 1.4,
+                  outline: 'none',
+                }}
+              />
+              <button
+                type="button"
+                className={`btn sm${canSend ? ' active' : ''}`}
+                disabled={!canSend}
+                onClick={() => void doSend()}
+                title={connected ? 'Send (Enter)' : 'Not connected'}
+              >
+                Send
+              </button>
+            </div>
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'flex-end',
+                fontSize: 10,
+                color: counterColor,
+                opacity: draft.length >= CHAR_WARN_THRESHOLD || draft.length === 0 ? 1 : 0.6,
+              }}
+            >
+              {draft.length >= CHAR_WARN_THRESHOLD ? `${remaining} left` : `${draft.length}/${MAX_MESSAGE_CHARS}`}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {profileCall ? (
+        <ProfileOverlay callsign={profileCall} onClose={() => setProfileCall(null)} />
+      ) : null}
+    </div>
+  );
+}

--- a/zeus-web/src/layout/panels/ChatPanel.tsx
+++ b/zeus-web/src/layout/panels/ChatPanel.tsx
@@ -41,6 +41,42 @@ function fmtFreqMhz(hz: number | null | undefined): string {
   return `${whole}.${khz}.${hhz}`;
 }
 
+/** Ham-band edges (Hz) for grouping the roster. Order = display order. */
+const BANDS: ReadonlyArray<{ label: string; lo: number; hi: number }> = [
+  { label: '2200m', lo: 135_700, hi: 137_800 },
+  { label: '630m', lo: 472_000, hi: 479_000 },
+  { label: '160m', lo: 1_800_000, hi: 2_000_000 },
+  { label: '80m', lo: 3_500_000, hi: 4_000_000 },
+  { label: '60m', lo: 5_250_000, hi: 5_450_000 },
+  { label: '40m', lo: 7_000_000, hi: 7_300_000 },
+  { label: '30m', lo: 10_100_000, hi: 10_150_000 },
+  { label: '20m', lo: 14_000_000, hi: 14_350_000 },
+  { label: '17m', lo: 18_068_000, hi: 18_168_000 },
+  { label: '15m', lo: 21_000_000, hi: 21_450_000 },
+  { label: '12m', lo: 24_890_000, hi: 24_990_000 },
+  { label: '10m', lo: 28_000_000, hi: 29_700_000 },
+  { label: '6m', lo: 50_000_000, hi: 54_000_000 },
+  { label: '4m', lo: 70_000_000, hi: 70_500_000 },
+  { label: '2m', lo: 144_000_000, hi: 148_000_000 },
+  { label: '1.25m', lo: 222_000_000, hi: 225_000_000 },
+  { label: '70cm', lo: 420_000_000, hi: 450_000_000 },
+  { label: '33cm', lo: 902_000_000, hi: 928_000_000 },
+  { label: '23cm', lo: 1_240_000_000, hi: 1_300_000_000 },
+];
+
+/** Band label for a frequency, or "Other" when off-band/unknown. */
+function bandForHz(hz: number | null | undefined): string {
+  if (typeof hz !== 'number' || !Number.isFinite(hz) || hz <= 0) return 'Other';
+  for (const b of BANDS) if (hz >= b.lo && hz <= b.hi) return b.label;
+  return 'Other';
+}
+
+/** Sort key for band labels (display order; "Other" last). */
+function bandOrder(label: string): number {
+  const i = BANDS.findIndex((b) => b.label === label);
+  return i < 0 ? BANDS.length : i;
+}
+
 /** Clock time (HH:MM) from epoch ms, in the operator's local zone. */
 function fmtClock(ts: number): string {
   if (!Number.isFinite(ts) || ts <= 0) return '';
@@ -165,11 +201,12 @@ function RosterRow({
             fontSize: 10.5,
             color: 'var(--fg-2)',
             whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
           }}
         >
           <span style={{ color: 'var(--power)' }}>{fmtFreqMhz(op.freqHz)}</span>
           {op.mode ? <span style={{ color: 'var(--fg-2)' }}>{op.mode}</span> : null}
-          {op.grid ? <span style={{ color: 'var(--fg-3)' }}>{op.grid}</span> : null}
         </div>
       </div>
     </div>
@@ -364,6 +401,18 @@ export function ChatPanel() {
     });
   }, [roster]);
 
+  // Group the (already status/callsign-sorted) roster by band for display.
+  const rosterByBand = useMemo(() => {
+    const groups = new Map<string, ChatOperator[]>();
+    for (const op of sortedRoster) {
+      const band = bandForHz(op.freqHz);
+      const arr = groups.get(band);
+      if (arr) arr.push(op);
+      else groups.set(band, [op]);
+    }
+    return [...groups.entries()].sort((a, b) => bandOrder(a[0]) - bandOrder(b[0]));
+  }, [sortedRoster]);
+
   const canSend = enabled && connected && draft.trim().length > 0 && draft.length <= MAX_MESSAGE_CHARS;
 
   const doSend = useCallback(async () => {
@@ -529,14 +578,42 @@ export function ChatPanel() {
           >
             Online · {sortedRoster.length}
           </div>
-          <div style={{ flex: 1, overflow: 'auto', minHeight: 0, padding: '0 4px 6px' }}>
+          <div
+            style={{
+              flex: 1,
+              overflowY: 'auto',
+              overflowX: 'hidden',
+              minHeight: 0,
+              padding: '0 4px 6px',
+            }}
+          >
             {sortedRoster.length === 0 ? (
               <div style={{ padding: '10px 8px', fontSize: 11, color: 'var(--fg-3)' }}>
                 No one here yet
               </div>
             ) : (
-              sortedRoster.map((op) => (
-                <RosterRow key={op.callsign} op={op} onOpen={openProfile} />
+              rosterByBand.map(([band, ops]) => (
+                <div key={band} style={{ marginBottom: 2 }}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      alignItems: 'baseline',
+                      justifyContent: 'space-between',
+                      padding: '5px 6px 2px',
+                      fontSize: 9.5,
+                      fontWeight: 700,
+                      letterSpacing: '0.1em',
+                      textTransform: 'uppercase',
+                      color: 'var(--accent-bright)',
+                    }}
+                  >
+                    <span>{band}</span>
+                    <span style={{ color: 'var(--fg-4)', fontWeight: 600 }}>{ops.length}</span>
+                  </div>
+                  {ops.map((op) => (
+                    <RosterRow key={op.callsign} op={op} onOpen={openProfile} />
+                  ))}
+                </div>
               ))
             )}
           </div>

--- a/zeus-web/src/realtime/ws-client.ts
+++ b/zeus-web/src/realtime/ws-client.ts
@@ -61,6 +61,7 @@ import { useRxMetersStore } from '../state/rx-meters-store';
 import { useAudioSuiteStore } from '../state/audio-suite-store';
 import { CW_STATE_FROM_BYTE, useCwStore } from '../state/cw-store';
 import { useSpotStore } from '../state/spot-store';
+import { useChatStore, type ChatEnvelope } from '../state/chat-store';
 import { warnOnce } from '../util/logger';
 import { clampFinite } from '../util/number';
 import { wsUrl as buildWsUrl } from '../serverUrl';
@@ -187,6 +188,14 @@ const AUDIO_MASTER_BYPASS_BYTES = 2;
 // Contract: Zeus.Contracts/RxAudioMasterBypassFrame.cs.
 export const MSG_TYPE_RX_AUDIO_MASTER_BYPASS = 0x34;
 const RX_AUDIO_MASTER_BYPASS_BYTES = 2;
+
+// Operator chat event. Variable-length frame: 1 type byte + UTF-8 JSON
+// envelope (camelCase). The envelope is discriminated on `kind`
+// (status | roster | message | history) and dispatched into chat-store's
+// ingest(). Server pushes these whenever roster, status, or messages change
+// so the ChatPanel stays live without polling. Contract:
+// Zeus.Contracts/ChatEventFrame.cs.
+export const MSG_TYPE_CHAT_EVENT = 0x35;
 
 // CW engine status — broadcast on every state edge of the host-side CW
 // keyer so the macro pad can render in-flight text + queue depth without
@@ -491,6 +500,18 @@ export function startRealtime(path = '/ws'): () => void {
           const csv = new TextDecoder('utf-8').decode(bytes);
           const ids = csv.length === 0 ? [] : csv.split(',');
           useAudioSuiteStore.getState().setRxChainOrderFromServer(ids);
+          return;
+        }
+        if (peekType === MSG_TYPE_CHAT_EVENT) {
+          // Variable-length UTF-8 JSON payload after the type byte.
+          const bytes = new Uint8Array(ev.data, 1);
+          const json = new TextDecoder('utf-8').decode(bytes);
+          try {
+            const envelope = JSON.parse(json) as ChatEnvelope;
+            useChatStore.getState().ingest(envelope);
+          } catch (err) {
+            warnOnce('ws-chat-event-parse', 'chat event frame parse failed', err);
+          }
           return;
         }
         if (peekType === MSG_TYPE_CW_ENGINE_STATUS) {

--- a/zeus-web/src/state/chat-store.test.ts
+++ b/zeus-web/src/state/chat-store.test.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useChatStore } from './chat-store';
+
+const RESET = {
+  enabled: false,
+  connected: false,
+  callsign: null,
+  relayUrl: null,
+  relayError: null,
+  roster: [],
+  messages: [],
+};
+
+function msg(id: string, ts: number, text = id, from = 'N9WAR', room = 'lobby') {
+  return { id, ts, text, from, room };
+}
+
+describe('chat-store ingest (0x35 live frames)', () => {
+  beforeEach(() => {
+    useChatStore.setState(RESET);
+  });
+
+  it('status frame updates connection fields', () => {
+    useChatStore.getState().ingest({
+      kind: 'status',
+      status: { enabled: true, connected: true, callsign: 'N9WAR', relayUrl: 'wss://x/chat', error: null },
+    });
+    const s = useChatStore.getState();
+    expect(s.enabled).toBe(true);
+    expect(s.connected).toBe(true);
+    expect(s.callsign).toBe('N9WAR');
+    expect(s.relayUrl).toBe('wss://x/chat');
+    expect(s.relayError).toBeNull();
+  });
+
+  it('roster frame replaces the roster with normalized operators', () => {
+    useChatStore.getState().ingest({
+      kind: 'roster',
+      roster: [
+        { callsign: 'N9WAR', grid: 'EL96eo', freqHz: 14_200_000, mode: 'USB', status: 'rx', since: 1 },
+        { callsign: 'W1ABC', freqHz: 7_074_000, status: 'tx', since: 2 },
+      ],
+    });
+    const r = useChatStore.getState().roster;
+    expect(r).toHaveLength(2);
+    expect(r[0].callsign).toBe('N9WAR');
+    expect(r[0].freqHz).toBe(14_200_000);
+    expect(r[1].status).toBe('tx');
+    expect(r[1].grid).toBeNull();
+  });
+
+  it('message frames append, de-dupe by id, and stay time-ordered', () => {
+    const ing = useChatStore.getState().ingest;
+    ing({ kind: 'message', message: msg('b', 200) });
+    ing({ kind: 'message', message: msg('a', 100) });
+    ing({ kind: 'message', message: msg('b', 200) }); // duplicate id — ignored
+    const m = useChatStore.getState().messages;
+    expect(m.map((x) => x.id)).toEqual(['a', 'b']);
+  });
+
+  it('history frame merges with existing messages without duplicates', () => {
+    const ing = useChatStore.getState().ingest;
+    ing({ kind: 'message', message: msg('a', 100) });
+    ing({ kind: 'history', messages: [msg('a', 100), msg('c', 300), msg('b', 200)] });
+    const m = useChatStore.getState().messages;
+    expect(m.map((x) => x.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('caps retained messages at 500, keeping the newest', () => {
+    const many = Array.from({ length: 600 }, (_, i) => msg(`m${i}`, i + 1));
+    useChatStore.getState().ingest({ kind: 'history', messages: many });
+    const m = useChatStore.getState().messages;
+    expect(m).toHaveLength(500);
+    expect(m[0].id).toBe('m100'); // oldest 100 dropped
+    expect(m[m.length - 1].id).toBe('m599');
+  });
+
+  it('ignores malformed or unknown envelopes without throwing', () => {
+    const ing = useChatStore.getState().ingest;
+    expect(() => ing({ kind: 'nope' } as never)).not.toThrow();
+    expect(() => ing(null as never)).not.toThrow();
+    expect(useChatStore.getState().messages).toHaveLength(0);
+  });
+});

--- a/zeus-web/src/state/chat-store.test.ts
+++ b/zeus-web/src/state/chat-store.test.ts
@@ -55,10 +55,10 @@ describe('chat-store ingest (0x35 live frames)', () => {
     });
     const r = useChatStore.getState().roster;
     expect(r).toHaveLength(2);
-    expect(r[0].callsign).toBe('N9WAR');
-    expect(r[0].freqHz).toBe(14_200_000);
-    expect(r[1].status).toBe('tx');
-    expect(r[1].grid).toBeNull();
+    expect(r[0]?.callsign).toBe('N9WAR');
+    expect(r[0]?.freqHz).toBe(14_200_000);
+    expect(r[1]?.status).toBe('tx');
+    expect(r[1]?.grid).toBeNull();
   });
 
   it('message frames append, de-dupe by id, and stay time-ordered', () => {
@@ -83,8 +83,8 @@ describe('chat-store ingest (0x35 live frames)', () => {
     useChatStore.getState().ingest({ kind: 'history', messages: many });
     const m = useChatStore.getState().messages;
     expect(m).toHaveLength(500);
-    expect(m[0].id).toBe('m100'); // oldest 100 dropped
-    expect(m[m.length - 1].id).toBe('m599');
+    expect(m[0]?.id).toBe('m100'); // oldest 100 dropped
+    expect(m[m.length - 1]?.id).toBe('m599');
   });
 
   it('ignores malformed or unknown envelopes without throwing', () => {

--- a/zeus-web/src/state/chat-store.ts
+++ b/zeus-web/src/state/chat-store.ts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+// Operator-to-operator chat state. Hydrated via REST on panel mount
+// (refreshStatus / loadHistory / loadRoster) and kept live thereafter by the
+// 0x35 MSG_TYPE_CHAT_EVENT push frames decoded in realtime/ws-client.ts, which
+// dispatch their parsed envelope straight into ingest(). The store is global
+// so the WS can drive it whether or not the ChatPanel is mounted.
+
+import { create } from 'zustand';
+import {
+  chatStatus,
+  chatSetEnabled,
+  chatSend,
+  chatMessages,
+  chatRoster,
+  normalizeStatus,
+  normalizeOperator,
+  normalizeMessage,
+  type ChatOperator,
+  type ChatMessage,
+  type ChatStatus,
+} from '../api/chat';
+import { ApiError } from '../api/client';
+import { warnOnce } from '../util/logger';
+
+const HISTORY_LIMIT = 200;
+
+/** Cap retained messages so a long-lived session can't grow unbounded. */
+const MAX_MESSAGES = 500;
+
+// The JSON envelope carried by each 0x35 frame. Discriminated on `kind`.
+export type ChatEnvelope =
+  | { kind: 'status'; status: unknown }
+  | { kind: 'roster'; roster: unknown }
+  | { kind: 'message'; message: unknown }
+  | { kind: 'history'; messages: unknown };
+
+export type ChatStoreState = {
+  enabled: boolean;
+  connected: boolean;
+  callsign: string | null;
+  relayUrl: string | null;
+  relayError: string | null;
+  roster: ChatOperator[];
+  messages: ChatMessage[];
+
+  refreshStatus: () => Promise<void>;
+  setEnabled: (enabled: boolean) => Promise<void>;
+  send: (text: string) => Promise<boolean>;
+  loadHistory: () => Promise<void>;
+  loadRoster: () => Promise<void>;
+  ingest: (envelope: ChatEnvelope) => void;
+};
+
+function applyStatus(s: ChatStatus): Partial<ChatStoreState> {
+  return {
+    enabled: s.enabled,
+    connected: s.connected,
+    callsign: s.callsign,
+    relayUrl: s.relayUrl,
+    relayError: s.error,
+  };
+}
+
+/** Append a message, de-duping by id and keeping chronological order. */
+function appendMessage(existing: ChatMessage[], msg: ChatMessage): ChatMessage[] {
+  if (msg.id && existing.some((m) => m.id === msg.id)) return existing;
+  const next = [...existing, msg];
+  next.sort((a, b) => a.ts - b.ts);
+  return next.length > MAX_MESSAGES ? next.slice(next.length - MAX_MESSAGES) : next;
+}
+
+function mergeHistory(existing: ChatMessage[], incoming: ChatMessage[]): ChatMessage[] {
+  const byId = new Map<string, ChatMessage>();
+  for (const m of existing) if (m.id) byId.set(m.id, m);
+  for (const m of incoming) if (m.id) byId.set(m.id, m);
+  const merged = [...byId.values()];
+  merged.sort((a, b) => a.ts - b.ts);
+  return merged.length > MAX_MESSAGES ? merged.slice(merged.length - MAX_MESSAGES) : merged;
+}
+
+export const useChatStore = create<ChatStoreState>((set) => ({
+  enabled: false,
+  connected: false,
+  callsign: null,
+  relayUrl: null,
+  relayError: null,
+  roster: [],
+  messages: [],
+
+  refreshStatus: async () => {
+    try {
+      const status = await chatStatus();
+      set(applyStatus(status));
+    } catch {
+      // Status is a read-only sanity probe — leave prior state on failure.
+    }
+  },
+
+  setEnabled: async (enabled) => {
+    try {
+      const status = await chatSetEnabled(enabled);
+      set(applyStatus(status));
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : String(err);
+      set({ relayError: msg });
+    }
+  },
+
+  send: async (text) => {
+    const trimmed = text.trim();
+    if (!trimmed) return false;
+    try {
+      const { ok } = await chatSend(trimmed);
+      return ok;
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : String(err);
+      set({ relayError: msg });
+      return false;
+    }
+  },
+
+  loadHistory: async () => {
+    try {
+      const messages = await chatMessages(HISTORY_LIMIT);
+      set((s) => ({ messages: mergeHistory(s.messages, messages) }));
+    } catch {
+      // History is best-effort; live frames will backfill.
+    }
+  },
+
+  loadRoster: async () => {
+    try {
+      const roster = await chatRoster();
+      set({ roster });
+    } catch {
+      // Roster is best-effort; a live roster frame will replace it.
+    }
+  },
+
+  ingest: (envelope) => {
+    if (!envelope || typeof envelope !== 'object') return;
+    switch (envelope.kind) {
+      case 'status':
+        set(applyStatus(normalizeStatus(envelope.status)));
+        return;
+      case 'roster':
+        set({
+          roster: Array.isArray(envelope.roster)
+            ? envelope.roster.map(normalizeOperator)
+            : [],
+        });
+        return;
+      case 'message': {
+        const msg = normalizeMessage(envelope.message);
+        set((s) => ({ messages: appendMessage(s.messages, msg) }));
+        return;
+      }
+      case 'history': {
+        const incoming = Array.isArray(envelope.messages)
+          ? envelope.messages.map(normalizeMessage)
+          : [];
+        set((s) => ({ messages: mergeHistory(s.messages, incoming) }));
+        return;
+      }
+      default:
+        warnOnce('chat-ingest-unknown-kind', `unknown chat envelope kind: ${String((envelope as { kind?: unknown }).kind)}`);
+    }
+  },
+}));
+
+// Convenience for callers that only need the current callsign synchronously.
+export function ownCallsign(): string | null {
+  return useChatStore.getState().callsign;
+}
+
+// Re-export the wire types so panels can import them from one place.
+export type { ChatOperator, ChatMessage, ChatStatus } from '../api/chat';

--- a/zeus-web/src/styles/all-panels.css
+++ b/zeus-web/src/styles/all-panels.css
@@ -273,6 +273,7 @@
 .workspace-tile[data-panel-id='logbook'] > .workspace-tile-body,
 .workspace-tile[data-panel-id='qrz'] > .workspace-tile-body,
 .workspace-tile[data-panel-id='dsp'] > .workspace-tile-body,
+.workspace-tile[data-panel-id='chat'] > .workspace-tile-body,
 .workspace-tile[data-panel-id='filterpresets'] > .workspace-tile-body {
   display: flex;
   flex-direction: column;
@@ -286,6 +287,7 @@
 .workspace-tile[data-panel-id='logbook'] > .workspace-tile-body > *,
 .workspace-tile[data-panel-id='qrz'] > .workspace-tile-body > *,
 .workspace-tile[data-panel-id='dsp'] > .workspace-tile-body > *,
+.workspace-tile[data-panel-id='chat'] > .workspace-tile-body > *,
 .workspace-tile[data-panel-id='filterpresets'] > .workspace-tile-body > * {
   flex: 1 1 auto;
   min-height: 0;


### PR DESCRIPTION
## ZeusChat — operator-to-operator chat

Adds a new **Chat** panel: real-time text chat between Zeus operators, with QRZ identity, click-to-profile, and live frequency sharing.

### What it does
- **Identity = QRZ-verified callsign.** Chat is gated on QRZ login; your callsign comes from your QRZ session (reuses `QrzService`). Any QRZ login tier works (no subscription required).
- **Live presence.** Each operator's current VFO frequency + mode + rx/tx/away status is shared; the roster is **organized by band**.
- **Click-to-profile.** Clicking any callsign (roster or message) opens that operator's QRZ profile, reusing the existing `QrzCard` + lookup cache.
- **Opt-in, default off.** Enabling discloses that it broadcasts your callsign + live frequency to other operators.

### Architecture
- **Relay:** standalone Cloudflare Worker + Durable Object (WebSocket Hibernation) at `wss://chat.openhpsdrzeus.com/chat`. Source in `cloud/zeuschat-relay/`. Every operator runs their own local backend, so the relay is the shared meeting point.
- **Backend chat node:** `ChatService` (Zeus.Server.Hosting) opens an outbound WSS to the relay only when chat is enabled **and** QRZ is logged in; presents the QRZ session as headers so the relay's QRZ gate admits it. Publishes frequency from `RadioService.StateChanged`. REST: `/api/chat/status|enable|send|messages|roster`.
- **Push:** new `StreamingHub` frame `MsgType.ChatEvent = 0x35` (`[type][UTF-8 JSON]`, kinds `status`/`roster`/`message`/`history`), decoded in `realtime/ws-client.ts` into a zustand `chat-store`.

### Security / abuse
- **QRZ verification is the access gate** — the relay validates the session against the QRZ XML API before admitting (fails closed). No shared secret is shipped in builds.
- **Rate limiting:** per-IP connection limit (30/60s, `RateLimiter` DO) protects the QRZ-verify path; per-connection message limit (6/5s) protects the room. Positive QRZ verdicts are edge-cached ~5 min.
- **Known limitation:** QRZ's API can't prove which callsign *owns* a session, so callsign↔account binding is best-effort (a modified client could assert another callsign). Disclosed in the UI and documented in the relay README.

### Testing
- `dotnet test Zeus.slnx`: **0 failures** (Server 1238 passed incl. 15 new ChatService tests; Dsp 172).
- `npm test` (zeus-web): **794 passed** incl. new chat-store reducer tests.
- **Live e2e verified:** QRZ-gated connect (N9WAR through the live relay), live frequency in roster, message round-trip, all four `0x35` frame kinds, bidirectional cross-client fan-out, connection 429 after 30/min, message limit 6/8 delivered.

### Deploy notes
- Relay is already deployed to the project Cloudflare account (`chat.openhpsdrzeus.com`, `*.workers.dev` fallback). `cd cloud/zeuschat-relay && npm i && wrangler deploy`.
- Backend relay URL overridable via `ZEUSCHAT_RELAY_URL`.

### Not in this PR (follow-ups)
- Band-keyed rooms, unread badges, server-side message history persistence.
- A real two-different-callsign smoke test (fan-out was proven with two connections on one account).
- Branch is based on an earlier `develop`; rebase before merge if desired.
