### PR TITLE
feat(chat): friends consent, rooms/DMs, moderation, freq privacy

### DIFF
--- a/Zeus.Contracts/ChatDtos.cs
+++ b/Zeus.Contracts/ChatDtos.cs
@@ -86,10 +86,54 @@ public sealed record ChatStatusDto(
     bool Connected,
     string? Callsign,
     string RelayUrl,
-    string? Error);
+    string? Error,
+    bool IsAdmin = false,
+    bool FreqPublic = true);
+
+/// <summary>
+/// A chat channel visible to the operator: the public lobby, an admin-created
+/// group, or a DM. <paramref name="Kind"/> is "public"|"group"|"dm";
+/// <paramref name="Members"/> is empty for the public room.
+/// </summary>
+public sealed record ChatRoomDto(
+    string Id,
+    string Name,
+    string Kind,
+    IReadOnlyList<string> Members);
+
+/// <summary>
+/// The local operator's friend graph, mirrored from the relay. <paramref name="Accepted"/>
+/// are mutual friends (whose frequency is visible); <paramref name="Incoming"/> are
+/// requests awaiting this operator's accept/deny; <paramref name="Outgoing"/> are
+/// requests this operator has sent that are still pending. Callsigns are uppercased.
+/// </summary>
+public sealed record ChatFriendsDto(
+    IReadOnlyList<string> Accepted,
+    IReadOnlyList<string> Incoming,
+    IReadOnlyList<string> Outgoing);
 
 // ── REST request/response shapes ──────────────────────────────────────────
 
 public sealed record ChatEnableRequest(bool Enabled);
 
-public sealed record ChatSendRequest(string Text);
+/// <summary>Outgoing message; <paramref name="Room"/> defaults to the public lobby.</summary>
+public sealed record ChatSendRequest(string Text, string? Room = null);
+
+/// <summary>A single-callsign request body for the friend endpoints
+/// (request / accept / deny / remove) and admin ban/unban.</summary>
+public sealed record ChatFriendRequest(string Callsign);
+
+/// <summary>Send a direct message to <paramref name="To"/>.</summary>
+public sealed record ChatDmRequest(string To, string Text);
+
+/// <summary>Admin: create a private group named <paramref name="Name"/>.</summary>
+public sealed record ChatRoomCreateRequest(string Name);
+
+/// <summary>Admin: add/remove <paramref name="Callsign"/> to/from <paramref name="Room"/>.</summary>
+public sealed record ChatRoomMemberRequest(string Room, string Callsign);
+
+/// <summary>Admin: delete a private group, or request history for a room.</summary>
+public sealed record ChatRoomRequest(string Room);
+
+/// <summary>Toggle whether this operator's frequency may be shared (eye toggle).</summary>
+public sealed record ChatFreqVisibilityRequest(bool Public);

--- a/Zeus.Contracts/ChatEventFrame.cs
+++ b/Zeus.Contracts/ChatEventFrame.cs
@@ -17,7 +17,10 @@ namespace Zeus.Contracts;
 /// {"kind":"status","status":{...ChatStatusDto...}}
 /// {"kind":"roster","roster":[{...ChatOperator...}, ...]}
 /// {"kind":"message","message":{...ChatMessage...}}
-/// {"kind":"history","messages":[{...ChatMessage...}, ...]}
+/// {"kind":"history","room":"lobby","messages":[{...ChatMessage...}, ...]}
+/// {"kind":"friends","friends":{...ChatFriendsDto...}}
+/// {"kind":"rooms","rooms":[{...ChatRoomDto...}, ...]}
+/// {"kind":"banned","message":"..."}
 /// </code>
 ///
 /// JSON (rather than fixed binary) because the payload is small, low-rate, and
@@ -45,9 +48,21 @@ public static class ChatEventFrame
     public static byte[] Message(ChatMessage message) =>
         Encode(new MessageEnvelope(message));
 
-    /// <summary>Encodes a history (message list) envelope into a 0x35 frame.</summary>
-    public static byte[] History(IReadOnlyList<ChatMessage> messages) =>
-        Encode(new HistoryEnvelope(messages));
+    /// <summary>Encodes a history (message list) envelope for a room into a 0x35 frame.</summary>
+    public static byte[] History(string room, IReadOnlyList<ChatMessage> messages) =>
+        Encode(new HistoryEnvelope(room, messages));
+
+    /// <summary>Encodes a friend-graph envelope into a 0x35 frame.</summary>
+    public static byte[] Friends(ChatFriendsDto friends) =>
+        Encode(new FriendsEnvelope(friends));
+
+    /// <summary>Encodes the operator's visible-rooms list into a 0x35 frame.</summary>
+    public static byte[] Rooms(IReadOnlyList<ChatRoomDto> rooms) =>
+        Encode(new RoomsEnvelope(rooms));
+
+    /// <summary>Encodes a ban/kick notice into a 0x35 frame.</summary>
+    public static byte[] Banned(string message) =>
+        Encode(new BannedEnvelope(message));
 
     /// <summary>Serialises <paramref name="envelope"/> to UTF-8 JSON and
     /// prefixes the ChatEvent type byte.</summary>
@@ -90,8 +105,23 @@ public static class ChatEventFrame
         public string Kind => "message";
     }
 
-    public sealed record HistoryEnvelope(IReadOnlyList<ChatMessage> Messages)
+    public sealed record HistoryEnvelope(string Room, IReadOnlyList<ChatMessage> Messages)
     {
         public string Kind => "history";
+    }
+
+    public sealed record FriendsEnvelope(ChatFriendsDto Friends)
+    {
+        public string Kind => "friends";
+    }
+
+    public sealed record RoomsEnvelope(IReadOnlyList<ChatRoomDto> Rooms)
+    {
+        public string Kind => "rooms";
+    }
+
+    public sealed record BannedEnvelope(string Message)
+    {
+        public string Kind => "banned";
     }
 }

--- a/Zeus.Server.Hosting/ChatEnabledStore.cs
+++ b/Zeus.Server.Hosting/ChatEnabledStore.cs
@@ -64,6 +64,41 @@ public sealed class ChatEnabledStore : IDisposable
         }
     }
 
+    /// <summary>Whether the operator's frequency may be shared (eye toggle).
+    /// Defaults to true (visible to friends) when unset.</summary>
+    public bool GetFreqPublic()
+    {
+        lock (_sync)
+        {
+            var entry = _state.FindAll().FirstOrDefault();
+            return entry?.FreqPublic ?? true;
+        }
+    }
+
+    public void SetFreqPublic(bool freqPublic)
+    {
+        lock (_sync)
+        {
+            var existing = _state.FindAll().FirstOrDefault();
+            var nowUtc = DateTime.UtcNow;
+            if (existing is null)
+            {
+                _state.Insert(new ChatEnabledEntry
+                {
+                    Enabled = false,
+                    FreqPublic = freqPublic,
+                    UpdatedUtc = nowUtc,
+                });
+            }
+            else
+            {
+                existing.FreqPublic = freqPublic;
+                existing.UpdatedUtc = nowUtc;
+                _state.Update(existing);
+            }
+        }
+    }
+
     public void Dispose() => _db.Dispose();
 }
 
@@ -71,5 +106,8 @@ public sealed class ChatEnabledEntry
 {
     public int Id { get; set; }
     public bool Enabled { get; set; }
+    // Nullable so rows written before this field default to "visible" (null → true)
+    // rather than LiteDB's bool default of false, which would silently hide freq.
+    public bool? FreqPublic { get; set; }
     public DateTime UpdatedUtc { get; set; }
 }

--- a/Zeus.Server.Hosting/ChatService.cs
+++ b/Zeus.Server.Hosting/ChatService.cs
@@ -53,9 +53,23 @@ public sealed class ChatService : BackgroundService
     private readonly string _relayUrl;
     private readonly string? _relaySecret;
 
+    private static readonly ChatFriendsDto EmptyFriends =
+        new(Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>());
+
     private readonly ChatMessageRing _messages = new(MessageHistoryCap);
     private readonly object _rosterSync = new();
     private IReadOnlyList<ChatOperator> _roster = Array.Empty<ChatOperator>();
+
+    // The operator's friend graph, mirrored from the relay (accepted / incoming
+    // / outgoing). Replaced wholesale on each relay "friends" frame.
+    private volatile ChatFriendsDto _friends = EmptyFriends;
+
+    // Rooms the operator can see (public + groups + DMs), mirrored from the relay.
+    private readonly object _roomsSync = new();
+    private IReadOnlyList<ChatRoomDto> _rooms = Array.Empty<ChatRoomDto>();
+
+    // Whether the operator is a relay moderator (from the welcome frame).
+    private volatile bool _isAdmin;
 
     // Live connection state, set on the worker loop and read by the API.
     private volatile bool _connected;
@@ -109,7 +123,9 @@ public sealed class ChatService : BackgroundService
         Connected: _connected,
         Callsign: _selfCallsign,
         RelayUrl: _relayUrl,
-        Error: _lastError);
+        Error: _lastError,
+        IsAdmin: _isAdmin,
+        FreqPublic: _store.GetFreqPublic());
 
     /// <summary>Persists the opt-in and wakes the worker to connect/disconnect.</summary>
     public ChatStatusDto SetEnabled(bool enabled)
@@ -136,16 +152,136 @@ public sealed class ChatService : BackgroundService
     /// <see cref="ArgumentException"/> when the text is empty — the endpoint
     /// maps these to 409 / 400.
     /// </summary>
-    public async Task SendMessageAsync(string text, CancellationToken ct)
+    public async Task SendMessageAsync(string text, string? room, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(text))
             throw new ArgumentException("message text is empty", nameof(text));
 
+        var socket = RequireSocket();
+        var roomId = string.IsNullOrWhiteSpace(room) ? "lobby" : room.Trim();
+        await SendFrameAsync(socket, new { t = "msg", text, room = roomId }, ct);
+    }
+
+    /// <summary>Sends a direct message to <paramref name="to"/> (creates the DM on demand).</summary>
+    public async Task SendDmAsync(string to, string text, CancellationToken ct)
+    {
+        var call = (to ?? string.Empty).Trim().ToUpperInvariant();
+        if (call.Length == 0) throw new ArgumentException("recipient is empty", nameof(to));
+        if (string.IsNullOrWhiteSpace(text)) throw new ArgumentException("message text is empty", nameof(text));
+        var socket = RequireSocket();
+        await SendFrameAsync(socket, new { t = "dm", to = call, text }, ct);
+    }
+
+    /// <summary>Asks the relay for recent history of a room (pushed back as a 0x35 frame).</summary>
+    public async Task RequestHistoryAsync(string room, CancellationToken ct)
+    {
+        var roomId = string.IsNullOrWhiteSpace(room) ? "lobby" : room.Trim();
+        var socket = RequireSocket();
+        await SendFrameAsync(socket, new { t = "history", room = roomId }, ct);
+    }
+
+    /// <summary>Rooms the operator can currently see.</summary>
+    public IReadOnlyList<ChatRoomDto> GetRooms()
+    {
+        lock (_roomsSync) return _rooms;
+    }
+
+    // ── Admin / moderation ─────────────────────────────────────────────────
+
+    public Task CreateRoomAsync(string name, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("room name is empty", nameof(name));
+        return SendFrameAsync(RequireSocket(), new { t = "admin_create_room", name = name.Trim() }, ct);
+    }
+
+    public Task DeleteRoomAsync(string room, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(room)) throw new ArgumentException("room is empty", nameof(room));
+        return SendFrameAsync(RequireSocket(), new { t = "admin_delete_room", room = room.Trim() }, ct);
+    }
+
+    public Task AddMemberAsync(string room, string callsign, CancellationToken ct) =>
+        SendRoomMemberAsync("admin_add_member", room, callsign, ct);
+
+    public Task RemoveMemberAsync(string room, string callsign, CancellationToken ct) =>
+        SendRoomMemberAsync("admin_remove_member", room, callsign, ct);
+
+    public Task BanAsync(string callsign, CancellationToken ct) =>
+        SendFriendActionAsync("admin_ban", "callsign", callsign, ct);
+
+    public Task UnbanAsync(string callsign, CancellationToken ct) =>
+        SendFriendActionAsync("admin_unban", "callsign", callsign, ct);
+
+    private Task SendRoomMemberAsync(string verb, string room, string callsign, CancellationToken ct)
+    {
+        var call = (callsign ?? string.Empty).Trim().ToUpperInvariant();
+        if (string.IsNullOrWhiteSpace(room)) throw new ArgumentException("room is empty", nameof(room));
+        if (call.Length == 0) throw new ArgumentException("callsign is empty", nameof(callsign));
+        return SendFrameAsync(RequireSocket(),
+            new Dictionary<string, string> { ["t"] = verb, ["room"] = room.Trim(), ["callsign"] = call }, ct);
+    }
+
+    // ── Frequency visibility (eye toggle) ──────────────────────────────────
+
+    /// <summary>Persists the eye toggle and, if connected, tells the relay at once.</summary>
+    public async Task SetFreqVisibilityAsync(bool isPublic, CancellationToken ct)
+    {
+        _store.SetFreqPublic(isPublic);
+        PushStatus();
+        var socket = _socket;
+        if (socket is not null && socket.State == WebSocketState.Open && _connected)
+        {
+            var snap = _radio.Snapshot();
+            await SendFrameAsync(socket, new
+            {
+                t = "presence",
+                freq = snap.VfoHz,
+                mode = snap.Mode.ToString(),
+                status = CurrentStatus(),
+                freqPublic = isPublic,
+            }, ct);
+        }
+    }
+
+    private ClientWebSocket RequireSocket()
+    {
         var socket = _socket;
         if (socket is null || socket.State != WebSocketState.Open || !_connected)
             throw new InvalidOperationException("chat relay is not connected");
+        return socket;
+    }
 
-        await SendFrameAsync(socket, new { t = "msg", text }, ct);
+    /// <summary>The operator's current friend graph (accepted / incoming / outgoing).</summary>
+    public ChatFriendsDto GetFriends() => _friends;
+
+    /// <summary>Sends a friend request to <paramref name="callsign"/>.</summary>
+    public Task SendFriendRequestAsync(string callsign, CancellationToken ct) =>
+        SendFriendActionAsync("friend_req", "to", callsign, ct);
+
+    /// <summary>Accepts the incoming friend request from <paramref name="callsign"/>.</summary>
+    public Task AcceptFriendAsync(string callsign, CancellationToken ct) =>
+        SendFriendActionAsync("friend_accept", "from", callsign, ct);
+
+    /// <summary>Declines the incoming friend request from <paramref name="callsign"/>.</summary>
+    public Task DenyFriendAsync(string callsign, CancellationToken ct) =>
+        SendFriendActionAsync("friend_deny", "from", callsign, ct);
+
+    /// <summary>Removes a friendship and/or cancels a pending request with
+    /// <paramref name="callsign"/>.</summary>
+    public Task RemoveFriendAsync(string callsign, CancellationToken ct) =>
+        SendFriendActionAsync("friend_remove", "callsign", callsign, ct);
+
+    // Common path for the four friend verbs. Validates like SendMessageAsync so
+    // the endpoints map empty callsign → 400 and not-connected → 409. Builds the
+    // frame as a dictionary so the field name (to/from/callsign) is emitted
+    // verbatim (lowercase) rather than camelCased.
+    private async Task SendFriendActionAsync(string verb, string field, string callsign, CancellationToken ct)
+    {
+        var call = (callsign ?? string.Empty).Trim().ToUpperInvariant();
+        if (call.Length == 0)
+            throw new ArgumentException("callsign is empty", nameof(callsign));
+
+        await SendFrameAsync(RequireSocket(), new Dictionary<string, string> { ["t"] = verb, [field] = call }, ct);
     }
 
     // ── Background worker ──────────────────────────────────────────────────
@@ -164,8 +300,15 @@ public sealed class ChatService : BackgroundService
             var identity = await TryGetIdentityAsync(stoppingToken);
             if (identity is null)
             {
-                // Logged out (or no session) while enabled — wait and retry.
-                _lastError = "QRZ not logged in";
+                // Logged out (or no session) while enabled — surface the reason
+                // so the panel can say "Login to QRZ" instead of spinning on
+                // "Connecting…", then wait and retry. Push only on transition to
+                // avoid spamming a status frame every backoff tick.
+                if (_lastError != "QRZ not logged in")
+                {
+                    _lastError = "QRZ not logged in";
+                    PushStatus();
+                }
                 await WaitForWakeAsync(backoff, stoppingToken);
                 continue;
             }
@@ -236,6 +379,7 @@ public sealed class ChatService : BackgroundService
             freq = snap.VfoHz,
             mode = snap.Mode.ToString(),
             status = CurrentStatus(),
+            freqPublic = _store.GetFreqPublic(),
             client = "zeus",
         }, ct);
 
@@ -314,6 +458,8 @@ public sealed class ChatService : BackgroundService
                 case "welcome":
                     if (root.TryGetProperty("self", out var selfEl))
                         _selfCallsign = ReadString(selfEl, "callsign") ?? _selfCallsign;
+                    _isAdmin = root.TryGetProperty("isAdmin", out var adminEl)
+                        && adminEl.ValueKind == JsonValueKind.True;
                     UpdateRoster(root, "roster");
                     PushStatus();
                     break;
@@ -322,8 +468,29 @@ public sealed class ChatService : BackgroundService
                     break;
                 case "msg":
                     var msg = ParseMessage(root);
-                    _messages.Add(msg);
+                    // The in-memory ring is the public-room snapshot cache only;
+                    // group/DM history comes from the relay on demand.
+                    if (string.IsNullOrEmpty(msg.Room) || msg.Room == "lobby")
+                        _messages.Add(msg);
                     _hub.BroadcastChatEvent(ChatEventFrame.Message(msg));
+                    break;
+                case "friends":
+                    _friends = ParseFriends(root);
+                    _hub.BroadcastChatEvent(ChatEventFrame.Friends(_friends));
+                    break;
+                case "rooms":
+                    var rooms = ParseRooms(root);
+                    lock (_roomsSync) _rooms = rooms;
+                    _hub.BroadcastChatEvent(ChatEventFrame.Rooms(rooms));
+                    break;
+                case "history":
+                    var histRoom = ReadString(root, "room") ?? "lobby";
+                    _hub.BroadcastChatEvent(ChatEventFrame.History(histRoom, ParseHistory(root)));
+                    break;
+                case "banned":
+                    _lastError = ReadString(root, "message") ?? "You have been banned from ZeusChat.";
+                    _hub.BroadcastChatEvent(ChatEventFrame.Banned(_lastError));
+                    PushStatus();
                     break;
                 case "error":
                     var code = ReadString(root, "code");
@@ -386,6 +553,55 @@ public sealed class ChatService : BackgroundService
         return list;
     }
 
+    /// <summary>
+    /// Parses a relay <c>{t:"friends",...}</c> frame into a <see cref="ChatFriendsDto"/>.
+    /// Missing arrays default to empty. Internal for unit tests.
+    /// </summary>
+    internal static ChatFriendsDto ParseFriends(JsonElement root) => new(
+        Accepted: ReadStringArray(root, "accepted"),
+        Incoming: ReadStringArray(root, "incoming"),
+        Outgoing: ReadStringArray(root, "outgoing"));
+
+    private static IReadOnlyList<string> ReadStringArray(JsonElement root, string name)
+    {
+        if (!root.TryGetProperty(name, out var arr) || arr.ValueKind != JsonValueKind.Array)
+            return Array.Empty<string>();
+        var list = new List<string>(arr.GetArrayLength());
+        foreach (var el in arr.EnumerateArray())
+        {
+            var s = el.GetString();
+            if (!string.IsNullOrWhiteSpace(s)) list.Add(s);
+        }
+        return list;
+    }
+
+    /// <summary>Parses a relay <c>{t:"rooms",rooms:[...]}</c> frame. Internal for tests.</summary>
+    internal static IReadOnlyList<ChatRoomDto> ParseRooms(JsonElement root)
+    {
+        if (!root.TryGetProperty("rooms", out var arr) || arr.ValueKind != JsonValueKind.Array)
+            return Array.Empty<ChatRoomDto>();
+        var list = new List<ChatRoomDto>(arr.GetArrayLength());
+        foreach (var r in arr.EnumerateArray())
+        {
+            list.Add(new ChatRoomDto(
+                Id: ReadString(r, "id") ?? string.Empty,
+                Name: ReadString(r, "name") ?? string.Empty,
+                Kind: ReadString(r, "kind") ?? "group",
+                Members: ReadStringArray(r, "members")));
+        }
+        return list;
+    }
+
+    /// <summary>Parses a relay <c>{t:"history",messages:[...]}</c> frame. Internal for tests.</summary>
+    internal static IReadOnlyList<ChatMessage> ParseHistory(JsonElement root)
+    {
+        if (!root.TryGetProperty("messages", out var arr) || arr.ValueKind != JsonValueKind.Array)
+            return Array.Empty<ChatMessage>();
+        var list = new List<ChatMessage>(arr.GetArrayLength());
+        foreach (var m in arr.EnumerateArray()) list.Add(ParseMessage(m));
+        return list;
+    }
+
     // ── Presence / status helpers ──────────────────────────────────────────
 
     private void OnRadioStateChanged(StateDto state)
@@ -414,11 +630,15 @@ public sealed class ChatService : BackgroundService
     {
         IReadOnlyList<ChatOperator> roster;
         lock (_rosterSync) roster = _roster;
+        IReadOnlyList<ChatRoomDto> rooms;
+        lock (_roomsSync) rooms = _rooms;
         return new[]
         {
             ChatEventFrame.Status(GetStatus()),
             ChatEventFrame.Roster(roster),
-            ChatEventFrame.History(_messages.Snapshot(MessageHistoryCap)),
+            ChatEventFrame.Friends(_friends),
+            ChatEventFrame.Rooms(rooms),
+            ChatEventFrame.History("lobby", _messages.Snapshot(MessageHistoryCap)),
         };
     }
 
@@ -427,14 +647,22 @@ public sealed class ChatService : BackgroundService
     private void SetDisconnected()
     {
         _socket = null;
-        if (_connected)
-        {
-            _connected = false;
+        var wasConnected = _connected;
+        _connected = false;
+        // Push when we drop a live link, or when there's an error to report:
+        // a first-attempt connect failure never set _connected, but the operator
+        // still needs to see why (e.g. relay unreachable) rather than "Connecting…".
+        _isAdmin = false;
+        if (wasConnected || _lastError is not null)
             PushStatus();
-        }
-        else
+        // Relay-sourced state (friend graph + rooms) is dropped so nothing stale
+        // lingers while offline. Fresh snapshots arrive on reconnect.
+        if (wasConnected)
         {
-            _connected = false;
+            _friends = EmptyFriends;
+            _hub.BroadcastChatEvent(ChatEventFrame.Friends(_friends));
+            lock (_roomsSync) _rooms = Array.Empty<ChatRoomDto>();
+            _hub.BroadcastChatEvent(ChatEventFrame.Rooms(Array.Empty<ChatRoomDto>()));
         }
     }
 

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -2441,7 +2441,7 @@ public static class ZeusEndpoints
                 return Results.BadRequest(new { error = "message text required" });
             try
             {
-                await chat.SendMessageAsync(req.Text, ctx.RequestAborted);
+                await chat.SendMessageAsync(req.Text, req.Room, ctx.RequestAborted);
                 return Results.Ok(new { ok = true });
             }
             catch (ArgumentException ex)
@@ -2459,6 +2459,76 @@ public static class ZeusEndpoints
 
         app.MapGet("/api/chat/roster", (ChatService chat) =>
             Results.Ok(new { operators = chat.GetRoster() }));
+
+        // Friend graph (consent gate for seeing another operator's frequency).
+        app.MapGet("/api/chat/friends", (ChatService chat) => Results.Ok(chat.GetFriends()));
+
+        // request / accept / deny / remove all take { callsign } and share the
+        // same 400 (empty) / 409 (not connected) error mapping as /send.
+        static async Task<IResult> FriendAction(
+            Func<string, CancellationToken, Task> action, ChatFriendRequest req, HttpContext ctx)
+        {
+            if (string.IsNullOrWhiteSpace(req.Callsign))
+                return Results.BadRequest(new { error = "callsign required" });
+            try
+            {
+                await action(req.Callsign, ctx.RequestAborted);
+                return Results.Ok(new { ok = true });
+            }
+            catch (ArgumentException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status409Conflict);
+            }
+        }
+
+        app.MapPost("/api/chat/friends/request", (ChatFriendRequest req, ChatService chat, HttpContext ctx) =>
+            FriendAction(chat.SendFriendRequestAsync, req, ctx));
+        app.MapPost("/api/chat/friends/accept", (ChatFriendRequest req, ChatService chat, HttpContext ctx) =>
+            FriendAction(chat.AcceptFriendAsync, req, ctx));
+        app.MapPost("/api/chat/friends/deny", (ChatFriendRequest req, ChatService chat, HttpContext ctx) =>
+            FriendAction(chat.DenyFriendAsync, req, ctx));
+        app.MapPost("/api/chat/friends/remove", (ChatFriendRequest req, ChatService chat, HttpContext ctx) =>
+            FriendAction(chat.RemoveFriendAsync, req, ctx));
+
+        // Rooms, DMs, history, moderation, eye toggle — all share the 400/409 map.
+        static async Task<IResult> Run(Func<Task> action)
+        {
+            try { await action(); return Results.Ok(new { ok = true }); }
+            catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
+            catch (InvalidOperationException ex)
+            {
+                return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status409Conflict);
+            }
+        }
+
+        app.MapGet("/api/chat/rooms", (ChatService chat) => Results.Ok(new { rooms = chat.GetRooms() }));
+
+        app.MapPost("/api/chat/dm", (ChatDmRequest req, ChatService chat, HttpContext ctx) =>
+            Run(() => chat.SendDmAsync(req.To, req.Text, ctx.RequestAborted)));
+
+        app.MapPost("/api/chat/history", (ChatRoomRequest req, ChatService chat, HttpContext ctx) =>
+            Run(() => chat.RequestHistoryAsync(req.Room, ctx.RequestAborted)));
+
+        app.MapPost("/api/chat/freq-visibility", (ChatFreqVisibilityRequest req, ChatService chat, HttpContext ctx) =>
+            Run(() => chat.SetFreqVisibilityAsync(req.Public, ctx.RequestAborted)));
+
+        // Admin/moderation (relay enforces that the caller is actually an admin).
+        app.MapPost("/api/chat/admin/room/create", (ChatRoomCreateRequest req, ChatService chat, HttpContext ctx) =>
+            Run(() => chat.CreateRoomAsync(req.Name, ctx.RequestAborted)));
+        app.MapPost("/api/chat/admin/room/delete", (ChatRoomRequest req, ChatService chat, HttpContext ctx) =>
+            Run(() => chat.DeleteRoomAsync(req.Room, ctx.RequestAborted)));
+        app.MapPost("/api/chat/admin/room/add", (ChatRoomMemberRequest req, ChatService chat, HttpContext ctx) =>
+            Run(() => chat.AddMemberAsync(req.Room, req.Callsign, ctx.RequestAborted)));
+        app.MapPost("/api/chat/admin/room/remove", (ChatRoomMemberRequest req, ChatService chat, HttpContext ctx) =>
+            Run(() => chat.RemoveMemberAsync(req.Room, req.Callsign, ctx.RequestAborted)));
+        app.MapPost("/api/chat/admin/ban", (ChatFriendRequest req, ChatService chat, HttpContext ctx) =>
+            Run(() => chat.BanAsync(req.Callsign, ctx.RequestAborted)));
+        app.MapPost("/api/chat/admin/unban", (ChatFriendRequest req, ChatService chat, HttpContext ctx) =>
+            Run(() => chat.UnbanAsync(req.Callsign, ctx.RequestAborted)));
 
         // Point-to-point propagation (DE → DX). Proxies the HamClock sidecar's
         // ITU-R P.533-14 engine; always returns 200 with an {available:false}

--- a/cloud/zeuschat-relay/src/chat-room.ts
+++ b/cloud/zeuschat-relay/src/chat-room.ts
@@ -4,9 +4,17 @@ import {
   type ClientToRelay,
   type RelayToClient,
   type Operator,
+  type RoomInfo,
+  type RoomKind,
+  type Msg,
   type PresenceStatus,
   MAX_MESSAGE_LEN,
-  DEFAULT_ROOM,
+  PUBLIC_ROOM,
+  PUBLIC_RETENTION_MS,
+  PRIVATE_RETENTION_MS,
+  PRUNE_INTERVAL_MS,
+  HISTORY_LIMIT,
+  dmRoomId,
 } from './protocol';
 
 /**
@@ -20,24 +28,63 @@ interface Attachment {
   freq?: number;
   mode?: string;
   status?: PresenceStatus;
+  /** Whether this operator's freq may ever be shared (eye toggle). Default true. */
+  freqPublic?: boolean;
   since: number;
   // Per-connection message rate-limit window (fixed window).
   rlWindowStart?: number;
   rlCount?: number;
 }
 
+/** Persisted metadata for a non-public room (group or DM). */
+interface RoomMeta {
+  id: string;
+  name: string;
+  kind: RoomKind;
+  createdBy?: string;
+  ts: number;
+}
+
 /** Max messages a single connection may send per RL_WINDOW_MS. */
 const MSG_RATE_LIMIT = 6;
 const RL_WINDOW_MS = 5000;
 
+function norm(callsign: string): string {
+  return callsign.trim().toUpperCase();
+}
+
 /**
- * A single chat room. Each connected Zeus backend holds one WebSocket here.
- * Uses the WebSocket Hibernation API so the DO can evict from memory while
- * sockets stay open — presence/roster is reconstructed from socket attachments.
+ * The single shared chat room DO (idFromName("lobby")) — it actually owns the
+ * whole network: the public roster, the friend consent graph, admin-created
+ * private rooms, DMs, bans, and persisted message history. Uses the WebSocket
+ * Hibernation API so it can evict from memory while sockets stay open;
+ * graph/room/ban state is persisted in DO storage and lazily rehydrated.
+ *
+ * Frequency is private: an operator's freq is only included in another
+ * operator's roster when (a) they are mutual friends AND (b) the owner has not
+ * hidden their frequency via the eye toggle (freqPublic=false).
  */
 export class ChatRoom extends DurableObject<Env> {
+  // Friend graph (callsign -> related callsigns).
+  private friends = new Map<string, Set<string>>(); // accepted, mutual
+  private incoming = new Map<string, Set<string>>(); // to -> froms awaiting decision
+  private outgoing = new Map<string, Set<string>>(); // from -> tos still pending
+  // Rooms (groups + DMs; the public lobby is implicit, never stored).
+  private rooms = new Map<string, RoomMeta>(); // roomId -> meta
+  private members = new Map<string, Set<string>>(); // roomId -> member callsigns
+  private userRooms = new Map<string, Set<string>>(); // callsign -> roomIds
+  private bans = new Set<string>();
+  private admins: Set<string>;
+  private loaded = false;
+
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
+    this.admins = new Set(
+      (env.ADMINS ?? 'N9WAR,KB2UKA')
+        .split(',')
+        .map((s) => s.trim().toUpperCase())
+        .filter(Boolean),
+    );
     // Auto-answer keepalives without waking the DO. Backends must send the
     // exact request string for this to match.
     this.ctx.setWebSocketAutoResponse(
@@ -55,10 +102,7 @@ export class ChatRoom extends DurableObject<Env> {
     const server = pair[1];
 
     this.ctx.acceptWebSocket(server);
-    // The Worker entry verifies the QRZ login and forwards the authoritative
-    // callsign here. When present it is locked in (hello cannot change it);
-    // when absent (local dev with QRZ_VERIFY=off) the callsign comes from hello.
-    const verified = (request.headers.get('X-Operator-Callsign') ?? '').trim().toUpperCase();
+    const verified = norm(request.headers.get('X-Operator-Callsign') ?? '');
     const initial: Attachment = { callsign: verified, since: Date.now() };
     server.serializeAttachment(initial);
 
@@ -80,13 +124,19 @@ export class ChatRoom extends DurableObject<Env> {
       since: Date.now(),
     };
 
+    await this.ensureLoaded();
+    const me = att.callsign;
+
     switch (msg.t) {
       case 'hello': {
-        // Prefer the verified callsign locked in at connect; fall back to the
-        // hello-provided one only when the relay didn't verify one (local dev).
-        const callsign = att.callsign || (msg.callsign ?? '').trim().toUpperCase();
+        const callsign = me || norm(msg.callsign ?? '');
         if (!callsign) {
           this.send(ws, { t: 'error', code: 'no_callsign', message: 'callsign required' });
+          return;
+        }
+        if (this.bans.has(callsign)) {
+          this.send(ws, { t: 'banned', message: 'You have been banned from ZeusChat.' });
+          try { ws.close(4403, 'banned'); } catch { /* already closing */ }
           return;
         }
         const next: Attachment = {
@@ -95,21 +145,31 @@ export class ChatRoom extends DurableObject<Env> {
           freq: msg.freq,
           mode: msg.mode,
           status: msg.status ?? 'rx',
+          freqPublic: msg.freqPublic,
           since: att.since || Date.now(),
         };
         ws.serializeAttachment(next);
-        this.send(ws, { t: 'welcome', self: toOperator(next), roster: this.roster() });
+        this.send(ws, {
+          t: 'welcome',
+          self: toOperator(next),
+          roster: this.rosterFor(callsign),
+          isAdmin: this.admins.has(callsign),
+        });
         this.broadcastRoster();
+        this.notify(callsign); // friend graph
+        this.send(ws, { t: 'rooms', rooms: this.roomsFor(callsign) });
+        await this.sendHistory(ws, callsign, PUBLIC_ROOM); // instant public scrollback
         return;
       }
 
       case 'presence': {
-        if (!att.callsign) return; // ignore until identified
+        if (!me) return;
         const next: Attachment = {
           ...att,
           freq: msg.freq ?? att.freq,
           mode: msg.mode ?? att.mode,
           status: msg.status ?? att.status,
+          freqPublic: msg.freqPublic ?? att.freqPublic,
         };
         ws.serializeAttachment(next);
         this.broadcastRoster();
@@ -117,109 +177,463 @@ export class ChatRoom extends DurableObject<Env> {
       }
 
       case 'msg': {
-        if (!att.callsign) {
+        if (!me) {
           this.send(ws, { t: 'error', code: 'no_hello', message: 'send hello first' });
+          return;
+        }
+        const room = msg.room ?? PUBLIC_ROOM;
+        if (!this.canAccess(me, room)) {
+          this.send(ws, { t: 'error', code: 'no_access', message: 'not a member of that room' });
           return;
         }
         const text = (msg.text ?? '').slice(0, MAX_MESSAGE_LEN);
         if (!text.trim()) return;
-
-        // Per-connection fixed-window message rate limit.
-        const now = Date.now();
-        const fresh = now - (att.rlWindowStart ?? 0) > RL_WINDOW_MS;
-        const count = fresh ? 0 : att.rlCount ?? 0;
-        if (count >= MSG_RATE_LIMIT) {
-          this.send(ws, { t: 'error', code: 'rate_limited', message: 'Slow down — too many messages' });
-          return;
-        }
-        ws.serializeAttachment({
-          ...att,
-          rlWindowStart: fresh ? now : att.rlWindowStart,
-          rlCount: count + 1,
-        });
-
-        this.broadcast({
-          t: 'msg',
-          id: crypto.randomUUID(),
-          from: att.callsign,
-          text,
-          ts: now,
-          room: msg.room ?? DEFAULT_ROOM,
-        });
+        if (!this.checkRate(ws, att)) return;
+        await this.postMessage(room, me, text);
         return;
       }
 
-      case 'ping': {
-        // Normally handled by auto-response; respond anyway if it reaches here.
+      case 'dm': {
+        if (!me) return;
+        const to = norm(msg.to ?? '');
+        if (!to || to === me || this.bans.has(to)) return;
+        const text = (msg.text ?? '').slice(0, MAX_MESSAGE_LEN);
+        if (!text.trim()) return;
+        if (!this.checkRate(ws, att)) return;
+        const room = await this.ensureDm(me, to);
+        await this.postMessage(room, me, text);
+        return;
+      }
+
+      case 'history': {
+        if (!me) return;
+        await this.sendHistory(ws, me, msg.room);
+        return;
+      }
+
+      case 'friend_req':
+        if (me) await this.friendRequest(me, norm(msg.to ?? ''));
+        return;
+      case 'friend_accept':
+        if (me) await this.friendAccept(me, norm(msg.from ?? ''));
+        return;
+      case 'friend_deny':
+        if (me) await this.friendDeny(me, norm(msg.from ?? ''));
+        return;
+      case 'friend_remove':
+        if (me) await this.friendRemove(me, norm(msg.callsign ?? ''));
+        return;
+
+      case 'admin_create_room':
+        if (this.isAdmin(me)) await this.createRoom(me, (msg.name ?? '').trim());
+        return;
+      case 'admin_delete_room':
+        if (this.isAdmin(me)) await this.deleteRoom(me, msg.room ?? '');
+        return;
+      case 'admin_add_member':
+        if (this.isAdmin(me)) await this.addMember(msg.room ?? '', norm(msg.callsign ?? ''));
+        return;
+      case 'admin_remove_member':
+        if (this.isAdmin(me)) await this.removeMember(msg.room ?? '', norm(msg.callsign ?? ''));
+        return;
+      case 'admin_ban':
+        if (this.isAdmin(me)) await this.banUser(me, norm(msg.callsign ?? ''));
+        return;
+      case 'admin_unban':
+        if (this.isAdmin(me)) await this.unbanUser(norm(msg.callsign ?? ''));
+        return;
+
+      case 'ping':
         this.send(ws, { t: 'pong' });
         return;
+    }
+  }
+
+  override async webSocketClose(ws: WebSocket, code: number, reason: string): Promise<void> {
+    try { ws.close(code, reason); } catch { /* already closing */ }
+    this.broadcastRoster();
+  }
+
+  override async webSocketError(): Promise<void> {
+    this.broadcastRoster();
+  }
+
+  /** Scheduled retention sweep: public room hourly, private rooms/DMs daily. */
+  override async alarm(): Promise<void> {
+    const now = Date.now();
+    const all = await this.ctx.storage.list<Msg>({ prefix: 'm:' });
+    const dead: string[] = [];
+    for (const [key, m] of all) {
+      const cutoff = m.room === PUBLIC_ROOM ? PUBLIC_RETENTION_MS : PRIVATE_RETENTION_MS;
+      if (now - m.ts > cutoff) dead.push(key);
+    }
+    if (dead.length) await this.ctx.storage.delete(dead);
+    await this.ctx.storage.setAlarm(now + PRUNE_INTERVAL_MS);
+  }
+
+  // --- persistence load ------------------------------------------------------
+
+  private async ensureLoaded(): Promise<void> {
+    if (this.loaded) return;
+    const fr = await this.ctx.storage.list<number>({ prefix: 'fr:' });
+    for (const key of fr.keys()) {
+      const [, a, b] = key.split(':');
+      if (a && b) addTo(this.friends, a, b);
+    }
+    const req = await this.ctx.storage.list<number>({ prefix: 'req:' });
+    for (const key of req.keys()) {
+      const [, from, to] = key.split(':');
+      if (from && to) {
+        addTo(this.outgoing, from, to);
+        addTo(this.incoming, to, from);
       }
     }
+    const rooms = await this.ctx.storage.list<RoomMeta>({ prefix: 'room:' });
+    for (const meta of rooms.values()) this.rooms.set(meta.id, meta);
+    const um = await this.ctx.storage.list<number>({ prefix: 'um:' });
+    for (const key of um.keys()) {
+      // um:{CALL}:{ROOMID} — ROOMID may itself contain ':' (dm:LO:HI).
+      const rest = key.slice(3);
+      const sep = rest.indexOf(':');
+      if (sep < 0) continue;
+      const call = rest.slice(0, sep);
+      const roomId = rest.slice(sep + 1);
+      addTo(this.userRooms, call, roomId);
+      addTo(this.members, roomId, call);
+    }
+    const bans = await this.ctx.storage.list<number>({ prefix: 'ban:' });
+    for (const key of bans.keys()) this.bans.add(key.slice(4));
+
+    if ((await this.ctx.storage.getAlarm()) === null) {
+      await this.ctx.storage.setAlarm(Date.now() + PRUNE_INTERVAL_MS);
+    }
+    this.loaded = true;
   }
 
-  override async webSocketClose(
-    ws: WebSocket,
-    code: number,
-    reason: string,
-    _wasClean: boolean,
-  ): Promise<void> {
-    try {
-      ws.close(code, reason);
-    } catch {
-      // already closing
+  // --- messages --------------------------------------------------------------
+
+  private async postMessage(room: string, from: string, text: string): Promise<void> {
+    const msg: Msg = { id: crypto.randomUUID(), from, text, ts: Date.now(), room };
+    const key = `m:${room}:${String(msg.ts).padStart(15, '0')}:${crypto.randomUUID().slice(0, 8)}`;
+    await this.ctx.storage.put(key, msg);
+    this.deliverToRoom(room, { t: 'msg', ...msg });
+  }
+
+  private deliverToRoom(room: string, frame: RelayToClient): void {
+    if (room === PUBLIC_ROOM) {
+      this.broadcast(frame);
+      return;
+    }
+    const members = this.members.get(room);
+    if (!members) return;
+    for (const ws of this.ctx.getWebSockets()) {
+      const att = ws.deserializeAttachment() as Attachment | null;
+      if (att?.callsign && members.has(att.callsign)) this.send(ws, frame);
+    }
+  }
+
+  private async sendHistory(ws: WebSocket, viewer: string, room: string): Promise<void> {
+    if (!this.canAccess(viewer, room)) return;
+    const all = await this.ctx.storage.list<Msg>({ prefix: `m:${room}:` });
+    const messages = [...all.values()].slice(-HISTORY_LIMIT);
+    this.send(ws, { t: 'history', room, messages });
+  }
+
+  // --- rooms / DMs -----------------------------------------------------------
+
+  private canAccess(callsign: string, room: string): boolean {
+    if (room === PUBLIC_ROOM) return true;
+    return this.members.get(room)?.has(callsign) ?? false;
+  }
+
+  private roomsFor(callsign: string): RoomInfo[] {
+    const out: RoomInfo[] = [{ id: PUBLIC_ROOM, name: 'Public', kind: 'public', members: [] }];
+    for (const roomId of this.userRooms.get(callsign) ?? []) {
+      const meta = this.rooms.get(roomId);
+      if (!meta) continue;
+      out.push({
+        id: meta.id,
+        name: meta.name,
+        kind: meta.kind,
+        members: [...(this.members.get(roomId) ?? [])].sort(),
+      });
+    }
+    return out;
+  }
+
+  private pushRooms(callsign: string): void {
+    const rooms = this.roomsFor(callsign);
+    for (const ws of this.ctx.getWebSockets()) {
+      const att = ws.deserializeAttachment() as Attachment | null;
+      if (att?.callsign === callsign) this.send(ws, { t: 'rooms', rooms });
+    }
+  }
+
+  private async ensureDm(a: string, b: string): Promise<string> {
+    const id = dmRoomId(a, b);
+    if (this.rooms.has(id)) return id;
+    const meta: RoomMeta = { id, name: '', kind: 'dm', ts: Date.now() };
+    this.rooms.set(id, meta);
+    await this.ctx.storage.put(`room:${id}`, meta);
+    const lo = norm(a);
+    const hi = norm(b);
+    for (const call of [lo, hi]) {
+      addTo(this.members, id, call);
+      addTo(this.userRooms, call, id);
+      await this.ctx.storage.put(`rm:${id}:${call}`, Date.now());
+      await this.ctx.storage.put(`um:${call}:${id}`, Date.now());
+    }
+    this.pushRooms(lo);
+    this.pushRooms(hi);
+    return id;
+  }
+
+  private async createRoom(admin: string, name: string): Promise<void> {
+    if (!name) return;
+    const id = `g${crypto.randomUUID().replace(/-/g, '').slice(0, 10)}`;
+    const meta: RoomMeta = { id, name, kind: 'group', createdBy: admin, ts: Date.now() };
+    this.rooms.set(id, meta);
+    await this.ctx.storage.put(`room:${id}`, meta);
+    await this.addMember(id, admin); // creator joins their own room
+  }
+
+  private async addMember(room: string, callsign: string): Promise<void> {
+    const meta = this.rooms.get(room);
+    if (!meta || meta.kind !== 'group' || !callsign) return;
+    if (this.members.get(room)?.has(callsign)) return;
+    addTo(this.members, room, callsign);
+    addTo(this.userRooms, callsign, room);
+    await this.ctx.storage.put(`rm:${room}:${callsign}`, Date.now());
+    await this.ctx.storage.put(`um:${callsign}:${room}`, Date.now());
+    this.pushRooms(callsign);
+  }
+
+  private async removeMember(room: string, callsign: string): Promise<void> {
+    const meta = this.rooms.get(room);
+    if (!meta || meta.kind !== 'group' || !callsign) return;
+    if (!this.members.get(room)?.has(callsign)) return;
+    removeFrom(this.members, room, callsign);
+    removeFrom(this.userRooms, callsign, room);
+    await this.ctx.storage.delete(`rm:${room}:${callsign}`);
+    await this.ctx.storage.delete(`um:${callsign}:${room}`);
+    this.pushRooms(callsign); // tab disappears for them
+  }
+
+  private async deleteRoom(admin: string, room: string): Promise<void> {
+    const meta = this.rooms.get(room);
+    if (!meta || meta.kind !== 'group') return;
+    const exMembers = [...(this.members.get(room) ?? [])];
+    for (const call of exMembers) {
+      removeFrom(this.userRooms, call, room);
+      await this.ctx.storage.delete(`rm:${room}:${call}`);
+      await this.ctx.storage.delete(`um:${call}:${room}`);
+    }
+    this.members.delete(room);
+    this.rooms.delete(room);
+    await this.ctx.storage.delete(`room:${room}`);
+    const msgKeys = [...(await this.ctx.storage.list({ prefix: `m:${room}:` })).keys()];
+    if (msgKeys.length) await this.ctx.storage.delete(msgKeys);
+    for (const call of exMembers) this.pushRooms(call);
+  }
+
+  // --- bans ------------------------------------------------------------------
+
+  private isAdmin(callsign: string): boolean {
+    return !!callsign && this.admins.has(callsign);
+  }
+
+  private async banUser(admin: string, callsign: string): Promise<void> {
+    if (!callsign || this.admins.has(callsign)) return; // never ban an admin
+    this.bans.add(callsign);
+    await this.ctx.storage.put(`ban:${callsign}`, Date.now());
+    // Kick any live sockets for the banned operator.
+    for (const ws of this.ctx.getWebSockets()) {
+      const att = ws.deserializeAttachment() as Attachment | null;
+      if (att?.callsign === callsign) {
+        this.send(ws, { t: 'banned', message: `You were banned by ${admin}.` });
+        try { ws.close(4403, 'banned'); } catch { /* already closing */ }
+      }
     }
     this.broadcastRoster();
   }
 
-  override async webSocketError(_ws: WebSocket, _error: unknown): Promise<void> {
+  private async unbanUser(callsign: string): Promise<void> {
+    if (!callsign || !this.bans.has(callsign)) return;
+    this.bans.delete(callsign);
+    await this.ctx.storage.delete(`ban:${callsign}`);
+  }
+
+  // --- friendship graph ------------------------------------------------------
+
+  private async friendRequest(from: string, to: string): Promise<void> {
+    if (!to || to === from) return;
+    if (this.friends.get(from)?.has(to)) {
+      this.notify(from);
+      return;
+    }
+    if (this.incoming.get(from)?.has(to)) {
+      await this.friendAccept(from, to); // mutual → auto-accept
+      return;
+    }
+    if (this.outgoing.get(from)?.has(to)) {
+      this.notify(from);
+      return;
+    }
+    await this.ctx.storage.put(`req:${from}:${to}`, Date.now());
+    addTo(this.outgoing, from, to);
+    addTo(this.incoming, to, from);
+    this.notify(from);
+    this.notify(to);
+  }
+
+  private async friendAccept(by: string, from: string): Promise<void> {
+    if (!from) return;
+    if (!this.incoming.get(by)?.has(from)) {
+      if (this.friends.get(by)?.has(from)) this.notify(by);
+      return;
+    }
+    await this.ctx.storage.delete(`req:${from}:${by}`);
+    removeFrom(this.incoming, by, from);
+    removeFrom(this.outgoing, from, by);
+    await this.ctx.storage.put(`fr:${by}:${from}`, Date.now());
+    await this.ctx.storage.put(`fr:${from}:${by}`, Date.now());
+    addTo(this.friends, by, from);
+    addTo(this.friends, from, by);
+    this.notify(by);
+    this.notify(from);
     this.broadcastRoster();
+  }
+
+  private async friendDeny(by: string, from: string): Promise<void> {
+    if (!from || !this.incoming.get(by)?.has(from)) return;
+    await this.ctx.storage.delete(`req:${from}:${by}`);
+    removeFrom(this.incoming, by, from);
+    removeFrom(this.outgoing, from, by);
+    this.notify(by);
+    this.notify(from);
+  }
+
+  private async friendRemove(by: string, other: string): Promise<void> {
+    if (!other) return;
+    let changed = false;
+    let unfriended = false;
+    if (this.friends.get(by)?.has(other)) {
+      await this.ctx.storage.delete(`fr:${by}:${other}`);
+      await this.ctx.storage.delete(`fr:${other}:${by}`);
+      removeFrom(this.friends, by, other);
+      removeFrom(this.friends, other, by);
+      changed = true;
+      unfriended = true;
+    }
+    if (this.outgoing.get(by)?.has(other)) {
+      await this.ctx.storage.delete(`req:${by}:${other}`);
+      removeFrom(this.outgoing, by, other);
+      removeFrom(this.incoming, other, by);
+      changed = true;
+    }
+    if (this.incoming.get(by)?.has(other)) {
+      await this.ctx.storage.delete(`req:${other}:${by}`);
+      removeFrom(this.incoming, by, other);
+      removeFrom(this.outgoing, other, by);
+      changed = true;
+    }
+    if (!changed) return;
+    this.notify(by);
+    this.notify(other);
+    if (unfriended) this.broadcastRoster();
+  }
+
+  private friendsSnapshot(callsign: string): RelayToClient {
+    return {
+      t: 'friends',
+      accepted: [...(this.friends.get(callsign) ?? [])].sort(),
+      incoming: [...(this.incoming.get(callsign) ?? [])].sort(),
+      outgoing: [...(this.outgoing.get(callsign) ?? [])].sort(),
+    };
+  }
+
+  private notify(callsign: string): void {
+    if (!callsign) return;
+    const snap = this.friendsSnapshot(callsign);
+    for (const ws of this.ctx.getWebSockets()) {
+      const att = ws.deserializeAttachment() as Attachment | null;
+      if (att?.callsign === callsign) this.send(ws, snap);
+    }
   }
 
   // --- helpers ---------------------------------------------------------------
 
-  private send(ws: WebSocket, msg: RelayToClient): void {
-    try {
-      ws.send(JSON.stringify(msg));
-    } catch {
-      // socket gone
+  private checkRate(ws: WebSocket, att: Attachment): boolean {
+    const now = Date.now();
+    const fresh = now - (att.rlWindowStart ?? 0) > RL_WINDOW_MS;
+    const count = fresh ? 0 : att.rlCount ?? 0;
+    if (count >= MSG_RATE_LIMIT) {
+      this.send(ws, { t: 'error', code: 'rate_limited', message: 'Slow down — too many messages' });
+      return false;
     }
+    ws.serializeAttachment({ ...att, rlWindowStart: fresh ? now : att.rlWindowStart, rlCount: count + 1 });
+    return true;
+  }
+
+  private send(ws: WebSocket, msg: RelayToClient): void {
+    try { ws.send(JSON.stringify(msg)); } catch { /* socket gone */ }
   }
 
   private broadcast(msg: RelayToClient): void {
     const payload = JSON.stringify(msg);
     for (const ws of this.ctx.getWebSockets()) {
-      try {
-        ws.send(payload);
-      } catch {
-        // skip dead sockets
-      }
+      try { ws.send(payload); } catch { /* skip dead sockets */ }
     }
   }
 
-  private roster(): Operator[] {
+  /** Public roster as seen by `viewer`: freq only for friends whose eye is open. */
+  private rosterFor(viewer: string): Operator[] {
+    const fset = this.friends.get(viewer);
     const seen = new Set<string>();
     const out: Operator[] = [];
     for (const ws of this.ctx.getWebSockets()) {
       const att = ws.deserializeAttachment() as Attachment | null;
       if (!att || !att.callsign) continue;
-      if (seen.has(att.callsign)) continue; // de-dup multi-tab/same call
+      if (seen.has(att.callsign)) continue;
       seen.add(att.callsign);
-      out.push(toOperator(att));
+      const canSeeFreq =
+        att.callsign === viewer || (att.freqPublic !== false && (fset?.has(att.callsign) ?? false));
+      out.push(toOperator(att, canSeeFreq));
     }
     out.sort((a, b) => a.callsign.localeCompare(b.callsign));
     return out;
   }
 
   private broadcastRoster(): void {
-    this.broadcast({ t: 'roster', roster: this.roster() });
+    for (const ws of this.ctx.getWebSockets()) {
+      const att = ws.deserializeAttachment() as Attachment | null;
+      if (!att) continue;
+      this.send(ws, { t: 'roster', roster: this.rosterFor(att.callsign) });
+    }
   }
 }
 
-function toOperator(a: Attachment): Operator {
+function addTo(map: Map<string, Set<string>>, key: string, value: string): void {
+  let set = map.get(key);
+  if (!set) {
+    set = new Set();
+    map.set(key, set);
+  }
+  set.add(value);
+}
+
+function removeFrom(map: Map<string, Set<string>>, key: string, value: string): void {
+  const set = map.get(key);
+  if (!set) return;
+  set.delete(value);
+  if (set.size === 0) map.delete(key);
+}
+
+function toOperator(a: Attachment, includeFreq = true): Operator {
   return {
     callsign: a.callsign,
     grid: a.grid,
-    freq: a.freq,
+    freq: includeFreq ? a.freq : undefined,
     mode: a.mode,
     status: a.status,
     since: a.since,

--- a/cloud/zeuschat-relay/src/protocol.ts
+++ b/cloud/zeuschat-relay/src/protocol.ts
@@ -18,13 +18,19 @@
 /** Operator presence/activity state. */
 export type PresenceStatus = 'rx' | 'tx' | 'away';
 
+/** The kind of a channel. "public" is the single all-operators lobby. */
+export type RoomKind = 'public' | 'group' | 'dm';
+
+/** The well-known id of the public (all-operators) room. */
+export const PUBLIC_ROOM = 'lobby';
+
 /** A connected operator as seen by everyone in the room. */
 export interface Operator {
   /** Uppercased callsign (QRZ-verified on the backend that asserted it). */
   callsign: string;
   /** Maidenhead grid square, if known. */
   grid?: string;
-  /** Current VFO frequency in Hz. */
+  /** Current VFO frequency in Hz. Omitted unless the viewer may see it. */
   freq?: number;
   /** Current mode (e.g. "USB", "CW"). */
   mode?: string;
@@ -32,6 +38,28 @@ export interface Operator {
   status?: PresenceStatus;
   /** Epoch ms the operator connected. */
   since: number;
+}
+
+/** A chat channel the operator can see: the public lobby, a group, or a DM. */
+export interface RoomInfo {
+  /** Stable id: "lobby", a "g…" group id, or "dm:LO:HI". */
+  id: string;
+  /** Display name (group name; for DMs the relay sends the member list). */
+  name: string;
+  kind: RoomKind;
+  /** Member callsigns (empty for the public room). For a DM, the two parties. */
+  members: string[];
+}
+
+/** A stored/relayed chat message. */
+export interface Msg {
+  id: string;
+  from: string;
+  text: string;
+  /** Epoch ms. */
+  ts: number;
+  /** Room id this message belongs to. */
+  room: string;
 }
 
 /** Messages sent by a backend chat node TO the relay. */
@@ -44,13 +72,32 @@ export type ClientToRelay =
       freq?: number;
       mode?: string;
       status?: PresenceStatus;
+      /** Whether this operator's frequency may be shared at all (eye toggle).
+       *  false hides it from everyone, friends included. Default true. */
+      freqPublic?: boolean;
       /** Client identifier, e.g. "zeus/0.9.0". Informational. */
       client?: string;
     }
-  // Live presence update (frequency / mode / status changed).
-  | { t: 'presence'; freq?: number; mode?: string; status?: PresenceStatus }
-  // Outgoing chat message.
+  // Live presence update (frequency / mode / status / freq-visibility changed).
+  | { t: 'presence'; freq?: number; mode?: string; status?: PresenceStatus; freqPublic?: boolean }
+  // Outgoing chat message to a room (defaults to the public lobby).
   | { t: 'msg'; text: string; room?: string }
+  // Send a direct message to another operator (creates the DM room on demand).
+  | { t: 'dm'; to: string; text: string }
+  // Request recent history for a room the operator can see.
+  | { t: 'history'; room: string }
+  // --- friends (consent graph) ---------------------------------------------
+  | { t: 'friend_req'; to: string }
+  | { t: 'friend_accept'; from: string }
+  | { t: 'friend_deny'; from: string }
+  | { t: 'friend_remove'; callsign: string }
+  // --- admin / moderation (ignored unless the sender is an admin) -----------
+  | { t: 'admin_create_room'; name: string }
+  | { t: 'admin_delete_room'; room: string }
+  | { t: 'admin_add_member'; room: string; callsign: string }
+  | { t: 'admin_remove_member'; room: string; callsign: string }
+  | { t: 'admin_ban'; callsign: string }
+  | { t: 'admin_unban'; callsign: string }
   // Keepalive. The relay auto-responds with {t:"pong"} without waking (see
   // setWebSocketAutoResponse in chat-room.ts) — send this EXACT string:
   // '{"t":"ping"}'.
@@ -58,12 +105,22 @@ export type ClientToRelay =
 
 /** Messages sent by the relay TO a backend chat node. */
 export type RelayToClient =
-  // Acknowledges hello: echoes the caller's resolved operator + current roster.
-  | { t: 'welcome'; self: Operator; roster: Operator[] }
-  // Roster changed (someone joined/left or updated presence).
+  // Acknowledges hello: the caller's resolved operator, the public roster, and
+  // whether the caller is a moderator.
+  | { t: 'welcome'; self: Operator; roster: Operator[]; isAdmin: boolean }
+  // Public-room roster changed (someone joined/left or updated presence).
   | { t: 'roster'; roster: Operator[] }
-  // A chat message (including the sender's own, for echo/ordering).
+  // The set of rooms this operator can see (public + their groups + their DMs).
+  | { t: 'rooms'; rooms: RoomInfo[] }
+  // Recent history for a room, in response to a history request (or pushed on
+  // join). Ordered oldest→newest.
+  | { t: 'history'; room: string; messages: Msg[] }
+  // A chat message in a room the operator is a member of (including own echo).
   | { t: 'msg'; id: string; from: string; text: string; ts: number; room: string }
+  // The operator's friend graph (see ChatFriendsDto on the C# side).
+  | { t: 'friends'; accepted: string[]; incoming: string[]; outgoing: string[] }
+  // The operator has been banned/kicked; the socket is about to close.
+  | { t: 'banned'; message: string }
   // Protocol/validation error. Non-fatal unless the socket is also closed.
   | { t: 'error'; code: string; message: string }
   // Keepalive response.
@@ -72,5 +129,21 @@ export type RelayToClient =
 /** Max accepted chat message length (characters); longer is truncated. */
 export const MAX_MESSAGE_LEN = 2000;
 
-/** The single room used in P0. Band-derived rooms arrive in P3. */
-export const DEFAULT_ROOM = 'lobby';
+/** The single room used in P0. Kept as an alias of PUBLIC_ROOM. */
+export const DEFAULT_ROOM = PUBLIC_ROOM;
+
+/** Retention windows (ms): the public room prunes hourly, private rooms/DMs daily. */
+export const PUBLIC_RETENTION_MS = 60 * 60 * 1000;
+export const PRIVATE_RETENTION_MS = 24 * 60 * 60 * 1000;
+
+/** How often the prune alarm fires. */
+export const PRUNE_INTERVAL_MS = 60 * 60 * 1000;
+
+/** Max messages returned in a history reply. */
+export const HISTORY_LIMIT = 100;
+
+/** Build the canonical DM room id for two callsigns (order-independent). */
+export function dmRoomId(a: string, b: string): string {
+  const [lo, hi] = [a.toUpperCase(), b.toUpperCase()].sort();
+  return `dm:${lo}:${hi}`;
+}

--- a/cloud/zeuschat-relay/src/types.ts
+++ b/cloud/zeuschat-relay/src/types.ts
@@ -23,4 +23,11 @@ export interface Env {
    * WebSocket clients cannot set request headers.
    */
   QRZ_VERIFY?: string;
+
+  /**
+   * Comma-separated callsigns with moderator powers (create/delete private
+   * rooms, add/remove members, ban/unban). Defaults to "N9WAR,KB2UKA" when
+   * unset. Case-insensitive.
+   */
+  ADMINS?: string;
 }

--- a/tests/Zeus.Server.Tests/ChatServiceTests.cs
+++ b/tests/Zeus.Server.Tests/ChatServiceTests.cs
@@ -159,6 +159,18 @@ public class ChatServiceTests : IDisposable
         Assert.Null(ChatService.ParseRoster(doc.RootElement, "roster"));
     }
 
+    [Fact]
+    public void ParseFriends_ReadsArrays_AndDefaultsMissingToEmpty()
+    {
+        using var doc = JsonDocument.Parse(
+            """{"t":"friends","accepted":["N9WAR","EI6LF"],"incoming":["KB2UKA"]}""");
+        var f = ChatService.ParseFriends(doc.RootElement);
+
+        Assert.Equal(new[] { "N9WAR", "EI6LF" }, f.Accepted);
+        Assert.Equal(new[] { "KB2UKA" }, f.Incoming);
+        Assert.Empty(f.Outgoing); // missing array → empty, not null
+    }
+
     // ── ChatEvent (0x35) envelope serialization (outbound, frontend wire) ───
 
     [Fact]
@@ -215,13 +227,29 @@ public class ChatServiceTests : IDisposable
         }
 
         var msg = new ChatMessage("id1", "EI6LF", "hi", 1700000000000, "lobby");
-        var historyFrame = ChatEventFrame.History(new[] { msg });
+        var historyFrame = ChatEventFrame.History("lobby", new[] { msg });
         using (var doc = JsonDocument.Parse(ChatEventFrame.Payload(historyFrame).ToArray()))
         {
             var root = doc.RootElement;
             Assert.Equal("history", root.GetProperty("kind").GetString());
             Assert.Equal("id1", root.GetProperty("messages")[0].GetProperty("id").GetString());
         }
+    }
+
+    [Fact]
+    public void ChatEvent_FriendsEnvelope_UsesCamelCaseArrays()
+    {
+        var friends = new ChatFriendsDto(
+            Accepted: new[] { "N9WAR" }, Incoming: new[] { "EI6LF" }, Outgoing: Array.Empty<string>());
+        var frame = ChatEventFrame.Friends(friends);
+
+        using var doc = JsonDocument.Parse(ChatEventFrame.Payload(frame).ToArray());
+        var root = doc.RootElement;
+        Assert.Equal("friends", root.GetProperty("kind").GetString());
+        var f = root.GetProperty("friends");
+        Assert.Equal("N9WAR", f.GetProperty("accepted")[0].GetString());
+        Assert.Equal("EI6LF", f.GetProperty("incoming")[0].GetString());
+        Assert.Empty(f.GetProperty("outgoing").EnumerateArray());
     }
 
     [Fact]
@@ -244,7 +272,7 @@ public class ChatServiceTests : IDisposable
 
         // Send must fail with 409-mapped exception when not connected.
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => chat.SendMessageAsync("hello", CancellationToken.None));
+            () => chat.SendMessageAsync("hello", null, CancellationToken.None));
     }
 
     [Fact]
@@ -261,7 +289,7 @@ public class ChatServiceTests : IDisposable
         Assert.True(store.GetEnabled());
 
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => chat.SendMessageAsync("hi", CancellationToken.None));
+            () => chat.SendMessageAsync("hi", null, CancellationToken.None));
 
         chat.SetEnabled(false);
         Assert.False(store.GetEnabled());
@@ -272,7 +300,29 @@ public class ChatServiceTests : IDisposable
     {
         using var chat = BuildChat();
         await Assert.ThrowsAsync<ArgumentException>(
-            () => chat.SendMessageAsync("   ", CancellationToken.None));
+            () => chat.SendMessageAsync("   ", null, CancellationToken.None));
+    }
+
+    [Fact]
+    public void Friends_DefaultEmpty_WhenNeverConnected()
+    {
+        using var chat = BuildChat();
+        var f = chat.GetFriends();
+        Assert.Empty(f.Accepted);
+        Assert.Empty(f.Incoming);
+        Assert.Empty(f.Outgoing);
+    }
+
+    [Fact]
+    public async Task FriendRequest_WhenNotConnected_Throws()
+    {
+        using var chat = BuildChat();
+        // Not connected → 409-mapped exception, like SendMessageAsync.
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => chat.SendFriendRequestAsync("EI6LF", CancellationToken.None));
+        // Empty callsign → 400-mapped exception.
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => chat.AcceptFriendAsync("  ", CancellationToken.None));
     }
 
     // ── helpers ────────────────────────────────────────────────────────────

--- a/zeus-web/src/api/chat.ts
+++ b/zeus-web/src/api/chat.ts
@@ -43,6 +43,28 @@ export type ChatStatus = {
   callsign: string | null;
   relayUrl: string | null;
   error: string | null;
+  /** Whether this operator is a relay moderator (can create rooms / ban). */
+  isAdmin: boolean;
+  /** Whether this operator's frequency is shared at all (eye toggle). */
+  freqPublic: boolean;
+};
+
+export type ChatRoomKind = 'public' | 'group' | 'dm';
+
+export type ChatRoom = {
+  id: string;
+  name: string;
+  kind: ChatRoomKind;
+  members: string[];
+};
+
+export type ChatFriends = {
+  /** Mutual friends — their frequency is visible to you. */
+  accepted: string[];
+  /** Requests awaiting your accept/deny. */
+  incoming: string[];
+  /** Requests you've sent that are still pending. */
+  outgoing: string[];
 };
 
 function toStr(v: unknown): string | null {
@@ -65,6 +87,19 @@ export function normalizeStatus(raw: unknown): ChatStatus {
     callsign: toStr(r.callsign),
     relayUrl: toStr(r.relayUrl),
     error: toStr(r.error),
+    isAdmin: Boolean(r.isAdmin),
+    freqPublic: r.freqPublic !== false, // default visible
+  };
+}
+
+export function normalizeRoom(raw: unknown): ChatRoom {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  const kind = r.kind === 'public' || r.kind === 'dm' ? r.kind : 'group';
+  return {
+    id: typeof r.id === 'string' ? r.id : '',
+    name: typeof r.name === 'string' ? r.name : '',
+    kind,
+    members: toCallList(r.members),
   };
 }
 
@@ -77,6 +112,21 @@ export function normalizeOperator(raw: unknown): ChatOperator {
     mode: toStr(r.mode),
     status: toStatus(r.status),
     since: toNum(r.since) ?? 0,
+  };
+}
+
+function toCallList(v: unknown): string[] {
+  return Array.isArray(v)
+    ? v.filter((c): c is string => typeof c === 'string' && c.length > 0).map((c) => c.toUpperCase())
+    : [];
+}
+
+export function normalizeFriends(raw: unknown): ChatFriends {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  return {
+    accepted: toCallList(r.accepted),
+    incoming: toCallList(r.incoming),
+    outgoing: toCallList(r.outgoing),
   };
 }
 
@@ -134,13 +184,13 @@ export function chatSetEnabled(enabled: boolean, signal?: AbortSignal): Promise<
   );
 }
 
-export function chatSend(text: string, signal?: AbortSignal): Promise<{ ok: boolean }> {
+export function chatSend(text: string, room?: string, signal?: AbortSignal): Promise<{ ok: boolean }> {
   return jsonFetch(
     '/api/chat/send',
     {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ text }),
+      body: JSON.stringify(room ? { text, room } : { text }),
       signal,
     },
     (raw) => ({ ok: Boolean((raw as { ok?: unknown } | null)?.ok) }),
@@ -164,3 +214,73 @@ export function chatRoster(signal?: AbortSignal): Promise<ChatOperator[]> {
     return Array.isArray(arr) ? arr.map(normalizeOperator) : [];
   });
 }
+
+export function chatFriends(signal?: AbortSignal): Promise<ChatFriends> {
+  return jsonFetch('/api/chat/friends', { signal }, normalizeFriends);
+}
+
+/** request / accept / deny / remove — all POST { callsign } and return { ok }. */
+function friendAction(
+  path: 'request' | 'accept' | 'deny' | 'remove',
+  callsign: string,
+  signal?: AbortSignal,
+): Promise<{ ok: boolean }> {
+  return jsonFetch(
+    `/api/chat/friends/${path}`,
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ callsign }),
+      signal,
+    },
+    (raw) => ({ ok: Boolean((raw as { ok?: unknown } | null)?.ok) }),
+  );
+}
+
+export const chatFriendRequest = (callsign: string, signal?: AbortSignal) =>
+  friendAction('request', callsign, signal);
+export const chatFriendAccept = (callsign: string, signal?: AbortSignal) =>
+  friendAction('accept', callsign, signal);
+export const chatFriendDeny = (callsign: string, signal?: AbortSignal) =>
+  friendAction('deny', callsign, signal);
+export const chatFriendRemove = (callsign: string, signal?: AbortSignal) =>
+  friendAction('remove', callsign, signal);
+
+// ── Rooms / DMs / history / moderation / eye toggle ───────────────────────
+
+function postOk(path: string, body: unknown, signal?: AbortSignal): Promise<{ ok: boolean }> {
+  return jsonFetch(
+    path,
+    { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body), signal },
+    (raw) => ({ ok: Boolean((raw as { ok?: unknown } | null)?.ok) }),
+  );
+}
+
+export function chatRooms(signal?: AbortSignal): Promise<ChatRoom[]> {
+  return jsonFetch('/api/chat/rooms', { signal }, (raw) => {
+    const arr = (raw as { rooms?: unknown } | null)?.rooms;
+    return Array.isArray(arr) ? arr.map(normalizeRoom) : [];
+  });
+}
+
+export const chatDm = (to: string, text: string, signal?: AbortSignal) =>
+  postOk('/api/chat/dm', { to, text }, signal);
+
+export const chatRequestHistory = (room: string, signal?: AbortSignal) =>
+  postOk('/api/chat/history', { room }, signal);
+
+export const chatSetFreqVisibility = (isPublic: boolean, signal?: AbortSignal) =>
+  postOk('/api/chat/freq-visibility', { public: isPublic }, signal);
+
+export const chatCreateRoom = (name: string, signal?: AbortSignal) =>
+  postOk('/api/chat/admin/room/create', { name }, signal);
+export const chatDeleteRoom = (room: string, signal?: AbortSignal) =>
+  postOk('/api/chat/admin/room/delete', { room }, signal);
+export const chatAddMember = (room: string, callsign: string, signal?: AbortSignal) =>
+  postOk('/api/chat/admin/room/add', { room, callsign }, signal);
+export const chatRemoveMember = (room: string, callsign: string, signal?: AbortSignal) =>
+  postOk('/api/chat/admin/room/remove', { room, callsign }, signal);
+export const chatBan = (callsign: string, signal?: AbortSignal) =>
+  postOk('/api/chat/admin/ban', { callsign }, signal);
+export const chatUnban = (callsign: string, signal?: AbortSignal) =>
+  postOk('/api/chat/admin/unban', { callsign }, signal);

--- a/zeus-web/src/layout/panels/ChatPanel.tsx
+++ b/zeus-web/src/layout/panels/ChatPanel.tsx
@@ -10,16 +10,20 @@
 // option) any later version. See the LICENSE file at the root of this
 // repository for the full text, or https://www.gnu.org/licenses/.
 //
-// ChatPanel — operator-to-operator chat tile. A roster of online operators
-// (live frequency + mode + rx/tx/away status), a scrollable message thread,
-// and a send box. Hydrated on mount via chat-store REST calls and kept live
-// by the 0x35 push frames decoded in realtime/ws-client.ts. Clicking any
-// callsign (roster or message) opens that operator's QRZ profile in an
-// overlay, reusing the QrzCard component and the qrz-store lookup cache so we
-// don't re-implement the profile card or burn QRZ quota.
+// ChatPanel — operator-to-operator chat tile. Premium tabbed UI: left roster
+// sidebar (public operators, friends, friend requests), tab bar across the top
+// (Public → Groups → DMs), message thread, and auto-growing composer. Non-public
+// rooms get a warm golden glow as the signature premium cue. Hydrated on mount
+// via chat-store REST calls and kept live by 0x35 push frames.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useChatStore, type ChatMessage, type ChatOperator } from '../../state/chat-store';
+import {
+  useChatStore,
+  dmOther,
+  PUBLIC_ROOM,
+  type ChatMessage,
+  type ChatOperator,
+} from '../../state/chat-store';
 import { useQrzStore } from '../../state/qrz-store';
 import { QrzCard } from '../../components/design/QrzCard';
 import { qrzStationToContact } from '../../components/design/qrz-contact';
@@ -27,21 +31,21 @@ import type { Contact } from '../../components/design/data';
 import type { QrzStation } from '../../api/qrz';
 
 const MAX_MESSAGE_CHARS = 2000;
-const CHAR_WARN_THRESHOLD = 1800;
 
-/** Hz → MHz with the operator-friendly "14.074.00" grouping. */
+// ---------------------------------------------------------------------------
+// Utility helpers
+// ---------------------------------------------------------------------------
+
 function fmtFreqMhz(hz: number | null | undefined): string {
   if (typeof hz !== 'number' || !Number.isFinite(hz) || hz <= 0) return '—';
   const mhz = hz / 1_000_000;
-  // e.g. 14074000 → "14.074.00": MHz . kHz(3) . hHz(2)
   const whole = Math.floor(mhz);
-  const frac = Math.round((mhz - whole) * 100_000); // 5 fractional digits
+  const frac = Math.round((mhz - whole) * 100_000);
   const khz = String(Math.floor(frac / 100)).padStart(3, '0');
   const hhz = String(frac % 100).padStart(2, '0');
   return `${whole}.${khz}.${hhz}`;
 }
 
-/** Ham-band edges (Hz) for grouping the roster. Order = display order. */
 const BANDS: ReadonlyArray<{ label: string; lo: number; hi: number }> = [
   { label: '2200m', lo: 135_700, hi: 137_800 },
   { label: '630m', lo: 472_000, hi: 479_000 },
@@ -64,26 +68,22 @@ const BANDS: ReadonlyArray<{ label: string; lo: number; hi: number }> = [
   { label: '23cm', lo: 1_240_000_000, hi: 1_300_000_000 },
 ];
 
-/** Band label for a frequency, or "Other" when off-band/unknown. */
 function bandForHz(hz: number | null | undefined): string {
   if (typeof hz !== 'number' || !Number.isFinite(hz) || hz <= 0) return 'Other';
   for (const b of BANDS) if (hz >= b.lo && hz <= b.hi) return b.label;
   return 'Other';
 }
 
-/** Sort key for band labels (display order; "Other" last). */
 function bandOrder(label: string): number {
   const i = BANDS.findIndex((b) => b.label === label);
   return i < 0 ? BANDS.length : i;
 }
 
-/** Clock time (HH:MM) from epoch ms, in the operator's local zone. */
 function fmtClock(ts: number): string {
   if (!Number.isFinite(ts) || ts <= 0) return '';
   return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
 }
 
-/** Short relative age, e.g. "now", "3m", "2h", or a date for older stamps. */
 function fmtRelative(ts: number): string {
   if (!Number.isFinite(ts) || ts <= 0) return '';
   const deltaMs = Date.now() - ts;
@@ -104,6 +104,10 @@ const STATUS_META: Record<string, { color: string; label: string }> = {
   away: { color: 'var(--fg-3)', label: 'Away' },
 };
 
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
 function StatusDot({ status }: { status: ChatOperator['status'] }) {
   const meta = (status && STATUS_META[status]) || { color: 'var(--fg-4)', label: 'Unknown' };
   return (
@@ -112,18 +116,17 @@ function StatusDot({ status }: { status: ChatOperator['status'] }) {
       aria-label={meta.label}
       style={{
         display: 'inline-block',
-        width: 8,
-        height: 8,
+        width: 7,
+        height: 7,
         borderRadius: '50%',
         background: meta.color,
-        boxShadow: status === 'tx' ? '0 0 6px var(--tx)' : 'none',
+        boxShadow: status === 'tx' ? '0 0 5px var(--tx)' : 'none',
         flexShrink: 0,
       }}
     />
   );
 }
 
-/** A callsign that opens the QRZ profile overlay when clicked. */
 function CallsignButton({
   callsign,
   onOpen,
@@ -148,7 +151,7 @@ function CallsignButton({
         cursor: 'pointer',
         font: 'inherit',
         fontWeight: prominent ? 700 : 600,
-        fontSize: prominent ? 13 : 12,
+        fontSize: prominent ? 12.5 : 12,
         letterSpacing: '0.04em',
         color: own ? 'var(--accent-bright)' : 'var(--fg-0)',
         textAlign: 'left',
@@ -161,54 +164,233 @@ function CallsignButton({
   );
 }
 
+function GroupHeader({ label, count, accent }: { label: string; count: number; accent: string }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'baseline',
+        justifyContent: 'space-between',
+        padding: '6px 8px 2px',
+        fontSize: 9,
+        fontWeight: 700,
+        letterSpacing: '0.12em',
+        textTransform: 'uppercase',
+        color: accent,
+      }}
+    >
+      <span>{label}</span>
+      <span style={{ color: 'var(--fg-4)', fontWeight: 600 }}>{count}</span>
+    </div>
+  );
+}
+
+type FriendRelation = 'friend' | 'requested' | 'none';
+
+const STAR_META: Record<FriendRelation, { glyph: string; color: string; title: string }> = {
+  friend: { glyph: '★', color: 'var(--power)', title: 'Friends — click to remove' },
+  requested: { glyph: '☆', color: 'var(--accent-bright)', title: 'Request pending — click to cancel' },
+  none: { glyph: '☆', color: 'var(--fg-4)', title: 'Add friend (send request)' },
+};
+
 function RosterRow({
   op,
   onOpen,
+  relation,
+  onStar,
+  onDm,
+  isAdmin,
+  onBan,
 }: {
   op: ChatOperator;
   onOpen: (callsign: string) => void;
+  relation: FriendRelation;
+  onStar: (callsign: string) => void;
+  onDm: (callsign: string) => void;
+  isAdmin: boolean;
+  onBan: (callsign: string) => void;
 }) {
+  const [hovered, setHovered] = useState(false);
+  const freq = fmtFreqMhz(op.freqHz);
   const tip = [
     STATUS_META[op.status ?? '']?.label,
-    op.grid ? `Grid ${op.grid}` : null,
+    freq !== '—' ? `${freq} MHz` : null,
     op.mode ?? null,
+    op.grid ? `Grid ${op.grid}` : null,
   ]
     .filter(Boolean)
     .join(' · ');
+  const star = STAR_META[relation];
+  const starVisible = relation !== 'none' || hovered;
+
   return (
     <div
       title={tip || undefined}
       style={{
         display: 'flex',
         alignItems: 'center',
-        gap: 8,
-        padding: '5px 8px',
+        gap: 6,
+        padding: '4px 8px',
         borderRadius: 'var(--r-sm)',
+        background: hovered ? 'var(--bg-3)' : 'transparent',
         transition: 'background var(--dur-fast) var(--ease-out)',
       }}
-      onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--bg-3)')}
-      onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
     >
       <StatusDot status={op.status} />
-      <div style={{ display: 'flex', flexDirection: 'column', minWidth: 0, flex: 1 }}>
+      <div style={{ minWidth: 0, flex: 1 }}>
         <CallsignButton callsign={op.callsign} onOpen={onOpen} prominent />
-        <div
-          className="mono"
+      </div>
+      {/* DM button — appears on hover */}
+      {hovered && (
+        <button
+          type="button"
+          onClick={() => onDm(op.callsign)}
+          title={`Message ${op.callsign}`}
+          aria-label={`Start DM with ${op.callsign}`}
           style={{
-            display: 'flex',
-            gap: 6,
-            alignItems: 'baseline',
-            fontSize: 10.5,
-            color: 'var(--fg-2)',
-            whiteSpace: 'nowrap',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
+            flexShrink: 0,
+            background: 'none',
+            border: 'none',
+            padding: '0 2px',
+            cursor: 'pointer',
+            fontSize: 11,
+            lineHeight: 1,
+            color: 'var(--accent-bright)',
+            opacity: 0.8,
           }}
         >
-          <span style={{ color: 'var(--power)' }}>{fmtFreqMhz(op.freqHz)}</span>
-          {op.mode ? <span style={{ color: 'var(--fg-2)' }}>{op.mode}</span> : null}
+          {/* Inline chat bubble SVG */}
+          <svg
+            width="13"
+            height="13"
+            viewBox="0 0 16 16"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+          >
+            <path
+              d="M2 2h12a1 1 0 0 1 1 1v8a1 1 0 0 1-1 1H5l-3 3V3a1 1 0 0 1 1-1z"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+      )}
+      {/* Admin ban button — subtle, appears on hover */}
+      {isAdmin && hovered && (
+        <button
+          type="button"
+          onClick={() => onBan(op.callsign)}
+          title={`Ban ${op.callsign}`}
+          aria-label={`Ban ${op.callsign}`}
+          style={{
+            flexShrink: 0,
+            background: 'none',
+            border: 'none',
+            padding: '0 2px',
+            cursor: 'pointer',
+            fontSize: 11,
+            lineHeight: 1,
+            color: 'var(--tx)',
+            opacity: 0.6,
+          }}
+        >
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 16 16"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+          >
+            <circle cx="8" cy="8" r="6.5" stroke="currentColor" strokeWidth="1.5" />
+            <line x1="3" y1="13" x2="13" y2="3" stroke="currentColor" strokeWidth="1.5" />
+          </svg>
+        </button>
+      )}
+      {/* Star control */}
+      <button
+        type="button"
+        onClick={() => onStar(op.callsign)}
+        title={star.title}
+        aria-label={`${star.title} — ${op.callsign}`}
+        aria-pressed={relation === 'friend'}
+        style={{
+          flexShrink: 0,
+          background: 'none',
+          border: 'none',
+          padding: '0 2px',
+          cursor: 'pointer',
+          fontSize: 12,
+          lineHeight: 1,
+          color: star.color,
+          opacity: starVisible ? 1 : 0,
+          transition: 'opacity var(--dur-fast) var(--ease-out)',
+        }}
+      >
+        {star.glyph}
+      </button>
+    </div>
+  );
+}
+
+function RequestRow({
+  callsign,
+  onOpen,
+  onAccept,
+  onDeny,
+}: {
+  callsign: string;
+  onOpen: (callsign: string) => void;
+  onAccept: (callsign: string) => void;
+  onDeny: (callsign: string) => void;
+}) {
+  const btn = (label: string, color: string, title: string, fn: () => void) => (
+    <button
+      type="button"
+      onClick={fn}
+      title={title}
+      aria-label={`${title} — ${callsign}`}
+      style={{
+        flexShrink: 0,
+        width: 20,
+        height: 20,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'none',
+        border: `1px solid ${color}`,
+        borderRadius: 'var(--r-sm)',
+        color,
+        cursor: 'pointer',
+        fontSize: 11,
+        lineHeight: 1,
+      }}
+    >
+      {label}
+    </button>
+  );
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 6,
+        padding: '4px 8px',
+        borderRadius: 'var(--r-sm)',
+      }}
+    >
+      <div style={{ minWidth: 0, flex: 1 }}>
+        <CallsignButton callsign={callsign} onOpen={onOpen} prominent />
+        <div style={{ fontSize: 9, color: 'var(--fg-3)', letterSpacing: '0.04em', marginTop: 1 }}>
+          wants to be friends
         </div>
       </div>
+      {btn('✓', 'var(--ok)', 'Accept request', () => onAccept(callsign))}
+      {btn('✗', 'var(--tx)', 'Deny request', () => onDeny(callsign))}
     </div>
   );
 }
@@ -228,20 +410,24 @@ function MessageRow({
         display: 'flex',
         flexDirection: 'column',
         alignItems: own ? 'flex-end' : 'flex-start',
-        gap: 2,
+        gap: 3,
         padding: '0 10px',
       }}
     >
       <div style={{ display: 'flex', gap: 6, alignItems: 'baseline' }}>
         <CallsignButton callsign={msg.from} onOpen={onOpen} own={own} />
-        <span className="mono" title={fmtClock(msg.ts)} style={{ fontSize: 10, color: 'var(--fg-3)' }}>
+        <span
+          className="mono"
+          title={fmtClock(msg.ts)}
+          style={{ fontSize: 9.5, color: 'var(--fg-3)' }}
+        >
           {fmtRelative(msg.ts)}
         </span>
       </div>
       <div
         style={{
           maxWidth: '85%',
-          padding: '6px 10px',
+          padding: '5px 10px',
           borderRadius: 'var(--r-lg)',
           background: own ? 'var(--accent-soft)' : 'var(--bg-2)',
           border: own ? '1px solid var(--accent-line)' : '1px solid var(--line)',
@@ -355,42 +541,384 @@ function ProfileOverlay({
   );
 }
 
+// ---------------------------------------------------------------------------
+// Eye icon — inline SVG for freq visibility toggle
+// ---------------------------------------------------------------------------
+
+function EyeIcon({ open }: { open: boolean }) {
+  if (open) {
+    return (
+      <svg
+        width="15"
+        height="15"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <ellipse cx="8" cy="8" rx="6" ry="3.5" stroke="currentColor" strokeWidth="1.4" />
+        <circle cx="8" cy="8" r="1.8" fill="currentColor" />
+      </svg>
+    );
+  }
+  return (
+    <svg
+      width="15"
+      height="15"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <ellipse cx="8" cy="8" rx="6" ry="3.5" stroke="currentColor" strokeWidth="1.4" />
+      <circle cx="8" cy="8" r="1.8" fill="currentColor" />
+      <line x1="2" y1="14" x2="14" y2="2" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tab bar sub-components
+// ---------------------------------------------------------------------------
+
+/**
+ * Gold glow style for non-public private room tabs/threads.
+ * Tuned to be soft — a premium cue, not a neon sign.
+ */
+const GOLD_RING_IDLE =
+  'inset 0 0 0 1px rgba(255,177,60,0.22), 0 0 8px rgba(255,177,60,0.10)';
+const GOLD_RING_HOVER =
+  'inset 0 0 0 1px rgba(255,177,60,0.35), 0 0 12px rgba(255,177,60,0.16)';
+const GOLD_RING_ACTIVE =
+  'inset 0 0 0 1px rgba(255,177,60,0.40), 0 0 14px rgba(255,177,60,0.20)';
+
+interface TabItemProps {
+  id: string;
+  label: string;
+  isPrivate: boolean;
+  isActive: boolean;
+  unread: number;
+  closable?: boolean;
+  onClick: () => void;
+  onClose?: () => void;
+}
+
+function TabItem({ id: _id, label, isPrivate, isActive, unread, closable, onClick, onClose }: TabItemProps) {
+  const [hovered, setHovered] = useState(false);
+
+  const boxShadow = isPrivate
+    ? isActive
+      ? GOLD_RING_ACTIVE
+      : hovered
+      ? GOLD_RING_HOVER
+      : GOLD_RING_IDLE
+    : 'none';
+
+  const borderBottom = isActive
+    ? isPrivate
+      ? '2px solid var(--power)'
+      : '2px solid var(--accent-bright)'
+    : '2px solid transparent';
+
+  return (
+    <div
+      role="tab"
+      aria-selected={isActive}
+      onClick={onClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        position: 'relative',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 5,
+        padding: '0 10px',
+        height: '100%',
+        cursor: 'pointer',
+        boxShadow,
+        borderBottom,
+        background: isActive ? 'var(--bg-2)' : hovered ? 'var(--bg-2)' : 'transparent',
+        transition: `background var(--dur-fast) var(--ease-out), box-shadow var(--dur-fast) var(--ease-out)`,
+        userSelect: 'none',
+        flexShrink: 0,
+      }}
+    >
+      <span
+        style={{
+          fontSize: 11,
+          fontWeight: isActive ? 700 : 500,
+          letterSpacing: '0.04em',
+          color: isActive
+            ? isPrivate
+              ? 'var(--power)'
+              : 'var(--fg-0)'
+            : 'var(--fg-2)',
+          transition: `color var(--dur-fast) var(--ease-out)`,
+          maxWidth: 88,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {label}
+      </span>
+      {unread > 0 && !isActive && (
+        <span
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            minWidth: 15,
+            height: 15,
+            padding: '0 4px',
+            borderRadius: 8,
+            background: isPrivate ? 'var(--power)' : 'var(--accent)',
+            color: '#fff',
+            fontSize: 9,
+            fontWeight: 700,
+            lineHeight: 1,
+          }}
+        >
+          {unread > 99 ? '99+' : unread}
+        </span>
+      )}
+      {closable && onClose && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onClose();
+          }}
+          aria-label={`Close ${label} tab`}
+          style={{
+            flexShrink: 0,
+            background: 'none',
+            border: 'none',
+            padding: 0,
+            cursor: 'pointer',
+            fontSize: 10,
+            lineHeight: 1,
+            color: 'var(--fg-3)',
+            marginLeft: 2,
+            opacity: hovered ? 1 : 0,
+            transition: `opacity var(--dur-fast) var(--ease-out)`,
+          }}
+        >
+          ✕
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Group room management strip (admin only)
+// ---------------------------------------------------------------------------
+
+function GroupManagementStrip({
+  roomId,
+  members,
+}: {
+  roomId: string;
+  members: string[];
+}) {
+  const [open, setOpen] = useState(false);
+  const addMember = useChatStore((s) => s.addMember);
+  const removeMember = useChatStore((s) => s.removeMember);
+  const deleteRoom = useChatStore((s) => s.deleteRoom);
+  const setActiveRoom = useChatStore((s) => s.setActiveRoom);
+
+  const handleAdd = () => {
+    const call = window.prompt('Add member — enter callsign:');
+    if (call && call.trim()) void addMember(roomId, call.trim().toUpperCase());
+  };
+
+  const handleRemove = (call: string) => {
+    if (window.confirm(`Remove ${call} from this group?`)) void removeMember(roomId, call);
+  };
+
+  const handleDelete = () => {
+    if (window.confirm('Delete this group room? This cannot be undone.')) {
+      void deleteRoom(roomId);
+      setActiveRoom(PUBLIC_ROOM);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        borderBottom: '1px solid var(--line)',
+        background: 'var(--bg-1)',
+      }}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+          width: '100%',
+          padding: '4px 10px',
+          background: 'none',
+          border: 'none',
+          cursor: 'pointer',
+          fontSize: 9.5,
+          fontWeight: 700,
+          letterSpacing: '0.10em',
+          textTransform: 'uppercase',
+          color: 'var(--power)',
+        }}
+      >
+        <span style={{ fontSize: 9, opacity: 0.7 }}>{open ? '▼' : '▶'}</span>
+        Group Management
+      </button>
+      {open && (
+        <div
+          style={{
+            padding: '4px 10px 8px',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 4,
+          }}
+        >
+          {/* Member list */}
+          {members.length > 0 && (
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginBottom: 4 }}>
+              {members.map((m) => (
+                <span
+                  key={m}
+                  className="mono"
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 4,
+                    padding: '2px 6px',
+                    borderRadius: 'var(--r-sm)',
+                    background: 'var(--bg-2)',
+                    border: '1px solid var(--line)',
+                    fontSize: 10.5,
+                    color: 'var(--fg-1)',
+                  }}
+                >
+                  {m}
+                  <button
+                    type="button"
+                    onClick={() => handleRemove(m)}
+                    aria-label={`Remove ${m} from group`}
+                    style={{
+                      background: 'none',
+                      border: 'none',
+                      padding: 0,
+                      cursor: 'pointer',
+                      fontSize: 9,
+                      color: 'var(--fg-3)',
+                      lineHeight: 1,
+                    }}
+                  >
+                    ✕
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+          <div style={{ display: 'flex', gap: 6 }}>
+            <button
+              type="button"
+              className="btn sm"
+              onClick={handleAdd}
+            >
+              + Add member
+            </button>
+            <button
+              type="button"
+              className="btn sm"
+              onClick={handleDelete}
+              style={{ color: 'var(--tx)', borderColor: 'var(--tx)', marginLeft: 'auto' }}
+            >
+              Delete room
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main panel
+// ---------------------------------------------------------------------------
+
 export function ChatPanel() {
   const enabled = useChatStore((s) => s.enabled);
   const connected = useChatStore((s) => s.connected);
   const ownCall = useChatStore((s) => s.callsign);
   const relayError = useChatStore((s) => s.relayError);
+  const isAdmin = useChatStore((s) => s.isAdmin);
+  const freqPublic = useChatStore((s) => s.freqPublic);
   const roster = useChatStore((s) => s.roster);
-  const messages = useChatStore((s) => s.messages);
+  const rooms = useChatStore((s) => s.rooms);
+  const activeRoom = useChatStore((s) => s.activeRoom);
+  const messagesByRoom = useChatStore((s) => s.messagesByRoom);
+  const unreadByRoom = useChatStore((s) => s.unreadByRoom);
+  const acceptedFriends = useChatStore((s) => s.acceptedFriends);
+  const incomingRequests = useChatStore((s) => s.incomingRequests);
+  const outgoingRequests = useChatStore((s) => s.outgoingRequests);
+
   const refreshStatus = useChatStore((s) => s.refreshStatus);
   const setEnabled = useChatStore((s) => s.setEnabled);
   const send = useChatStore((s) => s.send);
   const loadHistory = useChatStore((s) => s.loadHistory);
   const loadRoster = useChatStore((s) => s.loadRoster);
+  const loadRooms = useChatStore((s) => s.loadRooms);
+  const loadFriends = useChatStore((s) => s.loadFriends);
+  const setActiveRoom = useChatStore((s) => s.setActiveRoom);
+  const openDm = useChatStore((s) => s.openDm);
+  const setFreqVisibility = useChatStore((s) => s.setFreqVisibility);
+  const requestFriend = useChatStore((s) => s.requestFriend);
+  const acceptFriend = useChatStore((s) => s.acceptFriend);
+  const denyFriend = useChatStore((s) => s.denyFriend);
+  const removeFriend = useChatStore((s) => s.removeFriend);
+  const createRoom = useChatStore((s) => s.createRoom);
+  const ban = useChatStore((s) => s.ban);
 
   const qrzConnected = useQrzStore((s) => s.connected);
 
   const [draft, setDraft] = useState('');
   const [profileCall, setProfileCall] = useState<string | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLTextAreaElement | null>(null);
 
-  // Hydrate on mount; live 0x35 frames keep us current afterwards.
+  // Auto-grow textarea
+  useEffect(() => {
+    const el = inputRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${Math.min(el.scrollHeight, 90)}px`;
+  }, [draft]);
+
+  // Hydrate on mount
   useEffect(() => {
     void refreshStatus();
     void loadHistory();
     void loadRoster();
-  }, [refreshStatus, loadHistory, loadRoster]);
+    void loadRooms();
+    void loadFriends();
+  }, [refreshStatus, loadHistory, loadRoster, loadRooms, loadFriends]);
 
-  // Auto-scroll to newest message when the thread grows.
+  // Auto-scroll to newest message in the active room
+  const activeMessages = messagesByRoom[activeRoom] ?? [];
   useEffect(() => {
     const el = scrollRef.current;
     if (el) el.scrollTop = el.scrollHeight;
-  }, [messages.length]);
+  }, [activeMessages.length, activeRoom]);
 
   const openProfile = useCallback((callsign: string) => {
     setProfileCall(callsign.trim().toUpperCase());
   }, []);
 
+  // Sorted roster
   const sortedRoster = useMemo(() => {
     const rank: Record<string, number> = { tx: 0, rx: 1, away: 2 };
     return [...roster].sort((a, b) => {
@@ -401,17 +929,82 @@ export function ChatPanel() {
     });
   }, [roster]);
 
-  // Group the (already status/callsign-sorted) roster by band for display.
+  const friendSet = useMemo(() => new Set(acceptedFriends.map((c) => c.toUpperCase())), [acceptedFriends]);
+  const outgoingSet = useMemo(() => new Set(outgoingRequests.map((c) => c.toUpperCase())), [outgoingRequests]);
+  const incomingSet = useMemo(() => new Set(incomingRequests.map((c) => c.toUpperCase())), [incomingRequests]);
+
+  const friendsOnline = useMemo(
+    () => sortedRoster.filter((op) => friendSet.has(op.callsign.toUpperCase())),
+    [sortedRoster, friendSet],
+  );
+
   const rosterByBand = useMemo(() => {
     const groups = new Map<string, ChatOperator[]>();
     for (const op of sortedRoster) {
+      const call = op.callsign.toUpperCase();
+      if (friendSet.has(call) || incomingSet.has(call)) continue;
       const band = bandForHz(op.freqHz);
       const arr = groups.get(band);
       if (arr) arr.push(op);
       else groups.set(band, [op]);
     }
     return [...groups.entries()].sort((a, b) => bandOrder(a[0]) - bandOrder(b[0]));
-  }, [sortedRoster]);
+  }, [sortedRoster, friendSet, incomingSet]);
+
+  const relationFor = useCallback(
+    (callsign: string): FriendRelation => {
+      const c = callsign.toUpperCase();
+      if (friendSet.has(c)) return 'friend';
+      if (outgoingSet.has(c)) return 'requested';
+      return 'none';
+    },
+    [friendSet, outgoingSet],
+  );
+
+  const onStar = useCallback(
+    (callsign: string) => {
+      const rel = relationFor(callsign);
+      if (rel === 'friend' || rel === 'requested') void removeFriend(callsign);
+      else void requestFriend(callsign);
+    },
+    [relationFor, removeFriend, requestFriend],
+  );
+
+  const onBan = useCallback(
+    (callsign: string) => {
+      if (window.confirm(`Ban ${callsign} from ZeusChat?`)) void ban(callsign);
+    },
+    [ban],
+  );
+
+  // Tab ordering: public first, then groups, then DMs
+  const orderedRooms = useMemo(() => {
+    const pub = rooms.filter((r) => r.kind === 'public');
+    const grp = rooms.filter((r) => r.kind === 'group');
+    const dms = rooms.filter((r) => r.kind === 'dm');
+    return [...pub, ...grp, ...dms];
+  }, [rooms]);
+
+  const activeRoomObj = useMemo(
+    () => rooms.find((r) => r.id === activeRoom) ?? null,
+    [rooms, activeRoom],
+  );
+
+  const isPrivateRoom = activeRoomObj ? activeRoomObj.kind !== 'public' : false;
+
+  // Placeholder label for the composer
+  const composerPlaceholder = (() => {
+    if (!connected) return 'Not connected';
+    if (!activeRoomObj) return 'Message… (Enter to send)';
+    if (activeRoomObj.kind === 'dm') {
+      const other = dmOther(activeRoomObj.id, ownCall);
+      return `Message @${other ?? activeRoomObj.name} (Enter to send, Shift+Enter for newline)`;
+    }
+    if (activeRoomObj.kind === 'group') {
+      return `Message #${activeRoomObj.name} (Enter to send, Shift+Enter for newline)`;
+    }
+    return 'Message everyone (Enter to send, Shift+Enter for newline)';
+  })();
 
   const canSend = enabled && connected && draft.trim().length > 0 && draft.length <= MAX_MESSAGE_CHARS;
 
@@ -420,22 +1013,38 @@ export function ChatPanel() {
     if (!text || !connected || text.length > MAX_MESSAGE_CHARS) return;
     setDraft('');
     const ok = await send(text);
-    if (!ok) setDraft(text); // restore on failure so the operator can retry
+    if (!ok) setDraft(text);
   }, [draft, connected, send]);
 
+  // Status pill
   const statusPill = (() => {
     if (!enabled) return { color: 'var(--fg-3)', bg: 'var(--bg-2)', label: 'Disabled' };
     if (connected) return { color: 'var(--ok)', bg: 'var(--ok-soft)', label: 'Connected' };
+    if (relayError) {
+      const label = /qrz/i.test(relayError) ? 'Login to QRZ' : 'Disconnected';
+      return { color: 'var(--tx)', bg: 'var(--tx-soft)', label };
+    }
     return { color: 'var(--power)', bg: 'var(--power-soft)', label: 'Connecting…' };
   })();
 
-  const remaining = MAX_MESSAGE_CHARS - draft.length;
-  const counterColor =
-    draft.length > MAX_MESSAGE_CHARS
-      ? 'var(--tx)'
-      : draft.length >= CHAR_WARN_THRESHOLD
-        ? 'var(--power)'
-        : 'var(--fg-3)';
+  // Handle DM tab close: just navigate back to public
+  const handleTabClose = useCallback(
+    (id: string) => {
+      if (activeRoom === id) setActiveRoom(PUBLIC_ROOM);
+    },
+    [activeRoom, setActiveRoom],
+  );
+
+  // Admin: create group room
+  const handleCreateRoom = () => {
+    const name = window.prompt('New group name:');
+    if (name && name.trim()) void createRoom(name.trim());
+  };
+
+  // Golden thread border for private rooms
+  const threadTopBorder = isPrivateRoom
+    ? '2px solid rgba(255,177,60,0.30)'
+    : '1px solid transparent';
 
   return (
     <div
@@ -447,20 +1056,20 @@ export function ChatPanel() {
         position: 'relative',
       }}
     >
-      {/* Header */}
+      {/* ── Header ── */}
       <div
         style={{
-          padding: '6px 10px',
+          padding: '5px 10px',
           borderBottom: '1px solid var(--panel-border)',
           display: 'flex',
           alignItems: 'center',
-          gap: 8,
-          flexWrap: 'wrap',
+          gap: 7,
+          flexShrink: 0,
         }}
       >
         <span
           style={{
-            fontSize: 13,
+            fontSize: 12,
             fontWeight: 700,
             letterSpacing: '0.14em',
             textTransform: 'uppercase',
@@ -469,37 +1078,78 @@ export function ChatPanel() {
         >
           Chat
         </span>
+
+        {/* Status pill */}
         <span
           title={relayError ?? statusPill.label}
           style={{
             display: 'inline-flex',
             alignItems: 'center',
-            gap: 5,
-            padding: '2px 8px',
+            gap: 4,
+            padding: '2px 7px',
             borderRadius: 'var(--r-lg)',
             background: statusPill.bg,
             color: statusPill.color,
-            fontSize: 10.5,
+            fontSize: 10,
             fontWeight: 600,
             letterSpacing: '0.04em',
+            flexShrink: 0,
           }}
         >
           <span
             style={{
-              width: 6,
-              height: 6,
+              width: 5,
+              height: 5,
               borderRadius: '50%',
               background: statusPill.color,
+              flexShrink: 0,
             }}
           />
           {statusPill.label}
         </span>
+
+        {/* Own callsign */}
         {ownCall ? (
-          <span className="mono" style={{ fontSize: 11, color: 'var(--fg-2)' }}>
+          <span className="mono" style={{ fontSize: 10.5, color: 'var(--fg-2)', flexShrink: 0 }}>
             {ownCall}
           </span>
         ) : null}
+
         <div style={{ flex: 1 }} />
+
+        {/* Freq visibility eye toggle */}
+        {enabled && connected && (
+          <button
+            type="button"
+            onClick={() => void setFreqVisibility(!freqPublic)}
+            aria-label={
+              freqPublic
+                ? 'Your frequency is visible to friends — click to hide'
+                : 'Your frequency is hidden from everyone — click to share'
+            }
+            aria-pressed={freqPublic}
+            title={
+              freqPublic
+                ? 'Your frequency is visible to friends'
+                : 'Your frequency is hidden from everyone'
+            }
+            style={{
+              background: 'none',
+              border: 'none',
+              padding: '2px 4px',
+              cursor: 'pointer',
+              color: freqPublic ? 'var(--accent-bright)' : 'var(--fg-3)',
+              display: 'flex',
+              alignItems: 'center',
+              borderRadius: 'var(--r-sm)',
+              transition: 'color var(--dur-fast) var(--ease-out)',
+            }}
+          >
+            <EyeIcon open={freqPublic} />
+          </button>
+        )}
+
+        {/* Enable/disable toggle */}
         {!enabled ? (
           <button
             type="button"
@@ -521,16 +1171,17 @@ export function ChatPanel() {
         )}
       </div>
 
-      {/* Call-to-action banners */}
-      {!enabled ? (
+      {/* ── Call-to-action banners ── */}
+      {!enabled && (
         <div
           style={{
-            padding: '6px 10px',
+            padding: '5px 10px',
             borderBottom: '1px solid var(--panel-border)',
             background: 'var(--bg-2)',
-            fontSize: 11.5,
+            fontSize: 11,
             color: 'var(--fg-2)',
             lineHeight: 1.4,
+            flexShrink: 0,
           }}
         >
           Enabling chat connects you to the public operator relay and{' '}
@@ -539,106 +1190,216 @@ export function ChatPanel() {
           </strong>{' '}
           to other logged-in operators.
         </div>
-      ) : null}
-      {enabled && !qrzConnected ? (
+      )}
+      {enabled && !qrzConnected && (
         <div
           style={{
-            padding: '6px 10px',
+            padding: '5px 10px',
             borderBottom: '1px solid var(--panel-border)',
             background: 'var(--bg-2)',
-            fontSize: 11.5,
+            fontSize: 11,
             color: 'var(--fg-2)',
             display: 'flex',
             alignItems: 'center',
             gap: 6,
+            flexShrink: 0,
           }}
         >
           <span>Log into QRZ to chat and view operator profiles.</span>
           <span style={{ color: 'var(--fg-3)' }}>(Settings → QRZ)</span>
         </div>
-      ) : null}
-      {relayError ? (
+      )}
+      {relayError && (
         <div
           style={{
-            padding: '6px 10px',
+            padding: '5px 10px',
             borderBottom: '1px solid var(--panel-border)',
             background: 'var(--tx-soft)',
-            fontSize: 11.5,
+            fontSize: 11,
             color: 'var(--tx)',
+            flexShrink: 0,
           }}
         >
           {relayError}
         </div>
-      ) : null}
+      )}
 
-      {/* Body: roster column + message thread */}
+      {/* ── Body: sidebar + right column ── */}
       <div style={{ flex: 1, display: 'flex', minHeight: 0, overflow: 'hidden' }}>
-        {/* Roster */}
+
+        {/* ── Left sidebar: public roster ── */}
         <div
           style={{
-            width: 150,
+            width: 148,
             flexShrink: 0,
             borderRight: '1px solid var(--panel-border)',
             display: 'flex',
             flexDirection: 'column',
             minHeight: 0,
+            background: 'var(--bg-1)',
           }}
         >
+          {/* Online count header */}
           <div
             style={{
               padding: '5px 8px 3px',
-              fontSize: 10,
+              fontSize: 9,
               fontWeight: 700,
               letterSpacing: '0.12em',
               textTransform: 'uppercase',
               color: 'var(--fg-3)',
+              borderBottom: '1px solid var(--line)',
+              flexShrink: 0,
             }}
           >
             Online · {sortedRoster.length}
           </div>
+
+          {/* Scrollable roster list */}
           <div
             style={{
               flex: 1,
               overflowY: 'auto',
               overflowX: 'hidden',
               minHeight: 0,
-              padding: '0 4px 6px',
+              padding: '2px 4px 6px',
             }}
           >
-            {sortedRoster.length === 0 ? (
-              <div style={{ padding: '10px 8px', fontSize: 11, color: 'var(--fg-3)' }}>
+            {sortedRoster.length === 0 && incomingRequests.length === 0 ? (
+              <div style={{ padding: '10px 8px', fontSize: 10.5, color: 'var(--fg-3)' }}>
                 No one here yet
               </div>
             ) : (
-              rosterByBand.map(([band, ops]) => (
-                <div key={band} style={{ marginBottom: 2 }}>
-                  <div
-                    style={{
-                      display: 'flex',
-                      alignItems: 'baseline',
-                      justifyContent: 'space-between',
-                      padding: '5px 6px 2px',
-                      fontSize: 9.5,
-                      fontWeight: 700,
-                      letterSpacing: '0.1em',
-                      textTransform: 'uppercase',
-                      color: 'var(--accent-bright)',
-                    }}
-                  >
-                    <span>{band}</span>
-                    <span style={{ color: 'var(--fg-4)', fontWeight: 600 }}>{ops.length}</span>
+              <>
+                {/* Friends section */}
+                {(incomingRequests.length > 0 || friendsOnline.length > 0) && (
+                  <div style={{ marginBottom: 3 }}>
+                    <GroupHeader
+                      label="Friends"
+                      count={friendsOnline.length + incomingRequests.length}
+                      accent="var(--power)"
+                    />
+                    {incomingRequests.map((call) => (
+                      <RequestRow
+                        key={`req-${call}`}
+                        callsign={call}
+                        onOpen={openProfile}
+                        onAccept={acceptFriend}
+                        onDeny={denyFriend}
+                      />
+                    ))}
+                    {friendsOnline.map((op) => (
+                      <RosterRow
+                        key={op.callsign}
+                        op={op}
+                        onOpen={openProfile}
+                        relation="friend"
+                        onStar={onStar}
+                        onDm={openDm}
+                        isAdmin={isAdmin}
+                        onBan={onBan}
+                      />
+                    ))}
                   </div>
-                  {ops.map((op) => (
-                    <RosterRow key={op.callsign} op={op} onOpen={openProfile} />
-                  ))}
-                </div>
-              ))
+                )}
+
+                {/* Band groups */}
+                {rosterByBand.map(([band, ops]) => (
+                  <div key={band} style={{ marginBottom: 2 }}>
+                    <GroupHeader label={band} count={ops.length} accent="var(--accent-bright)" />
+                    {ops.map((op) => (
+                      <RosterRow
+                        key={op.callsign}
+                        op={op}
+                        onOpen={openProfile}
+                        relation={relationFor(op.callsign)}
+                        onStar={onStar}
+                        onDm={openDm}
+                        isAdmin={isAdmin}
+                        onBan={onBan}
+                      />
+                    ))}
+                  </div>
+                ))}
+              </>
             )}
           </div>
         </div>
 
-        {/* Thread */}
+        {/* ── Right column: tab bar + thread + composer ── */}
         <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+
+          {/* ── Tab bar ── */}
+          <div
+            role="tablist"
+            aria-label="Chat rooms"
+            style={{
+              display: 'flex',
+              alignItems: 'stretch',
+              height: 30,
+              borderBottom: '1px solid var(--panel-border)',
+              background: 'var(--bg-1)',
+              overflowX: 'auto',
+              overflowY: 'hidden',
+              flexShrink: 0,
+            }}
+          >
+            {orderedRooms.map((room) => {
+              const isDm = room.kind === 'dm';
+              const isPrivate = room.kind !== 'public';
+              const label = isDm
+                ? (dmOther(room.id, ownCall) ?? room.name)
+                : room.name;
+              return (
+                <TabItem
+                  key={room.id}
+                  id={room.id}
+                  label={label}
+                  isPrivate={isPrivate}
+                  isActive={activeRoom === room.id}
+                  unread={unreadByRoom[room.id] ?? 0}
+                  closable={isDm}
+                  onClick={() => setActiveRoom(room.id)}
+                  onClose={isDm ? () => handleTabClose(room.id) : undefined}
+                />
+              );
+            })}
+
+            {/* Admin: create group room */}
+            {isAdmin && (
+              <button
+                type="button"
+                onClick={handleCreateRoom}
+                aria-label="Create group room"
+                title="Create group room"
+                style={{
+                  flexShrink: 0,
+                  background: 'none',
+                  border: 'none',
+                  padding: '0 10px',
+                  cursor: 'pointer',
+                  fontSize: 16,
+                  lineHeight: 1,
+                  color: 'var(--fg-3)',
+                  alignSelf: 'center',
+                  display: 'flex',
+                  alignItems: 'center',
+                }}
+              >
+                +
+              </button>
+            )}
+          </div>
+
+          {/* Admin group management strip */}
+          {isAdmin && activeRoomObj?.kind === 'group' && (
+            <GroupManagementStrip
+              roomId={activeRoom}
+              members={activeRoomObj.members}
+            />
+          )}
+
+          {/* ── Message thread ── */}
           <div
             ref={scrollRef}
             style={{
@@ -649,9 +1410,11 @@ export function ChatPanel() {
               flexDirection: 'column',
               gap: 8,
               padding: '10px 0',
+              borderTop: threadTopBorder,
+              transition: `border-color var(--dur-fast) var(--ease-out)`,
             }}
           >
-            {messages.length === 0 ? (
+            {activeMessages.length === 0 ? (
               <div
                 style={{
                   margin: 'auto',
@@ -661,28 +1424,39 @@ export function ChatPanel() {
                   padding: 16,
                 }}
               >
-                {enabled ? 'No messages' : 'Chat is disabled — enable it to join the conversation.'}
+                {enabled
+                  ? 'No messages yet'
+                  : 'Chat is disabled — enable it to join the conversation.'}
               </div>
             ) : (
-              messages.map((m) => {
+              activeMessages.map((m) => {
                 const own = !!ownCall && m.from.toUpperCase() === ownCall.toUpperCase();
-                return <MessageRow key={m.id || `${m.from}-${m.ts}`} msg={m} own={own} onOpen={openProfile} />;
+                return (
+                  <MessageRow
+                    key={m.id || `${m.from}-${m.ts}`}
+                    msg={m}
+                    own={own}
+                    onOpen={openProfile}
+                  />
+                );
               })
             )}
           </div>
 
-          {/* Input row */}
+          {/* ── Composer ── */}
           <div
             style={{
               borderTop: '1px solid var(--panel-border)',
-              padding: '6px 8px',
+              padding: '5px 8px',
               display: 'flex',
               flexDirection: 'column',
               gap: 4,
+              flexShrink: 0,
             }}
           >
             <div style={{ display: 'flex', gap: 6, alignItems: 'flex-end' }}>
               <textarea
+                ref={inputRef}
                 className="mono"
                 value={draft}
                 onChange={(e) => setDraft(e.target.value)}
@@ -692,25 +1466,28 @@ export function ChatPanel() {
                     void doSend();
                   }
                 }}
-                placeholder={
-                  connected ? 'Message… (Enter to send, Shift+Enter for newline)' : 'Not connected'
-                }
+                placeholder={composerPlaceholder}
                 disabled={!connected}
                 rows={1}
                 maxLength={MAX_MESSAGE_CHARS + 64}
                 style={{
                   flex: 1,
                   resize: 'none',
+                  overflowY: 'auto',
                   maxHeight: 90,
                   minHeight: 28,
                   padding: '5px 8px',
+                  boxSizing: 'border-box',
                   borderRadius: 'var(--r-sm)',
-                  border: '1px solid var(--line-strong)',
+                  border: isPrivateRoom
+                    ? '1px solid rgba(255,177,60,0.28)'
+                    : '1px solid var(--line-strong)',
                   background: connected ? '#0c0c10' : 'var(--bg-1)',
                   color: '#d8d8dc',
-                  fontSize: 12.5,
+                  fontSize: 12,
                   lineHeight: 1.4,
                   outline: 'none',
+                  transition: `border-color var(--dur-fast) var(--ease-out)`,
                 }}
               />
               <button
@@ -723,21 +1500,24 @@ export function ChatPanel() {
                 Send
               </button>
             </div>
-            <div
-              style={{
-                display: 'flex',
-                justifyContent: 'flex-end',
-                fontSize: 10,
-                color: counterColor,
-                opacity: draft.length >= CHAR_WARN_THRESHOLD || draft.length === 0 ? 1 : 0.6,
-              }}
-            >
-              {draft.length >= CHAR_WARN_THRESHOLD ? `${remaining} left` : `${draft.length}/${MAX_MESSAGE_CHARS}`}
-            </div>
+            {/* Character counter when near limit */}
+            {draft.length > MAX_MESSAGE_CHARS * 0.8 && (
+              <div
+                style={{
+                  fontSize: 9.5,
+                  textAlign: 'right',
+                  color: draft.length > MAX_MESSAGE_CHARS ? 'var(--tx)' : 'var(--fg-3)',
+                  paddingRight: 2,
+                }}
+              >
+                {draft.length}/{MAX_MESSAGE_CHARS}
+              </div>
+            )}
           </div>
         </div>
       </div>
 
+      {/* ── QRZ profile overlay ── */}
       {profileCall ? (
         <ProfileOverlay callsign={profileCall} onClose={() => setProfileCall(null)} />
       ) : null}

--- a/zeus-web/src/state/chat-store.test.ts
+++ b/zeus-web/src/state/chat-store.test.ts
@@ -11,38 +11,53 @@
 // repository for the full text, or https://www.gnu.org/licenses/.
 
 import { beforeEach, describe, expect, it } from 'vitest';
-import { useChatStore } from './chat-store';
+import { useChatStore, PUBLIC_ROOM } from './chat-store';
 
+// Per-room store: messages live in messagesByRoom keyed by room id, the active
+// tab gates unread counting, and friends/rooms mirror relay frames.
 const RESET = {
   enabled: false,
   connected: false,
   callsign: null,
   relayUrl: null,
   relayError: null,
+  isAdmin: false,
+  freqPublic: true,
   roster: [],
-  messages: [],
+  rooms: [{ id: PUBLIC_ROOM, name: 'Public', kind: 'public' as const, members: [] }],
+  activeRoom: PUBLIC_ROOM,
+  messagesByRoom: {},
+  unreadByRoom: {},
+  acceptedFriends: [],
+  incomingRequests: [],
+  outgoingRequests: [],
 };
 
-function msg(id: string, ts: number, text = id, from = 'N9WAR', room = 'lobby') {
+function msg(id: string, ts: number, text = id, from = 'N9WAR', room = PUBLIC_ROOM) {
   return { id, ts, text, from, room };
 }
+
+const lobby = () => useChatStore.getState().messagesByRoom[PUBLIC_ROOM] ?? [];
 
 describe('chat-store ingest (0x35 live frames)', () => {
   beforeEach(() => {
     useChatStore.setState(RESET);
   });
 
-  it('status frame updates connection fields', () => {
+  it('status frame updates connection + capability fields', () => {
     useChatStore.getState().ingest({
       kind: 'status',
-      status: { enabled: true, connected: true, callsign: 'N9WAR', relayUrl: 'wss://x/chat', error: null },
+      status: {
+        enabled: true, connected: true, callsign: 'N9WAR',
+        relayUrl: 'wss://x/chat', error: null, isAdmin: true, freqPublic: false,
+      },
     });
     const s = useChatStore.getState();
     expect(s.enabled).toBe(true);
     expect(s.connected).toBe(true);
     expect(s.callsign).toBe('N9WAR');
-    expect(s.relayUrl).toBe('wss://x/chat');
-    expect(s.relayError).toBeNull();
+    expect(s.isAdmin).toBe(true);
+    expect(s.freqPublic).toBe(false);
   });
 
   it('roster frame replaces the roster with normalized operators', () => {
@@ -61,36 +76,67 @@ describe('chat-store ingest (0x35 live frames)', () => {
     expect(r[1]?.grid).toBeNull();
   });
 
-  it('message frames append, de-dupe by id, and stay time-ordered', () => {
+  it('message frames append to their room, de-dupe by id, and stay time-ordered', () => {
     const ing = useChatStore.getState().ingest;
     ing({ kind: 'message', message: msg('b', 200) });
     ing({ kind: 'message', message: msg('a', 100) });
     ing({ kind: 'message', message: msg('b', 200) }); // duplicate id — ignored
-    const m = useChatStore.getState().messages;
-    expect(m.map((x) => x.id)).toEqual(['a', 'b']);
+    expect(lobby().map((x) => x.id)).toEqual(['a', 'b']);
   });
 
-  it('history frame merges with existing messages without duplicates', () => {
+  it('routes messages to the correct room and counts unread for inactive rooms', () => {
+    const ing = useChatStore.getState().ingest;
+    ing({ kind: 'message', message: msg('g1', 100, 'hi', 'W1ABC', 'g123') });
+    expect(useChatStore.getState().messagesByRoom['g123']?.map((m) => m.id)).toEqual(['g1']);
+    // active room is lobby, so a g123 message bumps its unread badge.
+    expect(useChatStore.getState().unreadByRoom['g123']).toBe(1);
+    expect(useChatStore.getState().unreadByRoom[PUBLIC_ROOM] ?? 0).toBe(0);
+  });
+
+  it('history frame merges into the named room without duplicates', () => {
     const ing = useChatStore.getState().ingest;
     ing({ kind: 'message', message: msg('a', 100) });
-    ing({ kind: 'history', messages: [msg('a', 100), msg('c', 300), msg('b', 200)] });
-    const m = useChatStore.getState().messages;
-    expect(m.map((x) => x.id)).toEqual(['a', 'b', 'c']);
+    ing({ kind: 'history', room: PUBLIC_ROOM, messages: [msg('a', 100), msg('c', 300), msg('b', 200)] });
+    expect(lobby().map((x) => x.id)).toEqual(['a', 'b', 'c']);
   });
 
-  it('caps retained messages at 500, keeping the newest', () => {
+  it('caps retained messages per room at 500, keeping the newest', () => {
     const many = Array.from({ length: 600 }, (_, i) => msg(`m${i}`, i + 1));
-    useChatStore.getState().ingest({ kind: 'history', messages: many });
-    const m = useChatStore.getState().messages;
+    useChatStore.getState().ingest({ kind: 'history', room: PUBLIC_ROOM, messages: many });
+    const m = lobby();
     expect(m).toHaveLength(500);
     expect(m[0]?.id).toBe('m100'); // oldest 100 dropped
     expect(m[m.length - 1]?.id).toBe('m599');
+  });
+
+  it('friends frame mirrors the consent graph', () => {
+    useChatStore.getState().ingest({
+      kind: 'friends',
+      friends: { accepted: ['W1ABC'], incoming: ['K9XYZ'], outgoing: ['N0DEF'] },
+    });
+    const s = useChatStore.getState();
+    expect(s.acceptedFriends).toEqual(['W1ABC']);
+    expect(s.incomingRequests).toEqual(['K9XYZ']);
+    expect(s.outgoingRequests).toEqual(['N0DEF']);
+  });
+
+  it('rooms frame replaces the visible room list', () => {
+    useChatStore.getState().ingest({
+      kind: 'rooms',
+      rooms: [
+        { id: PUBLIC_ROOM, name: 'Public', kind: 'public', members: [] },
+        { id: 'g1', name: 'Net Control', kind: 'group', members: ['N9WAR'] },
+      ],
+    });
+    const ids = useChatStore.getState().rooms.map((r) => r.id);
+    expect(ids).toContain('g1');
+    expect(useChatStore.getState().rooms.find((r) => r.id === 'g1')?.kind).toBe('group');
   });
 
   it('ignores malformed or unknown envelopes without throwing', () => {
     const ing = useChatStore.getState().ingest;
     expect(() => ing({ kind: 'nope' } as never)).not.toThrow();
     expect(() => ing(null as never)).not.toThrow();
-    expect(useChatStore.getState().messages).toHaveLength(0);
+    expect(lobby()).toHaveLength(0);
   });
 });

--- a/zeus-web/src/state/chat-store.ts
+++ b/zeus-web/src/state/chat-store.ts
@@ -10,40 +10,84 @@
 // option) any later version. See the LICENSE file at the root of this
 // repository for the full text, or https://www.gnu.org/licenses/.
 
-// Operator-to-operator chat state. Hydrated via REST on panel mount
-// (refreshStatus / loadHistory / loadRoster) and kept live thereafter by the
-// 0x35 MSG_TYPE_CHAT_EVENT push frames decoded in realtime/ws-client.ts, which
-// dispatch their parsed envelope straight into ingest(). The store is global
-// so the WS can drive it whether or not the ChatPanel is mounted.
+// Operator-to-operator chat state. Hydrated via REST on panel mount and kept
+// live by the 0x35 MSG_TYPE_CHAT_EVENT push frames decoded in
+// realtime/ws-client.ts, which dispatch their parsed envelope into ingest().
+// The store is global so the WS can drive it whether or not the ChatPanel is
+// mounted.
+//
+// Channels: the public lobby ("lobby"), admin-created groups ("g…"), and DMs
+// ("dm:LO:HI"). Messages are kept per-room; the active tab selects which thread
+// the panel shows. Friendships, frequency visibility, rooms, and admin status
+// are all relay-authoritative (mirrored from frames), never invented locally.
 
 import { create } from 'zustand';
 import {
   chatStatus,
   chatSetEnabled,
   chatSend,
+  chatDm,
   chatMessages,
   chatRoster,
+  chatRooms,
+  chatRequestHistory,
+  chatFriends,
+  chatFriendRequest,
+  chatFriendAccept,
+  chatFriendDeny,
+  chatFriendRemove,
+  chatSetFreqVisibility,
+  chatCreateRoom,
+  chatDeleteRoom,
+  chatAddMember,
+  chatRemoveMember,
+  chatBan,
+  chatUnban,
   normalizeStatus,
   normalizeOperator,
   normalizeMessage,
+  normalizeFriends,
+  normalizeRoom,
   type ChatOperator,
   type ChatMessage,
   type ChatStatus,
+  type ChatRoom,
+  type ChatFriends,
 } from '../api/chat';
 import { ApiError } from '../api/client';
 import { warnOnce } from '../util/logger';
 
 const HISTORY_LIMIT = 200;
+export const PUBLIC_ROOM = 'lobby';
 
-/** Cap retained messages so a long-lived session can't grow unbounded. */
+/** Cap retained messages per room so a long-lived session can't grow unbounded. */
 const MAX_MESSAGES = 500;
+
+/** Canonical DM room id for two callsigns (order-independent, uppercased). */
+export function dmRoomId(a: string, b: string): string {
+  const [lo, hi] = [a.toUpperCase(), b.toUpperCase()].sort();
+  return `dm:${lo}:${hi}`;
+}
+
+/** The other party in a "dm:LO:HI" id, relative to `me`. */
+export function dmOther(roomId: string, me: string | null): string | null {
+  if (!roomId.startsWith('dm:')) return null;
+  const [, a, b] = roomId.split(':');
+  const meUp = (me ?? '').toUpperCase();
+  if (a && a !== meUp) return a;
+  if (b && b !== meUp) return b;
+  return a ?? b ?? null;
+}
 
 // The JSON envelope carried by each 0x35 frame. Discriminated on `kind`.
 export type ChatEnvelope =
   | { kind: 'status'; status: unknown }
   | { kind: 'roster'; roster: unknown }
   | { kind: 'message'; message: unknown }
-  | { kind: 'history'; messages: unknown };
+  | { kind: 'history'; room?: unknown; messages: unknown }
+  | { kind: 'friends'; friends: unknown }
+  | { kind: 'rooms'; rooms: unknown }
+  | { kind: 'banned'; message?: unknown };
 
 export type ChatStoreState = {
   enabled: boolean;
@@ -51,14 +95,43 @@ export type ChatStoreState = {
   callsign: string | null;
   relayUrl: string | null;
   relayError: string | null;
+  isAdmin: boolean;
+  freqPublic: boolean;
   roster: ChatOperator[];
-  messages: ChatMessage[];
+
+  // Channels + per-room message threads + which tab is active.
+  rooms: ChatRoom[];
+  activeRoom: string;
+  messagesByRoom: Record<string, ChatMessage[]>;
+  unreadByRoom: Record<string, number>;
+
+  // Friend graph (consent gate for seeing freq).
+  acceptedFriends: string[];
+  incomingRequests: string[];
+  outgoingRequests: string[];
 
   refreshStatus: () => Promise<void>;
   setEnabled: (enabled: boolean) => Promise<void>;
   send: (text: string) => Promise<boolean>;
   loadHistory: () => Promise<void>;
   loadRoster: () => Promise<void>;
+  loadRooms: () => Promise<void>;
+  loadFriends: () => Promise<void>;
+  setActiveRoom: (room: string) => void;
+  openDm: (callsign: string) => void;
+  requestRoomHistory: (room: string) => Promise<void>;
+  setFreqVisibility: (isPublic: boolean) => Promise<void>;
+  requestFriend: (callsign: string) => Promise<void>;
+  acceptFriend: (callsign: string) => Promise<void>;
+  denyFriend: (callsign: string) => Promise<void>;
+  removeFriend: (callsign: string) => Promise<void>;
+  // Admin / moderation.
+  createRoom: (name: string) => Promise<void>;
+  deleteRoom: (room: string) => Promise<void>;
+  addMember: (room: string, callsign: string) => Promise<void>;
+  removeMember: (room: string, callsign: string) => Promise<void>;
+  ban: (callsign: string) => Promise<void>;
+  unban: (callsign: string) => Promise<void>;
   ingest: (envelope: ChatEnvelope) => void;
 };
 
@@ -69,6 +142,16 @@ function applyStatus(s: ChatStatus): Partial<ChatStoreState> {
     callsign: s.callsign,
     relayUrl: s.relayUrl,
     relayError: s.error,
+    isAdmin: s.isAdmin,
+    freqPublic: s.freqPublic,
+  };
+}
+
+function applyFriends(f: ChatFriends): Partial<ChatStoreState> {
+  return {
+    acceptedFriends: f.accepted,
+    incomingRequests: f.incoming,
+    outgoingRequests: f.outgoing,
   };
 }
 
@@ -89,19 +172,30 @@ function mergeHistory(existing: ChatMessage[], incoming: ChatMessage[]): ChatMes
   return merged.length > MAX_MESSAGES ? merged.slice(merged.length - MAX_MESSAGES) : merged;
 }
 
-export const useChatStore = create<ChatStoreState>((set) => ({
+function errMsg(err: unknown): string {
+  return err instanceof ApiError ? err.message : String(err);
+}
+
+export const useChatStore = create<ChatStoreState>((set, get) => ({
   enabled: false,
   connected: false,
   callsign: null,
   relayUrl: null,
   relayError: null,
+  isAdmin: false,
+  freqPublic: true,
   roster: [],
-  messages: [],
+  rooms: [{ id: PUBLIC_ROOM, name: 'Public', kind: 'public', members: [] }],
+  activeRoom: PUBLIC_ROOM,
+  messagesByRoom: {},
+  unreadByRoom: {},
+  acceptedFriends: [],
+  incomingRequests: [],
+  outgoingRequests: [],
 
   refreshStatus: async () => {
     try {
-      const status = await chatStatus();
-      set(applyStatus(status));
+      set(applyStatus(await chatStatus()));
     } catch {
       // Status is a read-only sanity probe — leave prior state on failure.
     }
@@ -109,23 +203,27 @@ export const useChatStore = create<ChatStoreState>((set) => ({
 
   setEnabled: async (enabled) => {
     try {
-      const status = await chatSetEnabled(enabled);
-      set(applyStatus(status));
+      set(applyStatus(await chatSetEnabled(enabled)));
     } catch (err) {
-      const msg = err instanceof ApiError ? err.message : String(err);
-      set({ relayError: msg });
+      set({ relayError: errMsg(err) });
     }
   },
 
   send: async (text) => {
     const trimmed = text.trim();
     if (!trimmed) return false;
+    const { activeRoom, callsign } = get();
     try {
-      const { ok } = await chatSend(trimmed);
-      return ok;
+      if (activeRoom.startsWith('dm:')) {
+        const other = dmOther(activeRoom, callsign);
+        if (!other) return false;
+        await chatDm(other, trimmed);
+      } else {
+        await chatSend(trimmed, activeRoom);
+      }
+      return true;
     } catch (err) {
-      const msg = err instanceof ApiError ? err.message : String(err);
-      set({ relayError: msg });
+      set({ relayError: errMsg(err) });
       return false;
     }
   },
@@ -133,7 +231,9 @@ export const useChatStore = create<ChatStoreState>((set) => ({
   loadHistory: async () => {
     try {
       const messages = await chatMessages(HISTORY_LIMIT);
-      set((s) => ({ messages: mergeHistory(s.messages, messages) }));
+      set((s) => ({
+        messagesByRoom: { ...s.messagesByRoom, [PUBLIC_ROOM]: mergeHistory(s.messagesByRoom[PUBLIC_ROOM] ?? [], messages) },
+      }));
     } catch {
       // History is best-effort; live frames will backfill.
     }
@@ -141,11 +241,101 @@ export const useChatStore = create<ChatStoreState>((set) => ({
 
   loadRoster: async () => {
     try {
-      const roster = await chatRoster();
-      set({ roster });
+      set({ roster: await chatRoster() });
     } catch {
       // Roster is best-effort; a live roster frame will replace it.
     }
+  },
+
+  loadRooms: async () => {
+    try {
+      const rooms = await chatRooms();
+      if (rooms.length) set({ rooms });
+    } catch {
+      // Best-effort; a live rooms frame will replace it.
+    }
+  },
+
+  loadFriends: async () => {
+    try {
+      set(applyFriends(await chatFriends()));
+    } catch {
+      // Best-effort; a live friends frame will replace it.
+    }
+  },
+
+  setActiveRoom: (room) => {
+    set((s) => ({ activeRoom: room, unreadByRoom: { ...s.unreadByRoom, [room]: 0 } }));
+    if (get().messagesByRoom[room] === undefined) void get().requestRoomHistory(room);
+  },
+
+  openDm: (callsign) => {
+    const me = get().callsign ?? '';
+    const id = dmRoomId(callsign, me || callsign);
+    set((s) => {
+      const exists = s.rooms.some((r) => r.id === id);
+      const rooms = exists
+        ? s.rooms
+        : [...s.rooms, { id, name: callsign.toUpperCase(), kind: 'dm' as const, members: [me, callsign.toUpperCase()].filter(Boolean) }];
+      return { rooms, activeRoom: id, unreadByRoom: { ...s.unreadByRoom, [id]: 0 } };
+    });
+    if (get().messagesByRoom[id] === undefined) void get().requestRoomHistory(id);
+  },
+
+  requestRoomHistory: async (room) => {
+    if (room === PUBLIC_ROOM) {
+      await get().loadHistory();
+      return;
+    }
+    try {
+      await chatRequestHistory(room); // relay pushes a history frame back
+    } catch {
+      // Best-effort; the tab simply has no scrollback yet.
+    }
+  },
+
+  setFreqVisibility: async (isPublic) => {
+    set({ freqPublic: isPublic }); // optimistic; status frame confirms
+    try {
+      await chatSetFreqVisibility(isPublic);
+    } catch (err) {
+      set({ relayError: errMsg(err) });
+      void get().refreshStatus();
+    }
+  },
+
+  // Friend actions are fire-and-forget: the relay echoes the resulting graph
+  // back as a 0x35 friends frame, which ingest() applies as the source of truth.
+  requestFriend: async (callsign) => {
+    try { await chatFriendRequest(callsign); } catch (err) { set({ relayError: errMsg(err) }); }
+  },
+  acceptFriend: async (callsign) => {
+    try { await chatFriendAccept(callsign); } catch (err) { set({ relayError: errMsg(err) }); }
+  },
+  denyFriend: async (callsign) => {
+    try { await chatFriendDeny(callsign); } catch (err) { set({ relayError: errMsg(err) }); }
+  },
+  removeFriend: async (callsign) => {
+    try { await chatFriendRemove(callsign); } catch (err) { set({ relayError: errMsg(err) }); }
+  },
+
+  createRoom: async (name) => {
+    try { await chatCreateRoom(name); } catch (err) { set({ relayError: errMsg(err) }); }
+  },
+  deleteRoom: async (room) => {
+    try { await chatDeleteRoom(room); } catch (err) { set({ relayError: errMsg(err) }); }
+  },
+  addMember: async (room, callsign) => {
+    try { await chatAddMember(room, callsign); } catch (err) { set({ relayError: errMsg(err) }); }
+  },
+  removeMember: async (room, callsign) => {
+    try { await chatRemoveMember(room, callsign); } catch (err) { set({ relayError: errMsg(err) }); }
+  },
+  ban: async (callsign) => {
+    try { await chatBan(callsign); } catch (err) { set({ relayError: errMsg(err) }); }
+  },
+  unban: async (callsign) => {
+    try { await chatUnban(callsign); } catch (err) { set({ relayError: errMsg(err) }); }
   },
 
   ingest: (envelope) => {
@@ -155,24 +345,51 @@ export const useChatStore = create<ChatStoreState>((set) => ({
         set(applyStatus(normalizeStatus(envelope.status)));
         return;
       case 'roster':
-        set({
-          roster: Array.isArray(envelope.roster)
-            ? envelope.roster.map(normalizeOperator)
-            : [],
-        });
+        set({ roster: Array.isArray(envelope.roster) ? envelope.roster.map(normalizeOperator) : [] });
         return;
       case 'message': {
         const msg = normalizeMessage(envelope.message);
-        set((s) => ({ messages: appendMessage(s.messages, msg) }));
+        const room = msg.room || PUBLIC_ROOM;
+        set((s) => {
+          const next = appendMessage(s.messagesByRoom[room] ?? [], msg);
+          const own = !!s.callsign && msg.from.toUpperCase() === s.callsign.toUpperCase();
+          const bump = s.activeRoom !== room && !own;
+          return {
+            messagesByRoom: { ...s.messagesByRoom, [room]: next },
+            unreadByRoom: bump
+              ? { ...s.unreadByRoom, [room]: (s.unreadByRoom[room] ?? 0) + 1 }
+              : s.unreadByRoom,
+          };
+        });
         return;
       }
       case 'history': {
-        const incoming = Array.isArray(envelope.messages)
-          ? envelope.messages.map(normalizeMessage)
-          : [];
-        set((s) => ({ messages: mergeHistory(s.messages, incoming) }));
+        const room = typeof envelope.room === 'string' ? envelope.room : PUBLIC_ROOM;
+        const incoming = Array.isArray(envelope.messages) ? envelope.messages.map(normalizeMessage) : [];
+        set((s) => ({
+          messagesByRoom: { ...s.messagesByRoom, [room]: mergeHistory(s.messagesByRoom[room] ?? [], incoming) },
+        }));
         return;
       }
+      case 'friends':
+        set(applyFriends(normalizeFriends(envelope.friends)));
+        return;
+      case 'rooms': {
+        const incoming = Array.isArray(envelope.rooms) ? envelope.rooms.map(normalizeRoom) : [];
+        set((s) => {
+          // Preserve any local placeholder DM tabs the relay hasn't echoed yet.
+          const ids = new Set(incoming.map((r) => r.id));
+          const placeholders = s.rooms.filter((r) => r.kind === 'dm' && !ids.has(r.id));
+          const rooms = [...incoming, ...placeholders];
+          // If the active tab vanished (room deleted / membership removed), fall back to public.
+          const activeRoom = rooms.some((r) => r.id === s.activeRoom) ? s.activeRoom : PUBLIC_ROOM;
+          return { rooms, activeRoom };
+        });
+        return;
+      }
+      case 'banned':
+        set({ relayError: typeof envelope.message === 'string' ? envelope.message : 'You have been banned from ZeusChat.' });
+        return;
       default:
         warnOnce('chat-ingest-unknown-kind', `unknown chat envelope kind: ${String((envelope as { kind?: unknown }).kind)}`);
     }
@@ -185,4 +402,4 @@ export function ownCallsign(): string | null {
 }
 
 // Re-export the wire types so panels can import them from one place.
-export type { ChatOperator, ChatMessage, ChatStatus } from '../api/chat';
+export type { ChatOperator, ChatMessage, ChatStatus, ChatRoom } from '../api/chat';


### PR DESCRIPTION
## Summary

Relay-mediated upgrade to ZeusChat across all layers (Cloudflare relay DO, .NET backend, web). The single shared `ChatRoom` Durable Object now owns the whole network state: public roster, the friend consent graph, admin-created private rooms, DMs, bans, and persisted message history.

### Friends (bidirectional consent)
- Frequency is **private**: an operator's freq is shown only to mutual friends — and only while their eye toggle is open.
- Star control on roster rows sends / cancels / removes requests; incoming requests surface with accept (✓) / deny (✗) in the roster's Friends section.

### Rooms & DMs (tabs)
- Public lobby (band-grouped) + admin-created member-gated **groups** + 1:1 **DMs**, presented as tabs. Non-public rooms carry a golden premium glow.
- Messages persisted per-room on the relay; per-room history loaded on demand.

### Moderation
- `N9WAR` + `KB2UKA` are admins (override via the relay `ADMINS` var). They can create/delete groups, add/remove members, and ban/unban (a ban kicks live sockets and blocks reconnect). Admins can't be banned.

### Frequency privacy (eye toggle)
- An eye control hides your frequency from **everyone, including accepted friends**; persisted in LiteDB.

### Retention
- Relay `alarm()` prunes the public room hourly and private rooms/DMs at 24h.

## ⚠️ Deploy requirement
All the friend/room/DM/ban/prune/privacy logic lives in the Cloudflare Worker. **This needs `cd cloud/zeuschat-relay && npm run deploy`** to take effect against `chat.openhpsdrzeus.com`. It uses the existing `ChatRoom` SQLite namespace — no `wrangler.toml` migration needed. Until deployed, the live relay ignores the new frames and the UI degrades quietly (one Public tab, no rooms/DMs).

## Testing
- **Backend**: full suite green (1305 passed / 0 failed); chat unit tests 19/19 (envelope (de)serialization incl. friends/rooms, freq-visibility persistence, friend/admin gating).
- **Frontend**: real `tsc -b` + `vite build` clean; `chat-store` vitest 9/9 (per-room routing, unread, friends/rooms ingest); eslint clean.
- **Relay e2e**: 25/25 assertions against a local `wrangler dev` relay driven by simulated operators over real WebSockets — friend request/accept, freq gating (non-friend hidden / friend visible / eye-off hides even from friends), admin rooms + membership, room message delivery to members only, non-admin create rejected, DM delivery, history persistence to late joiners, and ban (notice + reconnect refused).

Not exercised end-to-end: the time-based prune alarm, and the full desktop stack with live QRZ (the relay itself is thoroughly covered).