### PR TITLE
feat(audio): external TX audio-source select across all radios (re-port of #639)

### DIFF
--- a/Zeus.Contracts/BoardCapabilities.cs
+++ b/Zeus.Contracts/BoardCapabilities.cs
@@ -102,7 +102,35 @@ public sealed record BoardCapabilities(
     /// disabled when this flag is false, so operators can see the
     /// feature exists without being able to drive a non-supporting
     /// board.</summary>
-    bool SupportsAnvelinaDxOc = false)
+    bool SupportsAnvelinaDxOc = false,
+    // ---- TX audio front-end (external-audio-jacks re-port) ----------------
+    /// <summary>Board decodes the host→radio audio STREAM (TLV320 codec) — the
+    /// path the radio's own analog mic / line-in jack uses. True for Hermes-
+    /// class and every ANAN board. False for Hermes-Lite 2, which has no stream
+    /// codec. STREAM codec only; does NOT gate the HL2 mic front-end (see
+    /// <see cref="HermesLite2MicFrontEnd"/>). Gates the Radio Mic / Line-In /
+    /// XLR options on the wire and in the UI.</summary>
+    bool HasOnboardCodec = false,
+    /// <summary>Hermes-Lite 2 has an analog mic front-end on Protocol-1
+    /// register 0x0a (wire byte 0x14): mic_trs, mic_bias and a 5-bit
+    /// line_in_gain. Distinct from <see cref="HasOnboardCodec"/> — HL2 has the
+    /// mic front-end but not the stream codec. Kept INERT in v1 (plumbing only)
+    /// until confirmed on hardware; mic_bias defaults OFF. True for HL2 only.</summary>
+    bool HermesLite2MicFrontEnd = false,
+    /// <summary>Board has a switchable analog line-in jack as a selectable
+    /// TX-audio source (<see cref="Contracts.TxAudioSource.RadioLineIn"/>). True
+    /// for the ANAN-10E (HermesII), 100D/200D and the 0x0A Saturn family.</summary>
+    bool HasRadioLineIn = false,
+    /// <summary>Board has a switchable balanced XLR microphone input
+    /// (<see cref="Contracts.TxAudioSource.RadioBalancedXlr"/>). True ONLY for
+    /// the Saturn-FPGA G2 / G2-1K. Use this flag (never
+    /// <see cref="HasAudioAmplifier"/>) to gate XLR.</summary>
+    bool HasBalancedXlr = false,
+    /// <summary>Board can enable the Orion electret mic-bias supply on its mic
+    /// jack. Do NOT derive this from <see cref="HasAudioAmplifier"/>. mic_bias
+    /// defaults OFF (a floating connector with bias can hang PTT). True for
+    /// 100D/200D/7000DLE/8000DLE/G2/G2-1K.</summary>
+    bool HasMicBias = false)
 {
     /// <summary>Safe defaults for an unrecognised / disconnected board.
     /// Single ADC, no extras — minimum-surprise capability set so a

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -1078,7 +1078,14 @@ public sealed record StateDto(
     // RX preamp toggle. Persisted with the rest of the radio-state controls so
     // PRE comes back exactly as the operator left it after a backend restart.
     // Hidden on HL2 in the frontend because that board has no hardware preamp.
-    bool PreampOn = false);
+    bool PreampOn = false,
+
+    // ---- TX-audio source (external-audio-jacks re-port) ----
+    // The RESOLVED (board-clamped) TX-audio source the server is currently
+    // pushing. The frontend hydrates the audio picker from this and never
+    // clobbers the server on connect (PR #359/#360 anti-clobber pattern).
+    // Default Host is byte-identical to today on every board.
+    TxAudioSource TxAudioSource = TxAudioSource.Host);
 
 /// <summary>Canonical CW constants shared between backend and wire DTOs.
 /// Single source of truth — CwOffset (server-side) and StateDto both
@@ -1632,6 +1639,36 @@ public sealed record RadioSelectionSetRequest(
 // (issue #218). String-typed for forward compatibility — server parses
 // against the OrionMkIIVariant enum. Empty / unknown rejected with 400.
 public sealed record RadioVariantSetRequest(string Variant);
+
+// Global (per-radio, NOT per-band) TX-audio SOURCE selection
+// (external-audio-jacks re-port). GET carries the per-board source-availability
+// gates so the single-select picker renders only the sources the connected
+// board offers: HasOnboardCodec gates RadioMic; HasRadioLineIn gates
+// RadioLineIn; HasBalancedXlr gates RadioBalancedXlr; HasMicBias gates the bias
+// toggle; HermesLite2MicFrontEnd flags the (inert v1) HL2 mic front-end.
+// `Source` is the RESOLVED (board-clamped) source the server is pushing — the
+// frontend hydrates from it and never clobbers the server on connect. MicBoost /
+// MicBias / LineInGain are the parameters OF the selected source.
+public sealed record AudioFrontEndDto(
+    bool HasOnboardCodec,
+    bool HermesLite2MicFrontEnd,
+    bool HasRadioLineIn,
+    bool HasBalancedXlr,
+    bool HasMicBias,
+    TxAudioSource Source,
+    bool MicBoost,
+    bool MicBias,
+    int LineInGain);
+
+// Mutating version — sets the whole global TX-audio source. LineInGain is
+// clamped to 0..31 server-side. The server clamps Source against the board's
+// capabilities (an unsupported jack → Host) and returns the resolved state plus
+// the live capability gates.
+public sealed record AudioFrontEndSetRequest(
+    TxAudioSource Source,
+    bool MicBoost,
+    bool MicBias,
+    int LineInGain);
 
 // HL2-specific optional toggles surfaced via /api/radio/hl2-options.
 // Shape is an object (not a bare bool) so future mi0bot HL2 toggles can

--- a/Zeus.Contracts/TxAudioSource.cs
+++ b/Zeus.Contracts/TxAudioSource.cs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.Contracts;
+
+/// <summary>
+/// The single mutually-exclusive TX-audio SOURCE for a connected radio
+/// (external-ports plan, §2). Replaces the prior four-bool
+/// <c>AudioFrontEndSelection</c> mic-PARAMETER model, which only set codec wire
+/// bits and never switched the TX pipeline (host mic kept flowing regardless of
+/// the operator's pick) and allowed illegal combinations (line-in AND balanced,
+/// etc.). With this enum, illegal states are unrepresentable: exactly one source
+/// is active at a time.
+///
+/// <see cref="Host"/> = 0 is the default and the universal fallback. A persisted
+/// row that names a source the connected board can't honour (e.g. a balanced-XLR
+/// selection after a G2→Hermes swap) is clamped back to <see cref="Host"/> at
+/// connect, so the wire is never handed a source the hardware lacks.
+///
+/// MicBoost / MicBias / LineInGain are PARAMETERS OF a chosen source (carried
+/// alongside in <c>AudioSettingsStore</c>), never peer toggles — they apply only
+/// to whichever radio jack is selected and are suppressed entirely under
+/// <see cref="Host"/>.
+///
+/// RED-LIGHT but ADDITIVE and back-compatible: the underlying byte values are
+/// wire-stable and serialised into <c>zeus-prefs.db</c>; default 0 reproduces
+/// today's behaviour bit-for-bit on every board.
+/// </summary>
+public enum TxAudioSource : byte
+{
+    /// <summary>Host-supplied TX audio (USB/network mic, TCI, WAV playback —
+    /// whatever feeds the host TX pipeline today). The default and the only
+    /// option on boards with no radio-audio jack (Hermes-Lite 2). The radio's
+    /// own analog input is suppressed; the wire is byte-identical to today.</summary>
+    Host = 0,
+
+    /// <summary>The radio's analog 3.5 mm microphone jack. Honours the
+    /// per-source <c>MicBoost</c> parameter on every codec/P2 board and
+    /// <c>MicBias</c> on the bias-capable boards (200D / 7000DLE / 8000DLE /
+    /// G2 / G2-1K / ANVELINA-PRO3).</summary>
+    RadioMic = 1,
+
+    /// <summary>The radio's analog 3.5 mm line-in jack. Honours the per-source
+    /// 0..31 <c>LineInGain</c>. Offered on ANAN-200D and the 0x0A Saturn family
+    /// only (Zeus has no P1 radio-mic receive path in v1, so pure-P1 codec
+    /// boards do not expose it — §6 deviation note).</summary>
+    RadioLineIn = 2,
+
+    /// <summary>The radio's balanced XLR microphone input. Switchable on the
+    /// Saturn-FPGA G2 / G2-1K only (<c>HasBalancedXlr</c>). Implies the XLR wire
+    /// select; no separate "balanced" flag is persisted.</summary>
+    RadioBalancedXlr = 3,
+}

--- a/Zeus.Protocol1/ControlFrame.cs
+++ b/Zeus.Protocol1/ControlFrame.cs
@@ -249,7 +249,33 @@ internal static class ControlFrame
         // WriteCwKeyerConfigPayload. Default mode Straight makes the write a
         // no-op until the operator opts into iambic. See zeus-bks.
         int CwKeyerSpeedWpm = 0,
-        CwKeyerMode CwKeyerMode = CwKeyerMode.Straight);
+        CwKeyerMode CwKeyerMode = CwKeyerMode.Straight,
+        // ---- Audio front-end (external-audio-jacks re-port) -----------------
+        // Two distinct P1 audio surfaces, both verified against ramdor Thetis
+        // networkproto1.c and piHPSDR old_protocol.c:
+        //
+        //  (a) Hermes-class codec boards — DriveFilter (0x12) frame:
+        //        C2[0] = mic_boost, C2[1] = mic_linein
+        //      (Thetis networkproto1.c:581; piHPSDR old_protocol.c:2154-2156.)
+        //      These default false → byte-identical to today's 0x12 frame.
+        //
+        //  (b) Hermes-Lite 2 — 0x0a / wire-0x14 frame (read-modify-write):
+        //        C1[4] = mic_trs, C1[5] = mic_bias, C2[4:0] = line_in_gain
+        //      (Thetis networkproto1.c:597-599 case 11; same in mi0bot.)
+        //      The SAME frame carries C2[6] = puresignal_run and the C4 PGA /
+        //      step-attenuator byte — those are written by the existing
+        //      WriteAttenuatorPayload logic and MUST survive. The audio fields
+        //      only set their own bits on top.
+        //
+        // mic_bias defaults OFF — enabling it on a floating connector can hang
+        // PTT (BoardCapabilities.HermesLite2MicFrontEnd / HasMicBias guard the
+        // surface). mic_ptt routing is a PTT-IN concern, not this feature, so
+        // it is intentionally not written here (stays 0, as today).
+        bool MicBoost = false,
+        bool MicLineIn = false,
+        bool MicTrs = false,
+        bool MicBias = false,
+        byte LineInGain = 0);
 
     /// <summary>
     /// Write the 5 C&amp;C bytes for <paramref name="register"/> given the current
@@ -297,6 +323,18 @@ internal static class ControlFrame
                 if (state.Board == HpsdrBoardKind.HermesLite2 && state.Mox)
                 {
                     cc[2] |= 0x08;
+                }
+                // Hermes-class codec boards carry mic_boost (C2[0]) and
+                // mic_linein (C2[1]) on this 0x12 frame — Thetis
+                // networkproto1.c:581, piHPSDR old_protocol.c:2154-2156. HL2
+                // has no stream codec and routes mic/line through the 0x14
+                // frame instead, so it is excluded here. Both default false so
+                // an operator who never touches the audio panel emits the same
+                // bytes as today (byte-identical default-unsent).
+                else if (state.Board != HpsdrBoardKind.HermesLite2)
+                {
+                    if (state.MicBoost) cc[2] |= 0x01;   // C2[0] mic_boost
+                    if (state.MicLineIn) cc[2] |= 0x02;  // C2[1] mic_linein
                 }
                 break;
 
@@ -358,6 +396,32 @@ internal static class ControlFrame
         c14[1] = 0;   // C2
         c14[2] = 0;   // C3
         c14[3] = c4;
+
+        // HL2 mic front-end (external-audio-jacks re-port). This C0=0x14 frame
+        // is register 0x0a, which on HL2 carries the real mic/line-in front-
+        // end ALONGSIDE puresignal_run and the C4 step-attenuator byte. The
+        // verified layout (Thetis networkproto1.c:597-599 case 11; identical in
+        // mi0bot):
+        //   C1[4] = mic_trs, C1[5] = mic_bias, C1[6] = mic_ptt
+        //   C2[4:0] = line_in_gain, C2[6] = puresignal_run
+        // We READ-MODIFY-WRITE: set ONLY the audio bits, leaving the C4 PGA /
+        // step-attenuator byte (already in c14[3]) and the C2[6] PS bit (set
+        // below) untouched. mic_ptt is a PTT-IN concern, not this feature, so
+        // C1[6] is intentionally left 0 — same as today. mic_bias (C1[5])
+        // defaults OFF: enabling it on a floating connector can hang PTT, so the
+        // operator must opt in explicitly via the audio panel. At defaults
+        // (mic_trs/mic_bias off, line_in_gain 0) every byte is unchanged, so
+        // this block is byte-identical to today on HL2.
+        if (s.Board == HpsdrBoardKind.HermesLite2)
+        {
+            byte c1 = 0;
+            if (s.MicTrs)  c1 |= 1 << 4;   // C1[4] mic_trs
+            if (s.MicBias) c1 |= 1 << 5;   // C1[5] mic_bias
+            c14[0] = c1;
+            // line_in_gain is the low 5 bits of C2; OR it in so the PS bit
+            // (set below) and the reserved high bits stay clear.
+            c14[1] |= (byte)(s.LineInGain & 0x1F);
+        }
 
         // HL2 PureSignal: register 0x0a bit 22 = puresignal_run. Bit 22 lives
         // in C2 bit 6 (22 - 16 = 6) of this same C0=0x14 frame. mi0bot

--- a/Zeus.Protocol1/IProtocol1Client.cs
+++ b/Zeus.Protocol1/IProtocol1Client.cs
@@ -251,6 +251,19 @@ public interface IProtocol1Client : IDisposable
     void SetCwKeyerConfig(int wpm, CwKeyerMode mode);
 
     /// <summary>
+    /// Set the TX audio front-end (external-audio-jacks re-port). Global
+    /// per-radio. <paramref name="micBoost"/> / <paramref name="micLineIn"/>
+    /// ride the 0x12 codec frame on Hermes-class boards; <paramref name="micTrs"/>
+    /// / <paramref name="micBias"/> / <paramref name="lineInGain"/> (0..31) ride
+    /// the 0x14 frame on HL2 via read-modify-write (PureSignal bit + C4 step-att
+    /// preserved). Per-board gating lives in <see cref="ControlFrame"/>, so a
+    /// value for the wrong board is ignored on the wire. All-zero/false is the
+    /// default and is byte-identical to today. mic_bias defaults OFF
+    /// (floating-connector PTT-hang guard).
+    /// </summary>
+    void SetAudioFrontEnd(bool micBoost, bool micLineIn, bool micTrs, bool micBias, int lineInGain);
+
+    /// <summary>
     /// 1024-sample paired feedback blocks decoded from the EP6 stream when
     /// PS is armed. TX side comes from the in-flight TX-IQ ring (the
     /// samples we just wrote to the wire); RX side is DDC1, the dedicated

--- a/Zeus.Protocol1/Protocol1Client.cs
+++ b/Zeus.Protocol1/Protocol1Client.cs
@@ -124,6 +124,16 @@ public sealed class Protocol1Client : IProtocol1Client
     // a no-op until the operator opts into iambic. See zeus-bks.
     private int _cwKeyerSpeedWpm;
     private int _cwKeyerMode; // CwKeyerMode as int for Interlocked
+    // TX audio front-end (external-audio-jacks re-port). mic_boost / mic_linein
+    // ride the 0x12 frame on codec boards; mic_trs / mic_bias / line_in_gain
+    // ride the 0x14 frame on HL2 (read-modify-write — see ControlFrame). All
+    // default to the off / zero state so an untouched radio is byte-identical
+    // to today. mic_bias defaults OFF (floating-connector PTT-hang guard).
+    private int _micBoost;     // 0 / 1
+    private int _micLineIn;    // 0 / 1
+    private int _micTrs;       // 0 / 1
+    private int _micBias;      // 0 / 1
+    private int _lineInGain;   // 0..31 (5-bit HL2 line_in_gain)
     private long _droppedFrames;
     private long _totalFrames;
 
@@ -631,6 +641,26 @@ public sealed class Protocol1Client : IProtocol1Client
         Interlocked.Exchange(ref _cwKeyerMode, (int)mode);
     }
 
+    /// <summary>
+    /// Set the TX audio front-end (external-audio-jacks re-port). Global,
+    /// per-radio — not per-band. <paramref name="micBoost"/> /
+    /// <paramref name="micLineIn"/> ride the 0x12 frame on Hermes-class codec
+    /// boards; <paramref name="micTrs"/> / <paramref name="micBias"/> /
+    /// <paramref name="lineInGain"/> ride the 0x14 frame on HL2. Which fields
+    /// actually reach the wire is gated per-board in ControlFrame, so a value
+    /// for the wrong board is simply ignored. mic_bias defaults OFF and the
+    /// caller (RadioService / REST) guards the gate; passing it true is the
+    /// operator's explicit opt-in.
+    /// </summary>
+    public void SetAudioFrontEnd(bool micBoost, bool micLineIn, bool micTrs, bool micBias, int lineInGain)
+    {
+        Interlocked.Exchange(ref _micBoost, micBoost ? 1 : 0);
+        Interlocked.Exchange(ref _micLineIn, micLineIn ? 1 : 0);
+        Interlocked.Exchange(ref _micTrs, micTrs ? 1 : 0);
+        Interlocked.Exchange(ref _micBias, micBias ? 1 : 0);
+        Interlocked.Exchange(ref _lineInGain, Math.Clamp(lineInGain, 0, 31));
+    }
+
     public void SetHl2TxStepAttenuationDb(int db)
     {
         // Range matches mi0bot console.cs:2084 (udTXStepAttData.Minimum=-28,
@@ -709,7 +739,12 @@ public sealed class Protocol1Client : IProtocol1Client
             // untouched, fall through to the RX-side encoding above.
             Hl2TxAttnDb: Volatile.Read(ref _hl2TxAttnDb),
             CwKeyerSpeedWpm: Volatile.Read(ref _cwKeyerSpeedWpm),
-            CwKeyerMode: (CwKeyerMode)Volatile.Read(ref _cwKeyerMode));
+            CwKeyerMode: (CwKeyerMode)Volatile.Read(ref _cwKeyerMode),
+            MicBoost: Volatile.Read(ref _micBoost) != 0,
+            MicLineIn: Volatile.Read(ref _micLineIn) != 0,
+            MicTrs: Volatile.Read(ref _micTrs) != 0,
+            MicBias: Volatile.Read(ref _micBias) != 0,
+            LineInGain: (byte)Volatile.Read(ref _lineInGain));
     }
 
     private void RxLoop()

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -224,6 +224,25 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // out as the reserved-bit safe default for non-Anvelina firmware.
     private byte _ocDxTxMask;
     private byte _ocDxRxMask;
+    // TX audio front-end (external-audio-jacks re-port). Wire-encoded into the
+    // TxSpecific (CmdTx, port 1026) packet byte 50 (mic_control flags) + byte
+    // 51 (line_in_gain) — Thetis network.c:1234,1236. Both default 0, which is
+    // byte-identical to today's all-zero CmdTx tail. The byte-50 / byte-51
+    // values are resolved as pure functions of the selected TxAudioSource
+    // upstream (RadioService / ExternalPortEncoder); this client just latches
+    // them and re-pushes CmdTx via SetAudioFrontEndBytes.
+    private byte _micControl;
+    private byte _lineInGain;
+
+    // TxSpecific byte-50 mic_control bit layout (Thetis network.c:1226-1233).
+    // Public so the wire-format golden tests can assert against the canonical
+    // bit positions. The byte itself is resolved upstream from the selected
+    // TxAudioSource (ExternalPortAudio in Zeus.Server.Hosting).
+    public const byte MicControlLineIn   = 0x01; // bit0 — line-in select
+    public const byte MicControlMicBoost = 0x02; // bit1 — mic 20 dB boost
+    public const byte MicControlMicBias  = 0x10; // bit4 — Orion mic bias enable
+    public const byte MicControlXlr      = 0x20; // bit5 — balanced/XLR input
+
     private bool _moxOn;
     private bool _tuneActive;
     private long _totalFrames;
@@ -350,6 +369,40 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // Mirrors the P1 surface; the IqFrame / PsFeedbackFrame types are
     // per-protocol because the protocol projects do not reference each other.
     private IRxPacketSink? _rxSink;
+
+    // ---- Radio-mic stream (UDP 1026) — external-audio-jacks re-port --------
+    // The radio digitises its analog jack (mic / line-in / balanced-XLR) and
+    // ships it on source port 1026. We DROP it by default (the RX loop just
+    // skips it) — there is ZERO added RX cost unless a radio audio source is
+    // armed and a handler is attached via AttachRadioMicHandler. The handler is
+    // called SYNCHRONOUSLY on the RX loop thread with a span over the receive
+    // buffer; it must copy/consume before returning (RadioMicReceiver does, by
+    // re-blocking into its own accumulator). volatile so the attach/detach on a
+    // source switch is a full fence against the RX thread.
+    private volatile RadioMicPacketHandler? _radioMicHandler;
+
+    /// <summary>
+    /// Synchronous handler for one decoded UDP-1026 radio-mic packet. Invoked on
+    /// the RX loop thread with a span over the live receive buffer — copy before
+    /// returning. The packet is the raw 132-byte 1026 payload (4-byte BE seq +
+    /// 64 × int16 BE @ 48 kHz); decoding/re-blocking is the handler's job.
+    /// </summary>
+    public delegate void RadioMicPacketHandler(ReadOnlySpan<byte> packet);
+
+    /// <summary>
+    /// Attach the radio-mic (UDP 1026) handler. Until this is set the 1026
+    /// stream is dropped with one cheap srcPort comparison — Host-default has no
+    /// added cost. Pass <see cref="DetachRadioMicHandler"/> on a switch back to
+    /// Host.
+    /// </summary>
+    public void AttachRadioMicHandler(RadioMicPacketHandler handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        _radioMicHandler = handler;
+    }
+
+    /// <summary>Detach the radio-mic handler, reverting to drop-on-RX.</summary>
+    public void DetachRadioMicHandler() => _radioMicHandler = null;
 
     /// <summary>
     /// Attach a synchronous RX sink. While non-null, the RX loop calls the
@@ -1410,8 +1463,26 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
 
     private void SendCmdTx()
     {
-        var p = ComposeCmdTxBuffer(_seqCmdTx++, (ushort)_sampleRateKhz, _txStepAttnDb, _paEnabled, _psFeedbackEnabled);
+        var p = ComposeCmdTxBuffer(_seqCmdTx++, (ushort)_sampleRateKhz, _txStepAttnDb, _paEnabled, _psFeedbackEnabled, _micControl, _lineInGain);
         _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1026));
+    }
+
+    /// <summary>
+    /// Set the audio front-end from already-composed wire bytes
+    /// (external-audio-jacks re-port). The TX-audio source model resolves
+    /// byte-50 mic_control and byte-51 line_in_gain as pure functions of the
+    /// selected <c>TxAudioSource</c> upstream (RadioService / ExternalPortEncoder),
+    /// so the client just latches them and re-pushes CmdTx on the next TX cycle.
+    /// With <c>micControl == 0 &amp;&amp; lineInGain == 0</c> (the Host source) the
+    /// CmdTx tail is byte-identical to today. Re-pushing CmdTx on every change is
+    /// load-bearing — the radio keeps its last-remembered input otherwise
+    /// (pihpsdr transmit_specific risk).
+    /// </summary>
+    public void SetAudioFrontEndBytes(byte micControl, byte lineInGain)
+    {
+        _micControl = micControl;
+        _lineInGain = lineInGain;
+        if (_rxTask is not null) SendCmdTx();
     }
 
     // Test-seamed Compose for the CmdTx (TxSpecific) packet. Layout per
@@ -1438,12 +1509,19 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // 57/58/59) — operator's normal voice TX has been validated working
     // with that wire form on G2 MkII, so we don't ship a wire change
     // beyond the PS-armed window in this patch.
-    internal static byte[] ComposeCmdTxBuffer(uint seq, ushort sampleRateKhz, byte txStepAttnDb, bool paEnabled, bool psEnabled)
+    internal static byte[] ComposeCmdTxBuffer(uint seq, ushort sampleRateKhz, byte txStepAttnDb, bool paEnabled, bool psEnabled, byte micControl = 0, byte lineInGain = 0)
     {
         var p = new byte[60];
         WriteBeU32(p, 0, seq);
         p[4] = 1;                 // num_dac
         WriteBeU16(p, 14, sampleRateKhz);
+
+        // Audio front-end (external-audio-jacks re-port). Byte 50 = mic_control
+        // flags, byte 51 = line_in_gain — Thetis network.c:1234,1236. Both
+        // default 0, so an untouched audio front-end is byte-identical to the
+        // historical all-zero tail.
+        p[50] = micControl;
+        p[51] = lineInGain;
 
         if (psEnabled)
         {
@@ -1921,8 +1999,22 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
                     // because TxMetersService had no telemetry feed.
                     HandleHiPriStatusPacket(buf, n);
                 }
-                // mic samples (1026), wideband ADC0..7 (1027..1034)
-                // intentionally ignored for now — separate features.
+                else if (srcPort == 1026)
+                {
+                    // Radio-mic stream (external-audio-jacks re-port): the
+                    // radio's digitised analog jack (mic / line-in /
+                    // balanced-XLR), 4-byte BE seq + 64 × int16 BE @ 48 kHz =
+                    // 132 bytes (pihpsdr new_protocol.c process_mic_data).
+                    // Dropped unless a radio audio source is armed AND a handler
+                    // is attached — the volatile read is the only added cost
+                    // under Host. The handler decodes + re-blocks synchronously
+                    // on this thread.
+                    var radioMic = _radioMicHandler;
+                    if (radioMic is not null && n >= 132)
+                        radioMic(new ReadOnlySpan<byte>(buf, 0, n));
+                }
+                // wideband ADC0..7 (1027..1034) intentionally ignored — a
+                // separate feature.
             }
         }
         finally

--- a/Zeus.Server.Hosting/AudioSettingsStore.cs
+++ b/Zeus.Server.Hosting/AudioSettingsStore.cs
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// Global (per-radio, NOT per-band) TX-audio SOURCE selection (external-ports
+// plan, §2/§8). This REPLACES the prior four-bool AudioFrontEndSelection
+// (LineIn/MicBoost/MicBias/BalancedInput/LineInGain) — that model only set codec
+// mic-gain wire bits and never switched the TX pipeline, and it allowed illegal
+// combinations. The model is now a single mutually-exclusive
+// <see cref="Zeus.Contracts.TxAudioSource"/> selector PLUS the parameters that
+// apply to whichever radio jack is chosen (MicBoost, MicBias, LineInGain).
+//
+// Mirrors AntennaSettingsStore's LiteDB pattern but holds ONE global row instead
+// of a band-keyed collection — the audio source is a per-radio front-panel
+// state, not per-band. Upsert uses DeleteMany+Insert rather than Update/Upsert to
+// dodge the LiteDB `Id=0`-always-inserts bug (PR #387). The store is deliberately
+// board-agnostic; the persisted Source is clamped against the connected board's
+// capabilities at the RadioService push (a board that can't honour a jack falls
+// back to Host), so a value stored on one radio is simply ignored on another.
+//
+// LEGACY MIGRATION: a pre-rework DB carries an AudioFrontEndEntry row WITHOUT the
+// `Source` field. LiteDB is schema-less, so that row hydrates `Source` to its
+// default value 0 == TxAudioSource.Host — exactly the clean fallback the plan
+// requires (§8). The dropped `LineIn`/`BalancedInput` columns are simply ignored.
+
+using LiteDB;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+public sealed class AudioSettingsStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<AudioFrontEndEntry> _rows;
+    private readonly ILogger<AudioSettingsStore> _log;
+    private readonly object _sync = new();
+
+    // Fired on any write so RadioService can re-push the audio state to the
+    // live client — same pattern as AntennaSettingsStore.Changed.
+    public event Action? Changed;
+
+    public AudioSettingsStore(ILogger<AudioSettingsStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _rows = _db.GetCollection<AudioFrontEndEntry>("audio_frontend");
+
+        _log.LogInformation("AudioSettingsStore initialized at {Path}", dbPath);
+    }
+
+    /// <summary>
+    /// The persisted global TX-audio source state. A missing row (fresh install
+    /// / pre-feature DB) — AND a legacy four-bool row that has no
+    /// <c>Source</c> field — defaults to <see cref="TxAudioSource.Host"/>, the
+    /// radio's power-on state with the analog jacks suppressed. That default is
+    /// byte-identical to today's wire output on every board.
+    /// </summary>
+    public AudioSourceSelection Get()
+    {
+        lock (_sync)
+        {
+            var e = _rows.FindAll().FirstOrDefault();
+            return e is null
+                ? AudioSourceSelection.Default
+                : new AudioSourceSelection(
+                    Source: ClampSource(e.Source),
+                    MicBoost: e.MicBoost,
+                    MicBias: e.MicBias,
+                    LineInGain: ClampGain(e.LineInGain));
+        }
+    }
+
+    /// <summary>
+    /// Replace the global TX-audio source state. Uses DeleteMany+Insert so the
+    /// single global row is rewritten cleanly regardless of its Id (the LiteDB
+    /// Id=0-always-inserts bug, PR #387). mic_bias is stored as-given; the
+    /// REST / UI layer is responsible for the floating-connector guard.
+    /// </summary>
+    public void Set(AudioSourceSelection sel)
+    {
+        lock (_sync)
+        {
+            _rows.DeleteMany(_ => true);
+            _rows.Insert(new AudioFrontEndEntry
+            {
+                Source = (byte)ClampSource((byte)sel.Source),
+                MicBoost = sel.MicBoost,
+                MicBias = sel.MicBias,
+                LineInGain = ClampGain(sel.LineInGain),
+                UpdatedUtc = DateTime.UtcNow,
+            });
+        }
+        Changed?.Invoke();
+    }
+
+    // line_in_gain is a 5-bit field (0..31) on both the HL2 0x14 frame and the
+    // P2 TxSpecific byte 51. Clamp defensively on read/write so a stale value
+    // can never overflow the wire field.
+    private static byte ClampGain(int v) => (byte)Math.Clamp(v, 0, 31);
+
+    // An out-of-range persisted source byte (corruption / a future enum value an
+    // older build can't represent) falls back to Host rather than reaching the
+    // wire as an undefined selection.
+    private static TxAudioSource ClampSource(byte raw) =>
+        Enum.IsDefined(typeof(TxAudioSource), raw) ? (TxAudioSource)raw : TxAudioSource.Host;
+
+    public void Dispose() => _db.Dispose();
+}
+
+/// <summary>
+/// Resolved global TX-audio source selection (external-ports plan, §2).
+/// <see cref="Source"/> is the single mutually-exclusive selector; the remaining
+/// fields are PARAMETERS OF that source and apply only when the matching radio
+/// jack is chosen: <see cref="MicBoost"/>/<see cref="MicBias"/> for
+/// <see cref="TxAudioSource.RadioMic"/> (and MicBoost optionally for XLR),
+/// <see cref="LineInGain"/> (0..31) for <see cref="TxAudioSource.RadioLineIn"/>.
+/// Under <see cref="TxAudioSource.Host"/> none of the params reach the wire — the
+/// encoder is a pure function of Source and returns literal zero for Host.
+/// </summary>
+public sealed record AudioSourceSelection(
+    TxAudioSource Source,
+    bool MicBoost,
+    bool MicBias,
+    byte LineInGain)
+{
+    /// <summary>Power-on default: Host audio (radio jacks suppressed), no
+    /// boost/bias, gain 0 — byte-identical to today's wire output.</summary>
+    public static readonly AudioSourceSelection Default =
+        new(Source: TxAudioSource.Host, MicBoost: false, MicBias: false, LineInGain: 0);
+}
+
+/// <summary>
+/// Runtime audio front-end push payload (external-ports plan). RadioService fires
+/// this on <c>AudioFrontEndChanged</c>; DspPipelineService forwards it into the
+/// live Protocol2Client (TxSpecific bytes 50/51). The wire bytes are already
+/// resolved (board-clamped + Host-zeroed) by the time it is raised — the payload
+/// carries the literal byte-50 mic_control + byte-51 line_in_gain so the
+/// forwarder does no source interpretation of its own.
+/// </summary>
+public sealed record AudioFrontEndPush(
+    TxAudioSource Source,
+    byte MicControlByte,
+    byte LineInGain);
+
+public sealed class AudioFrontEndEntry
+{
+    public int Id { get; set; }
+    // The persisted TX-audio source (TxAudioSource as byte). LiteDB is
+    // schema-less, so a legacy four-bool row that predates this field hydrates
+    // Source = 0 == TxAudioSource.Host — the correct migration default.
+    public byte Source { get; set; }
+    // Per-source parameters. MicBoost/MicBias apply to RadioMic; LineInGain to
+    // RadioLineIn. All ignored under Host.
+    public bool MicBoost { get; set; }
+    public bool MicBias { get; set; }
+    // 0..31 line-in gain. Rows written before this feature hydrate this as 0,
+    // the correct legacy default.
+    public byte LineInGain { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/BoardCapabilitiesTable.cs
+++ b/Zeus.Server.Hosting/BoardCapabilitiesTable.cs
@@ -87,6 +87,11 @@ internal static class BoardCapabilitiesTable
             // keeps SupportsAnvelinaDxOc=false so the wire path stays
             // closed on G2 / 7000DLE / Apache OrionMkII original / etc.
             OrionMkIIVariant.AnvelinaPro3 => SaturnAnvelinaPro3,
+            // Red Pitaya — Saturn-class hardware but Thetis DISABLES the Orion
+            // mic-bias panel there (HasMicBias=false) and it has no balanced XLR.
+            OrionMkIIVariant.RedPitaya    => SaturnRedPitaya,
+            // 7000DLE and the default 0x0A fall to the Saturn baseline: analog
+            // line-in + Orion mic bias, NO balanced XLR (G2 / G2-1K only).
             _                             => Saturn,
         },
         // --- ANAN-G2E (HermesC10, N1GP) ---
@@ -115,7 +120,10 @@ internal static class BoardCapabilitiesTable
         HasAudioAmplifier: false,
         HasSteppedAttenuationRx2: false, // single-RX: RX2 doesn't exist
         SupportsPathIllustrator: true,
-        MaxPowerWatts: 10);
+        MaxPowerWatts: 10,
+        // Hermes-class codec board: radio mic jack selectable. No line-in / XLR
+        // / mic-bias surface (Hermes/ANAN-10/100 line-in is scoped OUT).
+        HasOnboardCodec: true);
 
     // ANAN-10E (HermesII firmware) — same Hermes-class fingerprint but the
     // 10E hardware is rated to ~30 W, so its meter axis gets the bigger top.
@@ -129,7 +137,12 @@ internal static class BoardCapabilitiesTable
         HasAudioAmplifier: false,
         HasSteppedAttenuationRx2: false,
         SupportsPathIllustrator: true,
-        MaxPowerWatts: 30);
+        MaxPowerWatts: 30,
+        // ANAN-10E (HermesII): codec + analog line-in jack (issue #667 fix is
+        // HermesII-only; Hermes/ANAN-10/100 line-in stays scoped OUT). No XLR /
+        // mic-bias.
+        HasOnboardCodec: true,
+        HasRadioLineIn: true);
 
     // ANAN-100D — 100 W class. Meter axis 120 W gives some headroom past
     // the rated rail without truncating PEP overshoots.
@@ -143,7 +156,11 @@ internal static class BoardCapabilitiesTable
         HasAudioAmplifier: false,
         HasSteppedAttenuationRx2: true,
         SupportsPathIllustrator: true,
-        MaxPowerWatts: 120);
+        MaxPowerWatts: 120,
+        // ANAN-100D: codec + analog line-in jack + Orion mic bias. No XLR.
+        HasOnboardCodec: true,
+        HasRadioLineIn: true,
+        HasMicBias: true);
 
     // ANAN-200D — 200 W class but axis matches the 100/200/G2 family at
     // 120 W: half-axis at 100 W is the natural reading point.
@@ -157,7 +174,12 @@ internal static class BoardCapabilitiesTable
         HasAudioAmplifier: false,
         HasSteppedAttenuationRx2: true,
         SupportsPathIllustrator: true,
-        MaxPowerWatts: 120);
+        MaxPowerWatts: 120,
+        // ANAN-200D (Orion): codec + analog line-in jack + Orion mic bias
+        // (Thetis ORION bias panel Enabled). No balanced XLR.
+        HasOnboardCodec: true,
+        HasRadioLineIn: true,
+        HasMicBias: true);
 
     // 0x0A family conservative baseline (7000DLE / 8000DLE / OrionMkII /
     // ANVELINA-PRO3 / Red Pitaya). Saturn-class facts. 100–200 W typical →
@@ -173,20 +195,36 @@ internal static class BoardCapabilitiesTable
         HasAudioAmplifier: true,
         HasSteppedAttenuationRx2: true,
         SupportsPathIllustrator: false,
-        MaxPowerWatts: 120);
+        MaxPowerWatts: 120,
+        // 0x0A Saturn baseline (7000DLE / 8000DLE / default): codec + analog
+        // line-in + Orion mic bias. NO balanced XLR — that is G2 / G2-1K only.
+        HasOnboardCodec: true,
+        HasRadioLineIn: true,
+        HasMicBias: true);
 
     // ANAN-G2 — local Thetis parity notes pin RX1/RX2 at
-    // 48/96/192/384/768/1536 kHz over Protocol 2.
+    // 48/96/192/384/768/1536 kHz over Protocol 2. Saturn-FPGA G2 / G2-1K
+    // additionally carry the switchable balanced-XLR mic input.
     private static readonly BoardCapabilities SaturnG2 = Saturn with
     {
         MaxRxSampleRateHz = 1_536_000,
         SupportsG2AdcOptions = true,
+        HasBalancedXlr = true,
     };
 
-    // ANAN-8000DLE — 250 W per Apache spec; axis snaps to that.
+    // ANAN-8000DLE — 250 W per Apache spec; axis snaps to that. Saturn-class
+    // audio (line-in + mic bias), NO balanced XLR (G2 / G2-1K only).
     private static readonly BoardCapabilities Saturn8000DLE = Saturn with
     {
         MaxPowerWatts = 250,
+    };
+
+    // Red Pitaya (DH1KLM) — Saturn-class hardware but Thetis DISABLES the Orion
+    // mic-bias panel for it (DIY connector foot-gun) and it has no balanced XLR.
+    // Analog line-in only.
+    private static readonly BoardCapabilities SaturnRedPitaya = Saturn with
+    {
+        HasMicBias = false,
     };
 
     // ANAN-G2-1K — kilowatt-class with internal 1 kW PA. Same Saturn fingerprint
@@ -200,9 +238,12 @@ internal static class BoardCapabilitiesTable
     // extension (USEROUT7..10) wired into P2 byte 1397 bits [4:1] —
     // issue #407, EU2AV's Open_Collector_Anvelina_DX for Thetis spec.
     // This is the only variant where SupportsAnvelinaDxOc flips true.
+    // ANVELINA-PRO3 (EU2AV) — Saturn-class plus DX OC. Thetis disables the Orion
+    // mic-bias panel here (DIY connector), so HasMicBias is forced false; no XLR.
     private static readonly BoardCapabilities SaturnAnvelinaPro3 = Saturn with
     {
         SupportsAnvelinaDxOc = true,
+        HasMicBias = false,
     };
 
     private static readonly BoardCapabilities HermesC10 = new(
@@ -215,7 +256,10 @@ internal static class BoardCapabilitiesTable
         HasAudioAmplifier: true,
         HasSteppedAttenuationRx2: false, // single-RX: RX2 doesn't exist
         SupportsPathIllustrator: false,
-        MaxPowerWatts: 120);
+        MaxPowerWatts: 120,
+        // ANAN-G2E: codec board (radio mic). No line-in / XLR (Thetis hard-gates
+        // balanced to G2 / G2-1K and excludes G2E) / mic-bias surface in v1.
+        HasOnboardCodec: true);
 
     // Apache OrionMkII original (Orion-MkII firmware, 100 W) — Saturn-class
     // hardware fingerprint but without on-board telemetry / audio amp per
@@ -231,7 +275,12 @@ internal static class BoardCapabilitiesTable
         HasAudioAmplifier: false,
         HasSteppedAttenuationRx2: true,
         SupportsPathIllustrator: false,
-        MaxPowerWatts: 120);
+        MaxPowerWatts: 120,
+        // Apache OrionMkII original: codec + analog line-in jack, NO balanced
+        // XLR (Saturn-FPGA G2 / G2-1K only) and HasMicBias stays FALSE per
+        // clsHardwareSpecific (ORIONMKII excluded from the bias panel).
+        HasOnboardCodec: true,
+        HasRadioLineIn: true);
 
     // HermesLite2 — rated 5 W stock but operators routinely run to 10 W with
     // adequate cooling, so the meter axis is 10 W to cover the realistic
@@ -253,5 +302,10 @@ internal static class BoardCapabilitiesTable
         HasSteppedAttenuationRx2: false,
         SupportsPathIllustrator: false,
         MaxPowerWatts: 10,
-        HasHl2OptionalToggles: true);
+        HasHl2OptionalToggles: true,
+        // HL2 has no stream codec, so HasOnboardCodec stays false — the Radio
+        // Mic / Line-In / XLR options are gated OFF. It DOES have a 0x14 mic
+        // front-end, exposed only as inert plumbing in v1 (default Host); the
+        // frontend surfaces nothing for it until confirmed on hardware.
+        HermesLite2MicFrontEnd: true);
 }

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -704,6 +704,19 @@ public class DspPipelineService : BackgroundService,
     // keeping it isolated avoids touching any P1 behavior.
     private Zeus.Protocol2.Protocol2Client? _p2Client;
 
+    // Radio-mic (UDP 1026) routing — external-audio-jacks re-port. The
+    // re-blocker buffers 64-sample 1026 packets into the 960-sample mic blocks
+    // TxAudioIngest consumes; it forwards into OnMicPcmBytesFromRadioMic, whose
+    // in-lock _activeSource gate drops them unless a radio jack is armed. The
+    // 1026 handler is attached to the live P2 client ONLY while a radio source
+    // is selected, so Host-default has zero added RX cost. Both are lazily wired
+    // (TxAudioIngest depends on this service, so it's resolved through a factory
+    // to avoid a DI cycle — feedback_di_cycle_iservice_provider pattern).
+    private readonly Func<TxAudioIngest?>? _txIngestFactory;
+    private TxAudioIngest? _txIngest;
+    private RadioMicReceiver? _radioMicReceiver;
+    private bool _radioMicAttached;
+
     private RxMode _appliedMode = RxMode.USB;
     private int _appliedLowHz;
     private int _appliedHighHz;
@@ -1029,7 +1042,8 @@ public class DspPipelineService : BackgroundService,
         ILoggerFactory loggerFactory,
         CwSidetoneSource? sidetone = null,
         FrontendDspSceneDiagnosticsService? frontendDspScene = null,
-        DisplaySettingsStore? displaySettings = null)
+        DisplaySettingsStore? displaySettings = null,
+        Func<TxAudioIngest?>? txIngestFactory = null)
     {
         _radio = radio;
         _hub = hub;
@@ -1040,7 +1054,25 @@ public class DspPipelineService : BackgroundService,
         _frontendDspScene = frontendDspScene;
         _loggerFactory = loggerFactory;
         _displaySettings = displaySettings;
+        _txIngestFactory = txIngestFactory;
         _log = loggerFactory.CreateLogger<DspPipelineService>();
+    }
+
+    // Lazily resolve TxAudioIngest (DI cycle avoidance — see field comment) and
+    // build the radio-mic re-blocker on first use. Returns null in tests that
+    // didn't supply a factory; the radio-mic path then simply no-ops.
+    private TxAudioIngest? ResolveTxIngest()
+    {
+        if (_txIngest is not null) return _txIngest;
+        _txIngest = _txIngestFactory?.Invoke();
+        if (_txIngest is not null && _radioMicReceiver is null)
+        {
+            var ingest = _txIngest;
+            _radioMicReceiver = new RadioMicReceiver(
+                block => ingest.OnMicPcmBytesFromRadioMic(block),
+                _loggerFactory.CreateLogger<RadioMicReceiver>());
+        }
+        return _txIngest;
     }
 
     // Persisted TX display analyzer config (live TX waterfall feature). Optional
@@ -1120,6 +1152,11 @@ public class DspPipelineService : BackgroundService,
         _radio.Disconnected += OnRadioDisconnected;
         _radio.StateChanged += OnRadioStateChanged;
         _radio.PaSnapshotChanged += OnPaSnapshotChanged;
+        // Audio front-end (external-audio-jacks re-port) — global per-radio.
+        // RadioService can't reach the P2 client directly (ActiveClient is
+        // P1-only), so forward TxSpecific bytes 50/51 here, and route the
+        // radio-mic STREAM (1026) gate.
+        _radio.AudioFrontEndChanged += OnAudioFrontEndChanged;
         _radio.MoxChanged += OnRadioMoxChanged;
         _radio.TunActiveChanged += OnRadioTunActiveChanged;
         _radio.PreampChanged += OnRadioPreampChanged;
@@ -1157,6 +1194,7 @@ public class DspPipelineService : BackgroundService,
             _radio.Disconnected -= OnRadioDisconnected;
             _radio.StateChanged -= OnRadioStateChanged;
             _radio.PaSnapshotChanged -= OnPaSnapshotChanged;
+            _radio.AudioFrontEndChanged -= OnAudioFrontEndChanged;
             _radio.MoxChanged -= OnRadioMoxChanged;
             _radio.TunActiveChanged -= OnRadioTunActiveChanged;
             _radio.PreampChanged -= OnRadioPreampChanged;
@@ -3876,6 +3914,11 @@ public class DspPipelineService : BackgroundService,
         // Push current PA snapshot into the brand-new client so byte 345 /
         // byte 1401 / CmdGeneral[58] reflect PaSettingsStore from frame 1.
         _radio.ReplayPaSnapshot();
+        // Push the persisted audio front-end (TxSpecific bytes 50/51) into the
+        // fresh P2 client so mic/line-in/boost/bias/gain are correct from the
+        // first CmdTx, not deferred until a store edit. No-op on boards without
+        // an audio front-end (gated + OFF defaults).
+        _radio.ReplayAudioFrontEnd();
         return sampleRateKhz;
     }
 
@@ -3891,6 +3934,69 @@ public class DspPipelineService : BackgroundService,
         // stay at zero per EU2AV's reserved-bit rule.
         p2.SetOcDxMasks(snap.OcDxTxMask, snap.OcDxRxMask);
         p2.SetPaEnabled(snap.PaEnabled);
+    }
+
+    private void OnAudioFrontEndChanged(AudioFrontEndPush a)
+    {
+        // Route the radio-mic STREAM (external-audio-jacks re-port, §3). This
+        // runs on EVERY resolved-source push (store edit AND connect, via
+        // ReplayAudioFrontEnd) so the pipeline's active source tracks the wire
+        // bytes. Done BEFORE the byte forward and independent of _p2Client so a
+        // switch back to Host always quiesces the gate even mid-disconnect.
+        ApplyRadioMicRouting(a.Source);
+
+        var p2 = _p2Client;
+        if (p2 is null) return;
+        // TxSpecific byte 50 mic_control flags + byte 51 line_in_gain, already
+        // RESOLVED (board-clamped + source-encoded, Host → 0) by
+        // RadioService.PushAudioFrontEnd. The forwarder pushes the literal bytes
+        // with no source interpretation of its own.
+        p2.SetAudioFrontEndBytes(a.MicControlByte, a.LineInGain);
+    }
+
+    // Arm/disarm the radio-mic stream for a resolved TxAudioSource
+    // (external-audio-jacks re-port, §3, atomic single-select). Idempotent and
+    // cheap on Host (the common case): it sets the in-lock _activeSource on
+    // TxAudioIngest (which quiesces its WDSP accumulator), resets the 1026
+    // re-blocker so no pre-switch audio stitches onto the post-switch source,
+    // and attaches / detaches the UDP-1026 decode on the live P2 client so there
+    // is zero added RX cost while Host is selected. P1 radios have no 1026
+    // stream — the handler simply never fires there; the _activeSource gate still
+    // arbitrates host vs (absent) radio harmlessly.
+    private void ApplyRadioMicRouting(TxAudioSource source)
+    {
+        var ingest = ResolveTxIngest();
+        if (ingest is null) return;
+
+        bool radioActive = source != TxAudioSource.Host;
+
+        // Arm the in-lock single-select gate FIRST. Under TxAudioIngest._sync
+        // this flips _activeSource and clears its half-written WDSP block, so the
+        // instant the gate is armed the host mic is dropped (radio armed) or the
+        // radio mic is dropped (Host armed) — no overlap window.
+        ingest.SetActiveSource(source);
+
+        // Always reset the re-blocker on any switch so a <960-sample remainder
+        // of the old source can't stitch onto the new one.
+        _radioMicReceiver?.Reset();
+
+        var p2 = _p2Client;
+        if (radioActive)
+        {
+            // Subscribe the 1026 decode only while a radio jack is armed. No-op
+            // if already attached or if P1 (no 1026 stream / null p2Client).
+            if (!_radioMicAttached && p2 is not null && _radioMicReceiver is not null)
+            {
+                var rb = _radioMicReceiver;
+                p2.AttachRadioMicHandler(rb.Accept);
+                _radioMicAttached = true;
+            }
+        }
+        else if (_radioMicAttached)
+        {
+            p2?.DetachRadioMicHandler();
+            _radioMicAttached = false;
+        }
     }
 
     private void OnRadioMoxChanged(bool on)
@@ -4040,6 +4146,12 @@ public class DspPipelineService : BackgroundService,
         // and no further callbacks land. client.StopAsync joins the RX task,
         // so by the time it returns the RX thread is gone.
         DetachRxSinkP2();
+        // The 1026 radio-mic handler is bound to this client instance; clear our
+        // attach latch so a reconnect (which re-fires ReplayAudioFrontEnd) re-
+        // attaches against the fresh client. The handler reference dies with the
+        // disposed client. Quiesce the re-blocker so no stale remainder survives.
+        _radioMicAttached = false;
+        _radioMicReceiver?.Reset();
         try { await client.StopAsync(ct).ConfigureAwait(false); } catch { }
         await client.DisposeAsync().ConfigureAwait(false);
 

--- a/Zeus.Server.Hosting/ExternalPortEncoder.cs
+++ b/Zeus.Server.Hosting/ExternalPortEncoder.cs
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// External-port AUDIO encoder seam (external-audio-jacks re-port).
+//
+// This is the FIREWALL for the TX audio-source feature: every audio-front-end
+// bit on the wire — P2 TxSpecific byte-50 mic_control / byte-51 line_in_gain,
+// and the P1 0x12-codec mic_boost/mic_linein bits — is composed behind one
+// board-branched / protocol-branched encoder instead of scattered bit literals
+// in the emission code.
+//
+// Default-inert / byte-identical: at defaults (Host, no boost/bias, gain 0) the
+// encoder produces literal zero on every surface, so the wire bytes are
+// unchanged on every board. The PureSignal golden suites stay green.
+//
+// (The sibling antenna / OC encoder surfaces from the original external-ports
+// plan are NOT part of this audio re-port — they land separately. This seam
+// carries audio only.)
+
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Immutable canonical desired TX-audio-source state. Protocol-agnostic — holds
+/// no wire bits, only the operator-meaningful selection. Global per-radio (NOT
+/// per-band). The wire bytes are PURE FUNCTIONS of <see cref="Source"/> (plus
+/// that source's params).
+///
+/// Source == <see cref="TxAudioSource.Host"/> → every audio surface is literal
+/// zero, byte-identical to today; the encoder must NOT fall through to read the
+/// params under Host.
+/// </summary>
+public readonly record struct ExternalPortState(
+    /// <summary>The single mutually-exclusive TX-audio source.</summary>
+    TxAudioSource Source = TxAudioSource.Host,
+    /// <summary>Mic boost — parameter of <see cref="TxAudioSource.RadioMic"/>
+    /// (and optionally XLR). Ignored under Host / RadioLineIn.</summary>
+    bool MicBoost = false,
+    /// <summary>Mic bias enable — parameter of <see cref="TxAudioSource.RadioMic"/>
+    /// (and XLR). DEFAULTS OFF — enabling on a floating connector can hang PTT;
+    /// the gate guards it. Ignored under Host / RadioLineIn.</summary>
+    bool MicBias = false,
+    /// <summary>Line-in gain, 0..31 — parameter of
+    /// <see cref="TxAudioSource.RadioLineIn"/>. Ignored under every other
+    /// source.</summary>
+    byte LineInGain = 0)
+{
+    /// <summary>Default state: Host audio, no boost/bias, gain 0 — reproduces
+    /// today's wire emission bit-for-bit on every board.</summary>
+    public static readonly ExternalPortState Default = new();
+}
+
+/// <summary>
+/// Per-board / per-protocol TX-audio bit encoder. Mirrors
+/// <see cref="IRadioDriveProfile"/>'s seam: a small strategy interface,
+/// concrete per-protocol implementations, and an
+/// <see cref="ExternalPortEncoders.For(HpsdrBoardKind, OrionMkIIVariant, RadioProtocol)"/>
+/// dispatch. This is the single place external-port audio bit math lives.
+/// </summary>
+public interface IExternalPortEncoder
+{
+    /// <summary>Diagnostic label for the encoder strategy.</summary>
+    string Label { get; }
+
+    /// <summary>
+    /// Encode the Protocol-2 TxSpecific (port 1026) byte-50 mic_control flags as
+    /// a PURE FUNCTION of <see cref="ExternalPortState.Source"/>. Only emitted on
+    /// codec boards; a board without <see cref="BoardCapabilities.HasOnboardCodec"/>
+    /// returns 0 so its TxSpecific tail stays byte-identical to today. Bit layout
+    /// (Thetis network.c:1226-1233): bit0=line_in, bit1=mic_boost, bit4=mic_bias,
+    /// bit5=balanced/XLR. <see cref="TxAudioSource.Host"/> returns LITERAL 0 with
+    /// NO fallthrough that reads the params, so a persisted non-zero
+    /// MicBoost/MicBias can never leak onto the wire after a revert to Host.
+    /// Pairs with <see cref="EncodeP2LineInGainByte"/> (byte 51).
+    /// </summary>
+    byte EncodeP2MicControlByte(in ExternalPortState state);
+
+    /// <summary>
+    /// Encode the Protocol-2 TxSpecific byte-51 line_in_gain (0..31). Non-zero
+    /// ONLY for <see cref="TxAudioSource.RadioLineIn"/>; every other source
+    /// (including Host) returns 0 so the radio's last-remembered gain is cleared
+    /// the moment line-in is deselected. Pure function of Source.
+    /// </summary>
+    byte EncodeP2LineInGainByte(in ExternalPortState state);
+
+    /// <summary>
+    /// Resolve the Protocol-1 codec (0x12 DriveFilter frame) audio bits as a
+    /// PURE FUNCTION of <see cref="ExternalPortState.Source"/>. C2[0]=mic_boost,
+    /// C2[1]=mic_linein. <see cref="TxAudioSource.RadioMic"/> drives mic_boost
+    /// from the param; every other source (Host included) returns
+    /// <c>(false,false)</c> — no param leak. RadioLineIn is intentionally
+    /// unreachable on pure-P1 codec boards in v1 (no P1 radio-mic RX path), so
+    /// mic_linein stays clear. HL2 is Host-only and never calls this.
+    /// </summary>
+    (bool MicBoost, bool MicLineIn) EncodeP1CodecAudioBits(in ExternalPortState state);
+}
+
+/// <summary>
+/// Protocol-1 encoder for codec / Alex boards (Hermes-class, ANAN-100D/200D,
+/// ANAN-G2E). Carries mic_boost / mic_linein on the 0x12 codec frame; no P2
+/// TxSpecific bytes.
+/// </summary>
+public sealed class Protocol1PortEncoder : IExternalPortEncoder
+{
+    private readonly HpsdrBoardKind _board;
+
+    public Protocol1PortEncoder(HpsdrBoardKind board) => _board = board;
+
+    public string Label => $"P1({_board})";
+
+    public byte EncodeP2MicControlByte(in ExternalPortState state)
+        // P1 codec boards carry mic_boost/mic_linein on the 0x12 frame, not the
+        // P2 TxSpecific byte 50.
+        => 0;
+
+    public byte EncodeP2LineInGainByte(in ExternalPortState state)
+        // P1 boards have no P2 TxSpecific byte 51.
+        => 0;
+
+    public (bool MicBoost, bool MicLineIn) EncodeP1CodecAudioBits(in ExternalPortState state)
+        // Pure function of Source: RadioMic → mic_boost; Host / everything else
+        // → all clear (no param leak).
+        => ExternalPortAudio.P1CodecAudioBits(state.Source, state.MicBoost);
+}
+
+/// <summary>
+/// Protocol-2 encoder for the 0x0A / Saturn family (G2 / 7000DLE / 8000DLE /
+/// G2-1K / OrionMkII original / ANVELINA-PRO3 / Red Pitaya). Audio rides the
+/// TxSpecific byte 50 (mic_control) / byte 51 (line_in_gain).
+/// </summary>
+public sealed class Protocol2PortEncoder : IExternalPortEncoder
+{
+    private readonly HpsdrBoardKind _board;
+    private readonly OrionMkIIVariant _variant;
+    private readonly bool _hasOnboardCodec;
+
+    public Protocol2PortEncoder(HpsdrBoardKind board, OrionMkIIVariant variant, bool hasOnboardCodec)
+    {
+        _board = board;
+        _variant = variant;
+        _hasOnboardCodec = hasOnboardCodec;
+    }
+
+    public string Label => $"P2({_board}/{_variant})";
+
+    public byte EncodeP2MicControlByte(in ExternalPortState state)
+    {
+        // Gate on codec presence: a board without the stream codec gets the
+        // zero byte, so its TxSpecific tail is byte-identical to today. The
+        // shared helper is the single source of the byte-50 bit math, computed
+        // PURELY from the source — Host returns literal 0 with no param read.
+        if (!_hasOnboardCodec) return 0;
+        return ExternalPortAudio.P2MicControlByte(state.Source, state.MicBoost, state.MicBias);
+    }
+
+    public byte EncodeP2LineInGainByte(in ExternalPortState state)
+    {
+        // byte 51 is non-zero only for RadioLineIn; suppressed (0) for every
+        // other source so a deselected line-in jack drops its remembered gain.
+        if (!_hasOnboardCodec) return 0;
+        return ExternalPortAudio.P2LineInGainByte(state.Source, state.LineInGain);
+    }
+
+    public (bool MicBoost, bool MicLineIn) EncodeP1CodecAudioBits(in ExternalPortState state)
+        // P2 boards do not use the P1 0x12 codec frame.
+        => (false, false);
+}
+
+/// <summary>
+/// Shared PURE audio-source bit math. Single source of truth for the P2
+/// TxSpecific byte-50 mic_control / byte-51 line_in_gain layout (Thetis
+/// network.c:1226-1233) and the P1 0x12 codec bits, computed straight from
+/// <see cref="TxAudioSource"/> so the encoder seam and any test agree.
+///
+/// CRUCIAL PURITY INVARIANT: <see cref="TxAudioSource.Host"/> returns literal 0
+/// on every surface WITHOUT reading MicBoost/MicBias/LineInGain — a persisted
+/// non-zero param must never leak onto the wire after a revert to Host. The
+/// switch's Host arm short-circuits before any param is consulted.
+/// </summary>
+internal static class ExternalPortAudio
+{
+    // TxSpecific byte-50 mic_control flags (Thetis network.c:1226-1233).
+    private const byte LineInBit   = 0x01; // bit0 — line-in select
+    private const byte MicBoostBit = 0x02; // bit1 — mic boost
+    private const byte MicBiasBit  = 0x10; // bit4 — enable Orion mic bias
+    private const byte XlrBit      = 0x20; // bit5 — balanced/XLR input (Saturn)
+
+    /// <summary>P2 byte-50 mic_control as a pure function of the source.</summary>
+    public static byte P2MicControlByte(TxAudioSource source, bool micBoost, bool micBias) => source switch
+    {
+        // Host: literal zero, no param read. The analog jacks are suppressed.
+        TxAudioSource.Host => 0,
+        // RadioMic: boost (bit1) + bias (bit4) from the params, mic jack implied
+        // (no line-in / XLR bit).
+        TxAudioSource.RadioMic =>
+            (byte)((micBoost ? MicBoostBit : 0) | (micBias ? MicBiasBit : 0)),
+        // RadioLineIn: line-in select (bit0); gain rides byte 51. Mic params do
+        // not apply.
+        TxAudioSource.RadioLineIn => LineInBit,
+        // RadioBalancedXlr: XLR select (bit5) | optional boost/bias (the XLR
+        // front-end still honours the Orion mic-bias / boost stage on G2).
+        TxAudioSource.RadioBalancedXlr =>
+            (byte)(XlrBit | (micBoost ? MicBoostBit : 0) | (micBias ? MicBiasBit : 0)),
+        _ => 0,
+    };
+
+    /// <summary>P2 byte-51 line_in_gain — non-zero ONLY for RadioLineIn.</summary>
+    public static byte P2LineInGainByte(TxAudioSource source, byte lineInGain) =>
+        source == TxAudioSource.RadioLineIn ? (byte)(lineInGain & 0x1F) : (byte)0;
+
+    /// <summary>P1 0x12 codec bits (mic_boost C2[0], mic_linein C2[1]) as a pure
+    /// function of the source. RadioMic drives mic_boost; everything else,
+    /// including Host, returns all-clear — no param leak.</summary>
+    public static (bool MicBoost, bool MicLineIn) P1CodecAudioBits(TxAudioSource source, bool micBoost) => source switch
+    {
+        TxAudioSource.RadioMic => (micBoost, false),
+        // RadioLineIn is unreachable on pure-P1 codec boards in v1 (no P1
+        // radio-mic RX path); Host/XLR are not P1-codec sources. All clear.
+        _ => (false, false),
+    };
+}
+
+/// <summary>
+/// Hermes-Lite 2 encoder. HL2 has no stream codec and no P2 TxSpecific frame;
+/// its mic front-end rides the 0x14 frame and is handled in
+/// <c>ControlFrame</c> via the read-modify-write that preserves the PureSignal
+/// bit + C4 PGA. This encoder emits no codec audio bits — the HL2 0x14 mic
+/// fields are driven directly through <c>IProtocol1Client.SetAudioFrontEnd</c>.
+/// </summary>
+public sealed class HermesLite2PortEncoder : IExternalPortEncoder
+{
+    public string Label => "HL2(0x14 mic front-end)";
+
+    public byte EncodeP2MicControlByte(in ExternalPortState state)
+        // HL2 has no stream codec and no P2 TxSpecific frame at all.
+        => 0;
+
+    public byte EncodeP2LineInGainByte(in ExternalPortState state)
+        // HL2 has no P2 TxSpecific byte 51.
+        => 0;
+
+    public (bool MicBoost, bool MicLineIn) EncodeP1CodecAudioBits(in ExternalPortState state)
+        // HL2 is not a stream-codec board — its 0x12 codec audio bits stay
+        // clear. The HL2 mic front-end (0x14) is encoded in ControlFrame.
+        => (false, false);
+}
+
+/// <summary>
+/// Which transport a connected board uses, for encoder dispatch. The 0x0A
+/// family runs Protocol 2 in Zeus; every other supported board runs Protocol 1.
+/// </summary>
+public enum RadioProtocol
+{
+    Protocol1,
+    Protocol2,
+}
+
+/// <summary>
+/// Per-board / per-protocol dispatch for <see cref="IExternalPortEncoder"/>.
+/// Mirrors <see cref="RadioDriveProfiles.For"/>. Every <see cref="HpsdrBoardKind"/>
+/// maps to a non-null encoder (the board-coverage test asserts this).
+/// </summary>
+public static class ExternalPortEncoders
+{
+    /// <summary>
+    /// Resolve the external-port audio encoder for a connected board. The
+    /// protocol is derived from the board kind when not given explicitly: the
+    /// 0x0A OrionMkII family is Protocol 2, everything else Protocol 1.
+    /// </summary>
+    public static IExternalPortEncoder For(
+        HpsdrBoardKind board,
+        OrionMkIIVariant variant = OrionMkIIVariant.G2,
+        RadioProtocol? protocol = null)
+    {
+        var caps = BoardCapabilitiesTable.For(board, variant);
+        var p = protocol ?? DefaultProtocolFor(board);
+
+        // HL2 first — it is the no-codec special case (mic front-end rides the
+        // 0x14 frame, handled in ControlFrame).
+        if (board == HpsdrBoardKind.HermesLite2)
+            return new HermesLite2PortEncoder();
+
+        return p == RadioProtocol.Protocol2
+            ? new Protocol2PortEncoder(board, variant, caps.HasOnboardCodec)
+            : new Protocol1PortEncoder(board);
+    }
+
+    /// <summary>The transport Zeus uses for a given board kind.</summary>
+    public static RadioProtocol DefaultProtocolFor(HpsdrBoardKind board) => board switch
+    {
+        HpsdrBoardKind.OrionMkII => RadioProtocol.Protocol2,
+        _                        => RadioProtocol.Protocol1,
+    };
+}

--- a/Zeus.Server.Hosting/NativeMicCapture.cs
+++ b/Zeus.Server.Hosting/NativeMicCapture.cs
@@ -285,17 +285,25 @@ internal sealed class NativeMicCapture : IHostedService, IDisposable
                 // are discarded — TxAudioIngest still gets the unmodified
                 // mic block via FlushBlock, so the on-air audio path is
                 // bit-identical to the no-preview case.
-                try
+                // Only run the host-mic plugin preview when Host is the active
+                // source. When a radio jack is selected the host mic is off the
+                // air, so its per-plugin IN / OUT / GR preview meters must not
+                // animate from it either (same source-awareness as the level
+                // meter above).
+                if (_ingest.ActiveSource == MicBlockSource.Host)
                 {
-                    _bridge.ProcessLivePreview(
-                        new ReadOnlySpan<float>(_accum, 0, MicBlockSamples),
-                        sampleRate: 48_000);
-                }
-                catch (Exception ex)
-                {
-                    if (++_previewErrLogged <= 4)
-                        _log.LogWarning(ex,
-                            "audio.native.tx plugin preview threw (suppressed after 4)");
+                    try
+                    {
+                        _bridge.ProcessLivePreview(
+                            new ReadOnlySpan<float>(_accum, 0, MicBlockSamples),
+                            sampleRate: 48_000);
+                    }
+                    catch (Exception ex)
+                    {
+                        if (++_previewErrLogged <= 4)
+                            _log.LogWarning(ex,
+                                "audio.native.tx plugin preview threw (suppressed after 4)");
+                    }
                 }
 
                 FlushBlock();
@@ -307,13 +315,24 @@ internal sealed class NativeMicCapture : IHostedService, IDisposable
 
     private void FlushPeakWindow()
     {
+        // The mic meter must reflect the ACTIVE TX audio source, not always the
+        // host mic. When the operator selects a radio jack (Radio Mic / Line In /
+        // Balanced) the host mic is gated off the air in TxAudioIngest — and it
+        // must drop off the METER too, otherwise the operator sees host-mic level
+        // on a radio source with nothing connected (the meter would "lie"). So:
+        //   Host source  → this device's host-mic window peak.
+        //   Radio source → the radio-jack peak TxAudioIngest tracked, which is
+        //                   silence (0) when no UDP-1026 audio is arriving.
+        // Either way this is a steady ~10 Hz heartbeat, so a radio source with no
+        // input falls to silence rather than freezing on the last host value.
+        //
         // Convert linear peak (0..1) to dBFS via the shared converter on the
         // contract type. Flooring + clipping happens inside LinearToDbfs.
-        // Timestamp the frame here so a client can detect mic-stream stalls
-        // (e.g. if the OS unplugs the input device, the frame stops
-        // arriving and the operator sees the meter freeze rather than fall
-        // to silence — that's the right behaviour).
-        float peakDbfs = MicPeakFrame.LinearToDbfs(_peakWindow);
+        // Timestamp the frame here so a client can detect mic-stream stalls.
+        float peakLinear = _ingest.ActiveSource == MicBlockSource.Host
+            ? _peakWindow
+            : _ingest.ConsumeRadioPeakLinear();
+        float peakDbfs = MicPeakFrame.LinearToDbfs(peakLinear);
         long tsUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
         try
         {

--- a/Zeus.Server.Hosting/RadioMicReceiver.cs
+++ b/Zeus.Server.Hosting/RadioMicReceiver.cs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Distributed under the GNU General Public License v2 or later. See the
+// LICENSE file at the root of this repository for full text.
+
+using System.Buffers.Binary;
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Decoder + 960-sample re-blocker for the Saturn radio-mic stream (UDP 1026,
+/// external-ports plan, §3). The radio digitises its analog jack (mic / line-in
+/// / balanced-XLR) and ships 64 samples per packet at 48 kHz; downstream
+/// <see cref="TxAudioIngest.OnMicPcmBytesFromRadioMic"/> hard-rejects anything
+/// that isn't exactly 960 samples / 3840 bytes (<c>MicBlockBytes</c>). A raw
+/// 64-sample block would be counted as a dropped frame → dead air. So, exactly
+/// as <see cref="Zeus.Server.Tci.TciTxAudioReceiver"/> does for arbitrary TCI
+/// chunk sizes, this buffers the 64-sample/packet f32-mono stream and emits only
+/// full 3840-byte blocks, carrying the &lt;960-sample remainder across packets.
+/// No resampler — the 1026 stream is natively 48 kHz; only the block SIZE is
+/// repacked.
+///
+/// Packet format (verified against pihpsdr <c>src/new_protocol.c</c>
+/// <c>process_mic_data</c>, lines 2694-2714; <c>MIC_LINE_TO_HOST_PORT = 1026</c>,
+/// <c>MIC_SAMPLES = 64</c>):
+///   bytes 0..3  : 4-byte big-endian sequence number
+///   bytes 4..131: 64 × int16 BIG-ENDIAN samples → f32 mono via × (1 / 2^15)
+///   total = 4 + 64×2 = 132 bytes
+///
+/// Threading: <see cref="Accept"/> runs on the Protocol2Client RX loop thread.
+/// The mono accumulator is guarded by <see cref="_sync"/> so a <see cref="Reset"/>
+/// (issued on any source switch) doesn't tear a packet mid-decode. The forward
+/// delegate is invoked under the lock — it lands in
+/// <see cref="TxAudioIngest.OnMicPcmBytesFromRadioMic"/>, whose own _sync is a
+/// different object, so there is no lock nesting on a shared monitor.
+/// </summary>
+internal sealed class RadioMicReceiver
+{
+    /// <summary>Sample count carried in one 1026 packet (pihpsdr MIC_SAMPLES).</summary>
+    public const int PacketSamples = 64;
+    /// <summary>Header (4 B seq) + 64 × int16 = 132 bytes.</summary>
+    public const int PacketBytes = 4 + PacketSamples * 2;
+
+    /// <summary>Mic block size <see cref="TxAudioIngest"/> consumes (20 ms @ 48 kHz).</summary>
+    public const int OutputBlockSamples = 960;
+    private const int OutputBlockBytes = OutputBlockSamples * 4;
+
+    // Worst-case headroom: 960-sample block + one full 64-sample packet.
+    private const int AccumulatorCapacity = OutputBlockSamples + PacketSamples + 64;
+
+    // int16 full-scale → f32. Matches pihpsdr's literal 0.00003051 (≈ 1/32768).
+    private const float Int16ToFloat = 1.0f / 32768.0f;
+
+    private readonly Action<ReadOnlyMemory<byte>> _forward;
+    private readonly ILogger _log;
+
+    private readonly object _sync = new();
+    private readonly float[] _monoAccumulator = new float[AccumulatorCapacity];
+    private int _monoFill;
+    private readonly byte[] _outputBuffer = new byte[OutputBlockBytes];
+
+    private long _totalPacketsAccepted;
+    private long _totalPacketsDropped;
+    private long _totalBlocksForwarded;
+
+    public RadioMicReceiver(Action<ReadOnlyMemory<byte>> forwardF32leMicBlock, ILogger log)
+    {
+        _forward = forwardF32leMicBlock ?? throw new ArgumentNullException(nameof(forwardF32leMicBlock));
+        _log = log;
+    }
+
+    public long TotalPacketsAccepted { get { lock (_sync) return _totalPacketsAccepted; } }
+    public long TotalPacketsDropped { get { lock (_sync) return _totalPacketsDropped; } }
+    public long TotalBlocksForwarded { get { lock (_sync) return _totalBlocksForwarded; } }
+
+    /// <summary>
+    /// Decode one UDP-1026 packet (4-byte BE seq + 64 × int16 BE @ 48 kHz),
+    /// append the 64 mono samples to the re-block accumulator, and forward every
+    /// full 960-sample block. The sequence header is skipped — gap detection is
+    /// not needed for TX audio (a dropped packet is a 1.3 ms silence the
+    /// accumulator simply doesn't see).
+    /// </summary>
+    public void Accept(ReadOnlySpan<byte> packet)
+    {
+        if (packet.Length < PacketBytes)
+        {
+            lock (_sync) _totalPacketsDropped++;
+            return;
+        }
+
+        lock (_sync)
+        {
+            if (_monoFill + PacketSamples > _monoAccumulator.Length)
+            {
+                // Producer outran the WDSP consumer (shouldn't happen at 48 kHz
+                // / 64-sample cadence vs. WDSP block drain). Flush + drop.
+                _log.LogWarning("radiomic overflow fill={Fill} cap={Cap}", _monoFill, _monoAccumulator.Length);
+                _monoFill = 0;
+                _totalPacketsDropped++;
+                return;
+            }
+
+            int b = 4; // skip the 4-byte BE sequence header
+            for (int i = 0; i < PacketSamples; i++, b += 2)
+            {
+                short s = BinaryPrimitives.ReadInt16BigEndian(packet.Slice(b, 2));
+                _monoAccumulator[_monoFill + i] = s * Int16ToFloat;
+            }
+            _monoFill += PacketSamples;
+            _totalPacketsAccepted++;
+
+            int writeOffset = 0;
+            while (_monoFill - writeOffset >= OutputBlockSamples)
+            {
+                for (int i = 0; i < OutputBlockSamples; i++)
+                {
+                    BinaryPrimitives.WriteSingleLittleEndian(
+                        _outputBuffer.AsSpan(i * 4, 4),
+                        _monoAccumulator[writeOffset + i]);
+                }
+                _forward(_outputBuffer);
+                writeOffset += OutputBlockSamples;
+                _totalBlocksForwarded++;
+            }
+
+            // Shift the remainder (< 960 samples) to the head.
+            int remainder = _monoFill - writeOffset;
+            if (remainder > 0 && writeOffset > 0)
+                Array.Copy(_monoAccumulator, writeOffset, _monoAccumulator, 0, remainder);
+            _monoFill = remainder;
+        }
+    }
+
+    /// <summary>
+    /// Drop any in-flight (&lt; 960-sample) remainder. Called on ANY TX-audio
+    /// source switch so pre-switch radio audio is never stitched onto the
+    /// post-switch source (external-ports plan, §3: "clear/reset this
+    /// accumulator on any source switch").
+    /// </summary>
+    public void Reset()
+    {
+        lock (_sync) _monoFill = 0;
+    }
+}

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -67,6 +67,9 @@ public sealed class RadioService : IDisposable
     private readonly PsSettingsStore? _psStore;
     private readonly FilterPresetStore? _filterPresetStore;
     private readonly RadioStateStore? _radioStateStore;
+    // Global (per-radio, NOT per-band) TX-audio source selection. Pushed via
+    // PushAudioFrontEnd on store edit + connect (external-audio-jacks re-port).
+    private readonly AudioSettingsStore? _audioStore;
     // Cached PS board key for the currently-connected radio. Set by
     // ApplyPsHwPeakForConnection (P1 or P2 connect path) and read by
     // PersistPsState to route HW Peak writes to the correct per-board slot.
@@ -246,13 +249,21 @@ public sealed class RadioService : IDisposable
     /// fresh-engine connect to re-apply notches the new WDSP channel lost.</summary>
     public IReadOnlyList<NotchDto> Notches { get { lock (_sync) return _notches.ToArray(); } }
 
+    /// <summary>Fires whenever the global audio front-end state changes (store
+    /// edit or connect). The wire bytes are RESOLVED (board-clamped + source-
+    /// encoded) by PushAudioFrontEnd; this event lets DspPipelineService forward
+    /// the same state into a live Protocol2Client (TxSpecific bytes 50/51) and
+    /// route the radio-mic STREAM gate. Audio is decoupled from PureSignal /
+    /// antenna / K36 — it never touches the alex word or PS bit.</summary>
+    public event Action<AudioFrontEndPush>? AudioFrontEndChanged;
+
     // Shared TX IQ source threaded through Protocol1Client. TxAudioIngest
     // writes into the same instance; this is the seam between "mic arrived
     // over WS" and "EP2 packet got real IQ". When null the client falls back
     // to its internal test-tone generator (dev / tests without a hub).
     private readonly Zeus.Protocol1.ITxIqSource? _txIqSource;
 
-    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, FilterPresetStore? filterPresetStore = null, Zeus.Protocol1.ITxIqSource? txIqSource = null, PreferredRadioStore? preferredRadioStore = null, PsSettingsStore? psStore = null, RadioStateStore? radioStateStore = null, CwSettingsStore? cwSettingsStore = null, TxAudioProfileStore? txAudioProfileStore = null)
+    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, FilterPresetStore? filterPresetStore = null, Zeus.Protocol1.ITxIqSource? txIqSource = null, PreferredRadioStore? preferredRadioStore = null, PsSettingsStore? psStore = null, RadioStateStore? radioStateStore = null, CwSettingsStore? cwSettingsStore = null, TxAudioProfileStore? txAudioProfileStore = null, AudioSettingsStore? audioStore = null)
     {
         _loggerFactory = loggerFactory;
         _log = loggerFactory.CreateLogger<RadioService>();
@@ -262,7 +273,13 @@ public sealed class RadioService : IDisposable
         _psStore = psStore;
         _filterPresetStore = filterPresetStore;
         _radioStateStore = radioStateStore;
+        _audioStore = audioStore;
         _paStore.Changed += RecomputePaAndPush;
+        // Audio front-end is global per-radio (not per-band), so it has its own
+        // store + push rather than riding the PA snapshot. A store edit re-pushes
+        // the resolved wire bytes + StateDto (PR #359/#360 anti-clobber pattern).
+        if (_audioStore is not null)
+            _audioStore.Changed += PushAudioFrontEnd;
         if (_preferredRadioStore is not null)
             _preferredRadioStore.Changed += RecomputePaAndPush;
         _txIqSource = txIqSource;
@@ -817,6 +834,12 @@ public sealed class RadioService : IDisposable
             // at the protocol defaults (drive=0, OC=0) until something else
             // moves.
             RecomputePaAndPush();
+            // Replay the global audio front-end (external-audio-jacks re-port)
+            // so the operator's source/boost/bias/gain selection is on the first
+            // outgoing frame, not deferred until they touch the panel. Per-board
+            // clamp + the OFF defaults make this a no-op (byte-identical) on
+            // boards without an audio front-end.
+            PushAudioFrontEnd();
             return Snapshot();
         }
         catch
@@ -2047,6 +2070,115 @@ public sealed class RadioService : IDisposable
     // next state change.
     public void ReplayPaSnapshot() => RecomputePaAndPush();
 
+    // Global audio front-end push (external-audio-jacks re-port). Server-
+    // authoritative: read AudioSettingsStore, clamp per-board, push to the P1
+    // client directly and fire AudioFrontEndChanged for the P2 forwarder + the
+    // radio-mic STREAM gate. Called on store edit and on connect (P1 + P2).
+    // Mirrors the PA RecomputePaAndPush discipline but for the GLOBAL (not
+    // per-band) audio state. Defaults (Host, no boost/bias, gain 0) reproduce
+    // today's wire output bit-for-bit on every board.
+    private void PushAudioFrontEnd()
+    {
+        var sel = _audioStore?.Get() ?? AudioSourceSelection.Default;
+        var board = EffectiveBoardKind;
+        var variant = EffectiveOrionMkIIVariant;
+        var caps = BoardCapabilitiesTable.For(board, variant);
+
+        // CLAMP the persisted source against the connected board's capabilities
+        // (external-audio-jacks re-port, safety invariant 5). Any source the
+        // board can't honour falls back to Host so the wire is never handed a
+        // jack the hardware lacks:
+        //   - HL2 (no onboard codec) is Host-only — any radio source → Host.
+        //   - RadioLineIn requires HasRadioLineIn (10E + 100D/200D + 0x0A).
+        //   - RadioBalancedXlr requires HasBalancedXlr (G2 / G2-1K only).
+        //   - RadioMic requires the stream codec.
+        // The mic-bias param is additionally suppressed on boards without
+        // HasMicBias, so a stale bias bit can never reach a non-bias board.
+        var resolved = ClampAudioSource(sel, caps);
+
+        // Encode the wire bytes as PURE FUNCTIONS of the resolved source. Host →
+        // literal zero on every surface, byte-identical to today; no param
+        // fallthrough.
+        var encoder = ExternalPortEncoders.For(board, variant);
+        var portState = new ExternalPortState(
+            Source: resolved.Source,
+            MicBoost: resolved.MicBoost,
+            MicBias: resolved.MicBias,
+            LineInGain: resolved.LineInGain);
+
+        // P1 codec boards (Hermes-class): mic_boost / mic_linein on the 0x12
+        // frame. HL2 is Host-only in v1 — the encoder returns all-clear, and
+        // ControlFrame's read-modify-write keeps the PS bit + C4 PGA intact.
+        // mic_trs / mic_bias / line_in_gain (HL2 0x14) stay clear in v1 (the HL2
+        // mic front-end is inert plumbing), so the host pipeline is unchanged.
+        var (p1Boost, p1LineIn) = encoder.EncodeP1CodecAudioBits(in portState);
+        ActiveClient?.SetAudioFrontEnd(
+            micBoost: p1Boost,
+            micLineIn: p1LineIn,
+            micTrs: false,
+            micBias: false,
+            lineInGain: 0);
+
+        // P2 (0x0A Saturn family): forward the resolved literal byte-50
+        // mic_control + byte-51 line_in_gain to the live Protocol2Client via
+        // DspPipelineService. The forwarder does no source interpretation. The
+        // same event drives the radio-mic STREAM (1026) single-select gate.
+        byte micControl = encoder.EncodeP2MicControlByte(in portState);
+        byte lineInGain = encoder.EncodeP2LineInGainByte(in portState);
+        AudioFrontEndChanged?.Invoke(new AudioFrontEndPush(
+            Source: resolved.Source,
+            MicControlByte: micControl,
+            LineInGain: lineInGain));
+
+        // Mirror the RESOLVED source into StateDto so the frontend hydrates from
+        // the server and never clobbers it on connect (PR #359/#360 pattern).
+        Mutate(s => s.TxAudioSource == resolved.Source ? s : s with { TxAudioSource = resolved.Source });
+    }
+
+    /// <summary>
+    /// Clamp a persisted <see cref="AudioSourceSelection"/> against a board's
+    /// capabilities (external-audio-jacks re-port). Returns Host (with no params)
+    /// whenever the board cannot honour the requested jack, and drops the
+    /// mic-bias param on boards without <c>HasMicBias</c>. Pure — no side
+    /// effects — so the endpoint and the push share one definition.
+    /// </summary>
+    internal static AudioSourceSelection ClampAudioSource(AudioSourceSelection sel, BoardCapabilities caps)
+    {
+        // A board with neither the stream codec nor the HL2 mic front-end has no
+        // audio jacks at all → Host.
+        bool audioCapable = caps.HasOnboardCodec || caps.HermesLite2MicFrontEnd;
+        if (!audioCapable) return AudioSourceSelection.Default;
+
+        switch (sel.Source)
+        {
+            case TxAudioSource.RadioMic:
+                // RadioMic needs the stream codec (HL2's mic front-end is inert
+                // plumbing in v1). Drop bias on non-bias boards.
+                if (!caps.HasOnboardCodec) return AudioSourceSelection.Default;
+                return sel with { MicBias = sel.MicBias && caps.HasMicBias };
+
+            case TxAudioSource.RadioLineIn:
+                if (!caps.HasOnboardCodec || !caps.HasRadioLineIn)
+                    return AudioSourceSelection.Default;
+                // Line-in carries gain, not mic params.
+                return new AudioSourceSelection(TxAudioSource.RadioLineIn, MicBoost: false, MicBias: false, LineInGain: sel.LineInGain);
+
+            case TxAudioSource.RadioBalancedXlr:
+                if (!caps.HasOnboardCodec || !caps.HasBalancedXlr)
+                    return AudioSourceSelection.Default;
+                return sel with { MicBias = sel.MicBias && caps.HasMicBias, LineInGain = 0 };
+
+            case TxAudioSource.Host:
+            default:
+                return AudioSourceSelection.Default;
+        }
+    }
+
+    // DspPipelineService calls this right after a P2 client is created so the
+    // fresh connection picks up the persisted audio front-end without waiting
+    // for a store edit. Public so the P2-connect hook can drive it.
+    public void ReplayAudioFrontEnd() => PushAudioFrontEnd();
+
     /// <summary>
     /// HL2 Band Volts PWM enable (issue #279). Updates the persisted
     /// per-radio preference AND any live Protocol-1 client so the next
@@ -2752,6 +2884,8 @@ public sealed class RadioService : IDisposable
     public void Dispose()
     {
         _paStore.Changed -= RecomputePaAndPush;
+        if (_audioStore is not null)
+            _audioStore.Changed -= PushAudioFrontEnd;
         try { DisconnectAsync(CancellationToken.None).GetAwaiter().GetResult(); }
         catch { /* best-effort */ }
         _stateFlushTimer?.Dispose();

--- a/Zeus.Server.Hosting/TxAudioIngest.cs
+++ b/Zeus.Server.Hosting/TxAudioIngest.cs
@@ -165,6 +165,16 @@ public sealed class TxAudioIngest : IDisposable
     // arbitration is re-done inside the accumulation lock against this owner.
     private MicBlockSource _accumulatorSource = MicBlockSource.Host;
 
+    // Peak radio-jack input level (linear 0..1) seen on ACCEPTED RadioMic blocks
+    // since the last meter read. Read/written ONLY under _sync. The desktop mic-
+    // meter heartbeat (NativeMicCapture) consumes this at ~10 Hz so the operator-
+    // facing meter shows the ACTUAL radio input when a radio source is armed —
+    // and reads silence (0) when no radio audio is arriving (no mic connected /
+    // no UDP-1026 stream). Without this, the meter would keep showing the host
+    // mic on a radio source (the reported "still listening to host" bug). Reset
+    // to 0 on any source switch so a stale value can't bleed across sources.
+    private float _radioPeakLinear;
+
     /// <summary>
     /// Arm the TX-audio source for the HOST↔RADIO single-select gate
     /// (external-audio-jacks re-port). Called by the pipeline when the resolved
@@ -189,11 +199,32 @@ public sealed class TxAudioIngest : IDisposable
             // Quiesce: drop any partially-accumulated old-source audio so it
             // can't stitch onto the post-switch source mid-WDSP-block.
             _accumulatorFill = 0;
+            // Drop any stale radio-meter peak so the meter doesn't carry a value
+            // across a source switch (e.g. host→radio shows fresh radio level,
+            // radio→host stops surfacing a frozen radio peak).
+            _radioPeakLinear = 0f;
         }
     }
 
     /// <summary>Current armed source for the host/radio gate (test/diagnostic).</summary>
     internal MicBlockSource ActiveSource { get { lock (_sync) return _activeSource; } }
+
+    /// <summary>
+    /// Read and reset the peak radio-jack input level (linear 0..1) seen on
+    /// accepted radio blocks since the last call. The desktop mic-meter heartbeat
+    /// consumes this so the meter reflects the ACTUAL radio input when a radio
+    /// source is armed, and reads silence (0) when no radio audio is arriving.
+    /// Thread-safe.
+    /// </summary>
+    internal float ConsumeRadioPeakLinear()
+    {
+        lock (_sync)
+        {
+            var peak = _radioPeakLinear;
+            _radioPeakLinear = 0f;
+            return peak;
+        }
+    }
 
     /// <summary>
     /// True when a TCI client is the authoritative source of TX audio right now
@@ -510,6 +541,25 @@ public sealed class TxAudioIngest : IDisposable
             if (_accumulatorFill > 0 && _accumulatorSource != source)
                 _accumulatorFill = 0;
             _accumulatorSource = source;
+
+            // Track the radio-jack input peak for the source-aware mic meter.
+            // Only on accepted RadioMic blocks (the gate above guarantees the
+            // radio jack is the armed source) — the host path is untouched. The
+            // desktop meter heartbeat consumes this via ConsumeRadioPeakLinear,
+            // so the meter shows the real radio level and falls to silence when
+            // no radio audio is arriving.
+            if (source == MicBlockSource.RadioMic)
+            {
+                var rspan = f32lePayload.Span;
+                float radioPeak = 0f;
+                for (int i = 0; i < MicBlockSamples; i++)
+                {
+                    float a = BinaryPrimitives.ReadSingleLittleEndian(rspan.Slice(i * 4, 4));
+                    if (a < 0) a = -a;
+                    if (a > radioPeak) radioPeak = a;
+                }
+                if (radioPeak > _radioPeakLinear) _radioPeakLinear = radioPeak;
+            }
 
             // Decode f32le into accumulator. WDSP wants -1..+1 range; browser
             // ships the same convention.

--- a/Zeus.Server.Hosting/TxAudioIngest.cs
+++ b/Zeus.Server.Hosting/TxAudioIngest.cs
@@ -45,10 +45,32 @@
 
 using System.Buffers.Binary;
 using Microsoft.Extensions.Logging;
+using Zeus.Contracts;
 using Zeus.Dsp;
 using Zeus.Protocol1;
 
 namespace Zeus.Server;
+
+/// <summary>
+/// Internal tag identifying which producer fed a TX-audio block into
+/// <see cref="TxAudioIngest.OnMicPcmBytes"/>. Carried explicitly (NOT inferred
+/// from recency) so the in-lock single-select gate can arbitrate the host mic
+/// against a radio jack deterministically across a source switch
+/// (external-audio-jacks re-port). TCI/WAV remain operator-explicit overrides
+/// and bypass the host/radio arbitration — their precedence is the existing
+/// recency hysteresis.
+/// </summary>
+internal enum MicBlockSource
+{
+    /// <summary>Browser / native host microphone (the default TX-audio source).</summary>
+    Host = 0,
+    /// <summary>Radio-digitised jack audio (Saturn mic/line-in/XLR via UDP 1026).</summary>
+    RadioMic,
+    /// <summary>TCI client TX audio (MSHV / WSJT-X …). Operator-explicit override.</summary>
+    Tci,
+    /// <summary>WAV-recording playback to the air. Operator-explicit override.</summary>
+    Wav,
+}
 
 /// <summary>
 /// Bridges browser-side mic audio to WDSP TXA and onward to the EP2 IQ
@@ -126,6 +148,52 @@ public sealed class TxAudioIngest : IDisposable
     // "live mic" source. Otherwise mobile PTT mixes phone audio with desktop
     // capture silence and feeds TXA at roughly 2x realtime.
     private long _lastBrowserMicTickMs;
+
+    // The currently-armed TX-audio source for HOST↔RADIO arbitration
+    // (external-audio-jacks re-port, "atomic single-select gate"). Read and
+    // written ONLY under _sync. OnMicPcmBytes rejects any Host- or
+    // RadioMic-tagged block whose tag != _activeSource, so when a radio jack is
+    // armed the host mic is dropped immediately by the in-lock compare (no
+    // overlap window) and vice versa. TCI/WAV-tagged blocks bypass this compare.
+    // Default Host so a fresh / un-switched ingest is byte/behaviour-identical
+    // to today.
+    private MicBlockSource _activeSource = MicBlockSource.Host;
+    // Source whose samples currently occupy the WDSP accumulator. Read/written
+    // ONLY under _sync. Enforces that a partially-filled accumulator is NEVER
+    // topped up by a different source: between the cheap top-of-method gate and
+    // the accumulation lock, _activeSource can flip, so the AUTHORITATIVE
+    // arbitration is re-done inside the accumulation lock against this owner.
+    private MicBlockSource _accumulatorSource = MicBlockSource.Host;
+
+    /// <summary>
+    /// Arm the TX-audio source for the HOST↔RADIO single-select gate
+    /// (external-audio-jacks re-port). Called by the pipeline when the resolved
+    /// <see cref="TxAudioSource"/> changes. Under <see cref="_sync"/> this sets
+    /// the new active source AND clears the WDSP accumulator so no half-block of
+    /// the old source survives onto the new source — the new source fills from
+    /// empty. The 1026 re-blocker (owned upstream) is reset by the same caller.
+    /// Maps every radio jack (Mic/Line-In/XLR) onto
+    /// <see cref="MicBlockSource.RadioMic"/> because they all arrive on the one
+    /// UDP-1026 stream; only Host is distinct here. TCI/WAV are not selectable
+    /// sources — they override transiently.
+    /// </summary>
+    internal void SetActiveSource(TxAudioSource source)
+    {
+        var mapped = source == TxAudioSource.Host
+            ? MicBlockSource.Host
+            : MicBlockSource.RadioMic;
+        lock (_sync)
+        {
+            if (_activeSource == mapped) return;
+            _activeSource = mapped;
+            // Quiesce: drop any partially-accumulated old-source audio so it
+            // can't stitch onto the post-switch source mid-WDSP-block.
+            _accumulatorFill = 0;
+        }
+    }
+
+    /// <summary>Current armed source for the host/radio gate (test/diagnostic).</summary>
+    internal MicBlockSource ActiveSource { get { lock (_sync) return _activeSource; } }
 
     /// <summary>
     /// True when a TCI client is the authoritative source of TX audio right now
@@ -238,7 +306,7 @@ public sealed class TxAudioIngest : IDisposable
     internal void OnMicPcmBytesFromTci(ReadOnlyMemory<byte> f32lePayload)
     {
         Volatile.Write(ref _lastTciTickMs, Environment.TickCount64);
-        OnMicPcmBytes(f32lePayload);
+        OnMicPcmBytes(f32lePayload, MicBlockSource.Tci);
     }
 
     /// <summary>
@@ -252,7 +320,7 @@ public sealed class TxAudioIngest : IDisposable
         long now = Environment.TickCount64;
         Volatile.Write(ref _lastBrowserMicTickMs, now);
         if (ShouldSuppressForAuthoritativeSource(now)) return;
-        OnMicPcmBytes(f32lePayload);
+        OnMicPcmBytes(f32lePayload, MicBlockSource.Host);
     }
 
     /// <summary>
@@ -267,7 +335,24 @@ public sealed class TxAudioIngest : IDisposable
         if (ShouldSuppressForAuthoritativeSource(now)) return;
         long lastBrowserMic = Volatile.Read(ref _lastBrowserMicTickMs);
         if (lastBrowserMic != 0 && now - lastBrowserMic < TciHysteresisMs) return;
-        OnMicPcmBytes(f32lePayload);
+        OnMicPcmBytes(f32lePayload, MicBlockSource.Host);
+    }
+
+    /// <summary>
+    /// Source-tagged entry point for radio-digitised jack audio (Saturn mic /
+    /// line-in / balanced-XLR, arriving on UDP 1026 and re-blocked to 960
+    /// samples upstream — external-audio-jacks re-port). Tagged
+    /// <see cref="MicBlockSource.RadioMic"/>; the in-lock
+    /// <see cref="_activeSource"/> compare in <see cref="OnMicPcmBytes"/> drops
+    /// it unless a radio jack is the armed source, so it can never leak onto the
+    /// air under Host. Like the host mic, it yields to a recent TCI/WAV override
+    /// so a remote/playback source is never mixed with radio-jack audio.
+    /// </summary>
+    internal void OnMicPcmBytesFromRadioMic(ReadOnlyMemory<byte> f32lePayload)
+    {
+        long now = Environment.TickCount64;
+        if (ShouldSuppressForAuthoritativeSource(now)) return;
+        OnMicPcmBytes(f32lePayload, MicBlockSource.RadioMic);
     }
 
     private bool ShouldSuppressForAuthoritativeSource(long now)
@@ -287,16 +372,40 @@ public sealed class TxAudioIngest : IDisposable
     internal void OnMicPcmBytesFromWav(ReadOnlyMemory<byte> f32lePayload)
     {
         Volatile.Write(ref _lastWavTickMs, Environment.TickCount64);
-        OnMicPcmBytes(f32lePayload);
+        OnMicPcmBytes(f32lePayload, MicBlockSource.Wav);
     }
 
     // Internal so tests can drive the ingest directly without standing up a WS.
+    // Untagged overload defaults to Host (host path byte/behaviour-identical to
+    // today).
     internal void OnMicPcmBytes(ReadOnlyMemory<byte> f32lePayload)
+        => OnMicPcmBytes(f32lePayload, MicBlockSource.Host);
+
+    // The source tag arbitrates the HOST↔RADIO single-select gate IN-LOCK (see
+    // _activeSource); TCI/WAV bypass that compare as operator-explicit overrides.
+    internal void OnMicPcmBytes(ReadOnlyMemory<byte> f32lePayload, MicBlockSource source)
     {
         if (f32lePayload.Length != MicBlockBytes)
         {
             lock (_sync) _droppedFrames++;
             return;
+        }
+
+        // Cheap early-out for the host/radio gate (external-audio-jacks
+        // re-port). This is NOT the hard gate — _activeSource can still flip
+        // between here and the accumulation lock below, so the AUTHORITATIVE
+        // single-select decision is re-checked atomically with the append (see
+        // "ATOMIC single-select gate" inside the accumulation lock). Doing the
+        // obvious reject here too avoids running the MOX-edge / tap / WDSP-sizing
+        // work for a block the authoritative check would drop anyway. TCI/WAV
+        // bypass this compare — they are operator-explicit overrides gated by the
+        // recency hysteresis above.
+        if (source is MicBlockSource.Host or MicBlockSource.RadioMic)
+        {
+            lock (_sync)
+            {
+                if (source != _activeSource) { _droppedFrames++; return; }
+            }
         }
 
         // Non-destructive mic tap, fired BEFORE the MOX/monitor gate so a
@@ -376,6 +485,32 @@ public sealed class TxAudioIngest : IDisposable
 
         lock (_sync)
         {
+            // ATOMIC single-select gate (external-audio-jacks re-port, the
+            // crux). This is the AUTHORITATIVE host/radio arbitration: it runs
+            // in the SAME critical section as the accumulator append, so no flip
+            // of _activeSource (by SetActiveSource, also under _sync) can slip
+            // between "decide" and "append". A Host/RadioMic block whose tag no
+            // longer matches the armed source is dropped, so two producer threads
+            // straddling a switch resolve to exactly one contributor per WDSP
+            // block — no double-feed. TCI/WAV bypass this (operator-explicit
+            // overrides; recency-gated above). Under Host with a Host block this
+            // is a pure no-op → host path byte/behaviour-identical to today.
+            if (source is MicBlockSource.Host or MicBlockSource.RadioMic
+                && source != _activeSource)
+            {
+                _droppedFrames++;
+                return;
+            }
+            // Guard the accumulator owner: if a half-filled block belongs to a
+            // different source than the one now appending (possible when the
+            // active source flipped while data sat buffered), drop the stale
+            // remainder so the two sources never mix inside one WDSP block.
+            // SetActiveSource already clears on the host/radio switch; this
+            // covers the TCI/WAV interleave as well.
+            if (_accumulatorFill > 0 && _accumulatorSource != source)
+                _accumulatorFill = 0;
+            _accumulatorSource = source;
+
             // Decode f32le into accumulator. WDSP wants -1..+1 range; browser
             // ships the same convention.
             var src = f32lePayload.Span;

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -2092,6 +2092,70 @@ public static class ZeusEndpoints
             return Results.Ok(externalPtt.Snapshot());
         });
 
+        // Global (per-radio) TX-audio source (external-audio-jacks re-port). GET
+        // surfaces the per-board capability gates + the RESOLVED (board-clamped)
+        // source so the single-select picker shows only the jacks the connected
+        // board offers and hydrates from what the server is actually pushing.
+        // Always 200 — a board with neither codec nor HL2 mic reports both gates
+        // false and the panel shows nothing.
+        app.MapGet("/api/radio/audio", (RadioService radio, AudioSettingsStore store) =>
+        {
+            var caps = BoardCapabilitiesTable.For(radio.EffectiveBoardKind, radio.EffectiveOrionMkIIVariant);
+            var resolved = RadioService.ClampAudioSource(store.Get(), caps);
+            return Results.Ok(new AudioFrontEndDto(
+                HasOnboardCodec: caps.HasOnboardCodec,
+                HermesLite2MicFrontEnd: caps.HermesLite2MicFrontEnd,
+                HasRadioLineIn: caps.HasRadioLineIn,
+                HasBalancedXlr: caps.HasBalancedXlr,
+                HasMicBias: caps.HasMicBias,
+                Source: resolved.Source,
+                MicBoost: resolved.MicBoost,
+                MicBias: resolved.MicBias,
+                LineInGain: resolved.LineInGain));
+        });
+
+        // PUT the whole global TX-audio source. Capability-gated: 409 when the
+        // connected board has no audio front-end at all (neither codec nor HL2
+        // mic), so a non-audio board can never be handed audio bytes. The
+        // requested Source is CLAMPED against the board's capabilities (an
+        // unsupported jack → Host) before persisting, so the store never holds a
+        // source the wire can't emit on this board. LineInGain is clamped 0..31.
+        // The save fires AudioSettingsStore.Changed -> RadioService.PushAudioFrontEnd,
+        // which re-clamps + pushes server-authoritatively to the live client
+        // (P1 SetAudioFrontEnd / P2 TxSpecific 50/51) and mirrors the resolved
+        // source into StateDto — never via the frontend, so no clobber-on-connect.
+        app.MapPut("/api/radio/audio", (AudioFrontEndSetRequest req, RadioService radio, AudioSettingsStore store) =>
+        {
+            if (req is null)
+                return Results.BadRequest(new { error = "body required" });
+
+            var caps = BoardCapabilitiesTable.For(radio.EffectiveBoardKind, radio.EffectiveOrionMkIIVariant);
+            bool audioCapable = caps.HasOnboardCodec || caps.HermesLite2MicFrontEnd;
+            if (!audioCapable)
+                return Results.Conflict(new { error = $"board {radio.EffectiveBoardKind} has no audio front-end" });
+
+            var requested = new AudioSourceSelection(
+                Source: req.Source,
+                MicBoost: req.MicBoost,
+                MicBias: req.MicBias,
+                LineInGain: (byte)Math.Clamp(req.LineInGain, 0, 31));
+            // Clamp to the board before persisting — a board that lacks the
+            // requested jack stores Host, never the illegal source.
+            store.Set(RadioService.ClampAudioSource(requested, caps));
+
+            var resolved = RadioService.ClampAudioSource(store.Get(), caps);
+            return Results.Ok(new AudioFrontEndDto(
+                caps.HasOnboardCodec,
+                caps.HermesLite2MicFrontEnd,
+                caps.HasRadioLineIn,
+                caps.HasBalancedXlr,
+                caps.HasMicBias,
+                resolved.Source,
+                resolved.MicBoost,
+                resolved.MicBias,
+                resolved.LineInGain));
+        });
+
         app.MapGet("/api/radio/power-calibration", (HardwareDiagnosticsService diag) =>
         {
             return Results.Ok(diag.PowerCalibrationSnapshot());

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -224,6 +224,11 @@ public static class ZeusHost
         builder.Services.AddSingleton<Zeus.Protocol1.TxIqRing>();
         builder.Services.AddSingleton<Zeus.Protocol1.ITxIqSource>(sp =>
             sp.GetRequiredService<Zeus.Protocol1.TxIqRing>());
+        // Global (per-radio) TX-audio source store (external-audio-jacks
+        // re-port). Registered before RadioService so the latter's optional
+        // AudioSettingsStore? ctor param resolves it and wires the Changed →
+        // PushAudioFrontEnd push. Shares zeus-prefs.db (single global row).
+        builder.Services.AddSingleton<AudioSettingsStore>();
         builder.Services.AddSingleton<RadioService>();
         builder.Services.AddSingleton<StreamingHub>();
         // RX audio publish seam (Phase 1). DspPipelineService.PublishAudio
@@ -301,7 +306,17 @@ public static class ZeusHost
         // Clients are told to keep Connect disabled until phase=Ready.
         builder.Services.AddSingleton<WdspWisdomInitializer>();
         builder.Services.AddHostedService<WisdomBootstrapService>();
-        builder.Services.AddSingleton<DspPipelineService>();
+        // DspPipelineService takes a lazy TxAudioIngest factory so the
+        // radio-mic (UDP 1026) stream can be routed into the TX pipeline without
+        // a DI cycle (TxAudioIngest depends on DspPipelineService). The Func is
+        // only invoked on the first radio-source switch, well after both
+        // singletons are constructed (feedback_di_cycle_iservice_provider).
+        builder.Services.AddSingleton<DspPipelineService>(sp =>
+        {
+            Func<TxAudioIngest?> txIngestFactory = () => sp.GetService<TxAudioIngest>();
+            return Microsoft.Extensions.DependencyInjection.ActivatorUtilities
+                .CreateInstance<DspPipelineService>(sp, txIngestFactory);
+        });
         builder.Services.AddHostedService(sp => sp.GetRequiredService<DspPipelineService>());
         // Per-radio frequency calibration (issue #325). Stateless coordinator —
         // owns no resources, just a SemaphoreSlim to prevent re-entry.

--- a/docs/designs/external-audio-jacks.md
+++ b/docs/designs/external-audio-jacks.md
@@ -1,0 +1,131 @@
+# External Audio-Jack Wiring — Re-Port Design (against new `develop`)
+
+Re-introduces the operator-selectable TX **audio input source** feature first shipped to the old
+develop in PR #639 (squash `78c3c28e`) and dropped during the base swap to Christian's fork. This is
+a faithful re-port adapted to the current base, where only the sibling **PTT-jack** feature
+(PR #799 / impl #797) has landed as a template.
+
+Pull every old reference file with `git show 78c3c28e:<path>`.
+
+## Scope
+
+Single mutually-exclusive per-radio TX audio source:
+
+```
+enum TxAudioSource : byte { Host = 0, RadioMic = 1, RadioLineIn = 2, RadioBalancedXlr = 3 }
+```
+
+plus `MicBoost` (20 dB), `MicBias` (Orion electret bias, **default OFF**), and `LineInGain` (0..31).
+`Host` = the browser/host mic pipeline that exists today. The three radio sources route the radio's
+own front-end audio (UDP port 1026) into the WDSP TX chain.
+
+**Output jacks (line-out / headphone / speaker) are NOT wire-selectable in either protocol** — they
+are fixed hardware fed by the RX DAC. We expose only the `HasAudioAmplifier` presence cap, nothing to
+control. "Wire all jacks" therefore means: all *input* sources selectable; outputs are presence-only.
+
+## Per-board capability matrix (source: Thetis ramdor + BoardJacks/OldCode research)
+
+| Board (HpsdrBoardKind / variant) | Codec | RadioMic | LineIn | XLR | MicBias |
+|---|---|---|---|---|---|
+| Metis 0x00 | ✅ | ✅ | ❌ | ❌ | ❌ |
+| Hermes 0x01 (ANAN-10/100) | ✅ | ✅ | ❌ | ❌ | ❌ |
+| HermesII 0x02 (**ANAN-10E**/100B) | ✅ | ✅ | ✅ (10E fix) | ❌ | ❌ |
+| Angelia 0x04 (ANAN-100D) | ✅ | ✅ | ✅ | ❌ | ✅ |
+| Orion 0x05 (ANAN-200D) | ✅ | ✅ | ✅ | ❌ | ✅ |
+| OrionMkII 0x0A → G2 / G2-1K | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 0x0A → 7000DLE / 8000DLE | ✅ | ✅ | ✅ | ❌ | ✅ |
+| 0x0A → OrionMkII (Apache orig) | ✅ | ✅ | ✅ | ❌ | ❌ |
+| 0x0A → AnvelinaPro3 / RedPitaya | ✅ | ✅ | ✅ | ❌ | ❌ † |
+| HermesC10 0x?? (G2E) | ✅ | ✅ | ❌ | ❌ ‡ | ❌ |
+| Hermes-Lite 2 0x06 | ❌ codec | ❌ * | ❌ * | ❌ | ✅ frame |
+
+* HL2 has no audio codec (no audio OUT). Mic-in exists on the 0x14 frame but is mi0bot-firmware
+  dependent — **expose nothing for HL2 in v1 except `HermesLite2MicFrontEnd` plumbing kept inert**
+  until confirmed on hardware. Default Host.
+† RedPitaya / AnvelinaPro3 bias: connector is DIY — bias gated OFF until confirmed (electret bias on
+  the wrong jack is a foot-gun).
+‡ G2E XLR: Thetis hard-gates balanced to G2/G2-1K and excludes G2E — keep excluded until N1GP/OK1BR
+  confirm (#289).
+
+### The 10E two-gate rule (issue #667 / fix `caac2f73`) — do NOT reintroduce the bug
+Visibility needs **both** gates to agree, each keyed on `ConnectedBoardKind`:
+1. **Capability gate** — `BoardCapabilitiesTable` sets `HasRadioLineIn` for `HermesII`. Surfaced via
+   `/api/radio/capabilities`; frontend gates the option + slider on it. Missing flag = control never
+   appears.
+2. **Encoder gate** — the encoder must actually emit the select bit + gain for that source on that
+   board. No-op-for-all default = silent dead control.
+
+Keep the 10E piece **HermesII-only**. KB2UKA explicitly scoped Hermes/ANAN-10/100 line-in OUT.
+
+## Wire encoding (verbatim from `78c3c28e`, Thetis `network.c:1226-1236`)
+
+```
+LineInBit   = 0x01  // bit0 line-in select
+MicBoostBit = 0x02  // bit1 mic 20dB boost
+MicBiasBit  = 0x10  // bit4 Orion mic bias
+XlrBit      = 0x20  // bit5 balanced/XLR (Saturn)
+
+P2 micControl byte (TxSpecific byte 50):
+  Host             -> 0                                        // literal 0, NEVER read params
+  RadioMic         -> (boost?0x02) | (bias?0x10)
+  RadioLineIn      -> 0x01                                     // gain rides byte 51
+  RadioBalancedXlr -> 0x20 | (boost?0x02) | (bias?0x10)
+P2 lineInGain byte (TxSpecific byte 51):
+  RadioLineIn -> gain & 0x1F   else 0
+
+P1 Hermes codec (0x12 frame): C2[0]=mic_boost, C2[1]=mic_linein   (default false = byte-identical)
+P1 HL2 (0x14 frame, reg 0x0a): C1[4]=mic_trs, C1[5]=mic_bias, C2[4:0]=line_in_gain
+  ** READ-MODIFY-WRITE preserving C2[6]=puresignal_run and the C4 PGA byte **  mic_ptt(C1[6])=0
+```
+
+## Safety invariants (enforce + verify with tests)
+1. **Host purity** — every encode of `Host` returns literal `0` without reading boost/bias/gain. No
+   stale-param wire leak on revert to host.
+2. **Default-inert / byte-identical** — at defaults (Host, bias off) every board's wire bytes are
+   unchanged. PureSignal golden suites (P1 + P2) MUST stay green.
+3. **HL2 0x14 RMW** preserves `C2[6]=puresignal_run` + C4 PGA. PS-adjacent burn-zone → bench-verify.
+4. **Audio is decoupled from PureSignal/K36** — audio rides byte 50/51 (P2) and 0x12/0x14 (P1);
+   it NEVER touches the alex word, PS bit, or the K36 RX-aux BYPASS path.
+5. **Board clamp** — persisted-but-unsupported source clamps to Host at connect (survives radio swap).
+6. **mic_bias default OFF** + explicit frontend confirm.
+
+## Implementation graft order (mirror PTT-jack #797 conventions)
+1. `Zeus.Contracts/TxAudioSource.cs` (new enum, STJ by name).
+2. `Zeus.Contracts/BoardCapabilities.cs` += `HasOnboardCodec`, `HermesLite2MicFrontEnd`,
+   `HasRadioLineIn`, `HasBalancedXlr`, `HasMicBias`. `Dtos.cs` += `AudioFrontEndDto`,
+   `AudioFrontEndSetRequest`, `StateDto.TxAudioSource` (resolved, anti-clobber).
+3. `BoardCapabilitiesTable.cs` per-board flags per matrix above (HermesII gets `HasRadioLineIn`).
+4. `Zeus.Server.Hosting/ExternalPortEncoder.cs` (new): `IExternalPortEncoder` +
+   P1/P2/HL2 encoders + `ExternalPortEncoders.For(board,variant,protocol)` + `ExternalPortAudio`
+   pure helpers with the bit math above. `InternalsVisibleTo` Hosting→Protocol1/2.
+5. `Zeus.Server.Hosting/AudioSettingsStore.cs` (new): LiteDB `audio_frontend` single global row,
+   `DeleteMany(_=>true)+Insert` (Id=0 bug PR #387), `PrefsDbPath.Get()` shared, clamp on `Get()`,
+   `Changed` event, legacy four-bool row → Host.
+6. DI in `ZeusHost.cs` next to `AudioDeviceSettingsStore`.
+7. `RadioService` wiring: ctor `AudioSettingsStore?`, `PushAudioFrontEnd()`, `ClampAudioSource`,
+   `ReplayAudioFrontEnd()`, `AudioFrontEndChanged` event, `StateDto.TxAudioSource` mutate.
+8. P1 emission: `IProtocol1Client.SetAudioFrontEnd(...)` + `ControlFrame.cs` 0x12 / 0x14 RMW.
+9. P2 emission: `Protocol2Client.ComposeCmdTxBuffer` += `micControl`,`lineInGain` →
+   `p[50]`,`p[51]`; `SetAudioFrontEndBytes`; 1026 RX dispatch + `_radioMicHandler`.
+10. Radio-mic RX: `RadioMicReceiver.cs` (decode UDP-1026: 4B BE seq + 64×int16 BE @48k = 132B →
+    960-sample f32le blocks), `TxAudioIngest` source-tagging (`MicBlockSource` enum,
+    `_activeSource`/`_accumulatorSource`, `SetActiveSource`, drop mistagged blocks), wire via
+    `DspPipelineService`. **Most invasive merge** — current `OnMicPcmBytes` is untagged/recency-based;
+    re-add tagging so it composes with TCI/WAV.
+11. Endpoints: `GET/PUT /api/radio/audio` (`AudioFrontEndDto`); 409 if no codec & no HL2 mic FE;
+    clamp gain + source before persist.
+12. Frontend: `state/audio-store.ts` (Zustand, optimistic-rollback); **add an "Audio Input" card to
+    the EXISTING `RadioSettingsPanel.tsx`** (do NOT duplicate the tab or PTT card);
+    `board-capabilities.ts` cap fields. mic-bias behind a `window.confirm` warning.
+13. Tests (re-port from `78c3c28e`): P2 `ControlFrameAudioEncoderTests`, `CmdTxAudioFrontEndTests`,
+    `ExternalPortAlexGoldenTests`; P1 `ExternalPortGoldenTests`; server `ExternalPortEncoderTests`,
+    `AudioEndpointTests`, `AudioSettingsStoreTests`, `RadioMicReceiverTests`, `TxAudioIngestTests`,
+    `BoardCapabilitiesTableTests`; web `audio-store.test.ts`, `RadioSettingsPanel.test.tsx`.
+
+## Verification gates
+- `dotnet build Zeus.slnx` green (all platforms via CI).
+- Full `dotnet test` green — **PureSignal golden suites byte-identical** is the acceptance proof.
+- `npm --prefix zeus-web run build` + vitest green.
+- **Bench gates before merge (draft PR):** HL2 0x14 RMW PS-safety on real HL2 + G2; live G2
+  capability read (G2 was offline during design). Flag in PR; do not merge without KB2UKA sign-off.
+```

--- a/tests/Zeus.Protocol1.Tests/ControlFrameAudioEncoderTests.cs
+++ b/tests/Zeus.Protocol1.Tests/ControlFrameAudioEncoderTests.cs
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Contracts;
+using Zeus.Protocol1.Discovery;
+
+namespace Zeus.Protocol1.Tests;
+
+/// <summary>
+/// GOLDEN-BYTE tests for the Protocol-1 audio front-end (external-ports plan,
+/// Phase 4). Two verified surfaces:
+///
+///   (a) Hermes-class codec boards — DriveFilter (0x12) frame:
+///         C2[0] = mic_boost, C2[1] = mic_linein
+///       (ramdor Thetis networkproto1.c:581; piHPSDR old_protocol.c:2154-2156).
+///
+///   (b) Hermes-Lite 2 — 0x0a / wire-0x14 frame, READ-MODIFY-WRITE:
+///         C1[4] = mic_trs, C1[5] = mic_bias, C2[4:0] = line_in_gain
+///       (ramdor Thetis networkproto1.c:597-599 case 11; same in mi0bot).
+///       The SAME frame carries C2[6] = puresignal_run and the C4 PGA /
+///       step-attenuator byte — those MUST survive any audio write.
+///
+/// The CRUX safety assertion: setting an HL2 audio field must NOT disturb
+/// puresignal_run (C2[6]) or the C4 step-attenuator byte. PureSignal lives next
+/// to audio on this frame; a clobber here would silently break PS.
+/// </summary>
+public class ControlFrameAudioEncoderTests
+{
+    private static ControlFrame.CcState Hermes() => new(
+        VfoAHz: 14_200_000,
+        Rate: HpsdrSampleRate.Rate48k,
+        PreampOn: false,
+        Atten: HpsdrAtten.Zero,
+        RxAntenna: HpsdrAntenna.Ant1,
+        Mox: false,
+        EnableHl2BandVolts: false,
+        Board: HpsdrBoardKind.Hermes,
+        DriveLevel: 0x80);
+
+    private static ControlFrame.CcState Hl2(bool ps = false) => new(
+        VfoAHz: 14_200_000,
+        Rate: HpsdrSampleRate.Rate48k,
+        PreampOn: false,
+        Atten: HpsdrAtten.Zero,
+        RxAntenna: HpsdrAntenna.Ant1,
+        Mox: false,
+        EnableHl2BandVolts: false,
+        Board: HpsdrBoardKind.HermesLite2,
+        PsEnabled: ps);
+
+    private static byte[] Frame(ControlFrame.CcRegister reg, in ControlFrame.CcState s)
+    {
+        Span<byte> cc = stackalloc byte[5];
+        ControlFrame.WriteCcBytes(cc, reg, s);
+        return cc.ToArray();
+    }
+
+    // ---- (a) Hermes-class codec — 0x12 frame mic_boost / mic_linein --------
+
+    [Fact]
+    public void DriveFilter_Hermes_DefaultAudio_IsByteIdentical()
+    {
+        // No audio fields set → C2/C3/C4 all zero (the historical 0x12 tail).
+        var cc = Frame(ControlFrame.CcRegister.DriveFilter, Hermes());
+        Assert.Equal(0x12, cc[0]);
+        Assert.Equal(0x80, cc[1]); // drive byte
+        Assert.Equal(0x00, cc[2]);
+        Assert.Equal(0x00, cc[3]);
+        Assert.Equal(0x00, cc[4]);
+    }
+
+    [Theory]
+    [InlineData(false, false, 0x00)]
+    [InlineData(true,  false, 0x01)] // mic_boost → C2[0]
+    [InlineData(false, true,  0x02)] // mic_linein → C2[1]
+    [InlineData(true,  true,  0x03)] // both
+    public void DriveFilter_Hermes_MicBits_LandInC2(bool boost, bool lineIn, byte expectedC2)
+    {
+        var cc = Frame(ControlFrame.CcRegister.DriveFilter,
+            Hermes() with { MicBoost = boost, MicLineIn = lineIn });
+        Assert.Equal(expectedC2, cc[2]);
+        // Drive byte untouched.
+        Assert.Equal(0x80, cc[1]);
+    }
+
+    [Fact]
+    public void DriveFilter_Hl2_DoesNotEmitCodecMicBits()
+    {
+        // HL2 has no stream codec — mic_boost/linein must NOT bleed onto the
+        // 0x12 frame (they ride the 0x14 frame instead). C2 stays at the HL2
+        // baseline (PA-enable only when MOX; here RX so 0).
+        var cc = Frame(ControlFrame.CcRegister.DriveFilter,
+            Hl2() with { MicBoost = true, MicLineIn = true });
+        Assert.Equal(0x00, cc[2]);
+    }
+
+    [Fact]
+    public void DriveFilter_Hl2_PaEnableBit_StillSetOnMox()
+    {
+        // Regression guard: the HL2 PA-enable C2[3] path must keep working with
+        // the new codec-board branch added alongside it.
+        var cc = Frame(ControlFrame.CcRegister.DriveFilter, Hl2() with { Mox = true });
+        Assert.Equal(0x08, cc[2] & 0x08);
+    }
+
+    // ---- (b) HL2 0x14 frame — mic_trs / mic_bias / line_in_gain ------------
+
+    [Fact]
+    public void Attenuator_Hl2_DefaultAudio_IsByteIdentical()
+    {
+        // No audio set: C1=0, C2=0 (no PS), C3=0, C4 = 0x40 | (60-0) = 0x7C.
+        // This is exactly today's WriteAttenuatorPayload output.
+        var cc = Frame(ControlFrame.CcRegister.Attenuator, Hl2());
+        Assert.Equal(0x14, cc[0]);
+        Assert.Equal(0x00, cc[1]);
+        Assert.Equal(0x00, cc[2]);
+        Assert.Equal(0x00, cc[3]);
+        Assert.Equal(0x7C, cc[4]); // 0x40 | 60
+    }
+
+    [Theory]
+    [InlineData(false, false, 0x00)]
+    [InlineData(true,  false, 0x10)] // mic_trs (balanced) → C1[4]
+    [InlineData(false, true,  0x20)] // mic_bias → C1[5]
+    [InlineData(true,  true,  0x30)] // both
+    public void Attenuator_Hl2_MicTrsBias_LandInC1(bool trs, bool bias, byte expectedC1)
+    {
+        var cc = Frame(ControlFrame.CcRegister.Attenuator,
+            Hl2() with { MicTrs = trs, MicBias = bias });
+        Assert.Equal(expectedC1, cc[1]); // C1 = cc[1]
+        // mic_ptt (C1[6]) is a PTT-IN concern, never written here.
+        Assert.Equal(0x00, cc[1] & (1 << 6));
+    }
+
+    [Theory]
+    [InlineData(0, 0x00)]
+    [InlineData(1, 0x01)]
+    [InlineData(31, 0x1F)]
+    [InlineData(63, 0x1F)] // clamps to the 5-bit field
+    public void Attenuator_Hl2_LineInGain_LandsInC2LowFiveBits(int gain, byte expectedLow)
+    {
+        var cc = Frame(ControlFrame.CcRegister.Attenuator,
+            Hl2() with { LineInGain = (byte)gain });
+        Assert.Equal(expectedLow, (byte)(cc[2] & 0x1F));
+        // No PS → C2[6] stays clear; line_in_gain must not bleed into it.
+        Assert.Equal(0x00, cc[2] & (1 << 6));
+    }
+
+    // ---- CRUX: audio writes must NOT disturb PureSignal or step-atten ------
+
+    [Fact]
+    public void Attenuator_Hl2_AudioSet_PreservesPureSignalRun()
+    {
+        // PS armed + ALL audio fields set. puresignal_run (C2[6]) MUST survive
+        // — this is the load-bearing safety property of the read-modify-write.
+        var s = Hl2(ps: true) with
+        {
+            MicTrs = true,
+            MicBias = true,
+            LineInGain = 0x15, // 10101
+        };
+        var cc = Frame(ControlFrame.CcRegister.Attenuator, s);
+
+        // PS bit survives.
+        Assert.Equal(1 << 6, cc[2] & (1 << 6));
+        // line_in_gain occupies the low 5 bits alongside it.
+        Assert.Equal(0x15, cc[2] & 0x1F);
+        // Full C2 = line_in_gain | PS bit = 0x15 | 0x40 = 0x55.
+        Assert.Equal(0x55, cc[2]);
+        // mic_trs + mic_bias in C1.
+        Assert.Equal(0x30, cc[1]);
+    }
+
+    [Fact]
+    public void Attenuator_Hl2_AudioSet_PreservesStepAttenuatorByte()
+    {
+        // C4 step-attenuator byte (PGA select 0x40 | 60-Db) must be untouched
+        // by an audio write. 20 dB atten → 0x40 | (60-20) = 0x68.
+        var s = Hl2(ps: true) with
+        {
+            Atten = new HpsdrAtten(20),
+            MicTrs = true,
+            MicBias = true,
+            LineInGain = 0x1F,
+        };
+        var cc = Frame(ControlFrame.CcRegister.Attenuator, s);
+        Assert.Equal(0x68, cc[4]);
+    }
+
+    [Fact]
+    public void Attenuator_Hl2_AudioSet_PreservesPsTxStepAtten_DuringMox()
+    {
+        // The HL2 PS auto-attenuate path (C4 = (31 - txAttn) | 0x40 during MOX)
+        // must also survive an audio write. txAttn = 5 → 0x40 | (31-5) = 0x5A.
+        var s = Hl2(ps: true) with
+        {
+            Mox = true,
+            Hl2TxAttnDb = 5,
+            MicTrs = true,
+            LineInGain = 0x10,
+        };
+        var cc = Frame(ControlFrame.CcRegister.Attenuator, s);
+        Assert.Equal(0x5A, cc[4]);
+        // PS + audio still intact in C2.
+        Assert.Equal(1 << 6, cc[2] & (1 << 6));
+        Assert.Equal(0x10, cc[2] & 0x1F);
+    }
+
+    [Fact]
+    public void Attenuator_NonHl2_AudioFields_DoNotTouchTheFrame()
+    {
+        // A Hermes board with the 0x14-frame audio fields set must NOT emit
+        // mic_trs/bias/line_in_gain there — that frame's mic surface is HL2-
+        // only. (Hermes mic bits ride the 0x12 frame instead.)
+        var s = Hermes() with { MicTrs = true, MicBias = true, LineInGain = 0x1F };
+        var cc = Frame(ControlFrame.CcRegister.Attenuator, s);
+        Assert.Equal(0x00, cc[1]); // C1 — no mic bits
+        Assert.Equal(0x00, cc[2] & 0x1F); // C2 — no line_in_gain
+    }
+}

--- a/tests/Zeus.Protocol2.Tests/CmdTxAudioFrontEndTests.cs
+++ b/tests/Zeus.Protocol2.Tests/CmdTxAudioFrontEndTests.cs
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.Protocol2.Tests;
+
+/// <summary>
+/// GOLDEN-BYTE tests for the Protocol-2 audio front-end (external-ports plan,
+/// Phase 4). The TxSpecific (CmdTx, port 1026) packet carries the mic/line-in
+/// front-end at byte 50 (mic_control flags) + byte 51 (line_in_gain) — verified
+/// against ramdor Thetis network.c:1234,1236 with the byte-50 bit layout from
+/// network.c:1226-1233:
+///   bit0 = line_in, bit1 = mic_boost, bit2 = mic_ptt_disabled,
+///   bit3 = mic_ptt_tip, bit4 = mic_bias_enable, bit5 = balanced(XLR) input.
+///
+/// DEFAULT-UNSENT: with the audio front-end at defaults, bytes 50/51 stay 0,
+/// so the CmdTx tail is byte-identical to the pre-feature all-zero memset.
+/// </summary>
+public class CmdTxAudioFrontEndTests
+{
+    [Fact]
+    public void CmdTx_DefaultAudio_Bytes50And51AreZero()
+    {
+        // No mic_control / line_in_gain args → both bytes stay at the memset 0,
+        // byte-identical to today's CmdTx.
+        var p = Protocol2Client.ComposeCmdTxBuffer(
+            seq: 1, sampleRateKhz: 48, txStepAttnDb: 0, paEnabled: true, psEnabled: false);
+        Assert.Equal((byte)0, p[50]);
+        Assert.Equal((byte)0, p[51]);
+    }
+
+    [Theory]
+    [InlineData(false, false, false, false, 0x00)]
+    [InlineData(true,  false, false, false, 0x01)] // line_in → bit0
+    [InlineData(false, true,  false, false, 0x02)] // mic_boost → bit1
+    [InlineData(false, false, true,  false, 0x10)] // mic_bias → bit4
+    [InlineData(false, false, false, true,  0x20)] // balanced/XLR → bit5
+    [InlineData(true,  true,  true,  true,  0x33)] // all four
+    public void CmdTx_MicControl_FlagLayoutIsLocked(
+        bool lineIn, bool micBoost, bool micBias, bool xlr, byte expected)
+    {
+        byte ctl = 0;
+        if (lineIn)   ctl |= Protocol2Client.MicControlLineIn;
+        if (micBoost) ctl |= Protocol2Client.MicControlMicBoost;
+        if (micBias)  ctl |= Protocol2Client.MicControlMicBias;
+        if (xlr)      ctl |= Protocol2Client.MicControlXlr;
+
+        Assert.Equal(expected, ctl);
+
+        var p = Protocol2Client.ComposeCmdTxBuffer(
+            seq: 1, sampleRateKhz: 48, txStepAttnDb: 0, paEnabled: true, psEnabled: false,
+            micControl: ctl, lineInGain: 0);
+        Assert.Equal(expected, p[50]);
+    }
+
+    [Theory]
+    [InlineData((byte)0)]
+    [InlineData((byte)15)]
+    [InlineData((byte)31)]
+    public void CmdTx_LineInGain_LandsInByte51(byte gain)
+    {
+        var p = Protocol2Client.ComposeCmdTxBuffer(
+            seq: 1, sampleRateKhz: 48, txStepAttnDb: 0, paEnabled: true, psEnabled: false,
+            micControl: 0, lineInGain: gain);
+        Assert.Equal(gain, p[51]);
+    }
+
+    [Fact]
+    public void CmdTx_AudioSet_DoesNotDisturbStepAttenuatorBytes()
+    {
+        // The audio bytes (50/51) are disjoint from the PS / PA-protection
+        // bytes (57/58/59). Setting audio must not move them.
+        var p = Protocol2Client.ComposeCmdTxBuffer(
+            seq: 1, sampleRateKhz: 48, txStepAttnDb: 17, paEnabled: true, psEnabled: true,
+            micControl: 0x33, lineInGain: 31);
+        // PS-on asymmetry preserved.
+        Assert.Equal((byte)0, p[57]);
+        Assert.Equal((byte)31, p[58]);
+        Assert.Equal((byte)17, p[59]);
+        // Audio landed.
+        Assert.Equal((byte)0x33, p[50]);
+        Assert.Equal((byte)31, p[51]);
+    }
+
+    // ---- HOST BYTE-IDENTICAL: FULL-BUFFER differential golden (regression guard) ----
+
+    [Theory]
+    [InlineData(false, false)] // PS off
+    [InlineData(true,  true)]  // PS on + PA
+    public void CmdTx_HostSource_Is_FullBuffer_ByteIdentical_To_PreFeatureEmission(
+        bool psEnabled, bool paEnabled)
+    {
+        // The TX-audio source model resolves Host → micControl=0, lineInGain=0
+        // (ExternalPortEncoder, verified in the server-test purity suite). With
+        // those literal zeros the WHOLE 60-byte CmdTx buffer must be identical to
+        // the pre-feature emission (the overload that omits the audio args — i.e.
+        // the historical all-zero tail). Asserting the full buffer, not just 50/51,
+        // is the regression guard the plan requires.
+        var baseline = Protocol2Client.ComposeCmdTxBuffer(
+            seq: 7, sampleRateKhz: 48, txStepAttnDb: 19, paEnabled: paEnabled, psEnabled: psEnabled);
+        var hostResolved = Protocol2Client.ComposeCmdTxBuffer(
+            seq: 7, sampleRateKhz: 48, txStepAttnDb: 19, paEnabled: paEnabled, psEnabled: psEnabled,
+            micControl: 0, lineInGain: 0);
+
+        Assert.Equal(baseline.Length, hostResolved.Length);
+        Assert.Equal(60, hostResolved.Length);
+        Assert.True(baseline.AsSpan().SequenceEqual(hostResolved),
+            "Host source must reproduce the pre-feature CmdTx buffer byte-for-byte.");
+    }
+}

--- a/tests/Zeus.Server.Tests/AudioEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/AudioEndpointTests.cs
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// External-audio-jacks re-port — capability-gated /api/radio/audio.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Capability-gating + persistence of the global audio front-end endpoint. The
+/// connected board is simulated via the PreferredRadioStore override so
+/// RadioService.EffectiveBoardKind resolves without a live radio.
+/// </summary>
+public class AudioEndpointTests : IClassFixture<AudioEndpointTests.Factory>
+{
+    private readonly Factory _factory;
+    public AudioEndpointTests(Factory factory) => _factory = factory;
+
+    // The server serializes enums as their member names (JsonStringEnumConverter
+    // is registered globally in ZeusHost). The default test deserializer can't
+    // read a string back into TxAudioSource, so mirror the server's converter.
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    private async Task<AudioFrontEndDto?> GetAudioAsync(HttpClient client) =>
+        await client.GetFromJsonAsync<AudioFrontEndDto>("/api/radio/audio", Json);
+
+    private static async Task<AudioFrontEndDto?> ReadAudioAsync(HttpResponseMessage resp) =>
+        await resp.Content.ReadFromJsonAsync<AudioFrontEndDto>(Json);
+
+    private void SetBoard(HpsdrBoardKind board)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var prefs = scope.ServiceProvider.GetRequiredService<PreferredRadioStore>();
+        prefs.Set(board, overrideDetection: true);
+    }
+
+    [Fact]
+    public async Task CodecBoard_GET_ReportsCodecGate()
+    {
+        SetBoard(HpsdrBoardKind.OrionMkII); // has onboard codec
+        using var client = _factory.CreateClient();
+
+        var dto = await GetAudioAsync(client);
+        Assert.NotNull(dto);
+        Assert.True(dto!.HasOnboardCodec);
+        Assert.False(dto.HermesLite2MicFrontEnd);
+    }
+
+    [Fact]
+    public async Task Hl2_GET_ReportsMicFrontEndGate()
+    {
+        SetBoard(HpsdrBoardKind.HermesLite2);
+        using var client = _factory.CreateClient();
+
+        var dto = await GetAudioAsync(client);
+        Assert.NotNull(dto);
+        Assert.False(dto!.HasOnboardCodec);     // HL2 has no stream codec
+        Assert.True(dto.HermesLite2MicFrontEnd); // but DOES have the mic front-end
+    }
+
+    [Fact]
+    public async Task CodecBoard_GET_ReportsSourceGates()
+    {
+        // OrionMkII default variant is G2 (Saturn FPGA): line-in + bias + XLR.
+        SetBoard(HpsdrBoardKind.OrionMkII);
+        using var client = _factory.CreateClient();
+
+        var dto = await GetAudioAsync(client);
+        Assert.NotNull(dto);
+        Assert.True(dto!.HasRadioLineIn);
+        Assert.True(dto.HasBalancedXlr);
+        Assert.True(dto.HasMicBias);
+    }
+
+    [Fact]
+    public async Task CodecBoard_PUT_PersistsAndRoundTrips()
+    {
+        SetBoard(HpsdrBoardKind.OrionMkII); // G2 — supports RadioLineIn
+        using var client = _factory.CreateClient();
+
+        var resp = await client.PutAsJsonAsync("/api/radio/audio",
+            new { source = "RadioLineIn", micBoost = false, micBias = false, lineInGain = 18 });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var dto = await ReadAudioAsync(resp);
+        Assert.NotNull(dto);
+        Assert.Equal(TxAudioSource.RadioLineIn, dto!.Source);
+        Assert.Equal(18, dto.LineInGain);
+
+        var got = await GetAudioAsync(client);
+        Assert.Equal(18, got!.LineInGain);
+        Assert.Equal(TxAudioSource.RadioLineIn, got.Source);
+    }
+
+    [Fact]
+    public async Task LineInGain_ClampedTo31()
+    {
+        SetBoard(HpsdrBoardKind.OrionMkII); // G2 — supports RadioLineIn
+        using var client = _factory.CreateClient();
+
+        var resp = await client.PutAsJsonAsync("/api/radio/audio",
+            new { source = "RadioLineIn", micBoost = false, micBias = false, lineInGain = 200 });
+        var dto = await ReadAudioAsync(resp);
+        Assert.Equal(31, dto!.LineInGain);
+    }
+
+    [Fact]
+    public async Task NonAudioBoard_PUT_Is409()
+    {
+        // A board with neither codec nor HL2 mic front-end is rejected — the
+        // wire never gets handed audio bytes. (UnknownDefaults has both false.)
+        SetBoard(HpsdrBoardKind.Unknown);
+        using var client = _factory.CreateClient();
+
+        var resp = await client.PutAsJsonAsync("/api/radio/audio",
+            new { source = "RadioMic", micBoost = false, micBias = false, lineInGain = 0 });
+        Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnsupportedSource_OnBoard_ClampsToHost()
+    {
+        // HL2 has a mic front-end (so the PUT is accepted, not 409) but no
+        // onboard codec → it is Host-only. A RadioMic request must clamp back to
+        // Host rather than persist an illegal jack the wire can't emit.
+        SetBoard(HpsdrBoardKind.HermesLite2);
+        using var client = _factory.CreateClient();
+
+        var resp = await client.PutAsJsonAsync("/api/radio/audio",
+            new { source = "RadioMic", micBoost = true, micBias = true, lineInGain = 9 });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var dto = await ReadAudioAsync(resp);
+        Assert.Equal(TxAudioSource.Host, dto!.Source);
+        // Params dropped with the source.
+        Assert.False(dto.MicBoost);
+        Assert.False(dto.MicBias);
+    }
+
+    // Derive from the shared IsolatedPrefsFactory so each test class gets a
+    // fresh zeus-prefs.db (Linux state-isolation, GH #682). It already sets the
+    // Test environment and removes hosted services.
+    public sealed class Factory : IsolatedPrefsFactory
+    {
+    }
+}

--- a/tests/Zeus.Server.Tests/AudioSettingsStoreTests.cs
+++ b/tests/Zeus.Server.Tests/AudioSettingsStoreTests.cs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// External-ports plan, §2/§8 — global TX-audio SOURCE persistence round-trip +
+// legacy four-bool row migration to Host.
+
+using LiteDB;
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class AudioSettingsStoreTests : IDisposable
+{
+    private readonly string _dbPath;
+
+    public AudioSettingsStoreTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"zeus-prefs-audio-{Guid.NewGuid():N}.db");
+    }
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+    }
+
+    private AudioSettingsStore NewStore() =>
+        new AudioSettingsStore(NullLogger<AudioSettingsStore>.Instance, _dbPath);
+
+    [Fact]
+    public void Unset_Defaults_To_Host_NoBias()
+    {
+        using var store = NewStore();
+        var sel = store.Get();
+        Assert.Equal(TxAudioSource.Host, sel.Source);
+        Assert.False(sel.MicBoost);
+        Assert.False(sel.MicBias); // mic_bias defaults OFF
+        Assert.Equal(0, sel.LineInGain);
+    }
+
+    [Fact]
+    public void Set_RoundTrips_AcrossReopen()
+    {
+        using (var store = NewStore())
+        {
+            store.Set(new AudioSourceSelection(
+                Source: TxAudioSource.RadioLineIn, MicBoost: true, MicBias: true, LineInGain: 21));
+        }
+
+        using var reopened = NewStore();
+        var sel = reopened.Get();
+        Assert.Equal(TxAudioSource.RadioLineIn, sel.Source);
+        Assert.True(sel.MicBoost);
+        Assert.True(sel.MicBias);
+        Assert.Equal(21, sel.LineInGain);
+    }
+
+    [Fact]
+    public void Set_Twice_Updates_NotDuplicates_DeleteManyInsert()
+    {
+        // The DeleteMany+Insert upsert must replace the single global row, not
+        // accumulate rows (the LiteDB Id=0-always-inserts bug, PR #387).
+        using var store = NewStore();
+        store.Set(new AudioSourceSelection(TxAudioSource.RadioMic, false, false, 5));
+        store.Set(new AudioSourceSelection(TxAudioSource.RadioBalancedXlr, true, true, 12));
+
+        var sel = store.Get();
+        Assert.Equal(TxAudioSource.RadioBalancedXlr, sel.Source);
+        Assert.True(sel.MicBoost);
+        Assert.True(sel.MicBias);
+        Assert.Equal(12, sel.LineInGain);
+    }
+
+    [Fact]
+    public void LineInGain_ClampedTo31()
+    {
+        using var store = NewStore();
+        store.Set(new AudioSourceSelection(TxAudioSource.RadioLineIn, false, false, 99));
+        Assert.Equal(31, store.Get().LineInGain);
+    }
+
+    [Fact]
+    public void Changed_Fires_On_Set()
+    {
+        using var store = NewStore();
+        int fired = 0;
+        store.Changed += () => fired++;
+        store.Set(AudioSourceSelection.Default with { MicBoost = true });
+        Assert.Equal(1, fired);
+    }
+
+    [Fact]
+    public void LegacyFourBoolRow_MigratesTo_Host()
+    {
+        // Write a pre-rework row directly into the audio_frontend collection with
+        // the OLD four-bool schema (LineIn / MicBoost / MicBias / BalancedInput /
+        // LineInGain) and NO `Source` field. The new store must hydrate Source
+        // to Host (the schema-less LiteDB default 0) — the §8 migration contract.
+        using (var db = new LiteDatabase($"Filename={_dbPath};Connection=shared"))
+        {
+            var col = db.GetCollection("audio_frontend");
+            col.Insert(new BsonDocument
+            {
+                ["_id"] = 1,
+                ["LineIn"] = true,
+                ["MicBoost"] = true,
+                ["MicBias"] = true,
+                ["BalancedInput"] = true,
+                ["LineInGain"] = 17,
+                ["UpdatedUtc"] = DateTime.UtcNow,
+            });
+        }
+
+        using var store = NewStore();
+        var sel = store.Get();
+        // No `Source` field on the legacy row → Host (the clean fallback).
+        Assert.Equal(TxAudioSource.Host, sel.Source);
+        // The carried-over params survive as raw values (clamped at push time),
+        // but the SOURCE — the thing that actually drives the wire — is Host.
+        Assert.True(sel.MicBoost);
+        Assert.True(sel.MicBias);
+        Assert.Equal(17, sel.LineInGain);
+    }
+
+    [Fact]
+    public void CorruptSourceByte_FallsBackToHost()
+    {
+        using (var db = new LiteDatabase($"Filename={_dbPath};Connection=shared"))
+        {
+            var col = db.GetCollection("audio_frontend");
+            col.Insert(new BsonDocument
+            {
+                ["_id"] = 1,
+                ["Source"] = 99, // out of TxAudioSource range
+                ["MicBoost"] = false,
+                ["MicBias"] = false,
+                ["LineInGain"] = 0,
+            });
+        }
+
+        using var store = NewStore();
+        Assert.Equal(TxAudioSource.Host, store.Get().Source);
+    }
+}

--- a/tests/Zeus.Server.Tests/ExternalPortEncoderTests.cs
+++ b/tests/Zeus.Server.Tests/ExternalPortEncoderTests.cs
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Contracts;
+using Zeus.Protocol1;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Coverage + byte-identity tests for the external-port encoder seam
+/// (external-ports plan, Phase 1).
+///
+/// 1. Every <see cref="HpsdrBoardKind"/> resolves to a non-null encoder.
+/// 2. The encoders produce the SAME antenna bits as today's wire path for the
+///    default (ANT1) state — these complement the golden-byte tests in the
+///    protocol test projects, asserting the firewall is byte-identical.
+/// </summary>
+public class ExternalPortEncoderTests
+{
+    [Theory]
+    [InlineData(HpsdrBoardKind.Metis)]
+    [InlineData(HpsdrBoardKind.Hermes)]
+    [InlineData(HpsdrBoardKind.HermesII)]
+    [InlineData(HpsdrBoardKind.Angelia)]
+    [InlineData(HpsdrBoardKind.Orion)]
+    [InlineData(HpsdrBoardKind.HermesLite2)]
+    [InlineData(HpsdrBoardKind.OrionMkII)]
+    [InlineData(HpsdrBoardKind.HermesC10)]
+    [InlineData(HpsdrBoardKind.Unknown)]
+    public void For_ReturnsNonNullEncoder_ForEveryBoardKind(HpsdrBoardKind board)
+    {
+        var encoder = ExternalPortEncoders.For(board);
+        Assert.NotNull(encoder);
+        Assert.False(string.IsNullOrWhiteSpace(encoder.Label));
+    }
+
+    [Fact]
+    public void For_ReturnsNonNullEncoder_ForEveryEnumeratedBoardKind()
+    {
+        foreach (HpsdrBoardKind board in Enum.GetValues<HpsdrBoardKind>())
+        {
+            Assert.NotNull(ExternalPortEncoders.For(board));
+        }
+    }
+
+    [Theory]
+    [InlineData(OrionMkIIVariant.G2)]
+    [InlineData(OrionMkIIVariant.G2_1K)]
+    [InlineData(OrionMkIIVariant.Anan7000DLE)]
+    [InlineData(OrionMkIIVariant.Anan8000DLE)]
+    [InlineData(OrionMkIIVariant.OrionMkII)]
+    [InlineData(OrionMkIIVariant.AnvelinaPro3)]
+    [InlineData(OrionMkIIVariant.RedPitaya)]
+    public void For_0x0A_RoutesToProtocol2Encoder_ForEveryVariant(OrionMkIIVariant variant)
+    {
+        var encoder = ExternalPortEncoders.For(HpsdrBoardKind.OrionMkII, variant);
+        Assert.IsType<Protocol2PortEncoder>(encoder);
+    }
+
+    [Fact]
+    public void For_Hermes_RoutesToProtocol1Encoder()
+        => Assert.IsType<Protocol1PortEncoder>(ExternalPortEncoders.For(HpsdrBoardKind.Hermes));
+
+    [Fact]
+    public void For_Hl2_RoutesToHl2Encoder()
+        => Assert.IsType<HermesLite2PortEncoder>(ExternalPortEncoders.For(HpsdrBoardKind.HermesLite2));
+
+    [Fact]
+    public void DefaultProtocolFor_0x0A_IsProtocol2_OthersProtocol1()
+    {
+        Assert.Equal(RadioProtocol.Protocol2, ExternalPortEncoders.DefaultProtocolFor(HpsdrBoardKind.OrionMkII));
+        Assert.Equal(RadioProtocol.Protocol1, ExternalPortEncoders.DefaultProtocolFor(HpsdrBoardKind.Hermes));
+        Assert.Equal(RadioProtocol.Protocol1, ExternalPortEncoders.DefaultProtocolFor(HpsdrBoardKind.HermesLite2));
+    }
+
+
+    // ---- TX-audio source: P2 byte-50/51 PURE FUNCTIONS (external-ports §2) ----
+
+    [Theory]
+    // Host: literal 0 regardless of any persisted params.
+    [InlineData(TxAudioSource.Host, false, false, (byte)0x00)]
+    [InlineData(TxAudioSource.Host, true, true, (byte)0x00)]
+    // RadioMic: boost (bit1) + bias (bit4) from params, no line-in/XLR bits.
+    [InlineData(TxAudioSource.RadioMic, false, false, (byte)0x00)]
+    [InlineData(TxAudioSource.RadioMic, true, false, (byte)0x02)]
+    [InlineData(TxAudioSource.RadioMic, false, true, (byte)0x10)]
+    [InlineData(TxAudioSource.RadioMic, true, true, (byte)0x12)]
+    // RadioLineIn: line-in select (bit0); mic params ignored.
+    [InlineData(TxAudioSource.RadioLineIn, true, true, (byte)0x01)]
+    // RadioBalancedXlr: XLR (bit5) | opt boost/bias.
+    [InlineData(TxAudioSource.RadioBalancedXlr, false, false, (byte)0x20)]
+    [InlineData(TxAudioSource.RadioBalancedXlr, true, true, (byte)0x32)]
+    public void P2Encoder_MicControlByte_IsPureFunctionOfSource(
+        TxAudioSource source, bool micBoost, bool micBias, byte expected)
+    {
+        var encoder = ExternalPortEncoders.For(HpsdrBoardKind.OrionMkII);
+        var state = new ExternalPortState(Source: source, MicBoost: micBoost, MicBias: micBias);
+        Assert.Equal(expected, encoder.EncodeP2MicControlByte(in state));
+    }
+
+    [Fact]
+    public void P2Encoder_Host_ByteIsLiteralZero_DespitePersistedParams()
+    {
+        // PURITY: a stale non-zero MicBoost/MicBias/LineInGain must NOT leak onto
+        // the wire after a revert to Host. Host returns literal 0 on every surface.
+        var encoder = ExternalPortEncoders.For(HpsdrBoardKind.OrionMkII);
+        var leaky = new ExternalPortState(
+            Source: TxAudioSource.Host, MicBoost: true, MicBias: true, LineInGain: 31);
+        Assert.Equal((byte)0x00, encoder.EncodeP2MicControlByte(in leaky));
+        Assert.Equal((byte)0x00, encoder.EncodeP2LineInGainByte(in leaky));
+    }
+
+    [Theory]
+    // Gain rides byte 51 ONLY for RadioLineIn; every other source returns 0.
+    [InlineData(TxAudioSource.RadioLineIn, (byte)19, (byte)19)]
+    [InlineData(TxAudioSource.RadioLineIn, (byte)63, (byte)31)] // 5-bit clamp
+    [InlineData(TxAudioSource.RadioMic, (byte)19, (byte)0)]
+    [InlineData(TxAudioSource.RadioBalancedXlr, (byte)19, (byte)0)]
+    [InlineData(TxAudioSource.Host, (byte)19, (byte)0)]
+    public void P2Encoder_LineInGainByte_OnlyForLineIn(
+        TxAudioSource source, byte gain, byte expected)
+    {
+        var encoder = ExternalPortEncoders.For(HpsdrBoardKind.OrionMkII);
+        var state = new ExternalPortState(Source: source, LineInGain: gain);
+        Assert.Equal(expected, encoder.EncodeP2LineInGainByte(in state));
+    }
+
+    [Theory]
+    // P1 codec 0x12 bits (mic_boost C2[0], mic_linein C2[1]). RadioMic → boost
+    // from param; Host / everything else → all clear (no leak).
+    [InlineData(TxAudioSource.Host, true, false, false)]
+    [InlineData(TxAudioSource.RadioMic, false, false, false)]
+    [InlineData(TxAudioSource.RadioMic, true, true, false)]
+    public void P1Encoder_CodecAudioBits_IsPureFunctionOfSource(
+        TxAudioSource source, bool micBoost, bool expBoost, bool expLineIn)
+    {
+        var encoder = ExternalPortEncoders.For(HpsdrBoardKind.Hermes);
+        var state = new ExternalPortState(Source: source, MicBoost: micBoost);
+        var (boost, lineIn) = encoder.EncodeP1CodecAudioBits(in state);
+        Assert.Equal(expBoost, boost);
+        Assert.Equal(expLineIn, lineIn);
+    }
+
+    [Fact]
+    public void Hl2Encoder_AllAudioSurfaces_AreZero_HostOnly()
+    {
+        // HL2 is Host-only — no codec audio bits, no P2 bytes, ever.
+        var encoder = ExternalPortEncoders.For(HpsdrBoardKind.HermesLite2);
+        var hot = new ExternalPortState(
+            Source: TxAudioSource.RadioMic, MicBoost: true, MicBias: true, LineInGain: 31);
+        Assert.Equal((byte)0, encoder.EncodeP2MicControlByte(in hot));
+        Assert.Equal((byte)0, encoder.EncodeP2LineInGainByte(in hot));
+        var (boost, lineIn) = encoder.EncodeP1CodecAudioBits(in hot);
+        Assert.False(boost);
+        Assert.False(lineIn);
+    }
+
+    // ---- RadioService.ClampAudioSource against board capabilities (§5/§8) ----
+
+    [Fact]
+    public void Clamp_BalancedXlr_OnNonXlrBoard_FallsBackToHost()
+    {
+        // 7000DLE has line-in + bias but NO balanced XLR. A persisted XLR
+        // selection (e.g. after a G2→7000DLE swap) must clamp to Host.
+        var caps = BoardCapabilitiesTable.For(HpsdrBoardKind.OrionMkII, OrionMkIIVariant.Anan7000DLE);
+        var got = RadioService.ClampAudioSource(
+            new AudioSourceSelection(TxAudioSource.RadioBalancedXlr, true, true, 0), caps);
+        Assert.Equal(TxAudioSource.Host, got.Source);
+    }
+
+    [Fact]
+    public void Clamp_LineIn_OnBoardWithoutLineIn_FallsBackToHost()
+    {
+        // Hermes (pure P1 codec) has no RadioLineIn exposure in v1.
+        var caps = BoardCapabilitiesTable.For(HpsdrBoardKind.Hermes);
+        var got = RadioService.ClampAudioSource(
+            new AudioSourceSelection(TxAudioSource.RadioLineIn, false, false, 12), caps);
+        Assert.Equal(TxAudioSource.Host, got.Source);
+    }
+
+    [Fact]
+    public void Clamp_AnyRadioSource_OnHl2_FallsBackToHost()
+    {
+        // HL2 has the mic front-end (so not a 409) but no codec → Host-only.
+        var caps = BoardCapabilitiesTable.For(HpsdrBoardKind.HermesLite2);
+        foreach (var src in new[] { TxAudioSource.RadioMic, TxAudioSource.RadioLineIn, TxAudioSource.RadioBalancedXlr })
+        {
+            var got = RadioService.ClampAudioSource(
+                new AudioSourceSelection(src, true, true, 9), caps);
+            Assert.Equal(TxAudioSource.Host, got.Source);
+        }
+    }
+
+    [Fact]
+    public void Clamp_MicBias_DroppedOnNonBiasBoard()
+    {
+        // Red Pitaya has line-in but NOT mic bias. RadioMic survives; the bias
+        // param is dropped so a stale bias bit can never reach the wire.
+        var caps = BoardCapabilitiesTable.For(HpsdrBoardKind.OrionMkII, OrionMkIIVariant.RedPitaya);
+        var got = RadioService.ClampAudioSource(
+            new AudioSourceSelection(TxAudioSource.RadioMic, MicBoost: true, MicBias: true, LineInGain: 0), caps);
+        Assert.Equal(TxAudioSource.RadioMic, got.Source);
+        Assert.True(got.MicBoost);
+        Assert.False(got.MicBias); // dropped — Red Pitaya has no mic bias
+    }
+
+    [Fact]
+    public void Clamp_G2_KeepsAllSources()
+    {
+        // G2 (default OrionMkII variant) honours every radio source.
+        var caps = BoardCapabilitiesTable.For(HpsdrBoardKind.OrionMkII);
+        Assert.Equal(TxAudioSource.RadioBalancedXlr,
+            RadioService.ClampAudioSource(new AudioSourceSelection(TxAudioSource.RadioBalancedXlr, false, false, 0), caps).Source);
+        Assert.Equal(TxAudioSource.RadioLineIn,
+            RadioService.ClampAudioSource(new AudioSourceSelection(TxAudioSource.RadioLineIn, false, false, 7), caps).Source);
+        var mic = RadioService.ClampAudioSource(new AudioSourceSelection(TxAudioSource.RadioMic, true, true, 0), caps);
+        Assert.Equal(TxAudioSource.RadioMic, mic.Source);
+        Assert.True(mic.MicBias); // G2 has mic bias
+    }
+}

--- a/tests/Zeus.Server.Tests/RadioMicReceiverTests.cs
+++ b/tests/Zeus.Server.Tests/RadioMicReceiverTests.cs
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Distributed under the GNU General Public License v2 or later. See the
+// LICENSE file at the root of this repository for full text.
+
+using System.Buffers.Binary;
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Dsp;
+using Zeus.Protocol1;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+// Covers the Saturn radio-mic (UDP 1026) parse + 960-sample re-blocker
+// (external-ports plan, §3). The packet layout is verified against pihpsdr
+// src/new_protocol.c process_mic_data (4-byte BE seq + 64 × int16 BE @ 48 kHz).
+public class RadioMicReceiverTests
+{
+    // Build one 132-byte 1026 packet: 4-byte BE seq + 64 × int16 BE samples.
+    private static byte[] BuildPacket(uint seq, Func<int, short> sampleAt)
+    {
+        var buf = new byte[RadioMicReceiver.PacketBytes];
+        BinaryPrimitives.WriteUInt32BigEndian(buf.AsSpan(0, 4), seq);
+        int b = 4;
+        for (int i = 0; i < RadioMicReceiver.PacketSamples; i++, b += 2)
+            BinaryPrimitives.WriteInt16BigEndian(buf.AsSpan(b, 2), sampleAt(i));
+        return buf;
+    }
+
+    [Fact]
+    public void ReBlocks_SixtyFourSamplePackets_IntoNineSixtySampleBlocks()
+    {
+        var blocks = new List<byte[]>();
+        var rx = new RadioMicReceiver(b => blocks.Add(b.ToArray()), NullLogger.Instance);
+
+        // 15 packets × 64 = 960 samples → exactly one 960-sample block.
+        for (uint i = 0; i < 15; i++)
+            rx.Accept(BuildPacket(i, _ => 8192));   // 8192/32768 = 0.25
+
+        Assert.Single(blocks);
+        Assert.Equal(RadioMicReceiver.OutputBlockSamples * 4, blocks[0].Length);
+
+        // Verify the decode: int16 8192 → f32 0.25, little-endian on the wire out.
+        float first = BinaryPrimitives.ReadSingleLittleEndian(blocks[0].AsSpan(0, 4));
+        Assert.Equal(0.25f, first, 5);
+
+        // 14 packets (896 samples) → no further block; remainder carried.
+        for (uint i = 15; i < 29; i++)
+            rx.Accept(BuildPacket(i, _ => 8192));
+        Assert.Single(blocks);
+
+        // One more packet (960 total) → second block emitted.
+        rx.Accept(BuildPacket(29, _ => 8192));
+        Assert.Equal(2, blocks.Count);
+    }
+
+    [Fact]
+    public void Reset_DropsRemainder_NoStitchAcrossSwitch()
+    {
+        var blocks = new List<byte[]>();
+        var rx = new RadioMicReceiver(b => blocks.Add(b.ToArray()), NullLogger.Instance);
+
+        // 10 packets (640 samples) accumulate, no block yet.
+        for (uint i = 0; i < 10; i++) rx.Accept(BuildPacket(i, _ => 16384));
+        Assert.Empty(blocks);
+
+        rx.Reset();   // source switch — drop the 640-sample remainder
+
+        // 15 fresh packets (960). Were the 640 NOT dropped, 640+960=1600 would
+        // emit a block at 960 with stale audio in front. After Reset the first
+        // block is purely the new audio and arrives only once 960 new samples land.
+        for (uint i = 0; i < 15; i++) rx.Accept(BuildPacket(i, _ => 16384));
+        Assert.Single(blocks);
+    }
+
+    [Fact]
+    public void RejectsUndersizedPacket()
+    {
+        var blocks = new List<byte[]>();
+        var rx = new RadioMicReceiver(b => blocks.Add(b.ToArray()), NullLogger.Instance);
+
+        rx.Accept(new byte[100]);   // < 132
+        Assert.Empty(blocks);
+        Assert.Equal(1, rx.TotalPacketsDropped);
+    }
+
+    // END-TO-END: a synthetic 64-sample 1026 feed, after re-blocking, reaches
+    // ProcessTxBlock and produces NON-ZERO IQ (external-ports plan, §3 / §10
+    // test register). Wires RadioMicReceiver → TxAudioIngest.OnMicPcmBytesFromRadioMic
+    // with a radio source armed, MOX on, and a stub engine that copies mic → I.
+    [Fact]
+    public void SyntheticPacketFeed_ReachesProcessTxBlock_ProducesNonZeroIq()
+    {
+        var engine = new CopyEngine { BlockSize = 1024 };
+        var ring = new TxIqRing();
+        var hub = new StreamingHub(new NullLogger<StreamingHub>());
+        using var ingest = new TxAudioIngest(
+            ring, () => engine, () => true, hub, new NullLogger<TxAudioIngest>());
+        ingest.SetActiveSource(TxAudioSource.RadioMic);   // arm the radio jack
+
+        var rx = new RadioMicReceiver(
+            block => ingest.OnMicPcmBytesFromRadioMic(block), NullLogger.Instance);
+
+        // Feed enough 64-sample packets to flush at least one WDSP block: WDSP
+        // wants 1024 samples; 1024/64 = 16 packets cover the first 960-sample mic
+        // block (15 pkts) plus carry — push 32 packets (2048 samples) to be safe.
+        for (uint i = 0; i < 32; i++)
+            rx.Accept(BuildPacket(i, _ => 16384));   // 0.5 amplitude
+
+        Assert.True(ingest.TotalTxBlocks >= 1);       // re-block reached WDSP
+        Assert.True(ring.Count > 0);                  // IQ produced and ringed
+
+        // Drain the ring (pairs) and confirm non-zero IQ samples are present.
+        int pairs = ring.Count;
+        bool nonZero = false;
+        for (int i = 0; i < pairs; i++)
+        {
+            var (iv, qv) = ring.Next(1.0);
+            if (iv != 0 || qv != 0) { nonZero = true; break; }
+        }
+        Assert.True(nonZero, "re-blocked radio-mic feed produced all-zero IQ");
+    }
+
+    // Minimal engine: copies mic mono into I (Q=0) so non-zero mic → non-zero IQ.
+    private sealed class CopyEngine : IDspEngine
+    {
+        public int BlockSize { get; set; } = 1024;
+        public int TxBlockSamples => BlockSize;
+        public int TxOutputSamples => BlockSize;
+
+        public int ProcessTxBlock(ReadOnlySpan<float> micMono, Span<float> iqInterleaved)
+        {
+            for (int i = 0; i < BlockSize; i++) { iqInterleaved[2 * i] = micMono[i]; iqInterleaved[2 * i + 1] = 0f; }
+            return BlockSize;
+        }
+
+        public int OpenChannel(int sampleRateHz, int pixelWidth) => 0;
+        public void CloseChannel(int channelId) { }
+        public void FeedIq(int channelId, ReadOnlySpan<double> interleavedIqSamples) { }
+        public void SetMode(int channelId, RxMode mode) { }
+        public void SetFilter(int channelId, int lowHz, int highHz) { }
+        public void SetVfoHz(int channelId, long vfoHz) { }
+        public void SetCtunShift(int channelId, int shiftHz) { }
+        public void SetAgcTop(int channelId, double topDb) { }
+        public void SetAgcThresh(int channelId, double threshDbm) { }
+        public double GetAgcTop(int channelId) => 0.0;
+        public double GetAgcThresh(int channelId) => 0.0;
+        public void SetAgc(int channelId, AgcConfig cfg) { }
+        public void SetSquelch(int channelId, SquelchConfig cfg) { }
+        public void SetTxLeveling(int channelId, TxLevelingConfig cfg) { }
+        public void SetNotches(IReadOnlyList<NotchDto> notches) { }
+        public void SetNotchTuneFrequencyHz(double loHz) { }
+        public void ConfigureTxDisplayAnalyzer(int fftSize, int windowType, double avgTauSec) { }
+        public void SetRxDisplayFastAttack(int channelId, bool fast) { }
+        public void SetRxAfGainDb(int channelId, double db) { }
+        public void SetNoiseReduction(int channelId, NrConfig cfg) { }
+        public void SetZoom(int channelId, int level) { }
+        public int ReadAudio(int channelId, Span<float> output) => 0;
+        public bool TryGetDisplayPixels(int channelId, DisplayPixout which, Span<float> dbOut) => false;
+        public bool TryGetTxDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
+        public bool TryGetPsFeedbackDisplayPixels(DisplayPixout which, Span<float> dbOut) => false;
+        public int OpenTxChannel(int outputRateHz = 48_000) => 0;
+        public void SetMox(bool moxOn) { }
+        public double GetRxaSignalDbm(int channelId) => -140.0;
+        public RxStageMeters GetRxStageMeters(int channelId) => RxStageMeters.Silent;
+        public void SetTxMode(RxMode mode) { }
+        public void SetTxFilter(int lowHz, int highHz) { }
+        public void SetTxPanelGain(double linearGain) { }
+        public void SetTxLevelerMaxGain(double maxGainDb) { }
+        public void SetTxTune(bool on) { }
+        public TxStageMeters GetTxStageMeters() => TxStageMeters.Silent;
+        public void SetTwoTone(bool on, double freq1, double freq2, double mag) { }
+        public void SetPsEnabled(bool enabled) { }
+        public void SetPsControl(bool autoCal, bool singleCal) { }
+        public void SetPsHold(bool hold) { }
+        public void SetPsAdvanced(bool ptol, double moxDelaySec, double loopDelaySec,
+                                  double ampDelayNs, double hwPeak, int ints, int spi) { }
+        public void SetPsHwPeak(double hwPeak) { }
+        public void FeedPsFeedbackBlock(ReadOnlySpan<float> txI, ReadOnlySpan<float> txQ,
+                                        ReadOnlySpan<float> rxI, ReadOnlySpan<float> rxQ) { }
+        public PsStageMeters GetPsStageMeters() => PsStageMeters.Silent;
+        public void ResetPs() { }
+        public void SavePsCorrection(string path) { }
+        public void RestorePsCorrection(string path) { }
+        public void SetCfcConfig(CfcConfig cfg) { }
+        public void SetTxMonitorEnabled(bool enabled) { }
+        public int ReadTxMonitorAudio(Span<float> output) => 0;
+        public bool IsTxMonitorOn => false;
+        public void Dispose() { }
+    }
+}

--- a/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
+++ b/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
@@ -256,6 +256,65 @@ public class TxAudioIngestTests
         Assert.True(ring.Count > 0);
     }
 
+    // ---- source-aware mic meter (radio-jack peak) ----
+
+    [Fact]
+    public void RadioArmed_RadioBlock_PopulatesRadioMeterPeak_ThenConsumeResets()
+    {
+        // The source-aware mic meter reads the radio-jack peak from accepted
+        // radio blocks, so the meter reflects the ACTUAL radio input instead of
+        // the host mic. ConsumeRadioPeakLinear returns the peak then resets, so
+        // the next heartbeat with no radio audio reads silence.
+        var engine = new StubEngine { BlockSize = 1024 };
+        var ring = new TxIqRing();
+        var hub = new StreamingHub(new NullLogger<StreamingHub>());
+        using var ingest = new TxAudioIngest(
+            ring, () => engine, () => true, hub, new NullLogger<TxAudioIngest>());
+
+        ingest.SetActiveSource(TxAudioSource.RadioMic);
+        var payload = BuildMicPcmPayload(_ => 0.5f);
+        ingest.OnMicPcmBytes(payload, MicBlockSource.RadioMic);
+
+        float peak = ingest.ConsumeRadioPeakLinear();
+        Assert.True(MathF.Abs(peak - 0.5f) < 1e-4f, $"expected ~0.5, got {peak}");
+        Assert.Equal(0f, ingest.ConsumeRadioPeakLinear());   // reset on consume
+    }
+
+    [Fact]
+    public void HostArmed_HostBlocks_DoNotPopulateRadioMeterPeak()
+    {
+        // While Host is armed the radio meter peak stays silent — it only tracks
+        // accepted radio blocks (the host meter comes from NativeMicCapture's own
+        // window peak). Guards against host audio bleeding into the radio meter.
+        var engine = new StubEngine { BlockSize = 1024 };
+        var ring = new TxIqRing();
+        var hub = new StreamingHub(new NullLogger<StreamingHub>());
+        using var ingest = new TxAudioIngest(
+            ring, () => engine, () => true, hub, new NullLogger<TxAudioIngest>());
+
+        var payload = BuildMicPcmPayload(_ => 0.5f);
+        ingest.OnMicPcmBytes(payload, MicBlockSource.Host);
+        ingest.OnMicPcmBytes(payload, MicBlockSource.Host);
+        Assert.Equal(0f, ingest.ConsumeRadioPeakLinear());
+    }
+
+    [Fact]
+    public void SourceSwitch_ClearsStaleRadioMeterPeak()
+    {
+        // Switching source drops any buffered radio meter peak so it can't bleed
+        // across a switch (radio→host must stop surfacing a frozen radio level).
+        var engine = new StubEngine { BlockSize = 1024 };
+        var ring = new TxIqRing();
+        var hub = new StreamingHub(new NullLogger<StreamingHub>());
+        using var ingest = new TxAudioIngest(
+            ring, () => engine, () => true, hub, new NullLogger<TxAudioIngest>());
+
+        ingest.SetActiveSource(TxAudioSource.RadioMic);
+        ingest.OnMicPcmBytes(BuildMicPcmPayload(_ => 0.5f), MicBlockSource.RadioMic);
+        ingest.SetActiveSource(TxAudioSource.Host);   // switch before heartbeat read
+        Assert.Equal(0f, ingest.ConsumeRadioPeakLinear());
+    }
+
     [Fact]
     public void MicPayload_SanitizesNonFiniteAndOverrangeSamplesBeforeWdsp()
     {

--- a/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
+++ b/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
@@ -206,6 +206,56 @@ public class TxAudioIngestTests
         Assert.Equal(0, engine.ProcessedBlocks);
     }
 
+    // ---- HOST↔RADIO single-select gate (external-audio-jacks re-port) ----
+
+    [Fact]
+    public void HostArmed_RadioMicBlock_IsDropped()
+    {
+        // Default armed source is Host. A RadioMic-tagged block must be dropped
+        // by the in-lock single-select gate — it can NEVER leak onto the air
+        // while Host is selected.
+        var engine = new StubEngine { BlockSize = 1024 };
+        var ring = new TxIqRing();
+        var hub = new StreamingHub(new NullLogger<StreamingHub>());
+        using var ingest = new TxAudioIngest(
+            ring, () => engine, () => true, hub, new NullLogger<TxAudioIngest>());
+
+        Assert.Equal(MicBlockSource.Host, ingest.ActiveSource);
+        var payload = BuildMicPcmPayload(_ => 0.5f);
+        ingest.OnMicPcmBytes(payload, MicBlockSource.RadioMic);
+        ingest.OnMicPcmBytes(payload, MicBlockSource.RadioMic);
+        Assert.Equal(0, engine.ProcessedBlocks);   // never reached WDSP
+        Assert.Equal(0, ring.Count);
+        Assert.True(ingest.DroppedFrames >= 2);
+    }
+
+    [Fact]
+    public void RadioArmed_HostBlock_IsDropped_RadioMicBlock_Flows()
+    {
+        // After arming RadioMic, the host mic is dropped and the radio jack
+        // feeds WDSP — exactly one contributor at a time, no double-feed.
+        var engine = new StubEngine { BlockSize = 1024 };
+        var ring = new TxIqRing();
+        var hub = new StreamingHub(new NullLogger<StreamingHub>());
+        using var ingest = new TxAudioIngest(
+            ring, () => engine, () => true, hub, new NullLogger<TxAudioIngest>());
+
+        ingest.SetActiveSource(TxAudioSource.RadioMic);
+        Assert.Equal(MicBlockSource.RadioMic, ingest.ActiveSource);
+
+        var payload = BuildMicPcmPayload(_ => 0.5f);
+        // Host blocks are dropped while the radio jack is armed.
+        ingest.OnMicPcmBytes(payload, MicBlockSource.Host);
+        ingest.OnMicPcmBytes(payload, MicBlockSource.Host);
+        Assert.Equal(0, engine.ProcessedBlocks);
+
+        // Radio-mic blocks flow through to WDSP.
+        ingest.OnMicPcmBytes(payload, MicBlockSource.RadioMic);
+        ingest.OnMicPcmBytes(payload, MicBlockSource.RadioMic);
+        Assert.Equal(1, engine.ProcessedBlocks);   // 1920 ≥ 1024 → one block
+        Assert.True(ring.Count > 0);
+    }
+
     [Fact]
     public void MicPayload_SanitizesNonFiniteAndOverrangeSamplesBeforeWdsp()
     {

--- a/zeus-web/src/api/board-capabilities.ts
+++ b/zeus-web/src/api/board-capabilities.ts
@@ -46,6 +46,19 @@ export interface BoardCapabilities {
    *  PA Settings panel's DX OUT subsection renders unconditionally but
    *  disables itself when this flag is false. */
   supportsAnvelinaDxOc: boolean;
+  // ---- TX audio front-end (external-audio-jacks re-port) ----
+  /** Board decodes the host→radio audio STREAM (TLV320 codec). Gates the
+   *  Radio Mic source. False on Hermes-Lite 2 (no stream codec). */
+  hasOnboardCodec: boolean;
+  /** Hermes-Lite 2 0x14-frame mic front-end (inert plumbing in v1). */
+  hermesLite2MicFrontEnd: boolean;
+  /** Board has a switchable analog line-in jack (gates RadioLineIn). */
+  hasRadioLineIn: boolean;
+  /** Board has a switchable balanced XLR mic input (G2 / G2-1K only). */
+  hasBalancedXlr: boolean;
+  /** Board can enable the Orion electret mic-bias supply (gates the bias
+   *  toggle). Defaults OFF; the UI confirms before enabling. */
+  hasMicBias: boolean;
 }
 
 // Safe defaults matching Zeus.Contracts.BoardCapabilities.UnknownDefaults —
@@ -67,6 +80,11 @@ export const UNKNOWN_BOARD_CAPABILITIES: BoardCapabilities = {
   maxPowerWatts: 100,
   maxRxSampleRateHz: 384_000,
   supportsAnvelinaDxOc: false,
+  hasOnboardCodec: false,
+  hermesLite2MicFrontEnd: false,
+  hasRadioLineIn: false,
+  hasBalancedXlr: false,
+  hasMicBias: false,
 };
 
 function parseSampleRateCeiling(raw: unknown): number {
@@ -118,6 +136,26 @@ export function parseBoardCapabilities(raw: unknown): BoardCapabilities {
       typeof r.supportsAnvelinaDxOc === 'boolean'
         ? r.supportsAnvelinaDxOc
         : UNKNOWN_BOARD_CAPABILITIES.supportsAnvelinaDxOc,
+    hasOnboardCodec:
+      typeof r.hasOnboardCodec === 'boolean'
+        ? r.hasOnboardCodec
+        : UNKNOWN_BOARD_CAPABILITIES.hasOnboardCodec,
+    hermesLite2MicFrontEnd:
+      typeof r.hermesLite2MicFrontEnd === 'boolean'
+        ? r.hermesLite2MicFrontEnd
+        : UNKNOWN_BOARD_CAPABILITIES.hermesLite2MicFrontEnd,
+    hasRadioLineIn:
+      typeof r.hasRadioLineIn === 'boolean'
+        ? r.hasRadioLineIn
+        : UNKNOWN_BOARD_CAPABILITIES.hasRadioLineIn,
+    hasBalancedXlr:
+      typeof r.hasBalancedXlr === 'boolean'
+        ? r.hasBalancedXlr
+        : UNKNOWN_BOARD_CAPABILITIES.hasBalancedXlr,
+    hasMicBias:
+      typeof r.hasMicBias === 'boolean'
+        ? r.hasMicBias
+        : UNKNOWN_BOARD_CAPABILITIES.hasMicBias,
   };
 }
 

--- a/zeus-web/src/audio/mic-uplink-session.ts
+++ b/zeus-web/src/audio/mic-uplink-session.ts
@@ -15,6 +15,7 @@ import { useMicUplinkDiagnosticsStore } from './mic-uplink-diagnostics-store';
 import { createMicUplinkAutoGain } from './mic-uplink-gain';
 import { sendMicPcm } from '../realtime/ws-client';
 import { useAudioDeviceStore } from '../state/audio-device-store';
+import { useAudioStore } from '../state/audio-store';
 import { useTxStore } from '../state/tx-store';
 import { warnOnce } from '../util/logger';
 
@@ -35,6 +36,21 @@ function micErrorMessage(err: unknown): string {
 }
 
 function onMicBlock(samples: Float32Array, peak: number): void {
+  // Single-select: when a RADIO audio source is active (Radio Mic / Line In /
+  // Balanced) the host browser mic is neither metered nor streamed — otherwise
+  // the operator would see host-mic level on a radio source (the meter would
+  // "lie") and we'd churn the WS with PCM the backend already drops. Park the
+  // meter at the silence floor on the normal visual cadence and bail.
+  if (useAudioStore.getState().settings.source !== 'Host') {
+    const nowSuppressed = performance.now();
+    if (nowSuppressed - lastEmit >= MIC_VISUAL_INTERVAL_MS) {
+      useTxStore.getState().setMicDbfs(MIC_DBFS_FLOOR);
+      lastEmit = nowSuppressed;
+      windowPeak = 0;
+    }
+    return;
+  }
+
   const tx = useTxStore.getState();
   const shouldSend = forceTxSend || tx.localMicArmed || tx.txMonitorEnabled;
   const outbound = shouldSend

--- a/zeus-web/src/components/RadioSettingsPanel.test.tsx
+++ b/zeus-web/src/components/RadioSettingsPanel.test.tsx
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// RadioSettingsPanel — Audio Input card behavior gates (external-audio-jacks
+// re-port):
+//   1. TX-audio source is SINGLE-SELECT — a radio-button group where exactly one
+//      option is checked at a time (the old multi-checkbox bug is structurally
+//      impossible).
+//   2. DEFAULT-OFF — with the server-authoritative store at Host, every param
+//      control (boost/bias/gain) is hidden.
+//   3. Dependent params are visible ONLY for the active source.
+//   4. Board-gating — the source list is driven by the per-board capability
+//      flags carried in the /api/radio/audio response: Balanced renders only
+//      when hasBalancedXlr; HL2 (codec false, mic-front-end true) collapses to
+//      Host-only.
+//
+// Uses the project's createRoot + act idiom (see SettingsMenu.test.tsx); no RTL.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { RadioSettingsPanel } from './RadioSettingsPanel';
+import { useAudioStore, type TxAudioSource } from '../state/audio-store';
+import { usePttStore } from '../state/ptt-store';
+
+type Gates = {
+  hasOnboardCodec: boolean;
+  hermesLite2MicFrontEnd: boolean;
+  hasRadioLineIn: boolean;
+  hasBalancedXlr: boolean;
+  hasMicBias: boolean;
+};
+
+// A fully-featured Saturn-class fingerprint: codec + line-in + balanced XLR +
+// mic-bias. Board-gating tests trim flags off this.
+const G2_GATES: Gates = {
+  hasOnboardCodec: true,
+  hermesLite2MicFrontEnd: false,
+  hasRadioLineIn: true,
+  hasBalancedXlr: true,
+  hasMicBias: true,
+};
+
+// HL2: no codec, no radio jacks — the mic front-end flag is set but
+// hasOnboardCodec is false, which is the Host-only collapse.
+const HL2_GATES: Gates = {
+  hasOnboardCodec: false,
+  hermesLite2MicFrontEnd: true,
+  hasRadioLineIn: false,
+  hasBalancedXlr: false,
+  hasMicBias: false,
+};
+
+function seedAudio(
+  gates: Gates,
+  source: TxAudioSource,
+  params?: Partial<{ micBoost: boolean; micBias: boolean; lineInGain: number }>,
+) {
+  useAudioStore.setState((s) => ({
+    ...s,
+    // Neutralize the mount-effect load so it can't clobber the seeded state.
+    load: async () => {},
+    settings: {
+      ...gates,
+      source,
+      micBoost: params?.micBoost ?? false,
+      micBias: params?.micBias ?? false,
+      lineInGain: params?.lineInGain ?? 0,
+    },
+    loaded: true,
+    inflight: false,
+  }));
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  // Neutralize the PTT mount-effect load too (no network in jsdom).
+  usePttStore.setState((s) => ({ ...s, load: async () => {} }));
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+function render() {
+  act(() => root.render(<RadioSettingsPanel />));
+}
+
+describe('RadioSettingsPanel — Audio Input card', () => {
+  it('renders the source radio-group for a codec board', () => {
+    seedAudio(G2_GATES, 'Host');
+    render();
+    const group = container.querySelector('[role="radiogroup"]');
+    expect(group).not.toBeNull();
+    const radios = group!.querySelectorAll('[role="radio"]');
+    // Host + RadioMic + RadioLineIn + RadioBalancedXlr = 4 sources on G2.
+    expect(radios.length).toBe(4);
+  });
+
+  it('is single-select — exactly one option checked at Host default', () => {
+    seedAudio(G2_GATES, 'Host');
+    render();
+    const checked = container.querySelectorAll('[role="radio"][aria-checked="true"]');
+    expect(checked.length).toBe(1);
+    expect(checked[0]!.textContent).toContain('Host');
+  });
+
+  it('hides every param control at Host default', () => {
+    seedAudio(G2_GATES, 'Host');
+    render();
+    const text = container.textContent ?? '';
+    expect(text).not.toContain('Mic Boost');
+    expect(text).not.toContain('Mic Bias');
+    expect(text).not.toContain('Line-In Gain');
+  });
+
+  it('shows Mic Boost + Mic Bias for RadioMic on a bias-capable board', () => {
+    seedAudio(G2_GATES, 'RadioMic');
+    render();
+    const text = container.textContent ?? '';
+    expect(text).toContain('Mic Boost');
+    expect(text).toContain('Mic Bias');
+    expect(text).not.toContain('Line-In Gain');
+  });
+
+  it('shows Line-In Gain only for RadioLineIn', () => {
+    seedAudio(G2_GATES, 'RadioLineIn');
+    render();
+    const text = container.textContent ?? '';
+    expect(text).toContain('Line-In Gain');
+    expect(text).not.toContain('Mic Boost');
+  });
+
+  it('hides Mic Bias on a board without mic bias', () => {
+    seedAudio({ ...G2_GATES, hasMicBias: false }, 'RadioMic');
+    render();
+    const text = container.textContent ?? '';
+    expect(text).toContain('Mic Boost');
+    expect(text).not.toContain('Mic Bias');
+  });
+
+  it('omits Balanced when hasBalancedXlr is false', () => {
+    seedAudio({ ...G2_GATES, hasBalancedXlr: false }, 'Host');
+    render();
+    const labels = Array.from(
+      container.querySelectorAll('[role="radio"]'),
+    ).map((n) => n.textContent ?? '');
+    expect(labels.some((l) => l.includes('Balanced'))).toBe(false);
+    // Host + Mic + Line In = 3.
+    expect(labels.length).toBe(3);
+  });
+
+  it('collapses to Host-only on HL2 (no codec)', () => {
+    seedAudio(HL2_GATES, 'Host');
+    render();
+    // No radio-group picker; a disabled Host-only select instead.
+    expect(container.querySelector('[role="radiogroup"]')).toBeNull();
+    const text = container.textContent ?? '';
+    expect(text).toContain('no onboard audio codec');
+  });
+});

--- a/zeus-web/src/components/RadioSettingsPanel.tsx
+++ b/zeus-web/src/components/RadioSettingsPanel.tsx
@@ -4,14 +4,17 @@
 // Copyright (C) 2025-2026 Brian Keating (EI6LF),
 //                         Douglas J. Cerrato (KB2UKA), and contributors.
 //
-// RADIO SETTINGS tab. First (and currently only) control: the hardware
-// PTT-IN → MOX opt-in gate, with a live PTT-IN status lamp.
+// RADIO SETTINGS tab. Cards:
+//   1. PTT-IN → MOX opt-in gate, with a live PTT-IN status lamp.
+//   2. Audio Input — the single-select TX-audio SOURCE (external-audio-jacks
+//      re-port). Board-gated off the per-board capability flags carried in the
+//      /api/radio/audio GET response, so the picker offers only the jacks the
+//      connected board has. Host is always available and is the default.
 //
-// Every board exposes a PTT-IN line (P1 boards via C0[0] / ptt_resp, P2 boards
-// via the UDP-1025 hi-priority PttIn bit), so this card is ungated by board.
-// The `keyed` lamp is driven live by the PttStatusFrame WS edge regardless of
-// the enable toggle; the toggle only controls whether a footswitch press is
-// promoted to host MOX. Defaults OFF (opt-in) server-side.
+// Every board exposes a PTT-IN line, so that card is ungated by board. The
+// `keyed` lamp is driven live by the PttStatusFrame WS edge regardless of the
+// enable toggle; the toggle only controls whether a footswitch press is promoted
+// to host MOX. Defaults OFF (opt-in) server-side.
 //
 // Visual idiom reuses PsSettingsPanel's `.ps-shell` / `.ps-card` / `.ps-field`
 // surfaces (tokens only, no new chrome / palette). Layout / visual specifics
@@ -19,6 +22,27 @@
 
 import { useEffect } from 'react';
 import { usePttStore } from '../state/ptt-store';
+import { useAudioStore, type TxAudioSource } from '../state/audio-store';
+
+// TX-audio source labels for the single-select control. The control is a radio-
+// button group (role="radiogroup") bound to the ONE TxAudioSource enum value —
+// exactly one is active at a time, so independent-checkbox combinations are
+// structurally impossible. Host is always offered; the radio jacks render only
+// when the connected board exposes them (board-gated below).
+const AUDIO_SOURCE_LABEL: Record<TxAudioSource, string> = {
+  Host: 'Host',
+  RadioMic: 'Radio Mic',
+  RadioLineIn: 'Radio Line In',
+  RadioBalancedXlr: 'Radio Balanced',
+};
+
+// Explicit confirmation copy for enabling mic bias — the floating-connector
+// RF / PTT-hang risk. Only gates turning bias ON; turning it OFF is unguarded.
+const MIC_BIAS_CONFIRM =
+  'Enable mic bias?\n\n' +
+  'This supplies DC bias voltage on the mic connector for electret ' +
+  'microphones. On a floating or unconnected mic jack it can hang PTT or ' +
+  'couple RF. Leave it OFF unless your microphone needs bias.';
 
 export function RadioSettingsPanel() {
   const pttKeyed = usePttStore((s) => s.keyed);
@@ -28,9 +52,41 @@ export function RadioSettingsPanel() {
   const loadPtt = usePttStore((s) => s.load);
   const setPttEnabled = usePttStore((s) => s.setEnabled);
 
+  const audio = useAudioStore((s) => s.settings);
+  const audioInflight = useAudioStore((s) => s.inflight);
+  const loadAudio = useAudioStore((s) => s.load);
+  const updateAudio = useAudioStore((s) => s.update);
+
   useEffect(() => {
     void loadPtt();
-  }, [loadPtt]);
+    void loadAudio();
+  }, [loadPtt, loadAudio]);
+
+  // Per-board source-availability gates ride the /api/radio/audio response, so
+  // we read them straight off the audio settings (no separate caps fetch).
+  const hasCodecAudio = audio.hasOnboardCodec;
+  const hasHl2Audio = audio.hermesLite2MicFrontEnd;
+
+  // Board-gated single-select source list. Host is ALWAYS present and is the
+  // default / universal fallback; the radio jacks appear only when the board
+  // advertises them.
+  const audioSources: TxAudioSource[] = [
+    'Host',
+    ...(hasCodecAudio ? (['RadioMic'] as const) : []),
+    ...(hasCodecAudio && audio.hasRadioLineIn ? (['RadioLineIn'] as const) : []),
+    ...(hasCodecAudio && audio.hasBalancedXlr ? (['RadioBalancedXlr'] as const) : []),
+  ];
+
+  const onSelectSource = (next: TxAudioSource) => {
+    if (next === audio.source) return;
+    void updateAudio({ source: next });
+  };
+
+  const onToggleMicBias = (next: boolean) => {
+    // Confirm only when ENABLING — the floating-connector PTT-hang guard.
+    if (next && !window.confirm(MIC_BIAS_CONFIRM)) return;
+    void updateAudio({ micBias: next });
+  };
 
   return (
     <div className="ps-shell">
@@ -97,6 +153,154 @@ export function RadioSettingsPanel() {
           <span style={{ color: 'var(--fg-2)' }}>{pttHangMs} ms</span>
         </div>
       </div>
+
+      {/* Audio Input — only when the connected board exposes a radio audio
+          source (stream codec or the HL2 mic front-end). Host-only boards show
+          nothing here. */}
+      {hasCodecAudio || hasHl2Audio ? (
+        <div className="ps-card">
+          <h4>
+            <svg className="ps-ic-sm" viewBox="0 0 12 12">
+              <path d="M6 1a2 2 0 0 1 2 2v3a2 2 0 0 1-4 0V3a2 2 0 0 1 2-2zM3 6a3 3 0 0 0 6 0M6 9v2" />
+            </svg>
+            Audio Input
+            <span className="ps-card-hint">
+              {hasHl2Audio && !hasCodecAudio ? 'host only' : 'mic / line-in'}
+            </span>
+          </h4>
+
+          {/* HL2 has no codec → Host-only; render a note, no picker. */}
+          {hasHl2Audio && !hasCodecAudio ? (
+            <div className="ps-field">
+              <div className="ps-name">
+                TX Audio Source
+                <em>
+                  Hermes-Lite 2 has no onboard audio codec — TX audio comes from
+                  the host (USB / Ethernet) only.
+                </em>
+              </div>
+              <select className="ps-select-mini" value="Host" disabled>
+                <option value="Host">Host</option>
+              </select>
+            </div>
+          ) : (
+            <>
+              {/* Single-select TX-audio source — a radio-button group bound to
+                  the ONE TxAudioSource value, so it is physically impossible to
+                  pick more than one (illegal states unrepresentable). */}
+              <div className="ps-field">
+                <div className="ps-name">
+                  TX Audio Source
+                  <em>
+                    Which input feeds the transmitter. Host uses the computer
+                    mic / audio chain; the radio options digitize the rig's own
+                    analog jacks. Exactly one is active at a time.
+                  </em>
+                </div>
+                <div
+                  className="btn-row wrap"
+                  role="radiogroup"
+                  aria-label="TX audio source"
+                >
+                  {audioSources.map((src) => {
+                    const active = audio.source === src;
+                    return (
+                      <button
+                        key={src}
+                        type="button"
+                        role="radio"
+                        aria-checked={active}
+                        className={`btn sm ${active ? 'active' : ''}`}
+                        disabled={audioInflight}
+                        onClick={() => onSelectSource(src)}
+                      >
+                        {AUDIO_SOURCE_LABEL[src]}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {/* Mic boost — parameter of Radio Mic / Balanced. */}
+              {audio.source === 'RadioMic' ||
+              audio.source === 'RadioBalancedXlr' ? (
+                <div className="ps-field">
+                  <div className="ps-name">
+                    Mic Boost
+                    <em>+20 dB microphone preamp boost.</em>
+                  </div>
+                  <label className="ps-check">
+                    <input
+                      type="checkbox"
+                      checked={audio.micBoost}
+                      disabled={audioInflight}
+                      onChange={(e) =>
+                        void updateAudio({ micBoost: e.target.checked })
+                      }
+                    />
+                    <span className="ps-check-box" />
+                    <span>{audio.micBoost ? 'On' : 'Off'}</span>
+                  </label>
+                </div>
+              ) : null}
+
+              {/* Mic bias — DEFAULTS OFF, floating-connector PTT-hang guard.
+                  Parameter of Radio Mic / Balanced, bias-capable boards only. */}
+              {audio.hasMicBias &&
+              (audio.source === 'RadioMic' ||
+                audio.source === 'RadioBalancedXlr') ? (
+                <div className="ps-field">
+                  <div className="ps-name">
+                    Mic Bias
+                    <em>
+                      Supply bias voltage for electret microphones. Leave OFF
+                      unless your mic needs it — enabling it on a floating /
+                      unconnected connector can hang PTT.
+                    </em>
+                  </div>
+                  <label className="ps-check">
+                    <input
+                      type="checkbox"
+                      checked={audio.micBias}
+                      disabled={audioInflight}
+                      onChange={(e) => onToggleMicBias(e.target.checked)}
+                    />
+                    <span className="ps-check-box" />
+                    <span>{audio.micBias ? 'On' : 'Off (default)'}</span>
+                  </label>
+                </div>
+              ) : null}
+
+              {/* Line-in gain 0..31 — parameter of Radio Line In. */}
+              {audio.source === 'RadioLineIn' ? (
+                <div className="ps-field">
+                  <div className="ps-name">
+                    Line-In Gain
+                    <em>Line-in input gain (0–31).</em>
+                  </div>
+                  <input
+                    className="ps-select-mini"
+                    type="number"
+                    min={0}
+                    max={31}
+                    step={1}
+                    value={audio.lineInGain}
+                    disabled={audioInflight}
+                    onChange={(e) => {
+                      const n = Number.parseInt(e.target.value, 10);
+                      if (!Number.isNaN(n)) {
+                        void updateAudio({
+                          lineInGain: Math.min(31, Math.max(0, n)),
+                        });
+                      }
+                    }}
+                  />
+                </div>
+              ) : null}
+            </>
+          )}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/zeus-web/src/state/audio-store.test.ts
+++ b/zeus-web/src/state/audio-store.test.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// TX-audio source store — parse robustness + optimistic update round-trip
+// (external-ports plan, §2/§11).
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  fetchAudioFrontEnd,
+  updateAudioFrontEnd,
+  useAudioStore,
+} from './audio-store';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  useAudioStore.setState({
+    settings: {
+      hasOnboardCodec: false,
+      hermesLite2MicFrontEnd: false,
+      hasRadioLineIn: false,
+      hasBalancedXlr: false,
+      hasMicBias: false,
+      source: 'Host',
+      micBoost: false,
+      micBias: false,
+      lineInGain: 0,
+    },
+    loaded: false,
+    inflight: false,
+    error: null,
+  });
+});
+
+function stubFetch(body: unknown, status = 200) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+}
+
+describe('audio-store parsing', () => {
+  it('clamps lineInGain into 0..31', async () => {
+    stubFetch({ hasOnboardCodec: true, source: 'RadioLineIn', lineInGain: 99 });
+    const s = await fetchAudioFrontEnd();
+    expect(s.lineInGain).toBe(31);
+  });
+
+  it('defaults gates false + source Host on garbage', async () => {
+    stubFetch(42);
+    const s = await fetchAudioFrontEnd();
+    expect(s.hasOnboardCodec).toBe(false);
+    expect(s.hermesLite2MicFrontEnd).toBe(false);
+    expect(s.source).toBe('Host');
+    expect(s.lineInGain).toBe(0);
+  });
+
+  it('parses the numeric enum form of source', async () => {
+    stubFetch({ source: 1 }); // RadioMic
+    const s = await fetchAudioFrontEnd();
+    expect(s.source).toBe('RadioMic');
+  });
+
+  it('falls back to Host on an unknown source string', async () => {
+    stubFetch({ source: 'Nonsense' });
+    const s = await fetchAudioFrontEnd();
+    expect(s.source).toBe('Host');
+  });
+
+  it('throws on a 409 from the PUT', async () => {
+    stubFetch({ error: 'no audio' }, 409);
+    await expect(
+      updateAudioFrontEnd({
+        source: 'RadioMic',
+        micBoost: false,
+        micBias: false,
+        lineInGain: 0,
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('audio-store update', () => {
+  it('optimistically patches then adopts the server response', async () => {
+    stubFetch({
+      hasOnboardCodec: true,
+      hermesLite2MicFrontEnd: false,
+      source: 'RadioMic',
+      micBoost: true,
+      micBias: false,
+      lineInGain: 12,
+    });
+    await useAudioStore.getState().update({ source: 'RadioMic', micBoost: true });
+    const s = useAudioStore.getState().settings;
+    expect(s.source).toBe('RadioMic');
+    expect(s.micBoost).toBe(true);
+    expect(s.lineInGain).toBe(12);
+  });
+
+  it('rolls back on PUT failure', async () => {
+    useAudioStore.setState({
+      settings: {
+        hasOnboardCodec: true,
+        hermesLite2MicFrontEnd: false,
+        hasRadioLineIn: false,
+        hasBalancedXlr: false,
+        hasMicBias: true,
+        source: 'RadioMic',
+        micBoost: false,
+        micBias: false,
+        lineInGain: 3,
+      },
+    });
+    stubFetch({ error: 'boom' }, 409);
+    await useAudioStore.getState().update({ micBias: true });
+    const s = useAudioStore.getState().settings;
+    expect(s.micBias).toBe(false); // rolled back
+    expect(useAudioStore.getState().error).toBeTruthy();
+  });
+});

--- a/zeus-web/src/state/audio-store.ts
+++ b/zeus-web/src/state/audio-store.ts
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// Global (per-radio, NOT per-band) TX-audio SOURCE (external-ports plan, §2/§11).
+// Mirrors /api/radio/audio, which is server-authoritative: the backend reads
+// AudioSettingsStore, CLAMPS the source against the connected board, and pushes
+// the resolved selection to the live radio through PushAudioFrontEnd, so the
+// frontend never clobbers the server on connect — it only loads + PUTs operator
+// edits. The GET response carries per-board source-availability gates so the
+// single-select picker offers only the sources the board has (Host is always
+// available).
+//
+// This replaces the prior four-bool model (lineIn/balancedInput peers); line-in
+// and balanced are now distinct `source` enum values.
+
+import { create } from 'zustand';
+
+// Must match Zeus.Contracts.TxAudioSource (string round-trips via STJ enum
+// names — the wire carries the member name, e.g. "RadioMic").
+export type TxAudioSource = 'Host' | 'RadioMic' | 'RadioLineIn' | 'RadioBalancedXlr';
+
+const SOURCES: readonly TxAudioSource[] = ['Host', 'RadioMic', 'RadioLineIn', 'RadioBalancedXlr'];
+
+export interface AudioFrontEnd {
+  // Per-board source-availability gates (read-only / server-set).
+  hasOnboardCodec: boolean;
+  hermesLite2MicFrontEnd: boolean;
+  hasRadioLineIn: boolean;
+  hasBalancedXlr: boolean;
+  hasMicBias: boolean;
+  // The resolved (board-clamped) source + its params.
+  source: TxAudioSource;
+  micBoost: boolean;
+  micBias: boolean;
+  lineInGain: number;
+}
+
+const DEFAULT_AUDIO: AudioFrontEnd = {
+  hasOnboardCodec: false,
+  hermesLite2MicFrontEnd: false,
+  hasRadioLineIn: false,
+  hasBalancedXlr: false,
+  hasMicBias: false,
+  source: 'Host',
+  micBoost: false,
+  micBias: false,
+  lineInGain: 0,
+};
+
+function parseBool(v: unknown, fallback: boolean): boolean {
+  return typeof v === 'boolean' ? v : fallback;
+}
+
+function parseSource(v: unknown): TxAudioSource {
+  // Tolerate the numeric enum form (0..3) as well as the STJ member-name form.
+  if (typeof v === 'string' && (SOURCES as readonly string[]).includes(v)) {
+    return v as TxAudioSource;
+  }
+  if (typeof v === 'number' && Number.isInteger(v) && v >= 0 && v < SOURCES.length) {
+    return SOURCES[v] ?? 'Host';
+  }
+  return 'Host';
+}
+
+function parse(raw: unknown): AudioFrontEnd {
+  if (!raw || typeof raw !== 'object') return DEFAULT_AUDIO;
+  const r = raw as Record<string, unknown>;
+  const gain = typeof r.lineInGain === 'number' ? r.lineInGain : 0;
+  return {
+    hasOnboardCodec: parseBool(r.hasOnboardCodec, false),
+    hermesLite2MicFrontEnd: parseBool(r.hermesLite2MicFrontEnd, false),
+    hasRadioLineIn: parseBool(r.hasRadioLineIn, false),
+    hasBalancedXlr: parseBool(r.hasBalancedXlr, false),
+    hasMicBias: parseBool(r.hasMicBias, false),
+    source: parseSource(r.source),
+    micBoost: parseBool(r.micBoost, false),
+    micBias: parseBool(r.micBias, false),
+    lineInGain: Math.min(31, Math.max(0, Math.round(gain))),
+  };
+}
+
+// The mutable subset an operator can PUT (the gates are read-only / server-set).
+export type AudioFrontEndEdit = Pick<
+  AudioFrontEnd,
+  'source' | 'micBoost' | 'micBias' | 'lineInGain'
+>;
+
+export async function fetchAudioFrontEnd(
+  signal?: AbortSignal,
+): Promise<AudioFrontEnd> {
+  const res = await fetch('/api/radio/audio', { signal });
+  if (!res.ok) throw new Error(`GET /api/radio/audio → ${res.status}`);
+  return parse(await res.json());
+}
+
+export async function updateAudioFrontEnd(
+  edit: AudioFrontEndEdit,
+  signal?: AbortSignal,
+): Promise<AudioFrontEnd> {
+  const res = await fetch('/api/radio/audio', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(edit),
+    signal,
+  });
+  if (!res.ok) throw new Error(`PUT /api/radio/audio → ${res.status}`);
+  return parse(await res.json());
+}
+
+type AudioStore = {
+  settings: AudioFrontEnd;
+  loaded: boolean;
+  inflight: boolean;
+  error: string | null;
+  load: () => Promise<void>;
+  update: (patch: Partial<AudioFrontEndEdit>) => Promise<void>;
+};
+
+export const useAudioStore = create<AudioStore>((set, get) => ({
+  settings: DEFAULT_AUDIO,
+  loaded: false,
+  inflight: false,
+  error: null,
+
+  load: async () => {
+    set({ inflight: true, error: null });
+    try {
+      const s = await fetchAudioFrontEnd();
+      set({ settings: s, loaded: true, inflight: false });
+    } catch (err) {
+      set({
+        error: err instanceof Error ? err.message : String(err),
+        inflight: false,
+      });
+    }
+  },
+
+  update: async (patch) => {
+    // Optimistic local update, rollback on error — same idiom as the antenna
+    // store. The PUT returns the canonical settings (incl. board-clamped source
+    // + clamped gain) which we adopt so the local view stays in lockstep with
+    // the server.
+    const prev = get().settings;
+    const edit: AudioFrontEndEdit = {
+      source: patch.source ?? prev.source,
+      micBoost: patch.micBoost ?? prev.micBoost,
+      micBias: patch.micBias ?? prev.micBias,
+      lineInGain: patch.lineInGain ?? prev.lineInGain,
+    };
+    set({ settings: { ...prev, ...edit }, inflight: true, error: null });
+    try {
+      const s = await updateAudioFrontEnd(edit);
+      set({ settings: s, inflight: false });
+    } catch (err) {
+      set({
+        settings: prev,
+        error: err instanceof Error ? err.message : String(err),
+        inflight: false,
+      });
+    }
+  },
+}));


### PR DESCRIPTION
## What

Re-ports the operator-selectable **TX audio-input source** feature first shipped in PR #639 (squash `78c3c28e`) and dropped during the base swap to the new fork. Faithfully re-grafted against current `develop`, mirroring the landed PTT-jack conventions (PR #797/#799). **Audio slice only** — the antenna / open-collector surfaces from the original external-ports plan land separately.

Wires up all *selectable input* jacks each radio actually exposes. (Output jacks — line-out / headphone / speaker — are fixed hardware, not wire-selectable in either protocol, so they remain presence-only via `HasAudioAmplifier`.)

## How

- Single mutually-exclusive per-radio `TxAudioSource { Host, RadioMic, RadioLineIn, RadioBalancedXlr }` + mic boost / mic bias / line-in gain.
- `Host` (default) is today's browser/host mic pipeline. The radio sources digitize the rig's own analog jacks and route them into the WDSP TX chain via the radio-mic **UDP-1026 RX stream** (`RadioMicReceiver`, 64→960-sample re-block) behind an **atomic host/radio single-select gate** in `TxAudioIngest`.
- Wire encoding lives behind a new **`IExternalPortEncoder` firewall** (audio-only): P2 TxSpecific byte 50 `mic_control` / byte 51 `line_in_gain` (0x0A Saturn family); P1 `0x12` codec `mic_boost`/`mic_linein` (Hermes-class); HL2 `0x14` mic front-end via read-modify-write.
- Per-board capability gating (`BoardCapabilities` + `BoardCapabilitiesTable`), surfaced through `GET/PUT /api/radio/audio` and gated again in the frontend **Audio Input** card on the existing RADIO SETTINGS tab.

## Per-board scope

| Board | RadioMic | LineIn | XLR | MicBias |
|---|---|---|---|---|
| Hermes / ANAN-10 / 100 | ✅ | ❌ (scoped out) | ❌ | ❌ |
| **ANAN-10E (HermesII)** | ✅ | ✅ (#667 fix) | ❌ | ❌ |
| ANAN-100D / 200D | ✅ | ✅ | ❌ | ✅ |
| 7000DLE / 8000DLE / OrionMkII | ✅ | ✅ | ❌ | ✅/❌ |
| **G2 / G2-1K** | ✅ | ✅ | ✅ | ✅ |
| AnvelinaPro3 / RedPitaya | ✅ | ✅ | ❌ | ❌ (DIY foot-gun) |
| G2E (HermesC10) | ✅ | ❌ | ❌ | ❌ |
| Hermes-Lite 2 | ❌ (no codec) | ❌ | ❌ | inert v1 |

- **ANAN-10E line-in** is the issue **#667** two-gate fix (capability flag *and* encoder emission, both `HermesII`-gated). Hermes/ANAN-10/100 line-in stays deliberately scoped OUT.
- **Balanced XLR only on G2 / G2-1K**, exactly where Thetis gates it.
- **Mic bias defaults OFF** everywhere, behind an explicit enable confirm; forced off on RedPitaya / AnvelinaPro3.

## Safety invariants (test-enforced)

- **Host purity** — every encode of `Host` returns literal `0` with no param read; a persisted source can never leak onto the wire after revert.
- **Byte-identical at defaults on every board** — the PureSignal golden suites (P1 `ControlFramePsEncoderTests` + P2 `PsWireFormatTests`) stay green unchanged.
- **HL2 `0x14` write is read-modify-write preserving `C2[6]=puresignal_run` + the C4 PGA byte** (test `Attenuator_Hl2_AudioSet_PreservesPureSignalRun`). The audio path never touches the alex word, PS bit, or K36 RX-aux path — structurally decoupled from PureSignal.
- Persisted-but-unsupported source **clamps to Host at connect**.

## Tests

- `dotnet build Zeus.slnx` — 0 errors / 0 warnings.
- Backend **1487+ passed, 0 failed** (P1 +20, P2 +13, Server +62 audio). PS goldens byte-identical.
- Frontend `tsc -b` + `vite build` clean; new vitest suites `audio-store` + `RadioSettingsPanel` pass.

## ⚠️ Why this is a DRAFT — bench gates before merge

The G2 was offline during design, so the matrix is Thetis-source-derived and **all radio-source wire paths have unit-level + byte-identity verification only**. `Host`-default is fully byte-identical and safe. Needs KB2UKA bench sign-off on:

1. **HL2 `0x14` RMW PureSignal safety** on real HL2 + G2 (burn-zone — PS-adjacent frame).
2. **Live G2 capability read** + real mic / line-in / XLR path.
3. **UDP-1026 radio-mic stream end-to-end** on a Saturn radio.

Also flagged for hardware confirmation: HL2 mic-in reality (mi0bot firmware), G2E balanced mic (#289), RedPitaya / AnvelinaPro3 bias connectors. Metis is conservatively Host-only pending confirmation.

Design doc: `docs/designs/external-audio-jacks.md`