### PR TITLE
feat(ports): external antenna ports — TX/RX relays + RX-aux, all boards (#804)

### DIFF
--- a/Zeus.Contracts/BoardCapabilities.cs
+++ b/Zeus.Contracts/BoardCapabilities.cs
@@ -11,6 +11,27 @@
 namespace Zeus.Contracts;
 
 /// <summary>
+/// The set of auxiliary RX inputs a board's Alex / filter board exposes
+/// (external-ports plan — antenna slice, issue #804). A <c>[Flags]</c> set
+/// because a board advertises which aux feeds are wired; the per-band
+/// operator selection picks exactly one (see the server-side
+/// <c>RxAuxInputSel</c> single-choice enum). <see cref="All"/> is the full
+/// ANAN / Saturn-BPF set; <see cref="None"/> is Hermes-Lite 2 (single jack,
+/// no aux relays).
+/// </summary>
+[Flags]
+public enum RxAuxInputs
+{
+    None  = 0,
+    Ext1  = 1 << 0,
+    Ext2  = 1 << 1,
+    Xvtr  = 1 << 2,
+    Bypass = 1 << 3,
+    /// <summary>Every aux input — the full Alex / Saturn-BPF set.</summary>
+    All = Ext1 | Ext2 | Xvtr | Bypass,
+}
+
+/// <summary>
 /// Per-board capability fingerprint. Mirrors the facts Thetis MW0LGE
 /// special-cases in <c>clsHardwareSpecific.cs</c> — RX ADC count, MKII
 /// BPF support, ADC supply mV, LR audio swap, telemetry presence,
@@ -102,7 +123,38 @@ public sealed record BoardCapabilities(
     /// disabled when this flag is false, so operators can see the
     /// feature exists without being able to drive a non-supporting
     /// board.</summary>
-    bool SupportsAnvelinaDxOc = false)
+    bool SupportsAnvelinaDxOc = false,
+    /// <summary>True when the board has switchable TX antenna relays
+    /// (ANT1/2/3) — the 0x0A / Saturn OrionMkII family (G2 / G2-1K / 7000DLE /
+    /// 8000DLE / Apache OrionMkII original / ANVELINA-PRO3 / Red Pitaya), which
+    /// emit the alex0[26:24] TX-antenna bits over Protocol 2. Every other board
+    /// is ANT1-hardwired on transmit. The frontend gates the TX-antenna selector
+    /// on this flag; the server returns 409 to a non-ANT1 TX request when it is
+    /// false. External-ports plan — antenna slice (issue #804).</summary>
+    bool HasTxAntennaRelays = false,
+    /// <summary>True when the board has switchable RX antenna relays (ANT1/2/3).
+    /// Every ANAN / Hermes-class Protocol-1 board does (RX-antenna rides
+    /// Config-frame C3[7:5]); the 0x0A family does on the Alex word. FALSE only
+    /// for Hermes-Lite 2 — its single antenna jack forwards to the N2ADR pad and
+    /// is clamped to ANT1 at the wire layer
+    /// (<c>ControlFrame.EncodeRxAntennaC3Bits</c>). The server returns 409 to a
+    /// non-ANT1 RX request when false. External-ports plan — antenna slice
+    /// (issue #804).</summary>
+    bool HasRxAntennaRelays = false,
+    /// <summary>The auxiliary RX inputs the board's Alex / filter board exposes
+    /// (EXT1/EXT2/XVTR/BYPASS-K36). <see cref="Contracts.RxAuxInputs.All"/> for
+    /// the ANAN / Saturn family; <see cref="Contracts.RxAuxInputs.None"/> for
+    /// Hermes-Lite 2. The BYPASS (K36) bit is the SAME alex0 bit (11) PureSignal
+    /// external feedback uses — the wire path ORs PS routing AFTER the operator
+    /// aux so PS always wins while armed (the PS-K36 firewall). External-ports
+    /// plan — antenna slice (issue #804).</summary>
+    RxAuxInputs RxAuxInputs = RxAuxInputs.None,
+    /// <summary>True when the board has a dedicated RX2 antenna path (the
+    /// dual-ADC DDC family: ANAN-100D / ANAN-200D and the 0x0A Saturn family).
+    /// Informational for the frontend; the antenna wire path itself is RX1 /
+    /// shared-relay only in this slice. External-ports plan — antenna slice
+    /// (issue #804).</summary>
+    bool HasRx2AntennaPath = false)
 {
     /// <summary>Safe defaults for an unrecognised / disconnected board.
     /// Single ADC, no extras — minimum-surprise capability set so a

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -2056,3 +2056,36 @@ public sealed record RepoUpdateStatus(
     public long? ReleaseAssetSizeBytes { get; init; }
     public string? ReleaseAssetDigest { get; init; }
 }
+
+// ---- External antenna ports (external-ports plan — antenna slice, #804) ----
+//
+// Per-band TX/RX antenna relay + RX-aux selection. Surfaced via
+// /api/radio/antenna, NEVER via StateDto — antenna state is server-authoritative
+// and pushed to the live client on the Changed → RecomputePaAndPush path, so a
+// frontend reconnect can never clobber it (PR #359/#360 no-clobber pattern).
+//
+// TxAnt / RxAnt are antenna strings ("Ant1" | "Ant2" | "Ant3"); RxAux is the
+// auxiliary RX input string ("None" | "Ext1" | "Ext2" | "Xvtr" | "Bypass").
+// "Ant1" / "None" reproduce today's wire bytes bit-for-bit (default-inert).
+public sealed record AntennaBandDto(string Band, string TxAnt, string RxAnt, string RxAux = "None");
+
+// GET /api/radio/antenna response. HasTxAntennaRelays / HasRxAntennaRelays are
+// the board-capability gates the frontend renders the right selectors from; the
+// per-band rows list every HF band. AvailableRxAux is the set of aux-input
+// strings the connected board exposes (empty on HL2 — no aux). AlexRevision is
+// always "Modern" in this slice: the wire path routes PureSignal external
+// feedback to the BYPASS/K36 bit (Rev 24+ behaviour), and the operator-set
+// legacy Rev15/16 EXT1 routing is not wire-discoverable so it is deferred.
+public sealed record AntennaSettingsDto(
+    bool HasTxAntennaRelays,
+    bool HasRxAntennaRelays,
+    IReadOnlyList<AntennaBandDto> Bands,
+    IReadOnlyList<string>? AvailableRxAux = null,
+    string AlexRevision = "Modern");
+
+// PUT /api/radio/antenna — sets ONE band's antenna + RX-aux selection. Band must
+// be a known HF band; TxAnt/RxAnt must parse to HpsdrAntenna; RxAux to the
+// server-side RxAuxInputSel. The server returns 409 for a relay/aux the
+// connected board lacks (non-ANT1 on a relay-less board, an aux the board does
+// not expose), 400 on a malformed body / unknown band / unparseable value.
+public sealed record AntennaSetRequest(string Band, string TxAnt, string RxAnt, string RxAux = "None");

--- a/Zeus.Protocol1/AssemblyInfo.cs
+++ b/Zeus.Protocol1/AssemblyInfo.cs
@@ -46,3 +46,7 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Zeus.Protocol1.Tests")]
+// The external-port encoder seam (Zeus.Server.Hosting.IExternalPortEncoder)
+// delegates to ControlFrame's pure antenna-bit helpers so the firewall and the
+// wire path share one copy of the math — byte-identical by construction.
+[assembly: InternalsVisibleTo("Zeus.Server.Hosting")]

--- a/Zeus.Protocol1/ControlFrame.cs
+++ b/Zeus.Protocol1/ControlFrame.cs
@@ -492,7 +492,11 @@ internal static class ControlFrame
         // them, so the rename is purely client-side.
         if (s.EnableHl2BandVolts) c3 |= 1 << 3;
         if (s.PreampOn) c3 |= 1 << 4;             // Q#2: single global preamp bit for MVP.
-        c3 |= (byte)(((byte)s.RxAntenna & 0x07) << 5);
+        // RX-antenna relay select C3[7:5]. Routed through the shared pure helper
+        // so the wire-layer HL2 clamp (single jack → ANT1) and the external-port
+        // encoder seam emit identical bytes. Co-tenant C3[3] (band-volts) and
+        // C3[4] (preamp) are already OR'd above; the helper only touches [7:5].
+        c3 |= EncodeRxAntennaC3Bits(s.RxAntenna, s.Board);
         c14[2] = c3;
 
         // C4: Alex TX antenna [1:0] = 0 (RX-only MVP), duplex [2] = 1 (always, per
@@ -504,6 +508,42 @@ internal static class ControlFrame
         c4 |= (byte)((s.NumReceiversMinusOne & 0x07) << 3);
         c14[3] = c4;
     }
+
+    /// <summary>
+    /// Encode the Config-frame RX-antenna relay bits (C3[7:5]) for the given
+    /// board (external-ports plan — antenna slice, #804). Single source of the
+    /// C3[7:5] math, called both on the wire path (WriteConfigPayload) and from
+    /// the external-port encoder seam, so the two are byte-identical by
+    /// construction.
+    ///
+    /// WIRE-LAYER CLAMP: on a board with no RX-antenna relay (Hermes-Lite 2 —
+    /// its single antenna jack forwards to the N2ADR antenna pad, C3[5] does NOT
+    /// drive an ANT1/2/3 relay), the selection is forced to ANT1 here so a stale
+    /// per-band ANT2/3 value can never flip the N2ADR pad. This is the wire layer
+    /// of the three-layer defence (UI gate / REST 409 / wire clamp) and holds
+    /// even if an upstream layer is bypassed. Relay-capable boards emit the raw
+    /// selection — byte-identical to before this slice, so the default-ANT1
+    /// goldens stay green.
+    /// </summary>
+    internal static byte EncodeRxAntennaC3Bits(HpsdrAntenna rxAntenna, HpsdrBoardKind board)
+    {
+        // The capability record proper lives in Zeus.Server.Hosting (which this
+        // assembly cannot reference), so the single relay-less P1 board is named
+        // directly here — mirrors BoardCapabilities.HasRxAntennaRelays, false for
+        // HL2 only across the P1 lineup.
+        if (!P1BoardHasRxAntennaRelays(board)) rxAntenna = HpsdrAntenna.Ant1;
+        return (byte)(((byte)rxAntenna & 0x07) << 5);
+    }
+
+    /// <summary>
+    /// Whether a Protocol-1 board has switchable RX-antenna relays (ANT1/2/3).
+    /// Mirrors <c>BoardCapabilities.HasRxAntennaRelays</c> for the P1 lineup:
+    /// every ANAN / Hermes-class board does; Hermes-Lite 2 does not (single
+    /// jack). Kept local to the protocol assembly so the wire-layer clamp does
+    /// not need a reference to Zeus.Server.Hosting.
+    /// </summary>
+    internal static bool P1BoardHasRxAntennaRelays(HpsdrBoardKind board) =>
+        board != HpsdrBoardKind.HermesLite2;
 
     /// <summary>
     /// Build a complete 1032-byte Metis data frame with two USB frames carrying

--- a/Zeus.Protocol1/Protocol1Client.cs
+++ b/Zeus.Protocol1/Protocol1Client.cs
@@ -87,6 +87,12 @@ public sealed class Protocol1Client : IProtocol1Client
     private int _preamp;       // 0 / 1
     private int _attenDb;      // 0..31 dB (HpsdrAtten value)
     private int _antenna = (int)HpsdrAntenna.Ant1;
+    // RX-antenna relay change deferred while keyed (external-ports plan —
+    // antenna slice, #804). SAFETY: the Alex relay matrix must never be
+    // hot-switched under power. While MOX is on, SetAntennaRx stashes the
+    // desired antenna here (-1 = nothing pending) instead of mutating the live
+    // _antenna; it is flushed on the unkey edge in SetMox(false). -1 = none.
+    private int _pendingAntenna = -1;
     // HL2 Band Volts PWM enable. Wire encoding is C3 bit 3 of the Config
     // frame — same bit that legacy HPSDR boards used for ADC DITHER, which
     // HL2's AD9866 doesn't need (see hermes-lite2-protocol.md line 39 and
@@ -567,12 +573,40 @@ public sealed class Protocol1Client : IProtocol1Client
     public void SetSampleRate(HpsdrSampleRate rate) => Interlocked.Exchange(ref _rate, (int)rate);
     public void SetPreamp(bool on) => Interlocked.Exchange(ref _preamp, on ? 1 : 0);
     public void SetAttenuator(HpsdrAtten atten) => Interlocked.Exchange(ref _attenDb, atten.ClampedDb);
-    public void SetAntennaRx(HpsdrAntenna ant) => Interlocked.Exchange(ref _antenna, (int)ant);
+    /// <summary>
+    /// Select the RX antenna relay (ANT1/2/3). SAFETY (external-ports plan —
+    /// antenna slice, #804): while keyed, the Alex/relay matrix must not be
+    /// hot-switched, so the selection is stashed into <see cref="_pendingAntenna"/>
+    /// and applied on the unkey edge in <see cref="SetMox"/>(false). At idle it
+    /// is applied immediately. The HL2 single-jack clamp lives at the wire layer
+    /// (<c>ControlFrame.EncodeRxAntennaC3Bits</c>), so this method stores the raw
+    /// selection on every board.
+    /// </summary>
+    public void SetAntennaRx(HpsdrAntenna ant)
+    {
+        if (Volatile.Read(ref _mox) != 0)
+        {
+            Interlocked.Exchange(ref _pendingAntenna, (int)ant);
+            return;
+        }
+        Interlocked.Exchange(ref _antenna, (int)ant);
+    }
     public void SetBoardKind(HpsdrBoardKind board) => Interlocked.Exchange(ref _boardKind, (int)board);
 
     public HpsdrBoardKind BoardKind => (HpsdrBoardKind)Volatile.Read(ref _boardKind);
     public void SetHasN2adr(bool hasN2adr) => Interlocked.Exchange(ref _hasN2adr, hasN2adr ? 1 : 0);
-    public void SetMox(bool on) => Interlocked.Exchange(ref _mox, on ? 1 : 0);
+    public void SetMox(bool on)
+    {
+        Interlocked.Exchange(ref _mox, on ? 1 : 0);
+        // Unkey edge: apply any RX-antenna change deferred while keyed
+        // (external-ports plan — antenna slice, #804) so the relay matrix
+        // switches at idle, never under power.
+        if (!on)
+        {
+            int pending = Interlocked.Exchange(ref _pendingAntenna, -1);
+            if (pending >= 0) Interlocked.Exchange(ref _antenna, pending);
+        }
+    }
     public void SetDrive(int percent) =>
         Interlocked.Exchange(ref _drivePct, Math.Clamp(percent, 0, 100));
 

--- a/Zeus.Protocol2/AssemblyInfo.cs
+++ b/Zeus.Protocol2/AssemblyInfo.cs
@@ -46,3 +46,7 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Zeus.Protocol2.Tests")]
+// The external-port encoder seam (Zeus.Server.Hosting.IExternalPortEncoder)
+// delegates to Protocol2Client's pure antenna-bit helpers so the firewall and
+// the wire path share one copy of the math — byte-identical by construction.
+[assembly: InternalsVisibleTo("Zeus.Server.Hosting")]

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -224,6 +224,36 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // out as the reserved-bit safe default for non-Anvelina firmware.
     private byte _ocDxTxMask;
     private byte _ocDxRxMask;
+    // TX/RX antenna relay selection (external-ports plan — antenna slice, #804).
+    // 1-based wire selector (1=ANT1, 2=ANT2, 3=ANT3) — same convention as
+    // EncodeTxAntennaBits, so this assembly needs no reference to the
+    // HpsdrAntenna enum (which lives in Zeus.Protocol1; P2 references only
+    // Zeus.Contracts). _txAntenna feeds alex0[26:24]; _rxAntenna is the
+    // state-multiplexed RX-side antenna (carried on alex0 during RX). These are
+    // the *applied* values — the wire reads them. While keyed, an operator
+    // setter stashes into _pending* and is flushed on the next unkey edge so the
+    // Alex relay matrix is never hot-switched under power. The [26:24] emission
+    // is additionally gated on _hasTxAntennaRelays so non-relay boards never
+    // advertise ANT2/3. -1 = nothing pending.
+    private int _txAntenna = 1;
+    private int _rxAntenna = 1;
+    private int _pendingTxAntenna = -1;
+    private int _pendingRxAntenna = -1;
+    private bool _hasTxAntennaRelays;
+    // RX auxiliary input select (external-ports plan — antenna slice, #804).
+    // 0 = base ANT relay (no aux), 1=EXT1, 2=EXT2, 3=XVTR, 4=BYPASS(K36). When
+    // non-zero the alex0 aux bits replace the base RX path. Defaults 0 →
+    // byte-identical to today. The K36/BYPASS pick can NEVER override PS feedback
+    // routing — PS arbitration runs AFTER the operator aux in
+    // SendCmdHighPriority (the PS-K36 firewall). Deferred while keyed alongside
+    // the antennas. -1 = nothing pending.
+    private int _rxAuxInput;
+    private int _pendingRxAuxInput = -1;
+    // Whether the connected board's Alex/BPF board uses the ANAN-7000/Saturn
+    // master RX-select gating (bit 14 must accompany any aux selection). Set
+    // alongside the relay-population gate. MkII-BPF boards (0x0A / G2E) use it;
+    // classic-Alex boards do not.
+    private bool _mkiiBpfRxSelect;
     private bool _moxOn;
     private bool _tuneActive;
     private long _totalFrames;
@@ -786,6 +816,81 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         if (_rxTask is not null) SendCmdHighPriority(run: true);
     }
 
+    /// <summary>
+    /// Set the per-band TX/RX antenna relays (external-ports plan — antenna
+    /// slice, #804). <paramref name="txAntWire"/> / <paramref name="rxAntWire"/>
+    /// are 1-based wire selectors (1=ANT1, 2=ANT2, 3=ANT3); out-of-range coerces
+    /// to ANT1. <paramref name="hasTxAntennaRelays"/> is the board/variant relay
+    /// gate (from <c>BoardCapabilities.HasTxAntennaRelays</c>) — when false the
+    /// alex0[26:24] TX-antenna bits stay on ANT1 regardless of selection, so a
+    /// non-relay variant never advertises ANT2/3.
+    ///
+    /// SAFETY: the Alex relay matrix must never be hot-switched while keyed.
+    /// When MOX or TUNE is active this defers the new selection into
+    /// <see cref="_pendingTxAntenna"/>/<see cref="_pendingRxAntenna"/> and does
+    /// NOT re-push HighPriority; the deferred value is flushed and emitted on the
+    /// next unkey edge (<see cref="SetMox"/>/<see cref="SetTune"/> off). PS / MOX
+    /// / OC / duplex bytes are untouched here.
+    /// </summary>
+    public void SetAntennas(int txAntWire, int rxAntWire, bool hasTxAntennaRelays)
+        => SetAntennas(txAntWire, rxAntWire, hasTxAntennaRelays, rxAuxInput: 0, mkiiBpfRxSelect: false);
+
+    /// <summary>
+    /// Overload that also sets the RX auxiliary input
+    /// (<paramref name="rxAuxInput"/>: 0=base ANT, 1=EXT1, 2=EXT2, 3=XVTR,
+    /// 4=BYPASS) and the MkII-BPF master RX-select gate. The K36/BYPASS pick is
+    /// emitted on alex0 bit 11, but PureSignal external feedback OWNS that bit
+    /// while PS is armed — the arbitration runs in SendCmdHighPriority AFTER the
+    /// operator aux, so an aux=BYPASS choice can never steal the PS coupler (the
+    /// PS-K36 firewall). Same mid-key deferral as the base antennas.
+    /// </summary>
+    public void SetAntennas(int txAntWire, int rxAntWire, bool hasTxAntennaRelays, int rxAuxInput, bool mkiiBpfRxSelect)
+    {
+        int tx = (txAntWire is 1 or 2 or 3) ? txAntWire : 1;
+        int rx = (rxAntWire is 1 or 2 or 3) ? rxAntWire : 1;
+        int aux = (rxAuxInput is >= 0 and <= 4) ? rxAuxInput : 0;
+        _hasTxAntennaRelays = hasTxAntennaRelays;
+        _mkiiBpfRxSelect = mkiiBpfRxSelect;
+
+        if (_moxOn || _tuneActive)
+        {
+            // Keyed: stash the desired state, leave the live relay bits alone.
+            _pendingTxAntenna = tx;
+            _pendingRxAntenna = rx;
+            _pendingRxAuxInput = aux;
+            return;
+        }
+
+        bool changed = _txAntenna != tx || _rxAntenna != rx || _rxAuxInput != aux;
+        _txAntenna = tx;
+        _rxAntenna = rx;
+        _rxAuxInput = aux;
+        _pendingTxAntenna = -1;
+        _pendingRxAntenna = -1;
+        _pendingRxAuxInput = -1;
+        if (changed && _rxTask is not null) SendCmdHighPriority(run: true);
+    }
+
+    // Apply any antenna selection deferred while keyed. Called on the unkey edge
+    // from SetMox/SetTune AFTER the MOX/TUNE flag clears, so the relay re-push
+    // happens at idle, never under power. Returns true if a re-push is warranted
+    // (the caller's SendCmdHighPriority covers it).
+    private bool FlushPendingAntennas()
+    {
+        if (_pendingTxAntenna < 0 && _pendingRxAntenna < 0 && _pendingRxAuxInput < 0) return false;
+        int tx = _pendingTxAntenna >= 0 ? _pendingTxAntenna : _txAntenna;
+        int rx = _pendingRxAntenna >= 0 ? _pendingRxAntenna : _rxAntenna;
+        int aux = _pendingRxAuxInput >= 0 ? _pendingRxAuxInput : _rxAuxInput;
+        bool changed = _txAntenna != tx || _rxAntenna != rx || _rxAuxInput != aux;
+        _txAntenna = tx;
+        _rxAntenna = rx;
+        _rxAuxInput = aux;
+        _pendingTxAntenna = -1;
+        _pendingRxAntenna = -1;
+        _pendingRxAuxInput = -1;
+        return changed;
+    }
+
     public void SetPaEnabled(bool enabled)
     {
         _paEnabled = enabled;
@@ -796,6 +901,11 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     {
         _moxOn = on;
         if (!on) ResetTxIq();
+        // Unkey edge: apply any antenna selection deferred while keyed before the
+        // HighPriority re-push, so the relay matrix switches at idle and the very
+        // next HP frame carries the operator's new antenna. Only flush when fully
+        // unkeyed (a TUNE could still be active).
+        if (!on && !_tuneActive) FlushPendingAntennas();
         if (_rxTask is not null) SendCmdHighPriority(run: true);
     }
 
@@ -803,6 +913,7 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     {
         _tuneActive = on;
         if (!on) ResetTxIq();
+        if (!on && !_moxOn) FlushPendingAntennas();
         if (_rxTask is not null) SendCmdHighPriority(run: true);
     }
 
@@ -1598,15 +1709,45 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         // while keyed, protecting the ADC.
         bool xmit = _moxOn || _tuneActive;
         bool rx2Enabled = Volatile.Read(ref _rx2Enabled) != 0;
-        uint alex0Common = ComputeAlexWord(_rxFreqHz, _rxFreqHz, txAnt: 1, board: _boardKind);
-        uint alex0 = alex0Common | (xmit ? ALEX_TX_RELAY : 0u);
+        // TX-antenna relay select (external-ports plan — antenna slice, #804).
+        // Gate the alex0[26:24] emission on the board/variant relay population: a
+        // non-relay variant stays on ANT1 and never advertises ANT2/3. _txAntenna
+        // is the 1-based wire selector and is only ever updated at idle (mid-key
+        // changes defer), so the relay matrix is never hot-switched.
+        int txAntWire = _hasTxAntennaRelays ? _txAntenna : 1;
+        // alex0 ANT1/2/3 bits [26:24] are STATE-MULTIPLEXED (pihpsdr
+        // new_protocol.c:1331-1357): during RX they reflect the RX antenna;
+        // during TX — or when RX is on an aux input (EXT/XVTR/BYPASS), where the
+        // ANT relay isn't used for RX — they reflect the TX antenna. alex1 ALWAYS
+        // reflects TX. Without this, changing the TX antenna also moved the RX
+        // path because alex0 always carried the TX antenna.
+        int alex0AntWire = (xmit || _rxAuxInput != 0)
+            ? txAntWire
+            : ((_rxAntenna is 1 or 2 or 3) ? _rxAntenna : 1);
+        uint alex0Common = ComputeAlexWord(_rxFreqHz, _rxFreqHz, txAnt: txAntWire, board: _boardKind);
+        // alex1 keeps the TX antenna from txAntWire; alex0 swaps in the
+        // state-correct antenna (clear [26:24], re-OR via the shared encoder).
+        uint alex0 = (alex0Common & ~ALEX_TX_ANTENNA_MASK) | EncodeTxAntennaBits(alex0AntWire)
+                     | (xmit ? ALEX_TX_RELAY : 0u);
         uint alex1 = ComposeAlex1Word(
             _rxFreqHz,
             _rx2FreqHz,
             rx2Enabled,
             xmit,
             _psFeedbackEnabled,
-            _boardKind);
+            _boardKind,
+            txAntWire);
+        // RX auxiliary input select (external-ports plan — antenna slice, #804).
+        // Emitted on alex0 — XVTR/EXT1/EXT2/BYPASS bits 8..11 (+ Saturn RX_SELECT
+        // bit 14). ORDER IS LOAD-BEARING (the PS-K36 firewall): the operator aux
+        // bits are composed FIRST, then the PureSignal feedback routing below is
+        // applied AFTER and OWNS the K36/BYPASS (bit 11) relay while PS is armed.
+        // An operator aux=BYPASS choice can never steal the PS coupler. Computed
+        // via the shared pure helper so the golden test and the wire agree.
+        alex0 |= ComposeRxAuxBits(_rxAuxInput, _mkiiBpfRxSelect);
+        // ----- PureSignal feedback routing — applied AFTER operator aux. DO NOT
+        //       MOVE OR MODIFY: this block must stay physically last so the PS
+        //       coupler bit always wins over the operator aux (PS-K36 firewall).
         // ALEX_PS_BIT (0x00040000): pihpsdr new_protocol.c:994-998 ORs this
         // into alex0 (during xmit) and alex1 (always-on while PS armed).
         // ComposeAlex1Word owns the alex1 side because it also owns ADC1/RX2
@@ -1659,6 +1800,9 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     private const uint ALEX_TX_ANTENNA_1   = 0x01000000;
     private const uint ALEX_TX_ANTENNA_2   = 0x02000000;
     private const uint ALEX_TX_ANTENNA_3   = 0x04000000;
+    // TX-antenna field [26:24] — cleared before re-OR'ing the state-multiplexed
+    // antenna in SendCmdHighPriority (external-ports plan — antenna slice, #804).
+    private const uint ALEX_TX_ANTENNA_MASK = ALEX_TX_ANTENNA_1 | ALEX_TX_ANTENNA_2 | ALEX_TX_ANTENNA_3;
 
     // Flips the T/R relay on the LPF board so the TX path reaches the antenna
     // through the selected TX LPF instead of through the RX BPF path. OR'd
@@ -1672,6 +1816,15 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // operator picks the external feedback path. Internal coupler leaves
     // this bit clear.
     internal const uint AlexRxAntennaBypass = 0x00000800;
+    // Operator RX-auxiliary input select (external-ports plan — antenna slice,
+    // #804). alex0 bits 8..10 — pihpsdr alex.h: XVTR=bit8, EXT1=bit9, EXT2=bit10
+    // (BYPASS/K36 is bit 11 = AlexRxAntennaBypass above, shared with PS external
+    // feedback). Alex0Anan7000RxSelect (bit 14) is the Saturn/MkII-BPF master
+    // RX-select gate, OR'd alongside any non-base aux on those boards (alex.h).
+    internal const uint AlexRxAntennaXvtr   = 0x00000100;
+    internal const uint AlexRxAntennaExt1   = 0x00000200;
+    internal const uint AlexRxAntennaExt2   = 0x00000400;
+    internal const uint Alex0Anan7000RxSelect = 0x00004000;
     // Alex1-only: grounds the RX input while keyed so the hot TX field doesn't
     // back-feed into the Mercury ADC (pihpsdr alex.h ANAN7000_RX_GNDonTX).
     private const uint ALEX1_ANAN7000_RX_GNDonTX = 0x00000100;
@@ -1700,10 +1853,30 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         bool moxOn,
         bool psEnabled,
         bool psExternal,
-        HpsdrBoardKind board = HpsdrBoardKind.OrionMkII)
+        HpsdrBoardKind board = HpsdrBoardKind.OrionMkII,
+        int txAntWire = 1,
+        bool hasTxAntennaRelays = false,
+        int rxAuxInput = 0,
+        bool mkiiBpfRxSelect = false,
+        int rxAntWire = 1)
     {
-        uint alexCommon = ComputeAlexWord(rxFreqHz, rxFreqHz, txAnt: 1, board: board);
-        uint alex0 = alexCommon | (moxOn ? ALEX_TX_RELAY : 0u);
+        // Mirrors the SendCmdHighPriority alex0 path EXACTLY, in the same order,
+        // so the golden test asserts real behaviour:
+        //   1. base BPF/LPF bits + STATE-MULTIPLEXED ANT1/2/3 (RX ant on RX,
+        //      TX ant on xmit / RX-on-aux) — pihpsdr new_protocol.c:1331-1357
+        //   2. TX_RELAY during xmit
+        //   3. operator RX-aux bits — composed FIRST
+        //   4. PureSignal feedback routing — applied AFTER, owns K36 (firewall)
+        // Default args (rx ant = tx ant = ANT1, no relays/aux) reproduce the
+        // prior word, so the older golden tests stay byte-identical.
+        int wire = hasTxAntennaRelays ? txAntWire : 1;
+        int alex0AntWire = (moxOn || rxAuxInput != 0)
+            ? wire
+            : ((rxAntWire is 1 or 2 or 3) ? rxAntWire : 1);
+        uint alexCommon = ComputeAlexWord(rxFreqHz, rxFreqHz, txAnt: wire, board: board);
+        uint alex0 = (alexCommon & ~ALEX_TX_ANTENNA_MASK) | EncodeTxAntennaBits(alex0AntWire)
+                     | (moxOn ? ALEX_TX_RELAY : 0u);
+        alex0 |= ComposeRxAuxBits(rxAuxInput, mkiiBpfRxSelect);
         if (psEnabled && moxOn) alex0 |= AlexPsBit;
         if (psEnabled && psExternal && moxOn) alex0 |= AlexRxAntennaBypass;
         return alex0;
@@ -1715,11 +1888,33 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         bool rx2Enabled,
         bool moxOn,
         bool psEnabled,
-        HpsdrBoardKind board = HpsdrBoardKind.OrionMkII)
+        HpsdrBoardKind board = HpsdrBoardKind.OrionMkII,
+        int txAntWire = 1)
     {
         uint rx2FilterFreqHz = rx2Enabled ? rx2FreqHz : rxFreqHz;
-        uint alex1 = ComputeAlexWord(rx2FilterFreqHz, rx2FilterFreqHz, txAnt: 1, board: board);
+        // alex1 ALWAYS reflects the TX antenna (external-ports plan — antenna
+        // slice, #804) — it never carries the RX antenna, so the TX-antenna
+        // selector is threaded straight through here.
+        uint alex1 = ComputeAlexWord(rx2FilterFreqHz, rx2FilterFreqHz, txAnt: txAntWire, board: board);
         if (moxOn) alex1 |= ALEX_TX_RELAY | ALEX1_ANAN7000_RX_GNDonTX;
+        if (psEnabled) alex1 |= AlexPsBit;
+        return alex1;
+    }
+
+    /// <summary>
+    /// Compose the alex1 word the way <see cref="SendCmdHighPriority"/> does,
+    /// exposed internal so wire-format tests can assert the alex1 (offset 1428)
+    /// PureSignal / TX-relay / RX-ground bits without standing up a socket.
+    /// Single-RX, ANT1 default — the antenna-slice golden net pins these bits.
+    /// </summary>
+    internal static uint ComposeAlex1ForTest(
+        uint rxFreqHz,
+        bool moxOn,
+        bool psEnabled,
+        HpsdrBoardKind board = HpsdrBoardKind.OrionMkII)
+    {
+        uint alexCommon = ComputeAlexWord(rxFreqHz, rxFreqHz, txAnt: 1, board: board);
+        uint alex1 = alexCommon | (moxOn ? ALEX_TX_RELAY | ALEX1_ANAN7000_RX_GNDonTX : 0u);
         if (psEnabled) alex1 |= AlexPsBit;
         return alex1;
     }
@@ -1735,14 +1930,56 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         // ANAN-7000/Saturn BPF board) — confirmed against pihpsdr alex.h
         // and new_protocol.c. Same call for every board.
         word |= LpfBits(txFreqHz);
-        word |= txAnt switch
-        {
-            1 => ALEX_TX_ANTENNA_1,
-            2 => ALEX_TX_ANTENNA_2,
-            3 => ALEX_TX_ANTENNA_3,
-            _ => ALEX_TX_ANTENNA_1,
-        };
+        word |= EncodeTxAntennaBits(txAnt);
         return word;
+    }
+
+    /// <summary>
+    /// Pure encoder for the Protocol-2 alex0/alex1 TX-antenna bits [26:24]
+    /// (external-ports plan — antenna slice, #804). Single source of the
+    /// ANT1/2/3 → bit math, shared by <see cref="ComputeAlexWord"/>,
+    /// <see cref="SendCmdHighPriority"/>'s state-mux re-OR, and the
+    /// external-port encoder seam. Out-of-range → ANT1.
+    /// </summary>
+    internal static uint EncodeTxAntennaBits(int txAnt) => txAnt switch
+    {
+        1 => ALEX_TX_ANTENNA_1,
+        2 => ALEX_TX_ANTENNA_2,
+        3 => ALEX_TX_ANTENNA_3,
+        _ => ALEX_TX_ANTENNA_1,
+    };
+
+    /// <summary>
+    /// Pure encoder for the Protocol-2 alex0 RX-auxiliary-input bits
+    /// (external-ports plan — antenna slice, #804). Single source of the
+    /// aux-relay math, shared by <see cref="SendCmdHighPriority"/> and the
+    /// PS-K36 arbitration golden test.
+    ///
+    /// <paramref name="rxAux"/> selects the aux feed: 0=base ANT (no aux bits),
+    /// 1=EXT1, 2=EXT2, 3=XVTR, 4=BYPASS(K36). On MkII-BPF (Saturn) boards the
+    /// master RX-select bit (bit 14) is OR'd in alongside any non-base aux so the
+    /// jacks are actually gated onto the RX (alex.h); classic-Alex boards leave
+    /// bit 14 clear. Returns 0 for the base ANT path — byte-identical to today's
+    /// alex0 when no aux is selected.
+    ///
+    /// NOTE on the K36 (BYPASS) bit: this helper returns
+    /// <see cref="AlexRxAntennaBypass"/> for an operator BYPASS pick, but the
+    /// caller applies PureSignal feedback routing AFTER this, so PS owns the relay
+    /// while armed (the PS-K36 firewall). This helper never inspects PS state —
+    /// the arbitration is purely "PS OR runs last".
+    /// </summary>
+    internal static uint ComposeRxAuxBits(int rxAux, bool mkiiBpfRxSelect)
+    {
+        uint bits = rxAux switch
+        {
+            1 => AlexRxAntennaExt1,
+            2 => AlexRxAntennaExt2,
+            3 => AlexRxAntennaXvtr,
+            4 => AlexRxAntennaBypass,
+            _ => 0u,
+        };
+        if (bits != 0 && mkiiBpfRxSelect) bits |= Alex0Anan7000RxSelect;
+        return bits;
     }
 
     // RX BPF band splits lifted from pihpsdr new_protocol.c

--- a/Zeus.Server.Hosting/AntennaSettingsStore.cs
+++ b/Zeus.Server.Hosting/AntennaSettingsStore.cs
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// Per-band TX/RX antenna relay + RX-aux selection (external-ports plan —
+// antenna slice, issue #804).
+//
+// Reuses the band-keyed LiteDB pattern of PaSettingsStore (per-band entry in
+// the shared, unencrypted zeus-prefs.db) but keeps antenna out of the PA wire
+// DTO so the red-light Zeus.Contracts PA contract is untouched. The store is
+// deliberately band-only keyed — NO board/variant column. That is safe ONLY
+// because the wire layer gates emission: a per-band ANT3 persisted on a G2
+// rides into the same row an HL2 later reads, and HL2 is protected because its
+// encoder never emits TX-antenna bits and clamps RX-antenna to ANT1
+// (ControlFrame.EncodeRxAntennaC3Bits). All 0x0A variants share
+// HpsdrBoardKind.OrionMkII and identical antenna wire semantics, so a band row
+// round-trips across variants. Keep this wire-gate dependency in mind before
+// any refactor that drops the clamp.
+//
+// Connection=shared + PrefsDbPath.Get() mirror PaSettingsStore for cross-
+// platform parity; endpoint/store tests derive from IsolatedPrefsFactory to
+// avoid the Linux LiteDB shared-mode crash (GH #682).
+
+using LiteDB;
+using Zeus.Protocol1;
+
+namespace Zeus.Server;
+
+public sealed class AntennaSettingsStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<AntennaBandEntry> _bands;
+    private readonly ILogger<AntennaSettingsStore> _log;
+    private readonly object _sync = new();
+
+    // Fired on any write so RadioService can re-push the active band's antenna
+    // to the live client on the next recompute, same pattern as PaSettingsStore.
+    public event Action? Changed;
+
+    public AntennaSettingsStore(ILogger<AntennaSettingsStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _bands = _db.GetCollection<AntennaBandEntry>("antenna_bands");
+        _bands.EnsureIndex(x => x.Band, unique: true);
+
+        _log.LogInformation("AntennaSettingsStore initialized at {Path}", dbPath);
+    }
+
+    /// <summary>
+    /// Per-band antenna selection. Missing rows (fresh install, legacy DB)
+    /// default to ANT1/ANT1/None — the byte-identical "no relay change" state.
+    /// </summary>
+    public AntennaBandSelection GetBand(string band)
+    {
+        lock (_sync)
+        {
+            var e = _bands.FindOne(x => x.Band == band);
+            return e is null
+                ? new AntennaBandSelection(band, HpsdrAntenna.Ant1, HpsdrAntenna.Ant1, RxAuxInputSel.None)
+                : new AntennaBandSelection(band, ClampAnt(e.TxAnt), ClampAnt(e.RxAnt), ClampAux(e.RxAux));
+        }
+    }
+
+    /// <summary>All HF bands, missing rows defaulting to ANT1/ANT1/None.</summary>
+    public IReadOnlyList<AntennaBandSelection> GetAll()
+    {
+        lock (_sync)
+        {
+            var existing = _bands.FindAll().ToDictionary(e => e.Band, e => e);
+            return BandUtils.HfBands
+                .Select(b => existing.TryGetValue(b, out var e)
+                    ? new AntennaBandSelection(b, ClampAnt(e.TxAnt), ClampAnt(e.RxAnt), ClampAux(e.RxAux))
+                    : new AntennaBandSelection(b, HpsdrAntenna.Ant1, HpsdrAntenna.Ant1, RxAuxInputSel.None))
+                .ToArray();
+        }
+    }
+
+    /// <summary>Upsert one band's antenna selection. Invalid band names are
+    /// rejected by the caller; here we narrow to the HF set defensively.</summary>
+    public void SetBand(string band, HpsdrAntenna txAnt, HpsdrAntenna rxAnt)
+        => SetBand(band, txAnt, rxAnt, RxAuxInputSel.None);
+
+    /// <summary>Upsert one band's antenna + RX-aux selection.
+    /// <paramref name="rxAux"/> selects an auxiliary RX feed
+    /// (EXT1/EXT2/XVTR/BYPASS); <see cref="RxAuxInputSel.None"/> uses the base
+    /// RX-antenna relay. LiteDB is schema-less so rows written before this slice
+    /// hydrate RxAux as 0 = None.</summary>
+    public void SetBand(string band, HpsdrAntenna txAnt, HpsdrAntenna rxAnt, RxAuxInputSel rxAux)
+    {
+        if (!BandUtils.HfBands.Contains(band)) return;
+        lock (_sync)
+        {
+            var existing = _bands.FindOne(x => x.Band == band);
+            if (existing is null)
+            {
+                _bands.Insert(new AntennaBandEntry
+                {
+                    Band = band,
+                    TxAnt = (byte)txAnt,
+                    RxAnt = (byte)rxAnt,
+                    RxAux = (byte)rxAux,
+                    UpdatedUtc = DateTime.UtcNow,
+                });
+            }
+            else
+            {
+                existing.TxAnt = (byte)txAnt;
+                existing.RxAnt = (byte)rxAnt;
+                existing.RxAux = (byte)rxAux;
+                existing.UpdatedUtc = DateTime.UtcNow;
+                _bands.Update(existing);
+            }
+        }
+        Changed?.Invoke();
+    }
+
+    // Defensive clamp on read — a corrupt / out-of-range byte resolves to ANT1
+    // rather than throwing or producing a bogus enum value on the wire.
+    private static HpsdrAntenna ClampAnt(byte v) =>
+        v <= (byte)HpsdrAntenna.Ant3 ? (HpsdrAntenna)v : HpsdrAntenna.Ant1;
+
+    private static RxAuxInputSel ClampAux(byte v) =>
+        v <= (byte)RxAuxInputSel.Bypass ? (RxAuxInputSel)v : RxAuxInputSel.None;
+
+    public void Dispose() => _db.Dispose();
+}
+
+/// <summary>
+/// Per-band RX auxiliary input selection (external-ports plan — antenna slice,
+/// #804). A SINGLE-choice enum (the radio routes ONE RX source at a time) —
+/// distinct from the <c>[Flags]</c> <see cref="Zeus.Contracts.RxAuxInputs"/>
+/// capability set. Persisted as a byte; <see cref="None"/> means "use the base
+/// RX-antenna relay" (today's behaviour). Maps 1:1 to the Protocol2Client aux
+/// selector (1=EXT1, 2=EXT2, 3=XVTR, 4=BYPASS), with 0 = no aux.
+/// </summary>
+public enum RxAuxInputSel : byte
+{
+    None  = 0,
+    Ext1  = 1,
+    Ext2  = 2,
+    Xvtr  = 3,
+    Bypass = 4,
+}
+
+/// <summary>Resolved per-band antenna + RX-aux selection.</summary>
+public sealed record AntennaBandSelection(
+    string Band, HpsdrAntenna TxAnt, HpsdrAntenna RxAnt, RxAuxInputSel RxAux);
+
+public sealed class AntennaBandEntry
+{
+    public int Id { get; set; }
+    public string Band { get; set; } = string.Empty;
+    // 0-based HpsdrAntenna (Ant1=0). LiteDB is schema-less so rows persisted
+    // before this feature hydrate these as 0 = ANT1, the correct legacy default.
+    public byte TxAnt { get; set; }
+    public byte RxAnt { get; set; }
+    // RX auxiliary input (RxAuxInputSel byte). Pre-feature rows hydrate as
+    // 0 = None, the byte-identical legacy default.
+    public byte RxAux { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/BoardCapabilitiesTable.cs
+++ b/Zeus.Server.Hosting/BoardCapabilitiesTable.cs
@@ -115,7 +115,13 @@ internal static class BoardCapabilitiesTable
         HasAudioAmplifier: false,
         HasSteppedAttenuationRx2: false, // single-RX: RX2 doesn't exist
         SupportsPathIllustrator: true,
-        MaxPowerWatts: 10);
+        MaxPowerWatts: 10,
+        // Hermes-class boards carry the Alex/filter RX-antenna relays (C3[7:5])
+        // and the full EXT1/EXT2/XVTR/BYPASS aux set — antenna slice (#804). No
+        // TX-antenna relay (P1, ANT1-hardwired on transmit); single RX → no RX2
+        // antenna path.
+        HasRxAntennaRelays: true,
+        RxAuxInputs: RxAuxInputs.All);
 
     // ANAN-10E (HermesII firmware) — same Hermes-class fingerprint but the
     // 10E hardware is rated to ~30 W, so its meter axis gets the bigger top.
@@ -129,7 +135,9 @@ internal static class BoardCapabilitiesTable
         HasAudioAmplifier: false,
         HasSteppedAttenuationRx2: false,
         SupportsPathIllustrator: true,
-        MaxPowerWatts: 30);
+        MaxPowerWatts: 30,
+        HasRxAntennaRelays: true,
+        RxAuxInputs: RxAuxInputs.All);
 
     // ANAN-100D — 100 W class. Meter axis 120 W gives some headroom past
     // the rated rail without truncating PEP overshoots.
@@ -143,7 +151,12 @@ internal static class BoardCapabilitiesTable
         HasAudioAmplifier: false,
         HasSteppedAttenuationRx2: true,
         SupportsPathIllustrator: true,
-        MaxPowerWatts: 120);
+        MaxPowerWatts: 120,
+        // Dual-ADC DDC board: RX-antenna relays + full aux set + a dedicated RX2
+        // antenna path — antenna slice (#804). P1, so no TX-antenna relay.
+        HasRxAntennaRelays: true,
+        RxAuxInputs: RxAuxInputs.All,
+        HasRx2AntennaPath: true);
 
     // ANAN-200D — 200 W class but axis matches the 100/200/G2 family at
     // 120 W: half-axis at 100 W is the natural reading point.
@@ -157,7 +170,10 @@ internal static class BoardCapabilitiesTable
         HasAudioAmplifier: false,
         HasSteppedAttenuationRx2: true,
         SupportsPathIllustrator: true,
-        MaxPowerWatts: 120);
+        MaxPowerWatts: 120,
+        HasRxAntennaRelays: true,
+        RxAuxInputs: RxAuxInputs.All,
+        HasRx2AntennaPath: true);
 
     // 0x0A family conservative baseline (7000DLE / 8000DLE / OrionMkII /
     // ANVELINA-PRO3 / Red Pitaya). Saturn-class facts. 100–200 W typical →
@@ -173,7 +189,15 @@ internal static class BoardCapabilitiesTable
         HasAudioAmplifier: true,
         HasSteppedAttenuationRx2: true,
         SupportsPathIllustrator: false,
-        MaxPowerWatts: 120);
+        MaxPowerWatts: 120,
+        // 0x0A / Saturn family: switchable TX antenna relays (alex0[26:24], P2),
+        // RX-antenna relays, full EXT1/EXT2/XVTR/BYPASS aux set, and an RX2
+        // antenna path — antenna slice (#804). All Saturn variants ('with'
+        // derivations below) inherit these.
+        HasTxAntennaRelays: true,
+        HasRxAntennaRelays: true,
+        RxAuxInputs: RxAuxInputs.All,
+        HasRx2AntennaPath: true);
 
     // ANAN-G2 — local Thetis parity notes pin RX1/RX2 at
     // 48/96/192/384/768/1536 kHz over Protocol 2.
@@ -215,7 +239,12 @@ internal static class BoardCapabilitiesTable
         HasAudioAmplifier: true,
         HasSteppedAttenuationRx2: false, // single-RX: RX2 doesn't exist
         SupportsPathIllustrator: false,
-        MaxPowerWatts: 120);
+        MaxPowerWatts: 120,
+        // ANAN-G2E (HermesC10) runs Protocol 1 with the MkII BPF board: RX-antenna
+        // relays + full aux set, but ANT1-hardwired on transmit (no P2 Alex word)
+        // and single-RX (no RX2 antenna path) — antenna slice (#804).
+        HasRxAntennaRelays: true,
+        RxAuxInputs: RxAuxInputs.All);
 
     // Apache OrionMkII original (Orion-MkII firmware, 100 W) — Saturn-class
     // hardware fingerprint but without on-board telemetry / audio amp per
@@ -231,7 +260,15 @@ internal static class BoardCapabilitiesTable
         HasAudioAmplifier: false,
         HasSteppedAttenuationRx2: true,
         SupportsPathIllustrator: false,
-        MaxPowerWatts: 120);
+        MaxPowerWatts: 120,
+        // Apache OrionMkII original is a 0x0A / P2 board: TX + RX antenna relays,
+        // full aux set, RX2 antenna path — antenna slice (#804). Same antenna
+        // semantics as the Saturn baseline; only the telemetry/audio-amp facts
+        // differ.
+        HasTxAntennaRelays: true,
+        HasRxAntennaRelays: true,
+        RxAuxInputs: RxAuxInputs.All,
+        HasRx2AntennaPath: true);
 
     // HermesLite2 — rated 5 W stock but operators routinely run to 10 W with
     // adequate cooling, so the meter axis is 10 W to cover the realistic
@@ -253,5 +290,15 @@ internal static class BoardCapabilitiesTable
         HasSteppedAttenuationRx2: false,
         SupportsPathIllustrator: false,
         MaxPowerWatts: 10,
-        HasHl2OptionalToggles: true);
+        HasHl2OptionalToggles: true,
+        // HL2 has a SINGLE antenna jack forwarding to the N2ADR pad: NO RX
+        // antenna relays, NO TX antenna relays, NO aux inputs — antenna slice
+        // (#804). Explicit (not just defaulted) because the wire-layer clamp in
+        // ControlFrame.EncodeRxAntennaC3Bits depends on this being false: a stale
+        // per-band ANT2/3 (shared band rows are board-agnostic) must collapse to
+        // ANT1 so the N2ADR pad never flips.
+        HasTxAntennaRelays: false,
+        HasRxAntennaRelays: false,
+        RxAuxInputs: RxAuxInputs.None,
+        HasRx2AntennaPath: false);
 }

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -3891,6 +3891,18 @@ public class DspPipelineService : BackgroundService,
         // stay at zero per EU2AV's reserved-bit rule.
         p2.SetOcDxMasks(snap.OcDxTxMask, snap.OcDxRxMask);
         p2.SetPaEnabled(snap.PaEnabled);
+        // External antenna (antenna slice — #804). HpsdrAntenna.Ant1=0 → wire 1
+        // → ALEX_TX_ANTENNA_1, so the +1 maps the 0-based enum to the 1-based
+        // wire selector. SetAntennas gates the TX-antenna emission on
+        // HasTxAntennaRelays, defers a mid-key relay change to the unkey edge,
+        // and routes the operator RX-aux strictly BEFORE the PS coupler OR
+        // (the PS-K36 firewall lives in Protocol2Client.SendCmdHighPriority).
+        p2.SetAntennas(
+            (int)snap.TxAntenna + 1,
+            (int)snap.RxAntenna + 1,
+            snap.HasTxAntennaRelays,
+            snap.RxAuxInput,
+            snap.MkiiBpfRxSelect);
     }
 
     private void OnRadioMoxChanged(bool on)

--- a/Zeus.Server.Hosting/ExternalPortEncoder.cs
+++ b/Zeus.Server.Hosting/ExternalPortEncoder.cs
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// External-port encoder seam — antenna slice (external-ports plan, issue #804).
+//
+// This is the FIREWALL: every external-antenna relay bit on the wire —
+// RX-antenna select (P1 C3[7:5]) and TX-antenna select (P2 alex0[26:24]) — is
+// composed behind one board-branched / protocol-branched encoder, instead of
+// scattered bit literals in the emission code.
+//
+// The encoders delegate to the very same pure helpers the wire path already
+// uses (ControlFrame.EncodeRxAntennaC3Bits on P1; Protocol2Client.
+// EncodeTxAntennaBits on P2), so the bits they produce are identical to the
+// wire path for every supported board — byte-identical by construction. The
+// per-board wire-layer clamp (force ANT1 on relay-less boards) lives in the
+// shared P1 helper itself (HL2 single-jack case).
+//
+// Dependency direction: Zeus.Server.Hosting references Zeus.Protocol1 /
+// Zeus.Protocol2 (not the reverse), so this seam consults the protocol layer's
+// pure helpers via InternalsVisibleTo. The protocol clients never call back
+// into this assembly — that would be a cycle.
+//
+// SCOPE: antenna only. Audio front-end / mic / codec / RX-aux-on-P1 emission
+// are intentionally NOT part of this seam (separate slices). RX-aux on P2 rides
+// the Protocol2Client.SetAntennas path directly (it is state, not a pure
+// per-call encode), so it is not modelled here either.
+
+using Zeus.Contracts;
+using Zeus.Protocol1;
+using Zeus.Protocol2;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Immutable canonical desired external-antenna state. Protocol-agnostic — holds
+/// no wire bits, only the operator-meaningful selections. Antenna slice carries
+/// the TX/RX antenna relay picks; RX-aux is threaded through the
+/// Protocol2Client.SetAntennas state path, not this per-call encoder.
+/// </summary>
+public readonly record struct ExternalPortState(
+    /// <summary>TX antenna relay select. Honoured only on boards with
+    /// <see cref="BoardCapabilities.HasTxAntennaRelays"/> (0x0A / Saturn family);
+    /// every other board is ANT1-hardwired on transmit — the encoder gates the
+    /// emission so a non-relay board never advertises ANT2/3.</summary>
+    HpsdrAntenna TxAnt = HpsdrAntenna.Ant1,
+    /// <summary>RX antenna relay select (C3[7:5] on P1). Clamped to ANT1 at the
+    /// wire layer on boards without
+    /// <see cref="BoardCapabilities.HasRxAntennaRelays"/> (Hermes-Lite 2).</summary>
+    HpsdrAntenna RxAnt = HpsdrAntenna.Ant1)
+{
+    /// <summary>Default state: ANT1 / ANT1 — reproduces today's wire emission
+    /// bit-for-bit on every board.</summary>
+    public static readonly ExternalPortState Default = new();
+}
+
+/// <summary>
+/// Per-board / per-protocol external-antenna bit encoder. Mirrors
+/// <see cref="IRadioDriveProfile"/>'s seam: a small strategy interface,
+/// concrete per-protocol implementations, and an
+/// <see cref="ExternalPortEncoders.For(HpsdrBoardKind, OrionMkIIVariant, RadioProtocol?)"/>
+/// dispatch. This is the single place external-antenna relay math lives.
+/// </summary>
+public interface IExternalPortEncoder
+{
+    /// <summary>Diagnostic label for the encoder strategy.</summary>
+    string Label { get; }
+
+    /// <summary>
+    /// Encode the Protocol-1 Config-frame RX-antenna relay bits (C3[7:5]) for
+    /// the desired <paramref name="state"/>. Returns the byte to OR into C3.
+    /// Delegates to the wire path's own pure helper so the bytes match exactly
+    /// (including the HL2 wire-layer ANT1 clamp).
+    /// </summary>
+    byte EncodeP1RxAntennaC3Bits(in ExternalPortState state);
+
+    /// <summary>
+    /// Encode the Protocol-2 Alex-word TX-antenna relay bits (alex0[26:24]) for
+    /// the desired <paramref name="state"/>. Returns the bits to OR into the
+    /// Alex word. Delegates to the wire path's own pure helper.
+    /// </summary>
+    uint EncodeP2TxAntennaBits(in ExternalPortState state);
+}
+
+/// <summary>
+/// Protocol-1 encoder for boards that DO have switchable RX antenna relays
+/// (Hermes-class, ANAN-100D/200D, ANAN-G2E). Emits C3[7:5] straight from the
+/// desired RX antenna. These boards are ANT1-hardwired on transmit (no P2 Alex
+/// word), so the P2 TX-antenna path returns ANT1.
+/// </summary>
+public sealed class Protocol1PortEncoder : IExternalPortEncoder
+{
+    private readonly bool _hasRxAntennaRelays;
+    private readonly HpsdrBoardKind _board;
+
+    public Protocol1PortEncoder(HpsdrBoardKind board, bool hasRxAntennaRelays)
+    {
+        _board = board;
+        _hasRxAntennaRelays = hasRxAntennaRelays;
+    }
+
+    public string Label => $"P1({_board}, rxRelays={_hasRxAntennaRelays})";
+
+    public byte EncodeP1RxAntennaC3Bits(in ExternalPortState state)
+    {
+        // The shared pure helper applies the wire-layer relay-presence clamp
+        // itself (forcing ANT1 on relay-less boards), so a relay-capable P1 board
+        // emits the raw selection and HL2 is clamped — same bytes the inline wire
+        // path produces. _hasRxAntennaRelays is retained for the encoder's own
+        // gating / diagnostics.
+        _ = _hasRxAntennaRelays;
+        return ControlFrame.EncodeRxAntennaC3Bits(state.RxAnt, _board);
+    }
+
+    public uint EncodeP2TxAntennaBits(in ExternalPortState state)
+        // P1 boards do not emit a P2 Alex word; ANT1-hardwired on transmit.
+        => Protocol2Client.EncodeTxAntennaBits(txAnt: 1);
+}
+
+/// <summary>
+/// Protocol-2 encoder for the 0x0A / Saturn family (G2 / 7000DLE / 8000DLE /
+/// G2-1K / OrionMkII original / ANVELINA-PRO3 / Red Pitaya). These boards have
+/// switchable TX antenna relays (alex0[26:24]). The P1 C3 path is unused.
+/// </summary>
+public sealed class Protocol2PortEncoder : IExternalPortEncoder
+{
+    private readonly HpsdrBoardKind _board;
+    private readonly OrionMkIIVariant _variant;
+    private readonly bool _hasTxAntennaRelays;
+
+    public Protocol2PortEncoder(HpsdrBoardKind board, OrionMkIIVariant variant, bool hasTxAntennaRelays)
+    {
+        _board = board;
+        _variant = variant;
+        _hasTxAntennaRelays = hasTxAntennaRelays;
+    }
+
+    public string Label => $"P2({_board}/{_variant}, txRelays={_hasTxAntennaRelays})";
+
+    public byte EncodeP1RxAntennaC3Bits(in ExternalPortState state)
+        // P2 boards do not use the P1 Config frame; the RX-antenna select rides
+        // the Alex word on the SetAntennas state path.
+        => 0;
+
+    public uint EncodeP2TxAntennaBits(in ExternalPortState state)
+    {
+        // Gate the alex0[26:24] TX-antenna emission on the variant's relay
+        // population: a board/variant without TX-antenna relays stays on ANT1
+        // regardless of the requested selection, so it can never advertise
+        // ANT2/3. Relay-capable variants thread the real per-band TxAnt through
+        // the shared pure helper (1-based wire selector).
+        int wire = _hasTxAntennaRelays ? (int)state.TxAnt + 1 : 1;
+        return Protocol2Client.EncodeTxAntennaBits(wire);
+    }
+}
+
+/// <summary>
+/// Hermes-Lite 2 encoder. HL2 has a single antenna jack: C3[5] does NOT drive
+/// an ANT1/2/3 relay, it forwards to the N2ADR antenna pad. The RX-antenna
+/// selection is therefore clamped to ANT1 at the wire layer
+/// (<see cref="BoardCapabilities.HasRxAntennaRelays"/> is false for HL2). HL2
+/// has no P2 Alex word and is ANT1-hardwired on transmit.
+/// </summary>
+public sealed class HermesLite2PortEncoder : IExternalPortEncoder
+{
+    public string Label => "HL2(singleJack, rxClampToAnt1)";
+
+    public byte EncodeP1RxAntennaC3Bits(in ExternalPortState state)
+        // The shared pure helper applies the HL2 clamp, so whatever RxAnt the
+        // operator persisted, the emitted bits are ANT1 — the N2ADR pad never
+        // flips off a stale per-band ANT2/3.
+        => ControlFrame.EncodeRxAntennaC3Bits(state.RxAnt, HpsdrBoardKind.HermesLite2);
+
+    public uint EncodeP2TxAntennaBits(in ExternalPortState state)
+        => Protocol2Client.EncodeTxAntennaBits(txAnt: 1);
+}
+
+/// <summary>
+/// Which transport a connected board uses, for encoder dispatch. The 0x0A
+/// family runs Protocol 2 in Zeus; every other supported board runs Protocol 1.
+/// </summary>
+public enum RadioProtocol
+{
+    Protocol1,
+    Protocol2,
+}
+
+/// <summary>
+/// Per-board / per-protocol dispatch for <see cref="IExternalPortEncoder"/>.
+/// Mirrors <see cref="RadioDriveProfiles.For"/>. Every <see cref="HpsdrBoardKind"/>
+/// maps to a non-null encoder (the board-coverage test asserts this).
+/// </summary>
+public static class ExternalPortEncoders
+{
+    /// <summary>
+    /// Resolve the external-antenna encoder for a connected board. The protocol
+    /// is derived from the board kind when not given explicitly: the 0x0A
+    /// OrionMkII family is Protocol 2, everything else Protocol 1.
+    /// </summary>
+    public static IExternalPortEncoder For(
+        HpsdrBoardKind board,
+        OrionMkIIVariant variant = OrionMkIIVariant.G2,
+        RadioProtocol? protocol = null)
+    {
+        var caps = BoardCapabilitiesTable.For(board, variant);
+        var p = protocol ?? DefaultProtocolFor(board);
+
+        // HL2 first — it is the single-jack special case (the one P1 board with
+        // no RX-antenna relay), so its dedicated encoder owns the clamp.
+        if (board == HpsdrBoardKind.HermesLite2)
+            return new HermesLite2PortEncoder();
+
+        return p == RadioProtocol.Protocol2
+            ? new Protocol2PortEncoder(board, variant, caps.HasTxAntennaRelays)
+            : new Protocol1PortEncoder(board, caps.HasRxAntennaRelays);
+    }
+
+    /// <summary>The transport Zeus uses for a given board kind.</summary>
+    public static RadioProtocol DefaultProtocolFor(HpsdrBoardKind board) => board switch
+    {
+        HpsdrBoardKind.OrionMkII => RadioProtocol.Protocol2,
+        _                        => RadioProtocol.Protocol1,
+    };
+}

--- a/Zeus.Server.Hosting/PaSettingsStore.cs
+++ b/Zeus.Server.Hosting/PaSettingsStore.cs
@@ -223,13 +223,26 @@ public sealed class PaSettingsStore : IDisposable
 // OcDxTxMask / OcDxRxMask carry the Anvelina-PRO3 DX OUT 7..10 wiring (4-bit
 // masks, bit 0..3 = DX OUT 7..10). Pushed unconditionally; Protocol2Client
 // gates whether they reach the wire by board + variant (#407 / EU2AV).
+//
+// TxAntenna / RxAntenna / HasTxAntennaRelays / RxAuxInput / MkiiBpfRxSelect
+// carry the per-band external-antenna selection (external-ports plan — antenna
+// slice, #804). Pushed unconditionally to the P2 client via
+// DspPipelineService.SetAntennas; Protocol2Client gates the TX-antenna emission
+// on HasTxAntennaRelays and routes the operator RX-aux strictly BEFORE the PS
+// coupler OR (the PS-K36 firewall). All defaulted so existing constructions stay
+// valid (default ANT1/ANT1/None = byte-identical to today).
 public sealed record PaRuntimeSnapshot(
     byte DriveByte,
     byte OcTxMask,
     byte OcRxMask,
     bool PaEnabled,
     byte OcDxTxMask = 0,
-    byte OcDxRxMask = 0);
+    byte OcDxRxMask = 0,
+    HpsdrAntenna TxAntenna = HpsdrAntenna.Ant1,
+    HpsdrAntenna RxAntenna = HpsdrAntenna.Ant1,
+    bool HasTxAntennaRelays = false,
+    int RxAuxInput = 0,
+    bool MkiiBpfRxSelect = false);
 
 public sealed class PaBandEntry
 {

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -63,6 +63,10 @@ public sealed class RadioService : IDisposable
     private readonly ILogger<RadioService> _log;
     private readonly DspSettingsStore _dspSettingsStore;
     private readonly PaSettingsStore _paStore;
+    // Per-band external-antenna selection (external-ports plan — antenna slice,
+    // #804). Optional so existing constructions (tests) stay valid; null → the
+    // antenna path resolves to ANT1/ANT1/None (byte-identical to today).
+    private readonly AntennaSettingsStore? _antennaStore;
     private readonly PreferredRadioStore? _preferredRadioStore;
     private readonly PsSettingsStore? _psStore;
     private readonly FilterPresetStore? _filterPresetStore;
@@ -252,17 +256,23 @@ public sealed class RadioService : IDisposable
     // to its internal test-tone generator (dev / tests without a hub).
     private readonly Zeus.Protocol1.ITxIqSource? _txIqSource;
 
-    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, FilterPresetStore? filterPresetStore = null, Zeus.Protocol1.ITxIqSource? txIqSource = null, PreferredRadioStore? preferredRadioStore = null, PsSettingsStore? psStore = null, RadioStateStore? radioStateStore = null, CwSettingsStore? cwSettingsStore = null, TxAudioProfileStore? txAudioProfileStore = null)
+    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, FilterPresetStore? filterPresetStore = null, Zeus.Protocol1.ITxIqSource? txIqSource = null, PreferredRadioStore? preferredRadioStore = null, PsSettingsStore? psStore = null, RadioStateStore? radioStateStore = null, CwSettingsStore? cwSettingsStore = null, TxAudioProfileStore? txAudioProfileStore = null, AntennaSettingsStore? antennaStore = null)
     {
         _loggerFactory = loggerFactory;
         _log = loggerFactory.CreateLogger<RadioService>();
         _dspSettingsStore = dspSettingsStore;
         _paStore = paStore;
+        _antennaStore = antennaStore;
         _preferredRadioStore = preferredRadioStore;
         _psStore = psStore;
         _filterPresetStore = filterPresetStore;
         _radioStateStore = radioStateStore;
         _paStore.Changed += RecomputePaAndPush;
+        // An antenna edit re-pushes the active band's selection server-
+        // authoritatively through the same RecomputePaAndPush fan-out (P1
+        // SetAntennaRx directly / P2 via PaSnapshotChanged → SetAntennas).
+        if (_antennaStore is not null)
+            _antennaStore.Changed += RecomputePaAndPush;
         if (_preferredRadioStore is not null)
             _preferredRadioStore.Changed += RecomputePaAndPush;
         _txIqSource = txIqSource;
@@ -2227,6 +2237,24 @@ public sealed class RadioService : IDisposable
         ActiveClient?.SetDriveByte(driveByte);
         ActiveClient?.SetOcMasks(bandCfg.OcTx, bandCfg.OcRx);
 
+        // ---- External-antenna resolution (antenna slice — #804) ----
+        // Server-authoritative: resolve the active band's persisted TX/RX
+        // antenna + RX-aux, gate the aux against the connected board's
+        // capability set (HL2's None collapses any stale value), and push.
+        // P1 RX-antenna goes straight to the active client; P2 (TX antenna +
+        // RX-aux state-mux) rides the PaRuntimeSnapshot into
+        // DspPipelineService.SetAntennas. The wire layer clamps HL2 RX to ANT1
+        // and defers any mid-key relay change to the unkey edge; PS owns the
+        // K36/BYPASS relay while armed regardless of an aux=BYPASS pick.
+        var caps = BoardCapabilitiesTable.For(ConnectedBoardKind, EffectiveOrionMkIIVariant);
+        var antSel = (_antennaStore is not null && bandName is not null)
+            ? _antennaStore.GetBand(bandName)
+            : new AntennaBandSelection(bandName ?? "unknown", HpsdrAntenna.Ant1, HpsdrAntenna.Ant1, RxAuxInputSel.None);
+        int rxAuxWire = GateRxAux(antSel.RxAux, caps.RxAuxInputs);
+        // P1: RX-antenna relay (C3[7:5], HL2-clamped at the wire). ActiveClient
+        // is null on P2 — the P2 RX-antenna rides the SetAntennas path below.
+        ActiveClient?.SetAntennaRx(antSel.RxAnt);
+
         PaSnapshotChanged?.Invoke(new PaRuntimeSnapshot(
             DriveByte: driveByte,
             OcTxMask: bandCfg.OcTx,
@@ -2238,8 +2266,31 @@ public sealed class RadioService : IDisposable
             // gated by board+variant, so non-Anvelina radios receive a
             // SetOcDxMasks call but the bytes never reach the wire.
             OcDxTxMask: bandCfg.OcDxTx,
-            OcDxRxMask: bandCfg.OcDxRx));
+            OcDxRxMask: bandCfg.OcDxRx,
+            // External antenna (#804). HasTxAntennaRelays gates the alex0[26:24]
+            // emission on the P2 client; RxAuxInput/MkiiBpfRxSelect drive the
+            // operator RX-aux ORs (composed strictly before the PS coupler).
+            TxAntenna: antSel.TxAnt,
+            RxAntenna: antSel.RxAnt,
+            HasTxAntennaRelays: caps.HasTxAntennaRelays,
+            RxAuxInput: rxAuxWire,
+            MkiiBpfRxSelect: caps.MkiiBpf));
     }
+
+    // Gate a persisted per-band RX-aux pick against the connected board's
+    // capability set (antenna slice — #804). Band rows are board-agnostic (no
+    // board column), so a stale aux persisted on an ANAN must collapse to None
+    // (base ANT relay) on a board that does not expose it — notably HL2, whose
+    // RxAuxInputs is None. Returns the 1-based wire selector the P2 client uses
+    // (0=None .. 4=BYPASS); the RxAuxInputSel byte already maps 1:1.
+    private static int GateRxAux(RxAuxInputSel sel, RxAuxInputs available) => sel switch
+    {
+        RxAuxInputSel.Ext1   => available.HasFlag(RxAuxInputs.Ext1)   ? (int)sel : 0,
+        RxAuxInputSel.Ext2   => available.HasFlag(RxAuxInputs.Ext2)   ? (int)sel : 0,
+        RxAuxInputSel.Xvtr   => available.HasFlag(RxAuxInputs.Xvtr)   ? (int)sel : 0,
+        RxAuxInputSel.Bypass => available.HasFlag(RxAuxInputs.Bypass) ? (int)sel : 0,
+        _                    => 0,
+    };
 
     // Back-compat shim for callers/tests that predate IRadioDriveProfile.
     // Runtime RecomputePaAndPush no longer goes through here — it uses the
@@ -2752,6 +2803,8 @@ public sealed class RadioService : IDisposable
     public void Dispose()
     {
         _paStore.Changed -= RecomputePaAndPush;
+        if (_antennaStore is not null)
+            _antennaStore.Changed -= RecomputePaAndPush;
         try { DisconnectAsync(CancellationToken.None).GetAwaiter().GetResult(); }
         catch { /* best-effort */ }
         _stateFlushTimer?.Dispose();

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -2177,6 +2177,66 @@ public static class ZeusEndpoints
             return Results.Ok(new Hl2OptionsDto(BandVolts: effective));
         });
 
+        // External antenna ports (external-ports plan — antenna slice, #804).
+        // GET returns the per-band TX/RX antenna + RX-aux selection plus the
+        // board-capability gates the frontend renders the right selectors from.
+        // Antenna state is server-authoritative and NEVER enters StateDto.
+        app.MapGet("/api/radio/antenna", (RadioService radio, AntennaSettingsStore store) =>
+        {
+            var caps = BoardCapabilitiesTable.For(radio.EffectiveBoardKind, radio.EffectiveOrionMkIIVariant);
+            var bands = store.GetAll()
+                .Select(b => new AntennaBandDto(b.Band, b.TxAnt.ToString(), b.RxAnt.ToString(), b.RxAux.ToString()))
+                .ToArray();
+            return Results.Ok(new AntennaSettingsDto(
+                HasTxAntennaRelays: caps.HasTxAntennaRelays,
+                HasRxAntennaRelays: caps.HasRxAntennaRelays,
+                Bands: bands,
+                AvailableRxAux: AvailableRxAux(caps.RxAuxInputs)));
+        });
+
+        // PUT one band's antenna selection. Capability-gated: 400 on a malformed
+        // body / unknown band / unparseable antenna; 409 when the request asks
+        // for a relay the connected board does not have (a non-ANT1 TX on a board
+        // without TX relays, a non-ANT1 RX on a board without RX relays, or an
+        // aux the board does not expose). ANT1 / None are always accepted (the
+        // hardwired default on every board). The save fires Changed →
+        // RadioService.RecomputePaAndPush, which pushes server-authoritatively to
+        // the live client (P1 SetAntennaRx / P2 SetAntennas) — never via the
+        // frontend, so no clobber-on-connect. The wire layer defers a mid-key
+        // relay change to the unkey edge; PS owns the K36/BYPASS relay while armed
+        // regardless of an aux=BYPASS pick (PS-K36 firewall).
+        app.MapPut("/api/radio/antenna", (AntennaSetRequest req, RadioService radio, AntennaSettingsStore store) =>
+        {
+            if (req is null || string.IsNullOrWhiteSpace(req.Band))
+                return Results.BadRequest(new { error = "band required" });
+            if (!BandUtils.HfBands.Contains(req.Band))
+                return Results.BadRequest(new { error = $"unknown band '{req.Band}'" });
+            if (!Enum.TryParse<HpsdrAntenna>(req.TxAnt, ignoreCase: true, out var txAnt))
+                return Results.BadRequest(new { error = $"unknown txAnt '{req.TxAnt}'" });
+            if (!Enum.TryParse<HpsdrAntenna>(req.RxAnt, ignoreCase: true, out var rxAnt))
+                return Results.BadRequest(new { error = $"unknown rxAnt '{req.RxAnt}'" });
+            var rxAuxStr = string.IsNullOrWhiteSpace(req.RxAux) ? "None" : req.RxAux;
+            if (!Enum.TryParse<RxAuxInputSel>(rxAuxStr, ignoreCase: true, out var rxAux))
+                return Results.BadRequest(new { error = $"unknown rxAux '{req.RxAux}'" });
+
+            var caps = BoardCapabilitiesTable.For(radio.EffectiveBoardKind, radio.EffectiveOrionMkIIVariant);
+            if (txAnt != HpsdrAntenna.Ant1 && !caps.HasTxAntennaRelays)
+                return Results.Conflict(new { error = $"board {radio.EffectiveBoardKind} has no TX antenna relays; only Ant1 is valid" });
+            if (rxAnt != HpsdrAntenna.Ant1 && !caps.HasRxAntennaRelays)
+                return Results.Conflict(new { error = $"board {radio.EffectiveBoardKind} has no RX antenna relays; only Ant1 is valid" });
+            if (rxAux != RxAuxInputSel.None && !RxAuxSupported(rxAux, caps.RxAuxInputs))
+                return Results.Conflict(new { error = $"board {radio.EffectiveBoardKind} does not expose RX-aux input {rxAux}" });
+
+            store.SetBand(req.Band, txAnt, rxAnt, rxAux);
+
+            var bands = store.GetAll()
+                .Select(b => new AntennaBandDto(b.Band, b.TxAnt.ToString(), b.RxAnt.ToString(), b.RxAux.ToString()))
+                .ToArray();
+            return Results.Ok(new AntennaSettingsDto(
+                caps.HasTxAntennaRelays, caps.HasRxAntennaRelays, bands,
+                AvailableRxAux(caps.RxAuxInputs)));
+        });
+
         // ANAN-G2 / Saturn-class ADC options. Dither/random write Protocol-2
         // CmdRx bytes 5/6 when the connected/effective board advertises
         // SupportsG2AdcOptions; non-G2 boards still persist the preference but
@@ -2879,6 +2939,29 @@ public static class ZeusEndpoints
         var trimmed = deviceId?.Trim();
         return string.IsNullOrWhiteSpace(trimmed) ? null : trimmed;
     }
+
+    // The aux-input strings the connected board's Alex / filter board exposes
+    // (external-ports plan — antenna slice, #804). Empty on boards with no aux
+    // inputs (HL2). Names match the RxAuxInputSel single-choice enum the PUT
+    // request parses.
+    static string[] AvailableRxAux(RxAuxInputs caps)
+    {
+        var list = new List<string>(4);
+        if (caps.HasFlag(RxAuxInputs.Ext1))   list.Add(nameof(RxAuxInputSel.Ext1));
+        if (caps.HasFlag(RxAuxInputs.Ext2))   list.Add(nameof(RxAuxInputSel.Ext2));
+        if (caps.HasFlag(RxAuxInputs.Xvtr))   list.Add(nameof(RxAuxInputSel.Xvtr));
+        if (caps.HasFlag(RxAuxInputs.Bypass)) list.Add(nameof(RxAuxInputSel.Bypass));
+        return list.ToArray();
+    }
+
+    static bool RxAuxSupported(RxAuxInputSel sel, RxAuxInputs caps) => sel switch
+    {
+        RxAuxInputSel.Ext1   => caps.HasFlag(RxAuxInputs.Ext1),
+        RxAuxInputSel.Ext2   => caps.HasFlag(RxAuxInputs.Ext2),
+        RxAuxInputSel.Xvtr   => caps.HasFlag(RxAuxInputs.Xvtr),
+        RxAuxInputSel.Bypass => caps.HasFlag(RxAuxInputs.Bypass),
+        _                    => true, // None always allowed
+    };
 
     static bool TryParseIpEndpoint(string raw, out IPEndPoint ep)
     {

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -363,6 +363,10 @@ public static class ZeusHost
         // PTT-IN status lamp tracks the footswitch regardless.
         builder.Services.AddSingleton<PttSettingsStore>();
         builder.Services.AddSingleton<ExternalPttService>();
+        // Per-band external antenna (TX/RX relay + RX-aux) selection (external-
+        // ports plan — antenna slice, #804). RadioService takes it as an
+        // optional ctor param and re-pushes on its Changed event.
+        builder.Services.AddSingleton<AntennaSettingsStore>();
         builder.Services.AddHostedService(sp => sp.GetRequiredService<ExternalPttService>());
 
         // QRZ.com XML client. HttpClient default timeout is 100 s — cap at 10 s so a

--- a/tests/Zeus.Protocol1.Tests/ControlFrameTests.cs
+++ b/tests/Zeus.Protocol1.Tests/ControlFrameTests.cs
@@ -229,11 +229,27 @@ public class ControlFrameTests
     [Fact]
     public void ControlFrame_AntennaSelection_Ant2_SetsC3UpperBits()
     {
+        // RX-antenna C3[7:5] is emitted only on relay-capable boards. BaseState
+        // is HL2 (single jack → clamped to ANT1, see the clamp test below), so
+        // use a relay board (Hermes) to exercise the antenna-select math itself.
         Span<byte> cc = stackalloc byte[5];
-        var s = BaseState() with { RxAntenna = HpsdrAntenna.Ant2 };
+        var s = BaseState() with { RxAntenna = HpsdrAntenna.Ant2, Board = HpsdrBoardKind.Hermes };
         ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Config, s);
         // C3 [7:5] = antenna select; ANT2 = 0b001 → value 0x20.
         Assert.Equal(0b001 << 5, cc[3] & 0b11100000);
+    }
+
+    [Fact]
+    public void ControlFrame_AntennaSelection_Hl2_ClampedToAnt1()
+    {
+        // External-ports plan — antenna slice (#804): HL2 has a single antenna
+        // jack — C3[5] forwards to the N2ADR antenna pad, not an ANT1/2/3 relay
+        // — so a non-ANT1 RX-antenna selection MUST be clamped to ANT1 at the
+        // wire layer (ControlFrame.EncodeRxAntennaC3Bits).
+        Span<byte> cc = stackalloc byte[5];
+        var s = BaseState() with { RxAntenna = HpsdrAntenna.Ant3 }; // HL2
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Config, s);
+        Assert.Equal(0x00, cc[3] & 0b11100000);
     }
 
     [Fact]

--- a/tests/Zeus.Protocol1.Tests/ExternalPortGoldenTests.cs
+++ b/tests/Zeus.Protocol1.Tests/ExternalPortGoldenTests.cs
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Contracts;
+using Zeus.Protocol1.Discovery;
+
+namespace Zeus.Protocol1.Tests;
+
+/// <summary>
+/// GOLDEN-BYTE CHARACTERIZATION tests for the Protocol-1 Config (0x00) frame
+/// (external-ports plan, Phase 1). These lock the *current* emitted C0..C4
+/// bytes for the external-port-relevant fields — RX antenna (C3[7:5]), OC
+/// masks (C2[7:1]), duplex (C4[2]), and RX-count (C4[5:3]) — across boards
+/// and MOX states.
+///
+/// These are the safety net for the IExternalPortEncoder refactor: the
+/// encoder must reproduce these bytes EXACTLY. A single byte diff means the
+/// refactor changed behaviour. Do not "fix" these to match new output —
+/// they ARE the contract.
+///
+/// Co-tenancy is the point: C3 carries RxAntenna[7:5] alongside HL2 band-volts
+/// [3] and preamp [4]; C4 carries duplex[2] + RX-count[5:3] and must NEVER pick
+/// up TX-antenna bits for any supported board. The asserts below pin every
+/// co-tenant so the refactor can't clobber one while moving another.
+/// </summary>
+public class ExternalPortGoldenTests
+{
+    // A clean ANAN-class (codec board, RX relays) state at 14.2 MHz, RX.
+    private static ControlFrame.CcState HermesState() => new(
+        VfoAHz: 14_200_000,
+        Rate: HpsdrSampleRate.Rate48k,
+        PreampOn: false,
+        Atten: HpsdrAtten.Zero,
+        RxAntenna: HpsdrAntenna.Ant1,
+        Mox: false,
+        EnableHl2BandVolts: false,
+        Board: HpsdrBoardKind.Hermes);
+
+    private static ControlFrame.CcState Hl2State() => new(
+        VfoAHz: 14_200_000,
+        Rate: HpsdrSampleRate.Rate48k,
+        PreampOn: false,
+        Atten: HpsdrAtten.Zero,
+        RxAntenna: HpsdrAntenna.Ant1,
+        Mox: false,
+        EnableHl2BandVolts: false,
+        Board: HpsdrBoardKind.HermesLite2);
+
+    private static byte[] Config(in ControlFrame.CcState s)
+    {
+        Span<byte> cc = stackalloc byte[5];
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Config, s);
+        return cc.ToArray();
+    }
+
+    // ---- RX antenna C3[7:5] across Ant1/Ant2/Ant3 (Hermes / codec board) ----
+
+    [Theory]
+    [InlineData(HpsdrAntenna.Ant1, 0x00)] // 0 << 5
+    [InlineData(HpsdrAntenna.Ant2, 0x20)] // 1 << 5
+    [InlineData(HpsdrAntenna.Ant3, 0x40)] // 2 << 5
+    public void Config_C3_RxAntenna_Bits_AreLocked(HpsdrAntenna ant, byte expectedC3)
+    {
+        var cc = Config(HermesState() with { RxAntenna = ant });
+
+        // C0 = Config wire byte, RX (MOX off).
+        Assert.Equal(0x00, cc[0]);
+        // C1 = sample rate (48k = 0).
+        Assert.Equal(0x00, cc[1]);
+        // C2 = OC pins (none) << 1 = 0.
+        Assert.Equal(0x00, cc[2]);
+        // C3 = preamp off, band-volts off → just the RX-antenna bits.
+        Assert.Equal(expectedC3, cc[3]);
+        // C4 = duplex(1<<2) | rx-count(0).
+        Assert.Equal(0x04, cc[4]);
+    }
+
+    // RxAntenna co-tenants C3 with preamp[4] and (HL2-only) band-volts[3].
+    // Pin that the antenna shift never clobbers the neighbours.
+    [Fact]
+    public void Config_C3_RxAntenna_CoTenants_Preamp_AreLocked()
+    {
+        var cc = Config(HermesState() with
+        {
+            RxAntenna = HpsdrAntenna.Ant3,
+            PreampOn = true,
+        });
+
+        // preamp[4]=0x10 | antenna Ant3 [7:5]=0x40 → 0x50.
+        Assert.Equal(0x50, cc[3]);
+        Assert.Equal(0x04, cc[4]);
+    }
+
+    // DIFFERENTIAL (external-ports plan, Phase 2): the HL2 RX-antenna wire
+    // clamp. HL2 has a single jack — C3[5] drives the N2ADR antenna pad, not an
+    // ANT1/2/3 relay — so an operator (or a stale per-band) ANT2/3 MUST be
+    // forced to ANT1 at the wire layer. The co-tenant band-volts[3] / preamp[4]
+    // bits are preserved; only the [7:5] antenna field is zeroed.
+    [Theory]
+    [InlineData(HpsdrAntenna.Ant1)]
+    [InlineData(HpsdrAntenna.Ant2)]
+    [InlineData(HpsdrAntenna.Ant3)]
+    public void Config_Hl2_C3_RxAntenna_IsClampedToAnt1(HpsdrAntenna requested)
+    {
+        var cc = Config(Hl2State() with
+        {
+            RxAntenna = requested,
+            EnableHl2BandVolts = true,
+            PreampOn = true,
+        });
+
+        // band-volts[3]=0x08 | preamp[4]=0x10 | antenna [7:5]=0 (clamped) → 0x18,
+        // regardless of which antenna was requested.
+        Assert.Equal(0x18, cc[3]);
+        Assert.Equal(0x04, cc[4]);
+        // Antenna field is hard-zero on HL2.
+        Assert.Equal(0x00, cc[3] & 0xE0);
+    }
+
+    // A relay-capable P1 board (Hermes) reflects the selection in C3[7:5] — the
+    // other side of the differential. This is the same lock as
+    // Config_C3_RxAntenna_Bits_AreLocked but stated as the HL2-clamp contrast.
+    [Theory]
+    [InlineData(HpsdrAntenna.Ant1, 0x00)]
+    [InlineData(HpsdrAntenna.Ant2, 0x20)]
+    [InlineData(HpsdrAntenna.Ant3, 0x40)]
+    public void Config_RelayBoard_C3_RxAntenna_ReflectsSelection(HpsdrAntenna ant, byte expectedC3)
+    {
+        var cc = Config(HermesState() with { RxAntenna = ant });
+        Assert.Equal(expectedC3, cc[3]);
+    }
+
+    // ---- OC mask C2[7:1] — MOX selects TX vs RX mask ----
+
+    [Fact]
+    public void Config_C2_OcMask_Rx_IsShiftedLeftOne()
+    {
+        // UserOcRxMask 0x05 (7-bit) → C2 = 0x05 << 1 = 0x0A (RX, MOX off).
+        var cc = Config(HermesState() with { UserOcRxMask = 0x05, UserOcTxMask = 0x42 });
+        Assert.Equal(0x0A, cc[2]);
+    }
+
+    [Fact]
+    public void Config_C2_OcMask_Tx_IsSelectedWhenMox()
+    {
+        // MOX on → TX mask 0x42 << 1 = 0x84.
+        var cc = Config(HermesState() with
+        {
+            Mox = true,
+            UserOcRxMask = 0x05,
+            UserOcTxMask = 0x42,
+        });
+        Assert.Equal(0x01, cc[0]);    // Config + MOX bit
+        Assert.Equal(0x84, cc[2]);
+    }
+
+    [Fact]
+    public void Config_Hl2_C2_OcMask_OrsN2adrAutoMask()
+    {
+        // HL2 with N2ADR ORs the auto-filter mask first, then the user mask.
+        // 14.2 MHz lives in the 20m N2ADR bucket; lock whatever that resolves
+        // to today combined with a user RX bit.
+        byte n2adr = N2adrBands.RxOcMask(14_200_000);
+        var cc = Config(Hl2State() with { HasN2adr = true, UserOcRxMask = 0x01 });
+        byte expectedC2 = (byte)(((n2adr | 0x01) & 0x7F) << 1);
+        Assert.Equal(expectedC2, cc[2]);
+    }
+
+    // ---- C4 duplex + RX-count, never TX antenna ----
+
+    [Theory]
+    [InlineData((byte)0, 0x04)] // duplex only
+    [InlineData((byte)1, 0x0C)] // duplex | (1<<3)
+    [InlineData((byte)3, 0x1C)] // duplex | (3<<3)
+    public void Config_C4_Duplex_And_RxCount_AreLocked(byte rxMinusOne, byte expectedC4)
+    {
+        var cc = Config(HermesState() with { NumReceiversMinusOne = rxMinusOne });
+        Assert.Equal(expectedC4, cc[4]);
+        // Bit 2 (duplex) always set.
+        Assert.Equal(0x04, cc[4] & 0x04);
+        // Bits [1:0] (TX antenna on legacy Alex) always clear — Zeus emits no
+        // TX-antenna relay bits on the P1 Config frame for any board.
+        Assert.Equal(0x00, cc[4] & 0x03);
+    }
+
+    [Fact]
+    public void Config_C4_NeverCarriesTxAntenna_EvenWithRxAntennaSet()
+    {
+        // Selecting a non-default RX antenna must not bleed into C4.
+        var cc = Config(HermesState() with
+        {
+            RxAntenna = HpsdrAntenna.Ant3,
+            NumReceiversMinusOne = 1,
+        });
+        Assert.Equal(0x0C, cc[4]);          // duplex | rx-count, no TX-ant bits
+        Assert.Equal(0x00, cc[4] & 0x03);
+    }
+}

--- a/tests/Zeus.Protocol2.Tests/ExternalPortAlexGoldenTests.cs
+++ b/tests/Zeus.Protocol2.Tests/ExternalPortAlexGoldenTests.cs
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Xunit;
+using Zeus.Contracts;
+
+namespace Zeus.Protocol2.Tests;
+
+/// <summary>
+/// GOLDEN-BYTE CHARACTERIZATION tests for the Protocol-2 Alex words on the
+/// Saturn / 0x0A (OrionMkII) path (external-ports plan, Phase 1). These lock
+/// the *current* 32-bit alex0 (HighPriority offset 1432) and alex1 (offset
+/// 1428) values for the antenna + TX-relay + PureSignal bits across idle/xmit
+/// and PS-armed/not.
+///
+/// This is the safety net for the IExternalPortEncoder refactor: moving the
+/// TX/RX antenna bits behind the encoder must reproduce these words EXACTLY.
+/// A single differing bit means the refactor changed behaviour — and the
+/// PureSignal bits (AlexPsBit 0x00040000, AlexRxAntennaBypass 0x00000800) and
+/// TX_RELAY (0x08000000) are pinned here precisely so a refactor cannot
+/// disturb them.
+///
+/// Canonical fixture: 14.1 MHz on the OrionMkII (Saturn BPF) board.
+///   BPF (20/15m bucket)      = 0x00000002
+///   LPF (30/20m bucket)      = 0x00100000
+///   TX antenna 1 (hardcoded) = 0x01000000
+///   => alexCommon            = 0x01100002
+/// </summary>
+public class ExternalPortAlexGoldenTests
+{
+    private const uint Rx = 14_100_000u;
+
+    // The composed base word (no TX-relay, no PS) for the canonical fixture.
+    private const uint AlexCommon = 0x01100002u;
+
+    // Live-path OR constants (must match Protocol2Client private consts).
+    private const uint TxRelay = 0x08000000u;
+    private const uint Gnd0nTx = 0x00000100u; // alex1-only RX-ground while keyed
+    private const uint PsBit = 0x00040000u;
+    private const uint Bypass = 0x00000800u;
+
+    // ---- alex0 (offset 1432) ----
+
+    [Fact]
+    public void Alex0_Idle_NoPs_IsAlexCommon()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: false, psEnabled: false, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII);
+        Assert.Equal(AlexCommon, alex0);
+    }
+
+    [Fact]
+    public void Alex0_Xmit_NoPs_AddsTxRelay()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: true, psEnabled: false, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII);
+        Assert.Equal(AlexCommon | TxRelay, alex0);
+    }
+
+    [Fact]
+    public void Alex0_Xmit_PsInternal_AddsTxRelayAndPsBit()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: true, psEnabled: true, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII);
+        Assert.Equal(AlexCommon | TxRelay | PsBit, alex0);
+    }
+
+    [Fact]
+    public void Alex0_Xmit_PsExternal_AddsBypassBit()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: true, psEnabled: true, psExternal: true,
+            board: HpsdrBoardKind.OrionMkII);
+        Assert.Equal(AlexCommon | TxRelay | PsBit | Bypass, alex0);
+    }
+
+    [Fact]
+    public void Alex0_Idle_PsArmed_DoesNotAddTxRelayOrPsOrBypass()
+    {
+        // PS armed but not keyed: alex0 stays at the base word (PS rides alex1
+        // always, alex0 only during xmit).
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: false, psEnabled: true, psExternal: true,
+            board: HpsdrBoardKind.OrionMkII);
+        Assert.Equal(AlexCommon, alex0);
+    }
+
+    // ---- TX-antenna select alex0[26:24] (external-ports plan, Phase 2) ----
+
+    // The fixture's BPF+LPF bits without ANY TX-antenna bit (AlexCommon minus
+    // ALEX_TX_ANTENNA_1). Antenna bits are added on top per selection.
+    private const uint AlexNoAnt = 0x00100002u;
+    private const uint TxAnt1 = 0x01000000u;
+    private const uint TxAnt2 = 0x02000000u;
+    private const uint TxAnt3 = 0x04000000u;
+
+    // DIFFERENTIAL: alex0 ANT1/2/3 [26:24] is STATE-MULTIPLEXED (pihpsdr
+    // new_protocol.c:1331-1357, bench-confirmed on G2). DURING XMIT alex0 carries
+    // the TX antenna (+ TX_RELAY); nothing else moves.
+    [Theory]
+    [InlineData(1, TxAnt1)]
+    [InlineData(2, TxAnt2)]
+    [InlineData(3, TxAnt3)]
+    public void Alex0_Xmit_CarriesTxAntenna_OnRelayBoard(int txAntWire, uint expectedAntBits)
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: true, psEnabled: false, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII,
+            txAntWire: txAntWire, hasTxAntennaRelays: true);
+        Assert.Equal(AlexNoAnt | expectedAntBits | TxRelay, alex0);
+    }
+
+    // AT IDLE (RX) alex0 carries the RX antenna, NOT the TX antenna.
+    [Theory]
+    [InlineData(1, TxAnt1)]
+    [InlineData(2, TxAnt2)]
+    [InlineData(3, TxAnt3)]
+    public void Alex0_Idle_CarriesRxAntenna_OnRelayBoard(int rxAntWire, uint expectedAntBits)
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: false, psEnabled: false, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII,
+            txAntWire: 1, hasTxAntennaRelays: true, rxAntWire: rxAntWire);
+        Assert.Equal(AlexNoAnt | expectedAntBits, alex0);
+    }
+
+    // THE BENCH BUG: at idle, changing the TX antenna must NOT move the RX path.
+    // TX=ANT2 with RX=ANT1 → alex0 stays on ANT1 (RX), so RX doesn't go away.
+    [Fact]
+    public void Alex0_Idle_TxAntennaChange_DoesNotMoveRx()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: false, psEnabled: false, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII,
+            txAntWire: 2, hasTxAntennaRelays: true, rxAntWire: 1);
+        Assert.Equal(AlexNoAnt | TxAnt1, alex0);
+    }
+
+    // During xmit the TX-relay rides alongside the selected antenna — confirm
+    // the two are disjoint and both present.
+    [Fact]
+    public void Alex0_Xmit_TxAntenna2_AddsAntAndTxRelay()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: true, psEnabled: false, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII,
+            txAntWire: 2, hasTxAntennaRelays: true);
+        Assert.Equal(AlexNoAnt | TxAnt2 | TxRelay, alex0);
+    }
+
+    // PS armed + ANT3 mid-xmit: the PS bit and the antenna bits coexist; PS is
+    // never disturbed by the antenna selection.
+    [Fact]
+    public void Alex0_Xmit_TxAntenna3_PsInternal_KeepsPsBit()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: true, psEnabled: true, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII,
+            txAntWire: 3, hasTxAntennaRelays: true);
+        Assert.Equal(AlexNoAnt | TxAnt3 | TxRelay | PsBit, alex0);
+    }
+
+    // GATE: a board/variant WITHOUT TX-antenna relays must NOT advertise ANT2/3
+    // even when ANT2/3 is requested — it stays on ANT1. This is the single-relay
+    // / non-relay safety, and it keeps the ANT1 default byte-identical.
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    public void Alex0_Idle_NonRelayBoard_StaysOnAnt1(int txAntWire)
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: false, psEnabled: false, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII,
+            txAntWire: txAntWire, hasTxAntennaRelays: false);
+        Assert.Equal(AlexCommon, alex0); // AlexCommon already carries ANT1
+    }
+
+    // ---- alex1 (offset 1428) ----
+
+    [Fact]
+    public void Alex1_Idle_NoPs_IsAlexCommon()
+    {
+        uint alex1 = Protocol2Client.ComposeAlex1ForTest(
+            rxFreqHz: Rx, moxOn: false, psEnabled: false,
+            board: HpsdrBoardKind.OrionMkII);
+        Assert.Equal(AlexCommon, alex1);
+    }
+
+    [Fact]
+    public void Alex1_Xmit_NoPs_AddsTxRelayAndGndOnTx()
+    {
+        uint alex1 = Protocol2Client.ComposeAlex1ForTest(
+            rxFreqHz: Rx, moxOn: true, psEnabled: false,
+            board: HpsdrBoardKind.OrionMkII);
+        Assert.Equal(AlexCommon | TxRelay | Gnd0nTx, alex1);
+    }
+
+    [Fact]
+    public void Alex1_Idle_PsArmed_AddsPsBitAlways()
+    {
+        // PS rides alex1 whenever armed, regardless of MOX.
+        uint alex1 = Protocol2Client.ComposeAlex1ForTest(
+            rxFreqHz: Rx, moxOn: false, psEnabled: true,
+            board: HpsdrBoardKind.OrionMkII);
+        Assert.Equal(AlexCommon | PsBit, alex1);
+    }
+
+    [Fact]
+    public void Alex1_Xmit_PsArmed_AddsTxRelayGndAndPs()
+    {
+        uint alex1 = Protocol2Client.ComposeAlex1ForTest(
+            rxFreqHz: Rx, moxOn: true, psEnabled: true,
+            board: HpsdrBoardKind.OrionMkII);
+        Assert.Equal(AlexCommon | TxRelay | Gnd0nTx | PsBit, alex1);
+    }
+
+    // ============================================================
+    //  Phase 5 — RX-aux inputs (EXT1/EXT2/XVTR/BYPASS) + RX_SELECT
+    // ============================================================
+    // Verified against pihpsdr src/alex.h:43-47, 122.
+    private const uint AuxXvtr   = 0x00000100u; // bit 8
+    private const uint AuxExt1   = 0x00000200u; // bit 9
+    private const uint AuxExt2   = 0x00000400u; // bit 10
+    private const uint AuxBypass = 0x00000800u; // bit 11  (== Bypass / K36)
+    private const uint RxSelect  = 0x00004000u; // bit 14  Saturn master RX-select
+
+    // selector ints used by ComposeRxAuxBits / ComposeAlex0ForTest:
+    // 0=None, 1=EXT1, 2=EXT2, 3=XVTR, 4=BYPASS.
+
+    [Fact]
+    public void RxAux_None_IsByteIdentical()
+    {
+        // The default-unsent invariant: aux=None leaves alex0 exactly as the
+        // pre-Phase-5 word.
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: false, psEnabled: false, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII,
+            rxAuxInput: 0, mkiiBpfRxSelect: true);
+        Assert.Equal(AlexCommon, alex0);
+    }
+
+    [Theory]
+    [InlineData(1, AuxExt1)]
+    [InlineData(2, AuxExt2)]
+    [InlineData(3, AuxXvtr)]
+    [InlineData(4, AuxBypass)]
+    public void RxAux_ClassicAlex_SetsJustTheJacketBit(int aux, uint expected)
+    {
+        // Classic-Alex board (no MkII master RX-select): the aux jacket bit
+        // alone, RX_SELECT clear.
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: false, psEnabled: false, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII,
+            rxAuxInput: aux, mkiiBpfRxSelect: false);
+        Assert.Equal(AlexCommon | expected, alex0);
+        Assert.Equal(0u, alex0 & RxSelect);
+    }
+
+    [Theory]
+    [InlineData(1, AuxExt1)]
+    [InlineData(2, AuxExt2)]
+    [InlineData(3, AuxXvtr)]
+    [InlineData(4, AuxBypass)]
+    public void RxAux_SaturnBpf_AlsoSetsRxSelectBit14(int aux, uint expected)
+    {
+        // MkII / Saturn BPF board: the aux jacket bit AND the master RX-select
+        // (bit 14) so the jack is actually gated onto the RX (alex.h:122).
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: false, psEnabled: false, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII,
+            rxAuxInput: aux, mkiiBpfRxSelect: true);
+        Assert.Equal(AlexCommon | expected | RxSelect, alex0);
+    }
+
+    // ============================================================
+    //  Phase 5 — PS-K36 ARBITRATION (the load-bearing firewall, §3.4(2))
+    // ============================================================
+
+    // THE GOLDEN TEST. Operator selects aux=BYPASS AND PureSignal is armed
+    // (external feedback) during xmit: the wire MUST still carry the PS coupler
+    // routing. Because both the operator BYPASS and PS-external use bit 11, and
+    // PS routing is OR'd AFTER the operator aux, the PS coupler bit is present
+    // regardless — the operator pick can NEVER strip it. Encoded order:
+    // operator-aux first, PS last.
+    [Fact]
+    public void PsK36_AuxBypassPlusPsExternal_StillEmitsPsCoupler()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: true, psEnabled: true, psExternal: true,
+            board: HpsdrBoardKind.OrionMkII,
+            rxAuxInput: 4 /* BYPASS */, mkiiBpfRxSelect: true);
+
+        // PS coupler bit (K36 / bit 11) present, PS bit present, TX-relay present.
+        Assert.Equal(AuxBypass, alex0 & AuxBypass); // K36 set (== PS coupler)
+        Assert.Equal(PsBit, alex0 & PsBit);          // PS feedback-coupler enable
+        Assert.Equal(TxRelay, alex0 & TxRelay);
+        // The exact word: base + RX_SELECT (operator aux on Saturn) + K36 + PS + TX-relay.
+        Assert.Equal(AlexCommon | RxSelect | AuxBypass | PsBit | TxRelay, alex0);
+    }
+
+    // Even with a CONFLICTING aux (operator picks EXT1, not BYPASS) while PS is
+    // armed-external during xmit, the PS coupler (BYPASS/K36) is still asserted —
+    // PS owns the relay. The operator's EXT1 bit also rides (it is a different
+    // bit, bit 9) but it cannot suppress the PS coupler.
+    [Fact]
+    public void PsK36_AuxExt1PlusPsExternal_PsCouplerNotStolen()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: true, psEnabled: true, psExternal: true,
+            board: HpsdrBoardKind.OrionMkII,
+            rxAuxInput: 1 /* EXT1 */, mkiiBpfRxSelect: true);
+        Assert.Equal(AuxBypass, alex0 & AuxBypass); // PS coupler still set
+        Assert.Equal(PsBit, alex0 & PsBit);
+    }
+
+    // PS armed but INTERNAL coupler + operator aux=BYPASS during xmit: the K36
+    // bit comes purely from the operator's aux here (PS internal doesn't set it),
+    // which is the operator's prerogative when PS isn't using the external path.
+    // The PS bit is still present (feedback-coupler enable). This documents that
+    // the arbitration is "PS external OWNS K36"; PS internal leaves the operator
+    // aux in control of bit 11.
+    [Fact]
+    public void PsK36_AuxBypassPlusPsInternal_OperatorBypassRides()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: true, psEnabled: true, psExternal: false,
+            board: HpsdrBoardKind.OrionMkII,
+            rxAuxInput: 4 /* BYPASS */, mkiiBpfRxSelect: true);
+        Assert.Equal(AuxBypass, alex0 & AuxBypass);
+        Assert.Equal(PsBit, alex0 & PsBit);
+        Assert.Equal(AlexCommon | RxSelect | AuxBypass | PsBit | TxRelay, alex0);
+    }
+
+    // Idle (not keyed), PS armed external, operator aux=BYPASS: alex0 carries the
+    // operator BYPASS (RX-time aux routing) but NOT the PS coupler/PS bit (those
+    // ride alex0 only during xmit). Confirms the aux path works at RX and the PS
+    // xmit-only gating is intact.
+    [Fact]
+    public void PsK36_Idle_AuxBypass_PsExternal_NoPsBitButAuxRides()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: Rx, moxOn: false, psEnabled: true, psExternal: true,
+            board: HpsdrBoardKind.OrionMkII,
+            rxAuxInput: 4 /* BYPASS */, mkiiBpfRxSelect: true);
+        Assert.Equal(AlexCommon | RxSelect | AuxBypass, alex0);
+        Assert.Equal(0u, alex0 & PsBit);
+    }
+}

--- a/tests/Zeus.Server.Tests/AntennaCapabilitiesTests.cs
+++ b/tests/Zeus.Server.Tests/AntennaCapabilitiesTests.cs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// Per-board antenna capability matrix (external-ports plan — antenna slice,
+// #804). Pins HasTxAntennaRelays / HasRxAntennaRelays / RxAuxInputs /
+// HasRx2AntennaPath per board so the wire gates (and the REST 409 gates) stay
+// aligned with the hardware. Audio / GPIO caps are out of this slice's scope.
+
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class AntennaCapabilitiesTests
+{
+    [Fact]
+    public void TxAntennaRelays_Only_OrionMkII_0x0A_Family()
+    {
+        // Only the 0x0A / Saturn family has switchable TX antenna relays.
+        // Every variant in that family (incl. Apache OrionMkII original) does.
+        foreach (var variant in Enum.GetValues<OrionMkIIVariant>())
+            Assert.True(BoardCapabilitiesTable.For(HpsdrBoardKind.OrionMkII, variant).HasTxAntennaRelays);
+
+        // No P1 board and not HL2.
+        foreach (var board in new[] {
+            HpsdrBoardKind.Metis, HpsdrBoardKind.Hermes, HpsdrBoardKind.HermesII,
+            HpsdrBoardKind.Angelia, HpsdrBoardKind.Orion, HpsdrBoardKind.HermesC10,
+            HpsdrBoardKind.HermesLite2 })
+            Assert.False(BoardCapabilitiesTable.For(board).HasTxAntennaRelays);
+    }
+
+    [Fact]
+    public void RxAntennaRelays_Every_ANAN_Not_HL2()
+    {
+        // Every ANAN / Hermes-class board has Alex RX-antenna relays; HL2 does
+        // not (single jack → N2ADR pad, clamped to ANT1 at the wire layer).
+        foreach (var board in new[] {
+            HpsdrBoardKind.Metis, HpsdrBoardKind.Hermes, HpsdrBoardKind.HermesII,
+            HpsdrBoardKind.Angelia, HpsdrBoardKind.Orion, HpsdrBoardKind.OrionMkII,
+            HpsdrBoardKind.HermesC10 })
+            Assert.True(BoardCapabilitiesTable.For(board).HasRxAntennaRelays);
+
+        Assert.False(BoardCapabilitiesTable.For(HpsdrBoardKind.HermesLite2).HasRxAntennaRelays);
+    }
+
+    [Fact]
+    public void RxAuxInputs_All_On_Alex_Boards_None_On_HL2()
+    {
+        // Every Alex-class P1 board and the 0x0A family exposes the full RX-aux
+        // input set (EXT1/EXT2/XVTR/BYPASS). HL2 exposes NONE — the jacks don't
+        // physically exist.
+        foreach (var board in new[] {
+            HpsdrBoardKind.Metis, HpsdrBoardKind.Hermes, HpsdrBoardKind.HermesII,
+            HpsdrBoardKind.Angelia, HpsdrBoardKind.Orion, HpsdrBoardKind.OrionMkII,
+            HpsdrBoardKind.HermesC10 })
+            Assert.Equal(RxAuxInputs.All, BoardCapabilitiesTable.For(board).RxAuxInputs);
+
+        Assert.Equal(RxAuxInputs.None, BoardCapabilitiesTable.For(HpsdrBoardKind.HermesLite2).RxAuxInputs);
+    }
+
+    [Fact]
+    public void Rx2AntennaPath_Only_DualAdc_Boards()
+    {
+        // The dual-ADC boards (100D / 200D / 0x0A family) have a second RX
+        // antenna path; single-RX boards (Hermes-class, G2E, HL2) do not.
+        foreach (var board in new[] {
+            HpsdrBoardKind.Angelia, HpsdrBoardKind.Orion, HpsdrBoardKind.OrionMkII })
+            Assert.True(BoardCapabilitiesTable.For(board).HasRx2AntennaPath);
+
+        foreach (var board in new[] {
+            HpsdrBoardKind.Metis, HpsdrBoardKind.Hermes, HpsdrBoardKind.HermesII,
+            HpsdrBoardKind.HermesC10, HpsdrBoardKind.HermesLite2 })
+            Assert.False(BoardCapabilitiesTable.For(board).HasRx2AntennaPath);
+    }
+
+    [Fact]
+    public void All_0x0A_Variants_Share_Antenna_Semantics()
+    {
+        // The 0x0A family shares HpsdrBoardKind.OrionMkII, so every variant must
+        // report the same antenna fingerprint — the band rows are board-agnostic
+        // and round-trip across variants.
+        foreach (var variant in Enum.GetValues<OrionMkIIVariant>())
+        {
+            var caps = BoardCapabilitiesTable.For(HpsdrBoardKind.OrionMkII, variant);
+            Assert.True(caps.HasTxAntennaRelays);
+            Assert.True(caps.HasRxAntennaRelays);
+            Assert.Equal(RxAuxInputs.All, caps.RxAuxInputs);
+            Assert.True(caps.HasRx2AntennaPath);
+        }
+    }
+
+    [Fact]
+    public void UnknownDefaults_Advertise_No_Antenna_Ports()
+    {
+        // Conservative: an unrecognised board must not claim any antenna port.
+        var u = BoardCapabilities.UnknownDefaults;
+        Assert.False(u.HasTxAntennaRelays);
+        Assert.False(u.HasRxAntennaRelays);
+        Assert.Equal(RxAuxInputs.None, u.RxAuxInputs);
+        Assert.False(u.HasRx2AntennaPath);
+    }
+}

--- a/tests/Zeus.Server.Tests/AntennaEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/AntennaEndpointTests.cs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// External-ports plan — antenna slice (#804): capability-gated
+// /api/radio/antenna. Derives from IsolatedPrefsFactory so each test gets a
+// fresh prefs DB (Linux LiteDB shared-mode isolation — GH #682).
+
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Capability-gating + persistence of the per-band antenna endpoint. The
+/// connected board is simulated by writing the PreferredRadioStore override so
+/// RadioService.EffectiveBoardKind resolves without a live radio.
+/// </summary>
+public class AntennaEndpointTests : IClassFixture<AntennaEndpointTests.Factory>
+{
+    private readonly Factory _factory;
+    public AntennaEndpointTests(Factory factory) => _factory = factory;
+
+    private void SetBoard(HpsdrBoardKind board)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var prefs = scope.ServiceProvider.GetRequiredService<PreferredRadioStore>();
+        prefs.Set(board, overrideDetection: true);
+    }
+
+    [Fact]
+    public async Task RelayBoard_Accepts_Ant2_And_Persists()
+    {
+        SetBoard(HpsdrBoardKind.OrionMkII); // has TX + RX antenna relays
+        using var client = _factory.CreateClient();
+
+        var resp = await client.PutAsJsonAsync("/api/radio/antenna",
+            new { band = "20m", txAnt = "Ant2", rxAnt = "Ant3" });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var dto = await resp.Content.ReadFromJsonAsync<AntennaSettingsDto>();
+        Assert.NotNull(dto);
+        Assert.True(dto!.HasTxAntennaRelays);
+        Assert.True(dto.HasRxAntennaRelays);
+        var b20 = dto.Bands.First(b => b.Band == "20m");
+        Assert.Equal("Ant2", b20.TxAnt);
+        Assert.Equal("Ant3", b20.RxAnt);
+
+        // GET reflects the persisted selection.
+        var got = await client.GetFromJsonAsync<AntennaSettingsDto>("/api/radio/antenna");
+        Assert.Equal("Ant2", got!.Bands.First(b => b.Band == "20m").TxAnt);
+    }
+
+    [Fact]
+    public async Task NonRelayBoard_Rejects_TxAnt2_With_409()
+    {
+        SetBoard(HpsdrBoardKind.HermesLite2); // single jack: no TX/RX relays
+        using var client = _factory.CreateClient();
+
+        var resp = await client.PutAsJsonAsync("/api/radio/antenna",
+            new { band = "20m", txAnt = "Ant2", rxAnt = "Ant1" });
+        Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task NonRelayBoard_Rejects_RxAnt3_With_409()
+    {
+        SetBoard(HpsdrBoardKind.HermesLite2);
+        using var client = _factory.CreateClient();
+
+        var resp = await client.PutAsJsonAsync("/api/radio/antenna",
+            new { band = "20m", txAnt = "Ant1", rxAnt = "Ant3" });
+        Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task NonRelayBoard_Accepts_Ant1()
+    {
+        SetBoard(HpsdrBoardKind.HermesLite2);
+        using var client = _factory.CreateClient();
+
+        // ANT1 is the hardwired default on every board — always valid.
+        var resp = await client.PutAsJsonAsync("/api/radio/antenna",
+            new { band = "20m", txAnt = "Ant1", rxAnt = "Ant1" });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Unknown_Band_Is_400()
+    {
+        SetBoard(HpsdrBoardKind.OrionMkII);
+        using var client = _factory.CreateClient();
+
+        var resp = await client.PutAsJsonAsync("/api/radio/antenna",
+            new { band = "not-a-band", txAnt = "Ant1", rxAnt = "Ant1" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Unparseable_Antenna_Is_400()
+    {
+        SetBoard(HpsdrBoardKind.OrionMkII);
+        using var client = _factory.CreateClient();
+
+        var resp = await client.PutAsJsonAsync("/api/radio/antenna",
+            new { band = "20m", txAnt = "Ant9", rxAnt = "Ant1" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    // ---- RX-aux gating ----
+
+    [Fact]
+    public async Task AuxBoard_Exposes_AvailableRxAux_And_Accepts_Bypass()
+    {
+        SetBoard(HpsdrBoardKind.OrionMkII); // RxAuxInputs.All
+        using var client = _factory.CreateClient();
+
+        var resp = await client.PutAsJsonAsync("/api/radio/antenna",
+            new { band = "20m", txAnt = "Ant1", rxAnt = "Ant1", rxAux = "Bypass" });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var dto = await resp.Content.ReadFromJsonAsync<AntennaSettingsDto>();
+        Assert.NotNull(dto);
+        Assert.Contains("Bypass", dto!.AvailableRxAux!);
+        Assert.Equal("Modern", dto.AlexRevision);
+        Assert.Equal("Bypass", dto.Bands.First(b => b.Band == "20m").RxAux);
+    }
+
+    [Fact]
+    public async Task Hl2_Rejects_RxAux_With_409()
+    {
+        SetBoard(HpsdrBoardKind.HermesLite2); // RxAuxInputs.None
+        using var client = _factory.CreateClient();
+
+        var resp = await client.PutAsJsonAsync("/api/radio/antenna",
+            new { band = "20m", txAnt = "Ant1", rxAnt = "Ant1", rxAux = "Ext1" });
+        Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+
+        // The GET advertises NO aux inputs on HL2.
+        var got = await client.GetFromJsonAsync<AntennaSettingsDto>("/api/radio/antenna");
+        Assert.Empty(got!.AvailableRxAux!);
+    }
+
+    public sealed class Factory : IsolatedPrefsFactory { }
+}

--- a/tests/Zeus.Server.Tests/AntennaSettingsStoreTests.cs
+++ b/tests/Zeus.Server.Tests/AntennaSettingsStoreTests.cs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// External-ports plan, Phase 2 — per-band antenna persistence round-trip.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Protocol1;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class AntennaSettingsStoreTests : IDisposable
+{
+    private readonly string _dbPath;
+
+    public AntennaSettingsStoreTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"zeus-prefs-antenna-{Guid.NewGuid():N}.db");
+    }
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+    }
+
+    private AntennaSettingsStore NewStore() =>
+        new AntennaSettingsStore(NullLogger<AntennaSettingsStore>.Instance, _dbPath);
+
+    [Fact]
+    public void Unset_Band_Defaults_To_Ant1()
+    {
+        using var store = NewStore();
+        var sel = store.GetBand("20m");
+        Assert.Equal(HpsdrAntenna.Ant1, sel.TxAnt);
+        Assert.Equal(HpsdrAntenna.Ant1, sel.RxAnt);
+    }
+
+    [Fact]
+    public void SetBand_RxAux_RoundTrips_PerBand()
+    {
+        // Phase 5: the RX-aux selection persists per band alongside the antennas.
+        using (var store = NewStore())
+        {
+            store.SetBand("20m", HpsdrAntenna.Ant1, HpsdrAntenna.Ant1, RxAuxInputSel.Bypass);
+            store.SetBand("40m", HpsdrAntenna.Ant2, HpsdrAntenna.Ant1, RxAuxInputSel.Ext1);
+        }
+        using var reopened = NewStore();
+        Assert.Equal(RxAuxInputSel.Bypass, reopened.GetBand("20m").RxAux);
+        var b40 = reopened.GetBand("40m");
+        Assert.Equal(HpsdrAntenna.Ant2, b40.TxAnt);
+        Assert.Equal(RxAuxInputSel.Ext1, b40.RxAux);
+    }
+
+    [Fact]
+    public void SetBand_RoundTrips_PerBand()
+    {
+        using (var store = NewStore())
+        {
+            store.SetBand("20m", HpsdrAntenna.Ant2, HpsdrAntenna.Ant3);
+            store.SetBand("40m", HpsdrAntenna.Ant3, HpsdrAntenna.Ant1);
+        }
+
+        // Reopen to prove it survives a backend restart (the whole point of
+        // server-authoritative persistence).
+        using var reopened = NewStore();
+        var b20 = reopened.GetBand("20m");
+        Assert.Equal(HpsdrAntenna.Ant2, b20.TxAnt);
+        Assert.Equal(HpsdrAntenna.Ant3, b20.RxAnt);
+
+        var b40 = reopened.GetBand("40m");
+        Assert.Equal(HpsdrAntenna.Ant3, b40.TxAnt);
+        Assert.Equal(HpsdrAntenna.Ant1, b40.RxAnt);
+
+        // An untouched band is still ANT1 — selections are per-band, not global.
+        var b15 = reopened.GetBand("15m");
+        Assert.Equal(HpsdrAntenna.Ant1, b15.TxAnt);
+        Assert.Equal(HpsdrAntenna.Ant1, b15.RxAnt);
+        // RX-aux defaults to None for pre-Phase-5 / untouched rows.
+        Assert.Equal(RxAuxInputSel.None, b15.RxAux);
+        Assert.Equal(RxAuxInputSel.None, b20.RxAux); // 3-arg SetBand → None
+    }
+
+    [Fact]
+    public void SetBand_Upsert_Updates_Existing()
+    {
+        using var store = NewStore();
+        store.SetBand("20m", HpsdrAntenna.Ant2, HpsdrAntenna.Ant2);
+        store.SetBand("20m", HpsdrAntenna.Ant3, HpsdrAntenna.Ant1);
+
+        var sel = store.GetBand("20m");
+        Assert.Equal(HpsdrAntenna.Ant3, sel.TxAnt);
+        Assert.Equal(HpsdrAntenna.Ant1, sel.RxAnt);
+    }
+
+    [Fact]
+    public void Changed_Fires_On_Save()
+    {
+        using var store = NewStore();
+        int fired = 0;
+        store.Changed += () => fired++;
+        store.SetBand("20m", HpsdrAntenna.Ant2, HpsdrAntenna.Ant1);
+        Assert.Equal(1, fired);
+    }
+
+    [Fact]
+    public void GetAll_Returns_Every_HfBand()
+    {
+        using var store = NewStore();
+        store.SetBand("20m", HpsdrAntenna.Ant2, HpsdrAntenna.Ant3);
+        var all = store.GetAll();
+        Assert.All(BandUtils.HfBands, b => Assert.Contains(all, x => x.Band == b));
+        var b20 = all.First(x => x.Band == "20m");
+        Assert.Equal(HpsdrAntenna.Ant2, b20.TxAnt);
+        Assert.Equal(HpsdrAntenna.Ant3, b20.RxAnt);
+    }
+}

--- a/tests/Zeus.Server.Tests/ExternalPortEncoderTests.cs
+++ b/tests/Zeus.Server.Tests/ExternalPortEncoderTests.cs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Contracts;
+using Zeus.Protocol1;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Coverage + byte-identity tests for the external-port encoder seam
+/// (external-ports plan, Phase 1).
+///
+/// 1. Every <see cref="HpsdrBoardKind"/> resolves to a non-null encoder.
+/// 2. The encoders produce the SAME antenna bits as today's wire path for the
+///    default (ANT1) state — these complement the golden-byte tests in the
+///    protocol test projects, asserting the firewall is byte-identical.
+/// </summary>
+public class ExternalPortEncoderTests
+{
+    [Theory]
+    [InlineData(HpsdrBoardKind.Metis)]
+    [InlineData(HpsdrBoardKind.Hermes)]
+    [InlineData(HpsdrBoardKind.HermesII)]
+    [InlineData(HpsdrBoardKind.Angelia)]
+    [InlineData(HpsdrBoardKind.Orion)]
+    [InlineData(HpsdrBoardKind.HermesLite2)]
+    [InlineData(HpsdrBoardKind.OrionMkII)]
+    [InlineData(HpsdrBoardKind.HermesC10)]
+    [InlineData(HpsdrBoardKind.Unknown)]
+    public void For_ReturnsNonNullEncoder_ForEveryBoardKind(HpsdrBoardKind board)
+    {
+        var encoder = ExternalPortEncoders.For(board);
+        Assert.NotNull(encoder);
+        Assert.False(string.IsNullOrWhiteSpace(encoder.Label));
+    }
+
+    [Fact]
+    public void For_ReturnsNonNullEncoder_ForEveryEnumeratedBoardKind()
+    {
+        foreach (HpsdrBoardKind board in Enum.GetValues<HpsdrBoardKind>())
+        {
+            Assert.NotNull(ExternalPortEncoders.For(board));
+        }
+    }
+
+    [Theory]
+    [InlineData(OrionMkIIVariant.G2)]
+    [InlineData(OrionMkIIVariant.G2_1K)]
+    [InlineData(OrionMkIIVariant.Anan7000DLE)]
+    [InlineData(OrionMkIIVariant.Anan8000DLE)]
+    [InlineData(OrionMkIIVariant.OrionMkII)]
+    [InlineData(OrionMkIIVariant.AnvelinaPro3)]
+    [InlineData(OrionMkIIVariant.RedPitaya)]
+    public void For_0x0A_RoutesToProtocol2Encoder_ForEveryVariant(OrionMkIIVariant variant)
+    {
+        var encoder = ExternalPortEncoders.For(HpsdrBoardKind.OrionMkII, variant);
+        Assert.IsType<Protocol2PortEncoder>(encoder);
+    }
+
+    [Fact]
+    public void For_Hermes_RoutesToProtocol1Encoder()
+        => Assert.IsType<Protocol1PortEncoder>(ExternalPortEncoders.For(HpsdrBoardKind.Hermes));
+
+    [Fact]
+    public void For_Hl2_RoutesToHl2Encoder()
+        => Assert.IsType<HermesLite2PortEncoder>(ExternalPortEncoders.For(HpsdrBoardKind.HermesLite2));
+
+    [Fact]
+    public void DefaultProtocolFor_0x0A_IsProtocol2_OthersProtocol1()
+    {
+        Assert.Equal(RadioProtocol.Protocol2, ExternalPortEncoders.DefaultProtocolFor(HpsdrBoardKind.OrionMkII));
+        Assert.Equal(RadioProtocol.Protocol1, ExternalPortEncoders.DefaultProtocolFor(HpsdrBoardKind.Hermes));
+        Assert.Equal(RadioProtocol.Protocol1, ExternalPortEncoders.DefaultProtocolFor(HpsdrBoardKind.HermesLite2));
+    }
+
+    // ---- byte-identity: encoder output == wire path for the default state ----
+
+    [Theory]
+    [InlineData(HpsdrAntenna.Ant1, 0x00)]
+    [InlineData(HpsdrAntenna.Ant2, 0x20)]
+    [InlineData(HpsdrAntenna.Ant3, 0x40)]
+    public void P1Encoder_RxAntennaC3Bits_MatchWirePath(HpsdrAntenna ant, byte expected)
+    {
+        var encoder = ExternalPortEncoders.For(HpsdrBoardKind.Hermes);
+        byte bits = encoder.EncodeP1RxAntennaC3Bits(new ExternalPortState(RxAnt: ant));
+        Assert.Equal(expected, bits);
+    }
+
+    [Theory]
+    [InlineData(HpsdrAntenna.Ant1)]
+    [InlineData(HpsdrAntenna.Ant2)]
+    [InlineData(HpsdrAntenna.Ant3)]
+    public void Hl2Encoder_RxAntennaC3Bits_ClampedToAnt1(HpsdrAntenna requested)
+    {
+        // Phase 2: HL2 has no RX-antenna relay — C3[7:5] is hard-clamped to
+        // ANT1 (0x00) at the wire layer regardless of the requested antenna,
+        // so a stale per-band ANT2/3 can never flip the N2ADR antenna pad.
+        var encoder = ExternalPortEncoders.For(HpsdrBoardKind.HermesLite2);
+        byte bits = encoder.EncodeP1RxAntennaC3Bits(new ExternalPortState(RxAnt: requested));
+        Assert.Equal(0x00, bits);
+    }
+
+    [Theory]
+    [InlineData(HpsdrAntenna.Ant1, 0x01000000u)]
+    [InlineData(HpsdrAntenna.Ant2, 0x02000000u)]
+    [InlineData(HpsdrAntenna.Ant3, 0x04000000u)]
+    public void P2Encoder_TxAntennaBits_ThreadSelection_OnRelayBoard(HpsdrAntenna ant, uint expected)
+    {
+        // Phase 2: a relay-capable variant (G2 / OrionMkII) threads the real
+        // per-band TX antenna into alex0[26:24].
+        var encoder = ExternalPortEncoders.For(HpsdrBoardKind.OrionMkII);
+        uint bits = encoder.EncodeP2TxAntennaBits(new ExternalPortState(TxAnt: ant));
+        Assert.Equal(expected, bits);
+    }
+
+    [Theory]
+    [InlineData(HpsdrAntenna.Ant1)]
+    [InlineData(HpsdrAntenna.Ant2)]
+    [InlineData(HpsdrAntenna.Ant3)]
+    public void P1Encoder_TxAntennaBits_AlwaysAnt1(HpsdrAntenna ant)
+    {
+        // P1 boards are ANT1-hardwired on transmit (no P2 Alex word).
+        var encoder = ExternalPortEncoders.For(HpsdrBoardKind.Hermes);
+        uint bits = encoder.EncodeP2TxAntennaBits(new ExternalPortState(TxAnt: ant));
+        Assert.Equal(0x01000000u, bits); // ALEX_TX_ANTENNA_1
+    }
+
+    [Theory]
+    [InlineData(HpsdrAntenna.Ant1)]
+    [InlineData(HpsdrAntenna.Ant2)]
+    [InlineData(HpsdrAntenna.Ant3)]
+    public void Hl2Encoder_TxAntennaBits_AlwaysAnt1(HpsdrAntenna ant)
+    {
+        // HL2 has no P2 Alex word and is ANT1-hardwired on transmit.
+        var encoder = ExternalPortEncoders.For(HpsdrBoardKind.HermesLite2);
+        uint bits = encoder.EncodeP2TxAntennaBits(new ExternalPortState(TxAnt: ant));
+        Assert.Equal(0x01000000u, bits);
+    }
+}

--- a/zeus-web/src/components/RadioSettingsPanel.tsx
+++ b/zeus-web/src/components/RadioSettingsPanel.tsx
@@ -19,6 +19,13 @@
 
 import { useEffect } from 'react';
 import { usePttStore } from '../state/ptt-store';
+import {
+  useAntennaStore,
+  type AntennaName,
+  type RxAuxName,
+} from '../state/antenna-store';
+
+const ANTENNA_OPTIONS: AntennaName[] = ['Ant1', 'Ant2', 'Ant3'];
 
 export function RadioSettingsPanel() {
   const pttKeyed = usePttStore((s) => s.keyed);
@@ -28,9 +35,25 @@ export function RadioSettingsPanel() {
   const loadPtt = usePttStore((s) => s.load);
   const setPttEnabled = usePttStore((s) => s.setEnabled);
 
+  const antSettings = useAntennaStore((s) => s.settings);
+  const antInflight = useAntennaStore((s) => s.inflight);
+  const loadAntenna = useAntennaStore((s) => s.load);
+  const setAntennaBand = useAntennaStore((s) => s.setBand);
+
   useEffect(() => {
     void loadPtt();
-  }, [loadPtt]);
+    void loadAntenna();
+  }, [loadPtt, loadAntenna]);
+
+  // The antenna card renders only when the connected board exposes at least one
+  // antenna control — otherwise (HL2's single jack) there's nothing to set.
+  const showAntenna =
+    antSettings.hasTxAntennaRelays ||
+    antSettings.hasRxAntennaRelays ||
+    antSettings.availableRxAux.length > 0;
+  // Order the bands by the server's HF list as returned.
+  const bands = antSettings.bands;
+  const rxAuxOptions: RxAuxName[] = ['None', ...antSettings.availableRxAux];
 
   return (
     <div className="ps-shell">
@@ -97,6 +120,100 @@ export function RadioSettingsPanel() {
           <span style={{ color: 'var(--fg-2)' }}>{pttHangMs} ms</span>
         </div>
       </div>
+
+      {showAntenna && (
+        <div className="ps-card">
+          <h4>
+            <svg className="ps-ic-sm" viewBox="0 0 12 12">
+              <path d="M6 1.5v9M3 3.5l3-2 3 2M2 6.5l4 4 4-4" fill="none" />
+            </svg>
+            Antenna
+            <span className="ps-card-hint">per-band TX / RX relay + RX-aux</span>
+          </h4>
+
+          {bands.map((b) => (
+            <div className="ps-field" key={b.band}>
+              <div className="ps-name">
+                {b.band}
+                <em>
+                  TX / RX antenna relay and auxiliary RX input for this band.
+                </em>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                {antSettings.hasTxAntennaRelays && (
+                  <label style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+                    <span style={{ color: 'var(--fg-2)', fontSize: '0.8em' }}>TX</span>
+                    <select
+                      value={b.txAnt}
+                      disabled={antInflight}
+                      onChange={(e) =>
+                        void setAntennaBand(
+                          b.band,
+                          e.target.value as AntennaName,
+                          b.rxAnt,
+                          b.rxAux,
+                        )
+                      }
+                    >
+                      {ANTENNA_OPTIONS.map((a) => (
+                        <option key={a} value={a}>
+                          {a}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                )}
+                {antSettings.hasRxAntennaRelays && (
+                  <label style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+                    <span style={{ color: 'var(--fg-2)', fontSize: '0.8em' }}>RX</span>
+                    <select
+                      value={b.rxAnt}
+                      disabled={antInflight}
+                      onChange={(e) =>
+                        void setAntennaBand(
+                          b.band,
+                          b.txAnt,
+                          e.target.value as AntennaName,
+                          b.rxAux,
+                        )
+                      }
+                    >
+                      {ANTENNA_OPTIONS.map((a) => (
+                        <option key={a} value={a}>
+                          {a}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                )}
+                {antSettings.availableRxAux.length > 0 && (
+                  <label style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+                    <span style={{ color: 'var(--fg-2)', fontSize: '0.8em' }}>AUX</span>
+                    <select
+                      value={b.rxAux}
+                      disabled={antInflight}
+                      onChange={(e) =>
+                        void setAntennaBand(
+                          b.band,
+                          b.txAnt,
+                          b.rxAnt,
+                          e.target.value as RxAuxName,
+                        )
+                      }
+                    >
+                      {rxAuxOptions.map((a) => (
+                        <option key={a} value={a}>
+                          {a}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/zeus-web/src/state/antenna-store.test.ts
+++ b/zeus-web/src/state/antenna-store.test.ts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Antenna store — parse robustness + optimistic setBand round-trip
+// (external-ports plan, Phase 2).
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  fetchAntennaSettings,
+  updateAntennaBand,
+  useAntennaStore,
+} from './antenna-store';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  useAntennaStore.setState({
+    settings: {
+      hasTxAntennaRelays: false,
+      hasRxAntennaRelays: false,
+      bands: [],
+      availableRxAux: [],
+      alexRevision: 'Modern',
+    },
+    loaded: false,
+    inflight: false,
+    error: null,
+  });
+});
+
+function stubFetch(body: unknown, status = 200) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+}
+
+describe('antenna-store parsing', () => {
+  it('coerces unknown antenna strings to Ant1', async () => {
+    stubFetch({
+      hasTxAntennaRelays: true,
+      hasRxAntennaRelays: true,
+      bands: [{ band: '20m', txAnt: 'Ant9', rxAnt: 'Ant2' }],
+    });
+    const s = await fetchAntennaSettings();
+    expect(s.bands[0]?.txAnt).toBe('Ant1');
+    expect(s.bands[0]?.rxAnt).toBe('Ant2');
+  });
+
+  it('defaults gates false and bands [] on garbage', async () => {
+    stubFetch(42);
+    const s = await fetchAntennaSettings();
+    expect(s.hasTxAntennaRelays).toBe(false);
+    expect(s.bands).toEqual([]);
+  });
+
+  it('throws on a 409 from the PUT', async () => {
+    stubFetch({ error: 'no relays' }, 409);
+    await expect(updateAntennaBand('20m', 'Ant2', 'Ant1', 'None')).rejects.toThrow();
+  });
+});
+
+describe('antenna-store setBand', () => {
+  it('optimistically updates then adopts the server response', async () => {
+    stubFetch({
+      hasTxAntennaRelays: true,
+      hasRxAntennaRelays: true,
+      bands: [{ band: '20m', txAnt: 'Ant3', rxAnt: 'Ant1' }],
+    });
+    await useAntennaStore.getState().setBand('20m', 'Ant3', 'Ant1', 'None');
+    const b = useAntennaStore.getState().settings.bands.find((x) => x.band === '20m');
+    expect(b?.txAnt).toBe('Ant3');
+  });
+
+  it('round-trips a per-band RX-aux selection', async () => {
+    stubFetch({
+      hasTxAntennaRelays: true,
+      hasRxAntennaRelays: true,
+      bands: [{ band: '20m', txAnt: 'Ant1', rxAnt: 'Ant1', rxAux: 'Bypass' }],
+      availableRxAux: ['Ext1', 'Ext2', 'Xvtr', 'Bypass'],
+      alexRevision: 'Modern',
+    });
+    await useAntennaStore.getState().setBand('20m', 'Ant1', 'Ant1', 'Bypass');
+    const b = useAntennaStore.getState().settings.bands.find((x) => x.band === '20m');
+    expect(b?.rxAux).toBe('Bypass');
+    expect(useAntennaStore.getState().settings.availableRxAux).toContain('Bypass');
+  });
+
+  it('rolls back on PUT failure', async () => {
+    // Seed a known-good current state, then fail the PUT.
+    useAntennaStore.setState({
+      settings: {
+        hasTxAntennaRelays: true,
+        hasRxAntennaRelays: true,
+        bands: [{ band: '20m', txAnt: 'Ant1', rxAnt: 'Ant1', rxAux: 'None' }],
+        availableRxAux: [],
+        alexRevision: 'Modern',
+      },
+    });
+    stubFetch({ error: 'boom' }, 409);
+    await useAntennaStore.getState().setBand('20m', 'Ant2', 'Ant1', 'None');
+    const b = useAntennaStore.getState().settings.bands.find((x) => x.band === '20m');
+    expect(b?.txAnt).toBe('Ant1'); // rolled back
+    expect(useAntennaStore.getState().error).toBeTruthy();
+  });
+});

--- a/zeus-web/src/state/antenna-store.ts
+++ b/zeus-web/src/state/antenna-store.ts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Per-band TX/RX antenna relay selection (external-ports plan, Phase 2).
+// Mirrors /api/radio/antenna, which is server-authoritative: the backend reads
+// AntennaSettingsStore and pushes the active band's selection to the live radio
+// through RecomputePaAndPush (the same path OC uses), so the frontend never
+// clobbers the server on connect — it only loads + PUTs operator edits.
+//
+// The GET response carries the relay-capability gates so the panel can render
+// the right selectors; the per-band rows let the operator stage selections for
+// every band even when only the current band is shown.
+
+import { create } from 'zustand';
+
+export type AntennaName = 'Ant1' | 'Ant2' | 'Ant3';
+// RX auxiliary input (external-ports plan, Phase 5). 'None' = use the base
+// RX-antenna relay; the rest are the Alex/filter-board aux feeds.
+export type RxAuxName = 'None' | 'Ext1' | 'Ext2' | 'Xvtr' | 'Bypass';
+
+export interface AntennaBand {
+  band: string;
+  txAnt: AntennaName;
+  rxAnt: AntennaName;
+  rxAux: RxAuxName;
+}
+
+export interface AntennaSettings {
+  hasTxAntennaRelays: boolean;
+  hasRxAntennaRelays: boolean;
+  bands: AntennaBand[];
+  /** Aux inputs the connected board's Alex/filter board exposes (Phase 5).
+   *  Empty on boards with no aux inputs (HL2). */
+  availableRxAux: RxAuxName[];
+  /** K36-BYPASS direction family (operator-set, NOT wire-discoverable):
+   *  'Modern' (Rev 24+, PS routes to BYPASS — safe default) or 'Legacy15Or16'. */
+  alexRevision: string;
+}
+
+const DEFAULT_SETTINGS: AntennaSettings = {
+  hasTxAntennaRelays: false,
+  hasRxAntennaRelays: false,
+  bands: [],
+  availableRxAux: [],
+  alexRevision: 'Modern',
+};
+
+function parseAnt(v: unknown): AntennaName {
+  return v === 'Ant2' || v === 'Ant3' ? v : 'Ant1';
+}
+
+const RX_AUX_NAMES: RxAuxName[] = ['None', 'Ext1', 'Ext2', 'Xvtr', 'Bypass'];
+function parseRxAux(v: unknown): RxAuxName {
+  return typeof v === 'string' && (RX_AUX_NAMES as string[]).includes(v)
+    ? (v as RxAuxName)
+    : 'None';
+}
+
+function parse(raw: unknown): AntennaSettings {
+  if (!raw || typeof raw !== 'object') return DEFAULT_SETTINGS;
+  const r = raw as Record<string, unknown>;
+  const bandsRaw = Array.isArray(r.bands) ? r.bands : [];
+  const auxRaw = Array.isArray(r.availableRxAux) ? r.availableRxAux : [];
+  return {
+    hasTxAntennaRelays:
+      typeof r.hasTxAntennaRelays === 'boolean' ? r.hasTxAntennaRelays : false,
+    hasRxAntennaRelays:
+      typeof r.hasRxAntennaRelays === 'boolean' ? r.hasRxAntennaRelays : false,
+    bands: bandsRaw.map((b) => {
+      const e = (b ?? {}) as Record<string, unknown>;
+      return {
+        band: typeof e.band === 'string' ? e.band : '',
+        txAnt: parseAnt(e.txAnt),
+        rxAnt: parseAnt(e.rxAnt),
+        rxAux: parseRxAux(e.rxAux),
+      };
+    }),
+    availableRxAux: auxRaw
+      .map((a) => parseRxAux(a))
+      .filter((a) => a !== 'None'),
+    alexRevision: typeof r.alexRevision === 'string' ? r.alexRevision : 'Modern',
+  };
+}
+
+export async function fetchAntennaSettings(
+  signal?: AbortSignal,
+): Promise<AntennaSettings> {
+  const res = await fetch('/api/radio/antenna', { signal });
+  if (!res.ok) throw new Error(`GET /api/radio/antenna → ${res.status}`);
+  return parse(await res.json());
+}
+
+export async function updateAntennaBand(
+  band: string,
+  txAnt: AntennaName,
+  rxAnt: AntennaName,
+  rxAux: RxAuxName,
+  signal?: AbortSignal,
+): Promise<AntennaSettings> {
+  const res = await fetch('/api/radio/antenna', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ band, txAnt, rxAnt, rxAux }),
+    signal,
+  });
+  if (!res.ok) throw new Error(`PUT /api/radio/antenna → ${res.status}`);
+  return parse(await res.json());
+}
+
+type AntennaStore = {
+  settings: AntennaSettings;
+  loaded: boolean;
+  inflight: boolean;
+  error: string | null;
+  load: () => Promise<void>;
+  setBand: (
+    band: string,
+    txAnt: AntennaName,
+    rxAnt: AntennaName,
+    rxAux: RxAuxName,
+  ) => Promise<void>;
+};
+
+export const useAntennaStore = create<AntennaStore>((set, get) => ({
+  settings: DEFAULT_SETTINGS,
+  loaded: false,
+  inflight: false,
+  error: null,
+
+  load: async () => {
+    set({ inflight: true, error: null });
+    try {
+      const s = await fetchAntennaSettings();
+      set({ settings: s, loaded: true, inflight: false });
+    } catch (err) {
+      set({
+        error: err instanceof Error ? err.message : String(err),
+        inflight: false,
+      });
+    }
+  },
+
+  setBand: async (band, txAnt, rxAnt, rxAux) => {
+    // Optimistic local update, rollback on error — same idiom as pa-store /
+    // radio-options-store. The PUT returns the canonical settings which we
+    // adopt so the local view stays in lockstep with the server.
+    const prev = get().settings;
+    const nextBands = (() => {
+      const found = prev.bands.some((b) => b.band === band);
+      if (found) {
+        return prev.bands.map((b) =>
+          b.band === band ? { ...b, txAnt, rxAnt, rxAux } : b,
+        );
+      }
+      return [...prev.bands, { band, txAnt, rxAnt, rxAux }];
+    })();
+    set({ settings: { ...prev, bands: nextBands }, inflight: true, error: null });
+    try {
+      const s = await updateAntennaBand(band, txAnt, rxAnt, rxAux);
+      set({ settings: s, inflight: false });
+    } catch (err) {
+      set({
+        settings: prev,
+        error: err instanceof Error ? err.message : String(err),
+        inflight: false,
+      });
+    }
+  },
+}));


### PR DESCRIPTION
DO NOT MERGE — draft for review + bench. Second external-ports piece (after PTT #799/#803). Implements #804.

Operator control of antenna routing across the full board lineup + HL2, both protocols, per-band, in the **Radio Settings** tab — server-authoritative via `AntennaSettingsStore` + `/api/radio/antenna` (never `StateDto`).

## What's in
- **TX antenna** ANT1/2/3 — P2 0x0A OrionMkII family, `alex0[26:24]`, state-multiplexed with RX.
- **RX antenna** ANT1/2/3 — P1 ANAN/Hermes-class, config `C3[7:5]`; **HL2 clamped to ANT1 at the wire**.
- **RX-aux** EXT1/EXT2/XVTR/BYPASS — P2 (`alex0` bits 8–11 + Saturn RX_SELECT bit 14). P1 RX-aux is forwarded through store/REST but intentionally **not wire-emitted** (no ANAN-P1 bench board).

| Board | TX relays | RX relays | RX-aux |
|---|---|---|---|
| 0x0A OrionMkII family (G2/7000/8000/…) P2 | ✅ | ✅ | All |
| Hermes/Metis, HermesII/10E, HermesC10 P1 | — | ✅ | All |
| ANAN-100D / 200D P1 | — | ✅ | All |
| **HermesLite2** | — | **clamped ANT1** | None |

## Invariants (all golden-tested, verified by me)
- **PureSignal untouched / PS-K36 firewall** — RX-aux bits are OR'd in **immediately before the unmodified PS-coupler block** in `SendCmdHighPriority` (guarded with a "DO NOT MOVE/MODIFY" comment), so the PS bit always wins when armed. **Zero PS-logic lines changed.** `PsK36_AuxBypassPlusPsExternal_StillEmitsPsCoupler` + `PsK36_AuxExt1PlusPsExternal_PsCouplerNotStolen` pass.
- **Default-inert** — ANT1/ANT1/None reproduces today's bytes byte-for-byte (golden).
- **TX/RX state-multiplex** — a TX antenna change never moves the RX antenna.
- **HL2 RX-ant clamp** — closes the dormant `ControlFrame.cs` C3[5] N2ADR-pad footgun.
- **Mid-key relay deferral** — no relay/Alex mutation while keyed (stash + flush on unkey edge, both clients).

## Tests / build
- Build 0/0; npm build clean.
- P2 Alex/PS-K36 goldens **50** · P1 + ControlFrame/HL2-clamp **109** · Server antenna store/endpoint/caps **55** · Contracts **100** · frontend antenna-store **6**.

## 🚩 Red-light — your/Brian's sign-off
1. **Zeus.Contracts wire surface** (`BoardCapabilities` + `Dtos`) — additive-optional, appended after the last param; **confirm field-order vs Christian's `zeus-prefs.db` byte layout.**
2. **Operator-felt default** — ANT1/ANT1/None on every board (= today's bytes). Confirm that's the desired first-connect default.
3. **HL2 clamp behavior change (intended)** — fixes the dormant raw-write footgun; one existing test retargeted off HL2 + a dedicated clamp test added (same fix the original squash made).
4. **Radio Settings antenna UI** — token-only colors, capability-gated; placement/visuals are Brian/Doug.
5. **Deferred:** P1 RX-aux wire emission; AlexRevision Legacy routing (not wire-discoverable); TCI rx_antenna wire-through.

Bench (you): G2 (P2) ANT/aux relays switch + **PS-armed aux=BYPASS still emits the PS coupler** (hard gate); HL2 RX stays on ANT1.

Refs #804
