### PR TITLE
test: fix flaky VST hang-watchdog test on Windows CI

### DIFF
--- a/tests/Zeus.Plugins.Host.Tests/VstEngineSupervisorTests.cs
+++ b/tests/Zeus.Plugins.Host.Tests/VstEngineSupervisorTests.cs
@@ -73,7 +73,28 @@ public class VstEngineSupervisorTests
         public bool EngineReady { get; set; }
         public int WaitBudgetMs { get; set; }
         public int ResetCount { get; private set; }
-        public long DegradedBlocks => Interlocked.Read(ref _degraded);
+
+        /// <summary>
+        /// When > 0, every read of <see cref="DegradedBlocks"/> advances the counter
+        /// by this much — modelling an engine that keeps dropping blocks. This makes
+        /// the hang-watchdog deterministic: it sees a positive delta on every sampling
+        /// interval, so its consecutive-interval streak can't be reset by CI thread-pool
+        /// starvation (the source of a Windows-only flake when a background pump drove
+        /// the counter instead).
+        /// </summary>
+        public long DegradePerRead { get; set; }
+
+        public long DegradedBlocks
+        {
+            get
+            {
+                long step = DegradePerRead;
+                return step > 0
+                    ? Interlocked.Add(ref _degraded, step)
+                    : Interlocked.Read(ref _degraded);
+            }
+        }
+
         public void AddDegraded(long n) => Interlocked.Add(ref _degraded, n);
 
         public bool Process(ReadOnlySpan<float> input, Span<float> output, AudioBlockContext ctx)
@@ -197,16 +218,14 @@ public class VstEngineSupervisorTests
         Assert.Equal(VstEngineStartResult.Started, start);
         var bridge = getBridge()!;
 
-        // Simulate the engine no longer servicing blocks: degraded count climbs.
-        var stop = false;
-        var pump = Task.Run(async () =>
-        {
-            while (!stop) { bridge.AddDegraded(10); await Task.Delay(5); }
-        });
+        // Simulate the engine no longer servicing blocks: every watchdog sample of
+        // DegradedBlocks sees the count climb past the threshold. Driving it from the
+        // read (instead of a background pump) keeps the watchdog's consecutive-interval
+        // streak from being reset by CI thread-pool starvation — previously flaky on
+        // Windows, where the pump task could be starved long enough to zero the delta.
+        bridge.DegradePerRead = c.HangDegradedThreshold * 2;
 
         var recycled = await WaitUntilAsync(() => c.RestartCount >= 1, 4000);
-        stop = true;
-        await pump;
 
         Assert.True(recycled, "watchdog should force-recycle a hung engine");
         Assert.True(created.Count >= 2);


### PR DESCRIPTION
## Problem

`Build and Test` was failing on **windows-latest only** (macOS + Linux green). The pasted failure tail looked like `Zeus.Server.Tests`, but the real failure was a *concurrently-running* assembly — pulled from the actual job log:

```
Zeus.Plugins.Host.Tests.VstEngineSupervisorTests.HungEngine_IsRecycledByWatchdog [FAIL]
  watchdog should force-recycle a hung engine   (VstEngineSupervisorTests.cs:211)
```

## Root cause

The hang-watchdog force-recycles an engine only after it sees `delta >= HangDegradedThreshold` for **`HangConsecutiveIntervals` consecutive** 15ms sampling intervals. The test drove the degraded-block counter from a thread-pool pump:

```csharp
var pump = Task.Run(async () => { while (!stop) { bridge.AddDegraded(10); await Task.Delay(5); } });
```

Under solution-wide parallel `dotnet test` (7 assemblies at once), the Windows runner's thread pool saturates and starves the pump long enough that some watchdog ticks observe `delta = 0`, resetting `_hangStreak`. It then never accrues the required consecutive intervals within the 4s budget → timeout → fail.

This is a **test-harness artifact only**. Production watchdog config (1s intervals, hundreds of degraded blocks/sec under a real hang) is unaffected and not touched.

## Fix

Add a `DegradePerRead` mode to the test `FakeBridge`: when set, every read of `DegradedBlocks` advances the counter. The watchdog now observes a positive delta >= threshold on **every** sample, independent of thread scheduling — fully deterministic. The background pump is removed.

`DegradePerRead` defaults to `0` (old behaviour), so the other supervisor tests are unaffected.

## Verification

- Target test: 4s flaky timeout → **~110ms** deterministic pass.
- Full `Zeus.Plugins.Host.Tests` assembly: **112 passed / 4 skipped**, green on **5 consecutive** local runs.
- No production code changed (test-only).