### PR TITLE
feat(tx-fidelity): auto-tune the full TX dynamics chain

### DIFF
--- a/zeus-web/src/audio/tx-auto-tune.test.ts
+++ b/zeus-web/src/audio/tx-auto-tune.test.ts
@@ -2,7 +2,12 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { CFC_CONFIG_DEFAULT, type CfcConfigDto } from '../api/client';
+import {
+  CFC_CONFIG_DEFAULT,
+  TX_LEVELING_CONFIG_DEFAULT,
+  type CfcConfigDto,
+  type TxLevelingConfigDto,
+} from '../api/client';
 import {
   recommendTxAutoTune,
   type TxAutoTuneSample,
@@ -19,12 +24,17 @@ function cfc(preCompDb = 1): CfcConfigDto {
   };
 }
 
+function leveling(overrides: Partial<TxLevelingConfigDto> = {}): TxLevelingConfigDto {
+  return { ...TX_LEVELING_CONFIG_DEFAULT, ...overrides };
+}
+
 function settings(overrides: Partial<TxAutoTuneSettings> = {}): TxAutoTuneSettings {
   return {
     micGainDb: -6,
     levelerMaxGainDb: 6,
     drivePercent: 80,
     cfcConfig: cfc(),
+    txLeveling: leveling(),
     targetSpectralDensity: 95,
     keyed: false,
     audioSuiteActive: true,
@@ -39,6 +49,8 @@ function sample(overrides: Partial<TxAutoTuneSample> = {}): TxAutoTuneSample {
     outPkDbfs: -7,
     outAvDbfs: -18,
     audioSuiteOutputDbfs: -7,
+    compPkDbfs: -8,
+    compAvDbfs: -20,
     alcGrDb: 3,
     lvlrGrDb: 3,
     cfcGrDb: 2,
@@ -153,5 +165,73 @@ describe('recommendTxAutoTune', () => {
 
     expect(plan.settings.drivePercent).toBe(95);
     expect(plan.actions).toContain('drive +5% after clean keyed sample');
+  });
+
+  it('eases ALC make-up gain when the ALC limiter is slamming', () => {
+    const plan = recommendTxAutoTune(
+      settings({ txLeveling: leveling({ alcMaxGainDb: 3 }) }),
+      samples({ alcGrDb: 12 }),
+    );
+
+    expect(plan.settings.txLeveling.alcMaxGainDb).toBe(2);
+    expect(plan.actions.join(' ')).toContain('ALC max gain -1');
+    expect(plan.changed).toBe(true);
+  });
+
+  it('backs the CPDR compressor off when it pinches the crest', () => {
+    const plan = recommendTxAutoTune(
+      settings({ txLeveling: leveling({ compressorEnabled: true, compressorGainDb: 6 }) }),
+      samples({
+        outPkDbfs: -7,
+        outAvDbfs: -10, // pinched chain crest -> protecting, no re-raise
+        compPkDbfs: -8,
+        compAvDbfs: -12, // pinched compressor crest
+      }),
+    );
+
+    expect(plan.settings.txLeveling.compressorGainDb).toBe(4);
+    expect(plan.settings.txLeveling.compressorEnabled).toBe(true);
+    expect(plan.actions.join(' ')).toContain('compressor -2');
+  });
+
+  it('engages ALC make-up and the compressor on a clean keyed max-density sample', () => {
+    const plan = recommendTxAutoTune(
+      settings({
+        keyed: true,
+        drivePercent: 90,
+        targetSpectralDensity: 100,
+        txLeveling: leveling({ alcMaxGainDb: 3, compressorEnabled: false, compressorGainDb: 0 }),
+      }),
+      samples({
+        micPkDbfs: -14,
+        outPkDbfs: -6,
+        outAvDbfs: -18, // wide-open 12 dB crest with output headroom
+        alcGrDb: 2,
+        lvlrGrDb: 2,
+        cfcGrDb: 1,
+        psFeedbackLevel: 150,
+        swr: 1.2,
+      }),
+    );
+
+    expect(plan.blockers).toEqual([]);
+    expect(plan.settings.txLeveling.alcMaxGainDb).toBe(4);
+    expect(plan.settings.txLeveling.compressorEnabled).toBe(true);
+    expect(plan.settings.txLeveling.compressorGainDb).toBe(2);
+    expect(plan.settings.cfcConfig.prePeqDb).toBeGreaterThan(0);
+    expect(plan.actions.join(' ')).toContain('compressor on');
+  });
+
+  it('slows a pumping leveler instead of leaving it chasing syllables', () => {
+    const pumping = Array.from({ length: 40 }, (_, i) =>
+      sample({ lvlrGrDb: i < 30 ? 2 : 12 }),
+    );
+    const plan = recommendTxAutoTune(
+      settings({ txLeveling: leveling({ levelerDecayMs: 50 }) }),
+      pumping,
+    );
+
+    expect(plan.settings.txLeveling.levelerDecayMs).toBe(90);
+    expect(plan.actions.join(' ')).toContain('leveler decay slower');
   });
 });

--- a/zeus-web/src/audio/tx-auto-tune.ts
+++ b/zeus-web/src/audio/tx-auto-tune.ts
@@ -1,15 +1,42 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import type { CfcConfigDto } from '../api/client';
+import type { CfcConfigDto, TxLevelingConfigDto } from '../api/client';
 
 const DBFS_FLOOR = -200;
 const MIN_VOICED_SAMPLES = 8;
+
+// CFC pre-comp / pre-PEQ are unbounded on the server; the frontend owns the
+// ±12 dB operational window (matches the CFC panel + withPreComp).
+const CFC_SHAPE_MIN = -12;
+const CFC_SHAPE_MAX = 12;
+
+// TxLeveling clamps. The hard server bounds (RadioService.SetTxLeveling) are
+// ALC max [0,120], ALC decay [1,50], leveler decay [1,5000], comp gain [0,20].
+// Auto Tune uses TIGHTER operational ceilings when it RAISES a value so it
+// never drives the chain to an extreme in a single bounded run, but it clamps
+// the carried-forward config only to the hard bounds — so a no-op run never
+// rewrites an operator-set value that already sits above the operational cap.
+const ALC_MAX_HARD_MIN = 0;
+const ALC_MAX_HARD_MAX = 120;
+const ALC_MAX_RAISE_GUARD = 6; // only auto-raise ALC make-up below this
+const ALC_MAX_RAISE_CEIL = 8; // and never above this via a raise step
+const ALC_DECAY_MIN = 1;
+const ALC_DECAY_MAX = 50;
+const LEVELER_DECAY_MIN = 1;
+const LEVELER_DECAY_MAX = 5000;
+const LEVELER_DECAY_DENSITY_CEIL = 180; // smooth-for-density target
+const LEVELER_DECAY_PUMP_CEIL = 400; // slow the leveler to stop pumping
+const COMP_GAIN_HARD_MIN = 0;
+const COMP_GAIN_HARD_MAX = 20;
+const COMP_GAIN_RAISE_CEIL = 10; // operational density ceiling
 
 export type TxAutoTuneSample = {
   micPkDbfs: number | null;
   outPkDbfs: number | null;
   outAvDbfs: number | null;
   audioSuiteOutputDbfs: number | null;
+  compPkDbfs: number | null;
+  compAvDbfs: number | null;
   alcGrDb: number;
   lvlrGrDb: number;
   cfcGrDb: number;
@@ -28,6 +55,7 @@ export type TxAutoTuneSettings = {
   levelerMaxGainDb: number;
   drivePercent: number;
   cfcConfig: CfcConfigDto;
+  txLeveling: TxLevelingConfigDto;
   targetSpectralDensity: number;
   keyed: boolean;
   audioSuiteActive: boolean;
@@ -44,8 +72,10 @@ export type TxAutoTuneStats = {
   audioSuiteOutP95Dbfs: number | null;
   audioSuiteOutMaxDbfs: number | null;
   crestMedianDb: number | null;
+  compCrestMedianDb: number | null;
   alcP95Db: number;
   lvlrP95Db: number;
+  lvlrGrSpreadDb: number;
   cfcP95Db: number;
   swrP95: number;
   psFeedbackMedian: number | null;
@@ -127,6 +157,15 @@ function crestValues(samples: ReadonlyArray<TxAutoTuneSample>): number[] {
   return out;
 }
 
+function compCrestValues(samples: ReadonlyArray<TxAutoTuneSample>): number[] {
+  const out: number[] = [];
+  for (const s of samples) {
+    if (!validDbfs(s.compPkDbfs) || !validDbfs(s.compAvDbfs) || s.compAvDbfs > s.compPkDbfs) continue;
+    out.push(s.compPkDbfs - s.compAvDbfs);
+  }
+  return out;
+}
+
 function sumDeltas(samples: ReadonlyArray<TxAutoTuneSample>, pick: (s: TxAutoTuneSample) => number | null): number {
   let total = 0;
   for (const sample of samples) {
@@ -158,8 +197,40 @@ function withPreComp(config: CfcConfigDto, deltaDb: number, forceEnable: boolean
     next.enabled = true;
     next.postEqEnabled = true;
   }
-  next.preCompDb = roundTenth(clamp(next.preCompDb + deltaDb, -12, 12));
+  next.preCompDb = roundTenth(clamp(next.preCompDb + deltaDb, CFC_SHAPE_MIN, CFC_SHAPE_MAX));
   return next;
+}
+
+function withPrePeq(config: CfcConfigDto, deltaDb: number, forceEnable: boolean): CfcConfigDto {
+  const next = cloneCfc(config);
+  if (forceEnable) next.enabled = true;
+  next.prePeqDb = roundTenth(clamp(next.prePeqDb + deltaDb, CFC_SHAPE_MIN, CFC_SHAPE_MAX));
+  return next;
+}
+
+// Carry the operator's leveling config forward, clamped only to the HARD server
+// bounds so a run that touches nothing rewrites no value. Tuning rules below
+// apply their own tighter operational ceilings when they actively raise a value.
+function clampLeveling(c: TxLevelingConfigDto): TxLevelingConfigDto {
+  return {
+    alcMaxGainDb: clamp(c.alcMaxGainDb, ALC_MAX_HARD_MIN, ALC_MAX_HARD_MAX),
+    alcDecayMs: roundInt(clamp(c.alcDecayMs, ALC_DECAY_MIN, ALC_DECAY_MAX)),
+    levelerEnabled: c.levelerEnabled,
+    levelerDecayMs: roundInt(clamp(c.levelerDecayMs, LEVELER_DECAY_MIN, LEVELER_DECAY_MAX)),
+    compressorEnabled: c.compressorEnabled,
+    compressorGainDb: roundTenth(clamp(c.compressorGainDb, COMP_GAIN_HARD_MIN, COMP_GAIN_HARD_MAX)),
+  };
+}
+
+function levelingChanged(a: TxLevelingConfigDto, b: TxLevelingConfigDto): boolean {
+  return (
+    a.alcMaxGainDb !== b.alcMaxGainDb ||
+    a.alcDecayMs !== b.alcDecayMs ||
+    a.levelerEnabled !== b.levelerEnabled ||
+    a.levelerDecayMs !== b.levelerDecayMs ||
+    a.compressorEnabled !== b.compressorEnabled ||
+    a.compressorGainDb !== b.compressorGainDb
+  );
 }
 
 function settingChanged(a: TxAutoTuneSettings, b: TxAutoTuneSettings): boolean {
@@ -177,7 +248,8 @@ function settingChanged(a: TxAutoTuneSettings, b: TxAutoTuneSettings): boolean {
         band.freqHz !== other.freqHz ||
         band.compLevelDb !== other.compLevelDb ||
         band.postGainDb !== other.postGainDb;
-    })
+    }) ||
+    levelingChanged(a.txLeveling, b.txLeveling)
   );
 }
 
@@ -194,9 +266,12 @@ export function summarizeTxAutoTuneSamples(samples: ReadonlyArray<TxAutoTuneSamp
   const out = values(samples, (s) => s.outPkDbfs);
   const suiteOut = values(samples, (s) => s.audioSuiteOutputDbfs);
   const crest = crestValues(samples);
+  const compCrest = compCrestValues(samples);
   const alc = grValues(samples, (s) => s.alcGrDb);
   const lvlr = grValues(samples, (s) => s.lvlrGrDb);
   const cfc = grValues(samples, (s) => s.cfcGrDb);
+  const lvlrP95 = percentile(lvlr, 0.95) ?? 0;
+  const lvlrP50 = percentile(lvlr, 0.5) ?? 0;
   const swr = samples
     .map((s) => s.swr)
     .filter((v) => Number.isFinite(v) && v > 0);
@@ -219,8 +294,10 @@ export function summarizeTxAutoTuneSamples(samples: ReadonlyArray<TxAutoTuneSamp
     audioSuiteOutP95Dbfs: percentile(suiteOut, 0.95),
     audioSuiteOutMaxDbfs: maxOrNull(suiteOut),
     crestMedianDb: percentile(crest, 0.5),
+    compCrestMedianDb: percentile(compCrest, 0.5),
     alcP95Db: percentile(alc, 0.95) ?? 0,
-    lvlrP95Db: percentile(lvlr, 0.95) ?? 0,
+    lvlrP95Db: lvlrP95,
+    lvlrGrSpreadDb: Math.max(0, lvlrP95 - lvlrP50),
     cfcP95Db: percentile(cfc, 0.95) ?? 0,
     swrP95: percentile(swr, 0.95) ?? 1,
     psFeedbackMedian: percentile(psFeedback, 0.5),
@@ -244,6 +321,7 @@ export function recommendTxAutoTune(
     levelerMaxGainDb: roundHalf(clamp(current.levelerMaxGainDb, 0, 20)),
     drivePercent: roundInt(clamp(current.drivePercent, 0, 100)),
     cfcConfig: cloneCfc(current.cfcConfig),
+    txLeveling: clampLeveling(current.txLeveling),
   };
   const actions: string[] = [];
   const blockers: string[] = [];
@@ -333,6 +411,53 @@ export function recommendTxAutoTune(
     actions.push('CFC pre-comp -0.4 dB');
   }
 
+  // ---- Protective leveling/compressor easing -------------------------------
+  // When the ALC safety limiter is slamming, its make-up gain is fighting the
+  // limiter — ease it so the upstream mic cut actually buys headroom instead of
+  // being clawed back. Bounded -1 dB per run, floored at 0.
+  if (stats.alcP95Db > 11 && next.txLeveling.alcMaxGainDb > ALC_MAX_HARD_MIN) {
+    next.txLeveling = {
+      ...next.txLeveling,
+      alcMaxGainDb: roundTenth(clamp(next.txLeveling.alcMaxGainDb - 1, ALC_MAX_HARD_MIN, ALC_MAX_HARD_MAX)),
+    };
+    actions.push('ALC max gain -1 dB');
+  }
+
+  // CPDR compressor over-squash: a pinched compressor crest (or a pinched chain
+  // crest while the compressor is doing the squashing) means the compander is
+  // flattening the speech. Back its gain off, disabling it once it reaches 0.
+  const compPinched =
+    next.txLeveling.compressorEnabled &&
+    next.txLeveling.compressorGainDb > COMP_GAIN_HARD_MIN &&
+    ((stats.compCrestMedianDb !== null && stats.compCrestMedianDb < 5) ||
+      (stats.crestMedianDb !== null && stats.crestMedianDb < 6));
+  if (compPinched) {
+    const reduced = roundTenth(clamp(next.txLeveling.compressorGainDb - 2, COMP_GAIN_HARD_MIN, COMP_GAIN_HARD_MAX));
+    next.txLeveling = {
+      ...next.txLeveling,
+      compressorGainDb: reduced,
+      compressorEnabled: reduced > 0,
+    };
+    actions.push(reduced > 0 ? 'compressor -2 dB' : 'compressor off');
+  }
+
+  // Leveler pumping: heavy leveler GR that swings sample-to-sample with a fast
+  // decay is audible breathing. Slow the leveler so it rides the average
+  // instead of chasing every syllable. Bounded toward the pump ceiling.
+  if (
+    stats.lvlrP95Db > 8 &&
+    stats.lvlrGrSpreadDb > 6 &&
+    next.txLeveling.levelerDecayMs < LEVELER_DECAY_PUMP_CEIL
+  ) {
+    const slower = roundInt(
+      clamp(next.txLeveling.levelerDecayMs * 1.4 + 20, LEVELER_DECAY_MIN, LEVELER_DECAY_PUMP_CEIL),
+    );
+    if (slower > next.txLeveling.levelerDecayMs) {
+      next.txLeveling = { ...next.txLeveling, levelerDecayMs: slower };
+      actions.push('leveler decay slower');
+    }
+  }
+
   const protecting = suiteHot || outputHot || micHot || dynamicsHot;
   const mayRaise = blockers.length === 0 && !protecting;
   const target = clamp(current.targetSpectralDensity, 0, 100);
@@ -380,11 +505,89 @@ export function recommendTxAutoTune(
       next.drivePercent = roundInt(clamp(next.drivePercent + 5, 0, 100));
       actions.push('drive +5% after clean keyed sample');
     }
+
+    // ---- Density-raising leveling/compressor (clean chain only) -----------
+    // mayRaise already guarantees the chain is not protecting (ALC/leveler/CFC
+    // GR moderate, crest >= 6, nothing hot), so these only add controlled
+    // density when there is genuine headroom.
+
+    // Smooth, dense leveling for higher targets: a very fast leveler that is
+    // barely working leaves the audio peaky. Lengthen its decay toward the
+    // density ceiling so quiet passages stay up without pumping.
+    if (
+      target >= 70 &&
+      stats.lvlrP95Db < 4 &&
+      stats.lvlrGrSpreadDb < 4 &&
+      next.txLeveling.levelerDecayMs < LEVELER_DECAY_DENSITY_CEIL
+    ) {
+      const slower = roundInt(
+        clamp(next.txLeveling.levelerDecayMs + 40, LEVELER_DECAY_MIN, LEVELER_DECAY_DENSITY_CEIL),
+      );
+      if (slower > next.txLeveling.levelerDecayMs) {
+        next.txLeveling = { ...next.txLeveling, levelerDecayMs: slower };
+        actions.push('leveler decay +40 ms for density');
+      }
+    }
+
+    // ALC make-up headroom: when the ALC is barely engaging on a clean chain,
+    // a little more make-up gain lifts the average without touching the
+    // limiter. Bounded +1 dB, only below the raise guard/ceiling.
+    if (
+      target >= 80 &&
+      stats.alcP95Db < 5 &&
+      next.txLeveling.alcMaxGainDb < ALC_MAX_RAISE_GUARD
+    ) {
+      next.txLeveling = {
+        ...next.txLeveling,
+        alcMaxGainDb: roundTenth(
+          clamp(next.txLeveling.alcMaxGainDb + 1, ALC_MAX_HARD_MIN, ALC_MAX_RAISE_CEIL),
+        ),
+      };
+      actions.push('ALC max gain +1 dB');
+    }
+
+    // Presence pre-PEQ for high targets: a small CFC pre-PEQ lift adds speech
+    // articulation density once compression is already controlled.
+    if (
+      target >= 85 &&
+      stats.cfcP95Db < 4 &&
+      stats.crestMedianDb !== null &&
+      stats.crestMedianDb >= 7 &&
+      next.cfcConfig.prePeqDb < 4
+    ) {
+      next.cfcConfig = withPrePeq(next.cfcConfig, 0.4, true);
+      actions.push('CFC pre-PEQ +0.4 dB');
+    }
+
+    // CPDR compressor for max density: the compander is the strongest clean
+    // talk-power lever. Only engage it on a wide-open crest with real output
+    // headroom so it tightens dynamics instead of pinching them.
+    if (
+      target >= 90 &&
+      stats.alcP95Db < 6 &&
+      stats.crestMedianDb !== null &&
+      stats.crestMedianDb > 10 &&
+      stats.outP95Dbfs !== null &&
+      stats.outP95Dbfs <= -5 &&
+      next.txLeveling.compressorGainDb < COMP_GAIN_RAISE_CEIL
+    ) {
+      const enabling = !next.txLeveling.compressorEnabled || next.txLeveling.compressorGainDb <= 0;
+      const step = enabling ? 2 : 1;
+      next.txLeveling = {
+        ...next.txLeveling,
+        compressorEnabled: true,
+        compressorGainDb: roundTenth(
+          clamp(next.txLeveling.compressorGainDb + step, COMP_GAIN_HARD_MIN, COMP_GAIN_RAISE_CEIL),
+        ),
+      };
+      actions.push(enabling ? `compressor on +${step} dB` : `compressor +${step} dB`);
+    }
   }
 
   next.micGainDb = roundInt(clamp(next.micGainDb, -40, 10));
   next.levelerMaxGainDb = roundHalf(clamp(next.levelerMaxGainDb, 0, 20));
   next.drivePercent = roundInt(clamp(next.drivePercent, 0, 100));
+  next.txLeveling = clampLeveling(next.txLeveling);
   const changed = settingChanged(current, next);
   let summary = 'Auto tune held current settings';
   if (stats.voicedSampleCount < MIN_VOICED_SAMPLES) {

--- a/zeus-web/src/layout/panels/TxFidelityPanel.tsx
+++ b/zeus-web/src/layout/panels/TxFidelityPanel.tsx
@@ -144,6 +144,8 @@ function autoTuneSampleFromDiagnostics(
       micPkDbfs: diag.stage.micPkDbfs ?? finiteDbfs(tx.wdspMicPk) ?? finiteDbfs(tx.micDbfs),
       outPkDbfs: diag.stage.outPkDbfs ?? finiteDbfs(tx.outPk),
       outAvDbfs: diag.stage.outAvDbfs ?? finiteDbfs(tx.outAv),
+      compPkDbfs: diag.stage.compPkDbfs ?? finiteDbfs(tx.compPk),
+      compAvDbfs: diag.stage.compAvDbfs ?? finiteDbfs(tx.compAv),
       audioSuiteOutputDbfs: chain.outputDbfs,
       alcGrDb: Number.isFinite(diag.stage.alcGrDb) ? diag.stage.alcGrDb : tx.alcGr,
       lvlrGrDb: Number.isFinite(diag.stage.lvlrGrDb) ? diag.stage.lvlrGrDb : tx.lvlrGr,
@@ -208,6 +210,17 @@ function cfcConfigChanged(a: TxAutoTuneSettings['cfcConfig'], b: TxAutoTuneSetti
       band.compLevelDb !== other.compLevelDb ||
       band.postGainDb !== other.postGainDb;
   });
+}
+
+function txLevelingChanged(a: TxLevelingConfigDto, b: TxLevelingConfigDto): boolean {
+  return (
+    a.alcMaxGainDb !== b.alcMaxGainDb ||
+    a.alcDecayMs !== b.alcDecayMs ||
+    a.levelerEnabled !== b.levelerEnabled ||
+    a.levelerDecayMs !== b.levelerDecayMs ||
+    a.compressorEnabled !== b.compressorEnabled ||
+    a.compressorGainDb !== b.compressorGainDb
+  );
 }
 
 function autoTuneMessage(plan: TxAutoTunePlan): string {
@@ -325,6 +338,7 @@ function AudioSuitePreviewToggle() {
 function TxFidelityAutoTune({ targetSpectralDensity }: { targetSpectralDensity: number }) {
   const status = useConnectionStore((s) => s.status);
   const applyState = useConnectionStore((s) => s.applyState);
+  const setTxLevelingLocal = useConnectionStore((s) => s.setTxLeveling);
   const hydrateTxFromState = useTxStore((s) => s.hydrateFromState);
   const tunOn = useTxStore((s) => s.tunOn);
   const setMicGainDb = useTxStore((s) => s.setMicGainDb);
@@ -366,6 +380,13 @@ function TxFidelityAutoTune({ targetSpectralDensity }: { targetSpectralDensity: 
         hydrateTxFromState(state);
         setCfcConfigLocal(state.cfc);
       }
+      const beforeLeveling = useConnectionStore.getState().txLeveling;
+      if (txLevelingChanged(beforeLeveling, plan.settings.txLeveling)) {
+        setTxLevelingLocal(plan.settings.txLeveling);
+        const state = await setTxLeveling(plan.settings.txLeveling, signal);
+        applyState(state);
+        hydrateTxFromState(state);
+      }
       if (plan.settings.drivePercent !== before.drivePercent) {
         const drive = await setDrive(plan.settings.drivePercent, signal);
         setDrivePercent(drive.drivePercent);
@@ -378,6 +399,7 @@ function TxFidelityAutoTune({ targetSpectralDensity }: { targetSpectralDensity: 
       setDrivePercent,
       setLevelerMaxGainDb,
       setMicGainDb,
+      setTxLevelingLocal,
     ],
   );
 
@@ -446,6 +468,7 @@ function TxFidelityAutoTune({ targetSpectralDensity }: { targetSpectralDensity: 
           levelerMaxGainDb: tx.levelerMaxGainDb,
           drivePercent: tx.drivePercent,
           cfcConfig: tx.cfcConfig,
+          txLeveling: useConnectionStore.getState().txLeveling,
           targetSpectralDensity,
           keyed: tx.moxOn,
           audioSuiteActive: !audio.masterBypassed && (tx.moxOn || tx.txMonitorEnabled),


### PR DESCRIPTION
## Summary

TX Fidelity **Auto Tune** previously adjusted only 4 scalars — mic gain, leveler max gain, CFC pre-comp, and drive — leaving the entire ALC / leveler-decay / CPDR-compressor / CFC pre-PEQ surface untouched, even though the per-stage telemetry needed to drive them (comp pk/av, leveler-GR spread) was already on the wire. This extends the planner to manage the full gain-staging + dynamics surface, in the existing **protect-before-raise**, bounded-per-run idiom.

## What changed

| Parameter | Protective (ease) | Density-raise (clean chain only) |
|---|---|---|
| **ALC make-up gain** | −1 dB when the limiter slams (ALC GR p95 > 11) | +1 dB on a clean chain (operational ceiling 8 dB) |
| **Leveler decay** | slow a *pumping* leveler (heavy GR + large sample-to-sample spread) | lengthen toward the density ceiling on a clean, fast leveler |
| **CPDR compressor** | back gain off / disable at 0 when it pinches the crest | engage only on a wide-open crest with real output headroom |
| **CFC pre-PEQ** | — | small presence lift once compression is controlled |

- Every step stays **bounded per run** and behind the existing safety blockers (SWR, PS feedback, transport/VST health, voiced-sample count).
- Carried-forward leveling config is clamped only to the **hard server bounds** (`RadioService.SetTxLeveling`), so a no-op run never rewrites an operator-set value.
- New comp-stage telemetry is wired into the sampler; `txLeveling` changes apply through the existing `/api/tx/leveling` seam.

## Deliberately *not* auto-tuned

Per-band CFC EQ (`compLevelDb`/`postGainDb`) needs per-band **spectral** data the sampler doesn't collect, and TX bandpass width (low/high cut) is a deliberate bandwidth/regulatory choice. Both stay operator/profile-curated rather than guessed from aggregate meters.

## Testing

- 5 new unit tests in `tx-auto-tune.test.ts` (ALC ease, compressor back-off, clean-keyed max-density engage, leveler de-pump).
- Full frontend suite green (**835 passed**), `tsc --noEmit` clean, ESLint clean.
- Live end-to-end exercise needs a connected radio + voice sample (Preview/MOX), which can't be driven in CI.

## Notes

Scoped strictly to 3 frontend files — no contract/DTO or backend changes. Drive/PA/TX-power paths are untouched (drive % handling is unchanged from the prior Auto Tune).