### PR TITLE
test: align workspace drag e2e with drop swap

### DIFF
--- a/zeus-web/e2e/workspace-panel-drag.spec.ts
+++ b/zeus-web/e2e/workspace-panel-drag.spec.ts
@@ -238,7 +238,7 @@ function expectNoReactDragLoop(pageErrors: string[]) {
   );
 }
 
-test('dragging a panel into an occupied workspace slot swaps without blanking the grid', async ({
+test('dragging a panel into an occupied workspace slot swaps on drop without blanking the grid', async ({
   page,
 }) => {
   const { pageErrors, layoutWrites } = await openStubbedWorkspace(page);
@@ -261,15 +261,14 @@ test('dragging a panel into an occupied workspace slot swaps without blanking th
   await page.mouse.down();
   await page.mouse.move(target.x, target.y, { steps: 12 });
   await waitForRectNear(page, 'tile-filterpresets', targetBefore);
-  await waitForRectNear(page, 'tile-tx', draggedBefore);
   await page.waitForTimeout(1100);
   expect(layoutWrites.count).toBe(0);
 
   const duringDrag = await tileRects(page);
   expect(duringDrag).toHaveLength(8);
-  expect(overlapPairs(duringDrag)).toEqual([]);
+  expect(overlapPairs(duringDrag)).toContainEqual(['tile-filterpresets', 'tile-tx']);
   expectRectNear(rectFor(duringDrag, 'tile-filterpresets'), targetBefore);
-  expectRectNear(rectFor(duringDrag, 'tile-tx'), draggedBefore);
+  expectRectNear(rectFor(duringDrag, 'tile-tx'), targetBefore);
 
   await page.mouse.up();
   await waitForRectNear(page, 'tile-filterpresets', targetBefore);


### PR DESCRIPTION
## Summary
- update the occupied-slot workspace drag E2E for the current fixed-lattice model
- assert that the dragged tile may overlap the target during live drag, with no layout write before mouseup
- keep the existing post-drop swap and no-blanking assertions

## Verification
- npm --prefix zeus-web run test:e2e -- workspace-panel-drag.spec.ts
- npm --prefix zeus-web run test -- workspaceGrid lockedWorkspaceLayout
- npm --prefix zeus-web run lint (passes with existing svgChrome fast-refresh warning)