### PR TITLE
fix: keep band modes DB-authoritative during fast switching

### DIFF
--- a/zeus-web/src/components/BandButtons.test.tsx
+++ b/zeus-web/src/components/BandButtons.test.tsx
@@ -9,8 +9,10 @@ import {
   setMode,
   setVfo,
   type RadioStateDto,
+  type RxMode,
 } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import { BAND_MEMORY_UPDATED_EVENT, type BandMemoryUpdatedDetail } from '../util/band-memory';
 import { act, render } from './meters/__tests__/harness';
 import { BandButtons } from './BandButtons';
 
@@ -39,6 +41,17 @@ function resetStore() {
   });
 }
 
+function dispatchBandMemoryUpdated(
+  band: string,
+  hz: number,
+  mode: RxMode,
+) {
+  window.dispatchEvent(new CustomEvent<BandMemoryUpdatedDetail>(
+    BAND_MEMORY_UPDATED_EVENT,
+    { detail: { band, hz, mode } },
+  ));
+}
+
 describe('BandButtons', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -52,6 +65,9 @@ describe('BandButtons', () => {
 
   it('flushes mode memory for the departing band before selecting another band', async () => {
     vi.useFakeTimers();
+    vi.mocked(fetchBandMemory).mockResolvedValue([
+      { band: '20m', hz: 14_200_000, mode: 'USB' },
+    ]);
     const { container, unmount } = render(createElement(BandButtons));
     await act(async () => {
       await Promise.resolve();
@@ -60,6 +76,7 @@ describe('BandButtons', () => {
 
     act(() => {
       useConnectionStore.setState({ mode: 'LSB' });
+      dispatchBandMemoryUpdated('20m', 14_200_000, 'LSB');
     });
     const fortyMeters = Array.from(container.querySelectorAll<HTMLButtonElement>('button'))
       .find((button) => button.textContent === '40m');
@@ -104,6 +121,35 @@ describe('BandButtons', () => {
     expect(setVfoCallOrder).toBeDefined();
     expect(setModeCallOrder!).toBeLessThan(setVfoCallOrder!);
     expect(useConnectionStore.getState().mode).toBe('AM');
+
+    unmount();
+  });
+
+  it('does not overwrite a remembered band mode from a transient mode snapshot', async () => {
+    vi.useFakeTimers();
+    vi.mocked(fetchBandMemory).mockResolvedValue([
+      { band: '20m', hz: 14_200_000, mode: 'USB' },
+    ]);
+    const { container, unmount } = render(createElement(BandButtons));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    vi.clearAllMocks();
+
+    act(() => {
+      useConnectionStore.setState({ mode: 'LSB' });
+    });
+    const fortyMeters = Array.from(container.querySelectorAll<HTMLButtonElement>('button'))
+      .find((button) => button.textContent === '40m');
+
+    await act(async () => {
+      fortyMeters?.click();
+      await Promise.resolve();
+    });
+
+    expect(fortyMeters).toBeTruthy();
+    expect(saveBandMemory).toHaveBeenCalledWith('20m', 14_200_000, 'USB');
+    expect(saveBandMemory).not.toHaveBeenCalledWith('20m', 14_200_000, 'LSB');
 
     unmount();
   });

--- a/zeus-web/src/components/BandButtons.tsx
+++ b/zeus-web/src/components/BandButtons.tsx
@@ -53,6 +53,10 @@ import {
   type RxMode,
 } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import {
+  BAND_MEMORY_UPDATED_EVENT,
+  type BandMemoryUpdatedDetail,
+} from '../util/band-memory';
 import { BANDS, bandOf } from './design/data';
 import { toolbarFavDragMime } from './toolbar/toolbarFavoriteDrag';
 
@@ -61,6 +65,11 @@ type BandEntry = {
   centerHz: number;
   rangeStart: number;
   rangeEnd: number;
+};
+
+type PendingBandHzSave = {
+  band: string;
+  hz: number;
 };
 
 // HF bands only (160m-10m) for Hermes Lite 2 coverage
@@ -91,7 +100,7 @@ export function BandButtons() {
   // band click can apply the saved (hz, mode) without an extra round-trip.
   const memoryRef = useRef<Map<string, BandMemoryEntry>>(new Map());
   const saveTimerRef = useRef<number | null>(null);
-  const pendingSaveRef = useRef<BandMemoryEntry | null>(null);
+  const pendingSaveRef = useRef<PendingBandHzSave | null>(null);
   const lastBandRef = useRef<string>(currentBand);
 
   // Initial load of server-persisted band memory
@@ -109,6 +118,19 @@ export function BandButtons() {
     return () => ac.abort();
   }, []);
 
+  useEffect(() => {
+    const onBandMemoryUpdated = (event: Event) => {
+      const { detail } = event as CustomEvent<BandMemoryUpdatedDetail>;
+      if (!detail) return;
+      memoryRef.current.set(detail.band, detail);
+    };
+
+    window.addEventListener(BAND_MEMORY_UPDATED_EVENT, onBandMemoryUpdated);
+    return () => {
+      window.removeEventListener(BAND_MEMORY_UPDATED_EVENT, onBandMemoryUpdated);
+    };
+  }, []);
+
   const clearSaveTimer = useCallback(() => {
     if (saveTimerRef.current !== null) {
       window.clearTimeout(saveTimerRef.current);
@@ -122,8 +144,12 @@ export function BandButtons() {
 
     pendingSaveRef.current = null;
     clearSaveTimer();
-    memoryRef.current.set(pending.band, pending);
-    saveBandMemory(pending.band, pending.hz, pending.mode).catch(() => {
+    const remembered = memoryRef.current.get(pending.band);
+    if (!remembered) return;
+
+    const next = { ...remembered, hz: pending.hz };
+    memoryRef.current.set(next.band, next);
+    saveBandMemory(next.band, next.hz, next.mode).catch(() => {
       /* best-effort — next tune will retry */
     });
   }, [clearSaveTimer]);
@@ -135,9 +161,9 @@ export function BandButtons() {
     };
   }, [clearSaveTimer]);
 
-  // Track current band + debounced save of (hz, mode) for that band.
-  // Crossing bands flushes the previous band's pending row so a quick
-  // mode-change-then-band-click does not drop the old band's mode memory.
+  // Track current band + debounced save of the last Hz for that band. The
+  // remembered mode is preserved from DB/user mode changes, never inferred
+  // from transient mode snapshots during band switching.
   useEffect(() => {
     const band = bandOf(vfoHz);
     setCurrentBand(band);
@@ -147,10 +173,10 @@ export function BandButtons() {
     }
     if (band === '—') return;
 
-    pendingSaveRef.current = { band, hz: vfoHz, mode };
+    pendingSaveRef.current = { band, hz: vfoHz };
     clearSaveTimer();
     saveTimerRef.current = window.setTimeout(flushPendingSave, SAVE_DEBOUNCE_MS);
-  }, [clearSaveTimer, flushPendingSave, vfoHz, mode]);
+  }, [clearSaveTimer, flushPendingSave, vfoHz]);
 
   const selectBand = useCallback(
     (band: BandEntry) => {

--- a/zeus-web/src/components/toolbar/BandFavorites.test.tsx
+++ b/zeus-web/src/components/toolbar/BandFavorites.test.tsx
@@ -11,9 +11,11 @@ import {
   setVfo,
   setVfoB,
   type RadioStateDto,
+  type RxMode,
 } from '../../api/client';
 import { useConnectionStore } from '../../state/connection-store';
 import { useToolbarFavoritesStore } from '../../state/toolbar-favorites-store';
+import { BAND_MEMORY_UPDATED_EVENT, type BandMemoryUpdatedDetail } from '../../util/band-memory';
 import { BandFavorites } from './BandFavorites';
 
 function currentStateDto(): RadioStateDto {
@@ -50,6 +52,17 @@ function resetStores() {
   });
 }
 
+function dispatchBandMemoryUpdated(
+  band: string,
+  hz: number,
+  mode: RxMode,
+) {
+  window.dispatchEvent(new CustomEvent<BandMemoryUpdatedDetail>(
+    BAND_MEMORY_UPDATED_EVENT,
+    { detail: { band, hz, mode } },
+  ));
+}
+
 describe('BandFavorites', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -83,6 +96,9 @@ describe('BandFavorites', () => {
 
   it('flushes focused receiver mode memory before changing bands', async () => {
     vi.useFakeTimers();
+    vi.mocked(fetchBandMemory).mockResolvedValue([
+      { band: '40m', hz: 7_200_000, mode: 'LSB' },
+    ]);
     const { container, unmount } = render(createElement(BandFavorites));
     await act(async () => {
       await Promise.resolve();
@@ -91,6 +107,7 @@ describe('BandFavorites', () => {
 
     act(() => {
       useConnectionStore.setState({ modeB: 'CWU' });
+      dispatchBandMemoryUpdated('40m', 7_200_000, 'CWU');
     });
     const twentyMeters = Array.from(container.querySelectorAll<HTMLButtonElement>('button'))
       .find((button) => button.textContent === '20m');
@@ -131,6 +148,35 @@ describe('BandFavorites', () => {
     expect(setVfo).not.toHaveBeenCalled();
     expect(useConnectionStore.getState().mode).toBe('USB');
     expect(useConnectionStore.getState().modeB).toBe('DIGU');
+
+    unmount();
+  });
+
+  it('does not overwrite focused-receiver band mode from a transient mode snapshot', async () => {
+    vi.useFakeTimers();
+    vi.mocked(fetchBandMemory).mockResolvedValue([
+      { band: '40m', hz: 7_200_000, mode: 'LSB' },
+    ]);
+    const { container, unmount } = render(createElement(BandFavorites));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    vi.clearAllMocks();
+
+    act(() => {
+      useConnectionStore.setState({ modeB: 'CWU' });
+    });
+    const twentyMeters = Array.from(container.querySelectorAll<HTMLButtonElement>('button'))
+      .find((button) => button.textContent === '20m');
+
+    await act(async () => {
+      twentyMeters?.click();
+      await Promise.resolve();
+    });
+
+    expect(twentyMeters).toBeTruthy();
+    expect(saveBandMemory).toHaveBeenCalledWith('40m', 7_200_000, 'LSB');
+    expect(saveBandMemory).not.toHaveBeenCalledWith('40m', 7_200_000, 'CWU');
 
     unmount();
   });

--- a/zeus-web/src/components/toolbar/BandFavorites.tsx
+++ b/zeus-web/src/components/toolbar/BandFavorites.tsx
@@ -19,12 +19,21 @@ import {
 } from '../../api/client';
 import { useConnectionStore } from '../../state/connection-store';
 import { viewCenterFor } from '../../state/view-center';
+import {
+  BAND_MEMORY_UPDATED_EVENT,
+  type BandMemoryUpdatedDetail,
+} from '../../util/band-memory';
 import { BANDS, bandOf } from '../design/data';
 import { ToolbarFavorites, type ToolbarOption } from './ToolbarFavorites';
 
 type BandEntry = {
   name: string;
   centerHz: number;
+};
+
+type PendingBandHzSave = {
+  band: string;
+  hz: number;
 };
 
 const HF_BANDS: readonly BandEntry[] = BANDS.slice(0, 10).map((b) => ({
@@ -58,7 +67,7 @@ export function BandFavorites() {
   const [currentBand, setCurrentBand] = useState<string>(() => bandOf(activeVfoHz));
   const memoryRef = useRef<Map<string, BandMemoryEntry>>(new Map());
   const saveTimerRef = useRef<number | null>(null);
-  const pendingSaveRef = useRef<BandMemoryEntry | null>(null);
+  const pendingSaveRef = useRef<PendingBandHzSave | null>(null);
   const lastBandRef = useRef<string>(currentBand);
 
   useEffect(() => {
@@ -75,6 +84,19 @@ export function BandFavorites() {
     return () => ac.abort();
   }, []);
 
+  useEffect(() => {
+    const onBandMemoryUpdated = (event: Event) => {
+      const { detail } = event as CustomEvent<BandMemoryUpdatedDetail>;
+      if (!detail) return;
+      memoryRef.current.set(detail.band, detail);
+    };
+
+    window.addEventListener(BAND_MEMORY_UPDATED_EVENT, onBandMemoryUpdated);
+    return () => {
+      window.removeEventListener(BAND_MEMORY_UPDATED_EVENT, onBandMemoryUpdated);
+    };
+  }, []);
+
   const clearSaveTimer = useCallback(() => {
     if (saveTimerRef.current !== null) {
       window.clearTimeout(saveTimerRef.current);
@@ -88,8 +110,12 @@ export function BandFavorites() {
 
     pendingSaveRef.current = null;
     clearSaveTimer();
-    memoryRef.current.set(pending.band, pending);
-    saveBandMemory(pending.band, pending.hz, pending.mode).catch(() => { /* next tune retries */ });
+    const remembered = memoryRef.current.get(pending.band);
+    if (!remembered) return;
+
+    const next = { ...remembered, hz: pending.hz };
+    memoryRef.current.set(next.band, next);
+    saveBandMemory(next.band, next.hz, next.mode).catch(() => { /* next tune retries */ });
   }, [clearSaveTimer]);
 
   useEffect(() => {
@@ -108,10 +134,10 @@ export function BandFavorites() {
     }
     if (band === '—') return;
 
-    pendingSaveRef.current = { band, hz: activeVfoHz, mode: activeMode };
+    pendingSaveRef.current = { band, hz: activeVfoHz };
     clearSaveTimer();
     saveTimerRef.current = window.setTimeout(flushPendingSave, SAVE_DEBOUNCE_MS);
-  }, [activeVfoHz, activeMode, clearSaveTimer, flushPendingSave]);
+  }, [activeVfoHz, clearSaveTimer, flushPendingSave]);
 
   const onSelect = useCallback(
     (key: string) => {

--- a/zeus-web/src/util/band-memory.ts
+++ b/zeus-web/src/util/band-memory.ts
@@ -8,6 +8,8 @@ import {
 import { bandOf } from '../components/design/data';
 import { useConnectionStore } from '../state/connection-store';
 
+export const BAND_MEMORY_UPDATED_EVENT = 'zeus-band-memory-updated';
+
 type BandMemoryState = {
   vfoHz: number;
   vfoBHz: number;
@@ -16,12 +18,30 @@ type BandMemoryState = {
   modeB: RxMode;
 };
 
+export type BandMemoryUpdatedDetail = {
+  band: string;
+  hz: number;
+  mode: RxMode;
+};
+
+function dispatchBandMemoryUpdated(detail: BandMemoryUpdatedDetail): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent<BandMemoryUpdatedDetail>(
+    BAND_MEMORY_UPDATED_EVENT,
+    { detail },
+  ));
+}
+
 export function saveBandModeMemory(hz: number, mode: RxMode): void {
   const band = bandOf(hz);
   if (band === '—') return;
-  saveBandMemory(band, hz, mode).catch(() => {
-    /* best-effort; the next tune or mode change retries */
-  });
+  const optimistic = { band, hz, mode };
+  dispatchBandMemoryUpdated(optimistic);
+  saveBandMemory(band, hz, mode)
+    .then((saved) => dispatchBandMemoryUpdated(saved))
+    .catch(() => {
+      /* best-effort; the next tune or mode change retries */
+    });
 }
 
 export function saveReceiverBandModeMemory(


### PR DESCRIPTION
## Summary
- keep per-band DB mode authoritative during band switching
- automatic band tracking now updates last Hz while preserving the remembered DB/user mode
- explicit mode changes still save to the band-memory DB immediately and notify band selectors synchronously
- add regressions that distinguish explicit user mode saves from transient mode snapshots

## Verification
- npm --prefix zeus-web run test -- BandButtons BandFavorites
- npm --prefix zeus-web run test -- BandButtons BandFavorites ModeFavorites ModeBandwidth
- npm --prefix zeus-web run typecheck
- npm --prefix zeus-web run lint (passes with existing svgChrome fast-refresh warning)
- npm --prefix zeus-web run build
- npm --prefix zeus-web run test