### PR TITLE
feat(logbook): refine search actions and QRZ visibility

### DIFF
--- a/zeus-web/src/components/design/LogbookLive.tsx
+++ b/zeus-web/src/components/design/LogbookLive.tsx
@@ -42,8 +42,7 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { Search, X } from 'lucide-react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useLoggerStore } from '../../state/logger-store';
 import type { LogEntry } from '../../api/log';
 import { formatQsoDateUtc, formatQsoTimeUtc } from './logbook-formatters';
@@ -79,7 +78,12 @@ function logRowTitle(entry: LogEntry): string {
   ]);
 }
 
-export function LogbookLive() {
+type LogbookLiveProps = {
+  searchText: string;
+  hideQrzPublished: boolean;
+};
+
+export function LogbookLive({ searchText, hideQrzPublished }: LogbookLiveProps) {
   const entries = useLoggerStore((s) => s.entries);
   const totalCount = useLoggerStore((s) => s.totalCount);
   const loading = useLoggerStore((s) => s.loading);
@@ -90,9 +94,12 @@ export function LogbookLive() {
   const toggleSelected = useLoggerStore((s) => s.toggleSelected);
   const setSelectedIds = useLoggerStore((s) => s.setSelectedIds);
   const selectAllRef = useRef<HTMLInputElement>(null);
-  const [searchText, setSearchText] = useState('');
   const query = searchText.trim();
-  const filteredEntries = useMemo(() => filterLogEntries(entries, searchText), [entries, searchText]);
+  const filteredEntries = useMemo(
+    () => filterLogEntries(entries, searchText, { hideQrzPublished }),
+    [entries, hideQrzPublished, searchText],
+  );
+  const filtersActive = query.length > 0 || hideQrzPublished;
   const visibleIds = useMemo(() => new Set(filteredEntries.map((entry) => entry.id)), [filteredEntries]);
   const selectedVisibleCount = filteredEntries.reduce(
     (count, entry) => count + (selectedIds.has(entry.id) ? 1 : 0),
@@ -139,28 +146,6 @@ export function LogbookLive() {
 
   return (
     <div className="logbook">
-      <div className="log-search">
-        <Search size={14} strokeWidth={2} aria-hidden="true" />
-        <input
-          type="search"
-          value={searchText}
-          onChange={(event) => setSearchText(event.target.value)}
-          placeholder="Search logbook"
-          aria-label="Search logbook"
-          spellCheck={false}
-        />
-        {query && (
-          <button
-            type="button"
-            className="log-search-clear"
-            onClick={() => setSearchText('')}
-            aria-label="Clear logbook search"
-            title="Clear search"
-          >
-            <X size={13} strokeWidth={2.2} aria-hidden="true" />
-          </button>
-        )}
-      </div>
       <div className="log-head mono">
         <span className="log-select-cell">
           <input
@@ -190,7 +175,9 @@ export function LogbookLive() {
       <div className="log-rows">
         {filteredEntries.length === 0 && (
           <div className="log-empty">
-            No log entries match "{query}".
+            {query
+              ? `No log entries match "${query}".`
+              : 'No unpublished log entries to show.'}
           </div>
         )}
         {filteredEntries.map((entry) => (
@@ -243,7 +230,7 @@ export function LogbookLive() {
       <div className="log-foot">
         <span style={{ flex: 1 }} />
         <span className="label-xs">
-          {query
+          {filtersActive
             ? `${filteredEntries.length} of ${entries.length} visible · ${totalCount} total`
             : `${entries.length} of ${totalCount}`}
         </span>

--- a/zeus-web/src/components/design/logbook-search.test.ts
+++ b/zeus-web/src/components/design/logbook-search.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, it } from 'vitest';
 import type { LogEntry } from '../../api/log';
-import { filterLogEntries, logEntrySearchText } from './logbook-search';
+import { filterLogEntries, isQrzPublished, logEntrySearchText } from './logbook-search';
 
 function entry(overrides: Partial<LogEntry>): LogEntry {
   return {
@@ -76,5 +76,15 @@ describe('logbook search', () => {
   it('includes UTC date and time in the searchable text', () => {
     expect(logEntrySearchText(entries[0]!)).toContain('14:22');
     expect(filterLogEntries(entries, '2026 14:22').map((qso) => qso.id)).toEqual(['a', 'b']);
+  });
+
+  it('can hide QRZ-published entries', () => {
+    expect(isQrzPublished(entries[0]!)).toBe(true);
+    expect(filterLogEntries(entries, ' ', { hideQrzPublished: true }).map((qso) => qso.id)).toEqual(['b']);
+  });
+
+  it('composes QRZ-published hiding with text search', () => {
+    expect(filterLogEntries(entries, '20m', { hideQrzPublished: true }).map((qso) => qso.id)).toEqual(['b']);
+    expect(filterLogEntries(entries, '40m', { hideQrzPublished: true })).toEqual([]);
   });
 });

--- a/zeus-web/src/components/design/logbook-search.ts
+++ b/zeus-web/src/components/design/logbook-search.ts
@@ -14,6 +14,14 @@ function compactSearchParts(parts: Array<string | number | null | undefined>): s
     .toLocaleLowerCase();
 }
 
+export type LogEntryFilterOptions = {
+  hideQrzPublished?: boolean;
+};
+
+export function isQrzPublished(entry: LogEntry): boolean {
+  return !!entry.qrzLogId;
+}
+
 export function logEntrySearchText(entry: LogEntry): string {
   return compactSearchParts([
     entry.callsign,
@@ -38,11 +46,18 @@ export function logEntrySearchText(entry: LogEntry): string {
   ]);
 }
 
-export function filterLogEntries(entries: LogEntry[], query: string): LogEntry[] {
+export function filterLogEntries(
+  entries: LogEntry[],
+  query: string,
+  options: LogEntryFilterOptions = {},
+): LogEntry[] {
+  const candidates = options.hideQrzPublished
+    ? entries.filter((entry) => !isQrzPublished(entry))
+    : entries;
   const terms = normalizeSearchText(query).split(/\s+/).filter(Boolean);
-  if (terms.length === 0) return entries;
+  if (terms.length === 0) return candidates;
 
-  return entries.filter((entry) => {
+  return candidates.filter((entry) => {
     const haystack = logEntrySearchText(entry);
     return terms.every((term) => haystack.includes(term));
   });

--- a/zeus-web/src/layout/panels/LogbookPanel.tsx
+++ b/zeus-web/src/layout/panels/LogbookPanel.tsx
@@ -42,19 +42,70 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
+import { useState } from 'react';
+import { Eye, EyeOff, Search, X } from 'lucide-react';
 import { LogbookLive } from '../../components/design/LogbookLive';
+import { useLoggerStore } from '../../state/logger-store';
 import { useWorkspace } from '../WorkspaceContext';
 
 export function LogbookPanel() {
   const { logbookActions } = useWorkspace();
+  const [searchText, setSearchText] = useState('');
+  const [hideQrzPublished, setHideQrzPublished] = useState(false);
+  const qrzPublishedCount = useLoggerStore((s) =>
+    s.entries.reduce((count, entry) => count + (entry.qrzLogId ? 1 : 0), 0),
+  );
+  const query = searchText.trim();
+  const qrzPublishedLabel = qrzPublishedCount === 1
+    ? '1 QRZ-published QSO'
+    : `${qrzPublishedCount} QRZ-published QSOs`;
+  const qrzToggleTitle = hideQrzPublished
+    ? `Show ${qrzPublishedLabel}`
+    : qrzPublishedCount > 0
+      ? `Hide ${qrzPublishedLabel}`
+      : 'No QRZ-published QSOs to hide';
+  const QrzVisibilityIcon = hideQrzPublished ? EyeOff : Eye;
 
   return (
-    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'auto' }}>
-      <div style={{ padding: '4px 8px', borderBottom: '1px solid var(--panel-border)', display: 'flex', gap: 4, justifyContent: 'flex-end' }}>
+    <div className="logbook-panel">
+      <div className="logbook-actions">
+        <div className="log-search">
+          <Search size={14} strokeWidth={2} aria-hidden="true" />
+          <input
+            type="search"
+            value={searchText}
+            onChange={(event) => setSearchText(event.target.value)}
+            placeholder="Search logbook"
+            aria-label="Search logbook"
+            spellCheck={false}
+          />
+          {query && (
+            <button
+              type="button"
+              className="log-search-clear"
+              onClick={() => setSearchText('')}
+              aria-label="Clear logbook search"
+              title="Clear search"
+            >
+              <X size={13} strokeWidth={2.2} aria-hidden="true" />
+            </button>
+          )}
+        </div>
+        <button
+          type="button"
+          className={`btn ghost sm logbook-visibility-toggle ${hideQrzPublished ? 'active' : ''}`}
+          onClick={() => setHideQrzPublished((value) => !value)}
+          disabled={qrzPublishedCount === 0 && !hideQrzPublished}
+          aria-label={qrzToggleTitle}
+          aria-pressed={hideQrzPublished}
+          title={qrzToggleTitle}
+        >
+          <QrzVisibilityIcon size={14} strokeWidth={2.2} aria-hidden="true" />
+        </button>
         {logbookActions}
       </div>
-      <div style={{ flex: 1, overflow: 'auto' }}>
-        <LogbookLive />
+      <div className="logbook-panel-body">
+        <LogbookLive searchText={searchText} hideQrzPublished={hideQrzPublished} />
       </div>
     </div>
   );

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -2825,17 +2825,38 @@
 .cs-input:focus { outline: none; border-color: var(--accent); box-shadow: inset 0 1px 2px rgba(0,0,0,0.6), 0 0 0 1px var(--accent-soft); }
 
 /* ===== Logbook ===== */
+.logbook-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: auto;
+}
+.logbook-actions {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--panel-border);
+}
+.logbook-panel-body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+}
 .logbook { display: flex; flex-direction: column; height: 100%; min-height: 0; background: var(--bg-1); }
 .log-search {
-  flex: 0 0 auto;
+  flex: 1 1 190px;
   display: grid;
   grid-template-columns: 16px minmax(0, 1fr) 22px;
   align-items: center;
   gap: 6px;
-  padding: 5px 8px;
+  min-width: 140px;
+  max-width: 280px;
+  margin-right: auto;
   color: var(--fg-2);
-  background: var(--bg-2);
-  border-bottom: 1px solid rgba(0,0,0,0.35);
 }
 .log-search input {
   min-width: 0;
@@ -2869,6 +2890,20 @@
   color: var(--fg-0);
   background: var(--bg-0);
   border-color: var(--line-strong);
+}
+.logbook-visibility-toggle {
+  width: 28px;
+  min-width: 28px;
+  height: 24px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.logbook-visibility-toggle.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--btn-active-text);
 }
 .log-head {
   display: grid;


### PR DESCRIPTION
## Summary
- move Logbook search into the header action row beside Publish and Export
- add an eye toggle to hide QSOs already published to QRZ
- keep QRZ visibility filtering composed with text search and visible-row selection

## Tests
- npm --prefix zeus-web run typecheck
- npm --prefix zeus-web run test -- logbook-search LogbookLive.formatters.test
- npm --prefix zeus-web run lint
- npm --prefix zeus-web run build
- npm --prefix zeus-web run test:e2e