### PR TITLE
fix(workspace): stop large-panel drop from freezing the app

### DIFF
--- a/zeus-web/src/layout/workspaceGrid.test.ts
+++ b/zeus-web/src/layout/workspaceGrid.test.ts
@@ -321,6 +321,39 @@ describe('workspace grid collision policy', () => {
     expectNoCollisions(dropped);
   });
 
+  it('auto-fits a large dropped panel without an exponential search blowup', () => {
+    // Regression guard: autoFitDroppedPanel used to sweep every (y,x,w,h) of
+    // the dropped panel's footprint, each running full collision resolution.
+    // For the ~18×38 panadapter/hero tile that is hundreds of thousands of
+    // resolves — a multi-second main-thread freeze on drop. The full-size /
+    // origin fast path collapses the common case to a single resolve. The
+    // threshold is deliberately generous (the bug took seconds; the fix is
+    // sub-millisecond) so it flags a complexity regression, not CI jitter.
+    const layout: Layout = cloneLayout([
+      { i: 'filter', x: 0, y: 0, w: 12, h: 10 },
+      { i: 'filterpresets', x: 12, y: 0, w: 6, h: 10 },
+      { i: 'hero', x: 0, y: 10, w: 18, h: 38, minW: 8, minH: 8 },
+      { i: 'vfo', x: 18, y: 0, w: 6, h: 11 },
+      { i: 'smeter', x: 18, y: 11, w: 6, h: 5 },
+      { i: 'tx', x: 18, y: 16, w: 6, h: 10 },
+      { i: 'txmeters', x: 18, y: 26, w: 6, h: 12 },
+      { i: 'dsp', x: 18, y: 38, w: 6, h: 10 },
+    ]);
+    const dragged = layout.find((item) => item.i === 'hero')!;
+
+    const start = performance.now();
+    const next = fitMovedElement(layout, dragged, 6, 4);
+    const elapsedMs = performance.now() - start;
+
+    expect(elapsedMs).toBeLessThan(250);
+    // Full size is preserved — the dropped panel is placed, not shrunk.
+    expect(next.find((item) => item.i === 'hero')).toMatchObject({
+      w: 18,
+      h: 38,
+    });
+    expectNoCollisions(next);
+  });
+
   it('pushes a lower panel down when resize grows into it', () => {
     const layout = cloneLayout(baseLayout);
     layout[0]!.h = 4;

--- a/zeus-web/src/layout/workspaceGrid.ts
+++ b/zeus-web/src/layout/workspaceGrid.ts
@@ -96,6 +96,36 @@ export function autoFitDroppedPanel(
   const footprintRight = Math.min(cols, footprintX + startW);
   const footprintBottom = footprintY + startH;
 
+  // Fast path — full size at the drop origin. The search below ranks
+  // candidates by originDistance FIRST (|x−footprintX|+|y−footprintY|), and
+  // only the origin cell scores 0, so no farther placement can ever beat an
+  // origin one. At the origin the largest area is the panel's full
+  // (startW × startH) — exactly what the nested loop tries first. So when full
+  // size fits at the origin (the overwhelmingly common drag case, since
+  // resolveAnchorCollisions pushes movable neighbours aside), it is the global
+  // optimum and the whole O(footprintArea × maxW × maxH) sweep is redundant.
+  // Skipping it here is what stops a large panel (e.g. the panadapter/hero
+  // tile, ~18×38) from freezing the main thread for seconds on drop.
+  const originTrial = cloneLayout(base);
+  const originTarget = originTrial.find((item) => item.i === target.i);
+  if (originTarget) {
+    originTarget.x = footprintX;
+    originTarget.y = footprintY;
+    originTarget.w = startW;
+    originTarget.h = startH;
+    const originResolved = resolveAnchorCollisions(
+      originTrial,
+      target.i,
+      cols,
+      previousItem,
+    );
+    if (originResolved) {
+      return clearMovedFlags(
+        compactMagnetUp(originResolved.layout, target.i, swapped.displaced),
+      );
+    }
+  }
+
   let best: {
     layout: LayoutItem[];
     area: number;
@@ -104,8 +134,13 @@ export function autoFitDroppedPanel(
   } | null = null;
 
   for (let y = footprintY; y <= footprintBottom - minH; y += 1) {
+    // An origin candidate (originDistance 0) is unbeatable by anything farther
+    // out, so once one is found there is no need to keep sweeping the
+    // footprint — this caps the fallback search at the origin cell.
+    if (best && best.originDistance === 0) break;
     const maxCandidateH = Math.min(maxH, footprintBottom - y);
     for (let x = footprintX; x <= footprintRight - minW; x += 1) {
+      if (best && best.originDistance === 0) break;
       const maxCandidateW = Math.min(maxW, footprintRight - x);
       for (let w = maxCandidateW; w >= minW; w -= 1) {
         for (let h = maxCandidateH; h >= minH; h -= 1) {


### PR DESCRIPTION
## Problem

Dragging the panadapter/hero tile **intermittently freezes the whole app** on drop (also surfaces as flaky `workspace-panel-drag.spec.ts` e2e runs — that test pushes zero frames, so it isn't a rendering issue).

The freeze is synchronous compute in `autoFitDroppedPanel`. It sweeps **every `(y, x, w, h)` combination of the dropped panel's footprint**, cloning the layout and running full collision resolution each iteration. Cost scales with the panel's *area*, so the ~18×38 panadapter/hero tile runs **hundreds of thousands of resolves on the main thread** — a multi-second freeze. It's intermittent because cost depends on drop position and how many neighbours need pushing aside.

## Fix

A **provably behaviour-preserving** fast path:

- The search ranks candidates by `originDistance` (Manhattan distance from the drop origin) **first**, and only the origin cell scores `0` — no farther placement can ever beat an origin one.
- At the origin the largest area is the panel's full `(startW × startH)`, which is exactly the loop's first candidate.
- So when full-size-at-origin resolves (the normal drag case, since `resolveAnchorCollisions` already pushes movable neighbours aside) it is the **global optimum** and the whole sweep is redundant.

Try that placement first and return immediately when it fits; also early-break the fallback sweep once any origin candidate exists. The result is identical whenever full-size-at-origin fits, and falls through to the original search otherwise.

## Verification

- `zeus-web/src/layout/workspaceGrid.test.ts`: **15 passed**, including the existing large-hero drop and "stable through prop resync" (loop-prevention) cases, plus a new regression guard that drops the 18×38 hero tile and asserts it completes well under budget with full size preserved.
- `tsc --noEmit`: clean.

Scope: bug fix with a clear root cause; no UX/default/visual changes — layout outcomes are unchanged.