### PR TITLE
feat(rx): harden RX ingest to 1536 kHz + 8-DDC foundation + live diagnostics

### DIFF
--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -179,6 +179,31 @@ public sealed class WdspDspEngine : IDspEngine
     // consumer: ReadAudio caller on pipeline thread). Drops oldest when over capacity.
     private const int AudioRingCapacity = OutputRate;
 
+    /// <summary>
+    /// Per-RX-channel ingest health, latched once per ~1 s window by
+    /// <see cref="EmitRxDiag"/> and read lock-free by the diagnostics provider
+    /// (immutable record swapped behind a volatile field). All "PerWindow"
+    /// counts are over the last completed ~1 s window. This is the realtime
+    /// overflow/underrun signal for high-sample-rate / multi-DDC operation:
+    /// <c>DroppedPerWindow &gt; 0</c> means the worker fell behind and IQ frames
+    /// were dropped (drop-oldest); <c>WorkerMaxMs</c> approaching the per-frame
+    /// budget (1000·InSize/SampleRateHz) means the channel is CPU-bound.
+    /// </summary>
+    public sealed record RxChannelHealth(
+        int ChannelId,
+        int SampleRateHz,
+        int QueueDepth,
+        int QueueCapacity,
+        long FramesInPerWindow,
+        long QueueFullPerWindow,
+        long DroppedPerWindow,
+        long WorkerFramesPerWindow,
+        double WorkerAvgMs,
+        double WorkerMaxMs,
+        int AudioRingDepth,
+        long AudioOverrunPerWindow,
+        long AgeMs);
+
     private sealed class ChannelState
     {
         public required int Id;
@@ -188,6 +213,9 @@ public sealed class WdspDspEngine : IDspEngine
         public required int OutDoubles;
         public required Thread Worker;
         public required BlockingCollection<double[]> InQueue;
+        // Rate-scaled bound of InQueue (frames). Captured so diagnostics can show
+        // depth-vs-capacity; see ComputeInQueueCapacity.
+        public required int InQueueCapacity;
         public readonly ConcurrentQueue<double[]> FreeFrames = new();
         public double[] PartialFrame = new double[2 * InSize];
         public int PartialFill;
@@ -227,22 +255,43 @@ public sealed class WdspDspEngine : IDspEngine
         public int ZoomLevel = 1;
         public readonly object AnalyzerLock = new();
 
-        // --- TEMP diagnostics for RX2 crackle/lag (issue zeus-gdc7) ---
-        // All counters are reset each 1 Hz emit in ReadAudio. Cheap Interlocked
-        // increments on the hot paths; no allocation. Remove once the dual-RX
-        // realtime stall is root-caused.
+        // --- RX ingest health telemetry (issue zeus-gdc7; now permanent) ---
+        // Live overflow/underrun counters for high-sample-rate operation, reset
+        // each 1 Hz emit in EmitRxDiag. Cheap Interlocked increments on the hot
+        // paths; no allocation. These are the realtime signal that the worker is
+        // keeping up with the IQ frame rate at 768/1536 kHz with all DDCs active.
         public long DiagFramesIn;          // frames handed to InQueue this window
-        public long DiagEnqueueFull;       // enqueues where the bounded InQueue was already full (Add would block the RX net thread)
+        public long DiagEnqueueFull;       // enqueues that found the bounded InQueue full (worker fell behind)
+        public long DiagDroppedOldest;     // frames dropped (oldest evicted) to keep the RX thread non-blocking — bounded, deliberate glitch
         public long DiagWorkerFrames;      // frames the worker processed this window
         public long DiagWorkerTotalTicks;  // Σ per-frame fexchange0+Spectrum0 Stopwatch ticks
         public long DiagWorkerMaxTicks;    // max single-frame processing ticks
         public long DiagAudioOverrun;      // PushAudio writes that overwrote an unread sample (ring full → discontinuity)
         public long DiagLastLogTicks;      // Stopwatch timestamp of last 1 Hz emit
+        // Latched once per ~1 s by EmitRxDiag; read lock-free by the diagnostics
+        // provider via SnapshotRxChannels. Immutable record behind a volatile
+        // reference → no torn reads, no lock on the snapshot path.
+        public volatile RxChannelHealth? LastHealth;
     }
 
-    // Bounded depth of each channel's InQueue — mirrors the boundedCapacity
-    // passed at construction so the diagnostic "would-block" check matches.
-    private const int InQueueCapacity = 32;
+    // Each RX channel hands 1024-sample IQ frames from the realtime RX sink
+    // thread to its WDSP worker through a bounded queue. The frame RATE scales
+    // with the RX sample rate (≈47/s at 48 kHz … ≈1500/s at 1536 kHz), so a
+    // fixed frame count gave a 32× smaller TIME cushion at the top of the
+    // ladder. ComputeInQueueCapacity sizes the queue to hold ~InQueueTargetMs
+    // of IQ regardless of rate, floored at the legacy 32 frames and capped to
+    // bound memory/latency (each frame is 2*InSize doubles ≈ 16 KB, so the
+    // ceiling is ≈4 MB per channel — comfortable even with all DDCs running).
+    private const int InQueueFloorFrames = 32;
+    private const int InQueueCeilFrames = 256;
+    private const double InQueueTargetMs = 80.0;
+
+    private static int ComputeInQueueCapacity(int sampleRateHz)
+    {
+        double framesPerSec = (double)sampleRateHz / InSize;
+        int target = (int)Math.Ceiling(framesPerSec * (InQueueTargetMs / 1000.0));
+        return Math.Clamp(target, InQueueFloorFrames, InQueueCeilFrames);
+    }
 
     private readonly ConcurrentDictionary<int, ChannelState> _channels = new();
     private readonly object _nativeSlotLock = new();
@@ -551,6 +600,7 @@ public sealed class WdspDspEngine : IDspEngine
         ConfigureAnalyzer(id, sampleRateHz, InSize, pixelWidth, zoomLevel: 1, AnalyzerFftSize, AnalyzerWindow, AnalyzerKaiserPi);
         ConfigureDisplayAveraging(id);
 
+        int inQueueCapacity = ComputeInQueueCapacity(sampleRateHz);
         var state = new ChannelState
         {
             Id = id,
@@ -558,7 +608,8 @@ public sealed class WdspDspEngine : IDspEngine
             SampleRateHz = sampleRateHz,
             PixelWidth = pixelWidth,
             OutDoubles = outDoubles,
-            InQueue = new BlockingCollection<double[]>(boundedCapacity: InQueueCapacity),
+            InQueue = new BlockingCollection<double[]>(boundedCapacity: inQueueCapacity),
+            InQueueCapacity = inQueueCapacity,
             Worker = null!,
         };
 
@@ -624,15 +675,36 @@ public sealed class WdspDspEngine : IDspEngine
                     state.PartialFill = 0;
                     if (!state.InQueue.IsAddingCompleted)
                     {
-                        // TEMP diag (zeus-gdc7): a full bounded InQueue means the
-                        // next Add BLOCKS this thread — and FeedIq runs on the
-                        // realtime P2/P1 RX sink thread, so a stalled worker
-                        // stalls UDP intake (crackle + UI lag at modest CPU).
                         state.DiagFramesIn++;
-                        if (state.InQueue.Count >= InQueueCapacity)
-                            state.DiagEnqueueFull++;
-                        try { state.InQueue.Add(frame); }
-                        catch (InvalidOperationException) { state.FreeFrames.Enqueue(frame); }
+                        // Non-blocking hand-off with drop-OLDEST. FeedIq runs on
+                        // the realtime P1/P2 RX sink thread; a blocking Add would
+                        // stall UDP intake whenever the worker falls behind, and a
+                        // stalled intake lets the kernel socket buffer overflow →
+                        // dropped packets → sequence gaps (the cascading failure
+                        // this guard prevents). Instead, when the queue is full we
+                        // evict the OLDEST queued frame and keep the newest, so
+                        // display/audio latency stays bounded and the glitch is a
+                        // single counted dropped frame rather than a stall. Pairs
+                        // with the rate-scaled capacity (ComputeInQueueCapacity).
+                        try
+                        {
+                            if (!state.InQueue.TryAdd(frame))
+                            {
+                                state.DiagEnqueueFull++;
+                                if (state.InQueue.TryTake(out var stale))
+                                {
+                                    state.DiagDroppedOldest++;
+                                    state.FreeFrames.Enqueue(stale);
+                                }
+                                if (!state.InQueue.TryAdd(frame))
+                                    state.FreeFrames.Enqueue(frame);
+                            }
+                        }
+                        catch (InvalidOperationException)
+                        {
+                            // CompleteAdding raced the enqueue — recycle.
+                            state.FreeFrames.Enqueue(frame);
+                        }
                     }
                     else
                     {
@@ -1219,6 +1291,7 @@ public sealed class WdspDspEngine : IDspEngine
 
         long framesIn = Interlocked.Exchange(ref state.DiagFramesIn, 0);
         long enqueueFull = Interlocked.Exchange(ref state.DiagEnqueueFull, 0);
+        long droppedOldest = Interlocked.Exchange(ref state.DiagDroppedOldest, 0);
         long workerFrames = Interlocked.Exchange(ref state.DiagWorkerFrames, 0);
         long workerTotalTicks = Interlocked.Exchange(ref state.DiagWorkerTotalTicks, 0);
         long workerMaxTicks = Interlocked.Exchange(ref state.DiagWorkerMaxTicks, 0);
@@ -1232,12 +1305,53 @@ public sealed class WdspDspEngine : IDspEngine
         lock (state.AudioGate) audioRingDepth = state.AudioCount;
 
         _log.LogInformation(
-            "wdsp.rxdiag ch={Id} framesIn={FramesIn} queueDepth={QueueDepth} queueFull={QueueFull} " +
-            "workerFrames={WorkerFrames} workerAvgMs={WorkerAvgMs:F2} workerMaxMs={WorkerMaxMs:F2} " +
-            "audioRingDepth={AudioRingDepth} audioOverrun={AudioOverrun}",
-            state.Id, framesIn, queueDepth, enqueueFull,
-            workerFrames, workerAvgMs, workerMaxMs,
+            "wdsp.rxdiag ch={Id} rate={RateHz} framesIn={FramesIn} queueDepth={QueueDepth}/{QueueCap} " +
+            "queueFull={QueueFull} dropped={Dropped} workerFrames={WorkerFrames} workerAvgMs={WorkerAvgMs:F2} " +
+            "workerMaxMs={WorkerMaxMs:F2} audioRingDepth={AudioRingDepth} audioOverrun={AudioOverrun}",
+            state.Id, state.SampleRateHz, framesIn, queueDepth, state.InQueueCapacity,
+            enqueueFull, droppedOldest, workerFrames, workerAvgMs, workerMaxMs,
             audioRingDepth, audioOverrun);
+
+        // Latch the same window for on-demand diagnostics (live /api/diagnostics
+        // surface + 0x36 health push). Immutable record swap — lock-free read.
+        state.LastHealth = new RxChannelHealth(
+            ChannelId: state.Id,
+            SampleRateHz: state.SampleRateHz,
+            QueueDepth: queueDepth,
+            QueueCapacity: state.InQueueCapacity,
+            FramesInPerWindow: framesIn,
+            QueueFullPerWindow: enqueueFull,
+            DroppedPerWindow: droppedOldest,
+            WorkerFramesPerWindow: workerFrames,
+            WorkerAvgMs: workerAvgMs,
+            WorkerMaxMs: workerMaxMs,
+            AudioRingDepth: audioRingDepth,
+            AudioOverrunPerWindow: audioOverrun,
+            AgeMs: 0);
+    }
+
+    /// <summary>
+    /// Lock-free snapshot of every open RX channel's latest ingest-health window
+    /// (see <see cref="RxChannelHealth"/>). Allocation-light and free of any
+    /// realtime/WDSP work — safe to call from the diagnostics request thread.
+    /// <c>AgeMs</c> is filled in here from the latch timestamp so callers can
+    /// tell a live window from a stalled one. Channels with no completed window
+    /// yet are omitted.
+    /// </summary>
+    public IReadOnlyList<RxChannelHealth> SnapshotRxChannels()
+    {
+        long nowTicks = System.Diagnostics.Stopwatch.GetTimestamp();
+        double ticksToMs = 1000.0 / System.Diagnostics.Stopwatch.Frequency;
+        var list = new List<RxChannelHealth>(_channels.Count);
+        foreach (var kv in _channels)
+        {
+            var h = kv.Value.LastHealth;
+            if (h is null) continue;
+            long stamp = kv.Value.DiagLastLogTicks;
+            long ageMs = stamp != 0 ? (long)((nowTicks - stamp) * ticksToMs) : 0;
+            list.Add(h with { AgeMs = ageMs });
+        }
+        return list;
     }
 
     private static void PushAudio(ChannelState state, ReadOnlySpan<double> interleavedStereo, int monoSampleCount)

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -43,6 +43,7 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Net;
@@ -102,6 +103,22 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // demux helper below accepts both forms for RX2.
     private const int G2RxDdc = 2;
 
+    // OpenHPSDR Protocol-2 "DDC Command" (port 1025) enables DDCs via a SINGLE
+    // bitmask byte at offset 7 → DDC0..DDC7, so 8 concurrent DDCs is the hard
+    // protocol ceiling (verified 2026-06-21 against the openHPSDR P2 spec and
+    // the matthew-wolf-n4mtt/openhpsdr-e Wireshark dissector; pihpsdr + Zeus
+    // both already use only byte[7]). There is no second enable byte — "10
+    // DDCs" is not representable in standard P2. On Orion-family boards DDC0/1
+    // are reserved for the PureSignal feedback pair when PS is armed, leaving 6
+    // user receivers; with PS off, all 8. The N-receiver pipeline keys off this
+    // constant so the ceiling is a single-line change if firmware ever extends
+    // the enable field.
+    public const int MaxRxDdc = 8;
+
+    // RX IQ data arrives on UDP source ports RxDataPortBase + ddcIndex, i.e.
+    // 1035 (DDC0) .. 1035 + MaxRxDdc - 1 (DDC7).
+    private const int RxDataPortBase = 1035;
+
     // Hermes-class radios (Brick2 is the live consumer) use a single ADC
     // and have no PureSignal feedback DDCs reserved at the front of the pool.
     // The user-visible RX maps to DDC0 directly. Radio sends DDC0 IQ from
@@ -140,12 +157,13 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     private int _rx2Enabled;
     private uint _rx2FreqHz = 7_100_000;
     // Per-source-port IQ packet rate (packets in the last completed ~1 s
-    // window) for UDP ports 1035..1041 → index 0..6 → DDC 0..6. Written by the
-    // single RX thread on each window roll; read by the diagnostics thread
-    // under _rxPortRateLock. Surfaces multi-DDC RX streaming health (e.g. a
-    // second receiver whose DDC the radio isn't actually sending).
+    // window) for UDP ports RxDataPortBase..RxDataPortBase+MaxRxDdc-1 (1035..1042)
+    // → index 0..7 → DDC 0..7. Written by the single RX thread on each window
+    // roll; read by the diagnostics thread under _rxPortRateLock. Surfaces
+    // per-DDC RX streaming health (e.g. a receiver whose DDC the radio isn't
+    // actually sending) — the ground truth for full multi-DDC operation.
     private readonly object _rxPortRateLock = new();
-    private readonly long[] _rxPortRateSnapshot = new long[7];
+    private readonly long[] _rxPortRateSnapshot = new long[MaxRxDdc];
     private long _rxPortRateWindowMs;
     // Frequency-correction factor (issue #325) — dimensionless multiplier
     // near 1.0 applied to the incoming dial Hz before _rxFreqHz is updated,
@@ -406,7 +424,13 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         // Matched port convention — PC binds 1025, radio sends back with source
         // ports 1025/1026/1027/1035.. which we demux by fromaddr.
         sock.Bind(new IPEndPoint(localBind, 1025));
-        sock.ReceiveBufferSize = 1 << 20;
+        // 4 MiB RX socket buffer. At 1536 kHz a single DDC pushes ~9.3 MB/s, and
+        // with several DDCs streaming concurrently the kernel buffer must absorb
+        // scheduling jitter without dropping datagrams. 4 MiB ≈ 110 ms of one
+        // full-rate DDC (the OS may clamp to rmem_max on Linux — a hint, not a
+        // guarantee). See ComputeInQueueCapacity for the matching DSP-side cushion.
+        try { sock.ReceiveBufferSize = 4 << 20; }
+        catch (SocketException) { sock.ReceiveBufferSize = 1 << 20; }
         _sock = sock;
         _log.LogInformation(
             "p2.connect radio={Radio} localBind={Local} localPort=1025",
@@ -541,9 +565,9 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
 
     /// <summary>
     /// IQ packet rate (packets in the last completed ~1 s window) per UDP
-    /// source port 1035..1041 → index 0..6 → DDC 0..6. The RX2 DDC is
-    /// <see cref="Rx2Ddc"/>. A zero at the RX2 DDC index while RX2 is enabled
-    /// means the radio isn't streaming the second receiver at all. Returns a
+    /// source port 1035..1042 → index 0..7 → DDC 0..7. The RX2 DDC is
+    /// <see cref="Rx2Ddc"/>. A zero at an enabled DDC's index means the radio
+    /// isn't streaming that receiver at all. Returns a
     /// fresh copy; safe to call from any thread.
     /// </summary>
     public long[] SnapshotRxPortPacketRates()
@@ -1386,6 +1410,91 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         return p;
     }
 
+    /// <summary>
+    /// A single user receiver's DDC assignment for the generalized
+    /// Receive-Specific composer: which physical ADC feeds it (0 or 1 on a
+    /// dual-ADC board) and its IQ sample rate in kHz. The DDC index is derived
+    /// from the board's RX base (<see cref="RxBaseDdc"/>) plus the receiver's
+    /// position in the list.
+    /// </summary>
+    internal readonly record struct DdcReceiverSpec(byte AdcSource, ushort SampleRateKhz);
+
+    /// <summary>
+    /// Generalized "Receive Specific" composer for up to <see cref="MaxRxDdc"/>
+    /// concurrent DDCs, each independently assignable to either ADC and to its
+    /// own sample rate — the N-receiver foundation for full multi-RX operation.
+    /// The legacy <see cref="ComposeCmdRxBuffer"/> covers the RX1(+RX2)(+PS)
+    /// special case and stays byte-pinned by the wire tests; this method
+    /// produces byte-identical output for the equivalent single-/dual-receiver
+    /// inputs (see ComposeCmdRxBufferForReceiversTests) and extends cleanly to
+    /// all 8 DDCs.
+    ///
+    /// Receiver <c>i</c> is placed on DDC <c>RxBaseDdc(board) + i</c>.
+    /// PureSignal, when armed on Orion-family boards, additionally claims
+    /// DDC0/DDC1 for its feedback pair (192 kHz/24-bit + the byte-1363 sync)
+    /// exactly as the legacy composer does; callers must not assign user
+    /// receivers onto those reserved slots while PS is armed.
+    /// </summary>
+    internal static byte[] ComposeCmdRxBufferForReceivers(
+        uint seq,
+        byte numAdc,
+        IReadOnlyList<DdcReceiverSpec> receivers,
+        bool psEnabled = false,
+        HpsdrBoardKind boardKind = HpsdrBoardKind.OrionMkII,
+        bool adcDitherEnabled = false,
+        bool adcRandomEnabled = false)
+    {
+        ArgumentNullException.ThrowIfNull(receivers);
+        var p = new byte[BufLen];
+        WriteBeU32(p, 0, seq);
+        p[4] = numAdc;
+        byte adcMask = AdcOptionMask(numAdc);
+        p[5] = adcDitherEnabled ? adcMask : (byte)0;
+        p[6] = adcRandomEnabled ? adcMask : (byte)0;
+
+        int baseDdc = RxBaseDdc(boardKind);
+        byte ddcEnable = 0;
+
+        // PS feedback pair is Orion-family-only (DDC0+DDC1, byte 1363 sync) —
+        // mirror the legacy composer exactly; no-op on single-ADC Hermes-class.
+        bool psHardware = boardKind != HpsdrBoardKind.Hermes &&
+                          boardKind != HpsdrBoardKind.HermesII &&
+                          boardKind != HpsdrBoardKind.HermesC10;
+        if (psEnabled && psHardware)
+        {
+            ddcEnable |= 0x01;
+            WriteDdcConfigBlock(p, ddc: 0, adc: 0x00, sampleRateKhz: 192);
+            WriteDdcConfigBlock(p, ddc: 1, adc: numAdc, sampleRateKhz: 192);
+            p[1363] = 0x02;
+        }
+
+        for (int i = 0; i < receivers.Count; i++)
+        {
+            int ddc = baseDdc + i;
+            if (ddc > MaxRxDdc - 1)
+                throw new ArgumentOutOfRangeException(nameof(receivers),
+                    $"receiver {i} maps to DDC{ddc}, exceeding the {MaxRxDdc}-DDC protocol ceiling");
+            ddcEnable |= (byte)(1 << ddc);
+            WriteDdcConfigBlock(p, ddc, receivers[i].AdcSource, receivers[i].SampleRateKhz);
+        }
+
+        p[7] = ddcEnable;
+        return p;
+    }
+
+    // Writes one DDC's 6-byte Receive-Specific config block at offset
+    // 17 + ddc*6: [+0] ADC source, [+1..2] sample rate (kHz, big-endian),
+    // [+5] sample size (bit depth). Matches the inline writes in
+    // ComposeCmdRxBuffer byte-for-byte; bits defaults to 24 (the only depth any
+    // supported board uses).
+    private static void WriteDdcConfigBlock(byte[] p, int ddc, byte adc, ushort sampleRateKhz, byte bits = 24)
+    {
+        int off = 17 + ddc * 6;
+        p[off + 0] = adc;
+        WriteBeU16(p, off + 1, sampleRateKhz);
+        p[off + 5] = bits;
+    }
+
     private void SendCmdRx()
     {
         // Mirrors pihpsdr new_protocol_receive_specific for the MkII:
@@ -1850,7 +1959,7 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         // per ~1 s for diagnostics (SnapshotRxPortPacketRates). Shows which DDC
         // ports the radio is actually streaming — the ground truth for RX2/
         // multi-receiver health. Single-threaded loop, so plain locals here.
-        var portPkts = new long[7];
+        var portPkts = new long[MaxRxDdc];
         long lastPortRollMs = Environment.TickCount64;
 
         try
@@ -1882,24 +1991,24 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
                 }
 
                 var srcPort = ((IPEndPoint)from).Port;
-                if (srcPort >= 1035 && srcPort <= 1041)
+                if (srcPort >= RxDataPortBase && srcPort < RxDataPortBase + MaxRxDdc)
                 {
-                    portPkts[srcPort - 1035]++;
+                    portPkts[srcPort - RxDataPortBase]++;
                     long nowMs = Environment.TickCount64;
                     if (nowMs - lastPortRollMs >= 1000)
                     {
                         lock (_rxPortRateLock)
                         {
-                            Array.Copy(portPkts, _rxPortRateSnapshot, 7);
+                            Array.Copy(portPkts, _rxPortRateSnapshot, MaxRxDdc);
                             _rxPortRateWindowMs = nowMs;
                         }
                         Array.Clear(portPkts);
                         lastPortRollMs = nowMs;
                     }
                 }
-                if (srcPort >= 1035 && srcPort <= 1041 && n == BufLen)
+                if (srcPort >= RxDataPortBase && srcPort < RxDataPortBase + MaxRxDdc && n == BufLen)
                 {
-                    int ddcIndex = srcPort - 1035;
+                    int ddcIndex = srcPort - RxDataPortBase;
                     if (_psFeedbackEnabled && ddcIndex == 0)
                     {
                         // PS-armed paired-DDC packet: 6B DDC0 (TX-mod-IQ) + 6B
@@ -1945,11 +2054,21 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         }
 
         // 238 complex samples: I (int24 BE) + Q (int24 BE), starting at byte 16.
-        // We own the array for the lifetime of the IqFrame the downstream
-        // pump consumes; there's no back-channel to Return it to a pool, so
-        // plain GC allocation is both simpler and correct.
         const int samplesPerPacket = DiscoverySamplesPerPacket;
-        var samples = new double[samplesPerPacket * 2];
+        int sampleDoubles = samplesPerPacket * 2;
+        // Pool the IQ buffer when a synchronous sink is attached (the normal DSP
+        // path): OnIqFrame copies the samples inline (engine.FeedIq) and the
+        // RxIqAvailable contract requires subscribers to copy, so the array is
+        // dead the instant OnIqFrame returns and we recycle it in the finally
+        // below. At 1536 kHz (~6.5k packets/s) this removes ~24 MB/s of Gen0
+        // garbage whose GC pauses were a direct cause of worker stalls. The
+        // channel fallback (no sink) hands the array to an async reader with no
+        // return back-channel, so it keeps plain GC allocation.
+        var sinkSnap = Volatile.Read(ref _rxSink);
+        bool pooled = sinkSnap != null;
+        double[] samples = pooled
+            ? ArrayPool<double>.Shared.Rent(sampleDoubles)
+            : new double[sampleDoubles];
         // 1/2^23 normalises int24 to [-1,+1]; the per-board correction is 1.0
         // for everything except Hermes@48 kHz (Brick2 quirk — see IqGainCorrection).
         double scale = (1.0 / 8388608.0) * IqGainCorrection(_boardKind, _sampleRateKhz);
@@ -1982,13 +2101,13 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
             ReceiverIndex: receiverIndex);
 
         Interlocked.Increment(ref _totalFrames);
-        // iter5: prefer the synchronous sink when attached — bypasses the
+        // iter5: prefer the synchronous sink (snapshotted above) — bypasses the
         // Channel<T> hop that costs a TP wake-up per frame on the consumer.
-        var sinkSnap = Volatile.Read(ref _rxSink);
-        if (sinkSnap != null)
+        if (pooled)
         {
-            try { sinkSnap.OnIqFrame(in frame); }
+            try { sinkSnap!.OnIqFrame(in frame); }
             catch (Exception ex) { _log.LogError(ex, "p2.rx.sink_threw kind=iq"); }
+            finally { ArrayPool<double>.Shared.Return(samples); }
         }
         else
         {

--- a/Zeus.Server.Hosting/Diagnostics/Providers/RxIngestDiagnosticsProvider.cs
+++ b/Zeus.Server.Hosting/Diagnostics/Providers/RxIngestDiagnosticsProvider.cs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Dsp.Wdsp;
+
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>
+/// Live per-DDC / per-receiver RX ingest health — the realtime overflow/underrun
+/// signal for high-sample-rate (up to 1536 kHz) and full multi-DDC operation.
+/// Surfaces, per WDSP RX channel: queue depth vs the rate-scaled capacity,
+/// dropped-oldest frame count (the deliberate, bounded glitch the non-blocking
+/// feed emits when the worker falls behind), worker frame time vs the per-frame
+/// budget, and audio-ring overruns — plus per-DDC UDP packet rate (last ~1 s
+/// window) so an operator can confirm exactly how many DDCs the radio is
+/// actually streaming and whether any are overflowing/underrunning.
+/// </summary>
+public sealed class RxIngestDiagnosticsProvider : IDiagnosticsProvider
+{
+    private readonly DspPipelineService _dsp;
+
+    public RxIngestDiagnosticsProvider(DspPipelineService dsp) =>
+        _dsp = dsp ?? throw new ArgumentNullException(nameof(dsp));
+
+    public string Id => "rx.ingest-health";
+    public string RouteSegment => "rx-ingest-health";
+    public string Category => "dsp";
+    public int SchemaVersion => 1;
+    public string Description =>
+        "Per-DDC RX ingest health: WDSP queue depth/drops, worker timing vs per-frame budget, audio overruns, per-DDC packet rate.";
+
+    public object Snapshot() => _dsp.SnapshotRxIngestHealth();
+
+    public IReadOnlyList<DiagnosticsSelfCheck> SelfChecks => new[]
+    {
+        new DiagnosticsSelfCheck("rx-no-dropped-frames",
+            "No RX IQ frames dropped and no audio-ring overruns in the last window.",
+            DiagnosticsSeverity.Warn,
+            _ => EvaluateDropsAndOverruns()),
+        new DiagnosticsSelfCheck("rx-worker-within-budget",
+            "Every RX channel's worst-case WDSP frame time fits the per-frame budget for its rate.",
+            DiagnosticsSeverity.Warn,
+            _ => EvaluateWorkerBudget()),
+    };
+
+    private SelfCheckResult EvaluateDropsAndOverruns()
+    {
+        var channels = SnapshotChannels();
+        if (channels.Count == 0)
+            return new SelfCheckResult(SelfCheckOutcome.Pass, "No active RX channels.", DateTimeOffset.UtcNow);
+
+        long dropped = 0;
+        long overrun = 0;
+        foreach (var c in channels)
+        {
+            dropped += c.DroppedPerWindow;
+            overrun += c.AudioOverrunPerWindow;
+        }
+
+        if (dropped > 0)
+            return new SelfCheckResult(SelfCheckOutcome.Warn,
+                $"{dropped} IQ frame(s) dropped (oldest-evicted) in the last window across {channels.Count} channel(s) — worker behind / CPU-bound.",
+                DateTimeOffset.UtcNow);
+        if (overrun > 0)
+            return new SelfCheckResult(SelfCheckOutcome.Warn,
+                $"{overrun} audio-ring overrun(s) in the last window — audio consumer behind.",
+                DateTimeOffset.UtcNow);
+        return new SelfCheckResult(SelfCheckOutcome.Pass,
+            $"No drops or overruns across {channels.Count} active channel(s).",
+            DateTimeOffset.UtcNow);
+    }
+
+    private SelfCheckResult EvaluateWorkerBudget()
+    {
+        var channels = SnapshotChannels();
+        if (channels.Count == 0)
+            return new SelfCheckResult(SelfCheckOutcome.Pass, "No active RX channels.", DateTimeOffset.UtcNow);
+
+        foreach (var c in channels)
+        {
+            if (c.SampleRateHz <= 0) continue;
+            double budgetMs = 1000.0 * 1024.0 / c.SampleRateHz;
+            if (c.WorkerMaxMs > budgetMs)
+                return new SelfCheckResult(SelfCheckOutcome.Warn,
+                    $"ch{c.ChannelId} @ {c.SampleRateHz} Hz: worst frame {c.WorkerMaxMs:F2} ms exceeds the {budgetMs:F2} ms per-frame budget — CPU-bound at this rate.",
+                    DateTimeOffset.UtcNow);
+        }
+        return new SelfCheckResult(SelfCheckOutcome.Pass,
+            "All active channels are within their per-frame WDSP budget.",
+            DateTimeOffset.UtcNow);
+    }
+
+    private IReadOnlyList<WdspDspEngine.RxChannelHealth> SnapshotChannels() =>
+        (_dsp.CurrentEngine as WdspDspEngine)?.SnapshotRxChannels()
+        ?? (IReadOnlyList<WdspDspEngine.RxChannelHealth>)Array.Empty<WdspDspEngine.RxChannelHealth>();
+}

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -4078,6 +4078,64 @@ public class DspPipelineService : BackgroundService,
     public Zeus.Protocol2.Protocol2Client? ActiveP2Client => _p2Client;
 
     /// <summary>
+    /// Live per-DDC / per-receiver RX ingest health for the diagnostics surface
+    /// (overflow/underrun verification at high sample rate + multi-DDC). Reads
+    /// only cached, lock-free snapshots — no realtime/WDSP work on this path:
+    ///   * per-WDSP-channel ingest health (queue depth/cap, frames-in, queue-full,
+    ///     dropped-oldest, worker avg/max ms vs the per-frame budget, audio
+    ///     overrun) from <see cref="WdspDspEngine.SnapshotRxChannels"/>; and
+    ///   * per-DDC UDP packet rate (last ~1 s window) from the active P2 client,
+    ///     indexed by DDC (0..MaxRxDdc-1) — the ground truth for which DDCs the
+    ///     radio is actually streaming.
+    /// </summary>
+    public object SnapshotRxIngestHealth()
+    {
+        var channels = (CurrentEngine as WdspDspEngine)?.SnapshotRxChannels()
+                       ?? (IReadOnlyList<WdspDspEngine.RxChannelHealth>)System.Array.Empty<WdspDspEngine.RxChannelHealth>();
+        long[] portRates = ActiveP2Client?.SnapshotRxPortPacketRates() ?? System.Array.Empty<long>();
+
+        var channelDtos = new object[channels.Count];
+        for (int i = 0; i < channels.Count; i++)
+        {
+            var h = channels[i];
+            // Per-frame WDSP budget: a 1024-sample frame must be processed in
+            // (1000·1024/rate) ms on average or the queue backs up. workerMaxMs
+            // approaching this is the realtime "CPU-bound" signal.
+            double frameBudgetMs = h.SampleRateHz > 0 ? 1000.0 * 1024.0 / h.SampleRateHz : 0.0;
+            double headroomPct = frameBudgetMs > 0
+                ? System.Math.Round(100.0 * (1.0 - h.WorkerMaxMs / frameBudgetMs), 1)
+                : 0.0;
+            channelDtos[i] = new
+            {
+                channelId = h.ChannelId,
+                sampleRateHz = h.SampleRateHz,
+                queueDepth = h.QueueDepth,
+                queueCapacity = h.QueueCapacity,
+                framesInPerWindow = h.FramesInPerWindow,
+                queueFullPerWindow = h.QueueFullPerWindow,
+                droppedPerWindow = h.DroppedPerWindow,
+                workerFramesPerWindow = h.WorkerFramesPerWindow,
+                workerAvgMs = System.Math.Round(h.WorkerAvgMs, 3),
+                workerMaxMs = System.Math.Round(h.WorkerMaxMs, 3),
+                frameBudgetMs = System.Math.Round(frameBudgetMs, 3),
+                workerHeadroomPct = headroomPct,
+                audioRingDepth = h.AudioRingDepth,
+                audioOverrunPerWindow = h.AudioOverrunPerWindow,
+                ageMs = h.AgeMs,
+            };
+        }
+
+        return new
+        {
+            schemaVersion = 1,
+            maxRxDdc = Zeus.Protocol2.Protocol2Client.MaxRxDdc,
+            activeChannels = channels.Count,
+            rxPortPacketRates = portRates,
+            channels = channelDtos,
+        };
+    }
+
+    /// <summary>
     /// Panadapter pixel column width — exposed so the frequency-calibration
     /// service (issue #325) can size its capture buffer correctly without
     /// hard-coding the constant.
@@ -4203,9 +4261,12 @@ public class DspPipelineService : BackgroundService,
     }
 
     // ---- IRxPacketSink (Protocol 2) -----------------------------------------
-    // Same shape as P1; P2 doesn't ArrayPool its sample buffer (per
-    // Protocol2Client.cs:1024 — a freshly allocated double[] per packet), so
-    // no buffer return is required.
+    // Same shape as P1, but the buffer lifetime is owned by the PRODUCER: when a
+    // sink is attached, Protocol2Client.HandleDdcPacket rents the IQ buffer and
+    // returns it to the pool in its own finally right after this call returns
+    // (safe because everything below consumes the span synchronously). So this
+    // sink must NOT retain frame.InterleavedSamples past the call and does not
+    // return any buffer itself.
     void Zeus.Protocol2.IRxPacketSink.OnIqFrame(in Zeus.Protocol2.IqFrame frame)
     {
         DrainDspCommands();

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -454,6 +454,7 @@ public static class ZeusHost
         builder.Services.AddSingleton<Diagnostics.IDiagnosticsProvider, Diagnostics.ExternalPttProvider>();
         builder.Services.AddSingleton<Diagnostics.IDiagnosticsProvider, Diagnostics.Protocol2TxIqProvider>();
         builder.Services.AddSingleton<Diagnostics.IDiagnosticsProvider, Diagnostics.DspPipelineProvider>();
+        builder.Services.AddSingleton<Diagnostics.IDiagnosticsProvider, Diagnostics.RxIngestDiagnosticsProvider>();
         builder.Services.AddSingleton<Diagnostics.DiagnosticsProviderRegistry>();
         builder.Services.AddSingleton<Diagnostics.DiagnosticsSelfCheckCache>();
         builder.Services.AddSingleton<Diagnostics.DiagnosticsFramePublisher>();

--- a/tests/Zeus.Dsp.Tests/WdspDspEngineTests.cs
+++ b/tests/Zeus.Dsp.Tests/WdspDspEngineTests.cs
@@ -212,7 +212,21 @@ public class WdspDspEngineTests
                 iq[2 * n] = Amplitude * Math.Cos(phase);
                 iq[2 * n + 1] = Amplitude * Math.Sin(phase);
             }
-            engine.FeedIq(channel, iq);
+            // Feed in realtime-shaped chunks. FeedIq is non-blocking with
+            // drop-OLDEST (in production it runs on the realtime RX sink thread,
+            // where IQ arrives one packet at a time and the worker keeps pace),
+            // so dumping all 64 frames in a single synchronous call would
+            // overflow the bounded hand-off queue and intentionally drop most of
+            // the burst before the worker is even scheduled. Pacing the feed — as
+            // the network does — lets the worker drain each chunk so the analyzer
+            // integrates the whole tone. This mirrors production, not a workaround.
+            const int ChunkComplex = 8 * 1024; // 8 frames/chunk; queue holds ≥32
+            for (int off = 0; off < TotalComplex; off += ChunkComplex)
+            {
+                int count = Math.Min(ChunkComplex, TotalComplex - off);
+                engine.FeedIq(channel, iq.AsSpan(off * 2, count * 2));
+                Thread.Sleep(5); // let the worker drain before the next chunk
+            }
 
             var pan = new float[Width];
             Assert.True(WaitForPixels(engine, channel, pan),

--- a/tests/Zeus.Protocol2.Tests/ComposeCmdRxBufferForReceiversTests.cs
+++ b/tests/Zeus.Protocol2.Tests/ComposeCmdRxBufferForReceiversTests.cs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Xunit;
+using Zeus.Contracts;
+
+namespace Zeus.Protocol2.Tests;
+
+/// <summary>
+/// Wire-format tests for the generalized N-receiver Receive-Specific composer
+/// (<see cref="Protocol2Client.ComposeCmdRxBufferForReceivers"/>), the
+/// foundation for full multi-RX (up to <see cref="Protocol2Client.MaxRxDdc"/>
+/// concurrent DDCs across the dual phase-synchronous ADCs).
+///
+/// The first group pins byte-FOR-byte parity with the legacy
+/// <see cref="Protocol2Client.ComposeCmdRxBuffer"/> for the RX1 / RX1+RX2 / PS
+/// cases — so the generalization cannot drift from the wire shape every
+/// shipped G2 / Saturn / Hermes operator is validated against. The second
+/// group exercises the new capability: independent per-DDC ADC assignment and
+/// per-DDC sample rate across all 8 DDCs.
+/// </summary>
+public class ComposeCmdRxBufferForReceiversTests
+{
+    private static Protocol2Client.DdcReceiverSpec Rx(byte adc, ushort rateKhz) => new(adc, rateKhz);
+
+    // ---- Parity with the legacy composer -----------------------------------
+
+    [Fact]
+    public void SingleReceiver_OrionMkII_MatchesLegacy_Rx1Only()
+    {
+        var legacy = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 42, numAdc: 2, sampleRateKhz: 192, psEnabled: false);
+        var generalized = Protocol2Client.ComposeCmdRxBufferForReceivers(
+            seq: 42, numAdc: 2, receivers: [Rx(0, 192)]);
+
+        Assert.Equal(legacy, generalized);
+        Assert.Equal((byte)0x04, generalized[7]); // DDC2 enable
+    }
+
+    [Fact]
+    public void TwoReceivers_OrionMkII_MatchesLegacy_Rx2OnSameAdc()
+    {
+        var legacy = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 7, numAdc: 2, sampleRateKhz: 96, psEnabled: false, rx2Enabled: true);
+        // Legacy RX2 sources ADC0 (Rx2AdcSource) at the same rate as RX1.
+        var generalized = Protocol2Client.ComposeCmdRxBufferForReceivers(
+            seq: 7, numAdc: 2, receivers: [Rx(0, 96), Rx(0, 96)]);
+
+        Assert.Equal(legacy, generalized);
+        Assert.Equal((byte)0x0C, generalized[7]); // DDC2 | DDC3
+    }
+
+    [Fact]
+    public void PsArmed_SingleReceiver_OrionMkII_MatchesLegacyPs()
+    {
+        var legacy = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 9, numAdc: 2, sampleRateKhz: 192, psEnabled: true);
+        var generalized = Protocol2Client.ComposeCmdRxBufferForReceivers(
+            seq: 9, numAdc: 2, receivers: [Rx(0, 192)], psEnabled: true);
+
+        Assert.Equal(legacy, generalized);
+        Assert.Equal((byte)0x05, generalized[7]);  // DDC0 (PS) | DDC2 (RX1)
+        Assert.Equal((byte)0x02, generalized[1363]); // DDC1→DDC0 sync
+    }
+
+    [Fact]
+    public void SingleReceiver_Hermes_MatchesLegacy_Ddc0()
+    {
+        var legacy = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 1, numAdc: 1, sampleRateKhz: 48, psEnabled: false,
+            boardKind: HpsdrBoardKind.Hermes);
+        var generalized = Protocol2Client.ComposeCmdRxBufferForReceivers(
+            seq: 1, numAdc: 1, receivers: [Rx(0, 48)],
+            boardKind: HpsdrBoardKind.Hermes);
+
+        Assert.Equal(legacy, generalized);
+        Assert.Equal((byte)0x01, generalized[7]); // DDC0
+    }
+
+    [Fact]
+    public void AdcOptions_MatchLegacy()
+    {
+        var legacy = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 3, numAdc: 2, sampleRateKhz: 192, psEnabled: false,
+            adcDitherEnabled: true, adcRandomEnabled: true);
+        var generalized = Protocol2Client.ComposeCmdRxBufferForReceivers(
+            seq: 3, numAdc: 2, receivers: [Rx(0, 192)],
+            adcDitherEnabled: true, adcRandomEnabled: true);
+
+        Assert.Equal(legacy, generalized);
+        Assert.Equal((byte)0x07, generalized[5]);
+        Assert.Equal((byte)0x07, generalized[6]);
+    }
+
+    // ---- New capability: per-DDC ADC assignment + per-DDC rate --------------
+
+    [Fact]
+    public void FourReceivers_DualAdc_MixedRates_EnableBitsAndBlocks()
+    {
+        // RX0=ADC0@192, RX1=ADC1@384, RX2=ADC0@768, RX3=ADC1@1536 on OrionMkII
+        // → DDC2,3,4,5.
+        var p = Protocol2Client.ComposeCmdRxBufferForReceivers(
+            seq: 1, numAdc: 2,
+            receivers: [Rx(0, 192), Rx(1, 384), Rx(0, 768), Rx(1, 1536)]);
+
+        // Enable bits: DDC2|DDC3|DDC4|DDC5 = 0x3C.
+        Assert.Equal((byte)0x3C, p[7]);
+
+        // DDC2 @ off 29: ADC0, 192 kHz (0x00C0), 24-bit.
+        Assert.Equal((byte)0x00, p[29]);
+        Assert.Equal((byte)0x00, p[30]);
+        Assert.Equal((byte)0xC0, p[31]);
+        Assert.Equal((byte)24, p[34]);
+
+        // DDC3 @ off 35: ADC1, 384 kHz (0x0180), 24-bit.
+        Assert.Equal((byte)0x01, p[35]);
+        Assert.Equal((byte)0x01, p[36]);
+        Assert.Equal((byte)0x80, p[37]);
+        Assert.Equal((byte)24, p[40]);
+
+        // DDC4 @ off 41: ADC0, 768 kHz (0x0300), 24-bit.
+        Assert.Equal((byte)0x00, p[41]);
+        Assert.Equal((byte)0x03, p[42]);
+        Assert.Equal((byte)0x00, p[43]);
+        Assert.Equal((byte)24, p[46]);
+
+        // DDC5 @ off 47: ADC1, 1536 kHz (0x0600), 24-bit.
+        Assert.Equal((byte)0x01, p[47]);
+        Assert.Equal((byte)0x06, p[48]);
+        Assert.Equal((byte)0x00, p[49]);
+        Assert.Equal((byte)24, p[52]);
+    }
+
+    [Fact]
+    public void EightReceivers_Hermes_FillsDdc0ThroughDdc7()
+    {
+        // Single-ADC Hermes-class: RX0..RX7 map to DDC0..DDC7, all enabled.
+        var recv = new Protocol2Client.DdcReceiverSpec[8];
+        for (int i = 0; i < 8; i++) recv[i] = Rx(0, 96);
+
+        var p = Protocol2Client.ComposeCmdRxBufferForReceivers(
+            seq: 1, numAdc: 1, receivers: recv, boardKind: HpsdrBoardKind.Hermes);
+
+        Assert.Equal((byte)0xFF, p[7]); // all 8 DDC enable bits set
+        // Spot-check the last DDC's block (DDC7 @ off 17 + 7*6 = 59).
+        Assert.Equal((byte)0x00, p[59]);      // ADC0
+        Assert.Equal((byte)96, p[61]);        // 96 kHz BE low
+        Assert.Equal((byte)24, p[64]);        // 24-bit
+    }
+
+    [Fact]
+    public void ExceedingProtocolCeiling_Throws()
+    {
+        // OrionMkII base DDC is 2, so the 7th user receiver would land on DDC8,
+        // past the 8-DDC (DDC0..7) protocol ceiling.
+        var recv = new Protocol2Client.DdcReceiverSpec[7];
+        for (int i = 0; i < 7; i++) recv[i] = Rx(0, 192);
+
+        Assert.Throws<System.ArgumentOutOfRangeException>(() =>
+            Protocol2Client.ComposeCmdRxBufferForReceivers(
+                seq: 1, numAdc: 2, receivers: recv));
+    }
+
+    [Fact]
+    public void MaxRxDdc_IsEight()
+    {
+        // Pin the verified protocol ceiling so a future "bump to 10" is a
+        // deliberate, reviewed change rather than an accident.
+        Assert.Equal(8, Protocol2Client.MaxRxDdc);
+    }
+}


### PR DESCRIPTION
## Summary

Makes the RX ingest path safe at sample rates up to **1536 kHz** (no overflow/underrun), lays the **8-DDC** wire foundation for full multi-receiver operation, and adds a **live diagnostics provider** so ingest health is verifiable in realtime. This is a self-contained, fully-tested foundation; the receiver-array refactor + UI land in follow-ups (see *Remaining*).

## What's in here

### Phase A — high-sample-rate ingest hardening
- **Non-blocking drop-oldest** WDSP feed (was a blocking `Add`). The realtime RX sink thread never stalls — a stall used to cascade into kernel UDP drops / sequence gaps. Under genuine overload the result is a bounded, *counted* glitch instead of a cascade.
- **Rate-scaled hand-off queue** (`ComputeInQueueCapacity`, ~80 ms cushion, 32–256 frames) so the time-window stays constant across the 48k→1536k ladder instead of shrinking 32×.
- **Protocol 2 RX socket buffer 1→4 MiB** (clamped-safe) for multi-DDC jitter absorption.
- **Protocol 2 per-packet IQ pooling** (`ArrayPool`) on the synchronous-sink path — removes ~24 MB/s of Gen0 garbage at 1536 kHz (a direct cause of GC-pause worker stalls). Mirrors the existing P1 contract.

### 8-DDC foundation
- Verified against the OpenHPSDR P2 spec: the DDC Command enable byte covers **DDC0–DDC7 → 8 concurrent DDCs max** (no second enable byte; "10" isn't representable in standard P2). Encoded as `MaxRxDdc = 8`.
- Generalized N-receiver Receive-Specific composer (`ComposeCmdRxBufferForReceivers`) with **per-DDC ADC source + independent sample rate**, byte-identical to the legacy RX1/RX2/PS composer (proven by tests). RX demux widened to all 8 DDC ports (1035–1042).

### Live diagnostics (`/api/diagnostics/v2/rx-ingest-health`)
- New `IDiagnosticsProvider` surfacing per-RX-channel ingest health latched each ~1 s: queue depth/capacity, **dropped-oldest** count, worker avg/max ms **vs the per-frame budget**, audio-ring overruns, and per-DDC packet rate — plus self-checks for drops and CPU-budget. Also flows through the 0x36 health push.

## Testing
- Full solution builds clean (0 warnings / 0 errors).
- `Zeus.Protocol2.Tests` **136/136** (incl. new composer wire-parity + multi-DDC/dual-ADC cases).
- `Zeus.Dsp.Tests` **172/172**.
- `Zeus.Server.Tests` **1497 passed / 7 skipped** (incl. diagnostics conformance auto-covering the new provider).
- **Live e2e:** ran the host on an isolated port and confirmed `/api/diagnostics/v2/rx-ingest-health` returns a valid snapshot envelope (`maxRxDdc: 8`) and self-checks `pass`.

## Notes for review
- One DSP test (`ComplexTone_ProducesPeakAtExpectedSideOfCentre`) was updated to feed IQ in realtime-shaped chunks: its old bulk-feed-in-one-call relied on the now-removed blocking backpressure. The spectrum/orientation logic is unchanged; this mirrors how IQ actually arrives (one packet at a time).
- Sustained 1536 kHz is ultimately CPU-bound (WDSP `fexchange0`/`Spectrum0` run ~1500×/s/DDC); the new telemetry's `workerMaxMs` vs `frameBudgetMs` is the signal to watch — especially on Raspberry Pi.

## Remaining (follow-up PRs)
- **B2:** `DspPipelineService` receiver-indexed arrays (replace `_channelId`/`_rx2*`).
- **B3:** `StateDto` `receivers[]` refactor + wire-version bump; `RxId` on the RX meter frames; receiver-indexed `RadioService` setters.
- **B4:** frontend receivers array + Settings → Receivers/DDC panel (configurable count + per-DDC ADC0/ADC1), wired into RX A/B.