### PR TITLE
fix(workspace): error boundary + release panadapter WebGL context

### DIFF
--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -46,6 +46,7 @@ import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState, type
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { WorkspaceContext } from './layout/WorkspaceContext';
 import { FlexWorkspace } from './layout/FlexWorkspace';
+import { WorkspaceErrorBoundary } from './layout/WorkspaceErrorBoundary';
 import { currentDetachedWorkspaceLayoutId } from './layout/workspace-windows';
 import { ConfirmDialog } from './layout/ConfirmDialog';
 import { AfGainSlider } from './components/AfGainSlider';
@@ -183,6 +184,13 @@ export default function App() {
     void loadLayoutsForRadio(key);
   }, [loadLayoutsForRadio, radioConnected, radioLoaded]);
   const activeLayoutId = useLayoutStore((s) => s.activeLayoutId);
+
+  // Recover action for the workspace error boundary: reset the active layout to
+  // its default panel arrangement, which clears whatever layout/panel state
+  // drove a render to throw and blank the workspace.
+  const resetActiveWorkspaceLayout = useCallback(() => {
+    useLayoutStore.getState().resetActiveLayout();
+  }, []);
 
   useKeyboardShortcuts();
   useMicUplink();
@@ -797,10 +805,15 @@ export default function App() {
       >
         <div className="workspace-area detached-workspace-area">
           <AlertBanner />
-          <FlexWorkspace
+          <WorkspaceErrorBoundary
             key={detachedLayoutId}
-            layoutId={detachedLayoutId}
-          />
+            onReset={resetActiveWorkspaceLayout}
+          >
+            <FlexWorkspace
+              key={detachedLayoutId}
+              layoutId={detachedLayoutId}
+            />
+          </WorkspaceErrorBoundary>
         </div>
         {disconnectedOverlay}
       </div>
@@ -963,7 +976,12 @@ export default function App() {
             />
           </Suspense>
         ) : (
-          <FlexWorkspace key={activeLayoutId} />
+          <WorkspaceErrorBoundary
+            key={activeLayoutId}
+            onReset={resetActiveWorkspaceLayout}
+          >
+            <FlexWorkspace key={activeLayoutId} />
+          </WorkspaceErrorBoundary>
         )}
       </div>
 

--- a/zeus-web/src/components/Panadapter.tsx
+++ b/zeus-web/src/components/Panadapter.tsx
@@ -43,7 +43,12 @@
 // License for details.
 
 import { useEffect, useRef, type CSSProperties } from 'react';
-import { createPanRenderer, hexToRgbFloats } from '../gl/panadapter';
+import {
+  cancelPendingPanContextLoss,
+  createPanRenderer,
+  hexToRgbFloats,
+  schedulePanContextLoss,
+} from '../gl/panadapter';
 import { planForFrame } from '../gl/frame-plan';
 import { cancelDrawBusFrame, requestDrawBusFrame } from '../realtime/draw-bus';
 import { registerFrameConsumer, selectDisplaySlice, useDisplayStore } from '../state/display-store';
@@ -97,6 +102,11 @@ export function Panadapter({
     const canvas = canvasRef.current;
     const container = containerRef.current;
     if (!canvas || !container) return;
+
+    // A previous unmount may have scheduled a deferred context loss for this
+    // canvas; cancel it now that we're reusing the canvas so we don't tear down
+    // the context we're about to (re)create (mirrors Waterfall.tsx, #629).
+    cancelPendingPanContextLoss(canvas);
 
     const gl = canvas.getContext('webgl2', { antialias: true, alpha: true, premultipliedAlpha: true });
     if (!gl) {
@@ -408,6 +418,12 @@ export function Panadapter({
       document.removeEventListener('visibilitychange', onVisibilityChange);
       cancelDrawBusFrame(redraw);
       renderer.dispose();
+      // Free the ANGLE context slot on real unmounts, deferred so a StrictMode
+      // (or quick drag-induced) remount can cancel it and reuse the canvas
+      // rather than losing a live context (#629). dispose() frees GL objects;
+      // this releases the context itself so contexts don't accumulate across
+      // repeated workspace rearranges.
+      schedulePanContextLoss(canvas, gl);
       releaseFrameConsumer();
     };
   }, [receiver, stitched]);

--- a/zeus-web/src/gl/panadapter.ts
+++ b/zeus-web/src/gl/panadapter.ts
@@ -70,6 +70,45 @@ export type PanRenderer = {
   dispose: () => void;
 };
 
+// Deferred WebGL context teardown — mirrors Waterfall.tsx (#629). Each WebGL2
+// canvas holds a scarce ANGLE/driver context slot; freeing GL objects in
+// dispose() does NOT release the context itself. On a workspace where the
+// operator keeps rearranging panels, React can mount/unmount the panadapter
+// repeatedly, and without an explicit WEBGL_lose_context call the orphaned
+// contexts accumulate until the browser force-loses the oldest ones (the GPU
+// context-loss spiral that contributes to the "blank workspace" symptom). We
+// release the slot on real unmounts, but defer it briefly so React StrictMode's
+// dev-only effect remount (and a quick drag-induced remount) can cancel the
+// teardown and reuse the same canvas instead of tearing down a live context.
+const CONTEXT_LOSS_TEARDOWN_DELAY_MS = 250;
+const pendingContextLossTimers = new WeakMap<HTMLCanvasElement, number>();
+
+// Cancel a pending deferred context loss for this canvas (call on (re)mount
+// before creating the context). Returns nothing.
+export function cancelPendingPanContextLoss(canvas: HTMLCanvasElement): void {
+  const timer = pendingContextLossTimers.get(canvas);
+  if (timer !== undefined) {
+    window.clearTimeout(timer);
+    pendingContextLossTimers.delete(canvas);
+  }
+}
+
+// Schedule a deferred WEBGL_lose_context for this canvas (call on unmount,
+// AFTER renderer.dispose()). Safe no-op if the extension is unavailable.
+export function schedulePanContextLoss(
+  canvas: HTMLCanvasElement,
+  gl: WebGL2RenderingContext,
+): void {
+  const loseContext = gl.getExtension('WEBGL_lose_context');
+  if (!loseContext) return;
+  const timer = window.setTimeout(() => {
+    if (pendingContextLossTimers.get(canvas) !== timer) return;
+    pendingContextLossTimers.delete(canvas);
+    loseContext.loseContext();
+  }, CONTEXT_LOSS_TEARDOWN_DELAY_MS);
+  pendingContextLossTimers.set(canvas, timer);
+}
+
 // Convert a #RRGGBB string into the 0..1 RGB triplet the renderer wants.
 // Malformed input falls back to amber so a typo can never crash GL.
 export function hexToRgbFloats(hex: string): { r: number; g: number; b: number } {

--- a/zeus-web/src/layout/WorkspaceErrorBoundary.tsx
+++ b/zeus-web/src/layout/WorkspaceErrorBoundary.tsx
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+type Props = {
+  children: ReactNode;
+  /** Invoked when the operator clicks "Reset Workspace" in the fallback. */
+  onReset: () => void;
+};
+
+type State = {
+  error: Error | null;
+};
+
+/**
+ * Error boundary around the workspace grid (FlexWorkspace). The workspace is a
+ * drag/drop grid of arbitrary panels; a single misbehaving panel or a layout
+ * that drives react-grid-layout into a bad render must not blank the entire
+ * app. When a render throws, this catches it and shows a small token-styled
+ * fallback with a recover action (reset the active layout to its default
+ * arrangement, which clears whatever state triggered the throw) instead of a
+ * white screen.
+ *
+ * Styling uses tokens.css variables only — no raw hex — so it tracks the
+ * light/dark theme like the rest of the chrome.
+ */
+export class WorkspaceErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo) {
+    // Surface to the console so the desktop (WebView, no DevTools-on-LAN) build
+    // still leaves a breadcrumb. The visible fallback is the operator path.
+    console.error('Workspace render error:', error, info.componentStack);
+  }
+
+  private handleReset = () => {
+    // Clear the latched error first so the boundary re-renders its children,
+    // then ask the host to reset the active layout. If the reset removes the
+    // offending state the workspace comes back; if it throws again the boundary
+    // simply re-catches and shows the fallback once more.
+    this.setState({ error: null });
+    this.props.onReset();
+  };
+
+  override render() {
+    if (!this.state.error) return this.props.children;
+
+    return (
+      <div
+        role="alert"
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 12,
+          height: '100%',
+          minHeight: 160,
+          padding: 24,
+          textAlign: 'center',
+          background: 'var(--bg-1)',
+          color: 'var(--fg-1)',
+          border: '1px solid var(--panel-border)',
+          borderRadius: 6,
+        }}
+      >
+        <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--fg-0)' }}>
+          The workspace hit a rendering problem.
+        </div>
+        <div style={{ fontSize: 12, color: 'var(--fg-2)', maxWidth: 420 }}>
+          One of the panels in this layout failed to render. Resetting the
+          layout restores the default panel arrangement and clears the error.
+        </div>
+        <button
+          type="button"
+          className="btn sm"
+          onClick={this.handleReset}
+        >
+          Reset Workspace
+        </button>
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
Two defence-in-depth fixes salvaged from the panel-blank investigation. The layout-height *root cause* of the blank-after-many-moves bug is handled by **#710**; these are the orthogonal hardening bits that #710 doesn't include.

- **`WorkspaceErrorBoundary`** wraps `FlexWorkspace` in `App.tsx` — any future panel render exception now degrades to a recoverable fallback (with a reset-to-default-layout action) instead of unmounting the tree and blanking the whole app. The workspace had no error boundary above it.
- **Panadapter WebGL-context release on unmount** (`gl/panadapter.ts` / `Panadapter.tsx`): layout switches remount the panadapter, and without an explicit lose-context each remount accrued a context toward the browser's per-page WebGL cap — a real secondary leak. Deferred via a canvas-timer map like the waterfall already does.

No drag/layout-math changes (those belong to #710). Verified: `tsc -b && vite build` clean, no net-new test failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)