### PR TITLE
feat(audio-suite): + (New) button and in-place Save for TX/RX profile bars

### DIFF
--- a/zeus-web/src/components/AudioSuiteWindow.tsx
+++ b/zeus-web/src/components/AudioSuiteWindow.tsx
@@ -1342,9 +1342,28 @@ export function AudioSuiteWindow({
       });
     }
   };
-  const onSaveProfile = () => {
+  // "+" — capture the current chain under a NEW name (name dialog).
+  const onNewProfile = () => {
     setProfileDialogError(null);
     setProfileSaveOpen(true);
+  };
+  // "Save" — overwrite the currently-selected profile in place, no name
+  // prompt. With nothing selected there's no target, so fall back to the
+  // new-profile dialog.
+  const onSaveProfile = async () => {
+    if (!selectedProfile) {
+      onNewProfile();
+      return;
+    }
+    const result = await saveProfile(selectedProfile, route);
+    if (!result.ok) {
+      setVstNotice({
+        tone: 'error',
+        text: `Profile save failed:\n${result.error || `Could not save "${selectedProfile}"`}`,
+      });
+      return;
+    }
+    setVstNotice({ tone: 'ok', text: `Saved "${selectedProfile}".` });
   };
   const onDeleteProfile = () => {
     if (!selectedProfile) return;
@@ -1797,8 +1816,21 @@ export function AudioSuiteWindow({
           </select>
           <button
             type="button"
-            onClick={onSaveProfile}
-            title="Save the current chain as a profile"
+            onClick={onNewProfile}
+            title="Save the current chain as a new profile"
+            aria-label="New RX profile"
+            style={profileBtnStyle(false)}
+          >
+            +
+          </button>
+          <button
+            type="button"
+            onClick={() => void onSaveProfile()}
+            title={
+              selectedProfile
+                ? `Overwrite "${selectedProfile}" with the current chain`
+                : 'Save the current chain as a new profile'
+            }
             style={profileBtnStyle(false)}
           >
             Save
@@ -2024,9 +2056,8 @@ export function AudioSuiteWindow({
       )}
       {profileSaveOpen && (
         <TextInputDialog
-          title="Save profile"
+          title="New profile"
           label="Profile name"
-          initialValue={selectedProfile}
           placeholder="Ragchew"
           confirmLabel="Save Profile"
           onCancel={() => {

--- a/zeus-web/src/components/TxAudioProfileBar.test.tsx
+++ b/zeus-web/src/components/TxAudioProfileBar.test.tsx
@@ -87,15 +87,33 @@ describe('TxAudioProfileBar', () => {
     unmount();
   });
 
-  it('opens the name dialog and saves by name', async () => {
+  it('saves the selected profile in place when Save is pressed', async () => {
     const save = vi.fn(async () => ({ ok: true }));
     useTxAudioProfileStore.setState({ save });
     const { container, unmount } = render(createElement(TxAudioProfileBar));
     await act(flush);
 
+    // A profile is selected (lastLoadedId = studio-ssb), so Save overwrites it
+    // directly by name — no name dialog.
     const saveBtn = container.querySelector('[aria-label="Save TX audio profile"]') as HTMLButtonElement;
     await act(async () => {
       saveBtn.click();
+      await flush();
+    });
+    expect(save).toHaveBeenCalledWith('Studio SSB');
+    expect(document.querySelector('.text-input-dialog-field input')).toBeNull();
+    unmount();
+  });
+
+  it('opens the name dialog and saves by name via the New button', async () => {
+    const save = vi.fn(async () => ({ ok: true }));
+    useTxAudioProfileStore.setState({ save });
+    const { container, unmount } = render(createElement(TxAudioProfileBar));
+    await act(flush);
+
+    const newBtn = container.querySelector('[aria-label="New TX audio profile"]') as HTMLButtonElement;
+    await act(async () => {
+      newBtn.click();
       await flush();
     });
 

--- a/zeus-web/src/components/TxAudioProfileBar.tsx
+++ b/zeus-web/src/components/TxAudioProfileBar.tsx
@@ -17,7 +17,7 @@
 // server-side from live state; this component never assembles a profile body.
 
 import { useEffect, useId, useRef, useState, type CSSProperties } from 'react';
-import { ChevronDown } from 'lucide-react';
+import { ChevronDown, Plus } from 'lucide-react';
 
 import { ConfirmDialog } from '../layout/ConfirmDialog';
 import { TextInputDialog } from '../layout/TextInputDialog';
@@ -111,6 +111,7 @@ export function TxAudioProfileBar({ compact = false }: TxAudioProfileBarProps) {
     }
   };
 
+  // The "+" / name-dialog path: capture the live state under a NEW name.
   const onSaveSubmit = async (name: string) => {
     setSaveOpen(false);
     setNotice(null);
@@ -120,6 +121,23 @@ export function TxAudioProfileBar({ compact = false }: TxAudioProfileBarProps) {
       return;
     }
     setNotice({ tone: 'ok', text: `Saved "${name}".` });
+  };
+
+  // The "Save" button: overwrite the currently-selected profile in place, no
+  // name prompt. With nothing selected there's no target, so fall back to the
+  // new-profile dialog (the "+" path).
+  const onSaveSelected = async () => {
+    setNotice(null);
+    if (!selectedProfile) {
+      setSaveOpen(true);
+      return;
+    }
+    const result = await save(selectedProfile.name);
+    if (!result.ok) {
+      setNotice({ tone: 'error', text: result.error ?? 'Profile save failed.' });
+      return;
+    }
+    setNotice({ tone: 'ok', text: `Saved "${selectedProfile.name}".` });
   };
 
   const onDeleteConfirm = async () => {
@@ -242,13 +260,27 @@ export function TxAudioProfileBar({ compact = false }: TxAudioProfileBarProps) {
         </div>
         <button
           type="button"
-          aria-label="Save TX audio profile"
-          title="Save the current live TX audio settings as a named profile"
+          aria-label="New TX audio profile"
+          title="Save the current live TX audio settings as a new profile"
           disabled={busy}
           onClick={() => {
             setNotice(null);
             setSaveOpen(true);
           }}
+          style={{ ...buttonStyle(busy), display: 'inline-flex', alignItems: 'center', justifyContent: 'center', padding: '0 7px' }}
+        >
+          <Plus size={14} aria-hidden />
+        </button>
+        <button
+          type="button"
+          aria-label="Save TX audio profile"
+          title={
+            selectedProfile
+              ? `Overwrite "${selectedProfile.name}" with the current live TX audio settings`
+              : 'Save the current live TX audio settings as a new profile'
+          }
+          disabled={busy}
+          onClick={() => void onSaveSelected()}
           style={buttonStyle(busy, true)}
         >
           Save


### PR DESCRIPTION
## What

Adds a **+ (New)** button to both the **TX Audio Suite** and **RX Audio Suite** profile bars, and changes **Save** to write through to the currently-selected profile instead of always prompting for a name.

- **+** → creates a new named profile from the current live settings (opens the name dialog).
- **Save** → overwrites the currently-selected profile **in place**, no name prompt. With nothing selected it falls back to the new-profile dialog.

## Why

Operators editing a loaded profile previously had to retype the exact name to overwrite it. Save now does the obvious thing (update the selected profile), and creating a new one is an explicit, separate action.

## Changes

- **`TxAudioProfileBar.tsx`** — new `Plus` button opens the name dialog; `Save` now calls `save(selectedProfile.name)`. Backend save is idempotent by name/slug, so this is a true in-place overwrite.
- **`AudioSuiteWindow.tsx` (RX)** — new `+` button opens the (now empty) name dialog; `Save` PUTs the selected profile in place and reports via the existing notice strip; dialog retitled "New profile".
- **`TxAudioProfileBar.test.tsx`** — updated to cover in-place Save (no dialog) and the New-button dialog path.

## Notes

- No backend / wire-format changes; both save endpoints already overwrite by name.
- Token-only styling, no new deps.
- When no profile is selected, **Save** falls back to the new-profile dialog rather than being disabled — happy to flip to disabled if preferred.

## Verification

- `tsc --noEmit` clean.
- `TxAudioProfileBar.test.tsx` (4), `TxFidelityPanel.test.tsx` + `audio-suite-store.test.ts` (22) all pass.