### PR TITLE
fix: magnet-swap workspace panels

### DIFF
--- a/scripts/finish-work.ps1
+++ b/scripts/finish-work.ps1
@@ -15,7 +15,7 @@ param(
     [string]$BaseRemote = 'OpenHPSDR-Zeus-org',
     [string]$BaseBranch = 'develop',
     [string]$PrRepo = 'OpenHPSDR-Zeus-org/openhpsdr-zeus',
-    [string]$BdRemote = 'kb2uka',
+    [string]$BdRemote = 'origin',
     [switch]$Draft,
     [switch]$SkipTests,
     [switch]$NoPr,

--- a/zeus-web/e2e/workspace-panel-drag.spec.ts
+++ b/zeus-web/e2e/workspace-panel-drag.spec.ts
@@ -165,6 +165,19 @@ function overlapPairs(rects: TileRect[]) {
   return pairs;
 }
 
+function rectFor(rects: TileRect[], uid: string) {
+  const rect = rects.find((r) => r.uid === uid);
+  if (!rect) throw new Error(`Expected rect for ${uid}`);
+  return rect;
+}
+
+function expectRectNear(actual: TileRect, expected: TileRect) {
+  expect(Math.abs(actual.x - expected.x)).toBeLessThanOrEqual(4);
+  expect(Math.abs(actual.y - expected.y)).toBeLessThanOrEqual(4);
+  expect(Math.abs(actual.width - expected.width)).toBeLessThanOrEqual(4);
+  expect(Math.abs(actual.height - expected.height)).toBeLessThanOrEqual(4);
+}
+
 async function centerOf(locator: ReturnType<Page['locator']>) {
   const box = await locator.boundingBox();
   if (!box) throw new Error('Expected locator to have a bounding box');
@@ -189,6 +202,8 @@ test('dragging a panel into an occupied workspace slot displaces panels without 
 
   const before = await tileRects(page);
   expect(before).toHaveLength(8);
+  const draggedBefore = rectFor(before, 'tile-filterpresets');
+  const targetBefore = rectFor(before, 'tile-tx');
 
   const start = await centerOf(draggedHeader);
   const target = await centerOf(targetHeader);
@@ -200,6 +215,8 @@ test('dragging a panel into an occupied workspace slot displaces panels without 
   const duringDrag = await tileRects(page);
   expect(duringDrag).toHaveLength(8);
   expect(overlapPairs(duringDrag)).toEqual([]);
+  expectRectNear(rectFor(duringDrag, 'tile-filterpresets'), targetBefore);
+  expectRectNear(rectFor(duringDrag, 'tile-tx'), draggedBefore);
 
   await page.mouse.up();
   await page.waitForTimeout(500);
@@ -207,6 +224,8 @@ test('dragging a panel into an occupied workspace slot displaces panels without 
   const after = await tileRects(page);
   expect(after).toHaveLength(8);
   expect(overlapPairs(after)).toEqual([]);
+  expectRectNear(rectFor(after, 'tile-filterpresets'), targetBefore);
+  expectRectNear(rectFor(after, 'tile-tx'), draggedBefore);
   expect(pageErrors).not.toContainEqual(
     expect.stringContaining('Maximum update depth exceeded'),
   );

--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -38,9 +38,10 @@ import { useWorkspace } from './WorkspaceContext';
 import { parseLayoutOrDefault, useLayoutStore } from '../state/layout-store';
 import { getPanelDef } from './panels';
 import {
-  WORKSPACE_DRAG_COMPACTOR,
   WORKSPACE_RESIZE_COMPACTOR,
   autoFitDroppedPanel,
+  createWorkspaceDragCompactor,
+  type WorkspaceDragStartSnapshot,
 } from './workspaceGrid';
 import { usePluginPanels } from '../plugins/runtime/usePluginPanels';
 import {
@@ -237,7 +238,8 @@ function WorkspaceCanvas({
   const [containerHeight, setContainerHeight] = useState(0);
   const [gridInteraction, setGridInteraction] =
     useState<GridInteraction>(null);
-  const autoFitDropRef = useRef<LayoutItem | null>(null);
+  const dragStartRef = useRef<WorkspaceDragStartSnapshot | null>(null);
+  const autoFitDropRef = useRef<WorkspaceDragStartSnapshot | null>(null);
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
@@ -293,10 +295,14 @@ function WorkspaceCanvas({
     );
   }, [containerHeight, rowMargin, targetRows]);
 
+  const workspaceDragCompactor = useMemo(
+    () => createWorkspaceDragCompactor(() => dragStartRef.current),
+    [],
+  );
   const workspaceCompactor =
     gridInteraction === 'resize'
       ? WORKSPACE_RESIZE_COMPACTOR
-      : WORKSPACE_DRAG_COMPACTOR;
+      : workspaceDragCompactor;
 
   const onPointerDownCapture = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>) => {
@@ -318,7 +324,18 @@ function WorkspaceCanvas({
     [],
   );
 
-  const onDragStart = useCallback(() => setGridInteraction('drag'), []);
+  const onDragStart = useCallback((
+    layout: Layout,
+    oldItem: LayoutItem | null,
+  ) => {
+    dragStartRef.current = oldItem
+      ? {
+          item: { ...oldItem },
+          layout: layout.map((item) => ({ ...item })),
+        }
+      : null;
+    setGridInteraction('drag');
+  }, []);
   const onResizeStart = useCallback(() => setGridInteraction('resize'), []);
   const onDragStop = useCallback((
     _layout: Layout,
@@ -330,12 +347,14 @@ function WorkspaceCanvas({
       newItem &&
       (oldItem.x !== newItem.x || oldItem.y !== newItem.y)
     )
-      ? { ...oldItem }
+      ? dragStartRef.current ?? { item: { ...oldItem }, layout: [] }
       : null;
+    dragStartRef.current = null;
     setGridInteraction(null);
   }, []);
   const onResizeStop = useCallback(() => {
     autoFitDropRef.current = null;
+    dragStartRef.current = null;
     setGridInteraction(null);
   }, []);
   const handleLayoutChange = useCallback(

--- a/zeus-web/src/layout/workspaceGrid.test.ts
+++ b/zeus-web/src/layout/workspaceGrid.test.ts
@@ -8,6 +8,7 @@ import {
   WORKSPACE_DRAG_COMPACTOR,
   WORKSPACE_RESIZE_COMPACTOR,
   autoFitDroppedPanel,
+  createWorkspaceDragCompactor,
 } from './workspaceGrid';
 
 function cloneLayout(layout: Layout): Layout {
@@ -36,6 +37,7 @@ function fitMovedElement(
   y: number | undefined,
 ) {
   const previous = { ...dragged };
+  const previousLayout = cloneLayout(layout);
   return autoFitDroppedPanel(
     moveElement(
       layout,
@@ -49,7 +51,31 @@ function fitMovedElement(
       WORKSPACE_DRAG_COMPACTOR.allowOverlap,
     ),
     24,
-    previous,
+    { item: previous, layout: previousLayout },
+  );
+}
+
+function dragAndCompact(
+  layout: Layout,
+  dragged: Layout[number],
+  x: number | undefined,
+  y: number | undefined,
+) {
+  const dragStart = { item: { ...dragged }, layout: cloneLayout(layout) };
+  const compactor = createWorkspaceDragCompactor(() => dragStart);
+  return compactor.compact(
+    moveElement(
+      layout,
+      dragged,
+      x,
+      y,
+      true,
+      compactor.preventCollision,
+      compactor.type,
+      24,
+      compactor.allowOverlap,
+    ),
+    24,
   );
 }
 
@@ -70,7 +96,25 @@ describe('workspace grid collision policy', () => {
     ]);
   });
 
-  it('cascades drag displacement through the default right-column stack', () => {
+  it('swaps a lower panel into the dragged panel old slot during live drag', () => {
+    const layout = cloneLayout(baseLayout);
+    const dragged = layout[0]!;
+
+    const next = dragAndCompact(layout, dragged, undefined, 2);
+
+    expect(next.find((item) => item.i === 'dragged')).toMatchObject({
+      x: 0,
+      y: 2,
+      moved: false,
+    });
+    expect(next.find((item) => item.i === 'below')).toMatchObject({
+      x: 0,
+      y: 0,
+    });
+    expectNoCollisions(next);
+  });
+
+  it('swaps the covered panel into the old slot and keeps the stack tight', () => {
     const layout: Layout = cloneLayout([
       { i: 'filter', x: 0, y: 0, w: 12, h: 10 },
       { i: 'filterpresets', x: 12, y: 0, w: 6, h: 10 },
@@ -83,31 +127,23 @@ describe('workspace grid collision policy', () => {
     ]);
     const dragged = layout[1]!;
 
-    const moved = moveElement(
-      layout,
-      dragged,
-      18,
-      16,
-      true,
-      WORKSPACE_DRAG_COMPACTOR.preventCollision,
-      WORKSPACE_DRAG_COMPACTOR.type,
-      24,
-      WORKSPACE_DRAG_COMPACTOR.allowOverlap,
-    );
-    const next = WORKSPACE_DRAG_COMPACTOR.compact(moved, 24);
+    const next = dragAndCompact(layout, dragged, 18, 16);
 
     expect(next.find((item) => item.i === 'filterpresets')).toMatchObject({
       x: 18,
       y: 16,
       moved: false,
     });
-    expect(next.find((item) => item.i === 'tx')).toMatchObject({ y: 26 });
-    expect(next.find((item) => item.i === 'txmeters')).toMatchObject({ y: 36 });
-    expect(next.find((item) => item.i === 'dsp')).toMatchObject({ y: 48 });
+    expect(next.find((item) => item.i === 'tx')).toMatchObject({
+      x: 12,
+      y: 0,
+    });
+    expect(next.find((item) => item.i === 'txmeters')).toMatchObject({ y: 26 });
+    expect(next.find((item) => item.i === 'dsp')).toMatchObject({ y: 38 });
     expectNoCollisions(next);
   });
 
-  it('pushes a colliding panel out of the dragged panel target', () => {
+  it('swaps a colliding panel into the dragged panel old slot on drop', () => {
     const layout = cloneLayout(baseLayout);
     const dragged = layout[0]!;
 
@@ -121,7 +157,7 @@ describe('workspace grid collision policy', () => {
     });
     expect(next.find((item) => item.i === 'below')).toMatchObject({
       x: 0,
-      y: 4,
+      y: 0,
     });
     expectNoCollisions(next);
   });
@@ -142,7 +178,7 @@ describe('workspace grid collision policy', () => {
       h: 2,
     });
     expect(next.find((item) => item.i === 'right')).toMatchObject({
-      x: 14,
+      x: 0,
       y: 2,
       w: 10,
       h: 2,
@@ -194,14 +230,14 @@ describe('workspace grid collision policy', () => {
     expectNoCollisions(next);
   });
 
-  it('lets the dragged panel jump below the occupied slot once clear', () => {
+  it('snaps the dragged panel up against the occupied slot once clear', () => {
     const layout = cloneLayout(baseLayout);
     const dragged = layout[0]!;
 
     const next = fitMovedElement(layout, dragged, undefined, 4);
 
-    expect(next.find((item) => item.i === 'dragged')?.y).toBe(4);
-    expect(next.find((item) => item.i === 'below')?.y).toBe(2);
+    expect(next.find((item) => item.i === 'dragged')?.y).toBe(2);
+    expect(next.find((item) => item.i === 'below')?.y).toBe(0);
   });
 
   it('pushes a lower panel down when resize grows into it', () => {

--- a/zeus-web/src/layout/workspaceGrid.ts
+++ b/zeus-web/src/layout/workspaceGrid.ts
@@ -2,14 +2,26 @@
 
 import type { Compactor, Layout, LayoutItem } from 'react-grid-layout';
 
-// Keep the workspace sparse (no automatic gap-filling), but let RGL displace
-// occupied tiles during the live drag. The final drag-stop layout is normalized
-// by autoFitDroppedPanel below before it is persisted.
-export const WORKSPACE_DRAG_COMPACTOR: Compactor = {
-  type: null,
-  allowOverlap: false,
-  compact: compactDragSparse,
-};
+export interface WorkspaceDragStartSnapshot {
+  item: LayoutItem;
+  layout: Layout;
+}
+
+// Keep horizontal placement operator-directed, but make vertical placement
+// magnetic: when a tile is dragged into an occupied slot, the displaced tile
+// should swap into the dragged tile's old slot and the stack should close up.
+export const WORKSPACE_DRAG_COMPACTOR = createWorkspaceDragCompactor();
+
+export function createWorkspaceDragCompactor(
+  getDragStart?: () => WorkspaceDragStartSnapshot | null,
+): Compactor {
+  return {
+    type: null,
+    allowOverlap: false,
+    compact: (layout, cols) =>
+      compactDragMagnetic(layout, cols, getDragStart?.() ?? null),
+  };
+}
 
 export const WORKSPACE_RESIZE_COMPACTOR: Compactor = {
   type: null,
@@ -17,9 +29,31 @@ export const WORKSPACE_RESIZE_COMPACTOR: Compactor = {
   compact: compactResizePushDown,
 };
 
-function compactDragSparse(layout: Layout): Layout {
+function compactDragMagnetic(
+  layout: Layout,
+  cols: number,
+  dragStart: WorkspaceDragStartSnapshot | null,
+): Layout {
   const priorityId = layout.find((item) => item.moved)?.i;
-  return compactPushDownWithPriority(layout, priorityId).map((item) => ({
+  if (!priorityId || !dragStart) {
+    return compactPushDownWithPriority(layout, priorityId).map((item) => ({
+      ...item,
+      moved: false,
+    }));
+  }
+
+  const dragLayout = layoutFromDragStart(layout, priorityId, dragStart);
+  const swapped = swapDisplacedIntoPreviousSlot(
+    dragLayout,
+    cols,
+    priorityId,
+    dragStart,
+  );
+  return compactMagnetUp(
+    swapped.layout,
+    priorityId,
+    swapped.displaced,
+  ).map((item) => ({
     ...item,
     moved: false,
   }));
@@ -28,14 +62,25 @@ function compactDragSparse(layout: Layout): Layout {
 export function autoFitDroppedPanel(
   layout: Layout,
   cols: number,
-  previousItem?: LayoutItem | null,
+  previous?: LayoutItem | WorkspaceDragStartSnapshot | null,
 ): Layout {
+  const dragStart = normalizeDragStart(previous);
+  const previousItem = dragStart?.item ?? null;
   const dropped = previousItem
     ? layout.find((item) => item.i === previousItem.i)
     : findDroppedItem(layout);
   if (!dropped) return cloneLayout(layout);
 
-  const base = cloneLayout(layout);
+  const dragLayout = dragStart?.layout.length
+    ? layoutFromDragStart(layout, dropped.i, dragStart)
+    : layout;
+  const swapped = swapDisplacedIntoPreviousSlot(
+    dragLayout,
+    cols,
+    dropped.i,
+    dragStart?.layout.length ? dragStart : null,
+  );
+  const base = swapped.layout;
   const target = base.find((item) => item.i === dropped.i);
   if (!target) return base;
 
@@ -99,7 +144,7 @@ export function autoFitDroppedPanel(
     }
   }
 
-  if (best) return best.layout;
+  if (best) return compactMagnetUp(best.layout, target.i, swapped.displaced);
 
   const fallback = cloneLayout(base);
   const fallbackTarget = fallback.find((item) => item.i === target.i);
@@ -108,11 +153,182 @@ export function autoFitDroppedPanel(
   fallbackTarget.h = minH;
   fallbackTarget.x = clamp(fallbackTarget.x, 0, Math.max(0, cols - minW));
   fallbackTarget.y = Math.max(0, fallbackTarget.y);
-  return compactPushDownWithPriority(fallback, target.i);
+  return compactMagnetUp(fallback, target.i, swapped.displaced);
 }
 
 function compactResizePushDown(layout: Layout): Layout {
   return compactPushDownWithPriority(layout);
+}
+
+function swapDisplacedIntoPreviousSlot(
+  layout: Layout,
+  cols: number,
+  priorityId: string | undefined,
+  dragStart: WorkspaceDragStartSnapshot | null,
+): { layout: Layout; displaced: boolean } {
+  const next = cloneLayout(layout);
+  if (!priorityId || !dragStart || dragStart.item.i !== priorityId) {
+    return { layout: next, displaced: false };
+  }
+
+  const anchor = next.find((item) => item.i === priorityId);
+  if (!anchor) return { layout: next, displaced: false };
+
+  const previousById = new Map(dragStart.layout.map((item) => [item.i, item]));
+  const originalOrder = new Map(
+    dragStart.layout.map((item, index) => [item.i, index]),
+  );
+  const candidates = next
+    .filter((item) => item.i !== priorityId)
+    .map((item) => ({ item, previous: previousById.get(item.i) }))
+    .filter(
+      (
+        candidate,
+      ): candidate is { item: LayoutItem; previous: LayoutItem } =>
+        candidate.previous !== undefined &&
+        (placementChanged(candidate.item, candidate.previous) ||
+          collides(candidate.previous, anchor) ||
+          collides(candidate.item, anchor)),
+    )
+    .sort((a, b) =>
+      compareDisplacedCandidates(a, b, anchor, originalOrder),
+    );
+
+  for (const { item, previous } of candidates) {
+    const slot = nearestOpenSlot(
+      next,
+      item,
+      anchor,
+      cols,
+      previous,
+      dragStart.item,
+    );
+    if (slot === null) continue;
+    item.x = slot.x;
+    item.y = slot.y;
+    return { layout: next, displaced: true };
+  }
+
+  return { layout: next, displaced: false };
+}
+
+function layoutFromDragStart(
+  layout: Layout,
+  priorityId: string,
+  dragStart: WorkspaceDragStartSnapshot,
+): Layout {
+  const current = new Map(layout.map((item) => [item.i, item]));
+  const anchor = current.get(priorityId);
+  const next: LayoutItem[] = dragStart.layout.map((item) => {
+    if (item.i !== priorityId) return { ...item, moved: false };
+    return { ...(anchor ?? item), moved: true };
+  });
+
+  for (const item of layout) {
+    if (!dragStart.layout.some((startItem) => startItem.i === item.i)) {
+      next.push({ ...item });
+    }
+  }
+
+  return next;
+}
+
+function compactMagnetUp(
+  layout: Layout,
+  priorityId?: string,
+  preservePriority = false,
+): Layout {
+  const next = cloneLayout(layout);
+  const originalOrder = new Map(next.map((item, index) => [item.i, index]));
+  const priority = preservePriority && priorityId
+    ? next.find((item) => item.i === priorityId)
+    : undefined;
+  const placed: LayoutItem[] = priority ? [priority] : [];
+  const ordered = next
+    .filter((item) => item.i !== priority?.i)
+    .sort((a, b) => compareItems(a, b, originalOrder));
+
+  for (const item of ordered) {
+    if (!item.static) {
+      item.y = Math.max(0, item.y);
+      moveBelowCollisions(item, placed);
+      while (item.y > 0) {
+        item.y -= 1;
+        const collision = firstCollision(placed, item);
+        if (collision) {
+          item.y = collision.y + collision.h;
+          break;
+        }
+      }
+      moveBelowCollisions(item, placed);
+    }
+    placed.push(item);
+  }
+
+  return next;
+}
+
+function moveBelowCollisions(item: LayoutItem, placed: LayoutItem[]) {
+  let collision = firstCollision(placed, item);
+  while (collision) {
+    item.y = collision.y + collision.h;
+    collision = firstCollision(placed, item);
+  }
+}
+
+function firstCollision(
+  layout: LayoutItem[],
+  item: LayoutItem,
+): LayoutItem | undefined {
+  return layout.find((other) => collides(other, item));
+}
+
+function normalizeDragStart(
+  previous: LayoutItem | WorkspaceDragStartSnapshot | null | undefined,
+): WorkspaceDragStartSnapshot | null {
+  if (!previous) return null;
+  if ('item' in previous && 'layout' in previous) {
+    return {
+      item: { ...previous.item },
+      layout: cloneLayout(previous.layout),
+    };
+  }
+  return { item: { ...previous }, layout: [] };
+}
+
+function placementChanged(item: LayoutItem, previous: LayoutItem): boolean {
+  return (
+    item.x !== previous.x ||
+    item.y !== previous.y ||
+    item.w !== previous.w ||
+    item.h !== previous.h
+  );
+}
+
+function compareDisplacedCandidates(
+  a: { item: LayoutItem; previous: LayoutItem },
+  b: { item: LayoutItem; previous: LayoutItem },
+  anchor: LayoutItem,
+  originalOrder: Map<string, number>,
+) {
+  const aOldSlotHit = collides(a.previous, anchor);
+  const bOldSlotHit = collides(b.previous, anchor);
+  if (aOldSlotHit !== bOldSlotHit) return aOldSlotHit ? -1 : 1;
+
+  const aCurrentHit = collides(a.item, anchor);
+  const bCurrentHit = collides(b.item, anchor);
+  if (aCurrentHit !== bCurrentHit) return aCurrentHit ? -1 : 1;
+
+  const aDistance = rectDistance(a.previous, anchor);
+  const bDistance = rectDistance(b.previous, anchor);
+  return (
+    aDistance - bDistance ||
+    (originalOrder.get(a.item.i) ?? 0) - (originalOrder.get(b.item.i) ?? 0)
+  );
+}
+
+function rectDistance(a: LayoutItem, b: LayoutItem): number {
+  return Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
 }
 
 function compactPushDownWithPriority(


### PR DESCRIPTION
## Summary
- Make workspace panel dragging magnet-swap instead of push-down: the displaced tile moves into the dragged tile's old slot and stacks stay tight.
- Recompute live drag compaction from the drag-start layout each frame so intermediate hover targets do not accumulate stale pushes.
- Update the workspace drag e2e to assert the actual swap positions, not just non-overlap.
- Change `scripts/finish-work.ps1` so beads pushes default to `origin` instead of the stale `kb2uka` remote.

## Verification
- npm --prefix zeus-web run test -- workspaceGrid.test.ts
- npm --prefix zeus-web run typecheck
- npm --prefix zeus-web run test:e2e
- npm --prefix zeus-web run test
- npm --prefix zeus-web run lint
- npm --prefix zeus-web run smoke
- npm --prefix zeus-web run build

Note: `bd dolt push --remote origin` still fails with Dolt `PermissionDenied` against the org remote, but the workflow no longer defaults to `kb2uka`.