### PR TITLE
feat(layout): paginate panels onto a new workspace when the page is full

### DIFF
--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -173,6 +173,7 @@ export function FlexWorkspace({
         workspaceLocked={workspaceLocked}
         isLoaded={isLoaded}
         layoutId={targetLayoutId}
+        isPrimary={!layoutId}
         onLayoutChange={onLayoutChange}
         onRequestRemoveTile={(uid, title) => setPendingRemoveTile({ uid, title })}
         onToggleTileLock={(uid, locked, lockedHeightPx) =>
@@ -226,6 +227,9 @@ interface WorkspaceCanvasProps {
   workspaceLocked: boolean;
   isLoaded: boolean;
   layoutId: string;
+  /** True for the main dock workspace (not a detached window). Only the primary
+   *  reports its page size to the store, which drives add-panel pagination. */
+  isPrimary: boolean;
   onLayoutChange: (next: Layout) => void;
   onRequestRemoveTile: (uid: string, title: string) => void;
   onToggleTileLock: (
@@ -240,6 +244,7 @@ function WorkspaceCanvas({
   workspaceLocked,
   isLoaded,
   layoutId,
+  isPrimary,
   onLayoutChange,
   onRequestRemoveTile,
   onToggleTileLock,
@@ -371,6 +376,20 @@ function WorkspaceCanvas({
     [deriveTiles, gridHeight],
   );
   const { rowHeight, rowMargin } = derived;
+
+  // Report this workspace's live page size (in grid cells) to the store so the
+  // add-panel flow knows when a panel no longer fits the visible page and must
+  // spill onto a new workspace tab. Only the primary (docked) workspace reports;
+  // detached windows do not drive pagination.
+  const setViewportPage = useLayoutStore((s) => s.setViewportPage);
+  useEffect(() => {
+    if (!isPrimary || !(rowHeight > 0)) return;
+    const visibleRows = Math.max(
+      1,
+      Math.floor((gridHeight + rowMargin) / (rowHeight + rowMargin)),
+    );
+    setViewportPage(cols, visibleRows);
+  }, [isPrimary, cols, gridHeight, rowHeight, rowMargin, setViewportPage]);
 
   // Stored geometry, keyed by uid, for reconciling RGL's echo of the derived
   // (possibly shrunk) render layout back to what we persist. Refs keep the

--- a/zeus-web/src/layout/workspace.test.ts
+++ b/zeus-web/src/layout/workspace.test.ts
@@ -6,6 +6,7 @@ import {
   WORKSPACE_OVERSIZED_LAYOUT_NORMALIZED_ROWS,
   parseWorkspaceLayout,
   placeTileInGrid,
+  placeTileInPage,
   type WorkspaceTile,
 } from './workspace';
 
@@ -122,5 +123,34 @@ describe('placeTileInGrid', () => {
     ];
     const placed = placeTileInGrid('qrz', others);
     expect(others.some((t) => overlaps(placed, t))).toBe(false);
+  });
+});
+
+describe('placeTileInPage (pagination bounds)', () => {
+  it('places within the page when a slot is free', () => {
+    // cw is 8×8. Empty page → origin.
+    expect(placeTileInPage('cw', [], 24, 48)).toEqual({ x: 0, y: 0, w: 8, h: 8 });
+  });
+
+  it('returns null when nothing fits the page (signals paginate)', () => {
+    // A single tile filling the whole 24×48 page leaves no room for an 8×8.
+    const full = [tile({ uid: 'full', x: 0, y: 0, w: 24, h: 48 })];
+    expect(placeTileInPage('cw', full, 24, 48)).toBeNull();
+  });
+
+  it('finds a free slot inside the page rather than appending below', () => {
+    // Top 24×8 band is taken; an 8×8 should drop to the next free row, NOT below
+    // the page fold (placeTileInGrid would append below; this stays in-page).
+    const others = [tile({ uid: 'band', x: 0, y: 0, w: 24, h: 8 })];
+    const placed = placeTileInPage('cw', others, 24, 48);
+    expect(placed).not.toBeNull();
+    expect(placed!.y).toBe(8);
+    expect(placed!.y + placed!.h).toBeLessThanOrEqual(48);
+  });
+
+  it('places an oversized tile at the origin instead of paginating forever', () => {
+    // hero is 18×24; on a tiny 6×6 page it can never fit, so it must NOT return
+    // null (which would spill endlessly) — it lands at the origin.
+    expect(placeTileInPage('hero', [], 6, 6)).toMatchObject({ x: 0, y: 0 });
   });
 });

--- a/zeus-web/src/layout/workspace.ts
+++ b/zeus-web/src/layout/workspace.ts
@@ -168,6 +168,41 @@ export function placeTileInGrid(
   return { x: 0, y: bottom, w, h };
 }
 
+/** Find a home for a new tile WITHIN a fixed page (pageCols × pageRows), the
+ *  visible workspace area. Same first-fit scan as placeTileInGrid but bounded:
+ *  returns null when the tile's footprint does not fit in any free slot inside
+ *  the page. The caller (layout-store) uses null as the signal to paginate —
+ *  spill the panel onto a fresh workspace — instead of appending it below the
+ *  fold where it would be clipped (the workspace never scrolls). A tile taller
+ *  or wider than a whole page can never fit one, so it is placed at the origin
+ *  rather than triggering an endless paginate. */
+export function placeTileInPage(
+  panelId: string,
+  others: WorkspaceTile[],
+  pageCols: number,
+  pageRows: number,
+): { x: number; y: number; w: number; h: number } | null {
+  const span = defaultSpanFor(panelId);
+  const cols = Math.max(1, Math.floor(pageCols));
+  const rows = Math.max(1, Math.floor(pageRows));
+  const w = Math.min(span.w, cols);
+  const h = span.h;
+  // Larger than a whole page in either axis — no page can hold it, so don't
+  // paginate forever; place it at the origin of the current page.
+  if (h > rows || span.w > cols) return { x: 0, y: 0, w, h };
+  const maxX = cols - w;
+  const maxY = rows - h;
+  for (let y = 0; y <= maxY; y += 1) {
+    for (let x = 0; x <= maxX; x += 1) {
+      const candidate = { x, y, w, h };
+      if (!others.some((t) => tilesOverlap(candidate, t))) {
+        return candidate;
+      }
+    }
+  }
+  return null;
+}
+
 function tilesOverlap(
   a: { x: number; y: number; w: number; h: number },
   b: { x: number; y: number; w: number; h: number },

--- a/zeus-web/src/state/__tests__/layout-store.test.ts
+++ b/zeus-web/src/state/__tests__/layout-store.test.ts
@@ -40,11 +40,16 @@ describe('layout-store / workspace tile mutators', () => {
     vi.useRealTimers();
   });
 
-  it('addTile appends a new tile with a fresh uid', () => {
-    const before = useLayoutStore.getState().workspace.tiles.length;
+  it('addTile adds a tile with a fresh uid and default span when the page has room', () => {
+    // Empty page → the tile fits, so no pagination: it lands on the current
+    // workspace.
+    useLayoutStore.setState({ workspace: EMPTY_WORKSPACE_LAYOUT });
+    const activeBefore = useLayoutStore.getState().activeLayoutId;
     const uid = useLayoutStore.getState().addTile('cw');
-    const after = useLayoutStore.getState().workspace.tiles;
-    expect(after.length).toBe(before + 1);
+    const state = useLayoutStore.getState();
+    expect(state.activeLayoutId).toBe(activeBefore); // did not paginate
+    const after = state.workspace.tiles;
+    expect(after.length).toBe(1);
     const tile = after[after.length - 1];
     expect(tile?.panelId).toBe('cw');
     expect(tile?.uid).toBe(uid);
@@ -54,15 +59,23 @@ describe('layout-store / workspace tile mutators', () => {
     expect(tile?.h).toBe(8);
   });
 
-  it('addTile places the new tile at y = max(existing y+h)', () => {
-    // DEFAULT_WORKSPACE_LAYOUT's tallest existing y+h is hero/dsp at
-    // y=16+32 / y=38+10 = 48 on the 24×48 grid. So the new tile lands at y=48.
+  it('addTile spills onto a new workspace when the current page is full', () => {
+    // DEFAULT_WORKSPACE_LAYOUT fills the 24×48 page (no free 8×8 slot), so the
+    // workspace never scrolls — instead the panel paginates: a new workspace tab
+    // is created, switched to, and the panel lands at the origin of the fresh
+    // page.
+    const layoutsBefore = useLayoutStore.getState().layouts.length;
+    const activeBefore = useLayoutStore.getState().activeLayoutId;
     const uid = useLayoutStore.getState().addTile('cw');
-    const tile = useLayoutStore
-      .getState()
-      .workspace.tiles.find((t) => t.uid === uid);
-    expect(tile?.y).toBe(48);
+    const state = useLayoutStore.getState();
+    expect(state.layouts.length).toBe(layoutsBefore + 1);
+    expect(state.activeLayoutId).not.toBe(activeBefore);
+    const tiles = state.workspace.tiles;
+    expect(tiles.length).toBe(1);
+    const tile = tiles.find((t) => t.uid === uid);
+    expect(tile?.panelId).toBe('cw');
     expect(tile?.x).toBe(0);
+    expect(tile?.y).toBe(0);
   });
 
   it('addTile allows multi-instance panels (meters) to be added more than once', () => {

--- a/zeus-web/src/state/layout-store.ts
+++ b/zeus-web/src/state/layout-store.ts
@@ -23,6 +23,9 @@ import {
   newTileUid,
   parseWorkspaceLayout,
   placeTileInGrid,
+  placeTileInPage,
+  WORKSPACE_GRID_COLS,
+  WORKSPACE_TARGET_ROWS,
   type WorkspaceLayout,
   type WorkspaceTile,
 } from '../layout/workspace';
@@ -75,6 +78,15 @@ interface LayoutState {
   workspace: WorkspaceLayout;
   /** True after loadFromServer() has run (success or 404 / network error). */
   isLoaded: boolean;
+  // Live page size (in grid cells) of the visible PRIMARY workspace, reported
+  // by FlexWorkspace as the window resizes. Used by addTile to decide when a new
+  // panel no longer fits the current page and must spill onto a fresh workspace
+  // (pagination). Defaults to the authored design fold until the first report.
+  viewportCols: number;
+  viewportRows: number;
+  /** Report the visible primary-workspace page size (grid cells). No-op when
+   *  unchanged so it can be called freely from a resize effect. */
+  setViewportPage: (cols: number, rows: number) => void;
   // Add-Panel modal visibility — lifted into the store so the trigger
   // button can live wherever (LeftLayoutBar, FlexWorkspace) while the modal
   // itself still renders inside the workspace.
@@ -226,12 +238,34 @@ function findActive(layouts: NamedLayout[], id: string): NamedLayout | undefined
   return layouts.find((l) => l.id === id);
 }
 
+/** Name for a spillover page derived from the page it overflowed from. Strips a
+ *  trailing number off the base name ("Default 2" → "Default") and picks the
+ *  lowest free "Base N" (N ≥ 2), so pages read Default → Default 2 → Default 3. */
+function nextPageName(
+  layouts: NamedLayout[],
+  from: NamedLayout | undefined,
+): string {
+  const base = (from?.name ?? 'Workspace').replace(/\s+\d+$/, '').trim() || 'Workspace';
+  const taken = new Set(layouts.map((l) => l.name));
+  let n = 2;
+  while (taken.has(`${base} ${n}`)) n += 1;
+  return `${base} ${n}`;
+}
+
 export const useLayoutStore = create<LayoutState>((set, get) => ({
   radioKey: '',
   layouts: [],
   activeLayoutId: DEFAULT_LAYOUT_ID,
   workspace: DEFAULT_WORKSPACE_LAYOUT,
   isLoaded: false,
+  viewportCols: WORKSPACE_GRID_COLS,
+  viewportRows: WORKSPACE_TARGET_ROWS,
+  setViewportPage: (cols, rows) => {
+    const c = Math.max(1, Math.floor(cols));
+    const r = Math.max(1, Math.floor(rows));
+    if (get().viewportCols === c && get().viewportRows === r) return;
+    set({ viewportCols: c, viewportRows: r });
+  },
   addPanelOpen: false,
   setAddPanelOpen: (open) => set({ addPanelOpen: open }),
 
@@ -421,12 +455,38 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
   },
 
   addTileToLayout: (layoutId, panelId, opts) => {
-    const target = findActive(get().layouts, layoutId);
-    if (!target && layoutId !== get().activeLayoutId) return null;
-    const workspace = layoutId === get().activeLayoutId
-      ? get().workspace
+    const state = get();
+    const target = findActive(state.layouts, layoutId);
+    const isActive = layoutId === state.activeLayoutId;
+    if (!target && !isActive) return null;
+    const workspace = isActive
+      ? state.workspace
       : parseLayoutOrDefault(target!.layoutJson);
-    const placement = placeTileInGrid(panelId, workspace.tiles);
+
+    // Pagination — only for the visible (active) workspace. The workspace never
+    // scrolls, so a panel that would land below/right of the page must spill
+    // onto a fresh workspace tab rather than off-screen. placeTileInPage returns
+    // null when nothing fits the current page; in that case mint the next page,
+    // switch to it, and add there (the new page is empty, so it fits).
+    let placement: { x: number; y: number; w: number; h: number };
+    if (isActive) {
+      const fit = placeTileInPage(
+        panelId,
+        workspace.tiles,
+        state.viewportCols,
+        state.viewportRows,
+      );
+      if (fit === null) {
+        const newId = state.addLayout(
+          nextPageName(state.layouts, target),
+          target?.icon ? { icon: target.icon } : undefined,
+        );
+        return get().addTileToLayout(newId, panelId, opts);
+      }
+      placement = fit;
+    } else {
+      placement = placeTileInGrid(panelId, workspace.tiles);
+    }
     const uid = newTileUid();
     const tile: WorkspaceTile = {
       uid,


### PR DESCRIPTION
## Summary

Builds on the fixed-cell workspace (#798). Since the workspace never scrolls, a newly added panel that no longer fits the visible page needs somewhere reachable to go. Instead of appending it below the fold (where `overflow: hidden` clips it), it **spills onto a fresh workspace tab that opens** — the most intuitive/premium model (iOS Launchpad pages, adding a slide in Keynote, browser tab groups). Works identically whether the window is maximized or not, with zero scrollbars.

## How it works

- **`placeTileInPage(panelId, others, pageCols, pageRows)`** — bounded first-fit within the *visible* page; returns `null` when nothing fits (the paginate signal). A tile larger than a whole page is placed at the origin rather than paginating forever.
- **FlexWorkspace** reports the primary (docked) workspace's live page size in grid cells (`cols × visible rows`) to the store as the window resizes. Detached windows don't drive pagination.
- **`addTileToLayout`** — when the active page is full, it mints the next page (`Default → Default 2 → Default 3`), switches to it, and drops the panel at the origin. Because the new page becomes active, subsequent adds fill it first, so adding many panels doesn't spam near-empty pages.

## Verification

- Typecheck clean; layout + state tests pass, incl. new coverage:
  - `placeTileInPage`: fits-in-page, returns-null-when-full, in-page-gap (not below fold), oversized-at-origin.
  - `addTileToLayout`: adds in place when there's room; spills to a new workspace + switches when the page is full.
- Bench-test in the desktop app recommended (preview can't render the WebGL panels).

## Notes for review

Pages reuse the existing left-bar workspace tabs (no new chrome). Naming derives from the source page; auto-pages live in the same list as user layouts (Launchpad-style). Flagging the UX for maintainer eyes per CLAUDE.md.