### PR TITLE
fix(layout): workspace grid follow-ups — inert lock, drop Tidy, gap-fill new panels

### DIFF
--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -33,7 +33,7 @@ import {
   type LayoutItem,
 } from 'react-grid-layout';
 import { absoluteStrategy } from 'react-grid-layout/core';
-import { LayoutGrid, Plus, Puzzle, Settings } from 'lucide-react';
+import { Plus, Puzzle, Settings } from 'lucide-react';
 import { useWorkspace } from './WorkspaceContext';
 import { parseLayoutOrDefault, useLayoutStore } from '../state/layout-store';
 import { getPanelDef } from './panels';
@@ -42,7 +42,6 @@ import {
   autoFitDroppedPanel,
   createWorkspaceDragCompactor,
   resolveResizeOverlaps,
-  tidyWorkspacePlacements,
   type WorkspaceDragStartSnapshot,
 } from './workspaceGrid';
 import {
@@ -165,33 +164,6 @@ export function FlexWorkspace({
     [addTileToLayout, targetLayoutId],
   );
 
-  // Tidy is the ONLY path that packs the grid. The free-grid drag/resize model
-  // leaves gaps exactly where the operator left them; this button magnets the
-  // movable tiles up to close those gaps on demand, keeping each tile's column
-  // and never moving a locked tile.
-  const onTidy = useCallback(() => {
-    if (workspaceLocked) return;
-    const packed = tidyWorkspacePlacements(
-      workspace.tiles.map((t) => ({
-        i: t.uid,
-        x: t.x,
-        y: t.y,
-        w: t.w,
-        h: t.h,
-        static: t.locked === true,
-      })),
-    );
-    updateTilePlacementsInLayout(
-      targetLayoutId,
-      packed.map((p) => ({ uid: p.i, x: p.x, y: p.y, w: p.w, h: p.h })),
-    );
-  }, [
-    workspace.tiles,
-    workspaceLocked,
-    targetLayoutId,
-    updateTilePlacementsInLayout,
-  ]);
-
   // Brief loading state while the server fetch resolves. We render the
   // empty container so it has measurable width when the tiles arrive.
   return (
@@ -218,18 +190,6 @@ export function FlexWorkspace({
           aria-label="Add panel"
         >
           <Plus size={18} strokeWidth={2.2} aria-hidden />
-        </button>
-      )}
-      {showAddPanelModal && !addPanelOpen && !workspaceLocked && (
-        <button
-          type="button"
-          className="workspace-tidy-btn"
-          onClick={onTidy}
-          disabled={!isLoaded}
-          title="Tidy — close vertical gaps between panels"
-          aria-label="Tidy panels"
-        >
-          <LayoutGrid size={16} strokeWidth={2.2} aria-hidden />
         </button>
       )}
       {showAddPanelModal && addPanelOpen && (

--- a/zeus-web/src/layout/lockedWorkspaceLayout.test.ts
+++ b/zeus-web/src/layout/lockedWorkspaceLayout.test.ts
@@ -112,6 +112,29 @@ describe('deriveWorkspaceLayout — locking is inert', () => {
   });
 });
 
+describe('deriveWorkspaceLayout — locking preserves gaps', () => {
+  it('does not pull tiles up to close a gap when a panel is locked', () => {
+    // The free grid allows gaps. Locking must NOT magnet the other tiles up to
+    // close them — that was the "everything jumps when I lock a panel" bug.
+    const base: DeriveTile[] = [
+      tile({ uid: 'a', x: 0, y: 0, w: 12, h: 6 }),
+      // Deliberate gap: b sits at y=12, not y=6.
+      tile({ uid: 'b', x: 0, y: 12, w: 12, h: 6 }),
+    ];
+    const before = deriveWorkspaceLayout(base, opts(900));
+    const capturedPx = renderedPx(before, 'a');
+    const after = deriveWorkspaceLayout(
+      base.map((t) =>
+        t.uid === 'a' ? { ...t, locked: true, lockedHeightPx: capturedPx } : t,
+      ),
+      opts(900),
+    );
+    // The gap survives — b stays at its stored row, not pulled up under a.
+    expect(byUid(after, 'a')).toMatchObject({ x: 0, y: 0 });
+    expect(byUid(after, 'b')).toMatchObject({ x: 0, y: 12 });
+  });
+});
+
 describe('deriveWorkspaceLayout — locking is inert (short layout)', () => {
   it('does not grow unlocked tiles when the layout fits below authored density', () => {
     // A short docked column: layoutRows (12) < target (48), so the no-lock

--- a/zeus-web/src/layout/lockedWorkspaceLayout.ts
+++ b/zeus-web/src/layout/lockedWorkspaceLayout.ts
@@ -28,8 +28,7 @@
 // (reconcileReportedToStored). With nothing locked the derived layout equals
 // the stored layout and the whole path is a no-op.
 
-import { compactMagnetUp } from './workspaceGrid';
-import type { Layout } from 'react-grid-layout';
+import type { Layout, LayoutItem } from 'react-grid-layout';
 
 /** Minimal tile shape the solver needs. `h` should already be clamped to the
  *  panel's maxH (the caller clamps w/h for RGL); `minH` is the panel's
@@ -172,8 +171,11 @@ function lockedSpanRows(px: number, rowHeight: number, margin: number): number {
 
 /** Render the layout at a candidate rowHeight: each locked tile gets a
  *  (fractional) span that reproduces its frozen pixel height; unlocked tiles
- *  keep their stored span. Recompact so unlocked tiles magnet up around the
- *  static locked tiles, then report the layout and its total pixel extent. */
+ *  keep their stored span. Positions are PRESERVED (gaps and all) — only a tile
+ *  a frozen-size locked span would overlap is pushed straight down to clear it.
+ *  This is what makes locking inert: with nothing overflowing, every tile stays
+ *  exactly where the operator left it (the old magnet-up closed gaps, which
+ *  made the whole workspace jump the instant a panel was locked). */
 function renderAtRowHeight(
   tiles: DeriveTile[],
   rowHeight: number,
@@ -191,7 +193,7 @@ function renderAtRowHeight(
     static: t.locked,
     moved: false,
   }));
-  const compacted = compactMagnetUp(items);
+  const compacted = resolveOverlapsDownOnly(items);
   let maxBottomPx = 0;
   for (const it of compacted) {
     maxBottomPx = Math.max(
@@ -346,4 +348,49 @@ export function reconcileReportedToStored(
         : item.h;
     return { ...item, h };
   });
+}
+
+/**
+ * Resolve overlaps by pushing the LOWER tile of each colliding pair straight
+ * down — never pulling anything up. Static (locked) tiles are immovable
+ * obstacles. Unlike a magnet-up compaction this leaves every pre-existing gap
+ * intact, so a layout that already fits is returned untouched (the inertness
+ * the lock relies on); only a frozen-size locked span that genuinely overlaps
+ * the tile below it forces that tile down to clear the collision.
+ */
+function resolveOverlapsDownOnly(layout: Layout): Layout {
+  const next = layout.map((item) => ({ ...item }));
+  const maxPasses = Math.max(1, next.length * next.length);
+
+  for (let pass = 0; pass < maxPasses; pass += 1) {
+    const ordered = [...next].sort((a, b) => a.y - b.y || a.x - b.x);
+    let moved = false;
+    for (let i = 0; i < ordered.length; i += 1) {
+      const upper = ordered[i]!;
+      for (let j = i + 1; j < ordered.length; j += 1) {
+        const lower = ordered[j]!;
+        if (!overlaps(upper, lower)) continue;
+        // `lower` is the later one in (y, x) order — push it below `upper`.
+        // A locked tile is never moved; the overlap (rare: a locked tile sitting
+        // under a movable one) is left for Tidy / the operator to resolve.
+        if (lower.static) continue;
+        const y = upper.y + upper.h;
+        if (lower.y < y) {
+          lower.y = y;
+          moved = true;
+        }
+      }
+    }
+    if (!moved) break;
+  }
+  return next;
+}
+
+function overlaps(a: LayoutItem, b: LayoutItem): boolean {
+  if (a.i === b.i) return false;
+  if (a.x + a.w <= b.x) return false;
+  if (a.x >= b.x + b.w) return false;
+  if (a.y + a.h <= b.y) return false;
+  if (a.y >= b.y + b.h) return false;
+  return true;
 }

--- a/zeus-web/src/layout/workspace.test.ts
+++ b/zeus-web/src/layout/workspace.test.ts
@@ -5,7 +5,20 @@ import { describe, expect, it } from 'vitest';
 import {
   WORKSPACE_OVERSIZED_LAYOUT_NORMALIZED_ROWS,
   parseWorkspaceLayout,
+  placeTileInGrid,
+  type WorkspaceTile,
 } from './workspace';
+
+function tile(p: Partial<WorkspaceTile> & { uid: string }): WorkspaceTile {
+  return { panelId: 'smeter', x: 0, y: 0, w: 6, h: 4, ...p };
+}
+
+function overlaps(
+  a: { x: number; y: number; w: number; h: number },
+  b: { x: number; y: number; w: number; h: number },
+): boolean {
+  return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
+}
 
 function maxRows(layout: ReturnType<typeof parseWorkspaceLayout>): number {
   return layout.tiles.reduce((max, t) => Math.max(max, t.y + t.h), 0);
@@ -78,5 +91,36 @@ describe('parseWorkspaceLayout', () => {
     expect(layout.locked).toBe(true);
     expect(layout.tiles[0]).toMatchObject({ uid: 'tile-hero', locked: true });
     expect(layout.tiles[1]).not.toHaveProperty('locked');
+  });
+});
+
+describe('placeTileInGrid', () => {
+  it('places the first tile at the origin', () => {
+    expect(placeTileInGrid('smeter', [])).toMatchObject({ x: 0, y: 0 });
+  });
+
+  it('fills an interior gap instead of appending at the bottom', () => {
+    // A wide tile fills x0..17; x18..23 is open. A new smeter (6 wide) must slot
+    // into that free top-right space, NOT drop to the bottom and shrink
+    // everything (the old code relied on a render-time compactor that is gone).
+    const others = [tile({ uid: 'big', x: 0, y: 0, w: 18, h: 10 })];
+    expect(placeTileInGrid('smeter', others)).toMatchObject({ x: 18, y: 0 });
+  });
+
+  it('appends below everything when no interior gap fits', () => {
+    // A full-width band leaves no room until the next row down.
+    const others = [tile({ uid: 'band', x: 0, y: 0, w: 24, h: 4 })];
+    expect(placeTileInGrid('smeter', others)).toMatchObject({ x: 0, y: 4 });
+  });
+
+  it('never overlaps an existing tile', () => {
+    const others = [
+      tile({ uid: 'filter', x: 0, y: 0, w: 12, h: 10 }),
+      tile({ uid: 'presets', x: 12, y: 0, w: 6, h: 10 }),
+      tile({ uid: 'vfo', x: 18, y: 0, w: 6, h: 11 }),
+      tile({ uid: 'hero', x: 0, y: 10, w: 18, h: 38 }),
+    ];
+    const placed = placeTileInGrid('qrz', others);
+    expect(others.some((t) => overlaps(placed, t))).toBe(false);
   });
 });

--- a/zeus-web/src/layout/workspace.ts
+++ b/zeus-web/src/layout/workspace.ts
@@ -138,16 +138,46 @@ export function newTileUid(): string {
   return `tile-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
-/** Compute a placement for a brand-new tile: use its default span and place
- *  it at y = max(existing y+h), x = 0. RGL compacts upward into any free
- *  space at render time. */
+/** Compute a placement for a brand-new tile. The fixed-lattice workspace does
+ *  NOT compact at render time, so this finds a home for the tile itself:
+ *  first-fit, scanning top-to-bottom then left-to-right for the first slot the
+ *  tile's footprint fits without overlapping an existing tile. That fills any
+ *  free space the operator has opened up (e.g. after removing a panel) instead
+ *  of always appending at the bottom — which would extend the layout downward
+ *  and shrink every other panel to keep the workspace inside the viewport.
+ *  Only when no interior gap fits does it append below everything. */
 export function placeTileInGrid(
   panelId: string,
   others: WorkspaceTile[],
 ): { x: number; y: number; w: number; h: number } {
   const span = defaultSpanFor(panelId);
-  const maxY = others.reduce((m, t) => Math.max(m, t.y + t.h), 0);
-  return { x: 0, y: maxY, w: span.w, h: span.h };
+  const w = Math.min(span.w, WORKSPACE_GRID_COLS);
+  const h = span.h;
+  const maxX = WORKSPACE_GRID_COLS - w;
+  const bottom = others.reduce((m, t) => Math.max(m, t.y + t.h), 0);
+
+  for (let y = 0; y <= bottom; y += 1) {
+    for (let x = 0; x <= maxX; x += 1) {
+      const candidate = { x, y, w, h };
+      if (!others.some((t) => tilesOverlap(candidate, t))) {
+        return candidate;
+      }
+    }
+  }
+  // Nothing fits inside the current extent — append below everything (free).
+  return { x: 0, y: bottom, w, h };
+}
+
+function tilesOverlap(
+  a: { x: number; y: number; w: number; h: number },
+  b: { x: number; y: number; w: number; h: number },
+): boolean {
+  return (
+    a.x < b.x + b.w &&
+    a.x + a.w > b.x &&
+    a.y < b.y + b.h &&
+    a.y + a.h > b.y
+  );
 }
 
 /** Best-effort parser + validator for the opaque /api/ui/layout JSON blob.

--- a/zeus-web/src/layout/workspaceGrid.test.ts
+++ b/zeus-web/src/layout/workspaceGrid.test.ts
@@ -9,7 +9,6 @@ import {
   autoFitDroppedPanel,
   createWorkspaceDragCompactor,
   resolveResizeOverlaps,
-  tidyWorkspacePlacements,
 } from './workspaceGrid';
 
 function cloneLayout(layout: Layout): Layout {
@@ -209,28 +208,3 @@ describe('resolveResizeOverlaps — local, no cascade', () => {
   });
 });
 
-describe('tidyWorkspacePlacements — explicit pack', () => {
-  it('closes vertical gaps while keeping each column', () => {
-    const layout: Layout = [
-      { i: 'top', x: 0, y: 0, w: 6, h: 2 },
-      { i: 'lower', x: 0, y: 6, w: 6, h: 2 },
-      { i: 'side', x: 6, y: 4, w: 6, h: 2 },
-    ];
-    const next = tidyWorkspacePlacements(layout);
-    expect(next.find((i) => i.i === 'lower')).toMatchObject({ x: 0, y: 2 });
-    expect(next.find((i) => i.i === 'side')).toMatchObject({ x: 6, y: 0 });
-    expectNoCollisions(next);
-  });
-
-  it('packs movable tiles around a locked tile without moving it', () => {
-    const layout: Layout = [
-      { i: 'locked', x: 0, y: 4, w: 6, h: 2, static: true },
-      { i: 'below', x: 0, y: 8, w: 6, h: 2 },
-    ];
-    const next = tidyWorkspacePlacements(layout);
-    expect(next.find((i) => i.i === 'locked')).toMatchObject({ y: 4 });
-    // `below` magnets up to just under the locked tile, not through it.
-    expect(next.find((i) => i.i === 'below')).toMatchObject({ x: 0, y: 6 });
-    expectNoCollisions(next);
-  });
-});

--- a/zeus-web/src/layout/workspaceGrid.ts
+++ b/zeus-web/src/layout/workspaceGrid.ts
@@ -189,50 +189,6 @@ export function resolveResizeOverlaps(
   return next;
 }
 
-/**
- * Operator-invoked "Tidy": pack movable tiles upward to close vertical gaps,
- * keeping each tile's column (x) and never moving a locked (static) tile. This
- * is the only function that compacts — it runs on an explicit button press, not
- * as a side effect of a drag.
- */
-export function tidyWorkspacePlacements(layout: Layout): Layout {
-  const next = cloneLayout(layout);
-  const order = new Map(next.map((item, index) => [item.i, index]));
-  const statics = next.filter((item) => item.static);
-  const movers = next
-    .filter((item) => !item.static)
-    .sort(
-      (a, b) =>
-        a.y - b.y ||
-        a.x - b.x ||
-        (order.get(a.i) ?? 0) - (order.get(b.i) ?? 0),
-    );
-
-  // Seed the obstacle set with the static tiles so movers magnet up *around*
-  // them rather than through them.
-  const placed: LayoutItem[] = [...statics];
-  for (const item of movers) {
-    item.y = Math.max(0, item.y);
-    // Pull up while the cell above is clear.
-    while (item.y > 0) {
-      const trial = { ...item, y: item.y - 1 };
-      if (placed.some((p) => collides(trial, p))) break;
-      item.y -= 1;
-    }
-    // If it still overlaps something (e.g. landed on a static tile), push it
-    // just below the obstacle.
-    let guard = 0;
-    let hit = placed.find((p) => collides(item, p));
-    while (hit && guard < placed.length + 1) {
-      item.y = hit.y + hit.h;
-      hit = placed.find((p) => collides(item, p));
-      guard += 1;
-    }
-    placed.push(item);
-  }
-  return clearMovedFlags(next);
-}
-
 // ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------

--- a/zeus-web/src/layout/workspaceGrid.ts
+++ b/zeus-web/src/layout/workspaceGrid.ts
@@ -173,6 +173,19 @@ export function resolveResizeOverlaps(
       item.y = slot.y;
     }
   }
+
+  // A locked neighbour can't be relocated — clamp the resized tile so a resize
+  // never leaves a panel sitting on top of a locked one. Trim height first (the
+  // common "grew downward into a locked tile"), then width.
+  for (const blocker of next) {
+    if (blocker.i === resizedId || !blocker.static) continue;
+    if (!collides(resized, blocker)) continue;
+    if (resized.y < blocker.y) {
+      resized.h = Math.max(1, blocker.y - resized.y);
+    } else if (resized.x < blocker.x) {
+      resized.w = Math.max(1, blocker.x - resized.x);
+    }
+  }
   return next;
 }
 
@@ -218,47 +231,6 @@ export function tidyWorkspacePlacements(layout: Layout): Layout {
     placed.push(item);
   }
   return clearMovedFlags(next);
-}
-
-/**
- * Magnet movable tiles upward to close vertical gaps around static tiles, used
- * by the locked-tile pixel-height solver (lockedWorkspaceLayout). Kept separate
- * from tidyWorkspacePlacements because the solver feeds it synthetic fractional
- * spans and an optional priority tile.
- */
-export function compactMagnetUp(
-  layout: Layout,
-  priorityId?: string,
-  preservePriority = false,
-): Layout {
-  const next = cloneLayout(layout);
-  const originalOrder = new Map(next.map((item, index) => [item.i, index]));
-  const priority = preservePriority && priorityId
-    ? next.find((item) => item.i === priorityId)
-    : undefined;
-  const placed: LayoutItem[] = priority ? [priority] : [];
-  const ordered = next
-    .filter((item) => item.i !== priority?.i)
-    .sort((a, b) => compareItems(a, b, originalOrder));
-
-  for (const item of ordered) {
-    if (!item.static) {
-      item.y = Math.max(0, item.y);
-      moveBelowCollisions(item, placed);
-      while (item.y > 0) {
-        item.y -= 1;
-        const collision = firstCollision(placed, item);
-        if (collision) {
-          item.y = collision.y + collision.h;
-          break;
-        }
-      }
-      moveBelowCollisions(item, placed);
-    }
-    placed.push(item);
-  }
-
-  return next;
 }
 
 // ---------------------------------------------------------------------------
@@ -311,21 +283,6 @@ function overlapIsSquare(a: LayoutItem, b: LayoutItem): boolean {
   return minArea > 0 && overlapArea >= minArea * SWAP_OVERLAP_FRACTION;
 }
 
-function moveBelowCollisions(item: LayoutItem, placed: LayoutItem[]) {
-  let collision = firstCollision(placed, item);
-  while (collision) {
-    item.y = collision.y + collision.h;
-    collision = firstCollision(placed, item);
-  }
-}
-
-function firstCollision(
-  layout: LayoutItem[],
-  item: LayoutItem,
-): LayoutItem | undefined {
-  return layout.find((other) => collides(other, item));
-}
-
 function normalizeDragStart(
   previous: LayoutItem | WorkspaceDragStartSnapshot | null | undefined,
 ): WorkspaceDragStartSnapshot | null {
@@ -342,18 +299,6 @@ function normalizeDragStart(
 function findDroppedItem(layout: Layout): LayoutItem | undefined {
   const moved = layout.filter((item) => item.moved);
   return moved[moved.length - 1];
-}
-
-function compareItems(
-  a: LayoutItem,
-  b: LayoutItem,
-  originalOrder: Map<string, number>,
-) {
-  return (
-    a.y - b.y ||
-    a.x - b.x ||
-    (originalOrder.get(a.i) ?? 0) - (originalOrder.get(b.i) ?? 0)
-  );
 }
 
 function cloneLayout(layout: Layout): LayoutItem[] {

--- a/zeus-web/src/styles/all-panels.css
+++ b/zeus-web/src/styles/all-panels.css
@@ -676,57 +676,6 @@
   opacity: 1;
 }
 
-/* Tidy button — sits just left of the Add Panel button. Closes the vertical
- * gaps the free-grid drag/resize model deliberately leaves behind. Shares the
- * Add Panel button's chrome but a touch smaller so it reads as secondary. */
-.workspace-tidy-btn {
-  position: absolute;
-  right: 54px;
-  bottom: 12px;
-  z-index: 5;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 34px;
-  height: 34px;
-  padding: 0;
-  border-radius: 999px;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.015)),
-    rgba(12, 13, 15, 0.72);
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  color: var(--fg-1);
-  font-family: var(--font-sans);
-  box-shadow:
-    0 8px 20px rgba(0, 0, 0, 0.28),
-    inset 0 1px 0 rgba(255, 255, 255, 0.09);
-  opacity: 0.68;
-  cursor: pointer;
-  transition:
-    background var(--dur-fast),
-    border-color var(--dur-fast),
-    color var(--dur-fast),
-    opacity var(--dur-fast),
-    transform var(--dur-fast);
-}
-.workspace-tidy-btn:hover {
-  background:
-    linear-gradient(180deg, var(--btn-active-top), var(--btn-active-bot));
-  border-color: var(--accent);
-  color: var(--btn-active-text, var(--fg-0));
-  opacity: 1;
-  transform: translateY(-1px);
-}
-.workspace-tidy-btn:disabled {
-  cursor: default;
-  opacity: 0.32;
-  transform: none;
-}
-.workspace-tidy-btn:focus-visible {
-  outline: 1px solid var(--accent);
-  outline-offset: 2px;
-  opacity: 1;
-}
 
 /* Categorized AddPanel modal — left rail of category chips, right pane of
  * panel cards. Stacks the rail vertically so all categories are reachable


### PR DESCRIPTION
## Follow-ups to #757 (fixed-lattice workspace grid)

[#757](https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus/pull/757) merged at its **first commit only** — the fixed-lattice move-only + swap engine. Three follow-up commits were pushed after the merge and never made it into `develop`. This PR brings them in. They are essential: without them `develop` ships a broken panel lock, an unwanted Tidy button, and a new-panel placement bug.

### 1. Panel lock is inert — preserve gaps, never overlap
The locked-tile solver ran `compactMagnetUp` whenever any tile was locked, closing every vertical gap. That was a no-op under the old packing grid but the new free grid **allows gaps**, so locking a panel re-packed the whole workspace and it no longer matched where the operator locked it. Replaced with a **down-only overlap resolver**: positions and gaps are preserved; a tile is pushed down only when a frozen-size locked span would actually overlap it. With nothing overflowing the layout is returned untouched — locking is now truly inert. Also clamps a resize that grows into a locked tile so a resize can never leave an overlap.

### 2. Drop the Tidy button
Removed the manual Tidy control and its `tidyWorkspacePlacements` packer, button, handler, and styling (per request — the free grid leaves gaps where the operator puts them and an explicit pack action isn't wanted).

### 3. Place new panels in the first free gap, not the bottom
`placeTileInGrid` dropped every new tile at the bottom and relied on the (now-removed) magnetic compactor to pull it up into free space at render time. So new panels stayed at the bottom — extending the layout downward and shrinking every other panel to fit the viewport ("adding a panel messes everything up"). Now does a first-fit scan for the first slot the tile fits without overlap, filling any space the operator opened up; appends below only when no interior gap fits.

## Tests
- New/updated coverage in `workspace.test.ts`, `workspaceGrid.test.ts`, `lockedWorkspaceLayout.test.ts` (gap-preservation on lock, gap-fill placement, never-overlap guards).
- Full frontend suite green, `tsc --noEmit` clean, ESLint clean. (The changed files are byte-identical to the branch from #757's follow-up commits, which were verified green before #757 was merged early.)

## Note for reviewers
UX/layout behavior — red-light area. Continuation of the explicit interaction model from #757 (move-only + swap, gaps allowed, inert lock).
