### PR TITLE
fix(workspace): lock a panel at its current size (no jump, then frozen)

### DIFF
--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -174,8 +174,8 @@ export function FlexWorkspace({
         layoutId={targetLayoutId}
         onLayoutChange={onLayoutChange}
         onRequestRemoveTile={(uid, title) => setPendingRemoveTile({ uid, title })}
-        onToggleTileLock={(uid, locked) =>
-          setTileLockedInLayout(targetLayoutId, uid, locked)
+        onToggleTileLock={(uid, locked, lockedHeightPx) =>
+          setTileLockedInLayout(targetLayoutId, uid, locked, lockedHeightPx)
         }
       />
       <TerminatorLines active={terminatorActive} />
@@ -227,7 +227,11 @@ interface WorkspaceCanvasProps {
   layoutId: string;
   onLayoutChange: (next: Layout) => void;
   onRequestRemoveTile: (uid: string, title: string) => void;
-  onToggleTileLock: (uid: string, locked: boolean) => void;
+  onToggleTileLock: (
+    uid: string,
+    locked: boolean,
+    lockedHeightPx?: number,
+  ) => void;
 }
 
 function WorkspaceCanvas({
@@ -294,6 +298,9 @@ function WorkspaceCanvas({
           h,
           locked: workspaceLocked || t.locked === true,
           minH: def?.minH ?? WORKSPACE_TILE_MIN_H,
+          ...(t.lockedHeightPx !== undefined
+            ? { lockedHeightPx: t.lockedHeightPx }
+            : {}),
         };
       }),
     [tiles, pluginPanelKey, workspaceLocked],
@@ -343,6 +350,24 @@ function WorkspaceCanvas({
   const placementByUid = useMemo(
     () => new Map(derived.placements.map((p) => [p.uid, p])),
     [derived],
+  );
+
+  // When locking a tile, capture its current on-screen pixel height so the
+  // store can hold it there afterwards. The capture is the live rendered size,
+  // so clicking lock never resizes the panel (see deriveWorkspaceLayout).
+  const handleToggleTileLock = useCallback(
+    (uid: string, locked: boolean) => {
+      if (!locked) {
+        onToggleTileLock(uid, false);
+        return;
+      }
+      const p = placementByUid.get(uid);
+      const lockedHeightPx = p
+        ? derived.rowHeight * p.h + Math.max(0, p.h - 1) * derived.rowMargin
+        : undefined;
+      onToggleTileLock(uid, true, lockedHeightPx);
+    },
+    [onToggleTileLock, placementByUid, derived.rowHeight, derived.rowMargin],
   );
 
   const workspaceDragCompactor = useMemo(
@@ -548,7 +573,7 @@ function WorkspaceCanvas({
                   layoutId={layoutId}
                   workspaceLocked={workspaceLocked}
                   onRequestRemoveTile={onRequestRemoveTile}
-                  onToggleTileLock={onToggleTileLock}
+                  onToggleTileLock={handleToggleTileLock}
                 />
               </div>
             );

--- a/zeus-web/src/layout/lockedWorkspaceLayout.test.ts
+++ b/zeus-web/src/layout/lockedWorkspaceLayout.test.ts
@@ -43,10 +43,6 @@ function pxHeight(h: number, rowHeight: number, rowMargin: number): number {
   return h * rowHeight + (h - 1) * rowMargin;
 }
 
-function maxBottom(d: DerivedWorkspaceLayout): number {
-  return d.placements.reduce((mx, p) => Math.max(mx, p.y + p.h), 0);
-}
-
 function byUid(d: DerivedWorkspaceLayout, uid: string) {
   const p = d.placements.find((x) => x.uid === uid);
   if (!p) throw new Error(`no placement for ${uid}`);
@@ -69,88 +65,108 @@ describe('deriveWorkspaceLayout — no locked tiles', () => {
   });
 });
 
-describe('deriveWorkspaceLayout — locked tile, layout fits', () => {
-  it('renders at authored rowHeight with stored geometry', () => {
-    const tiles = [
-      tile({ uid: 'lock', y: 0, h: 20, locked: true }),
-      tile({ uid: 'b', y: 20, h: 10 }), // layoutRows 30
+/** On-screen pixel height a tile actually renders at in a derived layout. */
+function renderedPx(d: DerivedWorkspaceLayout, uid: string): number {
+  return pxHeight(byUid(d, uid).h, d.rowHeight, d.rowMargin);
+}
+
+/** Pixel bottom edge of the whole derived layout (RGL absoluteStrategy). */
+function bottomPx(d: DerivedWorkspaceLayout): number {
+  return d.placements.reduce((mx, p) => {
+    const bottom =
+      (d.rowHeight + d.rowMargin) * p.y + pxHeight(p.h, d.rowHeight, d.rowMargin);
+    return Math.max(mx, bottom);
+  }, 0);
+}
+
+describe('deriveWorkspaceLayout — locking is inert', () => {
+  it('does not change the row height or unlocked geometry when a tile is locked', () => {
+    const base: DeriveTile[] = [
+      tile({ uid: 'a', x: 0, y: 0, w: 12, h: 20 }),
+      tile({ uid: 'b', x: 0, y: 20, w: 12, h: 30 }), // layoutRows 50 → overflow on 600px
     ];
-    // Tall container: fitRows = floor((900+3)/18) = 50 >= 30.
-    const d = deriveWorkspaceLayout(tiles, opts(900));
-    expect(d.compensated).toBe(false);
-    expect(d.rowHeight).toBe(R);
-    expect(d.rowMargin).toBe(M);
-    expect(byUid(d, 'lock')).toMatchObject({ h: 20 });
-    expect(byUid(d, 'b')).toMatchObject({ h: 10 });
+    const before = deriveWorkspaceLayout(base, opts(600));
+    expect(before.rowHeight).toBeLessThan(R); // workspace runs below authored
+
+    // Capture a's exact on-screen height, then lock it (what the UI does).
+    const capturedPx = renderedPx(before, 'a');
+    const after = deriveWorkspaceLayout(
+      base.map((t) =>
+        t.uid === 'a' ? { ...t, locked: true, lockedHeightPx: capturedPx } : t,
+      ),
+      opts(600),
+    );
+
+    // No jump: row height unchanged, locked tile still its captured size, and
+    // the unlocked neighbour is where it was (its y reflows under the locked
+    // tile's compensated span, which equals its stored row to sub-pixel — the
+    // reconcile step restores the exact stored row for persistence).
+    expect(after.rowHeight).toBeCloseTo(before.rowHeight, 4);
+    expect(renderedPx(after, 'a')).toBeCloseTo(capturedPx, 3);
+    const beforeB = byUid(before, 'b');
+    const afterB = byUid(after, 'b');
+    expect(afterB.x).toBe(beforeB.x);
+    expect(afterB.w).toBe(beforeB.w);
+    expect(afterB.h).toBe(beforeB.h);
+    expect(afterB.y).toBeCloseTo(beforeB.y, 3);
   });
 });
 
-describe('deriveWorkspaceLayout — locked tile, overflow', () => {
-  const tiles = [
-    tile({ uid: 'lock', x: 0, y: 0, w: 12, h: 20, locked: true }),
-    tile({ uid: 'b', x: 0, y: 20, w: 12, h: 20 }),
-    tile({ uid: 'c', x: 12, y: 0, w: 12, h: 40 }),
-  ]; // layoutRows = 40
+describe('deriveWorkspaceLayout — frozen size', () => {
+  const layout = (fillH: number): DeriveTile[] => [
+    tile({
+      uid: 'lock',
+      x: 0,
+      y: 0,
+      w: 12,
+      h: 20,
+      locked: true,
+      lockedHeightPx: 240,
+    }),
+    tile({ uid: 'fill', x: 0, y: 20, w: 24, h: fillH }),
+  ];
 
-  it('keeps the locked tile at its exact stored height while unlocked shrink', () => {
-    // container 600 → fitRows = floor(603/18) = 33 < 40 → must compensate.
-    const d = deriveWorkspaceLayout(tiles, opts(600));
-    expect(d.compensated).toBe(true);
-    expect(d.rowHeight).toBe(R);
-    // Locked tile is untouched.
-    expect(byUid(d, 'lock')).toMatchObject({ x: 0, y: 0, w: 12, h: 20 });
-    // Unlocked tiles shrank.
-    expect(byUid(d, 'b').h).toBeLessThan(20);
-    expect(byUid(d, 'c').h).toBeLessThan(40);
-    // Everything fits the viewport (no scroll).
-    expect(maxBottom(d)).toBeLessThanOrEqual(33);
-  });
-
-  it('respects unlocked tile minH floors', () => {
-    const tight = [
-      tile({ uid: 'lock', y: 0, h: 18, locked: true }),
-      tile({ uid: 'b', y: 18, h: 20, minH: 6 }),
-    ];
-    // container small enough to force max shrink: fitRows tuned so b cannot go
-    // below minH=6 (lock 18 + b 6 = 24).
-    const d = deriveWorkspaceLayout(tight, opts(450)); // fitRows floor(453/18)=25
-    expect(byUid(d, 'b').h).toBeGreaterThanOrEqual(6);
-    expect(byUid(d, 'lock').h).toBe(18);
-  });
-});
-
-describe('deriveWorkspaceLayout — locked size invariance', () => {
-  it('holds the locked tile pixel height constant as the workspace grows/shrinks', () => {
-    const make = (extraRows: number): DeriveTile[] => [
-      tile({ uid: 'lock', x: 0, y: 0, w: 12, h: 20, locked: true }),
-      tile({ uid: 'fill', x: 0, y: 20, w: 24, h: 20 + extraRows }),
-    ];
-    const authoredPx = pxHeight(20, R, M); // 20*15 + 19*3 = 357
-
-    // Across a fitting layout AND an overflowing one, the locked tile renders at
-    // exactly the same pixel height.
-    for (const [container, extra] of [
-      [900, 0],
-      [900, 40],
-      [600, 0],
-      [600, 60],
+  it('renders a locked tile at exactly its captured height in any viewport', () => {
+    for (const [container, fillH] of [
+      [900, 10],
+      [600, 30],
+      [500, 60],
     ] as const) {
-      const d = deriveWorkspaceLayout(make(extra), opts(container));
-      const lock = byUid(d, 'lock');
-      expect(pxHeight(lock.h, d.rowHeight, d.rowMargin)).toBeCloseTo(authoredPx, 5);
+      const d = deriveWorkspaceLayout(layout(fillH), opts(container));
+      expect(renderedPx(d, 'lock')).toBeCloseTo(240, 3);
     }
   });
+
+  it('shrinks unlocked tiles (never the locked one) as the workspace grows', () => {
+    const small = deriveWorkspaceLayout(layout(10), opts(600));
+    const big = deriveWorkspaceLayout(layout(80), opts(600)); // much taller layout
+
+    expect(renderedPx(small, 'lock')).toBeCloseTo(240, 3);
+    expect(renderedPx(big, 'lock')).toBeCloseTo(240, 3);
+    // The growth is absorbed by the unlocked tile via a smaller row height.
+    expect(big.rowHeight).toBeLessThan(small.rowHeight);
+  });
+
+  it('keeps the whole layout within the viewport (never scrolls)', () => {
+    const d = deriveWorkspaceLayout(layout(80), opts(600));
+    expect(bottomPx(d)).toBeLessThanOrEqual(601); // +1px float slack
+  });
 });
 
-describe('deriveWorkspaceLayout — every tile locked', () => {
-  it('falls back to uniform shrink (no unlocked tile can absorb slack)', () => {
-    const tiles = [
-      tile({ uid: 'a', y: 0, h: 30, locked: true }),
-      tile({ uid: 'b', y: 30, h: 30, locked: true }),
+describe('deriveWorkspaceLayout — legacy locked tile (no captured height)', () => {
+  it('holds it at its no-lock-density height so locking stays inert', () => {
+    const base: DeriveTile[] = [
+      tile({ uid: 'a', x: 0, y: 0, w: 12, h: 20 }),
+      tile({ uid: 'b', x: 0, y: 20, w: 12, h: 30 }),
     ];
-    const d = deriveWorkspaceLayout(tiles, opts(600));
-    expect(d.compensated).toBe(false);
-    expect(d.rowHeight).toBeLessThan(R); // uniform shrink applied to all
+    const before = deriveWorkspaceLayout(base, opts(600));
+    const beforePx = renderedPx(before, 'a');
+    // Lock 'a' with NO lockedHeightPx (a tile persisted before the field).
+    const after = deriveWorkspaceLayout(
+      base.map((t) => (t.uid === 'a' ? { ...t, locked: true } : t)),
+      opts(600),
+    );
+    expect(renderedPx(after, 'a')).toBeCloseTo(beforePx, 1);
   });
 });
 

--- a/zeus-web/src/layout/lockedWorkspaceLayout.ts
+++ b/zeus-web/src/layout/lockedWorkspaceLayout.ts
@@ -7,19 +7,26 @@
 //
 // The workspace never scrolls: a single uniform `rowHeight` shrinks every tile
 // so the whole layout fits the viewport. That shrink also rescales LOCKED
-// tiles, which operators expect to stay put at their exact authored size.
+// tiles, which operators expect to stay put at the exact size they had when
+// they pinned them.
 //
-// A single uniform rowHeight cannot hold one tile fixed while shrinking others,
-// so when a tile is locked AND the layout would overflow, we instead pin
-// rowHeight at the authored value (locked tiles render at exactly h × authored
-// px, invariant to the workspace getting longer/shorter) and shrink only the
-// UNLOCKED tiles' grid heights, recompacting around the static locked tiles.
+// Locking must be INERT — clicking the lock must not change the panel's size —
+// AND the size must then stay fixed as the workspace grows/shrinks. A single
+// uniform rowHeight can't do both, so each locked tile carries the on-screen
+// pixel height it had at lock time (`lockedHeightPx`, captured by the
+// component). We then pick the largest rowHeight (<= authored) at which the
+// whole layout still fits, holding each locked tile at its frozen pixel height
+// via a compensated (fractional) grid span and letting the UNLOCKED tiles take
+// the remaining space. Because reserving a locked tile's *current* height
+// changes nothing, the solver lands on the pre-lock rowHeight at the moment of
+// locking (inert); as the workspace later grows, only the rowHeight — and thus
+// the unlocked tiles — shrink, while locked tiles keep their frozen height.
 //
 // The result is a RENDER layout. The stored layout is never mutated here; the
 // component reconciles RGL's echo of this derived layout back to stored
-// coordinates so the shrunken render geometry is never persisted
-// (reconcileReportedToStored). When nothing is compensated the derived layout
-// equals the stored layout and the whole path is a no-op.
+// coordinates so the compensated render geometry is never persisted
+// (reconcileReportedToStored). With nothing locked the derived layout equals
+// the stored layout and the whole path is a no-op.
 
 import { compactMagnetUp } from './workspaceGrid';
 import type { Layout } from 'react-grid-layout';
@@ -35,6 +42,11 @@ export interface DeriveTile {
   h: number;
   locked: boolean;
   minH: number;
+  /** On-screen pixel height captured when the tile was locked. Locked tiles are
+   *  held at exactly this height. Absent for tiles locked before the field
+   *  existed — those fall back to their height at the no-lock density so
+   *  locking stays inert. */
+  lockedHeightPx?: number;
 }
 
 export interface RenderPlacement {
@@ -136,24 +148,57 @@ function uniformResult(
   };
 }
 
-/** Render the layout with unlocked tile heights scaled by `scale`, recompacted
- *  so unlocked tiles magnet up around the static (locked) tiles. */
-function renderAtScale(
+/** On-screen pixel height of a tile spanning `h` grid rows. Mirrors RGL's
+ *  calcGridItemWHPx (minus the final px rounding, which we don't need here). */
+function tileHeightPx(h: number, rowHeight: number, margin: number): number {
+  return rowHeight * h + Math.max(0, h - 1) * margin;
+}
+
+/** Pixel bottom edge of a tile, matching RGL's absoluteStrategy positioning. */
+function tileBottomPx(
+  y: number,
+  h: number,
+  rowHeight: number,
+  margin: number,
+): number {
+  return (rowHeight + margin) * y + tileHeightPx(h, rowHeight, margin);
+}
+
+/** Grid rows a tile must span to render exactly `px` tall at `rowHeight`:
+ *  solve px = rowHeight·h + (h-1)·margin  ⇒  h = (px + margin)/(rowHeight + margin). */
+function lockedSpanRows(px: number, rowHeight: number, margin: number): number {
+  return (px + margin) / (rowHeight + margin);
+}
+
+/** Render the layout at a candidate rowHeight: each locked tile gets a
+ *  (fractional) span that reproduces its frozen pixel height; unlocked tiles
+ *  keep their stored span. Recompact so unlocked tiles magnet up around the
+ *  static locked tiles, then report the layout and its total pixel extent. */
+function renderAtRowHeight(
   tiles: DeriveTile[],
-  scale: number,
-): { placements: RenderPlacement[]; maxBottom: number } {
+  rowHeight: number,
+  margin: number,
+  lockedPxByUid: Map<string, number>,
+): { placements: RenderPlacement[]; maxBottomPx: number } {
   const items: Layout = tiles.map((t) => ({
     i: t.uid,
     x: t.x,
     y: t.y,
     w: t.w,
     h: t.locked
-      ? t.h
-      : Math.max(t.minH, Math.min(t.h, Math.round(t.h * scale))),
+      ? lockedSpanRows(lockedPxByUid.get(t.uid) ?? 0, rowHeight, margin)
+      : t.h,
     static: t.locked,
     moved: false,
   }));
   const compacted = compactMagnetUp(items);
+  let maxBottomPx = 0;
+  for (const it of compacted) {
+    maxBottomPx = Math.max(
+      maxBottomPx,
+      tileBottomPx(it.y, it.h, rowHeight, margin),
+    );
+  }
   return {
     placements: compacted.map((it) => ({
       uid: it.i,
@@ -162,53 +207,15 @@ function renderAtScale(
       w: it.w,
       h: it.h,
     })),
-    maxBottom: maxBottomOf(compacted),
+    maxBottomPx,
   };
 }
 
-/** Find the largest unlocked-height scale that keeps the compacted layout
- *  within `fitRows`. Returns null when even the minimum heights overflow
- *  (locked tiles alone exceed the viewport). */
-function fitUnlockedToRows(
-  tiles: DeriveTile[],
-  fitRows: number,
-): { placements: RenderPlacement[]; scale: number } | null {
-  const full = renderAtScale(tiles, 1);
-  if (full.maxBottom <= fitRows) {
-    return { placements: full.placements, scale: 1 };
-  }
-
-  // Binary-search the largest scale in (0, 1) that fits. 24 iterations resolves
-  // far finer than the 1-row grid quantisation.
-  let lo = 0;
-  let hi = 1;
-  let best: { placements: RenderPlacement[]; scale: number } | null = null;
-  for (let i = 0; i < 24; i += 1) {
-    const mid = (lo + hi) / 2;
-    const r = renderAtScale(tiles, mid);
-    if (r.maxBottom <= fitRows) {
-      best = { placements: r.placements, scale: mid };
-      lo = mid;
-    } else {
-      hi = mid;
-    }
-  }
-  if (best) return best;
-
-  // Floor: every unlocked tile at its minH. If that still overflows, the locked
-  // tiles themselves don't fit — caller falls back to a uniform shrink.
-  const floor = renderAtScale(tiles, 0);
-  if (floor.maxBottom <= fitRows) {
-    return { placements: floor.placements, scale: 0 };
-  }
-  return null;
-}
-
 /**
- * Compute the workspace render layout. When a tile is locked and the layout
- * would overflow, locked tiles are held at authored size (rowHeight pinned) and
- * unlocked tiles shrink to fit. Otherwise this reproduces the legacy uniform
- * shrink-to-fit exactly.
+ * Compute the workspace render layout. With nothing locked this reproduces the
+ * legacy uniform shrink-to-fit exactly. When tiles are locked, each is held at
+ * its frozen pixel height (captured at lock time) while the rowHeight — and so
+ * the unlocked tiles — shrink to keep the whole layout inside the viewport.
  */
 export function deriveWorkspaceLayout(
   tiles: DeriveTile[],
@@ -216,48 +223,77 @@ export function deriveWorkspaceLayout(
 ): DerivedWorkspaceLayout {
   const layoutRows = maxBottomOf(tiles);
   const anyLocked = tiles.some((t) => t.locked);
-  const anyUnlocked = tiles.some((t) => !t.locked);
 
-  // Nothing locked, no measurable container, or every tile locked (no unlocked
-  // tile can absorb the slack) → legacy uniform behaviour.
-  if (!anyLocked || !anyUnlocked || opts.containerHeight <= 0) {
+  if (!anyLocked || opts.containerHeight <= 0) {
     return uniformResult(tiles, layoutRows, opts);
   }
 
-  const { authoredRowHeightPx: R, gridMarginPx: m } = opts;
-  const fitRows = Math.floor((opts.containerHeight + m) / (R + m));
-  if (fitRows <= 0) {
+  const {
+    authoredRowHeightPx: R,
+    gridMarginPx: m,
+    minRowHeightPx: minR,
+    containerHeight: C,
+  } = opts;
+
+  // Use the same row margin the no-lock path would, so locking doesn't shift
+  // the gap (and thus the sizes). It depends only on the stored layout extent,
+  // not on the rowHeight we are about to solve for, so it is stable across the
+  // search.
+  const baseTargetRows = Math.max(layoutRows, opts.targetRows);
+  const rowMargin = uniformRowMargin(C, baseTargetRows, m, opts.rowGapShare);
+
+  // Frozen pixel height per locked tile. A tile locked before the captured
+  // field existed has no stored height, so use its height at the no-lock
+  // density — that keeps locking inert for legacy layouts too.
+  const baselineRowHeight = uniformRowHeight(C, baseTargetRows, rowMargin, R, minR);
+  const lockedPxByUid = new Map<string, number>();
+  for (const t of tiles) {
+    if (!t.locked) continue;
+    const px =
+      t.lockedHeightPx !== undefined && t.lockedHeightPx > 0
+        ? t.lockedHeightPx
+        : tileHeightPx(t.h, baselineRowHeight, rowMargin);
+    lockedPxByUid.set(t.uid, px);
+  }
+
+  // Pick the largest rowHeight (≤ authored) at which the whole layout still
+  // fits, with locked tiles held at their frozen pixel height. A larger
+  // rowHeight makes the unlocked tiles taller (more total height), so "fits"
+  // is monotonic and a binary search lands on the tightest non-overflowing
+  // value. Reserving a locked tile's *current* height changes nothing, so at
+  // the instant of locking this resolves to the pre-lock rowHeight (inert).
+  const atMax = renderAtRowHeight(tiles, R, rowMargin, lockedPxByUid);
+  let best: { rr: number; placements: RenderPlacement[] } | null =
+    atMax.maxBottomPx <= C ? { rr: R, placements: atMax.placements } : null;
+  if (!best) {
+    let lo = minR;
+    let hi = R;
+    for (let i = 0; i < 24; i += 1) {
+      const mid = (lo + hi) / 2;
+      const r = renderAtRowHeight(tiles, mid, rowMargin, lockedPxByUid);
+      if (r.maxBottomPx <= C) {
+        best = { rr: mid, placements: r.placements };
+        lo = mid;
+      } else {
+        hi = mid;
+      }
+    }
+  }
+
+  // Even the minimum rowHeight overflows — the locked tiles alone exceed the
+  // viewport. Never scroll: fall back to the uniform shrink, which lets locked
+  // tiles give up their frozen size as a last resort.
+  if (!best) {
     return uniformResult(tiles, layoutRows, opts);
   }
 
-  // Already fits at authored density → render as stored at the authored
-  // rowHeight. Locked tiles are exactly h × R px; spare height stays at the
-  // bottom (matching the sparse-layout behaviour the workspace already has).
-  if (layoutRows <= fitRows) {
-    return {
-      rowHeight: R,
-      rowMargin: m,
-      placements: tiles.map(passthrough),
-      compensated: false,
-      unlockedScale: 1,
-    };
-  }
-
-  // Overflow: shrink unlocked tiles to fit while locked tiles stay authored.
-  const fitted = fitUnlockedToRows(tiles, fitRows);
-  if (fitted) {
-    return {
-      rowHeight: R,
-      rowMargin: m,
-      placements: fitted.placements,
-      compensated: fitted.scale < 1,
-      unlockedScale: fitted.scale,
-    };
-  }
-
-  // Locked tiles alone overflow the viewport — unavoidable corner. Fall back to
-  // the uniform shrink (locked tiles shrink too) rather than show a scrollbar.
-  return uniformResult(tiles, layoutRows, opts);
+  return {
+    rowHeight: best.rr,
+    rowMargin,
+    placements: best.placements,
+    compensated: true,
+    unlockedScale: 1,
+  };
 }
 
 /**

--- a/zeus-web/src/layout/workspace.ts
+++ b/zeus-web/src/layout/workspace.ts
@@ -68,6 +68,12 @@ export interface WorkspaceTile {
   instanceConfig?: unknown;
   /** When true, the tile is pinned to its current grid space. */
   locked?: boolean;
+  /** On-screen pixel height captured at the moment the tile was locked. While
+   *  locked, the tile is held at exactly this height regardless of how the
+   *  workspace rows shrink (see deriveWorkspaceLayout). A raw pixel value — NOT
+   *  a grid coordinate, so it is not scaled by the v7→v8 GRID_SCALE migration.
+   *  Only meaningful when `locked` is true; cleared on unlock. */
+  lockedHeightPx?: number;
 }
 
 /** Top-level workspace blob persisted to /api/ui/layout.
@@ -193,6 +199,12 @@ export function parseWorkspaceLayout(raw: unknown): WorkspaceLayout {
         ? { instanceConfig: tile.instanceConfig }
         : {}),
       ...(tile.locked === true ? { locked: true } : {}),
+      // Pixel value — preserved verbatim, never scaled by GRID_SCALE.
+      ...(typeof tile.lockedHeightPx === 'number' &&
+      Number.isFinite(tile.lockedHeightPx) &&
+      tile.lockedHeightPx > 0
+        ? { lockedHeightPx: tile.lockedHeightPx }
+        : {}),
     });
   }
   return {

--- a/zeus-web/src/state/layout-store.ts
+++ b/zeus-web/src/state/layout-store.ts
@@ -154,8 +154,15 @@ interface LayoutState {
   ) => void;
   /** Toggle whether every tile in a layout is pinned in place. */
   setWorkspaceLockedInLayout: (layoutId: string, locked: boolean) => void;
-  /** Toggle whether one tile is pinned to its current grid space. */
-  setTileLockedInLayout: (layoutId: string, uid: string, locked: boolean) => void;
+  /** Toggle whether one tile is pinned to its current grid space. When locking,
+   *  `lockedHeightPx` is the tile's current on-screen pixel height, captured so
+   *  the tile can be held at exactly that size while the workspace reflows. */
+  setTileLockedInLayout: (
+    layoutId: string,
+    uid: string,
+    locked: boolean,
+    lockedHeightPx?: number,
+  ) => void;
   /** Replace a tile's instanceConfig blob. */
   updateTileInstanceConfig: (uid: string, instanceConfig: unknown) => void;
   /** Replace a tile's instanceConfig blob in a specific layout. */
@@ -528,7 +535,7 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
     applyWorkspaceMutationForLayout(set, get, layoutId, withWorkspaceLocked(workspace, locked));
   },
 
-  setTileLockedInLayout: (layoutId, uid, locked) => {
+  setTileLockedInLayout: (layoutId, uid, locked, lockedHeightPx) => {
     const target = findActive(get().layouts, layoutId);
     if (!target && layoutId !== get().activeLayoutId) return;
     const workspace = layoutId === get().activeLayoutId
@@ -539,7 +546,7 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
       if (t.uid !== uid) return t;
       if ((t.locked === true) === locked) return t;
       changed = true;
-      return withTileLocked(t, locked);
+      return withTileLocked(t, locked, lockedHeightPx);
     });
     if (!changed) return;
     applyWorkspaceMutationForLayout(set, get, layoutId, { ...workspace, tiles });
@@ -600,10 +607,23 @@ function withWorkspaceLocked(
   return next;
 }
 
-function withTileLocked(tile: WorkspaceTile, locked: boolean): WorkspaceTile {
-  if (locked) return { ...tile, locked: true };
+function withTileLocked(
+  tile: WorkspaceTile,
+  locked: boolean,
+  lockedHeightPx?: number,
+): WorkspaceTile {
+  if (locked) {
+    const next: WorkspaceTile = { ...tile, locked: true };
+    if (typeof lockedHeightPx === 'number' && lockedHeightPx > 0) {
+      next.lockedHeightPx = lockedHeightPx;
+    } else {
+      delete next.lockedHeightPx;
+    }
+    return next;
+  }
   const next = { ...tile };
   delete next.locked;
+  delete next.lockedHeightPx;
   return next;
 }
 


### PR DESCRIPTION
## Bug
Locking a panel changed its size. The first locked-size pass pinned the grid `rowHeight` to the authored maximum (15px) whenever a tile was locked, but on a normal-sized window the workspace runs *below* that (shrink-to-fit). So the act of locking bumped the whole grid up to authored density and the locked panel visibly grew — "why is the size changing when I lock?"

## Fix
Locking is now **inert**: the panel keeps the exact on-screen size it had the moment you locked it, and holds it as the workspace grows/shrinks.

- Each locked tile carries the pixel height captured at lock time (`lockedHeightPx`, set by the component from the live rendered size).
- `deriveWorkspaceLayout` picks the largest `rowHeight` (≤ authored) at which the whole layout still fits, holding each locked tile at its frozen height via a compensated (fractional) grid span and letting the unlocked tiles take the rest.
- Reserving a tile's *current* height changes nothing about the fit, so the solver resolves to the pre-lock `rowHeight` at the instant of locking → **no jump**. As the workspace later grows, only the unlocked tiles shrink.

## Why fractional spans are safe
RGL's `calcGridItemWHPx` multiplies `h` then rounds the px, and `correctBounds` never rounds `h` (verified in the vendored build). The derived layout stays render-only — `reconcileReportedToStored` keeps the compensated geometry out of persistence, and the store ignores locked tiles' placements regardless.

## Tests
`lockedWorkspaceLayout.test.ts`: locking is inert (rowHeight + unlocked geometry unchanged), a locked tile renders at exactly its captured height in any viewport, unlocked tiles absorb growth, the layout never scrolls, and a legacy locked tile (no captured height) falls back to its no-lock density. 216 layout/state tests green; typecheck + lint clean.

> Not browser-verified in this environment (the preview harness runs the primary checkout, not this worktree). Please confirm the feel on a real drag/lock.