### PR TITLE
fix: require fresh TX auto-tune samples

### DIFF
--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -832,6 +832,7 @@ public static class ZeusEndpoints
             var keying = hardware.KeyingSnapshot(externalPtt.Snapshot());
             var power = hardware.PowerCalibrationSnapshot();
             bool hostTxActive = tx.IsMoxOn || tx.IsTunOn || tx.IsTwoToneOn;
+            bool txStageActive = hostTxActive || radioState.TxMonitorEnabled;
             bool requiresMicUplink = tx.IsMoxOn && !tx.IsTunOn && !tx.IsTwoToneOn;
             var txStage = dsp.CurrentEngine?.GetTxStageMeters() ?? TxStageMeters.Silent;
             var activePower = string.Equals(power.ActiveProtocol, "P2", StringComparison.OrdinalIgnoreCase)
@@ -864,7 +865,7 @@ public static class ZeusEndpoints
                     hostTxActive,
                     micUplink,
                     requiresMicUplink),
-                stage = BuildTxStageDiagnostics(txStage, hostTxActive),
+                stage = BuildTxStageDiagnostics(txStage, txStageActive),
                 egress = BuildTxEgressHealth(
                     generatedUtc,
                     ring.TotalWritten,

--- a/tests/Zeus.Server.Tests/AudioSuitePreviewEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/AudioSuitePreviewEndpointTests.cs
@@ -94,6 +94,28 @@ public class AudioSuitePreviewEndpointTests : IClassFixture<AudioSuitePreviewEnd
     }
 
     [Fact]
+    public async Task TxDiagTreatsPreviewAsStageActiveOnly()
+    {
+        using var client = _factory.CreateClient();
+
+        var on = await client.PutAsJsonAsync(
+            "/api/tx-audio-suite/preview", new { enabled = true, meterOnly = true });
+        Assert.Equal(HttpStatusCode.OK, on.StatusCode);
+
+        using var json = await client.GetFromJsonAsync<JsonDocument>("/api/tx/diag");
+        Assert.NotNull(json);
+        var root = json!.RootElement;
+
+        Assert.True(root.GetProperty("stage").GetProperty("hostTxActive").GetBoolean());
+        Assert.False(root.GetProperty("audioPath").GetProperty("hostTxActive").GetBoolean());
+        Assert.False(root.GetProperty("egress").GetProperty("hostTxActive").GetBoolean());
+
+        var off = await client.PutAsJsonAsync(
+            "/api/tx-audio-suite/preview", new { enabled = false, meterOnly = true });
+        Assert.Equal(HttpStatusCode.OK, off.StatusCode);
+    }
+
+    [Fact]
     public async Task TxSuiteAliasesExposeTxRouteSurfaces()
     {
         using var client = _factory.CreateClient();

--- a/zeus-web/src/audio/tx-auto-tune.test.ts
+++ b/zeus-web/src/audio/tx-auto-tune.test.ts
@@ -46,6 +46,7 @@ function sample(overrides: Partial<TxAutoTuneSample> = {}): TxAutoTuneSample {
     psFeedbackLevel: 150,
     vstDegradedDelta: 0,
     ingestDroppedFrameDelta: 0,
+    txBlockDelta: 1,
     p2QueuedPackets: 0,
     p2TransportFailureDelta: 0,
     p2QueueFailureDelta: 0,
@@ -100,6 +101,27 @@ describe('recommendTxAutoTune', () => {
     expect(plan.blockers.join(' ')).toContain('audio engine');
     expect(plan.settings.micGainDb).toBe(-12);
     expect(plan.settings.levelerMaxGainDb).toBe(6);
+    expect(plan.changed).toBe(false);
+  });
+
+  it('holds settings when diagnostics do not show fresh TXA blocks', () => {
+    const plan = recommendTxAutoTune(
+      settings({ micGainDb: -12, levelerMaxGainDb: 4, targetSpectralDensity: 100 }),
+      samples({
+        micPkDbfs: -24,
+        outPkDbfs: -15,
+        outAvDbfs: -31,
+        alcGrDb: 0.5,
+        lvlrGrDb: 0.8,
+        cfcGrDb: 0.5,
+        txBlockDelta: 0,
+      }),
+    );
+
+    expect(plan.blockers.join(' ')).toContain('TXA did not process fresh mic blocks');
+    expect(plan.summary).toContain('fresh TX monitor samples');
+    expect(plan.settings.micGainDb).toBe(-12);
+    expect(plan.settings.levelerMaxGainDb).toBe(4);
     expect(plan.changed).toBe(false);
   });
 

--- a/zeus-web/src/audio/tx-auto-tune.ts
+++ b/zeus-web/src/audio/tx-auto-tune.ts
@@ -17,6 +17,7 @@ export type TxAutoTuneSample = {
   psFeedbackLevel: number | null;
   vstDegradedDelta: number | null;
   ingestDroppedFrameDelta: number | null;
+  txBlockDelta: number | null;
   p2QueuedPackets: number | null;
   p2TransportFailureDelta: number | null;
   p2QueueFailureDelta: number | null;
@@ -50,6 +51,7 @@ export type TxAutoTuneStats = {
   psFeedbackMedian: number | null;
   vstDegradedBlocks: number;
   ingestDroppedFrames: number;
+  txBlocksProcessed: number;
   p2QueuedPacketsMax: number;
   p2TransportFailures: number;
   p2QueueFailures: number;
@@ -224,6 +226,7 @@ export function summarizeTxAutoTuneSamples(samples: ReadonlyArray<TxAutoTuneSamp
     psFeedbackMedian: percentile(psFeedback, 0.5),
     vstDegradedBlocks: sumDeltas(samples, (s) => s.vstDegradedDelta),
     ingestDroppedFrames: sumDeltas(samples, (s) => s.ingestDroppedFrameDelta),
+    txBlocksProcessed: sumDeltas(samples, (s) => s.txBlockDelta),
     p2QueuedPacketsMax: maxCount(samples, (s) => s.p2QueuedPackets),
     p2TransportFailures: sumDeltas(samples, (s) => s.p2TransportFailureDelta),
     p2QueueFailures: sumDeltas(samples, (s) => s.p2QueueFailureDelta),
@@ -247,6 +250,17 @@ export function recommendTxAutoTune(
 
   if (stats.voicedSampleCount < MIN_VOICED_SAMPLES) {
     blockers.push('not enough voiced samples');
+  }
+  if (stats.txBlocksProcessed <= 0) {
+    blockers.push('TXA did not process fresh mic blocks during sampling');
+    return {
+      settings: current,
+      stats,
+      actions,
+      blockers,
+      changed: false,
+      summary: 'Auto tune needs fresh TX monitor samples',
+    };
   }
   if (stats.swrP95 >= 2.5) {
     blockers.push('SWR is too high for automatic power optimization');

--- a/zeus-web/src/layout/panels/TxFidelityPanel.tsx
+++ b/zeus-web/src/layout/panels/TxFidelityPanel.tsx
@@ -69,6 +69,7 @@ type AutoTuneChainMeters = {
 type AutoTuneCounters = {
   vstDegradedBlocks: number | null;
   ingestDroppedFrames: number | null;
+  txBlocks: number | null;
   p2TransportFailures: number | null;
   p2QueueFailures: number | null;
 };
@@ -149,11 +150,13 @@ function autoTuneSampleFromDiagnostics(
   const tx = useTxStore.getState();
   const degradedBlocks = finiteCount(diag.vstEngine?.degradedBlocks);
   const droppedFrames = finiteCount(diag.ingest.droppedFrames);
+  const txBlocks = finiteCount(diag.ingest.totalTxBlocks);
   const p2TransportFailures = finiteCount(diag.protocol2?.sendFailures);
   const p2QueueFailures = finiteCount(diag.protocol2?.queueWriteFailures);
   const counters = {
     vstDegradedBlocks: degradedBlocks,
     ingestDroppedFrames: droppedFrames,
+    txBlocks,
     p2TransportFailures,
     p2QueueFailures,
   };
@@ -172,6 +175,7 @@ function autoTuneSampleFromDiagnostics(
       psFeedbackLevel: finitePositive(tx.psFeedbackLevel),
       vstDegradedDelta: counterDelta(prev.vstDegradedBlocks, degradedBlocks),
       ingestDroppedFrameDelta: counterDelta(prev.ingestDroppedFrames, droppedFrames),
+      txBlockDelta: counterDelta(prev.txBlocks, txBlocks),
       p2QueuedPackets: finiteCount(diag.protocol2?.queuedPackets),
       p2TransportFailureDelta: counterDelta(prev.p2TransportFailures, p2TransportFailures),
       p2QueueFailureDelta: counterDelta(prev.p2QueueFailures, p2QueueFailures),
@@ -188,6 +192,7 @@ async function collectTxAutoTuneSamples(
   let counters: AutoTuneCounters = {
     vstDegradedBlocks: null,
     ingestDroppedFrames: null,
+    txBlocks: null,
     p2TransportFailures: null,
     p2QueueFailures: null,
   };


### PR DESCRIPTION
## Summary
- require TX Fidelity Auto Tune samples to prove fresh TXA block progress before applying settings
- mark TX Monitor preview as active for TXA stage diagnostics only, without changing RF egress host-TX semantics
- add focused frontend and server coverage for stale auto-tune samples and preview diagnostics

## Tests
- npm --prefix zeus-web run test:e2e
- npm --prefix zeus-web run test -- tx-auto-tune.test.ts
- npm --prefix zeus-web run test -- TxFidelityPanel.test.tsx
- dotnet test tests\Zeus.Server.Tests\Zeus.Server.Tests.csproj --filter FullyQualifiedName~AudioSuitePreviewEndpointTests

Beads: zeus-j57t