### PR TITLE
fix(installers): add N9WAR to installer copyright

### DIFF
--- a/.github/workflows/publish-downloads.yml
+++ b/.github/workflows/publish-downloads.yml
@@ -22,7 +22,12 @@ jobs:
       ref: main
     secrets: inherit
     permissions:
-      contents: read
+      # release.yml's create-release / create-nightly-release jobs declare
+      # `contents: write`. GitHub validates a called workflow's permission
+      # requirements at startup (before `if:` gating), so the calling job must
+      # grant write even though those jobs are skipped in download-main mode —
+      # otherwise the whole run fails with startup_failure. Matches nightly.yml.
+      contents: write
 
   publish:
     name: Publish to downloads.openhpsdrzeus.com


### PR DESCRIPTION
Adds Christian Suarez (N9WAR) to the Windows + Linux installer copyright to match the About panel. Needed before the v0.10.0 public release.