### PR TITLE
fix: right-align QRZ sync badge in logbook name column

### DIFF
--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -2983,6 +2983,7 @@
 }
 .log-sync-pill {
   flex-shrink: 0;
+  margin-left: auto;
   color: var(--accent);
   font-size: 9px;
   font-weight: 800;


### PR DESCRIPTION
## What

The `✓ QRZ` sync badge in the Logbook's **Name · QTH · Notes** column sat immediately after each contact's name, so it appeared at a different horizontal position on every row depending on name length.

This adds `margin-left: auto` to `.log-sync-pill`, pushing the badge to the right edge of the Name column so all the `✓ QRZ` checks line up in a clean vertical column.

## Why

Ragged badge placement made it hard to scan which QSOs are QRZ-published at a glance.

## Notes

- Pure CSS, one line. `flex-shrink: 0` already present keeps the pill intact; the name text still ellipsizes when long.
- No behavior, palette, or layout-structure changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)