### PR TITLE
Auto-fit workspace panels during drag

### DIFF
--- a/zeus-web/e2e/workspace-panel-drag.spec.ts
+++ b/zeus-web/e2e/workspace-panel-drag.spec.ts
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { expect, test, type Page, type Route } from '@playwright/test';
+
+const defaultWorkspaceLayout = {
+  schemaVersion: 8,
+  tiles: [
+    { uid: 'tile-filter', panelId: 'filter', x: 0, y: 0, w: 12, h: 10 },
+    { uid: 'tile-filterpresets', panelId: 'filterpresets', x: 12, y: 0, w: 6, h: 10 },
+    { uid: 'tile-hero', panelId: 'hero', x: 0, y: 10, w: 18, h: 38 },
+    { uid: 'tile-vfo', panelId: 'vfo', x: 18, y: 0, w: 6, h: 11 },
+    { uid: 'tile-smeter', panelId: 'smeter', x: 18, y: 11, w: 6, h: 5 },
+    { uid: 'tile-tx', panelId: 'tx', x: 18, y: 16, w: 6, h: 10 },
+    { uid: 'tile-txmeters', panelId: 'txmeters', x: 18, y: 26, w: 6, h: 12 },
+    { uid: 'tile-dsp', panelId: 'dsp', x: 18, y: 38, w: 6, h: 10 },
+  ],
+};
+
+interface TileRect {
+  uid: string | null;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+async function fulfillJson(route: Route, body: unknown) {
+  await route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  });
+}
+
+async function stubZeusApi(page: Page) {
+  await page.addInitScript(() => {
+    class MockZeusWebSocket extends EventTarget {
+      readonly url: string;
+      readonly protocol = '';
+      readonly extensions = '';
+      binaryType: BinaryType = 'blob';
+      bufferedAmount = 0;
+      readyState = WebSocket.CONNECTING;
+      onopen: ((this: WebSocket, ev: Event) => unknown) | null = null;
+      onmessage: ((this: WebSocket, ev: MessageEvent) => unknown) | null = null;
+      onerror: ((this: WebSocket, ev: Event) => unknown) | null = null;
+      onclose: ((this: WebSocket, ev: CloseEvent) => unknown) | null = null;
+
+      constructor(url: string | URL) {
+        super();
+        this.url = String(url);
+        window.setTimeout(() => {
+          if (this.readyState !== WebSocket.CONNECTING) return;
+          this.readyState = WebSocket.OPEN;
+          const event = new Event('open');
+          this.onopen?.call(this as unknown as WebSocket, event);
+          this.dispatchEvent(event);
+        }, 0);
+      }
+
+      send() {
+        /* No realtime frames are needed for this workspace drag test. */
+      }
+
+      close() {
+        if (this.readyState === WebSocket.CLOSED) return;
+        this.readyState = WebSocket.CLOSED;
+        const event = new CloseEvent('close');
+        this.onclose?.call(this as unknown as WebSocket, event);
+        this.dispatchEvent(event);
+      }
+    }
+
+    window.WebSocket = MockZeusWebSocket as unknown as typeof WebSocket;
+  });
+
+  await page.route(/^https?:\/\/[^/]+\/api(?:\/|\?|$)/, async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const method = request.method();
+
+    if (url.pathname === '/api/capabilities') {
+      await fulfillJson(route, {
+        host: 'server',
+        platform: 'windows',
+        architecture: 'X64',
+        version: '0.9.1',
+        lanHttpsUrls: [],
+        features: {},
+      });
+      return;
+    }
+
+    if (url.pathname === '/api/radio/selection') {
+      await fulfillJson(route, {
+        preferred: 'Auto',
+        connected: 'Unknown',
+        effective: 'Unknown',
+        overrideDetection: false,
+      });
+      return;
+    }
+
+    if (url.pathname === '/api/plugins') {
+      await fulfillJson(route, { sdkAbi: 1, sdkVersion: '0.9.1', plugins: [] });
+      return;
+    }
+
+    if (url.pathname === '/api/ui/layouts' && method === 'GET') {
+      await fulfillJson(route, {
+        radioKey: url.searchParams.get('radio') ?? 'default',
+        layouts: [
+          {
+            id: 'default',
+            name: 'Default',
+            layoutJson: JSON.stringify(defaultWorkspaceLayout),
+            updatedUtc: 0,
+          },
+        ],
+        activeLayoutId: 'default',
+      });
+      return;
+    }
+
+    if (url.pathname === '/api/ui/layouts') {
+      await route.fulfill({ status: 204, body: '' });
+      return;
+    }
+
+    if (url.pathname === '/api/theme-settings') {
+      await fulfillJson(route, { theme: 'dark', overrides: {} });
+      return;
+    }
+
+    await fulfillJson(route, {});
+  });
+}
+
+async function tileRects(page: Page): Promise<TileRect[]> {
+  return page.locator('[data-tile-uid]').evaluateAll((tiles) =>
+    tiles.map((tile) => {
+      const rect = tile.getBoundingClientRect();
+      return {
+        uid: tile.getAttribute('data-tile-uid'),
+        x: rect.x,
+        y: rect.y,
+        width: rect.width,
+        height: rect.height,
+      };
+    }),
+  );
+}
+
+function overlapPairs(rects: TileRect[]) {
+  const pairs: Array<[string | null, string | null]> = [];
+  for (let i = 0; i < rects.length; i += 1) {
+    for (let j = i + 1; j < rects.length; j += 1) {
+      const a = rects[i]!;
+      const b = rects[j]!;
+      const overlapX = a.x < b.x + b.width - 1 && a.x + a.width > b.x + 1;
+      const overlapY = a.y < b.y + b.height - 1 && a.y + a.height > b.y + 1;
+      if (overlapX && overlapY) pairs.push([a.uid, b.uid]);
+    }
+  }
+  return pairs;
+}
+
+async function centerOf(locator: ReturnType<Page['locator']>) {
+  const box = await locator.boundingBox();
+  if (!box) throw new Error('Expected locator to have a bounding box');
+  return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+}
+
+test('dragging a panel into an occupied workspace slot displaces panels without blanking the grid', async ({
+  page,
+}) => {
+  const pageErrors: string[] = [];
+  page.on('pageerror', (err) => pageErrors.push(err.message));
+  await stubZeusApi(page);
+
+  await page.goto('/');
+
+  const draggedHeader = page.locator(
+    '[data-tile-uid="tile-filterpresets"] .workspace-tile-header',
+  );
+  const targetHeader = page.locator('[data-tile-uid="tile-tx"] .workspace-tile-header');
+  await expect(draggedHeader).toBeVisible();
+  await expect(targetHeader).toBeVisible();
+
+  const before = await tileRects(page);
+  expect(before).toHaveLength(8);
+
+  const start = await centerOf(draggedHeader);
+  const target = await centerOf(targetHeader);
+  await page.mouse.move(start.x, start.y);
+  await page.mouse.down();
+  await page.mouse.move(target.x, target.y, { steps: 12 });
+  await page.waitForTimeout(250);
+
+  const duringDrag = await tileRects(page);
+  expect(duringDrag).toHaveLength(8);
+  expect(overlapPairs(duringDrag)).toEqual([]);
+
+  await page.mouse.up();
+  await page.waitForTimeout(500);
+
+  const after = await tileRects(page);
+  expect(after).toHaveLength(8);
+  expect(overlapPairs(after)).toEqual([]);
+  expect(pageErrors).not.toContainEqual(
+    expect.stringContaining('Maximum update depth exceeded'),
+  );
+  expect(pageErrors).not.toContainEqual(
+    expect.stringContaining('Minified React error #185'),
+  );
+});

--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -103,8 +103,8 @@ export function FlexWorkspace({
   const syncToServerBeforeUnload = useLayoutStore((s) => s.syncToServerBeforeUnload);
   const addTileToLayout = useLayoutStore((s) => s.addTileToLayout);
   const removeTileFromLayout = useLayoutStore((s) => s.removeTileFromLayout);
-  const updateTilePlacementInLayout = useLayoutStore(
-    (s) => s.updateTilePlacementInLayout,
+  const updateTilePlacementsInLayout = useLayoutStore(
+    (s) => s.updateTilePlacementsInLayout,
   );
   // Modal visibility lifted into the store so the trigger button can live
   // in the LeftLayoutBar — the workspace just renders the modal when the
@@ -133,16 +133,18 @@ export function FlexWorkspace({
       // RGL fires onLayoutChange on every render with the current layout
       // (including the very first paint). Diff each item against the store
       // and only PUT through when something actually moved.
-      for (const item of next) {
-        updateTilePlacementInLayout(targetLayoutId, item.i, {
+      updateTilePlacementsInLayout(
+        targetLayoutId,
+        next.map((item) => ({
+          uid: item.i,
           x: item.x,
           y: item.y,
           w: item.w,
           h: item.h,
-        });
-      }
+        })),
+      );
     },
-    [targetLayoutId, updateTilePlacementInLayout],
+    [targetLayoutId, updateTilePlacementsInLayout],
   );
 
   const onAddPanel = useCallback(

--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -235,7 +235,7 @@ function WorkspaceCanvas({
   const [containerHeight, setContainerHeight] = useState(0);
   const [gridInteraction, setGridInteraction] =
     useState<GridInteraction>(null);
-  const autoFitNextDropRef = useRef(false);
+  const autoFitDropRef = useRef<LayoutItem | null>(null);
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
@@ -323,24 +323,26 @@ function WorkspaceCanvas({
     oldItem: LayoutItem | null,
     newItem: LayoutItem | null,
   ) => {
-    autoFitNextDropRef.current = !!(
+    autoFitDropRef.current = (
       oldItem &&
       newItem &&
       (oldItem.x !== newItem.x || oldItem.y !== newItem.y)
-    );
+    )
+      ? { ...oldItem }
+      : null;
     setGridInteraction(null);
   }, []);
   const onResizeStop = useCallback(() => {
-    autoFitNextDropRef.current = false;
+    autoFitDropRef.current = null;
     setGridInteraction(null);
   }, []);
   const handleLayoutChange = useCallback(
     (next: Layout) => {
-      const shouldAutoFit = autoFitNextDropRef.current;
-      autoFitNextDropRef.current = false;
+      const previousDropItem = autoFitDropRef.current;
+      autoFitDropRef.current = null;
       onLayoutChange(
-        shouldAutoFit
-          ? autoFitDroppedPanel(next, WORKSPACE_GRID_COLS)
+        previousDropItem
+          ? autoFitDroppedPanel(next, WORKSPACE_GRID_COLS, previousDropItem)
           : next,
       );
     },

--- a/zeus-web/src/layout/workspaceGrid.test.ts
+++ b/zeus-web/src/layout/workspaceGrid.test.ts
@@ -59,6 +59,54 @@ describe('workspace grid collision policy', () => {
     { i: 'below', x: 0, y: 2, w: 6, h: 2 },
   ];
 
+  it('keeps drag layouts sparse while clearing transient moved flags', () => {
+    const next = WORKSPACE_DRAG_COMPACTOR.compact(
+      [{ i: 'dragged', x: 3, y: 4, w: 5, h: 2, moved: true }],
+      24,
+    );
+
+    expect(next).toEqual([
+      { i: 'dragged', x: 3, y: 4, w: 5, h: 2, moved: false },
+    ]);
+  });
+
+  it('cascades drag displacement through the default right-column stack', () => {
+    const layout: Layout = cloneLayout([
+      { i: 'filter', x: 0, y: 0, w: 12, h: 10 },
+      { i: 'filterpresets', x: 12, y: 0, w: 6, h: 10 },
+      { i: 'hero', x: 0, y: 10, w: 18, h: 38 },
+      { i: 'vfo', x: 18, y: 0, w: 6, h: 11 },
+      { i: 'smeter', x: 18, y: 11, w: 6, h: 5 },
+      { i: 'tx', x: 18, y: 16, w: 6, h: 10 },
+      { i: 'txmeters', x: 18, y: 26, w: 6, h: 12 },
+      { i: 'dsp', x: 18, y: 38, w: 6, h: 10 },
+    ]);
+    const dragged = layout[1]!;
+
+    const moved = moveElement(
+      layout,
+      dragged,
+      18,
+      16,
+      true,
+      WORKSPACE_DRAG_COMPACTOR.preventCollision,
+      WORKSPACE_DRAG_COMPACTOR.type,
+      24,
+      WORKSPACE_DRAG_COMPACTOR.allowOverlap,
+    );
+    const next = WORKSPACE_DRAG_COMPACTOR.compact(moved, 24);
+
+    expect(next.find((item) => item.i === 'filterpresets')).toMatchObject({
+      x: 18,
+      y: 16,
+      moved: false,
+    });
+    expect(next.find((item) => item.i === 'tx')).toMatchObject({ y: 26 });
+    expect(next.find((item) => item.i === 'txmeters')).toMatchObject({ y: 36 });
+    expect(next.find((item) => item.i === 'dsp')).toMatchObject({ y: 48 });
+    expectNoCollisions(next);
+  });
+
   it('pushes a colliding panel out of the dragged panel target', () => {
     const layout = cloneLayout(baseLayout);
     const dragged = layout[0]!;

--- a/zeus-web/src/layout/workspaceGrid.test.ts
+++ b/zeus-web/src/layout/workspaceGrid.test.ts
@@ -29,30 +29,41 @@ function expectNoCollisions(layout: Layout) {
   }
 }
 
+function fitMovedElement(
+  layout: Layout,
+  dragged: Layout[number],
+  x: number | undefined,
+  y: number | undefined,
+) {
+  const previous = { ...dragged };
+  return autoFitDroppedPanel(
+    moveElement(
+      layout,
+      dragged,
+      x,
+      y,
+      true,
+      WORKSPACE_DRAG_COMPACTOR.preventCollision,
+      WORKSPACE_DRAG_COMPACTOR.type,
+      24,
+      WORKSPACE_DRAG_COMPACTOR.allowOverlap,
+    ),
+    24,
+    previous,
+  );
+}
+
 describe('workspace grid collision policy', () => {
   const baseLayout: Layout = [
     { i: 'dragged', x: 0, y: 0, w: 6, h: 2 },
     { i: 'below', x: 0, y: 2, w: 6, h: 2 },
   ];
 
-  it('pushes a colliding neighbor sideways when the dragged panel hits it', () => {
+  it('reorders a colliding panel into the dragged panel old slot', () => {
     const layout = cloneLayout(baseLayout);
     const dragged = layout[0]!;
 
-    const next = autoFitDroppedPanel(
-      moveElement(
-        layout,
-        dragged,
-        undefined,
-        2,
-        true,
-        WORKSPACE_DRAG_COMPACTOR.preventCollision,
-        WORKSPACE_DRAG_COMPACTOR.type,
-        24,
-        WORKSPACE_DRAG_COMPACTOR.allowOverlap,
-      ),
-      24,
-    );
+    const next = fitMovedElement(layout, dragged, undefined, 2);
 
     expect(next.find((item) => item.i === 'dragged')).toMatchObject({
       x: 0,
@@ -61,48 +72,37 @@ describe('workspace grid collision policy', () => {
       h: 2,
     });
     expect(next.find((item) => item.i === 'below')).toMatchObject({
-      x: 6,
-      y: 2,
+      x: 0,
+      y: 0,
     });
+    expectNoCollisions(next);
   });
 
-  it('shrinks the dragged panel to the available grid gap', () => {
+  it('pushes an occupied gap panel out of the dropped panel target', () => {
     const layout: Layout = cloneLayout([
       { i: 'dragged', x: 0, y: 0, w: 10, h: 2, minW: 2, minH: 2 },
       { i: 'right', x: 14, y: 0, w: 10, h: 2 },
     ]);
     const dragged = layout[0]!;
 
-    const next = autoFitDroppedPanel(
-      moveElement(
-        layout,
-        dragged,
-        8,
-        0,
-        true,
-        WORKSPACE_DRAG_COMPACTOR.preventCollision,
-        WORKSPACE_DRAG_COMPACTOR.type,
-        24,
-        WORKSPACE_DRAG_COMPACTOR.allowOverlap,
-      ),
-      24,
-    );
+    const next = fitMovedElement(layout, dragged, 8, 0);
 
     expect(next.find((item) => item.i === 'dragged')).toMatchObject({
       x: 8,
       y: 0,
-      w: 6,
-      h: 2,
-    });
-    expect(next.find((item) => item.i === 'right')).toMatchObject({
-      x: 14,
-      y: 0,
       w: 10,
       h: 2,
     });
+    expect(next.find((item) => item.i === 'right')).toMatchObject({
+      x: 0,
+      y: 2,
+      w: 10,
+      h: 2,
+    });
+    expectNoCollisions(next);
   });
 
-  it('moves and shrinks the dropped panel into a free rectangle inside the drop footprint', () => {
+  it('displaces occupied panels when the dropped footprint is covered', () => {
     const layout: Layout = cloneLayout([
       { i: 'dragged', x: 0, y: 0, w: 12, h: 8, minW: 4, minH: 2 },
       { i: 'left-block', x: 0, y: 0, w: 8, h: 6 },
@@ -110,70 +110,47 @@ describe('workspace grid collision policy', () => {
     ]);
     const dragged = layout[0]!;
 
-    const next = autoFitDroppedPanel(
-      moveElement(
-        layout,
-        dragged,
-        2,
-        2,
-        true,
-        WORKSPACE_DRAG_COMPACTOR.preventCollision,
-        WORKSPACE_DRAG_COMPACTOR.type,
-        24,
-        WORKSPACE_DRAG_COMPACTOR.allowOverlap,
-      ),
-      24,
-    );
+    const next = fitMovedElement(layout, dragged, 2, 2);
 
     expect(next.find((item) => item.i === 'dragged')).toMatchObject({
       x: 2,
-      y: 6,
+      y: 2,
       w: 12,
-      h: 4,
+      h: 8,
     });
     expectNoCollisions(next);
   });
 
-  it('does not push another panel down during drag auto-fit', () => {
-    const layout = cloneLayout(baseLayout);
+  it('pushes a colliding panel down when the previous slot is blocked', () => {
+    const layout: Layout = cloneLayout([
+      { i: 'dragged', x: 0, y: 0, w: 6, h: 2 },
+      { i: 'old-slot-neighbor', x: 6, y: 0, w: 6, h: 2 },
+      { i: 'wide', x: 0, y: 2, w: 12, h: 2 },
+    ]);
     const dragged = layout[0]!;
 
-    const next = autoFitDroppedPanel(
-      moveElement(
-        layout,
-        dragged,
-        undefined,
-        2,
-        true,
-        WORKSPACE_DRAG_COMPACTOR.preventCollision,
-        WORKSPACE_DRAG_COMPACTOR.type,
-        24,
-        WORKSPACE_DRAG_COMPACTOR.allowOverlap,
-      ),
-      24,
-    );
+    const next = fitMovedElement(layout, dragged, undefined, 2);
 
-    expect(next.find((item) => item.i === 'below')?.y).toBe(2);
+    expect(next.find((item) => item.i === 'dragged')).toMatchObject({
+      x: 0,
+      y: 2,
+      w: 6,
+      h: 2,
+    });
+    expect(next.find((item) => item.i === 'wide')).toMatchObject({
+      x: 0,
+      y: 4,
+      w: 12,
+      h: 2,
+    });
+    expectNoCollisions(next);
   });
 
   it('lets the dragged panel jump below the occupied slot once clear', () => {
     const layout = cloneLayout(baseLayout);
     const dragged = layout[0]!;
 
-    const next = autoFitDroppedPanel(
-      moveElement(
-        layout,
-        dragged,
-        undefined,
-        4,
-        true,
-        WORKSPACE_DRAG_COMPACTOR.preventCollision,
-        WORKSPACE_DRAG_COMPACTOR.type,
-        24,
-        WORKSPACE_DRAG_COMPACTOR.allowOverlap,
-      ),
-      24,
-    );
+    const next = fitMovedElement(layout, dragged, undefined, 4);
 
     expect(next.find((item) => item.i === 'dragged')?.y).toBe(4);
     expect(next.find((item) => item.i === 'below')?.y).toBe(2);

--- a/zeus-web/src/layout/workspaceGrid.test.ts
+++ b/zeus-web/src/layout/workspaceGrid.test.ts
@@ -59,7 +59,7 @@ describe('workspace grid collision policy', () => {
     { i: 'below', x: 0, y: 2, w: 6, h: 2 },
   ];
 
-  it('reorders a colliding panel into the dragged panel old slot', () => {
+  it('pushes a colliding panel out of the dragged panel target', () => {
     const layout = cloneLayout(baseLayout);
     const dragged = layout[0]!;
 
@@ -73,7 +73,7 @@ describe('workspace grid collision policy', () => {
     });
     expect(next.find((item) => item.i === 'below')).toMatchObject({
       x: 0,
-      y: 0,
+      y: 4,
     });
     expectNoCollisions(next);
   });
@@ -94,7 +94,7 @@ describe('workspace grid collision policy', () => {
       h: 2,
     });
     expect(next.find((item) => item.i === 'right')).toMatchObject({
-      x: 0,
+      x: 14,
       y: 2,
       w: 10,
       h: 2,

--- a/zeus-web/src/layout/workspaceGrid.ts
+++ b/zeus-web/src/layout/workspaceGrid.ts
@@ -3,11 +3,10 @@
 import { getCompactor } from 'react-grid-layout/core';
 import type { Compactor, Layout, LayoutItem } from 'react-grid-layout';
 
-// Keep the workspace sparse (no automatic gap-filling). Dragging temporarily
-// allows overlap so the operator can drop a panel where they mean it; the
-// final drag-stop layout is normalized by autoFitDroppedPanel below before it
-// is persisted.
-export const WORKSPACE_DRAG_COMPACTOR = getCompactor(null, true, false);
+// Keep the workspace sparse (no automatic gap-filling), but let RGL displace
+// occupied tiles during the live drag. The final drag-stop layout is normalized
+// by autoFitDroppedPanel below before it is persisted.
+export const WORKSPACE_DRAG_COMPACTOR = getCompactor(null, false, false);
 
 export const WORKSPACE_RESIZE_COMPACTOR: Compactor = {
   type: null,
@@ -20,9 +19,9 @@ export function autoFitDroppedPanel(
   cols: number,
   previousItem?: LayoutItem | null,
 ): Layout {
-  const dropped =
-    findDroppedItem(layout) ??
-    (previousItem ? layout.find((item) => item.i === previousItem.i) : undefined);
+  const dropped = previousItem
+    ? layout.find((item) => item.i === previousItem.i)
+    : findDroppedItem(layout);
   if (!dropped) return cloneLayout(layout);
 
   const base = cloneLayout(layout);

--- a/zeus-web/src/layout/workspaceGrid.ts
+++ b/zeus-web/src/layout/workspaceGrid.ts
@@ -15,8 +15,14 @@ export const WORKSPACE_RESIZE_COMPACTOR: Compactor = {
   compact: compactResizePushDown,
 };
 
-export function autoFitDroppedPanel(layout: Layout, cols: number): Layout {
-  const dropped = findDroppedItem(layout);
+export function autoFitDroppedPanel(
+  layout: Layout,
+  cols: number,
+  previousItem?: LayoutItem | null,
+): Layout {
+  const dropped =
+    findDroppedItem(layout) ??
+    (previousItem ? layout.find((item) => item.i === previousItem.i) : undefined);
   if (!dropped) return cloneLayout(layout);
 
   const base = cloneLayout(layout);
@@ -56,17 +62,18 @@ export function autoFitDroppedPanel(layout: Layout, cols: number): Layout {
           trialTarget.w = w;
           trialTarget.h = h;
 
-          const resolved = resolveAnchorCollisionsHorizontally(
+          const resolved = resolveAnchorCollisions(
             trial,
             target.i,
             cols,
+            previousItem,
           );
           if (!resolved) continue;
 
           const area = w * h;
           const originDistance =
             Math.abs(x - footprintX) + Math.abs(y - footprintY);
-          const movement = horizontalMovement(base, resolved.layout, target.i);
+          const movement = placementMovement(base, resolved.layout, target.i);
           if (
             !best ||
             originDistance < best.originDistance ||
@@ -132,14 +139,17 @@ function compactPushDownWithPriority(
   return next;
 }
 
-function resolveAnchorCollisionsHorizontally(
+function resolveAnchorCollisions(
   layout: Layout,
   anchorId: string,
   cols: number,
+  preferredSlot?: LayoutItem | null,
 ): { layout: LayoutItem[] } | null {
   const next = cloneLayout(layout);
-  const originalX = new Map(next.map((item) => [item.i, item.x]));
-  const maxPasses = Math.max(1, next.length);
+  const originalPlacement = new Map(
+    next.map((item) => [item.i, { x: item.x, y: item.y }]),
+  );
+  const maxPasses = Math.max(1, next.length * next.length);
 
   for (let pass = 0; pass < maxPasses; pass += 1) {
     const anchor = next.find((item) => item.i === anchorId);
@@ -155,16 +165,18 @@ function resolveAnchorCollisionsHorizontally(
 
     let moved = false;
     for (const item of collisions) {
-      const x = nearestHorizontalSlot(
+      const slot = nearestOpenSlot(
         next,
         item,
         anchor,
         cols,
-        originalX.get(item.i) ?? item.x,
+        originalPlacement.get(item.i) ?? item,
+        preferredSlot,
       );
-      if (x === null) return null;
-      if (x !== item.x) {
-        item.x = x;
+      if (slot === null) return null;
+      if (slot.x !== item.x || slot.y !== item.y) {
+        item.x = slot.x;
+        item.y = slot.y;
         moved = true;
       }
     }
@@ -175,34 +187,71 @@ function resolveAnchorCollisionsHorizontally(
   return anyCollision(next) ? null : { layout: next };
 }
 
-function nearestHorizontalSlot(
+function nearestOpenSlot(
   layout: LayoutItem[],
   item: LayoutItem,
   anchor: LayoutItem,
   cols: number,
-  originalX: number,
-): number | null {
+  originalPlacement: Pick<LayoutItem, 'x' | 'y'>,
+  preferredSlot?: Pick<LayoutItem, 'x' | 'y'> | null,
+): Pick<LayoutItem, 'x' | 'y'> | null {
   const maxX = cols - item.w;
   if (maxX < 0) return null;
 
-  let best: { x: number; distance: number } | null = null;
-  for (let x = 0; x <= maxX; x += 1) {
-    const candidate = { ...item, x };
-    if (collides(candidate, anchor)) continue;
-    if (
-      layout.some((other) => {
-        if (other.i === item.i || other.i === anchor.i) return false;
-        return collides(candidate, other);
-      })
-    ) {
-      continue;
-    }
+  const layoutBottom = layout.reduce(
+    (bottom, candidate) => Math.max(bottom, candidate.y + candidate.h),
+    0,
+  );
+  const tallestItem = layout.reduce(
+    (height, candidate) => Math.max(height, candidate.h),
+    item.h,
+  );
+  const maxY = layoutBottom + tallestItem * Math.max(1, layout.length);
 
-    const distance = Math.abs(x - originalX);
-    if (!best || distance < best.distance) best = { x, distance };
+  let best: {
+    x: number;
+    y: number;
+    preferredDistance: number;
+    distance: number;
+  } | null = null;
+
+  for (let y = 0; y <= maxY; y += 1) {
+    for (let x = 0; x <= maxX; x += 1) {
+      const candidate = { ...item, x, y };
+      if (collides(candidate, anchor)) continue;
+      if (
+        layout.some((other) => {
+          if (other.i === item.i || other.i === anchor.i) return false;
+          return collides(candidate, other);
+        })
+      ) {
+        continue;
+      }
+
+      const preferredDistance = preferredSlot
+        ? Math.abs(x - preferredSlot.x) + Math.abs(y - preferredSlot.y)
+        : 0;
+      const distance =
+        Math.abs(x - originalPlacement.x) + Math.abs(y - originalPlacement.y);
+      if (
+        !best ||
+        preferredDistance < best.preferredDistance ||
+        (preferredDistance === best.preferredDistance &&
+          distance < best.distance) ||
+        (preferredDistance === best.preferredDistance &&
+          distance === best.distance &&
+          y < best.y) ||
+        (preferredDistance === best.preferredDistance &&
+          distance === best.distance &&
+          y === best.y &&
+          x < best.x)
+      ) {
+        best = { x, y, preferredDistance, distance };
+      }
+    }
   }
 
-  return best?.x ?? null;
+  return best ? { x: best.x, y: best.y } : null;
 }
 
 function findDroppedItem(layout: Layout): LayoutItem | undefined {
@@ -231,15 +280,23 @@ function cloneLayout(layout: Layout): LayoutItem[] {
   return layout.map((item) => ({ ...item }));
 }
 
-function horizontalMovement(
+function placementMovement(
   before: Layout,
   after: Layout,
   excludeId: string,
 ): number {
-  const beforeX = new Map(before.map((item) => [item.i, item.x]));
+  const beforePlacement = new Map(
+    before.map((item) => [item.i, { x: item.x, y: item.y }]),
+  );
   return after.reduce((sum, item) => {
     if (item.i === excludeId) return sum;
-    return sum + Math.abs(item.x - (beforeX.get(item.i) ?? item.x));
+    const previous = beforePlacement.get(item.i);
+    if (!previous) return sum;
+    return (
+      sum +
+      Math.abs(item.x - previous.x) +
+      Math.abs(item.y - previous.y)
+    );
   }, 0);
 }
 

--- a/zeus-web/src/layout/workspaceGrid.ts
+++ b/zeus-web/src/layout/workspaceGrid.ts
@@ -1,18 +1,29 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { getCompactor } from 'react-grid-layout/core';
 import type { Compactor, Layout, LayoutItem } from 'react-grid-layout';
 
 // Keep the workspace sparse (no automatic gap-filling), but let RGL displace
 // occupied tiles during the live drag. The final drag-stop layout is normalized
 // by autoFitDroppedPanel below before it is persisted.
-export const WORKSPACE_DRAG_COMPACTOR = getCompactor(null, false, false);
+export const WORKSPACE_DRAG_COMPACTOR: Compactor = {
+  type: null,
+  allowOverlap: false,
+  compact: compactDragSparse,
+};
 
 export const WORKSPACE_RESIZE_COMPACTOR: Compactor = {
   type: null,
   allowOverlap: false,
   compact: compactResizePushDown,
 };
+
+function compactDragSparse(layout: Layout): Layout {
+  const priorityId = layout.find((item) => item.moved)?.i;
+  return compactPushDownWithPriority(layout, priorityId).map((item) => ({
+    ...item,
+    moved: false,
+  }));
+}
 
 export function autoFitDroppedPanel(
   layout: Layout,

--- a/zeus-web/src/state/__tests__/layout-store.test.ts
+++ b/zeus-web/src/state/__tests__/layout-store.test.ts
@@ -107,6 +107,43 @@ describe('layout-store / workspace tile mutators', () => {
     expect(afterRef).toBe(beforeRef);
   });
 
+  it('updateTilePlacementsInLayout mutates changed tile placements in one pass', () => {
+    const before = useLayoutStore.getState().workspace;
+    const [first, second] = before.tiles;
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
+
+    useLayoutStore.getState().updateTilePlacementsInLayout('default', [
+      { uid: first!.uid, x: 3, y: 4, w: first!.w, h: first!.h },
+      { uid: second!.uid, x: 9, y: 10, w: second!.w, h: second!.h },
+    ]);
+
+    const after = useLayoutStore.getState().workspace;
+    expect(after.tiles.find((t) => t.uid === first!.uid)).toMatchObject({
+      x: 3,
+      y: 4,
+    });
+    expect(after.tiles.find((t) => t.uid === second!.uid)).toMatchObject({
+      x: 9,
+      y: 10,
+    });
+  });
+
+  it('updateTilePlacementsInLayout is a no-op when nothing changed', () => {
+    const before = useLayoutStore.getState().workspace;
+    useLayoutStore.getState().updateTilePlacementsInLayout(
+      'default',
+      before.tiles.map((t) => ({
+        uid: t.uid,
+        x: t.x,
+        y: t.y,
+        w: t.w,
+        h: t.h,
+      })),
+    );
+    expect(useLayoutStore.getState().workspace).toBe(before);
+  });
+
   it('updateTileInstanceConfig stores the opaque config blob', () => {
     const uid = useLayoutStore.getState().addTile('meters');
     const cfg = { schemaVersion: 1, widgets: [], title: 'My Meters' };

--- a/zeus-web/src/state/layout-store.ts
+++ b/zeus-web/src/state/layout-store.ts
@@ -145,6 +145,13 @@ interface LayoutState {
     uid: string,
     layout: Pick<WorkspaceTile, 'x' | 'y' | 'w' | 'h'>,
   ) => void;
+  /** Replace multiple tile grid placements in a specific layout atomically. */
+  updateTilePlacementsInLayout: (
+    layoutId: string,
+    placements: Array<
+      Pick<WorkspaceTile, 'uid' | 'x' | 'y' | 'w' | 'h'>
+    >,
+  ) => void;
   /** Replace a tile's instanceConfig blob. */
   updateTileInstanceConfig: (uid: string, instanceConfig: unknown) => void;
   /** Replace a tile's instanceConfig blob in a specific layout. */
@@ -466,6 +473,38 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
       }
       changed = true;
       return { ...t, ...layout };
+    });
+    if (!changed) return;
+    applyWorkspaceMutationForLayout(set, get, layoutId, { ...workspace, tiles });
+  },
+
+  updateTilePlacementsInLayout: (layoutId, placements) => {
+    const target = findActive(get().layouts, layoutId);
+    if (!target && layoutId !== get().activeLayoutId) return;
+    if (placements.length === 0) return;
+    const workspace = layoutId === get().activeLayoutId
+      ? get().workspace
+      : parseLayoutOrDefault(target!.layoutJson);
+    const nextPlacements = new Map(
+      placements.map((p) => [
+        p.uid,
+        { x: p.x, y: p.y, w: p.w, h: p.h },
+      ]),
+    );
+    let changed = false;
+    const tiles = workspace.tiles.map((t) => {
+      const next = nextPlacements.get(t.uid);
+      if (!next) return t;
+      if (
+        t.x === next.x &&
+        t.y === next.y &&
+        t.w === next.w &&
+        t.h === next.h
+      ) {
+        return t;
+      }
+      changed = true;
+      return { ...t, ...next };
     });
     if (!changed) return;
     applyWorkspaceMutationForLayout(set, get, layoutId, { ...workspace, tiles });


### PR DESCRIPTION
## Summary
- Auto-fit dropped workspace panels into occupied grid slots and cascade displaced panels out of the way.
- Batch layout placement persistence so live drag updates do not trigger React max-update-depth / minified #185 loops.
- Add focused grid/store tests plus Playwright e2e coverage for dragging into an occupied stack without blanking or overlap.

## Verification
- npm --prefix zeus-web run test -- workspaceGrid.test.ts layout-store.test.ts
- npm --prefix zeus-web run typecheck
- npm --prefix zeus-web run test:e2e
- npm --prefix zeus-web run test
- npm --prefix zeus-web run lint
- npm --prefix zeus-web run smoke
- npm --prefix zeus-web run build