### PR TITLE
chore: add .mailmap to consolidate contributor identities

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,15 @@
+# .mailmap — canonical contributor identities for `git shortlog`, `git log`, and
+# GitHub contributor stats. Folds each person's alternate name/email combos into
+# one identity. Display-only: this does NOT rewrite history.
+#
+# Format: Canonical Name <canonical@email> [Alt Name] <alt@email>
+
+# Christian Suarez (N9WAR) — also authors via the GitHub web UI as iamexemplar
+Christian Suarez (N9WAR) <christiantsuarez@gmail.com> EXE <133596045+iamexemplar@users.noreply.github.com>
+
+# Brian Keating — Enverus work address + name-only variant folded into personal identity
+Brian Keating <b@briankeating.net> <brian.keating@enverus.com>
+Brian Keating <b@briankeating.net> Brian <b@briankeating.net>
+
+# Doug (KB2UKA) — GitHub web-merge noreply identity folded in; casing normalized
+KB2UKA <kb2uka80@gmail.com> Kb2UKA <95453216+Kb2uka@users.noreply.github.com>


### PR DESCRIPTION
## What

Adds a `.mailmap` that folds each contributor's alternate name/email combos into a single canonical identity for `git shortlog`, `git log`, and GitHub contributor stats.

| Person | Was fragmented across | Now |
|---|---|---|
| Christian Suarez (N9WAR) | personal email + web-UI `iamexemplar` | one identity (1065 commits) |
| Brian Keating | Enverus work email + `b@briankeating.net` + name-only `Brian` | `Brian Keating <b@briankeating.net>` (734) |
| KB2UKA | `kb2uka80@gmail.com` + GitHub web-merge noreply | `KB2UKA <kb2uka80@gmail.com>` (536) |

## Why

Contributors appeared under multiple identities, splitting their commit counts. Merge commits are also attributed to whoever clicked the merge button (the web-UI noreply identity); this consolidates that back to the person.

## Safety

Display-only. `.mailmap` does **not** rewrite history, change commit SHAs, or touch authorship in stored objects. Fully reversible by deleting the file. Bot identities were intentionally left untouched.

## Notes for maintainers

Canonical email choices (Brian -> personal, KB2UKA -> gmail) are easy to flip if a different address is preferred.