### PR TITLE
fix: stabilize large workspace panel drag

### DIFF
--- a/zeus-web/e2e/workspace-panel-drag.spec.ts
+++ b/zeus-web/e2e/workspace-panel-drag.spec.ts
@@ -178,20 +178,61 @@ function expectRectNear(actual: TileRect, expected: TileRect) {
   expect(Math.abs(actual.height - expected.height)).toBeLessThanOrEqual(4);
 }
 
-async function centerOf(locator: ReturnType<Page['locator']>) {
-  const box = await locator.boundingBox();
-  if (!box) throw new Error('Expected locator to have a bounding box');
-  return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+async function waitForRectNear(page: Page, uid: string, expected: TileRect) {
+  await expect
+    .poll(
+      async () => {
+        const actual = rectFor(await tileRects(page), uid);
+        return Math.max(
+          Math.abs(actual.x - expected.x),
+          Math.abs(actual.y - expected.y),
+          Math.abs(actual.width - expected.width),
+          Math.abs(actual.height - expected.height),
+        );
+      },
+      { timeout: 1000 },
+    )
+    .toBeLessThanOrEqual(4);
 }
 
-test('dragging a panel into an occupied workspace slot displaces panels without blanking the grid', async ({
-  page,
-}) => {
+async function centerOf(locator: ReturnType<Page['locator']>) {
+  await expect(locator).toBeVisible();
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const box = await locator.boundingBox();
+    if (box && box.width > 0 && box.height > 0) {
+      return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+    }
+
+    await locator.page().waitForTimeout(50);
+  }
+
+  throw new Error('Expected locator to have a stable bounding box');
+}
+
+async function openStubbedWorkspace(page: Page) {
   const pageErrors: string[] = [];
   page.on('pageerror', (err) => pageErrors.push(err.message));
   await stubZeusApi(page);
 
   await page.goto('/');
+
+  return { pageErrors };
+}
+
+function expectNoReactDragLoop(pageErrors: string[]) {
+  expect(pageErrors).not.toContainEqual(
+    expect.stringContaining('Maximum update depth exceeded'),
+  );
+  expect(pageErrors).not.toContainEqual(
+    expect.stringContaining('Minified React error #185'),
+  );
+}
+
+test('dragging a panel into an occupied workspace slot swaps without blanking the grid', async ({
+  page,
+}) => {
+  const { pageErrors } = await openStubbedWorkspace(page);
 
   const draggedHeader = page.locator(
     '[data-tile-uid="tile-filterpresets"] .workspace-tile-header',
@@ -210,7 +251,8 @@ test('dragging a panel into an occupied workspace slot displaces panels without 
   await page.mouse.move(start.x, start.y);
   await page.mouse.down();
   await page.mouse.move(target.x, target.y, { steps: 12 });
-  await page.waitForTimeout(250);
+  await waitForRectNear(page, 'tile-filterpresets', targetBefore);
+  await waitForRectNear(page, 'tile-tx', draggedBefore);
 
   const duringDrag = await tileRects(page);
   expect(duringDrag).toHaveLength(8);
@@ -219,17 +261,47 @@ test('dragging a panel into an occupied workspace slot displaces panels without 
   expectRectNear(rectFor(duringDrag, 'tile-tx'), draggedBefore);
 
   await page.mouse.up();
-  await page.waitForTimeout(500);
+  await waitForRectNear(page, 'tile-filterpresets', targetBefore);
+  await waitForRectNear(page, 'tile-tx', draggedBefore);
 
   const after = await tileRects(page);
   expect(after).toHaveLength(8);
   expect(overlapPairs(after)).toEqual([]);
   expectRectNear(rectFor(after, 'tile-filterpresets'), targetBefore);
   expectRectNear(rectFor(after, 'tile-tx'), draggedBefore);
-  expect(pageErrors).not.toContainEqual(
-    expect.stringContaining('Maximum update depth exceeded'),
+  expectNoReactDragLoop(pageErrors);
+});
+
+test('dragging the large panadapter panel stays stable', async ({ page }) => {
+  const { pageErrors } = await openStubbedWorkspace(page);
+
+  const draggedHeader = page.locator(
+    '[data-tile-uid="tile-hero"] .workspace-tile-header',
   );
-  expect(pageErrors).not.toContainEqual(
-    expect.stringContaining('Minified React error #185'),
-  );
+  const targetHeader = page.locator('[data-tile-uid="tile-tx"] .workspace-tile-header');
+  await expect(draggedHeader).toBeVisible();
+  await expect(targetHeader).toBeVisible();
+
+  const before = await tileRects(page);
+  expect(before).toHaveLength(8);
+
+  const start = await centerOf(draggedHeader);
+  const target = await centerOf(targetHeader);
+  await page.mouse.move(start.x, start.y);
+  await page.mouse.down();
+  await page.mouse.move(target.x, target.y, { steps: 16 });
+  await page.waitForTimeout(250);
+
+  const duringDrag = await tileRects(page);
+  expect(duringDrag).toHaveLength(8);
+  expect(overlapPairs(duringDrag)).toEqual([]);
+  expectNoReactDragLoop(pageErrors);
+
+  await page.mouse.up();
+  await page.waitForTimeout(500);
+
+  const after = await tileRects(page);
+  expect(after).toHaveLength(8);
+  expect(overlapPairs(after)).toEqual([]);
+  expectNoReactDragLoop(pageErrors);
 });

--- a/zeus-web/e2e/workspace-panel-drag.spec.ts
+++ b/zeus-web/e2e/workspace-panel-drag.spec.ts
@@ -24,6 +24,10 @@ interface TileRect {
   height: number;
 }
 
+interface StubbedZeusApi {
+  layoutWrites: { count: number };
+}
+
 async function fulfillJson(route: Route, body: unknown) {
   await route.fulfill({
     status: 200,
@@ -32,7 +36,9 @@ async function fulfillJson(route: Route, body: unknown) {
   });
 }
 
-async function stubZeusApi(page: Page) {
+async function stubZeusApi(page: Page): Promise<StubbedZeusApi> {
+  const layoutWrites = { count: 0 };
+
   await page.addInitScript(() => {
     class MockZeusWebSocket extends EventTarget {
       readonly url: string;
@@ -123,6 +129,7 @@ async function stubZeusApi(page: Page) {
     }
 
     if (url.pathname === '/api/ui/layouts') {
+      layoutWrites.count += 1;
       await route.fulfill({ status: 204, body: '' });
       return;
     }
@@ -134,6 +141,8 @@ async function stubZeusApi(page: Page) {
 
     await fulfillJson(route, {});
   });
+
+  return { layoutWrites };
 }
 
 async function tileRects(page: Page): Promise<TileRect[]> {
@@ -213,11 +222,11 @@ async function centerOf(locator: ReturnType<Page['locator']>) {
 async function openStubbedWorkspace(page: Page) {
   const pageErrors: string[] = [];
   page.on('pageerror', (err) => pageErrors.push(err.message));
-  await stubZeusApi(page);
+  const api = await stubZeusApi(page);
 
   await page.goto('/');
 
-  return { pageErrors };
+  return { pageErrors, layoutWrites: api.layoutWrites };
 }
 
 function expectNoReactDragLoop(pageErrors: string[]) {
@@ -232,7 +241,7 @@ function expectNoReactDragLoop(pageErrors: string[]) {
 test('dragging a panel into an occupied workspace slot swaps without blanking the grid', async ({
   page,
 }) => {
-  const { pageErrors } = await openStubbedWorkspace(page);
+  const { pageErrors, layoutWrites } = await openStubbedWorkspace(page);
 
   const draggedHeader = page.locator(
     '[data-tile-uid="tile-filterpresets"] .workspace-tile-header',
@@ -253,6 +262,8 @@ test('dragging a panel into an occupied workspace slot swaps without blanking th
   await page.mouse.move(target.x, target.y, { steps: 12 });
   await waitForRectNear(page, 'tile-filterpresets', targetBefore);
   await waitForRectNear(page, 'tile-tx', draggedBefore);
+  await page.waitForTimeout(1100);
+  expect(layoutWrites.count).toBe(0);
 
   const duringDrag = await tileRects(page);
   expect(duringDrag).toHaveLength(8);
@@ -263,6 +274,7 @@ test('dragging a panel into an occupied workspace slot swaps without blanking th
   await page.mouse.up();
   await waitForRectNear(page, 'tile-filterpresets', targetBefore);
   await waitForRectNear(page, 'tile-tx', draggedBefore);
+  await expect.poll(() => layoutWrites.count, { timeout: 3500 }).toBeGreaterThan(0);
 
   const after = await tileRects(page);
   expect(after).toHaveLength(8);

--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -238,8 +238,9 @@ function WorkspaceCanvas({
   const [containerHeight, setContainerHeight] = useState(0);
   const [gridInteraction, setGridInteraction] =
     useState<GridInteraction>(null);
+  const draggingRef = useRef(false);
+  const skipPostDropLayoutChangeRef = useRef(false);
   const dragStartRef = useRef<WorkspaceDragStartSnapshot | null>(null);
-  const autoFitDropRef = useRef<WorkspaceDragStartSnapshot | null>(null);
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
@@ -328,6 +329,8 @@ function WorkspaceCanvas({
     layout: Layout,
     oldItem: LayoutItem | null,
   ) => {
+    draggingRef.current = true;
+    skipPostDropLayoutChangeRef.current = false;
     dragStartRef.current = oldItem
       ? {
           item: { ...oldItem },
@@ -338,34 +341,50 @@ function WorkspaceCanvas({
   }, []);
   const onResizeStart = useCallback(() => setGridInteraction('resize'), []);
   const onDragStop = useCallback((
-    _layout: Layout,
+    layout: Layout,
     oldItem: LayoutItem | null,
     newItem: LayoutItem | null,
   ) => {
-    autoFitDropRef.current = (
-      oldItem &&
-      newItem &&
-      (oldItem.x !== newItem.x || oldItem.y !== newItem.y)
-    )
-      ? dragStartRef.current ?? { item: { ...oldItem }, layout: [] }
+    const dragStart = dragStartRef.current;
+    const finalItem = dragStart
+      ? layout.find((item) => item.i === dragStart.item.i)
+      : newItem;
+    const moved = dragStart && finalItem
+      ? dragStart.item.x !== finalItem.x || dragStart.item.y !== finalItem.y
+      : Boolean(
+          oldItem &&
+            newItem &&
+            (oldItem.x !== newItem.x || oldItem.y !== newItem.y),
+        );
+    const previousDropItem = moved
+      ? dragStart ?? (oldItem ? { item: { ...oldItem }, layout: [] } : null)
       : null;
+    draggingRef.current = false;
     dragStartRef.current = null;
     setGridInteraction(null);
-  }, []);
+
+    if (previousDropItem) {
+      skipPostDropLayoutChangeRef.current = true;
+      window.setTimeout(() => {
+        skipPostDropLayoutChangeRef.current = false;
+      }, 250);
+      onLayoutChange(
+        autoFitDroppedPanel(layout, WORKSPACE_GRID_COLS, previousDropItem),
+      );
+    }
+  }, [onLayoutChange]);
   const onResizeStop = useCallback(() => {
-    autoFitDropRef.current = null;
+    draggingRef.current = false;
     dragStartRef.current = null;
     setGridInteraction(null);
   }, []);
   const handleLayoutChange = useCallback(
     (next: Layout) => {
-      const previousDropItem = autoFitDropRef.current;
-      autoFitDropRef.current = null;
-      onLayoutChange(
-        previousDropItem
-          ? autoFitDroppedPanel(next, WORKSPACE_GRID_COLS, previousDropItem)
-          : next,
-      );
+      if (draggingRef.current || skipPostDropLayoutChangeRef.current) {
+        return;
+      }
+
+      onLayoutChange(next);
     },
     [onLayoutChange],
   );

--- a/zeus-web/src/layout/workspaceGrid.test.ts
+++ b/zeus-web/src/layout/workspaceGrid.test.ts
@@ -30,6 +30,12 @@ function expectNoCollisions(layout: Layout) {
   }
 }
 
+function expectStableCompaction(layout: Layout) {
+  const once = WORKSPACE_DRAG_COMPACTOR.compact(layout, 24);
+  const twice = WORKSPACE_DRAG_COMPACTOR.compact(once, 24);
+  expect(twice).toEqual(once);
+}
+
 function fitMovedElement(
   layout: Layout,
   dragged: Layout[number],
@@ -238,6 +244,60 @@ describe('workspace grid collision policy', () => {
 
     expect(next.find((item) => item.i === 'dragged')?.y).toBe(2);
     expect(next.find((item) => item.i === 'below')?.y).toBe(0);
+  });
+
+  it('keeps large panadapter drag compaction stable', () => {
+    const layout: Layout = cloneLayout([
+      { i: 'filter', x: 0, y: 0, w: 12, h: 10 },
+      { i: 'filterpresets', x: 12, y: 0, w: 6, h: 10 },
+      { i: 'hero', x: 0, y: 10, w: 18, h: 38, minW: 8, minH: 8 },
+      { i: 'vfo', x: 18, y: 0, w: 6, h: 11 },
+      { i: 'smeter', x: 18, y: 11, w: 6, h: 5 },
+      { i: 'tx', x: 18, y: 16, w: 6, h: 10 },
+      { i: 'txmeters', x: 18, y: 26, w: 6, h: 12 },
+      { i: 'dsp', x: 18, y: 38, w: 6, h: 10 },
+    ]);
+    const dragged = layout.find((item) => item.i === 'hero')!;
+    const next = dragAndCompact(layout, dragged, 6, 16);
+
+    expect(next.find((item) => item.i === 'hero')).toMatchObject({
+      x: 6,
+      moved: false,
+    });
+    expectNoCollisions(next);
+    expectStableCompaction(next);
+  });
+
+  it('keeps large panadapter final drop stable through prop resync', () => {
+    const layout: Layout = cloneLayout([
+      { i: 'filter', x: 0, y: 0, w: 12, h: 10 },
+      { i: 'filterpresets', x: 12, y: 0, w: 6, h: 10 },
+      { i: 'hero', x: 0, y: 10, w: 18, h: 38, minW: 8, minH: 8 },
+      { i: 'vfo', x: 18, y: 0, w: 6, h: 11 },
+      { i: 'smeter', x: 18, y: 11, w: 6, h: 5 },
+      { i: 'tx', x: 18, y: 16, w: 6, h: 10 },
+      { i: 'txmeters', x: 18, y: 26, w: 6, h: 12 },
+      { i: 'dsp', x: 18, y: 38, w: 6, h: 10 },
+    ]);
+    const dragged = layout.find((item) => item.i === 'hero')!;
+    const dragStart = { item: { ...dragged }, layout: cloneLayout(layout) };
+    const moved = moveElement(
+      layout,
+      dragged,
+      6,
+      16,
+      true,
+      WORKSPACE_DRAG_COMPACTOR.preventCollision,
+      WORKSPACE_DRAG_COMPACTOR.type,
+      24,
+      WORKSPACE_DRAG_COMPACTOR.allowOverlap,
+    );
+
+    const dropped = autoFitDroppedPanel(moved, 24, dragStart);
+    const resynced = WORKSPACE_DRAG_COMPACTOR.compact(dropped, 24);
+
+    expect(resynced).toEqual(dropped);
+    expectNoCollisions(dropped);
   });
 
   it('pushes a lower panel down when resize grows into it', () => {

--- a/zeus-web/src/layout/workspaceGrid.ts
+++ b/zeus-web/src/layout/workspaceGrid.ts
@@ -69,7 +69,7 @@ export function autoFitDroppedPanel(
   const dropped = previousItem
     ? layout.find((item) => item.i === previousItem.i)
     : findDroppedItem(layout);
-  if (!dropped) return cloneLayout(layout);
+  if (!dropped) return clearMovedFlags(cloneLayout(layout));
 
   const dragLayout = dragStart?.layout.length
     ? layoutFromDragStart(layout, dropped.i, dragStart)
@@ -82,7 +82,7 @@ export function autoFitDroppedPanel(
   );
   const base = swapped.layout;
   const target = base.find((item) => item.i === dropped.i);
-  if (!target) return base;
+  if (!target) return clearMovedFlags(base);
 
   const minW = boundedMin(target.minW, 1, cols);
   const maxW = boundedMax(target.maxW, minW, cols);
@@ -144,16 +144,20 @@ export function autoFitDroppedPanel(
     }
   }
 
-  if (best) return compactMagnetUp(best.layout, target.i, swapped.displaced);
+  if (best) {
+    return clearMovedFlags(
+      compactMagnetUp(best.layout, target.i, swapped.displaced),
+    );
+  }
 
   const fallback = cloneLayout(base);
   const fallbackTarget = fallback.find((item) => item.i === target.i);
-  if (!fallbackTarget) return fallback;
+  if (!fallbackTarget) return clearMovedFlags(fallback);
   fallbackTarget.w = minW;
   fallbackTarget.h = minH;
   fallbackTarget.x = clamp(fallbackTarget.x, 0, Math.max(0, cols - minW));
   fallbackTarget.y = Math.max(0, fallbackTarget.y);
-  return compactMagnetUp(fallback, target.i, swapped.displaced);
+  return clearMovedFlags(compactMagnetUp(fallback, target.i, swapped.displaced));
 }
 
 function compactResizePushDown(layout: Layout): Layout {
@@ -504,6 +508,10 @@ function compareItems(
 
 function cloneLayout(layout: Layout): LayoutItem[] {
   return layout.map((item) => ({ ...item }));
+}
+
+function clearMovedFlags(layout: Layout): LayoutItem[] {
+  return layout.map((item) => ({ ...item, moved: false }));
 }
 
 function placementMovement(


### PR DESCRIPTION
## Summary
- clear transient React Grid Layout `moved` flags from all final auto-fit layouts to stop post-drop prop resync loops
- preserve magnetic swap/compact behavior when dragging into occupied workspace slots
- keep live drag layouts out of the persisted workspace store so the preview does not jitter from controlled-state feedback
- commit the final auto-fit layout directly on drag stop and add regression coverage for no layout writes while the mouse is still down
- add large panadapter drag regression coverage and harden workspace drag e2e assertions for minified preview timing

## Verification
- npm --prefix zeus-web run test -- workspaceGrid.test.ts
- npm --prefix zeus-web run typecheck
- npm --prefix zeus-web run test:e2e -- workspace-panel-drag.spec.ts
- npm --prefix zeus-web run lint
- npm --prefix zeus-web run test -- notch-store.test.ts
- npm --prefix zeus-web run test
- npm --prefix zeus-web run smoke
- npm --prefix zeus-web run build
- production preview on 127.0.0.1:5175 + E2E_PORT=5175 npm --prefix zeus-web run test:e2e -- workspace-panel-drag.spec.ts

## Beads
- Closed and synced `zeus-ane0`