### PR TITLE
fix(agc): restrict AGC-T slider to the useful 30-80 dB range

### DIFF
--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -57,6 +57,15 @@ public sealed class RadioService : IDisposable
 {
     private const int DefaultHpsdrPort = 1024;
     internal const double DefaultAgcTopDb = 80.0;
+    // Operator AGC-T baseline range. Below ~30 dB the RX audio is effectively
+    // muted and above ~80 dB it is the loudest the AGC will drive; the old
+    // -20..120 span (mirroring the raw Thetis slider) exposed a large dead
+    // region the operator never used. The slider is linear across this window.
+    // NOTE: this bounds only the manual baseline (AgcTopDb). Auto-AGC's offset
+    // (AgcOffsetDb) and the effective value it pushes to WDSP are NOT bounded
+    // by this — see AgcMinEffectiveAgcT / AgcMaxEffectiveAgcT.
+    internal const double MinAgcTopDb = 30.0;
+    internal const double MaxAgcTopDb = 80.0;
 
     private readonly object _sync = new();
     private readonly ILoggerFactory _loggerFactory;
@@ -401,8 +410,10 @@ public sealed class RadioService : IDisposable
             // headroom to normalize weak post-demod audio immediately after a
             // fresh start. Operator overrides persist via
             // DspSettingsStore.SetAgcTopDb so deliberate lower AGC-T settings
-            // still stick across restarts.
-            AgcTopDb: _dspSettingsStore.GetAgcTopDb() ?? DefaultAgcTopDb,
+            // still stick across restarts. Clamp the rehydrated value into the
+            // operator range so a legacy out-of-range persisted baseline (from
+            // the old -20..120 slider) can't park the thumb off the rail.
+            AgcTopDb: Math.Clamp(_dspSettingsStore.GetAgcTopDb() ?? DefaultAgcTopDb, MinAgcTopDb, MaxAgcTopDb),
             Agc: persistedAgc,
             Squelch: persistedSquelch,
             TxLeveling: persistedTxLeveling,
@@ -2249,12 +2260,16 @@ public sealed class RadioService : IDisposable
     internal static byte ComputeDriveByte(int drivePct, double paGainDb, int maxWatts)
         => DriveByteMath.ComputeFullByte(drivePct, paGainDb, maxWatts);
 
-    // Thetis "AGC Top" slider — max post-AGC gain in dB. Clamped to the
-    // Thetis UI range (−20..120). DspPipelineService picks this up through the
-    // StateChanged event and forwards it to the active engine.
+    // "AGC Top" slider — max post-AGC gain in dB. Clamped to the operator
+    // baseline range (MinAgcTopDb..MaxAgcTopDb = 30..80); below 30 the audio
+    // is effectively muted and above 80 it's the loudest the AGC drives, so the
+    // wider raw-Thetis span was dead travel. This clamp is authoritative for
+    // BOTH the REST /api/agcGain endpoint and the TCI agc_gain command.
+    // DspPipelineService picks this up through the StateChanged event and
+    // forwards it to the active engine.
     public StateDto SetAgcTop(double topDb)
     {
-        double clamped = Math.Clamp(topDb, -20.0, 120.0);
+        double clamped = Math.Clamp(topDb, MinAgcTopDb, MaxAgcTopDb);
         // Grabbing the AGC-T slider takes MANUAL control. The value pushed to
         // WDSP is the EFFECTIVE AGC-T = AgcTopDb + AgcOffsetDb, where the offset
         // is the Auto-AGC control-loop accumulator. If Auto-AGC kept running,

--- a/Zeus.Server.Hosting/Tci/TciSession.cs
+++ b/Zeus.Server.Hosting/Tci/TciSession.cs
@@ -1146,8 +1146,9 @@ public sealed class TciSession : IDisposable
     private void HandleAgcGain(string[] args)
     {
         // agc_gain:<rx>,<db> or agc_gain:<rx> (query)
-        // ExpertSDR3 TCI spec: AGC gain is synonymous with AGC top (max gain)
-        // Range: -20 to 120 dB per Thetis convention
+        // ExpertSDR3 TCI spec: AGC gain is synonymous with AGC top (max gain).
+        // The value is clamped to the operator baseline range (30..80 dB) by
+        // RadioService.SetAgcTop — same authority as the REST slider.
         if (args.Length < 1) return;
         if (!TciProtocol.TryParseInt(args[0], out int rx)) return;
 

--- a/tests/Zeus.Server.Tests/RadioServiceAutoAgcTests.cs
+++ b/tests/Zeus.Server.Tests/RadioServiceAutoAgcTests.cs
@@ -209,8 +209,48 @@ public sealed class RadioServiceAutoAgcTests : IDisposable
     public void SetAgcTop_ClampsBaselineToRange()
     {
         using var radio = NewRadio();
-        Assert.Equal(120.0, radio.SetAgcTop(200.0).AgcTopDb);
-        Assert.Equal(-20.0, radio.SetAgcTop(-50.0).AgcTopDb);
+        // Operator baseline range is 30..80 dB (loudest 80 / quietest 30).
+        Assert.Equal(80.0, radio.SetAgcTop(200.0).AgcTopDb);
+        Assert.Equal(30.0, radio.SetAgcTop(-50.0).AgcTopDb);
+        // Just outside each rail clamps to the rail; in-range passes through.
+        Assert.Equal(80.0, radio.SetAgcTop(80.5).AgcTopDb);
+        Assert.Equal(30.0, radio.SetAgcTop(29.5).AgcTopDb);
+        Assert.Equal(55.0, radio.SetAgcTop(55.0).AgcTopDb);
+    }
+
+    [Fact]
+    public void HydratedBaseline_ClampsLegacyAboveMaxIntoRange()
+    {
+        // A legacy persisted value from the old -20..120 slider must not park
+        // the thumb off the new 30..80 rail on restart.
+        using (var seed = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance, _basePath + ".dsp.db"))
+        {
+            seed.SetAgcTopDb(120.0);
+        }
+        using var radio = NewRadio(); // reopens the same dsp.db, hydrates on construct
+        Assert.Equal(80.0, radio.Snapshot().AgcTopDb);
+    }
+
+    [Fact]
+    public void HydratedBaseline_ClampsLegacyBelowMinIntoRange()
+    {
+        using (var seed = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance, _basePath + ".dsp.db"))
+        {
+            seed.SetAgcTopDb(10.0);
+        }
+        using var radio = NewRadio();
+        Assert.Equal(30.0, radio.Snapshot().AgcTopDb);
+    }
+
+    [Fact]
+    public void HydratedBaseline_PreservesInRangePersistedValue()
+    {
+        using (var seed = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance, _basePath + ".dsp.db"))
+        {
+            seed.SetAgcTopDb(45.0);
+        }
+        using var radio = NewRadio();
+        Assert.Equal(45.0, radio.Snapshot().AgcTopDb);
     }
 
     // ── AGC knee removed: AGC-T is the single manual AGC control ───────────────

--- a/zeus-web/src/components/AgcSettingsSection.tsx
+++ b/zeus-web/src/components/AgcSettingsSection.tsx
@@ -132,7 +132,11 @@ export function AgcSettingsSection() {
 
   const isCustom = agc.mode === 'Custom';
   const isFixed = agc.mode === 'Fixed';
-  const effectiveTop = Math.round(Math.max(0, Math.min(120, agcTopDb + offsetDb)));
+  // Slider baseline is 30..80 (loudest 80 / quietest 30). The effective value
+  // (baseline + Auto-AGC offset) can roam wider, so the "eff" hint is clamped to
+  // the server's effective range (RadioService AgcMin/MaxEffectiveAgcT = 20..100),
+  // not the slider bounds, so Auto's authority isn't visually clipped.
+  const effectiveTop = Math.round(Math.max(20, Math.min(100, agcTopDb + offsetDb)));
   const topDisabled = !connected || autoEnabled;
 
   return (
@@ -183,12 +187,12 @@ export function AgcSettingsSection() {
         </span>
         <input
           type="range"
-          min={0}
-          max={120}
+          min={30}
+          max={80}
           step={1}
           value={agcTopDb}
           disabled={topDisabled}
-          title={autoEnabled ? 'Auto-AGC is controlling max gain' : 'AGC-T max gain'}
+          title={autoEnabled ? 'Auto-AGC is controlling max gain' : 'AGC-T max gain (30-80 dB)'}
           onChange={(e) => sendTop(Number(e.currentTarget.value))}
           style={{
             flex: 1,

--- a/zeus-web/src/components/AgcSlider.tsx
+++ b/zeus-web/src/components/AgcSlider.tsx
@@ -55,11 +55,19 @@ import {
 import { useConnectionStore } from '../state/connection-store';
 import { useLiveSlider } from '../hooks/useLiveSlider';
 
-// AGC top (max gain) in dB. 80 is the Thetis AGC_MEDIUM default; the WDSP
-// docs call this the upper gain limit before compression kicks in.
-// 0-120 mirrors the range Thetis exposes on its AGC-T slider.
-const MIN = 0;
-const MAX = 120;
+// AGC top (max gain) in dB. 80 is the loudest the AGC drives (the Thetis
+// AGC_MEDIUM default / upper gain limit); 30 is the quietest useful baseline.
+// The slider is linear across this 30..80 window — the old 0..120 span was
+// mostly dead travel the operator never used. The backend enforces the same
+// bounds (RadioService.MinAgcTopDb/MaxAgcTopDb).
+const MIN = 30;
+const MAX = 80;
+// Auto-AGC adds an offset on top of the baseline, so the EFFECTIVE value the
+// readout shows can roam outside 30..80. Clamp the readout to the wider
+// effective range the server allows (RadioService AgcMin/MaxEffectiveAgcT =
+// 20..100) so Auto's real authority isn't visually clipped.
+const EFF_MIN = 20;
+const EFF_MAX = 100;
 
 // AGC mode dropdown order matches Thetis (enums.cs:152-162).
 const AGC_MODES: readonly AgcMode[] = ['Fixed', 'Long', 'Slow', 'Med', 'Fast', 'Custom'];
@@ -136,7 +144,7 @@ export function AgcSlider() {
   // Slider thumb edits the user baseline (agcTopDb); the displayed number shows
   // the effective AGC on the DSP so the user can watch the auto ramp.
   const sliderValue = dragValue ?? userAgc;
-  const effective = Math.round(Math.max(MIN, Math.min(MAX, sliderValue + offsetDb)));
+  const effective = Math.round(Math.max(EFF_MIN, Math.min(EFF_MAX, sliderValue + offsetDb)));
   const sliderDisabled = !connected || autoEnabled;
 
   const autoAbort = useRef<AbortController | null>(null);


### PR DESCRIPTION
## What

Narrows the **AGC-T (max-gain) slider** from the raw Thetis span (0–120 dB, backend clamp −20..120) to a **linear 30–80 dB** window — *loudest 80 / quietest 30*. Below ~30 dB the RX audio is effectively muted; above ~80 dB is the loudest the AGC drives. The wide span was mostly dead travel.

## How

- **Single authoritative clamp** in `RadioService.SetAgcTop` (`30..80` via `MinAgcTopDb`/`MaxAgcTopDb`), which backs **both** the REST `/api/agcGain` endpoint and the **TCI `agc_gain`** command — one source of truth.
- **Hydrate clamp** on startup so a legacy out-of-range persisted baseline can't park the thumb off the new rail.
- Frontend: `AgcSlider.tsx` (`MIN/MAX = 30/80`) and `AgcSettingsSection.tsx` (`min/max = 30/80`). Step is already `1` (linear).

## Auto-AGC is untouched (important)

The manual baseline (`AgcTopDb`) and the Auto-AGC accumulator (`AgcOffsetDb`) stay **separate** and sum at the DSP seam. Auto-AGC can still drive the **effective** value across its full `20..100` dB envelope (`AgcMin/MaxEffectiveAgcT`) regardless of the tighter manual window. The frontend **effective-value readouts are decoupled** from the slider bounds and clamped to `20..100`, so Auto's authority is never visually clipped.

## Tests

- Updated `SetAgcTop_ClampsBaselineToRange` to the new 30/80 rails + boundary cases.
- Added hydrate-clamp coverage: above-max → 80, below-min → 30, in-range passthrough.
- `dotnet build` ✅, `RadioServiceAutoAgc*` 15/15 ✅, `npm run build` ✅, frontend AGC unit tests ✅.
- **Live-verified** against a running backend: every boundary clamps correctly (200→80, −50→30, 80.5→80, 29.5→30, 55→55); manual grab zeroes the offset + disables auto; Auto-AGC toggles cleanly with the baseline preserved.

## Review notes

This changes an operator-facing range (red-light per CLAUDE.md), but it's a directly-requested behavior change. Draft for KB2UKA sign-off before merge.