### PR TITLE
feat(mobile): add install-as-app (PWA) banner to mobile view

### DIFF
--- a/zeus-web/src/main.tsx
+++ b/zeus-web/src/main.tsx
@@ -90,6 +90,9 @@ import App from './App.tsx';
 import { AppErrorBoundary } from './layout/AppErrorBoundary';
 import { installFetchInterceptor } from './serverUrl';
 import { loadInstalledPluginUis } from './plugins/runtime/pluginRuntime';
+// Side-effect import: registers the `beforeinstallprompt` capture before the
+// lazily-loaded mobile shell mounts, so the install banner can replay it.
+import './pwa/pwa-install';
 
 // Capacitor / standalone-host builds set localStorage["zeus.serverUrl"]
 // to a LAN address; on plain web this is a no-op (relative paths).

--- a/zeus-web/src/mobile/MobileApp.tsx
+++ b/zeus-web/src/mobile/MobileApp.tsx
@@ -32,6 +32,7 @@ import { Panadapter } from '../components/Panadapter';
 import { WaterfallSurface } from '../components/WaterfallSurface';
 import { MobilePttButton } from '../components/MobilePttButton';
 import { MobileFrequencyTrackpad } from './MobileFrequencyTrackpad';
+import { MobileInstallPrompt } from './MobileInstallPrompt';
 import { TunButton } from '../components/TunButton';
 import { PsToggleButton } from '../components/PsToggleButton';
 import { AudioToggle } from '../components/AudioToggle';
@@ -270,6 +271,7 @@ export function MobileApp() {
       )}
 
       <main className="m-stack">
+        <MobileInstallPrompt />
         {activeTab === 'radio' ? (
           <>
             <Section label="Frequency" meta="VFO A">

--- a/zeus-web/src/mobile/MobileInstallPrompt.tsx
+++ b/zeus-web/src/mobile/MobileInstallPrompt.tsx
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+import { useEffect, useState } from 'react';
+import { Download, Share, SquarePlus, X } from 'lucide-react';
+import { isCapacitorRuntime } from '../serverUrl';
+import {
+  getDeferredPrompt,
+  isAppInstalled,
+  isIosSafari,
+  isRunningStandalone,
+  subscribeInstallState,
+  triggerInstall,
+} from '../pwa/pwa-install';
+
+const DISMISS_KEY = 'zeus.pwa.installDismissed';
+
+function readDismissed(): boolean {
+  try {
+    return localStorage.getItem(DISMISS_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function writeDismissed(): void {
+  try {
+    localStorage.setItem(DISMISS_KEY, '1');
+  } catch {
+    /* private mode — banner just reappears next session, harmless. */
+  }
+}
+
+/**
+ * "Install as app" banner for the mobile shell. Two paths:
+ *  - Chromium (Android, desktop) hands us a `beforeinstallprompt` we replay
+ *    behind an Install button.
+ *  - iOS Safari can't be prompted programmatically, so we show the manual
+ *    Share → Add to Home Screen steps instead.
+ * Hidden when already installed (standalone), inside the Capacitor native
+ * shell, or once the operator dismisses it.
+ */
+export function MobileInstallPrompt() {
+  // Re-render when the deferred prompt arrives or the app gets installed.
+  const [, forceTick] = useState(0);
+  useEffect(() => subscribeInstallState(() => forceTick((n) => n + 1)), []);
+
+  const [dismissed, setDismissed] = useState(readDismissed);
+  const [installing, setInstalling] = useState(false);
+
+  // Never offer a PWA install inside the native Capacitor wrapper — it already
+  // is the installed app.
+  if (isCapacitorRuntime()) return null;
+  if (dismissed) return null;
+  if (isRunningStandalone() || isAppInstalled()) return null;
+
+  const canPrompt = getDeferredPrompt() != null;
+  const iosManual = !canPrompt && isIosSafari();
+
+  // Nothing actionable on this browser (e.g. desktop Firefox, iOS Chrome) —
+  // stay out of the way rather than show instructions that lead nowhere.
+  if (!canPrompt && !iosManual) return null;
+
+  const dismiss = () => {
+    writeDismissed();
+    setDismissed(true);
+  };
+
+  const onInstall = async () => {
+    setInstalling(true);
+    try {
+      const outcome = await triggerInstall();
+      // Accepted → appinstalled fires and unmounts us. Dismissed → leave the
+      // banner so the operator can reconsider; only an explicit X hides it.
+      if (outcome === 'accepted') dismiss();
+    } finally {
+      setInstalling(false);
+    }
+  };
+
+  return (
+    <div className="m-install" role="region" aria-label="Install Zeus as an app">
+      <div className="m-install__icon" aria-hidden="true">
+        <Download size={20} strokeWidth={2.2} />
+      </div>
+      <div className="m-install__body">
+        <div className="m-install__title">Install Zeus</div>
+        {iosManual ? (
+          <div className="m-install__msg">
+            Tap <Share size={13} strokeWidth={2.4} className="m-install__inline" aria-label="Share" />{' '}
+            then <SquarePlus size={13} strokeWidth={2.4} className="m-install__inline" aria-label="Add to Home Screen" />{' '}
+            <strong>Add to Home Screen</strong> to run Zeus full-screen like an app.
+          </div>
+        ) : (
+          <div className="m-install__msg">
+            Add Zeus to your home screen for a full-screen, app-like experience.
+          </div>
+        )}
+      </div>
+      {canPrompt && (
+        <button
+          type="button"
+          className="m-install__btn"
+          onClick={onInstall}
+          disabled={installing}
+        >
+          {installing ? 'Installing…' : 'Install'}
+        </button>
+      )}
+      <button
+        type="button"
+        className="m-install__close"
+        onClick={dismiss}
+        aria-label="Dismiss install prompt"
+        title="Dismiss"
+      >
+        <X size={16} strokeWidth={2.4} />
+      </button>
+    </div>
+  );
+}

--- a/zeus-web/src/mobile/mobile.css
+++ b/zeus-web/src/mobile/mobile.css
@@ -574,6 +574,79 @@
   min-height: 36px;
 }
 .m-mic-gate__btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* "Install as app" banner (mobile). Accent-tinted card — inviting, not an
+   alert (mic-gate owns the red/tx treatment). Sits at the top of the stack
+   and is dismissible. */
+.m-install {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  background: var(--accent-soft);
+  border: 1px solid var(--accent);
+  border-radius: var(--r-md);
+  color: var(--fg-1);
+}
+.m-install__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 34px;
+  height: 34px;
+  border-radius: var(--r-md);
+  background: var(--accent);
+  color: #06121f;
+}
+.m-install__body { flex: 1 1 auto; min-width: 0; }
+.m-install__title {
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: 0.2px;
+  color: var(--fg-0);
+}
+.m-install__msg {
+  font-size: 11.5px;
+  line-height: 1.4;
+  color: var(--fg-2);
+  margin-top: 2px;
+}
+.m-install__msg strong { color: var(--fg-0); }
+.m-install__inline {
+  display: inline-block;
+  vertical-align: -2px;
+  color: var(--accent);
+}
+.m-install__btn {
+  flex: 0 0 auto;
+  padding: 8px 14px;
+  border-radius: var(--r-md);
+  background: var(--accent);
+  color: #06121f;
+  font-weight: 700;
+  font-size: 12px;
+  letter-spacing: 0.4px;
+  cursor: pointer;
+  border: none;
+  min-height: 36px;
+}
+.m-install__btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.m-install__close {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  border-radius: var(--r-md);
+  background: transparent;
+  color: var(--fg-3);
+  cursor: pointer;
+}
+.m-install__close:hover { color: var(--fg-0); }
 .m-mox-row {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;

--- a/zeus-web/src/pwa/pwa-install.ts
+++ b/zeus-web/src/pwa/pwa-install.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+// PWA install plumbing. Chromium fires `beforeinstallprompt` once, early in
+// page life — usually before the lazily-loaded mobile shell mounts. This
+// module is imported eagerly from main.tsx so the event is captured and
+// stashed regardless of which UI tree (desktop or mobile) renders, and the
+// banner can replay the saved prompt whenever it mounts.
+
+// The event isn't in lib.dom yet; model the bits we use.
+export interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: string[];
+  prompt(): Promise<void>;
+  readonly userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+}
+
+let deferredPrompt: BeforeInstallPromptEvent | null = null;
+let installed = false;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const l of listeners) l();
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('beforeinstallprompt', (e) => {
+    // Stop Chrome's default mini-infobar so we can offer install on our own
+    // terms inside the mobile shell.
+    e.preventDefault();
+    deferredPrompt = e as BeforeInstallPromptEvent;
+    emit();
+  });
+  window.addEventListener('appinstalled', () => {
+    installed = true;
+    deferredPrompt = null;
+    emit();
+  });
+}
+
+/** The saved install event, or null when none is pending. */
+export function getDeferredPrompt(): BeforeInstallPromptEvent | null {
+  return deferredPrompt;
+}
+
+/** True once the browser reports the app was installed this session. */
+export function isAppInstalled(): boolean {
+  return installed;
+}
+
+/** Subscribe to install-availability changes. Returns an unsubscribe fn. */
+export function subscribeInstallState(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+/**
+ * Replay the saved install prompt. Resolves with the user's choice, or
+ * 'unavailable' when no prompt is pending (e.g. iOS, already installed).
+ * The prompt is single-use — it's cleared once shown.
+ */
+export async function triggerInstall(): Promise<'accepted' | 'dismissed' | 'unavailable'> {
+  const pending = deferredPrompt;
+  if (!pending) return 'unavailable';
+  await pending.prompt();
+  const choice = await pending.userChoice;
+  deferredPrompt = null;
+  emit();
+  return choice.outcome;
+}
+
+/**
+ * True when the page is already running as an installed PWA (standalone
+ * display mode, or iOS Safari's legacy navigator.standalone flag).
+ */
+export function isRunningStandalone(): boolean {
+  if (typeof window === 'undefined') return false;
+  if (window.matchMedia?.('(display-mode: standalone)').matches) return true;
+  if (window.matchMedia?.('(display-mode: fullscreen)').matches) return true;
+  // iOS Safari predates display-mode and exposes a non-standard flag.
+  return (window.navigator as { standalone?: boolean }).standalone === true;
+}
+
+/** True on iOS / iPadOS, where install is a manual Add-to-Home-Screen flow. */
+export function isIosDevice(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent || '';
+  if (/iPad|iPhone|iPod/.test(ua)) return true;
+  // iPadOS 13+ reports a desktop Mac UA; touch points disambiguate it.
+  return navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1;
+}
+
+/**
+ * True on an iOS browser that can actually Add to Home Screen — only Safari's
+ * WebKit shell offers it. Chrome/Firefox/Edge on iOS (CriOS/FxiOS/EdgiOS) and
+ * in-app webviews cannot, so we don't show them instructions they can't follow.
+ */
+export function isIosSafari(): boolean {
+  if (!isIosDevice()) return false;
+  const ua = navigator.userAgent || '';
+  return /Safari/.test(ua) && !/CriOS|FxiOS|EdgiOS|GSA/.test(ua);
+}


### PR DESCRIPTION
## What

Adds a dismissible **"Install Zeus"** banner to the top of the mobile shell so any visitor — on any device — can install the web client as a home-screen app. The PWA itself was already fully configured (vite-plugin-pwa, manifest, service worker); what was missing was UI to invite the install.

## How

Two install paths, auto-detected:

- **Android / desktop Chromium** → captures the `beforeinstallprompt` event and replays it behind an **Install** button.
- **iOS Safari** (can't be prompted programmatically) → shows the manual **Share → Add to Home Screen** steps with inline icons.

The banner hides itself when:
- already running standalone (installed PWA — `display-mode: standalone` or iOS `navigator.standalone`),
- inside the Capacitor native shell,
- on browsers that can't install (e.g. desktop Firefox, iOS Chrome),
- or once the operator dismisses it (persisted to `localStorage`).

The install event is captured eagerly in `main.tsx` because Chromium fires `beforeinstallprompt` early — before the lazily-loaded mobile shell mounts.

## Files

- `zeus-web/src/pwa/pwa-install.ts` *(new)* — install-event capture + platform helpers.
- `zeus-web/src/mobile/MobileInstallPrompt.tsx` *(new)* — the banner component.
- `zeus-web/src/mobile/mobile.css` — `.m-install` styles (accent-tinted card, uses existing tokens only — distinct from the red mic-gate alert).
- `zeus-web/src/mobile/MobileApp.tsx` — renders the banner at the top of the stack.
- `zeus-web/src/main.tsx` — eager side-effect import of the capture module.

## Verification

- `tsc --noEmit` — clean
- `eslint` on all changed files — clean
- Confirmed all design tokens (`--accent`, `--accent-soft`, `--fg-0..3`, `--r-md`) and lucide icons resolve.

Browser preview was **not** run: the banner is gated on `beforeinstallprompt` / iOS-Safari / HTTPS, none of which fire in a desktop-localhost-HTTP dev context. To see it live, load a production build over HTTPS on a phone (or force the mobile shell with `?mobile=1` on an installable origin).

## Maintainer notes (red-light)

- Banner **copy, styling, and placement** are visual/UX calls — happy to adjust wording, position, or whether it auto-shows vs. living behind a menu item. It's minimal and token-faithful, but surfacing an install nag at all is a UX decision for Brian/Doug.
- Dismissal is currently **permanent** (one `localStorage` flag). If you'd prefer it to reappear after N days, that's a one-line change.
