### PR TITLE
test(server): gate hanging WDSP fixture-matrix smoke behind opt-in env

### DIFF
--- a/tests/Zeus.Server.Tests/DspModernizationValidationToolTests.cs
+++ b/tests/Zeus.Server.Tests/DspModernizationValidationToolTests.cs
@@ -1276,6 +1276,21 @@ public sealed class DspModernizationValidationToolTests
     {
         Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "PowerShell WDSP fixture matrix smoke runs on Windows.");
 
+        // Opt-in gate: this heavy WDSP fixture-matrix smoke shells out to
+        // tools/run-dsp-wdsp-fixture-matrix.ps1 and, on an un-validated Windows
+        // dev host, hangs past its own 4-minute budget — wedging the whole
+        // Zeus.Server.Tests run (the blame-hang collector then aborts it, which
+        // reads as a host crash). It belongs to the same un-validated live/fixture
+        // matrix smoke family already gated behind ZEUS_RUN_DSP_VALIDATION_SMOKE
+        // (see ValidationTriageLiveMatrixActionCapturesParityComparisons); this
+        // one was simply missed. The behaviour under test (external opt-in bypass
+        // profile wiring) is unchanged — the assertions below are intact. Set
+        // ZEUS_RUN_DSP_VALIDATION_SMOKE=1 to run it once a Windows harness has
+        // been validated. Pending Windows harness validation by N9WAR.
+        Skip.IfNot(
+            Environment.GetEnvironmentVariable("ZEUS_RUN_DSP_VALIDATION_SMOKE") == "1",
+            "DSP WDSP fixture-matrix smoke is opt-in (set ZEUS_RUN_DSP_VALIDATION_SMOKE=1); pending Windows harness validation by N9WAR.");
+
         var powerShell = FindPowerShell();
         Skip.If(powerShell is null, "PowerShell executable was not found.");
 


### PR DESCRIPTION
## Problem

`dotnet test Zeus.slnx` reliably **wedges** in the `Zeus.Server.Tests` assembly. The test host stops making progress; under `--blame-hang` the collector aborts after its inactivity window and the run surfaces as *"test host process crashed"* (with incidental `prefs.guard ... ArgumentOutOfRangeException: Ticks ...` stderr that is **not** the cause — just the last thing written before the stall).

Root-caused via blame `Sequence_*.xml` (`Completed="False"`) to a single test:

```
Zeus.Server.Tests.DspModernizationValidationToolTests.WdspFixtureMatrixCarriesExternalOptInBypassProfile
```

It shells out to `tools/run-dsp-wdsp-fixture-matrix.ps1` and, on an un-validated Windows dev host, hangs **past its own 4-minute budget**, so the whole suite never finishes. Reproduced deterministically across multiple runs.

## Fix

Gate the test behind `ZEUS_RUN_DSP_VALIDATION_SMOKE=1`, exactly matching the **already-established pattern** for its sibling live/fixture-matrix smokes — e.g. `ValidationTriageLiveMatrixActionCapturesParityComparisons`, which carries the same *"pending Windows harness validation by N9WAR"* gate. This test was simply **missed** when the others were moved to opt-in.

- **No behaviour change** to the code under test (external opt-in bypass profile wiring); the assertions are untouched and still run when the env var is set.
- Pure test-harness gating — no product code modified.

## Verification

With the gate in place, the full assembly now completes:

```
Passed!  - Failed: 0, Passed: 1407, Skipped: 7, Total: 1414, Duration: 16m 20s - Zeus.Server.Tests.dll (net10.0)
```

(Before: host wedged indefinitely / blame-aborted at the inactivity window.)

Branch is rebased onto current `develop`.