### PR TITLE
fix(dsp): stop held RX leveler gain from blasting on a sudden strong signal

### DIFF
--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -308,6 +308,16 @@ public class DspPipelineService : BackgroundService,
         double currentDb = double.IsFinite(state.GainDb) ? state.GainDb : 0.0;
         currentDb = Math.Clamp(currentDb, RxLevelerMaxCutDb, RxLevelerMaxBoostDb);
 
+        // True when the gain we are currently holding would, on its own, drive
+        // this block's peak past the limiter target — i.e. a gain "held" high
+        // across a quiet gap (pause memory / catch-up) is about to be dumped onto
+        // a louder block. The raw input-peak gate below (peak > target) misses
+        // this case because the danger is gain × peak, not peak alone: a signal
+        // whose input peak is modest still blasts the speaker if the held gain is
+        // large. When this is set we cut as urgently as a clipping peak would.
+        bool currentGainOverdrivesPeak =
+            double.IsFinite(peakHeadroomDb) && currentDb > peakHeadroomDb;
+
         double nextDb = currentDb;
         if (belowGate)
         {
@@ -370,18 +380,29 @@ public class DspPipelineService : BackgroundService,
         }
         else if (!belowGate)
         {
-            double cutSlewDb = (peak > RxLevelerPeakTarget || peakLimited)
+            double cutSlewDb = (peak > RxLevelerPeakTarget || peakLimited || currentGainOverdrivesPeak)
                 ? Math.Max(RxLevelerSmoothCutDb, currentDb - desiredDb)
                 : RxLevelerSmoothCutDb;
             nextDb = Math.Max(desiredDb, currentDb - cutSlewDb);
         }
         nextDb = Math.Clamp(nextDb, RxLevelerMaxCutDb, RxLevelerMaxBoostDb);
 
+        // Hard per-block peak guard. The smooth boost/cut slews above track
+        // loudness gently; this is the safety floor that stops a held-high gain
+        // from ever being *applied* to a block whose peak would then exceed the
+        // limiter target. Without it, gain banked across a quiet gap gets dumped
+        // onto the first loud-ish block of a new signal and rides the soft-limit
+        // ceiling for several blocks before the slew catches up — the "sudden
+        // strong signal blasts the speaker" failure this leveler exists to stop.
+        // Cutting straight to the peak-safe gain is inaudible next to that blast.
+        if (!belowGate && double.IsFinite(peakHeadroomDb) && nextDb > peakHeadroomDb)
+            nextDb = Math.Clamp(peakHeadroomDb, RxLevelerMaxCutDb, RxLevelerMaxBoostDb);
+
         int rampSamples = Math.Clamp(Math.Min(samples.Length, RxLevelerGainRampMaxSamples), 1, Math.Max(1, samples.Length));
         double preLimitPeak = 0.0;
         int outputLimitSampleCount = 0;
         double appliedEndDb = belowGate ? 0.0 : nextDb;
-        bool emergencyCut = !belowGate && desiredDb < currentDb && (peak > RxLevelerPeakTarget || peakLimited);
+        bool emergencyCut = !belowGate && nextDb < currentDb && (peak > RxLevelerPeakTarget || peakLimited || currentGainOverdrivesPeak);
         for (int i = 0; i < samples.Length; i++)
         {
             float clean = SanitizeAudioSample(samples[i]);

--- a/tests/Zeus.Server.Tests/DspPipelineAudioSanitizerTests.cs
+++ b/tests/Zeus.Server.Tests/DspPipelineAudioSanitizerTests.cs
@@ -674,6 +674,35 @@ public sealed class DspPipelineAudioSanitizerTests
     }
 
     [Fact]
+    public void ApplyRxAudioLeveler_ModeratePeakSignalAfterWeakSignalDoesNotBlast()
+    {
+        // The input peak (0.45) sits *below* the limiter target (0.74), so the
+        // raw input-peak fast-cut gate never fires. The danger is the gain banked
+        // across the weak run being dumped onto this louder block: gain × peak,
+        // not peak alone. Without the per-block peak guard the first block rides
+        // the soft-limit ceiling for several blocks — the "hard audio" blast.
+        var state = new DspPipelineService.RxAudioLevelerState();
+        float[] block = new float[1024];
+
+        for (int i = 0; i < 18; i++)
+        {
+            Array.Fill(block, 0.01f);
+            DspPipelineService.ApplyRxAudioLeveler(block, ref state);
+        }
+
+        Assert.True(state.GainDb > 20.0);
+
+        Array.Fill(block, 0.45f);
+        DspPipelineService.ApplyRxAudioLeveler(block, ref state);
+
+        // Output is leveled to target on the very first block, never blasted: the
+        // peak stays well under the 0.74 limiter ceiling instead of riding it.
+        Assert.True(PeakAbs(block) < 0.5f);
+        Assert.InRange(Rms(block), 0.10f, 0.15f);
+        Assert.True(state.GainDb < 0.0);
+    }
+
+    [Fact]
     public void ApplyRxAudioLeveler_ReportsPeakHeadroomConstraint()
     {
         var state = new DspPipelineService.RxAudioLevelerState();


### PR DESCRIPTION
## Problem

Operators report that **sometimes hard/loud audio comes through** — a sudden strong signal occasionally blasts the speaker instead of being normalized. This is exactly the failure mode the final RX loudness guard (`ApplyRxAudioLeveler` in `DspPipelineService.cs`) is supposed to prevent; its own comment says it lifts weak audio *"without letting a sudden strong signal blast the speaker."*

## Root cause

The leveler banks up to **+36 dB** of gain during weak/quiet passages and holds it across short gaps (pause memory + catch-up). Its fast/emergency cut was gated **only on the raw input peak** exceeding the 0.74 limiter target:

```csharp
(peak > RxLevelerPeakTarget || peakLimited)
```

But the danger is **gain × peak, not peak alone**. When a signal whose *input* peak is modest (e.g. 0.45, below the ceiling) arrives while a large gain is still held, that gain gets dumped onto its first blocks → output rides the soft-limit ceiling for ~6+ blocks (≈100+ ms) before the gentle 6 dB/block smooth cut catches up. That burst is the "hard audio."

## Fix

- Add `currentGainOverdrivesPeak` (`currentDb > peakHeadroomDb`) — true when the *currently held* gain would, on its own, drive this block past the limiter target — and fold it into the fast-cut-slew and `emergencyCut` (flat, no up-ramp) gates, so a held-high gain meeting any louder block is cut to its peak-safe target in **one block**.
- Add a **hard per-block peak guard** that never *applies* a gain whose output would exceed the limiter target — a safety floor independent of the slew tuning.

Weak-signal lifting, smooth small cuts, and full-amplitude transients are unchanged (all existing leveler tests stay green).

## Test

Adds `ApplyRxAudioLeveler_ModeratePeakSignalAfterWeakSignalDoesNotBlast`, which reproduces the exact gap (input peak 0.45, gain banked >20 dB) and asserts the output is leveled to target instead of riding the 0.74 ceiling. Existing `...StrongSignalAfterWeakSignalDoesNotBlast` only covered a full-amplitude (0.9) signal, where the old input-peak gate already fired.

`dotnet test --filter DspPipelineAudioSanitizer` → **29/29 passing**.

Server-side audio DSP only; not browser-previewable — verified via unit tests.