### PR TITLE
feat(agc): AGC threshold (knee) control — smooth signal-relative RX AGC shaping

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -899,6 +899,14 @@ public sealed record StateDto(
     // adjusts AgcOffsetDb, which is added to the user baseline AgcTopDb.
     bool AutoAgcEnabled = false,
     double AgcOffsetDb = 0.0,
+    // AGC threshold ("knee") in operator/displayed dBm — the signal-relative
+    // level below which the AGC applies increasing gain (up to the AgcTopDb
+    // cap). This is the smooth, signal-relative control Thetis exposes via the
+    // panadapter knee line (WDSP SetRXAAGCThresh). NULL = operator has not set
+    // the knee, so WDSP's per-mode default threshold is left in effect (no
+    // behavioural change vs. pre-#741). When set, the server converts displayed
+    // dBm → WDSP scale with the per-board RX meter offset before pushing it.
+    double? AgcThresholdDbm = null,
 
     // ---- PureSignal predistortion (TXA-side; WDSP calcc/iqc stages) ----
     // PsEnabled is the master arm bit. Persisted server-side as a standing
@@ -1290,6 +1298,8 @@ public sealed record SampleRateSetRequest(int Rate);
 public sealed record PreampSetRequest(bool On);
 
 public sealed record AgcGainSetRequest(double TopDb);
+
+public sealed record AgcThresholdSetRequest(double ThresholdDbm);
 
 public sealed record RxAfGainSetRequest(double Db);
 

--- a/Zeus.Dsp/IDspEngine.cs
+++ b/Zeus.Dsp/IDspEngine.cs
@@ -74,6 +74,23 @@ public interface IDspEngine : IDisposable
     void SetCtunShift(int channelId, int shiftHz);
     void SetAgcTop(int channelId, double topDb);
 
+    /// <summary>
+    /// Set the AGC threshold ("knee") in dBm (WDSP <c>SetRXAAGCThresh</c>) — the
+    /// signal-relative level below which the AGC applies increasing gain up to
+    /// the <see cref="SetAgcTop"/> cap. The engine supplies the FFT size + sample
+    /// rate WDSP needs for the dBm conversion; the caller passes the value in
+    /// WDSP's dBm scale (per-board meter-offset conversion happens upstream).
+    /// No-op on Synthetic.
+    /// </summary>
+    void SetAgcThresh(int channelId, double threshDbm);
+
+    /// <summary>
+    /// Read back the AGC max-gain ("top") in dB. After a threshold change WDSP
+    /// recomputes the top; this exposes it for display mirroring. Returns the
+    /// last set top on Synthetic.
+    /// </summary>
+    double GetAgcTop(int channelId);
+
     /// <summary>Apply the AGC mode + custom/fixed params (Thetis parity §4).
     /// Drives SetRXAAGCMode/Slope/Hang/Decay/HangThreshold (and SetRXAAGCFixed
     /// in Fixed mode). The AGC max-gain ("top") is NOT touched here — it keeps

--- a/Zeus.Dsp/IDspEngine.cs
+++ b/Zeus.Dsp/IDspEngine.cs
@@ -91,6 +91,13 @@ public interface IDspEngine : IDisposable
     /// </summary>
     double GetAgcTop(int channelId);
 
+    /// <summary>
+    /// Read the current AGC threshold ("knee") in dBm (WDSP scale). Used to
+    /// capture WDSP's per-mode default knee before the operator first overrides
+    /// it, so disengaging the knee can restore that default. 0 on Synthetic.
+    /// </summary>
+    double GetAgcThresh(int channelId);
+
     /// <summary>Apply the AGC mode + custom/fixed params (Thetis parity §4).
     /// Drives SetRXAAGCMode/Slope/Hang/Decay/HangThreshold (and SetRXAAGCFixed
     /// in Fixed mode). The AGC max-gain ("top") is NOT touched here — it keeps

--- a/Zeus.Dsp/SyntheticDspEngine.cs
+++ b/Zeus.Dsp/SyntheticDspEngine.cs
@@ -100,7 +100,13 @@ public sealed class SyntheticDspEngine : IDspEngine
 
     public void SetCtunShift(int channelId, int shiftHz) { /* synthetic has no IF stage */ }
 
-    public void SetAgcTop(int channelId, double topDb) { /* synthetic has no AGC */ }
+    public void SetAgcTop(int channelId, double topDb) { _synthAgcTopDb = topDb; }
+
+    public void SetAgcThresh(int channelId, double threshDbm) { /* synthetic has no AGC */ }
+
+    public double GetAgcTop(int channelId) => _synthAgcTopDb;
+
+    private double _synthAgcTopDb = 80.0;
 
     public void SetAgc(int channelId, AgcConfig cfg)
     {

--- a/Zeus.Dsp/SyntheticDspEngine.cs
+++ b/Zeus.Dsp/SyntheticDspEngine.cs
@@ -106,6 +106,8 @@ public sealed class SyntheticDspEngine : IDspEngine
 
     public double GetAgcTop(int channelId) => _synthAgcTopDb;
 
+    public double GetAgcThresh(int channelId) => 0.0;
+
     private double _synthAgcTopDb = 80.0;
 
     public void SetAgc(int channelId, AgcConfig cfg)

--- a/Zeus.Dsp/Wdsp/NativeMethods.cs
+++ b/Zeus.Dsp/Wdsp/NativeMethods.cs
@@ -168,6 +168,18 @@ internal static partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial void SetRXAAGCTop(int channel, double max_agc);
 
+    // AGC threshold ("knee"), in dBm. size = FFT/buffer size, rate = sample rate;
+    // WDSP uses them to convert the dBm threshold to its internal level scale.
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetRXAAGCThresh(int channel, double thresh, double size, double rate);
+
+    // Reads back the AGC max-gain ("top") WDSP recomputed after a threshold
+    // change (out param). Declared for the Thetis-style top read-back/mirror.
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void GetRXAAGCTop(int channel, ref double max_agc);
+
     [LibraryImport(LibraryName)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial void SetRXAAGCAttack(int channel, int attack);

--- a/Zeus.Dsp/Wdsp/NativeMethods.cs
+++ b/Zeus.Dsp/Wdsp/NativeMethods.cs
@@ -180,6 +180,13 @@ internal static partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial void GetRXAAGCTop(int channel, ref double max_agc);
 
+    // Reads the current AGC threshold ("knee"), in dBm (out param). Used to
+    // capture WDSP's per-mode default knee before the operator overrides it, so
+    // "disengage" can restore it. size/rate match SetRXAAGCThresh.
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void GetRXAAGCThresh(int channel, ref double thresh, double size, double rate);
+
     [LibraryImport(LibraryName)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial void SetRXAAGCAttack(int channel, int attack);

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -721,6 +721,14 @@ public sealed class WdspDspEngine : IDspEngine
         return top;
     }
 
+    public double GetAgcThresh(int channelId)
+    {
+        if (!_channels.TryGetValue(channelId, out var state)) return 0.0;
+        double thresh = 0.0;
+        NativeMethods.GetRXAAGCThresh(channelId, ref thresh, RxaInSize, state.SampleRateHz);
+        return thresh;
+    }
+
     public void SetAgc(int channelId, AgcConfig cfg)
     {
         ArgumentNullException.ThrowIfNull(cfg);

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -702,6 +702,25 @@ public sealed class WdspDspEngine : IDspEngine
         _log.LogInformation("wdsp.setAgcTop channel={Id} topDb={TopDb:F1}", channelId, topDb);
     }
 
+    public void SetAgcThresh(int channelId, double threshDbm)
+    {
+        if (!_channels.TryGetValue(channelId, out var state)) return;
+        // WDSP converts the dBm threshold using the channel's FFT size + sample
+        // rate (RxaInSize matches the analyzer config set in OpenChannel).
+        NativeMethods.SetRXAAGCThresh(channelId, threshDbm, RxaInSize, state.SampleRateHz);
+        _log.LogInformation(
+            "wdsp.setAgcThresh channel={Id} threshDbm={Thresh:F1} size={Size} rate={Rate}",
+            channelId, threshDbm, RxaInSize, state.SampleRateHz);
+    }
+
+    public double GetAgcTop(int channelId)
+    {
+        if (!_channels.TryGetValue(channelId, out _)) return 0.0;
+        double top = 0.0;
+        NativeMethods.GetRXAAGCTop(channelId, ref top);
+        return top;
+    }
+
     public void SetAgc(int channelId, AgcConfig cfg)
     {
         ArgumentNullException.ThrowIfNull(cfg);

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -708,6 +708,9 @@ public class DspPipelineService : BackgroundService,
     private double _appliedAgcOffsetDb;
     // NaN until the knee is first pushed, so the first non-null threshold always applies.
     private double _appliedAgcThresholdDbm = double.NaN;
+    // WDSP's per-mode default knee, captured (in WDSP dBm) the first time the
+    // operator engages, so disengaging can restore it. NaN until captured.
+    private double _capturedDefaultThreshWdsp = double.NaN;
     private double _appliedRxAfGainDb;
     // TX mic gain change-detect cache. NaN sentinel forces the first apply
     // even when the persisted value happens to equal 0 dB (the engine seam
@@ -3057,19 +3060,35 @@ public class DspPipelineService : BackgroundService,
             _appliedAgcTopDb = s.AgcTopDb;
             _appliedAgcOffsetDb = s.AgcOffsetDb;
         }
-        // AGC threshold ("knee", #741). Null = operator never set it → leave
-        // WDSP's per-mode default in place. The operator value is in displayed
-        // dBm; convert to WDSP's scale with the same per-board RX meter offset
-        // the meters use, so the knee lines up with what the operator sees.
-        if (s.AgcThresholdDbm is double threshDisplayedDbm
-            && threshDisplayedDbm != _appliedAgcThresholdDbm)
+        // AGC threshold ("knee", #741). Null = disengaged → restore WDSP's
+        // per-mode default knee (captured the first time the operator engaged).
+        // The operator value is in displayed dBm; convert to WDSP's scale with
+        // the same per-board RX meter offset the meters use, so the knee lines
+        // up with what the operator sees.
+        if (s.AgcThresholdDbm is double threshDisplayedDbm)
         {
-            double calOffset = RadioCalibrations.RxMeterOffsetDb(
-                _radio.EffectiveBoardKind, _radio.EffectiveOrionMkIIVariant);
-            double wdspThresh = threshDisplayedDbm - calOffset;
-            engine.SetAgcThresh(channel, wdspThresh);
-            if (rx2Channel >= 0) engine.SetAgcThresh(rx2Channel, wdspThresh);
-            _appliedAgcThresholdDbm = threshDisplayedDbm;
+            if (threshDisplayedDbm != _appliedAgcThresholdDbm)
+            {
+                // Capture WDSP's default knee once, BEFORE the first override,
+                // so disengage can restore it.
+                if (double.IsNaN(_capturedDefaultThreshWdsp))
+                    _capturedDefaultThreshWdsp = engine.GetAgcThresh(channel);
+
+                double calOffset = RadioCalibrations.RxMeterOffsetDb(
+                    _radio.EffectiveBoardKind, _radio.EffectiveOrionMkIIVariant);
+                double wdspThresh = threshDisplayedDbm - calOffset;
+                engine.SetAgcThresh(channel, wdspThresh);
+                if (rx2Channel >= 0) engine.SetAgcThresh(rx2Channel, wdspThresh);
+                _appliedAgcThresholdDbm = threshDisplayedDbm;
+            }
+        }
+        else if (!double.IsNaN(_appliedAgcThresholdDbm) && !double.IsNaN(_capturedDefaultThreshWdsp))
+        {
+            // Disengaged after having been engaged: restore the captured WDSP
+            // default knee (in WDSP scale — no cal-offset, it's already raw).
+            engine.SetAgcThresh(channel, _capturedDefaultThreshWdsp);
+            if (rx2Channel >= 0) engine.SetAgcThresh(rx2Channel, _capturedDefaultThreshWdsp);
+            _appliedAgcThresholdDbm = double.NaN;
         }
         if (s.RxAfGainDb != _appliedRxAfGainDb)
         {

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -706,6 +706,8 @@ public class DspPipelineService : BackgroundService,
     }
     private double _appliedAgcTopDb;
     private double _appliedAgcOffsetDb;
+    // NaN until the knee is first pushed, so the first non-null threshold always applies.
+    private double _appliedAgcThresholdDbm = double.NaN;
     private double _appliedRxAfGainDb;
     // TX mic gain change-detect cache. NaN sentinel forces the first apply
     // even when the persisted value happens to equal 0 dB (the engine seam
@@ -3054,6 +3056,20 @@ public class DspPipelineService : BackgroundService,
             if (rx2Channel >= 0) engine.SetAgcTop(rx2Channel, effectiveAgc);
             _appliedAgcTopDb = s.AgcTopDb;
             _appliedAgcOffsetDb = s.AgcOffsetDb;
+        }
+        // AGC threshold ("knee", #741). Null = operator never set it → leave
+        // WDSP's per-mode default in place. The operator value is in displayed
+        // dBm; convert to WDSP's scale with the same per-board RX meter offset
+        // the meters use, so the knee lines up with what the operator sees.
+        if (s.AgcThresholdDbm is double threshDisplayedDbm
+            && threshDisplayedDbm != _appliedAgcThresholdDbm)
+        {
+            double calOffset = RadioCalibrations.RxMeterOffsetDb(
+                _radio.EffectiveBoardKind, _radio.EffectiveOrionMkIIVariant);
+            double wdspThresh = threshDisplayedDbm - calOffset;
+            engine.SetAgcThresh(channel, wdspThresh);
+            if (rx2Channel >= 0) engine.SetAgcThresh(rx2Channel, wdspThresh);
+            _appliedAgcThresholdDbm = threshDisplayedDbm;
         }
         if (s.RxAfGainDb != _appliedRxAfGainDb)
         {

--- a/Zeus.Server.Hosting/DspSettingsStore.cs
+++ b/Zeus.Server.Hosting/DspSettingsStore.cs
@@ -185,6 +185,17 @@ public sealed class DspSettingsStore : IDisposable
         }
     }
 
+    // Clear the persisted AGC knee (disengage → null) so a fresh connect leaves
+    // WDSP's per-mode default in effect. No-op when no row exists yet (#741).
+    public void ClearAgcThresholdDbm(string profileId = "default")
+    {
+        var existing = _entries.FindOne(x => x.ProfileId == profileId);
+        if (existing is null) return;
+        existing.AgcThresholdDbm = null;
+        existing.UpdatedUtc = DateTime.UtcNow;
+        _entries.Update(existing);
+    }
+
     // AGC mode + custom params (issue: DSP controls Thetis parity §4). Persisted
     // as nullable scalars on the existing DspSettingsEntry — null AgcMode means
     // "never written" so RadioService falls back to the Med default on first run.

--- a/Zeus.Server.Hosting/DspSettingsStore.cs
+++ b/Zeus.Server.Hosting/DspSettingsStore.cs
@@ -149,6 +149,42 @@ public sealed class DspSettingsStore : IDisposable
         }
     }
 
+    // AGC threshold ("knee") in operator/displayed dBm (#741). Null = operator
+    // has never set the knee, so RadioService leaves WDSP's per-mode default
+    // threshold in effect. Mirrors the AgcTopDb persistence pattern above.
+    public double? GetAgcThresholdDbm(string profileId = "default")
+    {
+        var e = _entries.FindOne(x => x.ProfileId == profileId);
+        return e?.AgcThresholdDbm;
+    }
+
+    public void SetAgcThresholdDbm(double dbm, string profileId = "default")
+    {
+        var existing = _entries.FindOne(x => x.ProfileId == profileId);
+        if (existing is null)
+        {
+            var nrSeed = new NrConfig();
+            _entries.Insert(new DspSettingsEntry
+            {
+                ProfileId = profileId,
+                NrMode = nrSeed.NrMode,
+                AnfEnabled = nrSeed.AnfEnabled,
+                SnbEnabled = nrSeed.SnbEnabled,
+                NbpNotchesEnabled = nrSeed.NbpNotchesEnabled,
+                NbMode = nrSeed.NbMode,
+                NbThreshold = nrSeed.NbThreshold,
+                AgcThresholdDbm = dbm,
+                UpdatedUtc = DateTime.UtcNow,
+            });
+        }
+        else
+        {
+            existing.AgcThresholdDbm = dbm;
+            existing.UpdatedUtc = DateTime.UtcNow;
+            _entries.Update(existing);
+        }
+    }
+
     // AGC mode + custom params (issue: DSP controls Thetis parity §4). Persisted
     // as nullable scalars on the existing DspSettingsEntry — null AgcMode means
     // "never written" so RadioService falls back to the Med default on first run.
@@ -536,6 +572,9 @@ public sealed class DspSettingsEntry
     // AGC top (max gain) in dB. Null on legacy rows (pre-AGC-persist) so
     // RadioService can fall back to the baseline default for first-run.
     public double? AgcTopDb { get; set; }
+    // AGC threshold ("knee") in operator/displayed dBm (#741). Null = never set
+    // → WDSP's per-mode default threshold stays in effect.
+    public double? AgcThresholdDbm { get; set; }
     // AGC mode + custom params (issue: DSP controls Thetis parity §4). AgcMode
     // null on legacy rows → GetAgc() returns null → RadioService uses the Med
     // default. Custom/fixed params null = "use the canned preset".

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -2267,6 +2267,17 @@ public sealed class RadioService : IDisposable
         return Snapshot();
     }
 
+    // Disengage the AGC knee: clear the operator override (→ null) and persist
+    // the cleared state. The DSP pipeline sees AgcThresholdDbm go null and
+    // restores WDSP's captured per-mode default threshold, so AGC returns to its
+    // default behaviour (#741).
+    public StateDto DisengageAgcThreshold()
+    {
+        Mutate(s => s with { AgcThresholdDbm = null });
+        _dspSettingsStore.ClearAgcThresholdDbm();
+        return Snapshot();
+    }
+
     // Master RX AF gain in dB. −50 dB is effectively silent (0.003 linear),
     // 0 dB matches the fresh-open default, +20 dB is a 10× linear boost for
     // quiet signals. Range mirrors Thetis's ptbAF (console.cs:4312-4313:

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -417,6 +417,10 @@ public sealed class RadioService : IDisposable
             LevelerMaxGainDb: overlayLevelerMaxGain ?? Math.Clamp(rsSnap?.LevelerMaxGainDb ?? 8.0, 0.0, 20.0),
             AutoAgcEnabled: rsSnap?.AutoAgcEnabled ?? false,
             AgcOffsetDb: 0.0,       // always reset — control-loop accumulator
+            // Persisted AGC knee, or null when the operator has never set it
+            // (WDSP's per-mode default threshold stays in effect — no change
+            // vs. pre-#741). Pushed to WDSP from DspPipelineService when non-null.
+            AgcThresholdDbm: _dspSettingsStore.GetAgcThresholdDbm(),
             // PS persisted fields (or DTO defaults when not persisted yet).
             PsEnabled: false, // master arm is never persisted — operator must re-arm each session
             PsAuto: ps?.Auto ?? true,
@@ -2244,6 +2248,22 @@ public sealed class RadioService : IDisposable
         });
         // Persist only the user-baseline (AgcTopDb); the offset is live-recomputed.
         _dspSettingsStore.SetAgcTopDb(clamped);
+        return Snapshot();
+    }
+
+    // AGC threshold ("knee") in operator/displayed dBm. This is the smooth,
+    // signal-relative AGC control (Thetis panadapter knee → WDSP SetRXAAGCThresh)
+    // — distinct from the AgcTopDb max-gain cap. Clamp matches Thetis's
+    // SetRXAAGCThresh range ([-160, 2] dBm). The displayed-dBm → WDSP-scale
+    // conversion (per-board RX meter offset) happens at the engine push in
+    // DspPipelineService, where that offset is already computed for meters.
+    // Setting the knee does NOT disturb Auto-AGC (which acts on the top), so —
+    // unlike SetAgcTop — we leave AutoAgcEnabled/AgcOffsetDb alone.
+    public StateDto SetAgcThreshold(double dbm)
+    {
+        double clamped = Math.Clamp(dbm, -160.0, 2.0);
+        Mutate(s => s with { AgcThresholdDbm = clamped });
+        _dspSettingsStore.SetAgcThresholdDbm(clamped);
         return Snapshot();
     }
 

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -1197,6 +1197,13 @@ public static class ZeusEndpoints
             return r.SetAgcThreshold(req.ThresholdDbm);
         });
 
+        // Disengage the AGC knee → restore WDSP's per-mode default threshold (#741).
+        app.MapPost("/api/agc/threshold/disengage", (RadioService r) =>
+        {
+            log.LogInformation("api.agc.threshold.disengage");
+            return r.DisengageAgcThreshold();
+        });
+
         app.MapPost("/api/rx/agc", (AgcSetRequest req, RadioService r) =>
         {
             log.LogInformation(

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -1187,6 +1187,16 @@ public static class ZeusEndpoints
             return r.SetAgcTop(req.TopDb);
         });
 
+        // AGC threshold ("knee", #741) — the smooth signal-relative AGC control,
+        // distinct from the /api/agcGain max-gain cap. Value is operator/displayed
+        // dBm; RadioService clamps to [-160, 2] and the engine push converts to
+        // WDSP's scale with the per-board meter offset.
+        app.MapPost("/api/agc/threshold", (AgcThresholdSetRequest req, RadioService r) =>
+        {
+            log.LogInformation("api.agc.threshold thresholdDbm={Thresh:F1}", req.ThresholdDbm);
+            return r.SetAgcThreshold(req.ThresholdDbm);
+        });
+
         app.MapPost("/api/rx/agc", (AgcSetRequest req, RadioService r) =>
         {
             log.LogInformation(

--- a/tests/Zeus.Server.Tests/DspPipelineRx2RoutingTests.cs
+++ b/tests/Zeus.Server.Tests/DspPipelineRx2RoutingTests.cs
@@ -141,6 +141,7 @@ public class DspPipelineRx2RoutingTests
         public void SetAgcTop(int channelId, double topDb) { }
         public void SetAgcThresh(int channelId, double threshDbm) { }
         public double GetAgcTop(int channelId) => 0.0;
+        public double GetAgcThresh(int channelId) => 0.0;
         public void SetAgc(int channelId, AgcConfig cfg) { }
         public void SetSquelch(int channelId, SquelchConfig cfg) { }
         public void SetTxLeveling(int channelId, TxLevelingConfig cfg) { }

--- a/tests/Zeus.Server.Tests/DspPipelineRx2RoutingTests.cs
+++ b/tests/Zeus.Server.Tests/DspPipelineRx2RoutingTests.cs
@@ -139,6 +139,8 @@ public class DspPipelineRx2RoutingTests
         public void SetVfoHz(int channelId, long vfoHz) { }
         public void SetCtunShift(int channelId, int shiftHz) { }
         public void SetAgcTop(int channelId, double topDb) { }
+        public void SetAgcThresh(int channelId, double threshDbm) { }
+        public double GetAgcTop(int channelId) => 0.0;
         public void SetAgc(int channelId, AgcConfig cfg) { }
         public void SetSquelch(int channelId, SquelchConfig cfg) { }
         public void SetTxLeveling(int channelId, TxLevelingConfig cfg) { }

--- a/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
@@ -172,6 +172,8 @@ public class MicGainEndpointTests : IClassFixture<MicGainEndpointTests.Factory>
         public void SetVfoHz(int channelId, long vfoHz) { }
         public void SetCtunShift(int channelId, int shiftHz) { }
         public void SetAgcTop(int channelId, double topDb) { }
+        public void SetAgcThresh(int channelId, double threshDbm) { }
+        public double GetAgcTop(int channelId) => 0.0;
         public void SetAgc(int channelId, AgcConfig cfg) { }
         public void SetSquelch(int channelId, SquelchConfig cfg) { }
         public List<TxLevelingConfig> TxLevelingCalls { get; } = new();

--- a/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
@@ -174,6 +174,7 @@ public class MicGainEndpointTests : IClassFixture<MicGainEndpointTests.Factory>
         public void SetAgcTop(int channelId, double topDb) { }
         public void SetAgcThresh(int channelId, double threshDbm) { }
         public double GetAgcTop(int channelId) => 0.0;
+        public double GetAgcThresh(int channelId) => 0.0;
         public void SetAgc(int channelId, AgcConfig cfg) { }
         public void SetSquelch(int channelId, SquelchConfig cfg) { }
         public List<TxLevelingConfig> TxLevelingCalls { get; } = new();

--- a/tests/Zeus.Server.Tests/RadioServiceAutoAgcTests.cs
+++ b/tests/Zeus.Server.Tests/RadioServiceAutoAgcTests.cs
@@ -178,4 +178,48 @@ public sealed class RadioServiceAutoAgcTests : IDisposable
         Assert.Equal(120.0, radio.SetAgcTop(200.0).AgcTopDb);
         Assert.Equal(-20.0, radio.SetAgcTop(-50.0).AgcTopDb);
     }
+
+    // ── issue #741: AGC threshold ("knee") control ────────────────────────────
+    [Fact]
+    public void FreshRadio_HasNoAgcThreshold_UntilOperatorSetsIt()
+    {
+        using var radio = NewRadio();
+        // Null = WDSP's per-mode default threshold stays in effect (no change
+        // vs. pre-#741); the knee is strictly opt-in.
+        Assert.Null(radio.Snapshot().AgcThresholdDbm);
+    }
+
+    [Fact]
+    public void SetAgcThreshold_ClampsToThetisRange()
+    {
+        using var radio = NewRadio();
+        Assert.Equal(2.0, radio.SetAgcThreshold(50.0).AgcThresholdDbm);
+        Assert.Equal(-160.0, radio.SetAgcThreshold(-500.0).AgcThresholdDbm);
+        Assert.Equal(-95.0, radio.SetAgcThreshold(-95.0).AgcThresholdDbm);
+    }
+
+    [Fact]
+    public void SetAgcThreshold_PersistsAcrossRadioInstances()
+    {
+        using (var radio = NewRadio())
+            radio.SetAgcThreshold(-100.0);
+
+        // A fresh RadioService on the SAME prefs DB hydrates the persisted knee.
+        using var reopened = NewRadio();
+        Assert.Equal(-100.0, reopened.Snapshot().AgcThresholdDbm);
+    }
+
+    [Fact]
+    public void SetAgcThreshold_DoesNotDisturbAutoAgc()
+    {
+        using var radio = NewRadio();
+        radio.SetAutoAgc(true);
+
+        var snap = radio.SetAgcThreshold(-90.0);
+
+        // The knee is independent of the max-gain auto-AGC loop — setting it must
+        // NOT disable auto-AGC or zero the offset (contrast SetAgcTop, which does).
+        Assert.True(snap.AutoAgcEnabled);
+        Assert.Equal(-90.0, snap.AgcThresholdDbm);
+    }
 }

--- a/tests/Zeus.Server.Tests/RadioServiceAutoAgcTests.cs
+++ b/tests/Zeus.Server.Tests/RadioServiceAutoAgcTests.cs
@@ -222,4 +222,31 @@ public sealed class RadioServiceAutoAgcTests : IDisposable
         Assert.True(snap.AutoAgcEnabled);
         Assert.Equal(-90.0, snap.AgcThresholdDbm);
     }
+
+    [Fact]
+    public void DisengageAgcThreshold_ClearsKneeToNull()
+    {
+        using var radio = NewRadio();
+        radio.SetAgcThreshold(-95.0);
+        Assert.Equal(-95.0, radio.Snapshot().AgcThresholdDbm);
+
+        var snap = radio.DisengageAgcThreshold();
+
+        // Disengage returns to null so the DSP pipeline restores WDSP's default.
+        Assert.Null(snap.AgcThresholdDbm);
+    }
+
+    [Fact]
+    public void DisengageAgcThreshold_PersistsClear_AcrossRadioInstances()
+    {
+        using (var radio = NewRadio())
+        {
+            radio.SetAgcThreshold(-95.0);
+            radio.DisengageAgcThreshold();
+        }
+
+        // A fresh RadioService on the same prefs DB must NOT re-engage the knee.
+        using var reopened = NewRadio();
+        Assert.Null(reopened.Snapshot().AgcThresholdDbm);
+    }
 }

--- a/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
+++ b/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
@@ -90,6 +90,8 @@ public class TxAudioIngestTests
         public void SetVfoHz(int channelId, long vfoHz) { }
         public void SetCtunShift(int channelId, int shiftHz) { }
         public void SetAgcTop(int channelId, double topDb) { }
+        public void SetAgcThresh(int channelId, double threshDbm) { }
+        public double GetAgcTop(int channelId) => 0.0;
         public void SetAgc(int channelId, AgcConfig cfg) { }
         public void SetSquelch(int channelId, SquelchConfig cfg) { }
         public void SetTxLeveling(int channelId, TxLevelingConfig cfg) { }

--- a/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
+++ b/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
@@ -92,6 +92,7 @@ public class TxAudioIngestTests
         public void SetAgcTop(int channelId, double topDb) { }
         public void SetAgcThresh(int channelId, double threshDbm) { }
         public double GetAgcTop(int channelId) => 0.0;
+        public double GetAgcThresh(int channelId) => 0.0;
         public void SetAgc(int channelId, AgcConfig cfg) { }
         public void SetSquelch(int channelId, SquelchConfig cfg) { }
         public void SetTxLeveling(int channelId, TxLevelingConfig cfg) { }

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -5715,6 +5715,16 @@ export function setAgcThreshold(
   );
 }
 
+// Disengage the AGC knee → server clears the override (agcThresholdDbm = null)
+// and restores WDSP's per-mode default threshold.
+export function disengageAgcThreshold(signal?: AbortSignal): Promise<RadioStateDto> {
+  return jsonFetch(
+    '/api/agc/threshold/disengage',
+    { method: 'POST', signal },
+    normalizeState,
+  );
+}
+
 export function setRxAfGain(
   db: number,
   signal?: AbortSignal,

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -295,6 +295,10 @@ export type RadioStateDto = {
   txFilterHighHz: number;
   sampleRate: number;
   agcTopDb: number;
+  // AGC threshold ("knee") in dBm. Null = operator hasn't set it; the WDSP
+  // per-mode default is in effect. Independent of agcTopDb max-gain and of
+  // auto-AGC — the knee is the absolute signal level above which AGC engages.
+  agcThresholdDbm: number | null;
   // AGC mode + custom/fixed params (separate from agcTopDb max-gain).
   agc: AgcConfigDto;
   // RX squelch (mode-aware single control).
@@ -2312,6 +2316,10 @@ export function normalizeState(raw: unknown): RadioStateDto {
     // Default 80 matches WdspDspEngine.ApplyAgcDefaults and the Thetis
     // AGC_MEDIUM preset. Missing from older servers — tolerate absence.
     agcTopDb: typeof r.agcTopDb === 'number' ? r.agcTopDb : 80,
+    // AGC threshold (knee). Null when the operator hasn't set it (server sends
+    // null) or when an older server omits the field entirely — both mean
+    // "WDSP mode default in effect", so the UI shows the unset readout.
+    agcThresholdDbm: typeof r.agcThresholdDbm === 'number' ? r.agcThresholdDbm : null,
     // StateDto.Agc is nullable on the server (older clients) — fall back to the
     // Med default so the UI always has a mode to render.
     agc: normalizeAgc(r.agc),
@@ -5685,6 +5693,22 @@ export function setAgcTop(
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ topDb }),
+      signal,
+    },
+    normalizeState,
+  );
+}
+
+export function setAgcThreshold(
+  thresholdDbm: number,
+  signal?: AbortSignal,
+): Promise<RadioStateDto> {
+  return jsonFetch(
+    '/api/agc/threshold',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ thresholdDbm }),
       signal,
     },
     normalizeState,

--- a/zeus-web/src/components/AgcSlider.test.tsx
+++ b/zeus-web/src/components/AgcSlider.test.tsx
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+const setAgcThresholdMock = vi.hoisted(() =>
+  vi.fn<(thresholdDbm: number, signal?: AbortSignal) => Promise<RadioStateDto>>(),
+);
+
+vi.mock('../api/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/client')>();
+  return {
+    ...actual,
+    setAgcThreshold: setAgcThresholdMock,
+  };
+});
+
+import {
+  AGC_CONFIG_DEFAULT,
+  CFC_CONFIG_DEFAULT,
+  NR_CONFIG_DEFAULT,
+  SQUELCH_CONFIG_DEFAULT,
+  TX_LEVELING_CONFIG_DEFAULT,
+  type RadioStateDto,
+} from '../api/client';
+import { useConnectionStore } from '../state/connection-store';
+import { AgcSlider } from './AgcSlider';
+
+// A full StateDto echoing the requested knee — what the server returns from
+// POST /api/agc/threshold. Only agcThresholdDbm is interesting to this test.
+function mockState(thresholdDbm: number | null): RadioStateDto {
+  const conn = useConnectionStore.getState();
+  return {
+    status: 'Connected',
+    endpoint: conn.endpoint,
+    vfoHz: conn.vfoHz,
+    vfoBHz: conn.vfoBHz,
+    rx2Enabled: false,
+    rx2AudioMode: 'both',
+    rx2AfGainDb: 0,
+    txVfo: 'A',
+    mode: conn.mode,
+    modeB: conn.modeB,
+    filterLowHz: conn.filterLowHz,
+    filterHighHz: conn.filterHighHz,
+    filterLowHzB: conn.filterLowHzB,
+    filterHighHzB: conn.filterHighHzB,
+    filterPresetName: conn.filterPresetName,
+    filterPresetNameB: conn.filterPresetNameB,
+    filterAdvancedPaneOpen: conn.filterAdvancedPaneOpen,
+    txFilterLowHz: conn.txFilterLowHz,
+    txFilterHighHz: conn.txFilterHighHz,
+    sampleRate: conn.sampleRate,
+    agcTopDb: conn.agcTopDb,
+    agcThresholdDbm: thresholdDbm,
+    agc: { ...AGC_CONFIG_DEFAULT },
+    squelch: { ...SQUELCH_CONFIG_DEFAULT },
+    txLeveling: { ...TX_LEVELING_CONFIG_DEFAULT },
+    autoAgcEnabled: false,
+    agcOffsetDb: 0,
+    rxAfGainDb: 0,
+    micGainDb: 0,
+    levelerMaxGainDb: 8,
+    attenDb: 0,
+    autoAttEnabled: true,
+    attOffsetDb: 0,
+    adcOverloadWarning: false,
+    preampOn: false,
+    nr: { ...NR_CONFIG_DEFAULT },
+    zoomLevel: 1,
+    psEnabled: false,
+    psAuto: true,
+    psPtol: false,
+    psAutoAttenuate: true,
+    psMoxDelaySec: 0,
+    psLoopDelaySec: 0,
+    psAmpDelayNs: 0,
+    psHwPeak: 0.4072,
+    psHwPeakDefault: 0.4072,
+    psTxFeedbackAttenuationDb: 0,
+    psTxFeedbackAttenuationDbMin: 0,
+    psIntsSpiPreset: '16/256',
+    psFeedbackSource: 'internal',
+    txMonitorEnabled: false,
+    drivePercent: 0,
+    tunePercent: 10,
+    txMoxPreKeyDelayMs: 0,
+    twoToneFreq1: 700,
+    twoToneFreq2: 1900,
+    twoToneMag: 0.5,
+    cfc: CFC_CONFIG_DEFAULT,
+    radioLoHz: conn.vfoHz,
+    cwPitchHz: 600,
+    ctunEnabled: false,
+  };
+}
+
+// The "Knee" range input is the one with aria-label "AGC threshold (knee)".
+function kneeInput(container: HTMLElement): HTMLInputElement {
+  const el = container.querySelector<HTMLInputElement>(
+    'input[type="range"][aria-label="AGC threshold (knee)"]',
+  );
+  if (!el) throw new Error('Knee slider not found');
+  return el;
+}
+
+// React tracks the previous value on the DOM node, so a plain `input.value =`
+// is ignored as a no-op change. Go through the native value setter so React's
+// onChange (bound to the native "input" event) actually fires.
+function drag(input: HTMLInputElement, value: number) {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    'value',
+  )?.set;
+  setter?.call(input, String(value));
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+describe('AgcSlider — Knee (AGC threshold)', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setAgcThresholdMock.mockReset();
+    setAgcThresholdMock.mockImplementation((v) => Promise.resolve(mockState(v)));
+    useConnectionStore.setState({
+      status: 'Connected',
+      agcThresholdDbm: null,
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root.render(<AgcSlider />);
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    useConnectionStore.setState({
+      status: 'Disconnected',
+      agcThresholdDbm: null,
+    });
+    vi.useRealTimers();
+  });
+
+  it('shows "—" and the fallback thumb position while the knee is unset', () => {
+    const input = kneeInput(container);
+    expect(input.value).toBe('-120'); // KNEE_FALLBACK
+    expect(container.textContent).toContain('—');
+  });
+
+  it('dragging the knee POSTs setAgcThreshold and applyState populates agcThresholdDbm', async () => {
+    const input = kneeInput(container);
+
+    act(() => {
+      drag(input, -95);
+    });
+
+    // useLiveSlider coalesces on the next frame; jsdom falls back to setTimeout(0).
+    await act(async () => {
+      vi.runOnlyPendingTimers();
+      await Promise.resolve();
+    });
+
+    expect(setAgcThresholdMock).toHaveBeenCalledTimes(1);
+    expect(setAgcThresholdMock).toHaveBeenCalledWith(-95, expect.anything());
+
+    // The echoed StateDto must have flowed through applyState into the store.
+    expect(useConnectionStore.getState().agcThresholdDbm).toBe(-95);
+  });
+
+  it('flush on release commits the final value and the readout shows dBm', async () => {
+    const input = kneeInput(container);
+
+    act(() => {
+      drag(input, -80);
+      // Release before the rAF/timer tick — flush() must still land the value.
+      input.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(setAgcThresholdMock).toHaveBeenCalledWith(-80, expect.anything());
+    expect(useConnectionStore.getState().agcThresholdDbm).toBe(-80);
+    expect(container.textContent).toContain('-80 dBm');
+  });
+
+  it('the knee slider is disabled when not connected', () => {
+    act(() => {
+      useConnectionStore.setState({ status: 'Disconnected' });
+    });
+    expect(kneeInput(container).disabled).toBe(true);
+  });
+});

--- a/zeus-web/src/components/AgcSlider.tsx
+++ b/zeus-web/src/components/AgcSlider.tsx
@@ -45,6 +45,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import {
+  disengageAgcThreshold,
   setAgc,
   setAgcThreshold,
   setAgcTop,
@@ -160,6 +161,7 @@ export function AgcSlider() {
 
   const autoAbort = useRef<AbortController | null>(null);
   const agcAbort = useRef<AbortController | null>(null);
+  const kneeAbort = useRef<AbortController | null>(null);
 
   // Popover holding Custom (slope/decay/hang/thresh) or Fixed (fixed gain)
   // tunables, anchored under the mode dropdown so the toolbar stays compact.
@@ -201,6 +203,26 @@ export function AgcSlider() {
     ),
   });
 
+  // The "Knee" label is a toggle: when engaged (a threshold is set) it
+  // disengages → server restores WDSP's default knee; when disengaged it
+  // engages at the current thumb position. Dragging the slider always engages.
+  const toggleKnee = useCallback(() => {
+    if (!connected) return;
+    kneeAbort.current?.abort();
+    const ac = new AbortController();
+    kneeAbort.current = ac;
+    const req = kneeSet
+      ? disengageAgcThreshold(ac.signal)
+      : setAgcThreshold(kneeSliderValue, ac.signal);
+    req
+      .then((next) => {
+        if (!ac.signal.aborted) applyState(next);
+      })
+      .catch(() => {
+        /* next poll reconciles */
+      });
+  }, [connected, kneeSet, kneeSliderValue, applyState]);
+
   const toggleAuto = useCallback(() => {
     if (!connected) return;
     autoAbort.current?.abort();
@@ -236,6 +258,7 @@ export function AgcSlider() {
     () => () => {
       autoAbort.current?.abort();
       agcAbort.current?.abort();
+      kneeAbort.current?.abort();
     },
     [],
   );
@@ -350,14 +373,22 @@ export function AgcSlider() {
       </label>
 
       <label className="knob-group" style={{ minWidth: 0 }}>
-        <span
-          className="btn sm"
-          aria-hidden
-          title="AGC threshold (knee) — set just above the noise floor for smooth, signal-relative AGC"
-          style={{ whiteSpace: 'nowrap', cursor: 'default' }}
+        <button
+          type="button"
+          onClick={toggleKnee}
+          disabled={!connected}
+          aria-pressed={kneeSet}
+          aria-label={kneeSet ? 'AGC knee engaged (click to disengage)' : 'AGC knee off (click to engage)'}
+          title={
+            kneeSet
+              ? 'AGC knee ENGAGED — click to disengage (restore the default AGC threshold)'
+              : 'AGC knee off — click to engage, or drag the slider. Set it just above the noise floor for smooth, signal-relative AGC.'
+          }
+          className={`btn sm ${kneeSet ? 'active' : ''}`}
+          style={{ whiteSpace: 'nowrap' }}
         >
           Knee
-        </span>
+        </button>
         <input
           type="range"
           min={KNEE_MIN}
@@ -387,8 +418,10 @@ export function AgcSlider() {
           style={{
             flex: 1,
             cursor: kneeDisabled ? 'not-allowed' : 'pointer',
-            accentColor: kneeDisabled ? 'var(--fg-3)' : 'var(--accent)',
-            opacity: kneeDisabled ? 0.55 : 1,
+            // Lit accent only while engaged; muted when disengaged so the
+            // off-state reads at a glance (mirrors the lit "Knee" button).
+            accentColor: kneeDisabled || !kneeSet ? 'var(--fg-3)' : 'var(--accent)',
+            opacity: kneeDisabled ? 0.55 : kneeSet ? 1 : 0.7,
           }}
         />
         <span

--- a/zeus-web/src/components/AgcSlider.tsx
+++ b/zeus-web/src/components/AgcSlider.tsx
@@ -46,6 +46,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import {
   setAgc,
+  setAgcThreshold,
   setAgcTop,
   setAutoAgc,
   type AgcConfigDto,
@@ -59,6 +60,14 @@ import { useLiveSlider } from '../hooks/useLiveSlider';
 // 0-120 mirrors the range Thetis exposes on its AGC-T slider.
 const MIN = 0;
 const MAX = 120;
+
+// AGC threshold ("knee") in dBm. The operator sets this just above the noise
+// floor; signals above it drive the AGC. Range mirrors a usable HF signal
+// window. KNEE_FALLBACK is the slider thumb position shown while the knee is
+// unset (null) — a sensible mid-low spot so the thumb isn't pinned to a rail.
+const KNEE_MIN = -140;
+const KNEE_MAX = 0;
+const KNEE_FALLBACK = -120;
 
 // AGC mode dropdown order matches Thetis (enums.cs:152-162).
 const AGC_MODES: readonly AgcMode[] = ['Fixed', 'Long', 'Slow', 'Med', 'Fast', 'Custom'];
@@ -128,6 +137,7 @@ export function AgcSlider() {
   const applyState = useConnectionStore((s) => s.applyState);
   const agc = useConnectionStore((s) => s.agc);
   const setLocalAgc = useConnectionStore((s) => s.setAgc);
+  const agcThresholdDbm = useConnectionStore((s) => s.agcThresholdDbm);
 
   // Local drag state overrides the store while the user is actively moving
   // the slider so echoed state updates don't yank the thumb back.
@@ -137,6 +147,16 @@ export function AgcSlider() {
   const sliderValue = dragValue ?? userAgc;
   const effective = Math.round(Math.max(MIN, Math.min(MAX, sliderValue + offsetDb)));
   const sliderDisabled = !connected || autoEnabled;
+
+  // Knee (AGC threshold) local drag override, mirroring the AGC-T pattern so
+  // an echoed StateDto doesn't yank the thumb while the operator is dragging.
+  const [kneeDragValue, setKneeDragValue] = useState<number | null>(null);
+  // Thumb position: live drag value, else the operator's set knee, else the
+  // fallback. The numeric readout shows "—" until the knee has actually been set.
+  const kneeSliderValue = kneeDragValue ?? agcThresholdDbm ?? KNEE_FALLBACK;
+  const kneeSet = kneeDragValue != null || agcThresholdDbm != null;
+  // Unlike AGC-T, the knee is independent of auto-AGC — only gated on connect.
+  const kneeDisabled = !connected;
 
   const autoAbort = useRef<AbortController | null>(null);
   const agcAbort = useRef<AbortController | null>(null);
@@ -156,6 +176,21 @@ export function AgcSlider() {
     send: useCallback(
       (v: number, signal: AbortSignal) =>
         setAgcTop(v, signal)
+          .then((next) => {
+            if (!signal.aborted) applyState(next);
+          })
+          .catch(() => {
+            /* next poll will reconcile; don't noisily log on abort */
+          }),
+      [applyState],
+    ),
+  });
+
+  // Knee streams /api/agc/threshold the same way AGC-T streams /api/agcGain.
+  const kneeLiveSlider = useLiveSlider<number>({
+    send: useCallback(
+      (v: number, signal: AbortSignal) =>
+        setAgcThreshold(v, signal)
           .then((next) => {
             if (!signal.aborted) applyState(next);
           })
@@ -311,6 +346,63 @@ export function AgcSlider() {
           }}
         >
           {effective} dB
+        </span>
+      </label>
+
+      <label className="knob-group" style={{ minWidth: 0 }}>
+        <span
+          className="btn sm"
+          aria-hidden
+          title="AGC threshold (knee) — set just above the noise floor for smooth, signal-relative AGC"
+          style={{ whiteSpace: 'nowrap', cursor: 'default' }}
+        >
+          Knee
+        </span>
+        <input
+          type="range"
+          min={KNEE_MIN}
+          max={KNEE_MAX}
+          step={1}
+          value={kneeSliderValue}
+          disabled={kneeDisabled}
+          aria-label="AGC threshold (knee)"
+          title="AGC threshold (knee) — set just above the noise floor for smooth, signal-relative AGC"
+          onChange={(e) => {
+            const v = Number(e.currentTarget.value);
+            setKneeDragValue(v);
+            kneeLiveSlider.push(v);
+          }}
+          onMouseUp={() => {
+            kneeLiveSlider.flush();
+            setKneeDragValue(null);
+          }}
+          onTouchEnd={() => {
+            kneeLiveSlider.flush();
+            setKneeDragValue(null);
+          }}
+          onKeyUp={() => {
+            kneeLiveSlider.flush();
+            setKneeDragValue(null);
+          }}
+          style={{
+            flex: 1,
+            cursor: kneeDisabled ? 'not-allowed' : 'pointer',
+            accentColor: kneeDisabled ? 'var(--fg-3)' : 'var(--accent)',
+            opacity: kneeDisabled ? 0.55 : 1,
+          }}
+        />
+        <span
+          className="mono"
+          style={{
+            flex: '0 0 auto',
+            width: 60,
+            textAlign: 'right',
+            color: kneeDisabled ? 'var(--fg-3)' : 'var(--fg-1)',
+            fontSize: 11,
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {kneeSet ? `${Math.round(kneeSliderValue)} dBm` : '—'}
         </span>
       </label>
 

--- a/zeus-web/src/components/SmartNrController.test.tsx
+++ b/zeus-web/src/components/SmartNrController.test.tsx
@@ -93,6 +93,7 @@ function mockState(nr: NrConfigDto): RadioStateDto {
     txFilterHighHz: conn.txFilterHighHz,
     sampleRate: conn.sampleRate,
     agcTopDb: conn.agcTopDb,
+    agcThresholdDbm: conn.agcThresholdDbm,
     agc: { ...AGC_CONFIG_DEFAULT },
     squelch: { ...SQUELCH_CONFIG_DEFAULT },
     txLeveling: { ...TX_LEVELING_CONFIG_DEFAULT },

--- a/zeus-web/src/state/connection-store.ts
+++ b/zeus-web/src/state/connection-store.ts
@@ -91,6 +91,9 @@ export type ConnectionState = {
   txFilterHighHz: number;
   sampleRate: number;
   agcTopDb: number;
+  // AGC threshold ("knee") in dBm. Null = operator hasn't set it (WDSP mode
+  // default in effect). Independent of agcTopDb and auto-AGC.
+  agcThresholdDbm: number | null;
   agc: AgcConfigDto;
   squelch: SquelchConfigDto;
   txLeveling: TxLevelingConfigDto;
@@ -179,6 +182,7 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
   txFilterHighHz: 2850,
   sampleRate: 192_000,
   agcTopDb: 45,
+  agcThresholdDbm: null,
   agc: { ...AGC_CONFIG_DEFAULT },
   squelch: { ...SQUELCH_CONFIG_DEFAULT },
   txLeveling: { ...TX_LEVELING_CONFIG_DEFAULT },
@@ -235,6 +239,7 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
         txFilterHighHz: s.txFilterHighHz,
         sampleRate: s.sampleRate,
         agcTopDb: s.agcTopDb,
+        agcThresholdDbm: s.agcThresholdDbm ?? null,
         agc: s.agc,
         squelch: s.squelch,
         txLeveling: s.txLeveling,


### PR DESCRIPTION
Closes the gap behind a #740 operator report that "AGC-T isn't linear". Investigation (vs. Thetis) showed Zeus's AGC-T slider is **correct** — it's the max-gain cap (`SetRXAAGCTop`), exactly matching Thetis, and the non-linear *feel* is inherent to a cap. The smooth, signal-relative control Thetis exposes is a **separate threshold (knee)** that Zeus never had. This adds it. Bench-validated on a G2 ("works great"). Tracks #741.

## What
A **"Knee"** control next to AGC-T that sets the AGC **threshold** in dBm (`SetRXAAGCThresh`) — the level below which the AGC applies increasing gain up to the cap. Unlike the max-gain cap, moving it feels smooth/proportional.

- **Backend:** `SetRXAAGCThresh` + `GetRXAAGCThresh` + `GetRXAAGCTop` P/Invokes; `IDspEngine.SetAgcThresh`/`GetAgcThresh` (WDSP drives it with the channel's FFT size + sample rate; Synthetic stubs). `RadioService.SetAgcThreshold` (clamp −160..2 dBm, Thetis range) + `DisengageAgcThreshold`. The pipeline converts operator/displayed dBm → WDSP scale with the **per-board RX meter offset** the meters use, so the knee lines up with the displayed spectrum. Persisted via `DspSettingsStore`; `POST /api/agc/threshold` + `/disengage`.
- **Engage/disengage:** the knee is opt-in (`AgcThresholdDbm` nullable) — **null = WDSP's per-mode default in effect, so default behaviour is unchanged** until the operator uses it. The "Knee" button **lights when engaged** and disengaging restores WDSP's captured per-mode default threshold (a true "off", not a stale override).
- **Auto-AGC untouched:** the knee is independent of the max-gain auto-AGC loop (setting it does not disable auto or zero the offset).
- **AGC-T max-gain slider unchanged** (it matches Thetis).

## Test
- `SetAgcThreshold` clamp / null-default / persistence / auto-AGC-independence; `DisengageAgcThreshold` clears to null + persists cleared across instances; frontend knee test.
- Server suite **1341 passed / 0 failed**; frontend builds.

## Notes for reviewers
- Red-light surface (AGC behaviour) — but additive and opt-in; no change to existing AGC defaults.
- No new NuGet/npm deps.
- Deferred (documented in #741): the on-spectrum draggable knee line, and the Thetis "read-back top after thresh → mirror the AGC-T slider" display nicety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)