### PR TITLE
fix(installers): add N9WAR to installer copyright (v0.10.0)

### DIFF
--- a/installers/create-linux-package.sh
+++ b/installers/create-linux-package.sh
@@ -294,7 +294,7 @@ For more information:
 https://github.com/Kb2uka/openhpsdr-zeus
 
 License: GNU GPL v2 or later
-Copyright (C) 2025-2026 Brian Keating (EI6LF), Douglas J. Cerrato (KB2UKA), and contributors
+Copyright (C) 2025-2026 Brian Keating (EI6LF), Douglas J. Cerrato (KB2UKA), Christian Suarez (N9WAR), and contributors
 EOF
 
 # Copy LICENSE

--- a/installers/zeus-windows.iss
+++ b/installers/zeus-windows.iss
@@ -8,7 +8,7 @@
 
 #define MyAppName "OpenHPSDR-Zeus"
 #define MyAppShortName "OpenHPSDR-Zeus"
-#define MyAppPublisher "Brian Keating (EI6LF) and contributors"
+#define MyAppPublisher "Brian Keating (EI6LF), Douglas J. Cerrato (KB2UKA), Christian Suarez (N9WAR), and contributors"
 #define MyAppURL "https://github.com/Kb2uka/openhpsdr-zeus"
 #define MyAppExeName "OpenhpsdrZeus.exe"
 


### PR DESCRIPTION
Adds Christian Suarez (N9WAR) to the Windows + Linux installer copyright to match the About panel — needed before the v0.10.0 public release. (The earlier #773 merged develop before this fix had landed.)