### PR TITLE
feat(ports): external PTT-IN → MOX (opt-in) + Radio Settings tab (#797)

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -599,7 +599,19 @@ public sealed record ExternalPttStatusDto(
     bool CwMode,
     bool SidetoneAvailable,
     string DiagnosticRecommendation,
-    DateTimeOffset GeneratedUtc);
+    DateTimeOffset GeneratedUtc,
+    // Hardware-PTT-IN → MOX enable gate (per-install, default OFF). Nullable so
+    // the read-only diagnostic snapshot (/api/tx/diag, /api/cw/hardware-keying)
+    // can omit it (null) while the dedicated /api/radio/ptt-status endpoint
+    // populates it from PttSettingsStore. When the gate is OFF the PTT-IN lamp
+    // still tracks the footswitch, but no MOX is promoted.
+    bool? Enabled = null);
+
+// Request body for PUT /api/radio/ptt-status — flips the per-install
+// hardware-PTT-IN → MOX enable gate. Persisted in PttSettingsStore; a
+// persisted ON flag only ARMS the gate, it never auto-keys MOX (MOX still
+// requires a physical footswitch edge).
+public sealed record PttEnableSetRequest(bool Enabled);
 
 public sealed record HardwareKeyingStatusDto(
     int SchemaVersion,

--- a/Zeus.Contracts/MsgType.cs
+++ b/Zeus.Contracts/MsgType.cs
@@ -231,4 +231,19 @@ public enum MsgType : byte
     // it cleanly. Encoded by DiagnosticsFramePublisher (source-gen serialised
     // for the hot push path).
     DiagnosticsHealth = 0x36,
+
+    // Server → client (hardware PTT-IN status edge). Broadcast on every
+    // footswitch / mic-PTT / rear-KEY edge so the Radio Settings "PTT-IN:
+    // idle / keyed" lamp tracks the physical input. P1 boards are driven by
+    // the Protocol1Client HardwarePttChanged event, P2 boards by the UDP-1025
+    // hi-priority status PttIn bit. Read-only indicator — does NOT drive MOX
+    // (ExternalPttService promotes the same edges into MOX separately through
+    // TxService.TrySetMox arbitration). Payload: [type:1][keyed:u8] = 2
+    // bytes total. See PttStatusFrame.cs.
+    //
+    // NOTE: 0x33 was used for this type in the unmerged external-ports squash
+    // (78c3c28e); 0x33–0x35 are RxAudioChainOrder / RxAudioMasterBypass /
+    // ChatEvent and 0x36 is DiagnosticsHealth on this base, so PttStatus uses
+    // the next free byte 0x37.
+    PttStatus = 0x37,
 }

--- a/Zeus.Contracts/PttStatusFrame.cs
+++ b/Zeus.Contracts/PttStatusFrame.cs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Buffers;
+
+namespace Zeus.Contracts;
+
+// Hardware-PTT-IN (footswitch / mic PTT / rear KEY) status edge frame. 2 bytes:
+//   [PttStatus][keyed:u8]
+//
+// Read-only status for the Radio Settings "PTT-IN: idle / keyed" lamp. The
+// SOURCE of the edge is per-protocol: P1 boards are driven by the
+// Protocol1Client HardwarePttChanged event (C0[0] / ptt_resp), P2 boards by
+// the UDP-1025 hi-priority status PttIn bit (byte0 bit0). This is a pure
+// indicator — it does NOT drive MOX (ExternalPttService promotes the same
+// edges into MOX separately, through TxService.TrySetMox arbitration). The
+// lamp tracks every physical edge regardless of the enable gate.
+public readonly record struct PttStatusFrame(bool Keyed)
+{
+    public const int ByteLength = 2;
+
+    public void Serialize(IBufferWriter<byte> writer)
+    {
+        var span = writer.GetSpan(ByteLength);
+        span[0] = (byte)MsgType.PttStatus;
+        span[1] = Keyed ? (byte)1 : (byte)0;
+        writer.Advance(ByteLength);
+    }
+
+    public static PttStatusFrame Deserialize(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length < ByteLength)
+            throw new InvalidDataException($"PttStatusFrame requires {ByteLength} bytes, got {bytes.Length}");
+        if (bytes[0] != (byte)MsgType.PttStatus)
+            throw new InvalidDataException($"expected PttStatus (0x{(byte)MsgType.PttStatus:X2}), got 0x{bytes[0]:X2}");
+        return new PttStatusFrame(Keyed: bytes[1] != 0);
+    }
+}

--- a/Zeus.Server.Hosting/ExternalPttService.cs
+++ b/Zeus.Server.Hosting/ExternalPttService.cs
@@ -51,27 +51,54 @@ public sealed class ExternalPttService : IHostedService, IDisposable
     // on the per-mode DSP settings panel alongside the CW pitch.
     private static readonly TimeSpan HangTime = TimeSpan.FromMilliseconds(250);
 
+    /// <summary>Read-only hang time surfaced to the UI ("Hang: 250 ms") and the
+    /// REST status endpoint. The knob itself is out of scope for this pass.</summary>
+    public static int HangMs => (int)HangTime.TotalMilliseconds;
+
+    /// <summary>Live PTT-IN level (lamp state) for the REST status snapshot.
+    /// Fed by both protocol edge sources; false when disconnected.</summary>
+    public bool IsKeyed => _rawHigh;
+
     private readonly RadioService _radio;
     private readonly TxService _tx;
+    private readonly StreamingHub _hub;
+    private readonly PttSettingsStore _settings;
     private readonly CwSidetoneSource? _sidetone;
     private readonly ILogger<ExternalPttService> _log;
 
     private readonly object _sync = new();
     private IProtocol1Client? _client;
+    private Zeus.Protocol2.Protocol2Client? _p2Client;
     // True iff the most recent MOX-on we caused has not been released yet.
     // Cleared by the hang-release path, by TxActiveChanged(false) from any
     // other source, and by disconnect.
     private bool _owned;
+    // Latest raw hardware-PTT level, fed by BOTH protocol edge sources. Used by
+    // the hang-release race-guard (protocol-agnostic replacement for the P1-only
+    // IProtocol1Client.HardwarePtt latched property) and surfaced as the lamp
+    // state. Volatile: written on the RX thread, read on the timer ThreadPool.
+    private volatile bool _rawHigh;
+    // Previous P2 PttIn level, for edge detection on the level-sampled P2
+    // telemetry stream. Owned by the P2 RX thread only.
+    private bool _p2PrevPtt;
     // Single-shot timer used to debounce falling edges. Created lazily and
     // re-armed via Change(); the underlying System.Threading.Timer is thread
     // safe so cancellation from the RX thread and fire-and-handle on the
     // ThreadPool coexist cleanly.
     private Timer? _hangTimer;
 
-    public ExternalPttService(RadioService radio, TxService tx, ILogger<ExternalPttService> log, CwSidetoneSource? sidetone = null)
+    public ExternalPttService(
+        RadioService radio,
+        TxService tx,
+        StreamingHub hub,
+        PttSettingsStore settings,
+        ILogger<ExternalPttService> log,
+        CwSidetoneSource? sidetone = null)
     {
         _radio = radio;
         _tx = tx;
+        _hub = hub;
+        _settings = settings;
         _sidetone = sidetone;
         _log = log;
     }
@@ -80,6 +107,8 @@ public sealed class ExternalPttService : IHostedService, IDisposable
     {
         _radio.Connected += OnConnected;
         _radio.Disconnected += OnDisconnected;
+        _radio.P2Connected += OnP2Connected;
+        _radio.P2Disconnected += OnP2Disconnected;
         _tx.TxActiveChanged += OnTxActiveChanged;
         return Task.CompletedTask;
     }
@@ -88,14 +117,18 @@ public sealed class ExternalPttService : IHostedService, IDisposable
     {
         _radio.Connected -= OnConnected;
         _radio.Disconnected -= OnDisconnected;
+        _radio.P2Connected -= OnP2Connected;
+        _radio.P2Disconnected -= OnP2Disconnected;
         _tx.TxActiveChanged -= OnTxActiveChanged;
         IProtocol1Client? client;
-        lock (_sync) { client = _client; _client = null; _owned = false; }
+        Zeus.Protocol2.Protocol2Client? p2;
+        lock (_sync) { client = _client; _client = null; p2 = _p2Client; _p2Client = null; _owned = false; }
         if (client is not null)
         {
             client.HardwarePttChanged -= OnHardwarePttChanged;
             client.CwKeyDownChanged -= OnCwKeyDownChanged;
         }
+        if (p2 is not null) p2.TelemetryReceived -= OnP2Telemetry;
         _hangTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
         return Task.CompletedTask;
     }
@@ -108,15 +141,21 @@ public sealed class ExternalPttService : IHostedService, IDisposable
     public ExternalPttStatusDto Snapshot()
     {
         IProtocol1Client? client;
+        Zeus.Protocol2.Protocol2Client? p2;
         bool owned;
         lock (_sync)
         {
             client = _client;
+            p2 = _p2Client;
             owned = _owned;
         }
 
-        bool available = client is not null;
-        bool? hardwarePtt = client?.HardwarePtt;
+        // PTT-IN is wired on BOTH protocols (P1 HardwarePttChanged, P2 hi-pri
+        // PttIn telemetry), so availability/level must be protocol-agnostic.
+        bool available = client is not null || p2 is not null;
+        // _rawHigh is the protocol-agnostic raw footswitch level, fed by both
+        // edge sources — use it instead of the P1-only IProtocol1Client.HardwarePtt.
+        bool? hardwarePtt = available ? _rawHigh : (bool?)null;
         bool? cwKeyDown = client?.CwKeyDown;
         var mode = _radio.Snapshot().Mode;
         bool moxOn = _tx.IsMoxOn;
@@ -124,7 +163,7 @@ public sealed class ExternalPttService : IHostedService, IDisposable
         bool twoToneOn = _tx.IsTwoToneOn;
         string? owner = _tx.MoxOwner?.ToString();
         string recommendation = !available
-            ? "No Protocol-1 hardware PTT client is attached; external PTT takeover is idle."
+            ? "No hardware PTT client is attached; external PTT takeover is idle."
             : owned
                 ? "External PTT owns MOX through the hardware source path; falling edges release only hardware-owned transmissions after hang time."
                 : hardwarePtt == true && !moxOn
@@ -134,7 +173,7 @@ public sealed class ExternalPttService : IHostedService, IDisposable
         return new(
             SchemaVersion: 1,
             Available: available,
-            Protocol: available ? "P1" : "none",
+            Protocol: client is not null ? "P1" : p2 is not null ? "P2" : "none",
             HardwarePtt: hardwarePtt,
             CwKeyDown: cwKeyDown,
             OwnedMox: owned,
@@ -146,12 +185,13 @@ public sealed class ExternalPttService : IHostedService, IDisposable
             CwMode: IsCwMode(mode),
             SidetoneAvailable: _sidetone is not null,
             DiagnosticRecommendation: recommendation,
-            GeneratedUtc: DateTimeOffset.UtcNow);
+            GeneratedUtc: DateTimeOffset.UtcNow,
+            Enabled: _settings.Get());
     }
 
     private void OnConnected(IProtocol1Client client)
     {
-        lock (_sync) { _client = client; _owned = false; }
+        lock (_sync) { _client = client; _owned = false; _rawHigh = false; }
         client.HardwarePttChanged += OnHardwarePttChanged;
         client.CwKeyDownChanged += OnCwKeyDownChanged;
     }
@@ -159,13 +199,14 @@ public sealed class ExternalPttService : IHostedService, IDisposable
     private void OnDisconnected()
     {
         IProtocol1Client? client;
-        lock (_sync) { client = _client; _client = null; _owned = false; }
+        lock (_sync) { client = _client; _client = null; _owned = false; _rawHigh = false; }
         if (client is not null)
         {
             client.HardwarePttChanged -= OnHardwarePttChanged;
             client.CwKeyDownChanged -= OnCwKeyDownChanged;
         }
         _hangTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+        BroadcastLamp(false);
     }
 
     // Sidetone follows the gateware's shaped keyer output (C0[2] /
@@ -182,14 +223,58 @@ public sealed class ExternalPttService : IHostedService, IDisposable
         else _sidetone.Up();
     }
 
-    private void OnHardwarePttChanged(bool on)
+    private void OnHardwarePttChanged(bool on) => HandleRawPtt(on);
+
+    // ---- Protocol 2 wiring (P2 PTT-in → MOX, §4) -------------------------
+
+    private void OnP2Connected(Zeus.Protocol2.Protocol2Client client)
     {
+        lock (_sync) { _p2Client = client; _owned = false; _rawHigh = false; _p2PrevPtt = false; }
+        client.TelemetryReceived += OnP2Telemetry;
+    }
+
+    private void OnP2Disconnected()
+    {
+        Zeus.Protocol2.Protocol2Client? client;
+        lock (_sync) { client = _p2Client; _p2Client = null; _owned = false; _rawHigh = false; _p2PrevPtt = false; }
+        if (client is not null) client.TelemetryReceived -= OnP2Telemetry;
+        _hangTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+        BroadcastLamp(false);
+    }
+
+    // UDP-1025 hi-priority status is LEVEL-sampled at the P2 status cadence, not
+    // an edge event — derive rising/falling by comparing against the previous
+    // PttIn level. Runs on the Protocol2Client RX thread.
+    private void OnP2Telemetry(Zeus.Protocol2.P2TelemetryReading reading)
+    {
+        bool ptt = reading.PttIn;
+        if (ptt == _p2PrevPtt) return; // no edge
+        _p2PrevPtt = ptt;
+        HandleRawPtt(ptt);
+    }
+
+    // ---- Shared debounce / hang / ownership engine -----------------------
+
+    private static bool IsCwMode(RxMode mode) =>
+        mode is RxMode.CWU or RxMode.CWL;
+
+    // Single entry point for a raw hardware-PTT edge from EITHER protocol. The
+    // lamp always tracks the physical input; MOX promotion is gated by the
+    // operator Enable toggle. Edge-triggered: MOX is only ever promoted here,
+    // never on connect/reconnect — so a persisted-ON gate arms without keying.
+    private void HandleRawPtt(bool on)
+    {
+        _rawHigh = on;
+        BroadcastLamp(on);
+        // Enable gate: when off, the lamp still tracks the footswitch but we
+        // never promote it to MOX (UI-only keying). Checked on each edge so a
+        // toggle takes effect immediately without restart.
+        if (!_settings.Get()) return;
         if (on) HandleRising();
         else HandleFalling();
     }
 
-    private static bool IsCwMode(RxMode mode) =>
-        mode is RxMode.CWU or RxMode.CWL;
+    private void BroadcastLamp(bool keyed) => _hub.Broadcast(new PttStatusFrame(keyed));
 
     private void HandleRising()
     {
@@ -244,9 +329,10 @@ public sealed class ExternalPttService : IHostedService, IDisposable
     {
         // Race guard: a rising edge inside the hang window cancels the timer,
         // but the timer can already be in-flight on the ThreadPool when the
-        // cancel arrives. Re-check the latest level before acting.
-        var client = _client;
-        if (client is not null && client.HardwarePtt) return;
+        // cancel arrives. Re-check the latest raw level before acting. _rawHigh
+        // is fed by both protocols, so this is protocol-agnostic; on P1 it
+        // tracks the same C0[0] level the old IProtocol1Client.HardwarePtt did.
+        if (_rawHigh) return;
 
         bool releaseNow;
         lock (_sync) { releaseNow = _owned; _owned = false; }
@@ -270,4 +356,19 @@ public sealed class ExternalPttService : IHostedService, IDisposable
         if (active) return;
         lock (_sync) _owned = false;
     }
+
+    // ---- Test seams ------------------------------------------------------
+
+    /// <summary>Test seam: drive a raw P1-style hardware-PTT edge through the
+    /// full shared engine (lamp + gated MOX promotion). Mirrors what
+    /// <see cref="OnHardwarePttChanged"/> does for a live P1 client.</summary>
+    internal void TestRawPttP1(bool on) => OnHardwarePttChanged(on);
+
+    /// <summary>Test seam: feed a P2 hi-priority telemetry sample through the
+    /// level→edge derivation and the shared engine, exactly as a live
+    /// Protocol2Client TelemetryReceived would.</summary>
+    internal void TestP2Telemetry(Zeus.Protocol2.P2TelemetryReading reading) => OnP2Telemetry(reading);
+
+    /// <summary>Test seam: current latched raw PTT-IN (lamp) level.</summary>
+    internal bool TestRawHigh => _rawHigh;
 }

--- a/Zeus.Server.Hosting/PttSettingsStore.cs
+++ b/Zeus.Server.Hosting/PttSettingsStore.cs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// Global (per-install, NOT per-band/per-radio) hardware-PTT-IN → MOX enable
+// gate. When OFF, ExternalPttService still drives the per-protocol PTT-IN
+// status lamp (so the operator sees the footswitch press) but does NOT promote
+// the hardware edge to MOX — keying stays UI-only.
+//
+// Defaults OFF (opt-in): a fresh install / pre-feature DB leaves the footswitch
+// inert until the operator enables the gate in Radio Settings. A persisted ON
+// flag only ARMS the gate across restarts; it never auto-keys MOX — actual TX
+// still requires a physical footswitch edge (edge-triggered in
+// ExternalPttService).
+//
+// Single-row LiteDB collection ("ptt_settings") sharing zeus-prefs.db, mirroring
+// ChatEnabledStore. Insert/Update (NOT Upsert with Id=0) avoids the LiteDB
+// Id=0-always-inserts bug (PR #387).
+
+using LiteDB;
+
+namespace Zeus.Server;
+
+public sealed class PttSettingsStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<PttSettingsEntry> _rows;
+    private readonly ILogger<PttSettingsStore> _log;
+    private readonly object _sync = new();
+
+    // Fired on any write so the UI / status endpoint re-reads the gate.
+    public event Action? Changed;
+
+    public PttSettingsStore(ILogger<PttSettingsStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _rows = _db.GetCollection<PttSettingsEntry>("ptt_settings");
+
+        _log.LogInformation("PttSettingsStore initialized at {Path}", dbPath);
+    }
+
+    /// <summary>Whether hardware PTT-IN is promoted to MOX. A missing row (fresh
+    /// install / pre-feature DB) defaults to OFF — hardware PTT-IN keying is
+    /// opt-in; the operator enables the footswitch gate in Radio Settings.</summary>
+    public bool Get()
+    {
+        lock (_sync)
+        {
+            var entry = _rows.FindAll().FirstOrDefault();
+            return entry?.Enabled ?? false;
+        }
+    }
+
+    /// <summary>Replace the global enable gate. Insert-then-Update (matching
+    /// ChatEnabledStore) avoids the LiteDB Id=0 upsert bug (PR #387).</summary>
+    public void Set(bool enabled)
+    {
+        lock (_sync)
+        {
+            var existing = _rows.FindAll().FirstOrDefault();
+            var nowUtc = DateTime.UtcNow;
+            if (existing is null)
+            {
+                _rows.Insert(new PttSettingsEntry { Enabled = enabled, UpdatedUtc = nowUtc });
+            }
+            else
+            {
+                existing.Enabled = enabled;
+                existing.UpdatedUtc = nowUtc;
+                _rows.Update(existing);
+            }
+        }
+        Changed?.Invoke();
+    }
+
+    public void Dispose() => _db.Dispose();
+}
+
+public sealed class PttSettingsEntry
+{
+    public int Id { get; set; }
+    public bool Enabled { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/StreamingHub.cs
+++ b/Zeus.Server.Hosting/StreamingHub.cs
@@ -681,6 +681,19 @@ public sealed class StreamingHub
         }
     }
 
+    public void Broadcast(in PttStatusFrame frame)
+    {
+        if (_clients.IsEmpty) return;
+
+        var payload = new byte[PttStatusFrame.ByteLength];
+        var writer = new FixedBufferWriter(payload, PttStatusFrame.ByteLength);
+        frame.Serialize(writer);
+        foreach (var client in _clients.Values)
+        {
+            if (!client.TryEnqueue(payload)) System.Threading.Interlocked.Increment(ref _dropsOther);
+        }
+    }
+
     public void Broadcast(in AudioChainOrderFrame frame)
     {
         if (_clients.IsEmpty) return;

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -2075,6 +2075,23 @@ public static class ZeusEndpoints
             return Results.Ok(diag.KeyingSnapshot(externalPtt.Snapshot()));
         });
 
+        // Hardware-PTT-IN → MOX enable gate (per-install, default OFF). GET
+        // returns the live lamp level + persisted enable flag + hang time; PUT
+        // flips the gate. A persisted ON flag only ARMS the gate — MOX still
+        // requires a physical footswitch edge (edge-triggered, never on
+        // connect/restart). The lamp tracks the footswitch regardless of the
+        // gate. Ungated per board — every board exposes a PTT-IN line.
+        app.MapGet("/api/radio/ptt-status", (ExternalPttService externalPtt) =>
+        {
+            return Results.Ok(externalPtt.Snapshot());
+        });
+
+        app.MapPut("/api/radio/ptt-status", (PttEnableSetRequest req, PttSettingsStore store, ExternalPttService externalPtt) =>
+        {
+            store.Set(req.Enabled);
+            return Results.Ok(externalPtt.Snapshot());
+        });
+
         app.MapGet("/api/radio/power-calibration", (HardwareDiagnosticsService diag) =>
         {
             return Results.Ok(diag.PowerCalibrationSnapshot());

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -358,6 +358,10 @@ public static class ZeusHost
         // PTT line) into a host MOX request — without it the gateware-driven
         // CW carrier transmits while Zeus stays unkeyed (UI off, meters at
         // idle cadence, FR-6 timeout disarmed).
+        // Per-install hardware-PTT-IN → MOX enable gate (default OFF). Gates
+        // whether ExternalPttService promotes a footswitch edge to MOX; the
+        // PTT-IN status lamp tracks the footswitch regardless.
+        builder.Services.AddSingleton<PttSettingsStore>();
         builder.Services.AddSingleton<ExternalPttService>();
         builder.Services.AddHostedService(sp => sp.GetRequiredService<ExternalPttService>());
 

--- a/tests/Zeus.Contracts.Tests/PttStatusFrameTests.cs
+++ b/tests/Zeus.Contracts.Tests/PttStatusFrameTests.cs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// PTT-IN status lamp wire frame (MsgType 0x37).
+
+using System.Buffers;
+using Zeus.Contracts;
+using Xunit;
+
+namespace Zeus.Contracts.Tests;
+
+public class PttStatusFrameTests
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void RoundTrip_PreservesKeyed(bool keyed)
+    {
+        var frame = new PttStatusFrame(Keyed: keyed);
+
+        var writer = new ArrayBufferWriter<byte>();
+        frame.Serialize(writer);
+
+        Assert.Equal(PttStatusFrame.ByteLength, writer.WrittenCount);
+        Assert.Equal(2, writer.WrittenCount);
+
+        var bytes = writer.WrittenSpan;
+        Assert.Equal((byte)MsgType.PttStatus, bytes[0]);
+        Assert.Equal(keyed ? (byte)1 : (byte)0, bytes[1]);
+
+        var decoded = PttStatusFrame.Deserialize(bytes);
+        Assert.Equal(keyed, decoded.Keyed);
+    }
+
+    [Fact]
+    public void MsgType_PttStatus_Is0x37()
+    {
+        // 0x33–0x35 are RxAudioChainOrder / RxAudioMasterBypass / ChatEvent on
+        // this base, so PttStatus occupies the next free control-plane slot.
+        Assert.Equal((byte)0x37, (byte)MsgType.PttStatus);
+    }
+
+    [Fact]
+    public void Deserialize_RejectsWrongMsgType()
+    {
+        var bogus = new byte[PttStatusFrame.ByteLength];
+        bogus[0] = (byte)MsgType.MoxState; // not PttStatus
+        Assert.Throws<InvalidDataException>(() => PttStatusFrame.Deserialize(bogus));
+    }
+
+    [Fact]
+    public void Deserialize_RejectsTruncated()
+    {
+        var buf = new byte[PttStatusFrame.ByteLength - 1];
+        buf[0] = (byte)MsgType.PttStatus;
+        Assert.Throws<InvalidDataException>(() => PttStatusFrame.Deserialize(buf));
+    }
+}

--- a/tests/Zeus.Server.Tests/ExternalPttServiceTests.cs
+++ b/tests/Zeus.Server.Tests/ExternalPttServiceTests.cs
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Hardware PTT-IN → MOX, both protocols.
+//
+// These tests drive the SHARED debounce/hang/_owned engine through the P1 and
+// P2 entry-point seams and assert:
+//   • P2 PttIn rising → MOX-on with MoxSource.Hardware.
+//   • P2 PttIn falling → 250 ms hang → MOX-off.
+//   • P1 path behaviour unchanged (rising→MOX, falling→hang→off).
+//   • The lamp tracks the raw input per protocol.
+//   • A re-key inside the hang window cancels the release (CW inter-char gap).
+//   • Hardware can never drop a UI/CWX-owned MOX (arbitration preserved → PS
+//     keying untouched).
+//   • The Enable gate stops MOX promotion but the lamp still tracks the input.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Protocol2;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class ExternalPttServiceTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-extptt-{Guid.NewGuid():N}.db");
+    private readonly string _pttDbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-extptt-ptt-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        foreach (var p in new[] { _dbPath, _dbPath + ".pa", _pttDbPath })
+        {
+            try { if (File.Exists(p)) File.Delete(p); } catch { }
+        }
+    }
+
+    private sealed class Harness : IDisposable
+    {
+        public RadioService Radio { get; }
+        public TxService Tx { get; }
+        public StreamingHub Hub { get; }
+        public PttSettingsStore Settings { get; }
+        public ExternalPttService Service { get; }
+
+        public Harness(string dbPath, string pttDbPath, bool enabled = true)
+        {
+            var loggerFactory = NullLoggerFactory.Instance;
+            var dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance, dbPath);
+            var paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, dbPath + ".pa");
+            Radio = new RadioService(loggerFactory, dspStore, paStore);
+            // Connect P2 so TrySetMox's "not connected" interlock passes —
+            // exactly how a live G2 looks to the service.
+            Radio.MarkProtocol2Connected("127.0.0.1:1024", 48_000);
+            Hub = new StreamingHub(new NullLogger<StreamingHub>());
+            var pipeline = new DspPipelineService(Radio, Hub, Array.Empty<IRxAudioSink>(), loggerFactory);
+            Tx = new TxService(Radio, pipeline, Hub, NullBandPlanService.Instance, new NullLogger<TxService>());
+            Settings = new PttSettingsStore(NullLogger<PttSettingsStore>.Instance, pttDbPath);
+            // Set explicitly (PTT-IN defaults OFF / opt-in) so the harness is
+            // deterministic regardless of the store's power-on default.
+            Settings.Set(enabled);
+            Service = new ExternalPttService(Radio, Tx, Hub, Settings, new NullLogger<ExternalPttService>());
+        }
+
+        public void Dispose()
+        {
+            Service.Dispose();
+            Settings.Dispose();
+        }
+    }
+
+    // The MOX takeover/release run on Task.Run; poll briefly for the expected
+    // state instead of racing the ThreadPool.
+    private static bool WaitFor(Func<bool> cond, int timeoutMs = 2000)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.ElapsedMilliseconds < timeoutMs)
+        {
+            if (cond()) return true;
+            Thread.Sleep(5);
+        }
+        return cond();
+    }
+
+    private static P2TelemetryReading Ptt(bool on) =>
+        new P2TelemetryReading(FwdAdc: 0, RevAdc: 0, ExciterAdc: 0, PttIn: on, PllLocked: true);
+
+    [Fact]
+    public void P2_PttInRising_KeysMox_WithHardwareSource()
+    {
+        using var h = new Harness(_dbPath, _pttDbPath);
+
+        h.Service.TestP2Telemetry(Ptt(true));
+
+        Assert.True(WaitFor(() => h.Tx.IsMoxOn));
+        Assert.Equal(MoxSource.Hardware, h.Tx.MoxOwner);
+        Assert.True(h.Service.IsKeyed);
+    }
+
+    [Fact]
+    public void P2_PttInFalling_HoldsForHang_ThenReleases()
+    {
+        using var h = new Harness(_dbPath, _pttDbPath);
+
+        h.Service.TestP2Telemetry(Ptt(true));
+        Assert.True(WaitFor(() => h.Tx.IsMoxOn));
+
+        h.Service.TestP2Telemetry(Ptt(false));
+        // Within the 250 ms hang MOX must still be up (bridges CW gaps).
+        Assert.True(h.Tx.IsMoxOn, "MOX dropped before the 250 ms hang elapsed");
+        Assert.False(h.Service.IsKeyed); // lamp tracks the raw input immediately
+
+        // After the hang the release fires (timer → Task on the ThreadPool).
+        Assert.True(WaitFor(() => !h.Tx.IsMoxOn, timeoutMs: 2000));
+        Assert.Null(h.Tx.MoxOwner);
+    }
+
+    [Fact]
+    public void P2_ReKeyInsideHang_CancelsRelease()
+    {
+        using var h = new Harness(_dbPath, _pttDbPath);
+
+        h.Service.TestP2Telemetry(Ptt(true));
+        Assert.True(WaitFor(() => h.Tx.IsMoxOn));
+
+        h.Service.TestP2Telemetry(Ptt(false)); // arm hang
+        Thread.Sleep(50);
+        h.Service.TestP2Telemetry(Ptt(true));  // re-key inside the window
+
+        // MOX must stay up well past the hang window — the release was cancelled.
+        Thread.Sleep(350);
+        Assert.True(h.Tx.IsMoxOn);
+        Assert.True(h.Service.IsKeyed);
+    }
+
+    [Fact]
+    public void P2_LevelSampled_NoEdge_DoesNotReKey()
+    {
+        // P2 telemetry is level-sampled at high rate; repeated identical levels
+        // must not be treated as edges (no MOX churn, no ownership reseat).
+        using var h = new Harness(_dbPath, _pttDbPath);
+
+        h.Service.TestP2Telemetry(Ptt(true));
+        Assert.True(WaitFor(() => h.Tx.IsMoxOn));
+
+        // Many redundant "still keyed" samples — must remain a single claim.
+        for (int i = 0; i < 20; i++) h.Service.TestP2Telemetry(Ptt(true));
+        Assert.True(h.Tx.IsMoxOn);
+        Assert.Equal(MoxSource.Hardware, h.Tx.MoxOwner);
+    }
+
+    [Fact]
+    public void P1_PttInRising_KeysMox_WithHardwareSource_Unchanged()
+    {
+        using var h = new Harness(_dbPath, _pttDbPath);
+
+        h.Service.TestRawPttP1(true);
+
+        Assert.True(WaitFor(() => h.Tx.IsMoxOn));
+        Assert.Equal(MoxSource.Hardware, h.Tx.MoxOwner);
+        Assert.True(h.Service.IsKeyed);
+
+        h.Service.TestRawPttP1(false);
+        Assert.True(h.Tx.IsMoxOn, "P1 MOX dropped before the hang elapsed");
+        Assert.True(WaitFor(() => !h.Tx.IsMoxOn, timeoutMs: 2000));
+    }
+
+    [Fact]
+    public void Hardware_CannotDrop_UiOwnedMox_ArbitrationPreserved()
+    {
+        // PURESIGNAL / UI keying is paramount: a footswitch release must never
+        // truncate a UI-keyed transmission. The hardware path goes through the
+        // EXISTING TrySetMox(MoxSource.Hardware) arbitration.
+        using var h = new Harness(_dbPath, _pttDbPath);
+
+        Assert.True(h.Tx.TrySetMox(true, MoxSource.UI, out _));
+        Assert.Equal(MoxSource.UI, h.Tx.MoxOwner);
+
+        // Hardware rising while UI owns: the IsMoxOn gate ignores the echo, so
+        // no takeover and ownership stays UI.
+        h.Service.TestP2Telemetry(Ptt(true));
+        Thread.Sleep(50);
+        Assert.True(h.Tx.IsMoxOn);
+        Assert.Equal(MoxSource.UI, h.Tx.MoxOwner);
+
+        // Hardware falling + full hang: the release is attempted but rejected by
+        // the arbitration (foreign source can't drop UI's MOX).
+        h.Service.TestP2Telemetry(Ptt(false));
+        Thread.Sleep(350);
+        Assert.True(h.Tx.IsMoxOn);
+        Assert.Equal(MoxSource.UI, h.Tx.MoxOwner);
+    }
+
+    [Fact]
+    public void EnableGate_Off_SuppressesMox_ButLampStillTracks()
+    {
+        using var h = new Harness(_dbPath, _pttDbPath, enabled: false);
+
+        h.Service.TestP2Telemetry(Ptt(true));
+        Thread.Sleep(50);
+
+        // No MOX promotion when the gate is off…
+        Assert.False(h.Tx.IsMoxOn);
+        // …but the lamp still reflects the physical footswitch press.
+        Assert.True(h.Service.IsKeyed);
+
+        h.Service.TestP2Telemetry(Ptt(false));
+        Assert.False(h.Service.IsKeyed);
+    }
+
+    [Fact]
+    public void EnableGate_On_PromotesToMox()
+    {
+        using var h = new Harness(_dbPath, _pttDbPath, enabled: true);
+
+        h.Service.TestP2Telemetry(Ptt(true));
+
+        Assert.True(WaitFor(() => h.Tx.IsMoxOn));
+        Assert.Equal(MoxSource.Hardware, h.Tx.MoxOwner);
+    }
+}

--- a/tests/Zeus.Server.Tests/PttSettingsStoreTests.cs
+++ b/tests/Zeus.Server.Tests/PttSettingsStoreTests.cs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// PttSettingsStore — per-install hardware-PTT-IN → MOX enable gate.
+//   • Default OFF: a fresh DB (no row) returns false (opt-in safety).
+//   • Set/Get round-trips both directions.
+//   • The flag PERSISTS across a store re-open on the same DB path (a persisted
+//     ON flag arms the gate after restart; it never auto-keys MOX — that stays
+//     edge-triggered in ExternalPttService).
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class PttSettingsStoreTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-pttstore-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+    }
+
+    [Fact]
+    public void Get_FreshDb_DefaultsOff()
+    {
+        using var store = new PttSettingsStore(NullLogger<PttSettingsStore>.Instance, _dbPath);
+        Assert.False(store.Get());
+    }
+
+    [Fact]
+    public void SetGet_RoundTripsBothDirections()
+    {
+        using var store = new PttSettingsStore(NullLogger<PttSettingsStore>.Instance, _dbPath);
+
+        store.Set(true);
+        Assert.True(store.Get());
+
+        store.Set(false);
+        Assert.False(store.Get());
+    }
+
+    [Fact]
+    public void Set_RaisesChanged()
+    {
+        using var store = new PttSettingsStore(NullLogger<PttSettingsStore>.Instance, _dbPath);
+        int fired = 0;
+        store.Changed += () => fired++;
+
+        store.Set(true);
+        store.Set(false);
+
+        Assert.Equal(2, fired);
+    }
+
+    [Fact]
+    public void Enabled_PersistsAcrossReopen()
+    {
+        // Set ON, dispose, reopen on the same DB path — the gate stays armed.
+        using (var store = new PttSettingsStore(NullLogger<PttSettingsStore>.Instance, _dbPath))
+        {
+            store.Set(true);
+        }
+
+        using (var reopened = new PttSettingsStore(NullLogger<PttSettingsStore>.Instance, _dbPath))
+        {
+            Assert.True(reopened.Get());
+        }
+    }
+
+    [Fact]
+    public void Disabled_PersistsAcrossReopen()
+    {
+        // Flipping back OFF must also survive a restart (no stale ON row).
+        using (var store = new PttSettingsStore(NullLogger<PttSettingsStore>.Instance, _dbPath))
+        {
+            store.Set(true);
+            store.Set(false);
+        }
+
+        using (var reopened = new PttSettingsStore(NullLogger<PttSettingsStore>.Instance, _dbPath))
+        {
+            Assert.False(reopened.Get());
+        }
+    }
+}

--- a/zeus-web/src/components/RadioSettingsPanel.tsx
+++ b/zeus-web/src/components/RadioSettingsPanel.tsx
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// RADIO SETTINGS tab. First (and currently only) control: the hardware
+// PTT-IN → MOX opt-in gate, with a live PTT-IN status lamp.
+//
+// Every board exposes a PTT-IN line (P1 boards via C0[0] / ptt_resp, P2 boards
+// via the UDP-1025 hi-priority PttIn bit), so this card is ungated by board.
+// The `keyed` lamp is driven live by the PttStatusFrame WS edge regardless of
+// the enable toggle; the toggle only controls whether a footswitch press is
+// promoted to host MOX. Defaults OFF (opt-in) server-side.
+//
+// Visual idiom reuses PsSettingsPanel's `.ps-shell` / `.ps-card` / `.ps-field`
+// surfaces (tokens only, no new chrome / palette). Layout / visual specifics
+// are the maintainer's call — this stays clean and minimal.
+
+import { useEffect } from 'react';
+import { usePttStore } from '../state/ptt-store';
+
+export function RadioSettingsPanel() {
+  const pttKeyed = usePttStore((s) => s.keyed);
+  const pttEnabled = usePttStore((s) => s.enabled);
+  const pttHangMs = usePttStore((s) => s.hangMs);
+  const pttInflight = usePttStore((s) => s.inflight);
+  const loadPtt = usePttStore((s) => s.load);
+  const setPttEnabled = usePttStore((s) => s.setEnabled);
+
+  useEffect(() => {
+    void loadPtt();
+  }, [loadPtt]);
+
+  return (
+    <div className="ps-shell">
+      <div className="ps-card">
+        <h4>
+          <svg className="ps-ic-sm" viewBox="0 0 12 12">
+            <path d="M6 1v4M3.5 5h5v3a2.5 2.5 0 0 1-5 0z" />
+          </svg>
+          PTT-IN
+          <span className="ps-card-hint">footswitch / mic-PTT / rear KEY</span>
+        </h4>
+
+        <div className="ps-field">
+          <div className="ps-name">
+            Status
+            <em>
+              Live hardware PTT-IN level. Read-only — the radio drives this when
+              you press the footswitch / mic PTT (or ground the rear KEY).
+            </em>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <span
+              aria-hidden
+              style={{
+                width: '0.6rem',
+                height: '0.6rem',
+                borderRadius: '50%',
+                background: pttKeyed ? 'var(--tx)' : 'var(--fg-3)',
+                boxShadow: pttKeyed ? '0 0 6px var(--tx-soft)' : 'none',
+                transition: 'background 60ms linear',
+              }}
+            />
+            <span style={{ color: pttKeyed ? 'var(--tx)' : 'var(--fg-2)' }}>
+              {pttKeyed ? 'KEYED' : 'idle'}
+            </span>
+          </div>
+        </div>
+
+        <div className="ps-field">
+          <div className="ps-name">
+            Enable
+            <em>
+              When off, the footswitch is ignored for keying (UI-only TX). The
+              lamp above still shows the physical input.
+            </em>
+          </div>
+          <label className="ps-check">
+            <input
+              type="checkbox"
+              checked={pttEnabled}
+              disabled={pttInflight}
+              onChange={(e) => void setPttEnabled(e.target.checked)}
+            />
+            <span className="ps-check-box" />
+            <span>Hardware PTT → MOX</span>
+          </label>
+        </div>
+
+        <div className="ps-field">
+          <div className="ps-name">
+            Hang
+            <em>Release hang time — bridges CW inter-character gaps. Fixed for now.</em>
+          </div>
+          <span style={{ color: 'var(--fg-2)' }}>{pttHangMs} ms</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/zeus-web/src/components/SettingsMenu.tsx
+++ b/zeus-web/src/components/SettingsMenu.tsx
@@ -28,6 +28,7 @@ import { CalibrationPanel } from './CalibrationPanel';
 import { DisplayPanel } from './DisplayPanel';
 import { QrzSettingsPanel } from './QrzSettingsPanel';
 import { RadioOptionsPanel } from './RadioOptionsPanel';
+import { RadioSettingsPanel } from './RadioSettingsPanel';
 import { RotatorSettingsPanel } from './RotatorSettingsPanel';
 import { ServerUrlPanel } from './ServerUrlPanel';
 import { TciSettingsPanel } from './TciSettingsPanel';
@@ -60,6 +61,7 @@ export type SettingsTabId =
   | 'spots'
   | 'server'
   | 'radio'
+  | 'radio-settings'
   | 'calibration'
   | 'updates'
   | 'about';
@@ -80,6 +82,7 @@ const TABS: ReadonlyArray<{ id: SettingsTabId; label: string }> = [
   { id: 'spots', label: 'SPOTS' },
   { id: 'server', label: 'SERVER' },
   { id: 'radio', label: 'RADIO' },
+  { id: 'radio-settings', label: 'RADIO SETTINGS' },
   { id: 'calibration', label: 'CALIBRATION' },
   { id: 'updates', label: 'UPDATES' },
   { id: 'about', label: 'ABOUT' },
@@ -219,6 +222,7 @@ export function SettingsView({ initialTab, onClose }: Props) {
           {activeTab === 'spots' && <SpotsSettingsPanel />}
           {activeTab === 'server' && <ServerUrlPanel />}
           {activeTab === 'radio' && hasRadioOptions && <RadioOptionsPanel />}
+          {activeTab === 'radio-settings' && <RadioSettingsPanel />}
           {activeTab === 'calibration' && <CalibrationPanel />}
           {activeTab === 'updates' && <UpdatesPanel />}
           {activeTab === 'about' && <AboutPanel />}

--- a/zeus-web/src/realtime/ws-client.ts
+++ b/zeus-web/src/realtime/ws-client.ts
@@ -63,6 +63,7 @@ import { useAudioSuiteStore } from '../state/audio-suite-store';
 import { CW_STATE_FROM_BYTE, useCwStore } from '../state/cw-store';
 import { useSpotStore } from '../state/spot-store';
 import { useChatStore, type ChatEnvelope } from '../state/chat-store';
+import { usePttStore } from '../state/ptt-store';
 import { warnOnce } from '../util/logger';
 import { clampFinite } from '../util/number';
 import { wsUrl as buildWsUrl } from '../serverUrl';
@@ -197,6 +198,14 @@ const RX_AUDIO_MASTER_BYPASS_BYTES = 2;
 // so the ChatPanel stays live without polling. Contract:
 // Zeus.Contracts/ChatEventFrame.cs.
 export const MSG_TYPE_CHAT_EVENT = 0x35;
+
+// Hardware PTT-IN status edge — broadcast on every footswitch / mic-PTT /
+// rear-KEY edge so the Radio Settings PTT-IN lamp tracks the physical input
+// (P1 HardwarePttChanged, P2 UDP-1025 PttIn). Read-only indicator; does NOT
+// drive MOX (that flows through the gated server-side ExternalPttService).
+// Wire shape: [0x37][keyed:u8] = 2 bytes. Contract: Zeus.Contracts/PttStatusFrame.cs.
+export const MSG_TYPE_PTT_STATUS = 0x37;
+const PTT_STATUS_BYTES = 2;
 
 // CW engine status — broadcast on every state edge of the host-side CW
 // keyer so the macro pad can render in-flight text + queue depth without
@@ -579,6 +588,18 @@ export function startRealtime(path = '/ws'): () => void {
           }
           const bypassed = new DataView(ev.data).getUint8(1) !== 0;
           useAudioSuiteStore.getState().setRxMasterBypassedFromServer(bypassed);
+          return;
+        }
+        if (peekType === MSG_TYPE_PTT_STATUS) {
+          if (ev.data.byteLength < PTT_STATUS_BYTES) {
+            warnOnce(
+              'ws-ptt-status-short',
+              `PTT status frame too short: ${ev.data.byteLength}`,
+            );
+            return;
+          }
+          const keyed = new DataView(ev.data).getUint8(1) !== 0;
+          usePttStore.getState().setKeyed(keyed);
           return;
         }
         if (peekType === MSG_TYPE_PA_TEMP) {

--- a/zeus-web/src/state/ptt-store.ts
+++ b/zeus-web/src/state/ptt-store.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Hardware-PTT-IN status store. Holds the live footswitch / mic-PTT / rear-KEY
+// level for the Radio Settings "PTT-IN: idle / keyed" lamp, plus the
+// MOX-promotion enable gate and the fixed release hang.
+//
+// `keyed` is written from the WS dispatcher on every PttStatusFrame (0x37).
+// The frame source is per-protocol on the server (P1 HardwarePttChanged, P2
+// UDP-1025 PttIn) so the lamp tracks the physical input regardless of board.
+// `enabled` / `hangMs` hydrate from GET /api/radio/ptt-status on mount and
+// re-sync on a PUT toggle — server-authoritative, never clobbered on connect.
+
+import { create } from 'zustand';
+
+export interface PttStatus {
+  /** Live PTT-IN level — true while the hardware footswitch/mic-PTT is held. */
+  keyed: boolean;
+  /** Whether hardware PTT is promoted to MOX. Defaults OFF server-side (opt-in). */
+  enabled: boolean;
+  /** Fixed release hang in ms (250). Read-only label; knob is out of scope. */
+  hangMs: number;
+}
+
+// The server returns ExternalPttStatusDto (camelCase JSON). We only consume the
+// `enabled` gate and `hangTimeMs` here; the live lamp level rides the WS frame.
+function parse(raw: unknown): { enabled: boolean; hangMs: number } {
+  const r = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+  return {
+    enabled: typeof r.enabled === 'boolean' ? r.enabled : false,
+    hangMs: typeof r.hangTimeMs === 'number' ? r.hangTimeMs : 250,
+  };
+}
+
+export async function fetchPttStatus(signal?: AbortSignal): Promise<{ enabled: boolean; hangMs: number }> {
+  const res = await fetch('/api/radio/ptt-status', { signal });
+  if (!res.ok) throw new Error(`GET /api/radio/ptt-status → ${res.status}`);
+  return parse(await res.json());
+}
+
+export async function updatePttEnable(
+  enabled: boolean,
+  signal?: AbortSignal,
+): Promise<{ enabled: boolean; hangMs: number }> {
+  const res = await fetch('/api/radio/ptt-status', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ enabled }),
+    signal,
+  });
+  if (!res.ok) throw new Error(`PUT /api/radio/ptt-status → ${res.status}`);
+  return parse(await res.json());
+}
+
+interface PttState extends PttStatus {
+  loaded: boolean;
+  inflight: boolean;
+  error: string | null;
+  /** WS-driven live lamp update (PttStatusFrame). */
+  setKeyed: (keyed: boolean) => void;
+  /** Hydrate enable/hang from the REST snapshot. */
+  load: () => Promise<void>;
+  /** Toggle the MOX-promotion gate (optimistic, server-authoritative). */
+  setEnabled: (enabled: boolean) => Promise<void>;
+  __resetForTests: () => void;
+}
+
+export const usePttStore = create<PttState>((set, get) => ({
+  keyed: false,
+  enabled: false,
+  hangMs: 250,
+  loaded: false,
+  inflight: false,
+  error: null,
+
+  setKeyed: (keyed) => set({ keyed }),
+
+  load: async () => {
+    set({ inflight: true, error: null });
+    try {
+      const s = await fetchPttStatus();
+      // Don't clobber the live lamp with the REST snapshot — the WS frame is
+      // the authority for `keyed` once connected.
+      set({ enabled: s.enabled, hangMs: s.hangMs, loaded: true, inflight: false });
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : String(err), inflight: false });
+    }
+  },
+
+  setEnabled: async (enabled) => {
+    const prev = get().enabled;
+    set({ enabled, inflight: true, error: null });
+    try {
+      const s = await updatePttEnable(enabled);
+      set({ enabled: s.enabled, hangMs: s.hangMs, inflight: false });
+    } catch (err) {
+      set({ enabled: prev, error: err instanceof Error ? err.message : String(err), inflight: false });
+    }
+  },
+
+  __resetForTests: () =>
+    set({ keyed: false, enabled: false, hangMs: 250, loaded: false, inflight: false, error: null }),
+}));


### PR DESCRIPTION
DO NOT MERGE — draft for review (first piece of the external-ports rebuild)

Implements #797: hardware **PTT-IN → MOX** promotion across both protocols, opt-in (default OFF), persisted per-profile, with a new **Radio Settings** Settings tab. Re-port of the PTT slice of old PR #639 (`78c3c28e`).

## Behavior
- A new **RADIO SETTINGS** tab → **PTT-IN** card: a live PTT-IN lamp + an **enable** toggle.
- **PTT only promotes to MOX when (a) you've enabled the toggle AND (b) the physical footswitch is pressed.** Edge-triggered — it **never auto-keys** on connect/reconnect/restart, even with the gate persisted ON.
- The enable flag **persists to the active prefs database** (the profile you pick at startup, via `PrefsDbPath.Get()`), default **OFF**, and survives restart — same store pattern as `ChatEnabledStore`.
- The lamp tracks the footswitch on every edge regardless of the gate; only MOX promotion is gated.

## How it stays safe
- **Default-inert:** promotion routes *only* through `TxService.TrySetMox(true, MoxSource.Hardware, out _)`. The service emits **zero new wire bytes** on any board (verified — no `ControlFrame`/alex writes); the status frame is server→UI only.
- **PureSignal untouched:** diff has **0** PS identifiers (`puresignal|pssettings|psenabled|hwpeak|…`).
- **Protocol1/2 unchanged** — the hooks already existed (`IProtocol1Client.HardwarePtt`, `Protocol2Client.TelemetryReceived → PttIn`).
- Cross-platform (`PrefsDbPath.Get()`, `Connection=shared`).

## Files
New: `Zeus.Contracts/PttStatusFrame.cs`, `Zeus.Server.Hosting/PttSettingsStore.cs`, `zeus-web/src/components/RadioSettingsPanel.tsx`, `zeus-web/src/state/ptt-store.ts`, + 3 test files.
Changed: `MsgType.cs`, `Dtos.cs`, `ExternalPttService.cs` (additive graft), `StreamingHub.cs`, `ZeusEndpoints.cs` (`/api/radio/ptt-status`), `ZeusHost.cs` (DI), `SettingsMenu.tsx`, `ws-client.ts`.

## 🚩 Needs your sign-off (red-light)
1. **Zeus.Contracts wire change** — new `MsgType.PttStatus = 0x36` + `PttStatusFrame` + nullable `ExternalPttStatusDto.Enabled` + `PttEnableSetRequest`. Append-only/nullable, no existing consumer broke.
2. **P1 default-behavior inversion (operator-facing)** — previously P1 hardware PTT promoted to MOX *unconditionally*; it's now gated default-OFF (matching your "only engage when the user engages it"). **Existing P1/HL2 footswitch users will find the footswitch inert until they enable it** in Radio Settings. This is the safety-correct behavior, but it's a felt default change — your/Brian's call.
3. **PTT card visuals/UX** are red-light (Brian/Doug).

## Test plan
- [x] `dotnet build Zeus.slnx` 0/0 · `npm run build` clean
- [x] PttStatusFrame 5/5 · ExternalPttService + PttSettingsStore (incl. persistence-across-restart + default-OFF) + keying regression 19/19
- [ ] **Bench (you):** on G2 (P2) and/or HL2 (P1) — enable the toggle, press footswitch → keys MOX; disable → footswitch inert; lamp tracks footswitch either way; setting survives restart. Not bench-tested on live hardware yet (per scope).

Refs #797
