### PR TITLE
test: move WDSP-v2 DSP-modernization tooling suites off the per-PR gate

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -44,8 +44,17 @@ jobs:
       - name: Build .NET solution
         run: dotnet build Zeus.slnx --configuration Release --no-restore
 
+      # The "DspModernization" trait covers the WDSP-v2 evidence/validation
+      # tooling suites (bakeoff-report ranking, artifact-manifest scaffolds,
+      # validation triage, manual-tune observer, live-diagnostics scene). They
+      # exercise the experimental evaluation harness, not DSP/protocol
+      # correctness, and the lineage-parity design doc calls for running broad
+      # modernization combinatorics as opt-in diagnostics rather than PR gates.
+      # They run on a schedule via dsp-modernization-tests.yml instead. The
+      # DSP-correctness + channel-lifecycle gates (Zeus.Dsp.Tests, etc.) stay
+      # in the per-PR run below.
       - name: Run .NET tests
-        run: dotnet test Zeus.slnx --configuration Release --no-build --verbosity normal
+        run: dotnet test Zeus.slnx --configuration Release --no-build --verbosity normal --filter "Category!=DspModernization"
 
       - name: Install frontend dependencies
         run: npm ci

--- a/.github/workflows/dsp-modernization-tests.yml
+++ b/.github/workflows/dsp-modernization-tests.yml
@@ -1,0 +1,41 @@
+name: DSP Modernization Tests
+
+# Runs the WDSP-v2 "DSP modernization" evidence/validation tooling suites
+# (Category=DspModernization): bakeoff-report ranking, artifact-manifest
+# scaffolds, validation triage, manual-tune observer, live-diagnostics scene.
+#
+# These exercise the experimental evaluation harness around the WDSP-v2 effort,
+# not DSP/protocol correctness, so per docs/designs/wdsp-lineage-parity-analysis.md
+# they run as opt-in diagnostics on a schedule rather than gating every PR. The
+# per-PR Build and Test workflow excludes this trait (Category!=DspModernization).
+#
+# Triggers:
+#   1. schedule (04:00 UTC) — offset one hour from the nightly release build.
+#      GitHub only honours `schedule:` once the file reaches the default branch
+#      (main), so the cron is dormant until the next develop->main merge.
+#   2. workflow_dispatch    — run on demand from any branch.
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+jobs:
+  dsp-modernization-tests:
+    name: DSP modernization tests (ubuntu-latest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore .NET dependencies
+        run: dotnet restore Zeus.slnx
+
+      - name: Build .NET solution
+        run: dotnet build Zeus.slnx --configuration Release --no-restore
+
+      - name: Run DSP modernization tests
+        run: dotnet test Zeus.slnx --configuration Release --no-build --verbosity normal --filter "Category=DspModernization"

--- a/tests/Zeus.Server.Tests/DspLiveDiagnosticsServiceTests.cs
+++ b/tests/Zeus.Server.Tests/DspLiveDiagnosticsServiceTests.cs
@@ -5,6 +5,7 @@ using Zeus.Server;
 
 namespace Zeus.Server.Tests;
 
+[Trait("Category", "DspModernization")]
 public sealed class DspLiveDiagnosticsServiceTests
 {
     [Fact]

--- a/tests/Zeus.Server.Tests/DspManualTuneObserverToolTests.cs
+++ b/tests/Zeus.Server.Tests/DspManualTuneObserverToolTests.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 
 namespace Zeus.Server.Tests;
 
+[Trait("Category", "DspModernization")]
 public sealed class DspManualTuneObserverToolTests
 {
     private static readonly JsonSerializerOptions CamelCaseJson = new()

--- a/tests/Zeus.Server.Tests/DspManualTuneObserverValidationToolTests.cs
+++ b/tests/Zeus.Server.Tests/DspManualTuneObserverValidationToolTests.cs
@@ -8,6 +8,7 @@ using Zeus.Server;
 
 namespace Zeus.Server.Tests;
 
+[Trait("Category", "DspModernization")]
 public sealed class DspManualTuneObserverValidationToolTests
 {
     private static readonly JsonSerializerOptions CamelCaseJson = new()

--- a/tests/Zeus.Server.Tests/DspModernizationValidationToolTests.cs
+++ b/tests/Zeus.Server.Tests/DspModernizationValidationToolTests.cs
@@ -13,6 +13,7 @@ using Zeus.Server;
 
 namespace Zeus.Server.Tests;
 
+[Trait("Category", "DspModernization")]
 public sealed class DspModernizationValidationToolTests
 {
     private static readonly JsonSerializerOptions CamelCaseJson = new()

--- a/tests/Zeus.Server.Tests/FrontendDspSceneDiagnosticsServiceTests.cs
+++ b/tests/Zeus.Server.Tests/FrontendDspSceneDiagnosticsServiceTests.cs
@@ -5,6 +5,7 @@ using Zeus.Server;
 
 namespace Zeus.Server.Tests;
 
+[Trait("Category", "DspModernization")]
 public sealed class FrontendDspSceneDiagnosticsServiceTests
 {
     private static readonly JsonSerializerOptions CamelCaseJson = new()


### PR DESCRIPTION
## Why

A large, lopsided share of the CI test load comes from the **WDSP-v2 "DSP modernization" tooling**, not from DSP/protocol correctness. The bulk:

| Suite | Tests | What it tests |
|---|---|---|
| `DspModernizationValidationToolTests` (600+ KB) | 73 | bakeoff-report ranking, artifact-manifest scaffolds, validation triage, live-history coverage gates |
| `DspManualTuneObserverToolTests` / `…ValidationToolTests` | 17 | manual-tune observer tooling |
| `DspLiveDiagnosticsServiceTests` | 16 | live-diagnostics scene plumbing |
| `FrontendDspSceneDiagnosticsServiceTests` | 20 | frontend DSP scene diagnostics |

These exercise the **experimental evaluation harness** around the WDSP-v2 effort. `docs/designs/wdsp-lineage-parity-analysis.md` already says to run *"broad modernization combinatorics as an opt-in diagnostic until the native lifecycle issue is isolated"* — not as a per-PR gate. Today they run on **every PR across all three OSes**.

## What

- Tag the five tooling classes with `[Trait("Category", "DspModernization")]` (~124 tests).
- Per-PR **Build and Test** now runs `--filter "Category!=DspModernization"`.
- New **`dsp-modernization-tests.yml`** workflow runs `Category=DspModernization` on a schedule (04:00 UTC, offset from nightly) + manual dispatch, on ubuntu.

The DSP-**correctness** and channel-lifecycle gates (`Zeus.Dsp.Tests`, the `-400`-meter / channel-lifecycle tests, etc.) are **untagged** and stay in the PR gate.

## Verification

Built `Zeus.Server.Tests` (Release) and ran both partitions:

- `Category=DspModernization` → **124 tests, 0 failed** (1 skipped)
- `Category!=DspModernization` → **1146 tests, 0 failed** (5 skipped), tooling suite excluded

Clean partition, both green.

## Notes

CI/test-infra change only — no production code touched. The scheduled trigger stays dormant until this file reaches `main` (GitHub only honours `schedule:` on the default branch); `workflow_dispatch` works immediately from any branch.