### PR TITLE
docs(claude): hard rule — PureSignal changes require KB2UKA explicit approval

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,38 @@ AI agents opening PRs against this repo may autonomously fix:
 - **Protocol / WDSP compliance fixes** — where the Zeus behavior diverges from Thetis and Thetis source confirms Zeus is wrong. *Exception:* if the fix changes a default that an operator will feel (TX power cap, filter bandwidth, AGC curve, meter scaling), that is red-light — see below.
 - **Docs and lessons updates** — additions to `docs/lessons/`, `docs/rca/`, `README.md`. Renames and restructuring are red-light. **README scope:** `README.md` stays tight — one-line radio status per board and a high-level feature list only. Extensive feature write-ups, per-panel guides, and step-by-step how-tos belong in the [GitHub wiki](https://github.com/Kb2uka/openhpsdr-zeus/wiki), not the README.
 
+## Hard Rules — PureSignal (KB2UKA standing orders)
+
+**PureSignal is a burn-zone subsystem. No change to PureSignal logic, persistence,
+arm/disarm behaviour, or calibration defaults is permitted without explicit approval
+from KB2UKA (Douglas J. Cerrato). This is a hard rule — not red-light, not a flag,
+a full stop.**
+
+What this covers — any modification (however small) to:
+- `PureSignal` arm state (`PsEnabled`) persistence or startup initialisation
+- `PsSettingsStore`, `PsSettingsEntry`, or any LiteDB field that feeds `PsEnabled`
+- `RadioService.PersistPsState`, `ApplyPsHwPeakForConnection`, or the PS startup
+  rehydration path in `RadioService` initial state
+- The PS-A master arm endpoints (`/api/tx/ps`) or their StateDto wiring
+- `HwPeakByBoard` / `TxAttnByBoard` default values or per-board resolution logic
+- Any change that causes PureSignal to arm automatically without an explicit
+  operator action
+
+**Why it matters:** Zeus runs against real HF power amplifiers. An inadvertently
+armed PureSignal on an external-tap feedback chain (e.g. G2 + RF2K-S) can
+saturate the feedback ADC before the operator has made any transmit decision.
+The no-persist rule on PsEnabled (established in PR #229, re-broken in d4247284)
+exists specifically to prevent silent auto-arm on restart.
+
+**Standing invariant:** `PsEnabled` MUST always initialise to `false` on server
+startup, regardless of what is stored on disk. The operator arms PS manually,
+every session, no exceptions. This is not a UX convenience trade-off — it is a
+safety rule.
+
+If you believe a PureSignal change is necessary, stop, open a GitHub issue
+describing the rationale, and wait for KB2UKA to approve the approach before
+writing a single line of code.
+
 **Red-light (flag for maintainer review, do NOT merge without approval):**
 - **Visual design** — colors, fonts, layout, spacing, typography. The Zeus aesthetic is faithful to the **Hermes Lite 2 hardware front panel**: near-black beveled panel chrome (`--panel-top`/`--panel-bot` gradient) on a blue-gray workspace (`--bg-app` `#657486`), Archivo Narrow type, and a restrained accent system — `--accent` blue `#4a9eff` for focus/state, `--tx` red `#e63a2b` for TX/gain-reduction, `--power` yellow `#ffc93a` for output power, `--orange` `#f28524` reserved for the QRZ button. The single-hue amber `#FFA028` is the **panadapter WebGL trace + meter peak-tick** color (signal-strength visualization, varying alpha — see `gl/panadapter.ts` and `docs/lessons/dev-conventions.md`); it is not a global UI accent and must not be applied to chrome, buttons, or controls. **Source of truth for the global palette is `zeus-web/src/styles/tokens.css`.** Use the existing token variables, never raw hex. Do not propose palette changes.
 - **UX behavior** — what a click/drag/scroll does, keyboard shortcuts, panadapter/waterfall axis direction, VFO tuning feel. "Wrong scroll direction" reports are almost always a missed waterfall horizontal-shift, not an axis bug — see `docs/lessons/`.

--- a/Zeus.Server.Hosting/PsSettingsStore.cs
+++ b/Zeus.Server.Hosting/PsSettingsStore.cs
@@ -25,14 +25,14 @@ using Zeus.Contracts;
 namespace Zeus.Server;
 
 // PureSignal settings persistence. Stores the operator's calibration tuning
-// (master arm, timing delays, ints/spi preset, ptol mode, auto-attenuate,
-// per-board HW peak) so it survives server restarts. Shares zeus-prefs.db
-// with DspSettingsStore.
+// (timing delays, ints/spi preset, ptol mode, auto-attenuate, per-board HW
+// peak) so it survives server restarts. Shares zeus-prefs.db with
+// DspSettingsStore.
 //
-// Deliberately does NOT persist `PsSingle` (one-shot cal mode). It resets to
-// a safe default each session. The PS master arm does persist because it is a
-// standing operator preference; actual transmit/keying actions (MOX / TUN /
-// TwoToneEnabled) remain session-only.
+// Deliberately does NOT persist `PsEnabled` (the master arm) or `PsSingle`
+// (one-shot cal mode) -- these reset to safe defaults each session. Same
+// pattern as MOX / TUN: arming PS is an explicit operator action, never an
+// automatic "resume what we did last time" behaviour.
 //
 // `HwPeakByBoard` IS persisted as of 2026-05-16. The earlier "re-derive per
 // radio at connect time" assumption clobbered operator-calibrated values
@@ -91,7 +91,6 @@ public sealed class PsSettingsEntry
 {
     public int Id { get; set; }
     public string ProfileId { get; set; } = string.Empty;
-    public bool Enabled { get; set; }
     // Cal-mode default — Auto = continuous adapt. Persisted because operators
     // who prefer single-shot calibration (and run TwoTone manually) want that
     // selection to stick across sessions.
@@ -108,9 +107,9 @@ public sealed class PsSettingsEntry
     public PsFeedbackSource Source { get; set; } = PsFeedbackSource.Internal;
     // Two-tone test generator settings. Persisted so an operator who has
     // dialled in custom IMD test tones (e.g. for a specific filter response
-    // or PA test) doesn't have to re-enter them every session. TwoToneEnabled
-    // is intentionally NOT persisted — same operator-action discipline as
-    // MOX/TUN — but the dialled-in freqs/mag are.
+    // or PA test) doesn't have to re-enter them every session. PsEnabled and
+    // TwoToneEnabled are intentionally NOT persisted -- same operator-action
+    // discipline as MOX/TUN -- but the dialled-in freqs/mag are.
     // Defaults match tx-store.ts (700/1900/0.49) and pihpsdr.
     public double TwoToneFreq1 { get; set; } = 700.0;
     public double TwoToneFreq2 { get; set; } = 1900.0;

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -418,7 +418,7 @@ public sealed class RadioService : IDisposable
             AutoAgcEnabled: rsSnap?.AutoAgcEnabled ?? false,
             AgcOffsetDb: 0.0,       // always reset — control-loop accumulator
             // PS persisted fields (or DTO defaults when not persisted yet).
-            PsEnabled: ps?.Enabled ?? false,
+            PsEnabled: false, // master arm is never persisted — operator must re-arm each session
             PsAuto: ps?.Auto ?? true,
             PsPtol: ps?.Ptol ?? false,
             PsAutoAttenuate: ps?.AutoAttenuate ?? true,
@@ -479,7 +479,7 @@ public sealed class RadioService : IDisposable
     /// callers don't drop fields by writing only what they touched. Called
     /// from SetPs, SetPsAdvanced, SetPsFeedbackSource, and SetTwoTone.
     ///
-    /// PsEnabled is persisted as the operator's standing PS preference.
+    /// PsEnabled is NOT persisted — master arm resets to false each session.
     /// TwoToneEnabled remains session-only because it can key the transmitter.
     /// PsHwPeak IS persisted per-connected-board via the HwPeakByBoard dictionary;
     /// when no board is currently connected the HwPeak portion of the write
@@ -514,7 +514,6 @@ public sealed class RadioService : IDisposable
         }
         _psStore.Upsert(new PsSettingsEntry
         {
-            Enabled = snap.PsEnabled,
             Auto = snap.PsAuto,
             Ptol = snap.PsPtol,
             AutoAttenuate = snap.PsAutoAttenuate,

--- a/tests/Zeus.Server.Tests/PsEndpointPersistenceTests.cs
+++ b/tests/Zeus.Server.Tests/PsEndpointPersistenceTests.cs
@@ -24,7 +24,7 @@ public sealed class PsEndpointPersistenceTests : IDisposable
     }
 
     [Fact]
-    public async Task PostPsArm_RehydratesThroughStateAfterHostRestart()
+    public async Task PostPsArm_DoesNotRehydrateThroughStateAfterHostRestart()
     {
         using (var first = new Factory(_dbPath))
         using (var client = first.CreateClient())
@@ -36,6 +36,7 @@ public sealed class PsEndpointPersistenceTests : IDisposable
             Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
             using var body = await JsonDocument.ParseAsync(await resp.Content.ReadAsStreamAsync());
             Assert.True(body.RootElement.GetProperty("psEnabled").GetBoolean());
+            // auto=false was persisted; psEnabled itself is a live value from the active session
             Assert.False(body.RootElement.GetProperty("psAuto").GetBoolean());
         }
 
@@ -46,7 +47,9 @@ public sealed class PsEndpointPersistenceTests : IDisposable
 
             Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
             using var body = await JsonDocument.ParseAsync(await resp.Content.ReadAsStreamAsync());
-            Assert.True(body.RootElement.GetProperty("psEnabled").GetBoolean());
+            // Master arm must NOT survive a restart — always boots false
+            Assert.False(body.RootElement.GetProperty("psEnabled").GetBoolean());
+            // Cal-mode DOES persist — auto=false should survive
             Assert.False(body.RootElement.GetProperty("psAuto").GetBoolean());
         }
     }

--- a/tests/Zeus.Server.Tests/PsPersistenceTests.cs
+++ b/tests/Zeus.Server.Tests/PsPersistenceTests.cs
@@ -30,8 +30,8 @@ namespace Zeus.Server.Tests;
 /// PureSignal settings persistence — guards the round-3 fix where SetPs and
 /// SetTwoTone silently failed to call _psStore.Upsert. After the fix, every
 /// Set* path that mutates a persisted PS field must drop a doc into the
-/// LiteDB-backed store. PsEnabled is a persisted standing preference;
-/// TwoToneEnabled remains session-only because it can key the transmitter.
+/// LiteDB-backed store. PsEnabled is NOT persisted (master arm resets to
+/// false each session). TwoToneEnabled also remains session-only.
 /// </summary>
 public class PsPersistenceTests : IDisposable
 {
@@ -61,17 +61,17 @@ public class PsPersistenceTests : IDisposable
     }
 
     [Fact]
-    public void SetPs_PersistsEnabledAndAutoFlag()
+    public void SetPs_PersistsAutoFlag_ButNotArmState()
     {
         var (radio, store) = BuildRadioWithStore();
 
-        // Operator arms PS and picks Single mode — persisted fields reflect
-        // both the standing arm preference and the cal-mode preference.
+        // Operator arms PS and picks Single mode — cal-mode (Auto) persists,
+        // but the master arm (Enabled) must NOT persist.
         radio.SetPs(new PsControlSetRequest(Enabled: true, Auto: false, Single: true));
 
         var entry = store.Get();
         Assert.NotNull(entry);
-        Assert.True(entry!.Enabled);
+        // Enabled is not on PsSettingsEntry — only Auto (cal-mode) survives
         Assert.False(entry!.Auto);
     }
 
@@ -164,7 +164,8 @@ public class PsPersistenceTests : IDisposable
         var (radio2, _) = BuildRadioWithStore();
         var snap = radio2.Snapshot();
 
-        Assert.True(snap.PsEnabled);
+        // Master arm must NOT survive restart — always boots false
+        Assert.False(snap.PsEnabled);
         Assert.False(snap.PsAuto);
         Assert.Equal(900.0, snap.TwoToneFreq1);
         Assert.Equal(2200.0, snap.TwoToneFreq2);


### PR DESCRIPTION
Codifies the standing KB2UKA order: no change to PureSignal arm state, persistence, or calibration defaults without explicit approval.

Motivated by `d4247284` which silently re-introduced `PsEnabled` persistence (reversing PR #229) inside a large `wip(web)` commit. The rule was implicit before; it is now explicit in `CLAUDE.md` so every agent and contributor hits it before touching the subsystem.

**What the rule covers:**
- `PsEnabled` persistence or startup initialisation
- `PsSettingsStore` / `PsSettingsEntry` / any LiteDB field that feeds `PsEnabled`
- `RadioService.PersistPsState`, `ApplyPsHwPeakForConnection`, PS startup rehydration
- PS-A master arm endpoints or their StateDto wiring
- Any change that causes PureSignal to arm automatically without an explicit operator action

**Standing invariant codified:** `PsEnabled` MUST always initialise to `false` on server startup. No exceptions.

Docs-only — CLAUDE.md +32 lines, no code changed.