### PR TITLE
fix: remove duplicate TX fidelity audio tools card

### DIFF
--- a/zeus-web/src/components/SettingsMenu.test.tsx
+++ b/zeus-web/src/components/SettingsMenu.test.tsx
@@ -167,10 +167,7 @@ describe('SettingsView — Audio Tools', () => {
     });
     expect(container.textContent).toContain('TX Audio');
     expect(container.textContent).toContain('RX Audio');
-    expect(container.textContent).toContain('TX Fidelity Policy');
-    // The legacy "Station Profile" macro was unified into the single named
-    // "TX Audio Profile" (one save/recall over the entire TX audio chain).
-    expect(container.textContent).toContain('TX Audio Profile');
+    expect(container.textContent).not.toContain('TX Fidelity Policy');
     expect(container.textContent).toContain('Continuous Frequency Compressor');
   });
 });

--- a/zeus-web/src/components/TxAudioToolsPanel.tsx
+++ b/zeus-web/src/components/TxAudioToolsPanel.tsx
@@ -16,7 +16,6 @@
 import { useEffect, useMemo, type CSSProperties, type ReactNode } from 'react';
 import { CfcSettingsPanel } from './CfcSettingsPanel';
 import { DownloadAudioSuiteButton } from './DownloadAudioSuiteButton';
-import { TxFidelityPanel } from '../layout/panels/TxFidelityPanel';
 import { usePluginPanels } from '../plugins/runtime/usePluginPanels';
 import type { RegisteredPluginPanel } from '../plugins/runtime/pluginRuntime';
 import { useAudioSuiteStore } from '../state/audio-suite-store';
@@ -645,14 +644,6 @@ export function TxAudioToolsPanel() {
           TX
         </span>
         <span>Transmit tools</span>
-      </div>
-
-      <div className="ps-card">
-        <h4>
-          TX Fidelity Policy
-          <span className="ps-card-hint">station profile / target density / apply chain</span>
-        </h4>
-        <TxFidelityPanel />
       </div>
 
       <CfcSettingsPanel />


### PR DESCRIPTION
Summary:
- Removed the embedded TX Fidelity Policy card from the Audio Tools settings pane.
- Left the dockable TX Fidelity panel registration intact.
- Updated the Audio Tools settings test to guard against the duplicate card returning while keeping TX/RX audio flow and CFC coverage.

Verification:
- npm --prefix zeus-web run test
- npm --prefix zeus-web run typecheck
- npm --prefix zeus-web run build
- dotnet test Zeus.slnx was attempted via scripts/finish-work.ps1; it timed out in tests/Zeus.Server.Tests. The earlier failure in the web build was resolved by initializing the DeepCW submodule.

Beads: zeus-zb57