### PR TITLE
fix(ptt): enable-gate in PTT status recommendation + P2 snapshot regression tests

### DIFF
--- a/Zeus.Server.Hosting/ExternalPttService.cs
+++ b/Zeus.Server.Hosting/ExternalPttService.cs
@@ -162,13 +162,16 @@ public sealed class ExternalPttService : IHostedService, IDisposable
         bool tunOn = _tx.IsTunOn;
         bool twoToneOn = _tx.IsTwoToneOn;
         string? owner = _tx.MoxOwner?.ToString();
+        bool enabled = _settings.Get();
         string recommendation = !available
             ? "No hardware PTT client is attached; external PTT takeover is idle."
             : owned
                 ? "External PTT owns MOX through the hardware source path; falling edges release only hardware-owned transmissions after hang time."
-                : hardwarePtt == true && !moxOn
-                    ? "Hardware PTT is asserted but MOX is not active; check connection state, band guard, and TX interlocks."
-                    : "External PTT takeover is armed and read-only diagnostics are live.";
+                : !enabled
+                    ? "Hardware PTT-IN is read-only: the lamp tracks the footswitch, but PTT-IN will not key MOX until enabled in Radio Settings."
+                    : hardwarePtt == true && !moxOn
+                        ? "Hardware PTT is asserted but MOX is not active; check connection state, band guard, and TX interlocks."
+                        : "External PTT takeover is armed and read-only diagnostics are live.";
 
         return new(
             SchemaVersion: 1,
@@ -186,7 +189,7 @@ public sealed class ExternalPttService : IHostedService, IDisposable
             SidetoneAvailable: _sidetone is not null,
             DiagnosticRecommendation: recommendation,
             GeneratedUtc: DateTimeOffset.UtcNow,
-            Enabled: _settings.Get());
+            Enabled: enabled);
     }
 
     private void OnConnected(IProtocol1Client client)
@@ -363,6 +366,11 @@ public sealed class ExternalPttService : IHostedService, IDisposable
     /// full shared engine (lamp + gated MOX promotion). Mirrors what
     /// <see cref="OnHardwarePttChanged"/> does for a live P1 client.</summary>
     internal void TestRawPttP1(bool on) => OnHardwarePttChanged(on);
+
+    /// <summary>Test seam: simulate a P2 client connect, exactly as the
+    /// RadioService.P2Connected event would (so Snapshot reports the P2
+    /// client + protocol). Mirrors <see cref="OnP2Connected"/>.</summary>
+    internal void TestP2Connect(Zeus.Protocol2.Protocol2Client client) => OnP2Connected(client);
 
     /// <summary>Test seam: feed a P2 hi-priority telemetry sample through the
     /// level→edge derivation and the shared engine, exactly as a live

--- a/tests/Zeus.Server.Tests/ExternalPttServiceTests.cs
+++ b/tests/Zeus.Server.Tests/ExternalPttServiceTests.cs
@@ -90,6 +90,43 @@ public class ExternalPttServiceTests : IDisposable
         new P2TelemetryReading(FwdAdc: 0, RevAdc: 0, ExciterAdc: 0, PttIn: on, PllLocked: true);
 
     [Fact]
+    public void P2Connect_Snapshot_ReportsAvailableAndProtocolP2()
+    {
+        // Regression for the bench finding on a G2: a P2-connected radio must
+        // surface in the PTT status (available + protocol "P2"), driven by the
+        // protocol-agnostic raw level — not the P1-only client.
+        using var h = new Harness(_dbPath, _pttDbPath);
+        using var p2 = new Protocol2Client(NullLogger<Protocol2Client>.Instance);
+
+        h.Service.TestP2Connect(p2);
+
+        var snap = h.Service.Snapshot();
+        Assert.True(snap.Available);
+        Assert.Equal("P2", snap.Protocol);
+        Assert.Equal(false, snap.HardwarePtt); // idle until an edge
+
+        h.Service.TestP2Telemetry(Ptt(true));  // footswitch press
+        Assert.True(h.Service.Snapshot().HardwarePtt == true);
+    }
+
+    [Fact]
+    public void Snapshot_Recommendation_ReflectsEnableGate()
+    {
+        using var h = new Harness(_dbPath, _pttDbPath, enabled: true);
+        using var p2 = new Protocol2Client(NullLogger<Protocol2Client>.Instance);
+        h.Service.TestP2Connect(p2);
+
+        var on = h.Service.Snapshot();
+        Assert.True(on.Enabled);
+        Assert.DoesNotContain("will not key MOX", on.DiagnosticRecommendation);
+
+        h.Settings.Set(false);
+        var off = h.Service.Snapshot();
+        Assert.False(off.Enabled);
+        Assert.Contains("will not key MOX", off.DiagnosticRecommendation);
+    }
+
+    [Fact]
     public void P2_PttInRising_KeysMox_WithHardwareSource()
     {
         using var h = new Harness(_dbPath, _pttDbPath);


### PR DESCRIPTION
DO NOT MERGE — draft. Two follow-ups to #799 (PTT-IN), both from the live G2 bench.

## Changes
1. **`ExternalPttService.Snapshot()` recommendation reflects the enable gate.** When PTT-IN is attached but the toggle is OFF, it now reports *"Hardware PTT-IN is read-only: the lamp tracks the footswitch, but PTT-IN will not key MOX until enabled in Radio Settings"* instead of the misleading *"armed and read-only diagnostics are live."* (cosmetic-only; the gate logic itself was already correct).
2. **P2 snapshot regression tests** — adds a `TestP2Connect` seam and two tests:
   - `P2Connect_Snapshot_ReportsAvailableAndProtocolP2` — locks the bench fix (a P2-connected G2 surfaces `available=true`, `protocol="P2"`; idle until an edge, then `hardwarePtt=true`).
   - `Snapshot_Recommendation_ReflectsEnableGate` — recommendation + `Enabled` flip with the gate.

## Safe
- 2 files only (`ExternalPttService.cs` + its tests); no PureSignal logic.
- Build 0/0; PTT tests **20/20** (the +2 new).

Refs #797