### PR TITLE
feat(chat): only list operators who have the Chat panel open

### DIFF
--- a/Zeus.Contracts/ChatDtos.cs
+++ b/Zeus.Contracts/ChatDtos.cs
@@ -117,6 +117,15 @@ public sealed record ChatFriendsDto(
 
 public sealed record ChatEnableRequest(bool Enabled);
 
+/// <summary>
+/// Heartbeat from the web client reporting whether the operator currently has
+/// the Chat panel displayed. Presence (the relay connection) is gated on this
+/// in addition to <see cref="ChatEnableRequest"/>: an enabled operator who is
+/// not showing the panel stays off everyone's roster. Sent on panel mount, on
+/// a periodic interval while shown, and as <c>false</c> on unmount.
+/// </summary>
+public sealed record ChatVisibleRequest(bool Visible);
+
 /// <summary>Outgoing message; <paramref name="Room"/> defaults to the public lobby.</summary>
 public sealed record ChatSendRequest(string Text, string? Room = null);
 

--- a/Zeus.Server.Hosting/ChatService.cs
+++ b/Zeus.Server.Hosting/ChatService.cs
@@ -45,6 +45,11 @@ public sealed class ChatService : BackgroundService
     private static readonly TimeSpan ReconnectMinDelay = TimeSpan.FromSeconds(1);
     private static readonly TimeSpan ReconnectMaxDelay = TimeSpan.FromSeconds(30);
 
+    // How long a panel-visible heartbeat keeps the operator "showing the panel"
+    // before it lapses. The web client re-pings every ~15s; this leaves room for
+    // a couple of misses before we drop presence (e.g. the browser was closed).
+    private static readonly TimeSpan PanelActiveTimeout = TimeSpan.FromSeconds(45);
+
     private readonly QrzService _qrz;
     private readonly RadioService _radio;
     private readonly StreamingHub _hub;
@@ -86,6 +91,11 @@ public sealed class ChatService : BackgroundService
     // throttle. Written by event handlers, drained by the worker.
     private readonly PresenceThrottle _presence = new(PresenceThrottleWindow);
     private volatile bool _moxOn;
+
+    // UTC ticks of the last "Chat panel is displayed" heartbeat from the web
+    // client; 0 means the panel is not shown. Presence is gated on this so an
+    // enabled operator who has the panel closed never appears on the roster.
+    private long _panelHeartbeatTicks;
 
     // The live socket, set while connected so SendMessageAsync (API path) can
     // post a {t:"msg"} frame. Null when disconnected.
@@ -138,6 +148,34 @@ public sealed class ChatService : BackgroundService
         }
         Wake();
         return GetStatus();
+    }
+
+    /// <summary>
+    /// Records a heartbeat from the web client reporting whether the operator
+    /// currently has the Chat panel displayed, and wakes the worker so it can
+    /// connect (panel shown) or drop presence (panel hidden). Presence is gated
+    /// on this in addition to the enabled opt-in — see <see cref="PanelActive"/>.
+    /// </summary>
+    public ChatStatusDto ReportPanelVisible(bool visible)
+    {
+        Interlocked.Exchange(ref _panelHeartbeatTicks, visible ? DateTimeOffset.UtcNow.UtcTicks : 0L);
+        Wake();
+        return GetStatus();
+    }
+
+    /// <summary>
+    /// True while a recent panel-visible heartbeat is in force. Lapses
+    /// <see cref="PanelActiveTimeout"/> after the last heartbeat so a closed
+    /// browser (which can't send the explicit <c>false</c>) still drops off.
+    /// </summary>
+    private bool PanelActive
+    {
+        get
+        {
+            var ticks = Interlocked.Read(ref _panelHeartbeatTicks);
+            if (ticks == 0L) return false;
+            return DateTimeOffset.UtcNow - new DateTimeOffset(ticks, TimeSpan.Zero) < PanelActiveTimeout;
+        }
     }
 
     public IReadOnlyList<ChatMessage> GetMessages(int limit) => _messages.Snapshot(limit);
@@ -292,7 +330,10 @@ public sealed class ChatService : BackgroundService
         var backoff = ReconnectMinDelay;
         while (!stoppingToken.IsCancellationRequested)
         {
-            if (!_store.GetEnabled())
+            // Connect only while the operator both opted in AND is showing the
+            // Chat panel. Idling here (no socket) keeps them off everyone's
+            // roster. A heartbeat or enable toggle wakes the loop to re-evaluate.
+            if (!_store.GetEnabled() || !PanelActive)
             {
                 await WaitForWakeAsync(Timeout.InfiniteTimeSpan, stoppingToken);
                 continue;
@@ -432,6 +473,12 @@ public sealed class ChatService : BackgroundService
             // Short wait so pending presence changes flush near the throttle
             // boundary without a busy loop.
             await WaitForWakeAsync(TimeSpan.FromSeconds(1), ct);
+
+            // If the operator disabled chat or stopped showing the panel (the
+            // visible heartbeat lapsed, or the browser closed), tear the link
+            // down so the relay drops them from everyone's roster.
+            if (!_store.GetEnabled() || !PanelActive)
+                return;
 
             var now = DateTimeOffset.UtcNow;
             if (_presence.TryTake(now, out var p))

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -2449,6 +2449,11 @@ public static class ZeusEndpoints
         // ── ZeusChat — operator-to-operator chat over the Cloudflare relay ──
         app.MapGet("/api/chat/status", (ChatService chat) => chat.GetStatus());
 
+        // Web-client heartbeat: presence is published only while the operator is
+        // showing the Chat panel (so closing/hiding it drops them off the roster).
+        app.MapPost("/api/chat/visible", (ChatVisibleRequest req, ChatService chat) =>
+            Results.Ok(chat.ReportPanelVisible(req.Visible)));
+
         app.MapPost("/api/chat/enable", (ChatEnableRequest req, ChatService chat) =>
         {
             log.LogInformation("api.chat.enable enabled={Enabled}", req.Enabled);

--- a/zeus-web/src/api/chat.ts
+++ b/zeus-web/src/api/chat.ts
@@ -185,6 +185,24 @@ export function chatSetEnabled(enabled: boolean, signal?: AbortSignal): Promise<
   );
 }
 
+/**
+ * Heartbeat telling the backend whether this client currently has the Chat
+ * panel displayed. Presence (the relay connection) is gated on this, so an
+ * enabled operator who isn't showing the panel stays off everyone's roster.
+ */
+export function chatSetVisible(visible: boolean, signal?: AbortSignal): Promise<ChatStatus> {
+  return jsonFetch(
+    '/api/chat/visible',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ visible }),
+      signal,
+    },
+    normalizeStatus,
+  );
+}
+
 export function chatSend(text: string, room?: string, signal?: AbortSignal): Promise<{ ok: boolean }> {
   return jsonFetch(
     '/api/chat/send',

--- a/zeus-web/src/layout/panels/ChatPanel.tsx
+++ b/zeus-web/src/layout/panels/ChatPanel.tsx
@@ -1009,6 +1009,7 @@ export function ChatPanel() {
 
   const refreshStatus = useChatStore((s) => s.refreshStatus);
   const setEnabled = useChatStore((s) => s.setEnabled);
+  const setPanelVisible = useChatStore((s) => s.setPanelVisible);
   const send = useChatStore((s) => s.send);
   const loadHistory = useChatStore((s) => s.loadHistory);
   const loadRoster = useChatStore((s) => s.loadRoster);
@@ -1049,6 +1050,18 @@ export function ChatPanel() {
     void loadRooms();
     void loadFriends();
   }, [refreshStatus, loadHistory, loadRoster, loadRooms, loadFriends]);
+
+  // Presence is gated on the operator actually showing this panel: heartbeat
+  // "visible" while mounted (re-pinged so a closed browser lapses on the
+  // backend timeout) and "hidden" on unmount, which drops us off the roster.
+  useEffect(() => {
+    void setPanelVisible(true);
+    const id = window.setInterval(() => void setPanelVisible(true), 15_000);
+    return () => {
+      window.clearInterval(id);
+      void setPanelVisible(false);
+    };
+  }, [setPanelVisible]);
 
   // Auto-scroll to newest message in the active room
   const activeMessages = messagesByRoom[activeRoom] ?? [];

--- a/zeus-web/src/state/chat-store.ts
+++ b/zeus-web/src/state/chat-store.ts
@@ -26,6 +26,7 @@ import { create } from 'zustand';
 import {
   chatStatus,
   chatSetEnabled,
+  chatSetVisible,
   chatSend,
   chatDm,
   chatMessages,
@@ -116,6 +117,8 @@ export type ChatStoreState = {
 
   refreshStatus: () => Promise<void>;
   setEnabled: (enabled: boolean) => Promise<void>;
+  /** Report whether the Chat panel is currently displayed (gates presence). */
+  setPanelVisible: (visible: boolean) => Promise<void>;
   send: (text: string) => Promise<boolean>;
   loadHistory: () => Promise<void>;
   loadRoster: () => Promise<void>;
@@ -212,6 +215,15 @@ export const useChatStore = create<ChatStoreState>((set, get) => ({
       set(applyStatus(await chatSetEnabled(enabled)));
     } catch (err) {
       set({ relayError: errMsg(err) });
+    }
+  },
+
+  setPanelVisible: async (visible) => {
+    try {
+      set(applyStatus(await chatSetVisible(visible)));
+    } catch {
+      // Best-effort presence heartbeat; a missed ping just lapses on the
+      // backend timeout and the next interval tick re-asserts visibility.
     }
   },
 


### PR DESCRIPTION
## What

An operator is now listed in other operators' rosters (the chat "sidebar") **only when chat is enabled *and* they currently have the Chat panel displayed**. Previously, presence was published to the relay whenever chat was enabled server-side, so an operator who had opted in but had the Chat panel closed (or not in the active layout) still showed up as online for everyone.

## Why

The relay roster is built from connected sockets, and the server connected to the relay purely on the persisted `enabled` opt-in. There was no signal of whether the operator was actually looking at chat, so "online" didn't mean "present in chat."

## How

The relay connection (which is what publishes presence) is now gated on a **panel-visibility heartbeat** in addition to the enabled flag:

- **Frontend** — while `ChatPanel` is mounted it pings `visible: true` on mount, re-pings every 15 s, and sends `visible: false` on unmount.
- **Backend** — `ChatService` records the heartbeat (`ReportPanelVisible`) and only connects while `enabled && PanelActive`. The live connection is torn down within ~1 s of the panel hiding (clean unmount), and the heartbeat lapses after **45 s** so a hard browser/tab close still drops the operator off the roster. Disconnecting triggers the relay's normal roster broadcast, so others' lists update.

### Changes
- `Zeus.Contracts` — `ChatVisibleRequest(bool Visible)`
- `Zeus.Server.Hosting/ChatService.cs` — `ReportPanelVisible` / `PanelActive`; gate the worker loop's idle branch and tear down the connection when the panel stops being shown
- `Zeus.Server.Hosting/ZeusEndpoints.cs` — `POST /api/chat/visible`
- `zeus-web` — `chatSetVisible` API, `setPanelVisible` store action, `ChatPanel` mount/interval/unmount heartbeat

## Behavior notes
- **Trade-off:** while the panel is closed the client is disconnected from the relay, so live messages don't accumulate in the background — consistent with "not showing chat → not in chat." Reopening the panel reconnects and re-hydrates roster/history. This doesn't affect the per-tab unread badges (those only matter while the panel is open).
- Timings (15 s heartbeat / 45 s lapse) are easy knobs if a different feel is wanted.

## Testing
- `dotnet build` (Zeus.Server.Hosting): 0 warnings / 0 errors
- `tsc --noEmit`: clean
- `vitest run src/state/chat-store.test.ts`: 9/9 pass
- Live roster behavior needs the cloud relay + a second logged-in operator, so it wasn't exercised locally; the gating logic is covered by build + typecheck + the existing chat-store tests.