### PR TITLE
ci: fix Publish Website Downloads startup_failure (contents:write) [develop mirror]

### DIFF
--- a/.github/workflows/publish-downloads.yml
+++ b/.github/workflows/publish-downloads.yml
@@ -22,7 +22,12 @@ jobs:
       ref: main
     secrets: inherit
     permissions:
-      contents: read
+      # release.yml's create-release / create-nightly-release jobs declare
+      # `contents: write`. GitHub validates a called workflow's permission
+      # requirements at startup (before `if:` gating), so the calling job must
+      # grant write even though those jobs are skipped in download-main mode —
+      # otherwise the whole run fails with startup_failure. Matches nightly.yml.
+      contents: write
 
   publish:
     name: Publish to downloads.openhpsdrzeus.com


### PR DESCRIPTION
Mirror of #771 onto `develop` so the fix isn't lost on the next `develop→main` merge.

Same one-line change: the `build` job in `publish-downloads.yml` calls `release.yml` via `workflow_call`; `release.yml`'s `create-release`/`create-nightly-release` declare `contents: write`, which GitHub validates at workflow startup (before `if:` gating). Granting only `contents: read` caused a `startup_failure`, so no release ever reached downloads.openhpsdrzeus.com. `nightly.yml` already grants `contents: write` and works.

See #771 for the full root-cause writeup.