### PR TITLE
fix(tx-fidelity): show resulting values in Auto Tune summary

### DIFF
--- a/zeus-web/src/audio/tx-auto-tune.test.ts
+++ b/zeus-web/src/audio/tx-auto-tune.test.ts
@@ -225,6 +225,36 @@ describe('recommendTxAutoTune', () => {
     expect(plan.actions.join(' ')).toContain('compressor on');
   });
 
+  it('reports the resulting values so consecutive runs are distinguishable', () => {
+    const hot = samples({ micPkDbfs: -8, audioSuiteOutputDbfs: -0.4, outPkDbfs: -6 });
+    const first = recommendTxAutoTune(settings({ micGainDb: -4 }), hot);
+
+    // The headline now leads with where each moved setting LANDED, not just the
+    // delta — so it carries the absolute mic value and differs run-to-run.
+    expect(first.summary).toContain('→');
+    expect(first.summary).toContain(`mic ${first.settings.micGainDb} dB`);
+
+    // Re-run from the just-applied mic gain against the same hot sample: the
+    // chain backs off again, lands on a different value, and the summary text
+    // is no longer identical to the previous run.
+    const second = recommendTxAutoTune(settings({ micGainDb: first.settings.micGainDb }), hot);
+    expect(second.settings.micGainDb).toBeLessThan(first.settings.micGainDb);
+    expect(second.summary).not.toBe(first.summary);
+  });
+
+  it('only names settings that actually moved in the result clause', () => {
+    const plan = recommendTxAutoTune(
+      settings({ micGainDb: -4, audioSuiteActive: true }),
+      samples({ micPkDbfs: -8, audioSuiteOutputDbfs: -0.4, outPkDbfs: -6 }),
+    );
+
+    // VST chain hot -> only mic gain is cut; the clause must not invent a
+    // leveler/drive change the run never made.
+    expect(plan.summary).toContain('mic');
+    expect(plan.summary).not.toContain('leveler');
+    expect(plan.summary).not.toContain('drive');
+  });
+
   it('slows a pumping leveler instead of leaving it chasing syllables', () => {
     const pumping = Array.from({ length: 40 }, (_, i) =>
       sample({ lvlrGrDb: i < 30 ? 2 : 12 }),

--- a/zeus-web/src/audio/tx-auto-tune.ts
+++ b/zeus-web/src/audio/tx-auto-tune.ts
@@ -257,6 +257,37 @@ function fmtDb(v: number | null): string {
   return v === null ? '--' : `${v.toFixed(1)} dB`;
 }
 
+// A compact clause of the RESULTING (post-tune) values for every setting Auto
+// Tune actually moved. The `actions` list carries the per-step DELTAS (e.g.
+// "mic -1.5 dB"), which read byte-for-byte identical on every run even while
+// the chain is genuinely walking down — so the headline summary looked frozen.
+// Reporting where each value LANDED makes consecutive runs visibly differ and
+// tells the operator the absolute state, not just the nudge.
+function resultClause(current: TxAutoTuneSettings, next: TxAutoTuneSettings): string {
+  const parts: string[] = [];
+  if (next.micGainDb !== current.micGainDb) parts.push(`mic ${next.micGainDb} dB`);
+  if (next.levelerMaxGainDb !== current.levelerMaxGainDb) {
+    parts.push(`leveler ${next.levelerMaxGainDb} dB`);
+  }
+  if (next.drivePercent !== current.drivePercent) parts.push(`drive ${next.drivePercent}%`);
+  if (next.cfcConfig.preCompDb !== current.cfcConfig.preCompDb) {
+    parts.push(`CFC pre-comp ${next.cfcConfig.preCompDb} dB`);
+  }
+  if (next.cfcConfig.prePeqDb !== current.cfcConfig.prePeqDb) {
+    parts.push(`CFC pre-PEQ ${next.cfcConfig.prePeqDb} dB`);
+  }
+  if (next.txLeveling.alcMaxGainDb !== current.txLeveling.alcMaxGainDb) {
+    parts.push(`ALC max ${next.txLeveling.alcMaxGainDb} dB`);
+  }
+  if (next.txLeveling.compressorGainDb !== current.txLeveling.compressorGainDb) {
+    parts.push(`comp ${next.txLeveling.compressorGainDb} dB`);
+  }
+  if (next.txLeveling.levelerDecayMs !== current.txLeveling.levelerDecayMs) {
+    parts.push(`leveler decay ${next.txLeveling.levelerDecayMs} ms`);
+  }
+  return parts.join(', ');
+}
+
 function fmtDbfs(v: number | null): string {
   return v === null ? '--' : `${v.toFixed(1)} dBFS`;
 }
@@ -599,7 +630,8 @@ export function recommendTxAutoTune(
   if (stats.voicedSampleCount < MIN_VOICED_SAMPLES) {
     summary = 'Auto tune needs a stronger speech sample';
   } else if (actions.length > 0) {
-    summary = `Auto tune applied ${actions.length} bounded change${actions.length === 1 ? '' : 's'}`;
+    const landed = resultClause(current, next);
+    summary = `Auto tune applied ${actions.length} bounded change${actions.length === 1 ? '' : 's'}${landed ? ` → ${landed}` : ''}`;
   } else if (blockers.length > 0) {
     summary = `Auto tune held settings: ${blockers[0]}`;
   } else {


### PR DESCRIPTION
## Problem

Auto Tune in the TX Fidelity panel looked like it **"always returns the same result no matter what"** — e.g. every run reported:

> Auto tune applied 2 bounded changes: mic -1.5 dB for headroom, CFC pre-comp -0.8 dB

## Root cause

`recommendTxAutoTune()` is a **pure function of the captured 15 s sample** — no randomness, no memory. The repeated text was a **reporting artifact**, not a tuning bug: the status headline was built only from the per-step *delta* action strings (`"mic -1.5 dB for headroom"`, `"CFC pre-comp -0.8 dB"`), which are constant text. So even when Auto Tune was genuinely walking the chain down run after run, the headline read byte-for-byte identical.

(There is a separate, deeper observation that the recommender's decision surface collapses onto a couple of coarse "always-true" branches for normal speech, and that the entire density-*raising* half is gated off whenever anything reads hot. That's a tuning-calibration discussion that changes operator-felt defaults, so it's intentionally **out of scope** here and left for maintainer review.)

## Fix

Lead the applied-summary with a **result clause** naming where each setting that actually moved **landed** — absolute mic gain, leveler max, drive, CFC pre-comp/pre-PEQ, ALC max, compressor gain, leveler decay. Example:

> Auto tune applied 2 bounded changes → mic -6 dB, CFC pre-comp 0.2 dB: mic -1.5 dB for headroom, CFC pre-comp -0.8 dB

Consecutive runs now visibly differ and the operator sees the resulting state, not just the nudge. The delta actions + reasons remain in the message tail and the panel tooltip.

**Only the displayed summary string changes — no tuning thresholds, behavior, or defaults are touched.**

## Tests

- Added: resulting values appear in the summary and two consecutive hot-sample runs produce **different** summary text.
- Added: the result clause names only settings that actually moved (no phantom leveler/drive changes).
- `vitest` (11 passed), `tsc --noEmit`, and `eslint` all clean.
