### PR TITLE
fix(chat): closable DM tabs + roster icon spacing

### DIFF
--- a/zeus-web/src/layout/panels/ChatPanel.tsx
+++ b/zeus-web/src/layout/panels/ChatPanel.tsx
@@ -314,97 +314,112 @@ function RosterRow({
       <div style={{ minWidth: 0, flex: 1 }}>
         <CallsignButton callsign={op.callsign} onOpen={onOpen} prominent />
       </div>
-      {/* DM button — appears on hover */}
-      {hovered && (
-        <button
-          type="button"
-          onClick={() => onDm(op.callsign)}
-          title={`Message ${op.callsign}`}
-          aria-label={`Start DM with ${op.callsign}`}
-          style={{
-            flexShrink: 0,
-            background: 'none',
-            border: 'none',
-            padding: '0 2px',
-            cursor: 'pointer',
-            fontSize: 11,
-            lineHeight: 1,
-            color: 'var(--accent-bright)',
-            opacity: 0.8,
-          }}
-        >
-          {/* Inline chat bubble SVG */}
-          <svg
-            width="13"
-            height="13"
-            viewBox="0 0 16 16"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            aria-hidden="true"
-          >
-            <path
-              d="M2 2h12a1 1 0 0 1 1 1v8a1 1 0 0 1-1 1H5l-3 3V3a1 1 0 0 1 1-1z"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinejoin="round"
-            />
-          </svg>
-        </button>
-      )}
-      {/* Admin ban button — subtle, appears on hover */}
-      {isAdmin && hovered && (
-        <button
-          type="button"
-          onClick={() => onBan(op.callsign)}
-          title={`Ban ${op.callsign}`}
-          aria-label={`Ban ${op.callsign}`}
-          style={{
-            flexShrink: 0,
-            background: 'none',
-            border: 'none',
-            padding: '0 2px',
-            cursor: 'pointer',
-            fontSize: 11,
-            lineHeight: 1,
-            color: 'var(--tx)',
-            opacity: 0.6,
-          }}
-        >
-          <svg
-            width="12"
-            height="12"
-            viewBox="0 0 16 16"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            aria-hidden="true"
-          >
-            <circle cx="8" cy="8" r="6.5" stroke="currentColor" strokeWidth="1.5" />
-            <line x1="3" y1="13" x2="13" y2="3" stroke="currentColor" strokeWidth="1.5" />
-          </svg>
-        </button>
-      )}
-      {/* Star control */}
-      <button
-        type="button"
-        onClick={() => onStar(op.callsign)}
-        title={star.title}
-        aria-label={`${star.title} — ${op.callsign}`}
-        aria-pressed={relation === 'friend'}
+      {/* Action icons — grouped + spaced away from the callsign */}
+      <div
         style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
           flexShrink: 0,
-          background: 'none',
-          border: 'none',
-          padding: '0 2px',
-          cursor: 'pointer',
-          fontSize: 12,
-          lineHeight: 1,
-          color: star.color,
-          opacity: starVisible ? 1 : 0,
-          transition: 'opacity var(--dur-fast) var(--ease-out)',
+          marginLeft: 8,
         }}
       >
-        {star.glyph}
-      </button>
+        {/* DM button — appears on hover */}
+        {hovered && (
+          <button
+            type="button"
+            onClick={() => onDm(op.callsign)}
+            title={`Message ${op.callsign}`}
+            aria-label={`Start DM with ${op.callsign}`}
+            style={{
+              flexShrink: 0,
+              display: 'flex',
+              alignItems: 'center',
+              background: 'none',
+              border: 'none',
+              padding: 0,
+              cursor: 'pointer',
+              lineHeight: 1,
+              color: 'var(--accent-bright)',
+              opacity: 0.8,
+            }}
+          >
+            {/* Inline chat bubble SVG */}
+            <svg
+              width="13"
+              height="13"
+              viewBox="0 0 16 16"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+            >
+              <path
+                d="M2 2h12a1 1 0 0 1 1 1v8a1 1 0 0 1-1 1H5l-3 3V3a1 1 0 0 1 1-1z"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        )}
+        {/* Admin ban button — subtle, appears on hover */}
+        {isAdmin && hovered && (
+          <button
+            type="button"
+            onClick={() => onBan(op.callsign)}
+            title={`Ban ${op.callsign}`}
+            aria-label={`Ban ${op.callsign}`}
+            style={{
+              flexShrink: 0,
+              display: 'flex',
+              alignItems: 'center',
+              background: 'none',
+              border: 'none',
+              padding: 0,
+              cursor: 'pointer',
+              lineHeight: 1,
+              color: 'var(--tx)',
+              opacity: 0.6,
+            }}
+          >
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 16 16"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+            >
+              <circle cx="8" cy="8" r="6.5" stroke="currentColor" strokeWidth="1.5" />
+              <line x1="3" y1="13" x2="13" y2="3" stroke="currentColor" strokeWidth="1.5" />
+            </svg>
+          </button>
+        )}
+        {/* Star control */}
+        <button
+          type="button"
+          onClick={() => onStar(op.callsign)}
+          title={star.title}
+          aria-label={`${star.title} — ${op.callsign}`}
+          aria-pressed={relation === 'friend'}
+          style={{
+            flexShrink: 0,
+            display: 'flex',
+            alignItems: 'center',
+            background: 'none',
+            border: 'none',
+            padding: 0,
+            cursor: 'pointer',
+            fontSize: 12,
+            lineHeight: 1,
+            color: star.color,
+            opacity: starVisible ? 1 : 0,
+            transition: 'opacity var(--dur-fast) var(--ease-out)',
+          }}
+        >
+          {star.glyph}
+        </button>
+      </div>
     </div>
   );
 }
@@ -981,6 +996,8 @@ export function ChatPanel() {
   const loadFriends = useChatStore((s) => s.loadFriends);
   const setActiveRoom = useChatStore((s) => s.setActiveRoom);
   const openDm = useChatStore((s) => s.openDm);
+  const closeDm = useChatStore((s) => s.closeDm);
+  const hiddenDms = useChatStore((s) => s.hiddenDms);
   const setFreqVisibility = useChatStore((s) => s.setFreqVisibility);
   const requestFriend = useChatStore((s) => s.requestFriend);
   const acceptFriend = useChatStore((s) => s.acceptFriend);
@@ -1083,11 +1100,12 @@ export function ChatPanel() {
 
   // Tab ordering: public first, then groups, then DMs
   const orderedRooms = useMemo(() => {
+    const hidden = new Set(hiddenDms);
     const pub = rooms.filter((r) => r.kind === 'public');
     const grp = rooms.filter((r) => r.kind === 'group');
-    const dms = rooms.filter((r) => r.kind === 'dm');
+    const dms = rooms.filter((r) => r.kind === 'dm' && !hidden.has(r.id));
     return [...pub, ...grp, ...dms];
-  }, [rooms]);
+  }, [rooms, hiddenDms]);
 
   const activeRoomObj = useMemo(
     () => rooms.find((r) => r.id === activeRoom) ?? null,
@@ -1131,13 +1149,8 @@ export function ChatPanel() {
     return { color: 'var(--power)', bg: 'var(--power-soft)', label: 'Connecting…' };
   })();
 
-  // Handle DM tab close: just navigate back to public
-  const handleTabClose = useCallback(
-    (id: string) => {
-      if (activeRoom === id) setActiveRoom(PUBLIC_ROOM);
-    },
-    [activeRoom, setActiveRoom],
-  );
+  // Close (hide) a DM tab; a new message or reopening brings it back.
+  const handleTabClose = useCallback((id: string) => closeDm(id), [closeDm]);
 
   // Admin: create group room
   const handleCreateRoom = () => setCreatingRoom(true);

--- a/zeus-web/src/state/chat-store.ts
+++ b/zeus-web/src/state/chat-store.ts
@@ -104,6 +104,9 @@ export type ChatStoreState = {
   activeRoom: string;
   messagesByRoom: Record<string, ChatMessage[]>;
   unreadByRoom: Record<string, number>;
+  // DM room ids the operator has closed (hidden from the tab bar until a new
+  // message arrives or they reopen the DM). Session-local.
+  hiddenDms: string[];
 
   // Friend graph (consent gate for seeing freq).
   acceptedFriends: string[];
@@ -119,6 +122,7 @@ export type ChatStoreState = {
   loadFriends: () => Promise<void>;
   setActiveRoom: (room: string) => void;
   openDm: (callsign: string) => void;
+  closeDm: (room: string) => void;
   requestRoomHistory: (room: string) => Promise<void>;
   setFreqVisibility: (isPublic: boolean) => Promise<void>;
   requestFriend: (callsign: string) => Promise<void>;
@@ -189,6 +193,7 @@ export const useChatStore = create<ChatStoreState>((set, get) => ({
   activeRoom: PUBLIC_ROOM,
   messagesByRoom: {},
   unreadByRoom: {},
+  hiddenDms: [],
   acceptedFriends: [],
   incomingRequests: [],
   outgoingRequests: [],
@@ -277,9 +282,21 @@ export const useChatStore = create<ChatStoreState>((set, get) => ({
       const rooms = exists
         ? s.rooms
         : [...s.rooms, { id, name: callsign.toUpperCase(), kind: 'dm' as const, members: [me, callsign.toUpperCase()].filter(Boolean) }];
-      return { rooms, activeRoom: id, unreadByRoom: { ...s.unreadByRoom, [id]: 0 } };
+      return {
+        rooms,
+        activeRoom: id,
+        unreadByRoom: { ...s.unreadByRoom, [id]: 0 },
+        hiddenDms: s.hiddenDms.filter((x) => x !== id), // reopening un-hides
+      };
     });
     if (get().messagesByRoom[id] === undefined) void get().requestRoomHistory(id);
+  },
+
+  closeDm: (room) => {
+    set((s) => ({
+      hiddenDms: s.hiddenDms.includes(room) ? s.hiddenDms : [...s.hiddenDms, room],
+      activeRoom: s.activeRoom === room ? PUBLIC_ROOM : s.activeRoom,
+    }));
   },
 
   requestRoomHistory: async (room) => {
@@ -359,6 +376,8 @@ export const useChatStore = create<ChatStoreState>((set, get) => ({
             unreadByRoom: bump
               ? { ...s.unreadByRoom, [room]: (s.unreadByRoom[room] ?? 0) + 1 }
               : s.unreadByRoom,
+            // A new message in a closed DM brings its tab back.
+            hiddenDms: s.hiddenDms.includes(room) ? s.hiddenDms.filter((x) => x !== room) : s.hiddenDms,
           };
         });
         return;


### PR DESCRIPTION
Follow-up chat-panel polish (on top of #750).

- **DM tab close** — the × on a DM tab now actually hides the tab. Previously it only navigated back to Public, so the tab reappeared (the DM room comes from the relay's room list). Added `closeDm` + a session-local `hiddenDms` set in the store; the tab bar filters hidden DMs out. A new message in a closed DM — or reopening it from the roster — brings the tab back.
- **Roster icon spacing** — the DM / ban / star action icons are now grouped in their own flex container with a left margin and consistent gap, so the DM bubble no longer crowds the callsign.

Frontend-only. `tsc -b` + eslint clean.