### PR TITLE
feat: add selectable audio devices

### DIFF
--- a/.github/workflows/build-native-libs.yml
+++ b/.github/workflows/build-native-libs.yml
@@ -356,6 +356,81 @@ jobs:
           # files land in the artifact alongside libwdsp.so.
           path: Zeus.Dsp/runtimes/linux-${{ matrix.arch }}/native/
 
+  build-macos:
+    name: Build macOS Native Libraries
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          # fftw bottle ships both fftw3 (double, for WDSP) and fftw3f
+          # (single, for libspecbleach / NR4). cmake is preinstalled on
+          # macos-14 but brew keeps this aligned with release.yml.
+          brew install fftw cmake
+
+      - name: Configure CMake
+        run: |
+          cmake -S native/wdsp -B native/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DWDSP_WITH_NR3=OFF \
+            -DWDSP_WITH_NR4=ON
+
+      - name: Build
+        run: cmake --build native/build --config Release --parallel
+
+      - name: Verify SBNR exports
+        run: |
+          # macOS nm prefixes C symbols with an underscore.
+          count=$(nm -gU native/build/libwdsp.dylib | grep -c "_SetRXASBNR" || true)
+          echo "Found $count _SetRXASBNR* exports"
+          if [ "$count" -ne 8 ]; then
+            echo "ERROR: Expected 8 _SetRXASBNR* exports, got $count. NR4 did not link correctly."
+            exit 1
+          fi
+
+      - name: Stage dylib + bundled FFTW
+        run: |
+          set -eux
+          destDir="Zeus.Dsp/runtimes/osx-arm64/native"
+          mkdir -p "$destDir"
+          cp native/build/libwdsp.dylib "$destDir/libwdsp.dylib"
+
+          fftw_lib="$(brew --prefix fftw)/lib"
+          cp "${fftw_lib}/libfftw3.3.dylib"  "$destDir/libfftw3.3.dylib"
+          cp "${fftw_lib}/libfftw3f.3.dylib" "$destDir/libfftw3f.3.dylib"
+
+          install_name_tool \
+            -change "${fftw_lib}/libfftw3.3.dylib"  @loader_path/libfftw3.3.dylib \
+            -change "${fftw_lib}/libfftw3f.3.dylib" @loader_path/libfftw3f.3.dylib \
+            "$destDir/libwdsp.dylib"
+
+          if otool -L "$destDir/libwdsp.dylib" | grep -q '/opt/homebrew'; then
+            echo "ERROR: Homebrew absolute paths still present after install_name_tool rewrite"
+            otool -L "$destDir/libwdsp.dylib"
+            exit 1
+          fi
+          otool -L "$destDir/libwdsp.dylib"
+
+      # ---------- miniaudio (desktop-mode RX sink + TX mic capture) -------
+      #
+      # Pure C, CoreAudio backend. macOS frameworks (CoreAudio /
+      # AudioToolbox / AudioUnit / CoreFoundation) come from the SDK that
+      # ships with Xcode CLT on macos-14.
+      - name: Build & stage miniaudio
+        run: |
+          set -eux
+          cmake -S native/miniaudio -B native/build-miniaudio -DCMAKE_BUILD_TYPE=Release
+          cmake --build native/build-miniaudio --config Release --parallel
+          cp native/build-miniaudio/libminiaudio.dylib Zeus.Dsp/runtimes/osx-arm64/native/libminiaudio.dylib
+          otool -L Zeus.Dsp/runtimes/osx-arm64/native/libminiaudio.dylib
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wdsp-osx-arm64
+          path: Zeus.Dsp/runtimes/osx-arm64/native/
+
   # ---------- zeus-vst-bridge (in-process VST3 host) ------------------
   #
   # The bridge hosts VST3 plugins via Steinberg's MIT-licensed vst3sdk,

--- a/Zeus.Server.Hosting/AudioDeviceSettingsStore.cs
+++ b/Zeus.Server.Hosting/AudioDeviceSettingsStore.cs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using LiteDB;
+
+namespace Zeus.Server;
+
+public sealed record AudioDeviceSettings(string? InputDeviceId, string? OutputDeviceId);
+
+public sealed class AudioDeviceSettingsStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<AudioDeviceSettingsEntry> _docs;
+    private readonly ILogger<AudioDeviceSettingsStore> _log;
+    private readonly object _sync = new();
+
+    public AudioDeviceSettingsStore(
+        ILogger<AudioDeviceSettingsStore> log,
+        string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _docs = _db.GetCollection<AudioDeviceSettingsEntry>("audio_device_settings");
+
+        _log.LogInformation("AudioDeviceSettingsStore initialized at {Path}", dbPath);
+    }
+
+    public AudioDeviceSettings Get()
+    {
+        lock (_sync)
+        {
+            var e = _docs.FindAll().FirstOrDefault();
+            return e is null
+                ? new AudioDeviceSettings(InputDeviceId: null, OutputDeviceId: null)
+                : new AudioDeviceSettings(
+                    InputDeviceId: Normalize(e.InputDeviceId),
+                    OutputDeviceId: Normalize(e.OutputDeviceId));
+        }
+    }
+
+    public void SetInputDeviceId(string? inputDeviceId)
+    {
+        lock (_sync)
+        {
+            var e = GetOrCreateEntry();
+            e.InputDeviceId = Normalize(inputDeviceId);
+            SaveEntry(e);
+        }
+    }
+
+    public void SetOutputDeviceId(string? outputDeviceId)
+    {
+        lock (_sync)
+        {
+            var e = GetOrCreateEntry();
+            e.OutputDeviceId = Normalize(outputDeviceId);
+            SaveEntry(e);
+        }
+    }
+
+    public void Set(string? inputDeviceId, string? outputDeviceId)
+    {
+        lock (_sync)
+        {
+            var e = GetOrCreateEntry();
+            e.InputDeviceId = Normalize(inputDeviceId);
+            e.OutputDeviceId = Normalize(outputDeviceId);
+            SaveEntry(e);
+        }
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private AudioDeviceSettingsEntry GetOrCreateEntry() =>
+        _docs.FindAll().FirstOrDefault() ?? new AudioDeviceSettingsEntry();
+
+    private void SaveEntry(AudioDeviceSettingsEntry e)
+    {
+        e.UpdatedUtc = DateTime.UtcNow;
+        if (e.Id == 0) _docs.Insert(e);
+        else _docs.Update(e);
+    }
+
+    private static string? Normalize(string? value)
+    {
+        var trimmed = value?.Trim();
+        return string.IsNullOrWhiteSpace(trimmed) ? null : trimmed;
+    }
+}
+
+public sealed class AudioDeviceSettingsEntry
+{
+    public int Id { get; set; }
+    public string? InputDeviceId { get; set; }
+    public string? OutputDeviceId { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/MiniAudioDevices.cs
+++ b/Zeus.Server.Hosting/MiniAudioDevices.cs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Runtime.InteropServices;
+
+namespace Zeus.Server;
+
+internal sealed record MiniAudioDeviceInfo(string Id, string Name, bool IsDefault);
+
+internal sealed record MiniAudioDeviceSnapshot(
+    IReadOnlyList<MiniAudioDeviceInfo> Outputs,
+    IReadOnlyList<MiniAudioDeviceInfo> Inputs)
+{
+    public static MiniAudioDeviceSnapshot Empty { get; } = new([], []);
+}
+
+internal static class MiniAudioDevices
+{
+    public static MiniAudioDeviceSnapshot Enumerate()
+    {
+        MiniAudioInterop.EnsureResolverRegistered();
+        IntPtr snapshot = MiniAudioInterop.DevicesCreate();
+        if (snapshot == IntPtr.Zero) return MiniAudioDeviceSnapshot.Empty;
+
+        try
+        {
+            return new MiniAudioDeviceSnapshot(
+                Outputs: ReadDevices(
+                    snapshot,
+                    MiniAudioInterop.DevicesPlaybackCount,
+                    MiniAudioInterop.DevicesPlaybackId,
+                    MiniAudioInterop.DevicesPlaybackName,
+                    MiniAudioInterop.DevicesPlaybackDefault),
+                Inputs: ReadDevices(
+                    snapshot,
+                    MiniAudioInterop.DevicesCaptureCount,
+                    MiniAudioInterop.DevicesCaptureId,
+                    MiniAudioInterop.DevicesCaptureName,
+                    MiniAudioInterop.DevicesCaptureDefault));
+        }
+        finally
+        {
+            MiniAudioInterop.DevicesDestroy(snapshot);
+        }
+    }
+
+    private static IReadOnlyList<MiniAudioDeviceInfo> ReadDevices(
+        IntPtr snapshot,
+        Func<IntPtr, uint> countFn,
+        Func<IntPtr, uint, IntPtr> idFn,
+        Func<IntPtr, uint, IntPtr> nameFn,
+        Func<IntPtr, uint, int> defaultFn)
+    {
+        uint count = countFn(snapshot);
+        if (count == 0) return [];
+
+        var devices = new List<MiniAudioDeviceInfo>(checked((int)count));
+        for (uint i = 0; i < count; i++)
+        {
+            string id = Marshal.PtrToStringUTF8(idFn(snapshot, i)) ?? "";
+            if (string.IsNullOrWhiteSpace(id)) continue;
+            string name = Marshal.PtrToStringUTF8(nameFn(snapshot, i)) ?? "";
+            if (string.IsNullOrWhiteSpace(name)) name = $"Audio device {i + 1}";
+            devices.Add(new MiniAudioDeviceInfo(id, name, defaultFn(snapshot, i) != 0));
+        }
+        return devices;
+    }
+}

--- a/Zeus.Server.Hosting/MiniAudioInput.cs
+++ b/Zeus.Server.Hosting/MiniAudioInput.cs
@@ -36,6 +36,7 @@ internal sealed class MiniAudioInput : IDisposable
     public MiniAudioInput(
         FramesCallback onFrames,
         Action<int>? onNotify = null,
+        string? deviceIdHex = null,
         uint preferSampleRate = 48_000,
         uint preferChannels = 1,
         uint periodFrames = 480,
@@ -49,11 +50,12 @@ internal sealed class MiniAudioInput : IDisposable
         _nativeDataCb = NativeDataCallback;
         _nativeNotifyCb = NativeNotifyCallback;
 
-        _handle = MiniAudioInterop.InputCreate(
+        _handle = CreateNativeHandle(
             preferSampleRate,
             preferChannels,
             periodFrames,
             periods,
+            deviceIdHex,
             Marshal.GetFunctionPointerForDelegate(_nativeDataCb),
             Marshal.GetFunctionPointerForDelegate(_nativeNotifyCb),
             IntPtr.Zero);
@@ -61,11 +63,54 @@ internal sealed class MiniAudioInput : IDisposable
         if (_handle == IntPtr.Zero)
         {
             throw new InvalidOperationException(
-                "miniaudio: failed to open default capture device (zeus_ma_input_create returned NULL).");
+                deviceIdHex is null
+                    ? "miniaudio: failed to open default capture device (zeus_ma_input_create returned NULL)."
+                    : "miniaudio: failed to open selected capture device (zeus_ma_input_create_for_device returned NULL).");
         }
 
         SampleRate = MiniAudioInterop.InputSampleRate(_handle);
         Channels = MiniAudioInterop.InputChannels(_handle);
+    }
+
+    private static IntPtr CreateNativeHandle(
+        uint preferSampleRate,
+        uint preferChannels,
+        uint periodFrames,
+        uint periods,
+        string? deviceIdHex,
+        IntPtr dataCallback,
+        IntPtr notifyCallback,
+        IntPtr user)
+    {
+        if (string.IsNullOrWhiteSpace(deviceIdHex))
+        {
+            return MiniAudioInterop.InputCreate(
+                preferSampleRate,
+                preferChannels,
+                periodFrames,
+                periods,
+                dataCallback,
+                notifyCallback,
+                user);
+        }
+
+        IntPtr deviceIdPtr = Marshal.StringToCoTaskMemUTF8(deviceIdHex);
+        try
+        {
+            return MiniAudioInterop.InputCreateForDevice(
+                preferSampleRate,
+                preferChannels,
+                periodFrames,
+                periods,
+                deviceIdPtr,
+                dataCallback,
+                notifyCallback,
+                user);
+        }
+        finally
+        {
+            Marshal.FreeCoTaskMem(deviceIdPtr);
+        }
     }
 
     public void Start()

--- a/Zeus.Server.Hosting/MiniAudioInterop.cs
+++ b/Zeus.Server.Hosting/MiniAudioInterop.cs
@@ -127,6 +127,18 @@ internal static partial class MiniAudioInterop
         IntPtr notifyCallback,
         IntPtr user);
 
+    [LibraryImport(LibraryName, EntryPoint = "zeus_ma_output_create_for_device")]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    internal static partial IntPtr OutputCreateForDevice(
+        uint preferSampleRate,
+        uint preferChannels,
+        uint periodFrames,
+        uint periods,
+        IntPtr deviceIdHex,
+        IntPtr dataCallback,
+        IntPtr notifyCallback,
+        IntPtr user);
+
     [LibraryImport(LibraryName, EntryPoint = "zeus_ma_output_start")]
     [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
     internal static partial int OutputStart(IntPtr handle);
@@ -160,6 +172,18 @@ internal static partial class MiniAudioInterop
         IntPtr notifyCallback,
         IntPtr user);
 
+    [LibraryImport(LibraryName, EntryPoint = "zeus_ma_input_create_for_device")]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    internal static partial IntPtr InputCreateForDevice(
+        uint preferSampleRate,
+        uint preferChannels,
+        uint periodFrames,
+        uint periods,
+        IntPtr deviceIdHex,
+        IntPtr dataCallback,
+        IntPtr notifyCallback,
+        IntPtr user);
+
     [LibraryImport(LibraryName, EntryPoint = "zeus_ma_input_start")]
     [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
     internal static partial int InputStart(IntPtr handle);
@@ -179,6 +203,48 @@ internal static partial class MiniAudioInterop
     [LibraryImport(LibraryName, EntryPoint = "zeus_ma_input_destroy")]
     [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
     internal static partial void InputDestroy(IntPtr handle);
+
+    // ---- Device enumeration ---------------------------------------------
+
+    [LibraryImport(LibraryName, EntryPoint = "zeus_ma_devices_create")]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    internal static partial IntPtr DevicesCreate();
+
+    [LibraryImport(LibraryName, EntryPoint = "zeus_ma_devices_playback_count")]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    internal static partial uint DevicesPlaybackCount(IntPtr snapshot);
+
+    [LibraryImport(LibraryName, EntryPoint = "zeus_ma_devices_capture_count")]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    internal static partial uint DevicesCaptureCount(IntPtr snapshot);
+
+    [LibraryImport(LibraryName, EntryPoint = "zeus_ma_devices_playback_id")]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    internal static partial IntPtr DevicesPlaybackId(IntPtr snapshot, uint index);
+
+    [LibraryImport(LibraryName, EntryPoint = "zeus_ma_devices_capture_id")]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    internal static partial IntPtr DevicesCaptureId(IntPtr snapshot, uint index);
+
+    [LibraryImport(LibraryName, EntryPoint = "zeus_ma_devices_playback_name")]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    internal static partial IntPtr DevicesPlaybackName(IntPtr snapshot, uint index);
+
+    [LibraryImport(LibraryName, EntryPoint = "zeus_ma_devices_capture_name")]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    internal static partial IntPtr DevicesCaptureName(IntPtr snapshot, uint index);
+
+    [LibraryImport(LibraryName, EntryPoint = "zeus_ma_devices_playback_default")]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    internal static partial int DevicesPlaybackDefault(IntPtr snapshot, uint index);
+
+    [LibraryImport(LibraryName, EntryPoint = "zeus_ma_devices_capture_default")]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    internal static partial int DevicesCaptureDefault(IntPtr snapshot, uint index);
+
+    [LibraryImport(LibraryName, EntryPoint = "zeus_ma_devices_destroy")]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    internal static partial void DevicesDestroy(IntPtr snapshot);
 
     // ---- Version probe ---------------------------------------------------
 

--- a/Zeus.Server.Hosting/MiniAudioOutput.cs
+++ b/Zeus.Server.Hosting/MiniAudioOutput.cs
@@ -67,6 +67,7 @@ internal sealed class MiniAudioOutput : IDisposable
     public MiniAudioOutput(
         FramesCallback onFrames,
         Action<int>? onNotify = null,
+        string? deviceIdHex = null,
         uint preferSampleRate = 48_000,
         uint preferChannels = 2,
         uint periodFrames = 480,
@@ -83,11 +84,12 @@ internal sealed class MiniAudioOutput : IDisposable
         _nativeDataCb = NativeDataCallback;
         _nativeNotifyCb = NativeNotifyCallback;
 
-        _handle = MiniAudioInterop.OutputCreate(
+        _handle = CreateNativeHandle(
             preferSampleRate,
             preferChannels,
             periodFrames,
             periods,
+            deviceIdHex,
             Marshal.GetFunctionPointerForDelegate(_nativeDataCb),
             Marshal.GetFunctionPointerForDelegate(_nativeNotifyCb),
             IntPtr.Zero);
@@ -95,11 +97,54 @@ internal sealed class MiniAudioOutput : IDisposable
         if (_handle == IntPtr.Zero)
         {
             throw new InvalidOperationException(
-                "miniaudio: failed to open default playback device (zeus_ma_output_create returned NULL).");
+                deviceIdHex is null
+                    ? "miniaudio: failed to open default playback device (zeus_ma_output_create returned NULL)."
+                    : "miniaudio: failed to open selected playback device (zeus_ma_output_create_for_device returned NULL).");
         }
 
         SampleRate = MiniAudioInterop.OutputSampleRate(_handle);
         Channels = MiniAudioInterop.OutputChannels(_handle);
+    }
+
+    private static IntPtr CreateNativeHandle(
+        uint preferSampleRate,
+        uint preferChannels,
+        uint periodFrames,
+        uint periods,
+        string? deviceIdHex,
+        IntPtr dataCallback,
+        IntPtr notifyCallback,
+        IntPtr user)
+    {
+        if (string.IsNullOrWhiteSpace(deviceIdHex))
+        {
+            return MiniAudioInterop.OutputCreate(
+                preferSampleRate,
+                preferChannels,
+                periodFrames,
+                periods,
+                dataCallback,
+                notifyCallback,
+                user);
+        }
+
+        IntPtr deviceIdPtr = Marshal.StringToCoTaskMemUTF8(deviceIdHex);
+        try
+        {
+            return MiniAudioInterop.OutputCreateForDevice(
+                preferSampleRate,
+                preferChannels,
+                periodFrames,
+                periods,
+                deviceIdPtr,
+                dataCallback,
+                notifyCallback,
+                user);
+        }
+        finally
+        {
+            Marshal.FreeCoTaskMem(deviceIdPtr);
+        }
     }
 
     /// <summary>Start the device. Idempotent.</summary>

--- a/Zeus.Server.Hosting/NativeAudioSink.cs
+++ b/Zeus.Server.Hosting/NativeAudioSink.cs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026 Brian Keating (EI6LF) and contributors.
 //
 // Desktop-mode RX audio sink: drains demodulated audio (mono float32 48 kHz,
-// produced by DspPipelineService) directly into the OS default playback
+// produced by DspPipelineService) directly into the selected OS playback
 // device via miniaudio. The WebSocket fan-out is skipped entirely in this
 // mode — the SPA's audio-decoder is opted out by Phase 2c.
 //
@@ -21,7 +21,7 @@ namespace Zeus.Server;
 
 /// <summary>
 /// <see cref="IRxAudioSink"/> implementation that pushes RX audio straight
-/// to the OS default playback device via miniaudio. Used in desktop mode
+/// to the selected OS playback device via miniaudio. Used in desktop mode
 /// (<see cref="ZeusHostMode.Desktop"/>) in place of
 /// <see cref="WebSocketAudioSink"/>.
 ///
@@ -84,6 +84,7 @@ internal sealed class NativeAudioSink : IRxAudioSink, IPreviewAudioSink, IHosted
     private const int PreviewRingCapacity = 16_384;
 
     private readonly ILogger<NativeAudioSink> _log;
+    private readonly AudioDeviceSettingsStore? _deviceSettings;
     // Service-provider-based lookup for TxService, used to subscribe to
     // TxActiveChanged in StartAsync. NativeAudioSink can NOT take TxService
     // as a constructor dep directly: DspPipelineService depends on
@@ -94,6 +95,7 @@ internal sealed class NativeAudioSink : IRxAudioSink, IPreviewAudioSink, IHosted
     private readonly IServiceProvider? _services;
     private readonly FloatSpscRing _ring = new(RingCapacity);
     private readonly FloatSpscRing _previewRing = new(PreviewRingCapacity);
+    private readonly object _deviceSync = new();
 
     // Resolved on Start, kept so Stop can detach the handler cleanly.
     // Null when no TxService was available (legacy test ctor or
@@ -102,6 +104,7 @@ internal sealed class NativeAudioSink : IRxAudioSink, IPreviewAudioSink, IHosted
     private Action<bool>? _txActiveHandler;
 
     private MiniAudioOutput? _output;
+    private string? _activeOutputDeviceId;
     private bool _disposed;
 
     // Mute flag for the Photino-side Mute/Unmute button. Read on the DSP
@@ -123,6 +126,8 @@ internal sealed class NativeAudioSink : IRxAudioSink, IPreviewAudioSink, IHosted
 
     public bool IsMuted => _muted;
     public bool IsEnabled => _previewEnabled;
+    public string? ConfiguredOutputDeviceId => _deviceSettings?.Get().OutputDeviceId;
+    public string? ActiveOutputDeviceId => _activeOutputDeviceId;
 
     public void SetMuted(bool muted)
     {
@@ -167,9 +172,13 @@ internal sealed class NativeAudioSink : IRxAudioSink, IPreviewAudioSink, IHosted
     private long _totalSamplesOut;
     private DateTime _lastLogUtc = DateTime.UtcNow;
 
-    public NativeAudioSink(ILogger<NativeAudioSink> log, IServiceProvider? services = null)
+    public NativeAudioSink(
+        ILogger<NativeAudioSink> log,
+        AudioDeviceSettingsStore? deviceSettings = null,
+        IServiceProvider? services = null)
     {
         _log = log;
+        _deviceSettings = deviceSettings;
         _services = services;
     }
 
@@ -182,26 +191,10 @@ internal sealed class NativeAudioSink : IRxAudioSink, IPreviewAudioSink, IHosted
     /// </summary>
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        if (_output != null) return Task.CompletedTask;
-        try
+        lock (_deviceSync)
         {
-            _output = new MiniAudioOutput(
-                onFrames: OnPlaybackData,
-                onNotify: OnDeviceNotification,
-                preferSampleRate: FrameRateHz,
-                preferChannels: 2,
-                periodFrames: 480,   // ≈10 ms @ 48 kHz
-                periods: 2);
-            _output.Start();
-            _log.LogInformation(
-                "audio.native.rx open rate={Rate}Hz channels={Channels} version={Version}",
-                _output.SampleRate, _output.Channels, MiniAudioInterop.Version());
-        }
-        catch (Exception ex)
-        {
-            _log.LogWarning(ex, "audio.native.rx open failed; RX audio output disabled");
-            _output?.Dispose();
-            _output = null;
+            if (_output != null) return Task.CompletedTask;
+            OpenOutputLocked(ConfiguredOutputDeviceId);
         }
 
         // Subscribe to TX-active edges so we can drain the ring on TX-on.
@@ -232,9 +225,93 @@ internal sealed class NativeAudioSink : IRxAudioSink, IPreviewAudioSink, IHosted
             _tx.TxActiveChanged -= _txActiveHandler;
             _txActiveHandler = null;
         }
+        lock (_deviceSync)
+        {
+            try { _output?.Stop(); }
+            catch (Exception ex) { _log.LogWarning(ex, "audio.native.rx stop threw"); }
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task SetOutputDeviceAsync(string? deviceId, CancellationToken cancellationToken = default)
+    {
+        string? normalized = NormalizeDeviceId(deviceId);
+        _deviceSettings?.SetOutputDeviceId(normalized);
+
+        lock (_deviceSync)
+        {
+            CloseOutputLocked(dispose: true);
+            _ring.Clear();
+            _previewRing.Clear();
+            _rebuffering = true;
+            OpenOutputLocked(normalized);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void OpenOutputLocked(string? requestedDeviceId)
+    {
+        try
+        {
+            _output = CreateOutput(requestedDeviceId);
+            _output.Start();
+            _activeOutputDeviceId = NormalizeDeviceId(requestedDeviceId);
+            _log.LogInformation(
+                "audio.native.rx open device={Device} rate={Rate}Hz channels={Channels} version={Version}",
+                _activeOutputDeviceId is null ? "default" : "selected",
+                _output.SampleRate, _output.Channels, MiniAudioInterop.Version());
+            return;
+        }
+        catch (Exception ex) when (!string.IsNullOrWhiteSpace(requestedDeviceId))
+        {
+            _log.LogWarning(ex, "audio.native.rx selected output open failed; falling back to default");
+            CloseOutputLocked(dispose: true);
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "audio.native.rx open failed; RX audio output disabled");
+            CloseOutputLocked(dispose: true);
+            return;
+        }
+
+        try
+        {
+            _output = CreateOutput(null);
+            _output.Start();
+            _activeOutputDeviceId = null;
+            _log.LogInformation(
+                "audio.native.rx open device=default rate={Rate}Hz channels={Channels} version={Version}",
+                _output.SampleRate, _output.Channels, MiniAudioInterop.Version());
+        }
+        catch (Exception fallbackEx)
+        {
+            _log.LogWarning(fallbackEx, "audio.native.rx default fallback open failed; RX audio output disabled");
+            CloseOutputLocked(dispose: true);
+        }
+    }
+
+    private MiniAudioOutput CreateOutput(string? deviceId) =>
+        new(
+            onFrames: OnPlaybackData,
+            onNotify: OnDeviceNotification,
+            deviceIdHex: NormalizeDeviceId(deviceId),
+            preferSampleRate: FrameRateHz,
+            preferChannels: 2,
+            periodFrames: 480,
+            periods: 2);
+
+    private void CloseOutputLocked(bool dispose)
+    {
         try { _output?.Stop(); }
         catch (Exception ex) { _log.LogWarning(ex, "audio.native.rx stop threw"); }
-        return Task.CompletedTask;
+        if (dispose)
+        {
+            try { _output?.Dispose(); }
+            catch (Exception ex) { _log.LogWarning(ex, "audio.native.rx dispose threw"); }
+        }
+        _output = null;
+        _activeOutputDeviceId = null;
     }
 
     /// <summary>
@@ -429,12 +506,19 @@ internal sealed class NativeAudioSink : IRxAudioSink, IPreviewAudioSink, IHosted
             inS, outS, under, over);
     }
 
+    private static string? NormalizeDeviceId(string? deviceId)
+    {
+        var trimmed = deviceId?.Trim();
+        return string.IsNullOrWhiteSpace(trimmed) ? null : trimmed;
+    }
+
     public void Dispose()
     {
         if (_disposed) return;
         _disposed = true;
-        try { _output?.Dispose(); }
-        catch (Exception ex) { _log.LogWarning(ex, "audio.native.rx dispose threw"); }
-        _output = null;
+        lock (_deviceSync)
+        {
+            CloseOutputLocked(dispose: true);
+        }
     }
 }

--- a/Zeus.Server.Hosting/NativeMicCapture.cs
+++ b/Zeus.Server.Hosting/NativeMicCapture.cs
@@ -12,7 +12,7 @@
 // Frame shape: f32le little-endian, 960 samples mono @ 48 kHz (20 ms
 // blocks), matching the browser worklet's MicPcm payload exactly. The
 // AudioWorklet on the SPA emits the same shape; this just produces it from
-// the OS default input device instead of getUserMedia.
+// the selected OS input device instead of getUserMedia.
 
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
@@ -22,7 +22,7 @@ using Zeus.Contracts;
 namespace Zeus.Server;
 
 /// <summary>
-/// Desktop-mode hosted service that opens the OS default input device via
+/// Desktop-mode hosted service that opens the selected OS input device via
 /// miniaudio and feeds 960-sample (20 ms @ 48 kHz mono) f32le blocks into
 /// <see cref="TxAudioIngest.OnMicPcmBytes"/>. Service mode never registers
 /// this service so the .dylib never loads from the server-only build.
@@ -58,8 +58,11 @@ internal sealed class NativeMicCapture : IHostedService, IDisposable
     private readonly StreamingHub _hub;
     private readonly AudioPluginBridge _bridge;
     private readonly ILogger<NativeMicCapture> _log;
+    private readonly AudioDeviceSettingsStore? _deviceSettings;
 
     private MiniAudioInput? _input;
+    private readonly object _deviceSync = new();
+    private string? _activeInputDeviceId;
     private readonly float[] _accum = new float[MicBlockSamples];
     private int _accumFill;
     // Pre-allocated payload buffer reused for every flush; OnMicPcmBytes
@@ -84,52 +87,133 @@ internal sealed class NativeMicCapture : IHostedService, IDisposable
         TxAudioIngest ingest,
         StreamingHub hub,
         AudioPluginBridge bridge,
-        ILogger<NativeMicCapture> log)
+        ILogger<NativeMicCapture> log,
+        AudioDeviceSettingsStore? deviceSettings = null)
     {
         _ingest = ingest;
         _hub = hub;
         _bridge = bridge;
         _log = log;
+        _deviceSettings = deviceSettings;
     }
+
+    public string? ConfiguredInputDeviceId => _deviceSettings?.Get().InputDeviceId;
+    public string? ActiveInputDeviceId => _activeInputDeviceId;
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        try
+        lock (_deviceSync)
         {
-            _input = new MiniAudioInput(
-                onFrames: OnCaptureData,
-                onNotify: OnDeviceNotification,
-                preferSampleRate: 48_000,
-                preferChannels: 1,
-                periodFrames: 480,
-                periods: 2);
-            _input.Start();
-            _log.LogInformation(
-                "audio.native.tx mic open rate={Rate}Hz channels={Channels}",
-                _input.SampleRate, _input.Channels);
-        }
-        catch (Exception ex)
-        {
-            // Don't kill the host — desktop mode without a working mic should
-            // still RX. The operator may not even have a mic plugged in.
-            _log.LogWarning(ex, "audio.native.tx mic open failed; TX uplink disabled");
-            _input = null;
+            if (_input != null) return Task.CompletedTask;
+            OpenInputLocked(ConfiguredInputDeviceId);
         }
         return Task.CompletedTask;
     }
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
-        try { _input?.Stop(); }
-        catch (Exception ex) { _log.LogWarning(ex, "audio.native.tx stop threw"); }
+        lock (_deviceSync)
+        {
+            try { _input?.Stop(); }
+            catch (Exception ex) { _log.LogWarning(ex, "audio.native.tx stop threw"); }
+        }
         return Task.CompletedTask;
     }
 
     public void Dispose()
     {
-        try { _input?.Dispose(); }
-        catch (Exception ex) { _log.LogWarning(ex, "audio.native.tx dispose threw"); }
+        lock (_deviceSync)
+        {
+            CloseInputLocked(dispose: true);
+        }
+    }
+
+    public Task SetInputDeviceAsync(string? deviceId, CancellationToken cancellationToken = default)
+    {
+        string? normalized = NormalizeDeviceId(deviceId);
+        _deviceSettings?.SetInputDeviceId(normalized);
+
+        lock (_deviceSync)
+        {
+            CloseInputLocked(dispose: true);
+            ResetAccumulation();
+            OpenInputLocked(normalized);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void OpenInputLocked(string? requestedDeviceId)
+    {
+        try
+        {
+            _input = CreateInput(requestedDeviceId);
+            _input.Start();
+            _activeInputDeviceId = NormalizeDeviceId(requestedDeviceId);
+            _log.LogInformation(
+                "audio.native.tx mic open device={Device} rate={Rate}Hz channels={Channels}",
+                _activeInputDeviceId is null ? "default" : "selected",
+                _input.SampleRate, _input.Channels);
+            return;
+        }
+        catch (Exception ex) when (!string.IsNullOrWhiteSpace(requestedDeviceId))
+        {
+            _log.LogWarning(ex, "audio.native.tx selected mic open failed; falling back to default");
+            CloseInputLocked(dispose: true);
+        }
+        catch (Exception ex)
+        {
+            // Don't kill the host; desktop mode without a working mic should
+            // still RX. The operator may not even have a mic plugged in.
+            _log.LogWarning(ex, "audio.native.tx mic open failed; TX uplink disabled");
+            CloseInputLocked(dispose: true);
+            return;
+        }
+
+        try
+        {
+            _input = CreateInput(null);
+            _input.Start();
+            _activeInputDeviceId = null;
+            _log.LogInformation(
+                "audio.native.tx mic open device=default rate={Rate}Hz channels={Channels}",
+                _input.SampleRate, _input.Channels);
+        }
+        catch (Exception fallbackEx)
+        {
+            _log.LogWarning(fallbackEx, "audio.native.tx default mic fallback open failed; TX uplink disabled");
+            CloseInputLocked(dispose: true);
+        }
+    }
+
+    private MiniAudioInput CreateInput(string? deviceId) =>
+        new(
+            onFrames: OnCaptureData,
+            onNotify: OnDeviceNotification,
+            deviceIdHex: NormalizeDeviceId(deviceId),
+            preferSampleRate: 48_000,
+            preferChannels: 1,
+            periodFrames: 480,
+            periods: 2);
+
+    private void CloseInputLocked(bool dispose)
+    {
+        try { _input?.Stop(); }
+        catch (Exception ex) { _log.LogWarning(ex, "audio.native.tx stop threw"); }
+        if (dispose)
+        {
+            try { _input?.Dispose(); }
+            catch (Exception ex) { _log.LogWarning(ex, "audio.native.tx dispose threw"); }
+        }
         _input = null;
+        _activeInputDeviceId = null;
+    }
+
+    private void ResetAccumulation()
+    {
+        _accumFill = 0;
+        _peakWindow = 0f;
+        _peakWindowFill = 0;
     }
 
     private void OnCaptureData(ReadOnlySpan<float> input, uint frameCount, uint channels)
@@ -285,6 +369,12 @@ internal sealed class NativeMicCapture : IHostedService, IDisposable
 
     internal static float SanitizeCapturedSample(float sample)
         => DspPipelineService.SanitizeAudioSample(sample);
+
+    private static string? NormalizeDeviceId(string? deviceId)
+    {
+        var trimmed = deviceId?.Trim();
+        return string.IsNullOrWhiteSpace(trimmed) ? null : trimmed;
+    }
 
     internal static float DownmixCapturedFrame(
         ReadOnlySpan<float> interleavedSamples,

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -106,6 +106,8 @@ public static class ZeusEndpoints
             sink.SetMuted(body.Muted);
             return Results.Ok(new { supported = true, muted = sink.IsMuted });
         });
+        app.MapGet("/api/audio/devices", GetNativeAudioDevices);
+        app.MapPut("/api/audio/devices", SetNativeAudioDevices);
 
         static IResult GetAudioSuitePreview(RadioService radio)
         {
@@ -2639,6 +2641,112 @@ public static class ZeusEndpoints
 
     // ---------- helpers (formerly local functions in Program.cs) -------------
 
+    private static IResult GetNativeAudioDevices(IServiceProvider sp)
+    {
+        var sink = sp.GetService<NativeAudioSink>();
+        var mic = sp.GetService<NativeMicCapture>();
+        if (sink is null && mic is null)
+        {
+            return Results.Ok(new NativeAudioDevicesResponse(
+                Supported: false,
+                InputDeviceId: null,
+                OutputDeviceId: null,
+                ActiveInputDeviceId: null,
+                ActiveOutputDeviceId: null,
+                Inputs: [],
+                Outputs: [],
+                Error: null));
+        }
+
+        try
+        {
+            var snapshot = MiniAudioDevices.Enumerate();
+            return Results.Ok(BuildNativeAudioDevicesResponse(
+                sink,
+                mic,
+                snapshot,
+                supported: true,
+                error: null));
+        }
+        catch (Exception ex) when (ex is DllNotFoundException or EntryPointNotFoundException or BadImageFormatException)
+        {
+            return Results.Ok(BuildNativeAudioDevicesResponse(
+                sink,
+                mic,
+                MiniAudioDeviceSnapshot.Empty,
+                supported: false,
+                error: ex.Message));
+        }
+    }
+
+    private static async Task<IResult> SetNativeAudioDevices(
+        NativeAudioDevicesSetRequest body,
+        IServiceProvider sp,
+        CancellationToken ct)
+    {
+        var sink = sp.GetService<NativeAudioSink>();
+        var mic = sp.GetService<NativeMicCapture>();
+        if (sink is null && mic is null)
+            return Results.NotFound(new { error = "native audio not active in this host mode" });
+
+        string? inputDeviceId = NormalizeDeviceId(body?.InputDeviceId);
+        string? outputDeviceId = NormalizeDeviceId(body?.OutputDeviceId);
+
+        MiniAudioDeviceSnapshot snapshot;
+        try
+        {
+            snapshot = MiniAudioDevices.Enumerate();
+        }
+        catch (Exception ex) when (ex is DllNotFoundException or EntryPointNotFoundException or BadImageFormatException)
+        {
+            return Results.BadRequest(new { error = $"native audio device enumeration unavailable: {ex.Message}" });
+        }
+
+        if (inputDeviceId is not null && snapshot.Inputs.All(d => d.Id != inputDeviceId))
+            return Results.BadRequest(new { error = "inputDeviceId is not in the current native input device list" });
+        if (outputDeviceId is not null && snapshot.Outputs.All(d => d.Id != outputDeviceId))
+            return Results.BadRequest(new { error = "outputDeviceId is not in the current native output device list" });
+
+        if (mic is not null)
+            await mic.SetInputDeviceAsync(inputDeviceId, ct);
+        if (sink is not null)
+            await sink.SetOutputDeviceAsync(outputDeviceId, ct);
+
+        return Results.Ok(BuildNativeAudioDevicesResponse(
+            sink,
+            mic,
+            snapshot,
+            supported: true,
+            error: null));
+    }
+
+    private static NativeAudioDevicesResponse BuildNativeAudioDevicesResponse(
+        NativeAudioSink? sink,
+        NativeMicCapture? mic,
+        MiniAudioDeviceSnapshot snapshot,
+        bool supported,
+        string? error)
+    {
+        return new NativeAudioDevicesResponse(
+            Supported: supported,
+            InputDeviceId: mic?.ConfiguredInputDeviceId,
+            OutputDeviceId: sink?.ConfiguredOutputDeviceId,
+            ActiveInputDeviceId: mic?.ActiveInputDeviceId,
+            ActiveOutputDeviceId: sink?.ActiveOutputDeviceId,
+            Inputs: snapshot.Inputs.Select(ToNativeAudioDeviceDto).ToArray(),
+            Outputs: snapshot.Outputs.Select(ToNativeAudioDeviceDto).ToArray(),
+            Error: error);
+    }
+
+    private static NativeAudioDeviceDto ToNativeAudioDeviceDto(MiniAudioDeviceInfo device) =>
+        new(device.Id, device.Name, device.IsDefault);
+
+    private static string? NormalizeDeviceId(string? deviceId)
+    {
+        var trimmed = deviceId?.Trim();
+        return string.IsNullOrWhiteSpace(trimmed) ? null : trimmed;
+    }
+
     static bool TryParseIpEndpoint(string raw, out IPEndPoint ep)
     {
         ep = null!;
@@ -3636,6 +3744,17 @@ public static class ZeusEndpoints
 }
 
 internal sealed record NativeMuteRequest(bool Muted);
+internal sealed record NativeAudioDevicesSetRequest(string? InputDeviceId, string? OutputDeviceId);
+internal sealed record NativeAudioDeviceDto(string Id, string Name, bool IsDefault);
+internal sealed record NativeAudioDevicesResponse(
+    bool Supported,
+    string? InputDeviceId,
+    string? OutputDeviceId,
+    string? ActiveInputDeviceId,
+    string? ActiveOutputDeviceId,
+    IReadOnlyList<NativeAudioDeviceDto> Inputs,
+    IReadOnlyList<NativeAudioDeviceDto> Outputs,
+    string? Error);
 internal sealed record PreviewSetRequest(bool Enabled, bool? MeterOnly = null);
 internal sealed record ChainOrderSetRequest(List<string> PluginIds);
 internal sealed record ChainMembershipSetRequest(bool Active);

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -209,7 +209,7 @@ public static class ZeusHost
         //  - Server mode → WebSocketAudioSink (default): bit-for-bit
         //    equivalent of the pre-seam direct hub broadcast.
         //  - Desktop mode → NativeAudioSink (Phase 2b): pushes RX audio
-        //    straight to the OS default output device via miniaudio,
+        //    straight to the selected OS output device via miniaudio,
         //    bypassing the WS path entirely. The SPA's audio decoder is
         //    opted out by Phase 2c so the browser never tries to play
         //    audio it isn't being sent.
@@ -368,6 +368,7 @@ public static class ZeusHost
         builder.Services.AddSingleton<DisplayIntelligenceSettingsStore>();
         builder.Services.AddSingleton<ToolbarSettingsStore>();
         builder.Services.AddSingleton<NrUiPrefsStore>();
+        builder.Services.AddSingleton<AudioDeviceSettingsStore>();
         builder.Services.AddSingleton<TxStationProfileStore>();
         builder.Services.AddSingleton<TxFidelityPolicyStore>();
         // Unified TX Audio Profile store — the single operator-named macro that

--- a/native/miniaudio/zeus_miniaudio.c
+++ b/native/miniaudio/zeus_miniaudio.c
@@ -59,6 +59,80 @@ typedef struct {
     uint32_t                 negotiated_channels;
 } zeus_ma_input;
 
+typedef struct {
+    char                     id_hex[(sizeof(ma_device_id) * 2) + 1];
+    char                     name[MA_MAX_DEVICE_NAME_LENGTH + 1];
+    int32_t                  is_default;
+} zeus_ma_device_snapshot_entry;
+
+typedef struct {
+    uint32_t                         playback_count;
+    uint32_t                         capture_count;
+    zeus_ma_device_snapshot_entry*   playback;
+    zeus_ma_device_snapshot_entry*   capture;
+} zeus_ma_device_snapshot;
+
+/* ------------------------------------------------------------------------ */
+/* Device id helpers                                                        */
+/* ------------------------------------------------------------------------ */
+
+static char zeus_ma_hex_digit(unsigned int v)
+{
+    return (char)(v < 10 ? ('0' + v) : ('a' + (v - 10)));
+}
+
+static int zeus_ma_hex_value(char c)
+{
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return 10 + (c - 'a');
+    if (c >= 'A' && c <= 'F') return 10 + (c - 'A');
+    return -1;
+}
+
+static void zeus_ma_encode_device_id(const ma_device_id* id, char* out_hex)
+{
+    const unsigned char* bytes = (const unsigned char*)id;
+    size_t i;
+    for (i = 0; i < sizeof(ma_device_id); i += 1) {
+        out_hex[i * 2] = zeus_ma_hex_digit((bytes[i] >> 4) & 0x0F);
+        out_hex[(i * 2) + 1] = zeus_ma_hex_digit(bytes[i] & 0x0F);
+    }
+    out_hex[sizeof(ma_device_id) * 2] = '\0';
+}
+
+static ma_bool32 zeus_ma_decode_device_id(const char* hex, ma_device_id* out_id)
+{
+    size_t expected = sizeof(ma_device_id) * 2;
+    size_t i;
+    unsigned char* bytes;
+    if (hex == NULL || out_id == NULL) return MA_FALSE;
+    if (strlen(hex) != expected) return MA_FALSE;
+
+    memset(out_id, 0, sizeof(*out_id));
+    bytes = (unsigned char*)out_id;
+    for (i = 0; i < sizeof(ma_device_id); i += 1) {
+        int hi = zeus_ma_hex_value(hex[i * 2]);
+        int lo = zeus_ma_hex_value(hex[(i * 2) + 1]);
+        if (hi < 0 || lo < 0) return MA_FALSE;
+        bytes[i] = (unsigned char)((hi << 4) | lo);
+    }
+    return MA_TRUE;
+}
+
+static void zeus_ma_copy_device_entries(
+    zeus_ma_device_snapshot_entry* dst,
+    const ma_device_info* src,
+    uint32_t count)
+{
+    uint32_t i;
+    for (i = 0; i < count; i += 1) {
+        zeus_ma_encode_device_id(&src[i].id, dst[i].id_hex);
+        strncpy(dst[i].name, src[i].name, MA_MAX_DEVICE_NAME_LENGTH);
+        dst[i].name[MA_MAX_DEVICE_NAME_LENGTH] = '\0';
+        dst[i].is_default = src[i].isDefault ? 1 : 0;
+    }
+}
+
 /* ------------------------------------------------------------------------ */
 /* miniaudio callbacks (audio worker thread)                                */
 /* ------------------------------------------------------------------------ */
@@ -121,11 +195,12 @@ static void zeus_ma_input_notify_proc(const ma_device_notification* n)
 /* Playback                                                                 */
 /* ------------------------------------------------------------------------ */
 
-ZEUS_MA_EXPORT void* zeus_ma_output_create(
+static void* zeus_ma_output_create_internal(
     uint32_t prefer_sample_rate,
     uint32_t prefer_channels,
     uint32_t period_frames,
     uint32_t periods,
+    const char* device_id_hex,
     zeus_ma_playback_cb data_cb,
     zeus_ma_notify_cb notify_cb,
     void* user)
@@ -139,7 +214,18 @@ ZEUS_MA_EXPORT void* zeus_ma_output_create(
     h->notify_cb = notify_cb;
     h->user      = user;
 
+    ma_device_id requested_id;
+    ma_device_id* requested_id_ptr = NULL;
+    if (device_id_hex != NULL && device_id_hex[0] != '\0') {
+        if (!zeus_ma_decode_device_id(device_id_hex, &requested_id)) {
+            free(h);
+            return NULL;
+        }
+        requested_id_ptr = &requested_id;
+    }
+
     ma_device_config cfg = ma_device_config_init(ma_device_type_playback);
+    cfg.playback.pDeviceID = requested_id_ptr;
     cfg.playback.format    = ma_format_f32;
     cfg.playback.channels  = prefer_channels;        /* 0 = device native */
     cfg.sampleRate         = prefer_sample_rate;     /* 0 = device native */
@@ -171,6 +257,47 @@ ZEUS_MA_EXPORT void* zeus_ma_output_create(
     h->negotiated_rate     = h->device.sampleRate;
     h->negotiated_channels = h->device.playback.channels;
     return h;
+}
+
+ZEUS_MA_EXPORT void* zeus_ma_output_create(
+    uint32_t prefer_sample_rate,
+    uint32_t prefer_channels,
+    uint32_t period_frames,
+    uint32_t periods,
+    zeus_ma_playback_cb data_cb,
+    zeus_ma_notify_cb notify_cb,
+    void* user)
+{
+    return zeus_ma_output_create_internal(
+        prefer_sample_rate,
+        prefer_channels,
+        period_frames,
+        periods,
+        NULL,
+        data_cb,
+        notify_cb,
+        user);
+}
+
+ZEUS_MA_EXPORT void* zeus_ma_output_create_for_device(
+    uint32_t prefer_sample_rate,
+    uint32_t prefer_channels,
+    uint32_t period_frames,
+    uint32_t periods,
+    const char* device_id_hex,
+    zeus_ma_playback_cb data_cb,
+    zeus_ma_notify_cb notify_cb,
+    void* user)
+{
+    return zeus_ma_output_create_internal(
+        prefer_sample_rate,
+        prefer_channels,
+        period_frames,
+        periods,
+        device_id_hex,
+        data_cb,
+        notify_cb,
+        user);
 }
 
 ZEUS_MA_EXPORT int32_t zeus_ma_output_start(void* handle)
@@ -211,11 +338,12 @@ ZEUS_MA_EXPORT void zeus_ma_output_destroy(void* handle)
 /* Capture                                                                  */
 /* ------------------------------------------------------------------------ */
 
-ZEUS_MA_EXPORT void* zeus_ma_input_create(
+static void* zeus_ma_input_create_internal(
     uint32_t prefer_sample_rate,
     uint32_t prefer_channels,
     uint32_t period_frames,
     uint32_t periods,
+    const char* device_id_hex,
     zeus_ma_capture_cb data_cb,
     zeus_ma_notify_cb notify_cb,
     void* user)
@@ -229,7 +357,18 @@ ZEUS_MA_EXPORT void* zeus_ma_input_create(
     h->notify_cb = notify_cb;
     h->user      = user;
 
+    ma_device_id requested_id;
+    ma_device_id* requested_id_ptr = NULL;
+    if (device_id_hex != NULL && device_id_hex[0] != '\0') {
+        if (!zeus_ma_decode_device_id(device_id_hex, &requested_id)) {
+            free(h);
+            return NULL;
+        }
+        requested_id_ptr = &requested_id;
+    }
+
     ma_device_config cfg = ma_device_config_init(ma_device_type_capture);
+    cfg.capture.pDeviceID = requested_id_ptr;
     cfg.capture.format     = ma_format_f32;
     cfg.capture.channels   = prefer_channels;
     cfg.sampleRate         = prefer_sample_rate;
@@ -255,6 +394,47 @@ ZEUS_MA_EXPORT void* zeus_ma_input_create(
     h->negotiated_rate     = h->device.sampleRate;
     h->negotiated_channels = h->device.capture.channels;
     return h;
+}
+
+ZEUS_MA_EXPORT void* zeus_ma_input_create(
+    uint32_t prefer_sample_rate,
+    uint32_t prefer_channels,
+    uint32_t period_frames,
+    uint32_t periods,
+    zeus_ma_capture_cb data_cb,
+    zeus_ma_notify_cb notify_cb,
+    void* user)
+{
+    return zeus_ma_input_create_internal(
+        prefer_sample_rate,
+        prefer_channels,
+        period_frames,
+        periods,
+        NULL,
+        data_cb,
+        notify_cb,
+        user);
+}
+
+ZEUS_MA_EXPORT void* zeus_ma_input_create_for_device(
+    uint32_t prefer_sample_rate,
+    uint32_t prefer_channels,
+    uint32_t period_frames,
+    uint32_t periods,
+    const char* device_id_hex,
+    zeus_ma_capture_cb data_cb,
+    zeus_ma_notify_cb notify_cb,
+    void* user)
+{
+    return zeus_ma_input_create_internal(
+        prefer_sample_rate,
+        prefer_channels,
+        period_frames,
+        periods,
+        device_id_hex,
+        data_cb,
+        notify_cb,
+        user);
 }
 
 ZEUS_MA_EXPORT int32_t zeus_ma_input_start(void* handle)
@@ -289,6 +469,132 @@ ZEUS_MA_EXPORT void zeus_ma_input_destroy(void* handle)
     zeus_ma_input* h = (zeus_ma_input*)handle;
     ma_device_uninit(&h->device);
     free(h);
+}
+
+/* ------------------------------------------------------------------------ */
+/* Device enumeration                                                       */
+/* ------------------------------------------------------------------------ */
+
+ZEUS_MA_EXPORT void* zeus_ma_devices_create(void)
+{
+    ma_context ctx;
+    ma_device_info* playback_infos = NULL;
+    ma_device_info* capture_infos = NULL;
+    ma_uint32 playback_count = 0;
+    ma_uint32 capture_count = 0;
+    zeus_ma_device_snapshot* s = NULL;
+
+    if (ma_context_init(NULL, 0, NULL, &ctx) != MA_SUCCESS) {
+        return NULL;
+    }
+
+    if (ma_context_get_devices(&ctx, &playback_infos, &playback_count, &capture_infos, &capture_count) != MA_SUCCESS) {
+        ma_context_uninit(&ctx);
+        return NULL;
+    }
+
+    s = (zeus_ma_device_snapshot*)calloc(1, sizeof(*s));
+    if (s == NULL) {
+        ma_context_uninit(&ctx);
+        return NULL;
+    }
+
+    s->playback_count = (uint32_t)playback_count;
+    s->capture_count = (uint32_t)capture_count;
+
+    if (s->playback_count > 0) {
+        s->playback = (zeus_ma_device_snapshot_entry*)calloc(s->playback_count, sizeof(*s->playback));
+        if (s->playback == NULL) {
+            zeus_ma_devices_destroy(s);
+            ma_context_uninit(&ctx);
+            return NULL;
+        }
+        zeus_ma_copy_device_entries(s->playback, playback_infos, s->playback_count);
+    }
+
+    if (s->capture_count > 0) {
+        s->capture = (zeus_ma_device_snapshot_entry*)calloc(s->capture_count, sizeof(*s->capture));
+        if (s->capture == NULL) {
+            zeus_ma_devices_destroy(s);
+            ma_context_uninit(&ctx);
+            return NULL;
+        }
+        zeus_ma_copy_device_entries(s->capture, capture_infos, s->capture_count);
+    }
+
+    ma_context_uninit(&ctx);
+    return s;
+}
+
+ZEUS_MA_EXPORT uint32_t zeus_ma_devices_playback_count(void* snapshot)
+{
+    if (snapshot == NULL) return 0;
+    return ((zeus_ma_device_snapshot*)snapshot)->playback_count;
+}
+
+ZEUS_MA_EXPORT uint32_t zeus_ma_devices_capture_count(void* snapshot)
+{
+    if (snapshot == NULL) return 0;
+    return ((zeus_ma_device_snapshot*)snapshot)->capture_count;
+}
+
+static zeus_ma_device_snapshot_entry* zeus_ma_playback_entry(void* snapshot, uint32_t index)
+{
+    zeus_ma_device_snapshot* s = (zeus_ma_device_snapshot*)snapshot;
+    if (s == NULL || s->playback == NULL || index >= s->playback_count) return NULL;
+    return &s->playback[index];
+}
+
+static zeus_ma_device_snapshot_entry* zeus_ma_capture_entry(void* snapshot, uint32_t index)
+{
+    zeus_ma_device_snapshot* s = (zeus_ma_device_snapshot*)snapshot;
+    if (s == NULL || s->capture == NULL || index >= s->capture_count) return NULL;
+    return &s->capture[index];
+}
+
+ZEUS_MA_EXPORT const char* zeus_ma_devices_playback_id(void* snapshot, uint32_t index)
+{
+    zeus_ma_device_snapshot_entry* e = zeus_ma_playback_entry(snapshot, index);
+    return e == NULL ? "" : e->id_hex;
+}
+
+ZEUS_MA_EXPORT const char* zeus_ma_devices_capture_id(void* snapshot, uint32_t index)
+{
+    zeus_ma_device_snapshot_entry* e = zeus_ma_capture_entry(snapshot, index);
+    return e == NULL ? "" : e->id_hex;
+}
+
+ZEUS_MA_EXPORT const char* zeus_ma_devices_playback_name(void* snapshot, uint32_t index)
+{
+    zeus_ma_device_snapshot_entry* e = zeus_ma_playback_entry(snapshot, index);
+    return e == NULL ? "" : e->name;
+}
+
+ZEUS_MA_EXPORT const char* zeus_ma_devices_capture_name(void* snapshot, uint32_t index)
+{
+    zeus_ma_device_snapshot_entry* e = zeus_ma_capture_entry(snapshot, index);
+    return e == NULL ? "" : e->name;
+}
+
+ZEUS_MA_EXPORT int32_t zeus_ma_devices_playback_default(void* snapshot, uint32_t index)
+{
+    zeus_ma_device_snapshot_entry* e = zeus_ma_playback_entry(snapshot, index);
+    return e == NULL ? 0 : e->is_default;
+}
+
+ZEUS_MA_EXPORT int32_t zeus_ma_devices_capture_default(void* snapshot, uint32_t index)
+{
+    zeus_ma_device_snapshot_entry* e = zeus_ma_capture_entry(snapshot, index);
+    return e == NULL ? 0 : e->is_default;
+}
+
+ZEUS_MA_EXPORT void zeus_ma_devices_destroy(void* snapshot)
+{
+    zeus_ma_device_snapshot* s = (zeus_ma_device_snapshot*)snapshot;
+    if (s == NULL) return;
+    free(s->playback);
+    free(s->capture);
+    free(s);
 }
 
 /* ------------------------------------------------------------------------ */

--- a/native/miniaudio/zeus_miniaudio.c
+++ b/native/miniaudio/zeus_miniaudio.c
@@ -133,6 +133,14 @@ static void zeus_ma_copy_device_entries(
     }
 }
 
+static void zeus_ma_device_snapshot_free(zeus_ma_device_snapshot* s)
+{
+    if (s == NULL) return;
+    free(s->playback);
+    free(s->capture);
+    free(s);
+}
+
 /* ------------------------------------------------------------------------ */
 /* miniaudio callbacks (audio worker thread)                                */
 /* ------------------------------------------------------------------------ */
@@ -505,7 +513,7 @@ ZEUS_MA_EXPORT void* zeus_ma_devices_create(void)
     if (s->playback_count > 0) {
         s->playback = (zeus_ma_device_snapshot_entry*)calloc(s->playback_count, sizeof(*s->playback));
         if (s->playback == NULL) {
-            zeus_ma_devices_destroy(s);
+            zeus_ma_device_snapshot_free(s);
             ma_context_uninit(&ctx);
             return NULL;
         }
@@ -515,7 +523,7 @@ ZEUS_MA_EXPORT void* zeus_ma_devices_create(void)
     if (s->capture_count > 0) {
         s->capture = (zeus_ma_device_snapshot_entry*)calloc(s->capture_count, sizeof(*s->capture));
         if (s->capture == NULL) {
-            zeus_ma_devices_destroy(s);
+            zeus_ma_device_snapshot_free(s);
             ma_context_uninit(&ctx);
             return NULL;
         }
@@ -590,11 +598,7 @@ ZEUS_MA_EXPORT int32_t zeus_ma_devices_capture_default(void* snapshot, uint32_t 
 
 ZEUS_MA_EXPORT void zeus_ma_devices_destroy(void* snapshot)
 {
-    zeus_ma_device_snapshot* s = (zeus_ma_device_snapshot*)snapshot;
-    if (s == NULL) return;
-    free(s->playback);
-    free(s->capture);
-    free(s);
+    zeus_ma_device_snapshot_free((zeus_ma_device_snapshot*)snapshot);
 }
 
 /* ------------------------------------------------------------------------ */

--- a/native/miniaudio/zeus_miniaudio.h
+++ b/native/miniaudio/zeus_miniaudio.h
@@ -61,6 +61,16 @@ ZEUS_MA_EXPORT void* zeus_ma_output_create(
     zeus_ma_notify_cb notify_cb,    /* may be NULL */
     void* user);
 
+ZEUS_MA_EXPORT void* zeus_ma_output_create_for_device(
+    uint32_t prefer_sample_rate,
+    uint32_t prefer_channels,
+    uint32_t period_frames,
+    uint32_t periods,
+    const char* device_id_hex,      /* NULL / empty = default device */
+    zeus_ma_playback_cb data_cb,
+    zeus_ma_notify_cb notify_cb,
+    void* user);
+
 ZEUS_MA_EXPORT int32_t  zeus_ma_output_start(void* handle);
 ZEUS_MA_EXPORT int32_t  zeus_ma_output_stop(void* handle);
 ZEUS_MA_EXPORT uint32_t zeus_ma_output_sample_rate(void* handle);
@@ -78,11 +88,37 @@ ZEUS_MA_EXPORT void* zeus_ma_input_create(
     zeus_ma_notify_cb notify_cb,
     void* user);
 
+ZEUS_MA_EXPORT void* zeus_ma_input_create_for_device(
+    uint32_t prefer_sample_rate,
+    uint32_t prefer_channels,
+    uint32_t period_frames,
+    uint32_t periods,
+    const char* device_id_hex,      /* NULL / empty = default device */
+    zeus_ma_capture_cb data_cb,
+    zeus_ma_notify_cb notify_cb,
+    void* user);
+
 ZEUS_MA_EXPORT int32_t  zeus_ma_input_start(void* handle);
 ZEUS_MA_EXPORT int32_t  zeus_ma_input_stop(void* handle);
 ZEUS_MA_EXPORT uint32_t zeus_ma_input_sample_rate(void* handle);
 ZEUS_MA_EXPORT uint32_t zeus_ma_input_channels(void* handle);
 ZEUS_MA_EXPORT void     zeus_ma_input_destroy(void* handle);
+
+/* ---------------- Device enumeration ---------------------------------- */
+
+/* Returns an opaque snapshot handle. The *_id functions return a hex-encoded
+ * opaque ma_device_id blob suitable for passing back to *_create_for_device().
+ * The caller must copy returned strings before zeus_ma_devices_destroy(). */
+ZEUS_MA_EXPORT void*    zeus_ma_devices_create(void);
+ZEUS_MA_EXPORT uint32_t zeus_ma_devices_playback_count(void* snapshot);
+ZEUS_MA_EXPORT uint32_t zeus_ma_devices_capture_count(void* snapshot);
+ZEUS_MA_EXPORT const char* zeus_ma_devices_playback_id(void* snapshot, uint32_t index);
+ZEUS_MA_EXPORT const char* zeus_ma_devices_capture_id(void* snapshot, uint32_t index);
+ZEUS_MA_EXPORT const char* zeus_ma_devices_playback_name(void* snapshot, uint32_t index);
+ZEUS_MA_EXPORT const char* zeus_ma_devices_capture_name(void* snapshot, uint32_t index);
+ZEUS_MA_EXPORT int32_t zeus_ma_devices_playback_default(void* snapshot, uint32_t index);
+ZEUS_MA_EXPORT int32_t zeus_ma_devices_capture_default(void* snapshot, uint32_t index);
+ZEUS_MA_EXPORT void zeus_ma_devices_destroy(void* snapshot);
 
 /* ---------------- Library probe --------------------------------------- */
 

--- a/tests/Zeus.Server.Tests/AudioDeviceEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/AudioDeviceEndpointTests.cs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Net;
+using System.Text.Json;
+
+namespace Zeus.Server.Tests;
+
+public sealed class AudioDeviceEndpointTests
+{
+    [Fact]
+    public async Task GetAudioDevices_ReturnsUnsupportedInServerHost()
+    {
+        using var factory = new Factory();
+        using var client = factory.CreateClient();
+
+        var resp = await client.GetAsync("/api/audio/devices");
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        using var body = await JsonDocument.ParseAsync(await resp.Content.ReadAsStreamAsync());
+        var root = body.RootElement;
+        Assert.False(root.GetProperty("supported").GetBoolean());
+        Assert.Null(root.GetProperty("inputDeviceId").GetString());
+        Assert.Null(root.GetProperty("outputDeviceId").GetString());
+        Assert.Null(root.GetProperty("activeInputDeviceId").GetString());
+        Assert.Null(root.GetProperty("activeOutputDeviceId").GetString());
+        Assert.Equal(0, root.GetProperty("inputs").GetArrayLength());
+        Assert.Equal(0, root.GetProperty("outputs").GetArrayLength());
+    }
+
+    private sealed class Factory : IsolatedPrefsFactory
+    {
+    }
+}

--- a/tests/Zeus.Server.Tests/AudioDeviceSettingsStoreTests.cs
+++ b/tests/Zeus.Server.Tests/AudioDeviceSettingsStoreTests.cs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public sealed class AudioDeviceSettingsStoreTests : IDisposable
+{
+    private readonly string _dbPath = Path.Combine(
+        Path.GetTempPath(),
+        $"zeus-audio-devices-{Guid.NewGuid():N}.db");
+
+    [Fact]
+    public void Get_DefaultsToSystemDevices()
+    {
+        using var store = NewStore();
+
+        var settings = store.Get();
+
+        Assert.Null(settings.InputDeviceId);
+        Assert.Null(settings.OutputDeviceId);
+    }
+
+    [Fact]
+    public void Set_RoundTripsInputAndOutputDeviceIds()
+    {
+        using (var store = NewStore())
+        {
+            store.Set(" input-id ", " output-id ");
+        }
+
+        using (var store = NewStore())
+        {
+            var settings = store.Get();
+            Assert.Equal("input-id", settings.InputDeviceId);
+            Assert.Equal("output-id", settings.OutputDeviceId);
+        }
+    }
+
+    [Fact]
+    public void PerDeviceSetters_PreserveTheOtherRoute()
+    {
+        using var store = NewStore();
+        store.Set("mic-a", "speaker-a");
+
+        store.SetInputDeviceId("mic-b");
+        Assert.Equal("mic-b", store.Get().InputDeviceId);
+        Assert.Equal("speaker-a", store.Get().OutputDeviceId);
+
+        store.SetOutputDeviceId(null);
+        Assert.Equal("mic-b", store.Get().InputDeviceId);
+        Assert.Null(store.Get().OutputDeviceId);
+    }
+
+    public void Dispose()
+    {
+        try { File.Delete(_dbPath); } catch { /* ignore */ }
+    }
+
+    private AudioDeviceSettingsStore NewStore() =>
+        new(NullLogger<AudioDeviceSettingsStore>.Instance, _dbPath);
+}

--- a/zeus-web/e2e/audio-devices.spec.ts
+++ b/zeus-web/e2e/audio-devices.spec.ts
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { expect, test, type Page, type Route } from '@playwright/test';
+
+type HostPlatform = 'linux' | 'darwin';
+
+type AudioDeviceSelection = {
+  inputDeviceId: string | null;
+  outputDeviceId: string | null;
+};
+
+async function fulfillJson(route: Route, body: unknown) {
+  await route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  });
+}
+
+function audioDevices(selection: AudioDeviceSelection) {
+  return {
+    supported: true,
+    inputDeviceId: selection.inputDeviceId,
+    outputDeviceId: selection.outputDeviceId,
+    activeInputDeviceId: selection.inputDeviceId,
+    activeOutputDeviceId: selection.outputDeviceId,
+    inputs: [
+      { id: 'capture-default', name: 'System Capture', isDefault: true },
+      { id: 'capture-headset', name: 'Headset Mic', isDefault: false },
+    ],
+    outputs: [
+      { id: 'playback-default', name: 'System Playback', isDefault: true },
+      { id: 'playback-monitor', name: 'Monitor Speakers', isDefault: false },
+    ],
+    error: null,
+  };
+}
+
+async function stubZeusApi(page: Page, platform: HostPlatform) {
+  const selection: AudioDeviceSelection = {
+    inputDeviceId: null,
+    outputDeviceId: null,
+  };
+  const writes: AudioDeviceSelection[] = [];
+
+  await page.addInitScript(() => {
+    const NativeWebSocket = window.WebSocket;
+    class MockZeusWebSocket extends EventTarget {
+      readonly url: string;
+      readonly protocol = '';
+      readonly extensions = '';
+      binaryType: BinaryType = 'blob';
+      bufferedAmount = 0;
+      readyState = NativeWebSocket.CONNECTING;
+      onopen: ((this: WebSocket, ev: Event) => unknown) | null = null;
+      onmessage: ((this: WebSocket, ev: MessageEvent) => unknown) | null = null;
+      onerror: ((this: WebSocket, ev: Event) => unknown) | null = null;
+      onclose: ((this: WebSocket, ev: CloseEvent) => unknown) | null = null;
+
+      constructor(url: string | URL) {
+        super();
+        this.url = String(url);
+        window.setTimeout(() => {
+          if (this.readyState !== NativeWebSocket.CONNECTING) return;
+          this.readyState = NativeWebSocket.OPEN;
+          const event = new Event('open');
+          this.onopen?.call(this as unknown as WebSocket, event);
+          this.dispatchEvent(event);
+        }, 0);
+      }
+
+      send() {
+        /* No realtime frames are needed for this settings e2e. */
+      }
+
+      close() {
+        if (this.readyState === NativeWebSocket.CLOSED) return;
+        this.readyState = NativeWebSocket.CLOSED;
+        const event = new CloseEvent('close');
+        this.onclose?.call(this as unknown as WebSocket, event);
+        this.dispatchEvent(event);
+      }
+    }
+
+    window.WebSocket = MockZeusWebSocket as unknown as typeof WebSocket;
+  });
+
+  await page.route(/^https?:\/\/[^/]+\/api(?:\/|\?|$)/, async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const method = request.method();
+
+    if (url.pathname === '/api/capabilities') {
+      await fulfillJson(route, {
+        host: 'desktop',
+        platform,
+        architecture: platform === 'darwin' ? 'arm64' : 'x64',
+        version: 'e2e',
+        lanHttpsUrls: [],
+        features: {},
+      });
+      return;
+    }
+
+    if (url.pathname === '/api/audio/devices') {
+      if (method === 'PUT') {
+        const body = JSON.parse(request.postData() ?? '{}') as AudioDeviceSelection;
+        selection.inputDeviceId = body.inputDeviceId ?? null;
+        selection.outputDeviceId = body.outputDeviceId ?? null;
+        writes.push({ ...selection });
+      }
+      await fulfillJson(route, audioDevices(selection));
+      return;
+    }
+
+    if (url.pathname === '/api/radio/selection') {
+      await fulfillJson(route, {
+        preferred: 'Auto',
+        connected: 'Unknown',
+        effective: 'Unknown',
+        overrideDetection: false,
+      });
+      return;
+    }
+
+    if (url.pathname === '/api/plugins') {
+      await fulfillJson(route, { sdkAbi: 1, sdkVersion: 'e2e', plugins: [] });
+      return;
+    }
+
+    if (url.pathname === '/api/ui/layouts' && method === 'GET') {
+      await fulfillJson(route, {
+        radioKey: url.searchParams.get('radio') ?? 'default',
+        layouts: [],
+        activeLayoutId: 'default',
+      });
+      return;
+    }
+
+    if (url.pathname === '/api/ui/layouts') {
+      await route.fulfill({ status: 204, body: '' });
+      return;
+    }
+
+    if (url.pathname === '/api/theme-settings') {
+      await fulfillJson(route, { theme: 'dark', overrides: {} });
+      return;
+    }
+
+    if (url.pathname.endsWith('/processing-mode')) {
+      await fulfillJson(route, { mode: 'native', engineAvailable: false, engineActive: false });
+      return;
+    }
+
+    if (url.pathname.endsWith('/master-bypass')) {
+      await fulfillJson(route, { bypassed: false });
+      return;
+    }
+
+    if (url.pathname.endsWith('/profiles')) {
+      await fulfillJson(route, { profiles: [] });
+      return;
+    }
+
+    if (url.pathname === '/api/audio-suite/preview') {
+      await fulfillJson(route, { supported: true, enabled: false, meterOnly: false });
+      return;
+    }
+
+    await fulfillJson(route, {});
+  });
+
+  return writes;
+}
+
+for (const platform of ['linux', 'darwin'] as const) {
+  test(`Audio Tools native device selectors round-trip on ${platform}`, async ({ page }) => {
+    const pageErrors: string[] = [];
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+    const writes = await stubZeusApi(page, platform);
+
+    await page.goto('/#pa');
+    await expect(page.getByRole('region', { name: 'Settings' })).toBeVisible();
+    await page.getByRole('tab', { name: 'AUDIO TOOLS' }).click();
+
+    await expect(page.getByRole('region', { name: 'Audio Devices' })).toBeVisible();
+    await expect(page.getByText('HOST')).toBeVisible();
+
+    const input = page.getByLabel('Audio input device');
+    const output = page.getByLabel('Audio output device');
+    await expect(input).toContainText('Headset Mic');
+    await expect(output).toContainText('Monitor Speakers');
+
+    await input.selectOption('capture-headset');
+    await expect.poll(() => writes).toContainEqual({
+      inputDeviceId: 'capture-headset',
+      outputDeviceId: null,
+    });
+
+    await output.selectOption('playback-monitor');
+    await expect.poll(() => writes).toContainEqual({
+      inputDeviceId: 'capture-headset',
+      outputDeviceId: 'playback-monitor',
+    });
+
+    await expect(input).toHaveValue('capture-headset');
+    await expect(output).toHaveValue('playback-monitor');
+    expect(pageErrors).toEqual([]);
+  });
+}

--- a/zeus-web/src/api/audio-devices.ts
+++ b/zeus-web/src/api/audio-devices.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+export interface NativeAudioDevice {
+  id: string;
+  name: string;
+  isDefault: boolean;
+}
+
+export interface NativeAudioDevicesResponse {
+  supported: boolean;
+  inputDeviceId: string | null;
+  outputDeviceId: string | null;
+  activeInputDeviceId: string | null;
+  activeOutputDeviceId: string | null;
+  inputs: NativeAudioDevice[];
+  outputs: NativeAudioDevice[];
+  error?: string | null;
+}
+
+export async function fetchNativeAudioDevices(): Promise<NativeAudioDevicesResponse> {
+  const res = await fetch('/api/audio/devices');
+  if (!res.ok) throw new Error(`GET /api/audio/devices ${res.status}`);
+  return (await res.json()) as NativeAudioDevicesResponse;
+}
+
+export async function setNativeAudioDevices(
+  inputDeviceId: string | null,
+  outputDeviceId: string | null,
+): Promise<NativeAudioDevicesResponse> {
+  const res = await fetch('/api/audio/devices', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ inputDeviceId, outputDeviceId }),
+  });
+  if (!res.ok) {
+    let detail = `${res.status}`;
+    try {
+      const body = (await res.json()) as { error?: string };
+      if (body.error) detail = body.error;
+    } catch {
+      // Fall through to the status code.
+    }
+    throw new Error(detail);
+  }
+  return (await res.json()) as NativeAudioDevicesResponse;
+}

--- a/zeus-web/src/audio/audio-client.ts
+++ b/zeus-web/src/audio/audio-client.ts
@@ -44,6 +44,7 @@
 
 import type { DecodedAudioFrame } from './frame';
 import { isNativeAudio } from './host-mode';
+import { useAudioDeviceStore } from '../state/audio-device-store';
 
 // createBuffer + scheduled-playback model ported from ProjectLongBanana
 // commit 4acc255b, herpes-client audioPlayer.ts. Drops the AudioWorklet +
@@ -96,6 +97,10 @@ export type AudioPlaybackDiagnosticsSnapshot = {
 };
 
 type Listener = (state: AudioClientState, stats: AudioStats | null) => void;
+
+type SinkSelectableAudioContext = AudioContext & {
+  setSinkId?: (sinkId: string) => Promise<void>;
+};
 
 // Adaptive re-anchor target. A fixed 300 ms floor (the previous value) made the
 // waterfall lead the audio by ~0.3 s — perceptible as display/audio lag. Instead
@@ -198,6 +203,12 @@ class AudioClient {
     return this.starting;
   }
 
+  async setOutputDevice(deviceId = useAudioDeviceStore.getState().browserOutputDeviceId): Promise<void> {
+    const ctx = this.context;
+    if (!ctx) return;
+    await this.applyOutputDevice(ctx, deviceId, true);
+  }
+
   private async doStart() {
     this.setState({ kind: 'loading' });
     try {
@@ -209,6 +220,7 @@ class AudioClient {
       // streaming load). Costs a few extra ms of intrinsic latency, but the
       // operator-perceptible gap is dominated by BUFFER_TARGET_SECS anyway.
       const ctx = new AudioContext({ sampleRate: 48000, latencyHint: 'playback' });
+      await this.applyOutputDevice(ctx, useAudioDeviceStore.getState().browserOutputDeviceId, false);
       const gain = ctx.createGain();
       gain.gain.value = 1.0;
       gain.connect(ctx.destination);
@@ -231,6 +243,30 @@ class AudioClient {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       this.setState({ kind: 'error', message });
+    }
+  }
+
+  private async applyOutputDevice(
+    ctx: AudioContext,
+    deviceId: string,
+    strict: boolean,
+  ): Promise<void> {
+    const normalized = deviceId.trim();
+    const selectable = ctx as SinkSelectableAudioContext;
+    if (typeof selectable.setSinkId !== 'function') {
+      if (strict && normalized) {
+        throw new Error('browser audio output selection is not supported');
+      }
+      if (normalized) {
+        console.warn('audio.output.setSinkId unsupported; using browser default output');
+      }
+      return;
+    }
+    try {
+      await selectable.setSinkId(normalized || '');
+    } catch (err) {
+      if (strict) throw err;
+      console.warn('audio.output.setSinkId failed; using browser default output', err);
     }
   }
 

--- a/zeus-web/src/audio/mic-uplink-session.ts
+++ b/zeus-web/src/audio/mic-uplink-session.ts
@@ -13,6 +13,7 @@ import { startMicUplink, type MicUplinkHandle } from './mic-uplink';
 import { useMicUplinkDiagnosticsStore } from './mic-uplink-diagnostics-store';
 import { createMicUplinkAutoGain } from './mic-uplink-gain';
 import { sendMicPcm } from '../realtime/ws-client';
+import { useAudioDeviceStore } from '../state/audio-device-store';
 import { useTxStore } from '../state/tx-store';
 import { warnOnce } from '../util/logger';
 
@@ -91,7 +92,8 @@ export async function ensureMicUplinkRunning(): Promise<boolean> {
   }
 
   if (!starting) {
-    starting = startMicUplink(onMicBlock)
+    const inputDeviceId = useAudioDeviceStore.getState().browserInputDeviceId || undefined;
+    starting = startMicUplink(onMicBlock, inputDeviceId)
       .then((h) => {
         handle = h;
         useTxStore.getState().setMicError(null);
@@ -113,6 +115,15 @@ export async function ensureMicUplinkRunning(): Promise<boolean> {
 
   await starting;
   return handle !== null;
+}
+
+export async function restartMicUplinkRunning(): Promise<void> {
+  const shouldRestart = consumers > 0;
+  if (starting) {
+    try { await starting; } catch { /* ensureMicUplinkRunning owns visible errors */ }
+  }
+  await stopMicUplinkRunning();
+  if (shouldRestart) await ensureMicUplinkRunning();
 }
 
 export async function stopMicUplinkRunning(): Promise<void> {

--- a/zeus-web/src/audio/mic-uplink.ts
+++ b/zeus-web/src/audio/mic-uplink.ts
@@ -65,14 +65,12 @@ export type MicUplinkHandle = {
   stop: () => Promise<void>;
 };
 
-const MIC_CONSTRAINTS: MediaStreamConstraints = {
-  audio: {
-    echoCancellation: false,
-    noiseSuppression: false,
-    autoGainControl: false,
-    channelCount: 1,
-    sampleRate: 48000,
-  },
+const MIC_BASE_CONSTRAINTS: MediaTrackConstraints = {
+  echoCancellation: false,
+  noiseSuppression: false,
+  autoGainControl: false,
+  channelCount: 1,
+  sampleRate: 48000,
 };
 
 const WORKLET_URL = '/mic-uplink-worklet.js';
@@ -84,6 +82,7 @@ function sanitizeMicPeak(value: unknown): number {
 
 export async function startMicUplink(
   onBlock: MicUplinkBlockHandler,
+  deviceId?: string,
 ): Promise<MicUplinkHandle> {
   // Phase 2c — desktop mode runs a native miniaudio capture in the host
   // process; calling getUserMedia in the webview would race the device
@@ -96,7 +95,9 @@ export async function startMicUplink(
   if (typeof navigator === 'undefined' || !navigator.mediaDevices?.getUserMedia) {
     throw new Error('getUserMedia not available in this environment');
   }
-  const stream = await navigator.mediaDevices.getUserMedia(MIC_CONSTRAINTS);
+  const audio: MediaTrackConstraints = { ...MIC_BASE_CONSTRAINTS };
+  if (deviceId?.trim()) audio.deviceId = { exact: deviceId.trim() };
+  const stream = await navigator.mediaDevices.getUserMedia({ audio });
   const context = new AudioContext({ sampleRate: 48000, latencyHint: 0.04 });
 
   const cleanupStream = () => {

--- a/zeus-web/src/components/TxAudioToolsPanel.tsx
+++ b/zeus-web/src/components/TxAudioToolsPanel.tsx
@@ -13,18 +13,29 @@
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 
-import { useEffect, useMemo, type CSSProperties, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useState, type CSSProperties, type ReactNode } from 'react';
+import { RefreshCw } from 'lucide-react';
 import { CfcSettingsPanel } from './CfcSettingsPanel';
 import { DownloadAudioSuiteButton } from './DownloadAudioSuiteButton';
 import { usePluginPanels } from '../plugins/runtime/usePluginPanels';
 import type { RegisteredPluginPanel } from '../plugins/runtime/pluginRuntime';
+import {
+  fetchNativeAudioDevices,
+  setNativeAudioDevices,
+  type NativeAudioDevicesResponse,
+} from '../api/audio-devices';
+import { getAudioClient } from '../audio/audio-client';
+import { restartMicUplinkRunning } from '../audio/mic-uplink-session';
 import { useAudioSuiteStore } from '../state/audio-suite-store';
+import { useAudioDeviceStore } from '../state/audio-device-store';
+import { useCapabilitiesStore } from '../state/capabilities-store';
 
 const CHAIN_SLOT = 'tx-audio-tools.chain';
 const RX_CHAIN_SLOT = 'rx-audio-tools.chain';
 
 type AudioRoute = 'tx' | 'rx';
 type ChainFlowSlot = { id: string; title: string; installed: boolean };
+type DeviceOption = { id: string; name: string; isDefault?: boolean };
 
 function routeColor(route: AudioRoute) {
   return route === 'tx' ? 'var(--tx)' : 'var(--accent)';
@@ -154,6 +165,279 @@ function RouteStatusPill({
     >
       {label}
     </span>
+  );
+}
+
+function selectStyle(disabled: boolean): CSSProperties {
+  return {
+    minWidth: 180,
+    maxWidth: 280,
+    height: 26,
+    padding: '3px 8px',
+    borderRadius: 4,
+    border: '1px solid var(--line)',
+    background: disabled ? 'var(--bg-1)' : 'var(--bg-2)',
+    color: disabled ? 'var(--fg-3)' : 'var(--fg-1)',
+    fontFamily: 'var(--font-sans, Inter, system-ui, sans-serif)',
+    fontSize: 11,
+    fontWeight: 600,
+    letterSpacing: 0,
+  };
+}
+
+const refreshButtonStyle: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 28,
+  height: 26,
+  borderRadius: 4,
+  border: '1px solid var(--line)',
+  background: 'var(--bg-2)',
+  color: 'var(--fg-1)',
+  cursor: 'pointer',
+};
+
+function DeviceSelect({
+  label,
+  value,
+  devices,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  devices: DeviceOption[];
+  disabled: boolean;
+  onChange(value: string): void;
+}) {
+  const selectedMissing = value && !devices.some((device) => device.id === value);
+  return (
+    <label
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 6,
+        minWidth: 0,
+        color: 'var(--fg-2)',
+        fontSize: 10,
+        fontWeight: 800,
+        letterSpacing: 0,
+        textTransform: 'uppercase',
+      }}
+    >
+      <span style={{ flex: '0 0 auto' }}>{label}</span>
+      <select
+        aria-label={`Audio ${label.toLowerCase()} device`}
+        value={value}
+        disabled={disabled}
+        onChange={(ev) => onChange(ev.currentTarget.value)}
+        style={selectStyle(disabled)}
+      >
+        <option value="">System default</option>
+        {devices.map((device) => (
+          <option key={device.id} value={device.id}>
+            {device.name}{device.isDefault ? ' (default)' : ''}
+          </option>
+        ))}
+        {selectedMissing && <option value={value}>Missing device</option>}
+      </select>
+    </label>
+  );
+}
+
+function AudioDevicesRail() {
+  const hostMode = useCapabilitiesStore((s) => s.capabilities?.host ?? null);
+  if (hostMode === null) return null;
+  return hostMode === 'desktop' ? <NativeAudioDevicesRail /> : <BrowserAudioDevicesRail />;
+}
+
+function NativeAudioDevicesRail() {
+  const [devices, setDevices] = useState<NativeAudioDevicesResponse | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      setDevices(await fetchNativeAudioDevices());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const apply = useCallback(
+    async (next: { input?: string; output?: string }) => {
+      const input = next.input ?? devices?.inputDeviceId ?? '';
+      const output = next.output ?? devices?.outputDeviceId ?? '';
+      setBusy(true);
+      setError(null);
+      try {
+        setDevices(await setNativeAudioDevices(input || null, output || null));
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setBusy(false);
+      }
+    },
+    [devices],
+  );
+
+  const supported = devices?.supported !== false;
+  const effectiveError = error ?? devices?.error ?? null;
+  const inputValue = devices?.inputDeviceId ?? '';
+  const outputValue = devices?.outputDeviceId ?? '';
+
+  return (
+    <RouteRail
+      route="rx"
+      title="Audio Devices"
+      status={
+        <RouteStatusPill
+          route="rx"
+          label={effectiveError ? 'NATIVE ERR' : 'HOST'}
+          title={effectiveError ?? 'Native desktop input and output devices'}
+          muted={!!effectiveError}
+        />
+      }
+      actions={
+        <button
+          type="button"
+          onClick={() => void load()}
+          disabled={busy}
+          style={refreshButtonStyle}
+          title="Refresh audio device list"
+          aria-label="Refresh audio device list"
+        >
+          <RefreshCw size={13} aria-hidden />
+        </button>
+      }
+    >
+      <DeviceSelect
+        label="Input"
+        value={inputValue}
+        devices={devices?.inputs ?? []}
+        disabled={busy || !supported}
+        onChange={(input) => void apply({ input })}
+      />
+      <DeviceSelect
+        label="Output"
+        value={outputValue}
+        devices={devices?.outputs ?? []}
+        disabled={busy || !supported}
+        onChange={(output) => void apply({ output })}
+      />
+    </RouteRail>
+  );
+}
+
+function BrowserAudioDevicesRail() {
+  const inputs = useAudioDeviceStore((s) => s.browserInputs);
+  const outputs = useAudioDeviceStore((s) => s.browserOutputs);
+  const inputDeviceId = useAudioDeviceStore((s) => s.browserInputDeviceId);
+  const outputDeviceId = useAudioDeviceStore((s) => s.browserOutputDeviceId);
+  const outputSupported = useAudioDeviceStore((s) => s.browserOutputSupported);
+  const deviceError = useAudioDeviceStore((s) => s.browserDeviceError);
+  const refresh = useAudioDeviceStore((s) => s.refreshBrowserDevices);
+  const setInputDeviceId = useAudioDeviceStore((s) => s.setBrowserInputDeviceId);
+  const setOutputDeviceId = useAudioDeviceStore((s) => s.setBrowserOutputDeviceId);
+  const [busy, setBusy] = useState(false);
+  const [applyError, setApplyError] = useState<string | null>(null);
+
+  const refreshDevices = useCallback(async () => {
+    setBusy(true);
+    setApplyError(null);
+    try {
+      await refresh();
+    } finally {
+      setBusy(false);
+    }
+  }, [refresh]);
+
+  useEffect(() => {
+    void refreshDevices();
+    const mediaDevices = typeof navigator !== 'undefined' ? navigator.mediaDevices : undefined;
+    if (!mediaDevices?.addEventListener) return;
+    const onChange = () => void refreshDevices();
+    mediaDevices.addEventListener('devicechange', onChange);
+    return () => mediaDevices.removeEventListener('devicechange', onChange);
+  }, [refreshDevices]);
+
+  const onInput = useCallback(
+    async (id: string) => {
+      setInputDeviceId(id);
+      setApplyError(null);
+      try {
+        await restartMicUplinkRunning();
+      } catch (err) {
+        setApplyError(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [setInputDeviceId],
+  );
+
+  const onOutput = useCallback(
+    async (id: string) => {
+      setOutputDeviceId(id);
+      setApplyError(null);
+      try {
+        await getAudioClient().setOutputDevice(id);
+      } catch (err) {
+        setApplyError(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [setOutputDeviceId],
+  );
+
+  const effectiveError = applyError ?? deviceError;
+
+  return (
+    <RouteRail
+      route="rx"
+      title="Audio Devices"
+      status={
+        <RouteStatusPill
+          route="rx"
+          label={effectiveError ? 'BROWSER ERR' : 'BROWSER'}
+          title={effectiveError ?? 'Browser input and output devices'}
+          muted={!!effectiveError}
+        />
+      }
+      actions={
+        <button
+          type="button"
+          onClick={() => void refreshDevices()}
+          disabled={busy}
+          style={refreshButtonStyle}
+          title="Refresh audio device list"
+          aria-label="Refresh audio device list"
+        >
+          <RefreshCw size={13} aria-hidden />
+        </button>
+      }
+    >
+      <DeviceSelect
+        label="Input"
+        value={inputDeviceId}
+        devices={inputs}
+        disabled={busy}
+        onChange={(id) => void onInput(id)}
+      />
+      <DeviceSelect
+        label="Output"
+        value={outputDeviceId}
+        devices={outputs}
+        disabled={busy || !outputSupported}
+        onChange={(id) => void onOutput(id)}
+      />
+    </RouteRail>
   );
 }
 
@@ -616,6 +900,7 @@ export function TxAudioToolsPanel() {
           alignItems: 'stretch',
         }}
       >
+        <AudioDevicesRail />
         <TxChainFlow chainPanels={chainPanels} />
         <RxChainFlow chainPanels={rxChainPanels} />
       </div>

--- a/zeus-web/src/state/audio-device-store.test.ts
+++ b/zeus-web/src/state/audio-device-store.test.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  browserOutputSelectionSupported,
+  useAudioDeviceStore,
+} from './audio-device-store';
+
+const originalMediaDevices = navigator.mediaDevices;
+
+function setMediaDevices(devices: MediaDeviceInfo[]) {
+  Object.defineProperty(navigator, 'mediaDevices', {
+    configurable: true,
+    value: {
+      enumerateDevices: vi.fn(async () => devices),
+    },
+  });
+}
+
+describe('audio-device-store', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useAudioDeviceStore.getState().__resetForTests();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: originalMediaDevices,
+    });
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    localStorage.clear();
+    useAudioDeviceStore.getState().__resetForTests();
+  });
+
+  it('persists selected browser input and output ids', () => {
+    const s = useAudioDeviceStore.getState();
+
+    s.setBrowserInputDeviceId(' mic-1 ');
+    s.setBrowserOutputDeviceId(' speaker-1 ');
+
+    const next = useAudioDeviceStore.getState();
+    expect(next.browserInputDeviceId).toBe('mic-1');
+    expect(next.browserOutputDeviceId).toBe('speaker-1');
+    expect(localStorage.getItem('zeus-audio-devices')).toContain('speaker-1');
+  });
+
+  it('refreshBrowserDevices maps browser media devices by route', async () => {
+    class TestAudioContext {}
+    (TestAudioContext.prototype as { setSinkId?: () => Promise<void> }).setSinkId =
+      async () => {};
+    vi.stubGlobal('AudioContext', TestAudioContext);
+    setMediaDevices([
+      { kind: 'audioinput', deviceId: 'default', label: 'Default mic' },
+      { kind: 'audioinput', deviceId: 'mic-2', label: 'USB mic' },
+      { kind: 'audiooutput', deviceId: 'speaker-2', label: 'USB speaker' },
+      { kind: 'videoinput', deviceId: 'cam-1', label: 'Camera' },
+    ] as MediaDeviceInfo[]);
+
+    await useAudioDeviceStore.getState().refreshBrowserDevices();
+
+    const s = useAudioDeviceStore.getState();
+    expect(s.browserDevicesLoaded).toBe(true);
+    expect(s.browserInputDeviceId).toBe('');
+    expect(s.browserInputs.map((device) => device.name)).toEqual([
+      'Default mic',
+      'USB mic',
+    ]);
+    expect(s.browserOutputs.map((device) => device.id)).toEqual(['speaker-2']);
+    expect(s.browserOutputSupported).toBe(true);
+    expect(browserOutputSelectionSupported()).toBe(true);
+  });
+});

--- a/zeus-web/src/state/audio-device-store.ts
+++ b/zeus-web/src/state/audio-device-store.ts
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export interface BrowserAudioDevice {
+  id: string;
+  name: string;
+  isDefault: boolean;
+}
+
+interface AudioDeviceState {
+  browserInputDeviceId: string;
+  browserOutputDeviceId: string;
+  browserInputs: BrowserAudioDevice[];
+  browserOutputs: BrowserAudioDevice[];
+  browserOutputSupported: boolean;
+  browserDevicesLoaded: boolean;
+  browserDeviceError: string | null;
+  setBrowserInputDeviceId(id: string): void;
+  setBrowserOutputDeviceId(id: string): void;
+  refreshBrowserDevices(): Promise<void>;
+  __resetForTests(): void;
+}
+
+const DEFAULT_DEVICE_ID = '';
+
+function normalizeDeviceId(id: string | null | undefined): string {
+  return id?.trim() || DEFAULT_DEVICE_ID;
+}
+
+export function browserOutputSelectionSupported(): boolean {
+  if (typeof AudioContext === 'undefined') return false;
+  return typeof (AudioContext.prototype as AudioContext & {
+    setSinkId?: unknown;
+  }).setSinkId === 'function';
+}
+
+function deviceLabel(device: MediaDeviceInfo, fallback: string): string {
+  return device.label?.trim() || fallback;
+}
+
+function mapBrowserDevices(devices: MediaDeviceInfo[], kind: MediaDeviceKind): BrowserAudioDevice[] {
+  const matching = devices.filter((device) => device.kind === kind);
+  return matching.map((device, index) => ({
+    id: normalizeDeviceId(device.deviceId),
+    name: deviceLabel(device, kind === 'audioinput' ? `Input ${index + 1}` : `Output ${index + 1}`),
+    isDefault: device.deviceId === 'default',
+  }));
+}
+
+const initialTransientState = {
+  browserInputs: [] as BrowserAudioDevice[],
+  browserOutputs: [] as BrowserAudioDevice[],
+  browserOutputSupported: false,
+  browserDevicesLoaded: false,
+  browserDeviceError: null as string | null,
+};
+
+export const useAudioDeviceStore = create<AudioDeviceState>()(
+  persist(
+    (set) => ({
+      browserInputDeviceId: DEFAULT_DEVICE_ID,
+      browserOutputDeviceId: DEFAULT_DEVICE_ID,
+      ...initialTransientState,
+
+      setBrowserInputDeviceId: (id) =>
+        set({ browserInputDeviceId: normalizeDeviceId(id) }),
+      setBrowserOutputDeviceId: (id) =>
+        set({ browserOutputDeviceId: normalizeDeviceId(id) }),
+
+      refreshBrowserDevices: async () => {
+        const mediaDevices = typeof navigator !== 'undefined'
+          ? navigator.mediaDevices
+          : undefined;
+        if (!mediaDevices?.enumerateDevices) {
+          set({
+            ...initialTransientState,
+            browserOutputSupported: browserOutputSelectionSupported(),
+            browserDeviceError: 'audio device enumeration unavailable',
+          });
+          return;
+        }
+
+        try {
+          const devices = await mediaDevices.enumerateDevices();
+          set({
+            browserInputs: mapBrowserDevices(devices, 'audioinput'),
+            browserOutputs: mapBrowserDevices(devices, 'audiooutput'),
+            browserOutputSupported: browserOutputSelectionSupported(),
+            browserDevicesLoaded: true,
+            browserDeviceError: null,
+          });
+        } catch (err) {
+          set({
+            ...initialTransientState,
+            browserOutputSupported: browserOutputSelectionSupported(),
+            browserDeviceError: err instanceof Error ? err.message : String(err),
+          });
+        }
+      },
+
+      __resetForTests: () =>
+        set({
+          browserInputDeviceId: DEFAULT_DEVICE_ID,
+          browserOutputDeviceId: DEFAULT_DEVICE_ID,
+          ...initialTransientState,
+        }),
+    }),
+    {
+      name: 'zeus-audio-devices',
+      version: 1,
+      partialize: (s) => ({
+        browserInputDeviceId: s.browserInputDeviceId,
+        browserOutputDeviceId: s.browserOutputDeviceId,
+      }),
+    },
+  ),
+);


### PR DESCRIPTION
## Summary
- add native miniaudio device enumeration and selected input/output device open paths
- persist desktop audio device choices and expose GET/PUT /api/audio/devices
- add Audio Tools device selectors for desktop native audio and browser input/output selection

## Verification
- npm --prefix zeus-web run typecheck
- npm --prefix zeus-web run test -- audio-device-store
- npm --prefix zeus-web run test
- npm --prefix zeus-web run build
- dotnet test tests\Zeus.Server.Tests\Zeus.Server.Tests.csproj --filter "AudioDevice" --no-restore -m:1
- dotnet test tests\Zeus.Server.Tests\Zeus.Server.Tests.csproj --filter "FullyQualifiedName~G2OptionsEndpointTests" --no-restore -m:1
- dotnet test non-server test projects returned exit code 0: Contracts, Dsp, Plugins.Contracts, Plugins.Host, Protocol1, Protocol2

Note: full Zeus.Server.Tests did not complete in this local worktree; it exited/hung in unrelated endpoint/plugin-loading tests after the audio-device tests had already completed.
