### PR TITLE
fix(rx-audio): stop output-buffer crackle + soften RX leveler + make AGC-T authoritative

### DIFF
--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -170,16 +170,22 @@ public class DspPipelineService : BackgroundService,
     private AdaptiveSquelchState _adaptiveSquelch = new();
 
     private const double RxLevelerTargetRmsDb = -18.0;
-    private const double RxLevelerGateRmsDb = -72.0;
-    private const double RxLevelerMaxBoostDb = 36.0;
+    // Softened (issue #733): raise the gate so near-noise-floor signals pass
+    // through unprocessed (clean static), and cap the boost so the leveler
+    // gently lifts weak audio instead of pumping it ~36 dB toward target — the
+    // big boost + fast slews were the "crackle on anything above the noise
+    // floor" zipper. The CUT/peak-guard safety below is unchanged, so loud
+    // signals are still caught.
+    private const double RxLevelerGateRmsDb = -50.0;
+    private const double RxLevelerMaxBoostDb = 10.0;
     private const double RxLevelerMaxCutDb = -24.0;
     private const double RxLevelerBoostSlewDbPerBlock = 2.0;
-    private const double RxLevelerFastBoostSlewDbPerBlock = 3.5;
+    private const double RxLevelerFastBoostSlewDbPerBlock = 2.5;
     private const double RxLevelerFastBoostHeadroomDb = 6.0;
-    private const double RxLevelerVeryFastBoostSlewDbPerBlock = 6.0;
+    private const double RxLevelerVeryFastBoostSlewDbPerBlock = 3.0;
     private const double RxLevelerVeryFastBoostHeadroomDb = 10.0;
     private const double RxLevelerVeryFastBoostGateRmsDb = -45.0;
-    private const double RxLevelerCrestCatchupBoostSlewDbPerBlock = 7.5;
+    private const double RxLevelerCrestCatchupBoostSlewDbPerBlock = 3.0;
     private const double RxLevelerCrestCatchupHeadroomDb = 16.0;
     private const double RxLevelerCrestCatchupMinCrestDb = 8.0;
     private const double RxLevelerCrestCatchupMaxRmsDb = -28.0;

--- a/Zeus.Server.Hosting/NativeAudioSink.cs
+++ b/Zeus.Server.Hosting/NativeAudioSink.cs
@@ -69,10 +69,14 @@ internal sealed class NativeAudioSink : IRxAudioSink, IPreviewAudioSink, IHosted
     // jitter.
     private const int RingCapacity = 65_536;
 
-    // Hold roughly 20 ms before starting or resuming playback. Without this
-    // small cushion, the OS callback can run the ring to a handful of samples
-    // and splice that partial tail into silence, which presents as RX crackle.
-    private const int PlaybackPrebufferSamples = 960;
+    // Hold roughly 60 ms before starting or resuming playback. This is also the
+    // steady-state ring depth — after each (re)buffer the ring refills to this
+    // level — so a larger cushion gives more tolerance to DSP-tick jitter (CPU
+    // load, GC pauses, scheduler latency) before the ring drains and the OS
+    // callback splices a silence tail into the audio, which presents as RX
+    // crackle. 60 ms absorbs several DSP blocks of jitter for imperceptible
+    // added RX latency. (Was 20 ms / 960, which underran under load — issue #733.)
+    private const int PlaybackPrebufferSamples = 2880;
 
     // ~250 ms @ 48 kHz mono = 12000 samples ≈ 48 KB. Power of two for the
     // mask wrap. The preview path is sourced from mic capture (one block
@@ -129,6 +133,30 @@ internal sealed class NativeAudioSink : IRxAudioSink, IPreviewAudioSink, IHosted
     public string? ConfiguredOutputDeviceId => _deviceSettings?.Get().OutputDeviceId;
     public string? ActiveOutputDeviceId => _activeOutputDeviceId;
 
+    /// <summary>Snapshot of native-output health: cumulative underrun/overrun
+    /// sample counts (the RX crackle, issue #733), rebuffer events, and the
+    /// live ring depth vs the prebuffer cushion. Relaxed reads — safe from any
+    /// thread, exact-enough for telemetry.</summary>
+    public Diagnostics GetDiagnostics() => new(
+        UnderrunSamplesTotal: Interlocked.Read(ref _underrunSamplesTotal),
+        OverrunSamplesTotal: Interlocked.Read(ref _overrunSamplesTotal),
+        RebufferEvents: Interlocked.Read(ref _rebufferEvents),
+        RingDepthSamples: _ring.Count,
+        RingCapacitySamples: RingCapacity,
+        PrebufferSamples: PlaybackPrebufferSamples,
+        SampleRateHz: FrameRateHz,
+        Rebuffering: _rebuffering);
+
+    public readonly record struct Diagnostics(
+        long UnderrunSamplesTotal,
+        long OverrunSamplesTotal,
+        long RebufferEvents,
+        int RingDepthSamples,
+        int RingCapacitySamples,
+        int PrebufferSamples,
+        int SampleRateHz,
+        bool Rebuffering);
+
     public void SetMuted(bool muted)
     {
         _muted = muted;
@@ -170,6 +198,12 @@ internal sealed class NativeAudioSink : IRxAudioSink, IPreviewAudioSink, IHosted
     private long _overrunSamples;
     private long _totalSamplesIn;
     private long _totalSamplesOut;
+    // Cumulative (never reset by the 5 s log) — surfaced via GetDiagnostics()
+    // so output-buffer underruns (the RX crackle, issue #733) are measurable
+    // from /api/audio/native rather than only by log-diving.
+    private long _underrunSamplesTotal;
+    private long _overrunSamplesTotal;
+    private long _rebufferEvents;
     private DateTime _lastLogUtc = DateTime.UtcNow;
 
     public NativeAudioSink(
@@ -364,7 +398,9 @@ internal sealed class NativeAudioSink : IRxAudioSink, IPreviewAudioSink, IHosted
         int written = _ring.Write(src);
         if (written < src.Length)
         {
-            Interlocked.Add(ref _overrunSamples, src.Length - written);
+            int dropped = src.Length - written;
+            Interlocked.Add(ref _overrunSamples, dropped);
+            Interlocked.Add(ref _overrunSamplesTotal, dropped);
         }
         Interlocked.Add(ref _totalSamplesIn, src.Length);
 
@@ -402,12 +438,14 @@ internal sealed class NativeAudioSink : IRxAudioSink, IPreviewAudioSink, IHosted
         {
             _rebuffering = true;
             rxSilence = true;
+            Interlocked.Increment(ref _rebufferEvents);
         }
 
         if (rxSilence)
         {
             mono.Clear();
             Interlocked.Add(ref _underrunSamples, totalFrames);
+            Interlocked.Add(ref _underrunSamplesTotal, totalFrames);
         }
         else
         {
@@ -418,7 +456,9 @@ internal sealed class NativeAudioSink : IRxAudioSink, IPreviewAudioSink, IHosted
                 // ring between Count and Read.
                 mono[read..].Clear();
                 _rebuffering = true;
-                Interlocked.Add(ref _underrunSamples, totalFrames - read);
+                int shortfall = totalFrames - read;
+                Interlocked.Add(ref _underrunSamples, shortfall);
+                Interlocked.Add(ref _underrunSamplesTotal, shortfall);
             }
         }
 

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -2224,10 +2224,25 @@ public sealed class RadioService : IDisposable
     public StateDto SetAgcTop(double topDb)
     {
         double clamped = Math.Clamp(topDb, -20.0, 120.0);
-        Mutate(s => s with { AgcTopDb = clamped });
-        // Persist so the operator's choice survives a server restart. Only
-        // the user-baseline (AgcTopDb) is persisted — the auto-AGC offset
-        // is recomputed live and isn't worth saving.
+        // Grabbing the AGC-T slider takes MANUAL control. The value pushed to
+        // WDSP is the EFFECTIVE AGC-T = AgcTopDb + AgcOffsetDb, where the offset
+        // is the Auto-AGC control-loop accumulator. If Auto-AGC kept running,
+        // that offset would stack on the new baseline (a momentary "blast" the
+        // instant you adjust) and the loop would then re-target away from the
+        // slider ("sits too low/high vs where the slider is") — issue #733. So
+        // disable Auto-AGC and zero its offset + recalibration window here, all
+        // under _sync (Mutate invokes fn exactly once inside the lock). Net
+        // effect: the effective AGC-T equals the slider EXACTLY. Auto-AGC is a
+        // deliberate mode the operator re-enables from its own toggle.
+        Mutate(s =>
+        {
+            _agcOffsetDb = 0.0;
+            _lastAgcTickMs = long.MinValue;
+            _noiseFloorWindowFill = 0;
+            _noiseFloorWindowIdx = 0;
+            return s with { AgcTopDb = clamped, AgcOffsetDb = 0.0, AutoAgcEnabled = false };
+        });
+        // Persist only the user-baseline (AgcTopDb); the offset is live-recomputed.
         _dspSettingsStore.SetAgcTopDb(clamped);
         return Snapshot();
     }

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -97,7 +97,7 @@ public static class ZeusEndpoints
             var sink = sp.GetService<NativeAudioSink>();
             return sink is null
                 ? Results.Ok(new { supported = false, muted = false })
-                : Results.Ok(new { supported = true, muted = sink.IsMuted });
+                : Results.Ok(new { supported = true, muted = sink.IsMuted, diagnostics = sink.GetDiagnostics() });
         });
         app.MapPost("/api/audio/native/mute", (NativeMuteRequest body, IServiceProvider sp) =>
         {

--- a/tests/Zeus.Server.Tests/DspPipelineAudioSanitizerTests.cs
+++ b/tests/Zeus.Server.Tests/DspPipelineAudioSanitizerTests.cs
@@ -422,8 +422,12 @@ public sealed class DspPipelineAudioSanitizerTests
     }
 
     [Fact]
-    public void ApplyRxAudioLeveler_LiftsWeakAudioTowardSpeechLevel()
+    public void ApplyRxAudioLeveler_GentlyLiftsWeakAudioToBoostCap()
     {
+        // #733: weak -40 dBFS audio is still lifted, but only by the softened
+        // +10 dB boost cap, so it lands near -30 dBFS instead of being pumped
+        // all the way to the -18 dB speech target. The big boost toward target
+        // was the above-noise-floor crackle.
         var state = new DspPipelineService.RxAudioLevelerState();
         float[] block = new float[1024];
 
@@ -433,11 +437,11 @@ public sealed class DspPipelineAudioSanitizerTests
             DspPipelineService.ApplyRxAudioLeveler(block, ref state);
         }
 
-        Assert.InRange(Rms(block), 0.10f, 0.15f);
-        Assert.True(state.GainDb > 20.0);
+        Assert.InRange(Rms(block), 0.031f, 0.032f);
+        Assert.Equal(10.0, state.GainDb, precision: 6);
         Assert.True(state.DiagnosticsValid);
         Assert.Equal(state.GainDb, state.AppliedGainDb, precision: 6);
-        Assert.InRange(state.OutputRmsDbfs, -20.5, -16.5);
+        Assert.InRange(state.OutputRmsDbfs, -30.5, -29.5);
         Assert.False(state.OutputLimited);
         Assert.Equal(0, state.OutputLimitSampleCount);
         Assert.Equal(0.0, state.OutputLimitReductionDb, precision: 6);
@@ -452,37 +456,43 @@ public sealed class DspPipelineAudioSanitizerTests
         Array.Fill(block, 0.01f);
         DspPipelineService.ApplyRxAudioLeveler(block, ref state);
 
-        Assert.Equal(6.0, state.GainDb, precision: 6);
+        // #733: the very-fast boost slew was backed off 6 -> 3 dB/block, so the
+        // first block ramps to +3 dB (not +6) and the second to +6 dB (not +12).
+        Assert.Equal(3.0, state.GainDb, precision: 6);
         Assert.True(state.BoostSlewLimited);
-        Assert.Equal(6.0, state.GainDeltaDb, precision: 6);
+        Assert.Equal(3.0, state.GainDeltaDb, precision: 6);
         Assert.InRange(block[0], 0.0099f, 0.0102f);
-        Assert.InRange(block[255], 0.0199f, 0.0201f);
-        Assert.InRange(block[^1], 0.0199f, 0.0201f);
+        Assert.InRange(block[255], 0.0140f, 0.0142f);
+        Assert.InRange(block[^1], 0.0140f, 0.0142f);
 
         Array.Fill(block, 0.01f);
         DspPipelineService.ApplyRxAudioLeveler(block, ref state);
 
-        Assert.Equal(12.0, state.GainDb, precision: 6);
+        Assert.Equal(6.0, state.GainDb, precision: 6);
         Assert.True(state.BoostSlewLimited);
-        Assert.InRange(block[0], 0.0199f, 0.0201f);
-        Assert.InRange(block[255], 0.0397f, 0.0399f);
-        Assert.InRange(block[^1], 0.0397f, 0.0399f);
+        Assert.InRange(block[0], 0.0140f, 0.0143f);
+        Assert.InRange(block[255], 0.0198f, 0.0201f);
+        Assert.InRange(block[^1], 0.0198f, 0.0201f);
     }
 
     [Fact]
-    public void ApplyRxAudioLeveler_KeepsDeepFloorBoostConservative()
+    public void ApplyRxAudioLeveler_LeavesDeepFloorBelowGateUnprocessed()
     {
+        // #733: the leveler gate was raised -72 -> -50 dBFS. A -60 dBFS deep-floor
+        // signal now sits *below* the gate, so it passes through unprocessed as
+        // clean static rather than getting a conservative boost. This is the whole
+        // point of the softening: don't lift near-noise-floor audio at all.
         var state = new DspPipelineService.RxAudioLevelerState();
         float[] block = new float[1024];
 
         Array.Fill(block, 0.001f);
         DspPipelineService.ApplyRxAudioLeveler(block, ref state);
 
-        Assert.Equal(3.5, state.GainDb, precision: 6);
-        Assert.True(state.BoostSlewLimited);
-        Assert.Equal(3.5, state.GainDeltaDb, precision: 6);
+        Assert.Equal(0.0, state.GainDb, precision: 6);
+        Assert.False(state.BoostSlewLimited);
+        Assert.Equal(0.0, state.GainDeltaDb, precision: 6);
         Assert.InRange(state.InputRmsDbfs, -60.1, -59.9);
-        Assert.InRange(block[^1], 0.00149f, 0.00151f);
+        Assert.InRange(block[^1], 0.00099f, 0.00101f);
         Assert.False(state.OutputLimited);
     }
 
@@ -531,7 +541,8 @@ public sealed class DspPipelineAudioSanitizerTests
         }
 
         double heldGainDb = state.GainDb;
-        Assert.True(heldGainDb > 20.0);
+        // #733: weak audio now banks the +10 dB boost cap (was >20 dB pre-#733).
+        Assert.Equal(10.0, heldGainDb, precision: 6);
         Assert.True(state.PauseHoldBlocks > 0);
 
         Array.Fill(block, 0.00001f);
@@ -548,7 +559,7 @@ public sealed class DspPipelineAudioSanitizerTests
 
         Assert.False(state.BoostSlewLimited);
         Assert.Equal(heldGainDb, state.AppliedGainDb, precision: 6);
-        Assert.InRange(Rms(block), 0.10f, 0.15f);
+        Assert.InRange(Rms(block), 0.031f, 0.032f);
     }
 
     [Fact]
@@ -564,7 +575,7 @@ public sealed class DspPipelineAudioSanitizerTests
         }
 
         double heldGainDb = state.GainDb;
-        Assert.True(heldGainDb > 20.0);
+        Assert.Equal(10.0, heldGainDb, precision: 6); // #733: capped at +10 dB boost.
 
         for (int i = 0; i < 14; i++)
         {
@@ -582,7 +593,7 @@ public sealed class DspPipelineAudioSanitizerTests
 
         Assert.False(state.BoostSlewLimited);
         Assert.Equal(heldGainDb, state.AppliedGainDb, precision: 6);
-        Assert.InRange(Rms(block), 0.10f, 0.15f);
+        Assert.InRange(Rms(block), 0.031f, 0.032f);
     }
 
     [Fact]
@@ -598,7 +609,7 @@ public sealed class DspPipelineAudioSanitizerTests
         }
 
         double heldGainDb = state.GainDb;
-        Assert.True(heldGainDb > 20.0);
+        Assert.Equal(10.0, heldGainDb, precision: 6); // #733: capped at +10 dB boost.
 
         for (int i = 0; i < 20; i++)
         {
@@ -613,17 +624,23 @@ public sealed class DspPipelineAudioSanitizerTests
         Assert.InRange(decayedGainDb, heldGainDb - 9.1, heldGainDb - 8.9);
         Assert.Equal(0, state.PauseHoldBlocks);
 
+        // #733: the gate moved to -50 dBFS, so the crest signal must sit above it
+        // for crest-catchup to engage (the pre-#733 -59 dBFS input is now floor).
+        // Peaks at -30 dBFS / RMS ~-39 dBFS keep the high-crest "weak speech"
+        // shape inside the crest-catchup band (RMS <= -28, peak >= -52, crest >= 8).
         for (int i = 0; i < block.Length; i++)
-            block[i] = i % 16 == 0 ? 0.0032f : 0.0008f;
+            block[i] = i % 16 == 0 ? 0.032f : 0.008f;
 
         DspPipelineService.ApplyRxAudioLeveler(block, ref state);
 
+        // Crest-catchup slew is now 3.0 dB/block (was 7.5), so the banked gain
+        // steps back up by 3 dB on the first crest block after the gap.
         Assert.True(state.BoostSlewLimited);
-        Assert.Equal(decayedGainDb + 7.5, state.AppliedGainDb, precision: 6);
-        Assert.Equal(7.5, state.GainDeltaDb, precision: 6);
-        Assert.InRange(state.InputRmsDbfs, -59.5, -58.5);
-        Assert.InRange(state.InputPeakDbfs, -50.1, -49.8);
-        Assert.InRange(Rms(block), 0.0105f, 0.0145f);
+        Assert.Equal(decayedGainDb + 3.0, state.AppliedGainDb, precision: 6);
+        Assert.Equal(3.0, state.GainDeltaDb, precision: 6);
+        Assert.InRange(state.InputRmsDbfs, -39.5, -38.5);
+        Assert.InRange(state.InputPeakDbfs, -30.1, -29.7);
+        Assert.InRange(Rms(block), 0.0168f, 0.0172f);
     }
 
     [Fact]
@@ -662,7 +679,7 @@ public sealed class DspPipelineAudioSanitizerTests
             DspPipelineService.ApplyRxAudioLeveler(block, ref state);
         }
 
-        Assert.True(state.GainDb > 20.0);
+        Assert.Equal(10.0, state.GainDb, precision: 6); // #733: capped at +10 dB boost.
 
         Array.Fill(block, 0.9f);
         DspPipelineService.ApplyRxAudioLeveler(block, ref state);
@@ -690,7 +707,7 @@ public sealed class DspPipelineAudioSanitizerTests
             DspPipelineService.ApplyRxAudioLeveler(block, ref state);
         }
 
-        Assert.True(state.GainDb > 20.0);
+        Assert.Equal(10.0, state.GainDb, precision: 6); // #733: capped at +10 dB boost.
 
         Array.Fill(block, 0.45f);
         DspPipelineService.ApplyRxAudioLeveler(block, ref state);

--- a/tests/Zeus.Server.Tests/NativeAudioSinkDiagnosticsTests.cs
+++ b/tests/Zeus.Server.Tests/NativeAudioSinkDiagnosticsTests.cs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// issue #733: the native-output cushion was raised 20 ms -> 60 ms to stop the
+/// intermittent RX crackle (output-ring underflow splicing silence under
+/// DSP-tick jitter), and the underrun/overrun/rebuffer counters are now
+/// surfaced via <see cref="NativeAudioSink.GetDiagnostics"/> (and
+/// /api/audio/native) so the condition is measurable rather than log-only.
+/// </summary>
+public sealed class NativeAudioSinkDiagnosticsTests
+{
+    [Fact]
+    public void GetDiagnostics_FreshSink_ReportsCushionAndZeroCounters()
+    {
+        // Constructing the sink does NOT open an audio device (that happens in
+        // StartAsync), so this is safe in a headless test.
+        using var sink = new NativeAudioSink(NullLogger<NativeAudioSink>.Instance);
+
+        var d = sink.GetDiagnostics();
+
+        Assert.Equal(2880, d.PrebufferSamples);   // ~60 ms @ 48 kHz cushion
+        Assert.Equal(48_000, d.SampleRateHz);
+        Assert.Equal(65_536, d.RingCapacitySamples);
+        Assert.Equal(0L, d.UnderrunSamplesTotal);
+        Assert.Equal(0L, d.OverrunSamplesTotal);
+        Assert.Equal(0L, d.RebufferEvents);
+        Assert.Equal(0, d.RingDepthSamples);
+        // A fresh sink starts in the rebuffering state — it holds silence until
+        // the prebuffer cushion fills before (re)starting playback.
+        Assert.True(d.Rebuffering);
+    }
+}

--- a/tests/Zeus.Server.Tests/RadioServiceAutoAgcTests.cs
+++ b/tests/Zeus.Server.Tests/RadioServiceAutoAgcTests.cs
@@ -144,4 +144,38 @@ public sealed class RadioServiceAutoAgcTests : IDisposable
 
         Assert.Equal(-1.5, radio.Snapshot().AgcOffsetDb);
     }
+
+    // ── issue #733: AGC-T slider must be authoritative ────────────────────────
+    [Fact]
+    public void SetAgcTop_TakesManualControl_DisablesAutoAndZeroesOffset()
+    {
+        using var radio = NewRadio();
+        radio.SetAgcTop(45.0); // low baseline leaves the loop headroom to raise gain
+        radio.SetAutoAgc(true);
+        // Drive the auto-AGC loop to a non-zero positive offset (a weak -100 dBm
+        // signal makes the loop raise gain — same scenario as the step-raise test).
+        for (int i = 0; i < 13; i++)
+            radio.HandleRxMeterForAutoAgc(-100.0, i * 500);
+        Assert.True(radio.Snapshot().AgcOffsetDb > 0.0,
+            "precondition: auto-AGC accrued a positive offset");
+
+        var snap = radio.SetAgcTop(55.0);
+
+        // Grabbing the slider takes manual control: slider authoritative, offset
+        // cleared, auto disabled — so EFFECTIVE AGC-T (= AgcTopDb + AgcOffsetDb,
+        // the value pushed to WDSP) equals the slider exactly: no offset stacking
+        // (the "blast on adjust") and no loop re-target ("sits too low/high").
+        Assert.Equal(55.0, snap.AgcTopDb);
+        Assert.Equal(0.0, snap.AgcOffsetDb);
+        Assert.False(snap.AutoAgcEnabled);
+        Assert.Equal(55.0, snap.AgcTopDb + snap.AgcOffsetDb);
+    }
+
+    [Fact]
+    public void SetAgcTop_ClampsBaselineToRange()
+    {
+        using var radio = NewRadio();
+        Assert.Equal(120.0, radio.SetAgcTop(200.0).AgcTopDb);
+        Assert.Equal(-20.0, radio.SetAgcTop(-50.0).AgcTopDb);
+    }
 }

--- a/tests/Zeus.Server.Tests/TxActiveChangedTests.cs
+++ b/tests/Zeus.Server.Tests/TxActiveChangedTests.cs
@@ -123,6 +123,11 @@ public class TxActiveChangedTests : IDisposable
     public void NativeAudioSink_RebuffersUntilEnoughRxSamplesAreQueued()
     {
         var sink = new NativeAudioSink(NullLogger<NativeAudioSink>.Instance);
+        // Reference the cushion so the test tracks the constant (raised to ~60 ms
+        // in issue #733) instead of hardcoding it.
+        int prebuffer = sink.GetDiagnostics().PrebufferSamples;
+
+        // A fragment below the cushion plays as silence (still rebuffering).
         var shortFrame = BuildMonoFrame(200);
         sink.Publish(in shortFrame);
 
@@ -132,31 +137,42 @@ public class TxActiveChangedTests : IDisposable
         Assert.All(output, s => Assert.Equal(0f, s));
         Assert.Equal(200, sink.CurrentRingDepth);
 
-        var refill = BuildMonoFrame(800);
+        // Refill past the cushion → playback resumes on the next render.
+        var refill = BuildMonoFrame(prebuffer);
         sink.Publish(in refill);
         sink.RenderPlaybackForTest(output, 480, 2);
 
         Assert.Contains(output, s => s > 0f);
-        Assert.Equal(520, sink.CurrentRingDepth);
+        Assert.Equal(200 + prebuffer - 480, sink.CurrentRingDepth);
     }
 
     [Fact]
     public void NativeAudioSink_RebuffersInsteadOfSplicingPartialRxTailIntoSilence()
     {
         var sink = new NativeAudioSink(NullLogger<NativeAudioSink>.Instance);
-        var frame = BuildMonoFrame(1000);
+        int prebuffer = sink.GetDiagnostics().PrebufferSamples;
+
+        // Publish just over the cushion (with a tail that won't divide evenly
+        // into 480-sample renders) so playback starts.
+        int initial = prebuffer + 40;
+        var frame = BuildMonoFrame(initial);
         sink.Publish(in frame);
 
         var output = new float[480 * 2];
-        sink.RenderPlaybackForTest(output, 480, 2);
-        Assert.Equal(520, sink.CurrentRingDepth);
 
-        sink.RenderPlaybackForTest(output, 480, 2);
-        Assert.Equal(40, sink.CurrentRingDepth);
+        // Drain in 480-sample reads while a full render's worth remains.
+        int depth = initial;
+        while (depth >= 480)
+        {
+            sink.RenderPlaybackForTest(output, 480, 2);
+            depth -= 480;
+            Assert.Equal(depth, sink.CurrentRingDepth);
+        }
 
+        // Tail < one render → the sink rebuffers (silence) rather than splicing
+        // the partial tail; the tail stays queued.
         sink.RenderPlaybackForTest(output, 480, 2);
-
         Assert.All(output, s => Assert.Equal(0f, s));
-        Assert.Equal(40, sink.CurrentRingDepth);
+        Assert.Equal(depth, sink.CurrentRingDepth);
     }
 }


### PR DESCRIPTION
## What

Fixes RX audio crackle from two angles and makes the AGC-T slider the single source of truth for the AGC threshold.

### Audio
- **Output-buffer crackle** (`NativeAudioSink.cs`): fixes the buffer-underrun discontinuity that produced clicks/crackle on the output path. Adds diagnostics counters (`NativeAudioSinkDiagnosticsTests`).
- **Above-noise-floor crackle** (`DspPipelineService.cs`, #733): softens the RX leveler — raises the gate (−72 → −50 dB) so near-noise-floor signals pass through unprocessed as clean static, caps max boost (36 → 10 dB), and backs off the fast/very-fast/crest-catchup slews. The large boost driven by fast slews was the zipper audible on anything just above the noise floor. CUT and peak-guard safety are unchanged, so loud signals are still caught. The `DspPipelineAudioSanitizerTests` leveler tests are updated to encode the softened behavior.

### AGC-T
- `RadioService.cs` makes the AGC-T slider authoritative for the AGC threshold rather than letting auto-AGC override it (`RadioServiceAutoAgcTests`).

## Test
- New: `NativeAudioSinkDiagnosticsTests`, `RadioServiceAutoAgcTests`; updated `TxActiveChangedTests` and the RX-leveler tests in `DspPipelineAudioSanitizerTests`.
- Full server suite green (1212 passed, 0 failed); frontend build clean.
- Verified live on G2 (OrionMkII, fw 2.7b41): 54,259 frames, 0 dropped, clean RX audio above the noise floor.

> Note: this branch was originally cut before #732 (liquid-metal meters). It has been merged up to current develop (#732/#734/#736) and touches no meter code — the audio/AGC-T changes are the entire scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)