### PR TITLE
fix(workspace): smooth panel drag-to-reorder, no boundary flicker

### DIFF
--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -453,7 +453,9 @@ function WorkspaceCanvas({
         <div style={{ minHeight: 80 }} aria-hidden />
       ) : (
         <ResponsiveGridLayout
-          className="all-panels-grid"
+          className={`all-panels-grid${
+            gridInteraction ? ' all-panels-grid--interacting' : ''
+          }`}
           width={width}
           breakpoints={{ lg: 0 }}
           cols={{ lg: WORKSPACE_GRID_COLS }}

--- a/zeus-web/src/layout/workspaceGrid.test.ts
+++ b/zeus-web/src/layout/workspaceGrid.test.ts
@@ -149,6 +149,65 @@ describe('workspace grid collision policy', () => {
     expectNoCollisions(next);
   });
 
+  it('keeps the dragged tile pinned to the pointer when no swap fires', () => {
+    // Root cause of the "quick back and forth" report: the compactor used to
+    // pack the dragged tile upward on any frame that did not fire a swap, then
+    // RGL dragged it back toward the pointer — a 2-cycle at the swap boundary.
+    // A live drag now pins the dragged tile to its pointer cell unconditionally,
+    // so dragging `below` into empty space leaves it where the pointer is rather
+    // than snapping it back up against `above`.
+    const layout: Layout = cloneLayout([
+      { i: 'above', x: 0, y: 0, w: 6, h: 2 },
+      { i: 'below', x: 0, y: 2, w: 6, h: 2 },
+    ]);
+    const below = layout[1]!;
+
+    const next = dragAndCompact(layout, below, 0, 6);
+
+    expect(next.find((i) => i.i === 'below')).toMatchObject({ x: 0, y: 6 });
+    expect(next.find((i) => i.i === 'above')).toMatchObject({ x: 0, y: 0 });
+    expectNoCollisions(next);
+  });
+
+  it('keeps a neighbour swap engaged across the touch boundary', () => {
+    // Reproduces the boundary jitter with one compactor instance (one live
+    // drag). Once `below` engages at full overlap it must stay displaced when
+    // the dragged tile jitters back to the touching row — engagement is sticky,
+    // so the neighbour never snaps home and back (the visible flicker).
+    const base: Layout = cloneLayout([
+      { i: 'dragged', x: 0, y: 0, w: 6, h: 2 },
+      { i: 'below', x: 0, y: 2, w: 6, h: 2 },
+    ]);
+    const dragStart = { item: { ...base[0]! }, layout: cloneLayout(base) };
+    const compactor = createWorkspaceDragCompactor(() => dragStart);
+
+    const step = (y: number) => {
+      const work = cloneLayout(base);
+      const item = work.find((i) => i.i === 'dragged')!;
+      return compactor.compact(
+        moveElement(
+          work,
+          item,
+          0,
+          y,
+          true,
+          compactor.preventCollision,
+          compactor.type,
+          24,
+          compactor.allowOverlap,
+        ),
+        24,
+      );
+    };
+
+    // Engage the swap (full overlap of `below`), then jitter up one row so the
+    // tiles only touch. `below` stays out of its original slot.
+    expect(step(2).find((i) => i.i === 'below')).toMatchObject({ x: 0, y: 0 });
+    const boundary = step(1);
+    expect(boundary.find((i) => i.i === 'below')?.y).not.toBe(2);
+    expectNoCollisions(boundary);
+  });
+
   it('swaps a colliding panel into the dragged panel old slot on drop', () => {
     const layout = cloneLayout(baseLayout);
     const dragged = layout[0]!;

--- a/zeus-web/src/layout/workspaceGrid.ts
+++ b/zeus-web/src/layout/workspaceGrid.ts
@@ -15,11 +15,32 @@ export const WORKSPACE_DRAG_COMPACTOR = createWorkspaceDragCompactor();
 export function createWorkspaceDragCompactor(
   getDragStart?: () => WorkspaceDragStartSnapshot | null,
 ): Compactor {
+  // Per-drag hysteresis state. `engaged` holds the ids of neighbours currently
+  // committed to a swap; it is rebuilt whenever the drag snapshot identity
+  // changes (a new gesture) and dropped when the drag ends (snapshot null).
+  // Carrying it across frames is what gives the swap a deadband — without it
+  // the swap re-derives from scratch every frame and flickers at the boundary.
+  let session: {
+    dragStart: WorkspaceDragStartSnapshot;
+    engaged: Set<string>;
+  } | null = null;
   return {
     type: null,
     allowOverlap: false,
-    compact: (layout, cols) =>
-      compactDragMagnetic(layout, cols, getDragStart?.() ?? null),
+    compact: (layout, cols) => {
+      const dragStart = getDragStart?.() ?? null;
+      if (!dragStart) {
+        session = null;
+      } else if (!session || session.dragStart !== dragStart) {
+        session = { dragStart, engaged: new Set() };
+      }
+      return compactDragMagnetic(
+        layout,
+        cols,
+        dragStart,
+        session?.engaged ?? null,
+      );
+    },
   };
 }
 
@@ -33,6 +54,7 @@ function compactDragMagnetic(
   layout: Layout,
   cols: number,
   dragStart: WorkspaceDragStartSnapshot | null,
+  engaged: Set<string> | null,
 ): Layout {
   const priorityId = layout.find((item) => item.moved)?.i;
   if (!priorityId || !dragStart) {
@@ -48,11 +70,19 @@ function compactDragMagnetic(
     cols,
     priorityId,
     dragStart,
+    engaged,
   );
+  // During a live drag keep the dragged tile pinned to the pointer cell, even
+  // on frames where no swap fires. Toggling preservePriority with the swap
+  // (the old behaviour) let compactMagnetUp yank the tile upward the instant
+  // its overlap dipped below a collision; RGL then dragged it back toward the
+  // pointer next frame — the preserve-toggle 2-cycle that read as a "quick
+  // back and forth" at the swap boundary. A live session pins unconditionally.
+  const preservePriority = engaged ? true : swapped.displaced;
   return compactMagnetUp(
     swapped.layout,
     priorityId,
-    swapped.displaced,
+    preservePriority,
   ).map((item) => ({
     ...item,
     moved: false,
@@ -79,6 +109,7 @@ export function autoFitDroppedPanel(
     cols,
     dropped.i,
     dragStart?.layout.length ? dragStart : null,
+    null,
   );
   const base = swapped.layout;
   const target = base.find((item) => item.i === dropped.i);
@@ -204,6 +235,7 @@ function swapDisplacedIntoPreviousSlot(
   cols: number,
   priorityId: string | undefined,
   dragStart: WorkspaceDragStartSnapshot | null,
+  engaged: Set<string> | null,
 ): { layout: Layout; displaced: boolean } {
   const next = cloneLayout(layout);
   if (!priorityId || !dragStart || dragStart.item.i !== priorityId) {
@@ -223,11 +255,26 @@ function swapDisplacedIntoPreviousSlot(
     .filter(
       (
         candidate,
-      ): candidate is { item: LayoutItem; previous: LayoutItem } =>
-        candidate.previous !== undefined &&
-        (placementChanged(candidate.item, candidate.previous) ||
+      ): candidate is { item: LayoutItem; previous: LayoutItem } => {
+        if (candidate.previous === undefined) return false;
+        // Live drag: gate engagement through the per-drag hysteresis set so a
+        // neighbour holds its swapped slot across the touch boundary instead of
+        // flickering. Drop / one-shot compaction (engaged === null) keeps the
+        // immediate collision test — there is no next frame to flicker into.
+        if (engaged) {
+          return updateSwapEngagement(
+            candidate.item.i,
+            candidate.previous,
+            anchor,
+            engaged,
+          );
+        }
+        return (
+          placementChanged(candidate.item, candidate.previous) ||
           collides(candidate.previous, anchor) ||
-          collides(candidate.item, anchor)),
+          collides(candidate.item, anchor)
+        );
+      },
     )
     .sort((a, b) =>
       compareDisplacedCandidates(a, b, anchor, originalOrder),
@@ -601,6 +648,47 @@ function collides(a: LayoutItem, b: LayoutItem) {
   if (a.y + a.h <= b.y) return false;
   if (a.y >= b.y + b.h) return false;
   return true;
+}
+
+// Hysteresis thresholds for the live magnetic swap (grid rows). A neighbour
+// engages once the dragged tile overlaps it by at least ENGAGE rows, and only
+// disengages once they are separated by more than RELEASE rows (a strict gap).
+// The band between them — the touch boundary, where RGL's grid-rounding jitters
+// the dragged tile by a single row — is a deadband: a neighbour that is already
+// committed stays committed across it, so the swap can't flicker on and off.
+const SWAP_ENGAGE_ROWS = 1;
+const SWAP_RELEASE_ROWS = 0;
+
+// Signed vertical overlap between the dragged anchor and a neighbour, in rows:
+// positive when they overlap, zero when edges touch, negative (a gap) when they
+// are apart. Returns -Infinity when their columns don't overlap at all, so a
+// neighbour off to the side never engages and any engaged one releases at once.
+function verticalOverlapRows(anchor: LayoutItem, neighbor: LayoutItem): number {
+  if (anchor.x + anchor.w <= neighbor.x || anchor.x >= neighbor.x + neighbor.w) {
+    return Number.NEGATIVE_INFINITY;
+  }
+  return (
+    Math.min(anchor.y + anchor.h, neighbor.y + neighbor.h) -
+    Math.max(anchor.y, neighbor.y)
+  );
+}
+
+// Advance the per-drag engagement set for one neighbour and report whether it
+// is currently committed to a swap. Engage on real overlap, release only on a
+// clear gap; the touch boundary in between is sticky.
+function updateSwapEngagement(
+  id: string,
+  previous: LayoutItem,
+  anchor: LayoutItem,
+  engaged: Set<string>,
+): boolean {
+  const overlap = verticalOverlapRows(anchor, previous);
+  if (engaged.has(id)) {
+    if (overlap < SWAP_RELEASE_ROWS) engaged.delete(id);
+  } else if (overlap >= SWAP_ENGAGE_ROWS) {
+    engaged.add(id);
+  }
+  return engaged.has(id);
 }
 
 function boundedMin(value: number | undefined, fallback: number, ceiling: number) {

--- a/zeus-web/src/styles/all-panels.css
+++ b/zeus-web/src/styles/all-panels.css
@@ -65,6 +65,19 @@
     height var(--dur-fast) var(--ease-out);
 }
 
+/* Premium reflow: while the operator is actively dragging or resizing, let the
+ * OTHER tiles glide to their new slots instead of snapping instantly. Scoped to
+ * the live interaction (the --interacting class is toggled by WorkspaceCanvas)
+ * and to non-dragged tiles, so idle tiles keep `transition: none` and are never
+ * promoted to a GPU compositor layer — preserving the WebGL-panadapter cost
+ * guard the base .react-grid-item rule above exists for. absoluteStrategy
+ * positions tiles via top/left, so those are the properties we ease. */
+.all-panels-grid--interacting
+  .react-grid-item:not(.react-draggable-dragging):not(.resizing) {
+  transition: top var(--dur-fast) var(--ease-out),
+    left var(--dur-fast) var(--ease-out);
+}
+
 /* Drop placeholder — accent-blue ghost where the dragged tile will land. */
 .all-panels-grid .react-grid-placeholder {
   background: var(--accent);


### PR DESCRIPTION
## Problem

Moving a workspace panel produced a **quick back-and-forth jitter** near the swap boundary — panels would flick into and out of place until the pointer was pushed well past the transition point.

## Root cause

Two compounding issues in the drag compactor (`workspaceGrid.ts`):

1. **`preservePriority` 2-cycle (dominant).** `compactDragMagnetic` toggled `preservePriority` based on whether a swap fired that frame. One grid-row of pointer jitter dropped the overlap → the dragged tile was packed *upward* away from the pointer → RGL dragged it back next frame → repeat. This triggered over a wide band near any panel boundary.
2. **No hysteresis on the swap trigger.** A neighbour swapped on *any* 1-row collision and un-swapped the instant overlap hit 0, so it also flickered right at the touch line.

## Fix

- **Pin the dragged tile to the pointer during a live drag** — `preservePriority` is now unconditional for the live session, killing the 2-cycle so the placeholder never snaps away.
- **Sticky hysteresis on swap engagement** — a per-drag `engaged` set (held in the compactor closure, rebuilt per gesture) engages a neighbour on real overlap and only releases on a clear gap. The touching row in between is a deadband, so a committed swap can't flicker on/off.
- **Premium reflow glide** — a scoped `.all-panels-grid--interacting` class eases displaced tiles' `top`/`left` so the one-time reflow slides instead of snapping. Scoped to active interaction and non-dragged tiles only, so idle tiles keep `transition: none` and the WebGL-panadapter GPU-layer cost guard is preserved. (Confirmed `absoluteStrategy` positions via `top`/`left`.)

Drop-path compaction is intentionally unchanged.

## Testing

- Added two regression tests: pointer-pin when no swap fires, and sticky engagement across the touch boundary.
- Full frontend suite green: **827 tests pass**; `tsc --noEmit` clean.
- Not driven via a live in-browser pointer-drag (headless preview can't render the canvas panels); the oscillation logic is exercised frame-by-frame by the unit tests. Worth a quick manual smoke test of drag feel.

## Notes for reviewers

This touches drag/drop UX behaviour (red-light per `CLAUDE.md`). No palette/token changes. Defaults and drop behaviour are unchanged.