### PR TITLE
ci: drop deprecated macos-x64 (Intel) test leg

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -59,18 +59,19 @@ jobs:
             arch: arm64
             experimental: true
 
-          # ---- macOS x64 (Intel) coverage (NEW) --------------------------
-          # macos-13 is the last x64 (Intel) hosted image. Apple Silicon is the
-          # default now, so without this leg Intel Macs are silently untested.
-          # Tradeoff: Intel macOS hosted capacity is limited and the image is on
-          # a deprecation track, so this is experimental (informational) rather
-          # than a hard gate — we still want the signal when it is available.
-          # TODO(maintainer): keep an eye on macos-13 availability; if/when it
-          # is retired, drop this leg and note Intel macOS is best-effort.
-          - name: macos-x64
-            os: macos-13
-            arch: x64
-            experimental: true
+          # ---- macOS x64 (Intel) coverage — RETIRED ----------------------
+          # The macos-x64 leg ran on `macos-13`, GitHub's last Intel hosted
+          # image. That pool is on GitHub's deprecation track and its hosted
+          # capacity collapsed: jobs sat `queued` for 1h+ and never picked up a
+          # runner, leaving a perpetual "pending" check on every PR (the leg was
+          # already continue-on-error, so it never gated — only added noise and
+          # burned a queue slot). Per the leg's own retirement note, it is now
+          # dropped. Intel macOS is BEST-EFFORT / untested in CI; macos-arm64
+          # remains the required macOS gate. Note: arch-specific native bits
+          # (Intel dylib + FFTW bundling) are no longer exercised here — see
+          # docs/lessons on macOS FFTW bundling before shipping Intel changes.
+          # build-voyeur-engines.yml shows the migration path (cross-build
+          # x86_64 on macos-14) if a hard Intel gate is wanted again later.
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What

Removes the `macos-x64` leg (pinned to GitHub's `macos-13` Intel image) from the Build and Test matrix.

## Why

GitHub's `macos-13` hosted Intel pool is on a deprecation track and its capacity has collapsed. The `macos-x64` job sat **`queued` for over an hour** without ever picking up a runner, leaving a perpetual *pending* check on every open PR (and on `develop` itself). Every other platform — including `macos-arm64` — completes in minutes.

The leg was already `continue-on-error: true`, so it **never gated merges** — it only added a stuck check and burned a macOS queue slot. The leg's own in-file note already said to drop it once `macos-13` was retired in practice; that point has arrived.

## Impact

- **Required macOS gate unchanged:** `macos-arm64` (Apple Silicon) stays as the hard macOS gate.
- **Intel macOS is now best-effort / untested in CI.** Arch-specific native bits (Intel dylib + FFTW bundling) are no longer exercised — see the macOS-FFTW-bundling lesson before shipping Intel-specific changes.
- No change to merge gating (required status checks aren't enabled on `develop`/`main`, and this leg was non-blocking regardless).

## Follow-up (not in this PR)

If a hard Intel-macOS gate is wanted again, `build-voyeur-engines.yml` already shows the path: cross-build `x86_64` on the healthy `macos-14` Apple-Silicon runner instead of depending on `macos-13`.

## Test

- YAML validates; matrix parses to the 5 intended legs (linux-x64, windows-x64, macos-arm64 + experimental linux-arm64, windows-arm64).
- No source/build change.