### PR TITLE
fix(layout): panel-lock inertness, empty category chips, panel sizing

### DIFF
--- a/zeus-web/src/components/TxAudioToolsPanel.tsx
+++ b/zeus-web/src/components/TxAudioToolsPanel.tsx
@@ -170,8 +170,10 @@ function RouteStatusPill({
 
 function selectStyle(disabled: boolean): CSSProperties {
   return {
-    minWidth: 180,
+    flex: '1 1 0',
+    minWidth: 0,
     maxWidth: 280,
+    width: '100%',
     height: 26,
     padding: '3px 8px',
     borderRadius: 4,
@@ -218,6 +220,7 @@ function DeviceSelect({
         display: 'flex',
         alignItems: 'center',
         gap: 6,
+        flex: '1 1 0',
         minWidth: 0,
         color: 'var(--fg-2)',
         fontSize: 10,

--- a/zeus-web/src/components/design/QrzCard.tsx
+++ b/zeus-web/src/components/design/QrzCard.tsx
@@ -293,6 +293,71 @@ export function QrzCard({
 
   return (
     <div className="qrz-card">
+      <div className="qrz-footer">
+        <span className="mono" style={{ color: 'var(--fg-2)', fontSize: 10 }}>
+          {contact.email}
+        </span>
+        <span style={{ flex: 1 }} />
+        {rotConnected && qrzHome?.lat != null && qrzHome?.lon != null
+          && contact.lat != null && contact.lon != null && (() => {
+          const sp = bearingDeg(qrzHome.lat, qrzHome.lon, contact.lat, contact.lon);
+          const lp = (sp + 180) % 360;
+          return (
+            <>
+              <button
+                type="button"
+                onClick={() => { void setRotatorAz(Math.round(sp)); }}
+                className="rc-btn rc-btn--path qrz-footer-rotate-btn"
+                title="Rotate short-path"
+              >
+                SP {fmtBearing(sp)}
+              </button>
+              <button
+                type="button"
+                onClick={() => { void setRotatorAz(Math.round(lp)); }}
+                className="rc-btn rc-btn--path qrz-footer-rotate-btn"
+                title="Rotate long-path"
+              >
+                LP {fmtBearing(lp)}
+              </button>
+            </>
+          );
+        })()}
+        {onClear && canClear && (
+          <button
+            type="button"
+            onClick={onClear}
+            className="rc-btn rc-btn--neutral qrz-footer-rotate-btn"
+          >
+            Clear
+          </button>
+        )}
+        {onLogQso && canLogQso && (
+          <button
+            type="button"
+            onClick={onLogQso}
+            className="rc-btn rc-btn--neutral qrz-footer-rotate-btn"
+          >
+            Log QSO
+          </button>
+        )}
+        {contact.qrzUrl ? (
+          <a
+            className="mono"
+            href={contact.qrzUrl}
+            target="_blank"
+            rel="noreferrer"
+            style={{ color: 'var(--accent)', fontSize: 10, fontWeight: 700, textDecoration: 'none' }}
+          >
+            QRZ.COM ↗
+          </a>
+        ) : (
+          <span className="mono" style={{ color: 'var(--accent)', fontSize: 10, fontWeight: 700 }}>
+            QRZ.COM ✓
+          </span>
+        )}
+      </div>
+
       <div className="qrz-card-main">
         <div className="qrz-info-col">
           <div className="qrz-id">
@@ -413,71 +478,6 @@ export function QrzCard({
           </div>
         </div>
       )}
-
-      <div className="qrz-footer">
-        <span className="mono" style={{ color: 'var(--fg-2)', fontSize: 10 }}>
-          {contact.email}
-        </span>
-        <span style={{ flex: 1 }} />
-        {rotConnected && qrzHome?.lat != null && qrzHome?.lon != null
-          && contact.lat != null && contact.lon != null && (() => {
-          const sp = bearingDeg(qrzHome.lat, qrzHome.lon, contact.lat, contact.lon);
-          const lp = (sp + 180) % 360;
-          return (
-            <>
-              <button
-                type="button"
-                onClick={() => { void setRotatorAz(Math.round(sp)); }}
-                className="rc-btn rc-btn--path qrz-footer-rotate-btn"
-                title="Rotate short-path"
-              >
-                SP {fmtBearing(sp)}
-              </button>
-              <button
-                type="button"
-                onClick={() => { void setRotatorAz(Math.round(lp)); }}
-                className="rc-btn rc-btn--path qrz-footer-rotate-btn"
-                title="Rotate long-path"
-              >
-                LP {fmtBearing(lp)}
-              </button>
-            </>
-          );
-        })()}
-        {onClear && canClear && (
-          <button
-            type="button"
-            onClick={onClear}
-            className="rc-btn rc-btn--neutral qrz-footer-rotate-btn"
-          >
-            Clear
-          </button>
-        )}
-        {onLogQso && canLogQso && (
-          <button
-            type="button"
-            onClick={onLogQso}
-            className="rc-btn rc-btn--neutral qrz-footer-rotate-btn"
-          >
-            Log QSO
-          </button>
-        )}
-        {contact.qrzUrl ? (
-          <a
-            className="mono"
-            href={contact.qrzUrl}
-            target="_blank"
-            rel="noreferrer"
-            style={{ color: 'var(--accent)', fontSize: 10, fontWeight: 700, textDecoration: 'none' }}
-          >
-            QRZ.COM ↗
-          </a>
-        ) : (
-          <span className="mono" style={{ color: 'var(--accent)', fontSize: 10, fontWeight: 700 }}>
-            QRZ.COM ✓
-          </span>
-        )}
-      </div>
     </div>
   );
 }

--- a/zeus-web/src/layout/AddPanelModal.tsx
+++ b/zeus-web/src/layout/AddPanelModal.tsx
@@ -52,7 +52,21 @@ export function AddPanelModal({ existingPanels, onAdd, onClose }: AddPanelModalP
     onClose,
   });
 
-  const availablePanels = getAllPanels().filter((panel) => {
+  const allPanels = getAllPanels();
+
+  // Only surface category chips that actually hold at least one panel. Three
+  // categories (amplifiers / tuners / switches) are defined for future panels
+  // but have no members today — rendering them as chips produced dead filters
+  // that always landed on an empty "No panels match" pane. Derive the rail
+  // from the live registry (plugin panels included) so a category appears the
+  // moment a panel claims it and disappears if it ever empties out. Order
+  // follows PANEL_CATEGORIES.
+  const categoriesWithPanels = new Set(allPanels.map((panel) => panel.category));
+  const visibleCategories = PANEL_CATEGORIES.filter((cat) =>
+    categoriesWithPanels.has(cat),
+  );
+
+  const availablePanels = allPanels.filter((panel) => {
     // Single-instance panels disappear from the list once added; multi-
     // instance panels stay visible (the badge changes to "+ Add another").
     if (existingPanels.has(panel.id) && !panel.multiInstance) return false;
@@ -117,7 +131,7 @@ export function AddPanelModal({ existingPanels, onAdd, onClose }: AddPanelModalP
           >
             All
           </button>
-          {PANEL_CATEGORIES.map((cat) => (
+          {visibleCategories.map((cat) => (
             <button
               key={cat}
               type="button"

--- a/zeus-web/src/layout/__tests__/AddPanelModal.test.tsx
+++ b/zeus-web/src/layout/__tests__/AddPanelModal.test.tsx
@@ -46,7 +46,7 @@ describe('AddPanelModal', () => {
     unmount();
   });
 
-  it('renders the category rail with All + every PanelCategory', () => {
+  it('renders the category rail with All + every non-empty PanelCategory', () => {
     const { container, unmount } = setup();
     const rail = container.querySelector(
       '[data-testid="add-panel-rail"]',
@@ -62,12 +62,52 @@ describe('AddPanelModal', () => {
       'dsp',
       'log',
       'tools',
-      'amplifiers',
       'controls',
     ]) {
       expect(
         rail.querySelector(`[data-testid="add-panel-category-${cat}"]`),
       ).not.toBeNull();
+    }
+    unmount();
+  });
+
+  it('omits category chips that hold no panels (no dead filters)', () => {
+    const { container, unmount } = setup();
+    const rail = container.querySelector(
+      '[data-testid="add-panel-rail"]',
+    ) as HTMLElement;
+    // amplifiers / tuners / switches are defined for future panels but have
+    // no members today, so their chips must not render.
+    for (const cat of ['amplifiers', 'tuners', 'switches']) {
+      expect(
+        rail.querySelector(`[data-testid="add-panel-category-${cat}"]`),
+      ).toBeNull();
+    }
+    unmount();
+  });
+
+  it('every rendered category chip yields at least one panel card', () => {
+    const { container, unmount } = setup();
+    const chips = Array.from(
+      container.querySelectorAll<HTMLButtonElement>(
+        '[data-testid="add-panel-rail"] .add-panel-category-btn',
+      ),
+    ).filter(
+      (btn) =>
+        btn.getAttribute('data-testid') !== 'add-panel-category-all',
+    );
+    expect(chips.length).toBeGreaterThan(0);
+    for (const chip of chips) {
+      act(() => {
+        chip.click();
+      });
+      const cards = container.querySelectorAll(
+        '[data-testid="add-panel-cards"] .add-panel-card',
+      );
+      expect(
+        cards.length,
+        `category ${chip.getAttribute('data-testid')} should not be empty`,
+      ).toBeGreaterThan(0);
     }
     unmount();
   });

--- a/zeus-web/src/layout/lockedWorkspaceLayout.test.ts
+++ b/zeus-web/src/layout/lockedWorkspaceLayout.test.ts
@@ -112,6 +112,35 @@ describe('deriveWorkspaceLayout — locking is inert', () => {
   });
 });
 
+describe('deriveWorkspaceLayout — locking is inert (short layout)', () => {
+  it('does not grow unlocked tiles when the layout fits below authored density', () => {
+    // A short docked column: layoutRows (12) < target (48), so the no-lock
+    // uniform path already runs BELOW authored R (the target-row divisor shrinks
+    // it) even though the layout would fit at R. Locking must stay inert here —
+    // it must not jump rowHeight up toward R and grow the unlocked neighbour.
+    const base: DeriveTile[] = [
+      tile({ uid: 'a', x: 0, y: 0, w: 12, h: 8 }),
+      tile({ uid: 'b', x: 0, y: 8, w: 12, h: 4 }),
+    ];
+    const before = deriveWorkspaceLayout(base, opts(600));
+    expect(before.rowHeight).toBeLessThan(R); // shrunk by the target-row divisor
+
+    const capturedPx = renderedPx(before, 'a');
+    const after = deriveWorkspaceLayout(
+      base.map((t) =>
+        t.uid === 'a' ? { ...t, locked: true, lockedHeightPx: capturedPx } : t,
+      ),
+      opts(600),
+    );
+
+    // No upward jump: the locked tile keeps its captured height and the
+    // unlocked neighbour does not grow.
+    expect(after.rowHeight).toBeCloseTo(before.rowHeight, 4);
+    expect(renderedPx(after, 'a')).toBeCloseTo(capturedPx, 3);
+    expect(renderedPx(after, 'b')).toBeCloseTo(renderedPx(before, 'b'), 3);
+  });
+});
+
 describe('deriveWorkspaceLayout — frozen size', () => {
   const layout = (fillH: number): DeriveTile[] => [
     tile({

--- a/zeus-web/src/layout/lockedWorkspaceLayout.ts
+++ b/zeus-web/src/layout/lockedWorkspaceLayout.ts
@@ -256,18 +256,27 @@ export function deriveWorkspaceLayout(
     lockedPxByUid.set(t.uid, px);
   }
 
-  // Pick the largest rowHeight (≤ authored) at which the whole layout still
-  // fits, with locked tiles held at their frozen pixel height. A larger
-  // rowHeight makes the unlocked tiles taller (more total height), so "fits"
-  // is monotonic and a binary search lands on the tightest non-overflowing
-  // value. Reserving a locked tile's *current* height changes nothing, so at
-  // the instant of locking this resolves to the pre-lock rowHeight (inert).
-  const atMax = renderAtRowHeight(tiles, R, rowMargin, lockedPxByUid);
+  // Pick the largest rowHeight at which the whole layout still fits, with
+  // locked tiles held at their frozen pixel height. A larger rowHeight makes
+  // the unlocked tiles taller (more total height), so "fits" is monotonic and
+  // a binary search lands on the tightest non-overflowing value.
+  //
+  // The ceiling is `baselineRowHeight` — the rowHeight the NO-LOCK uniform path
+  // would use right now — NOT the authored `R`. Locking must never make an
+  // unlocked tile bigger than it would be with nothing locked; the feature only
+  // ever shrinks unlocked tiles to make room for frozen locked ones. Capping at
+  // `R` was a bug: when the layout is shorter than WORKSPACE_TARGET_ROWS the
+  // no-lock path already runs below `R` (the target-row divisor shrinks it), yet
+  // such a layout still "fits" at `R`, so the solver jumped rowHeight UP on lock
+  // — growing every unlocked tile and opening a gap around the pinned panel.
+  // Reserving a locked tile's *current* height changes nothing, so at the
+  // instant of locking this resolves to the pre-lock baseline rowHeight (inert).
+  const atMax = renderAtRowHeight(tiles, baselineRowHeight, rowMargin, lockedPxByUid);
   let best: { rr: number; placements: RenderPlacement[] } | null =
-    atMax.maxBottomPx <= C ? { rr: R, placements: atMax.placements } : null;
+    atMax.maxBottomPx <= C ? { rr: baselineRowHeight, placements: atMax.placements } : null;
   if (!best) {
     let lo = minR;
-    let hi = R;
+    let hi = baselineRowHeight;
     for (let i = 0; i < 24; i += 1) {
       const mid = (lo + hi) / 2;
       const r = renderAtRowHeight(tiles, mid, rowMargin, lockedPxByUid);

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -2555,8 +2555,8 @@
 .qrz-grid-rows { display: flex; flex-direction: column; gap: 0; }
 .qrz-grid-rows .qrz-row { border-bottom: 1px dotted rgba(255,255,255,0.06); }
 .qrz-footer {
-  display: flex; align-items: center; padding-top: 6px; margin-top: 2px;
-  border-top: 1px solid rgba(74,158,255,0.2);
+  display: flex; align-items: center; padding-bottom: 6px; margin-bottom: 2px;
+  border-bottom: 1px solid rgba(74,158,255,0.2);
 }
 /* SP / LP rotator buttons inline in the QRZ footer — only rendered when a
  * rotator is connected and both home + contact have coordinates. Sized to


### PR DESCRIPTION
## Summary
Four small, independent layout/panel fixes on the desktop workspace.

### Panel-lock inertness (gap-on-lock bug)
Locking a panel in a layout shorter than `WORKSPACE_TARGET_ROWS` jumped the grid taller and opened a gap above/around the pinned panel. Root cause: `deriveWorkspaceLayout` searched for the largest row height up to the **authored** row height, but the no-lock workspace already runs **below** that (the target-row divisor shrinks it for short layouts). Such a layout still "fits" at the authored height, so the solver grew every unlocked tile on lock.

Fix: cap the search at the **no-lock baseline row height** — locking can now only ever shrink unlocked tiles to make room for frozen locked ones, never grow them. Adds a short-layout regression test (the prior "inert" test only covered tall/overflowing layouts).

### Add-panel empty category chips
Only render category chips that actually hold a panel. `amplifiers` / `tuners` / `switches` were defined for future panels but had no members, producing dead filters that always landed on an empty "No panels match" pane. Derived from the live registry (plugin panels included). Tests added.

### TX audio device-select sizing
Let the device-select dropdowns flex to fill their row instead of a fixed `minWidth`.

### QRZ card footer
Move the footer divider to the bottom edge (border/padding bottom).

## Testing
- `vitest run` — locked-layout + add-panel suites green (20 tests).
- `npm run build` (tsc -b + vite build) — clean; bundle emitted to `wwwroot` (desktop/Photino path).