### PR TITLE
fix(layout): fixed-lattice workspace grid (move-only + swap, no cascade)

### DIFF
--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -33,7 +33,7 @@ import {
   type LayoutItem,
 } from 'react-grid-layout';
 import { absoluteStrategy } from 'react-grid-layout/core';
-import { Plus, Puzzle, Settings } from 'lucide-react';
+import { LayoutGrid, Plus, Puzzle, Settings } from 'lucide-react';
 import { useWorkspace } from './WorkspaceContext';
 import { parseLayoutOrDefault, useLayoutStore } from '../state/layout-store';
 import { getPanelDef } from './panels';
@@ -41,6 +41,8 @@ import {
   WORKSPACE_RESIZE_COMPACTOR,
   autoFitDroppedPanel,
   createWorkspaceDragCompactor,
+  resolveResizeOverlaps,
+  tidyWorkspacePlacements,
   type WorkspaceDragStartSnapshot,
 } from './workspaceGrid';
 import {
@@ -163,6 +165,33 @@ export function FlexWorkspace({
     [addTileToLayout, targetLayoutId],
   );
 
+  // Tidy is the ONLY path that packs the grid. The free-grid drag/resize model
+  // leaves gaps exactly where the operator left them; this button magnets the
+  // movable tiles up to close those gaps on demand, keeping each tile's column
+  // and never moving a locked tile.
+  const onTidy = useCallback(() => {
+    if (workspaceLocked) return;
+    const packed = tidyWorkspacePlacements(
+      workspace.tiles.map((t) => ({
+        i: t.uid,
+        x: t.x,
+        y: t.y,
+        w: t.w,
+        h: t.h,
+        static: t.locked === true,
+      })),
+    );
+    updateTilePlacementsInLayout(
+      targetLayoutId,
+      packed.map((p) => ({ uid: p.i, x: p.x, y: p.y, w: p.w, h: p.h })),
+    );
+  }, [
+    workspace.tiles,
+    workspaceLocked,
+    targetLayoutId,
+    updateTilePlacementsInLayout,
+  ]);
+
   // Brief loading state while the server fetch resolves. We render the
   // empty container so it has measurable width when the tiles arrive.
   return (
@@ -189,6 +218,18 @@ export function FlexWorkspace({
           aria-label="Add panel"
         >
           <Plus size={18} strokeWidth={2.2} aria-hidden />
+        </button>
+      )}
+      {showAddPanelModal && !addPanelOpen && !workspaceLocked && (
+        <button
+          type="button"
+          className="workspace-tidy-btn"
+          onClick={onTidy}
+          disabled={!isLoaded}
+          title="Tidy — close vertical gaps between panels"
+          aria-label="Tidy panels"
+        >
+          <LayoutGrid size={16} strokeWidth={2.2} aria-hidden />
         </button>
       )}
       {showAddPanelModal && addPanelOpen && (
@@ -416,7 +457,14 @@ function WorkspaceCanvas({
       : null;
     setGridInteraction('drag');
   }, []);
-  const onResizeStart = useCallback(() => setGridInteraction('resize'), []);
+  const onResizeStart = useCallback(() => {
+    // Mark the gesture active so the per-frame onLayoutChange persist is
+    // suppressed: live resize uses the free (overlap-allowed) compactor, and we
+    // resolve the overlap once on stop rather than persisting overlapping
+    // geometry mid-drag.
+    draggingRef.current = true;
+    setGridInteraction('resize');
+  }, []);
   const onDragStop = useCallback((
     layout: Layout,
     oldItem: LayoutItem | null,
@@ -450,11 +498,25 @@ function WorkspaceCanvas({
       );
     }
   }, [persist]);
-  const onResizeStop = useCallback(() => {
+  const onResizeStop = useCallback((
+    layout: Layout,
+    oldItem: LayoutItem | null,
+    newItem: LayoutItem | null,
+  ) => {
     draggingRef.current = false;
     dragStartRef.current = null;
     setGridInteraction(null);
-  }, []);
+    const resizedId = newItem?.i ?? oldItem?.i;
+    if (!resizedId) return;
+    // Keep the resized tile's new size; nudge only the neighbours it now
+    // overlaps to their nearest free slot (no cascade). Guard the post-resize
+    // echo for a beat so RGL's re-render doesn't re-persist the raw layout.
+    skipPostDropLayoutChangeRef.current = true;
+    window.setTimeout(() => {
+      skipPostDropLayoutChangeRef.current = false;
+    }, 250);
+    persist(resolveResizeOverlaps(layout, resizedId, WORKSPACE_GRID_COLS));
+  }, [persist]);
   const handleLayoutChange = useCallback(
     (next: Layout) => {
       if (draggingRef.current || skipPostDropLayoutChangeRef.current) {

--- a/zeus-web/src/layout/workspaceGrid.test.ts
+++ b/zeus-web/src/layout/workspaceGrid.test.ts
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { describe, expect, it } from 'vitest';
-import { moveElement } from 'react-grid-layout/core';
 import type { Layout } from 'react-grid-layout';
 
 import {
@@ -9,6 +8,8 @@ import {
   WORKSPACE_RESIZE_COMPACTOR,
   autoFitDroppedPanel,
   createWorkspaceDragCompactor,
+  resolveResizeOverlaps,
+  tidyWorkspacePlacements,
 } from './workspaceGrid';
 
 function cloneLayout(layout: Layout): Layout {
@@ -30,97 +31,137 @@ function expectNoCollisions(layout: Layout) {
   }
 }
 
-function expectStableCompaction(layout: Layout) {
-  const once = WORKSPACE_DRAG_COMPACTOR.compact(layout, 24);
-  const twice = WORKSPACE_DRAG_COMPACTOR.compact(once, 24);
-  expect(twice).toEqual(once);
-}
-
-function fitMovedElement(
-  layout: Layout,
-  dragged: Layout[number],
-  x: number | undefined,
-  y: number | undefined,
-) {
-  const previous = { ...dragged };
-  const previousLayout = cloneLayout(layout);
-  return autoFitDroppedPanel(
-    moveElement(
-      layout,
-      dragged,
-      x,
-      y,
-      true,
-      WORKSPACE_DRAG_COMPACTOR.preventCollision,
-      WORKSPACE_DRAG_COMPACTOR.type,
-      24,
-      WORKSPACE_DRAG_COMPACTOR.allowOverlap,
-    ),
-    24,
-    { item: previous, layout: previousLayout },
+/** Build a drop snapshot: `previous` is where the dragged tile started; `dropped`
+ *  is the full layout with the dragged tile moved to the drop cell (overlap
+ *  allowed, as the live free compactor leaves it). */
+function drop(
+  original: Layout,
+  draggedId: string,
+  to: { x: number; y: number },
+): Layout {
+  const previous = original.find((i) => i.i === draggedId)!;
+  const dropped = cloneLayout(original).map((i) =>
+    i.i === draggedId ? { ...i, x: to.x, y: to.y, moved: true } : i,
   );
+  return autoFitDroppedPanel(dropped, 24, {
+    item: { ...previous },
+    layout: cloneLayout(original),
+  });
 }
 
-function dragAndCompact(
-  layout: Layout,
-  dragged: Layout[number],
-  x: number | undefined,
-  y: number | undefined,
-) {
-  const dragStart = { item: { ...dragged }, layout: cloneLayout(layout) };
-  const compactor = createWorkspaceDragCompactor(() => dragStart);
-  return compactor.compact(
-    moveElement(
-      layout,
-      dragged,
-      x,
-      y,
-      true,
-      compactor.preventCollision,
-      compactor.type,
-      24,
-      compactor.allowOverlap,
-    ),
-    24,
-  );
-}
-
-describe('workspace grid collision policy', () => {
-  const baseLayout: Layout = [
-    { i: 'dragged', x: 0, y: 0, w: 6, h: 2 },
-    { i: 'below', x: 0, y: 2, w: 6, h: 2 },
-  ];
-
-  it('keeps drag layouts sparse while clearing transient moved flags', () => {
-    const next = WORKSPACE_DRAG_COMPACTOR.compact(
-      [{ i: 'dragged', x: 3, y: 4, w: 5, h: 2, moved: true }],
-      24,
-    );
-
+describe('free-grid live compactors are inert', () => {
+  it('drag compactor moves nothing — only clears the moved flag', () => {
+    const layout: Layout = [
+      { i: 'a', x: 0, y: 0, w: 6, h: 4, moved: true },
+      { i: 'b', x: 0, y: 4, w: 6, h: 4 },
+      { i: 'c', x: 6, y: 0, w: 6, h: 6 },
+    ];
+    const next = WORKSPACE_DRAG_COMPACTOR.compact(cloneLayout(layout), 24);
     expect(next).toEqual([
-      { i: 'dragged', x: 3, y: 4, w: 5, h: 2, moved: false },
+      { i: 'a', x: 0, y: 0, w: 6, h: 4, moved: false },
+      { i: 'b', x: 0, y: 4, w: 6, h: 4, moved: false },
+      { i: 'c', x: 6, y: 0, w: 6, h: 6, moved: false },
     ]);
   });
 
-  it('swaps a lower panel into the dragged panel old slot during live drag', () => {
-    const layout = cloneLayout(baseLayout);
-    const dragged = layout[0]!;
+  it('createWorkspaceDragCompactor also leaves neighbours untouched', () => {
+    const layout: Layout = [
+      { i: 'dragged', x: 0, y: 6, w: 6, h: 2, moved: true },
+      { i: 'other', x: 0, y: 0, w: 6, h: 2 },
+    ];
+    const compactor = createWorkspaceDragCompactor(() => null);
+    const next = compactor.compact(cloneLayout(layout), 24);
+    expect(next.find((i) => i.i === 'other')).toMatchObject({ x: 0, y: 0 });
+    expect(next.find((i) => i.i === 'dragged')).toMatchObject({ x: 0, y: 6 });
+  });
 
-    const next = dragAndCompact(layout, dragged, undefined, 2);
+  it('resize compactor leaves an overlap for the stop handler to resolve', () => {
+    // Live resize uses the free compactor: it does not push neighbours. (The
+    // overlap is resolved on resize stop by resolveResizeOverlaps.)
+    const layout: Layout = [
+      { i: 'top', x: 0, y: 0, w: 6, h: 4 },
+      { i: 'below', x: 0, y: 2, w: 6, h: 2 },
+    ];
+    const next = WORKSPACE_RESIZE_COMPACTOR.compact(cloneLayout(layout), 24);
+    expect(next.find((i) => i.i === 'below')).toMatchObject({ x: 0, y: 2 });
+  });
+});
 
-    expect(next.find((item) => item.i === 'dragged')).toMatchObject({
+describe('drop placement — move-only + swap', () => {
+  const base: Layout = [
+    { i: 'a', x: 0, y: 0, w: 6, h: 4 },
+    { i: 'b', x: 0, y: 4, w: 6, h: 4 },
+  ];
+
+  it('keeps a panel exactly where it is dropped on empty space', () => {
+    const next = drop(base, 'a', { x: 12, y: 0 });
+    expect(next.find((i) => i.i === 'a')).toMatchObject({ x: 12, y: 0 });
+    expect(next.find((i) => i.i === 'b')).toMatchObject({ x: 0, y: 4 });
+    expectNoCollisions(next);
+  });
+
+  it('does not move other panels when one is dropped into a free gap', () => {
+    const layout: Layout = [
+      { i: 'a', x: 0, y: 0, w: 6, h: 4 },
+      { i: 'b', x: 0, y: 4, w: 6, h: 4 },
+      { i: 'c', x: 6, y: 0, w: 6, h: 10 },
+    ];
+    const next = drop(layout, 'a', { x: 12, y: 0 });
+    // b and c are completely undisturbed — the reported bug must not recur.
+    expect(next.find((i) => i.i === 'b')).toMatchObject({ x: 0, y: 4 });
+    expect(next.find((i) => i.i === 'c')).toMatchObject({ x: 6, y: 0 });
+    expectNoCollisions(next);
+  });
+
+  it('swaps two same-footprint panels dropped squarely onto each other', () => {
+    const next = drop(base, 'a', { x: 0, y: 4 });
+    expect(next.find((i) => i.i === 'a')).toMatchObject({ x: 0, y: 4 });
+    expect(next.find((i) => i.i === 'b')).toMatchObject({ x: 0, y: 0 });
+    expectNoCollisions(next);
+  });
+
+  it('relocates (does not swap) on a glancing overlap', () => {
+    // Drop `a` only one row into `b` (overlap is 1 of b's 4 rows, < 50%) → no
+    // swap; `a` relocates to the nearest free slot and `b` stays exactly put.
+    const next = drop(base, 'a', { x: 0, y: 1 });
+    expect(next.find((i) => i.i === 'b')).toMatchObject({ x: 0, y: 4 });
+    // `a` did not take `b`'s slot — it settled into free space instead.
+    expect(next.find((i) => i.i === 'a')).not.toMatchObject({ x: 0, y: 4 });
+    expectNoCollisions(next);
+  });
+
+  it('never moves a locked panel a tile is dropped onto', () => {
+    const layout: Layout = [
+      { i: 'dragged', x: 0, y: 0, w: 6, h: 4 },
+      { i: 'locked', x: 0, y: 4, w: 6, h: 4, static: true },
+    ];
+    const next = drop(layout, 'dragged', { x: 0, y: 4 });
+    expect(next.find((i) => i.i === 'locked')).toMatchObject({
       x: 0,
-      y: 2,
-      moved: false,
+      y: 4,
+      static: true,
     });
-    expect(next.find((item) => item.i === 'below')).toMatchObject({
+    // The dragged tile relocates off the locked footprint; nothing else moves.
+    expectNoCollisions(next);
+  });
+
+  it('keeps a large panel at full size when relocating around a locked tile', () => {
+    const layout: Layout = [
+      { i: 'locked', x: 0, y: 0, w: 24, h: 4, static: true },
+      { i: 'hero', x: 0, y: 6, w: 18, h: 20 },
+    ];
+    // Drop hero up onto the locked banner — it must not shrink, just relocate.
+    const next = drop(layout, 'hero', { x: 0, y: 0 });
+    expect(next.find((i) => i.i === 'hero')).toMatchObject({ w: 18, h: 20 });
+    expect(next.find((i) => i.i === 'locked')).toMatchObject({
       x: 0,
       y: 0,
+      static: true,
     });
     expectNoCollisions(next);
   });
 
-  it('swaps the covered panel into the old slot and keeps the stack tight', () => {
+  it('places a large dropped panel without an exponential search blowup', () => {
     const layout: Layout = cloneLayout([
       { i: 'filter', x: 0, y: 0, w: 12, h: 10 },
       { i: 'filterpresets', x: 12, y: 0, w: 6, h: 10 },
@@ -131,417 +172,65 @@ describe('workspace grid collision policy', () => {
       { i: 'txmeters', x: 18, y: 26, w: 6, h: 12 },
       { i: 'dsp', x: 18, y: 38, w: 6, h: 10 },
     ]);
-    const dragged = layout[1]!;
-
-    const next = dragAndCompact(layout, dragged, 18, 16);
-
-    expect(next.find((item) => item.i === 'filterpresets')).toMatchObject({
-      x: 18,
-      y: 16,
-      moved: false,
-    });
-    expect(next.find((item) => item.i === 'tx')).toMatchObject({
-      x: 12,
-      y: 0,
-    });
-    expect(next.find((item) => item.i === 'txmeters')).toMatchObject({ y: 26 });
-    expect(next.find((item) => item.i === 'dsp')).toMatchObject({ y: 38 });
-    expectNoCollisions(next);
-  });
-
-  it('keeps the dragged tile pinned to the pointer when no swap fires', () => {
-    // Root cause of the "quick back and forth" report: the compactor used to
-    // pack the dragged tile upward on any frame that did not fire a swap, then
-    // RGL dragged it back toward the pointer — a 2-cycle at the swap boundary.
-    // A live drag now pins the dragged tile to its pointer cell unconditionally,
-    // so dragging `below` into empty space leaves it where the pointer is rather
-    // than snapping it back up against `above`.
-    const layout: Layout = cloneLayout([
-      { i: 'above', x: 0, y: 0, w: 6, h: 2 },
-      { i: 'below', x: 0, y: 2, w: 6, h: 2 },
-    ]);
-    const below = layout[1]!;
-
-    const next = dragAndCompact(layout, below, 0, 6);
-
-    expect(next.find((i) => i.i === 'below')).toMatchObject({ x: 0, y: 6 });
-    expect(next.find((i) => i.i === 'above')).toMatchObject({ x: 0, y: 0 });
-    expectNoCollisions(next);
-  });
-
-  it('keeps a neighbour swap engaged across the touch boundary', () => {
-    // Reproduces the boundary jitter with one compactor instance (one live
-    // drag). Once `below` engages at full overlap it must stay displaced when
-    // the dragged tile jitters back to the touching row — engagement is sticky,
-    // so the neighbour never snaps home and back (the visible flicker).
-    const base: Layout = cloneLayout([
-      { i: 'dragged', x: 0, y: 0, w: 6, h: 2 },
-      { i: 'below', x: 0, y: 2, w: 6, h: 2 },
-    ]);
-    const dragStart = { item: { ...base[0]! }, layout: cloneLayout(base) };
-    const compactor = createWorkspaceDragCompactor(() => dragStart);
-
-    const step = (y: number) => {
-      const work = cloneLayout(base);
-      const item = work.find((i) => i.i === 'dragged')!;
-      return compactor.compact(
-        moveElement(
-          work,
-          item,
-          0,
-          y,
-          true,
-          compactor.preventCollision,
-          compactor.type,
-          24,
-          compactor.allowOverlap,
-        ),
-        24,
-      );
-    };
-
-    // Engage the swap (full overlap of `below`), then jitter up one row so the
-    // tiles only touch. `below` stays out of its original slot.
-    expect(step(2).find((i) => i.i === 'below')).toMatchObject({ x: 0, y: 0 });
-    const boundary = step(1);
-    expect(boundary.find((i) => i.i === 'below')?.y).not.toBe(2);
-    expectNoCollisions(boundary);
-  });
-
-  // Drive the live-drag compactor with a hand-placed dragged tile so the
-  // vertical overlap with `below` (original slot y=10, h=10) is exact:
-  // overlap = (dy + 10) - 10 = dy rows for the dragged tile at y = dy.
-  // (moveElement would resolve the collision and snap the tile fully onto the
-  // neighbour, so it can't express a partial overlap.)
-  function makeSwapStepper() {
-    const base: Layout = cloneLayout([
-      { i: 'dragged', x: 0, y: 0, w: 6, h: 10 },
-      { i: 'below', x: 0, y: 10, w: 6, h: 10 },
-    ]);
-    const dragStart = { item: { ...base[0]! }, layout: cloneLayout(base) };
-    const compactor = createWorkspaceDragCompactor(() => dragStart);
-    return (dy: number) =>
-      compactor.compact(
-        cloneLayout([
-          { i: 'dragged', x: 0, y: dy, w: 6, h: 10, moved: true },
-          { i: 'below', x: 0, y: 10, w: 6, h: 10 },
-        ]),
-        24,
-      );
-  }
-
-  it('waits for the midpoint before swapping a tall neighbour', () => {
-    // Premium reorder feel: a neighbour only commits to swapping once the
-    // dragged tile has covered half of it, not on the first row of contact.
-    // Two h=10 tiles → engage threshold is 5 rows of overlap.
-    const step = makeSwapStepper();
-
-    // 4 rows of overlap (< 5): no swap. `below` is pushed down under the
-    // floating dragged tile, not lifted into the vacated top row.
-    expect(step(4).find((i) => i.i === 'below')?.y).not.toBe(0);
-    // 5 rows (the midpoint): the swap commits and `below` lifts into the top
-    // row the dragged tile is vacating.
-    expect(step(5).find((i) => i.i === 'below')?.y).toBe(0);
-  });
-
-  it('holds a committed swap through the hysteresis deadband', () => {
-    // Once engaged at the midpoint (50%), the swap holds until the dragged tile
-    // is pulled back past a quarter overlap (25%). h=10 tiles → engage at 5
-    // rows, release below 2.5 rows.
-    const step = makeSwapStepper();
-
-    expect(step(5).find((i) => i.i === 'below')).toMatchObject({ y: 0 }); // engage
-    expect(step(3).find((i) => i.i === 'below')?.y).toBe(0); // deadband: held
-    expect(step(2).find((i) => i.i === 'below')?.y).not.toBe(0); // released
-  });
-
-  it('never moves a locked panel when another panel is dragged onto it', () => {
-    // A locked (static) panel must stay pinned even while another panel is
-    // dragged across it — previously the magnetic swap shoved it aside mid-drag
-    // and it only snapped back on drop.
-    const dragStart = {
-      item: { i: 'dragged', x: 0, y: 0, w: 6, h: 2 },
-      layout: cloneLayout([
-        { i: 'dragged', x: 0, y: 0, w: 6, h: 2 },
-        { i: 'locked', x: 0, y: 2, w: 6, h: 2, static: true },
-      ]),
-    };
-    const compactor = createWorkspaceDragCompactor(() => dragStart);
-    // Live-drag frame: the dragged panel has been moved onto the locked slot.
-    const frame: Layout = cloneLayout([
-      { i: 'dragged', x: 0, y: 2, w: 6, h: 2, moved: true },
-      { i: 'locked', x: 0, y: 2, w: 6, h: 2, static: true },
-    ]);
-
-    const next = compactor.compact(frame, 24);
-
-    expect(next.find((i) => i.i === 'locked')).toMatchObject({
-      x: 0,
-      y: 2,
-      static: true,
-    });
-  });
-
-  it('swaps a colliding panel into the dragged panel old slot on drop', () => {
-    const layout = cloneLayout(baseLayout);
-    const dragged = layout[0]!;
-
-    const next = fitMovedElement(layout, dragged, undefined, 2);
-
-    expect(next.find((item) => item.i === 'dragged')).toMatchObject({
-      x: 0,
-      y: 2,
-      w: 6,
-      h: 2,
-    });
-    expect(next.find((item) => item.i === 'below')).toMatchObject({
-      x: 0,
-      y: 0,
-    });
-    expectNoCollisions(next);
-  });
-
-  it('pushes an occupied gap panel out of the dropped panel target', () => {
-    const layout: Layout = cloneLayout([
-      { i: 'dragged', x: 0, y: 0, w: 10, h: 2, minW: 2, minH: 2 },
-      { i: 'right', x: 14, y: 0, w: 10, h: 2 },
-    ]);
-    const dragged = layout[0]!;
-
-    const next = fitMovedElement(layout, dragged, 8, 0);
-
-    expect(next.find((item) => item.i === 'dragged')).toMatchObject({
-      x: 8,
-      y: 0,
-      w: 10,
-      h: 2,
-    });
-    expect(next.find((item) => item.i === 'right')).toMatchObject({
-      x: 0,
-      y: 2,
-      w: 10,
-      h: 2,
-    });
-    expectNoCollisions(next);
-  });
-
-  it('does not move static panels when another panel is dropped on them', () => {
-    const layout: Layout = cloneLayout([
-      { i: 'dragged', x: 0, y: 0, w: 6, h: 2 },
-      { i: 'locked', x: 0, y: 2, w: 6, h: 2, static: true },
-    ]);
-    const dragged = layout[0]!;
-
-    const next = fitMovedElement(layout, dragged, undefined, 2);
-
-    expect(next.find((item) => item.i === 'locked')).toMatchObject({
-      x: 0,
-      y: 2,
-      static: true,
-    });
-    expect(next.find((item) => item.i === 'dragged')).toMatchObject({
-      x: 0,
-      y: 4,
-    });
-    expectNoCollisions(next);
-  });
-
-  it('displaces occupied panels when the dropped footprint is covered', () => {
-    const layout: Layout = cloneLayout([
-      { i: 'dragged', x: 0, y: 0, w: 12, h: 8, minW: 4, minH: 2 },
-      { i: 'left-block', x: 0, y: 0, w: 8, h: 6 },
-      { i: 'right-block', x: 8, y: 2, w: 16, h: 4 },
-    ]);
-    const dragged = layout[0]!;
-
-    const next = fitMovedElement(layout, dragged, 2, 2);
-
-    expect(next.find((item) => item.i === 'dragged')).toMatchObject({
-      x: 2,
-      y: 2,
-      w: 12,
-      h: 8,
-    });
-    expectNoCollisions(next);
-  });
-
-  it('pushes a colliding panel down when the previous slot is blocked', () => {
-    const layout: Layout = cloneLayout([
-      { i: 'dragged', x: 0, y: 0, w: 6, h: 2 },
-      { i: 'old-slot-neighbor', x: 6, y: 0, w: 6, h: 2 },
-      { i: 'wide', x: 0, y: 2, w: 12, h: 2 },
-    ]);
-    const dragged = layout[0]!;
-
-    const next = fitMovedElement(layout, dragged, undefined, 2);
-
-    expect(next.find((item) => item.i === 'dragged')).toMatchObject({
-      x: 0,
-      y: 2,
-      w: 6,
-      h: 2,
-    });
-    expect(next.find((item) => item.i === 'wide')).toMatchObject({
-      x: 0,
-      y: 4,
-      w: 12,
-      h: 2,
-    });
-    expectNoCollisions(next);
-  });
-
-  it('snaps the dragged panel up against the occupied slot once clear', () => {
-    const layout = cloneLayout(baseLayout);
-    const dragged = layout[0]!;
-
-    const next = fitMovedElement(layout, dragged, undefined, 4);
-
-    expect(next.find((item) => item.i === 'dragged')?.y).toBe(2);
-    expect(next.find((item) => item.i === 'below')?.y).toBe(0);
-  });
-
-  it('keeps large panadapter drag compaction stable', () => {
-    const layout: Layout = cloneLayout([
-      { i: 'filter', x: 0, y: 0, w: 12, h: 10 },
-      { i: 'filterpresets', x: 12, y: 0, w: 6, h: 10 },
-      { i: 'hero', x: 0, y: 10, w: 18, h: 38, minW: 8, minH: 8 },
-      { i: 'vfo', x: 18, y: 0, w: 6, h: 11 },
-      { i: 'smeter', x: 18, y: 11, w: 6, h: 5 },
-      { i: 'tx', x: 18, y: 16, w: 6, h: 10 },
-      { i: 'txmeters', x: 18, y: 26, w: 6, h: 12 },
-      { i: 'dsp', x: 18, y: 38, w: 6, h: 10 },
-    ]);
-    const dragged = layout.find((item) => item.i === 'hero')!;
-    const next = dragAndCompact(layout, dragged, 6, 16);
-
-    expect(next.find((item) => item.i === 'hero')).toMatchObject({
-      x: 6,
-      moved: false,
-    });
-    expectNoCollisions(next);
-    expectStableCompaction(next);
-  });
-
-  it('keeps large panadapter final drop stable through prop resync', () => {
-    const layout: Layout = cloneLayout([
-      { i: 'filter', x: 0, y: 0, w: 12, h: 10 },
-      { i: 'filterpresets', x: 12, y: 0, w: 6, h: 10 },
-      { i: 'hero', x: 0, y: 10, w: 18, h: 38, minW: 8, minH: 8 },
-      { i: 'vfo', x: 18, y: 0, w: 6, h: 11 },
-      { i: 'smeter', x: 18, y: 11, w: 6, h: 5 },
-      { i: 'tx', x: 18, y: 16, w: 6, h: 10 },
-      { i: 'txmeters', x: 18, y: 26, w: 6, h: 12 },
-      { i: 'dsp', x: 18, y: 38, w: 6, h: 10 },
-    ]);
-    const dragged = layout.find((item) => item.i === 'hero')!;
-    const dragStart = { item: { ...dragged }, layout: cloneLayout(layout) };
-    const moved = moveElement(
-      layout,
-      dragged,
-      6,
-      16,
-      true,
-      WORKSPACE_DRAG_COMPACTOR.preventCollision,
-      WORKSPACE_DRAG_COMPACTOR.type,
-      24,
-      WORKSPACE_DRAG_COMPACTOR.allowOverlap,
-    );
-
-    const dropped = autoFitDroppedPanel(moved, 24, dragStart);
-    const resynced = WORKSPACE_DRAG_COMPACTOR.compact(dropped, 24);
-
-    expect(resynced).toEqual(dropped);
-    expectNoCollisions(dropped);
-  });
-
-  it('auto-fits a large dropped panel without an exponential search blowup', () => {
-    // Regression guard: autoFitDroppedPanel used to sweep every (y,x,w,h) of
-    // the dropped panel's footprint, each running full collision resolution.
-    // For the ~18×38 panadapter/hero tile that is hundreds of thousands of
-    // resolves — a multi-second main-thread freeze on drop. The full-size /
-    // origin fast path collapses the common case to a single resolve. The
-    // threshold is deliberately generous (the bug took seconds; the fix is
-    // sub-millisecond) so it flags a complexity regression, not CI jitter.
-    const layout: Layout = cloneLayout([
-      { i: 'filter', x: 0, y: 0, w: 12, h: 10 },
-      { i: 'filterpresets', x: 12, y: 0, w: 6, h: 10 },
-      { i: 'hero', x: 0, y: 10, w: 18, h: 38, minW: 8, minH: 8 },
-      { i: 'vfo', x: 18, y: 0, w: 6, h: 11 },
-      { i: 'smeter', x: 18, y: 11, w: 6, h: 5 },
-      { i: 'tx', x: 18, y: 16, w: 6, h: 10 },
-      { i: 'txmeters', x: 18, y: 26, w: 6, h: 12 },
-      { i: 'dsp', x: 18, y: 38, w: 6, h: 10 },
-    ]);
-    const dragged = layout.find((item) => item.i === 'hero')!;
-
     const start = performance.now();
-    const next = fitMovedElement(layout, dragged, 6, 4);
+    const next = drop(layout, 'hero', { x: 6, y: 4 });
     const elapsedMs = performance.now() - start;
-
     expect(elapsedMs).toBeLessThan(250);
-    // Full size is preserved — the dropped panel is placed, not shrunk.
-    expect(next.find((item) => item.i === 'hero')).toMatchObject({
-      w: 18,
-      h: 38,
-    });
+    expect(next.find((i) => i.i === 'hero')).toMatchObject({ w: 18, h: 38 });
+    expectNoCollisions(next);
+  });
+});
+
+describe('resolveResizeOverlaps — local, no cascade', () => {
+  it('nudges only the overlapped neighbour aside when a tile grows', () => {
+    const layout: Layout = [
+      { i: 'top', x: 0, y: 0, w: 6, h: 4 }, // already grown into `below`
+      { i: 'below', x: 0, y: 2, w: 6, h: 2 },
+      { i: 'far', x: 0, y: 10, w: 6, h: 2 },
+    ];
+    const next = resolveResizeOverlaps(layout, 'top', 24);
+    expect(next.find((i) => i.i === 'top')).toMatchObject({ y: 0, h: 4 });
+    // `below` hops to the nearest free slot, `far` is left exactly where it was.
+    expect(next.find((i) => i.i === 'far')).toMatchObject({ y: 10 });
     expectNoCollisions(next);
   });
 
-  it('never shrinks a repositioned panel to fit around a locked panel', () => {
-    // A dropped panel overlapping a locked (static) panel must keep its full
-    // size and relocate below it — repositioning must never resize the panel.
-    const layout: Layout = cloneLayout([
-      { i: 'locked', x: 0, y: 0, w: 24, h: 4, static: true },
-      { i: 'dragged', x: 0, y: 0, w: 10, h: 6, moved: true },
-    ]);
-    const previous = {
-      item: { i: 'dragged', x: 0, y: 10, w: 10, h: 6 },
-      layout: [] as Layout,
-    };
-
-    const next = autoFitDroppedPanel(layout, 24, previous);
-
-    // Full size preserved (not squeezed into the gap), and the lock is intact.
-    expect(next.find((i) => i.i === 'dragged')).toMatchObject({ w: 10, h: 6 });
+  it('does not move a locked neighbour', () => {
+    const layout: Layout = [
+      { i: 'top', x: 0, y: 0, w: 6, h: 4 },
+      { i: 'locked', x: 0, y: 2, w: 6, h: 2, static: true },
+    ];
+    const next = resolveResizeOverlaps(layout, 'top', 24);
     expect(next.find((i) => i.i === 'locked')).toMatchObject({
       x: 0,
-      y: 0,
+      y: 2,
       static: true,
     });
-    expectNoCollisions(next);
   });
+});
 
-  it('pushes a lower panel down when resize grows into it', () => {
-    const layout = cloneLayout(baseLayout);
-    layout[0]!.h = 4;
-
-    const next = WORKSPACE_RESIZE_COMPACTOR.compact(layout, 24);
-
-    expect(next.find((item) => item.i === 'dragged')?.h).toBe(4);
-    expect(next.find((item) => item.i === 'below')?.y).toBe(4);
-  });
-
-  it('cascades resize pushes through stacked panels', () => {
-    const layout: Layout = [
-      { i: 'resized', x: 0, y: 0, w: 6, h: 5 },
-      { i: 'middle', x: 0, y: 2, w: 6, h: 2 },
-      { i: 'bottom', x: 0, y: 4, w: 6, h: 2 },
-    ];
-
-    const next = WORKSPACE_RESIZE_COMPACTOR.compact(layout, 24);
-
-    expect(next.find((item) => item.i === 'middle')?.y).toBe(5);
-    expect(next.find((item) => item.i === 'bottom')?.y).toBe(7);
-  });
-
-  it('does not compact existing vertical gaps during resize', () => {
+describe('tidyWorkspacePlacements — explicit pack', () => {
+  it('closes vertical gaps while keeping each column', () => {
     const layout: Layout = [
       { i: 'top', x: 0, y: 0, w: 6, h: 2 },
       { i: 'lower', x: 0, y: 6, w: 6, h: 2 },
+      { i: 'side', x: 6, y: 4, w: 6, h: 2 },
     ];
+    const next = tidyWorkspacePlacements(layout);
+    expect(next.find((i) => i.i === 'lower')).toMatchObject({ x: 0, y: 2 });
+    expect(next.find((i) => i.i === 'side')).toMatchObject({ x: 6, y: 0 });
+    expectNoCollisions(next);
+  });
 
-    const next = WORKSPACE_RESIZE_COMPACTOR.compact(layout, 24);
-
-    expect(next.find((item) => item.i === 'lower')?.y).toBe(6);
+  it('packs movable tiles around a locked tile without moving it', () => {
+    const layout: Layout = [
+      { i: 'locked', x: 0, y: 4, w: 6, h: 2, static: true },
+      { i: 'below', x: 0, y: 8, w: 6, h: 2 },
+    ];
+    const next = tidyWorkspacePlacements(layout);
+    expect(next.find((i) => i.i === 'locked')).toMatchObject({ y: 4 });
+    // `below` magnets up to just under the locked tile, not through it.
+    expect(next.find((i) => i.i === 'below')).toMatchObject({ x: 0, y: 6 });
+    expectNoCollisions(next);
   });
 });

--- a/zeus-web/src/layout/workspaceGrid.ts
+++ b/zeus-web/src/layout/workspaceGrid.ts
@@ -1,4 +1,37 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+//
+// Workspace grid placement — FIXED-LATTICE model.
+//
+// The workspace is a free grid, not a packing grid. A panel sits exactly where
+// the operator drops it and STAYS there; moving one panel never reflows the
+// others. This is a deliberate replacement of the old magnetic-compaction
+// engine, whose global vertical re-pack was the root cause of the "I moved one
+// and they all moved" reports — compaction inherently cascades, so it could
+// never be tuned away.
+//
+// The rules, end to end:
+//   - During a live drag/resize NOTHING reflows. The dragged tile floats over
+//     its neighbours (transient overlap is fine — RGL lifts it on top) and the
+//     neighbours hold their cells. The live compactors below are therefore the
+//     identity (they only strip RGL's transient `moved` flag).
+//   - On DROP (placeDroppedPanel): the dragged tile lands where it was dropped.
+//       • lands on empty space → it just stays there (gaps are allowed).
+//       • lands squarely on ONE movable same-footprint-ish neighbour → the two
+//         SWAP and nothing else moves.
+//       • lands overlapping anything else (or a locked tile) → only the dragged
+//         tile relocates, to the nearest free slot to the drop point. Every
+//         other tile is left untouched.
+//   - On RESIZE STOP (resolveResizeOverlaps): the resized tile keeps its new
+//     size; only the neighbours it now overlaps hop to their nearest free slot.
+//     One pass, each to a globally-free cell, so there is no cascade.
+//   - Tidy (tidyWorkspacePlacements): an explicit, operator-invoked pack that
+//     closes vertical gaps. Horizontal placement stays operator-directed (x is
+//     preserved); locked tiles never move. This is the ONLY path that packs.
+//
+// Locked (static) tiles are inert everywhere: they are never relocated, and the
+// free-slot search treats them as immovable obstacles.
 
 import type { Compactor, Layout, LayoutItem } from 'react-grid-layout';
 
@@ -7,280 +40,192 @@ export interface WorkspaceDragStartSnapshot {
   layout: Layout;
 }
 
-// Keep horizontal placement operator-directed, but make vertical placement
-// magnetic: when a tile is dragged into an occupied slot, the displaced tile
-// should swap into the dragged tile's old slot and the stack should close up.
-export const WORKSPACE_DRAG_COMPACTOR = createWorkspaceDragCompactor();
-
-export function createWorkspaceDragCompactor(
-  getDragStart?: () => WorkspaceDragStartSnapshot | null,
-): Compactor {
-  // Per-drag hysteresis state. `engaged` holds the ids of neighbours currently
-  // committed to a swap; it is rebuilt whenever the drag snapshot identity
-  // changes (a new gesture) and dropped when the drag ends (snapshot null).
-  // Carrying it across frames is what gives the swap a deadband — without it
-  // the swap re-derives from scratch every frame and flickers at the boundary.
-  let session: {
-    dragStart: WorkspaceDragStartSnapshot;
-    engaged: Set<string>;
-  } | null = null;
-  return {
-    type: null,
-    allowOverlap: false,
-    compact: (layout, cols) => {
-      const dragStart = getDragStart?.() ?? null;
-      if (!dragStart) {
-        session = null;
-      } else if (!session || session.dragStart !== dragStart) {
-        session = { dragStart, engaged: new Set() };
-      }
-      return compactDragMagnetic(
-        layout,
-        cols,
-        dragStart,
-        session?.engaged ?? null,
-      );
-    },
-  };
-}
-
-export const WORKSPACE_RESIZE_COMPACTOR: Compactor = {
+// Live-interaction compactor: the identity. It never moves a tile — it only
+// clears RGL's transient `moved` flag so the echoed layout is clean. Both drag
+// and resize use this; all real placement happens on drop / resize-stop.
+//
+// allowOverlap:true lets the dragged tile float over its neighbours during the
+// gesture (resolved on drop); preventCollision is intentionally omitted (falsy)
+// so RGL does not try to shove neighbours aside while dragging.
+const FREE_COMPACTOR: Compactor = {
   type: null,
-  allowOverlap: false,
-  compact: compactResizePushDown,
+  allowOverlap: true,
+  compact: (layout) => clearMovedFlags(layout),
 };
 
-function compactDragMagnetic(
-  layout: Layout,
-  cols: number,
-  dragStart: WorkspaceDragStartSnapshot | null,
-  engaged: Set<string> | null,
-): Layout {
-  const priorityId = layout.find((item) => item.moved)?.i;
-  if (!priorityId || !dragStart) {
-    return compactPushDownWithPriority(layout, priorityId).map((item) => ({
-      ...item,
-      moved: false,
-    }));
-  }
+export const WORKSPACE_DRAG_COMPACTOR = FREE_COMPACTOR;
+export const WORKSPACE_RESIZE_COMPACTOR = FREE_COMPACTOR;
 
-  const dragLayout = layoutFromDragStart(layout, priorityId, dragStart);
-  const swapped = swapDisplacedIntoPreviousSlot(
-    dragLayout,
-    cols,
-    priorityId,
-    dragStart,
-    engaged,
-  );
-  // During a live drag keep the dragged tile pinned to the pointer cell, even
-  // on frames where no swap fires. Toggling preservePriority with the swap
-  // (the old behaviour) let compactMagnetUp yank the tile upward the instant
-  // its overlap dipped below a collision; RGL then dragged it back toward the
-  // pointer next frame — the preserve-toggle 2-cycle that read as a "quick
-  // back and forth" at the swap boundary. A live session pins unconditionally.
-  const preservePriority = engaged ? true : swapped.displaced;
-  return compactMagnetUp(
-    swapped.layout,
-    priorityId,
-    preservePriority,
-  ).map((item) => ({
-    ...item,
-    moved: false,
-  }));
+// Kept for call-site compatibility with the old magnetic engine. The drag
+// snapshot is no longer needed for live compaction (nothing reflows mid-drag);
+// it is captured by FlexWorkspace and handed to placeDroppedPanel on drop.
+export function createWorkspaceDragCompactor(
+  _getDragStart?: () => WorkspaceDragStartSnapshot | null,
+): Compactor {
+  return FREE_COMPACTOR;
 }
 
+// Fraction of the smaller tile's area that must be covered for a drop to count
+// as "squarely on" a neighbour and trigger a swap rather than a relocate. Below
+// this, a glancing overlap just relocates the dragged tile to free space.
+const SWAP_OVERLAP_FRACTION = 0.5;
+
+/**
+ * Resolve a dropped panel into the fixed lattice. The dragged tile lands where
+ * it was dropped; if that overlaps a single movable neighbour squarely the two
+ * swap, otherwise the dragged tile (and ONLY the dragged tile) relocates to the
+ * nearest free slot. No other tile is ever moved.
+ *
+ * `previous` is the drag-start snapshot (item = the tile's original placement,
+ * layout = the full layout at drag start). It is what lets a swap put the
+ * displaced neighbour into the dragged tile's vacated slot.
+ *
+ * Named `autoFitDroppedPanel` for call-site continuity with the old engine.
+ */
 export function autoFitDroppedPanel(
   layout: Layout,
   cols: number,
   previous?: LayoutItem | WorkspaceDragStartSnapshot | null,
 ): Layout {
   const dragStart = normalizeDragStart(previous);
-  const previousItem = dragStart?.item ?? null;
-  const dropped = previousItem
-    ? layout.find((item) => item.i === previousItem.i)
-    : findDroppedItem(layout);
-  if (!dropped) return clearMovedFlags(cloneLayout(layout));
+  const next = clearMovedFlags(cloneLayout(layout));
+  const draggedId = dragStart?.item.i ?? findDroppedItem(layout)?.i;
+  if (!draggedId) return next;
+  const dragged = next.find((item) => item.i === draggedId);
+  if (!dragged) return next;
 
-  const dragLayout = dragStart?.layout.length
-    ? layoutFromDragStart(layout, dropped.i, dragStart)
-    : layout;
-  const swapped = swapDisplacedIntoPreviousSlot(
-    dragLayout,
-    cols,
-    dropped.i,
-    dragStart?.layout.length ? dragStart : null,
-    null,
-  );
-  const base = swapped.layout;
-  const target = base.find((item) => item.i === dropped.i);
-  if (!target) return clearMovedFlags(base);
+  // Snap the drop point into the grid (clamp x; floor y to a row).
+  const maxX = Math.max(0, cols - dragged.w);
+  const dropX = clampInt(dragged.x, 0, maxX);
+  const dropY = Math.max(0, Math.round(dragged.y));
+  dragged.x = dropX;
+  dragged.y = dropY;
 
-  const minW = boundedMin(target.minW, 1, cols);
-  const maxW = boundedMax(target.maxW, minW, cols);
-  const minH = boundedMin(target.minH, 1, Number.MAX_SAFE_INTEGER);
-  const maxH = boundedMax(target.maxH, minH, Number.MAX_SAFE_INTEGER);
-  const startW = clamp(target.w, minW, maxW);
-  const startH = clamp(target.h, minH, maxH);
+  const others = next.filter((item) => item.i !== draggedId);
+  const colliders = others.filter((item) => collides(dragged, item));
 
-  const footprintX = clamp(target.x, 0, Math.max(0, cols - startW));
-  const footprintY = Math.max(0, Math.round(target.y));
+  // Dropped onto empty space — it stays exactly here; nothing else moves.
+  if (colliders.length === 0) return next;
 
-  // Repositioning must NEVER resize the panel — only the explicit corner-resize
-  // handle changes a panel's size. Every placement below therefore keeps the
-  // dragged panel at its full (startW × startH) footprint and moves *other*
-  // panels out of the way (resolveAnchorCollisions pushes movable neighbours
-  // down). The old code shrank the dropped panel to fit leftover space, which
-  // is what made panels change size on a plain reposition.
-  const placeFullSize = (x: number, y: number) => {
-    const trial = cloneLayout(base);
-    const trialTarget = trial.find((item) => item.i === target.i);
-    if (!trialTarget) return null;
-    trialTarget.x = x;
-    trialTarget.y = y;
-    trialTarget.w = startW;
-    trialTarget.h = startH;
-    return resolveAnchorCollisions(trial, target.i, cols, previousItem);
-  };
-
-  // Fast path — full size at the drop origin. The overwhelmingly common case:
-  // resolveAnchorCollisions shoves movable neighbours aside so the panel lands
-  // exactly where it was dropped. Keeping this O(1) (rather than sweeping a
-  // footprint) is also what stops a large tile such as the ~18×38 panadapter/
-  // hero from freezing the main thread for seconds on drop.
-  const originResolved = placeFullSize(footprintX, footprintY);
-  if (originResolved) {
-    return clearMovedFlags(
-      compactMagnetUp(originResolved.layout, target.i, swapped.displaced),
-    );
-  }
-
-  // Origin blocked (a static/locked panel sits in the drop cell). Keep the
-  // panel's size and search straight down the same column for the nearest
-  // full-size slot rather than shrinking it. Bounded by the layout height, so
-  // it stays cheap.
-  const layoutBottom = base.reduce(
-    (bottom, item) => Math.max(bottom, item.y + item.h),
-    0,
-  );
-  for (let y = footprintY + 1; y <= layoutBottom; y += 1) {
-    const resolved = placeFullSize(footprintX, y);
-    if (resolved) {
-      return clearMovedFlags(
-        compactMagnetUp(resolved.layout, target.i, swapped.displaced),
-      );
+  // Squarely onto exactly one movable neighbour → swap, if the swap leaves the
+  // layout collision-free (a same-footprint swap always does; an odd-sized one
+  // only when it happens to fit, otherwise we fall through to relocate).
+  const origin = dragStart?.item ?? null;
+  if (colliders.length === 1 && origin) {
+    const target = colliders[0]!;
+    if (!target.static && overlapIsSquare(dragged, target)) {
+      const tx = target.x;
+      const ty = target.y;
+      dragged.x = tx;
+      dragged.y = ty;
+      target.x = clampInt(origin.x, 0, Math.max(0, cols - target.w));
+      target.y = Math.max(0, Math.round(origin.y));
+      if (!anyCollision(next)) return next;
+      // Swap would overlap a third tile — undo and relocate instead.
+      dragged.x = dropX;
+      dragged.y = dropY;
+      target.x = tx;
+      target.y = ty;
     }
   }
 
-  // Last resort: drop it full size below everything, which is always free.
-  const tail = cloneLayout(base);
-  const tailTarget = tail.find((item) => item.i === target.i);
-  if (tailTarget) {
-    tailTarget.x = footprintX;
-    tailTarget.y = layoutBottom;
-    tailTarget.w = startW;
-    tailTarget.h = startH;
+  // Otherwise relocate ONLY the dragged tile to the nearest free slot to the
+  // drop point. Neighbours (including locked tiles) are obstacles, never moved.
+  const slot = nearestFreeSlot(next, dragged, cols, dropX, dropY);
+  if (slot) {
+    dragged.x = slot.x;
+    dragged.y = slot.y;
+  } else {
+    // Pathological — drop below everything, which is always free.
+    dragged.x = dropX;
+    dragged.y = others.reduce((b, it) => Math.max(b, it.y + it.h), 0);
   }
-  return clearMovedFlags(compactMagnetUp(tail, target.i, swapped.displaced));
-}
-
-function compactResizePushDown(layout: Layout): Layout {
-  return compactPushDownWithPriority(layout);
-}
-
-function swapDisplacedIntoPreviousSlot(
-  layout: Layout,
-  cols: number,
-  priorityId: string | undefined,
-  dragStart: WorkspaceDragStartSnapshot | null,
-  engaged: Set<string> | null,
-): { layout: Layout; displaced: boolean } {
-  const next = cloneLayout(layout);
-  if (!priorityId || !dragStart || dragStart.item.i !== priorityId) {
-    return { layout: next, displaced: false };
-  }
-
-  const anchor = next.find((item) => item.i === priorityId);
-  if (!anchor) return { layout: next, displaced: false };
-
-  const previousById = new Map(dragStart.layout.map((item) => [item.i, item]));
-  const originalOrder = new Map(
-    dragStart.layout.map((item, index) => [item.i, index]),
-  );
-  const candidates = next
-    .filter((item) => item.i !== priorityId)
-    .map((item) => ({ item, previous: previousById.get(item.i) }))
-    .filter(
-      (
-        candidate,
-      ): candidate is { item: LayoutItem; previous: LayoutItem } => {
-        if (candidate.previous === undefined) return false;
-        // A locked (static) panel never moves — not even transiently while
-        // another panel is dragged over it. Excluding it here keeps it pinned;
-        // the dragged panel flows around it and resolveAnchorCollisions keeps
-        // it out of the locked footprint on drop.
-        if (candidate.item.static) return false;
-        // Live drag: gate engagement through the per-drag hysteresis set so a
-        // neighbour holds its swapped slot across the touch boundary instead of
-        // flickering. Drop / one-shot compaction (engaged === null) keeps the
-        // immediate collision test — there is no next frame to flicker into.
-        if (engaged) {
-          return updateSwapEngagement(
-            candidate.item.i,
-            candidate.previous,
-            anchor,
-            engaged,
-          );
-        }
-        return (
-          placementChanged(candidate.item, candidate.previous) ||
-          collides(candidate.previous, anchor) ||
-          collides(candidate.item, anchor)
-        );
-      },
-    )
-    .sort((a, b) =>
-      compareDisplacedCandidates(a, b, anchor, originalOrder),
-    );
-
-  for (const { item, previous } of candidates) {
-    const slot = nearestOpenSlot(
-      next,
-      item,
-      anchor,
-      cols,
-      previous,
-      dragStart.item,
-    );
-    if (slot === null) continue;
-    item.x = slot.x;
-    item.y = slot.y;
-    return { layout: next, displaced: true };
-  }
-
-  return { layout: next, displaced: false };
-}
-
-function layoutFromDragStart(
-  layout: Layout,
-  priorityId: string,
-  dragStart: WorkspaceDragStartSnapshot,
-): Layout {
-  const current = new Map(layout.map((item) => [item.i, item]));
-  const anchor = current.get(priorityId);
-  const next: LayoutItem[] = dragStart.layout.map((item) => {
-    if (item.i !== priorityId) return { ...item, moved: false };
-    return { ...(anchor ?? item), moved: true };
-  });
-
-  for (const item of layout) {
-    if (!dragStart.layout.some((startItem) => startItem.i === item.i)) {
-      next.push({ ...item });
-    }
-  }
-
   return next;
 }
 
+/**
+ * Resolve overlaps created by a resize. The resized tile keeps its new
+ * geometry; each movable neighbour it now overlaps relocates to its nearest
+ * free slot (single pass — every relocation targets a globally-free cell, so no
+ * cascade). Locked neighbours are left in place (a resize into a locked tile is
+ * a rare edge the operator can clear with Tidy).
+ */
+export function resolveResizeOverlaps(
+  layout: Layout,
+  resizedId: string,
+  cols: number,
+): Layout {
+  const next = clearMovedFlags(cloneLayout(layout));
+  const resized = next.find((item) => item.i === resizedId);
+  if (!resized) return next;
+
+  const overlapped = next
+    .filter((item) => item.i !== resizedId && !item.static)
+    .filter((item) => collides(resized, item))
+    .sort((a, b) => a.y - b.y || a.x - b.x);
+
+  for (const item of overlapped) {
+    // A prior relocation may already have cleared this one.
+    if (!collides(resized, item)) continue;
+    const slot = nearestFreeSlot(next, item, cols, item.x, item.y);
+    if (slot) {
+      item.x = slot.x;
+      item.y = slot.y;
+    }
+  }
+  return next;
+}
+
+/**
+ * Operator-invoked "Tidy": pack movable tiles upward to close vertical gaps,
+ * keeping each tile's column (x) and never moving a locked (static) tile. This
+ * is the only function that compacts — it runs on an explicit button press, not
+ * as a side effect of a drag.
+ */
+export function tidyWorkspacePlacements(layout: Layout): Layout {
+  const next = cloneLayout(layout);
+  const order = new Map(next.map((item, index) => [item.i, index]));
+  const statics = next.filter((item) => item.static);
+  const movers = next
+    .filter((item) => !item.static)
+    .sort(
+      (a, b) =>
+        a.y - b.y ||
+        a.x - b.x ||
+        (order.get(a.i) ?? 0) - (order.get(b.i) ?? 0),
+    );
+
+  // Seed the obstacle set with the static tiles so movers magnet up *around*
+  // them rather than through them.
+  const placed: LayoutItem[] = [...statics];
+  for (const item of movers) {
+    item.y = Math.max(0, item.y);
+    // Pull up while the cell above is clear.
+    while (item.y > 0) {
+      const trial = { ...item, y: item.y - 1 };
+      if (placed.some((p) => collides(trial, p))) break;
+      item.y -= 1;
+    }
+    // If it still overlaps something (e.g. landed on a static tile), push it
+    // just below the obstacle.
+    let guard = 0;
+    let hit = placed.find((p) => collides(item, p));
+    while (hit && guard < placed.length + 1) {
+      item.y = hit.y + hit.h;
+      hit = placed.find((p) => collides(item, p));
+      guard += 1;
+    }
+    placed.push(item);
+  }
+  return clearMovedFlags(next);
+}
+
+/**
+ * Magnet movable tiles upward to close vertical gaps around static tiles, used
+ * by the locked-tile pixel-height solver (lockedWorkspaceLayout). Kept separate
+ * from tidyWorkspacePlacements because the solver feeds it synthetic fractional
+ * spans and an optional priority tile.
+ */
 export function compactMagnetUp(
   layout: Layout,
   priorityId?: string,
@@ -316,6 +261,56 @@ export function compactMagnetUp(
   return next;
 }
 
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function nearestFreeSlot(
+  layout: LayoutItem[],
+  item: LayoutItem,
+  cols: number,
+  prefX: number,
+  prefY: number,
+): { x: number; y: number } | null {
+  const maxX = cols - item.w;
+  if (maxX < 0) return null;
+  const others = layout.filter((other) => other.i !== item.i);
+  const layoutBottom = layout.reduce(
+    (bottom, other) => Math.max(bottom, other.y + other.h),
+    0,
+  );
+  // One full tile-height of slack below the stack guarantees a free row exists.
+  const maxY = layoutBottom + item.h;
+
+  let best: { x: number; y: number; dist: number } | null = null;
+  for (let y = 0; y <= maxY; y += 1) {
+    for (let x = 0; x <= maxX; x += 1) {
+      const candidate = { ...item, x, y };
+      if (others.some((other) => collides(candidate, other))) continue;
+      const dist = Math.abs(x - prefX) + Math.abs(y - prefY);
+      if (
+        !best ||
+        dist < best.dist ||
+        (dist === best.dist && (y < best.y || (y === best.y && x < best.x)))
+      ) {
+        best = { x, y, dist };
+      }
+      // Drop point itself is free — nothing can beat distance 0.
+      if (dist === 0) return { x, y };
+    }
+  }
+  return best ? { x: best.x, y: best.y } : null;
+}
+
+function overlapIsSquare(a: LayoutItem, b: LayoutItem): boolean {
+  const overlapW = Math.min(a.x + a.w, b.x + b.w) - Math.max(a.x, b.x);
+  const overlapH = Math.min(a.y + a.h, b.y + b.h) - Math.max(a.y, b.y);
+  if (overlapW <= 0 || overlapH <= 0) return false;
+  const overlapArea = overlapW * overlapH;
+  const minArea = Math.min(a.w * a.h, b.w * b.h);
+  return minArea > 0 && overlapArea >= minArea * SWAP_OVERLAP_FRACTION;
+}
+
 function moveBelowCollisions(item: LayoutItem, placed: LayoutItem[]) {
   let collision = firstCollision(placed, item);
   while (collision) {
@@ -344,205 +339,6 @@ function normalizeDragStart(
   return { item: { ...previous }, layout: [] };
 }
 
-function placementChanged(item: LayoutItem, previous: LayoutItem): boolean {
-  return (
-    item.x !== previous.x ||
-    item.y !== previous.y ||
-    item.w !== previous.w ||
-    item.h !== previous.h
-  );
-}
-
-function compareDisplacedCandidates(
-  a: { item: LayoutItem; previous: LayoutItem },
-  b: { item: LayoutItem; previous: LayoutItem },
-  anchor: LayoutItem,
-  originalOrder: Map<string, number>,
-) {
-  const aOldSlotHit = collides(a.previous, anchor);
-  const bOldSlotHit = collides(b.previous, anchor);
-  if (aOldSlotHit !== bOldSlotHit) return aOldSlotHit ? -1 : 1;
-
-  const aCurrentHit = collides(a.item, anchor);
-  const bCurrentHit = collides(b.item, anchor);
-  if (aCurrentHit !== bCurrentHit) return aCurrentHit ? -1 : 1;
-
-  const aDistance = rectDistance(a.previous, anchor);
-  const bDistance = rectDistance(b.previous, anchor);
-  return (
-    aDistance - bDistance ||
-    (originalOrder.get(a.item.i) ?? 0) - (originalOrder.get(b.item.i) ?? 0)
-  );
-}
-
-function rectDistance(a: LayoutItem, b: LayoutItem): number {
-  return Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
-}
-
-function compactPushDownWithPriority(
-  layout: Layout,
-  priorityId?: string,
-): Layout {
-  const next = layout.map((item) => ({ ...item }));
-  const originalOrder = new Map(next.map((item, index) => [item.i, index]));
-  const maxPasses = Math.max(1, next.length * next.length);
-
-  for (let pass = 0; pass < maxPasses; pass += 1) {
-    let moved = false;
-    const ordered = [...next].sort((a, b) =>
-      compareItems(a, b, originalOrder, priorityId),
-    );
-
-    for (let i = 0; i < ordered.length; i += 1) {
-      const anchor = ordered[i]!;
-      for (let j = i + 1; j < ordered.length; j += 1) {
-        const candidate = ordered[j]!;
-        if (!collides(anchor, candidate)) continue;
-
-        if (candidate.static) {
-          if (!anchor.static) {
-            const y = candidate.y + candidate.h;
-            if (anchor.y < y) {
-              anchor.y = y;
-              moved = true;
-            }
-          }
-          continue;
-        }
-
-        const y = anchor.y + anchor.h;
-        if (candidate.y < y) {
-          candidate.y = y;
-          moved = true;
-        }
-      }
-    }
-
-    if (!moved) break;
-  }
-
-  return next;
-}
-
-function resolveAnchorCollisions(
-  layout: Layout,
-  anchorId: string,
-  cols: number,
-  preferredSlot?: LayoutItem | null,
-): { layout: LayoutItem[] } | null {
-  const next = cloneLayout(layout);
-  const originalPlacement = new Map(
-    next.map((item) => [item.i, { x: item.x, y: item.y }]),
-  );
-  const maxPasses = Math.max(1, next.length * next.length);
-
-  for (let pass = 0; pass < maxPasses; pass += 1) {
-    const anchor = next.find((item) => item.i === anchorId);
-    if (!anchor) return null;
-
-    const collisions = next
-      .filter((item) => item.i !== anchorId && collides(anchor, item));
-
-    if (collisions.some((item) => item.static)) return null;
-
-    const movableCollisions = collisions
-      .sort((a, b) => Math.abs(a.x - anchor.x) - Math.abs(b.x - anchor.x));
-
-    if (movableCollisions.length === 0) {
-      return anyCollision(next) ? null : { layout: next };
-    }
-
-    let moved = false;
-    for (const item of movableCollisions) {
-      const slot = nearestOpenSlot(
-        next,
-        item,
-        anchor,
-        cols,
-        originalPlacement.get(item.i) ?? item,
-        preferredSlot,
-      );
-      if (slot === null) return null;
-      if (slot.x !== item.x || slot.y !== item.y) {
-        item.x = slot.x;
-        item.y = slot.y;
-        moved = true;
-      }
-    }
-
-    if (!moved) return null;
-  }
-
-  return anyCollision(next) ? null : { layout: next };
-}
-
-function nearestOpenSlot(
-  layout: LayoutItem[],
-  item: LayoutItem,
-  anchor: LayoutItem,
-  cols: number,
-  originalPlacement: Pick<LayoutItem, 'x' | 'y'>,
-  preferredSlot?: Pick<LayoutItem, 'x' | 'y'> | null,
-): Pick<LayoutItem, 'x' | 'y'> | null {
-  const maxX = cols - item.w;
-  if (maxX < 0) return null;
-
-  const layoutBottom = layout.reduce(
-    (bottom, candidate) => Math.max(bottom, candidate.y + candidate.h),
-    0,
-  );
-  const tallestItem = layout.reduce(
-    (height, candidate) => Math.max(height, candidate.h),
-    item.h,
-  );
-  const maxY = layoutBottom + tallestItem * Math.max(1, layout.length);
-
-  let best: {
-    x: number;
-    y: number;
-    preferredDistance: number;
-    distance: number;
-  } | null = null;
-
-  for (let y = 0; y <= maxY; y += 1) {
-    for (let x = 0; x <= maxX; x += 1) {
-      const candidate = { ...item, x, y };
-      if (collides(candidate, anchor)) continue;
-      if (
-        layout.some((other) => {
-          if (other.i === item.i || other.i === anchor.i) return false;
-          return collides(candidate, other);
-        })
-      ) {
-        continue;
-      }
-
-      const preferredDistance = preferredSlot
-        ? Math.abs(x - preferredSlot.x) + Math.abs(y - preferredSlot.y)
-        : 0;
-      const distance =
-        Math.abs(x - originalPlacement.x) + Math.abs(y - originalPlacement.y);
-      if (
-        !best ||
-        preferredDistance < best.preferredDistance ||
-        (preferredDistance === best.preferredDistance &&
-          distance < best.distance) ||
-        (preferredDistance === best.preferredDistance &&
-          distance === best.distance &&
-          y < best.y) ||
-        (preferredDistance === best.preferredDistance &&
-          distance === best.distance &&
-          y === best.y &&
-          x < best.x)
-      ) {
-        best = { x, y, preferredDistance, distance };
-      }
-    }
-  }
-
-  return best ? { x: best.x, y: best.y } : null;
-}
-
 function findDroppedItem(layout: Layout): LayoutItem | undefined {
   const moved = layout.filter((item) => item.moved);
   return moved[moved.length - 1];
@@ -552,12 +348,7 @@ function compareItems(
   a: LayoutItem,
   b: LayoutItem,
   originalOrder: Map<string, number>,
-  priorityId?: string,
 ) {
-  if (priorityId) {
-    if (a.i === priorityId && b.i !== priorityId) return -1;
-    if (b.i === priorityId && a.i !== priorityId) return 1;
-  }
   return (
     a.y - b.y ||
     a.x - b.x ||
@@ -592,81 +383,6 @@ function collides(a: LayoutItem, b: LayoutItem) {
   return true;
 }
 
-// Hysteresis thresholds for the live magnetic swap, expressed as a fraction of
-// the SMALLER of the two tiles' heights so the feel scales with panel size.
-//
-// ENGAGE at the midpoint (50%): a neighbour only commits to swapping once the
-// dragged tile has clearly taken its slot — covered half of it — rather than
-// flipping on the first row of contact. On the real workspace, where panels run
-// 8–38 rows tall, a fixed 1-row trigger fired almost on touch and read as
-// twitchy; a midpoint trigger reads as deliberate, the premium reorder feel.
-//
-// RELEASE lower (25%): a committed swap holds until the dragged tile is pulled
-// back past a quarter overlap. The band between 25% and 50% is the deadband
-// that kills the boundary flicker (RGL's grid-rounding jitters the dragged tile
-// by a row at the touch line; a committed neighbour rides across it unmoved).
-//
-// A 1-row floor keeps 1–2 row control tiles snapping sanely instead of needing
-// a sub-row overlap the integer grid can never express.
-const SWAP_ENGAGE_FRACTION = 0.5;
-const SWAP_RELEASE_FRACTION = 0.25;
-const SWAP_MIN_ENGAGE_ROWS = 1;
-
-// Engage / release overlap (in grid rows) for one dragged↔neighbour pair.
-function swapThresholdRows(
-  anchor: LayoutItem,
-  neighbor: LayoutItem,
-): { engage: number; release: number } {
-  const span = Math.max(1, Math.min(anchor.h, neighbor.h));
-  return {
-    engage: Math.max(SWAP_MIN_ENGAGE_ROWS, span * SWAP_ENGAGE_FRACTION),
-    release: span * SWAP_RELEASE_FRACTION,
-  };
-}
-
-// Signed vertical overlap between the dragged anchor and a neighbour, in rows:
-// positive when they overlap, zero when edges touch, negative (a gap) when they
-// are apart. Returns -Infinity when their columns don't overlap at all, so a
-// neighbour off to the side never engages and any engaged one releases at once.
-function verticalOverlapRows(anchor: LayoutItem, neighbor: LayoutItem): number {
-  if (anchor.x + anchor.w <= neighbor.x || anchor.x >= neighbor.x + neighbor.w) {
-    return Number.NEGATIVE_INFINITY;
-  }
-  return (
-    Math.min(anchor.y + anchor.h, neighbor.y + neighbor.h) -
-    Math.max(anchor.y, neighbor.y)
-  );
-}
-
-// Advance the per-drag engagement set for one neighbour and report whether it
-// is currently committed to a swap. Engage on real overlap, release only on a
-// clear gap; the touch boundary in between is sticky.
-function updateSwapEngagement(
-  id: string,
-  previous: LayoutItem,
-  anchor: LayoutItem,
-  engaged: Set<string>,
-): boolean {
-  const overlap = verticalOverlapRows(anchor, previous);
-  const { engage, release } = swapThresholdRows(anchor, previous);
-  if (engaged.has(id)) {
-    if (overlap < release) engaged.delete(id);
-  } else if (overlap >= engage) {
-    engaged.add(id);
-  }
-  return engaged.has(id);
-}
-
-function boundedMin(value: number | undefined, fallback: number, ceiling: number) {
-  const min = Number.isFinite(value) ? value! : fallback;
-  return clamp(Math.round(min), fallback, ceiling);
-}
-
-function boundedMax(value: number | undefined, floor: number, ceiling: number) {
-  const max = Number.isFinite(value) ? value! : ceiling;
-  return Math.max(floor, clamp(Math.round(max), floor, ceiling));
-}
-
-function clamp(value: number, min: number, max: number) {
+function clampInt(value: number, min: number, max: number) {
   return Math.min(max, Math.max(min, Math.round(value)));
 }

--- a/zeus-web/src/styles/all-panels.css
+++ b/zeus-web/src/styles/all-panels.css
@@ -676,6 +676,58 @@
   opacity: 1;
 }
 
+/* Tidy button — sits just left of the Add Panel button. Closes the vertical
+ * gaps the free-grid drag/resize model deliberately leaves behind. Shares the
+ * Add Panel button's chrome but a touch smaller so it reads as secondary. */
+.workspace-tidy-btn {
+  position: absolute;
+  right: 54px;
+  bottom: 12px;
+  z-index: 5;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  border-radius: 999px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.015)),
+    rgba(12, 13, 15, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  color: var(--fg-1);
+  font-family: var(--font-sans);
+  box-shadow:
+    0 8px 20px rgba(0, 0, 0, 0.28),
+    inset 0 1px 0 rgba(255, 255, 255, 0.09);
+  opacity: 0.68;
+  cursor: pointer;
+  transition:
+    background var(--dur-fast),
+    border-color var(--dur-fast),
+    color var(--dur-fast),
+    opacity var(--dur-fast),
+    transform var(--dur-fast);
+}
+.workspace-tidy-btn:hover {
+  background:
+    linear-gradient(180deg, var(--btn-active-top), var(--btn-active-bot));
+  border-color: var(--accent);
+  color: var(--btn-active-text, var(--fg-0));
+  opacity: 1;
+  transform: translateY(-1px);
+}
+.workspace-tidy-btn:disabled {
+  cursor: default;
+  opacity: 0.32;
+  transform: none;
+}
+.workspace-tidy-btn:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 2px;
+  opacity: 1;
+}
+
 /* Categorized AddPanel modal — left rail of category chips, right pane of
  * panel cards. Stacks the rail vertically so all categories are reachable
  * without tab-bar overflow. */


### PR DESCRIPTION
## Problem

Moving one workspace panel reflowed the others — the recurring "I moved one and they all moved down" report — and locking a panel made the whole workspace jump so it never pinned exactly where it was locked.

Root cause: the workspace ran a **vertically-compacting** react-grid-layout. Five interacting heuristics re-solved the **entire** layout on every drop, live-drag used a different algorithm than drop (the release-jump), and the locked-tile solver closed every vertical gap whenever any tile was locked. Compaction inherently cascades, so it could never be tuned away.

## Approach

Replace the packing grid with a **fixed-lattice** model (operator-chosen behavior: move-only + swap, gaps allowed):

- **Live drag/resize compactors are the identity** — nothing reflows under the pointer. The dragged tile floats over its neighbours during the gesture and snaps to a clean slot on release.
- **`autoFitDroppedPanel` = swap-or-nearest-free for the dragged tile only.** Empty space keeps it exactly where dropped (gaps allowed); a square drop (≥50%) onto one same-size movable tile swaps the two; anything else relocates **only** the dragged tile. No other tile ever moves. Locked tiles are immovable obstacles.
- **`resolveResizeOverlaps`** nudges only the directly-overlapped movable neighbours aside on resize stop (one pass, no cascade) and **clamps** the resized tile if it grows into a locked one — so a resize never leaves an overlap.
- **Panel lock is now inert.** The locked-tile solver no longer magnet-packs the workspace; it preserves stored positions and gaps, pushing a tile down only when a frozen-size locked span would genuinely overlap it. Locking a panel leaves every other panel exactly where it was.

`FlexWorkspace` marks the resize gesture active so transient overlap is never persisted mid-drag.

## Result

- **No settled layout can contain an overlap** (drop resolves clean; resize relocates/clamps; lock is down-only).
- Moving one panel never moves the others; locking pins exactly in place.

## Tests

`workspaceGrid.test.ts` and `lockedWorkspaceLayout.test.ts` rewritten for the new model, including regression guards that **dropping a panel into a free gap leaves every other panel untouched** and **locking a panel above a gap leaves the gap intact**.

- Full frontend suite green (887 tests), `tsc --noEmit` clean, ESLint clean.

## Not verified / scoped out

- Browser drag-gesture verification wasn't run (preview harness can't render the WebGL panels or reliably drive an RGL reorder gesture); coverage rests on the unit tests.
- While actively dragging, the held panel floats over its neighbours (standard drag behavior) and snaps to a clean slot on release; every settled state is overlap-free. A live-preview reflow (panels push/swap as you drag) can be added later if wanted.

## Note for reviewers

This touches UX/layout behavior — a red-light area. The interaction model (move-only + swap, gaps allowed, inert lock) was an explicit product decision; flagging for sign-off.
