### PR TITLE
feat(updates): check production download domain instead of dev repo

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -1970,18 +1970,20 @@ public sealed record TxFidelityPolicyDto(
     int TargetSpectralDensity);
 
 /// <summary>Status of the local install relative to the latest available Zeus
-/// update, for the Settings -> Updates panel (GET /api/system/update).
-/// <para>When <see cref="IsGitRepo"/> is false the app is running from a
-/// packaged build; release fields describe the matching GitHub Release asset
-/// when a network check has completed. All SHAs are short form.
-/// <see cref="Behind"/>/<see cref="Ahead"/> count commits relative to
-/// <see cref="UpstreamRef"/> (e.g. "upstream/main"). <see cref="CanFastForward"/>
-/// is true only when behind &gt; 0, HEAD is an ancestor of the upstream tip, and
-/// the working tree is clean. <see cref="UpdateAction"/> is "pull" for git
-/// checkouts, "download" for packaged builds with a matching asset,
-/// "openRelease" when only the release page is available, or "none".
-/// <see cref="Error"/> carries a human message when a git or release check
-/// failed; the rest of the fields hold the last locally-known values.</para></summary>
+/// PRODUCTION build, for the Settings -> Updates panel (GET /api/system/update).
+/// <para>The latest build is read from the download domain
+/// (downloads.openhpsdrzeus.com), published from <c>main</c> only. The
+/// <c>Release*</c> fields describe the platform-matched download asset when a
+/// network check has completed: <see cref="ReleaseDownloadUrl"/> +
+/// <see cref="ReleaseAssetName"/> + <see cref="ReleaseAssetDigest"/> (sha256).
+/// <see cref="UpdateAction"/> is "download" when a matching asset exists,
+/// "openRelease" when only the website is available, or "none".
+/// <see cref="IsGitRepo"/>/<see cref="Branch"/>/<see cref="CurrentShortSha"/> are
+/// diagnostics for source checkouts; the git fast-forward path was removed, so
+/// <see cref="Behind"/>/<see cref="Ahead"/>/<see cref="CanFastForward"/>/
+/// <see cref="UpstreamRef"/> are always 0/false/null. <see cref="Error"/> carries
+/// a human message when the network check failed; the rest of the fields hold the
+/// last locally-known values.</para></summary>
 public sealed record RepoUpdateStatus(
     bool IsGitRepo,
     string? Branch,
@@ -2014,13 +2016,3 @@ public sealed record RepoUpdateStatus(
     public long? ReleaseAssetSizeBytes { get; init; }
     public string? ReleaseAssetDigest { get; init; }
 }
-
-/// <summary>Result of a fast-forward pull (POST /api/system/update/pull).
-/// <see cref="RequiresRebuild"/> is true whenever source actually changed —
-/// the running binaries are stale until the operator rebuilds and restarts
-/// (see scripts/update.*). <see cref="Message"/> is operator-facing.</summary>
-public sealed record RepoUpdateResult(
-    bool Ok,
-    string? NewSha,
-    bool RequiresRebuild,
-    string Message);

--- a/Zeus.Server.Hosting/RepoUpdateService.cs
+++ b/Zeus.Server.Hosting/RepoUpdateService.cs
@@ -7,17 +7,19 @@
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
-// RepoUpdateService — reports whether the running checkout is behind its
-// configured git upstream, or whether a packaged install is behind the latest
-// GitHub Release. The git path remains a thin CLI wrapper (no new dependencies):
-// every operation shells out to the `git` already on PATH, scoped to the repo
-// root with `git -C <root>`.
+// RepoUpdateService — reports whether the running install is behind the latest
+// PRODUCTION build published to the Zeus download domain
+// (downloads.openhpsdrzeus.com). The domain manifest is the single source of
+// truth: it is produced only from `main` by .github/workflows/publish-downloads.yml,
+// so the in-app updater never points operators at develop / nightly / dev code.
 //
-// This drives Settings -> Updates (/api/system/update). Git checkout updates
-// deliberately do NOT rebuild or restart — the running binaries are stale after
-// a pull, so the UI tells the operator to run scripts/update.* and restart.
-// Packaged builds surface the matching release asset download URL; replacing
-// the running executable is left to the installer / DMG / AppImage flow.
+// This drives Settings -> Updates (/api/system/update). The service NEVER pulls,
+// rebuilds, or restarts: it tells the operator which production build is newest
+// and surfaces the platform-matched installer / DMG / AppImage / tarball download
+// URL (with its published SHA-256). Replacing the running binary is left to the
+// installer / DMG / AppImage flow. Developers running from a git checkout still
+// update their source manually with scripts/update.* — that path is intentionally
+// not exposed in the UI.
 
 using System.Diagnostics;
 using System.Net;
@@ -30,14 +32,20 @@ using Zeus.Contracts;
 
 namespace Zeus.Server;
 
-/// <summary>Git-checkout update helper backing the Settings -> Updates panel.
+/// <summary>Download-domain update helper backing the Settings -> Updates panel.
 /// Registered as a singleton in <c>ZeusHost</c>.</summary>
 public sealed partial class RepoUpdateService
 {
-    internal const string LatestReleaseApi =
-        "https://api.github.com/repos/OpenHPSDR-Zeus-org/openhpsdr-zeus/releases/latest";
+    // The production download manifest. Published from `main` only (see
+    // publish-downloads.yml + tools/update-download-manifest.mjs). `latest.json`
+    // is the newest version entry; overridable for tests / staging via env.
+    internal const string DefaultManifestUrl = "https://downloads.openhpsdrzeus.com/latest.json";
 
-    private static readonly JsonSerializerOptions GitHubJsonOptions = new(JsonSerializerDefaults.Web);
+    // Operator-facing landing page used when no platform asset is present in the
+    // manifest (e.g. an arch we don't yet build) — "Update now" then opens this.
+    internal const string DownloadsPageUrl = "https://openhpsdrzeus.com/download";
+
+    private static readonly JsonSerializerOptions ManifestJsonOptions = new(JsonSerializerDefaults.Web);
 
     private readonly ILogger<RepoUpdateService> _log;
     private readonly IHttpClientFactory _httpClientFactory;
@@ -49,210 +57,140 @@ public sealed partial class RepoUpdateService
         _httpClientFactory = httpClientFactory;
         _repoRoot = ResolveRepoRoot();
         if (_repoRoot is null)
-            _log.LogInformation("RepoUpdateService: not running from a git checkout; release updates enabled");
+            _log.LogInformation("RepoUpdateService: packaged install; checking {Url}", ManifestUrl());
         else
-            _log.LogInformation("RepoUpdateService: repo root {Root}", _repoRoot);
+            _log.LogInformation("RepoUpdateService: source checkout at {Root}; checking {Url}", _repoRoot, ManifestUrl());
     }
 
-    /// <summary>Compute the checkout's status versus its upstream. When
-    /// <paramref name="fetch"/> is true the upstream is fetched first (network);
-    /// a failed fetch is non-fatal and the last-known counts are returned with
-    /// an <see cref="RepoUpdateStatus.Error"/> note.</summary>
+    /// <summary>Report the install's status versus the latest production build on
+    /// the download domain. When <paramref name="fetch"/> is true the manifest is
+    /// fetched (network); a failed fetch is non-fatal and surfaces as an
+    /// <see cref="RepoUpdateStatus.Error"/> note with the last locally-known
+    /// version still populated.</summary>
     public async Task<RepoUpdateStatus> GetStatusAsync(bool fetch, CancellationToken ct)
     {
-        if (_repoRoot is null)
-            return await AddReleaseStatusAsync(NotAGitRepo(), fetch, ct).ConfigureAwait(false);
-
-        try
-        {
-            var branch = NullIfEmpty((await GitAsync(ct, 10_000, "rev-parse", "--abbrev-ref", "HEAD")).Out);
-
-            var upstream = await GitAsync(ct, 10_000, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}");
-            var upstreamRef = upstream.Ok ? NullIfEmpty(upstream.Out) : null;
-            var remote = upstreamRef is { } u && u.Contains('/') ? u[..u.IndexOf('/')] : null;
-
-            // Surface an explicit note when there's no upstream (detached HEAD or a
-            // branch with no tracking ref) so the UI doesn't fall through to a
-            // misleading "up to date" with behind=0.
-            string? note = upstreamRef is null
-                ? "No upstream branch configured — set one with: git branch --set-upstream-to=<remote>/<branch>"
-                : null;
-            if (fetch && remote is not null)
-            {
-                var f = await GitAsync(ct, 30_000, "fetch", "--quiet", remote);
-                if (!f.Ok)
-                {
-                    note = $"fetch failed (offline?): {Trunc(PreferErr(f))}";
-                    _log.LogDebug("git fetch failed: {Err}", PreferErr(f));
-                }
-            }
-
-            var currentSha = NullIfEmpty((await GitAsync(ct, 10_000, "rev-parse", "HEAD")).Out);
-            var shortSha = NullIfEmpty((await GitAsync(ct, 10_000, "rev-parse", "--short", "HEAD")).Out);
-            var subject = NullIfEmpty((await GitAsync(ct, 10_000, "log", "-1", "--format=%s")).Out);
-            var dirty = !string.IsNullOrWhiteSpace((await GitAsync(ct, 10_000, "status", "--porcelain")).Out);
-
-            var behind = 0;
-            var ahead = 0;
-            string? latestSha = null;
-            string? latestSubject = null;
-            var canFf = false;
-
-            if (upstreamRef is not null)
-            {
-                behind = ParseInt((await GitAsync(ct, 10_000, "rev-list", "--count", "HEAD..@{u}")).Out);
-                ahead = ParseInt((await GitAsync(ct, 10_000, "rev-list", "--count", "@{u}..HEAD")).Out);
-                latestSha = NullIfEmpty((await GitAsync(ct, 10_000, "rev-parse", "--short", "@{u}")).Out);
-                latestSubject = NullIfEmpty((await GitAsync(ct, 10_000, "log", "-1", "--format=%s", "@{u}")).Out);
-                var ancestor = await GitAsync(ct, 10_000, "merge-base", "--is-ancestor", "HEAD", "@{u}");
-                canFf = behind > 0 && ancestor.Ok && !dirty;
-            }
-
-            string? remoteUrl = remote is not null
-                ? NullIfEmpty((await GitAsync(ct, 10_000, "remote", "get-url", remote)).Out)
-                : null;
-
-            return new RepoUpdateStatus(
-                IsGitRepo: true,
-                Branch: branch,
-                CurrentSha: currentSha,
-                CurrentShortSha: shortSha,
-                CurrentSubject: subject,
-                UpstreamRef: upstreamRef,
-                Behind: behind,
-                Ahead: ahead,
-                Dirty: dirty,
-                CanFastForward: canFf,
-                LatestRemoteSha: latestSha,
-                LatestRemoteSubject: latestSubject,
-                RemoteUrl: remoteUrl,
-                CheckedUtc: DateTime.UtcNow.ToString("o"),
-                Error: note)
-            {
-                InstalledVersion = InstalledVersion(),
-                RuntimePlatform = RuntimePlatform(),
-                RuntimeArchitecture = RuntimeInformation.OSArchitecture.ToString(),
-                UpdateAvailable = behind > 0,
-                UpdateAction = canFf ? "pull" : "none",
-            };
-        }
-        catch (Exception ex)
-        {
-            _log.LogWarning(ex, "repo update status failed");
-            return new RepoUpdateStatus(
-                IsGitRepo: true, Branch: null, CurrentSha: null, CurrentShortSha: null,
-                CurrentSubject: null, UpstreamRef: null, Behind: 0, Ahead: 0, Dirty: false,
-                CanFastForward: false, LatestRemoteSha: null, LatestRemoteSubject: null,
-                RemoteUrl: null, CheckedUtc: DateTime.UtcNow.ToString("o"),
-                Error: GitMissing(ex) ? "git is not installed or not on PATH" : ex.Message)
-            {
-                InstalledVersion = InstalledVersion(),
-                RuntimePlatform = RuntimePlatform(),
-                RuntimeArchitecture = RuntimeInformation.OSArchitecture.ToString(),
-            };
-        }
+        var local = await BuildLocalStatusAsync(ct).ConfigureAwait(false);
+        if (!fetch)
+            return local;
+        return await AddDownloadStatusAsync(local, ct).ConfigureAwait(false);
     }
 
-    /// <summary>Fast-forward the checkout to its upstream. Refuses when the
-    /// working tree is dirty (a ff would otherwise be rejected or clobber edits).
-    /// Never rebuilds/restarts — the caller surfaces RequiresRebuild.</summary>
-    public async Task<RepoUpdateResult> PullAsync(CancellationToken ct)
+    /// <summary>Assemble the local half of the status: installed version, runtime
+    /// platform/arch, and (for source checkouts) the branch/sha/dirty diagnostics.
+    /// No network and no git fetch — the update decision comes from the domain
+    /// manifest in <see cref="AddDownloadStatusAsync"/>.</summary>
+    private async Task<RepoUpdateStatus> BuildLocalStatusAsync(CancellationToken ct)
     {
-        if (_repoRoot is null)
-            return new RepoUpdateResult(false, null, false,
-                "Not running from a git checkout — download the latest Zeus release.");
+        var isGitRepo = _repoRoot is not null;
+        string? branch = null;
+        string? shortSha = null;
+        string? subject = null;
+        var dirty = false;
 
-        try
+        if (isGitRepo)
         {
-            var dirty = !string.IsNullOrWhiteSpace((await GitAsync(ct, 10_000, "status", "--porcelain")).Out);
-            if (dirty)
-                return new RepoUpdateResult(false, null, false,
-                    "Working tree has uncommitted changes — commit or stash them before updating.");
-
-            var before = NullIfEmpty((await GitAsync(ct, 10_000, "rev-parse", "--short", "HEAD")).Out);
-            var pull = await GitAsync(ct, 60_000, "pull", "--ff-only");
-            var after = NullIfEmpty((await GitAsync(ct, 10_000, "rev-parse", "--short", "HEAD")).Out);
-
-            if (!pull.Ok)
-                return new RepoUpdateResult(false, after, false, $"git pull failed: {Trunc(PreferErr(pull))}");
-
-            var changed = before is not null && after is not null && before != after;
-            var msg = changed
-                ? $"Updated {before} -> {after}. Rebuild and restart Zeus to apply (scripts/update)."
-                : "Already up to date.";
-            return new RepoUpdateResult(true, after, changed, msg);
+            // Best-effort diagnostics only. git not being installed must never
+            // break the (network-driven) update check, so failures are swallowed.
+            try
+            {
+                branch = NullIfEmpty((await GitAsync(ct, 10_000, "rev-parse", "--abbrev-ref", "HEAD")).Out);
+                shortSha = NullIfEmpty((await GitAsync(ct, 10_000, "rev-parse", "--short", "HEAD")).Out);
+                subject = NullIfEmpty((await GitAsync(ct, 10_000, "log", "-1", "--format=%s")).Out);
+                dirty = !string.IsNullOrWhiteSpace((await GitAsync(ct, 10_000, "status", "--porcelain")).Out);
+            }
+            catch (Exception ex)
+            {
+                _log.LogDebug(ex, "git diagnostics unavailable");
+            }
         }
-        catch (Exception ex)
+
+        return new RepoUpdateStatus(
+            IsGitRepo: isGitRepo,
+            Branch: branch,
+            CurrentSha: null,
+            CurrentShortSha: shortSha,
+            CurrentSubject: subject,
+            UpstreamRef: null,
+            Behind: 0,
+            Ahead: 0,
+            Dirty: dirty,
+            CanFastForward: false,
+            LatestRemoteSha: null,
+            LatestRemoteSubject: null,
+            RemoteUrl: null,
+            CheckedUtc: null,
+            Error: null)
         {
-            _log.LogWarning(ex, "repo update pull failed");
-            return new RepoUpdateResult(false, null, false,
-                GitMissing(ex) ? "git is not installed or not on PATH" : ex.Message);
-        }
+            InstalledVersion = InstalledVersion(),
+            RuntimePlatform = RuntimePlatform(),
+            RuntimeArchitecture = RuntimeInformation.OSArchitecture.ToString(),
+            UpdateAvailable = false,
+            UpdateAction = "none",
+        };
     }
 
-    private async Task<RepoUpdateStatus> AddReleaseStatusAsync(
+    /// <summary>Fetch the production download manifest and layer the
+    /// update decision + platform asset onto <paramref name="status"/>.</summary>
+    private async Task<RepoUpdateStatus> AddDownloadStatusAsync(
         RepoUpdateStatus status,
-        bool fetch,
         CancellationToken ct)
     {
-        if (!fetch)
-            return status;
-
+        var checkedUtc = DateTime.UtcNow.ToString("o");
         try
         {
             using var response = await _httpClientFactory.CreateClient("ZeusUpdates")
-                .GetAsync(LatestReleaseApi, ct)
+                .GetAsync(ManifestUrl(), ct)
                 .ConfigureAwait(false);
             if (response.StatusCode == HttpStatusCode.NotFound)
             {
                 return status with
                 {
-                    CheckedUtc = DateTime.UtcNow.ToString("o"),
-                    Error = MergeNotes(status.Error, "No published Zeus release was found on GitHub."),
+                    CheckedUtc = checkedUtc,
+                    Error = MergeNotes(status.Error, "No published Zeus download was found."),
                 };
             }
 
             response.EnsureSuccessStatusCode();
-            var release = await response.Content
-                .ReadFromJsonAsync<GitHubRelease>(GitHubJsonOptions, ct)
+            var manifest = await response.Content
+                .ReadFromJsonAsync<ZeusDownloadManifest>(ManifestJsonOptions, ct)
                 .ConfigureAwait(false);
-            if (release is null || string.IsNullOrWhiteSpace(release.TagName))
+            if (manifest is null || string.IsNullOrWhiteSpace(manifest.Version))
             {
                 return status with
                 {
-                    CheckedUtc = DateTime.UtcNow.ToString("o"),
-                    Error = MergeNotes(status.Error, "GitHub returned an empty release response."),
+                    CheckedUtc = checkedUtc,
+                    Error = MergeNotes(status.Error, "The download manifest was empty."),
                 };
             }
 
-            var asset = SelectReleaseAsset(
-                release.Assets,
+            var latestVersion = manifest.Version.Trim();
+            var asset = SelectDownloadAsset(
+                manifest.Assets,
                 RuntimePlatform(),
                 RuntimeInformation.OSArchitecture,
                 IsRunningFromAppImage(),
                 IsServerMode());
-            var latestVersion = NormalizeReleaseVersion(release.TagName);
-            var updateAvailable = IsReleaseNewer(latestVersion, status.InstalledVersion);
+            var updateAvailable = IsManifestNewer(status.InstalledVersion, latestVersion);
             var updateAction = updateAvailable
-                ? asset?.BrowserDownloadUrl is { Length: > 0 }
+                ? asset?.Url is { Length: > 0 }
                     ? "download"
-                    : !string.IsNullOrWhiteSpace(release.HtmlUrl) ? "openRelease" : "none"
+                    : "openRelease"
                 : "none";
 
             return status with
             {
-                CheckedUtc = DateTime.UtcNow.ToString("o"),
+                CheckedUtc = checkedUtc,
                 UpdateAvailable = updateAvailable,
                 UpdateAction = updateAction,
                 LatestVersion = latestVersion,
-                ReleaseTag = release.TagName,
-                ReleaseName = release.Name,
-                ReleaseUrl = release.HtmlUrl,
-                ReleasePublishedUtc = release.PublishedAt,
-                ReleaseAssetName = asset?.Name,
-                ReleaseDownloadUrl = asset?.BrowserDownloadUrl,
+                ReleaseTag = NullIfEmpty(manifest.Source?.Commit ?? string.Empty),
+                ReleaseName = $"Zeus {latestVersion}",
+                ReleaseUrl = DownloadsPageUrl,
+                ReleasePublishedUtc = manifest.PublishedAt,
+                ReleaseAssetName = asset?.Filename,
+                ReleaseDownloadUrl = asset?.Url,
                 ReleaseAssetSizeBytes = asset?.Size,
-                ReleaseAssetDigest = asset?.Digest,
+                ReleaseAssetDigest = FormatDigest(asset?.Sha256),
             };
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -261,16 +199,16 @@ public sealed partial class RepoUpdateService
         }
         catch (Exception ex)
         {
-            _log.LogDebug(ex, "release update check failed");
+            _log.LogDebug(ex, "download manifest check failed");
             return status with
             {
-                CheckedUtc = DateTime.UtcNow.ToString("o"),
-                Error = MergeNotes(status.Error, $"release check failed (offline?): {Trunc(ex.Message)}"),
+                CheckedUtc = checkedUtc,
+                Error = MergeNotes(status.Error, $"update check failed (offline?): {Trunc(ex.Message)}"),
             };
         }
     }
 
-    // ----- git process helper -----
+    // ----- git process helper (diagnostics only) -----
 
     private async Task<(bool Ok, string Out, string Err)> GitAsync(
         CancellationToken ct, int timeoutMs, params string[] args)
@@ -321,25 +259,11 @@ public sealed partial class RepoUpdateService
 
     // ----- helpers -----
 
-    private static RepoUpdateStatus NotAGitRepo() => new(
-        IsGitRepo: false, Branch: null, CurrentSha: null, CurrentShortSha: null,
-        CurrentSubject: null, UpstreamRef: null, Behind: 0, Ahead: 0, Dirty: false,
-        CanFastForward: false, LatestRemoteSha: null, LatestRemoteSubject: null,
-        RemoteUrl: null, CheckedUtc: null, Error: null)
+    private static string ManifestUrl()
     {
-        InstalledVersion = InstalledVersion(),
-        RuntimePlatform = RuntimePlatform(),
-        RuntimeArchitecture = RuntimeInformation.OSArchitecture.ToString(),
-    };
-
-    private static string PreferErr((bool Ok, string Out, string Err) r)
-        => !string.IsNullOrWhiteSpace(r.Err) ? r.Err : r.Out;
-
-    private static bool GitMissing(Exception ex)
-        => ex is System.ComponentModel.Win32Exception;
-
-    private static int ParseInt(string s)
-        => int.TryParse(s.Trim(), out var n) ? n : 0;
+        var env = Environment.GetEnvironmentVariable("ZEUS_UPDATE_MANIFEST_URL");
+        return string.IsNullOrWhiteSpace(env) ? DefaultManifestUrl : env.Trim();
+    }
 
     private static string? NullIfEmpty(string s)
         => string.IsNullOrWhiteSpace(s) ? null : s.Trim();
@@ -350,28 +274,66 @@ public sealed partial class RepoUpdateService
     private static string MergeNotes(string? first, string second)
         => string.IsNullOrWhiteSpace(first) ? second : $"{first}; {second}";
 
+    private static string? FormatDigest(string? sha256)
+    {
+        if (string.IsNullOrWhiteSpace(sha256)) return null;
+        var hex = sha256.Trim();
+        return hex.StartsWith("sha256:", StringComparison.OrdinalIgnoreCase) ? hex : $"sha256:{hex}";
+    }
+
     private static string InstalledVersion()
     {
         var assembly = Assembly.GetExecutingAssembly();
         var attr = assembly.GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false)
             .FirstOrDefault() as AssemblyInformationalVersionAttribute;
-        return string.IsNullOrWhiteSpace(attr?.InformationalVersion)
-            ? "unknown"
-            : attr.InformationalVersion;
+        if (string.IsNullOrWhiteSpace(attr?.InformationalVersion))
+            return "unknown";
+        // Strip SourceLink's "+<commit-sha>" build-metadata so the version we
+        // compare against the manifest is the clean SemVer-ish string.
+        var v = attr.InformationalVersion;
+        var plus = v.IndexOf('+');
+        return plus >= 0 ? v[..plus] : v;
     }
 
-    internal static string NormalizeReleaseVersion(string? value)
-    {
-        if (string.IsNullOrWhiteSpace(value)) return string.Empty;
-        var m = VersionPattern().Match(value);
-        return m.Success ? m.Value.TrimStart('v', 'V') : value.Trim().TrimStart('v', 'V');
-    }
-
+    /// <summary>True when <paramref name="latest"/> is a strictly newer numeric
+    /// MAJOR.MINOR.PATCH than <paramref name="installed"/>. Suffix/build metadata
+    /// is ignored — use <see cref="IsManifestNewer"/> for the build-level decision
+    /// that also accounts for same-prefix rolling builds.</summary>
     internal static bool IsReleaseNewer(string? latest, string? installed)
     {
         return TryParseReleaseVersion(latest, out var latestVersion)
             && TryParseReleaseVersion(installed, out var installedVersion)
             && latestVersion.CompareTo(installedVersion) > 0;
+    }
+
+    /// <summary>Decide whether the manifest's latest build is newer than what's
+    /// installed. Production `main` builds share a single numeric VersionPrefix
+    /// and differ only by the <c>main.YYYYMMDD.&lt;sha&gt;</c> suffix, so a plain
+    /// numeric compare can't see a new build — when the numeric prefixes match we
+    /// fall back to a string difference (the domain only ever rolls forward).
+    /// A strictly-greater installed prefix (a local build ahead of the published
+    /// line) is never treated as an available update.</summary>
+    internal static bool IsManifestNewer(string? installed, string? latest)
+    {
+        if (string.IsNullOrWhiteSpace(latest)) return false;
+        var latestTrim = latest.Trim();
+        var installedTrim = installed?.Trim() ?? string.Empty;
+        if (string.Equals(installedTrim, latestTrim, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var gotInstalled = TryParseReleaseVersion(installedTrim, out var vi);
+        var gotLatest = TryParseReleaseVersion(latestTrim, out var vl);
+        if (gotInstalled && gotLatest)
+        {
+            var cmp = vl.CompareTo(vi);
+            if (cmp != 0) return cmp > 0;
+            // Same numeric prefix, different build string → newer rolling build.
+            return true;
+        }
+
+        // One side couldn't be parsed (e.g. installed "unknown"): any difference
+        // means the manifest offers something concrete to move to.
+        return !string.Equals(installedTrim, latestTrim, StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool TryParseReleaseVersion(string? value, out Version version)
@@ -390,8 +352,11 @@ public sealed partial class RepoUpdateService
     [GeneratedRegex(@"[vV]?(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)")]
     private static partial Regex VersionPattern();
 
-    internal static GitHubReleaseAsset? SelectReleaseAsset(
-        IReadOnlyList<GitHubReleaseAsset>? assets,
+    /// <summary>Pick the manifest asset matching this platform + architecture.
+    /// Linux prefers the matching-mode AppImage when the running process is itself
+    /// an AppImage, otherwise the tarball.</summary>
+    internal static ZeusDownloadAsset? SelectDownloadAsset(
+        IReadOnlyList<ZeusDownloadAsset>? assets,
         string platform,
         Architecture architecture,
         bool runningFromAppImage,
@@ -399,41 +364,34 @@ public sealed partial class RepoUpdateService
     {
         if (assets is null || assets.Count == 0) return null;
 
-        var isArm64 = architecture == Architecture.Arm64;
+        var arch = architecture == Architecture.Arm64 ? "arm64" : "x64";
+        bool Matches(ZeusDownloadAsset a, string kind)
+            => string.Equals(a.Platform, platform, StringComparison.OrdinalIgnoreCase)
+               && string.Equals(a.Arch, arch, StringComparison.OrdinalIgnoreCase)
+               && string.Equals(a.Kind, kind, StringComparison.OrdinalIgnoreCase);
+
         if (string.Equals(platform, "windows", StringComparison.OrdinalIgnoreCase))
-        {
-            return FindAsset(assets, isArm64 ? "-win-arm64-setup.exe" : "-win-x64-setup.exe");
-        }
+            return assets.FirstOrDefault(a => Matches(a, "installer"));
 
         if (string.Equals(platform, "macos", StringComparison.OrdinalIgnoreCase))
-        {
-            return FindAsset(assets, isArm64 ? "-macos-arm64.dmg" : "-macos-x64.dmg");
-        }
+            return assets.FirstOrDefault(a => Matches(a, "dmg"));
 
         if (string.Equals(platform, "linux", StringComparison.OrdinalIgnoreCase))
         {
             if (runningFromAppImage)
             {
-                var appImageArch = isArm64 ? "aarch64" : "x86_64";
-                var suffix = $"-linux-{appImageArch}.AppImage";
+                var mode = serverMode ? "server" : "desktop";
                 var appImage = assets.FirstOrDefault(a =>
-                    a.Name.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)
-                    && (serverMode
-                        ? a.Name.StartsWith("OpenhpsdrZeus-Server-", StringComparison.OrdinalIgnoreCase)
-                        : !a.Name.StartsWith("OpenhpsdrZeus-Server-", StringComparison.OrdinalIgnoreCase)));
+                    Matches(a, "appimage")
+                    && string.Equals(a.Mode, mode, StringComparison.OrdinalIgnoreCase));
                 if (appImage is not null) return appImage;
             }
 
-            return FindAsset(assets, isArm64 ? "-linux-arm64.tar.gz" : "-linux-x64.tar.gz");
+            return assets.FirstOrDefault(a => Matches(a, "tarball"));
         }
 
         return null;
     }
-
-    private static GitHubReleaseAsset? FindAsset(
-        IReadOnlyList<GitHubReleaseAsset> assets,
-        string suffix)
-        => assets.FirstOrDefault(a => a.Name.EndsWith(suffix, StringComparison.OrdinalIgnoreCase));
 
     private static string RuntimePlatform()
     {
@@ -466,35 +424,64 @@ public sealed partial class RepoUpdateService
     }
 }
 
-internal sealed class GitHubRelease
+/// <summary>One version entry from the download domain (`latest.json` / the head
+/// of `manifest.json`). Produced by tools/update-download-manifest.mjs.</summary>
+internal sealed class ZeusDownloadManifest
 {
-    [JsonPropertyName("tag_name")]
-    public string? TagName { get; set; }
+    [JsonPropertyName("version")]
+    public string? Version { get; set; }
 
-    [JsonPropertyName("name")]
-    public string? Name { get; set; }
+    [JsonPropertyName("channel")]
+    public string? Channel { get; set; }
 
-    [JsonPropertyName("html_url")]
-    public string? HtmlUrl { get; set; }
-
-    [JsonPropertyName("published_at")]
+    [JsonPropertyName("publishedAt")]
     public string? PublishedAt { get; set; }
 
+    [JsonPropertyName("source")]
+    public ZeusDownloadSource? Source { get; set; }
+
     [JsonPropertyName("assets")]
-    public List<GitHubReleaseAsset> Assets { get; set; } = [];
+    public List<ZeusDownloadAsset> Assets { get; set; } = [];
 }
 
-internal sealed class GitHubReleaseAsset
+internal sealed class ZeusDownloadSource
 {
-    [JsonPropertyName("name")]
-    public string Name { get; set; } = string.Empty;
+    [JsonPropertyName("branch")]
+    public string? Branch { get; set; }
 
-    [JsonPropertyName("browser_download_url")]
-    public string? BrowserDownloadUrl { get; set; }
+    [JsonPropertyName("commit")]
+    public string? Commit { get; set; }
+
+    [JsonPropertyName("runUrl")]
+    public string? RunUrl { get; set; }
+}
+
+internal sealed class ZeusDownloadAsset
+{
+    [JsonPropertyName("filename")]
+    public string Filename { get; set; } = string.Empty;
+
+    [JsonPropertyName("url")]
+    public string? Url { get; set; }
 
     [JsonPropertyName("size")]
     public long Size { get; set; }
 
-    [JsonPropertyName("digest")]
-    public string? Digest { get; set; }
+    [JsonPropertyName("sha256")]
+    public string? Sha256 { get; set; }
+
+    [JsonPropertyName("platform")]
+    public string? Platform { get; set; }
+
+    [JsonPropertyName("arch")]
+    public string? Arch { get; set; }
+
+    [JsonPropertyName("kind")]
+    public string? Kind { get; set; }
+
+    [JsonPropertyName("mode")]
+    public string? Mode { get; set; }
+
+    [JsonPropertyName("label")]
+    public string? Label { get; set; }
 }

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -84,22 +84,14 @@ public static class ZeusEndpoints
                 return Results.Ok(saved);
             });
 
-        // Self-update status. Git checkouts report upstream fast-forward state;
-        // packaged builds report the latest GitHub Release asset for this
-        // platform. POST is git-checkout-only and fast-forwards source; packaged
-        // installs download their installer/DMG/AppImage from the GET response.
+        // Self-update status. The latest PRODUCTION build is read from the Zeus
+        // download domain (downloads.openhpsdrzeus.com), which is published from
+        // `main` only — never develop/nightly. The GET response carries the
+        // platform-matched installer/DMG/AppImage/tarball URL + its SHA-256; the
+        // app opens that download. Zeus never pulls/rebuilds/restarts itself.
         app.MapGet("/api/system/update",
             async (RepoUpdateService updates, bool? fetch, CancellationToken ct) =>
                 Results.Ok(await updates.GetStatusAsync(fetch ?? true, ct)));
-
-        app.MapPost("/api/system/update/pull",
-            async (RepoUpdateService updates, CancellationToken ct) =>
-            {
-                var result = await updates.PullAsync(ct);
-                log.LogInformation("api.system.update.pull ok={Ok} newSha={Sha} msg={Msg}",
-                    result.Ok, result.NewSha, result.Message);
-                return Results.Ok(result);
-            });
 
         // Native RX audio (miniaudio) — desktop-mode mute control. The
         // Mute/Unmute button in the Photino window POSTs here to silence

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -354,13 +354,13 @@ public static class ZeusHost
         // Localhost proxy to the HamClock sidecar's propagation engine. The first
         // P.533-14 prediction for a cold path can take ~20 s upstream; allow for it.
         builder.Services.AddHttpClient("Propagation", c => c.Timeout = TimeSpan.FromSeconds(25));
-        // Public GitHub release metadata for packaged-app update checks.
+        // Production download manifest (downloads.openhpsdrzeus.com) for in-app
+        // update checks. Plain JSON — no GitHub API headers.
         builder.Services.AddHttpClient("ZeusUpdates", c =>
         {
             c.Timeout = TimeSpan.FromSeconds(15);
             c.DefaultRequestHeaders.UserAgent.ParseAdd("OpenHPSDR-Zeus-Updater/1.0");
-            c.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
-            c.DefaultRequestHeaders.Add("X-GitHub-Api-Version", "2022-11-28");
+            c.DefaultRequestHeaders.Accept.ParseAdd("application/json");
         });
         builder.Services.AddSingleton<CredentialStore>();
         builder.Services.AddSingleton<BandMemoryStore>();

--- a/tests/Zeus.Server.Tests/RepoUpdateServiceTests.cs
+++ b/tests/Zeus.Server.Tests/RepoUpdateServiceTests.cs
@@ -22,6 +22,26 @@ public class RepoUpdateServiceTests
     }
 
     [Theory]
+    // Identical build string → nothing to do.
+    [InlineData("0.9.1-main.20260620.abc1234", "0.9.1-main.20260620.abc1234", false)]
+    // Same numeric prefix, different rolling-build suffix → newer build available.
+    [InlineData("0.9.1-main.20260620.abc1234", "0.9.1-main.20260621.def5678", true)]
+    // A plain local/dev build vs the published main build of the same prefix.
+    [InlineData("0.9.1-dev", "0.9.1-main.20260621.def5678", true)]
+    // Strictly newer numeric prefix.
+    [InlineData("0.9.1-main.20260620.abc1234", "0.10.0-main.20260701.aaa0001", true)]
+    // Local build ahead of the published line → not an update.
+    [InlineData("0.10.0-main.20260701.aaa0001", "0.9.1-main.20260620.abc1234", false)]
+    // Unknown installed version → offer whatever is published.
+    [InlineData("unknown", "0.9.1-main.20260620.abc1234", true)]
+    // Empty manifest version → never an update.
+    [InlineData("0.9.1-main.20260620.abc1234", "", false)]
+    public void IsManifestNewer_HandlesRollingMainBuilds(string installed, string latest, bool expected)
+    {
+        Assert.Equal(expected, RepoUpdateService.IsManifestNewer(installed, latest));
+    }
+
+    [Theory]
     [InlineData("windows", Architecture.X64, false, false, "openhpsdr-zeus-0.9.1-win-x64-setup.exe")]
     [InlineData("windows", Architecture.Arm64, false, false, "openhpsdr-zeus-0.9.1-win-arm64-setup.exe")]
     [InlineData("macos", Architecture.Arm64, false, false, "OpenhpsdrZeus-0.9.1-macos-arm64.dmg")]
@@ -29,46 +49,67 @@ public class RepoUpdateServiceTests
     [InlineData("linux", Architecture.Arm64, false, false, "openhpsdr-zeus-0.9.1-linux-arm64.tar.gz")]
     [InlineData("linux", Architecture.X64, true, false, "OpenhpsdrZeus-0.9.1-linux-x86_64.AppImage")]
     [InlineData("linux", Architecture.X64, true, true, "OpenhpsdrZeus-Server-0.9.1-linux-x86_64.AppImage")]
-    public void SelectReleaseAsset_PicksPlatformAsset(
+    public void SelectDownloadAsset_PicksPlatformAsset(
         string platform,
         Architecture architecture,
         bool appImage,
         bool serverMode,
         string expected)
     {
-        var asset = RepoUpdateService.SelectReleaseAsset(
-            ReleaseAssets(),
+        var asset = RepoUpdateService.SelectDownloadAsset(
+            DownloadAssets(),
             platform,
             architecture,
             appImage,
             serverMode);
 
         Assert.NotNull(asset);
-        Assert.Equal(expected, asset.Name);
+        Assert.Equal(expected, asset.Filename);
     }
 
     [Fact]
-    public void SelectReleaseAsset_FallsBackToTarballWhenArm64AppImageIsMissing()
+    public void SelectDownloadAsset_FallsBackToTarballWhenArm64AppImageIsMissing()
     {
-        var asset = RepoUpdateService.SelectReleaseAsset(
-            ReleaseAssets(),
+        var asset = RepoUpdateService.SelectDownloadAsset(
+            DownloadAssets(),
             "linux",
             Architecture.Arm64,
             runningFromAppImage: true,
             serverMode: false);
 
         Assert.NotNull(asset);
-        Assert.Equal("openhpsdr-zeus-0.9.1-linux-arm64.tar.gz", asset.Name);
+        Assert.Equal("openhpsdr-zeus-0.9.1-linux-arm64.tar.gz", asset.Filename);
     }
 
-    private static List<GitHubReleaseAsset> ReleaseAssets() => new()
+    [Fact]
+    public void SelectDownloadAsset_ReturnsNullWhenPlatformMissing()
     {
-        new() { Name = "openhpsdr-zeus-0.9.1-linux-arm64.tar.gz" },
-        new() { Name = "openhpsdr-zeus-0.9.1-linux-x64.tar.gz" },
-        new() { Name = "openhpsdr-zeus-0.9.1-win-arm64-setup.exe" },
-        new() { Name = "openhpsdr-zeus-0.9.1-win-x64-setup.exe" },
-        new() { Name = "OpenhpsdrZeus-0.9.1-linux-x86_64.AppImage" },
-        new() { Name = "OpenhpsdrZeus-0.9.1-macos-arm64.dmg" },
-        new() { Name = "OpenhpsdrZeus-Server-0.9.1-linux-x86_64.AppImage" },
+        var asset = RepoUpdateService.SelectDownloadAsset(
+            DownloadAssets(),
+            "windows",
+            Architecture.X64,
+            runningFromAppImage: false,
+            serverMode: false);
+        Assert.NotNull(asset);
+
+        var none = RepoUpdateService.SelectDownloadAsset(
+            new List<ZeusDownloadAsset>(),
+            "windows",
+            Architecture.X64,
+            runningFromAppImage: false,
+            serverMode: false);
+        Assert.Null(none);
+    }
+
+    // Mirrors the asset shape produced by tools/update-download-manifest.mjs.
+    private static List<ZeusDownloadAsset> DownloadAssets() => new()
+    {
+        new() { Filename = "openhpsdr-zeus-0.9.1-win-x64-setup.exe", Platform = "windows", Arch = "x64", Kind = "installer" },
+        new() { Filename = "openhpsdr-zeus-0.9.1-win-arm64-setup.exe", Platform = "windows", Arch = "arm64", Kind = "installer" },
+        new() { Filename = "OpenhpsdrZeus-0.9.1-macos-arm64.dmg", Platform = "macos", Arch = "arm64", Kind = "dmg" },
+        new() { Filename = "openhpsdr-zeus-0.9.1-linux-x64.tar.gz", Platform = "linux", Arch = "x64", Kind = "tarball" },
+        new() { Filename = "openhpsdr-zeus-0.9.1-linux-arm64.tar.gz", Platform = "linux", Arch = "arm64", Kind = "tarball" },
+        new() { Filename = "OpenhpsdrZeus-0.9.1-linux-x86_64.AppImage", Platform = "linux", Arch = "x64", Kind = "appimage", Mode = "desktop" },
+        new() { Filename = "OpenhpsdrZeus-Server-0.9.1-linux-x86_64.AppImage", Platform = "linux", Arch = "x64", Kind = "appimage", Mode = "server" },
     };
 }

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -260,9 +260,10 @@ export default function App() {
     const ctrl = new AbortController();
     fetchUpdateStatus(true, ctrl.signal)
       .then((next) => {
+        // A newer production build (from the download domain) is available and
+        // we have somewhere to send the operator — prompt on startup.
         const actionableRelease =
-          !next.isGitRepo
-          && next.updateAvailable
+          next.updateAvailable
           && (next.updateAction === 'download' || next.updateAction === 'openRelease');
         if (actionableRelease) setStartupUpdate(next);
       })

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -4985,10 +4985,10 @@ export function restartApp(
   );
 }
 
-export type UpdateAction = 'none' | 'pull' | 'download' | 'openRelease';
+export type UpdateAction = 'none' | 'download' | 'openRelease';
 
-/** Status of the local install vs its configured update source
- *  (GET /api/system/update). Mirrors Zeus.Contracts.RepoUpdateStatus. */
+/** Status of the local install vs the latest production build on the download
+ *  domain (GET /api/system/update). Mirrors Zeus.Contracts.RepoUpdateStatus. */
 export interface RepoUpdateStatus {
   isGitRepo: boolean;
   branch: string | null;
@@ -5021,16 +5021,8 @@ export interface RepoUpdateStatus {
   releaseAssetDigest: string | null;
 }
 
-/** Result of POST /api/system/update/pull. Mirrors Zeus.Contracts.RepoUpdateResult. */
-export interface RepoUpdateResult {
-  ok: boolean;
-  newSha: string | null;
-  requiresRebuild: boolean;
-  message: string;
-}
-
-/** Check how far the running checkout is behind upstream. `fetch=false` skips
- *  the network and reports the last-known counts. */
+/** Read the latest production build vs the installed version. `fetch=false`
+ *  skips the network and reports the last-known local version. */
 export function fetchUpdateStatus(
   fetch = true,
   signal?: AbortSignal,
@@ -5039,16 +5031,6 @@ export function fetchUpdateStatus(
     `/api/system/update?fetch=${fetch ? 'true' : 'false'}`,
     { signal },
     (raw) => raw as RepoUpdateStatus,
-  );
-}
-
-/** Fast-forward the checkout to upstream. Source only — a rebuild + restart is
- *  still required (result.requiresRebuild). */
-export function pullUpdate(signal?: AbortSignal): Promise<RepoUpdateResult> {
-  return jsonFetch(
-    '/api/system/update/pull',
-    { method: 'POST', signal },
-    (raw) => raw as RepoUpdateResult,
   );
 }
 

--- a/zeus-web/src/components/UpdatesPanel.tsx
+++ b/zeus-web/src/components/UpdatesPanel.tsx
@@ -7,17 +7,14 @@
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
-// UpdatesPanel — Settings -> Updates. Git checkouts can fast-forward their
-// configured upstream. Packaged builds check GitHub Releases and open the
-// matching installer / DMG / AppImage asset for this platform.
+// UpdatesPanel — Settings -> Updates. Reports the latest PRODUCTION build from
+// the Zeus download domain (downloads.openhpsdrzeus.com, published from `main`
+// only) and opens the matching installer / DMG / AppImage / tarball for this
+// platform. Source checkouts see the same domain status; they update their
+// source manually with scripts/update.*.
 
 import { useCallback, useEffect, useState, type CSSProperties, type ReactNode } from 'react';
-import {
-  fetchUpdateStatus,
-  pullUpdate,
-  type RepoUpdateStatus,
-  type RepoUpdateResult,
-} from '../api/client';
+import { fetchUpdateStatus, type RepoUpdateStatus } from '../api/client';
 
 const labelStyle: CSSProperties = { fontSize: 11, fontWeight: 600, letterSpacing: '0.06em', color: 'var(--fg-2)' };
 const valueStyle: CSSProperties = { fontSize: 12, color: 'var(--fg-1)', fontFamily: 'monospace' };
@@ -54,17 +51,14 @@ function openExternal(url: string | null | undefined) {
   window.open(url, '_blank', 'noopener,noreferrer');
 }
 
-function statusLabel(status: RepoUpdateStatus, updateAvailable: boolean): string {
-  if (updateAvailable && !status.isGitRepo && status.latestVersion) {
+function statusLabel(status: RepoUpdateStatus): string {
+  if (status.updateAvailable && status.latestVersion) {
     return `Version ${status.latestVersion} available`;
   }
-  if (status.isGitRepo && status.behind > 0) {
-    return `${status.behind} update${status.behind === 1 ? '' : 's'} available`;
-  }
-  if (!status.isGitRepo && !status.latestVersion && !status.error) {
+  if (!status.latestVersion && !status.error) {
     return 'Checking releases';
   }
-  if (!status.error && (!status.isGitRepo || status.behind === 0)) {
+  if (!status.error) {
     return 'Up to date';
   }
   return 'Status unknown';
@@ -73,8 +67,7 @@ function statusLabel(status: RepoUpdateStatus, updateAvailable: boolean): string
 export function UpdatesPanel() {
   const [status, setStatus] = useState<RepoUpdateStatus | null>(null);
   const [checking, setChecking] = useState(false);
-  const [pulling, setPulling] = useState(false);
-  const [result, setResult] = useState<RepoUpdateResult | null>(null);
+  const [result, setResult] = useState<string | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
 
   const check = useCallback(async (fetch: boolean) => {
@@ -90,7 +83,7 @@ export function UpdatesPanel() {
   }, []);
 
   // Quick local-only read on mount (no network), then a fetch in the background
-  // so the panel paints instantly but still reflects the real upstream/release state.
+  // so the panel paints instantly but still reflects the real release state.
   useEffect(() => {
     void (async () => {
       await check(false);
@@ -98,53 +91,22 @@ export function UpdatesPanel() {
     })();
   }, [check]);
 
-  const doPull = async () => {
-    setPulling(true);
-    setResult(null);
-    try {
-      const r = await pullUpdate();
-      setResult(r);
-      await check(false);
-    } catch (err) {
-      setResult({
-        ok: false,
-        newSha: null,
-        requiresRebuild: false,
-        message: err instanceof Error ? err.message : 'Update failed',
-      });
-    } finally {
-      setPulling(false);
-    }
-  };
-
-  const doUpdate = async () => {
+  const doUpdate = () => {
     if (!status) return;
-    const action = status.updateAction ?? (status.canFastForward ? 'pull' : 'none');
-    if (action === 'pull') {
-      await doPull();
-      return;
-    }
-
     const url = status.releaseDownloadUrl ?? status.releaseUrl;
     openExternal(url);
-    setResult({
-      ok: Boolean(url),
-      newSha: null,
-      requiresRebuild: false,
-      message: url
+    setResult(
+      url
         ? status.releaseDownloadUrl
           ? `Opened ${status.releaseAssetName ?? 'the latest Zeus download'}.`
-          : 'Opened the latest Zeus release page.'
-        : 'No release download is available for this platform.',
-    });
+          : 'Opened the Zeus downloads page.'
+        : 'No download is available for this platform.',
+    );
   };
 
-  const action = status?.updateAction ?? (status?.canFastForward ? 'pull' : 'none');
-  const updateAvailable = status?.updateAvailable ?? (status?.isGitRepo ? status.behind > 0 : false);
-  const canUpdate = status != null
-    && (action === 'pull'
-      ? status.canFastForward
-      : action === 'download' || action === 'openRelease');
+  const action = status?.updateAction ?? 'none';
+  const updateAvailable = status?.updateAvailable ?? false;
+  const canUpdate = action === 'download' || action === 'openRelease';
   const assetSize = fmtBytes(status?.releaseAssetSizeBytes ?? null);
 
   return (
@@ -168,48 +130,36 @@ export function UpdatesPanel() {
 
       {status && (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-          {status.isGitRepo ? (
-            <section style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-              <Row label="Branch">{status.branch ?? '-'}</Row>
-              <Row label="Installed">
-                {status.currentShortSha ?? '-'}
-                {status.currentSubject ? (
-                  <span style={{ color: 'var(--fg-3)', fontFamily: 'inherit' }}> - {status.currentSubject}</span>
-                ) : null}
+          <section style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <Row label="Installed">{status.installedVersion ?? 'unknown'}</Row>
+            <Row label="Latest">{status.latestVersion ?? (checking ? 'checking...' : '-')}</Row>
+            <Row label="Platform">
+              {(status.runtimePlatform ?? 'unknown')}/{status.runtimeArchitecture ?? 'unknown'}
+            </Row>
+            {status.releaseUrl && (
+              <Row label="Release">
+                <a href={status.releaseUrl} target="_blank" rel="noreferrer" style={linkStyle}>
+                  {status.releaseName ?? 'openhpsdrzeus.com'}
+                </a>
               </Row>
-              <Row label="Upstream">{status.upstreamRef ?? '-'}</Row>
-              {status.latestRemoteSha && (
-                <Row label="Available">
-                  {status.latestRemoteSha}
-                  {status.latestRemoteSubject ? (
-                    <span style={{ color: 'var(--fg-3)', fontFamily: 'inherit' }}> - {status.latestRemoteSubject}</span>
-                  ) : null}
-                </Row>
-              )}
-            </section>
-          ) : (
-            <section style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-              <Row label="Installed">{status.installedVersion ?? 'unknown'}</Row>
-              <Row label="Latest">{status.latestVersion ?? (checking ? 'checking...' : '-')}</Row>
-              <Row label="Platform">
-                {(status.runtimePlatform ?? 'unknown')}/{status.runtimeArchitecture ?? 'unknown'}
+            )}
+            {status.releaseAssetName && (
+              <Row label="Download">
+                {status.releaseAssetName}
+                {assetSize && (
+                  <span style={{ color: 'var(--fg-3)', fontFamily: 'inherit' }}> - {assetSize}</span>
+                )}
               </Row>
-              {status.releaseUrl && (
-                <Row label="Release">
-                  <a href={status.releaseUrl} target="_blank" rel="noreferrer" style={linkStyle}>
-                    {status.releaseName ?? status.releaseTag ?? 'GitHub Releases'}
-                  </a>
-                </Row>
-              )}
-              {status.releaseAssetName && (
-                <Row label="Download">
-                  {status.releaseAssetName}
-                  {assetSize && (
-                    <span style={{ color: 'var(--fg-3)', fontFamily: 'inherit' }}> - {assetSize}</span>
-                  )}
-                </Row>
-              )}
-            </section>
+            )}
+          </section>
+
+          {status.isGitRepo && (
+            <div style={hintStyle}>
+              Running from source{status.branch ? ` — ${status.branch}` : ''}
+              {status.currentShortSha ? ` @ ${status.currentShortSha}` : ''}. Update the source
+              with <code>scripts/update.ps1</code> (Windows) or <code>scripts/update.sh</code>{' '}
+              (macOS/Linux), then restart Zeus.
+            </div>
           )}
 
           <section
@@ -230,21 +180,13 @@ export function UpdatesPanel() {
                 color: updateAvailable ? 'var(--power)' : 'var(--fg-1)',
               }}
             >
-              {statusLabel(status, updateAvailable)}
+              {statusLabel(status)}
             </span>
-            {status.isGitRepo && status.ahead > 0 && (
-              <span style={hintStyle}>- {status.ahead} local commit{status.ahead === 1 ? '' : 's'} ahead</span>
-            )}
             {status.checkedUtc && (
               <span style={{ ...hintStyle, marginLeft: 'auto' }}>checked {fmtChecked(status.checkedUtc)}</span>
             )}
           </section>
 
-          {status.dirty && (
-            <div style={{ fontSize: 11, color: 'var(--tx)' }}>
-              Working tree has uncommitted changes. Commit or stash them before updating.
-            </div>
-          )}
           {status.error && (
             <div style={{ fontSize: 11, color: 'var(--tx)' }}>{status.error}</div>
           )}
@@ -253,7 +195,7 @@ export function UpdatesPanel() {
             <button
               type="button"
               className="btn sm"
-              disabled={checking || pulling}
+              disabled={checking}
               onClick={() => void check(true)}
             >
               {checking ? 'CHECKING...' : 'CHECK FOR UPDATES'}
@@ -261,51 +203,27 @@ export function UpdatesPanel() {
             <button
               type="button"
               className="btn sm active"
-              disabled={!canUpdate || pulling || checking}
-              onClick={() => void doUpdate()}
+              disabled={!canUpdate || checking}
+              onClick={() => doUpdate()}
               title={
-                action === 'pull'
-                  ? status.canFastForward
-                    ? 'Fast-forward the checkout to the latest upstream commit'
-                    : status.dirty
-                      ? 'Commit or stash local changes first'
-                      : status.behind === 0
-                        ? 'Already up to date'
-                        : 'Cannot fast-forward; local commits diverge from upstream'
-                  : action === 'download'
-                    ? 'Open the latest Zeus download for this platform'
-                    : action === 'openRelease'
-                      ? 'Open the latest Zeus release page'
-                      : 'Already up to date'
+                action === 'download'
+                  ? 'Open the latest Zeus download for this platform'
+                  : action === 'openRelease'
+                    ? 'Open the Zeus downloads page'
+                    : 'Already up to date'
               }
             >
-              {pulling ? 'UPDATING...' : 'UPDATE NOW'}
+              UPDATE NOW
             </button>
           </div>
 
           {result && (
-            <div
-              style={{
-                fontSize: 12,
-                color: result.ok ? 'var(--fg-1)' : 'var(--tx)',
-                lineHeight: 1.5,
-              }}
-            >
-              {result.message}
-              {result.requiresRebuild && (
-                <div style={{ ...hintStyle, marginTop: 6 }}>
-                  Source updated. The running app is still on the old build. Rebuild and restart
-                  Zeus to apply: run <code>scripts/update.ps1</code> on Windows or{' '}
-                  <code>scripts/update.sh</code> on macOS/Linux, then relaunch.
-                </div>
-              )}
-            </div>
+            <div style={{ fontSize: 12, color: 'var(--fg-1)', lineHeight: 1.5 }}>{result}</div>
           )}
 
           <div style={hintStyle}>
-            {status.isGitRepo
-              ? 'Update now fast-forwards your checkout. Rebuild and restart Zeus to run the new source.'
-              : 'Update now opens the latest installer or package for this platform. Run the downloaded update and restart Zeus to apply it.'}
+            Update now opens the latest installer or package for this platform. Run the downloaded
+            update and restart Zeus to apply it.
           </div>
         </div>
       )}


### PR DESCRIPTION
## What

Reworks Settings → Updates so the in-app updater sources **only production builds from the download domain** (`downloads.openhpsdrzeus.com`), and removes the git fast-forward-of-`develop` path entirely.

### Before
- Git checkouts tracked their upstream branch (**`develop`** in this project) and offered `git pull --ff-only` as "the update" — i.e. the updater pulled dev code.
- Packaged builds checked the GitHub Releases API.
- Neither path used the domain manifest that `publish-downloads.yml` already publishes.

### After
- Single source of truth: `downloads.openhpsdrzeus.com/latest.json` — the `main`-only manifest produced by `publish-downloads.yml` + `tools/update-download-manifest.mjs` (per-asset `sha256`, size, url, platform/arch/kind, source commit).
- New-vs-installed decision uses the build **hash/suffix** (`IsManifestNewer`): rolling `main` builds share a numeric `VersionPrefix` and differ only by `main.<date>.<sha>`, so a numeric-prefix compare can't see a new build.
- A newer build → startup prompt (`StartupUpdatePrompt`); otherwise it sits in Settings → Updates. "Update now" opens the platform-matched installer/DMG/AppImage/tarball.
- `develop` is never offered. Source checkouts get a read-only "running from source — use `scripts/update.*`" note.
- Removed `POST /api/system/update/pull`, `PullAsync`, `RepoUpdateResult`, and the GitHub-releases path.

## Tests
- Backend `RepoUpdateServiceTests`: **21/21** (new `IsManifestNewer` + `SelectDownloadAsset` coverage).
- Web unit tests: **878/878**. `tsc --noEmit` clean. Full `Zeus.slnx` + frontend build green.

## Notes
- `RepoUpdateStatus` wire shape is unchanged (git-diagnostic fields kept, now always 0/null) to avoid a Contracts wire-format break.
- Manifest URL overridable via `ZEUS_UPDATE_MANIFEST_URL` for staging/tests.

Target: develop