### PR TITLE
feat: add local agent workflow automation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,10 +53,10 @@ bd dolt push          # Push beads data to remote
   of feature-branch commits.
 - Add `-TakeNext` to `finish-work.ps1` when a session should push its PR and
   immediately allocate the next ready issue into a fresh worktree.
-- Add `-PromoteLocal -RemoveWorktree -TakeNext` after a successful finish when
-  the session should open/update the PR, merge the finished branch into
-  `local/develop` for immediate combined local testing, remove the completed
-  worktree, and allocate the next ready issue.
+- Finish agent lanes with `pwsh scripts/finish-work.ps1 -Message "<subject>"
+  -Issue <id> -Autopilot`. Autopilot requires a PR, merges the finished branch
+  into `local/develop` for immediate combined local testing, removes the
+  completed worktree, and allocates the next ready issue.
 - The workflow scripts configure `core.hooksPath=.githooks`; the hooks block
   direct commits on `main` and `develop`.
 - After the PR merges, run `pwsh scripts/cleanup-merged-worktrees.ps1` to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,10 @@ bd dolt push          # Push beads data to remote
 - Start new work with `pwsh scripts/start-work.ps1 feature "<short name>"` or
   `pwsh scripts/start-work.ps1 fix "<short name>"`. Pass `-Issue <id>` when a
   beads issue exists or was just created.
+- For parallel agent lanes, use `pwsh scripts/take-work.ps1 -Count <n>` to
+  atomically claim ready beads work and create one worktree per claimed issue.
+  Narrow the queue with filters such as `-Type bug`, `-Priority 1`, or
+  `-Unassigned` when needed.
 - Use branch names such as `feature/<short-descriptive-name>` or
   `fix/<short-descriptive-name>`.
 - Worktrees live beside the primary checkout under
@@ -40,6 +44,8 @@ bd dolt push          # Push beads data to remote
   test gates, pushes the branch, pushes beads data, and opens a PR into
   `develop` when `gh` is available. It leaves passive beads JSONL exports out
   of feature-branch commits.
+- Add `-TakeNext` to `finish-work.ps1` when a session should push its PR and
+  immediately allocate the next ready issue into a fresh worktree.
 - The workflow scripts configure `core.hooksPath=.githooks`; the hooks block
   direct commits on `main` and `develop`.
 - After the PR merges, run `pwsh scripts/cleanup-merged-worktrees.ps1` to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,10 @@ bd dolt push          # Push beads data to remote
   of feature-branch commits.
 - Add `-TakeNext` to `finish-work.ps1` when a session should push its PR and
   immediately allocate the next ready issue into a fresh worktree.
+- Add `-PromoteLocal -RemoveWorktree -TakeNext` after a successful finish when
+  the session should open/update the PR, merge the finished branch into
+  `local/develop` for immediate combined local testing, remove the completed
+  worktree, and allocate the next ready issue.
 - The workflow scripts configure `core.hooksPath=.githooks`; the hooks block
   direct commits on `main` and `develop`.
 - After the PR merges, run `pwsh scripts/cleanup-merged-worktrees.ps1` to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,13 @@ bd dolt push          # Push beads data to remote
 
 ## Automatic Development Workflow
 
+- Fast local-trunk mode is available when you want the speed of committing
+  locally and testing the combined latest code immediately:
+  `pwsh scripts/start-local-dev.ps1` creates or updates `local/develop` from
+  `OpenHPSDR-Zeus-org/develop`. Commit logical changes there, then export a
+  clean PR branch with
+  `pwsh scripts/export-pr.ps1 -Commit HEAD -Name "<short name>" -Issue <id>`.
+  Use `-Range "<base>..HEAD"` to export multiple local commits as one PR.
 - For each new feature, bug fix, or similarly scoped development task,
   automatically work in a dedicated worktree from `develop` unless you are
   already in a task-specific worktree/branch created for that task.

--- a/scripts/export-pr.ps1
+++ b/scripts/export-pr.ps1
@@ -1,0 +1,325 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Export local trunk commit(s) into a clean PR branch based on org develop.
+#
+# Examples:
+#   pwsh scripts/export-pr.ps1 -Commit HEAD -Name "rx meter guard" -Issue zeus-123
+#   pwsh scripts/export-pr.ps1 -Range "HEAD~2..HEAD" -Kind fix -Name "audio underrun probe"
+
+[CmdletBinding()]
+param(
+    [string]$Commit = 'HEAD',
+    [string]$Range,
+    [string]$Name,
+    [string]$Issue,
+
+    [ValidateSet('auto', 'feature', 'feat', 'fix', 'bug', 'bugfix', 'chore', 'docs')]
+    [string]$Kind = 'auto',
+
+    [string]$Message,
+    [string]$PushRemote = 'origin',
+    [string]$BaseRemote = 'OpenHPSDR-Zeus-org',
+    [string]$BaseBranch = 'develop',
+    [string]$PrRepo = 'OpenHPSDR-Zeus-org/openhpsdr-zeus',
+    [string]$WorktreeRoot,
+    [switch]$Draft,
+    [switch]$SkipTests,
+    [switch]$NoPr,
+    [switch]$NoBdPush,
+    [switch]$NoFetch,
+    [switch]$DryRun
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Invoke-GitCapture {
+    param([string[]]$Arguments)
+
+    $output = & git @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "git $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
+    }
+
+    return $output
+}
+
+function Invoke-Native {
+    param(
+        [string]$Label,
+        [string]$File,
+        [string[]]$Arguments
+    )
+
+    Write-Host "==> $Label" -ForegroundColor Cyan
+    & $File @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Label failed with exit code $LASTEXITCODE"
+    }
+}
+
+function ConvertFrom-JsonOutput {
+    param(
+        [string[]]$Lines,
+        [string]$Context
+    )
+
+    $text = ($Lines -join [Environment]::NewLine).Trim()
+    if ([string]::IsNullOrWhiteSpace($text) -or $text -eq '[]') {
+        return $null
+    }
+
+    try {
+        return $text | ConvertFrom-Json
+    }
+    catch {
+        throw "Could not parse JSON from $Context`: $($_.Exception.Message)"
+    }
+}
+
+function Select-FirstJsonObject {
+    param($Value)
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    $items = @($Value)
+    if ($items.Count -eq 0) {
+        return $null
+    }
+
+    return $items[0]
+}
+
+function ConvertTo-Slug {
+    param([string]$Text)
+
+    $slug = $Text.ToLowerInvariant() -replace '[^a-z0-9]+', '-'
+    $slug = $slug.Trim('-') -replace '-{2,}', '-'
+    if ([string]::IsNullOrWhiteSpace($slug)) {
+        throw "Cannot derive a branch slug from '$Text'."
+    }
+
+    return $slug
+}
+
+function Get-WorkName {
+    param([string]$Text)
+
+    $slug = ConvertTo-Slug $Text
+    if ($slug.Length -le 72) {
+        return $slug
+    }
+
+    return $slug.Substring(0, 72).Trim('-')
+}
+
+function Get-BranchPrefix {
+    param([string]$RequestedKind)
+
+    switch ($RequestedKind) {
+        'feat' { return 'feature' }
+        'bug' { return 'fix' }
+        'bugfix' { return 'fix' }
+        default { return $RequestedKind }
+    }
+}
+
+function Resolve-BranchKind {
+    param(
+        [string]$IssueType,
+        [string]$RequestedKind
+    )
+
+    if ($RequestedKind -ne 'auto') {
+        return (Get-BranchPrefix $RequestedKind)
+    }
+
+    switch ($IssueType) {
+        'bug' { return 'fix' }
+        'chore' { return 'chore' }
+        default { return 'feature' }
+    }
+}
+
+function Test-GitRef {
+    param([string]$Ref)
+
+    & git show-ref --verify --quiet $Ref
+    return $LASTEXITCODE -eq 0
+}
+
+function Get-PrimaryWorktree {
+    $lines = Invoke-GitCapture @('worktree', 'list', '--porcelain')
+    foreach ($line in $lines) {
+        if ($line.StartsWith('worktree ')) {
+            return $line.Substring('worktree '.Length)
+        }
+    }
+
+    return (Invoke-GitCapture @('rev-parse', '--show-toplevel') | Select-Object -First 1)
+}
+
+function Get-IssueDetails {
+    param([string]$IssueId)
+
+    if (-not (Get-Command bd -ErrorAction SilentlyContinue)) {
+        return $null
+    }
+
+    $output = & bd show $IssueId --json
+    if ($LASTEXITCODE -ne 0) {
+        return $null
+    }
+
+    return Select-FirstJsonObject (ConvertFrom-JsonOutput @($output) "bd show $IssueId")
+}
+
+function Get-CommitList {
+    if ($Range) {
+        return @(Invoke-GitCapture @('rev-list', '--reverse', $Range))
+    }
+
+    return @((Invoke-GitCapture @('rev-parse', '--verify', "$Commit^{commit}") | Select-Object -First 1))
+}
+
+$repoRoot = (Invoke-GitCapture @('rev-parse', '--show-toplevel') | Select-Object -First 1)
+Set-Location $repoRoot
+
+$status = @(Invoke-GitCapture @('status', '--porcelain'))
+if ($status.Count -gt 0 -and -not $DryRun) {
+    throw "Working tree has uncommitted changes; commit before exporting a PR branch."
+}
+elseif ($status.Count -gt 0) {
+    Write-Warning "Working tree has uncommitted changes; dry run will only describe committed refs."
+}
+
+$commits = @(Get-CommitList)
+if ($commits.Count -eq 0) {
+    throw "No commits matched the requested export range."
+}
+
+$firstCommit = $commits[0]
+$commitSubject = (Invoke-GitCapture @('log', '-1', '--format=%s', $firstCommit) | Select-Object -First 1)
+$issueDetails = if ($Issue) { Get-IssueDetails $Issue } else { $null }
+$issueType = if ($issueDetails) { [string]$issueDetails.issue_type } else { '' }
+$sourceName = if ($Name) {
+    $Name
+}
+elseif ($issueDetails -and $issueDetails.title) {
+    [string]$issueDetails.title
+}
+else {
+    $commitSubject
+}
+
+$workName = Get-WorkName $sourceName
+$branchKind = Resolve-BranchKind -IssueType $issueType -RequestedKind $Kind
+$branchSlug = $workName
+if ($Issue) {
+    $branchSlug = "$(ConvertTo-Slug $Issue)-$branchSlug"
+}
+
+$branch = "$branchKind/$branchSlug"
+$worktreeName = $branch -replace '[\\/:-]+', '_'
+$baseRef = "$BaseRemote/$BaseBranch"
+
+if (-not $Message) {
+    $Message = $commitSubject
+}
+
+if (-not $WorktreeRoot) {
+    $primary = Resolve-Path -LiteralPath (Get-PrimaryWorktree)
+    $primaryPath = $primary.ProviderPath
+    $WorktreeRoot = Join-Path (Split-Path -Parent $primaryPath) "$(Split-Path -Leaf $primaryPath).Worktrees"
+}
+
+$exportPath = Join-Path $WorktreeRoot $worktreeName
+
+Write-Host "==> Export branch: $branch" -ForegroundColor Cyan
+Write-Host "==> Export worktree: $exportPath" -ForegroundColor Cyan
+Write-Host "==> Commits: $($commits.Count)" -ForegroundColor Cyan
+
+if ($DryRun) {
+    if (-not $NoFetch) {
+        Write-Host "DRY RUN: git fetch $BaseRemote $BaseBranch"
+    }
+
+    Write-Host "DRY RUN: git worktree add -b '$branch' '$exportPath' '$baseRef'"
+    foreach ($sha in $commits) {
+        Write-Host "DRY RUN: git -C '$exportPath' cherry-pick $sha"
+    }
+
+    Write-Host "DRY RUN: pwsh scripts/finish-work.ps1 -Message '$Message'$(if ($Issue) { " -Issue $Issue" })"
+    exit 0
+}
+
+if (-not $NoPr -and -not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    throw "GitHub CLI 'gh' is required to create the PR. Install gh or pass -NoPr."
+}
+
+if (-not $NoFetch) {
+    Invoke-Native "Fetch $BaseRemote/$BaseBranch" 'git' @('fetch', $BaseRemote, $BaseBranch)
+}
+
+if (-not (Test-GitRef "refs/remotes/$baseRef")) {
+    throw "Base ref '$baseRef' is not available. Check the remote name or run git fetch."
+}
+
+if (Test-GitRef "refs/heads/$branch") {
+    throw "Local branch '$branch' already exists. Pick a different -Name or delete/update the existing export branch."
+}
+
+if (Test-Path -LiteralPath $exportPath) {
+    throw "Export worktree path already exists: $exportPath"
+}
+
+New-Item -ItemType Directory -Path $WorktreeRoot -Force | Out-Null
+Invoke-Native "Create export worktree from $baseRef" 'git' @('worktree', 'add', '-b', $branch, $exportPath, $baseRef)
+
+try {
+    foreach ($sha in $commits) {
+        Invoke-Native "Cherry-pick $sha" 'git' @('-C', $exportPath, 'cherry-pick', $sha)
+    }
+
+    $finishScript = Join-Path $exportPath 'scripts/finish-work.ps1'
+    $finishArgs = @(
+        $finishScript,
+        '-Message', $Message,
+        '-PushRemote', $PushRemote,
+        '-BaseRemote', $BaseRemote,
+        '-BaseBranch', $BaseBranch,
+        '-PrRepo', $PrRepo
+    )
+
+    if ($Issue) {
+        $finishArgs += @('-Issue', $Issue)
+    }
+
+    if ($Draft) {
+        $finishArgs += '-Draft'
+    }
+
+    if ($SkipTests) {
+        $finishArgs += '-SkipTests'
+    }
+
+    if ($NoPr) {
+        $finishArgs += '-NoPr'
+    }
+
+    if ($NoBdPush) {
+        $finishArgs += '-NoBdPush'
+    }
+
+    Invoke-Native 'Finish export branch' 'pwsh' $finishArgs
+}
+catch {
+    Write-Warning "Export worktree left for inspection: $exportPath"
+    throw
+}
+
+Write-Host "==> Export complete" -ForegroundColor Green
+Write-Host "  Branch: $branch"
+Write-Host "  Worktree: $exportPath"

--- a/scripts/finish-work.ps1
+++ b/scripts/finish-work.ps1
@@ -100,12 +100,21 @@ function Invoke-TakeNextIfRequested {
     Invoke-Native 'Take next ready work' 'pwsh' @($takeWorkScript, '-Count', [string]$NextCount)
 }
 
-function Update-SubmodulesIfNeeded {
+function Update-RequiredSubmodulesIfNeeded {
     if (-not (Test-Path -LiteralPath (Join-Path $repoRoot '.gitmodules'))) {
         return
     }
 
-    Invoke-Native 'Update git submodules' 'git' @('submodule', 'update', '--init', '--recursive')
+    $deepCwModel = Join-Path $repoRoot 'zeus-web/external/deepcw-engine/model.onnx'
+    if (-not (Test-Path -LiteralPath $deepCwModel)) {
+        Invoke-Native 'Update DeepCW model submodule' 'git' @(
+            'submodule',
+            'update',
+            '--init',
+            '--',
+            'zeus-web/external/deepcw-engine'
+        )
+    }
 }
 
 $repoRoot = (Invoke-GitCapture @('rev-parse', '--show-toplevel') | Select-Object -First 1)
@@ -154,7 +163,7 @@ if ($ahead -eq 0) {
 }
 
 if (-not $SkipTests) {
-    Update-SubmodulesIfNeeded
+    Update-RequiredSubmodulesIfNeeded
     Invoke-Native 'Run dotnet tests' 'dotnet' @('test', 'Zeus.slnx')
 
     if (Test-Path -LiteralPath (Join-Path $repoRoot 'zeus-web/package.json')) {

--- a/scripts/finish-work.ps1
+++ b/scripts/finish-work.ps1
@@ -16,10 +16,14 @@ param(
     [string]$BaseBranch = 'develop',
     [string]$PrRepo = 'OpenHPSDR-Zeus-org/openhpsdr-zeus',
     [string]$BdRemote = 'kb2uka',
+    [string]$LocalBranch = 'local/develop',
+    [string]$WorktreeRoot,
     [switch]$Draft,
     [switch]$SkipTests,
     [switch]$NoPr,
     [switch]$NoBdPush,
+    [switch]$PromoteLocal,
+    [switch]$RemoveWorktree,
     [switch]$TakeNext,
     [ValidateRange(1, 32)]
     [int]$NextCount = 1
@@ -47,7 +51,7 @@ function Invoke-Native {
     )
 
     Write-Host "==> $Label" -ForegroundColor Cyan
-    & $File @Arguments
+    & $File @Arguments | ForEach-Object { Write-Host $_ }
     if ($LASTEXITCODE -ne 0) {
         throw "$Label failed with exit code $LASTEXITCODE"
     }
@@ -87,12 +91,71 @@ function Get-RemoteOwner {
     return $null
 }
 
+function Get-WorktreeRecords {
+    $records = @()
+    $current = $null
+    $lines = Invoke-GitCapture @('worktree', 'list', '--porcelain')
+
+    foreach ($line in $lines) {
+        if ($line.StartsWith('worktree ')) {
+            if ($current) {
+                $records += [pscustomobject]$current
+            }
+
+            $current = [ordered]@{
+                Path = $line.Substring('worktree '.Length)
+                Branch = $null
+            }
+            continue
+        }
+
+        if ($current -and $line.StartsWith('branch refs/heads/')) {
+            $current.Branch = $line.Substring('branch refs/heads/'.Length)
+        }
+    }
+
+    if ($current) {
+        $records += [pscustomobject]$current
+    }
+
+    return $records
+}
+
+function Get-PrimaryWorktree {
+    $records = Get-WorktreeRecords
+    if ($records.Count -eq 0) {
+        return (Invoke-GitCapture @('rev-parse', '--show-toplevel') | Select-Object -First 1)
+    }
+
+    return $records[0].Path
+}
+
+function Test-GitRef {
+    param([string]$Ref)
+
+    & git show-ref --verify --quiet $Ref
+    return $LASTEXITCODE -eq 0
+}
+
+function Test-PathInside {
+    param(
+        [string]$Path,
+        [string]$Parent
+    )
+
+    $resolvedPath = [System.IO.Path]::GetFullPath($Path)
+    $resolvedParent = [System.IO.Path]::GetFullPath($Parent).TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar
+    return $resolvedPath.StartsWith($resolvedParent, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
 function Invoke-TakeNextIfRequested {
+    param([string]$Root = $repoRoot)
+
     if (-not $TakeNext) {
         return
     }
 
-    $takeWorkScript = Join-Path $repoRoot 'scripts/take-work.ps1'
+    $takeWorkScript = Join-Path $Root 'scripts/take-work.ps1'
     if (-not (Test-Path -LiteralPath $takeWorkScript)) {
         throw "Cannot take next work; missing script: $takeWorkScript"
     }
@@ -117,6 +180,70 @@ function Update-RequiredSubmodulesIfNeeded {
     }
 }
 
+function Invoke-PromoteLocalIfRequested {
+    if (-not $PromoteLocal) {
+        return $repoRoot
+    }
+
+    $primary = Resolve-Path -LiteralPath (Get-PrimaryWorktree)
+    $primaryPath = $primary.ProviderPath
+    $primaryStatus = @(git -C $primaryPath status --porcelain)
+    if ($LASTEXITCODE -ne 0) {
+        throw "git -C '$primaryPath' status failed with exit code $LASTEXITCODE"
+    }
+
+    if ($primaryStatus.Count -gt 0) {
+        throw "Primary checkout has uncommitted changes; cannot promote into $LocalBranch`: $primaryPath"
+    }
+
+    Invoke-Native "Fetch $BaseRemote/$BaseBranch for local trunk" 'git' @('-C', $primaryPath, 'fetch', $BaseRemote, $BaseBranch)
+    $baseRef = "$BaseRemote/$BaseBranch"
+
+    if (Test-GitRef "refs/heads/$LocalBranch") {
+        Invoke-Native "Switch primary checkout to $LocalBranch" 'git' @('-C', $primaryPath, 'switch', $LocalBranch)
+        Invoke-Native "Rebase $LocalBranch onto $baseRef" 'git' @('-C', $primaryPath, 'rebase', $baseRef)
+    }
+    else {
+        Invoke-Native "Create $LocalBranch from $baseRef" 'git' @('-C', $primaryPath, 'switch', '-c', $LocalBranch, $baseRef)
+    }
+
+    Invoke-Native "Merge $branch into $LocalBranch" 'git' @('-C', $primaryPath, 'merge', '--no-edit', $branch)
+    return $primaryPath
+}
+
+function Remove-CurrentWorktreeIfRequested {
+    param([string]$PostActionRoot)
+
+    if (-not $RemoveWorktree) {
+        return $PostActionRoot
+    }
+
+    $primary = Resolve-Path -LiteralPath (Get-PrimaryWorktree)
+    $primaryPath = $primary.ProviderPath
+    if ([System.IO.Path]::GetFullPath($primaryPath) -eq [System.IO.Path]::GetFullPath($repoRoot)) {
+        throw "Refusing to remove the primary checkout as a worktree."
+    }
+
+    $rootForWorktrees = $WorktreeRoot
+    if (-not $rootForWorktrees) {
+        $rootForWorktrees = Join-Path (Split-Path -Parent $primaryPath) "$(Split-Path -Leaf $primaryPath).Worktrees"
+    }
+
+    if (-not (Test-PathInside -Path $repoRoot -Parent $rootForWorktrees)) {
+        throw "Refusing to remove worktree outside expected root '$rootForWorktrees': $repoRoot"
+    }
+
+    Set-Location $primaryPath
+    Invoke-Native "Remove finished worktree $branch" 'git' @('worktree', 'remove', '--force', $repoRoot)
+    return $primaryPath
+}
+
+function Invoke-PostPrSuccess {
+    $postActionRoot = Invoke-PromoteLocalIfRequested
+    $postActionRoot = Remove-CurrentWorktreeIfRequested -PostActionRoot $postActionRoot
+    Invoke-TakeNextIfRequested -Root $postActionRoot
+}
+
 $repoRoot = (Invoke-GitCapture @('rev-parse', '--show-toplevel') | Select-Object -First 1)
 Set-Location $repoRoot
 Set-GitHooksPath
@@ -126,8 +253,8 @@ Assert-FeatureBranch $branch
 
 Write-Host "==> Finishing $branch" -ForegroundColor Cyan
 
-if ($NoPr -and $TakeNext) {
-    throw "-TakeNext requires PR creation; remove -NoPr or run scripts/take-work.ps1 separately."
+if ($NoPr -and ($TakeNext -or $PromoteLocal -or $RemoveWorktree)) {
+    throw "-TakeNext, -PromoteLocal, and -RemoveWorktree require PR creation; remove -NoPr or run the follow-up step separately."
 }
 
 $status = @(Invoke-GitCapture @('status', '--porcelain'))
@@ -192,8 +319,8 @@ if ($NoPr) {
 }
 
 if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
-    if ($TakeNext) {
-        throw "Cannot use -TakeNext because GitHub CLI 'gh' is not installed or not on PATH; PR was not created."
+    if ($TakeNext -or $PromoteLocal -or $RemoveWorktree) {
+        throw "Cannot run post-PR actions because GitHub CLI 'gh' is not installed or not on PATH; PR was not created."
     }
 
     Write-Warning "GitHub CLI 'gh' is not installed or not on PATH. Branch is pushed; create the PR manually into $BaseBranch."
@@ -205,7 +332,7 @@ $head = if ($owner) { "$owner`:$branch" } else { $branch }
 $existingPr = & gh pr list --repo $PrRepo --head $branch --json url --jq '.[0].url' 2>$null
 if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($existingPr)) {
     Write-Host "==> PR already exists: $existingPr" -ForegroundColor Green
-    Invoke-TakeNextIfRequested
+    Invoke-PostPrSuccess
     exit 0
 }
 
@@ -233,4 +360,4 @@ if ($Draft) {
 }
 
 Invoke-Native 'Create PR' 'gh' $prArgs
-Invoke-TakeNextIfRequested
+Invoke-PostPrSuccess

--- a/scripts/finish-work.ps1
+++ b/scripts/finish-work.ps1
@@ -4,6 +4,7 @@
 #
 # Example:
 #   pwsh scripts/finish-work.ps1 -Message "fix: persist RX suite settings" -Issue zeus-123
+#   pwsh scripts/finish-work.ps1 -Message "fix: persist RX suite settings" -Issue zeus-123 -Autopilot
 
 [CmdletBinding()]
 param(
@@ -22,6 +23,7 @@ param(
     [switch]$SkipTests,
     [switch]$NoPr,
     [switch]$NoBdPush,
+    [switch]$Autopilot,
     [switch]$PromoteLocal,
     [switch]$RemoveWorktree,
     [switch]$TakeNext,
@@ -253,8 +255,14 @@ Assert-FeatureBranch $branch
 
 Write-Host "==> Finishing $branch" -ForegroundColor Cyan
 
+if ($Autopilot) {
+    $PromoteLocal = $true
+    $RemoveWorktree = $true
+    $TakeNext = $true
+}
+
 if ($NoPr -and ($TakeNext -or $PromoteLocal -or $RemoveWorktree)) {
-    throw "-TakeNext, -PromoteLocal, and -RemoveWorktree require PR creation; remove -NoPr or run the follow-up step separately."
+    throw "-Autopilot, -TakeNext, -PromoteLocal, and -RemoveWorktree require PR creation; remove -NoPr or run the follow-up step separately."
 }
 
 $status = @(Invoke-GitCapture @('status', '--porcelain'))

--- a/scripts/finish-work.ps1
+++ b/scripts/finish-work.ps1
@@ -100,6 +100,14 @@ function Invoke-TakeNextIfRequested {
     Invoke-Native 'Take next ready work' 'pwsh' @($takeWorkScript, '-Count', [string]$NextCount)
 }
 
+function Update-SubmodulesIfNeeded {
+    if (-not (Test-Path -LiteralPath (Join-Path $repoRoot '.gitmodules'))) {
+        return
+    }
+
+    Invoke-Native 'Update git submodules' 'git' @('submodule', 'update', '--init', '--recursive')
+}
+
 $repoRoot = (Invoke-GitCapture @('rev-parse', '--show-toplevel') | Select-Object -First 1)
 Set-Location $repoRoot
 Set-GitHooksPath
@@ -146,6 +154,7 @@ if ($ahead -eq 0) {
 }
 
 if (-not $SkipTests) {
+    Update-SubmodulesIfNeeded
     Invoke-Native 'Run dotnet tests' 'dotnet' @('test', 'Zeus.slnx')
 
     if (Test-Path -LiteralPath (Join-Path $repoRoot 'zeus-web/package.json')) {

--- a/scripts/finish-work.ps1
+++ b/scripts/finish-work.ps1
@@ -19,7 +19,10 @@ param(
     [switch]$Draft,
     [switch]$SkipTests,
     [switch]$NoPr,
-    [switch]$NoBdPush
+    [switch]$NoBdPush,
+    [switch]$TakeNext,
+    [ValidateRange(1, 32)]
+    [int]$NextCount = 1
 )
 
 Set-StrictMode -Version Latest
@@ -84,6 +87,19 @@ function Get-RemoteOwner {
     return $null
 }
 
+function Invoke-TakeNextIfRequested {
+    if (-not $TakeNext) {
+        return
+    }
+
+    $takeWorkScript = Join-Path $repoRoot 'scripts/take-work.ps1'
+    if (-not (Test-Path -LiteralPath $takeWorkScript)) {
+        throw "Cannot take next work; missing script: $takeWorkScript"
+    }
+
+    Invoke-Native 'Take next ready work' 'pwsh' @($takeWorkScript, '-Count', [string]$NextCount)
+}
+
 $repoRoot = (Invoke-GitCapture @('rev-parse', '--show-toplevel') | Select-Object -First 1)
 Set-Location $repoRoot
 Set-GitHooksPath
@@ -92,6 +108,10 @@ $branch = (Invoke-GitCapture @('branch', '--show-current') | Select-Object -Firs
 Assert-FeatureBranch $branch
 
 Write-Host "==> Finishing $branch" -ForegroundColor Cyan
+
+if ($NoPr -and $TakeNext) {
+    throw "-TakeNext requires PR creation; remove -NoPr or run scripts/take-work.ps1 separately."
+}
 
 $status = @(Invoke-GitCapture @('status', '--porcelain'))
 if ($status.Count -gt 0) {
@@ -149,10 +169,15 @@ if (-not $NoBdPush -and (Get-Command bd -ErrorAction SilentlyContinue)) {
 
 if ($NoPr) {
     Write-Host "==> PR creation skipped because -NoPr was supplied" -ForegroundColor Yellow
+    Invoke-TakeNextIfRequested
     exit 0
 }
 
 if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    if ($TakeNext) {
+        throw "Cannot use -TakeNext because GitHub CLI 'gh' is not installed or not on PATH; PR was not created."
+    }
+
     Write-Warning "GitHub CLI 'gh' is not installed or not on PATH. Branch is pushed; create the PR manually into $BaseBranch."
     exit 0
 }
@@ -162,6 +187,7 @@ $head = if ($owner) { "$owner`:$branch" } else { $branch }
 $existingPr = & gh pr list --repo $PrRepo --head $branch --json url --jq '.[0].url' 2>$null
 if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($existingPr)) {
     Write-Host "==> PR already exists: $existingPr" -ForegroundColor Green
+    Invoke-TakeNextIfRequested
     exit 0
 }
 
@@ -189,3 +215,4 @@ if ($Draft) {
 }
 
 Invoke-Native 'Create PR' 'gh' $prArgs
+Invoke-TakeNextIfRequested

--- a/scripts/start-local-dev.ps1
+++ b/scripts/start-local-dev.ps1
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Switch to a fast local integration branch that tracks the latest org develop.
+# Commit locally here, then export logical commits with scripts/export-pr.ps1.
+#
+# Example:
+#   pwsh scripts/start-local-dev.ps1
+
+[CmdletBinding()]
+param(
+    [string]$Branch = 'local/develop',
+    [string]$BaseRemote = 'OpenHPSDR-Zeus-org',
+    [string]$BaseBranch = 'develop',
+    [switch]$NoFetch
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Invoke-GitCapture {
+    param([string[]]$Arguments)
+
+    $output = & git @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "git $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
+    }
+
+    return $output
+}
+
+function Invoke-Native {
+    param(
+        [string]$Label,
+        [string]$File,
+        [string[]]$Arguments
+    )
+
+    Write-Host "==> $Label" -ForegroundColor Cyan
+    & $File @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Label failed with exit code $LASTEXITCODE"
+    }
+}
+
+function Set-GitHooksPath {
+    if (-not (Test-Path -LiteralPath '.githooks')) {
+        return
+    }
+
+    $configured = & git config --get core.hooksPath
+    if ($LASTEXITCODE -ne 0 -or $configured -ne '.githooks') {
+        Invoke-Native 'Configure git hooks path' 'git' @('config', 'core.hooksPath', '.githooks')
+    }
+}
+
+function Test-GitRef {
+    param([string]$Ref)
+
+    & git show-ref --verify --quiet $Ref
+    return $LASTEXITCODE -eq 0
+}
+
+$repoRoot = (Invoke-GitCapture @('rev-parse', '--show-toplevel') | Select-Object -First 1)
+Set-Location $repoRoot
+Set-GitHooksPath
+
+$status = @(Invoke-GitCapture @('status', '--porcelain'))
+if ($status.Count -gt 0) {
+    throw "Working tree has uncommitted changes; commit or stash before switching local trunks."
+}
+
+if (-not $NoFetch) {
+    Invoke-Native "Fetch $BaseRemote/$BaseBranch" 'git' @('fetch', $BaseRemote, $BaseBranch)
+}
+
+$baseRef = "$BaseRemote/$BaseBranch"
+if (-not (Test-GitRef "refs/remotes/$baseRef")) {
+    throw "Base ref '$baseRef' is not available. Check the remote name or run git fetch."
+}
+
+if (Test-GitRef "refs/heads/$Branch") {
+    Invoke-Native "Switch to $Branch" 'git' @('switch', $Branch)
+    Invoke-Native "Rebase $Branch onto $baseRef" 'git' @('rebase', $baseRef)
+}
+else {
+    Invoke-Native "Create $Branch from $baseRef" 'git' @('switch', '-c', $Branch, $baseRef)
+}
+
+Write-Host "==> Local trunk ready" -ForegroundColor Green
+Write-Host "  Commit normally on $Branch."
+Write-Host "  Export a PR with: pwsh scripts/export-pr.ps1 -Commit HEAD -Name '<short name>' -Issue <id>"

--- a/scripts/start-work.ps1
+++ b/scripts/start-work.ps1
@@ -20,7 +20,8 @@ param(
     [string]$BaseBranch = 'develop',
     [string]$WorktreeRoot,
     [switch]$NoFetch,
-    [switch]$DryRun
+    [switch]$DryRun,
+    [switch]$NoClaim
 )
 
 Set-StrictMode -Version Latest
@@ -175,7 +176,7 @@ if ($DryRun) {
         Write-Host "DRY RUN: git worktree add -b '$branch' '$worktreePath' '$BaseRemote/$BaseBranch'"
     }
 
-    if ($Issue) {
+    if ($Issue -and -not $NoClaim) {
         Write-Host "DRY RUN: bd update $Issue --claim"
     }
 
@@ -200,7 +201,7 @@ else {
     Invoke-Native "Create worktree from $baseRef" 'git' @('worktree', 'add', '-b', $branch, $worktreePath, $baseRef)
 }
 
-if ($Issue -and (Get-Command bd -ErrorAction SilentlyContinue)) {
+if ($Issue -and -not $NoClaim -and (Get-Command bd -ErrorAction SilentlyContinue)) {
     try {
         Invoke-Native "Claim beads issue $Issue" 'bd' @('update', $Issue, '--claim')
     }

--- a/scripts/take-work.ps1
+++ b/scripts/take-work.ps1
@@ -1,0 +1,394 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Claim ready beads work and prepare one or more isolated Zeus worktrees.
+#
+# Examples:
+#   pwsh scripts/take-work.ps1 -Count 3 -Unassigned
+#   pwsh scripts/take-work.ps1 -Issue zeus-123
+#   pwsh scripts/take-work.ps1 -Type bug -Priority 1
+
+[CmdletBinding()]
+param(
+    [ValidateRange(1, 32)]
+    [int]$Count = 1,
+
+    [string[]]$Issue,
+
+    [ValidateSet('auto', 'feature', 'feat', 'fix', 'bug', 'bugfix', 'chore', 'docs')]
+    [string]$Kind = 'auto',
+
+    [string]$Type,
+    [int]$Priority = -1,
+    [string[]]$Label,
+    [string[]]$ExcludeLabel,
+    [string[]]$ExcludeType,
+    [switch]$Unassigned,
+
+    [string]$BaseRemote = 'OpenHPSDR-Zeus-org',
+    [string]$BaseBranch = 'develop',
+    [string]$WorktreeRoot,
+    [switch]$NoFetch,
+    [switch]$DryRun
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Invoke-GitCapture {
+    param([string[]]$Arguments)
+
+    $output = & git @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "git $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
+    }
+
+    return $output
+}
+
+function Invoke-NativeCapture {
+    param(
+        [string]$File,
+        [string[]]$Arguments,
+        [switch]$AllowFailure
+    )
+
+    $output = & $File @Arguments
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0 -and -not $AllowFailure) {
+        throw "$File $($Arguments -join ' ') failed with exit code $exitCode"
+    }
+
+    return [pscustomobject]@{
+        Output = @($output)
+        ExitCode = $exitCode
+    }
+}
+
+function Invoke-Native {
+    param(
+        [string]$Label,
+        [string]$File,
+        [string[]]$Arguments
+    )
+
+    Write-Host "==> $Label" -ForegroundColor Cyan
+    & $File @Arguments | ForEach-Object { Write-Host $_ }
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Label failed with exit code $LASTEXITCODE"
+    }
+}
+
+function ConvertFrom-JsonOutput {
+    param(
+        [string[]]$Lines,
+        [string]$Context
+    )
+
+    $text = ($Lines -join [Environment]::NewLine).Trim()
+    if ([string]::IsNullOrWhiteSpace($text) -or $text -eq '[]') {
+        return $null
+    }
+
+    try {
+        return $text | ConvertFrom-Json
+    }
+    catch {
+        throw "Could not parse JSON from $Context`: $($_.Exception.Message)"
+    }
+}
+
+function Select-FirstJsonObject {
+    param($Value)
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    $items = @($Value)
+    if ($items.Count -eq 0) {
+        return $null
+    }
+
+    return $items[0]
+}
+
+function ConvertTo-Slug {
+    param([string]$Text)
+
+    $slug = $Text.ToLowerInvariant() -replace '[^a-z0-9]+', '-'
+    $slug = $slug.Trim('-') -replace '-{2,}', '-'
+    if ([string]::IsNullOrWhiteSpace($slug)) {
+        throw "Cannot derive a branch slug from '$Text'."
+    }
+
+    return $slug
+}
+
+function Get-BranchPrefix {
+    param([string]$RequestedKind)
+
+    switch ($RequestedKind) {
+        'feat' { return 'feature' }
+        'bug' { return 'fix' }
+        'bugfix' { return 'fix' }
+        default { return $RequestedKind }
+    }
+}
+
+function Resolve-BranchKind {
+    param(
+        [string]$IssueType,
+        [string]$RequestedKind
+    )
+
+    if ($RequestedKind -ne 'auto') {
+        return (Get-BranchPrefix $RequestedKind)
+    }
+
+    switch ($IssueType) {
+        'bug' { return 'fix' }
+        'chore' { return 'chore' }
+        default { return 'feature' }
+    }
+}
+
+function Get-BranchName {
+    param(
+        [string]$BranchKind,
+        [string]$IssueId,
+        [string]$Title
+    )
+
+    $nameSlug = ConvertTo-Slug $Title
+    if ($IssueId) {
+        $issueSlug = ConvertTo-Slug $IssueId
+        $nameSlug = "$issueSlug-$nameSlug"
+    }
+
+    return "$BranchKind/$nameSlug"
+}
+
+function Get-WorkName {
+    param([string]$Title)
+
+    $slug = ConvertTo-Slug $Title
+    if ($slug.Length -le 72) {
+        return $slug
+    }
+
+    return $slug.Substring(0, 72).Trim('-')
+}
+
+function Get-WorktreeForBranch {
+    param([string]$Branch)
+
+    $currentPath = $null
+    $lines = Invoke-GitCapture @('worktree', 'list', '--porcelain')
+    foreach ($line in $lines) {
+        if ($line.StartsWith('worktree ')) {
+            $currentPath = $line.Substring('worktree '.Length)
+            continue
+        }
+
+        if ($line -eq "branch refs/heads/$Branch") {
+            return $currentPath
+        }
+    }
+
+    return $null
+}
+
+function Get-IssueDetails {
+    param([string]$IssueId)
+
+    if (-not (Get-Command bd -ErrorAction SilentlyContinue)) {
+        throw "bd is required to resolve beads issue '$IssueId'."
+    }
+
+    $result = Invoke-NativeCapture 'bd' @('show', $IssueId, '--json')
+    return Select-FirstJsonObject (ConvertFrom-JsonOutput $result.Output "bd show $IssueId")
+}
+
+function Get-ReadyIssues {
+    param(
+        [int]$Limit = 1,
+        [switch]$Claim
+    )
+
+    if (-not (Get-Command bd -ErrorAction SilentlyContinue)) {
+        throw "bd is required to inspect ready work."
+    }
+
+    $arguments = @('ready')
+    if ($Claim) {
+        $arguments += '--claim'
+    }
+
+    $arguments += @('--json', '--limit', [string]$Limit)
+    if ($Type) {
+        $arguments += @('--type', $Type)
+    }
+
+    if ($Priority -ge 0) {
+        $arguments += @('--priority', [string]$Priority)
+    }
+
+    if ($Unassigned) {
+        $arguments += '--unassigned'
+    }
+
+    foreach ($item in @($Label)) {
+        if ($item) {
+            $arguments += @('--label', $item)
+        }
+    }
+
+    foreach ($item in @($ExcludeLabel)) {
+        if ($item) {
+            $arguments += @('--exclude-label', $item)
+        }
+    }
+
+    foreach ($item in @($ExcludeType)) {
+        if ($item) {
+            $arguments += @('--exclude-type', $item)
+        }
+    }
+
+    $result = Invoke-NativeCapture 'bd' $arguments -AllowFailure
+    if ($result.ExitCode -ne 0) {
+        $details = ($result.Output -join [Environment]::NewLine).Trim()
+        if ($details) {
+            throw "bd $($arguments -join ' ') failed with exit code $($result.ExitCode): $details"
+        }
+
+        throw "bd $($arguments -join ' ') failed with exit code $($result.ExitCode)"
+    }
+
+    $json = ConvertFrom-JsonOutput $result.Output "bd $($arguments -join ' ')"
+    if ($null -eq $json) {
+        return @()
+    }
+
+    return @($json)
+}
+
+function Start-Lane {
+    param(
+        $IssueDetails,
+        [bool]$AlreadyClaimed
+    )
+
+    $issueId = [string]$IssueDetails.id
+    $title = [string]$IssueDetails.title
+    $issueType = [string]$IssueDetails.issue_type
+    if ([string]::IsNullOrWhiteSpace($title)) {
+        $title = $issueId
+    }
+
+    $workName = Get-WorkName $title
+    $branchKind = Resolve-BranchKind -IssueType $issueType -RequestedKind $Kind
+    $branch = Get-BranchName -BranchKind $branchKind -IssueId $issueId -Title $workName
+    $startScript = Join-Path $repoRoot 'scripts/start-work.ps1'
+
+    $arguments = @(
+        $branchKind,
+        $workName,
+        '-Issue', $issueId,
+        '-BaseRemote', $BaseRemote,
+        '-BaseBranch', $BaseBranch
+    )
+
+    if ($WorktreeRoot) {
+        $arguments += @('-WorktreeRoot', $WorktreeRoot)
+    }
+
+    if ($NoFetch) {
+        $arguments += '-NoFetch'
+    }
+
+    if ($DryRun) {
+        $arguments += '-DryRun'
+    }
+
+    if ($AlreadyClaimed) {
+        $arguments += '-NoClaim'
+    }
+
+    $pwshArguments = @($startScript) + $arguments
+    Invoke-Native "Prepare $issueId" 'pwsh' $pwshArguments
+
+    return [pscustomobject]@{
+        Issue = $issueId
+        Title = $title
+        Type = $issueType
+        Branch = $branch
+        Worktree = Get-WorktreeForBranch $branch
+    }
+}
+
+$repoRoot = (Invoke-GitCapture @('rev-parse', '--show-toplevel') | Select-Object -First 1)
+Set-Location $repoRoot
+
+$workItems = @()
+if ($Issue -and $Issue.Count -gt 0) {
+    foreach ($issueId in $Issue) {
+        $details = Get-IssueDetails $issueId
+        if ($null -eq $details) {
+            throw "Issue '$issueId' was not found."
+        }
+
+        $workItems += [pscustomobject]@{
+            Details = $details
+            AlreadyClaimed = $false
+        }
+    }
+}
+else {
+    if ($DryRun) {
+        Write-Host "DRY RUN: bd ready --claim would reserve each selected issue atomically." -ForegroundColor Yellow
+        foreach ($readyIssue in @(Get-ReadyIssues -Limit $Count)) {
+            $workItems += [pscustomobject]@{
+                Details = $readyIssue
+                AlreadyClaimed = $true
+            }
+        }
+
+        if ($workItems.Count -eq 0) {
+            Write-Warning "No ready beads work matched the requested filters."
+        }
+    }
+    else {
+        for ($i = 0; $i -lt $Count; $i++) {
+            $claimed = Select-FirstJsonObject @(Get-ReadyIssues -Limit 1 -Claim)
+            if ($null -eq $claimed) {
+                Write-Warning "No ready beads work matched the requested filters."
+                break
+            }
+
+            $workItems += [pscustomobject]@{
+                Details = $claimed
+                AlreadyClaimed = $true
+            }
+        }
+    }
+}
+
+if ($workItems.Count -eq 0) {
+    throw "No work was selected."
+}
+
+$lanes = @()
+foreach ($item in $workItems) {
+    $lanes += Start-Lane -IssueDetails $item.Details -AlreadyClaimed $item.AlreadyClaimed
+}
+
+Write-Host "==> Ready lanes" -ForegroundColor Green
+foreach ($lane in $lanes) {
+    Write-Host "  $($lane.Issue): $($lane.Title)"
+    Write-Host "    branch:   $($lane.Branch)"
+    if ($lane.Worktree) {
+        Write-Host "    worktree: $($lane.Worktree)"
+        Write-Host "    finish:   pwsh scripts/finish-work.ps1 -Message '<commit subject>' -Issue $($lane.Issue) -TakeNext"
+    }
+}

--- a/scripts/take-work.ps1
+++ b/scripts/take-work.ps1
@@ -389,6 +389,6 @@ foreach ($lane in $lanes) {
     Write-Host "    branch:   $($lane.Branch)"
     if ($lane.Worktree) {
         Write-Host "    worktree: $($lane.Worktree)"
-        Write-Host "    finish:   pwsh scripts/finish-work.ps1 -Message '<commit subject>' -Issue $($lane.Issue) -TakeNext"
     }
+    Write-Host "    finish:   pwsh scripts/finish-work.ps1 -Message '<commit subject>' -Issue $($lane.Issue) -Autopilot"
 }


### PR DESCRIPTION
## Summary
- Add `scripts/take-work.ps1` to atomically claim ready beads issues and prepare parallel worktree lanes.
- Add fast local-trunk tooling: `scripts/start-local-dev.ps1` and `scripts/export-pr.ps1` for local commits with clean PR export branches.
- Extend `finish-work.ps1` with a single normal lane finish switch: `-Autopilot`.
- `-Autopilot` requires a PR, then promotes the finished branch into `local/develop`, removes the completed worktree, and allocates the next ready issue.
- Keep lower-level `-TakeNext`, `-PromoteLocal`, and `-RemoveWorktree` switches for exceptional/manual cases.
- Limit finish-time submodule setup to the DeepCW model submodule needed by the frontend build on fresh worktrees.

## Normal agent loop
1. `pwsh scripts/take-work.ps1 -Count <n>`
2. Work in the created lane.
3. `pwsh scripts/finish-work.ps1 -Message "<subject>" -Issue <id> -Autopilot`

After step 3 succeeds, the script pushes/updates the PR, merges locally into `local/develop`, deletes the finished worktree, and takes the next issue.

## Verification
- PowerShell parser checks passed for `start-work.ps1`, `take-work.ps1`, `finish-work.ps1`, `start-local-dev.ps1`, and `export-pr.ps1`.
- `pwsh scripts/take-work.ps1 -Count 2 -DryRun -NoFetch -Type bug` passed.
- `pwsh scripts/take-work.ps1 -Issue zeus-lgli -DryRun -NoFetch` prints the `-Autopilot` finish command.
- `pwsh scripts/export-pr.ps1 -Commit HEAD -Name "agent workflow tooling" -Issue zeus-lgli -DryRun -NoFetch -SkipTests` passed.
- `npm --prefix zeus-web run test` passed locally: 90 files / 802 tests.
- Previous CI run: Ubuntu Build and Test passed; Windows Build and Test passed; macOS failed in an unrelated allocation-count test.

## Known blockers
- Local `dotnet test Zeus.slnx` is blocked by existing issue `zeus-9hld`: `Zeus.Server.Tests.DspModernizationValidationToolTests.WdspFixtureMatrixCarriesExternalOptInBypassProfile` timed out after the suite had built the frontend and passed the other visible project/test groups.
- CI macOS failed in `Zeus.Plugins.Host.Tests.AudioChainProcessNoAllocTests.Process_OverManyBlocks_DoesNotAllocate` with expected allocation count 0, actual 5848. Filed follow-up `zeus-jtu0`.

## Beads
- Beads: zeus-lgli
- Attempted `bd dolt push` to configured `origin` and documented `kb2uka`; both failed with DoltHub `PermissionDenied` in this environment.