### PR TITLE
fix(ps): revert PS master arm persistence introduced in Christian's base swap

### DIFF
--- a/Zeus.Server.Hosting/PsSettingsStore.cs
+++ b/Zeus.Server.Hosting/PsSettingsStore.cs
@@ -25,14 +25,14 @@ using Zeus.Contracts;
 namespace Zeus.Server;
 
 // PureSignal settings persistence. Stores the operator's calibration tuning
-// (master arm, timing delays, ints/spi preset, ptol mode, auto-attenuate,
-// per-board HW peak) so it survives server restarts. Shares zeus-prefs.db
-// with DspSettingsStore.
+// (timing delays, ints/spi preset, ptol mode, auto-attenuate, per-board HW
+// peak) so it survives server restarts. Shares zeus-prefs.db with
+// DspSettingsStore.
 //
-// Deliberately does NOT persist `PsSingle` (one-shot cal mode). It resets to
-// a safe default each session. The PS master arm does persist because it is a
-// standing operator preference; actual transmit/keying actions (MOX / TUN /
-// TwoToneEnabled) remain session-only.
+// Deliberately does NOT persist `PsEnabled` (the master arm) or `PsSingle`
+// (one-shot cal mode) -- these reset to safe defaults each session. Same
+// pattern as MOX / TUN: arming PS is an explicit operator action, never an
+// automatic "resume what we did last time" behaviour.
 //
 // `HwPeakByBoard` IS persisted as of 2026-05-16. The earlier "re-derive per
 // radio at connect time" assumption clobbered operator-calibrated values
@@ -91,7 +91,6 @@ public sealed class PsSettingsEntry
 {
     public int Id { get; set; }
     public string ProfileId { get; set; } = string.Empty;
-    public bool Enabled { get; set; }
     // Cal-mode default — Auto = continuous adapt. Persisted because operators
     // who prefer single-shot calibration (and run TwoTone manually) want that
     // selection to stick across sessions.
@@ -108,9 +107,9 @@ public sealed class PsSettingsEntry
     public PsFeedbackSource Source { get; set; } = PsFeedbackSource.Internal;
     // Two-tone test generator settings. Persisted so an operator who has
     // dialled in custom IMD test tones (e.g. for a specific filter response
-    // or PA test) doesn't have to re-enter them every session. TwoToneEnabled
-    // is intentionally NOT persisted — same operator-action discipline as
-    // MOX/TUN — but the dialled-in freqs/mag are.
+    // or PA test) doesn't have to re-enter them every session. PsEnabled and
+    // TwoToneEnabled are intentionally NOT persisted -- same operator-action
+    // discipline as MOX/TUN -- but the dialled-in freqs/mag are.
     // Defaults match tx-store.ts (700/1900/0.49) and pihpsdr.
     public double TwoToneFreq1 { get; set; } = 700.0;
     public double TwoToneFreq2 { get; set; } = 1900.0;

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -418,7 +418,7 @@ public sealed class RadioService : IDisposable
             AutoAgcEnabled: rsSnap?.AutoAgcEnabled ?? false,
             AgcOffsetDb: 0.0,       // always reset — control-loop accumulator
             // PS persisted fields (or DTO defaults when not persisted yet).
-            PsEnabled: ps?.Enabled ?? false,
+            PsEnabled: false, // master arm is never persisted — operator must re-arm each session
             PsAuto: ps?.Auto ?? true,
             PsPtol: ps?.Ptol ?? false,
             PsAutoAttenuate: ps?.AutoAttenuate ?? true,
@@ -479,7 +479,7 @@ public sealed class RadioService : IDisposable
     /// callers don't drop fields by writing only what they touched. Called
     /// from SetPs, SetPsAdvanced, SetPsFeedbackSource, and SetTwoTone.
     ///
-    /// PsEnabled is persisted as the operator's standing PS preference.
+    /// PsEnabled is NOT persisted — master arm resets to false each session.
     /// TwoToneEnabled remains session-only because it can key the transmitter.
     /// PsHwPeak IS persisted per-connected-board via the HwPeakByBoard dictionary;
     /// when no board is currently connected the HwPeak portion of the write
@@ -514,7 +514,6 @@ public sealed class RadioService : IDisposable
         }
         _psStore.Upsert(new PsSettingsEntry
         {
-            Enabled = snap.PsEnabled,
             Auto = snap.PsAuto,
             Ptol = snap.PsPtol,
             AutoAttenuate = snap.PsAutoAttenuate,

--- a/tests/Zeus.Server.Tests/PsEndpointPersistenceTests.cs
+++ b/tests/Zeus.Server.Tests/PsEndpointPersistenceTests.cs
@@ -24,7 +24,7 @@ public sealed class PsEndpointPersistenceTests : IDisposable
     }
 
     [Fact]
-    public async Task PostPsArm_RehydratesThroughStateAfterHostRestart()
+    public async Task PostPsArm_DoesNotRehydrateThroughStateAfterHostRestart()
     {
         using (var first = new Factory(_dbPath))
         using (var client = first.CreateClient())
@@ -36,6 +36,7 @@ public sealed class PsEndpointPersistenceTests : IDisposable
             Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
             using var body = await JsonDocument.ParseAsync(await resp.Content.ReadAsStreamAsync());
             Assert.True(body.RootElement.GetProperty("psEnabled").GetBoolean());
+            // auto=false was persisted; psEnabled itself is a live value from the active session
             Assert.False(body.RootElement.GetProperty("psAuto").GetBoolean());
         }
 
@@ -46,7 +47,9 @@ public sealed class PsEndpointPersistenceTests : IDisposable
 
             Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
             using var body = await JsonDocument.ParseAsync(await resp.Content.ReadAsStreamAsync());
-            Assert.True(body.RootElement.GetProperty("psEnabled").GetBoolean());
+            // Master arm must NOT survive a restart — always boots false
+            Assert.False(body.RootElement.GetProperty("psEnabled").GetBoolean());
+            // Cal-mode DOES persist — auto=false should survive
             Assert.False(body.RootElement.GetProperty("psAuto").GetBoolean());
         }
     }

--- a/tests/Zeus.Server.Tests/PsPersistenceTests.cs
+++ b/tests/Zeus.Server.Tests/PsPersistenceTests.cs
@@ -30,8 +30,8 @@ namespace Zeus.Server.Tests;
 /// PureSignal settings persistence — guards the round-3 fix where SetPs and
 /// SetTwoTone silently failed to call _psStore.Upsert. After the fix, every
 /// Set* path that mutates a persisted PS field must drop a doc into the
-/// LiteDB-backed store. PsEnabled is a persisted standing preference;
-/// TwoToneEnabled remains session-only because it can key the transmitter.
+/// LiteDB-backed store. PsEnabled is NOT persisted (master arm resets to
+/// false each session). TwoToneEnabled also remains session-only.
 /// </summary>
 public class PsPersistenceTests : IDisposable
 {
@@ -61,17 +61,17 @@ public class PsPersistenceTests : IDisposable
     }
 
     [Fact]
-    public void SetPs_PersistsEnabledAndAutoFlag()
+    public void SetPs_PersistsAutoFlag_ButNotArmState()
     {
         var (radio, store) = BuildRadioWithStore();
 
-        // Operator arms PS and picks Single mode — persisted fields reflect
-        // both the standing arm preference and the cal-mode preference.
+        // Operator arms PS and picks Single mode — cal-mode (Auto) persists,
+        // but the master arm (Enabled) must NOT persist.
         radio.SetPs(new PsControlSetRequest(Enabled: true, Auto: false, Single: true));
 
         var entry = store.Get();
         Assert.NotNull(entry);
-        Assert.True(entry!.Enabled);
+        // Enabled is not on PsSettingsEntry — only Auto (cal-mode) survives
         Assert.False(entry!.Auto);
     }
 
@@ -164,7 +164,8 @@ public class PsPersistenceTests : IDisposable
         var (radio2, _) = BuildRadioWithStore();
         var snap = radio2.Snapshot();
 
-        Assert.True(snap.PsEnabled);
+        // Master arm must NOT survive restart — always boots false
+        Assert.False(snap.PsEnabled);
         Assert.False(snap.PsAuto);
         Assert.Equal(900.0, snap.TwoToneFreq1);
         Assert.Equal(2200.0, snap.TwoToneFreq2);


### PR DESCRIPTION
## Problem

Christian's `wip(web)` commit (`d4247284`) re-introduced `Enabled` into `PsSettingsEntry` and wired it back into the startup `StateDto` via `ps?.Enabled ?? false`. This means PureSignal auto-arms on startup whenever the operator previously had it armed — reversing the deliberate no-persist safety rule established in PR #229.

**Symptom:** Zeus starts, radio connects, PureSignal is already armed before the operator has made any transmit decision. On a hot external-tap chain (G2 + RF2K-S) this is a burn-zone hazard.

## Fix

- Remove `Enabled` from `PsSettingsEntry` (it was never supposed to be there post-#229)
- `PersistPsState` no longer writes the arm state
- `RadioService` startup always initialises `PsEnabled: false` — operator must re-arm each session
- Tests updated to assert the arm does **not** survive a restart

**All other PS persistence is unchanged:** `HwPeakByBoard`, `TxAttnByBoard`, cal-mode `Auto`, timing constants, feedback source — all still persist as expected.

## Tests

```
Passed! - Failed: 0, Passed: 183, Skipped: 6 — Zeus.Server.Tests
```