### PR TITLE
refactor(tx-fidelity): tighten Auto Tune compressor back-off + dedup

### DIFF
--- a/zeus-web/src/audio/tx-auto-tune.test.ts
+++ b/zeus-web/src/audio/tx-auto-tune.test.ts
@@ -215,9 +215,12 @@ describe('recommendTxAutoTune', () => {
     );
 
     expect(plan.blockers).toEqual([]);
-    expect(plan.settings.txLeveling.alcMaxGainDb).toBe(4);
+    // Lock the full per-run blast radius of a clean max-density run so the
+    // number of dynamics stages that move at once stays explicit.
+    expect(plan.settings.txLeveling.alcMaxGainDb).toBe(4); // 3 -> +1
     expect(plan.settings.txLeveling.compressorEnabled).toBe(true);
-    expect(plan.settings.txLeveling.compressorGainDb).toBe(2);
+    expect(plan.settings.txLeveling.compressorGainDb).toBe(2); // off -> on +2
+    expect(plan.settings.txLeveling.levelerDecayMs).toBe(140); // 100 -> +40
     expect(plan.settings.cfcConfig.prePeqDb).toBeGreaterThan(0);
     expect(plan.actions.join(' ')).toContain('compressor on');
   });

--- a/zeus-web/src/audio/tx-auto-tune.ts
+++ b/zeus-web/src/audio/tx-auto-tune.ts
@@ -222,7 +222,7 @@ function clampLeveling(c: TxLevelingConfigDto): TxLevelingConfigDto {
   };
 }
 
-function levelingChanged(a: TxLevelingConfigDto, b: TxLevelingConfigDto): boolean {
+export function levelingChanged(a: TxLevelingConfigDto, b: TxLevelingConfigDto): boolean {
   return (
     a.alcMaxGainDb !== b.alcMaxGainDb ||
     a.alcDecayMs !== b.alcDecayMs ||
@@ -423,14 +423,16 @@ export function recommendTxAutoTune(
     actions.push('ALC max gain -1 dB');
   }
 
-  // CPDR compressor over-squash: a pinched compressor crest (or a pinched chain
-  // crest while the compressor is doing the squashing) means the compander is
-  // flattening the speech. Back its gain off, disabling it once it reaches 0.
+  // CPDR compressor over-squash: only back the compander off when the
+  // COMPRESSOR's OWN crest is pinched. A tight chain crest is just as often the
+  // leveler or CFC doing the squashing, so attributing it to the compressor
+  // would wrongly disable an operator's deliberate compression. When the comp
+  // stage isn't metered (compCrestMedianDb null) we hold rather than guess.
   const compPinched =
     next.txLeveling.compressorEnabled &&
     next.txLeveling.compressorGainDb > COMP_GAIN_HARD_MIN &&
-    ((stats.compCrestMedianDb !== null && stats.compCrestMedianDb < 5) ||
-      (stats.crestMedianDb !== null && stats.crestMedianDb < 6));
+    stats.compCrestMedianDb !== null &&
+    stats.compCrestMedianDb < 5;
   if (compPinched) {
     const reduced = roundTenth(clamp(next.txLeveling.compressorGainDb - 2, COMP_GAIN_HARD_MIN, COMP_GAIN_HARD_MAX));
     next.txLeveling = {
@@ -561,7 +563,11 @@ export function recommendTxAutoTune(
 
     // CPDR compressor for max density: the compander is the strongest clean
     // talk-power lever. Only engage it on a wide-open crest with real output
-    // headroom so it tightens dynamics instead of pinching them.
+    // headroom so it tightens dynamics instead of pinching them. Unlike the
+    // drive raise (keyed-only, because it touches RF) this is deliberately
+    // allowed in silent Preview — the compressor is a pre-RF audio stage, so
+    // shaping it from a Preview sample is safe and matches how the operator
+    // would dial it in off-air.
     if (
       target >= 90 &&
       stats.alcP95Db < 6 &&

--- a/zeus-web/src/layout/panels/TxFidelityPanel.tsx
+++ b/zeus-web/src/layout/panels/TxFidelityPanel.tsx
@@ -21,6 +21,7 @@ import {
   type TxLevelingConfigDto,
 } from '../../api/client';
 import {
+  levelingChanged,
   recommendTxAutoTune,
   type TxAutoTunePlan,
   type TxAutoTuneSample,
@@ -212,17 +213,6 @@ function cfcConfigChanged(a: TxAutoTuneSettings['cfcConfig'], b: TxAutoTuneSetti
   });
 }
 
-function txLevelingChanged(a: TxLevelingConfigDto, b: TxLevelingConfigDto): boolean {
-  return (
-    a.alcMaxGainDb !== b.alcMaxGainDb ||
-    a.alcDecayMs !== b.alcDecayMs ||
-    a.levelerEnabled !== b.levelerEnabled ||
-    a.levelerDecayMs !== b.levelerDecayMs ||
-    a.compressorEnabled !== b.compressorEnabled ||
-    a.compressorGainDb !== b.compressorGainDb
-  );
-}
-
 function autoTuneMessage(plan: TxAutoTunePlan): string {
   if (plan.actions.length === 0) return plan.summary;
   return `${plan.summary}: ${plan.actions.join(', ')}`;
@@ -381,7 +371,7 @@ function TxFidelityAutoTune({ targetSpectralDensity }: { targetSpectralDensity: 
         setCfcConfigLocal(state.cfc);
       }
       const beforeLeveling = useConnectionStore.getState().txLeveling;
-      if (txLevelingChanged(beforeLeveling, plan.settings.txLeveling)) {
+      if (levelingChanged(beforeLeveling, plan.settings.txLeveling)) {
         setTxLevelingLocal(plan.settings.txLeveling);
         const state = await setTxLeveling(plan.settings.txLeveling, signal);
         applyState(state);


### PR DESCRIPTION
Follow-up refinements to the TX fidelity full-dynamics-chain Auto Tune that merged in #727, from an adversarial code-review pass.

- **Compressor back-off correctness:** the CPDR back-off no longer fires on a tight *chain* crest alone (which the leveler or CFC often causes) — it now requires the **compressor stage's own** crest to be pinched (`compCrestMedianDb < 5`). Prevents disabling an operator's deliberate compression when another stage tightened the crest. Holds (no change) when the comp stage isn't metered.
- **Dedup:** export `levelingChanged` from `tx-auto-tune.ts` and reuse it in `TxFidelityPanel`, deleting the duplicated field-by-field copy (drift risk if a leveling field is added).
- **Blast-radius test:** the clean max-density test now asserts the full leveling change set (ALC make-up, compressor on, leveler decay) so the number of dynamics stages that move per run stays explicit.
- **Doc:** note that compressor-engage is deliberately allowed in silent Preview (pre-RF audio stage), unlike the keyed-only drive raise.

Frontend-only; full web suite green (835), tsc + eslint clean.