### PR TITLE
feat(diagnostics): live diagnostics API v2 — provider framework, self-checks, push + test harness

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,12 +9,68 @@ on:
 
 jobs:
   build-and-test:
-    name: Build and Test (${{ matrix.os }})
+    name: Build and Test (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
+    # continue-on-error is driven per-leg from the matrix. Legs whose runner
+    # availability for THIS repo is not yet confirmed (native arm64, Intel
+    # macOS) are marked experimental so an infra gap does not turn the whole
+    # required check red. Promote them to hard gates (drop `experimental`)
+    # once a green run on real hardware confirms the runner label resolves.
+    continue-on-error: ${{ matrix.experimental || false }}
     strategy:
+      # fail-fast: false so one architecture failing still reports the others.
+      # We want to SEE which arch broke, not have GitHub cancel the siblings.
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          # ---- Hard-gated legs (required) --------------------------------
+          # x64 across all three OSes. These have always run and stay required.
+          - name: linux-x64
+            os: ubuntu-latest
+            arch: x64
+          - name: windows-x64
+            os: windows-latest
+            arch: x64
+          - name: macos-arm64
+            # macos-latest is Apple Silicon (arm64) as of the macOS 14 image.
+            os: macos-latest
+            arch: arm64
+
+          # ---- arm64 .NET test legs (NEW) --------------------------------
+          # GitHub's native arm64 runners are GA for public repos:
+          #   ubuntu-24.04-arm  -> Linux arm64 (covers Raspberry Pi class ABI)
+          #   windows-11-arm    -> Windows arm64
+          # We run `dotnet test` natively here rather than QEMU so the DSP /
+          # native-load path is exercised on real arm64 silicon. QEMU was
+          # rejected: it cannot validate the WDSP native .so/.dll load reliably
+          # (emulated syscalls + missing arm64 native runtimes) and is far
+          # slower. If a native arm runner label is ever disabled for this repo
+          # these legs will fail to schedule — that is why they are flagged
+          # experimental below until a maintainer confirms a green run.
+          # TODO(maintainer): drop `experimental: true` on these two legs once
+          # a run on the real arm64 runners is confirmed green; then they
+          # become required, satisfying the "green on every arch" rule.
+          - name: linux-arm64
+            os: ubuntu-24.04-arm
+            arch: arm64
+            experimental: true
+          - name: windows-arm64
+            os: windows-11-arm
+            arch: arm64
+            experimental: true
+
+          # ---- macOS x64 (Intel) coverage (NEW) --------------------------
+          # macos-13 is the last x64 (Intel) hosted image. Apple Silicon is the
+          # default now, so without this leg Intel Macs are silently untested.
+          # Tradeoff: Intel macOS hosted capacity is limited and the image is on
+          # a deprecation track, so this is experimental (informational) rather
+          # than a hard gate — we still want the signal when it is available.
+          # TODO(maintainer): keep an eye on macos-13 availability; if/when it
+          # is retired, drop this leg and note Intel macOS is best-effort.
+          - name: macos-x64
+            os: macos-13
+            arch: x64
+            experimental: true
 
     steps:
       - uses: actions/checkout@v4
@@ -41,8 +97,28 @@ jobs:
       - name: Restore .NET dependencies
         run: dotnet restore Zeus.slnx
 
+      # Warnings-as-errors is enforced globally via Directory.Build.props
+      # (<TreatWarningsAsErrors>true</TreatWarningsAsErrors>), so this build
+      # already fails on any C# warning. We pass `-warnaserror` redundantly as
+      # a belt-and-suspenders guard: if the prop is ever dropped or overridden
+      # by a project, CI still treats warnings as errors. Do NOT add
+      # `-p:TreatWarningsAsErrors=false` or `-warnaserror-` anywhere — that
+      # would silently re-open the warnings gate.
       - name: Build .NET solution
-        run: dotnet build Zeus.slnx --configuration Release --no-restore
+        run: dotnet build Zeus.slnx --configuration Release --no-restore -warnaserror
+
+      # Verify the WDSP native library actually loads on THIS OS/arch.
+      # tests/Zeus.Dsp.Tests/WdspNativeLoaderTests.cs probes
+      # WdspDspEngine.NativeLibraryLoadable via a SkippableFact — it does not
+      # hard-fail when the native runtime is absent/stale (common on a feature
+      # branch where committed native binaries may lag the platform set). We run
+      # the Zeus.Dsp.Tests project with detailed console output so the
+      # native-load result (loaded / skipped + reason) is VISIBLE per OS/arch in
+      # the log. This is informational on purpose: a stale committed runtime
+      # should surface as a clear skip message, not a red required check. The
+      # full DSP-correctness gates still run in the "Run .NET tests" step below.
+      - name: Probe WDSP native load (informational, per OS/arch)
+        run: dotnet test tests/Zeus.Dsp.Tests/Zeus.Dsp.Tests.csproj --configuration Release --no-build --logger "console;verbosity=detailed"
 
       # The "DspModernization" trait covers the WDSP-v2 evidence/validation
       # tooling suites (bakeoff-report ranking, artifact-manifest scaffolds,
@@ -52,7 +128,8 @@ jobs:
       # modernization combinatorics as opt-in diagnostics rather than PR gates.
       # They run on a schedule via dsp-modernization-tests.yml instead. The
       # DSP-correctness + channel-lifecycle gates (Zeus.Dsp.Tests, etc.) stay
-      # in the per-PR run below.
+      # in the per-PR run below. The diagnostics-conformance tests in
+      # Zeus.Server.Tests are NOT in this category, so this filter runs them.
       - name: Run .NET tests
         run: dotnet test Zeus.slnx --configuration Release --no-build --verbosity normal --filter "Category!=DspModernization"
 
@@ -68,10 +145,12 @@ jobs:
         run: npm run lint
         working-directory: zeus-web
 
+      # Type-check is a hard gate. Previously continue-on-error masked real type
+      # regressions ("missing @types in CI"); `npm ci` installs devDependencies
+      # so the types ARE present and a failure here is a genuine type error.
       - name: Type-check frontend
         run: npm run typecheck
         working-directory: zeus-web
-        continue-on-error: true  # Type checking may fail due to missing @types packages in CI
 
       - name: Run frontend tests
         run: npm test

--- a/Zeus.Contracts/DiagnosticsV2Dtos.cs
+++ b/Zeus.Contracts/DiagnosticsV2Dtos.cs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Live Diagnostics API v2 — wire DTOs for the unified diagnostics surface.
+//
+// These are the aggregate / framework-level shapes (index, self-check report,
+// health). Per-provider snapshot DTOs (DspLiveDiagnosticsDto, etc.) keep living
+// in Dtos.cs next to their domain. Severity/outcome are carried as strings here
+// (not the server-side enums) so Zeus.Contracts stays free of the provider
+// abstraction and older clients tolerate new values. SchemaVersion is the first
+// field on every DTO per the repo convention.
+
+namespace Zeus.Contracts;
+
+/// <summary>Index entry describing one registered diagnostics provider.</summary>
+public sealed record DiagnosticsProviderInfoDto(
+    int SchemaVersion,
+    string Id,
+    string RouteSegment,
+    string Category,
+    string Description,
+    int ProviderSchemaVersion,
+    string SnapshotUrl,
+    string SelfCheckUrl,
+    int SelfCheckCount);
+
+/// <summary>The catalogue of every provider on the v2 surface.</summary>
+public sealed record DiagnosticsIndexDto(
+    int SchemaVersion,
+    DateTimeOffset GeneratedUtc,
+    int ProviderCount,
+    DiagnosticsProviderInfoDto[] Providers);
+
+/// <summary>Result of a single self-check probe, flattened for the wire.</summary>
+public sealed record SelfCheckResultDto(
+    int SchemaVersion,
+    string Id,
+    string Description,
+    string Severity,   // info | warn | error
+    string Outcome,    // pass | warn | fail
+    string Detail,
+    DateTimeOffset RanUtc,
+    double DurationMs);
+
+/// <summary>All self-check results for one provider plus the worst outcome across them.</summary>
+public sealed record ProviderSelfCheckReportDto(
+    int SchemaVersion,
+    string ProviderId,
+    string Worst,      // pass | warn | fail
+    DateTimeOffset GeneratedUtc,
+    SelfCheckResultDto[] Checks);
+
+/// <summary>Aggregate health across all providers — the payload pushed over the hub at low rate.</summary>
+public sealed record DiagnosticsHealthDto(
+    int SchemaVersion,
+    DateTimeOffset GeneratedUtc,
+    string Overall,    // pass | warn | fail
+    int ProviderCount,
+    int PassCount,
+    int WarnCount,
+    int FailCount,
+    ProviderSelfCheckReportDto[] Providers);

--- a/Zeus.Contracts/MsgType.cs
+++ b/Zeus.Contracts/MsgType.cs
@@ -219,4 +219,15 @@ public enum MsgType : byte
     // shapes are richer than the other control frames. UI ignores unknown
     // kinds so older builds tolerate additions cleanly. See ChatEventFrame.cs.
     ChatEvent = 0x35,
+
+    // Server → client (Live Diagnostics v2 aggregate health). Broadcast by
+    // DiagnosticsFramePublisher at low rate (1-2 Hz) whenever clients are
+    // connected, and pushed once per client on WS attach (mirrors SpotList /
+    // ChatEvent push-on-attach). Carries the worst-of provider health so a
+    // dashboard can render live status without polling the REST endpoints.
+    // Payload: [type:1][UTF-8 JSON of DiagnosticsHealthDto]. JSON for the same
+    // reasons as ChatEvent; UI ignores unknown types so older builds tolerate
+    // it cleanly. Encoded by DiagnosticsFramePublisher (source-gen serialised
+    // for the hot push path).
+    DiagnosticsHealth = 0x36,
 }

--- a/Zeus.Diagnostics.TestGen/DiagnosticsTestGenerator.cs
+++ b/Zeus.Diagnostics.TestGen/DiagnosticsTestGenerator.cs
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Live Diagnostics API v2 — Layer 2 test framework.
+//
+// A Roslyn incremental source generator that emits ONE named xUnit test class
+// per IDiagnosticsProvider into the Zeus.Server.Tests assembly. Each provider
+// therefore shows up as its own discoverable, named test (e.g.
+// DspLiveDiagnosticsProviderGeneratedTests) so a missing/broken provider is an
+// obvious red test rather than a single data row in a [Theory].
+//
+// This COMPLEMENTS — does not replace — the hand-written reflection conformance
+// [Theory] that exercises all providers generically.
+//
+// FEASIBILITY NOTE (load-bearing): the providers live in the REFERENCED assembly
+// Zeus.Server.Hosting, not in the test project's own source. SyntaxProvider /
+// ForAttributeWithMetadataName only see source in the CURRENT (test) compilation,
+// so we must walk referenced-assembly SYMBOLS instead: take the compilation, get
+// the IDiagnosticsProvider symbol via GetTypeByMetadataName, then enumerate types
+// across SourceModule.ReferencedAssemblySymbols selecting concrete public classes
+// that implement that interface (AllInterfaces).
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Zeus.Diagnostics.TestGen
+{
+    [Generator(LanguageNames.CSharp)]
+    public sealed class DiagnosticsTestGenerator : IIncrementalGenerator
+    {
+        private const string ProviderInterfaceMetadataName =
+            "Zeus.Server.Diagnostics.IDiagnosticsProvider";
+
+        public void Initialize(IncrementalGeneratorInitializationContext context)
+        {
+            // CompilationProvider is required because the provider types we want
+            // live only in referenced assemblies, not in this compilation's syntax.
+            var providers = context.CompilationProvider.Select(static (compilation, _) =>
+                DiscoverProviders(compilation));
+
+            context.RegisterSourceOutput(providers, static (spc, models) =>
+            {
+                foreach (var model in models)
+                {
+                    spc.AddSource(model.TypeName + ".g.cs",
+                        SourceText.From(EmitTestClass(model), Encoding.UTF8));
+                }
+            });
+        }
+
+        private static ImmutableArray<ProviderModel> DiscoverProviders(Compilation compilation)
+        {
+            var ifaceSymbol = compilation.GetTypeByMetadataName(ProviderInterfaceMetadataName);
+            if (ifaceSymbol is null)
+            {
+                // The test compilation does not (yet) reference Zeus.Server.Hosting.
+                // Emit nothing rather than guessing.
+                return ImmutableArray<ProviderModel>.Empty;
+            }
+
+            var results = new List<ProviderModel>();
+            var seenTypeNames = new HashSet<string>();
+
+            foreach (var reference in compilation.SourceModule.ReferencedAssemblySymbols)
+            {
+                foreach (var type in EnumerateNamedTypes(reference.GlobalNamespace))
+                {
+                    if (!IsConcretePublicProvider(type, ifaceSymbol))
+                        continue;
+
+                    // Test-class identifiers are scoped to the generated namespace
+                    // and keyed off the simple type name. Two providers with the
+                    // same simple name in different namespaces would collide; if
+                    // that ever happens, skip the duplicate deterministically so
+                    // the build stays green (the conformance [Theory] still covers
+                    // every instance by Id).
+                    if (!seenTypeNames.Add(type.Name))
+                        continue;
+
+                    results.Add(new ProviderModel(typeName: type.Name));
+                }
+            }
+
+            // Deterministic ordering keeps generated output stable across runs and
+            // platforms (assembly enumeration order is not guaranteed).
+            results.Sort(static (a, b) => string.CompareOrdinal(a.TypeName, b.TypeName));
+            return results.ToImmutableArray();
+        }
+
+        private static IEnumerable<INamedTypeSymbol> EnumerateNamedTypes(INamespaceSymbol ns)
+        {
+            foreach (var member in ns.GetMembers())
+            {
+                if (member is INamespaceSymbol childNs)
+                {
+                    foreach (var nested in EnumerateNamedTypes(childNs))
+                        yield return nested;
+                }
+                else if (member is INamedTypeSymbol type)
+                {
+                    yield return type;
+                    foreach (var nested in EnumerateNestedTypes(type))
+                        yield return nested;
+                }
+            }
+        }
+
+        private static IEnumerable<INamedTypeSymbol> EnumerateNestedTypes(INamedTypeSymbol type)
+        {
+            foreach (var nested in type.GetTypeMembers())
+            {
+                yield return nested;
+                foreach (var deeper in EnumerateNestedTypes(nested))
+                    yield return deeper;
+            }
+        }
+
+        private static bool IsConcretePublicProvider(INamedTypeSymbol type, INamedTypeSymbol iface)
+        {
+            return type.TypeKind == TypeKind.Class
+                && !type.IsAbstract
+                && !type.IsStatic
+                && type.DeclaredAccessibility == Accessibility.Public
+                && !type.IsGenericType
+                && type.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, iface));
+        }
+
+        private static string EmitTestClass(ProviderModel model)
+        {
+            // Identifiers/strings here are all derived from C# symbol names, so they
+            // are already valid C# and safe to interpolate verbatim.
+            var sb = new StringBuilder();
+            sb.Append(
+@"// <auto-generated/>
+#nullable enable
+#pragma warning disable
+//
+// Live Diagnostics API v2 — Layer 2 generated test.
+// Source: Zeus.Diagnostics.TestGen.DiagnosticsTestGenerator.
+// One generated [Fact] suite per IDiagnosticsProvider. Do NOT edit by hand —
+// add your own [Fact]s in a sibling partial-class file instead.
+
+using System.Linq;
+using System.Net;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Zeus.Server.Diagnostics;
+
+namespace Zeus.Server.Tests
+{
+    /// <summary>
+    /// Generated coverage for the <c>");
+            sb.Append(model.TypeName);
+            sb.Append(
+@"</c> diagnostics provider.
+    /// Partial so developers can add their own [Fact]s in a sibling file.
+    /// </summary>
+    public sealed partial class ");
+            sb.Append(model.TypeName);
+            sb.Append(
+@"GeneratedTests
+    {
+        private const string ProviderTypeName = """);
+            sb.Append(model.TypeName);
+            sb.Append(
+@""";
+
+        private sealed class Factory : IsolatedPrefsFactory
+        {
+        }
+
+        private static IDiagnosticsProvider ResolveProvider(DiagnosticsProviderRegistry registry)
+        {
+            var provider = registry.All.FirstOrDefault(p => p.GetType().Name == ProviderTypeName);
+            Assert.True(
+                provider is not null,
+                $""Diagnostics provider '{ProviderTypeName}' was not registered in DI. "" +
+                ""Every concrete IDiagnosticsProvider must be registered so the unified "" +
+                ""v2 surface exposes it."");
+            return provider!;
+        }
+
+        [Fact]
+        public void Provider_IsRegistered_AndSnapshotIsNonNull()
+        {
+            using var factory = new Factory();
+            var registry = factory.Services.GetRequiredService<DiagnosticsProviderRegistry>();
+
+            var provider = ResolveProvider(registry);
+
+            Assert.False(string.IsNullOrWhiteSpace(provider.Id), ""Provider Id must be non-empty."");
+            Assert.False(string.IsNullOrWhiteSpace(provider.RouteSegment), ""Provider RouteSegment must be non-empty."");
+            Assert.NotNull(provider.Snapshot());
+        }
+
+        [Fact]
+        public async Task SnapshotEndpoint_Returns200_WithSchemaVersion()
+        {
+            using var factory = new Factory();
+            using var client = factory.CreateClient();
+            var registry = factory.Services.GetRequiredService<DiagnosticsProviderRegistry>();
+            var provider = ResolveProvider(registry);
+
+            var resp = await client.GetAsync(""/api/diagnostics/v2/"" + provider.RouteSegment);
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            using var body = await JsonDocument.ParseAsync(await resp.Content.ReadAsStreamAsync());
+            Assert.True(
+                body.RootElement.TryGetProperty(""schemaVersion"", out _),
+                ""Diagnostics snapshot JSON must expose a 'schemaVersion' property."");
+        }
+
+        [Fact]
+        public async Task SelfCheckEndpoint_Returns200()
+        {
+            using var factory = new Factory();
+            using var client = factory.CreateClient();
+            var registry = factory.Services.GetRequiredService<DiagnosticsProviderRegistry>();
+            var provider = ResolveProvider(registry);
+
+            var resp = await client.GetAsync(""/api/diagnostics/v2/"" + provider.RouteSegment + ""/selfcheck"");
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        }
+    }
+}
+");
+            return sb.ToString();
+        }
+
+        private readonly struct ProviderModel
+        {
+            public ProviderModel(string typeName)
+            {
+                TypeName = typeName;
+            }
+
+            public string TypeName { get; }
+        }
+    }
+}

--- a/Zeus.Diagnostics.TestGen/Zeus.Diagnostics.TestGen.csproj
+++ b/Zeus.Diagnostics.TestGen/Zeus.Diagnostics.TestGen.csproj
@@ -1,0 +1,47 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Live Diagnostics API v2 — Layer 2 test framework: a Roslyn incremental source
+    generator that emits one named xUnit test class per IDiagnosticsProvider into
+    Zeus.Server.Tests. See DiagnosticsTestGenerator.cs.
+
+    This is a Roslyn ANALYZER and MUST be netstandard2.0. The repo's
+    Directory.Build.props targets net10 features (ImplicitUsings, version stamping)
+    and turns warnings into errors — several of those are inappropriate for a
+    standalone analyzer, so the properties that matter are pinned/neutralized
+    locally below. TreatWarningsAsErrors is kept TRUE on purpose: the analyzer
+    assembly itself stays 100% warning-clean.
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+
+    <!-- Analyzers are never published or packed as a normal library. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IsPackable>false</IsPackable>
+
+    <!-- ImplicitUsings (inherited from Directory.Build.props) pulls in net10
+         implicit using sets that do not exist on netstandard2.0; disable it so
+         the analyzer compiles against the netstandard surface only. -->
+    <ImplicitUsings>disable</ImplicitUsings>
+
+    <!-- Keep warnings-as-errors (inherited) but silence the one warning that is
+         unavoidable for a netstandard2.0 analyzer referencing 4.x Roslyn:
+         NU1701 never applies here, but RS1041 (analyzer should target
+         netstandard2.0 only) is exactly what we already do. No suppressions are
+         needed today; this NoWarn is intentionally empty and left as a documented
+         seam. -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- 4.11.0 matches the version already vendored elsewhere in this repo
+         (tests/Zeus.Plugins.Host.Tests) and is compatible with the .NET 10 SDK
+         (10.0.301) in use. PrivateAssets=all keeps it out of consumer closure. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/Zeus.Server.Hosting/Diagnostics/DiagnosticsFramePublisher.cs
+++ b/Zeus.Server.Hosting/Diagnostics/DiagnosticsFramePublisher.cs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Live Diagnostics API v2 — push publisher.
+//
+// Background service that broadcasts the aggregate diagnostics health frame
+// (MsgType 0x36) over the StreamingHub at a low, fixed rate. Subscriber-gated
+// (skips the tick entirely when no clients are connected) and source-gen
+// serialised so the push path stays allocation-light. Building the health frame
+// runs the providers' self-checks — but only here, on this background thread,
+// never on a request or DSP/realtime thread.
+
+using System.Text.Json;
+using Zeus.Contracts;
+
+namespace Zeus.Server.Diagnostics;
+
+public sealed class DiagnosticsFramePublisher : BackgroundService
+{
+    private static readonly TimeSpan Period = TimeSpan.FromSeconds(1);
+
+    private readonly StreamingHub _hub;
+    private readonly DiagnosticsSelfCheckCache _cache;
+    private readonly ILogger<DiagnosticsFramePublisher> _log;
+
+    public DiagnosticsFramePublisher(
+        StreamingHub hub,
+        DiagnosticsSelfCheckCache cache,
+        ILogger<DiagnosticsFramePublisher> log)
+    {
+        _hub = hub ?? throw new ArgumentNullException(nameof(hub));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _log = log ?? throw new ArgumentNullException(nameof(log));
+    }
+
+    /// <summary>Encodes a DiagnosticsHealth (0x36) frame: [type:1][UTF-8 JSON]. Exposed for tests.</summary>
+    public static byte[] EncodeFrame(DiagnosticsHealthDto health)
+    {
+        var json = JsonSerializer.SerializeToUtf8Bytes(health, DiagnosticsJsonContext.Default.DiagnosticsHealthDto);
+        var frame = new byte[json.Length + 1];
+        frame[0] = (byte)MsgType.DiagnosticsHealth;
+        Buffer.BlockCopy(json, 0, frame, 1, json.Length);
+        return frame;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(Period);
+        try
+        {
+            while (await timer.WaitForNextTickAsync(stoppingToken))
+            {
+                // Subscriber gate: do no work (and run no self-checks) when nobody
+                // is listening. Cheap int read on the hub.
+                if (_hub.ClientCount == 0) continue;
+
+                try
+                {
+                    var frame = EncodeFrame(_cache.BuildHealth());
+                    _hub.BroadcastDiagnostics(frame);
+                }
+                catch (Exception ex)
+                {
+                    // A bad tick must not kill the publisher. Self-check probes are
+                    // already individually guarded; this catches anything else.
+                    _log.LogWarning(ex, "diagnostics frame publish tick failed");
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // normal shutdown
+        }
+    }
+}

--- a/Zeus.Server.Hosting/Diagnostics/DiagnosticsJsonContext.cs
+++ b/Zeus.Server.Hosting/Diagnostics/DiagnosticsJsonContext.cs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Live Diagnostics API v2 — System.Text.Json source-generation context.
+//
+// Performance is the #1 constraint here. The aggregate health frame is pushed
+// over the hub at 1-2 Hz to every connected client, and the index/snapshot
+// endpoints are polled — so the v2 DTOs serialise through fast, pre-generated
+// metadata instead of per-call reflection.
+//
+// This context is INSERTED at the front of the host's TypeInfoResolverChain
+// (see ZeusHost.Build). Types listed here use generated metadata; every other
+// DTO in the app (including the anonymous hardware-diagnostics snapshot and all
+// legacy contracts) falls through to the reflection resolver still in the chain,
+// so nothing else changes. CamelCase + string enums match the existing Web
+// defaults, keeping the wire output byte-identical.
+
+using System.Text.Json.Serialization;
+using Zeus.Contracts;
+
+namespace Zeus.Server.Diagnostics;
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    UseStringEnumConverter = true)]
+// Framework / aggregate DTOs (owned here, pushed + polled hot).
+[JsonSerializable(typeof(DiagnosticsIndexDto))]
+[JsonSerializable(typeof(DiagnosticsProviderInfoDto))]
+[JsonSerializable(typeof(ProviderSelfCheckReportDto))]
+[JsonSerializable(typeof(SelfCheckResultDto))]
+[JsonSerializable(typeof(DiagnosticsHealthDto))]
+// Typed per-provider snapshot DTOs.
+[JsonSerializable(typeof(DspLiveDiagnosticsDto))]
+[JsonSerializable(typeof(DspModernizationEvidenceSnapshotDto))]
+[JsonSerializable(typeof(FrontendAudioPlaybackDiagnosticsDto))]
+public sealed partial class DiagnosticsJsonContext : JsonSerializerContext
+{
+}

--- a/Zeus.Server.Hosting/Diagnostics/DiagnosticsProviderRegistry.cs
+++ b/Zeus.Server.Hosting/Diagnostics/DiagnosticsProviderRegistry.cs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Live Diagnostics API v2 — the provider registry.
+//
+// Built ONCE at startup from every IDiagnosticsProvider registered in DI.
+// Validates id/route-segment uniqueness and non-emptiness in the constructor so
+// a misconfigured provider fails fast at boot rather than at first request.
+// Lookups go through a FrozenDictionary for O(1) access with no per-request
+// reflection or LINQ-over-DI — the request hot path stays allocation-light.
+
+using System.Collections.Frozen;
+using Zeus.Contracts;
+
+namespace Zeus.Server.Diagnostics;
+
+public sealed class DiagnosticsProviderRegistry
+{
+    /// <summary>Base route the v2 surface is mounted at.</summary>
+    public const string BaseRoute = "/api/diagnostics/v2";
+
+    private const int IndexSchemaVersion = 1;
+
+    private readonly FrozenDictionary<string, IDiagnosticsProvider> _byId;
+    private readonly FrozenDictionary<string, IDiagnosticsProvider> _byRoute;
+
+    public DiagnosticsProviderRegistry(IEnumerable<IDiagnosticsProvider> providers)
+    {
+        ArgumentNullException.ThrowIfNull(providers);
+
+        var ordered = providers
+            .OrderBy(static p => p.Id, StringComparer.Ordinal)
+            .ToArray();
+
+        var seenIds = new HashSet<string>(StringComparer.Ordinal);
+        var seenRoutes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var p in ordered)
+        {
+            if (string.IsNullOrWhiteSpace(p.Id))
+                throw new InvalidOperationException(
+                    $"Diagnostics provider {p.GetType().FullName} has an empty Id.");
+            if (string.IsNullOrWhiteSpace(p.RouteSegment))
+                throw new InvalidOperationException(
+                    $"Diagnostics provider '{p.Id}' has an empty RouteSegment.");
+            if (!seenIds.Add(p.Id))
+                throw new InvalidOperationException(
+                    $"Duplicate diagnostics provider Id '{p.Id}'. Provider ids must be unique.");
+            if (!seenRoutes.Add(p.RouteSegment))
+                throw new InvalidOperationException(
+                    $"Duplicate diagnostics provider RouteSegment '{p.RouteSegment}' (id '{p.Id}'). Route segments must be unique.");
+        }
+
+        All = ordered;
+        _byId = ordered.ToFrozenDictionary(static p => p.Id, StringComparer.Ordinal);
+        _byRoute = ordered.ToFrozenDictionary(static p => p.RouteSegment, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Every registered provider, ordered by id. Stable for the process lifetime.</summary>
+    public IReadOnlyList<IDiagnosticsProvider> All { get; }
+
+    /// <summary>O(1) lookup by provider id (stable across renames; used by tests + self-check cache).</summary>
+    public bool TryGet(string id, out IDiagnosticsProvider provider)
+    {
+        if (!string.IsNullOrEmpty(id))
+            return _byId.TryGetValue(id, out provider!);
+        provider = null!;
+        return false;
+    }
+
+    /// <summary>O(1) lookup by URL route segment (what the v2 endpoints bind to).</summary>
+    public bool TryGetByRoute(string routeSegment, out IDiagnosticsProvider provider)
+    {
+        if (!string.IsNullOrEmpty(routeSegment))
+            return _byRoute.TryGetValue(routeSegment, out provider!);
+        provider = null!;
+        return false;
+    }
+
+    /// <summary>
+    /// Builds the provider index (metadata only — cheap, no snapshots taken).
+    /// <paramref name="generatedUtc"/> is injected so callers control the clock
+    /// (and so it stays test-deterministic where needed).
+    /// </summary>
+    public DiagnosticsIndexDto BuildIndex(DateTimeOffset generatedUtc)
+    {
+        var infos = new DiagnosticsProviderInfoDto[All.Count];
+        for (var i = 0; i < All.Count; i++)
+        {
+            var p = All[i];
+            infos[i] = new DiagnosticsProviderInfoDto(
+                SchemaVersion: 1,
+                Id: p.Id,
+                RouteSegment: p.RouteSegment,
+                Category: p.Category,
+                Description: p.Description,
+                ProviderSchemaVersion: p.SchemaVersion,
+                SnapshotUrl: $"{BaseRoute}/{p.RouteSegment}",
+                SelfCheckUrl: $"{BaseRoute}/{p.RouteSegment}/selfcheck",
+                SelfCheckCount: p.SelfChecks.Count);
+        }
+
+        return new DiagnosticsIndexDto(
+            SchemaVersion: IndexSchemaVersion,
+            GeneratedUtc: generatedUtc,
+            ProviderCount: infos.Length,
+            Providers: infos);
+    }
+}

--- a/Zeus.Server.Hosting/Diagnostics/DiagnosticsSelfCheckCache.cs
+++ b/Zeus.Server.Hosting/Diagnostics/DiagnosticsSelfCheckCache.cs
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Live Diagnostics API v2 — self-check runner + cache.
+//
+// Runs each provider's declared probes and caches the report with a short TTL.
+// Every probe delegate is wrapped in try/catch + a wall-clock guard so a single
+// throwing or slow probe degrades to a Fail result (with detail) instead of
+// faulting the endpoint or stalling the publisher. Probes read cached snapshots
+// only — they never run on the DSP/realtime path. The background publisher warms
+// this cache on its timer; pull endpoints return the warm copy (or recompute the
+// cheap snapshot reads under a per-provider lock if the TTL has lapsed).
+
+using System.Diagnostics;
+using Zeus.Contracts;
+
+namespace Zeus.Server.Diagnostics;
+
+public sealed class DiagnosticsSelfCheckCache
+{
+    private const int ReportSchemaVersion = 1;
+    private const int HealthSchemaVersion = 1;
+
+    // A single slow probe should not pin the runner. Self-checks are meant to be
+    // snapshot reads; anything beyond this is treated as a Fail.
+    private static readonly TimeSpan ProbeBudget = TimeSpan.FromSeconds(2);
+
+    private readonly DiagnosticsProviderRegistry _registry;
+    private readonly ILogger<DiagnosticsSelfCheckCache> _log;
+    private readonly TimeSpan _ttl;
+    private readonly Dictionary<string, Entry> _entries;
+
+    public DiagnosticsSelfCheckCache(
+        DiagnosticsProviderRegistry registry,
+        ILogger<DiagnosticsSelfCheckCache> log)
+    {
+        _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+        _log = log ?? throw new ArgumentNullException(nameof(log));
+        _ttl = TimeSpan.FromSeconds(3);
+        _entries = registry.All.ToDictionary(
+            static p => p.Id,
+            static p => new Entry(),
+            StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Returns the self-check report for one provider. Serves the cached copy when
+    /// fresh; otherwise re-runs the (cheap, snapshot-only) probes under a per-provider
+    /// lock so concurrent callers don't stampede. <paramref name="forceRefresh"/> bypasses
+    /// the TTL (POST .../selfcheck).
+    /// </summary>
+    public ProviderSelfCheckReportDto GetReport(string providerId, bool forceRefresh = false)
+    {
+        if (!_registry.TryGet(providerId, out var provider))
+            throw new KeyNotFoundException($"Unknown diagnostics provider '{providerId}'.");
+        return GetReport(provider, forceRefresh);
+    }
+
+    /// <summary>Report for a provider instance (avoids a second registry lookup on the hot path).</summary>
+    public ProviderSelfCheckReportDto GetReport(IDiagnosticsProvider provider, bool forceRefresh = false)
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+        var entry = GetEntry(provider.Id);
+
+        lock (entry.Gate)
+        {
+            var now = DateTimeOffset.UtcNow;
+            if (!forceRefresh
+                && entry.Cached is { } cached
+                && now - entry.GeneratedUtc < _ttl)
+            {
+                return cached;
+            }
+
+            var report = Run(provider, now);
+            entry.Cached = report;
+            entry.GeneratedUtc = now;
+            return report;
+        }
+    }
+
+    /// <summary>
+    /// Aggregate health across every provider — the payload pushed over the hub and
+    /// returned by <c>GET /api/diagnostics/v2/health</c>. Reuses warm per-provider
+    /// reports where possible.
+    /// </summary>
+    public DiagnosticsHealthDto BuildHealth(bool forceRefresh = false)
+    {
+        var providers = _registry.All;
+        var reports = new ProviderSelfCheckReportDto[providers.Count];
+        int pass = 0, warn = 0, fail = 0;
+
+        for (var i = 0; i < providers.Count; i++)
+        {
+            var report = GetReport(providers[i], forceRefresh);
+            reports[i] = report;
+            switch (report.Worst)
+            {
+                case "fail": fail++; break;
+                case "warn": warn++; break;
+                default: pass++; break;
+            }
+        }
+
+        var overall = fail > 0 ? "fail" : warn > 0 ? "warn" : "pass";
+        return new DiagnosticsHealthDto(
+            SchemaVersion: HealthSchemaVersion,
+            GeneratedUtc: DateTimeOffset.UtcNow,
+            Overall: overall,
+            ProviderCount: reports.Length,
+            PassCount: pass,
+            WarnCount: warn,
+            FailCount: fail,
+            Providers: reports);
+    }
+
+    private Entry GetEntry(string id)
+    {
+        // _entries is built once from the frozen registry and never mutated, so
+        // reads are safe without locking the dictionary itself.
+        if (_entries.TryGetValue(id, out var entry))
+            return entry;
+        throw new KeyNotFoundException($"Unknown diagnostics provider '{id}'.");
+    }
+
+    private ProviderSelfCheckReportDto Run(IDiagnosticsProvider provider, DateTimeOffset generatedUtc)
+    {
+        var checks = provider.SelfChecks;
+        var results = new SelfCheckResultDto[checks.Count];
+        var worst = SelfCheckOutcome.Pass;
+
+        for (var i = 0; i < checks.Count; i++)
+        {
+            var check = checks[i];
+            var sw = Stopwatch.StartNew();
+            SelfCheckOutcome outcome;
+            string detail;
+            try
+            {
+                using var cts = new CancellationTokenSource(ProbeBudget);
+                var result = check.Run(cts.Token);
+                outcome = result.Outcome;
+                detail = result.Detail ?? string.Empty;
+            }
+            catch (Exception ex)
+            {
+                // A throwing probe is a failed probe — never a 500. Surface the reason.
+                outcome = SelfCheckOutcome.Fail;
+                detail = $"probe threw: {ex.GetType().Name}: {ex.Message}";
+                _log.LogWarning(ex, "diagnostics self-check '{Provider}/{Check}' threw", provider.Id, check.Id);
+            }
+            sw.Stop();
+
+            if (outcome > worst) worst = outcome;
+            results[i] = new SelfCheckResultDto(
+                SchemaVersion: 1,
+                Id: check.Id,
+                Description: check.Description,
+                Severity: SeverityText(check.Severity),
+                Outcome: OutcomeText(outcome),
+                Detail: detail,
+                RanUtc: generatedUtc,
+                DurationMs: sw.Elapsed.TotalMilliseconds);
+        }
+
+        return new ProviderSelfCheckReportDto(
+            SchemaVersion: ReportSchemaVersion,
+            ProviderId: provider.Id,
+            Worst: OutcomeText(worst),
+            GeneratedUtc: generatedUtc,
+            Checks: results);
+    }
+
+    private static string OutcomeText(SelfCheckOutcome o) => o switch
+    {
+        SelfCheckOutcome.Fail => "fail",
+        SelfCheckOutcome.Warn => "warn",
+        _ => "pass",
+    };
+
+    private static string SeverityText(DiagnosticsSeverity s) => s switch
+    {
+        DiagnosticsSeverity.Error => "error",
+        DiagnosticsSeverity.Warn => "warn",
+        _ => "info",
+    };
+
+    private sealed class Entry
+    {
+        public readonly object Gate = new();
+        public ProviderSelfCheckReportDto? Cached;
+        public DateTimeOffset GeneratedUtc;
+    }
+}

--- a/Zeus.Server.Hosting/Diagnostics/DiagnosticsV2Endpoints.cs
+++ b/Zeus.Server.Hosting/Diagnostics/DiagnosticsV2Endpoints.cs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Live Diagnostics API v2 — registry-driven endpoint surface.
+//
+// One mapping for the whole platform: every registered IDiagnosticsProvider is
+// reachable here without per-feature wiring. Snapshots return object so typed
+// providers resolve through the source-gen context (fast) and anonymous ones
+// fall through to reflection. Self-checks are served from the off-path cache.
+
+namespace Zeus.Server.Diagnostics;
+
+public static class DiagnosticsV2Endpoints
+{
+    /// <summary>Maps the unified <c>/api/diagnostics/v2</c> surface. Called from MapZeusEndpoints.</summary>
+    public static WebApplication MapDiagnosticsV2(this WebApplication app)
+    {
+        const string b = DiagnosticsProviderRegistry.BaseRoute;
+
+        // Provider index — metadata only, no snapshots taken.
+        app.MapGet(b, (DiagnosticsProviderRegistry registry) =>
+            Results.Ok(registry.BuildIndex(DateTimeOffset.UtcNow)));
+
+        // Aggregate health (worst-of across providers). Literal route beats the
+        // {segment} param in ASP.NET routing, so this never collides below.
+        app.MapGet($"{b}/health", (DiagnosticsSelfCheckCache cache) =>
+            Results.Ok(cache.BuildHealth()));
+
+        // Single provider snapshot.
+        app.MapGet($"{b}/{{segment}}", (string segment, DiagnosticsProviderRegistry registry) =>
+            registry.TryGetByRoute(segment, out var provider)
+                ? Results.Ok(provider.Snapshot())
+                : Results.NotFound(new { error = "unknown-diagnostics-provider", segment }));
+
+        // Cached self-check report for one provider.
+        app.MapGet($"{b}/{{segment}}/selfcheck", (string segment, DiagnosticsProviderRegistry registry, DiagnosticsSelfCheckCache cache) =>
+            registry.TryGetByRoute(segment, out var provider)
+                ? Results.Ok(cache.GetReport(provider, forceRefresh: false))
+                : Results.NotFound(new { error = "unknown-diagnostics-provider", segment }));
+
+        // Force a fresh self-check run for one provider (still off the realtime path).
+        app.MapPost($"{b}/{{segment}}/selfcheck", (string segment, DiagnosticsProviderRegistry registry, DiagnosticsSelfCheckCache cache) =>
+            registry.TryGetByRoute(segment, out var provider)
+                ? Results.Ok(cache.GetReport(provider, forceRefresh: true))
+                : Results.NotFound(new { error = "unknown-diagnostics-provider", segment }));
+
+        return app;
+    }
+}

--- a/Zeus.Server.Hosting/Diagnostics/DiagnosticsV2Endpoints.cs
+++ b/Zeus.Server.Hosting/Diagnostics/DiagnosticsV2Endpoints.cs
@@ -25,10 +25,14 @@ public static class DiagnosticsV2Endpoints
         app.MapGet($"{b}/health", (DiagnosticsSelfCheckCache cache) =>
             Results.Ok(cache.BuildHealth()));
 
-        // Single provider snapshot.
+        // Single provider snapshot, wrapped in a uniform self-describing
+        // envelope so EVERY v2 response carries the same metadata (id, category,
+        // schemaVersion, timestamp) regardless of what the underlying provider
+        // returns. The raw provider payload sits under `snapshot`. Legacy routes
+        // are untouched and still return the bare payload for wire compat.
         app.MapGet($"{b}/{{segment}}", (string segment, DiagnosticsProviderRegistry registry) =>
             registry.TryGetByRoute(segment, out var provider)
-                ? Results.Ok(provider.Snapshot())
+                ? Results.Ok(Envelope(provider))
                 : Results.NotFound(new { error = "unknown-diagnostics-provider", segment }));
 
         // Cached self-check report for one provider.
@@ -45,4 +49,19 @@ public static class DiagnosticsV2Endpoints
 
         return app;
     }
+
+    // Uniform envelope around any provider snapshot. Anonymous object →
+    // reflection-serialised; the nested `snapshot` still resolves to the
+    // provider's runtime type (source-gen for typed DTOs) via the resolver chain.
+    private static object Envelope(IDiagnosticsProvider provider) => new
+    {
+        schemaVersion = 1,
+        id = provider.Id,
+        routeSegment = provider.RouteSegment,
+        category = provider.Category,
+        description = provider.Description,
+        providerSchemaVersion = provider.SchemaVersion,
+        generatedUtc = DateTimeOffset.UtcNow,
+        snapshot = provider.Snapshot(),
+    };
 }

--- a/Zeus.Server.Hosting/Diagnostics/IDiagnosticsProvider.cs
+++ b/Zeus.Server.Hosting/Diagnostics/IDiagnosticsProvider.cs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Live Diagnostics API v2 — the provider contract.
+//
+// A diagnostics provider is the single seam a feature implements to join the
+// unified diagnostics surface. Implement it, register it in DI as
+// IDiagnosticsProvider, and the feature automatically gets:
+//   * a pull endpoint  (GET /api/diagnostics/v2/{id})
+//   * a self-check endpoint (GET/POST /api/diagnostics/v2/{id}/selfcheck)
+//   * inclusion in the aggregate index + health + live push frame
+//   * autonomous test coverage via the conformance harness + source generator
+//
+// Snapshot() returns object (not a generic DTO) on purpose: several existing
+// diagnostics surfaces (e.g. HardwareDiagnosticsService) return anonymous
+// types that must serialise verbatim for wire compatibility. Typed providers
+// register their DTO with DiagnosticsJsonContext for source-gen serialisation;
+// untyped (anonymous) snapshots fall through to the reflection resolver. Both
+// paths are camelCase + string-enum identical on the wire.
+
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>Severity attached to a declared self-check (how bad a failure is).</summary>
+public enum DiagnosticsSeverity
+{
+    Info,
+    Warn,
+    Error,
+}
+
+/// <summary>Outcome of running a single self-check probe.</summary>
+public enum SelfCheckOutcome
+{
+    Pass,
+    Warn,
+    Fail,
+}
+
+/// <summary>
+/// Result of running one <see cref="DiagnosticsSelfCheck"/>. Cheap, allocation-light
+/// record returned by the probe delegate. <paramref name="RanUtc"/> is stamped by
+/// the runner so callers can reason about staleness.
+/// </summary>
+public sealed record SelfCheckResult(
+    SelfCheckOutcome Outcome,
+    string Detail,
+    DateTimeOffset RanUtc);
+
+/// <summary>
+/// A declared probe: pure metadata (<paramref name="Id"/>, <paramref name="Description"/>,
+/// <paramref name="Severity"/>) plus a delegate-as-data (<paramref name="Run"/>) that the
+/// off-path runner invokes. The delegate must be cheap and read snapshots only — it runs
+/// on a background timer, never on the realtime/request thread, and must not touch the DSP
+/// or TX hot path.
+/// </summary>
+public sealed record DiagnosticsSelfCheck(
+    string Id,
+    string Description,
+    DiagnosticsSeverity Severity,
+    Func<CancellationToken, SelfCheckResult> Run);
+
+/// <summary>
+/// The one interface a feature implements to expose live diagnostics. Implementations
+/// MUST be cheap, read-only snapshot producers — no DSP work, no blocking I/O on the
+/// request path. Register as <c>IDiagnosticsProvider</c> in DI; the
+/// <see cref="DiagnosticsProviderRegistry"/> picks every registration up once at startup.
+/// </summary>
+public interface IDiagnosticsProvider
+{
+    /// <summary>Stable, unique, kebab/dotted id, e.g. <c>"dsp.live"</c>. Used in URLs and tests.</summary>
+    string Id { get; }
+
+    /// <summary>Unique URL-safe path segment, e.g. <c>"dsp-live"</c>. Distinct from <see cref="Id"/>
+    /// so the wire route can stay clean while the id stays stable across renames.</summary>
+    string RouteSegment { get; }
+
+    /// <summary>Coarse grouping for the index, e.g. <c>"dsp"</c>, <c>"hardware"</c>, <c>"frontend"</c>.</summary>
+    string Category { get; }
+
+    /// <summary>Schema version of the snapshot DTO this provider returns.</summary>
+    int SchemaVersion { get; }
+
+    /// <summary>Human-readable one-liner describing what this provider reports.</summary>
+    string Description { get; }
+
+    /// <summary>
+    /// Produces the current snapshot. Returns <see cref="object"/> so providers can keep
+    /// returning their existing (sometimes anonymous) DTOs verbatim. Must be allocation-light
+    /// and free of realtime/DSP work — read cached state only.
+    /// </summary>
+    object Snapshot();
+
+    /// <summary>The probes this provider declares. May be empty. Run off the request path by
+    /// <see cref="DiagnosticsSelfCheckCache"/>.</summary>
+    IReadOnlyList<DiagnosticsSelfCheck> SelfChecks { get; }
+}

--- a/Zeus.Server.Hosting/Diagnostics/Providers/CoreServiceProviders.cs
+++ b/Zeus.Server.Hosting/Diagnostics/Providers/CoreServiceProviders.cs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// v2 providers that wrap existing read-only service snapshots verbatim — zero
+// behaviour change. Each surfaces an already-public Snapshot()/diagnostics
+// method on the unified diagnostics surface so an operator can read live state
+// for that subsystem (and the conformance harness auto-tests it).
+
+using Zeus.Protocol2;
+
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>Websocket hub health: client/subscriber counts + frame-drop counters.</summary>
+public sealed class StreamingHubProvider : IDiagnosticsProvider
+{
+    private readonly StreamingHub _hub;
+    public StreamingHubProvider(StreamingHub hub) => _hub = hub ?? throw new ArgumentNullException(nameof(hub));
+
+    public string Id => "streaming.hub";
+    public string RouteSegment => "streaming-hub";
+    public string Category => "streaming";
+    public int SchemaVersion => 1;
+    public string Description => "Websocket streaming hub: connected clients, subscribers, and frame-drop counters.";
+
+    public object Snapshot() => _hub.DiagnosticsSnapshot();
+
+    public IReadOnlyList<DiagnosticsSelfCheck> SelfChecks => new[]
+    {
+        new DiagnosticsSelfCheck("hub-snapshot-available",
+            "Streaming hub snapshot builds.", DiagnosticsSeverity.Info,
+            _ => DiagnosticsProbe.NonNull(_hub.DiagnosticsSnapshot(), "streaming hub")),
+    };
+}
+
+/// <summary>Current radio state (the /api/state payload).</summary>
+public sealed class RadioStateProvider : IDiagnosticsProvider
+{
+    private readonly RadioService _radio;
+    public RadioStateProvider(RadioService radio) => _radio = radio ?? throw new ArgumentNullException(nameof(radio));
+
+    public string Id => "radio.state";
+    public string RouteSegment => "radio-state";
+    public string Category => "radio";
+    public int SchemaVersion => 1;
+    public string Description => "Live radio state: VFO, mode, filter, sample rate, TX/RX posture.";
+
+    public object Snapshot() => _radio.Snapshot();
+
+    public IReadOnlyList<DiagnosticsSelfCheck> SelfChecks => new[]
+    {
+        new DiagnosticsSelfCheck("state-snapshot-available",
+            "Radio state snapshot builds.", DiagnosticsSeverity.Info,
+            _ => DiagnosticsProbe.NonNull(_radio.Snapshot(), "radio state")),
+    };
+}
+
+/// <summary>Board/feature capability fingerprint (the /api/capabilities payload).</summary>
+public sealed class RadioCapabilitiesProvider : IDiagnosticsProvider
+{
+    private readonly CapabilitiesService _caps;
+    public RadioCapabilitiesProvider(CapabilitiesService caps) => _caps = caps ?? throw new ArgumentNullException(nameof(caps));
+
+    public string Id => "radio.capabilities";
+    public string RouteSegment => "radio-capabilities";
+    public string Category => "radio";
+    public int SchemaVersion => 1;
+    public string Description => "Board type, radio type, feature flags, and host mode.";
+
+    public object Snapshot() => _caps.Snapshot();
+
+    public IReadOnlyList<DiagnosticsSelfCheck> SelfChecks => new[]
+    {
+        new DiagnosticsSelfCheck("capabilities-snapshot-available",
+            "Capabilities snapshot builds.", DiagnosticsSeverity.Info,
+            _ => DiagnosticsProbe.NonNull(_caps.Snapshot(), "capabilities")),
+    };
+}
+
+/// <summary>HamClock sidecar integration status.</summary>
+public sealed class HamClockProvider : IDiagnosticsProvider
+{
+    private readonly HamClockService _hamClock;
+    public HamClockProvider(HamClockService hamClock) => _hamClock = hamClock ?? throw new ArgumentNullException(nameof(hamClock));
+
+    public string Id => "integration.hamclock";
+    public string RouteSegment => "integration-hamclock";
+    public string Category => "integration";
+    public int SchemaVersion => 1;
+    public string Description => "HamClock sidecar install/process status and Node availability.";
+
+    public object Snapshot() => _hamClock.Snapshot();
+
+    public IReadOnlyList<DiagnosticsSelfCheck> SelfChecks => new[]
+    {
+        new DiagnosticsSelfCheck("hamclock-snapshot-available",
+            "HamClock status snapshot builds.", DiagnosticsSeverity.Info,
+            _ => DiagnosticsProbe.NonNull(_hamClock.Snapshot(), "hamclock")),
+    };
+}
+
+/// <summary>External PTT / serial keying line state.</summary>
+public sealed class ExternalPttProvider : IDiagnosticsProvider
+{
+    private readonly ExternalPttService _externalPtt;
+    public ExternalPttProvider(ExternalPttService externalPtt) => _externalPtt = externalPtt ?? throw new ArgumentNullException(nameof(externalPtt));
+
+    public string Id => "external-ptt.serial";
+    public string RouteSegment => "external-ptt";
+    public string Category => "hardware";
+    public int SchemaVersion => 1;
+    public string Description => "External PTT serial line: port state, CTS/RTS levels, last edge.";
+
+    public object Snapshot() => _externalPtt.Snapshot();
+
+    public IReadOnlyList<DiagnosticsSelfCheck> SelfChecks => new[]
+    {
+        new DiagnosticsSelfCheck("external-ptt-snapshot-available",
+            "External PTT snapshot builds.", DiagnosticsSeverity.Info,
+            _ => DiagnosticsProbe.NonNull(_externalPtt.Snapshot(), "external ptt")),
+    };
+}
+
+/// <summary>Protocol-2 TX IQ path health (when a P2 radio is connected).</summary>
+public sealed class Protocol2TxIqProvider : IDiagnosticsProvider
+{
+    private readonly DspPipelineService _dsp;
+    public Protocol2TxIqProvider(DspPipelineService dsp) => _dsp = dsp ?? throw new ArgumentNullException(nameof(dsp));
+
+    public string Id => "protocol2.tx-iq";
+    public string RouteSegment => "protocol2-tx-iq";
+    public string Category => "protocol";
+    public int SchemaVersion => 1;
+    public string Description => "Protocol-2 TX IQ queue health: queued packets, send failures, drain resets.";
+
+    public object Snapshot()
+    {
+        Protocol2Client? p2 = _dsp.ActiveP2Client;
+        object? diag = p2?.TxIqDiagnosticsSnapshot();
+        return diag is not null
+            ? new { schemaVersion = 1, available = true, txIq = diag }
+            : new { schemaVersion = 1, available = false, reason = "no-active-protocol2-client" };
+    }
+
+    public IReadOnlyList<DiagnosticsSelfCheck> SelfChecks => new[]
+    {
+        new DiagnosticsSelfCheck("protocol2-active",
+            "A Protocol-2 client is connected.", DiagnosticsSeverity.Info,
+            _ => _dsp.ActiveP2Client is not null
+                ? new SelfCheckResult(SelfCheckOutcome.Pass, "Protocol-2 client active.", DateTimeOffset.UtcNow)
+                : new SelfCheckResult(SelfCheckOutcome.Warn, "No active Protocol-2 client (idle or P1).", DateTimeOffset.UtcNow)),
+    };
+}
+
+/// <summary>Small shared helpers for provider self-checks.</summary>
+internal static class DiagnosticsProbe
+{
+    public static SelfCheckResult NonNull(object? value, string what) =>
+        value is not null
+            ? new SelfCheckResult(SelfCheckOutcome.Pass, $"{what} snapshot available.", DateTimeOffset.UtcNow)
+            : new SelfCheckResult(SelfCheckOutcome.Fail, $"{what} snapshot returned null.", DateTimeOffset.UtcNow);
+}

--- a/Zeus.Server.Hosting/Diagnostics/Providers/CoreServiceProviders.cs
+++ b/Zeus.Server.Hosting/Diagnostics/Providers/CoreServiceProviders.cs
@@ -5,6 +5,7 @@
 // method on the unified diagnostics surface so an operator can read live state
 // for that subsystem (and the conformance harness auto-tests it).
 
+using Zeus.Dsp.Wdsp;
 using Zeus.Protocol2;
 
 namespace Zeus.Server.Diagnostics;
@@ -147,6 +148,34 @@ public sealed class Protocol2TxIqProvider : IDiagnosticsProvider
             _ => _dsp.ActiveP2Client is not null
                 ? new SelfCheckResult(SelfCheckOutcome.Pass, "Protocol-2 client active.", DateTimeOffset.UtcNow)
                 : new SelfCheckResult(SelfCheckOutcome.Warn, "No active Protocol-2 client (idle or P1).", DateTimeOffset.UtcNow)),
+    };
+}
+
+/// <summary>DSP pipeline runtime: WDSP channel lifecycle, wisdom/FFT plan state, engine rates.</summary>
+public sealed class DspPipelineProvider : IDiagnosticsProvider
+{
+    private readonly DspPipelineService _dsp;
+    private readonly WdspWisdomInitializer _wisdom;
+
+    public DspPipelineProvider(DspPipelineService dsp, WdspWisdomInitializer wisdom)
+    {
+        _dsp = dsp ?? throw new ArgumentNullException(nameof(dsp));
+        _wisdom = wisdom ?? throw new ArgumentNullException(nameof(wisdom));
+    }
+
+    public string Id => "dsp.pipeline";
+    public string RouteSegment => "dsp-pipeline";
+    public string Category => "dsp";
+    public int SchemaVersion => 1;
+    public string Description => "DSP pipeline runtime: WDSP channels, wisdom/FFT plan state, engine status.";
+
+    public object Snapshot() => _dsp.SnapshotDiagnostics(_wisdom);
+
+    public IReadOnlyList<DiagnosticsSelfCheck> SelfChecks => new[]
+    {
+        new DiagnosticsSelfCheck("dsp-snapshot-available",
+            "DSP pipeline diagnostics snapshot builds.", DiagnosticsSeverity.Info,
+            _ => DiagnosticsProbe.NonNull(_dsp.SnapshotDiagnostics(_wisdom), "dsp pipeline")),
     };
 }
 

--- a/Zeus.Server.Hosting/Diagnostics/Providers/DspLiveDiagnosticsProvider.cs
+++ b/Zeus.Server.Hosting/Diagnostics/Providers/DspLiveDiagnosticsProvider.cs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// v2 provider wrapping the existing DSP modernization scorecard. Reproduces the
+// exact body of the legacy GET /api/dsp/live-diagnostics lambda so the unified
+// surface and the legacy route return byte-identical JSON. No behaviour change.
+
+using Zeus.Contracts;
+
+namespace Zeus.Server.Diagnostics;
+
+public sealed class DspLiveDiagnosticsProvider : IDiagnosticsProvider
+{
+    private readonly FrontendDspSceneDiagnosticsService _scene;
+    private readonly DspPipelineService _dsp;
+    private readonly RadioService _radio;
+
+    public DspLiveDiagnosticsProvider(
+        FrontendDspSceneDiagnosticsService scene,
+        DspPipelineService dsp,
+        RadioService radio)
+    {
+        _scene = scene ?? throw new ArgumentNullException(nameof(scene));
+        _dsp = dsp ?? throw new ArgumentNullException(nameof(dsp));
+        _radio = radio ?? throw new ArgumentNullException(nameof(radio));
+    }
+
+    public string Id => "dsp.live";
+    public string RouteSegment => "dsp-live";
+    public string Category => "dsp";
+    public int SchemaVersion => 1;
+    public string Description => "Live WDSP/Smart-NR modernization readiness scorecard.";
+
+    public object Snapshot() => Build();
+
+    public IReadOnlyList<DiagnosticsSelfCheck> SelfChecks => new[]
+    {
+        new DiagnosticsSelfCheck("wdsp-native-loadable",
+            "WDSP native library is loadable.", DiagnosticsSeverity.Error,
+            _ => Build() is { WdspNativeLoadable: true }
+                ? Pass("WDSP native is loadable.")
+                : Fail("WDSP native is not loadable; fix native packaging before judging DSP quality.")),
+
+        new DiagnosticsSelfCheck("wdsp-active",
+            "WDSP is the active DSP engine.", DiagnosticsSeverity.Warn,
+            _ => Build() is { WdspActive: true }
+                ? Pass("WDSP is active.")
+                : Warn("WDSP is not active; connect the radio or restart the DSP engine for live telemetry.")),
+
+        new DiagnosticsSelfCheck("frontend-scene-fresh",
+            "Frontend DSP scene evidence is present and fresh.", DiagnosticsSeverity.Warn,
+            _ =>
+            {
+                var dto = Build();
+                if (!dto.FrontendSceneAvailable)
+                    return Warn("No frontend DSP scene yet; open Signal Intelligence / Smart NR.");
+                return dto.FrontendSceneFresh
+                    ? Pass("Frontend scene is fresh.")
+                    : Warn("Frontend scene is stale; refresh or reconnect the client.");
+            }),
+
+        new DiagnosticsSelfCheck("smart-nr-runtime-aligned",
+            "Smart NR runtime is aligned with the requested profile.", DiagnosticsSeverity.Warn,
+            _ => Build().RuntimeAligned == false
+                ? Warn("Smart NR runtime is not aligned; reapply or inspect the DSP apply path.")
+                : Pass("Smart NR runtime alignment is OK or not applicable.")),
+    };
+
+    private DspLiveDiagnosticsDto Build()
+    {
+        var state = _radio.Snapshot();
+        var condition = _scene.SmartNrCondition(
+            _dsp.SnapshotNrRuntime(),
+            ZeusEndpoints.BuildSmartNrRxChainRuntime(state, _radio.GetAdcProtectionStatus()));
+        return DspLiveDiagnosticsService.Build(condition, _dsp.SnapshotLiveRuntimeEvidence(), state);
+    }
+
+    private static SelfCheckResult Pass(string detail) =>
+        new(SelfCheckOutcome.Pass, detail, DateTimeOffset.UtcNow);
+
+    private static SelfCheckResult Warn(string detail) =>
+        new(SelfCheckOutcome.Warn, detail, DateTimeOffset.UtcNow);
+
+    private static SelfCheckResult Fail(string detail) =>
+        new(SelfCheckOutcome.Fail, detail, DateTimeOffset.UtcNow);
+}

--- a/Zeus.Server.Hosting/Diagnostics/Providers/DspModernizationProvider.cs
+++ b/Zeus.Server.Hosting/Diagnostics/Providers/DspModernizationProvider.cs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// v2 provider wrapping the DSP modernization evidence bundle. Reproduces the
+// legacy GET /api/dsp/modernization-snapshot lambda verbatim.
+
+using Zeus.Contracts;
+
+namespace Zeus.Server.Diagnostics;
+
+public sealed class DspModernizationProvider : IDiagnosticsProvider
+{
+    private readonly FrontendDspSceneDiagnosticsService _scene;
+    private readonly DspPipelineService _dsp;
+    private readonly RadioService _radio;
+
+    public DspModernizationProvider(
+        FrontendDspSceneDiagnosticsService scene,
+        DspPipelineService dsp,
+        RadioService radio)
+    {
+        _scene = scene ?? throw new ArgumentNullException(nameof(scene));
+        _dsp = dsp ?? throw new ArgumentNullException(nameof(dsp));
+        _radio = radio ?? throw new ArgumentNullException(nameof(radio));
+    }
+
+    public string Id => "dsp.modernization";
+    public string RouteSegment => "dsp-modernization";
+    public string Category => "dsp";
+    public int SchemaVersion => 1;
+    public string Description => "Read-only WDSP modernization evidence bundle for capture tooling.";
+
+    public object Snapshot() => Build();
+
+    public IReadOnlyList<DiagnosticsSelfCheck> SelfChecks => new[]
+    {
+        new DiagnosticsSelfCheck("evidence-completeness",
+            "Modernization evidence completeness score.", DiagnosticsSeverity.Info,
+            _ =>
+            {
+                var dto = Build();
+                var detail = $"completeness={dto.EvidenceCompletenessScore} status={dto.Status}";
+                return dto.EvidenceCompletenessScore >= 75
+                    ? new SelfCheckResult(SelfCheckOutcome.Pass, detail, DateTimeOffset.UtcNow)
+                    : new SelfCheckResult(SelfCheckOutcome.Warn, detail, DateTimeOffset.UtcNow);
+            }),
+    };
+
+    private DspModernizationEvidenceSnapshotDto Build()
+    {
+        var state = _radio.Snapshot();
+        var condition = _scene.SmartNrCondition(
+            _dsp.SnapshotNrRuntime(),
+            ZeusEndpoints.BuildSmartNrRxChainRuntime(state, _radio.GetAdcProtectionStatus()));
+        var live = DspLiveDiagnosticsService.Build(condition, _dsp.SnapshotLiveRuntimeEvidence(), state);
+        var plan = DspBenchmarkPlanCatalog.Build();
+        var manifest = DspBenchmarkCaptureManifestService.Build(live, plan);
+        return DspModernizationEvidenceSnapshotService.Build(
+            condition, live, plan, manifest, DspExternalEngineCandidateCatalog.All());
+    }
+}

--- a/Zeus.Server.Hosting/Diagnostics/Providers/FrontendAudioPlaybackProvider.cs
+++ b/Zeus.Server.Hosting/Diagnostics/Providers/FrontendAudioPlaybackProvider.cs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// v2 provider wrapping the frontend RX audio-playback health snapshot. Returns
+// the same typed DTO as the legacy GET /api/radio/diagnostics/audio-playback
+// route (registered with the source-gen JSON context).
+
+namespace Zeus.Server.Diagnostics;
+
+public sealed class FrontendAudioPlaybackProvider : IDiagnosticsProvider
+{
+    private readonly FrontendAudioPlaybackDiagnosticsService _playback;
+
+    public FrontendAudioPlaybackProvider(FrontendAudioPlaybackDiagnosticsService playback)
+    {
+        _playback = playback ?? throw new ArgumentNullException(nameof(playback));
+    }
+
+    public string Id => "frontend.audio-playback";
+    public string RouteSegment => "frontend-audio-playback";
+    public string Category => "frontend";
+    public int SchemaVersion => 1;
+    public string Description => "Frontend RX audio playback health (buffering, underruns, dropouts).";
+
+    public object Snapshot() => _playback.Snapshot();
+
+    public IReadOnlyList<DiagnosticsSelfCheck> SelfChecks => new[]
+    {
+        new DiagnosticsSelfCheck("playback-published",
+            "A frontend client has published RX playback diagnostics.", DiagnosticsSeverity.Info,
+            _ => _playback.Snapshot().Available
+                ? new SelfCheckResult(SelfCheckOutcome.Pass, "Frontend playback diagnostics present.", DateTimeOffset.UtcNow)
+                : new SelfCheckResult(SelfCheckOutcome.Warn, "No frontend playback diagnostics published yet.", DateTimeOffset.UtcNow)),
+
+        new DiagnosticsSelfCheck("playback-fresh",
+            "Frontend RX playback diagnostics are not stale.", DiagnosticsSeverity.Warn,
+            _ =>
+            {
+                var dto = _playback.Snapshot();
+                if (!dto.Available)
+                    return new SelfCheckResult(SelfCheckOutcome.Warn, "No playback diagnostics to evaluate.", DateTimeOffset.UtcNow);
+                return dto.Stale
+                    ? new SelfCheckResult(SelfCheckOutcome.Warn, "Frontend playback diagnostics are stale.", DateTimeOffset.UtcNow)
+                    : new SelfCheckResult(SelfCheckOutcome.Pass, $"Playback status '{dto.Status}'.", DateTimeOffset.UtcNow);
+            }),
+
+        new DiagnosticsSelfCheck("playback-no-dropouts",
+            "No reported underruns or dropped scheduled samples.", DiagnosticsSeverity.Warn,
+            _ =>
+            {
+                var dto = _playback.Snapshot();
+                if (!dto.Available)
+                    return new SelfCheckResult(SelfCheckOutcome.Pass, "No playback diagnostics to evaluate.", DateTimeOffset.UtcNow);
+                return dto.UnderrunCount > 0 || dto.DroppedSamples > 0
+                    ? new SelfCheckResult(SelfCheckOutcome.Warn,
+                        $"underruns={dto.UnderrunCount} dropped={dto.DroppedSamples}", DateTimeOffset.UtcNow)
+                    : new SelfCheckResult(SelfCheckOutcome.Pass, "No underruns or dropped samples.", DateTimeOffset.UtcNow);
+            }),
+    };
+}

--- a/Zeus.Server.Hosting/Diagnostics/Providers/FrontendDspSceneProvider.cs
+++ b/Zeus.Server.Hosting/Diagnostics/Providers/FrontendDspSceneProvider.cs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// v2 provider wrapping the frontend-published DSP scene snapshot. Snapshot()
+// returns the same object the legacy GET /api/radio/diagnostics/dsp-scene route
+// returns (anonymous when present), so it serialises via the reflection resolver.
+
+namespace Zeus.Server.Diagnostics;
+
+public sealed class FrontendDspSceneProvider : IDiagnosticsProvider
+{
+    private readonly FrontendDspSceneDiagnosticsService _scene;
+
+    public FrontendDspSceneProvider(FrontendDspSceneDiagnosticsService scene)
+    {
+        _scene = scene ?? throw new ArgumentNullException(nameof(scene));
+    }
+
+    public string Id => "frontend.dsp-scene";
+    public string RouteSegment => "frontend-dsp-scene";
+    public string Category => "frontend";
+    public int SchemaVersion => 1;
+    public string Description => "Frontend-published spectrum/Smart-NR scene evidence (client-originated).";
+
+    public object Snapshot() => _scene.Snapshot();
+
+    public IReadOnlyList<DiagnosticsSelfCheck> SelfChecks => new[]
+    {
+        new DiagnosticsSelfCheck("snapshot-available",
+            "Frontend DSP scene snapshot builds without error.", DiagnosticsSeverity.Info,
+            _ => _scene.Snapshot() is not null
+                ? new SelfCheckResult(SelfCheckOutcome.Pass, "Frontend scene snapshot is available.", DateTimeOffset.UtcNow)
+                : new SelfCheckResult(SelfCheckOutcome.Fail, "Frontend scene snapshot returned null.", DateTimeOffset.UtcNow)),
+    };
+}

--- a/Zeus.Server.Hosting/Diagnostics/Providers/HardwareDiagnosticsProvider.cs
+++ b/Zeus.Server.Hosting/Diagnostics/Providers/HardwareDiagnosticsProvider.cs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// v2 provider wrapping the live hardware diagnostic snapshot. The underlying
+// Snapshot() returns an anonymous object (rich discovery/state/telemetry tree)
+// that must serialise verbatim for wire compatibility, so this provider returns
+// it unchanged — it falls through to the reflection JSON resolver (not the
+// source-gen context). Strictly read-only; touches no PureSignal arm state.
+
+namespace Zeus.Server.Diagnostics;
+
+public sealed class HardwareDiagnosticsProvider : IDiagnosticsProvider
+{
+    private readonly HardwareDiagnosticsService _diag;
+
+    public HardwareDiagnosticsProvider(HardwareDiagnosticsService diag)
+    {
+        _diag = diag ?? throw new ArgumentNullException(nameof(diag));
+    }
+
+    public string Id => "hardware.diagnostics";
+    public string RouteSegment => "hardware";
+    public string Category => "hardware";
+    public int SchemaVersion => 1;
+    public string Description => "Live hardware discovery, capabilities, and decoded P1/P2 wire telemetry.";
+
+    public object Snapshot() => _diag.Snapshot();
+
+    public IReadOnlyList<DiagnosticsSelfCheck> SelfChecks => new[]
+    {
+        new DiagnosticsSelfCheck("snapshot-available",
+            "Hardware diagnostics snapshot builds without error.", DiagnosticsSeverity.Error,
+            _ => _diag.Snapshot() is not null
+                ? new SelfCheckResult(SelfCheckOutcome.Pass, "Hardware snapshot is available.", DateTimeOffset.UtcNow)
+                : new SelfCheckResult(SelfCheckOutcome.Fail, "Hardware snapshot returned null.", DateTimeOffset.UtcNow)),
+    };
+}

--- a/Zeus.Server.Hosting/Diagnostics/Providers/PlatformDiagnosticsProvider.cs
+++ b/Zeus.Server.Hosting/Diagnostics/Providers/PlatformDiagnosticsProvider.cs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// v2 provider exposing the host platform/runtime fingerprint and WDSP native
+// load state. This is the "what am I running on, and did the native DSP load
+// here?" provider — the first thing to check when debugging an
+// architecture-specific issue (macOS/Windows/Linux, x64/arm64, Raspberry Pi).
+// Pure read-only reflection over RuntimeInformation + the WDSP static probes.
+
+using System.Runtime.InteropServices;
+using Zeus.Dsp.Wdsp;
+
+namespace Zeus.Server.Diagnostics;
+
+public sealed class PlatformDiagnosticsProvider : IDiagnosticsProvider
+{
+    public string Id => "system.platform";
+    public string RouteSegment => "platform";
+    public string Category => "system";
+    public int SchemaVersion => 1;
+    public string Description => "Host OS/architecture/runtime fingerprint and WDSP native load state.";
+
+    public object Snapshot()
+    {
+        bool wdspLoadable = SafeProbe(() => WdspDspEngine.NativeLibraryLoadable);
+        return new
+        {
+            schemaVersion = 1,
+            generatedUtc = DateTimeOffset.UtcNow,
+            os = new
+            {
+                description = RuntimeInformation.OSDescription,
+                platform = OsPlatformName(),
+                isWindows = OperatingSystem.IsWindows(),
+                isMacOS = OperatingSystem.IsMacOS(),
+                isLinux = OperatingSystem.IsLinux(),
+                architecture = RuntimeInformation.OSArchitecture.ToString(),
+            },
+            process = new
+            {
+                architecture = RuntimeInformation.ProcessArchitecture.ToString(),
+                is64Bit = Environment.Is64BitProcess,
+                processorCount = Environment.ProcessorCount,
+                pid = Environment.ProcessId,
+                workingSetMb = Math.Round(Environment.WorkingSet / (1024.0 * 1024.0), 1),
+                gcHeapMb = Math.Round(GC.GetTotalMemory(false) / (1024.0 * 1024.0), 1),
+                uptimeMs = Environment.TickCount64,
+            },
+            runtime = new
+            {
+                framework = RuntimeInformation.FrameworkDescription,
+                runtimeIdentifier = RuntimeInformation.RuntimeIdentifier,
+                dotnetVersion = Environment.Version.ToString(),
+            },
+            wdsp = new
+            {
+                nativeLoadable = wdspLoadable,
+                emnrPost2Available = wdspLoadable && SafeProbe(() => WdspDspEngine.EmnrPost2Available),
+                nr4SbnrAvailable = wdspLoadable && SafeProbe(() => WdspDspEngine.Nr4SbnrAvailable),
+            },
+        };
+    }
+
+    public IReadOnlyList<DiagnosticsSelfCheck> SelfChecks => new[]
+    {
+        new DiagnosticsSelfCheck("wdsp-native-loadable",
+            "WDSP native library loads on this platform/architecture.", DiagnosticsSeverity.Warn,
+            _ => SafeProbe(() => WdspDspEngine.NativeLibraryLoadable)
+                ? new SelfCheckResult(SelfCheckOutcome.Pass,
+                    $"WDSP native loaded ({RuntimeInformation.RuntimeIdentifier}).", DateTimeOffset.UtcNow)
+                : new SelfCheckResult(SelfCheckOutcome.Warn,
+                    $"WDSP native NOT loadable on {RuntimeInformation.RuntimeIdentifier}; DSP falls back to synthetic.", DateTimeOffset.UtcNow)),
+
+        new DiagnosticsSelfCheck("architecture-known",
+            "Process architecture is a known/supported value.", DiagnosticsSeverity.Info,
+            _ => RuntimeInformation.ProcessArchitecture is Architecture.X64 or Architecture.Arm64 or Architecture.X86 or Architecture.Arm
+                ? new SelfCheckResult(SelfCheckOutcome.Pass,
+                    $"arch={RuntimeInformation.ProcessArchitecture}", DateTimeOffset.UtcNow)
+                : new SelfCheckResult(SelfCheckOutcome.Warn,
+                    $"unexpected arch={RuntimeInformation.ProcessArchitecture}", DateTimeOffset.UtcNow)),
+    };
+
+    private static string OsPlatformName() =>
+        OperatingSystem.IsWindows() ? "windows"
+        : OperatingSystem.IsMacOS() ? "macos"
+        : OperatingSystem.IsLinux() ? "linux"
+        : "unknown";
+
+    private static bool SafeProbe(Func<bool> probe)
+    {
+        try { return probe(); }
+        catch { return false; }
+    }
+}

--- a/Zeus.Server.Hosting/StreamingHub.cs
+++ b/Zeus.Server.Hosting/StreamingHub.cs
@@ -91,6 +91,11 @@ public sealed class StreamingHub
     // they see the current spots without waiting for the next TCI spot event.
     private volatile byte[]? _spotPayload;
 
+    // Latest serialised DiagnosticsHealth (0x36) payload. Set by
+    // BroadcastDiagnostics on the publisher's timer; pushed to each new WS
+    // client on attach so a dashboard renders current health immediately.
+    private volatile byte[]? _diagnosticsPayload;
+
     // Supplies the ChatEvent (0x35) snapshot frames pushed to each new WS
     // client on attach: current status, the live roster, and the message
     // history. Set once by ChatService at startup (mirrors the SpotList
@@ -297,6 +302,11 @@ public sealed class StreamingHub
         // arrived before it connected (e.g. a skimmer that was already running).
         var spotSnap = _spotPayload;
         if (spotSnap is not null) session.TryEnqueue(spotSnap);
+
+        // Push the latest diagnostics health frame (0x36) so a dashboard that
+        // attaches between publisher ticks renders current health immediately.
+        var diagSnap = _diagnosticsPayload;
+        if (diagSnap is not null) session.TryEnqueue(diagSnap);
 
         // Push the current chat snapshot (status + roster + history) so a
         // late-joining client renders the conversation without waiting for the
@@ -758,6 +768,21 @@ public sealed class StreamingHub
     public void BroadcastChatEvent(byte[] payload)
     {
         if (_clients.IsEmpty) return;
+        foreach (var client in _clients.Values)
+        {
+            if (!client.TryEnqueue(payload)) System.Threading.Interlocked.Increment(ref _dropsOther);
+        }
+    }
+
+    /// <summary>
+    /// Broadcasts a pre-encoded DiagnosticsHealth (0x36) frame
+    /// ([type][UTF-8 JSON of <see cref="Zeus.Contracts.DiagnosticsHealthDto"/>]) to every
+    /// connected client and caches it for push-on-attach. Same fan-out shape as
+    /// <see cref="BroadcastSpots"/>; called by DiagnosticsFramePublisher on its timer.
+    /// </summary>
+    public void BroadcastDiagnostics(byte[] payload)
+    {
+        _diagnosticsPayload = payload;
         foreach (var client in _clients.Values)
         {
             if (!client.TryEnqueue(payload)) System.Threading.Interlocked.Increment(ref _dropsOther);

--- a/Zeus.Server.Hosting/StreamingHub.cs
+++ b/Zeus.Server.Hosting/StreamingHub.cs
@@ -197,6 +197,29 @@ public sealed class StreamingHub
 
     public int ClientCount => _clients.Count;
 
+    /// <summary>
+    /// Read-only websocket-hub health for the diagnostics v2 surface: connected
+    /// clients, audio/display subscriber counts, and the per-bucket frame-drop
+    /// counters (issue #299). All reads are Interlocked/Volatile so this is safe
+    /// to call from any thread off the broadcast path.
+    /// </summary>
+    public object DiagnosticsSnapshot() => new
+    {
+        schemaVersion = 1,
+        generatedUtc = DateTimeOffset.UtcNow,
+        connectedClients = ClientCount,
+        audioSubscribers = Volatile.Read(ref _audioStreamRequests),
+        displaySubscribers = Volatile.Read(ref _displayStreamRequests),
+        drops = new
+        {
+            audio = System.Threading.Interlocked.Read(ref _dropsAudio),
+            display = System.Threading.Interlocked.Read(ref _dropsDisplay),
+            meter = System.Threading.Interlocked.Read(ref _dropsMeter),
+            other = System.Threading.Interlocked.Read(ref _dropsOther),
+        },
+        micUplink = MicInboundDiagnosticsSnapshot(DateTimeOffset.UtcNow),
+    };
+
     public MicInboundDiagnostics MicPeakDiagnosticsSnapshot(DateTimeOffset now)
     {
         long lastUnixMs = Volatile.Read(ref _lastMicInboundUnixMs);

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -28,6 +28,10 @@ public static class ZeusEndpoints
     {
         var log = app.Services.GetRequiredService<ILogger<object>>();
 
+        // Live Diagnostics API v2 — unified, registry-driven surface
+        // (/api/diagnostics/v2). Legacy diagnostics routes below stay as-is.
+        app.MapDiagnosticsV2();
+
         app.MapGet("/api/version", () =>
         {
             var assembly = System.Reflection.Assembly.GetExecutingAssembly();

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -66,8 +66,21 @@ public static class ZeusHost
         // Emit enums as strings on the wire ("USB", not 1) per doc 04 §3. The
         // converter also accepts ordinal integers on read, so older clients that
         // POST numeric mode values keep working.
+        //
+        // Diagnostics API v2 (perf): prepend the source-generated DiagnosticsJsonContext
+        // so the v2 DTOs serialise through fast generated metadata. The reflection
+        // resolver stays in the chain (we ensure it's present), so every other DTO —
+        // including the anonymous hardware-diagnostics snapshot and all legacy
+        // contracts — serialises exactly as before. CamelCase + string enums in the
+        // context match the Web defaults, so the wire output is byte-identical.
         builder.Services.Configure<JsonOptions>(o =>
-            o.SerializerOptions.Converters.Add(new JsonStringEnumConverter()));
+        {
+            var json = o.SerializerOptions;
+            json.TypeInfoResolverChain.Insert(0, Diagnostics.DiagnosticsJsonContext.Default);
+            if (!json.TypeInfoResolverChain.OfType<System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver>().Any())
+                json.TypeInfoResolverChain.Add(new System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver());
+            json.Converters.Add(new JsonStringEnumConverter());
+        });
 
         // Self-diagnostic log capture (the "Report a problem" footer button). A
         // singleton ring buffer always retains the last ~1000 formatted log lines
@@ -421,6 +434,22 @@ public static class ZeusHost
         builder.Services.AddSingleton<FrontendAudioPlaybackDiagnosticsService>();
         builder.Services.AddSingleton<HardwareDiagnosticsService>();
         builder.Services.AddHostedService(sp => sp.GetRequiredService<HardwareDiagnosticsService>());
+
+        // Live Diagnostics API v2. Each provider self-registers as
+        // IDiagnosticsProvider; the registry collects them once at startup and the
+        // unified /api/diagnostics/v2 surface + push publisher are driven entirely
+        // off that collection. Adding a future provider is a single AddSingleton
+        // line here — it then auto-appears on the API, in the health frame, and in
+        // the conformance test harness with zero further wiring.
+        builder.Services.AddSingleton<Diagnostics.IDiagnosticsProvider, Diagnostics.DspLiveDiagnosticsProvider>();
+        builder.Services.AddSingleton<Diagnostics.IDiagnosticsProvider, Diagnostics.DspModernizationProvider>();
+        builder.Services.AddSingleton<Diagnostics.IDiagnosticsProvider, Diagnostics.HardwareDiagnosticsProvider>();
+        builder.Services.AddSingleton<Diagnostics.IDiagnosticsProvider, Diagnostics.FrontendDspSceneProvider>();
+        builder.Services.AddSingleton<Diagnostics.IDiagnosticsProvider, Diagnostics.FrontendAudioPlaybackProvider>();
+        builder.Services.AddSingleton<Diagnostics.DiagnosticsProviderRegistry>();
+        builder.Services.AddSingleton<Diagnostics.DiagnosticsSelfCheckCache>();
+        builder.Services.AddSingleton<Diagnostics.DiagnosticsFramePublisher>();
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<Diagnostics.DiagnosticsFramePublisher>());
 
         // Regional band planning (issue #65 PRD). BandPlanStore loads shipped
         // JSON under BandPlans/ at startup and resolves parent→override chains;

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -453,6 +453,7 @@ public static class ZeusHost
         builder.Services.AddSingleton<Diagnostics.IDiagnosticsProvider, Diagnostics.HamClockProvider>();
         builder.Services.AddSingleton<Diagnostics.IDiagnosticsProvider, Diagnostics.ExternalPttProvider>();
         builder.Services.AddSingleton<Diagnostics.IDiagnosticsProvider, Diagnostics.Protocol2TxIqProvider>();
+        builder.Services.AddSingleton<Diagnostics.IDiagnosticsProvider, Diagnostics.DspPipelineProvider>();
         builder.Services.AddSingleton<Diagnostics.DiagnosticsProviderRegistry>();
         builder.Services.AddSingleton<Diagnostics.DiagnosticsSelfCheckCache>();
         builder.Services.AddSingleton<Diagnostics.DiagnosticsFramePublisher>();

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -446,6 +446,13 @@ public static class ZeusHost
         builder.Services.AddSingleton<Diagnostics.IDiagnosticsProvider, Diagnostics.HardwareDiagnosticsProvider>();
         builder.Services.AddSingleton<Diagnostics.IDiagnosticsProvider, Diagnostics.FrontendDspSceneProvider>();
         builder.Services.AddSingleton<Diagnostics.IDiagnosticsProvider, Diagnostics.FrontendAudioPlaybackProvider>();
+        builder.Services.AddSingleton<Diagnostics.IDiagnosticsProvider, Diagnostics.PlatformDiagnosticsProvider>();
+        builder.Services.AddSingleton<Diagnostics.IDiagnosticsProvider, Diagnostics.StreamingHubProvider>();
+        builder.Services.AddSingleton<Diagnostics.IDiagnosticsProvider, Diagnostics.RadioStateProvider>();
+        builder.Services.AddSingleton<Diagnostics.IDiagnosticsProvider, Diagnostics.RadioCapabilitiesProvider>();
+        builder.Services.AddSingleton<Diagnostics.IDiagnosticsProvider, Diagnostics.HamClockProvider>();
+        builder.Services.AddSingleton<Diagnostics.IDiagnosticsProvider, Diagnostics.ExternalPttProvider>();
+        builder.Services.AddSingleton<Diagnostics.IDiagnosticsProvider, Diagnostics.Protocol2TxIqProvider>();
         builder.Services.AddSingleton<Diagnostics.DiagnosticsProviderRegistry>();
         builder.Services.AddSingleton<Diagnostics.DiagnosticsSelfCheckCache>();
         builder.Services.AddSingleton<Diagnostics.DiagnosticsFramePublisher>();

--- a/Zeus.slnx
+++ b/Zeus.slnx
@@ -17,4 +17,5 @@
   <Project Path="Zeus.Protocol2/Zeus.Protocol2.csproj" />
   <Project Path="OpenhpsdrZeus/OpenhpsdrZeus.csproj" />
   <Project Path="Zeus.Server.Hosting/Zeus.Server.Hosting.csproj" />
+  <Project Path="Zeus.Diagnostics.TestGen/Zeus.Diagnostics.TestGen.csproj" />
 </Solution>

--- a/docs/lessons/diagnostics-api-v2.md
+++ b/docs/lessons/diagnostics-api-v2.md
@@ -1,0 +1,106 @@
+# Live Diagnostics API v2 — debug anything, test everything
+
+Zeus exposes a unified, self-registering diagnostics platform at
+`/api/diagnostics/v2`. The design goal: any subsystem can publish live state
+through one seam, and every provider that does so is **automatically** tested
+across every architecture CI runs on. Adding a feature's diagnostics is one
+interface + one DI line; you get the endpoint, the live push frame, the
+self-check harness, and test coverage for free.
+
+## The seam: `IDiagnosticsProvider`
+
+`Zeus.Server.Hosting/Diagnostics/IDiagnosticsProvider.cs`. Implement it, then
+register the type as a singleton `IDiagnosticsProvider` in
+`ZeusHost.Build` (next to the other provider registrations). That's it.
+
+```csharp
+public sealed class MyThingProvider : IDiagnosticsProvider
+{
+    public string Id => "mything.state";        // stable, unique (URLs/tests)
+    public string RouteSegment => "mything";    // unique URL segment
+    public string Category => "mything";
+    public int SchemaVersion => 1;
+    public string Description => "What this reports.";
+    public object Snapshot() => _svc.Snapshot(); // cheap, read-only, no DSP work
+    public IReadOnlyList<DiagnosticsSelfCheck> SelfChecks => new[]
+    {
+        new DiagnosticsSelfCheck("alive", "Service is responsive.",
+            DiagnosticsSeverity.Warn,
+            _ => /* read a snapshot */ new SelfCheckResult(SelfCheckOutcome.Pass, "ok", DateTimeOffset.UtcNow)),
+    };
+}
+```
+
+Rules that keep this safe and fast:
+- `Snapshot()` returns `object` so you can return an existing (even anonymous)
+  DTO **verbatim** — no rewrite, no wire-format change. Typed DTOs that should
+  use fast source-gen JSON go in `DiagnosticsJsonContext`; everything else
+  falls through to reflection. Both are camelCase + string-enum identical.
+- Snapshots and self-checks must be **read-only** and free of realtime/DSP work
+  — they read cached state only. Self-checks run on a background timer in
+  `DiagnosticsSelfCheckCache`, never on the request or DSP thread, and each
+  probe is try/caught (a throwing probe becomes a `fail`, never a 500).
+- **PureSignal is read-only here, always.** Diagnostics may surface PS state but
+  must never expose arm/disarm or mutate `PsEnabled`. See the hard rule in
+  `CLAUDE.md`.
+
+## The surface
+
+- `GET /api/diagnostics/v2` — provider index (metadata only).
+- `GET /api/diagnostics/v2/{routeSegment}` — one provider snapshot.
+- `GET /api/diagnostics/v2/{routeSegment}/selfcheck` — cached self-check report.
+- `POST /api/diagnostics/v2/{routeSegment}/selfcheck` — force a fresh run.
+- `GET /api/diagnostics/v2/health` — aggregate worst-of health.
+
+Every `GET .../{routeSegment}` response is wrapped in a uniform self-describing
+envelope so all providers look the same on the wire regardless of what the
+underlying snapshot returns:
+
+```json
+{ "schemaVersion": 1, "id": "dsp.live", "routeSegment": "dsp-live",
+  "category": "dsp", "description": "...", "providerSchemaVersion": 1,
+  "generatedUtc": "…", "snapshot": { /* the raw provider payload */ } }
+```
+
+Legacy diagnostics routes (`/api/dsp/live-diagnostics`, `/api/radio/diagnostics`,
+…) are untouched and return the bare payload, so they stay byte-identical for
+existing clients. The bare payload equals the v2 envelope's `snapshot`.
+
+## Live push (MsgType 0x36)
+
+`DiagnosticsFramePublisher` (a `BackgroundService`) broadcasts the aggregate
+`DiagnosticsHealthDto` over the StreamingHub at ~1 Hz, only when clients are
+connected, source-gen serialised. The latest frame is cached and pushed on WS
+attach (mirrors SpotList / ChatEvent). Frame layout: `[0x36][UTF-8 JSON]`.
+Unknown frame types are ignored by clients, so it is backward-compatible.
+
+## The three test layers (why green ⇒ works)
+
+1. **Runtime self-checks** — each provider declares probes; the cache runs them
+   and the health endpoint/push surface the worst-of. This is live, in-product
+   debugging.
+2. **Conformance harness** (`tests/Zeus.Server.Tests/DiagnosticsConformanceTests.cs`)
+   — enumerates every registered provider from DI and asserts the contract
+   (200, `schemaVersion`, camelCase, valid self-check outcomes, unique
+   ids/routes, resolver-chain preserves string enums, v2 == legacy). A new
+   provider is covered the moment it's registered — **no new test file**.
+3. **Source-generated per-provider tests** (`Zeus.Diagnostics.TestGen`) — a
+   Roslyn incremental generator emits one named xUnit class per provider so each
+   shows up individually in the runner and devs can extend it via the `partial`.
+
+## Architecture coverage
+
+`system.platform` reports OS / architecture / RID / .NET version and the WDSP
+native load state per platform — the first thing to check for an
+architecture-specific bug. CI runs the suite on linux-x64, windows-x64,
+macos-arm64 (hard-gated) and linux-arm64, windows-arm64, macos-x64
+(experimental until the runners are confirmed green) with a per-arch WDSP
+native-load probe — so a green matrix means the diagnostics contract holds on
+every architecture, not just the dev's machine.
+
+## Adding coverage
+
+The provider inventory (TX/RX/protocol/DSP/streaming/plugins/persistence/
+integration/PureSignal-read-only) is large; the shipped set is representative,
+not exhaustive. Each remaining subsystem is a small, independent PR: wrap its
+snapshot, register it, done — the harness tests it automatically.

--- a/tests/Zeus.Server.Tests/DiagnosticsConformanceTests.cs
+++ b/tests/Zeus.Server.Tests/DiagnosticsConformanceTests.cs
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Layer-3 of the diagnostics test framework: a reflection/registry conformance
+// harness. It enumerates EVERY registered IDiagnosticsProvider from the live DI
+// container and asserts each one conforms to the v2 contract. The point is
+// AUTOMATIC coverage: a new feature that registers a provider is tested here
+// with no new test file. (Layer 2, the source generator, additionally emits a
+// per-provider NAMED test so each shows up individually in the runner.)
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Zeus.Server.Diagnostics;
+
+namespace Zeus.Server.Tests;
+
+public sealed class DiagnosticsConformanceTests : IClassFixture<DiagnosticsConformanceTests.Factory>
+{
+    private readonly Factory _factory;
+    public DiagnosticsConformanceTests(Factory factory) => _factory = factory;
+
+    public sealed class Factory : IsolatedPrefsFactory { }
+
+    private const string Base = "/api/diagnostics/v2";
+
+    [Fact]
+    public void Registry_HasProviders_WithUniqueIdsAndRoutes()
+    {
+        var registry = _factory.Services.GetRequiredService<DiagnosticsProviderRegistry>();
+        Assert.NotEmpty(registry.All);
+
+        var ids = registry.All.Select(p => p.Id).ToArray();
+        var routes = registry.All.Select(p => p.RouteSegment).ToArray();
+        Assert.Equal(ids.Length, ids.Distinct(StringComparer.Ordinal).Count());
+        Assert.Equal(routes.Length, routes.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+        Assert.All(registry.All, p =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(p.Id));
+            Assert.False(string.IsNullOrWhiteSpace(p.RouteSegment));
+            Assert.False(string.IsNullOrWhiteSpace(p.Category));
+            Assert.False(string.IsNullOrWhiteSpace(p.Description));
+        });
+    }
+
+    [Fact]
+    public async Task Index_ListsEveryProvider()
+    {
+        var registry = _factory.Services.GetRequiredService<DiagnosticsProviderRegistry>();
+        using var client = _factory.CreateClient();
+
+        using var doc = await GetJson(client, Base);
+        var root = doc.RootElement;
+        Assert.Equal(1, root.GetProperty("schemaVersion").GetInt32());
+        Assert.Equal(registry.All.Count, root.GetProperty("providerCount").GetInt32());
+
+        var listed = root.GetProperty("providers").EnumerateArray()
+            .Select(p => p.GetProperty("id").GetString())
+            .ToHashSet(StringComparer.Ordinal);
+        foreach (var p in registry.All)
+            Assert.Contains(p.Id, listed);
+    }
+
+    // The keystone: every provider's snapshot + self-check endpoints must conform.
+    // Looping (not MemberData) keeps it to a single shared host; failures are
+    // collected with provider context so one bad provider names itself.
+    [Fact]
+    public async Task EveryProvider_Snapshot_And_SelfCheck_Conform()
+    {
+        var registry = _factory.Services.GetRequiredService<DiagnosticsProviderRegistry>();
+        using var client = _factory.CreateClient();
+        var failures = new List<string>();
+
+        foreach (var provider in registry.All)
+        {
+            var snapUrl = $"{Base}/{provider.RouteSegment}";
+            try
+            {
+                using var snap = await GetJson(client, snapUrl);
+                if (!snap.RootElement.TryGetProperty("schemaVersion", out _))
+                    failures.Add($"{provider.Id}: snapshot missing camelCase 'schemaVersion' ({snapUrl})");
+            }
+            catch (Exception ex)
+            {
+                failures.Add($"{provider.Id}: snapshot GET failed: {ex.Message}");
+            }
+
+            try
+            {
+                using var report = await GetJson(client, $"{snapUrl}/selfcheck");
+                var r = report.RootElement;
+                if (r.GetProperty("providerId").GetString() != provider.Id)
+                    failures.Add($"{provider.Id}: self-check report providerId mismatch");
+                var worst = r.GetProperty("worst").GetString();
+                if (worst is not ("pass" or "warn" or "fail"))
+                    failures.Add($"{provider.Id}: invalid worst outcome '{worst}'");
+                foreach (var check in r.GetProperty("checks").EnumerateArray())
+                {
+                    var outcome = check.GetProperty("outcome").GetString();
+                    if (outcome is not ("pass" or "warn" or "fail"))
+                        failures.Add($"{provider.Id}: invalid check outcome '{outcome}'");
+                }
+            }
+            catch (Exception ex)
+            {
+                failures.Add($"{provider.Id}: self-check GET failed: {ex.Message}");
+            }
+
+            // POST forces a fresh run; must also succeed (off-path, never 500).
+            var post = await client.PostAsync($"{snapUrl}/selfcheck", new StringContent("", Encoding.UTF8));
+            if (post.StatusCode != HttpStatusCode.OK)
+                failures.Add($"{provider.Id}: POST selfcheck returned {(int)post.StatusCode}");
+        }
+
+        Assert.True(failures.Count == 0,
+            "Diagnostics provider conformance failures:\n  " + string.Join("\n  ", failures));
+    }
+
+    [Fact]
+    public async Task Health_AggregatesAllProviders()
+    {
+        var registry = _factory.Services.GetRequiredService<DiagnosticsProviderRegistry>();
+        using var client = _factory.CreateClient();
+
+        using var doc = await GetJson(client, $"{Base}/health");
+        var root = doc.RootElement;
+        Assert.Equal(1, root.GetProperty("schemaVersion").GetInt32());
+        Assert.Contains(root.GetProperty("overall").GetString(), new[] { "pass", "warn", "fail" });
+        Assert.Equal(registry.All.Count, root.GetProperty("providerCount").GetInt32());
+        Assert.Equal(registry.All.Count, root.GetProperty("providers").GetArrayLength());
+
+        int pass = root.GetProperty("passCount").GetInt32();
+        int warn = root.GetProperty("warnCount").GetInt32();
+        int fail = root.GetProperty("failCount").GetInt32();
+        Assert.Equal(registry.All.Count, pass + warn + fail);
+    }
+
+    [Fact]
+    public async Task UnknownProvider_Returns404()
+    {
+        using var client = _factory.CreateClient();
+        var resp = await client.GetAsync($"{Base}/this-provider-does-not-exist");
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    // Verifies the source-gen JSON resolver chain didn't break the existing
+    // reflection path: a legacy enum-bearing payload still serialises as a
+    // string, and a v2 typed DTO is camelCase.
+    [Fact]
+    public async Task ResolverChain_PreservesStringEnums_AndCamelCase()
+    {
+        using var client = _factory.CreateClient();
+
+        using var state = await GetJson(client, "/api/state");
+        // Mode is an enum on StateDto; the global JsonStringEnumConverter must
+        // still render it as a string (e.g. "USB"), not a number.
+        var mode = state.RootElement.GetProperty("mode");
+        Assert.Equal(JsonValueKind.String, mode.ValueKind);
+
+        using var live = await GetJson(client, $"{Base}/dsp-live");
+        // Envelope is camelCase first-letter-lowercase.
+        Assert.True(live.RootElement.TryGetProperty("schemaVersion", out _));
+        Assert.False(live.RootElement.TryGetProperty("SchemaVersion", out _));
+        // The nested typed DTO (source-gen context) is also camelCase.
+        var snap = live.RootElement.GetProperty("snapshot");
+        Assert.True(snap.TryGetProperty("schemaVersion", out _));
+        Assert.False(snap.TryGetProperty("SchemaVersion", out _));
+    }
+
+    // Backward-compat: the v2 route and the legacy route are backed by the same
+    // builder, so structural fields match.
+    [Fact]
+    public async Task V2DspLive_MatchesLegacyRoute()
+    {
+        using var client = _factory.CreateClient();
+        using var v2 = await GetJson(client, $"{Base}/dsp-live");
+        using var legacy = await GetJson(client, "/api/dsp/live-diagnostics");
+
+        // The v2 route wraps the same payload in an envelope; the bare legacy
+        // payload must match what's under `snapshot`.
+        var v2Snap = v2.RootElement.GetProperty("snapshot");
+        Assert.Equal(
+            legacy.RootElement.GetProperty("schemaVersion").GetInt32(),
+            v2Snap.GetProperty("schemaVersion").GetInt32());
+        Assert.Equal(
+            legacy.RootElement.GetProperty("status").GetString(),
+            v2Snap.GetProperty("status").GetString());
+    }
+
+    private static async Task<JsonDocument> GetJson(HttpClient client, string url)
+    {
+        var resp = await client.GetAsync(url);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        return await JsonDocument.ParseAsync(await resp.Content.ReadAsStreamAsync());
+    }
+}

--- a/tests/Zeus.Server.Tests/DiagnosticsPushTests.cs
+++ b/tests/Zeus.Server.Tests/DiagnosticsPushTests.cs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Tests for the diagnostics v2 push path (MsgType 0x36). The hosted
+// DiagnosticsFramePublisher itself is stripped under IsolatedPrefsFactory
+// (which removes IHostedService), so these exercise the encode + aggregate
+// pieces directly: the cache builds health, the publisher encodes the frame,
+// and the hub exposes its read-only snapshot.
+
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Zeus.Contracts;
+using Zeus.Server.Diagnostics;
+
+namespace Zeus.Server.Tests;
+
+public sealed class DiagnosticsPushTests : IClassFixture<DiagnosticsPushTests.Factory>
+{
+    private readonly Factory _factory;
+    public DiagnosticsPushTests(Factory factory) => _factory = factory;
+
+    public sealed class Factory : IsolatedPrefsFactory { }
+
+    [Fact]
+    public void Cache_BuildHealth_AggregatesProviders()
+    {
+        var registry = _factory.Services.GetRequiredService<DiagnosticsProviderRegistry>();
+        var cache = _factory.Services.GetRequiredService<DiagnosticsSelfCheckCache>();
+
+        var health = cache.BuildHealth();
+        Assert.Equal(registry.All.Count, health.ProviderCount);
+        Assert.Equal(registry.All.Count, health.Providers.Length);
+        Assert.Contains(health.Overall, new[] { "pass", "warn", "fail" });
+        Assert.Equal(health.ProviderCount, health.PassCount + health.WarnCount + health.FailCount);
+    }
+
+    [Fact]
+    public void EncodeFrame_PrependsTypeByte_AndIsValidJson()
+    {
+        var cache = _factory.Services.GetRequiredService<DiagnosticsSelfCheckCache>();
+        var health = cache.BuildHealth();
+
+        var frame = DiagnosticsFramePublisher.EncodeFrame(health);
+
+        Assert.True(frame.Length > 1);
+        Assert.Equal((byte)MsgType.DiagnosticsHealth, frame[0]);
+
+        using var doc = JsonDocument.Parse(frame.AsMemory(1));
+        Assert.Contains(doc.RootElement.GetProperty("overall").GetString(), new[] { "pass", "warn", "fail" });
+        Assert.Equal(1, doc.RootElement.GetProperty("schemaVersion").GetInt32());
+        // camelCase from the source-gen context.
+        Assert.True(doc.RootElement.TryGetProperty("providers", out _));
+    }
+
+    [Fact]
+    public void Publisher_IsRegistered_AsSingleton()
+    {
+        // AddSingleton + AddHostedService(sp => GetRequiredService) means the
+        // singleton survives even though IsolatedPrefsFactory strips hosted
+        // services — so the publisher is resolvable for direct testing.
+        var publisher = _factory.Services.GetService<DiagnosticsFramePublisher>();
+        Assert.NotNull(publisher);
+    }
+
+    [Fact]
+    public void Hub_DiagnosticsSnapshot_HasExpectedShape()
+    {
+        var hub = _factory.Services.GetRequiredService<StreamingHub>();
+        var json = JsonSerializer.Serialize(hub.DiagnosticsSnapshot());
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.Equal(0, root.GetProperty("connectedClients").GetInt32());
+        Assert.True(root.TryGetProperty("drops", out var drops));
+        Assert.True(drops.TryGetProperty("audio", out _));
+    }
+}

--- a/tests/Zeus.Server.Tests/Zeus.Server.Tests.csproj
+++ b/tests/Zeus.Server.Tests/Zeus.Server.Tests.csproj
@@ -25,6 +25,13 @@
     <ProjectReference Include="..\..\Zeus.Protocol1\Zeus.Protocol1.csproj" />
     <ProjectReference Include="..\..\Zeus.Contracts\Zeus.Contracts.csproj" />
     <ProjectReference Include="..\..\Zeus.Dsp\Zeus.Dsp.csproj" />
+
+    <!-- Live Diagnostics API v2 — Layer 2: source generator emits one named
+         xUnit test class per IDiagnosticsProvider. Analyzer reference only; its
+         assembly is not part of the test project's runtime closure. -->
+    <ProjectReference Include="..\..\Zeus.Diagnostics.TestGen\Zeus.Diagnostics.TestGen.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Rebased onto current `develop` from the stranded local branch `feature/live-diagnostics-api-v2` (3 commits, cherry-picked clean). This is the only piece of work that was sitting unpushed with no PR.

## What

A self-registering live-diagnostics framework, surfaced at `/api/diagnostics/v2`:

- **Provider framework** — `IDiagnosticsProvider` + `DiagnosticsProviderRegistry`; add a diagnostic by wrapping + registering a provider (auto-discovered).
- **Providers** — core services, platform, hardware, DSP live state, DSP modernization, frontend audio playback, frontend DSP scene, and a **`dsp.pipeline`** provider (WDSP channels + wisdom/FFT state).
- **Self-checks** — `DiagnosticsSelfCheckCache` with conformance validation.
- **Push** — `0x36` frame publisher over the streaming hub (`DiagnosticsFramePublisher`).
- **Source-gen JSON** — `DiagnosticsJsonContext` for AOT-safe serialization.
- **Test harness** — a Roslyn source generator (`Zeus.Diagnostics.TestGen`) that emits conformance tests per provider, plus `DiagnosticsConformanceTests` / `DiagnosticsPushTests` and cross-arch CI in `build-test.yml`.

## Verification

- `Zeus.Server.Hosting` (framework + all providers) builds clean: 0 warnings / 0 errors.
- `Zeus.Diagnostics.TestGen` source generator builds clean.
- Full conformance + push test suite runs in CI (the local frontend build error in my worktree was an uninitialized `deepcw-engine` submodule, unrelated to this change).

## Reviewer notes (architecture)

This adds a **new project** (`Zeus.Diagnostics.TestGen`, a netstandard2.0 source generator), a new `0x36` push frame, and new CI — flagging per the repo`s architecture-review convention.