### PR TITLE
feat(about): add Christian Suarez N9WAR to About panel

### DIFF
--- a/zeus-web/src/components/AboutPanel.tsx
+++ b/zeus-web/src/components/AboutPanel.tsx
@@ -2,7 +2,8 @@
 //
 // Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
 // Copyright (C) 2025-2026 Brian Keating (EI6LF),
-//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
 //
 // This program is free software: you can redistribute it and/or modify it
 // under the terms of the GNU General Public License as published by the
@@ -205,8 +206,8 @@ export function AboutPanel() {
           OpenHPSDR Zeus is a cross-platform SDR client for OpenHPSDR Protocol-1 and Protocol-2 radios.
         </p>
         <p style={{ margin: '0 0 12px 0', lineHeight: 1.6, color: 'var(--fg-2)' }}>
-          Copyright © 2025-2026 Brian Keating (EI6LF), Douglas J. Cerrato (KB2UKA), and
-          contributors.
+          Copyright © 2025-2026 Brian Keating (EI6LF), Douglas J. Cerrato (KB2UKA), Christian
+          Suarez (N9WAR), and contributors.
         </p>
         <p style={{ margin: 0, lineHeight: 1.6, color: 'var(--fg-2)', fontSize: 11 }}>
           Licensed under GNU GPL v2 or later. See{' '}


### PR DESCRIPTION
Adds Christian Suarez (N9WAR) to the visible copyright line in the About panel and to the file header, alongside Brian Keating (EI6LF) and Douglas J. Cerrato (KB2UKA).

Two lines changed in `AboutPanel.tsx`, nothing else.