### PR TITLE
fix(audio-suite): persist RX profile selection across restarts

### DIFF
--- a/Zeus.Server.Hosting/RxAudioProfileService.cs
+++ b/Zeus.Server.Hosting/RxAudioProfileService.cs
@@ -30,6 +30,8 @@ public sealed class RxAudioProfileService
 
     public IReadOnlyList<RxAudioProfileEntry> List() => _store.List();
 
+    public string? SelectedProfileName => _store.GetSelectedProfile();
+
     public async Task<RxAudioProfileEntry> SaveCurrentAsync(string name)
     {
         var states = await _rxVst.CaptureChainStatesAsync(CaptureTimeout).ConfigureAwait(false);
@@ -39,6 +41,7 @@ public sealed class RxAudioProfileService
             _chainOrder.ParkedIds,
             _masterBypass.IsRxBypassed,
             states);
+        _store.SetSelectedProfile(entry.Name);
         _log.LogInformation(
             "RX audio profile '{Name}' saved ({Active} active, {Parked} parked, {States} VST states, masterBypass={Bypass})",
             name,
@@ -57,12 +60,23 @@ public sealed class RxAudioProfileService
         _rxVst.SetPluginStates(profile.PluginStates);
         _chainOrder.ApplyMembershipAndOrder(profile.Order, profile.Parked);
         _masterBypass.SetRxMasterBypassed(profile.MasterBypass);
+        _store.SetSelectedProfile(profile.Name);
         _log.LogInformation(
             "RX audio profile '{Name}' applied ({States} VST states restored)",
             name,
             profile.PluginStates.Count);
         return Task.FromResult<RxAudioProfileEntry?>(profile);
     }
+
+    public Task<RxAudioProfileEntry?> ApplySelectedAsync(CancellationToken ct = default)
+    {
+        var selected = _store.GetSelectedProfile();
+        return string.IsNullOrWhiteSpace(selected)
+            ? Task.FromResult<RxAudioProfileEntry?>(null)
+            : ApplyAsync(selected, ct);
+    }
+
+    public void ClearSelectedProfile() => _store.SetSelectedProfile(null);
 
     public bool Delete(string name) => _store.Delete(name);
 }

--- a/Zeus.Server.Hosting/RxAudioProfileStartupService.cs
+++ b/Zeus.Server.Hosting/RxAudioProfileStartupService.cs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using Microsoft.Extensions.Hosting;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Re-applies the operator's selected RX Audio Suite profile during startup so
+/// RX VST state blobs reload before receive audio starts relying on the chain.
+/// </summary>
+public sealed class RxAudioProfileStartupService : IHostedService
+{
+    private readonly RxAudioProfileService _profiles;
+    private readonly ILogger<RxAudioProfileStartupService> _log;
+
+    public RxAudioProfileStartupService(
+        RxAudioProfileService profiles,
+        ILogger<RxAudioProfileStartupService> log)
+    {
+        _profiles = profiles;
+        _log = log;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var selected = _profiles.SelectedProfileName;
+        if (string.IsNullOrWhiteSpace(selected)) return;
+
+        var applied = await _profiles.ApplySelectedAsync(cancellationToken).ConfigureAwait(false);
+        if (applied is null)
+        {
+            _profiles.ClearSelectedProfile();
+            _log.LogWarning(
+                "Cleared stale RX audio profile selection '{Name}' because the profile no longer exists.",
+                selected);
+            return;
+        }
+
+        _log.LogInformation("RX audio profile '{Name}' restored on startup.", applied.Name);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/Zeus.Server.Hosting/RxAudioProfileStore.cs
+++ b/Zeus.Server.Hosting/RxAudioProfileStore.cs
@@ -10,6 +10,7 @@ public sealed class RxAudioProfileStore : IDisposable
 {
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<RxAudioProfileEntry> _profiles;
+    private readonly ILiteCollection<RxAudioProfileSelectionEntry> _selection;
     private readonly ILogger<RxAudioProfileStore> _log;
     private readonly object _sync = new();
 
@@ -24,6 +25,7 @@ public sealed class RxAudioProfileStore : IDisposable
         _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
         _profiles = _db.GetCollection<RxAudioProfileEntry>("rx_audio_profiles");
         _profiles.EnsureIndex(x => x.Name, unique: true);
+        _selection = _db.GetCollection<RxAudioProfileSelectionEntry>("rx_audio_profile_selection");
 
         _log.LogInformation("RxAudioProfileStore initialized at {Path}", dbPath);
     }
@@ -39,6 +41,40 @@ public sealed class RxAudioProfileStore : IDisposable
     public RxAudioProfileEntry? Get(string name)
     {
         lock (_sync) return _profiles.FindOne(p => p.Name == name);
+    }
+
+    public string? GetSelectedProfile()
+    {
+        lock (_sync) return GetSelectedProfileUnderLock();
+    }
+
+    public void SetSelectedProfile(string? name)
+    {
+        lock (_sync)
+        {
+            var trimmed = name?.Trim();
+            if (string.IsNullOrWhiteSpace(trimmed))
+            {
+                ClearSelectedProfileUnderLock();
+                return;
+            }
+
+            var nowUtc = DateTime.UtcNow;
+            var existing = _selection.FindAll().FirstOrDefault();
+            if (existing is null)
+            {
+                _selection.Insert(new RxAudioProfileSelectionEntry
+                {
+                    Name = trimmed,
+                    UpdatedUtc = nowUtc,
+                });
+                return;
+            }
+
+            existing.Name = trimmed;
+            existing.UpdatedUtc = nowUtc;
+            _selection.Update(existing);
+        }
     }
 
     public RxAudioProfileEntry Save(
@@ -83,10 +119,24 @@ public sealed class RxAudioProfileStore : IDisposable
 
     public bool Delete(string name)
     {
-        lock (_sync) return _profiles.DeleteMany(p => p.Name == name) > 0;
+        lock (_sync)
+        {
+            var deleted = _profiles.DeleteMany(p => p.Name == name) > 0;
+            if (deleted && string.Equals(GetSelectedProfileUnderLock(), name, StringComparison.Ordinal))
+                ClearSelectedProfileUnderLock();
+            return deleted;
+        }
     }
 
     public void Dispose() => _db.Dispose();
+
+    private string? GetSelectedProfileUnderLock() =>
+        _selection.FindAll().FirstOrDefault()?.Name;
+
+    private void ClearSelectedProfileUnderLock()
+    {
+        _selection.DeleteMany(_ => true);
+    }
 }
 
 public sealed class RxAudioProfileEntry
@@ -98,5 +148,12 @@ public sealed class RxAudioProfileEntry
     public bool MasterBypass { get; set; }
     public Dictionary<string, string> PluginStates { get; set; } = new();
     public DateTime CreatedUtc { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}
+
+public sealed class RxAudioProfileSelectionEntry
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = "";
     public DateTime UpdatedUtc { get; set; }
 }

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -403,7 +403,11 @@ public static class ZeusEndpoints
                 createdUtc = p.CreatedUtc,
                 updatedUtc = p.UpdatedUtc,
             });
-            return Results.Ok(new { profiles = list });
+            return Results.Ok(new
+            {
+                profiles = list,
+                selectedProfile = profiles.SelectedProfileName,
+            });
         });
         app.MapPut("/api/rx-audio-suite/profiles/{name}", async (string name, RxAudioProfileService profiles) =>
         {
@@ -418,6 +422,7 @@ public static class ZeusEndpoints
                 parked = entry.Parked,
                 masterBypass = entry.MasterBypass,
                 vstStates = entry.PluginStates.Count,
+                selectedProfile = profiles.SelectedProfileName,
                 createdUtc = entry.CreatedUtc,
                 updatedUtc = entry.UpdatedUtc,
             });
@@ -440,6 +445,7 @@ public static class ZeusEndpoints
                     engineAvailable = rxVst.EngineAvailable,
                     activePlugins = rxVst.ActivePluginCount,
                     degradedBlocks = rxVst.DegradedBlocks,
+                    selectedProfile = profiles.SelectedProfileName,
                     masterBypass = masterBypass.IsRxBypassed,
                 });
             return Results.NotFound(new { error = $"no RX audio profile named '{name}'" });

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -503,6 +503,7 @@ public static class ZeusHost
         builder.Services.AddSingleton<AudioChainSettingsStore>();
         builder.Services.AddSingleton<AudioChainMasterBypassService>();
         builder.Services.AddHostedService(sp => sp.GetRequiredService<AudioChainMasterBypassService>());
+        builder.Services.AddHostedService<RxAudioProfileStartupService>();
 
         // AudioProcessingModeService — operator's Native-vs-VST route selector.
         // Default is Native (Brian's in-process chain) so a fresh operator's TX

--- a/tests/Zeus.Server.Tests/RxAudioProfileServiceTests.cs
+++ b/tests/Zeus.Server.Tests/RxAudioProfileServiceTests.cs
@@ -98,6 +98,54 @@ public sealed class RxAudioProfileServiceTests : IDisposable
         Assert.False(MasterBypass.IsBypassed);
     }
 
+    [Fact]
+    public async Task SaveApplyAndDelete_MaintainSelectedProfile()
+    {
+        await MasterBypass.StartAsync(CancellationToken.None);
+        RxChainOrder.OnPluginAttached(RxClear);
+        RxChainOrder.OnPluginAttached(RxNoise);
+        Assert.True(RxChainOrder.TrySetParked(RxClear, parked: false, out _));
+        Assert.True(RxChainOrder.TrySetParked(RxNoise, parked: false, out _));
+
+        await Service.SaveCurrentAsync("Clear receive");
+
+        Assert.Equal("Clear receive", Service.SelectedProfileName);
+
+        await Service.ApplyAsync("Clear receive");
+
+        Assert.Equal("Clear receive", Service.SelectedProfileName);
+
+        Assert.True(Service.Delete("Clear receive"));
+
+        Assert.Null(Service.SelectedProfileName);
+    }
+
+    [Fact]
+    public async Task StartupService_ReappliesSelectedRxProfile()
+    {
+        await MasterBypass.StartAsync(CancellationToken.None);
+        MasterBypass.SetRxMasterBypassed(false);
+        RxChainOrder.OnPluginAttached(RxClear);
+        RxChainOrder.OnPluginAttached(RxNoise);
+        Assert.True(RxChainOrder.TrySetParked(RxClear, parked: false, out _));
+        Assert.True(RxChainOrder.TrySetParked(RxNoise, parked: false, out _));
+        Assert.True(RxChainOrder.TrySetOrder([RxNoise, RxClear], out _));
+
+        await Service.SaveCurrentAsync("Clear receive");
+
+        Assert.True(RxChainOrder.TrySetParked(RxClear, parked: true, out _));
+        MasterBypass.SetRxMasterBypassed(true);
+
+        var startup = new RxAudioProfileStartupService(
+            Service,
+            NullLogger<RxAudioProfileStartupService>.Instance);
+        await startup.StartAsync(CancellationToken.None);
+
+        Assert.Equal("Clear receive", Service.SelectedProfileName);
+        Assert.Equal([RxNoise, RxClear], RxChainOrder.CurrentOrder);
+        Assert.False(MasterBypass.IsRxBypassed);
+    }
+
     public void Dispose()
     {
         _rxVst.DisposeAsync().AsTask().GetAwaiter().GetResult();

--- a/tests/Zeus.Server.Tests/RxAudioProfileStoreTests.cs
+++ b/tests/Zeus.Server.Tests/RxAudioProfileStoreTests.cs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public sealed class RxAudioProfileStoreTests : IDisposable
+{
+    private readonly string _dbPath = Path.Combine(
+        Path.GetTempPath(),
+        $"zeus-prefs-rx-audioprofiles-{Guid.NewGuid():N}.db");
+
+    [Fact]
+    public void SelectedProfile_PersistsAcrossStoreInstances()
+    {
+        using (var first = NewStore())
+        {
+            first.Save(
+                "Clear receive",
+                ["com.openhpsdr.zeus.rxvst.clear"],
+                [],
+                masterBypass: false);
+            first.SetSelectedProfile("Clear receive");
+        }
+
+        using var second = NewStore();
+
+        Assert.Equal("Clear receive", second.GetSelectedProfile());
+    }
+
+    [Fact]
+    public void Delete_ClearsSelectedProfile()
+    {
+        using var store = NewStore();
+        store.Save(
+            "Clear receive",
+            ["com.openhpsdr.zeus.rxvst.clear"],
+            [],
+            masterBypass: false);
+        store.SetSelectedProfile("Clear receive");
+
+        Assert.True(store.Delete("Clear receive"));
+
+        Assert.Null(store.GetSelectedProfile());
+    }
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+    }
+
+    private RxAudioProfileStore NewStore() =>
+        new(NullLogger<RxAudioProfileStore>.Instance, _dbPath);
+}

--- a/zeus-web/src/state/audio-suite-store.test.ts
+++ b/zeus-web/src/state/audio-suite-store.test.ts
@@ -59,6 +59,16 @@ describe('audio-suite-store profile selection', () => {
     expect(useAudioSuiteStore.getState().selectedProfile).toBe('Ragchew');
   });
 
+  it('persists the selected RX profile until the operator changes it', async () => {
+    useAudioSuiteStore.getState().setSelectedProfileForRoute('rx', 'Clear RX');
+
+    const stored = JSON.parse(localStorage.getItem('zeus-audio-suite') ?? '{}');
+    expect(stored.state.rxSelectedProfile).toBe('Clear RX');
+
+    await rehydrateAudioSuiteFromStorage();
+    expect(useAudioSuiteStore.getState().rxSelectedProfile).toBe('Clear RX');
+  });
+
   it('opens TX and RX suites as independent windows', async () => {
     expect(useAudioSuiteStore.getState().suiteRoute).toBe('tx');
 
@@ -149,6 +159,52 @@ describe('audio-suite-store profile selection', () => {
 
     expect(useAudioSuiteStore.getState().profilesLoaded).toBe(true);
     expect(useAudioSuiteStore.getState().selectedProfile).toBe('');
+  });
+
+  it('hydrates the selected RX profile from the server when profiles load', async () => {
+    localStorage.setItem(
+      'zeus-audio-suite',
+      JSON.stringify({
+        state: { rxSelectedProfile: 'Old RX' },
+        version: 0,
+      }),
+    );
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(response({
+        selectedProfile: 'Clear RX',
+        profiles: [{ name: 'Clear RX' }],
+      }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await rehydrateAudioSuiteFromStorage();
+    await useAudioSuiteStore.getState().loadProfiles('rx');
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/rx-audio-suite/profiles');
+    expect(useAudioSuiteStore.getState().rxProfilesLoaded).toBe(true);
+    expect(useAudioSuiteStore.getState().rxSelectedProfile).toBe('Clear RX');
+  });
+
+  it('keeps a local RX profile selection when the server has no selected row yet', async () => {
+    localStorage.setItem(
+      'zeus-audio-suite',
+      JSON.stringify({
+        state: { rxSelectedProfile: 'Clear RX' },
+        version: 0,
+      }),
+    );
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(response({
+        selectedProfile: null,
+        profiles: [{ name: 'Clear RX' }],
+      }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await rehydrateAudioSuiteFromStorage();
+    await useAudioSuiteStore.getState().loadProfiles('rx');
+
+    expect(useAudioSuiteStore.getState().rxSelectedProfile).toBe('Clear RX');
   });
 
   it('marks a profile selected after a successful apply', async () => {

--- a/zeus-web/src/state/audio-suite-store.ts
+++ b/zeus-web/src/state/audio-suite-store.ts
@@ -62,6 +62,11 @@ type AudioProfileSummaryResponse = Omit<AudioProfileSummary, 'processingMode'> &
   processingMode?: string;
 };
 
+interface AudioProfilesResponse {
+  profiles?: AudioProfileSummaryResponse[];
+  selectedProfile?: string | null;
+}
+
 function normalizeAudioProfileSummary(profile: AudioProfileSummaryResponse): AudioProfileSummary {
   return {
     ...profile,
@@ -580,19 +585,29 @@ export const useAudioSuiteStore = create<AudioSuiteState>()(
         try {
           const res = await fetch(`/api/${route}-audio-suite/profiles`);
           if (!res.ok) return;
-          const body = (await res.json()) as { profiles?: AudioProfileSummaryResponse[] };
+          const body = (await res.json()) as AudioProfilesResponse;
           if (Array.isArray(body.profiles)) {
             const nextProfiles = body.profiles.map(normalizeAudioProfileSummary);
+            const serverSelected =
+              typeof body.selectedProfile === 'string'
+                ? body.selectedProfile.trim()
+                : '';
+            const profileExists = (name: string) =>
+              nextProfiles.some((p) => p.name === name);
+            const selectedFromServer =
+              serverSelected && profileExists(serverSelected)
+                ? serverSelected
+                : '';
             set((s) =>
               route === 'rx'
                 ? {
                     rxProfiles: nextProfiles,
                     rxProfilesLoaded: true,
                     rxSelectedProfile:
-                      s.rxSelectedProfile &&
-                      !nextProfiles.some((p) => p.name === s.rxSelectedProfile)
-                        ? ''
-                        : s.rxSelectedProfile,
+                      selectedFromServer ||
+                      (s.rxSelectedProfile && profileExists(s.rxSelectedProfile)
+                        ? s.rxSelectedProfile
+                        : ''),
                   }
                 : {
                     profiles: nextProfiles,


### PR DESCRIPTION
## What

Persists *which* RX Audio Suite profile the operator has selected, and re-applies it on server startup — so the selected RX profile (and its VST state blobs) survives a restart instead of resetting.

## Why

`develop` can save/load named RX audio profiles but does **not** remember the selected one across restarts, and has no startup-restore. On reconnect the operator's chosen RX chain was effectively forgotten. This work existed only on two stranded local branches (`fix/rx-suite-persistence` / `fix/rx-suite-profile-persistence`) whose remotes were deleted before merging — it was never landed. This re-lands the newer of the two onto current `develop`.

## How

- **`RxAudioProfileStore`** — new `rx_audio_profile_selection` LiteDB collection (single-row `RxAudioProfileSelectionEntry`) with `Get/SetSelectedProfile`; selection auto-clears when the selected profile is deleted.
- **`RxAudioProfileService`** — `SelectedProfileName`, sets selection on Save/Apply, adds `ApplySelectedAsync` + `ClearSelectedProfile`.
- **`RxAudioProfileStartupService`** (new `IHostedService`) — re-applies the selected profile during startup so RX VST state reloads before receive audio relies on the chain; clears a stale selection if the profile no longer exists.
- **`ZeusEndpoints`** — GET/PUT/POST `/api/rx-audio-suite/profiles` now return `selectedProfile`.
- **Frontend `audio-suite-store`** — hydrates `rxSelectedProfile` from the server's `selectedProfile`, falling back to existing client state.

## Verification

- `dotnet build Zeus.slnx` — clean.
- `vite build` — clean (production bundle + PWA).
- `dotnet test --filter RxAudioProfile` — **5/5 passed** (selection persists across store instances, clears on delete, plus service-level coverage).

## Cross-platform note

Pure LiteDB + hosted-service work, no platform-specific paths/timers — safe on macOS/Windows/Linux/Pi. CI will confirm across the matrix.