### PR TITLE
fix(desktop+installers): survive/diagnose startup failures; ensure webview runtime on Windows + Linux

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,7 @@
 .githooks/* text eol=lf
+
+# Shell scripts must stay LF in the repo and on checkout. The installer
+# launchers source zeus-preflight.sh at runtime on Linux; a CRLF sneaking in
+# from a Windows checkout would break `source` with `$'\r'` errors. CI builds
+# on Linux already get LF, but pin it so a Windows-side edit can't regress it.
+*.sh text eol=lf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -815,6 +815,24 @@ jobs:
           Invoke-WebRequest -Uri $url -OutFile $out -UseBasicParsing
           Get-Item $out | Select-Object Name, Length
 
+      # Download the Microsoft Edge WebView2 Evergreen Runtime bootstrapper.
+      # zeus-windows.iss bundles it and runs it at install time, guarded by a
+      # WebView2Needed() registry check so it skips machines that already have
+      # the runtime. Without WebView2, Photino cannot create the desktop window
+      # and Zeus flash-and-closes on first launch — common on Windows 11 LTSC /
+      # IoT / Enterprise N and debloated images. The fwlink redirect is
+      # Microsoft's stable evergreen URL; the same universal bootstrapper covers
+      # both x64 and arm64 (it detects the host arch), so it is not arch-suffixed.
+      - name: Download Edge WebView2 Runtime
+        if: matrix.config.os == 'windows'
+        shell: pwsh
+        run: |
+          $url = "https://go.microsoft.com/fwlink/p/?LinkId=2124703"
+          $out = "installers\MicrosoftEdgeWebview2Setup.exe"
+          Write-Host "Downloading $url -> $out"
+          Invoke-WebRequest -Uri $url -OutFile $out -UseBasicParsing
+          Get-Item $out | Select-Object Name, Length
+
       - name: Build Windows Installer (Inno Setup)
         if: matrix.config.os == 'windows'
         shell: pwsh

--- a/OpenhpsdrZeus/Program.cs
+++ b/OpenhpsdrZeus/Program.cs
@@ -49,6 +49,7 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.Extensions.DependencyInjection;
+using OpenhpsdrZeus;
 using Photino.NET;
 using Zeus.Plugins.Host.Audio;
 using Zeus.Server;
@@ -160,6 +161,12 @@ public partial class Program
             return VerifyVstBridge();
         }
 
+        // Verbose preflight + crash tracer. Writes a full environment/dependency
+        // report and per-phase markers to %LOCALAPPDATA%/Zeus/zeus-startup.log on
+        // every launch, and installs last-resort exception handlers. This is the
+        // durable record we ask a user to send when "the window just closes".
+        StartupDiagnostics.Begin(args);
+
         if (args.Contains("--desktop"))
         {
             HideConsoleOnWindows();
@@ -170,6 +177,15 @@ public partial class Program
             catch (Exception ex) when (IsAddressInUse(ex))
             {
                 ReportStartupAddressInUse(ex);
+                return 1;
+            }
+            catch (Exception ex)
+            {
+                // Any other startup failure would otherwise escape Main and the
+                // process would vanish silently — the console is already detached
+                // (HideConsoleOnWindows), so the operator sees the window flash
+                // and close with no diagnostics. Record it and surface a dialog.
+                ReportStartupFatal(ex);
                 return 1;
             }
         }
@@ -189,6 +205,11 @@ public partial class Program
             catch (Exception ex) when (IsAddressInUse(ex))
             {
                 ReportStartupAddressInUse(ex);
+                return 1;
+            }
+            catch (Exception ex)
+            {
+                ReportStartupFatal(ex);
                 return 1;
             }
         }
@@ -297,9 +318,13 @@ public partial class Program
             PrintConsoleBanner = false,
         };
 
+        StartupDiagnostics.Phase("desktop: ZeusHost.Build");
         var app = ZeusHost.Build(args, hostOptions);
+        StartupDiagnostics.Phase("desktop: ZeusHost.InitializeAsync");
         ZeusHost.InitializeAsync(app).GetAwaiter().GetResult();
+        StartupDiagnostics.Phase("desktop: app.StartAsync (Kestrel + hosted services)");
         app.StartAsync().GetAwaiter().GetResult();
+        StartupDiagnostics.Phase("desktop: host started");
 
         // Resolve the bound URLs after Start — Kestrel writes the OS-assigned
         // loopback port (plus the LAN HTTPS port we configured) into
@@ -361,6 +386,9 @@ public partial class Program
         var iconPath = Path.Combine(AppContext.BaseDirectory, iconFileName);
         var detachedWorkspaceWindows = new List<PhotinoWindow>();
 
+        // Window construction is where a missing WebView2 runtime throws — the
+        // last phase marker in the log will be this one if that's the cause.
+        StartupDiagnostics.Phase("desktop: creating Photino window (needs WebView2)");
         var window = new PhotinoWindow()
             .SetTitle("Zeus")
             .SetUseOsDefaultLocation(false)
@@ -500,6 +528,7 @@ public partial class Program
         // WaitForClose blocks the main thread until the user closes the window. On
         // macOS this satisfies Cocoa's "UI on main thread" requirement; Kestrel
         // runs on its own thread-pool, untouched by the windowing loop.
+        StartupDiagnostics.Phase("desktop: window created, entering message loop");
         window.WaitForClose();
         foreach (var child in detachedWorkspaceWindows.ToArray())
         {
@@ -719,6 +748,71 @@ public partial class Program
         Console.Error.WriteLine($"{title}: {message}");
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             _ = MessageBoxW(IntPtr.Zero, message, title, 0x00000040);
+    }
+
+    // A startup failure other than port-in-use. The desktop/server paths detach
+    // the console (FreeConsole) before this runs, so an uncaught exception would
+    // make the process vanish with the window never appearing and nothing logged.
+    // Persist the full exception to the shared startup log and show a dialog so
+    // the operator gets an actionable message instead of a silent flash-and-close.
+    private static void ReportStartupFatal(Exception ex)
+    {
+        var baseEx = ex.GetBaseException();
+        var missingWebView2 = LooksLikeMissingWebView2(ex);
+
+        // The full exception goes to the same zeus-startup.log the preflight
+        // wrote, so the dependency report and the crash sit in one file.
+        StartupDiagnostics.LogException("desktop startup failed", ex);
+
+        string title;
+        string message;
+        if (missingWebView2)
+        {
+            // The single most common fresh-Windows cause: Photino renders the UI
+            // through WebView2, which is absent on Windows 11 LTSC / IoT /
+            // Enterprise N, debloated images, and some VMs. Point the operator
+            // straight at the fix.
+            title = "Zeus needs the Microsoft Edge WebView2 Runtime";
+            message =
+                "Zeus could not open its window because the Microsoft Edge WebView2 " +
+                "Runtime is not installed on this PC.\n\n" +
+                "Install it (free, from Microsoft), then launch Zeus again:\n" +
+                "https://developer.microsoft.com/microsoft-edge/webview2/\n\n" +
+                $"Technical detail: {baseEx.GetType().Name}: {baseEx.Message}";
+        }
+        else
+        {
+            title = "Zeus failed to start";
+            message =
+                "Zeus hit an unexpected error while starting and had to close.\n\n" +
+                $"{baseEx.GetType().Name}: {baseEx.Message}\n\n" +
+                $"A full log was written to:\n{StartupDiagnostics.LogPath}";
+        }
+
+        // Console is detached on Windows desktop/server mode; on macOS/Linux this
+        // still reaches the launching terminal.
+        Console.Error.WriteLine($"{title}: {message}");
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            _ = MessageBoxW(IntPtr.Zero, message, title, 0x00000010); // MB_ICONERROR
+    }
+
+    // Heuristic: does this exception chain look like a missing WebView2 runtime?
+    // Photino surfaces the absence in different shapes across versions (a COM
+    // HRESULT, a DllNotFound, or a message naming WebView2 / msedgewebview2), so
+    // we match on the text across the whole inner-exception chain rather than a
+    // single exception type.
+    private static bool LooksLikeMissingWebView2(Exception ex)
+    {
+        for (var cur = ex; cur is not null; cur = cur.InnerException)
+        {
+            var m = cur.Message;
+            if (string.IsNullOrEmpty(m)) continue;
+            if (m.Contains("WebView2", StringComparison.OrdinalIgnoreCase) ||
+                m.Contains("msedgewebview2", StringComparison.OrdinalIgnoreCase) ||
+                m.Contains("Edge WebView", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
     }
 
     private static int RunServerWithStatus(string[] args)

--- a/OpenhpsdrZeus/StartupDiagnostics.cs
+++ b/OpenhpsdrZeus/StartupDiagnostics.cs
@@ -1,0 +1,385 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Zeus.Server;
+
+namespace OpenhpsdrZeus;
+
+// Verbose startup preflight + phase tracer.
+//
+// Why this exists: in --desktop / --server mode the console is detached
+// (FreeConsole), so when the backend or the Photino window fails to come up the
+// process vanishes with no visible error — the classic "window flashes and
+// closes, nothing happens" report. There was no durable record of *where* it
+// died or *what* the machine was missing.
+//
+// StartupDiagnostics writes a complete, human-readable report to
+// %LOCALAPPDATA%/Zeus/zeus-startup.log on EVERY launch:
+//   - environment (OS edition, arch, .NET, paths, args),
+//   - presence + loadability of every native dependency (WebView2, wdsp,
+//     miniaudio, Photino, VC runtime),
+//   - the shipped web assets and WDSP model files,
+//   - prefs DB health and TCP port availability,
+//   - a timestamped phase marker for each startup step.
+//
+// If startup then crashes, the last phase marker in the log pinpoints the
+// failing step and the preflight above it shows what was missing. Hand the user
+// a build, have them reproduce, and ask for this one file. Everything here is
+// best-effort and never throws — a diagnostic must not be able to crash the very
+// startup it is trying to diagnose.
+internal static class StartupDiagnostics
+{
+    private static readonly object Gate = new();
+    private static string? _logPath;
+
+    // The WebView2 Evergreen Runtime loader, shipped next to the binary by
+    // Photino. Returns S_OK and a version string when a runtime is installed;
+    // a failing HRESULT (or a DllNotFound when the loader itself is absent)
+    // means WebView2 is missing — the #1 fresh-Windows cause of flash-and-close.
+    [DllImport("WebView2Loader.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetAvailableCoreWebView2BrowserVersionString(
+        string? browserExecutableFolder, out IntPtr versionInfo);
+
+    public static string LogPath
+    {
+        get
+        {
+            if (_logPath is not null) return _logPath;
+            try { _logPath = Path.Combine(PrefsDbPath.DataDir, "zeus-startup.log"); }
+            catch { _logPath = Path.Combine(Path.GetTempPath(), "zeus-startup.log"); }
+            return _logPath;
+        }
+    }
+
+    // Call once at the very top of Main. Opens/rotates the log, installs
+    // last-resort exception handlers (so a crash on ANY thread is recorded —
+    // not just the synchronous startup path), and dumps the full preflight.
+    public static void Begin(string[] args)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(LogPath);
+            if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+
+            // Keep the file from growing without bound across launches, but
+            // preserve recent history for a test user reproducing intermittently.
+            try
+            {
+                if (File.Exists(LogPath) && new FileInfo(LogPath).Length > 512 * 1024)
+                    File.Delete(LogPath);
+            }
+            catch { /* best effort */ }
+
+            AppDomain.CurrentDomain.UnhandledException += (_, e) =>
+            {
+                LogException("AppDomain.UnhandledException (terminating=" + e.IsTerminating + ")",
+                    e.ExceptionObject as Exception);
+            };
+            TaskScheduler.UnobservedTaskException += (_, e) =>
+            {
+                LogException("TaskScheduler.UnobservedTaskException", e.Exception);
+                e.SetObserved();
+            };
+        }
+        catch { /* never block launch on diagnostics setup */ }
+
+        WriteHeader(args);
+        WritePreflight();
+    }
+
+    // Append a timestamped phase marker. The LAST marker in the log before a
+    // crash is the failing step.
+    public static void Phase(string name) => Write($"[phase] {name}");
+
+    public static void Log(string message) => Write(message);
+
+    public static void LogException(string context, Exception? ex)
+    {
+        if (ex is null) { Write($"[error] {context}: <no exception object>"); return; }
+        Write($"[error] {context}:\n{ex}");
+    }
+
+    private static void WriteHeader(string[] args)
+    {
+        var version = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? "unknown";
+        Write("================================================================");
+        Write($"Zeus startup  version={version}");
+        Write($"args=[{string.Join(' ', args)}]");
+        Write("================================================================");
+    }
+
+    private static void WritePreflight()
+    {
+        Section("environment");
+        Kv("os", RuntimeInformation.OSDescription);
+        Kv("os.arch", RuntimeInformation.OSArchitecture.ToString());
+        Kv("process.arch", RuntimeInformation.ProcessArchitecture.ToString());
+        Kv("runtime", RuntimeInformation.FrameworkDescription);
+        Kv("rid", RuntimeInformation.RuntimeIdentifier);
+        Kv("machine", SafeMachineName());
+        Kv("64bit.os", Environment.Is64BitOperatingSystem.ToString());
+        Kv("64bit.process", Environment.Is64BitProcess.ToString());
+        Kv("user.interactive", Environment.UserInteractive.ToString());
+        Kv("base.dir", AppContext.BaseDirectory);
+        Kv("cwd", SafeCwd());
+        Kv("localappdata", SafeFolder(Environment.SpecialFolder.LocalApplicationData));
+        Kv("temp", Path.GetTempPath());
+        Kv("env.ZEUS_WEBROOT", Environment.GetEnvironmentVariable("ZEUS_WEBROOT") ?? "<unset>");
+        Kv("env.ZEUS_PREFS_PATH", Environment.GetEnvironmentVariable("ZEUS_PREFS_PATH") ?? "<unset>");
+        Kv("env.ZEUS_DESKTOP_PORT", Environment.GetEnvironmentVariable("ZEUS_DESKTOP_PORT") ?? "<unset>");
+        Kv("env.ZEUS_ENABLE_VST_LOAD", Environment.GetEnvironmentVariable("ZEUS_ENABLE_VST_LOAD") ?? "<unset>");
+
+        Section("webview2 (desktop UI runtime)");
+        ProbeWebView2();
+
+        Section("native libraries");
+        ProbeNativeNextToExe("Photino.Native.dll");
+        ProbeNativeNextToExe("WebView2Loader.dll");
+        ProbeRuntimeNative("wdsp");
+        ProbeRuntimeNative("miniaudio");
+        ProbeVcRuntime();
+
+        Section("web assets + WDSP models");
+        var baseDir = AppContext.BaseDirectory;
+        var webRoot = Environment.GetEnvironmentVariable("ZEUS_WEBROOT");
+        var wwwroot = string.IsNullOrWhiteSpace(webRoot) ? Path.Combine(baseDir, "wwwroot") : webRoot;
+        ProbeFile("wwwroot", wwwroot);
+        ProbeFile("wwwroot/index.html", Path.Combine(wwwroot, "index.html"));
+        ProbeFile("zetaHat.bin", Path.Combine(baseDir, "zetaHat.bin"));
+        ProbeFile("calculus", Path.Combine(baseDir, "calculus"));
+        ProbeFile("zeus.ico", Path.Combine(baseDir, "zeus.ico"));
+        ProbeFile("appsettings.json", Path.Combine(baseDir, "appsettings.json"));
+
+        Section("preferences database");
+        ProbePrefsDb();
+
+        Section("network ports");
+        ProbePorts();
+
+        Section("end preflight");
+    }
+
+    // ---- WebView2 -------------------------------------------------------
+
+    private static void ProbeWebView2()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Kv("webview2", "n/a (non-Windows host uses the system WebKit)");
+            return;
+        }
+        try
+        {
+            var hr = GetAvailableCoreWebView2BrowserVersionString(null, out var ptr);
+            if (hr == 0 && ptr != IntPtr.Zero)
+            {
+                var version = Marshal.PtrToStringUni(ptr) ?? "<null>";
+                Marshal.FreeCoTaskMem(ptr);
+                Kv("webview2.runtime", $"OK version={version}");
+            }
+            else
+            {
+                if (ptr != IntPtr.Zero) Marshal.FreeCoTaskMem(ptr);
+                Kv("webview2.runtime",
+                    $"MISSING (hr=0x{hr:X8}) — install from https://developer.microsoft.com/microsoft-edge/webview2/");
+            }
+        }
+        catch (DllNotFoundException)
+        {
+            Kv("webview2.runtime", "MISSING (WebView2Loader.dll not found next to the binary)");
+        }
+        catch (Exception ex)
+        {
+            Kv("webview2.runtime", $"UNKNOWN ({ex.GetType().Name}: {ex.Message})");
+        }
+    }
+
+    // ---- native libraries ----------------------------------------------
+
+    private static void ProbeNativeNextToExe(string fileName)
+    {
+        // Self-contained publishes flatten these next to the exe; framework-
+        // dependent (dev) builds keep them under runtimes/<rid>/native. Check the
+        // flat location first, then the RID path, then the whole runtimes tree.
+        var flat = Path.Combine(AppContext.BaseDirectory, fileName);
+        var rid = Path.Combine(AppContext.BaseDirectory, "runtimes",
+            RuntimeInformation.RuntimeIdentifier, "native", fileName);
+        var path = File.Exists(flat) ? flat
+            : File.Exists(rid) ? rid
+            : FindUnderRuntimes(fileName);
+
+        if (path is null) { Kv(fileName, "MISSING (not next to binary or under runtimes/)"); return; }
+        TryLoad(fileName, path);
+    }
+
+    private static void ProbeRuntimeNative(string libName)
+    {
+        // Self-contained publishes lay native libs under
+        // runtimes/<rid>/native/<file>. Compute the expected file for this OS
+        // and, if the exact RID path isn't there, fall back to searching the
+        // runtimes tree so a slightly different RID still reports correctly.
+        var fileName = NativeFileName(libName);
+        var rid = RuntimeInformation.RuntimeIdentifier;
+        var primary = Path.Combine(AppContext.BaseDirectory, "runtimes", rid, "native", fileName);
+        var path = File.Exists(primary) ? primary : FindUnderRuntimes(fileName);
+
+        if (path is null) { Kv(libName, $"MISSING (no {fileName} under runtimes/*/native)"); return; }
+        TryLoad(libName, path);
+    }
+
+    // Loading by full path exercises the OS loader + dependency chain, so a
+    // wdsp.dll / miniaudio.dll that's present but un-loadable for want of the
+    // VC++ runtime is reported as a load FAILURE, not a false "OK".
+    private static void TryLoad(string label, string path)
+    {
+        try
+        {
+            var h = NativeLibrary.Load(path);
+            NativeLibrary.Free(h);
+            Kv(label, $"OK loadable ({path})");
+        }
+        catch (Exception ex)
+        {
+            Kv(label, $"PRESENT but FAILED to load: {ex.GetType().Name}: {ex.Message} ({path})");
+        }
+    }
+
+    private static void ProbeVcRuntime()
+    {
+        if (!OperatingSystem.IsWindows()) { Kv("vcruntime", "n/a (non-Windows)"); return; }
+        // wdsp.dll + miniaudio.dll are MSVC-linked; without the VC++ 2015-2022
+        // redistributable they fail to load and Zeus drops to synthetic DSP /
+        // no audio. Probe the runtime DLLs by name (resolved from the system).
+        foreach (var dll in new[] { "vcruntime140.dll", "vcruntime140_1.dll", "msvcp140.dll" })
+        {
+            try
+            {
+                var h = NativeLibrary.Load(dll);
+                NativeLibrary.Free(h);
+                Kv(dll, "OK present");
+            }
+            catch (Exception ex)
+            {
+                Kv(dll, $"MISSING ({ex.GetType().Name}) — install the VC++ 2015-2022 Redistributable");
+            }
+        }
+    }
+
+    private static string NativeFileName(string libName)
+    {
+        if (OperatingSystem.IsWindows()) return libName + ".dll";
+        if (OperatingSystem.IsMacOS()) return "lib" + libName + ".dylib";
+        return "lib" + libName + ".so";
+    }
+
+    private static string? FindUnderRuntimes(string fileName)
+    {
+        try
+        {
+            var root = Path.Combine(AppContext.BaseDirectory, "runtimes");
+            if (!Directory.Exists(root)) return null;
+            return Directory.EnumerateFiles(root, fileName, SearchOption.AllDirectories).FirstOrDefault();
+        }
+        catch { return null; }
+    }
+
+    // ---- files ----------------------------------------------------------
+
+    private static void ProbeFile(string label, string path)
+    {
+        try
+        {
+            if (Directory.Exists(path)) { Kv(label, $"OK dir ({path})"); return; }
+            if (File.Exists(path))
+            {
+                Kv(label, $"OK {new FileInfo(path).Length} bytes ({path})");
+                return;
+            }
+            Kv(label, $"MISSING ({path})");
+        }
+        catch (Exception ex)
+        {
+            Kv(label, $"UNKNOWN ({ex.GetType().Name}: {ex.Message})");
+        }
+    }
+
+    // ---- prefs DB -------------------------------------------------------
+
+    private static void ProbePrefsDb()
+    {
+        try
+        {
+            var path = PrefsDbPath.Get();
+            Kv("prefs.path", path);
+            Kv("prefs.exists", File.Exists(path) ? $"yes ({new FileInfo(path).Length} bytes)" : "no (fresh install)");
+            // EnsureUsable is the same guard the host runs; report its verdict so
+            // a corrupt-and-locked DB (which forces the temp-DB fallback) shows up.
+            var usable = PrefsDbPath.EnsureUsable(path);
+            Kv("prefs.usable", usable ? "yes" : "NO (corrupt + locked → temp DB fallback)");
+        }
+        catch (Exception ex)
+        {
+            Kv("prefs", $"UNKNOWN ({ex.GetType().Name}: {ex.Message})");
+        }
+    }
+
+    // ---- ports ----------------------------------------------------------
+
+    private static void ProbePorts()
+    {
+        try
+        {
+            var lanIps = LanCertificate.GetLanIps();
+            Kv("lan.ips", lanIps.Count == 0 ? "<none up>" : string.Join(", ", lanIps));
+            Kv("lan.https.port", LanCertificate.GetHttpsPort().ToString());
+        }
+        catch (Exception ex)
+        {
+            Kv("lan", $"UNKNOWN ({ex.GetType().Name}: {ex.Message})");
+        }
+    }
+
+    // ---- low-level helpers ---------------------------------------------
+
+    private static string SafeMachineName()
+    {
+        try { return Environment.MachineName; } catch { return "<unavailable>"; }
+    }
+
+    private static string SafeCwd()
+    {
+        try { return Directory.GetCurrentDirectory(); } catch { return "<unavailable>"; }
+    }
+
+    private static string SafeFolder(Environment.SpecialFolder folder)
+    {
+        try { return Environment.GetFolderPath(folder); } catch { return "<unavailable>"; }
+    }
+
+    private static void Section(string title) => Write($"---- {title} ----");
+
+    private static void Kv(string key, string value) => Write($"  {key,-22} {value}");
+
+    private static void Write(string line)
+    {
+        var stamped = $"{DateTime.UtcNow:HH:mm:ss.fff} {line}";
+        lock (Gate)
+        {
+            try { File.AppendAllText(LogPath, stamped + Environment.NewLine); }
+            catch { /* best effort — diagnostics must never throw */ }
+        }
+        // Also to stderr: detached on Windows desktop/server mode, but visible
+        // for `dotnet run`, service mode, and macOS/Linux launches.
+        try { Console.Error.WriteLine(stamped); } catch { /* ignore */ }
+    }
+}

--- a/installers/.gitignore
+++ b/installers/.gitignore
@@ -9,5 +9,13 @@ vc_redist.x64.exe
 vc_redist.arm64.exe
 vc_redist.x86.exe
 
+# Microsoft Edge WebView2 Evergreen Runtime bootstrapper — downloaded on-demand
+# by the release CI (release.yml "Download Edge WebView2 Runtime" step) before
+# iscc bundles it into the Windows installer. Local iscc builds need it fetched
+# manually; see the Source: line comment in zeus-windows.iss for the curl
+# command. Never commit it — Microsoft's fwlink redirect is the authoritative
+# source and the binary would bloat the repo.
+MicrosoftEdgeWebview2Setup.exe
+
 # Inno Setup build output goes into installers/output/ at install time.
 output/

--- a/installers/create-linux-desktop-appimage.sh
+++ b/installers/create-linux-desktop-appimage.sh
@@ -84,6 +84,13 @@ echo "Staging publish output into AppDir..."
 cp -r "${PUBLISH_DIR}"/* "${APPDIR}/usr/bin/"
 chmod +x "${APPDIR}/usr/bin/OpenhpsdrZeus"
 
+# Runtime dependency-check helper, sourced by AppRun to verify WebKitGTK
+# (Photino's webview backend) before opening the native window. Lands next to
+# the binary so AppRun can source it after cd'ing into usr/bin. The server-mode
+# AppDir below is copied from this one, so it inherits the helper automatically.
+cp "${SCRIPT_DIR}/linux-zeus-preflight.sh" "${APPDIR}/usr/bin/zeus-preflight.sh"
+chmod +x "${APPDIR}/usr/bin/zeus-preflight.sh"
+
 # Icon — top-level zeus.png is what AppImageLauncher / file managers show.
 if [ -f "${ICON_SOURCE}" ]; then
     cp "${ICON_SOURCE}" "${APPDIR}/usr/share/icons/hicolor/512x512/apps/zeus.png"
@@ -118,7 +125,14 @@ cat > "${APPDIR}/AppRun" << 'EOF'
 HERE="$(dirname "$(readlink -f "${0}")")"
 export LD_LIBRARY_PATH="${HERE}/usr/bin/runtimes/linux-x64/native:${HERE}/usr/bin/runtimes/linux-arm64/native:${LD_LIBRARY_PATH}"
 cd "${HERE}/usr/bin"
-exec ./OpenhpsdrZeus --desktop "$@"
+# Verify WebKitGTK before opening the Photino window; offer to install it /
+# fall back to the browser UI if it's missing.
+# shellcheck source=/dev/null
+. "./zeus-preflight.sh"
+if zeus_ensure_webkit; then
+    exec ./OpenhpsdrZeus --desktop "$@"
+fi
+zeus_run_service_with_browser "$@"
 EOF
 chmod +x "${APPDIR}/AppRun"
 
@@ -141,6 +155,10 @@ REQUIREMENTS
       Debian/Ubuntu:  sudo apt install libwebkit2gtk-4.1-0
       Fedora:         sudo dnf install webkit2gtk4.1
       Arch:           sudo pacman -S webkit2gtk-4.1
+
+  The AppImage detects WebKitGTK automatically: if it's missing it offers to
+  install it (when launched from a terminal) and otherwise falls back to the
+  browser UI so Zeus still starts.
 
   WebKitGTK is intentionally NOT bundled — at ~150 MB it would more than
   triple the AppImage size and lock us to a specific WebKit release. As a
@@ -200,7 +218,14 @@ cat > "${SERVER_APPDIR}/AppRun" << 'EOF'
 HERE="$(dirname "$(readlink -f "${0}")")"
 export LD_LIBRARY_PATH="${HERE}/usr/bin/runtimes/linux-x64/native:${HERE}/usr/bin/runtimes/linux-arm64/native:${LD_LIBRARY_PATH}"
 cd "${HERE}/usr/bin"
-exec ./OpenhpsdrZeus --server "$@"
+# Server mode also opens a Photino (WebKitGTK) status window — same check,
+# same browser-UI fallback as desktop mode.
+# shellcheck source=/dev/null
+. "./zeus-preflight.sh"
+if zeus_ensure_webkit; then
+    exec ./OpenhpsdrZeus --server "$@"
+fi
+zeus_run_service_with_browser "$@"
 EOF
 chmod +x "${SERVER_APPDIR}/AppRun"
 

--- a/installers/create-linux-package.sh
+++ b/installers/create-linux-package.sh
@@ -140,7 +140,14 @@ cd "${SCRIPT_DIR}"
 # Same DYLD/LD pin as the service-mode launcher — see openhpsdr-zeus.
 export LD_LIBRARY_PATH="${SCRIPT_DIR}/runtimes/linux-x64/native:${SCRIPT_DIR}/runtimes/linux-arm64/native:${LD_LIBRARY_PATH}"
 
-exec ./OpenhpsdrZeus --desktop "$@"
+# Verify the GUI runtime dependency (WebKitGTK) before opening the Photino
+# window; offer to install it / fall back to the browser UI if it's missing.
+# shellcheck source=/dev/null
+. "${SCRIPT_DIR}/zeus-preflight.sh"
+if zeus_ensure_webkit; then
+    exec ./OpenhpsdrZeus --desktop "$@"
+fi
+zeus_run_service_with_browser "$@"
 EOF
 chmod +x "${PACKAGE_DIR}/openhpsdr-zeus-desktop"
 
@@ -163,7 +170,14 @@ cd "${SCRIPT_DIR}"
 
 export LD_LIBRARY_PATH="${SCRIPT_DIR}/runtimes/linux-x64/native:${SCRIPT_DIR}/runtimes/linux-arm64/native:${LD_LIBRARY_PATH}"
 
-exec ./OpenhpsdrZeus --server "$@"
+# Server mode also opens a Photino (WebKitGTK) status window — same dependency
+# check as desktop mode; fall back to the headless browser UI if it's missing.
+# shellcheck source=/dev/null
+. "${SCRIPT_DIR}/zeus-preflight.sh"
+if zeus_ensure_webkit; then
+    exec ./OpenhpsdrZeus --server "$@"
+fi
+zeus_run_service_with_browser "$@"
 EOF
 chmod +x "${PACKAGE_DIR}/openhpsdr-zeus-server"
 
@@ -243,6 +257,11 @@ echo "To remove them later: rm ${APPS_DIR}/zeus-desktop.desktop ${APPS_DIR}/zeus
 EOF
 chmod +x "${PACKAGE_DIR}/install-icons.sh"
 
+# Runtime dependency-check helper, sourced by the desktop/server launchers to
+# verify WebKitGTK (Photino's webview backend) before opening the native window.
+cp "${SCRIPT_DIR}/linux-zeus-preflight.sh" "${PACKAGE_DIR}/zeus-preflight.sh"
+chmod +x "${PACKAGE_DIR}/zeus-preflight.sh"
+
 # Ship the icon next to the launchers so the .desktop entries can resolve
 # Icon= relative to the install dir.
 if [ -f "${REPO_ROOT}/docs/pics/zeus.png" ]; then
@@ -285,10 +304,13 @@ Desktop mode (--desktop) is the right choice for:
 Requirements:
 - Linux ${RID} system (glibc-based; no system packages required — FFTW3 is
   statically linked into libwdsp.so and the .NET runtime is bundled)
-- Desktop mode additionally requires libwebkit2gtk-4.1-0:
+- Desktop/server modes additionally require libwebkit2gtk-4.1-0:
     Debian/Ubuntu:  sudo apt install libwebkit2gtk-4.1-0
     Fedora:         sudo dnf install webkit2gtk4.1
     Arch:           sudo pacman -S webkit2gtk-4.1
+  The desktop/server launchers detect this automatically: if it's missing they
+  offer to install it (when run from a terminal) and otherwise fall back to the
+  browser UI so Zeus still starts.
 
 For more information:
 https://github.com/Kb2uka/openhpsdr-zeus

--- a/installers/linux-zeus-preflight.sh
+++ b/installers/linux-zeus-preflight.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# zeus-preflight.sh — Linux runtime-dependency check for the GUI (Photino) modes.
+#
+# Sourced by the desktop / server launchers (tarball) and by the AppImage AppRun.
+# Photino's webview backend on Linux is WebKitGTK (libwebkit2gtk). Without it the
+# native window cannot be created and Zeus exits immediately with no window — the
+# same "flashes and closes, nothing happens" failure that a missing WebView2
+# runtime causes on Windows. This is the Linux analogue of the Windows
+# installer's WebView2/VC-redist checks: detect the dependency, offer to install
+# it when we have a terminal, and otherwise guide the operator and fall back to
+# browser (service) mode so Zeus is never left silently dead.
+#
+# All functions are best-effort and must never abort the launcher with set -e
+# semantics — callers decide what to do with the return value.
+
+# True (0) when libwebkit2gtk (4.1 or 4.0) is resolvable by the dynamic linker.
+zeus_have_webkit() {
+    if command -v ldconfig >/dev/null 2>&1; then
+        ldconfig -p 2>/dev/null | grep -Eq 'libwebkit2gtk-4\.[01]' && return 0
+    fi
+    local d
+    for d in /usr/lib /usr/lib64 /usr/local/lib \
+             /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu; do
+        ls "${d}"/libwebkit2gtk-4.* >/dev/null 2>&1 && return 0
+    done
+    return 1
+}
+
+# Echo the distro-appropriate install command for WebKitGTK, or empty when the
+# package manager isn't recognised. Package names track the per-distro names
+# documented in the tarball/AppImage READMEs.
+zeus_webkit_install_cmd() {
+    if command -v apt-get >/dev/null 2>&1; then
+        echo "sudo apt-get install -y libwebkit2gtk-4.1-0"
+    elif command -v dnf >/dev/null 2>&1; then
+        echo "sudo dnf install -y webkit2gtk4.1"
+    elif command -v pacman >/dev/null 2>&1; then
+        echo "sudo pacman -S --needed --noconfirm webkit2gtk-4.1"
+    elif command -v zypper >/dev/null 2>&1; then
+        echo "sudo zypper install -y libwebkit2gtk-4_1-0"
+    else
+        echo ""
+    fi
+}
+
+# Best-effort desktop notification for the no-terminal (double-click) case.
+zeus_notify() {
+    local text="$1"
+    if command -v zenity >/dev/null 2>&1; then
+        zenity --warning --no-wrap --title="OpenHPSDR Zeus" --text="${text}" >/dev/null 2>&1 || true
+    elif command -v kdialog >/dev/null 2>&1; then
+        kdialog --title "OpenHPSDR Zeus" --sorry "${text}" >/dev/null 2>&1 || true
+    elif command -v notify-send >/dev/null 2>&1; then
+        notify-send "OpenHPSDR Zeus" "${text}" || true
+    fi
+}
+
+# Ensure WebKitGTK is present for GUI (Photino) modes.
+#   return 0 → proceed with the requested GUI mode
+#   return 1 → caller should fall back to browser/service mode
+# When run from a terminal, offers to install the dependency (real fulfilment);
+# from a GUI launch it pops a dialog with the exact command. Either way it never
+# leaves the operator with a silent dead launch.
+zeus_ensure_webkit() {
+    zeus_have_webkit && return 0
+
+    local cmd msg ans
+    cmd="$(zeus_webkit_install_cmd)"
+    msg="OpenHPSDR Zeus needs the WebKitGTK library (libwebkit2gtk) for its native window, but it is not installed."
+
+    if [ -t 0 ] && [ -t 1 ]; then
+        echo "${msg}" >&2
+        if [ -n "${cmd}" ]; then
+            echo "" >&2
+            echo "  Install command: ${cmd}" >&2
+            printf 'Install it now? [Y/n] ' >&2
+            read -r ans
+            case "${ans}" in
+                [Nn]*) ;;
+                *) eval "${cmd}" || echo "Install failed — run the command above manually." >&2 ;;
+            esac
+        else
+            echo "Could not detect your package manager — install libwebkit2gtk-4.1 with your distro's tools." >&2
+        fi
+        zeus_have_webkit && return 0
+        echo "WebKitGTK still missing — falling back to browser (service) mode." >&2
+        return 1
+    fi
+
+    # No controlling terminal (GUI double-click): we can't prompt or sudo, so
+    # show the install command and fall back to the browser UI.
+    local detail="${msg}"
+    if [ -n "${cmd}" ]; then
+        detail="${msg}
+
+Install it from a terminal with:
+    ${cmd}
+
+Zeus will open in your web browser for now."
+    fi
+    zeus_notify "${detail}"
+    return 1
+}
+
+# Browser/service-mode fallback: run the headless backend and open the default
+# browser at the local URL, so a missing GUI dependency still yields a working
+# Zeus. Expects the current directory to contain ./OpenhpsdrZeus (the launchers
+# cd there before sourcing this file). Passes through any extra args.
+zeus_run_service_with_browser() {
+    echo "Starting OpenHPSDR Zeus in browser (service) mode on http://localhost:6060" >&2
+    ./OpenhpsdrZeus "$@" &
+    local pid=$!
+    trap 'kill -TERM "${pid}" 2>/dev/null || true' EXIT INT TERM
+    sleep 2
+    local opener
+    for opener in xdg-open gnome-open kde-open; do
+        if command -v "${opener}" >/dev/null 2>&1; then
+            "${opener}" http://localhost:6060 >/dev/null 2>&1 &
+            break
+        fi
+    done
+    zeus_notify "OpenHPSDR Zeus is running in your web browser at http://localhost:6060"
+    wait "${pid}"
+}

--- a/installers/zeus-windows.iss
+++ b/installers/zeus-windows.iss
@@ -76,6 +76,21 @@ Source: "..\OpenhpsdrZeus\bin\Release\net10.0\win-{#Arch}\publish\*"; DestDir: "
 ;   x64:   curl -L -o installers/vc_redist.x64.exe   https://aka.ms/vs/17/release/vc_redist.x64.exe
 ;   arm64: curl -L -o installers/vc_redist.arm64.exe https://aka.ms/vs/17/release/vc_redist.arm64.exe
 Source: "vc_redist.{#Arch}.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall; Check: VCRedistNeeded
+; Microsoft Edge WebView2 Evergreen Runtime bootstrapper. Photino renders the
+; Zeus desktop UI through WebView2; without the runtime the Photino window
+; cannot be created and Zeus exits immediately on launch — the window "flashes
+; and closes" with no UI (the desktop console is detached, so there is no
+; visible error). WebView2 ships with stock Windows 11 but is ABSENT on
+; Windows 11 LTSC / IoT / Enterprise N, debloated/custom images, and some VMs.
+; The ~2 MB online bootstrapper installs the matching per-arch runtime and is
+; skipped via WebView2Needed() when a runtime is already present. It is the
+; same universal bootstrapper for x64 and arm64 (it detects the host arch), so
+; unlike vc_redist this file is NOT arch-suffixed.
+;
+; The release CI downloads it from Microsoft's stable fwlink redirect before
+; iscc runs. For LOCAL iscc builds, fetch it into the installers/ folder:
+;   curl -L -o installers/MicrosoftEdgeWebview2Setup.exe https://go.microsoft.com/fwlink/p/?LinkId=2124703
+Source: "MicrosoftEdgeWebview2Setup.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall; Check: WebView2Needed
 
 [Icons]
 ; Two Start Menu shortcuts under the "Openhpsdr Zeus" group:
@@ -99,6 +114,14 @@ Name: "{autodesktop}\{#MyAppShortName} Server"; Filename: "{app}\{#MyAppExeName}
 ; ~10-second silent reinstall and the UAC prompt for operators who already
 ; have it). See issue #452 for the symptoms this fix prevents.
 Filename: "{tmp}\vc_redist.{#Arch}.exe"; Parameters: "/install /quiet /norestart"; StatusMsg: "Installing Microsoft Visual C++ Runtime..."; Check: VCRedistNeeded; Flags: waituntilterminated
+
+; Install the Microsoft Edge WebView2 Runtime BEFORE launching Zeus — the
+; Photino desktop window cannot be created without it (Zeus would flash-and-
+; close on first launch). Skipped via WebView2Needed() when already present.
+; The bootstrapper is an online installer; /silent /install runs it without UI.
+; If the machine is offline at install time this step fails gracefully and the
+; app's own startup guard surfaces a "needs WebView2" dialog on first launch.
+Filename: "{tmp}\MicrosoftEdgeWebview2Setup.exe"; Parameters: "/silent /install"; StatusMsg: "Installing Microsoft Edge WebView2 Runtime..."; Check: WebView2Needed; Flags: waituntilterminated
 
 ; Post-install launch lands the operator in the desktop window — no console,
 ; no browser dance. Server mode is one Start Menu click away for the LAN /
@@ -200,6 +223,39 @@ end;
 function VCRedistNeeded: Boolean;
 begin
   Result := not VCRedistInstalled;
+end;
+
+// WebView2RuntimeInstalled — True when the Microsoft Edge WebView2 Evergreen
+// Runtime is present. Detection follows Microsoft's documented signal: a
+// non-empty "pv" (version) value under the Evergreen Runtime client GUID
+// {F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}. A pv of "" or "0.0.0.0" means
+// "registered but not actually installed", so both are treated as absent.
+//   https://learn.microsoft.com/microsoft-edge/webview2/concepts/distribution
+//
+// The runtime can be installed three ways, so we check all three locations:
+//   - per-machine x64:        HKLM\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\... (EdgeUpdate is 32-bit)
+//   - per-machine arm64/native: HKLM\SOFTWARE\Microsoft\EdgeUpdate\...
+//   - per-user:               HKCU\Software\Microsoft\EdgeUpdate\...
+function WebView2VersionPresent(RootKey: Integer; const SoftwarePrefix: String): Boolean;
+var
+  Version: String;
+begin
+  Result := RegQueryStringValue(RootKey,
+    SoftwarePrefix + '\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}',
+    'pv', Version) and (Version <> '') and (Version <> '0.0.0.0');
+end;
+
+function WebView2RuntimeInstalled: Boolean;
+begin
+  Result :=
+    WebView2VersionPresent(HKLM, 'SOFTWARE\WOW6432Node') or
+    WebView2VersionPresent(HKLM, 'SOFTWARE') or
+    WebView2VersionPresent(HKCU, 'Software');
+end;
+
+function WebView2Needed: Boolean;
+begin
+  Result := not WebView2RuntimeInstalled;
 end;
 
 procedure CurStepChanged(CurStep: TSetupStep);


### PR DESCRIPTION
## Problem

A new user installed the latest version; launching the desktop app **flashes a console open, instantly closes, and the Zeus window never appears.** Confirmed cause for the reporting user: a **missing Edge WebView2 runtime** (Photino renders through it). WebView2 ships with stock Win11 but is absent on Win11 LTSC / IoT / Enterprise N, debloated images, and some VMs.

Root mechanism: `OpenhpsdrZeus.exe` is console-subsystem, so `--desktop` briefly shows a console then `FreeConsole()` detaches it. `Main`'s desktop/server branches only caught **address-in-use** — any other startup exception escaped `Main` silently, killing the process before the window was created, with **zero diagnostics**. The installer also never *ensured* WebView2.

## Changes

### 1. App resilience + verbose diagnostics (`OpenhpsdrZeus`)
- **`StartupDiagnostics`** — full preflight to `%LOCALAPPDATA%/Zeus/zeus-startup.log` on **every** launch: environment, every native dep probed for presence *and* loadability (WebView2, wdsp, miniaudio, Photino, VC runtime), web assets, WDSP models, prefs-DB health, ports, plus a per-step **phase marker** so a crash pinpoints the failing step. Last-resort exception handlers. Best-effort; never throws.
- **`Program.cs`** — desktop/server paths catch **all** startup exceptions, log them, and show a `MessageBox` (WebView2-specific message + download link when that's the cause) instead of vanishing.

### 2. Windows installer ensures its runtime deps (`zeus-windows.iss`)
- Bundle + silently run the **Edge WebView2 Evergreen bootstrapper**, gated on a `WebView2Needed` registry check (mirrors the existing VC-redist handling). `release.yml` downloads it; `.gitignore` excludes the fetched binary.

### 3. Linux installers ensure WebKitGTK (`linux-zeus-preflight.sh`)
The Linux analogue of the WebView2 gap: the tarball launchers and AppImage `AppRun` `exec` straight into Photino, whose Linux webview is **WebKitGTK** (`libwebkit2gtk`). New sourced preflight:
- detects `libwebkit2gtk` (4.1/4.0) via `ldconfig` + common lib dirs
- **on a terminal:** offers to install it via the detected package manager (apt/dnf/pacman/zypper)
- **on a GUI double-click:** shows a dialog (zenity/kdialog/notify-send) with the exact install command
- **either way:** falls back to browser (service) mode + opens the default browser, so a missing GUI dep still yields a working Zeus
- `*.sh` pinned to LF in `.gitattributes` (the helper is sourced — CRLF would break it)

### macOS — no change needed
WKWebView is a system component, FFTW is statically linked into `libwdsp`, and the .NET runtime is bundled. Nothing to fulfil.

## Testing
- `OpenhpsdrZeus` builds clean; ran it and confirmed `zeus-startup.log` reports accurately (`webview2.runtime OK version=…`, `wdsp`/`miniaudio` `OK loadable`, VC runtime present, assets/prefs/ports).
- A CI dry-run installer built from this branch (with the WebView2 bundling) was installed on the affected user's machine — **Zeus now launches.**
- All shell scripts pass `bash -n`; helper functions and the generated launcher/AppRun bodies syntax-check; staged `.sh` blobs verified LF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)