### PR TITLE
feat(diagnostics): 'Report a problem' self-diagnostic button

### DIFF
--- a/OpenhpsdrZeus/Program.cs
+++ b/OpenhpsdrZeus/Program.cs
@@ -41,6 +41,7 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
+using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
@@ -371,8 +372,17 @@ public partial class Program
             .RegisterWebMessageReceivedHandler((sender, msg) =>
             {
                 if (sender is not PhotinoWindow owner) return;
-                if (!TryReadWorkspaceWindowRequest(msg, out var request)) return;
-                OpenWorkspaceWindow(owner, detachedWorkspaceWindows, request, iconPath);
+                if (TryReadWorkspaceWindowRequest(msg, out var request))
+                {
+                    OpenWorkspaceWindow(owner, detachedWorkspaceWindows, request, iconPath);
+                    return;
+                }
+                // External links (e.g. the "Report a problem" → GitHub button):
+                // window.open to an external site is unreliable inside the Photino
+                // webview, so the frontend posts a zeus.openExternal message and the
+                // host opens it in the operator's real browser via the OS opener.
+                if (TryReadOpenExternalRequest(msg, out var externalUrl))
+                    OpenExternalUrl(externalUrl);
             })
             .Load(new Uri(startUrl));
 
@@ -564,6 +574,48 @@ public partial class Program
         {
             detachedWorkspaceWindows.Remove(child);
             Console.Error.WriteLine($"detached workspace open failed: {ex.Message}");
+        }
+    }
+
+    private static bool TryReadOpenExternalRequest(string message, out string url)
+    {
+        url = "";
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<WorkspaceWindowRequest>(message, WebMessageJsonOptions);
+            if (parsed?.Type != "zeus.openExternal") return false;
+            if (string.IsNullOrWhiteSpace(parsed.Url)) return false;
+            if (!Uri.TryCreate(parsed.Url, UriKind.Absolute, out var uri)) return false;
+            // Only http/https — never hand an arbitrary scheme/command to the OS opener.
+            if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps) return false;
+            url = uri.AbsoluteUri;
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static void OpenExternalUrl(string url)
+    {
+        // Cross-platform OS browser launch. The URL is already validated http/https
+        // by the caller; ArgumentList (not a concatenated string) avoids any shell
+        // interpretation of the URL.
+        try
+        {
+            ProcessStartInfo psi;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                psi = new ProcessStartInfo { FileName = url, UseShellExecute = true };
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                psi = new ProcessStartInfo { FileName = "open", ArgumentList = { url }, UseShellExecute = false };
+            else
+                psi = new ProcessStartInfo { FileName = "xdg-open", ArgumentList = { url }, UseShellExecute = false };
+            Process.Start(psi);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"openExternal failed: {ex.Message}");
         }
     }
 

--- a/Zeus.Server.Hosting/Diagnostics/DiagnosticContext.cs
+++ b/Zeus.Server.Hosting/Diagnostics/DiagnosticContext.cs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>
+/// Read-only context handed to every <see cref="IDiagnosticProbe"/> and
+/// <see cref="IKnownIssueRule"/> while a report is built. Probes resolve the
+/// services they need from <see cref="Services"/> (e.g. <c>RadioService</c>,
+/// the capabilities table). NOTHING in the diagnostic path may mutate radio
+/// state — this is strictly read-only (global diagnostics rule), and the
+/// PureSignal probe in particular may read <c>PsEnabled</c>/HwPeak but must
+/// never arm or change PS state (burn-zone).
+/// </summary>
+public sealed class DiagnosticContext
+{
+    /// <summary>DI root for probes to resolve backend services.</summary>
+    public required IServiceProvider Services { get; init; }
+
+    /// <summary>The symptom the operator picked, if any.</summary>
+    public string? SymptomId { get; init; }
+
+    /// <summary>The operator's free-text description, if any (already redacted).</summary>
+    public string? FreeText { get; init; }
+
+    /// <summary>
+    /// The last lines of the main log (redacted), newest last. The report ships
+    /// the last <see cref="DiagnosticLogBuffer.ReportTailLines"/> (100) of these.
+    /// </summary>
+    public required IReadOnlyList<string> RecentLog { get; init; }
+}

--- a/Zeus.Server.Hosting/Diagnostics/DiagnosticLogBuffer.cs
+++ b/Zeus.Server.Hosting/Diagnostics/DiagnosticLogBuffer.cs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>
+/// Thread-safe in-memory ring buffer of recent formatted log lines. Registered
+/// as a singleton and fed by <c>RingBufferLoggerProvider</c>, which is attached
+/// to the host's logging pipeline so the main log is ALWAYS being captured —
+/// you cannot collect logs retroactively, so the button just snapshots whatever
+/// is already here.
+///
+/// Capacity is generous (<see cref="Capacity"/>) so a report can always include
+/// the most recent <see cref="ReportTailLines"/> (100) lines the operator asked
+/// for, plus headroom for recipe-specific filtering.
+/// </summary>
+public sealed class DiagnosticLogBuffer
+{
+    /// <summary>How many lines the ring retains.</summary>
+    public const int Capacity = 1000;
+
+    /// <summary>How many trailing lines the report ships (operator requirement).</summary>
+    public const int ReportTailLines = 100;
+
+    private readonly object _sync = new();
+    private readonly string[] _ring = new string[Capacity];
+    private int _next;   // index of next write
+    private int _count;  // number of valid entries (<= Capacity)
+
+    /// <summary>Append one formatted log line. Cheap; safe from any thread.</summary>
+    public void Add(string line)
+    {
+        if (string.IsNullOrEmpty(line)) return;
+        lock (_sync)
+        {
+            _ring[_next] = line;
+            _next = (_next + 1) % Capacity;
+            if (_count < Capacity) _count++;
+        }
+    }
+
+    /// <summary>
+    /// Snapshot up to <paramref name="maxLines"/> of the most recent lines,
+    /// oldest first. Defaults to <see cref="ReportTailLines"/>.
+    /// </summary>
+    public IReadOnlyList<string> Snapshot(int maxLines = ReportTailLines)
+    {
+        if (maxLines <= 0) return [];
+        lock (_sync)
+        {
+            int take = Math.Min(maxLines, _count);
+            var result = new string[take];
+            // The oldest of the `take` lines sits `take` slots behind _next.
+            int start = ((_next - take) % Capacity + Capacity) % Capacity;
+            for (int i = 0; i < take; i++)
+                result[i] = _ring[(start + i) % Capacity];
+            return result;
+        }
+    }
+}

--- a/Zeus.Server.Hosting/Diagnostics/DiagnosticModels.cs
+++ b/Zeus.Server.Hosting/Diagnostics/DiagnosticModels.cs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>
+/// Self-diagnostic report contracts. The "Report a problem" footer button
+/// asks the backend to assemble one of these: the operator declares a symptom
+/// (and optional free text), the backend runs the matching <see cref="IDiagnosticProbe"/>
+/// recipe + <see cref="IKnownIssueRule"/> set, and returns a redacted,
+/// paste-ready report plus a prefilled GitHub-issue URL.
+///
+/// Everything here is wire DTO shape — keep it serialisation-stable.
+/// </summary>
+
+/// <summary>Finding severity, ordered least → most urgent for sorting.</summary>
+public enum DiagnosticSeverity
+{
+    Info = 0,
+    Warning = 1,
+    /// <summary>A known-issue rule's best guess at the operator's root cause.</summary>
+    Likely = 2,
+    Critical = 3,
+}
+
+/// <summary>A single collected key/value (already redacted).</summary>
+public sealed record DiagnosticKeyValue(string Key, string Value);
+
+/// <summary>One probe's contribution: a titled group of key/values.</summary>
+public sealed record DiagnosticSection(
+    string Id,
+    string Title,
+    IReadOnlyList<DiagnosticKeyValue> Items);
+
+/// <summary>
+/// A rule's conclusion: a human-readable likely-cause or warning, optionally
+/// pointing at a docs/ lesson or RCA the operator (or maintainer) can read.
+/// </summary>
+public sealed record DiagnosticFinding(
+    string Title,
+    string Detail,
+    DiagnosticSeverity Severity,
+    string? DocRef = null);
+
+/// <summary>A selectable symptom shown in the report modal's picker.</summary>
+public sealed record Symptom(string Id, string Label, string Group);
+
+/// <summary>Request body for <c>POST /api/diagnostics/report</c>.</summary>
+public sealed record DiagnosticRequest(string? SymptomId, string? FreeText);
+
+/// <summary>The assembled report (the JSON half of the result).</summary>
+public sealed record DiagnosticReport(
+    string SchemaVersion,
+    DateTimeOffset GeneratedUtc,
+    string? SymptomId,
+    string? SymptomLabel,
+    string? FreeText,
+    IReadOnlyList<DiagnosticSection> Sections,
+    IReadOnlyList<DiagnosticFinding> Findings,
+    IReadOnlyList<string> RecentLog);
+
+/// <summary>
+/// What <c>POST /api/diagnostics/report</c> returns: the structured report,
+/// a paste-ready Markdown rendering, and a prefilled GitHub "new issue" URL
+/// (body may be trimmed to stay under GitHub's URL length ceiling — the full
+/// detail always lives in <see cref="Markdown"/>, which the UI copies).
+/// </summary>
+public sealed record DiagnosticReportResult(
+    DiagnosticReport Report,
+    string Markdown,
+    string GithubIssueUrl);

--- a/Zeus.Server.Hosting/Diagnostics/DiagnosticReportBuilder.cs
+++ b/Zeus.Server.Hosting/Diagnostics/DiagnosticReportBuilder.cs
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>
+/// Assembles a "Report a problem" diagnostic: snapshots the recent log, runs the
+/// probe recipe for the chosen symptom, evaluates the known-issue rules, and
+/// renders both the structured report and a paste-ready Markdown + prefilled
+/// GitHub-issue URL.
+///
+/// Registered as a singleton. Probes and rules are injected via
+/// <c>IEnumerable&lt;&gt;</c> so this type never references a concrete probe or
+/// rule. The whole path is read-only — it must never mutate radio/DSP/PS state.
+/// </summary>
+public sealed class DiagnosticReportBuilder
+{
+    /// <summary>Bumped when the wire shape of <see cref="DiagnosticReport"/> changes.</summary>
+    public const string SchemaVersion = "1";
+
+    private readonly IReadOnlyDictionary<string, IDiagnosticProbe> _probesById;
+    private readonly IReadOnlyList<IKnownIssueRule> _rules;
+    private readonly DiagnosticLogBuffer _logBuffer;
+    private readonly SymptomRegistry _symptoms;
+    private readonly IServiceProvider _services;
+    private readonly ILogger<DiagnosticReportBuilder> _log;
+
+    /// <summary>Light cap on free-text length (user prose — passed through, not log-redacted).</summary>
+    private const int FreeTextMaxChars = 2000;
+
+    public DiagnosticReportBuilder(
+        IEnumerable<IDiagnosticProbe> probes,
+        IEnumerable<IKnownIssueRule> rules,
+        DiagnosticLogBuffer logBuffer,
+        SymptomRegistry symptoms,
+        IServiceProvider services,
+        ILogger<DiagnosticReportBuilder> log)
+    {
+        // First-registration-wins on duplicate ids; keeps lookup O(1) per recipe id.
+        var byId = new Dictionary<string, IDiagnosticProbe>(StringComparer.OrdinalIgnoreCase);
+        foreach (var p in probes)
+            byId.TryAdd(p.Id, p);
+        _probesById = byId;
+
+        _rules = rules.ToList();
+        _logBuffer = logBuffer;
+        _symptoms = symptoms;
+        _services = services;
+        _log = log;
+    }
+
+    /// <summary>The selectable symptoms for the picker.</summary>
+    public IReadOnlyList<Symptom> Symptoms() => _symptoms.All;
+
+    /// <summary>Run the probe recipe + rules for a request and render the result.</summary>
+    public DiagnosticReportResult Build(DiagnosticRequest req)
+    {
+        var symptom = ResolveSymptom(req.SymptomId);
+        var freeText = TrimFreeText(req.FreeText);
+
+        // 1. Snapshot the recent log (already redacted by the ring-buffer logger).
+        IReadOnlyList<string> recentLog;
+        try
+        {
+            recentLog = _logBuffer.Snapshot(DiagnosticLogBuffer.ReportTailLines);
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "diagnostics.report log snapshot failed");
+            recentLog = [];
+        }
+
+        var ctx = new DiagnosticContext
+        {
+            Services = _services,
+            SymptomId = req.SymptomId,
+            FreeText = freeText,
+            RecentLog = recentLog,
+        };
+
+        // 2. Run the recipe probes, in the recipe's stable order. Guard each one.
+        var sections = new List<DiagnosticSection>();
+        foreach (var probeId in _symptoms.ProbeIdsFor(req.SymptomId))
+        {
+            if (!_probesById.TryGetValue(probeId, out var probe))
+            {
+                _log.LogWarning(
+                    "diagnostics.report recipe references unregistered probe {ProbeId}", probeId);
+                continue;
+            }
+
+            try
+            {
+                sections.Add(probe.Collect(ctx));
+            }
+            catch (Exception ex)
+            {
+                _log.LogWarning(ex, "diagnostics.report probe {ProbeId} threw", probeId);
+                sections.Add(new DiagnosticSection(
+                    probeId,
+                    probeId + " (collection failed)",
+                    [new DiagnosticKeyValue(
+                        "error", "This probe failed to collect; the rest of the report is unaffected.")]));
+            }
+        }
+
+        // 3. Evaluate the rules relevant to this symptom; collect non-null findings.
+        var findings = new List<DiagnosticFinding>();
+        foreach (var rule in _rules)
+        {
+            bool relevant = rule.Symptoms.Count == 0 ||
+                            (req.SymptomId is not null && rule.Symptoms.Contains(req.SymptomId));
+            if (!relevant) continue;
+
+            try
+            {
+                var finding = rule.Evaluate(ctx, sections);
+                if (finding is not null)
+                    findings.Add(finding);
+            }
+            catch (Exception ex)
+            {
+                _log.LogWarning(ex, "diagnostics.report rule {RuleId} threw", rule.Id);
+            }
+        }
+
+        // Order: most urgent first, then title for stability.
+        findings.Sort((a, b) =>
+        {
+            int s = b.Severity.CompareTo(a.Severity);
+            return s != 0 ? s : string.CompareOrdinal(a.Title, b.Title);
+        });
+
+        var report = new DiagnosticReport(
+            SchemaVersion: SchemaVersion,
+            GeneratedUtc: DateTimeOffset.UtcNow,
+            SymptomId: req.SymptomId,
+            SymptomLabel: symptom?.Label,
+            FreeText: freeText,
+            Sections: sections,
+            Findings: findings,
+            RecentLog: recentLog);
+
+        // 4. Render Markdown + GitHub URL.
+        string markdown = MarkdownReportRenderer.Render(report);
+        string githubUrl = MarkdownReportRenderer.BuildGithubIssueUrl(report, markdown);
+
+        return new DiagnosticReportResult(report, markdown, githubUrl);
+    }
+
+    private Symptom? ResolveSymptom(string? symptomId)
+    {
+        if (string.IsNullOrEmpty(symptomId)) return null;
+        foreach (var s in _symptoms.All)
+            if (string.Equals(s.Id, symptomId, StringComparison.OrdinalIgnoreCase))
+                return s;
+        return null;
+    }
+
+    private static string? TrimFreeText(string? freeText)
+    {
+        if (string.IsNullOrWhiteSpace(freeText)) return null;
+        var trimmed = freeText.Trim();
+        if (trimmed.Length > FreeTextMaxChars)
+            trimmed = trimmed[..FreeTextMaxChars];
+        return trimmed;
+    }
+}

--- a/Zeus.Server.Hosting/Diagnostics/DiagnosticReportBuilder.cs
+++ b/Zeus.Server.Hosting/Diagnostics/DiagnosticReportBuilder.cs
@@ -165,6 +165,9 @@ public sealed class DiagnosticReportBuilder
         var trimmed = freeText.Trim();
         if (trimmed.Length > FreeTextMaxChars)
             trimmed = trimmed[..FreeTextMaxChars];
-        return trimmed;
+        // The operator's prose ends up in a PUBLIC GitHub issue, and they may
+        // paste a password, email, or IP without realising. Scrub it with the
+        // same redaction the log lines get — secrets must never leave the box.
+        return Redaction.Scrub(trimmed);
     }
 }

--- a/Zeus.Server.Hosting/Diagnostics/IDiagnosticProbe.cs
+++ b/Zeus.Server.Hosting/Diagnostics/IDiagnosticProbe.cs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>
+/// A read-only collector for one subsystem (board, connection, DSP/audio,
+/// TX/PS, environment). Each probe contributes a <see cref="DiagnosticSection"/>
+/// to the report. Probes are registered in DI and discovered by the
+/// <c>DiagnosticReportBuilder</c> via <c>IEnumerable&lt;IDiagnosticProbe&gt;</c>;
+/// the active symptom's recipe decides which probe ids run.
+///
+/// Contract: probes MUST be side-effect free. Resolve services from
+/// <see cref="DiagnosticContext.Services"/>, read state, return values.
+/// Redaction is applied centrally by the builder, but a probe should still
+/// avoid placing obvious secrets (passwords, tokens) into its items.
+/// </summary>
+public interface IDiagnosticProbe
+{
+    /// <summary>Stable id used by recipes (e.g. "board", "connection", "dsp", "tx-ps", "environment").</summary>
+    string Id { get; }
+
+    /// <summary>Collect this subsystem's snapshot. Never throws out — return a section noting the failure instead.</summary>
+    DiagnosticSection Collect(DiagnosticContext ctx);
+}

--- a/Zeus.Server.Hosting/Diagnostics/IKnownIssueRule.cs
+++ b/Zeus.Server.Hosting/Diagnostics/IKnownIssueRule.cs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>
+/// A machine-checkable encoding of one piece of the team's hard-won
+/// "symptom → root cause" knowledge (seeded from docs/rca/ and docs/lessons/).
+/// Each rule inspects the collected probe sections + recent log + context and,
+/// when its pattern matches, emits a <see cref="DiagnosticFinding"/> that turns
+/// a raw log dump into "here's what's probably wrong, and here's the doc".
+///
+/// Rules are registered in DI and discovered via
+/// <c>IEnumerable&lt;IKnownIssueRule&gt;</c>. The builder only evaluates rules
+/// whose <see cref="Symptoms"/> include the active symptom (or that declare no
+/// symptoms, meaning "always relevant"). Rules are read-only like probes.
+/// </summary>
+public interface IKnownIssueRule
+{
+    /// <summary>Stable id (e.g. "ps-not-armed", "iq-write-gate", "rx-aux-bypass").</summary>
+    string Id { get; }
+
+    /// <summary>
+    /// Symptom ids this rule is relevant to. Empty = evaluate for every symptom.
+    /// </summary>
+    IReadOnlyCollection<string> Symptoms { get; }
+
+    /// <summary>
+    /// Inspect the collected sections + context. Return a finding when the rule's
+    /// pattern matches, or <c>null</c> when it does not apply. Must not throw.
+    /// </summary>
+    DiagnosticFinding? Evaluate(DiagnosticContext ctx, IReadOnlyList<DiagnosticSection> sections);
+}

--- a/Zeus.Server.Hosting/Diagnostics/MarkdownReportRenderer.cs
+++ b/Zeus.Server.Hosting/Diagnostics/MarkdownReportRenderer.cs
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using System.Globalization;
+using System.Text;
+
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>
+/// Renders an assembled <see cref="DiagnosticReport"/> to paste-ready Markdown and
+/// builds the prefilled GitHub "new issue" URL. Plain-language throughout — the
+/// operator reads this before they ever post it. Culture-invariant formatting so
+/// reports look the same on every platform/locale.
+/// </summary>
+internal static class MarkdownReportRenderer
+{
+    public const string GithubNewIssueBase =
+        "https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus/issues/new";
+
+    /// <summary>Rough ceiling for the whole prefilled URL before we drop the log block.</summary>
+    public const int MaxUrlLength = 7000;
+
+    /// <summary>Render the full report (including the recent-log block) to Markdown.</summary>
+    public static string Render(DiagnosticReport report) => Render(report, includeLog: true);
+
+    /// <summary>
+    /// Render the report to Markdown. When <paramref name="includeLog"/> is false the
+    /// recent-log section is replaced with a short note pointing the reader at the
+    /// in-app "Copy report" button (used only to keep the GitHub URL under the limit).
+    /// </summary>
+    public static string Render(DiagnosticReport report, bool includeLog)
+    {
+        var sb = new StringBuilder(2048);
+
+        sb.Append("Thanks for reporting a problem with Zeus. This report was generated ")
+          .Append("automatically by the \"Report a problem\" button — it describes what ")
+          .Append("you were doing, what Zeus could work out about the cause, and a ")
+          .Append("snapshot of the recent log. No personal data is included.")
+          .Append("\n\n");
+
+        // ## What I was doing
+        sb.Append("## What I was doing\n\n");
+        var label = string.IsNullOrWhiteSpace(report.SymptomLabel)
+            ? "Something else or not sure"
+            : report.SymptomLabel;
+        sb.Append("**Symptom:** ").Append(label).Append("\n\n");
+        if (!string.IsNullOrWhiteSpace(report.FreeText))
+        {
+            sb.Append("**Details:**\n\n");
+            sb.Append(report.FreeText!.Trim()).Append("\n\n");
+        }
+
+        // ## Findings
+        sb.Append("## Findings\n\n");
+        if (report.Findings.Count == 0)
+        {
+            sb.Append("_No known-issue patterns matched. The system snapshot and log ")
+              .Append("below should help a maintainer investigate._\n\n");
+        }
+        else
+        {
+            foreach (var f in report.Findings)
+            {
+                sb.Append("- ").Append(SeverityBadge(f.Severity)).Append(' ')
+                  .Append("**").Append(f.Title).Append("**\n\n");
+                sb.Append("  ").Append(f.Detail.Replace("\n", "\n  ")).Append('\n');
+                if (!string.IsNullOrWhiteSpace(f.DocRef))
+                    sb.Append("\n  See: `").Append(f.DocRef).Append("`\n");
+                sb.Append('\n');
+            }
+        }
+
+        // ## System
+        sb.Append("## System\n\n");
+        if (report.Sections.Count == 0)
+        {
+            sb.Append("_No system sections were collected._\n\n");
+        }
+        else
+        {
+            foreach (var section in report.Sections)
+            {
+                sb.Append("### ").Append(section.Title).Append("\n\n");
+                if (section.Items.Count == 0)
+                {
+                    sb.Append("_(no values)_\n\n");
+                    continue;
+                }
+                foreach (var item in section.Items)
+                    sb.Append("- **").Append(item.Key).Append(":** ")
+                      .Append(item.Value).Append('\n');
+                sb.Append('\n');
+            }
+        }
+
+        // ## Recent log
+        sb.Append("## Recent log (last ")
+          .Append(report.RecentLog.Count.ToString(CultureInfo.InvariantCulture))
+          .Append(" lines)\n\n");
+        if (includeLog)
+        {
+            sb.Append("```text\n");
+            foreach (var line in report.RecentLog)
+                sb.Append(line).Append('\n');
+            sb.Append("```\n");
+        }
+        else
+        {
+            sb.Append("(Log omitted from this link to keep it short — click ")
+              .Append("\"Copy report\" in Zeus and paste the full text here.)\n");
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Build the prefilled GitHub "new issue" URL. Uses the full Markdown body when it
+    /// fits under <see cref="MaxUrlLength"/>; otherwise re-renders without the recent-log
+    /// block (the full log always stays in the returned report Markdown, which the UI
+    /// copies). <paramref name="fullMarkdown"/> is the body that includes the log.
+    /// </summary>
+    public static string BuildGithubIssueUrl(DiagnosticReport report, string fullMarkdown)
+    {
+        var title = string.IsNullOrWhiteSpace(report.SymptomLabel)
+            ? "Problem report"
+            : "[Report] " + report.SymptomLabel;
+
+        string url = Compose(title, fullMarkdown);
+        if (url.Length <= MaxUrlLength)
+            return url;
+
+        // Too long — drop the log block from the URL body only.
+        string trimmed = Render(report, includeLog: false);
+        return Compose(title, trimmed);
+    }
+
+    private static string Compose(string title, string body)
+    {
+        var sb = new StringBuilder(GithubNewIssueBase.Length + body.Length * 2);
+        sb.Append(GithubNewIssueBase)
+          .Append("?title=").Append(Uri.EscapeDataString(title))
+          .Append("&body=").Append(Uri.EscapeDataString(body))
+          .Append("&labels=bug");
+        return sb.ToString();
+    }
+
+    private static string SeverityBadge(DiagnosticSeverity severity) => severity switch
+    {
+        DiagnosticSeverity.Critical => "[CRITICAL]",
+        DiagnosticSeverity.Likely => "[LIKELY CAUSE]",
+        DiagnosticSeverity.Warning => "[WARNING]",
+        _ => "[INFO]",
+    };
+}

--- a/Zeus.Server.Hosting/Diagnostics/Probes/BoardProbe.cs
+++ b/Zeus.Server.Hosting/Diagnostics/Probes/BoardProbe.cs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using Microsoft.Extensions.DependencyInjection;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>
+/// Board identity + static fingerprint. Reads <see cref="RadioService"/>'s
+/// <c>ConnectedBoardKind</c> / <c>EffectiveOrionMkIIVariant</c>, then resolves
+/// the read-only per-board capability table, PA defaults (rated watts + PA
+/// gain), and the forward-power calibration bucket. All lookups are pure
+/// static functions over the board kind — no radio I/O, no mutation.
+/// </summary>
+public sealed class BoardProbe : IDiagnosticProbe
+{
+    public string Id => "board";
+
+    public DiagnosticSection Collect(DiagnosticContext ctx)
+    {
+        var items = new List<DiagnosticKeyValue>();
+        try
+        {
+            var radio = ctx.Services.GetService<RadioService>();
+            if (radio is null)
+            {
+                items.Add(new("status", "unavailable"));
+                return new DiagnosticSection(Id, "Board", items);
+            }
+
+            var board = radio.ConnectedBoardKind;
+            var variant = radio.EffectiveOrionMkIIVariant;
+
+            items.Add(new("board.kind", board.ToString()));
+            // Variant only disambiguates the 0x0A (OrionMkII) wire-byte family.
+            if (board == HpsdrBoardKind.OrionMkII)
+                items.Add(new("board.variant", variant.ToString()));
+
+            // Static capability fingerprint (Zeus.Contracts.BoardCapabilities).
+            var caps = BoardCapabilitiesTable.For(board, variant);
+            items.Add(new("caps.rxAdcCount", caps.RxAdcCount.ToString()));
+            items.Add(new("caps.mkiiBpf", caps.MkiiBpf ? "true" : "false"));
+            items.Add(new("caps.adcSupplyMv", caps.AdcSupplyMv.ToString()));
+            items.Add(new("caps.lrAudioSwap", caps.LrAudioSwap ? "true" : "false"));
+            items.Add(new("caps.hasVolts", caps.HasVolts ? "true" : "false"));
+            items.Add(new("caps.hasAmps", caps.HasAmps ? "true" : "false"));
+            items.Add(new("caps.hasAudioAmplifier", caps.HasAudioAmplifier ? "true" : "false"));
+            items.Add(new("caps.hasSteppedAttenuationRx2", caps.HasSteppedAttenuationRx2 ? "true" : "false"));
+            items.Add(new("caps.supportsPathIllustrator", caps.SupportsPathIllustrator ? "true" : "false"));
+            items.Add(new("caps.maxPowerWatts", caps.MaxPowerWatts.ToString()));
+            items.Add(new("caps.maxRxSampleRateHz", caps.MaxRxSampleRateHz.ToString()));
+            items.Add(new("caps.hasHl2OptionalToggles", caps.HasHl2OptionalToggles ? "true" : "false"));
+            items.Add(new("caps.supportsG2AdcOptions", caps.SupportsG2AdcOptions ? "true" : "false"));
+            items.Add(new("caps.supportsAnvelinaDxOc", caps.SupportsAnvelinaDxOc ? "true" : "false"));
+
+            // PA defaults (read-only static seeds).
+            items.Add(new("pa.maxPowerWatts", PaDefaults.GetMaxPowerWatts(board, variant).ToString()));
+
+            // Forward-power calibration bucket for this board / variant.
+            var cal = RadioCalibrations.For(board, variant);
+            items.Add(new("cal.bridgeVolt", cal.BridgeVolt.ToString("0.###")));
+            items.Add(new("cal.refVoltage", cal.RefVoltage.ToString("0.###")));
+            items.Add(new("cal.adcCalOffset", cal.AdcCalOffset.ToString()));
+            items.Add(new("cal.maxWatts", cal.MaxWatts.ToString("0.###")));
+        }
+        catch (Exception ex)
+        {
+            items.Add(new("status", "error"));
+            items.Add(new("error", ex.GetType().Name));
+        }
+
+        return new DiagnosticSection(Id, "Board", items);
+    }
+}

--- a/Zeus.Server.Hosting/Diagnostics/Probes/ConnectionProbe.cs
+++ b/Zeus.Server.Hosting/Diagnostics/Probes/ConnectionProbe.cs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using Microsoft.Extensions.DependencyInjection;
+using Zeus.Server;
+
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>
+/// Connection snapshot from <see cref="RadioService"/>: connected flag,
+/// endpoint (the builder's central redaction scrubs the IP), protocol
+/// (Protocol 1 vs 2), connection status, and sample rate. Strictly read-only —
+/// reads <c>IsConnected</c>, <c>ActiveClient</c>, and the cached
+/// <c>Snapshot()</c> StateDto; never connects, disconnects, or mutates.
+/// </summary>
+public sealed class ConnectionProbe : IDiagnosticProbe
+{
+    public string Id => "connection";
+
+    public DiagnosticSection Collect(DiagnosticContext ctx)
+    {
+        var items = new List<DiagnosticKeyValue>();
+        try
+        {
+            var radio = ctx.Services.GetService<RadioService>();
+            if (radio is null)
+            {
+                items.Add(new("status", "unavailable"));
+                return new DiagnosticSection(Id, "Connection", items);
+            }
+
+            var connected = radio.IsConnected;
+            items.Add(new("connected", connected ? "true" : "false"));
+
+            // Protocol: a live Protocol-1 client means P1; connected with no
+            // P1 client means a Protocol-2 (ANAN / Orion) backend is active.
+            string protocol;
+            if (radio.ActiveClient is not null)
+                protocol = "Protocol 1";
+            else if (connected)
+                protocol = "Protocol 2";
+            else
+                protocol = "none";
+            items.Add(new("protocol", protocol));
+
+            var state = radio.Snapshot();
+            items.Add(new("status", state.Status.ToString()));
+            // Endpoint may contain an IP/host — the builder redacts it centrally.
+            items.Add(new("endpoint", string.IsNullOrWhiteSpace(state.Endpoint) ? "none" : state.Endpoint!));
+            items.Add(new("sample.rate.hz", state.SampleRate.ToString()));
+
+            // Firmware / gateware version: not surfaced by RadioService or
+            // IProtocol1Client today, so there is nothing read-only to report.
+            items.Add(new("firmware.version", "not exposed by RadioService"));
+        }
+        catch (Exception ex)
+        {
+            items.Add(new("status", "error"));
+            items.Add(new("error", ex.GetType().Name));
+        }
+
+        return new DiagnosticSection(Id, "Connection", items);
+    }
+}

--- a/Zeus.Server.Hosting/Diagnostics/Probes/DspAudioProbe.cs
+++ b/Zeus.Server.Hosting/Diagnostics/Probes/DspAudioProbe.cs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using Microsoft.Extensions.DependencyInjection;
+using Zeus.Server;
+
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>
+/// DSP + audio-output snapshot. Reports the active DSP engine kind (synthetic
+/// vs WDSP) via <see cref="DspPipelineService.CurrentEngine"/>, the audio sink
+/// route / mute state from <c>NativeAudioSink</c>, and the AGC + RX/TX leveler
+/// configuration from <see cref="RadioService"/>'s cached StateDto. Read-only:
+/// only getters and the cached state snapshot are touched.
+/// </summary>
+public sealed class DspAudioProbe : IDiagnosticProbe
+{
+    public string Id => "dsp-audio";
+
+    public DiagnosticSection Collect(DiagnosticContext ctx)
+    {
+        var items = new List<DiagnosticKeyValue>();
+        try
+        {
+            var anyService = false;
+
+            var dsp = ctx.Services.GetService<DspPipelineService>();
+            if (dsp is not null)
+            {
+                anyService = true;
+                // No member on IDspEngine names its kind; the concrete runtime
+                // type is the authoritative tell (SyntheticDspEngine vs
+                // WdspDspEngine). GetType().Name avoids a hard ref to either.
+                var engine = dsp.CurrentEngine;
+                items.Add(new("dsp.engine", engine is null ? "none" : engine.GetType().Name));
+                items.Add(new("dsp.audioOutputRateHz", DspPipelineService.AudioOutputRateHz.ToString()));
+                items.Add(new("dsp.monitorBacklog", dsp.MonitorBacklog.ToString()));
+            }
+            else
+            {
+                items.Add(new("dsp.engine", "unavailable"));
+            }
+
+            // Audio sink: NativeAudioSink owns mute + the active output route.
+            var sink = ctx.Services.GetService<NativeAudioSink>();
+            if (sink is not null)
+            {
+                anyService = true;
+                items.Add(new("audio.sink", "NativeAudioSink"));
+                items.Add(new("audio.muted", sink.IsMuted ? "true" : "false"));
+                items.Add(new("audio.previewEnabled", sink.IsEnabled ? "true" : "false"));
+                items.Add(new("audio.configuredDeviceId",
+                    string.IsNullOrWhiteSpace(sink.ConfiguredOutputDeviceId) ? "default" : sink.ConfiguredOutputDeviceId!));
+                items.Add(new("audio.activeDeviceId",
+                    string.IsNullOrWhiteSpace(sink.ActiveOutputDeviceId) ? "none" : sink.ActiveOutputDeviceId!));
+                try
+                {
+                    var d = sink.GetDiagnostics();
+                    items.Add(new("audio.sampleRateHz", d.SampleRateHz.ToString()));
+                    items.Add(new("audio.ringDepthSamples", d.RingDepthSamples.ToString()));
+                    items.Add(new("audio.ringCapacitySamples", d.RingCapacitySamples.ToString()));
+                    items.Add(new("audio.underrunSamplesTotal", d.UnderrunSamplesTotal.ToString()));
+                    items.Add(new("audio.overrunSamplesTotal", d.OverrunSamplesTotal.ToString()));
+                    items.Add(new("audio.rebufferEvents", d.RebufferEvents.ToString()));
+                    items.Add(new("audio.rebuffering", d.Rebuffering ? "true" : "false"));
+                }
+                catch (Exception ex)
+                {
+                    items.Add(new("audio.diagnostics", $"unavailable ({ex.GetType().Name})"));
+                }
+            }
+            else
+            {
+                items.Add(new("audio.sink", "unavailable"));
+            }
+
+            // AGC + leveler config live on the cached StateDto (read-only).
+            var radio = ctx.Services.GetService<RadioService>();
+            if (radio is not null)
+            {
+                anyService = true;
+                var state = radio.Snapshot();
+                items.Add(new("agc.mode", state.Agc?.Mode.ToString() ?? "Med (default)"));
+                items.Add(new("agc.topDb", state.AgcTopDb.ToString("0.#")));
+                items.Add(new("agc.auto", state.AutoAgcEnabled ? "true" : "false"));
+
+                // RX master AF gain (the closest read-only RX-gain surface; the
+                // internal RX-audio leveler runtime state is private to the
+                // pipeline and not exposed for read-out).
+                items.Add(new("rx.afGainDb", state.RxAfGainDb.ToString("0.#")));
+
+                // TX leveler config (read-only; null => engine defaults).
+                if (state.TxLeveling is { } txl)
+                {
+                    items.Add(new("tx.levelerEnabled", txl.LevelerEnabled ? "true" : "false"));
+                    items.Add(new("tx.levelerDecayMs", txl.LevelerDecayMs.ToString()));
+                }
+                items.Add(new("tx.levelerMaxGainDb", state.LevelerMaxGainDb.ToString("0.#")));
+            }
+
+            if (!anyService)
+            {
+                items.Clear();
+                items.Add(new("status", "unavailable"));
+            }
+        }
+        catch (Exception ex)
+        {
+            items.Add(new("status", "error"));
+            items.Add(new("error", ex.GetType().Name));
+        }
+
+        return new DiagnosticSection(Id, "DSP & Audio", items);
+    }
+}

--- a/Zeus.Server.Hosting/Diagnostics/Probes/EnvironmentProbe.cs
+++ b/Zeus.Server.Hosting/Diagnostics/Probes/EnvironmentProbe.cs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>
+/// Host-environment snapshot: Zeus version, OS / architecture / .NET runtime,
+/// and process uptime. Needs no backend services, so it is always available
+/// even in unit tests with an empty service provider.
+/// </summary>
+public sealed class EnvironmentProbe : IDiagnosticProbe
+{
+    public string Id => "environment";
+
+    public DiagnosticSection Collect(DiagnosticContext ctx)
+    {
+        var items = new List<DiagnosticKeyValue>();
+        try
+        {
+            items.Add(new("zeus.version", ZeusVersion()));
+            items.Add(new("os.description", RuntimeInformation.OSDescription));
+            items.Add(new("os.architecture", RuntimeInformation.OSArchitecture.ToString()));
+            items.Add(new("process.architecture", RuntimeInformation.ProcessArchitecture.ToString()));
+            items.Add(new("dotnet.version", RuntimeInformation.FrameworkDescription));
+
+            try
+            {
+                // Process uptime is cheap to read; guard anyway in case the
+                // platform restricts access to the current process metadata.
+                var uptime = DateTime.UtcNow - Process.GetCurrentProcess().StartTime.ToUniversalTime();
+                if (uptime < TimeSpan.Zero)
+                    uptime = TimeSpan.Zero;
+                items.Add(new("process.uptime", uptime.ToString(@"d\.hh\:mm\:ss")));
+            }
+            catch (Exception ex)
+            {
+                items.Add(new("process.uptime", $"unavailable ({ex.GetType().Name})"));
+            }
+        }
+        catch (Exception ex)
+        {
+            items.Add(new("status", "error"));
+            items.Add(new("error", ex.GetType().Name));
+        }
+
+        return new DiagnosticSection(Id, "Environment", items);
+    }
+
+    private static string ZeusVersion()
+    {
+        // Prefer the hosting assembly's informational version (the SemVer-ish
+        // string baked in by Directory.Build.props); fall back gracefully.
+        var asm = typeof(EnvironmentProbe).Assembly;
+        var info = asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        if (!string.IsNullOrWhiteSpace(info))
+            return info!;
+        return asm.GetName().Version?.ToString() ?? "unknown";
+    }
+}

--- a/Zeus.Server.Hosting/Diagnostics/Probes/TxPsProbe.cs
+++ b/Zeus.Server.Hosting/Diagnostics/Probes/TxPsProbe.cs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using Microsoft.Extensions.DependencyInjection;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>
+/// TX / PureSignal snapshot. STRICTLY READ-ONLY — this probe reads the cached
+/// StateDto (drive %, TUN %, PsEnabled, PS hardware-peak, feedback attenuation)
+/// and the per-board rated watts, and NEVER calls any setter, arm/disarm, or
+/// calibration path. PureSignal is a burn-zone subsystem: reading
+/// <c>PsEnabled</c> is permitted, mutating PS state is a hard violation, so
+/// this probe only inspects the snapshot the server already published.
+/// </summary>
+public sealed class TxPsProbe : IDiagnosticProbe
+{
+    public string Id => "tx-ps";
+
+    public DiagnosticSection Collect(DiagnosticContext ctx)
+    {
+        var items = new List<DiagnosticKeyValue>();
+        try
+        {
+            var radio = ctx.Services.GetService<RadioService>();
+            if (radio is null)
+            {
+                items.Add(new("status", "unavailable"));
+                return new DiagnosticSection(Id, "TX & PureSignal", items);
+            }
+
+            var state = radio.Snapshot();
+
+            // ---- Drive / TUN drive (operator slider positions, %) ----
+            items.Add(new("tx.drivePct", state.DrivePct.ToString()));
+            items.Add(new("tx.tunePct", state.TunePct.ToString()));
+            items.Add(new("tx.moxPreKeyDelayMs", radio.TxMoxPreKeyDelayMs.ToString()));
+
+            // ---- Rated power for the connected board (read-only static) ----
+            var board = radio.ConnectedBoardKind;
+            var variant = radio.EffectiveOrionMkIIVariant;
+            items.Add(new("tx.maxPowerWatts", PaDefaults.GetMaxPowerWatts(board, variant).ToString()));
+
+            // MOX / TUN: RadioService exposes these only as change events +
+            // setters, so there is no read-only runtime getter to sample here.
+            items.Add(new("tx.moxState", "not exposed (event/setter only)"));
+            items.Add(new("tx.tunState", "not exposed (event/setter only)"));
+
+            // ---- PureSignal (READ-ONLY) ----
+            // PsEnabled is always published false at startup by design (the
+            // standing PS auto-arm safety invariant); we report the snapshot
+            // value verbatim and never write it.
+            items.Add(new("ps.enabled", state.PsEnabled ? "true" : "false"));
+            items.Add(new("ps.hwPeak", state.PsHwPeak.ToString("0.####")));
+            items.Add(new("ps.hwPeakDefault", state.PsHwPeakDefault.ToString("0.####")));
+            items.Add(new("ps.txFeedbackAttenuationDb", state.PsTxFeedbackAttenuationDb.ToString()));
+            items.Add(new("ps.txFeedbackAttenuationDbMin", state.PsTxFeedbackAttenuationDbMin.ToString()));
+            items.Add(new("ps.feedbackSource", state.PsFeedbackSource.ToString()));
+            items.Add(new("ps.auto", state.PsAuto ? "true" : "false"));
+            items.Add(new("ps.autoAttenuate", state.PsAutoAttenuate ? "true" : "false"));
+            items.Add(new("ps.correcting", state.PsCorrecting ? "true" : "false"));
+            items.Add(new("ps.calibrationStalled", state.PsCalibrationStalled ? "true" : "false"));
+        }
+        catch (Exception ex)
+        {
+            items.Add(new("status", "error"));
+            items.Add(new("error", ex.GetType().Name));
+        }
+
+        return new DiagnosticSection(Id, "TX & PureSignal", items);
+    }
+}

--- a/Zeus.Server.Hosting/Diagnostics/Redaction.cs
+++ b/Zeus.Server.Hosting/Diagnostics/Redaction.cs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using System.Text.RegularExpressions;
+
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>
+/// Pure, deterministic PII/secret scrubber for log + free-text lines that ship
+/// in a "Report a problem" diagnostic bundle. The goal is to keep a line useful
+/// for diagnosis (callsigns, board names, firmware versions, frequencies all
+/// survive) while removing things that identify the operator or leak secrets:
+/// passwords/tokens, email addresses, IP/MAC addresses, the username embedded in
+/// home-directory paths, and the precise tail of a 6-character Maidenhead grid.
+///
+/// No I/O, no locale-dependent parsing, culture-invariant. All regexes are
+/// compiled once and reused; anchoring is deliberately conservative so ordinary
+/// prose is left intact.
+/// </summary>
+public static class Redaction
+{
+    private const RegexOptions Opts =
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase;
+
+    // key=value / key: value where key is a known secret-ish name. The value is
+    // everything up to whitespace, a quote, comma, semicolon, or end-of-line so
+    // we don't swallow the rest of a structured line. An optional auth scheme
+    // word (Bearer/Basic/Token) immediately after the separator is preserved so
+    // "Authorization: Bearer xyz" masks the actual credential, not the scheme.
+    private static readonly Regex SecretKv = new(
+        @"\b(password|passwd|pwd|secret|token|apikey|api[_-]?key|bearer|authorization)\b(\s*[:=]\s*)(""?)(?:(Bearer|Basic|Token)\s+)?([^\s""',;]+)",
+        Opts);
+
+    // Email address. Local-part and domain both collapse to ***.
+    private static readonly Regex Email = new(
+        @"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b",
+        Opts);
+
+    // MAC address (six colon- or hyphen-separated hex octets). Matched BEFORE
+    // IPv6 so we don't confuse it with an address; replaced with a fixed mask.
+    private static readonly Regex Mac = new(
+        @"\b(?:[0-9A-Fa-f]{2}[:\-]){5}[0-9A-Fa-f]{2}\b",
+        Opts);
+
+    // IPv4 dotted quad, each octet 0-255, word-boundaried so version strings
+    // like "10.0.0" partials inside longer tokens are not clipped mid-number.
+    private static readonly Regex Ipv4 = new(
+        @"\b(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\b",
+        Opts);
+
+    // IPv6, optionally bracketed. Two disjoint shapes so a 2-colon timestamp
+    // (HH:MM:SS) can never match:
+    //   (a) any token containing "::" (compressed form), with hex groups around it;
+    //   (b) the full uncompressed form of exactly eight hex groups (seven colons).
+    // A "HH:MM:SS.fff" timestamp has no "::" and only two colons, so neither fires.
+    private static readonly Regex Ipv6 = new(
+        @"\[?(?:[0-9A-Fa-f]{1,4}:){1,7}:(?:[0-9A-Fa-f]{1,4})?(?::[0-9A-Fa-f]{1,4})*\]?" +
+        @"|\[?::(?:[0-9A-Fa-f]{1,4}:){0,6}[0-9A-Fa-f]{1,4}\]?" +
+        @"|\[?(?:[0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}\]?",
+        Opts);
+
+    // Home-directory username in a path. Three platform shapes; capture the
+    // leading prefix so it is preserved and only the <name> segment is masked.
+    private static readonly Regex UnixHomeUsers = new(
+        @"(/Users/|/home/)[^/\\\s:]+",
+        Opts);
+    private static readonly Regex WinHomeUsers = new(
+        @"([A-Za-z]:\\Users\\)[^\\/\s:]+",
+        Opts);
+
+    // 6-character Maidenhead grid (field-square-subsquare), e.g. FN31pr. Keep
+    // the 4-char field+square (coarse, useful), drop the precise subsquare.
+    // Anchored with word boundaries and a strict shape so words like "letter"
+    // or "an12cd"-style tokens elsewhere are not mangled.
+    private static readonly Regex GridSquare6 = new(
+        @"\b([A-R]{2}\d{2})[a-x]{2}\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>Scrub a single line. Returns the line with PII/secrets masked.</summary>
+    public static string Scrub(string line)
+    {
+        if (string.IsNullOrEmpty(line)) return line;
+
+        string s = line;
+
+        // Secrets first: a token could itself look like an email/grid otherwise.
+        s = SecretKv.Replace(s, static m =>
+        {
+            string scheme = m.Groups[4].Success ? m.Groups[4].Value + " " : string.Empty;
+            return string.Concat(m.Groups[1].Value, m.Groups[2].Value, m.Groups[3].Value, scheme, "***");
+        });
+
+        // MAC before IPv6 (a MAC shares the colon-hex shape).
+        s = Mac.Replace(s, "xx:xx:xx:xx:xx:xx");
+        s = Email.Replace(s, "***@***");
+        s = Ipv4.Replace(s, "x.x.x.x");
+        s = Ipv6.Replace(s, "[ipv6]");
+
+        s = UnixHomeUsers.Replace(s, static m => m.Groups[1].Value + "<user>");
+        s = WinHomeUsers.Replace(s, static m => m.Groups[1].Value + "<user>");
+
+        s = GridSquare6.Replace(s, static m => m.Groups[1].Value);
+
+        return s;
+    }
+
+    /// <summary>Scrub every line in the input, preserving order.</summary>
+    public static IReadOnlyList<string> ScrubAll(IEnumerable<string> lines)
+    {
+        ArgumentNullException.ThrowIfNull(lines);
+        var result = new List<string>();
+        foreach (var line in lines)
+            result.Add(Scrub(line));
+        return result;
+    }
+}

--- a/Zeus.Server.Hosting/Diagnostics/RingBufferLoggerProvider.cs
+++ b/Zeus.Server.Hosting/Diagnostics/RingBufferLoggerProvider.cs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>
+/// An <see cref="ILoggerProvider"/> that mirrors every formatted log line (at
+/// Information level and above) into a singleton <see cref="DiagnosticLogBuffer"/>
+/// after running it through <see cref="Redaction.Scrub"/>. Attaching this to the
+/// host's logging pipeline means the "Report a problem" button can snapshot the
+/// recent log retroactively — the ring is always being filled.
+///
+/// Trace/Debug are intentionally dropped to keep the (capacity-bounded) ring
+/// signal-dense. Scopes are no-ops. The underlying buffer is thread-safe, so the
+/// provider holds no per-call lock of its own.
+/// </summary>
+public sealed class RingBufferLoggerProvider : ILoggerProvider
+{
+    private readonly DiagnosticLogBuffer _buffer;
+
+    public RingBufferLoggerProvider(DiagnosticLogBuffer buffer)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        _buffer = buffer;
+    }
+
+    public ILogger CreateLogger(string categoryName) =>
+        new RingBufferLogger(_buffer, ShortCategory(categoryName));
+
+    public void Dispose() { /* buffer is owned elsewhere (singleton); nothing to release */ }
+
+    /// <summary>Last dotted segment of a logger category (e.g. "Zeus.Server.RadioService" → "RadioService").</summary>
+    private static string ShortCategory(string category)
+    {
+        if (string.IsNullOrEmpty(category)) return category ?? string.Empty;
+        int dot = category.LastIndexOf('.');
+        return dot >= 0 && dot < category.Length - 1 ? category[(dot + 1)..] : category;
+    }
+
+    private sealed class RingBufferLogger : ILogger
+    {
+        private static readonly IDisposable NoopScope = new NoopDisposable();
+
+        private readonly DiagnosticLogBuffer _buffer;
+        private readonly string _shortCategory;
+
+        public RingBufferLogger(DiagnosticLogBuffer buffer, string shortCategory)
+        {
+            _buffer = buffer;
+            _shortCategory = shortCategory;
+        }
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NoopScope;
+
+        // Information and above only — keep the ring dense.
+        public bool IsEnabled(LogLevel logLevel) =>
+            logLevel >= LogLevel.Information && logLevel != LogLevel.None;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (!IsEnabled(logLevel)) return;
+            ArgumentNullException.ThrowIfNull(formatter);
+
+            string message = formatter(state, exception);
+            if (string.IsNullOrEmpty(message) && exception is null) return;
+
+            // "{HH:mm:ss.fff} {level} {category-short} {message}" — culture-invariant timestamp.
+            string ts = DateTime.Now.ToString("HH:mm:ss.fff", System.Globalization.CultureInfo.InvariantCulture);
+            string line = exception is null
+                ? $"{ts} {Level(logLevel)} {_shortCategory} {message}"
+                : $"{ts} {Level(logLevel)} {_shortCategory} {message} {exception}";
+
+            _buffer.Add(Redaction.Scrub(line));
+        }
+
+        private static string Level(LogLevel level) => level switch
+        {
+            LogLevel.Information => "INFO",
+            LogLevel.Warning => "WARN",
+            LogLevel.Error => "ERROR",
+            LogLevel.Critical => "CRIT",
+            _ => level.ToString().ToUpperInvariant(),
+        };
+
+        private sealed class NoopDisposable : IDisposable
+        {
+            public void Dispose() { }
+        }
+    }
+}

--- a/Zeus.Server.Hosting/Diagnostics/Rules/AudioUnderrunRule.cs
+++ b/Zeus.Server.Hosting/Diagnostics/Rules/AudioUnderrunRule.cs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>
+/// The most common cause of crackling / dropping receive audio: the output
+/// audio buffer keeps running dry (underruns). The DSP side can be perfectly
+/// healthy (no queue-full, no overruns) while the OS audio sink starves because
+/// the machine can't feed it on time — heard as crackle, stutter, or gaps. The
+/// dsp-audio probe reports the cumulative underrun sample count; this rule turns
+/// a large count into a plain-language likely-cause instead of leaving the
+/// number buried in the system dump.
+/// </summary>
+public sealed class AudioUnderrunRule : IKnownIssueRule
+{
+    public string Id => "audio-underrun";
+
+    public IReadOnlyCollection<string> Symptoms { get; } = ["rx-audio-quality", "rx-no-audio"];
+
+    public DiagnosticFinding? Evaluate(
+        DiagnosticContext ctx, IReadOnlyList<DiagnosticSection> sections)
+    {
+        var section = RuleInspection.Section(sections, "dsp-audio");
+        if (section is null) return null;
+
+        if (!TryParseLong(RuleInspection.Value(section, "audio.underrunSamplesTotal"), out long underruns))
+            return null;
+
+        int sampleRate = TryParseInt(RuleInspection.Value(section, "audio.sampleRateHz"), 48000);
+        if (sampleRate <= 0) sampleRate = 48000;
+
+        // Ignore a trivial handful (a single underrun at device start is normal).
+        // Flag once the lost audio exceeds ~0.1 s — that is clearly audible.
+        if (underruns < sampleRate / 10) return null;
+
+        double seconds = (double)underruns / sampleRate;
+        return new DiagnosticFinding(
+            Title: "Receive audio is dropping out (output buffer underruns)",
+            Detail:
+                $"Zeus's audio output ran out of buffered sound {underruns.ToString("N0", CultureInfo.InvariantCulture)} " +
+                $"times so far this session (about {seconds.ToString("0.0", CultureInfo.InvariantCulture)} seconds of audio lost). " +
+                "That is exactly what crackling, stuttering, or brief gaps sound like, and it means the " +
+                "computer could not feed the sound card fast enough — not a radio fault. Try: close other " +
+                "heavy apps, turn off power-saving / battery-saver, make sure the right output device is " +
+                "selected, and restart Zeus. If it keeps happening, include this report so we can dig in.",
+            Severity: DiagnosticSeverity.Likely,
+            DocRef: null);
+    }
+
+    private static bool TryParseLong(string? value, out long result) =>
+        long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
+
+    private static int TryParseInt(string? value, int fallback) =>
+        int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int v) ? v : fallback;
+}

--- a/Zeus.Server.Hosting/Diagnostics/Rules/DisconnectionRule.cs
+++ b/Zeus.Server.Hosting/Diagnostics/Rules/DisconnectionRule.cs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using System.Collections.Generic;
+
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>
+/// The radio won't connect or keeps dropping. The most common backend signature
+/// is a run of RX socket timeouts ("radio gone"), which points at the radio or
+/// the network rather than at Zeus — wired Ethernet vs WiFi is the usual culprit
+/// at Protocol 1 packet rates. Surfaced for the won't-connect symptom with a
+/// pointer to the troubleshooting guide.
+/// </summary>
+public sealed class DisconnectionRule : IKnownIssueRule
+{
+    public string Id => "disconnection";
+
+    public IReadOnlyCollection<string> Symptoms { get; } = ["wont-connect"];
+
+    public DiagnosticFinding? Evaluate(
+        DiagnosticContext ctx, IReadOnlyList<DiagnosticSection> sections)
+    {
+        bool rxTimeout =
+            RuleInspection.LogContains(ctx.RecentLog, "consecutive socket timeouts") ||
+            RuleInspection.LogContains(ctx.RecentLog, "radio gone");
+
+        if (rxTimeout)
+        {
+            return new DiagnosticFinding(
+                Title: "Radio stopped sending data (RX timeout)",
+                Detail:
+                    "The log shows the radio stopped sending data long enough for " +
+                    "Zeus to declare it gone (a run of receive timeouts). That points " +
+                    "at the radio or the network, not at Zeus. First, ping the radio's " +
+                    "IP: if it doesn't answer, the radio lost power or its firmware " +
+                    "restarted. If it does answer, you're losing UDP packets — switch " +
+                    "from WiFi to wired Gigabit Ethernet (Protocol 1 sends ~1200 " +
+                    "packets/second and WiFi drops them under contention) and reduce " +
+                    "other network load.",
+                Severity: DiagnosticSeverity.Likely,
+                DocRef: "docs/lessons/disconnection-troubleshooting.md");
+        }
+
+        // No timeout fingerprint: still offer the guide as general advice, but
+        // only as a Warning so it doesn't outrank a more specific finding.
+        return new DiagnosticFinding(
+            Title: "Connection / dropout troubleshooting",
+            Detail:
+                "Connect-and-drop problems are usually network rather than Zeus. " +
+                "Prefer wired Gigabit Ethernet over WiFi for Protocol 1 radios, make " +
+                "sure your computer and the radio are on the same subnet, and after " +
+                "switching networks click Disconnect then Discover (Zeus does not " +
+                "auto-reconnect after a network change). If you run the dev server, " +
+                "brief disconnects every time you save a file are expected Vite " +
+                "reloads, not a fault.",
+            Severity: DiagnosticSeverity.Warning,
+            DocRef: "docs/lessons/disconnection-troubleshooting.md");
+    }
+}

--- a/Zeus.Server.Hosting/Diagnostics/Rules/Hl2DriveModelRule.cs
+++ b/Zeus.Server.Hosting/Diagnostics/Rules/Hl2DriveModelRule.cs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using System.Collections.Generic;
+
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>
+/// Low transmit power on a Hermes Lite 2. The HL2 does NOT use the dB-based
+/// drive model the other HPSDR boards use — it uses a percentage-based model, so
+/// the "PA Gain (dB)" field is actually a per-band output percentage (0..100),
+/// shown in the UI as "PA Output (%)". Hand-calibrated dB values carried over
+/// from another radio (e.g. 40.5 or 26) get silently reinterpreted as a low
+/// percentage and produce ~20-40% of rated power. The fix is almost always
+/// "press Reset to Hermes Lite 2 defaults" (100% on HF). Informational guidance
+/// whenever the connected board is an HL2 and the symptom is low TX power.
+/// </summary>
+public sealed class Hl2DriveModelRule : IKnownIssueRule
+{
+    public string Id => "hl2-drive-model";
+
+    public IReadOnlyCollection<string> Symptoms { get; } = ["no-tx-power"];
+
+    public DiagnosticFinding? Evaluate(
+        DiagnosticContext ctx, IReadOnlyList<DiagnosticSection> sections)
+    {
+        if (!RuleInspection.IsHermesLite2(sections))
+            return null;
+
+        return new DiagnosticFinding(
+            Title: "Hermes Lite 2 uses a percentage drive model, not dB",
+            Detail:
+                "On the Hermes Lite 2 the \"PA Gain\" value is a per-band output " +
+                "PERCENTAGE (0-100, shown as \"PA Output (%)\"), not decibels like " +
+                "the other radios. If you carried over a hand-calibrated dB number " +
+                "from another rig (for example 40.5 or 26), the HL2 now reads it as " +
+                "that percentage of full output, which is why power tops out at " +
+                "roughly 20-40%. Open the PA Settings panel and press \"Reset to " +
+                "Hermes Lite 2 defaults\" to seed 100% on HF (and the lower 6 m " +
+                "soft-cap). Then key TUN and confirm full power.",
+            Severity: DiagnosticSeverity.Warning,
+            DocRef: "docs/lessons/hl2-drive-model.md");
+    }
+}

--- a/Zeus.Server.Hosting/Diagnostics/Rules/IqWriteGateRule.cs
+++ b/Zeus.Server.Hosting/Diagnostics/Rules/IqWriteGateRule.cs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using System.Collections.Generic;
+
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>
+/// No (or near-zero) transmit power on a Hermes-class board even though a drive
+/// byte is going out: the IQ-write gate isn't open, so the radio is keyed with a
+/// non-zero drive level but no modulation samples reach the wire. The fingerprint
+/// is a <c>p1.tx.rate</c> log line with a non-zero <c>drv=</c> while <c>peak=0</c>
+/// (drive present, IQ peak zero). PS can't calibrate against a flat carrier
+/// either, so this also explains a PS-won't-work report.
+/// </summary>
+public sealed class IqWriteGateRule : IKnownIssueRule
+{
+    public string Id => "iq-write-gate";
+
+    public IReadOnlyCollection<string> Symptoms { get; } = ["no-tx-power", "ps-not-working"];
+
+    public DiagnosticFinding? Evaluate(
+        DiagnosticContext ctx, IReadOnlyList<DiagnosticSection> sections)
+    {
+        if (!RuleInspection.IsHermesClass(sections))
+            return null;
+
+        if (!RuleInspection.HasTxRateDriveButZeroPeak(ctx.RecentLog))
+            return null;
+
+        return new DiagnosticFinding(
+            Title: "Transmit IQ never reaches the radio (IQ-write gate)",
+            Detail:
+                "The radio is being keyed with a drive level set, but the transmit " +
+                "log shows the outgoing IQ peak is zero (drv= is non-zero while " +
+                "peak=0). That means the modulation samples aren't being written to " +
+                "the wire — the radio transmits an unmodulated, near-zero-power " +
+                "signal. On Hermes-class boards this is the IQ-write-gate pattern: " +
+                "audio is flowing into the TX stage but the IQ-write gate to the " +
+                "protocol client isn't open. PureSignal also can't calibrate against " +
+                "a flat carrier, so this can show up as 'PS won't work' too.",
+            Severity: DiagnosticSeverity.Likely,
+            DocRef: "docs/rca/2026-05-25-anan10e-wire-0x06-reclassify.md");
+    }
+}

--- a/Zeus.Server.Hosting/Diagnostics/Rules/PsNotArmedRule.cs
+++ b/Zeus.Server.Hosting/Diagnostics/Rules/PsNotArmedRule.cs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using System.Collections.Generic;
+
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>
+/// PureSignal produced no correction because it was never armed this session.
+/// Zeus never auto-arms PS — that is a hard safety rule (PsEnabled always
+/// initialises to false on startup; the operator arms it manually every
+/// session). The fingerprint is either the auto-attenuate gate logging
+/// <c>skip=PsEnabled-off</c>, or the tx-ps probe reporting PsEnabled=false.
+/// </summary>
+public sealed class PsNotArmedRule : IKnownIssueRule
+{
+    public string Id => "ps-not-armed";
+
+    public IReadOnlyCollection<string> Symptoms { get; } = ["ps-not-working"];
+
+    public DiagnosticFinding? Evaluate(
+        DiagnosticContext ctx, IReadOnlyList<DiagnosticSection> sections)
+    {
+        // The psAutoAttn gate logs this exact marker when PS is not armed.
+        bool gateSkipped = RuleInspection.LogContains(ctx.RecentLog, "skip=PsEnabled-off");
+
+        // Or the tx-ps probe directly reports the arm flag is off (key "ps.enabled";
+        // "PsEnabled" accepted as a forward-compatible alias).
+        var psEnabled =
+            RuleInspection.Value(sections, "tx-ps", "ps.enabled") ??
+            RuleInspection.Value(sections, "tx-ps", "PsEnabled");
+        bool reportedOff = RuleInspection.IsFalse(psEnabled);
+
+        if (!gateSkipped && !reportedOff)
+            return null;
+
+        return new DiagnosticFinding(
+            Title: "PureSignal was not armed this session",
+            Detail:
+                "PureSignal never ran because it was not armed. Zeus never turns " +
+                "PureSignal on by itself — that is a safety rule, so PS always starts " +
+                "OFF every time the server starts, and you arm it manually each " +
+                "session. Open the PURESIGNAL panel and arm PS, then key up to let it " +
+                "calibrate. If it still won't converge, check the HW Peak setting next.",
+            Severity: DiagnosticSeverity.Likely,
+            DocRef: "CLAUDE.md");
+    }
+}

--- a/Zeus.Server.Hosting/Diagnostics/Rules/PsStartupArmedRule.cs
+++ b/Zeus.Server.Hosting/Diagnostics/Rules/PsStartupArmedRule.cs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using System.Collections.Generic;
+
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>
+/// Defensive safety-invariant check, evaluated for every symptom (no symptom
+/// filter). PureSignal MUST always initialise to OFF on server startup — the
+/// operator arms it manually each session. If the tx-ps probe reports PS armed
+/// immediately at startup (before any operator action), the no-auto-arm
+/// invariant has been violated and PS could be live on a feedback chain the
+/// operator hasn't checked, which can saturate the feedback ADC. This should
+/// essentially never fire; when it does, it is Critical.
+/// </summary>
+public sealed class PsStartupArmedRule : IKnownIssueRule
+{
+    public string Id => "ps-startup-armed";
+
+    // Empty = evaluate for every symptom.
+    public IReadOnlyCollection<string> Symptoms { get; } = [];
+
+    public DiagnosticFinding? Evaluate(
+        DiagnosticContext ctx, IReadOnlyList<DiagnosticSection> sections)
+    {
+        // The tx-ps probe is expected to flag this explicitly if it ever detects PS
+        // armed at startup with no operator action. No such key exists today (the
+        // probe only reports the current "ps.enabled" / "ps.armedAtStartup"), so in
+        // normal operation this rule stays silent — it is purely a tripwire for a
+        // regression of the PsEnabled-must-init-false invariant. We also honour a
+        // log marker if one is ever emitted.
+        var armedAtStartup =
+            RuleInspection.Value(sections, "tx-ps", "ps.armedAtStartup") ??
+            RuleInspection.Value(sections, "tx-ps", "ps.autoArmedAtStartup") ??
+            RuleInspection.Value(sections, "tx-ps", "PsArmedAtStartup") ??
+            RuleInspection.Value(sections, "tx-ps", "PsAutoArmedAtStartup");
+
+        bool flagged = RuleInspection.IsTrue(armedAtStartup) ||
+                       RuleInspection.LogContains(ctx.RecentLog, "ps.startup.autoArmed");
+
+        if (!flagged)
+            return null;
+
+        return new DiagnosticFinding(
+            Title: "PureSignal appears to have armed itself at startup",
+            Detail:
+                "PureSignal reports as armed at startup without any operator action. " +
+                "This should never happen: Zeus always starts with PureSignal OFF as " +
+                "a safety rule, and the operator arms it manually each session. An " +
+                "auto-armed PureSignal on an unchecked feedback chain can saturate " +
+                "the feedback ADC before you make any transmit decision. Do not " +
+                "transmit until you have disarmed PureSignal and confirmed it is off. " +
+                "Please report this with the log below — it indicates a real bug in " +
+                "the startup state.",
+            Severity: DiagnosticSeverity.Critical,
+            DocRef: "CLAUDE.md");
+    }
+}

--- a/Zeus.Server.Hosting/Diagnostics/Rules/RuleInspection.cs
+++ b/Zeus.Server.Hosting/Diagnostics/Rules/RuleInspection.cs
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using System;
+using System.Collections.Generic;
+
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>
+/// Small read-only helpers shared by the known-issue rules: find a probe's
+/// section by id, read a key's value out of it, and scan the recent log for a
+/// structured marker. Kept deliberately defensive — every helper tolerates
+/// missing sections / keys and returns a safe default, so a rule can be written
+/// as a chain of these without null-guards everywhere.
+/// </summary>
+internal static class RuleInspection
+{
+    /// <summary>The section a given probe id contributed, or null if it didn't run.</summary>
+    public static DiagnosticSection? Section(
+        IReadOnlyList<DiagnosticSection> sections, string probeId)
+    {
+        for (int i = 0; i < sections.Count; i++)
+            if (string.Equals(sections[i].Id, probeId, StringComparison.OrdinalIgnoreCase))
+                return sections[i];
+        return null;
+    }
+
+    /// <summary>
+    /// The value of <paramref name="key"/> in <paramref name="section"/>, or null
+    /// if the section is null or the key is absent. Case-insensitive on the key.
+    /// </summary>
+    public static string? Value(DiagnosticSection? section, string key)
+    {
+        if (section is null) return null;
+        var items = section.Items;
+        for (int i = 0; i < items.Count; i++)
+            if (string.Equals(items[i].Key, key, StringComparison.OrdinalIgnoreCase))
+                return items[i].Value;
+        return null;
+    }
+
+    /// <summary>Convenience: read a key directly out of a probe's section.</summary>
+    public static string? Value(
+        IReadOnlyList<DiagnosticSection> sections, string probeId, string key)
+        => Value(Section(sections, probeId), key);
+
+    /// <summary>True when <paramref name="value"/> reads as a boolean false-ish flag.</summary>
+    public static bool IsFalse(string? value) =>
+        value is not null &&
+        (value.Equals("false", StringComparison.OrdinalIgnoreCase) ||
+         value.Equals("no", StringComparison.OrdinalIgnoreCase) ||
+         value.Equals("off", StringComparison.OrdinalIgnoreCase) ||
+         value == "0");
+
+    /// <summary>True when <paramref name="value"/> reads as a boolean true-ish flag.</summary>
+    public static bool IsTrue(string? value) =>
+        value is not null &&
+        (value.Equals("true", StringComparison.OrdinalIgnoreCase) ||
+         value.Equals("yes", StringComparison.OrdinalIgnoreCase) ||
+         value.Equals("on", StringComparison.OrdinalIgnoreCase) ||
+         value == "1");
+
+    /// <summary>
+    /// True if any recent-log line contains <paramref name="marker"/>
+    /// (case-insensitive substring — the structured markers are ASCII).
+    /// </summary>
+    public static bool LogContains(IReadOnlyList<string> recentLog, string marker)
+    {
+        for (int i = 0; i < recentLog.Count; i++)
+        {
+            var line = recentLog[i];
+            if (line is not null &&
+                line.Contains(marker, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// True if any recent-log line contains <em>all</em> of the given markers.
+    /// Used to spot a single structured line carrying several fields, e.g.
+    /// <c>p1.tx.rate ... drv=240 peak=0</c>.
+    /// </summary>
+    public static bool LogLineContainsAll(IReadOnlyList<string> recentLog, params string[] markers)
+    {
+        for (int i = 0; i < recentLog.Count; i++)
+        {
+            var line = recentLog[i];
+            if (line is null) continue;
+            bool all = true;
+            for (int m = 0; m < markers.Length; m++)
+            {
+                if (!line.Contains(markers[m], StringComparison.OrdinalIgnoreCase))
+                {
+                    all = false;
+                    break;
+                }
+            }
+            if (all) return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Scan recent-log lines for a <c>p1.tx.rate</c> line that reports a non-zero
+    /// drive byte (<c>drv=</c>) while the measured peak is zero (<c>peak=0</c>) —
+    /// the IQ-write-gate fingerprint (audio present, no IQ on the wire).
+    /// </summary>
+    public static bool HasTxRateDriveButZeroPeak(IReadOnlyList<string> recentLog)
+    {
+        for (int i = 0; i < recentLog.Count; i++)
+        {
+            var line = recentLog[i];
+            if (line is null || !line.Contains("p1.tx.rate", StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (PeakIsZero(line) && DriveIsNonZero(line))
+                return true;
+        }
+        return false;
+    }
+
+    private static bool PeakIsZero(string line)
+    {
+        int v = FieldInt(line, "peak=", -1);
+        return v == 0;
+    }
+
+    private static bool DriveIsNonZero(string line)
+    {
+        int v = FieldInt(line, "drv=", 0);
+        return v > 0;
+    }
+
+    /// <summary>
+    /// True if any value in the board section contains <paramref name="needle"/>
+    /// (case-insensitive). The board probe's exact key names aren't part of our
+    /// contract, so we scan every value rather than guess a key. Returns false
+    /// when the board probe didn't run.
+    /// </summary>
+    public static bool BoardSectionMentions(
+        IReadOnlyList<DiagnosticSection> sections, string needle)
+    {
+        var section = Section(sections, "board");
+        if (section is null) return false;
+        var items = section.Items;
+        for (int i = 0; i < items.Count; i++)
+        {
+            var v = items[i].Value;
+            if (v is not null && v.Contains(needle, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>True when the connected board is Hermes Lite 2 (HL2).</summary>
+    public static bool IsHermesLite2(IReadOnlyList<DiagnosticSection> sections) =>
+        BoardSectionMentions(sections, "HermesLite2") ||
+        BoardSectionMentions(sections, "Hermes Lite 2") ||
+        BoardSectionMentions(sections, "Hermes-Lite 2") ||
+        BoardSectionMentions(sections, "HL2");
+
+    /// <summary>
+    /// True when the connected board is in the Hermes / Hermes-II family
+    /// (Hermes, HermesII, ANAN-10/10E/100/100B). Excludes Hermes Lite 2, which
+    /// has its own profile and is matched by <see cref="IsHermesLite2"/>.
+    /// </summary>
+    public static bool IsHermesClass(IReadOnlyList<DiagnosticSection> sections)
+    {
+        if (IsHermesLite2(sections)) return false;
+        return BoardSectionMentions(sections, "Hermes") ||
+               BoardSectionMentions(sections, "ANAN-10") ||
+               BoardSectionMentions(sections, "Anan10") ||
+               BoardSectionMentions(sections, "ANAN-100") ||
+               BoardSectionMentions(sections, "Anan100");
+    }
+
+    /// <summary>Parse the integer immediately after <paramref name="token"/> in a log line.</summary>
+    private static int FieldInt(string line, string token, int fallback)
+    {
+        int idx = line.IndexOf(token, StringComparison.OrdinalIgnoreCase);
+        if (idx < 0) return fallback;
+        int start = idx + token.Length;
+        int end = start;
+        while (end < line.Length && (char.IsDigit(line[end]) || (end == start && line[end] == '-')))
+            end++;
+        if (end == start) return fallback;
+        return int.TryParse(
+            line.AsSpan(start, end - start),
+            System.Globalization.NumberStyles.Integer,
+            System.Globalization.CultureInfo.InvariantCulture,
+            out int parsed)
+            ? parsed
+            : fallback;
+    }
+}

--- a/Zeus.Server.Hosting/Diagnostics/Rules/RxAuxBypassRule.cs
+++ b/Zeus.Server.Hosting/Diagnostics/Rules/RxAuxBypassRule.cs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using System.Collections.Generic;
+
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>
+/// A common receive foot-gun: a band's RX-aux setting is left on "Bypass", which
+/// routes that band's receive path to an empty/unused antenna jack instead of the
+/// real antenna. The classic signature is exactly one dead band with an unusually
+/// low noise floor while other bands are fine. This is an operator setting, not a
+/// Zeus bug — the fix is to set that band's RX-aux back to "None". Surfaced as a
+/// warning on both no-audio and crackle/distortion receive reports so the operator
+/// rules it out before chasing the DSP path.
+/// </summary>
+public sealed class RxAuxBypassRule : IKnownIssueRule
+{
+    public string Id => "rx-aux-bypass";
+
+    public IReadOnlyCollection<string> Symptoms { get; } = ["rx-no-audio", "rx-audio-quality"];
+
+    public DiagnosticFinding? Evaluate(
+        DiagnosticContext ctx, IReadOnlyList<DiagnosticSection> sections)
+    {
+        // No reliable per-band RX-aux signal is collected, so this rule always
+        // surfaces as advisory context for the receive symptoms — it's a cheap,
+        // high-frequency mistake worth ruling out first. It never claims to be
+        // the confirmed cause (Warning, not Likely).
+        return new DiagnosticFinding(
+            Title: "Check the band's RX-aux setting (Bypass routes to an empty jack)",
+            Detail:
+                "If only one band is dead — or much quieter than the others, with an " +
+                "unusually low noise floor — check that band's RX-aux setting. When " +
+                "RX-aux is set to \"Bypass\", receive is routed to an unused / empty " +
+                "antenna jack instead of your real antenna, so you hear little or " +
+                "nothing. This is a setting, not a fault. Set the affected band's " +
+                "RX-aux back to \"None\" and the antenna comes back. If every band is " +
+                "dead, this isn't it — look at the audio path instead.",
+            Severity: DiagnosticSeverity.Warning,
+            DocRef: null);
+    }
+}

--- a/Zeus.Server.Hosting/Diagnostics/Rules/RxAuxBypassRule.cs
+++ b/Zeus.Server.Hosting/Diagnostics/Rules/RxAuxBypassRule.cs
@@ -8,15 +8,16 @@ namespace Zeus.Server.Diagnostics;
 /// routes that band's receive path to an empty/unused antenna jack instead of the
 /// real antenna. The classic signature is exactly one dead band with an unusually
 /// low noise floor while other bands are fine. This is an operator setting, not a
-/// Zeus bug — the fix is to set that band's RX-aux back to "None". Surfaced as a
-/// warning on both no-audio and crackle/distortion receive reports so the operator
-/// rules it out before chasing the DSP path.
+/// Zeus bug — the fix is to set that band's RX-aux back to "None". Surfaced only on
+/// the no-audio report: Bypass causes silence/weak receive, NOT crackle/distortion,
+/// so firing it on a "crackles" report just misdirects the operator (the real
+/// crackle cause is the audio path — see <see cref="AudioUnderrunRule"/>).
 /// </summary>
 public sealed class RxAuxBypassRule : IKnownIssueRule
 {
     public string Id => "rx-aux-bypass";
 
-    public IReadOnlyCollection<string> Symptoms { get; } = ["rx-no-audio", "rx-audio-quality"];
+    public IReadOnlyCollection<string> Symptoms { get; } = ["rx-no-audio"];
 
     public DiagnosticFinding? Evaluate(
         DiagnosticContext ctx, IReadOnlyList<DiagnosticSection> sections)

--- a/Zeus.Server.Hosting/Diagnostics/Rules/RxaAudioSilenceRule.cs
+++ b/Zeus.Server.Hosting/Diagnostics/Rules/RxaAudioSilenceRule.cs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using System.Collections.Generic;
+
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>
+/// No receive audio while the panadapter still animates — the WDSP RXA channel
+/// opened but the DSP/meter worker (xrxa / xmeter) never ran, so the audio ring
+/// stays empty. The tell-tale is the RX S-meter sitting at the -400 sentinel:
+/// that value means the meter thread didn't run, which is the same condition that
+/// starves the audio path. Root cause is WDSP channel-state init ordering (open at
+/// state 0, flip to 1 only after the worker is live). Surfaced as advisory context
+/// for the no-RX-audio symptom.
+/// </summary>
+public sealed class RxaAudioSilenceRule : IKnownIssueRule
+{
+    public string Id => "rxa-audio-silence";
+
+    public IReadOnlyCollection<string> Symptoms { get; } = ["rx-no-audio"];
+
+    public DiagnosticFinding? Evaluate(
+        DiagnosticContext ctx, IReadOnlyList<DiagnosticSection> sections)
+    {
+        // Look for the -400 meter sentinel either in a probe's reported RX dBm
+        // (forward-compatible key, not collected today) or in the recent log. The
+        // panadapter animating while audio is silent is the classic misleading
+        // clue, so we don't require a "pan ok" signal.
+        var rxDbm =
+            RuleInspection.Value(sections, "dsp-audio", "rx.dbm") ??
+            RuleInspection.Value(sections, "dsp-audio", "RxDbm");
+        bool meterSentinel =
+            (rxDbm is not null && rxDbm.Contains("-400")) ||
+            RuleInspection.LogContains(ctx.RecentLog, "-400");
+
+        if (!meterSentinel)
+            return null;
+
+        return new DiagnosticFinding(
+            Title: "Receive DSP started but produced no audio (WDSP init ordering)",
+            Detail:
+                "The receive meter is reading the -400 sentinel, which means the DSP " +
+                "engine's receive worker never actually ran — even though the " +
+                "panadapter may keep animating (that runs on a separate path and is a " +
+                "misleading clue). When this happens there's no audio because the " +
+                "receive channel was brought up out of order. The known cause is a " +
+                "WDSP channel-state init-ordering issue (the channel must be opened " +
+                "idle and only switched on after its worker thread is live). If you " +
+                "see this consistently, disconnect and reconnect; if it persists, " +
+                "report it with the log below.",
+            Severity: DiagnosticSeverity.Likely,
+            DocRef: "docs/rca/2026-04-17-rxa-audio-silence.md");
+    }
+}

--- a/Zeus.Server.Hosting/Diagnostics/SymptomRegistry.cs
+++ b/Zeus.Server.Hosting/Diagnostics/SymptomRegistry.cs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>
+/// Canonical list of the symptoms the "Report a problem" picker offers, and the
+/// probe recipe (which <see cref="IDiagnosticProbe"/> ids to run) for each.
+///
+/// Recipe philosophy: be robust, not minimal. Always gather the cheap, always-
+/// relevant context (environment / connection / board) so a report is useful
+/// even when the operator picked the wrong symptom; layer the heavier DSP and
+/// TX/PS probes on top only where the symptom group implicates them. An unknown
+/// or "other"/null symptom runs everything.
+///
+/// Registered as a singleton; consumed by <see cref="DiagnosticReportBuilder"/>.
+/// </summary>
+public sealed class SymptomRegistry
+{
+    // Canonical probe ids (owned by the probe author; mirrored here for recipes).
+    private const string ProbeEnvironment = "environment";
+    private const string ProbeConnection = "connection";
+    private const string ProbeBoard = "board";
+    private const string ProbeDspAudio = "dsp-audio";
+    private const string ProbeTxPs = "tx-ps";
+
+    /// <summary>The base recipe every report includes, in a stable display order.</summary>
+    private static readonly string[] BaseProbes = [ProbeEnvironment, ProbeConnection, ProbeBoard];
+
+    /// <summary>Every probe id, in stable order — used for "other"/unknown/null.</summary>
+    private static readonly string[] AllProbes =
+        [ProbeEnvironment, ProbeConnection, ProbeBoard, ProbeDspAudio, ProbeTxPs];
+
+    private static readonly IReadOnlyList<Symptom> _all =
+    [
+        new Symptom("wont-connect", "Radio won't connect or keeps dropping", "Connection"),
+        new Symptom("no-tx-power", "No or low transmit power", "Transmit"),
+        new Symptom("ps-not-working", "PureSignal won't work or won't calibrate", "Transmit"),
+        new Symptom("tx-audio", "Transmit audio, mic, or processing problem", "Transmit"),
+        new Symptom("rx-no-audio", "No receive audio", "Receive"),
+        new Symptom("rx-audio-quality", "Receive audio crackles or distorts", "Receive"),
+        new Symptom("ui-display", "Display, waterfall, or panadapter problem", "Display"),
+        new Symptom("other", "Something else or not sure", "Other"),
+    ];
+
+    /// <summary>The eight selectable symptoms, in picker order.</summary>
+    public IReadOnlyList<Symptom> All => _all;
+
+    /// <summary>
+    /// Which probe ids to run for the given symptom. Robust by construction:
+    /// always includes environment/connection/board; adds dsp-audio for the
+    /// receive/tx-audio/display symptoms and tx-ps for the transmit-power/PS/
+    /// tx-audio symptoms. Unknown, "other", or null returns all five probes.
+    /// </summary>
+    public IReadOnlyList<string> ProbeIdsFor(string? symptomId)
+    {
+        switch (symptomId)
+        {
+            case "wont-connect":
+                return BaseProbes;
+
+            case "no-tx-power":
+            case "ps-not-working":
+                return [.. BaseProbes, ProbeTxPs];
+
+            case "tx-audio":
+                // Touches both the audio chain and the TX/PS path.
+                return [.. BaseProbes, ProbeDspAudio, ProbeTxPs];
+
+            case "rx-no-audio":
+            case "rx-audio-quality":
+            case "ui-display":
+                return [.. BaseProbes, ProbeDspAudio];
+
+            // "other", null, or anything we don't recognise → cast the widest net.
+            default:
+                return AllProbes;
+        }
+    }
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -13,6 +13,7 @@ using Zeus.Dsp.Wdsp;
 using Zeus.Protocol1;
 using Zeus.Protocol1.Discovery;
 using Zeus.Protocol2;
+using Zeus.Server.Diagnostics;
 using Zeus.Server.Tci;
 
 namespace Zeus.Server;
@@ -35,6 +36,20 @@ public static class ZeusEndpoints
             var version = attr?.InformationalVersion ?? "unknown";
             return Results.Ok(new { version });
         });
+
+        // Self-diagnostic "Report a problem" feature. The picker fetches the
+        // symptom list; submitting a symptom + free text returns a redacted,
+        // paste-ready report (Markdown + last-100 log lines) plus a prefilled
+        // GitHub "new issue" URL. Strictly read-only.
+        app.MapGet("/api/diagnostics/symptoms",
+            (DiagnosticReportBuilder diag) => Results.Ok(diag.Symptoms()));
+
+        app.MapPost("/api/diagnostics/report",
+            (DiagnosticRequest req, DiagnosticReportBuilder diag) =>
+            {
+                log.LogInformation("api.diagnostics.report symptom={Symptom}", req.SymptomId ?? "(none)");
+                return Results.Ok(diag.Build(req));
+            });
 
         // Capabilities snapshot — host-mode + platform metadata. Frontend
         // fetches once on app mount; future feature gates will reattach as

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -14,6 +14,7 @@ using Zeus.Dsp.Wdsp;
 using Zeus.Plugins.Host;
 using Zeus.Protocol1;
 using Zeus.Protocol1.Discovery;
+using Zeus.Server.Diagnostics;
 using Zeus.Server.Tci;
 
 namespace Zeus.Server;
@@ -67,6 +68,15 @@ public static class ZeusHost
         // POST numeric mode values keep working.
         builder.Services.Configure<JsonOptions>(o =>
             o.SerializerOptions.Converters.Add(new JsonStringEnumConverter()));
+
+        // Self-diagnostic log capture (the "Report a problem" footer button). A
+        // singleton ring buffer always retains the last ~1000 formatted log lines
+        // (you can't capture logs retroactively), and the report ships the last
+        // 100. The provider and the DI singleton MUST be the same instance so the
+        // report builder snapshots what the provider has been filling.
+        var diagnosticLogBuffer = new DiagnosticLogBuffer();
+        builder.Services.AddSingleton(diagnosticLogBuffer);
+        builder.Logging.AddProvider(new RingBufferLoggerProvider(diagnosticLogBuffer));
 
         // Resolve TCI bind settings from configuration before DI builds, because
         // Kestrel's listeners have to be declared now. TCI shares Kestrel (rather
@@ -358,6 +368,26 @@ public static class ZeusHost
         // Relaunch helper for the prefs-database (profile) selector — switching
         // the active DB applies on the next launch, so the endpoint relaunches.
         builder.Services.AddSingleton<AppRestartService>();
+
+        // Self-diagnostic "Report a problem" feature: read-only probes, the
+        // symptom→recipe registry, the known-issue rules (seeded from docs/rca +
+        // docs/lessons), and the report builder. All strictly read-only — the
+        // tx-ps probe reads PsEnabled/HwPeak but never arms PS (burn-zone).
+        builder.Services.AddSingleton<IDiagnosticProbe, EnvironmentProbe>();
+        builder.Services.AddSingleton<IDiagnosticProbe, ConnectionProbe>();
+        builder.Services.AddSingleton<IDiagnosticProbe, BoardProbe>();
+        builder.Services.AddSingleton<IDiagnosticProbe, DspAudioProbe>();
+        builder.Services.AddSingleton<IDiagnosticProbe, TxPsProbe>();
+        builder.Services.AddSingleton<IKnownIssueRule, PsNotArmedRule>();
+        builder.Services.AddSingleton<IKnownIssueRule, IqWriteGateRule>();
+        builder.Services.AddSingleton<IKnownIssueRule, RxAuxBypassRule>();
+        builder.Services.AddSingleton<IKnownIssueRule, Hl2DriveModelRule>();
+        builder.Services.AddSingleton<IKnownIssueRule, RxaAudioSilenceRule>();
+        builder.Services.AddSingleton<IKnownIssueRule, DisconnectionRule>();
+        builder.Services.AddSingleton<IKnownIssueRule, PsStartupArmedRule>();
+        builder.Services.AddSingleton<SymptomRegistry>();
+        builder.Services.AddSingleton<DiagnosticReportBuilder>();
+
         builder.Services.AddSingleton<DspSettingsStore>();
         builder.Services.AddSingleton<CfcPresetStore>();
         builder.Services.AddSingleton<PaSettingsStore>();

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -381,6 +381,7 @@ public static class ZeusHost
         builder.Services.AddSingleton<IKnownIssueRule, PsNotArmedRule>();
         builder.Services.AddSingleton<IKnownIssueRule, IqWriteGateRule>();
         builder.Services.AddSingleton<IKnownIssueRule, RxAuxBypassRule>();
+        builder.Services.AddSingleton<IKnownIssueRule, AudioUnderrunRule>();
         builder.Services.AddSingleton<IKnownIssueRule, Hl2DriveModelRule>();
         builder.Services.AddSingleton<IKnownIssueRule, RxaAudioSilenceRule>();
         builder.Services.AddSingleton<IKnownIssueRule, DisconnectionRule>();

--- a/tests/Zeus.Server.Tests/Diagnostics/DiagnosticLogBufferTests.cs
+++ b/tests/Zeus.Server.Tests/Diagnostics/DiagnosticLogBufferTests.cs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using System.Linq;
+using Xunit;
+using Zeus.Server.Diagnostics;
+
+namespace Zeus.Server.Tests;
+
+public class DiagnosticLogBufferTests
+{
+    [Fact]
+    public void Snapshot_EmptyBuffer_ReturnsEmpty()
+    {
+        var buf = new DiagnosticLogBuffer();
+        Assert.Empty(buf.Snapshot());
+    }
+
+    [Fact]
+    public void AddThenSnapshot_ReturnsOldestFirst()
+    {
+        var buf = new DiagnosticLogBuffer();
+        buf.Add("one");
+        buf.Add("two");
+        buf.Add("three");
+
+        Assert.Equal(new[] { "one", "two", "three" }, buf.Snapshot().ToArray());
+    }
+
+    [Fact]
+    public void Snapshot_MaxLines_ReturnsLastN_OldestFirst()
+    {
+        var buf = new DiagnosticLogBuffer();
+        buf.Add("a");
+        buf.Add("b");
+        buf.Add("c");
+        buf.Add("d");
+
+        Assert.Equal(new[] { "c", "d" }, buf.Snapshot(2).ToArray());
+    }
+
+    [Fact]
+    public void Snapshot_MaxLinesLargerThanCount_ReturnsAll()
+    {
+        var buf = new DiagnosticLogBuffer();
+        buf.Add("a");
+        buf.Add("b");
+
+        Assert.Equal(new[] { "a", "b" }, buf.Snapshot(100).ToArray());
+    }
+
+    [Fact]
+    public void Snapshot_NonPositiveMaxLines_ReturnsEmpty()
+    {
+        var buf = new DiagnosticLogBuffer();
+        buf.Add("a");
+
+        Assert.Empty(buf.Snapshot(0));
+        Assert.Empty(buf.Snapshot(-5));
+    }
+
+    [Fact]
+    public void WrapAround_PastCapacity_KeepsOnlyNewest_InOrder()
+    {
+        var buf = new DiagnosticLogBuffer();
+        int total = DiagnosticLogBuffer.Capacity + 50;
+        for (int i = 0; i < total; i++)
+            buf.Add("line-" + i);
+
+        // Ask for the whole ring.
+        var snap = buf.Snapshot(DiagnosticLogBuffer.Capacity);
+
+        Assert.Equal(DiagnosticLogBuffer.Capacity, snap.Count);
+        // Oldest retained is the (total - Capacity)th line; newest is the last.
+        Assert.Equal("line-" + (total - DiagnosticLogBuffer.Capacity), snap[0]);
+        Assert.Equal("line-" + (total - 1), snap[^1]);
+
+        // Strictly increasing / contiguous across the wrap point.
+        for (int i = 0; i < snap.Count; i++)
+            Assert.Equal("line-" + (total - DiagnosticLogBuffer.Capacity + i), snap[i]);
+    }
+
+    [Fact]
+    public void WrapAround_TailRequest_ReturnsNewestN()
+    {
+        var buf = new DiagnosticLogBuffer();
+        int total = DiagnosticLogBuffer.Capacity + 200;
+        for (int i = 0; i < total; i++)
+            buf.Add("line-" + i);
+
+        var snap = buf.Snapshot(10);
+        Assert.Equal(10, snap.Count);
+        Assert.Equal("line-" + (total - 10), snap[0]);
+        Assert.Equal("line-" + (total - 1), snap[^1]);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Add_NullOrEmpty_IsIgnored(string? line)
+    {
+        var buf = new DiagnosticLogBuffer();
+        buf.Add("real");
+        buf.Add(line!);
+        buf.Add("also-real");
+
+        Assert.Equal(new[] { "real", "also-real" }, buf.Snapshot().ToArray());
+    }
+}

--- a/tests/Zeus.Server.Tests/Diagnostics/DiagnosticReportBuilderTests.cs
+++ b/tests/Zeus.Server.Tests/Diagnostics/DiagnosticReportBuilderTests.cs
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+using Zeus.Server.Diagnostics;
+
+namespace Zeus.Server.Tests;
+
+public sealed class DiagnosticReportBuilderTests
+{
+    private sealed class FakeProbe : IDiagnosticProbe
+    {
+        public FakeProbe(string id, params (string, string)[] items)
+        {
+            Id = id;
+            Items = items.Select(i => new DiagnosticKeyValue(i.Item1, i.Item2)).ToList();
+        }
+
+        public string Id { get; }
+        public IReadOnlyList<DiagnosticKeyValue> Items { get; }
+        public bool WasRun { get; private set; }
+
+        public DiagnosticSection Collect(DiagnosticContext ctx)
+        {
+            WasRun = true;
+            return new DiagnosticSection(Id, "Section " + Id, Items);
+        }
+    }
+
+    private sealed class FakeRule : IKnownIssueRule
+    {
+        private readonly DiagnosticFinding? _finding;
+
+        public FakeRule(string id, IReadOnlyCollection<string> symptoms, DiagnosticFinding? finding)
+        {
+            Id = id;
+            Symptoms = symptoms;
+            _finding = finding;
+        }
+
+        public string Id { get; }
+        public IReadOnlyCollection<string> Symptoms { get; }
+        public DiagnosticFinding? Evaluate(
+            DiagnosticContext ctx, IReadOnlyList<DiagnosticSection> sections) => _finding;
+    }
+
+    private sealed class EmptyServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private static DiagnosticLogBuffer LogBufferWith(int lines)
+    {
+        var buf = new DiagnosticLogBuffer();
+        for (int i = 0; i < lines; i++)
+            buf.Add("log-line-" + i.ToString(CultureInfo.InvariantCulture));
+        return buf;
+    }
+
+    private static DiagnosticReportBuilder NewBuilder(
+        IEnumerable<IDiagnosticProbe> probes,
+        IEnumerable<IKnownIssueRule> rules,
+        DiagnosticLogBuffer logBuffer) =>
+        new(
+            probes,
+            rules,
+            logBuffer,
+            new SymptomRegistry(),
+            new EmptyServiceProvider(),
+            NullLogger<DiagnosticReportBuilder>.Instance);
+
+    [Fact]
+    public void Symptoms_ExposesAllEight()
+    {
+        var builder = NewBuilder([], [], new DiagnosticLogBuffer());
+        Assert.Equal(8, builder.Symptoms().Count);
+    }
+
+    [Fact]
+    public void Build_RunsOnlyRecipeProbes_ForSymptom()
+    {
+        var env = new FakeProbe("environment", ("OS", "macOS"));
+        var conn = new FakeProbe("connection");
+        var board = new FakeProbe("board", ("Board", "OrionMkII"));
+        var dsp = new FakeProbe("dsp-audio");
+        var txps = new FakeProbe("tx-ps", ("PsEnabled", "false"));
+
+        var builder = NewBuilder([env, conn, board, dsp, txps], [], LogBufferWith(150));
+
+        // wont-connect recipe = environment, connection, board (no dsp-audio, no tx-ps).
+        var result = builder.Build(new DiagnosticRequest("wont-connect", null));
+
+        Assert.True(env.WasRun);
+        Assert.True(conn.WasRun);
+        Assert.True(board.WasRun);
+        Assert.False(dsp.WasRun);
+        Assert.False(txps.WasRun);
+
+        var ids = result.Report.Sections.Select(s => s.Id).ToArray();
+        Assert.Equal(new[] { "environment", "connection", "board" }, ids);
+    }
+
+    [Fact]
+    public void Build_ProbeThatThrows_EmitsFailureSectionAndContinues()
+    {
+        var board = new FakeProbe("board", ("Board", "OrionMkII"));
+        var builder = NewBuilder(
+            [new ThrowingProbe("environment"), new FakeProbe("connection"), board],
+            [], new DiagnosticLogBuffer());
+
+        var result = builder.Build(new DiagnosticRequest("wont-connect", null));
+
+        var envSection = result.Report.Sections.Single(s => s.Id == "environment");
+        Assert.Contains(envSection.Items, i => i.Key == "error");
+        // The other probes still ran.
+        Assert.Contains(result.Report.Sections, s => s.Id == "board");
+    }
+
+    [Fact]
+    public void Build_OrdersFindingsBySeverityDescThenTitle()
+    {
+        var warn = new FakeRule("w", ["rx-no-audio"],
+            new DiagnosticFinding("Zeta warning", "d", DiagnosticSeverity.Warning));
+        var likely = new FakeRule("l", ["rx-no-audio"],
+            new DiagnosticFinding("Alpha likely", "d", DiagnosticSeverity.Likely));
+        var critical = new FakeRule("c", ["rx-no-audio"],
+            new DiagnosticFinding("Beta critical", "d", DiagnosticSeverity.Critical));
+
+        var builder = NewBuilder(
+            [new FakeProbe("environment"), new FakeProbe("connection"),
+             new FakeProbe("board"), new FakeProbe("dsp-audio")],
+            [warn, likely, critical], new DiagnosticLogBuffer());
+
+        var result = builder.Build(new DiagnosticRequest("rx-no-audio", null));
+
+        var titles = result.Report.Findings.Select(f => f.Title).ToArray();
+        Assert.Equal(new[] { "Beta critical", "Alpha likely", "Zeta warning" }, titles);
+    }
+
+    [Fact]
+    public void Build_OnlyEvaluatesRulesMatchingSymptomOrEmpty()
+    {
+        var matching = new FakeRule("m", ["rx-no-audio"],
+            new DiagnosticFinding("Matching", "d", DiagnosticSeverity.Likely));
+        var nonMatching = new FakeRule("n", ["no-tx-power"],
+            new DiagnosticFinding("Should not appear", "d", DiagnosticSeverity.Likely));
+        var always = new FakeRule("a", [],
+            new DiagnosticFinding("Always", "d", DiagnosticSeverity.Info));
+
+        var builder = NewBuilder(
+            [new FakeProbe("environment"), new FakeProbe("connection"),
+             new FakeProbe("board"), new FakeProbe("dsp-audio")],
+            [matching, nonMatching, always], new DiagnosticLogBuffer());
+
+        var result = builder.Build(new DiagnosticRequest("rx-no-audio", null));
+        var titles = result.Report.Findings.Select(f => f.Title).ToArray();
+
+        Assert.Contains("Matching", titles);
+        Assert.Contains("Always", titles);
+        Assert.DoesNotContain("Should not appear", titles);
+    }
+
+    [Fact]
+    public void Build_MarkdownContainsSectionsFindingsAndLastHundredLog()
+    {
+        var board = new FakeProbe("board", ("Board", "OrionMkII"));
+        var rule = new FakeRule("r", ["wont-connect"],
+            new DiagnosticFinding(
+                "Network looks flaky", "Try wired Ethernet.",
+                DiagnosticSeverity.Likely, "docs/lessons/disconnection-troubleshooting.md"));
+
+        var builder = NewBuilder(
+            [new FakeProbe("environment", ("OS", "macOS")),
+             new FakeProbe("connection"), board],
+            [rule], LogBufferWith(150));
+
+        var result = builder.Build(new DiagnosticRequest("wont-connect", "It keeps dropping."));
+        var md = result.Markdown;
+
+        // Symptom + free text.
+        Assert.Contains("Radio won't connect or keeps dropping", md);
+        Assert.Contains("It keeps dropping.", md);
+        // Section values.
+        Assert.Contains("Board", md);
+        Assert.Contains("OrionMkII", md);
+        // Finding + doc ref.
+        Assert.Contains("Network looks flaky", md);
+        Assert.Contains("docs/lessons/disconnection-troubleshooting.md", md);
+        // Report ships exactly the last 100 lines.
+        Assert.Equal(100, result.Report.RecentLog.Count);
+        Assert.Contains("log-line-149", md);  // newest
+        Assert.Contains("log-line-50", md);   // 100th-from-newest
+        Assert.DoesNotContain("log-line-49", md);  // older than the tail
+    }
+
+    [Fact]
+    public void Build_GithubUrl_TargetsRepoAndEncodesTitle()
+    {
+        var builder = NewBuilder(
+            [new FakeProbe("environment"), new FakeProbe("connection"), new FakeProbe("board")],
+            [], new DiagnosticLogBuffer());
+
+        var result = builder.Build(new DiagnosticRequest("wont-connect", null));
+
+        Assert.StartsWith(
+            "https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus/issues/new",
+            result.GithubIssueUrl);
+        // Title is "[Report] Radio won't connect or keeps dropping", URL-encoded.
+        Assert.Contains("title=", result.GithubIssueUrl);
+        Assert.Contains(Uri.EscapeDataString("[Report] Radio won't connect or keeps dropping"),
+            result.GithubIssueUrl);
+        Assert.Contains("labels=bug", result.GithubIssueUrl);
+    }
+
+    [Fact]
+    public void Build_NullSymptom_UsesProblemReportTitle()
+    {
+        var builder = NewBuilder(
+            [new FakeProbe("environment"), new FakeProbe("connection"),
+             new FakeProbe("board"), new FakeProbe("dsp-audio"), new FakeProbe("tx-ps")],
+            [], new DiagnosticLogBuffer());
+
+        var result = builder.Build(new DiagnosticRequest(null, null));
+
+        Assert.Contains("title=" + Uri.EscapeDataString("Problem report"), result.GithubIssueUrl);
+        // null/unknown runs all five probes.
+        Assert.Equal(5, result.Report.Sections.Count);
+    }
+
+    [Fact]
+    public void Build_LongLog_ProducesShorterUrlThanFullMarkdown()
+    {
+        // A log full of long lines blows past the URL ceiling; the URL should drop
+        // the log block (and so be much shorter than the full markdown the UI copies).
+        var buf = new DiagnosticLogBuffer();
+        for (int i = 0; i < 100; i++)
+            buf.Add(new string('x', 400) + i.ToString(CultureInfo.InvariantCulture));
+
+        var builder = NewBuilder(
+            [new FakeProbe("environment"), new FakeProbe("connection"), new FakeProbe("board")],
+            [], buf);
+
+        var result = builder.Build(new DiagnosticRequest("wont-connect", null));
+
+        // Full markdown keeps the whole log.
+        Assert.Contains("xxxx", result.Markdown);
+        Assert.True(result.Markdown.Length > 30_000,
+            "full markdown should carry the big log");
+
+        // URL stays under the ceiling and notes the omission.
+        Assert.True(result.GithubIssueUrl.Length <= 7000 + 256,
+            $"URL should be trimmed, was {result.GithubIssueUrl.Length}");
+        Assert.True(result.GithubIssueUrl.Length < result.Markdown.Length,
+            "trimmed URL should be shorter than full markdown");
+        Assert.Contains(
+            Uri.EscapeDataString("Log omitted from this link"),
+            result.GithubIssueUrl);
+    }
+
+    [Fact]
+    public void Build_FreeText_IsLengthCapped()
+    {
+        var builder = NewBuilder(
+            [new FakeProbe("environment"), new FakeProbe("connection"), new FakeProbe("board")],
+            [], new DiagnosticLogBuffer());
+
+        var huge = new string('a', 5000);
+        var result = builder.Build(new DiagnosticRequest("wont-connect", huge));
+
+        Assert.NotNull(result.Report.FreeText);
+        Assert.True(result.Report.FreeText!.Length <= 2000);
+    }
+
+    private sealed class ThrowingProbe : IDiagnosticProbe
+    {
+        public ThrowingProbe(string id) => Id = id;
+        public string Id { get; }
+        public DiagnosticSection Collect(DiagnosticContext ctx) =>
+            throw new InvalidOperationException("boom");
+    }
+}

--- a/tests/Zeus.Server.Tests/Diagnostics/DiagnosticReportBuilderTests.cs
+++ b/tests/Zeus.Server.Tests/Diagnostics/DiagnosticReportBuilderTests.cs
@@ -80,6 +80,24 @@ public sealed class DiagnosticReportBuilderTests
     }
 
     [Fact]
+    public void Build_RedactsSecretsFromFreeText()
+    {
+        // The free-text box lands in a PUBLIC GitHub issue; an operator may paste
+        // a password/email/IP without realising. It must be scrubbed like logs.
+        var builder = NewBuilder([], [], new DiagnosticLogBuffer());
+        var result = builder.Build(new DiagnosticRequest(
+            "ps-not-working",
+            "PS wont calibrate, password=hunter2, email bob@example.com on 10.70.120.229"));
+
+        foreach (var secret in new[] { "hunter2", "bob@example.com", "10.70.120.229" })
+        {
+            Assert.DoesNotContain(secret, result.Markdown);
+            Assert.DoesNotContain(secret, result.GithubIssueUrl);
+            Assert.DoesNotContain(secret, result.Report.FreeText ?? "");
+        }
+    }
+
+    [Fact]
     public void Build_RunsOnlyRecipeProbes_ForSymptom()
     {
         var env = new FakeProbe("environment", ("OS", "macOS"));

--- a/tests/Zeus.Server.Tests/Diagnostics/KnownIssueRuleTests.cs
+++ b/tests/Zeus.Server.Tests/Diagnostics/KnownIssueRuleTests.cs
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Zeus.Server.Diagnostics;
+
+namespace Zeus.Server.Tests;
+
+public sealed class KnownIssueRuleTests
+{
+    private static DiagnosticContext Ctx(
+        string? symptomId, IReadOnlyList<string> recentLog) =>
+        new()
+        {
+            Services = EmptyServiceProvider.Instance,
+            SymptomId = symptomId,
+            FreeText = null,
+            RecentLog = recentLog,
+        };
+
+    private static DiagnosticSection Section(
+        string id, params (string Key, string Value)[] items)
+    {
+        var kv = new List<DiagnosticKeyValue>();
+        foreach (var (k, v) in items)
+            kv.Add(new DiagnosticKeyValue(k, v));
+        return new DiagnosticSection(id, id, kv);
+    }
+
+    // ---- PsNotArmedRule ----
+
+    [Fact]
+    public void PsNotArmed_FiresOnGateSkipMarker()
+    {
+        var rule = new PsNotArmedRule();
+        var log = new[] { "info: psAutoAttn.gate skip=PsEnabled-off" };
+        var finding = rule.Evaluate(Ctx("ps-not-working", log), []);
+
+        Assert.NotNull(finding);
+        Assert.Equal(DiagnosticSeverity.Likely, finding!.Severity);
+        Assert.False(string.IsNullOrWhiteSpace(finding.DocRef));
+    }
+
+    [Fact]
+    public void PsNotArmed_FiresWhenProbeReportsPsEnabledFalse()
+    {
+        var rule = new PsNotArmedRule();
+        // Real probe key is "ps.enabled".
+        var sections = new[] { Section("tx-ps", ("ps.enabled", "false")) };
+        var finding = rule.Evaluate(Ctx("ps-not-working", []), sections);
+
+        Assert.NotNull(finding);
+        Assert.Equal(DiagnosticSeverity.Likely, finding!.Severity);
+    }
+
+    [Fact]
+    public void PsNotArmed_DoesNotFireWhenArmed()
+    {
+        var rule = new PsNotArmedRule();
+        var sections = new[] { Section("tx-ps", ("ps.enabled", "true")) };
+        var finding = rule.Evaluate(Ctx("ps-not-working", ["info: nothing relevant"]), sections);
+
+        Assert.Null(finding);
+    }
+
+    // ---- IqWriteGateRule ----
+
+    [Fact]
+    public void IqWriteGate_FiresOnHermesWithDrivePeakZero()
+    {
+        var rule = new IqWriteGateRule();
+        var sections = new[] { Section("board", ("board.kind", "HermesII")) };
+        var log = new[] { "p1.tx.rate pkts=120 drv=240 peak=0" };
+        var finding = rule.Evaluate(Ctx("no-tx-power", log), sections);
+
+        Assert.NotNull(finding);
+        Assert.Equal(DiagnosticSeverity.Likely, finding!.Severity);
+        Assert.False(string.IsNullOrWhiteSpace(finding.DocRef));
+    }
+
+    [Fact]
+    public void IqWriteGate_DoesNotFireWhenPeakNonZero()
+    {
+        var rule = new IqWriteGateRule();
+        var sections = new[] { Section("board", ("board.kind", "HermesII")) };
+        var log = new[] { "p1.tx.rate pkts=120 drv=240 peak=18000" };
+        Assert.Null(rule.Evaluate(Ctx("no-tx-power", log), sections));
+    }
+
+    [Fact]
+    public void IqWriteGate_DoesNotFireWhenDriveZero()
+    {
+        var rule = new IqWriteGateRule();
+        var sections = new[] { Section("board", ("board.kind", "HermesII")) };
+        var log = new[] { "p1.tx.rate pkts=120 drv=0 peak=0" };
+        Assert.Null(rule.Evaluate(Ctx("no-tx-power", log), sections));
+    }
+
+    [Fact]
+    public void IqWriteGate_DoesNotFireOnHermesLite2()
+    {
+        // HL2 is excluded from the Hermes-class match; its low-power story is the
+        // percentage drive model, not the IQ-write gate.
+        var rule = new IqWriteGateRule();
+        var sections = new[] { Section("board", ("board.kind", "HermesLite2")) };
+        var log = new[] { "p1.tx.rate pkts=120 drv=240 peak=0" };
+        Assert.Null(rule.Evaluate(Ctx("no-tx-power", log), sections));
+    }
+
+    // ---- Hl2DriveModelRule ----
+
+    [Fact]
+    public void Hl2DriveModel_FiresOnHl2()
+    {
+        var rule = new Hl2DriveModelRule();
+        var sections = new[] { Section("board", ("board.kind", "HermesLite2")) };
+        var finding = rule.Evaluate(Ctx("no-tx-power", []), sections);
+
+        Assert.NotNull(finding);
+        Assert.Equal("docs/lessons/hl2-drive-model.md", finding!.DocRef);
+    }
+
+    [Fact]
+    public void Hl2DriveModel_DoesNotFireOnOtherBoard()
+    {
+        var rule = new Hl2DriveModelRule();
+        var sections = new[] { Section("board", ("board.kind", "OrionMkII")) };
+        Assert.Null(rule.Evaluate(Ctx("no-tx-power", []), sections));
+    }
+
+    // ---- RxAuxBypassRule ----
+
+    [Fact]
+    public void RxAuxBypass_AlwaysProvidesAdvisoryForReceiveSymptoms()
+    {
+        var rule = new RxAuxBypassRule();
+        var finding = rule.Evaluate(Ctx("rx-no-audio", []), []);
+
+        Assert.NotNull(finding);
+        Assert.Equal(DiagnosticSeverity.Warning, finding!.Severity);
+        Assert.Contains("None", finding.Detail);
+    }
+
+    // ---- RxaAudioSilenceRule ----
+
+    [Fact]
+    public void RxaAudioSilence_FiresOnMinus400Sentinel()
+    {
+        var rule = new RxaAudioSilenceRule();
+        var sections = new[] { Section("dsp-audio", ("rx.dbm", "-400")) };
+        var finding = rule.Evaluate(Ctx("rx-no-audio", []), sections);
+
+        Assert.NotNull(finding);
+        Assert.Equal("docs/rca/2026-04-17-rxa-audio-silence.md", finding!.DocRef);
+    }
+
+    [Fact]
+    public void RxaAudioSilence_DoesNotFireOnHealthyMeter()
+    {
+        var rule = new RxaAudioSilenceRule();
+        var sections = new[] { Section("dsp-audio", ("rx.dbm", "-92.5")) };
+        Assert.Null(rule.Evaluate(Ctx("rx-no-audio", ["info: all good"]), sections));
+    }
+
+    // ---- DisconnectionRule ----
+
+    [Fact]
+    public void Disconnection_FiresLikelyOnRxTimeout()
+    {
+        var rule = new DisconnectionRule();
+        var log = new[] { "warn: RX: 10 consecutive socket timeouts — radio gone" };
+        var finding = rule.Evaluate(Ctx("wont-connect", log), []);
+
+        Assert.NotNull(finding);
+        Assert.Equal(DiagnosticSeverity.Likely, finding!.Severity);
+        Assert.Equal("docs/lessons/disconnection-troubleshooting.md", finding.DocRef);
+    }
+
+    [Fact]
+    public void Disconnection_FallsBackToWarningWithoutTimeout()
+    {
+        var rule = new DisconnectionRule();
+        var finding = rule.Evaluate(Ctx("wont-connect", ["info: nothing"]), []);
+
+        Assert.NotNull(finding);
+        Assert.Equal(DiagnosticSeverity.Warning, finding!.Severity);
+    }
+
+    // ---- PsStartupArmedRule ----
+
+    [Fact]
+    public void PsStartupArmed_HasNoSymptomFilter()
+    {
+        var rule = new PsStartupArmedRule();
+        Assert.Empty(rule.Symptoms);
+    }
+
+    [Fact]
+    public void PsStartupArmed_FiresCriticalWhenArmedAtStartup()
+    {
+        var rule = new PsStartupArmedRule();
+        var sections = new[] { Section("tx-ps", ("ps.armedAtStartup", "true")) };
+        var finding = rule.Evaluate(Ctx("other", []), sections);
+
+        Assert.NotNull(finding);
+        Assert.Equal(DiagnosticSeverity.Critical, finding!.Severity);
+    }
+
+    [Fact]
+    public void PsStartupArmed_SilentInNormalCase()
+    {
+        var rule = new PsStartupArmedRule();
+        var sections = new[] { Section("tx-ps", ("ps.enabled", "false")) };
+        Assert.Null(rule.Evaluate(Ctx("other", []), sections));
+    }
+
+    [Fact]
+    public void AllRules_DoNotThrowOnEmptyInput()
+    {
+        IKnownIssueRule[] rules =
+        [
+            new PsNotArmedRule(), new IqWriteGateRule(), new RxAuxBypassRule(),
+            new Hl2DriveModelRule(), new RxaAudioSilenceRule(), new DisconnectionRule(),
+            new PsStartupArmedRule(),
+        ];
+        foreach (var rule in rules)
+        {
+            var ex = Record.Exception(() => rule.Evaluate(Ctx(null, []), []));
+            Assert.Null(ex);
+        }
+    }
+
+    private sealed class EmptyServiceProvider : IServiceProvider
+    {
+        public static readonly EmptyServiceProvider Instance = new();
+        public object? GetService(Type serviceType) => null;
+    }
+}

--- a/tests/Zeus.Server.Tests/Diagnostics/KnownIssueRuleTests.cs
+++ b/tests/Zeus.Server.Tests/Diagnostics/KnownIssueRuleTests.cs
@@ -221,13 +221,62 @@ public sealed class KnownIssueRuleTests
         [
             new PsNotArmedRule(), new IqWriteGateRule(), new RxAuxBypassRule(),
             new Hl2DriveModelRule(), new RxaAudioSilenceRule(), new DisconnectionRule(),
-            new PsStartupArmedRule(),
+            new PsStartupArmedRule(), new AudioUnderrunRule(),
         ];
         foreach (var rule in rules)
         {
             var ex = Record.Exception(() => rule.Evaluate(Ctx(null, []), []));
             Assert.Null(ex);
         }
+    }
+
+    // ---- AudioUnderrunRule ----
+
+    [Fact]
+    public void AudioUnderrun_FiresLikely_OnLargeUnderrunCount()
+    {
+        var rule = new AudioUnderrunRule();
+        var sections = new[]
+        {
+            Section("dsp-audio",
+                ("audio.underrunSamplesTotal", "167520"),
+                ("audio.sampleRateHz", "48000")),
+        };
+        var finding = rule.Evaluate(Ctx("rx-audio-quality", []), sections);
+
+        Assert.NotNull(finding);
+        Assert.Equal(DiagnosticSeverity.Likely, finding!.Severity);
+        Assert.Contains("167,520", finding.Detail); // formatted count surfaced
+    }
+
+    [Fact]
+    public void AudioUnderrun_Silent_WhenUnderrunsAreTrivial()
+    {
+        var rule = new AudioUnderrunRule();
+        var sections = new[]
+        {
+            Section("dsp-audio",
+                ("audio.underrunSamplesTotal", "128"),
+                ("audio.sampleRateHz", "48000")),
+        };
+        Assert.Null(rule.Evaluate(Ctx("rx-audio-quality", []), sections));
+    }
+
+    [Fact]
+    public void AudioUnderrun_Silent_WhenNoDspAudioSection()
+    {
+        var rule = new AudioUnderrunRule();
+        Assert.Null(rule.Evaluate(Ctx("rx-audio-quality", []), []));
+    }
+
+    // ---- RxAuxBypassRule symptom scope (must not fire on crackle) ----
+
+    [Fact]
+    public void RxAuxBypass_ScopedToNoAudioOnly_NotCrackle()
+    {
+        var rule = new RxAuxBypassRule();
+        Assert.Contains("rx-no-audio", rule.Symptoms);
+        Assert.DoesNotContain("rx-audio-quality", rule.Symptoms);
     }
 
     private sealed class EmptyServiceProvider : IServiceProvider

--- a/tests/Zeus.Server.Tests/Diagnostics/ProbeTests.cs
+++ b/tests/Zeus.Server.Tests/Diagnostics/ProbeTests.cs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Zeus.Server.Diagnostics;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Every diagnostic probe must be side-effect free and resilient to missing
+/// services: with an empty service provider, <c>Collect</c> must return a
+/// well-formed section (correct id, non-null items) and never throw. These
+/// tests exercise exactly that contract — no radio, DSP, or audio service is
+/// registered, so each probe should degrade gracefully rather than fault.
+/// </summary>
+public sealed class ProbeTests
+{
+    private static DiagnosticContext EmptyContext() => new()
+    {
+        Services = new ServiceCollection().BuildServiceProvider(),
+        RecentLog = new List<string>(),
+    };
+
+    public static IEnumerable<object[]> Probes() => new[]
+    {
+        new object[] { new EnvironmentProbe(), "environment" },
+        new object[] { new ConnectionProbe(), "connection" },
+        new object[] { new BoardProbe(), "board" },
+        new object[] { new DspAudioProbe(), "dsp-audio" },
+        new object[] { new TxPsProbe(), "tx-ps" },
+    };
+
+    [Theory]
+    [MemberData(nameof(Probes))]
+    public void Collect_ReturnsExpectedSection_WithoutThrowing(IDiagnosticProbe probe, string expectedId)
+    {
+        var ctx = EmptyContext();
+
+        // The probe's advertised id must match the recipe-facing contract.
+        Assert.Equal(expectedId, probe.Id);
+
+        // Must not throw out even when every backend service is absent.
+        var thrown = Record.Exception(() => probe.Collect(ctx));
+        Assert.Null(thrown);
+    }
+
+    [Theory]
+    [MemberData(nameof(Probes))]
+    public void Collect_SectionHasMatchingIdAndNonNullItems(IDiagnosticProbe probe, string expectedId)
+    {
+        var ctx = EmptyContext();
+
+        DiagnosticSection result = probe.Collect(ctx);
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedId, result.Id);
+        Assert.False(string.IsNullOrWhiteSpace(result.Title));
+        Assert.NotNull(result.Items);
+        // A graceful probe always emits at least one item (real data, an
+        // "unavailable" marker, or an "error" marker) — never an empty void.
+        Assert.NotEmpty(result.Items);
+        foreach (var item in result.Items)
+        {
+            Assert.NotNull(item.Key);
+            Assert.NotNull(item.Value);
+        }
+    }
+
+    [Fact]
+    public void EnvironmentProbe_ReportsHostFactsWithoutServices()
+    {
+        // The environment probe needs no services and should always surface
+        // the runtime/version facts regardless of DI contents.
+        var section = new EnvironmentProbe().Collect(EmptyContext());
+
+        Assert.Contains(section.Items, kv => kv.Key == "zeus.version");
+        Assert.Contains(section.Items, kv => kv.Key == "dotnet.version");
+        Assert.Contains(section.Items, kv => kv.Key == "os.architecture");
+    }
+
+    [Fact]
+    public void ServiceDependentProbes_ReportUnavailable_WhenServicesMissing()
+    {
+        var ctx = EmptyContext();
+
+        foreach (IDiagnosticProbe probe in new IDiagnosticProbe[]
+                 {
+                     new ConnectionProbe(),
+                     new BoardProbe(),
+                     new DspAudioProbe(),
+                     new TxPsProbe(),
+                 })
+        {
+            var section = probe.Collect(ctx);
+            // With no RadioService/DspPipelineService/NativeAudioSink registered,
+            // each probe should mark itself unavailable rather than fabricate data.
+            Assert.Contains(section.Items, kv => kv.Value == "unavailable" || kv.Key == "status");
+        }
+    }
+}

--- a/tests/Zeus.Server.Tests/Diagnostics/RedactionTests.cs
+++ b/tests/Zeus.Server.Tests/Diagnostics/RedactionTests.cs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using Xunit;
+using Zeus.Server.Diagnostics;
+
+namespace Zeus.Server.Tests;
+
+public class RedactionTests
+{
+    // --- Secret key/value pairs ----------------------------------------------
+
+    [Theory]
+    [InlineData("password=hunter2", "password=***")]
+    [InlineData("pwd: s3cr3t", "pwd: ***")]
+    [InlineData("token=abc.def.ghi", "token=***")]
+    [InlineData("api_key = AKIA12345", "api_key = ***")]
+    [InlineData("apikey:zzz999", "apikey:***")]
+    [InlineData("Authorization: Bearer xyz", "Authorization: Bearer ***")] // scheme kept, credential masked
+    [InlineData("Authorization=Bearer abc123def", "Authorization=Bearer ***")]
+    [InlineData("secret=topsecret", "secret=***")]
+    public void Scrub_MasksSecretValues(string input, string expected)
+    {
+        Assert.Equal(expected, Redaction.Scrub(input));
+    }
+
+    [Fact]
+    public void Scrub_MasksSecret_KeepsSurroundingContext()
+    {
+        var result = Redaction.Scrub("connecting with password=hunter2 to radio");
+        Assert.Contains("password=***", result);
+        Assert.Contains("connecting with", result);
+        Assert.Contains("to radio", result);
+        Assert.DoesNotContain("hunter2", result);
+    }
+
+    // --- Email ----------------------------------------------------------------
+
+    [Fact]
+    public void Scrub_MasksEmail()
+    {
+        var result = Redaction.Scrub("operator kb2uka80@gmail.com reported an issue");
+        Assert.DoesNotContain("kb2uka80@gmail.com", result);
+        Assert.Contains("***@***", result);
+    }
+
+    // --- IPv4 -----------------------------------------------------------------
+
+    [Theory]
+    [InlineData("radio at 192.168.4.10 timed out", "192.168.4.10")]
+    [InlineData("discovered 10.70.120.219", "10.70.120.219")]
+    [InlineData("0.0.0.0 and 255.255.255.255", "255.255.255.255")]
+    public void Scrub_MasksIpv4(string input, string leaked)
+    {
+        var result = Redaction.Scrub(input);
+        Assert.DoesNotContain(leaked, result);
+        Assert.Contains("x.x.x.x", result);
+    }
+
+    // --- IPv6 -----------------------------------------------------------------
+
+    [Theory]
+    [InlineData("fe80::1ff:fe23:4567:890a")]
+    [InlineData("2001:db8:85a3::8a2e:370:7334")]
+    [InlineData("[2001:db8::1]")]
+    public void Scrub_MasksIpv6(string input)
+    {
+        var result = Redaction.Scrub("host " + input + " offline");
+        Assert.Contains("[ipv6]", result);
+        Assert.DoesNotContain("db8", result);
+    }
+
+    // --- MAC ------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("00:1a:2b:3c:4d:5e")]
+    [InlineData("AA-BB-CC-DD-EE-FF")]
+    public void Scrub_MasksMac(string mac)
+    {
+        var result = Redaction.Scrub("nic " + mac + " up");
+        Assert.Contains("xx:xx:xx:xx:xx:xx", result);
+        Assert.DoesNotContain(mac, result);
+    }
+
+    // --- Home-directory username ---------------------------------------------
+
+    [Theory]
+    [InlineData("/Users/kb2uka_mac/Programs/zeus.db", "/Users/<user>/Programs/zeus.db")]
+    [InlineData("/home/doug/.config/zeus", "/home/<user>/.config/zeus")]
+    [InlineData(@"C:\Users\Doug\AppData\zeus.db", @"C:\Users\<user>\AppData\zeus.db")]
+    public void Scrub_MasksHomeUsername(string input, string expected)
+    {
+        Assert.Equal(expected, Redaction.Scrub(input));
+    }
+
+    // --- Maidenhead grid ------------------------------------------------------
+
+    [Theory]
+    [InlineData("grid FN31pr", "FN31")]
+    [InlineData("locator JO62qm tonight", "JO62")]
+    public void Scrub_TruncatesPreciseGridToFourChars(string input, string keptField)
+    {
+        var result = Redaction.Scrub(input);
+        Assert.Contains(keptField, result);
+        // The 6-char form must be gone; coarse 4-char survives.
+        Assert.DoesNotContain(keptField + "pr", result);
+        Assert.DoesNotContain(keptField + "qm", result);
+    }
+
+    [Fact]
+    public void Scrub_LeavesFourCharGridIntact()
+    {
+        Assert.Equal("grid FN31", Redaction.Scrub("grid FN31"));
+    }
+
+    // --- Negative cases: diagnosis-critical data MUST survive -----------------
+
+    [Theory]
+    [InlineData("KB2UKA")]
+    [InlineData("EI6LF")]
+    [InlineData("N9WAR")]
+    [InlineData("MW0LGE")]
+    public void Scrub_KeepsCallsigns(string callsign)
+    {
+        Assert.Equal("worked " + callsign, Redaction.Scrub("worked " + callsign));
+    }
+
+    [Theory]
+    [InlineData("tuned to 14.046 MHz")]
+    [InlineData("VFO A 14046000 Hz")]
+    [InlineData("drive=48 peak=0.655")]
+    public void Scrub_KeepsFrequencyAndDriveInfo(string line)
+    {
+        Assert.Equal(line, Redaction.Scrub(line));
+    }
+
+    [Theory]
+    [InlineData("board=HermesLite2")]
+    [InlineData("OrionMkII variant G2")]
+    [InlineData("ANAN-7000DLE firmware 2.6")]
+    [InlineData("connected to Hermes-Lite 2")]
+    public void Scrub_KeepsBoardAndFirmware(string line)
+    {
+        Assert.Equal(line, Redaction.Scrub(line));
+    }
+
+    [Fact]
+    public void Scrub_DoesNotMangleTimestamps()
+    {
+        // A bare HH:mm:ss timestamp must not be mistaken for an IPv6 address.
+        var line = "10:11:12.345 INFO RadioService connected";
+        Assert.Equal(line, Redaction.Scrub(line));
+    }
+
+    [Fact]
+    public void Scrub_DoesNotMaskOrdinaryWords()
+    {
+        // Words that vaguely resemble a grid (wrong shape) must be left alone.
+        var line = "the letter arrived and version 12.3 shipped";
+        Assert.Equal(line, Redaction.Scrub(line));
+    }
+
+    [Fact]
+    public void Scrub_NullOrEmpty_ReturnedUnchanged()
+    {
+        Assert.Equal("", Redaction.Scrub(""));
+        Assert.Null(Redaction.Scrub(null!));
+    }
+
+    [Fact]
+    public void ScrubAll_PreservesOrderAndScrubsEach()
+    {
+        var input = new[] { "password=abc", "callsign KB2UKA", "ip 192.168.0.1" };
+        var result = Redaction.ScrubAll(input);
+        Assert.Equal(3, result.Count);
+        Assert.Equal("password=***", result[0]);
+        Assert.Equal("callsign KB2UKA", result[1]);
+        Assert.Equal("ip x.x.x.x", result[2]);
+    }
+}

--- a/tests/Zeus.Server.Tests/Diagnostics/SymptomRegistryTests.cs
+++ b/tests/Zeus.Server.Tests/Diagnostics/SymptomRegistryTests.cs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using System.Linq;
+using Xunit;
+using Zeus.Server.Diagnostics;
+
+namespace Zeus.Server.Tests;
+
+public sealed class SymptomRegistryTests
+{
+    private readonly SymptomRegistry _reg = new();
+
+    [Fact]
+    public void All_HasEightSymptoms_WithExpectedIds()
+    {
+        var ids = _reg.All.Select(s => s.Id).ToArray();
+        Assert.Equal(8, ids.Length);
+        Assert.Equal(
+            new[]
+            {
+                "wont-connect", "no-tx-power", "ps-not-working", "tx-audio",
+                "rx-no-audio", "rx-audio-quality", "ui-display", "other",
+            },
+            ids);
+    }
+
+    [Fact]
+    public void All_EverySymptom_HasLabelAndGroup()
+    {
+        foreach (var s in _reg.All)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(s.Label));
+            Assert.False(string.IsNullOrWhiteSpace(s.Group));
+        }
+    }
+
+    [Theory]
+    [InlineData("wont-connect", "environment", "connection", "board")]
+    [InlineData("no-tx-power", "environment", "connection", "board", "tx-ps")]
+    [InlineData("ps-not-working", "environment", "connection", "board", "tx-ps")]
+    [InlineData("tx-audio", "environment", "connection", "board", "dsp-audio", "tx-ps")]
+    [InlineData("rx-no-audio", "environment", "connection", "board", "dsp-audio")]
+    [InlineData("rx-audio-quality", "environment", "connection", "board", "dsp-audio")]
+    [InlineData("ui-display", "environment", "connection", "board", "dsp-audio")]
+    public void ProbeIdsFor_KnownSymptom_ReturnsExpectedRecipe(
+        string symptomId, params string[] expected)
+    {
+        var probes = _reg.ProbeIdsFor(symptomId);
+        Assert.Equal(expected, probes.ToArray());
+    }
+
+    [Fact]
+    public void ProbeIdsFor_AlwaysIncludesBaseProbes()
+    {
+        foreach (var s in _reg.All)
+        {
+            var probes = _reg.ProbeIdsFor(s.Id);
+            Assert.Contains("environment", probes);
+            Assert.Contains("connection", probes);
+            Assert.Contains("board", probes);
+        }
+    }
+
+    [Theory]
+    [InlineData("other")]
+    [InlineData(null)]
+    [InlineData("totally-unknown-symptom")]
+    [InlineData("")]
+    public void ProbeIdsFor_OtherNullOrUnknown_ReturnsAllFiveProbes(string? symptomId)
+    {
+        var probes = _reg.ProbeIdsFor(symptomId);
+        Assert.Equal(
+            new[] { "environment", "connection", "board", "dsp-audio", "tx-ps" },
+            probes.ToArray());
+    }
+}

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -69,6 +69,8 @@ import { PsToggleButton } from './components/PsToggleButton';
 import { PaTempChip } from './components/PaTempChip';
 import { QrzStatusPill } from './components/QrzStatusPill';
 import { RotatorStatusPill } from './components/RotatorStatusPill';
+import ReportProblemButton from './components/report-problem/ReportProblemButton';
+import ReportProblemModal from './components/report-problem/ReportProblemModal';
 import type { SettingsTabId } from './components/SettingsMenu';
 import { SignalIntelligenceController } from './components/SignalIntelligenceController';
 import { SmartNrController } from './components/SmartNrController';
@@ -1075,6 +1077,7 @@ export default function App() {
         </span>
         <RotatorStatusPill />
         <QrzStatusPill />
+        <ReportProblemButton />
         {/* Reset acts on the active layout's tile arrangement. Disabled
             while the Settings view is showing (no active workspace to
             mutate). Add Panel now lives inside the workspace surface. */}
@@ -1119,6 +1122,7 @@ export default function App() {
         onOpenSettings={() => setSettingsView(true, 'updates')}
       />
       <UpdatePrompt show={updateAvailable} onUpdate={installUpdate} />
+      <ReportProblemModal />
     </div>
     </SpectrumWheelActionsContext.Provider>
     </WorkspaceContext.Provider>

--- a/zeus-web/src/api/diagnostics.ts
+++ b/zeus-web/src/api/diagnostics.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+// "Report a problem" self-diagnostic REST surface. The backend collects a
+// snapshot of radio / DSP / connection state, formats it as a Markdown report,
+// and pre-fills a bug-report page URL the operator can open in their browser.
+//
+//   GET  /api/diagnostics/symptoms -> Symptom[]
+//   POST /api/diagnostics/report   -> { report, markdown, githubIssueUrl }
+
+import { ApiError } from './client';
+
+/** A pickable symptom shown in the report form's grouped dropdown. */
+export type Symptom = {
+  id: string;
+  label: string;
+  group: string;
+};
+
+/** Result of a diagnostic run. `report` is an opaque structured snapshot used
+ *  by the backend; the UI only consumes `markdown` (preview + clipboard) and
+ *  `githubIssueUrl` (the pre-filled bug-report page). */
+export type ReportResult = {
+  report: unknown;
+  markdown: string;
+  githubIssueUrl: string;
+};
+
+/** Request body for a diagnostic run. Either field may be null. */
+export type ReportRequest = {
+  symptomId: string | null;
+  freeText: string | null;
+};
+
+function toStr(v: unknown): string {
+  return typeof v === 'string' ? v : '';
+}
+
+function normalizeSymptom(raw: unknown): Symptom {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  return {
+    id: toStr(r.id),
+    label: toStr(r.label),
+    group: toStr(r.group),
+  };
+}
+
+function normalizeReportResult(raw: unknown): ReportResult {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  return {
+    report: r.report ?? null,
+    markdown: toStr(r.markdown),
+    githubIssueUrl: toStr(r.githubIssueUrl),
+  };
+}
+
+async function jsonFetch<T>(
+  input: RequestInfo,
+  init: RequestInit | undefined,
+  parse: (raw: unknown) => T,
+): Promise<T> {
+  const res = await fetch(input, init);
+  if (!res.ok) {
+    let message = `${res.status} ${res.statusText}`;
+    try {
+      const body = (await res.json()) as unknown;
+      if (
+        body &&
+        typeof body === 'object' &&
+        'error' in body &&
+        typeof (body as { error: unknown }).error === 'string'
+      ) {
+        message = (body as { error: string }).error;
+      }
+    } catch {
+      /* non-JSON body — keep status text */
+    }
+    throw new ApiError(res.status, message);
+  }
+  return parse((await res.json()) as unknown);
+}
+
+export function fetchSymptoms(signal?: AbortSignal): Promise<Symptom[]> {
+  return jsonFetch('/api/diagnostics/symptoms', { signal }, (raw) =>
+    Array.isArray(raw) ? raw.map(normalizeSymptom) : [],
+  );
+}
+
+export function runReport(
+  req: ReportRequest,
+  signal?: AbortSignal,
+): Promise<ReportResult> {
+  return jsonFetch(
+    '/api/diagnostics/report',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        symptomId: req.symptomId,
+        freeText: req.freeText,
+      }),
+      signal,
+    },
+    normalizeReportResult,
+  );
+}

--- a/zeus-web/src/components/report-problem/ReportProblemButton.tsx
+++ b/zeus-web/src/components/report-problem/ReportProblemButton.tsx
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+// Footer "Report a problem" button — opens the self-diagnostic modal. Lives in
+// the bottom transport bar; matches the bar's ghost-button styling.
+
+import { useReportProblemStore } from '../../state/report-problem-store';
+
+export default function ReportProblemButton() {
+  const open = useReportProblemStore((s) => s.open);
+
+  return (
+    <button
+      type="button"
+      className="btn ghost"
+      aria-label="Report a problem with Zeus"
+      title="Report a problem"
+      onClick={open}
+    >
+      <span aria-hidden="true" style={{ marginRight: 6 }}>
+        ⚠
+      </span>
+      Report a problem
+    </button>
+  );
+}

--- a/zeus-web/src/components/report-problem/ReportProblemModal.tsx
+++ b/zeus-web/src/components/report-problem/ReportProblemModal.tsx
@@ -1,0 +1,372 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+// "Report a problem" self-diagnostic modal. Two states:
+//   (a) FORM   — grouped symptom dropdown + free-text box + "Run diagnostic".
+//   (b) RESULT — dead-simple, jargon-free instructions for opening the
+//                pre-filled bug-report page, a "Copy report" fallback, and a
+//                transparency preview of exactly what will be sent.
+//
+// Language is written for a ham operator who has never heard of GitHub: we say
+// "bug report page", never "GitHub issue", and spell out every click.
+
+import { useMemo, useState } from 'react';
+import { useReportProblemStore } from '../../state/report-problem-store';
+import type { Symptom } from '../../api/diagnostics';
+
+// Shown verbatim so operators can read the page address; it is selectable text,
+// not a working hyperlink (the real link is the result's pre-filled URL button).
+const BUG_REPORT_PAGE_URL =
+  'https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus/issues';
+
+/** Group symptoms by their `group` field, preserving first-seen order. */
+function groupSymptoms(symptoms: Symptom[]): Array<[string, Symptom[]]> {
+  const order: string[] = [];
+  const byGroup = new Map<string, Symptom[]>();
+  for (const s of symptoms) {
+    const key = s.group || 'Other';
+    let bucket = byGroup.get(key);
+    if (!bucket) {
+      bucket = [];
+      byGroup.set(key, bucket);
+      order.push(key);
+    }
+    bucket.push(s);
+  }
+  return order.map((g) => [g, byGroup.get(g) ?? []]);
+}
+
+export default function ReportProblemModal() {
+  const isOpen = useReportProblemStore((s) => s.isOpen);
+  const symptoms = useReportProblemStore((s) => s.symptoms);
+  const selectedSymptomId = useReportProblemStore((s) => s.selectedSymptomId);
+  const freeText = useReportProblemStore((s) => s.freeText);
+  const loading = useReportProblemStore((s) => s.loading);
+  const error = useReportProblemStore((s) => s.error);
+  const result = useReportProblemStore((s) => s.result);
+  const close = useReportProblemStore((s) => s.close);
+  const setSymptom = useReportProblemStore((s) => s.setSymptom);
+  const setFreeText = useReportProblemStore((s) => s.setFreeText);
+  const run = useReportProblemStore((s) => s.run);
+  const reset = useReportProblemStore((s) => s.reset);
+
+  const [copied, setCopied] = useState(false);
+
+  const grouped = useMemo(() => groupSymptoms(symptoms), [symptoms]);
+
+  if (!isOpen) return null;
+
+  const onCopy = () => {
+    if (!result) return;
+    void navigator.clipboard
+      .writeText(result.markdown)
+      .then(() => {
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 2000);
+      })
+      .catch(() => {
+        // Clipboard can be blocked (insecure context / permissions). The
+        // preview below still lets the operator select + copy manually.
+        setCopied(false);
+      });
+  };
+
+  const onOpenPage = () => {
+    if (!result) return;
+    window.open(result.githubIssueUrl, '_blank', 'noopener');
+  };
+
+  const labelStyle: React.CSSProperties = {
+    fontSize: 11,
+    fontWeight: 600,
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+    color: 'var(--fg-2)',
+  };
+
+  return (
+    <div
+      className="modal-backdrop"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0, 0, 0, 0.7)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 10000,
+      }}
+      onClick={close}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="report-problem-title"
+        style={{
+          maxWidth: 560,
+          width: '92vw',
+          maxHeight: '88vh',
+          overflowY: 'auto',
+          padding: 20,
+          background: 'linear-gradient(180deg, var(--panel-top), var(--panel-bot))',
+          border: '1px solid var(--line)',
+          borderRadius: 8,
+          color: 'var(--fg-0)',
+          fontFamily: 'var(--font-sans, Inter, system-ui, sans-serif)',
+          boxShadow: '0 10px 30px rgba(0, 0, 0, 0.55)',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 14,
+        }}
+      >
+        <h2
+          id="report-problem-title"
+          style={{
+            margin: 0,
+            fontSize: 14,
+            fontWeight: 600,
+            letterSpacing: 1.5,
+            textTransform: 'uppercase',
+            color: 'var(--fg-0)',
+          }}
+        >
+          {result ? 'Send this to the developers' : 'Report a problem'}
+        </h2>
+
+        {error && (
+          <div
+            role="alert"
+            style={{
+              padding: '8px 12px',
+              background: 'var(--tx-soft)',
+              border: '1px solid var(--tx)',
+              borderRadius: 4,
+              fontSize: 13,
+              color: 'var(--fg-0)',
+              lineHeight: 1.5,
+            }}
+          >
+            <div style={{ marginBottom: 8 }}>
+              Sorry — something went wrong putting your report together. Please
+              try again.
+            </div>
+            <button type="button" className="btn ghost" onClick={() => void run()}>
+              Try again
+            </button>
+          </div>
+        )}
+
+        {!result ? (
+          // ---------------------------------------------------------------
+          // (a) FORM
+          // ---------------------------------------------------------------
+          <>
+            <p style={{ margin: 0, fontSize: 13, color: 'var(--fg-1)', lineHeight: 1.5 }}>
+              Tell us what's not working. Pick the closest match and/or describe
+              it in your own words — then run the diagnostic and we'll package it
+              all up for you.
+            </p>
+
+            <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              <span style={labelStyle}>What's the problem?</span>
+              <select
+                value={selectedSymptomId ?? ''}
+                onChange={(e) => setSymptom(e.target.value === '' ? null : e.target.value)}
+                style={{
+                  width: '100%',
+                  padding: '6px 8px',
+                  background: 'var(--bg-2)',
+                  color: 'var(--fg-0)',
+                  border: '1px solid var(--line-strong)',
+                  borderRadius: 4,
+                  fontSize: 13,
+                  fontFamily: 'inherit',
+                }}
+              >
+                <option value="">— Choose the closest match (optional) —</option>
+                {grouped.map(([group, items]) => (
+                  <optgroup key={group} label={group}>
+                    {items.map((s) => (
+                      <option key={s.id} value={s.id}>
+                        {s.label}
+                      </option>
+                    ))}
+                  </optgroup>
+                ))}
+              </select>
+            </label>
+
+            <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              <span style={labelStyle}>
+                Describe what's wrong in your own words (optional)
+              </span>
+              <textarea
+                value={freeText}
+                onChange={(e) => setFreeText(e.target.value)}
+                rows={5}
+                placeholder="For example: the audio cuts out for a second every time I transmit."
+                style={{
+                  width: '100%',
+                  padding: '8px',
+                  background: 'var(--bg-2)',
+                  color: 'var(--fg-0)',
+                  border: '1px solid var(--line-strong)',
+                  borderRadius: 4,
+                  fontSize: 13,
+                  fontFamily: 'inherit',
+                  resize: 'vertical',
+                }}
+              />
+            </label>
+
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+              <button type="button" className="btn ghost" onClick={close}>
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="btn sm active"
+                disabled={loading}
+                onClick={() => void run()}
+              >
+                {loading ? 'Running…' : 'Run diagnostic'}
+              </button>
+            </div>
+          </>
+        ) : (
+          // ---------------------------------------------------------------
+          // (b) RESULT
+          // ---------------------------------------------------------------
+          <>
+            <ol
+              style={{
+                margin: 0,
+                paddingLeft: 20,
+                fontSize: 13,
+                color: 'var(--fg-1)',
+                lineHeight: 1.6,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 8,
+              }}
+            >
+              <li>
+                Click the blue "Open bug report page" button below. It opens in
+                your web browser.
+              </li>
+              <li>
+                If the page asks you to sign in, create a free account (it only
+                takes a minute) or log in.
+              </li>
+              <li>
+                Good news — we already filled in the whole report for you. If the
+                title box at the top is empty, type a few words describing the
+                problem.
+              </li>
+              <li>
+                Click the green "Submit new issue" button at the bottom of that
+                page. That's it — you're done, and the developers will see it.
+              </li>
+            </ol>
+
+            <p style={{ margin: 0, fontSize: 12, color: 'var(--fg-2)', lineHeight: 1.5 }}>
+              If the page didn't fill itself in, click "Copy report" below, then
+              paste it into the big description box on that page (right-click →
+              Paste, or Ctrl/Cmd+V).
+            </p>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <span style={labelStyle}>The bug report page is here:</span>
+              <code
+                style={{
+                  userSelect: 'all',
+                  WebkitUserSelect: 'all',
+                  padding: '6px 8px',
+                  background: 'var(--bg-1)',
+                  border: '1px solid var(--line)',
+                  borderRadius: 4,
+                  fontSize: 12,
+                  fontFamily: 'var(--font-mono, JetBrains Mono, ui-monospace, monospace)',
+                  color: 'var(--fg-0)',
+                  wordBreak: 'break-all',
+                }}
+              >
+                {BUG_REPORT_PAGE_URL}
+              </code>
+            </div>
+
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+              <button
+                type="button"
+                className="btn sm active"
+                autoFocus
+                onClick={onOpenPage}
+              >
+                Open bug report page
+              </button>
+              <button type="button" className="btn ghost" onClick={onCopy}>
+                {copied ? 'Copied!' : 'Copy report'}
+              </button>
+              <button
+                type="button"
+                className="btn ghost"
+                style={{ marginLeft: 'auto' }}
+                onClick={close}
+              >
+                Close
+              </button>
+            </div>
+
+            <details>
+              <summary
+                style={{
+                  cursor: 'pointer',
+                  fontSize: 12,
+                  color: 'var(--fg-2)',
+                  marginBottom: 6,
+                }}
+              >
+                This is exactly what will be sent (you can read it first):
+              </summary>
+              <pre
+                style={{
+                  margin: 0,
+                  maxHeight: 240,
+                  overflow: 'auto',
+                  padding: 10,
+                  background: 'var(--bg-1)',
+                  border: '1px solid var(--line)',
+                  borderRadius: 4,
+                  fontSize: 11,
+                  lineHeight: 1.5,
+                  fontFamily: 'var(--font-mono, JetBrains Mono, ui-monospace, monospace)',
+                  color: 'var(--fg-1)',
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-word',
+                }}
+              >
+                {result.markdown}
+              </pre>
+            </details>
+
+            <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
+              <button type="button" className="btn ghost" onClick={reset}>
+                Report something else
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/zeus-web/src/components/report-problem/ReportProblemModal.tsx
+++ b/zeus-web/src/components/report-problem/ReportProblemModal.tsx
@@ -22,6 +22,7 @@
 import { useMemo, useState } from 'react';
 import { useReportProblemStore } from '../../state/report-problem-store';
 import type { Symptom } from '../../api/diagnostics';
+import { openExternalUrl } from './openExternalUrl';
 
 // Shown verbatim so operators can read the page address; it is selectable text,
 // not a working hyperlink (the real link is the result's pre-filled URL button).
@@ -82,7 +83,7 @@ export default function ReportProblemModal() {
 
   const onOpenPage = () => {
     if (!result) return;
-    window.open(result.githubIssueUrl, '_blank', 'noopener');
+    openExternalUrl(result.githubIssueUrl);
   };
 
   const labelStyle: React.CSSProperties = {

--- a/zeus-web/src/components/report-problem/openExternalUrl.ts
+++ b/zeus-web/src/components/report-problem/openExternalUrl.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+interface PhotinoSurface {
+  external?: { sendMessage?: (message: string) => void };
+}
+
+/**
+ * Open an external URL in the operator's real browser.
+ *
+ * Inside the Photino desktop shell, `window.open` to an external site is
+ * unreliable (the webview swallows it), so we post a `zeus.openExternal`
+ * message and the C# host opens it via the OS browser. In a normal browser
+ * (web-dev / LAN client) there is no host bridge, so we fall back to
+ * `window.open`.
+ */
+export function openExternalUrl(url: string): void {
+  const sendMessage = (window as unknown as PhotinoSurface).external?.sendMessage;
+  if (typeof sendMessage === 'function') {
+    sendMessage(JSON.stringify({ type: 'zeus.openExternal', url }));
+    return;
+  }
+  window.open(url, '_blank', 'noopener,noreferrer');
+}

--- a/zeus-web/src/state/report-problem-store.test.ts
+++ b/zeus-web/src/state/report-problem-store.test.ts
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ReportResult, Symptom } from '../api/diagnostics';
+
+vi.mock('../api/diagnostics', () => ({
+  fetchSymptoms: vi.fn(),
+  runReport: vi.fn(),
+}));
+
+import { fetchSymptoms, runReport } from '../api/diagnostics';
+import { ApiError } from '../api/client';
+import { useReportProblemStore } from './report-problem-store';
+
+const SYMPTOMS: Symptom[] = [
+  { id: 'no-audio', label: 'No receive audio', group: 'Audio' },
+  { id: 'tx-crackle', label: 'Crackling on transmit', group: 'Transmit' },
+];
+
+const RESULT: ReportResult = {
+  report: { foo: 'bar' },
+  markdown: '# Zeus problem report\n\nNo receive audio.\n',
+  githubIssueUrl: 'https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus/issues/new?body=...',
+};
+
+const RESET = {
+  isOpen: false,
+  symptoms: [],
+  symptomsLoaded: false,
+  selectedSymptomId: null,
+  freeText: '',
+  loading: false,
+  error: null,
+  result: null,
+};
+
+const mockFetchSymptoms = vi.mocked(fetchSymptoms);
+const mockRunReport = vi.mocked(runReport);
+
+describe('report-problem-store', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useReportProblemStore.setState(RESET);
+  });
+
+  it('open() opens the modal and lazy-loads symptoms', async () => {
+    mockFetchSymptoms.mockResolvedValue(SYMPTOMS);
+
+    useReportProblemStore.getState().open();
+    expect(useReportProblemStore.getState().isOpen).toBe(true);
+    expect(mockFetchSymptoms).toHaveBeenCalledTimes(1);
+
+    // Let the lazy load settle.
+    await vi.waitFor(() => {
+      expect(useReportProblemStore.getState().symptomsLoaded).toBe(true);
+    });
+    expect(useReportProblemStore.getState().symptoms).toEqual(SYMPTOMS);
+  });
+
+  it('open() does not re-fetch symptoms once loaded', async () => {
+    mockFetchSymptoms.mockResolvedValue(SYMPTOMS);
+
+    useReportProblemStore.getState().open();
+    await vi.waitFor(() => {
+      expect(useReportProblemStore.getState().symptomsLoaded).toBe(true);
+    });
+    useReportProblemStore.getState().close();
+    useReportProblemStore.getState().open();
+
+    expect(mockFetchSymptoms).toHaveBeenCalledTimes(1);
+  });
+
+  it('open() still marks symptoms loaded when the fetch fails', async () => {
+    mockFetchSymptoms.mockRejectedValue(new Error('network down'));
+
+    useReportProblemStore.getState().open();
+    await vi.waitFor(() => {
+      expect(useReportProblemStore.getState().symptomsLoaded).toBe(true);
+    });
+    expect(useReportProblemStore.getState().symptoms).toEqual([]);
+  });
+
+  it('setSymptom() and setFreeText() update the form fields', () => {
+    useReportProblemStore.getState().setSymptom('no-audio');
+    useReportProblemStore.getState().setFreeText('it is broken');
+    const s = useReportProblemStore.getState();
+    expect(s.selectedSymptomId).toBe('no-audio');
+    expect(s.freeText).toBe('it is broken');
+  });
+
+  it('run() populates result and passes the selected symptom + trimmed text', async () => {
+    mockRunReport.mockResolvedValue(RESULT);
+    useReportProblemStore.getState().setSymptom('no-audio');
+    useReportProblemStore.getState().setFreeText('  no sound at all  ');
+
+    await useReportProblemStore.getState().run();
+
+    expect(mockRunReport).toHaveBeenCalledWith({
+      symptomId: 'no-audio',
+      freeText: 'no sound at all',
+    });
+    const s = useReportProblemStore.getState();
+    expect(s.result).toEqual(RESULT);
+    expect(s.loading).toBe(false);
+    expect(s.error).toBeNull();
+  });
+
+  it('run() sends null freeText when the box is empty/whitespace', async () => {
+    mockRunReport.mockResolvedValue(RESULT);
+    useReportProblemStore.getState().setFreeText('   ');
+
+    await useReportProblemStore.getState().run();
+
+    expect(mockRunReport).toHaveBeenCalledWith({
+      symptomId: null,
+      freeText: null,
+    });
+  });
+
+  it('run() records the ApiError message and clears loading on failure', async () => {
+    mockRunReport.mockRejectedValue(new ApiError(500, 'server exploded'));
+
+    await useReportProblemStore.getState().run();
+
+    const s = useReportProblemStore.getState();
+    expect(s.result).toBeNull();
+    expect(s.loading).toBe(false);
+    expect(s.error).toBe('server exploded');
+  });
+
+  it('close() leaves the modal closed but keeps cached symptoms', async () => {
+    mockFetchSymptoms.mockResolvedValue(SYMPTOMS);
+    useReportProblemStore.getState().open();
+    await vi.waitFor(() => {
+      expect(useReportProblemStore.getState().symptomsLoaded).toBe(true);
+    });
+
+    useReportProblemStore.getState().close();
+    const s = useReportProblemStore.getState();
+    expect(s.isOpen).toBe(false);
+    expect(s.symptoms).toEqual(SYMPTOMS);
+  });
+
+  it('reset() clears the form + result but keeps cached symptoms', async () => {
+    mockFetchSymptoms.mockResolvedValue(SYMPTOMS);
+    mockRunReport.mockResolvedValue(RESULT);
+    useReportProblemStore.getState().open();
+    await vi.waitFor(() => {
+      expect(useReportProblemStore.getState().symptomsLoaded).toBe(true);
+    });
+    useReportProblemStore.getState().setSymptom('no-audio');
+    useReportProblemStore.getState().setFreeText('broken');
+    await useReportProblemStore.getState().run();
+
+    useReportProblemStore.getState().reset();
+    const s = useReportProblemStore.getState();
+    expect(s.selectedSymptomId).toBeNull();
+    expect(s.freeText).toBe('');
+    expect(s.result).toBeNull();
+    expect(s.error).toBeNull();
+    expect(s.loading).toBe(false);
+    // Cached catalogue survives a reset.
+    expect(s.symptoms).toEqual(SYMPTOMS);
+  });
+});

--- a/zeus-web/src/state/report-problem-store.ts
+++ b/zeus-web/src/state/report-problem-store.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+// "Report a problem" self-diagnostic state. The footer button opens the modal
+// (open() lazy-loads the symptom catalogue on first open); the operator picks a
+// symptom and/or types a description, then run() asks the backend to assemble a
+// Markdown report + a pre-filled bug-report page URL.
+
+import { create } from 'zustand';
+import {
+  fetchSymptoms,
+  runReport,
+  type ReportResult,
+  type Symptom,
+} from '../api/diagnostics';
+import { ApiError } from '../api/client';
+
+export type ReportProblemState = {
+  isOpen: boolean;
+  symptoms: Symptom[];
+  symptomsLoaded: boolean;
+  selectedSymptomId: string | null;
+  freeText: string;
+  loading: boolean;
+  error: string | null;
+  result: ReportResult | null;
+
+  /** Open the modal; lazy-loads the symptom catalogue on first open. */
+  open: () => void;
+  close: () => void;
+  setSymptom: (id: string | null) => void;
+  setFreeText: (s: string) => void;
+  /** Run the diagnostic and populate result/error/loading. */
+  run: () => Promise<void>;
+  /** Clear the form + result back to a pristine state (keeps cached symptoms). */
+  reset: () => void;
+};
+
+export const useReportProblemStore = create<ReportProblemState>((set, get) => ({
+  isOpen: false,
+  symptoms: [],
+  symptomsLoaded: false,
+  selectedSymptomId: null,
+  freeText: '',
+  loading: false,
+  error: null,
+  result: null,
+
+  open: () => {
+    set({ isOpen: true });
+    if (!get().symptomsLoaded) {
+      void (async () => {
+        try {
+          const symptoms = await fetchSymptoms();
+          set({ symptoms, symptomsLoaded: true });
+        } catch {
+          // The catalogue is best-effort; the operator can still type a
+          // free-text description and run the diagnostic without it.
+          set({ symptomsLoaded: true });
+        }
+      })();
+    }
+  },
+
+  close: () => set({ isOpen: false }),
+
+  setSymptom: (id) => set({ selectedSymptomId: id }),
+
+  setFreeText: (s) => set({ freeText: s }),
+
+  run: async () => {
+    const { selectedSymptomId, freeText } = get();
+    set({ loading: true, error: null, result: null });
+    try {
+      const trimmed = freeText.trim();
+      const result = await runReport({
+        symptomId: selectedSymptomId,
+        freeText: trimmed.length > 0 ? trimmed : null,
+      });
+      set({ result, loading: false });
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : String(err);
+      set({ error: msg, loading: false });
+    }
+  },
+
+  reset: () =>
+    set({
+      selectedSymptomId: null,
+      freeText: '',
+      loading: false,
+      error: null,
+      result: null,
+    }),
+}));


### PR DESCRIPTION
## What

Adds a **Report a problem** button to the footer (transport bar). The operator picks a symptom + optionally describes the issue in their own words; Zeus assembles a redacted, paste-ready report and walks a non-technical ham through filing it on GitHub (with a one-click "Open bug report page" that prefills title **and** body, a Copy fallback, and a transparency preview of exactly what's sent).

Verified live on a G2 (desktop): the button works, the report renders, and the prefilled GitHub page opens in the system browser.

### Phase 1 — capture + report
- **Ring-buffer log capture** (`DiagnosticLogBuffer` + `RingBufferLoggerProvider` on the logging pipeline): always retains the last 1000 formatted log lines; every report ships the **last 100** (you can't capture logs retroactively).
- **Redaction** (`Redaction`): scrubs passwords/tokens, emails, IPs, MACs, home-dir usernames, and precise grid squares from both log lines **and the operator's free text** (it lands in a public issue) — while keeping callsign/board/frequency for diagnosis.
- **Read-only probes**: environment, connection, board (capabilities/cal), dsp-audio, tx-ps. The tx-ps probe reads `PsEnabled`/HwPeak but **never arms PS** (burn-zone).
- **Report builder**: Markdown render + prefilled GitHub new-issue URL (trims the log from the URL past ~7k chars; full text stays in the copied report).
- Endpoints: `GET /api/diagnostics/symptoms`, `POST /api/diagnostics/report`.
- Desktop external-link fix: `window.open` is unreliable in the Photino webview, so a `zeus.openExternal` host bridge opens links in the real OS browser (validated http/https), with a `window.open` fallback in a normal browser.

### Phase 2 — knowledge (symptom → likely cause)
Symptom→recipe registry + known-issue rules seeded from `docs/rca` + `docs/lessons`:
- **PS not armed** (the #1 "PureSignal won't work" — Zeus never auto-arms)
- **Audio underruns** → crackling/dropping RX audio (caught the real cause in live testing)
- **IQ-write-gate** (Hermes-class, no TX power)
- **HL2 drive model**, **RXA audio silence**, **disconnection**, **RX-aux Bypass** (dead band), **PS-startup-armed** tripwire

## Test
- Full server suite: **1323 passed, 0 failed** (incl. redaction, ring-buffer, probe, symptom-registry, rule, and report-builder tests).
- Frontend builds; store test 9/9.

## Notes for reviewers
- No new NuGet/npm dependencies.
- `RxAuxBypassRule` and `AudioUnderrunRule` have no `DocRef` — no dedicated lesson exists yet. A short `docs/lessons/rx-aux-bypass.md` + an audio-underrun note would be worth adding as a follow-up.
- Phase 3 (relay-proxied issue creation / private phone-home via Christian's API) is intentionally **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)