### PR TITLE
ci: fix Publish Website Downloads startup_failure (contents:write)

### DIFF
--- a/.github/workflows/publish-downloads.yml
+++ b/.github/workflows/publish-downloads.yml
@@ -22,7 +22,12 @@ jobs:
       ref: main
     secrets: inherit
     permissions:
-      contents: read
+      # release.yml's create-release / create-nightly-release jobs declare
+      # `contents: write`. GitHub validates a called workflow's permission
+      # requirements at startup (before `if:` gating), so the calling job must
+      # grant write even though those jobs are skipped in download-main mode —
+      # otherwise the whole run fails with startup_failure. Matches nightly.yml.
+      contents: write
 
   publish:
     name: Publish to downloads.openhpsdrzeus.com


### PR DESCRIPTION
## Problem

`Publish Website Downloads` (the workflow that pushes installers to **downloads.openhpsdrzeus.com**, which feeds both the website `#download` section and the in-app updater) **startup-failed on every push to main** — 0s, *"workflow file issue"*. Result: nothing ever reached R2, the homepage shows **"Installers pending"**, and `latest.json` 404s.

## Root cause

The `build` job calls `release.yml` via `workflow_call` but granted only `contents: read`. `release.yml`'s `create-release` / `create-nightly-release` jobs declare `contents: write`. GitHub validates a **called workflow's permission requirements at startup — before `if:` gating** — so the read-only grant is rejected even though those jobs are *skipped* in `download-main` mode.

`nightly.yml` calls the same reusable workflow with `contents: write` and succeeds on every run — this brings the website-publish caller in line.

## Fix

One line: `build` job `permissions: contents: read` → `contents: write`. (The `publish` job still runs as `read`; it authenticates to Cloudflare via env secrets, not `GITHUB_TOKEN`.)

## After merge

The merge push to `main` re-triggers `Publish Website Downloads`; it builds all platforms, uploads to R2, writes `manifest.json`/`latest.json`, and the homepage download buttons populate. Verified the manifest↔updater asset contract by dry-run beforehand.

> Note: the identical bug exists on `develop` (this file came from there). A mirror PR to `develop` follows so it doesn't regress on the next `develop→main` merge.