### PR TITLE
fix(meters): remove liquid-metal glass animations from all panels

### DIFF
--- a/zeus-web/src/components/SMeter.tsx
+++ b/zeus-web/src/components/SMeter.tsx
@@ -349,8 +349,7 @@ export function SMeter(props: SMeterProps) {
               boxShadow: '0 0 6px rgba(255,176,60,0.9)',
             }}
           />
-          {/* Liquid-metal glass cover — domed upper-left specular + a slow
-              drifting sheen band gliding across the wet glass. */}
+          {/* Liquid-metal glass cover — static domed upper-left specular. */}
           <div
             aria-hidden
             className="absolute inset-0 overflow-hidden"
@@ -359,17 +358,7 @@ export function SMeter(props: SMeterProps) {
               background:
                 'radial-gradient(64% 130% at 32% 16%, var(--meter-glass-dome) 0%, var(--meter-glass-top) 46%, var(--meter-glass-bot) 100%)',
             }}
-          >
-            <div
-              className="lm-sheen absolute inset-y-0"
-              style={{
-                left: 0,
-                width: '16%',
-                background:
-                  'linear-gradient(100deg, transparent 0%, var(--meter-sheen) 50%, transparent 100%)',
-              }}
-            />
-          </div>
+          />
         </div>
 
         {/* Tick scale — marks always draw; labels thin out responsively. */}

--- a/zeus-web/src/components/TxStageMeters.tsx
+++ b/zeus-web/src/components/TxStageMeters.tsx
@@ -387,7 +387,7 @@ function MeterRow({
               }}
             />
           )}
-          {/* Liquid-metal glass cover — domed specular + drifting sheen. */}
+          {/* Liquid-metal glass cover — static domed specular. */}
           <MeterGlass radius={2} />
         </div>
       </div>

--- a/zeus-web/src/components/analog-meter/AnalogMeterFace.tsx
+++ b/zeus-web/src/components/analog-meter/AnalogMeterFace.tsx
@@ -343,15 +343,14 @@ export function AnalogMeterFace({
 
         <NeedleShadow angleDeg={angle} />
         <Needle angleDeg={angle} peakAngleDeg={peakAngle} />
-        {/* Liquid-metal glass dome over the dial — wet upper-left specular +
-            a slow drifting sheen, the "instrument under curved glass" tell. */}
+        {/* Liquid-metal glass dome over the dial — static upper-left specular,
+            the "instrument under curved glass" tell. */}
         <GlassDome
           defsId="analogMeterGlass"
           x={0}
           y={FACE.h * 0.05}
           width={FACE.w}
           height={FACE.h * 0.95}
-          caustic={false}
         />
       </svg>
     </div>

--- a/zeus-web/src/components/filter/FilterMiniPan.tsx
+++ b/zeus-web/src/components/filter/FilterMiniPan.tsx
@@ -1937,9 +1937,9 @@ function FilterMiniPanSurface({
         onPointerCancel={onPointerUp}
         onPointerLeave={onPointerLeave}
       />
-      {/* Liquid-metal glass over the bandwidth pan — wet sheen + caustic,
+      {/* Liquid-metal glass over the bandwidth pan — static specular,
           pointer-events:none so dragging the filter still works through it. */}
-      <MeterGlass caustic sheenWidth="12%" />
+      <MeterGlass />
       {editingWidth ? (
         <input
           autoFocus

--- a/zeus-web/src/components/immersive-meters/BigArc.tsx
+++ b/zeus-web/src/components/immersive-meters/BigArc.tsx
@@ -509,8 +509,8 @@ export function BigArc(props: BigArcProps) {
           fill="var(--immersive-lamp-needle)"
           style={{ filter: 'drop-shadow(0 0 5px var(--immersive-lamp-hub-glow))' }}
         />
-        {/* Liquid-metal glass over the arc face — wet specular + sheen. */}
-        <GlassDome defsId="bigArcGlass" x={0} y={0} width={240} height={150} caustic={false} />
+        {/* Liquid-metal glass over the arc face — static specular. */}
+        <GlassDome defsId="bigArcGlass" x={0} y={0} width={240} height={150} />
       </svg>
 
       <div style={readoutStyle}>

--- a/zeus-web/src/components/immersive-meters/VuColumn.tsx
+++ b/zeus-web/src/components/immersive-meters/VuColumn.tsx
@@ -263,8 +263,8 @@ export function VuColumn({ valueDb, name, sub, defsId, zoneTicks }: VuColumnProp
             })}
           </g>
         )}
-        {/* Liquid-metal glass over the VU column — wet specular + sheen. */}
-        <GlassDome defsId="vuColGlass" x={0} y={0} width={60} height={160} sheenWidthFrac={0.24} caustic={false} />
+        {/* Liquid-metal glass over the VU column — static specular. */}
+        <GlassDome defsId="vuColGlass" x={0} y={0} width={60} height={160} />
       </svg>
       <div style={numStyle}>
         {silent ? '−∞' : fmtDb(valueDb)}

--- a/zeus-web/src/components/meters/render/GlassDome.tsx
+++ b/zeus-web/src/components/meters/render/GlassDome.tsx
@@ -6,15 +6,9 @@
 //
 // GlassDome — the domed-glass specular layer reading as light catching curved
 // glass over an instrument. Layer (3). Renders ABOVE the well + fill, BELOW
-// the bezel. Elevated over the prior kit: in addition to the upper-left
-// specular dome, a top edge-light, and the slow horizontal sheen band, it now
-// carries a second TRAVELING CAUSTIC — a soft cool wet-light blob that drifts
-// across the glass on a longer, offset loop, so the glass reads alive rather
-// than a static highlight.
-//
-// All drift is compositor-only CSS @keyframes translateX (layout.css), PAUSED
-// by prefers-reduced-motion and when the gauge is off-screen. Paint-once defs.
-// DISPLAY-ONLY, id-namespaced.
+// the bezel. An upper-left specular dome plus a thin top edge-light. Paint-once
+// defs. DISPLAY-ONLY, id-namespaced. (The moving sheen / caustic light sweeps
+// were removed.)
 
 import { prefixDefs } from './svgChrome';
 
@@ -25,16 +19,8 @@ interface GlassDomeProps {
   width: number;
   height: number;
   rx?: number;
-  /** Draw the drifting sheen band. Default true. */
-  sheen?: boolean;
-  /** Draw the traveling caustic blob. Default true. */
-  caustic?: boolean;
-  /** Sheen band width as a fraction of width. Default 0.16. */
-  sheenWidthFrac?: number;
   /** Specular-dome colour (compact callers pass --meter-glass-dome-sm). */
   domeColor?: string;
-  /** Sheen band colour. */
-  sheenColor?: string;
 }
 
 /** Specular glass cover, lit from the shared upper-left key direction. */
@@ -45,17 +31,9 @@ export function GlassDome({
   width,
   height,
   rx,
-  sheen = true,
-  caustic = true,
-  sheenWidthFrac = 0.16,
   domeColor = 'var(--meter-glass-dome)',
-  sheenColor = 'var(--meter-sheen)',
 }: GlassDomeProps) {
   const domeId = prefixDefs(defsId, 'glassdome');
-  const sheenId = prefixDefs(defsId, 'glasssheen');
-  const causticId = prefixDefs(defsId, 'glasscaustic');
-  const sheenW = Math.max(2, width * sheenWidthFrac);
-  const causticW = Math.max(3, width * 0.28);
 
   return (
     <>
@@ -66,17 +44,6 @@ export function GlassDome({
           <stop offset="0.45" stopColor="var(--meter-glass-top)" />
           <stop offset="1" stopColor="var(--meter-glass-bot)" />
         </radialGradient>
-        {/* the moving sheen band — a thin bright vertical streak, soft edges */}
-        <linearGradient id={sheenId} x1="0" y1="0" x2="1" y2="0">
-          <stop offset="0" stopColor="var(--meter-sheen-soft)" stopOpacity="0" />
-          <stop offset="0.5" stopColor={sheenColor} />
-          <stop offset="1" stopColor="var(--meter-sheen-soft)" stopOpacity="0" />
-        </linearGradient>
-        {/* the traveling caustic — a soft cool wet-light blob */}
-        <radialGradient id={causticId} cx="50%" cy="40%" r="55%">
-          <stop offset="0" stopColor="var(--meter-caustic)" />
-          <stop offset="1" stopColor="var(--meter-caustic-soft)" stopOpacity="0" />
-        </radialGradient>
       </defs>
 
       {/* domed specular highlight over the whole glass */}
@@ -84,26 +51,6 @@ export function GlassDome({
 
       {/* thin top edge-light rim */}
       <rect x={x} y={y} width={width} height={Math.max(1, height * 0.06)} rx={rx} fill={domeColor} opacity={0.5} />
-
-      {/* traveling caustic — slower, offset loop (behind the sheen) */}
-      {caustic && (
-        <g
-          className="meter-caustic-drift"
-          style={{ ['--caustic-travel' as string]: `${width + causticW}px` }}
-        >
-          <rect x={x - causticW} y={y} width={causticW} height={height} rx={rx} fill={`url(#${causticId})`} />
-        </g>
-      )}
-
-      {/* drifting sheen band — compositor-only CSS drift */}
-      {sheen && (
-        <g
-          className="meter-sheen-drift"
-          style={{ ['--sheen-travel' as string]: `${width + sheenW}px` }}
-        >
-          <rect x={x - sheenW} y={y} width={sheenW} height={height} rx={rx} fill={`url(#${sheenId})`} />
-        </g>
-      )}
     </>
   );
 }

--- a/zeus-web/src/components/meters/render/LiquidMetalFrame.tsx
+++ b/zeus-web/src/components/meters/render/LiquidMetalFrame.tsx
@@ -11,11 +11,11 @@
 //   chrome bezel (gradient-border padding wrapper)
 //     └ recessed well (concave pocket, clipped)
 //         ├ {children}            — the live meter (bars / needle / readout)
-//         └ glass overlay         — domed specular + drifting sheen + caustic
+//         └ glass overlay         — static domed specular highlight
 //
 // Token-only, DISPLAY-ONLY. The glass overlay is pointer-events:none so it
-// never intercepts the meter's own interactions. Drift animations live in
-// layout.css and are paused by prefers-reduced-motion + off-screen.
+// never intercepts the meter's own interactions. (The moving sheen / caustic
+// light sweeps were removed.)
 
 import type { CSSProperties, ReactNode } from 'react';
 
@@ -43,10 +43,8 @@ export interface LiquidMetalFrameProps {
   warmHalo?: boolean;
   /** Outer cool instrument bloom. Default false. */
   glow?: boolean;
-  /** Draw the glass overlay (dome + sheen + caustic). Default true. */
+  /** Draw the glass overlay (static domed specular). Default true. */
   glass?: boolean;
-  /** Draw the moving sheen/caustic. Default true; false = static glass. */
-  animate?: boolean;
   className?: string;
   style?: CSSProperties;
   /** Style applied to the inner well (e.g. min-height, padding). */
@@ -60,7 +58,6 @@ export function LiquidMetalFrame({
   warmHalo = false,
   glow = false,
   glass = true,
-  animate = true,
   className,
   style,
   wellStyle,
@@ -127,34 +124,6 @@ export function LiquidMetalFrame({
                 opacity: 0.45,
               }}
             />
-            {animate && (
-              <>
-                {/* slow traveling caustic — cool wet-light blob */}
-                <div
-                  className="lm-caustic"
-                  style={{
-                    position: 'absolute',
-                    insetBlock: 0,
-                    left: 0,
-                    width: '30%',
-                    background:
-                      'radial-gradient(60% 130% at 50% 40%, var(--meter-caustic) 0%, var(--meter-caustic-soft) 100%)',
-                  }}
-                />
-                {/* drifting sheen band */}
-                <div
-                  className="lm-sheen"
-                  style={{
-                    position: 'absolute',
-                    insetBlock: 0,
-                    left: 0,
-                    width: '16%',
-                    background:
-                      'linear-gradient(100deg, transparent 0%, var(--meter-sheen) 50%, transparent 100%)',
-                  }}
-                />
-              </>
-            )}
           </div>
         )}
       </div>

--- a/zeus-web/src/components/meters/render/MeterGlass.tsx
+++ b/zeus-web/src/components/meters/render/MeterGlass.tsx
@@ -5,24 +5,18 @@
 //                         Douglas J. Cerrato (KB2UKA), and contributors.
 //
 // MeterGlass — drop-in glass cover for any relative, overflow-hidden meter
-// well. Domed upper-left specular + an optional drifting sheen band (and a
-// slower traveling caustic). pointer-events:none so it never blocks the meter.
-// One-liner application of the liquid-metal glass layer. DISPLAY-ONLY.
+// well. A static domed upper-left specular highlight. pointer-events:none so it
+// never blocks the meter. One-liner application of the liquid-metal glass
+// layer. DISPLAY-ONLY. (The moving sheen / caustic light sweeps were removed.)
 
 import type { CSSProperties } from 'react';
 
 export interface MeterGlassProps {
   /** Match the well's corner radius. */
   radius?: CSSProperties['borderRadius'];
-  /** Drifting sheen band. Default true. */
-  sheen?: boolean;
-  /** Traveling caustic blob. Default false (on for larger wells). */
-  caustic?: boolean;
-  /** Sheen band width (% of well). Default '16%'. */
-  sheenWidth?: string;
 }
 
-export function MeterGlass({ radius, sheen = true, caustic = false, sheenWidth = '16%' }: MeterGlassProps) {
+export function MeterGlass({ radius }: MeterGlassProps) {
   return (
     <div
       aria-hidden
@@ -35,32 +29,6 @@ export function MeterGlass({ radius, sheen = true, caustic = false, sheenWidth =
         background:
           'radial-gradient(64% 130% at 32% 16%, var(--meter-glass-dome) 0%, var(--meter-glass-top) 46%, var(--meter-glass-bot) 100%)',
       }}
-    >
-      {caustic && (
-        <div
-          className="lm-caustic"
-          style={{
-            position: 'absolute',
-            insetBlock: 0,
-            left: 0,
-            width: '30%',
-            background:
-              'radial-gradient(60% 130% at 50% 40%, var(--meter-caustic) 0%, var(--meter-caustic-soft) 100%)',
-          }}
-        />
-      )}
-      {sheen && (
-        <div
-          className="lm-sheen"
-          style={{
-            position: 'absolute',
-            insetBlock: 0,
-            left: 0,
-            width: sheenWidth,
-            background: 'linear-gradient(100deg, transparent 0%, var(--meter-sheen) 50%, transparent 100%)',
-          }}
-        />
-      )}
-    </div>
+    />
   );
 }

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -2234,27 +2234,15 @@
     inset 0 0 12px rgba(0,0,0,0.50);
   overflow: hidden;
 }
-/* liquid-metal glass cover on every shared bar — domed specular (::before)
-   + a drifting sheen band (::after). Above the fill, pointer-events:none. */
+/* liquid-metal glass cover on every shared bar — static domed specular
+   (::before) only. The drifting sheen band (::after) was removed along with
+   the rest of the moving liquid-metal lighting. Above the fill, pointer-
+   events:none. */
 .meter-bar::before {
   content: ''; position: absolute; inset: 0; pointer-events: none; z-index: 3;
   border-radius: inherit;
   background: radial-gradient(64% 130% at 32% 16%,
     var(--meter-glass-dome) 0%, var(--meter-glass-top) 46%, var(--meter-glass-bot) 100%);
-}
-.meter-bar::after {
-  content: ''; position: absolute; inset: 0; pointer-events: none; z-index: 3;
-  border-radius: inherit;
-  background: linear-gradient(100deg, transparent 42%, var(--meter-sheen) 50%, transparent 58%);
-  background-size: 280% 100%;
-  animation: meterBarSheen 6.9s linear infinite;
-}
-@keyframes meterBarSheen {
-  from { background-position: 220% 0; }
-  to   { background-position: -60% 0; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .meter-bar::after { animation: none; opacity: 0.25; }
 }
 .meter-fill {
   position: absolute; inset: 0 auto 0 0;
@@ -4293,58 +4281,8 @@
   animation: cwCursorBlink 1s steps(2) infinite;
 }
 
-/* ===== Liquid-metal meter kit (KB2UKA) — glass drift animations =========
-   Compositor-only translateX sweeps for the glass sheen + caustic. Two
-   variants: %-based for the DOM LiquidMetalFrame (.lm-sheen / .lm-caustic),
-   px-var-based for the SVG GlassDome (.meter-sheen-drift / .meter-caustic-
-   drift, driven by --sheen-travel / --caustic-travel). Paused by
-   prefers-reduced-motion. ============================================== */
-@keyframes lmSheenSweep {
-  0%   { transform: translateX(-150%); opacity: 0; }
-  10%  { opacity: 1; }
-  85%  { opacity: 1; }
-  100% { transform: translateX(760%); opacity: 0; }
-}
-@keyframes lmCausticSweep {
-  0%   { transform: translateX(-130%); opacity: 0; }
-  22%  { opacity: 1; }
-  78%  { opacity: 1; }
-  100% { transform: translateX(390%); opacity: 0; }
-}
-.lm-sheen {
-  animation: lmSheenSweep 6.9s linear infinite;
-  will-change: transform, opacity;
-}
-.lm-caustic {
-  animation: lmCausticSweep 11.25s ease-in-out infinite;
-  animation-delay: -3.2s;
-  will-change: transform, opacity;
-}
-
-/* SVG GlassDome variants — translate by the supplied user-unit travel. */
-@keyframes meterSheenDrift {
-  from { transform: translateX(0); }
-  to   { transform: translateX(var(--sheen-travel, 120px)); }
-}
-@keyframes meterCausticDrift {
-  from { transform: translateX(0); }
-  to   { transform: translateX(var(--caustic-travel, 160px)); }
-}
-.meter-sheen-drift {
-  animation: meterSheenDrift 6.9s linear infinite;
-  will-change: transform;
-}
-.meter-caustic-drift {
-  animation: meterCausticDrift 11.25s ease-in-out infinite;
-  animation-delay: -3.2s;
-  will-change: transform;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .lm-sheen, .lm-caustic,
-  .meter-sheen-drift, .meter-caustic-drift {
-    animation: none;
-  }
-  .lm-sheen, .meter-sheen-drift { opacity: 0.4; }
-  .lm-caustic, .meter-caustic-drift { opacity: 0.5; }
-}
+/* ===== Liquid-metal meter kit (KB2UKA) — glass drift animations REMOVED ====
+   The moving sheen + caustic light sweeps were removed per operator request.
+   The static domed-glass specular (the GlassDome / MeterGlass / LiquidMetal-
+   Frame dome layer and .meter-bar::before) is kept; the drift band elements
+   and their @keyframes are gone from the render components and this file. == */


### PR DESCRIPTION
## What

Removes the moving **liquid-metal glass lighting animations** from every meter panel, per operator request. The slow drifting "sheen" band and the traveling "caustic" wet-light blob that glided across the glass are gone. The **static domed-glass specular highlight is kept everywhere**, so meters still read as lit instruments under curved glass — they just no longer animate.

Affects all meters that used the kit: S-meter, TX stage meters, audio chain meters, immersive arc/VU gauges, filter mini-pan, and the analog meter face.

## Changes

- **`MeterGlass` / `GlassDome`** — drop the drifting sheen + caustic band elements (and their props / gradient defs); render only the dome + top edge-light.
- **`LiquidMetalFrame`** — drop the `animate` prop and the moving-band block.
- **`SMeter`** — drop the inline sheen band div; keep the dome cover.
- **`layout.css`** — remove the `meterBarSheen` / `lmSheenSweep` / `lmCausticSweep` / `meterSheenDrift` / `meterCausticDrift` `@keyframes` and the `.meter-bar::after` drifting sheen; keep the static `.meter-bar::before` dome.
- Update call sites (`FilterMiniPan`, `BigArc`, `VuColumn`, `AnalogMeterFace`, `TxStageMeters`) that passed the now-removed props.

Net: **+32 / −222 lines**, almost entirely deletions.

## Notes

- The `--meter-sheen*` / `--meter-caustic*` tokens in `tokens.css` are now unused but left in place (passive; no behavior change). Can prune in a follow-up if desired.
- This is purely a motion removal; no palette, layout, or default-value changes.

## Verification

`tsc -b && vite build` passes clean on a fresh `develop`-based worktree.