### PR TITLE
fix(workspace): stable panel sizing on reposition (no scrollbar, locked panels pinned)

### DIFF
--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -48,7 +48,6 @@ import {
   EMPTY_WORKSPACE_LAYOUT,
   WORKSPACE_GRID_COLS,
   WORKSPACE_ROW_HEIGHT_PX,
-  WORKSPACE_TARGET_ROWS,
   WORKSPACE_TILE_MIN_H,
   WORKSPACE_TILE_MIN_W,
   type WorkspaceTile,
@@ -70,7 +69,6 @@ import {
 } from './panels/urlEmbedConfig';
 
 const WORKSPACE_GRID_MARGIN_PX = 3;
-const WORKSPACE_ROW_GAP_SHARE = 6;
 
 type GridInteraction = 'drag' | 'resize' | null;
 
@@ -246,66 +244,22 @@ function WorkspaceCanvas({
   // Track container height so rowHeight can shrink when the workspace is
   // tight. Rows do not grow past the authored design density; extra viewport
   // height stays on the workspace ground instead of stretching every panel.
-  const [containerHeight, setContainerHeight] = useState(0);
   const [gridInteraction, setGridInteraction] =
     useState<GridInteraction>(null);
   const draggingRef = useRef(false);
   const skipPostDropLayoutChangeRef = useRef(false);
   const dragStartRef = useRef<WorkspaceDragStartSnapshot | null>(null);
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    setContainerHeight(el.getBoundingClientRect().height);
-    const ro = new ResizeObserver((entries) => {
-      for (const e of entries) setContainerHeight(e.contentRect.height);
-    });
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, [containerRef]);
-  // The actual vertical extent of the current layout, in grid rows. The
-  // default layout is authored to be exactly WORKSPACE_TARGET_ROWS tall, but
-  // the operator adds/rearranges panels freely — once the layout is taller
-  // than the target, dividing the viewport by a fixed target would render the
-  // grid taller than the container and force an outer scrollbar. Tracking the
-  // real extent keeps the workspace fitting the viewport no matter how many
-  // panels are docked.
-  const layoutRows = useMemo(
-    () => tiles.reduce((max, t) => Math.max(max, t.y + t.h), 0),
-    [tiles],
-  );
-  // Fit-to-viewport divisor: never smaller than the default target (so a
-  // sparse layout doesn't balloon its tiles to fill the screen — it just
-  // leaves empty space at the bottom, matching the prior behaviour), and
-  // grows to the layout's real height when the operator stacks panels past
-  // the default fold. Dense layouts shrink rather than asking the workspace
-  // shell for a scrollbar.
-  const targetRows = Math.max(layoutRows, WORKSPACE_TARGET_ROWS);
 
-  // Shrink-to-fit rowHeight: solve containerHeight ≈ rowHeight*N + margin*(N-1)
-  // + 2*containerPadding, but cap at WORKSPACE_ROW_HEIGHT_PX so resizing a
-  // window taller doesn't inject empty vertical space inside fixed-control
-  // panels. Margin and containerPadding here mirror the props passed to
-  // ResponsiveGridLayout below — keep them in sync if those change. The row
-  // gap shrinks with very dense layouts so gaps alone can never make the grid
-  // taller than the viewport.
-  const rowMargin = useMemo(() => {
-    if (containerHeight <= 0 || targetRows <= 1) return WORKSPACE_GRID_MARGIN_PX;
-    return Math.min(
-      WORKSPACE_GRID_MARGIN_PX,
-      containerHeight / (targetRows * WORKSPACE_ROW_GAP_SHARE),
-    );
-  }, [containerHeight, targetRows]);
-
-  const rowHeight = useMemo(() => {
-    if (containerHeight <= 0) return WORKSPACE_ROW_HEIGHT_PX;
-    const containerPadding = 0;
-    const inner =
-      containerHeight - 2 * containerPadding - rowMargin * Math.max(0, targetRows - 1);
-    return Math.min(
-      WORKSPACE_ROW_HEIGHT_PX,
-      Math.max(0.1, inner / Math.max(1, targetRows)),
-    );
-  }, [containerHeight, rowMargin, targetRows]);
+  // Fixed cell size. A panel's size only ever changes when the operator drags
+  // its resize handle — never as a side effect of repositioning. When a layout
+  // stacks taller than the viewport the workspace scrolls (see
+  // .all-panels-workspace in all-panels.css) instead of shrinking every panel
+  // to fit, matching how grid dashboards (Grafana, Gridstack) behave. Earlier
+  // builds divided the viewport height by the live layout height, so moving a
+  // panel that grew the stack rescaled every other panel — the incidental
+  // resize we deliberately removed here.
+  const rowHeight = WORKSPACE_ROW_HEIGHT_PX;
+  const rowMargin = WORKSPACE_GRID_MARGIN_PX;
 
   const workspaceDragCompactor = useMemo(
     () => createWorkspaceDragCompactor(() => dragStartRef.current),

--- a/zeus-web/src/layout/workspaceGrid.test.ts
+++ b/zeus-web/src/layout/workspaceGrid.test.ts
@@ -413,6 +413,30 @@ describe('workspace grid collision policy', () => {
     expectNoCollisions(next);
   });
 
+  it('never shrinks a repositioned panel to fit around a locked panel', () => {
+    // A dropped panel overlapping a locked (static) panel must keep its full
+    // size and relocate below it — repositioning must never resize the panel.
+    const layout: Layout = cloneLayout([
+      { i: 'locked', x: 0, y: 0, w: 24, h: 4, static: true },
+      { i: 'dragged', x: 0, y: 0, w: 10, h: 6, moved: true },
+    ]);
+    const previous = {
+      item: { i: 'dragged', x: 0, y: 10, w: 10, h: 6 },
+      layout: [] as Layout,
+    };
+
+    const next = autoFitDroppedPanel(layout, 24, previous);
+
+    // Full size preserved (not squeezed into the gap), and the lock is intact.
+    expect(next.find((i) => i.i === 'dragged')).toMatchObject({ w: 10, h: 6 });
+    expect(next.find((i) => i.i === 'locked')).toMatchObject({
+      x: 0,
+      y: 0,
+      static: true,
+    });
+    expectNoCollisions(next);
+  });
+
   it('pushes a lower panel down when resize grows into it', () => {
     const layout = cloneLayout(baseLayout);
     layout[0]!.h = 4;

--- a/zeus-web/src/layout/workspaceGrid.test.ts
+++ b/zeus-web/src/layout/workspaceGrid.test.ts
@@ -208,6 +208,33 @@ describe('workspace grid collision policy', () => {
     expectNoCollisions(boundary);
   });
 
+  it('never moves a locked panel when another panel is dragged onto it', () => {
+    // A locked (static) panel must stay pinned even while another panel is
+    // dragged across it — previously the magnetic swap shoved it aside mid-drag
+    // and it only snapped back on drop.
+    const dragStart = {
+      item: { i: 'dragged', x: 0, y: 0, w: 6, h: 2 },
+      layout: cloneLayout([
+        { i: 'dragged', x: 0, y: 0, w: 6, h: 2 },
+        { i: 'locked', x: 0, y: 2, w: 6, h: 2, static: true },
+      ]),
+    };
+    const compactor = createWorkspaceDragCompactor(() => dragStart);
+    // Live-drag frame: the dragged panel has been moved onto the locked slot.
+    const frame: Layout = cloneLayout([
+      { i: 'dragged', x: 0, y: 2, w: 6, h: 2, moved: true },
+      { i: 'locked', x: 0, y: 2, w: 6, h: 2, static: true },
+    ]);
+
+    const next = compactor.compact(frame, 24);
+
+    expect(next.find((i) => i.i === 'locked')).toMatchObject({
+      x: 0,
+      y: 2,
+      static: true,
+    });
+  });
+
   it('swaps a colliding panel into the dragged panel old slot on drop', () => {
     const layout = cloneLayout(baseLayout);
     const dragged = layout[0]!;

--- a/zeus-web/src/layout/workspaceGrid.ts
+++ b/zeus-web/src/layout/workspaceGrid.ts
@@ -124,106 +124,63 @@ export function autoFitDroppedPanel(
 
   const footprintX = clamp(target.x, 0, Math.max(0, cols - startW));
   const footprintY = Math.max(0, Math.round(target.y));
-  const footprintRight = Math.min(cols, footprintX + startW);
-  const footprintBottom = footprintY + startH;
 
-  // Fast path — full size at the drop origin. The search below ranks
-  // candidates by originDistance FIRST (|x−footprintX|+|y−footprintY|), and
-  // only the origin cell scores 0, so no farther placement can ever beat an
-  // origin one. At the origin the largest area is the panel's full
-  // (startW × startH) — exactly what the nested loop tries first. So when full
-  // size fits at the origin (the overwhelmingly common drag case, since
-  // resolveAnchorCollisions pushes movable neighbours aside), it is the global
-  // optimum and the whole O(footprintArea × maxW × maxH) sweep is redundant.
-  // Skipping it here is what stops a large panel (e.g. the panadapter/hero
-  // tile, ~18×38) from freezing the main thread for seconds on drop.
-  const originTrial = cloneLayout(base);
-  const originTarget = originTrial.find((item) => item.i === target.i);
-  if (originTarget) {
-    originTarget.x = footprintX;
-    originTarget.y = footprintY;
-    originTarget.w = startW;
-    originTarget.h = startH;
-    const originResolved = resolveAnchorCollisions(
-      originTrial,
-      target.i,
-      cols,
-      previousItem,
+  // Repositioning must NEVER resize the panel — only the explicit corner-resize
+  // handle changes a panel's size. Every placement below therefore keeps the
+  // dragged panel at its full (startW × startH) footprint and moves *other*
+  // panels out of the way (resolveAnchorCollisions pushes movable neighbours
+  // down). The old code shrank the dropped panel to fit leftover space, which
+  // is what made panels change size on a plain reposition.
+  const placeFullSize = (x: number, y: number) => {
+    const trial = cloneLayout(base);
+    const trialTarget = trial.find((item) => item.i === target.i);
+    if (!trialTarget) return null;
+    trialTarget.x = x;
+    trialTarget.y = y;
+    trialTarget.w = startW;
+    trialTarget.h = startH;
+    return resolveAnchorCollisions(trial, target.i, cols, previousItem);
+  };
+
+  // Fast path — full size at the drop origin. The overwhelmingly common case:
+  // resolveAnchorCollisions shoves movable neighbours aside so the panel lands
+  // exactly where it was dropped. Keeping this O(1) (rather than sweeping a
+  // footprint) is also what stops a large tile such as the ~18×38 panadapter/
+  // hero from freezing the main thread for seconds on drop.
+  const originResolved = placeFullSize(footprintX, footprintY);
+  if (originResolved) {
+    return clearMovedFlags(
+      compactMagnetUp(originResolved.layout, target.i, swapped.displaced),
     );
-    if (originResolved) {
+  }
+
+  // Origin blocked (a static/locked panel sits in the drop cell). Keep the
+  // panel's size and search straight down the same column for the nearest
+  // full-size slot rather than shrinking it. Bounded by the layout height, so
+  // it stays cheap.
+  const layoutBottom = base.reduce(
+    (bottom, item) => Math.max(bottom, item.y + item.h),
+    0,
+  );
+  for (let y = footprintY + 1; y <= layoutBottom; y += 1) {
+    const resolved = placeFullSize(footprintX, y);
+    if (resolved) {
       return clearMovedFlags(
-        compactMagnetUp(originResolved.layout, target.i, swapped.displaced),
+        compactMagnetUp(resolved.layout, target.i, swapped.displaced),
       );
     }
   }
 
-  let best: {
-    layout: LayoutItem[];
-    area: number;
-    originDistance: number;
-    movement: number;
-  } | null = null;
-
-  for (let y = footprintY; y <= footprintBottom - minH; y += 1) {
-    // An origin candidate (originDistance 0) is unbeatable by anything farther
-    // out, so once one is found there is no need to keep sweeping the
-    // footprint — this caps the fallback search at the origin cell.
-    if (best && best.originDistance === 0) break;
-    const maxCandidateH = Math.min(maxH, footprintBottom - y);
-    for (let x = footprintX; x <= footprintRight - minW; x += 1) {
-      if (best && best.originDistance === 0) break;
-      const maxCandidateW = Math.min(maxW, footprintRight - x);
-      for (let w = maxCandidateW; w >= minW; w -= 1) {
-        for (let h = maxCandidateH; h >= minH; h -= 1) {
-          const trial = cloneLayout(base);
-          const trialTarget = trial.find((item) => item.i === target.i);
-          if (!trialTarget) continue;
-          trialTarget.x = x;
-          trialTarget.y = y;
-          trialTarget.w = w;
-          trialTarget.h = h;
-
-          const resolved = resolveAnchorCollisions(
-            trial,
-            target.i,
-            cols,
-            previousItem,
-          );
-          if (!resolved) continue;
-
-          const area = w * h;
-          const originDistance =
-            Math.abs(x - footprintX) + Math.abs(y - footprintY);
-          const movement = placementMovement(base, resolved.layout, target.i);
-          if (
-            !best ||
-            originDistance < best.originDistance ||
-            (originDistance === best.originDistance && area > best.area) ||
-            (originDistance === best.originDistance &&
-              area === best.area &&
-              movement < best.movement)
-          ) {
-            best = { layout: resolved.layout, area, originDistance, movement };
-          }
-        }
-      }
-    }
+  // Last resort: drop it full size below everything, which is always free.
+  const tail = cloneLayout(base);
+  const tailTarget = tail.find((item) => item.i === target.i);
+  if (tailTarget) {
+    tailTarget.x = footprintX;
+    tailTarget.y = layoutBottom;
+    tailTarget.w = startW;
+    tailTarget.h = startH;
   }
-
-  if (best) {
-    return clearMovedFlags(
-      compactMagnetUp(best.layout, target.i, swapped.displaced),
-    );
-  }
-
-  const fallback = cloneLayout(base);
-  const fallbackTarget = fallback.find((item) => item.i === target.i);
-  if (!fallbackTarget) return clearMovedFlags(fallback);
-  fallbackTarget.w = minW;
-  fallbackTarget.h = minH;
-  fallbackTarget.x = clamp(fallbackTarget.x, 0, Math.max(0, cols - minW));
-  fallbackTarget.y = Math.max(0, fallbackTarget.y);
-  return clearMovedFlags(compactMagnetUp(fallback, target.i, swapped.displaced));
+  return clearMovedFlags(compactMagnetUp(tail, target.i, swapped.displaced));
 }
 
 function compactResizePushDown(layout: Layout): Layout {
@@ -609,26 +566,6 @@ function cloneLayout(layout: Layout): LayoutItem[] {
 
 function clearMovedFlags(layout: Layout): LayoutItem[] {
   return layout.map((item) => ({ ...item, moved: false }));
-}
-
-function placementMovement(
-  before: Layout,
-  after: Layout,
-  excludeId: string,
-): number {
-  const beforePlacement = new Map(
-    before.map((item) => [item.i, { x: item.x, y: item.y }]),
-  );
-  return after.reduce((sum, item) => {
-    if (item.i === excludeId) return sum;
-    const previous = beforePlacement.get(item.i);
-    if (!previous) return sum;
-    return (
-      sum +
-      Math.abs(item.x - previous.x) +
-      Math.abs(item.y - previous.y)
-    );
-  }, 0);
 }
 
 function anyCollision(layout: Layout): boolean {

--- a/zeus-web/src/layout/workspaceGrid.ts
+++ b/zeus-web/src/layout/workspaceGrid.ts
@@ -214,6 +214,11 @@ function swapDisplacedIntoPreviousSlot(
         candidate,
       ): candidate is { item: LayoutItem; previous: LayoutItem } => {
         if (candidate.previous === undefined) return false;
+        // A locked (static) panel never moves — not even transiently while
+        // another panel is dragged over it. Excluding it here keeps it pinned;
+        // the dragged panel flows around it and resolveAnchorCollisions keeps
+        // it out of the locked footprint on drop.
+        if (candidate.item.static) return false;
         // Live drag: gate engagement through the per-drag hysteresis set so a
         // neighbour holds its swapped slot across the touch boundary instead of
         // flickering. Drop / one-shot compaction (engaged === null) keeps the

--- a/zeus-web/src/styles/all-panels.css
+++ b/zeus-web/src/styles/all-panels.css
@@ -23,7 +23,12 @@
   position: relative;
   width: 100%;
   height: 100%;
-  overflow: hidden;
+  /* Panels keep a fixed cell size (see FlexWorkspace) rather than rescaling to
+   * fit, so a layout taller than the viewport scrolls vertically here instead
+   * of shrinking every panel. Horizontal extent is always the column grid, so
+   * x-overflow stays clipped. */
+  overflow-x: hidden;
+  overflow-y: auto;
   /* v3 Lifted Dark: workspace ground is the distinct mid-grey "table"
    * (--bg-workspace), so the chrome (--bg-0) and the panels (--bg-1) each
    * read as their own surface. */


### PR DESCRIPTION
## Problem

Repositioning a panel could change its size even though the operator never touched a resize handle. Panel size should change **only** on an explicit resize.

## How other systems do it

Mainstream grid-layout systems (react-grid-layout, Gridstack, Muuri, Grafana dashboards) follow one rule: **move = position only, fixed cell size, scroll on overflow, resize is a separate explicit gesture.** Docking systems (golden-layout/dockview/FlexLayout) instead size panels as ratios of split panes, so panels *do* resize on move — the wrong model for "size never changes unless I resize it." Zeus uses the grid model but had drifted from it in two places, both fixed here.

## Changes

**1. `autoFitDroppedPanel` no longer shrinks the dropped panel.** It now always places the panel at its full footprint: full size at the drop cell (pushing movable neighbours aside via `resolveAnchorCollisions`), else the nearest full-size slot straight below, else full size at the bottom (always free). The shrink-to-fit sweep and the min-size fallback are removed. This is also cheaper than the old footprint sweep, so the large-tile drop-freeze guard is preserved/strengthened.

**2. Fixed cell size instead of fit-to-viewport rescale.** `rowHeight` was derived from the *live* layout height, so moving a panel that grew the stack rescaled **every** panel to avoid a scrollbar. The cell size is now fixed (`WORKSPACE_ROW_HEIGHT_PX`); when a layout stacks taller than the viewport the workspace scrolls vertically (`.all-panels-workspace { overflow-y: auto }`).

## Trade-off (please sanity-check)

You can't have *fixed sizes* + *no scrollbar* + *free stacking* simultaneously — state-of-the-art picks fixed-size + scroll, which is what this implements. Consequence: the **default layout can now scroll on shorter viewports** instead of shrinking to fit, and panels render at their authored 15px/row size. This reverses the earlier deliberate "no scrollbar" behavior — flagging for @ review since it affects the default first-connect experience.

## Testing

- Added a regression test: a panel dropped onto a locked/static panel keeps its full size and relocates below (never shrinks).
- Frontend suite green: **830 tests pass**; `tsc --noEmit` clean.
- Not driven via a live in-browser drag (headless preview can't render the canvas panels); grid logic is covered by unit tests. A quick manual check of drag/scroll feel is worth doing.

## Notes for reviewers

Touches drag/drop UX and effectively a default-sizing behavior (red-light per `CLAUDE.md`). No palette/token changes.