### PR TITLE
fix(rx-audio): stop dual-RX clicking — RX1 audio clock-master in the mix (#787)

### DIFF
--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -4745,7 +4745,21 @@ public class DspPipelineService : BackgroundService,
         int audioSampleCount = engine.ReadAudio(channel, audioBuf);
         int rx2AudioSampleCount = 0;
         if (state.Rx2Enabled && rx2Channel >= 0)
-            rx2AudioSampleCount = engine.ReadAudio(rx2Channel, _rx2AudioBuf);
+        {
+            // RX1 is the audio clock-master when both receivers are mixed: read
+            // at most rx1Count samples from RX2 so the mixed stream is fed at
+            // exactly the RX sample rate. Draining RX2's ring fully and mixing
+            // max(rx1,rx2) over-feeds the sink — the two channels' per-tick
+            // counts jitter independently, so E[max] exceeds the true rate
+            // (~5% measured on a G2), saturating the output ring → overrun →
+            // dual-RX clicking (#787). The unread RX2 remainder stays buffered
+            // for the next tick, so no RX2 audio is dropped. RX2-only mode still
+            // drains RX2 fully (RX2 is the master there).
+            Span<float> rx2Span = state.Rx2AudioMode == Rx2AudioMode.Both
+                ? _rx2AudioBuf.AsSpan(0, Math.Min(audioSampleCount, _rx2AudioBuf.Length))
+                : _rx2AudioBuf.AsSpan();
+            rx2AudioSampleCount = engine.ReadAudio(rx2Channel, rx2Span);
+        }
         audioSampleCount = SelectRxAudio(
             state.Rx2AudioMode,
             audioBuf,


### PR DESCRIPTION
DO NOT MERGE — draft for on-air bench test

Fixes #787: with **both receivers active**, desktop RX audio clicks; a single receiver is clean.

## Root cause (confirmed live on a G2)
The dual-RX mix drains each WDSP channel's audio ring **independently** per tick and feeds the sink `max(rx1Count, rx2Count)` (`DspPipelineService.MixRxAudio`). The two per-tick counts jitter independently, so `E[max]` exceeds the true sample rate — the mix **over-feeds the output sink ~5%**, the ring saturates, and the surplus is dropped:

| State | Δin / window | Δout / window | overrun | result |
|---|---|---|---|---|
| Both RX | ~253k | ~240k (48 kHz) | ~13k/win | **OVERFEED → clicks** |
| RX1-only | ~242k | ~241k | ~0 | clean |
| RX2-only | ~242k | ~241k | ~0 | clean |

Output ring measured **pinned at 64928 / 65536 (99% full)**. It was never buffer size or thread priority — those were ruled out (periods=4 and worker-priority tries did not change it; both reverted).

## Fix (one change)
In `DspPipelineService` Tick, make **RX1 the audio clock-master** in Both mode: read at most `rx1Count` samples from the RX2 ring (`_rx2AudioBuf.AsSpan(0, rx1Count)`) so the mixed stream is fed at exactly the RX rate. `ReadAudio` leaves the unread RX2 remainder in its ring, so **no RX2 audio is lost**; it's consumed next tick. RX2-only mode still drains RX2 fully.

**Untouched:** #742 prebuffer, NativeAudioSink, thread priorities, and **all PureSignal code** (diff = one file, 0 PS identifiers).

## Test plan
- [x] `dotnet build Zeus.slnx` 0/0 · Zeus.Server.Tests audio/mix suite 190 ✓
- [ ] **Bench (KB2UKA):** engage RX2, run both on live audio — confirm no clicking and `audio.native.rx … overrun` stays ~0 (was ~13k/window).

Fixes #787