### PR TITLE
feat: add ADIF logbook import

### DIFF
--- a/Zeus.Contracts/LogDtos.cs
+++ b/Zeus.Contracts/LogDtos.cs
@@ -49,7 +49,7 @@ public sealed record LogEntry(
     DateTime QsoDateTimeUtc,
     string Callsign,
     string? Name,
-    double FrequencyMhz,
+    double? FrequencyMhz,
     string Band,
     string Mode,
     string RstSent,
@@ -85,6 +85,17 @@ public sealed record CreateLogEntryRequest(
 public sealed record LogEntriesResponse(
     IEnumerable<LogEntry> Entries,
     int TotalCount);
+
+public sealed record AdifImportResponse(
+    int TotalRecords,
+    int ImportedCount,
+    int DuplicateCount,
+    int SkippedCount,
+    IEnumerable<AdifImportError> Errors);
+
+public sealed record AdifImportError(
+    int RecordNumber,
+    string Message);
 
 public sealed record QrzPublishRequest(
     IEnumerable<string> LogEntryIds);

--- a/Zeus.Server.Hosting/AdifParser.cs
+++ b/Zeus.Server.Hosting/AdifParser.cs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+
+namespace Zeus.Server;
+
+internal sealed record AdifRecord(IReadOnlyDictionary<string, string> Fields);
+
+internal static class AdifParser
+{
+    public static IReadOnlyList<AdifRecord> Parse(string adif)
+    {
+        if (string.IsNullOrWhiteSpace(adif))
+            return [];
+
+        var records = new List<AdifRecord>();
+        var fields = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var pos = FindDataStart(adif);
+
+        while (pos < adif.Length)
+        {
+            var tagStart = adif.IndexOf('<', pos);
+            if (tagStart < 0)
+                break;
+
+            var tagEnd = adif.IndexOf('>', tagStart + 1);
+            if (tagEnd < 0)
+                throw new FormatException("ADIF tag is missing its closing '>'.");
+
+            var tag = adif.Substring(tagStart + 1, tagEnd - tagStart - 1).Trim();
+            pos = tagEnd + 1;
+            if (tag.Length == 0)
+                continue;
+
+            var parts = tag.Split(':', 3);
+            var fieldName = parts[0].Trim().ToUpperInvariant();
+            if (fieldName.Length == 0)
+                continue;
+
+            if (string.Equals(fieldName, "EOH", StringComparison.OrdinalIgnoreCase))
+            {
+                fields.Clear();
+                continue;
+            }
+
+            if (string.Equals(fieldName, "EOR", StringComparison.OrdinalIgnoreCase))
+            {
+                if (fields.Count > 0)
+                {
+                    records.Add(new AdifRecord(new Dictionary<string, string>(fields, StringComparer.OrdinalIgnoreCase)));
+                    fields.Clear();
+                }
+                continue;
+            }
+
+            if (parts.Length < 2)
+                continue;
+
+            var lengthText = parts[1].Trim();
+            if (!int.TryParse(lengthText, out var length) || length < 0)
+                throw new FormatException($"ADIF field '{fieldName}' has an invalid length specifier.");
+
+            if (pos + length > adif.Length)
+                throw new FormatException($"ADIF field '{fieldName}' length exceeds the available data.");
+
+            fields[fieldName] = adif.Substring(pos, length);
+            pos += length;
+        }
+
+        if (fields.Count > 0)
+            records.Add(new AdifRecord(new Dictionary<string, string>(fields, StringComparer.OrdinalIgnoreCase)));
+
+        return records;
+    }
+
+    private static int FindDataStart(string adif)
+    {
+        var pos = 0;
+        while (pos < adif.Length)
+        {
+            var tagStart = adif.IndexOf('<', pos);
+            if (tagStart < 0)
+                return 0;
+
+            var tagEnd = adif.IndexOf('>', tagStart + 1);
+            if (tagEnd < 0)
+                return 0;
+
+            var tag = adif.Substring(tagStart + 1, tagEnd - tagStart - 1).Trim();
+            var fieldName = tag.Split(':', 2)[0].Trim();
+            if (string.Equals(fieldName, "EOH", StringComparison.OrdinalIgnoreCase))
+                return tagEnd + 1;
+
+            pos = tagEnd + 1;
+        }
+
+        return 0;
+    }
+}

--- a/Zeus.Server.Hosting/LogService.cs
+++ b/Zeus.Server.Hosting/LogService.cs
@@ -202,6 +202,60 @@ public sealed class LogService : IDisposable
         }, ct);
     }
 
+    public async Task<AdifImportResponse> ImportAdifAsync(string adif, CancellationToken ct = default)
+    {
+        return await Task.Run(() =>
+        {
+            var records = AdifParser.Parse(adif);
+            var existingKeys = _logs.FindAll()
+                .Select(BuildImportKey)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            var errors = new List<AdifImportError>();
+            var imported = 0;
+            var duplicates = 0;
+            var skipped = 0;
+            var importedUtc = DateTime.UtcNow;
+
+            for (var i = 0; i < records.Count; i++)
+            {
+                var recordNumber = i + 1;
+                if (!TryCreateDocumentFromAdifRecord(records[i], importedUtc, out var doc, out var error))
+                {
+                    skipped++;
+                    if (errors.Count < 25)
+                        errors.Add(new AdifImportError(recordNumber, error));
+                    continue;
+                }
+
+                var key = BuildImportKey(doc);
+                if (existingKeys.Contains(key))
+                {
+                    duplicates++;
+                    continue;
+                }
+
+                _logs.Insert(doc);
+                existingKeys.Add(key);
+                imported++;
+            }
+
+            _log.LogInformation(
+                "Imported ADIF logbook records total={Total} imported={Imported} duplicates={Duplicates} skipped={Skipped}",
+                records.Count,
+                imported,
+                duplicates,
+                skipped);
+
+            return new AdifImportResponse(
+                TotalRecords: records.Count,
+                ImportedCount: imported,
+                DuplicateCount: duplicates,
+                SkippedCount: skipped,
+                Errors: errors);
+        }, ct);
+    }
+
     public void Dispose()
     {
         _db?.Dispose();
@@ -278,6 +332,175 @@ public sealed class LogService : IDisposable
             RecentQsos: recent);
     }
 
+    internal static bool TryCreateDocumentFromAdifRecord(
+        AdifRecord record,
+        DateTime createdUtc,
+        out LogEntryDocument doc,
+        out string error)
+    {
+        doc = new LogEntryDocument();
+        error = string.Empty;
+
+        var fields = record.Fields;
+        var callsign = FieldValue(fields, "CALL");
+        if (string.IsNullOrWhiteSpace(callsign))
+        {
+            error = "missing CALL";
+            return false;
+        }
+
+        var qsoDate = FieldValue(fields, "QSO_DATE");
+        if (string.IsNullOrWhiteSpace(qsoDate))
+        {
+            error = "missing QSO_DATE";
+            return false;
+        }
+
+        var timeOn = FieldValue(fields, "TIME_ON");
+        if (string.IsNullOrWhiteSpace(timeOn))
+        {
+            error = "missing TIME_ON";
+            return false;
+        }
+
+        if (!TryParseAdifDateTime(qsoDate, timeOn, out var qsoUtc))
+        {
+            error = "invalid QSO_DATE or TIME_ON";
+            return false;
+        }
+
+        var mode = FieldValue(fields, "MODE");
+        if (string.IsNullOrWhiteSpace(mode))
+        {
+            error = "missing MODE";
+            return false;
+        }
+
+        var band = FieldValue(fields, "BAND");
+        var frequencyMhz = ParseAdifNumber(FieldValue(fields, "FREQ"));
+        if (string.IsNullOrWhiteSpace(band) && !frequencyMhz.HasValue)
+        {
+            error = "missing BAND or FREQ";
+            return false;
+        }
+
+        var qrzLogId = FieldValue(fields, "APP_QRZLOG_LOGID", "APP_QRZ_LOGID");
+        doc = new LogEntryDocument
+        {
+            Id = Guid.NewGuid().ToString(),
+            QsoDateTimeUtc = qsoUtc,
+            Callsign = callsign.Trim().ToUpperInvariant(),
+            Name = FieldValue(fields, "NAME"),
+            FrequencyMhz = frequencyMhz,
+            Band = band ?? string.Empty,
+            Mode = mode.Trim().ToUpperInvariant(),
+            RstSent = FieldValue(fields, "RST_SENT") ?? string.Empty,
+            RstRcvd = FieldValue(fields, "RST_RCVD") ?? string.Empty,
+            Grid = FieldValue(fields, "GRIDSQUARE", "GRID"),
+            Country = FieldValue(fields, "COUNTRY"),
+            Dxcc = ParseAdifInteger(FieldValue(fields, "DXCC")),
+            CqZone = ParseAdifInteger(FieldValue(fields, "CQZ", "CQ_ZONE")),
+            ItuZone = ParseAdifInteger(FieldValue(fields, "ITUZ", "ITU_ZONE")),
+            State = FieldValue(fields, "STATE"),
+            Comment = FieldValue(fields, "COMMENT", "NOTES"),
+            CreatedUtc = createdUtc,
+            QrzLogId = qrzLogId,
+            QrzUploadedUtc = string.IsNullOrWhiteSpace(qrzLogId) ? null : createdUtc,
+            AdifFields = fields
+                .Where(kv => !string.IsNullOrWhiteSpace(kv.Key))
+                .ToDictionary(kv => kv.Key.Trim().ToUpperInvariant(), kv => kv.Value, StringComparer.OrdinalIgnoreCase),
+        };
+
+        return true;
+    }
+
+    private static string BuildImportKey(LogEntryDocument doc)
+    {
+        var bandOrFreq = !string.IsNullOrWhiteSpace(doc.Band)
+            ? doc.Band.Trim().ToUpperInvariant()
+            : doc.FrequencyMhz?.ToString("F6", CultureInfo.InvariantCulture) ?? string.Empty;
+
+        return string.Join(
+            "|",
+            NormalizeCallsign(doc.Callsign),
+            ToUtc(doc.QsoDateTimeUtc).Ticks.ToString(CultureInfo.InvariantCulture),
+            bandOrFreq,
+            EmptyToNull(doc.Mode)?.ToUpperInvariant() ?? string.Empty);
+    }
+
+    private static string? FieldValue(IReadOnlyDictionary<string, string> fields, params string[] names)
+    {
+        foreach (var name in names)
+        {
+            if (fields.TryGetValue(name, out var value))
+            {
+                var trimmed = value.Trim();
+                if (trimmed.Length > 0)
+                    return trimmed;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool TryParseAdifDateTime(string qsoDate, string timeOn, out DateTime qsoUtc)
+    {
+        qsoUtc = default;
+        if (!DateTime.TryParseExact(
+                qsoDate.Trim(),
+                "yyyyMMdd",
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out var date))
+        {
+            return false;
+        }
+
+        var time = timeOn.Trim();
+        if (time.Length != 4 && time.Length != 6)
+            return false;
+
+        if (!int.TryParse(time[..2], NumberStyles.None, CultureInfo.InvariantCulture, out var hour)
+            || !int.TryParse(time.Substring(2, 2), NumberStyles.None, CultureInfo.InvariantCulture, out var minute))
+        {
+            return false;
+        }
+
+        var second = 0;
+        if (time.Length == 6
+            && !int.TryParse(time.Substring(4, 2), NumberStyles.None, CultureInfo.InvariantCulture, out second))
+        {
+            return false;
+        }
+
+        if (hour is < 0 or > 23 || minute is < 0 or > 59 || second is < 0 or > 59)
+            return false;
+
+        qsoUtc = new DateTime(date.Year, date.Month, date.Day, hour, minute, second, DateTimeKind.Utc);
+        return true;
+    }
+
+    private static double? ParseAdifNumber(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        if (!double.TryParse(value.Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed))
+            return null;
+
+        return parsed > 0 && double.IsFinite(parsed) ? parsed : null;
+    }
+
+    private static int? ParseAdifInteger(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        return int.TryParse(value.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : null;
+    }
+
     /// <summary>Internal so AdifUtcTimezoneTests can pin the
     /// <see cref="DateTime.Kind"/> behaviour without standing up a LiteDB
     /// round-trip. The method itself remains a private detail of the ADIF
@@ -296,7 +519,8 @@ public sealed class LogService : IDisposable
         // because callers downstream rely on it being UTC).
         AppendAdifField(sb, "QSO_DATE", doc.QsoDateTimeUtc.ToUniversalTime().ToString("yyyyMMdd"));
         AppendAdifField(sb, "TIME_ON", doc.QsoDateTimeUtc.ToUniversalTime().ToString("HHmmss"));
-        AppendAdifField(sb, "FREQ", doc.FrequencyMhz.ToString("F6", CultureInfo.InvariantCulture));
+        if (doc.FrequencyMhz.HasValue)
+            AppendAdifField(sb, "FREQ", doc.FrequencyMhz.Value.ToString("F6", CultureInfo.InvariantCulture));
         AppendAdifField(sb, "BAND", doc.Band);
         AppendAdifField(sb, "MODE", doc.Mode);
         AppendAdifField(sb, "RST_SENT", doc.RstSent);
@@ -319,8 +543,43 @@ public sealed class LogService : IDisposable
         if (!string.IsNullOrEmpty(doc.Comment))
             AppendAdifField(sb, "COMMENT", doc.Comment);
 
+        AppendAdditionalAdifFields(sb, doc);
         sb.AppendLine("<EOR>");
     }
+
+    private static void AppendAdditionalAdifFields(StringBuilder sb, LogEntryDocument doc)
+    {
+        if (doc.AdifFields is null || doc.AdifFields.Count == 0)
+            return;
+
+        foreach (var (fieldName, value) in doc.AdifFields.OrderBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            if (ManagedAdifFields.Contains(fieldName))
+                continue;
+
+            AppendAdifField(sb, fieldName, value);
+        }
+    }
+
+    private static readonly HashSet<string> ManagedAdifFields = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "CALL",
+        "QSO_DATE",
+        "TIME_ON",
+        "FREQ",
+        "BAND",
+        "MODE",
+        "RST_SENT",
+        "RST_RCVD",
+        "NAME",
+        "GRIDSQUARE",
+        "COUNTRY",
+        "DXCC",
+        "CQZ",
+        "ITUZ",
+        "STATE",
+        "COMMENT",
+    };
 
     private static void AppendAdifField(StringBuilder sb, string fieldName, string value)
     {
@@ -384,7 +643,7 @@ internal sealed class LogEntryDocument
     public DateTime QsoDateTimeUtc { get; set; }
     public string Callsign { get; set; } = string.Empty;
     public string? Name { get; set; }
-    public double FrequencyMhz { get; set; }
+    public double? FrequencyMhz { get; set; }
     public string Band { get; set; } = string.Empty;
     public string Mode { get; set; } = string.Empty;
     public string RstSent { get; set; } = string.Empty;
@@ -399,6 +658,7 @@ internal sealed class LogEntryDocument
     public DateTime CreatedUtc { get; set; }
     public string? QrzLogId { get; set; }
     public DateTime? QrzUploadedUtc { get; set; }
+    public Dictionary<string, string>? AdifFields { get; set; }
 }
 
 public sealed record WorkedCallsignSummary(
@@ -424,7 +684,7 @@ public sealed record WorkedCallsignRecentQso(
     DateTime QsoDateTimeUtc,
     string? Band,
     string? Mode,
-    double FrequencyMhz,
+    double? FrequencyMhz,
     string? RstSent,
     string? RstRcvd,
     string? Name,

--- a/Zeus.Server.Hosting/QrzService.cs
+++ b/Zeus.Server.Hosting/QrzService.cs
@@ -477,7 +477,8 @@ public sealed class QrzService
         // award credit and DXCC matching for anyone outside UTC.
         AppendAdifField(sb, "QSO_DATE", entry.QsoDateTimeUtc.ToUniversalTime().ToString("yyyyMMdd"));
         AppendAdifField(sb, "TIME_ON", entry.QsoDateTimeUtc.ToUniversalTime().ToString("HHmmss"));
-        AppendAdifField(sb, "FREQ", entry.FrequencyMhz.ToString("F6", System.Globalization.CultureInfo.InvariantCulture));
+        if (entry.FrequencyMhz.HasValue)
+            AppendAdifField(sb, "FREQ", entry.FrequencyMhz.Value.ToString("F6", System.Globalization.CultureInfo.InvariantCulture));
         AppendAdifField(sb, "BAND", entry.Band);
         AppendAdifField(sb, "MODE", entry.Mode);
         AppendAdifField(sb, "RST_SENT", entry.RstSent);

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -2511,6 +2511,27 @@ public static class ZeusEndpoints
                 fileName);
         });
 
+        app.MapPost("/api/log/import/adif", async (LogService logService, HttpContext ctx) =>
+        {
+            using var reader = new StreamReader(
+                ctx.Request.Body,
+                System.Text.Encoding.UTF8,
+                detectEncodingFromByteOrderMarks: true);
+            var adif = await reader.ReadToEndAsync(ctx.RequestAborted);
+            if (string.IsNullOrWhiteSpace(adif))
+                return Results.BadRequest(new { error = "ADIF file is empty" });
+
+            try
+            {
+                var response = await logService.ImportAdifAsync(adif, ctx.RequestAborted);
+                return Results.Ok(response);
+            }
+            catch (FormatException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+        });
+
         app.MapPost("/api/log/publish/qrz", async (QrzPublishRequest req, QrzService qrz, LogService logService, HttpContext ctx) =>
         {
             if (req.LogEntryIds == null || !req.LogEntryIds.Any())

--- a/tests/Zeus.Server.Tests/AdifImportTests.cs
+++ b/tests/Zeus.Server.Tests/AdifImportTests.cs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+
+using System.Text;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public sealed class AdifImportTests
+{
+    [Fact]
+    public void Parser_HandlesHeaderAndLengthTaggedRecords()
+    {
+        const string adif = """
+            ADIF Export
+            <ADIF_VER:5>3.1.6<PROGRAMID:4>Zeus<EOH>
+            <CALL:5>N9WAR<QSO_DATE:8>20260619<TIME_ON:6>142205<FREQ:6>14.250<BAND:3>20M<MODE:3>SSB<EOR>
+            <CALL:5>EI6LF<QSO_DATE:8>20260620<TIME_ON:4>0830<BAND:3>40M<MODE:2>CW<EOR>
+            """;
+
+        var records = AdifParser.Parse(adif);
+
+        Assert.Equal(2, records.Count);
+        Assert.Equal("N9WAR", records[0].Fields["CALL"]);
+        Assert.Equal("142205", records[0].Fields["TIME_ON"]);
+        Assert.Equal("EI6LF", records[1].Fields["CALL"]);
+        Assert.Equal("0830", records[1].Fields["TIME_ON"]);
+    }
+
+    [Fact]
+    public void Mapping_ImportsBandOnlyQsoAndPreservesExtraAdifFields()
+    {
+        const string adif = """
+            <ADIF_VER:5>3.1.6<EOH>
+            <CALL:5>N9WAR<QSO_DATE:8>20260619<TIME_ON:4>1422<BAND:3>20M<MODE:3>SSB
+            <RST_SENT:2>59<RST_RCVD:2>57<GRIDSQUARE:4>EN61<NOTES:11>net checkin
+            <TIME_OFF:6>143000<STATION_CALLSIGN:5>N9WAR<APP_QRZLOG_LOGID:7>QRZ-123<EOR>
+            """;
+        var record = AdifParser.Parse(adif).Single();
+
+        var ok = LogService.TryCreateDocumentFromAdifRecord(
+            record,
+            new DateTime(2026, 6, 19, 14, 30, 0, DateTimeKind.Utc),
+            out var doc,
+            out var error);
+
+        Assert.True(ok, error);
+        Assert.Equal("N9WAR", doc.Callsign);
+        Assert.Equal(new DateTime(2026, 6, 19, 14, 22, 0, DateTimeKind.Utc), doc.QsoDateTimeUtc);
+        Assert.Null(doc.FrequencyMhz);
+        Assert.Equal("20M", doc.Band);
+        Assert.Equal("SSB", doc.Mode);
+        Assert.Equal("net checkin", doc.Comment);
+        Assert.Equal("QRZ-123", doc.QrzLogId);
+        Assert.NotNull(doc.QrzUploadedUtc);
+        Assert.Equal("143000", doc.AdifFields!["TIME_OFF"]);
+        Assert.Equal("N9WAR", doc.AdifFields["STATION_CALLSIGN"]);
+
+        var sb = new StringBuilder();
+        LogService.AppendAdifRecord(sb, doc);
+        var exported = sb.ToString();
+
+        Assert.DoesNotContain("<FREQ:", exported);
+        Assert.Contains("<TIME_OFF:6>143000", exported);
+        Assert.Contains("<STATION_CALLSIGN:5>N9WAR", exported);
+        Assert.Contains("<APP_QRZLOG_LOGID:7>QRZ-123", exported);
+    }
+
+    [Fact]
+    public void Mapping_RejectsRecordsMissingMinimumQsoFields()
+    {
+        var record = new AdifRecord(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["CALL"] = "N0CALL",
+            ["QSO_DATE"] = "20260619",
+            ["TIME_ON"] = "1422",
+            ["BAND"] = "20M",
+        });
+
+        var ok = LogService.TryCreateDocumentFromAdifRecord(
+            record,
+            DateTime.UtcNow,
+            out _,
+            out var error);
+
+        Assert.False(ok);
+        Assert.Equal("missing MODE", error);
+    }
+
+    [Fact]
+    public void Mapping_ParsesFrequencyAndSixDigitUtcTime()
+    {
+        var record = new AdifRecord(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["CALL"] = "ei6lf",
+            ["QSO_DATE"] = "20260620",
+            ["TIME_ON"] = "083015",
+            ["FREQ"] = "7.185",
+            ["MODE"] = "lsb",
+            ["DXCC"] = "245",
+            ["CQZ"] = "14",
+            ["ITUZ"] = "27",
+        });
+
+        var ok = LogService.TryCreateDocumentFromAdifRecord(
+            record,
+            DateTime.UtcNow,
+            out var doc,
+            out var error);
+
+        Assert.True(ok, error);
+        Assert.Equal("EI6LF", doc.Callsign);
+        Assert.Equal(new DateTime(2026, 6, 20, 8, 30, 15, DateTimeKind.Utc), doc.QsoDateTimeUtc);
+        Assert.Equal(7.185, doc.FrequencyMhz);
+        Assert.Equal(string.Empty, doc.Band);
+        Assert.Equal("LSB", doc.Mode);
+        Assert.Equal(245, doc.Dxcc);
+        Assert.Equal(14, doc.CqZone);
+        Assert.Equal(27, doc.ItuZone);
+    }
+}

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -42,8 +42,8 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
-import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from 'react';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent, type FormEvent } from 'react';
+import { ChevronLeft, ChevronRight, Download, Upload } from 'lucide-react';
 import { WorkspaceContext } from './layout/WorkspaceContext';
 import { FlexWorkspace } from './layout/FlexWorkspace';
 import { WorkspaceErrorBoundary } from './layout/WorkspaceErrorBoundary';
@@ -428,24 +428,39 @@ export default function App() {
   const logPublishInFlight = useLoggerStore((s) => s.publishInFlight);
   const logPublishResult = useLoggerStore((s) => s.lastPublishResult);
   const logPublishError = useLoggerStore((s) => s.publishError);
+  const logImportInFlight = useLoggerStore((s) => s.importInFlight);
+  const logImportResult = useLoggerStore((s) => s.lastImportResult);
+  const logImportError = useLoggerStore((s) => s.importError);
   const logSelectedIds = useLoggerStore((s) => s.selectedIds);
   const logPublishSelected = useLoggerStore((s) => s.publishSelectedToQrz);
   const logExportAdif = useLoggerStore((s) => s.exportAdif);
+  const logImportAdifFile = useLoggerStore((s) => s.importAdifFile);
   const workedSummary = useLoggerStore((s) => s.workedSummary);
   const workedSummaryLoading = useLoggerStore((s) => s.workedSummaryLoading);
   const loadWorkedSummary = useLoggerStore((s) => s.loadWorkedSummary);
   const clearWorkedSummary = useLoggerStore((s) => s.clearWorkedSummary);
   const qrzHasApiKey = useQrzStore((s) => s.hasApiKey);
 
-  const logbookTitle = logPublishInFlight
-    ? 'Logbook · Uploading…'
-    : logPublishError
-      ? `Logbook · ${logPublishError.length > 28 ? 'Publish failed' : logPublishError}`
-      : logPublishResult
-        ? logPublishResult.failedCount > 0
-          ? `Logbook · ${logPublishResult.successCount} ok, ${logPublishResult.failedCount} failed`
-          : `Logbook · Published ${logPublishResult.successCount}`
-        : 'Logbook';
+  const logImportInputRef = useRef<HTMLInputElement | null>(null);
+  let logbookTitle = 'Logbook';
+  if (logImportInFlight) {
+    logbookTitle = 'Logbook · Importing…';
+  } else if (logImportError) {
+    logbookTitle = `Logbook · ${logImportError.length > 28 ? 'Import failed' : logImportError}`;
+  } else if (logImportResult) {
+    const importParts = [`Imported ${logImportResult.importedCount}`];
+    if (logImportResult.duplicateCount > 0) importParts.push(`${logImportResult.duplicateCount} duplicates`);
+    if (logImportResult.skippedCount > 0) importParts.push(`${logImportResult.skippedCount} skipped`);
+    logbookTitle = `Logbook · ${importParts.join(', ')}`;
+  } else if (logPublishInFlight) {
+    logbookTitle = 'Logbook · Uploading…';
+  } else if (logPublishError) {
+    logbookTitle = `Logbook · ${logPublishError.length > 28 ? 'Publish failed' : logPublishError}`;
+  } else if (logPublishResult) {
+    logbookTitle = logPublishResult.failedCount > 0
+      ? `Logbook · ${logPublishResult.successCount} ok, ${logPublishResult.failedCount} failed`
+      : `Logbook · Published ${logPublishResult.successCount}`;
+  }
 
   const logSelectedCount = logSelectedIds.size;
   const publishDisabled = logSelectedCount === 0 || logPublishInFlight || !qrzHasApiKey;
@@ -455,8 +470,32 @@ export default function App() {
       ? 'Select one or more rows to publish'
       : 'Publish selected QSOs to QRZ logbook';
 
+  const handleLogImportFile = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.currentTarget.files?.[0];
+    event.currentTarget.value = '';
+    if (file) void logImportAdifFile(file);
+  }, [logImportAdifFile]);
+
   const logbookActions = useMemo(() => (
     <>
+      <input
+        ref={logImportInputRef}
+        type="file"
+        accept=".adi,.adif,.txt,text/plain"
+        onChange={handleLogImportFile}
+        style={{ display: 'none' }}
+      />
+      <button
+        type="button"
+        className="btn ghost sm"
+        onClick={() => logImportInputRef.current?.click()}
+        disabled={logImportInFlight}
+        title="Import an ADIF logbook file"
+        aria-label="Import ADIF logbook file"
+      >
+        <Upload size={13} strokeWidth={2.2} aria-hidden="true" />
+        {logImportInFlight ? 'Importing…' : 'Import'}
+      </button>
       <button
         type="button"
         className="btn ghost sm"
@@ -472,11 +511,14 @@ export default function App() {
         onClick={() => void logExportAdif()}
         title="Export all log entries to ADIF file"
       >
+        <Download size={13} strokeWidth={2.2} aria-hidden="true" />
         Export
       </button>
     </>
   ), [
+    handleLogImportFile,
     logExportAdif,
+    logImportInFlight,
     logPublishInFlight,
     logPublishSelected,
     logSelectedCount,

--- a/zeus-web/src/api/log.ts
+++ b/zeus-web/src/api/log.ts
@@ -49,7 +49,7 @@ export type LogEntry = {
   qsoDateTimeUtc: string;
   callsign: string;
   name: string | null;
-  frequencyMhz: number;
+  frequencyMhz: number | null;
   band: string;
   mode: string;
   rstSent: string;
@@ -93,7 +93,7 @@ export type WorkedCallsignRecentQso = {
   qsoDateTimeUtc: string;
   band: string | null;
   mode: string | null;
-  frequencyMhz: number;
+  frequencyMhz: number | null;
   rstSent: string | null;
   rstRcvd: string | null;
   name: string | null;
@@ -126,6 +126,19 @@ export type WorkedCallsignSummary = {
 
 export type QrzPublishRequest = {
   logEntryIds: string[];
+};
+
+export type AdifImportError = {
+  recordNumber: number;
+  message: string;
+};
+
+export type AdifImportResponse = {
+  totalRecords: number;
+  importedCount: number;
+  duplicateCount: number;
+  skippedCount: number;
+  errors: AdifImportError[];
 };
 
 export type QrzPublishResponse = {
@@ -192,6 +205,28 @@ export async function exportToAdif(signal?: AbortSignal): Promise<void> {
   a.click();
   window.URL.revokeObjectURL(url);
   document.body.removeChild(a);
+}
+
+export async function importAdif(file: File, signal?: AbortSignal): Promise<AdifImportResponse> {
+  const adif = await file.text();
+  const response = await fetch('/api/log/import/adif', {
+    method: 'POST',
+    headers: { 'Content-Type': 'text/plain;charset=utf-8' },
+    body: adif,
+    signal,
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    let message = text;
+    try {
+      const parsed = JSON.parse(text) as { error?: unknown };
+      if (typeof parsed.error === 'string') message = parsed.error;
+    } catch {
+      /* keep the raw response text */
+    }
+    throw new Error(message || `HTTP ${response.status}`);
+  }
+  return await response.json();
 }
 
 export async function publishToQrz(

--- a/zeus-web/src/components/design/LogbookLive.tsx
+++ b/zeus-web/src/components/design/LogbookLive.tsx
@@ -64,10 +64,15 @@ function logMeta(entry: LogEntry): string {
   ]) || '—';
 }
 
+function formatFrequencyMhz(freq: number | null | undefined): string | null {
+  return typeof freq === 'number' && Number.isFinite(freq) ? freq.toFixed(3) : null;
+}
+
 function logRowTitle(entry: LogEntry): string {
+  const frequency = formatFrequencyMhz(entry.frequencyMhz);
   return compactList([
     `${entry.callsign} ${formatQsoDateUtc(entry.qsoDateTimeUtc)} ${formatQsoTimeUtc(entry.qsoDateTimeUtc)}Z`,
-    `${entry.frequencyMhz.toFixed(3)} MHz`,
+    frequency ? `${frequency} MHz` : null,
     entry.band,
     entry.mode,
     `RST ${entry.rstSent}/${entry.rstRcvd}`,
@@ -87,6 +92,9 @@ export function LogbookLive({ searchText, hideQrzPublished }: LogbookLiveProps) 
   const entries = useLoggerStore((s) => s.entries);
   const totalCount = useLoggerStore((s) => s.totalCount);
   const loading = useLoggerStore((s) => s.loading);
+  const lastImportResult = useLoggerStore((s) => s.lastImportResult);
+  const importError = useLoggerStore((s) => s.importError);
+  const clearImportResult = useLoggerStore((s) => s.clearImportResult);
   const lastPublishResult = useLoggerStore((s) => s.lastPublishResult);
   const publishError = useLoggerStore((s) => s.publishError);
   const clearPublishResult = useLoggerStore((s) => s.clearPublishResult);
@@ -109,14 +117,15 @@ export function LogbookLive({ searchText, hideQrzPublished }: LogbookLiveProps) 
   const someVisibleSelected = selectedVisibleCount > 0 && !allVisibleSelected;
 
   useEffect(() => {
-    // Self-clear publish feedback (shown in the Logbook header) after a few seconds.
-    if (lastPublishResult || publishError) {
+    // Self-clear import/publish feedback (shown in the Logbook header) after a few seconds.
+    if (lastImportResult || importError || lastPublishResult || publishError) {
       const timer = setTimeout(() => {
+        clearImportResult();
         clearPublishResult();
       }, 4000);
       return () => clearTimeout(timer);
     }
-  }, [lastPublishResult, publishError, clearPublishResult]);
+  }, [lastImportResult, importError, lastPublishResult, publishError, clearImportResult, clearPublishResult]);
 
   useEffect(() => {
     if (selectAllRef.current) {
@@ -205,7 +214,7 @@ export function LogbookLive({ searchText, hideQrzPublished }: LogbookLiveProps) 
             </span>
             <span className="t-call">{entry.callsign}</span>
             <span className="t-freq log-cell-stack">
-              <span>{entry.frequencyMhz.toFixed(3)}</span>
+              <span>{formatFrequencyMhz(entry.frequencyMhz) ?? '—'}</span>
               <span className="log-sub">{entry.band || '—'}</span>
             </span>
             <span className="t-mode">{entry.mode}</span>

--- a/zeus-web/src/components/design/logbook-search.test.ts
+++ b/zeus-web/src/components/design/logbook-search.test.ts
@@ -78,6 +78,13 @@ describe('logbook search', () => {
     expect(filterLogEntries(entries, '2026 14:22').map((qso) => qso.id)).toEqual(['a', 'b']);
   });
 
+  it('handles imported entries without a frequency', () => {
+    const imported = entry({ id: 'imported', callsign: 'K1ABC', frequencyMhz: null, band: '20M', mode: 'SSB' });
+
+    expect(logEntrySearchText(imported)).not.toContain('null');
+    expect(filterLogEntries([imported], 'k1abc 20m ssb').map((qso) => qso.id)).toEqual(['imported']);
+  });
+
   it('can hide QRZ-published entries', () => {
     expect(isQrzPublished(entries[0]!)).toBe(true);
     expect(filterLogEntries(entries, ' ', { hideQrzPublished: true }).map((qso) => qso.id)).toEqual(['b']);

--- a/zeus-web/src/components/design/logbook-search.ts
+++ b/zeus-web/src/components/design/logbook-search.ts
@@ -23,13 +23,16 @@ export function isQrzPublished(entry: LogEntry): boolean {
 }
 
 export function logEntrySearchText(entry: LogEntry): string {
+  const frequencyFixed = typeof entry.frequencyMhz === 'number' && Number.isFinite(entry.frequencyMhz)
+    ? entry.frequencyMhz.toFixed(3)
+    : null;
   return compactSearchParts([
     entry.callsign,
     formatQsoDateUtc(entry.qsoDateTimeUtc),
     formatQsoTimeUtc(entry.qsoDateTimeUtc),
     entry.qsoDateTimeUtc,
-    entry.frequencyMhz.toFixed(3),
-    entry.frequencyMhz.toString(),
+    frequencyFixed,
+    entry.frequencyMhz,
     entry.band,
     entry.mode,
     entry.rstSent,

--- a/zeus-web/src/state/logger-store.ts
+++ b/zeus-web/src/state/logger-store.ts
@@ -46,6 +46,7 @@ import { create } from 'zustand';
 import type {
   LogEntry,
   CreateLogEntryRequest,
+  AdifImportResponse,
   QrzPublishResponse,
   WorkedCallsignSummary,
 } from '../api/log';
@@ -54,6 +55,7 @@ import {
   getWorkedCallsignSummary,
   createLogEntry,
   exportToAdif,
+  importAdif,
   publishToQrz,
 } from '../api/log';
 
@@ -62,6 +64,9 @@ type LoggerState = {
   totalCount: number;
   loading: boolean;
   error: string | null;
+  importInFlight: boolean;
+  importError: string | null;
+  lastImportResult: AdifImportResponse | null;
   publishInFlight: boolean;
   publishError: string | null;
   lastPublishResult: QrzPublishResponse | null;
@@ -76,6 +81,8 @@ type LoggerState = {
   clearWorkedSummary: () => void;
   addLogEntry: (request: CreateLogEntryRequest) => Promise<LogEntry | null>;
   exportAdif: () => Promise<void>;
+  importAdifFile: (file: File) => Promise<AdifImportResponse | null>;
+  clearImportResult: () => void;
   publishSelectedToQrz: (logEntryIds: string[]) => Promise<void>;
   clearPublishResult: () => void;
   toggleSelected: (id: string) => void;
@@ -88,6 +95,9 @@ export const useLoggerStore = create<LoggerState>((set, get) => ({
   totalCount: 0,
   loading: false,
   error: null,
+  importInFlight: false,
+  importError: null,
+  lastImportResult: null,
   publishInFlight: false,
   publishError: null,
   lastPublishResult: null,
@@ -158,6 +168,26 @@ export const useLoggerStore = create<LoggerState>((set, get) => ({
     } catch (err) {
       set({ error: err instanceof Error ? err.message : 'Failed to export ADIF' });
     }
+  },
+
+  importAdifFile: async (file: File) => {
+    set({ importInFlight: true, importError: null, lastImportResult: null, error: null });
+    try {
+      const result = await importAdif(file);
+      set({ lastImportResult: result, importInFlight: false });
+      await get().loadEntries();
+      return result;
+    } catch (err) {
+      set({
+        importError: err instanceof Error ? err.message : 'Failed to import ADIF',
+        importInFlight: false,
+      });
+      return null;
+    }
+  },
+
+  clearImportResult: () => {
+    set({ lastImportResult: null, importError: null });
   },
 
   publishSelectedToQrz: async (logEntryIds: string[]) => {


### PR DESCRIPTION
## Summary
- add ADIF import parsing and `/api/log/import/adif` for local logbook imports
- store/import core QSO fields while preserving extra ADIF fields for later export
- allow band-only imported QSOs by making log frequency nullable
- add Logbook Import/Export toolbar actions and nullable-frequency search/display handling

## Verification
- `dotnet test tests\Zeus.Server.Tests\Zeus.Server.Tests.csproj --no-restore --filter "AdifImportTests|AdifUtcTimezoneTests|LogServiceWorkedSummaryTests"`
- `npm --prefix zeus-web run test -- logbook-search.test.ts`
- `npm --prefix zeus-web run typecheck`
- `npm --prefix zeus-web run build`

Beads: zeus-y6d2