### PR TITLE
fix(rx-audio): kill output-buffer underrun crackle with an adaptive prebuffer

### DIFF
--- a/Zeus.Server.Hosting/NativeAudioSink.cs
+++ b/Zeus.Server.Hosting/NativeAudioSink.cs
@@ -69,14 +69,34 @@ internal sealed class NativeAudioSink : IRxAudioSink, IPreviewAudioSink, IHosted
     // jitter.
     private const int RingCapacity = 65_536;
 
-    // Hold roughly 60 ms before starting or resuming playback. This is also the
-    // steady-state ring depth — after each (re)buffer the ring refills to this
-    // level — so a larger cushion gives more tolerance to DSP-tick jitter (CPU
-    // load, GC pauses, scheduler latency) before the ring drains and the OS
-    // callback splices a silence tail into the audio, which presents as RX
-    // crackle. 60 ms absorbs several DSP blocks of jitter for imperceptible
-    // added RX latency. (Was 20 ms / 960, which underran under load — issue #733.)
-    private const int PlaybackPrebufferSamples = 2880;
+    // Floor for the prebuffer cushion: hold ~120 ms before starting/resuming
+    // playback, and refill to this depth after every (re)buffer.
+    //
+    // Why 120 ms and why adaptive (#742): the producer is the DSP RX tick, which
+    // publishes audio in BURSTS gated to ~33 ms (MaybeTickInline) on the RX
+    // packet thread — the same thread that also runs the squelch/leveler/plugin
+    // chain and the panadapter/waterfall work. The consumer is the miniaudio
+    // device callback draining steadily every device period. Between bursts the
+    // consumer drains with no production, so the ring must hold at least one
+    // inter-tick gap; any tick delayed by GC / CPU load / scheduler latency
+    // drains further. The old 60 ms (2880) was only ~2 tick intervals — a single
+    // delayed tick left too little margin and the callback short-read a silence
+    // tail (heard as crackle): a G2 report showed ~4.6% of callbacks short-read
+    // (222k silence samples) while the DSP side was provably healthy.
+    //
+    // 120 ms ≈ 3.6 tick intervals — absorbs a stalled tick with headroom. The
+    // EFFECTIVE target is also made adaptive at runtime to the negotiated device
+    // period (see OnPlaybackData): miniaudio may ignore our 480-frame request and
+    // hand us a larger callback, in which case the cushion grows to ≥ 4 callbacks
+    // so a big-period default device can't outrun a thin fixed cushion. Pure
+    // latency-vs-robustness trade — managed only, identical on every platform.
+    // (History: 20 ms underran badly, 60 ms underran under load — both #733/#742.)
+    private const int PlaybackPrebufferSamples = 5760;
+
+    // Effective prebuffer cushion actually in force — max(floor, 4×callbackFrames),
+    // recomputed per callback once the device's real period is known. Reported in
+    // diagnostics so a report shows the cushion that was active.
+    private volatile int _effectivePrebufferSamples = PlaybackPrebufferSamples;
 
     // ~250 ms @ 48 kHz mono = 12000 samples ≈ 48 KB. Power of two for the
     // mask wrap. The preview path is sourced from mic capture (one block
@@ -143,7 +163,7 @@ internal sealed class NativeAudioSink : IRxAudioSink, IPreviewAudioSink, IHosted
         RebufferEvents: Interlocked.Read(ref _rebufferEvents),
         RingDepthSamples: _ring.Count,
         RingCapacitySamples: RingCapacity,
-        PrebufferSamples: PlaybackPrebufferSamples,
+        PrebufferSamples: _effectivePrebufferSamples,
         SampleRateHz: FrameRateHz,
         Rebuffering: _rebuffering);
 
@@ -407,6 +427,21 @@ internal sealed class NativeAudioSink : IRxAudioSink, IPreviewAudioSink, IHosted
         MaybeLog();
     }
 
+    // Effective prebuffer/refill cushion for a device callback of
+    // <paramref name="totalFrames"/> frames: the larger of the 120 ms floor and
+    // four callbacks deep, capped to leave one callback of ring headroom (a
+    // target ≥ capacity would wedge rebuffering forever). #742.
+    internal static int ComputePrebufferTarget(int totalFrames)
+    {
+        if (totalFrames <= 0) return PlaybackPrebufferSamples;
+        int desired = Math.Max(PlaybackPrebufferSamples, totalFrames * 4);
+        // Keep one callback of ring headroom; a target >= capacity would wedge
+        // rebuffering forever. For an absurd period (> half the ring) just
+        // degrade to whatever headroom remains rather than throw.
+        int ceiling = Math.Max(1, RingCapacity - totalFrames);
+        return Math.Min(desired, ceiling);
+    }
+
     private void OnPlaybackData(Span<float> output, uint frameCount, uint channels)
     {
         // miniaudio's buffer is interleaved float32 sized frameCount * channels.
@@ -421,11 +456,17 @@ internal sealed class NativeAudioSink : IRxAudioSink, IPreviewAudioSink, IHosted
             ? stackalloc float[totalFrames]
             : new float[totalFrames];
 
+        // Size the cushion to the LARGER of the 120 ms floor and 4× this device's
+        // actual callback (the negotiated period may exceed our 480-frame
+        // request). #742.
+        int prebufferTarget = ComputePrebufferTarget(totalFrames);
+        _effectivePrebufferSamples = prebufferTarget;
+
         bool rxSilence = false;
         int queued = _ring.Count;
         if (_rebuffering)
         {
-            if (queued >= PlaybackPrebufferSamples)
+            if (queued >= prebufferTarget)
             {
                 _rebuffering = false;
             }

--- a/tests/Zeus.Server.Tests/NativeAudioSinkDiagnosticsTests.cs
+++ b/tests/Zeus.Server.Tests/NativeAudioSinkDiagnosticsTests.cs
@@ -6,10 +6,13 @@ using Zeus.Server;
 namespace Zeus.Server.Tests;
 
 /// <summary>
-/// issue #733: the native-output cushion was raised 20 ms -> 60 ms to stop the
-/// intermittent RX crackle (output-ring underflow splicing silence under
-/// DSP-tick jitter), and the underrun/overrun/rebuffer counters are now
-/// surfaced via <see cref="NativeAudioSink.GetDiagnostics"/> (and
+/// issue #733/#742: the native-output cushion stops intermittent RX crackle
+/// (output-ring underflow splicing silence under DSP-tick jitter). It was
+/// raised 20 ms -> 60 ms (#733) and then to a 120 ms floor that is also made
+/// adaptive to the device's real callback period (#742, the dominant cause: a
+/// bursty ~33 ms producer vs a steady device drain, a thin cushion, and a
+/// possibly-large negotiated period). The underrun/overrun/rebuffer counters
+/// are surfaced via <see cref="NativeAudioSink.GetDiagnostics"/> (and
 /// /api/audio/native) so the condition is measurable rather than log-only.
 /// </summary>
 public sealed class NativeAudioSinkDiagnosticsTests
@@ -23,7 +26,7 @@ public sealed class NativeAudioSinkDiagnosticsTests
 
         var d = sink.GetDiagnostics();
 
-        Assert.Equal(2880, d.PrebufferSamples);   // ~60 ms @ 48 kHz cushion
+        Assert.Equal(5760, d.PrebufferSamples);   // ~120 ms @ 48 kHz floor (#742)
         Assert.Equal(48_000, d.SampleRateHz);
         Assert.Equal(65_536, d.RingCapacitySamples);
         Assert.Equal(0L, d.UnderrunSamplesTotal);
@@ -33,5 +36,29 @@ public sealed class NativeAudioSinkDiagnosticsTests
         // A fresh sink starts in the rebuffering state — it holds silence until
         // the prebuffer cushion fills before (re)starting playback.
         Assert.True(d.Rebuffering);
+    }
+
+    [Theory]
+    // Small/typical device period (10 ms @ 48 kHz): the 120 ms floor dominates.
+    [InlineData(480, 5760)]
+    [InlineData(960, 5760)]
+    [InlineData(1024, 5760)]
+    // Large negotiated period: cushion grows to 4× the callback so a big-period
+    // default device can't outrun a thin fixed cushion (#742 hypothesis #2).
+    [InlineData(2048, 8192)]
+    [InlineData(4096, 16384)]
+    // Degenerate inputs stay safe (never negative, never >= ring capacity).
+    [InlineData(0, 5760)]
+    public void ComputePrebufferTarget_IsFloorOrFourCallbacks_Clamped(int totalFrames, int expected)
+    {
+        Assert.Equal(expected, NativeAudioSink.ComputePrebufferTarget(totalFrames));
+    }
+
+    [Fact]
+    public void ComputePrebufferTarget_NeverMeetsOrExceedsRingCapacity()
+    {
+        // A target >= capacity would wedge the sink in permanent rebuffering.
+        Assert.True(NativeAudioSink.ComputePrebufferTarget(40_000) <= 65_536 - 40_000);
+        Assert.True(NativeAudioSink.ComputePrebufferTarget(60_000) < 65_536);
     }
 }


### PR DESCRIPTION
Fixes the RX "crackle" surfaced by two #740 "Report a problem" diagnostics on a G2. Tracks #742.

## Root cause
The crackle is `NativeAudioSink` **output-ring underflow**, not a DSP overload. The diagnostics showed `audio.underrunSamplesTotal` reaching 167k–222k while the WDSP side was provably healthy (`queueDepth=0, audioOverrun=0, workerMaxMs≈0.08`). The producer is the DSP RX tick — it publishes audio in **bursts gated to ~33 ms** on the RX packet thread (shared with squelch/leveler/plugin + panadapter work); the consumer is the steady miniaudio device callback. The old 60 ms (2880-sample) cushion was only ~2 tick intervals, so a single tick delayed by GC / CPU / scheduler jitter drained the ring below one callback and the device spliced a silence tail — heard as crackle. (~4.6% of callbacks short-read in the report; that path counts underruns without tripping `rebufferEvents`, which is why the ring snapshot looked healthy and `rebufferEvents` was 0.)

## Fix (managed-only, cross-platform, no native rebuild)
- Raise the prebuffer/refill floor 60 ms → 120 ms (2880 → 5760), and make the effective cushion **adaptive**: `max(120 ms floor, 4 × the device's real callback frames)`. miniaudio may ignore our 480-frame request and hand back a larger negotiated period (the `activeDeviceId: none` / default-device tell) — sizing to 4× the actual callback means a big-period device can't outrun a thin fixed cushion. Capped to leave one callback of ring headroom so it can't wedge rebuffering forever.
- Logic extracted to `ComputePrebufferTarget` and unit-tested; the effective cushion is reported in `GetDiagnostics`.
- Cost: ~60 ms additional RX latency in the common case — imperceptible for listening.

## Test
- `ComputePrebufferTarget` floor / 4×-callback / clamp cases + fresh-sink diagnostics.
- Server suite **1223 passed / 0 failed**.

## Deferred (bench verification on real hardware — documented in #742, NOT in this PR)
- macOS/Linux playback-thread QoS hint (parity with the existing Windows Pro Audio MMCSS request) — touches native thread scheduling + needs a dylib rebuild.
- Surfacing miniaudio's **negotiated** period via a native shim getter, so the cushion can size to the true period rather than the requested one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)