### PR TITLE
fix(layout): icon-only left layout bar with hover tooltip

### DIFF
--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -144,8 +144,8 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 3px;
-  padding: 6px 2px 5px;
+  gap: 0;
+  padding: 8px 2px;
   color: var(--fg-2);
   background: transparent;
   border: 1px solid transparent;
@@ -153,7 +153,7 @@
   box-shadow: none;
   cursor: pointer;
   text-align: center;
-  min-height: 50px;
+  min-height: 40px;
   position: relative;
   transition: background var(--dur-fast), border-color var(--dur-fast),
     color var(--dur-fast);
@@ -200,11 +200,11 @@
      current colour so it picks up the active state. */
   font-family: var(--font-sans);
   font-weight: 700;
-  font-size: 16px;
+  font-size: 17px;
   letter-spacing: 0;
   text-transform: uppercase;
-  width: 22px;
-  height: 22px;
+  width: 24px;
+  height: 24px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -212,21 +212,20 @@
   border: 1px solid currentColor;
   opacity: 0.85;
 }
+/* Icon-only bar: the layout name is not shown inline (it wrapped mid-word in
+   the narrow column). The full name is revealed on hover via the tab's native
+   `title` tooltip. The span is kept in the DOM but visually hidden so screen
+   readers still announce the layout name. */
 .left-layout-bar .lb-tab-name {
-  font-family: var(--font-sans);
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  line-height: 1.1;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  line-clamp: 2;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
   overflow: hidden;
-  word-break: break-word;
-  hyphens: auto;
-  max-width: 100%;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 .left-layout-bar .lb-lock-indicator {
   position: absolute;


### PR DESCRIPTION
## What

The vertical left **layout bar** wrapped layout names mid-word in its narrow column (e.g. `HAMCLOCK` → `HAMCL` / `OCK`), because `.lb-tab-name` used `-webkit-line-clamp: 2` + `word-break: break-word`.

## Change

- Default the bar to **icon-only**. The inline name label is visually hidden (kept in the DOM for screen readers), so nothing wraps.
- The **full name now appears on hover** via the tab's existing native `title` tooltip (already wired in `LeftLayoutBar.tsx`).
- Tighten each tab to a single row (`min-height` 50→40px, no inter-element gap) and bump the icon (22→24px, 17px font) now that it's the sole content.

A styled flyout label was considered but rejected: the bar is a fixed-width grid column with `overflow:hidden` and a vertically-scrolling list, which would clip any flyout extending into the workspace — so the native tooltip is the robust, cross-platform choice.

## Scope

CSS-only, confined to `.left-layout-bar` rules in `zeus-web/src/styles/layout.css`. No palette tokens changed, no new colors. Verified in-browser (desktop viewport): label is clipped to 1px (no wrapping), tab is a compact single-row icon button, no console errors.

> Note: this touches UI chrome (CLAUDE.md red-light for visual/UX), so flagging for maintainer eyes — it's a layout/wrapping fix, not a palette or behavior change.