### PR TITLE
fix: preserve restored band mode through tune echo

### DIFF
--- a/zeus-web/src/components/BandButtons.test.tsx
+++ b/zeus-web/src/components/BandButtons.test.tsx
@@ -107,4 +107,55 @@ describe('BandButtons', () => {
 
     unmount();
   });
+
+  it('keeps the destination band memory when the tune response echoes the departing mode', async () => {
+    vi.useFakeTimers();
+    vi.mocked(fetchBandMemory).mockResolvedValue([
+      { band: '40m', hz: 7_150_000, mode: 'LSB' },
+      { band: '20m', hz: 14_210_000, mode: 'USB' },
+    ]);
+    vi.mocked(setVfo).mockImplementation(async (hz) => ({
+      ...currentStateDto(),
+      vfoHz: hz,
+      mode: hz === 14_210_000 ? 'LSB' : currentStateDto().mode,
+    }));
+    useConnectionStore.setState({ vfoHz: 7_150_000, mode: 'LSB' });
+
+    const { container, unmount } = render(createElement(BandButtons));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    vi.clearAllMocks();
+
+    const buttons = Array.from(container.querySelectorAll<HTMLButtonElement>('button'));
+    const twentyMeters = buttons.find((button) => button.textContent === '20m');
+    const fortyMeters = buttons.find((button) => button.textContent === '40m');
+
+    await act(async () => {
+      twentyMeters?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(useConnectionStore.getState().mode).toBe('USB');
+
+    await act(async () => {
+      fortyMeters?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(saveBandMemory).toHaveBeenCalledWith('20m', 14_210_000, 'USB');
+    expect(saveBandMemory).not.toHaveBeenCalledWith('20m', 14_210_000, 'LSB');
+
+    await act(async () => {
+      twentyMeters?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(setMode).toHaveBeenLastCalledWith('USB');
+
+    unmount();
+  });
 });

--- a/zeus-web/src/components/BandButtons.tsx
+++ b/zeus-web/src/components/BandButtons.tsx
@@ -49,6 +49,7 @@ import {
   setMode,
   setVfo,
   type BandMemoryEntry,
+  type RadioStateDto,
   type RxMode,
 } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
@@ -73,6 +74,10 @@ const HF_BANDS: readonly BandEntry[] = BANDS.slice(0, 10).map((b) => ({
 // Debounce the "save current (hz, mode) for the current band" write so tuning
 // the VFO doesn't hammer the server on every pixel of knob travel.
 const SAVE_DEBOUNCE_MS = 500;
+
+function withRestoredMode(state: RadioStateDto, mode: RxMode): RadioStateDto {
+  return { ...state, mode };
+}
 
 export function BandButtons() {
   const vfoHz = useConnectionStore((s) => s.vfoHz);
@@ -161,15 +166,22 @@ export function BandButtons() {
       );
 
       void (async () => {
+        let modeRestored = !targetMode || targetMode === mode;
         if (targetMode && targetMode !== mode) {
           try {
-            applyState(await setMode(targetMode));
+            applyState(withRestoredMode(await setMode(targetMode), targetMode));
+            modeRestored = true;
           } catch {
             /* next state poll will reconcile */
           }
         }
         try {
-          applyState(await setVfo(targetHz));
+          const next = await setVfo(targetHz);
+          applyState(
+            targetMode && modeRestored
+              ? withRestoredMode(next, targetMode)
+              : next,
+          );
         } catch {
           /* next state poll will reconcile */
         }

--- a/zeus-web/src/components/toolbar/BandFavorites.test.tsx
+++ b/zeus-web/src/components/toolbar/BandFavorites.test.tsx
@@ -134,4 +134,55 @@ describe('BandFavorites', () => {
 
     unmount();
   });
+
+  it('keeps focused-receiver band memory when the tune response echoes the departing mode', async () => {
+    vi.useFakeTimers();
+    vi.mocked(fetchBandMemory).mockResolvedValue([
+      { band: '40m', hz: 7_150_000, mode: 'LSB' },
+      { band: '20m', hz: 14_210_000, mode: 'USB' },
+    ]);
+    vi.mocked(setVfoB).mockImplementation(async (hz) => ({
+      ...currentStateDto(),
+      vfoBHz: hz,
+      modeB: hz === 14_210_000 ? 'LSB' : currentStateDto().modeB,
+    }));
+    useConnectionStore.setState({ vfoBHz: 7_150_000, modeB: 'LSB' });
+
+    const { container, unmount } = render(createElement(BandFavorites));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    vi.clearAllMocks();
+
+    const buttons = Array.from(container.querySelectorAll<HTMLButtonElement>('button'));
+    const twentyMeters = buttons.find((button) => button.textContent === '20m');
+    const fortyMeters = buttons.find((button) => button.textContent === '40m');
+
+    await act(async () => {
+      twentyMeters?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(useConnectionStore.getState().modeB).toBe('USB');
+
+    await act(async () => {
+      fortyMeters?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(saveBandMemory).toHaveBeenCalledWith('20m', 14_210_000, 'USB');
+    expect(saveBandMemory).not.toHaveBeenCalledWith('20m', 14_210_000, 'LSB');
+
+    await act(async () => {
+      twentyMeters?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(setMode).toHaveBeenLastCalledWith('USB', undefined, 'B');
+
+    unmount();
+  });
 });

--- a/zeus-web/src/components/toolbar/BandFavorites.tsx
+++ b/zeus-web/src/components/toolbar/BandFavorites.tsx
@@ -13,6 +13,7 @@ import {
   setVfo,
   setVfoB,
   type BandMemoryEntry,
+  type RadioStateDto,
   type RxMode,
   type TxVfo,
 } from '../../api/client';
@@ -37,6 +38,10 @@ const BAND_OPTIONS: readonly ToolbarOption[] = HF_BANDS.map((b) => ({
 }));
 
 const SAVE_DEBOUNCE_MS = 500;
+
+function withRestoredMode(state: RadioStateDto, receiver: TxVfo, mode: RxMode): RadioStateDto {
+  return receiver === 'B' ? { ...state, modeB: mode } : { ...state, mode };
+}
 
 export function BandFavorites() {
   const vfoHz = useConnectionStore((s) => s.vfoHz);
@@ -119,23 +124,37 @@ export function BandFavorites() {
 
       viewCenterFor(activeReceiver).markOptimisticTune();
       useConnectionStore.setState(
-        activeReceiver === 'B' ? { vfoBHz: targetHz } : { vfoHz: targetHz },
+        activeReceiver === 'B'
+          ? targetMode && targetMode !== activeMode
+            ? { vfoBHz: targetHz, modeB: targetMode }
+            : { vfoBHz: targetHz }
+          : targetMode && targetMode !== activeMode
+          ? { vfoHz: targetHz, mode: targetMode }
+          : { vfoHz: targetHz },
       );
       const postVfo = activeReceiver === 'B' ? setVfoB : setVfo;
 
       void (async () => {
+        let modeRestored = !targetMode || targetMode === activeMode;
         if (targetMode && targetMode !== activeMode) {
-          useConnectionStore.setState(
-            activeReceiver === 'B' ? { modeB: targetMode } : { mode: targetMode },
-          );
           try {
-            applyState(await setMode(targetMode, undefined, activeReceiver));
+            applyState(withRestoredMode(
+              await setMode(targetMode, undefined, activeReceiver),
+              activeReceiver,
+              targetMode,
+            ));
+            modeRestored = true;
           } catch {
             /* next state poll reconciles */
           }
         }
         try {
-          applyState(await postVfo(targetHz));
+          const next = await postVfo(targetHz);
+          applyState(
+            targetMode && modeRestored
+              ? withRestoredMode(next, activeReceiver, targetMode)
+              : next,
+          );
         } catch {
           /* next state poll reconciles */
         }


### PR DESCRIPTION
## Summary
- preserve the restored per-band mode when a later VFO command response echoes the departing mode
- apply the same stale-echo protection to panel/mobile BandButtons and toolbar BandFavorites, including RX2
- add 40m LSB -> 20m USB -> 40m LSB -> 20m USB regression coverage for both selectors

## Verification
- npm --prefix zeus-web run test -- BandButtons BandFavorites ModeFavorites ModeBandwidth
- npm --prefix zeus-web run lint (passes with existing svgChrome fast-refresh warning)
- npm --prefix zeus-web run build
- npm --prefix zeus-web run test