### PR TITLE
feat(settings): hide HARDWARE diagnostics folder behind brand-mark easter egg

### DIFF
--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -75,6 +75,7 @@ import { SmartNrController } from './components/SmartNrController';
 import { DspSceneDiagnosticsPublisher } from './components/DspSceneDiagnosticsPublisher';
 import { AudioPlaybackDiagnosticsPublisher } from './components/AudioPlaybackDiagnosticsPublisher';
 import { useTxAudioProfileDirtyTracker } from './state/tx-audio-profile-tracker';
+import { useEasterEggStore } from './state/easter-egg-store';
 import { ThemeApplier } from './components/ThemeApplier';
 import { StartupUpdatePrompt } from './components/StartupUpdatePrompt';
 import { StepFavorites } from './components/toolbar/StepFavorites';
@@ -198,6 +199,12 @@ export default function App() {
 
   const topbarControlsRef = useRef<HTMLDivElement | null>(null);
   const [topbarScroll, setTopbarScroll] = useState({ canLeft: false, canRight: false });
+
+  // Hidden HARDWARE diagnostics folder — easter egg. Tapping the brand-mark
+  // lightning bolt unlocks the folder for this session (it re-locks on the next
+  // launch; counting + threshold live in easter-egg-store). Deliberately exposes
+  // no hover, cursor, or title affordance so the bolt never advertises itself.
+  const registerBoltClick = useEasterEggStore((s) => s.registerBoltClick);
   const syncTopbarScroll = useCallback(() => {
     const el = topbarControlsRef.current;
     if (!el) return;
@@ -878,7 +885,11 @@ export default function App() {
                 className="brand-mark-wave brand-mark-wave--bottom"
                 d="M3.2 15.8c1.55 1.2 3.1 1.2 4.65 0l.75-.58c1.55-1.2 3.1-1.2 4.65 0l.75.58c1.55 1.2 3.1 1.2 4.65 0l1.15-.88"
               />
-              <path className="brand-mark-bolt" d="M13.4 2.5 7 12.1h4.15l-1.2 9.4L17 10.55h-4.25l.65-8.05Z" />
+              <path
+                className="brand-mark-bolt"
+                d="M13.4 2.5 7 12.1h4.15l-1.2 9.4L17 10.55h-4.25l.65-8.05Z"
+                onClick={registerBoltClick}
+              />
             </svg>
           </div>
           <div className="brand-text">

--- a/zeus-web/src/components/SettingsMenu.test.tsx
+++ b/zeus-web/src/components/SettingsMenu.test.tsx
@@ -10,6 +10,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import { SettingsView } from './SettingsMenu';
 import { useCapabilitiesStore } from '../state/capabilities-store';
 import { useRadioStore } from '../state/radio-store';
+import { useEasterEggStore } from '../state/easter-egg-store';
 import {
   UNKNOWN_BOARD_CAPABILITIES,
   type BoardCapabilities,
@@ -271,5 +272,66 @@ describe('SettingsView — RADIO tab gating', () => {
     expect(container.textContent).toContain('ANAN-G2 Options');
     expect(container.textContent).toContain('Dither Enabled');
     expect(container.textContent).toContain('Random Enabled');
+  });
+});
+
+describe('SettingsView — hidden HARDWARE folder (easter egg)', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    seed();
+    stubSettingsFetch();
+    // Default locked state — a fresh session never lists HARDWARE.
+    useEasterEggStore.setState({ hardwareUnlocked: false });
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.unstubAllGlobals();
+    useEasterEggStore.setState({ hardwareUnlocked: false });
+  });
+
+  it('hides the HARDWARE tab by default', async () => {
+    await act(async () => {
+      root.render(<SettingsView onClose={() => {}} />);
+      await flushEffects();
+    });
+    const tabs = Array.from(
+      container.querySelectorAll('[role="tablist"] button'),
+    ).map((b) => b.textContent?.trim() ?? '');
+    expect(tabs).not.toContain('HARDWARE');
+  });
+
+  it('bounces back to PA when opened on the locked HARDWARE tab', async () => {
+    await act(async () => {
+      root.render(<SettingsView onClose={() => {}} initialTab="hardware" />);
+      await flushEffects();
+    });
+    const tabs = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[role="tablist"] button'),
+    );
+    expect(tabs.map((b) => b.textContent?.trim() ?? '')).not.toContain('HARDWARE');
+    // PA is the fallback and becomes the active tab.
+    const pa = tabs.find((b) => b.textContent?.trim() === 'PA SETTINGS');
+    expect(pa?.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('shows the HARDWARE tab once unlocked', async () => {
+    useEasterEggStore.setState({ hardwareUnlocked: true });
+    await act(async () => {
+      root.render(<SettingsView onClose={() => {}} />);
+      await flushEffects();
+    });
+    const tabs = Array.from(
+      container.querySelectorAll('[role="tablist"] button'),
+    ).map((b) => b.textContent?.trim() ?? '');
+    expect(tabs).toContain('HARDWARE');
   });
 });

--- a/zeus-web/src/components/SettingsMenu.tsx
+++ b/zeus-web/src/components/SettingsMenu.tsx
@@ -33,6 +33,7 @@ import { TciSettingsPanel } from './TciSettingsPanel';
 import { RadioSelector } from './RadioSelector';
 import { usePaStore } from '../state/pa-store';
 import { useRadioStore } from '../state/radio-store';
+import { useEasterEggStore } from '../state/easter-egg-store';
 import { PsSettingsPanel } from './PsSettingsPanel';
 import { TxAudioToolsPanel } from './TxAudioToolsPanel';
 import { DspSettingsPanel } from './DspSettingsPanel';
@@ -107,9 +108,18 @@ export function SettingsView({ initialTab, onClose }: Props) {
     (s) => s.capabilities.supportsG2AdcOptions,
   );
   const hasRadioOptions = hasHl2OptionalToggles || supportsG2AdcOptions;
+  // HARDWARE is a hidden diagnostics folder — unlocked only via the header
+  // brand-mark easter egg (see easter-egg-store). It re-locks on every launch,
+  // so a fresh session never lists it.
+  const hardwareUnlocked = useEasterEggStore((s) => s.hardwareUnlocked);
   const visibleTabs = useMemo(
-    () => TABS.filter((t) => t.id !== 'radio' || hasRadioOptions),
-    [hasRadioOptions],
+    () =>
+      TABS.filter(
+        (t) =>
+          (t.id !== 'radio' || hasRadioOptions) &&
+          (t.id !== 'hardware' || hardwareUnlocked),
+      ),
+    [hasRadioOptions, hardwareUnlocked],
   );
 
   // If the operator was sitting on the RADIO tab and the board changed
@@ -120,6 +130,13 @@ export function SettingsView({ initialTab, onClose }: Props) {
       setActive('pa');
     }
   }, [active, hasRadioOptions]);
+
+  // Effective tab for rendering. If the stored `active` tab isn't currently
+  // visible — a hidden HARDWARE folder, or RADIO opened via initialTab without
+  // board options — fall back to PA so the operator never lands on a hidden
+  // tabpanel. Deriving this (rather than bouncing in an effect) avoids racing
+  // the initialTab effect, which could otherwise re-select a hidden tab.
+  const activeTab = visibleTabs.some((t) => t.id === active) ? active : 'pa';
 
   useEffect(() => {
     if (initialTab) setActive(initialTab);
@@ -169,7 +186,7 @@ export function SettingsView({ initialTab, onClose }: Props) {
           className="settings-view-tabs"
         >
           {visibleTabs.map((t) => {
-            const isActive = t.id === active;
+            const isActive = t.id === activeTab;
             return (
               <button
                 key={t.id}
@@ -186,28 +203,28 @@ export function SettingsView({ initialTab, onClose }: Props) {
         </nav>
 
         <div role="tabpanel" className="settings-view-panel">
-          {active === 'pa' && <PaSettingsPanel />}
-          {active === 'hardware' && <HardwareDiagnosticsPanel />}
-          {active === 'ps' && <PsSettingsPanel />}
-          {active === 'tx-audio' && <TxAudioToolsPanel />}
-          {active === 'dsp' && <DspSettingsPanel />}
-          {active === 'bandplan' && <BandPlanEditor />}
-          {active === 'qrz' && <QrzSettingsPanel />}
-          {active === 'rotator' && <RotatorSettingsPanel />}
-          {active === 'tci' && <TciSettingsPanel />}
-          {active === 'display' && <DisplayPanel />}
-          {active === 'plugins' && <PluginsPanel />}
-          {active === 'hamclock' && <HamClockSettingsPanel />}
-          {active === 'spots' && <SpotsSettingsPanel />}
-          {active === 'server' && <ServerUrlPanel />}
-          {active === 'radio' && hasRadioOptions && <RadioOptionsPanel />}
-          {active === 'calibration' && <CalibrationPanel />}
-          {active === 'updates' && <UpdatesPanel />}
-          {active === 'about' && <AboutPanel />}
+          {activeTab === 'pa' && <PaSettingsPanel />}
+          {activeTab === 'hardware' && hardwareUnlocked && <HardwareDiagnosticsPanel />}
+          {activeTab === 'ps' && <PsSettingsPanel />}
+          {activeTab === 'tx-audio' && <TxAudioToolsPanel />}
+          {activeTab === 'dsp' && <DspSettingsPanel />}
+          {activeTab === 'bandplan' && <BandPlanEditor />}
+          {activeTab === 'qrz' && <QrzSettingsPanel />}
+          {activeTab === 'rotator' && <RotatorSettingsPanel />}
+          {activeTab === 'tci' && <TciSettingsPanel />}
+          {activeTab === 'display' && <DisplayPanel />}
+          {activeTab === 'plugins' && <PluginsPanel />}
+          {activeTab === 'hamclock' && <HamClockSettingsPanel />}
+          {activeTab === 'spots' && <SpotsSettingsPanel />}
+          {activeTab === 'server' && <ServerUrlPanel />}
+          {activeTab === 'radio' && hasRadioOptions && <RadioOptionsPanel />}
+          {activeTab === 'calibration' && <CalibrationPanel />}
+          {activeTab === 'updates' && <UpdatesPanel />}
+          {activeTab === 'about' && <AboutPanel />}
         </div>
       </div>
 
-      {active === 'pa' && (
+      {activeTab === 'pa' && (
         <div className="settings-view-footer">
           <button type="button" className="btn sm" onClick={handleCancel} disabled={paInflight}>
             CANCEL

--- a/zeus-web/src/state/easter-egg-store.test.ts
+++ b/zeus-web/src/state/easter-egg-store.test.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — verify the hidden HARDWARE folder unlock (brand-mark easter egg):
+// locked by default, unlocks only after HARDWARE_UNLOCK_CLICKS bolt taps.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  HARDWARE_UNLOCK_CLICKS,
+  useEasterEggStore,
+} from './easter-egg-store';
+
+function reset() {
+  useEasterEggStore.setState({ hardwareUnlocked: false, boltClicks: 0 });
+}
+
+describe('easter-egg-store — hidden HARDWARE unlock', () => {
+  beforeEach(reset);
+  afterEach(reset);
+
+  it('starts locked', () => {
+    expect(useEasterEggStore.getState().hardwareUnlocked).toBe(false);
+  });
+
+  it('stays locked until the click threshold is reached', () => {
+    const { registerBoltClick } = useEasterEggStore.getState();
+    for (let i = 1; i < HARDWARE_UNLOCK_CLICKS; i++) {
+      registerBoltClick();
+      expect(useEasterEggStore.getState().hardwareUnlocked).toBe(false);
+    }
+    // The threshold-th click unlocks.
+    registerBoltClick();
+    expect(useEasterEggStore.getState().hardwareUnlocked).toBe(true);
+  });
+
+  it('stays unlocked on further clicks (idempotent)', () => {
+    const { registerBoltClick } = useEasterEggStore.getState();
+    for (let i = 0; i < HARDWARE_UNLOCK_CLICKS + 3; i++) registerBoltClick();
+    expect(useEasterEggStore.getState().hardwareUnlocked).toBe(true);
+  });
+});

--- a/zeus-web/src/state/easter-egg-store.ts
+++ b/zeus-web/src/state/easter-egg-store.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+// See LICENSE for the full GPL text.
+
+import { create } from 'zustand';
+
+// Hidden HARDWARE diagnostics surface.
+//
+// The HARDWARE settings folder (board/DSP diagnostics) is hidden by default
+// and unlocked as an easter egg: tapping the header brand-mark lightning bolt
+// HARDWARE_UNLOCK_CLICKS times reveals it. State is intentionally in-memory
+// only — it re-locks on every launch, so a fresh session never lists the
+// folder and an accidental discovery never permanently exposes it.
+
+export const HARDWARE_UNLOCK_CLICKS = 4;
+
+type EasterEggState = {
+  hardwareUnlocked: boolean;
+  boltClicks: number;
+  // Counts a brand-mark bolt tap; unlocks HARDWARE once the click threshold is
+  // reached. No-op once already unlocked.
+  registerBoltClick: () => void;
+};
+
+export const useEasterEggStore = create<EasterEggState>((set) => ({
+  hardwareUnlocked: false,
+  boltClicks: 0,
+  registerBoltClick: () =>
+    set((s) => {
+      if (s.hardwareUnlocked) return s;
+      const boltClicks = s.boltClicks + 1;
+      return boltClicks >= HARDWARE_UNLOCK_CLICKS
+        ? { boltClicks: 0, hardwareUnlocked: true }
+        : { boltClicks };
+    }),
+}));


### PR DESCRIPTION
## What

The HARDWARE settings folder (board/DSP diagnostics) is now hidden by default and revealed only as an easter egg: tapping the header brand-mark lightning bolt 4 times unlocks it for the current session.

- **`easter-egg-store`** — in-memory unlock state, deliberately **not** persisted, so the folder re-locks on every launch. A fresh session never lists it and an accidental discovery never permanently exposes it. Click counting + threshold (`HARDWARE_UNLOCK_CLICKS`) live here in one testable seam.
- **`App.tsx`** — the brand-mark bolt `<path>` calls `registerBoltClick` on click. No hover, cursor, or title affordance, so the bolt never advertises that it's interactive.
- **`SettingsMenu.tsx`** — HARDWARE is filtered out of the visible tab list until unlocked, and the panel is guarded behind the unlock flag. The active tab is now derived from tab visibility rather than bounced via an effect, which also fixes a latent race where the `initialTab` effect could re-select a hidden tab. Existing RADIO gating behaviour is preserved.

## Test
- `easter-egg-store` unlock threshold + idempotence.
- `SettingsMenu` hides HARDWARE by default, bounces a locked `initialTab` back to PA, and shows it once unlocked.
- RADIO gating tests unchanged and green. Frontend typecheck, lint, and production build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)