### PR TITLE
fix(p2): decode ANAN-200D via the Protocol-2 board-byte scheme (#780)

### DIFF
--- a/Zeus.Protocol2/Discovery/ReplyParser.cs
+++ b/Zeus.Protocol2/Discovery/ReplyParser.cs
@@ -109,16 +109,28 @@ public static class ReplyParser
         return true;
     }
 
+    // Protocol-2 discovery device byte (reply offset 11). This is the
+    // NEW-protocol numbering and is DIFFERENT from Protocol 1: the dual-ADC
+    // family is shifted by one. Authoritative sources agree —
+    // piHPSDR discovered.h (NEW_DEVICE_*), Thetis network.h / enums.cs,
+    // NereusSDR HpsdrModel.h:
+    //   P2: 0x03 Angelia(100D), 0x04 Orion(200D), 0x05 OrionMkII(7000/8000)
+    //   P1: 0x04 Angelia,       0x05 Orion,       0x0A OrionMkII
+    // Reusing the P1 numbers here was the cause of issue #780 (a real
+    // ANAN-200D sends P2 byte 0x04 and was mis-classified as Angelia/100D).
+    // DO NOT copy these values into Zeus.Protocol1.Discovery.ReplyParser —
+    // its 0x04/0x05/0x0A mapping is correct for the P1 wire and must stay.
     private static HpsdrBoardKind MapBoard(byte raw) => raw switch
     {
-        0x00 => HpsdrBoardKind.Metis,
+        0x00 => HpsdrBoardKind.Metis,        // Atlas
         0x01 => HpsdrBoardKind.Hermes,
         0x02 => HpsdrBoardKind.HermesII,
-        0x04 => HpsdrBoardKind.Angelia,
-        0x05 => HpsdrBoardKind.Orion,
+        0x03 => HpsdrBoardKind.Angelia,      // ANAN-100D
+        0x04 => HpsdrBoardKind.Orion,        // ANAN-200D (issue #780)
+        0x05 => HpsdrBoardKind.OrionMkII,    // ANAN-7000DLE / 8000DLE (Orion2)
         0x06 => HpsdrBoardKind.HermesLite2,
-        0x0A => HpsdrBoardKind.OrionMkII,
-        0x14 => HpsdrBoardKind.HermesC10,
+        0x0A => HpsdrBoardKind.OrionMkII,    // Saturn / ANAN-G2
+        0x14 => HpsdrBoardKind.HermesC10,    // ANAN-G2E
         _ => HpsdrBoardKind.Unknown,
     };
 

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -953,7 +953,7 @@ public static class ZeusEndpoints
             // Plumb the discovered board byte through so RadioService can
             // set the real board kind on the Protocol1Client rather than
             // defaulting to HermesLite2 for every P1 connection — issue #294.
-            var p1BoardKind = req.BoardId is byte bid ? MapBoardByte(bid) : HpsdrBoardKind.Unknown;
+            var p1BoardKind = req.BoardId is byte bid ? MapBoardByteP1(bid) : HpsdrBoardKind.Unknown;
 
             try
             {
@@ -996,7 +996,7 @@ public static class ZeusEndpoints
             // Plumb the discovered board byte through so RadioService can
             // surface the real board kind instead of defaulting to OrionMkII
             // for every P2 connection (issue #171 — Brick2 is Hermes/0x01 on P2).
-            var boardKind = req.BoardId is byte b ? MapBoardByte(b) : HpsdrBoardKind.Unknown;
+            var boardKind = req.BoardId is byte b ? MapBoardByteP2(b) : HpsdrBoardKind.Unknown;
 
             try
             {
@@ -2866,20 +2866,37 @@ public static class ZeusEndpoints
         return true;
     }
 
-    // Mirrors the byte→enum maps in Zeus.Protocol1.Discovery.ReplyParser and
-    // Zeus.Protocol2.Discovery.ReplyParser. Kept inline (not factored to a
-    // shared helper) because those parsers are deliberately self-contained
-    // per protocol; this is the connect-time projection of the same table.
-    static HpsdrBoardKind MapBoardByte(byte raw) => raw switch
+    // Connect-time projection of the discovered board byte → kind. Protocol 1
+    // and Protocol 2 use DIFFERENT wire numbering for the dual-ADC family
+    // (Angelia/Orion/OrionMkII), so they MUST use separate maps that mirror
+    // Zeus.Protocol1/Protocol2 Discovery.ReplyParser respectively. Reusing one
+    // table for both was the connect-time half of issue #780 (a P2 ANAN-200D,
+    // byte 0x04, was projected through the P1 table as Angelia/100D).
+    // Do NOT merge these two.
+    static HpsdrBoardKind MapBoardByteP1(byte raw) => raw switch
     {
         0x00 => HpsdrBoardKind.Metis,
         0x01 => HpsdrBoardKind.Hermes,
         0x02 => HpsdrBoardKind.HermesII,
-        0x04 => HpsdrBoardKind.Angelia,
-        0x05 => HpsdrBoardKind.Orion,
+        0x04 => HpsdrBoardKind.Angelia,      // ANAN-100D (P1 wire)
+        0x05 => HpsdrBoardKind.Orion,        // ANAN-200D (P1 wire)
         0x06 => HpsdrBoardKind.HermesLite2,
         0x0A => HpsdrBoardKind.OrionMkII,
         0x14 => HpsdrBoardKind.HermesC10,
+        _    => HpsdrBoardKind.Unknown,
+    };
+
+    static HpsdrBoardKind MapBoardByteP2(byte raw) => raw switch
+    {
+        0x00 => HpsdrBoardKind.Metis,        // Atlas
+        0x01 => HpsdrBoardKind.Hermes,
+        0x02 => HpsdrBoardKind.HermesII,
+        0x03 => HpsdrBoardKind.Angelia,      // ANAN-100D (P2 wire)
+        0x04 => HpsdrBoardKind.Orion,        // ANAN-200D (P2 wire — issue #780)
+        0x05 => HpsdrBoardKind.OrionMkII,    // ANAN-7000DLE / 8000DLE (P2 wire)
+        0x06 => HpsdrBoardKind.HermesLite2,
+        0x0A => HpsdrBoardKind.OrionMkII,    // Saturn / ANAN-G2
+        0x14 => HpsdrBoardKind.HermesC10,    // ANAN-G2E
         _    => HpsdrBoardKind.Unknown,
     };
 

--- a/tests/Zeus.Protocol2.Tests/DiscoveryTests.cs
+++ b/tests/Zeus.Protocol2.Tests/DiscoveryTests.cs
@@ -76,19 +76,23 @@ public class DiscoveryTests
     }
 
     [Fact]
-    public void Parses_Orion_Reply()
+    public void Parses_Anan200D_Orion_Reply()
     {
+        // ANAN-200D on Protocol 2 sends device byte 0x04 (NOT 0x05 — that is
+        // OrionMkII on the P2 wire). Regression guard for issue #780, where the
+        // P1 numbering (Orion=0x05) was wrongly applied to P2 and a real 200D
+        // mis-detected as Angelia (ANAN-100D).
         var reply = BuildReply(new ReplyFields(
             Status: 0x02,
             Mac: new byte[] { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66 },
-            BoardId: 0x05,
+            BoardId: 0x04,
             ProtocolSupported: 36,
             CodeVersion: 19,
             NumReceivers: 1));
 
         Assert.True(ReplyParser.TryParse(reply, FromIp, out var radio));
         Assert.Equal(HpsdrBoardKind.Orion, radio.Board);
-        Assert.Equal((byte)0x05, radio.Details.RawBoardId);
+        Assert.Equal((byte)0x04, radio.Details.RawBoardId);
     }
 
     [Fact]
@@ -109,17 +113,19 @@ public class DiscoveryTests
     [InlineData((byte)0x00, HpsdrBoardKind.Metis)]
     [InlineData((byte)0x01, HpsdrBoardKind.Hermes)]
     [InlineData((byte)0x02, HpsdrBoardKind.HermesII)]
-    [InlineData((byte)0x04, HpsdrBoardKind.Angelia)]
-    [InlineData((byte)0x05, HpsdrBoardKind.Orion)]
+    [InlineData((byte)0x03, HpsdrBoardKind.Angelia)]     // ANAN-100D (P2 wire — issue #780)
+    [InlineData((byte)0x04, HpsdrBoardKind.Orion)]       // ANAN-200D (P2 wire — issue #780)
+    [InlineData((byte)0x05, HpsdrBoardKind.OrionMkII)]   // ANAN-7000DLE/8000DLE (P2 wire)
     [InlineData((byte)0x06, HpsdrBoardKind.HermesLite2)]
-    [InlineData((byte)0x0A, HpsdrBoardKind.OrionMkII)]
+    [InlineData((byte)0x0A, HpsdrBoardKind.OrionMkII)]   // Saturn / ANAN-G2
     [InlineData((byte)0x14, HpsdrBoardKind.HermesC10)]
     public void Maps_Every_Recognised_WireByte_To_BoardKind(byte boardId, HpsdrBoardKind expected)
     {
-        // P2 counterpart to the P1 exhaustive-mapping test. Note 0x00
-        // names "Atlas" on P2 vs "Metis" on P1 — same wire byte, different
-        // historical labelling. Issue #218's enum unification will pick a
-        // canonical name; this test pins the current dispatch.
+        // P2 counterpart to the P1 exhaustive-mapping test. The dual-ADC family
+        // uses DIFFERENT wire bytes on P2 vs P1 (issue #780): on P2,
+        // 0x03=Angelia(100D), 0x04=Orion(200D), 0x05=OrionMkII; on P1 those are
+        // 0x04/0x05/0x0A. 0x00 names "Atlas" on P2 vs "Metis" on P1 — same wire
+        // byte, different historical labelling.
         var reply = BuildReply(new ReplyFields(
             Status: 0x02,
             Mac: new byte[] { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55 },


### PR DESCRIPTION
DO NOT MERGE — draft for review

Replaces #785 (rejected). That PR didn't fix the reported bug and flipped the Orion PA cap to a wrong/unsafe 200 W. This is the correct, minimal fix.

## The actual bug
A genuine **ANAN-200D on Protocol 2 sends discovery byte `0x04`**, but Zeus's P2 parser reused the **Protocol-1** numbering (`0x04=Angelia, 0x05=Orion`), so the 200D mis-detected as **ANAN-100D (Angelia)** — exactly the operator's snapshot (`board.kind: Angelia`). P1 and P2 use different wire numbering for the dual-ADC family; the P2 parser was using the P1 table. Confirmed against piHPSDR (`discovered.h` `NEW_DEVICE_*`), Thetis, and NereusSDR (`HpsdrModel.h`).

## Changes
- **`Zeus.Protocol2/Discovery/ReplyParser.cs`** — correct the P2 map to the new-protocol scheme: `0x03=Angelia (100D)`, `0x04=Orion (200D)`, `0x05=OrionMkII (7000/8000)`; keep `0x06=HL2`, `0x0A=OrionMkII (Saturn/G2)`, `0x14=HermesC10`.
- **`Zeus.Server.Hosting/ZeusEndpoints.cs`** — the shared connect-time `MapBoardByte` was P1-only but used by **both** `/connect/p1` and `/connect/p2`. Split into `MapBoardByteP1` / `MapBoardByteP2` and route each endpoint correctly (the connect-time twin of the same bug).
- **`tests/Zeus.Protocol2.Tests/DiscoveryTests.cs`** — the existing tests pinned the *buggy* mapping; corrected to the real P2 scheme and added explicit 100D/200D cases for #780.

## What is deliberately NOT changed
- **No PA power change.** `develop` already caps Orion at the correct **100 W** — the ANAN-200D is a 100 W radio (Apache Labs manual; Thetis `CurrentPowerRating`). #785's `Orion=>200` was wrong and is not carried here.
- **Protocol-1 parser untouched** — `0x05=Orion` is correct for the P1 wire; a 200D on P1 already works. (The P1 and P2 maps must stay separate — do not merge them.)

## Test plan
- [x] `dotnet build Zeus.slnx` — 0 warnings / 0 errors
- [x] Zeus.Protocol2.Tests 127 ✓ · Zeus.Protocol1.Tests 210 ✓ (P1 unchanged) · Zeus.Server.Tests 1360 ✓
- [ ] On a real ANAN-200D (P2): connect, confirm `board.kind: Orion` and 100 W PA scale — **no Override Detection needed**
- [ ] Spot-check inert on owned hardware: HL2 (P2 0x06) and G2 (P2 0x0A) still detect unchanged

## Known follow-up (out of scope)
- P2 `0x0B` (SaturnMkII / ANAN-G2 MkII) still maps to Unknown — pre-existing gap, not part of #780.

Fixes #780