### PR TITLE
feat(tx): live parametric-EQ analyzer in place of waterfall on TX

### DIFF
--- a/zeus-web/src/audio/mic-uplink-session.ts
+++ b/zeus-web/src/audio/mic-uplink-session.ts
@@ -140,3 +140,22 @@ export async function stopMicUplinkRunning(): Promise<void> {
 export function isMicUplinkRunning(): boolean {
   return handle !== null;
 }
+
+/** Geometry of the live mic spectrum tap, or null when no tap is available. */
+export function getMicSpectrumInfo(): { binCount: number; fftSize: number; sampleRate: number } | null {
+  if (!handle?.getSpectrum || !handle.spectrumBinCount) return null;
+  return {
+    binCount: handle.spectrumBinCount,
+    fftSize: handle.spectrumFftSize ?? handle.spectrumBinCount * 2,
+    sampleRate: handle.spectrumSampleRate ?? 48000,
+  };
+}
+
+/**
+ * Fill `out` (length must equal the current bin count) with the latest mic FFT
+ * magnitudes in dBFS. Returns false when no live analyser is running — e.g.
+ * desktop/native audio mode, or before the operator has granted the mic.
+ */
+export function getMicSpectrum(out: Float32Array): boolean {
+  return handle?.getSpectrum?.(out) ?? false;
+}

--- a/zeus-web/src/audio/mic-uplink.ts
+++ b/zeus-web/src/audio/mic-uplink.ts
@@ -63,7 +63,22 @@ export type MicUplinkBlockHandler = (samples: Float32Array, peak: number) => voi
 export type MicUplinkHandle = {
   resume?: () => Promise<void>;
   stop: () => Promise<void>;
+  // Real-time spectrum tap for the TX EQ analyzer. Fills `out` (length must
+  // equal spectrumBinCount) with FFT magnitudes in dBFS and returns true, or
+  // returns false when no live analyser is available (e.g. native audio mode).
+  getSpectrum?: (out: Float32Array) => boolean;
+  spectrumBinCount?: number;
+  spectrumFftSize?: number;
+  spectrumSampleRate?: number;
 };
+
+// Voice-band resolution: 4096-pt FFT at 48 kHz → ~11.7 Hz/bin, smoothed so the
+// trace reads cleanly without lagging speech transients. dB window matches the
+// analyzer's −100..0 dBFS scale.
+const ANALYSER_FFT_SIZE = 4096;
+const ANALYSER_SMOOTHING = 0.6;
+const ANALYSER_MIN_DB = -100;
+const ANALYSER_MAX_DB = 0;
 
 const MIC_BASE_CONSTRAINTS: MediaTrackConstraints = {
   echoCancellation: false,
@@ -137,11 +152,36 @@ export async function startMicUplink(
     node.connect(silentSink);
     silentSink.connect(context.destination);
 
+    // Spectrum tap: a parallel AnalyserNode off the raw mic source feeds the TX
+    // EQ analyzer. It's a pure sink (not connected onward) so it never affects
+    // the uplink audio. The analyser's effective sample rate is the context's
+    // actual rate, which may differ from the requested 48 kHz on some devices.
+    const analyser = context.createAnalyser();
+    analyser.fftSize = ANALYSER_FFT_SIZE;
+    analyser.smoothingTimeConstant = ANALYSER_SMOOTHING;
+    analyser.minDecibels = ANALYSER_MIN_DB;
+    analyser.maxDecibels = ANALYSER_MAX_DB;
+    source.connect(analyser);
+
+    const getSpectrum = (out: Float32Array): boolean => {
+      if (context.state !== 'running') return false;
+      if (out.length !== analyser.frequencyBinCount) return false;
+      // The DOM lib narrows the buffer generic to ArrayBuffer; our reusable
+      // scratch buffers are always plain (non-shared) ArrayBuffers.
+      analyser.getFloatFrequencyData(out as Float32Array<ArrayBuffer>);
+      return true;
+    };
+
     return {
       resume,
+      getSpectrum,
+      spectrumBinCount: analyser.frequencyBinCount,
+      spectrumFftSize: analyser.fftSize,
+      spectrumSampleRate: context.sampleRate,
       stop: async () => {
         try { node.port.onmessage = null; } catch { /* ignore */ }
         try { source.disconnect(); } catch { /* ignore */ }
+        try { analyser.disconnect(); } catch { /* ignore */ }
         try { node.disconnect(); } catch { /* ignore */ }
         try { silentSink.disconnect(); } catch { /* ignore */ }
         cleanupStream();

--- a/zeus-web/src/audio/tx-eq-analyzer-model.test.ts
+++ b/zeus-web/src/audio/tx-eq-analyzer-model.test.ts
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+
+import { describe, expect, it } from 'vitest';
+import {
+  DB_MIN,
+  DB_MAX,
+  F_MIN,
+  F_MAX,
+  binToFreq,
+  binsToColumns,
+  buildEqCurve,
+  dbToY,
+  formatStageDb,
+  freqToNorm,
+  freqToX,
+  gainToY,
+  normToFreq,
+} from './tx-eq-analyzer-model';
+
+describe('log-frequency mapping', () => {
+  it('pins the axis endpoints', () => {
+    expect(freqToNorm(F_MIN)).toBeCloseTo(0, 6);
+    expect(freqToNorm(F_MAX)).toBeCloseTo(1, 6);
+  });
+
+  it('clamps out-of-range frequencies', () => {
+    expect(freqToNorm(1)).toBe(0);
+    expect(freqToNorm(50_000)).toBe(1);
+    expect(freqToNorm(0)).toBe(0);
+    expect(freqToNorm(-100)).toBe(0);
+  });
+
+  it('is monotonic and invertible', () => {
+    expect(freqToNorm(300)).toBeLessThan(freqToNorm(3000));
+    expect(normToFreq(freqToNorm(1000))).toBeCloseTo(1000, 3);
+  });
+
+  it('offsets by x0 in pixel space', () => {
+    expect(freqToX(F_MIN, 10, 200)).toBeCloseTo(10, 6);
+    expect(freqToX(F_MAX, 10, 200)).toBeCloseTo(210, 6);
+  });
+});
+
+describe('level mapping', () => {
+  it('maps dB floor/ceiling to bottom/top', () => {
+    expect(dbToY(DB_MAX, 0, 100)).toBeCloseTo(0, 6);
+    expect(dbToY(DB_MIN, 0, 100)).toBeCloseTo(100, 6);
+    expect(dbToY((DB_MIN + DB_MAX) / 2, 0, 100)).toBeCloseTo(50, 6);
+  });
+
+  it('clamps levels beyond the scale', () => {
+    expect(dbToY(20, 0, 100)).toBeCloseTo(0, 6);
+    expect(dbToY(-300, 0, 100)).toBeCloseTo(100, 6);
+  });
+
+  it('centres unity EQ gain and rises for boost', () => {
+    const mid = gainToY(0, 0, 100);
+    expect(mid).toBeCloseTo(50, 6);
+    expect(gainToY(12, 0, 100)).toBeLessThan(mid); // boost goes up (smaller Y)
+    expect(gainToY(-12, 0, 100)).toBeGreaterThan(mid);
+  });
+});
+
+describe('binToFreq', () => {
+  it('computes bin centre frequencies', () => {
+    expect(binToFreq(0, 4096, 48000)).toBe(0);
+    expect(binToFreq(1, 4096, 48000)).toBeCloseTo(48000 / 4096, 6);
+    expect(binToFreq(2048, 4096, 48000)).toBe(24000);
+  });
+});
+
+describe('binsToColumns', () => {
+  const fftSize = 4096;
+  const sampleRate = 48000;
+  const bins = fftSize / 2;
+
+  it('returns a continuous (no -Inf gaps) column array of the requested width', () => {
+    const db = new Float32Array(bins).fill(-80);
+    // Put a strong tone near 1 kHz.
+    const toneBin = Math.round((1000 * fftSize) / sampleRate);
+    db[toneBin] = -10;
+
+    const width = 320;
+    const cols = binsToColumns(db, width, sampleRate, fftSize);
+    expect(cols.length).toBe(width);
+    for (const v of cols) expect(Number.isFinite(v)).toBe(true);
+
+    // The peak column should sit at the 1 kHz log-X position.
+    let maxX = 0;
+    for (let x = 1; x < width; x += 1) {
+      if ((cols[x] ?? -Infinity) > (cols[maxX] ?? -Infinity)) maxX = x;
+    }
+    const expectedX = Math.round(freqToNorm(1000) * (width - 1));
+    expect(Math.abs(maxX - expectedX)).toBeLessThanOrEqual(2);
+    expect(cols[maxX] ?? -Infinity).toBeGreaterThan(-40);
+  });
+
+  it('reuses the provided output buffer', () => {
+    const db = new Float32Array(bins).fill(-70);
+    const out = new Float32Array(128);
+    const cols = binsToColumns(db, 128, sampleRate, fftSize, out);
+    expect(cols).toBe(out);
+  });
+});
+
+describe('buildEqCurve', () => {
+  const width = 256;
+
+  it('is flat (unity) inside the passband with no band gains', () => {
+    const curve = buildEqCurve(
+      { filterLowHz: 150, filterHighHz: 2850, bands: [], bandsEnabled: true },
+      width,
+    );
+    const at = (hz: number) => curve[Math.round(freqToNorm(hz) * (width - 1))] ?? 0;
+    expect(at(1000)).toBeCloseTo(0, 3);
+    expect(at(500)).toBeCloseTo(0, 3);
+  });
+
+  it('rolls off below the low edge and above the high edge', () => {
+    const curve = buildEqCurve(
+      { filterLowHz: 300, filterHighHz: 2700, bands: [], bandsEnabled: true },
+      width,
+    );
+    const at = (hz: number) => curve[Math.round(freqToNorm(hz) * (width - 1))] ?? 0;
+    expect(at(60)).toBeLessThan(-10);
+    expect(at(5000)).toBeLessThan(-10);
+    expect(at(1000)).toBeGreaterThan(at(60));
+  });
+
+  it('adds a boost bump at an active band centre', () => {
+    const curve = buildEqCurve(
+      {
+        filterLowHz: 100,
+        filterHighHz: 4000,
+        bands: [{ freqHz: 1500, postGainDb: 9 }],
+        bandsEnabled: true,
+      },
+      width,
+    );
+    const at = (hz: number) => curve[Math.round(freqToNorm(hz) * (width - 1))] ?? 0;
+    expect(at(1500)).toBeGreaterThan(6);
+    expect(at(1500)).toBeGreaterThan(at(500));
+  });
+
+  it('ignores band gains when the band processor is disabled', () => {
+    const curve = buildEqCurve(
+      {
+        filterLowHz: 100,
+        filterHighHz: 4000,
+        bands: [{ freqHz: 1500, postGainDb: 9 }],
+        bandsEnabled: false,
+      },
+      width,
+    );
+    const at = (hz: number) => curve[Math.round(freqToNorm(hz) * (width - 1))] ?? 0;
+    expect(at(1500)).toBeCloseTo(0, 3);
+  });
+});
+
+describe('formatStageDb', () => {
+  it('formats real readings to one decimal', () => {
+    expect(formatStageDb(-12.34)).toBe('-12.3');
+    expect(formatStageDb(0)).toBe('0.0');
+  });
+
+  it('renders bypassed/idle stages as a dash', () => {
+    expect(formatStageDb(-200)).toBe('—');
+    expect(formatStageDb(-400)).toBe('—');
+    expect(formatStageDb(Number.NEGATIVE_INFINITY)).toBe('—');
+    expect(formatStageDb(Number.NaN)).toBe('—');
+  });
+});

--- a/zeus-web/src/audio/tx-eq-analyzer-model.ts
+++ b/zeus-web/src/audio/tx-eq-analyzer-model.ts
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+// Pure geometry/DSP helpers for the TX parametric-EQ analyzer. Kept free of
+// React / canvas / Web-Audio so the maths is unit-testable and identical on
+// every platform Zeus runs on.
+//
+// Coordinate model: the analyzer paints a log-frequency X axis (voice band)
+// and a linear-dBFS Y axis. The live spectrum uses the dBFS scale; the EQ
+// response curve uses a symmetric ±gain scale centred on the unity line so a
+// band cut/boost reads as a dip/bump regardless of the absolute spectrum.
+
+/** Lowest frequency drawn on the X axis (Hz). */
+export const F_MIN = 30;
+/** Highest frequency drawn on the X axis (Hz) — covers the SSB voice band. */
+export const F_MAX = 6000;
+/** Spectrum floor (dBFS) at the bottom of the canvas. */
+export const DB_MIN = -100;
+/** Spectrum ceiling (dBFS) at the top of the canvas. */
+export const DB_MAX = 0;
+/** Half-range of the EQ gain scale (dB) — unity sits at the vertical centre. */
+export const EQ_GAIN_RANGE = 18;
+/** Fraction of canvas height the ±EQ_GAIN_RANGE swing occupies (each side). */
+const EQ_GAIN_SPAN = 0.42;
+
+const LOG_F_MIN = Math.log(F_MIN);
+const LOG_F_MAX = Math.log(F_MAX);
+
+function clamp(v: number, lo: number, hi: number): number {
+  return v < lo ? lo : v > hi ? hi : v;
+}
+
+/** Map a frequency (Hz) to a normalised [0,1] X position on the log axis. */
+export function freqToNorm(hz: number): number {
+  if (!(hz > 0)) return 0;
+  return clamp((Math.log(hz) - LOG_F_MIN) / (LOG_F_MAX - LOG_F_MIN), 0, 1);
+}
+
+/** Map a frequency (Hz) to a pixel X within [x0, x0+width). */
+export function freqToX(hz: number, x0: number, width: number): number {
+  return x0 + freqToNorm(hz) * width;
+}
+
+/** Inverse of {@link freqToNorm} — normalised X back to frequency (Hz). */
+export function normToFreq(norm: number): number {
+  return Math.exp(LOG_F_MIN + clamp(norm, 0, 1) * (LOG_F_MAX - LOG_F_MIN));
+}
+
+/** Map a spectrum level (dBFS) to a pixel Y within [y0, y0+height). */
+export function dbToY(db: number, y0: number, height: number): number {
+  const t = clamp((db - DB_MIN) / (DB_MAX - DB_MIN), 0, 1);
+  return y0 + (1 - t) * height;
+}
+
+/** Map an EQ gain (dB, signed) to a pixel Y within [y0, y0+height). */
+export function gainToY(gainDb: number, y0: number, height: number): number {
+  const t = clamp(gainDb / EQ_GAIN_RANGE, -1, 1);
+  return y0 + height * (0.5 - t * EQ_GAIN_SPAN);
+}
+
+/** Centre frequency (Hz) of FFT bin `i` for the given size and sample rate. */
+export function binToFreq(i: number, fftSize: number, sampleRate: number): number {
+  return (i * sampleRate) / fftSize;
+}
+
+/**
+ * Resample a linear-frequency FFT magnitude array (dB per bin) onto a
+ * log-frequency pixel column array of length `width`. Each output column holds
+ * the peak dB of every bin that falls within it; columns with no bin (sparse
+ * low-frequency region) are linearly interpolated from their populated
+ * neighbours so the trace stays continuous.
+ *
+ * @param db        FFT magnitudes in dB (length = fftSize/2), as produced by
+ *                  AnalyserNode.getFloatFrequencyData.
+ * @param width     number of output pixel columns.
+ * @param sampleRate analyser sample rate (Hz).
+ * @param fftSize   analyser fftSize (db.length * 2).
+ * @param out       optional reusable Float32Array(width) to avoid allocation.
+ */
+export function binsToColumns(
+  db: Float32Array,
+  width: number,
+  sampleRate: number,
+  fftSize: number,
+  out?: Float32Array,
+): Float32Array {
+  const cols = out && out.length === width ? out : new Float32Array(width);
+  const filled = new Uint8Array(width);
+  cols.fill(DB_MIN);
+
+  const bins = db.length;
+  for (let i = 1; i < bins; i += 1) {
+    const f = binToFreq(i, fftSize, sampleRate);
+    if (f < F_MIN || f > F_MAX) continue;
+    const x = Math.min(width - 1, Math.max(0, Math.round(freqToNorm(f) * (width - 1))));
+    const v = db[i] ?? DB_MIN;
+    if (!filled[x] || v > (cols[x] ?? DB_MIN)) {
+      cols[x] = v;
+      filled[x] = 1;
+    }
+  }
+
+  // Interpolate across runs of empty columns (low-freq region where one bin
+  // spans many pixels).
+  let prev = -1;
+  for (let x = 0; x < width; x += 1) {
+    if (!filled[x]) continue;
+    if (prev >= 0 && x - prev > 1) {
+      const a = cols[prev] ?? DB_MIN;
+      const b = cols[x] ?? DB_MIN;
+      for (let k = prev + 1; k < x; k += 1) {
+        cols[k] = a + ((b - a) * (k - prev)) / (x - prev);
+      }
+    }
+    prev = x;
+  }
+  return cols;
+}
+
+export interface EqBand {
+  /** Centre frequency (Hz). */
+  freqHz: number;
+  /** Makeup / post gain applied by the band (dB, signed). */
+  postGainDb: number;
+}
+
+export interface EqCurveInput {
+  /** TX bandpass low edge (Hz). */
+  filterLowHz: number;
+  /** TX bandpass high edge (Hz). */
+  filterHighHz: number;
+  /** Per-band makeup gains (the CFC bands). */
+  bands: readonly EqBand[];
+  /** Whether the per-band processor is engaged (CFC master enable). */
+  bandsEnabled: boolean;
+}
+
+// 1/3-octave-ish bell width in natural-log frequency units.
+const BELL_SIGMA = 0.32;
+// Bandpass skirt steepness (dB per octave outside the passband).
+const SKIRT_DB_PER_OCT = 18;
+
+/**
+ * Build the TX EQ response curve (gain in dB) over a `width`-length log-X grid.
+ * Combines the bandpass passband (flat inside, sloped skirts outside) with a
+ * Gaussian bell per active band weighted by its makeup gain — the same shaping
+ * the operator hears on the air.
+ */
+export function buildEqCurve(input: EqCurveInput, width: number, out?: Float32Array): Float32Array {
+  const curve = out && out.length === width ? out : new Float32Array(width);
+  const lo = Math.min(input.filterLowHz, input.filterHighHz);
+  const hi = Math.max(input.filterLowHz, input.filterHighHz);
+
+  for (let x = 0; x < width; x += 1) {
+    const f = normToFreq(width <= 1 ? 0 : x / (width - 1));
+    let g = 0;
+
+    // Bandpass skirts: roll off outside the passband edges.
+    if (lo > 0 && f < lo) g -= SKIRT_DB_PER_OCT * Math.log2(lo / f);
+    if (hi > 0 && f > hi) g -= SKIRT_DB_PER_OCT * Math.log2(f / hi);
+
+    // Per-band makeup bells.
+    if (input.bandsEnabled) {
+      for (const band of input.bands) {
+        if (!(band.freqHz > 0) || band.postGainDb === 0) continue;
+        const d = Math.log(f / band.freqHz) / BELL_SIGMA;
+        g += band.postGainDb * Math.exp(-0.5 * d * d);
+      }
+    }
+
+    curve[x] = g;
+  }
+  return curve;
+}
+
+/**
+ * Treat WDSP stage levels at or below this dBFS as "bypassed/idle" rather than
+ * a genuine reading (mirrors the TxMetersV2 sentinel convention).
+ */
+export const STAGE_BYPASS_DBFS = -200;
+
+/** Format a stage dBFS value for the telemetry strip, or '—' when bypassed. */
+export function formatStageDb(db: number): string {
+  if (!Number.isFinite(db) || db <= STAGE_BYPASS_DBFS) return '—';
+  return db.toFixed(1);
+}

--- a/zeus-web/src/components/TxEqAnalyzer.tsx
+++ b/zeus-web/src/components/TxEqAnalyzer.tsx
@@ -1,0 +1,409 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+// TX EQ Analyzer — replaces the waterfall during MOX/TUN with a live,
+// parametric-EQ-style view of the transmitted audio. The spectrum trace is the
+// browser mic AnalyserNode tap (the audio actually going to the radio); the EQ
+// response curve is the real on-air shaping (TX bandpass + CFC makeup bands);
+// the telemetry strip reads the WDSP per-stage levels streamed at 10 Hz over
+// the TxMetersV2 WS frame. Pure maths lives in audio/tx-eq-analyzer-model.ts.
+
+import { useEffect, useRef } from 'react';
+import { getMicSpectrum, getMicSpectrumInfo } from '../audio/mic-uplink-session';
+import { useTxStore } from '../state/tx-store';
+import { useConnectionStore } from '../state/connection-store';
+import {
+  DB_MIN,
+  F_MAX,
+  F_MIN,
+  binsToColumns,
+  buildEqCurve,
+  dbToY,
+  formatStageDb,
+  freqToX,
+  gainToY,
+  type EqBand,
+} from '../audio/tx-eq-analyzer-model';
+
+// Frequency grid lines (Hz) and their short labels.
+const GRID_FREQS: readonly { hz: number; label: string }[] = [
+  { hz: 50, label: '50' },
+  { hz: 100, label: '100' },
+  { hz: 300, label: '300' },
+  { hz: 1000, label: '1k' },
+  { hz: 2000, label: '2k' },
+  { hz: 3000, label: '3k' },
+  { hz: 5000, label: '5k' },
+];
+const GRID_DBS = [-20, -40, -60, -80] as const;
+// Peak-hold decay (dB per second) so transients linger briefly then fall.
+const PEAK_DECAY_DB_PER_S = 36;
+
+interface Palette {
+  bg: string;
+  grid: string;
+  gridStrong: string;
+  text: string;
+  muted: string;
+  tx: string;
+  txSoft: string;
+  curve: string;
+  curveSoft: string;
+  power: string;
+}
+
+function readPalette(el: HTMLElement): Palette {
+  const cs = getComputedStyle(el);
+  const v = (name: string, fallback: string) => {
+    const raw = cs.getPropertyValue(name).trim();
+    return raw || fallback;
+  };
+  return {
+    bg: v('--bg-inset', '#060608'),
+    grid: v('--spec-grid', 'rgba(255,255,255,0.08)'),
+    gridStrong: v('--line-strong', '#2c2c32'),
+    text: v('--fg-1', '#cccccc'),
+    muted: v('--fg-3', '#5a5a60'),
+    tx: v('--tx', '#ff4a59'),
+    txSoft: v('--tx-soft', 'rgba(255,74,89,0.18)'),
+    curve: v('--accent-bright', '#4ea6ff'),
+    curveSoft: v('--accent-soft', 'rgba(46,142,255,0.14)'),
+    power: v('--power', '#ffb13c'),
+  };
+}
+
+interface StageChip {
+  key: string;
+  label: string;
+  pk: number;
+  gr?: number;
+}
+
+export interface TxEqAnalyzerProps {
+  transparent?: boolean;
+}
+
+export function TxEqAnalyzer({ transparent = false }: TxEqAnalyzerProps) {
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  // EQ curve inputs — read live in the draw loop via refs to avoid re-mounting
+  // the rAF loop on every parameter tweak.
+  const cfcConfig = useTxStore((s) => s.cfcConfig);
+  const txFilterLowHz = useConnectionStore((s) => s.txFilterLowHz);
+  const txFilterHighHz = useConnectionStore((s) => s.txFilterHighHz);
+  const tunOn = useTxStore((s) => s.tunOn);
+
+  const eqInputRef = useRef({
+    filterLowHz: txFilterLowHz,
+    filterHighHz: txFilterHighHz,
+    bands: cfcConfig.bands as readonly EqBand[],
+    bandsEnabled: cfcConfig.enabled,
+  });
+  eqInputRef.current = {
+    filterLowHz: txFilterLowHz,
+    filterHighHz: txFilterHighHz,
+    bands: cfcConfig.bands,
+    bandsEnabled: cfcConfig.enabled,
+  };
+
+  useEffect(() => {
+    const wrap = wrapRef.current;
+    const canvas = canvasRef.current;
+    if (!wrap || !canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    let raf = 0;
+    let cssW = 0;
+    let cssH = 0;
+    let dpr = 1;
+    let palette = readPalette(wrap);
+
+    let specBins: Float32Array | null = null;
+    let cols: Float32Array | null = null;
+    let peak: Float32Array | null = null;
+    let curve: Float32Array | null = null;
+    let specInfo = getMicSpectrumInfo();
+    let lastT = performance.now();
+
+    const resize = () => {
+      const r = wrap.getBoundingClientRect();
+      cssW = Math.max(1, Math.round(r.width));
+      cssH = Math.max(1, Math.round(r.height));
+      dpr = Math.min(2, Math.max(1, window.devicePixelRatio || 1));
+      canvas.width = Math.round(cssW * dpr);
+      canvas.height = Math.round(cssH * dpr);
+      canvas.style.width = `${cssW}px`;
+      canvas.style.height = `${cssH}px`;
+      palette = readPalette(wrap);
+      cols = new Float32Array(cssW);
+      peak = new Float32Array(cssW).fill(DB_MIN);
+      curve = new Float32Array(cssW);
+    };
+    resize();
+
+    const ro = new ResizeObserver(resize);
+    ro.observe(wrap);
+
+    const draw = () => {
+      raf = requestAnimationFrame(draw);
+      const now = performance.now();
+      const dt = Math.min(0.1, (now - lastT) / 1000);
+      lastT = now;
+      if (!cols || !peak || !curve) return;
+
+      ctx.save();
+      ctx.scale(dpr, dpr);
+      const W = cssW;
+      const H = cssH;
+      // Reserve the top strip for telemetry (HTML overlay), draw plot below.
+      const plotTop = 28;
+      const plotH = Math.max(1, H - plotTop - 16);
+
+      // Background.
+      ctx.clearRect(0, 0, W, H);
+      if (!transparent) {
+        ctx.fillStyle = palette.bg;
+        ctx.fillRect(0, 0, W, H);
+      }
+
+      // dB grid lines + labels.
+      ctx.strokeStyle = palette.grid;
+      ctx.fillStyle = palette.muted;
+      ctx.lineWidth = 1;
+      ctx.font = '10px Archivo Narrow, system-ui, sans-serif';
+      ctx.textBaseline = 'middle';
+      for (const db of GRID_DBS) {
+        const y = dbToY(db, plotTop, plotH);
+        ctx.beginPath();
+        ctx.moveTo(0, y + 0.5);
+        ctx.lineTo(W, y + 0.5);
+        ctx.stroke();
+        ctx.fillText(`${db}`, 3, y - 6);
+      }
+      // Frequency grid lines + labels.
+      ctx.textBaseline = 'alphabetic';
+      for (const g of GRID_FREQS) {
+        if (g.hz < F_MIN || g.hz > F_MAX) continue;
+        const x = freqToX(g.hz, 0, W);
+        ctx.beginPath();
+        ctx.moveTo(x + 0.5, plotTop);
+        ctx.lineTo(x + 0.5, plotTop + plotH);
+        ctx.stroke();
+        ctx.fillText(g.label, x + 3, plotTop + plotH + 12);
+      }
+
+      // Live spectrum.
+      const live = specInfo
+        ? (() => {
+            if (!specBins || specBins.length !== specInfo!.binCount) {
+              specBins = new Float32Array(specInfo!.binCount);
+            }
+            return getMicSpectrum(specBins);
+          })()
+        : false;
+      if (!live) {
+        // tap may have come up since mount (mic granted after keying)
+        specInfo = getMicSpectrumInfo();
+      }
+
+      if (live && specBins) {
+        binsToColumns(specBins, W, specInfo!.sampleRate, specInfo!.fftSize, cols);
+        // Decay + update peak-hold.
+        const decay = PEAK_DECAY_DB_PER_S * dt;
+        for (let x = 0; x < W; x += 1) {
+          const c = cols[x] ?? DB_MIN;
+          const p = (peak[x] ?? DB_MIN) - decay;
+          peak[x] = c > p ? c : p;
+        }
+
+        // Filled spectrum.
+        ctx.beginPath();
+        ctx.moveTo(0, plotTop + plotH);
+        for (let x = 0; x < W; x += 1) ctx.lineTo(x, dbToY(cols[x] ?? DB_MIN, plotTop, plotH));
+        ctx.lineTo(W, plotTop + plotH);
+        ctx.closePath();
+        const grad = ctx.createLinearGradient(0, plotTop, 0, plotTop + plotH);
+        grad.addColorStop(0, palette.tx);
+        grad.addColorStop(1, palette.txSoft);
+        ctx.globalAlpha = 0.55;
+        ctx.fillStyle = grad;
+        ctx.fill();
+        ctx.globalAlpha = 1;
+
+        // Spectrum edge.
+        ctx.beginPath();
+        for (let x = 0; x < W; x += 1) {
+          const y = dbToY(cols[x] ?? DB_MIN, plotTop, plotH);
+          if (x === 0) ctx.moveTo(x, y);
+          else ctx.lineTo(x, y);
+        }
+        ctx.strokeStyle = palette.tx;
+        ctx.lineWidth = 1.5;
+        ctx.stroke();
+
+        // Peak-hold trace.
+        ctx.beginPath();
+        for (let x = 0; x < W; x += 1) {
+          const y = dbToY(peak[x] ?? DB_MIN, plotTop, plotH);
+          if (x === 0) ctx.moveTo(x, y);
+          else ctx.lineTo(x, y);
+        }
+        ctx.strokeStyle = palette.power;
+        ctx.globalAlpha = 0.7;
+        ctx.lineWidth = 1;
+        ctx.stroke();
+        ctx.globalAlpha = 1;
+      } else {
+        ctx.fillStyle = palette.muted;
+        ctx.font = '12px Archivo Narrow, system-ui, sans-serif';
+        ctx.textAlign = 'center';
+        ctx.fillText('Live audio analysis available in browser (mic) mode', W / 2, plotTop + plotH / 2);
+        ctx.textAlign = 'left';
+      }
+
+      // EQ response curve (always drawn — the on-air shaping).
+      buildEqCurve(eqInputRef.current, W, curve);
+      ctx.beginPath();
+      for (let x = 0; x < W; x += 1) {
+        const y = gainToY(curve[x] ?? 0, plotTop, plotH);
+        if (x === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      }
+      ctx.strokeStyle = palette.curve;
+      ctx.lineWidth = 2;
+      ctx.stroke();
+
+      // Unity (0 dB gain) reference line.
+      const unityY = gainToY(0, plotTop, plotH);
+      ctx.beginPath();
+      ctx.setLineDash([3, 4]);
+      ctx.moveTo(0, unityY + 0.5);
+      ctx.lineTo(W, unityY + 0.5);
+      ctx.strokeStyle = palette.curveSoft;
+      ctx.lineWidth = 1;
+      ctx.stroke();
+      ctx.setLineDash([]);
+
+      // Band nodes.
+      const inp = eqInputRef.current;
+      if (inp.bandsEnabled) {
+        for (const band of inp.bands) {
+          if (!(band.freqHz >= F_MIN && band.freqHz <= F_MAX)) continue;
+          const x = freqToX(band.freqHz, 0, W);
+          const y = gainToY(band.postGainDb, plotTop, plotH);
+          ctx.beginPath();
+          ctx.arc(x, y, band.postGainDb !== 0 ? 4 : 2.5, 0, Math.PI * 2);
+          ctx.fillStyle = band.postGainDb !== 0 ? palette.curve : palette.muted;
+          ctx.fill();
+        }
+      }
+
+      ctx.restore();
+    };
+    raf = requestAnimationFrame(draw);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+    };
+  }, [transparent]);
+
+  return (
+    <div
+      ref={wrapRef}
+      data-tx-eq-analyzer
+      style={{ position: 'relative', width: '100%', height: '100%', minWidth: 0, minHeight: 0 }}
+    >
+      <canvas ref={canvasRef} style={{ display: 'block', width: '100%', height: '100%' }} />
+      <TxEqTelemetryStrip tune={tunOn} />
+    </div>
+  );
+}
+
+function TxEqTelemetryStrip({ tune }: { tune: boolean }) {
+  const fwdWatts = useTxStore((s) => s.fwdWatts);
+  const swr = useTxStore((s) => s.swr);
+  const micPk = useTxStore((s) => s.wdspMicPk);
+  const eqPk = useTxStore((s) => s.eqPk);
+  const lvlrPk = useTxStore((s) => s.lvlrPk);
+  const lvlrGr = useTxStore((s) => s.lvlrGr);
+  const cfcPk = useTxStore((s) => s.cfcPk);
+  const cfcGr = useTxStore((s) => s.cfcGr);
+  const compPk = useTxStore((s) => s.compPk);
+  const alcPk = useTxStore((s) => s.alcPk);
+  const alcGr = useTxStore((s) => s.alcGr);
+  const outPk = useTxStore((s) => s.outPk);
+
+  const stages: StageChip[] = [
+    { key: 'mic', label: 'MIC', pk: micPk },
+    { key: 'eq', label: 'EQ', pk: eqPk },
+    { key: 'lvlr', label: 'LVLR', pk: lvlrPk, gr: lvlrGr },
+    { key: 'cfc', label: 'CFC', pk: cfcPk, gr: cfcGr },
+    { key: 'comp', label: 'COMP', pk: compPk },
+    { key: 'alc', label: 'ALC', pk: alcPk, gr: alcGr },
+    { key: 'out', label: 'OUT', pk: outPk },
+  ];
+
+  const swrText = Number.isFinite(swr) && swr > 0 ? `${swr.toFixed(2)}:1` : '—';
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        height: 26,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        padding: '0 8px',
+        font: '11px Archivo Narrow, system-ui, sans-serif',
+        color: 'var(--fg-2)',
+        pointerEvents: 'none',
+        userSelect: 'none',
+        overflow: 'hidden',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      <span
+        style={{
+          color: '#fff',
+          background: 'var(--tx)',
+          borderRadius: 3,
+          padding: '1px 6px',
+          fontWeight: 700,
+          letterSpacing: '0.04em',
+        }}
+      >
+        {tune ? 'TUN' : 'TX'} EQ
+      </span>
+      <span style={{ color: 'var(--power)' }}>{Number.isFinite(fwdWatts) ? `${fwdWatts.toFixed(0)} W` : '— W'}</span>
+      <span>SWR {swrText}</span>
+      <span style={{ flex: '0 0 1px', alignSelf: 'stretch', background: 'var(--line-strong)' }} />
+      {stages.map((s) => (
+        <span key={s.key} style={{ display: 'inline-flex', alignItems: 'baseline', gap: 3 }}>
+          <span style={{ color: 'var(--fg-3)' }}>{s.label}</span>
+          <span style={{ color: 'var(--fg-1)', fontVariantNumeric: 'tabular-nums' }}>{formatStageDb(s.pk)}</span>
+          {s.gr !== undefined && s.gr > 0.1 && (
+            <span style={{ color: 'var(--tx)', fontVariantNumeric: 'tabular-nums' }}>−{s.gr.toFixed(1)}</span>
+          )}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/zeus-web/src/layout/panels/HeroPanel.tsx
+++ b/zeus-web/src/layout/panels/HeroPanel.tsx
@@ -47,6 +47,7 @@ import type { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent }
 import { GripVertical, X } from 'lucide-react';
 import { Panadapter } from '../../components/Panadapter';
 import { WaterfallSurface } from '../../components/WaterfallSurface';
+import { TxEqAnalyzer } from '../../components/TxEqAnalyzer';
 import { ZoomControl } from '../../components/ZoomControl';
 import { WaterfallSpeedControl } from '../../components/WaterfallSpeedControl';
 import { SpectrumControls } from '../../components/SpectrumControls';
@@ -54,6 +55,7 @@ import { LeafletWorldMap } from '../../components/design/LeafletWorldMap';
 import { LeafletMapErrorBoundary } from '../../components/design/LeafletMapErrorBoundary';
 import { setRx2, type Rx2AudioMode } from '../../api/client';
 import { useConnectionStore } from '../../state/connection-store';
+import { useTxStore } from '../../state/tx-store';
 import { useRotatorStore } from '../../state/rotator-store';
 import { useLayoutStore } from '../../state/layout-store';
 import { TileLockButton } from '../TileChrome';
@@ -127,6 +129,8 @@ export function HeroPanel({
   const rx2AudioMode = useConnectionStore((s) => s.rx2AudioMode);
   const rxFocus = useConnectionStore((s) => s.rxFocus);
   const setRxFocus = useConnectionStore((s) => s.setRxFocus);
+  // During TX the waterfall region becomes the live TX EQ analyzer.
+  const keyed = useTxStore((s) => s.moxOn || s.tunOn);
   const updateTileInstanceConfig = useLayoutStore(
     (s) => s.updateTileInstanceConfigInLayout,
   );
@@ -479,7 +483,11 @@ export function HeroPanel({
             onPointerDown={onSplitterPointerDown}
           />
           {connected && (
-            rx2Enabled ? (
+            keyed ? (
+              // On TX both receivers transmit the same audio, so a single
+              // full-width analyzer replaces the waterfall (or RX2 quad).
+              <TxEqAnalyzer transparent={bgActive} />
+            ) : rx2Enabled ? (
               <div style={stitchedGridStyle}>
                 <div style={{ minWidth: 0, minHeight: 0 }}>
                   <WaterfallSurface


### PR DESCRIPTION
## What

On TX (MOX or TUN), the bottom **waterfall** region of the spectrum stack turns into a live, parametric-EQ-style analyzer of the transmitted audio. The panadapter (top) is unchanged and keeps showing the TX RF spectrum — only the waterfall region swaps.

Three layers, drawn on a log-frequency voice-band axis (30 Hz – 6 kHz), FabFilter/Pro-Q style:

1. **Live spectrum** — a parallel `AnalyserNode` (4096-pt FFT @ 48 kHz) tapped off the existing mic `getUserMedia` graph: the audio actually going to the radio. Filled TX-red trace + decaying peak-hold.
2. **EQ response curve** — built from the *real* on-air shaping: the TX bandpass skirts (`txFilterLowHz/HighHz`) plus a makeup bell per active CFC band, with band nodes (accent-blue, unity reference line).
3. **Verbose telemetry strip** — `MIC → EQ → LVLR → CFC → COMP → ALC → OUT` per-stage levels with gain reduction, plus fwd watts and SWR, fed by the `TxMetersV2` WS frame already streaming at 10 Hz.

## How

- The `AnalyserNode` is a pure sink off the mic source — it never connects onward, so it can't affect the uplink audio.
- Falls back to the EQ curve + telemetry (with a hint) when there's no browser mic — e.g. desktop/native audio mode.
- All colors come from `tokens.css` variables (TX red signal, accent-blue curve); no raw hex.
- **No backend, wire-format, or dependency changes.** Cross-platform safe (Canvas2D + graceful fallback).

## Files

- `audio/tx-eq-analyzer-model.ts` — pure, platform-independent maths (log mapping, FFT-bins→columns resampling, EQ-curve builder) + 16 unit tests
- `audio/mic-uplink.ts` / `mic-uplink-session.ts` — parallel `AnalyserNode` + `getMicSpectrum()` accessor
- `components/TxEqAnalyzer.tsx` — the analyzer (Canvas2D spectrum/curve/nodes + telemetry overlay)
- `layout/panels/HeroPanel.tsx` — swaps `WaterfallSurface → TxEqAnalyzer` when keyed

## Verification

- `tsc -b` + `vite build`: green
- Vitest: model suite **16/16**, full audio suite **86/86**; eslint clean

**Not yet eyeballed live** — rendering the analyzer requires a keyed radio, and the canvas doesn't paint in the headless preview tool, so a real-browser TX is needed to visually confirm. Logic is covered by the build + unit tests.

## Notes for reviewers

- Visual styling/UX of the analyzer is open to maintainer direction (placement, colors within the token set, what telemetry to surface).
- The "EQ curve" represents Zeus's actual TX shaping (bandpass + CFC makeup), not a new parametric-EQ DSP stage — nothing in the TX DSP chain changed.