### PR TITLE
feat(tx-display): live TX waterfall + configurable TX display analyzer

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -1680,7 +1680,20 @@ public sealed record DisplaySettingsDto(
     double? WfDbMin,
     double? WfDbMax,
     double? WfTxDbMin,
-    double? WfTxDbMax);
+    double? WfTxDbMax,
+    // TX display analyzer parameters (issue: live TX waterfall). All
+    // display-only — they shape the transmitted-signal panadapter/waterfall
+    // visualization and never touch the transmitted audio, drive, or PA.
+    // Null on legacy rows / requests → server falls back to its defaults.
+    //   TxDisplayCalOffsetDb — dB added to the TX trace/waterfall pixels so the
+    //     operator can calibrate the absolute level (Thetis TXDisplayCalOffset).
+    //   TxDisplayFftSize     — WDSP TX analyzer FFT size (power of two).
+    //   TxDisplayWindow      — WDSP analyzer window type (win_type).
+    //   TxDisplayAvgTauMs    — TX trace visual smoothing time-constant (ms).
+    double? TxDisplayCalOffsetDb = null,
+    int? TxDisplayFftSize = null,
+    int? TxDisplayWindow = null,
+    double? TxDisplayAvgTauMs = null);
 
 public sealed record DisplaySettingsSetRequest(
     string Mode,
@@ -1693,7 +1706,11 @@ public sealed record DisplaySettingsSetRequest(
     double? WfDbMin = null,
     double? WfDbMax = null,
     double? WfTxDbMin = null,
-    double? WfTxDbMax = null);
+    double? WfTxDbMax = null,
+    double? TxDisplayCalOffsetDb = null,
+    int? TxDisplayFftSize = null,
+    int? TxDisplayWindow = null,
+    double? TxDisplayAvgTauMs = null);
 
 // Server-side mirror of the frontend Signal Intelligence weak-signal display
 // controls. The DSP math remains in zeus-web's signal-estimator; this DTO lets

--- a/Zeus.Dsp/IDspEngine.cs
+++ b/Zeus.Dsp/IDspEngine.cs
@@ -178,6 +178,16 @@ public interface IDspEngine : IDisposable
     /// see issue #81. No-op on Synthetic.</summary>
     bool TryGetTxDisplayPixels(DisplayPixout which, Span<float> dbOut);
 
+    /// <summary>Reconfigure the TX display analyzer (and the PS-feedback
+    /// analyzer, which shares the TX display span). <paramref name="fftSize"/>
+    /// is the analyzer FFT size (power of two); <paramref name="windowType"/>
+    /// is the WDSP <c>win_type</c>; <paramref name="avgTauSec"/> is the visual
+    /// log-recursive smoothing time-constant in seconds. Pure display — does
+    /// NOT change the transmitted audio, drive, or PA. Out-of-range values are
+    /// clamped/ignored by the implementation. No-op on Synthetic and when TXA
+    /// is not open.</summary>
+    void ConfigureTxDisplayAnalyzer(int fftSize, int windowType, double avgTauSec);
+
     /// <summary>PureSignal-feedback panadapter / waterfall pixels in dBm,
     /// sourced from a separate WDSP analyzer fed with the post-PA loopback
     /// IQ pumped through <see cref="FeedPsFeedbackBlock"/>. Returns false

--- a/Zeus.Dsp/SyntheticDspEngine.cs
+++ b/Zeus.Dsp/SyntheticDspEngine.cs
@@ -251,6 +251,9 @@ public sealed class SyntheticDspEngine : IDspEngine
     // while MOX is on, matching the existing "no new data" semantics.
     public bool TryGetTxDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
 
+    // Synthetic has no TX analyzer to reconfigure — no-op.
+    public void ConfigureTxDisplayAnalyzer(int fftSize, int windowType, double avgTauSec) { }
+
     // Synthetic has no PS feedback path either — the PS-Monitor toggle is a
     // no-op here, same shape as TryGetTxDisplayPixels.
     public bool TryGetPsFeedbackDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -322,6 +322,17 @@ public sealed class WdspDspEngine : IDspEngine
     private int _txDispRxSampleRateHz;
     private bool _txDispAlive;
 
+    // Configurable TX display analyzer params (live TX waterfall feature).
+    // Display-only — they shape the transmitted-signal panadapter/waterfall
+    // FFT, never the air. Defaults mirror the historical constants so an
+    // unconfigured engine renders byte-identically to before. _txFftSize /
+    // _txWinType are read on the TX + PS-FB analyzer config path; _txAvgTauSec
+    // is the visual log-recursive smoothing tau (guarded by _txDispLock for the
+    // TXA reconfig). See ConfigureTxDisplayAnalyzer.
+    private volatile int _txFftSize = AnalyzerFftSize;
+    private volatile int _txWinType = AnalyzerWindow;
+    private double _txAvgTauSec = TxAvgTauSec;
+
     // PureSignal feedback display analyzer (issue #121). Optional second WDSP
     // disp slot fed from FeedPsFeedbackBlock's rxI/rxQ — i.e. the post-PA
     // signal observed via the radio's loopback ADC. When the operator turns on
@@ -536,7 +547,7 @@ public sealed class WdspDspEngine : IDspEngine
         NativeMethods.XCreateAnalyzer(id, out int rc, MaxFftSize, 1, 1, null);
         if (rc != 0) throw new InvalidOperationException($"XCreateAnalyzer failed rc={rc}");
 
-        ConfigureAnalyzer(id, sampleRateHz, InSize, pixelWidth, zoomLevel: 1);
+        ConfigureAnalyzer(id, sampleRateHz, InSize, pixelWidth, zoomLevel: 1, AnalyzerFftSize, AnalyzerWindow, AnalyzerKaiserPi);
         ConfigureDisplayAveraging(id);
 
         var state = new ChannelState
@@ -778,7 +789,7 @@ public sealed class WdspDspEngine : IDspEngine
         {
             if (state.ZoomLevel == level) return;
             state.ZoomLevel = level;
-            ConfigureAnalyzer(channelId, state.SampleRateHz, InSize, state.PixelWidth, level);
+            ConfigureAnalyzer(channelId, state.SampleRateHz, InSize, state.PixelWidth, level, AnalyzerFftSize, AnalyzerWindow, AnalyzerKaiserPi);
         }
 
         // Mirror zoom onto the TX analyzer so the TX panadapter span stays
@@ -791,7 +802,7 @@ public sealed class WdspDspEngine : IDspEngine
             {
                 _txDispZoomLevel = level;
                 txaIdToReconfig = txa;
-                TryConfigureTxAnalyzer(txa, _txaDspRateHz, _txaDspSize, _txDispRxSampleRateHz, _txDispPixelWidth, level);
+                TryConfigureTxAnalyzer(txa, _txaDspRateHz, _txaDspSize, _txDispRxSampleRateHz, _txDispPixelWidth, level, _txFftSize, _txWinType, AnalyzerKaiserPi);
             }
         }
 
@@ -803,7 +814,7 @@ public sealed class WdspDspEngine : IDspEngine
             if (_psFbDispAlive && _psFbDispId is int psFb)
             {
                 _psFbDispZoomLevel = level;
-                TryConfigureTxAnalyzer(psFb, PsFeedbackSampleRateHz, PsFeedbackBlockSize, _psFbDispRxSampleRateHz, _psFbDispPixelWidth, level);
+                TryConfigureTxAnalyzer(psFb, PsFeedbackSampleRateHz, PsFeedbackBlockSize, _psFbDispRxSampleRateHz, _psFbDispPixelWidth, level, _txFftSize, _txWinType, AnalyzerKaiserPi);
             }
         }
 
@@ -1380,6 +1391,56 @@ public sealed class WdspDspEngine : IDspEngine
         }
     }
 
+    // Power-of-two FFT sizes the TX display analyzer accepts. Mirrors
+    // DisplaySettingsStore.TxFftSizes; an out-of-range request snaps to the
+    // 16384 default so a malformed value can never reach SetAnalyzer.
+    private static int NormalizeTxFftSize(int fftSize) => fftSize switch
+    {
+        2048 or 4096 or 8192 or 16384 or 32768 or 65536 => fftSize,
+        _ => AnalyzerFftSize,
+    };
+
+    public void ConfigureTxDisplayAnalyzer(int fftSize, int windowType, double avgTauSec)
+    {
+        if (_disposed != 0) return;
+
+        // Defense in depth — the store validates too, but the engine is also
+        // reachable from tests and future callers. Snap anything invalid to the
+        // historical defaults rather than feeding garbage to SetAnalyzer.
+        int fft = NormalizeTxFftSize(fftSize);
+        int win = (windowType >= 0 && windowType <= 11) ? windowType : AnalyzerWindow;
+        double tau = (avgTauSec > 0.0 && avgTauSec <= 2.0) ? avgTauSec : TxAvgTauSec;
+
+        _txFftSize = fft;
+        _txWinType = win;
+
+        // Reconfigure the live TX analyzer in place (when open). SetAnalyzer is
+        // serialized against the Spectrum0 feed and GetPixels by _txDispLock,
+        // matching SetZoom's reconfig path.
+        lock (_txDispLock)
+        {
+            _txAvgTauSec = tau;
+            if (_txDispAlive && _txaChannelId is int txa)
+            {
+                TryConfigureTxAnalyzer(txa, _txaDspRateHz, _txaDspSize, _txDispRxSampleRateHz, _txDispPixelWidth, _txDispZoomLevel, fft, win, AnalyzerKaiserPi);
+                ConfigureDisplayAveragingTau(txa, tau);
+            }
+        }
+
+        // The PS-feedback analyzer shares the TX display span — keep it in sync
+        // so toggling PS-Monitor doesn't change FFT resolution / smoothing.
+        lock (_psFbDispLock)
+        {
+            if (_psFbDispAlive && _psFbDispId is int psFb)
+            {
+                TryConfigureTxAnalyzer(psFb, PsFeedbackSampleRateHz, PsFeedbackBlockSize, _psFbDispRxSampleRateHz, _psFbDispPixelWidth, _psFbDispZoomLevel, fft, win, AnalyzerKaiserPi);
+                ConfigureDisplayAveragingTau(psFb, tau);
+            }
+        }
+
+        _log.LogInformation("wdsp.configureTxDisplay fft={Fft} win={Win} tauMs={Tau:F0}", fft, win, tau * 1000.0);
+    }
+
     public int OpenTxChannel(int outputRateHz = 48_000)
     {
         ObjectDisposedException.ThrowIf(_disposed != 0, this);
@@ -1647,10 +1708,10 @@ public sealed class WdspDspEngine : IDspEngine
                         // TXA.c:586). Pre-fix the analyzer was configured at
                         // the OUTPUT (post-cfir/rsmpout) rate and got fed the
                         // predistorted IQ — cosmetically dirty by design.
-                        configured = TryConfigureTxAnalyzer(id, _txaDspRateHz, _txaDspSize, rxSampleRateHz, rxPixelWidth, rxZoom);
+                        configured = TryConfigureTxAnalyzer(id, _txaDspRateHz, _txaDspSize, rxSampleRateHz, rxPixelWidth, rxZoom, _txFftSize, _txWinType, AnalyzerKaiserPi);
                         if (configured)
                         {
-                            ConfigureDisplayAveragingTau(id, TxAvgTauSec);
+                            ConfigureDisplayAveragingTau(id, _txAvgTauSec);
                             _txDispAlive = true;
                         }
                     }
@@ -2423,7 +2484,7 @@ public sealed class WdspDspEngine : IDspEngine
                 _log.LogWarning("wdsp.psFb.open XCreateAnalyzer rc={Rc} — PS-Monitor will fall back to TX trace", rc);
                 return;
             }
-            bool configured = TryConfigureTxAnalyzer(psFbId, PsFeedbackSampleRateHz, PsFeedbackBlockSize, rxRate, pixelWidth, zoom);
+            bool configured = TryConfigureTxAnalyzer(psFbId, PsFeedbackSampleRateHz, PsFeedbackBlockSize, rxRate, pixelWidth, zoom, _txFftSize, _txWinType, AnalyzerKaiserPi);
             if (!configured)
             {
                 NativeMethods.DestroyAnalyzer(psFbId);
@@ -2433,7 +2494,7 @@ public sealed class WdspDspEngine : IDspEngine
                     rxRate, PsFeedbackSampleRateHz);
                 return;
             }
-            ConfigureDisplayAveragingTau(psFbId, TxAvgTauSec);
+            ConfigureDisplayAveragingTau(psFbId, _txAvgTauSec);
             _psFbDispId = psFbId;
             _psFbDispPixelWidth = pixelWidth;
             _psFbDispRxSampleRateHz = rxRate;
@@ -3090,7 +3151,8 @@ public sealed class WdspDspEngine : IDspEngine
     // match (txRate is a positive integer multiple of rxRate). Callers that get
     // false skip TX analyzer creation and fall back to the RX analyzer during
     // MOX — matches the pre-issue-#81 behaviour for that codepath.
-    private static bool TryConfigureTxAnalyzer(int disp, int txSampleRateHz, int txBlockSize, int rxSampleRateHz, int pixelWidth, int rxZoomLevel)
+    private static bool TryConfigureTxAnalyzer(int disp, int txSampleRateHz, int txBlockSize, int rxSampleRateHz, int pixelWidth, int rxZoomLevel,
+        int fftSize, int winType, double piAlpha)
     {
         if (rxSampleRateHz <= 0 || txSampleRateHz < rxSampleRateHz || txSampleRateHz % rxSampleRateHz != 0)
             return false;
@@ -3099,16 +3161,21 @@ public sealed class WdspDspEngine : IDspEngine
         // (_txaOutSize: 1024 on P1, 2048 on P2). Hardcoding InSize left WDSP
         // reading only the first 1024 of each 2048-sample P2 block, aliasing at
         // (192000/1024) ≈ 188 Hz and producing a spur comb on the TUN carrier.
-        ConfigureAnalyzer(disp, txSampleRateHz, txBlockSize, pixelWidth, effectiveZoom);
+        ConfigureAnalyzer(disp, txSampleRateHz, txBlockSize, pixelWidth, effectiveZoom, fftSize, winType, piAlpha);
         return true;
     }
 
-    private static void ConfigureAnalyzer(int disp, int sampleRateHz, int bfSize, int pixelWidth, int zoomLevel)
+    // fftSize / winType / piAlpha let the TX display analyzer be reconfigured at
+    // runtime (live TX waterfall feature); RX callers pass the historical
+    // AnalyzerFftSize / AnalyzerWindow / AnalyzerKaiserPi constants so RX
+    // behaviour is byte-identical.
+    private static void ConfigureAnalyzer(int disp, int sampleRateHz, int bfSize, int pixelWidth, int zoomLevel,
+        int fftSize, int winType, double piAlpha)
     {
-        int overlap = (int)Math.Max(0, Math.Ceiling(AnalyzerFftSize - (double)sampleRateHz / AnalyzerFps));
-        int maxW = AnalyzerFftSize + (int)Math.Min(
+        int overlap = (int)Math.Max(0, Math.Ceiling(fftSize - (double)sampleRateHz / AnalyzerFps));
+        int maxW = fftSize + (int)Math.Min(
             AnalyzerKeepTime * sampleRateHz,
-            AnalyzerKeepTime * AnalyzerFftSize * AnalyzerFps);
+            AnalyzerKeepTime * fftSize * AnalyzerFps);
         int flp = 0;
 
         // fscLin/fscHin are integer bin counts to clip from the LOW and HIGH
@@ -3119,7 +3186,7 @@ public sealed class WdspDspEngine : IDspEngine
         double fscLin = 0.0, fscHin = 0.0;
         if (zoomLevel > 1)
         {
-            int clippedPerSide = AnalyzerFftSize * (zoomLevel - 1) / (2 * zoomLevel);
+            int clippedPerSide = fftSize * (zoomLevel - 1) / (2 * zoomLevel);
             fscLin = clippedPerSide;
             fscHin = clippedPerSide;
         }
@@ -3130,10 +3197,10 @@ public sealed class WdspDspEngine : IDspEngine
             n_fft: 1,
             typ: 1,
             flp: ref flp,
-            sz: AnalyzerFftSize,
+            sz: fftSize,
             bf_sz: bfSize,
-            win_type: AnalyzerWindow,
-            pi_alpha: AnalyzerKaiserPi,
+            win_type: winType,
+            pi_alpha: piAlpha,
             ovrlp: overlap,
             clp: 0,
             fscLin: fscLin,

--- a/Zeus.Server.Hosting/DisplaySettingsStore.cs
+++ b/Zeus.Server.Hosting/DisplaySettingsStore.cs
@@ -43,6 +43,31 @@ public sealed class DisplaySettingsStore : IDisposable
         return true;
     }
 
+    // Bounds for the TX display analyzer parameters. These are display-only
+    // (they shape the transmitted-signal visualization, never the air), but we
+    // still guard the persisted values so a malformed PUT can't poison the DB
+    // or push an out-of-range value into the WDSP analyzer reconfig.
+    private const double TxCalOffsetAbsDb = 60.0;
+    private const double TxAvgTauMaxMs = 2000.0;
+    // Power-of-two FFT sizes the WDSP TX analyzer accepts. 16384 is the engine
+    // default (matches the RX analyzer); smaller = faster/less resolution,
+    // larger = finer bins / heavier compute.
+    private static readonly int[] TxFftSizes = { 2048, 4096, 8192, 16384, 32768, 65536 };
+
+    private static bool IsValidCalOffset(double? v) =>
+        v.HasValue && !double.IsNaN(v.Value) && !double.IsInfinity(v.Value)
+        && Math.Abs(v.Value) <= TxCalOffsetAbsDb;
+
+    private static bool IsValidFftSize(int? v) => v.HasValue && Array.IndexOf(TxFftSizes, v.Value) >= 0;
+
+    // WDSP win_type values 0..11 (analyzer.c). Keep the accept range generous;
+    // the frontend only surfaces a friendly subset.
+    private static bool IsValidWindow(int? v) => v.HasValue && v.Value >= 0 && v.Value <= 11;
+
+    private static bool IsValidAvgTauMs(double? v) =>
+        v.HasValue && !double.IsNaN(v.Value) && !double.IsInfinity(v.Value)
+        && v.Value >= 0.0 && v.Value <= TxAvgTauMaxMs;
+
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<DisplaySettingsEntry> _docs;
     private readonly ILogger<DisplaySettingsStore> _log;
@@ -84,7 +109,11 @@ public sealed class DisplaySettingsStore : IDisposable
                     WfDbMin: null,
                     WfDbMax: null,
                     WfTxDbMin: null,
-                    WfTxDbMax: null);
+                    WfTxDbMax: null,
+                    TxDisplayCalOffsetDb: null,
+                    TxDisplayFftSize: null,
+                    TxDisplayWindow: null,
+                    TxDisplayAvgTauMs: null);
             }
             return new DisplaySettingsDto(
                 Mode: NormalizeMode(e.Mode),
@@ -99,7 +128,11 @@ public sealed class DisplaySettingsStore : IDisposable
                 WfDbMin: e.WfDbMin,
                 WfDbMax: e.WfDbMax,
                 WfTxDbMin: e.WfTxDbMin,
-                WfTxDbMax: e.WfTxDbMax);
+                WfTxDbMax: e.WfTxDbMax,
+                TxDisplayCalOffsetDb: e.TxDisplayCalOffsetDb,
+                TxDisplayFftSize: e.TxDisplayFftSize,
+                TxDisplayWindow: e.TxDisplayWindow,
+                TxDisplayAvgTauMs: e.TxDisplayAvgTauMs);
         }
     }
 
@@ -110,7 +143,9 @@ public sealed class DisplaySettingsStore : IDisposable
         double? dbMin = null, double? dbMax = null,
         double? txDbMin = null, double? txDbMax = null,
         double? wfDbMin = null, double? wfDbMax = null,
-        double? wfTxDbMin = null, double? wfTxDbMax = null)
+        double? wfTxDbMin = null, double? wfTxDbMax = null,
+        double? txDisplayCalOffsetDb = null, int? txDisplayFftSize = null,
+        int? txDisplayWindow = null, double? txDisplayAvgTauMs = null)
     {
         lock (_sync)
         {
@@ -127,6 +162,12 @@ public sealed class DisplaySettingsStore : IDisposable
             if (IsValidRange(txDbMin, txDbMax)) { e.TxDbMin = txDbMin; e.TxDbMax = txDbMax; }
             if (IsValidRange(wfDbMin, wfDbMax)) { e.WfDbMin = wfDbMin; e.WfDbMax = wfDbMax; }
             if (IsValidRange(wfTxDbMin, wfTxDbMax)) { e.WfTxDbMin = wfTxDbMin; e.WfTxDbMax = wfTxDbMax; }
+            // TX display analyzer params — each validated independently so a
+            // caller can update one knob without clobbering the others.
+            if (IsValidCalOffset(txDisplayCalOffsetDb)) e.TxDisplayCalOffsetDb = txDisplayCalOffsetDb;
+            if (IsValidFftSize(txDisplayFftSize)) e.TxDisplayFftSize = txDisplayFftSize;
+            if (IsValidWindow(txDisplayWindow)) e.TxDisplayWindow = txDisplayWindow;
+            if (IsValidAvgTauMs(txDisplayAvgTauMs)) e.TxDisplayAvgTauMs = txDisplayAvgTauMs;
             e.UpdatedUtc = DateTime.UtcNow;
             if (e.Id == 0) _docs.Insert(e);
             else _docs.Update(e);
@@ -232,5 +273,13 @@ public sealed class DisplaySettingsEntry
     public double? WfDbMax { get; set; }
     public double? WfTxDbMin { get; set; }
     public double? WfTxDbMax { get; set; }
+    // TX display analyzer params (display-only). Null on rows written before
+    // these fields existed — Get() returns null and the engine applies its
+    // built-in defaults (16384-bin FFT, Hann window (win_type 2), 175 ms
+    // smoothing, 0 dB cal offset).
+    public double? TxDisplayCalOffsetDb { get; set; }
+    public int? TxDisplayFftSize { get; set; }
+    public int? TxDisplayWindow { get; set; }
+    public double? TxDisplayAvgTauMs { get; set; }
     public DateTime UpdatedUtc { get; set; }
 }

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -1005,7 +1005,8 @@ public class DspPipelineService : BackgroundService,
         IEnumerable<IRxAudioSink> audioSinks,
         ILoggerFactory loggerFactory,
         CwSidetoneSource? sidetone = null,
-        FrontendDspSceneDiagnosticsService? frontendDspScene = null)
+        FrontendDspSceneDiagnosticsService? frontendDspScene = null,
+        DisplaySettingsStore? displaySettings = null)
     {
         _radio = radio;
         _hub = hub;
@@ -1015,7 +1016,72 @@ public class DspPipelineService : BackgroundService,
         _sidetone = sidetone;
         _frontendDspScene = frontendDspScene;
         _loggerFactory = loggerFactory;
+        _displaySettings = displaySettings;
         _log = loggerFactory.CreateLogger<DspPipelineService>();
+    }
+
+    // Persisted TX display analyzer config (live TX waterfall feature). Optional
+    // so test constructions of DspPipelineService keep working; when null the
+    // engine just runs at its built-in defaults. Display-only — never affects
+    // the transmitted signal.
+    private readonly DisplaySettingsStore? _displaySettings;
+    // dB added to the TX panadapter/waterfall pixels (Thetis TXDisplayCalOffset).
+    // Read on the hot Tick path; written from the connect path + endpoint.
+    private double _txDisplayCalOffsetDb;
+
+    // Default TX display analyzer params — mirror WdspDspEngine's constants and
+    // the frontend's TX_DISPLAY_* defaults. Used when the persisted value is null.
+    private const int DefaultTxDisplayFftSize = 16384;
+    private const int DefaultTxDisplayWindow = 2;
+    private const double DefaultTxDisplayAvgTauMs = 175.0;
+    private const double TxDisplayCalOffsetAbsDb = 60.0;
+
+    /// <summary>Seed a freshly constructed engine with the persisted TX display
+    /// config BEFORE its TX channel opens, so the analyzer comes up with the
+    /// operator's FFT/window/smoothing rather than engine defaults. Also seeds
+    /// the cal-offset field read by <see cref="Tick"/>. Display-only — never
+    /// touches the transmitted signal.</summary>
+    private void SeedTxDisplayConfig(WdspDspEngine wdsp)
+    {
+        var dto = _displaySettings?.Get();
+        Volatile.Write(ref _txDisplayCalOffsetDb, ResolveCalOffset(dto));
+        wdsp.ConfigureTxDisplayAnalyzer(
+            dto?.TxDisplayFftSize ?? DefaultTxDisplayFftSize,
+            dto?.TxDisplayWindow ?? DefaultTxDisplayWindow,
+            (dto?.TxDisplayAvgTauMs ?? DefaultTxDisplayAvgTauMs) / 1000.0);
+    }
+
+    /// <summary>Live update from the /api/display-settings endpoint — pushes the
+    /// new cal offset + analyzer config to the running engine (if any). Safe to
+    /// call with no radio connected; the values are re-seeded on next connect.
+    /// Display-only.</summary>
+    public void ApplyTxDisplaySettings(DisplaySettingsDto dto)
+    {
+        Volatile.Write(ref _txDisplayCalOffsetDb, ResolveCalOffset(dto));
+        int fft = dto.TxDisplayFftSize ?? DefaultTxDisplayFftSize;
+        int win = dto.TxDisplayWindow ?? DefaultTxDisplayWindow;
+        double tauSec = (dto.TxDisplayAvgTauMs ?? DefaultTxDisplayAvgTauMs) / 1000.0;
+        var engine = CurrentEngine;
+        if (engine is null) return;
+        lock (_engineLock)
+        {
+            engine.ConfigureTxDisplayAnalyzer(fft, win, tauSec);
+        }
+    }
+
+    private static double ResolveCalOffset(DisplaySettingsDto? dto)
+    {
+        double v = dto?.TxDisplayCalOffsetDb ?? 0.0;
+        if (double.IsNaN(v) || double.IsInfinity(v)) return 0.0;
+        return Math.Clamp(v, -TxDisplayCalOffsetAbsDb, TxDisplayCalOffsetAbsDb);
+    }
+
+    // Add a dB offset to every pixel of a display buffer (TX cal offset).
+    private static void AddDbOffset(float[] buf, double db)
+    {
+        if (db == 0.0) return;
+        float d = (float)db;
+        for (int i = 0; i < buf.Length; i++) buf[i] += d;
     }
 
     private void PublishAudio(in AudioFrame frame)
@@ -2866,6 +2932,9 @@ public class DspPipelineService : BackgroundService,
 
         var wdsp = new WdspDspEngine(_loggerFactory.CreateLogger<WdspDspEngine>());
         int channelId = wdsp.OpenChannel(rate, Width);
+        // Seed the operator's persisted TX display config before TXA opens so
+        // the analyzer comes up at their FFT/window/smoothing. Display-only.
+        SeedTxDisplayConfig(wdsp);
         // P1 DAC runs at 48 kHz; keep TXA at the 48/48/48 profile Hermes is
         // calibrated against.
         wdsp.OpenTxChannel(outputRateHz: 48_000);
@@ -3704,6 +3773,9 @@ public class DspPipelineService : BackgroundService,
         {
             var wdsp = new WdspDspEngine(_loggerFactory.CreateLogger<WdspDspEngine>());
             newChannelId = wdsp.OpenChannel(rateHz, Width);
+            // Seed the operator's persisted TX display config before TXA opens
+            // so the analyzer comes up at their FFT/window/smoothing. Display-only.
+            SeedTxDisplayConfig(wdsp);
             // G2 MkII DUC on P2 expects 192 kHz TX IQ. WDSP upsamples internally
             // (48k mic → 96k DSP → 192k out) and CFIR compensates the sinc
             // droop. Feeding 48 kHz IQ to a 192 kHz DUC as we did before
@@ -4471,6 +4543,18 @@ public class DspPipelineService : BackgroundService,
             {
                 wf = engine.TryGetDisplayPixels(channel, DisplayPixout.Waterfall, wfBuf);
                 if (wf) wfSource = "rx";
+            }
+
+            // TX display calibration offset (Thetis TXDisplayCalOffset). Pure
+            // dB shift of the transmitted-signal trace/waterfall so the operator
+            // can sit the in-passband level where they want it — display-only,
+            // never the air. Applied only to TX-sourced pixels (tx / PS
+            // feedback); RX pixels keep their own calibration.
+            double txCal = Volatile.Read(ref _txDisplayCalOffsetDb);
+            if (txCal != 0.0)
+            {
+                if (pan && (panSource == "tx" || panSource == "ps-feedback")) AddDbOffset(panBuf, txCal);
+                if (wf && (wfSource == "tx" || wfSource == "ps-feedback")) AddDbOffset(wfBuf, txCal);
             }
 
             // Flip to display order (low freq left, high freq right). WDSP emits

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -1786,14 +1786,20 @@ public static class ZeusEndpoints
         // browsers / devices instead of living in per-origin localStorage.
         app.MapGet("/api/display-settings", (DisplaySettingsStore store) => Results.Ok(store.Get()));
 
-        app.MapPut("/api/display-settings", (DisplaySettingsSetRequest req, DisplaySettingsStore store) =>
+        app.MapPut("/api/display-settings", (DisplaySettingsSetRequest req, DisplaySettingsStore store, DspPipelineService dsp) =>
         {
             if (string.IsNullOrWhiteSpace(req.Mode) || string.IsNullOrWhiteSpace(req.Fit))
                 return Results.BadRequest(new { error = "mode and fit required" });
             store.SaveMode(req.Mode, req.Fit, req.RxTraceColor,
                 req.DbMin, req.DbMax, req.TxDbMin, req.TxDbMax,
-                req.WfDbMin, req.WfDbMax, req.WfTxDbMin, req.WfTxDbMax);
-            return Results.Ok(store.Get());
+                req.WfDbMin, req.WfDbMax, req.WfTxDbMin, req.WfTxDbMax,
+                req.TxDisplayCalOffsetDb, req.TxDisplayFftSize,
+                req.TxDisplayWindow, req.TxDisplayAvgTauMs);
+            var saved = store.Get();
+            // Push the (validated, merged) TX display config to the running
+            // engine so the change is live without a reconnect. Display-only.
+            dsp.ApplyTxDisplaySettings(saved);
+            return Results.Ok(saved);
         });
 
         // Signal Intelligence weak-signal display policy. The frontend owns the

--- a/tests/Zeus.Server.Tests/DisplaySettingsStoreTxDisplayTests.cs
+++ b/tests/Zeus.Server.Tests/DisplaySettingsStoreTxDisplayTests.cs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// DisplaySettingsStore — TX display analyzer params (live TX waterfall).
+// Pins: null-on-first-run (engine falls back to defaults), round-trip of valid
+// values, per-field independence (updating one knob keeps the others), and
+// validation (out-of-range / NaN / non-power-of-two are dropped, not persisted).
+// These are display-only params; the safety value here is "a malformed PUT
+// can't poison zeus-prefs.db or push garbage into the WDSP analyzer reconfig".
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class DisplaySettingsStoreTxDisplayTests : IDisposable
+{
+    private readonly string _dbPath;
+
+    public DisplaySettingsStoreTxDisplayTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"zeus-prefs-txdisplay-{Guid.NewGuid():N}.db");
+    }
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+    }
+
+    private DisplaySettingsStore NewStore() =>
+        new DisplaySettingsStore(NullLogger<DisplaySettingsStore>.Instance, _dbPath);
+
+    private void Save(DisplaySettingsStore store,
+        double? cal = null, int? fft = null, int? win = null, double? tau = null) =>
+        store.SaveMode("basic", "fill", "#FFA028",
+            txDisplayCalOffsetDb: cal, txDisplayFftSize: fft,
+            txDisplayWindow: win, txDisplayAvgTauMs: tau);
+
+    [Fact]
+    public void FirstRun_TxDisplayParamsAreNull()
+    {
+        using var store = NewStore();
+        var dto = store.Get();
+        Assert.Null(dto.TxDisplayCalOffsetDb);
+        Assert.Null(dto.TxDisplayFftSize);
+        Assert.Null(dto.TxDisplayWindow);
+        Assert.Null(dto.TxDisplayAvgTauMs);
+    }
+
+    [Fact]
+    public void ValidValues_RoundTrip()
+    {
+        using var store = NewStore();
+        Save(store, cal: -12.5, fft: 32768, win: 1, tau: 250.0);
+        var dto = store.Get();
+        Assert.Equal(-12.5, dto.TxDisplayCalOffsetDb);
+        Assert.Equal(32768, dto.TxDisplayFftSize);
+        Assert.Equal(1, dto.TxDisplayWindow);
+        Assert.Equal(250.0, dto.TxDisplayAvgTauMs);
+    }
+
+    [Fact]
+    public void RoundTrip_SurvivesReopen()
+    {
+        using (var store = NewStore())
+            Save(store, cal: 6.0, fft: 8192, win: 5, tau: 100.0);
+        using var reopened = NewStore();
+        var dto = reopened.Get();
+        Assert.Equal(6.0, dto.TxDisplayCalOffsetDb);
+        Assert.Equal(8192, dto.TxDisplayFftSize);
+        Assert.Equal(5, dto.TxDisplayWindow);
+        Assert.Equal(100.0, dto.TxDisplayAvgTauMs);
+    }
+
+    [Fact]
+    public void PartialUpdate_LeavesOtherFieldsUntouched()
+    {
+        using var store = NewStore();
+        Save(store, cal: -10.0, fft: 16384, win: 2, tau: 175.0);
+        // Update only the cal offset; everything else must persist.
+        Save(store, cal: 3.0);
+        var dto = store.Get();
+        Assert.Equal(3.0, dto.TxDisplayCalOffsetDb);
+        Assert.Equal(16384, dto.TxDisplayFftSize);
+        Assert.Equal(2, dto.TxDisplayWindow);
+        Assert.Equal(175.0, dto.TxDisplayAvgTauMs);
+    }
+
+    [Theory]
+    [InlineData(200.0)]   // beyond ±60 dB
+    [InlineData(-200.0)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    public void InvalidCalOffset_IsDropped(double bad)
+    {
+        using var store = NewStore();
+        Save(store, cal: -8.0);            // seed a good value
+        Save(store, cal: bad);             // bad write must be ignored
+        Assert.Equal(-8.0, store.Get().TxDisplayCalOffsetDb);
+    }
+
+    [Theory]
+    [InlineData(3000)]    // not a power-of-two in the accepted set
+    [InlineData(0)]
+    [InlineData(1_000_000)]
+    public void InvalidFftSize_IsDropped(int bad)
+    {
+        using var store = NewStore();
+        Save(store, fft: 8192);
+        Save(store, fft: bad);
+        Assert.Equal(8192, store.Get().TxDisplayFftSize);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(12)]
+    public void InvalidWindow_IsDropped(int bad)
+    {
+        using var store = NewStore();
+        Save(store, win: 2);
+        Save(store, win: bad);
+        Assert.Equal(2, store.Get().TxDisplayWindow);
+    }
+
+    [Theory]
+    [InlineData(-5.0)]
+    [InlineData(5000.0)]  // beyond the 2000 ms cap
+    [InlineData(double.NaN)]
+    public void InvalidAvgTau_IsDropped(double bad)
+    {
+        using var store = NewStore();
+        Save(store, tau: 150.0);
+        Save(store, tau: bad);
+        Assert.Equal(150.0, store.Get().TxDisplayAvgTauMs);
+    }
+}

--- a/tests/Zeus.Server.Tests/DspPipelineRx2RoutingTests.cs
+++ b/tests/Zeus.Server.Tests/DspPipelineRx2RoutingTests.cs
@@ -154,6 +154,7 @@ public class DspPipelineRx2RoutingTests
         public int ReadAudio(int channelId, Span<float> output) => 0;
         public bool TryGetDisplayPixels(int channelId, DisplayPixout which, Span<float> dbOut) => false;
         public bool TryGetTxDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
+        public void ConfigureTxDisplayAnalyzer(int fftSize, int windowType, double avgTauSec) { }
         public bool TryGetPsFeedbackDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
         public int OpenTxChannel(int outputRateHz = 48_000) => 0;
         public void SetMox(bool moxOn) { }

--- a/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
@@ -188,6 +188,7 @@ public class MicGainEndpointTests : IClassFixture<MicGainEndpointTests.Factory>
         public int ReadAudio(int channelId, Span<float> output) => 0;
         public bool TryGetDisplayPixels(int channelId, DisplayPixout which, Span<float> dbOut) => false;
         public bool TryGetTxDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
+        public void ConfigureTxDisplayAnalyzer(int fftSize, int windowType, double avgTauSec) { }
         public bool TryGetPsFeedbackDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
         public int OpenTxChannel(int outputRateHz = 48_000) => 0;
         public void SetMox(bool moxOn) { }

--- a/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
+++ b/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
@@ -105,6 +105,7 @@ public class TxAudioIngestTests
         public int ReadAudio(int channelId, Span<float> output) => 0;
         public bool TryGetDisplayPixels(int channelId, DisplayPixout which, Span<float> dbOut) => false;
         public bool TryGetTxDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
+        public void ConfigureTxDisplayAnalyzer(int fftSize, int windowType, double avgTauSec) { }
         public bool TryGetPsFeedbackDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
         public int OpenTxChannel(int outputRateHz = 48_000) => 0;
         public void SetMox(bool moxOn) { }

--- a/zeus-web/src/api/display.ts
+++ b/zeus-web/src/api/display.ts
@@ -25,6 +25,13 @@ export type DisplaySettings = {
   wfDbMax: number | null;
   wfTxDbMin: number | null;
   wfTxDbMax: number | null;
+  // TX display analyzer params (live TX waterfall). Display-only — they shape
+  // the transmitted-signal panadapter/waterfall, never the air. null = server
+  // never stored a value → frontend uses its DEFAULT_TX_DISPLAY_* constants.
+  txDisplayCalOffsetDb: number | null;
+  txDisplayFftSize: number | null;
+  txDisplayWindow: number | null;
+  txDisplayAvgTauMs: number | null;
 };
 
 // Matches backend DisplaySettingsStore.DefaultRxTraceColor.
@@ -44,6 +51,10 @@ type DisplaySettingsDtoRaw = {
   wfDbMax?: number | null;
   wfTxDbMin?: number | null;
   wfTxDbMax?: number | null;
+  txDisplayCalOffsetDb?: number | null;
+  txDisplayFftSize?: number | null;
+  txDisplayWindow?: number | null;
+  txDisplayAvgTauMs?: number | null;
 };
 
 function normalizeRxTraceColor(raw: string | null | undefined): string {
@@ -78,6 +89,10 @@ function normalize(raw: DisplaySettingsDtoRaw): DisplaySettings {
     wfDbMax: normalizeDbValue(raw.wfDbMax),
     wfTxDbMin: normalizeDbValue(raw.wfTxDbMin),
     wfTxDbMax: normalizeDbValue(raw.wfTxDbMax),
+    txDisplayCalOffsetDb: normalizeDbValue(raw.txDisplayCalOffsetDb),
+    txDisplayFftSize: normalizeDbValue(raw.txDisplayFftSize),
+    txDisplayWindow: normalizeDbValue(raw.txDisplayWindow),
+    txDisplayAvgTauMs: normalizeDbValue(raw.txDisplayAvgTauMs),
   };
 }
 
@@ -99,6 +114,12 @@ export async function updateDisplaySettings(
   wfDbMax?: number | null,
   wfTxDbMin?: number | null,
   wfTxDbMax?: number | null,
+  txDisplay?: {
+    calOffsetDb?: number | null;
+    fftSize?: number | null;
+    window?: number | null;
+    avgTauMs?: number | null;
+  },
   signal?: AbortSignal,
 ): Promise<DisplaySettings> {
   const res = await fetch('/api/display-settings', {
@@ -116,6 +137,10 @@ export async function updateDisplaySettings(
       wfDbMax,
       wfTxDbMin,
       wfTxDbMax,
+      txDisplayCalOffsetDb: txDisplay?.calOffsetDb,
+      txDisplayFftSize: txDisplay?.fftSize,
+      txDisplayWindow: txDisplay?.window,
+      txDisplayAvgTauMs: txDisplay?.avgTauMs,
     }),
     signal,
   });

--- a/zeus-web/src/components/SpectrumScaleSettingsPanel.tsx
+++ b/zeus-web/src/components/SpectrumScaleSettingsPanel.tsx
@@ -6,8 +6,15 @@
 
 import type { CSSProperties } from 'react';
 import {
+  DEFAULT_TX_DISPLAY_AVG_TAU_MS,
+  DEFAULT_TX_DISPLAY_CAL_OFFSET_DB,
   FIXED_DB_MAX,
   FIXED_DB_MIN,
+  TX_DISPLAY_AVG_TAU_MAX_MS,
+  TX_DISPLAY_AVG_TAU_MIN_MS,
+  TX_DISPLAY_CAL_OFFSET_ABS_DB,
+  TX_DISPLAY_FFT_SIZES,
+  TX_DISPLAY_WINDOWS,
   TX_FIXED_DB_MAX,
   TX_FIXED_DB_MIN,
   useDisplaySettingsStore,
@@ -116,6 +123,13 @@ export function SpectrumScaleSettingsPanel() {
   const setWfTxDbRange = useDisplaySettingsStore((s) => s.setWfTxDbRange);
   const resetDbRanges = useDisplaySettingsStore((s) => s.resetDbRanges);
 
+  const txCalOffsetDb = useDisplaySettingsStore((s) => s.txDisplayCalOffsetDb);
+  const txFftSize = useDisplaySettingsStore((s) => s.txDisplayFftSize);
+  const txWindow = useDisplaySettingsStore((s) => s.txDisplayWindow);
+  const txAvgTauMs = useDisplaySettingsStore((s) => s.txDisplayAvgTauMs);
+  const setTxDisplayParams = useDisplaySettingsStore((s) => s.setTxDisplayParams);
+  const resetTxDisplayParams = useDisplaySettingsStore((s) => s.resetTxDisplayParams);
+
   return (
     <section>
       <div style={sectionHead}>
@@ -180,6 +194,131 @@ export function SpectrumScaleSettingsPanel() {
           defaultMax={TX_FIXED_DB_MAX}
           onChange={setWfTxDbRange}
         />
+      </div>
+
+      <div style={sectionHead}>
+        <h3 style={sectionH3}>TX Display Analyzer</h3>
+        <p style={sectionP}>
+          Shapes the live transmitted-signal panadapter &amp; waterfall during MOX/TUN.
+          Display-only — never affects the transmitted audio, drive, or PA.
+        </p>
+        <button type="button" className="btn sm" onClick={resetTxDisplayParams} style={allResetButton}>
+          Reset
+        </button>
+      </div>
+
+      <div style={card}>
+        <div style={rangeRow}>
+          <div style={rangeText}>
+            <span style={rangeTitle}>Cal Offset</span>
+            <span style={rangeDetail}>
+              dB shift of the TX trace/waterfall level. Lower this if the audio reads too
+              hot inside the bandwidth filter.
+            </span>
+          </div>
+          <label style={rangeLabel}>
+            dB
+            <input
+              type="number"
+              min={-TX_DISPLAY_CAL_OFFSET_ABS_DB}
+              max={TX_DISPLAY_CAL_OFFSET_ABS_DB}
+              step={1}
+              value={Math.round(txCalOffsetDb)}
+              onChange={(e) => {
+                const n = readNumber(e.currentTarget.value);
+                if (n !== null) setTxDisplayParams({ calOffsetDb: n });
+              }}
+              style={numberInput}
+            />
+          </label>
+          <button
+            type="button"
+            className="btn sm"
+            onClick={() => setTxDisplayParams({ calOffsetDb: DEFAULT_TX_DISPLAY_CAL_OFFSET_DB })}
+            title={`Reset to ${DEFAULT_TX_DISPLAY_CAL_OFFSET_DB} dB`}
+            style={resetButton}
+          >
+            Reset
+          </button>
+        </div>
+
+        <div style={rangeRow}>
+          <div style={rangeText}>
+            <span style={rangeTitle}>Smoothing</span>
+            <span style={rangeDetail}>
+              Visual averaging time-constant (ms). Lower = more responsive/alive,
+              higher = smoother envelope.
+            </span>
+          </div>
+          <label style={rangeLabel}>
+            ms
+            <input
+              type="number"
+              min={TX_DISPLAY_AVG_TAU_MIN_MS}
+              max={TX_DISPLAY_AVG_TAU_MAX_MS}
+              step={5}
+              value={Math.round(txAvgTauMs)}
+              onChange={(e) => {
+                const n = readNumber(e.currentTarget.value);
+                if (n !== null) setTxDisplayParams({ avgTauMs: n });
+              }}
+              style={numberInput}
+            />
+          </label>
+          <button
+            type="button"
+            className="btn sm"
+            onClick={() => setTxDisplayParams({ avgTauMs: DEFAULT_TX_DISPLAY_AVG_TAU_MS })}
+            title={`Reset to ${DEFAULT_TX_DISPLAY_AVG_TAU_MS} ms`}
+            style={resetButton}
+          >
+            Reset
+          </button>
+        </div>
+
+        <div style={rangeRow}>
+          <div style={rangeText}>
+            <span style={rangeTitle}>FFT Size</span>
+            <span style={rangeDetail}>Analyzer bin count — larger = finer resolution, heavier compute.</span>
+          </div>
+          <label style={rangeLabel}>
+            Bins
+            <select
+              value={txFftSize}
+              onChange={(e) => setTxDisplayParams({ fftSize: Number(e.currentTarget.value) })}
+              style={numberInput}
+            >
+              {TX_DISPLAY_FFT_SIZES.map((sz) => (
+                <option key={sz} value={sz}>
+                  {sz}
+                </option>
+              ))}
+            </select>
+          </label>
+          <span style={resetButton} />
+        </div>
+
+        <div style={rangeRow}>
+          <div style={rangeText}>
+            <span style={rangeTitle}>Window</span>
+            <span style={rangeDetail}>FFT window function. Hann is the default; Blackman-Harris trades resolution for lower sidelobes.</span>
+          </div>
+          <label style={{ ...rangeLabel, flex: '0 0 132px' }}>
+            Type
+            <select
+              value={txWindow}
+              onChange={(e) => setTxDisplayParams({ window: Number(e.currentTarget.value) })}
+              style={numberInput}
+            >
+              {TX_DISPLAY_WINDOWS.map((w) => (
+                <option key={w.value} value={w.value}>
+                  {w.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <span style={resetButton} />
+        </div>
       </div>
     </section>
   );

--- a/zeus-web/src/layout/panels/HeroPanel.tsx
+++ b/zeus-web/src/layout/panels/HeroPanel.tsx
@@ -47,7 +47,6 @@ import type { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent }
 import { GripVertical, X } from 'lucide-react';
 import { Panadapter } from '../../components/Panadapter';
 import { WaterfallSurface } from '../../components/WaterfallSurface';
-import { TxEqAnalyzer } from '../../components/TxEqAnalyzer';
 import { ZoomControl } from '../../components/ZoomControl';
 import { WaterfallSpeedControl } from '../../components/WaterfallSpeedControl';
 import { SpectrumControls } from '../../components/SpectrumControls';
@@ -129,7 +128,8 @@ export function HeroPanel({
   const rx2AudioMode = useConnectionStore((s) => s.rx2AudioMode);
   const rxFocus = useConnectionStore((s) => s.rxFocus);
   const setRxFocus = useConnectionStore((s) => s.setRxFocus);
-  // During TX the waterfall region becomes the live TX EQ analyzer.
+  // During TX the waterfall region shows the live transmitted spectrum
+  // (WDSP TX analyzer pixels, streamed by the server while keyed).
   const keyed = useTxStore((s) => s.moxOn || s.tunOn);
   const updateTileInstanceConfig = useLayoutStore(
     (s) => s.updateTileInstanceConfigInLayout,
@@ -484,9 +484,15 @@ export function HeroPanel({
           />
           {connected && (
             keyed ? (
-              // On TX both receivers transmit the same audio, so a single
-              // full-width analyzer replaces the waterfall (or RX2 quad).
-              <TxEqAnalyzer transparent={bgActive} />
+              // On TX both receivers transmit the same audio, and the server
+              // feeds the WDSP TX analyzer's pixels into the main display
+              // stream while keyed (DspPipelineService, issue #81). So a single
+              // full-width waterfall shows the live transmitted spectrum
+              // scrolling — paired with the panadapter above (also TX while
+              // keyed) it forms a real TX panafall. The TX dB window
+              // (wfTxDbMin/Max) and the left-edge WfDbScale drag let the
+              // operator set the in-passband brightness independently of RX.
+              <WaterfallSurface transparent={bgActive} />
             ) : rx2Enabled ? (
               <div style={stitchedGridStyle}>
                 <div style={{ minWidth: 0, minHeight: 0 }}>

--- a/zeus-web/src/state/display-settings-store.test.ts
+++ b/zeus-web/src/state/display-settings-store.test.ts
@@ -42,11 +42,17 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  DEFAULT_TX_DISPLAY_AVG_TAU_MS,
+  DEFAULT_TX_DISPLAY_CAL_OFFSET_DB,
+  DEFAULT_TX_DISPLAY_FFT_SIZE,
+  DEFAULT_TX_DISPLAY_WINDOW,
   DEFAULT_WF_SCROLL_SPEED,
   FIXED_DB_MAX,
   FIXED_DB_MIN,
+  TX_DISPLAY_CAL_OFFSET_ABS_DB,
+  TX_DISPLAY_AVG_TAU_MAX_MS,
   WATERFALL_SCROLL_SPEED_MAX,
   WATERFALL_SCROLL_SPEED_MIN,
   TX_FIXED_DB_MAX,
@@ -199,6 +205,66 @@ describe('display-settings-store', () => {
       wfDbMax: FIXED_DB_MAX,
       wfTxDbMin: TX_FIXED_DB_MIN,
       wfTxDbMax: TX_FIXED_DB_MAX,
+    });
+  });
+});
+
+describe('TX display analyzer params', () => {
+  beforeEach(() => {
+    // Stub fetch so the debounced server save is a no-op (and never leaks a
+    // rejected promise / pending timer into later tests).
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({}) })));
+    useDisplaySettingsStore.setState({
+      txDisplayCalOffsetDb: DEFAULT_TX_DISPLAY_CAL_OFFSET_DB,
+      txDisplayFftSize: DEFAULT_TX_DISPLAY_FFT_SIZE,
+      txDisplayWindow: DEFAULT_TX_DISPLAY_WINDOW,
+      txDisplayAvgTauMs: DEFAULT_TX_DISPLAY_AVG_TAU_MS,
+    });
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('updates a single param and leaves the rest untouched', () => {
+    useDisplaySettingsStore.getState().setTxDisplayParams({ fftSize: 32768 });
+    const s = useDisplaySettingsStore.getState();
+    expect(s.txDisplayFftSize).toBe(32768);
+    expect(s.txDisplayCalOffsetDb).toBe(DEFAULT_TX_DISPLAY_CAL_OFFSET_DB);
+    expect(s.txDisplayWindow).toBe(DEFAULT_TX_DISPLAY_WINDOW);
+    expect(s.txDisplayAvgTauMs).toBe(DEFAULT_TX_DISPLAY_AVG_TAU_MS);
+  });
+
+  it('clamps the cal offset to ±limit', () => {
+    useDisplaySettingsStore.getState().setTxDisplayParams({ calOffsetDb: 9999 });
+    expect(useDisplaySettingsStore.getState().txDisplayCalOffsetDb).toBe(TX_DISPLAY_CAL_OFFSET_ABS_DB);
+    useDisplaySettingsStore.getState().setTxDisplayParams({ calOffsetDb: -9999 });
+    expect(useDisplaySettingsStore.getState().txDisplayCalOffsetDb).toBe(-TX_DISPLAY_CAL_OFFSET_ABS_DB);
+  });
+
+  it('clamps smoothing tau to the allowed range', () => {
+    useDisplaySettingsStore.getState().setTxDisplayParams({ avgTauMs: 99999 });
+    expect(useDisplaySettingsStore.getState().txDisplayAvgTauMs).toBe(TX_DISPLAY_AVG_TAU_MAX_MS);
+  });
+
+  it('ignores a non-power-of-two FFT size', () => {
+    useDisplaySettingsStore.getState().setTxDisplayParams({ fftSize: 12345 });
+    expect(useDisplaySettingsStore.getState().txDisplayFftSize).toBe(DEFAULT_TX_DISPLAY_FFT_SIZE);
+  });
+
+  it('ignores an unknown window type', () => {
+    useDisplaySettingsStore.getState().setTxDisplayParams({ window: 99 });
+    expect(useDisplaySettingsStore.getState().txDisplayWindow).toBe(DEFAULT_TX_DISPLAY_WINDOW);
+  });
+
+  it('resets all params to defaults', () => {
+    const s = useDisplaySettingsStore.getState();
+    s.setTxDisplayParams({ calOffsetDb: -15, fftSize: 8192, window: 5, avgTauMs: 400 });
+    s.resetTxDisplayParams();
+    expect(useDisplaySettingsStore.getState()).toMatchObject({
+      txDisplayCalOffsetDb: DEFAULT_TX_DISPLAY_CAL_OFFSET_DB,
+      txDisplayFftSize: DEFAULT_TX_DISPLAY_FFT_SIZE,
+      txDisplayWindow: DEFAULT_TX_DISPLAY_WINDOW,
+      txDisplayAvgTauMs: DEFAULT_TX_DISPLAY_AVG_TAU_MS,
     });
   });
 });

--- a/zeus-web/src/state/display-settings-store.ts
+++ b/zeus-web/src/state/display-settings-store.ts
@@ -68,6 +68,29 @@ export const FIXED_DB_MAX = -50;
 export const TX_FIXED_DB_MIN = -80;
 export const TX_FIXED_DB_MAX = 20;
 
+// TX display analyzer params (live TX waterfall). Display-only — they shape the
+// transmitted-signal panadapter/waterfall, never the air. Defaults mirror the
+// backend WdspDspEngine constants. Window ints are WDSP win_type values
+// (analyzer.c new_window): 0 Rectangular, 1 Blackman-Harris, 2 Hann (default),
+// 3 Flat-top, 4 Hamming, 5 Kaiser, 6 Blackman-Harris 7-term.
+export const TX_DISPLAY_FFT_SIZES = [2048, 4096, 8192, 16384, 32768, 65536] as const;
+export const TX_DISPLAY_WINDOWS: readonly { value: number; label: string }[] = [
+  { value: 2, label: 'Hann' },
+  { value: 1, label: 'Blackman-Harris' },
+  { value: 6, label: 'Blackman-Harris 7' },
+  { value: 3, label: 'Flat-top' },
+  { value: 4, label: 'Hamming' },
+  { value: 5, label: 'Kaiser' },
+  { value: 0, label: 'Rectangular' },
+];
+export const DEFAULT_TX_DISPLAY_CAL_OFFSET_DB = 0;
+export const DEFAULT_TX_DISPLAY_FFT_SIZE = 16384;
+export const DEFAULT_TX_DISPLAY_WINDOW = 2;
+export const DEFAULT_TX_DISPLAY_AVG_TAU_MS = 175;
+export const TX_DISPLAY_CAL_OFFSET_ABS_DB = 60;
+export const TX_DISPLAY_AVG_TAU_MIN_MS = 0;
+export const TX_DISPLAY_AVG_TAU_MAX_MS = 2000;
+
 const STORAGE_KEY = 'zeus.display.dbRange';
 const TX_STORAGE_KEY = 'zeus.display.txDbRange';
 const WF_STORAGE_KEY = 'zeus.display.wfDbRange';
@@ -276,6 +299,38 @@ function scheduleDbRangeSave(): void {
   }, 1000);
 }
 
+// Debounced server save for the TX display analyzer params. Slider drags
+// (cal offset, smoothing) fire many updates; batch into one PUT. Shorter quiet
+// period than the dB-range save since these are discrete control tweaks, not a
+// continuous finger-drag on the panadapter scale.
+let txDisplayTimer: ReturnType<typeof setTimeout> | null = null;
+
+function scheduleTxDisplaySave(): void {
+  if (txDisplayTimer) clearTimeout(txDisplayTimer);
+  txDisplayTimer = setTimeout(() => {
+    const s = useDisplaySettingsStore.getState();
+    void updateDisplaySettings(
+      s.panBackground,
+      s.backgroundImageFit,
+      s.rxTraceColor,
+      s.dbMin,
+      s.dbMax,
+      s.txDbMin,
+      s.txDbMax,
+      s.wfDbMin,
+      s.wfDbMax,
+      s.wfTxDbMin,
+      s.wfTxDbMax,
+      {
+        calOffsetDb: s.txDisplayCalOffsetDb,
+        fftSize: s.txDisplayFftSize,
+        window: s.txDisplayWindow,
+        avgTauMs: s.txDisplayAvgTauMs,
+      },
+    );
+  }, 500);
+}
+
 // Exponential smoothing constant for the auto-range tracker. 0.1 trades
 // flicker resistance for responsiveness — band-change artifacts fade over
 // ~30 frames at 30 Hz (~1 s).
@@ -310,6 +365,15 @@ export type DisplaySettingsState = {
   // parity — see TX_FIXED_DB_MIN/MAX constants.
   txDbMin: number;
   txDbMax: number;
+  // TX display analyzer params (live TX waterfall). Display-only — they shape
+  // the transmitted-signal panadapter/waterfall FFT + level, never the air.
+  // calOffsetDb shifts the trace/waterfall level (Thetis TXDisplayCalOffset);
+  // fftSize/window are the WDSP analyzer config; avgTauMs is the visual
+  // smoothing time-constant. Persisted server-side; applied to the engine live.
+  txDisplayCalOffsetDb: number;
+  txDisplayFftSize: number;
+  txDisplayWindow: number;
+  txDisplayAvgTauMs: number;
   colormap: ColormapId;
   waterfallScrollSpeed: number;
   // Panadapter background overlay mode + (optional) user image. See the
@@ -339,6 +403,15 @@ export type DisplaySettingsState = {
   setTxDbRange: (txDbMin: number, txDbMax: number) => void;
   setWfDbRange: (wfDbMin: number, wfDbMax: number) => void;
   setWfTxDbRange: (wfTxDbMin: number, wfTxDbMax: number) => void;
+  // Update one or more TX display analyzer params; persisted + pushed to the
+  // engine (debounced). Omitted fields are left unchanged.
+  setTxDisplayParams: (p: {
+    calOffsetDb?: number;
+    fftSize?: number;
+    window?: number;
+    avgTauMs?: number;
+  }) => void;
+  resetTxDisplayParams: () => void;
   resetDbRanges: () => void;
   updateAutoRange: (wfDb: Float32Array) => void;
   // Shift dbMin and dbMax together by `deltaDb`. Used by the draggable dB
@@ -403,6 +476,10 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
   wfTxDbMax: initialWfTxRange.wfTxDbMax,
   txDbMin: initialTxRange.txDbMin,
   txDbMax: initialTxRange.txDbMax,
+  txDisplayCalOffsetDb: DEFAULT_TX_DISPLAY_CAL_OFFSET_DB,
+  txDisplayFftSize: DEFAULT_TX_DISPLAY_FFT_SIZE,
+  txDisplayWindow: DEFAULT_TX_DISPLAY_WINDOW,
+  txDisplayAvgTauMs: DEFAULT_TX_DISPLAY_AVG_TAU_MS,
   colormap: 'blue',
   waterfallScrollSpeed: initialWaterfallScrollSpeed,
   // Defaults until the server-side fetch lands (see hydrateFromServer at the
@@ -530,6 +607,40 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
     set({ wfTxDbMin: next.min, wfTxDbMax: next.max });
     writeSavedWfTxRange(next.min, next.max);
     scheduleDbRangeSave();
+  },
+  setTxDisplayParams: (p) => {
+    const clampNum = (v: number, lo: number, hi: number) =>
+      Math.max(lo, Math.min(hi, v));
+    const next: Partial<DisplaySettingsState> = {};
+    if (typeof p.calOffsetDb === 'number' && Number.isFinite(p.calOffsetDb)) {
+      next.txDisplayCalOffsetDb = clampNum(
+        p.calOffsetDb,
+        -TX_DISPLAY_CAL_OFFSET_ABS_DB,
+        TX_DISPLAY_CAL_OFFSET_ABS_DB,
+      );
+    }
+    if (typeof p.fftSize === 'number' && (TX_DISPLAY_FFT_SIZES as readonly number[]).includes(p.fftSize)) {
+      next.txDisplayFftSize = p.fftSize;
+    }
+    if (typeof p.window === 'number' && TX_DISPLAY_WINDOWS.some((w) => w.value === p.window)) {
+      next.txDisplayWindow = p.window;
+    }
+    if (typeof p.avgTauMs === 'number' && Number.isFinite(p.avgTauMs)) {
+      next.txDisplayAvgTauMs = clampNum(p.avgTauMs, TX_DISPLAY_AVG_TAU_MIN_MS, TX_DISPLAY_AVG_TAU_MAX_MS);
+    }
+    if (Object.keys(next).length === 0) return;
+    // No localStorage mirror — server is authoritative for these params.
+    set(next);
+    scheduleTxDisplaySave();
+  },
+  resetTxDisplayParams: () => {
+    set({
+      txDisplayCalOffsetDb: DEFAULT_TX_DISPLAY_CAL_OFFSET_DB,
+      txDisplayFftSize: DEFAULT_TX_DISPLAY_FFT_SIZE,
+      txDisplayWindow: DEFAULT_TX_DISPLAY_WINDOW,
+      txDisplayAvgTauMs: DEFAULT_TX_DISPLAY_AVG_TAU_MS,
+    });
+    scheduleTxDisplaySave();
   },
   resetDbRanges: () => {
     set({
@@ -717,6 +828,12 @@ async function hydrateFromServer(): Promise<void> {
           wfTxDbMax: wfTxRange!.max,
         }
       : {}),
+    // TX display analyzer params — server wins when present; null means never
+    // stored, so the in-memory default stands.
+    ...(server.txDisplayCalOffsetDb !== null ? { txDisplayCalOffsetDb: server.txDisplayCalOffsetDb } : {}),
+    ...(server.txDisplayFftSize !== null ? { txDisplayFftSize: server.txDisplayFftSize } : {}),
+    ...(server.txDisplayWindow !== null ? { txDisplayWindow: server.txDisplayWindow } : {}),
+    ...(server.txDisplayAvgTauMs !== null ? { txDisplayAvgTauMs: server.txDisplayAvgTauMs } : {}),
   });
 
   if (!serverHasDbRange || serverRangeWasCorrupt) {


### PR DESCRIPTION
## What & why

During TX, the waterfall region showed a **static, mic-only EQ analyzer** that went blank entirely in native-audio mode. The thing operators actually want there — the live transmitted spectrum, like Thetis — was **already streaming** from the WDSP TX analyzer while keyed (issue #81); `HeroPanel` was just hiding it behind the EQ view.

This PR brings the real TX waterfall back and makes the TX display tunable.

## Changes

**Live TX waterfall**
- `HeroPanel`: during MOX/TUN, render the live `WaterfallSurface` (real transmitted post-DSP spectrum, scrolling) instead of the static EQ analyzer. Paired with the TX trace already on the panadapter, it forms a true **TX panafall**. The renderers already supported a `tx-db` domain (`wfTxDbMin/Max`); they were just never shown.

**Configurable TX display analyzer** (all **display-only** — no change to transmitted audio, drive, PA, or PureSignal)
- **Cal offset (dB)** — shifts the TX trace/waterfall level (Thetis `TXDisplayCalOffset` analogue); the "too hot in the passband" control. Applied to TX / PS-feedback pixels in the display tick.
- **FFT size** + **window** (WDSP `win_type`) — reconfigures the TX analyzer (`SetAnalyzer`).
- **Smoothing** (averaging tau, ms) — the "alive vs smooth" feel.
- Persisted in `DisplaySettingsStore`, exposed via `PUT /api/display-settings`, **seeded into the engine on connect** and **applied live** on change (no reconnect).
- New **TX Display Analyzer** card in the Spectrum Scale settings panel; the existing **TX Panadapter / TX Waterfall** dB windows + left-edge drag now apply to the live TX waterfall.

## Safety / scope
- RX analyzer path is **byte-identical** (RX callers pass the historical FFT/window/Kaiser constants; only the TX path reads the configurable values).
- Wire-contract additions (`DisplaySettingsDto`/`SetRequest`) are **nullable / backward-compatible**.
- Synthetic engine: `ConfigureTxDisplayAnalyzer` is a no-op.

## Testing
- **Backend:** 52/52 (`dotnet test`) on a clean develop-based worktree, incl. new `DisplaySettingsStoreTxDisplayTests` (round-trip + per-field validation — out-of-range / NaN / non-power-of-two dropped).
- **Frontend:** `tsc -b` ✓, eslint ✓, 16/16 store tests ✓ (new clamp/validation cases).
- **Live API e2e:** booted the backend headless and exercised `PUT`/`GET /api/display-settings` — valid params round-trip and persist; invalid `fftSize`/`calOffset` are rejected and previous values kept. SPA serves from the built `wwwroot` with the new UI in the production bundle.
- **Not verifiable headlessly:** the WebGL TX waterfall rendering during a real keyed transmission (needs a radio + browser). Please confirm on-air that (1) it scrolls with your TX audio and (2) Cal Offset / dB windows tame the in-passband brightness.

## Follow-up
- `TxEqAnalyzer.tsx` is now unused — flagged separately to decide delete vs. keep behind a "waterfall ↔ EQ" toggle.