### PR TITLE
feat(workspace): lock panel size + premium panel-swap feel

### DIFF
--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -43,6 +43,11 @@ import {
   createWorkspaceDragCompactor,
   type WorkspaceDragStartSnapshot,
 } from './workspaceGrid';
+import {
+  deriveWorkspaceLayout,
+  reconcileReportedToStored,
+  type DeriveTile,
+} from './lockedWorkspaceLayout';
 import { usePluginPanels } from '../plugins/runtime/usePluginPanels';
 import {
   EMPTY_WORKSPACE_LAYOUT,
@@ -265,41 +270,80 @@ function WorkspaceCanvas({
   // The workspace must NEVER show a scrollbar — it fits the viewport like a
   // hardware front panel. So the grid is fit-to-viewport: the cell size is
   // sized so the whole layout fits the container height.
-  const layoutRows = useMemo(
-    () => tiles.reduce((max, t) => Math.max(max, t.y + t.h), 0),
+  //
+  // deriveWorkspaceLayout owns the whole fit. With no locked tiles it
+  // reproduces the legacy uniform shrink (divisor = max(layoutRows, target), so
+  // rearranging within the design fold never rescales a panel; only a layout
+  // taller than the fold shrinks the cell). When a tile is locked AND the
+  // layout would overflow, it instead pins rowHeight at the authored height —
+  // so locked tiles render at their exact authored pixel size, invariant to the
+  // workspace getting longer/shorter — and shrinks only the unlocked tiles to
+  // fit, recompacting around the static locked tiles. The result is a RENDER
+  // layout; the stored layout is untouched (see reconcile below).
+  const deriveTiles = useMemo<DeriveTile[]>(
+    () =>
+      tiles.map((t) => {
+        const def = getPanelDef(t.panelId, pluginPanelKey);
+        const w = def?.maxW !== undefined ? Math.min(t.w, def.maxW) : t.w;
+        const h = def?.maxH !== undefined ? Math.min(t.h, def.maxH) : t.h;
+        return {
+          uid: t.uid,
+          x: t.x,
+          y: t.y,
+          w,
+          h,
+          locked: workspaceLocked || t.locked === true,
+          minH: def?.minH ?? WORKSPACE_TILE_MIN_H,
+        };
+      }),
+    [tiles, pluginPanelKey, workspaceLocked],
+  );
+
+  const derived = useMemo(
+    () =>
+      deriveWorkspaceLayout(deriveTiles, {
+        containerHeight,
+        authoredRowHeightPx: WORKSPACE_ROW_HEIGHT_PX,
+        gridMarginPx: WORKSPACE_GRID_MARGIN_PX,
+        rowGapShare: WORKSPACE_ROW_GAP_SHARE,
+        targetRows: WORKSPACE_TARGET_ROWS,
+        minRowHeightPx: 0.1,
+      }),
+    [deriveTiles, containerHeight],
+  );
+  const { rowHeight, rowMargin } = derived;
+
+  // Stored geometry, keyed by uid, for reconciling RGL's echo of the derived
+  // (possibly shrunk) render layout back to what we persist. Refs keep the
+  // persist callback stable without going stale.
+  const storedByUid = useMemo(
+    () => new Map(tiles.map((t) => [t.uid, { x: t.x, y: t.y, w: t.w, h: t.h }])),
     [tiles],
   );
-  // Divisor is max(layoutRows, target): while panels are rearranged WITHIN the
-  // authored design height the divisor is the constant target, so repositioning
-  // never rescales a panel. Only stacking a layout taller than the design fold
-  // shrinks the cell — the unavoidable cost of never scrolling. A sparse layout
-  // keeps the authored density (capped at WORKSPACE_ROW_HEIGHT_PX) and just
-  // leaves empty ground at the bottom rather than ballooning its tiles.
-  const targetRows = Math.max(layoutRows, WORKSPACE_TARGET_ROWS);
+  const derivedRef = useRef(derived);
+  derivedRef.current = derived;
+  const storedByUidRef = useRef(storedByUid);
+  storedByUidRef.current = storedByUid;
+  // All persistence flows through here so the shrunk render geometry never
+  // reaches the store. When nothing is compensated this is the identity, so the
+  // common path is byte-identical to the legacy behaviour.
+  const persist = useCallback(
+    (next: Layout) => {
+      onLayoutChange(
+        reconcileReportedToStored(
+          next,
+          derivedRef.current,
+          storedByUidRef.current,
+        ),
+      );
+    },
+    [onLayoutChange],
+  );
 
-  // Shrink-to-fit rowHeight: solve containerHeight ≈ rowHeight*N + margin*(N-1)
-  // + 2*containerPadding, capped at WORKSPACE_ROW_HEIGHT_PX. Margin and
-  // containerPadding mirror the props passed to ResponsiveGridLayout below —
-  // keep them in sync if those change. The row gap shrinks with very dense
-  // layouts so gaps alone can never make the grid taller than the viewport.
-  const rowMargin = useMemo(() => {
-    if (containerHeight <= 0 || targetRows <= 1) return WORKSPACE_GRID_MARGIN_PX;
-    return Math.min(
-      WORKSPACE_GRID_MARGIN_PX,
-      containerHeight / (targetRows * WORKSPACE_ROW_GAP_SHARE),
-    );
-  }, [containerHeight, targetRows]);
-
-  const rowHeight = useMemo(() => {
-    if (containerHeight <= 0) return WORKSPACE_ROW_HEIGHT_PX;
-    const containerPadding = 0;
-    const inner =
-      containerHeight - 2 * containerPadding - rowMargin * Math.max(0, targetRows - 1);
-    return Math.min(
-      WORKSPACE_ROW_HEIGHT_PX,
-      Math.max(0.1, inner / Math.max(1, targetRows)),
-    );
-  }, [containerHeight, rowMargin, targetRows]);
+  const placementByUid = useMemo(
+    () => new Map(derived.placements.map((p) => [p.uid, p])),
+    [derived],
+  );
 
   const workspaceDragCompactor = useMemo(
     () => createWorkspaceDragCompactor(() => dragStartRef.current),
@@ -376,11 +420,11 @@ function WorkspaceCanvas({
       window.setTimeout(() => {
         skipPostDropLayoutChangeRef.current = false;
       }, 250);
-      onLayoutChange(
+      persist(
         autoFitDroppedPanel(layout, WORKSPACE_GRID_COLS, previousDropItem),
       );
     }
-  }, [onLayoutChange]);
+  }, [persist]);
   const onResizeStop = useCallback(() => {
     draggingRef.current = false;
     dragStartRef.current = null;
@@ -392,9 +436,9 @@ function WorkspaceCanvas({
         return;
       }
 
-      onLayoutChange(next);
+      persist(next);
     },
-    [onLayoutChange],
+    [persist],
   );
 
   // RGL needs a stable per-render layouts.lg array. Memoise against the
@@ -406,17 +450,21 @@ function WorkspaceCanvas({
       lg: tiles.map((t) => {
         const def = getPanelDef(t.panelId, pluginPanelKey);
         const tileLocked = workspaceLocked || t.locked === true;
-        // Clamp persisted size to the panel's maxW/maxH. RGL only enforces
-        // these caps during resize drags, so a tile saved wider than its cap
-        // (e.g. a Filter Presets tile placed before it gained maxW) would
-        // otherwise keep sprawling on load. Clamping here snaps it back into
-        // the right-column stack; the next onLayoutChange persists the fix.
-        const w = def?.maxW !== undefined ? Math.min(t.w, def.maxW) : t.w;
-        const h = def?.maxH !== undefined ? Math.min(t.h, def.maxH) : t.h;
+        // Geometry comes from the derived render layout: locked tiles stay at
+        // their authored size while unlocked tiles shrink to fit (see
+        // deriveWorkspaceLayout). The placement is already clamped to the
+        // panel's maxW/maxH (deriveTiles does the clamp before solving), so a
+        // tile saved wider than its cap snaps back here and the next persist
+        // writes the fix.
+        const placement = placementByUid.get(t.uid);
+        const w = placement?.w ?? t.w;
+        const h = placement?.h ?? t.h;
+        const x = placement?.x ?? t.x;
+        const y = placement?.y ?? t.y;
         return {
           i: t.uid,
-          x: t.x,
-          y: t.y,
+          x,
+          y,
           w,
           h,
           // Per-panel legibility floor when the panel declares one, else the
@@ -433,7 +481,7 @@ function WorkspaceCanvas({
         };
       }),
     }),
-    [tiles, pluginPanelKey, workspaceLocked],
+    [tiles, pluginPanelKey, workspaceLocked, placementByUid],
   );
 
   return (

--- a/zeus-web/src/layout/lockedWorkspaceLayout.test.ts
+++ b/zeus-web/src/layout/lockedWorkspaceLayout.test.ts
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  deriveWorkspaceLayout,
+  reconcileReportedToStored,
+  type DeriveOptions,
+  type DeriveTile,
+  type DerivedWorkspaceLayout,
+} from './lockedWorkspaceLayout';
+import type { Layout } from 'react-grid-layout';
+
+// Mirror of the FlexWorkspace constants so the tests read against real values.
+const R = 15; // WORKSPACE_ROW_HEIGHT_PX
+const M = 3; // WORKSPACE_GRID_MARGIN_PX
+const BASE_OPTS: Omit<DeriveOptions, 'containerHeight'> = {
+  authoredRowHeightPx: R,
+  gridMarginPx: M,
+  rowGapShare: 6,
+  targetRows: 48,
+  minRowHeightPx: 0.1,
+};
+
+function opts(containerHeight: number): DeriveOptions {
+  return { ...BASE_OPTS, containerHeight };
+}
+
+function tile(p: Partial<DeriveTile> & { uid: string }): DeriveTile {
+  return {
+    x: 0,
+    y: 0,
+    w: 12,
+    h: 4,
+    locked: false,
+    minH: 2,
+    ...p,
+  };
+}
+
+/** On-screen pixel height a tile renders at for a given grid rowHeight/margin. */
+function pxHeight(h: number, rowHeight: number, rowMargin: number): number {
+  return h * rowHeight + (h - 1) * rowMargin;
+}
+
+function maxBottom(d: DerivedWorkspaceLayout): number {
+  return d.placements.reduce((mx, p) => Math.max(mx, p.y + p.h), 0);
+}
+
+function byUid(d: DerivedWorkspaceLayout, uid: string) {
+  const p = d.placements.find((x) => x.uid === uid);
+  if (!p) throw new Error(`no placement for ${uid}`);
+  return p;
+}
+
+describe('deriveWorkspaceLayout — no locked tiles', () => {
+  it('reproduces the uniform shrink and never compensates', () => {
+    const tiles = [
+      tile({ uid: 'a', y: 0, h: 20 }),
+      tile({ uid: 'b', y: 20, h: 30 }), // layoutRows 50 > target
+    ];
+    const d = deriveWorkspaceLayout(tiles, opts(600));
+    expect(d.compensated).toBe(false);
+    expect(d.unlockedScale).toBe(1);
+    // Placements pass through stored geometry untouched.
+    expect(byUid(d, 'b')).toMatchObject({ y: 20, h: 30 });
+    // rowHeight is the shrunk uniform value (< authored) for an overflow layout.
+    expect(d.rowHeight).toBeLessThan(R);
+  });
+});
+
+describe('deriveWorkspaceLayout — locked tile, layout fits', () => {
+  it('renders at authored rowHeight with stored geometry', () => {
+    const tiles = [
+      tile({ uid: 'lock', y: 0, h: 20, locked: true }),
+      tile({ uid: 'b', y: 20, h: 10 }), // layoutRows 30
+    ];
+    // Tall container: fitRows = floor((900+3)/18) = 50 >= 30.
+    const d = deriveWorkspaceLayout(tiles, opts(900));
+    expect(d.compensated).toBe(false);
+    expect(d.rowHeight).toBe(R);
+    expect(d.rowMargin).toBe(M);
+    expect(byUid(d, 'lock')).toMatchObject({ h: 20 });
+    expect(byUid(d, 'b')).toMatchObject({ h: 10 });
+  });
+});
+
+describe('deriveWorkspaceLayout — locked tile, overflow', () => {
+  const tiles = [
+    tile({ uid: 'lock', x: 0, y: 0, w: 12, h: 20, locked: true }),
+    tile({ uid: 'b', x: 0, y: 20, w: 12, h: 20 }),
+    tile({ uid: 'c', x: 12, y: 0, w: 12, h: 40 }),
+  ]; // layoutRows = 40
+
+  it('keeps the locked tile at its exact stored height while unlocked shrink', () => {
+    // container 600 → fitRows = floor(603/18) = 33 < 40 → must compensate.
+    const d = deriveWorkspaceLayout(tiles, opts(600));
+    expect(d.compensated).toBe(true);
+    expect(d.rowHeight).toBe(R);
+    // Locked tile is untouched.
+    expect(byUid(d, 'lock')).toMatchObject({ x: 0, y: 0, w: 12, h: 20 });
+    // Unlocked tiles shrank.
+    expect(byUid(d, 'b').h).toBeLessThan(20);
+    expect(byUid(d, 'c').h).toBeLessThan(40);
+    // Everything fits the viewport (no scroll).
+    expect(maxBottom(d)).toBeLessThanOrEqual(33);
+  });
+
+  it('respects unlocked tile minH floors', () => {
+    const tight = [
+      tile({ uid: 'lock', y: 0, h: 18, locked: true }),
+      tile({ uid: 'b', y: 18, h: 20, minH: 6 }),
+    ];
+    // container small enough to force max shrink: fitRows tuned so b cannot go
+    // below minH=6 (lock 18 + b 6 = 24).
+    const d = deriveWorkspaceLayout(tight, opts(450)); // fitRows floor(453/18)=25
+    expect(byUid(d, 'b').h).toBeGreaterThanOrEqual(6);
+    expect(byUid(d, 'lock').h).toBe(18);
+  });
+});
+
+describe('deriveWorkspaceLayout — locked size invariance', () => {
+  it('holds the locked tile pixel height constant as the workspace grows/shrinks', () => {
+    const make = (extraRows: number): DeriveTile[] => [
+      tile({ uid: 'lock', x: 0, y: 0, w: 12, h: 20, locked: true }),
+      tile({ uid: 'fill', x: 0, y: 20, w: 24, h: 20 + extraRows }),
+    ];
+    const authoredPx = pxHeight(20, R, M); // 20*15 + 19*3 = 357
+
+    // Across a fitting layout AND an overflowing one, the locked tile renders at
+    // exactly the same pixel height.
+    for (const [container, extra] of [
+      [900, 0],
+      [900, 40],
+      [600, 0],
+      [600, 60],
+    ] as const) {
+      const d = deriveWorkspaceLayout(make(extra), opts(container));
+      const lock = byUid(d, 'lock');
+      expect(pxHeight(lock.h, d.rowHeight, d.rowMargin)).toBeCloseTo(authoredPx, 5);
+    }
+  });
+});
+
+describe('deriveWorkspaceLayout — every tile locked', () => {
+  it('falls back to uniform shrink (no unlocked tile can absorb slack)', () => {
+    const tiles = [
+      tile({ uid: 'a', y: 0, h: 30, locked: true }),
+      tile({ uid: 'b', y: 30, h: 30, locked: true }),
+    ];
+    const d = deriveWorkspaceLayout(tiles, opts(600));
+    expect(d.compensated).toBe(false);
+    expect(d.rowHeight).toBeLessThan(R); // uniform shrink applied to all
+  });
+});
+
+describe('reconcileReportedToStored', () => {
+  const stored = new Map([
+    ['lock', { x: 0, y: 0, w: 12, h: 20 }],
+    ['b', { x: 0, y: 20, w: 12, h: 20 }],
+  ]);
+
+  it('passes the report through unchanged when not compensated', () => {
+    const derived: DerivedWorkspaceLayout = {
+      rowHeight: 12,
+      rowMargin: 3,
+      placements: [],
+      compensated: false,
+      unlockedScale: 1,
+    };
+    const reported: Layout = [
+      { i: 'b', x: 1, y: 2, w: 6, h: 7 } as Layout[number],
+    ];
+    expect(reconcileReportedToStored(reported, derived, stored)).toEqual(reported);
+  });
+
+  it('restores stored geometry for a pure echo of the derived layout', () => {
+    const derived: DerivedWorkspaceLayout = {
+      rowHeight: R,
+      rowMargin: M,
+      placements: [
+        { uid: 'lock', x: 0, y: 0, w: 12, h: 20 },
+        { uid: 'b', x: 0, y: 20, w: 12, h: 13 }, // shrunk render height
+      ],
+      compensated: true,
+      unlockedScale: 0.65,
+    };
+    const reported: Layout = [
+      { i: 'lock', x: 0, y: 0, w: 12, h: 20 } as Layout[number],
+      { i: 'b', x: 0, y: 20, w: 12, h: 13 } as Layout[number], // echo
+    ];
+    const out = reconcileReportedToStored(reported, derived, stored);
+    // The shrunken render height is reverted to the stored authored height.
+    expect(out.find((x) => x.i === 'b')).toMatchObject({ h: 20 });
+  });
+
+  it('un-scales the height of a genuine edit during compensation', () => {
+    const derived: DerivedWorkspaceLayout = {
+      rowHeight: R,
+      rowMargin: M,
+      placements: [{ uid: 'b', x: 0, y: 20, w: 12, h: 13 }],
+      compensated: true,
+      unlockedScale: 0.5,
+    };
+    // User resized b in render space to h=10 (differs from derived h=13).
+    const reported: Layout = [
+      { i: 'b', x: 0, y: 20, w: 12, h: 10 } as Layout[number],
+    ];
+    const out = reconcileReportedToStored(reported, derived, stored);
+    expect(out.find((x) => x.i === 'b')).toMatchObject({ h: 20 }); // 10 / 0.5
+  });
+});

--- a/zeus-web/src/layout/lockedWorkspaceLayout.ts
+++ b/zeus-web/src/layout/lockedWorkspaceLayout.ts
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF) and contributors.
+//
+// Locked-tile size preservation for the FlexWorkspace grid.
+//
+// The workspace never scrolls: a single uniform `rowHeight` shrinks every tile
+// so the whole layout fits the viewport. That shrink also rescales LOCKED
+// tiles, which operators expect to stay put at their exact authored size.
+//
+// A single uniform rowHeight cannot hold one tile fixed while shrinking others,
+// so when a tile is locked AND the layout would overflow, we instead pin
+// rowHeight at the authored value (locked tiles render at exactly h × authored
+// px, invariant to the workspace getting longer/shorter) and shrink only the
+// UNLOCKED tiles' grid heights, recompacting around the static locked tiles.
+//
+// The result is a RENDER layout. The stored layout is never mutated here; the
+// component reconciles RGL's echo of this derived layout back to stored
+// coordinates so the shrunken render geometry is never persisted
+// (reconcileReportedToStored). When nothing is compensated the derived layout
+// equals the stored layout and the whole path is a no-op.
+
+import { compactMagnetUp } from './workspaceGrid';
+import type { Layout } from 'react-grid-layout';
+
+/** Minimal tile shape the solver needs. `h` should already be clamped to the
+ *  panel's maxH (the caller clamps w/h for RGL); `minH` is the panel's
+ *  legibility floor. `locked` folds in the workspace-level lock. */
+export interface DeriveTile {
+  uid: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  locked: boolean;
+  minH: number;
+}
+
+export interface RenderPlacement {
+  uid: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface DerivedWorkspaceLayout {
+  /** Live grid rowHeight to hand RGL. */
+  rowHeight: number;
+  /** Live grid vertical margin to hand RGL. */
+  rowMargin: number;
+  /** Per-tile render placement (same order as input). */
+  placements: RenderPlacement[];
+  /** True when unlocked tiles were shrunk to keep locked tiles authored-size. */
+  compensated: boolean;
+  /** Uniform scale applied to unlocked tile heights (1 = untouched). */
+  unlockedScale: number;
+}
+
+export interface DeriveOptions {
+  containerHeight: number;
+  /** Authored (maximum) row height in px — the size locked tiles are held at. */
+  authoredRowHeightPx: number;
+  /** Authored vertical grid margin in px. */
+  gridMarginPx: number;
+  /** Denominator share used to shrink the row gap on dense layouts. */
+  rowGapShare: number;
+  /** Baseline target rows the uniform shrink divides into. */
+  targetRows: number;
+  /** Hard floor for a shrunk rowHeight (matches FlexWorkspace's Math.max). */
+  minRowHeightPx: number;
+}
+
+function passthrough(t: DeriveTile): RenderPlacement {
+  return { uid: t.uid, x: t.x, y: t.y, w: t.w, h: t.h };
+}
+
+function maxBottomOf(tiles: readonly { y: number; h: number }[]): number {
+  return tiles.reduce((mx, t) => Math.max(mx, t.y + t.h), 0);
+}
+
+/** Mirror of FlexWorkspace's rowMargin calc so the uniform fallback matches the
+ *  legacy behaviour exactly. */
+function uniformRowMargin(
+  containerHeight: number,
+  targetRows: number,
+  gridMarginPx: number,
+  rowGapShare: number,
+): number {
+  if (containerHeight <= 0 || targetRows <= 1) return gridMarginPx;
+  return Math.min(gridMarginPx, containerHeight / (targetRows * rowGapShare));
+}
+
+/** Mirror of FlexWorkspace's rowHeight calc (containerPadding = 0). */
+function uniformRowHeight(
+  containerHeight: number,
+  targetRows: number,
+  rowMargin: number,
+  authoredRowHeightPx: number,
+  minRowHeightPx: number,
+): number {
+  if (containerHeight <= 0) return authoredRowHeightPx;
+  const inner = containerHeight - rowMargin * Math.max(0, targetRows - 1);
+  return Math.min(
+    authoredRowHeightPx,
+    Math.max(minRowHeightPx, inner / Math.max(1, targetRows)),
+  );
+}
+
+function uniformResult(
+  tiles: DeriveTile[],
+  layoutRows: number,
+  opts: DeriveOptions,
+): DerivedWorkspaceLayout {
+  const targetRows = Math.max(layoutRows, opts.targetRows);
+  const rowMargin = uniformRowMargin(
+    opts.containerHeight,
+    targetRows,
+    opts.gridMarginPx,
+    opts.rowGapShare,
+  );
+  const rowHeight = uniformRowHeight(
+    opts.containerHeight,
+    targetRows,
+    rowMargin,
+    opts.authoredRowHeightPx,
+    opts.minRowHeightPx,
+  );
+  return {
+    rowHeight,
+    rowMargin,
+    placements: tiles.map(passthrough),
+    compensated: false,
+    unlockedScale: 1,
+  };
+}
+
+/** Render the layout with unlocked tile heights scaled by `scale`, recompacted
+ *  so unlocked tiles magnet up around the static (locked) tiles. */
+function renderAtScale(
+  tiles: DeriveTile[],
+  scale: number,
+): { placements: RenderPlacement[]; maxBottom: number } {
+  const items: Layout = tiles.map((t) => ({
+    i: t.uid,
+    x: t.x,
+    y: t.y,
+    w: t.w,
+    h: t.locked
+      ? t.h
+      : Math.max(t.minH, Math.min(t.h, Math.round(t.h * scale))),
+    static: t.locked,
+    moved: false,
+  }));
+  const compacted = compactMagnetUp(items);
+  return {
+    placements: compacted.map((it) => ({
+      uid: it.i,
+      x: it.x,
+      y: it.y,
+      w: it.w,
+      h: it.h,
+    })),
+    maxBottom: maxBottomOf(compacted),
+  };
+}
+
+/** Find the largest unlocked-height scale that keeps the compacted layout
+ *  within `fitRows`. Returns null when even the minimum heights overflow
+ *  (locked tiles alone exceed the viewport). */
+function fitUnlockedToRows(
+  tiles: DeriveTile[],
+  fitRows: number,
+): { placements: RenderPlacement[]; scale: number } | null {
+  const full = renderAtScale(tiles, 1);
+  if (full.maxBottom <= fitRows) {
+    return { placements: full.placements, scale: 1 };
+  }
+
+  // Binary-search the largest scale in (0, 1) that fits. 24 iterations resolves
+  // far finer than the 1-row grid quantisation.
+  let lo = 0;
+  let hi = 1;
+  let best: { placements: RenderPlacement[]; scale: number } | null = null;
+  for (let i = 0; i < 24; i += 1) {
+    const mid = (lo + hi) / 2;
+    const r = renderAtScale(tiles, mid);
+    if (r.maxBottom <= fitRows) {
+      best = { placements: r.placements, scale: mid };
+      lo = mid;
+    } else {
+      hi = mid;
+    }
+  }
+  if (best) return best;
+
+  // Floor: every unlocked tile at its minH. If that still overflows, the locked
+  // tiles themselves don't fit — caller falls back to a uniform shrink.
+  const floor = renderAtScale(tiles, 0);
+  if (floor.maxBottom <= fitRows) {
+    return { placements: floor.placements, scale: 0 };
+  }
+  return null;
+}
+
+/**
+ * Compute the workspace render layout. When a tile is locked and the layout
+ * would overflow, locked tiles are held at authored size (rowHeight pinned) and
+ * unlocked tiles shrink to fit. Otherwise this reproduces the legacy uniform
+ * shrink-to-fit exactly.
+ */
+export function deriveWorkspaceLayout(
+  tiles: DeriveTile[],
+  opts: DeriveOptions,
+): DerivedWorkspaceLayout {
+  const layoutRows = maxBottomOf(tiles);
+  const anyLocked = tiles.some((t) => t.locked);
+  const anyUnlocked = tiles.some((t) => !t.locked);
+
+  // Nothing locked, no measurable container, or every tile locked (no unlocked
+  // tile can absorb the slack) → legacy uniform behaviour.
+  if (!anyLocked || !anyUnlocked || opts.containerHeight <= 0) {
+    return uniformResult(tiles, layoutRows, opts);
+  }
+
+  const { authoredRowHeightPx: R, gridMarginPx: m } = opts;
+  const fitRows = Math.floor((opts.containerHeight + m) / (R + m));
+  if (fitRows <= 0) {
+    return uniformResult(tiles, layoutRows, opts);
+  }
+
+  // Already fits at authored density → render as stored at the authored
+  // rowHeight. Locked tiles are exactly h × R px; spare height stays at the
+  // bottom (matching the sparse-layout behaviour the workspace already has).
+  if (layoutRows <= fitRows) {
+    return {
+      rowHeight: R,
+      rowMargin: m,
+      placements: tiles.map(passthrough),
+      compensated: false,
+      unlockedScale: 1,
+    };
+  }
+
+  // Overflow: shrink unlocked tiles to fit while locked tiles stay authored.
+  const fitted = fitUnlockedToRows(tiles, fitRows);
+  if (fitted) {
+    return {
+      rowHeight: R,
+      rowMargin: m,
+      placements: fitted.placements,
+      compensated: fitted.scale < 1,
+      unlockedScale: fitted.scale,
+    };
+  }
+
+  // Locked tiles alone overflow the viewport — unavoidable corner. Fall back to
+  // the uniform shrink (locked tiles shrink too) rather than show a scrollbar.
+  return uniformResult(tiles, layoutRows, opts);
+}
+
+/**
+ * Reconcile the layout RGL reports back into stored coordinates so the shrunken
+ * render geometry is never persisted.
+ *
+ * - Not compensated: render == stored, pass the report through untouched
+ *   (byte-identical to the legacy persistence path).
+ * - Compensated echo (report matches what we fed RGL): restore the tile's
+ *   stored geometry so the store diff sees no change.
+ * - Compensated genuine edit (report diverges from the derived layout):
+ *   keep the horizontal placement, un-scale the height back toward stored
+ *   density so a drag/resize during a shrink doesn't persist a shrunken size.
+ */
+export function reconcileReportedToStored(
+  reported: Layout,
+  derived: DerivedWorkspaceLayout,
+  storedByUid: Map<string, { x: number; y: number; w: number; h: number }>,
+): Layout {
+  if (!derived.compensated) return reported;
+  const derivedByUid = new Map(derived.placements.map((p) => [p.uid, p]));
+  return reported.map((item) => {
+    const stored = storedByUid.get(item.i);
+    const d = derivedByUid.get(item.i);
+    if (!stored) return item;
+    if (
+      d &&
+      item.x === d.x &&
+      item.y === d.y &&
+      item.w === d.w &&
+      item.h === d.h
+    ) {
+      // Pure echo of the derived layout → persist stored geometry (no change).
+      return { ...item, x: stored.x, y: stored.y, w: stored.w, h: stored.h };
+    }
+    // Genuine edit while compensated. Horizontal passes through; un-scale the
+    // height so a shrunken render size is not written back.
+    const h =
+      derived.unlockedScale > 0
+        ? Math.max(1, Math.round(item.h / derived.unlockedScale))
+        : item.h;
+    return { ...item, h };
+  });
+}

--- a/zeus-web/src/layout/workspaceGrid.test.ts
+++ b/zeus-web/src/layout/workspaceGrid.test.ts
@@ -208,6 +208,53 @@ describe('workspace grid collision policy', () => {
     expectNoCollisions(boundary);
   });
 
+  // Drive the live-drag compactor with a hand-placed dragged tile so the
+  // vertical overlap with `below` (original slot y=10, h=10) is exact:
+  // overlap = (dy + 10) - 10 = dy rows for the dragged tile at y = dy.
+  // (moveElement would resolve the collision and snap the tile fully onto the
+  // neighbour, so it can't express a partial overlap.)
+  function makeSwapStepper() {
+    const base: Layout = cloneLayout([
+      { i: 'dragged', x: 0, y: 0, w: 6, h: 10 },
+      { i: 'below', x: 0, y: 10, w: 6, h: 10 },
+    ]);
+    const dragStart = { item: { ...base[0]! }, layout: cloneLayout(base) };
+    const compactor = createWorkspaceDragCompactor(() => dragStart);
+    return (dy: number) =>
+      compactor.compact(
+        cloneLayout([
+          { i: 'dragged', x: 0, y: dy, w: 6, h: 10, moved: true },
+          { i: 'below', x: 0, y: 10, w: 6, h: 10 },
+        ]),
+        24,
+      );
+  }
+
+  it('waits for the midpoint before swapping a tall neighbour', () => {
+    // Premium reorder feel: a neighbour only commits to swapping once the
+    // dragged tile has covered half of it, not on the first row of contact.
+    // Two h=10 tiles → engage threshold is 5 rows of overlap.
+    const step = makeSwapStepper();
+
+    // 4 rows of overlap (< 5): no swap. `below` is pushed down under the
+    // floating dragged tile, not lifted into the vacated top row.
+    expect(step(4).find((i) => i.i === 'below')?.y).not.toBe(0);
+    // 5 rows (the midpoint): the swap commits and `below` lifts into the top
+    // row the dragged tile is vacating.
+    expect(step(5).find((i) => i.i === 'below')?.y).toBe(0);
+  });
+
+  it('holds a committed swap through the hysteresis deadband', () => {
+    // Once engaged at the midpoint (50%), the swap holds until the dragged tile
+    // is pulled back past a quarter overlap (25%). h=10 tiles → engage at 5
+    // rows, release below 2.5 rows.
+    const step = makeSwapStepper();
+
+    expect(step(5).find((i) => i.i === 'below')).toMatchObject({ y: 0 }); // engage
+    expect(step(3).find((i) => i.i === 'below')?.y).toBe(0); // deadband: held
+    expect(step(2).find((i) => i.i === 'below')?.y).not.toBe(0); // released
+  });
+
   it('never moves a locked panel when another panel is dragged onto it', () => {
     // A locked (static) panel must stay pinned even while another panel is
     // dragged across it — previously the magnetic swap shoved it aside mid-drag

--- a/zeus-web/src/layout/workspaceGrid.ts
+++ b/zeus-web/src/layout/workspaceGrid.ts
@@ -592,14 +592,37 @@ function collides(a: LayoutItem, b: LayoutItem) {
   return true;
 }
 
-// Hysteresis thresholds for the live magnetic swap (grid rows). A neighbour
-// engages once the dragged tile overlaps it by at least ENGAGE rows, and only
-// disengages once they are separated by more than RELEASE rows (a strict gap).
-// The band between them — the touch boundary, where RGL's grid-rounding jitters
-// the dragged tile by a single row — is a deadband: a neighbour that is already
-// committed stays committed across it, so the swap can't flicker on and off.
-const SWAP_ENGAGE_ROWS = 1;
-const SWAP_RELEASE_ROWS = 0;
+// Hysteresis thresholds for the live magnetic swap, expressed as a fraction of
+// the SMALLER of the two tiles' heights so the feel scales with panel size.
+//
+// ENGAGE at the midpoint (50%): a neighbour only commits to swapping once the
+// dragged tile has clearly taken its slot — covered half of it — rather than
+// flipping on the first row of contact. On the real workspace, where panels run
+// 8–38 rows tall, a fixed 1-row trigger fired almost on touch and read as
+// twitchy; a midpoint trigger reads as deliberate, the premium reorder feel.
+//
+// RELEASE lower (25%): a committed swap holds until the dragged tile is pulled
+// back past a quarter overlap. The band between 25% and 50% is the deadband
+// that kills the boundary flicker (RGL's grid-rounding jitters the dragged tile
+// by a row at the touch line; a committed neighbour rides across it unmoved).
+//
+// A 1-row floor keeps 1–2 row control tiles snapping sanely instead of needing
+// a sub-row overlap the integer grid can never express.
+const SWAP_ENGAGE_FRACTION = 0.5;
+const SWAP_RELEASE_FRACTION = 0.25;
+const SWAP_MIN_ENGAGE_ROWS = 1;
+
+// Engage / release overlap (in grid rows) for one dragged↔neighbour pair.
+function swapThresholdRows(
+  anchor: LayoutItem,
+  neighbor: LayoutItem,
+): { engage: number; release: number } {
+  const span = Math.max(1, Math.min(anchor.h, neighbor.h));
+  return {
+    engage: Math.max(SWAP_MIN_ENGAGE_ROWS, span * SWAP_ENGAGE_FRACTION),
+    release: span * SWAP_RELEASE_FRACTION,
+  };
+}
 
 // Signed vertical overlap between the dragged anchor and a neighbour, in rows:
 // positive when they overlap, zero when edges touch, negative (a gap) when they
@@ -625,9 +648,10 @@ function updateSwapEngagement(
   engaged: Set<string>,
 ): boolean {
   const overlap = verticalOverlapRows(anchor, previous);
+  const { engage, release } = swapThresholdRows(anchor, previous);
   if (engaged.has(id)) {
-    if (overlap < SWAP_RELEASE_ROWS) engaged.delete(id);
-  } else if (overlap >= SWAP_ENGAGE_ROWS) {
+    if (overlap < release) engaged.delete(id);
+  } else if (overlap >= engage) {
     engaged.add(id);
   }
   return engaged.has(id);

--- a/zeus-web/src/layout/workspaceGrid.ts
+++ b/zeus-web/src/layout/workspaceGrid.ts
@@ -281,7 +281,7 @@ function layoutFromDragStart(
   return next;
 }
 
-function compactMagnetUp(
+export function compactMagnetUp(
   layout: Layout,
   priorityId?: string,
   preservePriority = false,


### PR DESCRIPTION
Workspace refinement: two related changes to how panels size and reorder.

## 1. Locked panels keep their exact size when the workspace grows/shrinks
A single uniform grid `rowHeight` shrinks every tile so the workspace fits the viewport without scrolling. That shrink also rescaled **locked** tiles, so a panel an operator had pinned still changed size whenever the workspace got longer or shorter (panels added/removed/rearranged).

`deriveWorkspaceLayout` (`lockedWorkspaceLayout.ts`) now owns the fit:
- When a tile is locked **and** the layout would overflow, it pins `rowHeight` at the authored height — so locked tiles render at exactly `h × authored px`, **invariant** to workspace length — and shrinks only the **unlocked** tiles to fit, recompacting around the static locked tiles.
- Reuses `compactMagnetUp`, whose output is a fixed point of RGL's passive push-down compactor, so the derived layout never triggers a persistence loop.
- The derived layout is **render-only**; the stored layout is never mutated. `reconcileReportedToStored` maps RGL's echo of the shrunk geometry back to stored coords before persistence. With nothing locked, the whole path reproduces the legacy uniform shrink byte-for-byte.

Behavior decided with maintainer: **unlocked panels absorb the slack** (no scroll), **height only** (width is column-stable for a given window width).

## 2. Panel swaps commit at the midpoint, not on first contact
The live magnetic swap engaged after a single row of overlap — on tall panels that fired almost on touch (twitchy). Now the engage/release thresholds are a fraction of the smaller tile's height: **engage at 50%, release at 25%** (deadband still absorbs RGL row-jitter so committed swaps don't flicker). Tuning is two constants for quick feel adjustments.

> Note: this grid is `allowOverlap: false`, so a true "float-over then swap" isn't possible without reworking the collision model — the neighbor must physically shift. Swap *timing* is the lever. **Final feel still pending hands-on review** (hence draft).

## Tests
- `lockedWorkspaceLayout.test.ts`: pixel-height invariance across a growing/shrinking workspace, unlocked shrink with minH floors, all-locked fallback, reconcile echo/edit paths.
- `workspaceGrid.test.ts`: tall-neighbour waits for the midpoint; committed swap holds through the deadband. All pre-existing drag/drop/lock invariants stay green.

Typecheck + lint clean.