### PR TITLE
test: permanently de-flake load-sensitive Plugins.Host tests

### DIFF
--- a/tests/Zeus.Plugins.Host.Tests/AudioChainProcessNoAllocTests.cs
+++ b/tests/Zeus.Plugins.Host.Tests/AudioChainProcessNoAllocTests.cs
@@ -27,6 +27,7 @@ namespace Zeus.Plugins.Host.Tests;
 /// it survives integer division and trips the assert; the JIT artifact does
 /// not.
 /// </summary>
+[Collection("LoadSensitive")]
 public class AudioChainProcessNoAllocTests
 {
     private const int Iterations = 10_000;
@@ -40,12 +41,19 @@ public class AudioChainProcessNoAllocTests
         var ctx = new AudioBlockContext(48000, 1, 256, 0, false);
         for (int i = 0; i < input.Length; i++) input[i] = (float)i / 256f;
 
-        // Warm-up: prime any one-shot init that AudioChain does on
-        // first call.
-        for (int i = 0; i < 16; i++) chain.Process(input, output, ctx);
+        // Window 1 — warm up AND absorb tiered-JIT recompilation. Tiered
+        // compilation can promote Process() to tier-1 / perform on-stack
+        // replacement WHILE the loop is already running, charging a one-shot
+        // allocation to this thread that a short fixed warm-up races on a
+        // loaded runner (the intermittent macOS red, where the blip exceeded
+        // even a per-block threshold). Running a FULL window first drives the
+        // path fully into tier-1, so the measured window below is the true
+        // steady-state hot path. The [Collection("LoadSensitive")] isolation
+        // keeps sibling tests from perturbing this further.
+        for (int i = 0; i < Iterations; i++) chain.Process(input, output, ctx);
 
-        // Measure thread-local bytes allocated across the hot loop on this
-        // same thread. Immune to GCs triggered by other threads.
+        // Window 2 — fully warmed + tiered: measure thread-local bytes across
+        // the steady-state hot loop. Immune to GCs triggered by other threads.
         var startBytes = GC.GetAllocatedBytesForCurrentThread();
 
         for (int i = 0; i < Iterations; i++)

--- a/tests/Zeus.Plugins.Host.Tests/LoadSensitiveCollection.cs
+++ b/tests/Zeus.Plugins.Host.Tests/LoadSensitiveCollection.cs
@@ -1,0 +1,15 @@
+using Xunit;
+
+namespace Zeus.Plugins.Host.Tests;
+
+/// <summary>
+/// xUnit collection for tests that MEASURE timing or allocation and are
+/// therefore sensitive to parallel CPU/scheduling/GC contention. Marking them
+/// with <c>[Collection("LoadSensitive")]</c> + DisableParallelization makes the
+/// collection run on its own — not concurrently with the rest of the assembly —
+/// so the measurement isn't perturbed by sibling tests. This is the systemic
+/// fix for the intermittent CI flakes that appeared once the assembly grew
+/// (the watchdog/crash-loop timing tests and the no-allocation hot-path test).
+/// </summary>
+[CollectionDefinition("LoadSensitive", DisableParallelization = true)]
+public sealed class LoadSensitiveCollection { }

--- a/tests/Zeus.Plugins.Host.Tests/VstEngineSupervisorTests.cs
+++ b/tests/Zeus.Plugins.Host.Tests/VstEngineSupervisorTests.cs
@@ -12,7 +12,13 @@ namespace Zeus.Plugins.Host.Tests;
 /// watchdog, handshake validation, and reconnect replay. These run on ANY
 /// platform: the controller's test/seam constructor injects fake process and
 /// bridge implementations, so no real engine or Windows shared memory is needed.
+///
+/// In the LoadSensitive collection (non-parallel): these assert on timing
+/// (watchdog intervals, relaunch backoff), so running them without sibling
+/// tests competing for the runner's cores removes the contention that made
+/// them flaky once the assembly grew.
 /// </summary>
+[Collection("LoadSensitive")]
 public class VstEngineSupervisorTests
 {
     static VstEngineSupervisorTests()


### PR DESCRIPTION
## Why the flakes started *today* (and kept coming back)
All of today's CI flakes — `HungEngine_IsRecycledByWatchdog`, `PersistentLaunchFailure_TripsCrashLoopCap`, and `Process_OverManyBlocks_DoesNotAllocate` — live in `Zeus.Plugins.Host.Tests`. #701 (TX Audio Profiles) added `PluginSettingsStore` tests to that assembly. xUnit runs an assembly's tests **in parallel**; on a ~2-core CI runner the extra load starved/perturbed three latent-fragile *measurement* tests that previously had headroom.

Earlier point-fixes each patched one symptom (#698/#699/#702 raised the thread-pool floor; the no-alloc test got thread-local + per-block-average tweaks) — but the **root cause, parallel contention, kept surfacing new ones**. The no-alloc test re-flaked on macOS today even past its per-block threshold.

## The permanent fix (two parts)
1. **Non-parallel collection** — new `LoadSensitiveCollection` with `[CollectionDefinition(DisableParallelization = true)]`; `VstEngineSupervisorTests` and `AudioChainProcessNoAllocTests` join it via `[Collection("LoadSensitive")]`. They now run on their own, not concurrently with the rest of the assembly, so their timing/allocation measurements aren't perturbed by siblings. **This removes the contention root cause for all three.**
2. **Two-window no-alloc measurement** — tiered JIT can re-JIT `Process()` mid-loop and charge a one-shot allocation to the measuring thread; a fixed warm-up races it. Run a full warm-up window first (absorbs tiering), then measure the truly steady-state window.

## Verification
8/8 green locally running the full assembly repeatedly. **Test-only; no production code touched.** The real invariants are preserved (watchdog recycles a hung engine; crash-loop caps; RT audio hot path doesn't allocate per block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)