### PR TITLE
perf(ui): cut per-frame layout/GL churn in waterfall + filter cursor

### DIFF
--- a/zeus-web/src/components/FilterCursorOverlay.tsx
+++ b/zeus-web/src/components/FilterCursorOverlay.tsx
@@ -60,6 +60,12 @@ export function FilterCursorOverlay({ containerRef, receiver = 'A' }: FilterCurs
     let mouseY = 0;
     let visible = false;
     let raf = 0;
+    // Reading offsetWidth/Height forces a synchronous layout. The readout pill
+    // only resizes when its text changes, so cache the dims and re-measure only
+    // on a digit change instead of every animation frame.
+    let lastReadoutText = '';
+    let cachedLw = 0;
+    let cachedLh = 0;
 
     const apply = () => {
       raf = 0;
@@ -132,12 +138,18 @@ export function FilterCursorOverlay({ containerRef, receiver = 'A' }: FilterCurs
       const readout = readoutRef.current;
       if (readout) {
         if (tuneHz !== null) {
-          readout.textContent = formatTuneHz(tuneHz);
+          const text = formatTuneHz(tuneHz);
           readout.style.display = '';
+          if (text !== lastReadoutText) {
+            readout.textContent = text;
+            lastReadoutText = text;
+            cachedLw = readout.offsetWidth;
+            cachedLh = readout.offsetHeight;
+          }
           // Edge-aware placement: nudge the pill to the cursor, flip side near
           // the right edge, and keep it clear of the top/bottom rails.
-          const lw = readout.offsetWidth;
-          const lh = readout.offsetHeight;
+          const lw = cachedLw;
+          const lh = cachedLh;
           let lx = cursorX + 12;
           if (lx + lw > rectW - 4) lx = cursorX - 12 - lw;
           lx = Math.max(4, Math.min(lx, rectW - lw - 4));

--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -224,6 +224,9 @@ export function Waterfall({
     let enhBuf: Float32Array | null = null;
     let terrainBuf: Float32Array | null = null;
     let stitchBuf: Float32Array | null = null;
+    // Scroll speed is a rare toggle; cache the last value pushed to the renderer
+    // so a steady redraw loop skips the store read + GL uniform update per frame.
+    let lastScrollSpeed = -1;
     // Visibility gating: skip the rAF redraw when the waterfall tile is
     // scrolled offscreen or the tab is hidden. We still push frames into
     // the history texture so when visibility resumes the operator sees a
@@ -241,7 +244,8 @@ export function Waterfall({
 
     const redraw = () => {
       if (contextLost || !renderer) return;
-      const { wfDbMin, wfDbMax, wfTxDbMin, wfTxDbMax } = useDisplaySettingsStore.getState();
+      const { wfDbMin, wfDbMax, wfTxDbMin, wfTxDbMax, waterfallScrollSpeed } =
+        useDisplaySettingsStore.getState();
       const { moxOn, tunOn } = useTxStore.getState();
       const keyed = moxOn || tunOn;
       const pop = useSignalEnhanceStore.getState();
@@ -253,7 +257,10 @@ export function Waterfall({
       const popIntensity = popOn ? Math.max(0, Math.min(1, pop.popRenderIntensity / 100)) : 0;
       const reliefDepth = rxRenderable ? Math.max(0, Math.min(1, pop.waterfallReliefDepth / 100)) : 0;
       const smoothness = rxRenderable ? Math.max(0, Math.min(1, pop.waterfallSmoothness / 100)) : 0;
-      renderer.setScrollSpeed(useDisplaySettingsStore.getState().waterfallScrollSpeed);
+      if (waterfallScrollSpeed !== lastScrollSpeed) {
+        renderer.setScrollSpeed(waterfallScrollSpeed);
+        lastScrollSpeed = waterfallScrollSpeed;
+      }
       // Mirror DbScale.tsx — keyed (MOX/TUN) renders the TX waterfall
       // window so the operator's RX noise-floor view stays put.
       const dbMin = popOn ? 0 : keyed ? wfTxDbMin : wfDbMin;

--- a/zeus-web/src/styles/analog-meter.css
+++ b/zeus-web/src/styles/analog-meter.css
@@ -56,6 +56,10 @@
   color: var(--fg-0);
   background: var(--bg-2);
 }
+.am-h-gear:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: -2px;
+}
 .am-h-gear.on {
   background: var(--accent-soft);
   color: var(--fg-0);

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -2862,9 +2862,8 @@
 .cs-input:focus {
   outline: none;
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(46,142,255,0.15);
+  box-shadow: inset 0 1px 2px rgba(0,0,0,0.6), 0 0 0 1px var(--accent-soft);
 }
-.cs-input:focus { outline: none; border-color: var(--accent); box-shadow: inset 0 1px 2px rgba(0,0,0,0.6), 0 0 0 1px var(--accent-soft); }
 
 /* ===== Logbook ===== */
 .logbook-panel {


### PR DESCRIPTION
## What

Targeted, behavior-preserving frontend render-perf and UI-correctness fixes. **This PR touches only `zeus-web` (frontend) — no backend code.**

### Frontend render perf
- **Waterfall redraw** ([Waterfall.tsx](zeus-web/src/components/Waterfall.tsx)): the per-frame `redraw` loop did a second `useDisplaySettingsStore.getState()` and pushed the `setScrollSpeed` GL uniform every frame. Scroll speed is now destructured from the `getState()` already happening that frame and the uniform is pushed only when the value changes. The `applyRenderLook` path (runs only on look changes) is left as-is so a settings change still propagates immediately.
- **FilterCursorOverlay** ([FilterCursorOverlay.tsx](zeus-web/src/components/FilterCursorOverlay.tsx)): the hover-readout pill read `offsetWidth`/`offsetHeight` every animation frame, forcing a synchronous layout on every pointer-move. Dimensions are now cached and re-measured only when the displayed digits change. This was the highest-impact item — it removes a forced reflow from the hover hot path.

### UI correctness
- **layout.css**: removed a dead duplicate `.cs-input:focus` rule (the second silently overrode the first); consolidated into one, preserving the currently-rendered focus look.
- **analog-meter.css**: added `:focus-visible` to the S-meter gear button (keyboard a11y gap; no change to default appearance).

## Scope notes
Several other items from an internal perf audit were reviewed and **deliberately not** included: PassbandOverlay geometry memoization (only runs during a transient edge-drag), the Panadapter subscribe diff, the waterfall buffer-realloc guard — all imperceptible micro-costs whose "fixes" add complexity/invalidation risk without felt benefit. Component-specific hex colors were left untouched (rendered-color changes are a visual-design decision). Bundle analysis showed the app is already well-split (leaflet/settings/mobile lazy; 15 MB ONNX model + WASM load on-demand; PWA precache only 3.1 MB), so no lazy-loading churn was warranted for the gain.

## Verification
- **Full solution build (Release): green** (`dotnet build Zeus.slnx -c Release`).
- **Backend tests: 6/6 completed assemblies pass, 0 failures** — Zeus.Contracts (95), Zeus.Plugins.Contracts (11), Zeus.Protocol2 (126), Zeus.Protocol1 (210), Zeus.Plugins.Host (112), Zeus.Dsp (172).
- **Frontend: `tsc -b` clean, production build green, e2e 5/5** (incl. workspace panel-drag specs that exercise the panadapter/waterfall surfaces these changes touch).

> ⚠️ **Unrelated pre-existing issue found (not caused by this PR):** the `Zeus.Server.Tests` assembly crashes the test host mid-run with an unhandled `ArgumentOutOfRangeException: Ticks must be between DateTime.MinValue.Ticks and DateTime.MaxValue.Ticks` originating from a corrupt-prefs-DB probe path (`PrefsDbPath`/LiteDB `Connection=shared`). 737/738 tests pass before the crash; the blame-hang collector's 2-min wait makes it look like a hang. This is backend-only and independent of these frontend changes — filing separately rather than bundling it here.