### PR TITLE
fix(chat): show friend frequency inline in the roster

### DIFF
--- a/zeus-web/src/layout/panels/ChatPanel.tsx
+++ b/zeus-web/src/layout/panels/ChatPanel.tsx
@@ -313,6 +313,25 @@ function RosterRow({
       <StatusDot status={op.status} />
       <div style={{ minWidth: 0, flex: 1 }}>
         <CallsignButton callsign={op.callsign} onOpen={onOpen} prominent />
+        {/* Frequency / mode — only present for friends sharing their freq
+            (the relay strips freqHz for everyone else). */}
+        {freq !== '—' && (
+          <div
+            className="mono"
+            style={{
+              fontSize: 9.5,
+              color: 'var(--accent-bright)',
+              letterSpacing: '0.02em',
+              marginTop: 1,
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            {freq}
+            {op.mode ? <span style={{ color: 'var(--fg-3)' }}> · {op.mode}</span> : null}
+          </div>
+        )}
       </div>
       {/* Action icons — grouped + spaced away from the callsign */}
       <div


### PR DESCRIPTION
## Problem

In the Chat panel, a friend''s frequency could not be seen on screen — regardless of your own eye-toggle state. Reported by an operator: *"I cannot see my friend''s frequency whether or not I have it hidden."*

## Root cause

The frequency-sharing feature is fully wired end-to-end:

- **Relay** (`cloud/zeuschat-relay/src/chat-room.ts`) consent-gates `freq`: it is only sent to you for operators who are **mutual friends** *and* have **not hidden** their frequency (eye open).
- **Backend** (`Zeus.Server.Hosting/ChatService.cs`) parses relay `freq` → `FreqHz` → serialises camelCase `freqHz`.
- **Client** (`api/chat.ts` `normalizeOperator`) reads `r.freqHz` into `op.freqHz`. ✅ The data arrives correctly.

The bug was purely in rendering: in `ChatPanel.tsx` the friend''s frequency was computed but only placed into the roster row''s `title` (hover tooltip) — never drawn inline. Unless you hovered the exact row, you never saw it.

The eye toggle in the chat header controls whether *others* see *your* frequency, which is why flipping it had no effect on seeing *theirs* — matching the report exactly.

## Fix

Render the frequency (and mode) inline under the callsign in the roster row when present. Because the relay strips `freqHz` for anyone who isn''t a consenting friend, this line only appears for friends actively sharing — non-friends and hidden-frequency friends render exactly as before.

Display-only change. No protocol, consent gate, or default behaviour touched.

## Verification

- `tsc -b --noEmit` passes.
- Full browser verification requires a live relay connection plus a mutual friend with frequency-sharing on, which can''t be stood up headlessly; the render path is a straightforward conditional and typechecks.